### PR TITLE
Strip markdown from workspace cards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11738,6 +11738,11 @@
         "xtend": "^4.0.1"
       }
     },
+    "remove-markdown": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/remove-markdown/-/remove-markdown-0.3.0.tgz",
+      "integrity": "sha1-XktmdJOpNXlyjz1S7MHbnKUF3Jg="
+    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react-sortable-hoc": "^0.8.3",
     "react-virtualized": "^9.20.1",
     "recompose": "^0.30.0",
+    "remove-markdown": "^0.3.0",
     "uuid": "^3.3.2",
     "validate.js": "^0.12.0"
   },

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -2,6 +2,7 @@ import _ from 'lodash/fp'
 import { Fragment } from 'react'
 import { a, div, h, span } from 'react-hyperscript-helpers'
 import { pure } from 'recompose'
+import removeMd from 'remove-markdown'
 import { Clickable, PageFadeBox, search, spinnerOverlay, viewToggleButtons } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import NewWorkspaceModal from 'src/components/NewWorkspaceModal'
@@ -39,6 +40,7 @@ const styles = {
   },
   shortDescription: {
     flex: 'none',
+    whiteSpace: 'pre-wrap',
     lineHeight: '18px', height: '90px',
     overflow: 'hidden'
   },
@@ -77,9 +79,10 @@ const styles = {
 const WorkspaceCard = pure(({ listView, workspace: { workspace: { namespace, name, createdBy, lastModified, attributes: { description } } } }) => {
   const lastChanged = `Last changed: ${Utils.makePrettyDate(lastModified)}`
   const badge = div({ title: createdBy, style: styles.badge }, [createdBy[0].toUpperCase()])
-  const descText = description || span({ style: { color: colors.gray[2] } }, [
-    'No description added'
-  ])
+  const descText = description ?
+    removeMd(listView ? description.split('\n')[0] : description) :
+    span({ style: { color: colors.gray[2] } }, ['No description added'])
+
   return listView ? a({
     href: Nav.getLink('workspace', { namespace, name }),
     style: { ...styles.longCard, ...styles.longWorkspaceCard }


### PR DESCRIPTION
Fixes #656 

I couldn't find a single library that did both markdown stripping and rendering. There was a pair from the same developer that shared some dependencies, but they were harder to use (very imperative, would have had to write our own wrapper to make a Markdown component). This one's pretty small and has no dependencies of its own.