### PR TITLE
create general Clickable component

### DIFF
--- a/src/_tests/pages/workspaces/__snapshots__/List.test.js.snap
+++ b/src/_tests/pages/workspaces/__snapshots__/List.test.js.snap
@@ -154,6 +154,7 @@ Array [
         }
     >
         <div
+            disabled={undefined}
             onBlur={[Function]}
             onClick={[Function]}
             onDragEnd={[Function]}
@@ -188,6 +189,7 @@ Array [
             />
         </div>
         <div
+            disabled={undefined}
             onBlur={[Function]}
             onClick={[Function]}
             onDragEnd={[Function]}
@@ -234,6 +236,7 @@ Array [
     }
 >
     <div
+        disabled={undefined}
         onBlur={[Function]}
         onClick={[Function]}
         onDragEnd={[Function]}

--- a/src/components/ClusterManager.js
+++ b/src/components/ClusterManager.js
@@ -1,8 +1,7 @@
 import _ from 'lodash/fp'
 import { PureComponent, Fragment } from 'react'
 import { div, h, span } from 'react-hyperscript-helpers'
-import Interactive from 'react-interactive'
-import { buttonPrimary, buttonSecondary, LabeledCheckbox, Select } from 'src/components/common'
+import { buttonPrimary, buttonSecondary, Clickable, LabeledCheckbox, Select } from 'src/components/common'
 import DropdownBox from 'src/components/DropdownBox'
 import { icon } from 'src/components/icons'
 import { IntegerInput, textInput } from 'src/components/input'
@@ -196,10 +195,9 @@ const MachineSelector = ({ machineType, onChangeMachineType, diskSize, onChangeD
 }
 
 const ClusterIcon = ({ shape, onClick, disabled }) => {
-  return h(Interactive, {
+  return h(Clickable, {
     style: { color: onClick && !disabled && Style.colors.secondary },
-    as: 'div',
-    onClick: disabled ? undefined : onClick
+    onClick
   }, [icon(shape, { size: 20, class: 'is-solid' })])
 }
 
@@ -536,8 +534,7 @@ export default class ClusterManager extends PureComponent {
     ))
     return div({ style: styles.container }, [
       renderIcon(),
-      h(Interactive, {
-        as: 'div',
+      h(Clickable, {
         onClick: () => this.toggleDropdown(!open),
         style: { marginLeft: '0.5rem', paddingRight: '0.25rem' },
         className: 'cluster-manager-opener'

--- a/src/components/DropdownBox.js
+++ b/src/components/DropdownBox.js
@@ -1,6 +1,6 @@
-import Interactive from 'react-interactive'
 import { h, div } from 'react-hyperscript-helpers'
 import onClickOutside from 'react-onclickoutside'
+import { Clickable } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import * as Style from 'src/libs/style'
 
@@ -45,8 +45,7 @@ const DropdownBody = onClickOutside(({ width, children }) => {
 
 const DropdownBox = ({ open, onToggle, children, outsideClickIgnoreClass = 'dropdown-box-opener', width = 500 }) => {
   return div({ style: { position: 'relative' } }, [
-    h(Interactive, {
-      as: 'div',
+    h(Clickable, {
       className: outsideClickIgnoreClass,
       style: styles.button(open),
       onClick: () => onToggle(!open)

--- a/src/components/ErrorBanner.js
+++ b/src/components/ErrorBanner.js
@@ -1,6 +1,5 @@
 import { div, h } from 'react-hyperscript-helpers'
-import Interactive from 'react-interactive'
-import { buttonPrimary } from 'src/components/common'
+import { buttonPrimary, Clickable } from 'src/components/common'
 import ErrorView from 'src/components/ErrorView'
 import { icon } from 'src/components/icons'
 import Modal from 'src/components/Modal'
@@ -28,12 +27,11 @@ class ErrorBanner extends Component {
       }
     },
     [
-      h(Interactive, {
-        as: icon('angle left'),
+      h(Clickable, {
         disabled: onFirst,
-        style: onFirst ? { color: Style.colors.disabled } : {},
+        style: { display: 'flex', color: onFirst ? Style.colors.disabled : null },
         onClick: () => this.setState({ errorNumber: errorNumber - 1 })
-      }),
+      }, [icon('angle left')]),
       div({
         style: {
           fontWeight: 500,
@@ -41,15 +39,13 @@ class ErrorBanner extends Component {
           padding: '0.5rem 1rem', margin: '-0.25rem 0'
         }
       }, [errorNumber + 1, '/', errorState.length]),
-      h(Interactive, {
-        as: icon('angle right'),
+      h(Clickable, {
         disabled: onLast,
-        style: { marginRight: '1rem', color: onLast ? Style.colors.disabled : null },
+        style: { marginRight: '1rem', display: 'flex', color: onLast ? Style.colors.disabled : null },
         onClick: () => this.setState({ errorNumber: errorNumber + 1 })
-      }),
+      }, [icon('angle right')]),
       title,
-      h(Interactive, {
-        as: 'span',
+      h(Clickable, {
         style: { textDecoration: 'underline', marginLeft: '1rem' },
         onClick: () => this.setState({ modal: true })
       }, ['Details...']),

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -1,8 +1,7 @@
 import _ from 'lodash/fp'
 import * as ReactDOM from 'react-dom'
 import { div, h } from 'react-hyperscript-helpers'
-import Interactive from 'react-interactive'
-import { buttonPrimary, buttonSecondary } from 'src/components/common'
+import { buttonPrimary, buttonSecondary, Clickable } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
@@ -63,11 +62,10 @@ export default class Modal extends Component {
           div({ style: { fontSize: 18, fontWeight: 500, color: Style.colors.title } }, [title]),
           ...titleExtras,
           showX && div({ style: { flex: 1 } }),
-          showX && h(Interactive, {
-            as: icon('times-circle'),
+          showX && h(Clickable, {
             style: { alignSelf: 'flex-start' },
             onClick: onDismiss
-          })
+          }, [icon('times-circle')])
         ]),
         children,
         div({

--- a/src/components/PopupTrigger.js
+++ b/src/components/PopupTrigger.js
@@ -37,7 +37,7 @@ export default class PopupTrigger extends Component {
     return h(Fragment, [
       cloneElement(child, {
         id: this.id,
-        className: this.id,
+        className: `${child.props.className || ''} ${this.id}`,
         onClick: (...args) => {
           child.props.onClick && child.props.onClick(...args)
           this.setState({ open: !open })

--- a/src/components/TabBar.js
+++ b/src/components/TabBar.js
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp'
 import { h, div } from 'react-hyperscript-helpers'
-import Interactive from 'react-interactive'
+import { Clickable } from 'src/components/common'
 import * as Style from 'src/libs/style'
 
 const TabBar = ({ tabs, activeTab, onChangeTab, style }) => {
@@ -12,9 +12,8 @@ const TabBar = ({ tabs, activeTab, onChangeTab, style }) => {
     }
   }, [
     ..._.map(([i, { title, key }]) => {
-      return h(Interactive, {
+      return h(Clickable, {
         key,
-        as: 'div',
         style: {
           height: '2.25rem', display: 'flex', alignItems: 'center',
           fontSize: 16, fontWeight: 500, color: Style.colors.secondary,

--- a/src/components/TopBanner.js
+++ b/src/components/TopBanner.js
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp'
 import { div, h } from 'react-hyperscript-helpers'
-import Interactive from 'react-interactive'
+import { Clickable } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
@@ -39,14 +39,14 @@ export default class TopBanner extends Component {
     props), [
       div({ style: { flex: 1, display: 'flex', alignItems: 'center' } },
         children),
-      showX && h(Interactive, {
-        as: icon('times-circle', { size: 20, style: { marginLeft: '1rem' } }),
+      showX && h(Clickable, {
+        style: { marginLeft: '1rem' },
         title: 'Hide banner',
         onClick: () => {
           this.setState({ show: false })
           onDismiss && onDismiss()
         }
-      })
+      }, [icon('times-circle', { size: 20 })])
     ])
   }
 }

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -16,6 +16,13 @@ const styles = {
   }
 }
 
+export const Clickable = ({ as = 'div', disabled, onClick, children, ...props }) => {
+  return h(Interactive, _.merge({
+    as, disabled,
+    onClick: (...args) => onClick && !disabled && onClick(...args)
+  }, props), [children])
+}
+
 export const link = function(props, children) {
   return h(Interactive,
     _.merge({
@@ -29,11 +36,9 @@ export const link = function(props, children) {
     children)
 }
 
-export const buttonPrimary = ({ onClick, disabled, ...props }, children) => {
-  return h(Interactive, _.merge({
-    as: 'div',
+export const buttonPrimary = ({ disabled, ...props }, children) => {
+  return h(Clickable, _.merge({
     disabled,
-    onClick: (...args) => onClick && !disabled && onClick(...args),
     style: {
       ...styles.button,
       borderRadius: 5, color: 'white', padding: '0 1.5rem',
@@ -44,11 +49,9 @@ export const buttonPrimary = ({ onClick, disabled, ...props }, children) => {
   }, props), children)
 }
 
-export const buttonSecondary = ({ onClick, disabled, ...props }, children) => {
-  return h(Interactive, _.merge({
-    as: 'div',
+export const buttonSecondary = ({ disabled, ...props }, children) => {
+  return h(Clickable, _.merge({
     disabled,
-    onClick: (...args) => onClick && !disabled && onClick(...args),
     style: {
       ...styles.button,
       color: disabled ? Style.colors.disabled : Style.colors.text,
@@ -84,10 +87,9 @@ export const contextBar = function(props, children) {
   children)
 }
 
-export const MenuButton = ({ onClick, disabled, children, ...props }) => {
-  return h(Interactive, _.merge({
-    as: 'div', disabled,
-    onClick: (...args) => !disabled && onClick && onClick(...args),
+export const MenuButton = ({ disabled, children, ...props }) => {
+  return h(Clickable, _.merge({
+    disabled,
     style: {
       fontSize: 12,
       minWidth: 125,

--- a/src/libs/data-utils.js
+++ b/src/libs/data-utils.js
@@ -3,9 +3,8 @@ import filesize from 'filesize'
 import _ from 'lodash/fp'
 import { Fragment } from 'react'
 import { div, h, input } from 'react-hyperscript-helpers/lib/index'
-import Interactive from 'react-interactive'
 import Collapse from 'src/components/Collapse'
-import { buttonPrimary, link } from 'src/components/common'
+import { buttonPrimary, Clickable, link } from 'src/components/common'
 import { icon, spinner } from 'src/components/icons'
 import Modal from 'src/components/Modal'
 import { TextCell } from 'src/components/table'
@@ -117,8 +116,7 @@ export class UriViewer extends Component {
                   style: { flexGrow: 1, fontWeight: 300, fontFamily: 'Menlo, monospace' }
                 }),
                 h(TooltipTrigger, { content: 'Copy to clipboard' }, [
-                  h(Interactive, {
-                    as: icon(copied ? 'check' : 'copy-to-clipboard'),
+                  h(Clickable, {
                     style: { margin: '0 1rem', color: copied ? Style.colors.success : Style.colors.secondary },
                     onClick: async () => {
                       try {
@@ -129,7 +127,7 @@ export class UriViewer extends Component {
                         reportError('Error copying to clipboard', error)
                       }
                     }
-                  })
+                  }, [icon(copied ? 'check' : 'copy-to-clipboard')])
                 ])
               ])
             ])

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -1,9 +1,8 @@
 import _ from 'lodash/fp'
 import { Fragment } from 'react'
 import { a, div, h, span } from 'react-hyperscript-helpers'
-import Interactive from 'react-interactive'
 import { pure } from 'recompose'
-import { search, spinnerOverlay } from 'src/components/common'
+import { Clickable, search, spinnerOverlay } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import NewWorkspaceModal from 'src/components/NewWorkspaceModal'
 import { TopBar } from 'src/components/TopBar'
@@ -116,8 +115,7 @@ const WorkspaceCard = pure(({ listView, workspace: { workspace: { namespace, nam
 })
 
 const NewWorkspaceCard = pure(({ listView, onClick }) => {
-  return listView ? h(Interactive, {
-    as: 'div',
+  return listView ? h(Clickable, {
     style: { ...styles.longCard, ...styles.longCreateCard },
     onClick
   }, [
@@ -125,8 +123,7 @@ const NewWorkspaceCard = pure(({ listView, onClick }) => {
       'Create a New Workspace',
       icon('plus-circle', { style: { marginLeft: '1rem' }, size: 24 })
     ])
-  ]) : h(Interactive, {
-    as: 'div',
+  ]) : h(Clickable, {
     style: { ...styles.shortCard, ...styles.shortCreateCard },
     onClick
   }, [
@@ -190,13 +187,11 @@ export class WorkspaceList extends Component {
           'Workspaces'
         ]),
         div({ style: styles.toolbarButtons }, [
-          h(Interactive, {
-            as: 'div',
+          h(Clickable, {
             style: styles.toolbarButton(!listView),
             onClick: () => this.setState({ listView: false })
           }, [icon('view-cards', { size: 24 })]),
-          h(Interactive, {
-            as: 'div',
+          h(Clickable, {
             style: styles.toolbarButton(listView),
             onClick: () => this.setState({ listView: true })
           }, [icon('view-list', { size: 24 })])

--- a/src/pages/workspaces/workspace/JobHistory.js
+++ b/src/pages/workspaces/workspace/JobHistory.js
@@ -1,10 +1,9 @@
 import _ from 'lodash/fp'
 import { Fragment } from 'react'
 import { div, h, span, table, tbody, td, tr } from 'react-hyperscript-helpers'
-import Interactive from 'react-interactive'
 import { AutoSizer } from 'react-virtualized'
 import * as breadcrumbs from 'src/components/breadcrumbs'
-import { spinnerOverlay } from 'src/components/common'
+import { Clickable, spinnerOverlay } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import PopupTrigger from 'src/components/PopupTrigger'
 import { FlexTable, HeaderCell, TextCell } from 'src/components/table'
@@ -82,11 +81,10 @@ const statusCell = workflowStatuses => {
         ])
       ])
     }, [
-      h(Interactive, {
-        as: 'span'
-      }, [
-        icon('caretDown', { class: 'hover-only', size: 18, style: { color: Style.colors.primary } })
-      ])
+      h(Clickable, {
+        className: 'hover-only',
+        style: { color: Style.colors.primary }
+      }, [icon('caretDown', { size: 18 })])
     ])
   ])
 }

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -2,9 +2,8 @@ import _ from 'lodash/fp'
 import { createRef, Fragment } from 'react'
 import Dropzone from 'react-dropzone'
 import { a, div, h } from 'react-hyperscript-helpers'
-import Interactive from 'react-interactive'
 import * as breadcrumbs from 'src/components/breadcrumbs'
-import { link, MenuButton, spinnerOverlay } from 'src/components/common'
+import { Clickable, link, MenuButton, spinnerOverlay } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import { NotebookCreator, NotebookDeleter, NotebookDuplicator } from 'src/components/notebook-utils'
 import PopupTrigger from 'src/components/PopupTrigger'
@@ -50,8 +49,7 @@ class NotebookCard extends Component {
         }, ['Delete'])
       ])
     }, [
-      h(Interactive, {
-        as: 'div',
+      h(Clickable, {
         onClick: e => e.preventDefault(),
         style: { marginLeft: '1rem', cursor: 'pointer' }, focus: 'hover'
       }, [icon('ellipsis-vertical', { size: 18 })])

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -1,9 +1,8 @@
 import _ from 'lodash/fp'
 import { Component, createRef, Fragment, PureComponent } from 'react'
 import { a, div, h } from 'react-hyperscript-helpers'
-import Interactive from 'react-interactive'
 import ClusterManager from 'src/components/ClusterManager'
-import { buttonPrimary, comingSoon, contextBar, link, MenuButton, spinnerOverlay } from 'src/components/common'
+import { buttonPrimary, Clickable, comingSoon, contextBar, link, MenuButton, spinnerOverlay } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import Modal from 'src/components/Modal'
 import NewWorkspaceModal from 'src/components/NewWorkspaceModal'
@@ -70,8 +69,8 @@ class WorkspaceTabs extends PureComponent {
       navTab({ tabName: 'tools', href: Nav.getLink('workspace-tools', { namespace, name }) }),
       navTab({ tabName: 'job history', href: Nav.getLink('workspace-job-history',  { namespace, name }) }),
       div({ style: { flexGrow: 1 } }),
-      h(Interactive, {
-        as: 'div', ...navIconProps,
+      h(Clickable, {
+        ...navIconProps,
         onClick: onClone
       }, [icon('copy', { size: 22 })]),
       h(PopupTrigger, {
@@ -94,7 +93,7 @@ class WorkspaceTabs extends PureComponent {
         ]),
         position: 'bottom'
       }, [
-        h(Interactive, { as: 'div', ...navIconProps }, [icon('ellipsis-vertical', { size: 22 })])
+        h(Clickable, { ...navIconProps }, [icon('ellipsis-vertical', { size: 22 })])
       ])
     ])
   }


### PR DESCRIPTION
This creates a general 'pseudo-button' component. The intention is that this will replace direct use of `Interactive` for almost all common cases.
* Defaults to `div`
* Handles `disabled` and `onClick` correctly, the way buttons do.

Fixes #334 