### PR TITLE
implement bucket view on data page

### DIFF
--- a/src/components/table.js
+++ b/src/components/table.js
@@ -387,7 +387,13 @@ export const SimpleTable = ({ columns, rows }) => {
         hover: { backgroundColor: colors.blue[5] }
       }, [
         _.map(({ key, size }) => {
-          return div({ key, style: { ...cellStyles, ...styles.flexCell(size) } }, [row[key]])
+          return div({
+            key,
+            style: {
+              ...cellStyles, ...styles.flexCell(size),
+              borderTop: `1px solid ${colors.gray[5]}`
+            }
+          }, [row[key]])
         }, columns)
       ])
     }, _.toPairs(rows))

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -370,6 +370,30 @@ export class GridTable extends Component {
   }
 }
 
+export const SimpleTable = ({ columns, rows }) => {
+  const rowHeight = 24
+  const cellStyles = { display: 'flex', alignItems: 'center' }
+  return h(Fragment, [
+    div({ style: { display: 'flex', height: rowHeight } }, [
+      _.map(({ key, header, size }) => {
+        return div({ key, style: { ...cellStyles, ...styles.flexCell(size) } }, [header])
+      }, columns)
+    ]),
+    _.map(([i, row]) => {
+      return h(Interactive, {
+        key: i,
+        as: 'div',
+        style: { display: 'flex', height: rowHeight }, className: 'table-row',
+        hover: { backgroundColor: colors.blue[5] }
+      }, [
+        _.map(({ key, size }) => {
+          return div({ key, style: { ...cellStyles, ...styles.flexCell(size) } }, [row[key]])
+        }, columns)
+      ])
+    }, _.toPairs(rows))
+  ])
+}
+
 export const TextCell = props => {
   return div(_.merge({
     style: { overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' }

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -472,6 +472,31 @@ const Buckets = signal => ({
     return _.filter(({ name }) => name.endsWith('.ipynb'), items)
   },
 
+  list: async (namespace, bucket, prefix) => {
+    const res = await fetchBuckets(
+      `storage/v1/b/${bucket}/o?${qs.stringify({ prefix, delimiter: '/' })}`,
+      _.merge(authOpts(await User(signal).token(namespace)), { signal })
+    )
+    return res.json()
+  },
+
+  delete: async (namespace, bucket, name) => {
+    return fetchBuckets(
+      `storage/v1/b/${bucket}/o/${encodeURIComponent(name)}`,
+      _.merge(authOpts(await User(signal).token(namespace)), { signal, method: 'DELETE' })
+    )
+  },
+
+  upload: async (namespace, bucket, prefix, file) => {
+    return fetchBuckets(
+      `upload/storage/v1/b/${bucket}/o?uploadType=media&name=${encodeURIComponent(prefix + file.name)}`,
+      _.merge(authOpts(await User(signal).token(namespace)), {
+        signal, method: 'POST', body: file,
+        headers: { 'Content-Type': file.type, 'Content-Length': file.size }
+      })
+    )
+  },
+
   notebook: (namespace, bucket, name) => {
     const bucketUrl = `storage/v1/b/${bucket}/o`
 

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -555,8 +555,9 @@ const DeleteObjectModal = ajaxCaller(class DeleteObjectModal extends Component {
     return h(Modal, {
       onDismiss,
       okButton: () => this.delete(),
-      title: 'Are you sure you want to delete this file?'
+      title: 'Delete this file?'
     }, [
+      'Are you sure you want to delete this file from the Google bucket?',
       deleting && spinnerOverlay
     ])
   }
@@ -581,7 +582,7 @@ const BucketContent = ajaxCaller(class BucketContent extends Component {
 
   componentDidUpdate(prevProps) {
     if (prevProps.refreshKey !== this.props.refreshKey) {
-      this.load()
+      this.load('')
     }
     StateHistory.update(_.pick(['objects', 'prefix'], this.state))
   }
@@ -658,7 +659,10 @@ const BucketContent = ajaxCaller(class BucketContent extends Component {
             }, prefixes),
             ..._.map(({ name, size, updated }) => {
               return {
-                button: linkButton({ onClick: () => this.setState({ deletingName: name }) }, [
+                button: linkButton({
+                  style: { display: 'flex' }, onClick: () => this.setState({ deletingName: name }),
+                  tooltip: 'Delete file'
+                }, [
                   icon('trash', { size: 16, className: 'hover-only' })
                 ]),
                 name: h(TextCell, [

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -1,6 +1,8 @@
 import clipboard from 'clipboard-polyfill'
+import filesize from 'filesize'
 import _ from 'lodash/fp'
 import { createRef, Fragment } from 'react'
+import Dropzone from 'react-dropzone'
 import { div, form, h, input } from 'react-hyperscript-helpers'
 import { AutoSizer } from 'react-virtualized'
 import * as breadcrumbs from 'src/components/breadcrumbs'
@@ -9,7 +11,8 @@ import FloatingActionButton from 'src/components/FloatingActionButton'
 import { icon, spinner } from 'src/components/icons'
 import { textInput } from 'src/components/input'
 import Modal from 'src/components/Modal'
-import { ColumnSelector, FlexTable, GridTable, HeaderCell, paginator, Resizable, Sortable } from 'src/components/table'
+import { ColumnSelector, FlexTable, GridTable, HeaderCell, paginator, Resizable, SimpleTable, Sortable, TextCell } from 'src/components/table'
+import UriViewer from 'src/components/UriViewer'
 import { ajaxCaller } from 'src/libs/ajax'
 import { getUser } from 'src/libs/auth'
 import colors from 'src/libs/colors'
@@ -26,6 +29,7 @@ import { wrapWorkspace } from 'src/pages/workspaces/workspace/WorkspaceContainer
 const filterState = (props, state) => ({ ..._.pick(['pageNumber', 'itemsPerPage', 'sort'], state), ..._.pick(['refreshKey'], props) })
 
 const localVariables = 'localVariables'
+const bucketObjects = '__bucket_objects__'
 
 const initialSort = { field: 'name', direction: 'asc' }
 
@@ -47,16 +51,16 @@ const styles = {
   }
 }
 
-const DataTypeButton = ({ selected, children, ...props }) => {
+const DataTypeButton = ({ selected, children, iconName = 'listAlt', iconSize = 14, ...props }) => {
   return linkButton({
     style: { display: 'flex', alignItems: 'center', fontWeight: selected ? 500 : undefined, padding: '0.5rem 0' },
     ...props
   }, [
-    div({ style: { flex: 'none', width: '1.5rem' } }, [
+    div({ style: { flex: 'none', display: 'flex', width: '1.5rem' } }, [
       selected && icon('circle', { size: 14, className: 'is-solid' })
     ]),
-    div({ style: { flex: 'none', width: '1.5rem' } }, [
-      icon('listAlt', { size: 14 })
+    div({ style: { flex: 'none', display: 'flex', width: '1.5rem' } }, [
+      icon(iconName, { size: iconSize })
     ]),
     div({ style: { flex: 1, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' } }, [
       children
@@ -526,6 +530,171 @@ const EntitiesContent = ajaxCaller(class EntitiesContent extends Component {
   }
 })
 
+const DeleteObjectModal = ajaxCaller(class DeleteObjectModal extends Component {
+  constructor(props) {
+    super(props)
+    this.state = { deleting: false }
+  }
+
+  async delete() {
+    const { name, workspace: { workspace: { namespace, bucketName } }, ajax: { Buckets }, onSuccess } = this.props
+    try {
+      this.setState({ deleting: true })
+      await Buckets.delete(namespace, bucketName, name)
+      onSuccess()
+    } catch (error) {
+      reportError('Error deleting object', error)
+    } finally {
+      this.setState({ deleting: false })
+    }
+  }
+
+  render() {
+    const { onDismiss } = this.props
+    const { deleting } = this.state
+    return h(Modal, {
+      onDismiss,
+      okButton: () => this.delete(),
+      title: 'Are you sure you want to delete this file?'
+    }, [
+      deleting && spinnerOverlay
+    ])
+  }
+})
+
+const BucketContent = ajaxCaller(class BucketContent extends Component {
+  constructor(props) {
+    super(props)
+    const { prefix = '', objects } = props.firstRender ? StateHistory.get() : {}
+    this.state = {
+      prefix,
+      objects,
+      deletingName: undefined,
+      viewingName: undefined
+    }
+    this.uploader = createRef()
+  }
+
+  componentDidMount() {
+    this.load()
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.refreshKey !== this.props.refreshKey) {
+      this.load()
+    }
+    StateHistory.update(_.pick(['objects', 'prefix'], this.state))
+  }
+
+  async load(prefix = this.state.prefix) {
+    const { workspace: { workspace: { namespace, bucketName } }, ajax: { Buckets } } = this.props
+    try {
+      this.setState({ loading: true })
+      const { items, prefixes } = await Buckets.list(namespace, bucketName, prefix)
+      this.setState({ objects: items, prefixes, prefix })
+    } catch (error) {
+      reportError('Error loading bucket data', error)
+    } finally {
+      this.setState({ loading: false })
+    }
+  }
+
+  async uploadFiles(files) {
+    const { workspace: { workspace: { namespace, bucketName } }, ajax: { Buckets } } = this.props
+    const { prefix } = this.state
+    try {
+      this.setState({ uploading: true })
+      await Buckets.upload(namespace, bucketName, prefix, files[0])
+      this.load()
+    } catch (error) {
+      reportError('Error uploading file', error)
+    } finally {
+      this.setState({ uploading: false })
+    }
+  }
+
+  render() {
+    const { workspace, workspace: { accessLevel, workspace: { namespace, bucketName } } } = this.props
+    const { prefix, prefixes, objects, loading, uploading, deletingName, viewingName } = this.state
+    const prefixParts = _.dropRight(1, prefix.split('/'))
+    const canEdit = Utils.canWrite(accessLevel)
+    return h(Fragment, [
+      h(Dropzone, {
+        disabled: !canEdit,
+        disableClick: true,
+        style: { flexGrow: 1, backgroundColor: 'white', border: `1px solid ${colors.gray[3]}`, padding: '1rem' },
+        activeStyle: { backgroundColor: colors.blue[3], cursor: 'copy' },
+        ref: this.uploader,
+        onDropAccepted: files => this.uploadFiles(files)
+      }, [
+        div([
+          _.map(({ label, target }) => {
+            return h(Fragment, { key: target }, [
+              linkButton({ onClick: () => this.load(target) }, [label]),
+              ' / '
+            ])
+          }, [
+            { label: 'Files', target: '' },
+            ..._.map(n => {
+              return { label: prefixParts[n], target: _.map(s => `${s}/`, _.take(n + 1, prefixParts)).join('') }
+            }, _.range(0, prefixParts.length))
+          ])
+        ]),
+        div({ style: { margin: '1rem -1rem 1rem -1rem', borderBottom: `1px solid ${colors.gray[5]}` } }),
+        h(SimpleTable, {
+          columns: [
+            { size: { basis: 24, grow: 0 }, key: 'button' },
+            { header: h(HeaderCell, ['Name']), size: { grow: 1 }, key: 'name' },
+            { header: h(HeaderCell, ['Size']), size: { basis: 200, grow: 0 }, key: 'size' },
+            { header: h(HeaderCell, ['Last modified']), size: { basis: 200, grow: 0 }, key: 'updated' }
+          ],
+          rows: [
+            ..._.map(p => {
+              return {
+                name: h(TextCell, [
+                  linkButton({ onClick: () => this.load(p) }, [p.slice(prefix.length)])
+                ])
+              }
+            }, prefixes),
+            ..._.map(({ name, size, updated }) => {
+              return {
+                button: linkButton({ onClick: () => this.setState({ deletingName: name }) }, [
+                  icon('trash', { size: 16, className: 'hover-only' })
+                ]),
+                name: h(TextCell, [
+                  linkButton({ onClick: () => this.setState({ viewingName: name }) }, [
+                    name.slice(prefix.length)
+                  ])
+                ]),
+                size: filesize(size, { round: 0 }),
+                updated: Utils.makePrettyDate(updated)
+              }
+            }, objects)
+          ]
+        }),
+        deletingName && h(DeleteObjectModal, {
+          workspace, name: deletingName,
+          onDismiss: () => this.setState({ deletingName: undefined }),
+          onSuccess: () => {
+            this.setState({ deletingName: undefined })
+            this.load()
+          }
+        }),
+        viewingName && h(UriViewer, {
+          googleProject: namespace, uri: `gs://${bucketName}/${viewingName}`,
+          onDismiss: () => this.setState({ viewingName: undefined })
+        }),
+        canEdit && h(FloatingActionButton, {
+          label: 'Upload',
+          iconShape: 'plus',
+          onClick: () => this.uploader.current.open()
+        })
+      ]),
+      (loading || uploading) && spinnerOverlay
+    ])
+  }
+})
+
 const WorkspaceData = _.flow(
   wrapWorkspace({
     breadcrumbs: props => breadcrumbs.commonPaths.workspaceDashboard(props),
@@ -577,6 +746,7 @@ const WorkspaceData = _.flow(
     return Utils.cond(
       [!selectedDataType, () => 'none'],
       [selectedDataType === localVariables, () => 'localVariables'],
+      [selectedDataType === bucketObjects, () => 'bucketObjects'],
       [_.includes(selectedDataType, _.keys(referenceData)), () => 'referenceData'],
       () => 'entities'
     )
@@ -666,7 +836,14 @@ const WorkspaceData = _.flow(
               this.setState({ selectedDataType: localVariables })
               refreshWorkspace()
             }
-          }, ['Workspace Data'])
+          }, ['Workspace Data']),
+          h(DataTypeButton, {
+            iconName: 'folder', iconSize: 18,
+            selected: selectedDataType === bucketObjects,
+            onClick: () => {
+              this.setState({ selectedDataType: bucketObjects, refreshKey: refreshKey + 1 })
+            }
+          }, ['Files'])
         ]),
         div({ style: styles.tableViewPanel }, [
           Utils.switchCase(this.selectionType(),
@@ -683,6 +860,10 @@ const WorkspaceData = _.flow(
               loadingWorkspace,
               referenceKey: selectedDataType,
               firstRender
+            })],
+            ['bucketObjects', () => h(BucketContent, {
+              workspace,
+              firstRender, refreshKey
             })],
             ['entities', () => h(EntitiesContent, {
               key: selectedDataType,


### PR DESCRIPTION
This establishes an MVP of the bucket viewer on the data page. Currently you can navigate folders, upload individual files, preview/download files, and remove individual files.

We can add more features in follow-on stories.

Fixes #855 
Fixes #858 