### PR TITLE
implement galaxy status in cluster manager [SATURN-1804]

### DIFF
--- a/src/components/ClusterManager.js
+++ b/src/components/ClusterManager.js
@@ -277,7 +277,7 @@ export default class ClusterManager extends PureComponent {
       app && h(Clickable, {
         style: { display: 'flex', marginRight: '2rem' },
         onClick: () => {
-          // TODO galaxy: implement this action
+          // TODO galaxy SATURN-1855: implement this action
         }
       }, [
         img({ src: galaxyLogo, alt: '', style: { marginRight: '0.25rem' } }),

--- a/src/components/ClusterManager.js
+++ b/src/components/ClusterManager.js
@@ -9,10 +9,11 @@ import { icon } from 'src/components/icons'
 import Modal from 'src/components/Modal'
 import { NewClusterModal } from 'src/components/NewClusterModal'
 import { dataSyncingDocUrl } from 'src/data/machines'
+import galaxyLogo from 'src/images/galaxy.svg'
 import rLogo from 'src/images/r-logo.svg'
 import { Ajax } from 'src/libs/ajax'
 import { getDynamic, setDynamic } from 'src/libs/browser-storage'
-import { clusterCost, collapsedClusterStatus, currentCluster, persistentDiskCost, trimClustersOldestFirst } from 'src/libs/cluster-utils'
+import { clusterCost, collapsedClusterStatus, currentApp, currentCluster, persistentDiskCost, trimClustersOldestFirst } from 'src/libs/cluster-utils'
 import colors from 'src/libs/colors'
 import { reportError, withErrorReporting } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
@@ -204,9 +205,9 @@ export default class ClusterManager extends PureComponent {
   }
 
   render() {
-    const { namespace, name, clusters, canCompute, persistentDisks } = this.props
+    const { namespace, name, clusters, canCompute, persistentDisks, apps } = this.props
     const { busy, createModalDrawerOpen, errorModalOpen } = this.state
-    if (!clusters) {
+    if (!clusters || !apps) {
       return null
     }
     const currentCluster = this.getCurrentCluster()
@@ -270,7 +271,21 @@ export default class ClusterManager extends PureComponent {
     const appName = isRStudioImage ? 'RStudio' : 'terminal'
     const appLaunchLink = Nav.getLink('workspace-app-launch', { namespace, name, app: appName })
 
+    const app = currentApp(apps)
+
     return div({ style: styles.container }, [
+      app && h(Clickable, {
+        style: { display: 'flex', marginRight: '2rem' },
+        onClick: () => {
+          // TODO galaxy: implement this action
+        }
+      }, [
+        img({ src: galaxyLogo, alt: '', style: { marginRight: '0.25rem' } }),
+        div([
+          div({ style: { fontSize: 12, fontWeight: 'bold' } }, ['Galaxy']),
+          div({ style: { fontSize: 10, textTransform: 'uppercase' } }, [app.status])
+        ])
+      ]),
       (activeClusters.length > 1 || activeDisks.length > 1) && h(Link, {
         style: { marginRight: '1rem' },
         href: Nav.getLink('clusters'),

--- a/src/images/galaxy.svg
+++ b/src/images/galaxy.svg
@@ -1,0 +1,13 @@
+<svg width="34" height="26" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <linearGradient x1="100%" y1="50%" x2="25.1%" y2="50%" id="galaxy_svg__a">
+            <stop stop-color="#FFF" stop-opacity=".5" offset="0%"/>
+            <stop stop-color="#D8C21E" offset="100%"/>
+        </linearGradient>
+    </defs>
+    <g fill="none" fill-rule="evenodd">
+        <rect fill="#69696A" width="25" height="7" rx=".5"/>
+        <rect fill="#69696A" y="9.5" width="18" height="7" rx=".5"/>
+        <rect fill="url(#galaxy_svg__a)" x="9" y="19" width="25" height="7" rx=".5"/>
+    </g>
+</svg>

--- a/src/libs/cluster-utils.js
+++ b/src/libs/cluster-utils.js
@@ -79,6 +79,8 @@ export const currentCluster = clusters => {
   return !clusters ? undefined : (_.flow(trimClustersOldestFirst, _.last)(clusters) || null)
 }
 
+export const currentApp = _.first // TODO galaxy: fill in the correct logic here
+
 export const collapsedClusterStatus = cluster => {
   return cluster && (cluster.patchInProgress ? 'LeoReconfiguring' : cluster.status) // NOTE: preserves null vs undefined
 }

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -115,7 +115,8 @@ const WorkspaceContainer = ({ namespace, name, breadcrumbs, topBarContent, title
       ]),
       h(ClusterManager, {
         namespace, name, clusters, persistentDisks, refreshClusters,
-        canCompute: !!((workspace && workspace.canCompute) || (clusters && clusters.length))
+        canCompute: !!((workspace && workspace.canCompute) || (clusters && clusters.length)),
+        apps: [] // TODO galaxy: pass actual apps here
       })
     ]),
     showTabBar && h(WorkspaceTabs, { namespace, name, activeTab, refresh, workspace }),


### PR DESCRIPTION
This adds galaxy information to the 'cluster manager' widget in the upper right (if galaxy is running). By itself, this PR doesn't have any visible changes, since the actual data isn't wired in yet. Tested locally by passing some stub data to the cluster manager.