### PR TITLE
add redux to workspaces List

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5172,6 +5172,11 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
       "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA=="
     },
+    "immutable": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
+      "integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM="
+    },
     "import-lazy": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
@@ -6105,6 +6110,11 @@
       "version": "4.17.5",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
       "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+    },
+    "lodash-es": {
+      "version": "4.17.8",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.8.tgz",
+      "integrity": "sha512-I9mjAxengFAleSThFhhAhvba6fsO0hunb9/0sQ6qQihSZsJRBofv2rYH58WXaOb/O++eUmYpCLywSQ22GfU+sA=="
     },
     "lodash._getnative": {
       "version": "3.9.1",
@@ -8815,6 +8825,19 @@
         "prop-types": "15.6.0"
       }
     },
+    "react-redux": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.7.tgz",
+      "integrity": "sha512-5VI8EV5hdgNgyjfmWzBbdrqUkrVRKlyTKk1sGH3jzM2M2Mhj/seQgPXaz6gVAj2lz/nz688AdTqMO18Lr24Zhg==",
+      "requires": {
+        "hoist-non-react-statics": "2.5.0",
+        "invariant": "2.2.4",
+        "lodash": "4.17.5",
+        "lodash-es": "4.17.8",
+        "loose-envify": "1.3.1",
+        "prop-types": "15.6.0"
+      }
+    },
     "react-scripts": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-1.1.4.tgz",
@@ -9454,6 +9477,20 @@
           "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
         }
       }
+    },
+    "redux": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.0.tgz",
+      "integrity": "sha512-NnnHF0h0WVE/hXyrB6OlX67LYRuaf/rJcbWvnHHEPCF/Xa/AZpwhs/20WyqzQae5x4SD2F9nPObgBh2rxAgLiA==",
+      "requires": {
+        "loose-envify": "1.3.1",
+        "symbol-observable": "1.2.0"
+      }
+    },
+    "redux-thunk": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.2.0.tgz",
+      "integrity": "sha1-5hWhbha0ehmlFXZhM9Hj6Zt4UuU="
     },
     "regenerate": {
       "version": "1.3.3",
@@ -10495,6 +10532,11 @@
         "path-to-regexp": "1.7.0",
         "serviceworker-cache-polyfill": "4.0.0"
       }
+    },
+    "symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "symbol-tree": {
       "version": "3.2.2",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@clr/icons": "^0.11.12",
     "@webcomponents/custom-elements": "^1.1.0",
+    "immutable": "^3.8.2",
     "lodash": "^4.17.5",
     "mixin-deep": "^1.3.1",
     "rc-table": "^6.1.7",
@@ -15,7 +16,10 @@
     "react-hot-loader": "^4.0.1",
     "react-hyperscript-helpers": "^1.2.0",
     "react-interactive": "^0.8.1",
-    "react-scripts": "1.1.4"
+    "react-redux": "^5.0.7",
+    "react-scripts": "1.1.4",
+    "redux": "^4.0.0",
+    "redux-thunk": "^2.2.0"
   },
   "scripts": {
     "start": "react-app-rewired start",

--- a/src/_tests/pages/workspaces/List.test.js
+++ b/src/_tests/pages/workspaces/List.test.js
@@ -1,22 +1,26 @@
 import { mount } from 'enzyme'
+import { h } from 'react-hyperscript-helpers'
+import { Provider } from 'react-redux'
 import { DataGrid } from 'src/components/table'
 import { TopBar } from 'src/components/TopBar'
 import { WorkspaceList } from 'src/pages/workspaces/List'
+import store from 'src/store'
 
 const gridType = DataGrid().type
 const topBarType = TopBar().type
 
+const mountWorkspaceList = () => mount(h(Provider, { store }, [WorkspaceList()]))
 
 describe('WorkspaceList', () => {
   it('should render a TopBar and DataGrid', () => {
-    const wrapper = mount(WorkspaceList())
+    const wrapper = mountWorkspaceList()
 
     expect(wrapper.find(topBarType)).toHaveLength(1)
     expect(wrapper.find(gridType)).toHaveLength(1)
   })
 
   it('should switch between Grid and list view', () => {
-    const wrapper = mount(WorkspaceList())
+    const wrapper = mountWorkspaceList()
     const currentCardsPerRow = () => wrapper.find(gridType).props().cardsPerRow
 
     expect(currentCardsPerRow()).not.toEqual(1)

--- a/src/_tests/store.test.js
+++ b/src/_tests/store.test.js
@@ -1,0 +1,13 @@
+import { reducer } from 'src/store'
+
+describe('store', () => {
+  it('Workspaces.loadCompleted', () => {
+    const workspaces = [
+      { workspace: { name: 'c' }, public: false, accessLevel: 'READER' },
+      { workspace: { name: 'b' }, public: true, accessLevel: 'NO_ACCESS' },
+      { workspace: { name: 'a' }, public: true, accessLevel: 'OWNER' },
+    ]
+    const state = reducer(undefined, { type: 'Workspaces.loadCompleted', workspaces })
+    expect(state.workspaces.workspaces.map(w => w.workspace.name)).toEqual(['a', 'c'])
+  })
+})

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import ReactDOM from 'react-dom'
 import { h } from 'react-hyperscript-helpers'
+import { Provider } from 'react-redux'
 import Main from 'src/pages/Main'
+import store from 'src/store'
 
-
-ReactDOM.render(h(Main), document.getElementById('root'))
+ReactDOM.render(h(Provider, { store }, [h(Main)]), document.getElementById('root'))

--- a/src/pages/workspaces/actions.js
+++ b/src/pages/workspaces/actions.js
@@ -1,0 +1,10 @@
+import { Rawls } from 'src/libs/ajax'
+
+
+export const loadWorkspaces = () => (dispatch) => {
+  dispatch({ type: 'Workspaces.load' })
+  Rawls.workspacesList(
+    workspaces => dispatch({ type: 'Workspaces.loadCompleted', workspaces }),
+    failure => dispatch({ type: 'Workspaces.loadFailed', failure })
+  )
+}

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -1,0 +1,43 @@
+import { Record } from 'immutable'
+import _ from 'lodash'
+import { workspaceAccessLevels } from 'src/libs/utils'
+
+
+export const initialState = new (Record({
+  workspaces: new (Record({
+    filter: '',
+    listView: false,
+    itemsPerPage: 6,
+    pageNumber: 1,
+    workspaces: null,
+    failure: undefined,
+  }))()
+}))()
+
+export const reducers = {
+  'Workspaces.setFilter': (state, { filter }) => {
+    return state.mergeIn(['workspaces'], { filter })
+  },
+
+  'Workspaces.setListView': (state, { listView }) => {
+    return state.mergeIn(['workspaces'], { listView })
+  },
+
+  'Workspaces.setItemsPerPage': (state, { itemsPerPage }) => {
+    return state.mergeIn(['workspaces'], { itemsPerPage })
+  },
+
+  'Workspaces.setPageNumber': (state, { pageNumber }) => {
+    return state.mergeIn(['workspaces'], { pageNumber })
+  },
+
+  'Workspaces.loadCompleted': (state, { workspaces }) => {
+    return state.setIn(['workspaces', 'workspaces'], _.sortBy(_.filter(workspaces,
+      ws => !ws.public || workspaceAccessLevels.indexOf(ws.accessLevel) > workspaceAccessLevels.indexOf('READER')),
+      'workspace.name'))
+  },
+
+  'Workspaces.loadFailed': (state, { failure }) => {
+    return state.mergeIn(['workspaces'], { failure })
+  }
+}

--- a/src/store.js
+++ b/src/store.js
@@ -1,0 +1,23 @@
+import { createStore, applyMiddleware } from 'redux'
+import thunkMiddleware from 'redux-thunk'
+import { initialState, reducers } from 'src/reducers'
+
+
+const loggerMiddleware = store => next => action => {
+  if (process.env.NODE_ENV === 'development') {
+    console.log(`%caction`, 'color: #0f6db7', action)
+  }
+  const result = next(action)
+  window.state = store.getState()
+  return result
+}
+
+export const reducer = (state = initialState, action) => {
+  const fn = reducers[action.type]
+  return fn ? fn(state, action) : state
+}
+
+const store = createStore(reducer, applyMiddleware(thunkMiddleware, loggerMiddleware))
+window.store = store
+
+export default store


### PR DESCRIPTION
This is a canonical use of Redux in the workspaces List component. Highlights described here, and in code comments.

### Code separation

The List component has been simplified, and no longer contains state, state transition logic, or asynchronous ajax logic. Its only concerns are display, and responding to interaction. This has several benefits, including ease of refactoring and ease of testing.

### Logging and instrumentation

Because all state transitions are done via actions (which are just data), it is trivial to provide a real-time log of everything that happens.

![image](https://user-images.githubusercontent.com/555632/39134241-2906ce4c-46e4-11e8-9adf-e90367947b6f.png)

Relatedly, it is possible to simulate events by constructing and dispatching them directly.

![image](https://user-images.githubusercontent.com/555632/39134293-4d4ccaae-46e4-11e8-8eea-66f43ccf7814.png)

The store state is also available for direct inspection.

![image](https://user-images.githubusercontent.com/555632/39134349-6dbfd498-46e4-11e8-81ce-ca154978a546.png)

### Testing

Since the component no longer directly manages state or makes ajax calls, it is much more amenable to testing using e.g. a mocked store Provider. Also, the reducer is a pure function and therefore can be tested directly.

### Immutable.js

The store state is using [Immutable.js](http://facebook.github.io/immutable-js/), which provides clojure-inspired immutable data structures, including structural sharing, etc.

### Tradeoffs

Redux code will usually be slightly larger than the non-Redux equivalent. Reducers and connect calls constitute the bulk of it. The code tends to be simple and flat, and doesn't add to overall complexity.