### PR TITLE
explicitly await reportError to avoid race condition

### DIFF
--- a/src/components/ExportDataModal.js
+++ b/src/components/ExportDataModal.js
@@ -182,7 +182,7 @@ export default _.flow(
             }) //handles dangling references when deleting entities
             return
           default:
-            reportError('Error deleting data entries', error)
+            await reportError('Error deleting data entries', error)
             onDismiss()
         }
       }
@@ -199,7 +199,7 @@ export default _.flow(
           this.setState({ hardConflicts, softConflicts, copying: false })
           break
         default:
-          reportError('Error copying data entries', error)
+          await reportError('Error copying data entries', error)
           onDismiss()
       }
     }

--- a/src/components/notebook-utils.js
+++ b/src/components/notebook-utils.js
@@ -95,18 +95,16 @@ export const NotebookCreator = ajaxCaller(class NotebookCreator extends Componen
       okButton: buttonPrimary({
         disabled: creating || errors,
         tooltip: Utils.summarizeErrors(errors),
-        onClick: () => {
+        onClick: async () => {
           this.setState({ creating: true })
-          Buckets.notebook(namespace, bucketName, notebookName).create(notebookData[notebookKernel]).then(
-            () => {
-              reloadList()
-              onDismiss()
-            },
-            error => {
-              reportError('Error creating notebook', error)
-              onDismiss()
-            }
-          )
+          try {
+            await Buckets.notebook(namespace, bucketName, notebookName).create(notebookData[notebookKernel])
+            reloadList()
+            onDismiss()
+          } catch (error) {
+            await reportError('Error creating notebook', error)
+            onDismiss()
+          }
         }
       }, 'Create Notebook')
     }, [

--- a/src/libs/data-utils.js
+++ b/src/libs/data-utils.js
@@ -54,17 +54,17 @@ export const ReferenceDataImporter = ajaxCaller(class ReferenceDataImporter exte
       title: 'Add Reference Data',
       okButton: buttonPrimary({
         disabled: !selectedReference || loading,
-        onClick: () => {
+        onClick: async () => {
           this.setState({ loading: true })
-          Workspaces.workspace(namespace, name).shallowMergeNewAttributes(
-            _.mapKeys(k => `referenceData-${selectedReference}-${k}`, ReferenceData[selectedReference])
-          ).then(
-            onSuccess,
-            error => {
-              reportError('Error importing reference data', error)
-              onDismiss()
-            }
-          )
+          try {
+            await Workspaces.workspace(namespace, name).shallowMergeNewAttributes(
+              _.mapKeys(k => `referenceData-${selectedReference}-${k}`, ReferenceData[selectedReference])
+            )
+            onSuccess()
+          } catch (error) {
+            await reportError('Error importing reference data', error)
+            onDismiss()
+          }
         }
       }, 'OK')
     }, [
@@ -107,7 +107,7 @@ export const ReferenceDataDeleter = ajaxCaller(class ReferenceDataDeleter extend
             )
             onSuccess()
           } catch (error) {
-            reportError('Error deleting reference data', error)
+            await reportError('Error deleting reference data', error)
             onDismiss()
           }
         }
@@ -149,7 +149,7 @@ export const EntityDeleter = ajaxCaller(class EntityDeleter extends Component {
           this.setState({ additionalDeletions: _.filter(entity => entity.entityType !== selectedDataType, await error.json()), deleting: false })
           break
         default:
-          reportError('Error deleting data entries', error)
+          await reportError('Error deleting data entries', error)
           onDismiss()
       }
     }
@@ -225,7 +225,7 @@ export const EntityUploader = ajaxCaller(class EntityUploader extends Component 
       await Workspaces.workspace(namespace, name).importEntitiesFile(file)
       onSuccess()
     } catch (error) {
-      reportError('Error uploading entities', error)
+      await reportError('Error uploading entities', error)
       onDismiss()
     }
   }


### PR DESCRIPTION
Fixes #899 

This is a complex issue.
1. Depending on network latency, there's sometimes a delay between when we start receiving a response, and when it fully finishes arriving. In this case, the fetch promise will resolve as soon as we get a status code, but reading the body will block until the response is completely done.
2. In some modals, when we get an unexpected error, we call `reportError` and then immediately close the modal. The reason is that the error banner currently displays behind modals, and we want to make sure the error is visible.
3. Because we almost always use the cancelable version of our ajax calls, unmounting the modal also cancels the still-unfinished ajax request.
4. When `reportError` attempts to read the body in order to display the error, it throws because the request has been invalidated, effectively losing the error.

There are probably several things we could do better here, but as a first step, we can avoid the issue by explicitly waiting for `reportError` to finish before we close the modals.