### PR TITLE
Fix color contrast for info about entities being copied [SATURN-1572]

### DIFF
--- a/src/components/ExportDataModal.js
+++ b/src/components/ExportDataModal.js
@@ -17,9 +17,9 @@ import * as Utils from 'src/libs/utils'
 import validate from 'validate.js'
 
 
-const InfoTile = ({ infoStyle, content, iconName, iconColor }) => {
+const InfoTile = ({ infoStyle, content, icon: { name, color } }) => {
   return div({ style: { ...infoStyle, display: 'flex', alignItems: 'center' } }, [
-    icon(iconName, { size: 36, style: { color: iconColor, flex: 'none', marginRight: '0.5rem' } }),
+    icon(name, { size: 36, style: { color, flex: 'none', marginRight: '0.5rem' } }),
     content
   ])
 }
@@ -89,7 +89,7 @@ const ExportDataModal = withWorkspaces(class ExportDataModal extends Component {
       }, ['Copy'])
     }, [
       runningSubmissionsCount > 0 && InfoTile({
-        infoStyle: warningStyle, iconName: 'warning-standard', iconColor: colors.warning(),
+        infoStyle: warningStyle, icon: { name: 'warning-standard', color: colors.warning() },
         content: `WARNING: ${runningSubmissionsCount} workflows are currently running in this workspace. ` +
           'Copying the following data could cause failures if a workflow is using this data.'
       }),
@@ -102,15 +102,15 @@ const ExportDataModal = withWorkspaces(class ExportDataModal extends Component {
         })
       ]),
       (hardConflicts.length !== 0) && InfoTile({
-        infoStyle: errorStyle, iconName: 'error-standard', iconColor: colors.danger(),
+        infoStyle: errorStyle, icon: { name: 'error-standard', color: colors.danger() },
         content: 'Some of the following data already exists in the selected workspace. Click CANCEL to go back or COPY to override the existing data.'
       }),
       moreToDelete && InfoTile({
-        infoStyle: warningStyle, iconName: 'warning-standard', iconColor: colors.warning(),
+        infoStyle: warningStyle, icon: { name: 'warning-standard', color: colors.warning() },
         content: 'To override the selected data entries, the following entries that reference the original data will also be deleted.'
       }),
       (softConflicts.length !== 0) && InfoTile({
-        infoStyle: warningStyle, iconName: 'warning-standard', iconColor: colors.warning(),
+        infoStyle: warningStyle, icon: { name: 'warning-standard', color: colors.warning() },
         content: 'The following data is linked to entries which already exist in the selected workspace. You may re-link the following data to the existing entries by clicking COPY.'
       }),
       h(FormLabel, ['Entries selected']),

--- a/src/components/ExportDataModal.js
+++ b/src/components/ExportDataModal.js
@@ -33,6 +33,7 @@ const InfoTile = ({ isError = false, content }) => {
   const [style, shape, color] = isError ?
     [errorStyle, 'error-standard', colors.danger()] :
     [warningStyle, 'warning-standard', colors.warning()]
+
   return div({ style: { ...style, display: 'flex', alignItems: 'center' } }, [
     icon(shape, { size: 36, style: { color, flex: 'none', marginRight: '0.5rem' } }),
     content

--- a/src/components/ExportDataModal.js
+++ b/src/components/ExportDataModal.js
@@ -29,10 +29,10 @@ const errorStyle = {
   backgroundColor: colors.danger(0.15)
 }
 
-const InfoTile = ({ type = 'warning', content }) => {
-  const [style, shape, color] = Utils.switchCase(type,
-    ['error', () => [errorStyle, 'error-standard', colors.danger()]],
-    [Utils.DEFAULT, () => [warningStyle, 'warning-standard', colors.warning()]])
+const InfoTile = ({ isError = false, content }) => {
+  const [style, shape, color] = isError ?
+    [errorStyle, 'error-standard', colors.danger()] :
+    [warningStyle, 'warning-standard', colors.warning()]
   return div({ style: { ...style, display: 'flex', alignItems: 'center' } }, [
     icon(shape, { size: 36, style: { color, flex: 'none', marginRight: '0.5rem' } }),
     content
@@ -105,7 +105,7 @@ const ExportDataModal = withWorkspaces(class ExportDataModal extends Component {
         })
       ]),
       (hardConflicts.length !== 0) && InfoTile({
-        type: 'error',
+        isError: true,
         content: 'Some of the following data already exists in the selected workspace. Click CANCEL to go back or COPY to override the existing data.'
       }),
       moreToDelete && InfoTile({

--- a/src/components/ExportDataModal.js
+++ b/src/components/ExportDataModal.js
@@ -17,9 +17,24 @@ import * as Utils from 'src/libs/utils'
 import validate from 'validate.js'
 
 
-const InfoTile = ({ infoStyle, content, icon: { name, color } }) => {
-  return div({ style: { ...infoStyle, display: 'flex', alignItems: 'center' } }, [
-    icon(name, { size: 36, style: { color, flex: 'none', marginRight: '0.5rem' } }),
+const warningStyle = {
+  border: `1px solid ${colors.warning(0.8)}`, borderLeft: 'none', borderRight: 'none',
+  backgroundColor: colors.warning(0.15),
+  padding: '1rem 1.25rem', margin: '0 -1.25rem',
+  fontWeight: 'bold', fontSize: 12
+}
+const errorStyle = {
+  ...warningStyle,
+  border: `1px solid ${colors.danger(0.8)}`,
+  backgroundColor: colors.danger(0.15)
+}
+
+const InfoTile = ({ type = 'warning', content }) => {
+  const [style, shape, color] = Utils.switchCase(type,
+    ['error', () => [errorStyle, 'error-standard', colors.danger()]],
+    [Utils.DEFAULT, () => [warningStyle, 'warning-standard', colors.warning()]])
+  return div({ style: { ...style, display: 'flex', alignItems: 'center' } }, [
+    icon(shape, { size: 36, style: { color, flex: 'none', marginRight: '0.5rem' } }),
     content
   ])
 }
@@ -62,17 +77,6 @@ const ExportDataModal = withWorkspaces(class ExportDataModal extends Component {
     const { onDismiss, selectedEntities, runningSubmissionsCount, workspace, workspaces } = this.props
     const { copying, hardConflicts, softConflicts, error, selectedWorkspaceId, additionalDeletions } = this.state
     const moreToDelete = !!additionalDeletions.length
-    const warningStyle = {
-      border: `1px solid ${colors.warning(0.8)}`, borderLeft: 'none', borderRight: 'none',
-      backgroundColor: colors.warning(0.15),
-      padding: '1rem 1.25rem', margin: '0 -1.25rem',
-      fontWeight: 'bold', fontSize: 12
-    }
-    const errorStyle = {
-      ...warningStyle,
-      border: `1px solid ${colors.danger(0.8)}`,
-      backgroundColor: colors.danger(0.15)
-    }
 
     const errors = validate(
       { selectedWorkspaceId },
@@ -89,7 +93,6 @@ const ExportDataModal = withWorkspaces(class ExportDataModal extends Component {
       }, ['Copy'])
     }, [
       runningSubmissionsCount > 0 && InfoTile({
-        infoStyle: warningStyle, icon: { name: 'warning-standard', color: colors.warning() },
         content: `WARNING: ${runningSubmissionsCount} workflows are currently running in this workspace. ` +
           'Copying the following data could cause failures if a workflow is using this data.'
       }),
@@ -102,15 +105,13 @@ const ExportDataModal = withWorkspaces(class ExportDataModal extends Component {
         })
       ]),
       (hardConflicts.length !== 0) && InfoTile({
-        infoStyle: errorStyle, icon: { name: 'error-standard', color: colors.danger() },
+        type: 'error',
         content: 'Some of the following data already exists in the selected workspace. Click CANCEL to go back or COPY to override the existing data.'
       }),
       moreToDelete && InfoTile({
-        infoStyle: warningStyle, icon: { name: 'warning-standard', color: colors.warning() },
         content: 'To override the selected data entries, the following entries that reference the original data will also be deleted.'
       }),
       (softConflicts.length !== 0) && InfoTile({
-        infoStyle: warningStyle, icon: { name: 'warning-standard', color: colors.warning() },
         content: 'The following data is linked to entries which already exist in the selected workspace. You may re-link the following data to the existing entries by clicking COPY.'
       }),
       h(FormLabel, ['Entries selected']),

--- a/src/components/ExportDataModal.js
+++ b/src/components/ExportDataModal.js
@@ -17,9 +17,9 @@ import * as Utils from 'src/libs/utils'
 import validate from 'validate.js'
 
 
-const InfoTile = ({ infoStyle, content, iconName }) => {
+const InfoTile = ({ infoStyle, content, iconName, iconColor }) => {
   return div({ style: { ...infoStyle, display: 'flex', alignItems: 'center' } }, [
-    icon(iconName, { size: 36, style: { flex: 'none', marginRight: '0.5rem' } }),
+    icon(iconName, { size: 36, style: { color: iconColor, flex: 'none', marginRight: '0.5rem' } }),
     content
   ])
 }
@@ -64,15 +64,14 @@ const ExportDataModal = withWorkspaces(class ExportDataModal extends Component {
     const moreToDelete = !!additionalDeletions.length
     const warningStyle = {
       border: `1px solid ${colors.warning(0.8)}`, borderLeft: 'none', borderRight: 'none',
-      backgroundColor: colors.warning(0.4),
+      backgroundColor: colors.warning(0.15),
       padding: '1rem 1.25rem', margin: '0 -1.25rem',
-      color: colors.warning(), fontWeight: 'bold', fontSize: 12
+      fontWeight: 'bold', fontSize: 12
     }
     const errorStyle = {
       ...warningStyle,
       border: `1px solid ${colors.danger(0.8)}`,
-      backgroundColor: colors.danger(0.4),
-      color: colors.danger()
+      backgroundColor: colors.danger(0.15)
     }
 
     const errors = validate(
@@ -90,7 +89,7 @@ const ExportDataModal = withWorkspaces(class ExportDataModal extends Component {
       }, ['Copy'])
     }, [
       runningSubmissionsCount > 0 && InfoTile({
-        infoStyle: warningStyle, iconName: 'warning-standard',
+        infoStyle: warningStyle, iconName: 'warning-standard', iconColor: colors.warning(),
         content: `WARNING: ${runningSubmissionsCount} workflows are currently running in this workspace. ` +
           'Copying the following data could cause failures if a workflow is using this data.'
       }),
@@ -103,15 +102,15 @@ const ExportDataModal = withWorkspaces(class ExportDataModal extends Component {
         })
       ]),
       (hardConflicts.length !== 0) && InfoTile({
-        infoStyle: errorStyle, iconName: 'error-standard',
+        infoStyle: errorStyle, iconName: 'error-standard', iconColor: colors.danger(),
         content: 'Some of the following data already exists in the selected workspace. Click CANCEL to go back or COPY to override the existing data.'
       }),
       moreToDelete && InfoTile({
-        infoStyle: warningStyle, iconName: 'warning-standard',
+        infoStyle: warningStyle, iconName: 'warning-standard', iconColor: colors.warning(),
         content: 'To override the selected data entries, the following entries that reference the original data will also be deleted.'
       }),
       (softConflicts.length !== 0) && InfoTile({
-        infoStyle: warningStyle, iconName: 'warning-standard',
+        infoStyle: warningStyle, iconName: 'warning-standard', iconColor: colors.warning(),
         content: 'The following data is linked to entries which already exist in the selected workspace. You may re-link the following data to the existing entries by clicking COPY.'
       }),
       h(FormLabel, ['Entries selected']),


### PR DESCRIPTION
Pretty straightforward. Also had to update the style for warning/error banners in that modal. For example, take a workspace that has data, clone it, then try to copy some data from the workspace to the clone.