### PR TITLE
fix filtering workspace by tags [SATURN-1348]

### DIFF
--- a/src/components/workspace-utils.js
+++ b/src/components/workspace-utils.js
@@ -19,7 +19,7 @@ export const useWorkspaces = () => {
     Utils.withBusyState(setLoading)
   )(async () => {
     const ws = await Ajax(signal).Workspaces.list([
-      'accessLevel', 'public', 'workspace', 'workspaceSubmissionStats', 'workspace.attributes.description'
+      'accessLevel', 'public', 'workspace', 'workspaceSubmissionStats', 'workspace.attributes.description', 'workspace.attributes.tag:tags'
     ])
     workspacesStore.set(ws)
   })

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -243,8 +243,6 @@ export const WorkspaceList = () => {
   const initialFiltered = _.filter(ws => includePublic || !ws.public || Utils.canWrite(ws.accessLevel), workspaces)
   const noWorkspaces = _.isEmpty(initialFiltered) && !loadingWorkspaces
 
-  const returnTags = _.getOr([], ['tag:tags', 'items'])
-
   const noWorkspacesMessage = div({ style: { fontSize: 20, margin: '1rem' } }, [
     div([
       'To get started, click ', span({ style: { fontWeight: 600 } }, ['Create a New Workspace'])
@@ -259,12 +257,12 @@ export const WorkspaceList = () => {
 
   const filteredWorkspaces = _.flow(
     _.filter(ws => {
-      const { workspace: { namespace, name } } = ws
+      const { workspace: { namespace, name, attributes } } = ws
       return Utils.textMatch(filter, `${namespace}/${name}`) &&
         (_.isEmpty(accessLevelsFilter) || accessLevelsFilter.includes(ws.accessLevel)) &&
         (_.isEmpty(projectsFilter) || projectsFilter === namespace) &&
         (_.isEmpty(submissionsFilter) || submissionsFilter.includes(workspaceSubmissionStatus(ws))) &&
-        (_.isEmpty(tagsFilter) || _.every(_.identity, _.map(a => returnTags(ws.workspace.attributes).includes(a), tagsFilter)))
+        _.every(a => _.includes(a, _.get(['tag:tags', 'items'], attributes)), tagsFilter)
     }),
     _.sortBy('workspace.name')
   )(initialFiltered)


### PR DESCRIPTION
This adds the `tag:tags` attribute to the list of workspace fields we request from the server, since it's needed for tag filtering.

Also simplifies the filtering code slightly.

Tested by using the filter locally.