### PR TITLE
handle no access on newly created ws [SATURN-104]

### DIFF
--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -97,7 +97,7 @@ const LocalVariablesContent = class LocalVariablesContent extends Component {
   }
 
   render() {
-    const { workspace, workspace: { workspace: { namespace, name, attributes } }, refreshWorkspace, loadingWorkspace, firstRender } = this.props
+    const { workspace, workspace: { workspace: { namespace, name, attributes } }, refreshWorkspace, firstRender } = this.props
     const { editIndex, deleteIndex, editKey, editValue, editType, textFilter } = this.state
     const stopEditing = () => this.setState({ editIndex: undefined, editKey: undefined, editValue: undefined, editType: undefined })
     const filteredAttributes = _.flow(
@@ -284,13 +284,12 @@ const LocalVariablesContent = class LocalVariablesContent extends Component {
           })
         },
         'Delete Variable')
-      }, ['This will permanently delete the data from Workspace Data.']),
-      loadingWorkspace && spinnerOverlay
+      }, ['This will permanently delete the data from Workspace Data.'])
     ])
   }
 }
 
-const ReferenceDataContent = ({ workspace: { workspace: { namespace, attributes } }, referenceKey, loadingWorkspace, firstRender }) => {
+const ReferenceDataContent = ({ workspace: { workspace: { namespace, attributes } }, referenceKey, firstRender }) => {
   const [textFilter, setTextFilter] = useState('')
 
   const selectedData = _.flow(
@@ -326,8 +325,7 @@ const ReferenceDataContent = ({ workspace: { workspace: { namespace, attributes 
           ]
         })
       ])
-    ]),
-    loadingWorkspace && spinnerOverlay
+    ])
   ])
 }
 
@@ -732,7 +730,7 @@ const WorkspaceData = _.flow(
   }
 
   render() {
-    const { namespace, name, workspace, workspace: { workspace: { attributes } }, loadingWorkspace, refreshWorkspace } = this.props
+    const { namespace, name, workspace, workspace: { workspace: { attributes } }, refreshWorkspace } = this.props
     const { selectedDataType, entityMetadata, importingReference, deletingReference, firstRender, refreshKey, uploadingFile } = this.state
     const referenceData = getReferenceData(attributes)
 
@@ -830,13 +828,11 @@ const WorkspaceData = _.flow(
             ['localVariables', () => h(LocalVariablesContent, {
               workspace,
               refreshWorkspace,
-              loadingWorkspace,
               firstRender
             })],
             ['referenceData', () => h(ReferenceDataContent, {
               key: selectedDataType,
               workspace,
-              loadingWorkspace,
               referenceKey: selectedDataType,
               firstRender
             })],

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -1,8 +1,9 @@
+import { differenceInSeconds } from 'date-fns'
 import _ from 'lodash/fp'
 import { Fragment, PureComponent, useRef, useState } from 'react'
 import { div, h, h2, p, span } from 'react-hyperscript-helpers'
 import ClusterManager from 'src/components/ClusterManager'
-import { ButtonPrimary, Clickable, comingSoon, Link, makeMenuIcon, MenuButton, TabBar } from 'src/components/common'
+import { ButtonPrimary, Clickable, comingSoon, Link, makeMenuIcon, MenuButton, spinnerOverlay, TabBar } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import NewWorkspaceModal from 'src/components/NewWorkspaceModal'
 import { clearNotification, notify } from 'src/components/Notifications'
@@ -191,6 +192,7 @@ export const wrapWorkspace = ({ breadcrumbs, activeTab, title, topBarContent, sh
     const child = useRef()
     const signal = useCancellation()
     const [accessError, setAccessError] = useState(false)
+    const accessNotificationId = useRef()
     const cachedWorkspace = Utils.useAtom(workspaceStore)
     const [loadingWorkspace, setLoadingWorkspace] = useState(false)
     const [clusters, setClusters] = useState(undefined)
@@ -209,6 +211,22 @@ export const wrapWorkspace = ({ breadcrumbs, activeTab, title, topBarContent, sh
         const workspace = await Ajax(signal).Workspaces.workspace(namespace, name).details()
         const res = await checkBucketAccess(signal, namespace, name)
         workspaceStore.set({ hasBucketAccess: res, ...workspace })
+
+        const { accessLevel, workspace: { createdBy, createdDate } } = workspace
+        if (!Utils.isOwner(accessLevel) && (createdBy === getUser().email) && (differenceInSeconds(new Date(createdDate), new Date()) < 60)) {
+          accessNotificationId.current = notify('info', 'Workspace access synchronizing', {
+            message: h(Fragment, [
+              'It looks like you just created this workspace. It may take up to a minute before you have access to modify it. Refresh at any time to re-check.',
+              div({ style: { marginTop: '1rem' } }, [h(Link, {
+                variant: 'light',
+                onClick: () => {
+                  refreshWorkspace()
+                  clearNotification(accessNotificationId.current)
+                }
+              }, 'Click to refresh now')])
+            ])
+          })
+        }
       } catch (error) {
         if (error.status === 404) {
           setAccessError(true)
@@ -243,10 +261,11 @@ export const wrapWorkspace = ({ breadcrumbs, activeTab, title, topBarContent, sh
       }, [
         workspace && h(WrappedComponent, {
           ref: child,
-          workspace, loadingWorkspace, refreshWorkspace, refreshClusters,
+          workspace, refreshWorkspace, refreshClusters,
           cluster: !clusters ? undefined : (currentCluster(clusters) || null),
           ...props
-        })
+        }),
+        loadingWorkspace && spinnerOverlay
       ])
     }
   }


### PR DESCRIPTION
Notifies when a user appears to have incorrect access to a workspace that they created within the last minute.

Also pulls up the loading workspace spinner so it appears consistently.