### PR TITLE
change snapshot of tool when redacted

### DIFF
--- a/src/pages/workspaces/workspace/Tools.js
+++ b/src/pages/workspaces/workspace/Tools.js
@@ -10,6 +10,7 @@ import {
 import { centeredSpinner, icon } from 'src/components/icons'
 import Modal from 'src/components/Modal'
 import PopupTrigger from 'src/components/PopupTrigger'
+import TooltipTrigger from 'src/components/TooltipTrigger'
 import { ajaxCaller } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { getConfig } from 'src/libs/config'
@@ -23,7 +24,6 @@ import { dockstoreTile, fcMethodRepoTile, makeToolCard } from 'src/pages/library
 import DeleteToolModal from 'src/pages/workspaces/workspace/tools/DeleteToolModal'
 import ExportToolModal from 'src/pages/workspaces/workspace/tools/ExportToolModal'
 import { wrapWorkspace } from 'src/pages/workspaces/workspace/WorkspaceContainer'
-import TooltipTrigger from 'src/components/TooltipTrigger'
 
 
 const styles = {
@@ -86,7 +86,7 @@ const ToolCard = pure(({ listView, name, namespace, config, onCopy, onDelete, is
       h(MenuButton, {
         onClick: () => onCopy(),
         disabled: isRedacted,
-        tooltip: isRedacted ? 'This method is redacted' : undefined,
+        tooltip: isRedacted ? 'This tool version is redacted' : undefined,
         tooltipSide: 'left'
       }, [menuIcon('copy'), 'Copy to Another Workspace']),
       h(MenuButton, {
@@ -114,8 +114,7 @@ const ToolCard = pure(({ listView, name, namespace, config, onCopy, onDelete, is
     href: methodLink(config),
     style: styles.innerLink,
     target: '_blank',
-    disabled: isRedacted,
-    onClick: e => e.stopPropagation()
+    disabled: isRedacted
   }, sourceRepo === 'agora' ? 'FireCloud' : sourceRepo)
 
   const workflowLink = a({
@@ -124,15 +123,15 @@ const ToolCard = pure(({ listView, name, namespace, config, onCopy, onDelete, is
   })
 
   const redactedWarning = h(TooltipTrigger, {
-    content: 'Tool has been removed. You cannot view or run an analysis with this tool.'
+    content: 'Tool version has been removed. You cannot run an analysis until you change the version.'
   }, [icon('ban', { size: 20, style: { color: colors.orange[0], marginLeft: '.3rem', ...styles.innerLink } })])
 
   return listView ?
     div({ style: { ...styles.card, ...styles.longCard } }, [
-      isRedacted ? undefined: workflowLink,
+      workflowLink,
       div({ style: { ...styles.innerContent, display: 'flex', alignItems: 'center' } }, [
         div({ style: { marginRight: '1rem' } }, [toolCardMenu]),
-        div({ style: { ...styles.longTitle, ...(isRedacted ? { color: colors.gray[0] } : {}) } }, [workflowName]),
+        div({ style: { ...styles.longTitle } }, [workflowName]),
         div({ style: { ...styles.longMethodVersion, display: 'flex', alignItems: 'center' } }, [
           `V. ${methodVersion}`,
           isRedacted && redactedWarning
@@ -141,9 +140,9 @@ const ToolCard = pure(({ listView, name, namespace, config, onCopy, onDelete, is
       ])
     ]) :
     div({ style: { ...styles.card, ...styles.shortCard } }, [
-      !isRedacted && workflowLink,
+      workflowLink,
       div({ style: { ...styles.innerContent, display: 'flex', flexDirection: 'column', justifyContent: 'space-between', height: '100%' } }, [
-        div({ style: { ...styles.shortTitle, ...(isRedacted ? { color: colors.gray[0] } : {}) } }, [workflowName]),
+        div({ style: { ...styles.shortTitle } }, [workflowName]),
         div({ style: { display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end' } }, [
           div([
             div({ style: { display: 'flex', alignItems: 'center' } }, [

--- a/src/pages/workspaces/workspace/tools/WorkflowView.js
+++ b/src/pages/workspaces/workspace/tools/WorkflowView.js
@@ -365,7 +365,7 @@ const WorkflowView = _.flow(
     // modifiedConfig: active data, potentially unsaved
     const {
       isFreshData, savedConfig, launching, activeTab, useCallCache,
-      entitySelectionModel, variableSelected, modifiedConfig, isRedacted, updatingConfig
+      entitySelectionModel, variableSelected, modifiedConfig, updatingConfig
     } = this.state
     const { namespace, name, workspace } = this.props
     const workspaceId = { namespace, name }
@@ -456,7 +456,8 @@ const WorkflowView = _.flow(
 
   componentDidUpdate() {
     StateHistory.update(_.pick(
-      ['savedConfig', 'modifiedConfig', 'entityMetadata', 'savedInputsOutputs', 'modifiedInputsOutputs', 'invalid', 'activeTab', 'wdl', 'isRedacted', 'wasRedacted'],
+      ['savedConfig', 'modifiedConfig', 'entityMetadata', 'savedInputsOutputs', 'modifiedInputsOutputs', 'invalid', 'activeTab', 'wdl', 'isRedacted',
+        'wasRedacted'],
       this.state)
     )
   }
@@ -578,7 +579,7 @@ const WorkflowView = _.flow(
               methodVersion
           ]),
           div([
-            'Source: ', link({
+            'Source: ', isRedacted ? `${methodNamespace}/${methodName}/${methodVersion}` : link({
               href: methodLink(modifiedConfig),
               target: '_blank'
             }, methodPath ? methodPath : `${methodNamespace}/${methodName}/${methodVersion}`)
@@ -653,7 +654,7 @@ const WorkflowView = _.flow(
             onChangeTab: v => this.setState({ activeTab: v }),
             finalStep: buttonPrimary({
               disabled: !!Utils.computeWorkspaceError(ws) || !!noLaunchReason || isRedacted,
-              tooltip: Utils.computeWorkspaceError(ws) || noLaunchReason || isRedacted && 'Tool version was redacted.',
+              tooltip: Utils.computeWorkspaceError(ws) || noLaunchReason || (isRedacted && 'Tool version was redacted.'),
               onClick: () => this.setState({ launching: true }),
               style: {
                 height: StepButtonParams.buttonHeight, fontSize: StepButtonParams.fontSize

--- a/src/pages/workspaces/workspace/tools/WorkflowView.js
+++ b/src/pages/workspaces/workspace/tools/WorkflowView.js
@@ -431,13 +431,13 @@ const WorkflowView = _.flow(
       const isRedacted = !validationResponse
       const methods = await Methods.list({ namespace: workflowNamespace, name: workflowName })
       const snapshotIds = _.map(m => _.pick('snapshotId', m).snapshotId, methods)
-      const inputsOutputs = !isRedacted && await Methods.configInputsOutputs(config)
+      const inputsOutputs = isRedacted ? {} : await Methods.configInputsOutputs(config)
       this.setState({
         savedConfig: config, modifiedConfig: config,
         currentSnapRedacted: isRedacted, savedSnapRedacted: isRedacted,
         entityMetadata,
-        savedInputsOutputs: isRedacted ? [] : this.sortOptionalInputs(inputsOutputs),
-        modifiedInputsOutputs: isRedacted ? [] : this.sortOptionalInputs(inputsOutputs),
+        savedInputsOutputs: this.sortOptionalInputs(inputsOutputs),
+        modifiedInputsOutputs: this.sortOptionalInputs(inputsOutputs),
         snapshotIds,
         errors: isRedacted ? { inputs: {}, outputs: {} } : augmentErrors(validationResponse),
         entitySelectionModel: this.resetSelectionModel(config.rootEntityType),
@@ -845,11 +845,12 @@ const WorkflowView = _.flow(
   }
 
   cancel() {
-    const { savedConfig, savedInputsOutputs, savedConfig: { rootEntityType }, savedSnapRedacted } = this.state
+    const { savedConfig, savedInputsOutputs, savedConfig: { rootEntityType }, savedSnapRedacted, activeTab } = this.state
 
     this.setState({
       saved: false, modifiedConfig: savedConfig, modifiedInputsOutputs: savedInputsOutputs,
-      entitySelectionModel: this.resetSelectionModel(rootEntityType), currentSnapRedacted: savedSnapRedacted
+      entitySelectionModel: this.resetSelectionModel(rootEntityType), currentSnapRedacted: savedSnapRedacted,
+      activeTab: activeTab === 'wdl' && savedSnapRedacted ? 'inputs' : activeTab
     })
     this.updateSingleOrMultipleRadioState(savedConfig)
   }


### PR DESCRIPTION
When a tool references a redacted method snapshot, it's now possible to view the saved config and change the snapshot to a new one.