### PR TITLE
convert form label functions to components

### DIFF
--- a/src/components/ExportDataModal.js
+++ b/src/components/ExportDataModal.js
@@ -10,7 +10,7 @@ import { withWorkspaces, WorkspaceSelector } from 'src/components/workspace-util
 import { ajaxCaller } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { reportError } from 'src/libs/error'
-import { formLabel, requiredFormLabel } from 'src/libs/forms'
+import { FormLabel, RequiredFormLabel } from 'src/libs/forms'
 import * as Nav from 'src/libs/nav'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
@@ -99,7 +99,7 @@ export default _.flow(
           'Copying the following data could cause failures if a workflow is using this data.'
       }),
       !((hardConflicts.length !== 0) || moreToDelete || (softConflicts.length !== 0)) && h(Fragment, [
-        requiredFormLabel('Destination'),
+        h(RequiredFormLabel, ['Destination']),
         h(WorkspaceSelector, {
           workspaces: _.filter(Utils.isValidWsExportTarget(workspace), workspaces),
           value: selectedWorkspaceId,
@@ -118,7 +118,7 @@ export default _.flow(
         infoStyle: warningStyle, iconName: 'warning-standard',
         content: 'The following data is linked to entries which already exist in the selected workspace. You may re-link the following data to the existing entries by clicking COPY.'
       }),
-      formLabel('Entries selected'),
+      h(FormLabel, ['Entries selected']),
       ...Utils.cond(
         [moreToDelete, () => this.displayEntities(additionalDeletions, runningSubmissionsCount, true)],
         [(hardConflicts.length !== 0), () => this.displayEntities(hardConflicts, runningSubmissionsCount, true)],

--- a/src/components/NewWorkspaceModal.js
+++ b/src/components/NewWorkspaceModal.js
@@ -10,7 +10,7 @@ import { InfoBox } from 'src/components/PopupTrigger'
 import { ajaxCaller } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { reportError } from 'src/libs/error'
-import * as Forms from 'src/libs/forms'
+import { FormLabel, RequiredFormLabel } from 'src/libs/forms'
 import * as Utils from 'src/libs/utils'
 import validate from 'validate.js'
 
@@ -121,7 +121,7 @@ export default ajaxCaller(class NewWorkspaceModal extends Component {
         onClick: () => this.create()
       }, cloneWorkspace ? 'Clone Workspace' : 'Create Workspace')
     }, [
-      Forms.requiredFormLabel('Workspace name'),
+      h(RequiredFormLabel, ['Workspace name']),
       validatedInput({
         inputProps: {
           autoFocus: true,
@@ -131,7 +131,7 @@ export default ajaxCaller(class NewWorkspaceModal extends Component {
         },
         error: Utils.summarizeErrors(nameModified && errors && errors.name)
       }),
-      Forms.requiredFormLabel('Billing project'),
+      h(RequiredFormLabel, ['Billing project']),
       billingProjects && !billingProjects.length ? h(Fragment, [
         div({ style: { color: colors.red[0] } }, [
           icon('error', { size: 16 }),
@@ -152,19 +152,22 @@ export default ajaxCaller(class NewWorkspaceModal extends Component {
         onChange: ({ value }) => this.setState({ namespace: value }),
         options: _.uniq(_.map('projectName', billingProjects)).sort()
       }),
-      Forms.formLabel('Description'),
+      h(FormLabel, ['Description']),
       h(TextArea, {
         style: { height: 100 },
         placeholder: 'Enter a description',
         value: description,
         onChange: e => this.setState({ description: e.target.value })
       }),
-      Forms.formLabel('Authorization domain', h(InfoBox, [
-        'An authorization domain can only be set when creating a workspace. ',
-        'Once set, it cannot be changed. ',
-        'Any cloned workspace will automatically inherit the authorization domain(s) from the original workspace and cannot be removed. ',
-        link({ href: authDoc, target: '_blank' }, ['Read more about authorization domains'])
-      ])),
+      h(FormLabel, [
+        'Authorization domain',
+        h(InfoBox, [
+          'An authorization domain can only be set when creating a workspace. ',
+          'Once set, it cannot be changed. ',
+          'Any cloned workspace will automatically inherit the authorization domain(s) from the original workspace and cannot be removed. ',
+          link({ href: authDoc, target: '_blank' }, ['Read more about authorization domains'])
+        ])
+      ]),
       !!existingGroups.length && div({ style: styles.groupNotice }, [
         div({ style: { marginBottom: '0.2rem' } }, ['Inherited groups:']),
         ...existingGroups.join(', ')

--- a/src/components/SupportRequest.js
+++ b/src/components/SupportRequest.js
@@ -10,7 +10,7 @@ import { Ajax } from 'src/libs/ajax'
 import { authStore } from 'src/libs/auth'
 import colors from 'src/libs/colors'
 import { reportError } from 'src/libs/error'
-import * as Forms from 'src/libs/forms'
+import { FormLabel, RequiredFormLabel } from 'src/libs/forms'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 import { Component } from 'src/libs/wrapped-components'
@@ -133,7 +133,7 @@ const SupportRequest = _.flow(
         div({ style: { padding: '1rem' } }, [
           div({ style: { fontSize: 18, fontWeight: 'bold', color: colors.darkBlue[0] } }, ['Contact Us']),
           !this.hasName() && h(Fragment, [
-            Forms.requiredFormLabel('Name'),
+            h(RequiredFormLabel, ['Name']),
             textInput({
               placeholder: 'What should we call you?',
               autoFocus: true,
@@ -141,14 +141,14 @@ const SupportRequest = _.flow(
               onChange: e => this.setState({ nameEntered: e.target.value })
             })
           ]),
-          Forms.requiredFormLabel('Type'),
+          h(RequiredFormLabel, ['Type']),
           h(Select, {
             isMulti: false,
             value: type,
             onChange: ({ value }) => this.setState({ type: value }),
             options: [{ value: 'question', label: 'Question' }, { value: 'bug', label: 'Bug' }, { value: 'feature_request', label: 'Feature Request' }]
           }),
-          Forms.requiredFormLabel(`How can we help you${greetUser}?`),
+          h(RequiredFormLabel, [`How can we help you${greetUser}?`]),
           textInput({
             style: { borderBottomLeftRadius: 0, borderBottomRightRadius: 0, borderBottomStyle: 'dashed' },
             placeholder: 'Enter a subject',
@@ -162,7 +162,7 @@ const SupportRequest = _.flow(
             value: description,
             onChange: e => this.setState({ description: e.target.value })
           }),
-          Forms.formLabel('Attachment'),
+          h(FormLabel, ['Attachment']),
           attachmentToken ?
             div({ style: { display: 'flex', alignItems: 'center' } }, [
               h(Clickable, {
@@ -195,7 +195,7 @@ const SupportRequest = _.flow(
               ])
             ]),
           uploadingFile && spinnerOverlay,
-          Forms.requiredFormLabel('Contact email'),
+          h(RequiredFormLabel, ['Contact email']),
           textInput({
             value: email,
             placeholder: 'Enter your email address',

--- a/src/components/group-common.js
+++ b/src/components/group-common.js
@@ -10,7 +10,7 @@ import TooltipTrigger from 'src/components/TooltipTrigger'
 import { ajaxCaller } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { reportError } from 'src/libs/error'
-import * as Forms from 'src/libs/forms'
+import { FormLabel, RequiredFormLabel } from 'src/libs/forms'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 import { Component } from 'src/libs/wrapped-components'
@@ -122,7 +122,7 @@ export const NewUserModal = ajaxCaller(class NewUserModal extends Component {
         disabled: errors
       }, ['Add User'])
     }, [
-      Forms.requiredFormLabel('User email'),
+      h(RequiredFormLabel, ['User email']),
       h(AutocompleteSearch, {
         autoFocus: true,
         value: userEmail,
@@ -152,7 +152,7 @@ export const NewUserModal = ajaxCaller(class NewUserModal extends Component {
         renderInputComponent: textInput,
         theme: { suggestion: { padding: 0 } }
       }),
-      Forms.formLabel('Role'),
+      h(FormLabel, ['Role']),
       h(LabeledCheckbox, {
         checked: isAdmin,
         onChange: () => this.setState({ roles: [isAdmin ? userLabel : adminLabel] })

--- a/src/components/notebook-utils.js
+++ b/src/components/notebook-utils.js
@@ -7,7 +7,7 @@ import { validatedInput } from 'src/components/input'
 import Modal from 'src/components/Modal'
 import { ajaxCaller } from 'src/libs/ajax'
 import { reportError } from 'src/libs/error'
-import * as Forms from 'src/libs/forms'
+import { RequiredFormLabel } from 'src/libs/forms'
 import * as Utils from 'src/libs/utils'
 import { Component } from 'src/libs/wrapped-components'
 import validate from 'validate.js'
@@ -108,7 +108,7 @@ export const NotebookCreator = ajaxCaller(class NotebookCreator extends Componen
         }
       }, 'Create Notebook')
     }, [
-      Forms.requiredFormLabel('Name'),
+      h(RequiredFormLabel, ['Name']),
       notebookNameInput({
         error: Utils.summarizeErrors(nameTouched && errors && errors.notebookName),
         inputProps: {
@@ -116,7 +116,7 @@ export const NotebookCreator = ajaxCaller(class NotebookCreator extends Componen
           onChange: e => this.setState({ notebookName: e.target.value, nameTouched: true })
         }
       }),
-      Forms.requiredFormLabel('Language'),
+      h(RequiredFormLabel, ['Language']),
       h(Select, {
         isSearchable: false,
         placeholder: 'Select a language',
@@ -182,7 +182,7 @@ export const NotebookDuplicator = ajaxCaller(class NotebookDuplicator extends Co
     Utils.cond(
       [processing, () => [centeredSpinner()]],
       () => [
-        Forms.requiredFormLabel('New Name'),
+        h(RequiredFormLabel, ['New Name']),
         notebookNameInput({
           error: Utils.summarizeErrors(nameTouched && errors && errors.newName),
           inputProps: {

--- a/src/libs/forms.js
+++ b/src/libs/forms.js
@@ -14,19 +14,13 @@ const styles = {
 }
 
 
-export const formLabel = (text, ...extras) => {
-  return div({ style: styles.formLabel }, [
-    text,
-    ...extras
-  ])
+export const FormLabel = ({ style = {}, children, ...props }) => {
+  return div({ ...props, style: { ...styles.formLabel, ...style } }, [children])
 }
 
 
-export const requiredFormLabel = (text, ...extras) => {
-  return div({ style: styles.formLabel }, [
-    `${text} *`,
-    ...extras
-  ])
+export const RequiredFormLabel = ({ style = {}, children, ...props }) => {
+  return div({ ...props, style: { ...styles.formLabel, ...style } }, [children, ' *'])
 }
 
 

--- a/src/pages/groups/List.js
+++ b/src/pages/groups/List.js
@@ -10,7 +10,7 @@ import TopBar from 'src/components/TopBar'
 import { ajaxCaller } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { reportError } from 'src/libs/error'
-import * as Forms from 'src/libs/forms'
+import { formHint, RequiredFormLabel } from 'src/libs/forms'
 import * as Nav from 'src/libs/nav'
 import * as StateHistory from 'src/libs/state-history'
 import * as Style from 'src/libs/style'
@@ -54,7 +54,7 @@ const NewGroupModal = ajaxCaller(class NewGroupModal extends Component {
         onClick: () => this.submit()
       }, ['Create Group'])
     }, [
-      Forms.requiredFormLabel('Enter a unique name'),
+      h(RequiredFormLabel, ['Enter a unique name']),
       validatedInput({
         inputProps: {
           autoFocus: true,
@@ -63,7 +63,7 @@ const NewGroupModal = ajaxCaller(class NewGroupModal extends Component {
         },
         error: groupNameTouched && Utils.summarizeErrors(errors && errors.groupName)
       }),
-      !(groupNameTouched && errors) && Forms.formHint('Only letters, numbers, underscores, and dashes allowed'),
+      !(groupNameTouched && errors) && formHint('Only letters, numbers, underscores, and dashes allowed'),
       submitting && spinnerOverlay
     ])
   }

--- a/src/pages/workspaces/workspace/ShareWorkspaceModal.js
+++ b/src/pages/workspaces/workspace/ShareWorkspaceModal.js
@@ -9,7 +9,7 @@ import { ajaxCaller } from 'src/libs/ajax'
 import { getUser } from 'src/libs/auth'
 import colors from 'src/libs/colors'
 import { reportError } from 'src/libs/error'
-import * as Forms from 'src/libs/forms'
+import { FormLabel } from 'src/libs/forms'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 import validate from 'validate.js'
@@ -66,7 +66,7 @@ export default ajaxCaller(class ShareWorkspaceModal extends Component {
       okButton: buttonPrimary({ onClick: () => this.save() }, ['Save']),
       onDismiss
     }, [
-      Forms.formLabel('User email'),
+      h(FormLabel, ['User email']),
       h(AutocompleteTextInput, {
         placeholder: 'Add people or groups',
         value: searchValue,
@@ -74,7 +74,7 @@ export default ajaxCaller(class ShareWorkspaceModal extends Component {
         suggestions: _.difference(suggestions, _.map('email', acl)),
         style: { fontSize: 16 }
       }),
-      Forms.formLabel('Role'),
+      h(FormLabel, ['Role']),
       div({ style: { display: 'flex', alignItems: 'center', justifyContent: 'space-between' } }, [h(Select, {
         styles: { container: styles.roleSelect },
         isSearchable: false,

--- a/src/pages/workspaces/workspace/notebooks/ExportNotebookModal.js
+++ b/src/pages/workspaces/workspace/notebooks/ExportNotebookModal.js
@@ -4,7 +4,7 @@ import { buttonPrimary, spinnerOverlay } from 'src/components/common'
 import Modal from 'src/components/Modal'
 import { withWorkspaces, WorkspaceSelector } from 'src/components/workspace-utils'
 import { ajaxCaller } from 'src/libs/ajax'
-import { requiredFormLabel } from 'src/libs/forms'
+import { RequiredFormLabel } from 'src/libs/forms'
 import * as Nav from 'src/libs/nav'
 import * as Utils from 'src/libs/utils'
 import { Component } from 'src/libs/wrapped-components'
@@ -61,7 +61,7 @@ export default _.flow(
         onClick: () => this.copy()
       }, ['Copy'])
     }, [
-      requiredFormLabel('Destination'),
+      h(RequiredFormLabel, ['Destination']),
       h(WorkspaceSelector, {
         workspaces: _.filter(Utils.isValidWsExportTarget(workspace), workspaces),
         value: selectedWorkspaceId,
@@ -70,7 +70,7 @@ export default _.flow(
           this.findNotebooks(v)
         }
       }),
-      requiredFormLabel('Name'),
+      h(RequiredFormLabel, ['Name']),
       notebookNameInput({
         error: Utils.summarizeErrors(errors && errors.newName),
         inputProps: {

--- a/src/pages/workspaces/workspace/tools/ExportToolModal.js
+++ b/src/pages/workspaces/workspace/tools/ExportToolModal.js
@@ -5,7 +5,7 @@ import { validatedInput } from 'src/components/input'
 import Modal from 'src/components/Modal'
 import { withWorkspaces, WorkspaceSelector } from 'src/components/workspace-utils'
 import { ajaxCaller } from 'src/libs/ajax'
-import { requiredFormLabel } from 'src/libs/forms'
+import { RequiredFormLabel } from 'src/libs/forms'
 import * as Nav from 'src/libs/nav'
 import * as Utils from 'src/libs/utils'
 import { Component } from 'src/libs/wrapped-components'
@@ -64,7 +64,7 @@ export default _.flow(
         onClick: () => this.export()
       }, ['Copy'])
     }, [
-      requiredFormLabel('Destination'),
+      h(RequiredFormLabel, ['Destination']),
       h(WorkspaceSelector, {
         workspaces: _.filter(({ workspace: { workspaceId }, accessLevel }) => {
           return thisWorkspace.workspaceId !== workspaceId && Utils.canWrite(accessLevel)
@@ -72,7 +72,7 @@ export default _.flow(
         value: selectedWorkspaceId,
         onChange: v => this.setState({ selectedWorkspaceId: v })
       }),
-      requiredFormLabel('Name'),
+      h(RequiredFormLabel, ['Name']),
       validatedInput({
         error: Utils.summarizeErrors(errors && errors.toolName),
         inputProps: {


### PR DESCRIPTION
This converts a few 'component-like' functions into proper Components. This is in preparation for some accessibility improvements, which will involve converting these to `label` tags with `for` attributes, which requires a real props object.