### PR TITLE
update metrics calls for new API [SATURN-1535]

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -6,7 +6,7 @@ import { getUser } from 'src/libs/auth'
 import { getConfig } from 'src/libs/config'
 import { withErrorIgnoring } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
-import { ajaxOverridesStore, authStore, requesterPaysBuckets, requesterPaysProjectStore, workspaceStore } from 'src/libs/state'
+import { ajaxOverridesStore, requesterPaysBuckets, requesterPaysProjectStore, workspaceStore } from 'src/libs/state'
 import * as Utils from 'src/libs/utils'
 
 
@@ -1098,14 +1098,17 @@ const Metrics = signal => ({
       event,
       properties: {
         ...details,
-        userId: authStore.get().profile.anonymousGroup,
-        appId: window.location.hostname,
-        appPath: Nav.getCurrentRoute().name,
-        timestamp: Date.now()
+        appId: 'Saturn',
+        hostname: window.location.hostname,
+        appPath: Nav.getCurrentRoute().name
       }
     }
     // Remove the metricsEnabled feature flag once TOS and all metrics projects are setup
     return metricsEnabled && fetchBard('api/event', _.mergeAll([authOpts(), jsonBody(body), { signal, method: 'POST' }]))
+  }),
+
+  syncProfile: withErrorIgnoring(() => {
+    return metricsEnabled && fetchBard('api/syncProfile', _.merge(authOpts(), { signal, method: 'POST' }))
   })
 })
 

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -205,6 +205,12 @@ authStore.subscribe(withErrorReporting('Error loading NIH account link status', 
   }
 }))
 
+authStore.subscribe(async (state, oldState) => {
+  if (oldState.registrationStatus !== 'registered' && state.registrationStatus === 'registered') {
+    await Ajax().Metrics.syncProfile()
+  }
+})
+
 authStore.subscribe((state, oldState) => {
   if (state.nihStatus !== oldState.nihStatus) {
     const notificationId = 'nih-link-warning'


### PR DESCRIPTION
This changes the metrics calls to conform to the new bard API, including making a call to the new `syncProfile` endpoint on load/login.