### PR TITLE
Drop default disk size down to 50GB

### DIFF
--- a/src/components/ClusterManager.js
+++ b/src/components/ClusterManager.js
@@ -125,7 +125,7 @@ const MachineSelector = ({ machineType, onChangeMachineType, diskSize, onChangeD
           diskSize :
           h(IntegerInput, {
             style: styles.smallInput,
-            min: 100,
+            min: 10,
             max: 64000,
             value: diskSize,
             onChange: onChangeDiskSize

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -274,11 +274,11 @@ export const isValidWsExportTarget = _.curry((sourceWs, destWs) => {
 export const normalizeMachineConfig = ({ masterMachineType, masterDiskSize, numberOfWorkers, numberOfPreemptibleWorkers, workerMachineType, workerDiskSize }) => {
   return {
     masterMachineType: masterMachineType || 'n1-standard-4',
-    masterDiskSize: masterDiskSize || 500,
+    masterDiskSize: masterDiskSize || 50,
     numberOfWorkers: numberOfWorkers || 0,
     numberOfPreemptibleWorkers: (numberOfWorkers && numberOfPreemptibleWorkers) || 0,
     workerMachineType: (numberOfWorkers && workerMachineType) || 'n1-standard-4',
-    workerDiskSize: (numberOfWorkers && workerDiskSize) || 500
+    workerDiskSize: (numberOfWorkers && workerDiskSize) || 50
   }
 }
 


### PR DESCRIPTION
There's some work being done in Leo to allow for cluster disks to be resized after creation. Once that's in, it would be nice to lower the default disk size for clusters. 500GB is far more than most users need and if they can resize it (which we would also love to expose through the UI) then lowering it is a good idea. For reference, AoU defaults to something super low like 10GB.

This will save users about $0.72 per day which can certainly add up over time.

Will merge once reviewed by product & eng, _and_ the Leo changes are in place.