### PR TITLE
track mixpanel events for snapshots [AS-556]

### DIFF
--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -25,7 +25,8 @@ const eventsList = {
   workspaceClone: 'workspace:clone',
   workspaceCreate: 'workspace:create',
   workspaceDataImport: 'workspace:data:import',
-  workspaceShare: 'workspace:share'
+  workspaceShare: 'workspace:share',
+  workspaceSnapshotContentsView: 'workspace:snapshot:contents:view'
 }
 
 export const extractWorkspaceDetails = workspaceObject => {

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -460,7 +460,7 @@ const WorkspaceData = _.flow(
           error: snapshotMetadataError,
           retryFunction: loadSnapshotMetadata
         }, [
-          _.map(([snapshotName, { resource: { referenceId }, entityMetadata: snapshotTables, error: snapshotTablesError }]) => {
+          _.map(([snapshotName, { resource: { referenceId, reference: { snapshot } }, entityMetadata: snapshotTables, error: snapshotTablesError }]) => {
             const snapshotTablePairs = toSortedPairs(snapshotTables)
             return h(Collapse, {
               key: snapshotName,
@@ -504,7 +504,8 @@ const WorkspaceData = _.flow(
                       setSelectedDataType([snapshotName, tableName])
                       Ajax().Metrics.captureEvent(Events.workspaceSnapshotContentsView, {
                         ...extractWorkspaceDetails({ workspace }),
-                        snapshotId: referenceId,
+                        referenceId,
+                        snapshotId: snapshot,
                         entityType: tableName
                       })
                       forceRefresh()

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -21,6 +21,7 @@ import { SnapshotInfo } from 'src/components/workspace-utils'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { reportError, withErrorReporting } from 'src/libs/error'
+import Events, { extractWorkspaceDetails } from 'src/libs/events'
 import { pfbImportJobStore } from 'src/libs/state'
 import * as StateHistory from 'src/libs/state-history'
 import * as Style from 'src/libs/style'
@@ -501,6 +502,11 @@ const WorkspaceData = _.flow(
                     selected: _.isEqual(selectedDataType, [snapshotName, tableName]),
                     onClick: () => {
                       setSelectedDataType([snapshotName, tableName])
+                      Ajax().Metrics.captureEvent(Events.workspaceSnapshotContentsView, {
+                        ...extractWorkspaceDetails({ workspace }),
+                        snapshotName: snapshotName,
+                        entityType: tableName
+                      })
                       forceRefresh()
                     }
                   }, [`${tableName} (${count})`])

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -460,7 +460,7 @@ const WorkspaceData = _.flow(
           error: snapshotMetadataError,
           retryFunction: loadSnapshotMetadata
         }, [
-          _.map(([snapshotName, { entityMetadata: snapshotTables, error: snapshotTablesError }]) => {
+          _.map(([snapshotName, { resource: { referenceId }, entityMetadata: snapshotTables, error: snapshotTablesError }]) => {
             const snapshotTablePairs = toSortedPairs(snapshotTables)
             return h(Collapse, {
               key: snapshotName,
@@ -504,7 +504,7 @@ const WorkspaceData = _.flow(
                       setSelectedDataType([snapshotName, tableName])
                       Ajax().Metrics.captureEvent(Events.workspaceSnapshotContentsView, {
                         ...extractWorkspaceDetails({ workspace }),
-                        snapshotName,
+                        snapshotId: referenceId,
                         entityType: tableName
                       })
                       forceRefresh()

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -504,7 +504,7 @@ const WorkspaceData = _.flow(
                       setSelectedDataType([snapshotName, tableName])
                       Ajax().Metrics.captureEvent(Events.workspaceSnapshotContentsView, {
                         ...extractWorkspaceDetails({ workspace }),
-                        snapshotName: snapshotName,
+                        snapshotName,
                         entityType: tableName
                       })
                       forceRefresh()

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -407,7 +407,7 @@ const WorkflowView = _.flow(
           onDismiss: () => this.setState({ launching: false }),
           onSuccess: submissionId => {
             const { methodRepoMethod: { methodVersion, methodNamespace, methodName, methodPath, sourceRepo } } = modifiedConfig
-            Ajax().Metrics.captureEvent(Events.workflowLaunch, { ...extractWorkspaceDetails(workspace), methodVersion, sourceRepo, methodPath: sourceRepo === 'agora' ? `${methodNamespace}/${methodName}` : methodPath })
+            Ajax().Metrics.captureEvent(Events.workflowLaunch, { ...extractWorkspaceDetails(workspace), fromSnapshot: entitySelectionModel.type.description === 'process snapshot table', methodVersion, sourceRepo, methodPath: sourceRepo === 'agora' ? `${methodNamespace}/${methodName}` : methodPath })
             Nav.goToPath('workspace-submission-details', { submissionId, ...workspaceId })
           }
         }),

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -407,7 +407,7 @@ const WorkflowView = _.flow(
           onDismiss: () => this.setState({ launching: false }),
           onSuccess: submissionId => {
             const { methodRepoMethod: { methodVersion, methodNamespace, methodName, methodPath, sourceRepo } } = modifiedConfig
-            Ajax().Metrics.captureEvent(Events.workflowLaunch, { ...extractWorkspaceDetails(workspace), fromSnapshot: entitySelectionModel.type.description === 'process snapshot table', methodVersion, sourceRepo, methodPath: sourceRepo === 'agora' ? `${methodNamespace}/${methodName}` : methodPath })
+            Ajax().Metrics.captureEvent(Events.workflowLaunch, { ...extractWorkspaceDetails(workspace), fromSnapshot: entitySelectionModel.type === processSnapshotTable, methodVersion, sourceRepo, methodPath: sourceRepo === 'agora' ? `${methodNamespace}/${methodName}` : methodPath })
             Nav.goToPath('workspace-submission-details', { submissionId, ...workspaceId })
           }
         }),


### PR DESCRIPTION
This is to add some snapshot specific tracking to our mixpanel events. 

- (creating a snapshot reference was already taken care of by the data import tracking)
- added tracking for viewing snapshot entity contents 
- added a field to the launch workflow event to track whether it came from a snapshot or not

For the third point, I coerced it into a boolean, but I could also just track the import format. That would capture more info overall, but also require more work in mixpanel to be able to check how many workflows were launched from snapshots vs other data sources. If you have opinions on that please leave a comment! 

I did not create an event for deleting snapshot references because that function isn't in the UI yet 

