### PR TITLE
Kf mixpanel update environment options

### DIFF
--- a/src/components/NewClusterModal.js
+++ b/src/components/NewClusterModal.js
@@ -277,8 +277,7 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
     }
     if (shouldUpdateRuntime) {
       await Ajax().Clusters.cluster(namespace, currentCluster.runtimeName).update({
-        runtimeConfig
-      })
+        runtimeConfig })
     }
     if (shouldCreateRuntime) {
       await Ajax().Clusters.cluster(namespace, Utils.generateClusterName()).create({

--- a/src/components/NewClusterModal.js
+++ b/src/components/NewClusterModal.js
@@ -219,6 +219,22 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
     })
   }
 
+  sendUpdateMetrics(newRuntime, newPersistentDisk) {
+    const machineType = newRuntime.cloudService === cloudServices.GCE ? newRuntime.machineType : newRuntime.masterMachineType
+    const { cpu, memory } = findMachineType(machineType)
+
+    Ajax().Metrics.captureEvent(Events.cloudEnvironmentUpdate, {
+      ...extractWorkspaceDetails(this.makeWorkspaceObj()),
+      ...newRuntime,
+      cpu,
+      memory,
+      persistentDiskSize: newPersistentDisk?.size,
+      runtimeCostPerHour: Utils.formatUSD(runtimeConfigCost(this.getPendingRuntimeConfig())),
+      runtimePausedCostPerHour: Utils.formatUSD(ongoingCost(this.getPendingRuntimeConfig())),
+      persistentDiskCostPerMonth: (newPersistentDisk && Utils.formatUSD(persistentDiskCostMonthly(newPersistentDisk)))
+    })
+  }
+
   applyChanges = _.flow(
     Utils.withBusyState(() => this.setState({ loading: true })),
     withErrorReporting('Error creating cloud environment')
@@ -266,6 +282,10 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
       this.sendDeleteMetrics(shouldDeleteRuntime, this.willDeletePersistentDisk())
     }
 
+    if (shouldUpdateRuntime || shouldUpdatePersistentDisk) {
+      this.sendUpdateMetrics(newRuntime, newPersistentDisk)
+    }
+
     if (shouldDeleteRuntime) {
       await Ajax().Clusters.cluster(namespace, currentCluster.runtimeName).delete(this.hasAttachedDisk() && shouldDeletePersistentDisk)
     }
@@ -276,8 +296,7 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
       await Ajax().Disks.disk(namespace, currentPersistentDisk.name).update(newPersistentDisk.size)
     }
     if (shouldUpdateRuntime) {
-      await Ajax().Clusters.cluster(namespace, currentCluster.runtimeName).update({
-        runtimeConfig })
+      await Ajax().Clusters.cluster(namespace, currentCluster.runtimeName).update({ runtimeConfig })
     }
     if (shouldCreateRuntime) {
       await Ajax().Clusters.cluster(namespace, Utils.generateClusterName()).create({

--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -9,7 +9,6 @@ const eventsList = {
   aboutPersistentDiskView: 'about:persistentDisk:view',
   applicationLaunch: 'application:launch',
   cloudEnvironmentDelete: 'cloud:environment:delete',
-  cloudEnvironmentUpdate: 'cloud:environment:update',
   notebookLaunch: 'notebook:launch',
   notebookRename: 'notebook:rename',
   notebookCopy: 'notebook:copy',

--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -9,6 +9,7 @@ const eventsList = {
   aboutPersistentDiskView: 'about:persistentDisk:view',
   applicationLaunch: 'application:launch',
   cloudEnvironmentDelete: 'cloud:environment:delete',
+  cloudEnvironmentUpdate: 'cloud:environment:update',
   notebookLaunch: 'notebook:launch',
   notebookRename: 'notebook:rename',
   notebookCopy: 'notebook:copy',


### PR DESCRIPTION
Sending mixpanel metrics on the 'update' case for either a runtime or a PD. This one has a lot of suggested properties, I did my best to capture everything,  but if I missed something please let me know. Tested with multiple overrides, viewed results in mixpanel. 

See notes below on suggested properties:

Property: Default Config: Yes/No - NOT IMPLEMENTED (I couldn't find a way to determine the original defaults reliably without hardcoding them, Amelia okayed me to drop this)
Property: App Config: [name] - I believe this means the workspace info, but if anyone knows otherwise let me know
Property: CPUs: [number]
Property: Memory: [number]
Property: Disk: [number]
Property: Compute Type: [selection]
Property: Persistent Disk: [number]
Property: Cost [number]
Property: Delete Persistent Disk: [yes/no/NA] - N/A, this is handled under the 'delete' case
Property: Cloud Env: [GCE, dataproc]
Property: [placeholder for everything dataproc related]
Property: Reattach persistent disk [yes/no] - N/A, this is handled under the 'create' case
