### PR TITLE
remove data entities from state history

### DIFF
--- a/src/components/DataTable.js
+++ b/src/components/DataTable.js
@@ -206,7 +206,7 @@ export default ajaxCaller(class DataTable extends Component {
       this.loadData()
     }
     if (this.props.persist) {
-      StateHistory.update(_.pick(['entities', 'totalRowCount', 'itemsPerPage', 'pageNumber', 'sort', 'columnWidths', 'columnState'], this.state))
+      StateHistory.update(_.pick(['itemsPerPage', 'pageNumber', 'sort', 'columnWidths', 'columnState'], this.state))
     }
   }
 


### PR DESCRIPTION
This stops caching data entities in `StateHistory`. Because this data can easily be quite large, it's a risk for overflowing `sessionStorage` and causing the app to break.

The user-visible change is that reloading or navigating back to the entities page will no longer show a preview of the old data while it loads the most recent data.

Fixes #1259 