### PR TITLE
prevent UI actions when workspace is locked

### DIFF
--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -163,6 +163,22 @@ export const entityAttributeText = value => {
   )
 }
 
+// Returns a message explaining why the user can't edit the workspace, or undefined if they can
+export const editWorkspaceError = ({ accessLevel, workspace: { isLocked } }) => {
+  return cond(
+    [!canWrite(accessLevel), () => 'You do not have permission to modify this workspace.'],
+    [isLocked, () => 'This workspace is locked']
+  )
+}
+
+// Returns a message explaining why the user can't compute in the workspace, or undefined if they can
+export const computeWorkspaceError = ({ canCompute, workspace: { isLocked } }) => {
+  return cond(
+    [!canCompute, () => 'You do not have access to run analyses on this workspace.'],
+    [isLocked, () => 'This workspace is locked']
+  )
+}
+
 export const textMatch = _.curry((needle, haystack) => {
   return haystack.toLowerCase().includes(needle.toLowerCase())
 })

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -160,7 +160,7 @@ export const WorkspaceDashboard = _.flow(
 
   render() {
     const {
-      workspace: {
+      workspace, workspace: {
         accessLevel,
         workspace: {
           authorizationDomain, createdDate, lastModified, bucketName,
@@ -169,7 +169,6 @@ export const WorkspaceDashboard = _.flow(
       }
     } = this.props
     const { submissionsCount, storageCostEstimate, editDescription, saving, consentStatus } = this.state
-    const canWrite = Utils.canWrite(accessLevel)
     const isEditing = _.isString(editDescription)
 
     return div({ style: { flex: 1, display: 'flex' } }, [
@@ -178,8 +177,8 @@ export const WorkspaceDashboard = _.flow(
           'About the workspace',
           !isEditing && linkButton({
             style: { marginLeft: '0.5rem' },
-            disabled: !canWrite,
-            tooltip: !canWrite && 'You do not have permission to edit this workspace',
+            disabled: !!Utils.editWorkspaceError(workspace),
+            tooltip: Utils.editWorkspaceError(workspace),
             onClick: () => this.setState({ editDescription: description })
           }, [icon('edit', { className: 'is-solid' })])
         ]),

--- a/src/pages/workspaces/workspace/Tools.js
+++ b/src/pages/workspaces/workspace/Tools.js
@@ -78,7 +78,7 @@ const styles = {
   }
 }
 
-const ToolCard = pure(({ listView, name, namespace, config, onCopy, onDelete, isRedacted }) => {
+const ToolCard = pure(({ listView, name, namespace, config, onCopy, onDelete, isRedacted, workspace }) => {
   const { namespace: workflowNamespace, name: workflowName, methodRepoMethod: { sourceRepo, methodVersion } } = config
   const toolCardMenu = h(PopupTrigger, {
     closeOnClick: true,
@@ -90,6 +90,9 @@ const ToolCard = pure(({ listView, name, namespace, config, onCopy, onDelete, is
         tooltipSide: 'left'
       }, [menuIcon('copy'), 'Copy to Another Workspace']),
       h(MenuButton, {
+        disabled: !!Utils.editWorkspaceError(workspace),
+        tooltip: Utils.editWorkspaceError(workspace),
+        tooltipSide: 'left',
         onClick: () => onDelete()
       }, [menuIcon('trash'), 'Delete'])
     ])
@@ -297,14 +300,14 @@ export const Tools = _.flow(
   }
 
   render() {
-    const { namespace, name, listView, viewToggleButtons, workspace: { workspace } } = this.props
+    const { namespace, name, listView, viewToggleButtons, workspace: ws, workspace: { workspace } } = this.props
     const { loading, configs, copyingTool, deletingTool, findingTool } = this.state
     const tools = _.map(config => {
       const isRedacted = this.computeRedacted(config)
       return h(ToolCard, {
         onCopy: () => this.setState({ copyingTool: { namespace: config.namespace, name: config.name } }),
         onDelete: () => this.setState({ deletingTool: { namespace: config.namespace, name: config.name } }),
-        key: `${config.namespace}/${config.name}`, namespace, name, config, listView, isRedacted
+        key: `${config.namespace}/${config.name}`, namespace, name, config, listView, isRedacted, workspace: ws
       })
     }, configs)
 
@@ -327,6 +330,8 @@ export const Tools = _.flow(
       ]),
       div({ style: styles.cardContainer(listView) }, [
         h(Clickable, {
+          disabled: !!Utils.editWorkspaceError(ws),
+          tooltip: Utils.editWorkspaceError(ws),
           style: { ...styles.card, ...styles.shortCard, color: colors.green[0], fontSize: 18, lineHeight: '22px' },
           onClick: () => this.setState({ findingTool: true })
         }, [

--- a/src/pages/workspaces/workspace/tools/WorkflowView.js
+++ b/src/pages/workspaces/workspace/tools/WorkflowView.js
@@ -82,7 +82,7 @@ const ioTask = ({ name }) => _.nth(-2, name.split('.'))
 const ioVariable = ({ name }) => _.nth(-1, name.split('.'))
 const ioType = ({ inputType, outputType }) => (inputType || outputType).match(/(.*?)\??$/)[1] // unify, and strip off trailing '?'
 
-const WorkflowIOTable = ({ which, inputsOutputs: data, config, errors, onChange, onSetDefaults, onBrowse, suggestions }) => {
+const WorkflowIOTable = ({ which, inputsOutputs: data, config, errors, onChange, onSetDefaults, onBrowse, suggestions, readOnly }) => {
   return h(AutoSizer, [
     ({ width, height }) => {
       return h(FlexTable, {
@@ -118,7 +118,7 @@ const WorkflowIOTable = ({ which, inputsOutputs: data, config, errors, onChange,
           {
             headerRenderer: () => h(Fragment, [
               div({ style: { fontWeight: 'bold' } }, ['Attribute']),
-              onSetDefaults && h(Fragment, [
+              !readOnly && which === 'outputs' && h(Fragment, [
                 div({ style: { whiteSpace: 'pre' } }, ['  |  ']),
                 linkButton({ onClick: onSetDefaults }, ['Use defaults'])
               ])
@@ -129,14 +129,14 @@ const WorkflowIOTable = ({ which, inputsOutputs: data, config, errors, onChange,
               const error = errors[which][name]
               const isFile = (inputType === 'File') || (inputType === 'File?')
               return div({ style: { display: 'flex', alignItems: 'center', width: '100%' } }, [
-                onChange ? h(AutocompleteTextInput, {
+                !readOnly ? h(AutocompleteTextInput, {
                   placeholder: optional ? 'Optional' : 'Required',
                   value,
                   style: isFile ? { borderRadius: '4px 0px 0px 4px', borderRight: 'white' } : undefined,
                   onChange: v => onChange(name, v),
                   suggestions
                 }) : h(TextCell, { style: { flex: 1, borderRadius: '4px 0px 0px 4px', borderRight: 'white' } }, value),
-                isFile && h(Clickable, {
+                !readOnly && isFile && h(Clickable, {
                   style: {
                     height: '2.25rem',
                     border: `1px solid ${colors.grayBlue[2]}`, borderRadius: '0px 4px 4px 0px',
@@ -513,7 +513,7 @@ const WorkflowView = _.flow(
 
 
   renderSummary() {
-    const { workspace: { canCompute, workspace }, namespace, name: workspaceName } = this.props
+    const { workspace: ws, workspace: { workspace }, namespace, name: workspaceName } = this.props
     const {
       modifiedConfig, savedConfig, saving, saved, copying, deleting, selectingData, activeTab, errors, synopsis, documentation,
       selectedEntityType, entityMetadata, entitySelectionModel, snapshotIds, useCallCache
@@ -541,6 +541,9 @@ const WorkflowView = _.flow(
                     onClick: () => this.setState({ copying: true })
                   }, [menuIcon('copy'), 'Copy to Another Workspace']),
                   h(MenuButton, {
+                    disabled: !!Utils.editWorkspaceError(ws),
+                    tooltip: Utils.editWorkspaceError(ws),
+                    tooltipSide: 'right',
                     onClick: () => this.setState({ deleting: true })
                   }, [menuIcon('trash'), 'Delete'])
                 ])
@@ -550,10 +553,12 @@ const WorkflowView = _.flow(
             ]),
             span({ style: { color: colors.darkBlue[0], fontSize: 24 } }, name)
           ]),
-          div({ style: { marginTop: '0.5rem' } },
-            (sourceRepo === 'agora') ? [
-              'Snapshot', div({ style: { display: 'inline-block', marginLeft: '0.25rem', minWidth: 60  } }, [
+          div({ style: { marginTop: '0.5rem' } }, [
+            'Snapshot ',
+            sourceRepo === 'agora' ?
+              div({ style: { display: 'inline-block', marginLeft: '0.25rem', minWidth: 60  } }, [
                 h(Select, {
+                  isDisabled: !!Utils.editWorkspaceError(ws),
                   isClearable: false,
                   isSearchable: false,
                   value: methodVersion,
@@ -561,8 +566,9 @@ const WorkflowView = _.flow(
                   options: snapshotIds,
                   onChange: chosenSnapshot => this.loadNewMethodConfig(chosenSnapshot.value)
                 })
-              ])
-            ] : [`Snapshot ${methodVersion}`]),
+              ]) :
+              methodVersion
+          ]),
           div([
             'Source: ', link({
               href: methodLink(modifiedConfig),
@@ -581,6 +587,7 @@ const WorkflowView = _.flow(
           div({ style: { marginBottom: '1rem' } }, [
             div([
               h(RadioButton, {
+                disabled: !!Utils.editWorkspaceError(ws),
                 text: 'Process single workflow from files',
                 checked: this.isSingle(),
                 onChange: () => this.selectSingle(),
@@ -589,13 +596,14 @@ const WorkflowView = _.flow(
             ]),
             div([
               h(RadioButton, {
+                disabled: !!Utils.editWorkspaceError(ws),
                 text: `Process multiple workflows from:`,
                 checked: this.isMultiple(),
                 onChange: () => this.selectMultiple(),
                 labelStyle: { marginLeft: '0.5rem' }
               }),
               h(Select, {
-                isClearable: false, isDisabled: this.isSingle(), isSearchable: false,
+                isClearable: false, isDisabled: this.isSingle() || !!Utils.editWorkspaceError(ws), isSearchable: false,
                 placeholder: 'Select data type...',
                 styles: { container: old => ({ ...old, display: 'inline-block', width: 200, marginLeft: '0.5rem' }) },
                 getOptionLabel: ({ value }) => Utils.normalizeLabel(value),
@@ -607,7 +615,8 @@ const WorkflowView = _.flow(
                 options: _.keys(entityMetadata)
               }),
               linkButton({
-                disabled: this.isSingle() || !rootEntityType,
+                disabled: this.isSingle() || !rootEntityType || !!Utils.editWorkspaceError(ws),
+                tooltip: Utils.editWorkspaceError(ws),
                 onClick: () => this.setState({ selectingData: true }),
                 style: { marginLeft: '1rem' }
               }, ['Select Data'])
@@ -616,6 +625,7 @@ const WorkflowView = _.flow(
           ]),
           div({ style: { marginTop: '1rem' } }, [
             h(LabeledCheckbox, {
+              disabled: !!Utils.computeWorkspaceError(ws),
               checked: useCallCache,
               onChange: v => this.setState({ useCallCache: v })
             }, [' Use call caching']),
@@ -634,9 +644,8 @@ const WorkflowView = _.flow(
             activeTab,
             onChangeTab: v => this.setState({ activeTab: v }),
             finalStep: buttonPrimary({
-              disabled: !canCompute || !!noLaunchReason,
-              tooltip: !canCompute ? 'You do not have access to run analyses on this workspace.' :
-                !!noLaunchReason ? noLaunchReason : undefined,
+              disabled: !!Utils.computeWorkspaceError(ws) || !!noLaunchReason,
+              tooltip: Utils.computeWorkspaceError(ws) || noLaunchReason,
               onClick: () => this.setState({ launching: true }),
               style: {
                 height: StepButtonParams.buttonHeight, fontSize: StepButtonParams.fontSize
@@ -740,7 +749,7 @@ const WorkflowView = _.flow(
   }
 
   renderIOTable(key) {
-    const { workspace: { canCompute } } = this.props
+    const { workspace } = this.props
     const { modifiedConfig, modifiedInputsOutputs, errors, entityMetadata, workspaceAttributes, includeOptionalInputs } = this.state
     // Sometimes we're getting totally empty metadata. Not sure if that's valid; if not, revert this
     const { attributeNames } = entityMetadata[modifiedConfig.rootEntityType] || {}
@@ -753,7 +762,7 @@ const WorkflowView = _.flow(
     return h(Dropzone, {
       accept: '.json',
       multiple: false,
-      disabled: !canCompute,
+      disabled: !!Utils.editWorkspaceError(workspace),
       disableClick: true,
       style: { padding: `1rem ${sideMargin}`, flex: 'auto', display: 'flex', flexDirection: 'column' },
       activeStyle: { backgroundColor: colors.green[6], cursor: 'copy' },
@@ -768,25 +777,28 @@ const WorkflowView = _.flow(
             [includeOptionalInputs ? 'Hide optional inputs' : 'Show optional inputs']) :
           div({ style: { marginRight: 'auto' } }),
         linkButton({ onClick: () => this.downloadJson(key) }, ['Download json']),
-        div({ style: { whiteSpace: 'pre' } }, ['  |  Drag or click to ']),
-        linkButton({ onClick: () => this.uploader.current.open() }, ['upload json'])
+        !Utils.editWorkspaceError(workspace) && h(Fragment, [
+          div({ style: { whiteSpace: 'pre' } }, ['  |  Drag or click to ']),
+          linkButton({ onClick: () => this.uploader.current.open() }, ['upload json'])
+        ])
       ]),
       filteredData.length !== 0 &&
       div({ style: { flex: '1 0 500px' } }, [
         h(WorkflowIOTable, {
+          readOnly: !!Utils.editWorkspaceError(workspace),
           which: key,
           inputsOutputs: filteredData,
           config: modifiedConfig,
           errors,
           onBrowse: name => this.setState({ variableSelected: name }),
-          onChange: canCompute ? ((name, v) => this.setState(_.set(['modifiedConfig', key, name], v))) : undefined,
-          onSetDefaults: canCompute && key === 'outputs' ? () => {
+          onChange: (name, v) => this.setState(_.set(['modifiedConfig', key, name], v)),
+          onSetDefaults: () => {
             this.setState(_.update(['modifiedConfig', 'outputs'], _.flow(
               _.toPairs,
               _.map(([k, v]) => [k, v || `this.${_.last(k.split('.'))}`]),
               _.fromPairs
             )))
-          } : undefined,
+          },
           suggestions
         })
       ])


### PR DESCRIPTION
This addresses several places where we allowed the user to attempt an action that will fail due to permissions. These actions are now disabled with an appropriate message.

Fixes #1278 