### PR TITLE
update dockstore api url by request

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -92,7 +92,7 @@ const fetchLeo = async (path, options) => {
 }
 
 const fetchDockstore = async (path, options) => {
-  return fetchOk(`${getConfig().dockstoreUrlRoot}:8443/${path}`, options)
+  return fetchOk(`${getConfig().dockstoreUrlRoot}/api/${path}`, options)
 }
 // %23 = '#', %2F = '/'
 const dockstoreMethodPath = path => `api/ga4gh/v1/tools/%23workflow%2F${encodeURIComponent(path)}/versions`


### PR DESCRIPTION
see also broadinstitute/firecloud-develop#1617

> the issue you ran into earlier with the incorrect CORS header has been fixed on staging.dockstore.org. Could you try changing the base Dockstore URL you staging instance talks to https://staging.dockstore.org/api again, instead of https://staging.dockstore.org:8443.