### PR TITLE
Creating an ORSP ID attribute

### DIFF
--- a/src/data/workspace-attributes.js
+++ b/src/data/workspace-attributes.js
@@ -27,7 +27,8 @@ export const displayLibraryAttributes = [
   { key: 'library:cohortCountry', title: 'Cohort Country of Origin' },
   { key: 'library:requiresExternalApproval', title: 'Requires External Approval' },
   { key: 'library:lmsvn', title: 'Library Metadata Schema Version Number' },
-  { key: 'library:dulvn', title: 'Structured Data Use Limitations Version Number' }
+  { key: 'library:dulvn', title: 'Structured Data Use Limitations Version Number' },
+  { key: 'library:orsp', title: 'Structured Data Use Limitations ID' }
 ]
 
 export const displayConsentCodes = [


### PR DESCRIPTION
### **Addresses** 
The data attributes in FireCloud include ORSP code (ORSP-XXX)  in The Structured Data Use Limitations field.  However, the same workspace in Terra, shows near-identical data attributes, except for ORSP code. 

See [https://broadworkbench.atlassian.net/browse/DFE-318](https://broadworkbench.atlassian.net/browse/DFE-318)

### **Solution** 
Added ORSP ID to the list of displayed attribute

### **Tested**
This was tested by running the code locally and viewing the ORSP code in a workspace with an ORSP code; then the ORSP code hidden in a workspace without an ORSP code

### **Risk**
None

