### PR TITLE
make profile pic infobox not super tiny

### DIFF
--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -260,7 +260,7 @@ const Profile = _.flow(
           div({ style: styles.header.line }, [
             div({ style: { position: 'relative' } }, [
               profilePic({ size: 48 }),
-              h(InfoBox, { style: { alignSelf: 'flex-end', padding: '0.25rem' } }, [
+              h(InfoBox, { style: { alignSelf: 'flex-end' } }, [
                 'To change your profile image, visit your ',
                 h(Link, {
                   href: `https://myaccount.google.com?authuser=${getUser().email}`,


### PR DESCRIPTION
I noticed the infobox icon for changing your profile pic was eensy-weensy so I fixed it. 

Tested locally. Right now on local my profile pic itself is broken but I'm fairly sure that's unrelated. 
