### PR TITLE
check auth on a per-page basis

### DIFF
--- a/src/components/AuthContainer.js
+++ b/src/components/AuthContainer.js
@@ -13,13 +13,16 @@ export default class AuthContainer extends Component {
   }
 
   componentDidMount() {
+    Utils.isSignedIn.subscribe(this.handleSignIn)
     this.loadAuth()
+  }
+
+  componentWillUnmount() {
+    Utils.isSignedIn.unsubscribe(this.handleSignIn)
   }
 
   loadAuth = async () => {
     await Utils.initializeAuth()
-    this.handleSignIn(Utils.getAuthInstance().isSignedIn.get())
-    Utils.getAuthInstance().isSignedIn.listen(this.handleSignIn)
     window.gapi.signin2.render('signInButton', { scope: 'openid profile email' })
   }
 

--- a/src/components/Router.js
+++ b/src/components/Router.js
@@ -1,5 +1,6 @@
 import { Component } from 'react'
 import { h, h2 } from 'react-hyperscript-helpers'
+import AuthContainer from 'src/components/AuthContainer'
 import * as Nav from 'src/libs/nav'
 import * as Import from 'src/pages/Import'
 import * as StyleGuide from 'src/pages/StyleGuide'
@@ -44,6 +45,7 @@ export default class Router extends Component {
     if (!handler) {
       return h2('No matching path.')
     }
-    return h(handler.component, Nav.getHandlerProps(handler, pathname))
+    const el = h(handler.component, Nav.getHandlerProps(handler, pathname))
+    return handler.public ? el : h(AuthContainer, [el])
   }
 }

--- a/src/libs/nav.js
+++ b/src/libs/nav.js
@@ -14,7 +14,7 @@ let allPathHandlers = {}
  * @param {string} handler.path - path spec handled by path-to-regexp
  * @param handler.component - component to render
  */
-export const defPath = (k, { path, component }) => {
+export const defPath = (k, { path, component, ...data }) => {
   console.assert(!_.has(allPathHandlers, k), `Key ${k} is already defined`)
   const keys = [] // mutated by pathToRegexp
   const regex = pathToRegexp(path, keys)
@@ -22,7 +22,8 @@ export const defPath = (k, { path, component }) => {
     regex,
     component,
     keys: _.map(keys, 'name'),
-    makePath: pathToRegexp.compile(path)
+    makePath: pathToRegexp.compile(path),
+    ...data
   }
 }
 

--- a/src/pages/Main.js
+++ b/src/pages/Main.js
@@ -1,9 +1,8 @@
 import { hot } from 'react-hot-loader'
 import { h } from 'react-hyperscript-helpers'
-import AuthContainer from 'src/components/AuthContainer'
 import Router from 'src/components/Router'
 
 
-const Main = () => h(AuthContainer, [h(Router)])
+const Main = () => h(Router)
 
 export default hot(module)(Main)

--- a/src/pages/StyleGuide.js
+++ b/src/pages/StyleGuide.js
@@ -63,6 +63,7 @@ class StyleGuide extends Component {
 export const addNavPaths = () => {
   Nav.defPath('styles', {
     path: '/styles',
-    component: StyleGuide
+    component: StyleGuide,
+    public: true
   })
 }


### PR DESCRIPTION
This flips the order of AuthContainer and Router, so auth can be applied on a per-page basis.

Note: the `subscribable` thing is necessary because the Google Auth API doesn't seem to provide a way to unregister a listener e.g. on component unmount. So we set up one dedicated listener, and proxy the value through the `subscribable`, giving us the capabilities that we need.