### PR TITLE
fix workflow import and launch [SATURN-1222]

### DIFF
--- a/src/pages/workspaces/workspace/Workflows.js
+++ b/src/pages/workspaces/workspace/Workflows.js
@@ -259,7 +259,9 @@ const FindWorkflowModal = ajaxCaller(class FindWorkflowModal extends Component {
 
       await methodAjax.toWorkspace({ namespace, name }, config)
 
-      Nav.goToPath('workflow', { namespace, name, workflowNamespace: selectedWorkflow.namespace, workflowName: selectedWorkflow.name })
+      const { namespace: workflowNamespace, name: workflowName } = config || selectedWorkflow
+
+      Nav.goToPath('workflow', { namespace, name, workflowNamespace, workflowName })
     } catch (error) {
       reportError('Error importing workflow', error)
       this.setState({ exporting: false })

--- a/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
+++ b/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
@@ -4,7 +4,7 @@ import { div, h } from 'react-hyperscript-helpers'
 import { ButtonPrimary, CromwellVersionLink } from 'src/components/common'
 import { spinner } from 'src/components/icons'
 import Modal from 'src/components/Modal'
-import { ajaxCaller } from 'src/libs/ajax'
+import { Ajax, ajaxCaller } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { reportError } from 'src/libs/error'
 import EntitySelectionType from 'src/pages/workspaces/workspace/workflows/EntitySelectionType'
@@ -134,8 +134,7 @@ export default ajaxCaller(class LaunchAnalysisModal extends Component {
     const {
       workspaceId: { namespace, name },
       entitySelectionModel: { newSetName },
-      config: { rootEntityType },
-      ajax: { Workspaces }
+      config: { rootEntityType }
     } = this.props
 
     const setType = `${rootEntityType}_set`
@@ -153,7 +152,7 @@ export default ajaxCaller(class LaunchAnalysisModal extends Component {
     }
 
     try {
-      await Workspaces.workspace(namespace, name).createEntity(newSet)
+      await Ajax().Workspaces.workspace(namespace, name).createEntity(newSet)
     } catch (error) {
       this.setState({ launchError: await error.text(), message: undefined })
       return
@@ -166,11 +165,10 @@ export default ajaxCaller(class LaunchAnalysisModal extends Component {
     const {
       workspaceId: { namespace, name },
       config: { namespace: configNamespace, name: configName },
-      useCallCache,
-      ajax: { Workspaces }
+      useCallCache
     } = this.props
 
-    return Workspaces.workspace(namespace, name).methodConfig(configNamespace, configName).launch({
+    return Ajax().Workspaces.workspace(namespace, name).methodConfig(configNamespace, configName).launch({
       entityType, entityName, expression, useCallCache
     })
   }


### PR DESCRIPTION
Some pre-CUJ3 (SATURN-1080) fixes.
* Imported workflows are named after their configs, if available, so use that in building the link.
* AJAX calls that create things shouldn't be cancelled.

(tested in the UI)