### PR TITLE
Get more info on failure [SATURN-1475]

### DIFF
--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -169,5 +169,5 @@ module.exports = {
   navChild,
   findInDataTableRow,
   withScreenshot,
-  openNotification
+  openError
 }

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -107,7 +107,7 @@ const findInDataTableRow = (page, entityName, text) => {
   return findElement(page, `//*[@role="grid"]//*[contains(.,"${entityName}")]/following-sibling::*[contains(.,"${text}")]`)
 }
 
-const openNotification = async page => {
+const openError = async page => {
   //close out any non-error notifications first
   await dismissNotifications(page)
 

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -139,7 +139,7 @@ const withScreenshot = _.curry((testName, fn) => async options => {
         if (screenshotBucket) {
           const storage = new Storage()
           await storage.bucket(screenshotBucket).upload(path)
-          if (notificationsPresent) {
+          if (errorsPresent) {
             await storage.bucket(screenshotBucket).upload({ path: failureNotificationDetailsPath })
           }
         }

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -113,9 +113,7 @@ const openNotification = async page => {
 
   const errorDetails = await page.$x('(//a | //*[@role="button"] | //button)[contains(normalize-space(.),"Details")]')
 
-  await Promise.all(
-    errorDetails.map(handle => handle.click())
-  )
+  !!errorDetails[0] && await errorDetails[0].click()
 
   return errorDetails.length
 }

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -130,7 +130,7 @@ const withScreenshot = _.curry((testName, fn) => async options => {
 
         await page.screenshot({ path, fullPage: true })
 
-        const notificationsPresent = await openNotification(page)
+        const errorsPresent = await openError(page)
 
         if (!!notificationsPresent) {
           await page.screenshot({ path: failureNotificationDetailsPath, fullPage: true })

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -132,7 +132,7 @@ const withScreenshot = _.curry((testName, fn) => async options => {
 
         const errorsPresent = await openError(page)
 
-        if (!!notificationsPresent) {
+        if (errorsPresent) {
           await page.screenshot({ path: failureNotificationDetailsPath, fullPage: true })
         }
 

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -115,7 +115,7 @@ const openNotification = async page => {
 
   !!errorDetails[0] && await errorDetails[0].click()
 
-  return errorDetails.length
+  return !!errorDetails.length
 }
 
 const withScreenshot = _.curry((testName, fn) => async options => {


### PR DESCRIPTION
This will enable getting a screenshot of one of the error notification details as well as the general page screenshot when a test fails. This will help us understand what is happening with the flaky notebooks test. 

Also I added a 1 second delay to the helper that adds the test user to the billing (similar to the 1 second delay that was added to the register user helper) to make sure the request has enough time to fully go through. When I ran the test locally I _think_ I saw an error of 403 which is a permissions issue (I only have ever been able to reproduce this error once on purpose), so I am thinking it is possible the issue is not allowing enough time for the user to get fully added to the project before trying to access the notebooks.

Tested: 
With config overrides got a similar error to appear and got screenshots of the page and notification details successfully. When no error notification on failure still gets the regular whole page screenshot.


**NOTE**
This is an imperfect solution. Brett and I discussed a much better long term solution [(ticket here)](https://broadworkbench.atlassian.net/browse/SATURN-1512) the general idea being to enable a button or keyboard shortcut to get a dump of the error info whenever an error notification comes about which could be used for both tests and users. For now this PR is pretty specifically for getting details on the notebooks failure and can easily be pulled out when we develop a better more universal approach.