### PR TITLE
remove .gcloudignore

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,1 +1,0 @@
-node_modules/


### PR DESCRIPTION
gcloud complains if you try to deploy manually that this conflicts with the ignore pattern defined in app.yaml, which is covers this anyway