### PR TITLE
filter workspaces by submission status

### DIFF
--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -295,7 +295,8 @@ export const WorkspaceList = _.flow(
       h(PageBox, { style: { position: 'relative' } }, [
         div({ style: { display: 'flex', alignItems: 'center', marginBottom: '1rem' } }, [
           div({ style: { ...Style.elements.sectionHeader, textTransform: 'uppercase' } }, ['Workspaces']),
-          div({ style: { marginLeft: 'auto', flex: '0 0 300px' } }, [
+          div({ style: { flex: 1 } }),
+          div({ style: { marginLeft: '1rem', flex: '0 0 300px' } }, [
             h(Select, {
               isClearable: true,
               isMulti: true,


### PR DESCRIPTION
Fixes #1481 

To make things fit, this also rearranges the filters into two rows.