### PR TITLE
load react-simplemde-editor on demand only

### DIFF
--- a/src/components/FreeTrialEulas.js
+++ b/src/components/FreeTrialEulas.js
@@ -1,5 +1,5 @@
 import { div, h } from 'react-hyperscript-helpers'
-import { Markdown, newWindowLinkRenderer } from 'src/components/Markdown'
+import { MarkdownViewer, newWindowLinkRenderer } from 'src/components/markdown'
 
 
 const broadEula = `
@@ -1322,7 +1322,7 @@ https://cloud.google.com/docs
 
 const FreeTrialEulas = ({ pageTwo }) => {
   return div({ style: { maxHeight: 500, maxWidth: 1500, overflowY: 'auto', lineHeight: 1.5, marginTop: '1rem', paddingRight: '1rem' } }, [
-    h(Markdown, {
+    h(MarkdownViewer, {
       renderers: {
         link: newWindowLinkRenderer,
         paragraph: text => {

--- a/src/components/markdown.js
+++ b/src/components/markdown.js
@@ -1,5 +1,7 @@
 import marked from 'marked'
-import { div } from 'react-hyperscript-helpers'
+import { lazy, Suspense } from 'react'
+import { div, h } from 'react-hyperscript-helpers'
+import { centeredSpinner } from 'src/components/icons'
 
 
 /**
@@ -11,7 +13,7 @@ import { div } from 'react-hyperscript-helpers'
  * @returns {object} div containing rendered markdown
  * @constructor
  */
-export const Markdown = ({ children, renderers = {}, ...props }) => {
+export const MarkdownViewer = ({ children, renderers = {}, ...props }) => {
   const content = marked(children, {
     renderer: Object.assign(new marked.Renderer(), renderers)
   })
@@ -20,6 +22,17 @@ export const Markdown = ({ children, renderers = {}, ...props }) => {
     dangerouslySetInnerHTML: { __html: content }
   })
 }
+
 export const newWindowLinkRenderer = (href, title, text) => {
   return `<a href="${href}" ${(title ? `title=${title}` : '')} target="_blank">${text}</a>`
+}
+
+export const MarkdownEditor = props => {
+  const SimpleMDE = lazy(() => import('react-simplemde-editor'))
+
+  return h(Suspense, {
+    fallback: centeredSpinner()
+  }, [
+    h(SimpleMDE, props)
+  ])
 }

--- a/src/components/markdown.js
+++ b/src/components/markdown.js
@@ -30,9 +30,5 @@ export const newWindowLinkRenderer = (href, title, text) => {
 export const MarkdownEditor = props => {
   const SimpleMDE = lazy(() => import('react-simplemde-editor'))
 
-  return h(Suspense, {
-    fallback: centeredSpinner()
-  }, [
-    h(SimpleMDE, props)
-  ])
+  return h(Suspense, { fallback: centeredSpinner() }, [h(SimpleMDE, props)])
 }

--- a/src/components/markdown.js
+++ b/src/components/markdown.js
@@ -27,8 +27,8 @@ export const newWindowLinkRenderer = (href, title, text) => {
   return `<a href="${href}" ${(title ? `title=${title}` : '')} target="_blank">${text}</a>`
 }
 
-export const MarkdownEditor = props => {
-  const SimpleMDE = lazy(() => import('react-simplemde-editor'))
+const SimpleMDE = lazy(() => import('react-simplemde-editor'))
 
+export const MarkdownEditor = props => {
   return h(Suspense, { fallback: centeredSpinner() }, [h(SimpleMDE, props)])
 }

--- a/src/pages/PrivacyPolicy.js
+++ b/src/pages/PrivacyPolicy.js
@@ -1,5 +1,5 @@
 import { div, h } from 'react-hyperscript-helpers'
-import { Markdown, newWindowLinkRenderer } from 'src/components/Markdown'
+import { MarkdownViewer, newWindowLinkRenderer } from 'src/components/markdown'
 
 
 const privacyPolicy = `
@@ -98,7 +98,7 @@ We follow the laws of all the countries where we operate. We follow the laws of 
 
 const PrivacyPolicy = () => {
   return div({ role: 'main', style: { padding: '1rem' } }, [
-    h(Markdown, {
+    h(MarkdownViewer, {
       renderers: {
         link: newWindowLinkRenderer
       }

--- a/src/pages/TermsOfService.js
+++ b/src/pages/TermsOfService.js
@@ -1,7 +1,7 @@
 import { Component } from 'react'
 import { div, h, span } from 'react-hyperscript-helpers'
 import { backgroundLogo, ButtonPrimary, ButtonSecondary } from 'src/components/common'
-import { Markdown } from 'src/components/Markdown'
+import { MarkdownViewer } from 'src/components/markdown'
 import { Ajax } from 'src/libs/ajax'
 import { signOut } from 'src/libs/auth'
 import colors from 'src/libs/colors'
@@ -201,7 +201,7 @@ const termsTitle = div({ style: { color: colors.dark(), fontWeight: 600 } }, [
 const TOSMarkdown = div({
   style: { maxHeight: 400, overflowY: 'auto', lineHeight: 1.5, marginTop: '1rem', paddingRight: '1rem' }
 }, [
-  h(Markdown, {
+  h(MarkdownViewer, {
     renderers: {
       heading: (text, level) => {
         return `<h${level} style="color: ${colors.dark()}; margin-bottom: 0">${text}</h${level}>`

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -2,11 +2,10 @@ import * as clipboard from 'clipboard-polyfill'
 import _ from 'lodash/fp'
 import { Component, Fragment } from 'react'
 import { div, h, span } from 'react-hyperscript-helpers'
-import SimpleMDE from 'react-simplemde-editor'
 import * as breadcrumbs from 'src/components/breadcrumbs'
 import { ButtonPrimary, ButtonSecondary, Link, spinnerOverlay } from 'src/components/common'
 import { icon, spinner } from 'src/components/icons'
-import { Markdown } from 'src/components/Markdown'
+import { MarkdownEditor, MarkdownViewer } from 'src/components/markdown'
 import { InfoBox } from 'src/components/PopupTrigger'
 import { SimpleTable } from 'src/components/table'
 import TooltipTrigger from 'src/components/TooltipTrigger'
@@ -219,7 +218,7 @@ export const WorkspaceDashboard = _.flow(
         Utils.cond(
           [
             isEditing, () => h(Fragment, [
-              h(SimpleMDE, {
+              h(MarkdownEditor, {
                 options: {
                   autofocus: true,
                   placeholder: 'Enter a description',
@@ -240,7 +239,7 @@ export const WorkspaceDashboard = _.flow(
               saving && spinnerOverlay
             ])
           ],
-          [!!description, () => h(Markdown, [description])],
+          [!!description, () => h(MarkdownViewer, [description])],
           () => div({ style: { fontStyle: 'italic' } }, ['No description added'])),
         _.some(_.startsWith('library:'), _.keys(attributes)) && h(Fragment, [
           div({ style: styles.header }, ['Dataset Attributes']),

--- a/src/pages/workspaces/workspace/Workflows.js
+++ b/src/pages/workspaces/workspace/Workflows.js
@@ -9,7 +9,7 @@ import {
 } from 'src/components/common'
 import { centeredSpinner, icon } from 'src/components/icons'
 import { DelayedSearchInput } from 'src/components/input'
-import { Markdown } from 'src/components/Markdown'
+import { MarkdownViewer } from 'src/components/markdown'
 import Modal from 'src/components/Modal'
 import PopupTrigger from 'src/components/PopupTrigger'
 import TooltipTrigger from 'src/components/TooltipTrigger'
@@ -214,7 +214,7 @@ const FindWorkflowModal = ajaxCaller(class FindWorkflowModal extends Component {
         ])
       ]),
       div({ style: { fontSize: 18, fontWeight: 600, margin: '1rem 0 0.5rem' } }, ['Documentation']),
-      documentation && h(Markdown, { style: { maxHeight: 600, overflowY: 'auto' } }, [documentation]),
+      documentation && h(MarkdownViewer, { style: { maxHeight: 600, overflowY: 'auto' } }, [documentation]),
       (!selectedWorkflowDetails || exporting) && spinnerOverlay
     ]
 


### PR DESCRIPTION
I noticed that `react-simplemde-editor` pulls in `codemirror`, and it's only used when editing a workspace's description, so that's a lot of load (~80kb post-gzip, about a fifth of all our non-igv dependencies combined) for a specific use. Learn more about `lazy` and `Suspense` [here](https://reactjs.org/docs/code-splitting.html#reactlazy)