### PR TITLE
Create a labeled text input utilizing the existing textInput

### DIFF
--- a/src/components/input.js
+++ b/src/components/input.js
@@ -82,7 +82,7 @@ export const TextInput = forwardRef(({ onChange, nativeOnChange = false, ...prop
 
 export const LabeledTextInput = ({ onChange, ...props }) => {
   return h(IdContainer, [id => h(Fragment, [
-    h(TextInput, { onChange, 'aria-label': id, ...props }),
+    h(TextInput, { onChange, 'aria-label': id, ...props })
   ])])
 }
 

--- a/src/components/input.js
+++ b/src/components/input.js
@@ -4,7 +4,7 @@ import { Component, forwardRef, Fragment, useState } from 'react'
 import Autosuggest from 'react-autosuggest'
 import { div, h } from 'react-hyperscript-helpers'
 import Interactive from 'react-interactive'
-import { ButtonPrimary } from 'src/components/common'
+import { ButtonPrimary, IdContainer } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import { PopupPortal, useDynamicPosition } from 'src/components/popup-utils'
 import colors from 'src/libs/colors'
@@ -79,6 +79,12 @@ export const TextInput = forwardRef(({ onChange, nativeOnChange = false, ...prop
     }
   }, props))
 })
+
+export const LabeledTextInput = ({ onChange, ...props }) => {
+  return h(IdContainer, [id => h(Fragment, [
+    h(TextInput, { onChange, 'aria-label': id, ...props }),
+  ])])
+}
 
 export const ConfirmedSearchInput = ({ defaultValue = '', onChange = _.noop, ...props }) => {
   const [internalValue, setInternalValue] = useState(defaultValue)


### PR DESCRIPTION
Using the same pattern as the labeled checkbox, create a LabeledTextInput component. This component should handle a11y concerns without the developer having to directly handle a11y themselves.

Not sure if I did this right and saw you, @petesantos , wrote this ticket so I would love your feedback. Should I also be replacing the `TextInput` objects throughout the codebase with this?