### PR TITLE
Don't fail to show error message because of unexpected JSON

### DIFF
--- a/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
+++ b/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
@@ -194,7 +194,7 @@ export default ajaxCaller(class LaunchAnalysisModal extends Component {
       const { submissionId } = await this.baseLaunch(entityType, entityName, expression)
       onSuccess(submissionId)
     } catch (error) {
-      this.setState({ launchError: JSON.parse(await error.text()).message, message: undefined })
+      this.setState({ launchError: await error.text(), message: undefined })
     }
   }
 


### PR DESCRIPTION
This would have given us a better failure screenshot for the missing `deleteIntermediateOutputFiles` option error.