### PR TITLE
specify fields for workspace details

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -492,8 +492,8 @@ const Workspaces = signal => ({
         return res.json()
       },
 
-      details: async () => {
-        const res = await fetchRawls(root, _.merge(authOpts(), { signal }))
+      details: async fields => {
+        const res = await fetchRawls(`${root}?${qs.stringify({ fields }, { arrayFormat: 'comma' })}`, _.merge(authOpts(), { signal }))
         return res.json()
       },
 

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -98,7 +98,7 @@ const WorkspaceMenuContent = ({ namespace, name, onClone, onShare, onDelete }) =
   const [workspace, setWorkspace] = useState(undefined)
   const signal = useCancellation()
   const loadWorkspace = withErrorReporting('Error loading workspace', async () => {
-    setWorkspace(await Ajax(signal).Workspaces.workspace(namespace, name).details())
+    setWorkspace(await Ajax(signal).Workspaces.workspace(namespace, name).details(['accessLevel', 'canShare']))
   })
   Utils.useOnMount(() => {
     loadWorkspace()

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -180,7 +180,9 @@ export const wrapWorkspace = ({ breadcrumbs, activeTab, title, topBarContent, sh
       Utils.withBusyState(setLoadingWorkspace)
     )(async () => {
       try {
-        const workspace = await Ajax(signal).Workspaces.workspace(namespace, name).details()
+        const workspace = await Ajax(signal).Workspaces.workspace(namespace, name).details([
+          'accessLevel', 'canCompute', 'canShare', 'owners', 'workspace', 'workspace.attributes', 'workspaceSubmissionStats'
+        ])
         workspaceStore.set(workspace)
 
         const { accessLevel, workspace: { createdBy, createdDate } } = workspace

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -181,7 +181,9 @@ export const wrapWorkspace = ({ breadcrumbs, activeTab, title, topBarContent, sh
     )(async () => {
       try {
         const workspace = await Ajax(signal).Workspaces.workspace(namespace, name).details([
-          'accessLevel', 'canCompute', 'canShare', 'owners', 'workspace', 'workspace.attributes', 'workspaceSubmissionStats'
+          'accessLevel', 'canCompute', 'canShare', 'owners',
+          'workspace', 'workspace.attributes', 'workspace.authorizationDomain',
+          'workspaceSubmissionStats'
         ])
         workspaceStore.set(workspace)
 


### PR DESCRIPTION
attn: @davidangb 

Anecdotally, just excluding `bucketOptions` and `catalog` (which we don't use) appears to cut response time by half(!)