### PR TITLE
Add galaxy version

### DIFF
--- a/src/components/NewAppModal.js
+++ b/src/components/NewAppModal.js
@@ -132,7 +132,7 @@ export const NewAppModal = _.flow(
           div({ style: styles.headerText }, ['Environment Settings']),
           ul({ style: { paddingLeft: '1rem', lineHeight: 1.5 } }, [
             li({ style: { marginTop: '1rem' } }, [
-              'Galaxy version xxx'
+              'Galaxy version 20.09.3'
             ]),
             li({ style: { marginTop: '1rem' } }, [
               'Cloud Compute size of ', span({ style: { fontWeight: 600 } },


### PR DESCRIPTION
Tiny piece of info that was missing from galaxy config drawer. 

Not currently passed in the API response. The galaxy image version is specified in the helm chart, and the helm chart version is specified in Leo config. So going to hardcode this in the UI for now and if it changes or starts to be an issue like that will update accordingly.



