### PR TITLE
[IA-2566] Fix Galaxy 401

### DIFF
--- a/src/components/runtime-common.js
+++ b/src/components/runtime-common.js
@@ -136,7 +136,7 @@ export const GalaxyLaunchButton = ({ app, onClick, ...props }) => {
       onClick()
       Ajax().Metrics.captureEvent(Events.applicationLaunch, { app: 'Galaxy' })
     },
-    ...Utils.newTabLinkPropsGalaxy,
+    ...Utils.newTabLinkPropsWithReferrer, // Galaxy needs the referrer to be present so we can validate it, otherwise we fail with 401
     ...props
   }, ['Launch Galaxy'])
 }

--- a/src/components/runtime-common.js
+++ b/src/components/runtime-common.js
@@ -136,7 +136,7 @@ export const GalaxyLaunchButton = ({ app, onClick, ...props }) => {
       onClick()
       Ajax().Metrics.captureEvent(Events.applicationLaunch, { app: 'Galaxy' })
     },
-    ...Utils.newTabLinkProps,
+    ...Utils.newTabLinkPropsGalaxy,
     ...props
   }, ['Launch Galaxy'])
 }

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -358,7 +358,7 @@ export const useUniqueId = () => {
 
 export const newTabLinkProps = { target: '_blank', rel: 'noopener noreferrer' } // https://mathiasbynens.github.io/rel-noopener/
 
-export const newTabLinkPropsGalaxy = { target: '_blank', rel: 'noopener' } // Galaxy needs the referrer to be present so we can validate it, otherwise we fail with 401
+export const newTabLinkPropsWithReferrer = { target: '_blank', rel: 'noopener' }
 
 export const createHtmlElement = (doc, name, attrs) => {
   const element = doc.createElement(name)

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -358,6 +358,8 @@ export const useUniqueId = () => {
 
 export const newTabLinkProps = { target: '_blank', rel: 'noopener noreferrer' } // https://mathiasbynens.github.io/rel-noopener/
 
+export const newTabLinkPropsGalaxy = { target: '_blank', rel: 'noopener' } // Galaxy needs the referrer to be present so we can validate it, otherwise we fail with 401
+
 export const createHtmlElement = (doc, name, attrs) => {
   const element = doc.createElement(name)
   _.forEach(([k, v]) => element.setAttribute(k, v), _.toPairs(attrs))


### PR DESCRIPTION
We recently added a referrer check to all leo proxy routes (this feature is currently disabled in all environments until https://broadworkbench.atlassian.net/browse/IA-2566 is complete which is dependent on the AoU team). here is the PR for the referrer check: https://github.com/DataBiosphere/leonardo/pull/1854. we essentially check that every request to the leonardo proxy has a `Referer` header which is in our list of valid referrers to help prevent CSRF attacks

While doing some testing in dev with the referrer check enabled - realized that since Galaxy opens in a new tab (unlike jupyter and rstudio) that we were throwing a 401 since previously we were stripping the referrer in terra-ui when a new tab is opened:
![Screen Shot 2021-03-03 at 3 12 18 PM](https://user-images.githubusercontent.com/23626109/109866122-e3fab700-7c32-11eb-843b-027a7f53cb51.png)

This PR allows the referrer to be present in a new tab only when a user launches Galaxy. I tested this in my Fiab by pointing my local terra UI at my fiab and manually enabling the referrer check and verifying that Galaxy no longer fails with a 401:
![Screen Shot 2021-03-03 at 3 04 56 PM](https://user-images.githubusercontent.com/23626109/109865985-bf064400-7c32-11eb-85c1-85ca199ca95a.png)


