### PR TITLE
only refresh if not changing pages

### DIFF
--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -56,6 +56,7 @@ class WorkspaceTabs extends PureComponent {
       return h(Fragment, [
         a({
           style: { ...styles.tab, ...(selected ? styles.activeTab : {}) },
+          // some pages highlight a tab even when they're not on that url
           onClick: href === window.location.hash ? refresh : undefined,
           href
         }, tabName),

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -56,7 +56,7 @@ class WorkspaceTabs extends PureComponent {
       return h(Fragment, [
         a({
           style: { ...styles.tab, ...(selected ? styles.activeTab : {}) },
-          onClick: selected ? refresh : undefined,
+          onClick: href === window.location.hash ? refresh : undefined,
           href
         }, tabName),
         navSeparator


### PR DESCRIPTION
This fixes an issue where clicking on the tools tab from the workflow view would sometimes crash. This is because the toolbar tried to call refresh during the page transition. This change checks the actual URL and only tries to refresh if we're not changing pages.