### PR TITLE
cluster overview page

### DIFF
--- a/src/components/ClusterManager.js
+++ b/src/components/ClusterManager.js
@@ -318,7 +318,7 @@ export class NewClusterModal extends PureComponent {
   }
 }
 
-const ClusterErrorModal = ({ cluster, onDismiss }) => {
+export const ClusterErrorModal = ({ cluster, onDismiss }) => {
   const [error, setError] = useState()
   const [userscriptError, setUserscriptError] = useState(false)
   const [loadingClusterDetails, setLoadingClusterDetails] = useState(false)
@@ -345,6 +345,25 @@ const ClusterErrorModal = ({ cluster, onDismiss }) => {
   }, [
     div({ style: { whiteSpace: 'pre-wrap', overflowWrap: 'break-word', overflowY: 'auto', maxHeight: 500, background: colors.light() } }, [error]),
     loadingClusterDetails && spinnerOverlay
+  ])
+}
+
+export const DeleteClusterModal = ({ cluster: { googleProject, clusterName }, onDismiss, onSuccess }) => {
+  const [deleting, setDeleting] = useState()
+  const deleteCluster = _.flow(
+    Utils.withBusyState(setDeleting),
+    withErrorReporting('Error deleting cluster')
+  )(async () => {
+    await Ajax().Jupyter.cluster(googleProject, clusterName).delete()
+    onSuccess()
+  })
+  return h(Modal, {
+    title: 'Delete notebook runtime?',
+    onDismiss,
+    okButton: deleteCluster
+  }, [
+    'Deleting the notebook runtime will stop all running notebooks and associated costs. You can recreate it later, which will take several minutes.',
+    deleting && spinnerOverlay
   ])
 }
 
@@ -454,14 +473,6 @@ export default ajaxCaller(class ClusterManager extends PureComponent {
         ({ googleProject, clusterName }) => Jupyter.cluster(googleProject, clusterName).delete(),
         _.without([_.nth(keepIndex, activeClusters)], activeClusters)
       ))
-    )
-  }
-
-  destroyActiveCluster() {
-    const { ajax: { Jupyter } } = this.props
-    const { googleProject, clusterName } = this.getCurrentCluster()
-    this.executeAndRefresh(
-      Jupyter.cluster(googleProject, clusterName).delete()
     )
   }
 
@@ -604,14 +615,14 @@ export default ajaxCaller(class ClusterManager extends PureComponent {
           icon('cog', { size: 22, style: { color: isDisabled ? colors.dark(0.7) : colors.accent() } })
         ])
       ]),
-      deleteModalOpen && h(Modal, {
-        title: 'Delete notebook runtime?',
+      deleteModalOpen && h(DeleteClusterModal, {
+        cluster: this.getCurrentCluster(),
         onDismiss: () => this.setState({ deleteModalOpen: false }),
-        okButton: () => {
+        onSuccess: () => {
           this.setState({ deleteModalOpen: false })
-          this.destroyActiveCluster()
+          this.refreshClusters()
         }
-      }, ['Deleting the cluster will stop all running notebooks and associated costs. You can recreate it later, which will take several minutes.']),
+      }),
       createModalOpen && h(NewClusterModal, {
         namespace, currentCluster,
         onCancel: () => this.setState({ createModalOpen: false }),

--- a/src/components/ClusterManager.js
+++ b/src/components/ClusterManager.js
@@ -11,7 +11,7 @@ import PopupTrigger from 'src/components/PopupTrigger'
 import TooltipTrigger from 'src/components/TooltipTrigger'
 import { machineTypes, profiles } from 'src/data/clusters'
 import { Ajax, ajaxCaller } from 'src/libs/ajax'
-import { clusterCost, machineConfigCost, normalizeMachineConfig } from 'src/libs/cluster-utils'
+import { clusterCost, currentCluster, machineConfigCost, normalizeMachineConfig, trimClustersOldestFirst } from 'src/libs/cluster-utils'
 import colors from 'src/libs/colors'
 import { reportError, withErrorReporting } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
@@ -437,11 +437,12 @@ export default ajaxCaller(class ClusterManager extends PureComponent {
 
   getActiveClustersOldestFirst() {
     const { clusters } = this.props
-    return Utils.trimClustersOldestFirst(clusters)
+    return trimClustersOldestFirst(clusters)
   }
 
   getCurrentCluster() {
-    return _.last(this.getActiveClustersOldestFirst())
+    const { clusters } = this.props
+    return currentCluster(clusters)
   }
 
   async executeAndRefresh(promise) {

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -228,6 +228,10 @@ const TopBar = Utils.connectAtom(authStore, 'authState')(class TopBar extends Co
                 onClick: () => this.hideNav()
               }, ['Billing']),
               h(DropDownSubItem, {
+                href: Nav.getLink('clusters'),
+                onClick: () => this.hideNav()
+              }, ['Notebook runtimes']),
+              h(DropDownSubItem, {
                 onClick: signOut
               }, ['Sign Out'])
             ]) :

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -230,7 +230,7 @@ const TopBar = Utils.connectAtom(authStore, 'authState')(class TopBar extends Co
               h(DropDownSubItem, {
                 href: Nav.getLink('clusters'),
                 onClick: () => this.hideNav()
-              }, ['Notebook runtimes']),
+              }, ['Notebook Runtimes']),
               h(DropDownSubItem, {
                 onClick: signOut
               }, ['Sign Out'])

--- a/src/libs/cluster-utils.js
+++ b/src/libs/cluster-utils.js
@@ -41,3 +41,10 @@ export const clusterCost = ({ machineConfig, status }) => {
       return machineConfigCost(machineConfig)
   }
 }
+
+export const trimClustersOldestFirst = _.flow(
+  _.remove({ status: 'Deleting' }),
+  _.sortBy('createdDate')
+)
+
+export const currentCluster = _.flow(trimClustersOldestFirst, _.last)

--- a/src/libs/error.js
+++ b/src/libs/error.js
@@ -20,3 +20,11 @@ export const withErrorReporting = _.curry((title, fn) => async (...args) => {
     reportError(title, error)
   }
 })
+
+export const withErrorIgnoring = fn => async (...args) => {
+  try {
+    return await fn(...args)
+  } catch (error) {
+    // ignore error
+  }
+}

--- a/src/libs/error.js
+++ b/src/libs/error.js
@@ -21,6 +21,7 @@ export const withErrorReporting = _.curry((title, fn) => async (...args) => {
   }
 })
 
+// Transforms an async function so that it catches and ignores errors
 export const withErrorIgnoring = fn => async (...args) => {
   try {
     return await fn(...args)

--- a/src/libs/routes.js
+++ b/src/libs/routes.js
@@ -2,6 +2,7 @@ import _ from 'lodash/fp'
 import pathToRegexp from 'path-to-regexp'
 import { routeHandlersStore } from 'src/libs/state'
 import * as Projects from 'src/pages/billing/List'
+import * as Clusters from 'src/pages/Clusters'
 import * as Group from 'src/pages/groups/Group'
 import * as Groups from 'src/pages/groups/List'
 import * as HoF from 'src/pages/HoF'
@@ -55,6 +56,7 @@ const routes = _.flatten([
   Showcase.navPaths,
   Projects.navPaths,
   HoF.navPaths,
+  Clusters.navPaths,
   NotFound.navPaths // must be last
 ])
 

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -330,11 +330,6 @@ export const useGetter = value => {
   return () => ref.current
 }
 
-export const trimClustersOldestFirst = _.flow(
-  _.remove({ status: 'Deleting' }),
-  _.sortBy('createdDate')
-)
-
 export const handleNonRunningCluster = ({ status, googleProject, clusterName }, JupyterAjax) => {
   switch (status) {
     case 'Stopped':

--- a/src/pages/Clusters.js
+++ b/src/pages/Clusters.js
@@ -1,0 +1,168 @@
+import _ from 'lodash/fp'
+import { Fragment, useState } from 'react'
+import { div, h } from 'react-hyperscript-helpers'
+import { AutoSizer } from 'react-virtualized'
+import { ClusterErrorModal, DeleteClusterModal } from 'src/components/ClusterManager'
+import { Clickable, Link, spinnerOverlay } from 'src/components/common'
+import { icon } from 'src/components/icons'
+import { FlexTable, Sortable } from 'src/components/table'
+import TooltipTrigger from 'src/components/TooltipTrigger'
+import TopBar from 'src/components/TopBar'
+import { Ajax, useCancellation } from 'src/libs/ajax'
+import { getUser } from 'src/libs/auth'
+import { clusterCost } from 'src/libs/cluster-utils'
+import colors from 'src/libs/colors'
+import { withErrorIgnoring, withErrorReporting } from 'src/libs/error'
+import * as Nav from 'src/libs/nav'
+import * as Style from 'src/libs/style'
+import { delay, formatUSD, makeCompleteDate, trimClustersOldestFirst, useGetter, useOnMount, withBusyState } from 'src/libs/utils'
+
+
+const Clusters = () => {
+  const signal = useCancellation()
+  const [clusters, setClusters] = useState()
+  const [loading, setLoading] = useState(false)
+  const [errorClusterId, setErrorClusterId] = useState()
+  const getErrorClusterId = useGetter(errorClusterId)
+  const [deleteClusterId, setDeleteClusterId] = useState()
+  const getDeleteClusterId = useGetter(deleteClusterId)
+  const [sort, setSort] = useState({ field: 'project', direction: 'asc' })
+
+  const updateClusters = async () => {
+    const newClusters = _.filter({ creator: getUser().email }, await Ajax(signal).Jupyter.clustersList())
+    setClusters(newClusters)
+    if (!_.some({ id: getErrorClusterId() }, newClusters)) {
+      setErrorClusterId(undefined)
+    }
+    if (!_.some({ id: getDeleteClusterId() }, newClusters)) {
+      setDeleteClusterId(undefined)
+    }
+  }
+  const loadClusters = _.flow(
+    withErrorReporting('Error loading clusters'),
+    withBusyState(setLoading)
+  )(updateClusters)
+  const loadClustersSilently = withErrorIgnoring(updateClusters)
+  const pollClusters = async () => {
+    while (true) {
+      await delay(30000)
+      await loadClustersSilently()
+    }
+  }
+  useOnMount(() => {
+    loadClusters()
+    pollClusters()
+  })
+
+  const filteredClusters = _.orderBy([{
+    project: 'googleProject',
+    status: 'status',
+    created: 'createdDate',
+    accessed: 'dateAccessed',
+    cost: clusterCost
+  }[sort.field]], [sort.direction], clusters)
+
+  const totalCost = _.sum(_.map(clusterCost, clusters))
+
+  const clustersByProject = _.groupBy('googleProject', clusters)
+
+  return h(Fragment, [
+    h(TopBar, { title: 'Notebook runtimes', href: Nav.getLink('clusters') }),
+    div({ style: { padding: '1rem', flex: 1, display: 'flex', flexDirection: 'column' } }, [
+      div({ style: { ...Style.elements.sectionHeader, textTransform: 'uppercase', marginBottom: '1rem' } }, ['Your notebook runtimes']),
+      div({ style: { flex: 1 } }, [
+        clusters && h(AutoSizer, [
+          ({ width, height }) => h(FlexTable, {
+            width, height, rowCount: filteredClusters.length,
+            columns: [
+              {
+                headerRenderer: () => h(Sortable, { sort, field: 'project', onSort: setSort }, ['Billing project']),
+                cellRenderer: ({ rowIndex }) => {
+                  const cluster = filteredClusters[rowIndex]
+                  const inactive = !_.includes(cluster.status, ['Deleting', 'Error']) &&
+                    _.last(trimClustersOldestFirst(clustersByProject[cluster.googleProject])) !== cluster
+                  return h(Fragment, [
+                    cluster.googleProject,
+                    inactive && h(TooltipTrigger, {
+                      content: 'This billing project has multiple active runtime environments. Only the most recently created one will be used.'
+                    }, [icon('warning-standard', { style: { marginLeft: '0.25rem', color: colors.warning() } })])
+                  ])
+                }
+              },
+              {
+                size: { basis: 150, grow: 0 },
+                headerRenderer: () => h(Sortable, { sort, field: 'status', onSort: setSort }, ['Status']),
+                cellRenderer: ({ rowIndex }) => {
+                  const cluster = filteredClusters[rowIndex]
+                  return h(Fragment, [
+                    cluster.status,
+                    cluster.status === 'Error' && h(Clickable, {
+                      tooltip: 'View error',
+                      onClick: () => setErrorClusterId(cluster.id)
+                    }, [icon('warning-standard', { style: { marginLeft: '0.25rem', color: colors.danger() } })])
+                  ])
+                }
+              },
+              {
+                size: { basis: 250, grow: 0 },
+                headerRenderer: () => h(Sortable, { sort, field: 'created', onSort: setSort }, ['Created']),
+                cellRenderer: ({ rowIndex }) => {
+                  return makeCompleteDate(filteredClusters[rowIndex].createdDate)
+                }
+              },
+              {
+                size: { basis: 250, grow: 0 },
+                headerRenderer: () => h(Sortable, { sort, field: 'accessed', onSort: setSort }, ['Last accessed']),
+                cellRenderer: ({ rowIndex }) => {
+                  return makeCompleteDate(filteredClusters[rowIndex].dateAccessed)
+                }
+              },
+              {
+                size: { basis: 240, grow: 0 },
+                headerRenderer: () => {
+                  return h(Sortable, { sort, field: 'cost', onSort: setSort }, [`Cost / hr (${formatUSD(totalCost)} total)`])
+                },
+                cellRenderer: ({ rowIndex }) => {
+                  return formatUSD(clusterCost(filteredClusters[rowIndex]))
+                }
+              },
+              {
+                size: { basis: 50, grow: 0 },
+                headerRenderer: () => null,
+                cellRenderer: ({ rowIndex }) => {
+                  const cluster = filteredClusters[rowIndex]
+                  return h(Link, {
+                    tooltip: 'Delete notebook runtime',
+                    onClick: () => setDeleteClusterId(cluster.id)
+                  }, [icon('trash')])
+                }
+              }
+            ]
+          })
+        ])
+      ]),
+      errorClusterId && h(ClusterErrorModal, {
+        cluster: _.find({ id: errorClusterId }, clusters),
+        onDismiss: () => setErrorClusterId(undefined)
+      }),
+      deleteClusterId && h(DeleteClusterModal, {
+        cluster: _.find({ id: deleteClusterId }, clusters),
+        onDismiss: () => setDeleteClusterId(undefined),
+        onSuccess: () => {
+          setDeleteClusterId(undefined)
+          loadClusters()
+        }
+      }),
+      loading && spinnerOverlay
+    ])
+  ])
+}
+
+export const navPaths = [
+  {
+    name: 'clusters',
+    path: '/clusters',
+    component: Clusters,
+    title: 'Runtime environments'
+  }
+]

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -10,6 +10,7 @@ import PopupTrigger from 'src/components/PopupTrigger'
 import TopBar from 'src/components/TopBar'
 import { Ajax, useCancellation } from 'src/libs/ajax'
 import { getUser } from 'src/libs/auth'
+import { currentCluster } from 'src/libs/cluster-utils'
 import colors from 'src/libs/colors'
 import { withErrorReporting } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
@@ -243,7 +244,7 @@ export const wrapWorkspace = ({ breadcrumbs, activeTab, title, topBarContent, sh
         workspace && h(WrappedComponent, {
           ref: child,
           workspace, loadingWorkspace, refreshWorkspace, refreshClusters,
-          cluster: !clusters ? undefined : (_.flow(Utils.trimClustersOldestFirst, _.remove({ status: 'Error' }), _.last)(clusters) || null),
+          cluster: !clusters ? undefined : (currentCluster(clusters) || null),
           ...props
         })
       ])


### PR DESCRIPTION
This adds a page where users can view/manage all their clusters across projects. Two main motivations are:

* Enable some visibility into resource usage and cost.
* Enable cleaning up unwanted clusters.

Having this page available also opens up the possibility for future improvements to the cluster manager widget.