### PR TITLE
show abort button for all non terminal or aborting

### DIFF
--- a/src/pages/workspaces/workspace/JobHistory.js
+++ b/src/pages/workspaces/workspace/JobHistory.js
@@ -223,7 +223,7 @@ const JobHistory = _.flow(
                     status, submissionEntity
                   } = filteredSubmissions[rowIndex]
                   return h(Fragment, [
-                    (collapsedStatuses(workflowStatuses).running && status !== 'Aborting') && buttonPrimary({
+                    (!isTerminal(status) && status !== 'Aborting') && buttonPrimary({
                       onClick: () => this.setState({ aborting: submissionId })
                     }, ['Abort workflows']),
                     isTerminal(status) && (workflowStatuses['Failed'] || workflowStatuses['Aborted']) &&


### PR DESCRIPTION
Changed condition such that when a workflow is still in any non-terminal or already aborting state, the abort button shows

Resolves: https://broadworkbench.atlassian.net/browse/SATURN-137