### PR TITLE
Clarify "Delete Workspace" menu item

### DIFF
--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -57,7 +57,7 @@ class WorkspaceTabs extends PureComponent {
             tooltip: !isOwner && 'You must be an owner of this workspace or the underlying billing project',
             tooltipSide: 'left',
             onClick: () => onDelete()
-          }, [menuIcon('trash'), 'Delete'])
+          }, [menuIcon('trash'), 'Delete Workspace'])
         ]),
         side: 'bottom'
       }, [


### PR DESCRIPTION
This is in response to a user accidentally deleting their workspace when they meant to delete a method config. There's probably more that we can do, but this is a quick change that should help avoid the mistake.

Triage: Usability issue discovered by user in production.