### PR TITLE
Fetch billing accounts/projects from Google

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -669,12 +669,6 @@ const Buckets = signal => ({
 
 
 const GoogleBilling = signal => ({
-  listAccounts: async () => {
-    const response = await fetchGoogleBilling('billingAccounts', _.merge(authOpts(), { signal }))
-    const json = await response.json()
-    return json.billingAccounts
-  },
-
   listProjectNames: async billingAccountName => {
     const response = await fetchGoogleBilling(`${billingAccountName}/projects`, _.merge(authOpts(), { signal }))
     const json = await response.json()

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -3,9 +3,8 @@ import _ from 'lodash/fp'
 import * as qs from 'qs'
 import { h } from 'react-hyperscript-helpers'
 import { version } from 'src/data/clusters'
-import { getUser, hasBillingScope } from 'src/libs/auth'
+import { getUser } from 'src/libs/auth'
 import { getConfig } from 'src/libs/config'
-import { reportError } from 'src/libs/error'
 import * as Utils from 'src/libs/utils'
 
 
@@ -671,28 +670,15 @@ const Buckets = signal => ({
 
 const GoogleBilling = signal => ({
   listAccounts: async () => {
-    if (!hasBillingScope()) {
-      reportError('Terra does not have access to query your Google Cloud Billing information')
-    }
     const response = await fetchGoogleBilling('billingAccounts', _.merge(authOpts(), { signal }))
     const json = await response.json()
     return json.billingAccounts
   },
 
   listProjectNames: async billingAccountName => {
-    try {
-      const response = await fetchGoogleBilling(`${billingAccountName}/projects`, _.merge(authOpts(), { signal }))
-      const json = await response.json()
-      return _.map('projectId', json.projectBillingInfo)
-    } catch (errorResponse) {
-      // This might happen if the user has permission to create projects with this account
-      // but is missing the billing.resourceAssociations.list permission.
-      if (errorResponse.status === 403) {
-        return []
-      } else {
-        throw errorResponse
-      }
-    }
+    const response = await fetchGoogleBilling(`${billingAccountName}/projects`, _.merge(authOpts(), { signal }))
+    const json = await response.json()
+    return _.map('projectId', json.projectBillingInfo)
   }
 })
 

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -37,7 +37,7 @@ export const ensureBillingScope = async () => {
   if (!hasBillingScope()) {
     const options = new window.gapi.auth2.SigninOptionsBuilder({ 'scope': 'https://www.googleapis.com/auth/cloud-billing' })
     await getAuthInstance().currentUser.get().grant(options)
-    // Wait 100ms before continuing to avoid errors due to delays in applying the new scope grant
+    // Wait 250ms before continuing to avoid errors due to delays in applying the new scope grant
     await Utils.delay(250)
   }
 }

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -8,7 +8,7 @@ import { reportError } from 'src/libs/error'
 import * as Utils from 'src/libs/utils'
 
 
-export const getAuthInstance = () => {
+const getAuthInstance = () => {
   return window.gapi.auth2.getAuthInstance()
 }
 
@@ -38,7 +38,7 @@ export const ensureBillingScope = async () => {
     const options = new window.gapi.auth2.SigninOptionsBuilder({ 'scope': 'https://www.googleapis.com/auth/cloud-billing' })
     await getAuthInstance().currentUser.get().grant(options)
     // Wait 100ms before continuing to avoid errors due to delays in applying the new scope grant
-    await Utils.delay(100)
+    await Utils.delay(250)
   }
 }
 

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -26,20 +26,20 @@ export const hasBillingScope = () => {
 }
 
 /*
- * Request Google Cloud Billing scope if necessary, then do the thing.
+ * Request Google Cloud Billing scope if necessary.
  *
  * NOTE: Requesting additional scopes may invoke a browser pop-up which the browser might block.
- * If you use withBillingScope during page load and the pop-up is blocked, onFailure will be called.
- * In this case, you'll need to provide something for the user to deliberately click on and retry
- * withBillingScope in reaction to the click.
+ * If you use ensureBillingScope during page load and the pop-up is blocked, a rejected promise will
+ * be returned. In this case, you'll need to provide something for the user to deliberately click on
+ * and retry ensureBillingScope in reaction to the click.
  */
-export const withBillingScope = (f, onFailure) => {
+export const ensureBillingScope = async () => {
   if (hasBillingScope()) {
-    f()
+    return Promise.resolve()
   } else {
     const options = new window.gapi.auth2.SigninOptionsBuilder({ 'scope': 'https://www.googleapis.com/auth/cloud-billing' })
     // Wait 100ms before doing the thing to avoid errors due to delays in applying the new scope grant
-    getAuthInstance().currentUser.get().grant(options).then(() => setTimeout(f, 100), onFailure)
+    return getAuthInstance().currentUser.get().grant(options).then(() => new Promise(resolve => setTimeout(resolve, 100)))
   }
 }
 

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -34,12 +34,11 @@ export const hasBillingScope = () => {
  * and retry ensureBillingScope in reaction to the click.
  */
 export const ensureBillingScope = async () => {
-  if (hasBillingScope()) {
-    return Promise.resolve()
-  } else {
+  if (!hasBillingScope()) {
     const options = new window.gapi.auth2.SigninOptionsBuilder({ 'scope': 'https://www.googleapis.com/auth/cloud-billing' })
-    // Wait 100ms before doing the thing to avoid errors due to delays in applying the new scope grant
-    return getAuthInstance().currentUser.get().grant(options).then(() => new Promise(resolve => setTimeout(resolve, 100)))
+    await getAuthInstance().currentUser.get().grant(options)
+    // Wait 100ms before continuing to avoid errors due to delays in applying the new scope grant
+    await Utils.delay(100)
   }
 }
 

--- a/src/libs/billing.js
+++ b/src/libs/billing.js
@@ -4,11 +4,11 @@ import { ensureBillingScope } from 'src/libs/auth'
 
 
 export const listProjectsWithAccounts = async () => {
-  const { GoogleBilling } = Ajax()
+  const { Billing, GoogleBilling } = Ajax()
 
   await ensureBillingScope()
 
-  const accountNames = _.map('name', await GoogleBilling.listAccounts()) // or fetch account names from FireCloud
+  const accountNames = _.map('accountName', await Billing.listAccounts()) // or fetch account names from FireCloud
   const projectNames = await Promise.all(_.map(async accountName => {
     try {
       return await GoogleBilling.listProjectNames(accountName)

--- a/src/libs/billing.js
+++ b/src/libs/billing.js
@@ -1,0 +1,26 @@
+import _ from 'lodash/fp'
+import { Ajax } from 'src/libs/ajax'
+import { ensureBillingScope } from 'src/libs/auth'
+
+
+export const listProjectsWithAccounts = async () => {
+  const { GoogleBilling } = Ajax()
+
+  await ensureBillingScope()
+
+  const accountNames = _.map('name', await GoogleBilling.listAccounts()) // or fetch account names from FireCloud
+  const projectNames = await Promise.all(_.map(async accountName => {
+    try {
+      return await GoogleBilling.listProjectNames(accountName)
+    } catch (errorResponse) {
+      // This might happen if the user has permission to create projects with this account
+      // but is missing the billing.resourceAssociations.list permission.
+      if (errorResponse.status === 403) {
+        return []
+      } else {
+        throw errorResponse
+      }
+    }
+  }, accountNames))
+  return _.fromPairs(_.zip(accountNames, projectNames))
+}

--- a/src/pages/billing/List.js
+++ b/src/pages/billing/List.js
@@ -264,15 +264,12 @@ export const BillingList = ajaxCaller(class BillingList extends Component {
         ]),
         div({ style: Style.cardList.cardContainer }, [
           h(NewBillingProjectCard, {
-            onClick: () => {
-              if (Auth.getAuthInstance().currentUser.get().hasGrantedScopes('https://www.googleapis.com/auth/cloud-billing')) {
+            onClick: async () => {
+              try {
+                await Auth.ensureBillingScope()
                 this.setState({ creatingBillingProject: true })
-              } else {
-                const options = new window.gapi.auth2.SigninOptionsBuilder({ 'scope': 'https://www.googleapis.com/auth/cloud-billing' })
-                Auth.getAuthInstance().currentUser.get().grant(options).then(
-                  () => setTimeout(() => this.setState({ creatingBillingProject: true }), 250),
-                  () => reportError('Failed to grant permissions', 'To create a new billing project, you must allow Terra to view your Google billing account(s).')
-                )
+              } catch (error) {
+                reportError('Failed to grant permissions', 'To create a new billing project, you must allow Terra to view your Google billing account(s).')
               }
             }
           }),


### PR DESCRIPTION
Resolves: #1275 
Supports: #1188 

This PR does not contain any user-facing changes, only utilities to help with billing UI.

Usage example:
```
    await ensureBillingScope()
    const accountNames = _.map('name', await GoogleBilling.listAccounts()) // or fetch account names from FireCloud
    const projectNames = await Promise.all(_.map(async accountName => GoogleBilling.listProjectNames(accountName), accountNames))
    const projectsByAccount = _.fromPairs(_.zip(accountNames, projectNames))
```
~~withBillingScope(async () => {
  const accounts = await GoogleBilling.listAccounts()
  const projects = await _.flow(
    _.map('name'),
    GoogleBilling.listProjectsWithAccounts,
  )(accounts)
  doSomethingWith(projects)
}, () => {
  reportError('Google Cloud Billing scope not granted')
})~~