### PR TITLE
tweak workspace sharing UI

### DIFF
--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -84,7 +84,7 @@ export const formatNumber = new Intl.NumberFormat('en-US').format
 
 export const workspaceAccessLevels = ['NO ACCESS', 'READER', 'WRITER', 'OWNER', 'PROJECT_OWNER']
 
-const hasAccessLevel = _.curry((required, current) => {
+export const hasAccessLevel = _.curry((required, current) => {
   return workspaceAccessLevels.indexOf(current) >= workspaceAccessLevels.indexOf(required)
 })
 

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -369,8 +369,7 @@ export const WorkspaceList = _.flow(
           onSuccess: () => refreshWorkspaces()
         }),
         sharingWorkspaceId && h(ShareWorkspaceModal, {
-          namespace: this.getWorkspace(sharingWorkspaceId).workspace.namespace,
-          name: this.getWorkspace(sharingWorkspaceId).workspace.name,
+          workspace: this.getWorkspace(sharingWorkspaceId),
           onDismiss: () => { this.setState({ sharingWorkspaceId: undefined }) }
         }),
         loadingWorkspaces && (!workspaces ? transparentSpinnerOverlay : topSpinnerOverlay)

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -134,7 +134,7 @@ class WorkspaceContainer extends Component {
         onSuccess: ({ namespace, name }) => Nav.goToPath('workspace-dashboard', { namespace, name })
       }),
       sharingWorkspace && h(ShareWorkspaceModal, {
-        namespace, name,
+        workspace,
         onDismiss: () => this.setState({ sharingWorkspace: false })
       })
     ])


### PR DESCRIPTION
Fixes #1523 

This disallows selecting permissions higher than you currently have in the sharing modal. Note that there are outstanding bugs with how the backend handles this data, so this is not a comprehensive solution. However, it does cover one specific case that we know should be disallowed, so it's an improvement.