### PR TITLE
Check for billing projects before loading project detail

### DIFF
--- a/src/pages/billing/List.js
+++ b/src/pages/billing/List.js
@@ -279,7 +279,7 @@ export const BillingList = ajaxCaller(class BillingList extends Component {
             this.loadProjects()
           }
         }),
-        !!selectedName && h(ProjectDetail, { key: selectedName, project: _.find({ projectName: selectedName }, billingProjects) }),
+        !!selectedName && billingProjects && h(ProjectDetail, { key: selectedName, project: _.find({ projectName: selectedName }, billingProjects) }),
         isBusy && spinnerOverlay
       ])
     ])


### PR DESCRIPTION
Fixes bug when you go directly to the detail page of a billing project from a new tab