### PR TITLE
Validate special characters in notebook name

### DIFF
--- a/src/components/input.js
+++ b/src/components/input.js
@@ -36,7 +36,7 @@ const styles = {
   },
   validationError: {
     color: colors.red[0],
-    fontSize: 10, fontWeight: 500, textTransform: 'uppercase',
+    fontSize: 11, fontWeight: 600, textTransform: 'uppercase',
     marginLeft: '1rem', marginTop: '0.5rem'
   }
 }

--- a/src/components/notebook-utils.js
+++ b/src/components/notebook-utils.js
@@ -16,8 +16,8 @@ import validate from 'validate.js'
 export const notebookNameValidator = existing => ({
   presence: { allowEmpty: false },
   format: {
-    pattern: /^[^#[\]*?:;]*$/,
-    message: 'can\'t contain any of these characters: # [ ] * ? : ; '
+    pattern: /^[^#[\]*?:;@$%+=\\,/]*$/,
+    message: 'can\'t contain any of these characters: # [ ] * ? , : ; @ $ % + = / \\ '
   },
   exclusion: {
     within: existing,

--- a/src/components/notebook-utils.js
+++ b/src/components/notebook-utils.js
@@ -17,7 +17,7 @@ export const notebookNameValidator = existing => ({
   presence: { allowEmpty: false },
   format: {
     pattern: /^[^#[\]*?:]*$/,
-    message: 'cannot contain any of these characters: # [ ] * ? : '
+    message: 'can\'t contain any of these characters: # [ ] * ? : '
   },
   exclusion: {
     within: existing,

--- a/src/components/notebook-utils.js
+++ b/src/components/notebook-utils.js
@@ -16,8 +16,8 @@ import validate from 'validate.js'
 export const notebookNameValidator = existing => ({
   presence: { allowEmpty: false },
   format: {
-    pattern: /^[^#[\]*?]*$/,
-    message: 'can\'t contain any of these characters: "#[]*?"'
+    pattern: /^[^#[\]*?:]*$/,
+    message: 'cannot contain any of these characters: # [ ] * ? : '
   },
   exclusion: {
     within: existing,

--- a/src/components/notebook-utils.js
+++ b/src/components/notebook-utils.js
@@ -17,7 +17,7 @@ export const notebookNameValidator = existing => ({
   presence: { allowEmpty: false },
   format: {
     pattern: /^[^#[\]*?:;@$%+=\\,/]*$/,
-    message: 'can\'t contain any of these characters: # [ ] * ? , : ; @ $ % + = / \\ '
+    message: 'can\'t contain these characters: \r \r  @ # $ % * + = ? , [ ] : ; / \\ '
   },
   exclusion: {
     within: existing,

--- a/src/components/notebook-utils.js
+++ b/src/components/notebook-utils.js
@@ -16,8 +16,8 @@ import validate from 'validate.js'
 export const notebookNameValidator = existing => ({
   presence: { allowEmpty: false },
   format: {
-    pattern: /^[^#[\]*?:]*$/,
-    message: 'can\'t contain any of these characters: # [ ] * ? : '
+    pattern: /^[^#[\]*?:;]*$/,
+    message: 'can\'t contain any of these characters: # [ ] * ? : ; '
   },
   exclusion: {
     within: existing,


### PR DESCRIPTION
Fixes #1026 

- Notebook name cannot contain , : ; @ $ % = + / \
- Increased font size and weight to make validation errors slightly bolder