### PR TITLE
Cancelable AJAX calls

### DIFF
--- a/src/_tests/pages/workspaces/List.test.js
+++ b/src/_tests/pages/workspaces/List.test.js
@@ -17,15 +17,16 @@ describe('WorkspaceList', () => {
   it('should switch between Grid and List view', () => {
     const wrapper = mount(h(WorkspaceList))
     return waitOneTickAndUpdate(wrapper).then(() => {
-      const currentCardsPerRow = () => wrapper.state().listView
+      const actual = wrapper.instance().child
+      const isListView = () => actual.state.listView
 
-      expect(currentCardsPerRow()).not.toEqual(true)
+      expect(isListView()).toEqual(false)
 
       wrapper.findIcon('view-list').click()
-      expect(currentCardsPerRow()).toEqual(true)
+      expect(isListView()).toEqual(true)
 
       wrapper.findIcon('view-cards').click()
-      expect(currentCardsPerRow()).not.toEqual(true)
+      expect(isListView()).toEqual(false)
     })
   })
 })

--- a/src/components/ClusterManager.js
+++ b/src/components/ClusterManager.js
@@ -8,7 +8,7 @@ import { icon } from 'src/components/icons'
 import { IntegerInput, textInput } from 'src/components/input'
 import TooltipTrigger from 'src/components/TooltipTrigger'
 import { machineTypes, profiles, storagePrice } from 'src/data/clusters'
-import { Jupyter } from 'src/libs/ajax'
+import { ajaxCaller } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { reportError } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
@@ -191,7 +191,7 @@ const getUpdateIntervalMs = status => {
   }
 }
 
-export default class ClusterManager extends PureComponent {
+export default ajaxCaller(class ClusterManager extends PureComponent {
   constructor(props) {
     super(props)
     this.state = {
@@ -260,7 +260,7 @@ export default class ClusterManager extends PureComponent {
   }
 
   createCluster() {
-    const { namespace } = this.props
+    const { ajax: { Jupyter }, namespace } = this.props
     const { jupyterUserScriptUri } = this.state
     this.executeAndRefresh(
       Jupyter.cluster(namespace, Utils.generateClusterName()).create({
@@ -273,6 +273,7 @@ export default class ClusterManager extends PureComponent {
   }
 
   destroyClusters(keepIndex) {
+    const { ajax: { Jupyter } } = this.props
     const activeClusters = this.getActiveClustersOldestFirst()
     this.executeAndRefresh(
       Promise.all(_.map(
@@ -283,6 +284,7 @@ export default class ClusterManager extends PureComponent {
   }
 
   startCluster() {
+    const { ajax: { Jupyter } } = this.props
     const { googleProject, clusterName } = this.getCurrentCluster()
     this.executeAndRefresh(
       Jupyter.cluster(googleProject, clusterName).start()
@@ -290,6 +292,7 @@ export default class ClusterManager extends PureComponent {
   }
 
   stopCluster() {
+    const { ajax: { Jupyter } } = this.props
     const { googleProject, clusterName } = this.getCurrentCluster()
     this.executeAndRefresh(
       Jupyter.cluster(googleProject, clusterName).stop()
@@ -541,4 +544,4 @@ export default class ClusterManager extends PureComponent {
       this.renderDropdown()
     ])
   }
-}
+})

--- a/src/components/NewWorkspaceModal.js
+++ b/src/components/NewWorkspaceModal.js
@@ -6,7 +6,7 @@ import { icon } from 'src/components/icons'
 import { TextArea, validatedInput } from 'src/components/input'
 import Modal from 'src/components/Modal'
 import { InfoBox } from 'src/components/PopupTrigger'
-import { Billing, Groups, Workspaces } from 'src/libs/ajax'
+import { ajaxCaller } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { reportError } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
@@ -45,7 +45,7 @@ const styles = {
   }
 }
 
-export default class NewWorkspaceModal extends Component {
+export default ajaxCaller(class NewWorkspaceModal extends Component {
   constructor(props) {
     super(props)
     const { cloneWorkspace } = props
@@ -63,6 +63,7 @@ export default class NewWorkspaceModal extends Component {
   }
 
   async componentDidMount() {
+    const { ajax: { Billing, Groups } } = this.props
     try {
       const [billingProjects, allGroups] = await Promise.all([
         Billing.listProjects(),
@@ -75,7 +76,7 @@ export default class NewWorkspaceModal extends Component {
   }
 
   async create() {
-    const { cloneWorkspace } = this.props
+    const { cloneWorkspace, ajax: { Workspaces } } = this.props
     const { namespace, name, description, groups } = this.state
     try {
       this.setState({ createError: undefined, busy: true })
@@ -180,4 +181,4 @@ export default class NewWorkspaceModal extends Component {
       busy && spinnerOverlay
     ])
   }
-}
+})

--- a/src/components/WorkspaceSelector.js
+++ b/src/components/WorkspaceSelector.js
@@ -1,12 +1,12 @@
 import _ from 'lodash/fp'
 import { h } from 'react-hyperscript-helpers'
 import { Select } from 'src/components/common'
-import { Workspaces } from 'src/libs/ajax'
+import { ajaxCaller } from 'src/libs/ajax'
 import { reportError } from 'src/libs/error'
 import { Component } from 'src/libs/wrapped-components'
 
 
-export default class WorkspaceSelector extends Component {
+export default ajaxCaller(class WorkspaceSelector extends Component {
   render() {
     const { onWorkspaceSelected, selectedWorkspace } = this.props
     const { workspaces } = this.state
@@ -24,7 +24,7 @@ export default class WorkspaceSelector extends Component {
   }
 
   async componentDidMount() {
-    const { authorizationDomain: ad, filter } = this.props
+    const { authorizationDomain: ad, filter, ajax: { Workspaces } } = this.props
 
     try {
       const workspaces = _.flow(
@@ -37,4 +37,4 @@ export default class WorkspaceSelector extends Component {
       reportError('Error loading workspaces', error)
     }
   }
-}
+})

--- a/src/components/notebook-utils.js
+++ b/src/components/notebook-utils.js
@@ -4,7 +4,7 @@ import { buttonPrimary, Select, spinnerOverlay } from 'src/components/common'
 import { centeredSpinner } from 'src/components/icons'
 import { validatedInput } from 'src/components/input'
 import Modal from 'src/components/Modal'
-import { Buckets } from 'src/libs/ajax'
+import { ajaxCaller } from 'src/libs/ajax'
 import { reportError } from 'src/libs/error'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
@@ -63,7 +63,7 @@ const rNotebook = _.merge({
 }, baseNotebook)
 
 
-export class NotebookCreator extends Component {
+export const NotebookCreator = ajaxCaller(class extends Component {
   constructor(props) {
     super(props)
     this.state = { notebookName: '' }
@@ -71,7 +71,7 @@ export class NotebookCreator extends Component {
 
   render() {
     const { notebookName, notebookKernel, creating, nameTouched } = this.state
-    const { reloadList, onDismiss, namespace, bucketName, existingNames } = this.props
+    const { reloadList, onDismiss, namespace, bucketName, existingNames, ajax: { Buckets } } = this.props
 
     const errors = validate(
       { notebookName, notebookKernel },
@@ -140,16 +140,16 @@ export class NotebookCreator extends Component {
       creating && spinnerOverlay
     ])
   }
-}
+})
 
-export class NotebookDuplicator extends Component {
+export const NotebookDuplicator = ajaxCaller(class extends Component {
   constructor(props) {
     super(props)
     this.state = { newName: '' }
   }
 
   render() {
-    const { destroyOld, printName, namespace, bucketName, onDismiss, onSuccess, existingNames } = this.props
+    const { destroyOld, printName, namespace, bucketName, onDismiss, onSuccess, existingNames, ajax: { Buckets } } = this.props
     const { newName, processing, nameTouched } = this.state
 
     const errors = validate(
@@ -187,11 +187,11 @@ export class NotebookDuplicator extends Component {
       ]
     ))
   }
-}
+})
 
-export class NotebookDeleter extends Component {
+export const NotebookDeleter = ajaxCaller(class extends Component {
   render() {
-    const { printName, namespace, bucketName, onDismiss, onSuccess } = this.props
+    const { printName, namespace, bucketName, onDismiss, onSuccess, ajax: { Buckets } } = this.props
     const { processing } = this.state
 
     return h(Modal, {
@@ -220,4 +220,4 @@ export class NotebookDeleter extends Component {
       ]
     ))
   }
-}
+})

--- a/src/components/notebook-utils.js
+++ b/src/components/notebook-utils.js
@@ -63,7 +63,7 @@ const rNotebook = _.merge({
 }, baseNotebook)
 
 
-export const NotebookCreator = ajaxCaller(class extends Component {
+export const NotebookCreator = ajaxCaller(class NotebookCreator extends Component {
   constructor(props) {
     super(props)
     this.state = { notebookName: '' }
@@ -142,7 +142,7 @@ export const NotebookCreator = ajaxCaller(class extends Component {
   }
 })
 
-export const NotebookDuplicator = ajaxCaller(class extends Component {
+export const NotebookDuplicator = ajaxCaller(class NotebookDuplicator extends Component {
   constructor(props) {
     super(props)
     this.state = { newName: '' }
@@ -189,7 +189,7 @@ export const NotebookDuplicator = ajaxCaller(class extends Component {
   }
 })
 
-export const NotebookDeleter = ajaxCaller(class extends Component {
+export const NotebookDeleter = ajaxCaller(class NotebookDeleter extends Component {
   render() {
     const { printName, namespace, bucketName, onDismiss, onSuccess, ajax: { Buckets } } = this.props
     const { processing } = this.state

--- a/src/libs/__mocks__/ajax.js
+++ b/src/libs/__mocks__/ajax.js
@@ -1,4 +1,6 @@
 import _ from 'lodash/fp'
+import { h } from 'react-hyperscript-helpers'
+import { Component } from 'src/libs/wrapped-components'
 
 
 export const createWorkspace = overrides => {
@@ -36,7 +38,7 @@ export const createWorkspace = overrides => {
   }, overrides)
 }
 
-export const Workspaces = {
+const Workspaces = {
   list() {
     return Promise.resolve([createWorkspace(), createWorkspace()])
   },
@@ -50,8 +52,29 @@ export const Workspaces = {
   }
 }
 
-export const Jupyter = {
+const Jupyter = {
   clustersList() {
     return Promise.resolve([])
+  }
+}
+
+export const Ajax = () => ({
+  Workspaces, Jupyter
+})
+
+export const ajaxCaller = WrappedComponent => {
+  return class AjaxWrapper extends Component {
+    constructor(props) {
+      super(props)
+      this.ajax = Ajax()
+    }
+
+    render() {
+      return h(WrappedComponent, {
+        ref: component => this.child = component,
+        ajax: this.ajax,
+        ...this.props
+      })
+    }
   }
 }

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -544,7 +544,11 @@ export const ajaxCaller = WrappedComponent => {
     }
 
     render() {
-      return h(WrappedComponent, { ajax: this.ajax, ...this.props })
+      return h(WrappedComponent, {
+        ref: component => this.child = component,
+        ajax: this.ajax,
+        ...this.props
+      })
     }
 
     componentWillUnmount() {

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -509,3 +509,33 @@ export const Martha = {
     ).then(res => res.json())
   }
 }
+
+
+export const Ajax = controller => {
+  const signal = controller ? controller.signal : undefined
+
+  return {
+    workspaces: {
+      list: async () => {
+        const res = await fetchRawls('workspaces', _.merge({ signal }, authOpts()))
+        return res.json()
+      },
+
+      workspace: (namespace, name) => {
+        const root = `workspaces/${namespace}/${name}`
+
+        return {
+          listSubmissions: async () => {
+            const res = await fetchRawls(`${root}/submissions`, _.merge({ signal }, authOpts()))
+            return res.json()
+          },
+
+          storageCostEstimate: async () => {
+            const res = await fetchOrchestration(`/api/workspaces/${namespace}/${name}/storageCostEstimate`, _.merge({ signal }, authOpts()))
+            return res.json()
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -4,6 +4,8 @@ import { version } from 'src/data/clusters'
 import { getAuthToken } from 'src/libs/auth'
 import * as Config from 'src/libs/config'
 import * as Utils from 'src/libs/utils'
+import { Component } from 'src/libs/wrapped-components'
+import { h } from 'react-hyperscript-helpers'
 
 
 let mockResponse
@@ -511,7 +513,7 @@ export const Martha = {
 }
 
 
-export const Ajax = controller => {
+const Ajax = controller => {
   const signal = controller ? controller.signal : undefined
 
   return {
@@ -536,6 +538,25 @@ export const Ajax = controller => {
           }
         }
       }
+    }
+  }
+}
+
+
+export const ajaxCaller = WrappedComponent => {
+  return class AjaxWrapper extends Component {
+    constructor(props) {
+      super(props)
+      this.controller = new window.AbortController()
+      this.ajax = Ajax(this.controller)
+    }
+
+    render() {
+      return h(WrappedComponent, { ...this.props, ajax: this.ajax })
+    }
+
+    componentWillUnmount() {
+      this.controller.abort()
     }
   }
 }

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -54,7 +54,16 @@ const instrumentedFetch = (url, options) => {
     console.info('%cSimulating response:', consoleStyle, mockResponse())
     return Promise.resolve(mockResponse())
   }
-  return fetch(url, options)
+
+  return new Promise((resolve, reject) => {
+    fetch(url, options).then(resolve, error => {
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        // no-op, this is from an aborted call
+      } else {
+        reject(error)
+      }
+    })
+  })
 }
 
 const fetchOk = async (url, options) => {

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -93,28 +93,28 @@ const fetchOrchestration = async (path, options) => {
 }
 
 
-export const User = {
+const User = signal => ({
   token: Utils.memoizeWithTimeout(async namespace => {
     const scopes = ['https://www.googleapis.com/auth/devstorage.full_control']
     const res = await fetchSam(
       `api/google/user/petServiceAccount/${namespace}/token`,
-      _.mergeAll([authOpts(), jsonBody(scopes), { method: 'POST' }])
+      _.mergeAll([authOpts(), jsonBody(scopes), { signal, method: 'POST' }])
     )
     return res.json()
   }, namespace => namespace, 1000 * 60 * 30),
 
   getStatus: async () => {
-    return fetchSam('register/user/v2/self/info', authOpts())
+    return fetchSam('register/user/v2/self/info', _.merge(authOpts(), { signal }))
   },
 
   create: async () => {
-    const res = await fetchSam('register/user/v2/self', _.merge(authOpts(), { method: 'POST' }))
+    const res = await fetchSam('register/user/v2/self', _.merge(authOpts(), { signal, method: 'POST' }))
     return res.json()
   },
 
   profile: {
     get: async () => {
-      const res = await fetchOrchestration('register/profile', authOpts())
+      const res = await fetchOrchestration('register/profile', _.merge(authOpts(), { signal }))
       return res.json()
     },
     set: keysAndValues => {
@@ -132,21 +132,21 @@ export const User = {
       }
       return fetchOrchestration(
         'register/profile',
-        _.mergeAll([authOpts(), jsonBody(_.merge(blankProfile, keysAndValues)), { method: 'POST' }])
+        _.mergeAll([authOpts(), jsonBody(_.merge(blankProfile, keysAndValues)), { signal, method: 'POST' }])
       )
     }
   },
 
   getProxyGroup: async email => {
-    const res = await fetchOrchestration(`api/proxyGroup/${email}`, authOpts())
+    const res = await fetchOrchestration(`api/proxyGroup/${email}`, _.merge(authOpts(), { signal }))
     return res.json()
   }
-}
+})
 
 
-export const Groups = {
+const Groups = signal => ({
   list: async () => {
-    const res = await fetchSam('api/groups/v1', authOpts())
+    const res = await fetchSam('api/groups/v1', _.merge(authOpts(), { signal }))
     return res.json()
   },
 
@@ -154,29 +154,29 @@ export const Groups = {
     const root = `api/groups/v1/${groupName}`
 
     const addMember = async (role, email) => {
-      return fetchSam(`${root}/${role}/${email}`, _.merge(authOpts(), { method: 'PUT' }))
+      return fetchSam(`${root}/${role}/${email}`, _.merge(authOpts(), { signal, method: 'PUT' }))
     }
 
     const removeMember = async (role, email) => {
-      return fetchSam(`${root}/${role}/${email}`, _.merge(authOpts(), { method: 'DELETE' }))
+      return fetchSam(`${root}/${role}/${email}`, _.merge(authOpts(), { signal, method: 'DELETE' }))
     }
 
     return {
       create: () => {
-        return fetchSam(root, _.merge(authOpts(), { method: 'POST' }))
+        return fetchSam(root, _.merge(authOpts(), { signal, method: 'POST' }))
       },
 
       delete: () => {
-        return fetchSam(root, _.merge(authOpts(), { method: 'DELETE' }))
+        return fetchSam(root, _.merge(authOpts(), { signal, method: 'DELETE' }))
       },
 
       listMembers: async () => {
-        const res = await fetchSam(`${root}/member`, authOpts())
+        const res = await fetchSam(`${root}/member`, _.merge(authOpts(), { signal }))
         return res.json()
       },
 
       listAdmins: async () => {
-        const res = await fetchSam(`${root}/admin`, authOpts())
+        const res = await fetchSam(`${root}/admin`, _.merge(authOpts(), { signal }))
         return res.json()
       },
 
@@ -192,15 +192,15 @@ export const Groups = {
       }
     }
   }
-}
+})
 
 
-export const Billing = {
+const Billing = signal => ({
   listProjects: async () => {
-    const res = await fetchRawls('user/billing', authOpts())
+    const res = await fetchRawls('user/billing', _.merge(authOpts(), { signal }))
     return res.json()
   }
-}
+})
 
 const attributesUpdateOps = _.flow(
   _.toPairs,
@@ -211,19 +211,19 @@ const attributesUpdateOps = _.flow(
   })
 )
 
-export const Workspaces = {
+const Workspaces = signal => ({
   list: async () => {
-    const res = await fetchRawls('workspaces', authOpts())
+    const res = await fetchRawls('workspaces', _.merge(authOpts(), { signal }))
     return res.json()
   },
 
   create: async body => {
-    const res = await fetchRawls('workspaces', _.mergeAll([authOpts(), jsonBody(body), { method: 'POST' }]))
+    const res = await fetchRawls('workspaces', _.mergeAll([authOpts(), jsonBody(body), { signal, method: 'POST' }]))
     return res.json()
   },
 
   getShareLog: async () => {
-    const res = await fetchOrchestration('api/sharelog/sharees?shareType=workspace', authOpts())
+    const res = await fetchOrchestration('api/sharelog/sharees?shareType=workspace', _.merge(authOpts(), { signal }))
     return res.json()
   },
 
@@ -233,43 +233,43 @@ export const Workspaces = {
 
     return {
       details: async () => {
-        const res = await fetchRawls(root, authOpts())
+        const res = await fetchRawls(root, _.merge(authOpts(), { signal }))
         return res.json()
       },
 
       getAcl: async () => {
-        const res = await fetchRawls(`${root}/acl`, authOpts())
+        const res = await fetchRawls(`${root}/acl`, _.merge(authOpts(), { signal }))
         return res.json()
       },
 
       updateAcl: async (aclUpdates, inviteNew=true) => {
         const res = await fetchRawls(`${root}/acl?inviteUsersNotFound=${inviteNew}`,
-          _.mergeAll([authOpts(), jsonBody(aclUpdates), { method: 'PATCH' }]))
+          _.mergeAll([authOpts(), jsonBody(aclUpdates), { signal, method: 'PATCH' }]))
         return res.json()
       },
 
       entityMetadata: async () => {
-        const res = await fetchRawls(`${root}/entities`, authOpts())
+        const res = await fetchRawls(`${root}/entities`, _.merge(authOpts(), { signal }))
         return res.json()
       },
 
       entitiesOfType: async type => {
-        const res = await fetchRawls(`${root}/entities/${type}`, authOpts())
+        const res = await fetchRawls(`${root}/entities/${type}`, _.merge(authOpts(), { signal }))
         return res.json()
       },
 
       paginatedEntitiesOfType: async (type, parameters) => {
-        const res = await fetchRawls(`${root}/entityQuery/${type}?${qs.stringify(parameters)}`, authOpts())
+        const res = await fetchRawls(`${root}/entityQuery/${type}?${qs.stringify(parameters)}`, _.merge(authOpts(), { signal }))
         return res.json()
       },
 
       listMethodConfigs: async (allRepos = true) => {
-        const res = await fetchRawls(`${mcPath}?allRepos=${allRepos}`, authOpts())
+        const res = await fetchRawls(`${mcPath}?allRepos=${allRepos}`, _.merge(authOpts(), { signal }))
         return res.json()
       },
 
       importMethodConfigFromDocker: payload => {
-        return fetchRawls(mcPath, _.mergeAll([authOpts(), jsonBody(payload), { method: 'POST' }]))
+        return fetchRawls(mcPath, _.mergeAll([authOpts(), jsonBody(payload), { signal, method: 'POST' }]))
       },
 
       methodConfig: (configNamespace, configName) => {
@@ -277,17 +277,17 @@ export const Workspaces = {
 
         return {
           get: async () => {
-            const res = await fetchRawls(path, authOpts())
+            const res = await fetchRawls(path, _.merge(authOpts(), { signal }))
             return res.json()
           },
 
           save: async payload => {
-            const res = await fetchRawls(path, _.mergeAll([authOpts(), jsonBody(payload), { method: 'POST' }]))
+            const res = await fetchRawls(path, _.mergeAll([authOpts(), jsonBody(payload), { signal, method: 'POST' }]))
             return res.json()
           },
 
           validate: async () => {
-            const res = await fetchRawls(`${path}/validate`, authOpts())
+            const res = await fetchRawls(`${path}/validate`, _.merge(authOpts(), { signal }))
             return res.json()
           },
 
@@ -299,7 +299,7 @@ export const Workspaces = {
                 methodConfigurationNamespace: configNamespace,
                 methodConfigurationName: configName
               }),
-              { method: 'POST' }
+              { signal, method: 'POST' }
             ]))
             return res.json()
           }
@@ -307,37 +307,37 @@ export const Workspaces = {
       },
 
       listSubmissions: async () => {
-        const res = await fetchRawls(`${root}/submissions`, authOpts())
+        const res = await fetchRawls(`${root}/submissions`, _.merge(authOpts(), { signal }))
         return res.json()
       },
 
       abortSubmission: async submissionId => {
-        return fetchRawls(`${root}/submissions/${submissionId}`, _.merge(authOpts(), { method: 'DELETE' }))
+        return fetchRawls(`${root}/submissions/${submissionId}`, _.merge(authOpts(), { signal, method: 'DELETE' }))
       },
 
       delete: () => {
-        return fetchRawls(root, _.merge(authOpts(), { method: 'DELETE' }))
+        return fetchRawls(root, _.merge(authOpts(), { signal, method: 'DELETE' }))
       },
 
       clone: async body => {
-        const res = await fetchRawls(`${root}/clone`, _.mergeAll([authOpts(), jsonBody(body), { method: 'POST' }]))
+        const res = await fetchRawls(`${root}/clone`, _.mergeAll([authOpts(), jsonBody(body), { signal, method: 'POST' }]))
         return res.json()
       },
 
       shallowMergeNewAttributes: attributesObject => {
         const payload = attributesUpdateOps(attributesObject)
-        return fetchRawls(root, _.mergeAll([authOpts(), jsonBody(payload), { method: 'PATCH' }]))
+        return fetchRawls(root, _.mergeAll([authOpts(), jsonBody(payload), { signal, method: 'PATCH' }]))
       },
 
       deleteAttributes: attributeNames => {
         const payload = _.map(attributeName => ({ op: 'RemoveAttribute', attributeName }), attributeNames)
-        return fetchRawls(root, _.mergeAll([authOpts(), jsonBody(payload), { method: 'PATCH' }]))
+        return fetchRawls(root, _.mergeAll([authOpts(), jsonBody(payload), { signal, method: 'PATCH' }]))
       },
 
       importBagit: bagitURL => {
         return fetchOrchestration(
           `api/workspaces/${namespace}/${name}/importBagit`,
-          _.mergeAll([authOpts(), jsonBody({ bagitURL, format: 'TSV' }), { method: 'POST' }])
+          _.mergeAll([authOpts(), jsonBody({ bagitURL, format: 'TSV' }), { signal, method: 'POST' }])
         )
       },
 
@@ -347,35 +347,41 @@ export const Workspaces = {
         const body = _.map(({ name, entityType, attributes }) => {
           return { name, entityType, operations: attributesUpdateOps(attributes) }
         }, payload)
-        return fetchRawls(`${root}/entities/batchUpsert`, _.mergeAll([authOpts(), jsonBody(body), { method: 'POST' }]))
+        return fetchRawls(`${root}/entities/batchUpsert`, _.mergeAll([authOpts(), jsonBody(body), { signal, method: 'POST' }]))
       },
 
       storageCostEstimate: async () => {
-        const res = await fetchOrchestration(`api/workspaces/${namespace}/${name}/storageCostEstimate`, authOpts())
+        const res = await fetchOrchestration(`api/workspaces/${namespace}/${name}/storageCostEstimate`, _.merge(authOpts(), { signal }))
         return res.json()
       }
     }
   }
-}
+})
 
 
-export const Buckets = {
+const Buckets = signal => ({
   getObject: async (bucket, object, namespace) => {
     return fetchBuckets(`storage/v1/b/${bucket}/o/${encodeURIComponent(object)}`,
-      authOpts(await User.token(namespace))).then(
+      _.merge(authOpts(await User(signal).token(namespace)), { signal })
+    ).then(
       res => res.json()
     )
   },
 
   getObjectPreview: async (bucket, object, namespace, previewFull = false) => {
     return fetchBuckets(`storage/v1/b/${bucket}/o/${encodeURIComponent(object)}?alt=media`,
-      _.merge(authOpts(await User.token(namespace)), previewFull ? {} : { headers: { Range: 'bytes=0-20000' } }))
+      _.mergeAll([
+        authOpts(await User(signal).token(namespace)),
+        { signal },
+        previewFull ? {} : { headers: { Range: 'bytes=0-20000' } }
+      ])
+    )
   },
 
   listNotebooks: async (namespace, name) => {
     const res = await fetchBuckets(
       `storage/v1/b/${name}/o?prefix=notebooks/`,
-      authOpts(await User.token(namespace))
+      _.merge(authOpts(await User(signal).token(namespace)), { signal })
     )
     const { items } = await res.json()
     return _.filter(({ name }) => name.endsWith('.ipynb'), items)
@@ -387,13 +393,13 @@ export const Buckets = {
     const copy = async newName => {
       return fetchBuckets(
         `${bucketUrl}/${nbName(name)}/copyTo/b/${bucket}/o/${nbName(newName)}`,
-        _.merge(authOpts(await User.token(namespace)), { method: 'POST' })
+        _.merge(authOpts(await User(signal).token(namespace)), { signal, method: 'POST' })
       )
     }
     const doDelete = async () => {
       return fetchBuckets(
         `${bucketUrl}/${nbName(name)}`,
-        _.merge(authOpts(await User.token(namespace)), { method: 'DELETE' })
+        _.merge(authOpts(await User(signal).token(namespace)), { signal, method: 'DELETE' })
       )
     }
     return {
@@ -402,8 +408,8 @@ export const Buckets = {
       create: async contents => {
         return fetchBuckets(
           `upload/${bucketUrl}?uploadType=media&name=${nbName(name)}`,
-          _.merge(authOpts(await User.token(namespace)), {
-            method: 'POST', body: JSON.stringify(contents),
+          _.merge(authOpts(await User(signal).token(namespace)), {
+            signal, method: 'POST', body: JSON.stringify(contents),
             headers: { 'Content-Type': 'application/x-ipynb+json' }
           })
         )
@@ -417,13 +423,13 @@ export const Buckets = {
       }
     }
   }
-}
+})
 
 
-export const Methods = {
+const Methods = signal => ({
   configInputsOutputs: async loadedConfig => {
     const res = await fetchRawls('methodconfigs/inputsOutputs',
-      _.mergeAll([authOpts(), jsonBody(loadedConfig.methodRepoMethod), { method: 'POST' }]))
+      _.mergeAll([authOpts(), jsonBody(loadedConfig.methodRepoMethod), { signal, method: 'POST' }]))
     return res.json()
   },
 
@@ -432,17 +438,17 @@ export const Methods = {
 
     return {
       get: async () => {
-        const res = await fetchAgora(root, authOpts())
+        const res = await fetchAgora(root, _.merge(authOpts(), { signal }))
         return res.json()
       }
     }
   }
-}
+})
 
 
-export const Jupyter = {
+const Jupyter = signal => ({
   clustersList: async () => {
-    const res = await fetchLeo('api/clusters?saturnAutoCreated=true', addAppIdentifier(authOpts()))
+    const res = await fetchLeo('api/clusters?saturnAutoCreated=true', _.mergeAll([authOpts(), appIdentifier, { signal }]))
     return res.json()
   },
 
@@ -455,19 +461,19 @@ export const Jupyter = {
           labels: { saturnAutoCreated: 'true', saturnVersion: version },
           defaultClientId: await Config.getGoogleClientId()
         })
-        return fetchLeo(root, _.mergeAll([authOpts(), jsonBody(body), { method: 'PUT' }, appIdentifier]))
+        return fetchLeo(root, _.mergeAll([authOpts(), jsonBody(body), { signal, method: 'PUT' }, appIdentifier]))
       },
 
       start: () => {
-        return fetchLeo(`${root}/start`, _.mergeAll([authOpts(), { method: 'POST' }, appIdentifier]))
+        return fetchLeo(`${root}/start`, _.mergeAll([authOpts(), { signal, method: 'POST' }, appIdentifier]))
       },
 
       stop: () => {
-        return fetchLeo(`${root}/stop`, _.mergeAll([authOpts(), { method: 'POST' }, appIdentifier]))
+        return fetchLeo(`${root}/stop`, _.mergeAll([authOpts(), { signal, method: 'POST' }, appIdentifier]))
       },
 
       delete: () => {
-        return fetchLeo(root, _.mergeAll([authOpts(), { method: 'DELETE' }, appIdentifier]))
+        return fetchLeo(root, _.mergeAll([authOpts(), { signal, method: 'DELETE' }, appIdentifier]))
       }
     }
   },
@@ -478,67 +484,53 @@ export const Jupyter = {
     return {
       localize: files => {
         return fetchLeo(`${root}/api/localize`,
-          _.mergeAll([authOpts(), jsonBody(files), { method: 'POST' }]))
+          _.mergeAll([authOpts(), jsonBody(files), { signal, method: 'POST' }]))
       },
 
       setCookie: () => {
         return fetchLeo(`${root}/setCookie`,
-          _.merge(authOpts(), { credentials: 'include' }))
+          _.merge(authOpts(), { signal, credentials: 'include' }))
       }
     }
   }
-}
+})
 
 
-export const Dockstore = {
+const Dockstore = signal => ({
   getWdl: async (path, version) => {
-    const res = await fetchDockstore(`${dockstoreMethodPath(path)}/${encodeURIComponent(version)}/WDL/descriptor`)
+    const res = await fetchDockstore(`${dockstoreMethodPath(path)}/${encodeURIComponent(version)}/WDL/descriptor`, { signal })
     return res.json()
   },
 
   getVersions: async path => {
-    const res = await fetchDockstore(dockstoreMethodPath(path))
+    const res = await fetchDockstore(dockstoreMethodPath(path), { signal })
     return res.json()
   }
+})
 
-}
 
-
-export const Martha = {
+const Martha = signal => ({
   call: async uri => {
     return fetchOk(await Config.getMarthaUrlRoot(),
-      _.mergeAll([jsonBody({ uri }), authOpts(), appIdentifier, { method: 'POST' }])
+      _.mergeAll([jsonBody({ uri }), authOpts(), appIdentifier, { signal, method: 'POST' }])
     ).then(res => res.json())
   }
-}
+})
 
 
-const Ajax = controller => {
-  const signal = controller ? controller.signal : undefined
+export const Ajax = controller => {
+  const signal = controller && controller.signal
 
   return {
-    workspaces: {
-      list: async () => {
-        const res = await fetchRawls('workspaces', _.merge({ signal }, authOpts()))
-        return res.json()
-      },
-
-      workspace: (namespace, name) => {
-        const root = `workspaces/${namespace}/${name}`
-
-        return {
-          listSubmissions: async () => {
-            const res = await fetchRawls(`${root}/submissions`, _.merge({ signal }, authOpts()))
-            return res.json()
-          },
-
-          storageCostEstimate: async () => {
-            const res = await fetchOrchestration(`/api/workspaces/${namespace}/${name}/storageCostEstimate`, _.merge({ signal }, authOpts()))
-            return res.json()
-          }
-        }
-      }
-    }
+    User: User(signal),
+    Groups: Groups(signal),
+    Billing: Billing(signal),
+    Workspaces: Workspaces(signal),
+    Buckets: Buckets(signal),
+    Methods: Methods(signal),
+    Jupyter: Jupyter(signal),
+    Dockstore: Dockstore(signal),
+    Martha: Martha(signal)
   }
 }
 
@@ -552,7 +544,7 @@ export const ajaxCaller = WrappedComponent => {
     }
 
     render() {
-      return h(WrappedComponent, { ...this.props, ajax: this.ajax })
+      return h(WrappedComponent, { ajax: this.ajax, ...this.props })
     }
 
     componentWillUnmount() {

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1,11 +1,11 @@
 import _ from 'lodash/fp'
+import { h } from 'react-hyperscript-helpers'
 import * as qs from 'qs'
 import { version } from 'src/data/clusters'
 import { getAuthToken } from 'src/libs/auth'
 import * as Config from 'src/libs/config'
 import * as Utils from 'src/libs/utils'
 import { Component } from 'src/libs/wrapped-components'
-import { h } from 'react-hyperscript-helpers'
 
 
 let mockResponse

--- a/src/libs/data-utils.js
+++ b/src/libs/data-utils.js
@@ -56,7 +56,7 @@ const getMaxDownloadCostNA = bytes => {
  * @param uri
  * @param googleProject
  */
-const UriViewer = ajaxCaller(class extends Component {
+const UriViewer = ajaxCaller(class UriViewer extends Component {
   async getMetadata() {
     const { googleProject, uri, ajax: { Buckets, Martha } } = this.props
     const isGsUri = isGs(uri)
@@ -219,7 +219,7 @@ export const renderDataCell = (data, namespace) => {
     renderCell(data)
 }
 
-export const ReferenceDataImporter = ajaxCaller(class extends Component {
+export const ReferenceDataImporter = ajaxCaller(class ReferenceDataImporter extends Component {
   render() {
     const { onDismiss, onSuccess, namespace, name, ajax: { Workspaces } } = this.props
     const { loading, selectedReference } = this.state
@@ -259,7 +259,7 @@ export const ReferenceDataImporter = ajaxCaller(class extends Component {
   }
 })
 
-export const ReferenceDataDeleter = ajaxCaller(class extends Component {
+export const ReferenceDataDeleter = ajaxCaller(class ReferenceDataDeleter extends Component {
   render() {
     const { onDismiss, onSuccess, namespace, name, referenceDataType, ajax: { Workspaces } } = this.props
     const { deleting } = this.state

--- a/src/libs/data-utils.js
+++ b/src/libs/data-utils.js
@@ -10,7 +10,7 @@ import Modal from 'src/components/Modal'
 import { TextCell } from 'src/components/table'
 import DownloadPrices from 'src/data/download-prices'
 import ReferenceData from 'src/data/reference-data'
-import { Buckets, Martha, Workspaces } from 'src/libs/ajax'
+import { ajaxCaller } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { reportError } from 'src/libs/error'
 import * as Utils from 'src/libs/utils'
@@ -56,9 +56,9 @@ const getMaxDownloadCostNA = bytes => {
  * @param uri
  * @param googleProject
  */
-class UriViewer extends Component {
+const UriViewer = ajaxCaller(class extends Component {
   async getMetadata() {
-    const { googleProject, uri } = this.props
+    const { googleProject, uri, ajax: { Buckets, Martha } } = this.props
     const isGsUri = isGs(uri)
     const [bucket, name] = isGsUri ? parseUri(uri) : []
 
@@ -204,7 +204,7 @@ class UriViewer extends Component {
       ])
     ])
   }
-}
+})
 
 export const renderDataCell = (data, namespace) => {
   const isUri = datum => isGs(datum) || _.startsWith('dos://', datum)
@@ -219,9 +219,9 @@ export const renderDataCell = (data, namespace) => {
     renderCell(data)
 }
 
-export class ReferenceDataImporter extends Component {
+export const ReferenceDataImporter = ajaxCaller(class extends Component {
   render() {
-    const { onDismiss, onSuccess, namespace, name } = this.props
+    const { onDismiss, onSuccess, namespace, name, ajax: { Workspaces } } = this.props
     const { loading, selectedReference } = this.state
 
     return h(Modal, {
@@ -257,11 +257,11 @@ export class ReferenceDataImporter extends Component {
       loading && spinnerOverlay
     ])
   }
-}
+})
 
-export class ReferenceDataDeleter extends Component {
+export const ReferenceDataDeleter = ajaxCaller(class extends Component {
   render() {
-    const { onDismiss, onSuccess, namespace, name, referenceDataType } = this.props
+    const { onDismiss, onSuccess, namespace, name, referenceDataType, ajax: { Workspaces } } = this.props
     const { deleting } = this.state
 
     return h(Modal, {
@@ -284,4 +284,4 @@ export class ReferenceDataDeleter extends Component {
       }, ['Delete'])
     }, [`Are you sure you want to delete ${referenceDataType}?`])
   }
-}
+})

--- a/src/libs/error.js
+++ b/src/libs/error.js
@@ -9,6 +9,8 @@ export const errorStore = Utils.atom([])
 const addError = item => errorStore.update(state => _.concat(state, [item]))
 
 export const reportError = async (title, obj) => {
+  if (obj instanceof DOMException && obj.name === 'AbortError') return
+
   if (obj instanceof Response && obj.status === 401 && await getUser().reloadAuthResponse().then(() => false).catch(() => true)) {
     addError({ title: 'Session timed out', error: 'You have been signed out due to inactivity', code: 'sessionTimeout' })
     signOut()

--- a/src/libs/error.js
+++ b/src/libs/error.js
@@ -9,8 +9,6 @@ export const errorStore = Utils.atom([])
 const addError = item => errorStore.update(state => _.concat(state, [item]))
 
 export const reportError = async (title, obj) => {
-  if (obj instanceof DOMException && obj.name === 'AbortError') return
-
   if (obj instanceof Response && obj.status === 401 && await getUser().reloadAuthResponse().then(() => false).catch(() => true)) {
     addError({ title: 'Session timed out', error: 'You have been signed out due to inactivity', code: 'sessionTimeout' })
     signOut()

--- a/src/pages/ImportData.js
+++ b/src/pages/ImportData.js
@@ -11,7 +11,7 @@ import { Component } from 'src/libs/wrapped-components'
 import { spinner } from 'src/components/icons'
 
 
-const Importer = ajaxCaller(class extends Component {
+const Importer = ajaxCaller(class Importer extends Component {
   render() {
     const { queryParams: { url, ad } } = this.props
     const { isImporting, selectedWorkspace } = this.state

--- a/src/pages/ImportData.js
+++ b/src/pages/ImportData.js
@@ -3,7 +3,7 @@ import { div, h } from 'react-hyperscript-helpers'
 import { buttonPrimary, pageColumn } from 'src/components/common'
 import { TopBar } from 'src/components/TopBar'
 import WorkspaceSelector from 'src/components/WorkspaceSelector'
-import { Workspaces } from 'src/libs/ajax'
+import { ajaxCaller } from 'src/libs/ajax'
 import { reportError } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
 import * as Utils from 'src/libs/utils'
@@ -11,7 +11,7 @@ import { Component } from 'src/libs/wrapped-components'
 import { spinner } from 'src/components/icons'
 
 
-class Importer extends Component {
+const Importer = ajaxCaller(class extends Component {
   render() {
     const { queryParams: { url, ad } } = this.props
     const { isImporting, selectedWorkspace } = this.state
@@ -46,7 +46,7 @@ class Importer extends Component {
   async import_() {
     this.setState({ isImporting: true })
     const { selectedWorkspace: { value: { namespace, name } } } = this.state
-    const { queryParams: { url, format } } = this.props
+    const { queryParams: { url, format }, ajax: { Workspaces } } = this.props
 
     try {
       await Utils.switchCase(format,
@@ -60,7 +60,7 @@ class Importer extends Component {
       this.setState({ isImporting: false })
     }
   }
-}
+})
 
 
 export const addNavPaths = () => {

--- a/src/pages/ImportTool.js
+++ b/src/pages/ImportTool.js
@@ -8,7 +8,7 @@ import { centeredSpinner, icon, spinner } from 'src/components/icons'
 import { TopBar } from 'src/components/TopBar'
 import WDLViewer from 'src/components/WDLViewer'
 import WorkspaceSelector from 'src/components/WorkspaceSelector'
-import { Dockstore, Workspaces } from 'src/libs/ajax'
+import { ajaxCaller } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { reportError } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
@@ -25,7 +25,7 @@ const mutabilityWarning = 'Please note: Dockstore cannot guarantee that the WDL 
 const wdlLoadError = 'Error loading WDL. Please verify the workflow path and version and ensure' +
   ' this workflow supports WDL.'
 
-class DockstoreImporter extends Component {
+const DockstoreImporter = ajaxCaller(class extends Component {
   render() {
     const { wdl, loadError } = this.state
 
@@ -37,6 +37,8 @@ class DockstoreImporter extends Component {
   }
 
   componentDidMount() {
+    const { ajax: { Workspaces } } = this.props
+
     this.loadWdl()
     Workspaces.list().then(
       workspaces => this.setState({ workspaces: writableWorkspacesOnly(workspaces) }),
@@ -51,7 +53,7 @@ class DockstoreImporter extends Component {
   }
 
   loadWdl() {
-    const { path, version } = this.props
+    const { path, version, ajax: { Dockstore } } = this.props
     Dockstore.getWdl(path, version).then(
       ({ descriptor }) => this.setState({ wdl: descriptor }),
       failure => this.setState({ loadError: failure })
@@ -120,7 +122,7 @@ class DockstoreImporter extends Component {
     this.setState({ isImporting: true })
 
     const { selectedWorkspace: { value: { namespace, name } } } = this.state
-    const { path, version } = this.props
+    const { path, version, ajax: { Workspaces } } = this.props
     const toolName = _.last(path.split('/'))
 
     const rawlsWorkspace = Workspaces.workspace(namespace, name)
@@ -150,7 +152,7 @@ class DockstoreImporter extends Component {
       h(ErrorView, { error: loadError })
     ])
   }
-}
+})
 
 
 class Importer extends Component {

--- a/src/pages/ImportTool.js
+++ b/src/pages/ImportTool.js
@@ -25,7 +25,7 @@ const mutabilityWarning = 'Please note: Dockstore cannot guarantee that the WDL 
 const wdlLoadError = 'Error loading WDL. Please verify the workflow path and version and ensure' +
   ' this workflow supports WDL.'
 
-const DockstoreImporter = ajaxCaller(class extends Component {
+const DockstoreImporter = ajaxCaller(class DockstoreImporter extends Component {
   render() {
     const { wdl, loadError } = this.state
 

--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -6,7 +6,7 @@ import { centeredSpinner, profilePic } from 'src/components/icons'
 import { textInput, validatedInput } from 'src/components/input'
 import { InfoBox } from 'src/components/PopupTrigger'
 import { TopBar } from 'src/components/TopBar'
-import { User } from 'src/libs/ajax'
+import { ajaxCaller } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import * as Nav from 'src/libs/nav'
 import * as Utils from 'src/libs/utils'
@@ -106,10 +106,11 @@ const profileKeys = [
 ]
 
 
-class Profile extends Component {
+const Profile = ajaxCaller(class extends Component {
   async refresh() {
     this.setState({ profileInfo: undefined, displayName: undefined, fractionCompleted: undefined, saving: false })
 
+    const { ajax: { User } } = this.props
     const { keyValuePairs } = await User.profile.get()
     const profileInfo = _.reduce(
       (accum, { key, value }) => _.assign(accum, { [key]: value === 'N/A' ? '' : value }),
@@ -282,6 +283,7 @@ class Profile extends Component {
 
   async save() {
     const { profileInfo } = this.state
+    const { ajax: { User } } = this.props
 
     this.setState({ saving: true })
     await User.profile.set(_.pickBy(_.identity, profileInfo))
@@ -291,7 +293,7 @@ class Profile extends Component {
   componentDidMount() {
     this.refresh()
   }
-}
+})
 
 
 export const addNavPaths = () => {

--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -106,7 +106,7 @@ const profileKeys = [
 ]
 
 
-const Profile = ajaxCaller(class extends Component {
+const Profile = ajaxCaller(class Profile extends Component {
   async refresh() {
     this.setState({ profileInfo: undefined, displayName: undefined, fractionCompleted: undefined, saving: false })
 

--- a/src/pages/Register.js
+++ b/src/pages/Register.js
@@ -4,7 +4,7 @@ import { buttonPrimary, buttonSecondary } from 'src/components/common'
 import { centeredSpinner, logo } from 'src/components/icons'
 import { textInput } from 'src/components/input'
 import planet from 'src/images/register-planet.svg'
-import { User } from 'src/libs/ajax'
+import { ajaxCaller } from 'src/libs/ajax'
 import { authStore, getBasicProfile, signOut } from 'src/libs/auth'
 import colors from 'src/libs/colors'
 import { reportError } from 'src/libs/error'
@@ -17,7 +17,7 @@ const constraints = {
   email: { presence: { allowEmpty: false } }
 }
 
-export default class Register extends Component {
+export default ajaxCaller(class Register extends Component {
   constructor(props) {
     super(props)
     const profile = getBasicProfile()
@@ -30,6 +30,7 @@ export default class Register extends Component {
   }
 
   async register() {
+    const { ajax: { User } } = this.props
     const { givenName, familyName, email } = this.state
     try {
       this.setState({ busy: true })
@@ -108,4 +109,4 @@ export default class Register extends Component {
       ])
     ])
   }
-}
+})

--- a/src/pages/groups/Group.js
+++ b/src/pages/groups/Group.js
@@ -8,7 +8,7 @@ import { textInput } from 'src/components/input'
 import Modal from 'src/components/Modal'
 import TooltipTrigger from 'src/components/TooltipTrigger'
 import { TopBar } from 'src/components/TopBar'
-import { Groups } from 'src/libs/ajax'
+import { ajaxCaller } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { reportError } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
@@ -34,7 +34,7 @@ const roleSelector = ({ role, updateState }) => h(Fragment, [
 ])
 
 
-class NewUserModal extends Component {
+const NewUserModal = ajaxCaller(class extends Component {
   constructor(props) {
     super(props)
     this.state = {
@@ -72,7 +72,7 @@ class NewUserModal extends Component {
   }
 
   async submit() {
-    const { groupName, onSuccess } = this.props
+    const { groupName, onSuccess, ajax: { Groups } } = this.props
     const { userEmail, role } = this.state
 
     try {
@@ -88,9 +88,9 @@ class NewUserModal extends Component {
       }
     }
   }
-}
+})
 
-class EditUserModal extends Component {
+const EditUserModal = ajaxCaller(class extends Component {
   constructor(props) {
     super(props)
     this.state = {
@@ -119,7 +119,7 @@ class EditUserModal extends Component {
   }
 
   async submit() {
-    const { groupName, user: { email }, onSuccess } = this.props
+    const { groupName, user: { email }, onSuccess, ajax: { Groups } } = this.props
     const { role } = this.state
 
     try {
@@ -131,7 +131,7 @@ class EditUserModal extends Component {
       reportError('Error updating user', error)
     }
   }
-}
+})
 
 const DeleteUserModal = pure(({ onDismiss, onSubmit, userEmail }) => {
   return h(Modal, {
@@ -183,7 +183,7 @@ const NewUserCard = pure(({ onClick }) => {
   ])
 })
 
-export class GroupDetails extends Component {
+export const GroupDetails = ajaxCaller(class extends Component {
   constructor(props) {
     super(props)
     this.state = {
@@ -198,11 +198,16 @@ export class GroupDetails extends Component {
   }
 
   async refresh() {
-    const { groupName } = this.props
+    const { groupName, ajax: { Groups } } = this.props
 
     try {
       this.setState({ loading: true, creatingNewUser: false, editingUser: false, deletingUser: false, updating: false })
-      const [membersEmails, adminsEmails] = await Promise.all([Groups.group(groupName).listMembers(), Groups.group(groupName).listAdmins()])
+
+      const [membersEmails, adminsEmails] = await Promise.all([
+        Groups.group(groupName).listMembers(),
+        Groups.group(groupName).listAdmins()
+      ])
+
       this.setState({
         members: _.sortBy(member => member.email.toUpperCase(), _.concat(
           _.map(adm => ({ email: adm, role: 'admin' }), adminsEmails),
@@ -223,7 +228,7 @@ export class GroupDetails extends Component {
 
   render() {
     const { members, adminCanEdit, loading, filter, creatingNewUser, editingUser, deletingUser, updating } = this.state
-    const { groupName } = this.props
+    const { groupName, ajax: { Groups } } = this.props
 
     return h(Fragment, [
       h(TopBar, { title: 'Groups', href: Nav.getLink('groups') }, [
@@ -290,7 +295,7 @@ export class GroupDetails extends Component {
       this.state)
     )
   }
-}
+})
 
 
 export const addNavPaths = () => {

--- a/src/pages/groups/Group.js
+++ b/src/pages/groups/Group.js
@@ -34,7 +34,7 @@ const roleSelector = ({ role, updateState }) => h(Fragment, [
 ])
 
 
-const NewUserModal = ajaxCaller(class extends Component {
+const NewUserModal = ajaxCaller(class NewUserModal extends Component {
   constructor(props) {
     super(props)
     this.state = {
@@ -90,7 +90,7 @@ const NewUserModal = ajaxCaller(class extends Component {
   }
 })
 
-const EditUserModal = ajaxCaller(class extends Component {
+const EditUserModal = ajaxCaller(class EditUserModal extends Component {
   constructor(props) {
     super(props)
     this.state = {
@@ -183,7 +183,7 @@ const NewUserCard = pure(({ onClick }) => {
   ])
 })
 
-export const GroupDetails = ajaxCaller(class extends Component {
+export const GroupDetails = ajaxCaller(class GroupDetails extends Component {
   constructor(props) {
     super(props)
     this.state = {

--- a/src/pages/groups/List.js
+++ b/src/pages/groups/List.js
@@ -27,7 +27,7 @@ const groupNameValidator = {
   }
 }
 
-const NewGroupModal = ajaxCaller(class extends Component {
+const NewGroupModal = ajaxCaller(class NewGroupModal extends Component {
   constructor(props) {
     super(props)
     this.state = {
@@ -130,7 +130,7 @@ const NewGroupCard = pure(({ onClick }) => {
   ])
 })
 
-export const GroupList = ajaxCaller(class extends Component {
+export const GroupList = ajaxCaller(class GroupList extends Component {
   constructor(props) {
     super(props)
     this.state = {

--- a/src/pages/groups/List.js
+++ b/src/pages/groups/List.js
@@ -7,7 +7,7 @@ import { icon } from 'src/components/icons'
 import { validatedInput } from 'src/components/input'
 import Modal from 'src/components/Modal'
 import { TopBar } from 'src/components/TopBar'
-import { Groups } from 'src/libs/ajax'
+import { ajaxCaller } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { reportError } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
@@ -27,7 +27,7 @@ const groupNameValidator = {
   }
 }
 
-class NewGroupModal extends Component {
+const NewGroupModal = ajaxCaller(class extends Component {
   constructor(props) {
     super(props)
     this.state = {
@@ -67,7 +67,7 @@ class NewGroupModal extends Component {
   }
 
   async submit() {
-    const { onSuccess } = this.props
+    const { onSuccess, ajax: { Groups } } = this.props
     const { groupName } = this.state
 
     try {
@@ -79,7 +79,7 @@ class NewGroupModal extends Component {
       reportError('Error creating group', error)
     }
   }
-}
+})
 
 const DeleteGroupModal = pure(({ groupName, onDismiss, onSubmit }) => {
   return h(Modal, {
@@ -130,7 +130,7 @@ const NewGroupCard = pure(({ onClick }) => {
   ])
 })
 
-export class GroupList extends Component {
+export const GroupList = ajaxCaller(class extends Component {
   constructor(props) {
     super(props)
     this.state = {
@@ -144,6 +144,8 @@ export class GroupList extends Component {
   }
 
   async refresh() {
+    const { ajax: { Groups } } = this.props
+
     try {
       this.setState({ isDataLoaded: false, creatingNewGroup: false, deletingGroup: false, updating: false })
       const groups = await Groups.list()
@@ -162,6 +164,7 @@ export class GroupList extends Component {
 
   render() {
     const { groups, isDataLoaded, filter, creatingNewGroup, deletingGroup, updating } = this.state
+    const { ajax: { Groups } } = this.props
 
     return h(Fragment, [
       h(TopBar, { title: 'Groups', href: Nav.getLink('groups') }, [
@@ -221,7 +224,7 @@ export class GroupList extends Component {
       this.state)
     )
   }
-}
+})
 
 
 export const addNavPaths = () => {

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -6,7 +6,7 @@ import { Clickable, search, spinnerOverlay } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import NewWorkspaceModal from 'src/components/NewWorkspaceModal'
 import { TopBar } from 'src/components/TopBar'
-import { Workspaces } from 'src/libs/ajax'
+import { ajaxCaller } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { reportError } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
@@ -134,7 +134,7 @@ const NewWorkspaceCard = pure(({ listView, onClick }) => {
   ])
 })
 
-export class WorkspaceList extends Component {
+export const WorkspaceList = ajaxCaller(class extends Component {
   constructor(props) {
     super(props)
     this.state = {
@@ -147,6 +147,7 @@ export class WorkspaceList extends Component {
   }
 
   async refresh() {
+    const { ajax: { Workspaces } } = this.props
     try {
       this.setState({ isDataLoaded: false })
       const workspaces = await Workspaces.list()
@@ -221,7 +222,7 @@ export class WorkspaceList extends Component {
       this.state)
     )
   }
-}
+})
 
 export const addNavPaths = () => {
   Nav.defPath('root', {

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -134,7 +134,7 @@ const NewWorkspaceCard = pure(({ listView, onClick }) => {
   ])
 })
 
-export const WorkspaceList = ajaxCaller(class extends Component {
+export const WorkspaceList = ajaxCaller(class WorkspaceList extends Component {
   constructor(props) {
     super(props)
     this.state = {

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -55,7 +55,7 @@ const InfoTile = ({ title, children }) => {
   ])
 }
 
-const EditWorkspaceModal = ajaxCaller(class extends Component {
+const EditWorkspaceModal = ajaxCaller(class EditWorkspaceModal extends Component {
   constructor(props) {
     super(props)
     this.state = {

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -6,7 +6,7 @@ import * as breadcrumbs from 'src/components/breadcrumbs'
 import { buttonPrimary, buttonSecondary, link, spinnerOverlay } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import Modal from 'src/components/Modal'
-import { ajaxCaller, Workspaces } from 'src/libs/ajax'
+import { ajaxCaller } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { reportError } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
@@ -55,7 +55,7 @@ const InfoTile = ({ title, children }) => {
   ])
 }
 
-class EditWorkspaceModal extends Component {
+const EditWorkspaceModal = ajaxCaller(class extends Component {
   constructor(props) {
     super(props)
     this.state = {
@@ -65,7 +65,7 @@ class EditWorkspaceModal extends Component {
   }
 
   async save() {
-    const { onSave, workspace: { workspace: { namespace, name } } } = this.props
+    const { onSave, workspace: { workspace: { namespace, name } }, ajax: { Workspaces } } = this.props
     const { description } = this.state
     try {
       this.setState({ saving: true })
@@ -102,7 +102,7 @@ class EditWorkspaceModal extends Component {
       saving && spinnerOverlay
     ])
   }
-}
+})
 
 export const WorkspaceDashboard = ajaxCaller(wrapWorkspace({
   breadcrumbs: () => breadcrumbs.commonPaths.workspaceList(),
@@ -119,12 +119,12 @@ class WorkspaceDashboardContent extends Component {
   }
 
   async componentDidMount() {
-    const { ajax, namespace, name, workspace: { accessLevel } } = this.props
+    const { ajax: { Workspaces }, namespace, name, workspace: { accessLevel } } = this.props
     try {
       const [submissions, estimate] = await Promise.all([
-        ajax.workspaces.workspace(namespace, name).listSubmissions(),
+        Workspaces.workspace(namespace, name).listSubmissions(),
         Utils.canWrite(accessLevel) ?
-          ajax.workspaces.workspace(namespace, name).storageCostEstimate() :
+          Workspaces.workspace(namespace, name).storageCostEstimate() :
           undefined
       ])
       this.setState({

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -6,7 +6,7 @@ import * as breadcrumbs from 'src/components/breadcrumbs'
 import { buttonPrimary, buttonSecondary, link, spinnerOverlay } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import Modal from 'src/components/Modal'
-import { Ajax, Workspaces } from 'src/libs/ajax'
+import { ajaxCaller, Workspaces } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { reportError } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
@@ -104,7 +104,7 @@ class EditWorkspaceModal extends Component {
   }
 }
 
-export const WorkspaceDashboard = wrapWorkspace({
+export const WorkspaceDashboard = ajaxCaller(wrapWorkspace({
   breadcrumbs: () => breadcrumbs.commonPaths.workspaceList(),
   activeTab: 'dashboard'
 },
@@ -116,13 +116,11 @@ class WorkspaceDashboardContent extends Component {
       storageCostEstimate: undefined,
       editingWorkspace: false
     }
-    this.controller = new window.AbortController()
   }
 
   async componentDidMount() {
-    const { namespace, name, workspace: { accessLevel } } = this.props
+    const { ajax, namespace, name, workspace: { accessLevel } } = this.props
     try {
-      const ajax = Ajax(this.controller)
       const [submissions, estimate] = await Promise.all([
         ajax.workspaces.workspace(namespace, name).listSubmissions(),
         Utils.canWrite(accessLevel) ?
@@ -136,10 +134,6 @@ class WorkspaceDashboardContent extends Component {
     } catch (error) {
       reportError('Error loading data', error)
     }
-  }
-
-  componentWillUnmount() {
-    this.controller.abort()
   }
 
   render() {
@@ -188,7 +182,7 @@ class WorkspaceDashboardContent extends Component {
       })
     ])
   }
-})
+}))
 
 export const addNavPaths = () => {
   Nav.defPath('workspace', {

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -7,7 +7,7 @@ import * as breadcrumbs from 'src/components/breadcrumbs'
 import { buttonPrimary, Clickable, linkButton, spinnerOverlay } from 'src/components/common'
 import { icon, spinner } from 'src/components/icons'
 import { ColumnSelector, FlexTable, GridTable, HeaderCell, paginator, Resizable, Sortable } from 'src/components/table'
-import { Workspaces } from 'src/libs/ajax'
+import { ajaxCaller } from 'src/libs/ajax'
 import * as auth from 'src/libs/auth'
 import colors from 'src/libs/colors'
 import * as Config from 'src/libs/config'
@@ -79,7 +79,7 @@ const saveScroll = _.throttle(100, (initialX, initialY) => {
   StateHistory.update({ initialX, initialY })
 })
 
-const WorkspaceData = wrapWorkspace({
+const WorkspaceData = ajaxCaller(wrapWorkspace({
   breadcrumbs: props => breadcrumbs.commonPaths.workspaceDashboard(props),
   title: 'Data', activeTab: 'data'
 },
@@ -102,7 +102,7 @@ class WorkspaceDataContent extends Component {
   }
 
   async loadMetadata() {
-    const { namespace, name } = this.props
+    const { namespace, name, ajax: { Workspaces } } = this.props
     try {
       const entityMetadata = await Workspaces.workspace(namespace, name).entityMetadata()
       this.setState({ entityMetadata })
@@ -112,7 +112,7 @@ class WorkspaceDataContent extends Component {
   }
 
   async loadData() {
-    const { namespace, name } = this.props
+    const { namespace, name, ajax: { Workspaces } } = this.props
     const { itemsPerPage, pageNumber, sort, selectedDataType, isDataModel } = this.state
 
     const getWorkspaceAttributes = async () => (await Workspaces.workspace(namespace, name).details()).workspace.attributes
@@ -497,7 +497,7 @@ class WorkspaceDataContent extends Component {
       this.loadData()
     }
   }
-})
+}))
 
 export const addNavPaths = () => {
   Nav.defPath('workspace-data', {

--- a/src/pages/workspaces/workspace/JobHistory.js
+++ b/src/pages/workspaces/workspace/JobHistory.js
@@ -8,7 +8,7 @@ import { icon } from 'src/components/icons'
 import Modal from 'src/components/Modal'
 import PopupTrigger from 'src/components/PopupTrigger'
 import { FlexTable, HeaderCell, TextCell } from 'src/components/table'
-import { Workspaces } from 'src/libs/ajax'
+import { ajaxCaller } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import * as Config from 'src/libs/config'
 import { reportError } from 'src/libs/error'
@@ -95,7 +95,7 @@ const statusCell = workflowStatuses => {
 const animationLengthMillis = 1000
 
 
-const JobHistory = wrapWorkspace({
+const JobHistory = ajaxCaller(wrapWorkspace({
   breadcrumbs: props => breadcrumbs.commonPaths.workspaceDashboard(props),
   title: 'Job History', activeTab: 'job history'
 },
@@ -111,7 +111,7 @@ class JobHistoryContent extends Component {
   }
 
   async refresh() {
-    const { namespace, name } = this.props
+    const { namespace, name, ajax: { Workspaces } } = this.props
 
     try {
       this.setState({ loading: true })
@@ -137,7 +137,7 @@ class JobHistoryContent extends Component {
   }
 
   render() {
-    const { namespace, name } = this.props
+    const { namespace, name, ajax: { Workspaces } } = this.props
     const { submissions, loading, aborting, newSubmissionId, highlightNewSubmission, firecloudRoot } = this.state
 
     return div({ style: styles.submissionsTable }, [
@@ -258,7 +258,7 @@ class JobHistoryContent extends Component {
       clearTimeout(this.scheduledRefresh)
     }
   }
-})
+}))
 
 
 export const addNavPaths = () => {

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp'
-import { Component, createRef, Fragment } from 'react'
+import { createRef, Fragment } from 'react'
 import Dropzone from 'react-dropzone'
 import { a, div, h } from 'react-hyperscript-helpers'
 import * as breadcrumbs from 'src/components/breadcrumbs'
@@ -8,12 +8,13 @@ import { icon } from 'src/components/icons'
 import { NotebookCreator, NotebookDeleter, NotebookDuplicator } from 'src/components/notebook-utils'
 import PopupTrigger from 'src/components/PopupTrigger'
 import TooltipTrigger from 'src/components/TooltipTrigger'
-import { Buckets } from 'src/libs/ajax'
+import { ajaxCaller } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { reportError } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
 import * as StateHistory from 'src/libs/state-history'
 import * as Style from 'src/libs/style'
+import { Component } from 'src/libs/wrapped-components'
 import * as Utils from 'src/libs/utils'
 import { wrapWorkspace } from 'src/pages/workspaces/workspace/WorkspaceContainer'
 
@@ -110,7 +111,7 @@ class NotebookCard extends Component {
   }
 }
 
-const WorkspaceNotebooks = wrapWorkspace({
+const WorkspaceNotebooks = ajaxCaller(wrapWorkspace({
   breadcrumbs: props => breadcrumbs.commonPaths.workspaceDashboard(props),
   title: 'Notebooks', activeTab: 'notebooks'
 },
@@ -132,7 +133,7 @@ class NotebooksContent extends Component {
   }
 
   async refresh() {
-    const { namespace, workspace: { workspace: { bucketName } } } = this.props
+    const { namespace, workspace: { workspace: { bucketName } }, ajax: { Buckets } } = this.props
 
     try {
       this.setState({ launching: false, loading: true })
@@ -146,7 +147,7 @@ class NotebooksContent extends Component {
   }
 
   async uploadFiles(files) {
-    const { namespace, workspace: { workspace: { bucketName } } } = this.props
+    const { namespace, workspace: { workspace: { bucketName } }, ajax: { Buckets } } = this.props
     const existingNames = this.getExistingNames()
     try {
       this.setState({ saving: true })
@@ -322,7 +323,7 @@ class NotebooksContent extends Component {
       this.state)
     )
   }
-})
+}))
 
 export const addNavPaths = () => {
   Nav.defPath('workspace-notebooks', {

--- a/src/pages/workspaces/workspace/ShareWorkspaceModal.js
+++ b/src/pages/workspaces/workspace/ShareWorkspaceModal.js
@@ -6,7 +6,7 @@ import { centeredSpinner, icon } from 'src/components/icons'
 import { AutocompleteSearch } from 'src/components/input'
 import Modal from 'src/components/Modal'
 import TooltipTrigger from 'src/components/TooltipTrigger'
-import { Groups, Workspaces } from 'src/libs/ajax'
+import { ajaxCaller } from 'src/libs/ajax'
 import { getBasicProfile } from 'src/libs/auth'
 import colors from 'src/libs/colors'
 import { reportError } from 'src/libs/error'
@@ -48,7 +48,7 @@ const styles = {
 }
 
 
-export default class ShareWorkspaceModal extends Component {
+export default ajaxCaller(class ShareWorkspaceModal extends Component {
   constructor(props) {
     super(props)
     this.state = {
@@ -169,7 +169,7 @@ export default class ShareWorkspaceModal extends Component {
   }
 
   async componentDidMount() {
-    const { namespace, name, onDismiss } = this.props
+    const { namespace, name, onDismiss, ajax: { Workspaces, Groups } } = this.props
 
     try {
       const [{ acl }, shareSuggestions, groups] = await Promise.all([
@@ -198,7 +198,7 @@ export default class ShareWorkspaceModal extends Component {
   }
 
   async save() {
-    const { namespace, name, onDismiss } = this.props
+    const { namespace, name, onDismiss, ajax: { Workspaces } } = this.props
     const { acl, originalAcl } = this.state
 
     const aclEmails = _.map('email', acl)
@@ -224,4 +224,4 @@ export default class ShareWorkspaceModal extends Component {
       this.setState({ updateError: await error.text(), working: false })
     }
   }
-}
+})

--- a/src/pages/workspaces/workspace/Tools.js
+++ b/src/pages/workspaces/workspace/Tools.js
@@ -3,7 +3,7 @@ import { a, div, h } from 'react-hyperscript-helpers'
 import { pure } from 'recompose'
 import * as breadcrumbs from 'src/components/breadcrumbs'
 import { spinnerOverlay } from 'src/components/common'
-import { Workspaces } from 'src/libs/ajax'
+import { ajaxCaller } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { reportError } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
@@ -42,7 +42,7 @@ const ToolCard = pure(({ name, namespace, config }) => {
   ])
 })
 
-const WorkspaceTools = wrapWorkspace({
+const WorkspaceTools = ajaxCaller(wrapWorkspace({
   breadcrumbs: props => breadcrumbs.commonPaths.workspaceDashboard(props),
   title: 'Tools', activeTab: 'tools'
 },
@@ -53,7 +53,7 @@ class ToolsContent extends Component {
   }
 
   async refresh() {
-    const { namespace, name } = this.props
+    const { namespace, name, ajax: { Workspaces } } = this.props
 
     try {
       this.setState({ loading: true })
@@ -85,7 +85,7 @@ class ToolsContent extends Component {
   componentDidUpdate() {
     StateHistory.update(_.pick(['configs'], this.state))
   }
-})
+}))
 
 export const addNavPaths = () => {
   Nav.defPath('workspace-tools', {

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -297,14 +297,7 @@ export const wrapWorkspace = ({ breadcrumbs, activeTab, title }, content) => {
         const workspace = await Workspaces.workspace(namespace, name).details()
         this.setState({ workspace })
       } catch (error) {
-        let errorText = 'Unknown'
-        try {
-          errorText = await error.text()
-        } catch (error2) {
-          // ignore, we're too deep in error territory
-        } finally {
-          this.setState({ workspaceError: error, errorText })
-        }
+        this.setState({ workspaceError: error, errorText: await error.text().catch(() => 'Unknown') })
       }
     }
   })

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -112,7 +112,7 @@ class WorkspaceTabs extends PureComponent {
 }
 
 
-const DeleteWorkspaceModal = ajaxCaller(class extends Component {
+const DeleteWorkspaceModal = ajaxCaller(class DeleteWorkspaceModal extends Component {
   constructor(props) {
     super(props)
     this.state = {

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -9,7 +9,7 @@ import Modal from 'src/components/Modal'
 import NewWorkspaceModal from 'src/components/NewWorkspaceModal'
 import PopupTrigger from 'src/components/PopupTrigger'
 import { TopBar } from 'src/components/TopBar'
-import { Jupyter, Workspaces } from 'src/libs/ajax'
+import { ajaxCaller } from 'src/libs/ajax'
 import { getBasicProfile } from 'src/libs/auth'
 import colors from 'src/libs/colors'
 import { reportError } from 'src/libs/error'
@@ -112,7 +112,7 @@ class WorkspaceTabs extends PureComponent {
 }
 
 
-class DeleteWorkspaceModal extends Component {
+const DeleteWorkspaceModal = ajaxCaller(class extends Component {
   constructor(props) {
     super(props)
     this.state = {
@@ -121,7 +121,7 @@ class DeleteWorkspaceModal extends Component {
   }
 
   async deleteWorkspace() {
-    const { workspace: { workspace: { namespace, name } } } = this.props
+    const { workspace: { workspace: { namespace, name } }, ajax: { Workspaces } } = this.props
     try {
       this.setState({ deleting: true })
       await Workspaces.workspace(namespace, name).delete()
@@ -154,7 +154,7 @@ class DeleteWorkspaceModal extends Component {
       deleting && spinnerOverlay
     ])
   }
-}
+})
 
 
 class WorkspaceContainer extends Component {
@@ -220,7 +220,7 @@ class WorkspaceContainer extends Component {
 
 
 export const wrapWorkspace = ({ breadcrumbs, activeTab, title }, content) => {
-  return class WorkspaceContainerWrapper extends Component {
+  return ajaxCaller(class WorkspaceContainerWrapper extends Component {
     constructor(props) {
       super(props)
       this.child = createRef()
@@ -282,7 +282,7 @@ export const wrapWorkspace = ({ breadcrumbs, activeTab, title }, content) => {
     }
 
     async refreshClusters() {
-      const { namespace } = this.props
+      const { namespace, ajax: { Jupyter } } = this.props
       try {
         const clusters = _.filter({ googleProject: namespace, creator: getBasicProfile().getEmail() }, await Jupyter.clustersList())
         this.setState({ clusters })
@@ -292,13 +292,20 @@ export const wrapWorkspace = ({ breadcrumbs, activeTab, title }, content) => {
     }
 
     async refresh() {
-      const { namespace, name } = this.props
+      const { namespace, name, ajax: { Workspaces } } = this.props
       try {
         const workspace = await Workspaces.workspace(namespace, name).details()
         this.setState({ workspace })
       } catch (error) {
-        this.setState({ workspaceError: error, errorText: await error.text() })
+        let errorText = 'Unknown'
+        try {
+          errorText = await error.text()
+        } catch (error2) {
+          // ignore, we're too deep in error territory
+        } finally {
+          this.setState({ workspaceError: error, errorText })
+        }
       }
     }
-  }
+  })
 }

--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -3,7 +3,7 @@ import { Fragment } from 'react'
 import { div, h, iframe } from 'react-hyperscript-helpers'
 import * as breadcrumbs from 'src/components/breadcrumbs'
 import { icon, spinner } from 'src/components/icons'
-import { Jupyter } from 'src/libs/ajax'
+import { ajaxCaller } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { reportError } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
@@ -34,7 +34,7 @@ const styles = {
 }
 
 
-const NotebookLauncher = wrapWorkspace({
+const NotebookLauncher = ajaxCaller(wrapWorkspace({
   breadcrumbs: props => breadcrumbs.commonPaths.workspaceDashboard(props),
   title: ({ notebookName }) => `Notebooks - ${notebookName}`,
   activeTab: 'notebooks'
@@ -80,7 +80,7 @@ class NotebookLauncherContent extends Component {
   }
 
   async startCluster() {
-    const { refreshClusters } = this.props
+    const { refreshClusters, ajax: { Jupyter } } = this.props
 
     while (this.mounted) {
       await refreshClusters()
@@ -106,7 +106,7 @@ class NotebookLauncherContent extends Component {
   }
 
   async localizeNotebook(clusterName) {
-    const { namespace, name: workspaceName, notebookName, workspace: { workspace: { bucketName } } } = this.props
+    const { namespace, name: workspaceName, notebookName, workspace: { workspace: { bucketName } }, ajax: { Jupyter } } = this.props
 
     while (this.mounted) {
       try {
@@ -162,7 +162,7 @@ class NotebookLauncherContent extends Component {
       ])
     ])
   }
-})
+}))
 
 
 export const addNavPaths = () => {

--- a/src/pages/workspaces/workspace/notebooks/TerminalLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/TerminalLauncher.js
@@ -3,14 +3,14 @@ import { findDOMNode } from 'react-dom'
 import { iframe } from 'react-hyperscript-helpers'
 import * as breadcrumbs from 'src/components/breadcrumbs'
 import { centeredSpinner } from 'src/components/icons'
-import { Jupyter } from 'src/libs/ajax'
+import { ajaxCaller } from 'src/libs/ajax'
 import { reportError } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
 import { Component } from 'src/libs/wrapped-components'
 import { wrapWorkspace } from 'src/pages/workspaces/workspace/WorkspaceContainer'
 
 
-const TerminalLauncher = wrapWorkspace({
+const TerminalLauncher = ajaxCaller(wrapWorkspace({
   breadcrumbs: props => breadcrumbs.commonPaths.workspaceDashboard(props),
   title: () => `Terminal`,
   activeTab: 'notebooks'
@@ -37,7 +37,7 @@ class TerminalLauncherContent extends Component {
   }
 
   async refreshCookie(clusterName) {
-    const { namespace } = this.props
+    const { namespace, ajax: { Jupyter } } = this.props
 
     this.scheduledRefresh = setTimeout(() => this.refreshCookie(clusterName), 1000 * 60 * 20)
 
@@ -72,7 +72,7 @@ class TerminalLauncherContent extends Component {
       }) :
       centeredSpinner()
   }
-})
+}))
 
 
 export const addNavPaths = () => {

--- a/src/pages/workspaces/workspace/tools/LaunchAnalysisModal.js
+++ b/src/pages/workspaces/workspace/tools/LaunchAnalysisModal.js
@@ -7,14 +7,14 @@ import { centeredSpinner } from 'src/components/icons'
 import Modal from 'src/components/Modal'
 import TabBar from 'src/components/TabBar'
 import { GridTable, HeaderCell, TextCell } from 'src/components/table'
-import { Workspaces } from 'src/libs/ajax'
+import { ajaxCaller } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { renderDataCell } from 'src/libs/data-utils'
 import * as Utils from 'src/libs/utils'
 import { Component } from 'src/libs/wrapped-components'
 
 
-export default class LaunchAnalysisModal extends Component {
+export default ajaxCaller(class LaunchAnalysisModal extends Component {
   constructor(props) {
     super(props)
 
@@ -61,7 +61,7 @@ export default class LaunchAnalysisModal extends Component {
   }
 
   componentDidMount() {
-    const { workspaceId: { namespace, name } } = this.props
+    const { workspaceId: { namespace, name }, ajax: { Workspaces } } = this.props
     const { entityType } = this.state
 
     if (_.isUndefined(entityType)) {
@@ -76,7 +76,7 @@ export default class LaunchAnalysisModal extends Component {
   }
 
   loadEntitiesOfType(type) {
-    const { workspaceId: { namespace, name } } = this.props
+    const { workspaceId: { namespace, name }, ajax: { Workspaces } } = this.props
 
     Workspaces.workspace(namespace, name).entitiesOfType(type).then(
       entities => this.setState({ entities, loadingNew: false }),
@@ -154,7 +154,8 @@ export default class LaunchAnalysisModal extends Component {
     const {
       workspaceId: { namespace, name },
       config: { namespace: configNamespace, name: configName, rootEntityType },
-      onSuccess
+      onSuccess,
+      ajax: { Workspaces }
     } = this.props
 
     const { selectedEntity, entityType } = this.state
@@ -173,4 +174,4 @@ export default class LaunchAnalysisModal extends Component {
       this.setState({ launchError: JSON.parse(error).message, launching: false })
     }
   }
-}
+})

--- a/src/pages/workspaces/workspace/tools/WorkflowView.js
+++ b/src/pages/workspaces/workspace/tools/WorkflowView.js
@@ -12,7 +12,7 @@ import TabBar from 'src/components/TabBar'
 import { FlexTable, HeaderCell, TextCell } from 'src/components/table'
 import TooltipTrigger from 'src/components/TooltipTrigger'
 import WDLViewer from 'src/components/WDLViewer'
-import { Dockstore, Methods, Workspaces } from 'src/libs/ajax'
+import { ajaxCaller } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { reportError } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
@@ -130,7 +130,7 @@ const WorkflowIOTable = ({ which, inputsOutputs, config, errors, onChange, sugge
   ])
 }
 
-const WorkflowView = wrapWorkspace({
+const WorkflowView = ajaxCaller(wrapWorkspace({
   breadcrumbs: props => breadcrumbs.commonPaths.workspaceTab(props, 'tools'),
   title: ({ workflowName }) => workflowName, activeTab: 'tools'
 },
@@ -178,7 +178,12 @@ class WorkflowViewContent extends Component {
   }
 
   async componentDidMount() {
-    const { namespace, name, workspace: { workspace: { attributes } }, workflowNamespace, workflowName } = this.props
+    const {
+      namespace, name, workflowNamespace, workflowName,
+      workspace: { workspace: { attributes } },
+      ajax: { Workspaces, Methods }
+    } = this.props
+
     try {
       const ws = Workspaces.workspace(namespace, name)
 
@@ -354,6 +359,7 @@ class WorkflowViewContent extends Component {
 
   async fetchWDL() {
     const { methodRepoMethod: { sourceRepo, methodNamespace, methodName, methodVersion, methodPath } } = this.state.savedConfig
+    const { ajax: { Dockstore, Methods } } = this.props
 
     this.setState({ loadedWdl: true })
     try {
@@ -374,7 +380,7 @@ class WorkflowViewContent extends Component {
   }
 
   async save() {
-    const { namespace, name, workflowNamespace, workflowName } = this.props
+    const { namespace, name, workflowNamespace, workflowName, ajax: { Workspaces } } = this.props
     const { modifiedConfig, inputsOutputs } = this.state
 
     this.setState({ saving: true })
@@ -402,7 +408,7 @@ class WorkflowViewContent extends Component {
 
     this.setState({ saved: false, modifiedConfig: savedConfig })
   }
-})
+}))
 
 
 export const addNavPaths = () => {


### PR DESCRIPTION
Fixes #496 

Approach: AbortController is a relatively new thing but seems to be well supported. You construct one, then pass its `signal` member to any `fetch`, and then calling `abort` aborts all fetches. In Chrome at least, this results in a `DOMException` with name `AbortError` being thrown.

I created a wrapper utility in `ajax.js` that gives the component an `ajax` prop, with the familiar Ajax objects (Workspaces, Jupyter, etc.) as members. Going through this object will cause the calls to cancel if the component is unmounted.

If you want to make Ajax calls from outside of a component, you can construct an `Ajax` object yourself, with your own `AbortController` or without. See `auth.js` for an example.

Edit: Thanks to Brett's suggestion on error catching, this also fixes the "cannot call setState on an unmounted component" issue!

This PR does not address #406, and I have not checked whether or not it addresses #476.