### PR TITLE
memoize token fetching to speed up subsequent requests

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -58,13 +58,13 @@ const fetchOk = (...args) => {
 
 
 const Sam = {
-  token: (namespace) => {
+  token: Utils.memoizeWithTimeout((namespace) => {
     const scopes = ['https://www.googleapis.com/auth/devstorage.full_control']
     return fetchOk(`${Config.getSamUrlRoot()}/api/google/user/petServiceAccount/${namespace}/token`,
       _.merge(authOpts(), jsonBody(scopes), { method: 'POST' })
     )
       .then(parseJson)
-  }
+  }, 1000 * 60 * 30)
 }
 
 

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -64,7 +64,7 @@ const Sam = {
       _.merge(authOpts(), jsonBody(scopes), { method: 'POST' })
     )
       .then(parseJson)
-  }, 1000 * 60 * 30)
+  }, namespace => namespace, 1000 * 60 * 30)
 }
 
 

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -63,3 +63,22 @@ export const cond = function(...args) {
 
   return maybeCall(match ? match[1] : defaultValue)
 }
+
+/**
+ * Memoizes the given function, but expires after the specified duration (ms).
+ * Uses the first argument of the function as the cache key.
+ */
+export const memoizeWithTimeout = (fn, ms) => {
+  const cache = {}
+  return (...args) => {
+    const now = Date.now()
+    const key = args[0]
+    const cached = cache[key]
+    if (cached && now < cached.timestamp + ms) {
+      return cached.value
+    }
+    const value = fn(...args)
+    cache[key] = { timestamp: now, value }
+    return value
+  }
+}

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -66,13 +66,13 @@ export const cond = function(...args) {
 
 /**
  * Memoizes the given function, but expires after the specified duration (ms).
- * Uses the first argument of the function as the cache key.
+ * The resolver function is used to generate a cache key from the arguments.
  */
-export const memoizeWithTimeout = (fn, ms) => {
+export const memoizeWithTimeout = (fn, resolver, ms) => {
   const cache = {}
   return (...args) => {
     const now = Date.now()
-    const key = args[0]
+    const key = resolver(...args)
     const cached = cache[key]
     if (cached && now < cached.timestamp + ms) {
       return cached.value


### PR DESCRIPTION
It turns out that getting a token from the Sam service takes about 800ms. That's enough to make it worthwhile to cache and reuse tokens to avoid paying that cost on every call.