### PR TITLE
fix messages for creating, starting, stopping

### DIFF
--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -248,7 +248,7 @@ const PreviewHeader = ({ queryParams, cluster, readOnlyAccess, onCreateCluster, 
         'Creating notebook runtime environment. You can navigate away and return in 3-5 minutes.'
       ])],
       [clusterStatus === 'Starting', () => h(StatusMessage, [
-        'Notebook runtime environment is stopped. Start it to edit your notebook or use the terminal.'
+        'Starting notebook runtime environment, this may take up to 2 minutes.'
       ])],
       [clusterStatus === 'Stopping', () => h(StatusMessage, [
         'Notebook runtime environment is stopping, which takes ~4 minutes. You can restart it after it finishes.'

--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -245,13 +245,13 @@ const PreviewHeader = ({ queryParams, cluster, readOnlyAccess, onCreateCluster, 
         ])
       ])],
       [clusterStatus === 'Creating', () => h(StatusMessage, [
-        'Creating notebook runtime, this will take 5-10 minutes. You can navigate away and return when it’s ready.'
+        'Creating notebook runtime environment. You can navigate away and return in 3-5 minutes.'
       ])],
       [clusterStatus === 'Starting', () => h(StatusMessage, [
-        'Starting notebook runtime, this may take up to 2 minutes.'
+        'Notebook runtime environment is stopped. Start it to edit your notebook or use the terminal.'
       ])],
       [clusterStatus === 'Stopping', () => h(StatusMessage, [
-        'Notebook runtime is stopping. You can restart it after it finishes.'
+        'Notebook runtime environment is stopping, which takes ~4 minutes. You can restart it after it finishes.'
       ])],
       [clusterStatus === 'Error', () => h(StatusMessage, { hideSpinner: true }, ['Notebook runtime error.'])]
     ),


### PR DESCRIPTION
These messages got reverted at some point but they should be what is in this google doc:
https://docs.google.com/document/d/1X78N_XViFWUL2NVup7LIBRP0wtu1tf5y2MNnaAG1bRs/edit

I have updated the wording for creating, starting and stopping to match

(Adrian is aware of these changes as he is the one who discovered that the outdated messages were still showing)