### PR TITLE
IA-2148 IA-2138 update patch criteria

### DIFF
--- a/src/components/NewClusterModal.js
+++ b/src/components/NewClusterModal.js
@@ -354,7 +354,6 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
 
     const bottomButtons = () => {
       const canUpdate = this.canUpdate()
-      console.log(`can update ${canUpdate}`)
       const updateOrReplace = canUpdate ? 'update' : 'replace'
 
       return h(Fragment, [

--- a/src/components/NewClusterModal.js
+++ b/src/components/NewClusterModal.js
@@ -188,13 +188,14 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
     const currentClusterConfig = normalizeRuntimeConfig(currentCluster.runtimeConfig)
     const userSelectedConfig = normalizeRuntimeConfig(this.getRuntimeConfig())
 
-    const cantWorkersUpdate = currentClusterConfig.numberOfWorkers !== userSelectedConfig.numberOfWorkers &&
-      (currentClusterConfig.numberOfWorkers < 2 || userSelectedConfig.numberOfWorkers < 2)
+    const cantWorkersUpdate = (currentCluster.status === 'Stopped' && (currentClusterConfig.numberOfWorkers !== userSelectedConfig.numberOfWorkers)) || (currentClusterConfig.numberOfWorkers !== userSelectedConfig.numberOfWorkers &&
+      (currentClusterConfig.numberOfWorkers < 2 || userSelectedConfig.numberOfWorkers < 2))
 
+    const isClusterRunning = currentCluster.status === 'Running'
     const hasUnUpdateableResourceChanged =
-      currentClusterConfig.workerDiskSize !== userSelectedConfig.workerDiskSize ||
-      currentClusterConfig.workerMachineType !== userSelectedConfig.workerMachineType ||
-      currentClusterConfig.numberOfWorkerLocalSSDs !== userSelectedConfig.numberOfWorkerLocalSSDs
+      (currentClusterConfig.workerDiskSize !== userSelectedConfig.workerDiskSize && isClusterRunning) ||
+      (currentClusterConfig.workerMachineType !== userSelectedConfig.workerMachineType && isClusterRunning) ||
+      (currentClusterConfig.numberOfWorkerLocalSSDs !== userSelectedConfig.numberOfWorkerLocalSSDs && isClusterRunning)
 
     const hasWorkers = currentClusterConfig.numberOfWorkers >= 2 || currentClusterConfig.numberOfPreemptibleWorkers >= 2
     const hasWorkersResourceChanged = hasWorkers && hasUnUpdateableResourceChanged
@@ -205,6 +206,7 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
 
     const cantUpdate = cantWorkersUpdate || hasWorkersResourceChanged || hasDiskSizeDecreased || hasCloudServiceChanged ||
       this.hasImageChanged() || this.hasStartUpScriptChanged()
+
     return !cantUpdate
   }
 
@@ -352,6 +354,7 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
 
     const bottomButtons = () => {
       const canUpdate = this.canUpdate()
+      console.log(`can update ${canUpdate}`)
       const updateOrReplace = canUpdate ? 'update' : 'replace'
 
       return h(Fragment, [


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2148

* When a cluster is `Stopped`, we want to disallow users to update worker number (limitation on leo side).
* When a cluster is `Stopped`, we want to allow users to update disk size, machine type, and number of worker local SSDs

Tested in fiab
![Screen Shot 2020-08-19 at 6 16 54 PM](https://user-images.githubusercontent.com/32771737/90695549-ab702e80-e248-11ea-92d2-f6bf26fbb8fd.png)
![Screen Shot 2020-08-19 at 6 16 36 PM](https://user-images.githubusercontent.com/32771737/90695553-af03b580-e248-11ea-89e0-d3d8ac1d8ac6.png)
