### PR TITLE
Add region to "Outputs" panel of WorkflowView [BW-449 spin-off]

### DIFF
--- a/src/components/region-common.js
+++ b/src/components/region-common.js
@@ -1,0 +1,27 @@
+// Get a { flag: ..., countryName: ... } object representing a google locationType/location input.
+// 'flag' will always be defined (even if it's a question mark.
+// 'regionDescription' is the same as location when locationType is 'multi-region', or a country name when locationType is 'region'.
+export const regionInfo = (location, locationType) => {
+  switch (locationType) {
+    case 'multi-region':
+      switch (location) {
+        case 'US':
+          return { flag: '🇺🇸', regionDescription: `${locationType}: ${location}` }
+        case 'EU':
+          return { flag: '🇪🇺', regionDescription: `${locationType}: ${location}` }
+        case 'ASIA':
+          return { flag: '🌏', regionDescription: `${locationType}: ${location}` }
+        default:
+          return { flag: '❓', regionDescription: `${locationType}: ${location}` }
+      }
+    case 'region':
+      switch (location) {
+        case 'EUROPE-NORTH1':
+          return { flag: '🇫🇮', regionDescription: `${locationType}: ${location} (Finland)` }
+        default:
+          return { flag: '❓', regionDescription: `${locationType}: ${location}` }
+      }
+    default:
+      return { flag: '❓', regionDescription: `${locationType}: ${location}` }
+  }
+}

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -544,6 +544,13 @@ const Workspaces = signal => ({
         return res.json()
       },
 
+      checkBucketLocation: async bucket => {
+        const res = await fetchBuckets(`storage/v1/b/${bucket}?fields=location%2ClocationType`,
+          _.merge(authOpts(await saToken(namespace)), { signal }))
+
+        return res.json()
+      },
+
       details: async fields => {
         const res = await fetchRawls(`${root}?${qs.stringify({ fields }, { arrayFormat: 'comma' })}`, _.merge(authOpts(), { signal }))
         return res.json()

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -46,8 +46,8 @@ import * as Utils from 'src/libs/utils'
 import { wrapWorkspace } from 'src/pages/workspaces/workspace/WorkspaceContainer'
 
 
-const localVariables = 'localVariables'
-const bucketObjects = '__bucket_objects__'
+export const localVariables = 'localVariables'
+export const bucketObjects = '__bucket_objects__'
 
 const styles = {
   tableContainer: {
@@ -934,7 +934,7 @@ const WorkspaceData = _.flow(
     this.state = {
       firstRender: true,
       refreshKey: 0,
-      selectedDataType,
+      selectedDataType: props.queryParams.initialDataType || selectedDataType,
       entityMetadata,
       importingReference: false,
       deletingReference: undefined
@@ -952,6 +952,10 @@ const WorkspaceData = _.flow(
   })
 
   componentDidMount() {
+    const { queryParams } = this.props
+    if (queryParams.initialDataType) {
+      Nav.history.replace({ search: qs.stringify(_.omit(['initialDataType'], queryParams)) })
+    }
     this.loadMetadata()
     this.setState({ firstRender: false })
   }

--- a/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
+++ b/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
@@ -1,12 +1,15 @@
 import _ from 'lodash/fp'
 import { Fragment, useState } from 'react'
-import { b, div, h, wbr } from 'react-hyperscript-helpers'
+import { b, div, h, p, span, wbr } from 'react-hyperscript-helpers'
 import { ButtonPrimary, CromwellVersionLink } from 'src/components/common'
 import { spinner } from 'src/components/icons'
 import Modal from 'src/components/Modal'
+import { InfoBox } from 'src/components/PopupTrigger'
+import { regionInfo } from 'src/components/region-common'
 import { Ajax } from 'src/libs/ajax'
 import { launch } from 'src/libs/analysis'
 import colors from 'src/libs/colors'
+import { withErrorReporting } from 'src/libs/error'
 import * as Utils from 'src/libs/utils'
 import {
   chooseRows, chooseSetComponents, chooseSets, processAll, processAllAsSet, processMergedSet
@@ -15,15 +18,24 @@ import {
 
 const LaunchAnalysisModal = ({
   onDismiss, entityMetadata,
-  workspace, workspace: { workspace: { namespace, name } }, processSingle,
+  workspace, workspace: { workspace: { namespace, name: workspaceName, bucketName } }, processSingle,
   entitySelectionModel: { type, selectedEntities, newSetName },
   config, config: { rootEntityType }, useCallCache, deleteIntermediateOutputFiles, onSuccess
 }) => {
   const [launching, setLaunching] = useState(undefined)
   const [message, setMessage] = useState(undefined)
   const [launchError, setLaunchError] = useState(undefined)
-
+  const [bucketLocation, setBucketLocation] = useState({})
   const signal = Utils.useCancellation()
+
+  Utils.useOnMount(() => {
+    const loadBucketLocation = withErrorReporting('Error loading bucket location', async () => {
+      const { location, locationType } = await Ajax(signal).Workspaces.workspace(namespace, workspaceName).checkBucketLocation(bucketName)
+      setBucketLocation({ location, locationType })
+    })
+
+    loadBucketLocation()
+  })
 
   const doLaunch = async () => {
     try {
@@ -32,7 +44,7 @@ const LaunchAnalysisModal = ({
         [processSingle, () => ({})],
         [type === processAll, async () => {
           setMessage('Fetching data...')
-          const selectedEntityNames = _.map('name', await Ajax(signal).Workspaces.workspace(namespace, name).entitiesOfType(rootEntityType))
+          const selectedEntityNames = _.map('name', await Ajax(signal).Workspaces.workspace(namespace, workspaceName).entitiesOfType(rootEntityType))
           return { selectedEntityType: rootEntityType, selectedEntityNames }
         }],
         [type === chooseRows || type === chooseSets, () => ({ selectedEntityType: rootEntityType, selectedEntityNames: _.keys(selectedEntities) })],
@@ -44,7 +56,7 @@ const LaunchAnalysisModal = ({
         [type === chooseSetComponents, () => ({ selectedEntityType: baseEntityType, selectedEntityNames: _.keys(selectedEntities) })],
         [type === processAllAsSet, async () => {
           setMessage('Fetching data...')
-          const selectedEntityNames = _.map('name', await Ajax(signal).Workspaces.workspace(namespace, name).entitiesOfType(baseEntityType))
+          const selectedEntityNames = _.map('name', await Ajax(signal).Workspaces.workspace(namespace, workspaceName).entitiesOfType(baseEntityType))
           return { selectedEntityType: baseEntityType, selectedEntityNames }
         }]
       )
@@ -71,6 +83,8 @@ const LaunchAnalysisModal = ({
     [type === processMergedSet, () => _.flow(mergeSets, _.uniqBy('entityName'))(selectedEntities).length]
   )
   const wrappableOnPeriods = _.flow(str => str?.split(/(\.)/), _.flatMap(sub => sub === '.' ? [wbr(), '.'] : sub))
+  const { location, locationType } = bucketLocation
+  const { flag, regionDescription } = regionInfo(location, locationType)
 
   return h(Modal, {
     title: !launching ? 'Confirm launch' : 'Launching Analysis',
@@ -100,6 +114,16 @@ const LaunchAnalysisModal = ({
     ]),
     div({ style: { color: colors.danger(), overflowWrap: 'break-word' } }, [
       h(Fragment, wrappableOnPeriods(launchError))
+    ]),
+    div(['Output files will be saved as workspace data in:']),
+    div({ style: { margin: '1rem' } }, [
+      location ? h(Fragment, [span({ style: { marginRight: '0.5rem' } }, [flag]),
+        span({ style: { marginRight: '0.5rem' } }, [regionDescription]),
+        h(InfoBox, [
+          p(['Cromwell will instruct its job runners to delocalize call outputs to your workspace bucket in this region.']),
+          p(['Tasks within your workflow might additionally move or copy the data elsewhere. You should carefully vet the workflows you run if region requirements are a concern.']),
+          p(['Note that metadata about this run will also be stored in the US.'])
+        ])]) : 'Loading...'
     ])
   ])
 }


### PR DESCRIPTION
Spun off from BW-449 to avoid overcomplicating it.

Tested live on alpha.

### Before:

||
|-|
| ![image](https://user-images.githubusercontent.com/13006282/101675028-37d87400-3a27-11eb-9d00-d07aabbca9ae.png) |

### After:

||
|-|
| ![image](https://user-images.githubusercontent.com/13006282/101675256-956cc080-3a27-11eb-86f4-c4e3511deb95.png) |


#### UX Changes:

* Move location content to a collapsible panel to avoid overwhelming the table below
* Show output bucket name and location
* "Files" becomes a link to the appropriate tab on the Data page (before this change, I just thought "Files" was just a (not especially helpful!) word, rather than a reference to the Data tab)
* Link to the Tables page (ditto)

