### PR TITLE
standardize ajax calls

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -190,8 +190,9 @@ const User = signal => ({
     } catch (error) {
       if (error.status === 403 || error.status === 404) {
         return false
+      } else {
+        throw error
       }
-      throw error
     }
   },
 

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -4,7 +4,7 @@ import { ShibbolethLink } from 'src/components/common'
 import { clearNotification, sessionTimeoutProps, notify } from 'src/components/Notifications'
 import { Ajax } from 'src/libs/ajax'
 import { getConfig } from 'src/libs/config'
-import { reportError, withErrorReporting } from 'src/libs/error'
+import { withErrorReporting } from 'src/libs/error'
 import { getAppName } from 'src/libs/logos'
 import * as Utils from 'src/libs/utils'
 
@@ -128,36 +128,31 @@ window.forceSignIn = async token => {
   })
 }
 
-authStore.subscribe(async (state, oldState) => {
-  if (!oldState.isSignedIn && state.isSignedIn) {
-    clearNotification(sessionTimeoutProps.id)
-
-    Ajax().User.getStatus().then(async response => {
-      if (response.status === 404) {
-        return 'unregistered'
-      } else if (!response.ok) {
-        throw response
-      } else {
-        return response.json().then(({ enabled }) => enabled ? 'registered' : 'disabled')
-      }
-    }).then(registrationStatus => {
-      authStore.update(state => ({ ...state, registrationStatus }))
-    }, error => {
-      reportError('Error checking registration', error)
-    })
-  }
-})
-
-authStore.subscribe(async (state, oldState) => {
-  if (!oldState.isSignedIn && state.isSignedIn) {
+authStore.subscribe(withErrorReporting('Error checking registration', async (state, oldState) => {
+  const getRegistrationStatus = async () => {
     try {
-      const acceptedTos = await Ajax().User.getTosAccepted()
-      authStore.update(state => ({ ...state, acceptedTos }))
+      const { enabled } = await Ajax().User.getStatus()
+      return enabled ? 'registered' : 'disabled'
     } catch (error) {
-      reportError('Error checking TOS', error)
+      if (error.status === 404) {
+        return 'unregistered'
+      }
+      throw error
     }
   }
-})
+  if (!oldState.isSignedIn && state.isSignedIn) {
+    clearNotification(sessionTimeoutProps.id)
+    const registrationStatus = await getRegistrationStatus()
+    authStore.update(state => ({ ...state, registrationStatus }))
+  }
+}))
+
+authStore.subscribe(withErrorReporting('Error checking TOS', async (state, oldState) => {
+  if (!oldState.isSignedIn && state.isSignedIn) {
+    const acceptedTos = await Ajax().User.getTosAccepted()
+    authStore.update(state => ({ ...state, acceptedTos }))
+  }
+}))
 
 /**
  * Developers can get access to a user's ID, so a determined person could compare user IDs to
@@ -175,11 +170,11 @@ export const refreshTerraProfile = async () => {
   authStore.update(state => _.set('profile', profile, state))
 }
 
-authStore.subscribe((state, oldState) => {
+authStore.subscribe(withErrorReporting('Error loading user profile', async (state, oldState) => {
   if (!oldState.isSignedIn && state.isSignedIn) {
-    refreshTerraProfile().catch(error => reportError('Error loading user profile', error))
+    await refreshTerraProfile()
   }
-})
+}))
 
 authStore.subscribe(withErrorReporting('Error loading NIH account link status', async (state, oldState) => {
   const loadNihStatus = async () => {

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -136,8 +136,9 @@ authStore.subscribe(withErrorReporting('Error checking registration', async (sta
     } catch (error) {
       if (error.status === 404) {
         return 'unregistered'
+      } else {
+        throw error
       }
-      throw error
     }
   }
   if (!oldState.isSignedIn && state.isSignedIn) {


### PR DESCRIPTION
This changes a few direct uses of `instrumentedFetch` to use `fetchOk` instead, to bring them in line with all the other ajax calls. This is a precursor to some simplification and enhancement of the instrumentation code.

Also converts a few explicit try/catch to `withErrorReporting`