### PR TITLE
Alternate implementation of share workspace modal to match mocks [SATURN-1477]

### DIFF
--- a/src/components/input.js
+++ b/src/components/input.js
@@ -250,7 +250,7 @@ const withAutocomplete = WrappedComponent => ({
             } else if (_.includes(e.key, ['ArrowUp', 'ArrowDown']) && !suggestions.length) {
               e.nativeEvent.preventDownshiftDefault = true
             } else if (e.key === 'Enter') {
-              onPick?.(value)
+              onPick && onPick(value)
             }
           },
           nativeOnChange: true,

--- a/src/components/input.js
+++ b/src/components/input.js
@@ -213,7 +213,7 @@ const AutocompleteSuggestions = ({ target: targetId, containerProps, children })
 }
 
 const withAutocomplete = WrappedComponent => ({
-  instructions, value, onChange, onPick,
+  instructions, value, onChange, onPick, onClick,
   suggestions: rawSuggestions, style, id, renderSuggestion = _.identity, openOnFocus = true, placeholderText, ...props
 }) => {
   const suggestions = _.filter(Utils.textMatch(value), rawSuggestions)
@@ -236,6 +236,10 @@ const withAutocomplete = WrappedComponent => ({
         h(WrappedComponent, getInputProps({
           style,
           type: 'search',
+          onClick: evt => {
+            openOnFocus && openMenu()
+            onClick && onClick(evt)
+          },
           onKeyDown: e => {
             if (e.key === 'Escape') {
               (value || isOpen) && e.stopPropagation() // prevent e.g. closing a modal
@@ -253,24 +257,20 @@ const withAutocomplete = WrappedComponent => ({
           nativeOnChange: true,
           ...props
         })),
-        isOpen && Utils.cond(
-          [!suggestions.length && placeholderText, () => h(AutocompleteSuggestions, {
-            target: getInputProps().id,
-            containerProps: getMenuProps()
-          }, [
-            div({
-              style: { textAlign: 'center', paddingTop: '0.75rem', height: '2.5rem', color: colors.dark(0.8) }
-            }, [placeholderText])
-          ])],
-          [!!suggestions.length, () => h(AutocompleteSuggestions, {
-            target: getInputProps().id,
-            containerProps: getMenuProps()
-          }, _.map(([index, item]) => {
+        isOpen && h(AutocompleteSuggestions, {
+          target: getInputProps().id,
+          containerProps: getMenuProps()
+        },
+        Utils.cond(
+          [!suggestions.length && placeholderText, () => [div({
+            style: { textAlign: 'center', paddingTop: '0.75rem', height: '2.5rem', color: colors.dark(0.8) }
+          }, [placeholderText])]],
+          [!!suggestions.length, () => _.map(([index, item]) => {
             return div(getItemProps({
               item, key: item,
               style: styles.suggestion(highlightedIndex === index)
             }), [renderSuggestion(item)])
-          }, Utils.toIndexPairs(suggestions)))]
+          }, Utils.toIndexPairs(suggestions))])
         )
       ])
     }

--- a/src/components/input.js
+++ b/src/components/input.js
@@ -261,10 +261,10 @@ const withAutocomplete = WrappedComponent => ({
           containerProps: getMenuProps()
         },
         Utils.cond(
-          [!suggestions.length && placeholderText, () => [div({
+          [_.isEmpty(suggestions) && placeholderText, () => [div({
             style: { textAlign: 'center', paddingTop: '0.75rem', height: '2.5rem', color: colors.dark(0.8) }
           }, [placeholderText])]],
-          [!!suggestions.length, () => _.map(([index, item]) => {
+          [!_.isEmpty(suggestions), () => _.map(([index, item]) => {
             return div(getItemProps({
               item, key: item,
               style: styles.suggestion(highlightedIndex === index)

--- a/src/components/input.js
+++ b/src/components/input.js
@@ -250,7 +250,7 @@ const withAutocomplete = WrappedComponent => ({
             } else if (_.includes(e.key, ['ArrowUp', 'ArrowDown']) && !suggestions.length) {
               e.nativeEvent.preventDownshiftDefault = true
             } else if (e.key === 'Enter') {
-              onPick && onPick(value)
+              onPick?.(value)
             }
           },
           nativeOnChange: true,

--- a/src/components/input.js
+++ b/src/components/input.js
@@ -20,8 +20,8 @@ const styles = {
     maxHeight: 36 * 8 + 2, overflowY: 'auto',
     backgroundColor: 'white',
     border: `1px solid ${colors.light()}`,
-    margin: '8px 0',
-    borderRadius: '4px',
+    margin: '0.5rem 0',
+    borderRadius: 4,
     boxShadow: '0 0 1px 0 rgba(0,0,0,0.12), 0 8px 8px 0 rgba(0,0,0,0.24)'
   },
   suggestion: isSelected => ({

--- a/src/components/input.js
+++ b/src/components/input.js
@@ -19,7 +19,10 @@ const styles = {
     position: 'fixed', top: 0, left: 0,
     maxHeight: 36 * 8 + 2, overflowY: 'auto',
     backgroundColor: 'white',
-    border: `1px solid ${colors.light()}`
+    border: `1px solid ${colors.light()}`,
+    margin: '8px 0',
+    borderRadius: '4px',
+    boxShadow: '0 0 1px 0 rgba(0,0,0,0.12), 0 8px 8px 0 rgba(0,0,0,0.24)'
   },
   suggestion: isSelected => ({
     display: 'block', lineHeight: '2.25rem',
@@ -213,8 +216,8 @@ const AutocompleteSuggestions = ({ target: targetId, containerProps, children })
 }
 
 const withAutocomplete = WrappedComponent => ({
-  instructions, value, onChange, onPick, onClick,
-  suggestions: rawSuggestions, style, id, renderSuggestion = _.identity, openOnFocus = true, placeholderText, ...props
+  instructions, value, onChange, onPick, suggestions: rawSuggestions, style, id,
+  renderSuggestion = _.identity, openOnFocus = true, placeholderText, ...props
 }) => {
   const suggestions = _.filter(Utils.textMatch(value), rawSuggestions)
 
@@ -236,10 +239,6 @@ const withAutocomplete = WrappedComponent => ({
         h(WrappedComponent, getInputProps({
           style,
           type: 'search',
-          onClick: evt => {
-            openOnFocus && openMenu()
-            onClick && onClick(evt)
-          },
           onKeyDown: e => {
             if (e.key === 'Escape') {
               (value || isOpen) && e.stopPropagation() // prevent e.g. closing a modal

--- a/src/pages/workspaces/workspace/ShareWorkspaceModal.js
+++ b/src/pages/workspaces/workspace/ShareWorkspaceModal.js
@@ -124,7 +124,7 @@ export default ajaxCaller(class ShareWorkspaceModal extends Component {
               this.setState(
                 _.flow(
                   _.update('acl', Utils.append({ email: value, accessLevel: 'READER' })),
-                  _.update('searchValue', () => '')
+                  _.set('searchValue', '')
                 ),
                 () => this.list.current.scrollTo({ top: this.list.current.scrollHeight, behavior: 'smooth' })
               )
@@ -135,7 +135,7 @@ export default ajaxCaller(class ShareWorkspaceModal extends Component {
           suggestions: Utils.cond(
             [searchValueValid && !_.includes(searchValue, aclEmails), () => [searchValue]],
             [remainingSuggestions.length, () => remainingSuggestions],
-            []
+            () => []
           ),
           style: { fontSize: 16 }
         })

--- a/src/pages/workspaces/workspace/ShareWorkspaceModal.js
+++ b/src/pages/workspaces/workspace/ShareWorkspaceModal.js
@@ -31,11 +31,12 @@ const styles = {
   }
 }
 
-const AclInput = ({ value, onChange, disabled, maxAccessLevel }) => {
+const AclInput = ({ value, onChange, disabled, maxAccessLevel, autoFocus }) => {
   const { accessLevel, canShare, canCompute } = value
   return div({ style: { display: 'flex', marginTop: '0.25rem' } }, [
     div({ style: { width: 200 } }, [
       h(Select, {
+        autoFocus,
         isSearchable: false,
         isDisabled: disabled,
         getOptionLabel: o => Utils.normalizeLabel(o.value),
@@ -159,6 +160,7 @@ export default ajaxCaller(class ShareWorkspaceModal extends Component {
     const { workspace } = this.props
     const { acl, originalAcl } = this.state
     const isOld = _.find({ email }, originalAcl)
+    const numAdditions = _.filter(({ email }) => !_.some({ email }, originalAcl), acl).length
 
     return div({
       style: {
@@ -172,6 +174,7 @@ export default ajaxCaller(class ShareWorkspaceModal extends Component {
         email,
         pending && div({ style: styles.pending }, ['Pending']),
         h(AclInput, {
+          autoFocus: !!numAdditions,
           value: aclItem,
           onChange: v => this.setState(_.set(['acl', index], v)),
           disabled,

--- a/src/pages/workspaces/workspace/ShareWorkspaceModal.js
+++ b/src/pages/workspaces/workspace/ShareWorkspaceModal.js
@@ -114,7 +114,6 @@ export default ajaxCaller(class ShareWorkspaceModal extends Component {
         h(FormLabel, { htmlFor: id }, ['User email']),
         h(AutocompleteTextInput, {
           id,
-          instructions: 'test',
           openOnFocus: true,
           placeholderText: _.includes(searchValue, aclEmails) ?
             'This email has already been added to the list' :

--- a/src/pages/workspaces/workspace/ShareWorkspaceModal.js
+++ b/src/pages/workspaces/workspace/ShareWorkspaceModal.js
@@ -166,7 +166,7 @@ export default ajaxCaller(class ShareWorkspaceModal extends Component {
       style: {
         display: 'flex', alignItems: 'center', borderRadius: 5,
         padding: '0.5rem 0.75rem', marginBottom: 10,
-        border: `1px solid ${isOld ? colors.dark(0.25) : colors.success(0.5)}`,
+        border: isOld ? `1px solid ${colors.dark(0.25)}` : ` 2px dashed ${colors.success(0.5)}`,
         backgroundColor: isOld ? colors.light(0.2) : colors.success(0.05)
       }
     }, [


### PR DESCRIPTION
I created an implementation that uses the autocomplete text box and downshift to get the same effect as the implementation in [2051](https://github.com/DataBiosphere/terra-ui/pull/2051/files).

I believe this approach alleviates the issues Brett pointed out wrt the select component being used as a text input.

I added a new option to the Autocomplete component to allow for events to occur on selection and enter. I also added the option to display placeholder text if there are no suggestions.

If we choose to go with this, this PR can be merged independently of 2051 and some of the changes in 2051 can be removed.