### PR TITLE
add select integration helper

### DIFF
--- a/src/_tests/integration/integration-utils.js
+++ b/src/_tests/integration/integration-utils.js
@@ -11,11 +11,16 @@ const findText = (page, text) => {
 }
 
 const findInput = (page, label) => {
-  return page.waitForXPath(`//input[contains(@aria-label,"${label}") or @id=//label[contains(normalize-space(.),"${label}")]/@for]`)
+  return page.waitForXPath(`(//input | //textarea)[contains(@aria-label,"${label}") or @id=//label[contains(normalize-space(.),"${label}")]/@for]`)
 }
 
 const fillIn = async (page, label, text) => {
   return (await findInput(page, label)).type(text, { delay: 20 })
+}
+
+const select = async (page, label, text) => {
+  (await findInput(page, label)).click()
+  return (await page.waitForXPath(`//div[starts-with(@id, "react-select-") and contains(normalize-space(.),"${text}")]`)).click()
 }
 
 const waitForNoSpinners = page => {
@@ -28,5 +33,6 @@ module.exports = {
   findText,
   findInput,
   fillIn,
+  select,
   waitForNoSpinners
 }

--- a/src/_tests/integration/integration.integration-test.js
+++ b/src/_tests/integration/integration.integration-test.js
@@ -1,4 +1,4 @@
-const { click, findText, findClickable, fillIn, waitForNoSpinners } = require('./integration-utils')
+const { click, findText, findClickable, fillIn, select, waitForNoSpinners } = require('./integration-utils')
 
 
 test('integration', async () => {
@@ -10,4 +10,6 @@ test('integration', async () => {
   await waitForNoSpinners(page)
   await click(page, 'New Workspace')
   await fillIn(page, 'Workspace name', 'My workspace')
+  await select(page, 'Billing project', 'general-dev-billing-account')
+  await fillIn(page, 'Description', '# This is my workspace')
 }, 60 * 1000)


### PR DESCRIPTION
* Adds a new integration test helper for filling in `Select` boxes
* Allows `fillIn` to work on `TextArea` as well
* Extends the test case to fill in more of the form.