### PR TITLE
improve build timestamp information [SATURN-52] [SATURN-162]

### DIFF
--- a/src/components/FooterWrapper.js
+++ b/src/components/FooterWrapper.js
@@ -40,8 +40,7 @@ const FooterWrapper = ({ children }) => {
       ]),
       div({ style: { flexGrow: 1 } }),
       div({ style: { fontWeight: 600, fontSize: '10px' } }, [
-        `Copyright ©${buildTimestamp.getFullYear()}. Built on `,
-        buildTimestamp.toLocaleString()
+        `Copyright ©${buildTimestamp.getFullYear()}.`
       ])
     ])
   ])

--- a/src/components/FooterWrapper.js
+++ b/src/components/FooterWrapper.js
@@ -40,7 +40,7 @@ const FooterWrapper = ({ children }) => {
       ]),
       div({ style: { flexGrow: 1 } }),
       div({ style: { fontWeight: 600, fontSize: '10px' } }, [
-        `Copyright ©${buildTimestamp.getFullYear()}.`
+        `Copyright ©${buildTimestamp.getFullYear()}`
       ])
     ])
   ])

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -336,6 +336,7 @@ export default _.flow(
             'Built on: ',
             a({
               href: `https://github.com/DataBiosphere/terra-ui/commits/${SATURN_VERSION}`,
+              ...Utils.newTabLinkProps,
               style: { textDecoration: 'underline', marginLeft: '0.25rem' }
             }, [new Date(SATURN_BUILD_TIMESTAMP).toLocaleString()])
           ])

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -334,7 +334,10 @@ export default _.flow(
             }
           }, [
             'Built on: ',
-            new Date(SATURN_BUILD_TIMESTAMP).toLocaleString()
+            a({
+              href: `https://github.com/DataBiosphere/terra-ui/commits/${SATURN_VERSION}`,
+              style: { textDecoration: 'underline', marginLeft: '0.25rem' }
+            }, [new Date(SATURN_BUILD_TIMESTAMP).toLocaleString()])
           ])
         ])
       ])


### PR DESCRIPTION
This turns the timestamp into a link to github showing the actual commits/PRs included in the current build. This should be an improvement over the current lack of information, and we can iterate on it if desired.