### PR TITLE
Add details to notebook launch (SATURN-1620)

### DIFF
--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -345,7 +345,7 @@ const NotebookPreviewFrame = ({ notebookName, workspace: { workspace: { namespac
 
 const JupyterFrameManager = ({ onClose, frameRef, details = {} }) => {
   Utils.useOnMount(() => {
-    Ajax().Metrics.captureEvent(Events.notebookLaunch, { 'Notebook Name': details.notebookName, ' Workspace Name': details.name, 'Workspace Namespace': details.namespace })
+    Ajax().Metrics.captureEvent(Events.notebookLaunch, { 'Notebook Name': details.notebookName, 'Workspace Name': details.name, 'Workspace Namespace': details.namespace })
 
     const isSaved = Utils.atom(true)
     const onMessage = e => {

--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -343,9 +343,9 @@ const NotebookPreviewFrame = ({ notebookName, workspace: { workspace: { namespac
   ])
 }
 
-const JupyterFrameManager = ({ onClose, frameRef }) => {
+const JupyterFrameManager = ({ onClose, frameRef, details = {} }) => {
   Utils.useOnMount(() => {
-    Ajax().Metrics.captureEvent(Events.notebookLaunch)
+    Ajax().Metrics.captureEvent(Events.notebookLaunch, { 'Notebook Name': details.notebookName, ' Workspace Name': details.name, 'Workspace Namespace': details.namespace })
 
     const isSaved = Utils.atom(true)
     const onMessage = e => {
@@ -438,7 +438,8 @@ const NotebookEditorFrame = ({ mode, notebookName, workspace: { workspace: { nam
       }),
       h(JupyterFrameManager, {
         frameRef,
-        onClose: () => Nav.goToPath('workspace-notebooks', { namespace, name })
+        onClose: () => Nav.goToPath('workspace-notebooks', { namespace, name }),
+        details: { notebookName, name, namespace }
       })
     ]),
     busy && copyingNotebookMessage
@@ -499,7 +500,8 @@ const WelderDisabledNotebookEditorFrame = ({ mode, notebookName, workspace: { wo
       }),
       h(JupyterFrameManager, {
         frameRef,
-        onClose: () => Nav.goToPath('workspace-notebooks', { namespace, name })
+        onClose: () => Nav.goToPath('workspace-notebooks', { namespace, name }),
+        details: { notebookName, name, namespace }
       })
     ]),
     busy && copyingNotebookMessage


### PR DESCRIPTION
Added the workspace name, workspace namespace and notebook name to the launch notebook event. Tested this locally by sending events to MixPanel

Before:
<img width="1198" alt="Screen Shot 2020-05-18 at 12 05 48 PM" src="https://user-images.githubusercontent.com/54322292/82236469-22242580-9902-11ea-93d8-ab5bbb6927bf.png">

After:
<img width="1213" alt="Screen Shot 2020-05-18 at 12 05 31 PM" src="https://user-images.githubusercontent.com/54322292/82236483-26504300-9902-11ea-936e-375a591abd29.png">
