### PR TITLE
More test parallelization on Circle [SATURN-1254]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,8 +162,8 @@ jobs:
             SCREENSHOT_DIR: "/tmp/failure-screenshots"
           command: |
             mkdir -p ${SCREENSHOT_DIR}
-            TERRA_TOKEN=$(node scripts/getBearerToken.js "${ALPHA_TEST_UA}" "${ALPHA_USER_SA_KEY_JSON}")
             TESTFILES=$(circleci tests glob "tests/*.js" | circleci tests split --split-by=timings)
+            TERRA_TOKEN=$(node scripts/getBearerToken.js "${ALPHA_TEST_UA}" "${ALPHA_USER_SA_KEY_JSON}") \
             npx npm@6.13 test $TESTFILES -- --ci --maxWorkers=2 --reporters=default --reporters=jest-junit
       - store_test_results:
           path: /tmp/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,6 +155,7 @@ jobs:
           background: true
       - run: timeout 120 bash -c "until nc -z localhost 3000; do sleep 3; done"
       - run:
+          name: Run integration tests
           working_directory: integration-tests
           environment:
             JEST_JUNIT_OUTPUT_DIR: "/tmp/test-results/integration-test-results.xml"
@@ -163,7 +164,7 @@ jobs:
             mkdir -p ${SCREENSHOT_DIR}
             TERRA_TOKEN=$(node scripts/getBearerToken.js "${ALPHA_TEST_UA}" "${ALPHA_USER_SA_KEY_JSON}")
             TESTFILES=$(circleci tests glob "integration-tests/tests/*" | circleci tests split --split-by=timings)
-            npx npm@6.13 test -- --ci --maxWorkers=2 --reporters=default --reporters=jest-junit $TESTFILES
+            npx npm@6.13 test $TESTFILES -- --ci --maxWorkers=2 --reporters=default --reporters=jest-junit
       - store_test_results:
           path: /tmp/test-results
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,7 +163,7 @@ jobs:
           command: |
             mkdir -p ${SCREENSHOT_DIR}
             TERRA_TOKEN=$(node scripts/getBearerToken.js "${ALPHA_TEST_UA}" "${ALPHA_USER_SA_KEY_JSON}")
-            TESTFILES=$(circleci tests glob "integration-tests/tests/*" | circleci tests split --split-by=timings)
+            TESTFILES=$(circleci tests split tests/ --split-by=timings)
             npx npm@6.13 test $TESTFILES -- --ci --maxWorkers=2 --reporters=default --reporters=jest-junit
       - store_test_results:
           path: /tmp/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,7 +163,7 @@ jobs:
           command: |
             mkdir -p ${SCREENSHOT_DIR}
             TERRA_TOKEN=$(node scripts/getBearerToken.js "${ALPHA_TEST_UA}" "${ALPHA_USER_SA_KEY_JSON}")
-            TESTFILES=$(circleci tests split tests/ --split-by=timings)
+            TESTFILES=$(circleci tests split --split-by=timings < tests/)
             npx npm@6.13 test $TESTFILES -- --ci --maxWorkers=2 --reporters=default --reporters=jest-junit
       - store_test_results:
           path: /tmp/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,7 +163,7 @@ jobs:
           command: |
             mkdir -p ${SCREENSHOT_DIR}
             TERRA_TOKEN=$(node scripts/getBearerToken.js "${ALPHA_TEST_UA}" "${ALPHA_USER_SA_KEY_JSON}")
-            TESTFILES=$(circleci tests split --split-by=timings < tests/)
+            TESTFILES=$(circleci tests glob "tests/*.js" | circleci tests split --split-by=timings)
             npx npm@6.13 test $TESTFILES -- --ci --maxWorkers=2 --reporters=default --reporters=jest-junit
       - store_test_results:
           path: /tmp/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,6 +132,7 @@ jobs:
             )
   integration-tests:
     executor: puppeteer
+    parallelism: 2
     steps:
       - checkout
       - attach_workspace:
@@ -160,8 +161,9 @@ jobs:
             SCREENSHOT_DIR: "/tmp/failure-screenshots"
           command: |
             mkdir -p ${SCREENSHOT_DIR}
-            TERRA_TOKEN=$(node scripts/getBearerToken.js "${ALPHA_TEST_UA}" "${ALPHA_USER_SA_KEY_JSON}") \
-            npx npm@6.13 test -- --ci --maxWorkers=2 --reporters=default --reporters=jest-junit
+            TERRA_TOKEN=$(node scripts/getBearerToken.js "${ALPHA_TEST_UA}" "${ALPHA_USER_SA_KEY_JSON}")
+            TESTFILES=$(circleci tests glob "integration-tests/tests/*" | circleci tests split --split-by=timings)
+            npx npm@6.13 test -- --ci --maxWorkers=2 --reporters=default --reporters=jest-junit $TESTFILES
       - store_test_results:
           path: /tmp/test-results
       - store_artifacts:


### PR DESCRIPTION
This allows circle to split the integration tests up between different instances. With this config, we have 2 instances, each of which can run 2 tests in parallel. Circle decides how to split things based on historic data on test duration.

See [here](https://circleci.com/docs/2.0/parallelism-faster-jobs/#splitting-by-timing-data) and [here](https://dev.to/drazisil/test-splitting-with-jest-on-circleci-1i0c) to learn more.