### PR TITLE
Updates to AMP PD section in datasets tab

### DIFF
--- a/src/data/datasets.js
+++ b/src/data/datasets.js
@@ -7,12 +7,12 @@ const datasets = [
   },
   {
     name: 'AMP PD - 2019_v1release_1015',
-    origin: 'https://amp-pd-data-explorers.appspot.com',
+    origin: 'https://data-explorer.amp-pd.org',
     authDomain: 'amp-pd-researchers'
   },
   {
     name: 'AMP PD Clinical - 2019_v1release_1015',
-    origin: 'https://amp-pd-clinical-data-explorers.appspot.com',
+    origin: 'https://clinical-data-explorer.amp-pd.org',
     authDomain: 'amp-pd-clinical-access'
   },
   {

--- a/src/data/datasets.js
+++ b/src/data/datasets.js
@@ -6,9 +6,14 @@ const datasets = [
     origin: 'https://test-data-explorer.appspot.com'
   },
   {
-    name: 'AMP PD - 2019_v1beta_0220',
-    origin: 'https://amp-pd-data-explorer.appspot.com',
+    name: 'AMP PD - 2019_v1release_1015',
+    origin: 'https://amp-pd-data-explorers.appspot.com',
     authDomain: 'amp-pd-researchers'
+  },
+  {
+    name: 'AMP PD Clinical - 2019_v1release_1015',
+    origin: 'https://amp-pd-clinical-data-explorers.appspot.com',
+    authDomain: 'amp-pd-clinical-access'
   },
   {
     name: 'Baseline Health Study',

--- a/src/pages/library/Datasets.js
+++ b/src/pages/library/Datasets.js
@@ -165,7 +165,7 @@ const amppd = () => h(Participant, {
       `The Accelerating Medicines Partnership (AMP) is a public-private partnership between the National Institutes of
     Health (NIH), multiple biopharmaceutical and life sciences companies, and non-profit organizations to identify and
     validate the most promising biological targets for therapeutics. This AMP effort aims to identify and validate the
-    most promising biological targets for therapeutics relevant to Parkinson's disease. Access to this data will be restricted until a launch in 2019-Q3.`
+    most promising biological targets for therapeutics relevant to Parkinson's disease.`
     ]),
     p(['Includes data from the following studies:']),
     div({ style: { margin: '0.4rem 0', fontWeight: 'bold', lineHeight: '150%' } }, [
@@ -179,11 +179,15 @@ const amppd = () => h(Participant, {
       ])
     ])
   ]),
-  sizeText: 'Participants: > 4,700'
+  sizeText: 'Participants: > 4,000'
 }, [
   h(ButtonPrimary, {
-    href: Nav.getLink('data-explorer-private', { dataset: 'AMP PD - 2019_v1beta_0220' })
-  }, ['Browse Data'])
+    style: { marginBottom: '1rem' },
+    href: Nav.getLink('data-explorer-private', { dataset: 'AMP PD Clinical - 2019_v1release_1015' })
+  }, ['Browse Tier 1 Data']),
+  h(ButtonPrimary, {
+    href: Nav.getLink('data-explorer-private', { dataset: 'AMP PD - 2019_v1release_1015' })
+  }, ['Browse Tier 2 Data'])
 ])
 
 const baseline = () => h(Participant, {

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -372,16 +372,16 @@ const ReferenceDataContent = ({ workspace: { workspace: { namespace, attributes 
 }
 
 const getDataset = dataExplorerUrl => {
-  if (dataExplorerUrl.includes('appspot.com')) {
-    // Cohort was imported from standalone Data Explorer, eg
-    // https://test-data-explorer.appspot.com/
-    return _.find({ origin: new URL(dataExplorerUrl).origin }, datasets)
-  } else {
-    // Cohort was imported from embedded Data Explorer, eg
+  // Either cohort was imported from standalone Data Explorer, eg
+  // https://test-data-explorer.appspot.com/
+  const dataset = _.find({ origin: new URL(dataExplorerUrl).origin }, datasets)
+  if (!dataset) {
+    // Or cohort was imported from embedded Data Explorer, eg
     // https://app.terra.bio/#library/datasets/public/1000%20Genomes/data-explorer
     const datasetName = unescape(dataExplorerUrl.split(/datasets\/(?:public\/)?([^/]+)\/data-explorer/)[1])
     return _.find({ name: datasetName }, datasets)
   }
+  return dataset
 }
 
 const ToolDrawer = _.flow(


### PR DESCRIPTION
The upcoming AMP PD release now uses a 2-tiered access model, and there is an updated data explorer for each tier.

![Screenshot from 2019-10-29 15-00-39](https://user-images.githubusercontent.com/6879774/67812680-f6704980-fa5c-11e9-92ca-db33c18454aa.png)

cc @mbookman @melissachang 