### PR TITLE
make assertions less noisy

### DIFF
--- a/src/components/input.js
+++ b/src/components/input.js
@@ -63,7 +63,7 @@ export const withDebouncedChange = WrappedComponent => {
 }
 
 export const TextInput = forwardRef(({ onChange, nativeOnChange = false, ...props }, ref) => {
-  console.assert(props.id || props['aria-label'], 'In order to be accessible, TextInput needs a label')
+  Utils.useConsoleAssert(props.id || props['aria-label'], 'In order to be accessible, TextInput needs a label')
 
   return h(Interactive, _.merge({
     refDOMNode: ref,
@@ -133,7 +133,7 @@ export const SearchInput = ({ value, onChange, ...props }) => {
 export const DelayedSearchInput = withDebouncedChange(SearchInput)
 
 export const NumberInput = ({ onChange, ...props }) => {
-  console.assert(props.id || props['aria-label'], 'In order to be accessible, NumberInput needs a label')
+  Utils.useConsoleAssert(props.id || props['aria-label'], 'In order to be accessible, NumberInput needs a label')
 
   return h(Interactive, _.merge({
     as: 'input',
@@ -334,7 +334,7 @@ export class AutocompleteSearch extends Component {
 export const DelayedAutocompleteTextInput = withDebouncedChange(AutocompleteTextInput)
 
 export const TextArea = ({ onChange, ...props }) => {
-  console.assert(props.id || props['aria-label'], 'In order to be accessible, TextArea needs a label')
+  Utils.useConsoleAssert(props.id || props['aria-label'], 'In order to be accessible, TextArea needs a label')
 
   return h(Interactive, _.merge({
     as: 'textarea',

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -362,3 +362,11 @@ export const mergeQueryParams = (params, urlString) => {
   url.search = qs.stringify({ ...qs.parse(url.search, { ignoreQueryPrefix: true, plainObjects: true }), ...params })
   return url.href
 }
+
+export const useConsoleAssert = (condition, message) => {
+  const printed = useRef(false)
+  if (!printed.current && !condition) {
+    printed.current = true
+    console.error(message)
+  }
+}

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -367,6 +367,6 @@ export const useConsoleAssert = (condition, message) => {
   const printed = useRef(false)
   if (!printed.current && !condition) {
     printed.current = true
-    console.error(message)
+    console.error(message) // Note: using error because assert halts execution
   }
 }


### PR DESCRIPTION
Currently the assertions trigger every render, leading to excess console noise. This adds a hook to fire them once per component.