### PR TITLE
introduce a modified redux implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5075,6 +5075,11 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
       "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA=="
     },
+    "immutable": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
+      "integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM="
+    },
     "import-lazy": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
@@ -6789,6 +6794,11 @@
       "version": "4.17.10",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
       "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+    },
+    "lodash-es": {
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.10.tgz",
+      "integrity": "sha512-iesFYPmxYYGTcmQK0sL8bX3TGHyM6b2qREaB4kamHfQyfPJP0xgoGxp19nsH16nsfquLdiyKyX3mQkfiSGV8Rg=="
     },
     "lodash._getnative": {
       "version": "3.9.1",
@@ -9426,6 +9436,19 @@
         "prop-types": "^15.6.0"
       }
     },
+    "react-redux": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.7.tgz",
+      "integrity": "sha512-5VI8EV5hdgNgyjfmWzBbdrqUkrVRKlyTKk1sGH3jzM2M2Mhj/seQgPXaz6gVAj2lz/nz688AdTqMO18Lr24Zhg==",
+      "requires": {
+        "hoist-non-react-statics": "^2.5.0",
+        "invariant": "^2.0.0",
+        "lodash": "^4.17.5",
+        "lodash-es": "^4.17.5",
+        "loose-envify": "^1.1.0",
+        "prop-types": "^15.6.0"
+      }
+    },
     "react-scripts": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-1.1.4.tgz",
@@ -9655,6 +9678,15 @@
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
           "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
         }
+      }
+    },
+    "redux": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.0.tgz",
+      "integrity": "sha512-NnnHF0h0WVE/hXyrB6OlX67LYRuaf/rJcbWvnHHEPCF/Xa/AZpwhs/20WyqzQae5x4SD2F9nPObgBh2rxAgLiA==",
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "symbol-observable": "^1.2.0"
       }
     },
     "regenerate": {
@@ -10798,6 +10830,11 @@
         "path-to-regexp": "^1.0.1",
         "serviceworker-cache-polyfill": "^4.0.0"
       }
+    },
+    "symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "symbol-tree": {
       "version": "3.2.2",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@clr/icons": "^0.11.14",
     "@webcomponents/custom-elements": "^1.1.0",
+    "immutable": "^3.8.2",
     "lodash": "^4.17.10",
     "rc-table": "^6.1.10",
     "react": "^16.3.2",
@@ -14,8 +15,10 @@
     "react-hot-loader": "^4.1.2",
     "react-hyperscript-helpers": "^1.2.0",
     "react-interactive": "^0.8.1",
+    "react-redux": "^5.0.7",
     "react-scripts": "1.1.4",
-    "react-select": "^1.2.1"
+    "react-select": "^1.2.1",
+    "redux": "^4.0.0"
   },
   "scripts": {
     "start": "react-app-rewired start",

--- a/src/_tests/pages/workspaces/List.test.js
+++ b/src/_tests/pages/workspaces/List.test.js
@@ -1,21 +1,25 @@
 import { mount } from 'enzyme'
 import { h } from 'react-hyperscript-helpers'
+import { Provider } from 'react-redux'
 import TestRenderer from 'react-test-renderer'
 import { DataGrid } from 'src/components/table'
 import { waitOneTick, waitOneTickAndUpdate } from 'src/libs/test-utils'
 import { WorkspaceList } from 'src/pages/workspaces/List'
+import store from 'src/store'
 
+
+const WrappedWorkspaceList = () => h(Provider, { store }, [h(WorkspaceList)])
 
 describe('WorkspaceList', () => {
   it('should render as expected', () => {
-    const renderer = TestRenderer.create(h(WorkspaceList))
+    const renderer = TestRenderer.create(h(WrappedWorkspaceList))
     return waitOneTick().then(() => {
       expect(renderer.toJSON()).toMatchSnapshot()
     })
   })
 
   it('should switch between Grid and List view', () => {
-    const wrapper = mount(h(WorkspaceList))
+    const wrapper = mount(h(WrappedWorkspaceList))
     return waitOneTickAndUpdate(wrapper).then(() => {
       const currentCardsPerRow = () => wrapper.find(DataGrid).props().cardsPerRow
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,9 @@
 import ReactDOM from 'react-dom'
 import { h } from 'react-hyperscript-helpers'
+import { Provider } from 'react-redux'
 import Main from 'src/pages/Main'
+import store from 'src/store'
 import 'src/style.css'
 
 
-ReactDOM.render(h(Main), document.getElementById('root'))
+ReactDOM.render(h(Provider, { store }, [h(Main)]), document.getElementById('root'))

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -63,3 +63,8 @@ export const cond = function(...args) {
 
   return maybeCall(match ? match[1] : defaultValue)
 }
+
+export const thunk = fn => {
+  fn.thunk = true
+  return fn
+}

--- a/src/store.js
+++ b/src/store.js
@@ -1,0 +1,32 @@
+import { Record } from 'immutable'
+import { createStore, applyMiddleware } from 'redux'
+
+const initialState = new (Record({
+  workspaces: new (Record({
+    filter: '',
+    listView: false,
+    itemsPerPage: 6,
+    pageNumber: 1,
+    workspaces: null,
+    failure: undefined,
+  }))()
+}))()
+
+const funcMiddleware = ({ dispatch, getState }) => next => action => {
+  if (typeof action === 'function') {
+    if (action.thunk) {
+      return action(dispatch, getState)
+    }
+    return next({ type: 'update', fn: action })
+  }
+  return next(action)
+}
+
+const reducer = (state = initialState, action) => {
+  return action.type === 'update' ? action.fn(state) : state
+}
+
+const store = createStore(reducer, applyMiddleware(funcMiddleware))
+window.store = store
+
+export default store


### PR DESCRIPTION
Here is a POC for a 'lite' implementation of redux. It effectively allows inline reducer functions, with the following results:

* State transition code remains attached to the calling component, keeping things local.
* Logging and instrumentation capabilities are reduced slightly.
* There is still a central store, with previously outlined benefits.
* Testing is slightly less straightforward.

Here's an overview of how it works:

We're still using Redux itself, but tweaking the flow of information. All dispatched actions are now expected to be functions. A plain function will be treated as a state transition, and should describe a transformation from one store state to the next. A function decorated with a `thunk` property will be treated as a thunk, and called as before. (There's a `thunk` utility function to make this concise)

See `List.js` for a good example of what it looks like in practice.