### PR TITLE
implement global error reporting mechanism

### DIFF
--- a/src/components/ClusterManager.js
+++ b/src/components/ClusterManager.js
@@ -8,6 +8,7 @@ import DropdownBox from 'src/components/DropdownBox'
 import { IntegerInput, textInput } from 'src/components/input'
 import { Leo } from 'src/libs/ajax'
 import { getBasicProfile } from 'src/libs/auth'
+import { reportError } from 'src/libs/error'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 import { Select } from 'src/libs/wrapped-components'
@@ -223,12 +224,16 @@ export default class ClusterManager extends Component {
 
   refreshClusters = async () => {
     const { namespace } = this.props
-    const allClusters = await Leo.clustersList()
-    const clusters = _.filter({
-      googleProject: namespace,
-      creator: getBasicProfile().getEmail()
-    }, allClusters)
-    this.setState({ clusters })
+    try {
+      const allClusters = await Leo.clustersList()
+      const clusters = _.filter({
+        googleProject: namespace,
+        creator: getBasicProfile().getEmail()
+      }, allClusters)
+      this.setState({ clusters })
+    } catch (error) {
+      reportError(`Error loading clusters: ${error}`)
+    }
   }
 
   componentDidMount() {
@@ -265,7 +270,7 @@ export default class ClusterManager extends Component {
       await promise
       await this.refreshClusters()
     } catch (error) {
-      Utils.log(`Cluster error`, error)
+      reportError(`Cluster error ${error}`)
     } finally {
       this.setState({ busy: false })
     }

--- a/src/components/ErrorBanner.js
+++ b/src/components/ErrorBanner.js
@@ -1,0 +1,13 @@
+import { h } from 'react-hyperscript-helpers'
+import Modal from 'src/components/Modal'
+import { errorStore, reportError } from 'src/libs/error'
+import * as Utils from 'src/libs/utils'
+
+export default Utils.connectAtom(errorStore, 'errorState')(
+  ({ errorState }) => {
+    return errorState ? h(Modal, {
+      showCancel: false,
+      onDismiss: () => reportError(undefined)
+    }, [errorState]) : null
+  }
+)

--- a/src/libs/error.js
+++ b/src/libs/error.js
@@ -1,0 +1,7 @@
+import * as Utils from 'src/libs/utils'
+
+export const errorStore = Utils.atom()
+
+export const reportError = text => {
+  errorStore.set(text)
+}

--- a/src/pages/ImportTool.js
+++ b/src/pages/ImportTool.js
@@ -7,6 +7,7 @@ import { centeredSpinner, icon, spinner } from 'src/components/icons'
 import { TopBar } from 'src/components/TopBar'
 import WDLViewer from 'src/components/WDLViewer'
 import { Dockstore, Rawls } from 'src/libs/ajax'
+import { reportError } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
@@ -57,7 +58,10 @@ export class DestinationProject extends Component {
   }
 
   componentDidMount() {
-    Rawls.workspacesList().then(workspaces => this.setState({ workspaces }))
+    Rawls.workspacesList().then(
+      workspaces => this.setState({ workspaces }),
+      error => reportError(`Error loading workspaces: ${error}`)
+    )
   }
 }
 
@@ -80,7 +84,10 @@ class DockstoreImporter extends Component {
 
   componentDidMount() {
     this.loadWdl()
-    Rawls.workspacesList().then(workspaces => this.setState({ workspaces }))
+    Rawls.workspacesList().then(
+      workspaces => this.setState({ workspaces }),
+      error => reportError(`Error loading workspaces: ${error}`)
+    )
   }
 
   componentWillReceiveProps(nextProps) {

--- a/src/pages/Main.js
+++ b/src/pages/Main.js
@@ -1,8 +1,10 @@
+import { Fragment } from 'react'
 import { hot } from 'react-hot-loader'
 import { h } from 'react-hyperscript-helpers'
+import ErrorBanner from 'src/components/ErrorBanner'
 import Router from 'src/components/Router'
 
 
-const Main = () => h(Router)
+const Main = () => h(Fragment, [h(Router), h(ErrorBanner)])
 
 export default hot(module)(Main)

--- a/src/pages/Register.js
+++ b/src/pages/Register.js
@@ -6,6 +6,7 @@ import { textInput } from 'src/components/input'
 import planet from 'src/images/register-planet.svg'
 import { Orchestration, Sam } from 'src/libs/ajax'
 import { authStore, getBasicProfile } from 'src/libs/auth'
+import { reportError } from 'src/libs/error'
 import * as Style from 'src/libs/style'
 
 
@@ -23,15 +24,20 @@ export default class Register extends Component {
 
   async register() {
     const { givenName, familyName, email } = this.state
-    this.setState({ busy: true })
-    await Sam.createUser()
-    await Orchestration.profile.set({
-      firstName: givenName,
-      lastName: familyName,
-      contactEmail: email
-    })
-    this.setState({ busy: false })
-    authStore.update(state => ({ ...state, isRegistered: true }))
+    try {
+      this.setState({ busy: true })
+      await Sam.createUser()
+      await Orchestration.profile.set({
+        firstName: givenName,
+        lastName: familyName,
+        contactEmail: email
+      })
+      authStore.update(state => ({ ...state, isRegistered: true }))
+    } catch (error) {
+      reportError(`Error registering: ${error}`)
+    } finally {
+      this.setState({ busy: false })
+    }
   }
 
   render() {

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -6,6 +6,7 @@ import { breadcrumb, centeredSpinner, icon } from 'src/components/icons'
 import { DataGrid } from 'src/components/table'
 import { TopBar } from 'src/components/TopBar'
 import { Rawls } from 'src/libs/ajax'
+import { reportError } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
 import * as StateHistory from 'src/libs/state-history'
 import * as Style from 'src/libs/style'
@@ -33,7 +34,7 @@ export class WorkspaceList extends Component {
           Utils.workspaceAccessLevels.indexOf(ws.accessLevel) > Utils.workspaceAccessLevels.indexOf('READER'),
         workspaces))
       }),
-      failure => this.setState({ failure })
+      error => reportError(`Error loading workspace list: ${error}`)
     )
   }
 
@@ -126,7 +127,7 @@ export class WorkspaceList extends Component {
 
 
   render() {
-    const { workspaces, filter, listView, failure } = this.state
+    const { workspaces, filter, listView } = this.state
 
     return h(Fragment, [
       h(TopBar, { title: 'Projects' },
@@ -165,7 +166,6 @@ export class WorkspaceList extends Component {
       ]),
       div({ style: { margin: '1rem auto', maxWidth: 1000, width: '100%' } }, [
         Utils.cond(
-          [failure, () => `Couldn't load workspace list: ${failure}`],
           [!workspaces, () => centeredSpinner({ size: 64 })],
           [_.isEmpty(workspaces), 'You don\'t seem to have access to any workspaces.'],
           [listView, () => this.wsList()],

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -4,6 +4,7 @@ import { buttonPrimary } from 'src/components/common'
 import { centeredSpinner } from 'src/components/icons'
 import Modal from 'src/components/Modal'
 import { Rawls } from 'src/libs/ajax'
+import { reportError } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
@@ -15,15 +16,15 @@ export default class WorkspaceDashboard extends Component {
   refresh() {
     const { namespace, name } = this.props
 
-    this.setState({ workspace: undefined, workspaceFailure: undefined })
+    this.setState({ workspace: undefined })
     Rawls.workspace(namespace, name).details().then(
       workspace => this.setState({ workspace }),
-      workspaceFailure => this.setState({ workspaceFailure })
+      error => reportError(`Error loading workspace: ${error}`)
     )
   }
 
   render() {
-    const { modal, workspace, workspaceFailure } = this.state
+    const { modal, workspace } = this.state
     const { namespace, name } = this.props
 
     return h(WorkspaceContainer,
@@ -34,7 +35,6 @@ export default class WorkspaceDashboard extends Component {
       },
       [
         Utils.cond(
-          [workspaceFailure, `Couldn't load workspace: ${workspaceFailure}`],
           [!workspace, () => centeredSpinner({ style: { marginTop: '2rem' } })],
           () => div({ style: { margin: '1rem' } }, [
             modal && h(Modal, {

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -4,6 +4,7 @@ import * as breadcrumbs from 'src/components/breadcrumbs'
 import { centeredSpinner, icon } from 'src/components/icons'
 import { DataTable } from 'src/components/table'
 import { Rawls } from 'src/libs/ajax'
+import { reportError } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
 import * as StateHistory from 'src/libs/state-history'
 import * as Style from 'src/libs/style'
@@ -23,10 +24,10 @@ class WorkspaceData extends Component {
     const { namespace, name } = this.props
     const { selectedEntityType } = this.state
 
-    this.setState({ workspaceEntities: undefined, entitiesFailure: undefined })
+    this.setState({ workspaceEntities: undefined })
     Rawls.workspace(namespace, name).entities().then(
       workspaceEntities => this.setState({ workspaceEntities }),
-      entitiesFailure => this.setState({ entitiesFailure })
+      error => reportError(`Error loading workspace entities: ${error}`)
     )
 
     if (selectedEntityType) {
@@ -39,7 +40,7 @@ class WorkspaceData extends Component {
 
     Rawls.workspace(namespace, name).entity(type).then(
       selectedEntities => this.setState({ selectedEntities }),
-      entityFailure => this.setState({ entityFailure })
+      error => reportError(`Error loading workspace entity: ${error}`)
     )
   }
 
@@ -48,7 +49,7 @@ class WorkspaceData extends Component {
   }
 
   render() {
-    const { selectedEntityType, selectedEntities, workspaceEntities, entitiesFailure, entityFailure } = this.state
+    const { selectedEntityType, selectedEntities, workspaceEntities } = this.state
     const { namespace, name } = this.props
 
     const entityTypeList = () => _.map(([type, typeDetails]) =>
@@ -108,7 +109,6 @@ class WorkspaceData extends Component {
           }
         },
         Utils.cond(
-          [entitiesFailure, () => `Couldn't load workspace entities: ${entitiesFailure}`],
           [!workspaceEntities, () => [centeredSpinner({ style: { margin: '2rem auto' } })]],
           [
             _.isEmpty(workspaceEntities),
@@ -132,7 +132,6 @@ class WorkspaceData extends Component {
               },
               [
                 Utils.cond(
-                  [entityFailure, () => `Couldn't load ${selectedEntityType}s: ${entityFailure}`],
                   [!selectedEntityType, 'Select a data type.'],
                   [!selectedEntities, centeredSpinner],
                   entityTable

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -9,6 +9,7 @@ import { NotebookCreator, NotebookDeleter, NotebookDuplicator } from 'src/compon
 import ShowOnClick from 'src/components/ShowOnClick'
 import { Buckets, Leo, Rawls } from 'src/libs/ajax'
 import { getBasicProfile } from 'src/libs/auth'
+import { reportError } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
@@ -185,7 +186,7 @@ class WorkspaceNotebooks extends Component {
         })
       }
     } catch (error) {
-      this.setState({ notebooksFailure: error })
+      reportError(`Error loading notebooks: ${error}`)
     }
   }
 
@@ -208,7 +209,7 @@ class WorkspaceNotebooks extends Component {
   }
 
   render() {
-    const { bucketName, notebooks, notebooksFailure, listView } = this.state
+    const { bucketName, notebooks, listView } = this.state
     const { namespace, name } = this.props
 
     return h(WorkspaceContainer,
@@ -220,7 +221,6 @@ class WorkspaceNotebooks extends Component {
       [
         div({ style: { margin: '1rem' } }, [
           Utils.cond(
-            [notebooksFailure, () => `Couldn't load notebooks: ${notebooksFailure}`],
             [!notebooks, centeredSpinner],
             () => h(Fragment, [
               div({

--- a/src/pages/workspaces/workspace/Tools.js
+++ b/src/pages/workspaces/workspace/Tools.js
@@ -4,6 +4,7 @@ import * as breadcrumbs from 'src/components/breadcrumbs'
 import { centeredSpinner } from 'src/components/icons'
 import { DataGrid } from 'src/components/table'
 import { Rawls } from 'src/libs/ajax'
+import { reportError } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
 import * as Style from 'src/libs/style'
 import { Component } from 'src/libs/wrapped-components'
@@ -20,8 +21,10 @@ class WorkspaceTools extends Component {
     const { namespace, name } = this.props
 
     this.setState({ configs: undefined })
-    Rawls.workspace(namespace, name).listMethodConfigs()
-      .then(configs => this.setState({ configs }))
+    Rawls.workspace(namespace, name).listMethodConfigs().then(
+      configs => this.setState({ configs }),
+      error => reportError(`Error loading configs: ${error}`)
+    )
   }
 
   render() {

--- a/src/pages/workspaces/workspace/tools/WorkflowView.js
+++ b/src/pages/workspaces/workspace/tools/WorkflowView.js
@@ -11,6 +11,7 @@ import { components, DataTable } from 'src/components/table'
 import WDLViewer from 'src/components/WDLViewer'
 import { Agora, Dockstore, Rawls } from 'src/libs/ajax'
 import * as Config from 'src/libs/config'
+import { reportError } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
@@ -101,22 +102,26 @@ class WorkflowView extends Component {
 
   async componentDidMount() {
     const { workspaceNamespace, workspaceName, workflowNamespace, workflowName } = this.props
-    const workspace = Rawls.workspace(workspaceNamespace, workspaceName)
+    try {
+      const workspace = Rawls.workspace(workspaceNamespace, workspaceName)
 
-    const entityTypes = _.map(
-      e => ({ value: e, label: e.replace('_', ' ') }),
-      _.keys(await workspace.entities())
-    )
+      const entityTypes = _.map(
+        e => ({ value: e, label: e.replace('_', ' ') }),
+        _.keys(await workspace.entities())
+      )
 
-    const validationResponse = await workspace.methodConfig(workflowNamespace, workflowName).validate()
-    const { methodConfiguration: config } = validationResponse
-    const ioDefinitions = await Rawls.methodConfigInputsOutputs(config)
+      const validationResponse = await workspace.methodConfig(workflowNamespace, workflowName).validate()
+      const { methodConfiguration: config } = validationResponse
+      const ioDefinitions = await Rawls.methodConfigInputsOutputs(config)
 
-    const inputsOutputs = this.createIOLists(validationResponse, ioDefinitions)
+      const inputsOutputs = this.createIOLists(validationResponse, ioDefinitions)
 
-    const firecloudRoot = await Config.getFirecloudUrlRoot()
+      const firecloudRoot = await Config.getFirecloudUrlRoot()
 
-    this.setState({ config, entityTypes, inputsOutputs, ioDefinitions, firecloudRoot })
+      this.setState({ config, entityTypes, inputsOutputs, ioDefinitions, firecloudRoot })
+    } catch (error) {
+      reportError(`Error loading data: ${error}`)
+    }
   }
 
   createIOLists(validationResponse, ioDefinitions = this.state.ioDefinitions) {
@@ -337,17 +342,21 @@ class WorkflowView extends Component {
     const { methodRepoMethod: { sourceRepo, methodNamespace, methodName, methodVersion, methodPath } } = this.state.config
 
     this.setState({ loadedWdl: true })
-    const wdl = await (() => {
-      switch (sourceRepo) {
-        case 'dockstore':
-          return Dockstore.getWdl(methodPath, methodVersion).then(({ descriptor }) => descriptor)
-        case 'agora':
-          return Agora.method(methodNamespace, methodName, methodVersion).get().then(({ payload }) => payload)
-        default:
-          throw new Error('unknown sourceRepo')
-      }
-    })()
-    this.setState({ wdl })
+    try {
+      const wdl = await (() => {
+        switch (sourceRepo) {
+          case 'dockstore':
+            return Dockstore.getWdl(methodPath, methodVersion).then(({ descriptor }) => descriptor)
+          case 'agora':
+            return Agora.method(methodNamespace, methodName, methodVersion).get().then(({ payload }) => payload)
+          default:
+            throw new Error('unknown sourceRepo')
+        }
+      })()
+      this.setState({ wdl })
+    } catch (error) {
+      reportError(`Error loading WDL: ${error}`)
+    }
   }
 
   save = async () => {
@@ -356,17 +365,23 @@ class WorkflowView extends Component {
 
     this.setState({ saving: true })
 
-    const validationResponse = await Rawls.workspace(workspaceNamespace, workspaceName)
-      .methodConfig(workflowNamespace, workflowName)
-      .save(_.merge(config, modifiedAttributes))
-    const inputsOutputs = this.createIOLists(validationResponse)
+    try {
+      const validationResponse = await Rawls.workspace(workspaceNamespace, workspaceName)
+        .methodConfig(workflowNamespace, workflowName)
+        .save(_.merge(config, modifiedAttributes))
+      const inputsOutputs = this.createIOLists(validationResponse)
 
-    this.setState({
-      saving: false, saved: true, modified: false,
-      modifiedAttributes: { inputs: {}, outputs: {} },
-      inputsOutputs,
-      config: validationResponse.methodConfiguration
-    })
+      this.setState({
+        saved: true, modified: false,
+        modifiedAttributes: { inputs: {}, outputs: {} },
+        inputsOutputs,
+        config: validationResponse.methodConfiguration
+      })
+    } catch (error) {
+      reportError(`Error saving: ${error}`)
+    } finally {
+      this.setState({ saving: false })
+    }
   }
 
   cancel = () => {


### PR DESCRIPTION
This adds a general mechanism for reporting unexpected failures, e.g. ajax errors, and other cases where something went wrong that shouldn't have. For validation errors or other 'expected' errors, we should continue to design and build friendly reporting into the UI itself.

We're initially showing the message in a modal, but we can change that later if we want.