### PR TITLE
Show current  runtime [SATURN-1124]

### DIFF
--- a/src/components/NewClusterModal.js
+++ b/src/components/NewClusterModal.js
@@ -170,6 +170,15 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
     ]))
   }
 
+  async componentDidMount() {
+    const { currentCluster } = this.props
+    if (currentCluster) {
+      const { clusterImages } = await Ajax().Jupyter.cluster(currentCluster.googleProject, currentCluster.clusterName).details()
+      const { dockerImage } = _.find({ tool: 'Jupyter' }, clusterImages)
+      this.setState({ selectedLeoImage: dockerImage })
+    }
+  }
+
   render() {
     const { currentCluster, onDismiss } = this.props
     const {

--- a/src/components/NewClusterModal.js
+++ b/src/components/NewClusterModal.js
@@ -11,6 +11,7 @@ import { imageValidationRegexp, leoImages } from 'src/data/leo-images'
 import { Ajax } from 'src/libs/ajax'
 import { machineConfigCost, normalizeMachineConfig } from 'src/libs/cluster-utils'
 import colors from 'src/libs/colors'
+import { withErrorReporting } from 'src/libs/error'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 
@@ -170,14 +171,19 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
     ]))
   }
 
-  async componentDidMount() {
+  componentDidMount = withErrorReporting('Error loading cluster', async () => {
     const { currentCluster } = this.props
     if (currentCluster) {
       const { clusterImages } = await Ajax().Jupyter.cluster(currentCluster.googleProject, currentCluster.clusterName).details()
       const { dockerImage } = _.find({ tool: 'Jupyter' }, clusterImages)
-      this.setState({ selectedLeoImage: dockerImage })
+
+      if (_.find({ image: dockerImage }, leoImages)) {
+        this.setState({ selectedLeoImage: dockerImage })
+      } else {
+        this.setState({ isCustomEnv: true, customEnvImage: dockerImage })
+      }
     }
-  }
+  })
 
   render() {
     const { currentCluster, onDismiss } = this.props


### PR DESCRIPTION
Previous issue: "I created a cluster with the Bioconductor image. When the cluster was ready I opened my Runtime environment and the drop-down said "Default". It would be better to display the runtime environment currently in use."

makes it so current runtime environment is shown as the default if one exists, otherwise uses default settings that previously existed. Also switches to showing the custom environment with their image name if they are using that instead.