### PR TITLE
fix output defaults on incomplete workflow configs

### DIFF
--- a/src/pages/workspaces/workspace/tools/WorkflowView.js
+++ b/src/pages/workspaces/workspace/tools/WorkflowView.js
@@ -801,11 +801,9 @@ const WorkflowView = _.flow(
           onBrowse: name => this.setState({ variableSelected: name }),
           onChange: (name, v) => this.setState(_.set(['modifiedConfig', key, name], v)),
           onSetDefaults: () => {
-            this.setState(_.update(['modifiedConfig', 'outputs'], _.flow(
-              _.toPairs,
-              _.map(([k, v]) => [k, v || `this.${_.last(k.split('.'))}`]),
-              _.fromPairs
-            )))
+            this.setState(_.set(['modifiedConfig', 'outputs'], _.fromPairs(_.map(({ name }) => {
+              return [name, modifiedConfig.outputs[name] || `this.${_.last(name.split('.'))}`]
+            }, modifiedInputsOutputs.outputs))))
           },
           suggestions
         })


### PR DESCRIPTION
Fixes #1362 

The issue is that method configs don't have to have values present for all inputs/outputs. Updating the existing list will miss values in that case. Instead, generate the new values from the original I/O definitions.