### PR TITLE
respect patchInProgress flag for runtime status [SATURN-1522]

### DIFF
--- a/src/components/ClusterManager.js
+++ b/src/components/ClusterManager.js
@@ -252,7 +252,7 @@ export default class ClusterManager extends PureComponent {
         case 'Stopping':
         case 'Updating':
         case 'Creating':
-        case 'Reconfiguring':
+        case 'LeoReconfiguring':
           return h(ClusterIcon, {
             shape: 'sync',
             disabled: true,
@@ -280,7 +280,7 @@ export default class ClusterManager extends PureComponent {
     }
     const totalCost = _.sum(_.map(clusterCost, clusters))
     const activeClusters = this.getActiveClustersOldestFirst()
-    const { Creating: creating, Updating: updating, Reconfiguring: reconfiguring } = _.countBy(collapsedClusterStatus, activeClusters)
+    const { Creating: creating, Updating: updating, LeoReconfiguring: reconfiguring } = _.countBy(collapsedClusterStatus, activeClusters)
     const isDisabled = !canCompute || creating || busy || updating || reconfiguring
 
     const isRStudioImage = currentCluster?.labels.tool === 'RStudio'
@@ -318,7 +318,7 @@ export default class ClusterManager extends PureComponent {
           div({ style: { marginLeft: '0.5rem', paddingRight: '0.5rem', color: colors.dark() } }, [
             div({ style: { fontSize: 12, fontWeight: 'bold' } }, 'Notebook Runtime'),
             div({ style: { fontSize: 10 } }, [
-              span({ style: { textTransform: 'uppercase', fontWeight: 500 } }, [currentStatus === 'Reconfiguring' ? 'Updating' : (currentStatus || 'None')]),
+              span({ style: { textTransform: 'uppercase', fontWeight: 500 } }, [currentStatus === 'LeoReconfiguring' ? 'Updating' : (currentStatus || 'None')]),
               currentStatus && ` (${Utils.formatUSD(totalCost)} hr)`
             ])
           ]),

--- a/src/components/NewClusterModal.js
+++ b/src/components/NewClusterModal.js
@@ -160,8 +160,8 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
     return onSuccess(
       Ajax().Clusters.cluster(googleProject, runtimeName).update({
         runtimeConfig: this.getRuntimeConfig()
-      }),
-      isStopRequired ? 5000 : 0)
+      })
+    )
   }
 
   hasStartUpScriptChanged() {

--- a/src/components/cluster-common.js
+++ b/src/components/cluster-common.js
@@ -4,7 +4,7 @@ import { b, div, h } from 'react-hyperscript-helpers'
 import { spinnerOverlay } from 'src/components/common'
 import { icon, spinner } from 'src/components/icons'
 import { Ajax } from 'src/libs/ajax'
-import { usableStatuses } from 'src/libs/cluster-utils'
+import { collapsedClusterStatus, usableStatuses } from 'src/libs/cluster-utils'
 import colors from 'src/libs/colors'
 import { withErrorIgnoring, withErrorReporting } from 'src/libs/error'
 import * as Utils from 'src/libs/utils'
@@ -25,7 +25,8 @@ export const ClusterKicker = ({ cluster, refreshClusters, onNullCluster }) => {
   const startClusterOnce = withErrorReporting('Error starting notebook runtime', async () => {
     while (!signal.aborted) {
       const currentCluster = getCluster()
-      const { status, googleProject, runtimeName } = currentCluster || {}
+      const { googleProject, runtimeName } = currentCluster || {}
+      const status = collapsedClusterStatus(currentCluster)
 
       if (status === 'Stopped') {
         setBusy(true)
@@ -74,7 +75,7 @@ export const PlaygroundHeader = ({ children }) => {
 }
 
 export const ClusterStatusMonitor = ({ cluster, onClusterStoppedRunning = _.noop, onClusterStartedRunning = _.noop }) => {
-  const currentStatus = cluster && cluster.status
+  const currentStatus = collapsedClusterStatus(cluster)
   const prevStatus = Utils.usePrevious(currentStatus)
 
   useEffect(() => {

--- a/src/libs/cluster-utils.js
+++ b/src/libs/cluster-utils.js
@@ -79,7 +79,7 @@ export const trimClustersOldestFirst = _.flow(
 export const currentCluster = _.flow(trimClustersOldestFirst, _.last)
 
 export const collapsedClusterStatus = cluster => {
-  return cluster && (cluster.patchInProgress ? 'Reconfiguring' : cluster.status) // NOTE: preserves null vs undefined
+  return cluster && (cluster.patchInProgress ? 'LeoReconfiguring' : cluster.status) // NOTE: preserves null vs undefined
 }
 
 export const deleteText = () => {

--- a/src/libs/cluster-utils.js
+++ b/src/libs/cluster-utils.js
@@ -78,6 +78,9 @@ export const trimClustersOldestFirst = _.flow(
 
 export const currentCluster = _.flow(trimClustersOldestFirst, _.last)
 
+export const collapsedClusterStatus = cluster => {
+  return cluster && (cluster.patchInProgress ? 'Reconfiguring' : cluster.status) // NOTE: preserves null vs undefined
+}
 
 export const deleteText = () => {
   return h(Fragment, [p({ style: { margin: '0px', lineHeight: '1.5rem' } }, [

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -161,7 +161,7 @@ const useClusterPolling = namespace => {
       const newClusters = await Ajax(signal).Clusters.list({ googleProject: namespace, creator: getUser().email })
       setClusters(newClusters)
       const cluster = currentCluster(newClusters)
-      reschedule(_.includes(collapsedClusterStatus(cluster), ['Creating', 'Starting', 'Stopping', 'Updating', 'Reconfiguring']) ? 10000 : 120000)
+      reschedule(_.includes(collapsedClusterStatus(cluster), ['Creating', 'Starting', 'Stopping', 'Updating', 'LeoReconfiguring']) ? 10000 : 120000)
     } catch (error) {
       reschedule(30000)
       throw error

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -11,7 +11,7 @@ import PopupTrigger from 'src/components/PopupTrigger'
 import TopBar from 'src/components/TopBar'
 import { Ajax, saToken } from 'src/libs/ajax'
 import { getUser } from 'src/libs/auth'
-import { currentCluster } from 'src/libs/cluster-utils'
+import { collapsedClusterStatus, currentCluster } from 'src/libs/cluster-utils'
 import colors from 'src/libs/colors'
 import { isTerra } from 'src/libs/config'
 import { withErrorIgnoring, withErrorReporting } from 'src/libs/error'
@@ -161,7 +161,7 @@ const useClusterPolling = namespace => {
       const newClusters = await Ajax(signal).Clusters.list({ googleProject: namespace, creator: getUser().email })
       setClusters(newClusters)
       const cluster = currentCluster(newClusters)
-      reschedule(_.includes(cluster && cluster.status, ['Creating', 'Starting', 'Stopping', 'Updating']) ? 10000 : 120000)
+      reschedule(_.includes(collapsedClusterStatus(cluster), ['Creating', 'Starting', 'Stopping', 'Updating', 'Reconfiguring']) ? 10000 : 120000)
     } catch (error) {
       reschedule(30000)
       throw error

--- a/src/pages/workspaces/workspace/applications/AppLauncher.js
+++ b/src/pages/workspaces/workspace/applications/AppLauncher.js
@@ -6,7 +6,7 @@ import { ClusterKicker, ClusterStatusMonitor, PeriodicCookieSetter, PlaygroundHe
 import { Link, spinnerOverlay } from 'src/components/common'
 import { NewClusterModal } from 'src/components/NewClusterModal'
 import { Ajax } from 'src/libs/ajax'
-import { collapsedClusterStatus } from 'src/libs/cluster-utils'
+import { collapsedClusterStatus, usableStatuses } from 'src/libs/cluster-utils'
 import { withErrorReporting } from 'src/libs/error'
 import Events from 'src/libs/events'
 import * as Nav from 'src/libs/nav'
@@ -42,7 +42,7 @@ const AppLauncher = _.flow(
       cluster, refreshClusters,
       onNullCluster: () => setShowCreate(true)
     }),
-    clusterStatus === 'Running' && cookieReady ?
+    _.includes(clusterStatus, usableStatuses) && cookieReady ?
       h(Fragment, [
         h(PeriodicCookieSetter, { namespace, runtimeName }),
         app === 'RStudio' && h(PlaygroundHeader, [
@@ -64,17 +64,17 @@ const AppLauncher = _.flow(
       ]) :
       div({ style: { padding: '2rem' } }, [
         !busy && h(StatusMessage, { hideSpinner: ['Error', 'Stopped', null].includes(clusterStatus) }, [
-          Utils.switchCase(clusterStatus,
-            ['Creating', () => 'Creating notebook runtime environment. You can navigate away and return in 3-5 minutes.'],
-            ['Starting', () => 'Starting notebook runtime environment, this may take up to 2 minutes.'],
-            ['Running', () => 'Almost ready...'],
-            ['Stopping', () => 'Notebook runtime environment is stopping, which takes ~4 minutes. You can restart it after it finishes.'],
-            ['Stopped', () => 'Notebook runtime environment is stopped. Start it to edit your notebook or use the terminal.'],
-            ['Reconfiguring', () => 'Notebook runtime environment is updating, please wait.'],
-            ['Error', () => 'Error with the notebook runtime environment, please try again.'],
-            [null, () => 'Create a notebook runtime to continue.'],
-            [undefined, () => 'Loading...'],
-            [Utils.DEFAULT, () => 'Unknown notebook runtime status. Please create a new runtime or contact support.']
+          Utils.cond(
+            [clusterStatus === 'Creating', () => 'Creating notebook runtime environment. You can navigate away and return in 3-5 minutes.'],
+            [clusterStatus === 'Starting', () => 'Starting notebook runtime environment, this may take up to 2 minutes.'],
+            [_.includes(clusterStatus, usableStatuses), () => 'Almost ready...'],
+            [clusterStatus === 'Stopping', () => 'Notebook runtime environment is stopping, which takes ~4 minutes. You can restart it after it finishes.'],
+            [clusterStatus === 'Stopped', () => 'Notebook runtime environment is stopped. Start it to edit your notebook or use the terminal.'],
+            [clusterStatus === 'LeoReconfiguring', () => 'Notebook runtime environment is updating, please wait.'],
+            [clusterStatus === 'Error', () => 'Error with the notebook runtime environment, please try again.'],
+            [clusterStatus === null, () => 'Create a notebook runtime to continue.'],
+            [clusterStatus === undefined, () => 'Loading...'],
+            () => 'Unknown notebook runtime status. Please create a new runtime or contact support.'
           )
         ]),
         h(NewClusterModal, {

--- a/src/pages/workspaces/workspace/applications/AppLauncher.js
+++ b/src/pages/workspaces/workspace/applications/AppLauncher.js
@@ -6,6 +6,7 @@ import { ClusterKicker, ClusterStatusMonitor, PeriodicCookieSetter, PlaygroundHe
 import { Link, spinnerOverlay } from 'src/components/common'
 import { NewClusterModal } from 'src/components/NewClusterModal'
 import { Ajax } from 'src/libs/ajax'
+import { collapsedClusterStatus } from 'src/libs/cluster-utils'
 import { withErrorReporting } from 'src/libs/error'
 import Events from 'src/libs/events'
 import * as Nav from 'src/libs/nav'
@@ -24,7 +25,7 @@ const AppLauncher = _.flow(
   const [showCreate, setShowCreate] = useState(false)
   const [busy, setBusy] = useState(false)
 
-  const clusterStatus = cluster && cluster.status // preserve null vs undefined
+  const clusterStatus = collapsedClusterStatus(cluster) // preserve null vs undefined
   const runtimeName = cluster?.runtimeName
 
   return h(Fragment, [
@@ -69,6 +70,7 @@ const AppLauncher = _.flow(
             ['Running', () => 'Almost ready...'],
             ['Stopping', () => 'Notebook runtime environment is stopping, which takes ~4 minutes. You can restart it after it finishes.'],
             ['Stopped', () => 'Notebook runtime environment is stopped. Start it to edit your notebook or use the terminal.'],
+            ['Reconfiguring', () => 'Notebook runtime environment is updating, please wait.'],
             ['Error', () => 'Error with the notebook runtime environment, please try again.'],
             [null, () => 'Create a notebook runtime to continue.'],
             [undefined, () => 'Loading...'],

--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -245,6 +245,10 @@ const PreviewHeader = ({ queryParams, cluster, readOnlyAccess, onCreateCluster, 
           h(HeaderButton, {}, [icon('ellipsis-v')])
         ])
       ])],
+      [_.includes(clusterStatus, usableStatuses), () => {
+        console.assert(false, `Expected notebook runtime to NOT be one of: [${usableStatuses}]`)
+        return null
+      }],
       [clusterStatus === 'Creating', () => h(StatusMessage, [
         'Creating notebook runtime environment. You can navigate away and return in 3-5 minutes.'
       ])],
@@ -254,7 +258,7 @@ const PreviewHeader = ({ queryParams, cluster, readOnlyAccess, onCreateCluster, 
       [clusterStatus === 'Stopping', () => h(StatusMessage, [
         'Notebook runtime environment is stopping, which takes ~4 minutes. You can restart it after it finishes.'
       ])],
-      [clusterStatus === 'Reconfiguring', () => h(StatusMessage, [
+      [clusterStatus === 'LeoReconfiguring', () => h(StatusMessage, [
         'Notebook runtime environment is updating, please wait.'
       ])],
       [clusterStatus === 'Error', () => h(StatusMessage, { hideSpinner: true }, ['Notebook runtime error.'])]

--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -16,7 +16,7 @@ import { findPotentialNotebookLockers, NotebookDuplicator, notebookLockHash } fr
 import PopupTrigger from 'src/components/PopupTrigger'
 import { dataSyncingDocUrl } from 'src/data/machines'
 import { Ajax } from 'src/libs/ajax'
-import { usableStatuses } from 'src/libs/cluster-utils'
+import { collapsedClusterStatus, usableStatuses } from 'src/libs/cluster-utils'
 import colors from 'src/libs/colors'
 import { withErrorReporting } from 'src/libs/error'
 import Events from 'src/libs/events'
@@ -47,7 +47,8 @@ const NotebookLauncher = _.flow(
   ({ queryParams, notebookName, workspace, workspace: { workspace: { namespace }, accessLevel, canCompute }, cluster, refreshClusters }, ref) => {
     const [createOpen, setCreateOpen] = useState(false)
     // Status note: undefined means still loading, null means no cluster
-    const { runtimeName, status, labels } = cluster || {}
+    const { runtimeName, labels } = cluster || {}
+    const status = collapsedClusterStatus(cluster)
     const [busy, setBusy] = useState()
     const { mode } = queryParams
 
@@ -183,7 +184,7 @@ const PreviewHeader = ({ queryParams, cluster, readOnlyAccess, onCreateCluster, 
   const [lockedBy, setLockedBy] = useState(null)
   const [exportingNotebook, setExportingNotebook] = useState(false)
   const [copyingNotebook, setCopyingNotebook] = useState(false)
-  const clusterStatus = cluster && cluster.status
+  const clusterStatus = collapsedClusterStatus(cluster)
   const welderEnabled = cluster && !cluster.labels.welderInstallFailed
   const { mode } = queryParams
   const notebookLink = Nav.getLink('workspace-notebook-launch', { namespace, name, notebookName })
@@ -252,6 +253,9 @@ const PreviewHeader = ({ queryParams, cluster, readOnlyAccess, onCreateCluster, 
       ])],
       [clusterStatus === 'Stopping', () => h(StatusMessage, [
         'Notebook runtime environment is stopping, which takes ~4 minutes. You can restart it after it finishes.'
+      ])],
+      [clusterStatus === 'Reconfiguring', () => h(StatusMessage, [
+        'Notebook runtime environment is updating, please wait.'
       ])],
       [clusterStatus === 'Error', () => h(StatusMessage, { hideSpinner: true }, ['Notebook runtime error.'])]
     ),


### PR DESCRIPTION
See ticket for details.

Adds a `collapsedClusterStatus` function to transform the `patchInProgress` flag into a new pseudo-status for the purposes of driving display and behavior. Note that while we display this new state as 'Updating', it behaves differently from the preexisting `'Updating'` status (which we see when adding workers to a dataproc cluster).