### PR TITLE
removing explicit sam registration

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -122,11 +122,6 @@ const User = signal => ({
     return instrumentedFetch(`${getConfig().samUrlRoot}/register/user/v2/self/info`, _.mergeAll([authOpts(), { signal }, appIdentifier]))
   },
 
-  create: async () => {
-    const res = await fetchSam('register/user/v2/self', _.merge(authOpts(), { signal, method: 'POST' }))
-    return res.json()
-  },
-
   profile: {
     get: async () => {
       const res = await fetchOrchestration('register/profile', _.merge(authOpts(), { signal }))

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -127,6 +127,8 @@ const User = signal => ({
       const res = await fetchOrchestration('register/profile', _.merge(authOpts(), { signal }))
       return res.json()
     },
+
+    //We are not calling SAM directly because free credits logic is in orchestration
     set: keysAndValues => {
       const blankProfile = {
         firstName: 'N/A',

--- a/src/pages/Register.js
+++ b/src/pages/Register.js
@@ -34,7 +34,6 @@ export default ajaxCaller(class Register extends Component {
     const { givenName, familyName, email } = this.state
     try {
       this.setState({ busy: true })
-      await User.create()
       await User.profile.set({
         firstName: givenName,
         lastName: familyName,


### PR DESCRIPTION
We would first register the user in SAM, which would cause the enabling free credits part of registration to get bypassed. User.profile.set still registers the user in SAM but also allows the user to be enabled for free credits automatically. Removing the first SAM call fixes the issue. 

If you register a new user in Terra, it should automatically be enabled for free trial (even in dev). 