### PR TITLE
Non-canCompute users can't edit data bindings or click 'Launch Analysis'

### DIFF
--- a/src/pages/workspaces/workspace/tools/WorkflowView.js
+++ b/src/pages/workspaces/workspace/tools/WorkflowView.js
@@ -221,6 +221,7 @@ class WorkflowViewContent extends Component {
   }
 
   renderIOTable(key) {
+    const { workspace: { canCompute } } = this.props
     const { modifiedConfig, inputsOutputs: { [key]: data }, entityMetadata, workspaceAttributes } = this.state
     // Sometimes we're getting totally empty metadata. Not sure if that's valid; if not, revert this
     const { attributeNames } = entityMetadata[modifiedConfig.rootEntityType] || {}
@@ -263,14 +264,15 @@ class WorkflowViewContent extends Component {
                 headerRenderer: () => h(HeaderCell, ['Attribute']),
                 cellRenderer: ({ rowIndex }) => {
                   const { name, optional, error } = data[rowIndex]
+                  const value = modifiedConfig[key][name] || ''
                   return div({ style: { display: 'flex', alignItems: 'center', width: '100%' } }, [
-                    h(AutocompleteTextInput, {
+                    canCompute ? h(AutocompleteTextInput, {
                       spellCheck: false,
                       placeholder: optional ? 'Optional' : 'Required',
-                      value: modifiedConfig[key][name] || '',
+                      value,
                       onChange: v => this.setState(_.set(['modifiedConfig', key, name], v)),
                       suggestions
-                    }),
+                    }) : div({ style: { flex: 1 } }, [value]),
                     error && h(TooltipTrigger, { content: error }, [
                       icon('error', {
                         size: 28, style: { marginLeft: '0.5rem', color: Style.colors.error, cursor: 'help' }

--- a/src/pages/workspaces/workspace/tools/WorkflowView.js
+++ b/src/pages/workspaces/workspace/tools/WorkflowView.js
@@ -159,6 +159,7 @@ class WorkflowViewContent extends Component {
   }
 
   renderSummary(invalidIO) {
+    const { workspace: { canCompute } } = this.props
     const { modifiedConfig, savedConfig, entityMetadata, saving, saved, activeTab } = this.state
     const { name, methodConfigVersion, methodRepoMethod: { methodPath }, rootEntityType } = modifiedConfig
     const modified = !_.isEqual(modifiedConfig, savedConfig)
@@ -190,9 +191,12 @@ class WorkflowViewContent extends Component {
           ])
         ]),
         div({ style: { flex: 'none', display: 'flex', flexDirection: 'column', alignItems: 'flex-end' } }, [
-          buttonPrimary({ disabled: noLaunchReason, onClick: () => this.setState({ launching: true }) },
-            'Launch analysis'),
-          noLaunchReason && div({
+          buttonPrimary({
+            disabled: !canCompute || !!noLaunchReason,
+            tooltip: !canCompute ? 'You do not have access to run analyses on this workspace.' : undefined,
+            onClick: () => this.setState({ launching: true })
+          }, ['Launch analysis']),
+          canCompute && noLaunchReason && div({
             style: {
               marginTop: '0.5rem', padding: '1rem',
               backgroundColor: Style.colors.warningBackground,


### PR DESCRIPTION
Fixes #400 
Fixes #398 