### PR TITLE
Flip the job detail switch from FireCloud to JobManager

### DIFF
--- a/src/pages/workspaces/workspace/JobHistory.js
+++ b/src/pages/workspaces/workspace/JobHistory.js
@@ -19,7 +19,7 @@ import { rerunFailures } from 'src/pages/workspaces/workspace/tools/FailureRerun
 import { wrapWorkspace } from 'src/pages/workspaces/workspace/WorkspaceContainer'
 
 
-export const linkToJobManager = false
+export const linkToJobManager = true
 
 const styles = {
   submissionsTable: {


### PR DESCRIPTION
This will "flip the switch" once we're ready to go live with job manager.

This PR should not be merged until we've assessed that JMUI works well in prod. After the merge, we can either do an on-demand release or wait for the regularly scheduled 10am release.