### PR TITLE
Encourage users to delete old clusters

### DIFF
--- a/src/components/ClusterManager.js
+++ b/src/components/ClusterManager.js
@@ -497,7 +497,7 @@ export default ajaxCaller(class ClusterManager extends PureComponent {
           }, ['Read here for more details.'])
         ])
       })
-    } else if (createdDate < twoMonthsAgo && !isToday(dateNotified)) {
+    } else if (isAfter(createdDate, twoMonthsAgo) && !isToday(dateNotified)) {
       setDynamic(sessionStorage, `notifiedOutdatedCluster${cluster.id}`, Date.now())
       notify('warn', 'Outdated Notebook Runtime', {
         message: 'Your notebook runtime is over two months old. Please consider deleting and recreating your runtime in order to access the latest features and security updates.'

--- a/src/components/ClusterManager.js
+++ b/src/components/ClusterManager.js
@@ -452,12 +452,6 @@ const ClusterErrorNotification = ({ cluster }) => {
   ])
 }
 
-const ClusterOutdatedNotification = () => {
-  return h(Fragment, [
-    p(['Your notebook runtime is over two months old. Please consider deleting and recreating your runtime in order to access the latest features and security updates.'])
-  ])
-}
-
 export default ajaxCaller(class ClusterManager extends PureComponent {
   static propTypes = {
     namespace: PropTypes.string.isRequired,
@@ -487,9 +481,9 @@ export default ajaxCaller(class ClusterManager extends PureComponent {
         message: h(ClusterErrorNotification, { cluster })
       })
       errorNotifiedClusters.update(Utils.append(cluster.id))
-    } else if (createdDate < twoMonthsAgo && !_.includes(cluster.id, outdatedNotifiedClusters.get())) {
+    } else if (createdDate > twoMonthsAgo && !_.includes(cluster.id, outdatedNotifiedClusters.get())) {
       notify('warn', 'Outdated Notebook Runtime', {
-        message: h(ClusterOutdatedNotification, {})
+        message: 'Your notebook runtime is over two months old. Please consider deleting and recreating your runtime in order to access the latest features and security updates.'
       })
       outdatedNotifiedClusters.update(Utils.append(cluster.id))
     }

--- a/src/components/ClusterManager.js
+++ b/src/components/ClusterManager.js
@@ -485,7 +485,7 @@ export default ajaxCaller(class ClusterManager extends PureComponent {
         message: h(ClusterErrorNotification, { cluster })
       })
       errorNotifiedClusters.update(Utils.append(cluster.id))
-    } else if (isAfter(createdDate, welderCutOff) && !isToday(dateNotified)) {
+    } else if (isAfter(createdDate, welderCutOff) && !isToday(dateNotified)) { // TODO: remove this notification some time after the data syncing release
       setDynamic(sessionStorage, `notifiedOutdatedCluster${cluster.id}`, Date.now())
       notify('warn', 'Please Update Your Runtime', {
         message: h(Fragment, [

--- a/src/components/ClusterManager.js
+++ b/src/components/ClusterManager.js
@@ -351,14 +351,13 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
           ]),
           !!currentCluster && div({ style: styles.warningBox }, [
             div({ style: styles.label }, ['Caution:']),
-            div({}, [
-              'Deleting your runtime will stop all running notebooks, and delete any files on the associated hard disk (e.g. input data or analysis outputs) and installed packages. To permanently save these files, ',
-              h(Link, {
-                href: 'https://support.terra.bio/hc/en-us/articles/360026639112',
-                ...Utils.newTabLinkProps
-              }, ['move them to the workspace bucket.']),
-              p(['You will be unable to work on the notebooks in this workspace while it updates, which can take a few minutes.'])
-            ])
+            'Deleting your runtime will stop all running notebooks, and delete any files on the associated hard disk (e.g. input data or analysis outputs) and installed packages. To permanently save these files, ',
+            h(Link, {
+              variant: 'light',
+              href: 'https://support.terra.bio/hc/en-us/articles/360026639112',
+              ...Utils.newTabLinkProps
+            }, ['move them to the workspace bucket.']),
+            p(['You will be unable to work on the notebooks in this workspace while it updates, which can take a few minutes.'])
           ]),
           div({ style: { flexGrow: 1 } }),
           div({ style: { display: 'flex', justifyContent: 'flex-end' } }, [
@@ -481,7 +480,7 @@ export default ajaxCaller(class ClusterManager extends PureComponent {
         message: h(ClusterErrorNotification, { cluster })
       })
       errorNotifiedClusters.update(Utils.append(cluster.id))
-    } else if (createdDate > twoMonthsAgo && !_.includes(cluster.id, outdatedNotifiedClusters.get())) {
+    } else if (createdDate < twoMonthsAgo && !_.includes(cluster.id, outdatedNotifiedClusters.get())) {
       notify('warn', 'Outdated Notebook Runtime', {
         message: 'Your notebook runtime is over two months old. Please consider deleting and recreating your runtime in order to access the latest features and security updates.'
       })

--- a/src/libs/state.js
+++ b/src/libs/state.js
@@ -27,8 +27,6 @@ export const rerunFailuresStatus = Utils.atom()
 
 export const errorNotifiedClusters = Utils.atom([])
 
-export const outdatedNotifiedClusters = Utils.atom([])
-
 export const requesterPaysBuckets = Utils.atom([])
 
 export const requesterPaysProjectStore = Utils.atom()

--- a/src/libs/state.js
+++ b/src/libs/state.js
@@ -27,6 +27,8 @@ export const rerunFailuresStatus = Utils.atom()
 
 export const errorNotifiedClusters = Utils.atom([])
 
+export const outdatedNotifiedClusters = Utils.atom([])
+
 export const requesterPaysBuckets = Utils.atom([])
 
 export const requesterPaysProjectStore = Utils.atom()


### PR DESCRIPTION
This PR focuses on two things: 
1. Encourages users to delete and create a new cluster if their existing cluster is older than two months. This will be helpful in the upcoming data syncing feature and is generally good practice to keep people updated with features and security updates. 
2. Provides users with a heads up when deleting/updating their clusters that all their files on the runtime will be deleted, and how to move it to the workspace bucket to persist them. 