### PR TITLE
support displaying invalid cluster configs [SATURN-1344]

### DIFF
--- a/src/components/NewClusterModal.js
+++ b/src/components/NewClusterModal.js
@@ -207,7 +207,7 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
         workerMachineType: machineTypeConstraints,
         customEnvImage: isSelectedImageInputted ? { format: { pattern: imageValidationRegexp } } : {}
       },
-      { prettify: v => ({ customEnvImage: 'Container image' }[v] || validate.prettify(v)) }
+      { prettify: v => ({ customEnvImage: 'Container image', masterMachineType: 'Main CPU/memory', workerMachineType: 'Worker CPU/memory' }[v] || validate.prettify(v)) }
     )
 
     const makeGroupedEnvSelect = id => h(GroupedSelect, {

--- a/src/components/NewClusterModal.js
+++ b/src/components/NewClusterModal.js
@@ -478,7 +478,7 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
                   value: customEnvImage,
                   onChange: customEnvImage => this.setState({ customEnvImage })
                 },
-                error: Utils.summarizeErrors(customEnvImage && errors && errors.customEnvImage)
+                error: Utils.summarizeErrors(customEnvImage && errors?.customEnvImage)
               })
             ])
           }],

--- a/src/components/NewClusterModal.js
+++ b/src/components/NewClusterModal.js
@@ -447,7 +447,7 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
                         value: customEnvImage,
                         onChange: customEnvImage => this.setState({ customEnvImage })
                       },
-                      error: Utils.summarizeErrors(customEnvImage && errors && errors.customEnvImage)
+                      error: Utils.summarizeErrors(customEnvImage && errors?.customEnvImage)
                     })
                   ])
                 ])

--- a/src/components/NewClusterModal.js
+++ b/src/components/NewClusterModal.js
@@ -10,11 +10,12 @@ import { InfoBox } from 'src/components/PopupTrigger'
 import TitleBar from 'src/components/TitleBar'
 import { machineTypes, profiles } from 'src/data/clusters'
 import { Ajax } from 'src/libs/ajax'
-import { deleteText, machineConfigCost, normalizeMachineConfig } from 'src/libs/cluster-utils'
+import { deleteText, findMachineType, machineConfigCost, normalizeMachineConfig } from 'src/libs/cluster-utils'
 import colors from 'src/libs/colors'
 import { withErrorReporting } from 'src/libs/error'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
+import validate from 'validate.js'
 
 
 const styles = {
@@ -41,8 +42,10 @@ const machineConfigsEqual = (a, b) => {
 // distilled from https://github.com/docker/distribution/blob/95daa793b83a21656fe6c13e6d5cf1c3999108c7/reference/regexp.go
 const imageValidationRegexp = /^[A-Za-z0-9]+[\w./-]+(?::\w[\w.-]+)?(?:@[\w+.-]+:[A-Fa-f0-9]{32,})?$/
 
+const validMachineTypes = _.filter(({ memory }) => memory >= 4, machineTypes)
+
 const MachineSelector = ({ machineType, onChangeMachineType, diskSize, onChangeDiskSize, readOnly }) => {
-  const { cpu: currentCpu, memory: currentMemory } = _.find({ name: machineType }, machineTypes)
+  const { cpu: currentCpu, memory: currentMemory } = findMachineType(machineType)
   return h(Fragment, [
     h(IdContainer, [
       id => h(Fragment, [
@@ -53,8 +56,8 @@ const MachineSelector = ({ machineType, onChangeMachineType, diskSize, onChangeD
               id,
               isSearchable: false,
               value: currentCpu,
-              onChange: ({ value }) => onChangeMachineType(_.find({ cpu: value }, machineTypes).name),
-              options: _.uniq(_.map('cpu', machineTypes))
+              onChange: ({ value }) => onChangeMachineType(_.find({ cpu: value }, validMachineTypes)?.name || machineType),
+              options: _.flow(_.map('cpu'), _.union([currentCpu]), _.sortBy(_.identity))(validMachineTypes)
             })
           ])
       ])
@@ -68,8 +71,8 @@ const MachineSelector = ({ machineType, onChangeMachineType, diskSize, onChangeD
               id,
               isSearchable: false,
               value: currentMemory,
-              onChange: ({ value }) => onChangeMachineType(_.find({ cpu: currentCpu, memory: value }, machineTypes).name),
-              options: _.map('memory', _.sortBy('memory', _.filter({ cpu: currentCpu }, machineTypes)))
+              onChange: ({ value }) => onChangeMachineType(_.find({ cpu: currentCpu, memory: value }, validMachineTypes)?.name || machineType),
+              options: _.flow(_.filter({ cpu: currentCpu }), _.map('memory'), _.union([currentMemory]), _.sortBy(_.identity))(validMachineTypes)
             })
           ])
       ])
@@ -194,8 +197,18 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
       options: _.map(({ label, image }) => ({ label, value: image }), leoImages)
     })
 
-    const isCustomImageInvalid = !imageValidationRegexp.test(customEnvImage)
     const isSelectedImageInputted = selectedLeoImage === CUSTOM_MODE || selectedLeoImage === PROJECT_SPECIFIC_MODE
+
+    const machineTypeConstraints = { inclusion: { within: _.map('name', validMachineTypes), message: 'is not supported' } }
+    const errors = validate(
+      { masterMachineType, workerMachineType, customEnvImage },
+      {
+        masterMachineType: machineTypeConstraints,
+        workerMachineType: machineTypeConstraints,
+        customEnvImage: isSelectedImageInputted ? { format: { pattern: imageValidationRegexp } } : {}
+      },
+      { prettify: v => ({ customEnvImage: 'Container image' }[v] || validate.prettify(v)) }
+    )
 
     const makeGroupedEnvSelect = id => h(GroupedSelect, {
       id,
@@ -224,8 +237,8 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
         div({ style: { flex: 1 } }),
         h(ButtonSecondary, { style: { marginRight: '2rem' }, onClick: onDismiss }, 'Cancel'),
         h(ButtonPrimary, {
-          disabled: isSelectedImageInputted && isCustomImageInvalid,
-          tooltip: isSelectedImageInputted && isCustomImageInvalid && 'Enter a valid docker image to use',
+          disabled: !!errors,
+          tooltip: Utils.summarizeErrors(errors),
           onClick: () => {
             if (isSelectedImageInputted) {
               this.setState({ viewMode: 'warning' })
@@ -434,7 +447,7 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
                         value: customEnvImage,
                         onChange: customEnvImage => this.setState({ customEnvImage })
                       },
-                      error: customEnvImage && isCustomImageInvalid && 'Not a valid image'
+                      error: Utils.summarizeErrors(customEnvImage && errors && errors.customEnvImage)
                     })
                   ])
                 ])
@@ -465,7 +478,7 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
                   value: customEnvImage,
                   onChange: customEnvImage => this.setState({ customEnvImage })
                 },
-                error: customEnvImage && isCustomImageInvalid && 'Not a valid image'
+                error: Utils.summarizeErrors(customEnvImage && errors && errors.customEnvImage)
               })
             ])
           }],

--- a/src/data/clusters.js
+++ b/src/data/clusters.js
@@ -1,6 +1,5 @@
 export const machineTypes = [
-  // disabled configs have insufficient memory
-  // { name: 'n1-standard-1', cpu: 1, memory: 3.75, price: 0.0475, preemptiblePrice: 0.0100 },
+  { name: 'n1-standard-1', cpu: 1, memory: 3.75, price: 0.0475, preemptiblePrice: 0.0100 },
   { name: 'n1-standard-2', cpu: 2, memory: 7.50, price: 0.0950, preemptiblePrice: 0.0200 },
   { name: 'n1-standard-4', cpu: 4, memory: 15, price: 0.1900, preemptiblePrice: 0.0400 },
   { name: 'n1-standard-8', cpu: 8, memory: 30, price: 0.3800, preemptiblePrice: 0.0800 },
@@ -15,8 +14,8 @@ export const machineTypes = [
   { name: 'n1-highmem-32', cpu: 32, memory: 208, price: 1.8944, preemptiblePrice: 0.4000 },
   { name: 'n1-highmem-64', cpu: 64, memory: 416, price: 3.7888, preemptiblePrice: 0.8000 },
   { name: 'n1-highmem-96', cpu: 96, memory: 624, price: 5.6832, preemptiblePrice: 1.2000 },
-  // { name: 'n1-highcpu-2', cpu: 2, memory: 1.8, price: 0.0709, preemptiblePrice: 0.0150 },
-  // { name: 'n1-highcpu-4', cpu: 4, memory: 3.6, price: 0.1418, preemptiblePrice: 0.0300 },
+  { name: 'n1-highcpu-2', cpu: 2, memory: 1.8, price: 0.0709, preemptiblePrice: 0.0150 },
+  { name: 'n1-highcpu-4', cpu: 4, memory: 3.6, price: 0.1418, preemptiblePrice: 0.0300 },
   { name: 'n1-highcpu-8', cpu: 8, memory: 7.2, price: 0.2836, preemptiblePrice: 0.0600 },
   { name: 'n1-highcpu-16', cpu: 16, memory: 14.4, price: 0.5672, preemptiblePrice: 0.1200 },
   { name: 'n1-highcpu-32', cpu: 32, memory: 28.8, price: 1.1344, preemptiblePrice: 0.2400 },

--- a/src/libs/cluster-utils.js
+++ b/src/libs/cluster-utils.js
@@ -22,10 +22,14 @@ const machineStorageCost = config => {
   return (masterDiskSize + numberOfWorkers * workerDiskSize) * storagePrice
 }
 
+export const findMachineType = name => {
+  return _.find({ name }, machineTypes) || { name, cpu: '?', memory: '?', price: NaN, preemptiblePrice: NaN }
+}
+
 export const machineConfigCost = config => {
   const { masterMachineType, numberOfWorkers, numberOfPreemptibleWorkers, workerMachineType } = normalizeMachineConfig(config)
-  const { price: masterPrice } = _.find({ name: masterMachineType }, machineTypes)
-  const { price: workerPrice, preemptiblePrice } = _.find({ name: workerMachineType }, machineTypes)
+  const { price: masterPrice } = findMachineType(masterMachineType)
+  const { price: workerPrice, preemptiblePrice } = findMachineType(workerMachineType)
   return _.sum([
     masterPrice,
     (numberOfWorkers - numberOfPreemptibleWorkers) * workerPrice,

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -95,7 +95,8 @@ export const makeStandardDate = dateString => dateFormat.format(new Date(dateStr
 
 export const makeCompleteDate = dateString => completeDateFormat.format(new Date(dateString))
 
-export const formatUSD = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format
+const usdFormatter = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' })
+export const formatUSD = v => _.isNaN(v) ? 'unknown' : usdFormatter.format(v)
 
 export const formatNumber = new Intl.NumberFormat('en-US').format
 


### PR DESCRIPTION
This makes the cluster code generally resilient to unknown or invalid machine types, to avoid crashing when dealing with e.g. clusters with no-longer-supported configurations. There are two main parts:

* The data for unsupported `n1-standard` machines has been uncommented, so we can correctly display and calculate cost for any remaining clusters that have these types. There is new validation logic to prevent trying to create new clusters with these types.
* Completely unknown machine types (which may be possible to create via the API) are populated with stub values, so they display values like '?' or 'unknown' when showing statistics like cost.

This also slightly changes the other validation language in the new cluster modal.

Tested locally by simulating unknown machine types and trying various flows.
