### PR TITLE
refactor data page

### DIFF
--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -23,7 +23,7 @@ import { Component } from 'src/libs/wrapped-components'
 import { wrapWorkspace } from 'src/pages/workspaces/workspace/WorkspaceContainer'
 
 
-const filterState = _.pick(['pageNumber', 'itemsPerPage', 'selectedDataType', 'sort'])
+const filterState = (props, state) => ({ ..._.pick(['pageNumber', 'itemsPerPage', 'sort'], state), ..._.pick(['refreshKey'], props) })
 
 const localVariables = 'localVariables'
 
@@ -36,13 +36,12 @@ const styles = {
   dataTypeSelectionPanel: {
     flex: 'none', width: 200, backgroundColor: 'white', padding: '1rem'
   },
-  tableViewPanel: hasSelection => ({
+  tableViewPanel: {
     position: 'relative',
     overflow: 'hidden',
     padding: '1rem', width: '100%',
-    textAlign: hasSelection ? undefined : 'center',
     flex: 1, display: 'flex', flexDirection: 'column'
-  }),
+  },
   dataTypeHeading: {
     fontWeight: 500, color: colors.darkBlue[0]
   }
@@ -82,344 +81,273 @@ const saveScroll = _.throttle(100, (initialX, initialY) => {
   StateHistory.update({ initialX, initialY })
 })
 
-const WorkspaceData = _.flow(
-  wrapWorkspace({
-    breadcrumbs: props => breadcrumbs.commonPaths.workspaceDashboard(props),
-    title: 'Data', activeTab: 'data'
+const getReferenceData = _.flow(
+  _.toPairs,
+  _.filter(([key]) => key.startsWith('referenceData-')),
+  _.map(([k, value]) => {
+    const [, datum, key] = /referenceData-([^-]+)-(.+)/.exec(k)
+    return { datum, key, value }
   }),
-  ajaxCaller
-)(class WorkspaceData extends Component {
-  constructor(props) {
-    super(props)
+  _.groupBy('datum')
+)
 
-    this.state = {
-      itemsPerPage: 25,
-      pageNumber: 1,
-      sort: initialSort,
-      loading: false,
-      workspaceAttributes: props.workspace.workspace.attributes,
-      columnWidths: {},
-      columnState: {},
-      selectedEntities: [],
-      ...StateHistory.get()
-    }
-    this.downloadForm = createRef()
-    this.table = createRef()
-  }
+const LocalVariablesContent = ajaxCaller(class LocalVariablesContent extends Component {
+  render() {
+    const { workspace: { accessLevel, workspace: { namespace, name, attributes } }, ajax: { Workspaces }, refreshWorkspace, loadingWorkspace, firstRender } = this.props
+    const { editIndex, deleteIndex, editKey, editValue, editType } = this.state
+    const canEdit = Utils.canWrite(accessLevel)
+    const stopEditing = () => this.setState({ editIndex: undefined, editKey: undefined, editValue: undefined, editType: undefined })
+    const filteredAttributes = _.flow(
+      _.toPairs,
+      _.remove(([key]) => key === 'description' || key.includes(':') || key.startsWith('referenceData-')),
+      _.sortBy(_.first)
+    )(attributes)
 
-  async loadMetadata() {
-    const { namespace, name, ajax: { Workspaces } } = this.props
-    const { selectedDataType } = this.state
+    const creatingNewVariable = editIndex === filteredAttributes.length
+    const amendedAttributes = [
+      ...filteredAttributes, ...(creatingNewVariable ? [['', '']] : [])
+    ]
 
-    try {
-      const entityMetadata = await Workspaces.workspace(namespace, name).entityMetadata()
-      this.setState({
-        selectedDataType: this.isDataModel() && !entityMetadata[selectedDataType] ? undefined : selectedDataType,
-        entityMetadata
-      })
-    } catch (error) {
-      reportError('Error loading workspace entity data', error)
-    }
-  }
+    const inputErrors = editIndex && [
+      ...(_.keys(_.unset(amendedAttributes[editIndex][0], attributes)).includes(editKey) ? ['Key must be unique'] : []),
+      ...(!editKey ? ['Key is required'] : []),
+      ...(!editValue ? ['Value is required'] : []),
+      ...(editValue && editType === 'number' && Utils.cantBeNumber(editValue) ? ['Value is not a number'] : []),
+      ...(editValue && editType === 'number list' && _.some(Utils.cantBeNumber, editValue.split(',')) ?
+        ['Value is not a comma-separated list of numbers'] : [])
+    ]
 
-  async loadData() {
-    const { namespace, name, ajax: { Workspaces } } = this.props
-    const { itemsPerPage, pageNumber, sort, selectedDataType } = this.state
-    const isDataModel = this.isDataModel()
-
-    const getWorkspaceAttributes = async () => (await Workspaces.workspace(namespace, name).details()).workspace.attributes
-
-    if (!selectedDataType) {
-      this.setState({ workspaceAttributes: await getWorkspaceAttributes() })
-    } else {
+    const saveAttribute = async originalKey => {
       try {
-        this.setState({ loading: true })
+        const isList = editType.includes('list')
+        const newBaseType = isList ? editType.slice(0, -5) : editType
 
-        const [workspaceAttributes, entities] = await Promise.all([
-          getWorkspaceAttributes(),
-          isDataModel ?
-            Workspaces.workspace(namespace, name)
-              .paginatedEntitiesOfType(selectedDataType, {
-                page: pageNumber, pageSize: itemsPerPage, sortField: sort.field, sortDirection: sort.direction
-              }) :
-            undefined
-        ])
+        const parsedValue = isList ? _.map(Utils.convertValue(newBaseType), editValue.split(/,s*/)) :
+          Utils.convertValue(newBaseType, editValue)
 
-        this.setState(_.merge(
-          isDataModel && { entities: entities.results, totalRowCount: entities.resultMetadata.unfilteredCount, selectedEntities: [] },
-          { workspaceAttributes }
-        ))
-      } catch (error) {
-        reportError('Error loading workspace data', error)
-      } finally {
-        this.setState({ loading: false })
+        this.setState({ saving: true })
+
+        await Workspaces.workspace(namespace, name).shallowMergeNewAttributes({ [editKey]: parsedValue })
+
+        if (editKey !== originalKey) {
+          await Workspaces.workspace(namespace, name).deleteAttributes([originalKey])
+        }
+
+        await refreshWorkspace()
+        stopEditing()
+      } catch (e) {
+        reportError('Error saving change to workspace variables', e)
       }
     }
-  }
 
-  getReferenceData() {
-    const { workspaceAttributes } = this.state
+    const { initialY } = firstRender ? StateHistory.get() : {}
+    return h(Fragment, [
+      Utils.cond(
+        [_.isEmpty(amendedAttributes), () => 'No Workspace Data defined'],
+        () => div({ style: { flex: 1 } }, [
+          h(AutoSizer, [
+            ({ width, height }) => h(FlexTable, {
+              width, height, rowCount: amendedAttributes.length,
+              onScroll: y => saveScroll(0, y),
+              initialY,
+              hoverHighlight: true,
+              columns: [
+                {
+                  size: { basis: 400, grow: 0 },
+                  headerRenderer: () => h(HeaderCell, ['Key']),
+                  cellRenderer: ({ rowIndex }) => editIndex === rowIndex ?
+                    textInput({
+                      autoFocus: true,
+                      value: editKey,
+                      onChange: e => this.setState({ editKey: e.target.value })
+                    }) :
+                    renderDataCell(amendedAttributes[rowIndex][0], namespace)
+                },
+                {
+                  size: { grow: 1 },
+                  headerRenderer: () => h(HeaderCell, ['Value']),
+                  cellRenderer: ({ rowIndex }) => {
+                    const originalKey = amendedAttributes[rowIndex][0]
+                    const originalValue = amendedAttributes[rowIndex][1]
 
-    return _.flow(
-      _.toPairs,
-      _.filter(([key]) => key.startsWith('referenceData-')),
-      _.map(([k, value]) => {
-        const [, datum, key] = /referenceData-([^-]+)-(.+)/.exec(k)
-        return { datum, key, value }
+                    return h(Fragment, [
+                      div({ style: { flex: 1, minWidth: 0, display: 'flex' } }, [
+                        editIndex === rowIndex ?
+                          textInput({
+                            value: editValue,
+                            onChange: e => this.setState({ editValue: e.target.value })
+                          }) :
+                          renderDataCell(originalValue, namespace)
+                      ]),
+                      editIndex === rowIndex ?
+                        h(Fragment, [
+                          h(Select, {
+                            styles: { container: base => ({ ...base, marginLeft: '1rem', width: 150 }) },
+                            isSearchable: false,
+                            isClearable: false,
+                            menuPortalTarget: document.getElementById('root'),
+                            getOptionLabel: ({ value }) => _.startCase(value),
+                            value: editType,
+                            onChange: ({ value }) => this.setState({ editType: value }),
+                            options: ['string', 'number', 'boolean', 'string list', 'number list', 'boolean list']
+                          }),
+                          linkButton({
+                            tooltip: Utils.summarizeErrors(inputErrors) || 'Save changes',
+                            disabled: !!inputErrors.length,
+                            style: { marginLeft: '1rem' },
+                            onClick: () => saveAttribute(originalKey)
+                          }, [icon('success-standard', { size: 23 })]),
+                          linkButton({
+                            tooltip: 'Cancel editing',
+                            style: { marginLeft: '1rem' },
+                            onClick: () => stopEditing()
+                          }, [icon('times-circle', { size: 23 })])
+                        ]) :
+                        div({ className: 'hover-only' }, [
+                          linkButton({
+                            disabled: !canEdit,
+                            tooltip: canEdit ? 'Edit variable' : 'You do not have access to modify data in this workspace.',
+                            style: { marginLeft: '1rem' },
+                            onClick: () => this.setState({
+                              editIndex: rowIndex,
+                              editValue: typeof originalValue === 'object' ? originalValue.items.join(', ') : originalValue,
+                              editKey: originalKey,
+                              editType: typeof originalValue === 'object' ? `${typeof originalValue.items[0]} list` : typeof originalValue
+                            })
+                          }, [icon('pencil', { size: 19 })]),
+                          linkButton({
+                            disabled: !canEdit,
+                            tooltip: canEdit ? 'Delete variable' : 'You do not have access to modify data in this workspace.',
+                            style: { marginLeft: '1rem' },
+                            onClick: () => this.setState({ deleteIndex: rowIndex })
+                          }, [icon('trash', { size: 19 })])
+                        ])
+                    ])
+                  }
+                }
+              ]
+            })
+          ])
+        ])
+      ),
+      !creatingNewVariable && canEdit && h(FloatingActionButton, {
+        label: 'ADD VARIABLE',
+        iconShape: 'plus',
+        onClick: () => this.setState({
+          editIndex: filteredAttributes.length,
+          editValue: '',
+          editKey: '',
+          editType: 'string'
+        })
       }),
-      _.groupBy('datum')
-    )(workspaceAttributes)
+      !_.isUndefined(deleteIndex) && h(Modal, {
+        onDismiss: () => this.setState({ deleteIndex: undefined }),
+        title: 'Are you sure you wish to delete this variable?',
+        okButton: buttonPrimary({
+          onClick: async () => {
+            try {
+              this.setState({ deleteIndex: undefined, saving: true })
+              await Workspaces.workspace(namespace, name).deleteAttributes([amendedAttributes[deleteIndex][0]])
+              refreshWorkspace()
+            } catch (e) {
+              reportError('Error deleting workspace variable', e)
+            } finally {
+              this.setState({ saving: false })
+            }
+          }
+        },
+        'Delete Variable')
+      }, ['This will permanently delete the data from Workspace Data.']),
+      loadingWorkspace && spinnerOverlay
+    ])
+  }
+})
+
+const ReferenceDataContent = ({ workspace: { workspace: { namespace, attributes } }, referenceKey, loadingWorkspace, firstRender }) => {
+  const selectedData = _.sortBy('key', getReferenceData(attributes)[referenceKey])
+  const { initialY } = firstRender ? StateHistory.get() : {}
+  return h(Fragment, [
+    div({ style: { flex: 1 } }, [
+      h(AutoSizer, [
+        ({ width, height }) => h(FlexTable, {
+          width, height, rowCount: selectedData.length,
+          onScroll: y => saveScroll(0, y),
+          initialY,
+          columns: [
+            {
+              size: { basis: 400, grow: 0 },
+              headerRenderer: () => h(HeaderCell, ['Key']),
+              cellRenderer: ({ rowIndex }) => renderDataCell(selectedData[rowIndex].key, namespace)
+            },
+            {
+              size: { grow: 1 },
+              headerRenderer: () => h(HeaderCell, ['Value']),
+              cellRenderer: ({ rowIndex }) => renderDataCell(selectedData[rowIndex].value, namespace)
+            }
+          ]
+        })
+      ])
+    ]),
+    loadingWorkspace && spinnerOverlay
+  ])
+}
+
+const EntitiesContent = ajaxCaller(class EntitiesContent extends Component {
+  constructor(props) {
+    super(props)
+    const { entities, totalRowCount = 0, itemsPerPage = 25, pageNumber = 1, sort = initialSort, columnWidths = {}, columnState = {} } = props.firstRender ? StateHistory.get() : {}
+    this.state = {
+      entities,
+      itemsPerPage,
+      pageNumber,
+      sort,
+      loading: false,
+      columnWidths,
+      columnState,
+      selectedEntities: [],
+      deletingEntities: false,
+      totalRowCount
+    }
+    this.table = createRef()
+    this.downloadForm = createRef()
   }
 
   async componentDidMount() {
-    this.loadMetadata()
     this.loadData()
-
     this.setState({ orchestrationRoot: await Config.getOrchestrationUrlRoot() })
   }
 
-  refresh() {
-    this.loadMetadata()
-    this.loadData()
+  componentDidUpdate(prevProps, prevState) {
+    if (!_.isEqual(filterState(prevProps, prevState), filterState(this.props, this.state))) {
+      this.loadData()
+    }
+    StateHistory.update(_.pick(['entities', 'totalRowCount', 'itemsPerPage', 'pageNumber', 'sort', 'columnWidths', 'columnState'], this.state))
   }
 
-  isDataModel() {
-    const { selectedDataType } = this.state
-    const referenceData = this.getReferenceData()
-
-    return !!selectedDataType && (selectedDataType !== localVariables) && !_.keys(referenceData).includes(selectedDataType)
-  }
-
-  render() {
-    const { namespace, name, workspace: { accessLevel, workspaceSubmissionStats: { runningSubmissionsCount } } } = this.props
-    const { selectedDataType, entityMetadata, loading, importingReference, deletingReference, deletingEntities, selectedEntities, uploadingFile } = this.state
-    const referenceData = this.getReferenceData()
-    const canEdit = Utils.canWrite(accessLevel)
-
-    return div({ style: styles.tableContainer }, [
-      !entityMetadata ? spinnerOverlay : h(Fragment, [
-        div({ style: styles.dataTypeSelectionPanel }, [
-          div({ style: { display: 'flex', alignItems: 'center', justifyContent: 'space-between' } }, [
-            div({ style: styles.dataTypeHeading }, 'Tables'),
-            linkButton({
-              disabled: !canEdit,
-              tooltip: canEdit ? 'Upload .tsv' : 'You do not have access add data to this workspace.',
-              onClick: () => this.setState({ uploadingFile: true })
-            }, [icon('plus-circle')])
-          ]),
-          _.map(([type, typeDetails]) => {
-            return h(DataTypeButton, {
-              key: type,
-              selected: selectedDataType === type,
-              onClick: () => {
-                saveScroll(0, 0)
-                selectedDataType === type ? this.loadData() :
-                  this.setState({ selectedDataType: type, pageNumber: 1, sort: initialSort, entities: undefined })
-              }
-            }, [`${type} (${typeDetails.count})`])
-          }, _.toPairs(entityMetadata)),
-          div({ style: { display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginTop: '1rem' } }, [
-            div({ style: styles.dataTypeHeading }, 'Reference Data'),
-            linkButton({
-              disabled: !canEdit,
-              tooltip: canEdit ? 'Add reference data' : 'You do not have access add data to this workspace.',
-              onClick: () => this.setState({ importingReference: true })
-            }, [icon('plus-circle')])
-          ]),
-          importingReference && h(ReferenceDataImporter, {
-            onDismiss: () => this.setState({ importingReference: false }),
-            onSuccess: () => this.setState({ importingReference: false }, () => this.loadData()),
-            namespace, name
-          }),
-          deletingReference && h(ReferenceDataDeleter, {
-            onDismiss: () => this.setState({ deletingReference: false }),
-            onSuccess: () => this.setState({
-              deletingReference: false,
-              selectedDataType: selectedDataType === deletingReference ? undefined : selectedDataType
-            }, () => this.loadData()),
-            namespace, name, referenceDataType: deletingReference
-          }),
-          deletingEntities && h(EntityDeleter, {
-            onDismiss: () => this.setState({ deletingEntities: false }),
-            onSuccess: () => this.setState({ deletingEntities: false }, () => this.refresh()),
-            namespace, name,
-            selectedEntities, selectedDataType, runningSubmissionsCount
-          }),
-          uploadingFile && h(EntityUploader, {
-            onDismiss: () => this.setState({ uploadingFile: false }),
-            onSuccess: () => this.setState({ uploadingFile: false }, () => this.refresh()),
-            namespace, name,
-            entityTypes: _.keys(entityMetadata)
-          }),
-          _.map(type => {
-            return h(DataTypeButton, {
-              key: type,
-              selected: selectedDataType === type,
-              onClick: () => {
-                saveScroll(0, 0)
-                this.setState({ selectedDataType: type })
-              }
-            }, [
-              div({ style: { display: 'flex', justifyContent: 'space-between' } }, [
-                type,
-                h(Clickable, {
-                  tooltip: `Delete ${type}`,
-                  onClick: e => {
-                    e.stopPropagation()
-                    this.setState({ deletingReference: type })
-                  }
-                }, [icon('minus-circle', { size: 16 })])
-              ])
-            ])
-          }, _.keys(referenceData)),
-          div({ style: { ...styles.dataTypeHeading, marginTop: '1rem' } }, 'Other Data'),
-          h(DataTypeButton, {
-            selected: selectedDataType === localVariables,
-            onClick: () => {
-              saveScroll(0, 0)
-              selectedDataType === localVariables ? this.loadData() :
-                this.setState({ selectedDataType: localVariables })
-            }
-          }, ['Workspace Data'])
-        ]),
-        div({ style: styles.tableViewPanel(selectedDataType) }, [
-          selectedDataType ? this.renderData() : 'Select a data type.',
-          loading && spinnerOverlay
-        ])
-      ])
-    ])
-  }
-
-  renderData() {
-    const { selectedDataType } = this.state
-    const referenceData = this.getReferenceData()
-
-    if (selectedDataType === localVariables) {
-      return this.renderLocalVariables()
-    } else if (_.keys(referenceData).includes(selectedDataType)) {
-      return this.renderReferenceData()
-    } else {
-      return this.renderEntityTable()
+  async loadData() {
+    const { entityKey, workspace: { workspace: { namespace, name } }, ajax: { Workspaces } } = this.props
+    const { pageNumber, itemsPerPage, sort } = this.state
+    try {
+      this.setState({ loading: true })
+      const { results, resultMetadata: { unfilteredCount } } = await Workspaces.workspace(namespace, name)
+        .paginatedEntitiesOfType(entityKey, {
+          page: pageNumber, pageSize: itemsPerPage, sortField: sort.field, sortDirection: sort.direction
+        })
+      this.setState({ entities: results, totalRowCount: unfilteredCount, selectedEntities: [] })
+    } catch (error) {
+      reportError('Error loading entities', error)
+    } finally {
+      this.setState({ loading: false })
     }
   }
 
-  renderEntityTable() {
-    const { namespace, workspace: { accessLevel } } = this.props
-    const { entities, selectedDataType, entityMetadata, totalRowCount, pageNumber, itemsPerPage, sort, columnWidths, columnState, selectedEntities } = this.state
-    const theseColumnWidths = columnWidths[selectedDataType] || {}
-    const columnSettings = applyColumnSettings(columnState[selectedDataType] || [], entityMetadata[selectedDataType].attributeNames)
-    const resetScroll = () => this.table.current.scrollToTop()
-    const nameWidth = theseColumnWidths['name'] || 150
-    return entities && h(Fragment, [
-      div({ style: { flex: 'none', marginBottom: '1rem' } }, [
-        this.renderDownloadButton(columnSettings),
-        this.renderCopyButton()
-      ]),
-      div({ style: { flex: 1 } }, [
-        h(AutoSizer, [
-          ({ width, height }) => {
-            return h(GridTable, {
-              ref: this.table,
-              width, height,
-              rowCount: entities.length,
-              onScroll: saveScroll,
-              initialX: StateHistory.get().initialX,
-              initialY: StateHistory.get().initialY,
-              columns: _.concat(Utils.canWrite(accessLevel) ? [
-                {
-                  width: 50,
-                  headerRenderer: () => {
-                    const checked = selectedEntities.length === entities.length
-                    return h(Checkbox, {
-                      checked,
-                      onChange: () => {
-                        this.setState({ selectedEntities: checked ? [] : _.map('name', entities) })
-                      }
-                    })
-                  },
-                  cellRenderer: ({ rowIndex }) => {
-                    const { name } = entities[rowIndex]
-                    const checked = selectedEntities.includes(name)
-                    return h(Checkbox, {
-                      checked,
-                      onChange: () => {
-                        this.setState(({ selectedEntities }) => ({ selectedEntities: (checked ? _.pullAll : _.concat)([name], selectedEntities) }))
-                      }
-                    })
-                  }
-                }
-              ] : [],
-              [
-                {
-                  width: nameWidth,
-                  headerRenderer: () => h(Resizable, {
-                    width: nameWidth, onWidthChange: delta => {
-                      this.setState({ columnWidths: _.set(`${selectedDataType}.name`, nameWidth + delta, columnWidths) },
-                        () => this.table.current.recomputeColumnSizes())
-                    }
-                  }, [
-                    h(Sortable, { sort, field: 'name', onSort: v => this.setState({ sort: v, selectedEntities: [] }) }, [
-                      h(HeaderCell, [`${selectedDataType}_id`])
-                    ])
-                  ]),
-                  cellRenderer: ({ rowIndex }) => renderDataCell(entities[rowIndex].name, namespace)
-                },
-                ..._.map(({ name }) => {
-                  const thisWidth = theseColumnWidths[name] || 300
-                  return {
-                    width: thisWidth,
-                    headerRenderer: () => h(Resizable, {
-                      width: thisWidth, onWidthChange: delta => {
-                        this.setState({ columnWidths: _.set(`${selectedDataType}.${name}`, thisWidth + delta, columnWidths) },
-                          () => this.table.current.recomputeColumnSizes())
-                      }
-                    }, [
-                      h(Sortable, { sort, field: name, onSort: v => this.setState({ sort: v }) }, [
-                        h(HeaderCell, [name])
-                      ])
-                    ]),
-                    cellRenderer: ({ rowIndex }) => {
-                      return renderDataCell(
-                        Utils.entityAttributeText(entities[rowIndex].attributes[name]), namespace
-                      )
-                    }
-                  }
-                }, _.filter('visible', columnSettings))
-              ])
-            })
-          }
-        ]),
-        h(ColumnSelector, {
-          columnSettings,
-          onSave: v => this.setState(_.set(['columnState', selectedDataType], v), () => {
-            this.table.current.recomputeColumnSizes()
-          })
-        })
-      ]),
-      div({ style: { flex: 'none', marginTop: '1rem' } }, [
-        paginator({
-          filteredDataLength: totalRowCount,
-          pageNumber,
-          setPageNumber: v => this.setState({ pageNumber: v }, resetScroll),
-          itemsPerPage,
-          setItemsPerPage: v => this.setState({ itemsPerPage: v, pageNumber: 1 }, resetScroll)
-        })
-      ]),
-      !!selectedEntities.length && h(FloatingActionButton, {
-        label: 'DELETE DATA',
-        iconShape: 'trash',
-        onClick: () => this.setState({ deletingEntities: true })
-      })
-    ])
-  }
-
   renderDownloadButton(columnSettings) {
-    const { namespace, name } = this.props
-    const { selectedDataType, orchestrationRoot } = this.state
+    const { workspace: { workspace: { namespace, name } }, entityKey } = this.props
+    const { orchestrationRoot } = this.state
     return h(Fragment, [
       form({
         ref: this.downloadForm,
-        action: `${orchestrationRoot}/cookie-authed/workspaces/${namespace}/${name}/entities/${selectedDataType}/tsv`,
+        action: `${orchestrationRoot}/cookie-authed/workspaces/${namespace}/${name}/entities/${entityKey}/tsv`,
         method: 'POST'
       }, [
         input({ type: 'hidden', name: 'FCtoken', value: getUser().token }),
@@ -438,14 +366,15 @@ const WorkspaceData = _.flow(
   }
 
   renderCopyButton() {
-    const { entities, selectedDataType, entityMetadata, copying, copied } = this.state
+    const { entityKey, entityMetadata } = this.props
+    const { entities, copying, copied } = this.state
 
     return h(Fragment, [
       buttonPrimary({
         style: { margin: '0 1rem' },
         tooltip: 'Copy only the current page to the clipboard',
         onClick: async () => {
-          const attributeNames = entityMetadata[selectedDataType].attributeNames
+          const attributeNames = entityMetadata[entityKey].attributeNames
 
           const entityToRow = entity => _.join('\t', [
             entity.name, ..._.map(
@@ -453,7 +382,7 @@ const WorkspaceData = _.flow(
               attributeNames)
           ])
 
-          const header = _.join('\t', [`${selectedDataType}_id`, ...attributeNames])
+          const header = _.join('\t', [`${entityKey}_id`, ...attributeNames])
 
           const str = _.join('\n', [header, ..._.map(entityToRow, entities)]) + '\n'
 
@@ -474,216 +403,303 @@ const WorkspaceData = _.flow(
     ])
   }
 
-  renderLocalVariables() {
-    const { namespace, name, workspace: { accessLevel }, ajax: { Workspaces } } = this.props
-    const { workspaceAttributes, editIndex, deleteIndex, editKey, editValue, editType } = this.state
-    const canEdit = Utils.canWrite(accessLevel)
-    const stopEditing = () => this.setState({ editIndex: undefined, editKey: undefined, editValue: undefined, editType: undefined })
-    const filteredAttributes = _.flow(
-      _.toPairs,
-      _.remove(([key]) => key === 'description' || key.includes(':') || key.startsWith('referenceData-')),
-      _.sortBy(_.first)
-    )(workspaceAttributes)
-
-    const creatingNewVariable = editIndex === filteredAttributes.length
-    const amendedAttributes = [
-      ...filteredAttributes, ...(creatingNewVariable ? [['', '']] : [])
-    ]
-
-    const inputErrors = editIndex && [
-      ...(_.keys(_.unset(amendedAttributes[editIndex][0], workspaceAttributes)).includes(editKey) ? ['Key must be unique'] : []),
-      ...(!editKey ? ['Key is required'] : []),
-      ...(!editValue ? ['Value is required'] : []),
-      ...(editValue && editType === 'number' && Utils.cantBeNumber(editValue) ? ['Value is not a number'] : []),
-      ...(editValue && editType === 'number list' && _.some(Utils.cantBeNumber, editValue.split(',')) ?
-        ['Value is not a comma-separated list of numbers'] : [])
-    ]
-
-    const saveAttribute = async originalKey => {
-      try {
-        const isList = editType.includes('list')
-        const newBaseType = isList ? editType.slice(0, -5) : editType
-
-        const parsedValue = isList ? _.map(Utils.convertValue(newBaseType), editValue.split(/,s*/)) :
-          Utils.convertValue(newBaseType, editValue)
-
-        this.setState({ loading: true })
-
-        await Workspaces.workspace(namespace, name).shallowMergeNewAttributes({ [editKey]: parsedValue })
-
-        if (editKey !== originalKey) {
-          await Workspaces.workspace(namespace, name).deleteAttributes([originalKey])
-        }
-
-        await this.loadData()
-        stopEditing()
-      } catch (e) {
-        reportError('Error saving change to workspace variables', e)
-      }
-    }
-
-    return Utils.cond(
-      [!amendedAttributes, () => undefined],
-      [_.isEmpty(amendedAttributes), () => 'No Workspace Data defined'],
-      () => div({ style: { flex: 1 } }, [
-        h(AutoSizer, [
-          ({ width, height }) => h(FlexTable, {
-            width, height, rowCount: amendedAttributes.length,
-            onScroll: y => saveScroll(0, y),
-            initialY: StateHistory.get().initialY,
-            hoverHighlight: true,
-            columns: [
-              {
-                size: { basis: 400, grow: 0 },
-                headerRenderer: () => h(HeaderCell, ['Key']),
-                cellRenderer: ({ rowIndex }) => editIndex === rowIndex ?
-                  textInput({
-                    autoFocus: true,
-                    value: editKey,
-                    onChange: e => this.setState({ editKey: e.target.value })
-                  }) :
-                  renderDataCell(amendedAttributes[rowIndex][0], namespace)
-              },
-              {
-                size: { grow: 1 },
-                headerRenderer: () => h(HeaderCell, ['Value']),
-                cellRenderer: ({ rowIndex }) => {
-                  const originalKey = amendedAttributes[rowIndex][0]
-                  const originalValue = amendedAttributes[rowIndex][1]
-
-                  return h(Fragment, [
-                    div({ style: { flex: 1, minWidth: 0, display: 'flex' } }, [
-                      editIndex === rowIndex ?
-                        textInput({
-                          value: editValue,
-                          onChange: e => this.setState({ editValue: e.target.value })
-                        }) :
-                        renderDataCell(originalValue, namespace)
-                    ]),
-                    editIndex === rowIndex ?
-                      h(Fragment, [
-                        h(Select, {
-                          styles: { container: base => ({ ...base, marginLeft: '1rem', width: 150 }) },
-                          isSearchable: false,
-                          isClearable: false,
-                          menuPortalTarget: document.getElementById('root'),
-                          getOptionLabel: ({ value }) => _.startCase(value),
-                          value: editType,
-                          onChange: ({ value }) => this.setState({ editType: value }),
-                          options: ['string', 'number', 'boolean', 'string list', 'number list', 'boolean list']
-                        }),
-                        linkButton({
-                          tooltip: Utils.summarizeErrors(inputErrors) || 'Save changes',
-                          disabled: !!inputErrors.length,
-                          style: { marginLeft: '1rem' },
-                          onClick: () => saveAttribute(originalKey)
-                        }, [icon('success-standard', { size: 23 })]),
-                        linkButton({
-                          tooltip: 'Cancel editing',
-                          style: { marginLeft: '1rem' },
-                          onClick: () => stopEditing()
-                        }, [icon('times-circle', { size: 23 })])
-                      ]) :
-                      div({ className: 'hover-only' }, [
-                        linkButton({
-                          disabled: !canEdit,
-                          tooltip: canEdit ? 'Edit variable' : 'You do not have access to modify data in this workspace.',
-                          style: { marginLeft: '1rem' },
-                          onClick: () => this.setState({
-                            editIndex: rowIndex,
-                            editValue: typeof originalValue === 'object' ? originalValue.items.join(', ') : originalValue,
-                            editKey: originalKey,
-                            editType: typeof originalValue === 'object' ? `${typeof originalValue.items[0]} list` : typeof originalValue
-                          })
-                        }, [icon('pencil', { size: 19 })]),
-                        linkButton({
-                          disabled: !canEdit,
-                          tooltip: canEdit ? 'Delete variable' : 'You do not have access to modify data in this workspace.',
-                          style: { marginLeft: '1rem' },
-                          onClick: () => this.setState({ deleteIndex: rowIndex })
-                        }, [icon('trash', { size: 19 })])
+  render() {
+    const { workspace: { accessLevel, workspace: { namespace, name }, workspaceSubmissionStats: { runningSubmissionsCount } }, entityKey, entityMetadata, loadMetadata, firstRender } = this.props
+    const { entities, totalRowCount, pageNumber, itemsPerPage, sort, columnWidths, columnState, selectedEntities, deletingEntities, loading } = this.state
+    const theseColumnWidths = columnWidths[entityKey] || {}
+    const columnSettings = applyColumnSettings(columnState[entityKey] || [], entityMetadata[entityKey].attributeNames)
+    const resetScroll = () => this.table.current.scrollToTop()
+    const nameWidth = theseColumnWidths['name'] || 150
+    const { initialX, initialY } = firstRender ? StateHistory.get() : {}
+    return h(Fragment, [
+      !!entities && h(Fragment, [
+        div({ style: { flex: 'none', marginBottom: '1rem' } }, [
+          this.renderDownloadButton(columnSettings),
+          this.renderCopyButton()
+        ]),
+        div({ style: { flex: 1 } }, [
+          h(AutoSizer, [
+            ({ width, height }) => {
+              return h(GridTable, {
+                ref: this.table,
+                width, height,
+                rowCount: entities.length,
+                onScroll: saveScroll,
+                initialX,
+                initialY,
+                columns: [
+                  ...(Utils.canWrite(accessLevel) ? [{
+                    width: 50,
+                    headerRenderer: () => {
+                      const checked = selectedEntities.length === entities.length
+                      return h(Checkbox, {
+                        checked,
+                        onChange: () => {
+                          this.setState({ selectedEntities: checked ? [] : _.map('name', entities) })
+                        }
+                      })
+                    },
+                    cellRenderer: ({ rowIndex }) => {
+                      const { name } = entities[rowIndex]
+                      const checked = selectedEntities.includes(name)
+                      return h(Checkbox, {
+                        checked,
+                        onChange: () => {
+                          this.setState(({ selectedEntities }) => ({ selectedEntities: (checked ? _.pullAll : _.concat)([name], selectedEntities) }))
+                        }
+                      })
+                    }
+                  }] : []),
+                  {
+                    width: nameWidth,
+                    headerRenderer: () => h(Resizable, {
+                      width: nameWidth, onWidthChange: delta => {
+                        this.setState({ columnWidths: _.set(`${entityKey}.name`, nameWidth + delta, columnWidths) },
+                          () => this.table.current.recomputeColumnSizes())
+                      }
+                    }, [
+                      h(Sortable, { sort, field: 'name', onSort: v => this.setState({ sort: v }) }, [
+                        h(HeaderCell, [`${entityKey}_id`])
                       ])
-                  ])
-                }
-              }
-            ]
+                    ]),
+                    cellRenderer: ({ rowIndex }) => renderDataCell(entities[rowIndex].name, namespace)
+                  },
+                  ..._.map(({ name }) => {
+                    const thisWidth = theseColumnWidths[name] || 300
+                    return {
+                      width: thisWidth,
+                      headerRenderer: () => h(Resizable, {
+                        width: thisWidth, onWidthChange: delta => {
+                          this.setState({ columnWidths: _.set(`${entityKey}.${name}`, thisWidth + delta, columnWidths) },
+                            () => this.table.current.recomputeColumnSizes())
+                        }
+                      }, [
+                        h(Sortable, { sort, field: name, onSort: v => this.setState({ sort: v }) }, [
+                          h(HeaderCell, [name])
+                        ])
+                      ]),
+                      cellRenderer: ({ rowIndex }) => {
+                        return renderDataCell(
+                          Utils.entityAttributeText(entities[rowIndex].attributes[name]), namespace
+                        )
+                      }
+                    }
+                  }, _.filter('visible', columnSettings))
+                ]
+              })
+            }
+          ]),
+          h(ColumnSelector, {
+            columnSettings,
+            onSave: v => this.setState(_.set(['columnState', entityKey], v), () => {
+              this.table.current.recomputeColumnSizes()
+            })
           })
         ]),
-        !creatingNewVariable && canEdit && h(FloatingActionButton, {
-          label: 'ADD VARIABLE',
-          iconShape: 'plus',
-          onClick: () => this.setState({
-            editIndex: filteredAttributes.length,
-            editValue: '',
-            editKey: '',
-            editType: 'string'
+        div({ style: { flex: 'none', marginTop: '1rem' } }, [
+          paginator({
+            filteredDataLength: totalRowCount,
+            pageNumber,
+            setPageNumber: v => this.setState({ pageNumber: v }, resetScroll),
+            itemsPerPage,
+            setItemsPerPage: v => this.setState({ itemsPerPage: v, pageNumber: 1 }, resetScroll)
           })
-        }),
-        !_.isUndefined(deleteIndex) && h(Modal, {
-          onDismiss: () => this.setState({ deleteIndex: undefined }),
-          title: 'Are you sure you wish to delete this variable?',
-          okButton: buttonPrimary({
-            onClick: async () => {
-              try {
-                this.setState({ deleteIndex: undefined, loading: true })
-                await Workspaces.workspace(namespace, name).deleteAttributes([amendedAttributes[deleteIndex][0]])
-              } catch (e) {
-                reportError('Error deleting workspace variable', e)
-              } finally {
-                this.loadData()
-              }
-            }
-          },
-          'Delete Variable')
-        }, ['This will permanently delete the data from Workspace Data.'])
-      ])
+        ])
+      ]),
+      !!selectedEntities.length && h(FloatingActionButton, {
+        label: 'DELETE DATA',
+        iconShape: 'trash',
+        onClick: () => this.setState({ deletingEntities: true })
+      }),
+      deletingEntities && h(EntityDeleter, {
+        onDismiss: () => this.setState({ deletingEntities: false }),
+        onSuccess: () => {
+          this.setState({ deletingEntities: false })
+          this.loadData()
+          loadMetadata()
+        },
+        namespace, name,
+        selectedEntities, selectedDataType: entityKey, runningSubmissionsCount
+      }),
+      loading && spinnerOverlay
+    ])
+  }
+})
+
+const WorkspaceData = _.flow(
+  wrapWorkspace({
+    breadcrumbs: props => breadcrumbs.commonPaths.workspaceDashboard(props),
+    title: 'Data', activeTab: 'data'
+  }),
+  ajaxCaller
+)(class WorkspaceData extends Component {
+  constructor(props) {
+    super(props)
+    const { selectedDataType, entityMetadata } = StateHistory.get()
+    this.state = {
+      firstRender: true,
+      refreshKey: 0,
+      selectedDataType,
+      entityMetadata,
+      importingReference: false,
+      deletingReference: undefined
+    }
+  }
+
+  async loadMetadata() {
+    const { namespace, name, ajax: { Workspaces } } = this.props
+    const { selectedDataType } = this.state
+
+    try {
+      const entityMetadata = await Workspaces.workspace(namespace, name).entityMetadata()
+      this.setState({
+        selectedDataType: this.selectionType() === 'entities' && !entityMetadata[selectedDataType] ? undefined : selectedDataType,
+        entityMetadata
+      })
+    } catch (error) {
+      reportError('Error loading workspace entity data', error)
+    }
+  }
+
+  async componentDidMount() {
+    this.loadMetadata()
+    this.setState({ firstRender: false })
+  }
+
+  refresh() {
+    this.setState(({ refreshKey }) => ({ refreshKey: refreshKey + 1 }))
+  }
+
+  selectionType() {
+    const { workspace: { workspace: { attributes } } } = this.props
+    const { selectedDataType } = this.state
+    const referenceData = getReferenceData(attributes)
+    return Utils.cond(
+      [!selectedDataType, () => 'none'],
+      [selectedDataType === localVariables, () => 'localVariables'],
+      [_.includes(selectedDataType, _.keys(referenceData)), () => 'referenceData'],
+      () => 'entities'
     )
   }
 
-  renderReferenceData() {
-    const { namespace } = this.props
-    const { selectedDataType } = this.state
-    const selectedData = _.sortBy('key', this.getReferenceData()[selectedDataType])
+  render() {
+    const { namespace, name, workspace, workspace: { accessLevel, workspace: { attributes } }, loadingWorkspace, refreshWorkspace } = this.props
+    const { selectedDataType, entityMetadata, importingReference, deletingReference, firstRender, refreshKey, uploadingFile } = this.state
+    const referenceData = getReferenceData(attributes)
+    const canEdit = Utils.canWrite(accessLevel)
 
-    return div({ style: { flex: 1 } }, [
-      h(AutoSizer, { key: selectedDataType }, [
-        ({ width, height }) => h(FlexTable, {
-          width, height, rowCount: selectedData.length,
-          onScroll: y => saveScroll(0, y),
-          initialY: StateHistory.get().initialY,
-          columns: [
-            {
-              size: { basis: 400, grow: 0 },
-              headerRenderer: () => h(HeaderCell, ['Key']),
-              cellRenderer: ({ rowIndex }) => renderDataCell(selectedData[rowIndex].key, namespace)
-            },
-            {
-              size: { grow: 1 },
-              headerRenderer: () => h(HeaderCell, ['Value']),
-              cellRenderer: ({ rowIndex }) => renderDataCell(selectedData[rowIndex].value, namespace)
+    return div({ style: styles.tableContainer }, [
+      !entityMetadata ? spinnerOverlay : h(Fragment, [
+        div({ style: styles.dataTypeSelectionPanel }, [
+          div({ style: { display: 'flex', alignItems: 'center', justifyContent: 'space-between' } }, [
+            div({ style: styles.dataTypeHeading }, 'Tables'),
+            linkButton({
+              disabled: !canEdit,
+              tooltip: canEdit ? 'Upload .tsv' : 'You do not have access add data to this workspace.',
+              onClick: () => this.setState({ uploadingFile: true })
+            }, [icon('plus-circle')])
+          ]),
+          _.map(([type, typeDetails]) => {
+            return h(DataTypeButton, {
+              key: type,
+              selected: selectedDataType === type,
+              onClick: () => {
+                this.setState({ selectedDataType: type, refreshKey: refreshKey + 1 })
+              }
+            }, [`${type} (${typeDetails.count})`])
+          }, _.toPairs(entityMetadata)),
+          div({ style: { display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginTop: '1rem' } }, [
+            div({ style: styles.dataTypeHeading }, 'Reference Data'),
+            linkButton({
+              disabled: !canEdit,
+              tooltip: canEdit ? 'Add reference data' : 'You do not have access add data to this workspace.',
+              onClick: () => this.setState({ importingReference: true })
+            }, [icon('plus-circle')])
+          ]),
+          importingReference && h(ReferenceDataImporter, {
+            onDismiss: () => this.setState({ importingReference: false }),
+            onSuccess: () => this.setState({ importingReference: false }, refreshWorkspace),
+            namespace, name
+          }),
+          deletingReference && h(ReferenceDataDeleter, {
+            onDismiss: () => this.setState({ deletingReference: false }),
+            onSuccess: () => this.setState({
+              deletingReference: false,
+              selectedDataType: selectedDataType === deletingReference ? undefined : selectedDataType
+            }, refreshWorkspace),
+            namespace, name, referenceDataType: deletingReference
+          }),
+          uploadingFile && h(EntityUploader, {
+            onDismiss: () => this.setState({ uploadingFile: false }),
+            onSuccess: () => this.setState({ uploadingFile: false }, () => {
+              this.loadMetadata()
+              this.refresh()
+            }),
+            namespace, name,
+            entityTypes: _.keys(entityMetadata)
+          }),
+          _.map(type => {
+            return h(DataTypeButton, {
+              key: type,
+              selected: selectedDataType === type,
+              onClick: () => {
+                this.setState({ selectedDataType: type })
+                refreshWorkspace()
+              }
+            }, [
+              div({ style: { display: 'flex', justifyContent: 'space-between' } }, [
+                type,
+                h(Clickable, {
+                  tooltip: `Delete ${type}`,
+                  onClick: e => {
+                    e.stopPropagation()
+                    this.setState({ deletingReference: type })
+                  }
+                }, [icon('minus-circle', { size: 16 })])
+              ])
+            ])
+          }, _.keys(referenceData)),
+          div({ style: { ...styles.dataTypeHeading, marginTop: '1rem' } }, 'Other Data'),
+          h(DataTypeButton, {
+            selected: selectedDataType === localVariables,
+            onClick: () => {
+              this.setState({ selectedDataType: localVariables })
+              refreshWorkspace()
             }
-          ]
-        })
+          }, ['Workspace Data'])
+        ]),
+        div({ style: styles.tableViewPanel }, [
+          Utils.switchCase(this.selectionType(),
+            ['none', () => div({ style: { textAlign: 'center' } }, ['Select a data type'])],
+            ['localVariables', () => h(LocalVariablesContent, {
+              workspace,
+              refreshWorkspace,
+              loadingWorkspace,
+              firstRender
+            })],
+            ['referenceData', () => h(ReferenceDataContent, {
+              key: selectedDataType,
+              workspace,
+              loadingWorkspace,
+              referenceKey: selectedDataType,
+              firstRender
+            })],
+            ['entities', () => h(EntitiesContent, {
+              key: selectedDataType,
+              workspace,
+              entityMetadata,
+              entityKey: selectedDataType,
+              loadMetadata: () => this.loadMetadata(),
+              firstRender, refreshKey
+            })]
+          )
+        ])
       ])
     ])
   }
 
-  componentDidUpdate(prevProps, prevState) {
-    StateHistory.update(_.pick(
-      [
-        'entityMetadata', 'selectedDataType', 'entities', 'workspaceAttributes', 'totalRowCount',
-        'itemsPerPage', 'pageNumber', 'sort', 'columnWidths', 'columnState'
-      ],
-      this.state)
-    )
-
-    if (this.state.selectedDataType !== prevState.selectedDataType) {
-      this.setState({ copying: false, copied: false })
-    }
-
-    if (!_.isEqual(filterState(prevState), filterState(this.state))) {
-      this.loadData()
-    }
+  componentDidUpdate() {
+    StateHistory.update(_.pick(['entityMetadata', 'selectedDataType'], this.state))
   }
 })
 

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -188,7 +188,7 @@ export const wrapWorkspace = ({ breadcrumbs, activeTab, title, topBarContent, sh
 
     renderSuccess() {
       const { namespace, name } = this.props
-      const { workspace, clusters } = this.state
+      const { workspace, clusters, loadingWorkspace } = this.state
 
       return h(WorkspaceContainer, {
         namespace, name, activeTab, showTabBar, workspace, clusters,
@@ -206,7 +206,7 @@ export const wrapWorkspace = ({ breadcrumbs, activeTab, title, topBarContent, sh
       }, [
         workspace && h(WrappedComponent, {
           ref: this.child,
-          workspace, clusters,
+          workspace, clusters, loadingWorkspace,
           refreshWorkspace: () => this.refresh(),
           refreshClusters: () => this.refreshClusters(),
           ...this.props
@@ -264,10 +264,13 @@ export const wrapWorkspace = ({ breadcrumbs, activeTab, title, topBarContent, sh
     async refresh() {
       const { namespace, name, ajax: { Workspaces } } = this.props
       try {
+        this.setState({ loadingWorkspace: true })
         const workspace = await Workspaces.workspace(namespace, name).details()
         this.setState({ workspace })
       } catch (error) {
         this.setState({ workspaceError: error, errorText: await error.text().catch(() => 'Unknown') })
+      } finally {
+        this.setState({ loadingWorkspace: false })
       }
     }
   })


### PR DESCRIPTION
This cleans up and formalizes the data page, which had a fair bit of organic growth over time. It should be beneficial on its own, but also sets things up nicely for the upcoming bucket file view.
* Formalizes the master-detail structure, creating some separation between the left and right sides.
* Separates detail contents into individual components with their own specific state.
* Leverages the workspace data from the page wrapper, rather than loading it again.
* Fixes a few edge case bugs, e.g. not being able to add local variables if you have none.

All existing UX is preserved.