### PR TITLE
Displaying attribute errors better

### DIFF
--- a/src/libs/style.js
+++ b/src/libs/style.js
@@ -21,7 +21,8 @@ export const colors = {
   textFadedLight: '#c5e1f3',
   title: '#224f83',
   titleAlt: '#8299a5',
-  warning: '#e28327'
+  warning: '#e28327',
+  warningBackground: '#fffcec'
 }
 
 export const standardShadow = '0 3px 2px 0 rgba(0,0,0,0.12)'

--- a/src/pages/Import.js
+++ b/src/pages/Import.js
@@ -121,12 +121,17 @@ class DockstoreImporter extends Component {
     )
   }
 
-  import = () => {
+  import = async () => {
     const { selectedWorkspace: { value: { namespace, name } } } = this.state
     const { path, version } = this.props
+    const workflowName = _.last(path.split('/'))
 
-    Rawls.workspace(namespace, name).importMethodConfigFromDocker({
-      namespace, name: _.last(path.split('/')), rootEntityType: 'participant',
+    const rawlsWorkspace = Rawls.workspace(namespace, name)
+
+    const entities = await rawlsWorkspace.entities()
+
+    rawlsWorkspace.importMethodConfigFromDocker({
+      namespace, name: workflowName, rootEntityType: _.first(_.keys(entities)),
       // the line of shame:
       inputs: {}, outputs: {}, prerequisites: {}, methodConfigVersion: 1, deleted: false,
       methodRepoMethod: {
@@ -135,7 +140,10 @@ class DockstoreImporter extends Component {
         methodVersion: version
       }
     }).then(
-      () => Nav.goToPath('workspace', { namespace, name, activeTab: 'tools' }),
+      () => Nav.goToPath('workflow', {
+        workspaceNamespace: namespace, workspaceName: name,
+        workflowNamespace: namespace, workflowName
+      }),
       importError => this.setState({ importError })
     )
   }

--- a/src/pages/Import.js
+++ b/src/pages/Import.js
@@ -131,7 +131,7 @@ class DockstoreImporter extends Component {
     const entities = await rawlsWorkspace.entities()
 
     rawlsWorkspace.importMethodConfigFromDocker({
-      namespace, name: workflowName, rootEntityType: _.first(_.keys(entities)),
+      namespace, name: workflowName, rootEntityType: _.head(_.keys(entities)),
       // the line of shame:
       inputs: {}, outputs: {}, prerequisites: {}, methodConfigVersion: 1, deleted: false,
       methodRepoMethod: {

--- a/src/pages/Import.js
+++ b/src/pages/Import.js
@@ -41,20 +41,16 @@ class DockstoreImporter extends Component {
 
   renderImport = () => {
     function section(title, flex, contents) {
-      return div(
-        { style: { flex, overflow: 'hidden', margin: '3rem' } },
-        [
-          div({ style: { ...Style.elements.sectionHeader, fontWeight: 500, marginBottom: '1rem' } }, title),
-          contents
-        ])
+      return div({ style: { flex, overflow: 'hidden', margin: '3rem' } }, [
+        div({ style: { ...Style.elements.sectionHeader, fontWeight: 500, marginBottom: '1rem' } }, title),
+        contents
+      ])
     }
 
-    return div({ style: { display: 'flex' } },
-      [
-        section('Importing', 5, this.renderWdlArea()),
-        section('Destination Project', 3, this.renderWorkspaceArea())
-      ]
-    )
+    return div({ style: { display: 'flex' } }, [
+      section('Importing', 5, this.renderWdlArea()),
+      section('Destination Project', 3, this.renderWorkspaceArea())
+    ])
   }
 
   renderWdlArea = () => {
@@ -81,9 +77,9 @@ class DockstoreImporter extends Component {
           icon('warning-standard', { class: 'is-solid', size: 32, style: { marginRight: '0.5rem', flex: '0 0 auto' } }),
           mutabilityWarning
         ]),
-        h(Collapse, { title: 'REVIEW WDL' },
-          [h(WDLViewer, { wdl, style: { maxHeight: 300 } })]
-        )
+        h(Collapse, { title: 'REVIEW WDL' }, [
+          h(WDLViewer, { wdl, style: { maxHeight: 300 } })
+        ])
       ]
     )
   }
@@ -91,34 +87,30 @@ class DockstoreImporter extends Component {
   renderWorkspaceArea = () => {
     const { selectedWorkspace, workspaces, importError } = this.state
 
-    return div({},
-      [
-        h(Select, {
-          clearable: false,
-          searchable: true,
-          disabled: !workspaces,
-          placeholder: workspaces ? 'Select a workspace' : 'Loading workspaces...',
-          value: selectedWorkspace,
-          onChange: selectedWorkspace => this.setState({ selectedWorkspace }),
-          options: _.map(({ workspace }) => {
-            return { value: workspace, label: workspace.name }
-          }, workspaces)
-        }),
-        buttonPrimary(
-          {
-            style: { marginTop: '1rem' },
-            disabled: !selectedWorkspace,
-            onClick: () => this.import()
-          },
-          'Import'),
-        importError && div({
-          style: { marginTop: '1rem', color: Style.colors.error }
-        }, [
-          icon('error'),
-          JSON.parse(importError).message
-        ])
-      ]
-    )
+    return div({}, [
+      h(Select, {
+        clearable: false,
+        searchable: true,
+        disabled: !workspaces,
+        placeholder: workspaces ? 'Select a workspace' : 'Loading workspaces...',
+        value: selectedWorkspace,
+        onChange: selectedWorkspace => this.setState({ selectedWorkspace }),
+        options: _.map(({ workspace }) => {
+          return { value: workspace, label: workspace.name }
+        }, workspaces)
+      }),
+      buttonPrimary(
+        {
+          style: { marginTop: '1rem' },
+          disabled: !selectedWorkspace,
+          onClick: () => this.import()
+        },
+        'Import'),
+      importError && div({ style: { marginTop: '1rem', color: Style.colors.error } }, [
+        icon('error'),
+        JSON.parse(importError).message
+      ])
+    ])
   }
 
   import = async () => {

--- a/src/pages/workspaces/workspace/tools/WorkflowView.js
+++ b/src/pages/workspaces/workspace/tools/WorkflowView.js
@@ -113,6 +113,14 @@ class WorkflowView extends Component {
 
     const processedIO = processIO(await Rawls.methodConfigInputsOutputs(config))
 
+    this.setState({
+      inputsOutputs: processedIO,
+      ...this.createInvalidIOMap(invalidInputs, invalidOutputs, config, processedIO),
+      config, entityTypes
+    })
+  }
+
+  createInvalidIOMap = (invalidInputs, invalidOutputs, config, io = this.state.inputsOutputs) => {
     const findMissing = ioKey => _.flow(
       _.reject('optional'),
       _.filter(({ name }) => !config[ioKey][name]),
@@ -120,14 +128,12 @@ class WorkflowView extends Component {
       _.mergeAll
     )
 
-    this.setState({
-      inputsOutputs: processedIO,
+    return {
       invalid: {
-        inputs: _.merge(invalidInputs, findMissing('inputs')(processedIO.inputs)),
-        outputs: _.merge(invalidOutputs, findMissing('outputs')(processedIO.outputs))
-      },
-      config, entityTypes
-    })
+        inputs: _.merge(invalidInputs, findMissing('inputs')(io.inputs)),
+        outputs: _.merge(invalidOutputs, findMissing('outputs')(io.outputs))
+      }
+    }
   }
 
   renderSummary = () => {
@@ -336,10 +342,7 @@ class WorkflowView extends Component {
     this.setState({
       saving: false, saved: true, modified: false,
       modifiedAttributes: { inputs: {}, outputs: {} },
-      invalid: {
-        inputs: invalidInputs,
-        outputs: invalidOutputs
-      },
+      ...this.createInvalidIOMap(invalidInputs, invalidOutputs, methodConfiguration),
       config: methodConfiguration
     })
   }

--- a/src/pages/workspaces/workspace/tools/WorkflowView.js
+++ b/src/pages/workspaces/workspace/tools/WorkflowView.js
@@ -116,7 +116,7 @@ class WorkflowView extends Component {
 
     this.setState({
       inputsOutputs: processedIO,
-      ...this.createInvalidIOMap(invalidInputs, invalidOutputs, config, processedIO),
+      invalid: this.createInvalidIOMap(invalidInputs, invalidOutputs, config, processedIO),
       config, entityTypes
     })
   }
@@ -130,10 +130,8 @@ class WorkflowView extends Component {
     )
 
     return {
-      invalid: {
-        inputs: _.merge(invalidInputs, findMissing('inputs')(io.inputs)),
-        outputs: _.merge(invalidOutputs, findMissing('outputs')(io.outputs))
-      }
+      inputs: _.merge(invalidInputs, findMissing('inputs')(io.inputs)),
+      outputs: _.merge(invalidOutputs, findMissing('outputs')(io.outputs))
     }
   }
 
@@ -360,7 +358,7 @@ class WorkflowView extends Component {
     this.setState({
       saving: false, saved: true, modified: false,
       modifiedAttributes: { inputs: {}, outputs: {} },
-      ...this.createInvalidIOMap(invalidInputs, invalidOutputs, methodConfiguration),
+      invalid: this.createInvalidIOMap(invalidInputs, invalidOutputs, methodConfiguration),
       config: methodConfiguration
     })
   }

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -9,6 +9,9 @@ configure({ adapter: new Adapter() })
 jest.mock('src/libs/ajax')
 jest.mock('src/libs/nav')
 
+window.gapi = {
+  load: () => {}
+}
 window.Element.prototype['insertAdjacentElement'] = () => {} // for custom icons
 
 // Mock dates due to time zone issues


### PR DESCRIPTION
In the interest of keeping things small, here's another checkpoint PR.

* Fixed a bug where after importing from dockstore, it sent you to the wrong place
* Display an error in the tab when any input/output is invalid
* Disable the Launch Analysis button when editing or attributes are invalid, and enable otherwise (still does nothing)

There seems to be a bug where Rawls reports a blank optional attribute as an error, but only after filling it, saving, and re-clearing it.