### PR TITLE
Remove/disable free credit enrollment [SATURN-1752]

### DIFF
--- a/src/components/NewWorkspaceModal.js
+++ b/src/components/NewWorkspaceModal.js
@@ -13,7 +13,7 @@ import { withErrorReporting } from 'src/libs/error'
 import Events from 'src/libs/events'
 import { FormLabel } from 'src/libs/forms'
 import * as Nav from 'src/libs/nav'
-import { authStore, freeCreditsActive } from 'src/libs/state'
+import { authStore } from 'src/libs/state'
 import * as Utils from 'src/libs/utils'
 import validate from 'validate.js'
 
@@ -125,12 +125,10 @@ export default _.flow(
   })
 
   render() {
-    const { onDismiss, cloneWorkspace, authState: { profile }, title, customMessage, buttonText } = this.props
-    const { trialState } = profile
+    const { onDismiss, cloneWorkspace, title, customMessage, buttonText } = this.props
     const { namespace, name, billingProjects, allGroups, groups, description, nameModified, loading, createError, creating } = this.state
     const existingGroups = this.getRequiredGroups()
     const hasBillingProjects = !!billingProjects && !!billingProjects.length
-    const hasFreeCredits = trialState === 'Enabled'
     const errors = validate({ namespace, name }, constraints, {
       prettify: v => ({ namespace: 'Billing project', name: 'Name' }[v] || validate.prettify(v))
     })
@@ -221,29 +219,6 @@ export default _.flow(
           style: { marginTop: '1rem', color: colors.danger() }
         }, [createError]),
         creating && spinnerOverlay
-      ])],
-      [hasFreeCredits, () => h(Modal, {
-        title: 'Set up Billing',
-        onDismiss,
-        showCancel: false,
-        okButton: h(ButtonPrimary, {
-          onClick: () => {
-            onDismiss()
-            freeCreditsActive.set(true)
-          }
-        }, 'Get Free Credits')
-      }, [
-        div({ style: { color: colors.warning() } }, [
-          icon('error-standard', { size: 16, style: { marginRight: '0.5rem' } }),
-          'You need a billing project to ', cloneWorkspace ? 'clone a' : 'create a new', ' workspace.'
-        ]),
-        div({ style: { marginTop: '0.5rem', fontWeight: 500, marginBottom: '0.5rem' } }, [
-          'You have $300 in ',
-          h(Link, {
-            href: 'https://support.terra.bio/hc/en-us/articles/360027940952',
-            ...Utils.newTabLinkProps
-          }, 'free credits'), ' available!'
-        ])
       ])],
       () => h(Modal, {
         title: 'Set up Billing',

--- a/src/components/RequesterPaysModal.js
+++ b/src/components/RequesterPaysModal.js
@@ -8,7 +8,7 @@ import { Ajax } from 'src/libs/ajax'
 import { withErrorReporting } from 'src/libs/error'
 import { FormLabel } from 'src/libs/forms'
 import * as Nav from 'src/libs/nav'
-import { authStore, freeCreditsActive, requesterPaysProjectStore } from 'src/libs/state'
+import { requesterPaysProjectStore } from 'src/libs/state'
 import * as Utils from 'src/libs/utils'
 
 
@@ -20,9 +20,6 @@ const billingHelpInfo = div({ style: { paddingTop: '1rem' } }, [
 ])
 
 const RequesterPaysModal = ({ onDismiss, onSuccess }) => {
-  const { profile } = Utils.useStore(authStore)
-  const { trialState } = profile
-  const hasFreeCredits = trialState === 'Enabled'
   const [loading, setLoading] = useState(false)
   const [billingList, setBillingList] = useState([])
   const [selectedBilling, setSelectedBilling] = useState(requesterPaysProjectStore.get())
@@ -67,29 +64,6 @@ const RequesterPaysModal = ({ onDismiss, onSuccess }) => {
         onChange: ({ value }) => setSelectedBilling(value),
         options: _.uniq(_.map('projectName', billingList)).sort()
       }),
-      billingHelpInfo
-    ])],
-    [hasFreeCredits, () => h(Modal, {
-      title: 'Cannot access data',
-      onDismiss,
-      okButton: h(ButtonPrimary, {
-        onClick: () => {
-          onDismiss()
-          freeCreditsActive.set(true)
-        }
-      }, 'Get Free Credits')
-    }, [
-      div('To view or download data in this workspace, please set up a billing project.'),
-      div([
-        'You have $300 in',
-        h(Link, {
-          style: { marginLeft: '0.25rem' },
-          href: 'https://support.terra.bio/hc/en-us/articles/360027940952',
-          ...Utils.newTabLinkProps
-        }, [
-          'free credits', icon('pop-out', { style: { margin: '0 0.25rem' }, size: 12 })
-        ]), 'available!'
-      ]),
       billingHelpInfo
     ])],
     () => h(Modal, {

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -22,7 +22,7 @@ import { reportError, withErrorReporting } from 'src/libs/error'
 import { FormLabel } from 'src/libs/forms'
 import { topBarLogo } from 'src/libs/logos'
 import * as Nav from 'src/libs/nav'
-import { authStore, contactUsActive, freeCreditsActive } from 'src/libs/state'
+import { authStore, contactUsActive } from 'src/libs/state'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 import { CookiesModal } from 'src/pages/SignIn'
@@ -232,17 +232,6 @@ const TopBar = Utils.connectStore(authStore, 'authState')(class TopBar extends C
             }, ['Workflows'])
           ]),
           Utils.switchCase(trialState,
-            ['Enabled', () => {
-              return h(NavSection, {
-                onClick: () => {
-                  this.hideNav()
-                  freeCreditsActive.set(true)
-                }
-              }, [
-                div({ style: styles.nav.icon }, [icon('cloud', { size: 20 })]),
-                'Sign up for free credits'
-              ])
-            }],
             ['Enrolled', () => {
               return h(NavSection, {
                 href: 'https://software.broadinstitute.org/firecloud/documentation/freecredits',

--- a/src/components/TrialBanner.js
+++ b/src/components/TrialBanner.js
@@ -63,6 +63,7 @@ export const TrialBanner = Utils.connectStore(authStore, 'authState')(class Tria
     const { finalizeTrial } = this.state
     const { trialState } = profile
     const removeBanner = localStorage.getItem('removeBanner')
+    if (trialState === 'Enabled') return null // Disable new sign-ups
     if (!trialState || !isSignedIn || !acceptedTos || trialState === 'Finalized' || removeBanner === 'true') return null
     const { [trialState]: { title, message, enabledLink, button, isWarning } } = messages
     return div([

--- a/src/pages/billing/List.js
+++ b/src/pages/billing/List.js
@@ -15,7 +15,7 @@ import colors from 'src/libs/colors'
 import { withErrorReporting } from 'src/libs/error'
 import { formHint, FormLabel } from 'src/libs/forms'
 import * as Nav from 'src/libs/nav'
-import { authStore, freeCreditsActive } from 'src/libs/state'
+import { authStore } from 'src/libs/state'
 import * as StateHistory from 'src/libs/state-history'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
@@ -63,18 +63,6 @@ const noBillingMessage = onClick => div({ style: { fontSize: 20, margin: '2rem' 
       ...Utils.newTabLinkProps,
       href: `https://support.terra.bio/hc/en-us/articles/360026182251`
     }, [`What is a billing project?`])
-  ])
-])
-
-const freeCreditsMessage = div({ style: { fontSize: 20, margin: '2rem' } }, [
-  div([
-    'Start your free trial by redeeming your ', span({ style: { fontWeight: 600 } }, ['Free Credits'])
-  ]),
-  div({ style: { marginTop: '1rem', fontSize: 16 } }, [
-    h(Link, {
-      ...Utils.newTabLinkProps,
-      href: `https://support.terra.bio/hc/en-us/articles/360027940952`
-    }, [`What are Free Credits?`])
   ])
 ])
 
@@ -261,9 +249,7 @@ export const BillingList = _.flow(
 
   render() {
     const { billingProjects, isLoadingProjects, isLoadingAccounts, isAuthorizing, creatingBillingProject, billingAccounts, isOwner } = this.state
-    const { queryParams: { selectedName }, authState: { profile } } = this.props
-    const { trialState } = profile
-    const hasFreeCredits = trialState === 'Enabled'
+    const { queryParams: { selectedName } } = this.props
     const hasBillingProjects = !_.isEmpty(billingProjects)
     const breadcrumbs = `Billing > Billing Project`
 
@@ -289,11 +275,6 @@ export const BillingList = _.flow(
             [icon('plus-circle', { size: 21, style: { color: colors.accent() } })]
             )
           ]),
-          hasFreeCredits && h(Clickable, {
-            style: { ...Style.navList.heading, color: 'white', backgroundColor: colors.accent() },
-            hover: { backgroundColor: colors.accent(0.85) },
-            onClick: () => freeCreditsActive.set(true)
-          }, ['Click for $300 free credits']),
           _.map(project => h(ProjectTab, {
             project, key: project.projectName,
             isActive: !!selectedName && project.projectName === selectedName
@@ -320,8 +301,7 @@ export const BillingList = _.flow(
             authorizeAndLoadAccounts: this.authorizeAndLoadAccounts
           })],
           [isOwner && !selectedName && hasBillingProjects, () => div({ style: { margin: '1rem auto 0 auto' } }, ['Select a Billing Project'])],
-          [!hasBillingProjects && hasFreeCredits, () => freeCreditsMessage],
-          [!hasBillingProjects && !hasFreeCredits, () => noBillingMessage(this.showCreateProjectModal)]
+          [!hasBillingProjects, () => noBillingMessage(this.showCreateProjectModal)]
         ),
         (isLoadingProjects || isAuthorizing || isLoadingAccounts) && spinnerOverlay
       ])


### PR DESCRIPTION
Entering the enrollment flow relies on setting global state `freeCreditsActive` in `state.js`. This removes just about every case where that happens, and also removes/changes handling of when the profile's `trialState` is `Enabled`.