### PR TITLE
[IA-1904] Rstudio users experiencing 401s after sustained use

### DIFF
--- a/src/components/cluster-common.js
+++ b/src/components/cluster-common.js
@@ -93,6 +93,6 @@ export const PeriodicCookieSetter = ({ namespace, runtimeName, leading }) => {
   const signal = Utils.useCancellation()
   Utils.usePollingEffect(
     withErrorIgnoring(() => Ajax(signal).Clusters.notebooks(namespace, runtimeName).setCookie()),
-    { ms: 15 * 60 * 1000, leading })
+    { ms: 5 * 60 * 1000, leading })
   return null
 }


### PR DESCRIPTION
This PR changes `PeriodCookieSetter` in `cluster-common.js` from setting every 15 minutes to setting every 5 minutes. We have been having Rstudio users report 401s after leaving Rstudio idle for some time and coming back to it. By setting our third party tool cookie more often we are hoping to mitigate this issue. 
