### PR TITLE
Making whitelist less restrictive part 1

### DIFF
--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -92,8 +92,10 @@ window.forceSignIn = async token => {
 }
 
 authStore.subscribe(async (state, oldState) => {
-  const isTrustedEmail = (state.user.email.match(/@.*/g) === '@broadinstitute.org') || (state.user.email.match(/@.*/g) === '@verily.com') || (state.user.email.match(/@.*/g) === '@channing.harvard.edu')
   if (!oldState.isSignedIn && state.isSignedIn) {
+    const isTrustedEmail = (state.user.email.match(/@.*/g) === '@broadinstitute.org') ||
+      (state.user.email.match(/@.*/g) === '@verily.com') ||
+      (state.user.email.match(/@.*/g) === '@channing.harvard.edu')
     clearErrorCode('sessionTimeout')
     if (getConfig().isProd && !ProdWhitelist.includes(md5(state.user.email)) && !isTrustedEmail) {
       authStore.update(state => ({ ...state, registrationStatus: 'unlisted' }))

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -93,9 +93,8 @@ window.forceSignIn = async token => {
 
 authStore.subscribe(async (state, oldState) => {
   if (!oldState.isSignedIn && state.isSignedIn) {
-    const isTrustedEmail = (state.user.email.match(/@.*/g) === '@broadinstitute.org') ||
-      (state.user.email.match(/@.*/g) === '@verily.com') ||
-      (state.user.email.match(/@.*/g) === '@channing.harvard.edu')
+    const userEmailString = state.user.email.match(/@.*/g).toString()
+    const isTrustedEmail = (userEmailString === '@broadinstitute.org') || (userEmailString === '@verily.com') || (userEmailString === '@channing.harvard.edu')
     clearErrorCode('sessionTimeout')
     if (getConfig().isProd && !ProdWhitelist.includes(md5(state.user.email)) && !isTrustedEmail) {
       authStore.update(state => ({ ...state, registrationStatus: 'unlisted' }))

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -93,8 +93,7 @@ window.forceSignIn = async token => {
 
 authStore.subscribe(async (state, oldState) => {
   if (!oldState.isSignedIn && state.isSignedIn) {
-    const userEmailString = state.user.email.match(/@.*/g).toString()
-    const isTrustedEmail = (userEmailString === '@broadinstitute.org') || (userEmailString === '@verily.com') || (userEmailString === '@channing.harvard.edu')
+    const isTrustedEmail = _.includes(state.user.email.match(/@.*/g)[0], ['@broadinstitute.org', '@verily.com', '@channing.harvard.edu'])
     clearErrorCode('sessionTimeout')
     if (getConfig().isProd && !ProdWhitelist.includes(md5(state.user.email)) && !isTrustedEmail) {
       authStore.update(state => ({ ...state, registrationStatus: 'unlisted' }))

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -92,9 +92,10 @@ window.forceSignIn = async token => {
 }
 
 authStore.subscribe(async (state, oldState) => {
+  const isTrustedEmail = (state.user.email.match(/@.*/g) === '@broadinstitute.org') || (state.user.email.match(/@.*/g) === '@verily.com') || (state.user.email.match(/@.*/g) === '@channing.harvard.edu')
   if (!oldState.isSignedIn && state.isSignedIn) {
     clearErrorCode('sessionTimeout')
-    if (getConfig().isProd && !ProdWhitelist.includes(md5(state.user.email))) {
+    if (getConfig().isProd && !ProdWhitelist.includes(md5(state.user.email)) && !isTrustedEmail) {
       authStore.update(state => ({ ...state, registrationStatus: 'unlisted' }))
       return
     }

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -93,7 +93,7 @@ window.forceSignIn = async token => {
 
 authStore.subscribe(async (state, oldState) => {
   if (!oldState.isSignedIn && state.isSignedIn) {
-    const isTrustedEmail = _.includes(state.user.email.match(/@.*/g)[0], ['@broadinstitute.org', '@verily.com', '@channing.harvard.edu'])
+    const isTrustedEmail = _.includes(state.user.email.match(/@.*/)[0], ['@broadinstitute.org', '@verily.com', '@channing.harvard.edu'])
     clearErrorCode('sessionTimeout')
     if (getConfig().isProd && !ProdWhitelist.includes(md5(state.user.email)) && !isTrustedEmail) {
       authStore.update(state => ({ ...state, registrationStatus: 'unlisted' }))


### PR DESCRIPTION
Gives access to those who are on a broadinstitute.org, verily.com, and channing.harvard.edu email access.

I don't have a verily or channing email, and my broad one is already on our whitelist. So, I wasn't able to test to see if this actually works. If any of you are able to test it, please let me know if it works. Otherwise, I can go in and remove myself from the whitelist and test it myself. 