### PR TITLE
return to older react-dropzone

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12040,9 +12040,9 @@
       }
     },
     "react-dropzone": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-8.0.0.tgz",
-      "integrity": "sha512-k4/Un1LD62NDDRg7Y10Ywb8VBBQ2Gi3yjYJUf38CuMulsENCWrB87QwsTxDIb9gSd5d3tReOpXTprIEf1JdtnA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-7.0.1.tgz",
+      "integrity": "sha512-J4rbzhFZPVW7k7K9CVb0OcwSOJGLWa0y+0rvtB4rBLVkvq0agH/o3kPJ0DCkd6ZVzL2K1NFqIOvtQkwQKpmJBA==",
       "requires": {
         "attr-accept": "^1.1.3",
         "prop-types": "^15.6.2"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "react-collapse": "^4.0.3",
     "react-dom": "~16.6.3",
     "react-draggable": "^3.0.5",
-    "react-dropzone": "^8.0.0",
+    "react-dropzone": "^7.0.1",
     "react-hyperscript-helpers": "^1.2.0",
     "react-interactive": "^0.8.1",
     "react-modal": "^3.7.1",


### PR DESCRIPTION
Turns out the new version of react-dropzone that we just updated to causes issues that I didn't catch, possibly due to bad hot-reloading. I'm going to look into that separately, but for the time being, I'm reverting this upgrade.