### PR TITLE
Add pagename to event name [SATURN-1619]

### DIFF
--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -23,7 +23,7 @@ export const PageViewReporter = () => {
 
   useEffect(() => {
     if (isSignedIn && registrationStatus === 'registered') {
-      Ajax().Metrics.captureEvent(eventsList.pageView)
+      Ajax().Metrics.captureEvent(`${eventsList.pageView}:${name}`)
     }
   }, [isSignedIn, name, registrationStatus])
 


### PR DESCRIPTION
Looking for thoughts on doing pageview:<page name> or some abbreviation on 'page view' to cut down on repetition.

Add the page path the event to make funnels and flows more obvious. (could previously be done by filtering by page view event and then filtering on appPath but this way you just filter by the event which is page:view:'pagename'

Tested locally.

Example funnel
<img width="1362" alt="Screen Shot 2020-05-26 at 2 51 53 PM" src="https://user-images.githubusercontent.com/54322292/82939114-d6f0bf00-9f60-11ea-9fb8-2f7147c673d8.png">
