### PR TITLE
Notification if sign-in fails 

### DIFF
--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp'
 import * as md5 from 'md5'
-import { clearNotification, sessionTimeoutProps } from 'src/components/Notifications'
+import { clearNotification, sessionTimeoutProps, notify } from 'src/components/Notifications'
 import ProdWhitelist from 'src/data/prod-whitelist'
 import { Ajax, fetchOk } from 'src/libs/ajax'
 import { getConfig } from 'src/libs/config'
@@ -45,6 +45,16 @@ export const initializeAuth = _.memoize(async () => {
       const authResponse = user.getAuthResponse(true)
       const profile = user.getBasicProfile()
       const isSignedIn = user.isSignedIn()
+      //The following few lines of code are to handle sign-in failures due to privacy tools.
+      if (state.isSignedIn===false && isSignedIn === false) {
+        //if both of these values are false, it means that the user was initially not signed in (state.isSignedIn === false),
+        //tried to sign in (invoking processUser) and was still not signed in (isSignedIn === false).
+        notify('info', 'Having trouble logging in?', {
+          message: 'Click for more information',
+          detail: 'Login failure may be due to privacy tools such as Privacy Badger or Ghostery. Please disable those tools, refresh, and try signing in again.',
+          timeout: 30000
+        })
+      }
       return {
         ...state,
         isSignedIn,

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -51,7 +51,7 @@ export const initializeAuth = _.memoize(async () => {
         //tried to sign in (invoking processUser) and was still not signed in (isSignedIn === false).
         notify('info', 'Having trouble logging in?', {
           message: 'Click for more information',
-          detail: 'Login failure may be due to privacy tools such as Privacy Badger or Ghostery. Please disable those tools, refresh, and try signing in again.',
+          detail: 'If you are using privacy blockers, they may be preventing you from signing in. Please disable those tools, refresh, and try signing in again.',
           timeout: 30000
         })
       }

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -49,7 +49,7 @@ export const initializeAuth = _.memoize(async () => {
       if (state.isSignedIn === false && isSignedIn === false) {
         //if both of these values are false, it means that the user was initially not signed in (state.isSignedIn === false),
         //tried to sign in (invoking processUser) and was still not signed in (isSignedIn === false).
-        notify('info', 'Having trouble logging in?', {
+        notify('error', 'Could not sign in', {
           message: 'Click for more information',
           detail: 'If you are using privacy blockers, they may be preventing you from signing in. Please disable those tools, refresh, and try signing in again.',
           timeout: 30000

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -46,7 +46,7 @@ export const initializeAuth = _.memoize(async () => {
       const profile = user.getBasicProfile()
       const isSignedIn = user.isSignedIn()
       //The following few lines of code are to handle sign-in failures due to privacy tools.
-      if (state.isSignedIn===false && isSignedIn === false) {
+      if (state.isSignedIn === false && isSignedIn === false) {
         //if both of these values are false, it means that the user was initially not signed in (state.isSignedIn === false),
         //tried to sign in (invoking processUser) and was still not signed in (isSignedIn === false).
         notify('info', 'Having trouble logging in?', {


### PR DESCRIPTION
Sign-in fails when a user is using a privacy tool like privacy badger or ghostery. 

This PR monitors to see if a user has tried to sign in, and it fails. If that occurs, a notification pops up letting the user know that the reason their sign-in failed could be due to a privacy blocker, and to disable the tool, refresh, and try signing in again. 

To test this: download either privacy badger or ghostery as an extension, then try signing into Terra. 
