### PR TITLE
Preserve quotes when uploading JSON

### DIFF
--- a/src/pages/workspaces/workspace/tools/WorkflowView.js
+++ b/src/pages/workspaces/workspace/tools/WorkflowView.js
@@ -284,10 +284,21 @@ class WorkflowViewContent extends Component {
     FileSaver.saveAs(blob, `${key}.json`)
   }
 
+  getTyped = updates => {
+    for (const key in updates) {
+      if (updates.hasOwnProperty(key)) {
+        if (!updates[key].startsWith('this.') && !updates[key].startsWith('workspace.')) {
+          updates[key] = `"` + updates[key] + `"`
+        }
+      }
+    }
+  }
+
   async uploadJson(key, file) {
     try {
       const text = await Utils.readFileAsText(file)
       const updates = _.mapValues(_.toString, JSON.parse(text))
+      this.getTyped(updates)
       this.setState(({ modifiedConfig, inputsOutputs }) => {
         const existing = _.map('name', inputsOutputs[key])
         return {

--- a/src/pages/workspaces/workspace/tools/WorkflowView.js
+++ b/src/pages/workspaces/workspace/tools/WorkflowView.js
@@ -291,7 +291,8 @@ class WorkflowViewContent extends Component {
       const rawUpdates = JSON.parse(await Utils.readFileAsText(file))
       const updates = _.mapValues(v => _.isString(v) && v.match(/\${(.*)}/) ?
         v.replace(/\${(.*)}/, (_, match) => match) :
-        JSON.stringify(v))(rawUpdates)
+        JSON.stringify(v)
+      )(rawUpdates)
       this.setState(({ modifiedConfig, inputsOutputs }) => {
         const existing = _.map('name', inputsOutputs[key])
         return {


### PR DESCRIPTION
Now when uploading a JSON input to a tool, if the name is **not** this.x or workspace.x, we want quotes around it. This behavior matches how FireCloud determines what gets or doesn't get quotes upon import. 

My solution feels a bit crude but does the intended behavior, so feedback is appreciated! 

Note: Dockstore dev is down so I couldn't test this on any dockstore tools 

<img width="1628" alt="screen shot 2018-09-26 at 1 33 11 pm" src="https://user-images.githubusercontent.com/42386483/46097780-c3d88b00-c190-11e8-8cdd-0db94f249ae1.png">
^^imported from a regular JSON where both values are simply just strings but the this.x doesn't have quotes while the other does 