### PR TITLE
Add xtra 50G disk for GCE runtimes [SATURN-1702]

### DIFF
--- a/src/components/NewClusterModal.js
+++ b/src/components/NewClusterModal.js
@@ -507,7 +507,7 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
         div({
           style: { backgroundColor: colors.dark(0.2), borderRadius: 100, width: 'fit-content', padding: '0.75rem 1.25rem', ...styles.row }
         }, [
-          span({ style: { ...styles.label, marginRight: '0.25rem' } }, ['COST:']),
+          span({ style: { ...styles.label, marginRight: '0.25rem', textTransform: 'uppercase' } }, ['cost:']),
           `${Utils.formatUSD(runtimeConfigCost(this.getRuntimeConfig(!currentCluster)))} per hour`
         ])
       ])

--- a/src/components/NewClusterModal.js
+++ b/src/components/NewClusterModal.js
@@ -119,10 +119,10 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
     }
   }
 
-  getRuntimeConfig() {
+  getRuntimeConfig(isNew = false) {
     return formatRuntimeConfig({
       cloudService: !!this.state.sparkMode ? 'DATAPROC' : 'GCE',
-      bootDiskSize: !!this.state.sparkMode ? null : 50,
+      isNew,
       ..._.pick(
         ['numberOfWorkers', 'masterMachineType', 'masterDiskSize', 'workerMachineType', 'workerDiskSize', 'numberOfPreemptibleWorkers'],
         this.state)
@@ -141,7 +141,7 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
     const { jupyterUserScriptUri, selectedLeoImage, customEnvImage } = this.state
     onSuccess(Promise.all([
       Ajax().Clusters.cluster(namespace, Utils.generateClusterName()).create({
-        runtimeConfig: this.getRuntimeConfig(),
+        runtimeConfig: this.getRuntimeConfig(true),
         toolDockerImage: selectedLeoImage === CUSTOM_MODE || selectedLeoImage === PROJECT_SPECIFIC_MODE ? customEnvImage : selectedLeoImage,
         labels: { saturnIsProjectSpecific: `${selectedLeoImage === PROJECT_SPECIFIC_MODE}` },
         ...(jupyterUserScriptUri ? { jupyterUserScriptUri } : {})
@@ -508,7 +508,7 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
           style: { backgroundColor: colors.dark(0.2), borderRadius: 100, width: 'fit-content', padding: '0.75rem 1.25rem', ...styles.row }
         }, [
           span({ style: { ...styles.label, marginRight: '0.25rem' } }, ['COST:']),
-          `${Utils.formatUSD(runtimeConfigCost(this.getRuntimeConfig()))} per hour`
+          `${Utils.formatUSD(runtimeConfigCost(this.getRuntimeConfig(!currentCluster)))} per hour`
         ])
       ])
     ])

--- a/src/components/NewClusterModal.js
+++ b/src/components/NewClusterModal.js
@@ -122,6 +122,7 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
   getRuntimeConfig() {
     return formatRuntimeConfig({
       cloudService: !!this.state.sparkMode ? 'DATAPROC' : 'GCE',
+      bootDiskSize: !!this.state.sparkMode ? null : 50,
       ..._.pick(
         ['numberOfWorkers', 'masterMachineType', 'masterDiskSize', 'workerMachineType', 'workerDiskSize', 'numberOfPreemptibleWorkers'],
         this.state)

--- a/src/libs/cluster-utils.js
+++ b/src/libs/cluster-utils.js
@@ -25,12 +25,12 @@ export const normalizeRuntimeConfig = ({ cloudService, machineType, diskSize, ma
 }
 
 export const formatRuntimeConfig = config => {
-  const { cloudService, masterMachineType, masterDiskSize, bootDiskSize } = config
+  const { cloudService, masterMachineType, masterDiskSize, bootDiskSize, isNew } = config
   return cloudService === 'GCE' ? {
     cloudService,
     machineType: masterMachineType,
     diskSize: masterDiskSize,
-    bootDiskSize
+    bootDiskSize: bootDiskSize || (isNew && 50) || 0
   } : config
 }
 


### PR DESCRIPTION
Leo has updated to use 2 dsisks for users, one will be the disk the user requests and the other will be for storing the installation. This is true for GCE runtimes.

See: https://broadworkbench.atlassian.net/browse/IA-1759 for details

tested creating a runtime in the UI and checking the cost