### PR TITLE
Remove wait message from error

### DIFF
--- a/src/components/NewGalaxyModal.js
+++ b/src/components/NewGalaxyModal.js
@@ -187,7 +187,7 @@ export const NewGalaxyModal = _.flow(
   }
 
   const getEnvMessageBasedOnStatus = isTitle => {
-    const waitMessage = isTitle ? '' : 'This process will take up to a few minutes'
+    const waitMessage = isTitle ? '' : 'This process will take up to a few minutes.'
 
     return !app ?
       isTitle ? 'Cloud environment' : 'Environment will consist of an application and cloud compute.' :
@@ -198,7 +198,7 @@ export const NewGalaxyModal = _.flow(
         ['PRESTARTING', () => 'Cloud environment is preparing to start.'],
         ['STARTING', () => `Cloud environment is starting. ${waitMessage}`],
         ['RUNNING', () => 'Environment consists of an application and cloud compute.'],
-        ['ERROR', () => `An error has occurred on your Cloud Environment. ${waitMessage}`]
+        ['ERROR', () => `An error has occurred on your cloud environment.`]
       )
   }
 


### PR DESCRIPTION
Previously the error'ed galaxy app told users to wait but their only option once it's error'ed is to delete or reach out to support so the wait message was confusing.

Before:
<img width="719" alt="Screen Shot 2021-02-22 at 10 17 29 AM" src="https://user-images.githubusercontent.com/54322292/108728712-d5f0bc00-74f7-11eb-945d-c660f96a8227.png">

After:
<img width="734" alt="Screen Shot 2021-02-22 at 10 22 05 AM" src="https://user-images.githubusercontent.com/54322292/108728757-dd17ca00-74f7-11eb-98ef-c6653f8650c7.png">

