### PR TITLE
tune up modal behavior

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -1,7 +1,6 @@
 import _ from 'lodash'
-import { Fragment } from 'react'
 import * as ReactDOM from 'react-dom'
-import { div, h } from 'react-hyperscript-helpers'
+import { div } from 'react-hyperscript-helpers'
 import { buttonPrimary } from 'src/components/common'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
@@ -41,22 +40,20 @@ export default class Modal extends Component {
   }
 
   render() {
-    const { onDismiss, title, children, showCancel = true, okButton } = this.props
+    const { onDismiss, title, children, width = 450, showCancel = true, okButton } = this.props
 
-    const component = h(Fragment, [
+    const component = div({
+      style: {
+        backgroundColor: 'rgba(0, 0, 0, 0.5)', padding: '2rem 1rem',
+        display: 'flex', justifyContent: 'center', alignItems: 'flex-start',
+        position: 'fixed', left: 0, right: 0, top: 0, bottom: 0, overflowY: 'auto'
+      }
+    }, [
       div({
         style: {
-          backgroundColor: 'black', opacity: '0.5',
-          position: 'fixed', left: 0, right: 0, top: 0, bottom: 0
-        }
-      }),
-      div({
-        style: {
-          minHeight: '20%', maxHeight: '90%', minWidth: '30%', maxWidth: '90%', borderRadius: 5,
+          width, borderRadius: 5,
           padding: '1.5rem 1.25rem',
-          backgroundColor: 'white', boxShadow: Style.modalShadow,
-          position: 'fixed', left: '50%', top: '50%', transform: 'translate(-50%, -50%)',
-          display: 'flex', flexDirection: 'column'
+          backgroundColor: 'white', boxShadow: Style.modalShadow
         }
       },
       [
@@ -64,8 +61,8 @@ export default class Modal extends Component {
         children,
         div({
           style: {
-            flexShrink: 0, marginTop: '1rem', alignSelf: 'flex-end',
-            display: 'flex', alignItems: 'baseline'
+            flexShrink: 0, marginTop: '1rem',
+            display: 'flex', justifyContent: 'flex-end', alignItems: 'baseline'
           }
         }, [
           showCancel ?

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -14,7 +14,8 @@ export default class WorkspaceDashboard extends Component {
         onDismiss: () => this.setState({ modal: false }),
         title: 'Workspace Info',
         showCancel: false,
-        okButton: 'Done'
+        okButton: 'Done',
+        width: 600
       }, [
         div({ style: { whiteSpace: 'pre', overflow: 'auto', padding: '1rem' } },
           JSON.stringify(this.props, null, 2))

--- a/src/pages/workspaces/workspace/Tools.js
+++ b/src/pages/workspaces/workspace/Tools.js
@@ -15,7 +15,8 @@ export default class WorkspaceTools extends Component {
     return div({ style: { margin: '1rem' } }, [
       modal ? h(Modal, {
         onDismiss: () => this.setState({ modal: false }),
-        okButton: buttonPrimary({ onClick: () => this.setState({ modal: false }) }, 'Run')
+        okButton: buttonPrimary({ onClick: () => this.setState({ modal: false }) }, 'Run'),
+        width: 800
       }, [
         img({ src: '/launchAnalysis.png', width: 759 }) // placeholder
       ]) : null,


### PR DESCRIPTION
This improves the UX of modals in certain use cases:
* Modals are pinned near the top of the screen, rather than the center. This causes the modal to grow downward, which eliminates certain vertical resize problems, e.g. validation messages causing the input to move up.
* Modal width is explicit, rather than implicit based on content and screen size. This should improve layout consistency.
* If the modal content is large enough to flow off the screen, a scroll bar will appear.