### PR TITLE
Cleanup and style implementation of various pages with fade boxes

### DIFF
--- a/src/components/common.js
+++ b/src/components/common.js
@@ -241,6 +241,7 @@ export const FadeBox = ({ fadePoint = '60%', style = {}, children }) => {
 
   return div({
     style: {
+      display: 'flex', flexDirection: 'column',
       background: `linear-gradient(to bottom, white 0%, ${backgroundColor} ${fadePoint}`,
       borderRadius: `${borderRadius} ${borderRadius} 0 0`,
       ...containerStyle
@@ -256,6 +257,7 @@ export const FadeBox = ({ fadePoint = '60%', style = {}, children }) => {
     }),
     div({
       style: {
+        flex: 1,
         padding: `0 ${paddingLR}`,
         borderWidth: 1,
         borderStyle: 'solid',
@@ -271,7 +273,7 @@ export const PageFadeBox = ({ children }) => {
   return h(FadeBox, {
     fadePoint: '125px',
     style: {
-      margin: '1.5rem', paddingTop: '1rem'
+      margin: '1.5rem', paddingTop: '1rem', minHeight: 125
     }
   }, [children])
 }

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -24,15 +24,14 @@ import ShareWorkspaceModal from 'src/pages/workspaces/workspace/ShareWorkspaceMo
 const styles = {
   cardContainer: listView => ({
     position: 'relative',
-    display: 'flex', flexWrap: listView ? undefined : 'wrap', marginRight: listView ? undefined : '-1rem'
+    display: 'flex', flexWrap: listView ? undefined : 'wrap',
+    marginRight: listView ? undefined : '-1rem'
   }),
   shortCard: {
     ...Style.elements.card,
+    display: 'flex', flexDirection: 'column', justifyContent: 'space-between',
     width: 300, height: 225,
     margin: '0 1rem 2rem 0'
-  },
-  shortWorkspaceCard: {
-    display: 'flex', flexDirection: 'column', justifyContent: 'space-between'
   },
   shortTitle: {
     flex: 'none',
@@ -52,11 +51,9 @@ const styles = {
   },
   longCard: {
     ...Style.elements.card,
+    display: 'flex', flexDirection: 'column', justifyContent: 'space-between',
     width: '100%', minWidth: 0, height: 80,
-    margin: '0.5rem 1rem 0 0'
-  },
-  longWorkspaceCard: {
-    display: 'flex', flexDirection: 'column', justifyContent: 'space-between', marginBottom: '0.5rem'
+    marginBottom: '0.5rem'
   },
   longTitle: {
     color: colors.blue[0], fontSize: 16,
@@ -121,7 +118,7 @@ const WorkspaceCard = pure(({ listView, onClone, onDelete, onShare, workspace: {
 
   return listView ? a({
     href: Nav.getLink('workspace', { namespace, name }),
-    style: { ...styles.longCard, ...styles.longWorkspaceCard }
+    style: styles.longCard
   }, [
     div({ style: { display: 'flex', alignItems: 'center' } }, [
       workspaceMenu,
@@ -136,7 +133,7 @@ const WorkspaceCard = pure(({ listView, onClone, onDelete, onShare, workspace: {
     ])
   ]) : a({
     href: Nav.getLink('workspace', { namespace, name }),
-    style: { ...styles.shortCard, ...styles.shortWorkspaceCard }
+    style: styles.shortCard
   }, [
     div({ style: styles.shortTitle }, [name]),
     div({ style: styles.shortDescription }, [descText]),
@@ -250,7 +247,7 @@ export const WorkspaceList = ajaxCaller(class WorkspaceList extends Component {
           }),
           !isDataLoaded && spinnerOverlay,
           listView ?
-            div({ style: { flex: 1, minWidth: 0, margin: '-0.5rem 0rem 0rem 0.75rem' } }, [
+            div({ style: { flex: 1, minWidth: 0 } }, [
               renderedWorkspaces
             ]) : renderedWorkspaces
         ]),

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -230,15 +230,8 @@ export const WorkspaceList = ajaxCaller(class WorkspaceList extends Component {
         })
       ]),
       h(PageFadeBox, [
-        div({
-          style: {
-            display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between',
-            marginBottom: '1rem'
-          }
-        }, [
-          div({ style: { ...Style.elements.sectionHeader, textTransform: 'uppercase' } }, [
-            'Workspaces'
-          ]),
+        div({ style: { display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '1rem' } }, [
+          div({ style: { ...Style.elements.sectionHeader, textTransform: 'uppercase' } }, ['Workspaces']),
           viewToggleButtons(listView, listView => this.setState({ listView }))
         ]),
         div({ style: styles.cardContainer(listView) }, [

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -272,9 +272,8 @@ class NotebooksContent extends Component {
       onDropAccepted: files => this.uploadFiles(files)
     }, [
       notebooks && h(PageFadeBox, {}, [
-        div({ style: { display: 'flex', alignItems: 'center', marginBottom: '1rem' } }, [
-          div({ style: { color: colors.darkBlue[0], fontSize: 16, fontWeight: 500 } }, 'NOTEBOOKS'),
-          div({ style: { flexGrow: 1 } }),
+        div({ style: { display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '1rem' } }, [
+          div({ style: { ...Style.elements.sectionHeader, textTransform: 'uppercase' } }, ['Notebooks']),
           viewToggleButtons(listView, listView => this.setState({ listView })),
           creating && h(NotebookCreator, {
             namespace, bucketName, existingNames,

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -3,7 +3,7 @@ import { createRef, Fragment } from 'react'
 import Dropzone from 'react-dropzone'
 import { a, div, h } from 'react-hyperscript-helpers'
 import * as breadcrumbs from 'src/components/breadcrumbs'
-import { Clickable, link, MenuButton, spinnerOverlay, viewToggleButtons } from 'src/components/common'
+import { Clickable, link, MenuButton, PageFadeBox, spinnerOverlay, viewToggleButtons } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import { NotebookCreator, NotebookDeleter, NotebookDuplicator } from 'src/components/notebook-utils'
 import PopupTrigger from 'src/components/PopupTrigger'
@@ -20,10 +20,10 @@ import { wrapWorkspace } from 'src/pages/workspaces/workspace/WorkspaceContainer
 
 
 const notebookCardCommonStyles = listView =>
-  _.merge({ margin: '1.25rem', display: 'flex' },
+  _.merge({ display: 'flex' },
     listView ?
-      { flexDirection: 'row' } :
-      { height: 250, width: 200, flexDirection: 'column' }
+      { marginBottom: '0.5rem', flexDirection: 'row' } :
+      { margin: '0 2.5rem 2.5rem 0', height: 250, width: 200, flexDirection: 'column' }
   )
 
 const printName = name => name.slice(10, -6) // removes 'notebooks/' and the .ipynb suffix
@@ -203,10 +203,15 @@ class NotebooksContent extends Component {
       onDelete: () => this.setState({ deletingNotebookName: name })
     }), notebooks)
 
-    return div({ style: { display: 'flex', flexWrap: listView ? undefined : 'wrap', padding: '0 2.25rem' } }, [
+    return div({
+      style: {
+        display: 'flex', flexWrap: listView ? undefined : 'wrap',
+        marginRight: listView ? undefined : '-2.5rem'
+      }
+    }, [
       div({
         style: {
-          margin: '1.25rem', display: 'flex',
+          margin: '0 2.5rem 2.5rem 0', display: 'flex',
           height: 250, width: 200, flexDirection: 'column',
           fontSize: 16, lineHeight: '22px'
         }
@@ -257,7 +262,7 @@ class NotebooksContent extends Component {
       disabled: !Utils.canWrite(accessLevel),
       disableClick: true,
       disablePreview: true,
-      style: { flexGrow: 1, padding: '1rem' },
+      style: { flexGrow: 1 },
       activeStyle: { backgroundColor: colors.blue[3], cursor: 'copy' }, // accept and reject don't work in all browsers
       acceptStyle: { cursor: 'copy' },
       rejectStyle: { cursor: 'no-drop' },
@@ -266,14 +271,9 @@ class NotebooksContent extends Component {
         'The selected file is not a ipynb notebook file. To import a notebook, upload a file with a .ipynb extension.'),
       onDropAccepted: files => this.uploadFiles(files)
     }, [
-      notebooks && h(Fragment, [
-        div({
-          style: {
-            display: 'flex', alignItems: 'center',
-            margin: '0 1.25rem'
-          }
-        }, [
-          div({ style: { color: colors.darkBlue[0], fontSize: 16, fontWeight: 500, padding: '0 2.25rem' } }, 'NOTEBOOKS'),
+      notebooks && h(PageFadeBox, {}, [
+        div({ style: { display: 'flex', alignItems: 'center', marginBottom: '1rem' } }, [
+          div({ style: { color: colors.darkBlue[0], fontSize: 16, fontWeight: 500 } }, 'NOTEBOOKS'),
           div({ style: { flexGrow: 1 } }),
           viewToggleButtons(listView, listView => this.setState({ listView })),
           creating && h(NotebookCreator, {

--- a/src/pages/workspaces/workspace/Tools.js
+++ b/src/pages/workspaces/workspace/Tools.js
@@ -1,9 +1,8 @@
 import _ from 'lodash/fp'
-import { Fragment } from 'react'
 import { a, div, h } from 'react-hyperscript-helpers'
 import { pure } from 'recompose'
 import * as breadcrumbs from 'src/components/breadcrumbs'
-import { spinnerOverlay, viewToggleButtons } from 'src/components/common'
+import { PageFadeBox, spinnerOverlay, viewToggleButtons } from 'src/components/common'
 import { ajaxCaller } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { reportError } from 'src/libs/error'
@@ -15,12 +14,12 @@ import { wrapWorkspace } from 'src/pages/workspaces/workspace/WorkspaceContainer
 
 
 const styles = {
-  cardContainer: {
-    padding: '1rem 4rem',
-    display: 'flex', flexWrap: 'wrap'
-  },
+  cardContainer: listView => ({
+    display: 'flex', flexWrap: 'wrap',
+    marginRight: listView ? undefined : '-1rem'
+  }),
   shortCard: {
-    ...Style.elements.card, width: 300, height: 125, margin: '1rem 0.5rem',
+    ...Style.elements.card, width: 300, height: 125, margin: '0 1rem 2rem 0',
     display: 'flex', flexDirection: 'column', justifyContent: 'space-between'
   },
   shortTitle: {
@@ -41,7 +40,7 @@ const styles = {
   longCard: {
     ...Style.elements.card,
     width: '100%', minWidth: 0,
-    margin: '0.25rem 0.5rem'
+    marginBottom: '0.5rem'
   },
   longTitle: {
     color: colors.blue[0], fontSize: 16,
@@ -105,18 +104,12 @@ class ToolsContent extends Component {
   render() {
     const { namespace, name } = this.props
     const { loading, configs, listView } = this.state
-    return h(Fragment, [
-      div({
-        style: {
-          display: 'flex', alignItems: 'flex-end', margin: '1rem 4.5rem', marginRight: '2.25rem', justifyContent: 'space-between'
-        }
-      }, [
-        div({ style: { ...Style.elements.sectionHeader, textTransform: 'uppercase' } }, [
-          'Tools'
-        ]),
+    return h(PageFadeBox, [
+      div({ style: { display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '1rem' } }, [
+        div({ style: { ...Style.elements.sectionHeader, textTransform: 'uppercase' } }, ['Tools']),
         viewToggleButtons(listView, listView => this.setState({ listView }))
       ]),
-      div({ style: styles.cardContainer }, [
+      div({ style: styles.cardContainer(listView) }, [
         _.map(config => {
           return h(ToolCard, { key: `${config.namespace}/${config.name}`, namespace, name, config, listView })
         }, configs),


### PR DESCRIPTION
I noticed these inconsistencies when working on the card/list view state thing.

* Added PageFadeBox to the Notebooks and Tools tabs, and updated the design to the mockups (smaller margins). Standardized the title/button bars.
* Cleaned up style across the workspaces list page. Only visible change: made it so the left edge of the first item doesn't move as you switch between list and card views.
* Gave PageFadeBox a min height, which unwonkifies the Tools tab when there are no tools.