### PR TITLE
Add back Terra's ToS and Privacy Policy [SATURN-1551]

### DIFF
--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -332,15 +332,13 @@ const TopBar = Utils.connectStore(authStore, 'authState')(class TopBar extends C
                   variant: 'light',
                   style: { display: 'block', textDecoration: 'underline', color: colors.accent(0.2) },
                   href: Nav.getLink('privacy'),
-                  onClick: () => this.hideNav(),
-                  ...Utils.newTabLinkProps
+                  onClick: () => this.hideNav()
                 }, ['Terra Privacy Policy']),
               h(Link, {
                 variant: 'light',
                 href: Nav.getLink('terms-of-service'),
                 style: { display: 'block', textDecoration: 'underline', color: colors.accent(0.2) },
-                onClick: () => this.hideNav(),
-                ...Utils.newTabLinkProps
+                onClick: () => this.hideNav()
               }, ['Terra Terms of Service'])
             ]),
             div({ style: { color: colors.dark(0.3), fontSize: 10, fontWeight: 600, marginTop: '0.5rem' } }, [

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -327,19 +327,21 @@ const TopBar = Utils.connectStore(authStore, 'authState')(class TopBar extends C
           }, [
             h(CromwellVersionLink, { variant: 'light', style: { textDecoration: 'underline', color: colors.accent(0.2) } }),
             isBioDataCatalyst() && h(Fragment, [
-              div([h(Link,
+              h(Link,
                 {
-                  style: { textDecoration: 'underline', color: colors.accent(0.2) },
+                  variant: 'light',
+                  style: { display: 'block', textDecoration: 'underline', color: colors.accent(0.2) },
                   href: Nav.getLink('privacy'),
                   onClick: () => this.hideNav(),
                   ...Utils.newTabLinkProps
-                }, ['Terra Privacy Policy'])]),
-              div([h(Link, {
+                }, ['Terra Privacy Policy']),
+              h(Link, {
+                variant: 'light',
                 href: Nav.getLink('terms-of-service'),
-                style: { textDecoration: 'underline', color: colors.accent(0.2) },
+                style: { display: 'block', textDecoration: 'underline', color: colors.accent(0.2) },
                 onClick: () => this.hideNav(),
                 ...Utils.newTabLinkProps
-              }, ['Terra Terms of Service'])])
+              }, ['Terra Terms of Service'])
             ]),
             div({ style: { color: colors.dark(0.3), fontSize: 10, fontWeight: 600, marginTop: '0.5rem' } }, [
               'Built on: ',

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -4,7 +4,9 @@ import { Component, Fragment, useState } from 'react'
 import { UnmountClosed as RCollapse } from 'react-collapse'
 import { a, b, div, h, img, span } from 'react-hyperscript-helpers'
 import { Transition } from 'react-transition-group'
-import { ButtonPrimary, Clickable, CromwellVersionLink, FocusTrapper, IdContainer, LabeledCheckbox, spinnerOverlay } from 'src/components/common'
+import {
+  ButtonPrimary, Clickable, CromwellVersionLink, FocusTrapper, IdContainer, LabeledCheckbox, Link, spinnerOverlay
+} from 'src/components/common'
 import { icon, profilePic } from 'src/components/icons'
 import { TextArea } from 'src/components/input'
 import Modal from 'src/components/Modal'
@@ -307,16 +309,6 @@ const TopBar = Utils.connectStore(authStore, 'authState')(class TopBar extends C
             icon('virus', { size: 24, style: styles.nav.icon }),
             'COVID-19 Data & Tools'
           ]),
-          isBioDataCatalyst() && h(NavSection, {
-            href: Nav.getLink('privacy'),
-            onClick: () => this.hideNav(),
-            ...Utils.newTabLinkProps
-          }, ['Terra Privacy Policy']),
-          isBioDataCatalyst() && h(NavSection, {
-            href: Nav.getLink('terms-of-service'),
-            onClick: () => this.hideNav(),
-            ...Utils.newTabLinkProps
-          }, ['Terra Terms of Service']),
           isFirecloud() && h(NavSection, {
             disabled: !isSignedIn,
             tooltip: isSignedIn ? undefined : 'Please sign in',
@@ -334,6 +326,20 @@ const TopBar = Utils.connectStore(authStore, 'authState')(class TopBar extends C
             style: { flex: 'none', padding: 28, marginTop: 'auto' }
           }, [
             h(CromwellVersionLink, { variant: 'light', style: { textDecoration: 'underline', color: colors.accent(0.2) } }),
+            isBioDataCatalyst() && h(Fragment, [
+              h(Link,
+                // {style: { textDecoration: 'underline', color: colors.accent(0.2) } },
+                {
+                  href: Nav.getLink('privacy'),
+                  onClick: () => this.hideNav(),
+                  ...Utils.newTabLinkProps
+                }, ['Terra Privacy Policy']),
+              h(Link, {
+                href: Nav.getLink('terms-of-service'),
+                onClick: () => this.hideNav(),
+                ...Utils.newTabLinkProps
+              }, ['Terra Terms of Service'])
+            ]),
             div({ style: { color: colors.dark(0.3), fontSize: 10, fontWeight: 600, marginTop: '0.5rem' } }, [
               'Built on: ',
               h(Clickable, {

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -307,6 +307,16 @@ const TopBar = Utils.connectStore(authStore, 'authState')(class TopBar extends C
             icon('virus', { size: 24, style: styles.nav.icon }),
             'COVID-19 Data & Tools'
           ]),
+          isBioDataCatalyst() && h(NavSection, {
+            href: Nav.getLink('privacy'),
+            onClick: () => this.hideNav(),
+            ...Utils.newTabLinkProps
+          }, ['Terra Privacy Policy']),
+          isBioDataCatalyst() && h(NavSection, {
+            href: Nav.getLink('terms-of-service'),
+            onClick: () => this.hideNav(),
+            ...Utils.newTabLinkProps
+          }, ['Terra Terms of Service']),
           isFirecloud() && h(NavSection, {
             disabled: !isSignedIn,
             tooltip: isSignedIn ? undefined : 'Please sign in',

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -327,18 +327,19 @@ const TopBar = Utils.connectStore(authStore, 'authState')(class TopBar extends C
           }, [
             h(CromwellVersionLink, { variant: 'light', style: { textDecoration: 'underline', color: colors.accent(0.2) } }),
             isBioDataCatalyst() && h(Fragment, [
-              h(Link,
-                // {style: { textDecoration: 'underline', color: colors.accent(0.2) } },
+              div([h(Link,
                 {
+                  style: { textDecoration: 'underline', color: colors.accent(0.2) },
                   href: Nav.getLink('privacy'),
                   onClick: () => this.hideNav(),
                   ...Utils.newTabLinkProps
-                }, ['Terra Privacy Policy']),
-              h(Link, {
+                }, ['Terra Privacy Policy'])]),
+              div([h(Link, {
                 href: Nav.getLink('terms-of-service'),
+                style: { textDecoration: 'underline', color: colors.accent(0.2) },
                 onClick: () => this.hideNav(),
                 ...Utils.newTabLinkProps
-              }, ['Terra Terms of Service'])
+              }, ['Terra Terms of Service'])])
             ]),
             div({ style: { color: colors.dark(0.3), fontSize: 10, fontWeight: 600, marginTop: '0.5rem' } }, [
               'Built on: ',


### PR DESCRIPTION
We removed Terra's ToS and privacy policy from the footer so we needed to add them back somewhere, so we decided to add them to the dropdown menu from the top bar.

I've tested these locally, they only show up for BDC and the links lead to a new tab with the correct information.

**I'm wondering if we want to add icons next to these titles as all the other menu items have icons.** Other than that, I believe this draft is complete.

Ticket is [here](https://broadworkbench.atlassian.net/browse/SATURN-1551?atlOrigin=eyJpIjoiZjQ0OTJmM2Y0ODE3NDk5YTgxMWFlNDQ5MzIyYWU2MmYiLCJwIjoiaiJ9)