### PR TITLE
always show account selector when signing in

### DIFF
--- a/src/components/SignInButton.js
+++ b/src/components/SignInButton.js
@@ -9,7 +9,8 @@ export default class SignInButton extends Component {
       'width': 250,
       'height': 56,
       'longtitle': true,
-      'theme': 'dark'
+      'theme': 'dark',
+      prompt: 'select_account'
     })
   }
 


### PR DESCRIPTION
(even when only signed in to one google account in the browser, so they can sign in to another)