### PR TITLE
[IA-2282] make galaxy apps per workspace per project

### DIFF
--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -186,7 +186,7 @@ const useCloudEnvironmentPolling = namespace => {
   return { runtimes, refreshRuntimes, persistentDisks }
 }
 
-const useAppPolling = namespace => {
+const useAppPolling = (namespace, name) => {
   const signal = Utils.useCancellation()
   const timeout = useRef()
   const [apps, setApps] = useState()
@@ -196,7 +196,7 @@ const useAppPolling = namespace => {
   }
   const loadApps = async () => {
     try {
-      const newApps = await Ajax(signal).Apps.list(namespace, { creator: getUser().email })
+      const newApps = await Ajax(signal).Apps.list(namespace, { creator: getUser().email, saturnWorkspaceName: name })
       setApps(newApps)
       const app = currentApp(newApps)
       reschedule((app && _.includes(app.status, ['PROVISIONING', 'PREDELETING'])) ? 10000 : 120000)
@@ -224,7 +224,7 @@ export const wrapWorkspace = ({ breadcrumbs, activeTab, title, topBarContent, sh
     const cachedWorkspace = Utils.useStore(workspaceStore)
     const [loadingWorkspace, setLoadingWorkspace] = useState(false)
     const { runtimes, refreshRuntimes, persistentDisks } = useCloudEnvironmentPolling(namespace)
-    const { apps, refreshApps } = useAppPolling(namespace)
+    const { apps, refreshApps } = useAppPolling(namespace, name)
     const workspace = cachedWorkspace && _.isEqual({ namespace, name }, _.pick(['namespace', 'name'], cachedWorkspace.workspace)) ?
       cachedWorkspace :
       undefined


### PR DESCRIPTION
This PR makes it so that galaxy apps are per user per workspace per project, as opposed to per user per project. 

I tested this by modifying `Notebooks.js` line 355 such that the galaxy app button always shows up. I then created an app in two different workspaces and observed that the UI treated them as two separate apps (separate status transitions, deleting one doesn't delete the other, etc). 

Had to do some heavy lifting for this. 