### PR TITLE
Fix rendering when editing workspace description

### DIFF
--- a/src/libs/style.js
+++ b/src/libs/style.js
@@ -22,7 +22,7 @@ export const elements = {
     }
   },
   sectionHeader: { color: colors.dark(), fontSize: 16, fontWeight: 600 },
-  pageContentContainer: { position: 'relative', flexGrow: 1, display: 'flex', flexDirection: 'column', zIndex: 0 }
+  pageContentContainer: { position: 'relative', flexGrow: 1, display: 'flex', flexDirection: 'column' }
 }
 
 export const tabBar = {


### PR DESCRIPTION
This change corrects an issue where the toolbar does not appear when editing the workspace description in side by side mode.