### PR TITLE
AS-690: real data repo prod URL

### DIFF
--- a/config/prod.json
+++ b/config/prod.json
@@ -3,7 +3,7 @@
   "bardRoot": "https://terra-bard-prod.appspot.com",
   "bondUrlRoot": "https://broad-bond-prod.appspot.com",
   "calhounUrlRoot": "https://terra-calhoun-prod.appspot.com",
-  "dataRepoUrlRoot": "https://jade-terra.datarepo-prod.broadinstitute.org",
+  "dataRepoUrlRoot": "https://data.terra.bio",
   "dockstoreUrlRoot": "https://dockstore.org",
   "firecloudBucketRoot": "https://storage.googleapis.com/firecloud-alerts",
   "firecloudUrlRoot": "https://portal.firecloud.org",


### PR DESCRIPTION
Correct prod URL for data repo. This is part of AS-690 but does not complete that ticket.

Untested, since TDR integration is not available in prod, but hopefully the change is constrained enough to assess via code review.

<!--
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Thanks!
--!>
