### PR TITLE
Add extra scopes to fence link for signed URLs [BT-213]

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -324,7 +324,7 @@ const User = signal => ({
 
   getFenceAuthUrl: async (provider, redirectUri) => {
     const queryParams = {
-      scopes: ['openid', 'google_credentials'],
+      scopes: ['openid', 'google_credentials', 'data', 'user'],
       redirect_uri: redirectUri,
       state: btoa(JSON.stringify({ provider }))
     }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/BT-213

@mikebaumann says that these additional scopes are needed in order for Gen3 to be able to generate and provide Terra with signed URLs for data access.

Please also review the CLIA and security fields on the Jira ticket as part of this review.