### PR TITLE
Split job history table

### DIFF
--- a/src/pages/workspaces/workspace/JobHistory.js
+++ b/src/pages/workspaces/workspace/JobHistory.js
@@ -215,7 +215,7 @@ const JobHistory = _.flow(
                 }
               },
               {
-                size: { basis: 215, grow: 0 },
+                size: { basis: 220, grow: 0 },
                 headerRenderer: () => h(HeaderCell, ['Controls']),
                 cellRenderer: ({ rowIndex }) => {
                   const {
@@ -236,7 +236,7 @@ const JobHistory = _.flow(
                         configName: methodConfigurationName,
                         onDone: () => this.refresh()
                       })
-                    }, ['Re-launch failures'])
+                    }, ['Relaunch failures'])
                   ])
                 }
               },

--- a/src/pages/workspaces/workspace/JobHistory.js
+++ b/src/pages/workspaces/workspace/JobHistory.js
@@ -216,7 +216,7 @@ const JobHistory = _.flow(
               },
               {
                 size: { basis: 220, grow: 0 },
-                headerRenderer: () => h(HeaderCell, ['Controls']),
+                headerRenderer: () => h(HeaderCell, ['Actions']),
                 cellRenderer: ({ rowIndex }) => {
                   const {
                     methodConfigurationNamespace, methodConfigurationName, submissionId, workflowStatuses,

--- a/src/pages/workspaces/workspace/JobHistory.js
+++ b/src/pages/workspaces/workspace/JobHistory.js
@@ -3,8 +3,7 @@ import { Fragment } from 'react'
 import { div, h, span, table, tbody, td, tr } from 'react-hyperscript-helpers'
 import { AutoSizer } from 'react-virtualized'
 import * as breadcrumbs from 'src/components/breadcrumbs'
-import { Clickable, link, spinnerOverlay } from 'src/components/common'
-import { icon } from 'src/components/icons'
+import { buttonPrimary, Clickable, link, spinnerOverlay } from 'src/components/common'
 import { DelayedSearchInput } from 'src/components/input'
 import { collapseStatus, failedIcon, runningIcon, submittedIcon, successIcon } from 'src/components/job-common'
 import Modal from 'src/components/Modal'
@@ -198,7 +197,7 @@ const JobHistory = _.flow(
                 }
               },
               {
-                size: { basis: 175, grow: 0 },
+                size: { basis: 170, grow: 0 },
                 headerRenderer: () => h(HeaderCell, ['No. of Workflows']),
                 cellRenderer: ({ rowIndex }) => {
                   const { workflowStatuses } = filteredSubmissions[rowIndex]
@@ -209,38 +208,35 @@ const JobHistory = _.flow(
                 size: { basis: 150, grow: 0 },
                 headerRenderer: () => h(HeaderCell, ['Status']),
                 cellRenderer: ({ rowIndex }) => {
+                  const { workflowStatuses, status } = filteredSubmissions[rowIndex]
+                  return h(Fragment, [
+                    statusCell(workflowStatuses), _.keys(collapsedStatuses(workflowStatuses)).length === 1 && status
+                  ])
+                }
+              },
+              {
+                size: { basis: 215, grow: 0 },
+                headerRenderer: () => h(HeaderCell, ['Controls']),
+                cellRenderer: ({ rowIndex }) => {
                   const {
                     methodConfigurationNamespace, methodConfigurationName, submissionId, workflowStatuses,
                     status, submissionEntity
                   } = filteredSubmissions[rowIndex]
                   return h(Fragment, [
-                    statusCell(workflowStatuses), _.keys(collapsedStatuses(workflowStatuses)).length === 1 && status,
-                    (collapsedStatuses(workflowStatuses).running && status !== 'Aborting') && h(TooltipTrigger, {
-                      content: 'Abort all workflows'
-                    }, [
-                      h(Clickable, {
-                        onClick: () => this.setState({ aborting: submissionId })
-                      }, [
-                        icon('times-circle', { size: 20, style: { color: colors.green[0], marginLeft: '0.5rem' } })
-                      ])
-                    ]),
+                    (collapsedStatuses(workflowStatuses).running && status !== 'Aborting') && buttonPrimary({
+                      onClick: () => this.setState({ aborting: submissionId })
+                    }, ['Abort workflows']),
                     isTerminal(status) && workflowStatuses['Failed'] &&
-                    submissionEntity && h(TooltipTrigger, {
-                      content: 'Re-run failures'
-                    }, [
-                      h(Clickable, {
-                        onClick: () => rerunFailures({
-                          namespace,
-                          name,
-                          submissionId,
-                          configNamespace: methodConfigurationNamespace,
-                          configName: methodConfigurationName,
-                          onDone: () => this.refresh()
-                        })
-                      }, [
-                        icon('refresh', { size: 18, style: { color: colors.green[0], marginLeft: '0.5rem' } })
-                      ])
-                    ])
+                    submissionEntity && buttonPrimary({
+                      onClick: () => rerunFailures({
+                        namespace,
+                        name,
+                        submissionId,
+                        configNamespace: methodConfigurationNamespace,
+                        configName: methodConfigurationName,
+                        onDone: () => this.refresh()
+                      })
+                    }, ['Re-run failures'])
                   ])
                 }
               },

--- a/src/pages/workspaces/workspace/JobHistory.js
+++ b/src/pages/workspaces/workspace/JobHistory.js
@@ -236,7 +236,7 @@ const JobHistory = _.flow(
                         configName: methodConfigurationName,
                         onDone: () => this.refresh()
                       })
-                    }, ['Re-run failures'])
+                    }, ['Re-launch failures'])
                   ])
                 }
               },

--- a/src/pages/workspaces/workspace/JobHistory.js
+++ b/src/pages/workspaces/workspace/JobHistory.js
@@ -215,7 +215,7 @@ const JobHistory = _.flow(
                 }
               },
               {
-                size: { basis: 220, grow: 0 },
+                size: { min: 220, max: 220 },
                 headerRenderer: () => h(HeaderCell, ['Actions']),
                 cellRenderer: ({ rowIndex }) => {
                   const {


### PR DESCRIPTION
Split status column into status and controls. Controls are where "Abort workflows" and "Relaunch failure" buttons are. Buttons became more obvious since users had reported it was difficult to find. 

<img width="1792" alt="Screen Shot 2019-05-14 at 11 25 04 AM" src="https://user-images.githubusercontent.com/42386483/57710536-23f64180-763b-11e9-842d-9f1a0c5a1656.png">
<img width="1792" alt="Screen Shot 2019-05-14 at 11 28 49 AM" src="https://user-images.githubusercontent.com/42386483/57710818-a8e15b00-763b-11e9-9d80-520f3b19dc9e.png">

Waiting on UX feedback from Jerome 