### PR TITLE
Enable HCA link [SATURN-1269]

### DIFF
--- a/src/pages/library/Datasets.js
+++ b/src/pages/library/Datasets.js
@@ -296,7 +296,7 @@ const hca = () => h(Participant, {
   h(ButtonPrimary, {
     href: 'https://data.humancellatlas.org/explore/projects',
     ...Utils.newTabLinkProps,
-    tooltip: 'Look for the export selected data icon to export data from this provider.'
+    tooltip: 'Look for the Export Selected Data button to export data from this provider.'
   }, ['Browse Data'])
 ])
 

--- a/src/pages/library/Datasets.js
+++ b/src/pages/library/Datasets.js
@@ -294,9 +294,7 @@ const hca = () => h(Participant, {
   monitoring, and treating disease.`
 }, [
   h(ButtonPrimary, {
-    disabled: true,
-    tooltip: 'HCA not yet in production'
-    //when in production, add this tooltip: browseTooltip
+    tooltip: browseTooltip
   }, ['Browse Data'])
 ])
 

--- a/src/pages/library/Datasets.js
+++ b/src/pages/library/Datasets.js
@@ -294,7 +294,9 @@ const hca = () => h(Participant, {
   monitoring, and treating disease.`
 }, [
   h(ButtonPrimary, {
-    tooltip: browseTooltip
+    href: 'https://data.humancellatlas.org/explore/projects',
+    target: '_blank',
+    tooltip: 'Look for the export selected data icon to export data from this provider.'
   }, ['Browse Data'])
 ])
 

--- a/src/pages/library/Datasets.js
+++ b/src/pages/library/Datasets.js
@@ -295,7 +295,7 @@ const hca = () => h(Participant, {
 }, [
   h(ButtonPrimary, {
     href: 'https://data.humancellatlas.org/explore/projects',
-    target: '_blank',
+    ...Utils.newTabLinkProps,
     tooltip: 'Look for the export selected data icon to export data from this provider.'
   }, ['Browse Data'])
 ])


### PR DESCRIPTION
Tested by walking through the page to make sure:

- [x] The button was enabled
- [x] The button linked to https://data.humancellatlas.org/explore/projects
- [x] Clicking on the button opened a new active tab
- [x] On hover over the button the text was “Look for the export selected data icon to export data from this provider.“

However, I'm not sure how to do this part specified on the ticket:

- [x] This change should take place on all sites that this data is exposed to (ie. app.terra.bio, firecloud.terra.bio, anvil.terra.bio, etc.)]

The ticket is [here](https://broadworkbench.atlassian.net/browse/SATURN-1269).
