### PR TITLE
AS-522: disable spellcheck for input and output fields in workflow configs [risk: no]

### DIFF
--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -156,6 +156,9 @@ const WorkflowIOTable = ({ which, inputsOutputs: data, config, errors, onChange,
               !readOnly ? h(DelayedAutocompleteTextArea, {
                 autosize: true,
                 'aria-label': name,
+                // without quoting both the key and value for spellcheck, it won't make it to the browser
+                // eslint-disable-next-line quote-props
+                'spellcheck': 'false',
                 placeholder: optional ? 'Optional' : 'Required',
                 value,
                 style: isFile ? { paddingRight: '2rem' } : undefined,

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -156,7 +156,7 @@ const WorkflowIOTable = ({ which, inputsOutputs: data, config, errors, onChange,
               !readOnly ? h(DelayedAutocompleteTextArea, {
                 autosize: true,
                 'aria-label': name,
-                spellcheck: 'false',
+                spellCheck: false,
                 placeholder: optional ? 'Optional' : 'Required',
                 value,
                 style: isFile ? { paddingRight: '2rem' } : undefined,

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -156,9 +156,7 @@ const WorkflowIOTable = ({ which, inputsOutputs: data, config, errors, onChange,
               !readOnly ? h(DelayedAutocompleteTextArea, {
                 autosize: true,
                 'aria-label': name,
-                // without quoting both the key and value for spellcheck, it won't make it to the browser
-                // eslint-disable-next-line quote-props
-                'spellcheck': 'false',
+                spellcheck: 'false',
                 placeholder: optional ? 'Optional' : 'Required',
                 value,
                 style: isFile ? { paddingRight: '2rem' } : undefined,


### PR DESCRIPTION
This disables spellcheck in the input/output textareas when configuring a workflow.

When spellcheck is enabled, it gives disconcerting warnings to end users if your input/output is namespaced:
![image (2)](https://user-images.githubusercontent.com/6041577/96901637-81620500-1461-11eb-8217-cd18fec41529.png)

Tested by running locally, plus inspecting via dev tools.