### PR TITLE
Send Appcues events to Mixpanel [BT-222]

### DIFF
--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -7,6 +7,7 @@ import { cookiesAcceptedKey } from 'src/components/CookieWarning'
 import { Ajax, fetchOk } from 'src/libs/ajax'
 import { getConfig } from 'src/libs/config'
 import { withErrorReporting } from 'src/libs/error'
+import Events from 'src/libs/events'
 import { getAppName } from 'src/libs/logos'
 import * as Nav from 'src/libs/nav'
 import { clearNotification, notify, sessionTimeoutProps } from 'src/libs/notifications'
@@ -185,9 +186,55 @@ authStore.subscribe(withErrorReporting('Error checking TOS', async (state, oldSt
 
 authStore.subscribe(async (state, oldState) => {
   if (!oldState.acceptedTos && state.acceptedTos) {
-    window.Appcues && window.Appcues.identify(state.user.id, {
-      dateJoined: parseJSON((await Ajax().User.firstTimestamp()).timestamp).getTime()
-    })
+    if (window.Appcues) {
+      window.Appcues.identify(state.user.id, {
+        dateJoined: parseJSON((await Ajax().User.firstTimestamp()).timestamp).getTime()
+      })
+      window.Appcues.on('all', async (eventName, event) => {
+        // Only record "public-facing events" (and related properties) as documented by Appcues: https://docs.appcues.com/article/301-client-side-events-reference
+        const publicEvents = [
+          'flow_started',
+          'flow_completed',
+          'flow_skipped',
+          'flow_aborted',
+          'step_started',
+          'step_completed',
+          'step_skipped',
+          'step_aborted',
+          'step_interacted',
+          'form_submitted',
+          'form_field_submitted'
+        ]
+        if (_.includes(eventName, publicEvents)) {
+          console.log('Appcues', eventName, JSON.stringify(event), event)
+          const eventProps = {
+            'appcues.flowId': event.flowId,
+            'appcues.flowName': event.flowName,
+            'appcues.flowType': event.flowType,
+            'appcues.flowVersion': event.flowVersion,
+            'appcues.id': event.id,
+            'appcues.interaction.category': event.interaction?.category,
+            'appcues.interaction.destination': event.interaction?.destination,
+            'appcues.interaction.element': event.interaction?.element,
+            'appcues.interaction.fields': event.interaction?.fields ? JSON.stringify(event.interaction.fields) : undefined,
+            'appcues.interaction.formId': event.interaction?.formId,
+            'appcues.interaction.text': event.interaction?.text, // not documented by Appcues, but observed and useful
+            'appcues.interactionType': event.interactionType,
+            'appcues.localeId': event.localeId,
+            'appcues.localeName': event.localeName,
+            'appcues.name': event.name,
+            'appcues.sessionId': event.sessionId,
+            'appcues.stepChildId': event.stepChildId,
+            'appcues.stepChildNumber': event.stepChildNumber,
+            'appcues.stepId': event.stepId,
+            'appcues.stepNumber': event.stepNumber,
+            'appcues.stepType': event.stepType,
+            'appcues.timestamp': event.timestamp
+          }
+          await Ajax().Metrics.captureEvent(Events.appcuesEvent, eventProps)
+        }
+      })
+    }
   }
 })
 

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -7,7 +7,7 @@ import { cookiesAcceptedKey } from 'src/components/CookieWarning'
 import { Ajax, fetchOk } from 'src/libs/ajax'
 import { getConfig } from 'src/libs/config'
 import { withErrorReporting } from 'src/libs/error'
-import Events from 'src/libs/events'
+import { captureAppcuesEvent } from 'src/libs/events'
 import { getAppName } from 'src/libs/logos'
 import * as Nav from 'src/libs/nav'
 import { clearNotification, notify, sessionTimeoutProps } from 'src/libs/notifications'
@@ -190,50 +190,7 @@ authStore.subscribe(async (state, oldState) => {
       window.Appcues.identify(state.user.id, {
         dateJoined: parseJSON((await Ajax().User.firstTimestamp()).timestamp).getTime()
       })
-      window.Appcues.on('all', async (eventName, event) => {
-        // Only record "public-facing events" (and related properties) as documented by Appcues: https://docs.appcues.com/article/301-client-side-events-reference
-        const publicEvents = [
-          'flow_started',
-          'flow_completed',
-          'flow_skipped',
-          'flow_aborted',
-          'step_started',
-          'step_completed',
-          'step_skipped',
-          'step_aborted',
-          'step_interacted',
-          'form_submitted',
-          'form_field_submitted'
-        ]
-        if (_.includes(eventName, publicEvents)) {
-          console.log('Appcues', eventName, JSON.stringify(event), event)
-          const eventProps = {
-            'appcues.flowId': event.flowId,
-            'appcues.flowName': event.flowName,
-            'appcues.flowType': event.flowType,
-            'appcues.flowVersion': event.flowVersion,
-            'appcues.id': event.id,
-            'appcues.interaction.category': event.interaction?.category,
-            'appcues.interaction.destination': event.interaction?.destination,
-            'appcues.interaction.element': event.interaction?.element,
-            'appcues.interaction.fields': event.interaction?.fields ? JSON.stringify(event.interaction.fields) : undefined,
-            'appcues.interaction.formId': event.interaction?.formId,
-            'appcues.interaction.text': event.interaction?.text, // not documented by Appcues, but observed and useful
-            'appcues.interactionType': event.interactionType,
-            'appcues.localeId': event.localeId,
-            'appcues.localeName': event.localeName,
-            'appcues.name': event.name,
-            'appcues.sessionId': event.sessionId,
-            'appcues.stepChildId': event.stepChildId,
-            'appcues.stepChildNumber': event.stepChildNumber,
-            'appcues.stepId': event.stepId,
-            'appcues.stepNumber': event.stepNumber,
-            'appcues.stepType': event.stepType,
-            'appcues.timestamp': event.timestamp
-          }
-          await Ajax().Metrics.captureEvent(Events.appcuesEvent, eventProps)
-        }
-      })
+      window.Appcues.on('all', captureAppcuesEvent)
     }
   }
 })

--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -90,7 +90,7 @@ export const captureAppcuesEvent = (eventName, event) => {
       'appcues.interaction.category': event.interaction?.category,
       'appcues.interaction.destination': event.interaction?.destination,
       'appcues.interaction.element': event.interaction?.element,
-      'appcues.interaction.fields': event.interaction?.fields && JSON.stringify(event.interaction.fields),
+      'appcues.interaction.fields': JSON.stringify(event.interaction?.fields),
       'appcues.interaction.formId': event.interaction?.formId,
       'appcues.interaction.text': event.interaction?.text, // not documented by Appcues, but observed and useful
       'appcues.interactionType': event.interactionType,

--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -1,3 +1,4 @@
+import _ from 'lodash/fp'
 import { useEffect } from 'react'
 import { Ajax } from 'src/libs/ajax'
 import { useRoute } from 'src/libs/nav'
@@ -62,6 +63,50 @@ export const PageViewReporter = () => {
   }, [name, params])
 
   return null
+}
+
+export const captureAppcuesEvent = (eventName, event) => {
+  // Only record "public-facing events" (and related properties) as documented by Appcues: https://docs.appcues.com/article/301-client-side-events-reference
+  const publicEvents = [
+    'flow_started',
+    'flow_completed',
+    'flow_skipped',
+    'flow_aborted',
+    'step_started',
+    'step_completed',
+    'step_skipped',
+    'step_aborted',
+    'step_interacted',
+    'form_submitted',
+    'form_field_submitted'
+  ]
+  if (_.includes(eventName, publicEvents)) {
+    const eventProps = {
+      'appcues.flowId': event.flowId,
+      'appcues.flowName': event.flowName,
+      'appcues.flowType': event.flowType,
+      'appcues.flowVersion': event.flowVersion,
+      'appcues.id': event.id,
+      'appcues.interaction.category': event.interaction?.category,
+      'appcues.interaction.destination': event.interaction?.destination,
+      'appcues.interaction.element': event.interaction?.element,
+      'appcues.interaction.fields': event.interaction?.fields ? JSON.stringify(event.interaction.fields) : undefined,
+      'appcues.interaction.formId': event.interaction?.formId,
+      'appcues.interaction.text': event.interaction?.text, // not documented by Appcues, but observed and useful
+      'appcues.interactionType': event.interactionType,
+      'appcues.localeId': event.localeId,
+      'appcues.localeName': event.localeName,
+      'appcues.name': event.name,
+      'appcues.sessionId': event.sessionId,
+      'appcues.stepChildId': event.stepChildId,
+      'appcues.stepChildNumber': event.stepChildNumber,
+      'appcues.stepId': event.stepId,
+      'appcues.stepNumber': event.stepNumber,
+      'appcues.stepType': event.stepType,
+      'appcues.timestamp': event.timestamp
+    }
+    return Ajax().Metrics.captureEvent(eventsList.appcuesEvent, eventProps)
+  }
 }
 
 export default eventsList

--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -5,6 +5,7 @@ import { useRoute } from 'src/libs/nav'
 
 const eventsList = {
   aboutPersistentDiskView: 'about:persistentDisk:view',
+  appcuesEvent: 'appcues:event',
   applicationLaunch: 'application:launch',
   applicationCreate: 'application:create',
   applicationDelete: 'application:delete',

--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -90,7 +90,7 @@ export const captureAppcuesEvent = (eventName, event) => {
       'appcues.interaction.category': event.interaction?.category,
       'appcues.interaction.destination': event.interaction?.destination,
       'appcues.interaction.element': event.interaction?.element,
-      'appcues.interaction.fields': event.interaction?.fields ? JSON.stringify(event.interaction.fields) : undefined,
+      'appcues.interaction.fields': event.interaction?.fields && JSON.stringify(event.interaction.fields),
       'appcues.interaction.formId': event.interaction?.formId,
       'appcues.interaction.text': event.interaction?.text, // not documented by Appcues, but observed and useful
       'appcues.interactionType': event.interactionType,

--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -81,7 +81,7 @@ export const captureAppcuesEvent = (eventName, event) => {
     'form_field_submitted'
   ]
   if (_.includes(eventName, publicEvents)) {
-    const eventProps = {
+    const eventProps = { // Building the props manually to make sure we're resilient to any changes in Appcues
       'appcues.flowId': event.flowId,
       'appcues.flowName': event.flowName,
       'appcues.flowType': event.flowType,


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/BT-222

Tested with various Appcues flows, including http://localhost:3000/?appcue=-M2cUbHaOgXdP2P4kMJu and opening the "Support > Tutorials and Videos" menu.

Reviewed the resulting events in Mixpanel with Amelia. We experimented with building funnels and she is fairly confident that she will be able to get the data she is looking for. Following the release to production, I will update the lexicon in the Mixpanel prod environment and create several custom events for convenience.

Khalid & Miguel, I probably only need one of you along with Isaac. Let me know if you want a walk-through.