### PR TITLE
support for import service status values [no ticket; risk: low]

### DIFF
--- a/src/components/ImportStatus.js
+++ b/src/components/ImportStatus.js
@@ -49,14 +49,17 @@ const ImportStatusItem = ({ job: { targetWorkspace, jobId }, onDone }) => {
     // TODO: only need to support both sets of statuses during the transition from avro-import to import service.
     // once import servie is fully adopted, we can/should remove the avro-import status values.
 
+    const successNotify = () => notify('success', 'Data imported successfully.',
+      { message: `Data import to workspace "${namespace} / ${name}" is complete. Please refresh the Data view.` })
+
+    const errorNotify = () => notify('error', 'Error importing PFB data.', message)
+
     if (!_.includes(status, ['PENDING', 'RUNNING', 'Pending', 'Translating', 'ReadyForUpsert', 'Upserting'])) {
       Utils.switchCase(status,
-        ['SUCCESS', () => notify('success', 'Data imported successfully.',
-          { message: `Data import to workspace "${namespace} / ${name}" is complete. Please refresh the Data view.` })],
-        ['Done', () => notify('success', 'Data imported successfully.',
-          { message: `Data import to workspace "${namespace} / ${name}" is complete. Please refresh the Data view.` })],
-        ['ERROR', () => notify('error', 'Error importing PFB data.', message)],
-        ['Error', () => notify('error', 'Error importing PFB data.', message)],
+        ['SUCCESS', successNotify],
+        ['Done', successNotify],
+        ['ERROR', errorNotify],
+        ['Error', errorNotify],
         [Utils.DEFAULT, () => notify('error', 'Unexpected error importing PFB data', response)]
       )
       clearNotification(jobId)

--- a/src/components/ImportStatus.js
+++ b/src/components/ImportStatus.js
@@ -44,11 +44,19 @@ const ImportStatusItem = ({ job: { targetWorkspace, jobId }, onDone }) => {
     const response = await fetchImportStatus()
     const { message, status } = response
 
-    if (!_.includes(status, ['PENDING', 'RUNNING'])) {
+    // avro-import statuses: PENDING, RUNNING, SUCCESS, ERROR
+    // import service statuses: Pending, Translating, ReadyForUpsert, Upserting, Done, Error
+    // TODO: only need to support both sets of statuses during the transition from avro-import to import service.
+    // once import servie is fully adopted, we can/should remove the avro-import status values.
+
+    if (!_.includes(status, ['PENDING', 'RUNNING', 'Pending', 'Translating', 'ReadyForUpsert', 'Upserting'])) {
       Utils.switchCase(status,
         ['SUCCESS', () => notify('success', 'Data imported successfully.',
           { message: `Data import to workspace "${namespace} / ${name}" is complete. Please refresh the Data view.` })],
+        ['Done', () => notify('success', 'Data imported successfully.',
+          { message: `Data import to workspace "${namespace} / ${name}" is complete. Please refresh the Data view.` })],
         ['ERROR', () => notify('error', 'Error importing PFB data.', message)],
+        ['Error', () => notify('error', 'Error importing PFB data.', message)],
         [Utils.DEFAULT, () => notify('error', 'Unexpected error importing PFB data', response)]
       )
       clearNotification(jobId)


### PR DESCRIPTION
We (app services) made a mistake: when building the new import service, we changed the job status values the service could return. This PR makes the UI resilient to those.

We've just deployed the cutover for avro-import to import service into the dev env - given the planned release schedule, it won't hit prod for at least a week. During this period, we should support both sets of statuses, which this PR handles. After we're fully on import service and avro-import is gone, we can/should remove the old status values.

I tested this by running it locally and seeing a successful import message. Without this PR, a successful backend job shows up as "unexpected error" in the UI because the UI doesn't recognize the status.