### PR TITLE
enable read-only notebook view

### DIFF
--- a/config/dev.json
+++ b/config/dev.json
@@ -1,5 +1,6 @@
 {
   "agoraUrlRoot": "https://agora.dsde-dev.broadinstitute.org",
+  "calhounUrlRoot": "https://terra-calhoun-dev.appspot.com",
   "devUrlRoot": "https://bvdp-saturn-dev.appspot.com",
   "dockstoreUrlRoot": "https://staging.dockstore.org:8443",
   "firecloudUrlRoot": "https://firecloud.dsde-dev.broadinstitute.org",

--- a/config/prod.json
+++ b/config/prod.json
@@ -1,5 +1,6 @@
 {
   "agoraUrlRoot": "https://agora.dsde-prod.broadinstitute.org",
+  "calhounUrlRoot": "https://terra-calhoun-prod.appspot.com",
   "dockstoreUrlRoot": "https://dockstore.org:8443",
   "firecloudUrlRoot": "https://portal.firecloud.org",
   "googleClientId": "424501080111-b3bt4p1vo4gbo4m0573nvi4d49784bp8.apps.googleusercontent.com",

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -426,6 +426,16 @@ const Buckets = signal => ({
       )
     }
     return {
+      preview: async () => {
+        const nb = await fetchBuckets(
+          `${bucketUrl}/${encodeURIComponent(`notebooks/${name}`)}?alt=media`,
+          _.merge(authOpts(await User(signal).token(namespace)), { signal })
+        ).then(res => res.text())
+        return fetchOk(`${await Config.getCalhounRoot()}/api/convert`,
+          _.mergeAll([authOpts(), { signal, method: 'POST', body: nb }])
+        ).then(res => res.text())
+      },
+
       copy,
 
       create: async contents => {

--- a/src/libs/config.js
+++ b/src/libs/config.js
@@ -25,6 +25,7 @@ const getConfig = async () => {
 }
 
 export const getAgoraUrlRoot = async () => (await getConfig()).agoraUrlRoot
+export const getCalhounRoot = async () => (await getConfig()).calhounUrlRoot
 export const getDevUrlRoot = async () => (await getConfig()).devUrlRoot
 export const getDockstoreUrlRoot = async () => (await getConfig()).dockstoreUrlRoot
 export const getFirecloudUrlRoot = async () => (await getConfig()).firecloudUrlRoot

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -31,12 +31,11 @@ const notebookCardCommonStyles = listView =>
 
 const printName = name => name.slice(10, -6) // removes 'notebooks/' and the .ipynb suffix
 
-const noCompute = 'You do not have access to run analyses on this workspace.'
 const noWrite = 'You do not have access to modify this workspace.'
 
 class NotebookCard extends Component {
   render() {
-    const { namespace, name, updated, listView, wsName, onRename, onCopy, onDelete, canCompute, canWrite } = this.props
+    const { namespace, name, updated, listView, wsName, onRename, onCopy, onDelete, canWrite } = this.props
 
     const notebookLink = Nav.getLink('workspace-notebook-launch', { namespace, name: wsName, notebookName: name.slice(10) })
 
@@ -99,38 +98,34 @@ class NotebookCard extends Component {
       }
     }, printName(name))
 
-    return h(Fragment, [
-      h(TooltipTrigger, { content: !canCompute ? noCompute : undefined }, [
-        a({
-          href: canCompute ? notebookLink : undefined,
-          style: {
-            ...Style.elements.card,
-            ...notebookCardCommonStyles(listView),
-            flexShrink: 0,
-            justifyContent: listView ? undefined : 'space-between',
-            alignItems: listView ? 'center' : undefined
-          }
-        }, listView ? [
-          notebookMenu,
-          title,
-          div({ style: { flexGrow: 1 } }),
-          h(TooltipTrigger, { content: Utils.makeCompleteDate(updated) }, [
-            div({ style: { fontSize: '0.8rem', marginRight: '0.5rem' } },
-              `Last edited: ${Utils.makePrettyDate(updated)}`)
+    return a({
+      href: notebookLink,
+      style: {
+        ...Style.elements.card,
+        ...notebookCardCommonStyles(listView),
+        flexShrink: 0,
+        justifyContent: listView ? undefined : 'space-between',
+        alignItems: listView ? 'center' : undefined
+      }
+    }, listView ? [
+      notebookMenu,
+      title,
+      div({ style: { flexGrow: 1 } }),
+      h(TooltipTrigger, { content: Utils.makeCompleteDate(updated) }, [
+        div({ style: { fontSize: '0.8rem', marginRight: '0.5rem' } },
+          `Last edited: ${Utils.makePrettyDate(updated)}`)
+      ])
+    ] : [
+      title,
+      jupyterIcon,
+      div({ style: { display: 'flex', justifyContent: 'space-between' } }, [
+        h(TooltipTrigger, { content: Utils.makeCompleteDate(updated) }, [
+          div({ style: { fontSize: '0.8rem', flexGrow: 1, marginRight: '0.5rem' } }, [
+            'Last edited:',
+            div({}, Utils.makePrettyDate(updated))
           ])
-        ] : [
-          title,
-          jupyterIcon,
-          div({ style: { display: 'flex', justifyContent: 'space-between' } }, [
-            h(TooltipTrigger, { content: Utils.makeCompleteDate(updated) }, [
-              div({ style: { fontSize: '0.8rem', flexGrow: 1, marginRight: '0.5rem' } }, [
-                'Last edited:',
-                div({}, Utils.makePrettyDate(updated))
-              ])
-            ]),
-            notebookMenu
-          ])
-        ])
+        ]),
+        notebookMenu
       ])
     ])
   }
@@ -209,12 +204,12 @@ const Notebooks = _.flow(
     const { notebooks } = this.state
     const {
       name: wsName, namespace, listView,
-      workspace: { accessLevel, canCompute, workspace: { bucketName } }
+      workspace: { accessLevel, workspace: { bucketName } }
     } = this.props
     const canWrite = Utils.canWrite(accessLevel)
     const renderedNotebooks = _.map(({ name, updated }) => h(NotebookCard, {
       key: name,
-      name, updated, listView, bucketName, namespace, wsName, canCompute, canWrite,
+      name, updated, listView, bucketName, namespace, wsName, canWrite,
       onRename: () => this.setState({ renamingNotebookName: name }),
       onCopy: () => this.setState({ copyingNotebookName: name }),
       onDelete: () => this.setState({ deletingNotebookName: name })


### PR DESCRIPTION
This wires up the new service and enables the basic read-only notebook view. The close button is included, but some of the additional messaging and workflows from #748 will be done in a separate ticket.