### PR TITLE
[IA-2391] fix cost calc for galaxy apps

### DIFF
--- a/src/components/NewGalaxyModal.js
+++ b/src/components/NewGalaxyModal.js
@@ -119,7 +119,7 @@ export const NewGalaxyModal = _.flow(
 
   const renderDefaultCase = () => {
     const { cpu, memory } = _.find({ name: 'n1-standard-8' }, machineTypes)
-    const cost = getGalaxyCost(app || { kubernetesRuntimeConfig: { machineType: 'n1-standard-8' } })
+    const cost = getGalaxyCost(app || { kubernetesRuntimeConfig: { machineType: 'n1-standard-8', numNodes: 2 } })
     return h(Fragment, [
       div([`Environment ${app ? 'consists' : 'will consist'} of an application and cloud compute.`]),
       div({ style: { ...styles.whiteBoxContainer, marginTop: '1rem' } }, [

--- a/src/libs/runtime-utils.js
+++ b/src/libs/runtime-utils.js
@@ -71,9 +71,9 @@ export const runtimeCost = ({ runtimeConfig, status }) => {
 
 export const getGalaxyCost = app => {
   // numNodes * price per node + diskCost + defaultNodepoolCost
-  const defaultNodepoolCost = machineCost("n1-standard-1")
+  const defaultNodepoolCost = machineCost('n1-standard-1')
   const appCost = app.kubernetesRuntimeConfig.numNodes * machineCost(app.kubernetesRuntimeConfig.machineType) + persistentDiskCost({ size: 250 + 10 + 100 + 100, status: 'Running' })
-  return  appCost + defaultNodepoolCost
+  return appCost + defaultNodepoolCost
   // diskCost: 250Gb for the NFS disk, 10Gb for the postgres disk, and 200Gb for boot disks (1 boot disk per nodepool)
   // to do: retrieve the disk sizes from the app not just hardcode them
 }
@@ -94,7 +94,7 @@ export const trimAppsOldestFirst = _.flow(
   _.sortBy('auditInfo.createdDate'))
 
 // TODO: factor status into cost
-export const machineCost = (machineType) => {
+export const machineCost = machineType => {
   return _.find(knownMachineType => knownMachineType.name === machineType, machineTypes).price
 }
 


### PR DESCRIPTION
Cost was originally NaN when no app existed because  there was no default value for num nodes.

I also added the node that belongs to the cluster to the cost calculation. This will be an overestimate for users with multiple apps in a cluster, but otherwise it is an underestimate for users with single apps in a cluster. I believe the former is better.