### PR TITLE
add react-modal for better focus management

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3478,6 +3478,11 @@
         "strip-eof": "^1.0.0"
       }
     },
+    "exenv": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+      "integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50="
+    },
     "expand-brackets": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
@@ -9509,6 +9514,17 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-modal": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.5.1.tgz",
+      "integrity": "sha512-GxL7ycOgKC+p641cR+V1bw5dC1faL2N86/AJlzbMVmvt1totoylgkJmn9zvLuHeuarGbB7CLfHMGpeRowaj2jQ==",
+      "requires": {
+        "exenv": "^1.2.0",
+        "prop-types": "^15.5.10",
+        "react-lifecycles-compat": "^3.0.0",
+        "warning": "^3.0.0"
+      }
     },
     "react-onclickoutside": {
       "version": "6.7.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-hot-loader": "^4.3.3",
     "react-hyperscript-helpers": "^1.2.0",
     "react-interactive": "^0.8.1",
+    "react-modal": "^3.5.1",
     "react-onclickoutside": "^6.7.1",
     "react-paginating": "^1.0.1",
     "react-portal-tooltip": "^2.4.0",

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -1,14 +1,30 @@
 import _ from 'lodash/fp'
-import * as ReactDOM from 'react-dom'
 import { div, h } from 'react-hyperscript-helpers'
+import RModal from 'react-modal'
 import { buttonPrimary, buttonSecondary, Clickable } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 import { Component } from 'src/libs/wrapped-components'
 
+RModal.defaultStyles = { overlay: {}, content: {} }
 
-const modalRoot = document.getElementById('modal-root')
+const styles = {
+  overlay: {
+    backgroundColor: 'rgba(0, 0, 0, 0.5)', padding: '2rem 1rem',
+    display: 'flex', justifyContent: 'center', alignItems: 'flex-start',
+    position: 'fixed', left: 0, right: 0, top: 0, bottom: 0, overflowY: 'auto'
+  },
+  modal: {
+    borderRadius: 5, position: 'relative',
+    padding: '1.5rem 1.25rem', outline: 'none',
+    backgroundColor: 'white', boxShadow: Style.modalShadow
+  },
+  buttonRow: {
+    marginTop: '1rem',
+    display: 'flex', justifyContent: 'flex-end', alignItems: 'baseline'
+  }
+}
 
 /**
  * @param onDismiss
@@ -18,84 +34,39 @@ const modalRoot = document.getElementById('modal-root')
  * @param okButton
  */
 export default class Modal extends Component {
-  constructor(props) {
-    super(props)
-    this.el = document.createElement('div')
-  }
-
-  listenForEscape = e => {
-    if (e.key === 'Escape') {
-      this.props.onDismiss()
-    }
-  }
-
-  componentDidMount() {
-    const root = document.getElementById('root')
-    root.classList.add('overlayOpen')
-    if (root.scrollHeight > window.innerHeight) {
-      root.classList.add('overHeight')
-    }
-
-    window.addEventListener('keydown', this.listenForEscape)
-    modalRoot.appendChild(this.el)
-  }
-
   render() {
-    const { onDismiss, title, titleExtras = [], children, width = 450, showCancel = true, showX = false, okButton } = this.props
+    const { onDismiss, title, titleExtras, children, width = 450, showCancel = true, showX = false, okButton } = this.props
 
-    const component = div({
-      style: {
-        backgroundColor: 'rgba(0, 0, 0, 0.5)', padding: '2rem 1rem',
-        display: 'flex', justifyContent: 'center', alignItems: 'flex-start',
-        position: 'fixed', left: 0, right: 0, top: 0, bottom: 0, overflowY: 'auto'
-      }
+    return h(RModal, {
+      parentSelector: () => document.getElementById('modal-root'),
+      isOpen: true,
+      onRequestClose: onDismiss,
+      style: { overlay: styles.overlay, content: { ...styles.modal, width } },
+      ariaHideApp: false
     }, [
-      div({
-        style: {
-          width, borderRadius: 5, position: 'relative',
-          padding: '1.5rem 1.25rem',
-          backgroundColor: 'white', boxShadow: Style.modalShadow
-        }
-      },
-      [
-        title && div({ style: { display: 'flex', alignItems: 'baseline', marginBottom: '1rem' } }, [
-          div({ style: { fontSize: 18, fontWeight: 500, color: Style.colors.title } }, [title]),
-          ...titleExtras,
-          showX && div({ style: { flex: 1 } }),
-          showX && h(Clickable, {
-            style: { alignSelf: 'flex-start' },
+      title && div({ style: { display: 'flex', alignItems: 'baseline', marginBottom: '1rem' } }, [
+        div({ style: { fontSize: 18, fontWeight: 500, color: Style.colors.title } }, [title]),
+        titleExtras,
+        showX && h(Clickable, {
+          style: { alignSelf: 'flex-start', marginLeft: 'auto' },
+          onClick: onDismiss
+        }, [icon('times-circle')])
+      ]),
+      children,
+      div({ style: styles.buttonRow }, [
+        showCancel ?
+          buttonSecondary({
+            style: { marginRight: '1rem' },
             onClick: onDismiss
-          }, [icon('times-circle')])
-        ]),
-        children,
-        div({
-          style: {
-            flexShrink: 0, marginTop: '1rem',
-            display: 'flex', justifyContent: 'flex-end', alignItems: 'baseline'
-          }
-        }, [
-          showCancel ?
-            buttonSecondary({
-              style: { marginRight: '1rem' },
-              onClick: onDismiss
-            }, 'Cancel') :
-            null,
-          Utils.cond(
-            [okButton === undefined, () => buttonPrimary({ onClick: onDismiss }, 'OK')],
-            [_.isString(okButton), () => buttonPrimary({ onClick: onDismiss }, okButton)],
-            [_.isFunction(okButton), () => buttonPrimary({ onClick: okButton }, 'OK')],
-            () => okButton
-          )
-        ])
+          }, 'Cancel') :
+          null,
+        Utils.cond(
+          [okButton === undefined, () => buttonPrimary({ onClick: onDismiss }, 'OK')],
+          [_.isString(okButton), () => buttonPrimary({ onClick: onDismiss }, okButton)],
+          [_.isFunction(okButton), () => buttonPrimary({ onClick: okButton }, 'OK')],
+          () => okButton
+        )
       ])
     ])
-
-    return ReactDOM.createPortal(component, this.el)
-  }
-
-  componentWillUnmount() {
-    document.getElementById('root').classList.remove('overlayOpen', 'overHeight')
-    window.removeEventListener('keydown', this.listenForEscape)
-    modalRoot.removeChild(this.el)
   }
 }

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -40,6 +40,7 @@ export default class Modal extends Component {
     return h(RModal, {
       parentSelector: () => document.getElementById('modal-root'),
       isOpen: true,
+      shouldCloseOnOverlayClick: false,
       onRequestClose: onDismiss,
       style: { overlay: styles.overlay, content: { ...styles.modal, width } },
       ariaHideApp: false

--- a/src/components/NewWorkspaceModal.js
+++ b/src/components/NewWorkspaceModal.js
@@ -115,6 +115,7 @@ export default class NewWorkspaceModal extends Component {
       div({ style: styles.label }, ['Workspace name *']),
       validatedInput({
         inputProps: {
+          autoFocus: true,
           placeholder: 'Enter a name',
           value: name,
           onChange: e => this.setState({ name: e.target.value, nameModified: true })

--- a/src/libs/data-utils.js
+++ b/src/libs/data-utils.js
@@ -233,6 +233,7 @@ export class ReferenceDataImporter extends Component {
       }, 'OK')
     }, [
       h(Select, {
+        autoFocus: true,
         searchable: false,
         clearable: false,
         placeholder: 'Select data',

--- a/src/pages/StyleGuide.js
+++ b/src/pages/StyleGuide.js
@@ -4,6 +4,7 @@ import { AutoSizer } from 'react-virtualized'
 import { buttonPrimary, buttonSecondary, Checkbox, link, search } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import { textInput, validatedInput } from 'src/components/input'
+import Modal from 'src/components/Modal'
 import PopupTrigger from 'src/components/PopupTrigger'
 import { FlexTable, GridTable, HeaderCell, TextCell } from 'src/components/table'
 import * as Nav from 'src/libs/nav'
@@ -145,6 +146,17 @@ class StyleGuide extends Component {
         buttonPrimary({
           tooltip: 'Hello there'
         }, 'Tooltip trigger')
+      ]),
+      div({ style: styles.container }, [
+        buttonPrimary({
+          onClick: () => this.setState({ modalOpen: true })
+        }, 'Open modal'),
+        this.state.modalOpen && h(Modal, {
+          title: 'Hello there',
+          onDismiss: () => this.setState({ modalOpen: false })
+        }, [
+          'This is a modal'
+        ])
       ])
     ])
   }

--- a/src/pages/groups/Group.js
+++ b/src/pages/groups/Group.js
@@ -59,6 +59,7 @@ class NewUserModal extends Component {
     }, [
       div({ style: styles.formLabel }, ['User email']),
       textInput({
+        autoFocus: true,
         value: userEmail,
         onChange: e => this.setState({ userEmail: e.target.value, emailTouched: true })
       }),

--- a/src/pages/groups/List.js
+++ b/src/pages/groups/List.js
@@ -52,6 +52,7 @@ class NewGroupModal extends Component {
       div({ style: styles.formLabel }, ['Enter a unique name']),
       validatedInput({
         inputProps: {
+          autoFocus: true,
           value: groupName,
           onChange: e => this.setState({ groupName: e.target.value, groupNameTouched: true })
         },

--- a/src/pages/workspaces/workspace/tools/LaunchAnalysisModal.js
+++ b/src/pages/workspaces/workspace/tools/LaunchAnalysisModal.js
@@ -31,22 +31,20 @@ export default class LaunchAnalysisModal extends Component {
     } : {
       onDismiss,
       title: 'Launch Analysis',
-      titleExtras: [
-        search({
-          wrapperProps: {
-            style: {
-              display: 'inline-flex',
-              width: 500,
-              marginLeft: '4rem'
-            }
-          },
-          inputProps: {
-            placeholder: 'FILTER',
-            value: filterText,
-            onChange: e => this.setState({ filterText: e.target.value })
+      titleExtras: search({
+        wrapperProps: {
+          style: {
+            display: 'inline-flex',
+            width: 500,
+            marginLeft: '4rem'
           }
-        })
-      ],
+        },
+        inputProps: {
+          placeholder: 'FILTER',
+          value: filterText,
+          onChange: e => this.setState({ filterText: e.target.value })
+        }
+      }),
       showX: true,
       width: 'calc(100% - 2rem)',
       okButton: buttonPrimary({


### PR DESCRIPTION
Introduces a lightweight modal library that handles focus management, close on escape, and close on overlay click.

Fixes #382 . The default behavior is that the modal itself will receive focus, and you can tab in from there. This PR also adds `autoFocus` in several places, so form-based modals will focus the first input.