### PR TITLE
(Possibly Better) Fix for busy spinner with css max API

### DIFF
--- a/src/components/AuthContainer.js
+++ b/src/components/AuthContainer.js
@@ -13,6 +13,7 @@ import TermsOfService from 'src/pages/TermsOfService'
 const AuthContainer = ({ children }) => {
   const { name, public: isPublic } = useRoute()
   const { isSignedIn, registrationStatus, acceptedTos, profile } = Utils.useStore(authStore)
+
   return Utils.cond(
     [isSignedIn === undefined && !isPublic, centeredSpinner],
     [isSignedIn === false && !isPublic, h(SignIn)],

--- a/src/components/icons.js
+++ b/src/components/icons.js
@@ -14,7 +14,16 @@ export const icon = (shape, { size = 16, ...props } = {}) => _.invokeArgs(shape,
 
 export const spinner = props => icon('loadingSpinner', _.merge({ size: 24, style: { color: colors.primary() } }, props))
 
-export const centeredSpinner = props => spinner(_.merge({ size: 48, style: { display: 'block', margin: 'auto' } }, props))
+export const centeredSpinner = ({ size = 48, ...props } = {}) => spinner(_.merge({
+  size, style: {
+    display: 'block',
+    position: 'sticky',
+    top: `calc(min(50%, 50vh) - ${size / 2}px)`,
+    bottom: `calc(min(50%, 50vh) - ${size / 2}px)`,
+    left: `calc(min(50%, 50vw) - ${size / 2}px)`,
+    right: `calc(min(50%, 50vw) - ${size / 2}px)`
+  }
+}, props))
 
 export const profilePic = ({ size, style, ...props } = {}) => img({
   alt: 'Google profile image',

--- a/src/style.css
+++ b/src/style.css
@@ -49,7 +49,7 @@ body {
   position: absolute;
   width: 100%;
   min-width: 1200px;
-  overflow-x: auto;
+  overflow: auto;
 }
 
 table {
@@ -62,7 +62,6 @@ a {
 }
 
 #root {
-  overflow: auto;
   height: 100%;
   position: relative;
   z-index: 0;


### PR DESCRIPTION
Here is a slightly simpler fix for the busy spinner. This one works better across the board as the spinner always sticks correctly.

However it does require 2 things:
1. A change to where the overflow is set on the root/body elements. I am not sure what the rationale is for having the overflows split between the elements, but I have not seen any issues. But I may be unaware of something else there.

2. The CSS "min" API. This is supported in all browsers except Firefox. It should be supported in the next version of Firefox which is projected to release on April 7th.

If we want to move forward with this we could theoretically merge around this time.
