### PR TITLE
make cluster management more manual

### DIFF
--- a/src/components/ClusterManager.js
+++ b/src/components/ClusterManager.js
@@ -509,7 +509,7 @@ export default ajaxCaller(class ClusterManager extends PureComponent {
         case 'Starting':
         case 'Stopping':
         case 'Creating':
-          return h(ClusterIcon, { shape: 'sync' })
+          return h(ClusterIcon, { shape: 'sync', disabled: true })
         case undefined:
           return h(ClusterIcon, {
             shape: 'play',
@@ -518,7 +518,7 @@ export default ajaxCaller(class ClusterManager extends PureComponent {
             tooltip: canCompute ? 'Create cluster' : noCompute
           })
         default:
-          return h(ClusterIcon, { shape: 'ban' })
+          return h(ClusterIcon, { shape: 'ban', disabled: true })
       }
     }
     const totalCost = _.sum(_.map(({ machineConfig, status }) => {
@@ -541,7 +541,7 @@ export default ajaxCaller(class ClusterManager extends PureComponent {
       }, [icon('terminal', { className: 'is-solid', size: 24 })]),
       renderIcon(),
       h(ClusterIcon, {
-        shape: 'stop',
+        shape: 'trash',
         onClick: () => this.setState({ deleting: true }),
         disabled: busy || !canCompute || !_.includes(currentStatus, ['Stopped', 'Running']),
         tooltip: 'Delete cluster',
@@ -582,7 +582,7 @@ export default ajaxCaller(class ClusterManager extends PureComponent {
           this.setState({ deleting: false })
           this.destroyActiveCluster()
         }
-      }, ['Deleting the machine will stop all associated costs. You can recreate it later, which will take several minutes.'])
+      }, ['Deleting the cluster will stop all running notebooks and associated costs. You can recreate it later, which will take several minutes.'])
     ])
   }
 })

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -247,3 +247,14 @@ export const isValidWsExportTarget = _.curry((sourceWs, destWs) => {
 
   return sourceId !== destId && canWrite(accessLevel) && (_.intersectionWith(_.isEqual, sourceAD, destAD).length === sourceAD.length)
 })
+
+export const normalizeMachineConfig = ({ masterMachineType, masterDiskSize, numberOfWorkers, numberOfPreemptibleWorkers, workerMachineType, workerDiskSize }) => {
+  return {
+    masterMachineType: masterMachineType || 'n1-standard-4',
+    masterDiskSize: masterDiskSize || 500,
+    numberOfWorkers: numberOfWorkers || 0,
+    numberOfPreemptibleWorkers: (numberOfWorkers && numberOfPreemptibleWorkers) || 0,
+    workerMachineType: (numberOfWorkers && workerMachineType) || 'n1-standard-4',
+    workerDiskSize: (numberOfWorkers && workerDiskSize) || 500
+  }
+}


### PR DESCRIPTION
Fixes #1083 

Note that a single cluster can still be auto-created by visiting a notebook link. We only do this once per page, but it's possible to create several clusters at once by e.g. opening multiple tabs quickly. We make an effort to be resilient to such an edge case, but addressing it properly would require a larger re-think of the underlying services.