### PR TITLE
Fix notebook renaming

### DIFF
--- a/src/components/notebook-utils.js
+++ b/src/components/notebook-utils.js
@@ -172,7 +172,7 @@ export const NotebookDuplicator = ajaxCaller(class NotebookDuplicator extends Co
           try {
             this.setState({ processing: true })
             await (destroyOld ?
-              Buckets.notebook(namespace, bucketName, printName).rename(newName, bucketName) :
+              Buckets.notebook(namespace, bucketName, printName).rename(newName) :
               Buckets.notebook(namespace, bucketName, printName).copy(newName, bucketName))
             onSuccess()
           } catch (error) {

--- a/src/components/notebook-utils.js
+++ b/src/components/notebook-utils.js
@@ -172,7 +172,7 @@ export const NotebookDuplicator = ajaxCaller(class NotebookDuplicator extends Co
           try {
             this.setState({ processing: true })
             await (destroyOld ?
-              Buckets.notebook(namespace, bucketName, printName).rename(newName) :
+              Buckets.notebook(namespace, bucketName, printName).rename(newName, bucketName) :
               Buckets.notebook(namespace, bucketName, printName).copy(newName, bucketName))
             onSuccess()
           } catch (error) {

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -495,7 +495,7 @@ const Buckets = signal => ({
 
       getObject,
 
-      rename: async (newName, bucket) => {
+      rename: async (newName) => {
         await copy(newName, bucket)
         return doDelete()
       }

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -495,8 +495,8 @@ const Buckets = signal => ({
 
       getObject,
 
-      rename: async newName => {
-        await copy(newName)
+      rename: async (newName, bucket) => {
+        await copy(newName, bucket)
         return doDelete()
       }
     }

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -495,7 +495,7 @@ const Buckets = signal => ({
 
       getObject,
 
-      rename: async (newName) => {
+      rename: async newName => {
         await copy(newName, bucket)
         return doDelete()
       }


### PR DESCRIPTION
Rename seems to be a copy and delete and operation. The copy part wasn't working because it didn't have a bucket to copy to. 