### PR TITLE
[SATURN-1892] Uploader bugfixes and performance improvements

### DIFF
--- a/src/components/ProgressBar.js
+++ b/src/components/ProgressBar.js
@@ -1,8 +1,8 @@
+import filesize from 'filesize'
 import { dd, div, dl, dt, h, p, strong } from 'react-hyperscript-helpers'
 import { ButtonPrimary } from 'src/components/common'
 import Modal from 'src/components/Modal'
 import colors from 'src/libs/colors'
-import { friendlyFileSize } from 'src/libs/uploads'
 
 
 export const ProgressBar = ({ max, now }) => {
@@ -77,7 +77,7 @@ export const UploadProgressModal = ({ status: { totalFiles, totalBytes, uploaded
       dt(['Size:']),
       dd({
         style: { margin: '0.4rem 0 1rem 0', fontWeight: 600 }
-      }, [friendlyFileSize(currentFile.size)])
+      }, [filesize(currentFile.size, { round: 1 })])
     ]),
     h(ProgressBar, {
       max: totalBytes,
@@ -85,9 +85,9 @@ export const UploadProgressModal = ({ status: { totalFiles, totalBytes, uploaded
     }),
     p({}, [
       'Transferred ',
-      strong([friendlyFileSize(uploadedBytes)]),
+      strong([filesize(uploadedBytes, { round: 1 })]),
       ' of ',
-      strong([friendlyFileSize(totalBytes)]),
+      strong([filesize(totalBytes, { round: 1 })]),
       ' ',
       strong(['(', (uploadedBytes / totalBytes * 100).toFixed(0), '%)'])
     ])

--- a/src/components/data/FileBrowser.js
+++ b/src/components/data/FileBrowser.js
@@ -11,7 +11,7 @@ import FloatingActionButton from 'src/components/FloatingActionButton'
 import { icon } from 'src/components/icons'
 import { NameModal } from 'src/components/NameModal'
 import { UploadProgressModal } from 'src/components/ProgressBar'
-import { GridTable, HeaderCell, TextCell } from 'src/components/table'
+import { FlexTable, HeaderCell, TextCell } from 'src/components/table'
 import UriViewer from 'src/components/UriViewer'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
@@ -41,7 +41,7 @@ export const FileBrowserPanel = _.flow(
   const signal = Utils.useCancellation()
   const { signal: uploadSignal, abort: abortUpload } = Utils.useCancelable()
 
-  const { initialX, initialY } = StateHistory.get() || {}
+  const { initialY } = StateHistory.get() || {}
   const table = useRef()
 
   // Helpers
@@ -97,8 +97,8 @@ export const FileBrowserPanel = _.flow(
   }, [uploadStatus]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
-    StateHistory.update({ prefix, initialX, initialY })
-  }, [prefix, initialX, initialY])
+    StateHistory.update({ prefix, initialY })
+  }, [prefix, initialY])
 
   useEffect(() => {
     if (uploadingFiles.length > 0) {
@@ -187,17 +187,16 @@ export const FileBrowserPanel = _.flow(
         'Drag and drop your files here'
       ]),
       div({
-        style: { fontSize: '1rem', flex: '1 1 auto', padding: '1em', height: '100%' }
+        style: { fontSize: '1rem', flex: '1 1 auto', padding: '1em', height: '100%', minHeight: '30em' }
       }, [
         h(AutoSizer, {}, [
-          ({ width, height }) => h(GridTable, {
+          ({ width, height }) => h(FlexTable, {
             ref: table,
             width,
             height,
             rowCount: numPrefixes + numObjects,
             noContentMessage: 'No files have been uploaded yet',
             onScroll: saveScroll,
-            initialX,
             initialY,
             rowHeight: 40,
             headerHeight: 40,
@@ -207,9 +206,10 @@ export const FileBrowserPanel = _.flow(
             styleHeader: () => {
               return { padding: '0.5em', borderRight: 'none', borderLeft: 'none' }
             },
+            hoverHighlight: true,
             columns: [
               {
-                width: 30,
+                size: { min: 30, grow: 0 },
                 headerRenderer: () => '',
                 cellRenderer: ({ rowIndex }) => {
                   if (rowIndex >= numPrefixes) {
@@ -228,7 +228,7 @@ export const FileBrowserPanel = _.flow(
                 }
               },
               {
-                width: width - 400, // Fill the remaining space
+                size: { min: 100, grow: 1 }, // Fill the remaining space
                 headerRenderer: () => h(HeaderCell, ['Name']),
                 cellRenderer: ({ rowIndex }) => {
                   if (rowIndex < numPrefixes) {
@@ -253,7 +253,7 @@ export const FileBrowserPanel = _.flow(
                 }
               },
               {
-                width: 150,
+                size: { min: 150, grow: 0 },
                 headerRenderer: () => h(HeaderCell, ['Size']),
                 cellRenderer: ({ rowIndex }) => {
                   if (rowIndex >= numPrefixes) {
@@ -263,7 +263,7 @@ export const FileBrowserPanel = _.flow(
                 }
               },
               {
-                width: 200,
+                size: { min: 200, grow: 0 },
                 headerRenderer: () => h(HeaderCell, ['Last modified']),
                 cellRenderer: ({ rowIndex }) => {
                   if (rowIndex >= numPrefixes) {

--- a/src/components/data/FileBrowser.js
+++ b/src/components/data/FileBrowser.js
@@ -90,7 +90,7 @@ export const FileBrowserPanel = _.flow(
     } else {
       // While the uploader is working, refresh the table no more often than every 5 seconds
       const now = Date.now()
-      if (lastRefresh < now - 10e3) {
+      if (lastRefresh < now - 5e3) {
         setLastRefresh(now)
       }
     }

--- a/src/components/data/UploadPreviewTable.js
+++ b/src/components/data/UploadPreviewTable.js
@@ -1,10 +1,10 @@
-import { icon } from '@fortawesome/fontawesome-svg-core'
 import _ from 'lodash/fp'
 import { Fragment, useEffect, useMemo, useRef, useState } from 'react'
-import { code, div, h, h2, h3, h4, li, p, span, strong, ul } from 'react-hyperscript-helpers'
+import { code, div, h, h3, h4, li, p, span, strong, ul } from 'react-hyperscript-helpers'
 import { AutoSizer } from 'react-virtualized'
 import { ButtonPrimary, ButtonSecondary, fixedSpinnerOverlay } from 'src/components/common'
 import { renderDataCell, saveScroll } from 'src/components/data/data-utils'
+import { icon } from 'src/components/icons'
 import { NameModal } from 'src/components/NameModal'
 import { GridTable, HeaderCell, Resizable, Sortable } from 'src/components/table'
 import { Ajax } from 'src/libs/ajax'
@@ -98,7 +98,7 @@ const UploadDataTable = props => {
   }, [])
 
   const sortedRows = useMemo(() => {
-    const i = _.findIndex(columns, sort.field)
+    const i = columns ? columns.indexOf(sort.field) : -1
     return i > -1 ? _.orderBy(row => row[i], sort.direction, rows) : rows
   }, [sort, rows, columns])
 
@@ -109,9 +109,6 @@ const UploadDataTable = props => {
     div({
       style: { position: 'relative', flex: '0 0 auto' }
     }, [
-      h2([
-        span({ ref: header, tabIndex: -1 }, ['Preview your data table'])
-      ]),
       div({
         style: { position: 'absolute', top: 0, right: 0, marginTop: '1em' }
       }, [
@@ -131,7 +128,17 @@ const UploadDataTable = props => {
       ]),
       metadata && div([
         metadata.isUpdate ? div([
-          h3(['Updating Table: ', strong(metadata.entityType)]),
+          h3([
+            'Updating Table: ',
+            strong(metadata.entityType),
+            h(ButtonSecondary, {
+              onClick: () => setRenamingTable(true),
+              style: { padding: '0 1em' }
+            }, [
+              icon('edit'),
+              span({ style: { paddingLeft: '1em' } }, 'Rename Table')
+            ])
+          ]),
           p({
             style: { color: colors.danger() }
           }, [
@@ -154,11 +161,6 @@ const UploadDataTable = props => {
           ])
         ]) : div([
           h3(['Creating a new Table: ', strong(metadata.entityType)])
-        ]),
-        h(ButtonPrimary, {
-          onClick: () => setRenamingTable(true)
-        }, [
-          'Rename table'
         ]),
         p(`If this table looks right to you, click the button on the right to ${metadata.isUpdate ?
           'update' :

--- a/src/components/data/UploadPreviewTable.js
+++ b/src/components/data/UploadPreviewTable.js
@@ -177,10 +177,10 @@ const UploadDataTable = props => {
             strong(metadata.entityType),
             h(ButtonSecondary, {
               onClick: () => setRenamingTable(true),
-              style: { padding: '0 1em' }
+              style: { padding: '0 2em' }
             }, [
               icon('renameIcon'),
-              span({ style: { paddingLeft: '1em' } }, 'Rename Table')
+              span({ style: { paddingLeft: '1ex' } }, 'Rename Table')
             ])
           ]),
           p({

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -289,8 +289,8 @@ export const SimpleFlexTable = ({ columns, rowCount, noContentMessage, hoverHigh
  * datasets which may require horizontal scrolling.
  */
 export const GridTable = Utils.forwardRefWithName('GridTable', ({
-  width, height, initialX = 0, initialY = 0,
-  rowCount, columns, styleCell = () => ({}), onScroll: customOnScroll = _.noop, noContentMessage
+  width, height, initialX = 0, initialY = 0, rowHeight = 48, headerHeight = 48, noContentMessage,
+  rowCount, columns, styleCell = () => ({}), styleHeader = () => ({}), onScroll: customOnScroll = _.noop
 }, ref) => {
   const [scrollbarSize, setScrollbarSize] = useState(0)
   const header = useRef()
@@ -326,16 +326,20 @@ export const GridTable = Utils.forwardRefWithName('GridTable', ({
         h(RVGrid, {
           ref: header,
           width: width - scrollbarSize,
-          height: 48,
+          height: headerHeight,
           columnWidth: ({ index }) => columns[index].width,
-          rowHeight: 48,
+          rowHeight: headerHeight,
           rowCount: 1,
           columnCount: columns.length,
           cellRenderer: data => {
             return div({
               key: data.key,
               className: 'table-cell',
-              style: { ...data.style, ...styles.header(data.columnIndex, columns.length) }
+              style: {
+                ...data.style,
+                ...styles.header(data.columnIndex, columns.length),
+                ...styleHeader(data)
+              }
             }, [
               columns[data.columnIndex].headerRenderer(data)
             ])
@@ -347,9 +351,9 @@ export const GridTable = Utils.forwardRefWithName('GridTable', ({
         h(RVGrid, {
           ref: body,
           width,
-          height: height - 48,
+          height: height - headerHeight,
           columnWidth: ({ index }) => columns[index].width,
-          rowHeight: 48,
+          rowHeight,
           rowCount,
           columnCount: columns.length,
           noContentRenderer: () => div({ style: { marginTop: '1rem', textAlign: 'center', fontStyle: 'italic' } }, [noContentMessage]),

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -167,7 +167,8 @@ export const tableHeight = ({ actualRows, maxRows, heightPerRow = 48 }) => (_.mi
  */
 export const FlexTable = ({
   initialY = 0, width, height, rowCount, variant, columns = [], hoverHighlight = false,
-  onScroll = _.noop, noContentMessage = null, ...props
+  onScroll = _.noop, noContentMessage = null, headerHeight = 48, rowHeight = 48,
+  styleCell = () => ({}), styleHeader = () => ({}), ...props
 }) => {
   const [scrollbarSize, setScrollbarSize] = useState(0)
   const body = useRef()
@@ -180,23 +181,27 @@ export const FlexTable = ({
     div({
       style: {
         width: width - scrollbarSize,
-        height: 48,
+        height: headerHeight,
         display: 'flex'
       }
     }, [
       ..._.map(([i, { size, headerRenderer }]) => {
         return div({
           key: i,
-          style: { ...styles.flexCell(size), ...(variant === 'light' ? {} : styles.header(i * 1, columns.length)) }
+          style: {
+            ...styles.flexCell(size),
+            ...(variant === 'light' ? {} : styles.header(i * 1, columns.length)),
+            ...(styleHeader ? styleHeader({ columnIndex: i }) : {})
+          }
         }, [headerRenderer()])
       }, _.toPairs(columns))
     ]),
     h(RVGrid, {
       ref: body,
       width,
-      height: height - 48,
+      height: height - headerHeight,
       columnWidth: width - scrollbarSize,
-      rowHeight: 48,
+      rowHeight,
       rowCount,
       columnCount: 1,
       onScrollbarPresenceChange: ({ vertical, size }) => {
@@ -214,7 +219,11 @@ export const FlexTable = ({
             return div({
               key: i,
               className: 'table-cell',
-              style: { ...styles.flexCell(size), ...(variant === 'light' ? {} : styles.cell(i * 1, columns.length)) }
+              style: {
+                ...styles.flexCell(size),
+                ...(variant === 'light' ? {} : styles.cell(i * 1, columns.length)),
+                ...(styleCell ? styleCell({ ...data, columnIndex: i }) : {})
+              }
             }, [cellRenderer(data)])
           }, _.toPairs(columns))
         ])
@@ -246,7 +255,11 @@ FlexTable.propTypes = {
     })
   })),
   hoverHighlight: PropTypes.bool,
-  onScroll: PropTypes.func
+  onScroll: PropTypes.func,
+  headerHeight: PropTypes.number,
+  rowHeight: PropTypes.number,
+  styleHeader: PropTypes.func,
+  styleCell: PropTypes.func
 }
 
 /**
@@ -393,9 +406,12 @@ GridTable.propTypes = {
   initialX: PropTypes.number,
   initialY: PropTypes.number,
   rowCount: PropTypes.number.isRequired,
+  styleHeader: PropTypes.func,
   styleCell: PropTypes.func,
   columns: PropTypes.arrayOf(PropTypes.shape({ width: PropTypes.number.isRequired })),
-  onScroll: PropTypes.func
+  onScroll: PropTypes.func,
+  headerHeight: PropTypes.number,
+  rowHeight: PropTypes.number
 }
 
 export const SimpleTable = ({ columns, rows }) => {

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -939,8 +939,8 @@ const Buckets = signal => ({
     const items = body.items || []
 
     // Get the next page recursively if there is one
-    if (res.nextPageToken) {
-      const next = await Buckets(signal).listAll(namespace, bucket, prefix, res.nextPageToken)
+    if (body.nextPageToken) {
+      const next = await Buckets(signal).listAll(namespace, bucket, prefix, body.nextPageToken)
       return items.concat(next)
     }
     return items

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -940,7 +940,8 @@ const Buckets = signal => ({
 
     // Get the next page recursively if there is one
     if (res.nextPageToken) {
-      return _.concat(items, await Buckets(signal).listAll(namespace, bucket, prefix, res.nextPageToken))
+      const next = await Buckets(signal).listAll(namespace, bucket, prefix, res.nextPageToken)
+      return items.concat(next)
     }
     return items
   },

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -941,7 +941,7 @@ const Buckets = signal => ({
     // Get the next page recursively if there is one
     if (body.nextPageToken) {
       const next = await Buckets(signal).listAll(namespace, bucket, prefix, body.nextPageToken)
-      return items.concat(next)
+      return _.concat(items, next)
     }
     return items
   },

--- a/src/libs/uploads.js
+++ b/src/libs/uploads.js
@@ -107,20 +107,3 @@ export const uploadFiles = async ({ namespace, bucketName, prefix, files, status
   }
   setStatus({ action: 'finish' })
 }
-
-export const friendlyFileSize = bytes => {
-  const bins = [
-    { pow: 5, fixed: 3, text: 'PB' },
-    { pow: 4, fixed: 3, text: 'TB' },
-    { pow: 3, fixed: 2, text: 'GB' },
-    { pow: 2, fixed: 1, text: 'MB' },
-    { pow: 1, fixed: 0, text: 'KB' }
-  ]
-  for (const bin of bins) {
-    const pow = Math.pow(1024, bin.pow)
-    if (bytes > pow) {
-      return `${(bytes / pow).toFixed(bin.fixed)} ${bin.text}`
-    }
-  }
-  return `${bytes} bytes`
-}

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -478,3 +478,8 @@ export const sha256 = async message => {
     _.join('')
   )(new Uint8Array(hashBuffer))
 }
+
+// Provide a way to pass leading and trailing options to Lodash debounce
+// See https://github.com/lodash/lodash/issues/2508
+const debounceNotFixed = _.debounce.convert({ fixed: false })
+export const withDebounce = _.curry(({ wait, leading, trailing }, fn) => debounceNotFixed(wait)(fn, { leading, trailing }))

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -478,8 +478,3 @@ export const sha256 = async message => {
     _.join('')
   )(new Uint8Array(hashBuffer))
 }
-
-// Provide a way to pass leading and trailing options to Lodash debounce
-// See https://github.com/lodash/lodash/issues/2508
-const debounceNotFixed = _.debounce.convert({ fixed: false })
-export const withDebounce = _.curry(({ wait, leading, trailing }, fn) => debounceNotFixed(wait)(fn, { leading, trailing }))

--- a/src/pages/Upload.js
+++ b/src/pages/Upload.js
@@ -49,10 +49,11 @@ const styles = {
     backgroundColor: colors.accent()
   },
   tableViewPanel: {
-    position: 'relative',
     padding: '1rem',
     width: '100%',
-    height: '100%'
+    height: '100%',
+    display: 'flex',
+    flexFlow: 'column nowrap'
   },
   workspaceTilesContainer: {
     textAlign: 'left',
@@ -420,19 +421,22 @@ const DataUploadPanel = _.flow(
     header.current && header.current.focus()
   }, [])
 
-  return h(Fragment, {}, [
-    h2({ style: styles.heading }, [
+  return div({ style: { display: 'flex', flexFlow: 'column nowrap', height: '100%' } }, [
+    h2({ style: { ...styles.heading, flex: 0 } }, [
       icon('fileAlt', { size: 20, style: { marginRight: '1em' } }),
       span({ ref: header, tabIndex: -1 }, ['Upload Your Data Files'])
     ]),
-    p({ style: styles.instructions }, [
-      'Upload the files to associate with this collection by dragging them into the table below, or clicking the Upload button.'
-    ]),
-    p({ style: styles.instructions }, [
-      ' You may upload as many files as you wish, but each filename must be unique.'
-    ]),
     children,
+    div({ style: { flex: 0 } }, [
+      p({ style: styles.instructions }, [
+        'Upload the files to associate with this collection by dragging them into the table below, or clicking the Upload button.'
+      ]),
+      p({ style: styles.instructions }, [
+        ' You may upload as many files as you wish, but each filename must be unique.'
+      ])
+    ]),
     h(FileBrowserPanel, {
+      style: { flex: 1 },
       workspace, onRequesterPaysError, setNumFiles, basePrefix, collection, allowNewFolders: false
     })
   ])

--- a/src/pages/Upload.js
+++ b/src/pages/Upload.js
@@ -436,7 +436,7 @@ const DataUploadPanel = _.flow(
       ])
     ]),
     h(FileBrowserPanel, {
-      style: { flex: 1 },
+      style: { flex: '1 1 auto' },
       workspace, onRequesterPaysError, setNumFiles, basePrefix, collection, allowNewFolders: false
     })
   ])
@@ -608,7 +608,8 @@ const MetadataUploadPanel = _.flow(
       icon('listAlt', { size: 20, style: { marginRight: '1em' } }),
       span({ ref: header, tabIndex: -1 }, ['Upload Your Metadata Files'])
     ]),
-    div({ style: { ...styles.instructions, flex: 0 } }, [
+    children,
+    !isPreviewing && div({ style: { ...styles.instructions, flex: 0 } }, [
       p('Upload a tab-separated file describing your table structures.'),
       ul([
         li('Any columns which reference files should include just the filenames, which will be matched up to the data files in this collection.'),
@@ -625,7 +626,6 @@ const MetadataUploadPanel = _.flow(
         ', a table named "sample" will be created with "sample_id" as its first column. There are no restrictions on other columns.'
       ])
     ]),
-    children,
     !isPreviewing && h(Dropzone, {
       disabled: !!Utils.editWorkspaceError(workspace),
       style: {
@@ -669,21 +669,17 @@ const MetadataUploadPanel = _.flow(
         _.map(e => li({ key: e }, [e]), metadataTable.errors)
       ])
     ]),
-    isPreviewing && div({
-      style: { borderTop: '1px solid', borderColor: colors.dark(0.75), flex: 1 }
-    }, [
-      h(UploadPreviewTable, {
-        workspace, metadataTable,
-        onConfirm: ({ metadata }) => {
-          doUpload(metadata)
-        },
-        onCancel: () => {
-          setMetadataFile(null)
-          setMetadataTable(null)
-        },
-        onRename: renameTable
-      })
-    ]),
+    isPreviewing && h(UploadPreviewTable, {
+      workspace, metadataTable,
+      onConfirm: ({ metadata }) => {
+        doUpload(metadata)
+      },
+      onCancel: () => {
+        setMetadataFile(null)
+        setMetadataTable(null)
+      },
+      onRename: renameTable
+    }),
     (filesLoading || uploading) && topSpinnerOverlay
   ])
 })
@@ -892,7 +888,7 @@ const UploadData = _.flow( // eslint-disable-line lodash-fp/no-single-compositio
                   setTableMetadata(metadata)
                   setCurrentStep('done')
                 }
-              }, [])
+              })
             ])],
             ['done', () => div({
               style: styles.tabPanelHeader


### PR DESCRIPTION
## Apr 2 update

* I switched the reload buffering in the FileBrowser to 5 seconds (rather than 10), to be consistent with the comment and also because it provides the user with slight more real-time feedback. This still only matters when uploading lots of small files; if a big file takes longer than 5 seconds, it will still only refresh once the file is fully uploaded.
* I switched the FileBrowser component to use a `FlexTable` rather than a `GridTable`, which is better suited for this use case.
* Both `FlexTable` and `GridTable` now accept optional parameters to change the row heights and override the header and cell styles. This allowed me to condense the rows and remove borders, to get the file browser to more closely match the way it looks in the Data tab in Workspaces. FWIW, that one should probably be updated to use a FlexTable too, or probably just reuse the new FileBrowser component, but I figured it would be better not to make that change in this PR.
* I updated the way the Metadata preview table is rendered to show more clearly which columns will be updated versus added, when updating an existing table. This provides a better user experience while dedicating more screen real-estate to the table, better supporting smaller displays.

## Original

This PR switches the table of uploaded files from a `SimpleTable` to a `GridTable`, so that only the visible rows are rendered into the DOM. This appears to resolve the performance issues Joel encountered when labs uploaded hundreds of thousands of files.

In order to make this look good, I added some new styling options to GridTable. You can now set the desired height of each header row and data row, as well as apply additional styling options to the header. This makes the file table in the uploader look much more like the one in the Data tab within Workspaces.  I was unable to get the delete button to hide except on hover, but this does not seem to be important enough to spend time on.

To further improve performance, I reduced the frequency with which the file table is update while files are uploading. Previously, every time a file finished the table would refresh so that users can see the new file. However, this is rather meaningless when uploading hundreds of files at a time since the table only renders a few of them, and results in unnecessary work. I've debounced it so the table will refresh no more often than once every 5 seconds.

In addition, I fixed the bug which was causing only the first thousand filenames in a metadata file to be translated to their bucket URLs. We will now grab as many pages of 1000 URLs as we can before attempting to do the matching.

On the other, the one caveat of the file table is that it only displays the first 1000 files in the bucket. If it's important, I can figure out how to add a pager, or do automatic paging like I do to count the URLs. But I'm not sure whether it's necessary for most users.

### Metadata Uploader improvements

To improve the user experience, I reduced the vertical size of the Metadata Upload panel so that more of the metadata table is visible.  Further improvements could be made here, such as listing the columns to be updated in a row rather than a bulleted list. But this is better than it was.

I also fixed a bug preventing table columns from being sorted properly. This is working now.