### PR TITLE
tidy up wrapper usage in integration tests

### DIFF
--- a/integration-tests/tests/find-workflow.js
+++ b/integration-tests/tests/find-workflow.js
@@ -1,10 +1,14 @@
+const _ = require('lodash/fp')
 const firecloud = require('../utils/firecloud-utils')
 const { withWorkspace } = require('../utils/integration-helpers')
 const { click, clickable, dismissNotifications, findElement, findText, signIntoTerra } = require('../utils/integration-utils')
 const { withUserToken } = require('../utils/terra-sa-utils')
 
 
-const testFindWorkflowFn = withUserToken(withWorkspace(async ({ billingProject, page, testUrl, token, workflowName, workspaceName }) => {
+const testFindWorkflowFn = _.flow(
+  withWorkspace,
+  withUserToken
+)(async ({ billingProject, page, testUrl, token, workflowName, workspaceName }) => {
   await page.goto(testUrl)
   await signIntoTerra(page, token)
   await dismissNotifications(page)
@@ -45,7 +49,7 @@ const testFindWorkflowFn = withUserToken(withWorkspace(async ({ billingProject, 
   await signIntoTerra(page, token)
   await findText(page, `${workflowName}-configured`)
   await findText(page, 'inputs')
-}))
+})
 
 const testFindWorkflow = {
   name: 'find-workflow',

--- a/integration-tests/tests/import-cohort-data.js
+++ b/integration-tests/tests/import-cohort-data.js
@@ -1,3 +1,4 @@
+const _ = require('lodash/fp')
 const { withWorkspace } = require('../utils/integration-helpers')
 const { findInGrid, click, clickable, dismissNotifications, fillIn, findIframe, input, signIntoTerra, select, svgText, waitForNoSpinners, findElement } = require('../utils/integration-utils')
 const { withUserToken } = require('../utils/terra-sa-utils')
@@ -5,7 +6,10 @@ const { withUserToken } = require('../utils/terra-sa-utils')
 
 const cohortName = `terra-ui-test-cohort`
 
-const testImportCohortDataFn = withUserToken(withWorkspace(async ({ page, testUrl, token, workspaceName }) => {
+const testImportCohortDataFn = _.flow(
+  withWorkspace,
+  withUserToken
+)(async ({ page, testUrl, token, workspaceName }) => {
   await page.goto(testUrl)
   await signIntoTerra(page, token)
   await dismissNotifications(page)
@@ -26,7 +30,7 @@ const testImportCohortDataFn = withUserToken(withWorkspace(async ({ page, testUr
   await click(page, clickable({ textContains: 'cohort' }))
   await findInGrid(page, '1000 Genomes')
   await findInGrid(page, cohortName)
-}))
+})
 
 const testImportCohortData = {
   name: 'import-cohort-data',

--- a/integration-tests/tests/import-dockstore-workflow.js
+++ b/integration-tests/tests/import-dockstore-workflow.js
@@ -1,3 +1,4 @@
+const _ = require('lodash/fp')
 const fetch = require('node-fetch')
 const { withWorkspace } = require('../utils/integration-helpers')
 const { click, clickable, dismissNotifications, findText, select, signIntoTerra } = require('../utils/integration-utils')
@@ -6,23 +7,29 @@ const { withUserToken } = require('../utils/terra-sa-utils')
 
 const testWorkflowIdentifier = 'github.com/DataBiosphere/topmed-workflows/UM_variant_caller_wdl:1.31.0'
 
-const testImportDockstoreWorkflowFn = withUserToken(async options => {
-  const { page, testUrl } = options
+const withDockstoreCheck = test => async options => {
+  const { testUrl } = options
   const { dockstoreUrlRoot } = await fetch(`${testUrl}/config.json`).then(res => res.json())
-
-  if (await fetch(`${dockstoreUrlRoot}/api/api/ga4gh/v1/metadata`).then(res => res.status !== 200)) {
-    console.error('Skipping dockstore test, API appears to be down')
+  const res = await fetch(`${dockstoreUrlRoot}/api/api/ga4gh/v1/metadata`)
+  if (res.status === 200) {
+    await test(options)
   } else {
-    await withWorkspace(async ({ token, workspaceName }) => {
-      await page.goto(`${testUrl}/#import-tool/dockstore/${testWorkflowIdentifier}`)
-      await signIntoTerra(page, token)
-      await dismissNotifications(page)
-      await findText(page, 'workflow TopMedVariantCaller')
-      await select(page, 'Select a workspace', workspaceName)
-      await click(page, clickable({ text: 'Import' }))
-      await findText(page, testWorkflowIdentifier)
-    })(options)
+    console.error('Skipping dockstore test, API appears to be down')
   }
+}
+
+const testImportDockstoreWorkflowFn = _.flow(
+  withWorkspace,
+  withUserToken,
+  withDockstoreCheck
+)(async ({ page, testUrl, token, workspaceName }) => {
+  await page.goto(`${testUrl}/#import-tool/dockstore/${testWorkflowIdentifier}`)
+  await signIntoTerra(page, token)
+  await dismissNotifications(page)
+  await findText(page, 'workflow TopMedVariantCaller')
+  await select(page, 'Select a workspace', workspaceName)
+  await click(page, clickable({ text: 'Import' }))
+  await findText(page, testWorkflowIdentifier)
 })
 
 const testImportDockstoreWorkflow = {

--- a/integration-tests/tests/run-notebook.js
+++ b/integration-tests/tests/run-notebook.js
@@ -1,35 +1,38 @@
+const _ = require('lodash/fp')
 const { withRegisteredUser, withBilling, withWorkspace } = require('../utils/integration-helpers')
 const { click, clickable, signIntoTerra, findElement, waitForNoSpinners, select, fillIn, input, findIframe, findText, dismissNotifications } = require('../utils/integration-utils')
 
 
 const notebookName = 'TestNotebook'
 
-const testRunNotebookFn = withRegisteredUser(async ({ billingProject, page, context, email, testUrl, token }) => {
-  await withBilling(withWorkspace(async ({ workspaceName }) => {
-    await page.goto(testUrl)
-    await click(page, clickable({ textContains: 'View Workspaces' }))
-    await signIntoTerra(page, token)
-    await dismissNotifications(page)
-    await findElement(page, clickable({ textContains: workspaceName }))
-    await waitForNoSpinners(page)
-    await click(page, clickable({ textContains: workspaceName }))
-    await click(page, clickable({ text: 'notebooks' }))
-    await click(page, clickable({ textContains: 'Create a' }))
-    await fillIn(page, input({ placeholder: 'Enter a name' }), notebookName)
-    await select(page, 'Language', 'Python 2')
-    await click(page, clickable({ text: 'Create Notebook' }))
-    await click(page, clickable({ textContains: notebookName }))
-    await click(page, clickable({ text: 'Edit' }))
-    await select(page, 'ENVIRONMENT', 'Hail')
-    await click(page, clickable({ text: 'Create' }))
-    await findElement(page, clickable({ textContains: 'Creating' }))
-    await findElement(page, clickable({ textContains: 'Running' }), { timeout: 10 * 60 * 1000 })
+const testRunNotebookFn = _.flow(
+  withWorkspace,
+  withBilling,
+  withRegisteredUser
+)(async ({ workspaceName, page, testUrl, token }) => {
+  await page.goto(testUrl)
+  await click(page, clickable({ textContains: 'View Workspaces' }))
+  await signIntoTerra(page, token)
+  await dismissNotifications(page)
+  await findElement(page, clickable({ textContains: workspaceName }))
+  await waitForNoSpinners(page)
+  await click(page, clickable({ textContains: workspaceName }))
+  await click(page, clickable({ text: 'notebooks' }))
+  await click(page, clickable({ textContains: 'Create a' }))
+  await fillIn(page, input({ placeholder: 'Enter a name' }), notebookName)
+  await select(page, 'Language', 'Python 2')
+  await click(page, clickable({ text: 'Create Notebook' }))
+  await click(page, clickable({ textContains: notebookName }))
+  await click(page, clickable({ text: 'Edit' }))
+  await select(page, 'ENVIRONMENT', 'Hail')
+  await click(page, clickable({ text: 'Create' }))
+  await findElement(page, clickable({ textContains: 'Creating' }))
+  await findElement(page, clickable({ textContains: 'Running' }), { timeout: 10 * 60 * 1000 })
 
-    const frame = await findIframe(page)
-    await fillIn(frame, '//textarea', 'print(123456789099876543210990+9876543219)')
-    await click(frame, clickable({ text: 'Run' }))
-    await findText(frame, '123456789099886419754209')
-  }))({ billingProject, context, email, testUrl, token })
+  const frame = await findIframe(page)
+  await fillIn(frame, '//textarea', 'print(123456789099876543210990+9876543219)')
+  await click(frame, clickable({ text: 'Run' }))
+  await findText(frame, '123456789099886419754209')
 })
 const testRunNotebook = {
   name: 'run-notebook',

--- a/integration-tests/tests/run-workflow.js
+++ b/integration-tests/tests/run-workflow.js
@@ -1,3 +1,4 @@
+const _ = require('lodash/fp')
 const pRetry = require('p-retry')
 const { withWorkspace, createEntityInWorkspace } = require('../utils/integration-helpers')
 const { click, clickable, dismissNotifications, findElement, fillIn, input, signIntoTerra, waitForNoSpinners, findInGrid, navChild, findInDataTableRow } = require('../utils/integration-utils')
@@ -7,7 +8,10 @@ const { withUserToken } = require('../utils/terra-sa-utils')
 const testEntity = { name: 'test_entity_1', entityType: 'test_entity', attributes: { input: 'foo' } }
 const findWorkflowButton = clickable({ textContains: 'Find a Workflow' })
 
-const testRunWorkflowFn = withUserToken(withWorkspace(async ({ billingProject, page, testUrl, token, workflowName, workspaceName }) => {
+const testRunWorkflowFn = _.flow(
+  withWorkspace,
+  withUserToken
+)(async ({ billingProject, page, testUrl, token, workflowName, workspaceName }) => {
   await page.goto(testUrl)
   await signIntoTerra(page, token)
   await dismissNotifications(page)
@@ -50,7 +54,7 @@ const testRunWorkflowFn = withUserToken(withWorkspace(async ({ billingProject, p
   await click(page, navChild('data'))
   await click(page, clickable({ textContains: 'test_entity' }))
   await findInDataTableRow(page, testEntity.name, testEntity.attributes.input)
-}))
+})
 
 const testRunWorkflow = {
   name: 'run-workflow',


### PR DESCRIPTION
This simplifies and standardizes usage patterns around async wrappers in the integration tests. It should not change any behavior.