### PR TITLE
Give config to integration tests

### DIFF
--- a/integration-tests/jest/jest-utils.js
+++ b/integration-tests/jest/jest-utils.js
@@ -1,12 +1,13 @@
-const { screenshotDir } = require('../utils/integration-config')
+const config = require('../utils/integration-config')
 const { defaultTimeout } = require('../utils/integration-helpers')
 
 
 const withGlobalJestPuppeteerContext = fn => () => fn({ context, page })
 
 const withScreenshot = (testName, fn) => async ({ context, page }) => {
+  const { screenshotDir } = config
   try {
-    await fn({ context, page })
+    await fn({ config, context, page })
   } catch (e) {
     if (screenshotDir) {
       await page.screenshot({ path: `${screenshotDir}/failure-${Date.now()}-${testName}.png`, fullPage: true })

--- a/integration-tests/tests/find-workflow.js
+++ b/integration-tests/tests/find-workflow.js
@@ -1,10 +1,11 @@
 const firecloud = require('../utils/firecloud-utils')
-const { billingProject, testUrl, workflowName } = require('../utils/integration-config')
 const { withWorkspace } = require('../utils/integration-helpers')
 const { click, clickable, findElement, findText, signIntoTerra } = require('../utils/integration-utils')
 
 
-const testFindWorkflowFn = withWorkspace(async ({ page, workspaceName }) => {
+const testFindWorkflowFn = withWorkspace(async ({ config, page, workspaceName }) => {
+  const { billingProject, testUrl, workflowName } = config
+
   await page.goto(testUrl)
   await signIntoTerra(page)
   await click(page, clickable({ textContains: 'View Examples' }))

--- a/integration-tests/tests/import-cohort-data.js
+++ b/integration-tests/tests/import-cohort-data.js
@@ -1,11 +1,12 @@
-const { testUrl } = require('../utils/integration-config')
 const { withWorkspace } = require('../utils/integration-helpers')
 const { findInGrid, click, clickable, fillIn, findIframe, input, signIntoTerra, select, svgText, waitForNoSpinners, findElement } = require('../utils/integration-utils')
 
 
 const cohortName = `terra-ui-test-cohort`
 
-const testImportCohortDataFn = withWorkspace(async ({ page, workspaceName }) => {
+const testImportCohortDataFn = withWorkspace(async ({ config, page, workspaceName }) => {
+  const { testUrl } = config
+
   await page.goto(testUrl)
   await signIntoTerra(page)
   await click(page, clickable({ textContains: 'Browse Data' }))

--- a/integration-tests/tests/import-dockstore-workflow.js
+++ b/integration-tests/tests/import-dockstore-workflow.js
@@ -1,14 +1,14 @@
 const fetch = require('node-fetch')
-const { testUrl } = require('../utils/integration-config')
 const { withWorkspace } = require('../utils/integration-helpers')
 const { click, clickable, findText, select, signIntoTerra } = require('../utils/integration-utils')
 
 
 const testWorkflowIdentifier = 'github.com/DataBiosphere/topmed-workflows/UM_variant_caller_wdl:1.32.0'
 
-const testImportDockstoreWorkflowFn = async ({ context, page }) => {
-  const { dockstoreUrlRoot } = await fetch(`${testUrl}/config.json`).then(res => res.json())
+const testImportDockstoreWorkflowFn = async options => {
+  const { config: { testUrl }, page } = options
 
+  const { dockstoreUrlRoot } = await fetch(`${testUrl}/config.json`).then(res => res.json())
   if (await fetch(`${dockstoreUrlRoot}/api/api/ga4gh/v1/metadata`).then(res => res.status !== 200)) {
     console.error('Skipping dockstore test, API appears to be down')
   } else {
@@ -19,7 +19,7 @@ const testImportDockstoreWorkflowFn = async ({ context, page }) => {
       await select(page, 'Select a workspace', workspaceName)
       await click(page, clickable({ text: 'Import' }))
       await findText(page, testWorkflowIdentifier)
-    })({ context })
+    })(options)
   }
 }
 

--- a/integration-tests/tests/register-user.js
+++ b/integration-tests/tests/register-user.js
@@ -1,9 +1,10 @@
-const { testUrl } = require('../utils/integration-config')
 const { withUser } = require('../utils/integration-helpers')
 const { findText, click, clickable, fillIn, input, signIntoTerra, waitForNoSpinners } = require('../utils/integration-utils')
 
 
-const testRegisterUserFn = withUser(async ({ page, token }) => {
+const testRegisterUserFn = withUser(async ({ config, page, token }) => {
+  const { testUrl } = config
+
   await page.goto(testUrl)
   await signIntoTerra(page, token)
   await fillIn(page, input({ labelContains: 'First Name' }), 'Integration')

--- a/integration-tests/tests/run-workflow.js
+++ b/integration-tests/tests/run-workflow.js
@@ -1,5 +1,4 @@
 const pRetry = require('p-retry')
-const { testUrl, workflowName, billingProject } = require('../utils/integration-config')
 const { withWorkspace, createEntityInWorkspace } = require('../utils/integration-helpers')
 const { click, clickable, findElement, input, signIntoTerra, waitForNoSpinners, findInGrid, navChild, findInDataTableRow } = require('../utils/integration-utils')
 
@@ -7,7 +6,9 @@ const { click, clickable, findElement, input, signIntoTerra, waitForNoSpinners, 
 const testEntity = { name: 'test_entity_1', entityType: 'test_entity', attributes: { input: 'foo' } }
 const findWorkflowButton = clickable({ textContains: 'Find a Workflow' })
 
-const testRunWorkflowFn = withWorkspace(async ({ page, workspaceName }) => {
+const testRunWorkflowFn = withWorkspace(async ({ config, page, workspaceName }) => {
+  const { testUrl, workflowName, billingProject } = config
+
   await page.goto(testUrl)
   await signIntoTerra(page)
 

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -1,11 +1,11 @@
-const { billingProject, testUrl } = require('./integration-config')
 const { delay, signIntoTerra } = require('./integration-utils')
 const { fetchLyle } = require('./lyle-utils')
 
 
 const defaultTimeout = 5 * 60 * 1000
 
-const makeWorkspace = async ({ context }) => {
+const makeWorkspace = async ({ config, context }) => {
+  const { billingProject, testUrl } = config
   const ajaxPage = await context.newPage()
 
   await ajaxPage.goto(testUrl)
@@ -26,7 +26,8 @@ const makeWorkspace = async ({ context }) => {
   return workspaceName
 }
 
-const deleteWorkspace = async ({ context, workspaceName }) => {
+const deleteWorkspace = async ({ config, context, workspaceName }) => {
+  const { billingProject, testUrl } = config
   const ajaxPage = await context.newPage()
 
   await ajaxPage.goto(testUrl)
@@ -41,13 +42,13 @@ const deleteWorkspace = async ({ context, workspaceName }) => {
   await ajaxPage.close()
 }
 
-const withWorkspace = test => async ({ context, ...args }) => {
-  const workspaceName = await makeWorkspace({ context })
+const withWorkspace = testFn => async options => {
+  const workspaceName = await makeWorkspace(options)
 
   try {
-    await test({ context, ...args, workspaceName })
+    await testFn({ ...options, workspaceName })
   } finally {
-    await deleteWorkspace({ context, workspaceName })
+    await deleteWorkspace({ ...options, workspaceName })
   }
 }
 
@@ -64,11 +65,11 @@ const makeUser = async () => {
   return { email, token }
 }
 
-const withUser = test => async args => {
+const withUser = test => async options => {
   const { email, token } = await makeUser()
 
   try {
-    await test({ ...args, email, token })
+    await test({ ...options, email, token })
   } finally {
     await fetchLyle('delete', email)
   }


### PR DESCRIPTION
Note: DRAFT. There are still a couple of references to global config that I missed.

Related to (but does not complete) https://broadworkbench.atlassian.net/browse/SATURN-1341. Will allow the service to dynamically point to different Terra deployments.