### PR TITLE
Fix reference to possible undefined [SATURN-1437]

### DIFF
--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -136,7 +136,7 @@ const deleteCluster = withUserToken(async ({ email, token }) => {
   await signIntoTerra(ajaxPage, token)
 
   const currentC = await getCurrentCluster()
-  await ajaxPage.evaluate((currentC, email, billingProject) => {
+  currentC || await ajaxPage.evaluate((currentC, email, billingProject) => {
     return window.Ajax().Clusters.cluster(billingProject, currentC.clusterName).delete()
   }, currentC, email, billingProject)
 

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -136,7 +136,7 @@ const deleteCluster = withUserToken(async ({ email, token }) => {
   await signIntoTerra(ajaxPage, token)
 
   const currentC = await getCurrentCluster()
-  currentC || await ajaxPage.evaluate((currentC, email, billingProject) => {
+  await ajaxPage.evaluate((currentC, email, billingProject) => {
     return window.Ajax().Clusters.cluster(billingProject, currentC.clusterName).delete()
   }, currentC, email, billingProject)
 

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -534,7 +534,7 @@ const WorkflowView = _.flow(
       [type === processMergedSet, () => `${rootEntityType}s from ${count} sets ${newSetMessage}`],
       [type === chooseRows, () => `${count} selected ${rootEntityType}s ${newSetMessage}`],
       [type === chooseSetComponents, () => `1 ${rootEntityType} containing ${count} ${baseEntityType}s ${newSetMessage}`],
-      [type === processAllAsSet, () => `1 ${rootEntityType} containing all ${entityMetadata[baseEntityType].count} ${baseEntityType}s ${newSetMessage}`],
+      [type === processAllAsSet, () => `1 ${rootEntityType} containing all ${entityMetadata[baseEntityType]?.count || 0} ${baseEntityType}s ${newSetMessage}`],
       [type === chooseSets, () => !!count ?
         `${count} selected ${rootEntityType}s` :
         `No ${rootEntityType}s selected`]


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/SATURN-1437

This affects cases where a workflow's root entity type is a set type and there are no entities of the base type in the workspace. I created an example of this and shared it with b.adm.firec:

https://bvdp-saturn-dev.appspot.com/#workspaces/general-dev-billing-account/breilly-2020-02-28

There are 2 workflows in this workspace. The one ending in "_set" throws this error on dev. This PR fixes the error.