### PR TITLE
Fix processing of imported JSON

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -328,7 +328,7 @@ export const Workspaces = {
         const payload = await res.json()
         const body = _.map(({ name, entityType, attributes }) => {
           return { name, entityType, operations: attributesUpdateOps(attributes) }
-        }, payload)
+        }, [payload])
         return fetchRawls(`${root}/entities/batchUpsert`, _.mergeAll([authOpts(), jsonBody(body), { method: 'POST' }]))
       },
 


### PR DESCRIPTION
Fixes #445. @panentheos 

[dev import-data](https://bvdp-saturn-dev.appspot.com/#import-data?format=entitiesJson&url=https%3A%2F%2Fstorage.googleapis.com%2Fmanual-entity-json-for-testing%2Fbigquery.json%3Fx-goog-signature%3Dbf0b751119069706e5edd0eb19fbbf558ddf94ef899440baf301c1a8fda116d079e0a63981c6809f0d3bc5a2be280094eb627dd58563154ada24f46d7900a253e7a8db757232a2aa46a4739ce8b3a51d2c152f2e6c40677bbd36095ac054693f595d8ff2050da490fed177814d852c16bd7a559445d6c71c80bca101c471af362bff62b8ae9410eb333e10edd8ef88b697cedd04151d2791bd9b7abb68b8b24cd18db90fe044a5ed5282cb1fdea836af2a1547cb04f8aee1ef67780fab7521fc2809fe48c3b2b1285b2812043c775224b45ca914aedf0c0f3b3cdd192a8f6a15be86495709b9dd646c2ca51e324fe427005471ccc549b14a966653e4e1a1d634%26x-goog-algorithm%3DGOOG4-RSA-SHA256%26x-goog-credential%3Dtest-data-explorer%2540appspot.gserviceaccount.com%252F20180802%252Fus-west2%252Fstorage%252Fgoog4_request%26x-goog-date%3D20180802T183312Z%26x-goog-expires%3D604800%26x-goog-signedheaders%3Dhost) fails with "The request content was malformed: Object is missing required member 'name'".

Local saturn-ui with fix works.

Some questions.
1. I see some strange behavior in Chrome debugger only with local deployment, not dev deployment. When I set a breakpoint and step through code, the `import _ from 'lodash/fp'` has an error "Uncaught SyntaxError: Unexpected identifier". The code runs fine; this only affects debugger. Do you know off the top of your head how to fix this?
2. In #445 Brad wanted to support a zip file, not a JSON file. Can you do that after this PR is in? If dealing with zip files is a pain in Javascript, perhaps we could come up with a different format.