### PR TITLE
Fix dockstore link to reflect  the current version of workflow [SATURN-1141]

### DIFF
--- a/src/components/common.js
+++ b/src/components/common.js
@@ -329,7 +329,7 @@ export const methodLink = config => {
   const { methodRepoMethod: { sourceRepo, methodVersion, methodNamespace, methodName, methodPath } } = config
   return sourceRepo === 'agora' ?
     `${getConfig().firecloudUrlRoot}/?return=${returnParam()}#methods/${methodNamespace}/${methodName}/${methodVersion}` :
-    `${getConfig().dockstoreUrlRoot}/workflows/${methodPath}`
+    `${getConfig().dockstoreUrlRoot}/workflows/${methodPath}:${methodVersion}`
 }
 
 export const ShibbolethLink = ({ children, ...props }) => {

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -554,7 +554,6 @@ const WorkflowView = _.flow(
     this.fetchInfo(config)
   })
 
-
   renderSummary() {
     const { workspace: ws, workspace: { workspace }, namespace, name: workspaceName } = this.props
     const {
@@ -630,11 +629,18 @@ const WorkflowView = _.flow(
               })
             ])
           ])]),
+          // console.log('methodNamespace:', methodNamespace),
+          // console.log('methodName', methodName),
+          // console.log('methodVersion', methodVersion),
+          // console.log('currentSnapRedacted', currentSnapRedacted),
+          // console.log('methodLink', methodLink),
+          // console.log('methodLink(modifiedConfig)', methodLink(modifiedConfig)),
+          // console.log('methodPath', methodPath),
           div([
             'Source: ', currentSnapRedacted ? `${methodNamespace}/${methodName}/${methodVersion}` : h(Link, {
-              href: methodLink(modifiedConfig),
+              href: sourceRepo === 'agora' ? methodLink(modifiedConfig) : methodLink(modifiedConfig) + ':'+methodVersion,
               ...Utils.newTabLinkProps
-            }, methodPath ? methodPath : `${methodNamespace}/${methodName}/${methodVersion}`)
+            }, methodPath ? methodPath + ':' + methodVersion : `${methodNamespace}/${methodName}/${methodVersion}`)
           ]),
           div(`Synopsis: ${synopsis ? synopsis : ''}`),
           documentation ?

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -632,7 +632,7 @@ const WorkflowView = _.flow(
           ])]),
           div([
             'Source: ', currentSnapRedacted ? `${methodNamespace}/${methodName}/${methodVersion}` : h(Link, {
-              href: sourceRepo === 'agora' ? methodLink(modifiedConfig) : methodLink(modifiedConfig) + ':' + methodVersion,
+              href: methodLink(modifiedConfig),
               ...Utils.newTabLinkProps
             }, methodPath ? methodPath + ':' + methodVersion : `${methodNamespace}/${methodName}/${methodVersion}`)
           ]),

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -554,6 +554,7 @@ const WorkflowView = _.flow(
     this.fetchInfo(config)
   })
 
+
   renderSummary() {
     const { workspace: ws, workspace: { workspace }, namespace, name: workspaceName } = this.props
     const {
@@ -629,16 +630,9 @@ const WorkflowView = _.flow(
               })
             ])
           ])]),
-          // console.log('methodNamespace:', methodNamespace),
-          // console.log('methodName', methodName),
-          // console.log('methodVersion', methodVersion),
-          // console.log('currentSnapRedacted', currentSnapRedacted),
-          // console.log('methodLink', methodLink),
-          // console.log('methodLink(modifiedConfig)', methodLink(modifiedConfig)),
-          // console.log('methodPath', methodPath),
           div([
             'Source: ', currentSnapRedacted ? `${methodNamespace}/${methodName}/${methodVersion}` : h(Link, {
-              href: sourceRepo === 'agora' ? methodLink(modifiedConfig) : methodLink(modifiedConfig) + ':'+methodVersion,
+              href: sourceRepo === 'agora' ? methodLink(modifiedConfig) : methodLink(modifiedConfig) + ':' + methodVersion,
               ...Utils.newTabLinkProps
             }, methodPath ? methodPath + ':' + methodVersion : `${methodNamespace}/${methodName}/${methodVersion}`)
           ]),

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -634,7 +634,7 @@ const WorkflowView = _.flow(
             'Source: ', currentSnapRedacted ? `${methodNamespace}/${methodName}/${methodVersion}` : h(Link, {
               href: methodLink(modifiedConfig),
               ...Utils.newTabLinkProps
-            }, methodPath ? methodPath + ':' + methodVersion : `${methodNamespace}/${methodName}/${methodVersion}`)
+            }, sourceRepo === 'agora' ? `${methodNamespace}/${methodName}/${methodVersion}` : `${methodPath}:${methodVersion}`)
           ]),
           div(`Synopsis: ${synopsis ? synopsis : ''}`),
           documentation ?


### PR DESCRIPTION
Previously the link for a dockstore sourced workflows did not update when changing versions, with these changes the version will show and also the redirect link will go to the version specific workflow.

To test this [workspace](https://bvdp-saturn-dev.appspot.com/#workspaces/this-is-a-testing-project-name/Test%20for%20Dockstore%20versioned%20link) has a dockstore sourced workflow with multiple versions and a terra sourced workflow with multiple snapshots