### PR TITLE
Fix workspace namespace references for IGV [SATURN-1698]

### DIFF
--- a/src/components/IGVBrowser.js
+++ b/src/components/IGVBrowser.js
@@ -33,7 +33,7 @@ const IGVBrowser = _.flow(
           return knownBucketStatus
         } else {
           try {
-            await Ajax(signal).Buckets.getObject(bucket, file, workspace.namespace, { fields: 'kind' })
+            await Ajax(signal).Buckets.getObject(bucket, file, workspace.workspace.namespace, { fields: 'kind' })
             return false
           } catch (e) {
             if (e.requesterPaysError) {
@@ -63,7 +63,7 @@ const IGVBrowser = _.flow(
             }, selectedFiles))
           }
 
-          igv.setGoogleOauthToken(() => saToken(workspace.namespace))
+          igv.setGoogleOauthToken(() => saToken(workspace.workspace.namespace))
           igv.createBrowser(containerRef.current, options)
         } catch (e) {
           reportError('Error loading IGV.js', e)


### PR DESCRIPTION
This fixes an IGV bug with fetching a Google OAuth token and determining buckets that require requester-pays access. Testing is tricky because, as it was before, it was asking to use a Google project called `undefined` which _actually exists in non-prod environments_! If you look at the network tab, you'll see weird calls to sam with a path parameter of `undefined`, but because the project exists, these calls work. These same calls fail in prod. (I could not find a billing project called `undefined` in any of our usual non-prod environments so I have no idea who actually has permission to use it... but it seems like most/all of our usual dev accounts can use it.) Therefore, you have to look at the network tab before/after to see the difference to validate that the change is correct.