### PR TITLE
mark some components as pure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1665,6 +1665,11 @@
         }
       }
     },
+    "change-emitter": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
+      "integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU="
+    },
     "chardet": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
@@ -9693,6 +9698,19 @@
         "set-immediate-shim": "^1.0.1"
       }
     },
+    "recompose": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.27.1.tgz",
+      "integrity": "sha512-p7xsyi/rfNjHfdP7vPU02uSFa+Q1eHhjKrvO+3+kRP4Ortj+MxEmpmd+UQtBGM2D2iNAjzNI5rCyBKp9Ob5McA==",
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "change-emitter": "^0.1.2",
+        "fbjs": "^0.8.1",
+        "hoist-non-react-statics": "^2.3.1",
+        "react-lifecycles-compat": "^3.0.2",
+        "symbol-observable": "^1.0.4"
+      }
+    },
     "recursive-readdir": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.1.tgz",
@@ -10930,6 +10948,11 @@
           }
         }
       }
+    },
+    "symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "symbol-tree": {
       "version": "3.2.2",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "react-scripts": "1.1.4",
     "react-select": "^1.2.1",
     "react-virtualized": "^9.19.1",
+    "recompose": "^0.27.1",
     "uuid": "^3.2.1",
     "validate.js": "^0.12.0"
   },

--- a/src/components/ClusterManager.js
+++ b/src/components/ClusterManager.js
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp'
-import { Component, Fragment } from 'react'
+import { PureComponent, Fragment } from 'react'
 import { div, h, span } from 'react-hyperscript-helpers'
 import Interactive from 'react-interactive'
 import { buttonPrimary, buttonSecondary, LabeledCheckbox } from 'src/components/common'
@@ -216,7 +216,7 @@ const getUpdateIntervalMs = status => {
   }
 }
 
-export default class ClusterManager extends Component {
+export default class ClusterManager extends PureComponent {
   constructor(props) {
     super(props)
     this.state = {


### PR DESCRIPTION
This improves rendering performance, and is noticeable during rapid updates, like typing in the I/O table. There are two ways to do this: stateful components can extend `PureComponent`, and stateless functional ones can use the `pure` helper from recompose.