### PR TITLE
Add dataJoined User Property for Appcues on-boarding [SATURN-1146]

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -131,6 +131,11 @@ const getServiceAccountToken = Utils.memoizeAsync(async (namespace, token) => {
 
 export const saToken = namespace => getServiceAccountToken(namespace, getUser().token)
 
+const getFirstTimeStamp = Utils.memoizeAsync(async token => {
+  const res = await fetchRex('firstTimestamps/record', _.mergeAll([authOpts(token), { method: 'POST' }]))
+  return res.json()
+}, { keyFn: (...args) => JSON.stringify(args) })
+
 const User = signal => ({
   getStatus: async () => {
     const res = await fetchOk(`${getConfig().samUrlRoot}/register/user/v2/self/info`, _.mergeAll([authOpts(), { signal }, appIdentifier]))
@@ -250,9 +255,8 @@ const User = signal => ({
     return (await res.json()).upload
   },
 
-  firstTimestamp: async () => {
-    const res = await fetchRex('firstTimestamps/record', _.mergeAll([authOpts(), { signal, method: 'POST' }]))
-    return res.json()
+  firstTimestamp: () => {
+    return getFirstTimeStamp(getUser().token)
   },
 
   lastNpsResponse: async () => {

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -15,6 +15,10 @@ const getAuthInstance = () => {
   return window.gapi.auth2.getAuthInstance()
 }
 
+const getDateJoined = async () => {
+  return parseJSON((await Ajax().User.firstTimestamp()).timestamp)
+}
+
 export const signOut = () => {
   sessionStorage.clear()
   getAuthInstance().signOut()
@@ -158,7 +162,7 @@ authStore.subscribe(async (state, oldState) => {
   if (!oldState.isSignedIn && state.isSignedIn) {
     window.newrelic.setCustomAttribute('userGoogleId', state.user.id)
     window.Appcues && window.Appcues.identify(state.user.id, {
-      dateCreated: parseJSON((await Ajax().User.firstTimestamp()).timestamp)
+      dateJoined: await getDateJoined()
     })
   }
 })

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -1,3 +1,4 @@
+import { parseJSON } from 'date-fns/fp'
 import _ from 'lodash/fp'
 import { div, h } from 'react-hyperscript-helpers'
 import { ShibbolethLink } from 'src/components/common'
@@ -153,10 +154,12 @@ authStore.subscribe(withErrorReporting('Error checking TOS', async (state, oldSt
  * hashes to identify a user in our analytics data. We trust our developers to refrain from
  * doing this.
  */
-authStore.subscribe((state, oldState) => {
+authStore.subscribe(async (state, oldState) => {
   if (!oldState.isSignedIn && state.isSignedIn) {
     window.newrelic.setCustomAttribute('userGoogleId', state.user.id)
-    window.Appcues && window.Appcues.identify(state.user.id)
+    window.Appcues && window.Appcues.identify(state.user.id, {
+      dateCreated: parseJSON((await Ajax().User.firstTimestamp()).timestamp)
+    })
   }
 })
 

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -167,7 +167,7 @@ export const toIndexPairs = _.flow(_.toPairs, _.map(([k, v]) => [k * 1, v]))
  * Memoizes an async function for up to `expires` ms.
  * Rejected promises are immediately removed from the cache.
  */
-export const memoizeAsync = (asyncFn, { keyFn = _.identity, expires }) => {
+export const memoizeAsync = (asyncFn, { keyFn = _.identity, expires = Infinity }) => {
   const cache = {}
   return (...args) => {
     const now = Date.now()


### PR DESCRIPTION
We want to use Appcues to show an on-boarding flow for new users. Appcues uses _User Properties_ to make decisions such as determining who the new users are. This change adds a _User Property_ called _dateJoined_, populated with the date that a user first logs into Terra (we are also already sending a unique user Id) so that Appcues can make this differentiation.
[ticket](https://broadworkbench.atlassian.net/browse/SATURN-1146?atlOrigin=eyJpIjoiZjQwNDA2YjBhZTY1NDg1YjhiYjdlZGFjMzFhOWI5MGIiLCJwIjoiaiJ9)

Note - This change also leverages _memoize_ so that the call to get the first-log-in-timestamp only occurs once and is cached (this value is also used in the NPS survey logic so are avoiding unnecessary network calls with this implementation)