### PR TITLE
clean up z-index hacks

### DIFF
--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -48,11 +48,6 @@ export class TopBar extends Component {
         [
           div({
             style: {
-              zIndex: 1,
-              /*
-               * MP: Rotating the 'angle' icon for breadcrumbs creates a new stacking context,
-               * causing it to appear above the overlay.
-               */
               display: 'table', width: 275, color: 'white', position: 'absolute', cursor: 'default',
               backgroundColor: Style.colors.primary, height: '100%',
               boxShadow: '3px 0 13px 0 rgba(0,0,0,0.3)'

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -147,7 +147,6 @@ export const spinnerOverlay = div(
       position: 'absolute',
       display: 'flex', alignItems: 'center',
       top: 0, right: 0, bottom: 0, left: 0,
-      zIndex: 1, // Needed to make overlay appear over tables
       backgroundColor: 'rgba(0, 0, 0, 0.1)'
     }
   }, [

--- a/src/pages/workspaces/workspace/JobHistory.js
+++ b/src/pages/workspaces/workspace/JobHistory.js
@@ -149,7 +149,6 @@ class JobHistory extends Component {
     const { submissions, loading, newSubmissionId, highlightNewSubmission } = this.state
 
     return div({ style: styles.submissionsTable }, [
-      loading && spinnerOverlay,
       submissions && h(AutoSizer, [
         ({ width, height }) => h(FlexTable, {
           width, height, rowCount: submissions.length,
@@ -208,7 +207,8 @@ class JobHistory extends Component {
             }
           ]
         })
-      ])
+      ]),
+      loading && spinnerOverlay
     ])
   }
 


### PR DESCRIPTION
After some investigation, these z-index declarations are no longer necessary, and we can leverage source order for all current use cases. We might revisit this later, as we add more stacking.

Fixes #295 