### PR TITLE
Create TOS page

### DIFF
--- a/src/components/FooterWrapper.js
+++ b/src/components/FooterWrapper.js
@@ -9,8 +9,6 @@ const styles = {
   link: { marginLeft: '2rem' }
 }
 
-const tosUrl = 'https://broadinstitute.zendesk.com/hc/en-us/articles/360024688731-Terms-of-Service'
-
 const FooterWrapper = ({ children }) => {
   return div({ style: { display: 'flex', flexDirection: 'column', minHeight: '100%', flexGrow: 1 } }, [
     children,
@@ -29,7 +27,7 @@ const FooterWrapper = ({ children }) => {
         icon('logoWhite', { size: 55 })
       ]),
       a({ href: Nav.getLink('privacy'), style: styles.link }, 'Privacy Policy'),
-      a({ target: '_blank', href: tosUrl, style: styles.link }, 'Terms of Service'),
+      a({ href: Nav.getLink('terms-of-service'), style: styles.link }, 'Terms of Service'),
       div({ style: { marginLeft: 'auto', fontWeight: 600, fontSize: '10px' } }, [
         'Built on: ',
         new Date(SATURN_BUILD_TIMESTAMP).toLocaleString()

--- a/src/components/Router.js
+++ b/src/components/Router.js
@@ -23,6 +23,7 @@ import * as JobHistory from 'src/pages/workspaces/workspace/JobHistory'
 import * as Notebooks from 'src/pages/workspaces/workspace/Notebooks'
 import * as NotebookLauncher from 'src/pages/workspaces/workspace/notebooks/NotebookLauncher'
 import * as TerminalLauncher from 'src/pages/workspaces/workspace/notebooks/TerminalLauncher'
+import * as TermsOfService from 'src/pages/TermsOfService'
 import * as Tools from 'src/pages/workspaces/workspace/Tools'
 import * as WorkflowView from 'src/pages/workspaces/workspace/tools/WorkflowView'
 import * as Projects from 'src/pages/billing/List'
@@ -50,6 +51,7 @@ const initNavPaths = () => {
   Groups.addNavPaths()
   Group.addNavPaths()
   TerminalLauncher.addNavPaths()
+  TermsOfService.addNavPaths()
   Code.addNavPaths()
   Datasets.addNavPaths()
   Showcase.addNavPaths()

--- a/src/pages/TermsOfService.js
+++ b/src/pages/TermsOfService.js
@@ -269,7 +269,7 @@ class TermsOfServicePage extends Component {
 
 export const addNavPaths = () => {
   Nav.defPath('terms-of-service', {
-    path: '/TermsOfService',
+    path: '/terms-of-service',
     component: TermsOfServicePage,
     public: true,
     title: 'Terms of Service'

--- a/src/pages/TermsOfService.js
+++ b/src/pages/TermsOfService.js
@@ -193,6 +193,25 @@ const styles = {
   }
 }
 
+const termsTitle = div({ style: { color: colors.gray[0], fontWeight: 600 } }, [
+  span({ style: { fontSize: 36 } }, ['TERRA ']), span({ style: { fontSize: 24 } }, ['Terms of Service'])
+])
+
+const TOSMarkdown = div({
+  style: { maxHeight: 400, overflowY: 'auto', lineHeight: 1.5, marginTop: '1rem', paddingRight: '1rem' }
+}, [
+  h(Markdown, {
+    renderers: {
+      heading: (text, level) => {
+        return `<h${level} style="color: ${colors.gray[0]}; margin-bottom: 0">${text}</h${level}>`
+      },
+      paragraph: text => {
+        return `<p style="margin-top: 0">${text}</p>`
+      }
+    }
+  }, [termsOfService])
+])
+
 export default class TermsOfService extends Component {
   constructor(props) {
     super(props)
@@ -216,22 +235,8 @@ export default class TermsOfService extends Component {
     return div({ style: styles.page }, [
       backgroundLogo,
       div({ style: styles.box }, [
-        div({ style: { color: colors.gray[0], fontWeight: 600 } }, [
-          span({ style: { fontSize: 36 } }, ['TERRA ']),
-          span({ style: { fontSize: 24 } }, ['Terms of Service'])
-        ]),
-        div({ style: { maxHeight: 400, overflowY: 'auto', lineHeight: 1.5, marginTop: '1rem', paddingRight: '1rem' } }, [
-          h(Markdown, {
-            renderers: {
-              heading: (text, level) => {
-                return `<h${level} style="color: ${colors.gray[0]}; margin-bottom: 0">${text}</h${level}>`
-              },
-              paragraph: text => {
-                return `<p style="margin-top: 0">${text}</p>`
-              }
-            }
-          }, [termsOfService])
-        ]),
+        termsTitle,
+        TOSMarkdown,
         div({ style: { display: 'flex', justifyContent: 'flex-end', marginTop: '2rem' } }, [
           buttonSecondary({ style: { marginRight: '1rem' }, onClick: signOut }, 'Cancel'),
           buttonPrimary({ onClick: () => this.accept(), disabled: busy }, ['Accept'])
@@ -246,22 +251,8 @@ class TermsOfServicePage extends Component {
     return div({ style: styles.page }, [
       backgroundLogo,
       div({ style: styles.box }, [
-        div({ style: { color: colors.gray[0], fontWeight: 600 } }, [
-          span({ style: { fontSize: 36 } }, ['TERRA ']),
-          span({ style: { fontSize: 24 } }, ['Terms of Service'])
-        ]),
-        div({ style: { maxHeight: 400, overflowY: 'auto', lineHeight: 1.5, marginTop: '1rem', paddingRight: '1rem' } }, [
-          h(Markdown, {
-            renderers: {
-              heading: (text, level) => {
-                return `<h${level} style="color: ${colors.gray[0]}; margin-bottom: 0">${text}</h${level}>`
-              },
-              paragraph: text => {
-                return `<p style="margin-top: 0">${text}</p>`
-              }
-            }
-          }, [termsOfService])
-        ])
+        termsTitle,
+        TOSMarkdown
       ])
     ])
   }

--- a/src/pages/TermsOfService.js
+++ b/src/pages/TermsOfService.js
@@ -5,6 +5,7 @@ import { Ajax } from 'src/libs/ajax'
 import { authStore, signOut } from 'src/libs/auth'
 import colors from 'src/libs/colors'
 import { reportError } from 'src/libs/error'
+import * as Nav from 'src/libs/nav'
 import * as Style from 'src/libs/style'
 
 // When updating the TOS, make sure you:
@@ -192,7 +193,7 @@ const styles = {
   }
 }
 
-class TermsOfService extends Component {
+export default class TermsOfService extends Component {
   constructor(props) {
     super(props)
     this.state = { busy: false }
@@ -240,4 +241,38 @@ class TermsOfService extends Component {
   }
 }
 
-export default TermsOfService
+class TermsOfServicePage extends Component {
+
+  render() {
+    return div({ style: styles.page }, [
+      backgroundLogo,
+      div({ style: styles.box }, [
+        div({ style: { color: colors.gray[0], fontWeight: 600 } }, [
+          span({ style: { fontSize: 36 } }, ['TERRA ']),
+          span({ style: { fontSize: 24 } }, ['Terms of Service'])
+        ]),
+        div({ style: { maxHeight: 400, overflowY: 'auto', lineHeight: 1.5, marginTop: '1rem', paddingRight: '1rem' } }, [
+          h(Markdown, {
+            renderers: {
+              heading: (text, level) => {
+                return `<h${level} style="color: ${colors.gray[0]}; margin-bottom: 0">${text}</h${level}>`
+              },
+              paragraph: text => {
+                return `<p style="margin-top: 0">${text}</p>`
+              }
+            }
+          }, [termsOfService])
+        ])
+      ])
+    ])
+  }
+}
+
+export const addNavPaths = () => {
+  Nav.defPath('terms-of-service', {
+    path: '/TermsOfService',
+    component: TermsOfServicePage,
+    public: true,
+    title: 'Terms of Service'
+  })
+}

--- a/src/pages/TermsOfService.js
+++ b/src/pages/TermsOfService.js
@@ -242,7 +242,6 @@ export default class TermsOfService extends Component {
 }
 
 class TermsOfServicePage extends Component {
-
   render() {
     return div({ style: styles.page }, [
       backgroundLogo,


### PR DESCRIPTION
This creates a TOS page that is identical to our current one except without "accept/cancel" buttons. You can see it from clicking "Terms of Service" in the footer on the landing page (which used to link to an external page). 