### PR TITLE
remove forwardRef for now

### DIFF
--- a/src/components/workspace-utils.js
+++ b/src/components/workspace-utils.js
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp'
-import { Component, forwardRef, Fragment } from 'react'
+import { Component, Fragment } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
 import { buttonPrimary, linkButton, Select } from 'src/components/common'
 import NewWorkspaceModal from 'src/components/NewWorkspaceModal'
@@ -45,18 +45,16 @@ export const withWorkspaces = ({ persist } = {}) => WrappedComponent => {
     }
 
     render() {
-      const { forwardedRef, forwardedProps } = this.props
       const { workspaces, loadingWorkspaces } = this.state
       return h(WrappedComponent, {
-        ...forwardedProps,
+        ...this.props,
         workspaces,
         loadingWorkspaces,
-        refreshWorkspaces: () => this.refresh(),
-        ref: forwardedRef
+        refreshWorkspaces: () => this.refresh()
       })
     }
   })
-  return forwardRef((props, ref) => h(Wrapper, { forwardedProps: props, forwardedRef: ref }))
+  return Wrapper
 }
 
 export const WorkspaceSelector = ({ workspaces, value, onChange }) => {

--- a/src/libs/__mocks__/ajax.js
+++ b/src/libs/__mocks__/ajax.js
@@ -1,7 +1,6 @@
 import _ from 'lodash/fp'
 import { h } from 'react-hyperscript-helpers'
 import { Component } from 'src/libs/wrapped-components'
-import { forwardRef } from 'react'
 
 
 export const createWorkspace = overrides => {
@@ -71,15 +70,12 @@ export const ajaxCaller = WrappedComponent => {
     }
 
     render() {
-      const { forwardedRef, forwardedProps } = this.props
-
       return h(WrappedComponent, {
-        ref: forwardedRef,
-        ajax: this.ajax,
-        ...forwardedProps
+        ...this.props,
+        ajax: this.ajax
       })
     }
   }
 
-  return forwardRef((props, ref) => h(Wrapper, { forwardedRef: ref, forwardedProps: props }))
+  return Wrapper
 }

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1,6 +1,5 @@
 import _ from 'lodash/fp'
 import * as qs from 'qs'
-import { forwardRef } from 'react'
 import { h } from 'react-hyperscript-helpers'
 import { version } from 'src/data/clusters'
 import { getUser } from 'src/libs/auth'
@@ -587,12 +586,9 @@ export const ajaxCaller = WrappedComponent => {
     static displayName = 'ajaxCaller()'
 
     render() {
-      const { forwardedRef, forwardedProps } = this.props
-
       return h(WrappedComponent, {
-        ref: forwardedRef,
-        ajax: this.ajax,
-        ...forwardedProps
+        ...this.props,
+        ajax: this.ajax
       })
     }
 
@@ -601,5 +597,5 @@ export const ajaxCaller = WrappedComponent => {
     }
   }
 
-  return forwardRef((props, ref) => h(Wrapper, { forwardedRef: ref, forwardedProps: props }))
+  return Wrapper
 }

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp'
-import { Component, forwardRef } from 'react'
+import { Component } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
 import uuid from 'uuid/v4'
 
@@ -57,18 +57,16 @@ export const connectAtom = (theAtom, name) => WrappedComponent => {
     }
 
     render() {
-      const { forwardedRef, forwardedProps } = this.props
       const { value } = this.state
 
       return h(WrappedComponent, {
-        ref: forwardedRef,
-        ...forwardedProps,
+        ...this.props,
         [name]: value
       })
     }
   }
 
-  return forwardRef((props, ref) => h(Wrapper, { forwardedRef: ref, forwardedProps: props }))
+  return Wrapper
 }
 
 export const makePrettyDate = function(dateString) {


### PR DESCRIPTION
`forwardRef` does not work with hot loading. This is a known issue, and we're able to do without the ref forwarding for now, as long as our HOCs are in the right order. We may need to revisit this at some point.