### PR TITLE
Increase CircleCI test timeout to accommodate potentially long-running tests [No Jira]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,7 @@ commands:
             JEST_JUNIT_OUTPUT_DIR: "/tmp/test-results/integration-test-results.xml"
             SCREENSHOT_DIR: "/tmp/failure-screenshots"
             ENVIRONMENT: << parameters.env >>
+          no_output_timeout: 16m
           command: |
             mkdir -p ${SCREENSHOT_DIR}
             yarn test --ci --maxWorkers=2 --reporters=default --reporters=jest-junit


### PR DESCRIPTION
Bump up the default CircleCI no-output timeout from the default of 10 minutes to 16 minutes. Our longest timeouts are currently 15 minutes (run-notebook and run-workflow) so this will give us enough headroom to allow Jest to timeout and capture a screenshot.

This avoids what we got this morning on alpha: https://app.circleci.com/pipelines/github/DataBiosphere/terra-ui/3433/workflows/9f4a5cfe-6e1a-4fb7-bb51-8a57e9855622/jobs/22151