### PR TITLE
Fixes icon spacing on create workspace

### DIFF
--- a/src/components/NewWorkspaceModal.js
+++ b/src/components/NewWorkspaceModal.js
@@ -177,7 +177,7 @@ export default _.flow(
         h(IdContainer, [id => h(Fragment, [
           h(FormLabel, { htmlFor: id }, [
             'Authorization domain',
-            h(InfoBox, [
+            h(InfoBox, { style: { marginLeft: '0.25rem' } }, [
               'An authorization domain can only be set when creating a workspace. ',
               'Once set, it cannot be changed. ',
               'Any cloned workspace will automatically inherit the authorization domain(s) from the original workspace and cannot be removed. ',


### PR DESCRIPTION
Adds a minor amount of spacing to the icon next to auth domains.
Previously:
<img width="454" alt="Screen Shot 2020-05-14 at 3 35 02 PM" src="https://user-images.githubusercontent.com/15351021/81982437-d0c51f00-95ff-11ea-9be7-62e88b5dc1db.png">
Now:
<img width="453" alt="Screen Shot 2020-05-14 at 4 27 39 PM" src="https://user-images.githubusercontent.com/15351021/81982461-d91d5a00-95ff-11ea-9988-5220dd1e8466.png">
