### PR TITLE
Upgrade docs to include vault info [SATURN-1696]

### DIFF
--- a/Vault.md
+++ b/Vault.md
@@ -1,0 +1,10 @@
+# Instructions for setting up Vault on your Local Machine
+
+The Terra UI team maintains our own instructions for using Vault, because we do not use it within docker. The instructions for how to use general Vault within Docker can be found [here](https://github.com/broadinstitute/dsde-toolbox#authenticating-to-vault)
+
+To setup Vault, you first need to ensure you have a github token with the read:org permission. This can be done by going to [the github personal access tokens page](https://github.com/settings/tokens) and creating a new github access token. This access token can then be used to authenticate vault.
+
+Once you have your github token saved, you can then run the following commands:
+1. `export VAULT_ADDR=https://clotho.broadinstitute.org:8200`
+2. ``vault login -method=github token=`cat <<PATH_TO_GITHUB_TOKEN>>` ``
+3. You can then run commands like: `vault read --format=json <<PATH_TO_SECRET>>`

--- a/integration-tests/Bueller.md
+++ b/integration-tests/Bueller.md
@@ -14,6 +14,12 @@ To generate a token, create a JWT with the additional claim `target_audience: 'h
 
 Pass the token in a header with every call: `Authorization: Bearer <token>`
 
+### Generating an OpenID Connect ID token: 
+
+First make sure you have vault set up on your computer. Instructions for how to do that can be found [here](Vault.md).
+
+At that point, you can run `node scripts/makeBearerToken.js "$(vault read --format=json secret/dsde/terra/envs/common/bueller-user-service-account-key | jq .data)" https://terra-bueller.appspot.com`, which will output an OpenID Connect ID token.
+
 ## Developing
 
 Install deps

--- a/integration-tests/Bueller.md
+++ b/integration-tests/Bueller.md
@@ -16,7 +16,7 @@ Pass the token in a header with every call: `Authorization: Bearer <token>`
 
 ### Generating an OpenID Connect ID token: 
 
-First make sure you have vault set up on your computer. Instructions for how to do that can be found [here](Vault.md).
+First make sure you have vault set up on your computer. Instructions for how to do that can be found [here](../Vault.md).
 
 At that point, you can run `node scripts/makeBearerToken.js "$(vault read --format=json secret/dsde/terra/envs/common/bueller-user-service-account-key | jq .data)" https://terra-bueller.appspot.com`, which will output an OpenID Connect ID token.
 
@@ -33,4 +33,12 @@ GCP_PROJECT=terra-bueller GOOGLE_APPLICATION_CREDENTIALS=<path-to-key-file> \
 TERRA_SA_KEY=$(vault read --format=json secret/dsde/alpha/common/firecloud-account.pem | jq .data) \
 LYLE_SA_KEY=$(vault read --format=json secret/dsde/terra/envs/common/lyle-user-service-account-key | jq .data) \
 yarn start-dev
+```
+
+Example of a curl command to run a test against a dev server:
+```bash
+curl --request POST --header \
+"Authorization: Bearer $(node scripts/makeBearerToken.js \
+"$(vault read --format=json secret/dsde/terra/envs/common/bueller-user-service-account-key | jq .data)" \
+ https://terra-bueller.appspot.com)" --url "http://localhost:8080/test/find-workflow?targetEnv=dev"
 ```


### PR DESCRIPTION
Each command listed has been run locally. I verified that vault needs the exported address, and each of the commands to access vault, and ping Bueller. I did not test any additional vault commands.