### PR TITLE
PoC for dockstore tool import [BW-318]

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -144,7 +144,11 @@ const fetchBard = withUrlPrefix(`${getConfig().bardRoot}/`, fetchOk)
 const nbName = name => encodeURIComponent(`notebooks/${name}.ipynb`)
 
 // %23 = '#', %2F = '/'
-const dockstoreMethodPath = path => `api/ga4gh/v1/tools/%23workflow%2F${encodeURIComponent(path)}/versions`
+// importType should be either 'workflow' or 'tool'
+const dockstoreMethodPath = (importType, path) => {
+  if (importType === 'workflow') return `ga4gh/v1/tools/%23workflow%2F${encodeURIComponent(path)}/versions`
+  else if (importType === 'tool') return `ga4gh/trs/v2/tools/${encodeURIComponent(path)}/versions`
+}
 
 /**
  * Only use this if the user has write access to the workspace to avoid proliferation of service accounts in projects containing public workspaces.
@@ -1211,14 +1215,14 @@ const Disks = signal => ({
 })
 
 const Dockstore = signal => ({
-  getWdl: async (path, version) => {
-    const res = await fetchDockstore(`${dockstoreMethodPath(path)}/${encodeURIComponent(version)}/WDL/descriptor`, { signal })
+  getWdl: async (importType, path, version) => {
+    const res = await fetchDockstore(`${dockstoreMethodPath(importType, path)}/${encodeURIComponent(version)}/WDL/descriptor`, { signal })
     const { url } = await res.json()
     return fetchOk(url, { signal }).then(res => res.text())
   },
 
-  getVersions: async path => {
-    const res = await fetchDockstore(dockstoreMethodPath(path), { signal })
+  getVersions: async (importType, path) => {
+    const res = await fetchDockstore(dockstoreMethodPath(importType, path), { signal })
     return res.json()
   }
 })

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -498,7 +498,8 @@ const WorkflowView = _.flow(
 
         this.setState({ versionIds: snapshotIds })
       } else if (sourceRepo === 'dockstore') {
-        const versions = await Ajax(signal).Dockstore.getVersions(methodPath)
+        // TODO: We would need to store 'workflow' vs 'tool' for dockstore imports. For now assume 'workflow':
+        const versions = await Ajax(signal).Dockstore.getVersions('workflow', methodPath)
         const versionIds = _.map('name', versions)
 
         this.setState({ versionIds })
@@ -532,7 +533,8 @@ const WorkflowView = _.flow(
           this.setState({ synopsis, documentation, wdl: payload })
         }
       } else if (sourceRepo === 'dockstore') {
-        const wdl = await Ajax(signal).Dockstore.getWdl(methodPath, methodVersion)
+        // TODO: We would need to store 'workflow' vs 'tool' for dockstore imports:
+        const wdl = await Ajax(signal).Dockstore.getWdl('workflow', methodPath, methodVersion)
         this.setState({ wdl })
       } else {
         throw new Error('unknown sourceRepo')


### PR DESCRIPTION
Proof-of-concept using a query parameter to allow tool imports from dockstore.

Tested with:

* A workflow import (existing functionality): http://localhost:3000/#import-workflow/dockstore/github.com/HumanCellAtlas/skylab/Optimus:terra-optimus
* A tool import (new functionality): http://localhost:3000/#import-workflow/dockstore/quay.io/briandoconnor/dockstore-tool-bamstats:develop?dockstoreImportType=tool

Note:

* The "not-yet-visible" `WorkflowView` page would not be able to display `tool` imports without an additional field stored somewhere to indicate tool vs workflow. Right now that page is not linked to from anywhere else in the UI but it still feels bad to "break" it without a plan to fix it again afterwards.