### PR TITLE
fix job views when no inputs/entities

### DIFF
--- a/src/pages/workspaces/workspace/JobHistory.js
+++ b/src/pages/workspaces/workspace/JobHistory.js
@@ -182,9 +182,8 @@ const JobHistory = _.flow(
                 size: { basis: 250, grow: 0 },
                 headerRenderer: () => h(HeaderCell, ['Data entity']),
                 cellRenderer: ({ rowIndex }) => {
-                  const { submissionEntity: { entityName, entityType } } = filteredSubmissions[rowIndex]
-                  const text = `${entityName} (${entityType})`
-                  return h(TooltipCell, [text])
+                  const { submissionEntity: { entityName, entityType } = {} } = filteredSubmissions[rowIndex]
+                  return h(TooltipCell, [entityName && `${entityName} (${entityType})`])
                 }
               },
               {

--- a/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
+++ b/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
@@ -204,8 +204,8 @@ const SubmissionDetails = _.flow(
             size: { basis: 225, grow: 0 },
             headerRenderer: () => h(Sortable, { sort, field: 'workflowEntity', onSort: setSort }, ['Data Entity']),
             cellRenderer: ({ rowIndex }) => {
-              const { entityName, entityType } = filteredWorkflows[rowIndex].workflowEntity
-              return h(TooltipCell, [`${entityName} (${entityType})`])
+              const { workflowEntity: { entityName, entityType } = {} } = filteredWorkflows[rowIndex]
+              return h(TooltipCell, [entityName && `${entityName} (${entityType})`])
             }
           }, {
             size: { basis: 225, grow: 0 },
@@ -236,12 +236,12 @@ const SubmissionDetails = _.flow(
             size: { basis: 150, grow: 0 },
             headerRenderer: () => h(Sortable, { sort, field: 'workflowId', onSort: setSort }, ['Workflow ID']),
             cellRenderer: ({ rowIndex }) => {
-              const { workflowId, inputResolutions: [{ inputName }] } = filteredWorkflows[rowIndex]
+              const { workflowId, inputResolutions: [{ inputName } = {}] } = filteredWorkflows[rowIndex]
               return h(TooltipCell, { tooltip: workflowId }, [
-                link({
+                inputName ? link({
                   target: '_blank',
-                  href: bucketBrowserUrl(`${bucketName}/${submissionId}/${inputName.split('.')[0]}/${workflowId}`)
-                }, [workflowId])
+                  href: inputName && bucketBrowserUrl(`${bucketName}/${submissionId}/${inputName.split('.')[0]}/${workflowId}`)
+                }, [workflowId]) : workflowId
               ])
             }
           }


### PR DESCRIPTION
This fixes a couple display crashes when dealing with submissions with no entities and/or no inputs.

Note that in the case of no inputs, we lack the information to display the bucket link, even though it should exist. FC currently generates an invalid link in this case, but we'll just skip it entirely for now. In the future we should modify the API to return the necessary information directly.