### PR TITLE
standardize class names and displayName

### DIFF
--- a/src/libs/__mocks__/ajax.js
+++ b/src/libs/__mocks__/ajax.js
@@ -64,22 +64,22 @@ export const Ajax = () => ({
 })
 
 export const ajaxCaller = WrappedComponent => {
-  class AjaxWrapper extends Component {
+  class Wrapper extends Component {
     constructor(props) {
       super(props)
       this.ajax = Ajax()
     }
 
     render() {
-      const { forwardedRef, ...rest } = this.props
+      const { forwardedRef, forwardedProps } = this.props
 
       return h(WrappedComponent, {
         ref: forwardedRef,
         ajax: this.ajax,
-        ...rest
+        ...forwardedProps
       })
     }
   }
 
-  return forwardRef((props, ref) => h(AjaxWrapper, { forwardedRef: ref, ...props }))
+  return forwardRef((props, ref) => h(Wrapper, { forwardedRef: ref, forwardedProps: props }))
 }

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -567,20 +567,22 @@ export const Ajax = controller => {
 
 
 export const ajaxCaller = WrappedComponent => {
-  class AjaxWrapper extends Component {
+  class Wrapper extends Component {
     constructor(props) {
       super(props)
       this.controller = new window.AbortController()
       this.ajax = Ajax(this.controller)
     }
 
+    static displayName = 'ajaxCaller()'
+
     render() {
-      const { forwardedRef, ...rest } = this.props
+      const { forwardedRef, forwardedProps } = this.props
 
       return h(WrappedComponent, {
         ref: forwardedRef,
         ajax: this.ajax,
-        ...rest
+        ...forwardedProps
       })
     }
 
@@ -589,5 +591,5 @@ export const ajaxCaller = WrappedComponent => {
     }
   }
 
-  return forwardRef((props, ref) => h(AjaxWrapper, { forwardedRef: ref, ...props }))
+  return forwardRef((props, ref) => h(Wrapper, { forwardedRef: ref, forwardedProps: props }))
 }

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -36,11 +36,13 @@ export const atom = initialValue => {
  * component will re-render
  */
 export const connectAtom = (theAtom, name) => WrappedComponent => {
-  class AtomWrapper extends Component {
+  class Wrapper extends Component {
     constructor(props) {
       super(props)
       this.state = { value: theAtom.get() }
     }
+
+    static displayName = 'connectAtom()'
 
     componentDidMount() {
       theAtom.subscribe(this.handleChange)
@@ -55,17 +57,18 @@ export const connectAtom = (theAtom, name) => WrappedComponent => {
     }
 
     render() {
-      const { forwardedRef, ...rest } = this.props
+      const { forwardedRef, forwardedProps } = this.props
       const { value } = this.state
 
-      return h(WrappedComponent, _.merge({
+      return h(WrappedComponent, {
         ref: forwardedRef,
-        ...rest
-      }, name && { [name]: value }))
+        ...forwardedProps,
+        [name]: value
+      })
     }
   }
 
-  return forwardRef((props, ref) => h(AtomWrapper, { forwardedRef: ref, ...props }))
+  return forwardRef((props, ref) => h(Wrapper, { forwardedRef: ref, forwardedProps: props }))
 }
 
 export const makePrettyDate = function(dateString) {

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -61,11 +61,13 @@ const InfoTile = ({ title, children }) => {
   ])
 }
 
-export const WorkspaceDashboard = ajaxCaller(wrapWorkspace({
-  breadcrumbs: () => breadcrumbs.commonPaths.workspaceList(),
-  activeTab: 'dashboard'
-},
-class WorkspaceDashboardContent extends Component {
+export const WorkspaceDashboard = _.flow(
+  wrapWorkspace({
+    breadcrumbs: () => breadcrumbs.commonPaths.workspaceList(),
+    activeTab: 'dashboard'
+  }),
+  ajaxCaller
+)(class WorkspaceDashboard extends Component {
   constructor(props) {
     super(props)
     this.state = {
@@ -182,7 +184,7 @@ class WorkspaceDashboardContent extends Component {
       ])
     ])
   }
-}))
+})
 
 export const addNavPaths = () => {
   Nav.defPath('workspace-dashboard', {

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -82,11 +82,13 @@ const saveScroll = _.throttle(100, (initialX, initialY) => {
   StateHistory.update({ initialX, initialY })
 })
 
-const WorkspaceData = ajaxCaller(wrapWorkspace({
-  breadcrumbs: props => breadcrumbs.commonPaths.workspaceDashboard(props),
-  title: 'Data', activeTab: 'data'
-},
-class WorkspaceDataContent extends Component {
+const WorkspaceData = _.flow(
+  wrapWorkspace({
+    breadcrumbs: props => breadcrumbs.commonPaths.workspaceDashboard(props),
+    title: 'Data', activeTab: 'data'
+  }),
+  ajaxCaller
+)(class WorkspaceData extends Component {
   constructor(props) {
     super(props)
 
@@ -649,7 +651,7 @@ class WorkspaceDataContent extends Component {
       this.loadData()
     }
   }
-}))
+})
 
 export const addNavPaths = () => {
   Nav.defPath('workspace-data', {

--- a/src/pages/workspaces/workspace/JobHistory.js
+++ b/src/pages/workspaces/workspace/JobHistory.js
@@ -93,11 +93,13 @@ const statusCell = workflowStatuses => {
 const animationLengthMillis = 1000
 
 
-const JobHistory = ajaxCaller(wrapWorkspace({
-  breadcrumbs: props => breadcrumbs.commonPaths.workspaceDashboard(props),
-  title: 'Job History', activeTab: 'job history'
-},
-class JobHistoryContent extends Component {
+const JobHistory = _.flow(
+  wrapWorkspace({
+    breadcrumbs: props => breadcrumbs.commonPaths.workspaceDashboard(props),
+    title: 'Job History', activeTab: 'job history'
+  }),
+  ajaxCaller
+)(class JobHistory extends Component {
   constructor(props) {
     super(props)
 
@@ -258,7 +260,7 @@ class JobHistoryContent extends Component {
       clearTimeout(this.scheduledRefresh)
     }
   }
-}))
+})
 
 
 export const addNavPaths = () => {

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -126,11 +126,14 @@ class NotebookCard extends Component {
   }
 }
 
-const WorkspaceNotebooks = ajaxCaller(togglesListView('notebooksTab')(wrapWorkspace({
-  breadcrumbs: props => breadcrumbs.commonPaths.workspaceDashboard(props),
-  title: 'Notebooks', activeTab: 'notebooks'
-},
-class NotebooksContent extends Component {
+const Notebooks = _.flow(
+  wrapWorkspace({
+    breadcrumbs: props => breadcrumbs.commonPaths.workspaceDashboard(props),
+    title: 'Notebooks', activeTab: 'notebooks'
+  }),
+  togglesListView('notebooksTab'),
+  ajaxCaller
+)(class Notebooks extends Component {
   constructor(props) {
     super(props)
     this.state = {
@@ -326,12 +329,12 @@ class NotebooksContent extends Component {
       this.state)
     )
   }
-})))
+})
 
 export const addNavPaths = () => {
   Nav.defPath('workspace-notebooks', {
     path: '/workspaces/:namespace/:name/notebooks',
-    component: WorkspaceNotebooks,
+    component: Notebooks,
     title: ({ name }) => `${name} - Notebooks`
   })
 }

--- a/src/pages/workspaces/workspace/Tools.js
+++ b/src/pages/workspaces/workspace/Tools.js
@@ -75,11 +75,14 @@ const ToolCard = pure(({ listView, name, namespace, config }) => {
   ])
 })
 
-export const WorkspaceTools = ajaxCaller(togglesListView('toolsTab')(wrapWorkspace({
-  breadcrumbs: props => breadcrumbs.commonPaths.workspaceDashboard(props),
-  title: 'Tools', activeTab: 'tools'
-},
-class ToolsContent extends Component {
+export const Tools = _.flow(
+  wrapWorkspace({
+    breadcrumbs: props => breadcrumbs.commonPaths.workspaceDashboard(props),
+    title: 'Tools', activeTab: 'tools'
+  }),
+  togglesListView('toolsTab'),
+  ajaxCaller
+)(class Tools extends Component {
   constructor(props) {
     super(props)
     this.state = StateHistory.get()
@@ -124,12 +127,12 @@ class ToolsContent extends Component {
   componentDidUpdate() {
     StateHistory.update(_.pick(['configs'], this.state))
   }
-})))
+})
 
 export const addNavPaths = () => {
   Nav.defPath('workspace-tools', {
     path: '/workspaces/:namespace/:name/tools',
-    component: WorkspaceTools,
+    component: Tools,
     title: ({ name }) => `${name} - Tools`
   })
 }

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -175,12 +175,14 @@ class WorkspaceContainer extends Component {
 }
 
 
-export const wrapWorkspace = ({ breadcrumbs, activeTab, title, showTabBar = true }, content) => {
-  return ajaxCaller(class WorkspaceContainerWrapper extends Component {
+export const wrapWorkspace = ({ breadcrumbs, activeTab, title, showTabBar = true }) => WrappedComponent => {
+  return ajaxCaller(class Wrapper extends Component {
     constructor(props) {
       super(props)
       this.child = createRef()
     }
+
+    static displayName = 'wrapWorkspace()'
 
     render() {
       const { workspaceError } = this.state
@@ -205,7 +207,7 @@ export const wrapWorkspace = ({ breadcrumbs, activeTab, title, showTabBar = true
         },
         refreshClusters: () => this.refreshClusters()
       }, [
-        workspace && h(content, {
+        workspace && h(WrappedComponent, {
           ref: this.child,
           workspace, clusters,
           refreshWorkspace: () => this.refresh(),

--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -42,12 +42,14 @@ const getCluster = clusters => {
   )(clusters)
 }
 
-const NotebookLauncher = ajaxCaller(wrapWorkspace({
-  breadcrumbs: props => breadcrumbs.commonPaths.workspaceDashboard(props),
-  title: ({ notebookName }) => `Notebooks - ${notebookName}`,
-  showTabBar: false
-},
-class NotebookLauncherContent extends Component {
+const NotebookLauncher = _.flow(
+  wrapWorkspace({
+    breadcrumbs: props => breadcrumbs.commonPaths.workspaceDashboard(props),
+    title: ({ notebookName }) => `Notebooks - ${notebookName}`,
+    showTabBar: false
+  }),
+  ajaxCaller
+)(class NotebookLauncher extends Component {
   saveNotebook() {
     this.notebookFrame.current.contentWindow.postMessage('save', '*')
   }
@@ -225,7 +227,7 @@ class NotebookLauncherContent extends Component {
       ])
     ])
   }
-}))
+})
 
 
 export const addNavPaths = () => {

--- a/src/pages/workspaces/workspace/notebooks/TerminalLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/TerminalLauncher.js
@@ -10,12 +10,14 @@ import { Component } from 'src/libs/wrapped-components'
 import { wrapWorkspace } from 'src/pages/workspaces/workspace/WorkspaceContainer'
 
 
-const TerminalLauncher = ajaxCaller(wrapWorkspace({
-  breadcrumbs: props => breadcrumbs.commonPaths.workspaceDashboard(props),
-  title: () => `Terminal`,
-  activeTab: 'notebooks'
-},
-class TerminalLauncherContent extends Component {
+const TerminalLauncher = _.flow(
+  wrapWorkspace({
+    breadcrumbs: props => breadcrumbs.commonPaths.workspaceDashboard(props),
+    title: () => `Terminal`,
+    activeTab: 'notebooks'
+  }),
+  ajaxCaller
+)(class TerminalLauncher extends Component {
   async loadIframe() {
     const { clusters } = this.props
     const { url } = this.state
@@ -72,7 +74,7 @@ class TerminalLauncherContent extends Component {
       }) :
       centeredSpinner()
   }
-}))
+})
 
 
 export const addNavPaths = () => {

--- a/src/pages/workspaces/workspace/tools/WorkflowView.js
+++ b/src/pages/workspaces/workspace/tools/WorkflowView.js
@@ -129,11 +129,13 @@ const WorkflowIOTable = ({ which, inputsOutputs, config, errors, onChange, sugge
 }
 
 
-const WorkflowView = ajaxCaller(wrapWorkspace({
-  breadcrumbs: props => breadcrumbs.commonPaths.workspaceTab(props, 'tools'),
-  title: ({ workflowName }) => workflowName, activeTab: 'tools'
-},
-class WorkflowViewContent extends Component {
+const WorkflowView = _.flow(
+  wrapWorkspace({
+    breadcrumbs: props => breadcrumbs.commonPaths.workspaceTab(props, 'tools'),
+    title: ({ workflowName }) => workflowName, activeTab: 'tools'
+  }),
+  ajaxCaller
+)(class WorkflowView extends Component {
   constructor(props) {
     super(props)
 
@@ -435,7 +437,7 @@ class WorkflowViewContent extends Component {
 
     this.setState({ saved: false, modifiedConfig: savedConfig })
   }
-}))
+})
 
 
 export const addNavPaths = () => {


### PR DESCRIPTION
* Names component classes the same as their file.
* Adds `displayName` for HOC wrappers with the same name as the function.
* Prefers `_.flow` when applying multiple HOCs.
* Tightens up prop forwarding in HOCs.