### PR TITLE
Reprioritize the "this will launch X analyses" counter [BW-487]

### DIFF
--- a/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
+++ b/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
@@ -101,6 +101,16 @@ const LaunchAnalysisModal = ({
       h(ButtonPrimary, { onClick: onDismiss }, ['OK'])
   }, [
     div({ style: { margin: '1rem 0' } }, ['This analysis will be run by ', h(CromwellVersionLink), '.']),
+    div(['Output files will be saved as workspace data in:']),
+    div({ style: { margin: '1rem' } }, [
+      location ? h(Fragment, [span({ style: { marginRight: '0.5rem' } }, [flag]),
+        span({ style: { marginRight: '0.5rem' } }, [regionDescription]),
+        h(InfoBox, [
+          p(['Output (and intermediate) files will be written to your workspace bucket in this region.']),
+          p(['Tasks within your workflow might additionally move or copy the data elsewhere. You should carefully vet the workflows you run if region requirements are a concern.']),
+          p(['Note that metadata about this run will be stored in the US.'])
+        ])]) : 'Loading...'
+    ]),
     div({ style: { margin: '1rem 0' } }, [
       'This will launch ', b([entityCount]), ` analys${entityCount === 1 ? 'is' : 'es'}`,
       '.',
@@ -114,16 +124,6 @@ const LaunchAnalysisModal = ({
     ]),
     div({ style: { color: colors.danger(), overflowWrap: 'break-word' } }, [
       h(Fragment, wrappableOnPeriods(launchError))
-    ]),
-    div(['Output files will be saved as workspace data in:']),
-    div({ style: { margin: '1rem' } }, [
-      location ? h(Fragment, [span({ style: { marginRight: '0.5rem' } }, [flag]),
-        span({ style: { marginRight: '0.5rem' } }, [regionDescription]),
-        h(InfoBox, [
-          p(['Output (and intermediate) files will be written to your workspace bucket in this region.']),
-          p(['Tasks within your workflow might additionally move or copy the data elsewhere. You should carefully vet the workflows you run if region requirements are a concern.']),
-          p(['Note that metadata about this run will be stored in the US.'])
-        ])]) : 'Loading...'
     ])
   ])
 }


### PR DESCRIPTION
Re-prioritizes the "this will launch X analyses" counter by putting it right before the `Launch` button again (instead of hidden amongst the other text).

In personal experience, I found myself regularly submitting too many analyses because this warning was not as visible as it used to be.

### Testing

Tested against the workflow launch modal for: http://localhost:3000/#workspaces/testing-job-manager/lots_of_workflows/workflows/dumbledore_methods/preemptibles_echo_two_strings

#### Before

![image](https://user-images.githubusercontent.com/13006282/104760702-c2e81080-572f-11eb-9663-b48e3716ef27.png)

#### After

![image](https://user-images.githubusercontent.com/13006282/104760683-b499f480-572f-11eb-923d-a871c3b8092a.png)
