### PR TITLE
Removes plus button

### DIFF
--- a/src/pages/workspaces/workspace/ShareWorkspaceModal.js
+++ b/src/pages/workspaces/workspace/ShareWorkspaceModal.js
@@ -93,8 +93,7 @@ export default ajaxCaller(class ShareWorkspaceModal extends Component {
                 icon('warning-standard', { style: { color: colors.red[0], marginRight: '0.5rem' } })
               ]),
               suggestion
-            ]),
-            canAdd(suggestion) && linkButton({}, [icon('plus-circle', { size: 24 })])
+            ])
           ]),
           onSuggestionSelected: selection => {
             if (canAdd(selection)) {


### PR DESCRIPTION
Plus button when adding people to share a workspace was causing lots of modal problems. Plus button also didn't add any other special functionality, so this PR removes the plus button entirely. Doing so also fixes the bugs associated with it. 

<img width="720" alt="screen shot 2019-01-17 at 11 12 15 am" src="https://user-images.githubusercontent.com/42386483/51333398-99665280-1a4b-11e9-8008-03820dd1a98f.png">
here's how it looks now