### PR TITLE
Fix overflow of titles in modals [SATURN-1312]

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -57,7 +57,7 @@ const Modal = ({ onDismiss, title, titleExtras, children, width = 450, showCance
     ...props
   }, [
     title && div({ style: { display: 'flex', alignItems: 'baseline', marginBottom: '1rem', flex: 'none' } }, [
-      div({ id: titleId, style: { fontSize: 18, fontWeight: 600 } }, [title]),
+      div({ id: titleId, style: { fontSize: 18, fontWeight: 600, ...Style.noWrapEllipsis } }, [title]),
       titleExtras,
       showX && h(Clickable, {
         'aria-label': 'Close modal',


### PR DESCRIPTION
Stopped titles from overrunning edges of modals.

Observed this problem when editing in data table and copying a notebook. Tested in browser and no longer see these problems. Tested many other instances of modals to ensure they look fine still