### PR TITLE
Fix bucket content Modal

### DIFF
--- a/src/pages/workspaces/workspace/tools/WorkflowView.js
+++ b/src/pages/workspaces/workspace/tools/WorkflowView.js
@@ -202,8 +202,6 @@ const BucketContentModal = ajaxCaller(class BucketContentModal extends Component
     const { prefix, prefixes, objects, loading } = this.state
     const prefixParts = _.dropRight(1, prefix.split('/'))
     return h(Modal, {
-      style: { flexGrow: 1, backgroundColor: 'white', border: `1px solid ${colors.gray[3]}`, padding: '1rem' },
-      activeStyle: { backgroundColor: colors.blue[3], cursor: 'copy' },
       onDismiss,
       title: 'Choose input file',
       showX: true,


### PR DESCRIPTION
Bucket content modal was totally not working, discovered when looking at something else. Here is a quick fix for it! 

Before (Modal pops up at the bottom of the screen, can't click to any of the files):
<img width="1679" alt="Screen Shot 2019-04-08 at 2 20 11 PM" src="https://user-images.githubusercontent.com/42386483/55747142-97d47700-5a09-11e9-86cf-b76c35692a1d.png">

After:
<img width="1674" alt="Screen Shot 2019-04-08 at 2 20 41 PM" src="https://user-images.githubusercontent.com/42386483/55747165-a6bb2980-5a09-11e9-8573-ee6295de7e8a.png">

this bug is also on prod--not sure when it happened