### PR TITLE
implement error boundary

### DIFF
--- a/src/components/ErrorWrapper.js
+++ b/src/components/ErrorWrapper.js
@@ -1,0 +1,20 @@
+import { Component } from 'react'
+import { reportError } from 'src/libs/error'
+
+export default class ErrorWrapper extends Component {
+  constructor(props) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  componentDidCatch(error) {
+    reportError('An error occurred', error)
+    this.setState({ hasError: true })
+  }
+
+  render() {
+    const { children } = this.props
+    const { hasError } = this.state
+    return hasError ? null : children
+  }
+}

--- a/src/pages/Main.js
+++ b/src/pages/Main.js
@@ -3,9 +3,16 @@ import { hot } from 'react-hot-loader'
 import { h } from 'react-hyperscript-helpers'
 import ConfigOverridesWarning from 'src/components/ConfigOverridesWarning'
 import ErrorBanner from 'src/components/ErrorBanner'
+import ErrorWrapper from 'src/components/ErrorWrapper'
 import Router from 'src/components/Router'
 
 
-const Main = () => h(Fragment, [h(Router), h(ErrorBanner), h(ConfigOverridesWarning)])
+const Main = () => {
+  return h(Fragment, [
+    h(ErrorWrapper, [h(Router)]),
+    h(ErrorBanner),
+    h(ConfigOverridesWarning)
+  ])
+}
 
 export default hot(module)(Main)


### PR DESCRIPTION
This implements a basic error boundary around the main component tree, so exceptions during render will cause the error banner to be shown. This offers some basic user feedback and prompts to reload the page. We can iterate on the UX going forward.

Fixes #639 
