### PR TITLE
Add tooltip for enabled create new workspace '+' button [SATURN-1606]

### DIFF
--- a/src/components/NewWorkspaceModal.js
+++ b/src/components/NewWorkspaceModal.js
@@ -146,7 +146,11 @@ export default _.flow(
         onDismiss,
         okButton: h(ButtonPrimary, {
           disabled: errors,
-          tooltip: Utils.summarizeErrors(errors),
+          tooltip: Utils.cond(
+            [errors, Utils.summarizeErrors(errors)],
+            [cloneWorkspace, 'Clone new workspace'],
+            [Utils.DEFAULT, 'Create new workspace']
+          ),
           onClick: () => this.create()
         }, Utils.cond(
           [buttonText, buttonText],

--- a/src/components/NewWorkspaceModal.js
+++ b/src/components/NewWorkspaceModal.js
@@ -146,11 +146,7 @@ export default _.flow(
         onDismiss,
         okButton: h(ButtonPrimary, {
           disabled: errors,
-          tooltip: Utils.cond(
-            [errors, Utils.summarizeErrors(errors)],
-            [cloneWorkspace, 'Clone new workspace'],
-            [Utils.DEFAULT, 'Create new workspace']
-          ),
+          tooltip: Utils.summarizeErrors(errors),
           onClick: () => this.create()
         }, Utils.cond(
           [buttonText, buttonText],

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -295,7 +295,12 @@ export const WorkspaceList = () => {
     div({ role: 'main', style: { padding: '1.5rem', flex: 1, display: 'flex', flexDirection: 'column' } }, [
       div({ style: { display: 'flex', alignItems: 'center', marginBottom: '1rem' } }, [
         div({ style: { ...Style.elements.sectionHeader, textTransform: 'uppercase' } }, ['Workspaces']),
-        h(Link, { 'aria-label': 'Create new workspace', onClick: () => setCreatingNewWorkspace(true), style: { marginLeft: '0.5rem' } }, [icon('lighter-plus-circle', { size: 24 })])
+        h(Link, {
+          'aria-label': 'Create new workspace', onClick: () => setCreatingNewWorkspace(true),
+          style: { marginLeft: '0.5rem' },
+          tooltip: 'Create a new workspace'
+        },
+        [icon('lighter-plus-circle', { size: 24 })])
       ]),
       div({ style: { display: 'flex', marginBottom: '1rem' } }, [
         div({ style: styles.filter }, [


### PR DESCRIPTION
Previously we did not have a tooltip for the button that allowed us to create a new workspace when it was enabled, so I added that.
I also noticed we were missing it for cloning a new workspace so I added that for that case as well.