### PR TITLE
Disable jupyterlab for readers

### DIFF
--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -55,6 +55,9 @@ class NotebookCard extends Component {
           }
         }, [menuIcon('copy-to-clipboard'), 'Copy notebook URL to clipboard']),
         h(MenuButton, {
+          disabled: !canWrite,
+          tooltip: !canWrite && noWrite,
+          tooltipSide: 'left',
           onClick: () => Nav.goToPath('workspace-notebook-launch', { namespace, app: 'lab', name: wsName, notebookName: name.slice(10) })
         }, [menuIcon('jupyterIcon'), 'Open in JupyterLab']),
         h(MenuButton, {


### PR DESCRIPTION
Fixes a bug where readers could try and open a notebook in jupyterlab 