### PR TITLE
deactivated launch with instructions [risk: low]

### DIFF
--- a/src/pages/workspaces/workspace/tools/LaunchAnalysisModal.js
+++ b/src/pages/workspaces/workspace/tools/LaunchAnalysisModal.js
@@ -23,7 +23,7 @@ export default ajaxCaller(class LaunchAnalysisModal extends Component {
 
   render() {
     const { onDismiss } = this.props
-    const { entityType, entityMetadata, entities, attributeFailure, entityFailure, filterText, launching } = this.state
+    const { entityType, entityMetadata, entities, attributeFailure, entityFailure, filterText, launching, selectedEntity } = this.state
     const { attributeNames } = entityMetadata ? entityMetadata[entityType] : {}
 
     return h(Modal, _.isUndefined(entityType) ? {
@@ -49,7 +49,8 @@ export default ajaxCaller(class LaunchAnalysisModal extends Component {
       width: 'calc(100% - 2rem)',
       okButton: buttonPrimary({
         onClick: () => this.launch(),
-        disabled: launching
+        disabled: launching || !selectedEntity,
+        tooltip: !selectedEntity && 'Please select an entity'
       }, [launching ? 'Launching...' : 'Launch'])
     }, [
       Utils.cond(


### PR DESCRIPTION
Does not allow the user to launch an analysis without first selecting a sample/entity to run on. Upon hover, also gives instructions to user to first select an entity. 

<img width="1563" alt="screen shot 2018-09-04 at 4 23 57 pm" src="https://user-images.githubusercontent.com/42386483/45055865-22618c00-b05f-11e8-87a5-66234c759933.png">
