### PR TITLE
[CA-1303] A11y: Landing Page, Top Menu and Sign-In Button (#2419)

### DIFF
--- a/src/components/CookieWarning.js
+++ b/src/components/CookieWarning.js
@@ -34,10 +34,11 @@ const CookieWarning = () => {
     signOut()
   }
   return !cookiesAccepted && div({
+    role: 'banner',
     style: {
-      position: 'fixed', height: 100, bottom: 0, width: '100%',
+      flex: 0, height: 100, width: '100%',
       display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-      backgroundColor: 'white', borderTop: `6px solid ${colors.primary()}`
+      backgroundColor: colors.dark(0.15), borderBottom: `6px solid ${colors.primary()}`
     }
   }, [
     div({ style: { padding: '0.9rem 2rem', height: '100%', display: 'flex', alignItems: 'center' } }, [

--- a/src/components/SignInButton.js
+++ b/src/components/SignInButton.js
@@ -1,8 +1,9 @@
-import { div } from 'react-hyperscript-helpers'
+import { h } from 'react-hyperscript-helpers'
+import { Clickable } from 'src/components/common'
 import * as Utils from 'src/libs/utils'
 
 
-const SignInButton = () => {
+const SignInButton = (props = {}) => {
   Utils.useOnMount(() => {
     window.gapi.signin2.render('signInButton', {
       scope: 'openid profile email',
@@ -14,7 +15,20 @@ const SignInButton = () => {
     })
   })
 
-  return div({ id: 'signInButton' })
+  // For some reason, Google's rendered Sign-In button is not at all keyboard accessible.
+  // To fix this, we wrap it as a button, and propagate the keyboard-accessible click event down to
+  // the inner DOM node inside the button, then let it bubble up to whatever it is that catches it.
+  return h(Clickable, {
+    ...props,
+    id: 'signInButton',
+    onClick: event => {
+      const elts = event.target.getElementsByClassName('abcRioButtonContents') // This could potentially be unstable if Google changes their markup
+      if (elts.length > 0) {
+        elts.item(0).click()
+      }
+    },
+    style: { outlineOffset: 5 }
+  })
 }
 
 export default SignInButton

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -55,6 +55,10 @@ const styles = {
     }),
     icon: {
       marginRight: 12, flex: 'none'
+    },
+    navSection: {
+      flex: 'none', height: 70, padding: '0 28px', fontWeight: 600,
+      borderTop: `1px solid ${colors.dark(0.55)}`, color: 'white'
     }
   }
 }
@@ -67,29 +71,43 @@ const NavItem = ({ children, ...props }) => {
 }
 
 const NavSection = ({ children, ...props }) => {
-  return h(NavItem, _.merge({
-    style: {
-      flex: 'none', height: 70, padding: '0 28px', fontWeight: 600,
-      borderTop: `1px solid ${colors.dark(0.55)}`, color: 'white'
-    }
-  }, props), [children])
+  return div({
+    role: 'listitem'
+  }, [
+    h(NavItem, _.merge({
+      style: styles.nav.navSection
+    }, props), [children])
+  ])
 }
 
 const DropDownSubItem = ({ children, ...props }) => {
-  return h(NavItem, _.merge({
-    style: { padding: '0 3rem', height: 40, fontWeight: 500 }
-  }, props), [children])
+  return div({
+    role: 'listitem'
+  }, [
+    h(NavItem, _.merge({
+      style: { padding: '0 3rem', height: 40, fontWeight: 500 }
+    }, props), [children])
+  ])
 }
 
 const DropDownSection = ({ titleIcon, title, isOpened, onClick, children }) => {
-  return h(Fragment, [
-    h(NavSection, { onClick }, [
+  return div({
+    role: 'group'
+  }, [
+    h(NavItem, {
+      onClick,
+      'aria-expanded': isOpened,
+      'aria-haspopup': 'menu',
+      style: styles.nav.navSection
+    }, [
       titleIcon && icon(titleIcon, { size: 24, style: styles.nav.icon }),
       title,
       div({ style: { flexGrow: 1 } }),
       icon(isOpened ? 'angle-up' : 'angle-down', { size: 18, style: { flex: 'none' } })
     ]),
-    div({ style: { flex: 'none' } }, [h(RCollapse, { isOpened }, [children])])
+    div({
+      style: { flex: 'none' }
+    }, [h(RCollapse, { isOpened }, [children])])
   ])
 }
 
@@ -132,7 +150,10 @@ const TopBar = ({ showMenu = true, title, href, children }) => {
         style: styles.nav.container(transitionState),
         onClick: e => e.stopPropagation()
       }, [
-        div({ style: { display: 'flex', flexDirection: 'column', overflowY: 'auto', flex: 1 } }, [
+        div({
+          role: 'list',
+          style: { display: 'flex', flexDirection: 'column', overflowY: 'auto', flex: 1 }
+        }, [
           isSignedIn ?
             h(DropDownSection, {
               title: h(Fragment, [
@@ -162,7 +183,10 @@ const TopBar = ({ showMenu = true, title, href, children }) => {
                 onClick: signOut
               }, ['Sign Out'])
             ]) :
-            div({ style: { flex: 'none', display: 'flex', justifyContent: 'center', alignItems: 'center', height: 95 } }, [
+            div({
+              style: { flex: 'none', display: 'flex', justifyContent: 'center', alignItems: 'center', height: 95 },
+              role: 'listitem'
+            }, [
               isDatastage() || isBioDataCatalyst() ?
                 h(Clickable, {
                   href: Nav.getLink('workspaces'),
@@ -172,9 +196,7 @@ const TopBar = ({ showMenu = true, title, href, children }) => {
                     width: 250, height: 56, display: 'flex', alignItems: 'center', justifyContent: 'center'
                   }
                 }, ['SIGN IN']) :
-                div([
-                  h(SignInButton)
-                ])
+                h(SignInButton)
             ]),
           h(NavSection, {
             href: Nav.getLink('workspaces'),
@@ -327,11 +349,13 @@ const TopBar = ({ showMenu = true, title, href, children }) => {
     }, [
       showMenu ?
         h(Clickable, {
-          'aria-label': 'Toggle main menu',
           style: { alignSelf: 'stretch', display: 'flex', alignItems: 'center', padding: '0 1rem', margin: '2px 1rem 0 2px' },
-          onClick: () => navShown ? hideNav() : showNav()
+          onClick: () => navShown ? hideNav() : showNav(),
+          'aria-expanded': navShown
         }, [
           icon('bars', {
+            'aria-label': 'Toggle main menu',
+            'aria-hidden': false,
             size: 36,
             style: {
               color: isTerra() ? 'white' : colors.accent(), flex: 'none',

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -3,7 +3,7 @@ import _ from 'lodash/fp'
 import * as qs from 'qs'
 import { Fragment, useState } from 'react'
 import FocusLock from 'react-focus-lock'
-import { b, div, h, img, input, label, span } from 'react-hyperscript-helpers'
+import { b, div, h, h1, img, input, label, span } from 'react-hyperscript-helpers'
 import RSelect, { components as RSelectComponents } from 'react-select'
 import RAsyncCreatableSelect from 'react-select/async-creatable'
 import RSwitch from 'react-switch'
@@ -506,11 +506,12 @@ export const HeroWrapper = ({ showMenu = true, bigSubhead = false, children }) =
         flexGrow: 1,
         color: colors.dark(),
         padding: '3rem 5rem',
+        backgroundColor: '#fafbfd', // This not-quite-white fallback color was extracted from the background image
         backgroundImage: `url(${landingPageHero})`,
         backgroundRepeat: 'no-repeat', backgroundSize: '750px', backgroundPosition: 'right 0 top 0'
       }
     }, [
-      div({ style: { fontSize: 54 } }, `Welcome to ${getAppName()}`),
+      h1({ style: { fontSize: 54 } }, `Welcome to ${getAppName()}`),
       div({ style: { margin: '1rem 0', width: 575, ...(bigSubhead ? { fontSize: 20, lineHeight: '28px' } : { fontSize: 16, lineHeight: 1.5 }) } }, [
         `${getAppName(true)} is a ${Utils.cond(
           [isTerra(), () => 'cloud-native platform'],

--- a/src/libs/logos.js
+++ b/src/libs/logos.js
@@ -40,10 +40,10 @@ const pickBrandLogo = (color = false) => Utils.cond(
   [isBaseline(), () => color ? baselineLogo : baselineLogoWhite]
 )
 
-export const terraLogoMaker = (logoVariant, style) => img({ alt: 'Terra logo', role: 'img', src: logoVariant, style })
+export const terraLogoMaker = (logoVariant, style) => img({ alt: 'Terra', role: 'img', src: logoVariant, style })
 
 const brandLogoMaker = (size, color = false) => img({
-  alt: `${getAppName()} logo`, role: 'img',
+  alt: getAppName(), role: 'img',
   src: pickBrandLogo(color),
   style: { height: size, marginRight: '1.5rem' }
 })

--- a/src/libs/style.js
+++ b/src/libs/style.js
@@ -99,6 +99,7 @@ export const navList = {
 export const breadcrumb = {
   breadcrumb: {
     display: 'flex', flexDirection: 'column',
+    color: isTerra() ? 'white' : colors.accent(),
     paddingLeft: '4rem', minWidth: 0, marginRight: '0.5rem'
   },
   textUnderBreadcrumb: {

--- a/src/pages/LandingPage.js
+++ b/src/pages/LandingPage.js
@@ -43,7 +43,7 @@ const makeCard = (link, title, body) => h(Clickable, {
   style: { ...Style.elements.card.container, height: 245, width: 225, marginRight: '1rem', justifyContent: undefined },
   hover: { boxShadow: '0 3px 7px 0 rgba(0,0,0,0.5), 0 5px 3px 0 rgba(0,0,0,0.2)' }
 }, [
-  div({ style: { color: colors.accent(), fontSize: 18, fontWeight: 500, lineHeight: '22px', marginBottom: '0.5rem' } }, title),
+  h2({ style: { color: colors.accent(), fontSize: 18, fontWeight: 500, lineHeight: '22px', marginBottom: '0.5rem' } }, title),
   div({ style: { lineHeight: '22px' } }, body),
   div({ style: { flexGrow: 1 } }),
   makeRightArrowWithBackgroundIcon()
@@ -71,6 +71,7 @@ const LandingPage = () => {
     ]),
     isTerra() && div({
       style: {
+        backgroundColor: '#191a1c', // This fallback color was extracted from the left edge of the background image
         backgroundImage: `url(${covidHero})`, backgroundSize: 'cover', borderRadius: 5,
         boxShadow: '0 2px 5px 0 rgba(0,0,0,0.35), 0 3px 2px 0 rgba(0,0,0,0.12)',
         color: 'white', padding: '2rem 1rem',

--- a/src/pages/Main.js
+++ b/src/pages/Main.js
@@ -21,6 +21,7 @@ import { LocationProvider, Router, TitleManager } from 'src/libs/nav'
 
 const Main = () => {
   return h(LocationProvider, [
+    h(CookieWarning),
     h(ReactNotification),
     h(ImportStatus),
     h(ServiceAlerts),
@@ -35,8 +36,7 @@ const Main = () => {
     h(PageViewReporter),
     h(SupportRequest),
     h(NpsSurvey),
-    h(ConfigOverridesWarning),
-    h(CookieWarning)
+    h(ConfigOverridesWarning)
   ])
 }
 

--- a/src/pages/billing/List.js
+++ b/src/pages/billing/List.js
@@ -279,12 +279,8 @@ export const BillingList = ({ queryParams: { selectedName } }) => {
 
   return h(FooterWrapper, { fixedHeight: true }, [
     h(TopBar, { title: 'Billing' }, [
-      !!selectedName && div({
-        style: {
-          color: 'white', paddingLeft: '5rem', minWidth: 0, marginRight: '0.5rem'
-        }
-      }, [
-        div(breadcrumbs),
+      !!selectedName && div({ style: Style.breadcrumb.breadcrumb }, [
+        div({ style: Style.noWrapEllipsis }, breadcrumbs),
         div({ style: Style.breadcrumb.textUnderBreadcrumb }, [selectedName])
       ])
     ]),


### PR DESCRIPTION
This branch and PR was created because @andrewmarcus's fork could not run tests in his PR:  https://github.com/DataBiosphere/terra-ui/pull/2419

So I created this branch and PR so that the tests can run before merging into `dev`.

Note that PR #2419 is already approved, so this one should not require more approvals.

* A11y enhancements for main flow through landing page
* Fixed Google Sign-In button
* Moved cookie banner to the top
* Added list roles to the main menu
* Cleaned up Terra logo alt text for concision
* Added h1 and h2 to the landing page

* Cleaned up brand logo alt text to match Terra alt text

* Added a default background color matching the hero image, to see if it resolved the false-positive color contrast issues identified by aXe. It didn't, but it doesn't hurt anything either to have it in there.

* Added more background fallback colors on the landing page

* Resolved linting issues and PR comments

* Added comments indicating where "magic" background colors came from

* Updated the breadcrumbs on the Billing page to use the same global styles as other breadcrumbs such as on the Workspace pages. In particular, this ensures that the text color will contrast with the TopBar background for any skin

<!--
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Thanks!
--!>
