### PR TITLE
wait for definitive auth status before sending events [BW-409]

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -2,7 +2,7 @@ import _ from 'lodash/fp'
 import * as qs from 'qs'
 import { h } from 'react-hyperscript-helpers'
 import { version } from 'src/data/machines'
-import { getUser } from 'src/libs/auth'
+import { ensureAuthSettled, getUser } from 'src/libs/auth'
 import { getConfig } from 'src/libs/config'
 import { withErrorIgnoring } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
@@ -1216,7 +1216,8 @@ const Duos = signal => ({
 })
 
 const Metrics = signal => ({
-  captureEvent: withErrorIgnoring((event, details = {}) => {
+  captureEvent: withErrorIgnoring(async (event, details = {}) => {
+    await ensureAuthSettled()
     const body = {
       event,
       properties: {

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -51,6 +51,23 @@ export const ensureBillingScope = async () => {
   }
 }
 
+export const ensureAuthSettled = () => {
+  const authSettled = ({ isSignedIn, registrationStatus }) => {
+    return isSignedIn !== undefined && (!isSignedIn || registrationStatus !== undefined)
+  }
+  if (authSettled(authStore.get())) {
+    return
+  }
+  return new Promise(resolve => {
+    const subscription = authStore.subscribe(state => {
+      if (authSettled(state)) {
+        resolve()
+        subscription.unsubscribe()
+      }
+    })
+  })
+}
+
 export const getUser = () => {
   return authStore.get().user
 }


### PR DESCRIPTION
This is a precursor to capturing and linking anonymous metrics events. It defers event logging until the auth status has 'settled', e.g. we know the whether the user is signed in and registered. We're not currently sending any events that would be affected by this, so there's no immediate effect, but once we open up the logic around page view events, this will ensure that the initial page view event gets correctly attributed if the user is already logged in.