### PR TITLE
avoid focus issues with contact form

### DIFF
--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -274,7 +274,10 @@ const TopBar = Utils.connectAtom(authStore, 'authState')(class TopBar extends Co
               ...Utils.newTabLinkProps
             }, ['What\'s different in Terra']),
             h(DropDownSubItem, {
-              onClick: () => contactUsActive.set(true)
+              onClick: () => {
+                this.hideNav()
+                contactUsActive.set(true)
+              }
             }, ['Contact Us'])
           ]),
           isFirecloud() && h(NavSection, {


### PR DESCRIPTION
Currently the focus lock on the left nav prevents interacting with the contact form if it's open. This tries to avoid the issue by closing the left nav when opening the contact form.

Note that this does not solve the underlying issue, as it's still possible to reopen the nav, but this will help users avoid the issue until we can come up with a robust solution.