### PR TITLE
combine link and linkButton

### DIFF
--- a/src/components/ConfigOverridesWarning.js
+++ b/src/components/ConfigOverridesWarning.js
@@ -1,5 +1,5 @@
 import { div } from 'react-hyperscript-helpers'
-import { linkButton } from 'src/components/common'
+import { link } from 'src/components/common'
 import colors from 'src/libs/colors'
 import { ajaxOverridesStore, configOverridesStore } from 'src/libs/state'
 import * as Utils from 'src/libs/utils'
@@ -17,11 +17,11 @@ const ConfigOverridesWarning = () => {
   }, [
     !!configOverrides && div([
       'Config overrides are in effect.',
-      linkButton({ variant: 'light', onClick: () => configOverridesStore.set() }, [' clear'])
+      link({ variant: 'light', onClick: () => configOverridesStore.set() }, [' clear'])
     ]),
     !!ajaxOverrides && div([
       'Ajax overrides are in effect.',
-      linkButton({ variant: 'light', onClick: () => ajaxOverridesStore.set() }, [' clear'])
+      link({ variant: 'light', onClick: () => ajaxOverridesStore.set() }, [' clear'])
     ])
   ])
 }

--- a/src/components/DataTable.js
+++ b/src/components/DataTable.js
@@ -2,7 +2,7 @@ import _ from 'lodash/fp'
 import { createRef, Fragment } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
 import { AutoSizer } from 'react-virtualized'
-import { Checkbox, Clickable, linkButton, MenuButton, RadioButton, spinnerOverlay } from 'src/components/common'
+import { Checkbox, Clickable, link, MenuButton, RadioButton, spinnerOverlay } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import { ConfirmedSearchInput } from 'src/components/input'
 import Modal from 'src/components/Modal'
@@ -172,7 +172,7 @@ export default ajaxCaller(class DataTable extends Component {
                         const dataInfo = entities[rowIndex].attributes[name]
                         const dataCell = renderDataCell(Utils.entityAttributeText(dataInfo), namespace)
                         return (!!dataInfo && _.isArray(dataInfo.items)) ?
-                          linkButton({
+                          link({
                             onClick: () => this.setState({ viewData: dataInfo })
                           },
                           [dataCell]) : dataCell

--- a/src/components/FooterWrapper.js
+++ b/src/components/FooterWrapper.js
@@ -1,5 +1,5 @@
 import { a, div } from 'react-hyperscript-helpers'
-import { linkButton } from 'src/components/common'
+import { link } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import colors from 'src/libs/colors'
 import { footerLogo } from 'src/libs/logos'
@@ -26,7 +26,7 @@ const FooterWrapper = ({ children }) => {
         color: 'white'
       }
     }, [
-      linkButton({ href: Nav.getLink('root') }, [
+      link({ href: Nav.getLink('root') }, [
         footerLogo()
       ]),
       a({ href: Nav.getLink('privacy'), style: styles.item }, 'Privacy Policy'),

--- a/src/components/IGVFileSelector.js
+++ b/src/components/IGVFileSelector.js
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp'
 import { div, h } from 'react-hyperscript-helpers'
 import { AutoSizer, List } from 'react-virtualized'
-import { buttonPrimary, Clickable, LabeledCheckbox, linkButton, Select } from 'src/components/common'
+import { buttonPrimary, Clickable, LabeledCheckbox, link, Select } from 'src/components/common'
 import Modal from 'src/components/Modal'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
@@ -80,9 +80,9 @@ export class IGVFileSelector extends Component {
     }, [
       div({ style: { marginBottom: '1rem', display: 'flex' } }, [
         div({ style: { fontWeight: 500 } }, ['Select:']),
-        linkButton({ style: { padding: '0 0.5rem' }, onClick: () => this.setAll(true) }, ['all']),
+        link({ style: { padding: '0 0.5rem' }, onClick: () => this.setAll(true) }, ['all']),
         '|',
-        linkButton({ style: { padding: '0 0.5rem' }, onClick: () => this.setAll(false) }, ['none'])
+        link({ style: { padding: '0 0.5rem' }, onClick: () => this.setAll(false) }, ['none'])
       ]),
       h(AutoSizer, { disableHeight: true }, [
         ({ width }) => {

--- a/src/components/SupportRequest.js
+++ b/src/components/SupportRequest.js
@@ -2,7 +2,7 @@ import _ from 'lodash/fp'
 import { createRef, Fragment } from 'react'
 import Dropzone from 'react-dropzone'
 import { div, h, span } from 'react-hyperscript-helpers'
-import { buttonPrimary, buttonSecondary, Clickable, link, linkButton, Select, spinnerOverlay } from 'src/components/common'
+import { buttonPrimary, buttonSecondary, Clickable, link, Select, spinnerOverlay } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import { TextArea, TextInput } from 'src/components/input'
 import { notify } from 'src/components/Notifications'
@@ -178,7 +178,7 @@ const SupportRequest = _.flow(
                   'Successfully uploaded: ', span({ style: { color: colors.dark() } }, [attachmentName])
                 ])
               ]),
-              linkButton({
+              link({
                 tooltip: 'Remove file',
                 style: { flex: 0, paddingTop: '0.5rem' },
                 onClick: () => this.setState({ attachmentToken: '' })

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -49,7 +49,7 @@ const linkProps = ({ disabled, variant }) => ({
 })
 
 export const link = ({ onClick, href, disabled, variant, ...props }, children) => {
-  return h(Interactive,
+  return h(Clickable,
     _.merge(linkProps({ disabled, variant }), {
       href, disabled,
       onClick: href && onClick ? e => {
@@ -58,12 +58,6 @@ export const link = ({ onClick, href, disabled, variant, ...props }, children) =
       } : onClick,
       ...props
     }),
-    children)
-}
-
-export const linkButton = ({ disabled, variant, ...props }, children) => {
-  return h(Clickable,
-    _.merge(linkProps({ disabled, variant }), { disabled, ...props }),
     children)
 }
 
@@ -104,8 +98,8 @@ export const buttonOutline = ({ disabled, ...props }, children) => {
   }, props), children)
 }
 
-export const iconButton = (shape, { disabled, size, iconProps = {}, ...props } = {}) => linkButton(
-  _.merge({
+export const iconButton = (shape, { disabled, size, iconProps = {}, ...props } = {}) => {
+  return h(Clickable, _.merge({
     as: 'span',
     disabled,
     style: {
@@ -116,9 +110,10 @@ export const iconButton = (shape, { disabled, size, iconProps = {}, ...props } =
         { mask: `url(${hexButton}) center no-repeat`, WebkitMask: `url(${hexButton}) center no-repeat` } :
         { borderRadius: '1rem' })
     }
-  }, props),
-  [icon(shape, _.merge({ style: { color: disabled ? colors.dark() : 'white' } }, iconProps))]
-)
+  }, props), [
+    icon(shape, _.merge({ style: { color: disabled ? colors.dark() : 'white' } }, iconProps))
+  ])
+}
 
 export const tabBar = ({ activeTab, tabNames, refresh = _.noop, getHref }, children = []) => {
   const navTab = currentTab => {

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -7,7 +7,7 @@ import Interactive from 'react-interactive'
 import Pagination from 'react-paginating'
 import { arrayMove, SortableContainer, SortableElement, SortableHandle } from 'react-sortable-hoc'
 import { AutoSizer, Grid as RVGrid, List, ScrollSync as RVScrollSync } from 'react-virtualized'
-import { buttonPrimary, Checkbox, Clickable, linkButton } from 'src/components/common'
+import { buttonPrimary, Checkbox, Clickable, link } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import Modal from 'src/components/Modal'
 import TooltipTrigger from 'src/components/TooltipTrigger'
@@ -520,11 +520,11 @@ export class ColumnSelector extends Component {
       }, [
         div({ style: { marginBottom: '1rem', display: 'flex' } }, [
           div({ style: { fontWeight: 500 } }, ['Show:']),
-          linkButton({ style: { padding: '0 0.5rem' }, onClick: () => this.setAll(true) }, ['all']),
+          link({ style: { padding: '0 0.5rem' }, onClick: () => this.setAll(true) }, ['all']),
           '|',
-          linkButton({ style: { padding: '0 0.5rem' }, onClick: () => this.setAll(false) }, ['none']),
+          link({ style: { padding: '0 0.5rem' }, onClick: () => this.setAll(false) }, ['none']),
           div({ style: { marginLeft: 'auto', fontWeight: 500 } }, ['Sort:']),
-          linkButton({ style: { padding: '0 0.5rem' }, onClick: () => this.sort() }, ['alphabetical'])
+          link({ style: { padding: '0 0.5rem' }, onClick: () => this.sort() }, ['alphabetical'])
         ]),
         h(AutoSizer, { disableHeight: true }, [
           ({ width }) => {

--- a/src/components/workspace-utils.js
+++ b/src/components/workspace-utils.js
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp'
 import { Component, Fragment, useState } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
-import { buttonPrimary, linkButton, Select } from 'src/components/common'
+import { buttonPrimary, link, Select } from 'src/components/common'
 import NewWorkspaceModal from 'src/components/NewWorkspaceModal'
 import { Ajax, useCancellation } from 'src/libs/ajax'
 import { withErrorReporting } from 'src/libs/error'
@@ -86,7 +86,7 @@ export const WorkspaceImporter = withWorkspaces()(class WorkspaceImporter extend
           onClick: () => onImport(this.getSelectedWorkspace().workspace)
         }, ['Import']),
         div({ style: { marginLeft: '1rem', whiteSpace: 'pre' } }, ['Or ']),
-        linkButton({
+        link({
           onClick: () => this.setState({ creatingWorkspace: true })
         }, ['create a new workspace'])
       ]),

--- a/src/pages/billing/List.js
+++ b/src/pages/billing/List.js
@@ -3,7 +3,7 @@ import * as qs from 'qs'
 import { Fragment } from 'react'
 import { a, div, h, span } from 'react-hyperscript-helpers'
 import Interactive from 'react-interactive'
-import { buttonPrimary, Clickable, linkButton, Select, spinnerOverlay } from 'src/components/common'
+import { buttonPrimary, Clickable, link, Select, spinnerOverlay } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import { ValidatedInput } from 'src/components/input'
 import Modal from 'src/components/Modal'
@@ -56,7 +56,7 @@ const noBillingMessage = div({ style: { fontSize: 20, margin: '2rem' } }, [
     'To get started, click the plus button to ', span({ style: { fontWeight: 600 } }, ['create a Billing Project'])
   ]),
   div({ style: { marginTop: '1rem', fontSize: 16 } }, [
-    linkButton({
+    link({
       ...Utils.newTabLinkProps,
       href: `https://support.terra.bio/hc/en-us/articles/360026182251`
     }, [`What is a billing project?`])
@@ -68,7 +68,7 @@ const freeCreditsMessage = div({ style: { fontSize: 20, margin: '2rem' } }, [
     'Start your free trial by redeeming your ', span({ style: { fontWeight: 600 } }, ['Free Credits'])
   ]),
   div({ style: { marginTop: '1rem', fontSize: 16 } }, [
-    linkButton({
+    link({
       ...Utils.newTabLinkProps,
       href: `https://support.terra.bio/hc/en-us/articles/360027940952`
     }, [`What are Free Credits?`])

--- a/src/pages/groups/List.js
+++ b/src/pages/groups/List.js
@@ -2,7 +2,7 @@ import _ from 'lodash/fp'
 import { Fragment } from 'react'
 import { a, b, div, h } from 'react-hyperscript-helpers'
 import { pure } from 'recompose'
-import { buttonPrimary, Clickable, linkButton, PageBox, spinnerOverlay } from 'src/components/common'
+import { buttonPrimary, Clickable, link, PageBox, spinnerOverlay } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import { DelayedSearchInput, ValidatedInput } from 'src/components/input'
 import Modal from 'src/components/Modal'
@@ -111,7 +111,7 @@ const GroupCard = pure(({ group: { groupName, groupEmail, role }, onDelete }) =>
     div({ style: { flexGrow: 1 } }, [groupEmail]),
     div({ style: { width: 100, display: 'flex', alignItems: 'center' } }, [
       div({ style: { flexGrow: 1 } }, [isAdmin ? 'Admin' : 'Member']),
-      isAdmin && linkButton({
+      isAdmin && link({
         onClick: onDelete,
         style: { margin: '-1rem', padding: '1rem' }
       }, [
@@ -137,7 +137,7 @@ const noGroupsMessage = div({ style: { fontSize: 20, margin: '0 1rem' } }, [
     'Create a group to share your workspaces with others.'
   ]),
   div({ style: { marginTop: '1rem', fontSize: 16 } }, [
-    linkButton({
+    link({
       ...Utils.newTabLinkProps,
       href: `https://support.terra.bio/hc/en-us/articles/360026775691`
     }, [`How do I use groups to manage authorization?`])

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -6,7 +6,7 @@ import { pure } from 'recompose'
 import removeMd from 'remove-markdown'
 import togglesListView from 'src/components/CardsListToggle'
 import {
-  AsyncCreatableSelect, Clickable, LabeledCheckbox, linkButton, MenuButton, menuIcon, PageBox, Select, topSpinnerOverlay, transparentSpinnerOverlay
+  AsyncCreatableSelect, Clickable, LabeledCheckbox, link, MenuButton, menuIcon, PageBox, Select, topSpinnerOverlay, transparentSpinnerOverlay
 } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import { DelayedSearchInput } from 'src/components/input'
@@ -149,7 +149,7 @@ const WorkspaceCard = pure(({
     closeOnClick: true,
     content: h(WorkspaceMenuContent, { namespace, name, onShare, onClone, onDelete })
   }, [
-    linkButton({
+    link({
       as: 'div',
       onClick: e => e.preventDefault(),
       disabled: !canView
@@ -298,7 +298,7 @@ export const WorkspaceList = _.flow(
         'To get started, click ', span({ style: { fontWeight: 600 } }, ['Create a New Workspace'])
       ]),
       div({ style: { marginTop: '1rem', fontSize: 16 } }, [
-        linkButton({
+        link({
           ...Utils.newTabLinkProps,
           href: `https://support.terra.bio/hc/en-us/articles/360022716811`
         }, [`What's a workspace?`])

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -5,7 +5,7 @@ import { Fragment } from 'react'
 import { div, h, span } from 'react-hyperscript-helpers'
 import SimpleMDE from 'react-simplemde-editor'
 import * as breadcrumbs from 'src/components/breadcrumbs'
-import { AsyncCreatableSelect, buttonPrimary, buttonSecondary, link, linkButton, spinnerOverlay } from 'src/components/common'
+import { AsyncCreatableSelect, buttonPrimary, buttonSecondary, link, spinnerOverlay } from 'src/components/common'
 import { icon, spinner } from 'src/components/icons'
 import { Markdown } from 'src/components/Markdown'
 import { InfoBox } from 'src/components/PopupTrigger'
@@ -221,7 +221,7 @@ export const WorkspaceDashboard = _.flow(
       div({ style: styles.leftBox }, [
         div({ style: styles.header }, [
           'About the workspace',
-          !isEditing && linkButton({
+          !isEditing && link({
             style: { marginLeft: '0.5rem' },
             disabled: !!Utils.editWorkspaceError(workspace),
             tooltip: Utils.editWorkspaceError(workspace),
@@ -309,7 +309,7 @@ export const WorkspaceDashboard = _.flow(
           _.map(tag => {
             return span({ key: tag, style: styles.tag }, [
               tag,
-              Utils.canWrite(accessLevel) && linkButton({
+              Utils.canWrite(accessLevel) && link({
                 tooltip: 'Remove tag',
                 disabled: busy,
                 onClick: () => this.deleteTag(tag),
@@ -337,7 +337,7 @@ export const WorkspaceDashboard = _.flow(
         ]),
         div({ style: { display: 'flex' } }, [
           div({ style: Style.noWrapEllipsis }, [bucketName]),
-          linkButton({
+          link({
             style: { margin: '0 0.5rem', flexShrink: 0 },
             tooltip: 'Copy bucket name',
             onClick: withErrorReporting('Error copying to clipboard', async () => {

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -8,7 +8,7 @@ import { div, form, h, input } from 'react-hyperscript-helpers'
 import { AutoSizer } from 'react-virtualized'
 import * as breadcrumbs from 'src/components/breadcrumbs'
 import { requesterPaysWrapper, withRequesterPaysHandler } from 'src/components/bucket-utils'
-import { buttonPrimary, linkButton, Select, spinnerOverlay } from 'src/components/common'
+import { buttonPrimary, Clickable, link, Select, spinnerOverlay } from 'src/components/common'
 import DataTable from 'src/components/DataTable'
 import ExportDataModal from 'src/components/ExportDataModal'
 import FloatingActionButton from 'src/components/FloatingActionButton'
@@ -53,9 +53,9 @@ const styles = {
 }
 
 const DataTypeButton = ({ selected, children, iconName = 'listAlt', iconSize = 14, ...props }) => {
-  return linkButton({
+  return h(Clickable, {
     as: 'span',
-    style: Style.navList.item(selected),
+    style: { ...Style.navList.item(selected), color: colors.accent() },
     hover: Style.navList.itemHover(selected),
     ...props
   }, [
@@ -161,10 +161,10 @@ const LocalVariablesContent = class LocalVariablesContent extends Component {
       onDropAccepted: upload
     }, [
       div({ style: { flex: 'none', display: 'flex', alignItems: 'center', marginBottom: '1rem', justifyContent: 'flex-end' } }, [
-        linkButton({ onClick: download }, ['Download TSV']),
+        link({ onClick: download }, ['Download TSV']),
         !Utils.editWorkspaceError(workspace) && h(Fragment, [
           div({ style: { whiteSpace: 'pre' } }, ['  |  Drag or click to ']),
-          linkButton({ onClick: () => this.uploader.current.open() }, ['upload TSV'])
+          link({ onClick: () => this.uploader.current.open() }, ['upload TSV'])
         ]),
         h(DelayedSearchInput, {
           style: { width: 300, marginLeft: '1rem' },
@@ -221,20 +221,20 @@ const LocalVariablesContent = class LocalVariablesContent extends Component {
                             onChange: ({ value }) => this.setState({ editType: value }),
                             options: ['string', 'number', 'boolean', 'string list', 'number list', 'boolean list']
                           }),
-                          linkButton({
+                          link({
                             tooltip: Utils.summarizeErrors(inputErrors) || 'Save changes',
                             disabled: !!inputErrors.length,
                             style: { marginLeft: '1rem' },
                             onClick: () => saveAttribute(originalKey)
                           }, [icon('success-standard', { size: 23 })]),
-                          linkButton({
+                          link({
                             tooltip: 'Cancel editing',
                             style: { marginLeft: '1rem' },
                             onClick: () => stopEditing()
                           }, [icon('times-circle', { size: 23 })])
                         ]) :
                         div({ className: 'hover-only' }, [
-                          linkButton({
+                          link({
                             disabled: !!Utils.editWorkspaceError(workspace),
                             tooltip: Utils.editWorkspaceError(workspace) || 'Edit variable',
                             style: { marginLeft: '1rem' },
@@ -245,7 +245,7 @@ const LocalVariablesContent = class LocalVariablesContent extends Component {
                               editType: typeof originalValue === 'object' ? `${typeof originalValue.items[0]} list` : typeof originalValue
                             })
                           }, [icon('edit', { size: 19 })]),
-                          linkButton({
+                          link({
                             disabled: !!Utils.editWorkspaceError(workspace),
                             tooltip: Utils.editWorkspaceError(workspace) || 'Delete variable',
                             style: { marginLeft: '1rem' },
@@ -615,7 +615,7 @@ const BucketContent = _.flow(
         div([
           _.map(({ label, target }) => {
             return h(Fragment, { key: target }, [
-              linkButton({ style: { textDecoration: 'underline' }, onClick: () => this.load(target) }, [label]),
+              link({ style: { textDecoration: 'underline' }, onClick: () => this.load(target) }, [label]),
               ' / '
             ])
           }, [
@@ -637,20 +637,20 @@ const BucketContent = _.flow(
             ..._.map(p => {
               return {
                 name: h(TextCell, [
-                  linkButton({ style: { textDecoration: 'underline' }, onClick: () => this.load(p) }, [p.slice(prefix.length)])
+                  link({ style: { textDecoration: 'underline' }, onClick: () => this.load(p) }, [p.slice(prefix.length)])
                 ])
               }
             }, prefixes),
             ..._.map(({ name, size, updated }) => {
               return {
-                button: linkButton({
+                button: link({
                   style: { display: 'flex' }, onClick: () => this.setState({ deletingName: name }),
                   tooltip: 'Delete file'
                 }, [
                   icon('trash', { size: 16, className: 'hover-only' })
                 ]),
                 name: h(TextCell, [
-                  linkButton({ style: { textDecoration: 'underline' }, onClick: () => this.setState({ viewingName: name }) }, [
+                  link({ style: { textDecoration: 'underline' }, onClick: () => this.setState({ viewingName: name }) }, [
                     name.slice(prefix.length)
                   ])
                 ]),
@@ -747,7 +747,7 @@ const WorkspaceData = _.flow(
         div({ style: styles.dataTypeSelectionPanel }, [
           div({ style: Style.navList.heading }, [
             div(['Tables']),
-            linkButton({
+            link({
               disabled: !!Utils.editWorkspaceError(workspace),
               tooltip: Utils.editWorkspaceError(workspace) || 'Upload .tsv',
               onClick: () => this.setState({ uploadingFile: true })
@@ -764,7 +764,7 @@ const WorkspaceData = _.flow(
           }, _.toPairs(entityMetadata)),
           div({ style: Style.navList.heading }, [
             div(['Reference Data']),
-            linkButton({
+            link({
               disabled: !!Utils.editWorkspaceError(workspace),
               tooltip: Utils.editWorkspaceError(workspace) || 'Add reference data',
               onClick: () => this.setState({ importingReference: true })
@@ -803,19 +803,14 @@ const WorkspaceData = _.flow(
             }, [
               div({ style: { display: 'flex', justifyContent: 'space-between' } }, [
                 type,
-                linkButton({
+                link({
                   disabled: !!Utils.editWorkspaceError(workspace),
                   tooltip: Utils.editWorkspaceError(workspace) || `Delete ${type}`,
                   onClick: e => {
                     e.stopPropagation()
                     this.setState({ deletingReference: type })
                   }
-                }, [
-                  icon('minus-circle', {
-                    size: 16,
-                    style: { color: colors.accent() }
-                  })
-                ])
+                }, [icon('minus-circle', { size: 16 })])
               ])
             ])
           }, _.keys(referenceData)),

--- a/src/pages/workspaces/workspace/ShareWorkspaceModal.js
+++ b/src/pages/workspaces/workspace/ShareWorkspaceModal.js
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp'
 import { Component } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
-import { buttonPrimary, LabeledCheckbox, linkButton, Select, spinnerOverlay } from 'src/components/common'
+import { buttonPrimary, LabeledCheckbox, link, Select, spinnerOverlay } from 'src/components/common'
 import { centeredSpinner, icon } from 'src/components/icons'
 import { AutocompleteTextInput } from 'src/components/input'
 import Modal from 'src/components/Modal'
@@ -166,7 +166,7 @@ export default ajaxCaller(class ShareWorkspaceModal extends Component {
           maxAccessLevel: workspace.accessLevel
         })
       ]),
-      !isPO && !isMe && linkButton({
+      !isPO && !isMe && link({
         onClick: () => this.setState({ acl: _.remove({ email }, acl) })
       }, [icon('minus-circle', { size: 24 })])
     ])

--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -4,7 +4,7 @@ import { div, h, iframe } from 'react-hyperscript-helpers'
 import * as breadcrumbs from 'src/components/breadcrumbs'
 import { requesterPaysWrapper, withRequesterPaysHandler } from 'src/components/bucket-utils'
 import { NewClusterModal } from 'src/components/ClusterManager'
-import { buttonOutline, buttonPrimary, linkButton } from 'src/components/common'
+import { buttonOutline, buttonPrimary, link } from 'src/components/common'
 import { spinner } from 'src/components/icons'
 import { notify } from 'src/components/Notifications'
 import { Ajax, useCancellation } from 'src/libs/ajax'
@@ -237,7 +237,7 @@ const NotebookEditor = ({ notebookName, workspace, workspace: { workspace: { nam
       ['Error', () => h(StatusMessage, ['Notebook runtime error.'])],
       [null, () => h(StatusMessage, [
         'You need a notebook runtime environment. ',
-        linkButton({ onClick: () => setCreateOpen(true) }, ['Create one']),
+        link({ onClick: () => setCreateOpen(true) }, ['Create one']),
         ' to get started.'
       ])]
     ),

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -7,7 +7,7 @@ import { div, h, span } from 'react-hyperscript-helpers'
 import { AutoSizer } from 'react-virtualized'
 import * as breadcrumbs from 'src/components/breadcrumbs'
 import {
-  buttonPrimary, buttonSecondary, Clickable, LabeledCheckbox, link, linkButton, MenuButton, menuIcon, methodLink, RadioButton, Select, spinnerOverlay
+  buttonPrimary, buttonSecondary, Clickable, LabeledCheckbox, link, MenuButton, menuIcon, methodLink, RadioButton, Select, spinnerOverlay
 } from 'src/components/common'
 import { centeredSpinner, icon } from 'src/components/icons'
 import { AutocompleteTextInput } from 'src/components/input'
@@ -123,7 +123,7 @@ const WorkflowIOTable = ({ which, inputsOutputs: data, config, errors, onChange,
               div({ style: { fontWeight: 'bold' } }, ['Attribute']),
               !readOnly && which === 'outputs' && h(Fragment, [
                 div({ style: { whiteSpace: 'pre' } }, ['  |  ']),
-                linkButton({ onClick: onSetDefaults }, ['Use defaults'])
+                link({ onClick: onSetDefaults }, ['Use defaults'])
               ])
             ]),
             cellRenderer: ({ rowIndex }) => {
@@ -212,7 +212,7 @@ const BucketContentModal = ajaxCaller(class BucketContentModal extends Component
       div([
         _.map(({ label, target }) => {
           return h(Fragment, { key: target }, [
-            linkButton({ onClick: () => this.load(target) }, [label]),
+            link({ onClick: () => this.load(target) }, [label]),
             ' / '
           ])
         }, [
@@ -231,14 +231,14 @@ const BucketContentModal = ajaxCaller(class BucketContentModal extends Component
           ..._.map(p => {
             return {
               name: h(TextCell, [
-                linkButton({ onClick: () => this.load(p) }, [p.slice(prefix.length)])
+                link({ onClick: () => this.load(p) }, [p.slice(prefix.length)])
               ])
             }
           }, prefixes),
           ..._.map(({ name }) => {
             return {
               name: h(TextCell, [
-                linkButton({ onClick: () => onSelect(`"gs://${bucketName}/${name}"`) }, [
+                link({ onClick: () => onSelect(`"gs://${bucketName}/${name}"`) }, [
                   name.slice(prefix.length)
                 ])
               ])
@@ -563,7 +563,7 @@ const WorkflowView = _.flow(
                   }, [menuIcon('trash'), 'Delete'])
                 ])
               }, [
-                linkButton({}, [icon('cardMenuIcon', { size: 22 })])
+                link({}, [icon('cardMenuIcon', { size: 22 })])
               ])
             ]),
             span({ style: { color: colors.dark(), fontSize: 24 } }, name)
@@ -634,7 +634,7 @@ const WorkflowView = _.flow(
                 },
                 options: _.keys(entityMetadata)
               }),
-              linkButton({
+              link({
                 disabled: currentSnapRedacted || this.isSingle() || !rootEntityType || !!Utils.editWorkspaceError(ws),
                 tooltip: Utils.editWorkspaceError(ws),
                 onClick: () => this.setState({ selectingData: true }),
@@ -792,13 +792,13 @@ const WorkflowView = _.flow(
     }, [
       div({ style: { flex: 'none', display: 'flex', marginBottom: '0.25rem' } }, [
         key === 'inputs' && _.some('optional', modifiedInputsOutputs['inputs']) ?
-          linkButton({ style: { marginRight: 'auto' }, onClick: () => this.setState({ includeOptionalInputs: !includeOptionalInputs }) },
+          link({ style: { marginRight: 'auto' }, onClick: () => this.setState({ includeOptionalInputs: !includeOptionalInputs }) },
             [includeOptionalInputs ? 'Hide optional inputs' : 'Show optional inputs']) :
           div({ style: { marginRight: 'auto' } }),
-        linkButton({ onClick: () => this.downloadJson(key) }, ['Download json']),
+        link({ onClick: () => this.downloadJson(key) }, ['Download json']),
         !currentSnapRedacted && !Utils.editWorkspaceError(workspace) && h(Fragment, [
           div({ style: { whiteSpace: 'pre' } }, ['  |  Drag or click to ']),
-          linkButton({ onClick: () => this.uploader.current.open() }, ['upload json'])
+          link({ onClick: () => this.uploader.current.open() }, ['upload json'])
         ])
       ]),
       filteredData.length !== 0 &&


### PR DESCRIPTION
These two were originally intended for separate use cases (`href` vs `onClick`), but they drifted closer over time, and at this point it seems clearer to combine them.

`link` is now the preferred component for anything clickable that looks like a link (e.g. blue text with a lighter hover). This can include standalone icons as well, since they pick up the text color.