### PR TITLE
allow searching in larger dropdowns

### DIFF
--- a/src/components/NewWorkspaceModal.js
+++ b/src/components/NewWorkspaceModal.js
@@ -135,7 +135,6 @@ export default class NewWorkspaceModal extends Component {
           'Or, email ', link({ href: `mailto:${billingMail}` }, [billingMail]), ' with questions.'
         ])
       ]) : h(Select, {
-        searchable: false,
         clearable: false,
         placeholder: 'Select a billing project',
         value: namespace,
@@ -164,7 +163,6 @@ export default class NewWorkspaceModal extends Component {
         'You may add groups to the authorization domain, but you may not remove existing ones.'
       ]),
       h(Select, {
-        searchable: false,
         clearable: false,
         multi: true,
         placeholder: 'Select groups',

--- a/src/pages/ImportTool.js
+++ b/src/pages/ImportTool.js
@@ -24,7 +24,6 @@ export class DestinationWorkspace extends Component {
       [
         h(Select, {
           clearable: false,
-          searchable: true,
           disabled: !workspaces,
           placeholder: workspaces ? 'Select a workspace' : 'Loading workspaces...',
           value: selectedWorkspace,


### PR DESCRIPTION
Fixes #383 
This is a decision that we will need to make on a case-by-case basis, but Brad has endorsed the general approach.
Note that `searchable: true` is the default