### PR TITLE
Enable Important Prefix [SATURN-1280]

### DIFF
--- a/src/libs/browser-storage.js
+++ b/src/libs/browser-storage.js
@@ -3,13 +3,13 @@ import { getUser } from 'src/libs/auth'
 import { maybeParseJSON } from 'src/libs/utils'
 
 
-export const getDynamic = (storage, key, { important = false } = {}) => {
+export const getDynamic = (storage, key, { important } = {}) => {
   const storageKey = maybeImportantKey(important, `dynamic-storage/${key}`)
   const data = maybeParseJSON(storage.getItem(storageKey))
   return data && data.value
 }
 
-export const setDynamic = (storage, key, value, { important = false } = {}) => {
+export const setDynamic = (storage, key, value, { important } = {}) => {
   const storageKey = maybeImportantKey(important, `dynamic-storage/${key}`)
   const storageValue = JSON.stringify({ timestamp: Date.now(), value })
   while (true) {
@@ -31,8 +31,8 @@ export const setDynamic = (storage, key, value, { important = false } = {}) => {
   }
 }
 
-export const removeDynamic = (storage, key) => {
-  const storageKey = `dynamic-storage/${key}`
+export const removeDynamic = (storage, key, { important }) => {
+  const storageKey = maybeImportantKey(important, `dynamic-storage/${key}`)
   storage.removeItem(storageKey)
 }
 

--- a/src/libs/browser-storage.js
+++ b/src/libs/browser-storage.js
@@ -5,13 +5,13 @@ import { maybeParseJSON } from 'src/libs/utils'
 
 export const getDynamic = (storage, key) => {
   const storageKey = `dynamic-storage/${key}`
-  const data = maybeParseJSON(storage.getItem(`!${storageKey}`)) || maybeParseJSON(storage.getItem(storageKey))
+  const data = maybeParseJSON(storage.getItem(`important-${storageKey}`) || storage.getItem(storageKey))
   return data && data.value
 }
 
 export const setDynamic = (storage, key, value, options = {}) => {
   const { important = true } = options
-  const storageKey = important ? `!dynamic-storage/${key}` : `dynamic-storage/${key}`
+  const storageKey = important ? `important-dynamic-storage/${key}` : `dynamic-storage/${key}`
   const storageValue = JSON.stringify({ timestamp: Date.now(), value })
   while (true) {
     try {

--- a/src/libs/browser-storage.js
+++ b/src/libs/browser-storage.js
@@ -4,13 +4,13 @@ import { maybeParseJSON } from 'src/libs/utils'
 
 
 export const getDynamic = (storage, key, { important = false } = {}) => {
-  const storageKey = important ? `important-dynamic-storage/${key}` : `dynamic-storage/${key}`
+  const storageKey = maybeImportantKey(important, `dynamic-storage/${key}`)
   const data = maybeParseJSON(storage.getItem(storageKey))
   return data && data.value
 }
 
 export const setDynamic = (storage, key, value, { important = false } = {}) => {
-  const storageKey = important ? `important-dynamic-storage/${key}` : `dynamic-storage/${key}`
+  const storageKey = maybeImportantKey(important, `dynamic-storage/${key}`)
   const storageValue = JSON.stringify({ timestamp: Date.now(), value })
   while (true) {
     try {
@@ -37,6 +37,7 @@ export const removeDynamic = (storage, key) => {
 }
 
 const withUserPrefix = key => `${getUser().id}/${key}`
+const maybeImportantKey = (important, key) => important ? `important/${key}` : key
 
 export const getLocalPref = key => getDynamic(localStorage, withUserPrefix(key))
 export const setLocalPref = (key, value) => setDynamic(localStorage, withUserPrefix(key), value)

--- a/src/libs/browser-storage.js
+++ b/src/libs/browser-storage.js
@@ -3,14 +3,13 @@ import { getUser } from 'src/libs/auth'
 import { maybeParseJSON } from 'src/libs/utils'
 
 
-export const getDynamic = (storage, key) => {
-  const storageKey = `dynamic-storage/${key}`
-  const data = maybeParseJSON(storage.getItem(`important-${storageKey}`) || storage.getItem(storageKey))
+export const getDynamic = (storage, key, { important = false } = {}) => {
+  const storageKey = important ? `important-dynamic-storage/${key}` : `dynamic-storage/${key}`
+  const data = maybeParseJSON(storage.getItem(storageKey))
   return data && data.value
 }
 
-export const setDynamic = (storage, key, value, options = {}) => {
-  const { important = true } = options
+export const setDynamic = (storage, key, value, { important = false } = {}) => {
   const storageKey = important ? `important-dynamic-storage/${key}` : `dynamic-storage/${key}`
   const storageValue = JSON.stringify({ timestamp: Date.now(), value })
   while (true) {

--- a/src/libs/browser-storage.js
+++ b/src/libs/browser-storage.js
@@ -5,12 +5,13 @@ import { maybeParseJSON } from 'src/libs/utils'
 
 export const getDynamic = (storage, key) => {
   const storageKey = `dynamic-storage/${key}`
-  const data = maybeParseJSON(storage.getItem(storageKey))
+  const data = maybeParseJSON(storage.getItem(`!${storageKey}`)) || maybeParseJSON(storage.getItem(storageKey))
   return data && data.value
 }
 
-export const setDynamic = (storage, key, value) => {
-  const storageKey = `dynamic-storage/${key}`
+export const setDynamic = (storage, key, value, options = {}) => {
+  const { important = true } = options
+  const storageKey = important ? `!dynamic-storage/${key}` : `dynamic-storage/${key}`
   const storageValue = JSON.stringify({ timestamp: Date.now(), value })
   while (true) {
     try {


### PR DESCRIPTION
Allow the addition of "important" items in our dynamic local storage mechanism. Important items will not be deleted when running out of space.

This change will be utilized by upcoming 15 minute signout changes.

I tested the existing behavior by manipulating the table columns with the important flag turned on and off.