### PR TITLE
Make Free Credits Banner have appropriate language for screen reader [SATURN-1561]

### DIFF
--- a/src/components/TrialBanner.js
+++ b/src/components/TrialBanner.js
@@ -109,6 +109,7 @@ export const TrialBanner = Utils.connectStore(authStore, 'authState')(class Tria
           h(Clickable, {
             style: { borderBottom: 'none' },
             tooltip: 'Hide banner',
+            'aria-label': 'Dismiss free credits offer',
             onClick: trialState === 'Terminated' ? () => this.setState({ finalizeTrial: true }) : () => {
               localStorage.setItem('removeBanner', 'true')
               this.forceUpdate()

--- a/src/components/TrialBanner.js
+++ b/src/components/TrialBanner.js
@@ -109,7 +109,7 @@ export const TrialBanner = Utils.connectStore(authStore, 'authState')(class Tria
           h(Clickable, {
             style: { borderBottom: 'none' },
             tooltip: 'Hide banner',
-            'aria-label': 'Dismiss free credits offer',
+            'aria-label': isWarning ? 'Dismiss expired free credits notification' : 'Dismiss free credits offer',
             onClick: trialState === 'Terminated' ? () => this.setState({ finalizeTrial: true }) : () => {
               localStorage.setItem('removeBanner', 'true')
               this.forceUpdate()

--- a/src/components/TrialBanner.js
+++ b/src/components/TrialBanner.js
@@ -109,7 +109,7 @@ export const TrialBanner = Utils.connectStore(authStore, 'authState')(class Tria
           h(Clickable, {
             style: { borderBottom: 'none' },
             tooltip: 'Hide banner',
-            'aria-label': isWarning ? 'Dismiss expired free credits notification' : 'Dismiss free credits offer',
+            'aria-label': 'Dismiss free credits notification',
             onClick: trialState === 'Terminated' ? () => this.setState({ finalizeTrial: true }) : () => {
               localStorage.setItem('removeBanner', 'true')
               this.forceUpdate()


### PR DESCRIPTION
added aria-label to x button in the free credits banner

I'm wondering if there should be a different message if they're currently using their free credits since the message is about learning more, not getting more. I am currently talking to Adrian about this, but I figured functionality could be tested.


To test:

- be logged in as Barty Admiralson
- go to `TrialBanner.js`
- toggle `removeBanner` to false
- be on any page on Terra (I used Workspaces) and go to `TrialBanner` in React Components
- toggle `authState.profile.trialState` to `Enabled` / `Enrolled` / `Terminated`