### PR TITLE
fix list in ws attributes [SATURN-896]

### DIFF
--- a/src/components/FloatingActionButton.js
+++ b/src/components/FloatingActionButton.js
@@ -17,8 +17,8 @@ export default class FloatingActionButton extends Component {
   }
 
   static defaultProps = {
-    bottom: 50,
-    right: 50
+    bottom: 30,
+    right: 30
   }
 
   render() {

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -485,7 +485,7 @@ class EntitiesContent extends Component {
       !_.isEmpty(selectedEntities) && h(FloatingActionButton, {
         label: 'COPY DATA',
         iconShape: 'copy',
-        bottom: 100,
+        bottom: 80,
         onClick: () => this.setState({ copyingEntities: true })
       }),
       !_.isEmpty(selectedEntities) && !Utils.editWorkspaceError(workspace) && h(FloatingActionButton, {

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -260,7 +260,7 @@ const LocalVariablesContent = class LocalVariablesContent extends Component {
           ])
         ])
       ),
-      !creatingNewVariable && !editIndex && !Utils.editWorkspaceError(workspace) && h(FloatingActionButton, {
+      !creatingNewVariable && editIndex === undefined && !Utils.editWorkspaceError(workspace) && h(FloatingActionButton, {
         label: 'ADD VARIABLE',
         iconShape: 'plus',
         onClick: () => this.setState({

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -113,6 +113,7 @@ const LocalVariablesContent = class LocalVariablesContent extends Component {
 
     const inputErrors = editIndex && [
       ...(_.keys(_.unset(amendedAttributes[editIndex][0], attributes)).includes(editKey) ? ['Key must be unique'] : []),
+      ...(!/^[\w-]*$/.test(editKey) ? ['Key can only contain letters, numbers, underscores, and dashes'] : []),
       ...(!editKey ? ['Key is required'] : []),
       ...(!editValue ? ['Value is required'] : []),
       ...(editValue && editType === 'number' && Utils.cantBeNumber(editValue) ? ['Value is not a number'] : []),
@@ -124,7 +125,7 @@ const LocalVariablesContent = class LocalVariablesContent extends Component {
       const isList = editType.includes('list')
       const newBaseType = isList ? editType.slice(0, -5) : editType
 
-      const parsedValue = isList ? _.map(Utils.convertValue(newBaseType), editValue.split(/,s*/)) :
+      const parsedValue = isList ? _.map(Utils.convertValue(newBaseType), editValue.split(/,\s*/)) :
         Utils.convertValue(newBaseType, editValue)
 
       this.setState({ saving: true })
@@ -259,7 +260,7 @@ const LocalVariablesContent = class LocalVariablesContent extends Component {
           ])
         ])
       ),
-      !creatingNewVariable && !Utils.editWorkspaceError(workspace) && h(FloatingActionButton, {
+      !creatingNewVariable && !editIndex && !Utils.editWorkspaceError(workspace) && h(FloatingActionButton, {
         label: 'ADD VARIABLE',
         iconShape: 'plus',
         onClick: () => this.setState({


### PR DESCRIPTION
1. Fixes mis-parsing of list type data from strings in workspace attributes when editing them (missing `\`)
2. Hides new attribute button when editing so it doesn't get in the way
3. Tweaks floating action button default position to not overlap rows so completely
4. Prevents trying to submit new ws attribute keys with non alphanumeric/hyphen/underscore characters, since it just leads to an error