### PR TITLE
block non-public pages until profile is loaded

### DIFF
--- a/src/components/AuthContainer.js
+++ b/src/components/AuthContainer.js
@@ -1,3 +1,4 @@
+import _ from 'lodash/fp'
 import { h } from 'react-hyperscript-helpers'
 import { centeredSpinner } from 'src/components/icons'
 import { authStore } from 'src/libs/auth'
@@ -9,7 +10,7 @@ import TermsOfService from 'src/pages/TermsOfService'
 
 
 const AuthContainer = ({ children, isPublic }) => {
-  const { isSignedIn, registrationStatus, acceptedTos } = Utils.useAtom(authStore)
+  const { isSignedIn, registrationStatus, acceptedTos, profile } = Utils.useAtom(authStore)
   return Utils.cond(
     [isSignedIn === undefined && !isPublic, centeredSpinner],
     [isSignedIn === false && !isPublic, h(SignIn)],
@@ -19,6 +20,7 @@ const AuthContainer = ({ children, isPublic }) => {
     [registrationStatus === 'unlisted', () => h(Unlisted)],
     [acceptedTos === undefined && !isPublic, centeredSpinner],
     [acceptedTos === false, () => h(TermsOfService)],
+    [_.isEmpty(profile) && !isPublic, centeredSpinner],
     children
   )
 }


### PR DESCRIPTION
I _think_ this fixes #1237 

In trying to reproduce that, I found an issue where the page breaks if the profile hasn't finished loading by the time it mounts. This fixes that issue, which I suspect was responsible for the original bug report.