### PR TITLE
use object spread syntax when possible

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -67,7 +67,7 @@ export default class Modal extends Component {
         }, [
           showCancel ?
             div({
-              style: _.merge({ marginRight: '1rem' }, Style.elements.button),
+              style: { ...Style.elements.button, marginRight: '1rem' },
               onClick: onDismiss
             }, 'Cancel') :
             null,

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -1,4 +1,3 @@
-import _ from 'lodash'
 import { createPortal } from 'react-dom'
 import { a, div } from 'react-hyperscript-helpers'
 import { link } from 'src/components/common'
@@ -52,11 +51,11 @@ export class TopBar extends Component {
             onClick: e => e.stopPropagation()
           }, [
             div({
-              style: _.assign({
+              style: {
+                ...Style.elements.pageTitle,
                 backgroundColor: 'white', padding: '1rem',
                 textAlign: 'center', display: 'flex', alignItems: 'center'
-              },
-              Style.elements.pageTitle)
+              }
             }, [
               icon('bars',
                 {
@@ -66,10 +65,10 @@ export class TopBar extends Component {
                   onClick: () => this.hideNav()
                 }),
               a({
-                style: _.assign({
+                style: {
+                  ...Style.elements.pageTitle,
                   textAlign: 'center', display: 'flex', alignItems: 'center'
                 },
-                Style.elements.pageTitle),
                 href: Nav.getLink('workspaces'),
                 onClick: () => this.hideNav()
               }, [logo(), 'Saturn'])
@@ -120,7 +119,7 @@ export class TopBar extends Component {
             onClick: () => this.showNav()
           }),
         a({
-          style: _.defaults({ display: 'flex', alignItems: 'center' }, Style.elements.pageTitle),
+          style: { ...Style.elements.pageTitle, display: 'flex', alignItems: 'center' },
           href: Nav.getLink('workspaces')
         },
         [

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -23,12 +23,13 @@ export const buttonPrimary = function(props, children) {
   return h(Interactive,
     _.merge({
       as: 'button',
-      style: _.defaults({
+      style: {
+        ...Style.elements.button,
         border: 'none', borderRadius: 5, color: 'white',
         height: '2.25rem', paddingLeft: '1.5rem', paddingRight: '1.5rem',
         backgroundColor: props.disabled ? Style.colors.disabled : Style.colors.secondary,
         cursor: props.disabled ? 'not-allowed' : 'pointer'
-      }, Style.elements.button),
+      },
       hover: props.disabled ? undefined : { backgroundColor: Style.colors.primary }
     }, props),
     children)

--- a/src/pages/Import.js
+++ b/src/pages/Import.js
@@ -44,7 +44,7 @@ class DockstoreImporter extends Component {
       return div(
         { style: { flex, overflow: 'hidden', margin: '3rem' } },
         [
-          div({ style: _.merge({ fontWeight: 500, marginBottom: '1rem' }, Style.elements.sectionHeader) }, title),
+          div({ style: { ...Style.elements.sectionHeader, fontWeight: 500, marginBottom: '1rem' } }, title),
           contents
         ])
     }

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -16,13 +16,14 @@ import { Component } from 'src/libs/wrapped-components'
 export class WorkspaceList extends Component {
   constructor(props) {
     super(props)
-    this.state = _.defaults(StateHistory.get(), {
+    this.state = {
       filter: '',
       listView: false,
       itemsPerPage: 6,
       pageNumber: 1,
-      workspaces: null
-    })
+      workspaces: null,
+      ...StateHistory.get()
+    }
   }
 
   componentWillMount() {
@@ -50,15 +51,16 @@ export class WorkspaceList extends Component {
   }
 
   wsList() {
-    return h(DataGrid, _.assign({
+    return h(DataGrid, {
       cardsPerRow: 1,
       renderCard: ({ workspace: { namespace, name, createdBy, lastModified } }) => {
         return a({
           href: Nav.getLink('workspace', { namespace, name }),
-          style: _.defaults({
+          style: {
+            ...Style.elements.card,
             width: '100%', margin: '0.5rem', textDecoration: 'none',
             color: Style.colors.text
-          }, Style.elements.card)
+          }
         },
         [
           div({ style: Style.elements.cardTitle }, `${name}`),
@@ -78,24 +80,25 @@ export class WorkspaceList extends Component {
               }, createdBy[0].toUpperCase())
             ])
         ])
-      }
-    }, this.getDataViewerProps()))
+      },
+      ...this.getDataViewerProps()
+    })
   }
 
   wsGrid() {
-    return h(DataGrid, _.assign({
-      renderCard: ({ workspace: { namespace, name, createdBy, lastModified } },
-        cardsPerRow) => {
+    return h(DataGrid, {
+      renderCard: ({ workspace: { namespace, name, createdBy, lastModified } }, cardsPerRow) => {
         return a({
           href: Nav.getLink('workspace', { namespace, name }),
-          style: _.defaults({
+          style: {
+            ...Style.elements.card,
             width: `calc(${100 / cardsPerRow}% - 2.5rem)`,
             margin: '1.25rem',
             textDecoration: 'none',
             display: 'flex', flexDirection: 'column',
             justifyContent: 'space-between',
             height: 225, color: Style.colors.text
-          }, Style.elements.card)
+          }
         },
         [
           div({ style: Style.elements.cardTitle }, `${name}`),
@@ -117,8 +120,9 @@ export class WorkspaceList extends Component {
             }, createdBy[0].toUpperCase())
           ])
         ])
-      }
-    }, this.getDataViewerProps()))
+      },
+      ...this.getDataViewerProps()
+    })
   }
 
 

--- a/src/pages/workspaces/workspace/Container.js
+++ b/src/pages/workspaces/workspace/Container.js
@@ -27,10 +27,11 @@ const tabBaseStyle = {
   alignSelf: 'stretch', display: 'flex', justifyContent: 'center', alignItems: 'center'
 }
 
-const tabActiveStyle = _.defaults({
+const tabActiveStyle = {
+  ...tabBaseStyle,
   backgroundColor: 'rgba(255,255,255,0.15)', color: 'unset',
   borderBottom: `4px solid ${Style.colors.secondary}`
-}, tabBaseStyle)
+}
 
 const navIconProps = {
   size: 22,

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -97,9 +97,11 @@ class NotebookCard extends Component {
 
     const title = div({
       title: printName,
-      style: _.defaults(notebookAccess ? {} : { color: Style.colors.disabled },
-        Style.elements.cardTitle,
-        { textOverflow: 'ellipsis', whiteSpace: 'nowrap', overflow: 'hidden' })
+      style: {
+        ...Style.elements.cardTitle,
+        textOverflow: 'ellipsis', whiteSpace: 'nowrap', overflow: 'hidden',
+        ...(notebookAccess ? {} : { color: Style.colors.disabled })
+      }
     }, printName)
 
     const statusIcon = Utils.cond(
@@ -114,7 +116,8 @@ class NotebookCard extends Component {
         href: notebookAccess ?
           `${clusterUrl}/notebooks/${wsName}/${printName}.ipynb` : // removes 'notebooks/'
           undefined,
-        style: _.defaults({
+        style: {
+          ...Style.elements.card,
           flexShrink: 0,
           width: listView ? undefined : 200,
           height: listView ? undefined : 250,
@@ -124,7 +127,7 @@ class NotebookCard extends Component {
           display: 'flex', flexDirection: listView ? 'row' : 'column',
           justifyContent: listView ? undefined : 'space-between',
           alignItems: listView ? 'center' : undefined
-        }, Style.elements.card)
+        }
       },
       listView ? [
         jupyterIcon,

--- a/src/pages/workspaces/workspace/Tools.js
+++ b/src/pages/workspaces/workspace/Tools.js
@@ -1,4 +1,3 @@
-import _ from 'lodash'
 import { div, h } from 'react-hyperscript-helpers'
 import { link } from 'src/components/common'
 import { icon, spinner } from 'src/components/icons'
@@ -31,10 +30,11 @@ export default class WorkspaceTools extends Component {
           renderCard: config => {
             const { name, namespace, methodRepoMethod: { sourceRepo, methodVersion } } = config
             return div({
-              style: _.defaults({
+              style: {
+                ...Style.elements.card,
                 width: '30%', margin: '1rem 1.5rem', textDecoration: 'none',
                 color: Style.colors.text
-              }, Style.elements.card)
+              }
             }, [
               link({
                 href: Nav.getLink('workflow', {

--- a/src/pages/workspaces/workspace/WorkspaceTabs.js
+++ b/src/pages/workspaces/workspace/WorkspaceTabs.js
@@ -18,10 +18,11 @@ const tabBaseStyle = {
   alignSelf: 'stretch', display: 'flex', justifyContent: 'center', alignItems: 'center'
 }
 
-const tabActiveStyle = _.defaults({
+const tabActiveStyle = {
+  ...tabBaseStyle,
   backgroundColor: 'rgba(255,255,255,0.15)', color: 'unset',
   borderBottom: `4px solid ${Style.colors.secondary}`
-}, tabBaseStyle)
+}
 
 const navTab = (tabName, { namespace, name, activeTab }) => {
   return h(Fragment, [


### PR DESCRIPTION
This syntax can be used for shallow merging instead of `_.assign` or `_.defaults`. It's nice because it avoids mutation, and the order of precedence is clear from the code.