### PR TITLE
add submitted icon

### DIFF
--- a/src/components/job-common.js
+++ b/src/components/job-common.js
@@ -6,18 +6,21 @@ export const collapseStatus = status => {
   switch (status) {
     case 'Succeeded':
       return 'succeeded'
-    case 'Aborting':
+    case 'Aborting': // only on submissions not workflows
     case 'Aborted':
     case 'Failed':
       return 'failed'
-    default:
+    case 'Running':
       return 'running'
+    default:
+      return 'submitted'
   }
 }
 
 export const successIcon = style => icon('check', { size: 24, style: { color: colors.green[0], ...style } })
 export const failedIcon = style => icon('warning-standard', { className: 'is-solid', size: 24, style: { color: colors.red[0], ...style } })
-export const runningIcon = style => icon('sync', { size: 24, style: { color: colors.green[0], ...style } })
+export const runningIcon = style => icon('sync', { size: 24, style: { color: colors.blue[0], ...style } })
+export const submittedIcon = style => icon('clock', { size: 24, style })
 
 export const statusIcon = (status, style) => {
   switch (collapseStatus(status)) {
@@ -25,7 +28,9 @@ export const statusIcon = (status, style) => {
       return successIcon(style)
     case 'failed':
       return failedIcon(style)
-    default:
+    case 'running':
       return runningIcon(style)
+    default:
+      return submittedIcon(style)
   }
 }

--- a/src/pages/workspaces/workspace/JobHistory.js
+++ b/src/pages/workspaces/workspace/JobHistory.js
@@ -6,7 +6,7 @@ import * as breadcrumbs from 'src/components/breadcrumbs'
 import { Clickable, link, spinnerOverlay } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import { SearchInput } from 'src/components/input'
-import { collapseStatus, failedIcon, runningIcon, successIcon } from 'src/components/job-common'
+import { collapseStatus, failedIcon, runningIcon, submittedIcon, successIcon } from 'src/components/job-common'
 import Modal from 'src/components/Modal'
 import { FlexTable, HeaderCell, TextCell, TooltipCell } from 'src/components/table'
 import TooltipTrigger from 'src/components/TooltipTrigger'
@@ -45,7 +45,7 @@ const collapsedStatuses = _.flow(
 )
 
 const statusCell = workflowStatuses => {
-  const { succeeded, failed, running } = collapsedStatuses(workflowStatuses)
+  const { succeeded, failed, running, submitted } = collapsedStatuses(workflowStatuses)
 
   return h(TooltipTrigger, {
     side: 'bottom',
@@ -55,12 +55,14 @@ const statusCell = workflowStatuses => {
         tr({}, [
           td(styles.statusDetailCell, [successIcon()]),
           td(styles.statusDetailCell, [failedIcon()]),
-          td(styles.statusDetailCell, [runningIcon()])
+          td(styles.statusDetailCell, [runningIcon()]),
+          td(styles.statusDetailCell, [submittedIcon()])
         ]),
         tr({}, [
           td(styles.statusDetailCell, [succeeded || 0]),
           td(styles.statusDetailCell, [failed || 0]),
-          td(styles.statusDetailCell, [running || 0])
+          td(styles.statusDetailCell, [running || 0]),
+          td(styles.statusDetailCell, [submitted || 0])
         ])
       ])
     ])
@@ -68,7 +70,8 @@ const statusCell = workflowStatuses => {
     div([
       succeeded && successIcon({ marginRight: '0.5rem' }),
       failed && failedIcon({ marginRight: '0.5rem' }),
-      running && runningIcon({ marginRight: '0.5rem' })
+      running && runningIcon({ marginRight: '0.5rem' }),
+      submitted && submittedIcon({ marginRight: '0.5rem' })
     ])
   ])
 }
@@ -203,7 +206,7 @@ const JobHistory = _.flow(
                     status, submissionEntity
                   } = filteredSubmissions[rowIndex]
                   return h(Fragment, [
-                    statusCell(workflowStatuses), status === 'Aborting' && 'Aborting',
+                    statusCell(workflowStatuses), _.keys(collapsedStatuses(workflowStatuses)).length === 1 && status,
                     (collapsedStatuses(workflowStatuses).running && status !== 'Aborting') && h(TooltipTrigger, {
                       content: 'Abort all workflows'
                     }, [
@@ -227,7 +230,7 @@ const JobHistory = _.flow(
                           onDone: () => this.refresh()
                         })
                       }, [
-                        icon('sync', { size: 18, style: { color: colors.green[0], marginLeft: '0.5rem' } })
+                        icon('refresh', { size: 18, style: { color: colors.green[0], marginLeft: '0.5rem' } })
                       ])
                     ])
                   ])

--- a/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
+++ b/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
@@ -6,7 +6,7 @@ import * as breadcrumbs from 'src/components/breadcrumbs'
 import { link, Select } from 'src/components/common'
 import { centeredSpinner, icon } from 'src/components/icons'
 import { textInput } from 'src/components/input'
-import { collapseStatus, failedIcon, runningIcon, statusIcon, successIcon } from 'src/components/job-common'
+import { collapseStatus, failedIcon, runningIcon, statusIcon, submittedIcon, successIcon } from 'src/components/job-common'
 import { FlexTable, Sortable, TextCell, TooltipCell } from 'src/components/table'
 import TooltipTrigger from 'src/components/TooltipTrigger'
 import { Ajax, useCancellation } from 'src/libs/ajax'
@@ -122,8 +122,7 @@ const SubmissionDetails = _.flow(
     sort.direction === 'asc' ? _.identity : _.reverse
   )(workflows)
 
-  const { succeeded, failed, running } = _.groupBy(wf => collapseStatus(wf.status), workflows)
-
+  const { succeeded, failed, running, submitted } = _.groupBy(wf => collapseStatus(wf.status), workflows)
   /*
    * Page render
    */
@@ -133,7 +132,8 @@ const SubmissionDetails = _.flow(
         div({ style: Style.elements.sectionHeader }, 'Workflow Statuses'),
         succeeded && makeStatusLine(successIcon, `Succeeded: ${succeeded.length}`),
         failed && makeStatusLine(failedIcon, `Failed: ${failed.length}`),
-        running && makeStatusLine(runningIcon, `Running: ${running.length}`)
+        running && makeStatusLine(runningIcon, `Running: ${running.length}`),
+        submitted && makeStatusLine(submittedIcon, `Submitted: ${submitted.length}`)
       ]),
       div({ style: { display: 'flex', flexWrap: 'wrap' } }, [
         makeSection('Workflow Configuration',


### PR DESCRIPTION
Adding a submitted icon for all statuses prior to "Running" (Queued, Launching, and Submitted). Made some minor changes along the way: 
- changed running icon to blue 
- changed re-run failures to a different icon so it was different from the running icon. 
- display the status next to the icon if there is only one icon. (Allowed users to see when a status is "aborting", but also avoids having like potentially 2-4 icons AND text).  