### PR TITLE
IA-2342: Adding Pause Resume features to Terra-UI

### DIFF
--- a/src/components/NewGalaxyModal.js
+++ b/src/components/NewGalaxyModal.js
@@ -88,7 +88,7 @@ export const NewGalaxyModal = _.flow(
       [Utils.DEFAULT, () => {
         return !!app ?
           h(Fragment, [
-            h(ButtonSecondary, { style: { marginRight: 'auto' }, onClick: () => setViewMode('deleteWarn') }, ['Delete']),
+            (app.status === 'RUNNING') && h(ButtonSecondary, { style: { marginRight: 'auto' }, onClick: () => setViewMode('deleteWarn') }, ['Delete']),
             (app.status === 'RUNNING') && h(ButtonSecondary, { style: { marginRight: '1rem' }, onClick: () => { pauseGalaxy() } }, ['Pause']),
             (app.status === 'STOPPED') && h(ButtonPrimary, { style: { marginRight: '1rem' }, onClick: () => { resumeGalaxy() } }, ['Resume']),
             (app.status === 'RUNNING') && h(ButtonPrimary, { onClick: () => setViewMode('launchWarn') }, ['Launch Galaxy'])

--- a/src/components/NewGalaxyModal.js
+++ b/src/components/NewGalaxyModal.js
@@ -88,12 +88,12 @@ export const NewGalaxyModal = _.flow(
       [Utils.DEFAULT, () => {
         return !!app ?
           h(Fragment, [
-            (app.status === 'RUNNING') && h(ButtonSecondary, { style: { marginRight: 'auto' }, onClick: () => setViewMode('deleteWarn') }, ['Delete']),
-            (app.status === 'RUNNING') && h(ButtonSecondary, { style: { marginRight: '1rem' }, onClick: () => { pauseGalaxy() } }, ['Pause']),
-            (app.status === 'STOPPED') && h(ButtonSecondary, { style: { marginRight: 'auto' }, onClick: () => setViewMode('deleteWarn') }, ['Delete']),
-            (app.status === 'STOPPED') && h(ButtonPrimary, { style: { marginRight: '1rem' }, onClick: () => { resumeGalaxy() } }, ['Resume']),
-            (app.status === 'ERROR') && h(ButtonSecondary, { style: { marginRight: 'auto' }, onClick: () => setViewMode('deleteWarn') }, ['Delete']),
-            (app.status === 'RUNNING') && h(ButtonPrimary, { onClick: () => setViewMode('launchWarn') }, ['Launch Galaxy'])
+            (app.status === 'RUNNING') && h(Fragment, [h(ButtonSecondary, { style: { marginRight: 'auto' }, onClick: () => setViewMode('deleteWarn') }, ['Delete']),
+              h(ButtonSecondary, { style: { marginRight: '1rem' }, onClick: () => { pauseGalaxy() } }, ['Pause']),
+              h(ButtonPrimary, { onClick: () => setViewMode('launchWarn') }, ['Launch Galaxy'])]),
+            (app.status === 'STOPPED') && h(Fragment, [h(ButtonSecondary, { style: { marginRight: 'auto' }, onClick: () => setViewMode('deleteWarn') }, ['Delete']),
+              h(ButtonPrimary, { style: { marginRight: '1rem' }, onClick: () => { resumeGalaxy() } }, ['Resume'])]),
+            (app.status === 'ERROR') && h(ButtonSecondary, { style: { marginRight: 'auto' }, onClick: () => setViewMode('deleteWarn') }, ['Delete'])
           ]) :
           h(ButtonPrimary, { onClick: () => setViewMode('createWarn') }, ['Next'])
       }]

--- a/src/components/NewGalaxyModal.js
+++ b/src/components/NewGalaxyModal.js
@@ -71,10 +71,10 @@ export const NewGalaxyModal = _.flow(
   const renderActionButton = () => {
     return Utils.switchCase(viewMode,
       ['deleteWarn', () => {
-        return h(ButtonPrimary, { onClick: () => deleteGalaxy() }, ['Delete'])
+        return h(ButtonPrimary, { onClick: deleteGalaxy }, ['Delete'])
       }],
       ['createWarn', () => {
-        return h(ButtonPrimary, { onClick: () => createGalaxy() }, ['Create'])
+        return h(ButtonPrimary, { onClick: createGalaxy }, ['Create'])
       }],
       ['launchWarn', () => {
         return h(GalaxyLaunchButton, { app, onClick: onDismiss })
@@ -82,7 +82,7 @@ export const NewGalaxyModal = _.flow(
       ['paused', () => {
         return h(Fragment, [
           h(ButtonPrimary, { style: { marginRight: 'auto' }, onClick: () => setViewMode('deleteWarn') }, ['Delete']),
-          h(ButtonSecondary, { style: { marginRight: '1rem' }, onClick: () => { resumeGalaxy() } }, ['Resume'])
+          h(ButtonSecondary, { style: { marginRight: '1rem' }, onClick: resumeGalaxy }, ['Resume'])
         ])
       }],
       [Utils.DEFAULT, () => {
@@ -101,10 +101,10 @@ export const NewGalaxyModal = _.flow(
   }
 
   const renderMessaging = () => {
-    return Utils.cond(
-      [viewMode === 'createWarn', renderCreateWarning],
-      [viewMode === 'deleteWarn', renderDeleteWarning],
-      [viewMode === 'launchWarn', renderLaunchWarning],
+    return Utils.switchCase( viewMode,
+      ['createWarn', renderCreateWarning],
+      ['deleteWarn', renderDeleteWarning],
+      ['launchWarn', renderLaunchWarning],
       [Utils.DEFAULT, renderDefaultCase]
     )
   }
@@ -135,7 +135,7 @@ export const NewGalaxyModal = _.flow(
             ]),
             div({ style: { ...styles.headerText, marginTop: '0.5rem' } }, ['Pause and auto-pause']),
             div({ style: { lineHeight: 1.5 } }, [
-              div(['You can pause anything during the compute, but it will auto-pause when']),
+              div(['You can pause  during the compute, but it will auto-pause when']),
               div(['the instance is idle more than 1 hour if the analysis is done.'])
             ])
           ])
@@ -184,12 +184,12 @@ export const NewGalaxyModal = _.flow(
 
   const getEnvMessageBasedOnStatus = isTitle => {
     return Utils.cond(
-      [!!app && (app.status === 'STOPPED'), () => `Cloud environment is now paused ${(!isTitle ? '...' : '')}`],
-      [!!app && (app.status === 'PRESTOPPING'), () => 'Cloud environment is preparing to stop.'],
-      [!!app && (app.status === 'STOPPING'), () => `Cloud environment is pausing. ${!isTitle ? 'This process will take up to a few minutes' : ''}`],
-      [!!app && (app.status === 'PRESTARTING'), () => 'Cloud environment is preparing to start.'],
-      [!!app && (app.status === 'STARTING'), () => `Cloud environment is starting. ${!isTitle ? 'This process will take up to a few minutes' : ''}`],
-      [!!app && (app.status === 'ERROR'), () => `An error has occurred on your Cloud Environment. ${!isTitle ? 'This process will take up to a few minutes' : ''}`],
+      [ (app?.status === 'STOPPED'), () => `Cloud environment is now paused ${(!isTitle ? '...' : '')}`],
+      [ (app?.status === 'PRESTOPPING'), () => 'Cloud environment is preparing to stop.'],
+      [ (app?.status === 'STOPPING'), () => `Cloud environment is pausing. ${!isTitle ? 'This process will take up to a few minutes' : ''}`],
+      [ (app?.status === 'PRESTARTING'), () => 'Cloud environment is preparing to start.'],
+      [ (app?.status === 'STARTING'), () => `Cloud environment is starting. ${!isTitle ? 'This process will take up to a few minutes' : ''}`],
+      [ (app?.status === 'ERROR'), () => `An error has occurred on your Cloud Environment. ${!isTitle ? 'This process will take up to a few minutes' : ''}`],
       () => isTitle ? 'Cloud environment' : `Environment ${app ? 'consists' : 'will consist'} of an application and cloud compute.`
     )
   }

--- a/src/components/NewGalaxyModal.js
+++ b/src/components/NewGalaxyModal.js
@@ -92,6 +92,7 @@ export const NewGalaxyModal = _.flow(
             (app.status === 'RUNNING') && h(ButtonSecondary, { style: { marginRight: '1rem' }, onClick: () => { pauseGalaxy() } }, ['Pause']),
             (app.status === 'STOPPED') && h(ButtonSecondary, { style: { marginRight: 'auto' }, onClick: () => setViewMode('deleteWarn') }, ['Delete']),
             (app.status === 'STOPPED') && h(ButtonPrimary, { style: { marginRight: '1rem' }, onClick: () => { resumeGalaxy() } }, ['Resume']),
+            (app.status === 'ERROR') && h(ButtonSecondary, { style: { marginRight: 'auto' }, onClick: () => setViewMode('deleteWarn') }, ['Delete']),
             (app.status === 'RUNNING') && h(ButtonPrimary, { onClick: () => setViewMode('launchWarn') }, ['Launch Galaxy'])
           ]) :
           h(ButtonPrimary, { onClick: () => setViewMode('createWarn') }, ['Next'])
@@ -185,9 +186,10 @@ export const NewGalaxyModal = _.flow(
     return Utils.cond(
       [!!app && (app.status === 'STOPPED'), () => `Cloud environment is now paused ${!isTitle ? '...' : undefined}`],
       [!!app && (app.status === 'PRESTOPPING'), () => 'Cloud environment is preparing to stop.'],
-      [!!app && (app.status === 'STOPPING'), () => `Cloud environment is pausing ${!isTitle ? 'This process will take up to a few minutes' : undefined}`],
+      [!!app && (app.status === 'STOPPING'), () => `Cloud environment is pausing. ${!isTitle ? 'This process will take up to a few minutes' : undefined}`],
       [!!app && (app.status === 'PRESTARTING'), () => 'Cloud environment is preparing to start.'],
-      [!!app && (app.status === 'STARTING'), () => `Cloud environment is starting ${!isTitle ? 'This process will take up to a few minutes' : undefined}`],
+      [!!app && (app.status === 'STARTING'), () => `Cloud environment is starting. ${!isTitle ? 'This process will take up to a few minutes' : undefined}`],
+      [!!app && (app.status === 'ERROR'), () => `An error has occurred on your Cloud Environment. ${!isTitle ? 'Your cloud environment has returned an error. You will not be able to launch the app' : undefined}`],
       () => isTitle ? 'Cloud environment' : `Environment ${app ? 'consists' : 'will consist'} of an application and cloud compute.`
     )
   }

--- a/src/components/NewGalaxyModal.js
+++ b/src/components/NewGalaxyModal.js
@@ -103,9 +103,6 @@ export const NewGalaxyModal = _.flow(
       [viewMode === 'createWarn', renderCreateWarning],
       [viewMode === 'deleteWarn', renderDeleteWarning],
       [viewMode === 'launchWarn', renderLaunchWarning],
-      [!!app && (app.status === 'STOPPED'), renderPaused],
-      [!!app && (app.status === 'STOPPING'), renderStoppingWarning],
-      [!!app && (app.status === 'STARTING'), renderStartingWarning],
       [Utils.DEFAULT, renderDefaultCase]
     )
   }
@@ -113,6 +110,12 @@ export const NewGalaxyModal = _.flow(
 
   const renderCreateWarning = () => {
     return h(Fragment, [
+      h(TitleBar, {
+        title: 'Cloud environment',
+        style: { marginBottom: '0.5rem' },
+        onDismiss,
+        onPrevious: !!viewMode ? () => setViewMode(undefined) : undefined
+      }),
       div({ style: { marginBottom: '1rem' } }, ['Environment will consist of an application and cloud compute.']),
       div({ style: { ...styles.whiteBoxContainer, backgroundColor: colors.accent(0.1), boxShadow: Style.standardShadow } }, [
         div({ style: { flex: '1', lineHeight: '1.5rem', minWidth: 0, display: 'flex' } }, [
@@ -130,8 +133,8 @@ export const NewGalaxyModal = _.flow(
             ]),
             div({ style: { ...styles.headerText, marginTop: '0.5rem' } }, ['Pause and auto-pause']),
             div({ style: { lineHeight: 1.5 } }, [
-              div(['You can pause anything during the compute, but it will auto-paused when']),
-              div(['the instance is idled more than 1 hour if the analysis is done.'])
+              div(['You can pause anything during the compute, but it will auto-pause when']),
+              div(['the instance is idle more than 1 hour if the analysis is done.'])
             ])
           ])
         ])
@@ -140,79 +143,39 @@ export const NewGalaxyModal = _.flow(
   }
 
   const renderDeleteWarning = () => {
-    return div({ style: { lineHeight: '22px' } }, [
-      div({ style: { marginTop: '0.5rem' } }, [
-        'Deleting your Cloud Environment will also ',
-        span({ style: { fontWeight: 600 } }, ['delete any files on the associated hard disk']),
-        ' (e.g. results files). Double check that your workflow results were written to ',
-        'the data tab in the workspace before clicking “Delete”'
-      ]),
-      div({ style: { marginTop: '1rem' } }, [
-        'Deleting your Cloud Environment will stop your ',
-        'running Galaxy application and your application costs. You can create a new Cloud Environment ',
-        'for Galaxy later, which will take 8-10 minutes.'
-      ])
-    ])
-  }
-
-  const renderStoppingWarning = () => {
     return h(Fragment, [
-      div({ style: { ...styles.whiteBoxContainer, marginTop: '1rem' } }, [
-        div([
-          ul({ style: { paddingLeft: '1rem', lineHeight: 1.5 } }, [
-            'The cloud environment is now pausing. This process will take up to a few minutes. Please check back when the environment has stopped.'
-          ])
-        ])
-      ])
-    ])
-  }
-
-
-  const renderStartingWarning = () => {
-    return h(Fragment, [
-      div({ style: { ...styles.whiteBoxContainer, marginTop: '1rem' } }, [
-        div([
-          ul({ style: { paddingLeft: '1rem', lineHeight: 1.5 } }, [
-            'The cloud environment is now starting. This process will take up to a few minutes. Please check back when the environment is running.'
-          ])
+      h(TitleBar, {
+        title: 'Delete Cloud Environment for Galaxy',
+        style: { marginBottom: '0.5rem' },
+        onDismiss,
+        onPrevious: !!viewMode ? () => setViewMode(undefined) : undefined
+      }),
+      div({ style: { lineHeight: '22px' } }, [
+        div({ style: { marginTop: '0.5rem' } }, [
+          'Deleting your Cloud Environment will also ',
+          span({ style: { fontWeight: 600 } }, ['delete any files on the associated hard disk']),
+          ' (e.g. results files). Double check that your workflow results were written to ',
+          'the data tab in the workspace before clicking “Delete”'
+        ]),
+        div({ style: { marginTop: '1rem' } }, [
+          'Deleting your Cloud Environment will stop your ',
+          'running Galaxy application and your application costs. You can create a new Cloud Environment ',
+          'for Galaxy later, which will take 8-10 minutes.'
         ])
       ])
     ])
   }
 
   const renderLaunchWarning = () => {
-    return div({ style: { lineHeight: '22px' } }, [
-      h(GalaxyWarning)
-    ])
-  }
-
-  const renderPaused = () => {
-    const { cpu, memory } = _.find({ name: 'n1-standard-8' }, machineTypes)
-    const cost = getGalaxyCost(app || { kubernetesRuntimeConfig: { machineType: 'n1-standard-8', numNodes: 2 } })
     return h(Fragment, [
-      div([`Cloud environment is now paused...`]),
-      div({ style: { ...styles.whiteBoxContainer, marginTop: '1rem' } }, [
-        div([
-          div({ style: styles.headerText }, ['Environment Settings']),
-          ul({ style: { paddingLeft: '1rem', lineHeight: 1.5 } }, [
-            li({ style: { marginTop: '1rem' } }, [
-              'Galaxy version 20.09'
-            ]),
-            li({ style: { marginTop: '1rem' } }, [
-              'Cloud Compute size of ',
-              // Temporarily hard-coded disk size, once it can be customized this should be revisited
-              span({ style: { fontWeight: 600 } }, [`${cpu} CPUS, ${memory} GB of memory, 250 GB disk space`])
-            ]),
-            li({ style: { marginTop: '1rem' } }, [
-              'Estimated cost of cloud compute: ',
-              span({ style: { fontWeight: 600 } }, [Utils.formatUSD(cost), ' per hr'])
-            ])
-          ]),
-          h(Link, { href: 'https://support.terra.bio/hc/en-us/articles/360050566271', ...Utils.newTabLinkProps }, [
-            'Learn more about Galaxy interactive environments',
-            icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })
-          ])
-        ])
+      h(TitleBar, {
+        title: h(WarningTitle, ['Launch Galaxy']),
+        style: { marginBottom: '0.5rem' },
+        onDismiss,
+        onPrevious: !!viewMode ? () => setViewMode(undefined) : undefined
+      }),
+      div({ style: { lineHeight: '22px' } }, [
+        h(GalaxyWarning)
       ])
     ])
   }
@@ -221,7 +184,29 @@ export const NewGalaxyModal = _.flow(
     const { cpu, memory } = _.find({ name: 'n1-standard-8' }, machineTypes)
     const cost = getGalaxyCost(app || { kubernetesRuntimeConfig: { machineType: 'n1-standard-8', numNodes: 2 } })
     return h(Fragment, [
-      div([`Environment ${app ? 'consists' : 'will consist'} of an application and cloud compute.`]),
+      h(TitleBar, {
+        title: Utils.cond(
+          [!!app && (app.status === 'STOPPED'), () => 'Cloud environment is now paused'],
+          [!!app && (app.status === 'PRESTOPPING'), () => 'Cloud environment is preparing to stop.'],
+          [!!app && (app.status === 'STOPPING'), () => 'Cloud environment is now pausing'],
+          [!!app && (app.status === 'PRESTARTING'), () => 'Cloud environment is preparing to start.'],
+          [!!app && (app.status === 'STARTING'), () => 'Cloud environment is now starting'],
+          () => 'Cloud environment'
+        ),
+        style: { marginBottom: '0.5rem' },
+        onDismiss,
+        onPrevious: !!viewMode ? () => setViewMode(undefined) : undefined
+      }),
+      div([
+        Utils.cond(
+          [!!app && (app.status === 'STOPPED'), () => `Cloud environment is now paused...`],
+          [!!app && (app.status === 'PRESTOPPING'), () => `Cloud environment is preparing to stop.`],
+          [!!app && (app.status === 'STOPPING'), () => `Cloud environment is pausing. This process will take up to a few minutes`],
+          [!!app && (app.status === 'PRESTARTING'), () => `Cloud environment is preparing to start.`],
+          [!!app && (app.status === 'STARTING'), () => `Cloud environment is starting. This process will take up to a few minutes`],
+          () => `Environment ${app ? 'consists' : 'will consist'} of an application and cloud compute.`
+        )
+      ]),
       div({ style: { ...styles.whiteBoxContainer, marginTop: '1rem' } }, [
         div([
           div({ style: styles.headerText }, ['Environment Settings']),
@@ -249,19 +234,6 @@ export const NewGalaxyModal = _.flow(
   }
 
   return div({ style: styles.drawerContent }, [
-    h(TitleBar, {
-      title: Utils.cond(
-        [viewMode === 'launchWarn', () => h(WarningTitle, ['Launch Galaxy'])],
-        [viewMode === 'deleteWarn', () => 'Delete Cloud Environment for Galaxy'],
-        [!!app && (app.status === 'STOPPED'), () => 'Cloud environment is now paused'],
-        [!!app && (app.status === 'STOPPING'), () => 'Cloud environment is now pausing'],
-        [!!app && (app.status === 'STARTING'), () => 'Cloud environment is now starting'],
-        () => 'Cloud environment'
-      ),
-      style: { marginBottom: '0.5rem' },
-      onDismiss,
-      onPrevious: !!viewMode ? () => setViewMode(undefined) : undefined
-    }),
     renderMessaging(),
     div({ style: { display: 'flex', marginTop: '2rem', justifyContent: 'flex-end' } }, [
       renderActionButton()

--- a/src/components/NewGalaxyModal.js
+++ b/src/components/NewGalaxyModal.js
@@ -184,12 +184,12 @@ export const NewGalaxyModal = _.flow(
 
   const getEnvMessageBasedOnStatus = isTitle => {
     return Utils.cond(
-      [!!app && (app.status === 'STOPPED'), () => `Cloud environment is now paused ${!isTitle ? '...' : undefined}`],
+      [!!app && (app.status === 'STOPPED'), () => `Cloud environment is now paused ${(!isTitle ? '...' : '')}`],
       [!!app && (app.status === 'PRESTOPPING'), () => 'Cloud environment is preparing to stop.'],
-      [!!app && (app.status === 'STOPPING'), () => `Cloud environment is pausing. ${!isTitle ? 'This process will take up to a few minutes' : undefined}`],
+      [!!app && (app.status === 'STOPPING'), () => `Cloud environment is pausing. ${!isTitle ? 'This process will take up to a few minutes' : ''}`],
       [!!app && (app.status === 'PRESTARTING'), () => 'Cloud environment is preparing to start.'],
-      [!!app && (app.status === 'STARTING'), () => `Cloud environment is starting. ${!isTitle ? 'This process will take up to a few minutes' : undefined}`],
-      [!!app && (app.status === 'ERROR'), () => `An error has occurred on your Cloud Environment. ${!isTitle ? 'Your cloud environment has returned an error. You will not be able to launch the app' : undefined}`],
+      [!!app && (app.status === 'STARTING'), () => `Cloud environment is starting. ${!isTitle ? 'This process will take up to a few minutes' : ''}`],
+      [!!app && (app.status === 'ERROR'), () => `An error has occurred on your Cloud Environment. ${!isTitle ? 'This process will take up to a few minutes' : ''}`],
       () => isTitle ? 'Cloud environment' : `Environment ${app ? 'consists' : 'will consist'} of an application and cloud compute.`
     )
   }

--- a/src/components/NewGalaxyModal.js
+++ b/src/components/NewGalaxyModal.js
@@ -52,9 +52,19 @@ export const NewGalaxyModal = _.flow(
 
   const pauseGalaxy = _.flow(
     Utils.withBusyState(setLoading),
-    withErrorReporting('Error deleting galaxy instance')
+    withErrorReporting('Error stopping galaxy instance')
   )(async () => {
+    await Ajax().Apps.app(app.googleProject, app.appName).pause()
     Ajax().Metrics.captureEvent(Events.applicationPause, { app: 'Galaxy', ...extractWorkspaceDetails(workspace) })
+    return onSuccess()
+  })
+
+  const resumeGalaxy = _.flow(
+    Utils.withBusyState(setLoading),
+    withErrorReporting('Error starting galaxy instance')
+  )(async () => {
+    await Ajax().Apps.app(app.googleProject, app.appName).resume()
+    Ajax().Metrics.captureEvent(Events.applicationResume, { app: 'Galaxy', ...extractWorkspaceDetails(workspace) })
     return onSuccess()
   })
 
@@ -72,14 +82,14 @@ export const NewGalaxyModal = _.flow(
       ['paused', () => {
         return h(Fragment, [
                            h(ButtonPrimary, { style: { marginRight: 'auto' }, onClick: () => setViewMode('deleteWarn') }, ['Delete']),
-                           h(ButtonSecondary, { style: { marginRight: '1rem' }}, ['Resume'])
+                           h(ButtonSecondary, { style: { marginRight: '1rem' }, onClick: () => { resumeGalaxy(); setViewMode(Utils.DEFAULT);} }, ['Resume'])
                          ])
       }],
       [Utils.DEFAULT, () => {
         return !!app ?
           h(Fragment, [
             h(ButtonSecondary, { style: { marginRight: 'auto' }, onClick: () => setViewMode('deleteWarn') }, ['Delete']),
-            h(ButtonSecondary, { style: { marginRight: '1rem' }, onClick: () => setViewMode('paused')}, ['Pause']),
+            h(ButtonSecondary, { style: { marginRight: '1rem' }, onClick: () => { pauseGalaxy(); setViewMode('paused'); }}, ['Pause']),
             h(ButtonPrimary, { onClick: () => setViewMode('launchWarn') }, ['Launch Galaxy'])
           ]) :
           h(ButtonPrimary, { onClick: () => setViewMode('createWarn') }, ['Next'])

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1179,6 +1179,12 @@ const Apps = signal => ({
           appType
         }
         return fetchLeo(root, _.mergeAll([authOpts(), jsonBody(body), { signal, method: 'POST' }, appIdentifier]))
+      },
+      pause: () => {
+        return fetchLeo(`${root}/stop`, _.mergeAll([authOpts(), { signal, method: 'POST' }, appIdentifier]))
+      },
+      resume: () => {
+        return fetchLeo(`${root}/start`, _.mergeAll([authOpts(), { signal, method: 'POST' }, appIdentifier]))
       }
     }
   }

--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -8,6 +8,7 @@ const eventsList = {
   applicationLaunch: 'application:launch',
   applicationCreate: 'application:create',
   applicationDelete: 'application:delete',
+  applicationPause: 'application:pause',
   cloudEnvironmentConfigOpen: 'cloudEnvironment:config:open',
   cloudEnvironmentCreate: 'cloudEnvironment:create',
   cloudEnvironmentDelete: 'cloudEnvironment:delete',

--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -9,6 +9,7 @@ const eventsList = {
   applicationCreate: 'application:create',
   applicationDelete: 'application:delete',
   applicationPause: 'application:pause',
+  applicationResume: 'application:resume',
   cloudEnvironmentConfigOpen: 'cloudEnvironment:config:open',
   cloudEnvironmentCreate: 'cloudEnvironment:create',
   cloudEnvironmentDelete: 'cloudEnvironment:delete',

--- a/src/libs/runtime-utils.js
+++ b/src/libs/runtime-utils.js
@@ -116,3 +116,7 @@ export const appIsSettingUp = app => {
 export const collapsedRuntimeStatus = runtime => {
   return runtime && (runtime.patchInProgress ? 'LeoReconfiguring' : runtime.status) // NOTE: preserves null vs undefined
 }
+
+export const getAppStatus = app => {
+  return app.status
+}

--- a/src/libs/runtime-utils.js
+++ b/src/libs/runtime-utils.js
@@ -116,7 +116,3 @@ export const appIsSettingUp = app => {
 export const collapsedRuntimeStatus = runtime => {
   return runtime && (runtime.patchInProgress ? 'LeoReconfiguring' : runtime.status) // NOTE: preserves null vs undefined
 }
-
-export const getAppStatus = app => {
-  return app.status
-}


### PR DESCRIPTION
I have added a few new buttons and screens for the New Galaxy Modal. 


First, we have the pause button. This button will stop the app. While it is in the stopping status, there will be a new modal with only a delete button. This modal will tell the user that the cloud environment is stopping and to return once it has stopped


Secondly, we have a resume button. This button will show up on the new Stopped screen of the New Galaxy Modal. It will trigger a start. When the app status is starting, we will display a new Starting modal with only a delete button. This Modal will tell the user to check back once it has started.


I think we should be able to use the 'Starting' workflow for 'Prestarting' (I've seen this status a few times, but can't replicate it consistently). 


I think there were some more changes that Joy wanted, but wanted to show this first draft.



I tested this locally and went through the workflow.


Mocks: https://projects.invisionapp.com/d/main?origin=v7#/console/20834248/438404970/preview?scrollOffset=0