### PR TITLE
don't show cost info to readers

### DIFF
--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -87,6 +87,7 @@ const hasAccessLevel = _.curry((required, current) => {
 })
 
 export const canWrite = hasAccessLevel('WRITER')
+export const canRead = hasAccessLevel('READER')
 
 export const log = function(...args) {
   console.groupCollapsed.apply(null, args)

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -152,9 +152,10 @@ export class WorkspaceList extends Component {
       const workspaces = await Workspaces.list()
       this.setState({
         isDataLoaded: true,
-        workspaces: _.sortBy('workspace.name', _.filter(ws => !ws.public ||
-          Utils.workspaceAccessLevels.indexOf(ws.accessLevel) > Utils.workspaceAccessLevels.indexOf('READER'),
-        workspaces))
+        workspaces: _.flow(
+          _.filter(ws => !ws.public || Utils.canRead(ws.accessLevel)),
+          _.sortBy('workspace.name')
+        )(workspaces)
       })
     } catch (error) {
       reportError('Error loading workspace list', error)

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -58,15 +58,17 @@ class WorkspaceDashboardContent extends Component {
   }
 
   async componentDidMount() {
-    const { namespace, name } = this.props
+    const { namespace, name, workspace: { accessLevel } } = this.props
     try {
       const [submissions, estimate] = await Promise.all([
         Workspaces.workspace(namespace, name).listSubmissions(),
-        Workspaces.workspace(namespace, name).storageCostEstimate()
+        Utils.canWrite(accessLevel) ?
+          Workspaces.workspace(namespace, name).storageCostEstimate() :
+          undefined
       ])
       this.setState({
         submissionsCount: submissions.length,
-        storageCostEstimate: estimate.estimate
+        storageCostEstimate: estimate && estimate.estimate
       })
     } catch (error) {
       reportError('Error loading data', error)
@@ -89,7 +91,9 @@ class WorkspaceDashboardContent extends Component {
           h(InfoTile, { title: 'Creation date' }, [new Date(createdDate).toLocaleDateString()]),
           h(InfoTile, { title: 'Submissions' }, [submissionsCount]),
           h(InfoTile, { title: 'Access level' }, [roleString[accessLevel]]),
-          h(InfoTile, { title: 'Est. $/month' }, [storageCostEstimate])
+          Utils.canWrite(accessLevel) && h(InfoTile, { title: 'Est. $/month' }, [
+            storageCostEstimate
+          ])
         ]),
         div({ style: { margin: '0.5rem 0', borderBottom: `1px solid ${colors.gray[3]}` } }),
         link({


### PR DESCRIPTION
Fixes #459 
Also default to listing workspaces that you are a Reader on, which we were not showing before.