### PR TITLE
fix run workflow test

### DIFF
--- a/src/pages/workspaces/workspace/Workflows.js
+++ b/src/pages/workspaces/workspace/Workflows.js
@@ -292,6 +292,7 @@ export const Workflows = _.flow(
   constructor(props) {
     super(props)
     this.state = {
+      loading: true,
       sortOrder: defaultSort.value,
       filter: '',
       ...StateHistory.get()


### PR DESCRIPTION
<!--
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Thanks!
--!>
Hopefully, this will fix intermittent failures of integration tests by ensuring that the loading spinner is always there immediately when loading the workflows tab. The refresh method is called right after mount, and it turns the spinner on, so this really only applies for one tick, but we think this may have been causing occasional failures.