### PR TITLE
Fix color contrast of 'click here for free credits' [SATURN-1564]

### DIFF
--- a/src/pages/billing/List.js
+++ b/src/pages/billing/List.js
@@ -290,7 +290,7 @@ export const BillingList = _.flow(
             )
           ]),
           hasFreeCredits && h(Clickable, {
-            style: { ...Style.navList.heading, color: colors.light(), backgroundColor: colors.accent() },
+            style: { ...Style.navList.heading, color: 'white', backgroundColor: colors.accent() },
             hover: { backgroundColor: colors.accent(0.85) },
             onClick: () => freeCreditsActive.set(true)
           }, ['Click for $300 free credits']),


### PR DESCRIPTION
Previously this 'button' had colors.light() for the text, however this didn't pass accessibility and our color scheme for primary buttons has the text as 'white'. I chose to set this text to 'white' as well since it's behavior is button-like.

tested locally in UI with ANDI