### PR TITLE
handle 401 errors more gracefully

### DIFF
--- a/src/libs/error.js
+++ b/src/libs/error.js
@@ -1,13 +1,19 @@
 import _ from 'lodash/fp'
+import { signOut } from 'src/libs/auth'
 import * as StateHistory from 'src/libs/state-history'
 import * as Utils from 'src/libs/utils'
 
 
 export const errorStore = Utils.atom([])
 
+const addError = item => errorStore.update(state => _.concat(state, [item]))
+
 export const reportError = async (title, obj) => {
-  const error = await (obj instanceof Response ? obj.text() : obj)
-  errorStore.update(old => _.concat(old, { title, error }))
+  if (obj instanceof Response && obj.status === 401) {
+    addError({ title: 'Session timed out', error: 'You have been signed out due to inactivity' })
+    return signOut()
+  }
+  addError({ title, error: await (obj instanceof Response ? obj.text() : obj) })
 }
 
 export const clearError = (hard = false) => {


### PR DESCRIPTION
If we get a 401, fully sign out and notify the user that they timed out. This may not be the final or optimal solution, but it fixes the existing problem and gives us a foundation for further tweaks.

Fixes #316 