### PR TITLE
use Context to broadcast location state

### DIFF
--- a/src/libs/nav.js
+++ b/src/libs/nav.js
@@ -1,7 +1,7 @@
 import { createHashHistory as createHistory } from 'history'
 import _ from 'lodash/fp'
 import * as qs from 'qs'
-import { Component, useEffect, useState } from 'react'
+import { Component, createContext, useContext, useEffect, useState } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
 import { getAppName } from 'src/libs/logos'
 import { routeHandlersStore } from 'src/libs/state'
@@ -63,12 +63,19 @@ const parseRoute = (handlers, { pathname, search }) => {
   }
 }
 
-export const useRoute = () => {
+const locationContext = createContext()
+
+export const LocationProvider = ({ children }) => {
   const [location, setLocation] = useState(history.location)
-  const handlers = useAtom(routeHandlersStore)
   useOnMount(() => {
     return history.listen(v => setLocation(v))
   })
+  return h(locationContext.Provider, { value: location }, [children])
+}
+
+export const useRoute = () => {
+  const location = useContext(locationContext)
+  const handlers = useAtom(routeHandlersStore)
   return parseRoute(handlers, location)
 }
 

--- a/src/pages/Main.js
+++ b/src/pages/Main.js
@@ -1,6 +1,5 @@
 import 'src/libs/routes'
 
-import { Fragment } from 'react'
 import { hot } from 'react-hot-loader/root'
 import { h } from 'react-hyperscript-helpers'
 import AuthContainer from 'src/components/AuthContainer'
@@ -13,11 +12,11 @@ import { NpsSurvey } from 'src/components/NpsSurvey'
 import ServiceAlerts from 'src/components/ServiceAlerts'
 import SupportRequest from 'src/components/SupportRequest'
 import { TrialBanner } from 'src/components/TrialBanner'
-import { Router, TitleManager } from 'src/libs/nav'
+import { LocationProvider, Router, TitleManager } from 'src/libs/nav'
 
 
 const Main = () => {
-  return h(Fragment, [
+  return h(LocationProvider, [
     h(Notifications),
     h(ServiceAlerts),
     h(FreeCreditsModal),


### PR DESCRIPTION
This reconfigures the handling of route information to fix some issues with nested routing.

Problem: With multiple listeners to the `history`, the order of updates depends on when those components mounted. In the case of the child finishing mounting first (which can happen on e.g. a full page refresh), the child might see route changes before the parent, causing inconsistencies.

Solution: We can instead use React's `Context` mechanism to make the location available to any component. The overall usage pattern is similar, but context changes always propagate from the root component outward, which avoids the inconsistency.