### PR TITLE
[IA-2334] Account for preemptible disk in running compute cost

### DIFF
--- a/src/libs/runtime-utils.js
+++ b/src/libs/runtime-utils.js
@@ -40,13 +40,14 @@ export const findMachineType = name => {
 }
 
 export const runtimeConfigCost = config => {
-  const { masterMachineType, numberOfWorkers, numberOfPreemptibleWorkers, workerMachineType } = normalizeRuntimeConfig(config)
+  const { masterMachineType, numberOfWorkers, numberOfPreemptibleWorkers, workerMachineType, workerDiskSize } = normalizeRuntimeConfig(config)
   const { price: masterPrice } = findMachineType(masterMachineType)
   const { price: workerPrice, preemptiblePrice } = findMachineType(workerMachineType)
   return _.sum([
     masterPrice,
     numberOfWorkers * workerPrice,
     numberOfPreemptibleWorkers * preemptiblePrice,
+    numberOfPreemptibleWorkers * workerDiskSize * storagePrice,
     runtimeConfigBaseCost(config)
   ])
 }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2334

Preemptible workers incur disk costs while they are running, but not while they are paused. This PR adds preemptible storage to the 'running' cost calculation function. Note Leo sets preemptible disk size equal to worker disk size.

Tested locally side by side with dev, verified I saw the increased cost with preemptibles in this branch.

<!--
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Thanks!
--!>
