### PR TITLE
[CA-1048] Post NIH callback to Orch instead of Terra Profile service

### DIFF
--- a/config/alpha.json
+++ b/config/alpha.json
@@ -14,7 +14,6 @@
   "leoUrlRoot": "https://leonardo.dsde-alpha.broadinstitute.org",
   "marthaUrlRoot": "https://us-central1-broad-dsde-alpha.cloudfunctions.net",
   "orchestrationUrlRoot": "https://firecloud-orchestration.dsde-alpha.broadinstitute.org",
-  "profileUrlRoot": "https://profile-dot-broad-shibboleth-prod.appspot.com/dev",
   "rawlsUrlRoot": "https://rawls.dsde-alpha.broadinstitute.org",
   "rexUrlRoot": "https://terra-rex-alpha.appspot.com",
   "samUrlRoot": "https://sam.dsde-alpha.broadinstitute.org",

--- a/config/dev.json
+++ b/config/dev.json
@@ -14,7 +14,6 @@
   "leoUrlRoot": "https://leonardo.dsde-dev.broadinstitute.org",
   "marthaUrlRoot": "https://us-central1-broad-dsde-dev.cloudfunctions.net",
   "orchestrationUrlRoot": "https://firecloud-orchestration.dsde-dev.broadinstitute.org",
-  "profileUrlRoot": "https://profile-dot-broad-shibboleth-prod.appspot.com/dev",
   "rawlsUrlRoot": "https://rawls.dsde-dev.broadinstitute.org",
   "rexUrlRoot": "https://terra-rex-dev.appspot.com",
   "samUrlRoot": "https://sam.dsde-dev.broadinstitute.org",

--- a/config/fiab.json
+++ b/config/fiab.json
@@ -13,7 +13,6 @@
   "leoUrlRoot": "https://leonardo-fiab.dsde-dev.broadinstitute.org:30443",
   "marthaUrlRoot": "https://martha-fiab.dsde-dev.broadinstitute.org:32443",
   "orchestrationUrlRoot": "https://firecloud-orchestration-fiab.dsde-dev.broadinstitute.org:23443",
-  "profileUrlRoot": "https://profile-dot-broad-shibboleth-prod.appspot.com/dev",
   "rawlsUrlRoot": "https://rawls-fiab.dsde-dev.broadinstitute.org:24443",
   "rexUrlRoot": "https://terra-rex-dev.appspot.com",
   "samUrlRoot": "https://sam-fiab.dsde-dev.broadinstitute.org:29443",

--- a/config/perf.json
+++ b/config/perf.json
@@ -14,7 +14,6 @@
   "leoUrlRoot": "https://leonardo.dsde-perf.broadinstitute.org",
   "marthaUrlRoot": "https://us-central1-broad-dsde-perf.cloudfunctions.net",
   "orchestrationUrlRoot": "https://firecloud-orchestration.dsde-perf.broadinstitute.org",
-  "profileUrlRoot": "https://profile-dot-broad-shibboleth-prod.appspot.com/dev",
   "rawlsUrlRoot": "https://rawls.dsde-perf.broadinstitute.org",
   "rexUrlRoot": "https://terra-rex-perf.appspot.com",
   "samUrlRoot": "https://sam.dsde-perf.broadinstitute.org",

--- a/config/prod.json
+++ b/config/prod.json
@@ -14,7 +14,6 @@
   "leoUrlRoot": "https://notebooks.firecloud.org",
   "marthaUrlRoot": "https://us-central1-broad-dsde-prod.cloudfunctions.net",
   "orchestrationUrlRoot": "https://api.firecloud.org",
-  "profileUrlRoot": "https://profile-dot-broad-shibboleth-prod.appspot.com",
   "rawlsUrlRoot": "https://rawls.dsde-prod.broadinstitute.org",
   "rexUrlRoot": "https://terra-rex-prod.appspot.com",
   "samUrlRoot": "https://sam.dsde-prod.broadinstitute.org",

--- a/config/staging.json
+++ b/config/staging.json
@@ -14,7 +14,6 @@
   "leoUrlRoot": "https://leonardo.dsde-staging.broadinstitute.org",
   "marthaUrlRoot": "https://us-central1-broad-dsde-staging.cloudfunctions.net",
   "orchestrationUrlRoot": "https://firecloud-orchestration.dsde-staging.broadinstitute.org",
-  "profileUrlRoot": "https://profile-dot-broad-shibboleth-prod.appspot.com/dev",
   "rawlsUrlRoot": "https://rawls.dsde-staging.broadinstitute.org",
   "rexUrlRoot": "https://terra-rex-staging.appspot.com",
   "samUrlRoot": "https://sam.dsde-staging.broadinstitute.org",

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -135,7 +135,6 @@ const fetchLeo = withUrlPrefix(`${getConfig().leoUrlRoot}/`, fetchOk)
 const fetchDockstore = withUrlPrefix(`${getConfig().dockstoreUrlRoot}/api/`, fetchOk)
 const fetchAgora = _.flow(withUrlPrefix(`${getConfig().agoraUrlRoot}/api/v1/`), withAppIdentifier)(fetchOk)
 const fetchOrchestration = _.flow(withUrlPrefix(`${getConfig().orchestrationUrlRoot}/`), withAppIdentifier)(fetchOk)
-const fetchProfile = withUrlPrefix(`${getConfig().profileUrlRoot}/`, fetchOk)
 const fetchRex = withUrlPrefix(`${getConfig().rexUrlRoot}/api/`, fetchOk)
 const fetchBond = withUrlPrefix(`${getConfig().bondUrlRoot}/`, fetchOk)
 const fetchMartha = withUrlPrefix(`${getConfig().marthaUrlRoot}/`, fetchOk)
@@ -306,7 +305,7 @@ const User = signal => ({
   },
 
   linkNihAccount: async token => {
-    const res = await fetchProfile('shibboleth-token', _.merge(authOpts(), { body: token, signal, method: 'POST' }))
+    const res = await fetchOrchestration('api/nih/callback', _.mergeAll([authOpts(), jsonBody({ jwt: token }), { signal, method: 'POST' }]))
     return res.json()
   },
 


### PR DESCRIPTION
Ticket: [CA-1048](https://broadworkbench.atlassian.net/browse/CA-1048)
This will fix the NIH relinking bug that is described in the ticket once the changes in all three of the following PRs are released:
https://github.com/broadinstitute/firecloud-develop/pull/2416
https://github.com/broadinstitute/firecloud-orchestration/pull/835
https://github.com/broadinstitute/shibboleth-service-provider/pull/35

This PR should not be merged until everything above has been released -- leaving it as a draft PR until then.

Tested by running it locally, first against a FiaB with the other changes, and subsequently against dev once those changes had been merged. Was able to successfully link an account through Shibboleth and have the allowlist authorizations show up immediately