### PR TITLE
Mixpanel - track notebook renames on clone and edit [SATURN-1633]

### DIFF
--- a/src/components/notebook-utils.js
+++ b/src/components/notebook-utils.js
@@ -228,8 +228,20 @@ export const NotebookDuplicator = ajaxCaller(class NotebookDuplicator extends Co
                 namespace, name: wsName, notebookName: `${newName}.ipynb`
               })
             }
-            const eventType = destroyOld ? Events.notebookRename : Events.notebookCopy
-            Ajax().Metrics.captureEvent(eventType, { oldName: printName, newName })
+            if (destroyOld) {
+              Ajax()
+                .Metrics
+                .captureEvent(Events.notebookRename, { oldName: printName, newName, workspaceName: wsName, workspaceNamespace: namespace })
+            } else {
+              Ajax().Metrics.captureEvent(Events.notebookCopy, {
+                oldName: printName,
+                newName,
+                fromWorkspaceNamespace: namespace,
+                fromWorkspaceName: wsName,
+                toWorkspaceNamespace: namespace,
+                toWorkspaceName: wsName
+              })
+            }
           } catch (error) {
             reportError(`Error ${destroyOld ? 'renaming' : 'copying'} notebook`, error)
           }

--- a/src/components/notebook-utils.js
+++ b/src/components/notebook-utils.js
@@ -226,8 +226,7 @@ export const NotebookDuplicator = ajaxCaller(class NotebookDuplicator extends Co
               [false, () => {
                 Ajax().Buckets.notebook(namespace, bucketName, printName).copy(newName, bucketName, !destroyOld)
                 Ajax().Metrics.captureEvent(Events.notebookClone, { oldName: printName, newName })
-              }],
-              [Utils.DEFAULT, reportError('Destroy old notebook not defined')])
+              }])
             onSuccess()
             if (fromLauncher) {
               Nav.goToPath('workspace-notebook-launch', {

--- a/src/components/notebook-utils.js
+++ b/src/components/notebook-utils.js
@@ -231,7 +231,12 @@ export const NotebookDuplicator = ajaxCaller(class NotebookDuplicator extends Co
             if (destroyOld) {
               Ajax()
                 .Metrics
-                .captureEvent(Events.notebookRename, { oldName: printName, newName, workspaceName: wsName, workspaceNamespace: namespace })
+                .captureEvent(Events.notebookRename, {
+                  oldName: printName,
+                  newName,
+                  workspaceName: wsName,
+                  workspaceNamespace: namespace
+                })
             } else {
               Ajax().Metrics.captureEvent(Events.notebookCopy, {
                 oldName: printName,

--- a/src/components/notebook-utils.js
+++ b/src/components/notebook-utils.js
@@ -228,7 +228,7 @@ export const NotebookDuplicator = ajaxCaller(class NotebookDuplicator extends Co
                 namespace, name: wsName, notebookName: `${newName}.ipynb`
               })
             }
-            const eventType = destroyOld ? Events.notebookRename : Events.notebookClone
+            const eventType = destroyOld ? Events.notebookRename : Events.notebookCopy
             Ajax().Metrics.captureEvent(eventType, { oldName: printName, newName })
           } catch (error) {
             reportError(`Error ${destroyOld ? 'renaming' : 'copying'} notebook`, error)
@@ -253,7 +253,6 @@ export const NotebookDuplicator = ajaxCaller(class NotebookDuplicator extends Co
     ))
   }
 })
-
 
 export const NotebookDeleter = class NotebookDeleter extends Component {
   static propTypes = {

--- a/src/components/notebook-utils.js
+++ b/src/components/notebook-utils.js
@@ -229,14 +229,12 @@ export const NotebookDuplicator = ajaxCaller(class NotebookDuplicator extends Co
               })
             }
             if (destroyOld) {
-              Ajax()
-                .Metrics
-                .captureEvent(Events.notebookRename, {
-                  oldName: printName,
-                  newName,
-                  workspaceName: wsName,
-                  workspaceNamespace: namespace
-                })
+              Ajax().Metrics.captureEvent(Events.notebookRename, {
+                oldName: printName,
+                newName,
+                workspaceName: wsName,
+                workspaceNamespace: namespace
+              })
             } else {
               Ajax().Metrics.captureEvent(Events.notebookCopy, {
                 oldName: printName,

--- a/src/components/notebook-utils.js
+++ b/src/components/notebook-utils.js
@@ -215,16 +215,16 @@ export const NotebookDuplicator = ajaxCaller(class NotebookDuplicator extends Co
       okButton: h(ButtonPrimary, {
         disabled: errors || processing,
         tooltip: Utils.summarizeErrors(errors),
-        onClick: async () => {
+        onClick: () => {
           try {
             this.setState({ processing: true })
-            await Utils.switchCase(destroyOld,
-              [true, () => {
-                Ajax().Buckets.notebook(namespace, bucketName, printName).rename(newName)
+            Utils.switchCase(destroyOld,
+              [true, async () => {
+                await Ajax().Buckets.notebook(namespace, bucketName, printName).rename(newName)
                 Ajax().Metrics.captureEvent(Events.notebookRename, { oldName: printName, newName })
               }],
-              [false, () => {
-                Ajax().Buckets.notebook(namespace, bucketName, printName).copy(newName, bucketName, !destroyOld)
+              [false, async () => {
+                await Ajax().Buckets.notebook(namespace, bucketName, printName).copy(newName, bucketName, !destroyOld)
                 Ajax().Metrics.captureEvent(Events.notebookClone, { oldName: printName, newName })
               }])
             onSuccess()

--- a/src/components/notebook-utils.js
+++ b/src/components/notebook-utils.js
@@ -225,7 +225,7 @@ export const NotebookDuplicator = ajaxCaller(class NotebookDuplicator extends Co
               Ajax().Buckets.notebook(namespace, bucketName, printName).copy(newName, bucketName, !destroyOld)
             )
           } catch (error) {
-            reportError(`Error renaming notebook`, error)
+            reportError(`Error ${destroyOld ? 'renaming' : 'copying'} notebook`, error)
           }
           onSuccess()
           if (fromLauncher) {

--- a/src/components/notebook-utils.js
+++ b/src/components/notebook-utils.js
@@ -170,7 +170,6 @@ export const NotebookCreator = class NotebookCreator extends Component {
   }
 }
 
-
 export const NotebookDuplicator = ajaxCaller(class NotebookDuplicator extends Component {
   static propTypes = {
     destroyOld: PropTypes.bool,
@@ -200,7 +199,6 @@ export const NotebookDuplicator = ajaxCaller(class NotebookDuplicator extends Co
     this.setState({ existingNames })
   }
 
-
   render() {
     const { destroyOld, fromLauncher, printName, wsName, namespace, bucketName, onDismiss, onSuccess } = this.props
     const { newName, processing, nameTouched, existingNames } = this.state
@@ -224,17 +222,17 @@ export const NotebookDuplicator = ajaxCaller(class NotebookDuplicator extends Co
               Ajax().Buckets.notebook(namespace, bucketName, printName).rename(newName) :
               Ajax().Buckets.notebook(namespace, bucketName, printName).copy(newName, bucketName, !destroyOld)
             )
+            onSuccess()
+            if (fromLauncher) {
+              Nav.goToPath('workspace-notebook-launch', {
+                namespace, name: wsName, notebookName: `${newName}.ipynb`
+              })
+            }
+            const eventType = destroyOld ? Events.notebookRename : Events.notebookClone
+            Ajax().Metrics.captureEvent(eventType, { oldName: printName, newName })
           } catch (error) {
             reportError(`Error ${destroyOld ? 'renaming' : 'copying'} notebook`, error)
           }
-          onSuccess()
-          if (fromLauncher) {
-            Nav.goToPath('workspace-notebook-launch', {
-              namespace, name: wsName, notebookName: `${newName}.ipynb`
-            })
-          }
-          const eventType = destroyOld ? Events.notebookRename : Events.notebookClone
-          Ajax().Metrics.captureEvent(eventType, { oldName: printName, newName })
         }
       }, `${destroyOld ? 'Rename' : 'Copy'} Notebook`)
     },

--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -9,7 +9,7 @@ const eventsList = {
   applicationLaunch: 'application:launch',
   notebookLaunch: 'notebook:launch',
   notebookRename: 'notebook:rename',
-  notebookClone: 'notebook:clone',
+  notebookCopy: 'notebook:copy',
   pageView: 'page:view',
   workflowImport: 'workflow:import',
   workflowLaunch: 'workflow:launch',

--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -25,6 +25,15 @@ export const extractWorkspaceDetails = workspaceObject => {
   return { workspaceName: name, workspaceNamespace: namespace }
 }
 
+export const extractCrossWorkspaceDetails = (fromWorkspace, toWorkspace) => {
+  return {
+    fromWorkspaceNamespace: fromWorkspace.workspace.namespace,
+    fromWorkspaceName: fromWorkspace.workspace.name,
+    toWorkspaceNamespace: toWorkspace.workspace.namespace,
+    toWorkspaceName: toWorkspace.workspace.name
+  }
+}
+
 export const PageViewReporter = () => {
   const { name } = useRoute()
   const { isSignedIn, registrationStatus } = Utils.useStore(authStore)

--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -8,6 +8,8 @@ import * as Utils from 'src/libs/utils'
 const eventsList = {
   applicationLaunch: 'application:launch',
   notebookLaunch: 'notebook:launch',
+  notebookRename: 'notebook:rename',
+  notebookClone: 'notebook:clone',
   pageView: 'page:view',
   workflowImport: 'workflow:import',
   workflowLaunch: 'workflow:launch',

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -346,7 +346,7 @@ const Notebooks = _.flow(
   render() {
     const { loading, saving, notebooks, creating, renamingNotebookName, copyingNotebookName, deletingNotebookName, exportingNotebookName, sortOrder, filter } = this.state
     const {
-      namespace, listView, setListView, workspace,
+      namespace, name, listView, setListView, workspace,
       workspace: { accessLevel, workspace: { bucketName } }
     } = this.props
     const existingNames = this.getExistingNames()
@@ -391,7 +391,7 @@ const Notebooks = _.flow(
           }),
           renamingNotebookName && h(NotebookDuplicator, {
             printName: printName(renamingNotebookName),
-            namespace, bucketName, destroyOld: true,
+            namespace, wsName: name, bucketName, destroyOld: true,
             onDismiss: () => this.setState({ renamingNotebookName: undefined }),
             onSuccess: () => {
               this.setState({ renamingNotebookName: undefined })
@@ -400,7 +400,7 @@ const Notebooks = _.flow(
           }),
           copyingNotebookName && h(NotebookDuplicator, {
             printName: printName(copyingNotebookName),
-            namespace, bucketName, destroyOld: false,
+            namespace, wsName: name, bucketName, destroyOld: false,
             onDismiss: () => this.setState({ copyingNotebookName: undefined }),
             onSuccess: () => {
               this.setState({ copyingNotebookName: undefined })

--- a/src/pages/workspaces/workspace/notebooks/ExportNotebookModal.js
+++ b/src/pages/workspaces/workspace/notebooks/ExportNotebookModal.js
@@ -8,6 +8,7 @@ import Modal from 'src/components/Modal'
 import { notebookNameInput, notebookNameValidator } from 'src/components/notebook-utils'
 import { withWorkspaces, WorkspaceSelector } from 'src/components/workspace-utils'
 import { Ajax, ajaxCaller } from 'src/libs/ajax'
+import Events from 'src/libs/events'
 import { FormLabel } from 'src/libs/forms'
 import * as Nav from 'src/libs/nav'
 import * as Utils from 'src/libs/utils'
@@ -150,6 +151,7 @@ export default _.flow(
         .notebook(workspace.workspace.namespace, workspace.workspace.bucketName, printName)
         .copy(newName, selectedWorkspace.bucketName)
       this.setState({ copied: true })
+      Ajax().Metrics.captureEvent(Events.notebookClone, { oldName: printName, newName })
     } catch (error) {
       this.setState({ error: await error.text(), copying: false })
     }

--- a/src/pages/workspaces/workspace/notebooks/ExportNotebookModal.js
+++ b/src/pages/workspaces/workspace/notebooks/ExportNotebookModal.js
@@ -8,7 +8,7 @@ import Modal from 'src/components/Modal'
 import { notebookNameInput, notebookNameValidator } from 'src/components/notebook-utils'
 import { withWorkspaces, WorkspaceSelector } from 'src/components/workspace-utils'
 import { Ajax, ajaxCaller } from 'src/libs/ajax'
-import Events from 'src/libs/events'
+import Events, { extractCrossWorkspaceDetails } from 'src/libs/events'
 import { FormLabel } from 'src/libs/forms'
 import * as Nav from 'src/libs/nav'
 import * as Utils from 'src/libs/utils'
@@ -143,15 +143,15 @@ export default _.flow(
   async copy() {
     const { printName, workspace } = this.props
     const { newName } = this.state
-    const selectedWorkspace = this.getSelectedWorkspace().workspace
+    const selectedWorkspace = this.getSelectedWorkspace()
     try {
       this.setState({ copying: true })
       await Ajax()
         .Buckets
         .notebook(workspace.workspace.namespace, workspace.workspace.bucketName, printName)
-        .copy(newName, selectedWorkspace.bucketName)
+        .copy(newName, selectedWorkspace.workspace.bucketName)
       this.setState({ copied: true })
-      Ajax().Metrics.captureEvent(Events.notebookCopy, { oldName: printName, newName })
+      Ajax().Metrics.captureEvent(Events.notebookCopy, { oldName: printName, newName, ...extractCrossWorkspaceDetails(workspace, selectedWorkspace) })
     } catch (error) {
       this.setState({ error: await error.text(), copying: false })
     }

--- a/src/pages/workspaces/workspace/notebooks/ExportNotebookModal.js
+++ b/src/pages/workspaces/workspace/notebooks/ExportNotebookModal.js
@@ -151,7 +151,7 @@ export default _.flow(
         .notebook(workspace.workspace.namespace, workspace.workspace.bucketName, printName)
         .copy(newName, selectedWorkspace.bucketName)
       this.setState({ copied: true })
-      Ajax().Metrics.captureEvent(Events.notebookClone, { oldName: printName, newName })
+      Ajax().Metrics.captureEvent(Events.notebookCopy, { oldName: printName, newName })
     } catch (error) {
       this.setState({ error: await error.text(), copying: false })
     }


### PR DESCRIPTION
#### Acceptance Criteria

- [x] Mixpanel event triggered when a notebook is cloned called “notebook:clone”
- [x] Mixpanel event triggered when a notebook is renamed “notebook:rename”
- [x] Properties on each event for the name of the parent “oldName” and the name of the new notebook “newName”
- [x] Description of event added to MixPanel lexicon
