### PR TITLE
memoize cell rendering in datatable

### DIFF
--- a/src/components/DataTable.js
+++ b/src/components/DataTable.js
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp'
-import { Fragment, useEffect, useRef, useState } from 'react'
+import { Fragment, memo, useEffect, useRef, useState } from 'react'
 import { div, h, span } from 'react-hyperscript-helpers'
 import { AutoSizer } from 'react-virtualized'
 import { Checkbox, Clickable, Link, MenuButton, spinnerOverlay } from 'src/components/common'
@@ -161,7 +161,7 @@ const DataTable = props => {
 
 
   // Memoized components
-  const checkboxCellRenderer = _.memoize((entityName, entity) => {
+  const CheckboxCell = memo(({ entityName, entity }) => {
     const checked = _.has([entityName], selected)
     return h(Checkbox, {
       'aria-label': entityName,
@@ -170,7 +170,7 @@ const DataTable = props => {
     })
   })
 
-  const nameCellRenderer = _.memoize(entityName => {
+  const NameCell = memo(({ entityName }) => {
     return h(Fragment, [
       renderDataCell(entityName, namespace),
       div({ style: { flexGrow: 1 } }),
@@ -181,7 +181,7 @@ const DataTable = props => {
     ])
   })
 
-  const columnHeaderRenderer = _.memoize((name, thisWidth) => {
+  const ColumnHeader = memo(({ name, thisWidth }) => {
     const [, columnNamespace, columnName] = /(.+:)?(.+)/.exec(name)
     return h(Resizable, {
       width: thisWidth, onWidthChange: delta => setColumnWidths(_.set(name, thisWidth + delta))
@@ -196,7 +196,7 @@ const DataTable = props => {
     ])
   })
 
-  const dataCellRenderer = _.memoize((dataInfo, entityName) => {
+  const DataCell = memo(({ dataInfo, entityName }) => {
     const dataCell = renderDataCell(Utils.entityAttributeText(dataInfo), namespace)
     return h(Fragment, [
       (!!dataInfo && _.isArray(dataInfo.items)) ?
@@ -271,7 +271,7 @@ const DataTable = props => {
                   },
                   cellRenderer: ({ rowIndex }) => {
                     const entity = entities[rowIndex]
-                    return checkboxCellRenderer(entity.name, entity)
+                    return h(CheckboxCell, { entityName: entity.name, entity })
                   }
                 },
                 {
@@ -285,16 +285,16 @@ const DataTable = props => {
                       h(HeaderCell, [`${entityType}_id`])
                     ])
                   ]),
-                  cellRenderer: ({ rowIndex }) => nameCellRenderer(entities[rowIndex].name)
+                  cellRenderer: ({ rowIndex }) => h(NameCell, { entityName: entities[rowIndex].name })
                 },
                 ..._.map(({ name }) => {
                   const thisWidth = columnWidths[name] || 300
                   return {
                     width: thisWidth,
-                    headerRenderer: () => columnHeaderRenderer(name, thisWidth),
+                    headerRenderer: () => h(ColumnHeader, { name, thisWidth }),
                     cellRenderer: ({ rowIndex }) => {
                       const { attributes: { [name]: dataInfo }, name: entityName } = entities[rowIndex]
-                      return dataCellRenderer(dataInfo, entityName)
+                      return h(DataCell, { dataInfo, entityName })
                     }
                   }
                 }, _.filter('visible', columnSettings))

--- a/src/components/DataTable.js
+++ b/src/components/DataTable.js
@@ -301,7 +301,7 @@ const DataTable = props => {
                     cellRenderer: ({ rowIndex }) => {
                       const { attributes: { [name]: dataInfo }, name: entityName } = entities[rowIndex]
 
-                      return dataCellRenderer(`${thisWidth}-${dataInfo}-${entityName}`, dataInfo, entityName)
+                      return dataCellRenderer(`${dataInfo}-${entityName}`, dataInfo, entityName)
                     }
                   }
                 }, _.filter('visible', columnSettings))

--- a/src/components/DataTable.js
+++ b/src/components/DataTable.js
@@ -161,7 +161,6 @@ const DataTable = props => {
 
 
   // Memoized components
-
   const checkboxCellRenderer = _.memoize((entityName, entity) => {
     const checked = _.has([entityName], selected)
     return h(Checkbox, {

--- a/src/components/DataTable.js
+++ b/src/components/DataTable.js
@@ -181,7 +181,7 @@ const DataTable = props => {
     ])
   })
 
-  const columnHeaderRenderer = _.memoize((memoKey, thisWidth, name) => {
+  const columnHeaderRenderer = _.memoize((name, thisWidth) => {
     const [, columnNamespace, columnName] = /(.+:)?(.+)/.exec(name)
     return h(Resizable, {
       width: thisWidth, onWidthChange: delta => setColumnWidths(_.set(name, thisWidth + delta))
@@ -196,7 +196,7 @@ const DataTable = props => {
     ])
   })
 
-  const dataCellRenderer = _.memoize((memoKey, dataInfo, entityName) => {
+  const dataCellRenderer = _.memoize((dataInfo, entityName) => {
     const dataCell = renderDataCell(Utils.entityAttributeText(dataInfo), namespace)
     return h(Fragment, [
       (!!dataInfo && _.isArray(dataInfo.items)) ?
@@ -291,10 +291,10 @@ const DataTable = props => {
                   const thisWidth = columnWidths[name] || 300
                   return {
                     width: thisWidth,
-                    headerRenderer: () => columnHeaderRenderer(`${thisWidth}-${name}`, thisWidth, name),
+                    headerRenderer: () => columnHeaderRenderer(name, thisWidth),
                     cellRenderer: ({ rowIndex }) => {
                       const { attributes: { [name]: dataInfo }, name: entityName } = entities[rowIndex]
-                      return dataCellRenderer(`${dataInfo}-${entityName}`, dataInfo, entityName)
+                      return dataCellRenderer(dataInfo, entityName)
                     }
                   }
                 }, _.filter('visible', columnSettings))

--- a/src/components/DataTable.js
+++ b/src/components/DataTable.js
@@ -167,11 +167,11 @@ const DataTable = props => {
     return h(Checkbox, {
       'aria-label': entityName,
       checked,
-      onChange: () => setSelected((checked ? _.unset([entity]) : _.set([entityName], entity))(selected))
+      onChange: () => setSelected((checked ? _.unset([entityName]) : _.set([entityName], entity))(selected))
     })
   })
 
-  const nameCellRenderer = _.memoize((memoKey, entityName) => {
+  const nameCellRenderer = _.memoize(entityName => {
     return h(Fragment, [
       renderDataCell(entityName, namespace),
       div({ style: { flexGrow: 1 } }),
@@ -286,21 +286,15 @@ const DataTable = props => {
                       h(HeaderCell, [`${entityType}_id`])
                     ])
                   ]),
-                  cellRenderer: ({ rowIndex }) => {
-                    const { name: entityName } = entities[rowIndex]
-                    return nameCellRenderer(`${nameWidth}-${entityName}`, entityName)
-                  }
+                  cellRenderer: ({ rowIndex }) => nameCellRenderer(entities[rowIndex].name)
                 },
                 ..._.map(({ name }) => {
                   const thisWidth = columnWidths[name] || 300
                   return {
                     width: thisWidth,
-                    headerRenderer: () => {
-                      return columnHeaderRenderer(`${thisWidth}-${name}`, thisWidth, name)
-                    },
+                    headerRenderer: () => columnHeaderRenderer(`${thisWidth}-${name}`, thisWidth, name),
                     cellRenderer: ({ rowIndex }) => {
                       const { attributes: { [name]: dataInfo }, name: entityName } = entities[rowIndex]
-
                       return dataCellRenderer(`${dataInfo}-${entityName}`, dataInfo, entityName)
                     }
                   }

--- a/src/components/DataTable.js
+++ b/src/components/DataTable.js
@@ -287,7 +287,7 @@ const DataTable = props => {
                     ])
                   ]),
                   cellRenderer: ({ rowIndex }) => {
-                    const {name: entityName} = entities[rowIndex]
+                    const { name: entityName } = entities[rowIndex]
                     return nameCellRenderer(`${nameWidth}-${entityName}`, entityName)
                   }
                 },


### PR DESCRIPTION
This should make datatable cell rendering a lot less expensive. Since lodash-fp doesn't allow providing a custom key function to memoize, I've added a memoKey as the first argument to the memoized renderers for the headers and cells that we map over.

I thought I might have some trouble with the checkbox cells, but they seem to be behaving nicely. I'm not honestly sure why- without the checked state in the key, I wouldn't expect them to re-render, so I wouldn't expect them to re-evaluate what's selected, and thus I wouldn't expect them to toggle correctly.