### PR TITLE
Increase timeout for run-notebook test

### DIFF
--- a/integration-tests/tests/run-notebook.js
+++ b/integration-tests/tests/run-notebook.js
@@ -24,7 +24,7 @@ const testRunNotebookFn = withRegisteredUser(async ({ page, context, email, toke
     await select(page, 'ENVIRONMENT', 'Hail')
     await click(page, clickable({ text: 'Create' }))
     await findElement(page, clickable({ textContains: 'Creating' }))
-    await findElement(page, clickable({ textContains: 'Running' }), { timeout: 5 * 60 * 1000 })
+    await findElement(page, clickable({ textContains: 'Running' }), { timeout: 7 * 60 * 1000 })
 
     const frame = await findIframe(page)
     await fillIn(frame, '//textarea', 'print(123456789099876543210990+9876543219)')


### PR DESCRIPTION
The run-notebook integration test failed four times over the weekend. At least two cases look to be due to the time out not being long enough waiting for a runtime cluster instance to be running.
