### PR TITLE
[AS-527] add baseline form to data explorer

### DIFF
--- a/src/components/PrivateDataExplorer.js
+++ b/src/components/PrivateDataExplorer.js
@@ -103,10 +103,10 @@ export default _.flow(
           p([
             `Thank you for your interest in the Baseline Health Study data. Baseline data is currently only being shared with our partner organizations at Duke and Stanford.
             If you are a researcher at one of our partner organizations, please reach out to your institutional contacts for information on how to obtain access.
-            If you are a researcher at our partner site and do not have an institutional contact, please complete the Terra Study Data Request form.`]),
-          p([`In the future, Baseline is planning to make this data available to qualified researchers outside of our partners. 
-            If you're interested in finding out when the data will be available to researchers outside of our partners, please complete the Terra Study Data Request form.`
+            If you are a researcher at our partner site and do not have an institutional contact, please complete the Terra Study Data Request form.`
           ]),
+          p([`In the future, Baseline is planning to make this data available to qualified researchers outside of our partners. 
+            If you're interested in finding out when the data will be available to researchers outside of our partners, please complete the Terra Study Data Request form.`]),
           p([
             'Please fill out the ',
             h(Link, {

--- a/src/components/PrivateDataExplorer.js
+++ b/src/components/PrivateDataExplorer.js
@@ -101,12 +101,22 @@ export default _.flow(
       ], [
         'baseline', () => h(Fragment, [
           p([
-            `Thank you for your interest in the Baseline Health Study data. Baseline data is currently only being shared
-             with Baseline Health Study partner sites, Duke and Stanford. If you are a current researcher at one of those sites,
-             please reach out to your institutional contacts for information on how to obtain access. In the future, Baseline
-             is planning to make this data available to qualified researchers, outside of these partner sites.`
+            `Thank you for your interest in the Baseline Health Study data. Baseline data is currently only being shared with our partner organizations at Duke and Stanford.
+            If you are a researcher at one of our partner organizations, please reach out to your institutional contacts for information on how to obtain access.
+            If you are a researcher at our partner site and do not have an institutional contact, please complete the Terra Study Data Request Form. `]),
+          p([`In the future, Baseline is planning to make this data available to qualified researchers outside of our partners. 
+            If you're interested in finding out when the data will be available to researchers outside of our partners, please complete the Terra Study Data Request Form.`
           ]),
-          p(['Please reach out to ', h(Link, { href: 'mailto:support@terra.bio' }, ['support@terra.bio']), ' if you have any additional questions.'])
+          p([
+            'Please fill out the ',
+            h(Link, {
+              href: 'https://forms.gle/d4vnyNvpagptcasf9',
+              ...Utils.newTabLinkProps
+            }, [
+              'Baseline Health Study Data Attestation form'
+            ]),
+            ' to be granted access.'
+          ])
         ])
       ], [
         'NHS', () => h(Fragment, [

--- a/src/components/PrivateDataExplorer.js
+++ b/src/components/PrivateDataExplorer.js
@@ -103,7 +103,7 @@ export default _.flow(
           p([
             `Thank you for your interest in the Baseline Health Study data. Baseline data is currently only being shared with our partner organizations at Duke and Stanford.
             If you are a researcher at one of our partner organizations, please reach out to your institutional contacts for information on how to obtain access.
-            If you are a researcher at our partner site and do not have an institutional contact, please complete the Terra Study Data Request Form. `]),
+            If you are a researcher at our partner site and do not have an institutional contact, please complete the Terra Study Data Request Form.`]),
           p([`In the future, Baseline is planning to make this data available to qualified researchers outside of our partners. 
             If you're interested in finding out when the data will be available to researchers outside of our partners, please complete the Terra Study Data Request Form.`
           ]),

--- a/src/components/PrivateDataExplorer.js
+++ b/src/components/PrivateDataExplorer.js
@@ -103,9 +103,9 @@ export default _.flow(
           p([
             `Thank you for your interest in the Baseline Health Study data. Baseline data is currently only being shared with our partner organizations at Duke and Stanford.
             If you are a researcher at one of our partner organizations, please reach out to your institutional contacts for information on how to obtain access.
-            If you are a researcher at our partner site and do not have an institutional contact, please complete the Terra Study Data Request Form.`]),
+            If you are a researcher at our partner site and do not have an institutional contact, please complete the Terra Study Data Request form.`]),
           p([`In the future, Baseline is planning to make this data available to qualified researchers outside of our partners. 
-            If you're interested in finding out when the data will be available to researchers outside of our partners, please complete the Terra Study Data Request Form.`
+            If you're interested in finding out when the data will be available to researchers outside of our partners, please complete the Terra Study Data Request form.`
           ]),
           p([
             'Please fill out the ',
@@ -113,7 +113,7 @@ export default _.flow(
               href: 'https://forms.gle/d4vnyNvpagptcasf9',
               ...Utils.newTabLinkProps
             }, [
-              'Baseline Health Study Data Attestation form'
+              'Terra Study Data Request Form'
             ]),
             ' to be granted access.'
           ])


### PR DESCRIPTION
Adds link to baseline google form to request access to their data instead of a link to terra support, and changes the associated description text. 
