### PR TITLE
Arrange call lists by start time [BW-527]

### DIFF
--- a/src/pages/workspaces/workspace/jobHistory/WorkflowDashboard.js
+++ b/src/pages/workspaces/workspace/jobHistory/WorkflowDashboard.js
@@ -118,7 +118,7 @@ const WorkflowDashboard = _.flow(
     }), simplifiedFailures)
   }
 
-  const callNames = calls ? _.sortBy(callName => _.minBy(callObject => callObject.start, calls[callName]).start, _.keys(calls)) : []
+  const callNames = _.sortBy(callName => _.minBy('start', calls[callName]).start, _.keys(calls))
 
   return div({ style: { padding: '1rem 2rem 2rem', flex: 1, display: 'flex', flexDirection: 'column' } }, [
     workflowDetailsBreadcrumbSubtitle(namespace, name, submissionId, workflowId),

--- a/src/pages/workspaces/workspace/jobHistory/WorkflowDashboard.js
+++ b/src/pages/workspaces/workspace/jobHistory/WorkflowDashboard.js
@@ -118,7 +118,7 @@ const WorkflowDashboard = _.flow(
     }), simplifiedFailures)
   }
 
-  const callNames = calls ? _.sortBy(callName => _.minBy(_.start, calls[callName]).start, _.keys(calls)) : []
+  const callNames = calls ? _.sortBy(callName => _.minBy(callObject => callObject.start, calls[callName]).start, _.keys(calls)) : []
 
   return div({ style: { padding: '1rem 2rem 2rem', flex: 1, display: 'flex', flexDirection: 'column' } }, [
     workflowDetailsBreadcrumbSubtitle(namespace, name, submissionId, workflowId),

--- a/src/pages/workspaces/workspace/jobHistory/WorkflowDashboard.js
+++ b/src/pages/workspaces/workspace/jobHistory/WorkflowDashboard.js
@@ -118,7 +118,7 @@ const WorkflowDashboard = _.flow(
     }), simplifiedFailures)
   }
 
-  const callNames = _.sortBy(_.identity, _.keys(calls))
+  const callNames = calls ? _.sortBy(callName => _.minBy(_.start, calls[callName]).start, _.keys(calls)) : []
 
   return div({ style: { padding: '1rem 2rem 2rem', flex: 1, display: 'flex', flexDirection: 'column' } }, [
     workflowDetailsBreadcrumbSubtitle(namespace, name, submissionId, workflowId),


### PR DESCRIPTION
Tested locally against a workflow with a couple of calls: http://localhost:3000/#workspaces/general-dev-billing-account/cjl_test_workspace/job_history/82e9c326-8fc0-4d3f-aab7-d674bcaafa9e/23f98406-5d7a-4eae-be7f-bf6f6392c4ec

The more natural order makes it easier to decipher the story of what was going on in the workflow that the previous "alphabetical" order.