### PR TITLE
Invite unknown users on share

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -240,8 +240,9 @@ export const Workspaces = {
         return res.json()
       },
 
-      updateAcl: async aclUpdates => {
-        const res = await fetchRawls(`${root}/acl`, _.mergeAll([authOpts(), jsonBody(aclUpdates), { method: 'PATCH' }]))
+      updateAcl: async (aclUpdates, inviteNew=true) => {
+        const res = await fetchRawls(`${root}/acl?inviteUsersNotFound=${inviteNew}`,
+          _.mergeAll([authOpts(), jsonBody(aclUpdates), { method: 'PATCH' }]))
         return res.json()
       },
 


### PR DESCRIPTION
I forgot about this corner case.

In FC we initially save with `?inviteUsersNotFound=false`, check the response for unknown users, and then pop up a second modal to invite them, re-saving with `?inviteUsersNotFound=true`. In Saturn we're just gonna automatically invite them.