### PR TITLE
Distinguish aborted vs failed workflows [BW-448]

### DIFF
--- a/src/components/job-common.js
+++ b/src/components/job-common.js
@@ -24,7 +24,7 @@ export const successIcon = style => icon('check', { size, style: { color: colors
 export const failedIcon = style => icon('warning-standard', { size, style: { color: colors.danger(), ...style } })
 export const runningIcon = style => icon('sync', { size, style: { color: colors.dark(), ...style } })
 export const submittedIcon = style => icon('clock', { size, style: { color: colors.dark(), ...style } })
-export const abortIcon = style => icon('aborting-aborted', { size, style: { color: colors.danger(), ...style } })
+export const abortIcon = style => icon('abort', { size, style: { color: colors.danger(), ...style } })
 
 export const statusIcon = (status, style) => {
   switch (collapseStatus(status)) {

--- a/src/components/job-common.js
+++ b/src/components/job-common.js
@@ -8,6 +8,7 @@ export const collapseStatus = status => {
       return 'succeeded'
     case 'Aborting': // only on submissions not workflows
     case 'Aborted':
+      return 'abort'
     case 'Failed':
       return 'failed'
     case 'Running':
@@ -23,6 +24,7 @@ export const successIcon = style => icon('check', { size, style: { color: colors
 export const failedIcon = style => icon('warning-standard', { size, style: { color: colors.danger(), ...style } })
 export const runningIcon = style => icon('sync', { size, style: { color: colors.dark(), ...style } })
 export const submittedIcon = style => icon('clock', { size, style: { color: colors.dark(), ...style } })
+export const abortIcon = style => icon('aborting-aborted', { size, style: { color: colors.danger(), ...style } })
 
 export const statusIcon = (status, style) => {
   switch (collapseStatus(status)) {
@@ -32,6 +34,8 @@ export const statusIcon = (status, style) => {
       return failedIcon(style)
     case 'running':
       return runningIcon(style)
+    case 'abort':
+      return abortIcon(style)
     default:
       return submittedIcon(style)
   }

--- a/src/libs/icon-dict.js
+++ b/src/libs/icon-dict.js
@@ -36,6 +36,7 @@ const custom = _.curry((shape, { size, ...props }) => h(shape,
 const rotate = _.curry((rotation, shape, props) => shape(_.merge({ style: { transform: `rotate(${rotation}deg)` } }, props)))
 
 const iconDict = {
+  abort: fa(faBan),
   'angle-down': rotate(180, custom(angleUp)),
   'angle-left': rotate(-90, custom(angleUp)),
   'angle-right': rotate(90, custom(angleUp)),
@@ -101,8 +102,7 @@ const iconDict = {
   'view-cards': fa(faGripHorizontal),
   'view-list': custom(list),
   virus: fa(faVirus),
-  'warning-standard': fa(faExclamationTriangle),
-  'aborting-aborted': fa(faBan)
+  'warning-standard': fa(faExclamationTriangle)
 }
 
 export default iconDict

--- a/src/libs/icon-dict.js
+++ b/src/libs/icon-dict.js
@@ -101,7 +101,8 @@ const iconDict = {
   'view-cards': fa(faGripHorizontal),
   'view-list': custom(list),
   virus: fa(faVirus),
-  'warning-standard': fa(faExclamationTriangle)
+  'warning-standard': fa(faExclamationTriangle),
+  'aborting-aborted': fa(faBan)
 }
 
 export default iconDict

--- a/src/pages/workspaces/workspace/JobHistory.js
+++ b/src/pages/workspaces/workspace/JobHistory.js
@@ -76,7 +76,7 @@ const statusCell = workflowStatuses => {
           td(['Aborted']),
           td(styles.statusDetailCell, [abort || 0])
         ]): undefined
-      ].filter( element => element !== undefined ))
+      ].filter(element => element !== undefined))
     ])
   }, [
     div([

--- a/src/pages/workspaces/workspace/JobHistory.js
+++ b/src/pages/workspaces/workspace/JobHistory.js
@@ -51,32 +51,32 @@ const statusCell = workflowStatuses => {
     type: 'light',
     content: table({ style: { margin: '0.5rem' } }, [
       tbody({}, [
-        submitted ? tr({}, [
+        submitted && tr({}, [
           td(styles.statusDetailCell, [submittedIcon()]),
           td(['Submitted']),
           td(styles.statusDetailCell, [submitted])
-        ]) : undefined,
-        running ? tr({}, [
+        ]),
+        running && tr({}, [
           td(styles.statusDetailCell, [runningIcon()]),
           td(['Running']),
           td(styles.statusDetailCell, [running])
-        ]): undefined,
-        succeeded ? tr({}, [
+        ]),
+        succeeded && tr({}, [
           td(styles.statusDetailCell, [successIcon()]),
           td(['Succeeded']),
           td(styles.statusDetailCell, [succeeded])
-        ]): undefined,
-        failed ? tr({}, [
+        ]),
+        failed && tr({}, [
           td(styles.statusDetailCell, [failedIcon()]),
           td(['Failed']),
           td(styles.statusDetailCell, [failed])
-        ]): undefined,
-        abort ? tr({}, [
+        ]),
+        abort && tr({}, [
           td(styles.statusDetailCell, [abortIcon()]),
           td(['Aborted']),
           td(styles.statusDetailCell, [abort])
-        ]): undefined
-      ].filter(element => element !== undefined))
+        ])
+      ])
     ])
   }, [
     div([
@@ -235,7 +235,7 @@ const JobHistory = _.flow(
                 headerRenderer: () => h(HeaderCell, ['Status']),
                 cellRenderer: ({ rowIndex }) => {
                   const { workflowStatuses, status } = filteredSubmissions[rowIndex]
-                  const collapsedStatusList= collapsedStatuses(workflowStatuses)
+                  const collapsedStatusList = collapsedStatuses(workflowStatuses)
                   const statusString =
                         'failed' in collapsedStatusList ? `Failed` :
                           'abort' in collapsedStatusList ? 'Aborted' :

--- a/src/pages/workspaces/workspace/JobHistory.js
+++ b/src/pages/workspaces/workspace/JobHistory.js
@@ -54,27 +54,27 @@ const statusCell = workflowStatuses => {
         submitted ? tr({}, [
           td(styles.statusDetailCell, [submittedIcon()]),
           td(['Submitted']),
-          td(styles.statusDetailCell, [submitted || 0])
+          td(styles.statusDetailCell, [submitted])
         ]) : undefined,
         running ? tr({}, [
           td(styles.statusDetailCell, [runningIcon()]),
           td(['Running']),
-          td(styles.statusDetailCell, [running || 0])
+          td(styles.statusDetailCell, [running])
         ]): undefined,
         succeeded ? tr({}, [
           td(styles.statusDetailCell, [successIcon()]),
           td(['Succeeded']),
-          td(styles.statusDetailCell, [succeeded || 0])
+          td(styles.statusDetailCell, [succeeded])
         ]): undefined,
         failed ? tr({}, [
           td(styles.statusDetailCell, [failedIcon()]),
           td(['Failed']),
-          td(styles.statusDetailCell, [failed || 0])
+          td(styles.statusDetailCell, [failed])
         ]): undefined,
         abort ? tr({}, [
           td(styles.statusDetailCell, [abortIcon()]),
           td(['Aborted']),
-          td(styles.statusDetailCell, [abort || 0])
+          td(styles.statusDetailCell, [abort])
         ]): undefined
       ].filter(element => element !== undefined))
     ])


### PR DESCRIPTION
- Separates the `Aborted` from the general `Failed` status because these are significantly different outcomes. While I was there / additionally:

#### Job Status Page

- Updates the Status page to consider `Aborted` statuses.
- Updates the Status tooltip to _name_ the status icons (since Aborted/Failed and Queued/Submitted were otherwise confusingly similar icons)
- Updates the Status tooltip to only list actual statuses in that submission
- Updates the Status name to name Failure and Aborted statuses rather than just calling everything "Done"
- Updates the Status icon to highlight the most important status (eg a mix of Succeeded and Failed workflows implies a Failed submission)

#### Before:

![image](https://user-images.githubusercontent.com/13006282/100112512-4fb3d380-2e3d-11eb-9644-d7c407fa95d1.png)

#### After:

![image](https://user-images.githubusercontent.com/13006282/100029167-9f06ef00-2dbe-11eb-88f2-ae97500ed5d5.png)

