### PR TITLE
add entity prefix on TSV [SATURN-935]

### DIFF
--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -449,7 +449,7 @@ class EntitiesContent extends Component {
         attributeNames)
     ])
 
-    const header = _.join('\t', [`${entityKey}_id`, ...attributeNames])
+    const header = _.join('\t', [`entity:${entityKey}_id`, ...attributeNames])
 
     return _.join('\n', [header, ..._.map(entityToRow, entities)]) + '\n'
   }


### PR DESCRIPTION
Fixes an issue when downloading partial entity data as a TSV. We need to add the `entity:` prefix to the header row.