### PR TITLE
AS-556: add data format to mixpanel workspace:data:import event [risk: no]

### DIFF
--- a/src/pages/ImportData.js
+++ b/src/pages/ImportData.js
@@ -115,7 +115,7 @@ const ImportData = () => {
         notify('success', 'Data imported successfully.', { timeout: 3000 })
       }]
     )
-    Ajax().Metrics.captureEvent(Events.workspaceDataImport, { ...extractWorkspaceDetails({ workspace }) })
+    Ajax().Metrics.captureEvent(Events.workspaceDataImport, { format: format, ...extractWorkspaceDetails({ workspace }) })
     Nav.goToPath('workspace-data', { namespace, name })
   })
 

--- a/src/pages/ImportData.js
+++ b/src/pages/ImportData.js
@@ -115,7 +115,7 @@ const ImportData = () => {
         notify('success', 'Data imported successfully.', { timeout: 3000 })
       }]
     )
-    Ajax().Metrics.captureEvent(Events.workspaceDataImport, { format: format, ...extractWorkspaceDetails({ workspace }) })
+    Ajax().Metrics.captureEvent(Events.workspaceDataImport, { format, ...extractWorkspaceDetails({ workspace }) })
     Nav.goToPath('workspace-data', { namespace, name })
   })
 


### PR DESCRIPTION
This is a small part of AS-556 but does not complete that ticket.

PR to gather feedback.  My goal is to 1) start understanding mixpanel, and 2) improve how mixpanel tracks data imports by including the format for the user's import, e.g. "snapshot" vs. "pfb".

Reviewers: is this all I'd have to do to add a property to this mixpanel event? I have not updated the lexicon in mixpanel itself, but I would do so before merging this PR, assuming this PR is safe to merge.

I have not tested this in the app, I only tested syntax via chrome console.
