### PR TITLE
rename 'clusters' to 'runtimes' in ajax

### DIFF
--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -101,9 +101,9 @@ const withBilling = test => async options => {
 
 const deleteRuntimes = _.flow(withSignedInPage, withUserToken)(async ({ page, billingProject, email }) => {
   const deletedRuntimes = await page.evaluate(async (billingProject, email) => {
-    const runtimes = await window.Ajax().Clusters.list({ googleProject: billingProject, creator: email })
+    const runtimes = await window.Ajax().Runtimes.list({ googleProject: billingProject, creator: email })
     return Promise.all(_.map(async runtime => {
-      await window.Ajax().Clusters.cluster(runtime.googleProject, runtime.runtimeName).delete(true) // true = also delete persistent disk
+      await window.Ajax().Runtimes.runtime(runtime.googleProject, runtime.runtimeName).delete(true) // true = also delete persistent disk
       return runtime.runtimeName
     }, _.remove({ status: 'Deleting' }, runtimes)))
   }, billingProject, email)

--- a/src/components/ClusterManager.js
+++ b/src/components/ClusterManager.js
@@ -67,7 +67,7 @@ export const ClusterErrorModal = ({ cluster, onDismiss }) => {
     withErrorReporting('Error loading cloud environment details'),
     Utils.withBusyState(setLoadingClusterDetails)
   )(async () => {
-    const { errors: clusterErrors } = await Ajax().Clusters.cluster(cluster.googleProject, cluster.runtimeName).details()
+    const { errors: clusterErrors } = await Ajax().Runtimes.runtime(cluster.googleProject, cluster.runtimeName).details()
     if (_.some(({ errorMessage }) => errorMessage.includes('Userscript failed'), clusterErrors)) {
       setError(
         await Ajax()
@@ -214,14 +214,14 @@ export default class ClusterManager extends PureComponent {
   startCluster() {
     const { googleProject, runtimeName } = this.getCurrentCluster()
     this.executeAndRefresh(
-      Ajax().Clusters.cluster(googleProject, runtimeName).start()
+      Ajax().Runtimes.runtime(googleProject, runtimeName).start()
     )
   }
 
   stopCluster() {
     const { googleProject, runtimeName } = this.getCurrentCluster()
     this.executeAndRefresh(
-      Ajax().Clusters.cluster(googleProject, runtimeName).stop()
+      Ajax().Runtimes.runtime(googleProject, runtimeName).stop()
     )
   }
 

--- a/src/components/NewClusterModal.js
+++ b/src/components/NewClusterModal.js
@@ -291,7 +291,7 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
     this.sendCloudEnvironmentMetrics()
 
     if (shouldDeleteRuntime) {
-      await Ajax().Clusters.cluster(namespace, currentClusterDetails.runtimeName).delete(this.hasAttachedDisk() && shouldDeletePersistentDisk)
+      await Ajax().Runtimes.runtime(namespace, currentClusterDetails.runtimeName).delete(this.hasAttachedDisk() && shouldDeletePersistentDisk)
     }
     if (shouldDeletePersistentDisk && !this.hasAttachedDisk()) {
       await Ajax().Disks.disk(namespace, currentPersistentDiskDetails.name).delete()
@@ -300,10 +300,10 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
       await Ajax().Disks.disk(namespace, currentPersistentDiskDetails.name).update(newPersistentDisk.size)
     }
     if (shouldUpdateRuntime) {
-      await Ajax().Clusters.cluster(namespace, currentClusterDetails.runtimeName).update({ runtimeConfig })
+      await Ajax().Runtimes.runtime(namespace, currentClusterDetails.runtimeName).update({ runtimeConfig })
     }
     if (shouldCreateRuntime) {
-      await Ajax().Clusters.cluster(namespace, Utils.generateClusterName()).create({
+      await Ajax().Runtimes.runtime(namespace, Utils.generateClusterName()).create({
         runtimeConfig,
         toolDockerImage: newRuntime.toolDockerImage,
         labels: { saturnIsProjectSpecific: `${selectedLeoImage === PROJECT_SPECIFIC_MODE}` },
@@ -465,7 +465,7 @@ export const NewClusterModal = withModalDrawer({ width: 675 })(class NewClusterM
       existingConfig: !!currentCluster, ...extractWorkspaceDetails(this.makeWorkspaceObj())
     })
     const [currentClusterDetails, newLeoImages, currentPersistentDiskDetails] = await Promise.all([
-      currentCluster ? Ajax().Clusters.cluster(currentCluster.googleProject, currentCluster.runtimeName).details() : null,
+      currentCluster ? Ajax().Runtimes.runtime(currentCluster.googleProject, currentCluster.runtimeName).details() : null,
       Ajax().Buckets.getObjectPreview('terra-docker-image-documentation', 'terra-docker-versions.json', namespace, true).then(res => res.json()),
       currentPersistentDisk ? Ajax().Disks.disk(currentPersistentDisk.googleProject, currentPersistentDisk.name).details() : null
     ])

--- a/src/components/cluster-common.js
+++ b/src/components/cluster-common.js
@@ -31,7 +31,7 @@ export const ClusterKicker = ({ cluster, refreshClusters, onNullCluster }) => {
 
       if (status === 'Stopped') {
         setBusy(true)
-        await Ajax().Clusters.cluster(googleProject, runtimeName).start()
+        await Ajax().Runtimes.runtime(googleProject, runtimeName).start()
         await refreshClusters()
         setBusy(false)
         return
@@ -99,7 +99,7 @@ export const PeriodicCookieSetter = () => {
   const signal = Utils.useCancellation()
   Utils.usePollingEffect(
     withErrorIgnoring(async () => {
-      await Ajax(signal).Clusters.setCookie()
+      await Ajax(signal).Runtimes.setCookie()
       cookieReadyStore.set(true)
     }),
     { ms: 5 * 60 * 1000, leading: true }

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1013,7 +1013,7 @@ const Submissions = signal => ({
 })
 
 
-const Clusters = signal => ({
+const Runtimes = signal => ({
   list: async (labels = {}) => {
     const res = await fetchLeo(`api/google/v1/runtimes?${qs.stringify({ saturnAutoCreated: true, ...labels })}`,
       _.mergeAll([authOpts(), appIdentifier, { signal }]))
@@ -1024,7 +1024,7 @@ const Clusters = signal => ({
     return fetchLeo(`proxy/setCookie`, _.merge(authOpts(), { signal, credentials: 'include' }))
   },
 
-  cluster: (project, name) => {
+  runtime: (project, name) => {
     const root = `api/google/v1/runtimes/${project}/${name}`
 
     return {
@@ -1032,8 +1032,8 @@ const Clusters = signal => ({
         const res = await fetchLeo(root, _.mergeAll([authOpts(), { signal }, appIdentifier]))
         return res.json()
       },
-      create: clusterOptions => {
-        const body = _.merge(clusterOptions, {
+      create: options => {
+        const body = _.merge(options, {
           labels: { saturnAutoCreated: 'true', saturnVersion: version },
           defaultClientId: getConfig().googleClientId,
           userJupyterExtensionConfig: {
@@ -1052,8 +1052,8 @@ const Clusters = signal => ({
         return fetchLeo(root, _.mergeAll([authOpts(), jsonBody(body), { signal, method: 'POST' }, appIdentifier]))
       },
 
-      update: clusterOptions => {
-        const body = { ...clusterOptions, allowStop: true }
+      update: options => {
+        const body = { ...options, allowStop: true }
         return fetchLeo(root, _.mergeAll([authOpts(), jsonBody(body), { signal, method: 'PATCH' }, appIdentifier]))
       },
 
@@ -1241,7 +1241,7 @@ export const Ajax = signal => {
     GoogleBilling: GoogleBilling(signal),
     Methods: Methods(signal),
     Submissions: Submissions(signal),
-    Clusters: Clusters(signal),
+    Runtimes: Runtimes(signal),
     Apps: Apps(signal),
     Dockstore: Dockstore(signal),
     Martha: Martha(signal),

--- a/src/pages/Clusters.js
+++ b/src/pages/Clusters.js
@@ -27,7 +27,7 @@ const DeleteClusterModal = ({ cluster: { googleProject, runtimeName, runtimeConf
     withBusyState(setDeleting),
     withErrorReporting('Error deleting cloud environment')
   )(async () => {
-    await Ajax().Clusters.cluster(googleProject, runtimeName).delete(deleteDisk)
+    await Ajax().Runtimes.runtime(googleProject, runtimeName).delete(deleteDisk)
     onSuccess()
   })
   return h(Modal, {
@@ -92,7 +92,7 @@ const Clusters = () => {
   const refreshClusters = withBusyState(setLoading, async () => {
     const creator = getUser().email
     const [newClusters, newDisks, galaxyDisks] = await Promise.all([
-      Ajax(signal).Clusters.list({ creator }),
+      Ajax(signal).Runtimes.list({ creator }),
       Ajax(signal).Disks.list({ creator }),
       Ajax(signal).Disks.list({ creator, saturnApplication: 'galaxy' })
     ])

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -163,7 +163,7 @@ const useCloudEnvironmentPolling = namespace => {
     try {
       const [newDisks, newClusters, galaxyDisks] = await Promise.all([
         Ajax(signal).Disks.list({ googleProject: namespace, creator: getUser().email }),
-        Ajax(signal).Clusters.list({ googleProject: namespace, creator: getUser().email }),
+        Ajax(signal).Runtimes.list({ googleProject: namespace, creator: getUser().email }),
         Ajax(signal).Disks.list({ googleProject: namespace, creator: getUser().email, saturnApplication: 'galaxy' })
       ])
       const galaxyDiskNames = _.map(disk => disk.name, galaxyDisks)

--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -414,16 +414,16 @@ const NotebookEditorFrame = ({ mode, notebookName, workspace: { workspace: { nam
     withErrorReporting('Error setting up notebook')
   )(async () => {
     await Ajax()
-      .Clusters
+      .Runtimes
       .notebooks(namespace, runtimeName)
       .setStorageLinks(localBaseDirectory, localSafeModeBaseDirectory, cloudStorageDirectory, `.*\\.ipynb`)
-    if (mode === 'edit' && !(await Ajax().Clusters.notebooks(namespace, runtimeName).lock(`${localBaseDirectory}/${notebookName}`))) {
+    if (mode === 'edit' && !(await Ajax().Runtimes.notebooks(namespace, runtimeName).lock(`${localBaseDirectory}/${notebookName}`))) {
       notify('error', 'Unable to Edit Notebook', {
         message: 'Another user is currently editing this notebook. You can run it in Playground Mode or make a copy.'
       })
       chooseMode(undefined)
     } else {
-      await Ajax().Clusters.notebooks(namespace, runtimeName).localize([{
+      await Ajax().Runtimes.notebooks(namespace, runtimeName).localize([{
         sourceUri: `${cloudStorageDirectory}/${notebookName}`,
         localDestinationPath: mode === 'edit' ? `${localBaseDirectory}/${notebookName}` : `${localSafeModeBaseDirectory}/${notebookName}`
       }])
@@ -474,7 +474,7 @@ const WelderDisabledNotebookEditorFrame = ({ mode, notebookName, workspace: { wo
       })
       chooseMode(undefined)
     } else {
-      await Ajax(signal).Clusters.notebooks(namespace, runtimeName).oldLocalize({
+      await Ajax(signal).Runtimes.notebooks(namespace, runtimeName).oldLocalize({
         [`~/${name}/${notebookName}`]: `gs://${bucketName}/notebooks/${notebookName}`
       })
       setLocalized(true)


### PR DESCRIPTION
This is a subset of the cluster -> runtime rename.