### PR TITLE
Enable prevention of encoding the URI in routes (fixes import WDL) [PROD-300] [SATURN-1242]

### DIFF
--- a/src/libs/routes.js
+++ b/src/libs/routes.js
@@ -60,13 +60,13 @@ const routes = _.flatten([
   NotFound.navPaths // must be last
 ])
 
-const handlers = _.map(({ path, ...data }) => {
+const handlers = _.map(({ path, encode = encodeURIComponent, ...data }) => {
   const keys = [] // mutated by pathToRegexp
   const regex = pathToRegexp(path, keys)
   return {
     regex,
     keys: _.map('name', keys),
-    makePath: compile(path, { encode: encodeURIComponent }),
+    makePath: compile(path, { encode }),
     ...data
   }
 }, routes)

--- a/src/pages/ImportWorkflow.js
+++ b/src/pages/ImportWorkflow.js
@@ -126,10 +126,12 @@ export const navPaths = [
     name: 'import-workflow',
     path: '/import-workflow/:source/:item(.*)',
     component: Importer,
+    encode: _.identity,
     title: 'Import Workflow'
   }, {
     name: 'import-tool', // legacy
     path: '/import-tool/:source/:item(.*)',
-    component: props => h(Nav.Redirector, { pathname: Nav.getPath('import-workflow', props, { encode: _.identity }) })
+    encode: _.identity,
+    component: props => h(Nav.Redirector, { pathname: Nav.getPath('import-workflow', props) })
   }
 ]


### PR DESCRIPTION
I test this by pasting a the Terra import URI from Dockstore into my browser and modifying the URI to hit my localhost.

The URI I used is:
http://localhost:3000/#import-tool/dockstore/github.com/DataBiosphere/topmed-workflows/UM_variant_caller_wdl:1.32.0

This fails in with the current code, passes with this change

