### PR TITLE
Import featured tools from inside workspace

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -676,15 +676,28 @@ const Methods = signal => ({
         return res.json()
       },
 
-      toWorkspace: async (workspace, target) => {
+      configs: async () => {
+        const res = await fetchAgora(`${root}/configurations`, _.merge(authOpts(), { signal }))
+        return res.json()
+      },
+
+      toWorkspace: async (workspace, config = {}) => {
         const res = await fetchRawls(`workspaces/${workspace.namespace}/${workspace.name}/methodconfigs`,
-          _.mergeAll([authOpts(), jsonBody({
+          _.mergeAll([authOpts(), jsonBody(_.merge({
             methodRepoMethod: {
-              methodUri: `agora://${namespace}/${name}/${snapshotId}`,
+              methodUri: `agora://${namespace}/${name}/${snapshotId}`
             },
-            name: target.name,
-            namespace: target.namespace,
-          }), { signal, method: 'POST' }]))
+            name,
+            namespace,
+            rootEntityType: '',
+            prerequisites: {},
+            inputs: {},
+            outputs: {},
+            methodConfigVersion: 1,
+            deleted: false
+          },
+          config.payloadObject
+          )), { signal, method: 'POST' }]))
         return res.json()
       }
     }

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -674,6 +674,18 @@ const Methods = signal => ({
       get: async () => {
         const res = await fetchAgora(root, _.merge(authOpts(), { signal }))
         return res.json()
+      },
+
+      toWorkspace: async (workspace, target) => {
+        const res = await fetchRawls(`workspaces/${workspace.namespace}/${workspace.name}/methodconfigs`,
+          _.mergeAll([authOpts(), jsonBody({
+            methodRepoMethod: {
+              methodUri: `agora://${namespace}/${name}/${snapshotId}`,
+            },
+            name: target.name,
+            namespace: target.namespace,
+          }), { signal, method: 'POST' }]))
+        return res.json()
       }
     }
   }

--- a/src/pages/library/Code.js
+++ b/src/pages/library/Code.js
@@ -22,7 +22,7 @@ const styles = {
   }
 }
 
-export const makeToolCard = (method, onClick) => {
+export const makeToolCard = ({ method, onClick }) => {
   const { namespace, name, synopsis } = method
 
   return h(Clickable, {
@@ -119,7 +119,7 @@ const Code = ajaxCaller(class Code extends Component {
           div({ style: { flex: 1, margin: '30px 0 30px 40px' } }, [
             div({ style: styles.header }, 'GATK4 Best Practices workflows'),
             div({ style: { display: 'flex', flexWrap: 'wrap' } }, [
-              ..._.map(method => makeToolCard(method), featuredMethods)
+              ..._.map(method => makeToolCard({ method }), featuredMethods)
             ])
           ]),
           div({ style: { width: 385, padding: '25px 30px', backgroundColor: colors.grayBlue[4], lineHeight: '20px' } }, [

--- a/src/pages/library/Code.js
+++ b/src/pages/library/Code.js
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp'
 import { Fragment } from 'react'
-import { a, div, h } from 'react-hyperscript-helpers'
-import { link } from 'src/components/common'
+import { div, h } from 'react-hyperscript-helpers'
+import { Clickable, link } from 'src/components/common'
 import { centeredSpinner } from 'src/components/icons'
 import { libraryTopMatter } from 'src/components/library-common'
 import dockstoreLogo from 'src/images/library/code/dockstore.svg'
@@ -22,18 +22,19 @@ const styles = {
   }
 }
 
-const makeCard = method => {
+export const makeToolCard = (method, onClick) => {
   const { namespace, name, synopsis } = method
 
-  return a({
-    href: `${getConfig().firecloudUrlRoot}/?return=terra#methods/${namespace}/${name}/`,
+  return h(Clickable, {
+    as: 'a',
+    href: _.isUndefined(onClick) ? `${getConfig().firecloudUrlRoot}/?return=terra#methods/${namespace}/${name}/` : undefined,
+    onClick,
     style: {
+      ...Style.elements.card.container,
       backgroundColor: 'white',
       width: 390, height: 140,
-      borderRadius: 5,
-      display: 'flex',
+      padding: undefined,
       margin: '0 30px 27px 0',
-      boxShadow: Style.standardShadow,
       position: 'relative'
     }
   }, [
@@ -62,6 +63,22 @@ const logoTile = logoFile => div({
     marginRight: 13
   }
 })
+
+export const dockstoreTile = div({ style: { display: 'flex' } }, [
+  logoTile(dockstoreLogo),
+  div([
+    link({ href: `${getConfig().dockstoreUrlRoot}/search?descriptorType=wdl&searchMode=files` }, 'Dockstore'),
+    div(['Browse WDL workflows in Dockstore, an open platform used by the GA4GH for sharing Docker-based tools'])
+  ])
+])
+
+export const fcMethodRepoTile = div({ style: { display: 'flex' } }, [
+  logoTile(firecloudLogo),
+  div([
+    link({ href: `${getConfig().firecloudUrlRoot}/?return=terra#methods` }, 'Firecloud Methods Repository'),
+    div(['Use FireCloud workflows in Terra. Share your own, or choose from > 700 public workflows'])
+  ])
+])
 
 
 const Code = ajaxCaller(class Code extends Component {
@@ -102,24 +119,14 @@ const Code = ajaxCaller(class Code extends Component {
           div({ style: { flex: 1, margin: '30px 0 30px 40px' } }, [
             div({ style: styles.header }, 'GATK4 Best Practices workflows'),
             div({ style: { display: 'flex', flexWrap: 'wrap' } }, [
-              ..._.map(makeCard, featuredMethods)
+              ..._.map(method => makeToolCard(method), featuredMethods)
             ])
           ]),
           div({ style: { width: 385, padding: '25px 30px', backgroundColor: colors.grayBlue[4], lineHeight: '20px' } }, [
             div({ style: { ...styles.header, fontSize: 16 } }, 'FIND ADDITIONAL WORKFLOWS'),
-            div({ style: { display: 'flex' } }, [
-              logoTile(dockstoreLogo),
-              div([
-                link({ href: `${getConfig().dockstoreUrlRoot}/search?descriptorType=wdl&searchMode=files` }, 'Dockstore'),
-                div(['Browse WDL workflows in Dockstore, an open platform used by the GA4GH for sharing Docker-based tools'])
-              ])
-            ]),
-            div({ style: { display: 'flex', marginTop: 40 } }, [
-              logoTile(firecloudLogo),
-              div([
-                link({ href: `${getConfig().firecloudUrlRoot}/?return=terra#methods` }, 'Firecloud Methods Repository'),
-                div(['Use FireCloud workflows in Terra. Share your own, or choose from > 700 public workflows'])
-              ])
+            dockstoreTile,
+            div({ style: { marginTop: 40 } }, [
+              fcMethodRepoTile
             ])
           ])
         ])

--- a/src/pages/library/Code.js
+++ b/src/pages/library/Code.js
@@ -64,7 +64,7 @@ const logoTile = logoFile => div({
   }
 })
 
-export const dockstoreTile = div({ style: { display: 'flex' } }, [
+export const dockstoreTile = () => div({ style: { display: 'flex' } }, [
   logoTile(dockstoreLogo),
   div([
     link({ href: `${getConfig().dockstoreUrlRoot}/search?descriptorType=wdl&searchMode=files` }, 'Dockstore'),
@@ -72,7 +72,7 @@ export const dockstoreTile = div({ style: { display: 'flex' } }, [
   ])
 ])
 
-export const fcMethodRepoTile = div({ style: { display: 'flex' } }, [
+export const fcMethodRepoTile = () => div({ style: { display: 'flex' } }, [
   logoTile(firecloudLogo),
   div([
     link({ href: `${getConfig().firecloudUrlRoot}/?return=terra#methods` }, 'Firecloud Methods Repository'),
@@ -124,9 +124,9 @@ const Code = ajaxCaller(class Code extends Component {
           ]),
           div({ style: { width: 385, padding: '25px 30px', backgroundColor: colors.grayBlue[4], lineHeight: '20px' } }, [
             div({ style: { ...styles.header, fontSize: 16 } }, 'FIND ADDITIONAL WORKFLOWS'),
-            dockstoreTile,
+            dockstoreTile(),
             div({ style: { marginTop: 40 } }, [
-              fcMethodRepoTile
+              fcMethodRepoTile()
             ])
           ])
         ])

--- a/src/pages/workspaces/workspace/Tools.js
+++ b/src/pages/workspaces/workspace/Tools.js
@@ -183,8 +183,8 @@ const FindToolModal = ajaxCaller(class FindToolModal extends Component {
       ]),
       div({ style: { fontSize: 18, fontWeight: 600, marginTop: '1rem' } }, ['Find Additional Tools']),
       div({ style: { display: 'flex', padding: '0.5rem' } }, [
-        div({ style: { flex: 1, marginRight: 10 } }, [dockstoreTile]),
-        div({ style: { flex: 1, marginLeft: 10 } }, [fcMethodRepoTile])
+        div({ style: { flex: 1, marginRight: 10 } }, [dockstoreTile()]),
+        div({ style: { flex: 1, marginLeft: 10 } }, [fcMethodRepoTile()])
       ])
     ]
 

--- a/src/pages/workspaces/workspace/Tools.js
+++ b/src/pages/workspaces/workspace/Tools.js
@@ -179,7 +179,9 @@ const FindToolModal = ajaxCaller(class FindToolModal extends Component {
 
     const renderList = () => [
       div({ style: { display: 'flex', flexWrap: 'wrap', overflowY: 'auto', height: 400, paddingTop: 5, paddingLeft: 5 } }, [
-        ...(featuredMethods ? _.map(method => makeToolCard(method, () => this.loadMethod(method)), featuredMethods) : [centeredSpinner()])
+        ...(featuredMethods ?
+          _.map(method => makeToolCard({ method, onClick: () => this.loadMethod(method) }), featuredMethods) :
+          [centeredSpinner()])
       ]),
       div({ style: { fontSize: 18, fontWeight: 600, marginTop: '1rem' } }, ['Find Additional Tools']),
       div({ style: { display: 'flex', padding: '0.5rem' } }, [
@@ -309,7 +311,6 @@ export const Tools = _.flow(
           namespace, name,
           onDismiss: () => this.setState({ findingTool: false })
         }),
-        configs && !configs.length && div(['No tools added']),
         loading && spinnerOverlay
       ])
     ])


### PR DESCRIPTION
Resolves #1282 

When viewing the tools tab in a workspace, a user now has a button to browse and import a featured method, or go directly to the FC or Dockstore repo.