### PR TITLE
Add workflow source and snapshotId [SATURN-1621]

### DIFF
--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -11,6 +11,7 @@ const eventsList = {
   pageView: 'page:view',
   workflowImport: 'workflow:import',
   workflowLaunch: 'workflow:launch',
+  workflowRerun: 'workflow:rerun',
   workspaceDataImport: 'workspace:data:import',
   workspaceShare: 'workspace:share'
 }

--- a/src/pages/workspaces/workspace/JobHistory.js
+++ b/src/pages/workspaces/workspace/JobHistory.js
@@ -128,7 +128,6 @@ const JobHistory = _.flow(
           return _.set('asText', subAsText, sub)
         })
       )(await Workspaces.workspace(namespace, name).listSubmissions())
-
       this.setState({ submissions })
 
       if (_.some(({ status }) => !isTerminal(status), submissions)) {

--- a/src/pages/workspaces/workspace/workflows/FailureRerunner.js
+++ b/src/pages/workspaces/workspace/workflows/FailureRerunner.js
@@ -61,11 +61,11 @@ export const rerunFailures = async ({ namespace, name, submissionId, configNames
         reportError('Error rerunning failed workflows', error)
       }
     })
-    Ajax().Metrics.captureEvent(Events.workflowLaunch, { rerun: true, success: true })
+    Ajax().Metrics.captureEvent(Events.workflowRerun, { success: true, configNamespace, configName })
 
     await Utils.delay(2000)
   } catch (error) {
-    Ajax().Metrics.captureEvent(Events.workflowLaunch, { rerun: true, success: false })
+    Ajax().Metrics.captureEvent(Events.workflowRerun, { success: false, configNamespace, configName })
     reportError('Error rerunning failed workflows', error)
   } finally {
     clearNotification(id)

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -397,11 +397,17 @@ const WorkflowView = _.flow(
     // savedConfig: unmodified copy of config for checking for unsaved edits
     // modifiedConfig: active data, potentially unsaved
     const {
-      isFreshData, savedConfig, entityMetadata, launching, activeTab, useCallCache, deleteIntermediateOutputFiles,
+      currentSnapRedacted, isFreshData, savedConfig, entityMetadata, launching, activeTab, useCallCache, deleteIntermediateOutputFiles,
       entitySelectionModel, variableSelected, modifiedConfig, updatingConfig
     } = this.state
+    const { methodVersion, methodNamespace, methodName, methodPath, sourceRepo } = modifiedConfig.methodRepoMethod
     const { namespace, name, workspace } = this.props
     const workspaceId = { namespace, name }
+    const workflowMetadata = {
+      // Source follows the logic of the rendering on the page. It is not identical because the rendering requires elements to be included.
+      snapshotId: modifiedConfig.methodRepoMethod.methodVersion, source: sourceRepo === 'agora' || currentSnapRedacted ?
+        `${methodNamespace}/${methodName}/${methodVersion}` : `${methodPath}:${methodVersion}`
+    }
     return h(Fragment, [
       savedConfig && h(Fragment, [
         this.renderSummary(),
@@ -416,11 +422,11 @@ const WorkflowView = _.flow(
           processSingle: this.isSingle(), entitySelectionModel, useCallCache, deleteIntermediateOutputFiles,
           onDismiss: () => this.setState({ launching: false }),
           onSuccess: submissionId => {
-            Ajax().Metrics.captureEvent(Events.workflowLaunch, { multi: false })
+            Ajax().Metrics.captureEvent(Events.workflowLaunch, { ...workflowMetadata, multi: false })
             Nav.goToPath('workspace-submission-details', { submissionId, ...workspaceId })
           },
           onSuccessMulti: () => {
-            Ajax().Metrics.captureEvent(Events.workflowLaunch, { multi: true })
+            Ajax().Metrics.captureEvent(Events.workflowLaunch, { ...workflowMetadata, multi: true })
             Nav.goToPath('workspace-job-history', workspaceId)
           }
         }),

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -400,13 +400,17 @@ const WorkflowView = _.flow(
       currentSnapRedacted, isFreshData, savedConfig, entityMetadata, launching, activeTab, useCallCache, deleteIntermediateOutputFiles,
       entitySelectionModel, variableSelected, modifiedConfig, updatingConfig
     } = this.state
-    const { methodVersion, methodNamespace, methodName, methodPath, sourceRepo } = modifiedConfig.methodRepoMethod
     const { namespace, name, workspace } = this.props
     const workspaceId = { namespace, name }
-    const workflowMetadata = {
-      // Source follows the logic of the rendering on the page. It is not identical because the rendering requires elements to be included.
-      snapshotId: modifiedConfig.methodRepoMethod.methodVersion, source: sourceRepo === 'agora' || currentSnapRedacted ?
-        `${methodNamespace}/${methodName}/${methodVersion}` : `${methodPath}:${methodVersion}`
+    let workflowMetadata
+    if (savedConfig) {
+      const { methodRepoMethod: { methodVersion, methodNamespace, methodName, methodPath, sourceRepo } } = modifiedConfig
+
+      workflowMetadata = {
+        // Source follows the logic of the rendering on the page. It is not identical because the rendering requires elements to be included.
+        snapshotId: modifiedConfig.methodRepoMethod.methodVersion, source: sourceRepo === 'agora' || currentSnapRedacted ?
+          `${methodNamespace}/${methodName}/${methodVersion}` : `${methodPath}:${methodVersion}`
+      }
     }
     return h(Fragment, [
       savedConfig && h(Fragment, [


### PR DESCRIPTION
This adds the source and snapshot ID to the bard reporting. I noticed that we also report here: https://github.com/DataBiosphere/terra-ui/blob/dev/src/pages/workspaces/workspace/workflows/FailureRerunner.js#L64 so I talked to Adrian. If this is an automated retry, we don't need all that info, because it isn't a user triggering it. If it is a manual process, we do. It looked automated to me, but I would love experienced eyes to confirm.