### PR TITLE
[SATURN-1887] Ensure that the Upload In Progress modal cannot be dismissed

### DIFF
--- a/src/components/ProgressBar.js
+++ b/src/components/ProgressBar.js
@@ -1,4 +1,5 @@
 import { dd, div, dl, dt, h, p, strong } from 'react-hyperscript-helpers'
+import { ButtonPrimary } from 'src/components/common'
 import Modal from 'src/components/Modal'
 import colors from 'src/libs/colors'
 import { friendlyFileSize } from 'src/libs/uploads'
@@ -52,8 +53,11 @@ export const UploadProgressModal = ({ status: { totalFiles, totalBytes, uploaded
   return h(Modal, {
     title: 'Upload in Progress...',
     showCancel: false,
-    onDismiss: abort,
-    okButton: 'Abort Upload',
+    onDismiss: () => {},
+    okButton: h(ButtonPrimary, {
+      onClick: abort,
+      danger: true
+    }, ['Abort Upload']),
     danger: true
   }, [
     p({

--- a/src/components/data/FileBrowser.js
+++ b/src/components/data/FileBrowser.js
@@ -134,26 +134,35 @@ export const FileBrowserPanel = _.flow(
       onDropAccepted: setUploadingFiles
     }, [({ openUploader }) => h(Fragment, [
       div({
-        style: { display: 'table', height: '100%' }
+        style: { display: 'flex', flexFlow: 'row nowrap', width: '100%' }
       }, [
-        _.map(({ label, target }) => {
-          return h(Fragment, { key: target }, [
-            makeBucketLink({
-              label, target: getFullPrefix(target),
-              onClick: () => setPrefix(target)
-            }),
-            ' / '
-          ])
+        div({
+          style: { display: 'table', height: '100%', flex: 1 }
         }, [
-          collection && { label: collection, target: '' },
-          ..._.map(n => {
-            return { label: prefixParts[n], target: _.map(s => `${s}/`, _.take(n + 1, prefixParts)).join('') }
-          }, _.range(0, prefixParts.length))
+          _.map(({ label, target }) => {
+            return h(Fragment, { key: target }, [
+              makeBucketLink({
+                label, target: getFullPrefix(target),
+                onClick: () => setPrefix(target)
+              }),
+              ' / '
+            ])
+          }, [
+            collection && { label: collection, target: '' },
+            ..._.map(n => {
+              return { label: prefixParts[n], target: _.map(s => `${s}/`, _.take(n + 1, prefixParts)).join('') }
+            }, _.range(0, prefixParts.length))
+          ]),
+          allowNewFolders && makeBucketLink({
+            label: span([icon('plus'), ' New folder']),
+            onClick: () => setCreating(true)
+          })
         ]),
-        allowNewFolders && makeBucketLink({
-          label: span([icon('plus'), ' New folder']),
-          onClick: () => setCreating(true)
-        })
+        uploadStatus.active && div({
+          style: { flex: 0 }
+        }, [
+          'Uploading...'
+        ])
       ]),
       div({ style: { margin: '1rem -1rem 1rem -1rem', borderBottom: `1px solid ${colors.dark(0.25)}` } }),
       (prefixes?.length > 0 || objects?.length > 0) ? div({


### PR DESCRIPTION
This PR ensures that the Upload in Progress modal on the `/#upload` page can't be dismissed accidentally, except by explicitly aborting the upload with the big red "Abort Upload" button. Currently, pressing the Escape key or clicking outside the modal aborts the upload but it's not clear that that's what happened.

This disables all of the other means of dismissing the modal besides the button. The user can't do anything else in their project while the upload is still going on, but they won't accidentally cancel the upload without realizing it.

In general it would be better to allow uploads in the background in order to not block the user when uploading large files. However, the Metadata Table functionality, the next step, expects all of the files to already be present in the bucket, so there's not really anything else we'd want users to be able to do while waiting anyway.

On the other hand, it's not necessary that all of the bytes actually be in Google so long as we can match filenames in the bucket. Perhaps a better future approach could be to use Google's streaming APIs instead and start all of the uploads synchronously, but then stream them in the background. The Streaming API requires significantly more local state management, though...