### PR TITLE
Update text instructions for creating custom image [SATURN-1192]

### DIFF
--- a/src/components/NewClusterModal.js
+++ b/src/components/NewClusterModal.js
@@ -279,8 +279,8 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
                 div({ style: { gridColumnStart: 2, gridColumnEnd: 'span 2', alignSelf: 'start' } }, [
                   h(Link, { href: imageInstructions, ...Utils.newTabLinkProps }, ['Custom notebook environments']),
                   span({ style: { fontWeight: 'bold' } }, [' must ']),
-                  ' be based off of the ',
-                  h(Link, { href: terraBaseImages, ...Utils.newTabLinkProps }, ['Terra base image.'])
+                  ' be based off one of the ',
+                  h(Link, { href: terraBaseImages, ...Utils.newTabLinkProps }, ['Terra base images.'])
                 ])
               ]) :
               h(Fragment, [

--- a/src/components/NewClusterModal.js
+++ b/src/components/NewClusterModal.js
@@ -277,9 +277,10 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
                   ])
                 ]),
                 div({ style: { gridColumnStart: 2, gridColumnEnd: 'span 2', alignSelf: 'start' } }, [
-                  h(Link, { href: imageInstructions, ...Utils.newTabLinkProps }, ['Learn how']),
-                  ' to create your own custom docker image from one of our ',
-                  h(Link, { href: terraBaseImages, ...Utils.newTabLinkProps }, ['Terra base images.'])
+                  h(Link, { href: imageInstructions, ...Utils.newTabLinkProps }, ['Custom notebook environments']),
+                  span({ style: { fontWeight: 'bold' } }, [' must ']),
+                  ' be based off of the ',
+                  h(Link, { href: terraBaseImages, ...Utils.newTabLinkProps }, ['Terra base image.'])
                 ])
               ]) :
               h(Fragment, [


### PR DESCRIPTION
Per the [ticket](https://broadworkbench.atlassian.net/browse/SATURN-1192?atlOrigin=eyJpIjoiOWRkYjg5MDZlMTEwNGI2NzhjMWQ2ZjNmODVjMWRmZjgiLCJwIjoiaiJ9):
Make the instructions to build a custom image more clear by updating text instructions from:
"Learn how to create your own custom docker image from one of our Terra base images."
to
"Custom notebook environments must be based off of the Terra base image."