### PR TITLE
enable config overrides for testing

### DIFF
--- a/src/components/ConfigOverridesWarning.js
+++ b/src/components/ConfigOverridesWarning.js
@@ -1,0 +1,21 @@
+import { div, pre } from 'react-hyperscript-helpers'
+import { configOverridesStore } from 'src/libs/config'
+import * as Style from 'src/libs/style'
+import * as Utils from 'src/libs/utils'
+
+const ConfigOverridesWarning = Utils.connectAtom(configOverridesStore, 'configOverrides')(
+  ({ configOverrides }) => {
+    return !!configOverrides && div({
+      style: {
+        position: 'fixed', bottom: 0, right: 0,
+        color: 'white', backgroundColor: Style.colors.accent,
+        padding: '1rem'
+      }
+    }, [
+      'Warning! Config overrides are in effect:',
+      pre(JSON.stringify(configOverrides, null, 2))
+    ])
+  }
+)
+
+export default ConfigOverridesWarning

--- a/src/libs/config.js
+++ b/src/libs/config.js
@@ -1,4 +1,5 @@
 import _ from 'lodash/fp'
+import * as Utils from 'src/libs/utils'
 
 
 const loadConfig = _.memoize(async () => {
@@ -6,11 +7,28 @@ const loadConfig = _.memoize(async () => {
   return res.json()
 })
 
-export const getAgoraUrlRoot = async () => (await loadConfig()).agoraUrlRoot
-export const getDockstoreUrlRoot = async () => (await loadConfig()).dockstoreUrlRoot
-export const getFirecloudUrlRoot = async () => (await loadConfig()).firecloudUrlRoot
-export const getGoogleClientId = async () => (await loadConfig()).googleClientId
-export const getLeoUrlRoot = async () => (await loadConfig()).leoUrlRoot
-export const getOrchestrationUrlRoot = async () => (await loadConfig()).orchestrationUrlRoot
-export const getRawlsUrlRoot = async () => (await loadConfig()).rawlsUrlRoot
-export const getSamUrlRoot = async () => (await loadConfig()).samUrlRoot
+export const configOverridesStore = Utils.atom(
+  sessionStorage['config-overrides'] && JSON.parse(sessionStorage['config-overrides'])
+)
+configOverridesStore.subscribe(v => {
+  if (!v) {
+    sessionStorage.removeItem('config-overrides')
+  } else {
+    sessionStorage['config-overrides'] = JSON.stringify(v)
+  }
+})
+// Values in this store will override config settings. This can be used from the console for testing.
+window.configOverridesStore = configOverridesStore
+
+const getConfig = async () => {
+  return _.merge(await loadConfig(), configOverridesStore.get())
+}
+
+export const getAgoraUrlRoot = async () => (await getConfig()).agoraUrlRoot
+export const getDockstoreUrlRoot = async () => (await getConfig()).dockstoreUrlRoot
+export const getFirecloudUrlRoot = async () => (await getConfig()).firecloudUrlRoot
+export const getGoogleClientId = async () => (await getConfig()).googleClientId
+export const getLeoUrlRoot = async () => (await getConfig()).leoUrlRoot
+export const getOrchestrationUrlRoot = async () => (await getConfig()).orchestrationUrlRoot
+export const getRawlsUrlRoot = async () => (await getConfig()).rawlsUrlRoot
+export const getSamUrlRoot = async () => (await getConfig()).samUrlRoot

--- a/src/libs/state-history.js
+++ b/src/libs/state-history.js
@@ -7,7 +7,7 @@ const getKey = () => {
   if (state && state.key) {
     return state.key
   } else {
-    const key = uuid()
+    const key = `state-history-${uuid()}`
     window.history.replaceState({ key }, '')
     return key
   }
@@ -38,9 +38,9 @@ export const set = newState => {
         return
       } else {
         const oldestKV = _.flow(
-          _.mapValues(JSON.parse),
           _.toPairs,
-          _.sortBy(p => p[1].timestamp),
+          _.filter(([k]) => _.startsWith('state-history-', k)),
+          _.sortBy(([k, v]) => JSON.parse(v).timestamp),
           _.first
         )(sessionStorage)
         sessionStorage.removeItem(oldestKV[0])

--- a/src/pages/Main.js
+++ b/src/pages/Main.js
@@ -1,10 +1,11 @@
 import { Fragment } from 'react'
 import { hot } from 'react-hot-loader'
 import { h } from 'react-hyperscript-helpers'
+import ConfigOverridesWarning from 'src/components/ConfigOverridesWarning'
 import ErrorBanner from 'src/components/ErrorBanner'
 import Router from 'src/components/Router'
 
 
-const Main = () => h(Fragment, [h(Router), h(ErrorBanner)])
+const Main = () => h(Fragment, [h(Router), h(ErrorBanner), h(ConfigOverridesWarning)])
 
 export default hot(module)(Main)


### PR DESCRIPTION
This is a lightweight mechanism for injecting config overrides from the console. Simply `set` a value in the `configOverridesStore` atom to activate. It's persisted to `sessionStorage` so should survive across refreshes.

Also namespaces the 'state history' storage keys so they can live alongside other session data.