### PR TITLE
Fix filtering on project list

### DIFF
--- a/src/components/table.js
+++ b/src/components/table.js
@@ -163,20 +163,12 @@ export class DataTable extends Component {
  * @param {number} [cardsPerRow=3]
  */
 export class DataGrid extends Component {
-  constructor(props) {
-    super(props)
-    this.state = {
-      pageNumber: props.initialPage || 1,
-      itemsPerPage: props.defaultItemsPerPage || 12
-    }
-  }
-
   render() {
     const {
       allowPagination = true, allowItemsPerPage = true, itemsPerPageOptions = [12, 24, 36, 48],
-      onItemsPerPageChanged, onPageChanged, dataSource, renderCard, cardsPerRow = 3
+      onItemsPerPageChanged, onPageChanged, dataSource, renderCard, cardsPerRow = 3,
+      pageNumber, itemsPerPage
     } = this.props
-    const { pageNumber, itemsPerPage } = this.state
 
     const listPage = dataSource.slice((pageNumber - 1) * itemsPerPage, pageNumber * itemsPerPage)
 
@@ -187,15 +179,9 @@ export class DataGrid extends Component {
         div({ style: { marginTop: 10 } }, [
           paginator({
             filteredDataLength: dataSource.length,
-            setPageNumber: (n => {
-              this.setState({ pageNumber: n })
-              if (onPageChanged) onPageChanged(n)
-            }),
+            setPageNumber: onPageChanged,
             pageNumber,
-            setItemsPerPage: allowItemsPerPage && (n => {
-              this.setState({ itemsPerPage: n })
-              if (onItemsPerPageChanged) onItemsPerPageChanged(n)
-            }),
+            setItemsPerPage: allowItemsPerPage && onItemsPerPageChanged,
             itemsPerPage, itemsPerPageOptions
           })
         ]) :

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -153,14 +153,14 @@ export class DataTable extends Component {
 /**
  * @param {bool} [allowPagination=true]
  * @param {bool} [allowItemsPerPage=true]
- * @param {number} [defaultItemsPerPage=12]
  * @param {number[]} [itemsPerPageOptions=[12, 24, 36, 48]]
  * @param {function(number)} [onItemsPerPageChanged]
- * @param {number} [initialPage=1]
  * @param {function(number)} [onPageChanged]
  * @param {object[]} dataSource
  * @param {function} renderCard - function(record, cardsPerRow) => renderable
  * @param {number} [cardsPerRow=3]
+ * @param {number} pageNumber
+ * @param {number} itemsPerPage
  */
 export class DataGrid extends Component {
   render() {

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -38,10 +38,10 @@ export class WorkspaceList extends Component {
 
   getDataViewerProps() {
     return {
-      defaultItemsPerPage: this.state.itemsPerPage,
       itemsPerPageOptions: [6, 12, 24, 36, 48],
+      itemsPerPage: this.state.itemsPerPage,
       onItemsPerPageChanged: n => this.setState({ itemsPerPage: n }),
-      initialPage: this.state.pageNumber,
+      pageNumber: this.state.pageNumber,
       onPageChanged: n => this.setState({ pageNumber: n }),
       dataSource: this.state.workspaces.filter(({ workspace: { namespace, name } }) =>
         `${namespace}/${name}`.includes(this.state.filter))
@@ -131,7 +131,7 @@ export class WorkspaceList extends Component {
             wrapperProps: { style: { marginLeft: '2rem', flexGrow: 1, maxWidth: 500 } },
             inputProps: {
               placeholder: 'SEARCH BIOSPHERE',
-              onChange: e => this.setState({ filter: e.target.value }),
+              onChange: e => this.setState({ filter: e.target.value, pageNumber: 1 }),
               value: filter
             }
           })


### PR DESCRIPTION
There was duplicated state between the project list and the DataGrid. I got rid of it, and made filtering reset the page to 1.

We're gonna have the same problem when we add filtering to the various DataTables. And with this pattern, each user of DataGrid/DataTable needs to create their own pageNumber/perPage/filterText state to pass in. So I don't like this going forward.