### PR TITLE
work around stale PD data after an update [SATURN-1853]

### DIFF
--- a/src/components/ClusterManager.js
+++ b/src/components/ClusterManager.js
@@ -226,7 +226,7 @@ export default class ClusterManager extends PureComponent {
   }
 
   render() {
-    const { namespace, name, clusters, canCompute, persistentDisks, apps, refreshApps, workspace } = this.props
+    const { namespace, name, clusters, refreshClusters, canCompute, persistentDisks, apps, refreshApps, workspace } = this.props
     const { busy, createModalDrawerOpen, errorModalOpen, galaxyDrawerOpen } = this.state
     if (!clusters || !apps) {
       return null
@@ -359,10 +359,13 @@ export default class ClusterManager extends PureComponent {
           clusters,
           persistentDisks,
           onDismiss: () => this.setState({ createModalDrawerOpen: false }),
-          onSuccess: promise => {
+          onSuccess: _.flow(
+            withErrorReporting('Error loading cloud environment'),
+            Utils.withBusyState(v => this.setState({ busy: v }))
+          )(async () => {
             this.setState({ createModalDrawerOpen: false })
-            this.executeAndRefresh(promise)
-          }
+            await refreshClusters(true)
+          })
         }),
         h(NewAppModal, {
           workspace,

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -159,7 +159,7 @@ const useCloudEnvironmentPolling = namespace => {
     clearTimeout(timeout.current)
     timeout.current = setTimeout(refreshClustersSilently, ms)
   }
-  const load = async () => {
+  const load = async maybeStale => {
     try {
       const [newDisks, newClusters, galaxyDisks] = await Promise.all([
         Ajax(signal).Disks.list({ googleProject: namespace, creator: getUser().email }),
@@ -171,7 +171,7 @@ const useCloudEnvironmentPolling = namespace => {
       setPersistentDisks(_.remove(disk => _.includes(disk.name, galaxyDiskNames), newDisks))
 
       const cluster = currentCluster(newClusters)
-      reschedule(_.includes(collapsedClusterStatus(cluster), ['Creating', 'Starting', 'Stopping', 'Updating', 'LeoReconfiguring']) ? 10000 : 120000)
+      reschedule(maybeStale || _.includes(collapsedClusterStatus(cluster), ['Creating', 'Starting', 'Stopping', 'Updating', 'LeoReconfiguring']) ? 10000 : 120000)
     } catch (error) {
       reschedule(30000)
       throw error

--- a/src/pages/workspaces/workspace/applications/AppLauncher.js
+++ b/src/pages/workspaces/workspace/applications/AppLauncher.js
@@ -81,10 +81,9 @@ const AppLauncher = _.flow(
           onSuccess: _.flow(
             withErrorReporting('Error creating cluster'),
             Utils.withBusyState(setBusy)
-          )(async promise => {
+          )(async () => {
             setShowCreate(false)
-            await promise
-            await refreshClusters()
+            await refreshClusters(true)
           })
         }),
         busy && spinnerOverlay

--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -70,12 +70,12 @@ const NotebookLauncher = _.flow(
           chooseMode(undefined)
           setCreateOpen(false)
         },
-        onSuccess: withErrorReporting('Error creating cluster', async promise => {
+        onSuccess: _.flow(
+          withErrorReporting('Error creating cluster'),
+          Utils.withBusyState(setBusy)
+        )(async () => {
           setCreateOpen(false)
-          setBusy(true)
-          await promise
-          await refreshClusters()
-          setBusy(false)
+          await refreshClusters(true)
         })
       }),
       busy && spinnerOverlay


### PR DESCRIPTION
This attempts to address the issue of runtime/disk status not being reflected immediately after an update. In cases where the status change may be delayed, we schedule a fast refresh for one polling cycle, in the hopes of picking up the new status.

Note that by itself, this won't solve the case of quickly re-opening the modal and pressing Create within 10 seconds after an update. If we want to address that, we'll need to go further, and add some additional state that disables the button during that time.