### PR TITLE
Remove reference to Dev environment from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 
 Guide [here](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md).
 
-Dev is up [here](https://bvdp-saturn-dev.appspot.com/).
-
 Builds/deploying handled by CircleCI.
 
 


### PR DESCRIPTION
This is an open source product, and we should be a little more careful exposing our dev environment