### PR TITLE
Whitelist google.com instead of verily.com

### DIFF
--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -98,7 +98,7 @@ authStore.subscribe(async (state, oldState) => {
 
     Ajax().User.getStatus().then(response => {
       if (response.status === 404) {
-        const isTrustedEmail = _.includes(state.user.email.match(/@.*/)[0], ['@broadinstitute.org', '@verily.com', '@channing.harvard.edu'])
+        const isTrustedEmail = _.includes(state.user.email.match(/@.*/)[0], ['@broadinstitute.org', '@google.com', '@channing.harvard.edu'])
 
         if (getConfig().isProd && !isTrustedEmail && !ProdWhitelist.includes(md5(state.user.email))) {
           return 'unlisted'


### PR DESCRIPTION
Minor fix to #1056 

verily.com is an alias for google.com. For authentication, only google.com is used. For example, if I want to add someone as a GCP Project Owner, I use their google.com email, not verily.com email.

In Chrome Developer Tools, I put a breakpoint in auth.js and confirmed that `state.user.email` is my @google.com email.

This opens up the whitelist to more people, as more people have google.com emails than verily.com emails. However, in practice, I don't think many (if any) non-Verily Googlers will use Terra (until GA).