### PR TITLE
add more eslint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,6 +42,14 @@ module.exports = {
 
 
     'arrow-parens': ['warn', 'as-needed'],
-    'arrow-spacing': 'warn'
+    'arrow-spacing': 'warn',
+    'no-duplicate-imports': 'warn',
+    'no-var': 'warn',
+    'prefer-arrow-callback': 'warn',
+    'prefer-const': 'warn',
+    'prefer-rest-params': 'warn',
+    'prefer-spread': 'warn',
+    'rest-spread-spacing': 'warn',
+    'template-curly-spacing': 'warn'
   }
 }

--- a/src/components/AuthContainer.js
+++ b/src/components/AuthContainer.js
@@ -41,7 +41,7 @@ export default class AuthContainer extends Component {
       })
 
       const [billingProjects, clusters] = await Promise.all([Rawls.listBillingProjects(), Leo.clustersList()])
-      let projectsWithoutClusters = _.difference(
+      const projectsWithoutClusters = _.difference(
         _.map(billingProjects, 'projectName'),
         _.map(clusters, 'googleProject')
       )

--- a/src/components/WDLViewer.js
+++ b/src/components/WDLViewer.js
@@ -4,7 +4,7 @@ import * as Style from 'src/libs/style'
 import { Component } from 'src/libs/wrapped-components'
 
 
-CodeMirror.defineMode('wdl', function() {
+CodeMirror.defineMode('wdl', () => {
   return {
     token: stream => {
       stream.eatSpace()

--- a/src/components/notebook-utils.js
+++ b/src/components/notebook-utils.js
@@ -159,7 +159,7 @@ export class NotebookDuplicator extends Component {
 
     return h(Modal, {
       onDismiss: onDismiss,
-      title: `${destroyOld ? 'Rename' : 'Duplicate' } "${printName}"`,
+      title: `${destroyOld ? 'Rename' : 'Duplicate'} "${printName}"`,
       okButton: buttonPrimary({
         disabled: nameErrors || processing,
         onClick: () => {
@@ -169,11 +169,11 @@ export class NotebookDuplicator extends Component {
             failure => this.setState({ failure })
           )
         }
-      }, `${destroyOld ? 'Rename' : 'Duplicate' } Notebook`)
+      }, `${destroyOld ? 'Rename' : 'Duplicate'} Notebook`)
     },
     Utils.cond(
       [processing, () => [spinner()]],
-      [failure, () => `Couldn't ${destroyOld ? 'rename' : 'copy' } notebook: ${failure}`],
+      [failure, () => `Couldn't ${destroyOld ? 'rename' : 'copy'} notebook: ${failure}`],
       () => [
         div({ style: Style.elements.sectionHeader }, 'New Name'),
         notebookNameInput({

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -47,7 +47,7 @@ export default class WorkspaceData extends Component {
       tableProps: {
         rowKey: 'name',
         scroll: { x: true },
-        columns: _.map(workspaceEntities[selectedEntityType]['attributeNames'], function(name) {
+        columns: _.map(workspaceEntities[selectedEntityType]['attributeNames'], name => {
           return {
             title: name,
             key: name,


### PR DESCRIPTION
This adds a few more rules around ES6 features. Of note:
* `var` is prohibited, and `const` is preferred over `let` if there is no mutation
* Arrow functions are preferred over `function` when used as a callback