### PR TITLE
fix minor style issue on notebook cards

### DIFF
--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -176,7 +176,7 @@ const NotebookCard = ({ namespace, name, updated, metadata, listView, wsName, on
         alignItems: 'center',
         justifyContent: 'space-between',
         borderTop: `solid 1px ${colors.dark(0.4)}`,
-        padding: '0.5rem',
+        paddingLeft: '0.5rem', paddingRight: '0.5rem', height: '2.5rem',
         backgroundColor: colors.light(0.4),
         borderRadius: '0 0 5px 5px'
       }


### PR DESCRIPTION
The bottom box was extending too far and obscuring the shadow:
![image](https://user-images.githubusercontent.com/555632/71830511-e2585200-3074-11ea-8fcd-7d172d84a7a9.png)
This fixes it:
![image](https://user-images.githubusercontent.com/555632/71830539-edab7d80-3074-11ea-8078-34b7c27937cf.png)
