### PR TITLE
[Saturn-1722] Update text to say cloud environment over notebook runtime

### DIFF
--- a/src/components/ClusterManager.js
+++ b/src/components/ClusterManager.js
@@ -58,7 +58,7 @@ export const ClusterErrorModal = ({ cluster, onDismiss }) => {
   const [loadingClusterDetails, setLoadingClusterDetails] = useState(false)
 
   const loadClusterError = _.flow(
-    withErrorReporting('Error loading notebook runtime details'),
+    withErrorReporting('Error loading cloud environment details'),
     Utils.withBusyState(setLoadingClusterDetails)
   )(async () => {
     const { errors: clusterErrors } = await Ajax().Clusters.cluster(cluster.googleProject, cluster.runtimeName).details()
@@ -77,7 +77,7 @@ export const ClusterErrorModal = ({ cluster, onDismiss }) => {
   Utils.useOnMount(() => { loadClusterError() })
 
   return h(Modal, {
-    title: `Notebook Runtime Error${userscriptError ? ' due to Userscript Error' : ''}`,
+    title: `Cloud Environment Creation Failed${userscriptError ? ' due to Userscript Error' : ''}`,
     showCancel: false,
     onDismiss
   }, [
@@ -134,7 +134,7 @@ export default class ClusterManager extends PureComponent {
     const rStudioLaunchLink = Nav.getLink('workspace-app-launch', { namespace, name, app: 'RStudio' })
 
     if (cluster.status === 'Error' && prevCluster.status !== 'Error' && !_.includes(cluster.id, errorNotifiedClusters.get())) {
-      notify('error', 'Error Found In Notebook Runtime', {
+      notify('error', 'Error Creating Cloud Environment', {
         message: h(ClusterErrorNotification, { cluster })
       })
       errorNotifiedClusters.update(Utils.append(cluster.id))
@@ -142,24 +142,24 @@ export default class ClusterManager extends PureComponent {
       cluster.status === 'Running' && prevCluster.status && prevCluster.status !== 'Running' &&
       cluster.labels.tool === 'RStudio' && window.location.hash !== rStudioLaunchLink
     ) {
-      const rStudioNotificationId = notify('info', 'Your runtime is ready.', {
+      const rStudioNotificationId = notify('info', 'Your cloud environment is ready.', {
         message: h(ButtonPrimary, {
           href: rStudioLaunchLink,
           onClick: () => clearNotification(rStudioNotificationId)
-        }, 'Launch Runtime')
+        }, 'Launch Cloud Environment')
       })
     } else if (isAfter(createdDate, welderCutOff) && !isToday(dateNotified)) { // TODO: remove this notification some time after the data syncing release
       setDynamic(sessionStorage, `notifiedOutdatedCluster${cluster.id}`, Date.now())
-      notify('warn', 'Please Update Your Runtime', {
+      notify('warn', 'Please Update Your Cloud Environment', {
         message: h(Fragment, [
-          p(['Last year, we introduced important updates to Terra that are not compatible with the older notebook runtime associated with this workspace. You are no longer able to save new changes to notebooks using this older runtime.']),
+          p(['Last year, we introduced important updates to Terra that are not compatible with the older cloud environment associated with this workspace. You are no longer able to save new changes to notebooks using this older cloud environment.']),
           h(Link, { href: dataSyncingDocUrl, ...Utils.newTabLinkProps }, ['Read here for more details.'])
         ])
       })
     } else if (isAfter(createdDate, twoMonthsAgo) && !isToday(dateNotified)) {
       setDynamic(sessionStorage, `notifiedOutdatedCluster${cluster.id}`, Date.now())
-      notify('warn', 'Outdated Notebook Runtime', {
-        message: 'Your notebook runtime is over two months old. Please consider deleting and recreating your runtime in order to access the latest features and security updates.'
+      notify('warn', 'Outdated Cloud Environment', {
+        message: 'Your cloud environment is over two months old. Please consider deleting and recreating your cloud environment in order to access the latest features and security updates.'
       })
     } else if (cluster.status === 'Running' && prevCluster.status === 'Updating') {
       notify('success', 'Number of workers has updated successfully.')
@@ -183,7 +183,7 @@ export default class ClusterManager extends PureComponent {
       await promise
       await refreshClusters()
     } catch (error) {
-      reportError('Notebook Runtime Error', error)
+      reportError('Cloud Environment Error', error)
     } finally {
       this.setState({ busy: false })
     }
@@ -219,16 +219,16 @@ export default class ClusterManager extends PureComponent {
             shape: 'play',
             onClick: () => this.startCluster(),
             disabled: busy || !canCompute,
-            tooltip: canCompute ? 'Start notebook runtime' : noCompute,
-            'aria-label': 'Start notebook runtime'
+            tooltip: canCompute ? 'Start cloud environment' : noCompute,
+            'aria-label': 'Start cloud environment'
           })
         case 'Running':
           return h(ClusterIcon, {
             shape: 'pause',
             onClick: () => this.stopCluster(),
             disabled: busy || !canCompute,
-            tooltip: canCompute ? 'Stop notebook runtime' : noCompute,
-            'aria-label': 'Stop notebook runtime'
+            tooltip: canCompute ? 'Stop cloud environment' : noCompute,
+            'aria-label': 'Stop cloud environment'
           })
         case 'Starting':
         case 'Stopping':
@@ -238,8 +238,8 @@ export default class ClusterManager extends PureComponent {
           return h(ClusterIcon, {
             shape: 'sync',
             disabled: true,
-            tooltip: 'Notebook runtime update in progress',
-            'aria-label': 'Notebook runtime update in progress'
+            tooltip: 'Cloud environment update in progress',
+            'aria-label': 'Cloud environment update in progress'
           })
         case 'Error':
           return h(ClusterIcon, {
@@ -255,8 +255,8 @@ export default class ClusterManager extends PureComponent {
             shape: 'play',
             onClick: () => this.setState({ createModalDrawerOpen: true }),
             disabled: busy || !canCompute,
-            tooltip: canCompute ? 'Create notebook runtime' : noCompute,
-            'aria-label': 'Create notebook runtime'
+            tooltip: canCompute ? 'Create cloud environment' : noCompute,
+            'aria-label': 'Create cloud environment'
           })
       }
     }
@@ -274,7 +274,7 @@ export default class ClusterManager extends PureComponent {
       (activeClusters.length > 1 || activeDisks.length > 1) && h(Link, {
         style: { marginRight: '1rem' },
         href: Nav.getLink('clusters'),
-        tooltip: 'Multiple runtimes and/or persistent disks found in this billing project. Click to select which to delete.'
+        tooltip: 'Multiple cloud environments found in this billing project. Click to select which to delete.'
       }, [icon('warning-standard', { size: 24, style: { color: colors.danger() } })]),
       h(Link, {
         href: appLaunchLink,
@@ -293,13 +293,13 @@ export default class ClusterManager extends PureComponent {
           tooltip: Utils.cond(
             [!canCompute, () => noCompute],
             [creating, () => 'Your environment is being created'],
-            () => 'Update runtime'
+            () => 'Update cloud environment'
           ),
           onClick: () => this.setState({ createModalDrawerOpen: true }),
           disabled: isDisabled
         }, [
           div({ style: { marginLeft: '0.5rem', paddingRight: '0.5rem', color: colors.dark() } }, [
-            div({ style: { fontSize: 12, fontWeight: 'bold' } }, 'Notebook Runtime'),
+            div({ style: { fontSize: 12, fontWeight: 'bold' } }, 'Cloud Environment'),
             div({ style: { fontSize: 10 } }, [
               span({ style: { textTransform: 'uppercase', fontWeight: 500 } }, [currentStatus === 'LeoReconfiguring' ? 'Updating' : (currentStatus || 'None')]),
               currentStatus && ` (${Utils.formatUSD(totalCost)} hr)`

--- a/src/components/NewClusterModal.js
+++ b/src/components/NewClusterModal.js
@@ -207,7 +207,7 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
 
   applyChanges = _.flow(
     Utils.withBusyState(() => this.setState({ loading: true })),
-    withErrorReporting('Error creating runtime')
+    withErrorReporting('Error creating cloud environment')
   )(async () => {
     const currentCluster = this.getCurrentCluster()
     const { onSuccess, namespace } = this.props
@@ -629,7 +629,7 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
             div({ style: { marginBottom: '0.5rem' } }, [
               label({ htmlFor: id, style: styles.label }, ['Application']),
               h(InfoBox, { style: { marginLeft: '0.5rem' } }, [
-                'The software application + programming languages + packages used when you create your runtime. '
+                'The software application + programming languages + packages used when you create your cloud environment. '
               ])
             ]),
             div({ style: { height: 45 } }, [renderImageSelect({ id, includeCustom: true })])
@@ -1098,7 +1098,6 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
         packages && h(ImageDepViewer, { packageLink: packages })
       ])
     }
-
     return div({
       style: {
         display: 'flex', flexDirection: 'column', flex: 1, padding: '1.5rem',

--- a/src/components/NewClusterModal.js
+++ b/src/components/NewClusterModal.js
@@ -864,7 +864,7 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
                 onChange: () => this.setState({ deleteDiskSelected: true })
               }, [
                 p([
-                  'Deletes your persistent disk (and its associated data). If you want to permanently save your data before deleting your disk, create a new runtime environment to access the disk and copy your data to the workspace bucket.'
+                  'Deletes your persistent disk (and its associated data). If you want to permanently save your data before deleting your disk, create a new cloud environment to access the disk and copy your data to the workspace bucket.'
                 ]),
                 h(Link, {
                   href: '',
@@ -876,7 +876,7 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
             () => {
               return h(Fragment, [
                 p([
-                  'Deleting your runtime will also ',
+                  'Deleting your cloud environment will also ',
                   span({ style: { fontWeight: 600 } }, ['delete any files on the associated hard disk ']),
                   '(e.g. input data or analysis outputs) and installed packages. To permanently save these files, ',
                   h(Link, {
@@ -885,7 +885,7 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
                   }, ['move them to the workspace bucket.'])
                 ]),
                 p([
-                  'Deleting your runtime will stop all running notebooks and associated costs. You can recreate your runtime later, which will take several minutes.'
+                  'Deleting your cloud environment will stop all running notebooks and associated costs. You can recreate your cloud environment later, which will take several minutes.'
                 ])
               ])
             }
@@ -1041,7 +1041,7 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
             renderRuntimeSection(),
             !!isPersistentDisk && renderPersistentDiskSection(),
             !sparkMode && !isPersistentDisk && div({ style: styles.whiteBoxContainer }, [
-              div(['Time to upgrade your compute runtime. Terra’s new persistent disk feature will safegard your work and data.']),
+              div(['Time to upgrade your cloud environment. Terra’s new persistent disk feature will safegard your work and data.']),
               // TODO PD: we should tell people how to get a PD here
               div({ style: { marginTop: '1rem' } }, [
                 h(Link, { onClick: () => handleLearnMoreAboutPersistentDisk() }, ['Learn more'])

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -181,7 +181,7 @@ const TopBar = Utils.connectStore(authStore, 'authState')(class TopBar extends C
               h(DropDownSubItem, {
                 href: Nav.getLink('clusters'),
                 onClick: () => this.hideNav()
-              }, ['Notebook Runtimes']),
+              }, ['Cloud Environments']),
               h(DropDownSubItem, {
                 onClick: signOut
               }, ['Sign Out'])

--- a/src/components/cluster-common.js
+++ b/src/components/cluster-common.js
@@ -22,7 +22,7 @@ export const ClusterKicker = ({ cluster, refreshClusters, onNullCluster }) => {
   const signal = Utils.useCancellation()
   const [busy, setBusy] = useState()
 
-  const startClusterOnce = withErrorReporting('Error starting notebook runtime', async () => {
+  const startClusterOnce = withErrorReporting('Error starting cloud environment', async () => {
     while (!signal.aborted) {
       const currentCluster = getCluster()
       const { googleProject, runtimeName } = currentCluster || {}

--- a/src/pages/Clusters.js
+++ b/src/pages/Clusters.js
@@ -33,13 +33,13 @@ const DeleteClusterModal = ({ cluster: { googleProject, runtimeName, runtimeConf
   const [deleting, setDeleting] = useState()
   const deleteCluster = _.flow(
     withBusyState(setDeleting),
-    withErrorReporting('Error deleting notebook runtime')
+    withErrorReporting('Error deleting cloud environment')
   )(async () => {
     await Ajax().Clusters.cluster(googleProject, runtimeName).delete(deleteDisk)
     onSuccess()
   })
   return h(Modal, {
-    title: 'Delete notebook runtime?',
+    title: 'Delete cloud environment?',
     onDismiss,
     okButton: deleteCluster
   }, [
@@ -49,11 +49,11 @@ const DeleteClusterModal = ({ cluster: { googleProject, runtimeName, runtimeConf
           span({ style: { fontWeight: 600 } }, [' Also delete the persistent disk and all files on it'])
         ]) :
         p([
-          'Deleting this runtime will also ', span({ style: { fontWeight: 600 } }, ['delete any files on the associated hard disk.'])
+          'Deleting this cloud environment will also ', span({ style: { fontWeight: 600 } }, ['delete any files on the associated hard disk.'])
         ]),
       h(SaveNotice),
       p([
-        'Deleting your runtime will stop all running notebooks and associated costs. You can recreate your runtime later, ',
+        'Deleting your cloud environment will stop all running notebooks and associated costs. You can recreate your cloud environment later, ',
         'which will take several minutes.'
       ])
     ]),
@@ -116,7 +116,7 @@ const Clusters = () => {
     }
   })
 
-  const loadClusters = withErrorReporting('Error loading notebook runtimes', refreshClusters)
+  const loadClusters = withErrorReporting('Error loading cloud environments', refreshClusters)
 
   useOnMount(() => { loadClusters() })
   usePollingEffect(withErrorIgnoring(refreshClusters), { ms: 30000 })
@@ -145,9 +145,9 @@ const Clusters = () => {
   const disksByProject = _.groupBy('googleProject', disks)
 
   return h(FooterWrapper, [
-    h(TopBar, { title: 'Notebook Runtimes' }),
+    h(TopBar, { title: 'Cloud Environments' }),
     div({ role: 'main', style: { padding: '1rem', flexGrow: 1 } }, [
-      div({ style: { ...Style.elements.sectionHeader, textTransform: 'uppercase', marginBottom: '1rem' } }, ['Your notebook runtimes']),
+      div({ style: { ...Style.elements.sectionHeader, textTransform: 'uppercase', marginBottom: '1rem' } }, ['Your cloud environments']),
       clusters && h(SimpleFlexTable, {
         rowCount: filteredClusters.length,
         columns: [
@@ -160,7 +160,7 @@ const Clusters = () => {
               return h(Fragment, [
                 cluster.googleProject,
                 inactive && h(TooltipTrigger, {
-                  content: 'This billing project has multiple active runtime environments. Only the most recently created one will be used.'
+                  content: 'This billing project has multiple active cloud environments. Only the most recently created one will be used.'
                 }, [icon('warning-standard', { style: { marginLeft: '0.25rem', color: colors.warning() } })])
               ])
             }
@@ -210,8 +210,8 @@ const Clusters = () => {
               const { id, status } = filteredClusters[rowIndex]
               return status !== 'Deleting' && h(Link, {
                 disabled: status === 'Creating',
-                'aria-label': 'Delete notebook runtime',
-                tooltip: status === 'Creating' ? 'Cannot delete a runtime while it is being created' : 'Delete notebook runtime',
+                'aria-label': 'Delete cloud environment',
+                tooltip: status === 'Creating' ? 'Cannot delete a cloud environment while it is being created' : 'Delete cloud environment',
                 onClick: () => setDeleteClusterId(id)
               }, [icon('trash')])
             }
@@ -282,7 +282,7 @@ const Clusters = () => {
               // TODO PD: there should be some way of identifying which disk is connected to which runtime
               const error = cond(
                 [status === 'Creating', () => 'Cannot delete this disk because it is still being created'],
-                [_.some({ runtimeConfig: { persistentDiskId: id } }, clusters), 'Cannot delete this disk because it is attached to a runtime. You must delete the runtime first.']
+                [_.some({ runtimeConfig: { persistentDiskId: id } }, clusters), 'Cannot delete this disk because it is attached. You must delete the cloud environment first.']
               )
               return status !== 'Deleting' && h(Link, {
                 'aria-label': 'Delete persistent disk',
@@ -324,6 +324,6 @@ export const navPaths = [
     name: 'clusters',
     path: '/clusters',
     component: Clusters,
-    title: 'Runtime environments'
+    title: 'Cloud environments'
   }
 ]

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -85,7 +85,7 @@ const NotebookCard = ({ namespace, name, updated, metadata, listView, wsName, on
     content: h(Fragment, [
       h(MenuButton, {
         href: notebookLink,
-        tooltip: canWrite && 'Open without cloud environment',
+        tooltip: canWrite && 'Open without cloud compute',
         tooltipSide: 'left'
       }, [makeMenuIcon('eye'), 'Open preview']),
       h(MenuButton, {

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -85,7 +85,7 @@ const NotebookCard = ({ namespace, name, updated, metadata, listView, wsName, on
     content: h(Fragment, [
       h(MenuButton, {
         href: notebookLink,
-        tooltip: canWrite && 'Open without runtime',
+        tooltip: canWrite && 'Open without cloud environment',
         tooltipSide: 'left'
       }, [makeMenuIcon('eye'), 'Open preview']),
       h(MenuButton, {

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -174,7 +174,7 @@ const useCloudEnvironmentPolling = namespace => {
       throw error
     }
   }
-  const refreshClusters = withErrorReporting('Error loading notebook runtimes', load)
+  const refreshClusters = withErrorReporting('Error loading cloud environments', load)
   const refreshClustersSilently = withErrorIgnoring(load)
   Utils.useOnMount(() => {
     refreshClusters()

--- a/src/pages/workspaces/workspace/applications/AppLauncher.js
+++ b/src/pages/workspaces/workspace/applications/AppLauncher.js
@@ -47,7 +47,7 @@ const AppLauncher = _.flow(
       h(Fragment, [
         h(PeriodicCookieSetter, { namespace, runtimeName }),
         app === 'RStudio' && h(PlaygroundHeader, [
-          'This feature is in early development. Your files are saved on your runtime but not to your workspace. We encourage you to frequently ',
+          'This feature is in early development. Your files are saved on your cloud environment but not to your workspace. We encourage you to frequently ',
           h(Link, {
             href: 'https://support.terra.bio/hc/en-us/articles/360037269472#h_822db925-41fa-4797-b0da-0839580a74da',
             ...Utils.newTabLinkProps
@@ -66,16 +66,16 @@ const AppLauncher = _.flow(
       div({ style: { padding: '2rem' } }, [
         !busy && h(StatusMessage, { hideSpinner: ['Error', 'Stopped', null].includes(clusterStatus) }, [
           Utils.cond(
-            [clusterStatus === 'Creating', () => 'Creating notebook runtime environment. You can navigate away and return in 3-5 minutes.'],
-            [clusterStatus === 'Starting', () => 'Starting notebook runtime environment, this may take up to 2 minutes.'],
+            [clusterStatus === 'Creating', () => 'Creating cloud environment. You can navigate away and return in 3-5 minutes.'],
+            [clusterStatus === 'Starting', () => 'Starting cloud environment, this may take up to 2 minutes.'],
             [_.includes(clusterStatus, usableStatuses), () => 'Almost ready...'],
-            [clusterStatus === 'Stopping', () => 'Notebook runtime environment is stopping, which takes ~4 minutes. You can restart it after it finishes.'],
-            [clusterStatus === 'Stopped', () => 'Notebook runtime environment is stopped. Start it to edit your notebook or use the terminal.'],
-            [clusterStatus === 'LeoReconfiguring', () => 'Notebook runtime environment is updating, please wait.'],
-            [clusterStatus === 'Error', () => 'Error with the notebook runtime environment, please try again.'],
-            [clusterStatus === null, () => 'Create a notebook runtime to continue.'],
+            [clusterStatus === 'Stopping', () => 'Cloud environment is stopping, which takes ~4 minutes. You can restart it after it finishes.'],
+            [clusterStatus === 'Stopped', () => 'Cloud environment is stopped. Start it to edit your notebook or use the terminal.'],
+            [clusterStatus === 'LeoReconfiguring', () => 'Cloud environment is updating, please wait.'],
+            [clusterStatus === 'Error', () => 'Error with the cloud environment, please try again.'],
+            [clusterStatus === null, () => 'Create a cloud environment to continue.'],
             [clusterStatus === undefined, () => 'Loading...'],
-            () => 'Unknown notebook runtime status. Please create a new runtime or contact support.'
+            () => 'Unknown cloud environment status. Please create a new cloud environment or contact support.'
           )
         ]),
         h(NewClusterModal, {

--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -124,8 +124,8 @@ const EditModeDisabledModal = ({ onDismiss, onRecreateCluster, onPlayground }) =
     onDismiss,
     showButtons: false
   }, [
-    p('We’ve released important updates that are not compatible with the older runtime associated with this workspace. To enable Edit Mode, please delete your existing runtime and create a new runtime.'),
-    p('If you have any files on your old runtime that you want to keep, you can access your old runtime using the Playground Mode option.'),
+    p('We’ve released important updates that are not compatible with the older cloud environment associated with this workspace. To enable Edit Mode, please delete your existing cloud environment and create a new cloud environment.'),
+    p('If you have any files on your old cloud environment that you want to keep, you can access your old cloud environment using the Playground Mode option.'),
     h(Link, {
       href: dataSyncingDocUrl,
       ...Utils.newTabLinkProps
@@ -142,7 +142,7 @@ const EditModeDisabledModal = ({ onDismiss, onRecreateCluster, onPlayground }) =
       h(ButtonPrimary, {
         style: { padding: '0 1rem', marginLeft: '2rem' },
         onClick: () => onRecreateCluster()
-      }, ['Recreate notebook runtime'])
+      }, ['Recreate cloud environment'])
     ])
   ])
 }
@@ -211,7 +211,7 @@ const PreviewHeader = ({ queryParams, cluster, readOnlyAccess, onCreateCluster, 
         [makeMenuIcon('export'), 'Copy to another workspace']
       )],
       [!!clusterStatus && cluster.labels.tool !== 'Jupyter', () => h(StatusMessage, { hideSpinner: true }, [
-        'Your notebook runtime doesn\'t appear to be running Jupyter. Create a new runtime with Jupyter on it to edit this notebook.'
+        'Your cloud environment doesn\'t appear to be running Jupyter. Create a new cloud environment with Jupyter on it to edit this notebook.'
       ])],
       [!mode || [null, 'Stopped'].includes(clusterStatus), () => h(Fragment, [
         Utils.cond(
@@ -246,22 +246,22 @@ const PreviewHeader = ({ queryParams, cluster, readOnlyAccess, onCreateCluster, 
         ])
       ])],
       [_.includes(clusterStatus, usableStatuses), () => {
-        console.assert(false, `Expected notebook runtime to NOT be one of: [${usableStatuses}]`)
+        console.assert(false, `Expected cloud environment to NOT be one of: [${usableStatuses}]`)
         return null
       }],
       [clusterStatus === 'Creating', () => h(StatusMessage, [
-        'Creating notebook runtime environment. You can navigate away and return in 3-5 minutes.'
+        'Creating cloud environment. You can navigate away and return in 3-5 minutes.'
       ])],
       [clusterStatus === 'Starting', () => h(StatusMessage, [
-        'Starting notebook runtime environment, this may take up to 2 minutes.'
+        'Starting cloud environment, this may take up to 2 minutes.'
       ])],
       [clusterStatus === 'Stopping', () => h(StatusMessage, [
-        'Notebook runtime environment is stopping, which takes ~4 minutes. You can restart it after it finishes.'
+        'Cloud environment is stopping, which takes ~4 minutes. You can restart it after it finishes.'
       ])],
       [clusterStatus === 'LeoReconfiguring', () => h(StatusMessage, [
-        'Notebook runtime environment is updating, please wait.'
+        'Cloud environment is updating, please wait.'
       ])],
-      [clusterStatus === 'Error', () => h(StatusMessage, { hideSpinner: true }, ['Notebook runtime error.'])]
+      [clusterStatus === 'Error', () => h(StatusMessage, { hideSpinner: true }, ['Cloud environment error.'])]
     ),
     div({ style: { flexGrow: 1 } }),
     div({ style: { position: 'relative' } }, [
@@ -393,12 +393,12 @@ const JupyterFrameManager = ({ onClose, frameRef, details = {} }) => {
 }
 
 const copyingNotebookMessage = div({ style: { paddingTop: '2rem' } }, [
-  h(StatusMessage, ['Copying notebook to runtime environment, almost ready...'])
+  h(StatusMessage, ['Copying notebook to cloud environment, almost ready...'])
 ])
 
 const NotebookEditorFrame = ({ mode, notebookName, workspace: { workspace: { namespace, name, bucketName } }, cluster: { runtimeName, proxyUrl, status, labels } }) => {
-  console.assert(_.includes(status, usableStatuses), `Expected notebook runtime to be one of: [${usableStatuses}]`)
-  console.assert(!labels.welderInstallFailed, 'Expected cluster to have Welder')
+  console.assert(_.includes(status, usableStatuses), `Expected cloud environment to be one of: [${usableStatuses}]`)
+  console.assert(!labels.welderInstallFailed, 'Expected cloud environment to have Welder')
   const frameRef = useRef()
   const [busy, setBusy] = useState(false)
   const [notebookSetupComplete, setNotebookSetupComplete] = useState(false)
@@ -455,8 +455,8 @@ const NotebookEditorFrame = ({ mode, notebookName, workspace: { workspace: { nam
 }
 
 const WelderDisabledNotebookEditorFrame = ({ mode, notebookName, workspace: { workspace: { namespace, name, bucketName } }, cluster: { runtimeName, proxyUrl, status, labels } }) => {
-  console.assert(status === 'Running', 'Expected notebook runtime to be running')
-  console.assert(!!labels.welderInstallFailed, 'Expected cluster to not have Welder')
+  console.assert(status === 'Running', 'Expected cloud environment to be running')
+  console.assert(!!labels.welderInstallFailed, 'Expected cloud environment to not have Welder')
   const frameRef = useRef()
   const signal = Utils.useCancellation()
   const [busy, setBusy] = useState(false)
@@ -469,7 +469,7 @@ const WelderDisabledNotebookEditorFrame = ({ mode, notebookName, workspace: { wo
     if (mode === 'edit') {
       notify('error', 'Cannot Edit Notebook', {
         message: h(Fragment, [
-          p(['Recent updates to Terra are not compatible with the older notebook runtime in this workspace. Please recreate your runtime in order to access Edit Mode for this notebook.']),
+          p(['Recent updates to Terra are not compatible with the older cloud environment in this workspace. Please recreate your cloud environment in order to access Edit Mode for this notebook.']),
           h(Link, { href: dataSyncingDocUrl, ...Utils.newTabLinkProps }, ['Read here for more details.'])
         ])
       })

--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -211,7 +211,7 @@ const PreviewHeader = ({ queryParams, cluster, readOnlyAccess, onCreateCluster, 
         [makeMenuIcon('export'), 'Copy to another workspace']
       )],
       [!!clusterStatus && cluster.labels.tool !== 'Jupyter', () => h(StatusMessage, { hideSpinner: true }, [
-        'Your cloud environment doesn\'t appear to be running Jupyter. Create a new cloud environment with Jupyter on it to edit this notebook.'
+        'Your cloud compute doesn\'t appear to be running Jupyter. Create a new cloud environment with Jupyter on it to edit this notebook.'
       ])],
       [!mode || [null, 'Stopped'].includes(clusterStatus), () => h(Fragment, [
         Utils.cond(


### PR DESCRIPTION
Tested by looking at a few places in the UI, did not exhaustively generate every error message, since the only change is the text. There are a few places I did not change it:

Still says runtime on NewClusterModal line 588 because that one is actually talking about specifically the runtime
WDLVIewer line 41 seems to have runtime in a stack of complicated | separated strings. I don't know what is going on there and didn't want to mess with it.
Clusters.js line 62 I did not change, because it seemed like it was actually still talking about notebook runtimes, but may potentially change in @panentheos 's work on SATURN-1747

List of changes was found by searching in the src directory for `runtime` (case insensitive) and then using intellij's breakdown to restrict me to looking at string constants only.