### PR TITLE
[No ticket] fix destructuring

### DIFF
--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -42,7 +42,7 @@ const NotebookLauncher = _.flow(
     showTabBar: false
   })
 )(
-  ({ queryParams, notebookName, workspace, accessLevel, canCompute, runtimes, persistentDisks, refreshRuntimes },
+  ({ queryParams, notebookName, workspace, workspace: { workspace: { namespace, name }, accessLevel, canCompute }, runtimes, persistentDisks, refreshRuntimes },
     ref) => {
     const [createOpen, setCreateOpen] = useState(false)
     const runtime = currentRuntime(runtimes)


### PR DESCRIPTION
If you try to open a notebook in a workspace created before last week with this change not present, the edit button will not appear due to this PR https://github.com/DataBiosphere/terra-ui/pull/2372 

This fixes the destructuring. I would like to clean this up, but not when I'm blocking release and distrust our test coverage. 

This is what `workspace` looks printed out in `NotebookLauncher.js`

<img width="757" alt="Screen Shot 2021-02-16 at 9 58 53 AM" src="https://user-images.githubusercontent.com/6465084/108083766-6edb8f00-7041-11eb-9b59-1e27c243672a.png">
