### PR TITLE
Update listClusters with userEmail and googleProject [SATURN-1094]

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -932,8 +932,8 @@ const Submissions = signal => ({
 
 
 const Jupyter = signal => ({
-  clustersList: async project => {
-    const res = await fetchLeo(`api/clusters${project ? `/${project}` : ''}?saturnAutoCreated=true`,
+  clustersList: async (labels = {}) => {
+    const res = await fetchLeo(`api/clusters?${qs.stringify({ saturnAutoCreated: true, ...labels })}`,
       _.mergeAll([authOpts(), appIdentifier, { signal }]))
     return res.json()
   },

--- a/src/pages/Clusters.js
+++ b/src/pages/Clusters.js
@@ -29,7 +29,7 @@ const Clusters = () => {
   const [sort, setSort] = useState({ field: 'project', direction: 'asc' })
 
   const refreshClusters = withBusyState(setLoading, async () => {
-    const newClusters = _.filter({ creator: getUser().email }, await Ajax(signal).Jupyter.clustersList())
+    const newClusters = await Ajax(signal).Jupyter.clustersList({ creator: getUser().email })
     setClusters(newClusters)
     if (!_.some({ id: getErrorClusterId() }, newClusters)) {
       setErrorClusterId(undefined)

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -143,7 +143,7 @@ const useClusterPolling = namespace => {
   }
   const loadClusters = async () => {
     try {
-      const newClusters = await Ajax(signal).Jupyter.clustersList({googleProject: namespace, creator: getUser().email})
+      const newClusters = await Ajax(signal).Jupyter.clustersList({ googleProject: namespace, creator: getUser().email })
       setClusters(newClusters)
       const cluster = currentCluster(newClusters)
       reschedule(_.includes(cluster && cluster.status, ['Creating', 'Starting', 'Stopping']) ? 10000 : 120000)

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -143,8 +143,8 @@ const useClusterPolling = namespace => {
   }
   const loadClusters = async () => {
     try {
-      const newClusters = await Ajax(signal).Jupyter.clustersList(namespace)
-      setClusters(_.filter({ creator: getUser().email }, newClusters))
+      const newClusters = await Ajax(signal).Jupyter.clustersList({googleProject: namespace, creator: getUser().email})
+      setClusters(newClusters)
       const cluster = currentCluster(newClusters)
       reschedule(_.includes(cluster && cluster.status, ['Creating', 'Starting', 'Stopping']) ? 10000 : 120000)
     } catch (error) {


### PR DESCRIPTION
Makes filtering be done on backend instead of clientside.
[Jira ticket](https://broadworkbench.atlassian.net/browse/SATURN-1094?atlOrigin=eyJpIjoiNjgxNDkyOGZlZDE0NDkxODgyODBiOTkwNmNiMmYzMGYiLCJwIjoiaiJ9)