### PR TITLE
delay processing error responses

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -52,9 +52,9 @@ const instrumentedFetch = (...args) => {
   return fetch(...args)
 }
 
-const fetchOk = (...args) => {
-  return instrumentedFetch(...args)
-    .then(res => res.ok ? res : res.text().then(text => Promise.reject(text)))
+const fetchOk = async (...args) => {
+  const res = await instrumentedFetch(...args)
+  return res.ok ? res : Promise.reject(res)
 }
 
 

--- a/src/libs/error.js
+++ b/src/libs/error.js
@@ -5,7 +5,8 @@ import * as Utils from 'src/libs/utils'
 
 export const errorStore = Utils.atom([])
 
-export const reportError = (title, error) => {
+export const reportError = async (title, obj) => {
+  const error = await (obj instanceof Response ? obj.text() : obj)
   errorStore.update(old => _.concat(old, { title, error }))
 }
 


### PR DESCRIPTION
This is a small tweak to enable easier custom error handling. It postpones transforming an error response into text, so that individual consumers can check status codes before passing to `reportError`.