### PR TITLE
Ez change saturn to terra

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -16,7 +16,7 @@
 
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.png">
     <script src="https://apis.google.com/js/platform.js"></script>
-    <title>Saturn</title>
+    <title>Terra</title>
   </head>
   <body>
     <noscript>

--- a/src/components/FooterWrapper.js
+++ b/src/components/FooterWrapper.js
@@ -29,7 +29,7 @@ const FooterWrapper = ({ children }) => {
         icon('logoGrey', { size: 36 }),
         div({
           style: { fontSize: 25, fontWeight: 500, textTransform: 'uppercase', marginLeft: '0.5rem' }
-        }, 'Saturn')
+        }, 'Terra')
       ]),
       a({ href: Nav.getLink('privacy'), style: styles.link }, 'Privacy Policy'),
       a({ target: '_blank', href: tosUrl, style: styles.link }, 'Terms of Service'),

--- a/src/components/Router.js
+++ b/src/components/Router.js
@@ -79,7 +79,7 @@ export default class Router extends Component {
         document.title = handler.title
       }
     } else {
-      document.title = 'Saturn'
+      document.title = 'Terra'
     }
   }
 

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -101,7 +101,7 @@ export default class TopBar extends Component {
               },
               href: Nav.getLink('workspaces'),
               onClick: () => this.hideNav()
-            }, [logo(), 'Saturn'])
+            }, [logo(), 'Terra'])
           ]),
           h(Collapse, {
             defaultHidden: true,
@@ -218,7 +218,7 @@ export default class TopBar extends Component {
         div({}, [
           div({
             style: { fontSize: '0.8rem', color: colors.slate, marginLeft: '0.1rem' }
-          }, ['Saturn']),
+          }, ['Terra']),
           title
         ])
       ]),

--- a/src/pages/BrowseData.js
+++ b/src/pages/BrowseData.js
@@ -108,7 +108,7 @@ class Participant extends Component {
 }
 
 
-const browseTooltip = 'Look for the Export to Saturn icon to export data from this provider.'
+const browseTooltip = 'Look for the Export to Terra icon to export data from this provider.'
 
 
 const NIHCommonsButtons = h(Fragment, [

--- a/src/pages/Disabled.js
+++ b/src/pages/Disabled.js
@@ -18,7 +18,7 @@ export const Disabled = () => {
 export const Unlisted = () => {
   return div({ style: { padding: '1rem' } }, [
     div([
-      'Saturn is under development. If you are interested in contributing feedback as part of our user panel, please email ',
+      'Terra is under development. If you are interested in contributing feedback as part of our user panel, please email ',
       link({ href: 'mailto:saturn-dev@broadinstitute.org' }, 'saturn-dev@broadinstitute.org'),
       '.'
     ]),

--- a/src/pages/PrivacyPolicy.js
+++ b/src/pages/PrivacyPolicy.js
@@ -5,40 +5,40 @@ import * as Nav from 'src/libs/nav'
 
 const PrivacyPolicy = () => {
   return div({ style: { paddingLeft: '1rem', paddingRight: '1rem' } }, [
-    h4('Saturn Privacy Policy'),
+    h4('Terra Privacy Policy'),
     p([
       'The following Privacy Policy discloses our information gathering and dissemination ',
-      'practices for the Broad Institute Saturn application accessed via this website. ',
-      'By using Saturn, you agree to the collection and use of information in accordance with ',
+      'practices for the Broad Institute Terra application accessed via this website. ',
+      'By using Terra, you agree to the collection and use of information in accordance with ',
       'this policy. This Privacy Policy is effective as of 1-19-2017.'
     ]),
     h4('Information Gathering'),
     p([
-      'The Broad Institute Saturn receives and stores information related to users’ Google ',
+      'The Broad Institute Terra receives and stores information related to users’ Google ',
       'profiles, including names, email addresses, user IDs, and OAuth tokens. This information ',
       'is gathered as part of the standard Google sign-in process.'
     ]),
     p([
-      'We also collect information that your browser sends whenever you visit the Saturn ',
+      'We also collect information that your browser sends whenever you visit the Terra ',
       'website (“Log Data”). This Log Data may include information such as your computer’s ',
       'Internet Protocol (“IP”) address, browser type, browser version, which pages of the ',
-      'Saturn Portal that you visit, the time and date of your visit, the time spent on ',
+      'Terra Portal that you visit, the time and date of your visit, the time spent on ',
       'individual pages, and other statistics. This information may include any search terms ',
-      'that you enter on the Saturn (e.g., dataset name, method name, tag labels). We do not ',
+      'that you enter on the Terra (e.g., dataset name, method name, tag labels). We do not ',
       'link IP addresses to any personally identifying information. User sessions will be ',
       'tracked, but users will remain anonymous.'
     ]),
     p([
       'In addition, we use web tools such as Google Analytics that collect, monitor, and analyze ',
       'the Log Data. User information (i.e., name and email address) is not included in our ',
-      'Google Analytics tracking, but can be internally linked within the Saturn development ',
+      'Google Analytics tracking, but can be internally linked within the Terra development ',
       'team.'
     ]),
     h4('Use of Information'),
     p([
-      'Saturn uses the information gathered above to enable integration with Google-based ',
+      'Terra uses the information gathered above to enable integration with Google-based ',
       'services that require a Google account, such as Google Cloud Storage Platform. We may ',
-      'also use this information to provide you with the services on Saturn, improve Saturn, and ',
+      'also use this information to provide you with the services on Terra, improve Terra, and ',
       'to communicate with you (e.g., about new feature announcements, unplanned site ',
       'maintenance, and general notices). Web server logs are retained on a temporary basis and ',
       'then deleted completely from our systems. User information is stored in a ',
@@ -50,10 +50,10 @@ const PrivacyPolicy = () => {
     ]),
     h4('Publicly Uploaded Information'),
     p([
-      'Some features of Saturn are public facing (e.g, publishing a workspace in the Data ',
+      'Some features of Terra are public facing (e.g, publishing a workspace in the Data ',
       'Library) and allow you to upload information (such as new studies) that you may choose to ',
       'make publicly available. If you choose to upload content is public-facing, third parties ',
-      'may access and use it. We do not sell any information that you provide to Saturn; it ',
+      'may access and use it. We do not sell any information that you provide to Terra; it ',
       'is yours. However, any information that you make publicly available may be accessed and ',
       'used by third parties, such as research organizations or commercial third parties.'
     ]),
@@ -67,7 +67,7 @@ const PrivacyPolicy = () => {
     h4('Changes'),
     p([
       'Although most changes are likely to be minor, we may change our Privacy Policy from time ',
-      'to time. We will notify you of material changes to this Privacy Policy through the Saturn ',
+      'to time. We will notify you of material changes to this Privacy Policy through the Terra ',
       'website at least 30 days before the change takes effect by posting a notice on our home ',
       'page or by sending an email to the email address associated with your user account. For ',
       'changes to this Privacy Policy that do not affect your rights, we encourage you to check ',
@@ -75,11 +75,11 @@ const PrivacyPolicy = () => {
     ]),
     h4('Third Party Sites'),
     p([
-      'Some Saturn pages may link to third party websites or services that are not maintained ',
+      'Some Terra pages may link to third party websites or services that are not maintained ',
       'by the Broad Institute. The Broad Institute is not responsible for the privacy practices ',
       'or the content of any such third party websites or services.'
     ]),
-    h4('Contacting the Saturn team'),
+    h4('Contacting the Terra team'),
     p([
       'If you have any questions about this privacy statement, the practices of this site, or ',
       'your dealings with this site, you can contact us through our ',

--- a/src/pages/Register.js
+++ b/src/pages/Register.js
@@ -61,7 +61,7 @@ export default ajaxCaller(class Register extends Component {
     }, [
       div({ style: { display: 'flex', alignItems: 'center' } }, [
         logo({ size: 100, style: { marginRight: 20 } }),
-        div({ style: { fontWeight: 500, fontSize: 70, color: colors.darkBlue[0] } }, ['SATURN'])
+        div({ style: { fontWeight: 500, fontSize: 70, color: colors.darkBlue[0] } }, ['TERRA'])
       ]),
       div({
         style: {

--- a/src/pages/SignIn.js
+++ b/src/pages/SignIn.js
@@ -31,12 +31,12 @@ export default class SignIn extends Component {
           div({ style: { display: 'flex', marginBottom: '1rem', alignItems: 'center' } }, [
             div({ style: { fontWeight: 500, marginRight: '2rem' } }, [
               div({ style: { fontSize: 40, color: colors.slate } }, ['Welcome to']),
-              div({ style: { fontSize: 80, color: colors.darkBlue[0] } }, ['SATURN'])
+              div({ style: { fontSize: 80, color: colors.darkBlue[0] } }, ['TERRA'])
             ]),
             logo({ size: 265 })
           ]),
           div({ style: { fontSize: 40, fontWeight: 500, color: colors.slate } }, ['New User?']),
-          div({ style: { fontSize: 20, marginBottom: '2rem' } }, ['Saturn requires a Google Account.']),
+          div({ style: { fontSize: 20, marginBottom: '2rem' } }, ['Terra requires a Google Account.']),
           div({ style: { display: 'flex', alignItems: 'center' } }, [
             div({
               style: {
@@ -45,9 +45,9 @@ export default class SignIn extends Component {
                   `1px solid ${colors.gray[0]}`
               }
             }, [
-              div(['Need to create a SATURN account? Saturn uses your Google account.']),
+              div(['Need to create a TERRA account? Terra uses your Google account.']),
               div({ style: { paddingBottom: '1rem' } },
-                ['Once you have signed in and completed the user profile registration step, you can start using SATURN.']
+                ['Once you have signed in and completed the user profile registration step, you can start using TERRA.']
               ),
               link({ target: '_blank', href: 'https://software.broadinstitute.org/firecloud/documentation/article?id=9846' },
                 'Learn how to create a Google account with any email address.'

--- a/src/pages/StyleGuide.js
+++ b/src/pages/StyleGuide.js
@@ -70,7 +70,7 @@ class StyleGuide extends Component {
             marginLeft: '2rem'
           }
         }, [
-          'SATURN STYLE GUIDE'
+          'TERRA STYLE GUIDE'
         ])
       ]),
       els.section('Color Styles', [

--- a/src/pages/TermsOfService.js
+++ b/src/pages/TermsOfService.js
@@ -8,9 +8,9 @@ import { reportError } from 'src/libs/error'
 import * as Style from 'src/libs/style'
 
 const termsOfService = `
-Your access to and use of Saturn is subject to the following terms and conditions, as well as all
+Your access to and use of Terra is subject to the following terms and conditions, as well as all
 Federal laws, including, but not limited to, the Privacy Act, 5 U.S.C. 552a. By accessing and using
-Saturn, you accept, without limitation or qualification, these Terms of Service.
+Terra, you accept, without limitation or qualification, these Terms of Service.
 
 #### Modification of the Agreement
 
@@ -21,15 +21,15 @@ review the current Terms of Service.
 
 #### Conduct
 
-You agree to access and use Saturn for lawful purposes only. You are solely responsible for the
+You agree to access and use Terra for lawful purposes only. You are solely responsible for the
 knowledge of and adherence to any and all laws, statutes, rules, and regulations pertaining to your
-use of Saturn.
+use of Terra.
 
-#### By accessing and using Saturn, you agree that you will:
+#### By accessing and using Terra, you agree that you will:
 
 * Conduct only authorized business on the system.
 * Notify the Broad Institute if you believe you are being granted access that you should not have.
-* Access Saturn using only your own individual account. Group or shared accounts are NOT permitted.
+* Access Terra using only your own individual account. Group or shared accounts are NOT permitted.
 * Maintain the confidentiality of your authentication credentials such as your password; a Broad
   Institute employee should never ask you to reveal your password.
 * Report any security incidents relating to lost passwords to the Broad Institute.
@@ -38,37 +38,37 @@ use of Saturn.
 * Ensure that Web browsers use Secure Socket Layer (SSL) version 3.0 (or higher) and Transport
   Layer Security (TLS) 1.0 (or higher). SSL and TLS must use a minimum of 256-bit, encryption.
 
-#### By accessing and using Saturn, you agree that you will NOT:
+#### By accessing and using Terra, you agree that you will NOT:
 
-* Use Saturn to commit a criminal offense, or to encourage others to conduct acts that would
+* Use Terra to commit a criminal offense, or to encourage others to conduct acts that would
   constitute a criminal offense or give rise to civil liability.
 * Browse, search or reveal any protected data except in accordance with that which is required to
   perform your legitimate tasks or assigned duties.
 * Retrieve protected data, or in any other way disclose information, for someone who does not have
   authority to access that information.
-* Establish any unauthorized interfaces with Saturn between systems, networks, and applications.
+* Establish any unauthorized interfaces with Terra between systems, networks, and applications.
 * Upload any content that contains a software virus, such as a Trojan Horse or any other computer
-  codes, files, or programs that may alter, damage, or interrupt the daily function of Saturn and
+  codes, files, or programs that may alter, damage, or interrupt the daily function of Terra and
   its users.
 * Post any material that infringes or violates the academic/intellectual rights of others.
-* View or use TCGA controlled access data hosted on Saturn unless you are authorized through dbGaP.
-* Share or distribute TCGA controlled access data hosted on Saturn with other users unless they
+* View or use TCGA controlled access data hosted on Terra unless you are authorized through dbGaP.
+* Share or distribute TCGA controlled access data hosted on Terra with other users unless they
   have dbGaP authorization.
 
 #### Registration
 
-You must sign up to Saturn under a Google-managed identity. Both private Gmail accounts and
-institutional Google Apps accounts are allowed. For increased security when using Saturn, we
+You must sign up to Terra under a Google-managed identity. Both private Gmail accounts and
+institutional Google Apps accounts are allowed. For increased security when using Terra, we
 recommend enabling 2-Step verification for your Google-managed identity.
 
 #### Restrictions on the Use of Shared and Group Accounts
 
-You cannot access Saturn using group or shared accounts. The credentials used for authenticating
-to Saturn must belong to a single individual.
+You cannot access Terra using group or shared accounts. The credentials used for authenticating
+to Terra must belong to a single individual.
 
 #### Restrictions on the Use of Tutorial Workspaces
 
-Saturn provides tutorial workspaces preloaded with best practice analysis pipelines and example
+Terra provides tutorial workspaces preloaded with best practice analysis pipelines and example
 data from TCGA. These workspaces are intended for tutorial purposes only, not for computing on
 personal data.
 
@@ -77,25 +77,25 @@ Configs). If you do not follow these guidelines, your Firecloud account may be d
 
 #### Accessing a Government Website
 
-Upon logging on to Saturn, a notification message informs you that you are entering a U.S.
+Upon logging on to Terra, a notification message informs you that you are entering a U.S.
 Government website. Please review and adhere to the content in this message.
 
-Saturn usage may be monitored, recorded, and subject to audit, and use of Saturn indicates
+Terra usage may be monitored, recorded, and subject to audit, and use of Terra indicates
 consent to monitoring and recording.
 
-Unauthorized use of Saturn is prohibited and subject to criminal and civil penalties.
+Unauthorized use of Terra is prohibited and subject to criminal and civil penalties.
 
 #### Access Levels
 
-Your level of access to Saturn is limited to ensure your access is no more than necessary to
+Your level of access to Terra is limited to ensure your access is no more than necessary to
 perform your legitimate tasks or assigned duties. If you believe you are being granted access that
 you should not have, you must immediately notify the Broad Institute.
 
 #### Restricted Use of TCGA Controlled-Access Data
 
-To access TCGA controlled access data, you must first request to link your Saturn account to the
+To access TCGA controlled access data, you must first request to link your Terra account to the
 eRA Commons or NIH identity under which you are granted dbGaP authorized access. If you have dbGaP
-authorized access, Saturn permits read access to the TCGA controlled-access data files.
+authorized access, Terra permits read access to the TCGA controlled-access data files.
 
 If the NIH or eRA commons identity authentication fails or the authenticated identity no longer
 appears in the NIH-provided whitelist, you can no longer access TCGA controlled access data files.
@@ -105,34 +105,34 @@ data to users unless they have dbGaP authorized access.
 
 #### Termination of Use
 
-We may in our sole discretion suspend/terminate your access to Saturn without notification for
+We may in our sole discretion suspend/terminate your access to Terra without notification for
 violation of the Terms of Service, or for other conduct that we deem harmful/unlawful to others. We
 may also periodically review accounts for which a user has not logged on.
 
 #### External Links
 
-Saturn may provide links that are maintained or controlled by external organizations. The listing
+Terra may provide links that are maintained or controlled by external organizations. The listing
 of links are not an endorsement of information, products, or services, and do not imply a direct
 association between the Broad Institute and the operators of the outside resource links.
 
 #### Content
 
-By accessing Saturn, you expressly consent to monitoring of your actions and all content or data
+By accessing Terra, you expressly consent to monitoring of your actions and all content or data
 transiting or stored therein. We reserve the right to delete, move, or edit any data, which we
 consider to be unacceptable or inappropriate whether for legal or other reasons.
 
 #### Disclaimer of Warranty
 
-You expressly understand and agree that your use of Saturn, or any material available through it,
-is at your own risk. Neither the Broad Institute nor its employees warrant that Saturn will be
+You expressly understand and agree that your use of Terra, or any material available through it,
+is at your own risk. Neither the Broad Institute nor its employees warrant that Terra will be
 uninterrupted, problem-free, free of omissions, or error-free; nor do they make any warranty as to
-the results that may be obtained from Saturn.
+the results that may be obtained from Terra.
 
 #### Limitation of Liability
 
 In no event will the Broad Institute or its employees be liable for the incidental, indirect,
 special, punitive, exemplary, or consequential damages, arising out of your use of or inability to
-use Saturn, including without limitation, loss of revenue or anticipated profits, loss of
+use Terra, including without limitation, loss of revenue or anticipated profits, loss of
 goodwill, loss of data, computer failure or malfunction, or any and all other damages.
 `
 
@@ -171,7 +171,7 @@ class TermsOfService extends Component {
       backgroundLogo,
       div({ style: styles.box }, [
         div({ style: { color: colors.darkBlue[0], fontWeight: 600 } }, [
-          span({ style: { fontSize: 36 } }, ['SATURN ']),
+          span({ style: { fontSize: 36 } }, ['TERRA ']),
           span({ style: { fontSize: 24 } }, ['Terms of Service'])
         ]),
         div({ style: { maxHeight: 400, overflowY: 'auto', lineHeight: 1.5, marginTop: '1rem', paddingRight: '1rem' } }, [

--- a/src/pages/groups/Group.js
+++ b/src/pages/groups/Group.js
@@ -52,7 +52,7 @@ const NewUserModal = ajaxCaller(class NewUserModal extends Component {
 
     return h(Modal, {
       onDismiss,
-      title: 'Add user to Saturn Group',
+      title: 'Add user to Terra Group',
       okButton: buttonPrimary({
         tooltip: Utils.summarizeErrors(errors),
         onClick: () => this.submit(),

--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -264,7 +264,7 @@ class NotebookEditor extends Component {
 
     return h(Fragment, [
       div({ style: styles.pageContainer }, [
-        div({ style: Style.elements.sectionHeader }, 'Saturn is preparing your notebook'),
+        div({ style: Style.elements.sectionHeader }, 'Terra is preparing your notebook'),
         step(1, 'Waiting for notebooks runtime to be ready'),
         step(2, localizeFailures ?
           `Error loading notebook, retry number ${localizeFailures}...` :


### PR DESCRIPTION
Changed everywhere it had 'Saturn' text to 'Terra' text. I didn't touch things like variable names, ajax calls, configs, document naming, app identifiers, etc. that still used Saturn. 