### PR TITLE
Add email/profile scopes to Leo clusters

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -729,7 +729,7 @@ const Jupyter = signal => ({
             serverExtensions: {},
             combinedExtensions: {}
           },
-          scopes: ['https://www.googleapis.com/auth/cloud-platform']
+          scopes: ['https://www.googleapis.com/auth/cloud-platform', 'https://www.googleapis.com/auth/userinfo.email', 'https://www.googleapis.com/auth/userinfo.profile']
         })
         return fetchLeo(`api/cluster/v2/${project}/${name}`, _.mergeAll([authOpts(), jsonBody(body), { signal, method: 'PUT' }, appIdentifier]))
       },


### PR DESCRIPTION
We need email/profile scopes on Leo clusters in addition to cloud-platform. Without them, pet service accounts can't access workbench services (our proxies reject the requests). This was a user issue raised by @mbookman.

TIL that cloud-platform does _not_ implicitly contain OAuth scopes: https://developers.google.com/identity/protocols/googlescopes

I manually created a Leo cluster with this set of scopes and verified everything works again. So I'm reasonably confident in this fix.

