### PR TITLE
Update clipboard export type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3632,9 +3632,9 @@
       }
     },
     "clipboard-polyfill": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/clipboard-polyfill/-/clipboard-polyfill-2.8.0.tgz",
-      "integrity": "sha512-SFaifu0fi07We/RASUcE6uUgeV3AgGn09BaBpJlOoNPiMVS4peTy6eWtvn1yNYMdJWwF+L4AbUAuffTdT0xn5Q=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/clipboard-polyfill/-/clipboard-polyfill-2.8.1.tgz",
+      "integrity": "sha512-2qclMYSM/L5Wv8mNeF2rvvtaKFJiG3y5mI2wwsFIUt0yE2hWjNg6qvsRo6D8TTaLTNXDfEI47TyaxSxjwD8ADQ=="
     },
     "cliui": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.8.2",
     "@fortawesome/react-fontawesome": "^0.1.4",
     "animate.css": "^3.7.0",
-    "clipboard-polyfill": "^2.8.0",
+    "clipboard-polyfill": "^2.8.1",
     "color": "^3.1.1",
     "date-fns": "^1.30.1",
     "debounce-promise": "^3.1.2",

--- a/src/components/UriViewer.js
+++ b/src/components/UriViewer.js
@@ -1,4 +1,4 @@
-import clipboard from 'clipboard-polyfill'
+import * as clipboard from 'clipboard-polyfill'
 import filesize from 'filesize'
 import _ from 'lodash/fp'
 import PropTypes from 'prop-types'

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -1,4 +1,4 @@
-import clipboard from 'clipboard-polyfill'
+import * as clipboard from 'clipboard-polyfill'
 import debouncePromise from 'debounce-promise'
 import 'easymde/dist/easymde.min.css'
 import _ from 'lodash/fp'

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -1,4 +1,4 @@
-import clipboard from 'clipboard-polyfill'
+import * as clipboard from 'clipboard-polyfill'
 import FileSaver from 'file-saver'
 import filesize from 'filesize'
 import _ from 'lodash/fp'

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -1,4 +1,4 @@
-import clipboard from 'clipboard-polyfill/build/clipboard-polyfill'
+import * as clipboard from 'clipboard-polyfill'
 import _ from 'lodash/fp'
 import * as qs from 'qs'
 import { createRef, Fragment } from 'react'


### PR DESCRIPTION
In an upcoming version of the clipboard-polyfill library, we'll need to import it differently as described here: https://github.com/lgarron/clipboard-polyfill/issues/101