### PR TITLE
Use Utils.hasAccessLevel when filtering workspace list by access level [no JIRA]

### DIFF
--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -262,7 +262,7 @@ export const WorkspaceList = () => {
     _.filter(ws => {
       const { workspace: { namespace, name } } = ws
       return Utils.textMatch(filter, `${namespace}/${name}`) &&
-        (_.isEmpty(accessLevelsFilter) || accessLevelsFilter.includes(ws.accessLevel)) &&
+        (_.isEmpty(accessLevelsFilter) || _.some(accessLevel => Utils.hasAccessLevel(accessLevel, ws.accessLevel), accessLevelsFilter)) && //accessLevelsFilter.includes(ws.accessLevel)) &&
         (_.isEmpty(projectsFilter) || projectsFilter === namespace) &&
         (_.isEmpty(submissionsFilter) || submissionsFilter.includes(workspaceSubmissionStatus(ws))) &&
         (_.isEmpty(tagsFilter) || _.every(_.identity, _.map(a => returnTags(ws.workspace.attributes).includes(a), tagsFilter)))


### PR DESCRIPTION
This allows you to filter on "Owner" and see workspaces that you are "Owner" on even if you are also "Project Owner".