### PR TITLE
enable upload and download of workspace attributes

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -557,6 +557,17 @@ const Workspaces = signal => ({
         return res.json()
       },
 
+      importAttributes: async file => {
+        const formData = new FormData()
+        formData.set('attributes', file)
+        return fetchOrchestration(`api/${root}/importAttributesTSV`, _.merge(authOpts(), { body: formData, signal, method: 'POST' }))
+      },
+
+      exportAttributes: async () => {
+        const res = await fetchOrchestration(`api/${root}/exportAttributesTSV`, _.merge(authOpts(), { signal }))
+        return res.blob()
+      },
+
       storageCostEstimate: async () => {
         const res = await fetchOrchestration(`api/workspaces/${namespace}/${name}/storageCostEstimate`, _.merge(authOpts(), { signal }))
         return res.json()


### PR DESCRIPTION
Fixes #1440 
Fixes #1442 

Note: This is bug-compatible with FC. In particular, downloading and re-uploading array types will not correctly preserve those values.