### PR TITLE
fix sticky table state in workflow config [SATURN-1024]

### DIFF
--- a/src/components/input.js
+++ b/src/components/input.js
@@ -45,8 +45,9 @@ export const withDebouncedChange = WrappedComponent => {
   const Wrapper = ({ onChange, value, ...props }) => {
     const [internalValue, setInternalValue] = useState()
     const getInternalValue = Utils.useGetter(internalValue)
+    const getOnChange = Utils.useGetter(onChange)
     const updateParent = Utils.useInstance(() => _.debounce(250, () => {
-      onChange(getInternalValue())
+      getOnChange()(getInternalValue())
       setInternalValue(undefined)
     }))
     return h(WrappedComponent, {

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -133,6 +133,7 @@ const WorkflowIOTable = ({ which, inputsOutputs: data, config, errors, onChange,
               const isFile = (inputType === 'File') || (inputType === 'File?')
               return div({ style: { display: 'flex', alignItems: 'center', width: '100%' } }, [
                 !readOnly ? h(DelayedAutocompleteTextInput, {
+                  key: JSON.stringify([which, name]), // force remount to reset state when dependencies change
                   placeholder: optional ? 'Optional' : 'Required',
                   value,
                   style: isFile ? { borderRadius: '4px 0px 0px 4px', borderRight: 'white' } : undefined,

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -791,6 +791,7 @@ const WorkflowView = _.flow(
     )(data)
 
     return h(Dropzone, {
+      key,
       accept: '.json',
       multiple: false,
       disabled: currentSnapRedacted || !!Utils.editWorkspaceError(workspace),

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -133,7 +133,6 @@ const WorkflowIOTable = ({ which, inputsOutputs: data, config, errors, onChange,
               const isFile = (inputType === 'File') || (inputType === 'File?')
               return div({ style: { display: 'flex', alignItems: 'center', width: '100%' } }, [
                 !readOnly ? h(DelayedAutocompleteTextInput, {
-                  key: JSON.stringify([which, name]), // force remount to reset state when dependencies change
                   placeholder: optional ? 'Optional' : 'Required',
                   value,
                   style: isFile ? { borderRadius: '4px 0px 0px 4px', borderRight: 'white' } : undefined,


### PR DESCRIPTION
When switching between 'inputs' and 'outputs' on the workflow config, the table and some of its contents stay mounted. This was causing some sticky state problems with the new debounced inputs.

Modifies the debounce wrapper to respect changes to the `onChange` prop, which fixes the issue.