### PR TITLE
use disk details call on opening modal to display updated disk size faster

### DIFF
--- a/src/components/NewClusterModal.js
+++ b/src/components/NewClusterModal.js
@@ -464,12 +464,15 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
     Ajax().Metrics.captureEvent(Events.cloudEnvironmentConfigOpen, {
       existingConfig: !!currentCluster, ...extractWorkspaceDetails(this.makeWorkspaceObj())
     })
-
+    console.log(currentPersistentDisk)
+    const currentPersistentDiskBlah = await Ajax().Disks.disk(currentPersistentDisk.googleProject, currentPersistentDisk.name).details()
+    console.log(currentPersistentDiskBlah)
     const [currentClusterDetails, newLeoImages, currentPersistentDiskDetails] = await Promise.all([
       currentCluster ? Ajax().Clusters.cluster(currentCluster.googleProject, currentCluster.runtimeName).details() : null,
       Ajax().Buckets.getObjectPreview('terra-docker-image-documentation', 'terra-docker-versions.json', namespace, true).then(res => res.json()),
       currentPersistentDisk ? Ajax().Disks.disk(currentPersistentDisk.googleProject, currentPersistentDisk.name).details() : null
     ])
+    console.log(currentPersistentDiskDetails)
 
     this.setState({ leoImages: newLeoImages, currentClusterDetails, currentPersistentDiskDetails })
     if (currentClusterDetails) {

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1290,7 +1290,7 @@ const Disks = signal => ({
       },
       details: () => {
         return fetchLeo(`api/google/v1/disks/${project}/${name}`,
-          _.mergeAll([authOpts(), appIdentifier, { signal, method: 'GET' }]))
+          _.mergeAll([authOpts(), appIdentifier, { signal, method: 'GET' }])).json()
       }
     }
   }

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1288,9 +1288,10 @@ const Disks = signal => ({
         return fetchLeo(`api/google/v1/disks/${project}/${name}`,
           _.mergeAll([authOpts(), jsonBody({ size }), appIdentifier, { signal, method: 'PATCH' }]))
       },
-      details: () => {
-        return fetchLeo(`api/google/v1/disks/${project}/${name}`,
-          _.mergeAll([authOpts(), appIdentifier, { signal, method: 'GET' }])).json()
+      details: async () => {
+        const res = await fetchLeo(`api/google/v1/disks/${project}/${name}`,
+          _.mergeAll([authOpts(), appIdentifier, { signal, method: 'GET' }]))
+        return res.json()
       }
     }
   }

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1287,6 +1287,10 @@ const Disks = signal => ({
       update: size => {
         return fetchLeo(`api/google/v1/disks/${project}/${name}`,
           _.mergeAll([authOpts(), jsonBody({ size }), appIdentifier, { signal, method: 'PATCH' }]))
+      },
+      details: () => {
+        return fetchLeo(`api/google/v1/disks/${project}/${name}`,
+          _.mergeAll([authOpts(), appIdentifier, { signal, method: 'GET' }]))
       }
     }
   }


### PR DESCRIPTION
co-authored by Sky

refactored getCurrentCluster() and getCurrentPersistentDisk() to use currentClusterDetails and currentPersistentDiskDetails from state instead, added call to getDisks when you open the runtime drawer so we can display the most current info available on disk size. 
