### PR TITLE
[IA-2545] Update Galaxy default conf to 1 n1-highmem-8 node

### DIFF
--- a/src/components/NewGalaxyModal.js
+++ b/src/components/NewGalaxyModal.js
@@ -203,8 +203,8 @@ export const NewGalaxyModal = _.flow(
   }
 
   const renderDefaultCase = () => {
-    const { cpu, memory } = _.find({ name: 'n1-standard-8' }, machineTypes)
-    const cost = getGalaxyCost(app || { kubernetesRuntimeConfig: { machineType: 'n1-standard-8', numNodes: 2 } })
+    const { cpu, memory } = _.find({ name: 'n1-highmem-8' }, machineTypes)
+    const cost = getGalaxyCost(app || { kubernetesRuntimeConfig: { machineType: 'n1-highmem-8', numNodes: 1 } })
     return h(Fragment, [
       h(TitleBar, {
         title: getEnvMessageBasedOnStatus(true),

--- a/src/components/NewGalaxyModal.js
+++ b/src/components/NewGalaxyModal.js
@@ -203,8 +203,9 @@ export const NewGalaxyModal = _.flow(
   }
 
   const renderDefaultCase = () => {
-    const { cpu, memory } = _.find({ name: 'n1-highmem-8' }, machineTypes)
-    const cost = getGalaxyCost(app || { kubernetesRuntimeConfig: { machineType: 'n1-highmem-8', numNodes: 1 } })
+    const defaultMachineType = 'n1-highmem-8'
+    const { cpu, memory } = _.find({ name: defaultMachineType }, machineTypes)
+    const cost = getGalaxyCost(app || { kubernetesRuntimeConfig: { machineType: defaultMachineType, numNodes: 1 } })
     return h(Fragment, [
       h(TitleBar, {
         title: getEnvMessageBasedOnStatus(true),


### PR DESCRIPTION
See rationale in JIRA ticket: https://broadworkbench.atlassian.net/browse/IA-2545

See corresponding Leo PR: https://github.com/DataBiosphere/leonardo/pull/1893

I tested locally. With the change:
![image](https://user-images.githubusercontent.com/5368863/109183823-56aff200-775c-11eb-916f-ba41019f1365.png)

Current dev:
![image](https://user-images.githubusercontent.com/5368863/109184779-4fd5af00-775d-11eb-8f76-e1db759934df.png)

Nice cost savings for the user too.