### PR TITLE
Add requester-pays-aware bucket check for launching a workflow

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -74,7 +74,7 @@ const checkRequesterPaysError = async response => {
  * project if the user has access, retrying the request once if necessary.
  */
 const withRequesterPays = wrappedFetch => (url, ...args) => {
-  const bucket = /\/b\/([^/]+)\//.exec(url)[1]
+  const bucket = /\/b\/([^/?]+)[/?]/.exec(url)[1]
   const workspace = workspaceStore.get()
   const userProject = workspace && Utils.canWrite(workspace.accessLevel) ? workspace.workspace.namespace : requesterPaysProjectStore.get()
   const tryRequest = async () => {
@@ -714,6 +714,12 @@ const Buckets = signal => ({
         headers: { 'Content-Type': file.type, 'Content-Length': file.size }
       })
     )
+  },
+
+  checkBucketAccess: async (bucket, namespace) => {
+    const res = await fetchBuckets(`storage/v1/b/${bucket}?fields=billing`,
+      _.merge(authOpts(await saToken(namespace)), { signal }))
+    return res.json()
   },
 
   notebook: (namespace, bucket, name) => {

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -443,6 +443,16 @@ const Workspaces = signal => ({
         return fetchRawls(`${root}/checkBucketReadAccess`, _.merge(authOpts(), { signal }))
       },
 
+      checkBucketAccess: async (bucket, accessLevel) => {
+        if (!Utils.canWrite(accessLevel)) {
+          return false
+        }
+
+        const res = await fetchBuckets(`storage/v1/b/${bucket}?fields=billing`,
+          _.merge(authOpts(await saToken(namespace)), { signal }))
+        return res.json()
+      },
+
       details: async () => {
         const res = await fetchRawls(root, _.merge(authOpts(), { signal }))
         return res.json()
@@ -714,12 +724,6 @@ const Buckets = signal => ({
         headers: { 'Content-Type': file.type, 'Content-Length': file.size }
       })
     )
-  },
-
-  checkBucketAccess: async (bucket, namespace) => {
-    const res = await fetchBuckets(`storage/v1/b/${bucket}?fields=billing`,
-      _.merge(authOpts(await saToken(namespace)), { signal }))
-    return res.json()
   },
 
   notebook: (namespace, bucket, name) => {

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -444,6 +444,7 @@ const Workspaces = signal => ({
       },
 
       checkBucketAccess: async (bucket, accessLevel) => {
+        // Protect against asking for a project-specific pet service account token if user cannot write to the workspace
         if (!Utils.canWrite(accessLevel)) {
           return false
         }

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -418,10 +418,10 @@ const WorkflowView = _.flow(
    * @returns {Promise<boolean>}
    */
   async preFlightBucketAccess() {
-    const { namespace, workspace: { workspace: { bucketName } }, ajax: { Buckets } } = this.props
+    const { namespace, name, workspace: { accessLevel, workspace: { bucketName } }, ajax: { Workspaces } } = this.props
 
     try {
-      await Buckets.checkBucketAccess(bucketName, namespace)
+      await Workspaces.workspace(namespace, name).checkBucketAccess(bucketName, accessLevel)
       return true
     } catch (error) {
       // Could check error.requesterPaysError here but for this purpose it really doesn't matter what the error was.

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -425,7 +425,7 @@ const WorkflowView = _.flow(
       const [entityMetadata, validationResponse, config] = await Promise.all([
         ws.entityMetadata(),
         this.getValidation(),
-        ws.methodConfig(workflowNamespace, workflowName).get(),
+        ws.methodConfig(workflowNamespace, workflowName).get()
       ])
       const { methodRepoMethod: { methodNamespace, methodName } } = config
       const isRedacted = !validationResponse


### PR DESCRIPTION
Eliminates use of the workspace-level non-requester-pays-aware bucket access check used as a factor in deciding whether or not to disable the launch analysis button. Replaces it with a custom implementation of a bucket access check that retries requester-pays-required responses with the workspace's project.

Note: This implementation is only applicable to writers and above. For readers, we need to instead use a "default pet service account" (which is behavior I may be adding before calling SATURN-860 done).

Testing this is... interesting. The primary purpose is to catch cases where the permissions in Google don't line up with sam, either because of lag or an synchronization error. Therefore, beyond testing requester-pays cases, the easiest way I found to test that behavior is to modify WorkflowView.js:424, replacing `bucketName` with a static string naming a bucket that exists that the signed-in user does not have access to.

EDIT 7/17: Related to testing note above, that line has moved to LaunchAnalysisModal:23