### PR TITLE
dismiss modal and refresh profile upon trial termination

### DIFF
--- a/src/components/TrialBanner.js
+++ b/src/components/TrialBanner.js
@@ -172,8 +172,11 @@ export const TrialBanner = _.flow(
           onClick: async () => {
             try {
               await User.finalizeTrial()
+              await refreshTerraProfile()
             } catch (error) {
               reportError('Error finalizing trial', error)
+            } finally {
+              this.setState({ finalizeTrial: false })
             }
           }
         }, ['Confirm'])


### PR DESCRIPTION
Noticed a bug when I was checking something else on prod with trial termination. After the credits have expired, the user could click the x to dismiss the banner forever. While it successfully finalized the trial, it didn't look like it did. The confirmation modal wouldn't disappear after clicking confirm, and the banner wouldn't go away until the user refreshed to page so the changes were used. This PR fixes that issue by dismissing the modal upon clicking confirm, and refreshing the terra profile so the banner gets removed. 