### PR TITLE
Workflow-level timing diagrams [BW-528]

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react-dropzone": "^11.3.2",
     "react-favicon": "^0.0.22",
     "react-focus-lock": "^2.5.0",
+    "react-google-charts": "^3.0.15",
     "react-hyperscript-helpers": "^1.2.0",
     "react-json-view": "^1.21.3",
     "react-modal": "^3.13.1",

--- a/src/pages/workspaces/workspace/jobHistory/WorkflowDashboard.js
+++ b/src/pages/workspaces/workspace/jobHistory/WorkflowDashboard.js
@@ -1,5 +1,6 @@
 import _ from 'lodash/fp'
 import { Fragment, useRef, useState } from 'react'
+import { Chart } from 'react-google-charts'
 import { div, h } from 'react-hyperscript-helpers'
 import ReactJson from 'react-json-view'
 import * as breadcrumbs from 'src/components/breadcrumbs'
@@ -19,6 +20,7 @@ import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 import CallTable from 'src/pages/workspaces/workspace/jobHistory/CallTable'
 import { wrapWorkspace } from 'src/pages/workspaces/workspace/WorkspaceContainer'
+import { WorkflowTimingDiagram } from 'src/pages/workspaces/workspace/jobHistory/WorkflowTimingDiagram'
 
 
 const styles = {
@@ -170,6 +172,13 @@ const WorkflowDashboard = _.flow(
               }, [icon('fileAlt', { size: 18 }), ' View execution log'])
             ])
           ])
+        ]),
+        h(Collapse, {
+          style: { marginBottom: '1rem' },
+          initialOpenState: true,
+          title: div({ style: Style.elements.sectionHeader }, ['Timing Diagram'])
+        }, [
+          h(WorkflowTimingDiagram, { callNames, callData: calls })
         ]),
         failures && h(Collapse,
           {

--- a/src/pages/workspaces/workspace/jobHistory/WorkflowDashboard.js
+++ b/src/pages/workspaces/workspace/jobHistory/WorkflowDashboard.js
@@ -1,6 +1,5 @@
 import _ from 'lodash/fp'
 import { Fragment, useRef, useState } from 'react'
-import { Chart } from 'react-google-charts'
 import { div, h } from 'react-hyperscript-helpers'
 import ReactJson from 'react-json-view'
 import * as breadcrumbs from 'src/components/breadcrumbs'
@@ -19,8 +18,8 @@ import { getConfig } from 'src/libs/config'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 import CallTable from 'src/pages/workspaces/workspace/jobHistory/CallTable'
-import { wrapWorkspace } from 'src/pages/workspaces/workspace/WorkspaceContainer'
 import { WorkflowTimingDiagram } from 'src/pages/workspaces/workspace/jobHistory/WorkflowTimingDiagram'
+import { wrapWorkspace } from 'src/pages/workspaces/workspace/WorkspaceContainer'
 
 
 const styles = {

--- a/src/pages/workspaces/workspace/jobHistory/WorkflowTimingDiagram.js
+++ b/src/pages/workspaces/workspace/jobHistory/WorkflowTimingDiagram.js
@@ -1,0 +1,83 @@
+import _ from 'lodash/fp'
+import { Chart } from 'react-google-charts'
+import { div, h } from 'react-hyperscript-helpers'
+
+
+export const WorkflowTimingDiagram = ({ callNames: sortedCallNames, callData }) => {
+  const timingData = _.map(callName => {
+    const callArray = callData[callName]
+    const now = Date.now()
+
+    const firstStartTime = _.flow(
+      _.map(c => c.start ? new Date(c.start) : (c.end ? new Date(c.end) - 1 : now - 1)),
+      _.minBy(_.identity)
+    )(callArray)
+
+    const finished = _.every(c => c.end, callArray)
+
+    const lastEndTime = finished ? _.flow(
+      _.map(c => new Date(c.end)),
+      _.maxBy(_.identity)
+    )(callArray) : now
+
+    return [callName, `${callName.replace(/.*\./, '')} × ${_.size(callData[callName])}`, firstStartTime, lastEndTime]
+  }, sortedCallNames)
+
+  const timingColors = _.map(callName => {
+    const statusCodes = {
+      Done: 'b',
+      RetryableFailure: 'b',
+      Running: 'c',
+      Aborting: 'd',
+      Aborted: 'd',
+      Failed: 'e'
+    }
+    const unknownCode = 'x'
+    const statusColors = {
+      a: 'rgb(204, 204, 255)',
+      b: 'rgb(116, 174, 67)',
+      c: 'rgb(0, 0, 153)',
+      d: 'rgb(236,156,88)',
+      e: 'rgb(204, 51, 0)',
+      x: 'rgb(204, 204, 255)'
+    }
+
+
+    let highestCode = 'a'
+    for (let i = 0; i < _.size(callData[callName]); i++) {
+      const thisStatus = callData[callName][i].executionStatus
+      const thisCode = _.getOr(unknownCode, thisStatus, statusCodes)
+      if (thisCode > highestCode) { highestCode = thisCode }
+    }
+
+    return statusColors[highestCode]
+  }, sortedCallNames)
+
+  return div({ style: { display: 'flex', width: '100%' } }, [
+    h(Chart, {
+      width: '100%',
+      height: (1 + _.min([_.size(callData), 10])) * 50,
+      chartType: 'Timeline',
+      loader: 'Loading Chart',
+      data: [
+        [
+          { type: 'string', id: 'CallName' },
+          { type: 'string', id: 'Label' },
+          { type: 'date', id: 'Start' },
+          { type: 'date', id: 'End' }
+        ],
+        ...timingData
+      ],
+      options: {
+        timeline: {
+          showRowLabels: false,
+          barLabelStyle: {
+            fontName: 'Courier New',
+            fontSize: 14
+          }
+        },
+        colors: timingColors
+      }
+    })
+  ])
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9648,6 +9648,13 @@ react-focus-lock@^2.5.0:
     use-callback-ref "^1.2.1"
     use-sidecar "^1.0.1"
 
+react-google-charts@^3.0.15:
+  version "3.0.15"
+  resolved "https://registry.yarnpkg.com/react-google-charts/-/react-google-charts-3.0.15.tgz#30759a470f48336e744fd383d054122b039a1ff2"
+  integrity sha512-78s5xOQOJvL+jIewrWQZEHtlVk+5Yh4zZy+ODA1on1o1FaRjKWXxoo4n4JQl1XuqkF/A9NWque3KqM6pMggjzQ==
+  dependencies:
+    react-load-script "^0.0.6"
+
 react-hot-loader@^4.13.0:
   version "4.13.0"
   resolved "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.13.0.tgz"
@@ -9698,6 +9705,11 @@ react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+
+react-load-script@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/react-load-script/-/react-load-script-0.0.6.tgz#db6851236aaa25bb622677a2eb51dad4f8d2c258"
+  integrity sha512-aRGxDGP9VoLxcsaYvKWIW+LRrMOzz2eEcubTS4NvQPPugjk2VvMhow0wWTkSl7RxookomD1MwcP4l5UStg5ShQ==
 
 react-modal@^3.13.1:
   version "3.13.1"


### PR DESCRIPTION
A "10,000 foot view" style timing diagram to show call-by-call timings (ie not x-ray-ing into scatters or backend events). Intended to give the broad picture of what happened in a workflow and let future diagrams (perhaps on call-specific pages) expand the call-specific events. 

The choice to collapse all rows of scatters and attempts into a single bar which does not break out per-call-event is based on:

* The observation that timing diagrams with >10,000 lines are not particularly useful.
* The assumption that seeing the shape of a workflow upfront is valuable (including which calls succeeded and which failed)
* The assumption that getting something high level out to users now - and adding a way to drill into per-call-details later - is also a good way to organize the user experience
* The fact that was much easier to bring the diagrams in than I thought it might be!

#### Screenshots

##### Successful workflow

![image](https://user-images.githubusercontent.com/13006282/107880463-e0ce9f80-6eac-11eb-9080-4b0faa8d0e2f.png)

##### Failed workflow

![image](https://user-images.githubusercontent.com/13006282/107880472-f348d900-6eac-11eb-8e52-993acb3b5b4e.png)

#### Review Recommendations

I would start with `WorkflowTimingDiagram.js`. I think my way of finding the "worst" status for each call and assigning it a color could almost certainly be improved and I'm very open to iterating on that code path. Otherwise, this change seemed fairly (even surprisingly!) straightforward.

#### Good test workflows:

* Workflow with scattered subworkflow:
  * A **DEV** [workflow](http://localhost:3000/#workspaces/general-dev-billing-account/cjl_test_workspace/job_history/5527bea1-3b3a-4331-9810-1728b5c01538/921c9bae-5e8a-40c9-90bc-726b9873ceac) which has a scattered subworkflow which failed.
  * The same **DEV** [workflow](http://localhost:3000/#workspaces/general-dev-billing-account/cjl_test_workspace/job_history/82e9c326-8fc0-4d3f-aab7-d674bcaafa9e/23f98406-5d7a-4eae-be7f-bf6f6392c4ec) which has a scattered subworkflow which succeeded.
  * DIY: Run the same workflow as in the previous few examples yourself (with call caching disabled or some slightly different inputs). See how the Running state is reported.
* A workflow which was aborted:
  * A **DEV** [workflow](http://localhost:3000/#workspaces/general-dev-billing-account/cjl_test_workspace/job_history/5527bea1-3b3a-4331-9810-1728b5c01538/921c9bae-5e8a-40c9-90bc-726b9873ceac) which has a task which was aborted.
  * Compare with the same workflow without the timing diagram. Note that the timing diagram makes is clear that the workflow was aborted (with the orange status bar) much more obviously even that the "Aborted" status text did.