### PR TITLE
implement login stub for tests

### DIFF
--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -4,7 +4,7 @@ import { a, div, h } from 'react-hyperscript-helpers'
 import Collapse from 'src/components/Collapse'
 import { Clickable, comingSoon, MenuButton } from 'src/components/common'
 import { icon, logo, profilePic } from 'src/components/icons'
-import { getBasicProfile, signOut } from 'src/libs/auth'
+import { getUser, signOut } from 'src/libs/auth'
 import colors from 'src/libs/colors'
 import * as Nav from 'src/libs/nav'
 import * as Style from 'src/libs/style'
@@ -115,7 +115,7 @@ export class TopBar extends Component {
                   profilePic({ size: 32 })
                 ]),
                 div({ style: { whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' } }, [
-                  getBasicProfile().getName()
+                  getUser().name
                 ]),
                 div({ style: { flexGrow: 1 } }),
                 icon(`angle ${userMenuOpen ? 'up' : 'down'}`,

--- a/src/components/icons.js
+++ b/src/components/icons.js
@@ -25,7 +25,7 @@ import workspace from 'src/icons/workspace.svg'
 import cardMenuIcon from 'src/icons/card-menu-icon.svg'
 import renameIcon from 'src/icons/rename-icon.svg'
 import share from 'src/icons/share-line.svg'
-import { getBasicProfile } from 'src/libs/auth'
+import { getUser } from 'src/libs/auth'
 import colors from 'src/libs/colors'
 
 
@@ -60,7 +60,7 @@ export const centeredSpinner = function(props) {
 }
 
 export const profilePic = ({ size, style, ...props } = {}) => img({
-  src: getBasicProfile().getImageUrl(),
+  src: getUser().imageUrl,
   height: size, width: size,
   style: { borderRadius: '100%', ...style },
   ...props

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -2,7 +2,7 @@ import _ from 'lodash/fp'
 import * as qs from 'qs'
 import { h } from 'react-hyperscript-helpers'
 import { version } from 'src/data/clusters'
-import { getAuthToken } from 'src/libs/auth'
+import { getUser } from 'src/libs/auth'
 import * as Config from 'src/libs/config'
 import * as Utils from 'src/libs/utils'
 import { Component } from 'src/libs/wrapped-components'
@@ -41,7 +41,7 @@ window.saturnMock = {
   }
 }
 
-const authOpts = (token = getAuthToken()) => ({ headers: { Authorization: `Bearer ${token}` } })
+const authOpts = (token = getUser().token) => ({ headers: { Authorization: `Bearer ${token}` } })
 const jsonBody = body => ({ body: JSON.stringify(body), headers: { 'Content-Type': 'application/json' } })
 const appIdentifier = { headers: { 'X-App-ID': 'Saturn' } }
 const addAppIdentifier = _.merge(appIdentifier)

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -12,10 +12,6 @@ const getAuthInstance = () => {
   return window.gapi.auth2.getAuthInstance()
 }
 
-export const getUser = () => {
-  return authStore.get().user
-}
-
 export const signOut = () => {
   sessionStorage.clear()
   getAuthInstance().signOut()
@@ -30,6 +26,10 @@ export const authStore = Utils.atom({
   registrationStatus: undefined,
   user: {}
 })
+
+export const getUser = () => {
+  return authStore.get().user
+}
 
 const initializeAuth = _.memoize(async () => {
   await new Promise(resolve => window.gapi.load('auth2', resolve))
@@ -46,11 +46,13 @@ const initializeAuth = _.memoize(async () => {
         user: {
           token: authResponse && authResponse.access_token,
           id: user.getId(),
-          email: profile && profile.getEmail(),
-          name: profile && profile.getName(),
-          givenName: profile && profile.getGivenName(),
-          familyName: profile && profile.getFamilyName(),
-          imageUrl: profile && profile.getImageUrl()
+          ...(profile ? {
+            email: profile.getEmail(),
+            name: profile.getName(),
+            givenName: profile.getGivenName(),
+            familyName: profile.getFamilyName(),
+            imageUrl: profile.getImageUrl()
+          } : {})
         }
       }
     })

--- a/src/libs/error.js
+++ b/src/libs/error.js
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp'
-import { getUser, signOut } from 'src/libs/auth'
+import { reloadAuthToken, signOut } from 'src/libs/auth'
 import * as StateHistory from 'src/libs/state-history'
 import * as Utils from 'src/libs/utils'
 
@@ -9,7 +9,7 @@ export const errorStore = Utils.atom([])
 const addError = item => errorStore.update(state => _.concat(state, [item]))
 
 export const reportError = async (title, obj) => {
-  if (obj instanceof Response && obj.status === 401 && await getUser().reloadAuthResponse().then(() => false).catch(() => true)) {
+  if (obj instanceof Response && obj.status === 401 && !(await reloadAuthToken())) {
     addError({ title: 'Session timed out', error: 'You have been signed out due to inactivity', code: 'sessionTimeout' })
     signOut()
   } else {

--- a/src/pages/Register.js
+++ b/src/pages/Register.js
@@ -5,7 +5,7 @@ import { centeredSpinner, logo } from 'src/components/icons'
 import { textInput } from 'src/components/input'
 import planet from 'src/images/register-planet.svg'
 import { ajaxCaller } from 'src/libs/ajax'
-import { authStore, getBasicProfile, signOut } from 'src/libs/auth'
+import { authStore, getUser, signOut } from 'src/libs/auth'
 import colors from 'src/libs/colors'
 import { reportError } from 'src/libs/error'
 import validate from 'validate.js'
@@ -20,12 +20,12 @@ const constraints = {
 export default ajaxCaller(class Register extends Component {
   constructor(props) {
     super(props)
-    const profile = getBasicProfile()
+    const { givenName, familyName, email } = getUser()
     this.state = {
       busy: false,
-      givenName: profile.getGivenName(),
-      familyName: profile.getFamilyName(),
-      email: profile.getEmail()
+      givenName,
+      familyName,
+      email
     }
   }
 

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -10,7 +10,7 @@ import { textInput } from 'src/components/input'
 import Modal from 'src/components/Modal'
 import { ColumnSelector, FlexTable, GridTable, HeaderCell, paginator, Resizable, Sortable } from 'src/components/table'
 import { ajaxCaller } from 'src/libs/ajax'
-import * as auth from 'src/libs/auth'
+import { getUser } from 'src/libs/auth'
 import colors from 'src/libs/colors'
 import * as Config from 'src/libs/config'
 import { ReferenceDataDeleter, ReferenceDataImporter, renderDataCell } from 'src/libs/data-utils'
@@ -363,7 +363,7 @@ class WorkspaceDataContent extends Component {
         action: `${orchestrationRoot}/cookie-authed/workspaces/${namespace}/${name}/entities/${selectedDataType}/tsv`,
         method: 'POST'
       }, [
-        input({ type: 'hidden', name: 'FCtoken', value: auth.getAuthToken() })
+        input({ type: 'hidden', name: 'FCtoken', value: getUser().token })
         /*
          * TODO: once column selection is implemented, add another hidden input with name: 'attributeNames' and
          * value: comma-separated list of attribute names to support downloading only the selected columns

--- a/src/pages/workspaces/workspace/ShareWorkspaceModal.js
+++ b/src/pages/workspaces/workspace/ShareWorkspaceModal.js
@@ -7,7 +7,7 @@ import { AutocompleteSearch } from 'src/components/input'
 import Modal from 'src/components/Modal'
 import TooltipTrigger from 'src/components/TooltipTrigger'
 import { ajaxCaller } from 'src/libs/ajax'
-import { getBasicProfile } from 'src/libs/auth'
+import { getUser } from 'src/libs/auth'
 import colors from 'src/libs/colors'
 import { reportError } from 'src/libs/error'
 import * as Style from 'src/libs/style'
@@ -136,7 +136,7 @@ export default ajaxCaller(class ShareWorkspaceModal extends Component {
   renderCollaborator = ({ email, accessLevel, pending }, index) => {
     const POAccessLevel = 'PROJECT_OWNER'
     const isPO = accessLevel === POAccessLevel
-    const isMe = email === getBasicProfile().getEmail()
+    const isMe = email === getUser().email
     const { acl } = this.state
 
     return div({

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -9,7 +9,7 @@ import NewWorkspaceModal from 'src/components/NewWorkspaceModal'
 import PopupTrigger from 'src/components/PopupTrigger'
 import { TopBar } from 'src/components/TopBar'
 import { ajaxCaller } from 'src/libs/ajax'
-import { getBasicProfile } from 'src/libs/auth'
+import { getUser } from 'src/libs/auth'
 import colors from 'src/libs/colors'
 import { reportError } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
@@ -240,7 +240,7 @@ export const wrapWorkspace = ({ breadcrumbs, activeTab, title, showTabBar = true
     async refreshClusters() {
       const { namespace, ajax: { Jupyter } } = this.props
       try {
-        const clusters = _.filter({ googleProject: namespace, creator: getBasicProfile().getEmail() }, await Jupyter.clustersList())
+        const clusters = _.filter({ googleProject: namespace, creator: getUser().email }, await Jupyter.clustersList())
         this.setState({ clusters })
       } catch (error) {
         reportError('Error loading clusters', error)


### PR DESCRIPTION
This refactors the auth flow to allow tests to short-circuit the process by injecting a pre-generated auth token.

Because the underlying APIs are substantially different, we're creating a unified data layer in the `authStore`, so that downstream code can read from that, rather than being tied to the `gapi.auth2` interface. Then the new login stub can just fetch the user info and write to the same place.

This doesn't change the security model at all: you still need a valid token to be logged in. However, since this does change the auth layer, it's marked high risk and should get some extra scrutiny.

Fixes #655