### PR TITLE
[CA-1312] Updated integration tests to properly identify tables

### DIFF
--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -28,7 +28,7 @@ const findIframe = async page => {
 }
 
 const findInGrid = (page, textContains, options) => {
-  return page.waitForXPath(`//*[@role="grid"][contains(normalize-space(.),"${textContains}")]`, options)
+  return page.waitForXPath(`//*[@role="table"][contains(normalize-space(.),"${textContains}")]`, options)
 }
 
 const clickable = ({ text, textContains }) => {
@@ -110,7 +110,7 @@ const navChild = text => {
 }
 
 const elementInDataTableRow = (entityName, text) => {
-  return `//*[@role="grid"]//*[contains(.,"${entityName}")]/following-sibling::*[contains(.,"${text}")]`
+  return `//*[@role="table"]//*[contains(.,"${entityName}")]/following-sibling::*[contains(.,"${text}")]`
 }
 
 const findInDataTableRow = (page, entityName, text) => {

--- a/src/components/Collapse.js
+++ b/src/components/Collapse.js
@@ -6,7 +6,7 @@ import { icon } from 'src/components/icons'
 import * as Style from 'src/libs/style'
 
 
-const Collapse = ({ title, buttonStyle, initialOpenState, children, titleFirst, afterToggle, onFirstOpen = () => {}, noTitleWrap, ...props }) => {
+const Collapse = ({ title, buttonStyle, buttonProps = {}, initialOpenState, children, titleFirst, afterToggle, onFirstOpen = () => {}, noTitleWrap, ...props }) => {
   const [isOpened, setIsOpened] = useState(initialOpenState)
   const angleIcon = icon(isOpened ? 'angle-down' : 'angle-right', { style: { marginRight: '0.25rem', flexShrink: 0 } })
 
@@ -23,7 +23,8 @@ const Collapse = ({ title, buttonStyle, initialOpenState, children, titleFirst, 
       h(Link, {
         'aria-expanded': isOpened,
         style: { display: 'flex', flex: 1, alignItems: 'center', marginBottom: '0.5rem', ...buttonStyle },
-        onClick: () => setIsOpened(!isOpened)
+        onClick: () => setIsOpened(!isOpened),
+        ...buttonProps
       }, [
         titleFirst && div({ style: { flexGrow: 1, ...(noTitleWrap ? Style.noWrapEllipsis : {}) } }, [title]),
         angleIcon,

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -52,7 +52,7 @@ const styles = {
   }
 }
 
-export const Clickable = ({ href, as = (!!href ? 'a' : 'div'), disabled, tooltip, tooltipSide, onClick, children, ...props }) => {
+export const Clickable = ({ href, as = (!!href ? 'a' : 'div'), disabled, tooltip, tooltipSide, tooltipDelay, onClick, children, ...props }) => {
   const child = h(Interactive, {
     'aria-disabled': !!disabled,
     as, disabled,
@@ -63,7 +63,7 @@ export const Clickable = ({ href, as = (!!href ? 'a' : 'div'), disabled, tooltip
   }, [children])
 
   if (tooltip) {
-    return h(TooltipTrigger, { content: tooltip, side: tooltipSide }, [child])
+    return h(TooltipTrigger, { content: tooltip, side: tooltipSide, delay: tooltipDelay }, [child])
   } else {
     return child
   }

--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -198,6 +198,7 @@ const DataTable = props => {
               onScroll,
               initialX,
               initialY,
+              sort,
               columns: [
                 {
                   width: 70,
@@ -206,7 +207,8 @@ const DataTable = props => {
                       h(Checkbox, {
                         checked: pageSelected(),
                         disabled: !entities.length,
-                        onChange: () => pageSelected() ? deselectPage() : selectPage()
+                        onChange: () => pageSelected() ? deselectPage() : selectPage(),
+                        'aria-label': 'Select all'
                       }),
                       h(PopupTrigger, {
                         closeOnClick: true,
@@ -233,6 +235,7 @@ const DataTable = props => {
                   }
                 },
                 {
+                  field: 'name',
                   width: nameWidth,
                   headerRenderer: () => h(Resizable, {
                     width: nameWidth, onWidthChange: delta => {
@@ -259,6 +262,7 @@ const DataTable = props => {
                   const thisWidth = columnWidths[name] || 300
                   const [, columnNamespace, columnName] = /(.+:)?(.+)/.exec(name)
                   return {
+                    field: name,
                     width: thisWidth,
                     headerRenderer: () => h(Resizable, {
                       width: thisWidth, onWidthChange: delta => setColumnWidths(_.set(name, thisWidth + delta))

--- a/src/components/data/UploadPreviewTable.js
+++ b/src/components/data/UploadPreviewTable.js
@@ -210,11 +210,12 @@ const UploadDataTable = props => {
               width, height,
               rowCount: sortedRows.length,
               noContentMessage: `No ${entityType}s to display.`,
-              onScroll: saveScroll, initialX, initialY,
+              onScroll: saveScroll, initialX, initialY, sort,
               columns: [
                 ..._.map(name => {
                   const thisWidth = columnWidths[name] || 300
                   return {
+                    field: name,
                     width: thisWidth,
                     headerRenderer: ({ columnIndex }) => h(Resizable, {
                       width: thisWidth, onWidthChange: delta => setColumnWidths(_.set(name, thisWidth + delta))

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -17,6 +17,7 @@ import ReferenceData from 'src/data/reference-data'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { reportError } from 'src/libs/error'
+import Events from 'src/libs/events'
 import { FormLabel } from 'src/libs/forms'
 import { requesterPaysProjectStore } from 'src/libs/state'
 import * as StateHistory from 'src/libs/state-history'
@@ -212,6 +213,9 @@ export const EntityUploader = ({ onSuccess, onDismiss, namespace, name, entityTy
       const workspace = Ajax().Workspaces.workspace(namespace, name)
       await (useFireCloudDataModel ? workspace.importEntitiesFile : workspace.importFlexibleEntitiesFile)(file)
       onSuccess()
+      Ajax().Metrics.captureEvent(Events.workspaceDataUpload, {
+        workspaceNamespace: namespace, workspaceName: name
+      })
     } catch (error) {
       await reportError('Error uploading entities', error)
       onDismiss()
@@ -339,6 +343,28 @@ export const EntityUploader = ({ onSuccess, onDismiss, namespace, name, entityTy
             [isInvalid, () => 'Invalid format: Data does not start with entity or membership definition.'],
             [showInvalidEntryMethodWarning, () => 'Invalid Data Entry Method: Copy and paste only']
           )
+        ]),
+        div({ style: { borderTop: Style.standardLine, marginTop: '1rem' } }, [
+          div({ style: { marginTop: '1rem', fontWeight: 600 } }, ['TSV file templates']),
+          div({ style: { marginTop: '1rem' } }, [
+            icon('downloadRegular', { style: { size: 14, marginRight: '0.5rem' } }),
+            'Download ',
+            h(Link, {
+              href: 'https://storage.googleapis.com/terra-featured-workspaces/Table_templates/2-template_sample-table.tsv',
+              ...Utils.newTabLinkProps,
+              onClick: () => Ajax().Metrics.captureEvent(Events.workspaceSampleTsvDownload, {
+                workspaceNamespace: namespace, workspaceName: name
+              })
+            }, ['sample_template.tsv '])
+          ]),
+          div({ style: { marginTop: '1rem' } }, [
+            icon('pop-out', { style: { size: 14, marginRight: '0.5rem' } }),
+            'Terra Support: ',
+            h(Link, {
+              href: 'https://support.terra.bio/hc/en-us/articles/360059242671',
+              ...Utils.newTabLinkProps
+            }, [' Importing Data - Using a Template'])
+          ])
         ])
       ]),
       uploading && spinnerOverlay

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -267,12 +267,18 @@ FlexTable.propTypes = {
  * since it does not provide scrolling. See FlexTable for prop types.
  */
 export const SimpleFlexTable = ({ columns, rowCount, noContentMessage, hoverHighlight }) => {
-  return h(Fragment, [
-    div({ style: { height: 48, display: 'flex' } }, [
+  return div({
+    role: 'grid',
+  }, [
+    div({
+      style: { height: 48, display: 'flex' },
+      role: 'row'
+    }, [
       _.map(([i, { size, headerRenderer }]) => {
         return div({
           key: i,
-          style: { ...styles.flexCell(size), ...styles.header(i * 1, columns.length) }
+          style: { ...styles.flexCell(size), ...styles.header(i * 1, columns.length) },
+          role: 'columnheader'
         }, [headerRenderer()])
       }, Utils.toIndexPairs(columns))
     ]),
@@ -281,6 +287,7 @@ export const SimpleFlexTable = ({ columns, rowCount, noContentMessage, hoverHigh
         key: rowIndex,
         as: 'div',
         className: 'table-row',
+        role: 'row',
         style: { backgroundColor: 'white', display: 'flex', minHeight: 48 },
         hover: hoverHighlight ? { backgroundColor: colors.light(0.4) } : undefined
       }, [
@@ -288,6 +295,7 @@ export const SimpleFlexTable = ({ columns, rowCount, noContentMessage, hoverHigh
           return div({
             key: i,
             className: 'table-cell',
+            role: 'gridcell',
             style: { ...styles.flexCell(size), ...styles.cell(i * 1, columns.length) }
           }, [cellRenderer({ rowIndex })])
         }, Utils.toIndexPairs(columns))
@@ -335,7 +343,11 @@ export const GridTable = Utils.forwardRefWithName('GridTable', ({
     ref: scrollSync
   }, [
     ({ onScroll, scrollLeft }) => {
-      return div([
+      return div({
+        role: 'grid',
+        'aria-rowcount': rowCount + 1, // count the header row too
+        'aria-colcount': columns.length
+      }, [
         h(RVGrid, {
           ref: header,
           width: width - scrollbarSize,
@@ -344,6 +356,9 @@ export const GridTable = Utils.forwardRefWithName('GridTable', ({
           rowHeight: headerHeight,
           rowCount: 1,
           columnCount: columns.length,
+          role: 'rowgroup',
+          containerRole: 'row',
+          'aria-label': '',
           cellRenderer: data => {
             return div({
               key: data.key,
@@ -352,7 +367,10 @@ export const GridTable = Utils.forwardRefWithName('GridTable', ({
                 ...data.style,
                 ...styles.header(data.columnIndex, columns.length),
                 ...styleHeader(data)
-              }
+              },
+              role: 'columnheader',
+              'aria-colindex': data.columnIndex,
+              'aria-rowindex': 1, // the rowindex property must start at 1
             }, [
               columns[data.columnIndex].headerRenderer(data)
             ])
@@ -369,6 +387,9 @@ export const GridTable = Utils.forwardRefWithName('GridTable', ({
           rowHeight,
           rowCount,
           columnCount: columns.length,
+          role: 'rowgroup',
+          containerRole: 'presentation',
+          'aria-label': '',
           noContentRenderer: () => div({ style: { marginTop: '1rem', textAlign: 'center', fontStyle: 'italic' } }, [noContentMessage]),
           onScrollbarPresenceChange: ({ vertical, size }) => {
             setScrollbarSize(vertical ? size : 0)
@@ -377,6 +398,9 @@ export const GridTable = Utils.forwardRefWithName('GridTable', ({
             return div({
               key: data.key,
               className: 'table-cell',
+              role: 'gridcell',
+              'aria-colindex': data.columnIndex,
+              'aria-rowindex': data.rowIndex + 2, // The header row is 1
               style: {
                 ...data.style,
                 ...styles.cell(data.columnIndex, columns.length),

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -499,10 +499,11 @@ GridTable.propTypes = {
   })
 }
 
-export const SimpleTable = ({ columns, rows }) => {
+export const SimpleTable = ({ columns, rows, tableName = 'data table' }) => {
   const cellStyles = { paddingTop: '0.25rem', paddingBottom: '0.25rem' }
   return h(div, {
-    role: 'table'
+    role: 'table',
+    'aria-label': tableName
   }, [
     div({ style: { display: 'flex' } }, [
       _.map(({ key, header, size }) => {

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -239,7 +239,7 @@ export const FlexTable = ({
               style: {
                 ...styles.flexCell(size),
                 ...(variant === 'light' ? {} : styles.cell(i * 1, columns.length)),
-                ...(styleCell ? styleCell({ ...data, columnIndex: i, rowIndex: data.rowIndex + 1 }) : {})
+                ...(styleCell ? styleCell({ ...data, columnIndex: i, rowIndex: data.rowIndex }) : {})
               }
             }, [cellRenderer({ ...data, columnIndex: i, rowIndex: data.rowIndex })])
           }, Utils.toIndexPairs(columns))

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -261,6 +261,7 @@ FlexTable.propTypes = {
   variant: PropTypes.oneOf(['light']),
   noContentMessage: PropTypes.node,
   columns: PropTypes.arrayOf(PropTypes.shape({
+    field: PropTypes.string,
     headerRenderer: PropTypes.func.isRequired,
     cellRenderer: PropTypes.func.isRequired,
     size: PropTypes.shape({
@@ -278,7 +279,10 @@ FlexTable.propTypes = {
   styleHeader: PropTypes.func,
   styleCell: PropTypes.func,
   tableName: PropTypes.string,
-  sort: PropTypes.shape({ field: PropTypes.string, direction: PropTypes.string })
+  sort: PropTypes.shape({
+    field: PropTypes.string,
+    direction: PropTypes.string
+  })
 }
 
 /**
@@ -332,7 +336,8 @@ export const SimpleFlexTable = ({ columns, rowCount, noContentMessage, hoverHigh
  */
 export const GridTable = Utils.forwardRefWithName('GridTable', ({
   width, height, initialX = 0, initialY = 0, rowHeight = 48, headerHeight = 48, noContentMessage,
-  rowCount, columns, styleCell = () => ({}), styleHeader = () => ({}), onScroll: customOnScroll = _.noop, tableName = 'data table'
+  rowCount, columns, styleCell = () => ({}), styleHeader = () => ({}), onScroll: customOnScroll = _.noop,
+  tableName = 'data table', sort = null
 }, ref) => {
   const [scrollbarSize, setScrollbarSize] = useState(0)
   const header = useRef()
@@ -365,7 +370,7 @@ export const GridTable = Utils.forwardRefWithName('GridTable', ({
   }, [
     ({ onScroll, scrollLeft }) => {
       return div({
-        role: 'grid',
+        role: 'table',
         'aria-rowcount': rowCount + 1, // count the header row too
         'aria-colcount': columns.length,
         'aria-label': tableName
@@ -383,12 +388,14 @@ export const GridTable = Utils.forwardRefWithName('GridTable', ({
           'aria-readonly': null, // Clear out ARIA properties which have been moved one level up
           'aria-label': `${tableName} header row`, // The whole table is a tab stop so it needs a label
           cellRenderer: data => {
+            const field = columns[data.columnIndex].field
             return div({
               key: data.key,
               className: 'table-cell',
               role: 'columnheader',
-              'aria-colindex': data.columnIndex,
-              'aria-rowindex': 1, // the rowindex property must start at 1
+              'aria-colindex': data.columnIndex + 1,
+              'aria-rowindex': 1, // the rowindex property must start at 1,
+              'aria-sort': !sort || !field ? null : sort.field === field ? sort.direction === 'asc' ? 'ascending' : 'descending' : 'none',
               style: {
                 ...data.style,
                 ...styles.header(data.columnIndex, columns.length),
@@ -411,7 +418,7 @@ export const GridTable = Utils.forwardRefWithName('GridTable', ({
           rowCount,
           columnCount: columns.length,
           role: 'rowgroup',
-          containerRole: 'presentation',
+          containerRole: 'row',
           'aria-readonly': null, // Clear out ARIA properties which have been moved one level up
           'aria-label': `${tableName} content`, // The whole table is a tab stop so it needs a label
           noContentRenderer: () => div({ style: { marginTop: '1rem', textAlign: 'center', fontStyle: 'italic' } }, [noContentMessage]),
@@ -422,8 +429,8 @@ export const GridTable = Utils.forwardRefWithName('GridTable', ({
             return div({
               key: data.key,
               className: 'table-cell',
-              role: 'gridcell',
-              'aria-colindex': data.columnIndex,
+              role: 'cell',
+              'aria-colindex': data.columnIndex + 1,
               'aria-rowindex': data.rowIndex + 2, // The header row is 1
               style: {
                 ...data.style,
@@ -456,12 +463,20 @@ GridTable.propTypes = {
   rowCount: PropTypes.number.isRequired,
   styleHeader: PropTypes.func,
   styleCell: PropTypes.func,
-  columns: PropTypes.arrayOf(PropTypes.shape({ width: PropTypes.number.isRequired })),
+  columns: PropTypes.arrayOf(PropTypes.shape({
+    field: PropTypes.string,
+    width: PropTypes.number.isRequired,
+    headerRenderer: PropTypes.func.isRequired,
+    cellRenderer: PropTypes.func.isRequired
+  })),
   onScroll: PropTypes.func,
   headerHeight: PropTypes.number,
   rowHeight: PropTypes.number,
   tableName: PropTypes.string,
-  sort: PropTypes.shape({ field: PropTypes.string, direction: PropTypes.string })
+  sort: PropTypes.shape({
+    field: PropTypes.string,
+    direction: PropTypes.string
+  })
 }
 
 export const SimpleTable = ({ columns, rows }) => {
@@ -524,10 +539,7 @@ export const Sortable = ({ sort, field, onSort, columnIndex, children }) => {
     sort.field === field && div({
       style: { color: colors.accent(), marginLeft: 'auto' }
     }, [
-      icon(sort.direction === 'asc' ? 'long-arrow-alt-down' : 'long-arrow-alt-up', {
-        'aria-hidden': false,
-        'aria-label': `sorted in ${sort.direction === 'asc' ? 'ascending' : 'descending'} order`
-      })
+      icon(sort.direction === 'asc' ? 'long-arrow-alt-down' : 'long-arrow-alt-up')
     ]),
     div({ id, style: { display: 'none' } }, ['Click to sort by this column'])
   ])])
@@ -543,10 +555,7 @@ export const MiniSortable = ({ sort, field, onSort, columnIndex, children }) => 
     sort.field === field && div({
       style: { color: colors.accent(), marginLeft: '1rem' }
     }, [
-      icon(sort.direction === 'asc' ? 'long-arrow-alt-down' : 'long-arrow-alt-up', {
-        'aria-hidden': false,
-        'aria-label': `sorted in ${sort.direction ? 'descending' : 'ascending'} order`
-      })
+      icon(sort.direction === 'asc' ? 'long-arrow-alt-down' : 'long-arrow-alt-up')
     ]),
     div({ id, style: { display: 'none' } }, ['Click to sort by this column'])
   ])])

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -375,14 +375,14 @@ export const GridTable = Utils.forwardRefWithName('GridTable', ({
             return div({
               key: data.key,
               className: 'table-cell',
+              role: 'columnheader',
+              'aria-colindex': data.columnIndex,
+              'aria-rowindex': 1, // the rowindex property must start at 1
               style: {
                 ...data.style,
                 ...styles.header(data.columnIndex, columns.length),
                 ...styleHeader(data)
-              },
-              role: 'columnheader',
-              'aria-colindex': data.columnIndex,
-              'aria-rowindex': 1, // the rowindex property must start at 1
+              }
             }, [
               columns[data.columnIndex].headerRenderer(data)
             ])
@@ -493,7 +493,7 @@ export const HeaderCell = props => {
 }
 
 export const Sortable = ({ sort, field, onSort, children }) => {
-  return h(IdContainer, [id => h(Clickable,{
+  return h(IdContainer, [id => h(Clickable, {
     style: { flex: 1, display: 'flex', alignItems: 'center', cursor: 'pointer', width: '100%', height: '100%' },
     onClick: () => onSort(Utils.nextSort(sort, field)),
     'aria-describedby': id
@@ -512,7 +512,7 @@ export const Sortable = ({ sort, field, onSort, children }) => {
 }
 
 export const MiniSortable = ({ sort, field, onSort, children }) => {
-  return h(IdContainer, [id => h(Clickable,{
+  return h(IdContainer, [id => h(Clickable, {
     style: { display: 'flex', alignItems: 'center', cursor: 'pointer', height: '100%' },
     onClick: () => onSort(Utils.nextSort(sort, field)),
     'aria-describedby': id

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -161,6 +161,9 @@ const styles = {
 // Note: We always need 1 extra row's worth of height for the table header row:
 export const tableHeight = ({ actualRows, maxRows, heightPerRow = 48 }) => (_.min([actualRows, maxRows]) + 1) * heightPerRow
 
+const ariaSort = (sort, field) => !sort || !field ? null :
+  sort.field !== field ? 'none' : sort.direction === 'asc' ? 'ascending' : 'descending'
+
 /**
  * A virtual table with a fixed header and flexible column widths. Intended to take up the full
  * available container width, without horizontal scrolling.
@@ -180,7 +183,7 @@ export const FlexTable = ({
 
   return div({
     role: 'table',
-    'aria-rowcount': rowCount,
+    'aria-rowcount': rowCount + 1, // count the header row too
     'aria-colcount': columns.length,
     'aria-label': tableName
   }, [
@@ -197,7 +200,7 @@ export const FlexTable = ({
         role: 'columnheader',
         'aria-rowindex': 1,
         'aria-colindex': i + 1,
-        'aria-sort': !sort || !field ? null : sort.field === field ? sort.direction === 'asc' ? 'ascending' : 'descending' : 'none',
+        'aria-sort': ariaSort(sort, field),
         style: {
           ...styles.flexCell(size),
           ...(variant === 'light' ? {} : styles.header(i * 1, columns.length)),
@@ -303,7 +306,7 @@ export const SimpleFlexTable = ({ columns, rowCount, noContentMessage, hoverHigh
           key: i,
           style: { ...styles.flexCell(size), ...styles.header(i * 1, columns.length) },
           role: 'columnheader',
-          'aria-sort': !sort || !field ? null : sort.field === field ? sort.direction === 'asc' ? 'ascending' : 'descending' : 'none'
+          'aria-sort': ariaSort(sort, field)
         }, [headerRenderer({ columnIndex: i })])
       }, Utils.toIndexPairs(columns))
     ]),
@@ -395,7 +398,7 @@ export const GridTable = Utils.forwardRefWithName('GridTable', ({
               role: 'columnheader',
               'aria-colindex': data.columnIndex + 1,
               'aria-rowindex': 1, // the rowindex property must start at 1,
-              'aria-sort': !sort || !field ? null : sort.field === field ? sort.direction === 'asc' ? 'ascending' : 'descending' : 'none',
+              'aria-sort': ariaSort(sort, field),
               style: {
                 ...data.style,
                 ...styles.header(data.columnIndex, columns.length),

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -183,18 +183,24 @@ export const FlexTable = ({
         width: width - scrollbarSize,
         height: headerHeight,
         display: 'flex'
-      }
+      },
+      role: 'grid',
+      'aria-rowcount': rowCount,
+      'aria-colcount': columns.length
     }, [
-      ..._.map(([i, { size, headerRenderer }]) => {
+      div({
+        role: 'row'
+      }, ..._.map(([i, { size, headerRenderer }]) => {
         return div({
           key: i,
+          role: 'columnheader',
           style: {
             ...styles.flexCell(size),
             ...(variant === 'light' ? {} : styles.header(i * 1, columns.length)),
             ...(styleHeader ? styleHeader({ columnIndex: i }) : {})
           }
         }, [headerRenderer()])
-      }, _.toPairs(columns))
+      }, _.toPairs(columns)))
     ]),
     h(RVGrid, {
       ref: body,
@@ -212,6 +218,7 @@ export const FlexTable = ({
           key: data.key,
           as: 'div',
           className: 'table-row',
+          role: 'row',
           style: { ...data.style, backgroundColor: 'white', display: 'flex' },
           hover: hoverHighlight ? { backgroundColor: colors.light(0.4) } : undefined
         }, [
@@ -219,6 +226,9 @@ export const FlexTable = ({
             return div({
               key: i,
               className: 'table-cell',
+              role: 'gridcell',
+              'aria-rowindex': data.rowIndex,
+              'aria-colindex': i,
               style: {
                 ...styles.flexCell(size),
                 ...(variant === 'light' ? {} : styles.cell(i * 1, columns.length)),
@@ -268,7 +278,7 @@ FlexTable.propTypes = {
  */
 export const SimpleFlexTable = ({ columns, rowCount, noContentMessage, hoverHighlight }) => {
   return div({
-    role: 'grid',
+    role: 'grid'
   }, [
     div({
       style: { height: 48, display: 'flex' },

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -550,10 +550,10 @@ export const HeaderCell = props => {
   return h(TextCell, _.merge({ style: { fontWeight: 500 } }, props))
 }
 
-export const Sortable = ({ sort, field, onSort, columnIndex, children }) => {
+export const Sortable = ({ sort, field, onSort, children }) => {
   return h(IdContainer, [id => h(Clickable, {
     style: { flex: 1, display: 'flex', alignItems: 'center', cursor: 'pointer', width: '100%', height: '100%' },
-    onClick: () => onSort(Utils.nextSort(sort, field, columnIndex)),
+    onClick: () => onSort(Utils.nextSort(sort, field)),
     'aria-describedby': id
   }, [
     children,
@@ -566,10 +566,10 @@ export const Sortable = ({ sort, field, onSort, columnIndex, children }) => {
   ])])
 }
 
-export const MiniSortable = ({ sort, field, onSort, columnIndex, children }) => {
+export const MiniSortable = ({ sort, field, onSort, children }) => {
   return h(IdContainer, [id => h(Clickable, {
     style: { display: 'flex', alignItems: 'center', cursor: 'pointer', height: '100%' },
-    onClick: () => onSort(Utils.nextSort(sort, field, columnIndex)),
+    onClick: () => onSort(Utils.nextSort(sort, field)),
     'aria-describedby': id
   }, [
     children,

--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -25,7 +25,9 @@ const eventsList = {
   workspaceClone: 'workspace:clone',
   workspaceCreate: 'workspace:create',
   workspaceDataDownload: 'workspace:data:download',
+  workspaceDataUpload: 'workspace:data:upload',
   workspaceDataImport: 'workspace:data:import',
+  workspaceSampleTsvDownload: 'workspace:sample-tsv:download',
   workspaceShare: 'workspace:share',
   workspaceSnapshotDelete: 'workspace:snapshot:delete',
   workspaceSnapshotContentsView: 'workspace:snapshot:contents:view'

--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -27,6 +27,7 @@ const eventsList = {
   workspaceDataDownload: 'workspace:data:download',
   workspaceDataUpload: 'workspace:data:upload',
   workspaceDataImport: 'workspace:data:import',
+  workspaceOpenFromList: 'workspace:open-from-list',
   workspaceSampleTsvDownload: 'workspace:sample-tsv:download',
   workspaceShare: 'workspace:share',
   workspaceSnapshotDelete: 'workspace:snapshot:delete',
@@ -48,11 +49,16 @@ export const extractCrossWorkspaceDetails = (fromWorkspace, toWorkspace) => {
 }
 
 export const PageViewReporter = () => {
-  const { name } = useRoute()
+  const { name, params } = useRoute()
 
   useEffect(() => {
-    Ajax().Metrics.captureEvent(`${eventsList.pageView}:${name}`)
-  }, [name])
+    const isWorkspace = /^#workspaces\/.+\/.+/.test(window.location.hash)
+
+    Ajax().Metrics.captureEvent(
+      `${eventsList.pageView}:${name}`,
+      isWorkspace ? extractWorkspaceDetails(params) : undefined
+    )
+  }, [name, params])
 
   return null
 }

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -143,9 +143,12 @@ const Environments = () => {
     div({ role: 'main', style: { padding: '1rem', flexGrow: 1 } }, [
       div({ style: { ...Style.elements.sectionHeader, textTransform: 'uppercase', marginBottom: '1rem' } }, ['Your cloud environments']),
       runtimes && h(SimpleFlexTable, {
+        sort,
+        tableName: 'cloud environments',
         rowCount: filteredRuntimes.length,
         columns: [
           {
+            field: 'project',
             headerRenderer: () => h(Sortable, { sort, field: 'project', onSort: setSort }, ['Billing project']),
             cellRenderer: ({ rowIndex }) => {
               const runtime = filteredRuntimes[rowIndex]
@@ -175,6 +178,7 @@ const Environments = () => {
           },
           {
             size: { basis: 150, grow: 0 },
+            field: 'status',
             headerRenderer: () => h(Sortable, { sort, field: 'status', onSort: setSort }, ['Status']),
             cellRenderer: ({ rowIndex }) => {
               const runtime = filteredRuntimes[rowIndex]
@@ -190,6 +194,7 @@ const Environments = () => {
           },
           {
             size: { basis: 250, grow: 0 },
+            field: 'created',
             headerRenderer: () => h(Sortable, { sort, field: 'created', onSort: setSort }, ['Created']),
             cellRenderer: ({ rowIndex }) => {
               return makeCompleteDate(filteredRuntimes[rowIndex].auditInfo.createdDate)
@@ -197,6 +202,7 @@ const Environments = () => {
           },
           {
             size: { basis: 250, grow: 0 },
+            field: 'accessed',
             headerRenderer: () => h(Sortable, { sort, field: 'accessed', onSort: setSort }, ['Last accessed']),
             cellRenderer: ({ rowIndex }) => {
               return makeCompleteDate(filteredRuntimes[rowIndex].auditInfo.dateAccessed)
@@ -204,6 +210,7 @@ const Environments = () => {
           },
           {
             size: { basis: 240, grow: 0 },
+            field: 'cost',
             headerRenderer: () => {
               return h(Sortable, { sort, field: 'cost', onSort: setSort }, [`Cost / hr (${formatUSD(totalCost)} total)`])
             },
@@ -228,9 +235,12 @@ const Environments = () => {
       }),
       div({ style: { ...Style.elements.sectionHeader, textTransform: 'uppercase', margin: '1rem 0' } }, ['Your persistent disks']),
       disks && h(SimpleFlexTable, {
+        sort: diskSort,
+        tableName: 'persistent disks',
         rowCount: filteredDisks.length,
         columns: [
           {
+            field: 'project',
             headerRenderer: () => h(Sortable, { sort: diskSort, field: 'project', onSort: setDiskSort }, ['Billing project']),
             cellRenderer: ({ rowIndex }) => {
               const disk = filteredDisks[rowIndex]
@@ -259,6 +269,7 @@ const Environments = () => {
           },
           {
             size: { basis: 120, grow: 0 },
+            field: 'size',
             headerRenderer: () => h(Sortable, { sort: diskSort, field: 'size', onSort: setDiskSort }, ['Size (GB)']),
             cellRenderer: ({ rowIndex }) => {
               const disk = filteredDisks[rowIndex]
@@ -267,6 +278,7 @@ const Environments = () => {
           },
           {
             size: { basis: 130, grow: 0 },
+            field: 'status',
             headerRenderer: () => h(Sortable, { sort: diskSort, field: 'status', onSort: setDiskSort }, ['Status']),
             cellRenderer: ({ rowIndex }) => {
               const disk = filteredDisks[rowIndex]
@@ -275,6 +287,7 @@ const Environments = () => {
           },
           {
             size: { basis: 240, grow: 0 },
+            field: 'created',
             headerRenderer: () => h(Sortable, { sort: diskSort, field: 'created', onSort: setDiskSort }, ['Created']),
             cellRenderer: ({ rowIndex }) => {
               return makeCompleteDate(filteredDisks[rowIndex].auditInfo.createdDate)
@@ -282,6 +295,7 @@ const Environments = () => {
           },
           {
             size: { basis: 240, grow: 0 },
+            field: 'accessed',
             headerRenderer: () => h(Sortable, { sort: diskSort, field: 'accessed', onSort: setDiskSort }, ['Last accessed']),
             cellRenderer: ({ rowIndex }) => {
               return makeCompleteDate(filteredDisks[rowIndex].auditInfo.dateAccessed)
@@ -289,6 +303,7 @@ const Environments = () => {
           },
           {
             size: { basis: 250, grow: 0 },
+            field: 'cost',
             headerRenderer: () => {
               return h(Sortable, { sort: diskSort, field: 'cost', onSort: setDiskSort }, [`Cost / month (${formatUSD(totalDiskCost)} total)`])
             },

--- a/src/pages/workflows/List.js
+++ b/src/pages/workflows/List.js
@@ -37,6 +37,7 @@ const WorkflowList = ({ queryParams: { tab, filter = '', ...query } }) => {
   }
 
   const tabName = tab || 'mine'
+  const tabs = { mine: 'My Workflows', public: 'Public Workflows', featured: 'Featured Workflows' }
 
   Utils.useOnMount(() => {
     const isMine = ({ public: isPublic, managers }) => !isPublic || _.includes(getUser().email, managers)
@@ -77,8 +78,8 @@ const WorkflowList = ({ queryParams: { tab, filter = '', ...query } }) => {
     ]),
     h(TabBar, {
       activeTab: tabName,
-      tabNames: ['mine', 'public', 'featured'],
-      displayNames: { mine: 'my workflows', public: 'public workflows', featured: 'featured workflows' },
+      tabNames: Object.keys(tabs),
+      displayNames: tabs,
       getHref: currentTab => `${Nav.getLink('workflows')}${getUpdatedQuery({ newTab: currentTab })}`,
       getOnClick: currentTab => e => {
         e.preventDefault()
@@ -89,10 +90,12 @@ const WorkflowList = ({ queryParams: { tab, filter = '', ...query } }) => {
       div({ style: { flex: 1 } }, [
         workflows && h(AutoSizer, [
           ({ width, height }) => h(FlexTable, {
-            width, height,
+            width, height, sort,
+            tableName: tabs[tabName],
             rowCount: sortedWorkflows.length,
             columns: [
               {
+                field: 'name',
                 headerRenderer: () => h(Sortable, { sort, field: 'name', onSort: setSort }, [h(HeaderCell, ['Workflow'])]),
                 cellRenderer: ({ rowIndex }) => {
                   const { namespace, name } = sortedWorkflows[rowIndex]
@@ -105,6 +108,7 @@ const WorkflowList = ({ queryParams: { tab, filter = '', ...query } }) => {
                 size: { basis: 300 }
               },
               {
+                field: 'synopsis',
                 headerRenderer: () => h(Sortable, { sort, field: 'synopsis', onSort: setSort }, [h(HeaderCell, ['Synopsis'])]),
                 cellRenderer: ({ rowIndex }) => {
                   const { synopsis } = sortedWorkflows[rowIndex]
@@ -114,6 +118,7 @@ const WorkflowList = ({ queryParams: { tab, filter = '', ...query } }) => {
                 size: { basis: 475 }
               },
               {
+                field: 'managers',
                 headerRenderer: () => h(Sortable, { sort, field: 'managers', onSort: setSort }, [h(HeaderCell, ['Owners'])]),
                 cellRenderer: ({ rowIndex }) => {
                   const { managers } = sortedWorkflows[rowIndex]
@@ -123,6 +128,7 @@ const WorkflowList = ({ queryParams: { tab, filter = '', ...query } }) => {
                 size: { basis: 225 }
               },
               {
+                field: 'numSnapshots',
                 headerRenderer: () => h(Sortable, { sort, field: 'numSnapshots', onSort: setSort }, [h(HeaderCell, ['Snapshots'])]),
                 cellRenderer: ({ rowIndex }) => {
                   const { numSnapshots } = sortedWorkflows[rowIndex]
@@ -132,6 +138,7 @@ const WorkflowList = ({ queryParams: { tab, filter = '', ...query } }) => {
                 size: { basis: 108, grow: 0, shrink: 0 }
               },
               {
+                field: 'numConfigurations',
                 headerRenderer: () => h(Sortable, { sort, field: 'numConfigurations', onSort: setSort }, [h(HeaderCell, ['Configurations'])]),
                 cellRenderer: ({ rowIndex }) => {
                   const { numConfigurations } = sortedWorkflows[rowIndex]

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -17,6 +17,7 @@ import { NoWorkspacesMessage, useWorkspaces, WorkspaceTagSelect } from 'src/comp
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { withErrorReporting } from 'src/libs/error'
+import Events from 'src/libs/events'
 import * as Nav from 'src/libs/nav'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
@@ -178,13 +179,17 @@ export const WorkspaceList = () => {
           cellRenderer: ({ rowIndex }) => {
             const { accessLevel, workspace: { workspaceId, namespace, name, attributes: { description } } } = sortedWorkspaces[rowIndex]
             const canView = Utils.canRead(accessLevel)
+            const canAccessWorkspace = () => !canView ? setRequestingAccessWorkspaceId(workspaceId) : undefined
 
             return div({ style: styles.tableCellContainer }, [
               div({ style: styles.tableCellContent }, [
                 h(Link, {
                   style: { color: canView ? undefined : colors.dark(0.7), fontWeight: 600, fontSize: 16, ...Style.noWrapEllipsis },
                   href: canView ? Nav.getLink('workspace-dashboard', { namespace, name }) : undefined,
-                  onClick: !canView ? () => setRequestingAccessWorkspaceId(workspaceId) : undefined,
+                  onClick: () => {
+                    canAccessWorkspace()
+                    !!canView && Ajax().Metrics.captureEvent(Events.workspaceOpenFromList, { workspaceName: name, workspaceNamespace: namespace })
+                  },
                   tooltip: !canView &&
                     'You cannot access this workspace because it is protected by an Authorization Domain. Click to learn about gaining access.',
                   tooltipSide: 'right'

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -172,8 +172,10 @@ export const WorkspaceList = () => {
       ),
       variant: 'light',
       rowHeight: 70,
+      sort,
       columns: [
         {
+          field: 'name',
           headerRenderer: makeHeaderRenderer('name'),
           cellRenderer: ({ rowIndex }) => {
             const { accessLevel, workspace: { workspaceId, namespace, name, attributes: { description } } } = sortedWorkspaces[rowIndex]
@@ -199,6 +201,7 @@ export const WorkspaceList = () => {
           },
           size: { basis: 400, grow: 2, shrink: 0 }
         }, {
+          field: 'lastModified',
           headerRenderer: makeHeaderRenderer('lastModified'),
           cellRenderer: ({ rowIndex }) => {
             const { workspace: { lastModified } } = sortedWorkspaces[rowIndex]
@@ -211,6 +214,7 @@ export const WorkspaceList = () => {
           },
           size: { basis: 100, grow: 1, shrink: 0 }
         }, {
+          field: 'createdBy',
           headerRenderer: makeHeaderRenderer('createdBy'),
           cellRenderer: ({ rowIndex }) => {
             const { workspace: { createdBy } } = sortedWorkspaces[rowIndex]
@@ -221,6 +225,7 @@ export const WorkspaceList = () => {
           },
           size: { basis: 200, grow: 1, shrink: 0 }
         }, {
+          field: 'accessLevel',
           headerRenderer: makeHeaderRenderer('accessLevel'),
           cellRenderer: ({ rowIndex }) => {
             const { accessLevel } = sortedWorkspaces[rowIndex]

--- a/src/pages/workspaces/workspace/ShareWorkspaceModal.js
+++ b/src/pages/workspaces/workspace/ShareWorkspaceModal.js
@@ -9,7 +9,7 @@ import { Ajax } from 'src/libs/ajax'
 import { getUser } from 'src/libs/auth'
 import colors from 'src/libs/colors'
 import { reportError } from 'src/libs/error'
-import Events, { extractWorkspaceDetails } from 'src/libs/events'
+import Events from 'src/libs/events'
 import { FormLabel } from 'src/libs/forms'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
@@ -95,7 +95,7 @@ const ShareWorkspaceModal = ({ onDismiss, workspace, workspace: { workspace: { n
     const aclEmails = _.map('email', acl)
     const needsDelete = _.remove(entry => aclEmails.includes(entry.email), originalAcl)
     const numAdditions = _.filter(({ email }) => !_.some({ email }, originalAcl), acl).length
-    const eventData = { numAdditions, ...extractWorkspaceDetails(workspace) }
+    const eventData = { numAdditions, workspaceName: name, workspaceNamespace: namespace }
 
     const aclUpdates = [
       ..._.flow(

--- a/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
+++ b/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
@@ -183,12 +183,13 @@ const SubmissionDetails = _.flow(
       ]),
       div({ style: { flex: 1 } }, [
         h(AutoSizer, [({ width, height }) => h(FlexTable, {
-          width, height,
+          width, height, sort,
           rowCount: filteredWorkflows.length,
           noContentMessage: 'No matching workflows',
           columns: [
             {
               size: { basis: 225 },
+              field: 'workflowEntity',
               headerRenderer: () => h(Sortable, { sort, field: 'workflowEntity', onSort: setSort }, ['Data Entity']),
               cellRenderer: ({ rowIndex }) => {
                 const { workflowEntity: { entityName, entityType } = {} } = filteredWorkflows[rowIndex]
@@ -198,12 +199,14 @@ const SubmissionDetails = _.flow(
               }
             }, {
               size: { basis: 225, grow: 0 },
+              field: 'statusLastChangedDate',
               headerRenderer: () => h(Sortable, { sort, field: 'statusLastChangedDate', onSort: setSort }, ['Last Changed']),
               cellRenderer: ({ rowIndex }) => {
                 return h(TextCell, [Utils.makeCompleteDate(filteredWorkflows[rowIndex].statusLastChangedDate)])
               }
             }, {
               size: { basis: 150, grow: 0 },
+              field: 'status',
               headerRenderer: () => h(Sortable, { sort, field: 'status', onSort: setSort }, ['Status']),
               cellRenderer: ({ rowIndex }) => {
                 const { status } = filteredWorkflows[rowIndex]
@@ -211,6 +214,7 @@ const SubmissionDetails = _.flow(
               }
             }, {
               size: { basis: 125, grow: 0 },
+              field: 'cost',
               headerRenderer: () => h(Sortable, { sort, field: 'cost', onSort: setSort }, ['Run Cost']),
               cellRenderer: ({ rowIndex }) => {
                 // handle undefined workflow cost as $0
@@ -218,6 +222,7 @@ const SubmissionDetails = _.flow(
               }
             }, {
               size: _.some(({ messages }) => !_.isEmpty(messages), filteredWorkflows) ? { basis: 200 } : { basis: 100, grow: 0 },
+              field: 'messages',
               headerRenderer: () => h(Sortable, { sort, field: 'messages', onSort: setSort }, ['Messages']),
               cellRenderer: ({ rowIndex }) => {
                 const messages = _.join('\n', filteredWorkflows[rowIndex].messages)
@@ -227,6 +232,7 @@ const SubmissionDetails = _.flow(
               }
             }, {
               size: { basis: 150 },
+              field: 'workflowId',
               headerRenderer: () => h(Sortable, { sort, field: 'workflowId', onSort: setSort }, ['Workflow ID']),
               cellRenderer: ({ rowIndex }) => {
                 const { workflowId } = filteredWorkflows[rowIndex]

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -108,9 +108,11 @@ const WorkflowIOTable = ({ which, inputsOutputs: data, config, errors, onChange,
   return h(SimpleFlexTable, {
     rowCount: sortedData.length,
     noContentMessage: `No matching ${which}.`,
+    sort,
     columns: [
       {
         size: { basis: 350, grow: 0 },
+        field: 'taskVariable',
         headerRenderer: () => h(Sortable, { sort, field: 'taskVariable', onSort: setSort }, [h(HeaderCell, ['Task name'])]),
         cellRenderer: ({ rowIndex }) => {
           const io = sortedData[rowIndex]
@@ -121,6 +123,7 @@ const WorkflowIOTable = ({ which, inputsOutputs: data, config, errors, onChange,
       },
       {
         size: { basis: 360, grow: 0 },
+        field: 'workflowVariable',
         headerRenderer: () => h(Sortable, { sort, field: 'workflowVariable', onSort: setSort }, ['Variable']),
         cellRenderer: ({ rowIndex }) => {
           const io = sortedData[rowIndex]


### PR DESCRIPTION
Previously, RVGrid was incorrectly marking up table headers and bodies separately with `role="grid"`.  #2460 changes this to use `role="table"` instead at the root of each of the 4 table types.

This tiny PR updates the integration tests to match. This should resolve the Circle CI build issues.