### PR TITLE
Add alt text to rstudio img [SATURN-1573]

### DIFF
--- a/src/components/ClusterManager.js
+++ b/src/components/ClusterManager.js
@@ -306,11 +306,11 @@ export default class ClusterManager extends PureComponent {
         href: appLaunchLink,
         onClick: window.location.hash === appLaunchLink && currentStatus === 'Stopped' ? () => this.startCluster() : undefined,
         tooltip: canCompute ? `Open ${appName}` : noCompute,
-        'aria-label': !isRStudioImage ? `Open ${appName}`: undefined,
+        'aria-label': `Open ${appName}`,
         disabled: !canCompute,
         style: { marginRight: '2rem', ...styles.verticalCenter },
         ...(isRStudioImage ? {} : Utils.newTabLinkProps)
-      }, [isRStudioImage ? img({ src: rLogo, alt: 'Open RStudio', style: { maxWidth: 24, maxHeight: 24 } }) : icon('terminal', { size: 24 })]),
+      }, [isRStudioImage ? img({ src: rLogo, alt: '', style: { maxWidth: 24, maxHeight: 24 } }) : icon('terminal', { size: 24 })]),
       renderIcon(),
       h(IdContainer, [id => h(Fragment, [
         h(Clickable, {

--- a/src/components/ClusterManager.js
+++ b/src/components/ClusterManager.js
@@ -306,11 +306,11 @@ export default class ClusterManager extends PureComponent {
         href: appLaunchLink,
         onClick: window.location.hash === appLaunchLink && currentStatus === 'Stopped' ? () => this.startCluster() : undefined,
         tooltip: canCompute ? `Open ${appName}` : noCompute,
-        'aria-label': `Open ${appName}`,
+        'aria-label': !isRStudioImage ? `Open ${appName}`: undefined,
         disabled: !canCompute,
         style: { marginRight: '2rem', ...styles.verticalCenter },
         ...(isRStudioImage ? {} : Utils.newTabLinkProps)
-      }, [isRStudioImage ? img({ src: rLogo, alt: 'R-Studio Logo', style: { maxWidth: 24, maxHeight: 24 } }) : icon('terminal', { size: 24 })]),
+      }, [isRStudioImage ? img({ src: rLogo, alt: 'Open RStudio', style: { maxWidth: 24, maxHeight: 24 } }) : icon('terminal', { size: 24 })]),
       renderIcon(),
       h(IdContainer, [id => h(Fragment, [
         h(Clickable, {

--- a/src/components/ClusterManager.js
+++ b/src/components/ClusterManager.js
@@ -310,7 +310,7 @@ export default class ClusterManager extends PureComponent {
         disabled: !canCompute,
         style: { marginRight: '2rem', ...styles.verticalCenter },
         ...(isRStudioImage ? {} : Utils.newTabLinkProps)
-      }, [isRStudioImage ? img({ src: rLogo, style: { maxWidth: 24, maxHeight: 24 } }) : icon('terminal', { size: 24 })]),
+      }, [isRStudioImage ? img({ src: rLogo, alt: 'R-Studio Logo', style: { maxWidth: 24, maxHeight: 24 } }) : icon('terminal', { size: 24 })]),
       renderIcon(),
       h(IdContainer, [id => h(Fragment, [
         h(Clickable, {


### PR DESCRIPTION
Added an alt tag to the img of the Rstudio Logo in the cluster manager widget

Tested by running locally and checking that an alt tag showed when inspected and also ran ANDI to confirm it had no issues with the img.