### PR TITLE
move workspace list from sessionStorage to memory

### DIFF
--- a/src/components/workspace-utils.js
+++ b/src/components/workspace-utils.js
@@ -1,43 +1,41 @@
 import _ from 'lodash/fp'
-import { Component, Fragment, useEffect, useState } from 'react'
+import { Component, Fragment, useState } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
 import { buttonPrimary, linkButton, Select } from 'src/components/common'
 import NewWorkspaceModal from 'src/components/NewWorkspaceModal'
 import { Ajax, useCancellation } from 'src/libs/ajax'
-import { reportError } from 'src/libs/error'
-import * as StateHistory from 'src/libs/state-history'
+import { authStore } from 'src/libs/auth'
+import { withErrorReporting } from 'src/libs/error'
 import * as Utils from 'src/libs/utils'
 
+const workspacesStore = Utils.atom()
 
-export const useWorkspaces = ({ persist } = {}) => {
+authStore.subscribe((state, oldState) => {
+  if (oldState.isSignedIn && !state.isSignedIn) {
+    workspacesStore.reset()
+  }
+})
+
+export const useWorkspaces = () => {
   const signal = useCancellation()
   const [loading, setLoading] = useState(false)
-  const [workspaces, setWorkspaces] = useState(() => persist ? StateHistory.get().workspaces : undefined)
-  const refresh = async () => {
-    try {
-      setLoading(true)
-      const workspaces = await Ajax(signal).Workspaces.list()
-      setWorkspaces(workspaces)
-    } catch (error) {
-      reportError('Error loading workspace list', error)
-    } finally {
-      setLoading(false)
-    }
-  }
+  const workspaces = Utils.useAtom(workspacesStore)
+  const refresh = _.flow(
+    withErrorReporting('Error loading workspace list'),
+    Utils.withBusyState(setLoading)
+  )(async () => {
+    const ws = await Ajax(signal).Workspaces.list()
+    workspacesStore.set(ws)
+  })
   Utils.useOnMount(() => {
     refresh()
   })
-  useEffect(() => {
-    if (persist) {
-      StateHistory.update({ workspaces })
-    }
-  }, [workspaces, persist])
   return { workspaces, refresh, loading }
 }
 
-export const withWorkspaces = ({ persist } = {}) => WrappedComponent => {
+export const withWorkspaces = () => WrappedComponent => {
   const Wrapper = props => {
-    const { workspaces, refresh, loading } = useWorkspaces({ persist })
+    const { workspaces, refresh, loading } = useWorkspaces()
     return h(WrappedComponent, {
       ...props,
       workspaces,

--- a/src/pages/library/Showcase.js
+++ b/src/pages/library/Showcase.js
@@ -50,7 +50,7 @@ const makeCard = isGATK => ({ workspace: { namespace, name, attributes: { descri
 }
 
 
-const Showcase = withWorkspaces({ persist: true })(class Showcase extends Component {
+const Showcase = withWorkspaces()(class Showcase extends Component {
   constructor(props) {
     super(props)
     this.state = { featuredList: StateHistory.get().featuredList }

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -191,7 +191,7 @@ const NewWorkspaceCard = pure(({ onClick }) => {
 export const WorkspaceList = _.flow(
   ajaxCaller,
   togglesListView('workspaceList'),
-  withWorkspaces({ persist: true })
+  withWorkspaces()
 )(class WorkspaceList extends Component {
   constructor(props) {
     super(props)


### PR DESCRIPTION
This is a fix for #1259 

Session storage is limited in capacity, so we can't store large data objects without running into limits. This moves the cache of workspaces into an `atom` instead. This will fix the crash, and have the following UX effects:

* Clicking away from the workspaces page and then pressing Back will still show the cached data while it loads a fresh copy (no change)
* Clicking away from the workspaces page and then clicking _to_ it (e.g. via a breadcrumb link) will now show the cached data while it loads a fresh copy (currently does not show the cached data)
* Refreshing the page will no longer retain the cached data (currently it does)

I think these changes are small and overall more consistent with expectations, and fixing the storage overflow issue is obviously very important.