### PR TITLE
disallow low memory machine type for clusters

### DIFF
--- a/src/data/clusters.js
+++ b/src/data/clusters.js
@@ -14,7 +14,8 @@ export const machineTypes = [
   { name: 'n1-highmem-32', cpu: 32, memory: 208, price: 1.8944, preemptiblePrice: 0.4000 },
   { name: 'n1-highmem-64', cpu: 64, memory: 416, price: 3.7888, preemptiblePrice: 0.8000 },
   { name: 'n1-highmem-96', cpu: 96, memory: 624, price: 5.6832, preemptiblePrice: 1.2000 },
-  { name: 'n1-highcpu-2', cpu: 2, memory: 1.8, price: 0.0709, preemptiblePrice: 0.0150 },
+  // NOTE: n1-highcpu-2 has too little memory for dataproc, and so is disallowed.
+  //{ name: 'n1-highcpu-2', cpu: 2, memory: 1.8, price: 0.0709, preemptiblePrice: 0.0150 },
   { name: 'n1-highcpu-4', cpu: 4, memory: 3.6, price: 0.1418, preemptiblePrice: 0.0300 },
   { name: 'n1-highcpu-8', cpu: 8, memory: 7.2, price: 0.2836, preemptiblePrice: 0.0600 },
   { name: 'n1-highcpu-16', cpu: 16, memory: 14.4, price: 0.5672, preemptiblePrice: 0.1200 },


### PR DESCRIPTION
This disables the `n1-highcpu-2` machine type during cluster configuration, because it cannot be used in dataproc clusters due to having too little memory.

Note: I opted to comment out rather than delete, because this data was pulled directly from google's docs, so it seems like a good idea to keep it intact for the sake of future maintenance and understanding.