### PR TITLE
remove hideSnapshots functionality (snapshot features always on) [AS-563]

### DIFF
--- a/config/prod.json
+++ b/config/prod.json
@@ -8,7 +8,6 @@
   "firecloudBucketRoot": "https://storage.googleapis.com/firecloud-alerts",
   "firecloudUrlRoot": "https://portal.firecloud.org",
   "googleClientId": "424501080111-b3bt4p1vo4gbo4m0573nvi4d49784bp8.apps.googleusercontent.com",
-  "hideSnapshots": true,
   "isProd": true,
   "jobManagerUrlRoot": "https://job-manager.dsde-prod.broadinstitute.org/jobs",
   "leoUrlRoot": "https://notebooks.firecloud.org",

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -658,9 +658,6 @@ const Workspaces = signal => ({
       },
 
       listSnapshot: async (limit, offset) => {
-        if (getConfig().hideSnapshots) {
-          return { resources: [] }
-        }
         const res = await fetchRawls(`${root}/snapshots?offset=${offset}&limit=${limit}`, _.merge(authOpts(), { signal }))
         return res.json()
       },


### PR DESCRIPTION
AS-563

remove the `hideSnapshots` feature flag, and remove the one place in the code that looked at that flag

When we merge this PR, the next deploy to prod will enable snapshot integration, so let's be judicious about when we merge it.