### PR TITLE
IA-2634 IA-2668 use bootDisk returned from leo

### DIFF
--- a/src/components/NewRuntimeModal.js
+++ b/src/components/NewRuntimeModal.js
@@ -340,7 +340,7 @@ export const NewRuntimeModal = withModalDrawer({ width: 675 })(class NewRuntimeM
             ...(jupyterUserScriptUri && { jupyterUserScriptUri }),
             ...(cloudService === cloudServices.GCE ? {
               machineType: masterMachineType || defaultGceMachineType,
-              bootDiskSize: oldRuntime?.bootDiskSize,
+              bootDiskSize: existingRuntime?.bootDiskSize,
               ...(this.shouldUsePersistentDisk() ? {
                 persistentDiskAttached: true
               } : {

--- a/src/components/NewRuntimeModal.js
+++ b/src/components/NewRuntimeModal.js
@@ -341,7 +341,7 @@ export const NewRuntimeModal = withModalDrawer({ width: 675 })(class NewRuntimeM
             ...(cloudService === cloudServices.GCE ? {
               machineType: masterMachineType || defaultGceMachineType,
               // bootDiskSize can be null if it's an really old runtime
-              bootDiskSize: existingRuntime?.bootDiskSize || 0,
+              bootDiskSize: existingRuntime?.bootDiskSize || 50,
               ...(this.shouldUsePersistentDisk() ? {
                 persistentDiskAttached: true
               } : {

--- a/src/components/NewRuntimeModal.js
+++ b/src/components/NewRuntimeModal.js
@@ -340,7 +340,8 @@ export const NewRuntimeModal = withModalDrawer({ width: 675 })(class NewRuntimeM
             ...(jupyterUserScriptUri && { jupyterUserScriptUri }),
             ...(cloudService === cloudServices.GCE ? {
               machineType: masterMachineType || defaultGceMachineType,
-              bootDiskSize: existingRuntime?.bootDiskSize,
+              // bootDiskSize can be null if it's an really old runtime
+              bootDiskSize: existingRuntime?.bootDiskSize || 0,
               ...(this.shouldUsePersistentDisk() ? {
                 persistentDiskAttached: true
               } : {

--- a/src/components/NewRuntimeModal.js
+++ b/src/components/NewRuntimeModal.js
@@ -183,11 +183,12 @@ export const NewRuntimeModal = withModalDrawer({ width: 675 })(class NewRuntimeM
    */
   getPendingRuntimeConfig() {
     const { runtime: desiredRuntime } = this.getDesiredEnvironmentConfig()
+
     return {
       cloudService: desiredRuntime.cloudService,
       ...(desiredRuntime.cloudService === cloudServices.GCE ? {
-        bootDiskSize: 50,
         machineType: desiredRuntime.machineType || defaultGceMachineType,
+        bootDiskSize: desiredRuntime.bootDiskSize,
         ...(desiredRuntime.diskSize ? {
           diskSize: desiredRuntime.diskSize
         } : {})
@@ -339,6 +340,7 @@ export const NewRuntimeModal = withModalDrawer({ width: 675 })(class NewRuntimeM
             ...(jupyterUserScriptUri && { jupyterUserScriptUri }),
             ...(cloudService === cloudServices.GCE ? {
               machineType: masterMachineType || defaultGceMachineType,
+              bootDiskSize: oldRuntime?.bootDiskSize,
               ...(this.shouldUsePersistentDisk() ? {
                 persistentDiskAttached: true
               } : {
@@ -379,6 +381,7 @@ export const NewRuntimeModal = withModalDrawer({ width: 675 })(class NewRuntimeM
         ...(currentRuntimeDetails?.jupyterUserScriptUri && { jupyterUserScriptUri: currentRuntimeDetails?.jupyterUserScriptUri }),
         ...(cloudService === cloudServices.GCE ? {
           machineType: runtimeConfig.machineType || defaultGceMachineType,
+          bootDiskSize: runtimeConfig.bootDiskSize,
           ...(runtimeConfig.persistentDiskId ? {
             persistentDiskAttached: true
           } : {

--- a/src/components/NewRuntimeModal.js
+++ b/src/components/NewRuntimeModal.js
@@ -340,8 +340,7 @@ export const NewRuntimeModal = withModalDrawer({ width: 675 })(class NewRuntimeM
             ...(jupyterUserScriptUri && { jupyterUserScriptUri }),
             ...(cloudService === cloudServices.GCE ? {
               machineType: masterMachineType || defaultGceMachineType,
-              // bootDiskSize can be null if it's an really old runtime
-              bootDiskSize: existingRuntime?.bootDiskSize || 50,
+              bootDiskSize: existingRuntime?.bootDiskSize,
               ...(this.shouldUsePersistentDisk() ? {
                 persistentDiskAttached: true
               } : {

--- a/src/libs/runtime-utils.js
+++ b/src/libs/runtime-utils.js
@@ -4,7 +4,7 @@ import * as Utils from 'src/libs/utils'
 
 
 export const DEFAULT_DISK_SIZE = 50
-export const DEFAULT_BOOT_DISK = 50
+export const DEFAULT_BOOT_DISK_SIZE = 50
 
 export const usableStatuses = ['Updating', 'Running']
 
@@ -26,10 +26,10 @@ export const normalizeRuntimeConfig = ({
     numberOfPreemptibleWorkers: (isDataproc && numberOfWorkers && numberOfPreemptibleWorkers) || 0,
     workerMachineType: (isDataproc && numberOfWorkers && workerMachineType) || defaultDataprocMachineType,
     workerDiskSize: (isDataproc && numberOfWorkers && workerDiskSize) || DEFAULT_DISK_SIZE,
-    // One caveact with using DEFAULT_BOOT_DISK here is this over-estimates old GCE runtimes without PD by 1 cent
+    // One caveact with using DEFAULT_BOOT_DISK_SIZE here is this over-estimates old GCE runtimes without PD by 1 cent
     // because those runtimes do not have a separate boot disk. But those old GCE runtimes are more than 1 year old if they exist.
     // Hence, we're okay with this caveat.
-    bootDiskSize: bootDiskSize || DEFAULT_BOOT_DISK
+    bootDiskSize: bootDiskSize || DEFAULT_BOOT_DISK_SIZE
   }
 }
 

--- a/src/libs/runtime-utils.js
+++ b/src/libs/runtime-utils.js
@@ -4,6 +4,7 @@ import * as Utils from 'src/libs/utils'
 
 
 export const DEFAULT_DISK_SIZE = 50
+export const DEFAULT_BOOT_DISK = 50
 
 export const usableStatuses = ['Updating', 'Running']
 
@@ -25,7 +26,10 @@ export const normalizeRuntimeConfig = ({
     numberOfPreemptibleWorkers: (isDataproc && numberOfWorkers && numberOfPreemptibleWorkers) || 0,
     workerMachineType: (isDataproc && numberOfWorkers && workerMachineType) || defaultDataprocMachineType,
     workerDiskSize: (isDataproc && numberOfWorkers && workerDiskSize) || DEFAULT_DISK_SIZE,
-    bootDiskSize: bootDiskSize || 0
+    // One caveact with using DEFAULT_BOOT_DISK here is this over-estimates old GCE runtimes without PD by 1 cent
+    // because those runtimes do not have a separate boot disk. But those old GCE runtimes are more than 1 year old if they exist.
+    // Hence, we're okay with this caveat.
+    bootDiskSize: bootDiskSize || DEFAULT_BOOT_DISK
   }
 }
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2634
https://broadworkbench.atlassian.net/browse/IA-2668

As part of gpu epic, we'll likely to change bootDiskSize. Hence, update cost estimate to rely on `bootDiskSize` returned from leo instead of hardcoded value.

Tested in Fiab. Notice `Running cloud compute cost` changed from 0.05 to 0.06 (I have terra-ui running against my fiab with `bootDisk` updated to 60G)
* Open the create runtime panel when there's no runtime existent
<img width="674" alt="Screen Shot 2021-04-16 at 4 46 07 PM" src="https://user-images.githubusercontent.com/32771737/115082122-5f5ab400-9ed3-11eb-805a-0c6ad90a2177.png">

* Open the create runtime panel when there is a runtime existent
<img width="642" alt="Screen Shot 2021-04-16 at 4 51 22 PM" src="https://user-images.githubusercontent.com/32771737/115082504-050e2300-9ed4-11eb-83f4-c793ce4b317a.png">

