### PR TITLE
fix dockstore api address

### DIFF
--- a/config/dev.json
+++ b/config/dev.json
@@ -2,7 +2,7 @@
   "agoraUrlRoot": "https://agora.dsde-dev.broadinstitute.org",
   "calhounUrlRoot": "https://terra-calhoun-dev.appspot.com",
   "devUrlRoot": "https://bvdp-saturn-dev.appspot.com",
-  "dockstoreUrlRoot": "https://staging.dockstore.org",
+  "dockstoreUrlRoot": "https://staging.dockstore.org:8443",
   "firecloudUrlRoot": "https://firecloud.dsde-dev.broadinstitute.org",
   "firecloudBucketRoot": "https://storage.googleapis.com/firecloud-alerts-dev",
   "googleClientId": "500025638838-s2v23ar3spugtd5t2v1vgfa2sp7ppg0d.apps.googleusercontent.com",

--- a/config/fiab.json
+++ b/config/fiab.json
@@ -2,7 +2,7 @@
   "agoraUrlRoot": "https://agora-fiab.dsde-dev.broadinstitute.org:20443",
   "calhounUrlRoot": "https://terra-calhoun-dev.appspot.com",
   "devUrlRoot": "https://bvdp-saturn-dev.appspot.com",
-  "dockstoreUrlRoot": "https://staging.dockstore.org",
+  "dockstoreUrlRoot": "https://staging.dockstore.org:8443",
   "firecloudUrlRoot": "https://firecloud-fiab.dsde-dev.broadinstitute.org",
   "firecloudBucketRoot": "https://storage.googleapis.com/firecloud-alerts-dev",
   "googleClientId": "500025638838-s2v23ar3spugtd5t2v1vgfa2sp7ppg0d.apps.googleusercontent.com",

--- a/config/prod.json
+++ b/config/prod.json
@@ -1,7 +1,7 @@
 {
   "agoraUrlRoot": "https://agora.dsde-prod.broadinstitute.org",
   "calhounUrlRoot": "https://terra-calhoun-prod.appspot.com",
-  "dockstoreUrlRoot": "https://dockstore.org",
+  "dockstoreUrlRoot": "https://dockstore.org:8443",
   "firecloudUrlRoot": "https://portal.firecloud.org",
   "firecloudBucketRoot": "https://storage.googleapis.com/firecloud-alerts",
   "googleClientId": "424501080111-b3bt4p1vo4gbo4m0573nvi4d49784bp8.apps.googleusercontent.com",


### PR DESCRIPTION
Matching https://github.com/broadinstitute/firecloud-develop/blob/dev/base-configs/firecloud-ui/config.json.ctmpl.

Easy test using `/#import-tool/dockstore/github.com/gatk-workflows/gatk4-somatic-snvs-indels/mutect2_pon:2.2.0`