### PR TITLE
intercept requester pays errors [SATURN-82]

### DIFF
--- a/src/components/UriViewer.js
+++ b/src/components/UriViewer.js
@@ -107,7 +107,7 @@ const UriViewer = _.flow(
       Utils.cond(
         [loadingError, () => h(Fragment, [
           div({ style: { paddingBottom: '1rem' } }, [
-            'Error loading data. You may not have permission to view this file.'
+            'Error loading data. This file does not exist or you do not have permission to view it.'
           ]),
           h(Collapse, { defaultHidden: true, title: 'Details' }, [
             div({ style: { whiteSpace: 'pre-wrap', fontFamily: 'monospace', overflowWrap: 'break-word' } }, [

--- a/src/components/UriViewer.js
+++ b/src/components/UriViewer.js
@@ -2,17 +2,18 @@ import clipboard from 'clipboard-polyfill'
 import filesize from 'filesize'
 import _ from 'lodash/fp'
 import PropTypes from 'prop-types'
-import { Fragment, useState } from 'react'
+import { Fragment } from 'react'
 import { div, h, img, input } from 'react-hyperscript-helpers'
+import { requesterPaysWrapper, withRequesterPaysHandler } from 'src/components/bucket-utils'
 import Collapse from 'src/components/Collapse'
 import { buttonPrimary, Clickable, link } from 'src/components/common'
 import { icon, spinner } from 'src/components/icons'
 import Modal from 'src/components/Modal'
 import DownloadPrices from 'src/data/download-prices'
-import { Ajax, ajaxCaller, useCancellation } from 'src/libs/ajax'
+import { ajaxCaller } from 'src/libs/ajax'
 import { bucketBrowserUrl } from 'src/libs/auth'
 import colors from 'src/libs/colors'
-import { reportError, withErrorReporting } from 'src/libs/error'
+import { reportError } from 'src/libs/error'
 import * as Utils from 'src/libs/utils'
 import { Component } from 'src/libs/wrapped-components'
 
@@ -44,22 +45,6 @@ const isFilePreviewable = ({ size, ...metadata }) => {
 
 const isGs = uri => _.startsWith('gs://', uri)
 
-const viewerProps = onDismiss => {
-  return {
-    onDismiss,
-    title: 'File Details',
-    showCancel: false,
-    showX: true,
-    okButton: 'Done'
-  }
-}
-const loadingMetadata = uri => {
-  return [
-    isGs(uri) ? 'Loading metadata...' : 'Resolving DOS object...',
-    spinner({ style: { marginLeft: 4 } })
-  ]
-}
-
 const parseUri = uri => _.drop(1, /gs:[/][/]([^/]+)[/](.+)/.exec(uri))
 const getMaxDownloadCostNA = bytes => {
   const nanos = DownloadPrices.pricingInfo[0].pricingExpression.tieredRates[1].unitPrice.nanos
@@ -68,50 +53,25 @@ const getMaxDownloadCostNA = bytes => {
   return downloadPrice < 0.01 ? '< $0.01' : Utils.formatUSD(downloadPrice)
 }
 
-const UriViewer = props => {
-  const signal = useCancellation()
-  const [hasBillingProject, setHasBillingProject] = useState(undefined)
-
-  const { googleProject, uri, onDismiss } = props
-  const isGsUri = isGs(uri)
-  const [bucket, name] = isGsUri ? parseUri(uri) : []
-
-  const pingObject = withErrorReporting('Error fetching file metadata', async () => {
-    if (isGsUri) {
-      try {
-        await Ajax(signal).Buckets.getObject(bucket, name, googleProject)
-        setHasBillingProject(true)
-      } catch (e) {
-        const isRequesterPays = e.status === 400 && (await e.json()).error.message.includes('requester pays')
-        setHasBillingProject(!isRequesterPays)
-      }
-    }
-  })
-
-  Utils.useOnMount(() => {
-    pingObject()
-  })
-
-  return Utils.switchCase(hasBillingProject,
-    [undefined, () => h(Modal, { ...viewerProps(onDismiss) }, loadingMetadata(uri))],
-    [true, () => h(UriViewerModal, props)],
-    [false, () => h(Modal, { ...viewerProps(onDismiss) }, ['Error: To view this file you must provide a billing project, because the file is in a requester pays Google Bucket.'])]
-  )
-}
-
-const UriViewerModal = ajaxCaller(class UriViewerModal extends Component {
+const UriViewer = _.flow(
+  ajaxCaller,
+  requesterPaysWrapper({ onDismiss: ({ onDismiss }) => onDismiss() }),
+)(class UriViewer extends Component {
   static propTypes = {
     googleProject: PropTypes.string.isRequired,
     uri: PropTypes.string.isRequired
   }
 
   async componentDidMount() {
-    const { googleProject, uri, ajax: { Buckets, Martha } } = this.props
+    const { googleProject, uri, ajax: { Buckets, Martha }, onRequesterPaysError } = this.props
     const isGsUri = isGs(uri)
     const [bucket, name] = isGsUri ? parseUri(uri) : []
 
     try {
-      const { signedUrl = false, ...metadata } = isGsUri ? await Buckets.getObject(bucket, name, googleProject) : await Martha.call(uri)
+      const loadObject = withRequesterPaysHandler(onRequesterPaysError, () => {
+        return Buckets.getObject(bucket, name, googleProject)
+      })
+      const { signedUrl = false, ...metadata } = isGsUri ? await loadObject() : await Martha.call(uri)
 
       const price = getMaxDownloadCostNA(metadata.size)
 
@@ -138,12 +98,16 @@ const UriViewerModal = ajaxCaller(class UriViewerModal extends Component {
     const gsutilCommand = `gsutil cp ${gsUri} .`
 
     return h(Modal, {
-      ...viewerProps(onDismiss)
+      onDismiss,
+      title: 'File Details',
+      showCancel: false,
+      showX: true,
+      okButton: 'Done'
     }, [
       Utils.cond(
         [loadingError, () => h(Fragment, [
           div({ style: { paddingBottom: '1rem' } }, [
-            'Error loading data. This file does not exist or you do not have permission to view it.'
+            'Error loading data. You may not have permission to view this file.'
           ]),
           h(Collapse, { defaultHidden: true, title: 'Details' }, [
             div({ style: { whiteSpace: 'pre-wrap', fontFamily: 'monospace', overflowWrap: 'break-word' } }, [
@@ -243,7 +207,10 @@ const UriViewerModal = ajaxCaller(class UriViewerModal extends Component {
           ]),
           div({ style: { fontSize: 10 } }, ['* Estimated. Download cost may be higher in China or Australia.'])
         ])],
-        () => loadingMetadata(uri)
+        () => h(Fragment, [
+          isGs(uri) ? 'Loading metadata...' : 'Resolving DOS object...',
+          spinner({ style: { marginLeft: 4 } })
+        ])
       )
     ])
   }

--- a/src/components/bucket-utils.js
+++ b/src/components/bucket-utils.js
@@ -1,0 +1,37 @@
+import _ from 'lodash/fp'
+import { forwardRef, useState } from 'react'
+import { h } from 'react-hyperscript-helpers'
+import Modal from 'src/components/Modal'
+import * as Utils from 'src/libs/utils'
+
+export const withRequesterPaysHandler = _.curry((handler, fn) => async (...args) => {
+  try {
+    return await fn(...args)
+  } catch (error) {
+    if (error.requesterPaysError) {
+      handler()
+      return Utils.abandonedPromise()
+    } else {
+      throw error
+    }
+  }
+})
+
+export const requesterPaysWrapper = ({ onDismiss }) => WrappedComponent => {
+  const Wrapper = forwardRef((props, ref) => {
+    const [showModal, setShowModal] = useState(false)
+    return showModal ?
+      h(Modal, {
+        title: 'Cannot access data',
+        onDismiss: () => onDismiss(props),
+        showCancel: false
+      }, [
+        'This data is in a requester pays bucket.'
+      ]) :
+      h(WrappedComponent, {
+        ref, ...props,
+        onRequesterPaysError: () => setShowModal(true)
+      })
+  })
+  return Wrapper
+}

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -64,9 +64,9 @@ const withUrlPrefix = prefix => wrappedFetch => async (path, ...args) => {
 
 const checkRequesterPaysError = async response => {
   if (response.status === 400) {
-    const data = await response.json()
-    const requesterPaysError = _.includes('requester pays', _.get(['error', 'message'], data))
-    return Object.assign(new Response(new Blob([JSON.stringify(data)]), response), { requesterPaysError })
+    const data = await response.text()
+    const requesterPaysError = _.includes('requester pays', data)
+    return Object.assign(new Response(new Blob([data]), response), { requesterPaysError })
   } else {
     return Object.assign(response, { requesterPaysError: false })
   }

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -174,6 +174,11 @@ export const delay = ms => {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
 
+// Returns a promise that will never resolve or reject. Useful for cancelling async flows.
+export const abandonedPromise = () => {
+  return new Promise(() => {})
+}
+
 export const generateClusterName = () => `saturn-${uuid()}`
 
 export const waitOneTick = () => new Promise(setImmediate)

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -5,6 +5,7 @@ import { createRef, Fragment } from 'react'
 import Dropzone from 'react-dropzone'
 import { a, div, h } from 'react-hyperscript-helpers'
 import * as breadcrumbs from 'src/components/breadcrumbs'
+import { requesterPaysWrapper, withRequesterPaysHandler } from 'src/components/bucket-utils'
 import togglesListView from 'src/components/CardsListToggle'
 import { Clickable, link, MenuButton, menuIcon, PageBox, Select, spinnerOverlay } from 'src/components/common'
 import { icon } from 'src/components/icons'
@@ -14,7 +15,7 @@ import PopupTrigger from 'src/components/PopupTrigger'
 import TooltipTrigger from 'src/components/TooltipTrigger'
 import { ajaxCaller } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
-import { reportError } from 'src/libs/error'
+import { reportError, withErrorReporting } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
 import * as StateHistory from 'src/libs/state-history'
 import * as Style from 'src/libs/style'
@@ -180,6 +181,9 @@ class NotebookCard extends Component {
 }
 
 const Notebooks = _.flow(
+  requesterPaysWrapper({
+    onDismiss: ({ namespace, name }) => Nav.goToPath('workspace-dashboard', { namespace, name })
+  }),
   wrapWorkspace({
     breadcrumbs: props => breadcrumbs.commonPaths.workspaceDashboard(props),
     title: 'Notebooks', activeTab: 'notebooks'
@@ -205,19 +209,15 @@ const Notebooks = _.flow(
     return _.map(({ name }) => printName(name), notebooks)
   }
 
-  async refresh() {
+  refresh = _.flow(
+    withRequesterPaysHandler(this.props.onRequesterPaysError),
+    withErrorReporting('Error loading notebooks'),
+    Utils.withBusyState(v => this.setState({ loading: v }))
+  )(async () => {
     const { namespace, workspace: { workspace: { bucketName } }, ajax: { Buckets } } = this.props
-
-    try {
-      this.setState({ launching: false, loading: true })
-      const notebooks = await Buckets.listNotebooks(namespace, bucketName)
-      this.setState({ notebooks: _.reverse(_.sortBy('updated', notebooks)) })
-    } catch (error) {
-      reportError('Error loading notebooks', error)
-    } finally {
-      this.setState({ loading: false })
-    }
-  }
+    const notebooks = await Buckets.listNotebooks(namespace, bucketName)
+    this.setState({ notebooks: _.reverse(_.sortBy('updated', notebooks)) })
+  })
 
   async uploadFiles(files) {
     const { namespace, workspace: { workspace: { bucketName } }, ajax: { Buckets } } = this.props

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -182,7 +182,7 @@ class NotebookCard extends Component {
 
 const Notebooks = _.flow(
   requesterPaysWrapper({
-    onDismiss: ({ namespace, name }) => Nav.goToPath('workspace-dashboard', { namespace, name })
+    onDismiss: () => Nav.history.goBack()
   }),
   wrapWorkspace({
     breadcrumbs: props => breadcrumbs.commonPaths.workspaceDashboard(props),


### PR DESCRIPTION
Adds an interstitial modal in various places where we might see requester pays errors. This provides a helpful error message, cleanly exits the flow on dismissal, and provides a place where we can prompt to select a billing account in the future.