### PR TITLE
Make modal title more descriptive [SATURN-1611]

### DIFF
--- a/src/pages/groups/List.js
+++ b/src/pages/groups/List.js
@@ -96,7 +96,7 @@ const NewGroupModal = class NewGroupModal extends Component {
 const DeleteGroupModal = ({ groupName, onDismiss, onSubmit }) => {
   return h(Modal, {
     onDismiss,
-    title: 'Confirm',
+    title: 'Confirm Group Delete',
     okButton: h(ButtonPrimary, {
       onClick: onSubmit
     }, ['Delete Group'])


### PR DESCRIPTION
From what I can tell, there were 3 issues related to `/groups`. This is one of them. The other two (B9 and J1) seem to indicate the same thing that seems to have been remediated in #2114. I could use a second opinion about whether or not there is anything else to be done for https://broadworkbench.atlassian.net/browse/SATURN-1611.