### PR TITLE
Error formatting

### DIFF
--- a/src/components/ClusterManager.js
+++ b/src/components/ClusterManager.js
@@ -232,7 +232,7 @@ export default class ClusterManager extends Component {
       }, allClusters)
       this.setState({ clusters })
     } catch (error) {
-      reportError(`Error loading clusters: ${error}`)
+      reportError({ title: 'Error loading clusters', error })
     }
   }
 
@@ -270,7 +270,7 @@ export default class ClusterManager extends Component {
       await promise
       await this.refreshClusters()
     } catch (error) {
-      reportError(`Cluster error ${error}`)
+      reportError({ title: 'Cluster Error', error })
     } finally {
       this.setState({ busy: false })
     }

--- a/src/components/ClusterManager.js
+++ b/src/components/ClusterManager.js
@@ -232,7 +232,7 @@ export default class ClusterManager extends Component {
       }, allClusters)
       this.setState({ clusters })
     } catch (error) {
-      reportError({ title: 'Error loading clusters', error })
+      reportError('Error loading clusters', error)
     }
   }
 
@@ -270,7 +270,7 @@ export default class ClusterManager extends Component {
       await promise
       await this.refreshClusters()
     } catch (error) {
-      reportError({ title: 'Cluster Error', error })
+      reportError('Cluster Error', error)
     } finally {
       this.setState({ busy: false })
     }

--- a/src/components/ErrorBanner.js
+++ b/src/components/ErrorBanner.js
@@ -1,7 +1,7 @@
 import { h } from 'react-hyperscript-helpers'
 import ErrorView from 'src/components/ErrorView'
 import Modal from 'src/components/Modal'
-import { errorStore, reportError } from 'src/libs/error'
+import { errorStore, clearError } from 'src/libs/error'
 import * as Utils from 'src/libs/utils'
 
 export default Utils.connectAtom(errorStore, 'errorState')(
@@ -13,7 +13,7 @@ export default Utils.connectAtom(errorStore, 'errorState')(
         width: 800,
         title,
         showCancel: false,
-        onDismiss: () => reportError(undefined)
+        onDismiss: () => clearError()
       }, [
         h(ErrorView, { error, collapses: false })
       ])

--- a/src/components/ErrorBanner.js
+++ b/src/components/ErrorBanner.js
@@ -6,14 +6,19 @@ import * as Utils from 'src/libs/utils'
 
 export default Utils.connectAtom(errorStore, 'errorState')(
   ({ errorState }) => {
-    return errorState ? h(Modal, {
-      width: 800,
-      showCancel: false,
-      onDismiss: () => reportError(undefined)
-    }, [
-      h(ErrorView, {
-        error: errorState, collapses: false
-      })
-    ]) : null
+    if (errorState) {
+      const { title, error } = errorState
+
+      return h(Modal, {
+        width: 800,
+        title,
+        showCancel: false,
+        onDismiss: () => reportError(undefined)
+      }, [
+        h(ErrorView, { error, collapses: false })
+      ])
+    } else {
+      return null
+    }
   }
 )

--- a/src/components/ErrorBanner.js
+++ b/src/components/ErrorBanner.js
@@ -1,4 +1,5 @@
 import { h } from 'react-hyperscript-helpers'
+import ErrorView from 'src/components/ErrorView'
 import Modal from 'src/components/Modal'
 import { errorStore, reportError } from 'src/libs/error'
 import * as Utils from 'src/libs/utils'
@@ -6,8 +7,13 @@ import * as Utils from 'src/libs/utils'
 export default Utils.connectAtom(errorStore, 'errorState')(
   ({ errorState }) => {
     return errorState ? h(Modal, {
+      width: 800,
       showCancel: false,
       onDismiss: () => reportError(undefined)
-    }, [errorState]) : null
+    }, [
+      h(ErrorView, {
+        error: errorState, collapses: false
+      })
+    ]) : null
   }
 )

--- a/src/components/ErrorView.js
+++ b/src/components/ErrorView.js
@@ -1,3 +1,4 @@
+import { Fragment } from 'react'
 import { div, h, iframe, pre } from 'react-hyperscript-helpers'
 import Collapse from 'src/components/Collapse'
 import * as Style from 'src/libs/style'
@@ -26,13 +27,17 @@ class StackTraceView extends Component {
 
 class JSONErrorView extends Component {
   render() {
-    const { statusCode, source, causes, stackTrace, message } = this.props
+    const { statusCode, source, causes, stackTrace, message, exceptionClass } = this.props
 
-    return div({
-
-    }, [
-      div({ style: Style.elements.cardTitle }, `Error ${statusCode}: ${message}`),
-      div({}, `Source: ${source}`),
+    return h(Fragment, [
+      div({ style: Style.elements.cardTitle }, [
+        statusCode && `Error ${statusCode}: `,
+        message
+      ]),
+      source && div({}, [
+        `Source: ${source}`,
+        exceptionClass && ` (${exceptionClass})`
+      ]),
       stackTrace && stackTrace[0] && h(StackTraceView, { lines: stackTrace }),
       causes && causes.map((cause, idx) => h(Collapse, {
         key: idx,

--- a/src/components/ErrorView.js
+++ b/src/components/ErrorView.js
@@ -1,0 +1,57 @@
+import { Fragment } from 'react'
+import { div, h, iframe } from 'react-hyperscript-helpers'
+import Collapse from 'src/components/Collapse'
+import * as Style from 'src/libs/style'
+import * as Utils from 'src/libs/utils'
+import { Component } from 'src/libs/wrapped-components'
+
+
+export default class ErrorView extends Component {
+  render() {
+    const { containerStyle, error } = this.props
+
+    return h(Collapse, {
+      style: { marginTop: '1rem', ...containerStyle },
+      title: 'Error details',
+      defaultHidden: true
+    }, [
+      Utils.cond(
+        [this.errorIsHTML(), () => this.renderHTMLError()],
+        () => `Unknown, text is: ${error}`
+      )
+    ])
+  }
+
+  errorIsHTML() {
+    const { error } = this.props
+    return error[0] === '<'
+  }
+
+  renderHTMLError() {
+    const { error } = this.props
+
+    const htmlDoc = new DOMParser().parseFromString(error, 'text/xml')
+    const textContent = htmlDoc.getElementsByTagName('body')[0].textContent
+
+    return h(Fragment, [
+      'The server returned an HTML document, its content is:',
+      div({ style: { padding: '0.5rem', fontWeight: 400 } }, [
+        decodeURIComponent(textContent)
+      ]),
+      h(Collapse, {
+        style: { padding: '0.5rem' },
+        title: 'Full response',
+        defaultHidden: true
+      }, [
+        iframe({
+          style: {
+            width: '100%',
+            border: Style.standardLine, borderRadius: 3,
+            padding: '1rem', backgroundColor: 'white'
+          },
+          srcDoc: error, sandbox: ''
+        })
+      ])
+    ])
+  }
+}

--- a/src/components/ErrorView.js
+++ b/src/components/ErrorView.js
@@ -6,20 +6,60 @@ import * as Utils from 'src/libs/utils'
 import { Component } from 'src/libs/wrapped-components'
 
 
-export default class ErrorView extends Component {
+class StackTraceView extends Component {
   render() {
-    const { containerStyle, error } = this.props
+    const { lines } = this.props
 
     return h(Collapse, {
+      style: { marginTop: '0.5rem' },
+      title: 'Stack Trace',
+      defaultHidden: true
+    }, [
+      lines.map(({ className, methodName, fileName, lineNumber }, idx) => div({ key: idx }, [
+        `${fileName} ${className}.${methodName} (line ${lineNumber})`
+      ]))
+    ])
+  }
+}
+
+
+class JSONErrorView extends Component {
+  render() {
+    const { statusCode, source, causes, stackTrace, message } = this.props
+
+    return div({
+
+    }, [
+      div({ style: Style.elements.cardTitle }, `Error ${statusCode}: ${message}`),
+      div({}, `Source: ${source}`),
+      stackTrace && stackTrace[0] && h(StackTraceView, { lines: stackTrace }),
+      causes && causes.map((cause, idx) => h(Collapse, {
+        key: idx,
+        style: { marginTop: '0.5rem' },
+        title: causes.length === 1 ? 'Cause' : `Cause ${idx}`,
+        defaultHidden: true
+      }, [h(JSONErrorView, cause)]))
+    ])
+  }
+}
+
+
+export default class ErrorView extends Component {
+  render() {
+    const { collapses=true, containerStyle, error } = this.props
+
+    const content = Utils.cond(
+      [this.errorIsHTML(), () => this.renderHTMLError()],
+      [this.errorIsJSON(), () => this.renderJSONError()],
+      () => error
+    )
+
+    return collapses ? h(Collapse, {
       style: { marginTop: '1rem', ...containerStyle },
       title: 'Error details',
       defaultHidden: true
-    }, [
-      Utils.cond(
-        [this.errorIsHTML(), () => this.renderHTMLError()],
-        () => `Unknown, text is: ${error}`
-      )
-    ])
+    }, [content]) :
+      content
   }
 
   errorIsHTML() {
@@ -53,5 +93,15 @@ export default class ErrorView extends Component {
         })
       ])
     ])
+  }
+
+  errorIsJSON() {
+    const { error } = this.props
+    return error[0] === '{'
+  }
+
+  renderJSONError() {
+    const { error } = this.props
+    return h(JSONErrorView, JSON.parse(error))
   }
 }

--- a/src/components/ErrorView.js
+++ b/src/components/ErrorView.js
@@ -6,48 +6,36 @@ import * as Utils from 'src/libs/utils'
 import { Component } from 'src/libs/wrapped-components'
 
 
-class StackTraceView extends Component {
-  render() {
-    const { lines } = this.props
-
-    return h(Collapse, {
-      style: { marginTop: '0.5rem' },
-      title: 'Stack Trace',
-      defaultHidden: true
-    }, [
-      pre({ style: { overflowX: 'auto' } }, [
-        lines.map(({ className, methodName, fileName, lineNumber }, idx) => div({ key: idx }, [
-          `${className}.${methodName} (${fileName}:${lineNumber})`
-        ]))
-      ])
-    ])
-  }
-}
+const stackTraceView = lines => h(Collapse, {
+  style: { marginTop: '0.5rem' },
+  title: 'Stack Trace',
+  defaultHidden: true
+}, [
+  pre({ style: { overflowX: 'auto' } }, [
+    lines.map(({ className, methodName, fileName, lineNumber }, idx) => div({ key: idx }, [
+      `${className}.${methodName} (${fileName}:${lineNumber})`
+    ]))
+  ])
+])
 
 
-class JSONErrorView extends Component {
-  render() {
-    const { statusCode, source, causes, stackTrace, message, exceptionClass } = this.props
-
-    return h(Fragment, [
-      div({ style: Style.elements.cardTitle }, [
-        statusCode && `Error ${statusCode}: `,
-        message
-      ]),
-      source && div({}, [
-        `Source: ${source}`,
-        exceptionClass && ` (${exceptionClass})`
-      ]),
-      stackTrace && stackTrace[0] && h(StackTraceView, { lines: stackTrace }),
-      causes && causes.map((cause, idx) => h(Collapse, {
-        key: idx,
-        style: { marginTop: '0.5rem' },
-        title: causes.length === 1 ? 'Cause' : `Cause ${idx}`,
-        defaultHidden: true
-      }, [h(JSONErrorView, cause)]))
-    ])
-  }
-}
+const jsonErrorView = ({ statusCode, source, causes, stackTrace, message, exceptionClass }) => h(Fragment, [
+  div({ style: Style.elements.cardTitle }, [
+    statusCode && `Error ${statusCode}: `,
+    message
+  ]),
+  source && div({}, [
+    `Source: ${source}`,
+    exceptionClass && ` (${exceptionClass})`
+  ]),
+  stackTrace && stackTrace[0] && stackTraceView(stackTrace),
+  causes && causes.map((cause, idx) => h(Collapse, {
+    key: idx,
+    style: { marginTop: '0.5rem' },
+    title: causes.length === 1 ? 'Cause' : `Cause ${idx + 1}`,
+    defaultHidden: true
+  }, jsonErrorView(cause)))
+])
 
 
 export default class ErrorView extends Component {
@@ -93,6 +81,6 @@ export default class ErrorView extends Component {
 
   renderJSONError() {
     const { error } = this.props
-    return h(JSONErrorView, JSON.parse(error))
+    return jsonErrorView(JSON.parse(error))
   }
 }

--- a/src/components/ErrorView.js
+++ b/src/components/ErrorView.js
@@ -45,7 +45,8 @@ export default class ErrorView extends Component {
     const content = Utils.cond(
       [this.errorIsHTML(), () => this.renderHTMLError()],
       [this.errorIsJSON(), () => this.renderJSONError()],
-      () => error
+      // 502s due to a service being down result in TypeError in a bunch of places.
+      () => error.message || error.toString()
     )
 
     return collapses ? h(Collapse, {

--- a/src/components/ErrorView.js
+++ b/src/components/ErrorView.js
@@ -1,5 +1,4 @@
-import { Fragment } from 'react'
-import { div, h, iframe } from 'react-hyperscript-helpers'
+import { div, h, iframe, pre } from 'react-hyperscript-helpers'
 import Collapse from 'src/components/Collapse'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
@@ -15,9 +14,11 @@ class StackTraceView extends Component {
       title: 'Stack Trace',
       defaultHidden: true
     }, [
-      lines.map(({ className, methodName, fileName, lineNumber }, idx) => div({ key: idx }, [
-        `${fileName} ${className}.${methodName} (line ${lineNumber})`
-      ]))
+      pre({ style: { overflowX: 'auto' } }, [
+        lines.map(({ className, methodName, fileName, lineNumber }, idx) => div({ key: idx }, [
+          `${className}.${methodName} (${fileName}:${lineNumber})`
+        ]))
+      ])
     ])
   }
 }

--- a/src/components/ErrorView.js
+++ b/src/components/ErrorView.js
@@ -70,29 +70,14 @@ export default class ErrorView extends Component {
   renderHTMLError() {
     const { error } = this.props
 
-    const htmlDoc = new DOMParser().parseFromString(error, 'text/xml')
-    const textContent = htmlDoc.getElementsByTagName('body')[0].textContent
-
-    return h(Fragment, [
-      'The server returned an HTML document, its content is:',
-      div({ style: { padding: '0.5rem', fontWeight: 400 } }, [
-        decodeURIComponent(textContent)
-      ]),
-      h(Collapse, {
-        style: { padding: '0.5rem' },
-        title: 'Full response',
-        defaultHidden: true
-      }, [
-        iframe({
-          style: {
-            width: '100%',
-            border: Style.standardLine, borderRadius: 3,
-            padding: '1rem', backgroundColor: 'white'
-          },
-          srcDoc: error, sandbox: ''
-        })
-      ])
-    ])
+    return iframe({
+      style: {
+        width: '100%',
+        border: Style.standardLine, borderRadius: 3,
+        padding: '1rem', backgroundColor: 'white'
+      },
+      srcDoc: error, sandbox: ''
+    })
   }
 
   errorIsJSON() {

--- a/src/components/notebook-utils.js
+++ b/src/components/notebook-utils.js
@@ -97,7 +97,7 @@ export class NotebookCreator extends Component {
                   },
                   error => {
                     this.setState({ creating: false })
-                    reportError({ error, title: 'Error creating notebook' })
+                    reportError('Error creating notebook', error)
                   }
                 )
               }
@@ -161,7 +161,7 @@ export class NotebookDuplicator extends Component {
           this.setState({ processing: true })
           Buckets.notebook(namespace, bucketName, printName)[destroyOld ? 'rename' : 'copy'](newName).then(
             onSuccess,
-            error => reportError({ error, title: `Error ${destroyOld ? 'renaming' : 'copying'} notebook` })
+            error => reportError(`Error ${destroyOld ? 'renaming' : 'copying'} notebook`, error)
           )
         }
       }, `${destroyOld ? 'Rename' : 'Duplicate'} Notebook`)
@@ -196,7 +196,7 @@ export class NotebookDeleter extends Component {
           this.setState({ processing: true })
           Buckets.notebook(namespace, bucketName, printName).delete().then(
             onSuccess,
-            error => reportError({ error, title: 'Error deleting notebook' })
+            error => reportError('Error deleting notebook', error)
           )
         }
       }, 'Delete Notebook')

--- a/src/components/notebook-utils.js
+++ b/src/components/notebook-utils.js
@@ -97,7 +97,7 @@ export class NotebookCreator extends Component {
                   },
                   error => {
                     this.setState({ creating: false })
-                    reportError(`Error creating notebook: ${error}`)
+                    reportError({ error, title: 'Error creating notebook' })
                   }
                 )
               }
@@ -161,7 +161,7 @@ export class NotebookDuplicator extends Component {
           this.setState({ processing: true })
           Buckets.notebook(namespace, bucketName, printName)[destroyOld ? 'rename' : 'copy'](newName).then(
             onSuccess,
-            error => reportError(`Error ${destroyOld ? 'renaming' : 'copying'} notebook: ${error}`)
+            error => reportError({ error, title: `Error ${destroyOld ? 'renaming' : 'copying'} notebook` })
           )
         }
       }, `${destroyOld ? 'Rename' : 'Duplicate'} Notebook`)
@@ -196,10 +196,10 @@ export class NotebookDeleter extends Component {
           this.setState({ processing: true })
           Buckets.notebook(namespace, bucketName, printName).delete().then(
             onSuccess,
-            error => reportError(`Error deleting notebook: ${error}`)
+            error => reportError({ error, title: 'Error deleting notebook' })
           )
         }
-      }, `Delete Notebook`)
+      }, 'Delete Notebook')
     },
     Utils.cond(
       [processing, () => [centeredSpinner()]],

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -34,7 +34,7 @@ authStore.subscribe((state, oldState) => {
     }).then(registrationStatus => {
       authStore.update(state => ({ ...state, registrationStatus }))
     }, error => {
-      reportError(`Error checking registration: ${error}`)
+      reportError({ error, title: 'Error checking registration' })
     })
   }
 })
@@ -76,7 +76,7 @@ authStore.subscribe(async (state, oldState) => {
         })
       }))
     } catch (error) {
-      reportError(`Error auto-creating clusters: ${error}`)
+      reportError({ error, title: 'Error auto-creating clusters' })
     }
   }
 })

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -34,7 +34,7 @@ authStore.subscribe((state, oldState) => {
     }).then(registrationStatus => {
       authStore.update(state => ({ ...state, registrationStatus }))
     }, error => {
-      reportError({ error, title: 'Error checking registration' })
+      reportError('Error checking registration', error)
     })
   }
 })
@@ -76,7 +76,7 @@ authStore.subscribe(async (state, oldState) => {
         })
       }))
     } catch (error) {
-      reportError({ error, title: 'Error auto-creating clusters' })
+      reportError('Error auto-creating clusters', error)
     }
   }
 })

--- a/src/libs/error.js
+++ b/src/libs/error.js
@@ -2,6 +2,6 @@ import * as Utils from 'src/libs/utils'
 
 export const errorStore = Utils.atom()
 
-export const reportError = text => {
-  errorStore.set(text)
+export const reportError = (title, error) => {
+  errorStore.set({ title, error })
 }

--- a/src/libs/error.js
+++ b/src/libs/error.js
@@ -5,3 +5,7 @@ export const errorStore = Utils.atom()
 export const reportError = (title, error) => {
   errorStore.set({ title, error })
 }
+
+export const clearError = () => {
+  errorStore.set(undefined)
+}

--- a/src/pages/ImportTool.js
+++ b/src/pages/ImportTool.js
@@ -3,6 +3,7 @@ import { Fragment } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
 import Collapse from 'src/components/Collapse'
 import { buttonPrimary, pageColumn } from 'src/components/common'
+import ErrorView from 'src/components/ErrorView'
 import { centeredSpinner, icon, spinner } from 'src/components/icons'
 import { TopBar } from 'src/components/TopBar'
 import WDLViewer from 'src/components/WDLViewer'
@@ -177,9 +178,9 @@ class DockstoreImporter extends Component {
   renderError() {
     const { loadError } = this.state
 
-    return h(Fragment, [
+    return div({ style: { padding: '2rem' } }, [
       div(wdlLoadError),
-      div(`Error: ${loadError}`)
+      h(ErrorView, { error: loadError })
     ])
   }
 }

--- a/src/pages/ImportTool.js
+++ b/src/pages/ImportTool.js
@@ -61,7 +61,7 @@ export class DestinationProject extends Component {
   componentDidMount() {
     Rawls.workspacesList().then(
       workspaces => this.setState({ workspaces }),
-      error => reportError({ error, title: 'Error loading workspaces' })
+      error => reportError('Error loading workspaces', error)
     )
   }
 }
@@ -87,7 +87,7 @@ class DockstoreImporter extends Component {
     this.loadWdl()
     Rawls.workspacesList().then(
       workspaces => this.setState({ workspaces }),
-      error => reportError({ error, title: 'Error loading workspaces' })
+      error => reportError('Error loading workspaces', error)
     )
   }
 

--- a/src/pages/Register.js
+++ b/src/pages/Register.js
@@ -34,7 +34,7 @@ export default class Register extends Component {
       })
       authStore.update(state => ({ ...state, isRegistered: true }))
     } catch (error) {
-      reportError(`Error registering: ${error}`)
+      reportError({ error, title: 'Error registering' })
     } finally {
       this.setState({ busy: false })
     }

--- a/src/pages/Register.js
+++ b/src/pages/Register.js
@@ -34,7 +34,7 @@ export default class Register extends Component {
       })
       authStore.update(state => ({ ...state, isRegistered: true }))
     } catch (error) {
-      reportError({ error, title: 'Error registering' })
+      reportError('Error registering', error)
     } finally {
       this.setState({ busy: false })
     }

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -174,7 +174,7 @@ export class WorkspaceList extends Component {
           Utils.workspaceAccessLevels.indexOf(ws.accessLevel) > Utils.workspaceAccessLevels.indexOf('READER'),
         workspaces))
       }),
-      error => reportError(`Error loading workspace list: ${error}`)
+      error => reportError('Error loading workspace list', error)
     )
   }
 

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -24,7 +24,7 @@ export default class WorkspaceDashboard extends Component {
 
     Rawls.workspace(namespace, name).details().then(
       workspace => this.setState({ isDataLoaded: true, workspace }),
-      error => reportError(`Error loading workspace: ${error}`)
+      error => reportError('Error loading workspace', error)
     )
   }
 

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -28,7 +28,7 @@ class WorkspaceData extends Component {
 
     Rawls.workspace(namespace, name).entities().then(
       workspaceEntities => this.setState({ workspaceEntities }),
-      error => reportError(`Error loading workspace entities: ${error}`)
+      error => reportError({ error, title: 'Error loading workspace entities' })
     )
 
     if (selectedEntityType) {
@@ -41,7 +41,7 @@ class WorkspaceData extends Component {
 
     Rawls.workspace(namespace, name).entity(type).then(
       selectedEntities => this.setState({ isDataLoaded: true, selectedEntities }),
-      error => reportError(`Error loading workspace entity: ${error}`)
+      error => reportError({ error, title: 'Error loading workspace entity' })
     )
   }
 

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -28,7 +28,7 @@ class WorkspaceData extends Component {
 
     Rawls.workspace(namespace, name).entities().then(
       workspaceEntities => this.setState({ workspaceEntities }),
-      error => reportError({ error, title: 'Error loading workspace entities' })
+      error => reportError('Error loading workspace entities', error)
     )
 
     if (selectedEntityType) {
@@ -41,7 +41,7 @@ class WorkspaceData extends Component {
 
     Rawls.workspace(namespace, name).entity(type).then(
       selectedEntities => this.setState({ isDataLoaded: true, selectedEntities }),
-      error => reportError({ error, title: 'Error loading workspace entity' })
+      error => reportError('Error loading workspace entity', error)
     )
   }
 

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -191,7 +191,7 @@ class WorkspaceNotebooks extends Component {
         })
       }
     } catch (error) {
-      reportError(`Error loading notebooks: ${error}`)
+      reportError({ error, title: 'Error loading notebooks' })
     }
   }
 

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -191,7 +191,7 @@ class WorkspaceNotebooks extends Component {
         })
       }
     } catch (error) {
-      reportError({ error, title: 'Error loading notebooks' })
+      reportError('Error loading notebooks', error)
     }
   }
 

--- a/src/pages/workspaces/workspace/Tools.js
+++ b/src/pages/workspaces/workspace/Tools.js
@@ -23,7 +23,7 @@ class WorkspaceTools extends Component {
 
     Rawls.workspace(namespace, name).listMethodConfigs().then(
       configs => this.setState({ isFreshData: true, configs }),
-      error => reportError({ error, title: 'Error loading configs' })
+      error => reportError('Error loading configs', error)
     )
   }
 

--- a/src/pages/workspaces/workspace/Tools.js
+++ b/src/pages/workspaces/workspace/Tools.js
@@ -23,7 +23,7 @@ class WorkspaceTools extends Component {
 
     Rawls.workspace(namespace, name).listMethodConfigs().then(
       configs => this.setState({ isFreshData: true, configs }),
-      error => reportError(`Error loading configs: ${error}`)
+      error => reportError({ error, title: 'Error loading configs' })
     )
   }
 

--- a/src/pages/workspaces/workspace/tools/WorkflowView.js
+++ b/src/pages/workspaces/workspace/tools/WorkflowView.js
@@ -122,7 +122,7 @@ class WorkflowView extends Component {
 
       this.setState({ isFreshData: true, config, entityTypes, inputsOutputs, ioDefinitions, firecloudRoot })
     } catch (error) {
-      reportError(`Error loading data: ${error}`)
+      reportError({ error, title: 'Error loading data' })
     }
   }
 
@@ -364,7 +364,7 @@ class WorkflowView extends Component {
       })()
       this.setState({ wdl })
     } catch (error) {
-      reportError(`Error loading WDL: ${error}`)
+      reportError({ error, title: 'Error loading WDL' })
     }
   }
 
@@ -387,7 +387,7 @@ class WorkflowView extends Component {
         config: validationResponse.methodConfiguration
       })
     } catch (error) {
-      reportError(`Error saving: ${error}`)
+      reportError({ error, title: 'Error saving' })
     } finally {
       this.setState({ saving: false })
     }

--- a/src/pages/workspaces/workspace/tools/WorkflowView.js
+++ b/src/pages/workspaces/workspace/tools/WorkflowView.js
@@ -122,7 +122,7 @@ class WorkflowView extends Component {
 
       this.setState({ isFreshData: true, config, entityTypes, inputsOutputs, ioDefinitions, firecloudRoot })
     } catch (error) {
-      reportError({ error, title: 'Error loading data' })
+      reportError('Error loading data', error)
     }
   }
 
@@ -364,7 +364,7 @@ class WorkflowView extends Component {
       })()
       this.setState({ wdl })
     } catch (error) {
-      reportError({ error, title: 'Error loading WDL' })
+      reportError('Error loading WDL', error)
     }
   }
 
@@ -387,7 +387,7 @@ class WorkflowView extends Component {
         config: validationResponse.methodConfiguration
       })
     } catch (error) {
-      reportError({ error, title: 'Error saving' })
+      reportError('Error saving', error)
     } finally {
       this.setState({ saving: false })
     }


### PR DESCRIPTION
* Made an ErrorView component that takes whatever error vomit and deals with it. Parameter for whether or not it's wrapped in a Collapse.
* Made `reportError` take a title and error

To test with HTML report, try to import something that doesn't exist, or edit any ajax endpoint to not include authOpts() and hit it.

To test with JSON, you can corrupt most json bodies. Looks like this:

<img width="841" alt="screen shot 2018-06-01 at 1 31 08 pm" src="https://user-images.githubusercontent.com/785011/40854909-e7b75e3a-65a0-11e8-95b7-afddab2ee3e9.png">

Here's one with a cause but no stack traces:

<img width="834" alt="screen shot 2018-06-01 at 1 42 21 pm" src="https://user-images.githubusercontent.com/785011/40855161-b8f181ec-65a1-11e8-82fd-7ffbbd2c62fc.png">

