### PR TITLE
make config api synchronous

### DIFF
--- a/src/components/common.js
+++ b/src/components/common.js
@@ -7,6 +7,7 @@ import RSelect from 'react-select'
 import { centeredSpinner, icon } from 'src/components/icons'
 import TooltipTrigger from 'src/components/TooltipTrigger'
 import colors from 'src/libs/colors'
+import { getConfig } from 'src/libs/config'
 import * as Style from 'src/libs/style'
 
 
@@ -316,9 +317,11 @@ export const backgroundLogo = icon('logoIcon', {
   style: { position: 'fixed', top: -100, left: -100, zIndex: -1, opacity: 0.65 }
 })
 
-export const methodLink = (config, firecloudRoot, dockstoreRoot) => {
+export const methodLink = config => {
   const { methodRepoMethod: { sourceRepo, methodVersion, methodNamespace, methodName, methodPath } } = config
-  return sourceRepo === 'agora' ? `${firecloudRoot}/#methods/${methodNamespace}/${methodName}/${methodVersion}` : `${dockstoreRoot}/workflows/${methodPath}`
+  return sourceRepo === 'agora' ?
+    `${getConfig().firecloudUrlRoot}/#methods/${methodNamespace}/${methodName}/${methodVersion}` :
+    `${getConfig().dockstoreUrlRoot}/workflows/${methodPath}`
 }
 
 export const Markdown = ({ children, renderers = {}, ...props }) => {

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,8 @@ import _ from 'lodash/fp'
 import marked from 'marked'
 import ReactDOM from 'react-dom'
 import { h } from 'react-hyperscript-helpers'
+import { initializeAuth } from 'src/libs/auth'
+import { loadConfig } from 'src/libs/config'
 import Main from 'src/pages/Main'
 import 'src/style.css'
 
@@ -10,3 +12,5 @@ window.SATURN_VERSION = SATURN_VERSION
 marked.setOptions({ sanitize: true, sanitizer: _.escape })
 
 ReactDOM.render(h(Main), document.getElementById('root'))
+
+loadConfig().then(initializeAuth)

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -3,7 +3,7 @@ import * as qs from 'qs'
 import { h } from 'react-hyperscript-helpers'
 import { version } from 'src/data/clusters'
 import { getUser } from 'src/libs/auth'
-import * as Config from 'src/libs/config'
+import { getConfig } from 'src/libs/config'
 import * as Utils from 'src/libs/utils'
 import { Component } from 'src/libs/wrapped-components'
 
@@ -75,32 +75,32 @@ const fetchOk = async (url, options) => {
 
 
 const fetchSam = async (path, options) => {
-  return fetchOk(`${await Config.getSamUrlRoot()}/${path}`, addAppIdentifier(options))
+  return fetchOk(`${getConfig().samUrlRoot}/${path}`, addAppIdentifier(options))
 }
 
 const fetchBuckets = (path, options) => fetchOk(`https://www.googleapis.com/${path}`, options)
 const nbName = name => encodeURIComponent(`notebooks/${name}.ipynb`)
 
 const fetchRawls = async (path, options) => {
-  return fetchOk(`${await Config.getRawlsUrlRoot()}/api/${path}`, addAppIdentifier(options))
+  return fetchOk(`${getConfig().rawlsUrlRoot}/api/${path}`, addAppIdentifier(options))
 }
 
 const fetchLeo = async (path, options) => {
-  return fetchOk(`${await Config.getLeoUrlRoot()}/${path}`, options)
+  return fetchOk(`${getConfig().leoUrlRoot}/${path}`, options)
 }
 
 const fetchDockstore = async (path, options) => {
-  return fetchOk(`${await Config.getDockstoreUrlRoot()}/${path}`, options)
+  return fetchOk(`${getConfig().dockstoreUrlRoot}/${path}`, options)
 }
 // %23 = '#', %2F = '/'
 const dockstoreMethodPath = path => `api/ga4gh/v1/tools/%23workflow%2F${encodeURIComponent(path)}/versions`
 
 const fetchAgora = async (path, options) => {
-  return fetchOk(`${await Config.getAgoraUrlRoot()}/api/v1/${path}`, addAppIdentifier(options))
+  return fetchOk(`${getConfig().agoraUrlRoot}/api/v1/${path}`, addAppIdentifier(options))
 }
 
 const fetchOrchestration = async (path, options) => {
-  return fetchOk(`${await Config.getOrchestrationUrlRoot()}/${path}`, addAppIdentifier(options))
+  return fetchOk(`${getConfig().orchestrationUrlRoot}/${path}`, addAppIdentifier(options))
 }
 
 
@@ -115,7 +115,7 @@ const User = signal => ({
   }, namespace => namespace, 1000 * 60 * 30),
 
   getStatus: async () => {
-    return instrumentedFetch(`${await Config.getSamUrlRoot()}/register/user/v2/self/info`, _.mergeAll([authOpts(), { signal }, appIdentifier]))
+    return instrumentedFetch(`${getConfig().samUrlRoot}/register/user/v2/self/info`, _.mergeAll([authOpts(), { signal }, appIdentifier]))
   },
 
   create: async () => {
@@ -154,7 +154,7 @@ const User = signal => ({
   },
 
   getTosAccepted: async () => {
-    const url = `${await Config.getTosUrlRoot()}/user/response?${qs.stringify(tosData)}`
+    const url = `${getConfig().tosUrlRoot}/user/response?${qs.stringify(tosData)}`
     const res = await instrumentedFetch(url, _.merge(authOpts(), { signal }))
     if (res.status === 403 || res.status === 404) {
       return false
@@ -168,7 +168,7 @@ const User = signal => ({
 
   acceptTos: async () => {
     await fetchOk(
-      `${await Config.getTosUrlRoot()}/user/response`,
+      `${getConfig().tosUrlRoot}/user/response`,
       _.mergeAll([authOpts(), { signal, method: 'POST' }, jsonBody({ ...tosData, accepted: true })])
     )
   },
@@ -538,7 +538,7 @@ const Buckets = signal => ({
           `${bucketUrl}/${encodeURIComponent(`notebooks/${name}`)}?alt=media`,
           _.merge(authOpts(await User(signal).token(namespace)), { signal })
         ).then(res => res.text())
-        return fetchOk(`${await Config.getCalhounRoot()}/api/convert`,
+        return fetchOk(`${getConfig().calhounUrlRoot}/api/convert`,
           _.mergeAll([authOpts(), { signal, method: 'POST', body: nb }])
         ).then(res => res.text())
       },
@@ -606,11 +606,11 @@ const Jupyter = signal => ({
       create: async clusterOptions => {
         const body = _.merge(clusterOptions, {
           labels: { saturnAutoCreated: 'true', saturnVersion: version },
-          defaultClientId: await Config.getGoogleClientId(),
+          defaultClientId: getConfig().googleClientId,
           userJupyterExtensionConfig: {
             nbExtensions: {
               'saturn-iframe-extension':
-                `${window.location.hostname === 'localhost' ? await Config.getDevUrlRoot() : window.location.origin}/jupyter-iframe-extension.js`
+                `${window.location.hostname === 'localhost' ? getConfig().devUrlRoot : window.location.origin}/jupyter-iframe-extension.js`
             },
             serverExtensions: {},
             combinedExtensions: {}
@@ -666,7 +666,7 @@ const Dockstore = signal => ({
 
 const Martha = signal => ({
   call: async uri => {
-    return fetchOk(await Config.getMarthaUrlRoot(),
+    return fetchOk(getConfig().marthaUrlRoot,
       _.mergeAll([jsonBody({ uri }), authOpts(), appIdentifier, { signal, method: 'POST' }])
     ).then(res => res.json())
   }

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -3,7 +3,7 @@ import * as md5 from 'md5'
 import { version } from 'src/data/clusters'
 import ProdWhitelist from 'src/data/prod-whitelist'
 import { Ajax } from 'src/libs/ajax'
-import * as Config from 'src/libs/config'
+import { getConfig } from 'src/libs/config'
 import { clearErrorCode, reportError } from 'src/libs/error'
 import * as Utils from 'src/libs/utils'
 
@@ -33,9 +33,9 @@ export const getUser = () => {
   return authStore.get().user
 }
 
-const initializeAuth = _.memoize(async () => {
+export const initializeAuth = _.memoize(async () => {
   await new Promise(resolve => window.gapi.load('auth2', resolve))
-  await window.gapi.auth2.init({ clientId: await Config.getGoogleClientId() })
+  await window.gapi.auth2.init({ clientId: getConfig().googleClientId })
   const processUser = user => {
     return authStore.update(state => {
       const authResponse = user.getAuthResponse(true)
@@ -94,7 +94,7 @@ window.forceSignIn = async token => {
 authStore.subscribe(async (state, oldState) => {
   if (!oldState.isSignedIn && state.isSignedIn) {
     clearErrorCode('sessionTimeout')
-    if (await Config.getIsProd() && !ProdWhitelist.includes(md5(state.user.email))) {
+    if (getConfig().isProd && !ProdWhitelist.includes(md5(state.user.email))) {
       authStore.update(state => ({ ...state, registrationStatus: 'unlisted' }))
       return
     }
@@ -187,5 +187,3 @@ authStore.subscribe(async (state, oldState) => {
     }
   }
 })
-
-initializeAuth()

--- a/src/libs/config.js
+++ b/src/libs/config.js
@@ -2,10 +2,10 @@ import _ from 'lodash/fp'
 import * as Utils from 'src/libs/utils'
 
 let loadedConfig
-export const loadConfig = _.memoize(async () => {
+export const loadConfig = async () => {
   const res = await fetch('config.json')
   loadedConfig = await res.json()
-})
+}
 
 export const configOverridesStore = Utils.atom(
   sessionStorage['config-overrides'] && JSON.parse(sessionStorage['config-overrides'])

--- a/src/libs/config.js
+++ b/src/libs/config.js
@@ -1,10 +1,10 @@
 import _ from 'lodash/fp'
 import * as Utils from 'src/libs/utils'
 
-
-const loadConfig = _.memoize(async () => {
+let loadedConfig
+export const loadConfig = _.memoize(async () => {
   const res = await fetch('config.json')
-  return res.json()
+  loadedConfig = await res.json()
 })
 
 export const configOverridesStore = Utils.atom(
@@ -20,21 +20,7 @@ configOverridesStore.subscribe(v => {
 // Values in this store will override config settings. This can be used from the console for testing.
 window.configOverridesStore = configOverridesStore
 
-const getConfig = async () => {
-  return _.merge(await loadConfig(), configOverridesStore.get())
+export const getConfig = () => {
+  console.assert(loadedConfig, 'Called getConfig before iniitialization')
+  return _.merge(loadedConfig, configOverridesStore.get())
 }
-
-export const getAgoraUrlRoot = async () => (await getConfig()).agoraUrlRoot
-export const getCalhounRoot = async () => (await getConfig()).calhounUrlRoot
-export const getDevUrlRoot = async () => (await getConfig()).devUrlRoot
-export const getDockstoreUrlRoot = async () => (await getConfig()).dockstoreUrlRoot
-export const getFirecloudUrlRoot = async () => (await getConfig()).firecloudUrlRoot
-export const getFirecloudBucketRoot = async () => (await getConfig()).firecloudBucketRoot
-export const getGoogleClientId = async () => (await getConfig()).googleClientId
-export const getIsProd = async () => (await getConfig()).isProd
-export const getLeoUrlRoot = async () => (await getConfig()).leoUrlRoot
-export const getMarthaUrlRoot = async () => (await getConfig()).marthaUrlRoot
-export const getOrchestrationUrlRoot = async () => (await getConfig()).orchestrationUrlRoot
-export const getRawlsUrlRoot = async () => (await getConfig()).rawlsUrlRoot
-export const getSamUrlRoot = async () => (await getConfig()).samUrlRoot
-export const getTosUrlRoot = async () => (await getConfig()).tosUrlRoot

--- a/src/pages/library/Code.js
+++ b/src/pages/library/Code.js
@@ -8,7 +8,7 @@ import dockstoreLogo from 'src/images/library/code/dockstore.svg'
 import firecloudLogo from 'src/images/library/code/firecloud.svg'
 import { ajaxCaller } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
-import * as Config from 'src/libs/config'
+import { getConfig } from 'src/libs/config'
 import * as Nav from 'src/libs/nav'
 import * as StateHistory from 'src/libs/state-history'
 import * as Style from 'src/libs/style'
@@ -22,11 +22,11 @@ const styles = {
   }
 }
 
-const makeCard = firecloudRoot => method => {
+const makeCard = method => {
   const { namespace, name, synopsis } = method
 
   return a({
-    href: `${firecloudRoot}/?return=terra#methods/${namespace}/${name}/`,
+    href: `${getConfig().firecloudUrlRoot}/?return=terra#methods/${namespace}/${name}/`,
     style: {
       backgroundColor: 'white',
       width: 390, height: 140,
@@ -67,27 +67,25 @@ const logoTile = logoFile => div({
 const Code = ajaxCaller(class Code extends Component {
   constructor(props) {
     super(props)
-    const { featuredList, methods, firecloudRoot } = StateHistory.get()
+    const { featuredList, methods } = StateHistory.get()
 
-    this.state = { featuredList, methods, firecloudRoot }
+    this.state = { featuredList, methods }
   }
 
   async componentDidMount() {
     const { ajax: { Methods } } = this.props
 
-    const [featuredList, methods, firecloudRoot, dockstoreRoot] = await Promise.all([
-      fetch(`${await Config.getFirecloudBucketRoot()}/featured-methods.json`).then(res => res.json()),
-      Methods.list({ namespace: 'gatk' }),
-      Config.getFirecloudUrlRoot(),
-      Config.getDockstoreUrlRoot()
+    const [featuredList, methods] = await Promise.all([
+      fetch(`${getConfig().firecloudBucketRoot}/featured-methods.json`).then(res => res.json()),
+      Methods.list({ namespace: 'gatk' })
     ])
 
-    this.setState({ featuredList, methods, firecloudRoot, dockstoreRoot })
-    StateHistory.update({ featuredList, methods, firecloudRoot, dockstoreRoot })
+    this.setState({ featuredList, methods })
+    StateHistory.update({ featuredList, methods })
   }
 
   render() {
-    const { featuredList, methods, firecloudRoot, dockstoreRoot } = this.state
+    const { featuredList, methods } = this.state
 
     const featuredMethods = _.compact(
       _.map(
@@ -104,7 +102,7 @@ const Code = ajaxCaller(class Code extends Component {
           div({ style: { flex: 1, margin: '30px 0 30px 40px' } }, [
             div({ style: styles.header }, 'GATK4 Best Practices workflows'),
             div({ style: { display: 'flex', flexWrap: 'wrap' } }, [
-              ..._.map(makeCard(firecloudRoot), featuredMethods)
+              ..._.map(makeCard, featuredMethods)
             ])
           ]),
           div({ style: { width: 385, padding: '25px 30px', backgroundColor: colors.gray[5], lineHeight: '20px' } }, [
@@ -112,14 +110,14 @@ const Code = ajaxCaller(class Code extends Component {
             div({ style: { display: 'flex' } }, [
               logoTile(dockstoreLogo),
               div([
-                link({ href: `${dockstoreRoot}/search?descriptorType=wdl&searchMode=files` }, 'Dockstore'),
+                link({ href: `${getConfig().dockstoreUrlRoot}/search?descriptorType=wdl&searchMode=files` }, 'Dockstore'),
                 div(['Browse WDL workflows in Dockstore, an open platform used by the GA4GH for sharing Docker-based tools'])
               ])
             ]),
             div({ style: { display: 'flex', marginTop: 40 } }, [
               logoTile(firecloudLogo),
               div([
-                link({ href: `${firecloudRoot}/?return=terra#methods` }, 'Firecloud Methods Repository'),
+                link({ href: `${getConfig().firecloudUrlRoot}/?return=terra#methods` }, 'Firecloud Methods Repository'),
                 div(['Use FireCloud workflows in Terra. Share your own, or choose from > 700 public workflows'])
               ])
             ])

--- a/src/pages/library/Datasets.js
+++ b/src/pages/library/Datasets.js
@@ -13,7 +13,7 @@ import nhsLogo from 'src/images/library/datasets/NHS@2x.png'
 import topMedLogo from 'src/images/library/datasets/TopMed@2x.png'
 import ukbLogo from 'src/images/library/datasets/UKB@2x.jpg'
 import colors from 'src/libs/colors'
-import * as Config from 'src/libs/config'
+import { getConfig } from 'src/libs/config'
 import * as Nav from 'src/libs/nav'
 import * as Style from 'src/libs/style'
 import { Component } from 'src/libs/wrapped-components'
@@ -64,7 +64,7 @@ const logoBox = ({ src, alt, height }) => div({
 class Participant extends Component {
   render() {
     const { logo, title, shortDescription, description, sizeText, children, isFirecloud } = this.props
-    const { showingModal, firecloudRoot } = this.state
+    const { showingModal } = this.state
     const child = Children.only(children)
 
     const titleElement = div({ style: styles.participant.title }, [title])
@@ -85,7 +85,7 @@ class Participant extends Component {
         div({ style: styles.participant.sizeText }, [sizeText]),
         div({ style: { marginTop: '1rem' } }, [
           isFirecloud ?
-            cloneElement(child, { href: firecloudRoot + child.props.href }) :
+            cloneElement(child, { href: getConfig().firecloudUrlRoot + child.props.href }) :
             children
         ])
       ]),
@@ -100,10 +100,6 @@ class Participant extends Component {
         sizeText && p([sizeText])
       ])
     ])
-  }
-
-  async componentDidMount() {
-    this.props.isFirecloud && this.setState({ firecloudRoot: await Config.getFirecloudUrlRoot() })
   }
 }
 
@@ -149,8 +145,8 @@ const ukb = h(Participant, {
   title: `UK Biobank`,
   description: h(Fragment, [
     link({ href: 'https://www.ukbiobank.ac.uk/', target: '_blank' }, 'UK Biobank'),
-    ` is a national and international health resource with unparalleled research opportunities, 
-    open to bona fide health researchers. UK Biobank aims to improve the prevention, diagnosis and treatment of a wide 
+    ` is a national and international health resource with unparalleled research opportunities,
+    open to bona fide health researchers. UK Biobank aims to improve the prevention, diagnosis and treatment of a wide
     range of serious and life-threatening illnesses`
   ]),
   sizeText: 'Participants: > 500,000'
@@ -187,7 +183,7 @@ const amppd = h(Participant, {
   description: h(Fragment, [
     p([
       `The Accelerating Medicines Partnership (AMP) is a public-private partnership between the National Institutes of
-    Health (NIH), multiple biopharmaceutical and life sciences companies, and non-profit organizations to identify and 
+    Health (NIH), multiple biopharmaceutical and life sciences companies, and non-profit organizations to identify and
     validate the most promising biological targets for therapeutics. This AMP effort aims to identify and validate the
     most promising biological targets for therapeutics relevant to Parkinson's disease.`
     ]),

--- a/src/pages/library/Showcase.js
+++ b/src/pages/library/Showcase.js
@@ -7,7 +7,7 @@ import { withWorkspaces } from 'src/components/workspace-utils'
 import featuredBg from 'src/images/library/showcase/featured-workspace.svg'
 import gatkLogo from 'src/images/library/showcase/gatk-logo-light.svg'
 import colors from 'src/libs/colors'
-import * as Config from 'src/libs/config'
+import { getConfig } from 'src/libs/config'
 import * as Nav from 'src/libs/nav'
 import * as StateHistory from 'src/libs/state-history'
 import * as Style from 'src/libs/style'
@@ -57,7 +57,7 @@ const Showcase = withWorkspaces({ persist: true })(class Showcase extends Compon
   }
 
   async componentDidMount() {
-    const featuredList = await fetch(`${await Config.getFirecloudBucketRoot()}/featured-workspaces.json`).then(res => res.json())
+    const featuredList = await fetch(`${getConfig().firecloudBucketRoot}/featured-workspaces.json`).then(res => res.json())
 
     this.setState({ featuredList })
     StateHistory.update({ featuredList })

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -18,7 +18,7 @@ import UriViewer from 'src/components/UriViewer'
 import { ajaxCaller } from 'src/libs/ajax'
 import { getUser } from 'src/libs/auth'
 import colors from 'src/libs/colors'
-import * as Config from 'src/libs/config'
+import { getConfig } from 'src/libs/config'
 import { EntityDeleter, EntityUploader, ReferenceDataDeleter, ReferenceDataImporter, renderDataCell } from 'src/libs/data-utils'
 import { reportError } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
@@ -327,7 +327,6 @@ const EntitiesContent = ajaxCaller(class EntitiesContent extends Component {
 
   async componentDidMount() {
     this.loadData()
-    this.setState({ orchestrationRoot: await Config.getOrchestrationUrlRoot() })
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -383,11 +382,11 @@ const EntitiesContent = ajaxCaller(class EntitiesContent extends Component {
 
   renderDownloadButton(columnSettings) {
     const { workspace: { workspace: { namespace, name } }, entityKey } = this.props
-    const { orchestrationRoot, selectedEntities } = this.state
+    const { selectedEntities } = this.state
     return h(Fragment, [
       form({
         ref: this.downloadForm,
-        action: `${orchestrationRoot}/cookie-authed/workspaces/${namespace}/${name}/entities/${entityKey}/tsv`,
+        action: `${getConfig().orchestrationUrlRoot}/cookie-authed/workspaces/${namespace}/${name}/entities/${entityKey}/tsv`,
         method: 'POST'
       }, [
         input({ type: 'hidden', name: 'FCtoken', value: getUser().token }),
@@ -395,7 +394,6 @@ const EntitiesContent = ajaxCaller(class EntitiesContent extends Component {
         input({ type: 'hidden', name: 'model', value: 'flexible' })
       ]),
       _.isEmpty(selectedEntities) ? buttonPrimary({
-        disabled: !orchestrationRoot,
         tooltip: 'Download all data as a file',
         onClick: () => this.downloadForm.current.submit()
       }, [

--- a/src/pages/workspaces/workspace/JobHistory.js
+++ b/src/pages/workspaces/workspace/JobHistory.js
@@ -11,7 +11,7 @@ import { FlexTable, HeaderCell, TextCell } from 'src/components/table'
 import TooltipTrigger from 'src/components/TooltipTrigger'
 import { ajaxCaller } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
-import * as Config from 'src/libs/config'
+import { getConfig } from 'src/libs/config'
 import { reportError } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
 import * as Utils from 'src/libs/utils'
@@ -141,7 +141,7 @@ const JobHistory = _.flow(
 
   render() {
     const { namespace, name, ajax: { Workspaces } } = this.props
-    const { submissions, loading, aborting, newSubmissionId, highlightNewSubmission, firecloudRoot } = this.state
+    const { submissions, loading, aborting, newSubmissionId, highlightNewSubmission } = this.state
 
     return div({ style: styles.submissionsTable }, [
       submissions && !!submissions.length && h(AutoSizer, [
@@ -186,7 +186,7 @@ const JobHistory = _.flow(
                       h(MenuButton, {
                         as: 'a',
                         target: '_blank',
-                        href: `${firecloudRoot}/#workspaces/${namespace}/${name}/monitor/${submissionId}`
+                        href: `${getConfig().firecloudUrlRoot}/#workspaces/${namespace}/${name}/monitor/${submissionId}`
                       }, [menuIcon('circle-arrow right'), 'View job details']),
                       isTerminal(status) && workflowStatuses['Failed'] &&
                       submissionEntity && submissionEntity.entityType.endsWith('_set') && h(MenuButton, {
@@ -263,7 +263,6 @@ const JobHistory = _.flow(
 
   async componentDidMount() {
     this.refresh()
-    this.setState({ firecloudRoot: await Config.getFirecloudUrlRoot() })
   }
 
   componentWillUnmount() {

--- a/src/pages/workspaces/workspace/Tools.js
+++ b/src/pages/workspaces/workspace/Tools.js
@@ -9,7 +9,6 @@ import { icon } from 'src/components/icons'
 import PopupTrigger from 'src/components/PopupTrigger'
 import { ajaxCaller } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
-import * as Config from 'src/libs/config'
 import { reportError } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
 import * as StateHistory from 'src/libs/state-history'
@@ -72,7 +71,7 @@ const styles = {
   }
 }
 
-const ToolCard = pure(({ listView, name, namespace, config, onCopy, onDelete, firecloudRoot, dockstoreRoot }) => {
+const ToolCard = pure(({ listView, name, namespace, config, onCopy, onDelete }) => {
   const { namespace: workflowNamespace, name: workflowName, methodRepoMethod: { sourceRepo, methodVersion } } = config
   const toolCardMenu = h(PopupTrigger, {
     closeOnClick: true,
@@ -99,7 +98,7 @@ const ToolCard = pure(({ listView, name, namespace, config, onCopy, onDelete, fi
     ])
   ])
   const repoLink = link({
-    href: methodLink(config, firecloudRoot, dockstoreRoot),
+    href: methodLink(config),
     style: styles.innerLink,
     target: '_blank',
     onClick: e => e.stopPropagation()
@@ -165,7 +164,7 @@ export const Tools = _.flow(
 
   render() {
     const { namespace, name, listView, viewToggleButtons, workspace: { workspace } } = this.props
-    const { loading, configs, copyingTool, deletingTool, firecloudRoot, dockstoreRoot } = this.state
+    const { loading, configs, copyingTool, deletingTool } = this.state
     return h(PageFadeBox, [
       div({ style: { display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '1rem' } }, [
         div({ style: { ...Style.elements.sectionHeader, textTransform: 'uppercase' } }, ['Tools']),
@@ -188,7 +187,7 @@ export const Tools = _.flow(
           return h(ToolCard, {
             onCopy: () => this.setState({ copyingTool: { namespace: config.namespace, name: config.name } }),
             onDelete: () => this.setState({ deletingTool: { namespace: config.namespace, name: config.name } }),
-            key: `${config.namespace}/${config.name}`, namespace, name, config, listView, firecloudRoot, dockstoreRoot
+            key: `${config.namespace}/${config.name}`, namespace, name, config, listView
           })
         }, configs),
         configs && !configs.length && div(['No tools added']),
@@ -199,7 +198,6 @@ export const Tools = _.flow(
 
   async componentDidMount() {
     this.refresh()
-    this.setState({ firecloudRoot: await Config.getFirecloudUrlRoot(), dockstoreRoot: await Config.getDockstoreUrlRoot() })
   }
 
   componentDidUpdate() {

--- a/src/pages/workspaces/workspace/tools/WorkflowView.js
+++ b/src/pages/workspaces/workspace/tools/WorkflowView.js
@@ -19,7 +19,6 @@ import TooltipTrigger from 'src/components/TooltipTrigger'
 import WDLViewer from 'src/components/WDLViewer'
 import { ajaxCaller } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
-import * as Config from 'src/libs/config'
 import { reportError } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
 import * as StateHistory from 'src/libs/state-history'
@@ -364,8 +363,6 @@ const WorkflowView = _.flow(
       this.setState({
         isFreshData: true, savedConfig: config, modifiedConfig: config,
         entityMetadata, inputsOutputs: _.update('inputs', _.sortBy('optional'), inputsOutputs),
-        firecloudRoot: await Config.getFirecloudUrlRoot(),
-        dockstoreRoot: await Config.getDockstoreUrlRoot(),
         errors: augmentErrors(validationResponse),
         workspaceAttributes: _.flow(
           _.without(['description']),
@@ -405,7 +402,7 @@ const WorkflowView = _.flow(
 
   renderSummary() {
     const { workspace: { canCompute, workspace }, namespace, name: workspaceName } = this.props
-    const { modifiedConfig, savedConfig, entityMetadata, saving, saved, copying, deleting, activeTab, errors, firecloudRoot, dockstoreRoot, synopsis, documentation } = this.state
+    const { modifiedConfig, savedConfig, entityMetadata, saving, saved, copying, deleting, activeTab, errors, synopsis, documentation } = this.state
     const { name, methodRepoMethod: { methodPath, methodVersion, methodNamespace, methodName }, rootEntityType } = modifiedConfig
     const modified = !_.isEqual(modifiedConfig, savedConfig)
     const noLaunchReason = Utils.cond(
@@ -440,7 +437,7 @@ const WorkflowView = _.flow(
           div({ style: { marginTop: '0.5rem' } }, `Snapshot ${methodVersion}`),
           div([
             'Source: ', link({
-              href: methodLink(modifiedConfig, firecloudRoot, dockstoreRoot),
+              href: methodLink(modifiedConfig),
               target: '_blank'
             }, methodPath ? methodPath : `${methodNamespace}/${methodName}/${methodVersion}`)
           ]),


### PR DESCRIPTION
This is an alternative approach to #970 suggested by Isaac. It walls off the async loading of the config, and thereafter treats it as always available synchronously. It provides a cleaner API, but with some caveats:

We need to be more careful about initialization, because order now matters in a way that it didn't before. It's possible to attempt to access the config before it's loaded, in which case we throw an error in the console.

We explicitly sequence the loading of the config, followed by the auth layer. Currently we do not have to delay mounting the root component, because there is nothing near the base of the tree that tries to access config (but we need to make sure it stays that way).