### PR TITLE
Widen the modal slightly so the text stays on one line

### DIFF
--- a/src/components/NpsSurvey.js
+++ b/src/components/NpsSurvey.js
@@ -109,7 +109,7 @@ export const NpsSurvey = Utils.connectAtom(authStore, 'authState')(class NpsSurv
         disabled: expanded,
         style: {
           height: expanded ? 325 : 100,
-          width: expanded ? 400 : 255,
+          width: expanded ? 405 : 255,
           padding: '1rem 1.5rem 1rem 1rem',
           overflow: 'hidden',
           backgroundColor: colors.darkBlue[0], color: 'white',


### PR DESCRIPTION
When adding padding, I didn't see that it broke the first line into two, which pushes down the submit button.

Before:
![screen shot 2019-01-31 at 11 18 12 am](https://user-images.githubusercontent.com/2395211/52068061-e701b580-2549-11e9-84f0-2df37db7efb0.png)

After:
![screen shot 2019-01-31 at 11 17 32 am](https://user-images.githubusercontent.com/2395211/52068017-cfc2c800-2549-11e9-8a6b-878daa1a7ae2.png)
