### PR TITLE
delay app rendering until config is loaded

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,9 +12,8 @@ import 'src/style.css'
 window.SATURN_VERSION = SATURN_VERSION
 marked.setOptions({ sanitize: true, sanitizer: _.escape })
 
-ReactDOM.render(h(Main), document.getElementById('root'))
-
 loadConfig().then(() => {
+  ReactDOM.render(h(Main), document.getElementById('root'))
   initializeAuth()
   initializeTCell()
 })


### PR DESCRIPTION
Fixes #1419 

In the event that loading the config is slow, users will see the static 'Loading' message from the HTML in the meantime.