### PR TITLE
Warning when notebook was recently edited

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -444,6 +444,14 @@ const Buckets = signal => ({
         _.merge(authOpts(await User(signal).token(namespace)), { signal, method: 'DELETE' })
       )
     }
+
+    const getObject = async () => {
+      const res = await fetchBuckets(
+        `${bucketUrl}/${nbName(name)}`,
+        _.merge(authOpts(await User(signal).token(namespace)), { signal, method: 'GET' })
+      )
+      return await res.json()
+    }
     return {
       preview: async () => {
         const nb = await fetchBuckets(
@@ -468,6 +476,8 @@ const Buckets = signal => ({
       },
 
       delete: doDelete,
+
+      getObject,
 
       rename: async newName => {
         await copy(newName)

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -130,7 +130,7 @@ class NotebookCard extends Component {
       }, [
         icon('info-standard', {
           size: 15,
-          style: { marginLeft: '0.25rem'}
+          style: { marginLeft: '0.25rem' }
         })
       ])
     ])

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -109,10 +109,8 @@ class NotebookCard extends Component {
       }
     }, printName(name))
 
-    const date = new Date(updated)
-    const now = new Date()
-    const tenMinutesAgo = _.tap(d => d.setMinutes(d.getMinutes() - 10), new Date(now))
-    const recent = date > tenMinutesAgo
+    const tenMinutesAgo = _.tap(d => d.setMinutes(d.getMinutes() - 10), new Date())
+    const isRecent = new Date(updated) > tenMinutesAgo
 
     return a({
       href: notebookLink,
@@ -128,7 +126,7 @@ class NotebookCard extends Component {
       title,
       div({ style: { flexGrow: 1 } }),
       h(TooltipTrigger, { content: Utils.makeCompleteDate(updated) }, [
-        div({ style: { fontSize: '0.8rem', marginRight: '0.5rem', color: recent ? colors.orange[0] : undefined } },
+        div({ style: { fontSize: '0.8rem', marginRight: '0.5rem', color: isRecent ? colors.orange[0] : undefined } },
           `Last edited: ${Utils.makePrettyDate(updated)}`)
       ])
     ] : [
@@ -136,7 +134,7 @@ class NotebookCard extends Component {
       jupyterIcon,
       div({ style: { display: 'flex', justifyContent: 'space-between' } }, [
         h(TooltipTrigger, { content: Utils.makeCompleteDate(updated) }, [
-          div({ style: { fontSize: '0.8rem', flexGrow: 1, marginRight: '0.5rem', color: recent ? colors.orange[0] : undefined  } }, [
+          div({ style: { fontSize: '0.8rem', flexGrow: 1, marginRight: '0.5rem', color: isRecent ? colors.orange[0] : undefined  } }, [
             'Last edited:',
             div({}, Utils.makePrettyDate(updated))
           ])

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -124,7 +124,7 @@ class NotebookCard extends Component {
       notebookMenu,
       title,
       div({ style: { flexGrow: 1 } }),
-      isRecent ? div({ style: { display: 'flex', color: colors.orange[0], marginRight: '2rem' } }, 'Possibly in use') : undefined,
+      isRecent ? div({ style: { display: 'flex', color: colors.orange[0], marginRight: '2rem' } }, 'Recently Edited') : undefined,
       h(TooltipTrigger, { content: Utils.makeCompleteDate(updated) }, [
         div({ style: { fontSize: '0.8rem', marginRight: '0.5rem' } },
           `Last edited: ${Utils.makePrettyDate(updated)}`)
@@ -132,7 +132,7 @@ class NotebookCard extends Component {
     ] : [
       title,
       jupyterIcon,
-      isRecent ? div({ style: { display: 'flex', color: colors.orange[0] } }, 'Possibly in use') : undefined,
+      isRecent ? div({ style: { display: 'flex', color: colors.orange[0] } }, 'Recently Edited') : undefined,
       div({ style: { display: 'flex', justifyContent: 'space-between' } }, [
         h(TooltipTrigger, { content: Utils.makeCompleteDate(updated) }, [
           div({ style: { fontSize: '0.8rem', flexGrow: 1, marginRight: '0.5rem' } }, [

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -36,7 +36,9 @@ const noWrite = 'You do not have access to modify this workspace.'
 class NotebookCard extends Component {
   render() {
     const { namespace, name, updated, listView, wsName, onRename, onCopy, onDelete, onExport, canWrite } = this.props
-    const notebookLink = Nav.getLink('workspace-notebook-launch', { namespace, name: wsName, notebookName: name.slice(10) })
+    const tenMinutesAgo = _.tap(d => d.setMinutes(d.getMinutes() - 10), new Date())
+    const isRecent = new Date(updated) > tenMinutesAgo
+    const notebookLink = Nav.getLink('workspace-notebook-launch', { namespace, name: wsName, notebookName: name.slice(10), isRecent })
 
     const notebookMenu = h(PopupTrigger, {
       position: 'right',
@@ -109,8 +111,6 @@ class NotebookCard extends Component {
       }
     }, printName(name))
 
-    const tenMinutesAgo = _.tap(d => d.setMinutes(d.getMinutes() - 10), new Date())
-    const isRecent = new Date(updated) > tenMinutesAgo
     return a({
       href: notebookLink,
       style: {

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -109,6 +109,11 @@ class NotebookCard extends Component {
       }
     }, printName(name))
 
+    const date = new Date(updated)
+    const now = new Date()
+    const tenMinutesAgo = _.tap(d => d.setMinutes(d.getMinutes() - 10), new Date(now))
+    const recent = date > tenMinutesAgo
+
     return a({
       href: notebookLink,
       style: {
@@ -123,7 +128,7 @@ class NotebookCard extends Component {
       title,
       div({ style: { flexGrow: 1 } }),
       h(TooltipTrigger, { content: Utils.makeCompleteDate(updated) }, [
-        div({ style: { fontSize: '0.8rem', marginRight: '0.5rem' } },
+        div({ style: { fontSize: '0.8rem', marginRight: '0.5rem', color: recent ? colors.orange[0] : undefined } },
           `Last edited: ${Utils.makePrettyDate(updated)}`)
       ])
     ] : [
@@ -131,7 +136,7 @@ class NotebookCard extends Component {
       jupyterIcon,
       div({ style: { display: 'flex', justifyContent: 'space-between' } }, [
         h(TooltipTrigger, { content: Utils.makeCompleteDate(updated) }, [
-          div({ style: { fontSize: '0.8rem', flexGrow: 1, marginRight: '0.5rem' } }, [
+          div({ style: { fontSize: '0.8rem', flexGrow: 1, marginRight: '0.5rem', color: recent ? colors.orange[0] : undefined  } }, [
             'Last edited:',
             div({}, Utils.makePrettyDate(updated))
           ])

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -111,30 +111,6 @@ class NotebookCard extends Component {
 
     const tenMinutesAgo = _.tap(d => d.setMinutes(d.getMinutes() - 10), new Date())
     const isRecent = new Date(updated) > tenMinutesAgo
-    const recentEditedInfo = h(PopupTrigger, {
-      position: listView ? 'bottom' : 'right',
-      closeOnClick: true,
-      content: div({ style: { padding: ' 1rem', borderRadius: '0.5rem', width: '20rem' } }, [
-        'This notebook was edited recently, so it may be in use. ',
-        'If you edit the notebook at the same time as someone else, your changes may be lost. ',
-        'If you made the recent changes yourself, you may disregard this message.'
-      ])
-    }, [
-      h(Clickable, {
-        onClick: e => e.preventDefault(),
-        style: {
-          cursor: 'pointer', color: colors.orange[0]
-        },
-        focus: 'hover',
-        hover: { color: colors.orange[2] }
-      }, [
-        icon('info-standard', {
-          size: 15,
-          style: { marginLeft: '0.25rem' }
-        })
-      ])
-    ])
-
     return a({
       href: notebookLink,
       style: {
@@ -148,7 +124,7 @@ class NotebookCard extends Component {
       notebookMenu,
       title,
       div({ style: { flexGrow: 1 } }),
-      isRecent ? div({ style: { display: 'flex', color: colors.orange[0], marginRight: '2rem' } }, ['Possibly in use', recentEditedInfo]) : undefined,
+      isRecent ? div({ style: { display: 'flex', color: colors.orange[0], marginRight: '2rem' } }, 'Possibly in use') : undefined,
       h(TooltipTrigger, { content: Utils.makeCompleteDate(updated) }, [
         div({ style: { fontSize: '0.8rem', marginRight: '0.5rem' } },
           `Last edited: ${Utils.makePrettyDate(updated)}`)
@@ -156,7 +132,7 @@ class NotebookCard extends Component {
     ] : [
       title,
       jupyterIcon,
-      isRecent ? div({ style: { display: 'flex', color: colors.orange[0] } }, ['Possibly in use', recentEditedInfo]) : undefined,
+      isRecent ? div({ style: { display: 'flex', color: colors.orange[0] } }, 'Possibly in use') : undefined,
       div({ style: { display: 'flex', justifyContent: 'space-between' } }, [
         h(TooltipTrigger, { content: Utils.makeCompleteDate(updated) }, [
           div({ style: { fontSize: '0.8rem', flexGrow: 1, marginRight: '0.5rem' } }, [

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -111,6 +111,29 @@ class NotebookCard extends Component {
 
     const tenMinutesAgo = _.tap(d => d.setMinutes(d.getMinutes() - 10), new Date())
     const isRecent = new Date(updated) > tenMinutesAgo
+    const recentEditedInfo = h(PopupTrigger, {
+      position: listView ? 'bottom' : 'right',
+      closeOnClick: true,
+      content: div({ style: { padding: ' 1rem', borderRadius: '0.5rem', width: '20rem' } }, [
+        'This notebook was edited recently, so it may be in use. ',
+        'If you edit the notebook at the same time as someone else, your changes may be lost. ',
+        'If you made the recent changes yourself, you may disregard this message.'
+      ])
+    }, [
+      h(Clickable, {
+        onClick: e => e.preventDefault(),
+        style: {
+          cursor: 'pointer', color: colors.orange[0]
+        },
+        focus: 'hover',
+        hover: { color: colors.orange[2] }
+      }, [
+        icon('info-standard', {
+          size: 15,
+          style: { marginLeft: '0.25rem'}
+        })
+      ])
+    ])
 
     return a({
       href: notebookLink,
@@ -125,7 +148,7 @@ class NotebookCard extends Component {
       notebookMenu,
       title,
       div({ style: { flexGrow: 1 } }),
-      isRecent ? div({ style: { color: colors.orange[0], marginRight: '1.5rem' } }, 'Possibly in use') : undefined,
+      isRecent ? div({ style: { display: 'flex', color: colors.orange[0], marginRight: '2rem' } }, ['Possibly in use', recentEditedInfo]) : undefined,
       h(TooltipTrigger, { content: Utils.makeCompleteDate(updated) }, [
         div({ style: { fontSize: '0.8rem', marginRight: '0.5rem' } },
           `Last edited: ${Utils.makePrettyDate(updated)}`)
@@ -133,7 +156,7 @@ class NotebookCard extends Component {
     ] : [
       title,
       jupyterIcon,
-      isRecent ? div({ style: { color: colors.orange[0] } }, 'Possibly in use') : undefined,
+      isRecent ? div({ style: { display: 'flex', color: colors.orange[0] } }, ['Possibly in use', recentEditedInfo]) : undefined,
       div({ style: { display: 'flex', justifyContent: 'space-between' } }, [
         h(TooltipTrigger, { content: Utils.makeCompleteDate(updated) }, [
           div({ style: { fontSize: '0.8rem', flexGrow: 1, marginRight: '0.5rem' } }, [

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -125,16 +125,18 @@ class NotebookCard extends Component {
       notebookMenu,
       title,
       div({ style: { flexGrow: 1 } }),
+      isRecent ? div({ style: { color: colors.orange[0], marginRight: '1.5rem' } }, 'Possibly in use') : undefined,
       h(TooltipTrigger, { content: Utils.makeCompleteDate(updated) }, [
-        div({ style: { fontSize: '0.8rem', marginRight: '0.5rem', color: isRecent ? colors.orange[0] : undefined } },
+        div({ style: { fontSize: '0.8rem', marginRight: '0.5rem' } },
           `Last edited: ${Utils.makePrettyDate(updated)}`)
       ])
     ] : [
       title,
       jupyterIcon,
+      isRecent ? div({ style: { color: colors.orange[0] } }, 'Possibly in use') : undefined,
       div({ style: { display: 'flex', justifyContent: 'space-between' } }, [
         h(TooltipTrigger, { content: Utils.makeCompleteDate(updated) }, [
-          div({ style: { fontSize: '0.8rem', flexGrow: 1, marginRight: '0.5rem', color: isRecent ? colors.orange[0] : undefined  } }, [
+          div({ style: { fontSize: '0.8rem', flexGrow: 1, marginRight: '0.5rem' } }, [
             'Last edited:',
             div({}, Utils.makePrettyDate(updated))
           ])

--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -50,9 +50,24 @@ const NotebookLauncher = _.flow(
   wrapWorkspace({
     breadcrumbs: props => breadcrumbs.commonPaths.workspaceDashboard(props),
     title: ({ notebookName }) => `Notebooks - ${notebookName}`,
-    topBarContent: ({ workspace, notebookName }) => {
-      return workspace && !(Utils.canWrite(workspace.accessLevel) && workspace.canCompute)
-        && h(ReadOnlyMessage, { notebookName, workspace })
+    topBarContent: ({ workspace, notebookName, updated }) => {
+      const tenMinutesAgo = _.tap(d => d.setMinutes(d.getMinutes() - 10), new Date())
+      const isRecent = new Date(updated) > tenMinutesAgo
+      if (workspace) {
+        if (!(Utils.canWrite(workspace.accessLevel) && workspace.canCompute)) {
+          return h(ReadOnlyMessage, { notebookName, workspace })
+        } else if (isRecent) {
+          return div({ style: { fontWeight: 'bold' } },
+            [
+              'This notebook has been edited recently, so it may be in use. ',
+              div({ style: { fontWeight: 'normal', width: '38rem' } },
+                [
+                  ' If you edit the notebook at the same time as someone else, your changes may be lost.',
+                  ' If you made the recent changes yourself, you may disregard this message.'
+                ])
+            ])
+        }
+      }
     },
     showTabBar: false
   }),

--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -132,11 +132,12 @@ class NotebookViewer extends Component {
 
 class NotebookInUseMessage extends Component {
   render() {
-    return div({ style: { backgroundColor: colors.orange[0], color: 'white', padding: '1rem', borderRadius: '0.5rem' } }, [
+    return div({ style: { backgroundColor: colors.orange[0], color: 'white', padding: '1.3rem', borderRadius: '0.5rem' } }, [
+      div({ style: { position: 'absolute', left: '22rem', top: 5 } }, [icon('times', { size: 18 })]),
       div({ style: { fontSize: 16, fontWeight: 'bold' } },
-        ['This notebook has been edited recently, so it may be in use.']),
+        ['This notebook has been edited recently']),
       div({ style: { fontSize: 14 } }, [
-        'If you edit the notebook at the same time as someone else, your changes may be lost. If you made the recent changes yourself, you may disregard this message.'
+        'If you recently edited this notebook, disregard this message. If another user is editing this notebook, your changes may be lost.'
       ])
     ])
   }

--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -1,7 +1,6 @@
 import _ from 'lodash/fp'
 import { createRef, Fragment } from 'react'
 import { div, h, iframe } from 'react-hyperscript-helpers'
-import { withState } from 'recompose'
 import * as breadcrumbs from 'src/components/breadcrumbs'
 import { linkButton, spinnerOverlay, link } from 'src/components/common'
 import { icon, spinner } from 'src/components/icons'

--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -52,22 +52,8 @@ const NotebookLauncher = _.flow(
   wrapWorkspace({
     breadcrumbs: props => breadcrumbs.commonPaths.workspaceDashboard(props),
     title: ({ notebookName }) => `Notebooks - ${notebookName}`,
-    topBarContent: ({ workspace, notebookName, isRecent }) => {
-      if (workspace) {
-        if (!(Utils.canWrite(workspace.accessLevel) && workspace.canCompute)) {
-          return h(ReadOnlyMessage, { notebookName, workspace })
-        } else if (isRecent) {
-          return div({ style: { fontWeight: 'bold' } },
-            [
-              'This notebook has been edited recently, so it may be in use. ',
-              div({ style: { fontWeight: 'normal', width: '38rem' } },
-                [
-                  ' If you edit the notebook at the same time as someone else, your changes may be lost.',
-                  ' If you made the recent changes yourself, you may disregard this message.'
-                ])
-            ])
-        }
-      }
+    topBarContent: ({ workspace, notebookName }) => {
+      workspace && !(Utils.canWrite(workspace.accessLevel) && workspace.canCompute) && h(ReadOnlyMessage, { notebookName, workspace })
     },
     showTabBar: false
   }),
@@ -146,10 +132,6 @@ class NotebookViewer extends Component {
 }
 
 class NotebookInUseMessage extends Component {
-  constructor(props) {
-    super(props)
-  }
-
   render() {
     return div({ style: { backgroundColor: colors.orange[0], color: 'white', padding: '1rem', borderRadius: '0.5rem' } }, [
       div({ style: { fontSize: 16, fontWeight: 'bold' } },
@@ -216,7 +198,7 @@ class NotebookEditor extends Component {
         Jupyter.notebooks(namespace, clusterName).setCookie()
       ])
 
-      const { workspace: { workspace: { bucketName } }, setRecent, notebookName, ajax: { Buckets } } = this.props
+      const { workspace: { workspace: { bucketName } }, notebookName, ajax: { Buckets } } = this.props
       const { updated } = await Buckets.notebook(namespace, bucketName, notebookName.slice(0, -6)).getObject()
       const tenMinutesAgo = _.tap(d => d.setMinutes(d.getMinutes() - 10), new Date())
       const isRecent = new Date(updated) > tenMinutesAgo

--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -58,7 +58,6 @@ const NotebookLauncher = _.flow(
     },
     showTabBar: false
   }),
-  withState('isRecent', 'setRecent', false),
   ajaxCaller
 )(({ workspace, ...props }) => {
   return Utils.canWrite(workspace.accessLevel) && workspace.canCompute ?

--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -132,7 +132,7 @@ class NotebookViewer extends Component {
 
 class NotebookInUseMessage extends Component {
   render() {
-    return div({ style: { backgroundColor: colors.orange[0], color: 'white', padding: '1.3rem', borderRadius: '0.5rem' } }, [
+    return div({ style: { backgroundColor: colors.orange[0], color: 'white', padding: '1.3rem', borderRadius: '0.3rem' } }, [
       div({ style: { position: 'absolute', left: '22rem', top: 5 } }, [icon('times', { size: 18 })]),
       div({ style: { fontSize: 16, fontWeight: 'bold' } },
         ['This notebook has been edited recently']),
@@ -206,7 +206,7 @@ class NotebookEditor extends Component {
         pushNotification({
           type: 'warning',
           dismissable: { click: true },
-          dismiss: { duration: 0 },
+          dismiss: { duration: 30000 },
           content: h(NotebookInUseMessage),
           width: 375
         })

--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -53,7 +53,8 @@ const NotebookLauncher = _.flow(
     breadcrumbs: props => breadcrumbs.commonPaths.workspaceDashboard(props),
     title: ({ notebookName }) => `Notebooks - ${notebookName}`,
     topBarContent: ({ workspace, notebookName }) => {
-      workspace && !(Utils.canWrite(workspace.accessLevel) && workspace.canCompute) && h(ReadOnlyMessage, { notebookName, workspace })
+      return workspace && !(Utils.canWrite(workspace.accessLevel) && workspace.canCompute)
+        && h(ReadOnlyMessage, { notebookName, workspace })
     },
     showTabBar: false
   }),

--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -50,9 +50,8 @@ const NotebookLauncher = _.flow(
   wrapWorkspace({
     breadcrumbs: props => breadcrumbs.commonPaths.workspaceDashboard(props),
     title: ({ notebookName }) => `Notebooks - ${notebookName}`,
-    topBarContent: ({ workspace, notebookName, updated }) => {
-      const tenMinutesAgo = _.tap(d => d.setMinutes(d.getMinutes() - 10), new Date())
-      const isRecent = new Date(updated) > tenMinutesAgo
+    topBarContent: ({ workspace, notebookName, isRecent }) => {
+      console.log(isRecent)
       if (workspace) {
         if (!(Utils.canWrite(workspace.accessLevel) && workspace.canCompute)) {
           return h(ReadOnlyMessage, { notebookName, workspace })


### PR DESCRIPTION
If a notebook was edited less than 10 minutes ago, the time shows up in an orange warning color like this:
<img width="541" alt="screen shot 2018-11-02 at 4 06 59 pm" src="https://user-images.githubusercontent.com/42386483/47938095-5ae3e180-deb9-11e8-9679-ba21db61dbdd.png">

Otherwise it shows up as usual 