### PR TITLE
New data selection

### DIFF
--- a/src/components/DataTable.js
+++ b/src/components/DataTable.js
@@ -121,7 +121,7 @@ export default ajaxCaller(class DataTable extends Component {
                       } else if (type === 'single') {
                         const { selected, setSelected } = selectionModel
                         return h(RadioButton, {
-                          checked: selected === thisEntity,
+                          checked: _.isEqual(selected, thisEntity),
                           onChange: () => setSelected(thisEntity)
                         })
                       }

--- a/src/components/DataTable.js
+++ b/src/components/DataTable.js
@@ -1,0 +1,259 @@
+import _ from 'lodash/fp'
+import { createRef, Fragment } from 'react'
+import { div, h } from 'react-hyperscript-helpers'
+import { AutoSizer } from 'react-virtualized'
+import { Checkbox, Clickable, MenuButton, RadioButton, spinnerOverlay } from 'src/components/common'
+import { icon } from 'src/components/icons'
+import PopupTrigger from 'src/components/PopupTrigger'
+import { ColumnSelector, GridTable, HeaderCell, paginator, Resizable, Sortable } from 'src/components/table'
+import { ajaxCaller } from 'src/libs/ajax'
+import { renderDataCell } from 'src/libs/data-utils'
+import { reportError } from 'src/libs/error'
+import * as StateHistory from 'src/libs/state-history'
+import * as Utils from 'src/libs/utils'
+import { Component } from 'src/libs/wrapped-components'
+
+
+const filterState = (props, state) => _.pick(['pageNumber', 'itemsPerPage', 'sort'], state)
+
+const entityMap = entities => {
+  return _.fromPairs(_.map(e => [e.name, e], entities))
+}
+
+const applyColumnSettings = (columnSettings, columns) => {
+  const lookup = _.flow(
+    Utils.toIndexPairs,
+    _.map(([i, v]) => ({ ...v, index: i })),
+    _.keyBy('name')
+  )(columnSettings)
+  return _.flow(
+    _.map(name => lookup[name] || { name, visible: true, index: -1 }),
+    _.sortBy('index'),
+    _.map(_.omit('index'))
+  )(columns)
+}
+
+
+export default ajaxCaller(class DataTable extends Component {
+  constructor(props) {
+    super(props)
+
+    const {
+      entities,
+      totalRowCount = 0, itemsPerPage = 25, pageNumber = 1,
+      sort = { field: 'name', direction: 'asc' },
+      columnWidths = {}, columnState = {}
+    } = props.firstRender ? StateHistory.get() : {}
+
+    this.table = createRef()
+    this.state = {
+      loading: false,
+      entities, totalRowCount, itemsPerPage, pageNumber, sort, columnWidths, columnState
+    }
+  }
+
+  render() {
+    const {
+      entityType, entityMetadata, workspaceId: { namespace },
+      onScroll, initialX, initialY,
+      selectionModel,
+      childrenBefore
+    } = this.props
+
+    const { loading, entities, totalRowCount, itemsPerPage, pageNumber, sort, columnWidths, columnState } = this.state
+
+    const theseColumnWidths = columnWidths[entityType] || {}
+    const columnSettings = applyColumnSettings(columnState[entityType] || [], entityMetadata[entityType].attributeNames)
+    const nameWidth = theseColumnWidths['name'] || 150
+
+    const resetScroll = () => this.table.current.scrollToTop()
+
+    return h(Fragment, [
+      !!entities && h(Fragment, [
+        childrenBefore && childrenBefore({ entities, columnSettings }),
+        div({ style: { flex: 1 } }, [
+          h(AutoSizer, [
+            ({ width, height }) => {
+              return h(GridTable, {
+                ref: this.table,
+                width, height,
+                rowCount: entities.length,
+                onScroll,
+                initialX,
+                initialY,
+                columns: [
+                  ...(selectionModel ? [{
+                    width: 70,
+                    headerRenderer: selectionModel.type === 'multiple' ? () => {
+                      return h(Fragment, [
+                        h(Checkbox, {
+                          checked: this.pageSelected(),
+                          onChange: () => this.pageSelected() ? this.deselectPage() : this.selectPage()
+                        }),
+                        h(PopupTrigger, {
+                          closeOnClick: true,
+                          content: h(Fragment, [
+                            h(MenuButton, { onClick: () => this.selectPage() }, ['Page']),
+                            h(MenuButton, { onClick: () => this.selectAll() }, [`All (${totalRowCount})`]),
+                            h(MenuButton, { onClick: () => this.selectNone() }, ['None'])
+                          ]),
+                          side: 'bottom'
+                        }, [
+                          h(Clickable, [icon('caretDown')])
+                        ])
+                      ])
+                    } : () => div(),
+                    cellRenderer: ({ rowIndex }) => {
+                      const thisEntity = entities[rowIndex]
+                      const { name } = thisEntity
+                      const { type } = selectionModel
+
+                      if (type === 'multiple') {
+                        const { selected, setSelected } = selectionModel
+                        const checked = _.has([name], selected)
+                        return h(Checkbox, {
+                          checked,
+                          onChange: () => setSelected((checked ? _.unset([name]) : _.set([name], thisEntity))(selected))
+                        })
+                      } else if (type === 'single') {
+                        const { selected, setSelected } = selectionModel
+                        return h(RadioButton, {
+                          checked: selected === thisEntity,
+                          onChange: () => setSelected(thisEntity)
+                        })
+                      }
+                    }
+                  }] : []),
+                  {
+                    width: nameWidth,
+                    headerRenderer: () => h(Resizable, {
+                      width: nameWidth, onWidthChange: delta => {
+                        this.setState({ columnWidths: _.set(`${entityType}.name`, nameWidth + delta, columnWidths) },
+                          () => this.table.current.recomputeColumnSizes())
+                      }
+                    }, [
+                      h(Sortable, { sort, field: 'name', onSort: v => this.setState({ sort: v }) }, [
+                        h(HeaderCell, [`${entityType}_id`])
+                      ])
+                    ]),
+                    cellRenderer: ({ rowIndex }) => renderDataCell(entities[rowIndex].name, namespace)
+                  },
+                  ..._.map(({ name }) => {
+                    const thisWidth = theseColumnWidths[name] || 300
+                    return {
+                      width: thisWidth,
+                      headerRenderer: () => h(Resizable, {
+                        width: thisWidth, onWidthChange: delta => {
+                          this.setState({ columnWidths: _.set(`${entityType}.${name}`, thisWidth + delta, columnWidths) },
+                            () => this.table.current.recomputeColumnSizes())
+                        }
+                      }, [
+                        h(Sortable, { sort, field: name, onSort: v => this.setState({ sort: v }) }, [
+                          h(HeaderCell, [name])
+                        ])
+                      ]),
+                      cellRenderer: ({ rowIndex }) => {
+                        return renderDataCell(
+                          Utils.entityAttributeText(entities[rowIndex].attributes[name]), namespace
+                        )
+                      }
+                    }
+                  }, _.filter('visible', columnSettings))
+                ]
+              })
+            }
+          ]),
+          h(ColumnSelector, {
+            columnSettings,
+            onSave: v => this.setState(_.set(['columnState', entityType], v), () => {
+              this.table.current.recomputeColumnSizes()
+            })
+          })
+        ]),
+        div({ style: { flex: 'none', marginTop: '1rem' } }, [
+          paginator({
+            filteredDataLength: totalRowCount,
+            pageNumber,
+            setPageNumber: v => this.setState({ pageNumber: v }, resetScroll),
+            itemsPerPage,
+            setItemsPerPage: v => this.setState({ itemsPerPage: v, pageNumber: 1 }, resetScroll)
+          })
+        ])
+      ]),
+      loading && spinnerOverlay
+    ])
+  }
+
+  componentDidMount() {
+    this.loadData()
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    if (!_.isEqual(filterState(prevProps, prevState), filterState(this.props, this.state)) || this.props.refreshKey !== prevProps.refreshKey) {
+      this.loadData()
+    }
+    if (this.props.persist) {
+      StateHistory.update(_.pick(['entities', 'totalRowCount', 'itemsPerPage', 'pageNumber', 'sort', 'columnWidths', 'columnState'], this.state))
+    }
+  }
+
+  async loadData() {
+    const {
+      entityType, workspaceId: { namespace, name },
+      ajax: { Workspaces }
+    } = this.props
+
+    const { pageNumber, itemsPerPage, sort } = this.state
+
+    try {
+      this.setState({ loading: true })
+      const { results, resultMetadata: { unfilteredCount } } = await Workspaces.workspace(namespace, name)
+        .paginatedEntitiesOfType(entityType, {
+          page: pageNumber, pageSize: itemsPerPage, sortField: sort.field, sortDirection: sort.direction
+        })
+      this.setState({ entities: results, totalRowCount: unfilteredCount })
+    } catch (error) {
+      reportError('Error loading entities', error)
+    } finally {
+      this.setState({ loading: false })
+    }
+  }
+
+  async selectAll() {
+    const { entityType, workspaceId: { namespace, name }, ajax: { Workspaces }, selectionModel: { setSelected } } = this.props
+    try {
+      this.setState({ loading: true })
+      const results = await Workspaces.workspace(namespace, name).entitiesOfType(entityType)
+      setSelected(entityMap(results))
+    } catch (error) {
+      reportError('Error loading entities', error)
+    } finally {
+      this.setState({ loading: false })
+    }
+  }
+
+  selectPage() {
+    const { selectionModel: { selected, setSelected } } = this.props
+    const { entities } = this.state
+    setSelected(_.assign(selected, entityMap(entities)))
+  }
+
+  deselectPage() {
+    const { selectionModel: { selected, setSelected } } = this.props
+    const { entities } = this.state
+    setSelected(_.omit(_.map(({ name }) => [name], entities), selected))
+  }
+
+  selectNone() {
+    const { selectionModel: { setSelected } } = this.props
+    setSelected({})
+  }
+
+  pageSelected() {
+    const { selectionModel: { selected } } = this.props
+    const { entities } = this.state
+    const entityKeys = _.map('name', entities)
+    const selectedKeys = _.keys(selected)
+    return _.every(k => _.includes(k, selectedKeys), entityKeys)
+  }
+})

--- a/src/components/StepButtons.js
+++ b/src/components/StepButtons.js
@@ -85,7 +85,7 @@ const StepButtons = ({ tabs, activeTab, onChangeTab, finalStep }) => {
       ([i, { key, title, isValid }]) => stepButton({ i: i * 1, key, title, isValid, selectedIndex, onChangeTab, tabs }),
       _.toPairs(tabs)
     ),
-    finalStep /*&& _.every('isValid', tabs)*/ && h(Fragment, [
+    finalStep && h(Fragment, [
       els.dot(true), els.dot(true),
       finalStep
     ])

--- a/src/components/StepButtons.js
+++ b/src/components/StepButtons.js
@@ -85,7 +85,7 @@ const StepButtons = ({ tabs, activeTab, onChangeTab, finalStep }) => {
       ([i, { key, title, isValid }]) => stepButton({ i: i * 1, key, title, isValid, selectedIndex, onChangeTab, tabs }),
       _.toPairs(tabs)
     ),
-    finalStep && _.every('isValid', tabs) && h(Fragment, [
+    finalStep /*&& _.every('isValid', tabs)*/ && h(Fragment, [
       els.dot(true), els.dot(true),
       finalStep
     ])

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -251,7 +251,7 @@ export const Select = ({ value, options, ...props }) => {
       multiValueRemove: base => _.merge(base, { ':hover': { backgroundColor: 'unset' } })
     },
     getOptionLabel: ({ value, label }) => label || value.toString(),
-    value: newValue,
+    value: newValue || null, // need null instead of undefined to clear the select
     options: newOptions
   }, props))
 }

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -91,7 +91,8 @@ export const search = function({ wrapperProps, inputProps }) {
           border: 'none', outline: 'none',
           flexGrow: 1,
           verticalAlign: 'bottom', marginLeft: '1rem',
-          fontSize: '1rem'
+          fontSize: '1rem',
+          backgroundColor: 'transparent'
         }
       }, inputProps))
     ])

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -7,14 +7,14 @@ import Dropzone from 'react-dropzone'
 import { div, form, h, input } from 'react-hyperscript-helpers'
 import { AutoSizer } from 'react-virtualized'
 import * as breadcrumbs from 'src/components/breadcrumbs'
-import { buttonPrimary, Checkbox, Clickable, linkButton, MenuButton, Select, spinnerOverlay } from 'src/components/common'
+import { buttonPrimary, Clickable, linkButton, Select, spinnerOverlay } from 'src/components/common'
+import DataTable from 'src/components/DataTable'
 import ExportDataModal from 'src/components/ExportDataModal'
 import FloatingActionButton from 'src/components/FloatingActionButton'
 import { icon, spinner } from 'src/components/icons'
 import { textInput } from 'src/components/input'
 import Modal from 'src/components/Modal'
-import PopupTrigger from 'src/components/PopupTrigger'
-import { ColumnSelector, FlexTable, GridTable, HeaderCell, paginator, Resizable, SimpleTable, Sortable, TextCell } from 'src/components/table'
+import { FlexTable, HeaderCell, SimpleTable, TextCell } from 'src/components/table'
 import UriViewer from 'src/components/UriViewer'
 import { ajaxCaller } from 'src/libs/ajax'
 import { getUser } from 'src/libs/auth'
@@ -29,12 +29,8 @@ import { Component } from 'src/libs/wrapped-components'
 import { wrapWorkspace } from 'src/pages/workspaces/workspace/WorkspaceContainer'
 
 
-const filterState = (props, state) => ({ ..._.pick(['pageNumber', 'itemsPerPage', 'sort'], state), ..._.pick(['refreshKey'], props) })
-
 const localVariables = 'localVariables'
 const bucketObjects = '__bucket_objects__'
-
-const initialSort = { field: 'name', direction: 'asc' }
 
 const styles = {
   tableContainer: {
@@ -72,19 +68,6 @@ const DataTypeButton = ({ selected, children, iconName = 'listAlt', iconSize = 1
   ])
 }
 
-const applyColumnSettings = (columnSettings, columns) => {
-  const lookup = _.flow(
-    Utils.toIndexPairs,
-    _.map(([i, v]) => ({ ...v, index: i })),
-    _.keyBy('name')
-  )(columnSettings)
-  return _.flow(
-    _.map(name => lookup[name] || { name, visible: true, index: -1 }),
-    _.sortBy('index'),
-    _.map(_.omit('index'))
-  )(columns)
-}
-
 const saveScroll = _.throttle(100, (initialX, initialY) => {
   StateHistory.update({ initialX, initialY })
 })
@@ -98,10 +81,6 @@ const getReferenceData = _.flow(
   }),
   _.groupBy('datum')
 )
-
-const entityMap = entities => {
-  return _.fromPairs(_.map(e => [e.name, e], entities))
-}
 
 const LocalVariablesContent = ajaxCaller(class LocalVariablesContent extends Component {
   render() {
@@ -306,82 +285,15 @@ const ReferenceDataContent = ({ workspace: { workspace: { namespace, attributes 
   ])
 }
 
-const EntitiesContent = ajaxCaller(class EntitiesContent extends Component {
+class EntitiesContent extends Component {
   constructor(props) {
     super(props)
-    const { entities, totalRowCount = 0, itemsPerPage = 25, pageNumber = 1, sort = initialSort, columnWidths = {}, columnState = {} } = props.firstRender ?
-      StateHistory.get() :
-      {}
     this.state = {
-      entities,
-      itemsPerPage,
-      pageNumber,
-      sort,
-      loading: false,
-      columnWidths,
-      columnState,
       selectedEntities: {},
       deletingEntities: false,
-      totalRowCount,
-      viewData: undefined
+      refreshKey: 0
     }
-    this.table = createRef()
     this.downloadForm = createRef()
-  }
-
-  async componentDidMount() {
-    this.loadData()
-  }
-
-  componentDidUpdate(prevProps, prevState) {
-    if (!_.isEqual(filterState(prevProps, prevState), filterState(this.props, this.state))) {
-      this.loadData()
-    }
-    StateHistory.update(_.pick(['entities', 'totalRowCount', 'itemsPerPage', 'pageNumber', 'sort', 'columnWidths', 'columnState'], this.state))
-  }
-
-  async loadData() {
-    const { entityKey, workspace: { workspace: { namespace, name } }, ajax: { Workspaces } } = this.props
-    const { pageNumber, itemsPerPage, sort } = this.state
-    try {
-      this.setState({ loading: true })
-      const { results, resultMetadata: { unfilteredCount } } = await Workspaces.workspace(namespace, name)
-        .paginatedEntitiesOfType(entityKey, {
-          page: pageNumber, pageSize: itemsPerPage, sortField: sort.field, sortDirection: sort.direction
-        })
-      this.setState({ entities: results, totalRowCount: unfilteredCount })
-    } catch (error) {
-      reportError('Error loading entities', error)
-    } finally {
-      this.setState({ loading: false })
-    }
-  }
-
-  async selectAll() {
-    const { entityKey, workspace: { workspace: { namespace, name } }, ajax: { Workspaces } } = this.props
-    try {
-      this.setState({ loading: true })
-      const results = await Workspaces.workspace(namespace, name).entitiesOfType(entityKey)
-      this.setState({ selectedEntities: entityMap(results) })
-    } catch (error) {
-      reportError('Error loading entities', error)
-    } finally {
-      this.setState({ loading: false })
-    }
-  }
-
-  selectPage() {
-    const { entities, selectedEntities } = this.state
-    this.setState({ selectedEntities: _.assign(selectedEntities, entityMap(entities)) })
-  }
-
-  deselectPage() {
-    const { entities, selectedEntities } = this.state
-    this.setState({ selectedEntities: _.omit(_.map(a => [a], _.map('name', entities)), selectedEntities) })
-  }
-
-  selectNone() {
-    this.setState({ selectedEntities: {} })
   }
 
   renderDownloadButton(columnSettings) {
@@ -417,8 +329,8 @@ const EntitiesContent = ajaxCaller(class EntitiesContent extends Component {
     ])
   }
 
-  renderCopyButton(columnSettings) {
-    const { entities, copying, copied } = this.state
+  renderCopyButton(entities, columnSettings) {
+    const { copying, copied } = this.state
 
     return h(Fragment, [
       buttonPrimary({
@@ -458,135 +370,32 @@ const EntitiesContent = ajaxCaller(class EntitiesContent extends Component {
     return _.join('\n', [header, ..._.map(entityToRow, entities)]) + '\n'
   }
 
-  pageSelected() {
-    const { entities, selectedEntities } = this.state
-    const entityKeys = _.map('name', entities)
-    const selectedKeys = _.keys(selectedEntities)
-    return _.every(k => _.includes(k, selectedKeys), entityKeys)
-  }
-
-  displayData(selectedData) {
-    const { itemsType, items } = selectedData
-    return _.map(entity => div({ style: { borderBottom: `1px solid ${colors.gray[2]}`, padding: '0.5rem' } },
-      itemsType === 'EntityReference' ? `${entity.entityName} (${entity.entityType})` : JSON.stringify(entity)), items)
-  }
-
   render() {
-    const { workspace, workspace: { accessLevel, workspace: { namespace, name }, workspaceSubmissionStats: { runningSubmissionsCount } }, entityKey, entityMetadata, loadMetadata, firstRender } = this.props
-    const { entities, totalRowCount, pageNumber, itemsPerPage, sort, columnWidths, columnState, selectedEntities, deletingEntities, loading, copyingEntities, viewData } = this.state
-    const theseColumnWidths = columnWidths[entityKey] || {}
-    const columnSettings = applyColumnSettings(columnState[entityKey] || [], entityMetadata[entityKey].attributeNames)
-    const resetScroll = () => this.table.current.scrollToTop()
-    const nameWidth = theseColumnWidths['name'] || 150
+    const {
+      workspace, workspace: { accessLevel, workspace: { namespace, name }, workspaceSubmissionStats: { runningSubmissionsCount } },
+      entityKey, entityMetadata, loadMetadata, firstRender
+    } = this.props
+    const { selectedEntities, deletingEntities, copyingEntities, refreshKey } = this.state
+
     const { initialX, initialY } = firstRender ? StateHistory.get() : {}
+
     return h(Fragment, [
-      !!entities && h(Fragment, [
-        div({ style: { flex: 'none', marginBottom: '1rem' } }, [
+      h(DataTable, {
+        persist: true, firstRender, refreshKey,
+        entityType: entityKey, entityMetadata, workspaceId: { namespace, name },
+        onScroll: saveScroll, initialX, initialY,
+        selectionModel: {
+          type: 'multiple',
+          selected: selectedEntities,
+          setSelected: Utils.canWrite(accessLevel) && (e => this.setState({ selectedEntities: e }))
+        },
+        childrenBefore: ({ entities, columnSettings }) => div({
+          style: { display: 'flex', alignItems: 'center', flex: 'none', marginBottom: '1rem' }
+        }, [
           this.renderDownloadButton(columnSettings),
-          this.renderCopyButton(columnSettings)
-        ]),
-        div({ style: { flex: 1 } }, [
-          h(AutoSizer, [
-            ({ width, height }) => {
-              return h(GridTable, {
-                ref: this.table,
-                width, height,
-                rowCount: entities.length,
-                onScroll: saveScroll,
-                initialX,
-                initialY,
-                columns: [
-                  ...(Utils.canWrite(accessLevel) ? [{
-                    width: 70,
-                    headerRenderer: () => {
-                      return h(Fragment, [
-                        h(Checkbox, {
-                          checked: this.pageSelected(),
-                          onChange: () => this.pageSelected() ? this.deselectPage() : this.selectPage()
-                        }),
-                        h(PopupTrigger, {
-                          closeOnClick: true,
-                          content: h(Fragment, [
-                            h(MenuButton, { onClick: () => this.selectPage() }, ['Page']),
-                            h(MenuButton, { onClick: () => this.selectAll() }, [`All (${totalRowCount})`]),
-                            h(MenuButton, { onClick: () => this.selectNone() }, ['None'])
-                          ]),
-                          side: 'bottom'
-                        }, [
-                          h(Clickable, [icon('caretDown')])
-                        ])
-                      ])
-                    },
-                    cellRenderer: ({ rowIndex }) => {
-                      const { name } = entities[rowIndex]
-                      const checked = _.has([name], selectedEntities)
-                      return h(Checkbox, {
-                        checked,
-                        onChange: () => this.setState(
-                          { selectedEntities: (checked ? _.unset([name]) : _.set([name], entities[rowIndex]))(selectedEntities) })
-                      })
-                    }
-                  }] : []),
-                  {
-                    width: nameWidth,
-                    headerRenderer: () => h(Resizable, {
-                      width: nameWidth, onWidthChange: delta => {
-                        this.setState({ columnWidths: _.set(`${entityKey}.name`, nameWidth + delta, columnWidths) },
-                          () => this.table.current.recomputeColumnSizes())
-                      }
-                    }, [
-                      h(Sortable, { sort, field: 'name', onSort: v => this.setState({ sort: v }) }, [
-                        h(HeaderCell, [`${entityKey}_id`])
-                      ])
-                    ]),
-                    cellRenderer: ({ rowIndex }) => renderDataCell(entities[rowIndex].name, namespace)
-                  },
-                  ..._.map(({ name }) => {
-                    const thisWidth = theseColumnWidths[name] || 300
-                    return {
-                      width: thisWidth,
-                      headerRenderer: () => h(Resizable, {
-                        width: thisWidth, onWidthChange: delta => {
-                          this.setState({ columnWidths: _.set(`${entityKey}.${name}`, thisWidth + delta, columnWidths) },
-                            () => this.table.current.recomputeColumnSizes())
-                        }
-                      }, [
-                        h(Sortable, { sort, field: name, onSort: v => this.setState({ sort: v }) }, [
-                          h(HeaderCell, [name])
-                        ])
-                      ]),
-                      cellRenderer: ({ rowIndex }) => {
-                        const dataInfo = entities[rowIndex].attributes[name]
-                        const dataCell = renderDataCell(Utils.entityAttributeText(dataInfo), namespace)
-                        return (dataInfo && _.isArray(dataInfo.items)) ?
-                          linkButton({
-                            onClick: () => this.setState({ viewData: dataInfo })
-                          },
-                          [dataCell]) : dataCell
-                      }
-                    }
-                  }, _.filter('visible', columnSettings))
-                ]
-              })
-            }
-          ]),
-          h(ColumnSelector, {
-            columnSettings,
-            onSave: v => this.setState(_.set(['columnState', entityKey], v), () => {
-              this.table.current.recomputeColumnSizes()
-            })
-          })
-        ]),
-        div({ style: { flex: 'none', marginTop: '1rem' } }, [
-          paginator({
-            filteredDataLength: totalRowCount,
-            pageNumber,
-            setPageNumber: v => this.setState({ pageNumber: v }, resetScroll),
-            itemsPerPage,
-            setItemsPerPage: v => this.setState({ itemsPerPage: v, pageNumber: 1 }, resetScroll)
-          })
+          this.renderCopyButton(entities, columnSettings)
         ])
-      ]),
+      }),
       !_.isEmpty(selectedEntities) && h(FloatingActionButton, {
         label: 'COPY DATA',
         iconShape: 'copy',
@@ -604,8 +413,7 @@ const EntitiesContent = ajaxCaller(class EntitiesContent extends Component {
       deletingEntities && h(EntityDeleter, {
         onDismiss: () => this.setState({ deletingEntities: false }),
         onSuccess: () => {
-          this.setState({ deletingEntities: false, selectedEntities: {} })
-          this.loadData()
+          this.setState({ deletingEntities: false, selectedEntities: {}, refreshKey: refreshKey + 1 })
           loadMetadata()
         },
         namespace, name,
@@ -615,17 +423,10 @@ const EntitiesContent = ajaxCaller(class EntitiesContent extends Component {
         onDismiss: () => this.setState({ copyingEntities: false }),
         workspace,
         selectedEntities: _.keys(selectedEntities), selectedDataType: entityKey, runningSubmissionsCount
-      }),
-      viewData && h(Modal, {
-        title: 'Contents',
-        showButtons: false,
-        showX: true,
-        onDismiss: () => this.setState({ viewData: undefined })
-      }, [div({ style: { maxHeight: '80vh', overflowY: 'auto' } }, [this.displayData(viewData)])]),
-      loading && spinnerOverlay
+      })
     ])
   }
-})
+}
 
 const DeleteObjectModal = ajaxCaller(class DeleteObjectModal extends Component {
   constructor(props) {

--- a/src/pages/workspaces/workspace/tools/DataStepContent.js
+++ b/src/pages/workspaces/workspace/tools/DataStepContent.js
@@ -99,14 +99,6 @@ export default class DataStepContent extends Component {
               onChange: () => this.setEntitySelectionModel({ type: EntitySelectionType.chooseRows, selectedEntities: {} }),
               labelStyle: { marginLeft: '0.75rem' }
             })
-          ]),
-          type !== EntitySelectionType.processFromSet && div([
-            span(['Selected rows will be saved as a new set named:']),
-            textInput({
-              style: { width: 500, marginLeft: '0.25rem' },
-              value: newSetName,
-              onChange: e => this.setEntitySelectionModel({ newSetName: e.target.value })
-            })
           ])
         ]),
         type !== EntitySelectionType.processAll && div({
@@ -123,6 +115,17 @@ export default class DataStepContent extends Component {
               type: (isSet || type === EntitySelectionType.processFromSet) ? 'single' : 'multiple',
               selected: selectedEntities, setSelected: e => this.setEntitySelectionModel({ selectedEntities: e })
             }
+          })
+        ]),
+        (type === EntitySelectionType.processAll ||
+        (type === EntitySelectionType.chooseRows && _.size(selectedEntities) > 1)) && div({
+          style: { marginTop: '1rem' }
+        }, [
+          span(['Selected rows will be saved as a new set named:']),
+          textInput({
+            style: { width: 500, marginLeft: '0.25rem' },
+            value: newSetName,
+            onChange: e => this.setEntitySelectionModel({ newSetName: e.target.value })
           })
         ])
       ])

--- a/src/pages/workspaces/workspace/tools/DataStepContent.js
+++ b/src/pages/workspaces/workspace/tools/DataStepContent.js
@@ -1,0 +1,127 @@
+import _ from 'lodash/fp'
+import { Fragment } from 'react'
+import { div, h, span } from 'react-hyperscript-helpers'
+import { Clickable, RadioButton } from 'src/components/common'
+import DataTable from 'src/components/DataTable'
+import { icon } from 'src/components/icons'
+import { textInput } from 'src/components/input'
+import colors from 'src/libs/colors'
+import * as Style from 'src/libs/style'
+import { Component } from 'src/libs/wrapped-components'
+import EntitySelectionType from 'src/pages/workspaces/workspace/tools/EntitySelectionType'
+
+
+const typeOption = ({ name, count, isSelected, selectSelf, unselect }) => div({
+  key: name,
+  style: {
+    display: 'flex', alignItems: 'center',
+    fontSize: 16,
+    padding: '0.5rem',
+    borderBottom: `1px solid ${colors.gray[4]}`
+  }
+}, [
+  isSelected ?
+    icon('check-circle', { size: 24, className: 'is-solid', style: { color: colors.blue[0], margin: '-2px 0' } }) :
+    h(Clickable, { onClick: selectSelf }, [icon('circle', { size: 20, style: { marginRight: 4 } })]),
+  icon('bullet-list', { style: { margin: '0 0.5rem' } }),
+  span({ style: { flex: 1 } }, [name]),
+  isSelected ?
+    h(Clickable, { onClick: unselect }, [icon('times', { size: 24, style: { color: colors.blue[0], margin: '-2px' } })]) :
+    `${count} row${count !== 1 ? 's' : ''}`
+])
+
+
+export default class DataStepContent extends Component {
+  render() {
+    const {
+      visible, workspaceId, entityMetadata,
+      rootEntityType, setRootEntityType,
+      entitySelectionModel: { type, selectedEntities, newSetName },
+      setEntitySelectionModel
+    } = this.props
+
+    const count = rootEntityType && entityMetadata[rootEntityType].count
+
+    const isSet = _.endsWith('_set', rootEntityType)
+    const setType = `${rootEntityType}_set`
+    const hasSet = _.has(setType, entityMetadata)
+
+    return div({
+      style: {
+        display: visible ? 'initial' : 'none'
+      }
+    }, [
+      div({ style: { ...Style.elements.sectionHeader, marginBottom: '1rem' } }, ['Select index file to process']),
+      div({ style: { maxWidth: 600 } }, [
+        rootEntityType ?
+          typeOption({
+            name: rootEntityType, isSelected: true,
+            unselect: () => setRootEntityType(undefined)
+          }) :
+          _.map(([name, { count }]) => typeOption({
+            name, count,
+            isSelected: false,
+            selectSelf: () =>  {
+              setRootEntityType(name)
+            }
+          }), _.toPairs(entityMetadata))
+      ]),
+      rootEntityType && div({
+        style: {
+          padding: '1rem 0.5rem', lineHeight: '1.5rem'
+        }
+      }, [
+        !isSet && h(Fragment, [
+          div([
+            h(RadioButton, {
+              text: `Process all ${count} rows`,
+              checked: type === EntitySelectionType.processAll,
+              onChange: () => setEntitySelectionModel({ type: EntitySelectionType.processAll, selectedEntities: {} }),
+              labelStyle: { marginLeft: '0.75rem' }
+            })
+          ]),
+          hasSet && div([
+            h(RadioButton, {
+              text: 'Choose an existing set',
+              checked: type === EntitySelectionType.chooseExisting,
+              onChange: () => setEntitySelectionModel({ type: EntitySelectionType.chooseExisting, selectedEntities: {} }),
+              labelStyle: { marginLeft: '0.75rem' }
+            })
+          ]),
+          div([
+            h(RadioButton, {
+              text: 'Choose specific rows to process',
+              checked: type === EntitySelectionType.chooseRows,
+              onChange: () => setEntitySelectionModel({ type: EntitySelectionType.chooseRows, selectedEntities: {} }),
+              labelStyle: { marginLeft: '0.75rem' }
+            })
+          ]),
+          type !== EntitySelectionType.chooseExisting && div([
+            span(['Selected rows will be saved as a new table named:']),
+            textInput({
+              style: { width: 500, marginLeft: '0.25rem' },
+              value: newSetName,
+              onChange: e => setEntitySelectionModel({ newSetName: e.target.value })
+            })
+          ])
+        ]),
+        type !== EntitySelectionType.processAll && div({
+          style: {
+            display: 'flex', flexDirection: 'column',
+            height: 500, marginTop: '1rem'
+          }
+        }, [
+          h(DataTable, {
+            key: type,
+            entityType: type === EntitySelectionType.chooseExisting ? setType : rootEntityType,
+            entityMetadata, workspaceId,
+            selectionModel: {
+              type: (isSet || type === EntitySelectionType.chooseExisting) ? 'single' : 'multiple',
+              selected: selectedEntities, setSelected: e => setEntitySelectionModel({ selectedEntities: e })
+            }
+          })
+        ])
+      ])
+    ])
+  }
+}

--- a/src/pages/workspaces/workspace/tools/DataStepContent.js
+++ b/src/pages/workspaces/workspace/tools/DataStepContent.js
@@ -1,4 +1,5 @@
 import _ from 'lodash/fp'
+import PropTypes from 'prop-types'
 import { Fragment } from 'react'
 import { div, h, span } from 'react-hyperscript-helpers'
 import { buttonPrimary, RadioButton } from 'src/components/common'
@@ -11,6 +12,21 @@ import EntitySelectionType from 'src/pages/workspaces/workspace/tools/EntitySele
 
 
 export default class DataStepContent extends Component {
+  static propTypes = {
+    entityMetadata: PropTypes.objectOf(PropTypes.shape({
+      count: PropTypes.number.isRequired
+    })).isRequired,
+    entitySelectionModel: PropTypes.shape({
+      newSetName: PropTypes.string.isRequired,
+      selectedElements: PropTypes.array,
+      type: PropTypes.oneOf(_.values(EntitySelectionType))
+    }),
+    onDismiss: PropTypes.func,
+    onSuccess: PropTypes.func,
+    rootEntityType: PropTypes.string,
+    workspaceId: PropTypes.object
+  }
+
   constructor(props) {
     super(props)
     const { rootEntityType, entitySelectionModel } = props
@@ -28,7 +44,7 @@ export default class DataStepContent extends Component {
     const { newSetName, selectedEntities, type } = entitySelectionModel
     const { entityType, name } = selectedEntities
     return (type === EntitySelectionType.processAll ||
-      (type === EntitySelectionType.chooseExisting && !!entityType && !!name) ||
+      (type === EntitySelectionType.processFromSet && !!entityType && !!name) ||
       (_.size(selectedEntities) > 0 && !!newSetName))
   }
 
@@ -71,8 +87,8 @@ export default class DataStepContent extends Component {
           hasSet && div([
             h(RadioButton, {
               text: 'Choose an existing set',
-              checked: type === EntitySelectionType.chooseExisting,
-              onChange: () => this.setEntitySelectionModel({ type: EntitySelectionType.chooseExisting, selectedEntities: {} }),
+              checked: type === EntitySelectionType.processFromSet,
+              onChange: () => this.setEntitySelectionModel({ type: EntitySelectionType.processFromSet, selectedEntities: {} }),
               labelStyle: { marginLeft: '0.75rem' }
             })
           ]),
@@ -84,7 +100,7 @@ export default class DataStepContent extends Component {
               labelStyle: { marginLeft: '0.75rem' }
             })
           ]),
-          type !== EntitySelectionType.chooseExisting && div([
+          type !== EntitySelectionType.processFromSet && div([
             span(['Selected rows will be saved as a new set named:']),
             textInput({
               style: { width: 500, marginLeft: '0.25rem' },
@@ -101,10 +117,10 @@ export default class DataStepContent extends Component {
         }, [
           h(DataTable, {
             key: type,
-            entityType: type === EntitySelectionType.chooseExisting ? setType : rootEntityType,
+            entityType: type === EntitySelectionType.processFromSet ? setType : rootEntityType,
             entityMetadata, workspaceId,
             selectionModel: {
-              type: (isSet || type === EntitySelectionType.chooseExisting) ? 'single' : 'multiple',
+              type: (isSet || type === EntitySelectionType.processFromSet) ? 'single' : 'multiple',
               selected: selectedEntities, setSelected: e => this.setEntitySelectionModel({ selectedEntities: e })
             }
           })

--- a/src/pages/workspaces/workspace/tools/EntitySelectionType.js
+++ b/src/pages/workspaces/workspace/tools/EntitySelectionType.js
@@ -1,5 +1,6 @@
 export default Object.freeze({
   processAll: 'process all',
-  chooseExisting: 'choose existing',
-  chooseRows: 'choose rows'
+  processFromSet: 'choose existing',
+  chooseRows: 'choose rows',
+  chooseSet: 'choose set'
 })

--- a/src/pages/workspaces/workspace/tools/EntitySelectionType.js
+++ b/src/pages/workspaces/workspace/tools/EntitySelectionType.js
@@ -1,0 +1,5 @@
+export default Object.freeze({
+  processAll: 'process all',
+  chooseExisting: 'choose existing',
+  chooseRows: 'choose rows'
+})

--- a/src/pages/workspaces/workspace/tools/LaunchAnalysisModal.js
+++ b/src/pages/workspaces/workspace/tools/LaunchAnalysisModal.js
@@ -1,178 +1,102 @@
 import _ from 'lodash/fp'
-import { Fragment } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
-import { AutoSizer } from 'react-virtualized'
-import { buttonPrimary, link, search } from 'src/components/common'
-import { centeredSpinner } from 'src/components/icons'
+import { buttonPrimary } from 'src/components/common'
+import { spinner } from 'src/components/icons'
 import Modal from 'src/components/Modal'
-import TabBar from 'src/components/TabBar'
-import { GridTable, HeaderCell, TextCell } from 'src/components/table'
 import { ajaxCaller } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
-import { renderDataCell } from 'src/libs/data-utils'
-import * as Utils from 'src/libs/utils'
 import { Component } from 'src/libs/wrapped-components'
+import EntitySelectionType from 'src/pages/workspaces/workspace/tools/EntitySelectionType'
 
 
 export default ajaxCaller(class LaunchAnalysisModal extends Component {
-  constructor(props) {
-    super(props)
-
-    this.state = { filterText: '', entityType: props.config.rootEntityType }
-  }
-
   render() {
     const { onDismiss } = this.props
-    const { entityType, entityMetadata, entities, attributeFailure, entityFailure, filterText, launching, selectedEntity } = this.state
-    const { attributeNames } = entityMetadata ? entityMetadata[entityType] : {}
+    const { message, launchError } = this.state
 
-    return h(Modal, _.isUndefined(entityType) ? {
-      title: 'Launching Analysis', showCancel: false, okButton: false
-    } : {
+    return h(Modal, {
+      title: 'Launching Analysis',
       onDismiss,
-      title: 'Launch Analysis',
-      titleExtras: search({
-        wrapperProps: {
-          style: {
-            display: 'inline-flex',
-            width: 500,
-            marginLeft: '4rem'
-          }
-        },
-        inputProps: {
-          placeholder: 'FILTER',
-          value: filterText,
-          onChange: e => this.setState({ filterText: e.target.value })
-        }
-      }),
-      showX: true,
-      width: 'calc(100% - 2rem)',
-      okButton: buttonPrimary({
-        onClick: () => this.launch(),
-        disabled: launching || !selectedEntity,
-        tooltip: !selectedEntity && 'Please select an entity'
-      }, [launching ? 'Launching...' : 'Launch'])
+      showCancel: false,
+      okButton: !!launchError && buttonPrimary({ onClick: onDismiss }, ['OK'])
     }, [
-      Utils.cond(
-        [attributeNames && entities, () => this.renderMain()],
-        [attributeFailure || entityFailure, () => this.renderError()],
-        () => centeredSpinner()
-      )
+      message && div([spinner({ style: { marginRight: '0.5rem' } }), message]),
+      launchError && div({ style: { color: colors.red[0] } }, [launchError])
     ])
   }
 
-  componentDidMount() {
-    const { workspaceId: { namespace, name }, ajax: { Workspaces } } = this.props
-    const { entityType } = this.state
+  async componentDidMount() {
+    const {
+      workspaceId: { namespace, name },
+      processSingle, entitySelectionModel: { type, selectedEntities },
+      config: { rootEntityType },
+      ajax: { Workspaces }
+    } = this.props
 
-    if (_.isUndefined(entityType)) {
+    if (processSingle) {
       this.launch()
-    } else {
-      Workspaces.workspace(namespace, name).entityMetadata().then(
-        entityMetadata => this.setState({ entityMetadata }),
-        attributeFailure => this.setState({ attributeFailure })
-      )
-      this.loadEntitiesOfType(entityType)
+    } else if (type === EntitySelectionType.processAll) {
+      this.setState({ message: 'Fetching data...' })
+      const entities = _.map('name', await Workspaces.workspace(namespace, name).entitiesOfType(rootEntityType))
+      this.createSetAndLaunch(entities)
+    } else if (type === EntitySelectionType.chooseRows) {
+      const entities = _.keys(selectedEntities)
+      this.createSetAndLaunch(entities)
+    } else if (type === EntitySelectionType.chooseExisting) {
+      const { entityType, name } = selectedEntities
+      this.launch(entityType, name, `this.${rootEntityType}s`)
     }
   }
 
-  loadEntitiesOfType(type) {
-    const { workspaceId: { namespace, name }, ajax: { Workspaces } } = this.props
-
-    Workspaces.workspace(namespace, name).entitiesOfType(type).then(
-      entities => this.setState({ entities, loadingNew: false }),
-      entityFailure => this.setState({ entityFailure })
-    )
-  }
-
-  renderMain() {
-    const { config: { rootEntityType }, workspaceId: { namespace } } = this.props
-    const { entityType, loadingNew, entities, filterText, launchError, entityMetadata, selectedEntity } = this.state
-    const { attributeNames, idName } = entityMetadata ? entityMetadata[entityType] : {}
-    const filteredEntities = _.filter(_.conformsTo({ name: Utils.textMatch(filterText) }), entities)
-
-    return h(Fragment, [
-      !!entityMetadata[`${rootEntityType}_set`] && TabBar({
-        tabs: [
-          { title: _.capitalize(rootEntityType), key: rootEntityType },
-          { title: _.capitalize(rootEntityType) + ' Set', key: `${rootEntityType}_set` }
-        ],
-        activeTab: entityType,
-        onChangeTab: key => {
-          this.setState({ entityType: key, loadingNew: true })
-          this.loadEntitiesOfType(key)
-        },
-        style: { margin: '0 -1rem 1rem', padding: '0 1rem' }
-      }),
-      loadingNew ? centeredSpinner() : h(AutoSizer, { disableHeight: true }, [
-        ({ width }) => {
-          return h(GridTable, {
-            width, height: 300,
-            rowCount: filteredEntities.length,
-            columns: [
-              {
-                width: 150,
-                headerRenderer: () => h(HeaderCell, [idName]),
-                cellRenderer: ({ rowIndex }) => {
-                  const { name } = filteredEntities[rowIndex]
-                  return h(TextCell, [
-                    link({ onClick: () => this.setState({ selectedEntity: name }), title: name }, [name])
-                  ])
-                }
-              },
-              ..._.map(name => ({
-                width: 300,
-                headerRenderer: () => h(HeaderCell, [name]),
-                cellRenderer: ({ rowIndex }) => {
-                  return renderDataCell(
-                    Utils.entityAttributeText(filteredEntities[rowIndex].attributes[name]), namespace
-                  )
-                }
-              }), attributeNames)
-            ],
-            styleCell: ({ rowIndex }) => {
-              return selectedEntity === filteredEntities[rowIndex].name ?
-                { backgroundColor: colors.grayBlue[5] } : {}
-            }
-          })
-        }
-      ]),
-      div({ style: { marginTop: 10, textAlign: 'right', color: colors.red[0] } }, [launchError])
-    ])
-  }
-
-  renderError() {
-    const { attributeFailure, entityFailure } = this.state
-
-    return div({}, [
-      div({}, 'Unable to load data entities'),
-      attributeFailure && div({}, attributeFailure),
-      entityFailure && div({}, entityFailure)
-    ])
-  }
-
-  async launch() {
+  async createSetAndLaunch(entities) {
     const {
       workspaceId: { namespace, name },
-      config: { namespace: configNamespace, name: configName, rootEntityType },
+      entitySelectionModel: { newSetName },
+      config: { rootEntityType },
+      ajax: { Workspaces }
+    } = this.props
+
+    const setType = `${rootEntityType}_set`
+
+    this.setState({ message: 'Creating data set...' })
+    const newSet = {
+      name: newSetName,
+      entityType: setType,
+      attributes: {
+        [`${rootEntityType}s`]: {
+          itemsType: 'EntityReference',
+          items: _.map(entityName => ({ entityName, entityType: rootEntityType }), entities)
+        }
+      }
+    }
+
+    try {
+      await Workspaces.workspace(namespace, name).createEntity(newSet)
+    } catch (error) {
+      this.setState({ launchError: await error.text(), message: undefined })
+      return
+    }
+
+    await this.launch(setType, newSetName, `this.${rootEntityType}s`)
+  }
+
+  async launch(entityType, entityName, expression) {
+    const {
+      workspaceId: { namespace, name },
+      config: { namespace: configNamespace, name: configName },
       onSuccess,
       ajax: { Workspaces }
     } = this.props
 
-    const { selectedEntity, entityType } = this.state
-
-    this.setState({ launching: true })
-
     try {
+      this.setState({ message: 'Launching analysis...' })
+
       const { submissionId } = await Workspaces.workspace(namespace, name).methodConfig(configNamespace, configName).launch({
-        entityType,
-        expression: entityType !== rootEntityType ? `this.${rootEntityType}s` : undefined,
-        entityName: selectedEntity,
-        useCallCache: true
+        entityType, entityName, expression, useCallCache: true
       })
       onSuccess(submissionId)
     } catch (error) {
-      this.setState({ launchError: JSON.parse(error).message, launching: false })
+      this.setState({ launchError: JSON.parse(await error.text()).message, message: undefined })
     }
   }
 })

--- a/src/pages/workspaces/workspace/tools/LaunchAnalysisModal.js
+++ b/src/pages/workspaces/workspace/tools/LaunchAnalysisModal.js
@@ -12,20 +12,28 @@ import EntitySelectionType from 'src/pages/workspaces/workspace/tools/EntitySele
 export default ajaxCaller(class LaunchAnalysisModal extends Component {
   render() {
     const { onDismiss } = this.props
-    const { message, launchError } = this.state
+    const { launching, message, launchError } = this.state
 
     return h(Modal, {
-      title: 'Launching Analysis',
+      title: !launching ? 'Run Analysis' : 'Launching Analysis',
       onDismiss,
-      showCancel: false,
-      okButton: !!launchError && buttonPrimary({ onClick: onDismiss }, ['OK'])
+      showCancel: !launching,
+      okButton: !launchError ?
+        buttonPrimary({
+          onClick: () => {
+            this.setState({ launching: true })
+            this.doLaunch()
+          }
+        }, ['Launch']) :
+        buttonPrimary({ onClick: onDismiss }, ['OK'])
     }, [
+      !launching && div('Confirm launch'),
       message && div([spinner({ style: { marginRight: '0.5rem' } }), message]),
       launchError && div({ style: { color: colors.red[0] } }, [launchError])
     ])
   }
 
-  async componentDidMount() {
+  async doLaunch() {
     const {
       workspaceId: { namespace, name },
       processSingle, entitySelectionModel: { type, selectedEntities },

--- a/src/pages/workspaces/workspace/tools/LaunchAnalysisModal.js
+++ b/src/pages/workspaces/workspace/tools/LaunchAnalysisModal.js
@@ -54,9 +54,11 @@ export default ajaxCaller(class LaunchAnalysisModal extends Component {
       } else {
         this.createSetAndLaunch(entities)
       }
-    } else if (type === EntitySelectionType.chooseExisting) {
+    } else if (type === EntitySelectionType.processFromSet) {
       const { entityType, name } = selectedEntities
       this.launch(entityType, name, `this.${rootEntityType}s`)
+    } else if (type === EntitySelectionType.chooseSet) {
+      this.launch(rootEntityType, selectedEntities['name'])
     }
   }
 

--- a/src/pages/workspaces/workspace/tools/LaunchAnalysisModal.js
+++ b/src/pages/workspaces/workspace/tools/LaunchAnalysisModal.js
@@ -41,7 +41,11 @@ export default ajaxCaller(class LaunchAnalysisModal extends Component {
       this.createSetAndLaunch(entities)
     } else if (type === EntitySelectionType.chooseRows) {
       const entities = _.keys(selectedEntities)
-      this.createSetAndLaunch(entities)
+      if (_.size(entities) === 1) {
+        this.launch(rootEntityType, _.head(entities))
+      } else {
+        this.createSetAndLaunch(entities)
+      }
     } else if (type === EntitySelectionType.chooseExisting) {
       const { entityType, name } = selectedEntities
       this.launch(entityType, name, `this.${rootEntityType}s`)

--- a/src/pages/workspaces/workspace/tools/WorkflowView.js
+++ b/src/pages/workspaces/workspace/tools/WorkflowView.js
@@ -467,10 +467,10 @@ const WorkflowView = _.flow(
     const newSetMessage = count > 1 ? `(will create a new set named "${newSetName}")` : ''
     return Utils.cond(
       [this.isSingle() || !rootEntityType, ''],
-      [type === EntitySelectionType.processAll, `all ${entityMetadata[rootEntityType].count} ${rootEntityType}s (will create a new set named "${newSetName}")`],
-      [type === EntitySelectionType.processFromSet, `${rootEntityType}s from ${name}`],
-      [type === EntitySelectionType.chooseRows, `${count} selected ${rootEntityType}s ${newSetMessage}`],
-      [type === EntitySelectionType.chooseSet, `${_.has('name', selectedEntities) ? 1 : 0} selected ${rootEntityType}`]
+      [type === EntitySelectionType.processAll, () => `all ${entityMetadata[rootEntityType].count} ${rootEntityType}s (will create a new set named "${newSetName}")`],
+      [type === EntitySelectionType.processFromSet, () => `${rootEntityType}s from ${name}`],
+      [type === EntitySelectionType.chooseRows, () => `${count} selected ${rootEntityType}s ${newSetMessage}`],
+      [type === EntitySelectionType.chooseSet, () => `${_.has('name', selectedEntities) ? 1 : 0} selected ${rootEntityType}`]
     )
   }
 

--- a/src/pages/workspaces/workspace/tools/WorkflowView.js
+++ b/src/pages/workspaces/workspace/tools/WorkflowView.js
@@ -461,13 +461,13 @@ const WorkflowView = _.flow(
   }
 
   describeSelectionModel() {
-    const { modifiedConfig: { rootEntityType }, entitySelectionModel: { newSetName, selectedEntities, type } } = this.state
+    const { modifiedConfig: { rootEntityType }, entityMetadata, entitySelectionModel: { newSetName, selectedEntities, type } } = this.state
     const { name } = selectedEntities // entityType?
     const count = _.size(selectedEntities)
     const newSetMessage = count > 1 ? `(will create a new set named "${newSetName}")` : ''
     return Utils.cond(
       [this.isSingle() || !rootEntityType, ''],
-      [type === EntitySelectionType.processAll, `all ${rootEntityType}s (will create a new set named "${newSetName}")`],
+      [type === EntitySelectionType.processAll, `all ${entityMetadata[rootEntityType].count} ${rootEntityType}s (will create a new set named "${newSetName}")`],
       [type === EntitySelectionType.processFromSet, `${rootEntityType}s from ${name}`],
       [type === EntitySelectionType.chooseRows, `${count} selected ${rootEntityType}s ${newSetMessage}`],
       [type === EntitySelectionType.chooseSet, `${_.has('name', selectedEntities) ? 1 : 0} selected ${rootEntityType}`]

--- a/src/pages/workspaces/workspace/tools/WorkflowView.js
+++ b/src/pages/workspaces/workspace/tools/WorkflowView.js
@@ -463,11 +463,13 @@ const WorkflowView = _.flow(
   describeSelectionModel() {
     const { modifiedConfig: { rootEntityType }, entitySelectionModel: { newSetName, selectedEntities, type } } = this.state
     const { name } = selectedEntities // entityType?
+    const count = _.size(selectedEntities)
+    const newSetMessage = count > 1 ? `(will create a new set named "${newSetName}")` : ''
     return Utils.cond(
       [this.isSingle() || !rootEntityType, ''],
-      [type === EntitySelectionType.processAll, `all ${rootEntityType}s`],
+      [type === EntitySelectionType.processAll, `all ${rootEntityType}s (will create a new set named "${newSetName}")`],
       [type === EntitySelectionType.processFromSet, `${rootEntityType}s from ${name}`],
-      [type === EntitySelectionType.chooseRows, `${_.size(selectedEntities)} selected ${rootEntityType}s (will create a new set named "${newSetName}")`],
+      [type === EntitySelectionType.chooseRows, `${count} selected ${rootEntityType}s ${newSetMessage}`],
       [type === EntitySelectionType.chooseSet, `${_.has('name', selectedEntities) ? 1 : 0} selected ${rootEntityType}`]
     )
   }
@@ -763,9 +765,9 @@ const WorkflowView = _.flow(
   }
 
   cancel() {
-    const { savedConfig } = this.state
+    const { savedConfig, savedConfig: { rootEntityType } } = this.state
 
-    this.setState({ saved: false, modifiedConfig: savedConfig })
+    this.setState({ saved: false, modifiedConfig: savedConfig, entitySelectionModel: this.resetSelectionModel(rootEntityType) })
     this.updateSingleOrMultipleRadioState(savedConfig)
   }
 })

--- a/src/pages/workspaces/workspace/tools/WorkflowView.js
+++ b/src/pages/workspaces/workspace/tools/WorkflowView.js
@@ -462,7 +462,7 @@ const WorkflowView = _.flow(
 
   describeSelectionModel() {
     const { modifiedConfig: { rootEntityType }, entityMetadata, entitySelectionModel: { newSetName, selectedEntities, type } } = this.state
-    const { name } = selectedEntities // entityType?
+    const { name } = selectedEntities
     const count = _.size(selectedEntities)
     const newSetMessage = count > 1 ? `(will create a new set named "${newSetName}")` : ''
     return Utils.cond(


### PR DESCRIPTION
Fixes #920 and #870. Supersedes PR #1019.

There are likely still some corner cases (can't fix invalid outputs if you're not using workspace data) and could use some improvements (being clear about how many jobs will be launched) but I believe this to be functional. There's also some code funkiness because of the need to manage what appears to be duplicated state but is really UI state. A better implementation would have a couple of functions to translate between server-side state and UI state, as well as consolidating state updates to avoid the desire to use previously set state for further state updates. If/when you notice the warts, please ask questions and offer alternatives if you have them. Thanks.