### PR TITLE
randomly generate cluster names

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-portal-tooltip": "^2.4.0",
     "react-scripts": "1.1.4",
     "react-select": "^1.2.1",
+    "uuid": "^3.2.1",
     "validate.js": "^0.12.0"
   },
   "scripts": {

--- a/src/components/AuthContainer.js
+++ b/src/components/AuthContainer.js
@@ -34,9 +34,7 @@ async function createClusters() {
   )
 
   projectsWithoutClusters.forEach(project => {
-    Leo.cluster(project,
-      `saturn-${userProfile.getId()}-${project}`.match(/(?:[a-z](?:[-a-z0-9]{0,49}[a-z0-9])?)/)[0] // regex used by google for valid names
-    ).create({
+    Leo.cluster(project, Utils.generateClusterName()).create({
       'labels': {},
       'machineConfig': {
         'numberOfWorkers': 0, 'masterMachineType': 'n1-standard-4',

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -1,5 +1,6 @@
 import _ from 'lodash/fp'
 import * as Config from 'src/libs/config'
+import uuid from 'uuid/v4'
 
 
 const subscribable = () => {
@@ -115,3 +116,5 @@ export const memoizeWithTimeout = (fn, resolver, ms) => {
 export const delay = ms => {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
+
+export const generateClusterName = () => `saturn-${uuid()}`


### PR DESCRIPTION
Somehow we got into a state where a cluster exists with the name we use for auto-creation, but it's not visible (owned by another user, perhaps?) This was causing auto-creation to fail repeatedly for that project.

This change introduces randomly generated cluster names, which should avoid this problem entirely.