### PR TITLE
Add perf project for integration tests [SATURN-1768]

### DIFF
--- a/integration-tests/utils/terra-envs.js
+++ b/integration-tests/utils/terra-envs.js
@@ -15,7 +15,7 @@ module.exports = {
     workflowName: 'echo_to_file'
   },
   perf: {
-    billingProject: '???',
+    billingProject: 'saturn-integration-test-perf',
     testUrl: 'https://bvdp-saturn-perf.appspot.com',
     workflowName: 'echo_to_file'
   },


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/SATURN-1768
Adds the project for running integration tests in the perf environment. Most of the stuff was already there, but I used the script (see ticket) to get the right method config in place. I ran all the tests locally against perf. One failed without manual intervention because of issues with bond and a notification getting in the way of creating a cohort from the data explorer, but the test code is fine.