### PR TITLE
cache service account tokens

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -126,7 +126,7 @@ const getServiceAccountToken = Utils.memoizeAsync(async (namespace, token) => {
     _.mergeAll([authOpts(token), jsonBody(scopes), { method: 'POST' }])
   )
   return res.json()
-}, { timeout: 1000 * 60 * 30, resolver: (...args) => JSON.stringify(args) })
+}, { expires: 1000 * 60 * 30, keyFn: (...args) => JSON.stringify(args) })
 
 const saToken = namespace => getServiceAccountToken(namespace, getUser().token)
 

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -119,16 +119,18 @@ const nbName = name => encodeURIComponent(`notebooks/${name}.ipynb`)
 // %23 = '#', %2F = '/'
 const dockstoreMethodPath = path => `api/ga4gh/v1/tools/%23workflow%2F${encodeURIComponent(path)}/versions`
 
-const User = signal => ({
-  token: Utils.memoizeWithTimeout(async namespace => {
-    const scopes = ['https://www.googleapis.com/auth/devstorage.full_control']
-    const res = await fetchSam(
-      `api/google/user/petServiceAccount/${namespace}/token`,
-      _.mergeAll([authOpts(), jsonBody(scopes), { signal, method: 'POST' }])
-    )
-    return res.json()
-  }, namespace => namespace, 1000 * 60 * 30),
+const getServiceAccountToken = Utils.memoizeAsync(async (namespace, token) => {
+  const scopes = ['https://www.googleapis.com/auth/devstorage.full_control']
+  const res = await fetchSam(
+    `api/google/user/petServiceAccount/${namespace}/token`,
+    _.mergeAll([authOpts(token), jsonBody(scopes), { method: 'POST' }])
+  )
+  return res.json()
+}, { timeout: 1000 * 60 * 30, resolver: (...args) => JSON.stringify(args) })
 
+const saToken = namespace => getServiceAccountToken(namespace, getUser().token)
+
+const User = signal => ({
   getStatus: async () => {
     const res = await fetchOk(`${getConfig().samUrlRoot}/register/user/v2/self/info`, _.mergeAll([authOpts(), { signal }, appIdentifier]))
     return res.json()
@@ -664,7 +666,7 @@ const Workspaces = signal => ({
 const Buckets = signal => ({
   getObject: async (bucket, object, namespace) => {
     return fetchBuckets(`storage/v1/b/${bucket}/o/${encodeURIComponent(object)}`,
-      _.merge(authOpts(await User(signal).token(namespace)), { signal })
+      _.merge(authOpts(await saToken(namespace)), { signal })
     ).then(
       res => res.json()
     )
@@ -673,7 +675,7 @@ const Buckets = signal => ({
   getObjectPreview: async (bucket, object, namespace, previewFull = false) => {
     return fetchBuckets(`storage/v1/b/${bucket}/o/${encodeURIComponent(object)}?alt=media`,
       _.mergeAll([
-        authOpts(await User(signal).token(namespace)),
+        authOpts(await saToken(namespace)),
         { signal },
         previewFull ? {} : { headers: { Range: 'bytes=0-20000' } }
       ])
@@ -688,7 +690,7 @@ const Buckets = signal => ({
   listNotebooks: async (namespace, name) => {
     const res = await fetchBuckets(
       `storage/v1/b/${name}/o?prefix=notebooks/`,
-      _.merge(authOpts(await User(signal).token(namespace)), { signal })
+      _.merge(authOpts(await saToken(namespace)), { signal })
     )
     const { items } = await res.json()
     return _.filter(({ name }) => name.endsWith('.ipynb'), items)
@@ -697,7 +699,7 @@ const Buckets = signal => ({
   list: async (namespace, bucket, prefix) => {
     const res = await fetchBuckets(
       `storage/v1/b/${bucket}/o?${qs.stringify({ prefix, delimiter: '/' })}`,
-      _.merge(authOpts(await User(signal).token(namespace)), { signal })
+      _.merge(authOpts(await saToken(namespace)), { signal })
     )
     return res.json()
   },
@@ -705,14 +707,14 @@ const Buckets = signal => ({
   delete: async (namespace, bucket, name) => {
     return fetchBuckets(
       `storage/v1/b/${bucket}/o/${encodeURIComponent(name)}`,
-      _.merge(authOpts(await User(signal).token(namespace)), { signal, method: 'DELETE' })
+      _.merge(authOpts(await saToken(namespace)), { signal, method: 'DELETE' })
     )
   },
 
   upload: async (namespace, bucket, prefix, file) => {
     return fetchBuckets(
       `upload/storage/v1/b/${bucket}/o?uploadType=media&name=${encodeURIComponent(prefix + file.name)}`,
-      _.merge(authOpts(await User(signal).token(namespace)), {
+      _.merge(authOpts(await saToken(namespace)), {
         signal, method: 'POST', body: file,
         headers: { 'Content-Type': file.type, 'Content-Length': file.size }
       })
@@ -725,20 +727,20 @@ const Buckets = signal => ({
     const copy = async (newName, newBucket) => {
       return fetchBuckets(
         `${bucketUrl}/${nbName(name)}/copyTo/b/${newBucket}/o/${nbName(newName)}`,
-        _.merge(authOpts(await User(signal).token(namespace)), { signal, method: 'POST' })
+        _.merge(authOpts(await saToken(namespace)), { signal, method: 'POST' })
       )
     }
     const doDelete = async () => {
       return fetchBuckets(
         `${bucketUrl}/${nbName(name)}`,
-        _.merge(authOpts(await User(signal).token(namespace)), { signal, method: 'DELETE' })
+        _.merge(authOpts(await saToken(namespace)), { signal, method: 'DELETE' })
       )
     }
 
     const getObject = async () => {
       const res = await fetchBuckets(
         `${bucketUrl}/${nbName(name)}`,
-        _.merge(authOpts(await User(signal).token(namespace)), { signal, method: 'GET' })
+        _.merge(authOpts(await saToken(namespace)), { signal, method: 'GET' })
       )
       return await res.json()
     }
@@ -746,7 +748,7 @@ const Buckets = signal => ({
       preview: async () => {
         const nb = await fetchBuckets(
           `${bucketUrl}/${encodeURIComponent(`notebooks/${name}`)}?alt=media`,
-          _.merge(authOpts(await User(signal).token(namespace)), { signal })
+          _.merge(authOpts(await saToken(namespace)), { signal })
         ).then(res => res.text())
         return fetchOk(`${getConfig().calhounUrlRoot}/api/convert`,
           _.mergeAll([authOpts(), { signal, method: 'POST', body: nb }])
@@ -758,7 +760,7 @@ const Buckets = signal => ({
       create: async contents => {
         return fetchBuckets(
           `upload/${bucketUrl}?uploadType=media&name=${nbName(name)}`,
-          _.merge(authOpts(await User(signal).token(namespace)), {
+          _.merge(authOpts(await saToken(namespace)), {
             signal, method: 'POST', body: JSON.stringify(contents),
             headers: { 'Content-Type': 'application/x-ipynb+json' }
           })


### PR DESCRIPTION
This restores the caching of service account keys, which stopped working at some point due to a restructuring of the ajax code. Also upgrades the underlying code to avoid caching failed responses, and behave correctly across multiple logins.

This makes certain interactions noticeably faster, e.g. browsing the files tab.