### PR TITLE
display dockstore WDLs directly from github [BW-421]

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1182,7 +1182,7 @@ const Dockstore = signal => ({
   getWdl: async (path, version) => {
     const res = await fetchDockstore(`${dockstoreMethodPath(path)}/${encodeURIComponent(version)}/WDL/descriptor`, { signal })
     const { url } = await res.json()
-    return fetchOk(url).then(res => res.text())
+    return fetchOk(url, { signal }).then(res => res.text())
   },
 
   getVersions: async path => {

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1182,7 +1182,8 @@ const Disks = signal => ({
 const Dockstore = signal => ({
   getWdl: async (path, version) => {
     const res = await fetchDockstore(`${dockstoreMethodPath(path)}/${encodeURIComponent(version)}/WDL/descriptor`, { signal })
-    return res.json()
+    const { url } = await res.json()
+    return fetchOk(url).then(res => res.text())
   },
 
   getVersions: async path => {

--- a/src/pages/ImportWorkflow.js
+++ b/src/pages/ImportWorkflow.js
@@ -49,8 +49,8 @@ const DockstoreImporter = ajaxCaller(class DockstoreImporter extends Component {
   async loadWdl() {
     try {
       const { path, version, ajax: { Dockstore } } = this.props
-      const { descriptor } = await Dockstore.getWdl(path, version)
-      this.setState({ wdl: descriptor, workflowName: _.last(path.split('/')) })
+      const wdl = await Dockstore.getWdl(path, version)
+      this.setState({ wdl, workflowName: _.last(path.split('/')) })
     } catch (error) {
       reportError('Error loading WDL', error)
     }

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -542,7 +542,7 @@ const WorkflowView = _.flow(
           this.setState({ synopsis, documentation, wdl: payload })
         }
       } else if (sourceRepo === 'dockstore') {
-        const wdl = await Dockstore.getWdl(methodPath, methodVersion).then(({ descriptor }) => descriptor)
+        const wdl = await Dockstore.getWdl(methodPath, methodVersion)
         this.setState({ wdl })
       } else {
         throw new Error('unknown sourceRepo')


### PR DESCRIPTION
For dockstore methods, the submission behavior was changed at some point to read the WDL code directly from github instead of using dockstore's duplicate copy. This can result in a mismatch in the UI if the dockstore copy is out of sync with the github reference.

This changes the UI to always load directly from github, to mirror what the backend does.