### PR TITLE
POC: implement nested error messages in modals

### DIFF
--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -15,17 +15,19 @@ import { Ajax } from 'src/libs/ajax'
 import { getUser } from 'src/libs/auth'
 import colors from 'src/libs/colors'
 import { withErrorIgnoring, withErrorReporting } from 'src/libs/error'
+import { LocalNotifications, useNotificationState } from 'src/libs/notifications'
 import { currentRuntime, persistentDiskCostMonthly, runtimeCost } from 'src/libs/runtime-utils'
 import * as Style from 'src/libs/style'
 import { cond, formatUSD, makeCompleteDate, useCancellation, useGetter, useOnMount, usePollingEffect, withBusyState } from 'src/libs/utils'
 
 
 const DeleteRuntimeModal = ({ runtime: { googleProject, runtimeName, runtimeConfig: { persistentDiskId } }, onDismiss, onSuccess }) => {
+  const { notificationState, reportError } = useNotificationState()
   const [deleteDisk, setDeleteDisk] = useState(false)
   const [deleting, setDeleting] = useState()
   const deleteRuntime = _.flow(
     withBusyState(setDeleting),
-    withErrorReporting('Error deleting cloud environment')
+    withErrorReporting(reportError('Error deleting cloud environment'))
   )(async () => {
     await Ajax().Runtimes.runtime(googleProject, runtimeName).delete(deleteDisk)
     onSuccess()
@@ -49,6 +51,7 @@ const DeleteRuntimeModal = ({ runtime: { googleProject, runtimeName, runtimeConf
         'which will take several minutes.'
       ])
     ]),
+    h(LocalNotifications, { notificationState }),
     deleting && spinnerOverlay
   ])
 }


### PR DESCRIPTION
This introduces a bit of infrastructure to allow notifications to be nested inside modals and drawers, which could be used to improve error handling within these parts of the UI.

There are three pieces that work together:
1. A new `useNotificationState` hook, which attaches a new local notification list to a component, and provides `notify` and `reportError` functions for updating it, which are compatible with their global counterparts.
2. A change to `withErrorReporting` to optionally accept a function, to allow routing error messages to the local list instead of the global one.
3. A new `LocalNotifications` component which can be used to render the local notifications within any 'positioned' container, e.g. modals, drawers.

See the `Environments.js` change for how this would look in practice. I tested by trying to delete one of the 'stuck' runtimes in dev, which generates an error.

This seems to work pretty well, but there are some caveats we might consider before moving forward:
* Currently we're rendering these similarly to the existing ones, as overlays in the upper right. Because modals are more compact, this might end up being overly disruptive. That said, the immediate use case is for errors, which are disruptive by definition.
* The local notifications don't currently use animation. Due to the positioning, we probably couldn't use the same 'slide' animation anyway, so we'd need to come up with something new if we wanted that.