### PR TITLE
refactor uri viewer

### DIFF
--- a/src/components/UriViewer.js
+++ b/src/components/UriViewer.js
@@ -51,13 +51,13 @@ const getMaxDownloadCostNA = bytes => {
   return downloadPrice < 0.01 ? '< $0.01' : `$${downloadPrice.toPrecision(2)}`
 }
 
-export default ajaxCaller(class UriViewer extends Component {
+const UriViewer = ajaxCaller(class UriViewer extends Component {
   static propTypes = {
     googleProject: PropTypes.string.isRequired,
     uri: PropTypes.string.isRequired
   }
 
-  async getMetadata() {
+  async componentDidMount() {
     const { googleProject, uri, ajax: { Buckets, Martha } } = this.props
     const isGsUri = isGs(uri)
     const [bucket, name] = isGsUri ? parseUri(uri) : []
@@ -83,132 +83,151 @@ export default ajaxCaller(class UriViewer extends Component {
     }
   }
 
-  renderMetadata() {
-    const { uri } = this.props
+  render() {
+    const { uri, onDismiss } = this.props
     const { metadata, preview, signedUrl, price, copied, loadingError } = this.state
     const { size, timeCreated, updated, bucket, name, gsUri } = metadata || {}
     const gsutilCommand = `gsutil cp ${gsUri || uri} .`
 
-    return h(Fragment,
+    return h(Modal, {
+      onDismiss,
+      title: 'File Details',
+      showCancel: false,
+      showX: true,
+      okButton: 'Done'
+    }, [
       Utils.cond(
-        [
-          loadingError, () => [
-            div({ style: { paddingBottom: '1rem' } }, ['Error loading data. You may not have permission to view this file.']),
-            h(Collapse, { defaultHidden: true, title: 'Details' }, [
-              div({ style: { whiteSpace: 'pre-wrap', fontFamily: 'monospace' } }, [JSON.stringify(loadingError, null, 2)])
+        [loadingError, () => h(Fragment, [
+          div({ style: { paddingBottom: '1rem' } }, [
+            'Error loading data. You may not have permission to view this file.'
+          ]),
+          h(Collapse, { defaultHidden: true, title: 'Details' }, [
+            div({ style: { whiteSpace: 'pre-wrap', fontFamily: 'monospace' } }, [
+              JSON.stringify(loadingError, null, 2)
             ])
-          ]
-        ],
-        [
-          metadata, () => [
-            els.cell([els.label('Filename'), els.data(_.last(name.split('/')).split('.').join('.\u200B'))]), // allow line break on periods
-            els.cell(Utils.cond(
-              [!isGs(uri), () => [els.label(`DOS uri's can't be previewed`)]],
-              [
-                isFilePreviewable(metadata), () => [
-                  els.label('Preview'),
-                  Utils.cond(
-                    [isImage(metadata), () => img({ src: preview, width: 400 })],
-                    [
-                      preview, () => div({
-                        style: {
-                          whiteSpace: 'pre', fontFamily: 'Menlo, monospace', fontSize: 12,
-                          overflowY: 'auto', maxHeight: 206,
-                          marginTop: '0.5rem', padding: '0.5rem',
-                          background: colors.gray[5], borderRadius: '0.2rem'
-                        }
-                      }, [preview])
-                    ],
-                    () => 'Loading preview...'
-                  )
-                ]
-              ],
-              [isImage(metadata), () => els.label('Image is too large to preview')],
-              () => [els.label(`File can't be previewed.`)]
-            )),
-            els.cell([els.label('File size'), els.data(filesize(parseInt(size, 10)))]),
-            els.cell([
-              link({
-                target: 'blank',
-                href: Utils.bucketBrowserUrl(bucket)
-              }, ['View this file in the Google Cloud Storage Browser'])
-            ]),
-            els.cell(
-              Utils.cond(
-                [signedUrl === false, () => 'Unable to generate download link.'],
-                () => [
-                  div({ style: { display: 'flex', justifyContent: 'center' } }, [
-                    buttonPrimary({
-                      as: 'a',
-                      disabled: !signedUrl,
-                      href: signedUrl,
-                      target: '_blank'
-                    }, signedUrl ?
-                      [`Download for ${price}*`] :
-                      ['Generating download link...', spinner({ style: { color: 'white', marginLeft: 4 } })]
-                    )
-                  ])
-                ]
-              )
-            ),
-            els.cell([
-              els.label('Terminal download command'),
-              els.data([
-                div({ style: { display: 'flex' } }, [
-                  input({
-                    readOnly: true,
-                    value: gsutilCommand,
-                    style: { flexGrow: 1, fontWeight: 400, fontFamily: 'Menlo, monospace' }
-                  }),
-                  h(Clickable, {
-                    style: { margin: '0 1rem', color: copied ? colors.green[0] : colors.blue[0] },
-                    tooltip: 'Copy to clipboard',
-                    onClick: async () => {
-                      try {
-                        await clipboard.writeText(gsutilCommand)
-                        this.setState({ copied: true },
-                          () => setTimeout(() => this.setState({ copied: undefined }), 1500))
-                      } catch (error) {
-                        reportError('Error copying to clipboard', error)
-                      }
+          ])
+        ])],
+        [metadata, () => h(Fragment, [
+          els.cell([
+            els.label('Filename'),
+            els.data(_.last(name.split('/')).split('.').join('.\u200B'))  // allow line break on periods
+          ]),
+          els.cell([
+            Utils.cond(
+              [!isGs(uri), () => els.label(`DOS uri's can't be previewed`)],
+              [isFilePreviewable(metadata), () => h(Fragment, [
+                els.label('Preview'),
+                Utils.cond(
+                  [isImage(metadata), () => img({ src: preview, width: 400 })],
+                  [preview, () => div({
+                    style: {
+                      whiteSpace: 'pre', fontFamily: 'Menlo, monospace', fontSize: 12,
+                      overflowY: 'auto', maxHeight: 206,
+                      marginTop: '0.5rem', padding: '0.5rem',
+                      background: colors.gray[5], borderRadius: '0.2rem'
                     }
-                  }, [icon(copied ? 'check' : 'copy-to-clipboard')])
+                  }, [preview])],
+                  () => 'Loading preview...'
+                )
+              ])],
+              [isImage(metadata), () => els.label('Image is too large to preview')],
+              () => els.label(`File can't be previewed.`)
+            )
+          ]),
+          els.cell([els.label('File size'), els.data(filesize(parseInt(size, 10)))]),
+          els.cell([
+            link({
+              target: 'blank',
+              href: Utils.bucketBrowserUrl(bucket)
+            }, ['View this file in the Google Cloud Storage Browser'])
+          ]),
+          els.cell([
+            signedUrl === false ?
+              'Unable to generate download link.' :
+              div({ style: { display: 'flex', justifyContent: 'center' } }, [
+                buttonPrimary({
+                  as: 'a',
+                  disabled: !signedUrl,
+                  href: signedUrl,
+                  target: '_blank'
+                }, [
+                  signedUrl ?
+                    `Download for ${price}*` :
+                    h(Fragment, ['Generating download link...', spinner({ style: { color: 'white', marginLeft: 4 } })])
                 ])
               ])
+          ]),
+          els.cell([
+            els.label('Terminal download command'),
+            els.data([
+              div({ style: { display: 'flex' } }, [
+                input({
+                  readOnly: true,
+                  value: gsutilCommand,
+                  style: { flexGrow: 1, fontWeight: 400, fontFamily: 'Menlo, monospace' }
+                }),
+                h(Clickable, {
+                  style: { margin: '0 1rem', color: copied ? colors.green[0] : colors.blue[0] },
+                  tooltip: 'Copy to clipboard',
+                  onClick: async () => {
+                    try {
+                      await clipboard.writeText(gsutilCommand)
+                      this.setState({ copied: true }, () => {
+                        setTimeout(() => this.setState({ copied: undefined }), 1500)
+                      })
+                    } catch (error) {
+                      reportError('Error copying to clipboard', error)
+                    }
+                  }
+                }, [icon(copied ? 'check' : 'copy-to-clipboard')])
+              ])
+            ])
+          ]),
+          (timeCreated || updated) && h(Collapse, {
+            title: 'More Information',
+            defaultHidden: true,
+            style: { marginTop: '2rem' }
+          }, [
+            timeCreated && els.cell([
+              els.label('Created'),
+              els.data(new Date(timeCreated).toLocaleString())
             ]),
-            (timeCreated || updated) && h(Collapse, { title: 'More Information', defaultHidden: true, style: { marginTop: '2rem' } }, [
-              timeCreated && els.cell([els.label('Created'), els.data(new Date(timeCreated).toLocaleString())]),
-              updated && els.cell([els.label('Updated'), els.data(new Date(updated).toLocaleString())])
-            ]),
-            div({ style: { fontSize: 10 } }, ['* Estimated. Download cost may be higher in China or Australia.'])
-          ]
-        ],
-        () => [isGs(uri) ? 'Loading metadata...' : 'Resolving DOS object...', spinner({ style: { marginLeft: 4 } })]
+            updated && els.cell([
+              els.label('Updated'),
+              els.data(new Date(updated).toLocaleString())
+            ])
+          ]),
+          div({ style: { fontSize: 10 } }, ['* Estimated. Download cost may be higher in China or Australia.'])
+        ])],
+        () => h(Fragment, [
+          isGs(uri) ? 'Loading metadata...' : 'Resolving DOS object...',
+          spinner({ style: { marginLeft: 4 } })
+        ])
       )
-    )
-  }
-
-  render() {
-    const { uri } = this.props
-    const { modalOpen } = this.state
-
-    return h(Fragment, [
-      link({
-        href: uri,
-        onClick: () => {
-          this.getMetadata()
-          this.setState({ modalOpen: true })
-        }
-      }, isGs(uri) ? _.last(uri.split('/')) : uri),
-      modalOpen && h(Modal, {
-        onDismiss: () => this.setState({ modalOpen: false }),
-        title: 'File Details',
-        showCancel: false,
-        showX: true,
-        okButton: 'Done'
-      }, [
-        this.renderMetadata()
-      ])
     ])
   }
 })
+
+export class UriViewerLink extends Component {
+  constructor(props) {
+    super(props)
+    this.state = { modalOpen: false }
+  }
+
+  render() {
+    const { uri, googleProject } = this.props
+    const { modalOpen } = this.state
+    return h(Fragment, [
+      link({
+        href: uri,
+        onClick: () => this.setState({ modalOpen: true })
+      }, [isGs(uri) ? _.last(uri.split('/')) : uri]),
+      modalOpen && h(UriViewer, {
+        onDismiss: () => this.setState({ modalOpen: false }),
+        uri, googleProject
+      })
+    ])
+  }
+}
+
+export default UriViewer

--- a/src/libs/data-utils.js
+++ b/src/libs/data-utils.js
@@ -6,7 +6,7 @@ import { buttonPrimary, Select, spinnerOverlay } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import Modal from 'src/components/Modal'
 import { TextCell } from 'src/components/table'
-import UriViewer from 'src/components/UriViewer'
+import { UriViewerLink } from 'src/components/UriViewer'
 import ReferenceData from 'src/data/reference-data'
 import { ajaxCaller } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
@@ -20,7 +20,7 @@ export const renderDataCell = (data, namespace) => {
   const isUri = datum => _.startsWith('gs://', datum) || _.startsWith('dos://', datum)
 
   const renderCell = datum => h(TextCell, { title: datum },
-    [isUri(datum) ? h(UriViewer, { uri: datum, googleProject: namespace }) : datum])
+    [isUri(datum) ? h(UriViewerLink, { uri: datum, googleProject: namespace }) : datum])
 
   return _.isObject(data) ?
     data.items.map((v, i) => h(Fragment, { key: i }, [


### PR DESCRIPTION
This refactor is to support the upcoming bucket view. There are two primary changes:
* Separates the preview modal from the link that launches it.
* Cleans up spacing and fragment handling.

The only user-visible change is that closing and then reopening the modal will now re-fetch the metadata (which seems the expected UX anyway).