### PR TITLE
Adjust test schedule for start of DST 2021

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,7 +233,7 @@ workflows:
   nightly-integration-tests:
     triggers:
       - schedule:
-          cron: "0 14 * * *"
+          cron: "0 13 * * *"
           filters:
             branches:
               only: dev


### PR DESCRIPTION
I did not create a Jira ticket for this because this change does not affect any production code in any way.