### PR TITLE
add anvil linkage [SATURN-1553]

### DIFF
--- a/src/libs/providers.js
+++ b/src/libs/providers.js
@@ -1,4 +1,5 @@
 export const allProviders = [
   { key: 'fence', name: 'NHLBI BioData Catalyst Framework Services' },
-  { key: 'dcf-fence', name: 'NCI CRDC Framework Services' }
+  { key: 'dcf-fence', name: 'NCI CRDC Framework Services' },
+  { key: 'anvil', name: 'NHGRI AnVIL Data Commons Framework Services' }
 ]

--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -269,7 +269,7 @@ const Profile = _.flow(
             div({ style: { marginTop: '0', marginLeft: '1rem' } }, [
               sectionTitle('Identity & External Servers'),
               h(NihLink, { nihToken: queryParams['nih-username-token'] }),
-              _.map(provider => h(FenceLink, { key: provider, provider }), allProviders)
+              _.map(provider => h(FenceLink, { key: provider.key, provider }), allProviders)
             ])
           ])
         ])


### PR DESCRIPTION
This adds the the Anvil linkage to the UI. Because the auth process enforces that the redirect URL matches its whitelist, I had to temporarily hack the domain to be 'bvdp-saturn-dev.appspot.com' while testing locally, but was able to verify the flow.

Also fixes a react `key` warning.