### PR TITLE
Show workspace bucket's region on the workspace dashboard [BW-444]

### DIFF
--- a/src/components/region-common.js
+++ b/src/components/region-common.js
@@ -1,6 +1,7 @@
 // Get a { flag: ..., countryName: ... } object representing a google locationType/location input.
 // 'flag' will always be defined (even if it's a question mark.
 // 'regionDescription' is the same as location when locationType is 'multi-region', or a country name when locationType is 'region'.
+export const unknownRegionFlag = '❓'
 export const regionInfo = (location, locationType) => {
   switch (locationType) {
     case 'multi-region':
@@ -12,16 +13,16 @@ export const regionInfo = (location, locationType) => {
         case 'ASIA':
           return { flag: '🌏', regionDescription: `${locationType}: ${location}` }
         default:
-          return { flag: '❓', regionDescription: `${locationType}: ${location}` }
+          return { flag: unknownRegionFlag, regionDescription: `${locationType}: ${location}` }
       }
     case 'region':
       switch (location) {
         case 'EUROPE-NORTH1':
           return { flag: '🇫🇮', regionDescription: `${locationType}: ${location} (Finland)` }
         default:
-          return { flag: '❓', regionDescription: `${locationType}: ${location}` }
+          return { flag: unknownRegionFlag, regionDescription: `${locationType}: ${location}` }
       }
     default:
-      return { flag: '❓', regionDescription: `${locationType}: ${location}` }
+      return { flag: unknownRegionFlag, regionDescription: `${locationType}: ${location}` }
   }
 }

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -1,13 +1,13 @@
 import _ from 'lodash/fp'
 import { Component, Fragment } from 'react'
-import { div, h, i, span } from 'react-hyperscript-helpers'
+import { div, h, i, p, span } from 'react-hyperscript-helpers'
 import * as breadcrumbs from 'src/components/breadcrumbs'
-import { ButtonPrimary, ButtonSecondary, Link, spinnerOverlay } from 'src/components/common'
+import { ButtonPrimary, ButtonSecondary, ClipboardButton, Link, spinnerOverlay } from 'src/components/common'
 import { icon, spinner } from 'src/components/icons'
 import { MarkdownEditor, MarkdownViewer } from 'src/components/markdown'
 import { InfoBox } from 'src/components/PopupTrigger'
-import RegionFlaggedContent from 'src/components/RegionFlaggedContent'
-import { SimpleTable } from 'src/components/table'
+import { regionInfo, unknownRegionFlag } from 'src/components/region-common'
+import { SimpleTable, TooltipCell } from 'src/components/table'
 import TooltipTrigger from 'src/components/TooltipTrigger'
 import { WorkspaceTagSelect } from 'src/components/workspace-utils'
 import { displayConsentCodes, displayLibraryAttributes } from 'src/data/workspace-attributes'
@@ -190,6 +190,7 @@ export const WorkspaceDashboard = _.flow(
       consentStatus, tagsList, busy, bucketLocation, bucketLocationType
     } = this.state
     const isEditing = _.isString(editDescription)
+    const { flag, regionDescription } = regionInfo(bucketLocation, bucketLocationType)
 
     return div({ style: { flex: 1, display: 'flex' } }, [
       div({ style: Style.dashboard.leftBox }, [
@@ -311,13 +312,18 @@ export const WorkspaceDashboard = _.flow(
         div({ style: { fontSize: '1rem', fontWeight: 500, marginBottom: '0.5rem' } }, [
           'Google Bucket'
         ]),
-        div({ style: { display: 'flex', alignItems: 'center' } }, [
-          h(RegionFlaggedContent, { location: bucketLocation, locationType: bucketLocationType, content: bucketName, clipboardText: bucketName }, [])
-        ]),
-        h(Link, {
-          ...Utils.newTabLinkProps,
-          href: bucketBrowserUrl(bucketName)
-        }, ['Open in browser', icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })])
+        div( { style: { display: 'flex' } }, [
+          (bucketLocation ?
+            h(TooltipCell, { style: { marginRight: '0.5rem' }, tooltip: `Bucket region: ${regionDescription}` }, [flag]) :
+            h(TooltipCell, { style: { marginRight: '0.5rem' }, tooltip: 'Bucket region loading...' }, [unknownRegionFlag])),
+          span({ style: { marginRight: '0.5rem', ...Style.noWrapEllipsis } }, [bucketName]),
+          h(ClipboardButton, { text: bucketName, style: { marginLeft: '0.25rem' } }),
+          h(Link, {
+            ...Utils.newTabLinkProps,
+            href: bucketBrowserUrl(bucketName),
+            tooltip: 'Open in browser'
+          }, [icon('pop-out', { style: { marginLeft: '0.25rem' } })])
+        ])
       ])
     ])
   }

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -113,7 +113,7 @@ export const WorkspaceDashboard = _.flow(
 
   loadBucketLocation = withErrorReporting('Error loading bucket location data', async () => {
     const { signal, namespace, workspaceName, workspace: { workspace: { bucketName } } } = this.props
-    const { location, locationType } = !_.isEmpty(bucketName) ? await Ajax(signal).Workspaces.workspace(namespace, workspaceName).checkBucketLocation(bucketName) : {}
+    const { location, locationType } = await Ajax(signal).Workspaces.workspace(namespace, workspaceName).checkBucketLocation(bucketName)
     this.setState({ bucketLocation: location, bucketLocationType: locationType })
   })
 
@@ -314,13 +314,15 @@ export const WorkspaceDashboard = _.flow(
         ]),
         div({ style: { marginBottom: '0.5rem', display: 'flex' } }, [
           div({ style: { marginRight: '0.5rem', fontWeight: 500 } }, ['Name:']),
-          h(TooltipCell, { tooltip: bucketName, style: { marginRight: '0.5rem', ...Style.noWrapEllipsis } }, [bucketName]),
+          h(TooltipCell, { style: { marginRight: '0.5rem' } }, [bucketName]),
           h(ClipboardButton, { text: bucketName, style: { marginLeft: '0.25rem' } })
         ]),
         div({ style: { marginBottom: '0.5rem', display: 'flex' } }, [
           div({ style: { marginRight: '0.5rem', fontWeight: 500 } }, ['Location:']),
-          div({ style: { marginRight: '0.5rem' } }, [flag || unknownRegionFlag]),
-          regionDescription || 'loading...'
+          bucketLocation ? h(Fragment, [
+            div({ style: { marginRight: '0.5rem' } }, [flag]),
+            regionDescription
+          ]) : 'Loading...'
         ]),
         h(Link, {
           ...Utils.newTabLinkProps,

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp'
 import { Component, Fragment } from 'react'
-import { div, h, i, p, span } from 'react-hyperscript-helpers'
+import { div, h, i, span } from 'react-hyperscript-helpers'
 import * as breadcrumbs from 'src/components/breadcrumbs'
 import { ButtonPrimary, ButtonSecondary, ClipboardButton, Link, spinnerOverlay } from 'src/components/common'
 import { icon, spinner } from 'src/components/icons'
@@ -312,7 +312,7 @@ export const WorkspaceDashboard = _.flow(
         div({ style: { fontSize: '1rem', fontWeight: 500, marginBottom: '0.5rem' } }, [
           'Google Bucket'
         ]),
-        div( { style: { display: 'flex' } }, [
+        div({ style: { display: 'flex' } }, [
           (bucketLocation ?
             h(TooltipCell, { style: { marginRight: '0.5rem' }, tooltip: `Bucket region: ${regionDescription}` }, [flag]) :
             h(TooltipCell, { style: { marginRight: '0.5rem' }, tooltip: 'Bucket region loading...' }, [unknownRegionFlag])),

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -6,7 +6,7 @@ import { ButtonPrimary, ButtonSecondary, ClipboardButton, Link, spinnerOverlay }
 import { icon, spinner } from 'src/components/icons'
 import { MarkdownEditor, MarkdownViewer } from 'src/components/markdown'
 import { InfoBox } from 'src/components/PopupTrigger'
-import { regionInfo, unknownRegionFlag } from 'src/components/region-common'
+import { regionInfo } from 'src/components/region-common'
 import { SimpleTable, TooltipCell } from 'src/components/table'
 import TooltipTrigger from 'src/components/TooltipTrigger'
 import { WorkspaceTagSelect } from 'src/components/workspace-utils'

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -312,18 +312,20 @@ export const WorkspaceDashboard = _.flow(
         div({ style: { fontSize: '1rem', fontWeight: 500, marginBottom: '0.5rem' } }, [
           'Google Bucket'
         ]),
-        div({ style: { display: 'flex' } }, [
-          (bucketLocation ?
-            h(TooltipCell, { style: { marginRight: '0.5rem' }, tooltip: `Bucket region: ${regionDescription}` }, [flag]) :
-            h(TooltipCell, { style: { marginRight: '0.5rem' }, tooltip: 'Bucket region loading...' }, [unknownRegionFlag])),
+        div({ style: { marginBottom: '0.5rem', display: 'flex' } }, [
+          div({ style: { marginRight: '0.5rem', fontWeight: 500 } }, ['Name:']),
           h(TooltipCell, { tooltip: bucketName, style: { marginRight: '0.5rem', ...Style.noWrapEllipsis } }, [bucketName]),
-          h(ClipboardButton, { text: bucketName, style: { marginLeft: '0.25rem' } }),
-          h(Link, {
-            ...Utils.newTabLinkProps,
-            href: bucketBrowserUrl(bucketName),
-            tooltip: 'Open in browser'
-          }, [icon('pop-out', { style: { marginLeft: '0.25rem' } })])
-        ])
+          h(ClipboardButton, { text: bucketName, style: { marginLeft: '0.25rem' } })
+        ]),
+        div({ style: { marginBottom: '0.5rem', display: 'flex' } }, [
+          div({ style: { marginRight: '0.5rem', fontWeight: 500 } }, ['Location:']),
+          div({ style: { marginRight: '0.5rem' } }, [flag || unknownRegionFlag]),
+          regionDescription || 'loading...'
+        ]),
+        h(Link, {
+          ...Utils.newTabLinkProps,
+          href: bucketBrowserUrl(bucketName)
+        }, ['Open in browser', icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })])
       ])
     ])
   }

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -316,7 +316,7 @@ export const WorkspaceDashboard = _.flow(
           (bucketLocation ?
             h(TooltipCell, { style: { marginRight: '0.5rem' }, tooltip: `Bucket region: ${regionDescription}` }, [flag]) :
             h(TooltipCell, { style: { marginRight: '0.5rem' }, tooltip: 'Bucket region loading...' }, [unknownRegionFlag])),
-          span({ style: { marginRight: '0.5rem', ...Style.noWrapEllipsis } }, [bucketName]),
+          h(TooltipCell, { tooltip: bucketName, style: { marginRight: '0.5rem', ...Style.noWrapEllipsis } }, [bucketName]),
           h(ClipboardButton, { text: bucketName, style: { marginLeft: '0.25rem' } }),
           h(Link, {
             ...Utils.newTabLinkProps,


### PR DESCRIPTION
Adds the region information for a workspace bucket to the workspace dashboard.

#### Before

![image](https://user-images.githubusercontent.com/13006282/100674463-2dd1b980-3333-11eb-8fee-7aeff9530420.png)

#### After:

||
|-|
|![image](https://user-images.githubusercontent.com/13006282/101829935-cae5dc80-3b01-11eb-8766-68838af899e3.png) |


