### PR TITLE
AS-554: link to baseline doc [risk: no]

### DIFF
--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -231,10 +231,10 @@ const TopBar = ({ showMenu = true, title, href, children }) => {
               ...Utils.newTabLinkProps
             }, ['How-to Guides']),
             isBaseline() && h(DropDownSubItem, {
-              href: 'https://blog.projectbaseline.com/',
+              href: 'https://support.terra.bio/hc/en-us/sections/360010495892-Baseline',
               onClick: hideNav,
               ...Utils.newTabLinkProps
-            }, ['Baseline Blog']),
+            }, ['Baseline Documentation']),
             h(DropDownSubItem, {
               href: 'https://support.terra.bio/hc/en-us/community/topics/360000500452',
               onClick: hideNav,

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -16,7 +16,7 @@ import headerRightHexes from 'src/images/header-right-hexes.svg'
 import { Ajax } from 'src/libs/ajax'
 import { signOut } from 'src/libs/auth'
 import colors from 'src/libs/colors'
-import { getConfig, isBioDataCatalyst, isDatastage, isFirecloud, isTerra } from 'src/libs/config'
+import { getConfig, isBaseline, isBioDataCatalyst, isDatastage, isFirecloud, isTerra } from 'src/libs/config'
 import { withErrorReporting } from 'src/libs/error'
 import { FormLabel } from 'src/libs/forms'
 import { topBarLogo, versionTag } from 'src/libs/logos'
@@ -230,6 +230,11 @@ const TopBar = ({ showMenu = true, title, href, children }) => {
               onClick: hideNav,
               ...Utils.newTabLinkProps
             }, ['How-to Guides']),
+            isBaseline() && h(DropDownSubItem, {
+              href: 'https://blog.projectbaseline.com/',
+              onClick: hideNav,
+              ...Utils.newTabLinkProps
+            }, ['Baseline Blog']),
             h(DropDownSubItem, {
               href: 'https://support.terra.bio/hc/en-us/community/topics/360000500452',
               onClick: hideNav,


### PR DESCRIPTION
This PR adds a link in the hamburger menu, specific to the Baseline skin, that goes to the Baseline documentation.

Tested by running locally and fiddling with `configOverridesStore.set({isBaseline:true})` in console - also tried `isFirecloud` for good measure to make sure the link was Baseline-specific. 

see the link "Baseline Documentation":
<img width="609" alt="Screen Shot 2020-12-04 at 11 02 57 AM" src="https://user-images.githubusercontent.com/6041577/101518833-6df6f480-3950-11eb-8ee4-033677671a0f.png">

