### PR TITLE
Implement footer and registration page requirements on https://terra.biodatacatalyst.nhlbi.nih.gov/ [SATURN-1416]

### DIFF
--- a/src/components/FooterWrapper.js
+++ b/src/components/FooterWrapper.js
@@ -1,7 +1,9 @@
+import { Fragment } from 'react'
 import { a, div, h } from 'react-hyperscript-helpers'
 import { Link } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import colors from 'src/libs/colors'
+import { isBioDataCatalyst } from 'src/libs/config'
 import { footerLogo } from 'src/libs/logos'
 import * as Nav from 'src/libs/nav'
 import * as Utils from 'src/libs/utils'
@@ -31,23 +33,36 @@ const FooterWrapper = ({ children }) => {
       h(Link, { href: Nav.getLink('root') }, [
         footerLogo()
       ]),
-      a({ href: Nav.getLink('privacy'), style: styles.item }, 'Privacy Policy'),
-      div({ style: styles.item }, '|'),
-      a({ href: Nav.getLink('terms-of-service'), style: styles.item }, 'Terms of Service'),
-      div({ style: styles.item }, '|'),
-      a({ href: 'https://support.terra.bio/hc/en-us/articles/360030793091-Terra-FireCloud-Security-Posture', target: '_blank', style: styles.item },
-        ['Security', icon('pop-out', { size: 12, style: { marginLeft: '0.5rem' } })]),
-      div({ style: styles.item }, '|'),
-      a({
-        href: 'https://support.terra.bio/hc/en-us', ...Utils.newTabLinkProps,
-        style: { ...styles.item, display: 'flex', alignItems: 'center' }
-      }, [
-        'Documentation', icon('pop-out', { size: 12, style: { marginLeft: '0.5rem' } })
-      ]),
-      div({ style: { flexGrow: 1 } }),
-      div({ onClick: () => Nav.goToPath('hall-of-fame'), style: { fontWeight: 600, fontSize: '10px' } }, [
-        `Copyright ©${buildTimestamp.getFullYear()}`
-      ])
+      isBioDataCatalyst() ?
+        div({ style: { display: 'grid', gridTemplateColumns: 'repeat(4, auto)', gap: '0.5rem 2rem', fontSize: 10 } }, [
+          a({ href: 'https://biodatacatalyst.nhlbi.nih.gov/privacy', ...Utils.newTabLinkProps }, 'Privacy Policy'),
+          a({ href: 'https://www.nhlbi.nih.gov/about/foia-fee-for-service-office', ...Utils.newTabLinkProps }, 'Freedom of Information Act (FOIA)'),
+          a({ href: 'https://biodatacatalyst.nhlbi.nih.gov/accessibility', ...Utils.newTabLinkProps }, 'Accessibility'),
+          a({ href: 'https://www.hhs.gov/', ...Utils.newTabLinkProps }, 'U.S. Department of Health &  Human Services'),
+          a({ href: 'https://osp.od.nih.gov/scientific-sharing/policies/', ...Utils.newTabLinkProps }, 'Data Sharing Policy'),
+          a({ href: 'https://www.nih.gov/', ...Utils.newTabLinkProps }, 'National Institutes of Health'),
+          a({ href: 'https://www.usa.gov/', ...Utils.newTabLinkProps }, 'USA.gov'),
+          a({ href: 'https://osp.od.nih.gov/scientific-sharing/policies/', ...Utils.newTabLinkProps }, 'National Heart, Lung, and Blood Institute')
+        ]) :
+        h(Fragment, [
+          a({ href: Nav.getLink('privacy'), style: styles.item }, 'Privacy Policy'),
+          div({ style: styles.item }, '|'),
+          a({ href: Nav.getLink('terms-of-service'), style: styles.item }, 'Terms of Service'),
+          div({ style: styles.item }, '|'),
+          a({ href: 'https://support.terra.bio/hc/en-us/articles/360030793091-Terra-FireCloud-Security-Posture', ...Utils.newTabLinkProps, style: styles.item },
+            ['Security', icon('pop-out', { size: 12, style: { marginLeft: '0.5rem' } })]),
+          div({ style: styles.item }, '|'),
+          a({
+            href: 'https://support.terra.bio/hc/en-us', ...Utils.newTabLinkProps,
+            style: { ...styles.item, display: 'flex', alignItems: 'center' }
+          }, [
+            'Documentation', icon('pop-out', { size: 12, style: { marginLeft: '0.5rem' } })
+          ]),
+          div({ style: { flexGrow: 1 } }),
+          div({ onClick: () => Nav.goToPath('hall-of-fame'), style: { fontWeight: 600, fontSize: '10px' } }, [
+            `Copyright ©${buildTimestamp.getFullYear()}`
+          ])
+        ])
     ])
   ])
 }

--- a/src/pages/SignIn.js
+++ b/src/pages/SignIn.js
@@ -1,10 +1,10 @@
 import { Component, Fragment } from 'react'
-import { div, h, p } from 'react-hyperscript-helpers'
+import { b, div, h, p } from 'react-hyperscript-helpers'
 import { Clickable, HeroWrapper, Link } from 'src/components/common'
 import Modal from 'src/components/Modal'
 import SignInButton from 'src/components/SignInButton'
 import colors from 'src/libs/colors'
-import { isFirecloud } from 'src/libs/config'
+import { isBioDataCatalyst, isFirecloud } from 'src/libs/config'
 import { getAppName } from 'src/libs/logos'
 import * as Nav from 'src/libs/nav'
 import * as Style from 'src/libs/style'
@@ -75,6 +75,29 @@ export default class SignIn extends Component {
                 href: 'https://www.cancer.gov/about-nci/organization/ccg/research/structural-genomics/tcga/history/policies/tcga-data-use-certification-agreement.pdf'
               }, ['DATA USE CERTIFICATION AGREEMENT (DUCA)'])
             ])
+          ]),
+          isBioDataCatalyst && p([
+            'This statement is provided pursuant to the Privacy Act of 1974 (5 U.S.C. ',
+            b('§ 552a): The information requested on this form is authorized to be collected pursuant to '),
+            h(Link, {
+              ...Utils.newTabLinkProps,
+              href: 'https://www.govinfo.gov/content/pkg/USCODE-2018-title42/html/USCODE-2018-title42-chap6A-subchapI-partA-sec217.htm'
+            }, ['42 U.S.C. 217']),
+            'a, 241, 281, 282, 284; 48 CFR Subpart 15.3; and Executive Order ',
+            h(Link, {
+              ...Utils.newTabLinkProps,
+              href: 'https://www.federalregister.gov/documents/2008/11/20/E8-27771/amendments-to-executive-order-9397-relating-to-federal-agency-use-of-social-security-numbers'
+            }, ['13478']),
+            `. Completing the form is voluntary, however, declining to provide any or all of the requested information may result in denial of access to controlled data.
+             The principal purpose for which the information will be used is to authenticate users who request access to controlled access data. The information will be 
+             used to contact you in response to requests you have specifically made on this Web site. Your personal information may also be used to audit your activity 
+             on the system in order to ensure compliance with NIH policies. The information you provide will be included in a Privacy Act system of Records, and will be 
+             used and may be disclosed for the purposes and routine uses described and published in the following System of Records Notice (SORN): 
+             09-90-1401, Records About Restricted Dataset Requesters, HHS/OS/Other `,
+            h(Link, {
+              ...Utils.newTabLinkProps,
+              href: 'https://www.federalregister.gov/documents/2018/03/14/2018-05176/privacy-act-of-1974-system-of-records'
+            }, ['https://www.federalregister.gov/documents/2018/03/14/2018-05176/privacy-act-of-1974-system-of-records'])
           ])
         ]),
         openCookiesModal && h(CookiesModal, {

--- a/src/pages/SignIn.js
+++ b/src/pages/SignIn.js
@@ -1,5 +1,5 @@
 import { Component, Fragment } from 'react'
-import { b, div, h, p } from 'react-hyperscript-helpers'
+import { div, h, p } from 'react-hyperscript-helpers'
 import { Clickable, HeroWrapper, Link } from 'src/components/common'
 import Modal from 'src/components/Modal'
 import SignInButton from 'src/components/SignInButton'
@@ -77,8 +77,7 @@ export default class SignIn extends Component {
             ])
           ]),
           isBioDataCatalyst && p([
-            'This statement is provided pursuant to the Privacy Act of 1974 (5 U.S.C. ',
-            b('§ 552a): The information requested on this form is authorized to be collected pursuant to '),
+            'This statement is provided pursuant to the Privacy Act of 1974 (5 U.S.C. §552a): The information requested on this form is authorized to be collected pursuant to ',
             h(Link, {
               ...Utils.newTabLinkProps,
               href: 'https://www.govinfo.gov/content/pkg/USCODE-2018-title42/html/USCODE-2018-title42-chap6A-subchapI-partA-sec217.htm'

--- a/src/pages/SignIn.js
+++ b/src/pages/SignIn.js
@@ -76,7 +76,7 @@ export default class SignIn extends Component {
               }, ['DATA USE CERTIFICATION AGREEMENT (DUCA)'])
             ])
           ]),
-          isBioDataCatalyst && p([
+          isBioDataCatalyst() && p([
             'This statement is provided pursuant to the Privacy Act of 1974 (5 U.S.C. §552a): The information requested on this form is authorized to be collected pursuant to ',
             h(Link, {
               ...Utils.newTabLinkProps,


### PR DESCRIPTION
Added links to the footer.
Though they are external links, the mockup shows no pop-out symbol next to each link so those were left off. I'm currently in a conversation with UX about whether to add them.

Though part of the ticket, the registration text requirement was left off of this branch as it is a separate task and the implementation is currently a little foggy, so @panentheos and I determined we could at least push the footer changes right now.

Ticket [here](https://broadworkbench.atlassian.net/browse/SATURN-1416?atlOrigin=eyJpIjoiZTQzYTUwYTk3NWY0NDEyOTk5MTExMTE4OTk0NGIyMzAiLCJwIjoiaiJ9).