### PR TITLE
[IA-2478] Account for Dataproc pricing for pre-emptibles

### DIFF
--- a/src/libs/runtime-utils.js
+++ b/src/libs/runtime-utils.js
@@ -6,7 +6,10 @@ export const DEFAULT_DISK_SIZE = 50
 
 export const usableStatuses = ['Updating', 'Running']
 
-export const normalizeRuntimeConfig = ({ cloudService, machineType, diskSize, masterMachineType, masterDiskSize, numberOfWorkers, numberOfPreemptibleWorkers, workerMachineType, workerDiskSize, bootDiskSize }) => {
+export const normalizeRuntimeConfig = ({
+  cloudService, machineType, diskSize, masterMachineType, masterDiskSize, numberOfWorkers,
+  numberOfPreemptibleWorkers, workerMachineType, workerDiskSize, bootDiskSize
+}) => {
   const isDataproc = cloudService === cloudServices.DATAPROC
 
   return {
@@ -23,7 +26,9 @@ export const normalizeRuntimeConfig = ({ cloudService, machineType, diskSize, ma
 }
 
 export const runtimeConfigBaseCost = config => {
-  const { cloudService, masterMachineType, masterDiskSize, numberOfWorkers, workerMachineType, workerDiskSize, bootDiskSize } = normalizeRuntimeConfig(
+  const {
+    cloudService, masterMachineType, masterDiskSize, numberOfWorkers, workerMachineType, workerDiskSize, bootDiskSize
+  } = normalizeRuntimeConfig(
     config)
   const { cpu: masterCpu } = findMachineType(masterMachineType)
   const { cpu: workerCpu } = findMachineType(workerMachineType)
@@ -40,7 +45,8 @@ export const findMachineType = name => {
 }
 
 export const runtimeConfigCost = config => {
-  const { cloudService, masterMachineType, numberOfWorkers, numberOfPreemptibleWorkers, workerMachineType, workerDiskSize } = normalizeRuntimeConfig(config)
+  const { cloudService, masterMachineType, numberOfWorkers, numberOfPreemptibleWorkers, workerMachineType, workerDiskSize } = normalizeRuntimeConfig(
+    config)
   const { price: masterPrice } = findMachineType(masterMachineType)
   const { price: workerPrice, preemptiblePrice } = findMachineType(workerMachineType)
   return _.sum([
@@ -74,7 +80,8 @@ export const runtimeCost = ({ runtimeConfig, status }) => {
 export const getGalaxyCost = app => {
   // numNodes * price per node + diskCost + defaultNodepoolCost
   const defaultNodepoolCost = machineCost('n1-standard-1')
-  const appCost = app.kubernetesRuntimeConfig.numNodes * machineCost(app.kubernetesRuntimeConfig.machineType) + persistentDiskCost({ size: 250 + 10 + 100 + 100, status: 'Running' })
+  const appCost = app.kubernetesRuntimeConfig.numNodes * machineCost(app.kubernetesRuntimeConfig.machineType) +
+    persistentDiskCost({ size: 250 + 10 + 100 + 100, status: 'Running' })
   return appCost + defaultNodepoolCost
   // diskCost: 250Gb for the NFS disk, 10Gb for the postgres disk, and 200Gb for boot disks (1 boot disk per nodepool)
   // to do: retrieve the disk sizes from the app not just hardcode them

--- a/src/libs/runtime-utils.js
+++ b/src/libs/runtime-utils.js
@@ -48,8 +48,7 @@ export const runtimeConfigCost = config => {
   const { cloudService, masterMachineType, numberOfWorkers, numberOfPreemptibleWorkers, workerMachineType, workerDiskSize } = normalizeRuntimeConfig(
     config)
   const { price: masterPrice } = findMachineType(masterMachineType)
-  const { price: workerPrice, preemptiblePrice } = findMachineType(workerMachineType)
-  const { cpu: workerCpu } = findMachineType(workerMachineType)
+  const { price: workerPrice, preemptiblePrice, cpu: workerCpu } = findMachineType(workerMachineType)
   return _.sum([
     masterPrice,
     numberOfWorkers * workerPrice,

--- a/src/libs/runtime-utils.js
+++ b/src/libs/runtime-utils.js
@@ -40,7 +40,7 @@ export const findMachineType = name => {
 }
 
 export const runtimeConfigCost = config => {
-  const { masterMachineType, numberOfWorkers, numberOfPreemptibleWorkers, workerMachineType, workerDiskSize } = normalizeRuntimeConfig(config)
+  const { cloudService, masterMachineType, numberOfWorkers, numberOfPreemptibleWorkers, workerMachineType, workerDiskSize } = normalizeRuntimeConfig(config)
   const { price: masterPrice } = findMachineType(masterMachineType)
   const { price: workerPrice, preemptiblePrice } = findMachineType(workerMachineType)
   return _.sum([
@@ -48,6 +48,7 @@ export const runtimeConfigCost = config => {
     numberOfWorkers * workerPrice,
     numberOfPreemptibleWorkers * preemptiblePrice,
     numberOfPreemptibleWorkers * workerDiskSize * storagePrice,
+    cloudService === cloudServices.DATAPROC && numberOfPreemptibleWorkers * dataprocCpuPrice,
     runtimeConfigBaseCost(config)
   ])
 }

--- a/src/libs/runtime-utils.js
+++ b/src/libs/runtime-utils.js
@@ -49,6 +49,7 @@ export const runtimeConfigCost = config => {
     config)
   const { price: masterPrice } = findMachineType(masterMachineType)
   const { price: workerPrice, preemptiblePrice } = findMachineType(workerMachineType)
+  const { cpu: workerCpu } = findMachineType(workerMachineType)
   return _.sum([
     masterPrice,
     numberOfWorkers * workerPrice,

--- a/src/libs/runtime-utils.js
+++ b/src/libs/runtime-utils.js
@@ -48,7 +48,7 @@ export const runtimeConfigCost = config => {
     numberOfWorkers * workerPrice,
     numberOfPreemptibleWorkers * preemptiblePrice,
     numberOfPreemptibleWorkers * workerDiskSize * storagePrice,
-    cloudService === cloudServices.DATAPROC && numberOfPreemptibleWorkers * dataprocCpuPrice,
+    cloudService === cloudServices.DATAPROC && numberOfPreemptibleWorkers * workerCpu * dataprocCpuPrice,
     runtimeConfigBaseCost(config)
   ])
 }


### PR DESCRIPTION
[JIRA ticket](https://broadworkbench.atlassian.net/browse/IA-2478)

Account for Dataproc premium for pre-emptibles when the cluster is running per [Google's pricing example](https://cloud.google.com/dataproc/pricing#pricing_example). Note that the aforementioned premium is separate from and charged in addition to any GCE and storage costs (which are correctly calculated as is). Since we remove pre-emptibles prior to stopping a Dataproc cluster, the cost addition only applies to clusters that are in _running_ state.

Tested manually on a local UI.