### PR TITLE
dont show table-output help text for snapshots [AS-675]

### DIFF
--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -837,7 +837,7 @@ const WorkflowView = _.flow(
                 span({ style: styles.placeholder }, 'workflow unique ID')
               ])
             ]),
-            !!rootEntityType && entitySelectionModel.type !== processSnapshotTable && h(Fragment, [
+            !!rootEntityType && (entitySelectionModel.type !== processSnapshotTable) && h(Fragment, [
               div({ style: { margin: '0.5rem 0', borderBottom: `1px solid ${colors.dark(0.55)}` } }),
               div({ style: styles.outputInfoLabel }, 'References to outputs will be written to'),
               div({ style: { display: 'flex', alignItems: 'center' } }, [

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -837,7 +837,7 @@ const WorkflowView = _.flow(
                 span({ style: styles.placeholder }, 'workflow unique ID')
               ])
             ]),
-            !!rootEntityType && entitySelectionModel.type != processSnapshotTable && h(Fragment, [
+            !!rootEntityType && entitySelectionModel.type !== processSnapshotTable && h(Fragment, [
               div({ style: { margin: '0.5rem 0', borderBottom: `1px solid ${colors.dark(0.55)}` } }),
               div({ style: styles.outputInfoLabel }, 'References to outputs will be written to'),
               div({ style: { display: 'flex', alignItems: 'center' } }, [

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -837,7 +837,7 @@ const WorkflowView = _.flow(
                 span({ style: styles.placeholder }, 'workflow unique ID')
               ])
             ]),
-            !!rootEntityType && h(Fragment, [
+            !!rootEntityType && entitySelectionModel.type != processSnapshotTable && h(Fragment, [
               div({ style: { margin: '0.5rem 0', borderBottom: `1px solid ${colors.dark(0.55)}` } }),
               div({ style: styles.outputInfoLabel }, 'References to outputs will be written to'),
               div({ style: { display: 'flex', alignItems: 'center' } }, [


### PR DESCRIPTION
AS-675

Don't show the "References to outputs will be written to ... " help text in the Workflows tab if the current workflow is set to run against a Data Repo snapshot. Snapshot-based workflows do not write back to tables.

Tested by running locally and toggling back and forth between a table, a snapshot, and file-based workflow inputs.

**workflow configured to run on a table:**
![analysis-on-table](https://user-images.githubusercontent.com/6041577/111503784-731cca00-871d-11eb-8568-e77230db7607.png)

**workflow configured to run on a snapshot:**
![analysis-on-snapshot](https://user-images.githubusercontent.com/6041577/111503800-7748e780-871d-11eb-8020-e19c4ae8f561.png)
