### PR TITLE
Make spinner position fixed

### DIFF
--- a/src/components/common.js
+++ b/src/components/common.js
@@ -171,7 +171,7 @@ export const RadioButton = ({ text, labelStyle, ...props }) => {
 export const spinnerDefault = ({ outerStyles = {}, innerStyles = {} }) => div(
   {
     style: {
-      position: 'absolute',
+      position: 'fixed',
       display: 'flex', alignItems: 'center',
       top: 0, right: 0, bottom: 0, left: 0,
       zIndex: 9999, // make sure it's on top of any third party components with z-indicies


### PR DESCRIPTION
Can anyone think of something that this would break? As is, there are situations where, when scrolled down, a spinner's background won't cover the entire page. I **think** we always want it to, right?