### PR TITLE
Try to make integration tests less flaky

### DIFF
--- a/integration-tests/tests/find-workflow.js
+++ b/integration-tests/tests/find-workflow.js
@@ -1,12 +1,13 @@
 const firecloud = require('../utils/firecloud-utils')
 const { billingProject, testUrl, workflowName } = require('../utils/integration-config')
 const { withWorkspace } = require('../utils/integration-helpers')
-const { click, clickable, findElement, findText, signIntoTerra } = require('../utils/integration-utils')
+const { click, clickable, dismissNotifications, findElement, findText, signIntoTerra } = require('../utils/integration-utils')
 
 
 const testFindWorkflowFn = withWorkspace(async ({ page, workspaceName }) => {
   await page.goto(testUrl)
   await signIntoTerra(page)
+  await dismissNotifications(page)
   await click(page, clickable({ textContains: 'View Examples' }))
   await click(page, clickable({ textContains: 'code & workflows' }))
   await click(page, clickable({ textContains: workflowName }))

--- a/integration-tests/tests/import-cohort-data.js
+++ b/integration-tests/tests/import-cohort-data.js
@@ -1,6 +1,6 @@
 const { testUrl } = require('../utils/integration-config')
 const { withWorkspace } = require('../utils/integration-helpers')
-const { findInGrid, click, clickable, fillIn, findIframe, input, signIntoTerra, select, svgText, waitForNoSpinners, findElement } = require('../utils/integration-utils')
+const { findInGrid, click, clickable, dismissNotifications, fillIn, findIframe, input, signIntoTerra, select, svgText, waitForNoSpinners, findElement } = require('../utils/integration-utils')
 
 
 const cohortName = `terra-ui-test-cohort`
@@ -8,6 +8,7 @@ const cohortName = `terra-ui-test-cohort`
 const testImportCohortDataFn = withWorkspace(async ({ page, workspaceName }) => {
   await page.goto(testUrl)
   await signIntoTerra(page)
+  await dismissNotifications(page)
   await click(page, clickable({ textContains: 'Browse Data' }))
   await click(page, clickable({ textContains: '1000 Genomes Low Coverage' }))
 

--- a/integration-tests/tests/import-dockstore-workflow.js
+++ b/integration-tests/tests/import-dockstore-workflow.js
@@ -1,7 +1,7 @@
 const fetch = require('node-fetch')
 const { testUrl } = require('../utils/integration-config')
 const { withWorkspace } = require('../utils/integration-helpers')
-const { click, clickable, findText, select, signIntoTerra } = require('../utils/integration-utils')
+const { click, clickable, dismissNotifications, findText, select, signIntoTerra } = require('../utils/integration-utils')
 
 
 const testWorkflowIdentifier = 'github.com/DataBiosphere/topmed-workflows/UM_variant_caller_wdl:1.32.0'
@@ -15,6 +15,7 @@ const testImportDockstoreWorkflowFn = async ({ context, page }) => {
     await withWorkspace(async ({ workspaceName }) => {
       await page.goto(`${testUrl}/#import-tool/dockstore/${testWorkflowIdentifier}`)
       await signIntoTerra(page)
+      await dismissNotifications(page)
       await findText(page, 'workflow TopMedVariantCaller')
       await select(page, 'Select a workspace', workspaceName)
       await click(page, clickable({ text: 'Import' }))

--- a/integration-tests/tests/register-user.js
+++ b/integration-tests/tests/register-user.js
@@ -1,11 +1,12 @@
 const { testUrl } = require('../utils/integration-config')
 const { withUser } = require('../utils/integration-helpers')
-const { findText, click, clickable, fillIn, input, signIntoTerra, waitForNoSpinners } = require('../utils/integration-utils')
+const { findText, click, clickable, dismissNotifications, fillIn, input, signIntoTerra, waitForNoSpinners } = require('../utils/integration-utils')
 
 
 const testRegisterUserFn = withUser(async ({ page, token }) => {
   await page.goto(testUrl)
   await signIntoTerra(page, token)
+  await dismissNotifications(page)
   await fillIn(page, input({ labelContains: 'First Name' }), 'Integration')
   await fillIn(page, input({ labelContains: 'Last Name' }), 'Test')
   await click(page, clickable({ textContains: 'Register' }))

--- a/integration-tests/tests/run-workflow.js
+++ b/integration-tests/tests/run-workflow.js
@@ -1,7 +1,7 @@
 const pRetry = require('p-retry')
 const { testUrl, workflowName, billingProject } = require('../utils/integration-config')
 const { withWorkspace, createEntityInWorkspace } = require('../utils/integration-helpers')
-const { click, clickable, findElement, input, signIntoTerra, waitForNoSpinners, findInGrid, navChild, findInDataTableRow } = require('../utils/integration-utils')
+const { click, clickable, dismissNotifications, findElement, input, signIntoTerra, waitForNoSpinners, findInGrid, navChild, findInDataTableRow } = require('../utils/integration-utils')
 
 
 const testEntity = { name: 'test_entity_1', entityType: 'test_entity', attributes: { input: 'foo' } }
@@ -10,6 +10,7 @@ const findWorkflowButton = clickable({ textContains: 'Find a Workflow' })
 const testRunWorkflowFn = withWorkspace(async ({ page, workspaceName }) => {
   await page.goto(testUrl)
   await signIntoTerra(page)
+  await dismissNotifications(page)
 
   await createEntityInWorkspace(page, billingProject, workspaceName, testEntity)
 

--- a/integration-tests/tests/run-workflow.js
+++ b/integration-tests/tests/run-workflow.js
@@ -43,7 +43,7 @@ const testRunWorkflowFn = withWorkspace(async ({ page, workspaceName }) => {
     } catch (e) {
       throw new Error(e)
     }
-  }, { retries: 5, factor: 1 })
+  }, { retries: 10, factor: 1 })
 
   await click(page, navChild('data'))
   await click(page, clickable({ textContains: 'test_entity' }))
@@ -53,7 +53,7 @@ const testRunWorkflowFn = withWorkspace(async ({ page, workspaceName }) => {
 const testRunWorkflow = {
   name: 'run workflow',
   fn: testRunWorkflowFn,
-  timeout: 10 * 60 * 1000
+  timeout: 15 * 60 * 1000
 }
 
 module.exports = { testRunWorkflow }

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -72,10 +72,23 @@ const delay = ms => {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
 
+const dismissNotifications = async page => {
+  if (await findElement(page, clickable({ text: 'Dismiss notification' }))) {
+    const notificationCloseButtons = await page.$x(clickable({ text: 'Dismiss notification' }))
+
+    return Promise.all(
+      notificationCloseButtons.map(handle => handle.click())
+    )
+  }
+}
+
 const signIntoTerra = async (page, token = bearerToken) => {
   await page.waitForXPath('//*[contains(normalize-space(.),"Loading Terra")]', { hidden: true })
   await waitForNoSpinners(page)
-  return page.evaluate(token => window.forceSignIn(token), token)
+  await page.evaluate(token => window.forceSignIn(token), token)
+  await delay(3000)
+  await dismissNotifications(page)
+  return delay(1000)
 }
 
 const findElement = (page, xpath) => {
@@ -97,6 +110,7 @@ const findInDataTableRow = (page, entityName, text) => {
 module.exports = {
   click,
   clickable,
+  dismissNotifications,
   findIframe,
   findInGrid,
   findElement,

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -73,22 +73,20 @@ const delay = ms => {
 }
 
 const dismissNotifications = async page => {
-  if (await findElement(page, clickable({ text: 'Dismiss notification' }))) {
-    const notificationCloseButtons = await page.$x(clickable({ text: 'Dismiss notification' }))
+  const notificationCloseButtons = await page.$x(clickable({ text: 'Dismiss notification' }))
 
-    return Promise.all(
-      notificationCloseButtons.map(handle => handle.click())
-    )
-  }
+  return Promise.all(
+    notificationCloseButtons.map(handle => handle.click())
+  )
 }
 
 const signIntoTerra = async (page, token = bearerToken) => {
   await page.waitForXPath('//*[contains(normalize-space(.),"Loading Terra")]', { hidden: true })
   await waitForNoSpinners(page)
   await page.evaluate(token => window.forceSignIn(token), token)
-  await delay(3000)
+  await delay(3000) // delayed for any alerts to show
   await dismissNotifications(page)
-  return delay(1000)
+  return delay(1000) // delayed for alerts to animate off
 }
 
 const findElement = (page, xpath) => {

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -73,20 +73,20 @@ const delay = ms => {
 }
 
 const dismissNotifications = async page => {
+  await delay(3000) // delayed for any alerts to show
   const notificationCloseButtons = await page.$x(clickable({ text: 'Dismiss notification' }))
 
-  return Promise.all(
+  await Promise.all(
     notificationCloseButtons.map(handle => handle.click())
   )
+
+  return !!notificationCloseButtons.length && delay(1000) // delayed for alerts to animate off
 }
 
 const signIntoTerra = async (page, token = bearerToken) => {
   await page.waitForXPath('//*[contains(normalize-space(.),"Loading Terra")]', { hidden: true })
   await waitForNoSpinners(page)
   await page.evaluate(token => window.forceSignIn(token), token)
-  await delay(3000) // delayed for any alerts to show
-  await dismissNotifications(page)
-  return delay(1000) // delayed for alerts to animate off
 }
 
 const findElement = (page, xpath) => {

--- a/src/components/Notifications.js
+++ b/src/components/Notifications.js
@@ -99,6 +99,7 @@ const NotificationDisplay = Utils.connectStore(notificationStore, 'notificationS
           }, ['Details'])
         ]),
         h(Clickable, {
+          'aria-label': 'Dismiss notification',
           title: 'Dismiss notification',
           onClick: () => store.removeNotification(id)
         }, [icon('times', { size: 20 })])


### PR DESCRIPTION
Hopefully fixes the notification issue that blocks on screen clickable things
- decided to dismiss all notifications immediately after login as these will be non-error type notifications at that time

Also adjusted the run-workflow time to be longer to test how circleCi will handle that for the tests tonight. Will go back and investigate if that's best solution
