### PR TITLE
[CA-964] Update billing validation to include uppercase letters and underscores

### DIFF
--- a/src/pages/billing/List.js
+++ b/src/pages/billing/List.js
@@ -44,8 +44,8 @@ const billingProjectNameValidator = existing => ({
   presence: { allowEmpty: false },
   length: { minimum: 6, maximum: 30 },
   format: {
-    pattern: /^[a-z]([a-z0-9-])*$/,
-    message: 'must start with a letter and can only contain lowercase letters, numbers, and hyphens.'
+    pattern: /^[A-z0-9-_]*$/,
+    message: 'can only contain letters, numbers, underscores and hyphens.'
   },
   exclusion: {
     within: existing,

--- a/src/pages/billing/List.js
+++ b/src/pages/billing/List.js
@@ -44,7 +44,7 @@ const billingProjectNameValidator = existing => ({
   presence: { allowEmpty: false },
   length: { minimum: 6, maximum: 30 },
   format: {
-    pattern: /^[A-z0-9-_]*$/,
+    pattern: /(\w|-)+/,
     message: 'can only contain letters, numbers, underscores and hyphens.'
   },
   exclusion: {


### PR DESCRIPTION
Tested by submitting the string `dm-AbcD4_-` which passes our validation and is URL safe, but does not pass googles. This should be considered part of our feature branch for the work to separate out google-project from billing-project and not merge until that code goes to production