### PR TITLE
fix firefox links with onClick

### DIFF
--- a/src/components/common.js
+++ b/src/components/common.js
@@ -6,9 +6,9 @@ import Interactive from 'react-interactive'
 import RSelect from 'react-select'
 import { centeredSpinner, icon } from 'src/components/icons'
 import TooltipTrigger from 'src/components/TooltipTrigger'
-import { logo } from 'src/libs/logos'
 import colors from 'src/libs/colors'
 import { getConfig } from 'src/libs/config'
+import { logo } from 'src/libs/logos'
 import * as Style from 'src/libs/style'
 
 
@@ -43,9 +43,16 @@ const linkProps = disabled => ({
   hover: disabled ? undefined : { color: colors.green[1] }
 })
 
-export const link = function(props, children) {
+export const link = ({ onClick, href, ...props }, children) => {
   return h(Interactive,
-    _.merge(linkProps(props.disabled), props),
+    _.merge(linkProps(props.disabled), {
+      href,
+      onClick: href && onClick ? e => {
+        e.preventDefault()
+        onClick(e)
+      } : onClick,
+      ...props
+    }),
     children)
 }
 


### PR DESCRIPTION
In Firefox, if a link has an `onClick` and an `href`, both will happen on click. In chrome, the latter is ignored. This normalizes the behavior.