### PR TITLE
support dockstore tools in method configs [CROM-6688]

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -144,7 +144,7 @@ const fetchBard = withUrlPrefix(`${getConfig().bardRoot}/`, fetchOk)
 const nbName = name => encodeURIComponent(`notebooks/${name}.ipynb`)
 
 // %23 = '#', %2F = '/'
-const dockstoreMethodPath = (path, isTool) => `api/ga4gh/v1/tools/${isTool ? '' : '%23workflow%2F'}${encodeURIComponent(path)}/versions`
+const dockstoreMethodPath = ({ path, isTool }) => `api/ga4gh/v1/tools/${isTool ? '' : '%23workflow%2F'}${encodeURIComponent(path)}/versions`
 
 /**
  * Only use this if the user has write access to the workspace to avoid proliferation of service accounts in projects containing public workspaces.
@@ -1225,14 +1225,14 @@ const Disks = signal => ({
 })
 
 const Dockstore = signal => ({
-  getWdl: async (path, version, isTool) => {
-    const res = await fetchDockstore(`${dockstoreMethodPath(path, isTool)}/${encodeURIComponent(version)}/WDL/descriptor`, { signal })
+  getWdl: async ({ path, version, isTool }) => {
+    const res = await fetchDockstore(`${dockstoreMethodPath({ path, isTool })}/${encodeURIComponent(version)}/WDL/descriptor`, { signal })
     const { url } = await res.json()
     return fetchOk(url, { signal }).then(res => res.text())
   },
 
-  getVersions: async (path, isTool) => {
-    const res = await fetchDockstore(dockstoreMethodPath(path, isTool), { signal })
+  getVersions: async ({ path, isTool }) => {
+    const res = await fetchDockstore(dockstoreMethodPath({ path, isTool }), { signal })
     return res.json()
   }
 })

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -144,7 +144,7 @@ const fetchBard = withUrlPrefix(`${getConfig().bardRoot}/`, fetchOk)
 const nbName = name => encodeURIComponent(`notebooks/${name}.ipynb`)
 
 // %23 = '#', %2F = '/'
-const dockstoreMethodPath = path => `api/ga4gh/v1/tools/%23workflow%2F${encodeURIComponent(path)}/versions`
+const dockstoreMethodPath = (path, isTool) => `api/ga4gh/v1/tools/${isTool ? '' : '%23workflow%2F'}${encodeURIComponent(path)}/versions`
 
 /**
  * Only use this if the user has write access to the workspace to avoid proliferation of service accounts in projects containing public workspaces.
@@ -1225,14 +1225,14 @@ const Disks = signal => ({
 })
 
 const Dockstore = signal => ({
-  getWdl: async (path, version) => {
-    const res = await fetchDockstore(`${dockstoreMethodPath(path)}/${encodeURIComponent(version)}/WDL/descriptor`, { signal })
+  getWdl: async (path, version, isTool) => {
+    const res = await fetchDockstore(`${dockstoreMethodPath(path, isTool)}/${encodeURIComponent(version)}/WDL/descriptor`, { signal })
     const { url } = await res.json()
     return fetchOk(url, { signal }).then(res => res.text())
   },
 
-  getVersions: async path => {
-    const res = await fetchDockstore(dockstoreMethodPath(path), { signal })
+  getVersions: async (path, isTool) => {
+    const res = await fetchDockstore(dockstoreMethodPath(path, isTool), { signal })
     return res.json()
   }
 })

--- a/src/pages/ImportWorkflow.js
+++ b/src/pages/ImportWorkflow.js
@@ -36,7 +36,7 @@ const styles = {
   }
 }
 
-const DockstoreImporter = ({ path, version }) => {
+const DockstoreImporter = ({ path, version, source }) => {
   const [isBusy, setIsBusy] = useState(false)
   const [wdl, setWdl] = useState(undefined)
   const [workflowName, setWorkflowName] = useState('')
@@ -47,7 +47,7 @@ const DockstoreImporter = ({ path, version }) => {
     withErrorReporting('Error loading WDL'),
     Utils.withBusyState(setIsBusy)
   )(async () => {
-    const wdl = await Ajax(signal).Dockstore.getWdl(path, version)
+    const wdl = await Ajax(signal).Dockstore.getWdl(path, version, source === 'dockstoretools')
     setWdl(wdl)
     setWorkflowName(_.last(path.split('/')))
   })
@@ -58,7 +58,7 @@ const DockstoreImporter = ({ path, version }) => {
 
   const doImport = Utils.withBusyState(setIsBusy, async workspace => {
     const { name, namespace } = workspace
-    const eventData = { source: 'dockstore', ...extractWorkspaceDetails({ workspace }) }
+    const eventData = { source, ...extractWorkspaceDetails({ workspace }) }
 
     try {
       const rawlsWorkspace = Ajax().Workspaces.workspace(namespace, name)
@@ -67,7 +67,7 @@ const DockstoreImporter = ({ path, version }) => {
         namespace, name: workflowName, rootEntityType: _.head(_.keys(entityMetadata)),
         inputs: {}, outputs: {}, prerequisites: {}, methodConfigVersion: 1, deleted: false,
         methodRepoMethod: {
-          sourceRepo: 'dockstore',
+          sourceRepo: source,
           methodPath: path,
           methodVersion: version
         }
@@ -128,7 +128,7 @@ const Importer = ({ source, item }) => {
     h(TopBar, { title: 'Import Workflow' }),
     div({ role: 'main', style: { flexGrow: 1 } }, [
       Utils.cond(
-        [source === 'dockstore', () => h(DockstoreImporter, { path, version })],
+        [source === 'dockstore' || source === 'dockstoretools', () => h(DockstoreImporter, { path, version, source })],
         () => `Unknown source '${source}'`
       )
     ])

--- a/src/pages/ImportWorkflow.js
+++ b/src/pages/ImportWorkflow.js
@@ -47,7 +47,7 @@ const DockstoreImporter = ({ path, version, source }) => {
     withErrorReporting('Error loading WDL'),
     Utils.withBusyState(setIsBusy)
   )(async () => {
-    const wdl = await Ajax(signal).Dockstore.getWdl(path, version, source === 'dockstoretools')
+    const wdl = await Ajax(signal).Dockstore.getWdl({ path, version, isTool: source === 'dockstoretools' })
     setWdl(wdl)
     setWorkflowName(_.last(path.split('/')))
   })

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -498,7 +498,7 @@ const WorkflowView = _.flow(
 
         this.setState({ versionIds: snapshotIds })
       } else if (sourceRepo === 'dockstore' || sourceRepo === 'dockstoretools') {
-        const versions = await Ajax(signal).Dockstore.getVersions(methodPath, sourceRepo === 'dockstoretools')
+        const versions = await Ajax(signal).Dockstore.getVersions({ path: methodPath, isTool: sourceRepo === 'dockstoretools' })
         const versionIds = _.map('name', versions)
 
         this.setState({ versionIds })
@@ -532,7 +532,7 @@ const WorkflowView = _.flow(
           this.setState({ synopsis, documentation, wdl: payload })
         }
       } else if (sourceRepo === 'dockstore' || sourceRepo === 'dockstoretools') {
-        const wdl = await Ajax(signal).Dockstore.getWdl(methodPath, methodVersion, sourceRepo === 'dockstoretools')
+        const wdl = await Ajax(signal).Dockstore.getWdl({ path: methodPath, version: methodVersion, isTool: sourceRepo === 'dockstoretools' })
         this.setState({ wdl })
       } else {
         throw new Error('unknown sourceRepo')

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -497,8 +497,8 @@ const WorkflowView = _.flow(
         const snapshotIds = _.map('snapshotId', methods)
 
         this.setState({ versionIds: snapshotIds })
-      } else if (sourceRepo === 'dockstore') {
-        const versions = await Ajax(signal).Dockstore.getVersions(methodPath)
+      } else if (sourceRepo === 'dockstore' || sourceRepo === 'dockstoretools') {
+        const versions = await Ajax(signal).Dockstore.getVersions(methodPath, sourceRepo === 'dockstoretools')
         const versionIds = _.map('name', versions)
 
         this.setState({ versionIds })
@@ -531,8 +531,8 @@ const WorkflowView = _.flow(
           const { synopsis, documentation, payload } = await Ajax(signal).Methods.method(methodNamespace, methodName, methodVersion).get()
           this.setState({ synopsis, documentation, wdl: payload })
         }
-      } else if (sourceRepo === 'dockstore') {
-        const wdl = await Ajax(signal).Dockstore.getWdl(methodPath, methodVersion)
+      } else if (sourceRepo === 'dockstore' || sourceRepo === 'dockstoretools') {
+        const wdl = await Ajax(signal).Dockstore.getWdl(methodPath, methodVersion, sourceRepo === 'dockstoretools')
         this.setState({ wdl })
       } else {
         throw new Error('unknown sourceRepo')


### PR DESCRIPTION
This adds proper handling for the new 'dockstoretools' sourceRepo in the UI. Method configs with the new sourceRepo can load and display the WDL and versions. Also changes the import page to be able to handle the new sourceRepo, though we will still need Dockstore to add the actual link on their end.

Tested locally by fabricating an import url locally, importing, and viewing the method config.