### PR TITLE
Wait for ws wf list page to load before waiting for spinners

### DIFF
--- a/integration-tests/tests/run-workflow.integration-test.js
+++ b/integration-tests/tests/run-workflow.integration-test.js
@@ -1,10 +1,11 @@
 const pRetry = require('p-retry')
 const { testUrl, workflowName, billingProject } = require('../utils/integration-config')
 const { withWorkspace, createEntityInWorkspace } = require('../utils/integration-helpers')
-const { click, clickable, input, signIntoTerra, waitForNoSpinners, findInGrid, navChild, findInDataTableRow } = require('../utils/integration-utils')
+const { click, clickable, findElement, input, signIntoTerra, waitForNoSpinners, findInGrid, navChild, findInDataTableRow } = require('../utils/integration-utils')
 
 
 const testEntity = { name: 'test_entity_1', entityType: 'test_entity', attributes: { input: 'foo' } }
+const findWorkflowButton = clickable({ textContains: 'Find a Workflow' })
 
 test('run workflow', withWorkspace(async ({ workspaceName }) => {
   await page.goto(testUrl)
@@ -16,8 +17,9 @@ test('run workflow', withWorkspace(async ({ workspaceName }) => {
   await click(page, clickable({ textContains: workspaceName }))
 
   await click(page, navChild('workflows'))
+  await findElement(page, findWorkflowButton)
   await waitForNoSpinners(page)
-  await click(page, clickable({ textContains: 'Find a Workflow' }))
+  await click(page, findWorkflowButton)
   await click(page, clickable({ textContains: workflowName }))
   await waitForNoSpinners(page)
   await click(page, clickable({ text: 'Add to Workspace' }))

--- a/integration-tests/tests/run-workflow.integration-test.js
+++ b/integration-tests/tests/run-workflow.integration-test.js
@@ -5,7 +5,7 @@ const { click, clickable, findElement, input, signIntoTerra, waitForNoSpinners, 
 
 
 const testEntity = { name: 'test_entity_1', entityType: 'test_entity', attributes: { input: 'foo' } }
-const workflowButton = clickable({ textContains: 'Find a Workflow' })
+const findWorkflowButton = clickable({ textContains: 'Find a Workflow' })
 
 test('run workflow', withWorkspace(async ({ workspaceName }) => {
   await page.goto(testUrl)
@@ -17,9 +17,9 @@ test('run workflow', withWorkspace(async ({ workspaceName }) => {
   await click(page, clickable({ textContains: workspaceName }))
 
   await click(page, navChild('workflows'))
-  await findElement(page, workflowButton)
+  await findElement(page, findWorkflowButton)
   await waitForNoSpinners(page)
-  await click(page, workflowButton)
+  await click(page, findWorkflowButton)
   await click(page, clickable({ textContains: workflowName }))
   await waitForNoSpinners(page)
   await click(page, clickable({ text: 'Add to Workspace' }))

--- a/integration-tests/tests/run-workflow.integration-test.js
+++ b/integration-tests/tests/run-workflow.integration-test.js
@@ -5,7 +5,7 @@ const { click, clickable, findElement, input, signIntoTerra, waitForNoSpinners, 
 
 
 const testEntity = { name: 'test_entity_1', entityType: 'test_entity', attributes: { input: 'foo' } }
-const findWorkflowButton = clickable({ textContains: 'Find a Workflow' })
+const workflowButton = clickable({ textContains: 'Find a Workflow' })
 
 test('run workflow', withWorkspace(async ({ workspaceName }) => {
   await page.goto(testUrl)
@@ -17,9 +17,9 @@ test('run workflow', withWorkspace(async ({ workspaceName }) => {
   await click(page, clickable({ textContains: workspaceName }))
 
   await click(page, navChild('workflows'))
-  await findElement(page, findWorkflowButton)
+  await findElement(page, workflowButton)
   await waitForNoSpinners(page)
-  await click(page, findWorkflowButton)
+  await click(page, workflowButton)
   await click(page, clickable({ textContains: workflowName }))
   await waitForNoSpinners(page)
   await click(page, clickable({ text: 'Add to Workspace' }))


### PR DESCRIPTION
Makes sure we're really on the workspace's list page, by checking that the find workflow button is there, before waiting for the spinner covering it to go away, to make sure that we're waiting for the _right_ spinner before trying to click the button.