### PR TITLE
Add support for previewing drs:// links

### DIFF
--- a/src/libs/data-utils.js
+++ b/src/libs/data-utils.js
@@ -26,7 +26,7 @@ const warningBoxStyle = {
 }
 
 export const renderDataCell = (data, namespace) => {
-  const isUri = datum => _.startsWith('gs://', datum) || _.startsWith('dos://', datum)
+  const isUri = datum => _.startsWith('gs://', datum) || _.startsWith('dos://', datum) || _.startsWith('drs://', datum)
 
   const renderCell = datum => h(TextCell, { title: datum },
     [isUri(datum) ? h(UriViewerLink, { uri: datum, googleProject: namespace }) : datum])


### PR DESCRIPTION
We already supported `gs://` and `dos://`. This adds `drs://`.

I have a workspace with some of these for testing: http://localhost:3000/#workspaces/general-dev-billing-account/pfb-test/data (sorry, for once I got the PR timing wrong so there's no PR site; you'll have to test locally)
Check the `submitted_aligned_reads` table. They aren't valid `drs://` URIs but it proves that we render the preview link.