### PR TITLE
add utility for setting up form labels properly

### DIFF
--- a/src/components/common.js
+++ b/src/components/common.js
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp'
 import marked from 'marked'
-import { Fragment } from 'react'
+import { Fragment, useState } from 'react'
 import { div, h, input, label, span } from 'react-hyperscript-helpers'
 import Interactive from 'react-interactive'
 import RSelect from 'react-select'
@@ -231,12 +231,13 @@ export const comingSoon = span({
  * @param props.value - a member of options
  * @param {Array} props.options - can be of any type; if objects, they should each contain a value and label, unless defining getOptionLabel
  */
-export const Select = ({ value, options, ...props }) => {
+export const Select = ({ value, options, id, ...props }) => {
   const newOptions = options && !_.isObject(options[0]) ? _.map(value => ({ value }), options) : options
   const findValue = target => _.find({ value: target }, newOptions)
   const newValue = props.isMulti ? _.map(findValue, value) : findValue(value)
 
   return h(RSelect, _.merge({
+    inputId: id,
     theme: base => _.merge(base, {
       colors: {
         primary: colors.green[0],
@@ -301,4 +302,9 @@ export const Markdown = ({ children, renderers = {}, ...props }) => {
     renderer: Object.assign(new marked.Renderer(), renderers)
   })
   return div({ className: 'markdown-body', ...props, dangerouslySetInnerHTML: { __html: content } })
+}
+
+export const IdContainer = ({ children }) => {
+  const [id] = useState(() => _.uniqueId('element-'))
+  return children(id)
 }

--- a/src/components/notebook-utils.js
+++ b/src/components/notebook-utils.js
@@ -1,7 +1,8 @@
 import _ from 'lodash/fp'
 import PropTypes from 'prop-types'
+import { Fragment } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
-import { buttonPrimary, Select, spinnerOverlay } from 'src/components/common'
+import { buttonPrimary, IdContainer, Select, spinnerOverlay } from 'src/components/common'
 import { centeredSpinner } from 'src/components/icons'
 import { validatedInput } from 'src/components/input'
 import Modal from 'src/components/Modal'
@@ -108,23 +109,27 @@ export const NotebookCreator = ajaxCaller(class NotebookCreator extends Componen
         }
       }, 'Create Notebook')
     }, [
-      h(RequiredFormLabel, ['Name']),
-      notebookNameInput({
-        error: Utils.summarizeErrors(nameTouched && errors && errors.notebookName),
-        inputProps: {
-          value: notebookName,
-          onChange: e => this.setState({ notebookName: e.target.value, nameTouched: true })
-        }
-      }),
-      h(RequiredFormLabel, ['Language']),
-      h(Select, {
-        isSearchable: false,
-        placeholder: 'Select a language',
-        getOptionLabel: ({ value }) => _.startCase(value),
-        value: notebookKernel,
-        onChange: ({ value: notebookKernel }) => this.setState({ notebookKernel }),
-        options: ['python2', 'python3', 'r']
-      }),
+      h(IdContainer, [id => h(Fragment, [
+        h(RequiredFormLabel, { htmlFor: id }, ['Name']),
+        notebookNameInput({
+          error: Utils.summarizeErrors(nameTouched && errors && errors.notebookName),
+          inputProps: {
+            id, value: notebookName,
+            onChange: e => this.setState({ notebookName: e.target.value, nameTouched: true })
+          }
+        })
+      ])]),
+      h(IdContainer, [id => h(Fragment, [
+        h(RequiredFormLabel, { htmlFor: id }, ['Language']),
+        h(Select, {
+          id, isSearchable: false,
+          placeholder: 'Select a language',
+          getOptionLabel: ({ value }) => _.startCase(value),
+          value: notebookKernel,
+          onChange: ({ value: notebookKernel }) => this.setState({ notebookKernel }),
+          options: ['python2', 'python3', 'r']
+        })
+      ])]),
       creating && spinnerOverlay
     ])
   }
@@ -182,14 +187,16 @@ export const NotebookDuplicator = ajaxCaller(class NotebookDuplicator extends Co
     Utils.cond(
       [processing, () => [centeredSpinner()]],
       () => [
-        h(RequiredFormLabel, ['New Name']),
-        notebookNameInput({
-          error: Utils.summarizeErrors(nameTouched && errors && errors.newName),
-          inputProps: {
-            value: newName,
-            onChange: e => this.setState({ newName: e.target.value, nameTouched: true })
-          }
-        })
+        h(IdContainer, [id => h(Fragment, [
+          h(RequiredFormLabel, { htmlFor: id }, ['New Name']),
+          notebookNameInput({
+            error: Utils.summarizeErrors(nameTouched && errors && errors.newName),
+            inputProps: {
+              id, value: newName,
+              onChange: e => this.setState({ newName: e.target.value, nameTouched: true })
+            }
+          })
+        ])])
       ]
     ))
   }

--- a/src/libs/forms.js
+++ b/src/libs/forms.js
@@ -1,10 +1,11 @@
-import { div } from 'react-hyperscript-helpers'
+import { div, label } from 'react-hyperscript-helpers'
 import * as Style from 'src/libs/style'
 
 
 const styles = {
   formLabel: {
     ...Style.elements.sectionHeader,
+    display: 'block',
     margin: '1rem 0 0.25rem'
   },
   formHint: {
@@ -15,12 +16,12 @@ const styles = {
 
 
 export const FormLabel = ({ style = {}, children, ...props }) => {
-  return div({ ...props, style: { ...styles.formLabel, ...style } }, [children])
+  return label({ ...props, style: { ...styles.formLabel, ...style } }, [children])
 }
 
 
 export const RequiredFormLabel = ({ style = {}, children, ...props }) => {
-  return div({ ...props, style: { ...styles.formLabel, ...style } }, [children, ' *'])
+  return label({ ...props, style: { ...styles.formLabel, ...style } }, [children, ' *'])
 }
 
 


### PR DESCRIPTION
This adds an `IdContainer` component, which can be used to generate local, stable, unique ids for the purpose of wiring up form labels (and other accessibility-related attributes). Includes a few examples in the notebook modals.

The rationale for this is threefold:
1. It allows clicking on the label to focus the input, which is good UX
2. It allows screen readers to associate the label with the input
3. It will allow tests to identify inputs using the same text that users do

Note: This uses the 'function as child' pattern, where the `children` parameter is a callback function that receives information from the parent (the ID in this case), and returns the actual content to render. 