### PR TITLE
Add error notification when Galaxy App transitions to Error [IA-2655]

### DIFF
--- a/src/components/RuntimeManager.js
+++ b/src/components/RuntimeManager.js
@@ -22,7 +22,7 @@ import { clearNotification, notify } from 'src/libs/notifications'
 import {
   appIsSettingUp, collapsedRuntimeStatus, currentApp, currentRuntime, persistentDiskCost, runtimeCost, trimRuntimesOldestFirst
 } from 'src/libs/runtime-utils'
-import { errorNotifiedRuntimes, errorNotifiedApps } from 'src/libs/state'
+import { errorNotifiedApps, errorNotifiedRuntimes } from 'src/libs/state'
 import * as Utils from 'src/libs/utils'
 
 

--- a/src/components/RuntimeManager.js
+++ b/src/components/RuntimeManager.js
@@ -236,7 +236,7 @@ export default class RuntimeManager extends PureComponent {
           })
         ])
       })
-    } else if (prevApp && prevApp.status !== 'ERROR' && app && app.status === 'ERROR' && !_.includes(app.appName, errorNotifiedApps.get())) {
+    } else if (app && app.status === 'ERROR' && !_.includes(app.appName, errorNotifiedApps.get())) {
       notify('error', 'Error Creating Galaxy App', {
         message: h(AppErrorNotification, { app })
       })

--- a/src/components/RuntimeManager.js
+++ b/src/components/RuntimeManager.js
@@ -119,7 +119,7 @@ export const AppErrorModal = ({ app, onDismiss }) => {
     Utils.withBusyState(setLoadingAppDetails)
   )(async () => {
     const { errors: appErrors } = await Ajax().Apps.app(app.googleProject, app.appName).details()
-    setError(appErrors[0].errorMessage)
+    setError(appErrors[0]?.errorMessage)
   })
 
   Utils.useOnMount(() => { loadAppError() })

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1265,6 +1265,10 @@ const Apps = signal => ({
       },
       resume: () => {
         return fetchLeo(`${root}/start`, _.mergeAll([authOpts(), { signal, method: 'POST' }, appIdentifier]))
+      },
+      details: async () => {
+        const res = await fetchLeo(root, _.mergeAll([authOpts(), { signal }, appIdentifier]))
+        return res.json()
       }
     }
   }

--- a/src/libs/state.js
+++ b/src/libs/state.js
@@ -35,6 +35,8 @@ export const rerunFailuresStatus = Utils.atom()
 
 export const errorNotifiedRuntimes = Utils.atom([])
 
+export const errorNotifiedApps = Utils.atom([])
+
 export const knownBucketRequesterPaysStatuses = Utils.atom({})
 
 export const requesterPaysProjectStore = Utils.atom()


### PR DESCRIPTION
Working on getting Galaxy apps to more parity with Notebooks
- previuosly a transition to "Error" status would not trigger a  popup, now it will
<img width="1009" alt="Screen Shot 2021-04-08 at 4 39 13 PM" src="https://user-images.githubusercontent.com/54322292/114093857-9ef91e80-9889-11eb-8e17-bcdc14201e68.png">

Possibly some code duplication in the error handling though
