### PR TITLE
Update AMP PD Data Explorer to v2 release

### DIFF
--- a/src/data/datasets.js
+++ b/src/data/datasets.js
@@ -6,13 +6,13 @@ const datasets = [
     origin: 'https://test-data-explorer.appspot.com'
   },
   {
-    name: 'AMP PD - 2019_v1release_1015',
+    name: 'AMP PD - 2020_v2release_1218',
     origin: 'https://data-explorer.amp-pd.org',
     authDomain: 'amp-pd-researchers',
     partner: 'AMP PD'
   },
   {
-    name: 'AMP PD Clinical - 2019_v1release_1015',
+    name: 'AMP PD Clinical - 2020_v2release_1218',
     origin: 'https://clinical-data-explorer.amp-pd.org',
     authDomain: 'amp-pd-clinical-access',
     partner: 'AMP PD'

--- a/src/pages/library/Datasets.js
+++ b/src/pages/library/Datasets.js
@@ -164,14 +164,14 @@ const amppd = () => h(Participant, {
       ])
     ])
   ]),
-  sizeText: 'Participants: > 4,000'
+  sizeText: 'Participants: > 10,000'
 }, [
   h(ButtonPrimary, {
     style: { marginBottom: '1rem' },
-    href: Nav.getLink('data-explorer-private', { dataset: 'AMP PD Clinical - 2019_v1release_1015' })
+    href: Nav.getLink('data-explorer-private', { dataset: 'AMP PD Clinical - 2020_v2release_1218' })
   }, ['Browse Tier 1 Data']),
   h(ButtonPrimary, {
-    href: Nav.getLink('data-explorer-private', { dataset: 'AMP PD - 2019_v1release_1015' })
+    href: Nav.getLink('data-explorer-private', { dataset: 'AMP PD - 2020_v2release_1218' })
   }, ['Browse Tier 2 Data'])
 ])
 

--- a/src/pages/library/Datasets.js
+++ b/src/pages/library/Datasets.js
@@ -164,7 +164,7 @@ const amppd = () => h(Participant, {
       ])
     ])
   ]),
-  sizeText: 'Participants: > 10,000'
+  sizeText: 'Participants: 10,247'
 }, [
   h(ButtonPrimary, {
     style: { marginBottom: '1rem' },


### PR DESCRIPTION
This PR updates the release version from 2019_v1release_1015 to 2020_v2release_1218. Also updates the text indicating number of participants. 

Tested by running locally. 
