### PR TITLE
[CA-1306] A11y: Workflows pages

### DIFF
--- a/src/components/WDLViewer.js
+++ b/src/components/WDLViewer.js
@@ -75,6 +75,7 @@ const WDLViewer = ({ wdl, ...props }) => {
 
   return pre(_.merge(
     {
+      tabIndex: 0,
       className: 'line-numbers',
       style: { border: Style.standardLine, backgroundColor: 'white' }
     },

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -119,11 +119,15 @@ export const ButtonOutline = ({ disabled, children, ...props }) => {
 }
 
 export const TabBar = ({ activeTab, tabNames, displayNames = {}, refresh = _.noop, getHref, getOnClick = _.noop, children }) => {
-  const navTab = currentTab => {
+  const navTab = (i, currentTab) => {
     const selected = currentTab === activeTab
     const href = getHref(currentTab)
 
     return h(Clickable, {
+      role: 'tab',
+      'aria-posinset': i + 1,
+      'aria-setsize': tabNames.length,
+      'aria-selected': selected,
       style: { ...Style.tabBar.tab, ...(selected ? Style.tabBar.active : {}) },
       hover: selected ? {} : Style.tabBar.hover,
       onClick: href === window.location.hash ? refresh : getOnClick(currentTab),
@@ -133,8 +137,12 @@ export const TabBar = ({ activeTab, tabNames, displayNames = {}, refresh = _.noo
     ])
   }
 
-  return div({ role: 'navigation', 'aria-label': 'Tab bar', style: Style.tabBar.container }, [
-    ..._.map(name => navTab(name), tabNames),
+  return div({
+    role: 'tablist',
+    'aria-label': 'Tab bar',
+    style: Style.tabBar.container
+  }, [
+    ..._.map(([i, name]) => navTab(i, name), Utils.toIndexPairs(tabNames)),
     div({ style: { flexGrow: 1 } }),
     children
   ])

--- a/src/style.css
+++ b/src/style.css
@@ -127,3 +127,27 @@ a {
   animation: progress-bar-stripes 1s linear infinite;
 }
 
+/* Prism theme overrides to increase contrast for accessibility */
+.token.punctuation {
+  color: #767676 !important; /* #999; */
+}
+
+.token.selector,
+.token.attr-name,
+.token.string,
+.token.char,
+.token.builtin,
+.token.inserted {
+  color: #518400 !important; /* #690; */
+}
+
+.token.function,
+.token.class-name {
+  color: #d3405e !important; /* #DD4A68; */
+}
+
+.token.regex,
+.token.important,
+.token.variable {
+  color: #b56000 !important; /* #e90; */
+}


### PR DESCRIPTION
This PR addresses accessibility issues on workflows pages.

## Summary of changes

* Marked up the TabBar widget as role=tablist
* Adjusted Prism code editor theme colors to increase contrast to 4.5:1
* Added a label to the snapshot selector input
* Added a "main" landmark surrounding the Workflows page contents
* Converted dashboard headers to actual h2 tags

## Notes and Questions

How do users actually navigate to this set of pages? I don't see it in the main menu, and the Workflows tab in the Workspaces section appears to not go here directly.

I've changed the Prism theme colors directly in the style.css file with `!important` overrides. However, it appears that Prism is based on a theme system and ships with a number of built-in themes, so perhaps it's also possible to define a custom theme? Would that be a better solution than what I did here?

How would I see an example of the code editor not being readonly? In every one of the handful of workflows I looked at on the dev server, nothing seemed to be editable...