### PR TITLE
handle hrefs in Clickable

### DIFF
--- a/src/components/FirecloudNotification.js
+++ b/src/components/FirecloudNotification.js
@@ -21,7 +21,6 @@ const FirecloudNotification = () => {
           'Please update your bookmarks to our new URL, firecloud.terra.bio. Welcome to the future of FireCloud!'
         ]),
         h(ButtonOutline, {
-          as: 'a',
           ...Utils.newTabLinkProps,
           href: 'https://support.terra.bio/hc/en-us/sections/360004482892',
           style: { marginTop: '1rem' }

--- a/src/components/StepButtons.js
+++ b/src/components/StepButtons.js
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp'
 import { Fragment } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
-import Interactive from 'react-interactive'
+import { Clickable } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import colors from 'src/libs/colors'
 import * as Style from 'src/libs/style'
@@ -30,8 +30,7 @@ const dots = div({ style: { display: 'flex', margin: '0 0.5rem' } }, [
   div({ style: styles.dot }), div({ style: styles.dot })
 ])
 
-const stepButton = ({ key, title, isValid, activeTabKey, onChangeTab }) => h(Interactive, {
-  as: 'a',
+const stepButton = ({ key, title, isValid, activeTabKey, onChangeTab }) => h(Clickable, {
   style: styles.button(key === activeTabKey),
   onClick: () => onChangeTab(key)
 }, [

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -54,21 +54,6 @@ const styles = {
       zIndex: 2,
       display: 'flex', flexDirection: 'column'
     }),
-    item: {
-      display: 'flex', alignItems: 'center', flex: 'none',
-      height: 70, padding: '0 28px',
-      fontWeight: 600,
-      borderTop: `1px solid ${colors.dark(0.55)}`, color: 'white'
-    },
-    dropDownItem: {
-      display: 'flex', alignItems: 'center',
-      backgroundColor: colors.dark(0.7),
-      color: 'white',
-      borderBottom: 'none',
-      padding: '0 3rem', height: 40,
-      fontSize: 'unset',
-      fontWeight: 500
-    },
     icon: {
       marginRight: 12, flex: 'none'
     }
@@ -84,35 +69,35 @@ const betaTag = b({
   }
 }, 'BETA')
 
-const DropDownSubItem = props => {
-  return h(Clickable, {
-    as: 'a',
-    style: styles.nav.dropDownItem,
-    hover: { backgroundColor: colors.dark(0.55) },
-    ...props
-  })
+const NavItem = ({ children, ...props }) => {
+  return h(Clickable, _.merge({
+    style: { display: 'flex', alignItems: 'center', color: 'white' },
+    hover: { backgroundColor: colors.dark(0.55) }
+  }, props), [children])
 }
 
-const DropDownSection = props => {
-  const { titleIcon, title, isOpened, onClick, children } = props
+const NavSection = ({ children, ...props }) => {
+  return h(NavItem, _.merge({
+    style: {
+      flex: 'none', height: 70, padding: '0 28px', fontWeight: 600,
+      borderTop: `1px solid ${colors.dark(0.55)}`, color: 'white'
+    }
+  }, props), [children])
+}
 
+const DropDownSubItem = ({ children, ...props }) => {
+  return h(NavItem, _.merge({
+    style: { padding: '0 3rem', height: 40, fontWeight: 500 }
+  }, props), [children])
+}
+
+const DropDownSection = ({ titleIcon, title, isOpened, onClick, children }) => {
   return h(Fragment, [
-    h(Clickable, {
-      style: styles.nav.item,
-      hover: { backgroundColor: colors.dark(0.55) },
-      onClick
-    }, [
-      titleIcon && icon(titleIcon, {
-        size: 24,
-        style: styles.nav.icon
-      }),
-      div({ style: Style.noWrapEllipsis }, [title]),
+    h(NavSection, { onClick }, [
+      titleIcon && icon(titleIcon, { size: 24, style: styles.nav.icon }),
+      title,
       div({ style: { flexGrow: 1 } }),
-      icon(`angle-${isOpened ? 'up' : 'down'}`,
-        {
-          size: 18,
-          style: { flex: 'none' }
-        })
+      icon(isOpened ? 'angle-up' : 'angle-down', { size: 18, style: { flex: 'none' } })
     ]),
     h(RCollapse, { isOpened, style: { flex: 'none' } }, [children])
   ])
@@ -152,49 +137,6 @@ const TopBar = Utils.connectAtom(authStore, 'authState')(class TopBar extends Co
     const { authState: { isSignedIn, profile: { firstName = 'Loading...', lastName = '', trialState } } } = this.props
     const { navShown, openLibraryMenu, openSupportMenu, openUserMenu } = this.state
 
-    const enabledCredits = h(Clickable, {
-      style: styles.nav.item,
-      hover: { backgroundColor: colors.dark(0.55) },
-      onClick: () => {
-        this.hideNav()
-        freeCreditsActive.set(true)
-      }
-    }, [
-      div({ style: styles.nav.icon }, [
-        icon('cloud', { size: 20 })
-      ]),
-      'Sign up for free credits'
-    ])
-
-    const enrolledCredits = h(Clickable, {
-      style: styles.nav.item,
-      as: 'a',
-      hover: { backgroundColor: colors.dark(0.55) },
-      href: 'https://software.broadinstitute.org/firecloud/documentation/freecredits',
-      ...Utils.newTabLinkProps,
-      onClick: () => this.hideNav()
-    }, [
-      div({ style: styles.nav.icon }, [
-        icon('cloud', { size: 20 })
-      ]),
-      'Access free credits',
-      icon('pop-out', {
-        size: 20,
-        style: { paddingLeft: '0.5rem' }
-      })
-    ])
-
-    const terminatedCredits = h(Clickable, {
-      style: styles.nav.item,
-      hover: { backgroundColor: colors.dark(0.55) },
-      onClick: () => this.setState({ finalizeTrial: true })
-    }, [
-      div({ style: styles.nav.icon }, [
-        icon('cloud', { size: 20 })
-      ]),
-      'Your free trial has ended'
-    ])
-
     return div({
       style: navShown ? styles.nav.background : undefined,
       onClick: () => {
@@ -208,9 +150,9 @@ const TopBar = Utils.connectAtom(authStore, 'authState')(class TopBar extends Co
         div({ style: { display: 'flex', flexDirection: 'column', overflowY: 'auto', flex: 1 } }, [
           isSignedIn ?
             h(DropDownSection, {
-              titleIcon: undefined,
-              title: div({ style: { ..._.omit('borderTop', styles.nav.item), padding: 0 } }, [
-                profilePic({ size: 32, style: { marginRight: 12 } }), `${firstName} ${lastName}`
+              title: h(Fragment, [
+                profilePic({ size: 32, style: { marginRight: 12, flex: 'none' } }),
+                div({ style: { ...Style.noWrapEllipsis } }, [`${firstName} ${lastName}`])
               ]),
               onClick: () => this.setState({ openUserMenu: !openUserMenu }),
               isOpened: openUserMenu
@@ -235,26 +177,17 @@ const TopBar = Utils.connectAtom(authStore, 'authState')(class TopBar extends Co
                 onClick: signOut
               }, ['Sign Out'])
             ]) :
-            div({
-              style: {
-                ...styles.nav.item,
-                justifyContent: 'center',
-                height: 95
-              }
-            }, [
+            div({ style: { flex: 'none', display: 'flex', justifyContent: 'center', alignItems: 'center', height: 95 } }, [
               div([
                 h(Clickable, {
                   hover: { textDecoration: 'underline' },
-                  style: { color: 'white', marginLeft: '9rem' },
+                  style: { color: 'white', marginLeft: '9rem', fontWeight: 600 },
                   onClick: () => this.setState({ openCookiesModal: true })
                 }, ['Cookies policy']),
                 h(SignInButton)
               ])
             ]),
-          h(Clickable, {
-            as: 'a',
-            style: styles.nav.item,
-            hover: { backgroundColor: colors.dark(0.55) },
+          h(NavSection, {
             href: Nav.getLink('workspaces'),
             onClick: () => this.hideNav()
           }, [
@@ -280,9 +213,38 @@ const TopBar = Utils.connectAtom(authStore, 'authState')(class TopBar extends Co
               onClick: () => this.hideNav()
             }, ['Workflows'])
           ]),
-          (trialState === 'Enabled') && enabledCredits,
-          (trialState === 'Enrolled') && enrolledCredits,
-          (trialState === 'Terminated') && terminatedCredits,
+          Utils.switchCase(trialState,
+            ['Enabled', () => {
+              return h(NavSection, {
+                onClick: () => {
+                  this.hideNav()
+                  freeCreditsActive.set(true)
+                }
+              }, [
+                div({ style: styles.nav.icon }, [icon('cloud', { size: 20 })]),
+                'Sign up for free credits'
+              ])
+            }],
+            ['Enrolled', () => {
+              return h(NavSection, {
+                href: 'https://software.broadinstitute.org/firecloud/documentation/freecredits',
+                ...Utils.newTabLinkProps,
+                onClick: () => this.hideNav()
+              }, [
+                div({ style: styles.nav.icon }, [icon('cloud', { size: 20 })]),
+                'Access free credits',
+                icon('pop-out', { size: 20, style: { paddingLeft: '0.5rem' } })
+              ])
+            }],
+            ['Terminated', () => {
+              return h(NavSection, {
+                onClick: () => this.setState({ finalizeTrial: true })
+              }, [
+                div({ style: styles.nav.icon }, [icon('cloud', { size: 20 })]),
+                'Your free trial has ended'
+              ])
+            }]
+          ),
           h(DropDownSection, {
             titleIcon: 'help',
             title: 'Terra Support',
@@ -313,11 +275,9 @@ const TopBar = Utils.connectAtom(authStore, 'authState')(class TopBar extends Co
               onClick: () => contactUsActive.set(true)
             }, ['Contact Us'])
           ]),
-          isFirecloud() && h(Clickable, {
-            style: styles.nav.item,
+          isFirecloud() && h(NavSection, {
             disabled: !isSignedIn,
             tooltip: isSignedIn ? undefined : 'Please sign in',
-            hover: { backgroundColor: colors.dark(0.55) },
             onClick: () => this.setState({ openFirecloudModal: true })
           }, [
             div({ style: styles.nav.icon }, [
@@ -326,15 +286,10 @@ const TopBar = Utils.connectAtom(authStore, 'authState')(class TopBar extends Co
           ]),
           div({ style: { borderTop: `1px solid ${colors.dark(0.55)}` } }, []),
           div({
-            style: {
-              ..._.omit('borderTop', styles.nav.item),
-              marginTop: 'auto',
-              color: colors.dark(0.55),
-              fontSize: 10
-            }
+            style: { flex: 'none', padding: 28, marginTop: 'auto', color: colors.dark(0.55), fontSize: 10, fontWeight: 600 }
           }, [
             'Built on: ',
-            a({
+            h(Clickable, {
               href: `https://github.com/DataBiosphere/terra-ui/commits/${SATURN_VERSION}`,
               ...Utils.newTabLinkProps,
               style: { textDecoration: 'underline', marginLeft: '0.25rem' }

--- a/src/components/UriViewer.js
+++ b/src/components/UriViewer.js
@@ -123,7 +123,6 @@ const DownloadButton = ({ uri, metadata: { bucket, name, size } }) => {
       'Unable to generate download link.' :
       div({ style: { display: 'flex', justifyContent: 'center' } }, [
         h(ButtonPrimary, {
-          as: 'a',
           disabled: !url,
           href: url,
           ...Utils.newTabLinkProps
@@ -268,7 +267,10 @@ export class UriViewerLink extends Component {
       h(Link, {
         style: { textDecoration: 'underline' },
         href: uri,
-        onClick: () => this.setState({ modalOpen: true })
+        onClick: e => {
+          e.preventDefault()
+          this.setState({ modalOpen: true })
+        }
       }, [isGs(uri) ? _.last(uri.split('/')) : uri]),
       modalOpen && h(UriViewer, {
         onDismiss: () => this.setState({ modalOpen: false }),

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -25,10 +25,11 @@ const styles = {
   }
 }
 
-export const Clickable = ({ as = 'div', disabled, tooltip, tooltipSide, onClick, children, ...props }) => {
+export const Clickable = ({ href, as = (!!href ? 'a' : 'div'), disabled, tooltip, tooltipSide, onClick, children, ...props }) => {
   const child = h(Interactive, {
     as, disabled,
     onClick: (...args) => onClick && !disabled && onClick(...args),
+    href: !disabled ? href : undefined,
     ...props
   }, [children])
 
@@ -39,24 +40,15 @@ export const Clickable = ({ as = 'div', disabled, tooltip, tooltipSide, onClick,
   }
 }
 
-const linkProps = ({ disabled, variant }) => ({
-  as: 'a',
-  style: {
-    color: disabled ? colors.dark(0.7) : colors.accent(variant === 'light' ? 0.3 : 1),
-    cursor: disabled ? 'not-allowed' : 'pointer',
-    fontWeight: 500
-  },
-  hover: disabled ? undefined : { color: colors.accent(variant === 'light' ? 0.1 : 0.8) }
-})
-
-export const Link = ({ onClick, href, disabled, variant, children, ...props }) => {
+export const Link = ({ disabled, variant, children, ...props }) => {
   return h(Clickable, _.merge({
-    ...linkProps({ disabled, variant }),
-    href, disabled,
-    onClick: href && onClick ? e => {
-      e.preventDefault()
-      onClick(e)
-    } : onClick
+    style: {
+      color: disabled ? colors.dark(0.7) : colors.accent(variant === 'light' ? 0.3 : 1),
+      cursor: disabled ? 'not-allowed' : 'pointer',
+      fontWeight: 500, display: 'inline'
+    },
+    hover: disabled ? undefined : { color: colors.accent(variant === 'light' ? 0.1 : 0.8) },
+    disabled
   }, props), [children])
 }
 
@@ -120,8 +112,7 @@ export const TabBar = ({ activeTab, tabNames, refresh = _.noop, getHref, childre
     const href = getHref(currentTab)
 
     return h(Fragment, [
-      h(Interactive, {
-        as: 'a',
+      h(Clickable, {
         style: { ...Style.tabBar.tab, ...(selected ? Style.tabBar.active : {}) },
         hover: selected ? {} : Style.tabBar.hover,
         onClick: href === window.location.hash ? refresh : undefined,

--- a/src/pages/LandingPage.js
+++ b/src/pages/LandingPage.js
@@ -29,7 +29,6 @@ const makeDocLink = (href, title) => h(Link, {
 
 
 const makeCard = (link, title, body) => h(Clickable, {
-  as: 'a',
   href: Nav.getLink(link),
   style: { ...Style.elements.card.container, height: 245, width: 225, marginRight: '1rem', justifyContent: undefined },
   hover: { boxShadow: '0 3px 7px 0 rgba(0,0,0,0.5), 0 5px 3px 0 rgba(0,0,0,0.2)' }

--- a/src/pages/billing/List.js
+++ b/src/pages/billing/List.js
@@ -1,8 +1,7 @@
 import _ from 'lodash/fp'
 import * as qs from 'qs'
 import { Fragment } from 'react'
-import { a, div, h, span } from 'react-hyperscript-helpers'
-import Interactive from 'react-interactive'
+import { div, h, span } from 'react-hyperscript-helpers'
 import { ButtonPrimary, Clickable, Link, Select, spinnerOverlay } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import { ValidatedInput } from 'src/components/input'
@@ -29,8 +28,7 @@ const ProjectTab = ({ project: { projectName, role, creationStatus }, isActive }
     { style: { color: colors.accent(), marginRight: '1rem', marginLeft: '0.5rem' } })
 
   return _.includes('Owner', role) && projectReady ?
-    h(Interactive, {
-      as: 'a',
+    h(Clickable, {
       style: { ...Style.navList.item(isActive), color: colors.accent() },
       href: `${Nav.getLink('billing')}?${qs.stringify({ selectedName: projectName, type: 'project' })}`,
       hover: Style.navList.itemHover(isActive)
@@ -109,11 +107,10 @@ const NewBillingProjectModal = ajaxCaller(class NewBillingProjectModal extends C
     }, [
       billingAccounts && billingAccounts.length === 0 && h(Fragment, [
         `You don't have access to any billing accounts.  `,
-        a({
-          style: { color: colors.accent(), fontWeight: 700 },
+        h(Link, {
           href: `https://support.terra.bio/hc/en-us/articles/360026182251`,
           ...Utils.newTabLinkProps
-        }, ['Learn how to create a billing account.', icon('pop-out', { size: 20, style: { marginLeft: '0.5rem' } })])
+        }, ['Learn how to create a billing account.', icon('pop-out', { size: 12, style: { marginLeft: '0.5rem' } })])
       ]),
       billingAccounts && billingAccounts.length !== 0 && h(Fragment, [
         h(RequiredFormLabel, ['Enter name']),
@@ -146,23 +143,19 @@ const NewBillingProjectModal = ajaxCaller(class NewBillingProjectModal extends C
             'Terra does not have access to this account. '),
           div({ style: { marginBottom: '0.25rem' } }, ['To grant access, add ', span({ style: { fontWeight: 'bold' } }, 'terra-billing@terra.bio'),
             ' as a ', span({ style: { fontWeight: 'bold' } }, 'Billing Account User'), ' on the ',
-            a({
-              style: { color: colors.accent(), fontWeight: 700 },
+            h(Link, {
               href: `https://console.cloud.google.com/billing/${chosenBillingAccount.accountName.split('/')[1]}?authuser=${Auth.getUser().email}`,
               ...Utils.newTabLinkProps
             }, ['Google Cloud Console', icon('pop-out', { style: { marginLeft: '0.25rem' }, size: 12 })])]),
           div({ style: { marginBottom: '0.25rem' } }, ['Then, ',
-            h(Clickable, {
-              as: 'span',
-              style: { color: colors.accent(), fontWeight: 700 },
+            h(Link, {
               onClick: () => {
                 this.setState({ billingAccounts: undefined })
                 this.loadAccounts()
               }
             }, ['click here']), ' to refresh your billing accounts.']),
           div({ style: { marginTop: '0.5rem' } }, [
-            a({
-              style: { color: colors.accent(), fontWeight: 700 },
+            h(Link, {
               href: `https://support.terra.bio/hc/en-us/articles/360026182251`,
               ...Utils.newTabLinkProps
             }, ['Need help?', icon('pop-out', { style: { marginLeft: '0.25rem' }, size: 12 })])

--- a/src/pages/library/Code.js
+++ b/src/pages/library/Code.js
@@ -26,7 +26,6 @@ export const makeWorkflowCard = ({ method, onClick }) => {
   const { namespace, name, synopsis } = method
 
   return h(Clickable, {
-    as: 'a',
     href: !onClick ? `${getConfig().firecloudUrlRoot}/?return=${returnParam()}#methods/${namespace}/${name}/` : undefined,
     onClick,
     style: {

--- a/src/pages/library/Datasets.js
+++ b/src/pages/library/Datasets.js
@@ -111,7 +111,6 @@ const browseTooltip = 'Look for the Export to Terra icon to export data from thi
 
 const NIHCommonsButtons = () => h(ButtonPrimary, {
   style: { margin: '0.25rem 0' },
-  as: 'a',
   href: 'https://gen3.datastage.io/explorer',
   ...Utils.newTabLinkProps,
   tooltip: browseTooltip
@@ -125,7 +124,6 @@ const thousandGenomesHighCoverage = () => h(Participant, {
   sizeText: 'Participants: 2,504'
 }, [
   h(ButtonPrimary, {
-    as: 'a',
     href: Nav.getLink('workspace-dashboard', { namespace: 'anvil-datastorage', name: '1000G-high-coverage-2019' }),
     tooltip: 'Visit the workspace'
   }, ['Browse data'])
@@ -143,7 +141,6 @@ const thousandGenomesLowCoverage = () => h(Participant, {
   sizeText: 'Participants: 3,500'
 }, [
   h(ButtonPrimary, {
-    as: 'a',
     href: Nav.getLink('library-datasets-data-explorer-public', { dataset: '1000 Genomes' }),
     tooltip: browseTooltip
   }, ['Browse data'])
@@ -177,7 +174,6 @@ const amppd = () => h(Participant, {
   sizeText: 'Participants: > 4,700'
 }, [
   h(ButtonPrimary, {
-    as: 'a',
     href: Nav.getLink('library-datasets-data-explorer-private', { dataset: 'AMP PD - 2019_v1beta_0220' })
   }, ['Browse Data'])
 ])
@@ -195,7 +191,6 @@ const baseline = () => h(Participant, {
   sizeText: 'Participants: > 1,500'
 }, [
   h(ButtonPrimary, {
-    as: 'a',
     href: Nav.getLink('library-datasets-data-explorer-private', { dataset: 'Baseline Health Study' })
   }, ['Browse Data'])
 ])
@@ -208,7 +203,6 @@ const ccdg = () => h(Participant, {
   sizeText: 'Participants: > 65,000'
 }, [
   h(ButtonPrimary, {
-    as: 'a',
     href: `${getConfig().firecloudUrlRoot}/?return=${returnParam()}&project=AnVIL CCDG&project=AnVIL CCDG CVD#library`,
     ...Utils.newTabLinkProps,
     tooltip: browseTooltip
@@ -223,7 +217,6 @@ const cmg = () => h(Participant, {
   sizeText: 'Participants: > 5,000'
 }, [
   h(ButtonPrimary, {
-    as: 'a',
     href: `${getConfig().firecloudUrlRoot}/?return=${returnParam()}&project=AnVIL CMG#library`,
     ...Utils.newTabLinkProps,
     tooltip: browseTooltip
@@ -242,7 +235,6 @@ const encode = () => h(Participant, {
   sizeText: 'Donors: > 650 ; Files: > 158,000'
 }, [
   h(ButtonPrimary, {
-    as: 'a',
     href: 'https://broad-gdr-encode.appspot.com/',
     ...Utils.newTabLinkProps,
     tooltip: browseTooltip
@@ -257,7 +249,6 @@ const fcDataLib = () => h(Participant, {
   sizeText: h(TooltipTrigger, { content: 'As of October 2018' }, [span('Samples: > 158,629')])
 }, [
   h(ButtonPrimary, {
-    as: 'a',
     href: `${getConfig().firecloudUrlRoot}/?return=${returnParam()}#library`,
     ...Utils.newTabLinkProps,
     tooltip: 'Search for dataset workspaces'
@@ -287,7 +278,6 @@ const nemo = () => h(Participant, {
   sizeText: h(TooltipTrigger, { content: 'As of March 2019' }, [span('Files: >= 210,000; Projects >= 5; Species >= 3')])
 }, [
   h(ButtonPrimary, {
-    as: 'a',
     href: 'http://portal.nemoarchive.org/',
     ...Utils.newTabLinkProps,
     tooltip: 'Look for the Export to Terra option in the Download Cart to export data.'
@@ -302,7 +292,6 @@ const nhs = () => h(Participant, {
   sizeText: 'Participants: > 120,000'
 }, [
   h(ButtonPrimary, {
-    as: 'a',
     href: Nav.getLink('library-datasets-data-explorer-private', { dataset: `Nurses' Health Study` })
   }, ['Browse Data'])
 ])
@@ -330,7 +319,6 @@ const ukb = () => h(Participant, {
   sizeText: 'Participants: > 500,000'
 }, [
   h(ButtonPrimary, {
-    as: 'a',
     href: Nav.getLink('library-datasets-data-explorer-private', { dataset: 'UK Biobank' })
   }, ['Browse Data'])
 ])

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -2,7 +2,7 @@ import { isAfter } from 'date-fns'
 import debouncePromise from 'debounce-promise'
 import _ from 'lodash/fp'
 import { Fragment, useState } from 'react'
-import { a, div, h, span } from 'react-hyperscript-helpers'
+import { div, h, span } from 'react-hyperscript-helpers'
 import { pure } from 'recompose'
 import removeMd from 'remove-markdown'
 import togglesListView from 'src/components/CardsListToggle'
@@ -150,11 +150,7 @@ const WorkspaceCard = pure(({
     closeOnClick: true,
     content: h(WorkspaceMenuContent, { namespace, name, onShare, onClone, onDelete })
   }, [
-    h(Link, {
-      as: 'div',
-      onClick: e => e.preventDefault(),
-      disabled: !canView
-    }, [
+    h(Link, { onClick: e => e.preventDefault(), disabled: !canView }, [
       icon('cardMenuIcon', {
         size: listView ? 18 : 24
       })
@@ -165,22 +161,6 @@ const WorkspaceCard = pure(({
     span({ style: { color: colors.dark(0.85) } }, ['No description added'])
   const titleOverrides = !canView ? { color: colors.dark(0.7) } : {}
 
-  const renderCard = children => {
-    const style = listView ? styles.longCard : styles.shortCard
-    if (canView) {
-      return a({
-        href: Nav.getLink('workspace-dashboard', { namespace, name }),
-        style
-      }, children)
-    } else {
-      return h(Clickable, {
-        as: 'a',
-        onClick: onRequestAccess,
-        style
-      }, children)
-    }
-  }
-
   return h(TooltipTrigger, {
     content: !canView && `
       You cannot access this workspace because it is protected by an Authorization Domain.
@@ -188,7 +168,11 @@ const WorkspaceCard = pure(({
     `,
     side: 'top'
   }, [
-    renderCard([
+    h(Clickable, {
+      href: canView ? Nav.getLink('workspace-dashboard', { namespace, name }) : undefined,
+      onClick: !canView ? onRequestAccess : undefined,
+      style: listView ? styles.longCard : styles.shortCard
+    }, [
       Utils.switchCase(workspaceSubmissionStatus(workspace),
         ['success', () => h(SubmissionIndicator, { shape: 'success-standard', color: colors.success() })],
         ['failure', () => h(SubmissionIndicator, { shape: 'error-standard', color: colors.danger(0.85) })],

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -54,7 +54,6 @@ const styles = {
 
 const DataTypeButton = ({ selected, children, iconName = 'listAlt', iconSize = 14, ...props }) => {
   return h(Clickable, {
-    as: 'span',
     style: { ...Style.navList.item(selected), color: colors.accent() },
     hover: Style.navList.itemHover(selected),
     ...props

--- a/src/pages/workspaces/workspace/JobHistory.js
+++ b/src/pages/workspaces/workspace/JobHistory.js
@@ -179,7 +179,6 @@ const JobHistory = _.flow(
                   const { failed, running, submitted } = collapsedStatuses(workflowStatuses)
 
                   return h(Clickable, {
-                    as: 'a',
                     hover: {
                       backgroundColor: Utils.cond([!!failed, colors.danger(0.2)], [!!running || !!submitted, colors.accent(0.2)], colors.success(0.2))
                     },

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -82,14 +82,12 @@ class NotebookCard extends Component {
       closeOnClick: true,
       content: h(Fragment, [
         h(MenuButton, {
-          as: 'a',
           href: notebookLink,
           disabled: !canWrite,
           tooltip: !canWrite && noWrite,
           tooltipSide: 'left'
         }, [makeMenuIcon('edit'), 'Open']),
         h(MenuButton, {
-          as: 'a',
           href: notebookReadOnlyLink,
           tooltip: canWrite && 'Open without runtime',
           tooltipSide: 'left'
@@ -127,14 +125,7 @@ class NotebookCard extends Component {
         }, [makeMenuIcon('trash'), 'Delete'])
       ])
     }, [
-      h(Clickable, {
-        onClick: e => e.preventDefault(),
-        style: {
-          cursor: 'pointer', color: colors.accent()
-        },
-        focus: 'hover',
-        hover: { color: colors.accent(0.85) }
-      }, [
+      h(Link, { onClick: e => e.preventDefault() }, [
         icon('cardMenuIcon', {
           size: listView ? 18 : 24
         })

--- a/src/pages/workspaces/workspace/Workflows.js
+++ b/src/pages/workspaces/workspace/Workflows.js
@@ -107,14 +107,7 @@ const WorkflowCard = pure(({ listView, name, namespace, config, onCopy, onDelete
       }, [makeMenuIcon('trash'), 'Delete'])
     ])
   }, [
-    h(Clickable, {
-      onClick: e => e.stopPropagation(),
-      style: {
-        cursor: 'pointer', color: colors.accent(), ...styles.innerLink
-      },
-      focus: 'hover',
-      hover: { color: colors.accent(0.85) }
-    }, [
+    h(Link, { onClick: e => e.stopPropagation(), style: styles.innerLink }, [
       icon('cardMenuIcon', {
         size: listView ? 18 : 24
       })

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -147,7 +147,6 @@ const WorkspaceAccessError = () => {
     ]),
     p(['If you think the workspace exists but you do not have access, please contact the workspace owner.']),
     h(ButtonPrimary, {
-      as: 'a',
       href: Nav.getLink('workspaces')
     }, ['Return to Workspace List'])
   ])

--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -51,7 +51,7 @@ const ReadOnlyMessage = ({ notebookName, workspace, workspace: { canCompute, wor
     Utils.cond(
       [!canCompute, () => h(ButtonOutline, { onClick: () => setCopying(true) }, ['copy to another workspace to edit'])],
       () => h(ButtonOutline, {
-        as: 'a', href: Nav.getLink('workspace-notebook-launch', { namespace, name, notebookName })
+        href: Nav.getLink('workspace-notebook-launch', { namespace, name, notebookName })
       }, ['edit in Jupyter'])
     ),
     div({ style: { flexGrow: 1 } }),


### PR DESCRIPTION
This finishes some standardization of the common button and link components. Highlights:

* `Clickable` now correctly handles `disabled` status with regard to `onClick`, `href`, or both. This fixes a few places where it was possible to click through a link that appeared disabled.
* `Clickable` defaults to `as: 'a'` if `href` is specified.
* `Link` no longer automatically does `preventDefault` if an `onClick` is specified. This need for this is actually uncommon relative to the default, so it seems appropriate for consumers to implement it themselves.