### PR TITLE
Isolate parallel integration tests [QA-1272]

### DIFF
--- a/integration-tests/jest-puppeteer.config.js
+++ b/integration-tests/jest-puppeteer.config.js
@@ -12,6 +12,7 @@ const printWarning = message => {
 }
 
 module.exports = {
+  browserContext: 'incognito',
   launch: {
     devtools: process.env.DEVTOOLS === 'true',
     headless: process.env.HEADLESS !== 'false',

--- a/integration-tests/tests/run-notebook.js
+++ b/integration-tests/tests/run-notebook.js
@@ -43,10 +43,6 @@ const testRunNotebookFn = _.flow(
   await findElement(page, clickable({ textContains: 'Creating' }))
   await findElement(page, clickable({ textContains: 'Running' }), { timeout: 10 * 60 * 1000 })
 
-  await page.evaluate(async () => {
-    await window.Ajax().Runtimes.setCookie() // make sure the right access cookie is set
-  })
-
   const frame = await findIframe(page)
   await fillIn(frame, '//textarea', 'print(123456789099876543210990+9876543219)')
   await click(frame, clickable({ text: 'Run' }))


### PR DESCRIPTION
Incognito window per integration test.
Revert run-notebook test change from yesterday since it's no longer needed.
