### PR TITLE
add transparent retry logic for requester pays requests

### DIFF
--- a/src/libs/state.js
+++ b/src/libs/state.js
@@ -24,6 +24,8 @@ export const rerunFailuresStatus = Utils.atom()
 
 export const errorNotifiedClusters = Utils.atom([])
 
+export const requesterPaysBuckets = Utils.atom([])
+
 /*
  * Modifies ajax responses for testing purposes.
  * Can be set to an array of objects of the form { fn, filter }.


### PR DESCRIPTION
This handles certain cases of accessing requester pays buckets. In particular, if you are in a workspace where you have at least write access, this will transparently detect and 'fix' errors when trying to access requester pays buckets by retrying the request with the billing project attached.

We maintain an in-memory cache of all requester pays buckets seen so far, so we only have to fail and retry the first time.