### PR TITLE
[IA-2491] Refactor dataproc cost calculation

### DIFF
--- a/src/libs/runtime-utils.js
+++ b/src/libs/runtime-utils.js
@@ -25,39 +25,73 @@ export const normalizeRuntimeConfig = ({
   }
 }
 
+export const findMachineType = name => {
+  return _.find({ name }, machineTypes) || { name, cpu: '?', memory: '?', price: NaN, preemptiblePrice: NaN }
+}
+
+export const dataprocCost = (machineType, numInstances) => {
+  const { cpu: cpuPrice } = findMachineType(machineType)
+
+  return cpuPrice * numInstances * dataprocCpuPrice
+}
+
 export const runtimeConfigBaseCost = config => {
   const {
     cloudService, masterMachineType, masterDiskSize, numberOfWorkers, workerMachineType, workerDiskSize, bootDiskSize
   } = normalizeRuntimeConfig(
     config)
-  const { cpu: masterCpu } = findMachineType(masterMachineType)
-  const { cpu: workerCpu } = findMachineType(workerMachineType)
 
   return _.sum([
     (masterDiskSize + numberOfWorkers * workerDiskSize) * storagePrice,
-    cloudService === cloudServices.DATAPROC && (masterCpu + workerCpu * numberOfWorkers) * dataprocCpuPrice,
+    cloudService === cloudServices.DATAPROC && (dataprocCost(masterMachineType, 1) + dataprocCost(workerMachineType, numberOfWorkers)),
     bootDiskSize * storagePrice
   ])
 }
 
-export const findMachineType = name => {
-  return _.find({ name }, machineTypes) || { name, cpu: '?', memory: '?', price: NaN, preemptiblePrice: NaN }
-}
+// export const runtimeConfigBaseCost = config => {
+//   const {
+//     cloudService, masterMachineType, masterDiskSize, numberOfWorkers, workerMachineType, workerDiskSize, bootDiskSize
+//   } = normalizeRuntimeConfig(
+//     config)
+//   const { cpu: masterCpu } = findMachineType(masterMachineType)
+//   const { cpu: workerCpu } = findMachineType(workerMachineType)
+//
+//   return _.sum([
+//     (masterDiskSize + numberOfWorkers * workerDiskSize) * storagePrice,
+//     cloudService === cloudServices.DATAPROC && (masterCpu + workerCpu * numberOfWorkers) * dataprocCpuPrice,
+//     bootDiskSize * storagePrice
+//   ])
+// }
 
 export const runtimeConfigCost = config => {
   const { cloudService, masterMachineType, numberOfWorkers, numberOfPreemptibleWorkers, workerMachineType, workerDiskSize } = normalizeRuntimeConfig(
     config)
   const { price: masterPrice } = findMachineType(masterMachineType)
-  const { price: workerPrice, preemptiblePrice, cpu: workerCpu } = findMachineType(workerMachineType)
+  const { price: workerPrice, preemptiblePrice } = findMachineType(workerMachineType)
   return _.sum([
     masterPrice,
     numberOfWorkers * workerPrice,
     numberOfPreemptibleWorkers * preemptiblePrice,
     numberOfPreemptibleWorkers * workerDiskSize * storagePrice,
-    cloudService === cloudServices.DATAPROC && numberOfPreemptibleWorkers * workerCpu * dataprocCpuPrice,
+    cloudService === cloudServices.DATAPROC && dataprocCost(workerMachineType, numberOfPreemptibleWorkers),
     runtimeConfigBaseCost(config)
   ])
 }
+
+// export const runtimeConfigCost = config => {
+//   const { cloudService, masterMachineType, numberOfWorkers, numberOfPreemptibleWorkers, workerMachineType, workerDiskSize } = normalizeRuntimeConfig(
+//     config)
+//   const { price: masterPrice } = findMachineType(masterMachineType)
+//   const { price: workerPrice, preemptiblePrice, cpu: workerCpu } = findMachineType(workerMachineType)
+//   return _.sum([
+//     masterPrice,
+//     numberOfWorkers * workerPrice,
+//     numberOfPreemptibleWorkers * preemptiblePrice,
+//     numberOfPreemptibleWorkers * workerDiskSize * storagePrice,
+//     cloudService === cloudServices.DATAPROC && numberOfPreemptibleWorkers * workerCpu * dataprocCpuPrice,
+//     runtimeConfigBaseCost(config)
+//   ])
+// }
 
 const generateDiskCostFunction = price => ({ size, status }) => {
   return _.includes(status, ['Deleting', 'Failed']) ? 0.0 : size * price

--- a/src/libs/runtime-utils.js
+++ b/src/libs/runtime-utils.js
@@ -29,7 +29,7 @@ export const findMachineType = name => {
   return _.find({ name }, machineTypes) || { name, cpu: '?', memory: '?', price: NaN, preemptiblePrice: NaN }
 }
 
-export const dataprocCost = (machineType, numInstances) => {
+const dataprocCost = (machineType, numInstances) => {
   const { cpu: cpuPrice } = findMachineType(machineType)
 
   return cpuPrice * numInstances * dataprocCpuPrice

--- a/src/libs/runtime-utils.js
+++ b/src/libs/runtime-utils.js
@@ -48,21 +48,6 @@ export const runtimeConfigBaseCost = config => {
   ])
 }
 
-// export const runtimeConfigBaseCost = config => {
-//   const {
-//     cloudService, masterMachineType, masterDiskSize, numberOfWorkers, workerMachineType, workerDiskSize, bootDiskSize
-//   } = normalizeRuntimeConfig(
-//     config)
-//   const { cpu: masterCpu } = findMachineType(masterMachineType)
-//   const { cpu: workerCpu } = findMachineType(workerMachineType)
-//
-//   return _.sum([
-//     (masterDiskSize + numberOfWorkers * workerDiskSize) * storagePrice,
-//     cloudService === cloudServices.DATAPROC && (masterCpu + workerCpu * numberOfWorkers) * dataprocCpuPrice,
-//     bootDiskSize * storagePrice
-//   ])
-// }
-
 export const runtimeConfigCost = config => {
   const { cloudService, masterMachineType, numberOfWorkers, numberOfPreemptibleWorkers, workerMachineType, workerDiskSize } = normalizeRuntimeConfig(
     config)
@@ -77,21 +62,6 @@ export const runtimeConfigCost = config => {
     runtimeConfigBaseCost(config)
   ])
 }
-
-// export const runtimeConfigCost = config => {
-//   const { cloudService, masterMachineType, numberOfWorkers, numberOfPreemptibleWorkers, workerMachineType, workerDiskSize } = normalizeRuntimeConfig(
-//     config)
-//   const { price: masterPrice } = findMachineType(masterMachineType)
-//   const { price: workerPrice, preemptiblePrice, cpu: workerCpu } = findMachineType(workerMachineType)
-//   return _.sum([
-//     masterPrice,
-//     numberOfWorkers * workerPrice,
-//     numberOfPreemptibleWorkers * preemptiblePrice,
-//     numberOfPreemptibleWorkers * workerDiskSize * storagePrice,
-//     cloudService === cloudServices.DATAPROC && numberOfPreemptibleWorkers * workerCpu * dataprocCpuPrice,
-//     runtimeConfigBaseCost(config)
-//   ])
-// }
 
 const generateDiskCostFunction = price => ({ size, status }) => {
   return _.includes(status, ['Deleting', 'Failed']) ? 0.0 : size * price


### PR DESCRIPTION
- [JIRA ticket](https://broadworkbench.atlassian.net/browse/IA-2491)

- Addresses @breilly2's feedback below on a previous [PR](https://github.com/DataBiosphere/terra-ui/pull/2367)

> TOL: I think it's worth considering extracting a dataprocCost function that takes machineType and numInstances. It would be called 3 times: from runtimeConfigBaseCost with (masterMachineType, 1) and (workerMachineType, numberOfWorkers) and from runtimeConfigCost with (workerMachineType, numberOfPreemptibleWorkers).

- Manually tested by comparing cost display on `local` vs. `dev` while flipping through cluster config parameter value combinations on the create cluster modal