### PR TITLE
Implement input/output tables and allow editing

### DIFF
--- a/src/components/table.js
+++ b/src/components/table.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 import RCTable from 'rc-table'
 import { Fragment } from 'react'
-import { button, div, h, option, select, td, tr } from 'react-hyperscript-helpers'
+import { button, div, h, option, select, table, td, tr } from 'react-hyperscript-helpers'
 import Interactive from 'react-interactive'
 import Pagination from 'react-paginating'
 import { icon } from 'src/components/icons'
@@ -132,10 +132,22 @@ const defaultComponents = {
     }, props)),
     cell: props => td(_.merge({
       style: {
-        padding: '16.25px 19px 12.75px'
+        padding: '16.25px 19px 12.75px',
+        overflow: 'hidden'
       }
     }, props))
   }
+}
+
+export const components = {
+  fullWidthTable: ({
+    table: props => table(_.merge({
+      style: {
+        tableLayout: 'fixed',
+        width: '100%'
+      }
+    }, props))
+  })
 }
 
 /**
@@ -161,7 +173,7 @@ export class DataTable extends Component {
   render() {
     const {
       allowPagination = true, allowItemsPerPage = true, itemsPerPageOptions = [10, 25, 50, 100],
-      onItemsPerPageChanged, onPageChanged, dataSource, tableProps
+      onItemsPerPageChanged, onPageChanged, dataSource, tableProps, customComponents
     } = this.props
     const { pageNumber, itemsPerPage } = this.state
 
@@ -170,7 +182,7 @@ export class DataTable extends Component {
     return h(Fragment, [
       h(RCTable, _.extend({
         data: listPage,
-        components: defaultComponents
+        components: _.merge({}, defaultComponents, customComponents)
       }, tableProps)),
       allowPagination ?
         div({ style: { marginTop: 10 } }, [

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -157,19 +157,28 @@ export const Rawls = {
         return res.json()
       },
 
-      methodConfigs: {
-        list: async (allRepos = true) => {
-          const res = await fetchRawls(`${mcPath}?allRepos=${allRepos}`, authOpts())
-          return res.json()
-        },
+      listMethodConfigs: async (allRepos = true) => {
+        const res = await fetchRawls(`${mcPath}?allRepos=${allRepos}`, authOpts())
+        return res.json()
+      },
 
-        importFromDocker: payload => {
-          return fetchRawls(mcPath, _.merge(authOpts(), jsonBody(payload), { method: 'POST' }))
-        },
+      importMethodConfigFromDocker: payload => {
+        return fetchRawls(mcPath, _.merge(authOpts(), jsonBody(payload), { method: 'POST' }))
+      },
 
-        get: async (configNamespace, configName) => {
-          const res = await fetchRawls(`${mcPath}/${configNamespace}/${configName}`, authOpts())
-          return res.json()
+      methodConfig: (configNamespace, configName) => {
+        const path = `${mcPath}/${configNamespace}/${configName}`
+
+        return {
+          get: async () => {
+            const res = await fetchRawls(path, authOpts())
+            return res.json()
+          },
+
+          save: async payload => {
+            const res = await fetchRawls(path, _.merge(authOpts(), jsonBody(payload), { method: 'POST' }))
+            return res.json()
+          }
         }
       }
     }

--- a/src/pages/Import.js
+++ b/src/pages/Import.js
@@ -125,7 +125,7 @@ class DockstoreImporter extends Component {
     const { selectedWorkspace: { value: { namespace, name } } } = this.state
     const { path, version } = this.props
 
-    Rawls.workspace(namespace, name).methodConfigs.importFromDocker({
+    Rawls.workspace(namespace, name).importMethodConfigFromDocker({
       namespace, name: _.last(path.split('/')), rootEntityType: 'participant',
       // the line of shame:
       inputs: {}, outputs: {}, prerequisites: {}, methodConfigVersion: 1, deleted: false,

--- a/src/pages/workspaces/workspace/Tools.js
+++ b/src/pages/workspaces/workspace/Tools.js
@@ -65,7 +65,7 @@ export default class WorkspaceTools extends Component {
   componentDidMount() {
     const { workspace: { namespace, name } } = this.props
 
-    Rawls.workspace(namespace, name).methodConfigs.list()
+    Rawls.workspace(namespace, name).listMethodConfigs()
       .then(configs => this.setState({ configs }))
   }
 }

--- a/src/pages/workspaces/workspace/tools/WorkflowView.js
+++ b/src/pages/workspaces/workspace/tools/WorkflowView.js
@@ -55,10 +55,6 @@ class WorkflowView extends Component {
       selectedTab: 'Inputs', loadedWdl: false, untouched: true,
       modifiedAttributes: { inputs: {}, outputs: {} }
     }
-
-    const { workspaceNamespace, workspaceName, workflowNamespace, workflowName } = props
-    this.rawlsMethodConfig = Rawls.workspace(workspaceNamespace, workspaceName).methodConfig(workflowNamespace, workflowName)
-    this.workspaceId = { namespace: workspaceNamespace, name: workspaceName }
   }
 
   componentDidUpdate() {
@@ -69,9 +65,9 @@ class WorkflowView extends Component {
   }
 
   render() {
-    const { workspaceId } = this
     const { config } = this.state
-    const { workflowName } = this.props
+    const { workspaceNamespace, workspaceName, workflowName } = this.props
+    const workspaceId = { namespace: workspaceNamespace, name: workspaceName }
 
     return div({ style: { display: 'flex', flexDirection: 'column', height: '100%' } }, [
       h(TopBar, { title: 'Projects' }, [
@@ -103,7 +99,11 @@ class WorkflowView extends Component {
   }
 
   async componentDidMount() {
-    const config = await this.rawlsMethodConfig.get()
+    const { workspaceNamespace, workspaceName, workflowNamespace, workflowName } = this.props
+
+    const config = await Rawls.workspace(workspaceNamespace, workspaceName)
+      .methodConfig(workflowNamespace, workflowName)
+      .get()
     this.setState({ config })
 
     const inputsOutputs = await Rawls.methodConfigInputsOutputs(config)
@@ -280,10 +280,13 @@ class WorkflowView extends Component {
   }
 
   save = async () => {
+    const { workspaceNamespace, workspaceName, workflowNamespace, workflowName } = this.props
     const { config, modifiedAttributes } = this.state
 
     this.setState({ saving: true })
-    await this.rawlsMethodConfig.save(_.merge(config, modifiedAttributes))
+    await Rawls.workspace(workspaceNamespace, workspaceName)
+      .methodConfig(workflowNamespace, workflowName)
+      .save(_.merge(config, modifiedAttributes))
     this.setState({ saving: false, modified: false, modifiedAttributes: { inputs: {}, outputs: {} } })
   }
 }

--- a/src/pages/workspaces/workspace/tools/WorkflowView.js
+++ b/src/pages/workspaces/workspace/tools/WorkflowView.js
@@ -284,7 +284,7 @@ class WorkflowView extends Component {
 
     this.setState({ saving: true })
     await this.rawlsMethodConfig.save(_.merge(config, modifiedAttributes))
-    this.setState({ saving: false, modified: false })
+    this.setState({ saving: false, modified: false, modifiedAttributes: { inputs: {}, outputs: {} } })
   }
 }
 

--- a/src/pages/workspaces/workspace/tools/WorkflowView.js
+++ b/src/pages/workspaces/workspace/tools/WorkflowView.js
@@ -5,6 +5,7 @@ import Interactive from 'react-interactive'
 import * as Breadcrumbs from 'src/components/breadcrumbs'
 import { buttonPrimary } from 'src/components/common'
 import { spinner } from 'src/components/icons'
+import { DataTable, components } from 'src/components/table'
 import { TopBar } from 'src/components/TopBar'
 import WDLViewer from 'src/components/WDLViewer'
 import { Agora, Dockstore, Rawls } from 'src/libs/ajax'
@@ -13,6 +14,8 @@ import * as Style from 'src/libs/style'
 import { Component } from 'src/libs/wrapped-components'
 import { tabBar } from 'src/pages/workspaces/workspace/WorkspaceTabs'
 
+
+const sideMargin = '3rem'
 
 const tableColumns = [
   { label: 'Task name', width: 350 },
@@ -60,7 +63,7 @@ class WorkflowView extends Component {
         h(Fragment, [
           div({
             style: {
-              backgroundColor: Style.colors.section, padding: '1.5rem 3rem 0',
+              backgroundColor: Style.colors.section, padding: `1.5rem ${sideMargin} 0`,
               borderBottom: `2px solid ${Style.colors.secondary}`
             }
           }, [
@@ -157,20 +160,52 @@ class WorkflowView extends Component {
   }
 
   renderDetail = () => {
-    const { selectedTab, wdl } = this.state
+    const { selectedTab, wdl, inputsOutputs, config } = this.state
 
-    if (selectedTab === 'WDL') {
-      return wdl ?
-        div({
-          style: {
-            flex: '1 1 auto', overflowY: 'auto', maxHeight: 500,
-            margin: '0 3rem', padding: '0.5rem', backgroundColor: 'white',
-            border: Style.standardLine, borderTop: 'unset'
+    if (selectedTab === 'WDL' && wdl) {
+      return div({
+        style: {
+          flex: '1 1 auto', overflowY: 'auto', maxHeight: 500,
+          margin: `0 ${sideMargin}`, padding: '0.5rem', backgroundColor: 'white',
+          border: Style.standardLine, borderTop: 'unset'
+        }
+      }, [h(WDLViewer, { wdl, readOnly: true })])
+    } else if (selectedTab !== 'WDL' && inputsOutputs) {
+      const key = selectedTab.toLowerCase() // 'inputs' or 'outputs'
+
+      return div({ style: { margin: `0 ${sideMargin}` } },
+        [h(DataTable, {
+          dataSource: inputsOutputs[key],
+          customComponents: components.fullWidthTable,
+          tableProps: {
+            showHeader: false, scroll: { y: 400 },
+            columns: [
+              {
+                key: 'task-name', width: 350,
+                render: ({ name }) =>
+                  div({
+                    style: {
+                      overflow: 'hidden', textOverflow: 'ellipsis'
+                    }
+                  }, name)
+              },
+              {
+                key: 'variable', width: 360,
+                render: ({ name }) => _.last(_.split(name, '.'))
+              },
+              {
+                key: 'type', width: 160,
+                dataIndex: `${key.slice(0, -1)}Type`
+              },
+              {
+                key: 'attribute', width: '100%',
+                render: ({ name }) => config[key][name]
+              }
+            ]
           }
-        }, [h(WDLViewer, { wdl, readOnly: true })]) :
-        spinner()
+        })])
     } else {
-      return selectedTab
+      return spinner({ style: { marginTop: '1rem' } })
     }
   }
 


### PR DESCRIPTION
Future work:

* No display of invalid attribute messages. Needs UI design.
* "Save" could fail. Should do something.
* "Save" endpoint returns a very handy object that includes the valid/invalid inputs/outputs and the entire new method config. Once we handle the above, we should use that.
* Reimplement FireCloud's autosuggesting data and workspace attributes
* Isaac requested a "cancel" button alongside "save"