### PR TITLE
streamline routing code

### DIFF
--- a/src/components/Router.js
+++ b/src/components/Router.js
@@ -1,5 +1,5 @@
 import { Component } from 'react'
-import { h, h2 } from 'react-hyperscript-helpers'
+import { h2 } from 'react-hyperscript-helpers'
 import * as Nav from 'src/libs/nav'
 import * as Import from 'src/pages/Import'
 import * as StyleGuide from 'src/pages/StyleGuide'
@@ -43,7 +43,6 @@ export default class Router extends Component {
 
   render() {
     const { windowHash } = this.state
-    const { component, makeProps } = Nav.findPathHandler(windowHash) || {}
-    return component ? h(component, makeProps()) : h2('No matching path.')
+    return Nav.renderPath(windowHash) || h2('No matching path.')
   }
 }

--- a/src/pages/Import.js
+++ b/src/pages/Import.js
@@ -176,9 +176,8 @@ export const addNavPaths = () => {
   Nav.defPath(
     'import',
     {
-      component: Importer,
       regex: /import\/([^/]+)\/(.+)$/,
-      makeProps: (source, item) => ({ source, item }),
+      render: (source, item) => h(Importer, { source, item }),
       makePath: (source, item) => `/import/${source}/${item}`
     }
   )

--- a/src/pages/StyleGuide.js
+++ b/src/pages/StyleGuide.js
@@ -64,9 +64,8 @@ export const addNavPaths = () => {
   Nav.defPath(
     'styles',
     {
-      component: StyleGuide,
       regex: /styles$/,
-      makeProps: () => ({}),
+      render: () => h(StyleGuide),
       makePath: () => 'styles'
     }
   )

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -178,9 +178,8 @@ export const addNavPaths = () => {
   Nav.defPath(
     'workspaces',
     {
-      component: WorkspaceList,
       regex: /workspaces$/,
-      makeProps: () => ({}),
+      render: () => h(WorkspaceList),
       makePath: () => 'workspaces'
     }
   )

--- a/src/pages/workspaces/workspace/Container.js
+++ b/src/pages/workspaces/workspace/Container.js
@@ -156,9 +156,8 @@ export const addNavPaths = () => {
   Nav.defPath(
     'workspace',
     {
-      component: WorkspaceContainer,
       regex: /workspaces\/([^/]+)\/([^/]+)\/?([^/]*)/,
-      makeProps: (namespace, name, activeTab) => ({ namespace, name, activeTab }),
+      render: (namespace, name, activeTab) => h(WorkspaceContainer, { namespace, name, activeTab }),
       makePath: (namespace, name, activeTab) =>
         `workspaces/${namespace}/${name}${activeTab ? `/${activeTab}` : ''}`
     }


### PR DESCRIPTION
This tweaks the route handling code to be a bit simpler and more flexible. The `makeProps` and `component` properties have been replaced by a `render` function, which takes the parsed regex parameters and returns a rendered element. This will enable an upcoming change to wrap certain individual pages in a wrapper component.