### PR TITLE
add firecloud as a return value

### DIFF
--- a/src/components/common.js
+++ b/src/components/common.js
@@ -6,7 +6,7 @@ import Interactive from 'react-interactive'
 import RSelect from 'react-select'
 import { centeredSpinner, icon } from 'src/components/icons'
 import TooltipTrigger from 'src/components/TooltipTrigger'
-import { logo } from 'src/libs/logos'
+import { isFirecloud, logo } from 'src/libs/logos'
 import colors from 'src/libs/colors'
 import { getConfig } from 'src/libs/config'
 import * as Style from 'src/libs/style'
@@ -289,7 +289,7 @@ export const backgroundLogo = logo({
 export const methodLink = config => {
   const { methodRepoMethod: { sourceRepo, methodVersion, methodNamespace, methodName, methodPath } } = config
   return sourceRepo === 'agora' ?
-    `${getConfig().firecloudUrlRoot}/?return=terra#methods/${methodNamespace}/${methodName}/${methodVersion}` :
+    `${getConfig().firecloudUrlRoot}/?return=${isFirecloud ? `firecloud` : `terra`}#methods/${methodNamespace}/${methodName}/${methodVersion}` :
     `${getConfig().dockstoreUrlRoot}/workflows/${methodPath}`
 }
 

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -296,7 +296,7 @@ export const backgroundLogo = () => logo({
 export const methodLink = config => {
   const { methodRepoMethod: { sourceRepo, methodVersion, methodNamespace, methodName, methodPath } } = config
   return sourceRepo === 'agora' ?
-    `${getConfig().firecloudUrlRoot}/?return=${isFirecloud ? `firecloud` : `terra`}#methods/${methodNamespace}/${methodName}/${methodVersion}` :
+    `${getConfig().firecloudUrlRoot}/?return=${isFirecloud() ? `firecloud` : `terra`}#methods/${methodNamespace}/${methodName}/${methodVersion}` :
     `${getConfig().dockstoreUrlRoot}/workflows/${methodPath}`
 }
 

--- a/src/libs/logos.js
+++ b/src/libs/logos.js
@@ -14,7 +14,7 @@ import { getConfig } from 'src/libs/config'
 
 ClarityIcons.add({ fcIcon, fcIconWhite, terraLogo, terraLogoWhite, terraLogoShadow })
 
-const isFirecloud = (window.location.hostname === 'firecloud.terra.bio') || getConfig().useFcLogo
+export const isFirecloud = (window.location.hostname === 'firecloud.terra.bio') || getConfig().useFcLogo
 
 const fcLongLogo = (size, color = false) => div({ style: { display: 'flex', maxHeight: size, marginRight: '1.5rem' } }, [
   div({ style: { color: color ? '#4e7dbf' : 'white', textAlign: 'right', fontSize: _.max([size / 10, 9]) } }, [

--- a/src/libs/logos.js
+++ b/src/libs/logos.js
@@ -14,7 +14,7 @@ import { getConfig } from 'src/libs/config'
 
 ClarityIcons.add({ fcIcon, fcIconWhite, terraLogo, terraLogoWhite, terraLogoShadow })
 
-export const isFirecloud = (window.location.hostname === 'firecloud.terra.bio') || getConfig().useFcLogo
+export const isFirecloud = () => (window.location.hostname === 'firecloud.terra.bio') || getConfig().useFcLogo
 
 const fcLongLogo = (size, color = false) => div({ style: { display: 'flex', maxHeight: size, marginRight: '1.5rem' } }, [
   div({ style: { color: color ? '#4e7dbf' : 'white', textAlign: 'right', fontSize: _.max([size / 10, 9]) } }, [

--- a/src/pages/library/Code.js
+++ b/src/pages/library/Code.js
@@ -9,6 +9,7 @@ import broadSquare from 'src/images/library/code/broad-square.svg'
 import { ajaxCaller } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { getConfig } from 'src/libs/config'
+import { isFirecloud } from 'src/libs/logos'
 import * as Nav from 'src/libs/nav'
 import * as StateHistory from 'src/libs/state-history'
 import * as Style from 'src/libs/style'
@@ -27,7 +28,7 @@ export const makeToolCard = ({ method, onClick }) => {
 
   return h(Clickable, {
     as: 'a',
-    href: _.isUndefined(onClick) ? `${getConfig().firecloudUrlRoot}/?return=terra#methods/${namespace}/${name}/` : undefined,
+    href: _.isUndefined(onClick) ? `${getConfig().firecloudUrlRoot}/?return=${isFirecloud ? `firecloud` : `terra`}#methods/${namespace}/${name}/` : undefined,
     onClick,
     style: {
       ...Style.elements.card.container,
@@ -76,7 +77,7 @@ export const dockstoreTile = () => div({ style: { display: 'flex' } }, [
 export const fcMethodRepoTile = () => div({ style: { display: 'flex' } }, [
   logoTile({ logoFile: broadSquare, style: { backgroundColor: undefined, backgroundSize: 37 } }),
   div([
-    link({ href: `${getConfig().firecloudUrlRoot}/?return=terra#methods` }, 'Broad Methods Repository'),
+    link({ href: `${getConfig().firecloudUrlRoot}/?return=${isFirecloud ? `firecloud` : `terra`}#methods` }, 'Broad Methods Repository'),
     div(['Use Broad workflows in Terra. Share your own, or choose from > 700 public workflows'])
   ])
 ])

--- a/src/pages/library/Code.js
+++ b/src/pages/library/Code.js
@@ -28,7 +28,7 @@ export const makeToolCard = ({ method, onClick }) => {
 
   return h(Clickable, {
     as: 'a',
-    href: _.isUndefined(onClick) ? `${getConfig().firecloudUrlRoot}/?return=${isFirecloud ? `firecloud` : `terra`}#methods/${namespace}/${name}/` : undefined,
+    href: _.isUndefined(onClick) ? `${getConfig().firecloudUrlRoot}/?return=${isFirecloud() ? `firecloud` : `terra`}#methods/${namespace}/${name}/` : undefined,
     onClick,
     style: {
       ...Style.elements.card.container,
@@ -77,7 +77,7 @@ export const dockstoreTile = () => div({ style: { display: 'flex' } }, [
 export const fcMethodRepoTile = () => div({ style: { display: 'flex' } }, [
   logoTile({ logoFile: broadSquare, style: { backgroundColor: undefined, backgroundSize: 37 } }),
   div([
-    link({ href: `${getConfig().firecloudUrlRoot}/?return=${isFirecloud ? `firecloud` : `terra`}#methods` }, 'Broad Methods Repository'),
+    link({ href: `${getConfig().firecloudUrlRoot}/?return=${isFirecloud() ? `firecloud` : `terra`}#methods` }, 'Broad Methods Repository'),
     div(['Use Broad workflows in Terra. Share your own, or choose from > 700 public workflows'])
   ])
 ])

--- a/src/pages/library/Datasets.js
+++ b/src/pages/library/Datasets.js
@@ -223,7 +223,7 @@ const fcDataLib = h(Participant, {
 }, [
   buttonPrimary({
     as: 'a',
-    href: `/?return=${isFirecloud ? `firecloud` : `terra`}#library`,
+    href: `/?return=${isFirecloud() ? `firecloud` : `terra`}#library`,
     target: '_blank',
     tooltip: 'Search for dataset workspaces'
   }, ['Browse Datasets'])

--- a/src/pages/library/Datasets.js
+++ b/src/pages/library/Datasets.js
@@ -18,6 +18,7 @@ import topMedLogo from 'src/images/library/datasets/TopMed@2x.png'
 import ukbLogo from 'src/images/library/datasets/UKB@2x.jpg'
 import colors from 'src/libs/colors'
 import { getConfig } from 'src/libs/config'
+import { isFirecloud } from 'src/libs/logos'
 import * as Nav from 'src/libs/nav'
 import * as Style from 'src/libs/style'
 import { Component } from 'src/libs/wrapped-components'
@@ -222,7 +223,7 @@ const fcDataLib = h(Participant, {
 }, [
   buttonPrimary({
     as: 'a',
-    href: `/?return=terra#library`,
+    href: `/?return=${isFirecloud ? `firecloud` : `terra`}#library`,
     target: '_blank',
     tooltip: 'Search for dataset workspaces'
   }, ['Browse Datasets'])


### PR DESCRIPTION
Pass "firecloud" or "terra" as a return parameter so that users will be redirected back to their correct domain when we link out to firecloud. 

Corresponding FC-ui PR: https://github.com/broadinstitute/firecloud-ui/pull/1527
Related FC-develop PR: https://github.com/broadinstitute/firecloud-develop/pull/1609