### PR TITLE
Revert linking to job manager: ONLY MERGE IF JOB MANAGER FAILS

### DIFF
--- a/src/pages/workspaces/workspace/JobHistory.js
+++ b/src/pages/workspaces/workspace/JobHistory.js
@@ -19,7 +19,7 @@ import { rerunFailures } from 'src/pages/workspaces/workspace/tools/FailureRerun
 import { wrapWorkspace } from 'src/pages/workspaces/workspace/WorkspaceContainer'
 
 
-export const linkToJobManager = true
+export const linkToJobManager = false
 
 const styles = {
   submissionsTable: {


### PR DESCRIPTION
Merge this ONLY to revert the job detail linking back to FireCloud instead of Job Manager.