### PR TITLE
[IA-2410] Update Leo calls with workspace v2 parameters.

### DIFF
--- a/src/components/NewRuntimeModal.js
+++ b/src/components/NewRuntimeModal.js
@@ -118,7 +118,7 @@ export const NewRuntimeModal = withModalDrawer({ width: 675 })(class NewRuntimeM
   static propTypes = {
     runtimes: PropTypes.array,
     persistentDisks: PropTypes.array,
-    namespace: PropTypes.string.isRequired,
+    workspace: PropTypes.object.isRequired,
     onDismiss: PropTypes.func.isRequired,
     onSuccess: PropTypes.func.isRequired
   }
@@ -155,9 +155,8 @@ export const NewRuntimeModal = withModalDrawer({ width: 675 })(class NewRuntimeM
     }
   }
 
-  makeWorkspaceObj() {
-    const { namespace, name } = this.props
-    return { workspace: { namespace, name } }
+  getWorkspaceObj() {
+    return this.props.workspace.workspace
   }
 
   getCurrentRuntime() {
@@ -227,7 +226,7 @@ export const NewRuntimeModal = withModalDrawer({ width: 675 })(class NewRuntimeM
     )
 
     Ajax().Metrics.captureEvent(Events[metricsEvent], {
-      ...extractWorkspaceDetails(this.makeWorkspaceObj()),
+      ...extractWorkspaceDetails(this.getWorkspaceObj()),
       ..._.mapKeys(key => `newRuntime_${key}`, newRuntime),
       newRuntime_exists: !!newRuntime,
       newRuntime_cpus: newRuntime && newRuntimeCpus,
@@ -249,7 +248,7 @@ export const NewRuntimeModal = withModalDrawer({ width: 675 })(class NewRuntimeM
     Utils.withBusyState(() => this.setState({ loading: true })),
     withErrorReporting('Error creating cloud environment')
   )(async () => {
-    const { onSuccess, namespace } = this.props
+    const { onSuccess } = this.props
     const { currentRuntimeDetails, currentPersistentDiskDetails } = this.state
     const { runtime: oldRuntime, persistentDisk: oldPersistentDisk } = this.getOldEnvironmentConfig()
     const { runtime: newRuntime, persistentDisk: newPersistentDisk } = this.getNewEnvironmentConfig()
@@ -258,6 +257,7 @@ export const NewRuntimeModal = withModalDrawer({ width: 675 })(class NewRuntimeM
     const shouldUpdateRuntime = this.canUpdateRuntime() && !_.isEqual(newRuntime, oldRuntime)
     const shouldDeleteRuntime = oldRuntime && !this.canUpdateRuntime()
     const shouldCreateRuntime = !this.canUpdateRuntime() && newRuntime
+    const { name, bucketName, googleProject } = this.getWorkspaceObj()
 
     const runtimeConfig = newRuntime && {
       cloudService: newRuntime.cloudService,
@@ -270,7 +270,8 @@ export const NewRuntimeModal = withModalDrawer({ width: 675 })(class NewRuntimeM
             name: currentPersistentDiskDetails.name
           } : {
             name: Utils.generatePersistentDiskName(),
-            size: newPersistentDisk.size
+            size: newPersistentDisk.size,
+            labels: { workspaceName: name }
           }
         })
       } : {
@@ -285,24 +286,32 @@ export const NewRuntimeModal = withModalDrawer({ width: 675 })(class NewRuntimeM
       })
     }
 
+    const customEnvVars = {
+      WORKSPACE_NAME: name,
+      WORKSPACE_BUCKET: `gs://${bucketName}`,
+      GOOGLE_PROJECT: googleProject
+    }
+
     this.sendCloudEnvironmentMetrics()
 
     if (shouldDeleteRuntime) {
-      await Ajax().Runtimes.runtime(namespace, currentRuntimeDetails.runtimeName).delete(this.hasAttachedDisk() && shouldDeletePersistentDisk)
+      await Ajax().Runtimes.runtime(googleProject, currentRuntimeDetails.runtimeName).delete(this.hasAttachedDisk() && shouldDeletePersistentDisk)
     }
     if (shouldDeletePersistentDisk && !this.hasAttachedDisk()) {
-      await Ajax().Disks.disk(namespace, currentPersistentDiskDetails.name).delete()
+      await Ajax().Disks.disk(googleProject, currentPersistentDiskDetails.name).delete()
     }
     if (shouldUpdatePersistentDisk) {
-      await Ajax().Disks.disk(namespace, currentPersistentDiskDetails.name).update(newPersistentDisk.size)
+      await Ajax().Disks.disk(googleProject, currentPersistentDiskDetails.name).update(newPersistentDisk.size)
     }
     if (shouldUpdateRuntime) {
-      await Ajax().Runtimes.runtime(namespace, currentRuntimeDetails.runtimeName).update({ runtimeConfig })
+      await Ajax().Runtimes.runtime(googleProject, currentRuntimeDetails.runtimeName).update({ runtimeConfig })
     }
     if (shouldCreateRuntime) {
-      await Ajax().Runtimes.runtime(namespace, Utils.generateRuntimeName()).create({
+      await Ajax().Runtimes.runtime(googleProject, Utils.generateRuntimeName()).create({
         runtimeConfig,
         toolDockerImage: newRuntime.toolDockerImage,
+        labels: { workspaceName: name },
+        customEnvironmentVariables: customEnvVars,
         ...(newRuntime.jupyterUserScriptUri ? { jupyterUserScriptUri: newRuntime.jupyterUserScriptUri } : {})
       })
     }
@@ -460,16 +469,16 @@ export const NewRuntimeModal = withModalDrawer({ width: 675 })(class NewRuntimeM
     withErrorReporting('Error loading cloud environment'),
     Utils.withBusyState(v => this.setState({ loading: v }))
   )(async () => {
-    const { namespace } = this.props
+    const { googleProject } = this.getWorkspaceObj()
     const currentRuntime = this.getCurrentRuntime()
     const currentPersistentDisk = this.getCurrentPersistentDisk()
 
     Ajax().Metrics.captureEvent(Events.cloudEnvironmentConfigOpen, {
-      existingConfig: !!currentRuntime, ...extractWorkspaceDetails(this.makeWorkspaceObj())
+      existingConfig: !!currentRuntime, ...extractWorkspaceDetails(this.getWorkspaceObj())
     })
     const [currentRuntimeDetails, newLeoImages, currentPersistentDiskDetails] = await Promise.all([
       currentRuntime ? Ajax().Runtimes.runtime(currentRuntime.googleProject, currentRuntime.runtimeName).details() : null,
-      Ajax().Buckets.getObjectPreview('terra-docker-image-documentation', 'terra-docker-versions.json', namespace, true).then(res => res.json()),
+      Ajax().Buckets.getObjectPreview('terra-docker-image-documentation', 'terra-docker-versions.json', googleProject, true).then(res => res.json()),
       currentPersistentDisk ? Ajax().Disks.disk(currentPersistentDisk.googleProject, currentPersistentDisk.name).details() : null
     ])
 
@@ -975,7 +984,7 @@ export const NewRuntimeModal = withModalDrawer({ width: 675 })(class NewRuntimeM
     const handleLearnMoreAboutPersistentDisk = () => {
       this.setState({ viewMode: 'aboutPersistentDisk' })
       Ajax().Metrics.captureEvent(Events.aboutPersistentDiskView, {
-        ...extractWorkspaceDetails(this.makeWorkspaceObj()),
+        ...extractWorkspaceDetails(this.getWorkspaceObj()),
         currentlyHasAttachedDisk: !!this.hasAttachedDisk()
       })
     }

--- a/src/components/NewRuntimeModal.js
+++ b/src/components/NewRuntimeModal.js
@@ -271,7 +271,7 @@ export const NewRuntimeModal = withModalDrawer({ width: 675 })(class NewRuntimeM
           } : {
             name: Utils.generatePersistentDiskName(),
             size: newPersistentDisk.size,
-            labels: { workspaceName: name }
+            labels: { saturnWorkspaceName: name }
           }
         })
       } : {
@@ -310,7 +310,7 @@ export const NewRuntimeModal = withModalDrawer({ width: 675 })(class NewRuntimeM
       await Ajax().Runtimes.runtime(googleProject, Utils.generateRuntimeName()).create({
         runtimeConfig,
         toolDockerImage: newRuntime.toolDockerImage,
-        labels: { workspaceName: name },
+        labels: { saturnWorkspaceName: name },
         customEnvironmentVariables: customEnvVars,
         ...(newRuntime.jupyterUserScriptUri ? { jupyterUserScriptUri: newRuntime.jupyterUserScriptUri } : {})
       })

--- a/src/components/RuntimeManager.js
+++ b/src/components/RuntimeManager.js
@@ -351,8 +351,7 @@ export default class RuntimeManager extends PureComponent {
         ])]),
         h(NewRuntimeModal, {
           isOpen: createModalDrawerOpen,
-          namespace,
-          name,
+          workspace,
           runtimes,
           persistentDisks,
           onDismiss: () => this.setState({ createModalDrawerOpen: false }),

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1060,7 +1060,7 @@ const Runtimes = signal => ({
     return fetchLeo(`proxy/setCookie`, _.merge(authOpts(), { signal, credentials: 'include' }))
   },
 
-  runtime: (project, name) => {
+  runtime: (project, name, workspaceName) => {
     const root = `api/google/v1/runtimes/${project}/${name}`
 
     return {
@@ -1168,7 +1168,8 @@ const Apps = signal => ({
           diskConfig: {
             name: diskName,
             labels: {
-              saturnApplication: 'galaxy'
+              saturnApplication: 'galaxy',
+              workspaceName
             }
           },
           customEnvironmentVariables: {

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1060,7 +1060,7 @@ const Runtimes = signal => ({
     return fetchLeo(`proxy/setCookie`, _.merge(authOpts(), { signal, credentials: 'include' }))
   },
 
-  runtime: (project, name, workspaceName) => {
+  runtime: (project, name) => {
     const root = `api/google/v1/runtimes/${project}/${name}`
 
     return {
@@ -1169,7 +1169,7 @@ const Apps = signal => ({
             name: diskName,
             labels: {
               saturnApplication: 'galaxy',
-              workspaceName
+              saturnWorkspaceName: workspaceName
             }
           },
           customEnvironmentVariables: {

--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -27,7 +27,7 @@ const eventsList = {
 }
 
 export const extractWorkspaceDetails = workspaceObject => {
-  const { workspace: { namespace, name } } = workspaceObject
+  const { name, namespace } = workspaceObject
   return { workspaceName: name, workspaceNamespace: namespace }
 }
 

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -348,7 +348,7 @@ const Notebooks = _.flow(
         }, [
           div({ style: { fontSize: 18, lineHeight: '22px', width: 150 } }, [
             div(['Create a']),
-            div(['New Notebook']),
+            div(['New Notebook'] ),
             icon('plus-circle', { style: { marginTop: '0.5rem' }, size: 21 })
           ])
         ]),

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -348,7 +348,7 @@ const Notebooks = _.flow(
         }, [
           div({ style: { fontSize: 18, lineHeight: '22px', width: 150 } }, [
             div(['Create a']),
-            div(['New Notebook'] ),
+            div(['New Notebook']),
             icon('plus-circle', { style: { marginTop: '0.5rem' }, size: 21 })
           ])
         ]),

--- a/src/pages/workspaces/workspace/applications/AppLauncher.js
+++ b/src/pages/workspaces/workspace/applications/AppLauncher.js
@@ -21,7 +21,7 @@ const ApplicationLauncher = _.flow(
     breadcrumbs: props => breadcrumbs.commonPaths.workspaceDashboard(props),
     title: _.get('application')
   })
-)(({ namespace, name, refreshRuntimes, runtimes, persistentDisks, application }, ref) => {
+)(({ namespace, name, refreshRuntimes, runtimes, persistentDisks, application, workspace }, ref) => {
   const cookieReady = Utils.useStore(cookieReadyStore)
   const [showCreate, setShowCreate] = useState(false)
   const [busy, setBusy] = useState(false)
@@ -68,7 +68,9 @@ const ApplicationLauncher = _.flow(
         ]),
         h(NewRuntimeModal, {
           isOpen: showCreate,
-          namespace, name, runtimes, persistentDisks,
+          workspace,
+          runtimes,
+          persistentDisks,
           onDismiss: () => setShowCreate(false),
           onSuccess: _.flow(
             withErrorReporting('Error loading cloud environment'),

--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -42,7 +42,7 @@ const NotebookLauncher = _.flow(
     showTabBar: false
   })
 )(
-  ({ queryParams, notebookName, workspace, workspace: { workspace: { namespace, name, bucketName }, accessLevel, canCompute }, runtimes, persistentDisks, refreshRuntimes },
+  ({ queryParams, notebookName, workspace, accessLevel, canCompute, runtimes, persistentDisks, refreshRuntimes },
     ref) => {
     const [createOpen, setCreateOpen] = useState(false)
     const runtime = currentRuntime(runtimes)

--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -63,7 +63,9 @@ const NotebookLauncher = _.flow(
       mode && h(RuntimeStatusMonitor, { runtime, onRuntimeStoppedRunning: () => chooseMode(undefined) }),
       h(NewRuntimeModal, {
         isOpen: createOpen,
-        namespace, name, runtimes, persistentDisks,
+        workspace,
+        runtimes,
+        persistentDisks,
         onDismiss: () => {
           chooseMode(undefined)
           setCreateOpen(false)

--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -42,7 +42,7 @@ const NotebookLauncher = _.flow(
     showTabBar: false
   })
 )(
-  ({ queryParams, notebookName, workspace, workspace: { workspace: { namespace, name }, accessLevel, canCompute }, runtimes, persistentDisks, refreshRuntimes },
+  ({ queryParams, notebookName, workspace, workspace: { workspace: { namespace, name, bucketName }, accessLevel, canCompute }, runtimes, persistentDisks, refreshRuntimes },
     ref) => {
     const [createOpen, setCreateOpen] = useState(false)
     const runtime = currentRuntime(runtimes)


### PR DESCRIPTION
Tested this locally by running through all the pages effected and checking the leo calls in the network tab.

This ticket details a few different changes which this PR accomplishes: https://broadworkbench.atlassian.net/browse/IA-2410 .

Note that the label and env variables already exist on apps. On app, the label is named something slightly different (`saturnWorkspaceName`, see [here](https://github.com/DataBiosphere/terra-ui/blob/dev/src/libs/ajax.js#L1167)) and it cannot be changed easily because the galaxy app depends on it as is. I'm open to changing it here for consistency, but I did what was in the acceptance criteria for now.