### PR TITLE
[IA-1508] Clusters can now be updated in some circumstances

### DIFF
--- a/src/components/ClusterManager.js
+++ b/src/components/ClusterManager.js
@@ -140,7 +140,7 @@ export default class ClusterManager extends PureComponent {
   }
 
   componentDidUpdate(prevProps) {
-    const { namespace, name, refreshClusters } = this.props
+    const { namespace, name } = this.props
     const prevCluster = _.last(_.sortBy('createdDate', _.remove({ status: 'Deleting' }, prevProps.clusters))) || {}
     const cluster = this.getCurrentCluster() || {}
     const twoMonthsAgo = _.tap(d => d.setMonth(d.getMonth() - 2), new Date())

--- a/src/components/ClusterManager.js
+++ b/src/components/ClusterManager.js
@@ -182,7 +182,7 @@ export default class ClusterManager extends PureComponent {
         message: 'Your notebook runtime is over two months old. Please consider deleting and recreating your runtime in order to access the latest features and security updates.'
       })
     } else if (cluster.status === 'Running' && prevCluster.status === 'Updating') {
-      notify('success', 'Your runtime update has completed successfully.', { timeout: 3000 })
+      notify('success', 'Your runtime update has completed successfully.', { timeout: 5000 })
     }
   }
 

--- a/src/components/ClusterManager.js
+++ b/src/components/ClusterManager.js
@@ -292,8 +292,7 @@ export default class ClusterManager extends PureComponent {
     }
     const totalCost = _.sum(_.map(clusterCost, clusters))
     const activeClusters = this.getActiveClustersOldestFirst()
-    const creating = _.some({ status: 'Creating' }, activeClusters)
-    const updating = _.some({ status: 'Updating' }, activeClusters)
+    const { Creating: creating, Updating: updating } = _.countBy('status', activeClusters)
     const isDisabled = !canCompute || creating || busy || updating
 
     const isRStudioImage = currentCluster?.labels.tool === 'RStudio'

--- a/src/components/ClusterManager.js
+++ b/src/components/ClusterManager.js
@@ -184,7 +184,7 @@ export default class ClusterManager extends PureComponent {
     } else if (cluster.status === 'Running' && prevCluster.status === 'Updating') {
       notify('success', 'Your runtime update has completed successfully.', { timeout: 3000 })
     }
-   }
+  }
 
   getActiveClustersOldestFirst() {
     const { clusters } = this.props

--- a/src/components/ClusterManager.js
+++ b/src/components/ClusterManager.js
@@ -197,18 +197,17 @@ export default class ClusterManager extends PureComponent {
   }
 
   async executeAndRefresh(promise, waitBeforeRefreshMillis = 0) {
-    await setTimeout(async () => {
-      try {
-        const { refreshClusters } = this.props
-        this.setState({ busy: true })
-        await promise
-        await refreshClusters()
-      } catch (error) {
-        reportError('Notebook Runtime Error', error)
-      } finally {
-        this.setState({ busy: false })
-      }
-    }, waitBeforeRefreshMillis)
+    try {
+      const { refreshClusters } = this.props
+      this.setState({ busy: true })
+      await promise
+      waitBeforeRefreshMillis && await Utils.delay(waitBeforeRefreshMillis)
+      await refreshClusters()
+    } catch (error) {
+      reportError('Notebook Runtime Error', error)
+    } finally {
+      this.setState({ busy: false })
+    }
   }
 
   createDefaultCluster() {

--- a/src/components/ClusterManager.js
+++ b/src/components/ClusterManager.js
@@ -196,17 +196,19 @@ export default class ClusterManager extends PureComponent {
     return currentCluster(clusters)
   }
 
-  async executeAndRefresh(promise) {
-    try {
-      const { refreshClusters } = this.props
-      this.setState({ busy: true })
-      await promise
-      await refreshClusters()
-    } catch (error) {
-      reportError('Notebook Runtime Error', error)
-    } finally {
-      this.setState({ busy: false })
-    }
+  async executeAndRefresh(promise, waitBeforeRefreshMillis = 0) {
+    await setTimeout(async () => {
+      try {
+        const { refreshClusters } = this.props
+        this.setState({ busy: true })
+        await promise
+        await refreshClusters()
+      } catch (error) {
+        reportError('Notebook Runtime Error', error)
+      } finally {
+        this.setState({ busy: false })
+      }
+    }, waitBeforeRefreshMillis)
   }
 
   createDefaultCluster() {
@@ -341,9 +343,9 @@ export default class ClusterManager extends PureComponent {
         namespace,
         currentCluster,
         onDismiss: () => this.setState({ createModalDrawerOpen: false }),
-        onSuccess: promise => {
+        onSuccess: (promise, waitBeforeRefreshMillis = 0) => {
           this.setState({ createModalDrawerOpen: false })
-          this.executeAndRefresh(promise)
+          this.executeAndRefresh(promise, waitBeforeRefreshMillis)
         }
       }),
       errorModalOpen && h(ClusterErrorModal, {

--- a/src/components/NewClusterModal.js
+++ b/src/components/NewClusterModal.js
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp'
 import PropTypes from 'prop-types'
 import { Component, Fragment } from 'react'
-import { b, div, h, image, label, p, span } from 'react-hyperscript-helpers'
+import { b, div, h, label, p, span } from 'react-hyperscript-helpers'
 import { ButtonPrimary, ButtonSecondary, GroupedSelect, IdContainer, LabeledCheckbox, Link, Select } from 'src/components/common'
 import { ImageDepViewer } from 'src/components/ImageDepViewer'
 import { NumberInput, TextInput, ValidatedInput } from 'src/components/input'
@@ -155,7 +155,7 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
     const { googleProject, clusterName } = currentCluster
 
     return Ajax().Clusters.cluster(googleProject, clusterName).update({
-        machineConfig: this.getMachineConfig()
+      machineConfig: this.getMachineConfig()
     })
   }
 
@@ -167,7 +167,7 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
       Ajax().Buckets.getObjectPreview('terra-docker-image-documentation', 'terra-docker-versions.json', namespace, true).then(res => res.json())
     ])
 
-    console.log("Current cluster details: ", currentClusterDetails)
+    console.log('Current cluster details: ', currentClusterDetails)
 
     this.setState({ leoImages: newLeoImages })
     if (currentClusterDetails) {
@@ -176,12 +176,12 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
       if (_.find({ image: imageUrl }, newLeoImages)) {
         this.setState({ selectedLeoImage: imageUrl, originalImageUrl: imageUrl })
       } else if (currentClusterDetails.labels.saturnIsProjectSpecific === 'true') {
-        this.setState({ selectedLeoImage: PROJECT_SPECIFIC_MODE, customEnvImage: imageUrl, originalImageUrl: imageUrl})
+        this.setState({ selectedLeoImage: PROJECT_SPECIFIC_MODE, customEnvImage: imageUrl, originalImageUrl: imageUrl })
       } else {
         this.setState({ selectedLeoImage: CUSTOM_MODE, customEnvImage: imageUrl, originalImageUrl: imageUrl })
       }
       if (jupyterUserScriptUri) {
-        this.setState({ jupyterUserScriptUri, profile: 'custom', originalJupyterUserScriptUri: jupyterUserScriptUri  })
+        this.setState({ jupyterUserScriptUri, profile: 'custom', originalJupyterUserScriptUri: jupyterUserScriptUri })
       }
     } else {
       this.setState({ selectedLeoImage: _.find({ id: 'terra-jupyter-gatk' }, newLeoImages).image })
@@ -258,17 +258,17 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
       const currentClusterConfig = currentCluster.machineConfig
       const userSelectedConfig = this.getMachineConfig()
 
-      const hasStartupScriptChanged = jupyterUserScriptUri != originalStartupScript
+      const hasStartupScriptChanged = jupyterUserScriptUri !== originalStartupScript
 
       const hasImageChanged = !_.includes(originalImageUrl, [selectedLeoImage, customEnvImage])
 
-      const workersCantUpdate = currentClusterConfig.numberOfWorkers != userSelectedConfig.numberOfWorkers &&
+      const workersCantUpdate = currentClusterConfig.numberOfWorkers !== userSelectedConfig.numberOfWorkers &&
         (currentClusterConfig.numberOfWorkers < 2 || userSelectedConfig.numberOfWorkers < 2)
 
       const hasUnUpdateableResourceChanged =
-        currentClusterConfig.workerDiskSize != userSelectedConfig.workerDiskSize ||
-        currentClusterConfig.workerMachineType != userSelectedConfig.workerMachineType ||
-        currentClusterConfig.numberOfWorkerLocalSSDs != userSelectedConfig.numberOfWorkerLocalSSDs
+        currentClusterConfig.workerDiskSize !== userSelectedConfig.workerDiskSize ||
+        currentClusterConfig.workerMachineType !== userSelectedConfig.workerMachineType ||
+        currentClusterConfig.numberOfWorkerLocalSSDs !== userSelectedConfig.numberOfWorkerLocalSSDs
 
       const hasWorkers = currentClusterConfig.numberOfWorkers >= 2 || currentClusterConfig.numberOfPreemptibleWorkers >= 2
 
@@ -285,14 +285,14 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
       const currentClusterConfig = currentCluster.machineConfig
       const userSelectedConfig = this.getMachineConfig()
 
-      const isMasterMachineTypeChanged = currentClusterConfig.masterMachineType != userSelectedConfig.masterMachineType
+      const isMasterMachineTypeChanged = currentClusterConfig.masterMachineType !== userSelectedConfig.masterMachineType
 
-      const isClusterRunning = currentCluster.status == 'Running'
+      const isClusterRunning = currentCluster.status === 'Running'
 
       return canUpdate() && isMasterMachineTypeChanged && isClusterRunning
     }
 
-    const getUpdateOrReplace = () => canUpdate() ? "Update" : "Replace"
+    const getUpdateOrReplace = () => canUpdate() ? 'Update' : 'Replace'
 
     const machineConfig = () => h(Fragment, [
       div({
@@ -460,13 +460,12 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
           h(ButtonPrimary, { onClick: () => this.createCluster() }, ['REPLACE'])
         ])
       ])],
-      [ 'update', () => h(Fragment, [
+      ['update', () => h(Fragment, [
         isStopRequired()
           ? p(['Changing the machine type (increasing or decreasing the # of CPUs or Mem) results in an update that requires a ',
             b(['restart']),
             ' of your runtime. This may take a few minutes.  Would you like to proceed? ',
-            b(['(You will not lose any files.)'])
-          ])
+            b(['(You will not lose any files.)'])])
           : p(['Increasing the disk size or changing the number of workers (when the number of workers is >2) results in a real-time update to your runtime. ',
             'During this update, you can continue to work']),
         div({ style: { display: 'flex', justifyContent: 'flex-end', marginTop: '1rem' } }, [

--- a/src/components/NewClusterModal.js
+++ b/src/components/NewClusterModal.js
@@ -181,7 +181,7 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
         this.setState({ selectedLeoImage: CUSTOM_MODE, customEnvImage: imageUrl, originalImageUrl: imageUrl })
       }
       if (jupyterUserScriptUri) {
-        this.setState({ jupyterUserScriptUri, profile: 'custom' })
+        this.setState({ jupyterUserScriptUri, profile: 'custom', originalJupyterUserScriptUri: jupyterUserScriptUri  })
       }
     } else {
       this.setState({ selectedLeoImage: _.find({ id: 'terra-jupyter-gatk' }, newLeoImages).image })
@@ -192,7 +192,7 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
     const { currentCluster, onDismiss, onSuccess } = this.props
     const {
       profile, masterMachineType, masterDiskSize, workerMachineType, numberOfWorkers, numberOfPreemptibleWorkers, workerDiskSize,
-      jupyterUserScriptUri, selectedLeoImage, customEnvImage, leoImages, viewMode, originalImageUrl
+      jupyterUserScriptUri, selectedLeoImage, customEnvImage, leoImages, viewMode, originalImageUrl, originalStartupScript
     } = this.state
     const { version, updated, packages } = _.find({ image: selectedLeoImage }, leoImages) || {}
 
@@ -258,6 +258,8 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
       const currentClusterConfig = currentCluster.machineConfig
       const userSelectedConfig = this.getMachineConfig()
 
+      const hasStartupScriptChanged = jupyterUserScriptUri != originalStartupScript
+
       const hasImageChanged = !_.includes(originalImageUrl, [selectedLeoImage, customEnvImage])
 
       const workersCantUpdate = currentClusterConfig.numberOfWorkers != userSelectedConfig.numberOfWorkers &&
@@ -274,7 +276,7 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
 
       const hasDiskSizeDecreased = currentClusterConfig.masterDiskSize > userSelectedConfig.masterDiskSize
 
-      const cantUpdate = workersCantUpdate || hasWorkersResourceChanged || hasDiskSizeDecreased || hasImageChanged
+      const cantUpdate = workersCantUpdate || hasWorkersResourceChanged || hasDiskSizeDecreased || hasImageChanged || hasStartupScriptChanged
       return !cantUpdate
     }
 

--- a/src/components/NewClusterModal.js
+++ b/src/components/NewClusterModal.js
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp'
 import PropTypes from 'prop-types'
 import { Component, Fragment } from 'react'
-import { b, div, h, label, p, pre, span } from 'react-hyperscript-helpers'
+import { b, div, h, label, p, span } from 'react-hyperscript-helpers'
 import { ButtonPrimary, ButtonSecondary, GroupedSelect, IdContainer, LabeledCheckbox, Link, Select } from 'src/components/common'
 import { ImageDepViewer } from 'src/components/ImageDepViewer'
 import { NumberInput, TextInput, ValidatedInput } from 'src/components/input'
@@ -455,7 +455,9 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
       ])],
       [ 'update', () => h(Fragment, [
         isStopRequired()
-          ? p(['Changing the machine type (increasing or decreasing the # of CPUs or Mem) results in an update that requires a restart of your runtime. This may take a few minutes.  Would you like to proceed? ',
+          ? p(['Changing the machine type (increasing or decreasing the # of CPUs or Mem) results in an update that requires a ',
+            b(['restart']),
+            ' of your runtime. This may take a few minutes.  Would you like to proceed? ',
             b(['(You will not lose any files.)'])
           ])
           : p(['Increasing the disk size or changing the number of workers (when the number of workers is >2) results in a real-time update to your runtime. ',

--- a/src/components/NewClusterModal.js
+++ b/src/components/NewClusterModal.js
@@ -150,7 +150,6 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
   }
 
   updateCluster() {
-    console.log('in update cluster')
     const { currentCluster } = this.props
     const { googleProject, clusterName } = currentCluster
 
@@ -166,8 +165,6 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
       currentCluster ? Ajax().Clusters.cluster(currentCluster.googleProject, currentCluster.clusterName).details() : null,
       Ajax().Buckets.getObjectPreview('terra-docker-image-documentation', 'terra-docker-versions.json', namespace, true).then(res => res.json())
     ])
-
-    console.log('Current cluster details: ', currentClusterDetails)
 
     this.setState({ leoImages: newLeoImages })
     if (currentClusterDetails) {

--- a/src/components/NewClusterModal.js
+++ b/src/components/NewClusterModal.js
@@ -177,11 +177,14 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
       } else {
         this.setState({ selectedLeoImage: CUSTOM_MODE, customEnvImage: imageUrl, originalImageUrl: imageUrl })
       }
+
       if (jupyterUserScriptUri) {
         this.setState({ jupyterUserScriptUri, profile: 'custom', originalJupyterUserScriptUri: jupyterUserScriptUri })
+      } else {
+        this.setState({ originalJupyterUserScriptUri: '' })
       }
     } else {
-      this.setState({ selectedLeoImage: _.find({ id: 'terra-jupyter-gatk' }, newLeoImages).image })
+      this.setState({ selectedLeoImage: _.find({ id: 'terra-jupyter-gatk' }, newLeoImages).image , originalImageUrl: '', originalJupyterUserScriptUri: '' })
     }
   })
 
@@ -189,7 +192,7 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
     const { currentCluster, onDismiss, onSuccess } = this.props
     const {
       profile, masterMachineType, masterDiskSize, workerMachineType, numberOfWorkers, numberOfPreemptibleWorkers, workerDiskSize,
-      jupyterUserScriptUri, selectedLeoImage, customEnvImage, leoImages, viewMode, originalImageUrl, originalStartupScript
+      jupyterUserScriptUri, selectedLeoImage, customEnvImage, leoImages, viewMode, originalImageUrl, originalJupyterUserScriptUri
     } = this.state
     const { version, updated, packages } = _.find({ image: selectedLeoImage }, leoImages) || {}
 
@@ -255,7 +258,8 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
       const currentClusterConfig = currentCluster.machineConfig
       const userSelectedConfig = this.getMachineConfig()
 
-      const hasStartupScriptChanged = jupyterUserScriptUri !== originalStartupScript
+      const hasStartupScriptChanged = jupyterUserScriptUri !== originalJupyterUserScriptUri
+      console.log(`curr: ${jupyterUserScriptUri}, original:${originalJupyterUserScriptUri}`)
 
       const hasImageChanged = !_.includes(originalImageUrl, [selectedLeoImage, customEnvImage])
 
@@ -274,6 +278,7 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
       const hasDiskSizeDecreased = currentClusterConfig.masterDiskSize > userSelectedConfig.masterDiskSize
 
       const cantUpdate = workersCantUpdate || hasWorkersResourceChanged || hasDiskSizeDecreased || hasImageChanged || hasStartupScriptChanged
+      console.log('update constituents: ', workersCantUpdate, hasWorkersResourceChanged, hasDiskSizeDecreased, hasImageChanged, hasStartupScriptChanged)
       return !cantUpdate
     }
 

--- a/src/components/NewClusterModal.js
+++ b/src/components/NewClusterModal.js
@@ -162,7 +162,7 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
       Ajax().Clusters.cluster(googleProject, clusterName).update({
         machineConfig: this.getMachineConfig()
       }),
-      5000)
+      isStopRequired ? 5000 : 0)
   }
 
   //determines whether the changes are applicable for a call to the leo patch endpoint

--- a/src/components/NewClusterModal.js
+++ b/src/components/NewClusterModal.js
@@ -480,15 +480,17 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
         ])
       ])],
       ['update', () => h(Fragment, [
-        this.isStopRequired() ? p([
-          'Changing the machine type (increasing or decreasing the # of CPUs or Mem) results in an update that requires a ',
-          b(['restart']),
-          ' of your runtime. This may take a few minutes.  Would you like to proceed? ',
-          b(['(You will not lose any files.)'])
-        ]) : p([
-          'Increasing the disk size or changing the number of workers (when the number of workers is >2) results in a real-time update to your runtime. ',
-          'During this update, you can continue to work'
-        ]),
+        this.isStopRequired() ?
+          p([
+            'Changing the machine type (increasing or decreasing the # of CPUs or Mem) results in an update that requires a ',
+            b(['restart']),
+            ' of your runtime. This may take a few minutes.  Would you like to proceed? ',
+            b(['(You will not lose any files.)'])
+          ]) :
+          p([
+            'Increasing the disk size or changing the number of workers (when the number of workers is >2) results in a real-time update to your runtime. ',
+            'During this update, you can continue to work'
+          ]),
         div({ style: { display: 'flex', justifyContent: 'flex-end', marginTop: '1rem' } }, [
           h(ButtonSecondary, {
             style: { marginRight: '2rem' },

--- a/src/components/NewClusterModal.js
+++ b/src/components/NewClusterModal.js
@@ -173,7 +173,7 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
 
   hasImageChanged() {
     const { selectedLeoImage, customEnvImage, currentClusterDetails } = this.state
-    const { imageUrl } =  currentClusterDetails ? this.getImageUrl(currentClusterDetails) : ''
+    const { imageUrl } = currentClusterDetails ? this.getImageUrl(currentClusterDetails) : ''
     return !_.includes(imageUrl, [selectedLeoImage, customEnvImage])
   }
 
@@ -194,7 +194,6 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
       currentClusterConfig.numberOfWorkerLocalSSDs !== userSelectedConfig.numberOfWorkerLocalSSDs
 
     const hasWorkers = currentClusterConfig.numberOfWorkers >= 2 || currentClusterConfig.numberOfPreemptibleWorkers >= 2
-
     const hasWorkersResourceChanged = hasWorkers && hasUnUpdateableResourceChanged
 
     const hasDiskSizeDecreased = currentClusterConfig.masterDiskSize > userSelectedConfig.masterDiskSize
@@ -230,7 +229,7 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
       Ajax().Buckets.getObjectPreview('terra-docker-image-documentation', 'terra-docker-versions.json', namespace, true).then(res => res.json())
     ])
 
-    this.setState({ leoImages: newLeoImages, currentClusterDetails: currentClusterDetails })
+    this.setState({ leoImages: newLeoImages, currentClusterDetails })
     if (currentClusterDetails) {
       const { jupyterUserScriptUri } = currentClusterDetails
       const { imageUrl } = this.getImageUrl(currentClusterDetails)

--- a/src/components/NewClusterModal.js
+++ b/src/components/NewClusterModal.js
@@ -155,7 +155,7 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
     const { googleProject, clusterName } = currentCluster
 
     if (isStopRequired) {
-      notify('success', 'To be updated, your runtime will now stop, and then start.', { timeout: 3000 })
+      notify('success', 'To be updated, your runtime will now stop, and then start.')
     }
 
     return onSuccess(
@@ -165,20 +165,27 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
       isStopRequired ? 5000 : 0)
   }
 
+  hasStartUpScriptChanged() {
+    const { jupyterUserScriptUri, currentClusterDetails } = this.state
+    const originalJupyterUserScriptUri = currentClusterDetails?.jupyterUserScriptUri || ''
+    return jupyterUserScriptUri !== originalJupyterUserScriptUri
+  }
+
+  hasImageChanged() {
+    const { selectedLeoImage, customEnvImage, currentClusterDetails } = this.state
+    const { imageUrl } =  currentClusterDetails ? this.getImageUrl(currentClusterDetails) : ''
+    return !_.includes(imageUrl, [selectedLeoImage, customEnvImage])
+  }
+
   //determines whether the changes are applicable for a call to the leo patch endpoint
   //see this for a diagram of the conditional this implements https://drive.google.com/file/d/1mtFFecpQTkGYWSgPlaHksYaIudWHa0dY/view
   //this function returns true for cases 2 & 3 in this diagram
   canUpdate() {
     const { currentCluster } = this.props
-    const { jupyterUserScriptUri, originalJupyterUserScriptUri, originalImageUrl, selectedLeoImage, customEnvImage } = this.state
     const currentClusterConfig = currentCluster.machineConfig
     const userSelectedConfig = this.getMachineConfig()
 
-    const hasStartupScriptChanged = jupyterUserScriptUri !== originalJupyterUserScriptUri
-
-    const hasImageChanged = !_.includes(originalImageUrl, [selectedLeoImage, customEnvImage])
-
-    const workersCantUpdate = currentClusterConfig.numberOfWorkers !== userSelectedConfig.numberOfWorkers &&
+    const cantWorkersUpdate = currentClusterConfig.numberOfWorkers !== userSelectedConfig.numberOfWorkers &&
       (currentClusterConfig.numberOfWorkers < 2 || userSelectedConfig.numberOfWorkers < 2)
 
     const hasUnUpdateableResourceChanged =
@@ -192,7 +199,7 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
 
     const hasDiskSizeDecreased = currentClusterConfig.masterDiskSize > userSelectedConfig.masterDiskSize
 
-    const cantUpdate = workersCantUpdate || hasWorkersResourceChanged || hasDiskSizeDecreased || hasImageChanged || hasStartupScriptChanged || !currentCluster
+    const cantUpdate = cantWorkersUpdate || hasWorkersResourceChanged || hasDiskSizeDecreased || this.hasImageChanged() || this.hasStartUpScriptChanged() || !currentCluster
     return !cantUpdate
   }
 
@@ -210,6 +217,11 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
     return this.canUpdate() && isMasterMachineTypeChanged && isClusterRunning
   }
 
+  getImageUrl(clusterDetails) {
+    const { clusterImages } = clusterDetails
+    return _.find(({ imageType }) => _.includes(imageType, ['Jupyter', 'RStudio']), clusterImages)
+  }
+
   componentDidMount = withErrorReporting('Error loading cluster', async () => {
     const { currentCluster, namespace } = this.props
 
@@ -218,25 +230,23 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
       Ajax().Buckets.getObjectPreview('terra-docker-image-documentation', 'terra-docker-versions.json', namespace, true).then(res => res.json())
     ])
 
-    this.setState({ leoImages: newLeoImages })
+    this.setState({ leoImages: newLeoImages, currentClusterDetails: currentClusterDetails })
     if (currentClusterDetails) {
-      const { clusterImages, jupyterUserScriptUri } = currentClusterDetails
-      const { imageUrl } = _.find(({ imageType }) => _.includes(imageType, ['Jupyter', 'RStudio']), clusterImages)
+      const { jupyterUserScriptUri } = currentClusterDetails
+      const { imageUrl } = this.getImageUrl(currentClusterDetails)
       if (_.find({ image: imageUrl }, newLeoImages)) {
-        this.setState({ selectedLeoImage: imageUrl, originalImageUrl: imageUrl })
+        this.setState({ selectedLeoImage: imageUrl })
       } else if (currentClusterDetails.labels.saturnIsProjectSpecific === 'true') {
-        this.setState({ selectedLeoImage: PROJECT_SPECIFIC_MODE, customEnvImage: imageUrl, originalImageUrl: imageUrl })
+        this.setState({ selectedLeoImage: PROJECT_SPECIFIC_MODE, customEnvImage: imageUrl })
       } else {
-        this.setState({ selectedLeoImage: CUSTOM_MODE, customEnvImage: imageUrl, originalImageUrl: imageUrl })
+        this.setState({ selectedLeoImage: CUSTOM_MODE, customEnvImage: imageUrl })
       }
 
       if (jupyterUserScriptUri) {
-        this.setState({ jupyterUserScriptUri, profile: 'custom', originalJupyterUserScriptUri: jupyterUserScriptUri })
-      } else {
-        this.setState({ originalJupyterUserScriptUri: '' })
+        this.setState({ jupyterUserScriptUri, profile: 'custom' })
       }
     } else {
-      this.setState({ selectedLeoImage: _.find({ id: 'terra-jupyter-gatk' }, newLeoImages).image, originalImageUrl: '', originalJupyterUserScriptUri: '' })
+      this.setState({ selectedLeoImage: _.find({ id: 'terra-jupyter-gatk' }, newLeoImages).image })
     }
   })
 
@@ -293,16 +303,16 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
             if (isSelectedImageInputted && !this.canUpdate()) {
               this.setState({ viewMode: 'warning' })
             } else if (!!currentCluster) {
-              this.setState({ viewMode: _.lowerCase(getUpdateOrReplace()) })
+              this.setState({ viewMode: getUpdateOrReplace() })
             } else {
               this.createCluster()
             }
           }
-        }, !!currentCluster ? getUpdateOrReplace() : 'Create')
+        }, !!currentCluster ? _.startCase(getUpdateOrReplace()) : 'Create')
       ])
     ])
 
-    const getUpdateOrReplace = () => this.canUpdate() ? 'Update' : 'Replace'
+    const getUpdateOrReplace = () => this.canUpdate() ? 'update' : 'replace'
 
     const machineConfig = () => h(Fragment, [
       div({
@@ -471,13 +481,15 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
         ])
       ])],
       ['update', () => h(Fragment, [
-        this.isStopRequired()
-          ? p(['Changing the machine type (increasing or decreasing the # of CPUs or Mem) results in an update that requires a ',
-            b(['restart']),
-            ' of your runtime. This may take a few minutes.  Would you like to proceed? ',
-            b(['(You will not lose any files.)'])])
-          : p(['Increasing the disk size or changing the number of workers (when the number of workers is >2) results in a real-time update to your runtime. ',
-            'During this update, you can continue to work']),
+        this.isStopRequired() ? p([
+          'Changing the machine type (increasing or decreasing the # of CPUs or Mem) results in an update that requires a ',
+          b(['restart']),
+          ' of your runtime. This may take a few minutes.  Would you like to proceed? ',
+          b(['(You will not lose any files.)'])
+        ]) : p([
+          'Increasing the disk size or changing the number of workers (when the number of workers is >2) results in a real-time update to your runtime. ',
+          'During this update, you can continue to work'
+        ]),
         div({ style: { display: 'flex', justifyContent: 'flex-end', marginTop: '1rem' } }, [
           h(ButtonSecondary, {
             style: { marginRight: '2rem' },

--- a/src/components/NewClusterModal.js
+++ b/src/components/NewClusterModal.js
@@ -192,7 +192,7 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
 
     const hasDiskSizeDecreased = currentClusterConfig.masterDiskSize > userSelectedConfig.masterDiskSize
 
-    const cantUpdate = workersCantUpdate || hasWorkersResourceChanged || hasDiskSizeDecreased || hasImageChanged || hasStartupScriptChanged
+    const cantUpdate = workersCantUpdate || hasWorkersResourceChanged || hasDiskSizeDecreased || hasImageChanged || hasStartupScriptChanged || !currentCluster
     return !cantUpdate
   }
 
@@ -290,7 +290,7 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
           disabled: isSelectedImageInputted && isCustomImageInvalid,
           tooltip: isSelectedImageInputted && isCustomImageInvalid && 'Enter a valid docker image to use',
           onClick: () => {
-            if (isSelectedImageInputted) {
+            if (isSelectedImageInputted && !this.canUpdate()) {
               this.setState({ viewMode: 'warning' })
             } else if (!!currentCluster) {
               this.setState({ viewMode: _.lowerCase(getUpdateOrReplace()) })
@@ -480,7 +480,8 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
             'During this update, you can continue to work']),
         div({ style: { display: 'flex', justifyContent: 'flex-end', marginTop: '1rem' } }, [
           h(ButtonSecondary, {
-            style: { marginRight: '2rem' }
+            style: { marginRight: '2rem' },
+            onClick: () => this.setState({ viewMode: undefined })
           }, ['BACK']),
           h(ButtonPrimary, { onClick: () => this.updateCluster(this.isStopRequired()) }, ['UPDATE'])
         ])

--- a/src/components/cluster-common.js
+++ b/src/components/cluster-common.js
@@ -4,10 +4,10 @@ import { b, div, h } from 'react-hyperscript-helpers'
 import { spinnerOverlay } from 'src/components/common'
 import { icon, spinner } from 'src/components/icons'
 import { Ajax } from 'src/libs/ajax'
+import { usableStatuses } from 'src/libs/cluster-utils'
 import colors from 'src/libs/colors'
 import { withErrorIgnoring, withErrorReporting } from 'src/libs/error'
 import * as Utils from 'src/libs/utils'
-import { usableStatuses } from 'src/libs/cluster-utils'
 
 
 export const StatusMessage = ({ hideSpinner, children }) => {

--- a/src/components/cluster-common.js
+++ b/src/components/cluster-common.js
@@ -7,6 +7,7 @@ import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { withErrorIgnoring, withErrorReporting } from 'src/libs/error'
 import * as Utils from 'src/libs/utils'
+import { usableStatuses } from 'src/libs/cluster-utils'
 
 
 export const StatusMessage = ({ hideSpinner, children }) => {
@@ -77,10 +78,9 @@ export const ClusterStatusMonitor = ({ cluster, onClusterStoppedRunning = _.noop
   const prevStatus = Utils.usePrevious(currentStatus)
 
   useEffect(() => {
-    const runningStatuses = ['Running', 'Updating']
-    if (prevStatus === 'Running' && !_.includes(currentStatus, runningStatuses)) {
+    if (prevStatus === 'Running' && !_.includes(currentStatus, usableStatuses)) {
       onClusterStoppedRunning()
-    } else if (prevStatus !== 'Running' && !_.includes(currentStatus, runningStatuses)) {
+    } else if (prevStatus !== 'Running' && !_.includes(currentStatus, usableStatuses)) {
       onClusterStartedRunning()
     }
   }, [currentStatus, onClusterStartedRunning, onClusterStoppedRunning, prevStatus])

--- a/src/components/cluster-common.js
+++ b/src/components/cluster-common.js
@@ -80,7 +80,7 @@ export const ClusterStatusMonitor = ({ cluster, onClusterStoppedRunning = _.noop
   useEffect(() => {
     if (prevStatus === 'Running' && !_.includes(currentStatus, usableStatuses)) {
       onClusterStoppedRunning()
-    } else if (prevStatus !== 'Running' && !_.includes(currentStatus, usableStatuses)) {
+    } else if (prevStatus !== 'Running' && _.includes(currentStatus, usableStatuses)) {
       onClusterStartedRunning()
     }
   }, [currentStatus, onClusterStartedRunning, onClusterStoppedRunning, prevStatus])

--- a/src/components/cluster-common.js
+++ b/src/components/cluster-common.js
@@ -77,9 +77,10 @@ export const ClusterStatusMonitor = ({ cluster, onClusterStoppedRunning = _.noop
   const prevStatus = Utils.usePrevious(currentStatus)
 
   useEffect(() => {
-    if (prevStatus === 'Running' && currentStatus !== 'Running') {
+    const runningStatuses = ['Running', 'Updating']
+    if (prevStatus === 'Running' && !_.includes(currentStatus, runningStatuses)) {
       onClusterStoppedRunning()
-    } else if (prevStatus !== 'Running' && currentStatus === 'Running') {
+    } else if (prevStatus !== 'Running' && !_.includes(currentStatus, runningStatuses)) {
       onClusterStartedRunning()
     }
   }, [currentStatus, onClusterStartedRunning, onClusterStoppedRunning, prevStatus])

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -993,6 +993,13 @@ const Clusters = signal => ({
         return fetchLeo(`api/cluster/v2/${project}/${name}`, _.mergeAll([authOpts(), jsonBody(body), { signal, method: 'PUT' }, appIdentifier]))
       },
 
+      update: clusterOptions => {
+        const body = _.merge(clusterOptions, {
+          allowStop: true
+        })
+        return fetchLeo(`api/cluster/${project}/${name}`, _.mergeAll([authOpts(), jsonBody(body), { signal, method: 'PATCH' }, appIdentifier]))
+      },
+
       start: () => {
         return fetchLeo(`${root}/start`, _.mergeAll([authOpts(), { signal, method: 'POST' }, appIdentifier]))
       },

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -994,9 +994,7 @@ const Clusters = signal => ({
       },
 
       update: clusterOptions => {
-        const body = _.merge(clusterOptions, {
-          allowStop: true
-        })
+        const body = { ...clusterOptions, allowStop: true }
         return fetchLeo(`api/cluster/${project}/${name}`, _.mergeAll([authOpts(), jsonBody(body), { signal, method: 'PATCH' }, appIdentifier]))
       },
 

--- a/src/libs/cluster-utils.js
+++ b/src/libs/cluster-utils.js
@@ -6,6 +6,8 @@ import { machineTypes, storagePrice } from 'src/data/clusters'
 import * as Utils from 'src/libs/utils'
 
 
+export const usableStatuses = ['Updating','Running']
+
 export const normalizeMachineConfig = ({ masterMachineType, masterDiskSize, numberOfWorkers, numberOfPreemptibleWorkers, workerMachineType, workerDiskSize }) => {
   return {
     masterMachineType: masterMachineType || 'n1-standard-4',

--- a/src/libs/cluster-utils.js
+++ b/src/libs/cluster-utils.js
@@ -6,7 +6,7 @@ import { machineTypes, storagePrice } from 'src/data/clusters'
 import * as Utils from 'src/libs/utils'
 
 
-export const usableStatuses = ['Updating','Running']
+export const usableStatuses = ['Updating', 'Running']
 
 export const normalizeMachineConfig = ({ masterMachineType, masterDiskSize, numberOfWorkers, numberOfPreemptibleWorkers, workerMachineType, workerDiskSize }) => {
   return {

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -146,7 +146,7 @@ const useClusterPolling = namespace => {
       const newClusters = await Ajax(signal).Clusters.list({ googleProject: namespace, creator: getUser().email })
       setClusters(newClusters)
       const cluster = currentCluster(newClusters)
-      reschedule(_.includes(cluster && cluster.status, ['Creating', 'Starting', 'Stopping']) ? 10000 : 120000)
+      reschedule(_.includes(cluster && cluster.status, ['Creating', 'Starting', 'Stopping', 'Updating']) ? 10000 : 120000)
     } catch (error) {
       reschedule(30000)
       throw error

--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -50,7 +50,7 @@ const NotebookLauncher = _.flow(
     const { mode } = queryParams
 
     return h(Fragment, [
-      (Utils.canWrite(accessLevel) && canCompute && !!mode && status === 'Running' && labels.tool === 'Jupyter') ?
+      (Utils.canWrite(accessLevel) && canCompute && !!mode && (status === 'Running' || status === 'Updating') && labels.tool === 'Jupyter') ?
         h(labels.welderInstallFailed ? WelderDisabledNotebookEditorFrame : NotebookEditorFrame,
           { key: clusterName, workspace, cluster, notebookName, mode }) :
         h(Fragment, [
@@ -385,7 +385,7 @@ const copyingNotebookMessage = div({ style: { paddingTop: '2rem' } }, [
 ])
 
 const NotebookEditorFrame = ({ mode, notebookName, workspace: { workspace: { namespace, name, bucketName } }, cluster: { clusterName, clusterUrl, status, labels } }) => {
-  console.assert(status === 'Running', 'Expected notebook runtime to be running')
+  console.assert(status === 'Running' || status === 'Updating', 'Expected notebook runtime to be running or updating')
   console.assert(!labels.welderInstallFailed, 'Expected cluster to have Welder')
   const frameRef = useRef()
   const [busy, setBusy] = useState(false)

--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -25,6 +25,7 @@ import { authStore } from 'src/libs/state'
 import * as Utils from 'src/libs/utils'
 import ExportNotebookModal from 'src/pages/workspaces/workspace/notebooks/ExportNotebookModal'
 import { wrapWorkspace } from 'src/pages/workspaces/workspace/WorkspaceContainer'
+import { usableStatuses } from 'src/libs/cluster-utils'
 
 
 const chooseMode = mode => {
@@ -50,7 +51,7 @@ const NotebookLauncher = _.flow(
     const { mode } = queryParams
 
     return h(Fragment, [
-      (Utils.canWrite(accessLevel) && canCompute && !!mode && (status === 'Running' || status === 'Updating') && labels.tool === 'Jupyter') ?
+      (Utils.canWrite(accessLevel) && canCompute && !!mode && _.includes(status, usableStatuses) && labels.tool === 'Jupyter') ?
         h(labels.welderInstallFailed ? WelderDisabledNotebookEditorFrame : NotebookEditorFrame,
           { key: clusterName, workspace, cluster, notebookName, mode }) :
         h(Fragment, [
@@ -385,7 +386,7 @@ const copyingNotebookMessage = div({ style: { paddingTop: '2rem' } }, [
 ])
 
 const NotebookEditorFrame = ({ mode, notebookName, workspace: { workspace: { namespace, name, bucketName } }, cluster: { clusterName, clusterUrl, status, labels } }) => {
-  console.assert(status === 'Running' || status === 'Updating', 'Expected notebook runtime to be running or updating')
+  console.assert(_.includes(status, usableStatuses), 'Expected notebook runtime to be running or updating')
   console.assert(!labels.welderInstallFailed, 'Expected cluster to have Welder')
   const frameRef = useRef()
   const [busy, setBusy] = useState(false)

--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -17,6 +17,7 @@ import { notify } from 'src/components/Notifications'
 import PopupTrigger from 'src/components/PopupTrigger'
 import { dataSyncingDocUrl } from 'src/data/clusters'
 import { Ajax } from 'src/libs/ajax'
+import { usableStatuses } from 'src/libs/cluster-utils'
 import colors from 'src/libs/colors'
 import { withErrorReporting } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
@@ -25,7 +26,6 @@ import { authStore } from 'src/libs/state'
 import * as Utils from 'src/libs/utils'
 import ExportNotebookModal from 'src/pages/workspaces/workspace/notebooks/ExportNotebookModal'
 import { wrapWorkspace } from 'src/pages/workspaces/workspace/WorkspaceContainer'
-import { usableStatuses } from 'src/libs/cluster-utils'
 
 
 const chooseMode = mode => {

--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -386,7 +386,7 @@ const copyingNotebookMessage = div({ style: { paddingTop: '2rem' } }, [
 ])
 
 const NotebookEditorFrame = ({ mode, notebookName, workspace: { workspace: { namespace, name, bucketName } }, cluster: { clusterName, clusterUrl, status, labels } }) => {
-  console.assert(_.includes(status, usableStatuses), 'Expected notebook runtime to be running or updating')
+  console.assert(_.includes(status, usableStatuses), `Expected notebook runtime to be one of: [${usableStatuses}]`)
   console.assert(!labels.welderInstallFailed, 'Expected cluster to have Welder')
   const frameRef = useRef()
   const [busy, setBusy] = useState(false)


### PR DESCRIPTION
Heavy manual verification done.

Implements this ticket: https://broadworkbench.atlassian.net/browse/IA-1508, which:
- allows users to 'Update' their cluster via the leo patch endpoint
- Leverages leo functionality to stop/restart a cluster for updates that require the cluster to be stopped
- The Update status is used only in specific updates, but the user is allowed to continue editting their notebook during this time

There is one bug, where the stop transition does not actually work when pointing to dev, pending: https://github.com/DataBiosphere/leonardo/pull/1249

I still need to lint and there'e some logic (indicated in this PR) I want to noodle on a bit more, but I want to start getting feedback on the approach

**This cannot be merged until this PR is in prod: https://github.com/DataBiosphere/leonardo/pull/1271/files**

edit: that pr is in prod as of 2/10

