### PR TITLE
[PF-691] Add Location column in Cloud Environments page

### DIFF
--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -189,6 +189,14 @@ const Environments = () => {
             }
           },
           {
+            size: { basis: 120, grow: 0.2 },
+            headerRenderer: () => 'Location',
+            cellRenderer: ({ rowIndex }) => {
+              const { runtimeConfig: { zone } } = filteredRuntimes[rowIndex]
+              return zone
+            }
+          },
+          {
             size: { basis: 250, grow: 0 },
             headerRenderer: () => h(Sortable, { sort, field: 'created', onSort: setSort }, ['Created']),
             cellRenderer: ({ rowIndex }) => {
@@ -263,6 +271,14 @@ const Environments = () => {
             cellRenderer: ({ rowIndex }) => {
               const disk = filteredDisks[rowIndex]
               return disk.size
+            }
+          },
+          {
+            size: { basis: 120, grow: 0.2 },
+            headerRenderer: () => 'Location',
+            cellRenderer: ({ rowIndex }) => {
+              const disk = filteredDisks[rowIndex]
+              return disk.zone
             }
           },
           {

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -193,9 +193,6 @@ const Environments = () => {
             headerRenderer: () => 'Location',
             cellRenderer: ({ rowIndex }) => {
               const { runtimeConfig: { zone, region } } = filteredRuntimes[rowIndex]
-              console.log('willy')
-              console.log(zone)
-              console.log(region)
               return zone ? zone : region
             }
           },

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -193,7 +193,7 @@ const Environments = () => {
             headerRenderer: () => 'Location',
             cellRenderer: ({ rowIndex }) => {
               const { runtimeConfig: { zone, region } } = filteredRuntimes[rowIndex]
-              return zone ? zone : region
+              return zone || region
             }
           },
           {

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -192,8 +192,11 @@ const Environments = () => {
             size: { basis: 120, grow: 0.2 },
             headerRenderer: () => 'Location',
             cellRenderer: ({ rowIndex }) => {
-              const { runtimeConfig: { zone } } = filteredRuntimes[rowIndex]
-              return zone
+              const { runtimeConfig: { zone, region } } = filteredRuntimes[rowIndex]
+              console.log('willy')
+              console.log(zone)
+              console.log(region)
+              return zone ? zone : region
             }
           },
           {


### PR DESCRIPTION
In DataBiosphere/leonardo#1933, zone and region parameters were added to createRuntime so Leo can now create instances outside of us-central1. In #2441, the Terra UI will allow use those new parameters.

This PR will updates the cloud enviroments page to show you the region/zone your environments are in.

Tested with a GCE instance and Dataproc cluster on both the default location (us-central1) and non-default locations.
![image](https://user-images.githubusercontent.com/6879774/114228872-eafc9f80-992b-11eb-928b-dac9c3e0e7c4.png)
![image](https://user-images.githubusercontent.com/6879774/114228835-e2a46480-992b-11eb-9fc3-8b5a8aff9af1.png)
![image](https://user-images.githubusercontent.com/6879774/114228854-e6d08200-992b-11eb-80f4-f098653a5fe9.png)


Discussion of UI changes related to locality have been happening [in this doc](https://docs.google.com/document/d/1--VH3sEGMVTzVvLu7suIaEvkdMgclS4kPLCpY2lgemE/edit?resourcekey=0-BdGkf63bItFtNRTeMixNJw#heading=h.cnp4jpyga990), including comments from UI team. 