### PR TITLE
Make test failure more meaningful [SATURN-1438]

### DIFF
--- a/integration-tests/tests/run-notebook.js
+++ b/integration-tests/tests/run-notebook.js
@@ -24,7 +24,7 @@ const testRunNotebookFn = withRegisteredUser(async ({ page, context, email, toke
     await select(page, 'ENVIRONMENT', 'Hail')
     await click(page, clickable({ text: 'Create' }))
     await findElement(page, clickable({ textContains: 'Creating' }))
-    await findElement(page, clickable({ textContains: 'Running' }), { timeout: 7 * 60 * 1000 })
+    await findElement(page, clickable({ textContains: 'Running' }), { timeout: 10 * 60 * 1000 })
 
     const frame = await findIframe(page)
     await fillIn(frame, '//textarea', 'print(123456789099876543210990+9876543219)')

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -20,7 +20,7 @@ const makeWorkspace = async ({ context, token }) => {
     return window.Ajax().Workspaces.create({ namespace: billingProject, name, attributes: {} })
   }, workspaceName, billingProject)
 
-  console.info(`created ${workspaceName}`)
+  console.info(`created workspace: ${workspaceName}`)
 
   await ajaxPage.close()
 
@@ -37,7 +37,7 @@ const deleteWorkspace = async (workspaceName, { context, token }) => {
     return window.Ajax().Workspaces.workspace(billingProject, name).delete()
   }, workspaceName, billingProject)
 
-  console.info(`deleted ${workspaceName}`)
+  console.info(`deleted workspace: ${workspaceName}`)
 
   await ajaxPage.close()
 }
@@ -84,6 +84,9 @@ const addUserToBilling = withUserToken(async ({ email, token }) => {
   await ajaxPage.evaluate((email, billingProject) => {
     return window.Ajax().Billing.project(billingProject).addUser(['User'], email)
   }, email, billingProject)
+
+  console.info(`added user to: ${billingProject}`)
+
   await ajaxPage.close()
 })
 
@@ -96,6 +99,9 @@ const removeUserFromBilling = withUserToken(async ({ email, token }) => {
   await ajaxPage.evaluate((email, billingProject) => {
     return window.Ajax().Billing.project(billingProject).removeUser(['User'], email)
   }, email, billingProject)
+
+  console.info(`removed user from: ${billingProject}`)
+
   await ajaxPage.close()
 })
 
@@ -139,6 +145,8 @@ const deleteCluster = withUserToken(async ({ email, token }) => {
   currentC && await ajaxPage.evaluate((currentC, email, billingProject) => {
     return window.Ajax().Clusters.cluster(billingProject, currentC.clusterName).delete()
   }, currentC, email, billingProject)
+
+  currentC && console.info(`deleted cluster: ${currentC.clusterName}`)
 
   await ajaxPage.close()
 })

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -136,7 +136,7 @@ const deleteCluster = withUserToken(async ({ email, token }) => {
   await signIntoTerra(ajaxPage, token)
 
   const currentC = await getCurrentCluster()
-  await ajaxPage.evaluate((currentC, email, billingProject) => {
+  currentC && await ajaxPage.evaluate((currentC, email, billingProject) => {
     return window.Ajax().Clusters.cluster(billingProject, currentC.clusterName).delete()
   }, currentC, email, billingProject)
 

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -118,6 +118,7 @@ const withBilling = test => async options => {
 
 const trimClustersOldestFirst = _.flow(
   _.remove({ status: 'Deleting' }),
+  _.remove({ status: 'Creating' }),
   _.sortBy('createdDate')
 )
 


### PR DESCRIPTION
- Updated the console.info in the integration tests to get more info for debugging when a test fails. 

- Also added a condition to only try to delete a cluster if it was successfully created. Since the cluster is created within the test it's possible that that fails, however the test then fails on deleting this nonexistent cluster as well and the real error stack trace can get covered up by that stack trace of not finding a cluster to delete.

- Also increased the timeout as I had a test that took 9 minutes to create a cluster and technically the max time in the UI warning is 10minutes, so I made it 10minutes now

- I couldn't finish testing locally because I got rate-limited by Sam so need to dig into that, but the integration tests passed here on dev so I think it should be okay