### PR TITLE
fix workflow json upload with unpopulated fields

### DIFF
--- a/src/pages/workspaces/workspace/tools/WorkflowView.js
+++ b/src/pages/workspaces/workspace/tools/WorkflowView.js
@@ -296,8 +296,8 @@ class WorkflowViewContent extends Component {
     try {
       const text = await Utils.readFileAsText(file)
       const updates = JSON.parse(text)
-      this.setState(({ modifiedConfig }) => {
-        const existing = _.keys(modifiedConfig[key])
+      this.setState(({ modifiedConfig, inputsOutputs }) => {
+        const existing = _.map('name', inputsOutputs[key])
         return {
           modifiedConfig: _.update(key, _.assign(_, _.pick(existing, updates)), modifiedConfig)
         }


### PR DESCRIPTION
The issue here is that we were looking at the config keys to decide which fields to accept. However, after a fresh import the config is empty. The solution is to use the original IO definitions instead.

Fixes #586 