### PR TITLE
Kf mixpanel delete environment event

### DIFF
--- a/src/components/NewClusterModal.js
+++ b/src/components/NewClusterModal.js
@@ -210,7 +210,7 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
     return { size: newPersistentDisk.size }
   }
 
-  getMixpanelDeleteMetrics(isDeleteRuntime, isDeletePersistentDisk) {
+  sendDeleteMetrics(isDeleteRuntime, isDeletePersistentDisk) {
     Ajax().Metrics.captureEvent(Events.cloudEnvironmentDelete, {
       ...extractWorkspaceDetails(this.makeWorkspaceObj()),
       isDeleteRuntime,
@@ -261,7 +261,9 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
       })
     }
 
-    this.getMixpanelDeleteMetrics(shouldDeleteRuntime, this.willDeletePersistentDisk())
+    if (shouldDeleteRuntime || this.willDeletePersistentDisk()) {
+      this.sendDeleteMetrics(shouldDeleteRuntime, this.willDeletePersistentDisk())
+    }
 
     if (shouldDeleteRuntime) {
       await Ajax().Clusters.cluster(namespace, currentCluster.runtimeName).delete(this.hasAttachedDisk() && shouldDeletePersistentDisk)

--- a/src/components/NewClusterModal.js
+++ b/src/components/NewClusterModal.js
@@ -254,7 +254,7 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
       await Ajax().Disks.disk(namespace, currentPersistentDisk.name).delete()
       Ajax().Metrics.captureEvent(Events.cloudEnvironmentDelete, {
         ...extractWorkspaceDetails(this.makeWorkspaceObj()),
-        isDeleteFloatingPersistentDisk: (shouldDeletePersistentDisk && !this.hasAttachedDisk())
+        isDeletePersistentDisk: (shouldDeletePersistentDisk && !this.hasAttachedDisk())
       })
     }
     if (shouldUpdatePersistentDisk) {

--- a/src/components/NewClusterModal.js
+++ b/src/components/NewClusterModal.js
@@ -252,6 +252,10 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
     }
     if (shouldDeletePersistentDisk && !this.hasAttachedDisk()) {
       await Ajax().Disks.disk(namespace, currentPersistentDisk.name).delete()
+      Ajax().Metrics.captureEvent(Events.cloudEnvironmentDelete, {
+        ...extractWorkspaceDetails(this.makeWorkspaceObj()),
+        isDeleteFloatingPersistentDisk: (shouldDeletePersistentDisk && !this.hasAttachedDisk())
+      })
     }
     if (shouldUpdatePersistentDisk) {
       await Ajax().Disks.disk(namespace, currentPersistentDisk.name).update(newPersistentDisk.size)

--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -8,6 +8,7 @@ import * as Utils from 'src/libs/utils'
 const eventsList = {
   aboutPersistentDiskView: 'about:persistentDisk:view',
   applicationLaunch: 'application:launch',
+  cloudEnvironmentDelete: 'cloud:environment:delete',
   notebookLaunch: 'notebook:launch',
   notebookRename: 'notebook:rename',
   notebookCopy: 'notebook:copy',


### PR DESCRIPTION
send an event to mixpanel when either a PD, a runtime, or both are deleted. I'm pretty sure this should report correctly in all of the delete cases, but I'd appreciate a double check on that! 

the event should track these properties: 

Property: Delete Persistent Disk: [yes/no]
Property: Delete Cloud Compute: [yes/no]
