### PR TITLE
Update Notebook Cards

### DIFF
--- a/src/libs/style.js
+++ b/src/libs/style.js
@@ -12,9 +12,10 @@ export const elements = {
     container: {
       display: 'flex', flexDirection: 'column', justifyContent: 'space-between',
       borderRadius: 5,
+      padding: '1rem',
       wordWrap: 'break-word',
       backgroundColor: 'white',
-      boxShadow: '0 2px 10px 0 rgba(0,0,0,0.45), 0 2px 10px 0 rgba(0,0,0,0.25)'
+      boxShadow: 'rgba(0, 0, 0, 0.35) 0px 2px 5px 0px, rgba(0, 0, 0, 0.12) 0px 3px 2px 0px, rgba(0, 0, 0, 0.12) 0px 0px 2px 0px'
     }
   },
   sectionHeader: { color: colors.gray[0], fontSize: 16, fontWeight: 'bold' },

--- a/src/libs/style.js
+++ b/src/libs/style.js
@@ -11,9 +11,10 @@ export const elements = {
     title: { color: colors.green[0], fontSize: 16, overflow: 'hidden' },
     container: {
       display: 'flex', flexDirection: 'column', justifyContent: 'space-between',
-      borderRadius: 5, padding: '1rem', wordWrap: 'break-word',
+      borderRadius: 5,
+      wordWrap: 'break-word',
       backgroundColor: 'white',
-      boxShadow: '0 2px 5px 0 rgba(0,0,0,0.35), 0 3px 2px 0 rgba(0,0,0,0.12), 0 0 2px 0 rgba(0,0,0,0.12)'
+      boxShadow: '0 2px 10px 0 rgba(0,0,0,0.45), 0 2px 10px 0 rgba(0,0,0,0.25)'
     }
   },
   sectionHeader: { color: colors.gray[0], fontSize: 16, fontWeight: 'bold' },

--- a/src/libs/style.js
+++ b/src/libs/style.js
@@ -11,11 +11,9 @@ export const elements = {
     title: { color: colors.green[0], fontSize: 16, overflow: 'hidden' },
     container: {
       display: 'flex', flexDirection: 'column', justifyContent: 'space-between',
-      borderRadius: 5,
-      padding: '1rem',
-      wordWrap: 'break-word',
+      borderRadius: 5, padding: '1rem', wordWrap: 'break-word',
       backgroundColor: 'white',
-      boxShadow: 'rgba(0, 0, 0, 0.35) 0px 2px 5px 0px, rgba(0, 0, 0, 0.12) 0px 3px 2px 0px, rgba(0, 0, 0, 0.12) 0px 0px 2px 0px'
+      boxShadow: '0 2px 5px 0 rgba(0,0,0,0.35), 0 3px 2px 0 rgba(0,0,0,0.12), 0 0 2px 0 rgba(0,0,0,0.12)'
     }
   },
   sectionHeader: { color: colors.gray[0], fontSize: 16, fontWeight: 'bold' },

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -26,8 +26,19 @@ import { wrapWorkspace } from 'src/pages/workspaces/workspace/WorkspaceContainer
 
 const notebookCardCommonStyles = listView => _.merge({ display: 'flex' },
   listView ?
-    { marginBottom: '0.5rem', flexDirection: 'row' } :
-    { margin: '0 2.5rem 2.5rem 0', height: 100, width: 400, flexDirection: 'column' }
+    {
+      marginBottom: '0.5rem',
+      flexDirection: 'row',
+      alignItems: 'center'
+    } :
+    {
+      margin: '0 2.5rem 2.5rem 0',
+      height: 100,
+      width: 400,
+      flexDirection: 'column',
+      boxShadow: '0 2px 10px 0 rgba(0,0,0,0.45), 0 2px 10px 0 rgba(0,0,0,0.25)',
+      padding: 0
+    }
 )
 
 const printName = name => name.slice(10, -6) // removes 'notebooks/' and the .ipynb suffix
@@ -124,17 +135,11 @@ class NotebookCard extends Component {
 
     return a({
       href: notebookLink,
-      style: _.merge({
+      style: {
         ...Style.elements.card.container,
         ...notebookCardCommonStyles(listView),
         flexShrink: 0
-      }, listView ? {
-        alignItems: 'center'
-      } : {
-        boxShadow: '0 2px 10px 0 rgba(0,0,0,0.45), 0 2px 10px 0 rgba(0,0,0,0.25)',
-        padding: 0,
-        alignItems: undefined
-      })
+      }
     }, listView ? [
       notebookMenu,
       title,

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -36,7 +36,6 @@ const notebookCardCommonStyles = listView => _.merge({ display: 'flex' },
       height: 100,
       width: 400,
       flexDirection: 'column',
-      boxShadow: '0 2px 10px 0 rgba(0,0,0,0.45), 0 2px 10px 0 rgba(0,0,0,0.25)',
       padding: 0
     }
 )

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -124,15 +124,17 @@ class NotebookCard extends Component {
 
     return a({
       href: notebookLink,
-      style: {
+      style: _.merge({
         ...Style.elements.card.container,
         ...notebookCardCommonStyles(listView),
-        flexShrink: 0,
-        alignItems: listView ? 'center' : undefined,
-        padding: listView ? '1rem' : undefined,
-        boxShadow: listView ? 'rgba(0, 0, 0, 0.35) 0px 2px 5px 0px, rgba(0, 0, 0, 0.12) 0px 3px 2px 0px, rgba(0, 0, 0, 0.12) 0px 0px 2px 0px': '0 2px 10px 0 rgba(0,0,0,0.45), 0 2px 10px 0 rgba(0,0,0,0.25)'
-
-      }
+        flexShrink: 0
+      }, listView ? {
+        alignItems: 'center'
+      } : {
+        boxShadow: '0 2px 10px 0 rgba(0,0,0,0.45), 0 2px 10px 0 rgba(0,0,0,0.25)',
+        padding: 0,
+        alignItems: undefined
+      })
     }, listView ? [
       notebookMenu,
       title,

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -27,7 +27,7 @@ import { wrapWorkspace } from 'src/pages/workspaces/workspace/WorkspaceContainer
 const notebookCardCommonStyles = listView => _.merge({ display: 'flex' },
   listView ?
     { marginBottom: '0.5rem', flexDirection: 'row' } :
-    { margin: '0 2.5rem 2.5rem 0', height: 250, width: 200, flexDirection: 'column' }
+    { margin: '0 2.5rem 2.5rem 0', height: 100, width: 400, flexDirection: 'column' }
 )
 
 const printName = name => name.slice(10, -6) // removes 'notebooks/' and the .ipynb suffix
@@ -113,22 +113,13 @@ class NotebookCard extends Component {
       ])
     ])
 
-    const jupyterIcon = icon('jupyterIcon', {
-      style: {
-        height: 125,
-        width: 'auto',
-        color: colors.gray[5]
-      }
-    })
-
     const title = div({
       title: printName(name),
       style: _.merge({
-        ...Style.elements.card.title,
-        textOverflow: 'ellipsis', whiteSpace: 'nowrap'
+        ...Style.elements.card.title, whiteSpace: 'normal'
       }, listView ? {
         marginLeft: '1rem'
-      } : undefined)
+      } : { height: 60, padding: '1rem' })
     }, printName(name))
 
     return a({
@@ -150,15 +141,14 @@ class NotebookCard extends Component {
       ])
     ] : [
       title,
-      jupyterIcon,
-      isRecent ? div({ style: { display: 'flex', color: colors.orange[0] } }, 'Recently Edited') : undefined,
-      div({ style: { display: 'flex', justifyContent: 'space-between' } }, [
+      div({ style: { display: 'flex', justifyContent: 'space-between', borderTop: `solid 1px ${colors.gray[4]}`, padding: '0.5rem', backgroundColor: colors.grayBlue[5], borderRadius: '0 0 5px 5px' } }, [
         h(TooltipTrigger, { content: Utils.makeCompleteDate(updated) }, [
           div({ style: { fontSize: '0.8rem', flexGrow: 1, marginRight: '0.5rem' } }, [
-            'Last edited:',
-            div({}, Utils.makePrettyDate(updated))
+            'Last edited: ',
+            Utils.makePrettyDate(updated)
           ])
         ]),
+        isRecent ? div({ style: { display: 'flex', color: colors.orange[0] } }, 'Recently Edited') : undefined,
         notebookMenu
       ])
     ])
@@ -265,7 +255,12 @@ const Notebooks = _.flow(
         }
       }, [
         h(Clickable, {
-          style: { ...Style.elements.card.container, flex: 1, color: colors.green[0] },
+          style: {
+            ...Style.elements.card.container,
+            padding: '1rem',
+            flex: 1,
+            color: colors.green[0]
+          },
           onClick: () => this.setState({ creating: true }),
           disabled: !canWrite,
           tooltip: !canWrite ? noWrite : undefined
@@ -280,7 +275,7 @@ const Notebooks = _.flow(
         h(Clickable, {
           style: {
             ...Style.elements.card.container, flex: 1,
-            backgroundColor: colors.gray[6], border: `1px dashed ${colors.gray[2]}`, boxShadow: 'none'
+            backgroundColor: colors.gray[6], border: `1px dashed ${colors.gray[2]}`, boxShadow: 'none', padding: '1rem'
           },
           onClick: () => this.uploader.current.open(),
           disabled: !canWrite,

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -141,9 +141,19 @@ class NotebookCard extends Component {
       ])
     ] : [
       title,
-      div({ style: { display: 'flex', justifyContent: 'space-between', borderTop: `solid 1px ${colors.gray[4]}`, padding: '0.5rem', backgroundColor: colors.grayBlue[5], borderRadius: '0 0 5px 5px' } }, [
+      div({
+        style: {
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          borderTop: `solid 1px ${colors.gray[4]}`,
+          padding: '0.5rem',
+          backgroundColor: colors.grayBlue[5],
+          borderRadius: '0 0 5px 5px'
+        }
+      }, [
         h(TooltipTrigger, { content: Utils.makeCompleteDate(updated) }, [
-          div({ style: { fontSize: '0.8rem', flexGrow: 1, marginRight: '0.5rem' } }, [
+          div({ style: { fontSize: '0.8rem', marginRight: '0.5rem' } }, [
             'Last edited: ',
             Utils.makePrettyDate(updated)
           ])

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -116,7 +116,7 @@ class NotebookCard extends Component {
     const title = div({
       title: printName(name),
       style: _.merge({
-        ...Style.elements.card.title, whiteSpace: 'normal'
+        ...Style.elements.card.title, whiteSpace: 'normal', overflowY: 'auto'
       }, listView ? {
         marginLeft: '1rem'
       } : { height: 60, padding: '1rem' })
@@ -128,7 +128,10 @@ class NotebookCard extends Component {
         ...Style.elements.card.container,
         ...notebookCardCommonStyles(listView),
         flexShrink: 0,
-        alignItems: listView ? 'center' : undefined
+        alignItems: listView ? 'center' : undefined,
+        padding: listView ? '1rem' : undefined,
+        boxShadow: listView ? 'rgba(0, 0, 0, 0.35) 0px 2px 5px 0px, rgba(0, 0, 0, 0.12) 0px 3px 2px 0px, rgba(0, 0, 0, 0.12) 0px 0px 2px 0px': '0 2px 10px 0 rgba(0,0,0,0.45), 0 2px 10px 0 rgba(0,0,0,0.25)'
+
       }
     }, listView ? [
       notebookMenu,
@@ -253,7 +256,7 @@ const Notebooks = _.flow(
 
     return div({
       style: {
-        display: 'flex', flexWrap: listView ? undefined : 'wrap',
+        display: 'flex',
         marginRight: listView ? undefined : '-2.5rem'
       }
     }, [
@@ -267,7 +270,6 @@ const Notebooks = _.flow(
         h(Clickable, {
           style: {
             ...Style.elements.card.container,
-            padding: '1rem',
             flex: 1,
             color: colors.green[0]
           },
@@ -285,7 +287,7 @@ const Notebooks = _.flow(
         h(Clickable, {
           style: {
             ...Style.elements.card.container, flex: 1,
-            backgroundColor: colors.gray[6], border: `1px dashed ${colors.gray[2]}`, boxShadow: 'none', padding: '1rem'
+            backgroundColor: colors.gray[6], border: `1px dashed ${colors.gray[2]}`, boxShadow: 'none'
           },
           onClick: () => this.uploader.current.open(),
           disabled: !canWrite,
@@ -301,7 +303,7 @@ const Notebooks = _.flow(
       listView ?
         div({ style: { flex: 1 } }, [
           renderedNotebooks
-        ]) : renderedNotebooks
+        ]) : div({ style: { display: 'flex', flexWrap: 'wrap' } }, renderedNotebooks)
     ])
   }
 


### PR DESCRIPTION
Changes how the notebook cards look to match the Invision mocks: 
https://projects.invisionapp.com/d/main#/console/16562871/343437622/inspect


<img width="1792" alt="Screen Shot 2019-03-08 at 4 58 09 PM" src="https://user-images.githubusercontent.com/42386483/54058279-632f8e80-41c3-11e9-941d-8e63ff37a839.png">

(You can scroll to view the rest of a long title) 

Changes only apply to notebook card view except:
- In the list view for notebooks, the title wraps and stretches the card down if the title is very long, instead of stretching the page out. See screenshots for visual explanation of difference

Old:
<img width="1792" alt="Screen Shot 2019-03-08 at 4 57 09 PM" src="https://user-images.githubusercontent.com/42386483/54058248-4a26dd80-41c3-11e9-8f2c-6509b97f6214.png">

New:
<img width="1792" alt="Screen Shot 2019-03-08 at 4 57 41 PM" src="https://user-images.githubusercontent.com/42386483/54058262-51e68200-41c3-11e9-8231-27681430f114.png">
