### PR TITLE
Error for invalid ipynb file

### DIFF
--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -162,7 +162,11 @@ class NotebooksContent extends Component {
       }, files))
       this.refresh()
     } catch (error) {
-      reportError('Error creating notebook', error)
+      if (error instanceof SyntaxError) {
+        reportError('Error uploading notebook', 'This ipynb file is not formatted correctly.')
+      } else {
+        reportError('Error creating notebook', error)
+      }
     } finally {
       this.setState({ saving: false })
     }


### PR DESCRIPTION
Fixes #478 

If a user uploads a file with the extension .ipynb we will try to parse it. If the JSON is invalid it will throw a weird error, so this gives the user a more helpful error that the ipynb file is invalid. 

If anyone has suggestions for what a user can do in this situation please comment. I couldn't come up with any helpful guidance. Remember, error messages should be Humble, Human and Helpful!