### PR TITLE
unify NumberInput and IntegerInput

### DIFF
--- a/src/components/ClusterManager.js
+++ b/src/components/ClusterManager.js
@@ -4,7 +4,7 @@ import { Fragment, PureComponent, useState } from 'react'
 import { div, h, label, span } from 'react-hyperscript-helpers'
 import { ButtonPrimary, ButtonSecondary, Clickable, IdContainer, LabeledCheckbox, Link, Select, spinnerOverlay } from 'src/components/common'
 import { icon } from 'src/components/icons'
-import { IntegerInput, TextInput } from 'src/components/input'
+import { NumberInput, TextInput } from 'src/components/input'
 import Modal from 'src/components/Modal'
 import { notify } from 'src/components/Notifications.js'
 import { Popup } from 'src/components/PopupTrigger'
@@ -109,11 +109,13 @@ const MachineSelector = ({ machineType, onChangeMachineType, diskSize, onChangeD
         div([
           readOnly ?
             diskSize :
-            h(IntegerInput, {
+            h(NumberInput, {
               id,
               style: styles.smallInput,
               min: 10,
               max: 64000,
+              isClearable: false,
+              onlyInteger: true,
               value: diskSize,
               onChange: onChangeDiskSize
             }),
@@ -269,10 +271,12 @@ export class NewClusterModal extends PureComponent {
             h(IdContainer, [id => h(Fragment, [
               label({ htmlFor: id, style: { ...styles.col1, ...styles.label } }, 'Workers'),
               div({ style: styles.col2 }, [
-                h(IntegerInput, {
+                h(NumberInput, {
                   id,
                   style: styles.smallInput,
                   min: 2,
+                  isClearable: false,
+                  onlyInteger: true,
                   value: numberOfWorkers,
                   onChange: v => this.setState({
                     numberOfWorkers: v,
@@ -284,11 +288,13 @@ export class NewClusterModal extends PureComponent {
             h(IdContainer, [id => h(Fragment, [
               label({ htmlFor: id, style: { ...styles.col3, ...styles.label } }, 'Preemptible'),
               div([
-                h(IntegerInput, {
+                h(NumberInput, {
                   id,
                   style: styles.smallInput,
                   min: 0,
                   max: numberOfWorkers,
+                  isClearable: false,
+                  onlyInteger: true,
                   value: numberOfPreemptibleWorkers,
                   onChange: v => this.setState({ numberOfPreemptibleWorkers: v })
                 })

--- a/src/components/input.js
+++ b/src/components/input.js
@@ -142,10 +142,10 @@ export const NumberInput = ({ onChange, onBlur, min = -Infinity, max = Infinity,
     className: 'focus-style',
     min, max,
     value: internalValue !== undefined ? internalValue : _.toString(value), // eslint-disable-line lodash-fp/preferred-alias
-    onChange: e => {
-      setInternalValue(e.target.value)
-      const constrain = v => _.clamp(min, max, onlyInteger ? _.floor(v) : v)
-      onChange(e.target.value === '' && isClearable ? null : constrain(e.target.value * 1))
+    onChange: ({ target: { value: newValue } }) => {
+      setInternalValue(newValue)
+      // note: floor and clamp implicitly convert the value to a number
+      onChange(newValue === '' && isClearable ? null : _.clamp(min, max, onlyInteger ? _.floor(newValue) : newValue))
     },
     onBlur: (...args) => {
       onBlur && onBlur(...args)


### PR DESCRIPTION
This improves `NumberInput` and allows it to handle the current use case of `IntegerInput`, plus some upcoming use cases.

Values going in and out are now numbers rather than strings. The input allows free typing (within the constraints set by the browser), but `onChange` is only called when the input is a valid number. Passing `min`, `max`, and `onlyInteger` will further constrain the output accordingly. On blur, the input resets its text to display the actual `value` it is receiving.

By default, the component will produce a value of `null` if the input is cleared completely. Passing `isClearable: false` will instead produce `0` in this case (clamped to the range if necessary).

Note that `onChange` is called while typing, unlike `IntegerInput` which only produced values on blur. This is arguably better for validation in the general case, but it does result in a slight UX change on the existing cluster manager: Typing a smaller number in the 'Workers' input will immediately constrain the 'Preemptible' input to match. Since these numbers are tied together and are meant to be set in-order anyway, that seems fine to me.