### PR TITLE
Add more details around the user bearer token to the logs for integration test

### DIFF
--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -58,7 +58,7 @@ const createEntityInWorkspace = (page, billingProject, workspaceName, testEntity
 const makeUser = async () => {
   const { email } = await fetchLyle('create')
   const { accessToken: token } = await fetchLyle('token', email)
-
+  console.info(`created a user with token: ${token}`)
   return { email, token }
 }
 
@@ -110,8 +110,9 @@ const deleteRuntimes = _.flow(withSignedInPage, withUserToken)(async ({ page, bi
   console.info(`deleted runtimes: ${deletedRuntimes}`)
 })
 
-const registerUser = withSignedInPage(async ({ page }) => {
+const registerUser = withSignedInPage(async ({ page, token }) => {
   // TODO: make this available to all puppeteer browser windows
+  console.info(`token of user in registerUser(): ${token}`)
   await page.evaluate(() => {
     window.catchErrorResponse = async fn => {
       try {
@@ -119,7 +120,8 @@ const registerUser = withSignedInPage(async ({ page }) => {
       } catch (e) {
         if (e instanceof Response) {
           const text = await e.text()
-          throw new Error(`Failed to Ajax: ${e.url} ${e.status}: ${text}`)
+          const headers = e.headers
+          throw new Error(`Failed to Ajax: ${e.url} authorization header was: ${headers.get('authorization')} and status of: ${e.status}: ${text}`)
         } else {
           throw e
         }

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -19,6 +19,8 @@ const withSignedInPage = fn => async options => {
   }
 }
 
+const clipToken = str => str.toString().substr(-10, 10)
+
 const makeWorkspace = withSignedInPage(async ({ page, billingProject }) => {
   const workspaceName = `test-workspace-${Math.floor(Math.random() * 100000)}`
 
@@ -58,7 +60,7 @@ const createEntityInWorkspace = (page, billingProject, workspaceName, testEntity
 const makeUser = async () => {
   const { email } = await fetchLyle('create')
   const { accessToken: token } = await fetchLyle('token', email)
-  console.info(`created a user with token: ...${token.toString().substr(-10, 10)}`)
+  console.info(`created a user with token: ...${clipToken(token)}`)
   return { email, token }
 }
 
@@ -112,7 +114,7 @@ const deleteRuntimes = _.flow(withSignedInPage, withUserToken)(async ({ page, bi
 
 const registerUser = withSignedInPage(async ({ page, token }) => {
   // TODO: make this available to all puppeteer browser windows
-  console.info(`token of user in registerUser(): ...${token.toString().substr(-10, 10)}`)
+  console.info(`token of user in registerUser(): ...${clipToken(token)}`)
   await page.evaluate(() => {
     window.catchErrorResponse = async fn => {
       try {
@@ -121,7 +123,7 @@ const registerUser = withSignedInPage(async ({ page, token }) => {
         if (e instanceof Response) {
           const text = await e.text()
           const headers = e.headers
-          const headerAuthToken = headers.get('authorization') ? `...${headers.get('authorization').toString().substr(-10, 10)}` : headers.get('authorization')
+          const headerAuthToken = headers.get('authorization') ? `...${clipToken(headers.get('authorization').toString())}` : headers.get('authorization')
           throw new Error(`Failed to Ajax: ${e.url} authorization header was: ${headerAuthToken} and status of: ${e.status}: ${text}`)
         } else {
           throw e

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -58,7 +58,7 @@ const createEntityInWorkspace = (page, billingProject, workspaceName, testEntity
 const makeUser = async () => {
   const { email } = await fetchLyle('create')
   const { accessToken: token } = await fetchLyle('token', email)
-  console.info(`created a user with token: ${token}`)
+  console.info(`created a user with token: ...${token.toString().substr(-10, 10)}`)
   return { email, token }
 }
 
@@ -112,7 +112,7 @@ const deleteRuntimes = _.flow(withSignedInPage, withUserToken)(async ({ page, bi
 
 const registerUser = withSignedInPage(async ({ page, token }) => {
   // TODO: make this available to all puppeteer browser windows
-  console.info(`token of user in registerUser(): ${token}`)
+  console.info(`token of user in registerUser(): ...${token.toString().substr(-10, 10)}`)
   await page.evaluate(() => {
     window.catchErrorResponse = async fn => {
       try {
@@ -121,7 +121,8 @@ const registerUser = withSignedInPage(async ({ page, token }) => {
         if (e instanceof Response) {
           const text = await e.text()
           const headers = e.headers
-          throw new Error(`Failed to Ajax: ${e.url} authorization header was: ${headers.get('authorization')} and status of: ${e.status}: ${text}`)
+          const headerAuthToken = headers.get('authorization') ? `...${headers.get('authorization').toString().substr(-10, 10)}` : headers.get('authorization')
+          throw new Error(`Failed to Ajax: ${e.url} authorization header was: ${headerAuthToken} and status of: ${e.status}: ${text}`)
         } else {
           throw e
         }


### PR DESCRIPTION
I can get the same error we are seeing in the nightly test runs here: `https://firecloud-orchestration.dsde-alpha.broadinstitute.org/#/Profile/getAll` if I try to execute the request without authorizing/logging in. Looking at the request header there is no authorization in the request header. However once I log in I do see the auth in the request. 

I am hoping to use these added logs to see if the authorization header is there and is the correct token in the test.
