### PR TITLE
add useAtom as an example react hook

### DIFF
--- a/src/components/AuthContainer.js
+++ b/src/components/AuthContainer.js
@@ -8,18 +8,19 @@ import SignIn from 'src/pages/SignIn'
 import TermsOfService from 'src/pages/TermsOfService'
 
 
-export default Utils.connectAtom(authStore, 'authState')(
-  ({ children, isPublic, authState: { isSignedIn, registrationStatus, acceptedTos } }) => {
-    return Utils.cond(
-      [isSignedIn === undefined && !isPublic, centeredSpinner],
-      [isSignedIn === false && !isPublic, h(SignIn)],
-      [registrationStatus === undefined && !isPublic, centeredSpinner],
-      [registrationStatus === 'unregistered', h(Register)],
-      [registrationStatus === 'disabled', () => h(Disabled)],
-      [registrationStatus === 'unlisted', () => h(Unlisted)],
-      [acceptedTos === undefined && !isPublic, centeredSpinner],
-      [acceptedTos === false, () => h(TermsOfService)],
-      children
-    )
-  }
-)
+const AuthContainer = ({ children, isPublic }) => {
+  const { isSignedIn, registrationStatus, acceptedTos } = Utils.useAtom(authStore)
+  return Utils.cond(
+    [isSignedIn === undefined && !isPublic, centeredSpinner],
+    [isSignedIn === false && !isPublic, h(SignIn)],
+    [registrationStatus === undefined && !isPublic, centeredSpinner],
+    [registrationStatus === 'unregistered', h(Register)],
+    [registrationStatus === 'disabled', () => h(Disabled)],
+    [registrationStatus === 'unlisted', () => h(Unlisted)],
+    [acceptedTos === undefined && !isPublic, centeredSpinner],
+    [acceptedTos === false, () => h(TermsOfService)],
+    children
+  )
+}
+
+export default AuthContainer

--- a/src/components/ConfigOverridesWarning.js
+++ b/src/components/ConfigOverridesWarning.js
@@ -3,19 +3,18 @@ import { configOverridesStore } from 'src/libs/config'
 import colors from 'src/libs/colors'
 import * as Utils from 'src/libs/utils'
 
-const ConfigOverridesWarning = Utils.connectAtom(configOverridesStore, 'configOverrides')(
-  ({ configOverrides }) => {
-    return !!configOverrides && div({
-      style: {
-        position: 'fixed', bottom: 0, right: 0,
-        color: 'white', backgroundColor: colors.purple[0],
-        padding: '1rem'
-      }
-    }, [
-      'Warning! Config overrides are in effect:',
-      pre(JSON.stringify(configOverrides, null, 2))
-    ])
-  }
-)
+const ConfigOverridesWarning = () => {
+  const configOverrides = Utils.useAtom(configOverridesStore)
+  return !!configOverrides && div({
+    style: {
+      position: 'fixed', bottom: 0, right: 0,
+      color: 'white', backgroundColor: colors.purple[0],
+      padding: '1rem'
+    }
+  }, [
+    'Warning! Config overrides are in effect:',
+    pre(JSON.stringify(configOverrides, null, 2))
+  ])
+}
 
 export default ConfigOverridesWarning


### PR DESCRIPTION
This serves as an example and introduction to Hooks, a new React feature. They allow state and lifecycle code to be used within function components. They often fill the same role as HOCs, but with the benefit of simpler code and not adding extra wrapper components.

https://reactjs.org/docs/hooks-intro.html

This adds a `useAtom` hook for using the value of an atom in a component. It's analogous to the `connectAtom` HOC (in fact, `connectAtom` is now implemented with `useAtom` under the hood). Note that by using the hook, we can 'un-nest' those components by one level.

This should have no user-visible changes.