### PR TITLE
ignore error clusters

### DIFF
--- a/src/components/ClusterManager.js
+++ b/src/components/ClusterManager.js
@@ -478,7 +478,7 @@ export default ajaxCaller(class ClusterManager extends PureComponent {
     const currentCluster = this.getCurrentCluster()
     const currentStatus = currentCluster && currentCluster.status
     const running = currentStatus === 'Running'
-    const isErrored = currentStatus === 'Error'
+    const spendingClusters = _.remove({ status: 'Deleting' }, _.remove({ status: 'Error' }, clusters))
     const renderIcon = () => {
       switch (currentStatus) {
         case 'Stopped':
@@ -508,9 +508,9 @@ export default ajaxCaller(class ClusterManager extends PureComponent {
           })
       }
     }
-    const totalCost = isErrored ? 0 : _.sum(_.map(({ machineConfig, status }) => {
+    const totalCost = _.sum(_.map(({ machineConfig, status }) => {
       return (status === 'Stopped' ? machineStorageCost : machineConfigCost)(machineConfig)
-    }, clusters))
+    }, spendingClusters))
     const activeClusters = this.getActiveClustersOldestFirst()
     const creating = _.some({ status: 'Creating' }, activeClusters)
     const multiple = !creating && activeClusters.length > 1
@@ -531,7 +531,7 @@ export default ajaxCaller(class ClusterManager extends PureComponent {
       h(ClusterIcon, {
         shape: 'trash',
         onClick: () => this.setState({ deleting: true }),
-        disabled: busy || !canCompute || !_.includes(currentStatus, ['Stopped', 'Running']),
+        disabled: busy || !canCompute || !_.includes(currentStatus, ['Stopped', 'Running', 'Error']),
         tooltip: 'Delete cluster',
         style: { marginLeft: '0.5rem' }
       }),
@@ -557,7 +557,7 @@ export default ajaxCaller(class ClusterManager extends PureComponent {
           }, [
             div({ style: { fontSize: 12, fontWeight: 'bold' } }, 'Notebook Runtime'),
             div({ style: { fontSize: 10 } }, [
-              span({ style: { textTransform: 'uppercase', fontWeight: 500 } }, isErrored ? 'None' : currentStatus || 'None'),
+              span({ style: { textTransform: 'uppercase', fontWeight: 500 } }, currentStatus || 'None'),
               ` (${Utils.formatUSD(totalCost)} hr)`
             ])
           ]),

--- a/src/components/ClusterManager.js
+++ b/src/components/ClusterManager.js
@@ -478,6 +478,7 @@ export default ajaxCaller(class ClusterManager extends PureComponent {
     const currentCluster = this.getCurrentCluster()
     const currentStatus = currentCluster && currentCluster.status
     const running = currentStatus === 'Running'
+    const isErrored = currentStatus === 'Error'
     const renderIcon = () => {
       switch (currentStatus) {
         case 'Stopped':
@@ -498,15 +499,13 @@ export default ajaxCaller(class ClusterManager extends PureComponent {
         case 'Stopping':
         case 'Creating':
           return h(ClusterIcon, { shape: 'sync', disabled: true })
-        case undefined:
+        default:
           return h(ClusterIcon, {
             shape: 'play',
             onClick: () => this.createDefaultCluster(),
             disabled: busy || !canCompute,
             tooltip: canCompute ? 'Create cluster' : noCompute
           })
-        default:
-          return h(ClusterIcon, { shape: 'ban', disabled: true })
       }
     }
     const totalCost = _.sum(_.map(({ machineConfig, status }) => {
@@ -557,8 +556,8 @@ export default ajaxCaller(class ClusterManager extends PureComponent {
           }, [
             div({ style: { fontSize: 12, fontWeight: 'bold' } }, 'Notebook Runtime'),
             div({ style: { fontSize: 10 } }, [
-              span({ style: { textTransform: 'uppercase', fontWeight: 500 } }, currentStatus || 'None'),
-              ` (${Utils.formatUSD(totalCost)} hr)`
+              span({ style: { textTransform: 'uppercase', fontWeight: 500 } }, isErrored ? 'None' : currentStatus || 'None'),
+              isErrored ? ' ($0.00 hr)': ` (${Utils.formatUSD(totalCost)} hr)`
             ])
           ]),
           icon('cog', { size: 22, className: 'is-solid', style: { color: isDisabled ? colors.gray[2] : colors.green[0] } })

--- a/src/components/ClusterManager.js
+++ b/src/components/ClusterManager.js
@@ -478,7 +478,7 @@ export default ajaxCaller(class ClusterManager extends PureComponent {
     const currentCluster = this.getCurrentCluster()
     const currentStatus = currentCluster && currentCluster.status
     const running = currentStatus === 'Running'
-    const spendingClusters = _.remove({ status: 'Deleting' }, _.remove({ status: 'Error' }, clusters))
+    const spendingClusters = _.remove(({ status }) => _.includes(status, ['Deleting', 'Error']), clusters)
     const renderIcon = () => {
       switch (currentStatus) {
         case 'Stopped':

--- a/src/components/ClusterManager.js
+++ b/src/components/ClusterManager.js
@@ -508,13 +508,14 @@ export default ajaxCaller(class ClusterManager extends PureComponent {
           })
       }
     }
-    const totalCost = _.sum(_.map(({ machineConfig, status }) => {
+    const totalCost = isErrored ? 0 : _.sum(_.map(({ machineConfig, status }) => {
       return (status === 'Stopped' ? machineStorageCost : machineConfigCost)(machineConfig)
     }, clusters))
     const activeClusters = this.getActiveClustersOldestFirst()
     const creating = _.some({ status: 'Creating' }, activeClusters)
     const multiple = !creating && activeClusters.length > 1
     const isDisabled = !canCompute || creating || multiple || busy
+
     return div({ style: styles.container }, [
       h(MiniLink, {
         href: Nav.getLink('workspace-terminal-launch', { namespace, name }),
@@ -557,7 +558,7 @@ export default ajaxCaller(class ClusterManager extends PureComponent {
             div({ style: { fontSize: 12, fontWeight: 'bold' } }, 'Notebook Runtime'),
             div({ style: { fontSize: 10 } }, [
               span({ style: { textTransform: 'uppercase', fontWeight: 500 } }, isErrored ? 'None' : currentStatus || 'None'),
-              isErrored ? ' ($0.00 hr)': ` (${Utils.formatUSD(totalCost)} hr)`
+              ` (${Utils.formatUSD(totalCost)} hr)`
             ])
           ]),
           icon('cog', { size: 22, className: 'is-solid', style: { color: isDisabled ? colors.gray[2] : colors.green[0] } })

--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -43,6 +43,7 @@ const styles = {
 const getCluster = clusters => {
   return _.flow(
     _.remove({ status: 'Deleting' }),
+    _.remove({ status: 'Error' }),
     _.sortBy('createdDate'),
     _.first
   )(clusters)


### PR DESCRIPTION
Treat clusters in an error state as if they didn't exist. This means that errored clusters would: 
* Show up as "None" on Runtime
* Show an estimated cost of $0.00hr
* Have the "play" button clickable, and upon clicking, spin up a new standard cluster 
* Have the "cog" clickable, user can specify the new cluster they wish to spin up.

Current view:
<img width="368" alt="Screen Shot 2019-03-20 at 2 30 21 PM" src="https://user-images.githubusercontent.com/42386483/54709868-bdfaab80-4b1c-11e9-9e2f-c8e7a6bfecaa.png">


This branch's view: 
<img width="398" alt="Screen Shot 2019-03-20 at 2 29 48 PM" src="https://user-images.githubusercontent.com/42386483/54709846-aae7db80-4b1c-11e9-86d0-3613cff333f8.png">

Testing:
To purposely error out a cluster, 
1. Make a script kinda like this: https://github.com/DataBiosphere/leonardo/blob/develop/automation/src/test/resources/bucket-tests/invalid_user_script.sh
2. Put it in a bucket accessible by your user
3. Put the gs:// path in the "Startup script" field of the cluster config

I have already done this in my "Terra Demo" workspace that I play around in. You can find the file, testErrorScript, in the bucket on the data tab to get the gs:// path. Spinning up clusters takes some time, so be wary that you might need to wait around a bit while testing. 
