### PR TITLE
Make Landing and Workspace list page better for screenreaders [SATURN-1506]

### DIFF
--- a/src/components/common.js
+++ b/src/components/common.js
@@ -11,7 +11,6 @@ import { centeredSpinner, icon } from 'src/components/icons'
 import Interactive from 'src/components/Interactive'
 import TooltipTrigger from 'src/components/TooltipTrigger'
 import TopBar from 'src/components/TopBar'
-import hexButton from 'src/images/hex-button.svg'
 import landingPageHero from 'src/images/landing-page-hero.jpg'
 import scienceBackground from 'src/images/science-background.jpg'
 import { Ajax } from 'src/libs/ajax'
@@ -112,23 +111,6 @@ export const ButtonOutline = ({ disabled, children, ...props }) => {
     },
     hover: disabled ? undefined : { backgroundColor: colors.accent(0.1) }
   }, props), [children])
-}
-
-export const makeIconButton = (shape, { disabled, size, iconProps = {}, ...props } = {}) => {
-  return h(Clickable, _.merge({
-    as: 'span',
-    disabled,
-    style: {
-      height: size, width: size,
-      display: 'flex', alignItems: 'center', justifyContent: 'center',
-      backgroundColor: disabled ? colors.dark(0.15) : colors.accent(),
-      ...(isTerra() ?
-        { mask: `url(${hexButton}) center no-repeat`, WebkitMask: `url(${hexButton}) center no-repeat` } :
-        { borderRadius: '1rem' })
-    }
-  }, props), [
-    icon(shape, _.merge({ style: { color: disabled ? colors.dark() : 'white' } }, iconProps))
-  ])
 }
 
 export const TabBar = ({ activeTab, tabNames, displayNames = {}, refresh = _.noop, getHref, getOnClick = _.noop, children }) => {

--- a/src/pages/LandingPage.js
+++ b/src/pages/LandingPage.js
@@ -1,8 +1,9 @@
 import { Fragment } from 'react'
 import { div, h, h2 } from 'react-hyperscript-helpers'
-import { Clickable, HeroWrapper, Link, makeIconButton } from 'src/components/common'
+import { Clickable, HeroWrapper, Link } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import covidHero from 'src/images/covid-hero.jpg'
+import hexButton from 'src/images/hex-button.svg'
 import colors from 'src/libs/colors'
 import { isFirecloud, isTerra } from 'src/libs/config'
 import * as Nav from 'src/libs/nav'
@@ -25,6 +26,18 @@ const makeDocLink = (href, title) => {
   ])
 }
 
+const makeRightArrowWithBackgroundIcon = () => div({
+  style: {
+    height: 30, width: 30,
+    display: 'flex', alignItems: 'center', justifyContent: 'center',
+    alignSelf: 'flex-end',
+    backgroundColor: colors.accent(),
+    ...(isTerra() ?
+      { mask: `url(${hexButton}) center no-repeat`, WebkitMask: `url(${hexButton}) center no-repeat` } :
+      { borderRadius: '1rem' })
+  }
+}, [icon('arrowRight', { color: 'white' })])
+
 const makeCard = (link, title, body) => h(Clickable, {
   href: Nav.getLink(link),
   style: { ...Style.elements.card.container, height: 245, width: 225, marginRight: '1rem', justifyContent: undefined },
@@ -33,7 +46,7 @@ const makeCard = (link, title, body) => h(Clickable, {
   div({ style: { color: colors.accent(), fontSize: 18, fontWeight: 500, lineHeight: '22px', marginBottom: '0.5rem' } }, title),
   div({ style: { lineHeight: '22px' } }, body),
   div({ style: { flexGrow: 1 } }),
-  makeIconButton('arrowRight', { tabIndex: '-1', 'aria-hidden': true, size: 30, style: { alignSelf: 'flex-end' } })
+  makeRightArrowWithBackgroundIcon()
 ])
 
 const LandingPage = () => {

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -258,7 +258,7 @@ export const WorkspaceList = () => {
                   closeOnClick: true,
                   content: h(WorkspaceMenuContent, { namespace, name, onShare, onClone, onDelete })
                 }, [
-                  h(Link, { 'aria-label': 'Workspace menu', disabled: !canView, 'aria-hidden': false }, [icon('cardMenuIcon', { size: 20 })])
+                  h(Link, { 'aria-label': `Menu for Workspace: ${name}`, disabled: !canView }, [icon('cardMenuIcon', { size: 20 })])
                 ])
               ]),
               div({ style: styles.tableCellContent }, [

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -258,7 +258,7 @@ export const WorkspaceList = () => {
                   closeOnClick: true,
                   content: h(WorkspaceMenuContent, { namespace, name, onShare, onClone, onDelete })
                 }, [
-                  h(Link, { 'aria-label': 'Workspace menu', disabled: !canView }, [icon('cardMenuIcon', { size: 20 })])
+                  h(Link, { 'aria-label': 'Workspace menu', disabled: !canView, 'aria-hidden': false }, [icon('cardMenuIcon', { size: 20 })])
                 ])
               ]),
               div({ style: styles.tableCellContent }, [
@@ -295,7 +295,7 @@ export const WorkspaceList = () => {
     div({ role: 'main', style: { padding: '1.5rem', flex: 1, display: 'flex', flexDirection: 'column' } }, [
       div({ style: { display: 'flex', alignItems: 'center', marginBottom: '1rem' } }, [
         div({ style: { ...Style.elements.sectionHeader, textTransform: 'uppercase' } }, ['Workspaces']),
-        h(Link, { onClick: () => setCreatingNewWorkspace(true), style: { marginLeft: '0.5rem' } }, [icon('lighter-plus-circle', { size: 24 })])
+        h(Link, { 'aria-label': 'Create new workspace', onClick: () => setCreatingNewWorkspace(true), style: { marginLeft: '0.5rem' } }, [icon('lighter-plus-circle', { size: 24 })])
       ]),
       div({ style: { display: 'flex', marginBottom: '1rem' } }, [
         div({ style: styles.filter }, [


### PR DESCRIPTION
**Part 1**
Remove `makeIconButton()` and replace its one usage with a more specific simplified version that is a11y compliant.

Looking for opinions:
TOL
The function `makeIconButton() `was in `common.js` however it was only being used one time in `LandingPage.js`. It also had a lot of options for dealing with props and merging props for the different pieces of the icon that were never used/needed. I took this all out to simplify my understanding while I made the change to make it an `image` rather than a `clickable` with the intention of putting that prop logic back in after. However now that I have finished it doesn't seem appropriate to add back as this is only used once and can be kept more simple and specific keeping it a function for this one icon in `LandingPage.js`. 

Is there a reason to keep the original makeIconButton that I am missing? Is it appropriate to take out the extra logic or should it be kept in so that in the future if there is need for it it's there?

Tested using ANDI to ensure the a11y errors were gone for the arrow buttons
Before:
<img width="1546" alt="Screen Shot 2020-04-09 at 1 14 53 PM" src="https://user-images.githubusercontent.com/54322292/78928055-f80f5600-7a6d-11ea-993b-9ec04f4580a0.png">

After:
<img width="1285" alt="Screen Shot 2020-04-09 at 1 14 41 PM" src="https://user-images.githubusercontent.com/54322292/78928080-01002780-7a6e-11ea-9647-d02c1796dc71.png">

**Part 2**
Fix the workspace list page so that the 3-dot menus and the make new workspace button have a11y compliance

Before:
<img width="1184" alt="Screen Shot 2020-04-09 at 3 33 47 PM" src="https://user-images.githubusercontent.com/54322292/78933613-948a2600-7a77-11ea-8c3d-0b6adce5eaf7.png">

After:
<img width="1107" alt="Screen Shot 2020-04-09 at 3 34 05 PM" src="https://user-images.githubusercontent.com/54322292/78933635-9a800700-7a77-11ea-9c44-1032b0aa7d62.png">
