### PR TITLE
replace mixin-deep with lodash merge

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -1,15 +1,15 @@
-const mixinDeep = require('mixin-deep')
+const _ = require('lodash')
 const rewireReactHotLoader = require('react-app-rewire-hot-loader')
 const manualOverrides = require('./webpack.config')
 
 /* config-overrides.js */
 module.exports = {
   webpack: function override(config, env) {
-    config = mixinDeep(config, manualOverrides)
+    config = _.merge(config, manualOverrides)
     return rewireReactHotLoader(config, env)
   },
   jest: function(config) {
-    return mixinDeep(config, {
+    return _.merge(config, {
       moduleDirectories: ['node_modules', ''] // to allow Jest to resolve absolute module paths
     })
   }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "@clr/icons": "^0.11.12",
     "@webcomponents/custom-elements": "^1.1.0",
     "lodash": "^4.17.5",
-    "mixin-deep": "^1.3.1",
     "rc-table": "^6.1.7",
     "react": "^16.3.1",
     "react-app-rewire-hot-loader": "^1.0.1",

--- a/src/components/ShowOnClick.js
+++ b/src/components/ShowOnClick.js
@@ -1,4 +1,4 @@
-import mixinDeep from 'mixin-deep'
+import _ from 'lodash'
 import { div, hh } from 'react-hyperscript-helpers/lib/index'
 import { Component } from 'src/libs/wrapped-components'
 
@@ -27,7 +27,7 @@ export default hh(class ShowOnClick extends Component {
     const { visible } = this.state
     const { containerProps, button, bgProps, closeOnClick = true, closeOnEsc = true, children } = this.props
 
-    return div(mixinDeep({
+    return div(_.merge({
         onClick: (e) => {
           this.setState({ visible: true })
           e.preventDefault()
@@ -39,7 +39,7 @@ export default hh(class ShowOnClick extends Component {
       [
         button,
         !visible ? null :
-          div(mixinDeep({
+          div(_.merge({
             style: {
               position: 'fixed', left: 0, right: 0, top: 0, bottom: 0, cursor: 'pointer'
             },

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -1,5 +1,4 @@
 import _ from 'lodash'
-import mixinDeep from 'mixin-deep'
 import { div, h, input } from 'react-hyperscript-helpers'
 import { icon } from 'src/components/icons'
 import * as Style from 'src/libs/style'
@@ -8,7 +7,7 @@ import { Interactive } from 'src/libs/wrapped-components'
 
 export const link = function(props, children) {
   return Interactive(
-    mixinDeep({
+    _.merge({
       as: 'a',
       style: {
         textDecoration: 'none',
@@ -22,7 +21,7 @@ export const link = function(props, children) {
 
 export const buttonPrimary = function(props, children) {
   return Interactive(
-    mixinDeep({
+    _.merge({
       as: 'button',
       style: _.defaults({
         border: 'none', padding: '0.5rem 2rem', borderRadius: 5, color: 'white',
@@ -36,11 +35,11 @@ export const buttonPrimary = function(props, children) {
 
 export const search = function({ wrapperProps, inputProps }) {
   return div(
-    mixinDeep({ style: { borderBottom: '1px solid black', padding: '0.5rem 0', display: 'flex' } },
+    _.merge({ style: { borderBottom: '1px solid black', padding: '0.5rem 0', display: 'flex' } },
       wrapperProps),
     [
       icon('search'),
-      input(mixinDeep({
+      input(_.merge({
         style: {
           border: 'none', outline: 'none',
           flexGrow: 1,
@@ -51,7 +50,7 @@ export const search = function({ wrapperProps, inputProps }) {
 }
 
 export const contextBar = function(props, children) {
-  return div(mixinDeep({
+  return div(_.merge({
       style: {
         display: 'flex', alignItems: 'center', backgroundColor: Style.colors.primary,
         color: Style.colors.textAlt, fontWeight: 500,
@@ -69,7 +68,7 @@ export const contextMenu = function(items) {
       }
     },
     _.map(items, ([props, contents]) => h(Interactive,
-      mixinDeep({
+      _.merge({
         as: 'div',
         style: { fontSize: 12, padding: '0.5rem 1.5rem' },
         hover: { backgroundColor: Style.colors.highlight, fontWeight: 500 }

--- a/src/components/icons.js
+++ b/src/components/icons.js
@@ -2,7 +2,7 @@ import '@webcomponents/custom-elements' // must be before icons
 import { ClarityIcons } from '@clr/icons'
 import '@clr/icons/clr-icons.css'
 import '@clr/icons/shapes/essential-shapes'
-import mixinDeep from 'mixin-deep'
+import _ from 'lodash'
 import { h } from 'react-hyperscript-helpers'
 import { jupyterIcon, loadingSpinner, logoIcon, table } from 'src/libs/custom-icons'
 import * as Style from 'src/libs/style'
@@ -14,20 +14,20 @@ import * as Style from 'src/libs/style'
  * @param {object} [props]
  */
 export const icon = function(shape, props) {
-  return h('clr-icon', mixinDeep({ shape }, props))
+  return h('clr-icon', _.merge({ shape }, props))
 }
 
 export const breadcrumb = function(props) {
-  return icon('angle right', mixinDeep({ size: 10, style: { padding: '0 0.25rem' } }, props))
+  return icon('angle right', _.merge({ size: 10, style: { padding: '0 0.25rem' } }, props))
 }
 
 export const logo = function(props) {
-  return icon('logoIcon', mixinDeep({ size: 48, style: { marginRight: '0.5rem' } }, props))
+  return icon('logoIcon', _.merge({ size: 48, style: { marginRight: '0.5rem' } }, props))
 }
 
 export const spinner = function(props) {
   return icon('loadingSpinner',
-    mixinDeep(
+    _.merge(
       { size: 48, style: { color: Style.colors.primary, display: 'block', margin: 'auto' } },
       props))
 }

--- a/src/libs/__mocks__/ajax.js
+++ b/src/libs/__mocks__/ajax.js
@@ -1,11 +1,10 @@
 import _ from 'lodash'
-import mixinDeep from 'mixin-deep'
 
 
 export const createWorkspace = (overrides) => {
   const workspaceId = _.uniqueId('workspace')
 
-  return mixinDeep({
+  return _.merge({
     accessLevel: 'NO ACCESS',
     owners: ['bob@example.com'],
     public: false,

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -1,5 +1,4 @@
 import _ from 'lodash'
-import mixinDeep from 'mixin-deep'
 import { div, hh, table } from 'react-hyperscript-helpers'
 import { icon, spinner } from 'src/components/icons'
 import { DataTable } from 'src/components/table'
@@ -49,10 +48,10 @@ export default hh(class WorkspaceData extends Component {
         rowKey: 'name',
         scroll: { x: true },
         components: {
-          table: props => table(mixinDeep({ style: { borderCollapse: 'collapse' } }, props)),
+          table: props => table(_.merge({ style: { borderCollapse: 'collapse' } }, props)),
           body: {
             row: props => Interactive(
-              mixinDeep({
+              _.merge({
                   as: 'tr', style: { cursor: null },
                   hover: { backgroundColor: Style.colors.highlightFaded }
                 },

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -1,5 +1,4 @@
 import _ from 'lodash'
-import mixinDeep from 'mixin-deep'
 import { a, div, hh } from 'react-hyperscript-helpers'
 import { buttonPrimary, link } from 'src/components/common'
 import { icon, spinner } from 'src/components/icons'
@@ -68,9 +67,9 @@ export default hh(class WorkspaceNotebooks extends Component {
               [`~/${workspace.name}/${name.slice(10)}`]: `gs://${bucket}/${name}`
             },
             () => this.setState(
-              oldState => mixinDeep({ notebookAccess: { [name]: true } }, oldState)),
+              oldState => _.merge({ notebookAccess: { [name]: true } }, oldState)),
             () => this.setState(
-              oldState => mixinDeep({ notebookAccess: { [name]: false } }, oldState))
+              oldState => _.merge({ notebookAccess: { [name]: false } }, oldState))
           )
         })
       },


### PR DESCRIPTION
Lodash's `merge` function performs a deep merge, and works as a drop-in replacement for `mixin-deep`. Since lodash is already well established and understood, this provides a small decrease in cognitive overhead.