### PR TITLE
Configure autosave after notebook loads

### DIFF
--- a/public/jupyter-iframe-extension.js
+++ b/public/jupyter-iframe-extension.js
@@ -1,7 +1,9 @@
 define([
-  'base/js/namespace'
+  'base/js/namespace',
+  'base/js/promises'
 ], function(
-  Jupyter
+  Jupyter,
+  promises
 ) {
   function close_notebook() {
     Jupyter.notebook.shutdown_kernel({ confirm: false })
@@ -44,7 +46,9 @@ define([
     $('#menubar-close-button').on('click', close_notebook)
 
     // frequent autosave
-    Jupyter.notebook.set_autosave_interval(5000)
+    promises.notebook_loaded.then(function() {
+      Jupyter.notebook.set_autosave_interval(5000);
+    });
 
     // listen for explicit save command
     window.addEventListener('message', e => {

--- a/src/data/clusters.js
+++ b/src/data/clusters.js
@@ -49,4 +49,4 @@ export const profiles = [
   }
 ]
 
-export const version = '5'
+export const version = '6'  // updated jupyter-iframe-extension.js


### PR DESCRIPTION
Context: https://docs.google.com/document/d/1KsRQfwvumo5bjAT-gzNoPPML51wKHpO_RGYXJDTrndc/edit#heading=h.c74odyqs5ipq

The rationale for this change is that if Jupyter is slow to load a notebook (as is frequently the case after resuming clusters), it will forcibly disable auto-save as a "feature" to avoid saving partial data. This PR changes the Terra extension to only configure autosave _after_ the notebook is finished loading.

This is consistent with various online examples on how to configure the autosave interval via extension.

I tested this on a Terra cluster and it seems to work: before I was able to consistently reproduce autosave breaking; now it works every time.

If releasing this, users will need to recreate their clusters for it to take effect.

cc @mbookman @deflaux @calbach 