### PR TITLE
refactor fence linking [SATURN-1686]

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -291,8 +291,16 @@ const User = signal => ({
   },
 
   getNihStatus: async () => {
-    const res = await fetchOrchestration('api/nih/status', _.merge(authOpts(), { signal }))
-    return res.json()
+    try {
+      const res = await fetchOrchestration('api/nih/status', _.merge(authOpts(), { signal }))
+      return res.json()
+    } catch (error) {
+      if (error.status === 404) {
+        return {}
+      } else {
+        throw error
+      }
+    }
   },
 
   linkNihAccount: async token => {
@@ -301,8 +309,16 @@ const User = signal => ({
   },
 
   getFenceStatus: async provider => {
-    const res = await fetchBond(`api/link/v1/${provider}`, _.merge(authOpts(), { signal }))
-    return res.json()
+    try {
+      const res = await fetchBond(`api/link/v1/${provider}`, _.merge(authOpts(), { signal }))
+      return res.json()
+    } catch (error) {
+      if (error.status === 404) {
+        return {}
+      } else {
+        throw error
+      }
+    }
   },
 
   getFenceAuthUrl: async (provider, redirectUri) => {

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -9,6 +9,7 @@ import { withErrorReporting } from 'src/libs/error'
 import { getAppName } from 'src/libs/logos'
 import * as Nav from 'src/libs/nav'
 import { clearNotification, notify, sessionTimeoutProps } from 'src/libs/notifications'
+import { allProviders, providerName } from 'src/libs/providers'
 import { authStore, pfbImportJobStore, requesterPaysProjectStore, workspacesStore, workspaceStore } from 'src/libs/state'
 import * as Utils from 'src/libs/utils'
 
@@ -80,8 +81,7 @@ export const initializeAuth = _.memoize(async () => {
         acceptedTos: isSignedIn ? state.acceptedTos : undefined,
         profile: isSignedIn ? state.profile : {},
         nihStatus: isSignedIn ? state.nihStatus : undefined,
-        fenceDCPStatus: isSignedIn ? state.fenceDCPStatus : undefined,
-        fenceDCFStatus: isSignedIn ? state.fenceDCFStatus : undefined,
+        fenceStatus: isSignedIn ? state.fenceStatus : {},
         isTimeoutEnabled: isSignedIn ? state.isTimeoutEnabled : undefined,
         user: {
           token: authResponse && authResponse.access_token,
@@ -186,47 +186,6 @@ export const refreshTerraProfile = async () => {
   authStore.update(state => ({ ...state, profile }))
 }
 
-//helpers for external services statuses
-
-const fetchServiceStatus = async statusPromise => {
-  try {
-    return await statusPromise
-  } catch (error) {
-    if (error.status === 404) {
-      return {}
-    } else {
-      throw error
-    }
-  }
-}
-
-const fenceNotify = (stateKey, notificationId, serviceName, provider) => (state, oldState) => {
-  const status = state[stateKey]
-  const oldStatus = oldState[stateKey]
-  if (status !== oldStatus) {
-    const redirectUrl = `${window.location.origin}/${Nav.getLink('fence-callback')}`
-    const now = Date.now()
-    const dateOfExpiration = status && addDays(30, parseJSON(status.issued_at))
-    const dateFiveDaysBeforeExpiration = dateOfExpiration && addDays(-5, dateOfExpiration)
-    const expireStatus = Utils.cond(
-      [!dateOfExpiration, () => null],
-      [now >= dateOfExpiration, () => 'has expired'],
-      [now >= dateFiveDaysBeforeExpiration, () => `will expire in ${differenceInDays(now, dateOfExpiration)} day(s)`]
-    )
-    if (expireStatus) {
-      notify('info', div([
-        `Your access to ${serviceName} Framework Services ${expireStatus}. To `,
-        expireStatus === 'has expired' ? 'restore ' : 'renew ',
-        'access, log-in to Framework Services to ',
-        h(FrameworkServiceLink, { linkText: 're-link', provider, redirectUrl }),
-        ' your account'
-      ]), { id: notificationId })
-    } else {
-      clearNotification(notificationId)
-    }
-  }
-}
-
 authStore.subscribe(withErrorReporting('Error loading user profile', async (state, oldState) => {
   if (!oldState.isSignedIn && state.isSignedIn) {
     await refreshTerraProfile()
@@ -235,7 +194,7 @@ authStore.subscribe(withErrorReporting('Error loading user profile', async (stat
 
 authStore.subscribe(withErrorReporting('Error loading NIH account link status', async (state, oldState) => {
   if (oldState.registrationStatus !== 'registered' && state.registrationStatus === 'registered') {
-    const nihStatus = await fetchServiceStatus(Ajax().User.getNihStatus())
+    const nihStatus = await Ajax().User.getNihStatus()
     authStore.update(state => ({ ...state, nihStatus }))
   }
 }))
@@ -271,26 +230,44 @@ authStore.subscribe((state, oldState) => {
   }
 })
 
-authStore.subscribe(withErrorReporting('Error loading DCP Framework Services account status', async (state, oldState) => {
+authStore.subscribe(withErrorReporting('Error loading Framework Services account status', async (state, oldState) => {
   if (oldState.registrationStatus !== 'registered' && state.registrationStatus === 'registered') {
-    const fenceDCPStatus = await fetchServiceStatus(Ajax().User.getFenceStatus('fence'))
-    authStore.update(state => ({ ...state, fenceDCPStatus }))
+    await Promise.all(_.map(async provider => {
+      const status = await Ajax().User.getFenceStatus(provider)
+      authStore.update(_.set(['fenceStatus', provider], status))
+    }, allProviders))
   }
 }))
 
-authStore.subscribe(withErrorReporting('Error loading DCF Framework Services account status', async (state, oldState) => {
-  if (oldState.registrationStatus !== 'registered' && state.registrationStatus === 'registered') {
-    const fenceDCFStatus = await fetchServiceStatus(Ajax().User.getFenceStatus('dcf-fence'))
-    authStore.update(state => ({ ...state, fenceDCFStatus }))
-  }
-}))
-
-//DCP
-authStore.subscribe(fenceNotify('fenceDCPStatus', 'fence-dcp-link-warning', 'DCP', 'fence'))
-
-
-//DCF
-authStore.subscribe(fenceNotify('fenceDCFStatus', 'fence-dcf-link-warning', 'DCF', 'dcf-fence'))
+authStore.subscribe((state, oldState) => {
+  _.forEach(provider => {
+    const notificationId = `fence-${provider}-link-warning`
+    const status = state.fenceStatus[provider]
+    const oldStatus = oldState.fenceStatus[provider]
+    if (status !== oldStatus) {
+      const redirectUrl = `${window.location.origin}/${Nav.getLink('fence-callback')}`
+      const now = Date.now()
+      const dateOfExpiration = status && addDays(30, parseJSON(status.issued_at))
+      const dateFiveDaysBeforeExpiration = dateOfExpiration && addDays(-5, dateOfExpiration)
+      const expireStatus = Utils.cond(
+        [!dateOfExpiration, () => null],
+        [now >= dateOfExpiration, () => 'has expired'],
+        [now >= dateFiveDaysBeforeExpiration, () => `will expire in ${differenceInDays(now, dateOfExpiration)} day(s)`]
+      )
+      if (expireStatus) {
+        notify('info', div([
+          `Your access to ${providerName(provider)} Framework Services ${expireStatus}. To `,
+          expireStatus === 'has expired' ? 'restore ' : 'renew ',
+          'access, log-in to Framework Services to ',
+          h(FrameworkServiceLink, { linkText: 're-link', provider, redirectUrl }),
+          ' your account'
+        ]), { id: notificationId })
+      } else {
+        clearNotification(notificationId)
+      }
+    }
+  }, allProviders)
+})
 
 authStore.subscribe((state, oldState) => {
   if (oldState.isSignedIn && !state.isSignedIn) {

--- a/src/libs/providers.js
+++ b/src/libs/providers.js
@@ -1,0 +1,9 @@
+export const allProviders = ['fence', 'dcf-fence', 'anvil']
+
+export const providerName = provider => {
+  return {
+    fence: 'DCP',
+    'dcf-fence': 'DCF',
+    anvil: 'NHGRI AnVIL Data Commons'
+  }[provider]
+}

--- a/src/libs/providers.js
+++ b/src/libs/providers.js
@@ -1,9 +1,4 @@
-export const allProviders = ['fence', 'dcf-fence', 'anvil']
-
-export const providerName = provider => {
-  return {
-    fence: 'DCP',
-    'dcf-fence': 'DCF',
-    anvil: 'NHGRI AnVIL Data Commons'
-  }[provider]
-}
+export const allProviders = [
+  { key: 'fence', name: 'DCP' },
+  { key: 'dcf-fence', name: 'DCF' }
+]

--- a/src/libs/state.js
+++ b/src/libs/state.js
@@ -9,7 +9,8 @@ export const authStore = Utils.atom({
   registrationStatus: undefined,
   acceptedTos: undefined,
   user: {},
-  profile: {}
+  profile: {},
+  fenceStatus: {}
 })
 
 export const lastActiveTimeStore = staticStorageSlot(localStorage, 'idleTimeout')


### PR DESCRIPTION
This unifies the code dealing with the existing fence link providers, since it looks like we're leaning into having a uniform experience across the various providers. This will make adding additional providers (e.g. Anvil) straightforward.

Also fixes a bug where current link information wasn't shown on the profile.

Testing note: I was not able to test the full flow locally, since the auth server rejects `localhost` as a return url. Still looking for a way to test end-to-end.