### PR TITLE
Viewing a redacted snapshot should not erase IO data [WA-343]

### DIFF
--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -481,9 +481,9 @@ const WorkflowView = _.flow(
       // Dockstore users who target floating tags can change their WDL via Github without explicitly selecting a new version in Terra.
       // Before letting the user edit the config we retrieved from the DB, drop any keys that are no longer valid. [WA-291]
       // N.B. this causes `config` and `modifiedConfig` to be unequal, so we (accurately) prompt the user to save before launching
-      const modifiedConfig = filterConfigIO(inputsOutputs)(
-        readSelection ? _.set('rootEntityType', selection.entityType, config) : config
-      )
+      // DO NOT filter when a config is redacted, when there's no IO from the WDL we would erase the user's inputs
+      const unfilteredConfig = readSelection ? _.set('rootEntityType', selection.entityType, config) : config
+      const modifiedConfig = isRedacted ? unfilteredConfig : filterConfigIO(inputsOutputs)(unfilteredConfig)
 
       this.setState({
         savedConfig: config, modifiedConfig,

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -482,8 +482,10 @@ const WorkflowView = _.flow(
       // Before letting the user edit the config we retrieved from the DB, drop any keys that are no longer valid. [WA-291]
       // N.B. this causes `config` and `modifiedConfig` to be unequal, so we (accurately) prompt the user to save before launching
       // DO NOT filter when a config is redacted, when there's no IO from the WDL we would erase the user's inputs
-      const unfilteredConfig = readSelection ? _.set('rootEntityType', selection.entityType, config) : config
-      const modifiedConfig = isRedacted ? unfilteredConfig : filterConfigIO(inputsOutputs)(unfilteredConfig)
+      const modifiedConfig = _.flow(
+        readSelection ? _.set('rootEntityType', selection.entityType) : _.identity,
+        !isRedacted ? filterConfigIO(inputsOutputs) : _.identity
+      )(config)
 
       this.setState({
         savedConfig: config, modifiedConfig,


### PR DESCRIPTION
Fixes regression introduced in [WA-291](https://broadworkbench.atlassian.net/browse/WA-291)/https://github.com/DataBiosphere/terra-ui/pull/2209

Repro steps in ticket: https://broadworkbench.atlassian.net/browse/WA-343

Tested locally that:
- The redacted snapshot erasing behavior is gone
- The original bug remains fixed, i.e. renaming a WDL input does not break launching workflows