### PR TITLE
Embed Data Explorers for other datasets

### DIFF
--- a/src/pages/library/DataExplorer.js
+++ b/src/pages/library/DataExplorer.js
@@ -9,7 +9,11 @@ import * as Style from 'src/libs/style'
 
 const datasetToUrl = {
   // key must be dataset name from Data Explorer dataset.json
-  '1000 Genomes': 'https://test-data-explorer.appspot.com/?embed'
+  '1000 Genomes': 'https://test-data-explorer.appspot.com/?embed',
+  'AMP PD - 2019_v1beta_0220': 'https://amp-pd-data-explorer.appspot.com/?embed',
+  'Baseline Health Study': 'https://baseline-baseline-explorer.appspot.com/?embed',
+  'Nurses\' Health Study': 'https://nhs-explorer.appspot.com/?embed',
+  'UK Biobank': 'https://biobank-explorer.appspot.com/?embed'
 }
 
 

--- a/src/pages/library/Datasets.js
+++ b/src/pages/library/Datasets.js
@@ -127,8 +127,7 @@ const thousandGenomes = () => h(Participant, {
 }, [
   buttonPrimary({
     as: 'a',
-    href: Nav.getLink('library-datasets-data-explorer', { dataset: '1000 Genomes' }),
-    tooltip: browseTooltip
+    href: Nav.getLink('library-datasets-data-explorer', { dataset: '1000 Genomes' })
   }, ['Browse data'])
 ])
 
@@ -161,9 +160,7 @@ const amppd = () => h(Participant, {
 }, [
   buttonPrimary({
     as: 'a',
-    href: 'http://amp-pd-data-explorer.appspot.com/',
-    target: '_blank',
-    tooltip: browseTooltip
+    href: Nav.getLink('library-datasets-data-explorer', { dataset: 'AMP PD - 2019_v1beta_0220' })
   }, ['Browse Data'])
 ])
 
@@ -181,9 +178,7 @@ const baseline = () => h(Participant, {
 }, [
   buttonPrimary({
     as: 'a',
-    href: 'https://baseline-baseline-explorer.appspot.com/',
-    target: '_blank',
-    tooltip: browseTooltip
+    href: Nav.getLink('library-datasets-data-explorer', { dataset: 'Baseline Health Study' })
   }, ['Browse Data'])
 ])
 
@@ -270,9 +265,7 @@ const nhs = () => h(Participant, {
 }, [
   buttonPrimary({
     as: 'a',
-    href: 'http://nhs-explorer.appspot.com/',
-    target: '_blank',
-    tooltip: browseTooltip
+    href: Nav.getLink('library-datasets-data-explorer', { dataset: `Nurses' Health Study` })
   }, ['Browse Data'])
 ])
 
@@ -300,9 +293,7 @@ const ukb = () => h(Participant, {
 }, [
   buttonPrimary({
     as: 'a',
-    href: 'https://biobank-explorer.appspot.com/',
-    target: '_blank',
-    tooltip: browseTooltip
+    href: Nav.getLink('library-datasets-data-explorer', { dataset: 'UK Biobank' })
   }, ['Browse Data'])
 ])
 


### PR DESCRIPTION
Part of #1457.

"Browse data" tooltip has "Export to Terra icon". This is out of date. Rather than update the tooltip, I deleted it, because Save button is pretty obvious.

These Data Explorers are private. [Identity-Aware Proxy](https://cloud.google.com/iap/docs/) is used to restrict who can see them to a Google group (that corresponds with a SAM group).

Future PRs will handle different auth cases. Here's my current thinking.
- If user is not signed into Google at all (not just not registered with Terra), "Browse data" button opens login window/account switcher for DE
- If user has registered with Terra and is not in dataset's auth domain, "Browse data" button opens up login window/account switcher for DE. If applicable, also show "Apply for access" button. To detect this case, I will hard-code each dataset's auth domain and fetch the user's SAM groups.