### PR TITLE
add sample tsv to data import modal

### DIFF
--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -17,6 +17,7 @@ import ReferenceData from 'src/data/reference-data'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { reportError } from 'src/libs/error'
+import Events from 'src/libs/events'
 import { FormLabel } from 'src/libs/forms'
 import { requesterPaysProjectStore } from 'src/libs/state'
 import * as StateHistory from 'src/libs/state-history'
@@ -212,6 +213,9 @@ export const EntityUploader = ({ onSuccess, onDismiss, namespace, name, entityTy
       const workspace = Ajax().Workspaces.workspace(namespace, name)
       await (useFireCloudDataModel ? workspace.importEntitiesFile : workspace.importFlexibleEntitiesFile)(file)
       onSuccess()
+      Ajax().Metrics.captureEvent(Events.workspaceDataUpload, {
+        workspaceNamespace: namespace, workspaceName: name
+      })
     } catch (error) {
       await reportError('Error uploading entities', error)
       onDismiss()
@@ -339,6 +343,28 @@ export const EntityUploader = ({ onSuccess, onDismiss, namespace, name, entityTy
             [isInvalid, () => 'Invalid format: Data does not start with entity or membership definition.'],
             [showInvalidEntryMethodWarning, () => 'Invalid Data Entry Method: Copy and paste only']
           )
+        ]),
+        div({ style: { borderTop: Style.standardLine, marginTop: '1rem' } }, [
+          div({ style: { marginTop: '1rem', fontWeight: 600 } }, ['TSV file templates']),
+          div({ style: { marginTop: '1rem' } }, [
+            icon('downloadRegular', { style: { size: 14, marginRight: '0.5rem' } }),
+            'Download ',
+            h(Link, {
+              href: 'https://storage.googleapis.com/terra-featured-workspaces/Table_templates/2-template_sample-table.tsv',
+              ...Utils.newTabLinkProps,
+              onClick: () => Ajax().Metrics.captureEvent(Events.workspaceSampleTsvDownload, {
+                workspaceNamespace: namespace, workspaceName: name
+              })
+            }, ['sample_template.tsv '])
+          ]),
+          div({ style: { marginTop: '1rem' } }, [
+            icon('pop-out', { style: { size: 14, marginRight: '0.5rem' } }),
+            'Terra Support: ',
+            h(Link, {
+              href: 'https://support.terra.bio/hc/en-us/articles/360059242671',
+              ...Utils.newTabLinkProps
+            }, [' Importing Data - Using a Template'])
+          ])
         ])
       ]),
       uploading && spinnerOverlay

--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -25,7 +25,9 @@ const eventsList = {
   workspaceClone: 'workspace:clone',
   workspaceCreate: 'workspace:create',
   workspaceDataDownload: 'workspace:data:download',
+  workspaceDataUpload: 'workspace:data:upload',
   workspaceDataImport: 'workspace:data:import',
+  workspaceSampleTsvDownload: 'workspace:sample-tsv:download',
   workspaceShare: 'workspace:share',
   workspaceSnapshotDelete: 'workspace:snapshot:delete',
   workspaceSnapshotContentsView: 'workspace:snapshot:contents:view'


### PR DESCRIPTION
Adds a downloadable sample TSV file and a link to a terra support page from the 'import table data' modal on the data page. 

Also adds mixpanel tracking for downloading the example TSV and for uploading data through the modal. 

Tested in the UI and verified events in mixpanel.
