### PR TITLE
convert popups and tooltips to hooks

### DIFF
--- a/src/components/ClusterManager.js
+++ b/src/components/ClusterManager.js
@@ -7,7 +7,7 @@ import { icon } from 'src/components/icons'
 import { IntegerInput, TextInput } from 'src/components/input'
 import Modal from 'src/components/Modal'
 import { notify } from 'src/components/Notifications.js'
-import PopupTrigger from 'src/components/PopupTrigger'
+import { Popup } from 'src/components/PopupTrigger'
 import { machineTypes, profiles } from 'src/data/clusters'
 import { Ajax, ajaxCaller } from 'src/libs/ajax'
 import { clusterCost, currentCluster, machineConfigCost, normalizeMachineConfig, trimClustersOldestFirst } from 'src/libs/cluster-utils'
@@ -580,13 +580,9 @@ export default ajaxCaller(class ClusterManager extends PureComponent {
         'aria-label': 'Delete cluster',
         style: { marginLeft: '0.5rem' }
       }),
-      h(PopupTrigger, {
-        side: 'bottom',
-        open: multiple,
-        width: 300,
-        content: this.renderDestroyForm()
-      }, [
+      h(IdContainer, [id => h(Fragment, [
         h(Clickable, {
+          id,
           style: styles.button(isDisabled),
           tooltip: Utils.cond(
             [!canCompute, () => noCompute],
@@ -607,8 +603,9 @@ export default ajaxCaller(class ClusterManager extends PureComponent {
             ])
           ]),
           icon('cog', { size: 22, style: { color: isDisabled ? colors.dark(0.7) : colors.accent() } })
-        ])
-      ]),
+        ]),
+        multiple && h(Popup, { side: 'bottom', target: id, handleClickOutside: _.noop }, [this.renderDestroyForm()])
+      ])]),
       deleteModalOpen && h(DeleteClusterModal, {
         cluster: this.getCurrentCluster(),
         onDismiss: () => this.setState({ deleteModalOpen: false }),

--- a/src/components/TooltipTrigger.js
+++ b/src/components/TooltipTrigger.js
@@ -1,6 +1,5 @@
 import _ from 'lodash/fp'
-import PropTypes from 'prop-types'
-import { Children, cloneElement, Component, Fragment, useRef } from 'react'
+import { Children, cloneElement, Fragment, useRef, useState } from 'react'
 import { div, h, path, svg } from 'react-hyperscript-helpers'
 import { computePopupPosition, PopupPortal, useDynamicPosition } from 'src/components/popup-utils'
 import colors from 'src/libs/colors'
@@ -71,55 +70,35 @@ const Tooltip = ({ side = 'bottom', type, target: targetId, children, id }) => {
   ])
 }
 
-export default class TooltipTrigger extends Component {
-  static propTypes = {
-    content: PropTypes.node, // No tooltip if falsy
-    side: PropTypes.string,
-    children: PropTypes.node,
-    type: PropTypes.string
-  }
-
-  static defaultProps = {
-    side: 'bottom',
-    type: 'default'
-  }
-
-  constructor(props) {
-    super(props)
-    this.state = { open: false }
-    this.id = `tooltip-trigger-${_.uniqueId()}`
-    this.tooltipId = `tooltip-${_.uniqueId()}`
-  }
-
-  render() {
-    const { children, type, content, ...props } = this.props
-    const { open } = this.state
-    if (!content) {
-      return children
-    }
-    const child = Children.only(children)
-    return h(Fragment, [
-      cloneElement(child, {
-        id: this.id,
-        'aria-describedby': open ? this.tooltipId : undefined,
-        onMouseEnter: (...args) => {
-          child.props.onMouseEnter && child.props.onMouseEnter(...args)
-          this.setState({ open: true })
-        },
-        onMouseLeave: (...args) => {
-          child.props.onMouseLeave && child.props.onMouseLeave(...args)
-          this.setState({ open: false })
-        },
-        onFocus: (...args) => {
-          child.props.onFocus && child.props.onFocus(...args)
-          this.setState({ open: true })
-        },
-        onBlur: (...args) => {
-          child.props.onBlur && child.props.onBlur(...args)
-          this.setState({ open: false })
-        }
-      }),
-      open && h(Tooltip, { target: this.id, id: this.tooltipId, type, ...props }, [content])
-    ])
-  }
+const TooltipTrigger = ({ children, content, ...props }) => {
+  const [open, setOpen] = useState(false)
+  const id = Utils.useUniqueId()
+  const tooltipId = Utils.useUniqueId()
+  const child = Children.only(children)
+  const childId = child.props.id || id
+  return h(Fragment, [
+    cloneElement(child, {
+      id: childId,
+      'aria-describedby': open ? tooltipId : undefined,
+      onMouseEnter: (...args) => {
+        child.props.onMouseEnter && child.props.onMouseEnter(...args)
+        setOpen(true)
+      },
+      onMouseLeave: (...args) => {
+        child.props.onMouseLeave && child.props.onMouseLeave(...args)
+        setOpen(false)
+      },
+      onFocus: (...args) => {
+        child.props.onFocus && child.props.onFocus(...args)
+        setOpen(true)
+      },
+      onBlur: (...args) => {
+        child.props.onBlur && child.props.onBlur(...args)
+        setOpen(false)
+      }
+    }),
+    open && !!content && h(Tooltip, { target: childId, id: tooltipId, ...props }, [content])
+  ])
 }
+
+export default TooltipTrigger


### PR DESCRIPTION
Converts `TooltipTrigger` and `PopupTrigger` to hooks.

Also removes some unused code in `PopupTrigger`, after converting the unusual usage pattern in `ClusterManager` to just use `Popup` directly instead.