### PR TITLE
[SATURN-1682] change datetime display format in job history

### DIFF
--- a/src/pages/workspaces/workspace/JobHistory.js
+++ b/src/pages/workspaces/workspace/JobHistory.js
@@ -257,7 +257,7 @@ const JobHistory = _.flow(
                 headerRenderer: () => h(HeaderCell, ['Submitted']),
                 cellRenderer: ({ rowIndex }) => {
                   const { submissionDate } = filteredSubmissions[rowIndex]
-                  return h(TooltipCell, { tooltip: Utils.makeCompleteDate(submissionDate) }, [Utils.makePrettyDate(submissionDate)])
+                  return h(TooltipCell, { tooltip: Utils.makeCompleteDate(submissionDate) }, [Utils.makeCompleteDate(submissionDate)])
                 }
               },
               {


### PR DESCRIPTION
Change the display format of the submitted date in the "job history" page so it always displays MMM dd yyyy HH:mm instead of "today" 

checked in browser
