### PR TITLE
Preview notebook while cluster isn't running

### DIFF
--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -358,7 +358,7 @@ class NotebookEditor extends Component {
           'Loading notebook')
       ]),
       (clusterStatus !== 'Running') && h(Fragment, [
-        div({ style: { color: colors.gray[2], fontSize: 14, fontWeight: 'bold', padding: '0 0 0 2rem' } }, ['Preview of your notebook:']),
+        div({ style: { color: colors.gray[2], fontSize: 14, fontWeight: 'bold', padding: '0 0 0 2rem' } }, ['Read-only preview of your notebook:']),
         h(NotebookPreviewFrame, { ...this.props })
       ])
     ])

--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -357,7 +357,10 @@ class NotebookEditor extends Component {
           `Error loading notebook, retry number ${localizeFailures}...` :
           'Loading notebook')
       ]),
-      (clusterStatus !== 'Running') && h(NotebookPreviewFrame, { ...this.props })
+      (clusterStatus !== 'Running') && h(Fragment, [
+        div({ style: { color: colors.gray[2], fontSize: 14, fontWeight: 'bold', padding: '0 0 0 2rem' } }, ['Preview of your notebook:']),
+        h(NotebookPreviewFrame, { ...this.props })
+      ])
     ])
   }
 }

--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -61,7 +61,7 @@ const NotebookLauncher = _.flow(
 )(({ workspace, app, ...props }) => {
   return Utils.canWrite(workspace.accessLevel) && workspace.canCompute ?
     h(NotebookEditor, { workspace, app, ...props }) :
-    h(NotebookViewer, { workspace, ...props })
+    h(NotebookPreview, { workspace, ...props })
 })
 
 class ReadOnlyMessage extends Component {
@@ -91,7 +91,20 @@ class ReadOnlyMessage extends Component {
   }
 }
 
-class NotebookViewer extends Component {
+class NotebookPreview extends Component {
+  render() {
+    const { namespace, name } = this.props
+    return h(Fragment, [
+      linkButton({
+        style: { position: 'absolute', top: 20, left: 'calc(50% + 570px)' },
+        onClick: () => Nav.goToPath('workspace-notebooks', { namespace, name })
+      }, [icon('times-circle', { size: 30 })]),
+      h(NotebookPreviewFrame, { ...this.props })
+    ])
+  }
+}
+
+class NotebookPreviewFrame extends Component {
   constructor(props) {
     super(props)
     this.state = {
@@ -114,17 +127,12 @@ class NotebookViewer extends Component {
   }
 
   render() {
-    const { namespace, name } = this.props
     const { preview, busy } = this.state
     return h(Fragment, [
       preview && iframe({
         style: { border: 'none', flex: 1 },
         srcDoc: preview
       }),
-      preview && linkButton({
-        style: { position: 'absolute', top: 20, left: 'calc(50% + 570px)' },
-        onClick: () => Nav.goToPath('workspace-notebooks', { namespace, name })
-      }, [icon('times-circle', { size: 30 })]),
       busy && spinnerOverlay
     ])
   }
@@ -348,7 +356,8 @@ class NotebookEditor extends Component {
         step(2, localizeFailures ?
           `Error loading notebook, retry number ${localizeFailures}...` :
           'Loading notebook')
-      ])
+      ]),
+      (clusterStatus !== 'Running') && h(NotebookPreviewFrame, { ...this.props })
     ])
   }
 }


### PR DESCRIPTION
This is the first of multiple PRs toward the AC in #1085, unconnected because there is more work remaining.

Acceptance Criteria:

1. When a writer has a cluster that is creating, starting, stopping, or stopped, display a preview of the notebook. 
2. Once the cluster is running, display the editable notebook.

Question: how should we refer to notebook previews? (@bradtaylor & @jeromechadel please weigh in)
- Read-only notebook
- Read-only mode
- Read-only version
- View-only notebook
- View-only mode
- View-only version
- Preview your notebook

Do you have any other suggestions?

Looks like this: 
<img width="1429" alt="screen shot 2019-02-28 at 3 11 55 pm" src="https://user-images.githubusercontent.com/2395211/53595433-3ea43880-3b6b-11e9-8b04-a461e64abce8.png">