### PR TITLE
fix a11y on pre-load template [SATURN-1560]

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -70,7 +70,7 @@
           <div style="font-weight: 600; font-size: 10px; color: white;" id="copyright"></div>
           <script>
             const buildTimestamp = new Date(parseInt('%REACT_APP_BUILD_TIMESTAMP%', 10))
-            window.document.getElementById('copyright').innerHTML = `Copyright © ${buildTimestamp.getFullYear()}`
+            window.document.getElementById('copyright').innerHTML = `Copyright ©${buildTimestamp.getFullYear()}`
           </script>
         </div>
       </div>

--- a/public/index.html
+++ b/public/index.html
@@ -67,11 +67,6 @@
             style="flex: 0 0 auto; display: flex; align-items: center; justify-content: space-between; height: 66px; padding: 0 1rem; background-color: rgb(109, 110, 112);">
           <img role="img" src="%PUBLIC_URL%/logo-grey.svg" alt="Terra logo"
                style="height: 40px; margin-bottom: 4px;">
-          <div style="font-weight: 600; font-size: 10px; color: white;" id="copyright"></div>
-          <script>
-            const buildTimestamp = new Date(parseInt('%REACT_APP_BUILD_TIMESTAMP%', 10))
-            window.document.getElementById('copyright').innerHTML = `Copyright ©${buildTimestamp.getFullYear()}`
-          </script>
         </div>
       </div>
     </div>

--- a/public/index.html
+++ b/public/index.html
@@ -59,15 +59,19 @@
           style="position: absolute; left: 0; top: 0; display: flex; flex-direction: column; height: 100vh; width: 100vw; background-color: #fafbfc; font-family: 'Montserrat', sans-serif; font-variant-numeric: tabular-nums; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale;">
         <div
             style="flex-grow: 1; color: rgb(51, 63, 82); font-size: 54px; display: flex; align-items: center; justify-content: center;">
-          <img role="img" src="%PUBLIC_URL%/loading-spinner.svg"
+          <img role="img" src="%PUBLIC_URL%/loading-spinner.svg" alt=""
                style="height: 54px; margin-right: 2rem; opacity: 0.5;">
           Loading Terra...
         </div>
         <div
             style="flex: 0 0 auto; display: flex; align-items: center; justify-content: space-between; height: 66px; padding: 0 1rem; background-color: rgb(109, 110, 112);">
-          <img role="img" src="%PUBLIC_URL%/logo-grey.svg"
+          <img role="img" src="%PUBLIC_URL%/logo-grey.svg" alt="Terra logo"
                style="height: 40px; margin-bottom: 4px;">
-          <div style="font-weight: 600; font-size: 10px; color: white;">Copyright ©2019</div>
+          <div style="font-weight: 600; font-size: 10px; color: white;" id="copyright"></div>
+          <script>
+            const buildTimestamp = new Date(parseInt('%REACT_APP_BUILD_TIMESTAMP%', 10))
+            window.document.getElementById('copyright').innerHTML = `Copyright © ${buildTimestamp.getFullYear()}`
+          </script>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Adds alt tags to images, and implements the same logic the app uses to keep the copyright year current in the pre-load.