### PR TITLE
add compliance warnings to logged out screen

### DIFF
--- a/src/components/AuthContainer.js
+++ b/src/components/AuthContainer.js
@@ -1,15 +1,17 @@
 import _ from 'lodash'
 import { Component, Fragment } from 'react'
-import { div, h } from 'react-hyperscript-helpers'
+import { div, h, h4, hr, p } from 'react-hyperscript-helpers'
 import Modal from 'src/components/Modal'
+import { link } from 'src/components/common'
 import { Leo, Rawls, Sam } from 'src/libs/ajax'
+import * as Nav from 'src/libs/nav'
 import * as Utils from 'src/libs/utils'
 
 
 export default class AuthContainer extends Component {
   constructor(props) {
     super(props)
-    this.state = { isSignedIn: false, isShowingNotRegisteredModal: false }
+    this.state = { isSignedIn: undefined, isShowingNotRegisteredModal: false }
   }
 
   componentDidMount() {
@@ -72,13 +74,55 @@ export default class AuthContainer extends Component {
     }, 'Registering in Saturn is not yet supported. Please register by logging into FireCloud.')
   }
 
+  renderSignedOut = () => {
+    return div({ style: { paddingLeft: '1rem', paddingRight: '1rem' } }, [
+      h4('WARNING NOTICE'),
+      p([
+        'You are accessing a US Government web site which may contain information that must be ',
+        'protected under the US Privacy Act or other sensitive information and is intended for ',
+        'Government authorized use only.'
+      ]),
+      p([
+        'Unauthorized attempts to upload information, change information, or use of this web site ',
+        'may result in disciplinary action, civil, and/or criminal penalties. Unauthorized users ',
+        'of this website should have no expectation of privacy regarding any communications or ',
+        'data processed by this website.'
+      ]),
+      p([
+        'Anyone accessing this website expressly consents to monitoring of their actions and all ',
+        'communications or data transiting or stored on related to this website and is advised ',
+        'that if such monitoring reveals possible evidence of criminal activity, NIH may provide ',
+        'that evidence to law enforcement officials.'
+      ]),
+      h4('WARNING NOTICE (when accessing TCGA controlled data)'),
+      p([
+        'You are reminded that when accessing TCGA controlled access information you are bound by ',
+        'the dbGaP TCGA ',
+        link({ target: '_blank', href: 'http://cancergenome.nih.gov/pdfs/Data_Use_Certv082014' }, [
+          'DATA USE CERTIFICATION AGREEMENT (DUCA)'
+        ])
+      ]),
+      hr(),
+      p([
+        'Copyright © 2018, Broad Institute, Inc., Verily Life Sciences LLC | ',
+        link({ href: 'http://gatkforums.broadinstitute.org/firecloud/discussion/6819/firecloud-terms-of-service#latest' }, 'Terms of Service'),
+        ' | ',
+        link({ href: Nav.getLink('privacy') }, 'Privacy Policy')
+      ])
+    ])
+  }
+
   render() {
     const { children } = this.props
     const { isSignedIn, isShowingNotRegisteredModal } = this.state
     return h(Fragment, [
       div({ id: 'signInButton', style: { display: isSignedIn ? 'none' : 'block' } }),
       isShowingNotRegisteredModal && this.renderNotRegisteredModal(),
-      isSignedIn && children
+      Utils.cond(
+        [isSignedIn === false, this.renderSignedOut],
+        [isSignedIn === true, children],
+        null
+      )
     ])
   }
 }

--- a/src/components/Router.js
+++ b/src/components/Router.js
@@ -3,6 +3,7 @@ import { h, h2 } from 'react-hyperscript-helpers'
 import AuthContainer from 'src/components/AuthContainer'
 import * as Nav from 'src/libs/nav'
 import * as Import from 'src/pages/Import'
+import * as PrivacyPolicy from 'src/pages/PrivacyPolicy'
 import * as StyleGuide from 'src/pages/StyleGuide'
 import * as WorkspaceList from 'src/pages/workspaces/List'
 import * as WorkspaceContainer from 'src/pages/workspaces/workspace/Container'
@@ -14,6 +15,7 @@ const initNavPaths = () => {
   WorkspaceContainer.addNavPaths()
   StyleGuide.addNavPaths()
   Import.addNavPaths()
+  PrivacyPolicy.addNavPaths()
 }
 
 export default class Router extends Component {

--- a/src/pages/PrivacyPolicy.js
+++ b/src/pages/PrivacyPolicy.js
@@ -1,0 +1,99 @@
+import { div, h4, p } from 'react-hyperscript-helpers'
+import { link } from 'src/components/common'
+import * as Nav from 'src/libs/nav'
+
+const url = 'https://bvdp-saturn-prod.appspot.com/'
+
+const PrivacyPolicy = () => {
+  return div({ style: { paddingLeft: '1rem', paddingRight: '1rem' } }, [
+    h4('Saturn Privacy Policy'),
+    p([
+      'The following Privacy Policy discloses our information gathering and dissemination ',
+      'practices for the Broad Institute Saturn application accessed via the website ',
+      link({ href: url }, url),
+      '. By using Saturn, you agree to the collection and use of information in accordance with ',
+      'this policy. This Privacy Policy is effective as of 1-19-2017.'
+    ]),
+    h4('Information Gathering'),
+    p([
+      'The Broad Institute Saturn receives and stores information related to users’ Google ',
+      'profiles, including names, email addresses, user IDs, and OAuth tokens. This information ',
+      'is gathered as part of the standard Google sign-in process.'
+    ]),
+    p([
+      'We also collect information that your browser sends whenever you visit the Saturn ',
+      'website (“Log Data”). This Log Data may include information such as your computer’s ',
+      'Internet Protocol (“IP”) address, browser type, browser version, which pages of the ',
+      'Saturn Portal that you visit, the time and date of your visit, the time spent on ',
+      'individual pages, and other statistics. This information may include any search terms ',
+      'that you enter on the Saturn (e.g., dataset name, method name, tag labels). We do not ',
+      'link IP addresses to any personally identifying information. User sessions will be ',
+      'tracked, but users will remain anonymous.'
+    ]),
+    p([
+      'In addition, we use web tools such as Google Analytics that collect, monitor, and analyze ',
+      'the Log Data. User information (i.e., name and email address) is not included in our ',
+      'Google Analytics tracking, but can be internally linked within the Saturn development ',
+      'team.'
+    ]),
+    h4('Use of Information'),
+    p([
+      'Saturn uses the information gathered above to enable integration with Google-based ',
+      'services that require a Google account, such as Google Cloud Storage Platform. We may ',
+      'also use this information to provide you with the services on Saturn, improve Saturn, and ',
+      'to communicate with you (e.g., about new feature announcements, unplanned site ',
+      'maintenance, and general notices). Web server logs are retained on a temporary basis and ',
+      'then deleted completely from our systems. User information is stored in a ',
+      'password-protected database, and OAuth tokens are only stored for the length of an active ',
+      'session, are encrypted at rest, and are deleted upon sign out.'
+    ]),
+    p([
+      'At no time do we disclose any user information to third parties.'
+    ]),
+    h4('Publicly Uploaded Information'),
+    p([
+      'Some features of Saturn are public facing (e.g, publishing a workspace in the Data ',
+      'Library) and allow you to upload information (such as new studies) that you may choose to ',
+      'make publicly available. If you choose to upload content is public-facing, third parties ',
+      'may access and use it. We do not sell any information that you provide to Saturn; it ',
+      'is yours. However, any information that you make publicly available may be accessed and ',
+      'used by third parties, such as research organizations or commercial third parties.'
+    ]),
+    h4('Security'),
+    p([
+      'This site has security measures in place to prevent the loss, misuse, or alteration of ',
+      'the information under our control. It is compliant with NIST-800-53 and has been audited ',
+      'as per FISMA Moderate. The Broad Institute, however, is not liable for the loss, misuse, ',
+      'or alteration of information on this site by any third party.'
+    ]),
+    h4('Changes'),
+    p([
+      'Although most changes are likely to be minor, we may change our Privacy Policy from time ',
+      'to time. We will notify you of material changes to this Privacy Policy through the Saturn ',
+      'website at least 30 days before the change takes effect by posting a notice on our home ',
+      'page or by sending an email to the email address associated with your user account. For ',
+      'changes to this Privacy Policy that do not affect your rights, we encourage you to check ',
+      'this page frequently.'
+    ]),
+    h4('Third Party Sites'),
+    p([
+      'Some Saturn pages may link to third party websites or services that are not maintained ',
+      'by the Broad Institute. The Broad Institute is not responsible for the privacy practices ',
+      'or the content of any such third party websites or services.'
+    ]),
+    h4('Contacting the Saturn team'),
+    p([
+      'If you have any questions about this privacy statement, the practices of this site, or ',
+      'your dealings with this site, you can contact us through our ',
+      link({ href: 'http://gatkforums.broadinstitute.org/firecloud' }, 'help forum')
+    ])
+  ])
+}
+
+export const addNavPaths = () => {
+  Nav.defPath('privacy', {
+    path: '/privacy',
+    component: PrivacyPolicy,
+    public: true
+  })
+}


### PR DESCRIPTION
Adds standard compliance warnings from Firecloud to the logged out page. Also adds a privacy policy page, which is the same text as Firecloud, but with the name swapped.

Note: this will be made nicer looking in a followup effort.