### PR TITLE
fix extraneous react key warnings [SATURN-1232]

### DIFF
--- a/src/components/notebook-utils.js
+++ b/src/components/notebook-utils.js
@@ -51,12 +51,14 @@ export const notebookNameValidator = existing => ({
   }
 })
 
-export const notebookNameInput = props => h(ValidatedInput, _.merge({
+export const notebookNameInput = ({ inputProps, ...props }) => h(ValidatedInput, {
+  ...props,
   inputProps: {
+    ...inputProps,
     autoFocus: true,
     placeholder: 'Enter a name'
   }
-}, props))
+})
 
 
 const baseNotebook = {


### PR DESCRIPTION
This fixes a key react key warning when passing a `Fragment` as an error message. The deep merge was modifying the underlying react element and changing its behavior. In general we should probably avoid blindly deep merging, since it can cause subtle problems like this.

Tested by clicking through the UI.