### PR TITLE
Move cancellation hook to utils.js in preparation for inactive session code [SATURN-1243]

### DIFF
--- a/src/components/RequesterPaysModal.js
+++ b/src/components/RequesterPaysModal.js
@@ -4,7 +4,7 @@ import { div, h } from 'react-hyperscript-helpers'
 import { ButtonPrimary, Link, Select, spinnerOverlay } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import Modal from 'src/components/Modal'
-import { Ajax, useCancellation } from 'src/libs/ajax'
+import { Ajax } from 'src/libs/ajax'
 import { withErrorReporting } from 'src/libs/error'
 import { FormLabel } from 'src/libs/forms'
 import * as Nav from 'src/libs/nav'
@@ -26,7 +26,7 @@ const RequesterPaysModal = ({ onDismiss, onSuccess }) => {
   const [loading, setLoading] = useState(false)
   const [billingList, setBillingList] = useState([])
   const [selectedBilling, setSelectedBilling] = useState(requesterPaysProjectStore.get())
-  const signal = useCancellation()
+  const signal = Utils.useCancellation()
 
   Utils.useOnMount(() => {
     const loadBillingProjects = _.flow(

--- a/src/components/UriViewer.js
+++ b/src/components/UriViewer.js
@@ -9,7 +9,7 @@ import { ButtonPrimary, Clickable, Link } from 'src/components/common'
 import { icon, spinner } from 'src/components/icons'
 import Modal from 'src/components/Modal'
 import DownloadPrices from 'src/data/download-prices'
-import { Ajax, useCancellation } from 'src/libs/ajax'
+import { Ajax } from 'src/libs/ajax'
 import { bucketBrowserUrl } from 'src/libs/auth'
 import colors from 'src/libs/colors'
 import { withErrorReporting } from 'src/libs/error'
@@ -63,7 +63,7 @@ const getMaxDownloadCostNA = bytes => {
 }
 
 const PreviewContent = ({ uri, metadata, metadata: { bucket, name }, googleProject }) => {
-  const signal = useCancellation()
+  const signal = Utils.useCancellation()
   const [preview, setPreview] = useState()
   const loadPreview = async () => {
     try {
@@ -101,7 +101,7 @@ const PreviewContent = ({ uri, metadata, metadata: { bucket, name }, googleProje
 }
 
 const DownloadButton = ({ uri, metadata: { bucket, name, size } }) => {
-  const signal = useCancellation()
+  const signal = Utils.useCancellation()
   const [url, setUrl] = useState()
   const getUrl = async () => {
     try {
@@ -137,7 +137,7 @@ const UriViewer = _.flow(
   Utils.withDisplayName('UriViewer'),
   requesterPaysWrapper({ onDismiss: ({ onDismiss }) => onDismiss() })
 )(({ googleProject, uri, onDismiss, onRequesterPaysError }) => {
-  const signal = useCancellation()
+  const signal = Utils.useCancellation()
   const [metadata, setMetadata] = useState()
   const [copied, setCopied] = useState()
   const [loadingError, setLoadingError] = useState()

--- a/src/components/WorkflowSelector.js
+++ b/src/components/WorkflowSelector.js
@@ -2,7 +2,7 @@ import _ from 'lodash/fp'
 import { Fragment, useState } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
 import { centeredSpinner } from 'src/components/icons'
-import { Ajax, useCancellation } from 'src/libs/ajax'
+import { Ajax } from 'src/libs/ajax'
 import { withErrorReporting } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
 import { workflowSelectionStore } from 'src/libs/state'
@@ -12,7 +12,7 @@ import { ModalToolButton } from 'src/pages/workspaces/workspace/Data'
 
 
 const WorkflowSelector = ({ workspace: { workspace: { namespace, name } }, selectedEntities }) => {
-  const { Workspaces } = Ajax(useCancellation())
+  const { Workspaces } = Ajax(Utils.useCancellation())
   const [loading, setLoading] = useState()
   const [configs, setConfigs] = useState()
   const selectionKey = Utils.useUniqueId()

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -11,7 +11,7 @@ import Interactive from 'src/components/Interactive'
 import TooltipTrigger from 'src/components/TooltipTrigger'
 import hexButton from 'src/images/hex-button.svg'
 import scienceBackground from 'src/images/science-background.jpg'
-import { Ajax, useCancellation } from 'src/libs/ajax'
+import { Ajax } from 'src/libs/ajax'
 import colors, { terraSpecial } from 'src/libs/colors'
 import { getConfig, isTerra } from 'src/libs/config'
 import { returnParam } from 'src/libs/logos'
@@ -368,7 +368,7 @@ export const FocusTrapper = ({ children, onBreakout, ...props }) => {
 
 export const CromwellVersionLink = props => {
   const [version, setVersion] = useState()
-  const signal = useCancellation()
+  const signal = Utils.useCancellation()
 
   Utils.useOnMount(() => {
     const setCromwellVersion = async () => {

--- a/src/components/workspace-utils.js
+++ b/src/components/workspace-utils.js
@@ -4,14 +4,14 @@ import { Fragment, useState } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
 import { AsyncCreatableSelect, ButtonPrimary, Link, Select } from 'src/components/common'
 import NewWorkspaceModal from 'src/components/NewWorkspaceModal'
-import { Ajax, useCancellation } from 'src/libs/ajax'
+import { Ajax } from 'src/libs/ajax'
 import { withErrorReporting } from 'src/libs/error'
 import { workspacesStore } from 'src/libs/state'
 import * as Utils from 'src/libs/utils'
 
 
 export const useWorkspaces = () => {
-  const signal = useCancellation()
+  const signal = Utils.useCancellation()
   const [loading, setLoading] = useState(false)
   const workspaces = Utils.useAtom(workspacesStore)
   const refresh = _.flow(
@@ -98,7 +98,7 @@ export const WorkspaceImporter = _.flow(
 })
 
 export const WorkspaceTagSelect = props => {
-  const signal = useCancellation()
+  const signal = Utils.useCancellation()
   const getTagSuggestions = Utils.useInstance(() => debouncePromise(withErrorReporting('Error loading tags', async text => {
     if (text.length > 2) {
       return _.map(({ tag, count }) => {

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1,6 +1,5 @@
 import _ from 'lodash/fp'
 import * as qs from 'qs'
-import { useEffect, useRef } from 'react'
 import { h } from 'react-hyperscript-helpers'
 import { version } from 'src/data/clusters'
 import { getUser } from 'src/libs/auth'
@@ -1089,20 +1088,9 @@ export const Ajax = signal => {
 // Exposing Ajax for use by integration tests (and debugging, or whatever)
 window.Ajax = Ajax
 
-export const useCancellation = () => {
-  const controller = useRef()
-  useEffect(() => {
-    return () => controller.current.abort()
-  }, [])
-  if (!controller.current) {
-    controller.current = new window.AbortController()
-  }
-  return controller.current.signal
-}
-
 export const ajaxCaller = WrappedComponent => {
   return Utils.withDisplayName('ajaxCaller', props => {
-    const signal = useCancellation()
+    const signal = Utils.useCancellation()
     return h(WrappedComponent, { ...props, ajax: Ajax(signal) })
   })
 }

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -394,6 +394,18 @@ export const useConsoleAssert = (condition, message) => {
   }
 }
 
+
+export const useCancellation = () => {
+  const controller = useRef()
+  useEffect(() => {
+    return () => controller.current.abort()
+  }, [])
+  if (!controller.current) {
+    controller.current = new window.AbortController()
+  }
+  return controller.current.signal
+}
+
 export const maybeParseJSON = maybeJSONString => {
   try {
     return JSON.parse(maybeJSONString)

--- a/src/pages/Clusters.js
+++ b/src/pages/Clusters.js
@@ -8,14 +8,14 @@ import { icon } from 'src/components/icons'
 import { FlexTable, Sortable } from 'src/components/table'
 import TooltipTrigger from 'src/components/TooltipTrigger'
 import TopBar from 'src/components/TopBar'
-import { Ajax, useCancellation } from 'src/libs/ajax'
+import { Ajax } from 'src/libs/ajax'
 import { getUser } from 'src/libs/auth'
 import { clusterCost, currentCluster } from 'src/libs/cluster-utils'
 import colors from 'src/libs/colors'
 import { withErrorIgnoring, withErrorReporting } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
 import * as Style from 'src/libs/style'
-import { delay, formatUSD, makeCompleteDate, useGetter, useOnMount, withBusyState } from 'src/libs/utils'
+import { delay, formatUSD, makeCompleteDate, useCancellation, useGetter, useOnMount, withBusyState } from 'src/libs/utils'
 
 
 const Clusters = () => {

--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -8,7 +8,7 @@ import { centeredSpinner, icon, profilePic, spinner } from 'src/components/icons
 import { TextInput, ValidatedInput } from 'src/components/input'
 import { InfoBox } from 'src/components/PopupTrigger'
 import TopBar from 'src/components/TopBar'
-import { Ajax, ajaxCaller, useCancellation } from 'src/libs/ajax'
+import { Ajax, ajaxCaller } from 'src/libs/ajax'
 import { getUser, refreshTerraProfile } from 'src/libs/auth'
 import colors from 'src/libs/colors'
 import { withErrorReporting } from 'src/libs/error'
@@ -67,7 +67,7 @@ const NihLink = ({ nihToken }) => {
    */
   const { nihStatus } = Utils.useAtom(authStore)
   const [linking, setLinking] = useState(false)
-  const signal = useCancellation()
+  const signal = Utils.useCancellation()
 
   Utils.useOnMount(() => {
     const { User } = Ajax(signal)
@@ -176,7 +176,7 @@ const FenceLink = ({ provider, displayName }) => {
   const [isLoadingStatus, setIsLoadingStatus] = useState(false)
   const [isLoadingAuthUrl, setIsLoadingAuthUrl] = useState(false)
   const [isLinking, setIsLinking] = useState(false)
-  const signal = useCancellation()
+  const signal = Utils.useCancellation()
 
   const { User } = Ajax(signal)
 

--- a/src/pages/library/Code.js
+++ b/src/pages/library/Code.js
@@ -6,14 +6,14 @@ import { centeredSpinner } from 'src/components/icons'
 import { libraryTopMatter } from 'src/components/library-common'
 import broadSquare from 'src/images/library/code/broad-square.svg'
 import dockstoreLogo from 'src/images/library/code/dockstore.svg'
-import { Ajax, useCancellation } from 'src/libs/ajax'
+import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { getConfig } from 'src/libs/config'
 import { withErrorReporting } from 'src/libs/error'
 import { getAppName, returnParam } from 'src/libs/logos'
 import * as StateHistory from 'src/libs/state-history'
 import * as Style from 'src/libs/style'
-import { useOnMount, withBusyState } from 'src/libs/utils'
+import { useCancellation, useOnMount, withBusyState } from 'src/libs/utils'
 
 
 const styles = {

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -15,7 +15,7 @@ import PopupTrigger from 'src/components/PopupTrigger'
 import TooltipTrigger from 'src/components/TooltipTrigger'
 import TopBar from 'src/components/TopBar'
 import { useWorkspaces, WorkspaceTagSelect } from 'src/components/workspace-utils'
-import { Ajax, useCancellation } from 'src/libs/ajax'
+import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { withErrorReporting } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
@@ -96,7 +96,7 @@ const workspaceSubmissionStatus = ({ workspaceSubmissionStats: { runningSubmissi
 
 const WorkspaceMenuContent = ({ namespace, name, onClone, onShare, onDelete }) => {
   const [workspace, setWorkspace] = useState(undefined)
-  const signal = useCancellation()
+  const signal = Utils.useCancellation()
   const loadWorkspace = withErrorReporting('Error loading workspace', async () => {
     setWorkspace(await Ajax(signal).Workspaces.workspace(namespace, name).details(['accessLevel', 'canShare']))
   })

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -31,7 +31,7 @@ import dataExplorerLogo from 'src/images/data-explorer-logo.svg'
 import igvLogo from 'src/images/igv-logo.png'
 import jupyterLogo from 'src/images/jupyter-logo.svg'
 import wdlLogo from 'src/images/wdl-logo.png'
-import { Ajax, ajaxCaller, useCancellation } from 'src/libs/ajax'
+import { Ajax, ajaxCaller } from 'src/libs/ajax'
 import { getUser } from 'src/libs/auth'
 import colors from 'src/libs/colors'
 import { getConfig } from 'src/libs/config'
@@ -398,7 +398,7 @@ const ToolDrawer = _.flow(
 }) => {
   const [toolMode, setToolMode] = useState()
   const [notebookNames, setNotebookNames] = useState()
-  const signal = useCancellation()
+  const signal = Utils.useCancellation()
 
   const { Buckets } = Ajax(signal)
 

--- a/src/pages/workspaces/workspace/RequestAccessModal.js
+++ b/src/pages/workspaces/workspace/RequestAccessModal.js
@@ -4,9 +4,9 @@ import { div, h, span, table, tbody, td, th, thead, tr } from 'react-hyperscript
 import { ButtonPrimary, Link } from 'src/components/common'
 import { centeredSpinner, icon } from 'src/components/icons'
 import Modal from 'src/components/Modal'
-import { Ajax, useCancellation } from 'src/libs/ajax'
+import { Ajax } from 'src/libs/ajax'
 import { withErrorReporting } from 'src/libs/error'
-import { cond, useOnMount, withBusyState } from 'src/libs/utils'
+import { cond, useCancellation, useOnMount, withBusyState } from 'src/libs/utils'
 
 
 export const RequestAccessModal = ({ onDismiss, workspace }) => {

--- a/src/pages/workspaces/workspace/SubmissionQueueStatus.js
+++ b/src/pages/workspaces/workspace/SubmissionQueueStatus.js
@@ -3,9 +3,9 @@ import _ from 'lodash/fp'
 import { Fragment, useState } from 'react'
 import { h, table, tbody, td, tr } from 'react-hyperscript-helpers'
 import { spinner } from 'src/components/icons'
-import { Ajax, useCancellation } from 'src/libs/ajax'
+import { Ajax } from 'src/libs/ajax'
 import { withErrorReporting } from 'src/libs/error'
-import { useOnMount, withBusyState } from 'src/libs/utils'
+import { useCancellation, useOnMount, withBusyState } from 'src/libs/utils'
 
 
 export const SubmissionQueueStatus = () => {

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -9,7 +9,7 @@ import NewWorkspaceModal from 'src/components/NewWorkspaceModal'
 import { clearNotification, notify } from 'src/components/Notifications'
 import PopupTrigger from 'src/components/PopupTrigger'
 import TopBar from 'src/components/TopBar'
-import { Ajax, saToken, useCancellation } from 'src/libs/ajax'
+import { Ajax, saToken } from 'src/libs/ajax'
 import { getUser } from 'src/libs/auth'
 import { currentCluster } from 'src/libs/cluster-utils'
 import colors from 'src/libs/colors'
@@ -134,7 +134,7 @@ const WorkspaceAccessError = () => {
 }
 
 const useClusterPolling = namespace => {
-  const signal = useCancellation()
+  const signal = Utils.useCancellation()
   const timeout = useRef()
   const [clusters, setClusters] = useState()
   const reschedule = ms => {
@@ -165,7 +165,7 @@ export const wrapWorkspace = ({ breadcrumbs, activeTab, title, topBarContent, sh
   const Wrapper = props => {
     const { namespace, name } = props
     const child = useRef()
-    const signal = useCancellation()
+    const signal = Utils.useCancellation()
     const [accessError, setAccessError] = useState(false)
     const accessNotificationId = useRef()
     const cachedWorkspace = Utils.useAtom(workspaceStore)

--- a/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
+++ b/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
@@ -10,7 +10,7 @@ import { collapseStatus, failedIcon, runningIcon, statusIcon, submittedIcon, suc
 import PopupTrigger from 'src/components/PopupTrigger'
 import { FlexTable, Sortable, TextCell, TooltipCell } from 'src/components/table'
 import TooltipTrigger from 'src/components/TooltipTrigger'
-import { Ajax, useCancellation } from 'src/libs/ajax'
+import { Ajax } from 'src/libs/ajax'
 import { bucketBrowserUrl } from 'src/libs/auth'
 import colors from 'src/libs/colors'
 import { getConfig } from 'src/libs/config'
@@ -39,7 +39,7 @@ const SubmissionDetails = _.flow(
   const [statusFilter, setStatusFilter] = useState([])
   const [textFilter, setTextFilter] = useState('')
   const [sort, setSort] = useState({ field: 'workflowEntity', direction: 'asc' })
-  const { Workspaces } = Ajax(useCancellation())
+  const { Workspaces } = Ajax(Utils.useCancellation())
 
   /*
    * Data fetchers

--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -13,7 +13,7 @@ import { findPotentialNotebookLockers, NotebookDuplicator, notebookLockHash } fr
 import { notify } from 'src/components/Notifications'
 import PopupTrigger from 'src/components/PopupTrigger'
 import { dataSyncingDocUrl } from 'src/data/clusters'
-import { Ajax, useCancellation } from 'src/libs/ajax'
+import { Ajax } from 'src/libs/ajax'
 import * as BrowserStorage from 'src/libs/browser-storage'
 import colors from 'src/libs/colors'
 import { withErrorReporting } from 'src/libs/error'
@@ -33,7 +33,7 @@ const StatusMessage = ({ hideSpinner, children }) => {
 
 const ClusterKicker = ({ cluster, refreshClusters, onNullCluster }) => {
   const getCluster = Utils.useGetter(cluster)
-  const signal = useCancellation()
+  const signal = Utils.useCancellation()
   const [busy, setBusy] = useState()
 
   const startClusterOnce = withErrorReporting('Error starting notebook runtime', async () => {
@@ -235,7 +235,7 @@ const PlaygroundHeader = () => {
 }
 
 const PreviewHeader = ({ queryParams, cluster, readOnlyAccess, onCreateCluster, refreshClusters, notebookName, workspace, workspace: { canShare, workspace: { namespace, name, bucketName } } }) => {
-  const signal = useCancellation()
+  const signal = Utils.useCancellation()
   const { user: { email } } = Utils.useAtom(authStore)
   const [fileInUseOpen, setFileInUseOpen] = useState(false)
   const [editModeDisabledOpen, setEditModeDisabledOpen] = useState(false)
@@ -380,7 +380,7 @@ const PreviewHeader = ({ queryParams, cluster, readOnlyAccess, onCreateCluster, 
 }
 
 const NotebookPreviewFrame = ({ notebookName, workspace: { workspace: { namespace, bucketName } }, onRequesterPaysError }) => {
-  const signal = useCancellation()
+  const signal = Utils.useCancellation()
   const [busy, setBusy] = useState(false)
   const [preview, setPreview] = useState()
   const frame = useRef()
@@ -512,7 +512,7 @@ const WelderDisabledNotebookEditorFrame = ({ mode, notebookName, workspace: { wo
   console.assert(status === 'Running', 'Expected notebook runtime to be running')
   console.assert(!!labels.welderInstallFailed, 'Expected cluster to not have Welder')
   const frameRef = useRef()
-  const signal = useCancellation()
+  const signal = Utils.useCancellation()
   const [busy, setBusy] = useState(false)
   const [localized, setLocalized] = useState(false)
 


### PR DESCRIPTION
Moving this hook into utils.js in preparation for adding a polling hook for the inactive timeout.

The inactive timeout hook will utilize useCancellation. If the polling hook is added to Utils this will create a circular dependency between the ajax an utils modules, this change will prevent that.

Tested by:
1. Clicking through pages on the site
2. Throttling the speed down to "Slow 3g" in the dev tools network tab and
  a. closing modals before ajax requests completed and observing the cancellation in the network tools
  b. Navigating away before an ajax request was completed and observing the cancellation in the network tools