### PR TITLE
improve cluster polling and error reporting [SATURN-919]

### DIFF
--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -152,10 +152,10 @@ const WorkspaceAccessError = () => {
   ])
 }
 
-const useClusterPolling = ({ namespace }) => {
+const useClusterPolling = namespace => {
   const signal = useCancellation()
   const timeout = useRef()
-  const [clusters, setClusters] = useState(undefined)
+  const [clusters, setClusters] = useState()
   const reschedule = ms => {
     clearTimeout(timeout.current)
     timeout.current = setTimeout(refreshClustersSilently, ms)
@@ -189,7 +189,7 @@ export const wrapWorkspace = ({ breadcrumbs, activeTab, title, topBarContent, sh
     const accessNotificationId = useRef()
     const cachedWorkspace = Utils.useAtom(workspaceStore)
     const [loadingWorkspace, setLoadingWorkspace] = useState(false)
-    const { clusters, refreshClusters } = useClusterPolling({ namespace })
+    const { clusters, refreshClusters } = useClusterPolling(namespace)
     const workspace = cachedWorkspace && _.isEqual({ namespace, name }, _.pick(['namespace', 'name'], cachedWorkspace.workspace)) ? cachedWorkspace : undefined
 
     const refreshWorkspace = _.flow(


### PR DESCRIPTION
* Moves the cluster polling logic from the cluster manager to the workspace wrapper
* Unifies refresh handling so that explicit refreshes reset the polling timer. This should reduce redundant requests.
* Silences errors during implicit polling requests. This should eliminate the common 'Error loading clusters' seen when putting laptops to sleep.

FYI since the new polling and timing logic is complex, it could use some extra scrutiny. Thanks!