### PR TITLE
Add rename workflow option to 'Find a Workflow' import modal [SATURN-1253]

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -906,13 +906,13 @@ const Methods = signal => ({
         return res.json()
       },
 
-      toWorkspace: async (workspace, config = {}) => {
+      toWorkspace: async (workspace, config = {}, workflowRename) => {
         const res = await fetchRawls(`workspaces/${workspace.namespace}/${workspace.name}/methodconfigs`,
           _.mergeAll([authOpts(), jsonBody(_.merge({
             methodRepoMethod: {
               methodUri: `agora://${namespace}/${name}/${snapshotId}`
             },
-            name,
+            name: workflowRename ? workflowRename : name,
             namespace,
             rootEntityType: '',
             prerequisites: {},

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -911,7 +911,7 @@ const Methods = signal => ({
             methodRepoMethod: {
               methodUri: `agora://${namespace}/${name}/${snapshotId}`
             },
-            name: workflowRename ? workflowRename : name,
+            name: workflowRename || name,
             namespace,
             rootEntityType: '',
             prerequisites: {},

--- a/src/libs/workflow-utils.js
+++ b/src/libs/workflow-utils.js
@@ -1,0 +1,15 @@
+import validate from 'validate.js'
+
+
+export const validateWorkflowName = (workflowName, selectedWorkspace) => {
+  return validate({ workflowName, selectedWorkspace }, {
+    selectedWorkspace: { presence: true },
+    workflowName: {
+      presence: { allowEmpty: false },
+      format: {
+        pattern: /^[A-Za-z0-9_\-.]*$/,
+        message: 'can only contain letters, numbers, underscores, dashes, and periods'
+      }
+    }
+  })
+}

--- a/src/pages/workspaces/workspace/Workflows.js
+++ b/src/pages/workspaces/workspace/Workflows.js
@@ -218,7 +218,7 @@ const FindWorkflowModal = ajaxCaller(class FindWorkflowModal extends Component {
                 style: { marginRight: '0.5rem' },
                 onClick: () => this.setState({ isEditingName: !isEditingName }),
                 'aria-label': 'Edit workflow name'
-              }, [icon('check', {style: {margin: 8}})])
+              }, [icon('check', { style: { margin: 8 } })])
             ])])]),
           div({ style: styles.sectionTitle }, ['Synopsis']),
           div([synopsis || (selectedWorkflowDetails && 'None')]),

--- a/src/pages/workspaces/workspace/Workflows.js
+++ b/src/pages/workspaces/workspace/Workflows.js
@@ -175,7 +175,7 @@ const FindWorkflowModal = ajaxCaller(class FindWorkflowModal extends Component {
       isEditingName: false,
       config: undefined,
       methodAjax: undefined,
-      prevWorkflowRename: undefined
+      editedWorkflowName: undefined
     }
   }
 
@@ -192,7 +192,7 @@ const FindWorkflowModal = ajaxCaller(class FindWorkflowModal extends Component {
 
   render() {
     const { onDismiss } = this.props
-    const { selectedWorkflow, featuredList, methods, selectedWorkflowDetails, exporting, workflowRename, isEditingName, prevWorkflowRename } = this.state
+    const { selectedWorkflow, featuredList, methods, selectedWorkflowDetails, exporting, workflowRename, isEditingName, editedWorkflowName } = this.state
 
     const featuredMethods = _.compact(_.map(
       ({ namespace, name }) => _.maxBy('snapshotId', _.filter({ namespace, name }, methods)),
@@ -201,7 +201,7 @@ const FindWorkflowModal = ajaxCaller(class FindWorkflowModal extends Component {
 
     const { synopsis, managers, documentation } = selectedWorkflowDetails || {}
 
-    const errors = validateWorkflowName(workflowRename, this.props.name)
+    const errors = validateWorkflowName(editedWorkflowName, this.props.name)
 
     const renderDetails = () => [
       div({ style: { display: 'flex' } }, [
@@ -221,8 +221,8 @@ const FindWorkflowModal = ajaxCaller(class FindWorkflowModal extends Component {
                   error: Utils.summarizeErrors(errors),
                   inputProps: {
                     id,
-                    value: prevWorkflowRename,
-                    onChange: prevWorkflowRename => { this.setState({ prevWorkflowRename }) }
+                    value: editedWorkflowName,
+                    onChange: editedWorkflowName => { this.setState({ editedWorkflowName }) }
                   }
                 })
               ])]),
@@ -230,10 +230,10 @@ const FindWorkflowModal = ajaxCaller(class FindWorkflowModal extends Component {
                 h(ButtonPrimary, {
                   style: { marginRight: '0.5rem' },
                   disabled: !!errors,
-                  onClick: () => this.setState({ isEditingName: !isEditingName, workflowRename: prevWorkflowRename })
+                  onClick: () => this.setState({ isEditingName: !isEditingName, workflowRename: editedWorkflowName })
                 }, ['save']),
                 h(ButtonSecondary, {
-                  onClick: () => this.setState({ isEditingName: !isEditingName, prevWorkflowRename: workflowRename })
+                  onClick: () => this.setState({ isEditingName: !isEditingName, editedWorkflowName: workflowRename })
                 }, ['cancel'])
               ])
             ]),
@@ -299,7 +299,7 @@ const FindWorkflowModal = ajaxCaller(class FindWorkflowModal extends Component {
 
       this.setState({ selectedWorkflowDetails, methodAjax })
 
-      config ? this.setState({ workflowRename: config.name, prevWorkflowRename: config.name, config }) : this.setState({ workflowRename: selectedWorkflow.name, prevWorkflowRename: selectedWorkflow.name })
+      config ? this.setState({ workflowRename: config.name, editedWorkflowName: config.name, config }) : this.setState({ workflowRename: selectedWorkflow.name, editedWorkflowName: selectedWorkflow.name })
     } catch (error) {
       reportError('Error loading workflow', error)
       this.setState({ selectedWorkflow: undefined })

--- a/src/pages/workspaces/workspace/Workflows.js
+++ b/src/pages/workspaces/workspace/Workflows.js
@@ -212,7 +212,7 @@ const FindWorkflowModal = ajaxCaller(class FindWorkflowModal extends Component {
       div({ style: { display: 'flex' } }, [
         div({ style: { flexGrow: 1, marginTop: '1rem' } }, [
           !isEditingName ?
-            h(Fragment, [span({ style: styles.sectionTitle }, ['Workflow Name: ']), `${workflowRename}`,
+            div([span({ style: styles.sectionTitle }, ['Workflow Name: ']), `${workflowRename}`,
               h(Link, {
                 style: { marginRight: '0.5rem' },
                 onClick: () => this.setState({ isEditingName: !isEditingName }),

--- a/src/pages/workspaces/workspace/Workflows.js
+++ b/src/pages/workspaces/workspace/Workflows.js
@@ -218,7 +218,7 @@ const FindWorkflowModal = ajaxCaller(class FindWorkflowModal extends Component {
                 style: { marginRight: '0.5rem' },
                 onClick: () => this.setState({ isEditingName: !isEditingName }),
                 'aria-label': 'Edit workflow name'
-              }, [icon('check')])
+              }, [icon('check', {style: {margin: 8}})])
             ])])]),
           div({ style: styles.sectionTitle }, ['Synopsis']),
           div([synopsis || (selectedWorkflowDetails && 'None')]),

--- a/src/pages/workspaces/workspace/workflows/ExportWorkflowModal.js
+++ b/src/pages/workspaces/workspace/workflows/ExportWorkflowModal.js
@@ -10,7 +10,7 @@ import { Ajax } from 'src/libs/ajax'
 import { FormLabel } from 'src/libs/forms'
 import * as Nav from 'src/libs/nav'
 import * as Utils from 'src/libs/utils'
-import validate from 'validate.js'
+import { validateWorkflowName } from 'src/libs/workflow-utils'
 
 
 const ExportWorkflowModal = withWorkspaces(class ExportWorkflowModal extends Component {
@@ -41,16 +41,7 @@ const ExportWorkflowModal = withWorkspaces(class ExportWorkflowModal extends Com
     const { workspaces, thisWorkspace, sameWorkspace, onDismiss } = this.props
     const { selectedWorkspaceId, workflowName, exporting, error } = this.state
 
-    const errors = validate({ selectedWorkspaceId, workflowName }, {
-      selectedWorkspaceId: { presence: true },
-      workflowName: {
-        presence: { allowEmpty: false },
-        format: {
-          pattern: /^[A-Za-z0-9_\-.]*$/,
-          message: 'can only contain letters, numbers, underscores, dashes, and periods'
-        }
-      }
-    })
+    const errors = validateWorkflowName(workflowName, selectedWorkspaceId)
 
     return h(Modal, {
       title: sameWorkspace ? 'Duplicate Workflow' : 'Copy to Workspace',


### PR DESCRIPTION
Add ability for users to rename a workflow before importing into a workspace from the 'Find a Workflow' modal accessible from the Workflows page view. (There is another place users can import workflows which will be addressed in another PR)

Tested by importing 10 different workflows into a workspace at least twice, once with default name and again with new name (including: switching order, using a name already in workspace, really long names, etc).

W̶h̶e̶n̶ ̶t̶e̶s̶t̶i̶n̶g̶ ̶p̶l̶e̶a̶s̶e̶ ̶n̶o̶t̶e̶ ̶t̶h̶a̶t̶ ̶t̶h̶e̶ ̶h̶a̶p̶l̶o̶t̶y̶p̶e̶c̶a̶l̶l̶e̶r̶-̶g̶v̶c̶f̶-̶g̶a̶t̶k̶4̶ ̶w̶o̶r̶k̶f̶l̶o̶w̶ ̶a̶l̶r̶e̶a̶d̶y̶ ̶h̶a̶d̶ ̶a̶ ̶s̶l̶i̶g̶h̶t̶l̶y̶ ̶d̶i̶f̶f̶e̶r̶e̶n̶t̶ ̶b̶e̶h̶a̶v̶i̶o̶r̶ ̶w̶h̶e̶n̶ ̶i̶m̶p̶o̶r̶t̶i̶n̶g̶ ̶(̶d̶e̶f̶a̶u̶l̶t̶ ̶i̶m̶p̶o̶r̶t̶ ̶n̶a̶m̶e̶ ̶g̶e̶t̶s̶ ̶'̶-̶c̶o̶n̶f̶i̶g̶u̶r̶e̶d̶'̶ ̶a̶d̶d̶e̶d̶ ̶t̶o̶ ̶e̶n̶d̶)̶.̶