### PR TITLE
add withErrorReporting and withBusyState wrappers

### DIFF
--- a/src/libs/error.js
+++ b/src/libs/error.js
@@ -1,3 +1,4 @@
+import _ from 'lodash/fp'
 import { notify, sessionTimeoutProps } from 'src/components/Notifications'
 import { reloadAuthToken, signOut } from 'src/libs/auth'
 
@@ -12,10 +13,10 @@ export const reportError = async (title, obj) => {
 }
 
 // Transforms an async function so that it catches and reports errors using the provided text
-export const withErrorReporting = title => fn => async (...args) => {
+export const withErrorReporting = _.curry((title, fn) => async (...args) => {
   try {
     return await fn(...args)
   } catch (error) {
     reportError(title, error)
   }
-}
+})

--- a/src/libs/error.js
+++ b/src/libs/error.js
@@ -10,3 +10,12 @@ export const reportError = async (title, obj) => {
     notify('error', title, { detail: await (obj instanceof Response ? obj.text() : obj) })
   }
 }
+
+// Transforms an async function so that it catches and reports errors using the provided text
+export const withErrorReporting = title => fn => async (...args) => {
+  try {
+    return await fn(...args)
+  } catch (error) {
+    reportError(title, error)
+  }
+}

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -246,11 +246,11 @@ export const normalizeMachineConfig = ({ masterMachineType, masterDiskSize, numb
 export const append = _.curry((value, arr) => _.concat(arr, [value]))
 
 // Transforms an async function so that it updates a busy flag via the provided callback
-export const withBusyState = setBusy => fn => async (...args) => {
+export const withBusyState = _.curry((setBusy, fn) => async (...args) => {
   try {
     setBusy(true)
     return await fn(...args)
   } finally {
     setBusy(false)
   }
-}
+})

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -244,3 +244,13 @@ export const normalizeMachineConfig = ({ masterMachineType, masterDiskSize, numb
 }
 
 export const append = _.curry((value, arr) => _.concat(arr, [value]))
+
+// Transforms an async function so that it updates a busy flag via the provided callback
+export const withBusyState = setBusy => fn => async (...args) => {
+  try {
+    setBusy(true)
+    return await fn(...args)
+  } finally {
+    setBusy(false)
+  }
+}

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -108,7 +108,7 @@ const LocalVariablesContent = ajaxCaller(class LocalVariablesContent extends Com
         ['Value is not a comma-separated list of numbers'] : [])
     ]
 
-    const saveAttribute = withErrorReporting('Error saving change to workspace variables')(async originalKey => {
+    const saveAttribute = withErrorReporting('Error saving change to workspace variables', async originalKey => {
       const isList = editType.includes('list')
       const newBaseType = isList ? editType.slice(0, -5) : editType
 
@@ -605,7 +605,7 @@ const WorkspaceData = _.flow(
   }
 
   loadMetadata() {
-    return withErrorReporting('Error loading workspace entity data')(async () => {
+    return withErrorReporting('Error loading workspace entity data', async () => {
       const { namespace, name, ajax: { Workspaces } } = this.props
       const { selectedDataType } = this.state
       const entityMetadata = await Workspaces.workspace(namespace, name).entityMetadata()

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -425,16 +425,14 @@ const DeleteObjectModal = ajaxCaller(class DeleteObjectModal extends Component {
     this.state = { deleting: false }
   }
 
-  delete() {
-    return _.flow(
-      withErrorReporting('Error deleting object'),
-      Utils.withBusyState(v => this.setState({ deleting: v }))
-    )(async () => {
-      const { name, workspace: { workspace: { namespace, bucketName } }, ajax: { Buckets }, onSuccess } = this.props
-      await Buckets.delete(namespace, bucketName, name)
-      onSuccess()
-    })()
-  }
+  delete = _.flow(
+    withErrorReporting('Error deleting object'),
+    Utils.withBusyState(v => this.setState({ deleting: v }))
+  )(async () => {
+    const { name, workspace: { workspace: { namespace, bucketName } }, ajax: { Buckets }, onSuccess } = this.props
+    await Buckets.delete(namespace, bucketName, name)
+    onSuccess()
+  })
 
   render() {
     const { onDismiss } = this.props
@@ -474,28 +472,24 @@ const BucketContent = ajaxCaller(class BucketContent extends Component {
     StateHistory.update(_.pick(['objects', 'prefix'], this.state))
   }
 
-  load(prefix = this.state.prefix) {
-    return _.flow(
-      withErrorReporting('Error loading bucket data'),
-      Utils.withBusyState(v => this.setState({ loading: v }))
-    )(async () => {
-      const { workspace: { workspace: { namespace, bucketName } }, ajax: { Buckets } } = this.props
-      const { items, prefixes } = await Buckets.list(namespace, bucketName, prefix)
-      this.setState({ objects: items, prefixes, prefix })
-    })()
-  }
+  load = _.flow(
+    withErrorReporting('Error loading bucket data'),
+    Utils.withBusyState(v => this.setState({ loading: v }))
+  )(async (prefix = this.state.prefix) => {
+    const { workspace: { workspace: { namespace, bucketName } }, ajax: { Buckets } } = this.props
+    const { items, prefixes } = await Buckets.list(namespace, bucketName, prefix)
+    this.setState({ objects: items, prefixes, prefix })
+  })
 
-  uploadFiles(files) {
-    return _.flow(
-      withErrorReporting('Error uploading file'),
-      Utils.withBusyState(v => this.setState({ uploading: v }))
-    )(async () => {
-      const { workspace: { workspace: { namespace, bucketName } }, ajax: { Buckets } } = this.props
-      const { prefix } = this.state
-      await Buckets.upload(namespace, bucketName, prefix, files[0])
-      this.load()
-    })()
-  }
+  uploadFiles = _.flow(
+    withErrorReporting('Error uploading file'),
+    Utils.withBusyState(v => this.setState({ uploading: v }))
+  )(async files => {
+    const { workspace: { workspace: { namespace, bucketName } }, ajax: { Buckets } } = this.props
+    const { prefix } = this.state
+    await Buckets.upload(namespace, bucketName, prefix, files[0])
+    this.load()
+  })
 
   render() {
     const { workspace, workspace: { accessLevel, workspace: { namespace, bucketName } } } = this.props
@@ -604,17 +598,15 @@ const WorkspaceData = _.flow(
     }
   }
 
-  loadMetadata() {
-    return withErrorReporting('Error loading workspace entity data', async () => {
-      const { namespace, name, ajax: { Workspaces } } = this.props
-      const { selectedDataType } = this.state
-      const entityMetadata = await Workspaces.workspace(namespace, name).entityMetadata()
-      this.setState({
-        selectedDataType: this.selectionType() === 'entities' && !entityMetadata[selectedDataType] ? undefined : selectedDataType,
-        entityMetadata
-      })
-    })()
-  }
+  loadMetadata = withErrorReporting('Error loading workspace entity data', async () => {
+    const { namespace, name, ajax: { Workspaces } } = this.props
+    const { selectedDataType } = this.state
+    const entityMetadata = await Workspaces.workspace(namespace, name).entityMetadata()
+    this.setState({
+      selectedDataType: this.selectionType() === 'entities' && !entityMetadata[selectedDataType] ? undefined : selectedDataType,
+      entityMetadata
+    })
+  })
 
   async componentDidMount() {
     this.loadMetadata()


### PR DESCRIPTION
Adds two 'higher order async functions' to factor out some common boilerplate. These functions effectively transform one `async` function to another, and so can be composed as needed.

`withErrorReporting` catches any exceptions and sends them to `reportError` along with the given title string. The returned wrapper function's promise will never reject. Note that this does not preclude handling specific kinds of errors inside the wrapped function.

`withBusyState` wraps the original function with a busy flag by calling the provided function with `true` on invocation, and `false` on exit.

