### PR TITLE
save preferences separately from profile

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -148,6 +148,10 @@ const User = signal => ({
         'register/profile',
         _.mergeAll([authOpts(), jsonBody(_.merge(blankProfile, keysAndValues)), { signal, method: 'POST' }])
       )
+    },
+
+    setPreferences: body => {
+      return fetchOrchestration('api/profile/preferences', _.mergeAll([authOpts(), jsonBody(body), { signal, method: 'POST' }]))
     }
   },
 


### PR DESCRIPTION
Some profile information needs to be written via the "preferences" endpoint rather than the "profile" endpoint.

Fixes #1401 