### PR TITLE
[IA-2418] Adjust default GCE and Dataproc runtime sizes individually

### DIFF
--- a/src/components/NewRuntimeModal.js
+++ b/src/components/NewRuntimeModal.js
@@ -39,6 +39,7 @@ const safeImageDocumentation = 'https://support.terra.bio/hc/en-us/articles/3600
 // distilled from https://github.com/docker/distribution/blob/95daa793b83a21656fe6c13e6d5cf1c3999108c7/reference/regexp.go
 const imageValidationRegexp = /^[A-Za-z0-9]+[\w./-]+(?::\w[\w.-]+)?(?:@[\w+.-]+:[A-Fa-f0-9]{32,})?$/
 
+const defaultMachineType = 'n1-standard-4'
 const validMachineTypes = _.filter(({ memory }) => memory >= 3.75, machineTypes)
 
 const MachineSelector = ({ value, onChange }) => {
@@ -146,11 +147,11 @@ export const NewRuntimeModal = withModalDrawer({ width: 675 })(class NewRuntimeM
     return {
       selectedPersistentDiskSize: disk?.size || DEFAULT_DISK_SIZE,
       sparkMode: runtimeConfig?.cloudService === cloudServices.DATAPROC ? (runtimeConfig.numberOfWorkers === 0 ? 'master' : 'cluster') : false,
-      masterMachineType: runtimeConfig?.masterMachineType || runtimeConfig?.machineType || 'n1-standard-4',
+      masterMachineType: runtimeConfig?.masterMachineType || runtimeConfig?.machineType || defaultMachineType,
       masterDiskSize: runtimeConfig?.masterDiskSize || runtimeConfig?.diskSize || DEFAULT_DISK_SIZE,
       numberOfWorkers: runtimeConfig?.numberOfWorkers || 2,
       numberOfPreemptibleWorkers: runtimeConfig?.numberOfPreemptibleWorkers || 0,
-      workerMachineType: runtimeConfig?.workerMachineType || 'n1-standard-4',
+      workerMachineType: runtimeConfig?.workerMachineType || defaultMachineType,
       workerDiskSize: runtimeConfig?.workerDiskSize || DEFAULT_DISK_SIZE
     }
   }
@@ -383,12 +384,12 @@ export const NewRuntimeModal = withModalDrawer({ width: 675 })(class NewRuntimeM
             diskSize: runtimeConfig.diskSize
           })
         } : {
-          masterMachineType: runtimeConfig.masterMachineType || 'n1-standard-4',
+          masterMachineType: runtimeConfig.masterMachineType || defaultMachineType,
           masterDiskSize: runtimeConfig.masterDiskSize || 100,
           numberOfWorkers,
           ...(numberOfWorkers && {
             numberOfPreemptibleWorkers: runtimeConfig.numberOfPreemptibleWorkers || 0,
-            workerMachineType: runtimeConfig.workerMachineType || 'n1-standard-4',
+            workerMachineType: runtimeConfig.workerMachineType || defaultMachineType,
             workerDiskSize: runtimeConfig.workerDiskSize || 100
           })
         })

--- a/src/components/NewRuntimeModal.js
+++ b/src/components/NewRuntimeModal.js
@@ -187,12 +187,12 @@ export const NewRuntimeModal = withModalDrawer({ width: 675 })(class NewRuntimeM
       cloudService: newRuntime.cloudService,
       ...(newRuntime.cloudService === cloudServices.GCE ? {
         bootDiskSize: 50,
-        machineType: newRuntime.machineType,
+        machineType: newRuntime.machineType || defaultGceMachineType,
         ...(newRuntime.diskSize ? {
           diskSize: newRuntime.diskSize
         } : {})
       } : {
-        masterMachineType: newRuntime.masterMachineType,
+        masterMachineType: newRuntime.masterMachineType || defaultDataprocMachineType,
         masterDiskSize: newRuntime.masterDiskSize,
         numberOfWorkers: newRuntime.numberOfWorkers,
         ...(newRuntime.numberOfWorkers && {
@@ -264,7 +264,7 @@ export const NewRuntimeModal = withModalDrawer({ width: 675 })(class NewRuntimeM
     const runtimeConfig = newRuntime && {
       cloudService: newRuntime.cloudService,
       ...(newRuntime.cloudService === cloudServices.GCE ? {
-        machineType: newRuntime.machineType,
+        machineType: newRuntime.machineType || defaultGceMachineType,
         ...(newRuntime.diskSize ? {
           diskSize: newRuntime.diskSize
         } : {
@@ -277,7 +277,7 @@ export const NewRuntimeModal = withModalDrawer({ width: 675 })(class NewRuntimeM
           }
         })
       } : {
-        masterMachineType: newRuntime.masterMachineType,
+        masterMachineType: newRuntime.masterMachineType || defaultDataprocMachineType,
         masterDiskSize: newRuntime.masterDiskSize,
         numberOfWorkers: newRuntime.numberOfWorkers,
         ...(newRuntime.numberOfWorkers && {
@@ -338,19 +338,19 @@ export const NewRuntimeModal = withModalDrawer({ width: 675 })(class NewRuntimeM
             toolDockerImage: selectedLeoImage === CUSTOM_MODE ? customEnvImage : selectedLeoImage,
             ...(jupyterUserScriptUri && { jupyterUserScriptUri }),
             ...(cloudService === cloudServices.GCE ? {
-              machineType: masterMachineType || getDefaultMachineType(sparkMode),
+              machineType: masterMachineType || defaultGceMachineType,
               ...(this.shouldUsePersistentDisk() ? {
                 persistentDiskAttached: true
               } : {
                 diskSize: masterDiskSize
               })
             } : {
-              machineType: masterMachineType || getDefaultMachineType(sparkMode),
+              machineType: masterMachineType || defaultDataprocMachineType,
               masterDiskSize,
               numberOfWorkers: newNumberOfWorkers,
               ...(newNumberOfWorkers && {
                 numberOfPreemptibleWorkers,
-                workerMachineType: workerMachineType || getDefaultMachineType(sparkMode),
+                workerMachineType: workerMachineType || defaultDataprocMachineType,
                 workerDiskSize
               })
             })

--- a/src/components/NewRuntimeModal.js
+++ b/src/components/NewRuntimeModal.js
@@ -1047,7 +1047,7 @@ export const NewRuntimeModal = withModalDrawer({ width: 675 })(class NewRuntimeM
                     h(Link, { onClick: () => this.setState({ viewMode: 'packages' }) }, ['What’s installed on this environment?'])
                   ]),
                   li({ style: { marginTop: '1rem' } }, [
-                    'Default compute size of ', span({ style: { fontWeight: 600 } }, [cpu, ' CPUs']), ', ',
+                    'Default compute size of ', span({ style: { fontWeight: 600 } }, [cpu, ' CPU(s)']), ', ',
                     span({ style: { fontWeight: 600 } }, [memory, ' GB memory']), ', and ',
                     oldPersistentDisk ?
                       h(Fragment, ['your existing ', renderDiskText()]) :

--- a/src/components/NewRuntimeModal.js
+++ b/src/components/NewRuntimeModal.js
@@ -39,7 +39,7 @@ const safeImageDocumentation = 'https://support.terra.bio/hc/en-us/articles/3600
 // distilled from https://github.com/docker/distribution/blob/95daa793b83a21656fe6c13e6d5cf1c3999108c7/reference/regexp.go
 const imageValidationRegexp = /^[A-Za-z0-9]+[\w./-]+(?::\w[\w.-]+)?(?:@[\w+.-]+:[A-Fa-f0-9]{32,})?$/
 
-const validMachineTypes = _.filter(({ memory }) => memory >= 4, machineTypes)
+const validMachineTypes = _.filter(({ memory }) => memory >= 3.75, machineTypes)
 
 const MachineSelector = ({ value, onChange }) => {
   const { cpu: currentCpu, memory: currentMemory } = findMachineType(value)

--- a/src/libs/runtime-utils.js
+++ b/src/libs/runtime-utils.js
@@ -7,6 +7,10 @@ export const DEFAULT_DISK_SIZE = 50
 
 export const usableStatuses = ['Updating', 'Running']
 
+export const defaultDataprocMachineType = 'n1-standard-2'
+export const defaultGceMachineType = 'n1-standard-1'
+export const getDefaultMachineType = isDataproc => isDataproc ? defaultDataprocMachineType : defaultGceMachineType
+
 export const normalizeRuntimeConfig = ({
   cloudService, machineType, diskSize, masterMachineType, masterDiskSize, numberOfWorkers,
   numberOfPreemptibleWorkers, workerMachineType, workerDiskSize, bootDiskSize
@@ -15,12 +19,12 @@ export const normalizeRuntimeConfig = ({
 
   return {
     cloudService: cloudService || cloudServices.GCE,
-    masterMachineType: masterMachineType || machineType || 'n1-standard-4',
-    masterDiskSize: masterDiskSize || diskSize || 50,
+    masterMachineType: masterMachineType || machineType || getDefaultMachineType(isDataproc),
+    masterDiskSize: masterDiskSize || diskSize || DEFAULT_DISK_SIZE,
     numberOfWorkers: (isDataproc && numberOfWorkers) || 0,
     numberOfPreemptibleWorkers: (isDataproc && numberOfWorkers && numberOfPreemptibleWorkers) || 0,
-    workerMachineType: (isDataproc && numberOfWorkers && workerMachineType) || 'n1-standard-4',
-    workerDiskSize: (isDataproc && numberOfWorkers && workerDiskSize) || 50,
+    workerMachineType: (isDataproc && numberOfWorkers && workerMachineType) || defaultDataprocMachineType,
+    workerDiskSize: (isDataproc && numberOfWorkers && workerDiskSize) || DEFAULT_DISK_SIZE,
     bootDiskSize: bootDiskSize || 0
   }
 }


### PR DESCRIPTION
### Ticket
[IA-2418
](https://broadworkbench.atlassian.net/browse/)

### Background
[CH's findings](https://broadworkbench.atlassian.net/browse/IA-2418?focusedCommentId=44310) had indicated that `n1-standard-1` should sufficient for basic `GCE` VM functionality and similarly should `n1-standard-2` for `Dataproc`. After verifying these findings, I was also able to successfully run [some of the tutorial notebooks](https://broadworkbench.atlassian.net/browse/IA-2418?focusedCommentId=44342) recommended by the User Ed team on a `n1-standard-1` machine.

### PR Highlights
We now
- set `n1-standard-1` as the default machine type for `GCE` VMs (as determined by corresponding images),
- set `n2-standard-2` as the default machine type for `Dataproc` nodes (as determined by corresponding images),
- remove `n1-standard-1` from machine type options if a user selects a `Dataproc` image at any point.

### Testing
- Tested the UI manually by flipping through the image and machine selectors against `dev`.
- Tested the new GCE default config against the tutorial notebooks recommended by the Comms team:
  - [GATKTutorials-Germline](https://app.terra.bio/#workspaces/help-gatk/GATKTutorials-Germline/notebooks) (3-cnn-tutorial notebook is known to fail with default image so didn't run that)
  - [Somatic-SNVs-Indels-GATK4](https://app.terra.bio/#workspaces/help-gatk/Somatic-SNVs-Indels-GATK4/notebooks)
  - [GATK4-Germline-Preprocessing-VariantCalling-JointCalling](https://app.terra.bio/#workspaces/help-gatk/GATK4-Germline-Preprocessing-VariantCalling-JointCalling/notebooks)
  - [Somatic-CNVs-GATK4](https://app.terra.bio/#workspaces/help-gatk/Somatic-CNVs-GATK4/notebooks)