### PR TITLE
add a basic style guide page to showcase components

### DIFF
--- a/src/pages/Main.js
+++ b/src/pages/Main.js
@@ -5,6 +5,7 @@ import * as Config from 'src/libs/config'
 import * as Nav from 'src/libs/nav'
 import * as Utils from 'src/libs/utils'
 import { Component } from 'src/libs/wrapped-components'
+import * as StyleGuide from 'src/pages/StyleGuide'
 import * as WorkspaceList from 'src/pages/workspaces/List'
 import * as WorkspaceContainer from 'src/pages/workspaces/workspace/Container'
 
@@ -13,6 +14,7 @@ const initNavPaths = () => {
   Nav.clearPaths()
   WorkspaceList.addNavPaths()
   WorkspaceContainer.addNavPaths()
+  StyleGuide.addNavPaths()
 }
 
 class Main extends Component {

--- a/src/pages/StyleGuide.js
+++ b/src/pages/StyleGuide.js
@@ -1,0 +1,46 @@
+import { div, h1 } from 'react-hyperscript-helpers'
+import * as Nav from 'src/libs/nav'
+import { buttonPrimary, textInput, link, search } from 'src/components/common'
+
+
+const styles = {
+  container: {
+    marginTop: '1rem',
+    marginBottom: '1rem'
+  }
+}
+
+const StyleGuide = () => {
+  return div({ style: { paddingLeft: '1rem', paddingRight: '1rem' } }, [
+    h1('Style guide'),
+    div({ style: styles.container }, [
+      buttonPrimary({}, 'Primary button')
+    ]),
+    div({ style: styles.container }, [
+      buttonPrimary({ disabled: true }, 'Disabled button')
+    ]),
+    div({ style: styles.container }, [
+      link({}, 'Link')
+    ]),
+    div({ style: styles.container }, [
+      search({ inputProps: { placeholder: 'Search' } })
+    ]),
+    div({ style: styles.container }, [
+      textInput({ placeholder: 'Text box' })
+    ])
+  ])
+}
+
+export default StyleGuide
+
+export const addNavPaths = () => {
+  Nav.defPath(
+    'styles',
+    {
+      component: StyleGuide,
+      regex: /styles$/,
+      makeProps: () => ({}),
+      makePath: () => 'styles'
+    }
+  )
+}


### PR DESCRIPTION
This will be useful as we build out and tweak components. It's very simple for now, but we can make it more sophisticated over time if desired.

The page lives at /#styles