### PR TITLE
delay NIH status check until user is registered

### DIFF
--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -212,7 +212,7 @@ authStore.subscribe(withErrorReporting('Error loading NIH account link status', 
       }
     }
   }
-  if (!oldState.isSignedIn && state.isSignedIn) {
+  if (oldState.registrationStatus !== 'registered' && state.registrationStatus === 'registered') {
     const nihStatus = await loadNihStatus()
     authStore.update(_.set('nihStatus', nihStatus))
   }


### PR DESCRIPTION
This fixes an error popup that new users were seeing. By waiting until the user is definitely registered, this check should succeed.