### PR TITLE
Change initialAttributes back to amendedAttributes [SATURN-1052]

### DIFF
--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -197,7 +197,7 @@ const LocalVariablesContent = class LocalVariablesContent extends Component {
         })
       ]),
       Utils.cond(
-        [_.isEmpty(initialAttributes), () => 'No Workspace Data defined'],
+        [_.isEmpty(amendedAttributes), () => 'No Workspace Data defined'],
         () => div({ style: { flex: 1 } }, [
           h(AutoSizer, [
             ({ width, height }) => h(FlexTable, {


### PR DESCRIPTION
This corrects an issue where clicking the add variable button when there is no workspace data does not perform any action.