### PR TITLE
add metrics events [SATURN-1270] [SATURN-1271] [SATURN-1273] [SATURN-1274]

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1088,7 +1088,7 @@ const Duos = signal => ({
 })
 
 const Metrics = signal => ({
-  captureEvent: withErrorIgnoring((event, details) => {
+  captureEvent: withErrorIgnoring((event, details = {}) => {
     const body = {
       event,
       data: {

--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -1,3 +1,5 @@
 export default {
-  workspaceShare: 'workspace:share'
+  workspaceShare: 'workspace:share',
+  workflowImportDockstore: 'workflow:import:dockstore',
+  workflowImportWorkspace: 'workflow:import:workspace'
 }

--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -1,5 +1,8 @@
 export default {
-  workspaceShare: 'workspace:share',
-  workflowImportDockstore: 'workflow:import:dockstore',
-  workflowImportWorkspace: 'workflow:import:workspace'
+  applicationLaunch: 'application:launch',
+  notebookLaunch: 'notebook:launch',
+  workflowImport: 'workflow:import',
+  workflowLaunch: 'workflow:launch',
+  workspaceDataImport: 'workspace:data:import',
+  workspaceShare: 'workspace:share'
 }

--- a/src/pages/ImportData.js
+++ b/src/pages/ImportData.js
@@ -13,6 +13,7 @@ import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { getConfig } from 'src/libs/config'
 import { withErrorReporting } from 'src/libs/error'
+import Events from 'src/libs/events'
 import * as Nav from 'src/libs/nav'
 import { pfbImportJobStore } from 'src/libs/state'
 import * as Style from 'src/libs/style'
@@ -106,6 +107,7 @@ const ImportData = () => {
         notify('success', 'Data imported successfully.', { timeout: 3000 })
       }]
     )
+    Ajax().Metrics.captureEvent(Events.workspaceDataImport)
     Nav.goToPath('workspace-data', { namespace, name })
   })
 

--- a/src/pages/ImportWorkflow.js
+++ b/src/pages/ImportWorkflow.js
@@ -116,11 +116,11 @@ const DockstoreImporter = ajaxCaller(class DockstoreImporter extends Component {
           methodVersion: version
         }
       })
-      Ajax().Metrics.captureEvent(Events.workflowImportDockstore, { success: true })
+      Ajax().Metrics.captureEvent(Events.workflowImport, { success: true, source: 'dockstore' })
       Nav.goToPath('workflow', { namespace, name, workflowNamespace: namespace, workflowName })
     } catch (error) {
       reportError('Error importing workflow', error)
-      Ajax().Metrics.captureEvent(Events.workflowImportDockstore, { success: false })
+      Ajax().Metrics.captureEvent(Events.workflowImport, { success: false, source: 'dockstore' })
     } finally {
       this.setState({ isImporting: false })
     }

--- a/src/pages/ImportWorkflow.js
+++ b/src/pages/ImportWorkflow.js
@@ -11,6 +11,7 @@ import importBackground from 'src/images/hex-import-background.svg'
 import { Ajax, ajaxCaller } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { reportError } from 'src/libs/error'
+import Events from 'src/libs/events'
 import * as Nav from 'src/libs/nav'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
@@ -115,9 +116,11 @@ const DockstoreImporter = ajaxCaller(class DockstoreImporter extends Component {
           methodVersion: version
         }
       })
+      Ajax().Metrics.captureEvent(Events.workflowImportDockstore, { success: true })
       Nav.goToPath('workflow', { namespace, name, workflowNamespace: namespace, workflowName })
     } catch (error) {
       reportError('Error importing workflow', error)
+      Ajax().Metrics.captureEvent(Events.workflowImportDockstore, { success: false })
     } finally {
       this.setState({ isImporting: false })
     }

--- a/src/pages/workspaces/workspace/Workflows.js
+++ b/src/pages/workspaces/workspace/Workflows.js
@@ -15,6 +15,7 @@ import { Ajax, ajaxCaller } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { getConfig } from 'src/libs/config'
 import { reportError } from 'src/libs/error'
+import Events from 'src/libs/events'
 import * as Nav from 'src/libs/nav'
 import * as StateHistory from 'src/libs/state-history'
 import * as Style from 'src/libs/style'
@@ -261,9 +262,11 @@ const FindWorkflowModal = ajaxCaller(class FindWorkflowModal extends Component {
 
       const { namespace: workflowNamespace, name: workflowName } = config || selectedWorkflow
 
+      Ajax().Metrics.captureEvent(Events.workflowImportWorkspace, { success: true })
       Nav.goToPath('workflow', { namespace, name, workflowNamespace, workflowName })
     } catch (error) {
       reportError('Error importing workflow', error)
+      Ajax().Metrics.captureEvent(Events.workflowImportWorkspace, { success: false })
       this.setState({ exporting: false })
     }
   }

--- a/src/pages/workspaces/workspace/Workflows.js
+++ b/src/pages/workspaces/workspace/Workflows.js
@@ -262,11 +262,11 @@ const FindWorkflowModal = ajaxCaller(class FindWorkflowModal extends Component {
 
       const { namespace: workflowNamespace, name: workflowName } = config || selectedWorkflow
 
-      Ajax().Metrics.captureEvent(Events.workflowImportWorkspace, { success: true })
+      Ajax().Metrics.captureEvent(Events.workflowImport, { success: true, source: 'repo' })
       Nav.goToPath('workflow', { namespace, name, workflowNamespace, workflowName })
     } catch (error) {
       reportError('Error importing workflow', error)
-      Ajax().Metrics.captureEvent(Events.workflowImportWorkspace, { success: false })
+      Ajax().Metrics.captureEvent(Events.workflowImport, { success: false, source: 'repo' })
       this.setState({ exporting: false })
     }
   }

--- a/src/pages/workspaces/workspace/applications/AppLauncher.js
+++ b/src/pages/workspaces/workspace/applications/AppLauncher.js
@@ -7,6 +7,7 @@ import { Link, spinnerOverlay } from 'src/components/common'
 import { NewClusterModal } from 'src/components/NewClusterModal'
 import { Ajax } from 'src/libs/ajax'
 import { withErrorReporting } from 'src/libs/error'
+import Events from 'src/libs/events'
 import * as Nav from 'src/libs/nav'
 import * as Utils from 'src/libs/utils'
 import { wrapWorkspace } from 'src/pages/workspaces/workspace/WorkspaceContainer'
@@ -32,6 +33,7 @@ const AppLauncher = _.flow(
       onClusterStartedRunning: async () => {
         await Ajax().Clusters.notebooks(namespace, clusterName).setCookie()
         setCookieReady(true)
+        Ajax().Metrics.captureEvent(Events.applicationLaunch, { app })
       },
       onClusterStoppedRunning: () => setCookieReady(false)
     }),

--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -19,6 +19,7 @@ import { dataSyncingDocUrl } from 'src/data/clusters'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { withErrorReporting } from 'src/libs/error'
+import Events from 'src/libs/events'
 import * as Nav from 'src/libs/nav'
 import { getLocalPref, setLocalPref } from 'src/libs/prefs'
 import { authStore } from 'src/libs/state'
@@ -343,6 +344,8 @@ const NotebookPreviewFrame = ({ notebookName, workspace: { workspace: { namespac
 
 const JupyterFrameManager = ({ onClose, frameRef }) => {
   Utils.useOnMount(() => {
+    Ajax().Metrics.captureEvent(Events.notebookLaunch)
+
     const isSaved = Utils.atom(true)
     const onMessage = e => {
       switch (e.data) {

--- a/src/pages/workspaces/workspace/workflows/FailureRerunner.js
+++ b/src/pages/workspaces/workspace/workflows/FailureRerunner.js
@@ -7,6 +7,7 @@ import { Ajax } from 'src/libs/ajax'
 import { launch } from 'src/libs/analysis'
 import colors from 'src/libs/colors'
 import { reportError } from 'src/libs/error'
+import Events from 'src/libs/events'
 import { rerunFailuresStatus } from 'src/libs/state'
 import * as Utils from 'src/libs/utils'
 
@@ -60,9 +61,11 @@ export const rerunFailures = async ({ namespace, name, submissionId, configNames
         reportError('Error rerunning failed workflows', error)
       }
     })
+    Ajax().Metrics.captureEvent(Events.workflowLaunch, { rerun: true, success: true })
 
     await Utils.delay(2000)
   } catch (error) {
+    Ajax().Metrics.captureEvent(Events.workflowLaunch, { rerun: true, success: false })
     reportError('Error rerunning failed workflows', error)
   } finally {
     clearNotification(id)

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -21,6 +21,7 @@ import WDLViewer from 'src/components/WDLViewer'
 import { Ajax, ajaxCaller } from 'src/libs/ajax'
 import colors, { terraSpecial } from 'src/libs/colors'
 import { reportError, withErrorReporting } from 'src/libs/error'
+import Events from 'src/libs/events'
 import * as Nav from 'src/libs/nav'
 import { workflowSelectionStore } from 'src/libs/state'
 import * as StateHistory from 'src/libs/state-history'
@@ -414,8 +415,14 @@ const WorkflowView = _.flow(
           accessLevel: workspace.accessLevel, bucketName: workspace.workspace.bucketName,
           processSingle: this.isSingle(), entitySelectionModel, useCallCache,
           onDismiss: () => this.setState({ launching: false }),
-          onSuccess: submissionId => Nav.goToPath('workspace-submission-details', { submissionId, ...workspaceId }),
-          onSuccessMulti: () => Nav.goToPath('workspace-job-history', workspaceId)
+          onSuccess: submissionId => {
+            Ajax().Metrics.captureEvent(Events.workflowLaunch, { multi: false })
+            Nav.goToPath('workspace-submission-details', { submissionId, ...workspaceId })
+          },
+          onSuccessMulti: () => {
+            Ajax().Metrics.captureEvent(Events.workflowLaunch, { multi: true })
+            Nav.goToPath('workspace-job-history', workspaceId)
+          }
         }),
         variableSelected && h(BucketContentModal, {
           workspace,


### PR DESCRIPTION
All verified in-browser.
New events and params:
- `application:launch`: `app` terminal/RStudio
- `notebook:launch`
- `workflow:import`: `success` true/false, `source` dockstore/repo
- `workflow:launch`: {`multi` true/false} or {`rerun` true, `success` true/false}
- `workspace:data:import`
