### PR TITLE
formalize common search components

### DIFF
--- a/src/components/DataTable.js
+++ b/src/components/DataTable.js
@@ -2,9 +2,9 @@ import _ from 'lodash/fp'
 import { createRef, Fragment } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
 import { AutoSizer } from 'react-virtualized'
-import { buttonPrimary, Checkbox, Clickable, linkButton, MenuButton, RadioButton, spinnerOverlay } from 'src/components/common'
+import { Checkbox, Clickable, linkButton, MenuButton, RadioButton, spinnerOverlay } from 'src/components/common'
 import { icon } from 'src/components/icons'
-import { SearchInput } from 'src/components/input'
+import { ConfirmedSearchInput } from 'src/components/input'
 import Modal from 'src/components/Modal'
 import PopupTrigger from 'src/components/PopupTrigger'
 import { ColumnSelector, GridTable, HeaderCell, paginator, Resizable, Sortable } from 'src/components/table'
@@ -45,7 +45,6 @@ export default ajaxCaller(class DataTable extends Component {
       entities,
       totalRowCount = 0, itemsPerPage = 25, pageNumber = 1,
       sort = { field: 'name', direction: 'asc' },
-      textFilter = '',
       activeTextFilter = '',
       columnWidths = {}, columnState = {}
     } = props.firstRender ? StateHistory.get() : {}
@@ -54,7 +53,7 @@ export default ajaxCaller(class DataTable extends Component {
     this.state = {
       loading: false,
       viewData: undefined,
-      entities, totalRowCount, itemsPerPage, pageNumber, sort, textFilter, activeTextFilter, columnWidths, columnState
+      entities, totalRowCount, itemsPerPage, pageNumber, sort, activeTextFilter, columnWidths, columnState
     }
   }
 
@@ -66,7 +65,7 @@ export default ajaxCaller(class DataTable extends Component {
       childrenBefore
     } = this.props
 
-    const { loading, entities, totalRowCount, itemsPerPage, pageNumber, sort, columnWidths, columnState, viewData, textFilter } = this.state
+    const { loading, entities, totalRowCount, itemsPerPage, pageNumber, sort, columnWidths, columnState, viewData, activeTextFilter } = this.state
 
     const theseColumnWidths = columnWidths[entityType] || {}
     const columnSettings = applyColumnSettings(columnState[entityType] || [], entityMetadata[entityType].attributeNames)
@@ -79,18 +78,12 @@ export default ajaxCaller(class DataTable extends Component {
         div({ style: { display: 'flex', marginBottom: '1rem' } }, [
           childrenBefore && childrenBefore({ entities, columnSettings }),
           div({ style: { flexGrow: 1 } }),
-          div({ style: { display: 'flex' } }, [
-            h(SearchInput, {
-              style: { width: 300, borderRadius: '4px 0 0 4px' },
-              placeholder: 'Filter',
-              onChange: ({ target: { value } }) => this.setState({ textFilter: value }),
-              onSearch: ({ target: { value } }) => this.setState({ activeTextFilter: value }),
-              value: textFilter
-            }),
-            buttonPrimary({
-              style: { borderRadius: '0 4px 4px 0', borderLeft: 'none' },
-              onClick: () => this.setState({ activeTextFilter: textFilter })
-            }, [icon('search', { size: 18 })])
+          div({ style: { width: 300 } }, [
+            h(ConfirmedSearchInput, {
+              placeholder: 'Search',
+              onChange: v => this.setState({ activeTextFilter: v }),
+              defaultValue: activeTextFilter
+            })
           ])
         ]),
         div({ style: { flex: 1 } }, [
@@ -226,7 +219,7 @@ export default ajaxCaller(class DataTable extends Component {
     }
     if (this.props.persist) {
       StateHistory.update(
-        _.pick(['itemsPerPage', 'pageNumber', 'sort', 'textFilter', 'activeTextFilter', 'columnWidths', 'columnState'], this.state))
+        _.pick(['itemsPerPage', 'pageNumber', 'sort', 'activeTextFilter', 'columnWidths', 'columnState'], this.state))
     }
   }
 

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -100,24 +100,6 @@ export const buttonOutline = ({ disabled, ...props }, children) => {
   }, props), children)
 }
 
-export const search = function({ wrapperProps, inputProps }) {
-  return div(
-    _.merge({ style: { padding: '0.5rem 0.2rem', display: 'flex', backgroundColor: 'white', borderRadius: 3 } },
-      wrapperProps),
-    [
-      icon('search', { size: 21 }),
-      input(_.merge({
-        style: {
-          border: 'none', outline: 'none',
-          flexGrow: 1,
-          verticalAlign: 'bottom', marginLeft: '1rem',
-          fontSize: '1rem',
-          backgroundColor: 'transparent'
-        }
-      }, inputProps))
-    ])
-}
-
 export const tabBar = ({ activeTab, tabNames, refresh = _.noop, getHref }, children = []) => {
   const navTab = currentTab => {
     const selected = currentTab === activeTab

--- a/src/components/input.js
+++ b/src/components/input.js
@@ -1,11 +1,11 @@
 import _ from 'lodash/fp'
 import PropTypes from 'prop-types'
-import { Component, createRef, Fragment, useRef } from 'react'
+import { Component, createRef, Fragment, useRef, useState } from 'react'
 import Autosuggest from 'react-autosuggest'
-import { createPortal, findDOMNode } from 'react-dom'
+import { createPortal } from 'react-dom'
 import { div, h } from 'react-hyperscript-helpers'
 import Interactive from 'react-interactive'
-import { search } from 'src/components/common'
+import { buttonPrimary } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import colors from 'src/libs/colors'
 import * as Utils from 'src/libs/utils'
@@ -56,38 +56,57 @@ export const textInput = props => h(Interactive,
   props)
 )
 
-export const SearchInput = ({ onSearch = _.noop, onChange, ...props }) => {
-  const supportsSearch = 'onsearch' in document.documentElement
+export const ConfirmedSearchInput = ({ defaultValue = '', onChange = _.noop, ...props }) => {
+  const [internalValue, setInternalValue] = useState(defaultValue)
+  return div({ style: { display: 'inline-flex', width: '100%' } }, [
+    textInput(_.merge({
+      type: 'search',
+      refDOMNode: el => {
+        el.addEventListener('search', e => {
+          setInternalValue(e.target.value)
+          onChange(e.target.value)
+        })
+      },
+      spellCheck: false,
+      style: { WebkitAppearance: 'none', borderColor: colors.gray[3], borderRadius: '4px 0 0 4px' },
+      value: internalValue,
+      onChange: e => setInternalValue(e.target.value),
+      onKeyDown: e => {
+        if (e.key === 'Enter') {
+          e.preventDefault()
+          onChange(internalValue)
+        } else if (e.key === 'Escape' && internalValue !== '') {
+          e.preventDefault()
+          e.stopPropagation()
+          setInternalValue('')
+          onChange('')
+        }
+      }
+    }, props)),
+    buttonPrimary({
+      style: { borderRadius: '0 4px 4px 0', borderLeft: 'none' },
+      onClick: () => onChange(internalValue)
+    }, [icon('search', { size: 18 })])
+  ])
+}
 
-  const searchEl = useRef()
-  const attachRef = node => {
-    if (node) {
-      const el = findDOMNode(node)
-      searchEl.current = el
-      el.addEventListener('search', onSearch)
-    } else {
-      searchEl.current.removeEventListener('search', onSearch)
-    }
-  }
-
+export const DelayedSearchInput = ({ defaultValue = '', onChange = _.noop, ...props }) => {
+  const [internalValue, setInternalValue] = useState(defaultValue)
+  const updateFn = useRef(_.debounce(250, onChange))
   return textInput(_.merge({
-    ref: attachRef,
     type: 'search',
     spellCheck: false,
     style: { WebkitAppearance: 'none', borderColor: colors.gray[3] },
-    onChange,
-    onKeyDown: supportsSearch ? undefined : e => { // to make firefox behave like webkit/blink
-      switch (e.which) {
-        case 13: // return
-          onSearch(e)
-          break
-        case 27: // escape
-          e.persist()
-          const touchedEvent = _.merge(e, { target: { value: '' } })
-          onChange(touchedEvent)
-          onSearch(touchedEvent)
-          break
-        default:
+    value: internalValue,
+    onChange: e => {
+      setInternalValue(e.target.value)
+      updateFn.current(e.target.value)
+    },
+    onKeyDown: e => {
+      if (e.key === 'Escape' && internalValue !== '') {
+        e.stopPropagation()
+        setInternalValue('')
+        updateFn.current('')
       }
     }
   }, props))
@@ -323,7 +342,7 @@ export class AutocompleteSearch extends Component {
         ])
       },
       renderSuggestion,
-      renderInputComponent: renderInputComponent || (inputProps => search({ inputProps })),
+      renderInputComponent: renderInputComponent || (inputProps => textInput({ inputProps })),
       theme: _.merge({
         container: { width: '100%' },
         suggestionsList: { margin: 0, padding: 0 },

--- a/src/pages/StyleGuide.js
+++ b/src/pages/StyleGuide.js
@@ -1,8 +1,8 @@
 import _ from 'lodash/fp'
 import { div, h, span } from 'react-hyperscript-helpers'
 import { AutoSizer } from 'react-virtualized'
-import { buttonPrimary, buttonSecondary, Checkbox, link, RadioButton, search } from 'src/components/common'
-import { textInput, validatedInput } from 'src/components/input'
+import { buttonPrimary, buttonSecondary, Checkbox, link, RadioButton } from 'src/components/common'
+import { ConfirmedSearchInput, DelayedSearchInput, textInput, validatedInput } from 'src/components/input'
 import Modal from 'src/components/Modal'
 import PopupTrigger from 'src/components/PopupTrigger'
 import { FlexTable, GridTable, HeaderCell, TextCell } from 'src/components/table'
@@ -127,7 +127,10 @@ class StyleGuide extends Component {
         ])
       ]),
       els.section('Search Box', [
-        search({ inputProps: { placeholder: 'Search' } })
+        els.columns([
+          els.fixWidth('30%', [h(DelayedSearchInput, { placeholder: 'Debounced search' })]),
+          els.fixWidth('30%', [h(ConfirmedSearchInput, { placeholder: 'Search with explicit confirmation' })])
+        ])
       ]),
       els.section('Text Box', [
         els.columns([

--- a/src/pages/groups/Group.js
+++ b/src/pages/groups/Group.js
@@ -1,8 +1,9 @@
 import _ from 'lodash/fp'
 import { Fragment } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
-import { PageBox, search, spinnerOverlay } from 'src/components/common'
+import { PageBox, spinnerOverlay } from 'src/components/common'
 import { DeleteUserModal, EditUserModal, MemberCard, NewUserCard, NewUserModal } from 'src/components/group-common'
+import { DelayedSearchInput } from 'src/components/input'
 import TopBar from 'src/components/TopBar'
 import { ajaxCaller } from 'src/libs/ajax'
 import { reportError } from 'src/libs/error'
@@ -63,13 +64,11 @@ export const GroupDetails = ajaxCaller(class GroupDetails extends Component {
 
     return h(Fragment, [
       h(TopBar, { title: 'Groups', href: Nav.getLink('groups') }, [
-        search({
-          wrapperProps: { style: { marginLeft: '2rem', flexGrow: 1, maxWidth: 500 } },
-          inputProps: {
-            placeholder: 'SEARCH GROUP',
-            onChange: e => this.setState({ filter: e.target.value }),
-            value: filter
-          }
+        h(DelayedSearchInput, {
+          style: { marginLeft: '2rem', width: 500 },
+          placeholder: 'SEARCH GROUP',
+          onChange: v => this.setState({ filter: v }),
+          defaultValue: filter
         })
       ]),
       h(PageBox, [

--- a/src/pages/groups/List.js
+++ b/src/pages/groups/List.js
@@ -2,9 +2,9 @@ import _ from 'lodash/fp'
 import { Fragment } from 'react'
 import { a, b, div, h } from 'react-hyperscript-helpers'
 import { pure } from 'recompose'
-import { buttonPrimary, Clickable, linkButton, PageBox, search, spinnerOverlay } from 'src/components/common'
+import { buttonPrimary, Clickable, linkButton, PageBox, spinnerOverlay } from 'src/components/common'
 import { icon } from 'src/components/icons'
-import { validatedInput } from 'src/components/input'
+import { DelayedSearchInput, validatedInput } from 'src/components/input'
 import Modal from 'src/components/Modal'
 import TopBar from 'src/components/TopBar'
 import { ajaxCaller } from 'src/libs/ajax'
@@ -171,13 +171,11 @@ export const GroupList = ajaxCaller(class GroupList extends Component {
     const { ajax: { Groups } } = this.props
     return h(Fragment, [
       h(TopBar, { title: 'Groups' }, [
-        search({
-          wrapperProps: { style: { marginLeft: '2rem', flexGrow: 1, maxWidth: 500 } },
-          inputProps: {
-            placeholder: 'SEARCH GROUPS',
-            onChange: e => this.setState({ filter: e.target.value }),
-            value: filter
-          }
+        h(DelayedSearchInput, {
+          style: { marginLeft: '2rem', width: 500 },
+          placeholder: 'SEARCH GROUPS',
+          onChange: v => this.setState({ filter: v }),
+          defaultValue: filter
         })
       ]),
       h(PageBox, [

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -1,13 +1,14 @@
 import _ from 'lodash/fp'
-import { Fragment, useRef, useState } from 'react'
+import { Fragment, useState } from 'react'
 import { a, div, h, span } from 'react-hyperscript-helpers'
 import { pure } from 'recompose'
 import removeMd from 'remove-markdown'
 import togglesListView from 'src/components/CardsListToggle'
 import {
-  Clickable, LabeledCheckbox, linkButton, MenuButton, menuIcon, PageBox, search, Select, topSpinnerOverlay, transparentSpinnerOverlay
+  Clickable, LabeledCheckbox, linkButton, MenuButton, menuIcon, PageBox, Select, topSpinnerOverlay, transparentSpinnerOverlay
 } from 'src/components/common'
 import { icon } from 'src/components/icons'
+import { DelayedSearchInput } from 'src/components/input'
 import NewWorkspaceModal from 'src/components/NewWorkspaceModal'
 import PopupTrigger from 'src/components/PopupTrigger'
 import TooltipTrigger from 'src/components/TooltipTrigger'
@@ -91,23 +92,6 @@ const workspaceSubmissionStatus = ({ workspaceSubmissionStats: { runningSubmissi
     [lastSuccessDate && (!lastFailureDate || new Date(lastSuccessDate) > new Date(lastFailureDate)), () => 'success'],
     [lastFailureDate, () => 'failure'],
   )
-}
-
-const WsSearch = ({ onChange }) => {
-  const [filter, setFilter] = useState('')
-  const updateParent = useRef(_.debounce(100, onChange))
-
-  return search({
-    wrapperProps: { style: { marginLeft: '2rem', flexGrow: 1, maxWidth: 500 } },
-    inputProps: {
-      placeholder: 'SEARCH WORKSPACES',
-      onChange: ({ target: { value } }) => {
-        setFilter(value)
-        updateParent.current(value)
-      },
-      value: filter
-    }
-  })
 }
 
 const WorkspaceMenuContent = ({ namespace, name, onClone, onShare, onDelete }) => {
@@ -309,7 +293,14 @@ export const WorkspaceList = _.flow(
       })
     }, data)
     return h(Fragment, [
-      h(TopBar, { title: 'Workspaces' }, [h(WsSearch, { onChange: v => this.setState({ filter: v }) })]),
+      h(TopBar, { title: 'Workspaces' }, [
+        h(DelayedSearchInput, {
+          style: { marginLeft: '2rem', width: 500 },
+          placeholder: 'SEARCH WORKSPACES',
+          onChange: v => this.setState({ filter: v }),
+          defaultValue: filter
+        })
+      ]),
       h(PageBox, { style: { position: 'relative' } }, [
         div({ style: { display: 'flex', alignItems: 'center', marginBottom: '1rem' } }, [
           div({ style: { ...Style.elements.sectionHeader, textTransform: 'uppercase' } }, ['Workspaces']),

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -12,7 +12,7 @@ import DataTable from 'src/components/DataTable'
 import ExportDataModal from 'src/components/ExportDataModal'
 import FloatingActionButton from 'src/components/FloatingActionButton'
 import { icon, spinner } from 'src/components/icons'
-import { SearchInput, textInput } from 'src/components/input'
+import { DelayedSearchInput, textInput } from 'src/components/input'
 import Modal from 'src/components/Modal'
 import { FlexTable, HeaderCell, SimpleTable, TextCell } from 'src/components/table'
 import UriViewer from 'src/components/UriViewer'
@@ -167,11 +167,11 @@ const LocalVariablesContent = ajaxCaller(class LocalVariablesContent extends Com
           div({ style: { whiteSpace: 'pre' } }, ['  |  Drag or click to ']),
           linkButton({ onClick: () => this.uploader.current.open() }, ['upload TSV'])
         ]),
-        h(SearchInput, {
+        h(DelayedSearchInput, {
           style: { width: 300, marginLeft: '1rem' },
-          placeholder: 'Filter',
-          onChange: ({ target: { value } }) => this.setState({ textFilter: value }),
-          value: textFilter
+          placeholder: 'Search',
+          onChange: v => this.setState({ textFilter: v }),
+          defaultValue: textFilter
         })
       ]),
       Utils.cond(
@@ -303,11 +303,11 @@ const ReferenceDataContent = ({ workspace: { workspace: { namespace, attributes 
   const { initialY } = firstRender ? StateHistory.get() : {}
 
   return h(Fragment, [
-    h(SearchInput, {
+    h(DelayedSearchInput, {
       style: { width: 300, marginBottom: '1rem', alignSelf: 'flex-end' },
-      placeholder: 'Filter',
-      onChange: ({ target: { value } }) => setTextFilter(value),
-      value: textFilter
+      placeholder: 'Search',
+      onChange: setTextFilter,
+      defaultValue: textFilter
     }),
     div({ style: { flex: 1 } }, [
       h(AutoSizer, [

--- a/src/pages/workspaces/workspace/JobHistory.js
+++ b/src/pages/workspaces/workspace/JobHistory.js
@@ -5,7 +5,7 @@ import { AutoSizer } from 'react-virtualized'
 import * as breadcrumbs from 'src/components/breadcrumbs'
 import { Clickable, link, spinnerOverlay } from 'src/components/common'
 import { icon } from 'src/components/icons'
-import { SearchInput } from 'src/components/input'
+import { DelayedSearchInput } from 'src/components/input'
 import { collapseStatus, failedIcon, runningIcon, submittedIcon, successIcon } from 'src/components/job-common'
 import Modal from 'src/components/Modal'
 import PopupTrigger from 'src/components/PopupTrigger'
@@ -143,11 +143,11 @@ const JobHistory = _.flow(
           content: div({ style: { margin: '0.5rem' } }, [h(SubmissionQueueStatus)]),
           side: 'bottom'
         }, [link({}, ['Queue Status'])]),
-        h(SearchInput, {
+        h(DelayedSearchInput, {
           style: { width: 300, marginLeft: '1rem' },
-          placeholder: 'Filter',
-          onChange: ({ target: { value } }) => this.setState({ textFilter: value }),
-          value: textFilter
+          placeholder: 'Search',
+          onChange: v => this.setState({ textFilter: v }),
+          defaultValue: textFilter
         })
       ]),
       div({ style: styles.submissionsTable }, [

--- a/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
+++ b/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
@@ -5,7 +5,7 @@ import { AutoSizer } from 'react-virtualized'
 import * as breadcrumbs from 'src/components/breadcrumbs'
 import { link, Select } from 'src/components/common'
 import { centeredSpinner, icon } from 'src/components/icons'
-import { textInput } from 'src/components/input'
+import { DelayedSearchInput } from 'src/components/input'
 import { collapseStatus, failedIcon, runningIcon, statusIcon, submittedIcon, successIcon } from 'src/components/job-common'
 import PopupTrigger from 'src/components/PopupTrigger'
 import { FlexTable, Sortable, TextCell, TooltipCell } from 'src/components/table'
@@ -169,11 +169,11 @@ const SubmissionDetails = _.flow(
       ])
     ]),
     div({ style: { margin: '1rem 0', display: 'flex', alignItems: 'center' } }, [
-      textInput({
+      h(DelayedSearchInput, {
         style: { marginRight: '2rem', flexBasis: 300, borderColor: colors.gray[3] },
-        placeholder: 'Filter',
-        onChange: ({ target: { value } }) => setTextFilter(value),
-        value: textFilter
+        placeholder: 'Search',
+        onChange: setTextFilter,
+        defaultValue: textFilter
       }),
       div({ style: { flexBasis: 350 } }, [
         h(Select, {


### PR DESCRIPTION
This unifies our various common search components into two:
* `DelayedSearchInput` - debounces keystrokes and calls `onChange` after a short delay.
* `ConfirmedSearchInput` - allows free typing, and only calls `onChange` after explicitly pressing the icon button or the Enter key.

Other changes, per Jerome:
* Removed the decorative magnifying glass icon
* Changed the placeholder text to 'Search' instead of 'Filter'