### PR TITLE
Change ajax call, update beta messaging 

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -68,7 +68,7 @@ const instrumentedFetch = (url, options) => {
 }
 
 
-const fetchOk = async (url, options) => {
+export const fetchOk = async (url, options) => {
   const res = await instrumentedFetch(url, options)
   return res.ok ? res : Promise.reject(res)
 }

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -109,9 +109,7 @@ authStore.subscribe(async (state, oldState) => {
             const tideWhitelist = await fetchOk(
               `https://www.googleapis.com/storage/v1/b/terra-tide-prod-data/o/${encodeURIComponent('whitelistEmails')}?alt=media`)
               .then(res => res.json())
-            if (!tideWhitelist.includes(md5(state.user.email))){
-              return 'unlisted'
-            }
+            if (!tideWhitelist.includes(md5(state.user.email))) return 'unlisted'
           } catch (error) {
             reportError('Error checking whitelist status', error)
           }

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -2,7 +2,7 @@ import _ from 'lodash/fp'
 import * as md5 from 'md5'
 import { clearNotification, sessionTimeoutProps } from 'src/components/Notifications'
 import ProdWhitelist from 'src/data/prod-whitelist'
-import { Ajax } from 'src/libs/ajax'
+import { Ajax, fetchOk } from 'src/libs/ajax'
 import { getConfig } from 'src/libs/config'
 import { reportError } from 'src/libs/error'
 import * as Utils from 'src/libs/utils'
@@ -105,12 +105,16 @@ authStore.subscribe(async (state, oldState) => {
           ['@broadinstitute.org', '@google.com', '@channing.harvard.edu', '@duke.corp-partner.google.com', '@stanford.corp-partner.google.com'])
 
         if (getConfig().isProd && !isTrustedEmail && !ProdWhitelist.includes(md5(state.user.email))) {
-          const tideWhitelist = await Ajax()
-            .Buckets
-            .getObjectPreview('terra-tide-prod-data', 'whitelistEmails', undefined, true)
-            .then(res => res.json())
-
-          if (!tideWhitelist.includes(md5(state.user.email))) return 'unlisted'
+          try {
+            const tideWhitelist = await fetchOk(
+              `https://www.googleapis.com/storage/v1/b/terra-tide-prod-data/o/${encodeURIComponent('whitelistEmails')}?alt=media`)
+              .then(res => res.json())
+            if (!tideWhitelist.includes(md5(state.user.email))){
+              return 'unlisted'
+            }
+          } catch (error) {
+            reportError('Error checking whitelist status', error)
+          }
         } else {
           return 'unregistered'
         }

--- a/src/pages/Disabled.js
+++ b/src/pages/Disabled.js
@@ -18,8 +18,8 @@ export const Disabled = () => {
 export const Unlisted = () => {
   return div({ style: { padding: '1rem' } }, [
     div([
-      'Terra is under development. If you are interested in contributing feedback as part of our user panel, please email ',
-      link({ href: 'mailto:saturn-dev@broadinstitute.org' }, 'saturn-dev@broadinstitute.org'),
+      'Terra is currently in a closed-access beta phase. If you are interested in contributing early-access feedback as part of our user panel, please email us at ',
+      link({ href: 'mailto:info@terra.bio' }, 'info@terra.bio'),
       '.'
     ]),
     div({ style: { marginTop: '1rem' } }, [


### PR DESCRIPTION
Resolves #1254 

also made the bucket with hashed emails public. The bucket only contains one file of hashed emails. 