### PR TITLE
New Baseline Health Study release

### DIFF
--- a/src/data/datasets.js
+++ b/src/data/datasets.js
@@ -12,8 +12,8 @@ const datasets = [
   },
   {
     name: 'Baseline Health Study',
-    origin: 'https://baseline-baseline-explorer.appspot.com',
-    authDomain: 'baseline-researchers'
+    origin: 'https://baseline-explorer.appspot.com',
+    authDomain: 'baseline-researchers-v1'
   },
   {
     name: 'Framingham Heart Study Teaching Dataset',

--- a/src/pages/library/Datasets.js
+++ b/src/pages/library/Datasets.js
@@ -189,13 +189,13 @@ const baseline = () => h(Participant, {
   logo: { src: baselineLogo, alt: `Project Baseline logo`, height: '55%' },
   title: `Baseline Health Study`,
   description: h(Fragment, [
-    h(Link, { href: 'https://www.projectbaseline.com/', ...Utils.newTabLinkProps }, 'Baseline Health Study'),
+    h(Link, { href: 'https://www.projectbaseline.com/study/project-baseline/', ...Utils.newTabLinkProps }, 'Baseline Health Study'),
     ` is a longitudinal study that will collect broad phenotypic health data
     from approximately 10,000 participants, who will each be followed over the
     course of at least four years. The study is part of a broader effort
     designed to develop a well-defined reference, or “baseline,” of health.`
   ]),
-  sizeText: 'Participants: > 1,500'
+  sizeText: 'Participants: > 2,500'
 }, [
   h(ButtonPrimary, {
     href: Nav.getLink('data-explorer-private', { dataset: 'Baseline Health Study' })


### PR DESCRIPTION
Later this week Verily will release a new version of Baseline Health Study dataset to researchers. I will merge after the release.