### PR TITLE
Uploads a copy of duplicated notebook

### DIFF
--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -148,19 +148,24 @@ class NotebooksContent extends Component {
   async uploadFiles(files) {
     const { namespace, workspace: { workspace: { bucketName } } } = this.props
     const existingNames = this.getExistingNames()
-    this.setState({ saving: true })
-    await Promise.all(_.map(async file => {
-      const name = file.name.slice(0, -6)
-      let resolvedName = name
-      let c = 0
-      while (_.includes(resolvedName, existingNames)) {
-        resolvedName = `${name}(${++c})`
-      }
-      const contents = await Utils.readFileAsText(file)
-      return Buckets.notebook(namespace, bucketName, resolvedName).create(JSON.parse(contents))
-    }, files))
-    this.refresh()
-    this.setState({ saving: false })
+    try {
+      this.setState({ saving: true })
+      await Promise.all(_.map(async file => {
+        const name = file.name.slice(0, -6)
+        let resolvedName = name
+        let c = 0
+        while (_.includes(resolvedName, existingNames)) {
+          resolvedName = `${name}(${++c})`
+        }
+        const contents = await Utils.readFileAsText(file)
+        return Buckets.notebook(namespace, bucketName, resolvedName).create(JSON.parse(contents))
+      }, files))
+      this.refresh()
+    } catch (error) {
+      reportError('Error creating notebook', error)
+    } finally {
+      this.setState({ saving: false })
+    }
   }
 
   componentWillMount() {

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -151,23 +151,13 @@ class NotebooksContent extends Component {
     this.setState({ saving: true })
     await Promise.all(_.map(async file => {
       const name = file.name.slice(0, -6)
-      if (_.includes(name, existingNames)) {
-        let c = 1
-        let doubleName = true
-        let NewName = `${name}(${c})`
-        while (doubleName) {
-          if (_.includes(NewName, existingNames)) {
-            c += 1
-            NewName = `${name}(${c})`
-          } else {
-            doubleName = false
-          }
-        }
-        const contents = await Utils.readFileAsText(file)
-        return Buckets.notebook(namespace, bucketName, NewName).create(JSON.parse(contents))
+      let resolvedName = name
+      let c = 0
+      while (_.includes(resolvedName, existingNames)) {
+        resolvedName = `${name}(${++c})`
       }
       const contents = await Utils.readFileAsText(file)
-      return Buckets.notebook(namespace, bucketName, name).create(JSON.parse(contents))
+      return Buckets.notebook(namespace, bucketName, resolvedName).create(JSON.parse(contents))
     }, files))
     this.refresh()
     this.setState({ saving: false })

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -148,22 +148,29 @@ class NotebooksContent extends Component {
   async uploadFiles(files) {
     const { namespace, workspace: { workspace: { bucketName } } } = this.props
     const existingNames = this.getExistingNames()
-    try {
-      this.setState({ saving: true })
-      await Promise.all(_.map(async file => {
-        const name = file.name.slice(0, -6)
-        if (_.includes(name, existingNames)) {
-          throw new Error(`${name} already exists`)
+    this.setState({ saving: true })
+    await Promise.all(_.map(async file => {
+      const name = file.name.slice(0, -6)
+      if (_.includes(name, existingNames)) {
+        let c = 1
+        let doubleName = true
+        let NewName = `${name}(${c})`
+        while (doubleName) {
+          if (_.includes(NewName, existingNames)) {
+            c += 1
+            NewName = `${name}(${c})`
+          } else {
+            doubleName = false
+          }
         }
         const contents = await Utils.readFileAsText(file)
-        return Buckets.notebook(namespace, bucketName, name).create(JSON.parse(contents))
-      }, files))
-      this.refresh()
-    } catch (error) {
-      reportError('Error creating notebook', error)
-    } finally {
-      this.setState({ saving: false })
-    }
+        return Buckets.notebook(namespace, bucketName, NewName).create(JSON.parse(contents))
+      }
+      const contents = await Utils.readFileAsText(file)
+      return Buckets.notebook(namespace, bucketName, name).create(JSON.parse(contents))
+    }, files))
+    this.refresh()
+    this.setState({ saving: false })
   }
 
   componentWillMount() {

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -155,7 +155,7 @@ class NotebooksContent extends Component {
         let resolvedName = name
         let c = 0
         while (_.includes(resolvedName, existingNames)) {
-          resolvedName = `${name}(${++c})`
+          resolvedName = `${name} ${++c}`
         }
         const contents = await Utils.readFileAsText(file)
         return Buckets.notebook(namespace, bucketName, resolvedName).create(JSON.parse(contents))


### PR DESCRIPTION
Fixes #541 
If there's a notebook already named "Thing", uploads notebook as "Thing(x)" where x is the next unique integer (1, 2, etc.) 

Two questions I have for review:
1) Is there a preference between "Thing(x)" vs. "Thing (x)" 
2) When re-downloading a notebook "Thing(x)", it downloads as "Thing%28x%29.ipynb". Is this also a concern? 
 