### PR TITLE
Don't crash on attribute values that are arrays

### DIFF
--- a/src/libs/data-utils.js
+++ b/src/libs/data-utils.js
@@ -32,13 +32,15 @@ export const renderDataCell = (data, namespace) => {
   const renderCell = datum => h(TextCell, { title: datum },
     [isUri(datum) ? h(UriViewerLink, { uri: datum, googleProject: namespace }) : datum])
 
+  const renderArray = items => {
+    return items.map((v, i) => h(Fragment, { key: i }, [
+      renderCell(v.toString()), i < (items.length - 1) && div({ style: { marginRight: '0.5rem', color: colors.dark(0.85) } }, ',')
+    ]))
+  }
+
   return Utils.cond(
-    [_.isArray(data), () => data.join(', ')],
-    [_.isObject(data), () => {
-      return data.items.map((v, i) => h(Fragment, { key: i }, [
-        renderCell(v.toString()), i < (data.items.length - 1) && div({ style: { marginRight: '0.5rem', color: colors.dark(0.85) } }, ',')
-      ]))
-    }],
+    [_.isArray(data), () => renderArray(data)],
+    [_.isObject(data), () => renderArray(data.items)],
     () => renderCell(data && data.toString())
   )
 }

--- a/src/libs/data-utils.js
+++ b/src/libs/data-utils.js
@@ -32,11 +32,15 @@ export const renderDataCell = (data, namespace) => {
   const renderCell = datum => h(TextCell, { title: datum },
     [isUri(datum) ? h(UriViewerLink, { uri: datum, googleProject: namespace }) : datum])
 
-  return _.isObject(data) ?
-    data.items.map((v, i) => h(Fragment, { key: i }, [
-      renderCell(v.toString()), i < (data.items.length - 1) && div({ style: { marginRight: '0.5rem', color: colors.dark(0.85) } }, ',')
-    ])) :
-    renderCell(data && data.toString())
+  return Utils.cond(
+    [_.isArray(data), () => data.join(', ')],
+    [_.isObject(data), () => {
+      return data.items.map((v, i) => h(Fragment, { key: i }, [
+        renderCell(v.toString()), i < (data.items.length - 1) && div({ style: { marginRight: '0.5rem', color: colors.dark(0.85) } }, ',')
+      ]))
+    }],
+    () => renderCell(data && data.toString())
+  )
 }
 
 export const ReferenceDataImporter = class ReferenceDataImporter extends Component {


### PR DESCRIPTION
SATURN-938

As noted in the JIRA issue, FC UI handles this correctly. Terra UI was crashing. We may not have noticed this because it may not be possible to import arrays from TSVs. However, I've been working with importing data directly into Rawls and wound up creating array attribute values that way.