### PR TITLE
combine (non-integration) test & build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ commands:
           success_message: ":circleci-pass: $CIRCLE_JOB ran successfully."
 
 jobs:
-  test:
+  build:
     executor: node
     steps:
       - checkout
@@ -129,16 +129,6 @@ jobs:
           paths:
             - node_modules
       - run: yarn test
-  build:
-    executor: node
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - deps4-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
-            - deps4-{{ checksum "package.json" }}-
-            - deps4-
-      - run: yarn install --frozen-lockfile
       - run: yarn build
       - run: tar -czf build.tgz .gcloudignore app.yaml build config
       - store_artifacts:
@@ -217,7 +207,6 @@ workflows:
   version: 2
   build-deploy:
     jobs:
-      - test
       - build
       - integration-tests-branch-against-dev:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,7 +217,6 @@ workflows:
                 - dev
       - deploy-pr:
           requires:
-            - test
             - build
           filters:
             branches:
@@ -225,28 +224,24 @@ workflows:
                 - dev
       - deploy-dev:
           requires:
-            - test
             - build
           filters:
             branches:
               only: dev
       - deploy-alpha:
           requires:
-            - test
             - build
           filters:
             branches:
               only: dev
       - deploy-perf:
           requires:
-            - test
             - build
           filters:
             branches:
               only: dev
       - deploy-staging:
           requires:
-            - test
             - build
           filters:
             branches:


### PR DESCRIPTION
Running test separately from build caused two sources to try to read the cache simultaneously, which slowed things down significantly.