### PR TITLE
remove table virtualization from workflow inputs

### DIFF
--- a/src/components/Dropzone.js
+++ b/src/components/Dropzone.js
@@ -9,6 +9,9 @@ const Dropzone = ({ disabled = false, onDragOver, onDrop, onDragLeave, style = {
 
   const { getRootProps, getInputProps, open: openUploader, ...dropProps } = useDropzone({
     noClick: true,
+    // Due to some sloppy internal state management, the keyboard handlers cause
+    // re-renders on every focus/blur, which causes performance problems on some pages.
+    noKeyboard: true,
     disabled,
     onDragOver: e => {
       setDragging(true)

--- a/src/components/input.js
+++ b/src/components/input.js
@@ -216,7 +216,11 @@ export const AutocompleteTextInput = ({ value, onChange, suggestions: rawSuggest
 
   return h(Downshift, {
     selectedItem: value,
-    onInputValueChange: onChange,
+    onInputValueChange: newValue => {
+      if (newValue !== value) {
+        onChange(newValue)
+      }
+    },
     inputId: id
   }, [
     ({ getInputProps, getMenuProps, getItemProps, isOpen, openMenu, toggleMenu, highlightedIndex }) => {

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -263,10 +263,10 @@ export class FlexTable extends Component {
 
 /**
  * A basic table with a header and flexible column widths. Intended for small amounts of data,
- * since it does not provide scrolling.
+ * since it does not provide scrolling. See FlexTable for prop types.
  */
 export const SimpleFlexTable = ({ columns, rowCount, noContentMessage, hoverHighlight }) => {
-  return div([
+  return h(Fragment, [
     div({ style: { height: 48, display: 'flex' } }, [
       _.map(([i, { size, headerRenderer }]) => {
         return div({

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -262,6 +262,41 @@ export class FlexTable extends Component {
 }
 
 /**
+ * A basic table with a header and flexible column widths. Intended for small amounts of data,
+ * since it does not provide scrolling.
+ */
+export const SimpleFlexTable = ({ columns, rowCount, noContentMessage, hoverHighlight }) => {
+  return div([
+    div({ style: { height: 48, display: 'flex' } }, [
+      _.map(([i, { size, headerRenderer }]) => {
+        return div({
+          key: i,
+          style: { ...styles.flexCell(size), ...styles.header(i * 1, columns.length) }
+        }, [headerRenderer()])
+      }, Utils.toIndexPairs(columns))
+    ]),
+    _.map(rowIndex => {
+      return h(Interactive, {
+        key: rowIndex,
+        as: 'div',
+        className: 'table-row',
+        style: { backgroundColor: 'white', display: 'flex', minHeight: 48 },
+        hover: hoverHighlight ? { backgroundColor: colors.light(0.4) } : undefined
+      }, [
+        _.map(([i, { size, cellRenderer }]) => {
+          return div({
+            key: i,
+            className: 'table-cell',
+            style: { ...styles.flexCell(size), ...styles.cell(i * 1, columns.length) }
+          }, [cellRenderer({ rowIndex })])
+        }, Utils.toIndexPairs(columns))
+      ])
+    }, _.range(0, rowCount)),
+    !rowCount && div({ style: { marginTop: '1rem', textAlign: 'center', fontStyle: 'italic' } }, [noContentMessage])
+  ])
+}
+
+/**
  * A virtual table with a fixed header and explicit column widths. Intended for displaying large
  * datasets which may require horizontal scrolling.
  */


### PR DESCRIPTION
This converts the workflow IO table into a non-virtualized one. This will enable better handling of multi-line inputs, which will be coming up in a separate PR. Based on a sampling of existing workflows, we don't expect a large number of inputs, so this shouldn't be a performance concern.

Because the new table is not height-constrained, it will not scroll internally, which changes the UX of the page. However, users reported being confused by the internal scrolling, so this should be an improvement.

This PR also fixes a minor visual issue with the file selector button.

Tested locally by interacting with the table.