### PR TITLE
enable cluster update button if current cluster is in error state

### DIFF
--- a/src/components/ClusterManager.js
+++ b/src/components/ClusterManager.js
@@ -316,7 +316,10 @@ export default ajaxCaller(class ClusterManager extends PureComponent {
   renderCreateForm() {
     const { busy, profile, masterMachineType, masterDiskSize, workerMachineType, numberOfWorkers, numberOfPreemptibleWorkers, workerDiskSize, jupyterUserScriptUri } = this.state
     const currentCluster = this.getCurrentCluster()
-    const changed = !currentCluster || !machineConfigsEqual(this.getMachineConfig(), currentCluster.machineConfig) || jupyterUserScriptUri
+    const changed = !currentCluster ||
+      currentCluster.status === 'Error' ||
+      !machineConfigsEqual(this.getMachineConfig(), currentCluster.machineConfig) ||
+      jupyterUserScriptUri
     return div({ style: { padding: '1rem' } }, [
       div({ style: { fontSize: 16, fontWeight: 500 } }, 'Runtime environment'),
       div({ style: styles.row }, [


### PR DESCRIPTION
This effectively allows you to retry cluster creation with the same config in case of a failure. Note that this should be an exceptional case, so we're just providing a basic affordance for trying to fix it.

Fixes #650 