### PR TITLE
Allow creating sets of sets and launching in a single submission [SATURN-1321]

### DIFF
--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -573,6 +573,7 @@ class EntitiesContent extends Component {
 
   renderDownloadButton(columnSettings) {
     const { workspace: { workspace: { namespace, name } }, entityKey } = this.props
+    const disabled = entityKey.endsWith('_set_set')
     return h(Fragment, [
       form({
         ref: this.downloadForm,
@@ -584,7 +585,10 @@ class EntitiesContent extends Component {
         input({ type: 'hidden', name: 'model', value: 'flexible' })
       ]),
       h(ButtonPrimary, {
-        tooltip: `Download a .tsv file containing all the ${entityKey}s in this table`,
+        disabled,
+        tooltip: disabled ?
+          'Downloading sets of sets as TSV is not supported at this time' :
+          `Download a .tsv file containing all the ${entityKey}s in this table`,
         onClick: () => this.downloadForm.current.submit()
       }, [
         icon('download', { style: { marginRight: '0.5rem' } }),
@@ -622,13 +626,17 @@ class EntitiesContent extends Component {
     const { selectedEntities } = this.state
     const isSet = _.endsWith('_set', entityKey)
     const noEdit = Utils.editWorkspaceError(workspace)
+    const disabled = entityKey.endsWith('_set_set')
 
     return !_.isEmpty(selectedEntities) && h(PopupTrigger, {
       side: 'bottom',
       closeOnClick: true,
       content: h(Fragment, [
         h(MenuButton, {
-          tooltip: `Download the selected data as a file`,
+          disabled,
+          tooltip: disabled ?
+            'Downloading sets of sets as TSV is not supported at this time' :
+            `Download the selected data as a file`,
           onClick: async () => {
             const tsv = this.buildTSV(columnSettings, selectedEntities)
             isSet ?

--- a/src/pages/workspaces/workspace/workflows/DataStepContent.js
+++ b/src/pages/workspaces/workspace/workflows/DataStepContent.js
@@ -50,7 +50,7 @@ export default class DataStepContent extends Component {
     return selectionSize === 1 ||
       (type === processAll && !!newSetName) ||
       (type === chooseRows && !!newSetName && selectionSize > 1) ||
-      (type === chooseSets && selectionSize > 1 && selectionSize <= 10) ||
+      (type === chooseSets && !!newSetName && selectionSize > 1) ||
       (type === processMergedSet && !!newSetName && selectionSize > 1) ||
       (type === chooseSetComponents && !!newSetName && selectionSize > 0) ||
       (type === processAllAsSet && !!newSetName)
@@ -181,7 +181,7 @@ export default class DataStepContent extends Component {
                 [isProcessMergedSet, () => 'Select one or more sets to combine and process'],
                 [isChooseRows, () => `Select ${rootEntityType}s to process`],
                 [isChooseSetComponents, () => `Select ${baseEntityType}s to create a new set to process`],
-                [isChooseSets, () => `Select up to 10 ${rootEntityType}s to process in parallel`]
+                [isChooseSets, () => `Select ${rootEntityType}s to process`]
               )
             ]),
             entityType: (isChooseSetComponents && baseEntityType) || (isProcessMergedSet && setType) || rootEntityType,
@@ -193,7 +193,7 @@ export default class DataStepContent extends Component {
           })
         ]),
         (isProcessAll || isProcessAllAsSet || (isChooseSetComponents && !_.isEmpty(selectedEntities)) ||
-          ((isChooseRows || isProcessMergedSet) && _.size(selectedEntities) > 1)) && h(IdContainer,
+          ((isChooseRows || isProcessMergedSet || isChooseSets) && _.size(selectedEntities) > 1)) && h(IdContainer,
           [id => div({ style: { marginTop: '1rem' } }, [
             h(FormLabel, { htmlFor: id }, [
               Utils.cond(
@@ -201,6 +201,7 @@ export default class DataStepContent extends Component {
                 [isProcessAllAsSet, () => `All ${baseEntityTypeCount} ${baseEntityType}s will be saved as a new set named:`],
                 [isProcessMergedSet, () => `Selected ${rootEntityType}s will have their membership combined into a new set named:`],
                 [isChooseSetComponents, () => `Selected ${baseEntityType}s will be saved as a new set named:`],
+                [isChooseSets, () => `Selected ${rootEntityType}s will be saved as a new set named:`],
                 [isChooseRows, () => `Selected ${rootEntityType}s will be saved as a new set named:`]
               )
             ]),

--- a/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
+++ b/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
@@ -90,7 +90,7 @@ export default ajaxCaller(class LaunchAnalysisModal extends Component {
       (!entities && !processSingle) ? spinner() : div({ style: { margin: '1rem 0' } }, [
         'This will launch ', b([entityCount]), ` analys${entityCount === 1 ? 'is' : 'es'}`,
         '.',
-        !processSingle && type !== chooseSets /* ??? */ && type !== processAll && entityCount !== entities.length && div({
+        !processSingle && type !== processAll && entityCount !== entities.length && div({
           style: { fontStyle: 'italic', marginTop: '0.5rem' }
         }, ['(Duplicate entities are only processed once.)'])
       ]),

--- a/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
+++ b/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
@@ -47,6 +47,7 @@ export default ajaxCaller(class LaunchAnalysisModal extends Component {
     if (!processSingle) {
       return Utils.switchCase(type,
         [chooseRows, () => _.keys(selectedEntities)],
+        [chooseSets, () => _.keys(selectedEntities)],
         [chooseSetComponents, () => _.keys(selectedEntities)],
         [processMergedSet, () => _.flow(
           _.flatMap(`attributes.${rootEntityType}s.items`),
@@ -88,9 +89,8 @@ export default ajaxCaller(class LaunchAnalysisModal extends Component {
       div({ style: { margin: '1rem 0' } }, ['This analysis will be run by ', h(CromwellVersionLink), '.']),
       (!entities && !processSingle) ? spinner() : div({ style: { margin: '1rem 0' } }, [
         'This will launch ', b([entityCount]), ` analys${entityCount === 1 ? 'is' : 'es'}`,
-        type === chooseSets && entityCount > 1 && ' simultaneously',
         '.',
-        !processSingle && type !== chooseSets && type !== processAll && entityCount !== entities.length && div({
+        !processSingle && type !== chooseSets /* ??? */ && type !== processAll && entityCount !== entities.length && div({
           style: { fontStyle: 'italic', marginTop: '0.5rem' }
         }, ['(Duplicate entities are only processed once.)'])
       ]),
@@ -134,7 +134,7 @@ export default ajaxCaller(class LaunchAnalysisModal extends Component {
       this.setState({ message: 'Fetching data...' })
       const allEntities = _.map('name', await Workspaces.workspace(namespace, name).entitiesOfType(rootEntityType))
       this.createSetAndLaunch(allEntities)
-    } else if (type === chooseRows) {
+    } else if (type === chooseRows || type === chooseSets) {
       if (entities.length === 1) {
         this.launch(rootEntityType, entities[0])
       } else {
@@ -148,12 +148,6 @@ export default ajaxCaller(class LaunchAnalysisModal extends Component {
       const baseEntityType = rootEntityType.slice(0, -4)
       const allBaseEntities = _.map('name', await Workspaces.workspace(namespace, name).entitiesOfType(baseEntityType))
       this.createSetAndLaunchOne(allBaseEntities)
-    } else if (type === chooseSets) {
-      if (_.size(entities) === 1) {
-        this.launch(rootEntityType, _.values(entities)[0].name)
-      } else {
-        this.launchParallel()
-      }
     }
   }
 

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -327,7 +327,7 @@ const WorkflowView = _.flow(
 
     return {
       type: Utils.cond(
-        [isSet(value), () => _.includes(value, _.keys(entityMetadata)) ? chooseSets : processAllAsSet],
+        [isSet(value), () => _.includes(value, _.keys(entityMetadata)) ? chooseSets : processAllAsSet], // ???
         [_.isEmpty(selectedEntities), () => processAll],
         () => chooseRows
       ),
@@ -549,7 +549,7 @@ const WorkflowView = _.flow(
       [type === chooseSetComponents, () => `1 ${rootEntityType} containing ${count} ${baseEntityType}s ${newSetMessage}`],
       [type === processAllAsSet, () => `1 ${rootEntityType} containing all ${entityMetadata[baseEntityType]?.count || 0} ${baseEntityType}s ${newSetMessage}`],
       [type === chooseSets, () => !!count ?
-        `${count} selected ${rootEntityType}s` :
+        `${count} selected ${rootEntityType}s ${newSetMessage}` :
         `No ${rootEntityType}s selected`]
     )
   }
@@ -592,7 +592,7 @@ const WorkflowView = _.flow(
       [saving || modified, () => 'Save or cancel to Launch Analysis'],
       [!_.isEmpty(errors.inputs) || !_.isEmpty(errors.outputs), () => 'At least one required attribute is missing or invalid'],
       [this.isMultiple() && (!entityMetadata[rootEntityType] && !_.includes(rootEntityType, possibleSetTypes)), () => `There are no ${selectedEntityType}s in this workspace.`],
-      [this.isMultiple() && (entitySelectionModel.type === chooseSets || entitySelectionModel.type === chooseSetComponents) && !_.size(entitySelectionModel.selectedEntities),
+      [this.isMultiple() && (entitySelectionModel.type === chooseSets || entitySelectionModel.type === chooseSetComponents) && !_.size(entitySelectionModel.selectedEntities), // ???
         () => 'Select or create a set']
     )
 

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -325,9 +325,11 @@ const WorkflowView = _.flow(
   resetSelectionModel(value, selectedEntities = {}, entityMetadata = this.state.entityMetadata) {
     const { workflowName } = this.props
 
+    // If the default for non-set types changes from `processAllAsSet` then the calculation of `noLaunchReason` in `renderSummary` needs to be updated accordingly.
+    // Currently, `renderSummary` assumes that it is not possible to have nothing selected for non-set types.
     return {
       type: Utils.cond(
-        [isSet(value), () => _.includes(value, _.keys(entityMetadata)) ? chooseSets : processAllAsSet], // ???
+        [isSet(value), () => _.includes(value, _.keys(entityMetadata)) ? chooseSets : processAllAsSet],
         [_.isEmpty(selectedEntities), () => processAll],
         () => chooseRows
       ),
@@ -592,7 +594,10 @@ const WorkflowView = _.flow(
       [saving || modified, () => 'Save or cancel to Launch Analysis'],
       [!_.isEmpty(errors.inputs) || !_.isEmpty(errors.outputs), () => 'At least one required attribute is missing or invalid'],
       [this.isMultiple() && (!entityMetadata[rootEntityType] && !_.includes(rootEntityType, possibleSetTypes)), () => `There are no ${selectedEntityType}s in this workspace.`],
-      [this.isMultiple() && (entitySelectionModel.type === chooseSets || entitySelectionModel.type === chooseSetComponents) && !_.size(entitySelectionModel.selectedEntities), // ???
+      // Default for _set types is `chooseSets` so we need to make sure something is selected.
+      // Default for non- _set types is `processAll` and the "Select Data" modal makes it impossible to have nothing selected for these types.
+      // Users have expressed dislike of the `processAll` default so this clause will likely need to be expanded along with any change to `resetSelectionModel`.
+      [this.isMultiple() && (entitySelectionModel.type === chooseSets || entitySelectionModel.type === chooseSetComponents) && !_.size(entitySelectionModel.selectedEntities),
         () => 'Select or create a set']
     )
 


### PR DESCRIPTION
Treat the "chooseSets" case more-or-less the same as the "chooseRows" case. This relates to https://broadworkbench.atlassian.net/browse/SATURN-1321 and the discussions today in #saturn and #saturn-team slack channels.

I'm not entirely sure why we didn't do this in the first place. Maybe we thought that Rawls didn't support it? It turns out that Rawls does support sets of sets (though Orch's TSV import doesn't). If anyone remembers anything different, please comment.

I tested this with a simple "echo_string" workflow with sample_set as the root entity type:
* selecting a single existing set, which launches that one workflow in a single submission as before
* selecting multiple sets, which creates a sample_set_set containing the selected sets and launches multiple workflows in a single submission as desired

I addressed the core functionality bits that allowed me to test. There are still a few instances of `chooseSets` that need a closer look than I've given; I've put `???` comments near those. It occurs to me now that we'd also want to audit occurrences of `chooseRows` to see if those conditions should also apply to `chooseSets`.