### PR TITLE
change cluster autocreate to be more conservative

### DIFF
--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -99,10 +99,10 @@ authStore.subscribe(async (state, oldState) => {
       const googleProjects = _.uniq(_.map('projectName', billingProjects)) // can have duplicates for multiple roles
       const groupedClusters = _.groupBy('googleProject', ownClusters)
       const projectsNeedingCluster = _.filter(p => {
-        return !_.some(c => c.labels.saturnVersion * 1 >= version * 1, groupedClusters[p])
+        return !_.some(c => _.toNumber(c.labels.saturnVersion) >= _.toNumber(version), groupedClusters[p])
       }, googleProjects)
       const oldClusters = _.filter(({ labels: { saturnVersion } }) => {
-        return saturnVersion * 1 < version * 1
+        return _.toNumber(saturnVersion) < _.toNumber(version)
       }, ownClusters)
       await Promise.all([
         ..._.map(p => {


### PR DESCRIPTION
This changes the cluster autocreate algorithm. The new behavior is as follows:
One cluster will be created for every project that does not already have a cluster with _at least_ the current version. The new cluster will copy the machine config from the newest existing cluster in the project, if present, otherwise will use the default.
All clusters with less than the current version will be deleted.