### PR TITLE
extract common tag select code

### DIFF
--- a/src/components/workspace-utils.js
+++ b/src/components/workspace-utils.js
@@ -1,7 +1,8 @@
+import debouncePromise from 'debounce-promise'
 import _ from 'lodash/fp'
 import { Fragment, useState } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
-import { ButtonPrimary, Link, Select } from 'src/components/common'
+import { AsyncCreatableSelect, ButtonPrimary, Link, Select } from 'src/components/common'
 import NewWorkspaceModal from 'src/components/NewWorkspaceModal'
 import { Ajax, useCancellation } from 'src/libs/ajax'
 import { withErrorReporting } from 'src/libs/error'
@@ -92,3 +93,22 @@ export const WorkspaceImporter = withWorkspaces(
     ])
   }
 )
+
+export const WorkspaceTagSelect = props => {
+  const signal = useCancellation()
+  const getTagSuggestions = Utils.useInstance(() => debouncePromise(withErrorReporting('Error loading tags', async text => {
+    if (text.length > 2) {
+      return _.map(({ tag, count }) => {
+        return { value: tag, label: `${tag} (${count})` }
+      }, _.take(10, await Ajax(signal).Workspaces.getTags(text)))
+    } else {
+      return []
+    }
+  }), 250))
+  return h(AsyncCreatableSelect, {
+    noOptionsMessage: () => 'Enter at least 3 characters to search',
+    allowCreateWhileLoading: true,
+    loadOptions: getTagSuggestions,
+    ...props
+  })
+}

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -320,6 +320,18 @@ export const useGetter = value => {
   return () => ref.current
 }
 
+/*
+ * Calls the provided function to produce and return a value tied to this component instance.
+ * The initializer function is only called once for each component instance, on first render.
+ */
+export const useInstance = fn => {
+  const ref = useRef()
+  if (!ref.current) {
+    ref.current = fn()
+  }
+  return ref.current
+}
+
 export const handleNonRunningCluster = ({ status, googleProject, clusterName }, JupyterAjax) => {
   switch (status) {
     case 'Stopped':

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -1,5 +1,4 @@
 import { isAfter } from 'date-fns'
-import debouncePromise from 'debounce-promise'
 import _ from 'lodash/fp'
 import { Fragment, useState } from 'react'
 import { div, h, span } from 'react-hyperscript-helpers'
@@ -7,7 +6,7 @@ import { pure } from 'recompose'
 import removeMd from 'remove-markdown'
 import togglesListView from 'src/components/CardsListToggle'
 import {
-  AsyncCreatableSelect, Clickable, LabeledCheckbox, Link, makeMenuIcon, MenuButton, PageBox, Select, topSpinnerOverlay, transparentSpinnerOverlay
+  Clickable, LabeledCheckbox, Link, makeMenuIcon, MenuButton, PageBox, Select, topSpinnerOverlay, transparentSpinnerOverlay
 } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import { DelayedSearchInput } from 'src/components/input'
@@ -15,7 +14,7 @@ import NewWorkspaceModal from 'src/components/NewWorkspaceModal'
 import PopupTrigger from 'src/components/PopupTrigger'
 import TooltipTrigger from 'src/components/TooltipTrigger'
 import TopBar from 'src/components/TopBar'
-import { withWorkspaces } from 'src/components/workspace-utils'
+import { withWorkspaces, WorkspaceTagSelect } from 'src/components/workspace-utils'
 import { Ajax, ajaxCaller, useCancellation } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { withErrorReporting } from 'src/libs/error'
@@ -247,17 +246,6 @@ export const WorkspaceList = _.flow(
     return _.find({ workspace: { workspaceId: id } }, workspaces)
   }
 
-  getTagSuggestions = debouncePromise(withErrorReporting('Error loading tags', async text => {
-    const { ajax: { Workspaces } } = this.props
-    if (text.length > 2) {
-      return _.map(({ tag, count }) => {
-        return { value: tag, label: `${tag} (${count})` }
-      }, _.take(10, await Workspaces.getTags(text)))
-    } else {
-      return []
-    }
-  }), 250)
-
   render() {
     const { workspaces, loadingWorkspaces, refreshWorkspaces, listView, viewToggleButtons } = this.props
     const { filter, creatingNewWorkspace, cloningWorkspaceId, deletingWorkspaceId, sharingWorkspaceId, requestingAccessWorkspaceId, accessLevelsFilter, projectsFilter, submissionsFilter, tagsFilter, includePublic } = this.state
@@ -335,16 +323,13 @@ export const WorkspaceList = _.flow(
         div({ style: { display: 'flex', marginBottom: '1rem' } }, [
           div({ style: { display: 'flex', alignItems: 'center', fontSize: '1rem' } }, ['Filter by']),
           div({ style: styles.filter }, [
-            h(AsyncCreatableSelect, {
+            h(WorkspaceTagSelect, {
               isClearable: true,
               isMulti: true,
-              noOptionsMessage: () => 'Enter at least 3 characters to search',
               formatCreateLabel: _.identity,
-              allowCreateWhileLoading: true,
               value: _.map(tag => ({ label: tag, value: tag }), tagsFilter),
               placeholder: 'Tags',
-              onChange: data => this.setState({ tagsFilter: _.map('value', data) }),
-              loadOptions: this.getTagSuggestions
+              onChange: data => this.setState({ tagsFilter: _.map('value', data) })
             })
           ]),
           div({ style: { ...styles.filter, flexBasis: '250px', minWidth: 0 } }, [

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -1,16 +1,16 @@
 import * as clipboard from 'clipboard-polyfill'
-import debouncePromise from 'debounce-promise'
 import _ from 'lodash/fp'
 import { Fragment } from 'react'
 import { div, h, span } from 'react-hyperscript-helpers'
 import SimpleMDE from 'react-simplemde-editor'
 import * as breadcrumbs from 'src/components/breadcrumbs'
-import { AsyncCreatableSelect, ButtonPrimary, ButtonSecondary, Link, spinnerOverlay } from 'src/components/common'
+import { ButtonPrimary, ButtonSecondary, Link, spinnerOverlay } from 'src/components/common'
 import { icon, spinner } from 'src/components/icons'
 import { Markdown } from 'src/components/Markdown'
 import { InfoBox } from 'src/components/PopupTrigger'
 import { SimpleTable } from 'src/components/table'
 import TooltipTrigger from 'src/components/TooltipTrigger'
+import { WorkspaceTagSelect } from 'src/components/workspace-utils'
 import { displayConsentCodes, displayLibraryAttributes } from 'src/data/workspace-attributes'
 import { Ajax, ajaxCaller } from 'src/libs/ajax'
 import { bucketBrowserUrl } from 'src/libs/auth'
@@ -156,17 +156,6 @@ export const WorkspaceDashboard = _.flow(
     }
   })
 
-  getTagSuggestions = debouncePromise(withErrorReporting('Error loading tags', async text => {
-    const { ajax: { Workspaces } } = this.props
-    if (text.length > 2) {
-      return _.map(({ tag, count }) => {
-        return { value: tag, label: `${tag} (${count})` }
-      }, _.take(10, await Workspaces.getTags(text)))
-    } else {
-      return []
-    }
-  }), 250)
-
   loadWsTags = withErrorReporting('Error loading workspace tags', async () => {
     const { ajax: { Workspaces }, namespace, name } = this.props
     this.setState({ tagsList: await Workspaces.workspace(namespace, name).getTags() })
@@ -296,13 +285,10 @@ export const WorkspaceDashboard = _.flow(
           ])
         ]),
         Utils.canWrite(accessLevel) && div({ style: { marginBottom: '0.5rem' } }, [
-          h(AsyncCreatableSelect, {
+          h(WorkspaceTagSelect, {
             value: null,
-            noOptionsMessage: () => 'Enter at least 3 characters to search',
-            allowCreateWhileLoading: true,
             placeholder: 'Add a tag',
-            onChange: ({ value }) => this.addTag(value),
-            loadOptions: this.getTagSuggestions
+            onChange: ({ value }) => this.addTag(value)
           })
         ]),
         div({ style: { display: 'flex', flexWrap: 'wrap' } }, [


### PR DESCRIPTION
Abstracts some duplicate code for picking workspace tags.

Also adds the `useInstance` utility to cover the case of creating values tied to component instances.