### PR TITLE
Remove unrelated COVID pics and replace with relevant pics [SATURN-1601]

### DIFF
--- a/src/pages/library/Showcase.js
+++ b/src/pages/library/Showcase.js
@@ -46,8 +46,8 @@ const makeCard = variant => ({ workspace: { namespace, name, attributes: { descr
         width: 87,
         ...Utils.switchCase(variant,
           ['new', () => Utils.switchCase(
-            [name.toLowerCase().includes('covid'), () =>({ backgroundImage: `url(${covidBg})` })],
-            [Utils.DEFAULT, () =>({ backgroundImage: `url(${featuredBg})`, opacity: 0.75 })]
+            [name.toLowerCase().includes('covid'), () => ({ backgroundImage: `url(${covidBg})` })],
+            [Utils.DEFAULT, () => ({ backgroundImage: `url(${featuredBg})`, opacity: 0.75 })]
           )],
           ['gatk', () => ({ backgroundColor: '#333', backgroundImage: `url(${gatkLogo})`, backgroundSize: undefined })],
           [Utils.DEFAULT, () => ({ backgroundImage: `url(${featuredBg})`, opacity: 0.75 })]

--- a/src/pages/library/Showcase.js
+++ b/src/pages/library/Showcase.js
@@ -45,7 +45,10 @@ const makeCard = variant => ({ workspace: { namespace, name, attributes: { descr
         backgroundRepeat: 'no-repeat', backgroundPosition: 'center', backgroundSize: 'auto 100%', borderRadius: '0 5px 5px 0',
         width: 87,
         ...Utils.switchCase(variant,
-          ['new', () => ({ backgroundImage: `url(${covidBg})` })],
+          ['new', () => Utils.switchCase(
+            [name.toLowerCase().includes('covid'), () =>({ backgroundImage: `url(${covidBg})` })],
+            [Utils.DEFAULT, () =>({ backgroundImage: `url(${featuredBg})`, opacity: 0.75 })]
+          )],
           ['gatk', () => ({ backgroundColor: '#333', backgroundImage: `url(${gatkLogo})`, backgroundSize: undefined })],
           [Utils.DEFAULT, () => ({ backgroundImage: `url(${featuredBg})`, opacity: 0.75 })]
         )

--- a/src/pages/library/Showcase.js
+++ b/src/pages/library/Showcase.js
@@ -44,13 +44,10 @@ const makeCard = variant => ({ workspace: { namespace, name, attributes: { descr
       style: {
         backgroundRepeat: 'no-repeat', backgroundPosition: 'center', backgroundSize: 'auto 100%', borderRadius: '0 5px 5px 0',
         width: 87,
-        ...Utils.switchCase(variant,
-          ['new', () => Utils.switchCase(
-            [name.toLowerCase().includes('covid'), () => ({ backgroundImage: `url(${covidBg})` })],
-            [Utils.DEFAULT, () => ({ backgroundImage: `url(${featuredBg})`, opacity: 0.75 })]
-          )],
-          ['gatk', () => ({ backgroundColor: '#333', backgroundImage: `url(${gatkLogo})`, backgroundSize: undefined })],
-          [Utils.DEFAULT, () => ({ backgroundImage: `url(${featuredBg})`, opacity: 0.75 })]
+        ...Utils.cond(
+          [name.toLowerCase().includes('covid'), { backgroundImage: `url(${covidBg})` }],
+          [variant === 'gatk', () => ({ backgroundColor: '#333', backgroundImage: `url(${gatkLogo})`, backgroundSize: undefined })],
+          { backgroundImage: `url(${featuredBg})`, opacity: 0.75 }
         )
       }
     })


### PR DESCRIPTION
in new and interesting, it was defaulted to make them all COVID virus images. However, this isn't related to every item in the list and a different, default image should be available. Now it only shows the COVID virus image if there is "COVID" in the title