### PR TITLE
if on tide whitelist, register

### DIFF
--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -109,7 +109,11 @@ authStore.subscribe(async (state, oldState) => {
             const tideWhitelist = await fetchOk(
               `https://www.googleapis.com/storage/v1/b/terra-tide-prod-data/o/${encodeURIComponent('whitelistEmails')}?alt=media`)
               .then(res => res.json())
-            if (!tideWhitelist.includes(md5(state.user.email))) return 'unlisted'
+            if (!tideWhitelist.includes(md5(state.user.email))) {
+              return 'unlisted'
+            } else {
+              return 'unregistered'
+            }
           } catch (error) {
             reportError('Error checking whitelist status', error)
           }


### PR DESCRIPTION
Problem: if a user wasn't on any whitelist except the new one via the google form, they'd reach the old if statement, have it go false, and hang there. 

Discovered: when trying to add one of my accounts via the form to access prod. 


This feels like a crude solution, suggestions appreciated. It'd be nice to keep it so that we only fetch the whitelist from the bucket if all the other checks fail. 