### PR TITLE
Create clusters for all billing projects

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -264,6 +264,10 @@ const Billing = signal => ({
   listProjects: async () => {
     const res = await fetchRawls('user/billing', _.merge(authOpts(), { signal }))
     return res.json()
+  },
+  listProjectsExtended: async () => {
+    const res = await fetchSam('api/resources/v1/billing-project', _.merge(authOpts(), { signal }))
+    return res.json()
   }
 })
 


### PR DESCRIPTION
Includes those for which the user has access only by having can-compute on a workspace, which aren't returned in the list from Rawls.