### PR TITLE
Fix display of fence status link [SATURN-1686]

### DIFF
--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -174,7 +174,11 @@ const FenceLink = ({ provider, displayName }) => {
   /*
    * Hooks
    */
-  const [{ username, issued_at: issuedAt }, setStatus] = useState({})
+  const auth = Utils.useStore(authStore)
+  const { username, issued_at: issuedAt } = Utils.switchCase(provider,
+    ['fence', () => auth.fenceDCPStatus || {}],
+    ['dcf-fence', () => auth.fenceDCFStatus || {}],
+    [Utils.DEFAULT, () => {}])
   const [isLinking, setIsLinking] = useState(false)
   const signal = Utils.useCancellation()
 
@@ -184,7 +188,8 @@ const FenceLink = ({ provider, displayName }) => {
     withErrorReporting('Error linking NIH account'),
     Utils.withBusyState(setIsLinking)
   )(async () => {
-    setStatus(await User.linkFenceAccount(provider, token, redirectUrl))
+    const resultStatus = await User.linkFenceAccount(provider, token, redirectUrl)
+    authStore.update(state => ({ ...state, resultStatus }))
   })
 
   Utils.useOnMount(() => {


### PR DESCRIPTION
We had some extra component-level state that wasn't needed anymore because the data is in `authStore`. Hooking that up fixes the display bug.

Note, this will need to be modified when merged with #2161.

Also, like #2161, I was not able to fully test locally. Linking does work on bvdp-saturn-dev.appspot.com, though, so I was able to establish a link there and verify that it is displayed on localhost.