### PR TITLE
Update sam API endpoint to register user and get user info

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -102,11 +102,11 @@ export const User = {
   }, namespace => namespace, 1000 * 60 * 30),
 
   getStatus: async () => {
-    return fetchSam('register/user', authOpts())
+    return fetchSam('register/user/v2/self/info', authOpts())
   },
 
   create: async () => {
-    const res = await fetchSam('register/user', _.merge(authOpts(), { method: 'POST' }))
+    const res = await fetchSam('register/user/v2/self', _.merge(authOpts(), { method: 'POST' }))
     return res.json()
   },
 

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -59,7 +59,7 @@ authStore.subscribe(async (state, oldState) => {
       } else if (!response.ok) {
         throw response
       } else {
-        return response.json().then(({ enabled: { ldap } }) => ldap ? 'registered' : 'disabled')
+        return response.json().then(({ enabled }) => enabled ? 'registered' : 'disabled')
       }
     }).then(registrationStatus => {
       authStore.update(state => ({ ...state, registrationStatus }))


### PR DESCRIPTION
Fixes #500 

SAM has a new API which makes it faster to check if a user is registered and to create a user.