### PR TITLE
deprecate passing non-function values to cond

### DIFF
--- a/src/components/AuthContainer.js
+++ b/src/components/AuthContainer.js
@@ -17,9 +17,9 @@ const AuthContainer = ({ children }) => {
 
   return Utils.cond(
     [isSignedIn === undefined && !isPublic, authspinner],
-    [isSignedIn === false && !isPublic, h(SignIn)],
+    [isSignedIn === false && !isPublic, () => h(SignIn)],
     [registrationStatus === undefined && !isPublic, authspinner],
-    [registrationStatus === 'unregistered', h(Register)],
+    [registrationStatus === 'unregistered', () => h(Register)],
     [registrationStatus === 'disabled', () => h(Disabled)],
     [acceptedTos === undefined && !isPublic, authspinner],
     [acceptedTos === false && name !== 'privacy', () => h(TermsOfService)],

--- a/src/components/IdleStatusMonitor.js
+++ b/src/components/IdleStatusMonitor.js
@@ -42,14 +42,14 @@ const IdleStatusMonitor = ({
   useEffect(() => { timedOut && !isSignedIn && setLastActive('expired') }, [isSignedIn, timedOut])
 
   return Utils.cond(
-    [isSignedIn && isTimeoutEnabled, h(InactivityTimer, { id, timeout, countdownStart })],
+    [isSignedIn && isTimeoutEnabled, () => h(InactivityTimer, { id, timeout, countdownStart })],
     [lastRecordedActivity === 'expired' && !isSignedIn, () => h(Modal, {
       title: 'Session Expired',
       showCancel: false,
       onDismiss: () => setLastActive(),
       onOk: () => setLastActive()
     }, ['Your session has expired to maintain security and protect clinical data'])],
-    null)
+    () => null)
 }
 
 const CountdownModal = ({ onCancel, countdown }) => {

--- a/src/components/Interactive.js
+++ b/src/components/Interactive.js
@@ -15,21 +15,21 @@ const Interactive = Utils.forwardRefWithName('Interactive', ({
   const { cursor } = style
 
   const computedCursor = Utils.cond(
-    [cursor, cursor],
-    [disabled, undefined],
-    [onClick || pointerTags.includes(as) || pointerTypes.includes(type), 'pointer']
+    [cursor, () => cursor],
+    [disabled, () => undefined],
+    [onClick || pointerTags.includes(as) || pointerTypes.includes(type), () => 'pointer']
   )
 
   const computedTabIndex = Utils.cond(
-    [_.isNumber(tabIndex), tabIndex],
-    [disabled, -1],
-    [onClick, 0],
-    undefined)
+    [_.isNumber(tabIndex), () => tabIndex],
+    [disabled, () => -1],
+    [onClick, () => 0],
+    () => undefined)
 
   const computedRole = Utils.cond(
-    [role, role],
-    [onClick && !['input', ...pointerTags].includes(as), 'button'],
-    undefined)
+    [role, () => role],
+    [onClick && !['input', ...pointerTags].includes(as), () => 'button'],
+    () => undefined)
 
   const cssVariables = _.flow(
     _.toPairs,

--- a/src/components/NewWorkspaceModal.js
+++ b/src/components/NewWorkspaceModal.js
@@ -139,7 +139,7 @@ export default _.flow(
         title: Utils.cond(
           [title, () => title],
           [cloneWorkspace, () => 'Clone a workspace'],
-          [true, () => 'Create a New Workspace']
+          () => 'Create a New Workspace'
         ),
         onDismiss,
         okButton: h(ButtonPrimary, {
@@ -149,7 +149,7 @@ export default _.flow(
         }, Utils.cond(
           [buttonText, () => buttonText],
           [cloneWorkspace, () => 'Clone Workspace'],
-          [true, () => 'Create Workspace']
+          () => 'Create Workspace'
         ))
       }, [
         h(IdContainer, [id => h(Fragment, [

--- a/src/components/NewWorkspaceModal.js
+++ b/src/components/NewWorkspaceModal.js
@@ -134,12 +134,12 @@ export default _.flow(
     })
 
     return Utils.cond(
-      [loading, spinnerOverlay],
+      [loading, () => spinnerOverlay],
       [hasBillingProjects, () => h(Modal, {
         title: Utils.cond(
-          [title, title],
-          [cloneWorkspace, 'Clone a workspace'],
-          [Utils.DEFAULT, 'Create a New Workspace']
+          [title, () => title],
+          [cloneWorkspace, () => 'Clone a workspace'],
+          [true, () => 'Create a New Workspace']
         ),
         onDismiss,
         okButton: h(ButtonPrimary, {
@@ -147,9 +147,9 @@ export default _.flow(
           tooltip: Utils.summarizeErrors(errors),
           onClick: () => this.create()
         }, Utils.cond(
-          [buttonText, buttonText],
-          [cloneWorkspace, 'Clone Workspace'],
-          [Utils.DEFAULT, 'Create Workspace']
+          [buttonText, () => buttonText],
+          [cloneWorkspace, () => 'Clone Workspace'],
+          [true, () => 'Create Workspace']
         ))
       }, [
         h(IdContainer, [id => h(Fragment, [

--- a/src/components/NpsSurvey.js
+++ b/src/components/NpsSurvey.js
@@ -68,9 +68,9 @@ export const NpsSurvey = Utils.connectStore(authStore, 'authState')(class NpsSur
     const scoreRadios = _.map(i => {
       const isSelected = i === score
       const bgColor = Utils.cond(
-        [i <= 6, colors.danger(0.5)],
-        [i <= 8, colors.warning(0.8)],
-        colors.success(0.8)
+        [i <= 6, () => colors.danger(0.5)],
+        [i <= 8, () => colors.warning(0.8)],
+        () => colors.success(0.8)
       )
 
       return h(Interactive, {

--- a/src/components/PrivateDataExplorer.js
+++ b/src/components/PrivateDataExplorer.js
@@ -103,7 +103,7 @@ export default _.flow(
           p([
             `Thank you for your interest in the Baseline Health Study data. Baseline data is currently only being shared
              with Baseline Health Study partner sites, Duke and Stanford. If you are a current researcher at one of those sites,
-             please reach out to your institutional contacts for information on how to obtain access. In the future, Baseline 
+             please reach out to your institutional contacts for information on how to obtain access. In the future, Baseline
              is planning to make this data available to qualified researchers, outside of these partner sites.`
           ]),
           p(['Please reach out to ', h(Link, { href: 'mailto:support@terra.bio' }, ['support@terra.bio']), ' if you have any additional questions.'])
@@ -143,10 +143,10 @@ export default _.flow(
 
     return h(Fragment, [
       Utils.cond(
-        [groups === undefined || completedDeOauth === undefined, centeredSpinner],
+        [groups === undefined || completedDeOauth === undefined, () => centeredSpinner],
         [groups && groups.includes(authDomain) && completedDeOauth === false, () => { window.open(origin, '_self') }],
-        [groups && groups.includes(authDomain), h(DataExplorerFrame, { dataset })],
-        notInAuthDomainError
+        [groups && groups.includes(authDomain), () => h(DataExplorerFrame, { dataset })],
+        () => notInAuthDomainError
       )
     ])
   }

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -178,7 +178,7 @@ export const Checkbox = ({ checked, onChange, disabled, ...props }) => {
     style: { verticalAlign: 'middle' },
     disabled
   }, props), [
-    icon('squareSolid', { style: { color: Utils.cond([disabled, colors.light(1.2)], [checked, colors.accent()], 'white') } }), // bg
+    icon('squareSolid', { style: { color: Utils.cond([disabled, () => colors.light(1.2)], [checked, () => colors.accent()], () => 'white') } }), // bg
     !disabled && icon('squareLight', { style: { color: checked ? colors.accent(1.2) : colors.dark(0.75) } }), // border
     checked && icon('check', { size: 8, style: { color: disabled ? colors.dark(0.75) : 'white' } }) // check
   ])
@@ -473,9 +473,9 @@ export const HeroWrapper = ({ showMenu = true, bigSubhead = false, children }) =
       div({ style: { fontSize: 54 } }, `Welcome to ${getAppName()}`),
       div({ style: { margin: '1rem 0', width: 575, ...(bigSubhead ? { fontSize: 20, lineHeight: '28px' } : { fontSize: 16, lineHeight: 1.5 }) } }, [
         `${getAppName(true)} is a ${Utils.cond(
-          [isTerra(), 'cloud-native platform'],
-          [isFirecloud(), 'NCI Cloud Resource project powered by Terra'],
-          'project powered by Terra'
+          [isTerra(), () => 'cloud-native platform'],
+          [isFirecloud(), () => 'NCI Cloud Resource project powered by Terra'],
+          () => 'project powered by Terra'
         )} for biomedical researchers to `,
         heavyWrapper('access data'), ', ', heavyWrapper('run analysis tools'), ', ',
         span({ style: { whiteSpace: 'nowrap' } }, ['and', heavyWrapper(' collaborate'), '.'])

--- a/src/components/group-common.js
+++ b/src/components/group-common.js
@@ -134,7 +134,7 @@ export const NewUserModal = ajaxCaller(class NewUserModal extends Component {
         cancelText: 'No',
         onDismiss: () => this.setState({ confirmAddUser: false })
       }, ['Add ', b(userEmail), ' to the group anyway?', busy && spinnerOverlay])],
-      h(Modal, {
+      () => h(Modal, {
         onDismiss,
         title,
         okButton: h(ButtonPrimary, {

--- a/src/components/workspace-utils.js
+++ b/src/components/workspace-utils.js
@@ -77,9 +77,9 @@ export const WorkspaceImporter = _.flow(
     div({ style: { display: 'flex', alignItems: 'center', marginTop: '1rem' } }, [
       h(ButtonPrimary, {
         disabled: !selectedWorkspace || additionalErrors,
-        tooltip: Utils.cond([!selectedWorkspace, 'Select valid a workspace to import'],
-          [additionalErrors, Utils.summarizeErrors(additionalErrors)],
-          'Import workflow to workspace'
+        tooltip: Utils.cond([!selectedWorkspace, () => 'Select valid a workspace to import'],
+          [additionalErrors, () => Utils.summarizeErrors(additionalErrors)],
+          () => 'Import workflow to workspace'
         ),
         onClick: () => onImport(selectedWorkspace.workspace)
       }, ['Import']),

--- a/src/libs/colors.js
+++ b/src/libs/colors.js
@@ -18,13 +18,13 @@ const baseColors = {
 }
 
 const colorPalette = Utils.cond(
-  [isFirecloud(), baseColors],
-  [isDatastage(), { ...baseColors, primary: '#c02f42', secondary: '#1a568c', accent: '#1a568c', light: '#f4f4f6', dark: '#12385a' }],
-  [isAnvil(), { ...baseColors, primary: '#e0dd10', accent: '#035c94', light: '#f6f7f4', dark: '#012840' }],
-  [isBioDataCatalyst(), { ...baseColors, primary: '#c02f42', secondary: '#1a568c', accent: '#1a568c', light: '#f4f4f6', dark: '#12385a' }],
-  [isUKBiobank(), { ...baseColors, primary: '#005f6f' }],
-  [isBaseline(), { ...baseColors, primary: '#c41061', secondary: '#31164c', light: '#f6f7f4', dark: '#012840' }],
-  { ...baseColors, primary: '#74ae43' }
+  [isFirecloud(), () => baseColors],
+  [isDatastage(), () => ({ ...baseColors, primary: '#c02f42', secondary: '#1a568c', accent: '#1a568c', light: '#f4f4f6', dark: '#12385a' })],
+  [isAnvil(), () => ({ ...baseColors, primary: '#e0dd10', accent: '#035c94', light: '#f6f7f4', dark: '#012840' })],
+  [isBioDataCatalyst(), () => ({ ...baseColors, primary: '#c02f42', secondary: '#1a568c', accent: '#1a568c', light: '#f4f4f6', dark: '#12385a' })],
+  [isUKBiobank(), () => ({ ...baseColors, primary: '#005f6f' })],
+  [isBaseline(), () => ({ ...baseColors, primary: '#c41061', secondary: '#31164c', light: '#f6f7f4', dark: '#012840' })],
+  () => ({ ...baseColors, primary: '#74ae43' })
 )
 
 const colors = _.fromPairs(_.map(

--- a/src/libs/data-utils.js
+++ b/src/libs/data-utils.js
@@ -456,28 +456,28 @@ export const EntityEditor = ({ entityType, entityName, attributeName, attributeV
   const initialIsReference = _.isObject(attributeValue) && (attributeValue.entityType || attributeValue.itemsType === 'EntityReference')
   const initialIsList = _.isObject(attributeValue) && attributeValue.items
   const initialType = Utils.cond(
-    [initialIsReference, 'reference'],
-    [(initialIsList ? attributeValue.items[0] : attributeValue) === undefined, 'string'],
+    [initialIsReference, () => 'reference'],
+    [(initialIsList ? attributeValue.items[0] : attributeValue) === undefined, () => 'string'],
     [initialIsList, () => typeof attributeValue.items[0]],
-    typeof attributeValue
+    () => typeof attributeValue
   )
 
   const [newValue, setNewValue] = useState(() => Utils.cond(
     [initialIsReference && initialIsList, () => _.map('entityName', attributeValue.items)],
     [initialIsList, () => attributeValue.items],
     [initialIsReference, () => attributeValue.entityName],
-    attributeValue
+    () => attributeValue
   ))
   const [linkedEntityType, setLinkedEntityType] = useState(() => Utils.cond(
     [initialIsReference && initialIsList, () => attributeValue.items[0] ? attributeValue.items[0].entityType : undefined],
     [initialIsReference, () => attributeValue.entityType],
-    entityTypes[0]
+    () => entityTypes[0]
   ))
   const [editType, setEditType] = useState(() => Utils.cond(
-    [initialIsReference, 'reference'],
-    [(initialIsList ? attributeValue.items[0] : attributeValue) === undefined, 'string'],
+    [initialIsReference, () => 'reference'],
+    [(initialIsList ? attributeValue.items[0] : attributeValue) === undefined, () => 'string'],
     [initialIsList, () => typeof attributeValue.items[0]],
-    typeof attributeValue
+    () => typeof attributeValue
   ))
   const [isBusy, setIsBusy] = useState()
   const [consideringDelete, setConsideringDelete] = useState()

--- a/src/libs/logos.js
+++ b/src/libs/logos.js
@@ -20,24 +20,24 @@ import * as Utils from 'src/libs/utils'
 
 
 export const getAppName = (longName = false) => Utils.cond(
-  [isFirecloud(), 'FireCloud'],
-  [isDatastage(), 'DataStage'],
-  [isAnvil(), longName ? 'The NHGRI AnVIL (Genomic Data Science Analysis, Visualization, and Informatics Lab-space)' : 'AnVIL'],
-  [isBioDataCatalyst(), 'NHLBI BioData Catalyst'],
-  [isUKBiobank(), 'UK Biobank'],
-  [isBaseline(), longName ? 'The Baseline Health Study Data Portal' : 'Project Baseline'],
-  'Terra'
+  [isFirecloud(), () => 'FireCloud'],
+  [isDatastage(), () => 'DataStage'],
+  [isAnvil(), () => longName ? 'The NHGRI AnVIL (Genomic Data Science Analysis, Visualization, and Informatics Lab-space)' : 'AnVIL'],
+  [isBioDataCatalyst(), () => 'NHLBI BioData Catalyst'],
+  [isUKBiobank(), () => 'UK Biobank'],
+  [isBaseline(), () => longName ? 'The Baseline Health Study Data Portal' : 'Project Baseline'],
+  () => 'Terra'
 )
 
 export const returnParam = () => getAppName().toLowerCase()
 
 const pickBrandLogo = (color = false) => Utils.cond(
-  [isFirecloud(), color ? fcLogo : fcLogoWhite],
-  [isDatastage(), color ? datastageLogo : datastageLogoWhite],
-  [isAnvil(), color ? anvilLogo : anvilLogoWhite],
-  [isBioDataCatalyst(), color ? bioDataCatalystLogo : bioDataCatalystLogoWhite],
-  [isUKBiobank(), color ? ukbLogo : ukbLogoWhite],
-  [isBaseline(), color ? baselineLogo : baselineLogoWhite]
+  [isFirecloud(), () => color ? fcLogo : fcLogoWhite],
+  [isDatastage(), () => color ? datastageLogo : datastageLogoWhite],
+  [isAnvil(), () => color ? anvilLogo : anvilLogoWhite],
+  [isBioDataCatalyst(), () => color ? bioDataCatalystLogo : bioDataCatalystLogoWhite],
+  [isUKBiobank(), () => color ? ukbLogo : ukbLogoWhite],
+  [isBaseline(), () => color ? baselineLogo : baselineLogoWhite]
 )
 
 export const terraLogoMaker = (logoVariant, style) => img({ alt: 'Terra logo', role: 'img', src: logoVariant, style })

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -124,13 +124,17 @@ export const log = (...args) => {
 const maybeCall = maybeFn => _.isFunction(maybeFn) ? maybeFn() : maybeFn
 
 /**
- * Returns the value for the first truthy predicate.
- * If the value is a function, it is invoked.
- *
- * Takes predicate/value pairs in arrays, followed by an optional default value.
+ * Takes any number of [predicate, value] pairs, followed by an optional default value.
+ * Returns value() for the first truthy predicate, otherwise returns the default value().
  * Returns undefined if no predicate matches and there is no default value.
+ *
+ * DEPRECATED: If a value is not a function, it will be returned directly instead.
+ * This behavior is deprecated, and will be removed in the future.
  */
 export const cond = (...args) => {
+  console.assert(_.every(arg => {
+    return _.isFunction(arg) || (_.isArray(arg) && arg.length === 2 && _.isFunction(arg[1]))
+  }, args), 'Invalid arguments to Utils.cond')
   for (const arg of args) {
     if (_.isArray(arg)) {
       const [predicate, value] = arg

--- a/src/pages/Clusters.js
+++ b/src/pages/Clusters.js
@@ -303,7 +303,7 @@ const Clusters = () => {
               const { id, status } = filteredDisks[rowIndex]
               const error = cond(
                 [status === 'Creating', () => 'Cannot delete this disk because it is still being created'],
-                [_.some({ runtimeConfig: { persistentDiskId: id } }, clusters), 'Cannot delete this disk because it is attached. You must delete the cloud environment first.']
+                [_.some({ runtimeConfig: { persistentDiskId: id } }, clusters), () => 'Cannot delete this disk because it is attached. You must delete the cloud environment first.']
               )
               return status !== 'Deleting' && h(Link, {
                 'aria-label': 'Delete persistent disk',

--- a/src/pages/library/Showcase.js
+++ b/src/pages/library/Showcase.js
@@ -45,9 +45,9 @@ const makeCard = variant => ({ workspace: { namespace, name, attributes: { descr
         backgroundRepeat: 'no-repeat', backgroundPosition: 'center', backgroundSize: 'auto 100%', borderRadius: '0 5px 5px 0',
         width: 87,
         ...Utils.cond(
-          [name.toLowerCase().includes('covid'), { backgroundImage: `url(${covidBg})` }],
+          [name.toLowerCase().includes('covid'), () => ({ backgroundImage: `url(${covidBg})` })],
           [variant === 'gatk', () => ({ backgroundColor: '#333', backgroundImage: `url(${gatkLogo})`, backgroundSize: undefined })],
-          { backgroundImage: `url(${featuredBg})`, opacity: 0.75 }
+          () => ({ backgroundImage: `url(${featuredBg})`, opacity: 0.75 })
         )
       }
     })

--- a/src/pages/workspaces/workspace/JobHistory.js
+++ b/src/pages/workspaces/workspace/JobHistory.js
@@ -177,13 +177,13 @@ const JobHistory = _.flow(
 
                   return h(Clickable, {
                     hover: {
-                      backgroundColor: Utils.cond([!!failed, colors.danger(0.2)], [!!running || !!submitted, colors.accent(0.2)], colors.success(0.2))
+                      backgroundColor: Utils.cond([!!failed, () => colors.danger(0.2)], [!!running || !!submitted, () => colors.accent(0.2)], () => colors.success(0.2))
                     },
                     style: {
                       flex: 1, alignSelf: 'stretch', display: 'flex', flexDirection: 'column', justifyContent: 'center',
                       margin: '0 -1rem', padding: '0 1rem', minWidth: 0,
                       fontWeight: 600,
-                      backgroundColor: Utils.cond([!!failed, colors.danger(0.1)], [!!running || !!submitted, colors.accent(0.1)], colors.success(0.1))
+                      backgroundColor: Utils.cond([!!failed, () => colors.danger(0.1)], [!!running || !!submitted, () => colors.accent(0.1)], () => colors.success(0.1))
                     },
                     href: Nav.getLink('workspace-submission-details', { namespace, name, submissionId })
                   }, [

--- a/src/pages/workspaces/workspace/RequestAccessModal.js
+++ b/src/pages/workspaces/workspace/RequestAccessModal.js
@@ -98,9 +98,9 @@ const RequestAccessButton = ({ groupName, instructions }) => {
     }
   }, [
     cond(
-      [requested, 'Request Sent'],
-      [requesting, 'Sending Request...'],
-      'Request Access'
+      [requested, () => 'Request Sent'],
+      [requesting, () => 'Sending Request...'],
+      () => 'Request Access'
     )
   ])
 }

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -558,7 +558,7 @@ const WorkflowView = _.flow(
       (type === chooseSetComponents && count > 0) || count > 1) ? `(will create a new set named "${newSetName}")` : ''
     const baseEntityType = isSet(rootEntityType) ? rootEntityType.slice(0, -4) : rootEntityType
     return Utils.cond(
-      [this.isSingle() || !rootEntityType, ''],
+      [this.isSingle() || !rootEntityType, () => ''],
       [type === processAll, () => `all ${entityMetadata[rootEntityType]?.count || 0} ${rootEntityType}s ${newSetMessage}`],
       [type === processMergedSet, () => `${rootEntityType}s from ${count} sets ${newSetMessage}`],
       [type === chooseRows, () => `${count} selected ${rootEntityType}s ${newSetMessage}`],


### PR DESCRIPTION
`Utils.cond` currently treats values differently depending on whether they are functions or non-functions. This leads to some inconsistency in how it's used, and can open the door to some subtle or surprising bugs.

This deprecates the usage of non-function values. The implementation is unchanged for now, but passing a non-function value will result in a message on the console. This also changes all existing usages to conform to the stricter API. After some additional testing, the intention is to remove the option entirely.