### PR TITLE
Re-add logic to catch unregistered user in downstream error handling

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -113,7 +113,7 @@ const User = signal => ({
   }, namespace => namespace, 1000 * 60 * 30),
 
   getStatus: async () => {
-    return fetchSam('register/user/v2/self/info', _.merge(authOpts(), { signal }))
+    return instrumentedFetch(`${await Config.getSamUrlRoot()}/register/user/v2/self/info`, _.mergeAll([authOpts(), { signal }, appIdentifier]))
   },
 
   create: async () => {


### PR DESCRIPTION
There was a bug that prevented new users from registering. When Sam responded that a user was unknown, we treated it as a failure so the user got an error and an endless spinner. 
Now when Sam responds that it doesn't know the user, we allow the user to register and get access. This was masked in production since there is the white list, but once that goes away this would have been exposed.

@panentheos should the risk be low or high?