### PR TITLE
extract useCancellation and useWorkspaces hooks

### DIFF
--- a/src/components/workspace-utils.js
+++ b/src/components/workspace-utils.js
@@ -1,59 +1,50 @@
 import _ from 'lodash/fp'
-import { Component, Fragment } from 'react'
+import { Component, Fragment, useEffect, useState } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
 import { buttonPrimary, linkButton, Select } from 'src/components/common'
 import NewWorkspaceModal from 'src/components/NewWorkspaceModal'
-import { ajaxCaller } from 'src/libs/ajax'
+import { Ajax, useCancellation } from 'src/libs/ajax'
 import { reportError } from 'src/libs/error'
 import * as StateHistory from 'src/libs/state-history'
 import * as Utils from 'src/libs/utils'
 
+export const useWorkspaces = ({ persist } = {}) => {
+  const signal = useCancellation()
+  const [loading, setLoading] = useState(false)
+  const [workspaces, setWorkspaces] = useState(() => persist ? StateHistory.get().workspaces : undefined)
+  const refresh = async () => {
+    try {
+      setLoading(true)
+      const workspaces = await Ajax(signal).Workspaces.list()
+      setWorkspaces(workspaces)
+    } catch (error) {
+      reportError('Error loading workspace list', error)
+    } finally {
+      setLoading(false)
+    }
+  }
+  useEffect(() => {
+    refresh()
+  }, [])
+  useEffect(() => {
+    if (persist) {
+      StateHistory.update({ workspaces })
+    }
+  }, [workspaces])
+  return { workspaces, refresh, loading }
+}
+
 export const withWorkspaces = ({ persist } = {}) => WrappedComponent => {
-  const Wrapper = ajaxCaller(class extends Component {
-    constructor(props) {
-      super(props)
-      this.state = {
-        workspaces: persist ? StateHistory.get().workspaces : undefined,
-        loadingWorkspaces: false
-      }
-    }
-
-    static displayName = 'withWorkspaces()'
-
-    async refresh() {
-      try {
-        const { ajax: { Workspaces } } = this.props
-        this.setState({ loadingWorkspaces: true })
-        const workspaces = await Workspaces.list()
-        this.setState({ workspaces })
-      } catch (error) {
-        reportError('Error loading workspace list', error)
-      } finally {
-        this.setState({ loadingWorkspaces: false })
-      }
-    }
-
-    componentDidMount() {
-      this.refresh()
-    }
-
-    componentDidUpdate() {
-      if (persist) {
-        const { workspaces } = this.state
-        StateHistory.update({ workspaces })
-      }
-    }
-
-    render() {
-      const { workspaces, loadingWorkspaces } = this.state
-      return h(WrappedComponent, {
-        ...this.props,
-        workspaces,
-        loadingWorkspaces,
-        refreshWorkspaces: () => this.refresh()
-      })
-    }
-  })
+  const Wrapper = props => {
+    const { workspaces, refresh, loading } = useWorkspaces({ persist })
+    return h(WrappedComponent, {
+      ...props,
+      workspaces,
+      loadingWorkspaces: loading,
+      refreshWorkspaces: refresh
+    })
+  }
+  Wrapper.displayName = 'withWorkspaces()'
   return Wrapper
 }
 


### PR DESCRIPTION
Adds more hook infrastructure. `useCancellation` returns a signal that can be passed to `Ajax` to get cancel-on-unmount behavior, and can be used instead of the `ajaxCaller` HOC.