### PR TITLE
Widen workflow ID column on Job History screen [no JIRA]

### DIFF
--- a/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
+++ b/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
@@ -249,7 +249,7 @@ const SubmissionDetails = _.flow(
                 return h(TooltipCell, [h(Fragment, _.map(div, filteredWorkflows[rowIndex].messages))])
               }
             }, {
-              size: { basis: 150, grow: 0 },
+              size: { basis: 375, grow: 0 },
               headerRenderer: () => h(Sortable, { sort, field: 'workflowId', onSort: setSort }, ['Workflow ID']),
               cellRenderer: ({ rowIndex }) => {
                 const { workflowId, inputResolutions: [{ inputName } = {}] } = filteredWorkflows[rowIndex]


### PR DESCRIPTION
I was working with a user who needed to copy the workflow IDs for 30 workflows.

Because the workflow ID is truncated (see below) the best way she could find to accomplish this task was to open 30 browser tabs and copy the ID from the address bar.

(A suggested workaround of right clicking the workflow ID and selecting "copy" did not work; she only had the "copy link address" option.)

Before:

<img width="1328" alt="Screen Shot 2019-12-06 at 2 47 02 PM (1)" src="https://user-images.githubusercontent.com/1087943/70354124-de9a9b00-183c-11ea-8918-f1d4e7627ac0.png">

After:

<img width="1438" alt="Screen Shot 2019-12-06 at 3 53 46 PM" src="https://user-images.githubusercontent.com/1087943/70355633-a432fd00-1840-11ea-9010-7685146fa04b.png">

---

Testing done: ran my branch locally to take the "after" screenshot.