### PR TITLE
Isaac adds check for Data model

### DIFF
--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -126,7 +126,7 @@ class WorkspaceDataContent extends Component {
               .paginatedEntitiesOfType(selectedDataType, {
                 page: pageNumber, pageSize: itemsPerPage, sortField: sort.field, sortDirection: sort.direction
               }) :
-            Promise.resolve()
+            undefined
         ])
 
         this.setState(_.merge(

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -109,7 +109,7 @@ class WorkspaceDataContent extends Component {
 
   async loadData() {
     const { namespace, name } = this.props
-    const { itemsPerPage, pageNumber, sort, selectedDataType } = this.state
+    const { itemsPerPage, pageNumber, sort, selectedDataType, isDataModel } = this.state
 
     const getWorkspaceAttributes = async () => (await Workspaces.workspace(namespace, name).details()).workspace.attributes
 
@@ -119,15 +119,20 @@ class WorkspaceDataContent extends Component {
       try {
         this.setState({ loading: true, refreshRequested: false })
 
-        const [workspaceAttributes, { results, resultMetadata: { unfilteredCount } }] = await Promise.all([
+        const [workspaceAttributes, entities] = await Promise.all([
           getWorkspaceAttributes(),
-          Workspaces.workspace(namespace, name)
-            .paginatedEntitiesOfType(selectedDataType, {
-              page: pageNumber, pageSize: itemsPerPage, sortField: sort.field, sortDirection: sort.direction
-            })
+          isDataModel ?
+            Workspaces.workspace(namespace, name)
+              .paginatedEntitiesOfType(selectedDataType, {
+                page: pageNumber, pageSize: itemsPerPage, sortField: sort.field, sortDirection: sort.direction
+              }) :
+            Promise.resolve()
         ])
 
-        this.setState({ entities: results, totalRowCount: unfilteredCount, workspaceAttributes })
+        this.setState(_.merge(
+          isDataModel && { entities: entities.results, totalRowCount: entities.resultMetadata.unfilteredCount },
+          { workspaceAttributes }
+        ))
       } catch (error) {
         reportError('Error loading workspace data', error)
       } finally {
@@ -179,7 +184,7 @@ class WorkspaceDataContent extends Component {
               onClick: () => {
                 this.setState(selectedDataType === type ?
                   { refreshRequested: true } :
-                  { selectedDataType: type, pageNumber: 1, sort: initialSort, entities: undefined }
+                  { selectedDataType: type, pageNumber: 1, sort: initialSort, entities: undefined, isDataModel: true }
                 )
               }
             }, [`${type} (${typeDetails.count})`])
@@ -211,7 +216,7 @@ class WorkspaceDataContent extends Component {
             return h(DataTypeButton, {
               key: type,
               selected: selectedDataType === type,
-              onClick: () => this.setState({ selectedDataType: type })
+              onClick: () => this.setState({ selectedDataType: type, isDataModel: false })
             }, [
               div({ style: { display: 'flex', justifyContent: 'space-between' } }, [
                 type,
@@ -231,7 +236,7 @@ class WorkspaceDataContent extends Component {
             onClick: () => {
               this.setState(selectedDataType === globalVariables ?
                 { refreshRequested: true } :
-                { selectedDataType: globalVariables }
+                { selectedDataType: globalVariables, isDataModel: false }
               )
             }
           }, ['Global Variables'])


### PR DESCRIPTION
Fixes #543 

If the user selects a data type that is in the data model, then it still calls the AJAX `paginatedEntitiesOfType` call. If it's a global variable or reference data, then it doesn't call it.

Co-Authored-By: @zarsky-broad 