### PR TITLE
refactor workflow launch code [SATURN-1662]

### DIFF
--- a/src/libs/analysis.js
+++ b/src/libs/analysis.js
@@ -1,91 +1,63 @@
 import _ from 'lodash/fp'
 import { Ajax } from 'src/libs/ajax'
-import { reportError } from 'src/libs/error'
+import * as Utils from 'src/libs/utils'
 
 
-const isSet = entityType => _.endsWith('_set', entityType)
-
-/**
- * Conditions this needs to handle:
- *
- * Method config "rootEntityType": sample (or other singular type)
- *   input:
- *     1 entity - create submission with a single job
- *       entityType: "sample"
- *       entityName: entity name
- *       expression: ""
- *     set - create submission with set with expression
- *       entityType: "sample_set"
- *       entityName: sample set name
- *       expression: "samples"
- *     many entities - create set, then create submission with set with expression
- *       entityType: "sample_set"
- *       entityName: sample set name
- *       expression: "samples"
- * Method config: sample_set (or other set type)
- *   input:
- *     set - create submission with set
- *       entityType: "sample_set"
- *       entityName: sample set name
- *       expression: ""
- */
 export const launch = async ({
-  workspaceNamespace, workspaceName,
+  workspace: { workspace: { namespace, name, bucketName }, accessLevel },
   config: { namespace: configNamespace, name: configName, rootEntityType },
-  entityType, entityNames, newSetName, expression, useCallCache = true, deleteIntermediateOutputFiles,
-  onCreateSet, onLaunch, onSuccess, onFailure
+  entityType, entityNames, newSetName, useCallCache = true, deleteIntermediateOutputFiles,
+  onProgress
 }) => {
-  const workspace = Ajax().Workspaces.workspace(workspaceNamespace, workspaceName)
-  const methodConfig = workspace.methodConfig(configNamespace, configName)
-
-  const launchParams = await resolveLaunchParams({ entityNames, entityType, onCreateSet, newSetName, rootEntityType, workspace })
-  if (!!launchParams) {
-    try {
-      !!onLaunch && onLaunch()
-      const { submissionId } = await methodConfig.launch({ ...launchParams, useCallCache, deleteIntermediateOutputFiles })
-      onSuccess(submissionId)
-    } catch (error) {
-      onFailure(error)
-    }
-  }
-}
-
-const resolveLaunchParams = async ({ entityNames, entityType, onCreateSet, newSetName, rootEntityType, workspace }) => {
-  const entityName = _.head(entityNames)
-
-  if (_.isEmpty(entityNames)) {
-    reportError('No entities selected')
-  } else if (isSet(rootEntityType)) {
-    if (_.size(entityNames) > 1) {
-      reportError('Cannot create a submission for multiple entity sets')
-    } else if (entityType !== rootEntityType) {
-      reportError(`Cannot use ${entityType} with method config that needs ${rootEntityType}`)
-    } else {
-      return { entityType: rootEntityType, entityName }
-    }
-  } else if (isSet(entityType)) {
-    return { entityType, entityName, expression: `this.${rootEntityType}s` }
-  } else if (_.size(entityNames) === 1) {
-    return { entityType, entityName }
-  } else {
-    const setType = `${entityType}_set`
-    const set = {
+  const createSet = () => {
+    onProgress('createSet')
+    return Ajax().Workspaces.workspace(namespace, name).createEntity({
       name: newSetName,
-      entityType: setType,
+      entityType: `${entityType}_set`,
       attributes: {
-        [`${rootEntityType}s`]: {
+        [`${entityType}s`]: {
           itemsType: 'EntityReference',
-          items: _.map(entityName => ({ entityName, entityType: rootEntityType }), entityNames)
+          items: _.map(entityName => ({ entityName, entityType }), entityNames)
         }
       }
-    }
-    try {
-      !!onCreateSet && onCreateSet()
-      await workspace.createEntity(set)
-    } catch (error) {
-      reportError('Error creating entity set', error)
-      return
-    }
-    return { entityType: setType, entityName: newSetName, expression: `this.${rootEntityType}s` }
+    })
   }
+  onProgress('checkBucketAccess')
+  try {
+    await Ajax().Workspaces.workspace(namespace, name).checkBucketAccess(bucketName, accessLevel)
+  } catch (error) {
+    throw new Error('Error confirming workspace bucket access. This may be a transient problem. Please try again in a few minutes. If the problem persists, please contact support.')
+  }
+  const { entityName, processSet = false } = await Utils.cond(
+    [entityType === undefined, () => ({})],
+    [`${entityType}_set` === rootEntityType, async () => {
+      await createSet()
+      return { entityName: newSetName }
+    }],
+    [entityType === rootEntityType, async () => {
+      if (_.size(entityNames) === 1) {
+        return { entityName: entityNames[0] }
+      } else {
+        await createSet()
+        return { entityName: newSetName, processSet: true }
+      }
+    }],
+    [entityType === `${rootEntityType}_set`, () => {
+      if (_.size(entityNames) > 1) {
+        throw new Error('Cannot launch against multiple sets')
+      }
+      return { entityName: entityNames[0], processSet: true }
+    }]
+  )
+  onProgress('launch')
+  return Ajax().Workspaces.workspace(namespace, name).methodConfig(configNamespace, configName).launch({
+    entityType: Utils.cond(
+      [!entityName, () => undefined],
+      [processSet, () => `${rootEntityType}_set`],
+      () => rootEntityType
+    ),
+    entityName,
+    expression: processSet ? `this.${rootEntityType}s` : undefined,
+    useCallCache, deleteIntermediateOutputFiles
+  })
 }

--- a/src/libs/analysis.js
+++ b/src/libs/analysis.js
@@ -52,7 +52,7 @@ export const launch = async ({
   onProgress('launch')
   return Ajax().Workspaces.workspace(namespace, name).methodConfig(configNamespace, configName).launch({
     entityType: Utils.cond(
-      [!entityName, () => undefined],
+      [entityName === undefined, () => undefined],
       [processSet, () => `${rootEntityType}_set`],
       () => rootEntityType
     ),

--- a/src/libs/data-utils.js
+++ b/src/libs/data-utils.js
@@ -452,21 +452,6 @@ export const EntityRenamer = ({ entityType, entityName, workspaceId: { namespace
   ])
 }
 
-export const createEntitySet = ({ entities, rootEntityType, newSetName, workspaceId: { namespace, name } }) => {
-  const newSet = {
-    name: newSetName,
-    entityType: `${rootEntityType}_set`, // this will be e.g. if rootEntityType is Sample, Sample_set
-    attributes: {
-      [`${rootEntityType}s`]: {
-        itemsType: 'EntityReference',
-        items: _.map(entityName => ({ entityName, entityType: rootEntityType }), entities)
-      }
-    }
-  }
-
-  return Ajax().Workspaces.workspace(namespace, name).createEntity(newSet)
-}
-
 export const EntityEditor = ({ entityType, entityName, attributeName, attributeValue, entityTypes, workspaceId: { namespace, name }, onDismiss, onSuccess }) => {
   const initialIsReference = _.isObject(attributeValue) && (attributeValue.entityType || attributeValue.itemsType === 'EntityReference')
   const initialIsList = _.isObject(attributeValue) && attributeValue.items

--- a/src/pages/workspaces/workspace/JobHistory.js
+++ b/src/pages/workspaces/workspace/JobHistory.js
@@ -142,7 +142,7 @@ const JobHistory = _.flow(
   }
 
   render() {
-    const { namespace, name, workspace: { workspace: { bucketName } } } = this.props
+    const { namespace, name, workspace, workspace: { workspace: { bucketName } } } = this.props
     const { submissions, loading, aborting, textFilter } = this.state
     const filteredSubmissions = _.filter(({ asText }) => _.every(term => asText.includes(term.toLowerCase()), textFilter.split(/\s+/)), submissions)
     const hasJobs = !_.isEmpty(submissions)
@@ -241,8 +241,7 @@ const JobHistory = _.flow(
                     isTerminal(status) && (workflowStatuses['Failed'] || workflowStatuses['Aborted']) &&
                     submissionEntity && !methodConfigurationDeleted && h(ButtonPrimary, {
                       onClick: () => rerunFailures({
-                        namespace,
-                        name,
+                        workspace,
                         submissionId,
                         configNamespace: methodConfigurationNamespace,
                         configName: methodConfigurationName,

--- a/src/pages/workspaces/workspace/workflows/FailureRerunner.js
+++ b/src/pages/workspaces/workspace/workflows/FailureRerunner.js
@@ -38,8 +38,8 @@ export const rerunFailures = async ({ workspace, workspace: { workspace: { names
 
     await launch({
       workspace, config,
-      entityType: config.rootEntityType,
-      entityNames: _.flow(
+      selectedEntityType: config.rootEntityType,
+      selectedEntityNames: _.flow(
         _.filter(v => (v.status === 'Aborted' || v.status === 'Failed')),
         _.map('workflowEntity.entityName')
       )(workflows),

--- a/src/pages/workspaces/workspace/workflows/FailureRerunner.js
+++ b/src/pages/workspaces/workspace/workflows/FailureRerunner.js
@@ -25,43 +25,32 @@ const ToastMessageComponent = Utils.connectStore(rerunFailuresStatus, 'status')(
   }
 })
 
-export const rerunFailures = async ({ namespace, name, submissionId, configNamespace, configName, onDone }) => {
+export const rerunFailures = async ({ workspace, workspace: { workspace: { namespace, name } }, submissionId, configNamespace, configName, onDone }) => {
   rerunFailuresStatus.set({ text: 'Loading workflow info...' })
   const id = notify('info', h(ToastMessageComponent))
-  const eventData = { ...extractWorkspaceDetails({ workspace: { name, namespace } }), configNamespace, configName }
+  const eventData = { ...extractWorkspaceDetails(workspace), configNamespace, configName }
 
   try {
-    const workspace = Ajax().Workspaces.workspace(namespace, name)
-    const methodConfig = workspace.methodConfig(configNamespace, configName)
-
-    const [{ workflows, useCallCache, deleteIntermediateOutputFiles }, { rootEntityType }] = await Promise.all([
-      workspace.submission(submissionId).get(),
-      methodConfig.get()
+    const [{ workflows, useCallCache, deleteIntermediateOutputFiles }, config] = await Promise.all([
+      Ajax().Workspaces.workspace(namespace, name).submission(submissionId).get(),
+      Ajax().Workspaces.workspace(namespace, name).methodConfig(configNamespace, configName).get()
     ])
 
-    const failedEntities = _.flow(
-      _.filter(v => (v.status === 'Aborted' || v.status === 'Failed')),
-      _.map('workflowEntity')
-    )(workflows)
-
-    const newSetName = Utils.sanitizeEntityName(`${configName}-resubmission-${new Date().toISOString().slice(0, -5)}`)
-
     await launch({
-      workspaceNamespace: namespace, workspaceName: name,
-      config: { namespace: configNamespace, name: configName, rootEntityType },
-      entityType: rootEntityType, entityNames: _.map('entityName', failedEntities),
-      newSetName, useCallCache, deleteIntermediateOutputFiles,
-      onCreateSet: () => rerunFailuresStatus.set({ text: 'Creating set from failures...' }),
-      onLaunch: () => rerunFailuresStatus.set({ text: 'Launching new job...' }),
-      onSuccess: () => {
-        rerunFailuresStatus.set({ text: 'Success!', done: true })
-        onDone()
-      },
-      onFailure: error => {
-        clearNotification(id)
-        reportError('Error rerunning failed workflows', error)
+      workspace, config,
+      entityType: config.rootEntityType,
+      entityNames: _.flow(
+        _.filter(v => (v.status === 'Aborted' || v.status === 'Failed')),
+        _.map('workflowEntity.entityName')
+      )(workflows),
+      newSetName: Utils.sanitizeEntityName(`${configName}-resubmission-${new Date().toISOString().slice(0, -5)}`),
+      useCallCache, deleteIntermediateOutputFiles,
+      onProgress: stage => {
+        rerunFailuresStatus.set({ text: { createSet: 'Creating set from failures...', launch: 'Launching new job...', checkBucketAccess: 'Checking bucket access...' }[stage] })
       }
     })
+    rerunFailuresStatus.set({ text: 'Success!', done: true })
+    onDone()
     Ajax().Metrics.captureEvent(Events.workflowRerun, { ...eventData, success: true })
 
     await Utils.delay(2000)

--- a/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
+++ b/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
@@ -71,7 +71,7 @@ export default ajaxCaller(class LaunchAnalysisModal extends Component {
     try {
       const { workspace, workspace: { workspace: { namespace, name } }, processSingle, entitySelectionModel: { type, selectedEntities, newSetName }, config, config: { rootEntityType }, useCallCache, deleteIntermediateOutputFiles, onSuccess, ajax: { Workspaces } } = this.props
 
-      const baseEntityType = rootEntityType.slice(0, -4)
+      const baseEntityType = rootEntityType && rootEntityType.slice(0, -4)
       const { selectedEntityType, selectedEntityNames } = await Utils.cond(
         [processSingle, () => ({})],
         [type === processAll, async () => {

--- a/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
+++ b/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
@@ -72,28 +72,28 @@ export default ajaxCaller(class LaunchAnalysisModal extends Component {
       const { workspace, workspace: { workspace: { namespace, name } }, processSingle, entitySelectionModel: { type, selectedEntities, newSetName }, config, config: { rootEntityType }, useCallCache, deleteIntermediateOutputFiles, onSuccess, ajax: { Workspaces } } = this.props
 
       const baseEntityType = rootEntityType.slice(0, -4)
-      const { entityType, entityNames } = await Utils.cond(
+      const { selectedEntityType, selectedEntityNames } = await Utils.cond(
         [processSingle, () => ({})],
         [type === processAll, async () => {
           this.setState({ message: 'Fetching data...' })
-          const entityNames = _.map('name', await Workspaces.workspace(namespace, name).entitiesOfType(rootEntityType))
-          return { entityType: rootEntityType, entityNames }
+          const selectedEntityNames = _.map('name', await Workspaces.workspace(namespace, name).entitiesOfType(rootEntityType))
+          return { selectedEntityType: rootEntityType, selectedEntityNames }
         }],
-        [type === chooseRows || type === chooseSets, () => ({ entityType: rootEntityType, entityNames: _.keys(selectedEntities) })],
+        [type === chooseRows || type === chooseSets, () => ({ selectedEntityType: rootEntityType, selectedEntityNames: _.keys(selectedEntities) })],
         [type === processMergedSet, () => {
           return _.size(selectedEntities) === 1 ?
-            { entityType: `${rootEntityType}_set`, entityNames: _.keys(selectedEntities) } :
-            { entityType: rootEntityType, entityNames: _.flow(_.flatMap(`attributes.${rootEntityType}s.items`), _.map('entityName'))(selectedEntities) }
+            { selectedEntityType: `${rootEntityType}_set`, selectedEntityNames: _.keys(selectedEntities) } :
+            { selectedEntityType: rootEntityType, selectedEntityNames: _.flow(_.flatMap(`attributes.${rootEntityType}s.items`), _.map('entityName'))(selectedEntities) }
         }],
-        [type === chooseSetComponents, () => ({ entityType: baseEntityType, entityNames: _.keys(selectedEntities) })],
+        [type === chooseSetComponents, () => ({ selectedEntityType: baseEntityType, selectedEntityNames: _.keys(selectedEntities) })],
         [type === processAllAsSet, async () => {
           this.setState({ message: 'Fetching data...' })
-          const entityNames = _.map('name', await Workspaces.workspace(namespace, name).entitiesOfType(baseEntityType))
-          return { entityType: baseEntityType, entityNames }
+          const selectedEntityNames = _.map('name', await Workspaces.workspace(namespace, name).entitiesOfType(baseEntityType))
+          return { selectedEntityType: baseEntityType, selectedEntityNames }
         }]
       )
       const { submissionId } = await launch({
-        workspace, config, entityType, entityNames, newSetName, useCallCache, deleteIntermediateOutputFiles,
+        workspace, config, selectedEntityType, selectedEntityNames, newSetName, useCallCache, deleteIntermediateOutputFiles,
         onProgress: stage => {
           this.setState({ message: { createSet: 'Creating set...', launch: 'Launching analysis...', checkBucketAccess: 'Checking bucket access...' }[stage] })
         }

--- a/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
+++ b/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
@@ -4,9 +4,9 @@ import { b, div, h, wbr } from 'react-hyperscript-helpers'
 import { ButtonPrimary, CromwellVersionLink } from 'src/components/common'
 import { spinner } from 'src/components/icons'
 import Modal from 'src/components/Modal'
-import { Ajax, ajaxCaller } from 'src/libs/ajax'
+import { ajaxCaller } from 'src/libs/ajax'
+import { launch } from 'src/libs/analysis'
 import colors from 'src/libs/colors'
-import { createEntitySet } from 'src/libs/data-utils'
 import * as Utils from 'src/libs/utils'
 import {
   chooseRows, chooseSetComponents, chooseSets, processAll, processAllAsSet, processMergedSet
@@ -21,52 +21,17 @@ export default ajaxCaller(class LaunchAnalysisModal extends Component {
     }
   }
 
-  /**
-   * Verify that the user's pet service account (used while running workflows) will be able to
-   * access the workspace bucket
-   *
-   * @returns {Promise<boolean>}
-   */
-  async preFlightBucketAccess() {
-    const { workspaceId: { namespace, name }, accessLevel, bucketName, ajax: { Workspaces } } = this.props
-
-    try {
-      await Workspaces.workspace(namespace, name).checkBucketAccess(bucketName, accessLevel)
-      return true
-    } catch (error) {
-      // Could check error.requesterPaysError here but for this purpose it really doesn't matter what the error was.
-      return false
-    }
-  }
-
-  getEntities() {
-    const { entitySelectionModel: { type, selectedEntities }, processSingle, config: { rootEntityType } } = this.props
-
-    if (!processSingle) {
-      return Utils.switchCase(type,
-        [chooseRows, () => _.keys(selectedEntities)],
-        [chooseSets, () => _.keys(selectedEntities)],
-        [chooseSetComponents, () => _.keys(selectedEntities)],
-        [processMergedSet, () => _.flow(
-          _.flatMap(`attributes.${rootEntityType}s.items`),
-          _.map('entityName')
-        )(selectedEntities)],
-        [Utils.DEFAULT, () => selectedEntities]
-      )
-    }
-  }
-
   render() {
-    const { onDismiss, entitySelectionModel: { type }, entityMetadata, config: { rootEntityType }, processSingle } = this.props
+    const { onDismiss, entitySelectionModel: { type, selectedEntities }, entityMetadata, config: { rootEntityType }, processSingle } = this.props
     const { launching, message, launchError } = this.state
-    const entities = this.getEntities()
+    const mergeSets = _.flatMap(`attributes.${rootEntityType}s.items`)
     const entityCount = Utils.cond(
       [processSingle, () => 1],
+      [type === chooseRows || type === chooseSets, () => _.size(selectedEntities)],
       [type === processAll, () => entityMetadata[rootEntityType].count],
       [type === processAllAsSet, () => 1],
       [type === chooseSetComponents, () => 1],
-      [_.isArray(entities), () => _.uniq(entities).length],
-      () => _.size(entities)
+      [type === processMergedSet, () => _.flow(mergeSets, _.uniqBy('entityName'))(selectedEntities).length]
     )
     const wrappableOnPeriods = _.flow(str => str?.split(/(\.)/), _.flatMap(sub => sub === '.' ? [wbr(), '.'] : sub))
 
@@ -82,13 +47,13 @@ export default ajaxCaller(class LaunchAnalysisModal extends Component {
             this.doLaunch()
           }
         }, ['Launch']) :
-        h(ButtonPrimary, { onClick: onDismiss, disabled: !entities }, ['OK'])
+        h(ButtonPrimary, { onClick: onDismiss }, ['OK'])
     }, [
       div({ style: { margin: '1rem 0' } }, ['This analysis will be run by ', h(CromwellVersionLink), '.']),
-      (!entities && !processSingle) ? spinner() : div({ style: { margin: '1rem 0' } }, [
+      div({ style: { margin: '1rem 0' } }, [
         'This will launch ', b([entityCount]), ` analys${entityCount === 1 ? 'is' : 'es'}`,
         '.',
-        !processSingle && type !== processAll && entityCount !== entities.length && div({
+        type === processMergedSet && entityCount !== mergeSets(selectedEntities).length && div({
           style: { fontStyle: 'italic', marginTop: '0.5rem' }
         }, ['(Duplicate entities are only processed once.)'])
       ]),
@@ -103,95 +68,39 @@ export default ajaxCaller(class LaunchAnalysisModal extends Component {
   }
 
   async doLaunch() {
-    const { workspaceId: { namespace, name }, processSingle, entitySelectionModel: { type }, config: { rootEntityType }, ajax: { Workspaces } } = this.props
-    const entities = this.getEntities()
+    try {
+      const { workspace, workspace: { workspace: { namespace, name } }, processSingle, entitySelectionModel: { type, selectedEntities, newSetName }, config, config: { rootEntityType }, useCallCache, deleteIntermediateOutputFiles, onSuccess, ajax: { Workspaces } } = this.props
 
-    this.setState({ message: 'Checking bucket access...' })
-    const hasBucketAccess = await this.preFlightBucketAccess()
-    if (!hasBucketAccess) {
-      this.setState({
-        message: undefined,
-        launchError: 'Error confirming workspace bucket access. This may be a transient problem. Please try again in a few minutes. If the problem persists, please contact support.'
-      })
-    } else if (processSingle) {
-      this.launch()
-    } else if (type === processAll) {
-      this.setState({ message: 'Fetching data...' })
-      const allEntities = _.map('name', await Workspaces.workspace(namespace, name).entitiesOfType(rootEntityType))
-      this.createSetAndLaunch(allEntities)
-    } else if (type === chooseRows || type === chooseSets) {
-      if (entities.length === 1) {
-        this.launch(rootEntityType, entities[0])
-      } else {
-        this.createSetAndLaunch(entities)
-      }
-    } else if (type === processMergedSet) {
-      this.createSetAndLaunch(entities)
-    } else if (type === chooseSetComponents) {
-      this.createSetAndLaunchOne(entities)
-    } else if (type === processAllAsSet) {
       const baseEntityType = rootEntityType.slice(0, -4)
-      const allBaseEntities = _.map('name', await Workspaces.workspace(namespace, name).entitiesOfType(baseEntityType))
-      this.createSetAndLaunchOne(allBaseEntities)
-    }
-  }
-
-  async createSetAndLaunch(entities) {
-    const {
-      workspaceId,
-      entitySelectionModel: { newSetName },
-      config: { rootEntityType }
-    } = this.props
-
-    try {
-      await createEntitySet({ entities, rootEntityType, newSetName, workspaceId })
-    } catch (error) {
-      this.setState({ launchError: await error.text(), message: undefined })
-      return
-    }
-
-    await this.launch(`${rootEntityType}_set`, newSetName, `this.${rootEntityType}s`)
-  }
-
-  async createSetAndLaunchOne(entities) {
-    const {
-      workspaceId,
-      entitySelectionModel: { newSetName },
-      config: { rootEntityType }
-    } = this.props
-
-    try {
-      await createEntitySet({ entities, rootEntityType: rootEntityType.slice(0, -4), newSetName, workspaceId })
-    } catch (error) {
-      this.setState({ launchError: await error.text(), message: undefined })
-      return
-    }
-
-    await this.launch(rootEntityType, newSetName)
-  }
-
-  baseLaunch(entityType, entityName, expression) {
-    const {
-      workspaceId: { namespace, name },
-      config: { namespace: configNamespace, name: configName },
-      useCallCache, deleteIntermediateOutputFiles
-    } = this.props
-
-    return Ajax().Workspaces.workspace(namespace, name).methodConfig(configNamespace, configName).launch({
-      entityType, entityName, expression, useCallCache, deleteIntermediateOutputFiles
-    })
-  }
-
-  async launch(entityType, entityName, expression) {
-    const { onSuccess } = this.props
-
-    try {
-      this.setState({ message: 'Launching analysis...' })
-
-      const { submissionId } = await this.baseLaunch(entityType, entityName, expression)
+      const { entityType, entityNames } = await Utils.cond(
+        [processSingle, () => ({})],
+        [type === processAll, async () => {
+          this.setState({ message: 'Fetching data...' })
+          const entityNames = _.map('name', await Workspaces.workspace(namespace, name).entitiesOfType(rootEntityType))
+          return { entityType: rootEntityType, entityNames }
+        }],
+        [type === chooseRows || type === chooseSets, () => ({ entityType: rootEntityType, entityNames: _.keys(selectedEntities) })],
+        [type === processMergedSet, () => {
+          return _.size(selectedEntities) === 1 ?
+            { entityType: `${rootEntityType}_set`, entityNames: _.keys(selectedEntities) } :
+            { entityType: rootEntityType, entityNames: _.flow(_.flatMap(`attributes.${rootEntityType}s.items`), _.map('entityName'))(selectedEntities) }
+        }],
+        [type === chooseSetComponents, () => ({ entityType: baseEntityType, entityNames: _.keys(selectedEntities) })],
+        [type === processAllAsSet, async () => {
+          this.setState({ message: 'Fetching data...' })
+          const entityNames = _.map('name', await Workspaces.workspace(namespace, name).entitiesOfType(baseEntityType))
+          return { entityType: baseEntityType, entityNames }
+        }]
+      )
+      const { submissionId } = await launch({
+        workspace, config, entityType, entityNames, newSetName, useCallCache, deleteIntermediateOutputFiles,
+        onProgress: stage => {
+          this.setState({ message: { createSet: 'Creating set...', launch: 'Launching analysis...', checkBucketAccess: 'Checking bucket access...' }[stage] })
+        }
+      })
       onSuccess(submissionId)
     } catch (error) {
-      this.setState({ launchError: await error.text(), message: undefined })
+      this.setState({ launchError: await (error instanceof Response ? error.text() : error.message), message: undefined })
     }
   }
 })

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -411,7 +411,7 @@ const WorkflowView = _.flow(
           ['outputs', () => this.renderIOTable('outputs')]
         ),
         launching && h(LaunchAnalysisModal, {
-          workspaceId, config: savedConfig, entityMetadata,
+          workspace, config: savedConfig, entityMetadata,
           accessLevel: workspace.accessLevel, bucketName: workspace.workspace.bucketName,
           processSingle: this.isSingle(), entitySelectionModel, useCallCache, deleteIntermediateOutputFiles,
           onDismiss: () => this.setState({ launching: false }),


### PR DESCRIPTION
This consolidates and formalizes the workflow launch code paths. Behavior changes:
* Relaunching failures on a set-of-sets workflow now works without errors
* Relaunching failures now performs a preflight bucket access check
* Launch progress messages are more consistent
* "Duplicate entities" message now only appears when merging sets with duplicate entities
* Choosing a single pre-existing set during launch no longer creates an unnecessary copy of that set