### PR TITLE
group already exists error is realtime

### DIFF
--- a/src/pages/groups/List.js
+++ b/src/pages/groups/List.js
@@ -169,7 +169,6 @@ export const GroupList = ajaxCaller(class GroupList extends Component {
   render() {
     const { groups, isDataLoaded, filter, creatingNewGroup, deletingGroup, updating } = this.state
     const { ajax: { Groups } } = this.props
-    
     return h(Fragment, [
       h(TopBar, { title: 'Groups', href: Nav.getLink('groups') }, [
         search({

--- a/src/pages/groups/List.js
+++ b/src/pages/groups/List.js
@@ -19,13 +19,17 @@ import { styles } from 'src/pages/groups/common'
 import { validate } from 'validate.js'
 
 
-const groupNameValidator = {
+const groupNameValidator = existing => ({
   presence: { allowEmpty: false },
   format: {
     pattern: /[A-Za-z0-9_-]*$/,
     message: 'can only contain letters, numbers, underscores, and dashes'
+  },
+  exclusion: {
+    within: existing,
+    message: 'already exists'
   }
-}
+})
 
 class NewGroupModal extends Component {
   constructor(props) {
@@ -37,10 +41,10 @@ class NewGroupModal extends Component {
   }
 
   render() {
-    const { onDismiss } = this.props
+    const { onDismiss, existingGroups } = this.props
     const { groupName, groupNameTouched, submitting } = this.state
 
-    const errors = validate({ groupName }, { groupName: groupNameValidator })
+    const errors = validate({ groupName }, { groupName: groupNameValidator(existingGroups) })
 
     return h(Modal, {
       onDismiss,
@@ -162,7 +166,6 @@ export class GroupList extends Component {
 
   render() {
     const { groups, isDataLoaded, filter, creatingNewGroup, deletingGroup, updating } = this.state
-
     return h(Fragment, [
       h(TopBar, { title: 'Groups', href: Nav.getLink('groups') }, [
         search({
@@ -194,6 +197,7 @@ export class GroupList extends Component {
         !isDataLoaded && spinnerOverlay
       ]),
       creatingNewGroup && h(NewGroupModal, {
+        existingGroups: _.map('groupName', groups),
         onDismiss: () => this.setState({ creatingNewGroup: false }),
         onSuccess: () => this.refresh()
       }),


### PR DESCRIPTION
Changed to mimic Notebooks real-time name checking to behave like this when you type an already existing name and prevents the user from creating the group:

<img width="1650" alt="screen shot 2018-08-31 at 12 09 20 pm" src="https://user-images.githubusercontent.com/42386483/44923624-cb824c80-ad16-11e8-99f5-96debd4a8189.png">

