### PR TITLE
removed 'Terra' from hamburger menu [SATURN-1067]

### DIFF
--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -198,7 +198,7 @@ const TopBar = Utils.connectAtom(authStore, 'authState')(class TopBar extends Co
           ]),
           h(DropDownSection, {
             titleIcon: 'library',
-            title: 'Terra Library',
+            title: 'Library',
             onClick: () => this.setState({ openLibraryMenu: !openLibraryMenu }),
             isOpened: openLibraryMenu
           }, [
@@ -249,7 +249,7 @@ const TopBar = Utils.connectAtom(authStore, 'authState')(class TopBar extends Co
           ),
           h(DropDownSection, {
             titleIcon: 'help',
-            title: 'Terra Support',
+            title: 'Support',
             onClick: () => this.setState({ openSupportMenu: !openSupportMenu }),
             isOpened: openSupportMenu
           }, [


### PR DESCRIPTION
[Ticket](https://broadworkbench.atlassian.net/browse/SATURN-1067)
Remove the word “Terra” from the hamburger menu items across the platform

Across all sites there is a hamburger menu that contains:

- User name
- Your Workspaces
- Terra Library
- Terra Support

_[Requirement: Remove the word “Terra” from within the menu. “Terra Library” changes to “Library” and “Terra Support” changes to “Support”. Note: across the board rather than just within FireCloud]_