### PR TITLE
add better tooltips to table names [AS-677]

### DIFF
--- a/src/components/Collapse.js
+++ b/src/components/Collapse.js
@@ -6,7 +6,7 @@ import { icon } from 'src/components/icons'
 import * as Style from 'src/libs/style'
 
 
-const Collapse = ({ title, buttonStyle, initialOpenState, children, titleFirst, afterToggle, onFirstOpen = () => {}, noTitleWrap, ...props }) => {
+const Collapse = ({ title, buttonStyle, buttonProps = {}, initialOpenState, children, titleFirst, afterToggle, onFirstOpen = () => {}, noTitleWrap, ...props }) => {
   const [isOpened, setIsOpened] = useState(initialOpenState)
   const angleIcon = icon(isOpened ? 'angle-down' : 'angle-right', { style: { marginRight: '0.25rem', flexShrink: 0 } })
 
@@ -23,7 +23,8 @@ const Collapse = ({ title, buttonStyle, initialOpenState, children, titleFirst, 
       h(Link, {
         'aria-expanded': isOpened,
         style: { display: 'flex', flex: 1, alignItems: 'center', marginBottom: '0.5rem', ...buttonStyle },
-        onClick: () => setIsOpened(!isOpened)
+        onClick: () => setIsOpened(!isOpened),
+        ...buttonProps
       }, [
         titleFirst && div({ style: { flexGrow: 1, ...(noTitleWrap ? Style.noWrapEllipsis : {}) } }, [title]),
         angleIcon,

--- a/src/components/TooltipTrigger.js
+++ b/src/components/TooltipTrigger.js
@@ -70,31 +70,46 @@ const Tooltip = ({ side = 'bottom', type, target: targetId, children, id }) => {
   ])
 }
 
-const TooltipTrigger = ({ children, content, ...props }) => {
+const TooltipTrigger = ({ children, content, delay, ...props }) => {
   const [open, setOpen] = useState(false)
+  const openTimeout = useRef()
   const id = Utils.useUniqueId()
   const tooltipId = Utils.useUniqueId()
   const child = Children.only(children)
   const childId = child.props.id || id
+
+  const doOpen = !delay ?
+    setOpen :
+    shouldOpen => {
+      if (shouldOpen) {
+        openTimeout.current = setTimeout(() => setOpen(true), delay)
+      } else {
+        if (openTimeout.current) {
+          clearTimeout(openTimeout.current)
+        }
+        setOpen(false)
+      }
+    }
+
   return h(Fragment, [
     cloneElement(child, {
       id: childId,
       'aria-describedby': open ? tooltipId : undefined,
       onMouseEnter: (...args) => {
         child.props.onMouseEnter && child.props.onMouseEnter(...args)
-        setOpen(true)
+        doOpen(true)
       },
       onMouseLeave: (...args) => {
         child.props.onMouseLeave && child.props.onMouseLeave(...args)
-        setOpen(false)
+        doOpen(false)
       },
       onFocus: (...args) => {
         child.props.onFocus && child.props.onFocus(...args)
-        setOpen(true)
+        doOpen(true)
       },
       onBlur: (...args) => {
         child.props.onBlur && child.props.onBlur(...args)
-        setOpen(false)
+        doOpen(false)
       }
     }),
     open && !!content && h(Tooltip, { target: childId, id: tooltipId, ...props }, [content])

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -52,7 +52,7 @@ const styles = {
   }
 }
 
-export const Clickable = ({ href, as = (!!href ? 'a' : 'div'), disabled, tooltip, tooltipSide, onClick, children, ...props }) => {
+export const Clickable = ({ href, as = (!!href ? 'a' : 'div'), disabled, tooltip, tooltipSide, tooltipDelay, onClick, children, ...props }) => {
   const child = h(Interactive, {
     'aria-disabled': !!disabled,
     as, disabled,
@@ -63,7 +63,7 @@ export const Clickable = ({ href, as = (!!href ? 'a' : 'div'), disabled, tooltip
   }, [children])
 
   if (tooltip) {
-    return h(TooltipTrigger, { content: tooltip, side: tooltipSide }, [child])
+    return h(TooltipTrigger, { content: tooltip, side: tooltipSide, delay: tooltipDelay }, [child])
   } else {
     return child
   }

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -48,29 +48,25 @@ const styles = {
   }
 }
 
-const DataTypeButton = ({ buttonName, children, entityCount, selected, iconName = 'listAlt', iconSize = 14, buttonStyle, isReference = false, ...props }) => {
+const DataTypeButton = ({ selected, buttonName, children, entityCount, iconName = 'listAlt', iconSize = 14, buttonStyle, isEntity, ...props }) => {
   return h(Clickable, {
     style: { ...Style.navList.item(selected), color: colors.accent(1.2), ...buttonStyle },
     hover: Style.navList.itemHover(selected),
-    ...(isReference ? {} : {
-      tooltip: buttonName,
-      tooltipSide: 'top',
-      tooltipDelay: 250
-    }),
+    ...(isEntity ? { tooltip: buttonName, tooltipDelay: 250 } : {}),
     ...props
   }, [
     div({ style: { flex: 'none', display: 'flex', width: '1.5rem' } }, [
       icon(iconName, { size: iconSize })
     ]),
-    isReference ? div({ style: { flex: 1, ...Style.noWrapEllipsis } }, [
-      children
-    ]) : h(Fragment, [
+    isEntity ? h(Fragment, [
       div({ style: { flex: 1, ...Style.noWrapEllipsis } }, [
         buttonName
       ]),
       entityCount === undefined ? '' : div({ title: entityCount }, [
         `(${entityCount})`
       ])
+    ]) : div({ style: { flex: 1, ...Style.noWrapEllipsis } }, [
+      children
     ])
   ])
 }
@@ -460,6 +456,7 @@ const WorkspaceData = _.flow(
             return h(DataTypeButton, {
               key: type,
               selected: selectedDataType === type,
+              isEntity: true,
               buttonName: type,
               entityCount: typeDetails.count,
               onClick: () => {
@@ -480,6 +477,7 @@ const WorkspaceData = _.flow(
               key: snapshotName,
               titleFirst: true,
               buttonStyle: { height: 50, color: colors.dark(), fontWeight: 600, marginBottom: 0, overflow: 'hidden' },
+              buttonProps: { tooltip: snapshotName, tooltipDelay: 250 },
               style: { fontSize: 14, paddingLeft: '1.5rem', borderBottom: `1px solid ${colors.dark(0.2)}` },
               title: snapshotName, noTitleWrap: true,
               afterToggle: h(Link, {
@@ -514,6 +512,7 @@ const WorkspaceData = _.flow(
                     buttonStyle: { borderBottom: 0, height: 40 },
                     key: `${snapshotName}_${tableName}`,
                     selected: _.isEqual(selectedDataType, [snapshotName, tableName]),
+                    isEntity: true,
                     buttonName: tableName,
                     entityCount: count,
                     onClick: () => {
@@ -572,7 +571,7 @@ const WorkspaceData = _.flow(
           return h(DataTypeButton, {
             key: type,
             selected: selectedDataType === type,
-            isReference: true,
+            isEntity: false,
             onClick: () => {
               setSelectedDataType(type)
               refreshWorkspace()
@@ -595,21 +594,21 @@ const WorkspaceData = _.flow(
         div({ style: Style.navList.heading }, 'Other Data'),
         h(DataTypeButton, {
           selected: selectedDataType === localVariables,
-          buttonName: 'Workspace Data',
+          isEntity: false,
           onClick: () => {
             setSelectedDataType(localVariables)
             forceRefresh()
           }
-        }),
+        }, ['Workspace Data']),
         h(DataTypeButton, {
           iconName: 'folder', iconSize: 18,
           selected: selectedDataType === bucketObjects,
-          buttonName: 'Files',
+          isEntity: false,
           onClick: () => {
             setSelectedDataType(bucketObjects)
             forceRefresh()
           }
-        })
+        }, ['Files'])
       ]),
       div({ style: styles.tableViewPanel }, [
         Utils.switchCase(getSelectionType(),

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -48,11 +48,11 @@ const styles = {
   }
 }
 
-const DataTypeButton = ({ selected, buttonName, children, entityCount, iconName = 'listAlt', iconSize = 14, buttonStyle, isEntity, ...props }) => {
+const DataTypeButton = ({ selected, entityName, children, entityCount, iconName = 'listAlt', iconSize = 14, buttonStyle, isEntity, ...props }) => {
   return h(Clickable, {
     style: { ...Style.navList.item(selected), color: colors.accent(1.2), ...buttonStyle },
     hover: Style.navList.itemHover(selected),
-    ...(isEntity ? { tooltip: buttonName, tooltipDelay: 250 } : {}),
+    ...(isEntity ? { tooltip: entityName, tooltipDelay: 250 } : {}),
     ...props
   }, [
     div({ style: { flex: 'none', display: 'flex', width: '1.5rem' } }, [
@@ -60,7 +60,7 @@ const DataTypeButton = ({ selected, buttonName, children, entityCount, iconName 
     ]),
     isEntity ? h(Fragment, [
       div({ style: { flex: 1, ...Style.noWrapEllipsis } }, [
-        buttonName
+        entityName
       ]),
       entityCount === undefined ? '' : div({ title: entityCount }, [
         `(${entityCount})`
@@ -457,7 +457,7 @@ const WorkspaceData = _.flow(
               key: type,
               selected: selectedDataType === type,
               isEntity: true,
-              buttonName: type,
+              entityName: type,
               entityCount: typeDetails.count,
               onClick: () => {
                 setSelectedDataType(type)
@@ -513,7 +513,7 @@ const WorkspaceData = _.flow(
                     key: `${snapshotName}_${tableName}`,
                     selected: _.isEqual(selectedDataType, [snapshotName, tableName]),
                     isEntity: true,
-                    buttonName: tableName,
+                    entityName: tableName,
                     entityCount: count,
                     onClick: () => {
                       setSelectedDataType([snapshotName, tableName])

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -58,16 +58,10 @@ const DataTypeButton = ({ selected, entityName, children, entityCount, iconName 
     div({ style: { flex: 'none', display: 'flex', width: '1.5rem' } }, [
       icon(iconName, { size: iconSize })
     ]),
-    isEntity ? h(Fragment, [
-      div({ style: { flex: 1, ...Style.noWrapEllipsis } }, [
-        entityName
-      ]),
-      entityCount === undefined ? '' : div({ title: entityCount }, [
-        `(${entityCount})`
-      ])
-    ]) : div({ style: { flex: 1, ...Style.noWrapEllipsis } }, [
-      children
-    ])
+    div({ style: { flex: 1, ...Style.noWrapEllipsis } }, [
+      entityName || children
+    ]),
+    isEntity && div([`(${entityCount})`])
   ])
 }
 

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -48,7 +48,27 @@ const styles = {
   }
 }
 
-const DataTypeButton = ({ selected, children, iconName = 'listAlt', iconSize = 14, buttonStyle, ...props }) => {
+const DataTypeButton = ({ entityName, entityCount, selected, iconName = 'listAlt', iconSize = 14, buttonStyle, ...props }) => {
+  return h(Clickable, {
+    style: { ...Style.navList.item(selected), color: colors.accent(1.2), ...buttonStyle },
+    hover: Style.navList.itemHover(selected),
+    tooltip: entityName,
+    tooltipSide: 'top',
+    ...props
+  }, [
+    div({ style: { flex: 'none', display: 'flex', width: '1.5rem' } }, [
+      icon(iconName, { size: iconSize })
+    ]),
+    div({ style: { flex: 1, ...Style.noWrapEllipsis }, title: entityName }, [
+      entityName
+    ]),
+    div({ title: entityCount }, [
+      `(${entityCount})`
+    ])
+  ])
+}
+
+const FileButton = ({ selected, children, iconName = 'listAlt', iconSize = 14, buttonStyle, ...props }) => {
   return h(Clickable, {
     style: { ...Style.navList.item(selected), color: colors.accent(1.2), ...buttonStyle },
     hover: Style.navList.itemHover(selected),
@@ -448,11 +468,13 @@ const WorkspaceData = _.flow(
             return h(DataTypeButton, {
               key: type,
               selected: selectedDataType === type,
+              entityName: type,
+              entityCount: typeDetails.count,
               onClick: () => {
                 setSelectedDataType(type)
                 forceRefresh()
               }
-            }, [`${type} (${typeDetails.count})`])
+            })
           }, sortedEntityPairs)
         ]),
         (!_.isEmpty(sortedSnapshotPairs) || snapshotMetadataError) && h(DataTypeSection, {
@@ -500,6 +522,8 @@ const WorkspaceData = _.flow(
                     buttonStyle: { borderBottom: 0, height: 40 },
                     key: `${snapshotName}_${tableName}`,
                     selected: _.isEqual(selectedDataType, [snapshotName, tableName]),
+                    entityName: tableName,
+                    entityCount: count,
                     onClick: () => {
                       setSelectedDataType([snapshotName, tableName])
                       Ajax().Metrics.captureEvent(Events.workspaceSnapshotContentsView, {
@@ -553,7 +577,7 @@ const WorkspaceData = _.flow(
           entityTypes: _.keys(entityMetadata)
         }),
         _.map(type => {
-          return h(DataTypeButton, {
+          return h(FileButton, {
             key: type,
             selected: selectedDataType === type,
             onClick: () => {
@@ -576,14 +600,14 @@ const WorkspaceData = _.flow(
           ])
         }, _.keys(referenceData)),
         div({ style: Style.navList.heading }, 'Other Data'),
-        h(DataTypeButton, {
+        h(FileButton, {
           selected: selectedDataType === localVariables,
           onClick: () => {
             setSelectedDataType(localVariables)
             forceRefresh()
           }
         }, ['Workspace Data']),
-        h(DataTypeButton, {
+        h(FileButton, {
           iconName: 'folder', iconSize: 18,
           selected: selectedDataType === bucketObjects,
           onClick: () => {

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -48,27 +48,27 @@ const styles = {
   }
 }
 
-const DataTypeButton = ({ entityName, entityCount, selected, iconName = 'listAlt', iconSize = 14, buttonStyle, ...props }) => {
+const DataTypeButton = ({ buttonName, entityCount, selected, iconName = 'listAlt', iconSize = 14, buttonStyle, ...props }) => {
   return h(Clickable, {
     style: { ...Style.navList.item(selected), color: colors.accent(1.2), ...buttonStyle },
     hover: Style.navList.itemHover(selected),
-    tooltip: entityName,
+    tooltip: buttonName,
     tooltipSide: 'top',
     ...props
   }, [
     div({ style: { flex: 'none', display: 'flex', width: '1.5rem' } }, [
       icon(iconName, { size: iconSize })
     ]),
-    div({ style: { flex: 1, ...Style.noWrapEllipsis }, title: entityName }, [
-      entityName
+    div({ style: { flex: 1, ...Style.noWrapEllipsis }, title: buttonName }, [
+      buttonName
     ]),
-    div({ title: entityCount }, [
+    entityCount === undefined ? '' : div({ title: entityCount }, [
       `(${entityCount})`
     ])
   ])
 }
 
-const FileButton = ({ selected, children, iconName = 'listAlt', iconSize = 14, buttonStyle, ...props }) => {
+const ReferenceDataButton = ({ selected, children, iconName = 'listAlt', iconSize = 14, buttonStyle, ...props }) => {
   return h(Clickable, {
     style: { ...Style.navList.item(selected), color: colors.accent(1.2), ...buttonStyle },
     hover: Style.navList.itemHover(selected),
@@ -468,7 +468,7 @@ const WorkspaceData = _.flow(
             return h(DataTypeButton, {
               key: type,
               selected: selectedDataType === type,
-              entityName: type,
+              buttonName: type,
               entityCount: typeDetails.count,
               onClick: () => {
                 setSelectedDataType(type)
@@ -522,7 +522,7 @@ const WorkspaceData = _.flow(
                     buttonStyle: { borderBottom: 0, height: 40 },
                     key: `${snapshotName}_${tableName}`,
                     selected: _.isEqual(selectedDataType, [snapshotName, tableName]),
-                    entityName: tableName,
+                    buttonName: tableName,
                     entityCount: count,
                     onClick: () => {
                       setSelectedDataType([snapshotName, tableName])
@@ -577,7 +577,7 @@ const WorkspaceData = _.flow(
           entityTypes: _.keys(entityMetadata)
         }),
         _.map(type => {
-          return h(FileButton, {
+          return h(ReferenceDataButton, {
             key: type,
             selected: selectedDataType === type,
             onClick: () => {
@@ -600,21 +600,23 @@ const WorkspaceData = _.flow(
           ])
         }, _.keys(referenceData)),
         div({ style: Style.navList.heading }, 'Other Data'),
-        h(FileButton, {
+        h(DataTypeButton, {
           selected: selectedDataType === localVariables,
+          buttonName: 'Workspace Data',
           onClick: () => {
             setSelectedDataType(localVariables)
             forceRefresh()
           }
-        }, ['Workspace Data']),
-        h(FileButton, {
+        }),
+        h(DataTypeButton, {
           iconName: 'folder', iconSize: 18,
           selected: selectedDataType === bucketObjects,
+          buttonName: 'Files',
           onClick: () => {
             setSelectedDataType(bucketObjects)
             forceRefresh()
           }
-        }, ['Files'])
+        })
       ]),
       div({ style: styles.tableViewPanel }, [
         Utils.switchCase(getSelectionType(),

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -48,37 +48,29 @@ const styles = {
   }
 }
 
-const DataTypeButton = ({ buttonName, entityCount, selected, iconName = 'listAlt', iconSize = 14, buttonStyle, ...props }) => {
+const DataTypeButton = ({ buttonName, children, entityCount, selected, iconName = 'listAlt', iconSize = 14, buttonStyle, isReference = false, ...props }) => {
   return h(Clickable, {
     style: { ...Style.navList.item(selected), color: colors.accent(1.2), ...buttonStyle },
     hover: Style.navList.itemHover(selected),
-    tooltip: buttonName,
-    tooltipSide: 'top',
+    ...(isReference ? {} : {
+      tooltip: buttonName,
+      tooltipSide: 'top',
+      tooltipDelay: 250
+    }),
     ...props
   }, [
     div({ style: { flex: 'none', display: 'flex', width: '1.5rem' } }, [
       icon(iconName, { size: iconSize })
     ]),
-    div({ style: { flex: 1, ...Style.noWrapEllipsis }, title: buttonName }, [
-      buttonName
-    ]),
-    entityCount === undefined ? '' : div({ title: entityCount }, [
-      `(${entityCount})`
-    ])
-  ])
-}
-
-const ReferenceDataButton = ({ selected, children, iconName = 'listAlt', iconSize = 14, buttonStyle, ...props }) => {
-  return h(Clickable, {
-    style: { ...Style.navList.item(selected), color: colors.accent(1.2), ...buttonStyle },
-    hover: Style.navList.itemHover(selected),
-    ...props
-  }, [
-    div({ style: { flex: 'none', display: 'flex', width: '1.5rem' } }, [
-      icon(iconName, { size: iconSize })
-    ]),
-    div({ style: { flex: 1, ...Style.noWrapEllipsis }, title: children }, [
+    isReference ? div({ style: { flex: 1, ...Style.noWrapEllipsis } }, [
       children
+    ]) : h(Fragment, [
+      div({ style: { flex: 1, ...Style.noWrapEllipsis } }, [
+        buttonName
+      ]),
+      entityCount === undefined ? '' : div({ title: entityCount }, [
+        `(${entityCount})`
+      ])
     ])
   ])
 }
@@ -577,9 +569,10 @@ const WorkspaceData = _.flow(
           entityTypes: _.keys(entityMetadata)
         }),
         _.map(type => {
-          return h(ReferenceDataButton, {
+          return h(DataTypeButton, {
             key: type,
             selected: selectedDataType === type,
+            isReference: true,
             onClick: () => {
               setSelectedDataType(type)
               refreshWorkspace()

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -48,7 +48,9 @@ const styles = {
   }
 }
 
-const DataTypeButton = ({ selected, entityName, children, entityCount, iconName = 'listAlt', iconSize = 14, buttonStyle, isEntity, ...props }) => {
+const DataTypeButton = ({ selected, entityName, children, entityCount, iconName = 'listAlt', iconSize = 14, buttonStyle, ...props }) => {
+  const isEntity = entityName !== undefined
+
   return h(Clickable, {
     style: { ...Style.navList.item(selected), color: colors.accent(1.2), ...buttonStyle },
     hover: Style.navList.itemHover(selected),
@@ -450,7 +452,6 @@ const WorkspaceData = _.flow(
             return h(DataTypeButton, {
               key: type,
               selected: selectedDataType === type,
-              isEntity: true,
               entityName: type,
               entityCount: typeDetails.count,
               onClick: () => {
@@ -506,7 +507,6 @@ const WorkspaceData = _.flow(
                     buttonStyle: { borderBottom: 0, height: 40 },
                     key: `${snapshotName}_${tableName}`,
                     selected: _.isEqual(selectedDataType, [snapshotName, tableName]),
-                    isEntity: true,
                     entityName: tableName,
                     entityCount: count,
                     onClick: () => {
@@ -565,7 +565,6 @@ const WorkspaceData = _.flow(
           return h(DataTypeButton, {
             key: type,
             selected: selectedDataType === type,
-            isEntity: false,
             onClick: () => {
               setSelectedDataType(type)
               refreshWorkspace()
@@ -588,7 +587,6 @@ const WorkspaceData = _.flow(
         div({ style: Style.navList.heading }, 'Other Data'),
         h(DataTypeButton, {
           selected: selectedDataType === localVariables,
-          isEntity: false,
           onClick: () => {
             setSelectedDataType(localVariables)
             forceRefresh()
@@ -597,7 +595,6 @@ const WorkspaceData = _.flow(
         h(DataTypeButton, {
           iconName: 'folder', iconSize: 18,
           selected: selectedDataType === bucketObjects,
-          isEntity: false,
           onClick: () => {
             setSelectedDataType(bucketObjects)
             forceRefresh()


### PR DESCRIPTION
Fixes the problem of long table/entity names being cut off without a good tooltip, also makes it so the number of entities is never cut off. Added the nice tooltips with a slight delay so it's not annoying if you temporarily mouse over things. 

Tested in the UI 
