### PR TITLE
Remove JupyterLab launch buttons

### DIFF
--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -71,12 +71,6 @@ class NotebookCard extends Component {
           tooltipSide: 'left'
         }, [menuIcon('eye'), 'Open read-only']),
         h(MenuButton, {
-          disabled: !canWrite,
-          tooltip: !canWrite && noWrite,
-          tooltipSide: 'left',
-          onClick: () => Nav.goToPath('workspace-notebook-launch', { namespace, app: 'lab', name: wsName, notebookName: name.slice(10) })
-        }, [menuIcon('jupyterIcon'), 'Open in JupyterLab']),
-        h(MenuButton, {
           onClick: () => onExport()
         }, [menuIcon('export'), 'Copy to another workspace']),
         h(MenuButton, {

--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -87,11 +87,7 @@ class ReadOnlyMessage extends Component {
             as: 'a',
             href: notebookLink,
             style: { marginRight: '1rem' }
-          }, ['edit in Jupyter']),
-          buttonOutline({
-            as: 'a',
-            href: notebookLabLink
-          }, ['edit in JupyterLab'])
+          }, ['edit in Jupyter'])
         ]) :
         buttonOutline({
           onClick: () => this.setState({ copying: true })

--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -75,7 +75,6 @@ class ReadOnlyMessage extends Component {
   render() {
     const { notebookName, workspace, workspace: { canCompute, workspace: { namespace, name } } } = this.props
     const notebookLink = Nav.getLink('workspace-notebook-launch', { namespace, name, notebookName })
-    const notebookLabLink = Nav.getLink('workspace-notebook-launch', { namespace, app: 'lab', name, notebookName })
     const { copying } = this.state
     return div({ style: { padding: '1rem 2rem', display: 'flex', alignItems: 'center' } }, [
       div({ style: { fontSize: 16, fontWeight: 'bold', position: 'absolute' } },


### PR DESCRIPTION
Product has decided that until the data-syncing issues (stale notebooks, clobbering work, etc) are fixed, we should remove the option to launch in JupyterLab from Terra UI. Our plan is to 1) send an email to users who are currently using Lab, 2) remove the options from Terra UI 3) a week or two later, we will disable Lab at the Leo level

Leo ticket: https://github.com/DataBiosphere/leonardo/issues/887