### PR TITLE
Draw form labels and hints from a central source

### DIFF
--- a/src/components/NewWorkspaceModal.js
+++ b/src/components/NewWorkspaceModal.js
@@ -110,7 +110,7 @@ export default ajaxCaller(class NewWorkspaceModal extends Component {
         onClick: () => this.create()
       }, cloneWorkspace ? 'Clone Workspace' : 'Create Workspace')
     }, [
-      Forms.createRequiredFormLabel('Workspace name'),
+      Forms.requiredFormLabel('Workspace name'),
       validatedInput({
         inputProps: {
           autoFocus: true,
@@ -120,7 +120,7 @@ export default ajaxCaller(class NewWorkspaceModal extends Component {
         },
         error: Utils.summarizeErrors(nameModified && errors && errors.name)
       }),
-      Forms.createRequiredFormLabel('Billing project'),
+      Forms.requiredFormLabel('Billing project'),
       billingProjects && !billingProjects.length ? h(Fragment, [
         div({ style: { color: colors.red[0] } }, [
           icon('error', { size: 16 }),
@@ -142,14 +142,14 @@ export default ajaxCaller(class NewWorkspaceModal extends Component {
           return { label: name, value: name }
         }, _.uniq(_.map('projectName', billingProjects)).sort())
       }),
-      Forms.createFormLabel('Description'),
+      Forms.formLabel('Description'),
       h(TextArea, {
         style: { height: 100 },
         placeholder: 'Enter a description',
         value: description,
         onChange: e => this.setState({ description: e.target.value })
       }),
-      Forms.createFormLabel('Authorization domain', h(InfoBox, [
+      Forms.formLabel('Authorization domain', h(InfoBox, [
         'Note: An authorization domain can only be set when creating a workspace. ',
         'Once set, it cannot be changed. ',
         link({ href: authDoc, target: '_blank' }, ['Read more about authorization domains'])

--- a/src/components/NewWorkspaceModal.js
+++ b/src/components/NewWorkspaceModal.js
@@ -9,8 +9,8 @@ import { InfoBox } from 'src/components/PopupTrigger'
 import { ajaxCaller } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { reportError } from 'src/libs/error'
+import * as Forms from 'src/libs/forms'
 import * as Nav from 'src/libs/nav'
-import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 import validate from 'validate.js'
 
@@ -34,10 +34,6 @@ const constraints = {
 }
 
 const styles = {
-  label: {
-    ...Style.elements.sectionHeader,
-    marginTop: '1rem', marginBottom: '0.25rem'
-  },
   groupNotice: {
     marginBottom: '0.25rem',
     fontSize: 12,
@@ -114,7 +110,7 @@ export default ajaxCaller(class NewWorkspaceModal extends Component {
         onClick: () => this.create()
       }, cloneWorkspace ? 'Clone Workspace' : 'Create Workspace')
     }, [
-      div({ style: styles.label }, ['Workspace name *']),
+      Forms.createRequiredFormLabel('Workspace name'),
       validatedInput({
         inputProps: {
           autoFocus: true,
@@ -124,7 +120,7 @@ export default ajaxCaller(class NewWorkspaceModal extends Component {
         },
         error: Utils.summarizeErrors(nameModified && errors && errors.name)
       }),
-      div({ style: styles.label }, ['Billing project *']),
+      Forms.createRequiredFormLabel('Billing project'),
       billingProjects && !billingProjects.length ? h(Fragment, [
         div({ style: { color: colors.red[0] } }, [
           icon('error', { size: 16 }),
@@ -146,21 +142,18 @@ export default ajaxCaller(class NewWorkspaceModal extends Component {
           return { label: name, value: name }
         }, _.uniq(_.map('projectName', billingProjects)).sort())
       }),
-      div({ style: styles.label }, ['Description']),
+      Forms.createFormLabel('Description'),
       h(TextArea, {
         style: { height: 100 },
         placeholder: 'Enter a description',
         value: description,
         onChange: e => this.setState({ description: e.target.value })
       }),
-      div({ style: styles.label }, [
-        'Authorization domain ',
-        h(InfoBox, [
-          'Note: An authorization domain can only be set when creating a workspace. ',
-          'Once set, it cannot be changed. ',
-          link({ href: authDoc, target: '_blank' }, ['Read more about authorization domains'])
-        ])
-      ]),
+      Forms.createFormLabel('Authorization domain', h(InfoBox, [
+        'Note: An authorization domain can only be set when creating a workspace. ',
+        'Once set, it cannot be changed. ',
+        link({ href: authDoc, target: '_blank' }, ['Read more about authorization domains'])
+      ])),
       !!existingGroups.length && div({ style: styles.groupNotice }, [
         'The cloned workspace will automatically inherit the authorization domain from this workspace. ',
         'You may add groups to the authorization domain, but you may not remove existing ones.'

--- a/src/components/notebook-utils.js
+++ b/src/components/notebook-utils.js
@@ -6,7 +6,7 @@ import { validatedInput } from 'src/components/input'
 import Modal from 'src/components/Modal'
 import { ajaxCaller } from 'src/libs/ajax'
 import { reportError } from 'src/libs/error'
-import * as Style from 'src/libs/style'
+import * as Forms from 'src/libs/forms'
 import * as Utils from 'src/libs/utils'
 import { Component } from 'src/libs/wrapped-components'
 import validate from 'validate.js'
@@ -24,14 +24,12 @@ const notebookNameValidator = existing => ({
   }
 })
 
-const notebookNameInput = props => div({ style: { margin: '0.5rem 0 1rem' } }, [
-  validatedInput(_.merge({
-    inputProps: {
-      autoFocus: true,
-      placeholder: 'Enter a name'
-    }
-  }, props))
-])
+const notebookNameInput = props => validatedInput(_.merge({
+  inputProps: {
+    autoFocus: true,
+    placeholder: 'Enter a name'
+  }
+}, props))
 
 
 const baseNotebook = {
@@ -103,7 +101,7 @@ export const NotebookCreator = ajaxCaller(class NotebookCreator extends Componen
         }
       }, 'Create Notebook')
     }, [
-      div({ style: Style.elements.sectionHeader }, 'Name *'),
+      Forms.createRequiredFormLabel('Name'),
       notebookNameInput({
         error: Utils.summarizeErrors(nameTouched && errors && errors.notebookName),
         inputProps: {
@@ -111,11 +109,10 @@ export const NotebookCreator = ajaxCaller(class NotebookCreator extends Componen
           onChange: e => this.setState({ notebookName: e.target.value, nameTouched: true })
         }
       }),
-      div({ style: Style.elements.sectionHeader }, 'Kernel *'),
+      Forms.createRequiredFormLabel('Kernel'),
       h(Select, {
         clearable: false,
         searchable: false,
-        wrapperStyle: { marginTop: '0.5rem' },
         placeholder: 'Select a kernel',
         value: notebookKernel,
         onChange: notebookKernel => this.setState({ notebookKernel }),
@@ -176,7 +173,7 @@ export const NotebookDuplicator = ajaxCaller(class NotebookDuplicator extends Co
     Utils.cond(
       [processing, () => [centeredSpinner()]],
       () => [
-        div({ style: Style.elements.sectionHeader }, 'New Name *'),
+        Forms.createRequiredFormLabel('New Name'),
         notebookNameInput({
           error: Utils.summarizeErrors(nameTouched && errors && errors.newName),
           inputProps: {

--- a/src/components/notebook-utils.js
+++ b/src/components/notebook-utils.js
@@ -101,7 +101,7 @@ export const NotebookCreator = ajaxCaller(class NotebookCreator extends Componen
         }
       }, 'Create Notebook')
     }, [
-      Forms.createRequiredFormLabel('Name'),
+      Forms.requiredFormLabel('Name'),
       notebookNameInput({
         error: Utils.summarizeErrors(nameTouched && errors && errors.notebookName),
         inputProps: {
@@ -109,7 +109,7 @@ export const NotebookCreator = ajaxCaller(class NotebookCreator extends Componen
           onChange: e => this.setState({ notebookName: e.target.value, nameTouched: true })
         }
       }),
-      Forms.createRequiredFormLabel('Kernel'),
+      Forms.requiredFormLabel('Kernel'),
       h(Select, {
         clearable: false,
         searchable: false,
@@ -173,7 +173,7 @@ export const NotebookDuplicator = ajaxCaller(class NotebookDuplicator extends Co
     Utils.cond(
       [processing, () => [centeredSpinner()]],
       () => [
-        Forms.createRequiredFormLabel('New Name'),
+        Forms.requiredFormLabel('New Name'),
         notebookNameInput({
           error: Utils.summarizeErrors(nameTouched && errors && errors.newName),
           inputProps: {

--- a/src/libs/forms.js
+++ b/src/libs/forms.js
@@ -14,7 +14,7 @@ const styles = {
 }
 
 
-export const createFormLabel = (text, ...extras) => {
+export const formLabel = (text, ...extras) => {
   return div({ style: styles.formLabel }, [
     text,
     ...extras
@@ -22,7 +22,7 @@ export const createFormLabel = (text, ...extras) => {
 }
 
 
-export const createRequiredFormLabel = (text, ...extras) => {
+export const requiredFormLabel = (text, ...extras) => {
   return div({ style: styles.formLabel }, [
     `${text} *`,
     ...extras
@@ -30,6 +30,6 @@ export const createRequiredFormLabel = (text, ...extras) => {
 }
 
 
-export const createFormHint = text => {
+export const formHint = text => {
   return div({ style: styles.formHint }, [text])
 }

--- a/src/libs/forms.js
+++ b/src/libs/forms.js
@@ -1,0 +1,35 @@
+import { div } from 'react-hyperscript-helpers'
+import * as Style from 'src/libs/style'
+
+
+const styles = {
+  formLabel: {
+    ...Style.elements.sectionHeader,
+    margin: '1rem 0 0.25rem'
+  },
+  formHint: {
+    fontSize: 'smaller',
+    marginTop: '0.25rem'
+  }
+}
+
+
+export const createFormLabel = (text, ...extras) => {
+  return div({ style: styles.formLabel }, [
+    text,
+    ...extras
+  ])
+}
+
+
+export const createRequiredFormLabel = (text, ...extras) => {
+  return div({ style: styles.formLabel }, [
+    `${text} *`,
+    ...extras
+  ])
+}
+
+
+export const createFormHint = text => {
+  return div({ style: styles.formHint }, [text])
+}

--- a/src/pages/groups/Group.js
+++ b/src/pages/groups/Group.js
@@ -59,13 +59,13 @@ const NewUserModal = ajaxCaller(class NewUserModal extends Component {
         disabled: errors
       }, ['Add User'])
     }, [
-      Forms.createRequiredFormLabel('User email'),
+      Forms.requiredFormLabel('User email'),
       textInput({
         autoFocus: true,
         value: userEmail,
         onChange: e => this.setState({ userEmail: e.target.value, emailTouched: true })
       }),
-      Forms.createRequiredFormLabel('Role'),
+      Forms.requiredFormLabel('Role'),
       roleSelector({ role, updateState: role => this.setState({ role }) }),
       submitError && div({ style: { marginTop: '0.5rem', textAlign: 'right', color: colors.red[0] } }, [submitError]),
       submitting && spinnerOverlay

--- a/src/pages/groups/Group.js
+++ b/src/pages/groups/Group.js
@@ -11,6 +11,7 @@ import { TopBar } from 'src/components/TopBar'
 import { ajaxCaller } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { reportError } from 'src/libs/error'
+import * as Forms from 'src/libs/forms'
 import * as Nav from 'src/libs/nav'
 import * as StateHistory from 'src/libs/state-history'
 import * as Style from 'src/libs/style'
@@ -58,13 +59,13 @@ const NewUserModal = ajaxCaller(class NewUserModal extends Component {
         disabled: errors
       }, ['Add User'])
     }, [
-      div({ style: styles.formLabel }, ['User email']),
+      Forms.createRequiredFormLabel('User email'),
       textInput({
         autoFocus: true,
         value: userEmail,
         onChange: e => this.setState({ userEmail: e.target.value, emailTouched: true })
       }),
-      div({ style: styles.formLabel }, ['Role']),
+      Forms.createRequiredFormLabel('Role'),
       roleSelector({ role, updateState: role => this.setState({ role }) }),
       submitError && div({ style: { marginTop: '0.5rem', textAlign: 'right', color: colors.red[0] } }, [submitError]),
       submitting && spinnerOverlay

--- a/src/pages/groups/List.js
+++ b/src/pages/groups/List.js
@@ -55,7 +55,7 @@ const NewGroupModal = ajaxCaller(class NewGroupModal extends Component {
         onClick: () => this.submit()
       }, ['Create Group'])
     }, [
-      Forms.createRequiredFormLabel('Enter a unique name'),
+      Forms.requiredFormLabel('Enter a unique name'),
       validatedInput({
         inputProps: {
           autoFocus: true,
@@ -64,7 +64,7 @@ const NewGroupModal = ajaxCaller(class NewGroupModal extends Component {
         },
         error: groupNameTouched && Utils.summarizeErrors(errors && errors.groupName)
       }),
-      !(groupNameTouched && errors) && Forms.createFormHint('Only letters, numbers, underscores, and dashes allowed'),
+      !(groupNameTouched && errors) && Forms.formHint('Only letters, numbers, underscores, and dashes allowed'),
       submitting && spinnerOverlay
     ])
   }

--- a/src/pages/groups/List.js
+++ b/src/pages/groups/List.js
@@ -10,6 +10,7 @@ import { TopBar } from 'src/components/TopBar'
 import { ajaxCaller } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { reportError } from 'src/libs/error'
+import * as Forms from 'src/libs/forms'
 import * as Nav from 'src/libs/nav'
 import * as StateHistory from 'src/libs/state-history'
 import * as Style from 'src/libs/style'
@@ -54,7 +55,7 @@ const NewGroupModal = ajaxCaller(class NewGroupModal extends Component {
         onClick: () => this.submit()
       }, ['Create Group'])
     }, [
-      div({ style: styles.formLabel }, ['Enter a unique name']),
+      Forms.createRequiredFormLabel('Enter a unique name'),
       validatedInput({
         inputProps: {
           autoFocus: true,
@@ -63,9 +64,7 @@ const NewGroupModal = ajaxCaller(class NewGroupModal extends Component {
         },
         error: groupNameTouched && Utils.summarizeErrors(errors && errors.groupName)
       }),
-      !(groupNameTouched && errors) && div({ style: { fontSize: 'smaller', marginTop: '0.25rem' } }, [
-        'Only letters, numbers, underscores, and dashes allowed'
-      ]),
+      !(groupNameTouched && errors) && Forms.createFormHint('Only letters, numbers, underscores, and dashes allowed'),
       submitting && spinnerOverlay
     ])
   }

--- a/src/pages/groups/common.js
+++ b/src/pages/groups/common.js
@@ -29,9 +29,5 @@ export const styles = {
   toolbarContainer: {
     flex: 'none', display: 'flex', alignItems: 'flex-end',
     margin: '2rem 4rem 2rem 5rem'
-  },
-  formLabel: {
-    ...Style.elements.sectionHeader,
-    margin: '1rem 0 0.25rem'
   }
 }


### PR DESCRIPTION
Fixes #615 

Turns out we were already pretty consistent with font size/color/weight and margins. Added some "*"s.

The only place that's different is the profile page. I'm okay with that one being different, as it's not very important and people don't look at it much (presumably).