### PR TITLE
implement autocomplete textbox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9358,6 +9358,26 @@
         "dotenv": "^4.0.0"
       }
     },
+    "react-autosuggest": {
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/react-autosuggest/-/react-autosuggest-9.3.4.tgz",
+      "integrity": "sha512-vcAsZw+6zkjimni4aun1tvuzVCGilmFihAgF8yCeVm/p82ssGgtQb0pnNCcEBcPzPTLJjQc2O8dLJidoOyjlcA==",
+      "requires": {
+        "prop-types": "^15.5.10",
+        "react-autowhatever": "^10.1.0",
+        "shallow-equal": "^1.0.0"
+      }
+    },
+    "react-autowhatever": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/react-autowhatever/-/react-autowhatever-10.1.1.tgz",
+      "integrity": "sha512-fcwjDnk1zKMYoJyKmEukw8eWJlwT6UVKZagY+Lfhj79Nx0D8Brj38ZLNtQOFrRLAZrIA+QX4UUjW0MUISqT9OA==",
+      "requires": {
+        "prop-types": "^15.5.8",
+        "react-themeable": "^1.1.0",
+        "section-iterator": "^2.0.0"
+      }
+    },
     "react-dev-utils": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-5.0.1.tgz",
@@ -9599,6 +9619,21 @@
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.0",
         "react-is": "^16.3.2"
+      }
+    },
+    "react-themeable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/react-themeable/-/react-themeable-1.1.0.tgz",
+      "integrity": "sha1-fURm3ZsrX6dQWHJ4JenxUro3mg4=",
+      "requires": {
+        "object-assign": "^3.0.0"
+      },
+      "dependencies": {
+        "object-assign": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
+        }
       }
     },
     "react-virtualized": {
@@ -10191,6 +10226,11 @@
         }
       }
     },
+    "section-iterator": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/section-iterator/-/section-iterator-2.0.0.tgz",
+      "integrity": "sha1-v0RNev7rlK1Dw5rS+yYVFifMuio="
+    },
     "select": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
@@ -10334,6 +10374,11 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
+    },
+    "shallow-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.0.0.tgz",
+      "integrity": "sha1-UI0YOLPeWQq4dXsBGyXkMJAJRfc="
     },
     "shallowequal": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react-app-rewire-eslint": "^0.2.3",
     "react-app-rewire-hot-loader": "^1.0.1",
     "react-app-rewired": "^1.5.2",
+    "react-autosuggest": "^9.3.4",
     "react-dom": "^16.3.2",
     "react-hot-loader": "^4.2.0",
     "react-hyperscript-helpers": "^1.2.0",

--- a/src/components/input.js
+++ b/src/components/input.js
@@ -1,9 +1,11 @@
 import _ from 'lodash/fp'
 import { Component, Fragment } from 'react'
+import Autosuggest from 'react-autosuggest'
 import { div, h } from 'react-hyperscript-helpers'
 import Interactive from 'react-interactive'
 import { icon } from 'src/components/icons'
 import * as Style from 'src/libs/style'
+import * as Utils from 'src/libs/utils'
 
 
 export const textInput = function(props) {
@@ -103,4 +105,51 @@ export const validatedInput = props => {
     _.map(fail => div({ style: { marginTop: '0.5rem' } }, `${name} ${fail}`), errors)
     )
   ])
+}
+
+export class AutocompleteTextInput extends Component {
+  constructor(props) {
+    super(props)
+    this.state = { show: false }
+  }
+
+  render() {
+    const { value, onChange, suggestions, ...props } = this.props
+    const { show } = this.state
+    return h(Autosuggest, {
+      inputProps: { value, onChange: e => onChange(e.target.value) },
+      suggestions: show ? _.take(10, _.filter(Utils.textMatch(value), suggestions)) : [],
+      onSuggestionsFetchRequested: ({ reason }) => {
+        this.setState({ show: reason !== 'input-focused' })
+      },
+      onSuggestionsClearRequested: () => this.setState({ show: false }),
+      onSuggestionSelected: (e, { suggestionValue }) => onChange(suggestionValue),
+      getSuggestionValue: _.identity,
+      renderSuggestion: v => v,
+      renderInputComponent: inputProps => {
+        return textInput({ value, onChange, ...props, ...inputProps })
+      },
+      theme: {
+        container: {
+          position: 'relative',
+          width: '100%'
+        },
+        suggestionsContainer: {
+          position: 'absolute', left: 0, right: 0, zIndex: 1,
+          backgroundColor: 'white'
+        },
+        suggestionsList: {
+          margin: 0, padding: 0,
+          border: `1px solid ${Style.colors.border}`
+        },
+        suggestion: {
+          display: 'block', lineHeight: '2.25rem',
+          paddingLeft: '1rem', paddingRight: '1rem'
+        },
+        suggestionHighlighted: {
+          backgroundColor: Style.colors.highlightFaded
+        }
+      }
+    })
+  }
 }

--- a/src/components/input.js
+++ b/src/components/input.js
@@ -8,6 +8,20 @@ import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 
 
+const styles = {
+  suggestionsContainer: {
+    position: 'absolute', left: 0, right: 0, zIndex: 1,
+    maxHeight: 36 * 8 + 2, overflowY: 'auto',
+    backgroundColor: 'white',
+    border: `1px solid ${Style.colors.border}`
+  },
+  suggestion: {
+    display: 'block', lineHeight: '2.25rem',
+    paddingLeft: '1rem', paddingRight: '1rem',
+    cursor: 'pointer'
+  }
+}
+
 export const textInput = function(props) {
   return h(Interactive, _.mergeAll([
     {
@@ -118,37 +132,28 @@ export class AutocompleteTextInput extends Component {
     const { show } = this.state
     return h(Autosuggest, {
       inputProps: { value, onChange: e => onChange(e.target.value) },
-      suggestions: show ? _.take(10, _.filter(Utils.textMatch(value), suggestions)) : [],
-      onSuggestionsFetchRequested: ({ reason }) => {
-        this.setState({ show: reason !== 'input-focused' })
-      },
+      suggestions: show ? (value ? _.filter(Utils.textMatch(value), suggestions) : suggestions) : [],
+      onSuggestionsFetchRequested: () => this.setState({ show: true }),
       onSuggestionsClearRequested: () => this.setState({ show: false }),
       onSuggestionSelected: (e, { suggestionValue }) => onChange(suggestionValue),
       getSuggestionValue: _.identity,
+      shouldRenderSuggestions: () => true,
+      focusInputOnSuggestionClick: false,
+      renderSuggestionsContainer: ({ containerProps, children }) => {
+        return children && div({
+          ...containerProps,
+          style: styles.suggestionsContainer
+        }, [children])
+      },
       renderSuggestion: v => v,
       renderInputComponent: inputProps => {
-        return textInput({ value, onChange, ...props, ...inputProps })
+        return textInput({ value, onChange, ...props, ...inputProps, type: 'search' })
       },
       theme: {
-        container: {
-          position: 'relative',
-          width: '100%'
-        },
-        suggestionsContainer: {
-          position: 'absolute', left: 0, right: 0, zIndex: 1,
-          backgroundColor: 'white'
-        },
-        suggestionsList: {
-          margin: 0, padding: 0,
-          border: `1px solid ${Style.colors.border}`
-        },
-        suggestion: {
-          display: 'block', lineHeight: '2.25rem',
-          paddingLeft: '1rem', paddingRight: '1rem'
-        },
-        suggestionHighlighted: {
-          backgroundColor: Style.colors.highlightFaded
-        }
+        container: { position: 'relative', width: '100%' },
+        suggestionsList: { margin: 0, padding: 0 },
+        suggestion: styles.suggestion,
+        suggestionHighlighted: { backgroundColor: Style.colors.highlightFaded }
       }
     })
   }

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -147,3 +147,5 @@ export const entityAttributeText = value => {
     () => value
   )
 }
+
+export const textMatch = _.curry((needle, haystack) => haystack.indexOf(needle) !== -1)

--- a/src/pages/workspaces/workspace/tools/WorkflowView.js
+++ b/src/pages/workspaces/workspace/tools/WorkflowView.js
@@ -294,7 +294,7 @@ class WorkflowView extends Component {
                   return div({ style: { display: 'flex', alignItems: 'center', width: '100%' } }, [
                     h(AutocompleteTextInput, {
                       placeholder: optional ? 'Optional' : 'Required',
-                      value: modifiedConfig[key][name],
+                      value: modifiedConfig[key][name] || '',
                       onChange: v => this.setState(_.set(['modifiedAttributes', key, name], v)),
                       suggestions
                     }),

--- a/src/pages/workspaces/workspace/tools/WorkflowView.js
+++ b/src/pages/workspaces/workspace/tools/WorkflowView.js
@@ -5,7 +5,7 @@ import { AutoSizer } from 'react-virtualized'
 import * as breadcrumbs from 'src/components/breadcrumbs'
 import { buttonPrimary, buttonSecondary, link, spinnerOverlay, tooltip } from 'src/components/common'
 import { centeredSpinner, icon } from 'src/components/icons'
-import { textInput } from 'src/components/input'
+import { AutocompleteTextInput } from 'src/components/input'
 import Modal from 'src/components/Modal'
 import TabBar from 'src/components/TabBar'
 import { FlexTable, TextCell } from 'src/components/table'
@@ -58,9 +58,15 @@ class WorkflowView extends Component {
     this.state = {
       activeTab: 'inputs',
       saved: false,
-      modifiedAttributes: { inputs: {}, outputs: {} },
+      modifiedAttributes: {},
+      workspaceAttributes: undefined,
       ...StateHistory.get()
     }
+  }
+
+  getModifiedConfig() {
+    const { config, modifiedAttributes } = this.state
+    return _.merge(config, modifiedAttributes)
   }
 
   render() {
@@ -120,20 +126,25 @@ class WorkflowView extends Component {
     try {
       const workspace = Rawls.workspace(workspaceNamespace, workspaceName)
 
-      const entityTypes = _.map(
-        e => ({ value: e, label: e.replace('_', ' ') }),
-        _.keys(await workspace.entityMetadata())
-      )
+      const [entityMetadata, workspaceDetails, validationResponse, firecloudRoot] = await Promise.all([
+        workspace.entityMetadata(),
+        workspace.details(),
+        workspace.methodConfig(workflowNamespace, workflowName).validate(),
+        Config.getFirecloudUrlRoot()
+      ])
 
-      const validationResponse = await workspace.methodConfig(workflowNamespace, workflowName).validate()
       const { methodConfiguration: config } = validationResponse
       const ioDefinitions = await Rawls.methodConfigInputsOutputs(config)
 
       const inputsOutputs = this.createIOLists(validationResponse, ioDefinitions)
 
-      const firecloudRoot = await Config.getFirecloudUrlRoot()
-
-      this.setState({ isFreshData: true, config, entityTypes, inputsOutputs, ioDefinitions, firecloudRoot })
+      this.setState({
+        isFreshData: true, config, entityMetadata, inputsOutputs, ioDefinitions, firecloudRoot,
+        workspaceAttributes: _.flow(
+          _.without(['description']),
+          _.remove(s => s.includes(':'))
+        )(_.keys(workspaceDetails.workspace.attributes))
+      })
     } catch (error) {
       reportError('Error loading data', error)
     }
@@ -173,17 +184,15 @@ class WorkflowView extends Component {
     }
 
     StateHistory.update(_.pick(
-      [
-        'config', 'entityTypes', 'inputsOutputs', 'invalid', 'modified', 'modifiedAttributes',
-        'activeTab', 'wdl'
-      ],
+      ['config', 'entityMetadata', 'inputsOutputs', 'invalid', 'modifiedAttributes', 'activeTab', 'wdl'],
       this.state)
     )
   }
 
   renderSummary = invalidIO => {
-    const { modifiedAttributes, config, entityTypes, saving, saved, modified, activeTab } = this.state
-    const { name, methodConfigVersion, methodRepoMethod: { methodPath } } = config
+    const { entityMetadata, saving, saved, activeTab, modifiedAttributes } = this.state
+    const { name, methodConfigVersion, methodRepoMethod: { methodPath }, rootEntityType } = this.getModifiedConfig()
+    const modified = !_.isEmpty(modifiedAttributes)
 
     const noLaunchReason = Utils.cond(
       [invalidIO.inputs || invalidIO.outputs, () => 'Add your inputs and outputs to Launch Analysis'],
@@ -201,12 +210,11 @@ class WorkflowView extends Component {
             Select({
               clearable: false, searchable: false,
               wrapperStyle: { display: 'inline-block', width: 200, marginLeft: '0.5rem' },
-              value: modifiedAttributes.rootEntityType || config.rootEntityType,
-              onChange: rootEntityType => {
-                modifiedAttributes.rootEntityType = rootEntityType.value
-                this.setState({ modifiedAttributes, modified: true })
+              value: rootEntityType,
+              onChange: ({ value }) => {
+                this.setState(_.set(['modifiedAttributes', 'rootEntityType'], value))
               },
-              options: entityTypes
+              options: _.map(k => ({ value: k, label: _.startCase(k) }), _.keys(entityMetadata))
             })
           ])
         ]),
@@ -242,7 +250,12 @@ class WorkflowView extends Component {
   }
 
   renderIOTable = key => {
-    const { inputsOutputs: { [key]: data }, modifiedAttributes, config } = this.state
+    const { inputsOutputs: { [key]: data }, entityMetadata, workspaceAttributes } = this.state
+    const modifiedConfig = this.getModifiedConfig()
+    const suggestions = [
+      ..._.map(name => `this.${name}`, entityMetadata[modifiedConfig.rootEntityType].attributeNames),
+      ..._.map(name => `workspace.${name}`, workspaceAttributes)
+    ]
 
     return div({ style: { margin: `1rem ${sideMargin}` } }, [
       h(AutoSizer, { disableHeight: true }, [
@@ -278,20 +291,12 @@ class WorkflowView extends Component {
                 headerRenderer: () => headerCell('Attribute'),
                 cellRenderer: ({ rowIndex }) => {
                   const { name, optional, error } = data[rowIndex]
-                  let value = modifiedAttributes[key][name]
-                  if (value === undefined) {
-                    value = config[key][name]
-                  }
-
                   return div({ style: { display: 'flex', alignItems: 'center', width: '100%' } }, [
-                    textInput({
-                      name, value,
-                      type: 'search',
+                    h(AutocompleteTextInput, {
                       placeholder: optional ? 'Optional' : 'Required',
-                      onChange: e => {
-                        modifiedAttributes[key][name] = e.target.value
-                        this.setState({ modifiedAttributes, modified: true })
-                      }
+                      value: modifiedConfig[key][name],
+                      onChange: v => this.setState(_.set(['modifiedAttributes', key, name], v)),
+                      suggestions
                     }),
                     error && tooltip({
                       component: icon('error', {
@@ -340,19 +345,18 @@ class WorkflowView extends Component {
 
   save = async () => {
     const { workspaceNamespace, workspaceName, workflowNamespace, workflowName } = this.props
-    const { config, modifiedAttributes } = this.state
 
     this.setState({ saving: true })
 
     try {
       const validationResponse = await Rawls.workspace(workspaceNamespace, workspaceName)
         .methodConfig(workflowNamespace, workflowName)
-        .save(_.merge(config, modifiedAttributes))
+        .save(this.getModifiedConfig())
       const inputsOutputs = this.createIOLists(validationResponse)
 
       this.setState({
-        saved: true, modified: false,
-        modifiedAttributes: { inputs: {}, outputs: {} },
+        saved: true,
+        modifiedAttributes: {},
         inputsOutputs,
         config: validationResponse.methodConfiguration
       })
@@ -364,7 +368,7 @@ class WorkflowView extends Component {
   }
 
   cancel = () => {
-    this.setState({ modified: false, saved: false, modifiedAttributes: { inputs: {}, outputs: {} } })
+    this.setState({ saved: false, modifiedAttributes: {} })
   }
 }
 


### PR DESCRIPTION
This adds a basic autocompleting textbox for suggesting attribute names in IO configuration. It also simplifies the state that tracks modifications on that form.

NOTE: The suggestions list gets cut off at the bottom of the table. This is a known issue, and is unavoidable for now given the `overflow: hidden` on the table. We can work around it by rendering the suggestions in a Portal, but that will be a non-trivial task, so I'm going to split that into a separate PR.