### PR TITLE
Warning about duplicate analyses of constant inputs [BW-599]

### DIFF
--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -25,7 +25,7 @@ import * as Utils from 'src/libs/utils'
 import validate from 'validate.js'
 
 
-const warningBoxStyle = {
+export const warningBoxStyle = {
   backgroundColor: colors.warning(0.15),
   padding: '1rem 1.25rem',
   color: colors.dark(), fontWeight: 'bold', fontSize: 12

--- a/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
+++ b/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
@@ -2,6 +2,7 @@ import _ from 'lodash/fp'
 import { Fragment, useState } from 'react'
 import { b, div, h, p, span, wbr } from 'react-hyperscript-helpers'
 import { ButtonPrimary, CromwellVersionLink } from 'src/components/common'
+import { warningBoxStyle } from 'src/components/data/data-utils'
 import { icon, spinner } from 'src/components/icons'
 import Modal from 'src/components/Modal'
 import { InfoBox } from 'src/components/PopupTrigger'
@@ -11,8 +12,6 @@ import { launch } from 'src/libs/analysis'
 import colors from 'src/libs/colors'
 import { withErrorReporting } from 'src/libs/error'
 import * as Utils from 'src/libs/utils'
-import {warningBoxStyle} from 'src/components/data/data-utils'
-
 import {
   chooseRows, chooseSetComponents, chooseSets, processAll, processAllAsSet, processMergedSet, processSnapshotTable
 } from 'src/pages/workspaces/workspace/workflows/EntitySelectionType'

--- a/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
+++ b/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
@@ -93,13 +93,6 @@ const LaunchAnalysisModal = ({
   const onlyConstantInputs = _.every(i => !i || Utils.maybeParseJSON(i) !== undefined, config.inputs)
   const warnDuplicateAnalyses = onlyConstantInputs && entityCount > 1
 
-  const fullWidthWarningStyle = {
-    ...warningBoxStyle,
-    borderLeft: 'none', borderRight: 'none',
-    margin: '0 -1.25rem',
-    fontSize: 14
-  }
-
   return h(Modal, {
     title: !launching ? 'Confirm launch' : 'Launching Analysis',
     onDismiss,
@@ -125,13 +118,18 @@ const LaunchAnalysisModal = ({
           p(['Note that metadata about this run will be stored in the US.'])
         ])]) : 'Loading...'
     ]),
-    // This will launch N analyses, but all the inputs are constant, so this will likely result in duplicated work." UX might have some ideas here.
-    warnDuplicateAnalyses ? div({ style: { margin: '1rem 0', ...fullWidthWarningStyle } }, [
-      icon('warning-standard', { size: 16, style: { color: colors.warning(), marginRight: '0.5rem' } }),
-      'Warning! This will launch ',
-      b([entityCount]),
-      span({ style: { fontWeight: 'bold', textDecoration: 'underline' } }, [' duplicate']),
-      ' analyses, but all of the inputs are constant. This is likely to result in re-calculation of the same result multiple times.'
+    warnDuplicateAnalyses ? div({
+      style: { ...warningBoxStyle, fontSize: 14, display: 'flex', flexDirection: 'column' }
+    }, [
+      div({ style: { display: 'flex', flexDirection: 'row', alignItems: 'center' } }, [
+        icon('warning-standard', { size: 19, style: { color: colors.warning(), flex: 'none', marginRight: '0.5rem' } }),
+        'Duplicate Analysis Warning'
+      ]),
+      div({ style: { fontWeight: 'normal', marginTop: '0.5rem' } }, [
+        'This will launch ',
+        b([entityCount]),
+        ' analyses, but all of the inputs are constant. This is likely to result in re-calculation of the same result multiple times.'
+      ])
     ]) : div({ style: { margin: '1rem 0' } }, [
       'This will launch ',
       b([entityCount]),

--- a/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
+++ b/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
@@ -125,13 +125,13 @@ const LaunchAnalysisModal = ({
           p(['Note that metadata about this run will be stored in the US.'])
         ])]) : 'Loading...'
     ]),
+    // This will launch N analyses, but all the inputs are constant, so this will likely result in duplicated work." UX might have some ideas here.
     warnDuplicateAnalyses ? div({ style: { margin: '1rem 0', ...fullWidthWarningStyle } }, [
       icon('warning-standard', { size: 16, style: { color: colors.warning(), marginRight: '0.5rem' } }),
       'Warning! This will launch ',
       b([entityCount]),
       span({ style: { fontWeight: 'bold', textDecoration: 'underline' } }, [' duplicate']),
-      entityCount === 1 ? ' analysis' : ' analyses',
-      warnDuplicateAnalyses && ' of the same set of constant inputs.'
+      ' analyses, but all of the inputs are constant. This is likely to result in re-calculation of the same result multiple times.'
     ]) : div({ style: { margin: '1rem 0' } }, [
       'This will launch ',
       b([entityCount]),

--- a/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
+++ b/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
@@ -11,6 +11,8 @@ import { launch } from 'src/libs/analysis'
 import colors from 'src/libs/colors'
 import { withErrorReporting } from 'src/libs/error'
 import * as Utils from 'src/libs/utils'
+import {warningBoxStyle} from 'src/components/data/data-utils'
+
 import {
   chooseRows, chooseSetComponents, chooseSets, processAll, processAllAsSet, processMergedSet, processSnapshotTable
 } from 'src/pages/workspaces/workspace/workflows/EntitySelectionType'
@@ -89,8 +91,15 @@ const LaunchAnalysisModal = ({
   const { location, locationType } = bucketLocation
   const { flag, regionDescription } = regionInfo(location, locationType)
 
-  const onlyConstantInputs = _.every(i => _.startsWith('"', i) && _.endsWith('"', i), config.inputs)
+  const onlyConstantInputs = _.every(i => !i || Utils.maybeParseJSON(i) !== undefined, config.inputs)
   const warnDuplicateAnalyses = onlyConstantInputs && entityCount > 1
+
+  const maybeWarningStyle = warnDuplicateAnalyses ? {
+    ...warningBoxStyle,
+    borderLeft: 'none', borderRight: 'none',
+    margin: '0 -1.25rem',
+    fontSize: 14
+  } : {}
 
   return h(Modal, {
     title: !launching ? 'Confirm launch' : 'Launching Analysis',
@@ -117,7 +126,7 @@ const LaunchAnalysisModal = ({
           p(['Note that metadata about this run will be stored in the US.'])
         ])]) : 'Loading...'
     ]),
-    div({ style: { margin: '1rem 0' } }, [
+    div({ style: { margin: '1rem 0', ...maybeWarningStyle } }, [
       warnDuplicateAnalyses && icon('warning-standard', { size: 16, style: { color: colors.warning(), marginRight: '0.5rem' } }),
       warnDuplicateAnalyses && 'Warning! ',
       'This will launch ',

--- a/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
+++ b/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
@@ -93,12 +93,12 @@ const LaunchAnalysisModal = ({
   const onlyConstantInputs = _.every(i => !i || Utils.maybeParseJSON(i) !== undefined, config.inputs)
   const warnDuplicateAnalyses = onlyConstantInputs && entityCount > 1
 
-  const maybeWarningStyle = warnDuplicateAnalyses ? {
+  const fullWidthWarningStyle = {
     ...warningBoxStyle,
     borderLeft: 'none', borderRight: 'none',
     margin: '0 -1.25rem',
     fontSize: 14
-  } : {}
+  }
 
   return h(Modal, {
     title: !launching ? 'Confirm launch' : 'Launching Analysis',
@@ -125,19 +125,21 @@ const LaunchAnalysisModal = ({
           p(['Note that metadata about this run will be stored in the US.'])
         ])]) : 'Loading...'
     ]),
-    div({ style: { margin: '1rem 0', ...maybeWarningStyle } }, [
-      warnDuplicateAnalyses && icon('warning-standard', { size: 16, style: { color: colors.warning(), marginRight: '0.5rem' } }),
-      warnDuplicateAnalyses && 'Warning! ',
+    warnDuplicateAnalyses ? div({ style: { margin: '1rem 0', ...fullWidthWarningStyle } }, [
+      icon('warning-standard', { size: 16, style: { color: colors.warning(), marginRight: '0.5rem' } }),
+      'Warning! This will launch ',
+      b([entityCount]),
+      span({ style: { fontWeight: 'bold', textDecoration: 'underline' } }, [' duplicate']),
+      entityCount === 1 ? ' analysis' : ' analyses',
+      warnDuplicateAnalyses && ' of the same set of constant inputs.'
+    ]) : div({ style: { margin: '1rem 0' } }, [
       'This will launch ',
       b([entityCount]),
-      warnDuplicateAnalyses && span({ style: { fontWeight: 'bold', textDecoration: 'underline' } }, [' duplicate']),
-      entityCount === 1 ? ' analysis' : ' analyses',
-      warnDuplicateAnalyses && ' of the same set of constant inputs',
-      '.',
-      type === processMergedSet && entityCount !== mergeSets(selectedEntities).length && div({
-        style: { fontStyle: 'italic', marginTop: '0.5rem' }
-      }, ['(Duplicate entities are only processed once.)'])
+      entityCount === 1 ? ' analysis.' : ' analyses.'
     ]),
+    type === processMergedSet && entityCount !== mergeSets(selectedEntities).length && div({
+      style: { fontStyle: 'italic', marginTop: '0.5rem' }
+    }, ['(Duplicate entities are only processed once.)']),
     message && div({ style: { display: 'flex' } }, [
       spinner({ style: { marginRight: '0.5rem' } }),
       message

--- a/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
+++ b/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
@@ -2,7 +2,7 @@ import _ from 'lodash/fp'
 import { Fragment, useState } from 'react'
 import { b, div, h, p, span, wbr } from 'react-hyperscript-helpers'
 import { ButtonPrimary, CromwellVersionLink } from 'src/components/common'
-import { spinner } from 'src/components/icons'
+import { icon, spinner } from 'src/components/icons'
 import Modal from 'src/components/Modal'
 import { InfoBox } from 'src/components/PopupTrigger'
 import { regionInfo } from 'src/components/region-common'
@@ -89,6 +89,9 @@ const LaunchAnalysisModal = ({
   const { location, locationType } = bucketLocation
   const { flag, regionDescription } = regionInfo(location, locationType)
 
+  const onlyConstantInputs = _.every(i => _.startsWith('"', i) && _.endsWith('"', i), config.inputs)
+  const warnDuplicateAnalyses = onlyConstantInputs && entityCount > 1
+
   return h(Modal, {
     title: !launching ? 'Confirm launch' : 'Launching Analysis',
     onDismiss,
@@ -115,7 +118,13 @@ const LaunchAnalysisModal = ({
         ])]) : 'Loading...'
     ]),
     div({ style: { margin: '1rem 0' } }, [
-      'This will launch ', b([entityCount]), ` analys${entityCount === 1 ? 'is' : 'es'}`,
+      warnDuplicateAnalyses && icon('warning-standard', { size: 16, style: { color: colors.warning(), marginRight: '0.5rem' } }),
+      warnDuplicateAnalyses && 'Warning! ',
+      'This will launch ',
+      b([entityCount]),
+      warnDuplicateAnalyses && ' duplicate',
+      entityCount === 1 ? ' analysis' : ' analyses',
+      warnDuplicateAnalyses && ' of the same set of constant inputs',
       '.',
       type === processMergedSet && entityCount !== mergeSets(selectedEntities).length && div({
         style: { fontStyle: 'italic', marginTop: '0.5rem' }

--- a/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
+++ b/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
@@ -122,7 +122,7 @@ const LaunchAnalysisModal = ({
       warnDuplicateAnalyses && 'Warning! ',
       'This will launch ',
       b([entityCount]),
-      warnDuplicateAnalyses && ' duplicate',
+      warnDuplicateAnalyses && span({ style: { fontWeight: 'bold', textDecoration: 'underline' } }, [' duplicate']),
       entityCount === 1 ? ' analysis' : ' analyses',
       warnDuplicateAnalyses && ' of the same set of constant inputs',
       '.',


### PR DESCRIPTION
Updates the launch modal to warn users if they're about to launch multiple workflows over the same constant set of input data.

This is certainly not a panacea for avoiding work-duplicating mistakes, but this little triangle would have saved at least one user in the region of $9000 recently due to an accidental duplicate analysis over 180 hard-coded input sets.

Example on dev: [link](http://localhost:3000/#workspaces/general-dev-billing-account/cjl_test_workspace/workflows/cjl/echo_input_string). Try switching the input type between inputs from the data table and "defined by file paths", and switching the input attribute from a constant string value to a participant ID to see how the modal changes in each case.

Example screenshot of the new warning message [updated 3/31]:

![image](https://user-images.githubusercontent.com/13006282/113182813-56a28680-9221-11eb-96ec-e8da3b3b85df.png)
