### PR TITLE
Fix null bug in notebook terminal [SATURN-1215]

### DIFF
--- a/src/pages/workspaces/workspace/notebooks/TerminalLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/TerminalLauncher.js
@@ -65,7 +65,7 @@ const TerminalLauncher = _.flow(
 
   async componentDidUpdate() {
     const { cluster } = this.props || {}
-    const { clusterUrl } = cluster || {}
+    const { clusterUrl } = cluster
     const { url } = this.state
 
     if (clusterUrl && !url) {

--- a/src/pages/workspaces/workspace/notebooks/TerminalLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/TerminalLauncher.js
@@ -64,7 +64,8 @@ const TerminalLauncher = _.flow(
   }
 
   async componentDidUpdate() {
-    const { cluster: { clusterUrl } = {} } = this.props
+    const { cluster } = this.props || {}
+    const { clusterUrl } = cluster || {}
     const { url } = this.state
 
     if (clusterUrl && !url) {
@@ -99,6 +100,8 @@ const TerminalLauncher = _.flow(
         },
         title: 'Interactive terminal iframe'
       })
+    } else if (clusterStatus === null) {
+      return div({ style: { padding: '2rem' } }, ['No existing notebook runtime environment, you can create a new one to edit your notebook or use the terminal.'])
     } else {
       return div({ style: { padding: '2rem' } }, [
         'Creating Stopping Starting Updating Deleting'.includes(clusterStatus) &&


### PR DESCRIPTION
Previously if you had a notebook runtime environment running and were in the terminal view then clicked the trashcan and deleted the runtime environment you would get an error "Unhandled Rejection (Type Error): Cannot read property 'clusterurl' of null. 

Changed the way the cluster object is de-structured in the terminalLauncher.js (found this guide helpful: https://medium.com/@crunchtech/object-destructuring-best-practice-in-javascript-9c8794699a0d). 

Also added a message status for a null cluster. "Deleting" and "Deleted" appear to be possible cluster statuses in Leo (so I did not remove the logic around these status messages in case they come through) however once a cluster is deleted on our end it seems to just be a null, so needed a case to show the correct message for that.

Testing:
Tested deleting a cluster that was in a running, stopping, and starting state while in the terminal view. Reproduced the error without these changes, then made these changes and did not see the error following the same steps.
