### PR TITLE
refactor browser storage to allow component connection [SATURN-1286]

### DIFF
--- a/src/components/CardsListToggle.js
+++ b/src/components/CardsListToggle.js
@@ -35,8 +35,6 @@ export const ViewToggleButtons = ({ listView, setListView }) => {
   ])
 }
 
-Utils.syncAtomToSessionStorage(toggleStateAtom, 'toggleState')
-
 export const useViewToggle = key => {
   const toggleState = Utils.useAtom(toggleStateAtom)
   return [toggleState[key], v => toggleStateAtom.update(_.set(key, v))]

--- a/src/components/DataTable.js
+++ b/src/components/DataTable.js
@@ -9,10 +9,10 @@ import Modal from 'src/components/Modal'
 import PopupTrigger from 'src/components/PopupTrigger'
 import { ColumnSelector, GridTable, HeaderCell, paginator, Resizable, Sortable } from 'src/components/table'
 import { ajaxCaller } from 'src/libs/ajax'
-import * as BrowserStorage from 'src/libs/browser-storage'
 import colors from 'src/libs/colors'
 import { EditDataLink, EntityEditor, EntityRenamer, renderDataCell } from 'src/libs/data-utils'
 import { reportError } from 'src/libs/error'
+import { getLocalPref, setLocalPref } from 'src/libs/prefs'
 import * as StateHistory from 'src/libs/state-history'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
@@ -61,7 +61,7 @@ export default ajaxCaller(class DataTable extends Component {
       sort = { field: 'name', direction: 'asc' },
       activeTextFilter = '',
       columnWidths = {}, columnState = columnDefaultState
-    } = { ...BrowserStorage.getLocalPref(makePersistenceId(props)), ...(props.firstRender ? StateHistory.get() : {}) }
+    } = { ...getLocalPref(makePersistenceId(props)), ...(props.firstRender ? StateHistory.get() : {}) }
 
     this.table = createRef()
     this.state = {
@@ -285,7 +285,7 @@ export default ajaxCaller(class DataTable extends Component {
     }
     if (this.props.persist) {
       StateHistory.update(_.pick(['itemsPerPage', 'pageNumber', 'sort', 'activeTextFilter'], this.state))
-      BrowserStorage.setLocalPref(makePersistenceId(this.props), _.pick(['columnWidths', 'columnState'], this.state))
+      setLocalPref(makePersistenceId(this.props), _.pick(['columnWidths', 'columnState'], this.state))
     }
   }
 

--- a/src/libs/browser-storage.js
+++ b/src/libs/browser-storage.js
@@ -1,20 +1,17 @@
 import _ from 'lodash/fp'
-import { getUser } from 'src/libs/auth'
-import { maybeParseJSON } from 'src/libs/utils'
+import { maybeParseJSON, subscribable } from 'src/libs/utils'
 
 
-export const getDynamic = (storage, key) => {
-  const storageKey = `dynamic-storage/${key}`
-  const data = maybeParseJSON(storage.getItem(storageKey))
-  return data && data.value
-}
+/*
+ * This library provides a higher level interface on top of localStorage and sessionStorage.
+ * Values must be JSON-serializable. The 'dynamic' version is preferred if possible, but dynamic
+ * values might be deleted in case of space overflow. For critical data, use the 'static' version.
+ */
 
-export const setDynamic = (storage, key, value) => {
-  const storageKey = `dynamic-storage/${key}`
-  const storageValue = JSON.stringify({ timestamp: Date.now(), value })
+const forceSetItem = (storage, key, value) => {
   while (true) {
     try {
-      storage.setItem(storageKey, storageValue)
+      storage.setItem(key, value)
       return
     } catch (error) {
       const candidates = _.filter(([k]) => _.startsWith('dynamic-storage/', k), _.toPairs(storage))
@@ -31,12 +28,74 @@ export const setDynamic = (storage, key, value) => {
   }
 }
 
-export const removeDynamic = (storage, key) => {
-  const storageKey = `dynamic-storage/${key}`
-  storage.removeItem(storageKey)
+export const getStatic = (storage, key) => {
+  return maybeParseJSON(storage.getItem(key))
 }
 
-const withUserPrefix = key => `${getUser().id}/${key}`
+export const setStatic = (storage, key, value) => {
+  if (value === undefined) {
+    storage.removeItem(key)
+  } else {
+    forceSetItem(storage, key, JSON.stringify(value))
+  }
+}
 
-export const getLocalPref = key => getDynamic(localStorage, withUserPrefix(key))
-export const setLocalPref = (key, value) => setDynamic(localStorage, withUserPrefix(key), value)
+export const listenStatic = (storage, key, fn) => {
+  window.addEventListener('storage', e => {
+    if (e.storageArea === storage && e.key === key) {
+      fn(maybeParseJSON(e.newValue))
+    }
+  })
+}
+
+export const getDynamic = (storage, key) => {
+  const storageKey = `dynamic-storage/${key}`
+  const data = maybeParseJSON(storage.getItem(storageKey))
+  return data && data.value
+}
+
+export const setDynamic = (storage, key, value) => {
+  const storageKey = `dynamic-storage/${key}`
+  if (value === undefined) {
+    storage.removeItem(storageKey)
+  } else {
+    forceSetItem(storage, storageKey, JSON.stringify({ timestamp: Date.now(), value }))
+  }
+}
+
+export const listenDynamic = (storage, key, fn) => {
+  const storageKey = `dynamic-storage/${key}`
+  window.addEventListener('storage', e => {
+    if (e.storageArea === storage && e.key === storageKey) {
+      const data = maybeParseJSON(e.newValue)
+      fn(data && data.value)
+    }
+  })
+}
+
+/**
+ * Returns a stateful object that manages the given storage location.
+ * Implements an atom-compaible interface, and can be passed to useAtom.
+ */
+
+export const staticStorageSlot = (storage, key) => {
+  const { subscribe, next } = subscribable()
+  const get = () => getStatic(storage, key)
+  const set = newValue => {
+    setStatic(storage, key, newValue)
+    next(newValue)
+  }
+  listenStatic(storage, key, next)
+  return { subscribe, get, set, update: fn => set(fn(get())) }
+}
+
+export const dynamicStorageSlot = (storage, key) => {
+  const { subscribe, next } = subscribable()
+  const get = () => getDynamic(storage, key)
+  const set = newValue => {
+    setDynamic(storage, key, newValue)
+    next(newValue)
+  }
+  listenDynamic(storage, key, next)
+  return { subscribe, get, set, update: fn => set(fn(get())) }
+}

--- a/src/libs/browser-storage.js
+++ b/src/libs/browser-storage.js
@@ -88,14 +88,3 @@ export const staticStorageSlot = (storage, key) => {
   listenStatic(storage, key, next)
   return { subscribe, get, set, update: fn => set(fn(get())) }
 }
-
-export const dynamicStorageSlot = (storage, key) => {
-  const { subscribe, next } = subscribable()
-  const get = () => getDynamic(storage, key)
-  const set = newValue => {
-    setDynamic(storage, key, newValue)
-    next(newValue)
-  }
-  listenDynamic(storage, key, next)
-  return { subscribe, get, set, update: fn => set(fn(get())) }
-}

--- a/src/libs/config.js
+++ b/src/libs/config.js
@@ -1,10 +1,7 @@
 import _ from 'lodash/fp'
 import { loadedConfigStore } from 'src/configStore'
 import { configOverridesStore } from 'src/libs/state'
-import * as Utils from 'src/libs/utils'
 
-
-Utils.syncAtomToSessionStorage(configOverridesStore, 'config-overrides')
 
 export const getConfig = () => {
   console.assert(loadedConfigStore.current, 'Called getConfig before initialization')

--- a/src/libs/prefs.js
+++ b/src/libs/prefs.js
@@ -1,0 +1,8 @@
+import { getUser } from 'src/libs/auth'
+import { getDynamic, setDynamic } from 'src/libs/browser-storage'
+
+
+const withUserPrefix = key => `${getUser().id}/${key}`
+
+export const getLocalPref = key => getDynamic(localStorage, withUserPrefix(key))
+export const setLocalPref = (key, value) => setDynamic(localStorage, withUserPrefix(key), value)

--- a/src/libs/state-history.js
+++ b/src/libs/state-history.js
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp'
-import { getDynamic, removeDynamic, setDynamic } from 'src/libs/browser-storage'
+import { getDynamic, setDynamic } from 'src/libs/browser-storage'
 import uuid from 'uuid/v4'
 
 
@@ -26,4 +26,4 @@ export const set = newState => {
 
 export const update = newState => { set({ ...get(), ...newState }) }
 
-export const clearCurrent = () => removeDynamic(sessionStorage, getKey())
+export const clearCurrent = () => setDynamic(sessionStorage, getKey(), undefined)

--- a/src/libs/state.js
+++ b/src/libs/state.js
@@ -1,3 +1,4 @@
+import { staticStorageSlot } from 'src/libs/browser-storage'
 import * as Utils from 'src/libs/utils'
 
 
@@ -11,7 +12,8 @@ export const authStore = Utils.atom({
   profile: {}
 })
 
-export const toggleStateAtom = Utils.atom({ notebooksTab: true })
+export const toggleStateAtom = staticStorageSlot(sessionStorage, 'toggleState')
+toggleStateAtom.update(v => v || { notebooksTab: true })
 
 export const freeCreditsActive = Utils.atom(false)
 
@@ -52,5 +54,5 @@ window.ajaxOverridesStore = ajaxOverridesStore
  * Modifies config settings for testing purposes.
  * Can be set to an object which will be merged with the loaded config object.
  */
-export const configOverridesStore = Utils.atom()
+export const configOverridesStore = staticStorageSlot(sessionStorage, 'config-overrides')
 window.configOverridesStore = configOverridesStore

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -7,31 +7,37 @@ import { div, h } from 'react-hyperscript-helpers'
 import uuid from 'uuid/v4'
 
 
+export const subscribable = () => {
+  let subscribers = []
+  return {
+    subscribe: fn => {
+      subscribers = append(fn, subscribers)
+      return {
+        unsubscribe: () => {
+          subscribers = _.without([fn], subscribers)
+        }
+      }
+    },
+    next: (...args) => {
+      _.forEach(fn => fn(...args), subscribers)
+    }
+  }
+}
+
 /**
  * A simple state container inspired by clojure atoms. Method names were chosen based on similarity
  * to lodash and Immutable. (deref => get, reset! => set, swap! => update, reset to go back to initial value)
  */
 export const atom = initialValue => {
   let value = initialValue
-  let subscribers = []
+  const { subscribe, next } = subscribable()
+  const get = () => value
   const set = newValue => {
     const oldValue = value
     value = newValue
-    subscribers.forEach(fn => fn(newValue, oldValue))
+    next(newValue, oldValue)
   }
-  return {
-    subscribe: fn => {
-      subscribers = _.union(subscribers, [fn])
-    },
-    unsubscribe: fn => {
-      console.assert(_.includes(fn, subscribers), 'Function is not subscribed')
-      subscribers = _.difference(subscribers, [fn])
-    },
-    get: () => value,
-    set,
-    update: fn => set(fn(value)),
-    reset: () => set(initialValue)
-  }
+  return { subscribe, get, set, update: fn => set(fn(get())), reset: () => set(initialValue) }
 }
 
 /**
@@ -40,9 +46,7 @@ export const atom = initialValue => {
 export const useAtom = theAtom => {
   const [value, setValue] = useState(theAtom.get())
   useEffect(() => {
-    const handleChange = v => setValue(v)
-    theAtom.subscribe(handleChange)
-    return () => theAtom.unsubscribe(handleChange)
+    return theAtom.subscribe(v => setValue(v)).unsubscribe
   }, [theAtom, setValue])
   return value
 }
@@ -69,29 +73,6 @@ export const connectAtom = (theAtom, name) => WrappedComponent => {
     const value = useAtom(theAtom)
     return h(WrappedComponent, { ...props, [name]: value })
   })
-}
-
-/**
- * Sets up the given atom to sync to/from sessionStorage at the given key.
- * On initialization, if the key exists, the value will be read in.
- * If it doesn't, the current value of the atom will be written out.
- */
-export const syncAtomToSessionStorage = (theAtom, key) => {
-  theAtom.subscribe(v => {
-    if (v === undefined) {
-      sessionStorage.removeItem(key)
-    } else {
-      sessionStorage[key] = JSON.stringify(v)
-    }
-  })
-  const existing = (() => {
-    try {
-      return JSON.parse(sessionStorage[key])
-    } catch (e) {
-      return undefined
-    }
-  })()
-  theAtom.update(v => existing === undefined ? v : existing)
 }
 
 const dateFormat = new Intl.DateTimeFormat('default', { day: 'numeric', month: 'short', year: 'numeric' })

--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -14,10 +14,10 @@ import { notify } from 'src/components/Notifications'
 import PopupTrigger from 'src/components/PopupTrigger'
 import { dataSyncingDocUrl } from 'src/data/clusters'
 import { Ajax } from 'src/libs/ajax'
-import * as BrowserStorage from 'src/libs/browser-storage'
 import colors from 'src/libs/colors'
 import { withErrorIgnoring, withErrorReporting } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
+import { getLocalPref, setLocalPref } from 'src/libs/prefs'
 import { authStore } from 'src/libs/state'
 import * as Utils from 'src/libs/utils'
 import ExportNotebookModal from 'src/pages/workspaces/workspace/notebooks/ExportNotebookModal'
@@ -202,7 +202,7 @@ const PlaygroundModal = ({ onDismiss, onPlayground }) => {
     onDismiss,
     okButton: h(ButtonPrimary, {
       onClick: () => {
-        BrowserStorage.setLocalPref('hidePlaygroundMessage', hidePlaygroundMessage)
+        setLocalPref('hidePlaygroundMessage', hidePlaygroundMessage)
         onPlayground()
       }
     },
@@ -289,7 +289,7 @@ const PreviewHeader = ({ queryParams, cluster, readOnlyAccess, onCreateCluster, 
             ),
             h(ButtonSecondary, {
               style: buttonStyle,
-              onClick: () => BrowserStorage.getLocalPref('hidePlaygroundMessage') ? chooseMode('playground') : setPlaygroundModalOpen(true)
+              onClick: () => getLocalPref('hidePlaygroundMessage') ? chooseMode('playground') : setPlaygroundModalOpen(true)
             }, [makeMenuIcon('chalkboard'), 'Playground mode']),
             h(PopupTrigger, {
               closeOnClick: true,


### PR DESCRIPTION
Evolves `syncAtomToSessionStorage` into a more general 'static' storage mechanism.

It can purge dynamic storage entries as needed to make space, but is not itself a candidate for automatic deletion. As such, it can serve as a more resilient storage area for 'important' data.

It also listens to the `storage` event, so will automatically sync across browser tabs in real-time.

It no longer maintains state in an atom, but instead provides an atom-compatible interface that can be used interchangably via `connectAtom`.

Tested existing usages by clicking through. Tested cross-tab communication with some temporary example code.