### PR TITLE
[CA-1312] A11y: Table roles

### DIFF
--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -198,6 +198,7 @@ const DataTable = props => {
               onScroll,
               initialX,
               initialY,
+              sort,
               columns: [
                 {
                   width: 70,
@@ -206,7 +207,8 @@ const DataTable = props => {
                       h(Checkbox, {
                         checked: pageSelected(),
                         disabled: !entities.length,
-                        onChange: () => pageSelected() ? deselectPage() : selectPage()
+                        onChange: () => pageSelected() ? deselectPage() : selectPage(),
+                        'aria-label': 'Select all'
                       }),
                       h(PopupTrigger, {
                         closeOnClick: true,
@@ -233,6 +235,7 @@ const DataTable = props => {
                   }
                 },
                 {
+                  field: 'name',
                   width: nameWidth,
                   headerRenderer: () => h(Resizable, {
                     width: nameWidth, onWidthChange: delta => {
@@ -259,6 +262,7 @@ const DataTable = props => {
                   const thisWidth = columnWidths[name] || 300
                   const [, columnNamespace, columnName] = /(.+:)?(.+)/.exec(name)
                   return {
+                    field: name,
                     width: thisWidth,
                     headerRenderer: () => h(Resizable, {
                       width: thisWidth, onWidthChange: delta => setColumnWidths(_.set(name, thisWidth + delta))

--- a/src/components/data/UploadPreviewTable.js
+++ b/src/components/data/UploadPreviewTable.js
@@ -210,11 +210,12 @@ const UploadDataTable = props => {
               width, height,
               rowCount: sortedRows.length,
               noContentMessage: `No ${entityType}s to display.`,
-              onScroll: saveScroll, initialX, initialY,
+              onScroll: saveScroll, initialX, initialY, sort,
               columns: [
                 ..._.map(name => {
                   const thisWidth = columnWidths[name] || 300
                   return {
+                    field: name,
                     width: thisWidth,
                     headerRenderer: ({ columnIndex }) => h(Resizable, {
                       width: thisWidth, onWidthChange: delta => setColumnWidths(_.set(name, thisWidth + delta))

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -267,12 +267,18 @@ FlexTable.propTypes = {
  * since it does not provide scrolling. See FlexTable for prop types.
  */
 export const SimpleFlexTable = ({ columns, rowCount, noContentMessage, hoverHighlight }) => {
-  return h(Fragment, [
-    div({ style: { height: 48, display: 'flex' } }, [
+  return div({
+    role: 'grid',
+  }, [
+    div({
+      style: { height: 48, display: 'flex' },
+      role: 'row'
+    }, [
       _.map(([i, { size, headerRenderer }]) => {
         return div({
           key: i,
-          style: { ...styles.flexCell(size), ...styles.header(i * 1, columns.length) }
+          style: { ...styles.flexCell(size), ...styles.header(i * 1, columns.length) },
+          role: 'columnheader'
         }, [headerRenderer()])
       }, Utils.toIndexPairs(columns))
     ]),
@@ -281,6 +287,7 @@ export const SimpleFlexTable = ({ columns, rowCount, noContentMessage, hoverHigh
         key: rowIndex,
         as: 'div',
         className: 'table-row',
+        role: 'row',
         style: { backgroundColor: 'white', display: 'flex', minHeight: 48 },
         hover: hoverHighlight ? { backgroundColor: colors.light(0.4) } : undefined
       }, [
@@ -288,6 +295,7 @@ export const SimpleFlexTable = ({ columns, rowCount, noContentMessage, hoverHigh
           return div({
             key: i,
             className: 'table-cell',
+            role: 'gridcell',
             style: { ...styles.flexCell(size), ...styles.cell(i * 1, columns.length) }
           }, [cellRenderer({ rowIndex })])
         }, Utils.toIndexPairs(columns))
@@ -335,7 +343,11 @@ export const GridTable = Utils.forwardRefWithName('GridTable', ({
     ref: scrollSync
   }, [
     ({ onScroll, scrollLeft }) => {
-      return div([
+      return div({
+        role: 'grid',
+        'aria-rowcount': rowCount + 1, // count the header row too
+        'aria-colcount': columns.length
+      }, [
         h(RVGrid, {
           ref: header,
           width: width - scrollbarSize,
@@ -344,6 +356,9 @@ export const GridTable = Utils.forwardRefWithName('GridTable', ({
           rowHeight: headerHeight,
           rowCount: 1,
           columnCount: columns.length,
+          role: 'rowgroup',
+          containerRole: 'row',
+          'aria-label': '',
           cellRenderer: data => {
             return div({
               key: data.key,
@@ -352,7 +367,10 @@ export const GridTable = Utils.forwardRefWithName('GridTable', ({
                 ...data.style,
                 ...styles.header(data.columnIndex, columns.length),
                 ...styleHeader(data)
-              }
+              },
+              role: 'columnheader',
+              'aria-colindex': data.columnIndex,
+              'aria-rowindex': 1, // the rowindex property must start at 1
             }, [
               columns[data.columnIndex].headerRenderer(data)
             ])
@@ -369,6 +387,9 @@ export const GridTable = Utils.forwardRefWithName('GridTable', ({
           rowHeight,
           rowCount,
           columnCount: columns.length,
+          role: 'rowgroup',
+          containerRole: 'presentation',
+          'aria-label': '',
           noContentRenderer: () => div({ style: { marginTop: '1rem', textAlign: 'center', fontStyle: 'italic' } }, [noContentMessage]),
           onScrollbarPresenceChange: ({ vertical, size }) => {
             setScrollbarSize(vertical ? size : 0)
@@ -377,6 +398,9 @@ export const GridTable = Utils.forwardRefWithName('GridTable', ({
             return div({
               key: data.key,
               className: 'table-cell',
+              role: 'gridcell',
+              'aria-colindex': data.columnIndex,
+              'aria-rowindex': data.rowIndex + 2, // The header row is 1
               style: {
                 ...data.style,
                 ...styles.cell(data.columnIndex, columns.length),

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -499,10 +499,11 @@ GridTable.propTypes = {
   })
 }
 
-export const SimpleTable = ({ columns, rows }) => {
+export const SimpleTable = ({ columns, rows, tableName = 'data table' }) => {
   const cellStyles = { paddingTop: '0.25rem', paddingBottom: '0.25rem' }
   return h(div, {
-    role: 'table'
+    role: 'table',
+    'aria-label': tableName
   }, [
     div({ style: { display: 'flex' } }, [
       _.map(({ key, header, size }) => {

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -239,7 +239,7 @@ export const FlexTable = ({
               style: {
                 ...styles.flexCell(size),
                 ...(variant === 'light' ? {} : styles.cell(i * 1, columns.length)),
-                ...(styleCell ? styleCell({ ...data, columnIndex: i, rowIndex: data.rowIndex + 1 }) : {})
+                ...(styleCell ? styleCell({ ...data, columnIndex: i, rowIndex: data.rowIndex }) : {})
               }
             }, [cellRenderer({ ...data, columnIndex: i, rowIndex: data.rowIndex })])
           }, Utils.toIndexPairs(columns))

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -261,6 +261,7 @@ FlexTable.propTypes = {
   variant: PropTypes.oneOf(['light']),
   noContentMessage: PropTypes.node,
   columns: PropTypes.arrayOf(PropTypes.shape({
+    field: PropTypes.string,
     headerRenderer: PropTypes.func.isRequired,
     cellRenderer: PropTypes.func.isRequired,
     size: PropTypes.shape({
@@ -278,7 +279,10 @@ FlexTable.propTypes = {
   styleHeader: PropTypes.func,
   styleCell: PropTypes.func,
   tableName: PropTypes.string,
-  sort: PropTypes.shape({ field: PropTypes.string, direction: PropTypes.string })
+  sort: PropTypes.shape({
+    field: PropTypes.string,
+    direction: PropTypes.string
+  })
 }
 
 /**
@@ -332,7 +336,8 @@ export const SimpleFlexTable = ({ columns, rowCount, noContentMessage, hoverHigh
  */
 export const GridTable = Utils.forwardRefWithName('GridTable', ({
   width, height, initialX = 0, initialY = 0, rowHeight = 48, headerHeight = 48, noContentMessage,
-  rowCount, columns, styleCell = () => ({}), styleHeader = () => ({}), onScroll: customOnScroll = _.noop, tableName = 'data table'
+  rowCount, columns, styleCell = () => ({}), styleHeader = () => ({}), onScroll: customOnScroll = _.noop,
+  tableName = 'data table', sort = null
 }, ref) => {
   const [scrollbarSize, setScrollbarSize] = useState(0)
   const header = useRef()
@@ -365,7 +370,7 @@ export const GridTable = Utils.forwardRefWithName('GridTable', ({
   }, [
     ({ onScroll, scrollLeft }) => {
       return div({
-        role: 'grid',
+        role: 'table',
         'aria-rowcount': rowCount + 1, // count the header row too
         'aria-colcount': columns.length,
         'aria-label': tableName
@@ -383,12 +388,14 @@ export const GridTable = Utils.forwardRefWithName('GridTable', ({
           'aria-readonly': null, // Clear out ARIA properties which have been moved one level up
           'aria-label': `${tableName} header row`, // The whole table is a tab stop so it needs a label
           cellRenderer: data => {
+            const field = columns[data.columnIndex].field
             return div({
               key: data.key,
               className: 'table-cell',
               role: 'columnheader',
-              'aria-colindex': data.columnIndex,
-              'aria-rowindex': 1, // the rowindex property must start at 1
+              'aria-colindex': data.columnIndex + 1,
+              'aria-rowindex': 1, // the rowindex property must start at 1,
+              'aria-sort': !sort || !field ? null : sort.field === field ? sort.direction === 'asc' ? 'ascending' : 'descending' : 'none',
               style: {
                 ...data.style,
                 ...styles.header(data.columnIndex, columns.length),
@@ -411,7 +418,7 @@ export const GridTable = Utils.forwardRefWithName('GridTable', ({
           rowCount,
           columnCount: columns.length,
           role: 'rowgroup',
-          containerRole: 'presentation',
+          containerRole: 'row',
           'aria-readonly': null, // Clear out ARIA properties which have been moved one level up
           'aria-label': `${tableName} content`, // The whole table is a tab stop so it needs a label
           noContentRenderer: () => div({ style: { marginTop: '1rem', textAlign: 'center', fontStyle: 'italic' } }, [noContentMessage]),
@@ -422,8 +429,8 @@ export const GridTable = Utils.forwardRefWithName('GridTable', ({
             return div({
               key: data.key,
               className: 'table-cell',
-              role: 'gridcell',
-              'aria-colindex': data.columnIndex,
+              role: 'cell',
+              'aria-colindex': data.columnIndex + 1,
               'aria-rowindex': data.rowIndex + 2, // The header row is 1
               style: {
                 ...data.style,
@@ -456,12 +463,20 @@ GridTable.propTypes = {
   rowCount: PropTypes.number.isRequired,
   styleHeader: PropTypes.func,
   styleCell: PropTypes.func,
-  columns: PropTypes.arrayOf(PropTypes.shape({ width: PropTypes.number.isRequired })),
+  columns: PropTypes.arrayOf(PropTypes.shape({
+    field: PropTypes.string,
+    width: PropTypes.number.isRequired,
+    headerRenderer: PropTypes.func.isRequired,
+    cellRenderer: PropTypes.func.isRequired
+  })),
   onScroll: PropTypes.func,
   headerHeight: PropTypes.number,
   rowHeight: PropTypes.number,
   tableName: PropTypes.string,
-  sort: PropTypes.shape({ field: PropTypes.string, direction: PropTypes.string })
+  sort: PropTypes.shape({
+    field: PropTypes.string,
+    direction: PropTypes.string
+  })
 }
 
 export const SimpleTable = ({ columns, rows }) => {
@@ -524,10 +539,7 @@ export const Sortable = ({ sort, field, onSort, columnIndex, children }) => {
     sort.field === field && div({
       style: { color: colors.accent(), marginLeft: 'auto' }
     }, [
-      icon(sort.direction === 'asc' ? 'long-arrow-alt-down' : 'long-arrow-alt-up', {
-        'aria-hidden': false,
-        'aria-label': `sorted in ${sort.direction === 'asc' ? 'ascending' : 'descending'} order`
-      })
+      icon(sort.direction === 'asc' ? 'long-arrow-alt-down' : 'long-arrow-alt-up')
     ]),
     div({ id, style: { display: 'none' } }, ['Click to sort by this column'])
   ])])
@@ -543,10 +555,7 @@ export const MiniSortable = ({ sort, field, onSort, columnIndex, children }) => 
     sort.field === field && div({
       style: { color: colors.accent(), marginLeft: '1rem' }
     }, [
-      icon(sort.direction === 'asc' ? 'long-arrow-alt-down' : 'long-arrow-alt-up', {
-        'aria-hidden': false,
-        'aria-label': `sorted in ${sort.direction ? 'descending' : 'ascending'} order`
-      })
+      icon(sort.direction === 'asc' ? 'long-arrow-alt-down' : 'long-arrow-alt-up')
     ]),
     div({ id, style: { display: 'none' } }, ['Click to sort by this column'])
   ])])

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -375,14 +375,14 @@ export const GridTable = Utils.forwardRefWithName('GridTable', ({
             return div({
               key: data.key,
               className: 'table-cell',
+              role: 'columnheader',
+              'aria-colindex': data.columnIndex,
+              'aria-rowindex': 1, // the rowindex property must start at 1
               style: {
                 ...data.style,
                 ...styles.header(data.columnIndex, columns.length),
                 ...styleHeader(data)
-              },
-              role: 'columnheader',
-              'aria-colindex': data.columnIndex,
-              'aria-rowindex': 1, // the rowindex property must start at 1
+              }
             }, [
               columns[data.columnIndex].headerRenderer(data)
             ])
@@ -493,7 +493,7 @@ export const HeaderCell = props => {
 }
 
 export const Sortable = ({ sort, field, onSort, children }) => {
-  return h(IdContainer, [id => h(Clickable,{
+  return h(IdContainer, [id => h(Clickable, {
     style: { flex: 1, display: 'flex', alignItems: 'center', cursor: 'pointer', width: '100%', height: '100%' },
     onClick: () => onSort(Utils.nextSort(sort, field)),
     'aria-describedby': id
@@ -512,7 +512,7 @@ export const Sortable = ({ sort, field, onSort, children }) => {
 }
 
 export const MiniSortable = ({ sort, field, onSort, children }) => {
-  return h(IdContainer, [id => h(Clickable,{
+  return h(IdContainer, [id => h(Clickable, {
     style: { display: 'flex', alignItems: 'center', cursor: 'pointer', height: '100%' },
     onClick: () => onSort(Utils.nextSort(sort, field)),
     'aria-describedby': id

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -161,6 +161,9 @@ const styles = {
 // Note: We always need 1 extra row's worth of height for the table header row:
 export const tableHeight = ({ actualRows, maxRows, heightPerRow = 48 }) => (_.min([actualRows, maxRows]) + 1) * heightPerRow
 
+const ariaSort = (sort, field) => !sort || !field ? null :
+  sort.field !== field ? 'none' : sort.direction === 'asc' ? 'ascending' : 'descending'
+
 /**
  * A virtual table with a fixed header and flexible column widths. Intended to take up the full
  * available container width, without horizontal scrolling.
@@ -180,7 +183,7 @@ export const FlexTable = ({
 
   return div({
     role: 'table',
-    'aria-rowcount': rowCount,
+    'aria-rowcount': rowCount + 1, // count the header row too
     'aria-colcount': columns.length,
     'aria-label': tableName
   }, [
@@ -197,7 +200,7 @@ export const FlexTable = ({
         role: 'columnheader',
         'aria-rowindex': 1,
         'aria-colindex': i + 1,
-        'aria-sort': !sort || !field ? null : sort.field === field ? sort.direction === 'asc' ? 'ascending' : 'descending' : 'none',
+        'aria-sort': ariaSort(sort, field),
         style: {
           ...styles.flexCell(size),
           ...(variant === 'light' ? {} : styles.header(i * 1, columns.length)),
@@ -303,7 +306,7 @@ export const SimpleFlexTable = ({ columns, rowCount, noContentMessage, hoverHigh
           key: i,
           style: { ...styles.flexCell(size), ...styles.header(i * 1, columns.length) },
           role: 'columnheader',
-          'aria-sort': !sort || !field ? null : sort.field === field ? sort.direction === 'asc' ? 'ascending' : 'descending' : 'none'
+          'aria-sort': ariaSort(sort, field)
         }, [headerRenderer({ columnIndex: i })])
       }, Utils.toIndexPairs(columns))
     ]),
@@ -395,7 +398,7 @@ export const GridTable = Utils.forwardRefWithName('GridTable', ({
               role: 'columnheader',
               'aria-colindex': data.columnIndex + 1,
               'aria-rowindex': 1, // the rowindex property must start at 1,
-              'aria-sort': !sort || !field ? null : sort.field === field ? sort.direction === 'asc' ? 'ascending' : 'descending' : 'none',
+              'aria-sort': ariaSort(sort, field),
               style: {
                 ...data.style,
                 ...styles.header(data.columnIndex, columns.length),

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -169,7 +169,7 @@ export const tableHeight = ({ actualRows, maxRows, heightPerRow = 48 }) => (_.mi
  * @param sort A state object containing the current sort order
  * @param sort.field An identifier for the field name currently being sorted.
  * @param sort.direction 'asc' or 'desc'
- * @param field The identifier of the field to check
+ * @param field The identifier of the field to check.
  * @return 'ascending' or 'descending' if currently sorting by the given field,
  *  'none' if the given field is sortable but the table is currently sorted by a different field,
  *  null if the table or column is not sortable.

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -183,18 +183,24 @@ export const FlexTable = ({
         width: width - scrollbarSize,
         height: headerHeight,
         display: 'flex'
-      }
+      },
+      role: 'grid',
+      'aria-rowcount': rowCount,
+      'aria-colcount': columns.length
     }, [
-      ..._.map(([i, { size, headerRenderer }]) => {
+      div({
+        role: 'row'
+      }, ..._.map(([i, { size, headerRenderer }]) => {
         return div({
           key: i,
+          role: 'columnheader',
           style: {
             ...styles.flexCell(size),
             ...(variant === 'light' ? {} : styles.header(i * 1, columns.length)),
             ...(styleHeader ? styleHeader({ columnIndex: i }) : {})
           }
         }, [headerRenderer()])
-      }, _.toPairs(columns))
+      }, _.toPairs(columns)))
     ]),
     h(RVGrid, {
       ref: body,
@@ -212,6 +218,7 @@ export const FlexTable = ({
           key: data.key,
           as: 'div',
           className: 'table-row',
+          role: 'row',
           style: { ...data.style, backgroundColor: 'white', display: 'flex' },
           hover: hoverHighlight ? { backgroundColor: colors.light(0.4) } : undefined
         }, [
@@ -219,6 +226,9 @@ export const FlexTable = ({
             return div({
               key: i,
               className: 'table-cell',
+              role: 'gridcell',
+              'aria-rowindex': data.rowIndex,
+              'aria-colindex': i,
               style: {
                 ...styles.flexCell(size),
                 ...(variant === 'light' ? {} : styles.cell(i * 1, columns.length)),
@@ -268,7 +278,7 @@ FlexTable.propTypes = {
  */
 export const SimpleFlexTable = ({ columns, rowCount, noContentMessage, hoverHighlight }) => {
   return div({
-    role: 'grid',
+    role: 'grid'
   }, [
     div({
       style: { height: 48, display: 'flex' },

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -550,10 +550,10 @@ export const HeaderCell = props => {
   return h(TextCell, _.merge({ style: { fontWeight: 500 } }, props))
 }
 
-export const Sortable = ({ sort, field, onSort, columnIndex, children }) => {
+export const Sortable = ({ sort, field, onSort, children }) => {
   return h(IdContainer, [id => h(Clickable, {
     style: { flex: 1, display: 'flex', alignItems: 'center', cursor: 'pointer', width: '100%', height: '100%' },
-    onClick: () => onSort(Utils.nextSort(sort, field, columnIndex)),
+    onClick: () => onSort(Utils.nextSort(sort, field)),
     'aria-describedby': id
   }, [
     children,
@@ -566,10 +566,10 @@ export const Sortable = ({ sort, field, onSort, columnIndex, children }) => {
   ])])
 }
 
-export const MiniSortable = ({ sort, field, onSort, columnIndex, children }) => {
+export const MiniSortable = ({ sort, field, onSort, children }) => {
   return h(IdContainer, [id => h(Clickable, {
     style: { display: 'flex', alignItems: 'center', cursor: 'pointer', height: '100%' },
-    onClick: () => onSort(Utils.nextSort(sort, field, columnIndex)),
+    onClick: () => onSort(Utils.nextSort(sort, field)),
     'aria-describedby': id
   }, [
     children,

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -143,9 +143,12 @@ const Environments = () => {
     div({ role: 'main', style: { padding: '1rem', flexGrow: 1 } }, [
       div({ style: { ...Style.elements.sectionHeader, textTransform: 'uppercase', marginBottom: '1rem' } }, ['Your cloud environments']),
       runtimes && h(SimpleFlexTable, {
+        sort,
+        tableName: 'cloud environments',
         rowCount: filteredRuntimes.length,
         columns: [
           {
+            field: 'project',
             headerRenderer: () => h(Sortable, { sort, field: 'project', onSort: setSort }, ['Billing project']),
             cellRenderer: ({ rowIndex }) => {
               const runtime = filteredRuntimes[rowIndex]
@@ -175,6 +178,7 @@ const Environments = () => {
           },
           {
             size: { basis: 150, grow: 0 },
+            field: 'status',
             headerRenderer: () => h(Sortable, { sort, field: 'status', onSort: setSort }, ['Status']),
             cellRenderer: ({ rowIndex }) => {
               const runtime = filteredRuntimes[rowIndex]
@@ -190,6 +194,7 @@ const Environments = () => {
           },
           {
             size: { basis: 250, grow: 0 },
+            field: 'created',
             headerRenderer: () => h(Sortable, { sort, field: 'created', onSort: setSort }, ['Created']),
             cellRenderer: ({ rowIndex }) => {
               return makeCompleteDate(filteredRuntimes[rowIndex].auditInfo.createdDate)
@@ -197,6 +202,7 @@ const Environments = () => {
           },
           {
             size: { basis: 250, grow: 0 },
+            field: 'accessed',
             headerRenderer: () => h(Sortable, { sort, field: 'accessed', onSort: setSort }, ['Last accessed']),
             cellRenderer: ({ rowIndex }) => {
               return makeCompleteDate(filteredRuntimes[rowIndex].auditInfo.dateAccessed)
@@ -204,6 +210,7 @@ const Environments = () => {
           },
           {
             size: { basis: 240, grow: 0 },
+            field: 'cost',
             headerRenderer: () => {
               return h(Sortable, { sort, field: 'cost', onSort: setSort }, [`Cost / hr (${formatUSD(totalCost)} total)`])
             },
@@ -228,9 +235,12 @@ const Environments = () => {
       }),
       div({ style: { ...Style.elements.sectionHeader, textTransform: 'uppercase', margin: '1rem 0' } }, ['Your persistent disks']),
       disks && h(SimpleFlexTable, {
+        sort: diskSort,
+        tableName: 'persistent disks',
         rowCount: filteredDisks.length,
         columns: [
           {
+            field: 'project',
             headerRenderer: () => h(Sortable, { sort: diskSort, field: 'project', onSort: setDiskSort }, ['Billing project']),
             cellRenderer: ({ rowIndex }) => {
               const disk = filteredDisks[rowIndex]
@@ -259,6 +269,7 @@ const Environments = () => {
           },
           {
             size: { basis: 120, grow: 0 },
+            field: 'size',
             headerRenderer: () => h(Sortable, { sort: diskSort, field: 'size', onSort: setDiskSort }, ['Size (GB)']),
             cellRenderer: ({ rowIndex }) => {
               const disk = filteredDisks[rowIndex]
@@ -267,6 +278,7 @@ const Environments = () => {
           },
           {
             size: { basis: 130, grow: 0 },
+            field: 'status',
             headerRenderer: () => h(Sortable, { sort: diskSort, field: 'status', onSort: setDiskSort }, ['Status']),
             cellRenderer: ({ rowIndex }) => {
               const disk = filteredDisks[rowIndex]
@@ -275,6 +287,7 @@ const Environments = () => {
           },
           {
             size: { basis: 240, grow: 0 },
+            field: 'created',
             headerRenderer: () => h(Sortable, { sort: diskSort, field: 'created', onSort: setDiskSort }, ['Created']),
             cellRenderer: ({ rowIndex }) => {
               return makeCompleteDate(filteredDisks[rowIndex].auditInfo.createdDate)
@@ -282,6 +295,7 @@ const Environments = () => {
           },
           {
             size: { basis: 240, grow: 0 },
+            field: 'accessed',
             headerRenderer: () => h(Sortable, { sort: diskSort, field: 'accessed', onSort: setDiskSort }, ['Last accessed']),
             cellRenderer: ({ rowIndex }) => {
               return makeCompleteDate(filteredDisks[rowIndex].auditInfo.dateAccessed)
@@ -289,6 +303,7 @@ const Environments = () => {
           },
           {
             size: { basis: 250, grow: 0 },
+            field: 'cost',
             headerRenderer: () => {
               return h(Sortable, { sort: diskSort, field: 'cost', onSort: setDiskSort }, [`Cost / month (${formatUSD(totalDiskCost)} total)`])
             },

--- a/src/pages/workflows/List.js
+++ b/src/pages/workflows/List.js
@@ -37,6 +37,7 @@ const WorkflowList = ({ queryParams: { tab, filter = '', ...query } }) => {
   }
 
   const tabName = tab || 'mine'
+  const tabs = { mine: 'My Workflows', public: 'Public Workflows', featured: 'Featured Workflows' }
 
   Utils.useOnMount(() => {
     const isMine = ({ public: isPublic, managers }) => !isPublic || _.includes(getUser().email, managers)
@@ -77,8 +78,8 @@ const WorkflowList = ({ queryParams: { tab, filter = '', ...query } }) => {
     ]),
     h(TabBar, {
       activeTab: tabName,
-      tabNames: ['mine', 'public', 'featured'],
-      displayNames: { mine: 'my workflows', public: 'public workflows', featured: 'featured workflows' },
+      tabNames: Object.keys(tabs),
+      displayNames: tabs,
       getHref: currentTab => `${Nav.getLink('workflows')}${getUpdatedQuery({ newTab: currentTab })}`,
       getOnClick: currentTab => e => {
         e.preventDefault()
@@ -89,10 +90,12 @@ const WorkflowList = ({ queryParams: { tab, filter = '', ...query } }) => {
       div({ style: { flex: 1 } }, [
         workflows && h(AutoSizer, [
           ({ width, height }) => h(FlexTable, {
-            width, height,
+            width, height, sort,
+            tableName: tabs[tabName],
             rowCount: sortedWorkflows.length,
             columns: [
               {
+                field: 'name',
                 headerRenderer: () => h(Sortable, { sort, field: 'name', onSort: setSort }, [h(HeaderCell, ['Workflow'])]),
                 cellRenderer: ({ rowIndex }) => {
                   const { namespace, name } = sortedWorkflows[rowIndex]
@@ -105,6 +108,7 @@ const WorkflowList = ({ queryParams: { tab, filter = '', ...query } }) => {
                 size: { basis: 300 }
               },
               {
+                field: 'synopsis',
                 headerRenderer: () => h(Sortable, { sort, field: 'synopsis', onSort: setSort }, [h(HeaderCell, ['Synopsis'])]),
                 cellRenderer: ({ rowIndex }) => {
                   const { synopsis } = sortedWorkflows[rowIndex]
@@ -114,6 +118,7 @@ const WorkflowList = ({ queryParams: { tab, filter = '', ...query } }) => {
                 size: { basis: 475 }
               },
               {
+                field: 'managers',
                 headerRenderer: () => h(Sortable, { sort, field: 'managers', onSort: setSort }, [h(HeaderCell, ['Owners'])]),
                 cellRenderer: ({ rowIndex }) => {
                   const { managers } = sortedWorkflows[rowIndex]
@@ -123,6 +128,7 @@ const WorkflowList = ({ queryParams: { tab, filter = '', ...query } }) => {
                 size: { basis: 225 }
               },
               {
+                field: 'numSnapshots',
                 headerRenderer: () => h(Sortable, { sort, field: 'numSnapshots', onSort: setSort }, [h(HeaderCell, ['Snapshots'])]),
                 cellRenderer: ({ rowIndex }) => {
                   const { numSnapshots } = sortedWorkflows[rowIndex]
@@ -132,6 +138,7 @@ const WorkflowList = ({ queryParams: { tab, filter = '', ...query } }) => {
                 size: { basis: 108, grow: 0, shrink: 0 }
               },
               {
+                field: 'numConfigurations',
                 headerRenderer: () => h(Sortable, { sort, field: 'numConfigurations', onSort: setSort }, [h(HeaderCell, ['Configurations'])]),
                 cellRenderer: ({ rowIndex }) => {
                   const { numConfigurations } = sortedWorkflows[rowIndex]

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -172,8 +172,10 @@ export const WorkspaceList = () => {
       ),
       variant: 'light',
       rowHeight: 70,
+      sort,
       columns: [
         {
+          field: 'name',
           headerRenderer: makeHeaderRenderer('name'),
           cellRenderer: ({ rowIndex }) => {
             const { accessLevel, workspace: { workspaceId, namespace, name, attributes: { description } } } = sortedWorkspaces[rowIndex]
@@ -199,6 +201,7 @@ export const WorkspaceList = () => {
           },
           size: { basis: 400, grow: 2, shrink: 0 }
         }, {
+          field: 'lastModified',
           headerRenderer: makeHeaderRenderer('lastModified'),
           cellRenderer: ({ rowIndex }) => {
             const { workspace: { lastModified } } = sortedWorkspaces[rowIndex]
@@ -211,6 +214,7 @@ export const WorkspaceList = () => {
           },
           size: { basis: 100, grow: 1, shrink: 0 }
         }, {
+          field: 'createdBy',
           headerRenderer: makeHeaderRenderer('createdBy'),
           cellRenderer: ({ rowIndex }) => {
             const { workspace: { createdBy } } = sortedWorkspaces[rowIndex]
@@ -221,6 +225,7 @@ export const WorkspaceList = () => {
           },
           size: { basis: 200, grow: 1, shrink: 0 }
         }, {
+          field: 'accessLevel',
           headerRenderer: makeHeaderRenderer('accessLevel'),
           cellRenderer: ({ rowIndex }) => {
             const { accessLevel } = sortedWorkspaces[rowIndex]

--- a/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
+++ b/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
@@ -183,12 +183,13 @@ const SubmissionDetails = _.flow(
       ]),
       div({ style: { flex: 1 } }, [
         h(AutoSizer, [({ width, height }) => h(FlexTable, {
-          width, height,
+          width, height, sort,
           rowCount: filteredWorkflows.length,
           noContentMessage: 'No matching workflows',
           columns: [
             {
               size: { basis: 225 },
+              field: 'workflowEntity',
               headerRenderer: () => h(Sortable, { sort, field: 'workflowEntity', onSort: setSort }, ['Data Entity']),
               cellRenderer: ({ rowIndex }) => {
                 const { workflowEntity: { entityName, entityType } = {} } = filteredWorkflows[rowIndex]
@@ -198,12 +199,14 @@ const SubmissionDetails = _.flow(
               }
             }, {
               size: { basis: 225, grow: 0 },
+              field: 'statusLastChangedDate',
               headerRenderer: () => h(Sortable, { sort, field: 'statusLastChangedDate', onSort: setSort }, ['Last Changed']),
               cellRenderer: ({ rowIndex }) => {
                 return h(TextCell, [Utils.makeCompleteDate(filteredWorkflows[rowIndex].statusLastChangedDate)])
               }
             }, {
               size: { basis: 150, grow: 0 },
+              field: 'status',
               headerRenderer: () => h(Sortable, { sort, field: 'status', onSort: setSort }, ['Status']),
               cellRenderer: ({ rowIndex }) => {
                 const { status } = filteredWorkflows[rowIndex]
@@ -211,6 +214,7 @@ const SubmissionDetails = _.flow(
               }
             }, {
               size: { basis: 125, grow: 0 },
+              field: 'cost',
               headerRenderer: () => h(Sortable, { sort, field: 'cost', onSort: setSort }, ['Run Cost']),
               cellRenderer: ({ rowIndex }) => {
                 // handle undefined workflow cost as $0
@@ -218,6 +222,7 @@ const SubmissionDetails = _.flow(
               }
             }, {
               size: _.some(({ messages }) => !_.isEmpty(messages), filteredWorkflows) ? { basis: 200 } : { basis: 100, grow: 0 },
+              field: 'messages',
               headerRenderer: () => h(Sortable, { sort, field: 'messages', onSort: setSort }, ['Messages']),
               cellRenderer: ({ rowIndex }) => {
                 const messages = _.join('\n', filteredWorkflows[rowIndex].messages)
@@ -227,6 +232,7 @@ const SubmissionDetails = _.flow(
               }
             }, {
               size: { basis: 150 },
+              field: 'workflowId',
               headerRenderer: () => h(Sortable, { sort, field: 'workflowId', onSort: setSort }, ['Workflow ID']),
               cellRenderer: ({ rowIndex }) => {
                 const { workflowId } = filteredWorkflows[rowIndex]

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -108,9 +108,11 @@ const WorkflowIOTable = ({ which, inputsOutputs: data, config, errors, onChange,
   return h(SimpleFlexTable, {
     rowCount: sortedData.length,
     noContentMessage: `No matching ${which}.`,
+    sort,
     columns: [
       {
         size: { basis: 350, grow: 0 },
+        field: 'taskVariable',
         headerRenderer: () => h(Sortable, { sort, field: 'taskVariable', onSort: setSort }, [h(HeaderCell, ['Task name'])]),
         cellRenderer: ({ rowIndex }) => {
           const io = sortedData[rowIndex]
@@ -121,6 +123,7 @@ const WorkflowIOTable = ({ which, inputsOutputs: data, config, errors, onChange,
       },
       {
         size: { basis: 360, grow: 0 },
+        field: 'workflowVariable',
         headerRenderer: () => h(Sortable, { sort, field: 'workflowVariable', onSort: setSort }, ['Variable']),
         cellRenderer: ({ rowIndex }) => {
           const io = sortedData[rowIndex]


### PR DESCRIPTION
This PR adds proper table rows to every type of table, to improve the accessibility of many pages within the app. This applies to the following table types:

* SimpleTable
* SimpleFlexTable
* FlexTable
* GridTable


## Summary of Changes

### Table Names

* Each of the 4 table types now supports an optional `tableName` property, which is converted to an `aria-label` on the root table element. If not specified, it will be "data table" by default.

### Table Roles

* Each table has `role="table"` at the top level. This role does not imply that the table supports keyboard navigation. If we go back later and add keyboard navigation in order to make it easier to scroll through the virtualized DOM, then at that point these should be switched to `role="grid"` to imply that [keyboard navigation is possible](https://www.digitala11y.com/grid-role/).
* The header row has `role="row"` and each header column has `role="columnheader"`.
* Each data row has `role="row"` and each data cell has `role="cell"`. If the top-level is changed to `role="grid"` in the future to support arrow-key navigation, then each cell should be changed to `role="gridcell"`.

### Virtualized Tables

In FlexTable and GridTable, not all cells will be included in the DOM. To support this:
* Each cell now includes `aria-rowindex` and `aria-colindex` attributes to indicate where in the table these cells are supposed to be.
* Each of the 3 main table types now also includes consistent `rowIndex` and `columnIndex` properties when calling its respective `cellRenderer` functions. I didn't change existing behavior, but added new optional properties that could be used by table definitions if they wish. These two properties should now be presented consistently regardless of which table type you're using.

### Sorting

Table definitions currently declare `Sortable` headers within the output of the `headerRenderer()` function for each column. However, to properly use the `aria-sort` ARIA attribute, the attribute must be placed directly on the element with `role="columnheader"`, which is several levels higher in the DOM. To support this:
* The `Sortable` and `MiniSortable` renderers now produce columns which are keyboard interactive, and provide an ARIA description indicating that the column will resort itself when clicking on it.
* Each sortable table must now be passed the `sort` state object.
* Each column which supports sorting must now specify the sorting field name, the same way it is defined in the `Sortable` renderer.

_Note:_ I don't like the duplication. It's problematic for a developer to have to add each field name in two places -- in the column definition and again in the `Sortable` definition -- and to keep them in sync. I'd prefer to try to recursively find a `Sortable` object in the `children` array and grab the 'sort' and `field` properties from there. But so far I've been trying to avoid that under the impression that it's bad practice to try to grab attributes from inside hyperscript children arrays. I certainly haven't seen this done anywhere else.

Is there a better way to do this without adding duplicate work for developers?

### Page-Specific updates

I've added duplicate field names to support `aria-sort` to:

* UploadPreviewTable.js (/#upload)
* Environment.js (/#clusters)
* List.js (/#workspaces/list)
* DataTable.js (/#workspaces/data)
* SubmissionDetails.js (/#workspaces/:workspace/jobHistory
* WorkflowView.js (/#workspaces/:workspace/workflows
* List.js (/#workflows/list)
