### PR TITLE
Use node 12 on app engine

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,4 +1,4 @@
-runtime: nodejs10
+runtime: nodejs12
 default_expiration: "2m"
 
 handlers:


### PR DESCRIPTION
This should functionally change nothing, since we only use app engine for serving static files.