### PR TITLE
fire event when clicking new email [SATURN-1502]

### DIFF
--- a/src/components/input.js
+++ b/src/components/input.js
@@ -223,7 +223,7 @@ const withAutocomplete = WrappedComponent => ({
 
   return h(Downshift, {
     selectedItem: value,
-    onChange: onPick,
+    onSelect: v => !!v && onPick(v),
     onInputValueChange: newValue => {
       if (newValue !== value) {
         onChange(newValue)


### PR DESCRIPTION
`onSelect` is a superset of `onChange`: it fires even when the selected value matches the value already in the input.