### PR TITLE
tweak ajax overrides to allow skipping request

### DIFF
--- a/src/_stories/NewUserModal.stories.js
+++ b/src/_stories/NewUserModal.stories.js
@@ -5,40 +5,25 @@ import { Fragment, useEffect, useState } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
 import { NewUserModal } from 'src/components/group-common'
 import { ajaxOverridesStore } from 'src/libs/state'
+import { delay } from 'src/libs/utils'
 
-
-const INVITE_SUCCEEDED = 201
-const USER_NOT_REGISTERED = 404
-const USER_IS_REGISTERED = 200
-const FAILED_REQUEST = 400
-
-const delayed = ({ ms, resolved, status }) => {
-  return new Promise((resolve, reject) => {
-    setTimeout(() => {
-      if (resolved) {
-        resolve(new Response({ status }))
-      } else {
-        reject({ status, json: () => ({ message: 'Failed to add user' }) })
-      }
-    }, ms)
-  })
-}
 
 const clearOverrides = () => ajaxOverridesStore.set([])
 
 const setOverrides = ({ isRegistered, ms }) => {
   ajaxOverridesStore.set([{
     filter: /api\/users\/v1\/(?!invite)/,
-    fn: () => {
+    fn: () => async () => {
       action('Checking if user is registered')()
-      const status = isRegistered ? USER_IS_REGISTERED : USER_NOT_REGISTERED
-      return delayed({ ms, resolved: isRegistered, status })
+      await delay(ms)
+      return isRegistered ? new Response(null, { status: 200 }) : new Response(null, { status: 404 })
     }
   }, {
     filter: /users\/v1\/invite/,
-    fn: () => {
+    fn: () => async () => {
       action('Requesting user invite')()
-      return delayed({ ms, resolved: true, status: INVITE_SUCCEEDED })
+      await delay(ms)
+      return new Response(null, { status: 201 })
     }
   }])
 }
@@ -66,10 +51,14 @@ const Modal = () => {
         title,
         adminLabel,
         userLabel,
-        addFunction: (role, userEmail) => {
+        addFunction: async (role, userEmail) => {
           action(`Attempting to add user ${userEmail} as a ${role}`)()
-          const resolved = addUnregisteredUser ? addSucceeds : isRegistered && addSucceeds
-          return delayed({ resolved, ms, status: FAILED_REQUEST })
+          await delay(ms)
+          if (addSucceeds) {
+            return
+          } else {
+            throw new Response(JSON.stringify({ message: 'Failed to add user' }), { status: 400 })
+          }
         },
         onSuccess: () => {
           action('Successfuly added user')()

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -10,11 +10,14 @@ import * as Utils from 'src/libs/utils'
 
 
 window.ajaxOverrideUtils = {
-  mapJsonBody: _.curry(async (fn, res) => {
-    return new Response(new Blob([JSON.stringify(fn(await res.json()))]), res)
+  mapJsonBody: _.curry((fn, wrappedFetch) => async (...args) => {
+    const res = await wrappedFetch(...args)
+    return new Response(JSON.stringify(fn(await res.json())), res)
   }),
-  makeError: _.curry(({ status, frequency = 1 }, res) => {
-    return Promise.resolve(Math.random() < frequency ? new Response('Instrumented error', { status }) : res)
+  makeError: _.curry(({ status, frequency = 1 }, wrappedFetch) => (...args) => {
+    return Math.random() < frequency ?
+      Promise.resolve(new Response('Instrumented error', { status })) :
+      wrappedFetch(...args)
   })
 }
 
@@ -25,9 +28,8 @@ const tosData = { appid: 'Saturn', tosversion: 4 }
 
 const withInstrumentation = wrappedFetch => (...args) => {
   return _.flow(
-    _.filter(({ filter }) => args[0].match(filter)),
-    _.reduce(async (rn, { fn }) => fn(await rn), wrappedFetch(...args))
-  )(ajaxOverridesStore.get())
+    ..._.map('fn', _.filter(({ filter }) => args[0].match(filter), ajaxOverridesStore.get()))
+  )(wrappedFetch)(...args)
 }
 
 const withCancellation = wrappedFetch => async (...args) => {

--- a/src/libs/state.js
+++ b/src/libs/state.js
@@ -40,7 +40,7 @@ export const workflowSelectionStore = Utils.atom({
 /*
  * Modifies ajax responses for testing purposes.
  * Can be set to an array of objects of the form { fn, filter }.
- * The fn should take a Response and return a Promise that resolves to a new Response. (See ajaxOverrideUtils)
+ * The fn should be a fetch wrapper (oldFetch => newFetch) that modifies the request process. (See ajaxOverrideUtils)
  * If present, filter should be a RegExp that is matched against the url to target specific requests.
  */
 export const ajaxOverridesStore = Utils.atom()


### PR DESCRIPTION
This changes the signature of the `fn` in ajax overrides to be a standard 'fetch wrapper', e.g. `wrappedFetch => async (...args) => {...}`. This means that overrides can decide to invoke or skip the original request, which is nice for e.g. mocking requests in storybooks.

Updates the included `mapJsonBody` and `makeError` helpers to match the new signature, so any existing snippets using these should continue to work.

Also updates and simplifies the override logic in the `NewUserModal` storybook.