### PR TITLE
add FlexTable and GridTable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2714,6 +2714,11 @@
         }
       }
     },
+    "dom-helpers": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.3.1.tgz",
+      "integrity": "sha512-2Sm+JaYn74OiTM2wHvxJOo3roiq/h25Yi69Fqk269cNUwIXsCvATB6CRSFC9Am/20G2b28hGv/+7NiWydIrPvg=="
+    },
     "dom-serializer": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
@@ -9687,6 +9692,19 @@
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.0",
         "react-is": "^16.3.2"
+      }
+    },
+    "react-virtualized": {
+      "version": "9.19.1",
+      "resolved": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-9.19.1.tgz",
+      "integrity": "sha512-2l6uFicZKZ3x4rdnS0W+1TfyLmPO/+hfZKsCtoChoSmH5aEezGLpSuHc7oplekNIOaEwChfCk30zjx+Zw6B8YQ==",
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "classnames": "^2.2.3",
+        "dom-helpers": "^2.4.0 || ^3.0.0",
+        "loose-envify": "^1.3.0",
+        "prop-types": "^15.6.0",
+        "react-lifecycles-compat": "^3.0.4"
       }
     },
     "read-pkg": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react-portal-tooltip": "^2.4.0",
     "react-scripts": "1.1.4",
     "react-select": "^1.2.1",
+    "react-virtualized": "^9.19.1",
     "uuid": "^3.2.1",
     "validate.js": "^0.12.0"
   },

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -4,6 +4,7 @@ import { Fragment } from 'react'
 import { button, div, h, option, select, table, td, th, tr } from 'react-hyperscript-helpers'
 import Interactive from 'react-interactive'
 import Pagination from 'react-paginating'
+import { Grid as RVGrid, ScrollSync as RVScrollSync } from 'react-virtualized'
 import { icon } from 'src/components/icons'
 import * as Style from 'src/libs/style'
 import { Component } from 'src/libs/wrapped-components'
@@ -268,4 +269,171 @@ export class DataGrid extends Component {
         null
     ])
   }
+}
+
+const cellStyles = {
+  display: 'flex',
+  alignItems: 'center',
+  paddingLeft: '1rem',
+  paddingRight: '1rem'
+}
+
+const styles = {
+  cell: (col, total) => ({
+    ...cellStyles,
+    borderBottom: `1px solid ${Style.colors.border}`,
+    borderLeft: col === 0 ? `1px solid ${Style.colors.border}` : undefined,
+    borderRight: col === total - 1 ? `1px solid ${Style.colors.border}` : undefined
+  }),
+  header: (col, total) => ({
+    ...cellStyles,
+    backgroundColor: Style.colors.sectionHighlight,
+    borderTop: `1px solid ${Style.colors.sectionBorder}`,
+    borderBottom: `2px solid ${Style.colors.sectionBorder}`,
+    borderLeft: col === 0 ? `1px solid ${Style.colors.sectionBorder}` : undefined,
+    borderRight: col === total - 1 ? `1px solid ${Style.colors.sectionBorder}` : undefined,
+    borderTopLeftRadius: col === 0 ? '5px' : undefined,
+    borderTopRightRadius: col === total - 1 ? '5px' : undefined
+  }),
+  flexCell: ({ basis = 0, grow = 1, shrink = 1, min = 0, max } = {}) => ({
+    flexGrow: grow,
+    flexShrink: shrink,
+    flexBasis: basis,
+    minWidth: min,
+    maxWidth: max
+  })
+}
+
+/**
+ * A virtual table with a fixed header and flexible column widths. Intended to take up the full
+ * available container width, without horizontal scrolling.
+ */
+
+export class FlexTable extends Component {
+  constructor(props) {
+    super(props)
+    this.state = { scrollbarSize: 0 }
+  }
+
+  render() {
+    const { width, height, rowCount, columns, hoverHighlight } = this.props
+    const { scrollbarSize } = this.state
+    return div([
+      div({
+        style: {
+          width: width - scrollbarSize,
+          height: 48,
+          display: 'flex'
+        }
+      }, [
+        ..._.map(([i, { size, headerRenderer }]) => {
+          return div({
+            key: i,
+            style: { ...styles.flexCell(size), ...styles.header(i * 1, columns.length) }
+          }, [headerRenderer()])
+        }, _.toPairs(columns))
+      ]),
+      h(RVGrid, {
+        width,
+        height: height - 48,
+        columnWidth: width - scrollbarSize,
+        rowHeight: 48,
+        rowCount,
+        columnCount: 1,
+        onScrollbarPresenceChange: ({ vertical, size }) => {
+          this.setState({ scrollbarSize: vertical ? size : 0 })
+        },
+        cellRenderer: data => {
+          return h(Interactive, {
+            key: data.key,
+            as: 'div',
+            style: { ...data.style, backgroundColor: '#ffffff', display: 'flex' },
+            hover: hoverHighlight ? { backgroundColor: Style.colors.highlightFaded } : undefined
+          }, [
+            ..._.map(([i, { size, cellRenderer }]) => {
+              return div({
+                key: i,
+                style: { ...styles.flexCell(size), ...styles.cell(i * 1, columns.length) }
+              }, [cellRenderer(data)])
+            }, _.toPairs(columns))
+          ])
+        },
+        style: { outline: 'none' }
+      })
+    ])
+  }
+}
+
+/**
+ * A virtual table with a fixed header and explicit column widths. Intended for displaying large
+ * datasets which may require horizontal scrolling.
+ */
+
+export class GridTable extends Component {
+  constructor(props) {
+    super(props)
+    this.state = { scrollbarSize: 0 }
+  }
+
+  render() {
+    const { width, height, rowCount, columns } = this.props
+    const { scrollbarSize } = this.state
+    return h(RVScrollSync, [
+      ({ onScroll, scrollLeft }) => {
+        return div([
+          h(RVGrid, {
+            width: width - scrollbarSize,
+            height: 48,
+            columnWidth: ({ index }) => columns[index].width,
+            rowHeight: 48,
+            rowCount: 1,
+            columnCount: columns.length,
+            cellRenderer: data => {
+              return div({
+                key: data.key,
+                style: { ...data.style, ...styles.header(data.columnIndex, columns.length) }
+              }, [
+                columns[data.columnIndex].headerRenderer(data)
+              ])
+            },
+            style: { outline: 'none', overflow: 'hidden' },
+            scrollLeft,
+            onScroll
+          }),
+          h(RVGrid, {
+            width,
+            height: height - 48,
+            columnWidth: ({ index }) => columns[index].width,
+            rowHeight: 48,
+            rowCount,
+            columnCount: columns.length,
+            onScrollbarPresenceChange: ({ vertical, size }) => {
+              this.setState({ scrollbarSize: vertical ? size : 0 })
+            },
+            cellRenderer: data => {
+              return div({
+                key: data.key,
+                style: {
+                  ...data.style,
+                  ...styles.cell(data.columnIndex, columns.length),
+                  backgroundColor: '#ffffff'
+                }
+              }, [
+                columns[data.columnIndex].cellRenderer(data)
+              ])
+            },
+            style: { outline: 'none' },
+            scrollLeft,
+            onScroll
+          })
+        ])
+      }
+    ])
+  }
+}
+
+export const TextCell = props => {
+  return div(_.merge({
+    style: { overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' }
+  }, props))
 }

--- a/src/pages/StyleGuide.js
+++ b/src/pages/StyleGuide.js
@@ -1,8 +1,10 @@
 import _ from 'lodash/fp'
 import { div, h, h1 } from 'react-hyperscript-helpers'
+import { AutoSizer } from 'react-virtualized'
 import { buttonPrimary, buttonSecondary, Checkbox, link, search } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import { textInput, validatedInput } from 'src/components/input'
+import { FlexTable, GridTable, TextCell } from 'src/components/table'
 import * as Nav from 'src/libs/nav'
 import * as Style from 'src/libs/style'
 import { Component } from 'src/libs/wrapped-components'
@@ -78,6 +80,55 @@ class StyleGuide extends Component {
         h(Checkbox, { checked: false }),
         h(Checkbox, { checked: true }),
         h(Checkbox, { checked: false, disabled: true })
+      ]),
+      div({ style: { ...styles.container, height: 300 } }, [
+        h(AutoSizer, [
+          ({ width, height }) => {
+            return h(FlexTable, {
+              width, height,
+              rowCount: 100,
+              hoverHighlight: true,
+              columns: [
+                {
+                  size: { basis: 100, grow: 0 },
+                  headerRenderer: () => 'ID',
+                  cellRenderer: ({ rowIndex }) => `id-${rowIndex}`
+                },
+                {
+                  size: { basis: 150, grow: 0 },
+                  headerRenderer: () => 'Name',
+                  cellRenderer: ({ rowIndex }) => {
+                    return h(TextCell, `name-${rowIndex} with long text`)
+                  }
+                },
+                {
+                  size: { basis: 150 },
+                  headerRenderer: () => 'Details',
+                  cellRenderer: ({ rowIndex }) => {
+                    return textInput({ readOnly: true, value: `details-${rowIndex}` })
+                  }
+                }
+              ]
+            })
+          }
+        ])
+      ]),
+      div({ style: { ...styles.container, height: 300 } }, [
+        h(AutoSizer, [
+          ({ width, height }) => {
+            return h(GridTable, {
+              width, height,
+              rowCount: 100,
+              columns: [
+                ..._.map(n => ({
+                  width: 150,
+                  headerRenderer: () => `header-${n}`,
+                  cellRenderer: ({ rowIndex }) => `data-${rowIndex}-${n}`
+                }), _.range(0, 20))
+              ]
+            })
+          }
+        ])
       ])
     ])
   }


### PR DESCRIPTION
This introduces the new table infrastructure based on `react-virtualized`. In order to keep PR sizes reasonable, this one just adds the new components with some style guide examples. Swapping out the existing tables will happen in followup PRs.