### PR TITLE
Disable button when cohort doesn't have data_explorer_url

### DIFF
--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -423,12 +423,17 @@ class EntitiesContent extends Component {
     const { workspace: { workspace: { workspaceId } } } = this.props
     const { selectedEntities } = this.state
 
+    const dataExplorerUrl =
+       _.size(selectedEntities) === 1 && _.values(selectedEntities)[0].attributes.data_explorer_url ? _.values(selectedEntities)[0].attributes.data_explorer_url
+         : ''
     return h(Fragment, [
       buttonPrimary({
-        disabled: _.size(selectedEntities) !== 1,
+        // Old cohorts (before mid-Apr 2019) don't have data_explorer_url
+        disabled: _.size(selectedEntities) !== 1 || !dataExplorerUrl,
         tooltip: _.size(selectedEntities) === 0 ? 'Select a cohort to open in Data Explorer' :
           _.size(selectedEntities) > 1 ? 'Select exactly one cohort to open in Data Explorer' :
-            '',
+            !dataExplorerUrl ? 'cohort must have data_explorer_url set' :
+              '',
         onClick: () => window.open(_.values(selectedEntities)[0].attributes.data_explorer_url + '&wid=' + workspaceId)
       }, [
         icon('search', { style: { marginRight: '0.5rem' } }),

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -434,7 +434,7 @@ class EntitiesContent extends Component {
           _.size(selectedEntities) > 1 ? 'Select exactly one cohort to open in Data Explorer' :
             !dataExplorerUrl ? 'cohort must have data_explorer_url set' :
               '',
-        onClick: () => window.open(_.values(selectedEntities)[0].attributes.data_explorer_url + '&wid=' + workspaceId)
+        onClick: () => window.open(dataExplorerUrl + '&wid=' + workspaceId)
       }, [
         icon('search', { style: { marginRight: '0.5rem' } }),
         'Open in Data Explorer'


### PR DESCRIPTION
Old cohorts don't have data_explorer_url. Before this PR, you could click the button which doesn't work:

![1](https://user-images.githubusercontent.com/10929390/58355323-d6db5200-7e28-11e9-88c3-37d5e7d48c3f.png)

After this PR, button is disabled.