### PR TITLE
warn about changes to circle secret handling code

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -1,11 +1,10 @@
 #!/bin/sh
-FORBIDDEN=( private_key )
+FORBIDDEN='private_key|sa_key_var|SA_KEY_JSON'
 
-for i in "${FORBIDDEN[@]}"
-do
-  git diff --cached --name-only | \
-        GREP_COLOR='4;5;37;41' xargs grep --color --with-filename -n ${i} --exclude .hooks/pre-commit && \
-        echo 'COMMIT REJECTED: Found "'${i}'" references. Please remove them before committing.' && exit 1
-done
-
-exit 0
+git diff --cached -U0 | grep -E --color ${FORBIDDEN}
+if [ $? -eq 0 ]; then
+  echo '\nCOMMIT REJECTED: Found changes containing sensitive keywords.'
+  echo 'Misuse of these keywords can potentially cause security vulnerabilities, even if they are pushed to a branch.'
+  echo 'Please remove these changes, or else check with another member of the team before proceeding.\n'
+  exit 1
+fi


### PR DESCRIPTION
Fixes #1612 

Proactive security guards. This adds some sensitive Circle variable names to the list of forbidden keywords in the pre-commit hook.

Also changes the logic so it only inspects changed lines rather than the whole file. (As expected, the hook fired on this commit since those keywords were added).

Also changes the error message to give appropriate context and guidance.