### PR TITLE
deactivate launch analysis button with any i/o errors [risk: low]

### DIFF
--- a/src/pages/workspaces/workspace/tools/WorkflowView.js
+++ b/src/pages/workspaces/workspace/tools/WorkflowView.js
@@ -223,7 +223,7 @@ class WorkflowViewContent extends Component {
 
   renderSummary(invalidIO) {
     const { workspace: { canCompute } } = this.props
-    const { modifiedConfig, savedConfig, entityMetadata, saving, saved, activeTab } = this.state
+    const { modifiedConfig, savedConfig, entityMetadata, saving, saved, activeTab, errors } = this.state
     const { name, methodRepoMethod: { methodPath, methodVersion }, rootEntityType } = modifiedConfig
     const modified = !_.isEqual(modifiedConfig, savedConfig)
 
@@ -231,6 +231,10 @@ class WorkflowViewContent extends Component {
       [invalidIO.inputs || invalidIO.outputs, () => 'Add your inputs and outputs to Launch Analysis'],
       [saving || modified, () => 'Save or cancel to Launch Analysis']
     )
+
+    const inputErrors = Object.keys(errors.inputs).length !== 0
+    const outputErrors = Object.keys(errors.outputs).length !== 0
+
     return div({ style: { backgroundColor: colors.blue[5], position: 'relative' } }, [
       div({ style: { display: 'flex', padding: `1.5rem ${sideMargin} 0`, minHeight: 120 } }, [
         div({ style: { flex: '1', lineHeight: '1.5rem' } }, [
@@ -254,8 +258,9 @@ class WorkflowViewContent extends Component {
         ]),
         div({ style: { flex: 'none', display: 'flex', flexDirection: 'column', alignItems: 'flex-end' } }, [
           buttonPrimary({
-            disabled: !canCompute || !!noLaunchReason,
-            tooltip: !canCompute ? 'You do not have access to run analyses on this workspace.' : undefined,
+            disabled: !canCompute || !!noLaunchReason || inputErrors || outputErrors,
+            tooltip: !canCompute ? 'You do not have access to run analyses on this workspace.' : undefined ||
+            inputErrors || outputErrors ? 'One or more of your inputs/outputs are invalid' : undefined,
             onClick: () => this.setState({ launching: true })
           }, ['Launch analysis']),
           canCompute && noLaunchReason && div({


### PR DESCRIPTION
Deactivates launch analysis button with any invalid input/outputs. Invalid inputs and outputs were defined by having any errors (red ! icon). Tooltip also added prompting user to check their inputs and outputs where they can find the specific error. Launch analysis only active when no errors exist. 

Looking for feedback particularly on the tooltip message and if this is the desired behavior!

Deactivated launch button on mouseover:
<img width="575" alt="screen shot 2018-09-05 at 11 37 40 am" src="https://user-images.githubusercontent.com/42386483/45104447-21346b80-b100-11e8-9ddf-a9352d5152f2.png">


**Examples with a variety of errors:** 
Missing inputs: https://github.com/DataBiosphere/saturn-ui/issues/605 
<img width="794" alt="screen shot 2018-09-05 at 11 36 54 am" src="https://user-images.githubusercontent.com/42386483/45104392-04983380-b100-11e8-86d1-7b8841af329c.png">

Invalid inputs: (this issue)
<img width="917" alt="screen shot 2018-09-05 at 11 35 06 am" src="https://user-images.githubusercontent.com/42386483/45104292-c864d300-b0ff-11e8-9d8e-c49a5fc404d2.png">

Missing data model & using this.x: https://github.com/DataBiosphere/saturn-ui/issues/604
<img width="618" alt="screen shot 2018-09-05 at 11 39 10 am" src="https://user-images.githubusercontent.com/42386483/45104554-5476fa80-b100-11e8-8297-f4070c8ed6ca.png">

