### PR TITLE
add fields specifier to workspaces list call

### DIFF
--- a/src/components/workspace-utils.js
+++ b/src/components/workspace-utils.js
@@ -18,7 +18,9 @@ export const useWorkspaces = () => {
     withErrorReporting('Error loading workspace list'),
     Utils.withBusyState(setLoading)
   )(async () => {
-    const ws = await Ajax(signal).Workspaces.list()
+    const ws = await Ajax(signal).Workspaces.list([
+      'accessLevel', 'public', 'workspace', 'workspaceSubmissionStats', 'workspace.attributes.description'
+    ])
     workspacesStore.set(ws)
   })
   Utils.useOnMount(() => {

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -444,8 +444,8 @@ const attributesUpdateOps = _.flow(
 )
 
 const Workspaces = signal => ({
-  list: async () => {
-    const res = await fetchRawls('workspaces', _.merge(authOpts(), { signal }))
+  list: async fields => {
+    const res = await fetchRawls(`workspaces?${qs.stringify({ fields }, { arrayFormat: 'comma' })}`, _.merge(authOpts(), { signal }))
     return res.json()
   },
 


### PR DESCRIPTION
This effectively omits the non-description workspace attributes, which reduces payload size by quite a bit.