### PR TITLE
Add ability to have groups in Selector

### DIFF
--- a/src/components/common.js
+++ b/src/components/common.js
@@ -303,7 +303,6 @@ const commonSelectProps = {
  * @param {Object} props - see {@link https://react-select.com/props#select-props}
  * @param props.value - a member of options
  * @param {Array} props.options - can be of any type; if objects, they should each contain a value and label, unless defining getOptionLabel
- * @param {boolean} [props.withGroups=false] - see {@link https://react-select.com/advanced#replacing-builtins} for info on formatting the options array
  */
 export const BaseSelect = ({ value, newOptions, id, findValue, ...props }) => {
   const newValue = props.isMulti ? _.map(findValue, value) : findValue(value)

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -306,7 +306,7 @@ const commonSelectProps = {
  * @param props.withGroups - boolean; see {@link https://react-select.com/advanced#replacing-builtins} for info on formatting the options array
  */
 export const Select = ({ value, options, id, withGroups = false, ...props }) => {
-  const newOptions = withGroups ? _.flatten(_.map('options', options)) : options && !_.isObject(options[0]) ? _.map(value => ({ value }), options) : options
+  const newOptions = withGroups ? _.flatMap('options', options) : options && !_.isObject(options[0]) ? _.map(value => ({ value }), options) : options
   const findValue = target => _.find({ value: target }, newOptions)
   const newValue = props.isMulti ? _.map(findValue, value) : findValue(value)
 

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -303,9 +303,10 @@ const commonSelectProps = {
  * @param {Object} props - see {@link https://react-select.com/props#select-props}
  * @param props.value - a member of options
  * @param {Array} props.options - can be of any type; if objects, they should each contain a value and label, unless defining getOptionLabel
+ * @param props.withGroups - boolean; see {@link https://react-select.com/advanced#replacing-builtins} for info on formatting the options array
  */
-export const Select = ({ value, options, id, ...props }) => {
-  const newOptions = options && !_.isObject(options[0]) ? _.map(value => ({ value }), options) : options
+export const Select = ({ value, options, id, withGroups = false, ...props }) => {
+  const newOptions = withGroups ? _.flatten(_.map('options', options)) : options && !_.isObject(options[0]) ? _.map(value => ({ value }), options) : options
   const findValue = target => _.find({ value: target }, newOptions)
   const newValue = props.isMulti ? _.map(findValue, value) : findValue(value)
 
@@ -314,7 +315,7 @@ export const Select = ({ value, options, id, ...props }) => {
     ...commonSelectProps,
     getOptionLabel: ({ value, label }) => label || value.toString(),
     value: newValue || null, // need null instead of undefined to clear the select
-    options: newOptions
+    options: withGroups ? options : newOptions
   }, props))
 }
 

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -303,11 +303,12 @@ const commonSelectProps = {
  * @param {Object} props - see {@link https://react-select.com/props#select-props}
  * @param props.value - a member of options
  * @param {Array} props.options - can be of any type; if objects, they should each contain a value and label, unless defining getOptionLabel
- * @param props.withGroups - boolean; see {@link https://react-select.com/advanced#replacing-builtins} for info on formatting the options array
+ * @param {boolean} [props.withGroups=false] - see {@link https://react-select.com/advanced#replacing-builtins} for info on formatting the options array
  */
 export const Select = ({ value, options, id, withGroups = false, ...props }) => {
-  const newOptions = withGroups ? _.flatMap('options', options) : options && !_.isObject(options[0]) ? _.map(value => ({ value }), options) : options
-  const findValue = target => _.find({ value: target }, newOptions)
+  const newOptions = !withGroups && options && !_.isObject(options[0]) ? _.map(value => ({ value }), options) : options
+  const flattenedOptions = withGroups ? _.flatMap('options', newOptions) : undefined
+  const findValue = target => _.find({ value: target }, flattenedOptions || newOptions)
   const newValue = props.isMulti ? _.map(findValue, value) : findValue(value)
 
   return h(RSelect, _.merge({
@@ -315,7 +316,7 @@ export const Select = ({ value, options, id, withGroups = false, ...props }) => 
     ...commonSelectProps,
     getOptionLabel: ({ value, label }) => label || value.toString(),
     value: newValue || null, // need null instead of undefined to clear the select
-    options: withGroups ? options : newOptions
+    options: newOptions
   }, props))
 }
 

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -305,10 +305,7 @@ const commonSelectProps = {
  * @param {Array} props.options - can be of any type; if objects, they should each contain a value and label, unless defining getOptionLabel
  * @param {boolean} [props.withGroups=false] - see {@link https://react-select.com/advanced#replacing-builtins} for info on formatting the options array
  */
-export const Select = ({ value, options, id, withGroups = false, ...props }) => {
-  const newOptions = !withGroups && options && !_.isObject(options[0]) ? _.map(value => ({ value }), options) : options
-  const flattenedOptions = withGroups ? _.flatMap('options', newOptions) : undefined
-  const findValue = target => _.find({ value: target }, flattenedOptions || newOptions)
+export const BaseSelect = ({ value, newOptions, id, findValue, ...props }) => {
   const newValue = props.isMulti ? _.map(findValue, value) : findValue(value)
 
   return h(RSelect, _.merge({
@@ -318,6 +315,20 @@ export const Select = ({ value, options, id, withGroups = false, ...props }) => 
     value: newValue || null, // need null instead of undefined to clear the select
     options: newOptions
   }, props))
+}
+
+export const Select = ({ value, options, id, ...props }) => {
+  const newOptions = options && !_.isObject(options[0]) ? _.map(value => ({ value }), options) : options
+  const findValue = target => _.find({ value: target }, newOptions)
+
+  return h(BaseSelect, { value, newOptions, id, findValue, ...props })
+}
+
+export const GroupedSelect = ({ value, options, id, ...props }) => {
+  const flattenedOptions = _.flatMap('options', options)
+  const findValue = target => _.find({ value: target }, flattenedOptions)
+
+  return h(BaseSelect, { value, newOptions: options, id, findValue, ...props })
 }
 
 export const AsyncCreatableSelect = props => {

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -304,7 +304,7 @@ const commonSelectProps = {
  * @param props.value - a member of options
  * @param {Array} props.options - can be of any type; if objects, they should each contain a value and label, unless defining getOptionLabel
  */
-export const BaseSelect = ({ value, newOptions, id, findValue, ...props }) => {
+const BaseSelect = ({ value, newOptions, id, findValue, ...props }) => {
   const newValue = props.isMulti ? _.map(findValue, value) : findValue(value)
 
   return h(RSelect, _.merge({


### PR DESCRIPTION
Pulled out this small PR from the ticket: [SATURN-1261]

-> Add ability to have groups in selectors

Should not currently see any difference in existing selectors, tested with my upcoming changes to the Application Compute drawer and observed the groups there, and tested existing selectors on many pages and saw no change in functionality. 

Looking particularly for code style reviews please and thank you!


[SATURN-1261]: https://broadworkbench.atlassian.net/browse/SATURN-1261