### PR TITLE
QA-1383: Adding logging when adding user to billing account

### DIFF
--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -85,7 +85,13 @@ const addUserToBilling = _.flow(withSignedInPage, withUserToken)(async ({ page, 
     return window.Ajax().Billing.project(billingProject).listUsers()
   }, billingProject)
 
-  console.info(`users in billing project: ${userList}`)
+  function getval(email) {
+
+    let obj = userList.filter(item => item.email === email)
+    return obj[0].role
+  }
+
+  console.info(`test user was added to the billing project with the role: ${getval(email)}`)
 })
 
 const removeUserFromBilling = _.flow(withSignedInPage, withUserToken)(async ({ page, billingProject, email }) => {

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -85,13 +85,12 @@ const addUserToBilling = _.flow(withSignedInPage, withUserToken)(async ({ page, 
     return window.Ajax().Billing.project(billingProject).listUsers()
   }, billingProject)
 
-  function getval(email) {
-
-    let obj = userList.filter(item => item.email === email)
-    return obj[0].role
+  const getVal = email => {
+    const userKey = _.find({email}, userList)
+    return userKey.map(user=> user.role)
   }
 
-  console.info(`test user was added to the billing project with the role: ${getval(email)}`)
+  console.info(`test user was added to the billing project with the role: ${getVal(email)}`)
 })
 
 const removeUserFromBilling = _.flow(withSignedInPage, withUserToken)(async ({ page, billingProject, email }) => {

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -80,6 +80,12 @@ const addUserToBilling = _.flow(withSignedInPage, withUserToken)(async ({ page, 
   }, email, billingProject)
 
   console.info(`added user to: ${billingProject}`)
+
+  const userList = await page.evaluate((billingProject) => {
+    return window.Ajax().Billing.project(billingProject).listUsers()
+  }, billingProject)
+
+  console.info(`users in billing project: ${userList}`)
 })
 
 const removeUserFromBilling = _.flow(withSignedInPage, withUserToken)(async ({ page, billingProject, email }) => {

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -87,7 +87,7 @@ const addUserToBilling = _.flow(withSignedInPage, withUserToken)(async ({ page, 
 
   const getVal = email => {
     const userKey = _.find({email}, userList)
-    return userKey.map(user=> user.role)
+    return userKey.role
   }
 
   console.info(`test user was added to the billing project with the role: ${getVal(email)}`)

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -85,12 +85,9 @@ const addUserToBilling = _.flow(withSignedInPage, withUserToken)(async ({ page, 
     return window.Ajax().Billing.project(billingProject).listUsers()
   }, billingProject)
 
-  const getVal = email => {
-    const userKey = _.find({email}, userList)
-    return userKey.role
-  }
+  const billingUser = _.find({ email }, userList)
 
-  console.info(`test user was added to the billing project with the role: ${getVal(email)}`)
+  console.info(`test user was added to the billing project with the role: ${!!billingUser && billingUser.role}`)
 })
 
 const removeUserFromBilling = _.flow(withSignedInPage, withUserToken)(async ({ page, billingProject, email }) => {


### PR DESCRIPTION
<!--
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Thanks!
--!>
This PR doesn't fix the underlying issue for the run-notebooks test, but it does add some additional console logging to help us debug in the future if we run into this issue again. Looking at the screenshot accompanying this error, it looks like the user doesn't have "Edit" permissions on the notebook, so we wanted to track to make sure the user gets added to the billing project correctly at the time of the test.

If this issue still persists even if the user is added properly, I think the next step would be to look into Rawls/Sam to see if there's a race condition of some sort. 

Tested this locally with @ehanna4 to make sure that the information was printed correctly in the console.