### PR TITLE
don't encode notebook names

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -69,7 +69,7 @@ const Sam = {
 
 
 const fetchBuckets = (path, ...args) => fetchOk(`https://www.googleapis.com/${path}`, ...args)
-const nbName = name => encodeURIComponent(`notebooks/${name}.ipynb`)
+const nbName = name => `notebooks/${name}.ipynb`
 
 export const Buckets = {
   copyNotebook: (namespace, bucket, oldName, newName) => {

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -192,7 +192,7 @@ export default class WorkspaceNotebooks extends Component {
 
         _.forEach(notebooks, ({ bucket, name }) => {
           Leo.localizeNotebooks(namespace, cluster, {
-              [`~/${wsName}/${name.slice(10)}`]: `gs://${bucket}/${encodeURIComponent(name)}`
+              [`~/${wsName}/${name.slice(10)}`]: `gs://${bucket}/${name}`
             }).then(
               () => this.setState(oldState => _.merge({ notebookAccess: { [name]: true } }, oldState)),
               () => this.setState(oldState => _.merge({ notebookAccess: { [name]: false } }, oldState))


### PR DESCRIPTION
This was causing downstream processing to fail when certain characters were used.