### PR TITLE
Personal Hackathon Part 2: Cache miss debug wizard link on CacheMiss'd calls [BW-508]

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -130,7 +130,6 @@ const fetchSam = _.flow(withUrlPrefix(`${getConfig().samUrlRoot}/`), withAppIden
 const fetchBuckets = _.flow(withRequesterPays, withUrlPrefix('https://storage.googleapis.com/'))(fetchOk)
 const fetchGoogleBilling = withUrlPrefix('https://cloudbilling.googleapis.com/v1/', fetchOk)
 const fetchRawls = _.flow(withUrlPrefix(`${getConfig().rawlsUrlRoot}/api/`), withAppIdentifier)(fetchOk)
-const fetchCromIAM = _.flow(withUrlPrefix(`${getConfig().orchestrationUrlRoot}/api/`), withAppIdentifier)(fetchOk)
 const fetchDataRepo = withUrlPrefix(`${getConfig().dataRepoUrlRoot}/api/`, fetchOk)
 const fetchLeo = withUrlPrefix(`${getConfig().leoUrlRoot}/`, fetchOk)
 const fetchDockstore = withUrlPrefix(`${getConfig().dockstoreUrlRoot}/api/`, fetchOk)
@@ -502,7 +501,10 @@ const attributesUpdateOps = _.flow(
 )
 
 const CromIAM = signal => ({
-  callCacheDiff: async (thisWorkflowId, thisCallFqn, thisIndex, thatWorkflowId, thatCallFqn, thatIndex) => {
+  callCacheDiff: async (thisWorkflow, thatWorkflow) => {
+    const { workflowId: thisWorkflowId, callFqn: thisCallFqn, index: thisIndex } = thisWorkflow
+    const { workflowId: thatWorkflowId, callFqn: thatCallFqn, index: thatIndex } = thatWorkflow
+
     const params = {
       workflowA: thisWorkflowId,
       callA: thisCallFqn,
@@ -511,12 +513,12 @@ const CromIAM = signal => ({
       callB: thatCallFqn,
       indexB: (thatIndex !== -1) ? thatIndex : undefined
     }
-    const res = await fetchCromIAM(`workflows/v1/callcaching/diff?${qs.stringify(params)}`, _.merge(authOpts(), { signal }))
+    const res = await fetchOrchestration(`api/workflows/v1/callcaching/diff?${qs.stringify(params)}`, _.merge(authOpts(), { signal }))
     return res.json()
   },
 
   workflowMetadata: async (workflowId, includeKey, excludeKey) => {
-    const res = await fetchCromIAM(`workflows/v1/${workflowId}/metadata?${qs.stringify({ includeKey, excludeKey }, { arrayFormat: 'repeat' })}`, _.merge(authOpts(), { signal }))
+    const res = await fetchOrchestration(`api/workflows/v1/${workflowId}/metadata?${qs.stringify({ includeKey, excludeKey }, { arrayFormat: 'repeat' })}`, _.merge(authOpts(), { signal }))
     return res.json()
   }
 })

--- a/src/libs/icon-dict.js
+++ b/src/libs/icon-dict.js
@@ -2,7 +2,7 @@ import { faClipboard, faClock, faClone, faEye, faFileAlt, faFolder, faFolderOpen
 import {
   faArrowLeft, faArrowRight, faBan, faCaretDown, faChalkboard, faCheck, faCheckCircle, faCircle, faCloud, faCog, faCreditCard, faDownload,
   faEllipsisV, faExclamationCircle, faExclamationTriangle, faFileInvoiceDollar, faGripHorizontal, faInfoCircle, faLock, faLongArrowAltDown,
-  faLongArrowAltUp, faMagic, faMinusCircle, faPause, faPen, faPlay, faPlus, faPlusCircle, faQuestion, faQuestionCircle, faSearch, faShareAlt, faSquare as faSquareSolid,
+  faLongArrowAltUp, faMinusCircle, faPause, faPen, faPlay, faPlus, faPlusCircle, faQuestion, faQuestionCircle, faSearch, faShareAlt, faSquare as faSquareSolid,
   faTachometerAlt, faTasks, faTerminal, faTrashAlt, faVirus
 } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -81,7 +81,6 @@ const iconDict = {
   lock: fa(faLock),
   'long-arrow-alt-down': fa(faLongArrowAltDown),
   'long-arrow-alt-up': fa(faLongArrowAltUp),
-  magic: fa(faMagic),
   'minus-circle': fa(faMinusCircle),
   pause: fa(faPause),
   play: fa(faPlay),

--- a/src/libs/icon-dict.js
+++ b/src/libs/icon-dict.js
@@ -2,7 +2,7 @@ import { faClipboard, faClock, faClone, faEye, faFileAlt, faFolder, faFolderOpen
 import {
   faArrowLeft, faArrowRight, faBan, faCaretDown, faChalkboard, faCheck, faCheckCircle, faCircle, faCloud, faCog, faCreditCard, faDownload,
   faEllipsisV, faExclamationCircle, faExclamationTriangle, faFileInvoiceDollar, faGripHorizontal, faInfoCircle, faLock, faLongArrowAltDown,
-  faLongArrowAltUp, faMinusCircle, faPause, faPen, faPlay, faPlus, faPlusCircle, faQuestion, faQuestionCircle, faSearch, faShareAlt, faSquare as faSquareSolid,
+  faLongArrowAltUp, faMagic, faMinusCircle, faPause, faPen, faPlay, faPlus, faPlusCircle, faQuestion, faQuestionCircle, faSearch, faShareAlt, faSquare as faSquareSolid,
   faTachometerAlt, faTasks, faTerminal, faTrashAlt, faVirus
 } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -81,6 +81,7 @@ const iconDict = {
   lock: fa(faLock),
   'long-arrow-alt-down': fa(faLongArrowAltDown),
   'long-arrow-alt-up': fa(faLongArrowAltUp),
+  magic: fa(faMagic),
   'minus-circle': fa(faMinusCircle),
   pause: fa(faPause),
   play: fa(faPlay),

--- a/src/pages/workspaces/workspace/jobHistory/CallCacheWizard.js
+++ b/src/pages/workspaces/workspace/jobHistory/CallCacheWizard.js
@@ -1,0 +1,263 @@
+import _ from 'lodash/fp'
+import { Fragment, useState } from 'react'
+import { div, h, hr } from 'react-hyperscript-helpers'
+import ReactJson from 'react-json-view'
+import Select from 'react-select'
+import { ButtonPrimary, ButtonSecondary } from 'src/components/common'
+import ErrorView from 'src/components/ErrorView'
+import { TextInput } from 'src/components/input'
+import { breadcrumbHistoryCaret } from 'src/components/job-common'
+import Modal from 'src/components/Modal'
+import { Ajax } from 'src/libs/ajax'
+import * as Style from 'src/libs/style'
+import * as Utils from 'src/libs/utils'
+
+
+const CallCacheWizard = ({
+  onDismiss, workflowId, callFqn, attempt, index
+}) => {
+  /*
+   * State setup
+   */
+
+  const [otherWorkflowId, setOtherWorkflowId] = useState()
+  const [otherWorkflowMetadata, setOtherWorkflowMetadata] = useState()
+  const [otherCallFqn, setOtherCallFqn] = useState()
+  const [otherIndex, setOtherIndex] = useState()
+  const [otherAttemptSucceeded, setOtherAttemptSucceeded] = useState()
+  const [otherCallSelected, setOtherCallSelected] = useState(false)
+  const [diff, setDiff] = useState()
+  const [metadataFetchError, setMetadataFetchError] = useState()
+  const [diffError, setDiffError] = useState()
+
+  const signal = Utils.useCancellation()
+
+  /*
+   * Data Fetchers
+   */
+
+  const readCalls = async otherWf => {
+    try {
+      const includeKey = [
+        'end', 'start', 'executionStatus'
+      ]
+      const excludeKey = []
+      // const wf = await Ajax(signal).Workspaces.workspace(otherNs, otherWs).submission(otherSub).getWorkflow(otherWf, includeKey, excludeKey)
+      const wf = await Ajax(signal).CromIAM.workflowMetadata(otherWf, includeKey, excludeKey)
+      setOtherWorkflowMetadata(wf)
+    } catch (error) {
+      console.log(error)
+      if (error instanceof Response) setMetadataFetchError(await error.text())
+      else if (_.isObject(error)) setMetadataFetchError(JSON.stringify(error))
+      else setMetadataFetchError(error)
+    }
+  }
+
+  const fetchDiff = async (otherWf, otherCall, otherIx) => {
+    try {
+      const diff = await Ajax(signal).CromIAM.callCacheDiff(workflowId, callFqn, Number(index), otherWf, otherCall, Number(otherIx))
+      setDiff(diff)
+    } catch (error) {
+      console.log(error)
+      if (error instanceof Response) setDiffError(await error.text())
+      else if (_.isObject(error)) setDiffError(JSON.stringify(error))
+      else setDiffError(error)
+    }
+  }
+
+  const otherCallFqnSelectionOptions = _.flow(
+    _.keys,
+    _.map(name => { return { value: name, label: name } })
+  )
+
+  const resetDiffResult = () => {
+    setDiff(undefined)
+    setDiffError(undefined)
+  }
+
+  const resetCallSelection = () => {
+    resetDiffResult()
+    setOtherCallFqn(undefined)
+    setOtherIndex(undefined)
+    setOtherAttemptSucceeded(undefined)
+    setOtherCallSelected(false)
+  }
+
+  const resetWorkflowSelection = () => {
+    resetCallSelection()
+    setOtherWorkflowId(undefined)
+    setMetadataFetchError(undefined)
+  }
+
+  /*
+   * Page render
+   */
+
+  const divider = hr({ style: { width: '100%', border: '1px ridge lightgray' } })
+
+  const step1 = () => {
+    return h(Fragment, [
+      div({ style: { paddingTop: '0.5rem', fontSize: 16, fontWeight: 500, ...Style.noWrapEllipsis } }, ['Step 1: Select the workflow you expected to cache from']),
+      div({ style: { marginTop: '0.5rem', marginBottom: '1rem', display: 'flex', flexDirection: 'row', alignItems: 'center' } }, [
+        div({ style: { paddingRight: '0.5rem' } }, ['Workflow ID:']),
+        div({ style: { paddingRight: '0.5rem', flex: '2 1 auto' } }, [h(TextInput, { style: Style.codeFont, id: 'otherWorkflowId' })]),
+        div([h(ButtonPrimary, {
+          style: { float: 'right' },
+          onClick: () => {
+            const otherWf = document.getElementById('otherWorkflowId').value
+            setOtherWorkflowId(otherWf)
+            readCalls(otherWf)
+          }
+        }, ['Continue >'])])
+      ]),
+      divider,
+      div({ style: { paddingTop: '0.5rem', fontSize: 16, fontWeight: 500, color: 'lightgray', ...Style.noWrapEllipsis } }, ['Step 2: Select the call you expected to cache from']),
+      divider,
+      div({ style: { paddingTop: '0.5rem', fontSize: 16, fontWeight: 500, color: 'lightgray', ...Style.noWrapEllipsis } }, ['Result: View cache diff'])
+    ])
+  }
+  const step2 = () => {
+    const otherCallIndexSelector = (metadata, fqn) => {
+      const shards = _.flow(
+        _.map(c => Number(c.shardIndex)),
+        _.uniq
+      )(metadata.calls[fqn])
+
+      if (shards.length === 1) {
+        if (otherIndex !== shards[0]) { setOtherIndex(shards[0]) }
+        if (shards[0] === -1) {
+          return 'N/A (this call was not scattered)'
+        } else {
+          return `${shards[0]} (exactly one shard in the scatter)`
+        }
+      } else {
+        const shardOptions = _.map(i => { return { value: i, label: i } }).apply(shards)
+        return h(Select, { id: 'otherCallIndex', options: shardOptions, onChange: i => setOtherIndex(i) })
+      }
+    }
+
+    const otherCallAttemptDecision = (metadata, fqn, index) => {
+      const successfulAttempt = _.flow(
+        _.filter(c => c.shardIndex === index && c.executionStatus === 'Done'),
+        _.map(c => c.attempt),
+        _.first
+      )(metadata.calls[fqn])
+
+      if (otherAttemptSucceeded !== successfulAttempt) setOtherAttemptSucceeded(successfulAttempt)
+
+      if (successfulAttempt) {
+        return `${successfulAttempt} (the first successful attempt of this call)`
+      } else {
+        return 'This index of the call did not succeed'
+      }
+    }
+
+    return h(Fragment, [
+      div({ style: { display: 'flex', alignItems: 'center', fontSize: 16, fontWeight: 500 } }, [
+        div(['Step 1: Selected workflow B: ']),
+        div({ style: { display: 'flex', flexDirection: 'row', alignItems: 'center', flex: '1 1 100px' } }, [
+          div({ style: { marginLeft: '0.5rem', ...Style.noWrapEllipsis, ...Style.codeFont } }, otherWorkflowId)
+        ]),
+        h(ButtonSecondary, { style: { paddingLeft: '1rem', height: '20px', color: 'darkred', justifyContent: 'right' }, onClick: () => resetWorkflowSelection() }, ['[X]'])
+      ]),
+      metadataFetchError && h(ErrorView, { error: metadataFetchError }),
+      divider,
+      div({ style: { paddingTop: '0.5rem', fontSize: 16, fontWeight: 500, ...Style.noWrapEllipsis } }, ['Step 2: Select which call in that workflow you expected to cache from']),
+      !metadataFetchError && (otherWorkflowMetadata ?
+        div([
+          div({ style: { marginTop: '1rem', display: 'flex', flexDirection: 'row', alignItems: 'center' } }, [
+            div({ style: { paddingRight: '0.5rem' } }, ['Call FQN:']),
+            div({ style: { paddingRight: '0.5rem', flex: '2 1 auto' } }, [
+              h(Select, { id: 'otherCallFqn', options: otherCallFqnSelectionOptions(otherWorkflowMetadata.calls), onChange: v => setOtherCallFqn(v.value) })
+            ])
+          ]),
+          div({ style: { marginTop: '0.25rem', display: 'flex', flexDirection: 'row', alignItems: 'center' } }, [
+            div({ style: { paddingRight: '0.5rem' } }, ['Shard Index:']),
+            otherCallFqn ?
+              div({ style: { paddingRight: '0.5rem', flex: '2 1 auto' } }, [otherCallIndexSelector(otherWorkflowMetadata, otherCallFqn)]) :
+              'Select a call FQN first'
+          ]),
+          div({ style: { marginTop: '0.25rem', marginBottom: '1rem', display: 'flex', flexDirection: 'row', alignItems: 'center' } }, [
+            div({ style: { paddingRight: '0.5rem' } }, ['Attempt:']),
+            (!!otherCallFqn && otherIndex !== undefined) ?
+              div({ style: { paddingRight: '0.5rem', flex: '2 1 auto' } }, [otherCallAttemptDecision(otherWorkflowMetadata, otherCallFqn, otherIndex)]) :
+              'Select a call FQN and an index first'
+          ]),
+          !!(otherCallFqn && otherIndex !== undefined && otherAttemptSucceeded) && h(ButtonPrimary, { style: { float: 'right' }, onClick: () => { fetchDiff(otherWorkflowId, otherCallFqn, otherIndex); setOtherCallSelected(true) } }, ['Compare Diff >'])
+        ]) :
+        'Loading other workflow calls...'),
+      divider,
+      div({ style: { paddingTop: '0.5rem', fontSize: 16, fontWeight: 500, color: 'lightgray', ...Style.noWrapEllipsis } }, ['Result: View cache diff'])
+    ])
+  }
+
+  const compareDiffs = () => {
+    return h(Fragment, [
+      div({ style: { display: 'flex', alignItems: 'center', fontSize: 16, fontWeight: 500 } }, [
+        div(['Step 1: Selected workflow B: ']),
+        div({ style: { display: 'flex', flexDirection: 'row', alignItems: 'center', flex: '1 1 100px' } }, [
+          div({ style: { marginLeft: '0.5rem', ...Style.noWrapEllipsis, ...Style.codeFont } }, otherWorkflowId)
+        ]),
+        h(ButtonSecondary, { style: { paddingLeft: '1rem', height: '20px', color: 'darkred', justifyContent: 'right' }, onClick: () => resetWorkflowSelection() }, ['[X]'])
+      ]),
+      divider,
+      div({ style: { display: 'flex', flexDirection: 'row', alignItems: 'center', fontSize: 16, fontWeight: 500 } }, [
+        div(['Step 2: Selected call B: ']),
+        div({ style: { display: 'flex', flexDirection: 'row', alignItems: 'center', flex: '1 1 100px' } }, [
+          div({ style: { marginLeft: '0.5rem', ...Style.noWrapEllipsis, ...Style.codeFont } }, otherCallFqn),
+          breadcrumbHistoryCaret,
+          div({ style: { marginLeft: '0.5rem', ...Style.noWrapEllipsis, ...Style.codeFont } }, `index ${otherIndex}`)
+        ]),
+        h(ButtonSecondary, { style: { justifyContent: 'right', paddingLeft: '1rem', height: '20px', color: 'darkred' }, onClick: () => resetCallSelection() }, ['[X]'])
+      ]),
+      divider,
+      div({ style: { display: 'flex', alignItems: 'center', fontSize: 16, fontWeight: 500 } }, ['Result: View cache diff']),
+      diffError ?
+        h(ErrorView, { error: diffError }) :
+        (diff ?
+          [div({ style: { marginTop: '0.5rem', marginBottom: '0.5rem' } }, ['Note: the diff is expressed in terms of hashes of values rather than raw values because it is hashes that determine cache hits.']),
+            h(ReactJson, {
+              style: { whiteSpace: 'pre-wrap', border: 'ridge', padding: '0.5rem' },
+              name: false,
+              shouldCollapse: ({ name }) => { return name === 'callA' || name === 'callB' },
+              enableClipboard: false,
+              displayDataTypes: false,
+              displayObjectSize: false,
+              src: { hashDifferential: diff.hashDifferential, ...diff }
+            })] :
+          'Cache diff loading...')
+    ])
+  }
+
+  const chooseStep = () => {
+    if (!otherWorkflowId) {
+      return step1()
+    } else if (!otherCallSelected) {
+      return step2()
+    } else {
+      return compareDiffs()
+    }
+  }
+
+  return h(Modal, {
+    title: 'Call Cache Debugging Wizard',
+    onDismiss,
+    width: '50%',
+    showButtons: false,
+    showX: true
+  }, [
+    div({ style: { padding: '1rem 2rem 2rem', flex: 1, display: 'flex', flexDirection: 'column' } }, [
+      'Debugging cache miss for call A:',
+      div({ style: { marginTop: '0.5rem', flex: 1, display: 'flex', alignItems: 'center', flexDirection: 'row' } }, [
+        div({ style: { fontSize: 16, fontWeight: 500, ...Style.codeFont } }, [workflowId]), breadcrumbHistoryCaret,
+        div({ style: { fontSize: 16, fontWeight: 500, ...Style.codeFont } }, [callFqn]),
+        Number(index) >= 0 && h(Fragment, [breadcrumbHistoryCaret, 'index', div({ style: { marginLeft: '0.25rem', fontSize: 16, fontWeight: 500, ...Style.codeFont } }, [index])]),
+        Number(attempt) > 1 && h(Fragment, [breadcrumbHistoryCaret, 'attempt', div({ style: { marginLeft: '0.25rem', fontSize: 16, fontWeight: 500, ...Style.codeFont } }, [attempt])])
+      ]),
+      divider,
+      chooseStep()
+    ])
+  ])
+}
+
+export default CallCacheWizard

--- a/src/pages/workspaces/workspace/jobHistory/CallCacheWizard.js
+++ b/src/pages/workspaces/workspace/jobHistory/CallCacheWizard.js
@@ -3,7 +3,7 @@ import { Fragment, useState } from 'react'
 import { div, h, hr, label } from 'react-hyperscript-helpers'
 import ReactJson from 'react-json-view'
 import Select from 'react-select'
-import { ButtonPrimary, ButtonSecondary, IdContainer, Link } from 'src/components/common'
+import { ButtonPrimary, IdContainer, Link } from 'src/components/common'
 import ErrorView from 'src/components/ErrorView'
 import { icon } from 'src/components/icons'
 import { TextInput } from 'src/components/input'
@@ -16,7 +16,7 @@ import * as Utils from 'src/libs/utils'
 
 
 const CallCacheWizard = ({
-  onDismiss, workflowId, callFqn, attempt, index
+  onDismiss, workflowId, callFqn, index
 }) => {
   /*
    * State setup

--- a/src/pages/workspaces/workspace/jobHistory/CallCacheWizard.js
+++ b/src/pages/workspaces/workspace/jobHistory/CallCacheWizard.js
@@ -157,7 +157,7 @@ const CallCacheWizard = ({
         div({ style: { display: 'flex', flexDirection: 'row', alignItems: 'center', flex: '1 1 100px' } }, [
           div({ style: { marginLeft: '0.5rem', ...Style.noWrapEllipsis, ...Style.codeFont } }, otherWorkflowId)
         ]),
-        h(ButtonSecondary, { style: { textTransform: 'none', paddingLeft: '1rem', height: '20px', justifyContent: 'right' }, onClick: () => resetWorkflowSelection() }, ['(reset)'])
+        h(ButtonSecondary, { style: { textTransform: 'none', paddingLeft: '1rem', height: '20px', justifyContent: 'right' }, onClick: () => resetWorkflowSelection() }, ['Reset'])
       ]),
       metadataFetchError && h(ErrorView, { error: metadataFetchError }),
       div({ style: { paddingTop: '0.5rem', fontSize: 16, fontWeight: 500, ...Style.noWrapEllipsis } }, ['Step 2: Select which call in that workflow you expected to cache from']),
@@ -196,7 +196,7 @@ const CallCacheWizard = ({
         div({ style: { display: 'flex', flexDirection: 'row', alignItems: 'center', flex: '1 1 100px' } }, [
           div({ style: { marginLeft: '0.5rem', ...Style.noWrapEllipsis, ...Style.codeFont } }, otherWorkflowId)
         ]),
-        h(ButtonSecondary, { style: { textTransform: 'none', paddingLeft: '1rem', height: '20px', justifyContent: 'right' }, onClick: () => resetWorkflowSelection() }, ['(reset)'])
+        h(ButtonSecondary, { style: { textTransform: 'none', paddingLeft: '1rem', height: '20px', justifyContent: 'right' }, onClick: () => resetWorkflowSelection() }, ['Reset'])
       ]),
       div({ style: { display: 'flex', flexDirection: 'row', alignItems: 'center', fontSize: 16, fontWeight: 500 } }, [
         div(['Selected call B: ']),
@@ -205,7 +205,7 @@ const CallCacheWizard = ({
           breadcrumbHistoryCaret,
           div({ style: { marginLeft: '0.5rem', ...Style.noWrapEllipsis, ...Style.codeFont } }, `index ${otherIndex}`)
         ]),
-        h(ButtonSecondary, { style: { textTransform: 'none', paddingLeft: '1rem', height: '20px', justifyContent: 'right' }, onClick: () => resetCallSelection() }, ['(reset)'])
+        h(ButtonSecondary, { style: { textTransform: 'none', paddingLeft: '1rem', height: '20px', justifyContent: 'right' }, onClick: () => resetCallSelection() }, ['Reset'])
       ]),
       divider,
       div({ style: { display: 'flex', alignItems: 'center', fontSize: 16, fontWeight: 500 } }, ['Result: View cache diff']),

--- a/src/pages/workspaces/workspace/jobHistory/CallCacheWizard.js
+++ b/src/pages/workspaces/workspace/jobHistory/CallCacheWizard.js
@@ -158,11 +158,13 @@ const CallCacheWizard = ({
       div({ style: { paddingTop: '0.5rem', fontSize: 16, fontWeight: 500 } }, ['Step 2: Select which call in that workflow you expected to cache from']),
       otherWorkflowMetadata ?
         div([
-          div({ style: { marginTop: '1rem', display: 'flex', flexDirection: 'row', alignItems: 'center' } }, [h(IdContainer, [id => h(Fragment[
-            label({ htmlFor: id, style: { paddingRight: '0.5rem' } }, ['Call name:']),
-            div({ style: { paddingRight: '0.5rem', flex: '1' } }, [
-              h(Select, { id, isSearchable: false, options: otherCallFqnSelectionOptions(otherWorkflowMetadata.calls), onChange: v => setOtherCallFqnDropdownValue(v.value) })
-            ])])])]),
+          div({ style: { marginTop: '1rem', display: 'flex', flexDirection: 'row', alignItems: 'center' } }, [
+            h(IdContainer, [id => h(Fragment, [
+              label({ htmlFor: id, style: { paddingRight: '0.5rem' } }, ['Call name:']),
+              div({ style: { paddingRight: '0.5rem', flex: '1' } }, [
+                h(Select, { id, isSearchable: false, options: otherCallFqnSelectionOptions(otherWorkflowMetadata.calls), onChange: v => setOtherCallFqnDropdownValue(v.value) })
+              ])])])
+          ]),
           otherCallFqnDropdownValue && div({ style: { marginTop: '0.25rem', display: 'flex', flexDirection: 'row', alignItems: 'center' } }, [
             h(IdContainer, [id => h(Fragment, [
               label({ htmlFor: id, style: { paddingRight: '0.5rem' } }, ['Shard Index:']),
@@ -213,6 +215,11 @@ const CallCacheWizard = ({
           div({ style: { marginTop: '0.5rem', marginBottom: '0.5rem' } },
             [
               'Note: the diff is expressed in terms of hashes of values rather than raw values because it is hashes that determine cache hits.',
+              diff.callB && diff.callB.allowResultReuse === false && div({ style: { marginTop: '0.5rem', marginBottom: '0.5rem'} }, [
+                icon('warning-standard', { size: 24, style: { color: colors.warning(), marginRight: '0.5rem' } }),
+                'Note: call B has allowResultReuse: false, and is ineligible to call cache from.',
+                ' This can sometimes happen if the WDL task has a \'volatile\' marker in its meta section.'
+              ]),
               h(ReactJson, {
                 style: { whiteSpace: 'pre-wrap', border: 'ridge', padding: '0.5rem' },
                 name: false,

--- a/src/pages/workspaces/workspace/jobHistory/CallCacheWizard.js
+++ b/src/pages/workspaces/workspace/jobHistory/CallCacheWizard.js
@@ -110,7 +110,8 @@ const CallCacheWizard = ({
         div({ style: { paddingRight: '0.5rem', flex: '1' } }, [h(TextInput, {
           style: Style.codeFont,
           value: otherWorkflowIdTextboxValue,
-          onChange: setOtherWorkflowIdTextboxValue
+          onChange: setOtherWorkflowIdTextboxValue,
+          id: 'otherWorkflowId'
         })]),
         h(ButtonPrimary, {
           disabled: _.isEmpty(otherWorkflowIdTextboxValue),

--- a/src/pages/workspaces/workspace/jobHistory/CallCacheWizard.js
+++ b/src/pages/workspaces/workspace/jobHistory/CallCacheWizard.js
@@ -42,7 +42,6 @@ const CallCacheWizard = ({
         'end', 'start', 'executionStatus'
       ]
       const excludeKey = []
-      // const wf = await Ajax(signal).Workspaces.workspace(otherNs, otherWs).submission(otherSub).getWorkflow(otherWf, includeKey, excludeKey)
       const wf = await Ajax(signal).CromIAM.workflowMetadata(otherWf, includeKey, excludeKey)
       setOtherWorkflowMetadata(wf)
     } catch (error) {

--- a/src/pages/workspaces/workspace/jobHistory/CallCacheWizard.js
+++ b/src/pages/workspaces/workspace/jobHistory/CallCacheWizard.js
@@ -5,6 +5,7 @@ import ReactJson from 'react-json-view'
 import Select from 'react-select'
 import { ButtonPrimary, ButtonSecondary } from 'src/components/common'
 import ErrorView from 'src/components/ErrorView'
+import { icon } from 'src/components/icons'
 import { TextInput } from 'src/components/input'
 import { breadcrumbHistoryCaret } from 'src/components/job-common'
 import Modal from 'src/components/Modal'
@@ -92,7 +93,7 @@ const CallCacheWizard = ({
    * Page render
    */
 
-  const divider = hr({ style: { width: '100%', border: '1px ridge lightgray' } })
+  const divider = hr({ style: { width: '100%', marginTop: '1rem', marginBottom: '1rem', border: '1px ridge lightgray' } })
 
   const step1 = () => {
     return h(Fragment, [
@@ -109,7 +110,6 @@ const CallCacheWizard = ({
           }
         }, ['Continue >'])])
       ]),
-      divider,
       div({ style: { paddingTop: '0.5rem', fontSize: 16, fontWeight: 500, color: 'lightgray', ...Style.noWrapEllipsis } }, ['Step 2: Select the call you expected to cache from']),
       divider,
       div({ style: { paddingTop: '0.5rem', fontSize: 16, fontWeight: 500, color: 'lightgray', ...Style.noWrapEllipsis } }, ['Result: View cache diff'])
@@ -153,14 +153,13 @@ const CallCacheWizard = ({
 
     return h(Fragment, [
       div({ style: { display: 'flex', alignItems: 'center', fontSize: 16, fontWeight: 500 } }, [
-        div(['Step 1: Selected workflow B: ']),
+        div(['Selected workflow B: ']),
         div({ style: { display: 'flex', flexDirection: 'row', alignItems: 'center', flex: '1 1 100px' } }, [
           div({ style: { marginLeft: '0.5rem', ...Style.noWrapEllipsis, ...Style.codeFont } }, otherWorkflowId)
         ]),
-        h(ButtonSecondary, { style: { paddingLeft: '1rem', height: '20px', color: 'darkred', justifyContent: 'right' }, onClick: () => resetWorkflowSelection() }, ['[X]'])
+        h(ButtonSecondary, { style: { textTransform: 'none', paddingLeft: '1rem', height: '20px', justifyContent: 'right' }, onClick: () => resetWorkflowSelection() }, ['(reset)'])
       ]),
       metadataFetchError && h(ErrorView, { error: metadataFetchError }),
-      divider,
       div({ style: { paddingTop: '0.5rem', fontSize: 16, fontWeight: 500, ...Style.noWrapEllipsis } }, ['Step 2: Select which call in that workflow you expected to cache from']),
       !metadataFetchError && (otherWorkflowMetadata ?
         div([
@@ -192,22 +191,21 @@ const CallCacheWizard = ({
 
   const compareDiffs = () => {
     return h(Fragment, [
-      div({ style: { display: 'flex', alignItems: 'center', fontSize: 16, fontWeight: 500 } }, [
-        div(['Step 1: Selected workflow B: ']),
+      div({ style: { paddingBottom: '0.5rem', display: 'flex', alignItems: 'center', fontSize: 16, fontWeight: 500 } }, [
+        div(['Selected workflow B: ']),
         div({ style: { display: 'flex', flexDirection: 'row', alignItems: 'center', flex: '1 1 100px' } }, [
           div({ style: { marginLeft: '0.5rem', ...Style.noWrapEllipsis, ...Style.codeFont } }, otherWorkflowId)
         ]),
-        h(ButtonSecondary, { style: { paddingLeft: '1rem', height: '20px', color: 'darkred', justifyContent: 'right' }, onClick: () => resetWorkflowSelection() }, ['[X]'])
+        h(ButtonSecondary, { style: { textTransform: 'none', paddingLeft: '1rem', height: '20px', justifyContent: 'right' }, onClick: () => resetWorkflowSelection() }, ['(reset)'])
       ]),
-      divider,
       div({ style: { display: 'flex', flexDirection: 'row', alignItems: 'center', fontSize: 16, fontWeight: 500 } }, [
-        div(['Step 2: Selected call B: ']),
+        div(['Selected call B: ']),
         div({ style: { display: 'flex', flexDirection: 'row', alignItems: 'center', flex: '1 1 100px' } }, [
           div({ style: { marginLeft: '0.5rem', ...Style.noWrapEllipsis, ...Style.codeFont } }, otherCallFqn),
           breadcrumbHistoryCaret,
           div({ style: { marginLeft: '0.5rem', ...Style.noWrapEllipsis, ...Style.codeFont } }, `index ${otherIndex}`)
         ]),
-        h(ButtonSecondary, { style: { justifyContent: 'right', paddingLeft: '1rem', height: '20px', color: 'darkred' }, onClick: () => resetCallSelection() }, ['[X]'])
+        h(ButtonSecondary, { style: { textTransform: 'none', paddingLeft: '1rem', height: '20px', justifyContent: 'right' }, onClick: () => resetCallSelection() }, ['(reset)'])
       ]),
       divider,
       div({ style: { display: 'flex', alignItems: 'center', fontSize: 16, fontWeight: 500 } }, ['Result: View cache diff']),
@@ -239,19 +237,29 @@ const CallCacheWizard = ({
   }
 
   return h(Modal, {
-    title: 'Call Cache Debugging Wizard',
+    title: [
+      icon('search'),
+      ' Call Cache Miss Debugging Wizard'
+    ],
     onDismiss,
     width: '50%',
     showButtons: false,
     showX: true
   }, [
     div({ style: { padding: '1rem 2rem 2rem', flex: 1, display: 'flex', flexDirection: 'column' } }, [
-      'Debugging cache miss for call A:',
-      div({ style: { marginTop: '0.5rem', flex: 1, display: 'flex', alignItems: 'center', flexDirection: 'row' } }, [
-        div({ style: { fontSize: 16, fontWeight: 500, ...Style.codeFont } }, [workflowId]), breadcrumbHistoryCaret,
-        div({ style: { fontSize: 16, fontWeight: 500, ...Style.codeFont } }, [callFqn]),
-        Number(index) >= 0 && h(Fragment, [breadcrumbHistoryCaret, 'index', div({ style: { marginLeft: '0.25rem', fontSize: 16, fontWeight: 500, ...Style.codeFont } }, [index])]),
-        Number(attempt) > 1 && h(Fragment, [breadcrumbHistoryCaret, 'attempt', div({ style: { marginLeft: '0.25rem', fontSize: 16, fontWeight: 500, ...Style.codeFont } }, [attempt])])
+      div({ style: { display: 'flex', alignItems: 'center', fontSize: 16, fontWeight: 500 } }, [
+        div(['Debugging workflow A: ']),
+        div({ style: { display: 'flex', flexDirection: 'row', alignItems: 'center', flex: '1 1 100px' } }, [
+          div({ style: { marginLeft: '0.5rem', ...Style.noWrapEllipsis, ...Style.codeFont } }, workflowId)
+        ])
+      ]),
+      div({ style: { paddingTop: '0.5rem', display: 'flex', flexDirection: 'row', alignItems: 'center', fontSize: 16, fontWeight: 500 } }, [
+        div(['Debugging call A: ']),
+        div({ style: { display: 'flex', flexDirection: 'row', alignItems: 'center', flex: '1 1 100px' } }, [
+          div({ style: { marginLeft: '0.5rem', ...Style.noWrapEllipsis, ...Style.codeFont } }, callFqn),
+          breadcrumbHistoryCaret,
+          div({ style: { marginLeft: '0.5rem', ...Style.noWrapEllipsis, ...Style.codeFont } }, `index ${index}`)
+        ])
       ]),
       divider,
       chooseStep()

--- a/src/pages/workspaces/workspace/jobHistory/CallCacheWizard.js
+++ b/src/pages/workspaces/workspace/jobHistory/CallCacheWizard.js
@@ -148,7 +148,7 @@ const CallCacheWizard = ({
         div({ style: { display: 'flex', flexDirection: 'row', alignItems: 'center', flex: '1' } }, [
           div({ style: { marginLeft: '0.5rem', ...Style.codeFont } }, otherWorkflowId)
         ]),
-        resetLink(() => resetWorkflowSelection(''))
+        (otherWorkflowMetadata || metadataFetchError) && resetLink(() => resetWorkflowSelection(''))
       ]),
       div({ style: { paddingTop: '0.5rem', fontSize: 16, fontWeight: 500 } }, ['Step 2: Select which call in that workflow you expected to cache from']),
       otherWorkflowMetadata ?

--- a/src/pages/workspaces/workspace/jobHistory/CallCacheWizard.js
+++ b/src/pages/workspaces/workspace/jobHistory/CallCacheWizard.js
@@ -3,7 +3,7 @@ import { Fragment, useState } from 'react'
 import { div, h, hr } from 'react-hyperscript-helpers'
 import ReactJson from 'react-json-view'
 import Select from 'react-select'
-import { ButtonPrimary, ButtonSecondary } from 'src/components/common'
+import { ButtonPrimary, ButtonSecondary, Link } from 'src/components/common'
 import ErrorView from 'src/components/ErrorView'
 import { icon } from 'src/components/icons'
 import { TextInput } from 'src/components/input'
@@ -90,8 +90,11 @@ const CallCacheWizard = ({
   const resetWorkflowSelection = (value = undefined) => {
     resetCallSelection()
     setOtherWorkflowId(value)
+    setOtherWorkflowIdTextboxValue(value)
     setMetadataFetchError(undefined)
   }
+
+  const resetLink = resetAction => h(Link, { style: { fontSize: '14px', justifyContent: 'right' }, onClick: resetAction }, ['Reset'])
 
   /*
    * Page render
@@ -101,16 +104,16 @@ const CallCacheWizard = ({
 
   const step1 = () => {
     return h(Fragment, [
-      div({ style: { paddingTop: '0.5rem', fontSize: 16, fontWeight: 500, ...Style.noWrapEllipsis } }, ['Step 1: Select the workflow you expected to cache from']),
+      div({ style: { paddingTop: '0.5rem', fontSize: 16, fontWeight: 500 } }, ['Step 1: Select the workflow you expected to cache from']),
       div({ style: { marginTop: '0.5rem', marginBottom: '1rem', display: 'flex', flexDirection: 'row', alignItems: 'center' } }, [
         div({ style: { paddingRight: '0.5rem' } }, ['Workflow ID:']),
-        div({ style: { paddingRight: '0.5rem', flex: '2 1 auto' } }, [h(TextInput, {
+        div({ style: { paddingRight: '0.5rem', flex: '1' } }, [h(TextInput, {
           style: Style.codeFont,
           value: otherWorkflowIdTextboxValue,
-          onChange: setOtherWorkflowIdTextboxValue,
-          id: 'otherWorkflowId'
+          onChange: setOtherWorkflowIdTextboxValue
         })]),
         h(ButtonPrimary, {
+          disabled: _.isEmpty(otherWorkflowIdTextboxValue),
           onClick: () => {
             resetWorkflowSelection(otherWorkflowIdTextboxValue)
             readCalls(otherWorkflowIdTextboxValue)
@@ -142,17 +145,17 @@ const CallCacheWizard = ({
     return h(Fragment, [
       div({ style: { display: 'flex', alignItems: 'center', fontSize: 16, fontWeight: 500 } }, [
         div(['Selected workflow B: ']),
-        div({ style: { display: 'flex', flexDirection: 'row', alignItems: 'center', flex: '1 1 100px' } }, [
-          div({ style: { marginLeft: '0.5rem', ...Style.noWrapEllipsis, ...Style.codeFont } }, otherWorkflowId)
+        div({ style: { display: 'flex', flexDirection: 'row', alignItems: 'center', flex: '1' } }, [
+          div({ style: { marginLeft: '0.5rem', ...Style.codeFont } }, otherWorkflowId)
         ]),
-        h(ButtonSecondary, { style: { textTransform: 'none', paddingLeft: '1rem', height: '20px', justifyContent: 'right' }, onClick: () => resetWorkflowSelection() }, ['Reset'])
+        resetLink(() => resetWorkflowSelection(undefined))
       ]),
-      div({ style: { paddingTop: '0.5rem', fontSize: 16, fontWeight: 500, ...Style.noWrapEllipsis } }, ['Step 2: Select which call in that workflow you expected to cache from']),
+      div({ style: { paddingTop: '0.5rem', fontSize: 16, fontWeight: 500 } }, ['Step 2: Select which call in that workflow you expected to cache from']),
       otherWorkflowMetadata ?
         div([
           div({ style: { marginTop: '1rem', display: 'flex', flexDirection: 'row', alignItems: 'center' } }, [
-            div({ style: { paddingRight: '0.5rem' } }, ['Call FQN:']),
-            div({ style: { paddingRight: '0.5rem', flex: '2 1 auto' } }, [
+            div({ style: { paddingRight: '0.5rem' } }, ['Call name:']),
+            div({ style: { paddingRight: '0.5rem', flex: '1' } }, [
               h(Select, { id: 'otherCallFqn', options: otherCallFqnSelectionOptions(otherWorkflowMetadata.calls), onChange: v => setOtherCallFqnDropdownValue(v.value) })
             ])
           ]),
@@ -168,7 +171,10 @@ const CallCacheWizard = ({
             icon('warning-standard', { size: 24, style: { color: colors.warning(), marginRight: '0.5rem' } }),
             'This call is ineligible for call caching because it did not succeed.'
           ]),
-          !!(otherCallFqnDropdownValue && selectedCallIndex && otherCallSucceeded) && h(ButtonPrimary, { style: { float: 'right' }, onClick: () => { fetchDiff(otherWorkflowId, otherCallFqnDropdownValue, selectedCallIndex); setOtherCallSelected(true) } }, ['Compare Diff'])
+          !!(otherCallFqnDropdownValue && selectedCallIndex && otherCallSucceeded) && h(ButtonPrimary, {
+            style: { float: 'right' },
+            onClick: () => { fetchDiff(otherWorkflowId, otherCallFqnDropdownValue, selectedCallIndex); setOtherCallSelected(true) }
+          }, ['Compare Diff'])
         ]) :
         'Loading workflow B\'s calls...'
     ])
@@ -178,36 +184,38 @@ const CallCacheWizard = ({
     return h(Fragment, [
       div({ style: { paddingBottom: '0.5rem', display: 'flex', alignItems: 'center', fontSize: 16, fontWeight: 500 } }, [
         div(['Selected workflow B: ']),
-        div({ style: { display: 'flex', flexDirection: 'row', alignItems: 'center', flex: '1 1 100px' } }, [
-          div({ style: { marginLeft: '0.5rem', ...Style.noWrapEllipsis, ...Style.codeFont } }, otherWorkflowId)
+        div({ style: { display: 'flex', flexDirection: 'row', alignItems: 'center', flex: '1' } }, [
+          div({ style: { marginLeft: '0.5rem', ...Style.codeFont } }, otherWorkflowId)
         ]),
-        h(ButtonSecondary, { style: { textTransform: 'none', paddingLeft: '1rem', height: '20px', justifyContent: 'right' }, onClick: () => resetWorkflowSelection() }, ['Reset'])
+        resetLink(() => resetWorkflowSelection(undefined))
       ]),
       div({ style: { display: 'flex', flexDirection: 'row', alignItems: 'center', fontSize: 16, fontWeight: 500 } }, [
         div(['Selected call B: ']),
         div({ style: { display: 'flex', flexDirection: 'row', alignItems: 'center', flex: '1 1 100px' } }, [
-          div({ style: { marginLeft: '0.5rem', ...Style.noWrapEllipsis, ...Style.codeFont } }, otherCallFqnDropdownValue),
+          div({ style: { marginLeft: '0.5rem', ...Style.codeFont } }, otherCallFqnDropdownValue),
           otherIndexDropdownValue && [breadcrumbHistoryCaret,
-            div({ style: { marginLeft: '0.5rem', ...Style.noWrapEllipsis, ...Style.codeFont } }, `index ${otherIndexDropdownValue}`)]
+            div({ style: { marginLeft: '0.5rem', ...Style.codeFont } }, `index ${otherIndexDropdownValue}`)]
         ]),
-        h(ButtonSecondary, { style: { textTransform: 'none', paddingLeft: '1rem', height: '20px', justifyContent: 'right' }, onClick: () => resetCallSelection() }, ['Reset'])
+        resetLink(() => resetCallSelection())
       ]),
       divider,
       div({ style: { display: 'flex', alignItems: 'center', fontSize: 16, fontWeight: 500 } }, ['Result: View cache diff']),
       diffError ?
         h(ErrorView, { error: diffError }) :
         (diff ?
-          [div({ style: { marginTop: '0.5rem', marginBottom: '0.5rem' } }, ['Note: the diff is expressed in terms of hashes of values rather than raw values because it is hashes that determine cache hits.']),
-            h(ReactJson, {
-              style: { whiteSpace: 'pre-wrap', border: 'ridge', padding: '0.5rem' },
-              name: false,
-              shouldCollapse: ({ name }) => { return name === 'callA' || name === 'callB' },
-              enableClipboard: false,
-              displayDataTypes: false,
-              displayObjectSize: false,
-              src: { hashDifferential: diff.hashDifferential, ...diff }
-            })] :
-          'Cache diff loading...')
+          div({ style: { marginTop: '0.5rem', marginBottom: '0.5rem' } },
+            [
+              'Note: the diff is expressed in terms of hashes of values rather than raw values because it is hashes that determine cache hits.',
+              h(ReactJson, {
+                style: { whiteSpace: 'pre-wrap', border: 'ridge', padding: '0.5rem' },
+                name: false,
+                shouldCollapse: ({ name }) => name === 'callA' || name === 'callB',
+                enableClipboard: false,
+                displayDataTypes: false,
+                displayObjectSize: false,
+                src: { hashDifferential: diff.hashDifferential, ...diff }
+              })
+            ]) : 'Cache diff loading...')
     ])
   }
 
@@ -223,11 +231,10 @@ const CallCacheWizard = ({
 
   return h(Modal, {
     title: [
-      icon('search'),
       ' Call Cache Miss Debugging Wizard'
     ],
     onDismiss,
-    width: '50%',
+    width: '850px',
     showButtons: false,
     showX: true
   }, [

--- a/src/pages/workspaces/workspace/jobHistory/CallCacheWizard.js
+++ b/src/pages/workspaces/workspace/jobHistory/CallCacheWizard.js
@@ -157,7 +157,7 @@ const CallCacheWizard = ({
           div({ style: { marginTop: '1rem', display: 'flex', flexDirection: 'row', alignItems: 'center' } }, [
             h(IdContainer, [id => h(Fragment, [
               label({ htmlFor: id, style: { paddingRight: '0.5rem' } }, ['Call name:']),
-              div({ style: { paddingRight: '0.5rem', flex: '1' } }, [
+              div({ style: { flex: '1' } }, [
                 h(Select, {
                   id,
                   isSearchable: false,
@@ -170,16 +170,16 @@ const CallCacheWizard = ({
               ])
             ])])
           ]),
-          otherCallFqnDropdownValue && div({ style: { marginTop: '0.25rem', display: 'flex', flexDirection: 'row', alignItems: 'center' } }, [
+          otherCallFqnDropdownValue && div({ style: { marginTop: '0.25rem', marginBottom: '0.5rem', display: 'flex', flexDirection: 'row', alignItems: 'center' } }, [
             h(IdContainer, [id => h(Fragment, [
               label({ htmlFor: id, style: { paddingRight: '0.5rem' } }, ['Shard Index:']),
-              Utils.cond(
+              div({ style: { flex: '1' } }, [Utils.cond(
                 [selectedCallIndex === -1, () => 'N/A (not scattered)'],
                 () => {
                   const options = _.uniqBy('value', _.map(({ shardIndex: i }) => { return { value: i, label: i } }, otherWorkflowMetadata.calls[otherCallFqnDropdownValue]))
                   return h(Select, { id, isSearchable: false, options, onChange: i => { setOtherIndexDropdownValue(i.value) } })
                 }
-              )
+              )])
             ])])
           ]),
           otherCallFqnDropdownValue && selectedCallIndex !== undefined && !otherCallSucceeded && div({ style: { display: 'flex', alignItems: 'center', marginTop: '0.5rem' } }, [

--- a/src/pages/workspaces/workspace/jobHistory/CallCacheWizard.js
+++ b/src/pages/workspaces/workspace/jobHistory/CallCacheWizard.js
@@ -175,7 +175,7 @@ const CallCacheWizard = ({
               label({ htmlFor: id, style: { paddingRight: '0.5rem' } }, ['Shard Index:']),
               div({ style: { flex: '1' } }, [Utils.cond(
                 [selectedCallIndex === -1, () => 'N/A (not scattered)'],
-                [_.size(otherWorkflowMetadata.calls[otherCallFqnDropdownValue]) === 1, `${otherWorkflowMetadata.calls[otherCallFqnDropdownValue][0].shardIndex} (exactly one shard in scatter)`],
+                [_.size(otherWorkflowMetadata.calls[otherCallFqnDropdownValue]) === 1, () => `${otherWorkflowMetadata.calls[otherCallFqnDropdownValue][0].shardIndex} (exactly one shard in scatter)`],
                 () => {
                   const options = _.uniqBy('value', _.map(({ shardIndex: i }) => { return { value: i, label: i } }, otherWorkflowMetadata.calls[otherCallFqnDropdownValue]))
                   return h(Select, {

--- a/src/pages/workspaces/workspace/jobHistory/CallCacheWizard.js
+++ b/src/pages/workspaces/workspace/jobHistory/CallCacheWizard.js
@@ -131,8 +131,8 @@ const CallCacheWizard = ({
           return `${shards[0]} (exactly one shard in the scatter)`
         }
       } else {
-        const shardOptions = _.map(i => { return { value: i, label: i } }).apply(shards)
-        return h(Select, { id: 'otherCallIndex', options: shardOptions, onChange: i => setOtherIndex(i) })
+        const shardOptions = _.map(i => { return { value: i, label: i } }, shards)
+        return h(Select, { options: shardOptions, onChange: i => { setOtherIndex(i.value) } })
       }
     }
 

--- a/src/pages/workspaces/workspace/jobHistory/CallCacheWizard.js
+++ b/src/pages/workspaces/workspace/jobHistory/CallCacheWizard.js
@@ -10,6 +10,7 @@ import { TextInput } from 'src/components/input'
 import { breadcrumbHistoryCaret } from 'src/components/job-common'
 import Modal from 'src/components/Modal'
 import { Ajax } from 'src/libs/ajax'
+import colors from 'src/libs/colors'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 
@@ -135,14 +136,8 @@ const CallCacheWizard = ({
       return h(Select, { options: shardOptions, onChange: i => { setOtherIndexDropdownValue(i.value) } })
     }
 
-    const otherCallSucceeded = (metadata, fqn, index) => {
-      return _.flow(
-        _.filter(c => c.shardIndex === index && c.executionStatus === 'Done'),
-        _.map(c => c.attempt),
-        _.first,
-        !_.isEmpty
-      )(metadata.calls[fqn])
-    }
+    const otherCallSucceeded = otherWorkflowMetadata && otherCallFqnDropdownValue && selectedCallIndex &&
+      _.some({ shardIndex: -1, executionStatus: 'Done' }, otherWorkflowMetadata.calls[otherCallFqnDropdownValue])
 
     return h(Fragment, [
       div({ style: { display: 'flex', alignItems: 'center', fontSize: 16, fontWeight: 500 } }, [
@@ -169,7 +164,10 @@ const CallCacheWizard = ({
               )
             )
           ]),
-          otherCallFqnDropdownValue && selectedCallIndex && !otherCallSucceeded && 'The call/index you have selected cannot be call cached from because it did not succeed.',
+          otherCallFqnDropdownValue && selectedCallIndex && !otherCallSucceeded && div({ style: { display: 'flex', alignItems: 'center', marginTop: '0.5rem' } }, [
+            icon('warning-standard', { size: 24, style: { color: colors.warning(), marginRight: '0.5rem' } }),
+            'This call is ineligible for call caching because it did not succeed.'
+          ]),
           !!(otherCallFqnDropdownValue && selectedCallIndex && otherCallSucceeded) && h(ButtonPrimary, { style: { float: 'right' }, onClick: () => { fetchDiff(otherWorkflowId, otherCallFqnDropdownValue, selectedCallIndex); setOtherCallSelected(true) } }, ['Compare Diff'])
         ]) :
         'Loading workflow B\'s calls...'

--- a/src/pages/workspaces/workspace/jobHistory/CallCacheWizard.js
+++ b/src/pages/workspaces/workspace/jobHistory/CallCacheWizard.js
@@ -22,7 +22,7 @@ const CallCacheWizard = ({
    * State setup
    */
 
-  const [otherWorkflowIdTextboxValue, setOtherWorkflowIdTextboxValue] = useState()
+  const [otherWorkflowIdTextboxValue, setOtherWorkflowIdTextboxValue] = useState('')
   const [otherWorkflowId, setOtherWorkflowId] = useState()
   const [otherWorkflowMetadata, setOtherWorkflowMetadata] = useState()
   const [otherCallFqnDropdownValue, setOtherCallFqnDropdownValue] = useState()

--- a/src/pages/workspaces/workspace/jobHistory/CallTable.js
+++ b/src/pages/workspaces/workspace/jobHistory/CallTable.js
@@ -82,7 +82,7 @@ const CallTable = ({ namespace, name, submissionId, workflowId, callName, callOb
               const failureCount = _.size(failures)
               const linkCount = (failures ? 1 : 0) + (ccResult === 'Cache Miss' ? 1 : 0)
               return linkCount > 0 ? [
-                h(Link, {
+                failureCount > 0 && h(Link, {
                   style: { marginLeft: '0.5rem' },
                   tooltip: `${failureCount} Message${failureCount > 1 ? 's' : ''}`,
                   onClick: () => setFailuresModalParams({ index, attempt, failures })

--- a/src/pages/workspaces/workspace/jobHistory/CallTable.js
+++ b/src/pages/workspaces/workspace/jobHistory/CallTable.js
@@ -64,7 +64,7 @@ const CallTable = ({ namespace, name, submissionId, workflowId, callName, callOb
             size: { basis: 200, grow: 2 },
             headerRenderer: () => 'Call Caching Result',
             cellRenderer: ({ rowIndex }) => {
-              const { shardIndex: index, attempt, callCaching: { effectiveCallCachingMode, result } = {} } = callObjects[rowIndex]
+              const { shardIndex: index, callCaching: { effectiveCallCachingMode, result } = {} } = callObjects[rowIndex]
               if (effectiveCallCachingMode === 'ReadAndWriteCache' || effectiveCallCachingMode === 'ReadCache') {
                 return result ? h(Fragment, [
                   h(TooltipCell, [result]),
@@ -73,7 +73,7 @@ const CallTable = ({ namespace, name, submissionId, workflowId, callName, callOb
                     style: { marginLeft: '0.5rem' },
                     tooltip: 'Call Cache Debug Wizard',
                     'aria-label': 'Call Cache Debug Wizard',
-                    onClick: () => setWizardSelection({ callFqn: callName, index, attempt })
+                    onClick: () => setWizardSelection({ callFqn: callName, index })
                   }, [
                     icon('search', { size: 18 })
                   ])

--- a/src/pages/workspaces/workspace/jobHistory/CallTable.js
+++ b/src/pages/workspaces/workspace/jobHistory/CallTable.js
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp'
-import { useState } from 'react'
+import { Fragment, useState } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
 import { AutoSizer } from 'react-virtualized'
 import { Link } from 'src/components/common'
@@ -66,17 +66,18 @@ const CallTable = ({ namespace, name, submissionId, workflowId, callName, callOb
             cellRenderer: ({ rowIndex }) => {
               const { shardIndex: index, attempt, callCaching: { effectiveCallCachingMode, result } = {} } = callObjects[rowIndex]
               if (effectiveCallCachingMode === 'ReadAndWriteCache' || effectiveCallCachingMode === 'ReadCache') {
-                return result ? [
+                return result ? h(Fragment, [
                   h(TooltipCell, [result]),
                   result === 'Cache Miss' && h(Link, {
                     key: 'cc',
                     style: { marginLeft: '0.5rem' },
                     tooltip: 'Call Cache Debug Wizard',
+                    'aria-label': 'Call Cache Debug Wizard',
                     onClick: () => setWizardSelection({ callFqn: callName, index, attempt })
                   }, [
                     icon('search', { size: 18 })
                   ])
-                ] :
+                ]) :
                   div({ style: { color: colors.dark(0.7) } }, ['No Information'])
               } else if (effectiveCallCachingMode === 'WriteCache') {
                 return div({ style: { color: colors.dark(0.7) } }, ['Lookup disabled; write enabled'])

--- a/src/pages/workspaces/workspace/jobHistory/CallTable.js
+++ b/src/pages/workspaces/workspace/jobHistory/CallTable.js
@@ -83,6 +83,7 @@ const CallTable = ({ namespace, name, submissionId, workflowId, callName, callOb
               const linkCount = (failures ? 1 : 0) + (ccResult === 'Cache Miss' ? 1 : 0)
               return linkCount > 0 ? [
                 failureCount > 0 && h(Link, {
+                  key: 'failures',
                   style: { marginLeft: '0.5rem' },
                   tooltip: `${failureCount} Message${failureCount > 1 ? 's' : ''}`,
                   onClick: () => setFailuresModalParams({ index, attempt, failures })
@@ -91,6 +92,7 @@ const CallTable = ({ namespace, name, submissionId, workflowId, callName, callOb
                   linkCount === 1 && ` ${failureCount} Message${failureCount > 1 ? 's' : ''}`
                 ])]),
                 ccResult === 'Cache Miss' && h(Link, {
+                  key: 'cc',
                   style: { marginLeft: '0.5rem' },
                   tooltip: 'Call Cache Debug Wizard',
                   onClick: () => setWizardSelection({ callFqn: callName, index, attempt })

--- a/src/pages/workspaces/workspace/jobHistory/CallTable.js
+++ b/src/pages/workspaces/workspace/jobHistory/CallTable.js
@@ -91,17 +91,17 @@ const CallTable = ({ namespace, name, submissionId, workflowId, callName, callOb
             cellRenderer: ({ rowIndex }) => {
               const { failures, shardIndex: index, attempt } = callObjects[rowIndex]
               const failureCount = _.size(failures)
-              if (failureCount > 0) {
-                return [h(Link, {
-                  key: 'failures',
+              return failures ? [
+                h(Link, {
                   style: { marginLeft: '0.5rem' },
-                  tooltip: `${failureCount} Message${failureCount > 1 ? 's' : ''}`,
                   onClick: () => setFailuresModalParams({ index, attempt, failures })
-                }, [div({ style: { display: 'flex', alignItems: 'center' } }, [
-                  icon('warning-standard', { size: 18, style: { color: colors.warning() } }),
-                  ` ${failureCount} Message${failureCount > 1 ? 's' : ''}`
-                ])])]
-              } else return []
+                }, [
+                  div({ style: { display: 'flex', alignItems: 'center' } }, [
+                    icon('warning-standard', { size: 18, style: { color: colors.warning(), marginRight: '0.5rem' } }),
+                    `${failureCount} Message${failureCount > 1 ? 's' : ''}`
+                  ])
+                ])
+              ] : undefined
             }
           }
         ]

--- a/src/pages/workspaces/workspace/jobHistory/CallTable.js
+++ b/src/pages/workspaces/workspace/jobHistory/CallTable.js
@@ -66,7 +66,7 @@ const CallTable = ({ namespace, name, submissionId, workflowId, callName, callOb
             cellRenderer: ({ rowIndex }) => {
               const { callCaching: { effectiveCallCachingMode, result } = {} } = callObjects[rowIndex]
               if (effectiveCallCachingMode === 'ReadAndWriteCache' || effectiveCallCachingMode === 'ReadCache') {
-                return result ? [h(TooltipCell, [result])] : div({ style: { color: colors.dark(0.7) } }, ['No Information'])
+                return result ? h(TooltipCell, [result]) : div({ style: { color: colors.dark(0.7) } }, ['No Information'])
               } else if (effectiveCallCachingMode === 'WriteCache') {
                 return div({ style: { color: colors.dark(0.7) } }, ['Lookup disabled; write enabled'])
               } else {


### PR DESCRIPTION
This is a hopefully more digestible "part 2" subset of #2362 to follow on from #2375's "part 1".

Implements the Call Cache Miss debug wizard as a link from the "calls" table for calls which tried but missed a call cache.

#### Example of the call cache modal in action:

See updated image in comment https://github.com/DataBiosphere/terra-ui/pull/2376#issuecomment-786845476 

#### Good example workflows to test against:

- Against the same **ALPHA** workflows as in #2375 to make sure the UX has not significantly regressed:
  - A workflow with a lot of calls: http://localhost:3000/#workspaces/cromwell-tests-billing-project/cromwell-tests-workspace/job_history/e60d7eab-4faa-4868-986e-5d86fc2b949d/e21fe7ab-8922-4552-9a66-3917925e3340
  - Test workflow from the original "Workflows Dashboard" hackathon PR: http://localhost:3000/#workspaces/cromwell-tests-billing-project/cromwell-tests-workspace/job_history/d873e5da-054a-401e-ae8b-4d8c3adf03ad/b95fc8f8-4410-4e6c-accf-fb14b1766984
- Against the same **DEV** workflows as in #2362 demonstrating the debug wizard:
  - Comparing the diff between two Dev workflows:
    - http://localhost:3000/#workspaces/testing-job-manager/lots_of_workflows/job_history/4210652d-f68c-4faf-9d26-6d7354b07b87/049bd35c-68a7-4d36-8340-76fd875c3df6
    - http://localhost:3000/#workspaces/testing-job-manager/lots_of_workflows/job_history/1e55deba-28bb-4581-b290-5fa3b0e1629e/49a8b6b8-4b3c-4e0a-aaa1-ac37c575fa37
  - Comparing the diff between two Dev workflows (currently "demonstrates" error handling because of a Cromwell bug):
    - http://localhost:3000/#workspaces/general-dev-billing-account/scale-abort-test/job_history/c4752583-839c-4319-bb0d-5eae15fa1fdc/d471802e-e1cc-405c-a816-536a6a7a69db
    - http://localhost:3000/#workspaces/general-dev-billing-account/scale-abort-test/job_history/b6647bde-603d-43d4-a24f-3b68bf04cf0e/2520d817-83ee-4e4d-961f-e582d29b1b6c
- Against a **DEV** workflow which has both a cache miss AND failure message:
  - http://localhost:3000/#workspaces/general-dev-billing-account/scale-abort-test/job_history/b5c5554e-2021-4ad4-ab58-34d1fe5f12f8/d37be105-559f-4e4a-aaf2-543b37aa51fa
- Against a **DEV** workflow which has a non-trivial drop down options:
  - http://localhost:3000/#workspaces/general-dev-billing-account/cjl_test_workspace/job_history/d4e06b20-3aad-480a-942b-ab5b48237f01/57734cb5-1452-49ad-a9d4-a8bd125a3e49
  - Compare `helloInScatter` shard 5's cache miss against shard 5 from the same task in `82b31604-c576-4c8d-b1dd-8f04f1e930d5`
  - Compare `read` against the same workflow to see another example of the "Cromwell can't call cache diff arrays" bug
  - Compare against `f9fbf5a7-2a17-4bf6-a661-0180a5905dc2` for a workflow which has exactly one shard index