### PR TITLE
clear billing project if inaccessible when cloning

### DIFF
--- a/src/components/NewWorkspaceModal.js
+++ b/src/components/NewWorkspaceModal.js
@@ -69,7 +69,10 @@ export default ajaxCaller(class NewWorkspaceModal extends Component {
         Billing.listProjects(),
         Groups.list()
       ])
-      this.setState({ billingProjects, allGroups })
+      this.setState(({ namespace }) => ({
+        billingProjects, allGroups,
+        namespace: _.some({ projectName: namespace }, billingProjects) ? namespace : undefined
+      }))
     } catch (error) {
       reportError('Error loading data', error)
     }


### PR DESCRIPTION
Fixes #1002 

The problem occurs when you clone a workspace in a billing project you don't have access to. The original billing project is selected in state, but the `Select` shows empty because the entry isn't in the returned project list.

Instead, when the billing project list comes in, evict the existing value if it's not accessible by the user.