### PR TITLE
Add more flag icons for regional buckets

### DIFF
--- a/src/components/region-common.js
+++ b/src/components/region-common.js
@@ -17,8 +17,48 @@ export const regionInfo = (location, locationType) => {
       }
     case 'region':
       switch (location) {
+        case 'ASIA-EAST1':
+          return { flag: '🇹🇼', regionDescription: `${locationType}: ${location} (Taiwan)` }
+        case 'ASIA-EAST2':
+          return { flag: '🇭🇰', regionDescription: `${locationType}: ${location} (Hong Kong)` }
+        case 'ASIA-NORTHEAST1':
+          return { flag: '🇯🇵', regionDescription: `${locationType}: ${location} (Tokyo)` }
+        case 'ASIA-NORTHEAST2':
+          return { flag: '🇯🇵', regionDescription: `${locationType}: ${location} (Osaka)` }
+        case 'ASIA-NORTHEAST3':
+          return { flag: '🇰🇷', regionDescription: `${locationType}: ${location} (Seoul)` }
+        case 'ASIA-SOUTH1':
+          return { flag: '🇮🇳', regionDescription: `${locationType}: ${location} (Mumbai)` }
+        case 'ASIA-SOUTHEAST1':
+          return { flag: '🇸🇬', regionDescription: `${locationType}: ${location} (Singapore)` }
+        case 'ASIA-SOUTHEAST2':
+          return { flag: '🇮🇩', regionDescription: `${locationType}: ${location} (Jakarta)` }
+        case 'AUSTRALIA-SOUTHEAST1':
+          return { flag: '🇦🇺', regionDescription: `${locationType}: ${location} (Sydney)` }
         case 'EUROPE-NORTH1':
           return { flag: '🇫🇮', regionDescription: `${locationType}: ${location} (Finland)` }
+        case 'EUROPE-WEST1':
+          return { flag: '🇧🇪', regionDescription: `${locationType}: ${location} (Belgium)` }
+        case 'EUROPE-WEST2':
+          return { flag: '🇬🇧', regionDescription: `${locationType}: ${location} (London)` }
+        case 'EUROPE-WEST3':
+          return { flag: '🇩🇪', regionDescription: `${locationType}: ${location} (Frankfurt)` }
+        case 'EUROPE-WEST4':
+          return { flag: '🇳🇱', regionDescription: `${locationType}: ${location} (Netherlands)` }
+        case 'EUROPE-WEST6':
+          return { flag: '🇨🇭', regionDescription: `${locationType}: ${location} (Zurich)` }
+        case 'NORTHAMERICA-NORTHEAST1':
+          return { flag: '🇨🇦', regionDescription: `${locationType}: ${location} (Montreal)` }
+        case 'SOUTHAMERICA-EAST1':
+          return { flag: '🇧🇷', regionDescription: `${locationType}: ${location} (Sao Paulo)` }
+        case 'US-CENTRAL1':
+        case 'US-EAST1':
+        case 'US-EAST4':
+        case 'US-WEST1':
+        case 'US-WEST2':
+        case 'US-WEST3':
+        case 'US-WEST4':
+          return { flag: '🇺🇸', regionDescription: `${locationType}: ${location}` }
         default:
           return { flag: unknownRegionFlag, regionDescription: `${locationType}: ${location}` }
       }

--- a/src/components/region-common.js
+++ b/src/components/region-common.js
@@ -52,13 +52,19 @@ export const regionInfo = (location, locationType) => {
         case 'SOUTHAMERICA-EAST1':
           return { flag: '🇧🇷', regionDescription: `${locationType}: ${location} (Sao Paulo)` }
         case 'US-CENTRAL1':
+          return { flag: '🇺🇸', regionDescription: `${locationType}: ${location} (Iowa)` }
         case 'US-EAST1':
+          return { flag: '🇺🇸', regionDescription: `${locationType}: ${location} (South Carolina)` }
         case 'US-EAST4':
+          return { flag: '🇺🇸', regionDescription: `${locationType}: ${location} (Northern Virginia)` }
         case 'US-WEST1':
+          return { flag: '🇺🇸', regionDescription: `${locationType}: ${location} (Oregon)` }
         case 'US-WEST2':
+          return { flag: '🇺🇸', regionDescription: `${locationType}: ${location} (Los Angeles)` }
         case 'US-WEST3':
+          return { flag: '🇺🇸', regionDescription: `${locationType}: ${location} (Salt Lake City)` }
         case 'US-WEST4':
-          return { flag: '🇺🇸', regionDescription: `${locationType}: ${location}` }
+          return { flag: '🇺🇸', regionDescription: `${locationType}: ${location} (Las Vegas)` }
         default:
           return { flag: unknownRegionFlag, regionDescription: `${locationType}: ${location}` }
       }


### PR DESCRIPTION
This pull requests gets all the regions from https://cloud.google.com/storage/docs/locations and adds an appropriate flag icon for it. 

Example screenshot from local testing:
![Screenshot 2021-03-10 4 15 06 PM](https://user-images.githubusercontent.com/6879774/110716842-ce4e3a00-81bc-11eb-9c30-6b6ceb9b7c2a.png)
