### PR TITLE
run nightly integration after alpha deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,7 +268,7 @@ workflows:
   nightly-integration-tests:
     triggers:
       - schedule:
-          cron: "0 0 * * *"
+          cron: "0 8 * * *"
           filters:
             branches:
               only: dev


### PR DESCRIPTION
Alpha deploy runs around 1:30 E(S/D)T, which is 5:30 or 6:30 UTC, depending on DST. Setting this to 8:00 GMT to make sure it happens well after, and is done before morning.