### PR TITLE
misc data table improvements

### DIFF
--- a/src/components/DataTable.js
+++ b/src/components/DataTable.js
@@ -81,7 +81,7 @@ export default ajaxCaller(class DataTable extends Component {
           div({ style: { width: 300 } }, [
             h(ConfirmedSearchInput, {
               placeholder: 'Search',
-              onChange: v => this.setState({ activeTextFilter: v }),
+              onChange: v => this.setState({ activeTextFilter: v, pageNumber: 1 }),
               defaultValue: activeTextFilter
             })
           ])
@@ -103,6 +103,7 @@ export default ajaxCaller(class DataTable extends Component {
                       return h(Fragment, [
                         h(Checkbox, {
                           checked: this.pageSelected(),
+                          disabled: !entities.length,
                           onChange: () => this.pageSelected() ? this.deselectPage() : this.selectPage()
                         }),
                         h(PopupTrigger, {
@@ -233,11 +234,11 @@ export default ajaxCaller(class DataTable extends Component {
 
     try {
       this.setState({ loading: true })
-      const { results, resultMetadata: { unfilteredCount } } = await Workspaces.workspace(namespace, name)
+      const { results, resultMetadata: { filteredCount } } = await Workspaces.workspace(namespace, name)
         .paginatedEntitiesOfType(entityType, {
           page: pageNumber, pageSize: itemsPerPage, sortField: sort.field, sortDirection: sort.direction, filterTerms: activeTextFilter
         })
-      this.setState({ entities: results, totalRowCount: unfilteredCount })
+      this.setState({ entities: results, totalRowCount: filteredCount })
     } catch (error) {
       reportError('Error loading entities', error)
     } finally {
@@ -280,7 +281,7 @@ export default ajaxCaller(class DataTable extends Component {
     const { entities } = this.state
     const entityKeys = _.map('name', entities)
     const selectedKeys = _.keys(selected)
-    return _.every(k => _.includes(k, selectedKeys), entityKeys)
+    return entities.length && _.every(k => _.includes(k, selectedKeys), entityKeys)
   }
 
   displayData(selectedData) {

--- a/src/components/DataTable.js
+++ b/src/components/DataTable.js
@@ -43,7 +43,7 @@ export default ajaxCaller(class DataTable extends Component {
 
     const {
       entities,
-      totalRowCount = 0, itemsPerPage = 25, pageNumber = 1,
+      filteredCount = 0, totalRowCount = 0, itemsPerPage = 25, pageNumber = 1,
       sort = { field: 'name', direction: 'asc' },
       activeTextFilter = '',
       columnWidths = {}, columnState = {}
@@ -53,7 +53,7 @@ export default ajaxCaller(class DataTable extends Component {
     this.state = {
       loading: false,
       viewData: undefined,
-      entities, totalRowCount, itemsPerPage, pageNumber, sort, activeTextFilter, columnWidths, columnState
+      entities, filteredCount, totalRowCount, itemsPerPage, pageNumber, sort, activeTextFilter, columnWidths, columnState
     }
   }
 
@@ -65,7 +65,7 @@ export default ajaxCaller(class DataTable extends Component {
       childrenBefore
     } = this.props
 
-    const { loading, entities, totalRowCount, itemsPerPage, pageNumber, sort, columnWidths, columnState, viewData, activeTextFilter } = this.state
+    const { loading, entities, filteredCount, totalRowCount, itemsPerPage, pageNumber, sort, columnWidths, columnState, viewData, activeTextFilter } = this.state
 
     const theseColumnWidths = columnWidths[entityType] || {}
     const columnSettings = applyColumnSettings(columnState[entityType] || [], entityMetadata[entityType].attributeNames)
@@ -192,7 +192,8 @@ export default ajaxCaller(class DataTable extends Component {
         ]),
         div({ style: { flex: 'none', marginTop: '1rem' } }, [
           paginator({
-            filteredDataLength: totalRowCount,
+            filteredDataLength: filteredCount,
+            unfilteredDataLength: totalRowCount,
             pageNumber,
             setPageNumber: v => this.setState({ pageNumber: v }, resetScroll),
             itemsPerPage,
@@ -234,11 +235,11 @@ export default ajaxCaller(class DataTable extends Component {
 
     try {
       this.setState({ loading: true })
-      const { results, resultMetadata: { filteredCount } } = await Workspaces.workspace(namespace, name)
+      const { results, resultMetadata: { filteredCount, unfilteredCount } } = await Workspaces.workspace(namespace, name)
         .paginatedEntitiesOfType(entityType, {
           page: pageNumber, pageSize: itemsPerPage, sortField: sort.field, sortDirection: sort.direction, filterTerms: activeTextFilter
         })
-      this.setState({ entities: results, totalRowCount: filteredCount })
+      this.setState({ entities: results, filteredCount, totalRowCount: unfilteredCount })
     } catch (error) {
       reportError('Error loading entities', error)
     } finally {

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -504,6 +504,7 @@ export class ColumnSelector extends Component {
     return h(Fragment, [
       h(Clickable, {
         style: styles.columnSelector,
+        tooltip: 'Select columns',
         onClick: () => this.setState({ open: true, modifiedColumnSettings: columnSettings })
       }, [icon('cog', { size: 20, className: 'is-solid' })]),
       open && h(Modal, {
@@ -522,7 +523,7 @@ export class ColumnSelector extends Component {
           '|',
           linkButton({ style: { padding: '0 0.5rem' }, onClick: () => this.setAll(false) }, ['none']),
           div({ style: { marginLeft: 'auto', fontWeight: 500 } }, ['Sort:']),
-          linkButton({ style: { padding: '0 0.5rem' }, onClick: () => this.sort() }, ['reset'])
+          linkButton({ style: { padding: '0 0.5rem' }, onClick: () => this.sort() }, ['alphabetical'])
         ]),
         h(AutoSizer, { disableHeight: true }, [
           ({ width }) => {

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -35,7 +35,7 @@ const paginatorButton = (props, label) => button(_.merge({
  */
 export const paginator = function(props) {
   const {
-    filteredDataLength, pageNumber, setPageNumber, setItemsPerPage,
+    filteredDataLength, unfilteredDataLength, pageNumber, setPageNumber, setItemsPerPage,
     itemsPerPage, itemsPerPageOptions = [10, 25, 50, 100]
   } = props
 
@@ -49,6 +49,7 @@ export const paginator = function(props) {
       [
         div({ style: { display: 'flex', justifyContent: 'flex-end', alignItems: 'center', marginRight: '1rem' } }, [
           `${(pageNumber - 1) * itemsPerPage + 1} - ${_.min([filteredDataLength, pageNumber * itemsPerPage])} of ${filteredDataLength}`,
+          unfilteredDataLength && filteredDataLength !== unfilteredDataLength && ` (filtered from ${unfilteredDataLength} total)`,
           div({ style: { display: 'inline-flex', padding: '0 1rem' } }, [
 
             paginatorButton(

--- a/src/libs/data-utils.js
+++ b/src/libs/data-utils.js
@@ -167,6 +167,7 @@ export const EntityDeleter = ajaxCaller(class EntityDeleter extends Component {
       margin: '0 -1.25rem'
     }
 
+    const total = selectedEntities.length + additionalDeletions.length
     return h(Modal, {
       onDismiss,
       title: 'Confirm Delete',
@@ -193,7 +194,7 @@ export const EntityDeleter = ajaxCaller(class EntityDeleter extends Component {
       Utils.toIndexPairs(moreToDelete ? additionalDeletions : selectedEntities)),
       div({
         style: { ...fullWidthWarning, textAlign: 'right' }
-      }, [`${selectedEntities.length + additionalDeletions.length} data entries to be deleted.`]),
+      }, [`${total} data ${total > 1 ?'entries' : 'entry'} to be deleted.`]),
       deleting && spinnerOverlay
     ])
   }


### PR DESCRIPTION
Fixes #906 
(Only certain pieces, see the ticket comment for details)

Additional fixes:
* Filtering now resets the page number to 1
* Filtering correctly reflects the number pages of filtered data
* Filtering down to zero rows now unchecks and disables the select-all checkbox