### PR TITLE
tweak cluster auto-create logic, ignore 403 codes

### DIFF
--- a/src/components/ClusterManager.js
+++ b/src/components/ClusterManager.js
@@ -7,7 +7,7 @@ import DropdownBox from 'src/components/DropdownBox'
 import { icon } from 'src/components/icons'
 import { IntegerInput, textInput } from 'src/components/input'
 import TooltipTrigger from 'src/components/TooltipTrigger'
-import { machineTypes, profiles, version } from 'src/data/clusters'
+import { machineTypes, profiles } from 'src/data/clusters'
 import { Jupyter } from 'src/libs/ajax'
 import { reportError } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
@@ -240,7 +240,6 @@ export default class ClusterManager extends PureComponent {
     const { jupyterUserScriptUri } = this.state
     this.executeAndRefresh(
       Jupyter.cluster(namespace, Utils.generateClusterName()).create({
-        labels: { 'saturnAutoCreated': 'true', 'saturnVersion': version },
         machineConfig: this.getMachineConfig(),
         ...(jupyterUserScriptUri ? { jupyterUserScriptUri } : {})
       }).then(() => {

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1,5 +1,6 @@
 import _ from 'lodash/fp'
 import * as qs from 'qs'
+import { version } from 'src/data/clusters'
 import { getAuthToken } from 'src/libs/auth'
 import * as Config from 'src/libs/config'
 import * as Utils from 'src/libs/utils'
@@ -411,7 +412,10 @@ export const Jupyter = {
 
     return {
       create: clusterOptions => {
-        return fetchLeo(root, _.mergeAll([authOpts(), jsonBody(clusterOptions), { method: 'PUT' }]))
+        const body = _.merge(clusterOptions, {
+          labels: { saturnAutoCreated: 'true', saturnVersion: version }
+        })
+        return fetchLeo(root, _.mergeAll([authOpts(), jsonBody(body), { method: 'PUT' }]))
       },
 
       start: () => {


### PR DESCRIPTION
Since it's not straightforward to determine if the user has compute permissions in a billing project, just go ahead and try auto-creating, and just ignore 403 errors. (Ok'd by product)
Fixes #413 