### PR TITLE
[CA-1135] Add google project box and copy to clipboard button

### DIFF
--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -180,7 +180,7 @@ export const WorkspaceDashboard = _.flow(
         accessLevel,
         owners,
         workspace: {
-          authorizationDomain, createdDate, lastModified, bucketName,
+          authorizationDomain, createdDate, lastModified, bucketName, googleProject,
           attributes, attributes: { description = '' }
         }
       }
@@ -257,6 +257,12 @@ export const WorkspaceDashboard = _.flow(
           h(InfoTile, { title: 'Access level' }, [roleString[accessLevel]]),
           Utils.canWrite(accessLevel) && h(InfoTile, { title: 'Est. $/month' }, [
             storageCostEstimate || '$ ...'
+          ]),
+          h(InfoTile, { title: 'Google Project Id' }, [
+            div({ style: { display: 'flex' } }, [
+              h(TooltipCell, [googleProject]),
+              h(ClipboardButton, { text: googleProject, style: { marginLeft: '0.25rem' } })
+            ])
           ])
         ]),
         div({ style: Style.dashboard.header }, ['Owners']),


### PR DESCRIPTION
Attached is a screenshot from a local terra instance. The icon copies the text to your clipboard. Jerome has signed off on this for now, with a redesign to this screen to come in the future. (Probably for App-Services to do, since its workspace related?)
<img width="325" alt="Screen Shot 2021-02-11 at 11 09 05 AM" src="https://user-images.githubusercontent.com/15351021/107664320-4d059500-6c5a-11eb-80ce-6f6436133c68.png">

