### PR TITLE
display the current environment in Runtime Configuration [SATURN-1124]

### DIFF
--- a/src/components/ClusterManager.js
+++ b/src/components/ClusterManager.js
@@ -20,6 +20,7 @@ import { clusterCost, currentCluster, machineConfigCost, normalizeMachineConfig,
 import colors from 'src/libs/colors'
 import { reportError, withErrorReporting } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
+import * as StateHistory from 'src/libs/state-history'
 import { errorNotifiedClusters } from 'src/libs/state.js'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
@@ -167,10 +168,11 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
       ({ machineConfig }) => machineConfigsEqual(machineConfig, currentConfig),
       profiles
     )
+    const { selectedLeoImage } = StateHistory.get()
     this.state = {
       profile: matchingProfile ? matchingProfile.name : 'custom',
       jupyterUserScriptUri: '',
-      selectedLeoImage: leoImages[0].image,
+      selectedLeoImage: selectedLeoImage || leoImages[0].image,
       ...normalizeMachineConfig(currentConfig)
     }
   }
@@ -376,6 +378,13 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
         ])
       ])
     ])
+  }
+
+  componentDidUpdate() {
+    StateHistory.update(_.pick(
+      ['selectedLeoImage'],
+      this.state)
+    )
   }
 })
 


### PR DESCRIPTION
Previous issue: "I created a cluster with the Bioconductor image. When the cluster was ready I opened my Runtime environment and the drop-down said "Default". It would be better to display the runtime environment currently in use."

makes it so current runtime environment is shown as the default if one exists, otherwise uses default settings that previously existed

(also having some issues merging with dev so not updated fully yet)