### PR TITLE
Change version of wdl SATURN-1481

### DIFF
--- a/integration-tests/tests/import-dockstore-workflow.js
+++ b/integration-tests/tests/import-dockstore-workflow.js
@@ -4,7 +4,7 @@ const { click, clickable, dismissNotifications, findText, select, signIntoTerra 
 const { withUserToken } = require('../utils/terra-sa-utils')
 
 
-const testWorkflowIdentifier = 'github.com/DataBiosphere/topmed-workflows/UM_variant_caller_wdl:1.32.0'
+const testWorkflowIdentifier = 'github.com/DataBiosphere/topmed-workflows/UM_variant_caller_wdl:1.31.0'
 
 const testImportDockstoreWorkflowFn = withUserToken(async options => {
   const { page, testUrl } = options


### PR DESCRIPTION
It appears the version of UM_variant_caller wdl we were using for the integration test is gone or renamed so I changed the version. Tested running locally against dev and alpha (unable to run staging tests successfully ever (something on my to do list of fixing) so did not try to test there if someone wants to run that one.


Note* this did not cause an issue in prod (aka not user facing) because there we just automatically get the most recent version whereas in the test we were specifically looking for version 1.32

List of versions here:
https://staging.dockstore.org/workflows/github.com/DataBiosphere/topmed-workflows/UM_variant_caller_wdl:1.31.0?tab=versions