### PR TITLE
minor text changes for notebookNameValidator [SATURN-1187]

### DIFF
--- a/src/components/notebook-utils.js
+++ b/src/components/notebook-utils.js
@@ -42,8 +42,9 @@ export const findPotentialNotebookLockers = async ({ canShare, namespace, wsName
 export const notebookNameValidator = existing => ({
   presence: { allowEmpty: false },
   format: {
-    pattern: /^[^#[\]*?:;@$%+=\\,/]*$/,
-    message: 'can\'t contain these characters: \r \r  @ # $ % * + = ? , [ ] : ; / \\ '
+    pattern: /^[^@#$%*+=?,[\]:;/\\]*$/,
+    message: 'can\'t contain these characters: @ # $ % * + = ? , [ ] : ; / \\ '
+
   },
   exclusion: {
     within: existing,

--- a/src/components/notebook-utils.js
+++ b/src/components/notebook-utils.js
@@ -43,7 +43,10 @@ export const notebookNameValidator = existing => ({
   presence: { allowEmpty: false },
   format: {
     pattern: /^[^@#$%*+=?,[\]:;/\\]*$/,
-    message: 'can\'t contain these characters: @ # $ % * + = ? , [ ] : ; / \\ '
+    message: h(Fragment, [
+      div('Name can\'t contain these characters:'),
+      div({ style: { margin: '0.5rem 1rem' } }, '@ # $ % * + = ? , [ ] : ; / \\ ')
+    ])
   },
   exclusion: {
     within: existing,

--- a/src/components/notebook-utils.js
+++ b/src/components/notebook-utils.js
@@ -44,7 +44,6 @@ export const notebookNameValidator = existing => ({
   format: {
     pattern: /^[^@#$%*+=?,[\]:;/\\]*$/,
     message: 'can\'t contain these characters: @ # $ % * + = ? , [ ] : ; / \\ '
-
   },
   exclusion: {
     within: existing,


### PR DESCRIPTION
reorder regex to match the character order in the error message and remove extraneous '/r /r'


Old:


<img width="567" alt="Screen Shot 2019-11-05 at 1 28 21 PM" src="https://user-images.githubusercontent.com/5375000/68235297-ff1ecd80-ffd0-11e9-8ff7-0029b0e4d017.png">

based on discussions with Brian, the text is now on 2 lines:

New:
<img width="547" alt="Screen Shot 2019-11-05 at 1 30 14 PM" src="https://user-images.githubusercontent.com/5375000/68235303-0219be00-ffd1-11e9-9464-9740cf8b5f5d.png">
