### PR TITLE
expose lodash/fp on console [SATURN-1238]

### DIFF
--- a/src/appLoader.js
+++ b/src/appLoader.js
@@ -17,6 +17,7 @@ RModal.setAppElement(appRoot)
 window.SATURN_VERSION = process.env.REACT_APP_VERSION
 marked.setOptions({ sanitize: true, sanitizer: _.escape })
 
+window._ = _
 
 ReactDOM.render(h(Main), appRoot)
 initializeAuth()


### PR DESCRIPTION
Previously, the `_` in the console pointed to the base `lodash`, rather than `lodash/fp`, which was confusing and unhelpful. This exposes `lodash/fp` instead, so we can use it for debugging.