### PR TITLE
enable passing data selections to workflows [SATURN-869]

### DIFF
--- a/src/libs/state.js
+++ b/src/libs/state.js
@@ -31,6 +31,12 @@ export const requesterPaysBuckets = Utils.atom([])
 
 export const requesterPaysProjectStore = Utils.atom()
 
+export const workflowSelectionStore = Utils.atom({
+  key: undefined,
+  entityType: undefined,
+  entities: undefined
+})
+
 /*
  * Modifies ajax responses for testing purposes.
  * Can be set to an array of objects of the form { fn, filter }.


### PR DESCRIPTION
This sets up some infrastructure to allow passing entity selections from the data page to the workflow page.

It introduces a store that is used like a 'mailbox' to hold data across the page transition. In order to trigger this behavior, the data page should populate the store with the appropriate selection data, as well as a unique key to identify this particular invocation. It should pass the key in a query param to the workflow page. On load, the workflow page looks for the query param, and if the key matches what's stored in the mailbox, it will pick up the selection data and apply the modifications to its state.

A couple noteworthy characteristics of this approach:
* The key ensures that we never mis-apply a selection to the wrong workflow, for example if the user uses the back button.
* Having a single value in the store means that we don't need to worry about a growing amount of data, since we only keep the last payload.
* If the selection data isn't available for some reason (due to back button usage or full page refresh), the page will just load the workflow unchanged as normal.

The other proposed approach was to lift selection state into a workspace wrapper components where it could be shared between the two pages. On reflection, that doesn't seem like the right model. Sharing implies a stronger two-way connection, whereas in this case we wouldn't expect (e.g.) changes on the workflow page to also show up on the data tab. This really comes down to a matter of _conveyance_ of data, not _unification_. They're still fundamentally different pieces of state, we just want to perform a one-time assignment from one to the other. Normally we'd pass this kind of data directly in the URL. Since the selection can be large, we need to do some indirection, but the basic operation is the same.

Note: If we had persistent workspace wrapper component, it might very well be cleaner for the 'mailbox' to live there instead of a global store. Since the patterns of access would be essentially the same, we can easily decide to move the data if/when we have that available.