### PR TITLE
Add mailto link if support request fails

### DIFF
--- a/src/components/SupportRequest.js
+++ b/src/components/SupportRequest.js
@@ -224,13 +224,24 @@ const SupportRequest = _.flow(
   }
 
   submit = Utils.withBusyState(v => this.setState({ submitting: v }), async () => {
+    const { type, email, subject, description, attachmentToken } = this.state
     const currUrl = window.location.href
+    const hasAttachment = attachmentToken !== ''
+
     try {
       await Ajax().User.createSupportRequest({ ...this.getRequest(), currUrl })
-      SupportRequest.dismiss()
       notify('success', 'Message sent successfully', { timeout: 3000 })
     } catch (error) {
-      reportError('Error submitting support request', error)
+      notify('error', div(['Error submitting support request. ',
+        link({
+          style: { fontWeight: 800, color: 'white' },
+          hover: { color: 'white', textDecoration: 'underline' },
+          href: `mailto:terra-support@broadinstitute.zendesk.org?subject=${type}%3A%20${subject}&body=Original%20support%20request%3A%0A------------------------------------%0AContact email%3A%20${email}%0A%0A${description}%0A%0A------------------------------------%0AError%20reported%20from%20Zendesk%3A%0A%0A${error}`,
+          ...Utils.newTabLinkProps
+        }, 'Click here to email support'), hasAttachment && ' and make sure to add your attachment to the email.']
+      ))
+    } finally {
+      SupportRequest.dismiss()
     }
   })
 })

--- a/src/components/SupportRequest.js
+++ b/src/components/SupportRequest.js
@@ -236,7 +236,7 @@ const SupportRequest = _.flow(
         link({
           style: { fontWeight: 800, color: 'white' },
           hover: { color: 'white', textDecoration: 'underline' },
-          href: `mailto:terra-support@broadinstitute.zendesk.org?subject=${type}%3A%20${subject}&body=Original%20support%20request%3A%0A------------------------------------%0AContact email%3A%20${email}%0A%0A${description}%0A%0A------------------------------------%0AError%20reported%20from%20Zendesk%3A%0A%0A${error}`,
+          href: `mailto:terra-support@broadinstitute.zendesk.org?subject=${type}%3A%20${subject}&body=Original%20support%20request%3A%0A------------------------------------%0AContact email%3A%20${email}%0A%0A${description}%0A%0A------------------------------------%0AError%20reported%20from%20Zendesk%3A%0A%0A${JSON.stringify(error)}`,
           ...Utils.newTabLinkProps
         }, 'Click here to email support'), hasAttachment && ' and make sure to add your attachment to the email.']
       ))


### PR DESCRIPTION
Fixes #977 

Hints for testing:
I comment out lines 232-234 so that the ajax call to `await Ajax().User.createSupportRequest({ ...this.getRequest(), currUrl })` doesn't make a zendesk ticket, and it forces the `notify('error')` to display.