### PR TITLE
[CA-1306] A11y: fix integration tests (#2450)

### DIFF
--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -106,7 +106,7 @@ const svgText = ({ textContains }) => {
 }
 
 const navChild = text => {
-  return `//*[@role="navigation"]/*[contains(normalize-space(.),"${text}")]`
+  return `//*[@role="tablist"]/*[contains(normalize-space(.),"${text}")]`
 }
 
 const elementInDataTableRow = (entityName, text) => {


### PR DESCRIPTION
The tabs on the workflows page now use the `tablist` role which is more descriptive semantically than the `navigation` role. As far as I can tell, the only tests calling the `navChild` function seem to pertain to the workspace page which has this new role. I couldn't find any instances where it might still need to be looking for `role="navigation"` on a different page I didn't upgrade, but that doesn't mean there aren't any. 

Let's run the tests and see what happens!