### PR TITLE
Groups on auth domain links to groups page

### DIFF
--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -171,7 +171,12 @@ export const WorkspaceDashboard = _.flow(
         !_.isEmpty(authorizationDomain) && h(Fragment, [
           div({ style: styles.header }, ['Authorization Domain']),
           div({ style: { marginBottom: '0.5rem' } }, [
-            'Collaborators must be a member of all of these groups to access this workspace.'
+            'Collaborators must be a member of all of these ',
+            link({
+              href: Nav.getLink('groups'),
+              target: '_blank'
+            }, 'groups'),
+            ' to access this workspace.'
           ]),
           ..._.map(({ membersGroupName }) => div({ style: styles.authDomain }, [membersGroupName]), authorizationDomain)
         ]),


### PR DESCRIPTION
Clicking the word "groups" in the authorization domain opens /#groups in a new tab from the dashboard of a workspace. 

Looks like this now:
<img width="345" alt="screen shot 2018-10-24 at 2 00 06 pm" src="https://user-images.githubusercontent.com/42386483/47451193-22dfee80-d795-11e8-89c9-dc7452c07015.png">
