### PR TITLE
convert project data and launch analysis tables

### DIFF
--- a/src/components/table.js
+++ b/src/components/table.js
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp'
 import RCTable from 'rc-table'
-import { Fragment } from 'react'
+import { Fragment, createRef } from 'react'
 import { button, div, h, option, select, table, td, th, tr } from 'react-hyperscript-helpers'
 import Interactive from 'react-interactive'
 import Pagination from 'react-paginating'
@@ -373,6 +373,11 @@ export class GridTable extends Component {
   constructor(props) {
     super(props)
     this.state = { scrollbarSize: 0 }
+    this.grid = createRef()
+  }
+
+  componentDidMount() {
+    this.grid.current.measureAllCells()
   }
 
   render() {
@@ -401,6 +406,7 @@ export class GridTable extends Component {
             onScroll
           }),
           h(RVGrid, {
+            ref: this.grid,
             width,
             height: height - 48,
             columnWidth: ({ index }) => columns[index].width,

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -376,7 +376,7 @@ export class GridTable extends Component {
   }
 
   render() {
-    const { width, height, rowCount, columns } = this.props
+    const { width, height, rowCount, columns, cellStyle } = this.props
     const { scrollbarSize } = this.state
     return h(RVScrollSync, [
       ({ onScroll, scrollLeft }) => {
@@ -416,7 +416,8 @@ export class GridTable extends Component {
                 style: {
                   ...data.style,
                   ...styles.cell(data.columnIndex, columns.length),
-                  backgroundColor: '#ffffff'
+                  backgroundColor: '#ffffff',
+                  ...(cellStyle ? cellStyle(data) : {})
                 }
               }, [
                 columns[data.columnIndex].cellRenderer(data)

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -139,3 +139,11 @@ export const delay = ms => {
 export const generateClusterName = () => `saturn-${uuid()}`
 
 export const waitOneTick = () => new Promise(setImmediate)
+
+export const entityAttributeText = value => {
+  return cond(
+    [_.has('entityName', value), () => value.entityName],
+    [_.has('items', value), () => `[${value.items.length}]`],
+    () => value
+  )
+}

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -74,7 +74,11 @@ class WorkspaceData extends Component {
               ..._.map(name => ({
                 width: 300,
                 headerRenderer: () => h(TextCell, name),
-                cellRenderer: ({ rowIndex }) => h(TextCell, selectedEntities[rowIndex].attributes[name])
+                cellRenderer: ({ rowIndex }) => {
+                  return h(TextCell, [
+                    Utils.entityAttributeText(selectedEntities[rowIndex].attributes[name])
+                  ])
+                }
               }), entityMetadata[selectedEntityType].attributeNames)
             ]
           })

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -1,10 +1,11 @@
 import _ from 'lodash/fp'
 import { Fragment } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
+import { AutoSizer } from 'react-virtualized'
 import * as breadcrumbs from 'src/components/breadcrumbs'
 import { spinnerOverlay } from 'src/components/common'
 import { icon } from 'src/components/icons'
-import { DataTable } from 'src/components/table'
+import { GridTable, TextCell, paginator } from 'src/components/table'
 import { Rawls } from 'src/libs/ajax'
 import { reportError } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
@@ -56,8 +57,43 @@ class WorkspaceData extends Component {
     this.refresh()
   }
 
+  renderEntityTable() {
+    const { selectedEntityType, selectedEntities, entityMetadata, totalRowCount, pageNumber, itemsPerPage } = this.state
+    return selectedEntities ? h(Fragment, [
+      h(AutoSizer, { disableHeight: true }, [
+        ({ width }) => {
+          return h(GridTable, {
+            width, height: 500,
+            rowCount: selectedEntities.length,
+            columns: [
+              {
+                width: 150,
+                headerRenderer: () => h(TextCell, `${selectedEntityType}_id`),
+                cellRenderer: ({ rowIndex }) => h(TextCell, selectedEntities[rowIndex].name)
+              },
+              ..._.map(name => ({
+                width: 300,
+                headerRenderer: () => h(TextCell, name),
+                cellRenderer: ({ rowIndex }) => h(TextCell, selectedEntities[rowIndex].attributes[name])
+              }), entityMetadata[selectedEntityType].attributeNames)
+            ]
+          })
+        }
+      ]),
+      div({ style: { marginTop: '1rem' } }, [
+        paginator({
+          filteredDataLength: totalRowCount,
+          pageNumber,
+          setPageNumber: v => this.setState({ pageNumber: v }),
+          itemsPerPage,
+          setItemsPerPage: v => this.setState({ itemsPerPage: v })
+        })
+      ])
+    ]) : spinnerOverlay
+  }
+
   render() {
-    const { selectedEntityType, selectedEntities, entityMetadata, totalRowCount } = this.state
+    const { selectedEntityType, entityMetadata } = this.state
     const { namespace, name } = this.props
 
     const entityTypeList = () => _.map(([type, typeDetails]) =>
@@ -76,35 +112,6 @@ class WorkspaceData extends Component {
         `${type} (${typeDetails.count})`
       ]),
     _.toPairs(entityMetadata))
-
-    const entityTable = () => h(Fragment, [
-      selectedEntities ? h(DataTable, {
-        defaultItemsPerPage: this.state.itemsPerPage,
-        onItemsPerPageChanged: itemsPerPage => this.setState({ itemsPerPage }),
-        initialPage: this.state.pageNumber,
-        onPageChanged: pageNumber => this.setState({ pageNumber }),
-        totalRowCount,
-        dataSource: selectedEntities,
-        tableProps: {
-          rowKey: 'name',
-          scroll: { x: true },
-          columns: _.concat([
-            {
-              title: selectedEntityType + '_id',
-              key: selectedEntityType + '_id',
-              render: entity => entity.name
-            }
-          ], _.map(name => {
-            return {
-              title: name,
-              key: name,
-              render: entity => entity.attributes[name]
-            }
-          }, entityMetadata[selectedEntityType]['attributeNames']))
-        }
-      }) : spinnerOverlay
-    ])
-
 
     return h(WorkspaceContainer,
       {
@@ -146,7 +153,7 @@ class WorkspaceData extends Component {
                     textAlign: selectedEntityType ? undefined : 'center'
                   }
                 },
-                [selectedEntityType ? entityTable() : 'Select a data type.']
+                [selectedEntityType ? this.renderEntityTable() : 'Select a data type.']
               )
             ])
           )

--- a/src/pages/workspaces/workspace/tools/LaunchAnalysisModal.js
+++ b/src/pages/workspaces/workspace/tools/LaunchAnalysisModal.js
@@ -99,7 +99,9 @@ export default class LaunchAnalysisModal extends Component {
                 width: 300,
                 headerRenderer: () => h(TextCell, name),
                 cellRenderer: ({ rowIndex }) => {
-                  return h(TextCell, filteredEntities[rowIndex].attributes[name])
+                  return h(TextCell, [
+                    Utils.entityAttributeText(filteredEntities[rowIndex].attributes[name])
+                  ])
                 }
               }), attributeNames)
             ],


### PR DESCRIPTION
Changes some tables over to the new implementation. For the launch analysis modal, we can get rid of pagination (for now, at least) because we have all of the data client-side, so just display it all.