### PR TITLE
fix warning bg color for accessibility [SATURN-1320]

### DIFF
--- a/src/libs/data-utils.js
+++ b/src/libs/data-utils.js
@@ -26,7 +26,7 @@ import validate from 'validate.js'
 const warningBoxStyle = {
   backgroundColor: colors.warning(0.15),
   padding: '1rem 1.25rem',
-  color: colors.dark(), fontWeight: 'bold', fontSize: 12
+  color: colors.dark(1) , fontWeight: 'bold', fontSize: 12
 }
 
 const errorTextStyle = { color: colors.danger(), fontWeight: 'bold', fontSize: 12, marginTop: '0.5rem' }

--- a/src/libs/data-utils.js
+++ b/src/libs/data-utils.js
@@ -24,9 +24,9 @@ import validate from 'validate.js'
 
 
 const warningBoxStyle = {
-  backgroundColor: colors.warning(1),
+  backgroundColor: colors.warning(0.15),
   padding: '1rem 1.25rem',
-  color: colors.light(1), fontWeight: 'bold', fontSize: 12
+  color: colors.dark(), fontWeight: 'bold', fontSize: 12
 }
 
 const errorTextStyle = { color: colors.danger(), fontWeight: 'bold', fontSize: 12, marginTop: '0.5rem' }

--- a/src/libs/data-utils.js
+++ b/src/libs/data-utils.js
@@ -26,7 +26,7 @@ import validate from 'validate.js'
 const warningBoxStyle = {
   backgroundColor: colors.warning(0.15),
   padding: '1rem 1.25rem',
-  color: colors.dark(1) , fontWeight: 'bold', fontSize: 12
+  color: colors.dark(), fontWeight: 'bold', fontSize: 12
 }
 
 const errorTextStyle = { color: colors.danger(), fontWeight: 'bold', fontSize: 12, marginTop: '0.5rem' }
@@ -365,7 +365,7 @@ export const EntityUploader = class EntityUploader extends Component {
           currentFile && _.includes(_.toLower(newEntityType), entityTypes) && div({
             style: { ...warningBoxStyle, margin: '1rem 0 0.5rem', display: 'flex', alignItems: 'center' }
           }, [
-            icon('warning-standard', { size: 19, style: { color: colors.light(.1), flex: 'none', marginRight: '0.5rem', marginLeft: '-0.5rem' } }),
+            icon('warning-standard', { size: 19, style: { color: colors.warning(), flex: 'none', marginRight: '0.5rem', marginLeft: '-0.5rem' } }),
             `Data with the type '${newEntityType}' already exists in this workspace. `,
             'Uploading more data for the same type may overwrite some entries.'
           ]),

--- a/src/libs/data-utils.js
+++ b/src/libs/data-utils.js
@@ -363,7 +363,7 @@ export const EntityUploader = class EntityUploader extends Component {
             })
           ]),
           currentFile && _.includes(_.toLower(newEntityType), entityTypes) && div({
-            style: { ...warningBoxStyle, margin: '1rem 0 0.5rem', color: colors.light(.1), display: 'flex', alignItems: 'center' }
+            style: { ...warningBoxStyle, margin: '1rem 0 0.5rem', display: 'flex', alignItems: 'center' }
           }, [
             icon('warning-standard', { size: 19, style: { color: colors.light(.1), flex: 'none', marginRight: '0.5rem', marginLeft: '-0.5rem' } }),
             `Data with the type '${newEntityType}' already exists in this workspace. `,


### PR DESCRIPTION
Currently in Terra the warning messages have a dark orange background with white text. This is difficult to read and does not meet accessibility standards. UI/UX have put together a new color scheme for these messages.

Also, it was noted by myself and @zarsky-broad `TrialBanner.js` line 72, there's coding for a banner that either doesn't meet the accessibility requirements or it's in a color that isn't our utils. How should we handle this?
