### PR TITLE
Fix color contrast of trial banner [SATURN-1505]

### DIFF
--- a/src/components/TrialBanner.js
+++ b/src/components/TrialBanner.js
@@ -76,8 +76,8 @@ export const TrialBanner = Utils.connectStore(authStore, 'authState')(class Tria
       [
         div({
           style: {
-            fontSize: '1.45rem', fontWeight: 500, textAlign: 'right', borderRight: '1px solid', paddingRight: '1rem', marginRight: '1rem',
-            maxWidth: 200, flexShrink: 0
+            fontSize: '1.5rem', fontWeight: 500, textAlign: 'right', borderRight: '1px solid', paddingRight: '1rem', marginRight: '1rem',
+            maxWidth: 225, flexShrink: 0
           }
         }, title),
         span({ style: { maxWidth: 600, lineHeight: '1.5rem' } },
@@ -135,3 +135,5 @@ export const TrialBanner = Utils.connectStore(authStore, 'authState')(class Tria
     ])
   }
 })
+
+

--- a/src/components/TrialBanner.js
+++ b/src/components/TrialBanner.js
@@ -69,7 +69,7 @@ export const TrialBanner = Utils.connectStore(authStore, 'authState')(class Tria
       div({
         style: {
           display: 'flex', alignItems: 'center', padding: '1.5rem', height: 95,
-          backgroundColor: isWarning ? colors.warning() : '#359448',
+          backgroundColor: isWarning ? colors.warning() : '#28873b',
           justifyContent: 'center', color: 'white', width: '100%', fontSize: '1rem'
         }
       },

--- a/src/components/TrialBanner.js
+++ b/src/components/TrialBanner.js
@@ -76,7 +76,7 @@ export const TrialBanner = Utils.connectStore(authStore, 'authState')(class Tria
       [
         div({
           style: {
-            fontSize: '1.5rem', fontWeight: 500, textAlign: 'right', borderRight: '1px solid', paddingRight: '1rem', marginRight: '1rem',
+            fontSize: '1.45rem', fontWeight: 500, textAlign: 'right', borderRight: '1px solid', paddingRight: '1rem', marginRight: '1rem',
             maxWidth: 200, flexShrink: 0
           }
         }, title),

--- a/src/components/TrialBanner.js
+++ b/src/components/TrialBanner.js
@@ -135,5 +135,3 @@ export const TrialBanner = Utils.connectStore(authStore, 'authState')(class Tria
     ])
   }
 })
-
-


### PR DESCRIPTION
Fix the color contrast of the Free Trial banner to meet a11y requirements. Also adjust the size of the title so that the NHLBI fits nicer.

Before:
<img width="1276" alt="Screen Shot 2020-04-13 at 12 15 24 PM" src="https://user-images.githubusercontent.com/54322292/79137784-5b0c3000-7d81-11ea-9407-265a4834e53d.png">

After:
<img width="1218" alt="Screen Shot 2020-04-13 at 12 22 24 PM" src="https://user-images.githubusercontent.com/54322292/79137834-737c4a80-7d81-11ea-81ba-fb44098979bf.png">

