### PR TITLE
use cached download prices

### DIFF
--- a/config/dev.json
+++ b/config/dev.json
@@ -2,7 +2,6 @@
   "agoraUrlRoot": "https://agora.dsde-dev.broadinstitute.org",
   "dockstoreUrlRoot": "https://staging.dockstore.org:8443",
   "googleClientId": "500025638838-s2v23ar3spugtd5t2v1vgfa2sp7ppg0d.apps.googleusercontent.com",
-  "googleCloudBillingKey": "AIzaSyDdGqv2Jcsv9CUd9Km0XhdavdPtrOAlZWU",
   "leoUrlRoot": "https://leonardo.dsde-dev.broadinstitute.org",
   "marthaUrlRoot": "https://us-central1-broad-dsde-prod.cloudfunctions.net/martha_v1",
   "orchestrationUrlRoot": "https://firecloud-orchestration.dsde-dev.broadinstitute.org",

--- a/config/prod.json
+++ b/config/prod.json
@@ -2,7 +2,6 @@
   "agoraUrlRoot": "https://agora.dsde-prod.broadinstitute.org",
   "dockstoreUrlRoot": "https://dockstore.org:8443",
   "googleClientId": "424501080111-b3bt4p1vo4gbo4m0573nvi4d49784bp8.apps.googleusercontent.com",
-  "googleCloudBillingKey": "AIzaSyBd0AHa95uDMxgHw7vGDBE7eLdRbaY1Nmc",
   "leoUrlRoot": "https://notebooks.firecloud.org",
   "marthaUrlRoot": "https://us-central1-broad-dsde-prod.cloudfunctions.net/martha_v1",
   "orchestrationUrlRoot": "https://api.firecloud.org",

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -99,7 +99,9 @@ export const Buckets = {
   },
 
   getDownloadCostsToNA: _.memoize(async () => {
-    return fetchOk('https://storage.googleapis.com/bvdp-saturn-prod-cloud-pricing/na-download-prices.json')
+    return fetchOk('https://storage.googleapis.com/bvdp-saturn-prod-cloud-pricing/na-download-prices.json').then(
+      res => res.json()
+    )
   }),
 
   listNotebooks: async (namespace, name) => {

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -99,10 +99,7 @@ export const Buckets = {
   },
 
   getDownloadCostsToNA: _.memoize(async () => {
-    return fetchOk(
-      `https://cloudbilling.googleapis.com/v1/services/95FF-2EF5-5EA1/skus?fields=skus(pricingInfo,skuId)&key=${await Config.getGoogleCloudBillingKey()}`)
-      .then(res => res.json())
-      .then(parsed => _.find({ skuId: '22EB-AAE8-FBCD' }, parsed.skus).pricingInfo[0]) // sku described as "Download Worldwide Destinations (excluding Asia & Australia)"
+    return fetchOk('https://storage.googleapis.com/bvdp-saturn-prod-cloud-pricing/na-download-prices.json')
   }),
 
   listNotebooks: async (namespace, name) => {

--- a/src/libs/config.js
+++ b/src/libs/config.js
@@ -27,7 +27,6 @@ const getConfig = async () => {
 export const getAgoraUrlRoot = async () => (await getConfig()).agoraUrlRoot
 export const getDockstoreUrlRoot = async () => (await getConfig()).dockstoreUrlRoot
 export const getGoogleClientId = async () => (await getConfig()).googleClientId
-export const getGoogleCloudBillingKey = async () => (await getConfig()).googleCloudBillingKey
 export const getLeoUrlRoot = async () => (await getConfig()).leoUrlRoot
 export const getMarthaUrlRoot = async () => (await getConfig()).marthaUrlRoot
 export const getOrchestrationUrlRoot = async () => (await getConfig()).orchestrationUrlRoot


### PR DESCRIPTION
This replaces the (very limited) API key we were using with a cached version of the data that we'll be updating nightly.

This is being done because we want to avoid the _appearance_ of having exposed a secret. While putting the key in the repo was intentional, because we estimated that the possibility and impact of any potential misuse was exceedingly small, it was observed that this could appear sloppy, and we want to avoid that.