### PR TITLE
add withModalDrawer wrapper

### DIFF
--- a/src/_stories/ModalDrawer.stories.js
+++ b/src/_stories/ModalDrawer.stories.js
@@ -8,32 +8,32 @@ import ModalDrawer from 'src/components/ModalDrawer'
 const openButton = ({ onClick }) => h('button', { onClick, style: { width: '100px' } }, 'Open Drawer')
 
 const ModalDrawerEmpty = () => {
-  const [openDrawer, setOpenDrawer] = useState(true)
+  const [isOpen, setIsOpen] = useState(true)
   const width = number('Width', 450)
 
   return h(Fragment, [
-    openButton({ onClick: () => setOpenDrawer(true) }),
+    openButton({ onClick: () => setIsOpen(true) }),
     div({ id: 'modal-root' }, [
       h(ModalDrawer, {
-        openDrawer,
+        isOpen,
         width,
-        onDismiss: () => setOpenDrawer(false)
+        onDismiss: () => setIsOpen(false)
       })
     ])
   ])
 }
 
 const ModalDrawerWithContent = () => {
-  const [openDrawer, setOpenDrawer] = useState(true)
+  const [isOpen, setIsOpen] = useState(true)
   const width = number('Width', 450)
 
   return h(Fragment, [
-    openButton({ onClick: () => setOpenDrawer(true) }),
+    openButton({ onClick: () => setIsOpen(true) }),
     div({ id: 'modal-root' }, [
       h(ModalDrawer, {
         width,
-        openDrawer,
-        onDismiss: () => setOpenDrawer(false)
+        isOpen,
+        onDismiss: () => setIsOpen(false)
       }, [
         h(div, {
           style: { display: 'flex', alignItems: 'baseline', marginBottom: '1rem', flex: 'none', padding: '1.5rem 1.25rem' }

--- a/src/components/ModalDrawer.js
+++ b/src/components/ModalDrawer.js
@@ -22,9 +22,9 @@ const drawer = {
   })
 }
 
-const ModalDrawer = ({ openDrawer, onDismiss, width = 450, children, ...props }) => {
+const ModalDrawer = ({ isOpen, onDismiss, width = 450, children, ...props }) => {
   return h(Transition, {
-    in: openDrawer,
+    in: isOpen,
     timeout: { exit: 200 },
     appear: true,
     mountOnEnter: true,
@@ -39,8 +39,17 @@ const ModalDrawer = ({ openDrawer, onDismiss, width = 450, children, ...props })
   }, [children])])
 }
 
+export const withModalDrawer = ({ width } = {}) => WrappedComponent => {
+  const Wrapper = ({ isOpen, onDismiss, ...props }) => {
+    return h(ModalDrawer, { isOpen, width, onDismiss }, [
+      isOpen && h(WrappedComponent, { onDismiss, ...props })
+    ])
+  }
+  return Wrapper
+}
+
 ModalDrawer.propTypes = {
-  openDrawer: PropTypes.bool,
+  isOpen: PropTypes.bool,
   onDismiss: PropTypes.func.isRequired,
   width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   children: PropTypes.node

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -18,7 +18,7 @@ import { IGVBrowser } from 'src/components/IGVBrowser'
 import { IGVFileSelector } from 'src/components/IGVFileSelector'
 import { DelayedSearchInput, TextInput } from 'src/components/input'
 import Modal from 'src/components/Modal'
-import ModalDrawer from 'src/components/ModalDrawer'
+import { withModalDrawer } from 'src/components/ModalDrawer'
 import { notify } from 'src/components/Notifications'
 import { FlexTable, HeaderCell, SimpleTable, TextCell } from 'src/components/table'
 import TitleBar from 'src/components/TitleBar'
@@ -358,14 +358,10 @@ const ReferenceDataContent = ({ workspace: { workspace: { namespace, attributes 
   ])
 }
 
-const ToolDrawer = ({ workspace, openDrawer, onDismiss: baseOnDismiss, onIgvSuccess, selectedEntities }) => {
+const ToolDrawer = withModalDrawer()(({ workspace, onDismiss, onIgvSuccess, selectedEntities }) => {
   const [toolMode, setToolMode] = useState()
   const entitiesCount = _.size(selectedEntities)
   const entitiesType = !!entitiesCount && selectedEntities[_.keys(selectedEntities)[0]].entityType
-  const onDismiss = () => {
-    baseOnDismiss()
-    setToolMode(undefined)
-  }
 
   const { title, drawerContent } = Utils.switchCase(toolMode, [
     'IGV', () => ({
@@ -411,33 +407,27 @@ const ToolDrawer = ({ workspace, openDrawer, onDismiss: baseOnDismiss, onIgvSucc
     })
   ])
 
-  return h(ModalDrawer, {
-    openDrawer,
-    onDismiss,
-    width: 450
-  }, [
-    h(Fragment, [
-      h(TitleBar, {
-        title,
-        onPrevious: toolMode ? () => { setToolMode(undefined) } : undefined,
-        onDismiss
-      }),
-      div({
-        style: {
-          borderRadius: '1rem',
-          border: `1px solid ${colors.dark(0.5)}`,
-          padding: '0.25rem 0.875rem',
-          margin: '-1rem 1.5rem 1.5rem',
-          alignSelf: 'flex-start',
-          fontSize: 12
-        }
-      }, [
-        `${entitiesCount} ${entitiesType + (entitiesCount > 1 ? 's' : '')} selected`
-      ]),
-      drawerContent
-    ])
+  return h(Fragment, [
+    h(TitleBar, {
+      title,
+      onPrevious: toolMode ? () => { setToolMode(undefined) } : undefined,
+      onDismiss
+    }),
+    div({
+      style: {
+        borderRadius: '1rem',
+        border: `1px solid ${colors.dark(0.5)}`,
+        padding: '0.25rem 0.875rem',
+        margin: '-1rem 1.5rem 1.5rem',
+        alignSelf: 'flex-start',
+        fontSize: 12
+      }
+    }, [
+      `${entitiesCount} ${entitiesType + (entitiesCount > 1 ? 's' : '')} selected`
+    ]),
+    drawerContent
   ])
-}
+})
 
 class EntitiesContent extends Component {
   constructor(props) {
@@ -651,7 +641,7 @@ class EntitiesContent extends Component {
         }),
         h(ToolDrawer, {
           workspace,
-          openDrawer: showToolSelector,
+          isOpen: showToolSelector,
           onDismiss: () => this.setState({ showToolSelector: false }),
           onIgvSuccess: newIgvData => this.setState({ showToolSelector: false, igvData: newIgvData }),
           selectedEntities


### PR DESCRIPTION
This adds a HOC that wraps the component with a `ModalDrawer`. It reads the `isOpen` and `onDismiss` props, and only renders the inner component if the drawer is open. This allows the wrapped component to use the mount/unmount cycle to manage state more naturally, even though the outer wrapper is persistent (because of animations).

This results in a subtle visual change where the contents of the drawer disappear immediately as it fades out.

Also renames `openDrawer` to `isOpen` to match the pattern from react-modal and elsewhere.