### PR TITLE
Prevent users from updating 'description' from workspace data [SATURN-1160]

### DIFF
--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -148,11 +148,11 @@ const LocalVariablesContent = class LocalVariablesContent extends Component {
       ...filteredAttributes, ...(creatingNewVariable ? [['', '']] : [])
     ]
 
-    const inputErrors = editIndex !== undefined && editIndex >= 0 && [
+    const inputErrors = editIndex !== undefined && [
       ...(_.keys(_.unset(amendedAttributes[editIndex][0], attributes)).includes(editKey) ? ['Key must be unique'] : []),
       ...(!/^[\w-]*$/.test(editKey) ? ['Key can only contain letters, numbers, underscores, and dashes'] : []),
-      ...(editKey === 'description' ? ['\`description\` is a reserved keyword'] : []),
-      ...(editKey.startsWith('referenceData_') ? ['\`referenceData_\` is a reserved keyword'] : []),
+      ...(editKey === 'description' ? ['Key cannot be \`description\`'] : []),
+      ...(editKey.startsWith('referenceData_') ? ['Key cannot start with \`referenceData_\`'] : []),
       ...(!editKey ? ['Key is required'] : []),
       ...(!editValue ? ['Value is required'] : []),
       ...(editValue && editType === 'number' && Utils.cantBeNumber(editValue) ? ['Value is not a number'] : []),

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -148,9 +148,11 @@ const LocalVariablesContent = class LocalVariablesContent extends Component {
       ...filteredAttributes, ...(creatingNewVariable ? [['', '']] : [])
     ]
 
-    const inputErrors = editIndex && [
+    const inputErrors = editIndex !== undefined && editIndex >= 0 && [
       ...(_.keys(_.unset(amendedAttributes[editIndex][0], attributes)).includes(editKey) ? ['Key must be unique'] : []),
       ...(!/^[\w-]*$/.test(editKey) ? ['Key can only contain letters, numbers, underscores, and dashes'] : []),
+      ...(editKey === 'description' ? ['\`description\` is a reserved keyword'] : []),
+      ...(editKey.startsWith('referenceData_') ? ['\`referenceData_\` is a reserved keyword'] : []),
       ...(!editKey ? ['Key is required'] : []),
       ...(!editValue ? ['Value is required'] : []),
       ...(editValue && editType === 'number' && Utils.cantBeNumber(editValue) ? ['Value is not a number'] : []),

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -151,8 +151,8 @@ const LocalVariablesContent = class LocalVariablesContent extends Component {
     const inputErrors = editIndex !== undefined && [
       ...(_.keys(_.unset(amendedAttributes[editIndex][0], attributes)).includes(editKey) ? ['Key must be unique'] : []),
       ...(!/^[\w-]*$/.test(editKey) ? ['Key can only contain letters, numbers, underscores, and dashes'] : []),
-      ...(editKey === 'description' ? ['Key cannot be \`description\`'] : []),
-      ...(editKey.startsWith('referenceData_') ? ['Key cannot start with \`referenceData_\`'] : []),
+      ...(editKey === 'description' ? ['Key cannot be \'description\''] : []),
+      ...(editKey.startsWith('referenceData_') ? ['Key cannot start with \'referenceData_\''] : []),
       ...(!editKey ? ['Key is required'] : []),
       ...(!editValue ? ['Value is required'] : []),
       ...(editValue && editType === 'number' && Utils.cantBeNumber(editValue) ? ['Value is not a number'] : []),


### PR DESCRIPTION
This PR solves the reported issue of having a 'description' entry in workspace data update the overall workspace description field.  [ticket](https://broadworkbench.atlassian.net/browse/SATURN-1160?atlOrigin=eyJpIjoiMGIwYzdiOWNiZGU4NGUyZWFhOTRjZTRhOTE1YWNiMmQiLCJwIjoiaiJ9)

It also stops users from being able to add an entry in workspace data with a key starting with 'referenceData_' (not reported but also found this to be a bug when testing)