### PR TITLE
convert ajax calls to make better use of promises

### DIFF
--- a/src/_tests/pages/workspaces/List.test.js
+++ b/src/_tests/pages/workspaces/List.test.js
@@ -1,25 +1,31 @@
 import { mount } from 'enzyme'
 import { h } from 'react-hyperscript-helpers'
-import renderer from 'react-test-renderer'
+import TestRenderer from 'react-test-renderer'
 import { DataGrid } from 'src/components/table'
+import { waitOneTick, waitOneTickAndUpdate } from 'src/libs/test-utils'
 import { WorkspaceList } from 'src/pages/workspaces/List'
 
 
 describe('WorkspaceList', () => {
   it('should render as expected', () => {
-    expect(renderer.create(h(WorkspaceList)).toJSON()).toMatchSnapshot()
+    const renderer = TestRenderer.create(h(WorkspaceList))
+    return waitOneTick().then(() => {
+      expect(renderer.toJSON()).toMatchSnapshot()
+    })
   })
 
   it('should switch between Grid and List view', () => {
     const wrapper = mount(h(WorkspaceList))
-    const currentCardsPerRow = () => wrapper.find(DataGrid).props().cardsPerRow
+    return waitOneTickAndUpdate(wrapper).then(() => {
+      const currentCardsPerRow = () => wrapper.find(DataGrid).props().cardsPerRow
 
-    expect(currentCardsPerRow()).not.toEqual(1)
+      expect(currentCardsPerRow()).not.toEqual(1)
 
-    wrapper.findIcon('view-list').click()
-    expect(currentCardsPerRow()).toEqual(1)
+      wrapper.findIcon('view-list').click()
+      expect(currentCardsPerRow()).toEqual(1)
 
-    wrapper.findIcon('view-cards').click()
-    expect(currentCardsPerRow()).not.toEqual(1)
+      wrapper.findIcon('view-cards').click()
+      expect(currentCardsPerRow()).not.toEqual(1)
+    })
   })
 })

--- a/src/_tests/pages/workspaces/workspace/Dashboard.test.js
+++ b/src/_tests/pages/workspaces/workspace/Dashboard.test.js
@@ -1,15 +1,16 @@
 import { mount } from 'enzyme'
 import { h } from 'react-hyperscript-helpers'
 import { Rawls } from 'src/libs/ajax'
+import { waitOneTickAndUpdate } from 'src/libs/test-utils'
 import { WorkspaceContainer } from 'src/pages/workspaces/workspace/Container'
 
 
 describe('Dashboard', () => {
   // Pretty much useless, exists to explore mock infrastructure
   it('should render the correct access level', () => {
-    jest.spyOn(Rawls, 'workspaceDetails').mockImplementationOnce((namespace, name, success) => {
+    jest.spyOn(Rawls, 'workspaceDetails').mockImplementationOnce((namespace, name) => {
         const { createWorkspace } = require.requireActual('src/libs/__mocks__/ajax')
-        success(createWorkspace({ namespace, name, accessLevel: 'OWNER' }))
+        return Promise.resolve(createWorkspace({ namespace, name, accessLevel: 'OWNER' }))
       }
     )
 
@@ -19,6 +20,8 @@ describe('Dashboard', () => {
         name: 'test-name'
       }))
 
-    expect(wrapper.testId('access-level').text()).toEqual('OWNER')
+    return waitOneTickAndUpdate(wrapper).then(() => {
+      expect(wrapper.testId('access-level').text()).toEqual('OWNER')
+    })
   })
 })

--- a/src/components/notebook-utils.js
+++ b/src/components/notebook-utils.js
@@ -75,12 +75,13 @@ export class NotebookCreator extends Component {
               disabled: !(notebookName && notebookKernel),
               onClick: () => {
                 this.setState({ modalOpen: false, creating: true })
-                Buckets.createNotebook(namespace, bucketName, notebookName, notebookKernel.data,
+                Buckets.createNotebook(namespace, bucketName, notebookName, notebookKernel.data).then(
                   () => {
                     this.setState({ creating: false })
                     reloadList()
                   },
-                  notebookFailure => this.setState({ notebookFailure, modalOpen: false }))
+                  notebookFailure => this.setState({ notebookFailure, modalOpen: false })
+                )
               }
             }, 'Create Notebook')
           }, [
@@ -139,9 +140,10 @@ export class NotebookDuplicator extends Component {
           onClick: () => {
             this.setState({ processing: true })
             Buckets[destroyOld ? 'renameNotebook' : 'copyNotebook'](
-              namespace, bucketName, printName, newName,
-              onSuccess,
-              failure => this.setState({ failure }))
+              namespace, bucketName, printName, newName).then(
+                onSuccess,
+                failure => this.setState({ failure })
+              )
           }
         }, `${destroyOld ? 'Rename' : 'Duplicate' } Notebook`)
       },
@@ -175,9 +177,10 @@ export class NotebookDeleter extends Component {
           disabled: processing,
           onClick: () => {
             this.setState({ processing: true })
-            Buckets.deleteNotebook(namespace, bucketName, printName,
+            Buckets.deleteNotebook(namespace, bucketName, printName).then(
               onSuccess,
-              failure => this.setState({ failure }))
+              failure => this.setState({ failure })
+            )
           }
         }, `Delete Notebook`)
       },

--- a/src/libs/__mocks__/ajax.js
+++ b/src/libs/__mocks__/ajax.js
@@ -37,13 +37,10 @@ export const createWorkspace = (overrides) => {
 }
 
 export const Rawls = {
-  workspacesList(success, _) {
-    success([
-      createWorkspace(),
-      createWorkspace()
-    ])
+  workspacesList() {
+    return Promise.resolve([createWorkspace(), createWorkspace()])
   },
-  workspaceDetails(namespace, name, success, _) {
-    success(createWorkspace({ namespace, name }))
+  workspaceDetails(namespace, name) {
+    return Promise.resolve(createWorkspace({ namespace, name }))
   }
 }

--- a/src/libs/test-utils.js
+++ b/src/libs/test-utils.js
@@ -1,0 +1,5 @@
+export const waitOneTick = () => new Promise(setImmediate)
+
+export const waitOneTickAndUpdate = wrapper => {
+  return waitOneTick().then(() => wrapper.update())
+}

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -25,7 +25,7 @@ export class WorkspaceList extends Component {
   }
 
   componentWillMount() {
-    Rawls.workspacesList(
+    Rawls.workspacesList().then(
       workspaces => this.setState({
         workspaces: _.sortBy(_.filter(workspaces,
           ws => !ws.public || Utils.workspaceAccessLevels.indexOf(ws.accessLevel) >

--- a/src/pages/workspaces/workspace/Container.js
+++ b/src/pages/workspaces/workspace/Container.js
@@ -66,8 +66,10 @@ export class WorkspaceContainer extends Component {
   loadWorkspace() {
     const { namespace, name } = this.props
 
-    Rawls.workspaceDetails(namespace, name, workspace => this.setState({ workspace }),
-      workspaceFailure => this.setState({ workspaceFailure }))
+    Rawls.workspaceDetails(namespace, name).then(
+      workspace => this.setState({ workspace }),
+      workspaceFailure => this.setState({ workspaceFailure })
+    )
   }
 
   render() {

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -13,7 +13,7 @@ export default class WorkspaceData extends Component {
   componentWillMount() {
     const { namespace, name } = this.props.workspace
 
-    Rawls.workspaceEntities(namespace, name,
+    Rawls.workspaceEntities(namespace, name).then(
       workspaceEntities => this.setState({ workspaceEntities }),
       entitiesFailure => this.setState({ entitiesFailure })
     )
@@ -31,7 +31,7 @@ export default class WorkspaceData extends Component {
           },
           onClick: () => {
             this.setState({ selectedEntityType: type, selectedEntities: null })
-            Rawls.workspaceEntity(namespace, name, type,
+            Rawls.workspaceEntity(namespace, name, type).then(
               selectedEntities => this.setState({ selectedEntities }),
               entityFailure => this.setState({ entityFailure })
             )


### PR DESCRIPTION
This converts the ajax code to leverage promises instead of callbacks. The main benefits are added flexibility via composition and chaining, and cleaner error handling. See `listNotebooks` for a good example of what's possible.

Notes:

* This pattern still allows us to abstract out common behaviors, e.g. treating non-200 responses as errors, and exposing their text content. See `fetchOk` for how that's done.
* This required tweaking the enzyme tests slightly to respect the async nature of the promises. See `Dashboard.test.js`
* I decided to make the auth options explicit rather than implicit, to make it clear where tokens are being used. (Open to discussion, of course)
* This opens up the possibility of using async/await to further flatten out the logic, if desired.