### PR TITLE
Tools list view

### DIFF
--- a/src/pages/workspaces/workspace/Tools.js
+++ b/src/pages/workspaces/workspace/Tools.js
@@ -1,8 +1,10 @@
 import _ from 'lodash/fp'
+import { Fragment } from 'react'
 import { a, div, h } from 'react-hyperscript-helpers'
 import { pure } from 'recompose'
 import * as breadcrumbs from 'src/components/breadcrumbs'
-import { spinnerOverlay } from 'src/components/common'
+import { Clickable, spinnerOverlay } from 'src/components/common'
+import { icon } from 'src/components/icons'
 import { ajaxCaller } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { reportError } from 'src/libs/error'
@@ -22,7 +24,7 @@ const styles = {
     ...Style.elements.card, width: 300, height: 125, margin: '1rem 0.5rem',
     display: 'flex', flexDirection: 'column', justifyContent: 'space-between'
   },
-/*  shortToolCard: {
+/*  shortToolCard: { // copied from workspaces/List.js
     display: 'flex', flexDirection: 'column', justifyContent: 'space-between'
   },*/ // possibly not necessary
   shortTitle: {
@@ -31,22 +33,49 @@ const styles = {
     lineHeight: '20px', height: '40px',
     overflow: 'hidden', overflowWrap: 'break-word'
   },
-  /*shortCreateCard: {
+  shortDescription: { // copied from workspaces/List.js
+    flex: 'none',
+    lineHeight: '18px', height: '90px',
+    overflow: 'hidden'
+  },
+  /*shortCreateCard: { // copied from workspaces/List.js
     display: 'flex', flexDirection: 'column', justifyContent: 'center',
     color: colors.blue[0], fontSize: 20, lineHeight: '28px'
   },*/  // To be added later
-  longCard: {
+  longCard: { // copied from workspaces/List.js
     ...Style.elements.card,
     width: '100%', minWidth: 0, height: 80,
     margin: '0.25rem 0.5rem'
   },
-/*  longToolCard: {
+/*  longToolCard: { // copied from workspaces/List.js
     display: 'flex', flexDirection: 'column', justifyContent: 'space-between'
   },*/ // possibly not necessary
-  longTitle: {
+  longTitle: { // copied from workspaces/List.js
     color: colors.blue[0], fontSize: 16,
     whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis'
-  }
+  },
+  longDescription: { // copied from workspaces/List.js
+    flex: 1,
+    paddingRight: '1rem',
+    whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis'
+  },
+  /*longCreateCard: { // copied from workspaces/List.js
+    display: 'flex', flexDirection: 'column', justifyContent: 'center',
+    color: colors.blue[0], fontSize: 16
+  }*/ // To be added later
+  toolbarContainer: {
+    flex: 'none', display: 'flex', alignItems: 'flex-end',
+    margin: '1rem 4.5rem'
+  },
+  toolbarButtons: { // copied from workspaces/List.js
+    marginLeft: 'auto', display: 'flex',
+    backgroundColor: 'white', borderRadius: 3
+  },
+  toolbarButton: active => ({ // copied from workspaces/List.js
+    display: 'flex', justifyContent: 'center', alignItems: 'center',
+    height: '2.25rem', width: '3rem',
+    color: active ? colors.blue[1] : colors.blue[0]
+  })
 }
 
 const ToolCard = pure(({ listView, name, namespace, config }) => {
@@ -63,19 +92,22 @@ const ToolCard = pure(({ listView, name, namespace, config }) => {
     href: Nav.getLink('workflow', { namespace, name, workflowNamespace, workflowName })
   }, [
     div({ style: styles.longTitle }, [workflowName]),
-    div([`V. ${methodVersion}`]),
-    div({ style: { flex: 'none', width: 400 } }, [`Source: ${sourceRepo}`])
+    div([`V. ${methodVersion}`]), //To do: how to add tool description
+    div({ style: { flex: 'none', width: '80% ' } }, [`Source: ${sourceRepo}`]) //To do: figure out how to get this right-aligned
   ])
 })
 
-const WorkspaceTools = ajaxCaller(wrapWorkspace({
+export const WorkspaceTools = ajaxCaller(wrapWorkspace({
   breadcrumbs: props => breadcrumbs.commonPaths.workspaceDashboard(props),
   title: 'Tools', activeTab: 'tools'
 },
 class ToolsContent extends Component {
   constructor(props) {
     super(props)
-    this.state = { ...StateHistory.get() }
+    this.state = {
+      listView: false,
+      ...StateHistory.get()
+    }
   }
 
   async refresh() {
@@ -94,13 +126,30 @@ class ToolsContent extends Component {
 
   render() {
     const { namespace, name } = this.props
-    const { loading, configs } = this.state
-    return div({ style: styles.cardContainer }, [
-      _.map(config => {
-        return h(ToolCard, { key: `${config.namespace}/${config.name}`, namespace, name, config })
-      }, configs),
-      configs && !configs.length && div(['No tools added']),
-      loading && spinnerOverlay
+    const { loading, configs, listView } = this.state
+    return h(Fragment, [
+      div({ style: styles.toolbarContainer }, [
+        div({ style: { ...Style.elements.sectionHeader, textTransform: 'uppercase' } }, [
+          'Tools'
+        ]),
+        div({ style: styles.toolbarButtons }, [
+          h(Clickable, {
+            style: styles.toolbarButton(!listView),
+            onClick: () => this.setState({ listView: false })
+          }, [icon('view-cards', { size: 24 })]),
+          h(Clickable, {
+            style: styles.toolbarButton(listView),
+            onClick: () => this.setState({ listView: true })
+          }, [icon('view-list', { size: 24 })])
+        ])
+      ]),
+      div({ style: styles.cardContainer }, [
+        _.map(config => {
+          return h(ToolCard, { key: `${config.namespace}/${config.name}`, namespace, name, config })
+        }, configs),
+        configs && !configs.length && div(['No tools added']),
+        loading && spinnerOverlay
+      ])
     ])
   }
 

--- a/src/pages/workspaces/workspace/Tools.js
+++ b/src/pages/workspaces/workspace/Tools.js
@@ -24,9 +24,6 @@ const styles = {
     ...Style.elements.card, width: 300, height: 125, margin: '1rem 0.5rem',
     display: 'flex', flexDirection: 'column', justifyContent: 'space-between'
   },
-/*  shortToolCard: { // copied from workspaces/List.js
-    display: 'flex', flexDirection: 'column', justifyContent: 'space-between'
-  },*/ // possibly not necessary
   shortTitle: {
     flex: 1,
     color: colors.blue[0], fontSize: 16,
@@ -38,18 +35,17 @@ const styles = {
     lineHeight: '18px', height: '90px',
     overflow: 'hidden'
   },
-  /*shortCreateCard: { // copied from workspaces/List.js
-    display: 'flex', flexDirection: 'column', justifyContent: 'center',
-    color: colors.blue[0], fontSize: 20, lineHeight: '28px'
-  },*/  // To be added later
+  /*
+   *shortCreateCard: { // copied from workspaces/List.js
+   *  display: 'flex', flexDirection: 'column', justifyContent: 'center',
+   *  color: colors.blue[0], fontSize: 20, lineHeight: '28px'
+   *},
+   */ // To be added later
   longCard: { // copied from workspaces/List.js
     ...Style.elements.card,
     width: '100%', minWidth: 0, height: 80,
     margin: '0.25rem 0.5rem'
   },
-/*  longToolCard: { // copied from workspaces/List.js
-    display: 'flex', flexDirection: 'column', justifyContent: 'space-between'
-  },*/ // possibly not necessary
   longTitle: { // copied from workspaces/List.js
     color: colors.blue[0], fontSize: 16,
     whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', flex: 1
@@ -59,10 +55,12 @@ const styles = {
     paddingRight: '1rem',
     whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis'
   },
-  /*longCreateCard: { // copied from workspaces/List.js
-    display: 'flex', flexDirection: 'column', justifyContent: 'center',
-    color: colors.blue[0], fontSize: 16
-  }*/ // To be added later
+  /*
+   *longCreateCard: { // copied from workspaces/List.js
+   *display: 'flex', flexDirection: 'column', justifyContent: 'center',
+   *color: colors.blue[0], fontSize: 16
+   *}
+   */ // To be added later
   toolbarContainer: {
     flex: 'none', display: 'flex', alignItems: 'flex-end',
     margin: '1rem 4.5rem'
@@ -98,6 +96,7 @@ const ToolCard = pure(({ listView, name, namespace, config }) => {
     href: Nav.getLink('workflow', { namespace, name, workflowNamespace, workflowName })
   }, [
     div({ style: styles.shortTitle }, [workflowName]),
+    //To do: add tool description
     div([`V. ${methodVersion}`]),
     div([`Source: ${sourceRepo}`])
   ])

--- a/src/pages/workspaces/workspace/Tools.js
+++ b/src/pages/workspaces/workspace/Tools.js
@@ -35,12 +35,6 @@ const styles = {
     lineHeight: '18px', height: '90px',
     overflow: 'hidden'
   },
-  /*
-   *shortCreateCard: {
-   *  display: 'flex', flexDirection: 'column', justifyContent: 'center',
-   *  color: colors.blue[0], fontSize: 20, lineHeight: '28px'
-   *},
-   */ //TODO: add short create card
   longCard: {
     ...Style.elements.card,
     width: '100%', minWidth: 0,
@@ -55,12 +49,6 @@ const styles = {
     paddingRight: '1rem',
     whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis'
   },
-  /*
-   *longCreateCard: {
-   *display: 'flex', flexDirection: 'column', justifyContent: 'center',
-   *color: colors.blue[0], fontSize: 16
-   *}
-   */ //TODO: Add long create card
   toolbarContainer: {
     flex: 'none', display: 'flex', alignItems: 'flex-end',
     margin: '1rem 4.5rem'
@@ -87,13 +75,11 @@ const ToolCard = pure(({ listView, name, namespace, config }) => {
       div({ style: { marginRight: '1rem' } }, [`V. ${methodVersion}`]),
       div({ style: { flex: 'none' } }, [`Source: ${sourceRepo}`])
     ])
-    // TODO: add tool description
   ]) : a({
     style: styles.shortCard,
     href: Nav.getLink('workflow', { namespace, name, workflowNamespace, workflowName })
   }, [
     div({ style: styles.shortTitle }, [workflowName]),
-    // TODO: add tool description
     div([`V. ${methodVersion}`]),
     div([`Source: ${sourceRepo}`])
   ])

--- a/src/pages/workspaces/workspace/Tools.js
+++ b/src/pages/workspaces/workspace/Tools.js
@@ -35,6 +35,10 @@ const styles = {
     lineHeight: '18px', height: '90px',
     overflow: 'hidden'
   },
+  longMethodVersion: {
+    marginRight: '1rem', width: 90,
+    whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis'
+  },
   longCard: {
     ...Style.elements.card,
     width: '100%', minWidth: 0,
@@ -72,8 +76,8 @@ const ToolCard = pure(({ listView, name, namespace, config }) => {
   }, [
     div({ style: { display: 'flex', alignItems: 'center' } }, [
       div({ style: styles.longTitle }, [workflowName]),
-      div({ style: { marginRight: '1rem' } }, [`V. ${methodVersion}`]),
-      div({ style: { flex: 'none' } }, [`Source: ${sourceRepo}`])
+      div({ style: styles.longMethodVersion }, [`V. ${methodVersion}`]),
+      div({ style: { flex: 'none', width: 130 } }, [`Source: ${sourceRepo}`])
     ])
   ]) : a({
     style: styles.shortCard,

--- a/src/pages/workspaces/workspace/Tools.js
+++ b/src/pages/workspaces/workspace/Tools.js
@@ -81,13 +81,6 @@ const styles = {
 const ToolCard = pure(({ listView, name, namespace, config }) => {
   const { namespace: workflowNamespace, name: workflowName, methodRepoMethod: { sourceRepo, methodVersion } } = config
   return listView ? a({
-    style: styles.shortCard,
-    href: Nav.getLink('workflow', { namespace, name, workflowNamespace, workflowName })
-  }, [
-    div({ style: styles.shortTitle }, [workflowName]),
-    div([`V. ${methodVersion}`]),
-    div([`Source: ${sourceRepo}`])
-  ]) : a({
     style: styles.longCard,
     href: Nav.getLink('workflow', { namespace, name, workflowNamespace, workflowName })
   }, [
@@ -95,11 +88,18 @@ const ToolCard = pure(({ listView, name, namespace, config }) => {
       div({ style: styles.longTitle }, [workflowName]),
       div([`V. ${methodVersion}`])
     ]),
-    //To do: how to add tool description
+    //To do: add tool description
     div({ style: { display: 'flex', alignItems: 'center' } }, [
       div({ style: { flex: 1 } }),
       div({ style: { flex: 'none' } }, [`Source: ${sourceRepo}`])
     ])
+  ]) : a({
+    style: styles.shortCard,
+    href: Nav.getLink('workflow', { namespace, name, workflowNamespace, workflowName })
+  }, [
+    div({ style: styles.shortTitle }, [workflowName]),
+    div([`V. ${methodVersion}`]),
+    div([`Source: ${sourceRepo}`])
   ])
 })
 
@@ -151,7 +151,7 @@ class ToolsContent extends Component {
       ]),
       div({ style: styles.cardContainer }, [
         _.map(config => {
-          return h(ToolCard, { key: `${config.namespace}/${config.name}`, namespace, name, config })
+          return h(ToolCard, { key: `${config.namespace}/${config.name}`, namespace, name, config, listView })
         }, configs),
         configs && !configs.length && div(['No tools added']),
         loading && spinnerOverlay
@@ -164,7 +164,7 @@ class ToolsContent extends Component {
   }
 
   componentDidUpdate() {
-    StateHistory.update(_.pick(['configs'], this.state))
+    StateHistory.update(_.pick(['configs', 'listView'], this.state))
   }
 }))
 

--- a/src/pages/workspaces/workspace/Tools.js
+++ b/src/pages/workspaces/workspace/Tools.js
@@ -28,7 +28,7 @@ const styles = {
     display: 'flex', flexDirection: 'column', justifyContent: 'space-between'
   },*/ // possibly not necessary
   shortTitle: {
-    flex: 'none',
+    flex: 1,
     color: colors.blue[0], fontSize: 16,
     lineHeight: '20px', height: '40px',
     overflow: 'hidden', overflowWrap: 'break-word'
@@ -52,7 +52,7 @@ const styles = {
   },*/ // possibly not necessary
   longTitle: { // copied from workspaces/List.js
     color: colors.blue[0], fontSize: 16,
-    whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis'
+    whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', flex: 1
   },
   longDescription: { // copied from workspaces/List.js
     flex: 1,
@@ -91,9 +91,15 @@ const ToolCard = pure(({ listView, name, namespace, config }) => {
     style: styles.longCard,
     href: Nav.getLink('workflow', { namespace, name, workflowNamespace, workflowName })
   }, [
-    div({ style: styles.longTitle }, [workflowName]),
-    div([`V. ${methodVersion}`]), //To do: how to add tool description
-    div({ style: { flex: 'none', width: '80% ' } }, [`Source: ${sourceRepo}`]) //To do: figure out how to get this right-aligned
+    div({ style: { display: 'flex', alignItems: 'center' } }, [
+      div({ style: styles.longTitle }, [workflowName]),
+      div([`V. ${methodVersion}`])
+    ]),
+    //To do: how to add tool description
+    div({ style: { display: 'flex', alignItems: 'center' } }, [
+      div({ style: { flex: 1 } }),
+      div({ style: { flex: 'none' } }, [`Source: ${sourceRepo}`])
+    ])
   ])
 })
 

--- a/src/pages/workspaces/workspace/Tools.js
+++ b/src/pages/workspaces/workspace/Tools.js
@@ -30,46 +30,46 @@ const styles = {
     lineHeight: '20px', height: '40px',
     overflow: 'hidden', overflowWrap: 'break-word'
   },
-  shortDescription: { // copied from workspaces/List.js
+  shortDescription: {
     flex: 'none',
     lineHeight: '18px', height: '90px',
     overflow: 'hidden'
   },
   /*
-   *shortCreateCard: { // copied from workspaces/List.js
+   *shortCreateCard: {
    *  display: 'flex', flexDirection: 'column', justifyContent: 'center',
    *  color: colors.blue[0], fontSize: 20, lineHeight: '28px'
    *},
-   */ // To be added later
-  longCard: { // copied from workspaces/List.js
+   */ //TODO: add short create card
+  longCard: {
     ...Style.elements.card,
-    width: '100%', minWidth: 0, height: 80,
+    width: '100%', minWidth: 0,
     margin: '0.25rem 0.5rem'
   },
-  longTitle: { // copied from workspaces/List.js
+  longTitle: {
     color: colors.blue[0], fontSize: 16,
     whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', flex: 1
   },
-  longDescription: { // copied from workspaces/List.js
+  longDescription: {
     flex: 1,
     paddingRight: '1rem',
     whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis'
   },
   /*
-   *longCreateCard: { // copied from workspaces/List.js
+   *longCreateCard: {
    *display: 'flex', flexDirection: 'column', justifyContent: 'center',
    *color: colors.blue[0], fontSize: 16
    *}
-   */ // To be added later
+   */ //TODO: Add long create card
   toolbarContainer: {
     flex: 'none', display: 'flex', alignItems: 'flex-end',
     margin: '1rem 4.5rem'
   },
-  toolbarButtons: { // copied from workspaces/List.js
+  toolbarButtons: {
     marginLeft: 'auto', display: 'flex',
     backgroundColor: 'white', borderRadius: 3
   },
-  toolbarButton: active => ({ // copied from workspaces/List.js
+  toolbarButton: active => ({
     display: 'flex', justifyContent: 'center', alignItems: 'center',
     height: '2.25rem', width: '3rem',
     color: active ? colors.blue[1] : colors.blue[0]
@@ -84,19 +84,16 @@ const ToolCard = pure(({ listView, name, namespace, config }) => {
   }, [
     div({ style: { display: 'flex', alignItems: 'center' } }, [
       div({ style: styles.longTitle }, [workflowName]),
-      div([`V. ${methodVersion}`])
-    ]),
-    //To do: add tool description
-    div({ style: { display: 'flex', alignItems: 'center' } }, [
-      div({ style: { flex: 1 } }),
+      div({style: { marginRight: '1rem' } }, [`V. ${methodVersion}`]),
       div({ style: { flex: 'none' } }, [`Source: ${sourceRepo}`])
     ])
+    // TODO: add tool description
   ]) : a({
     style: styles.shortCard,
     href: Nav.getLink('workflow', { namespace, name, workflowNamespace, workflowName })
   }, [
     div({ style: styles.shortTitle }, [workflowName]),
-    //To do: add tool description
+    // TODO: add tool description
     div([`V. ${methodVersion}`]),
     div([`Source: ${sourceRepo}`])
   ])

--- a/src/pages/workspaces/workspace/Tools.js
+++ b/src/pages/workspaces/workspace/Tools.js
@@ -18,27 +18,53 @@ const styles = {
     padding: '1rem 4rem',
     display: 'flex', flexWrap: 'wrap'
   },
-  card: {
+  shortCard: {
     ...Style.elements.card, width: 300, height: 125, margin: '1rem 0.5rem',
     display: 'flex', flexDirection: 'column', justifyContent: 'space-between'
   },
+/*  shortToolCard: {
+    display: 'flex', flexDirection: 'column', justifyContent: 'space-between'
+  },*/ // possibly not necessary
   shortTitle: {
     flex: 'none',
     color: colors.blue[0], fontSize: 16,
     lineHeight: '20px', height: '40px',
     overflow: 'hidden', overflowWrap: 'break-word'
+  },
+  /*shortCreateCard: {
+    display: 'flex', flexDirection: 'column', justifyContent: 'center',
+    color: colors.blue[0], fontSize: 20, lineHeight: '28px'
+  },*/  // To be added later
+  longCard: {
+    ...Style.elements.card,
+    width: '100%', minWidth: 0, height: 80,
+    margin: '0.25rem 0.5rem'
+  },
+/*  longToolCard: {
+    display: 'flex', flexDirection: 'column', justifyContent: 'space-between'
+  },*/ // possibly not necessary
+  longTitle: {
+    color: colors.blue[0], fontSize: 16,
+    whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis'
   }
 }
 
-const ToolCard = pure(({ name, namespace, config }) => {
+const ToolCard = pure(({ listView, name, namespace, config }) => {
   const { namespace: workflowNamespace, name: workflowName, methodRepoMethod: { sourceRepo, methodVersion } } = config
-  return a({
-    style: styles.card,
+  return listView ? a({
+    style: styles.shortCard,
     href: Nav.getLink('workflow', { namespace, name, workflowNamespace, workflowName })
   }, [
     div({ style: styles.shortTitle }, [workflowName]),
     div([`V. ${methodVersion}`]),
     div([`Source: ${sourceRepo}`])
+  ]) : a({
+    style: styles.longCard,
+    href: Nav.getLink('workflow', { namespace, name, workflowNamespace, workflowName })
+  }, [
+    div({ style: styles.longTitle }, [workflowName]),
+    div([`V. ${methodVersion}`]),
+    div({ style: { flex: 'none', width: 400 } }, [`Source: ${sourceRepo}`])
   ])
 })
 

--- a/src/pages/workspaces/workspace/Tools.js
+++ b/src/pages/workspaces/workspace/Tools.js
@@ -84,7 +84,7 @@ const ToolCard = pure(({ listView, name, namespace, config }) => {
   }, [
     div({ style: { display: 'flex', alignItems: 'center' } }, [
       div({ style: styles.longTitle }, [workflowName]),
-      div({style: { marginRight: '1rem' } }, [`V. ${methodVersion}`]),
+      div({ style: { marginRight: '1rem' } }, [`V. ${methodVersion}`]),
       div({ style: { flex: 'none' } }, [`Source: ${sourceRepo}`])
     ])
     // TODO: add tool description


### PR DESCRIPTION
Fixes #488 

Currently the tool description is not included: 
<img width="1136" alt="screen shot 2018-09-11 at 3 07 51 pm" src="https://user-images.githubusercontent.com/2395211/45381847-81ca1980-b5d4-11e8-9a66-c9c3d3384246.png">

<img width="1076" alt="screen shot 2018-09-11 at 3 08 03 pm" src="https://user-images.githubusercontent.com/2395211/45381850-82fb4680-b5d4-11e8-8086-7e43a2745243.png">

I can add it now or on a different ticket, but it will take a little work.