### PR TITLE
[SATURN-1701] fix runtimes sorting bug

### DIFF
--- a/src/pages/Clusters.js
+++ b/src/pages/Clusters.js
@@ -46,8 +46,8 @@ const Clusters = () => {
   const filteredClusters = _.orderBy([{
     project: 'googleProject',
     status: 'status',
-    created: 'createdDate',
-    accessed: 'dateAccessed',
+    created: 'auditInfo.createdDate',
+    accessed: 'auditInfo.dateAccessed',
     cost: clusterCost
   }[sort.field]], [sort.direction], clusters)
 


### PR DESCRIPTION
in the 'your notebook runtimes' page, fix the ability to sort a user's existing runtimes by a) date created or b) date last accessed

checked in the UI
