### PR TITLE
[IA-2379] Galaxy persistence

### DIFF
--- a/src/components/NewGalaxyModal.js
+++ b/src/components/NewGalaxyModal.js
@@ -18,6 +18,7 @@ import {
   getGalaxyDiskCost, RadioBlock
 } from 'src/libs/runtime-utils'
 import * as Style from 'src/libs/style'
+import { newTabLinkProps } from 'src/libs/utils'
 import * as Utils from 'src/libs/utils'
 
 // TODO Factor out common pieces with NewRuntimeModal.styles into runtime-utils
@@ -289,8 +290,11 @@ export const NewGalaxyModal = _.flow(
     return div({ style: { ...styles.whiteBoxContainer, marginTop: '1rem' } }, [
       div({ style: styles.headerText }, ['Persistent disk']),
       div({ style: { marginTop: '0.5rem' } }, [
-        'Persistent disks store analysis data.'
-        // TODO Add info on PDs for Galaxy (similarly to in NewRuntimeModal.js)
+        'Persistent disks store analysis data. ',
+        h(Link, { href: 'https://support.terra.bio/hc/en-us/articles/360050566271', ...Utils.newTabLinkProps }, [
+          'Learn more about about persistent disks',
+          icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })
+        ])
       ]),
       renderPersistentDiskSizeSection()
     ])

--- a/src/components/NewGalaxyModal.js
+++ b/src/components/NewGalaxyModal.js
@@ -49,7 +49,7 @@ export const NewGalaxyModal = _.flow(
   const [kubernetesRuntimeConfig, setKubernetesRuntimeConfig] = useState(app?.kubernetesRuntimeConfig || defaultKubernetesRuntimeConfig)
   const [viewMode, setViewMode] = useState(undefined)
   const [loading, setLoading] = useState(false)
-  const [deleteDiskSelected, setDeleteDiskSelected] = useState(false)
+  const [shouldDeleteDisk, setShouldDeleteDisk] = useState(false)
 
   const currentDataDisk = currentPersistentDisk(apps, galaxyDataDisks)
 
@@ -69,7 +69,7 @@ export const NewGalaxyModal = _.flow(
     Utils.withBusyState(setLoading),
     withErrorReporting('Error deleting galaxy instance')
   )(async () => {
-    await Ajax().Apps.app(app.googleProject, app.appName).delete(attachedDataDisk ? deleteDiskSelected : false)
+    await Ajax().Apps.app(app.googleProject, app.appName).delete(attachedDataDisk ? shouldDeleteDisk : false)
     Ajax().Metrics.captureEvent(Events.applicationDelete, { app: 'Galaxy', ...extractWorkspaceDetails(workspace) })
     return onSuccess()
   })
@@ -291,7 +291,7 @@ export const NewGalaxyModal = _.flow(
       div({ style: { marginTop: '0.5rem' } }, [
         'Persistent disks store analysis data. ',
         h(Link, { href: 'https://support.terra.bio/hc/en-us/articles/360050566271', ...Utils.newTabLinkProps }, [
-          'Learn more about about persistent disks',
+          'Learn more about persistent disks',
           icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })
         ])
       ]),
@@ -344,7 +344,7 @@ export const NewGalaxyModal = _.flow(
         onDismiss,
         onPrevious: () => {
           setViewMode(undefined)
-          setDeleteDiskSelected(false)
+          setShouldDeleteDisk(false)
         }
       }),
       div({ style: { lineHeight: '1.5rem' } }, [
@@ -352,8 +352,8 @@ export const NewGalaxyModal = _.flow(
           h(RadioBlock, {
             name: 'keep-persistent-disk',
             labelText: 'Keep persistent disk, delete application configuration and compute profile',
-            checked: !deleteDiskSelected,
-            onChange: () => setDeleteDiskSelected(false),
+            checked: !shouldDeleteDisk,
+            onChange: () => setShouldDeleteDisk(false),
             style: { marginTop: '1rem' }
           }, [
             p([
@@ -368,8 +368,8 @@ export const NewGalaxyModal = _.flow(
           h(RadioBlock, {
             name: 'delete-persistent-disk',
             labelText: 'Delete everything, including persistent disk',
-            checked: deleteDiskSelected,
-            onChange: () => setDeleteDiskSelected(true),
+            checked: shouldDeleteDisk,
+            onChange: () => setShouldDeleteDisk(true),
             style: { marginTop: '1rem' }
           }, [
             p([

--- a/src/components/NewGalaxyModal.js
+++ b/src/components/NewGalaxyModal.js
@@ -14,7 +14,8 @@ import colors from 'src/libs/colors'
 import { withErrorReporting } from 'src/libs/error'
 import Events, { extractWorkspaceDetails } from 'src/libs/events'
 import {
-  currentApp, currentAttachedDataDisk, findMachineType, getGalaxyComputeCost, getGalaxyDiskCost, RadioBlock
+  currentApp, currentAttachedDataDisk, currentPersistentDiskIncludingUnattached, findMachineType, getGalaxyComputeCost,
+  getGalaxyDiskCost, RadioBlock
 } from 'src/libs/runtime-utils'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
@@ -50,16 +51,7 @@ export const NewGalaxyModal = _.flow(
   const [loading, setLoading] = useState(false)
   const [deleteDiskSelected, setDeleteDiskSelected] = useState(false)
 
-  const getCurrentPersistentDiskName = (apps, galaxyDataDisks) => {
-    const currentGalaxyApp = currentApp(apps)
-    const currentDataDiskName = currentGalaxyApp?.diskName
-    const attachedDataDiskNames = _.without([undefined], _.map(app => app.diskName, apps))
-    return currentDataDiskName ?
-      _.find({ currentDataDiskName }, galaxyDataDisks) :
-      _.last(_.sortBy('auditInfo.createdDate', _.filter(({ name, status }) => status !== 'Deleting' && !_.includes(name, attachedDataDiskNames), galaxyDataDisks)))
-  }
-
-  const currentDataDisk = getCurrentPersistentDiskName(apps, galaxyDataDisks)
+  const currentDataDisk = currentPersistentDiskIncludingUnattached(apps, galaxyDataDisks)[0]
 
   const createGalaxy = _.flow(
     Utils.withBusyState(setLoading),

--- a/src/components/NewGalaxyModal.js
+++ b/src/components/NewGalaxyModal.js
@@ -311,9 +311,9 @@ export const NewGalaxyModal = _.flow(
         return div({ marginTop: '0.75rem' }, [
           div({ style: { ...gridStyle, marginTop: '0.5rem' } }, [
             div({ style: styles.label }, ['Size (GB): ']), h(TooltipTrigger,
-          { content: ['Persistent disk of size ', currentDataDisk.size, ' GB already exists and will be attached upon Galaxy creation'] }, [
-              div({ marginTop: '0.5rem', width: '5rem' }, [currentDataDisk.size])
-            ])
+              { content: ['Persistent disk of size ', currentDataDisk.size, ' GB already exists and will be attached upon Galaxy creation'] }, [
+                div({ marginTop: '0.5rem', width: '5rem' }, [currentDataDisk.size])
+              ])
           ])
         ])
       }],

--- a/src/components/NewGalaxyModal.js
+++ b/src/components/NewGalaxyModal.js
@@ -1,27 +1,32 @@
 import _ from 'lodash/fp'
 import { Fragment, useState } from 'react'
-import { div, h, label, span } from 'react-hyperscript-helpers'
+import { div, h, label, p, span } from 'react-hyperscript-helpers'
 import { ButtonPrimary, ButtonSecondary, IdContainer, Link, Select, spinnerOverlay, WarningTitle } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import { NumberInput } from 'src/components/input'
 import { withModalDrawer } from 'src/components/ModalDrawer'
-import { GalaxyLaunchButton, GalaxyWarning } from 'src/components/runtime-common'
+import { GalaxyLaunchButton, GalaxyWarning, SaveFilesHelpGalaxy } from 'src/components/runtime-common'
 import TitleBar from 'src/components/TitleBar'
+import TooltipTrigger from 'src/components/TooltipTrigger'
 import { machineTypes } from 'src/data/machines'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { withErrorReporting } from 'src/libs/error'
 import Events, { extractWorkspaceDetails } from 'src/libs/events'
-import { currentApp, currentDataDisk, findMachineType, getGalaxyComputeCost, getGalaxyDiskCost } from 'src/libs/runtime-utils'
+import {
+  currentApp, currentAttachedDataDisk, findMachineType, getGalaxyComputeCost, getGalaxyDiskCost, RadioBlock
+} from 'src/libs/runtime-utils'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 
 // TODO Factor out common pieces with NewRuntimeModal.styles into runtime-utils
 const styles = {
   label: { fontWeight: 600, whiteSpace: 'pre' },
+  value: { fontWeight: 400, whiteSpace: 'pre' },
   whiteBoxContainer: { padding: '1rem', borderRadius: 3, backgroundColor: 'white' },
   drawerContent: { display: 'flex', flexDirection: 'column', flex: 1, padding: '1.5rem' },
-  headerText: { fontSize: 16, fontWeight: 600 }
+  headerText: { fontSize: 16, fontWeight: 600 },
+  warningView: { backgroundColor: colors.warning(0.1) }
 }
 
 const defaultDataDiskSize = 500 // GB
@@ -37,19 +42,32 @@ export const NewGalaxyModal = _.flow(
 )(({ onDismiss, onSuccess, apps, galaxyDataDisks, workspace, workspace: { workspace: { namespace, bucketName, name: workspaceName } } }) => {
   // Assumption: If there is an app defined, there must be a data disk corresponding to it.
   const app = currentApp(apps)
-  const dataDisk = currentDataDisk(app, galaxyDataDisks)
+  const attachedDataDisk = currentAttachedDataDisk(app, galaxyDataDisks)
 
-  const [dataDiskSize, setDataDiskSize] = useState(dataDisk?.size || defaultDataDiskSize)
+  const [dataDiskSize, setDataDiskSize] = useState(attachedDataDisk?.size || defaultDataDiskSize)
   const [kubernetesRuntimeConfig, setKubernetesRuntimeConfig] = useState(app?.kubernetesRuntimeConfig || defaultKubernetesRuntimeConfig)
   const [viewMode, setViewMode] = useState(undefined)
   const [loading, setLoading] = useState(false)
+  const [deleteDiskSelected, setDeleteDiskSelected] = useState(false)
+
+  const getCurrentPersistentDiskName = (apps, galaxyDataDisks) => {
+    const currentGalaxyApp = currentApp(apps)
+    const currentDataDiskName = currentGalaxyApp?.diskName
+    const attachedDataDiskNames = _.without([undefined], _.map(app => app.diskName, apps))
+    return currentDataDiskName ?
+      _.find({ currentDataDiskName }, galaxyDataDisks) :
+      _.last(_.sortBy('auditInfo.createdDate', _.filter(({ name, status }) => status !== 'Deleting' && !_.includes(name, attachedDataDiskNames), galaxyDataDisks)))
+  }
+
+  const currentDataDisk = getCurrentPersistentDiskName(apps, galaxyDataDisks)
 
   const createGalaxy = _.flow(
     Utils.withBusyState(setLoading),
     withErrorReporting('Error creating app')
   )(async () => {
-    await Ajax().Apps.app(namespace, Utils.generateKubernetesClusterName()).create({
-      kubernetesRuntimeConfig, diskName: Utils.generatePersistentDiskName(), diskSize: dataDiskSize, appType: 'GALAXY', namespace, bucketName, workspaceName
+    await Ajax().Apps.app(namespace, Utils.generateGalaxyAppName()).create({
+      kubernetesRuntimeConfig, diskName: currentDataDisk ? currentDataDisk.name : Utils.generatePersistentDiskName(), diskSize: dataDiskSize,
+      appType: 'GALAXY', namespace, bucketName, workspaceName
     })
     Ajax().Metrics.captureEvent(Events.applicationCreate, { app: 'Galaxy', ...extractWorkspaceDetails(workspace) })
     return onSuccess()
@@ -59,7 +77,7 @@ export const NewGalaxyModal = _.flow(
     Utils.withBusyState(setLoading),
     withErrorReporting('Error deleting galaxy instance')
   )(async () => {
-    await Ajax().Apps.app(app.googleProject, app.appName).delete()
+    await Ajax().Apps.app(app.googleProject, app.appName).delete(attachedDataDisk ? deleteDiskSelected : false)
     Ajax().Metrics.captureEvent(Events.applicationDelete, { app: 'Galaxy', ...extractWorkspaceDetails(workspace) })
     return onSuccess()
   })
@@ -83,7 +101,8 @@ export const NewGalaxyModal = _.flow(
   })
 
   const renderActionButton = () => {
-    const deleteButton = h(ButtonSecondary, { disabled: false, style: { marginRight: 'auto' }, onClick: () => setViewMode('deleteWarn') }, ['Delete'])
+    const deleteButton = h(ButtonSecondary, { disabled: false, style: { marginRight: 'auto' }, onClick: () => setViewMode('deleteWarn') },
+      ['Delete Environment Options'])
     const pauseButton = h(ButtonSecondary, { disabled: false, style: { marginRight: '1rem' }, onClick: () => { pauseGalaxy() } }, ['Pause'])
     const resumeButton = h(ButtonSecondary, { disabled: false, style: { marginRight: '1rem' }, onClick: resumeGalaxy }, ['Resume'])
 
@@ -112,14 +131,21 @@ export const NewGalaxyModal = _.flow(
             h(ButtonPrimary, { disabled: false, onClick: () => setViewMode('launchWarn') }, ['Launch Galaxy'])
           ])],
           ['STOPPED', () => h(Fragment, [
-            h(ButtonSecondary, { disabled: true, style: { marginRight: 'auto' }, tooltip: 'Cloud Compute must be resumed first.', onClick: () => setViewMode('deleteWarn') }, ['Delete']),
+            h(ButtonSecondary, {
+              disabled: true, style: { marginRight: 'auto' }, tooltip: 'Cloud Compute must be resumed first.',
+              onClick: () => setViewMode('deleteWarn')
+            }, ['Delete']),
             resumeButton
           ])],
           ['ERROR', () => deleteButton],
           [Utils.DEFAULT, () => {
             return h(Fragment, { tooltip: 'Cloud Compute must be resumed first.' }, [
-              h(ButtonSecondary, { disabled: true, style: { marginRight: 'auto' }, tooltip: 'Cloud Compute must be running.', onClick: () => setViewMode('deleteWarn') }, ['Delete']),
-              h(ButtonSecondary, { disabled: true, style: { marginRight: '1rem' }, tooltip: 'Cloud Compute must be running.', onClick: () => { pauseGalaxy() } }, ['Pause'])
+              h(ButtonSecondary, {
+                disabled: true, style: { marginRight: 'auto' }, tooltip: 'Cloud Compute must be running.', onClick: () => setViewMode('deleteWarn')
+              }, ['Delete']),
+              h(ButtonSecondary,
+                { disabled: true, style: { marginRight: '1rem' }, tooltip: 'Cloud Compute must be running.', onClick: () => { pauseGalaxy() } },
+                ['Pause'])
             ])
           }]
         )]
@@ -129,14 +155,14 @@ export const NewGalaxyModal = _.flow(
   const renderMessaging = () => {
     return Utils.switchCase(viewMode,
       ['createWarn', renderCreateWarning],
-      ['deleteWarn', renderDeleteWarning],
+      ['deleteWarn', renderDeleteDiskChoices],
       ['launchWarn', renderLaunchWarning],
       [Utils.DEFAULT, renderDefaultCase]
     )
   }
 
   const renderCreateWarning = () => {
-    return h(Fragment, [
+    return div({ style: styles.drawerContent }, [
       h(TitleBar, {
         title: 'Cloud Environment',
         style: { marginBottom: '0.5rem' },
@@ -186,36 +212,15 @@ export const NewGalaxyModal = _.flow(
             ])
           ])
         ])
-      ])
-    ])
-  }
-
-  const renderDeleteWarning = () => {
-    return h(Fragment, [
-      h(TitleBar, {
-        title: 'Delete Cloud Environment for Galaxy',
-        style: { marginBottom: '0.5rem' },
-        onDismiss,
-        onPrevious: !!viewMode ? () => setViewMode(undefined) : undefined
-      }),
-      div({ style: { lineHeight: '22px' } }, [
-        div({ style: { marginTop: '0.5rem' } }, [
-          'Deleting your Cloud Environment will also ',
-          span({ style: { fontWeight: 600 } }, ['delete any files on the associated hard disk']),
-          ' (e.g. results files). Double check that your workflow results were written to ',
-          'the data tab in the workspace before clicking “Delete”'
-        ]),
-        div({ style: { marginTop: '1rem' } }, [
-          'Deleting your Cloud Environment will stop your ',
-          'running Galaxy application and your application costs. You can create a new Cloud Environment ',
-          'for Galaxy later, which will take 8-10 minutes.'
-        ])
+      ]),
+      div({ style: { display: 'flex', marginTop: '2rem', justifyContent: 'flex-end' } }, [
+        renderActionButton()
       ])
     ])
   }
 
   const renderLaunchWarning = () => {
-    return h(Fragment, [
+    return div({ style: styles.drawerContent }, [
       h(TitleBar, {
         title: h(WarningTitle, ['Launch Galaxy']),
         style: { marginBottom: '0.5rem' },
@@ -224,6 +229,9 @@ export const NewGalaxyModal = _.flow(
       }),
       div({ style: { lineHeight: '22px' } }, [
         h(GalaxyWarning)
+      ]),
+      div({ style: { display: 'flex', marginTop: '2rem', justifyContent: 'flex-end' } }, [
+        renderActionButton()
       ])
     ])
   }
@@ -286,37 +294,107 @@ export const NewGalaxyModal = _.flow(
   }
 
   const renderPersistentDiskSection = () => {
-    const gridStyle = { display: 'grid', gridTemplateColumns: '0.75fr 4.5rem 1fr 5.5rem 1fr 5.5rem', gridGap: '1rem', alignItems: 'center' }
     return div({ style: { ...styles.whiteBoxContainer, marginTop: '1rem' } }, [
       div({ style: styles.headerText }, ['Persistent disk']),
       div({ style: { marginTop: '0.5rem' } }, [
         'Persistent disks store analysis data.'
         // TODO Add info on PDs for Galaxy (similarly to in NewRuntimeModal.js)
       ]),
-      div({ style: { ...gridStyle, marginTop: '0.75rem' } }, [
-        h(IdContainer, [
-          id => h(Fragment, [
-            label({ htmlFor: id, style: styles.label }, ['Size (GB)']),
-            div([
-              h(NumberInput, {
-                id,
-                min: 100, // Leo rejects Galaxy data disks <100G
-                max: 64000,
-                isClearable: false,
-                onlyInteger: true,
-                value: dataDiskSize,
-                style: { marginTop: '0.5rem', width: '5rem' },
-                onChange: v => setDataDiskSize(v)
-              })
+      renderPersistentDiskSizeSection()
+    ])
+  }
+
+  const renderPersistentDiskSizeSection = () => {
+    const gridStyle = { display: 'grid', gridTemplateColumns: '0.75fr 4.5rem 1fr 5.5rem 1fr 5.5rem', gridGap: '1rem', alignItems: 'center' }
+    return Utils.cond(
+      [currentDataDisk, () => {
+        return div({ marginTop: '0.75rem' }, [
+          div({ style: { ...gridStyle, marginTop: '0.5rem' } }, [
+            div({ style: styles.label }, ['Size (GB): ']), h(TooltipTrigger,
+          { content: ['Persistent disk of size ', currentDataDisk.size, ' GB already exists and will be attached upon Galaxy creation'] }, [
+              div({ marginTop: '0.5rem', width: '5rem' }, [currentDataDisk.size])
             ])
           ])
         ])
+      }],
+      () => {
+        return div({ style: { ...gridStyle, marginTop: '0.75rem' } }, [
+          h(IdContainer, [
+            id => h(Fragment, [
+              label({ htmlFor: id, style: styles.label }, ['Size (GB)']),
+              div([
+                h(NumberInput, {
+                  id,
+                  min: 250, // Galaxy doesn't come up with a smaller data disk
+                  max: 64000,
+                  isClearable: false,
+                  onlyInteger: true,
+                  value: dataDiskSize,
+                  style: { marginTop: '0.5rem', width: '5rem' },
+                  onChange: v => setDataDiskSize(v)
+                })
+              ])
+            ])
+          ])
+        ])
+      }
+    )
+  }
+
+  const renderDeleteDiskChoices = () => {
+    return div({ style: { ...styles.drawerContent, ...styles.warningView } }, [
+      h(TitleBar, {
+        style: styles.titleBar,
+        title: h(WarningTitle, ['Delete environment options']),
+        onDismiss,
+        onPrevious: () => {
+          setViewMode(undefined)
+          setDeleteDiskSelected(false)
+        }
+      }),
+      div({ style: { lineHeight: '1.5rem' } }, [
+        h(Fragment, [
+          h(RadioBlock, {
+            name: 'keep-persistent-disk',
+            labelText: 'Keep persistent disk, delete application configuration and compute profile',
+            checked: !deleteDiskSelected,
+            onChange: () => setDeleteDiskSelected(false),
+            style: { marginTop: '1rem' }
+          }, [
+            p([
+              'Deletes your application configuration and cloud compute profile, but detaches your persistent disk and saves it for later. ',
+              'The disk will be automatically reattached the next time you create a Galaxy application.'
+            ]),
+            p({ style: { marginBottom: 0 } }, [
+              'You will continue to incur persistent disk cost at ',
+              span({ style: { fontWeight: 600 } }, [Utils.formatUSD(getGalaxyDiskCost(dataDiskSize)), ' per hour.'])
+            ])
+          ]),
+          h(RadioBlock, {
+            name: 'delete-persistent-disk',
+            labelText: 'Delete everything, including persistent disk',
+            checked: deleteDiskSelected,
+            onChange: () => setDeleteDiskSelected(true),
+            style: { marginTop: '1rem' }
+          }, [
+            p([
+              'Deletes your persistent disk, which will also ', span({ style: { fontWeight: 600 } }, ['delete all files on the disk.'])
+            ]),
+            p({ style: { marginBottom: 0 } }, [
+              'Also deletes your application configuration and cloud compute profile.'
+            ])
+          ]),
+          h(SaveFilesHelpGalaxy)
+        ])
+      ]),
+      div({ style: { display: 'flex', marginTop: '2rem', justifyContent: 'flex-end' } }, [
+        renderActionButton()
       ])
     ])
   }
 
   const renderDefaultCase = () => {
-    return h(Fragment, [
+    return div({ style: styles.drawerContent }, [
       h(TitleBar, {
         title: 'Cloud Environment',
         style: { marginBottom: '0.5rem' },
@@ -340,15 +418,15 @@ export const NewGalaxyModal = _.flow(
         ])
       ]),
       renderCloudComputeProfileSection(),
-      renderPersistentDiskSection()
+      renderPersistentDiskSection(),
+      div({ style: { display: 'flex', marginTop: '2rem', justifyContent: 'flex-end' } }, [
+        renderActionButton()
+      ])
     ])
   }
 
-  return div({ style: styles.drawerContent }, [
+  return h(Fragment, [
     renderMessaging(),
-    div({ style: { display: 'flex', marginTop: '2rem', justifyContent: 'flex-end' } }, [
-      renderActionButton()
-    ]),
     loading && spinnerOverlay
   ])
 })

--- a/src/components/NewGalaxyModal.js
+++ b/src/components/NewGalaxyModal.js
@@ -18,7 +18,6 @@ import {
   getGalaxyDiskCost, RadioBlock
 } from 'src/libs/runtime-utils'
 import * as Style from 'src/libs/style'
-import { newTabLinkProps } from 'src/libs/utils'
 import * as Utils from 'src/libs/utils'
 
 // TODO Factor out common pieces with NewRuntimeModal.styles into runtime-utils

--- a/src/components/NewGalaxyModal.js
+++ b/src/components/NewGalaxyModal.js
@@ -14,7 +14,7 @@ import colors from 'src/libs/colors'
 import { withErrorReporting } from 'src/libs/error'
 import Events, { extractWorkspaceDetails } from 'src/libs/events'
 import {
-  currentApp, currentAttachedDataDisk, currentPersistentDiskIncludingUnattached, findMachineType, getGalaxyComputeCost,
+  currentApp, currentAttachedDataDisk, currentPersistentDisk, findMachineType, getGalaxyComputeCost,
   getGalaxyDiskCost, RadioBlock
 } from 'src/libs/runtime-utils'
 import * as Style from 'src/libs/style'
@@ -51,7 +51,7 @@ export const NewGalaxyModal = _.flow(
   const [loading, setLoading] = useState(false)
   const [deleteDiskSelected, setDeleteDiskSelected] = useState(false)
 
-  const currentDataDisk = currentPersistentDiskIncludingUnattached(apps, galaxyDataDisks)[0]
+  const currentDataDisk = currentPersistentDisk(apps, galaxyDataDisks)
 
   const createGalaxy = _.flow(
     Utils.withBusyState(setLoading),

--- a/src/components/NewRuntimeModal.js
+++ b/src/components/NewRuntimeModal.js
@@ -1094,7 +1094,7 @@ export const NewRuntimeModal = withModalDrawer({ width: 675 })(class NewRuntimeM
           p(['A minimal cost per hour is associated with maintaining the disk even when the cloud compute is paused or deleted.']),
           p(['If you delete your cloud compute, but keep your PD, the PD will be reattached when creating the next cloud compute.']),
           h(Link, { href: 'https://support.terra.bio/hc/en-us/articles/360047318551', ...Utils.newTabLinkProps }, [
-            'Learn more about about persistent disks in the Terra Support site',
+            'Learn more about persistent disks',
             icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })
           ])
         ])

--- a/src/components/NewRuntimeModal.js
+++ b/src/components/NewRuntimeModal.js
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp'
 import PropTypes from 'prop-types'
 import { Component, Fragment } from 'react'
-import { b, br, code, div, fieldset, h, input, label, legend, li, p, span, ul } from 'react-hyperscript-helpers'
+import { b, br, code, div, fieldset, h, label, legend, li, p, span, ul } from 'react-hyperscript-helpers'
 import { ButtonOutline, ButtonPrimary, ButtonSecondary, GroupedSelect, IdContainer, Link, Select, spinnerOverlay, WarningTitle } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import { ImageDepViewer } from 'src/components/ImageDepViewer'
@@ -18,6 +18,7 @@ import Events, { extractWorkspaceDetails } from 'src/libs/events'
 import {
   currentRuntime, DEFAULT_DISK_SIZE, defaultDataprocMachineType, defaultGceMachineType, findMachineType, getDefaultMachineType,
   persistentDiskCostMonthly,
+  RadioBlock,
   runtimeConfigBaseCost, runtimeConfigCost
 } from 'src/libs/runtime-utils'
 import * as Style from 'src/libs/style'
@@ -91,26 +92,6 @@ const DiskSelector = ({ value, onChange }) => {
         onChange
       })
     ])
-  ])
-}
-
-const RadioBlock = ({ labelText, children, name, checked, onChange, style = {} }) => {
-  return div({
-    style: {
-      backgroundColor: colors.warning(0.2),
-      borderRadius: 3, border: `1px solid ${checked ? colors.accent() : 'transparent'}`,
-      boxShadow: checked ? Style.standardShadow : undefined,
-      display: 'flex', alignItems: 'baseline', padding: '.75rem',
-      ...style
-    }
-  }, [
-    h(IdContainer, [id => h(Fragment, [
-      input({ type: 'radio', name, checked, onChange, id }),
-      div({ style: { marginLeft: '.75rem' } }, [
-        label({ style: { fontWeight: 600, fontSize: 16 }, htmlFor: id }, [labelText]),
-        children
-      ])
-    ])])
   ])
 }
 
@@ -529,7 +510,7 @@ export const NewRuntimeModal = withModalDrawer({ width: 675 })(class NewRuntimeM
     const { deleteDiskSelected, currentPersistentDiskDetails, currentRuntimeDetails } = this.state
     return h(Fragment, [
       h(RadioBlock, {
-        name: 'delete-persistent-disk',
+        name: 'keep-persistent-disk',
         labelText: 'Keep persistent disk, delete application configuration and compute profile',
         checked: !deleteDiskSelected,
         onChange: () => this.setState({ deleteDiskSelected: false })

--- a/src/components/runtime-common.js
+++ b/src/components/runtime-common.js
@@ -123,6 +123,21 @@ export const SaveFilesHelp = () => {
   ])
 }
 
+export const SaveFilesHelpGalaxy = () => {
+  return h(Fragment, [
+    p([
+      'Deleting your Cloud Environment will stop your ',
+      'running Galaxy application and your application costs. You can create a new Cloud Environment ',
+      'for Galaxy later, which will take 8-10 minutes.'
+    ]),
+    p(['If you want to save some files permanently, such as input data, analysis outputs, or installed packages, ',
+      h(Link, {
+        href: 'https://support.terra.bio/hc/en-us/articles/360026639112',
+        ...Utils.newTabLinkProps
+      }, ['move them to the workspace bucket.'])])
+  ])
+}
+
 export const GalaxyWarning = () => {
   return h(Fragment, [
     p({ style: { fontWeight: 600 } }, 'Important: Please keep this tab open and logged in to Terra while using Galaxy.'),

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1240,8 +1240,8 @@ const Apps = signal => ({
   app: (project, name) => {
     const root = `api/google/v1/apps/${project}/${name}`
     return {
-      delete: () => {
-        return fetchLeo(`${root}${qs.stringify({ deleteDisk: true }, { addQueryPrefix: true })}`,
+      delete: deleteDisk => {
+        return fetchLeo(`${root}${qs.stringify({ deleteDisk }, { addQueryPrefix: true })}`,
           _.mergeAll([authOpts(), { signal, method: 'DELETE' }, appIdentifier]))
       },
       create: ({ kubernetesRuntimeConfig, diskName, diskSize, appType, namespace, bucketName, workspaceName }) => {

--- a/src/libs/runtime-utils.js
+++ b/src/libs/runtime-utils.js
@@ -1,5 +1,10 @@
 import _ from 'lodash/fp'
+import { Fragment } from 'react'
+import { div, h, input, label } from 'react-hyperscript-helpers'
+import { IdContainer } from 'src/components/common'
 import { cloudServices, dataprocCpuPrice, ephemeralExternalIpAddressPrice, machineTypes, monthlyStoragePrice, storagePrice } from 'src/data/machines'
+import colors from 'src/libs/colors'
+import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 
 
@@ -164,7 +169,7 @@ export const machineCost = machineType => {
 
 export const currentApp = _.flow(trimAppsOldestFirst, _.last)
 
-export const currentDataDisk = (app, galaxyDataDisks) => {
+export const currentAttachedDataDisk = (app, galaxyDataDisks) => {
   return _.find({ name: app?.diskName }, galaxyDataDisks)
 }
 
@@ -186,3 +191,24 @@ export const convertedAppStatus = appStatus => {
     [Utils.DEFAULT, () => _.capitalize(appStatus)]
   )
 }
+
+export const RadioBlock = ({ labelText, children, name, checked, onChange, style = {} }) => {
+  return div({
+    style: {
+      backgroundColor: colors.warning(0.2),
+      borderRadius: 3, border: `1px solid ${checked ? colors.accent() : 'transparent'}`,
+      boxShadow: checked ? Style.standardShadow : undefined,
+      display: 'flex', alignItems: 'baseline', padding: '.75rem',
+      ...style
+    }
+  }, [
+    h(IdContainer, [id => h(Fragment, [
+      input({ type: 'radio', name, checked, onChange, id }),
+      div({ style: { marginLeft: '.75rem' } }, [
+        label({ style: { fontWeight: 600, fontSize: 16 }, htmlFor: id }, [labelText]),
+        children
+      ])
+    ])])
+  ])
+}
+

--- a/src/libs/runtime-utils.js
+++ b/src/libs/runtime-utils.js
@@ -180,16 +180,17 @@ export const appIsSettingUp = app => {
 }
 
 export const currentPersistentDiskIncludingUnattached = (apps, galaxyDataDisks) => {
+  // a user's PD can either be attached to their current app, detaching from a deleting app or unattached
   const currentGalaxyApp = currentAppIncludingDeleting(apps)
   const currentDataDiskName = currentGalaxyApp?.diskName
   const attachedDataDiskNames = _.without([undefined], _.map(app => app.diskName, apps))
-  const currentDatDisk = currentDataDiskName ?
+  // if the disk is attached to an app (or being detached from a deleting app), return that disk. otherwise,
+  // return the newest galaxy disk that the user has unattached to an app
+  const currentDataDisk = currentDataDiskName ?
     _.find({ name: currentDataDiskName }, galaxyDataDisks) :
     _.last(_.sortBy('auditInfo.createdDate', _.filter(({ name, status }) => status !== 'Deleting' && !_.includes(name, attachedDataDiskNames), galaxyDataDisks)))
   const isCurrentDiskDetaching = currentGalaxyApp && (currentGalaxyApp.status === 'DELETING' || currentGalaxyApp.status === 'PREDELETING')
-  const res = [currentDatDisk, isCurrentDiskDetaching]
-  console.dir(res)
-  return res
+  return [currentDataDisk, isCurrentDiskDetaching]
 }
 
 export const collapsedRuntimeStatus = runtime => {

--- a/src/libs/runtime-utils.js
+++ b/src/libs/runtime-utils.js
@@ -193,7 +193,7 @@ export const currentPersistentDisk = (apps, galaxyDataDisks) => {
 
 export const isCurrentGalaxyDiskDetaching = apps => {
   const currentGalaxyApp = currentAppIncludingDeleting(apps)
-  return currentGalaxyApp && (currentGalaxyApp.status === 'DELETING' || currentGalaxyApp.status === 'PREDELETING')
+  return currentGalaxyApp && _.includes(currentGalaxyApp.status, ['DELETING', 'PREDELETING'])
 }
 
 export const collapsedRuntimeStatus = runtime => {

--- a/src/libs/runtime-utils.js
+++ b/src/libs/runtime-utils.js
@@ -179,20 +179,6 @@ export const appIsSettingUp = app => {
   return app && (app.status === 'PROVISIONING' || app.status === 'PRECREATING')
 }
 
-export const currentPersistentDiskIncludingUnattached = (apps, galaxyDataDisks) => {
-  // a user's PD can either be attached to their current app, detaching from a deleting app or unattached
-  const currentGalaxyApp = currentAppIncludingDeleting(apps)
-  const currentDataDiskName = currentGalaxyApp?.diskName
-  const attachedDataDiskNames = _.without([undefined], _.map(app => app.diskName, apps))
-  // if the disk is attached to an app (or being detached from a deleting app), return that disk. otherwise,
-  // return the newest galaxy disk that the user has unattached to an app
-  const currentDataDisk = currentDataDiskName ?
-    _.find({ name: currentDataDiskName }, galaxyDataDisks) :
-    _.last(_.sortBy('auditInfo.createdDate', _.filter(({ name, status }) => status !== 'Deleting' && !_.includes(name, attachedDataDiskNames), galaxyDataDisks)))
-  const isCurrentDiskDetaching = currentGalaxyApp && (currentGalaxyApp.status === 'DELETING' || currentGalaxyApp.status === 'PREDELETING')
-  return [currentDataDisk, isCurrentDiskDetaching]
-}
-
 export const currentPersistentDisk = (apps, galaxyDataDisks) => {
   // a user's PD can either be attached to their current app, detaching from a deleting app or unattached
   const currentGalaxyApp = currentAppIncludingDeleting(apps)

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -189,7 +189,7 @@ export const abandonedPromise = () => {
 
 export const generateRuntimeName = () => `saturn-${uuid()}`
 
-export const generateKubernetesClusterName = () => `saturn-k8-${uuid()}`
+export const generateGalaxyAppName = () => `saturn-k8-${uuid()}`
 
 export const generatePersistentDiskName = () => `saturn-pd-${uuid()}`
 

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -127,9 +127,6 @@ const Environments = ({ namespace }) => {
   const getDeleteAppId = useGetter(deleteAppId)
   const [sort, setSort] = useState({ field: 'project', direction: 'asc' })
   const [diskSort, setDiskSort] = useState({ field: 'project', direction: 'asc' })
-  // TODO: Can we not use a state variable for appSort, and use a local variable instead?
-  // eslint-disable-next-line
-  const [appSort, setAppSort] = useState({ field: 'project', direction: 'asc' })
 
   const refreshData = withBusyState(setLoading, async () => {
     const creator = getUser().email
@@ -189,7 +186,7 @@ const Environments = ({ namespace }) => {
     created: 'auditInfo.createdDate',
     accessed: 'auditInfo.dateAccessed',
     cost: getGalaxyCost
-  }[appSort.field]], [appSort.direction], apps)
+  }[sort.field]], [sort.direction], apps)
 
   const filteredCloudEnvironments = _.concat(filteredRuntimes, filteredApps)
 
@@ -325,11 +322,6 @@ const Environments = ({ namespace }) => {
               const cloudEnvironment = filteredCloudEnvironments[rowIndex]
               console.log(JSON.stringify(cloudEnvironment))
               // TODO: update return logic once we support more app types (will need a backend change to return appType in list apps endpoint as well)
-              // return Utils.cond(
-              //   [cloudEnvironment.appName, () => 'Galaxy'],
-              //   [cloudEnvironment.runtimeConfig.cloudService === 'DATAPROC', () => 'Dataproc'],
-              //   [cloudEnvironment.runtimeConfig.cloudService === 'GCE', () => cloudEnvironment.runtimeConfig.cloudService]
-              // )
               return cloudEnvironment.appName ? 'Galaxy' : (cloudEnvironment.runtimeConfig.cloudService === 'DATAPROC' ? 'Dataproc' : cloudEnvironment.runtimeConfig.cloudService)
             }
           },

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -320,7 +320,6 @@ const Environments = ({ namespace }) => {
             headerRenderer: () => h(Sortable, { sort, field: 'created', onSort: setSort }, ['Type']),
             cellRenderer: ({ rowIndex }) => {
               const cloudEnvironment = filteredCloudEnvironments[rowIndex]
-              console.log(JSON.stringify(cloudEnvironment))
               // TODO: update return logic once we support more app types (will need a backend change to return appType in list apps endpoint as well)
               return cloudEnvironment.appName ? 'Galaxy' : (cloudEnvironment.runtimeConfig.cloudService === 'DATAPROC' ? 'Dataproc' : cloudEnvironment.runtimeConfig.cloudService)
             }

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -17,8 +17,7 @@ import colors from 'src/libs/colors'
 import { withErrorIgnoring, withErrorReporting } from 'src/libs/error'
 import { currentApp, currentRuntime, getGalaxyComputeCost, getGalaxyCost, persistentDiskCostMonthly, runtimeCost } from 'src/libs/runtime-utils'
 import * as Style from 'src/libs/style'
-import { cond, formatUSD, makeCompleteDate, useCancellation, useGetter, useOnMount, usePollingEffect, withBusyState } from 'src/libs/utils'
-import * as Utils from 'src/libs/utils'
+import { cond, formatUSD, makeCompleteDate, switchCase, useCancellation, useGetter, useOnMount, usePollingEffect, withBusyState } from 'src/libs/utils'
 
 
 const DeleteRuntimeModal = ({ runtime: { googleProject, runtimeName, runtimeConfig: { persistentDiskId } }, onDismiss, onSuccess }) => {
@@ -71,11 +70,11 @@ const DeleteDiskModal = ({ disk: { googleProject, name }, isGalaxyDisk, onDismis
     p([
       'Deleting the persistent disk will ', span({ style: { fontWeight: 600 } }, ['delete all files on it.'])
     ]),
-    Utils.switchCase(isGalaxyDisk,
+    switchCase(isGalaxyDisk,
       [false, () => {
-      return h(SaveFilesHelp)
+        return h(SaveFilesHelp)
       }]
-      ),
+    ),
     busy && spinnerOverlay
   ])
 }
@@ -498,7 +497,7 @@ const Environments = ({ namespace }) => {
               const { id, status, name } = filteredDisks[rowIndex]
               const error = cond(
                 [status === 'Creating', () => 'Cannot delete this disk because it is still being created'],
-                [_.some({ runtimeConfig: { persistentDiskId: id } }, runtimes) || _.some({ diskName:  name}, apps), () => 'Cannot delete this disk because it is attached. You must delete the cloud environment first.']
+                [_.some({ runtimeConfig: { persistentDiskId: id } }, runtimes) || _.some({ diskName: name }, apps), () => 'Cannot delete this disk because it is attached. You must delete the cloud environment first.']
               )
               return status !== 'Deleting' && h(Link, {
                 'aria-label': 'Delete persistent disk',

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -6,8 +6,8 @@ import FooterWrapper from 'src/components/FooterWrapper'
 import { icon } from 'src/components/icons'
 import Modal from 'src/components/Modal'
 import PopupTrigger from 'src/components/PopupTrigger'
-import { SaveFilesHelp } from 'src/components/runtime-common'
-import { RuntimeErrorModal } from 'src/components/RuntimeManager'
+import { SaveFilesHelp, SaveFilesHelpGalaxy } from 'src/components/runtime-common'
+import { AppErrorModal, RuntimeErrorModal } from 'src/components/RuntimeManager'
 import { SimpleFlexTable, Sortable } from 'src/components/table'
 import TooltipTrigger from 'src/components/TooltipTrigger'
 import TopBar from 'src/components/TopBar'
@@ -15,9 +15,10 @@ import { Ajax } from 'src/libs/ajax'
 import { getUser } from 'src/libs/auth'
 import colors from 'src/libs/colors'
 import { withErrorIgnoring, withErrorReporting } from 'src/libs/error'
-import { currentRuntime, persistentDiskCostMonthly, runtimeCost } from 'src/libs/runtime-utils'
+import { currentApp, currentRuntime, getGalaxyComputeCost, getGalaxyCost, persistentDiskCostMonthly, runtimeCost } from 'src/libs/runtime-utils'
 import * as Style from 'src/libs/style'
 import { cond, formatUSD, makeCompleteDate, useCancellation, useGetter, useOnMount, usePollingEffect, withBusyState } from 'src/libs/utils'
+import * as Utils from 'src/libs/utils'
 
 
 const DeleteRuntimeModal = ({ runtime: { googleProject, runtimeName, runtimeConfig: { persistentDiskId } }, onDismiss, onSuccess }) => {
@@ -53,7 +54,7 @@ const DeleteRuntimeModal = ({ runtime: { googleProject, runtimeName, runtimeConf
   ])
 }
 
-const DeleteDiskModal = ({ disk: { googleProject, name }, onDismiss, onSuccess }) => {
+const DeleteDiskModal = ({ disk: { googleProject, name }, isGalaxyDisk, onDismiss, onSuccess }) => {
   const [busy, setBusy] = useState(false)
   const deleteDisk = _.flow(
     withBusyState(setBusy),
@@ -70,15 +71,50 @@ const DeleteDiskModal = ({ disk: { googleProject, name }, onDismiss, onSuccess }
     p([
       'Deleting the persistent disk will ', span({ style: { fontWeight: 600 } }, ['delete all files on it.'])
     ]),
-    h(SaveFilesHelp),
+    Utils.switchCase(isGalaxyDisk,
+      [false, () => {
+      return h(SaveFilesHelp)
+      }]
+      ),
     busy && spinnerOverlay
   ])
 }
 
-const Environments = () => {
+const DeleteAppModal = ({ app: { googleProject, appName, diskName }, onDismiss, onSuccess }) => {
+  const [deleteDisk, setDeleteDisk] = useState(false)
+  const [deleting, setDeleting] = useState()
+  const deleteApp = _.flow(
+    withBusyState(setDeleting),
+    withErrorReporting('Error deleting cloud environment')
+  )(async () => {
+    await Ajax().Apps.app(googleProject, appName).delete(deleteDisk)
+    onSuccess()
+  })
+  return h(Modal, {
+    title: 'Delete cloud environment?',
+    onDismiss,
+    okButton: deleteApp
+  }, [
+    div({ style: { lineHeight: 1.5 } }, [
+      diskName ?
+        h(LabeledCheckbox, { checked: deleteDisk, onChange: setDeleteDisk }, [
+          span({ style: { fontWeight: 600 } }, [' Also delete the persistent disk and all files on it'])
+        ]) :
+        p([
+          'Deleting this cloud environment will also ', span({ style: { fontWeight: 600 } }, ['delete any files on the associated hard disk.'])
+        ]),
+      h(SaveFilesHelpGalaxy)
+    ]),
+    deleting && spinnerOverlay
+  ])
+}
+
+const Environments = ({ namespace }) => {
   const signal = useCancellation()
   const [runtimes, setRuntimes] = useState()
+  const [apps, setApps] = useState()
   const [disks, setDisks] = useState()
+  const [galaxyDisks, setGalaxyDisks] = useState()
   const [loading, setLoading] = useState(false)
   const [errorRuntimeId, setErrorRuntimeId] = useState()
   const getErrorRuntimeId = useGetter(errorRuntimeId)
@@ -86,19 +122,29 @@ const Environments = () => {
   const getDeleteRuntimeId = useGetter(deleteRuntimeId)
   const [deleteDiskId, setDeleteDiskId] = useState()
   const getDeleteDiskId = useGetter(deleteDiskId)
+  const [errorAppId, setErrorAppId] = useState()
+  const getErrorAppId = useGetter(errorAppId)
+  const [deleteAppId, setDeleteAppId] = useState()
+  const getDeleteAppId = useGetter(deleteAppId)
   const [sort, setSort] = useState({ field: 'project', direction: 'asc' })
   const [diskSort, setDiskSort] = useState({ field: 'project', direction: 'asc' })
+  // TODO: Can we not use a state variable for appSort, and use a local variable instead?
+  // eslint-disable-next-line
+  const [appSort, setAppSort] = useState({ field: 'project', direction: 'asc' })
 
   const refreshData = withBusyState(setLoading, async () => {
     const creator = getUser().email
-    const [newRuntimes, newDisks, galaxyDisks] = await Promise.all([
+    const [newRuntimes, newDisks, galaxyDisks, newApps] = await Promise.all([
       Ajax(signal).Runtimes.list({ creator }),
       Ajax(signal).Disks.list({ creator }),
-      Ajax(signal).Disks.list({ creator, saturnApplication: 'galaxy' })
+      Ajax(signal).Disks.list({ creator, saturnApplication: 'galaxy' }),
+      Ajax(signal).Apps.listWithoutProject({ creator })
     ])
-    const galaxyDiskNames = _.map(disk => disk.name, galaxyDisks)
     setRuntimes(newRuntimes)
-    setDisks(_.remove(disk => _.includes(disk.name, galaxyDiskNames), newDisks))
+    setDisks(newDisks)
+    setGalaxyDisks(galaxyDisks)
+    setApps(newApps)
+
     if (!_.some({ id: getErrorRuntimeId() }, newRuntimes)) {
       setErrorRuntimeId(undefined)
     }
@@ -107,6 +153,12 @@ const Environments = () => {
     }
     if (!_.some({ id: getDeleteDiskId() }, newDisks)) {
       setDeleteDiskId(undefined)
+    }
+    if (!_.some({ appName: getErrorAppId() }, newApps)) {
+      setErrorAppId(undefined)
+    }
+    if (!_.some({ appName: getDeleteAppId() }, newApps)) {
+      setDeleteAppId(undefined)
     }
   })
 
@@ -132,11 +184,123 @@ const Environments = () => {
     size: 'size'
   }[diskSort.field]], [diskSort.direction], disks)
 
-  const totalCost = _.sum(_.map(runtimeCost, runtimes))
+  const filteredApps = _.orderBy([{
+    project: 'googleProject',
+    status: 'status',
+    created: 'auditInfo.createdDate',
+    accessed: 'auditInfo.dateAccessed',
+    cost: getGalaxyCost
+  }[appSort.field]], [appSort.direction], apps)
+
+  const filteredCloudEnvironments = _.concat(filteredRuntimes, filteredApps)
+
+  const totalRuntimeCost = _.sum(_.map(runtimeCost, runtimes))
+  const totalAppCost = _.sum(_.map(getGalaxyComputeCost, apps))
+  const totalCost = totalRuntimeCost + totalAppCost
   const totalDiskCost = _.sum(_.map(persistentDiskCostMonthly, disks))
 
   const runtimesByProject = _.groupBy('googleProject', runtimes)
   const disksByProject = _.groupBy('googleProject', disks)
+  const appsByProject = _.groupBy('googleProject', apps)
+
+  const renderBillingProjectApp = app => {
+    const inactive = !_.includes(app.status, ['DELETING', 'ERROR', 'PREDELETING']) &&
+      currentApp(appsByProject[app.googleProject]) !== app
+    return h(Fragment, [
+      app.googleProject,
+      inactive && h(TooltipTrigger, {
+        content: 'This billing project has multiple active cloud environments. Only the most recently created one will be used.'
+      }, [icon('warning-standard', { style: { marginLeft: '0.25rem', color: colors.warning() } })])
+    ])
+  }
+
+  const renderBillingProjectRuntime = runtime => {
+    const inactive = !_.includes(runtime.status, ['Deleting', 'Error']) &&
+      currentRuntime(runtimesByProject[runtime.googleProject]) !== runtime
+    return h(Fragment, [
+      runtime.googleProject,
+      inactive && h(TooltipTrigger, {
+        content: 'This billing project has multiple active cloud environments. Only the most recently created one will be used.'
+      }, [icon('warning-standard', { style: { marginLeft: '0.25rem', color: colors.warning() } })])
+    ])
+  }
+
+  const renderDetailsApp = (app, disks) => {
+    const { appName, diskName } = app
+    const disk = _.find({ name: diskName }, disks)
+    return h(PopupTrigger, {
+      content: div({ style: { padding: '0.5rem' } }, [
+        div([span({ style: { fontWeight: '600' } }, ['Name: ']), appName]),
+        disk && div([span({ style: { fontWeight: '600' } }, ['Persistent Disk: ']), disk.name])
+      ])
+    }, [h(Link, ['details'])])
+  }
+
+  const renderDetailsRuntime = (runtime, disks) => {
+    const { runtimeName, runtimeConfig: { persistentDiskId } } = runtime
+    const disk = _.find({ id: persistentDiskId }, disks)
+    return h(PopupTrigger, {
+      content: div({ style: { padding: '0.5rem' } }, [
+        div([span({ style: { fontWeight: '600' } }, ['Name: ']), runtimeName]),
+        disk && div([span({ style: { fontWeight: '600' } }, ['Persistent Disk: ']), disk.name])
+      ])
+    }, [h(Link, ['details'])])
+  }
+
+  const renderDeleteButtonApps = app => {
+    const { appName, status } = app
+    return status !== 'DELETING' && h(Link, {
+      disabled: status === 'CREATING',
+      'aria-label': 'Delete cloud environment',
+      tooltip: status === 'Creating' ? 'Cannot delete a cloud environment while it is being created' : 'Delete cloud environment',
+      onClick: () => setDeleteAppId(appName)
+    }, [icon('trash')])
+  }
+
+  const renderDeleteButtonRuntimes = runtime => {
+    const { id, status } = runtime
+    return status !== 'Deleting' && h(Link, {
+      disabled: status === 'Creating',
+      'aria-label': 'Delete cloud environment',
+      tooltip: status === 'Creating' ? 'Cannot delete a cloud environment while it is being created' : 'Delete cloud environment',
+      onClick: () => setDeleteRuntimeId(id)
+    }, [icon('trash')])
+  }
+
+  const renderErrorApps = app => {
+    return h(Fragment, [
+      app.status[0] + app.status.substring(1).toLowerCase(),
+      app.status === 'ERROR' && h(Clickable, {
+        tooltip: 'View error',
+        'aria-label': 'View error',
+        onClick: () => setErrorAppId(app.appName)
+      }, [icon('warning-standard', { style: { marginLeft: '0.25rem', color: colors.danger() } })])
+    ])
+  }
+
+  const renderErrorRuntimes = runtime => {
+    return h(Fragment, [
+      runtime.status,
+      runtime.status === 'Error' && h(Clickable, {
+        tooltip: 'View error',
+        'aria-label': 'View error',
+        onClick: () => setErrorRuntimeId(runtime.id)
+      }, [icon('warning-standard', { style: { marginLeft: '0.25rem', color: colors.danger() } })])
+    ])
+  }
+
+  const renderDeleteDiskModal = disk => {
+    const diskName = disk.name
+    return h(DeleteDiskModal, {
+      disk,
+      isGalaxyDisk: _.some({ name: diskName }, galaxyDisks),
+      onDismiss: () => setDeleteDiskId(undefined),
+      onSuccess: () => {
+        setDeleteDiskId(undefined)
+        loadData()
+      }
+    })
+  }
 
   return h(FooterWrapper, [
     h(TopBar, { title: 'Cloud Environments' }),
@@ -145,35 +309,37 @@ const Environments = () => {
       runtimes && h(SimpleFlexTable, {
         sort,
         tableName: 'cloud environments',
-        rowCount: filteredRuntimes.length,
+        rowCount: filteredCloudEnvironments.length,
         columns: [
           {
             field: 'project',
             headerRenderer: () => h(Sortable, { sort, field: 'project', onSort: setSort }, ['Billing project']),
             cellRenderer: ({ rowIndex }) => {
-              const runtime = filteredRuntimes[rowIndex]
-              const inactive = !_.includes(runtime.status, ['Deleting', 'Error']) &&
-                currentRuntime(runtimesByProject[runtime.googleProject]) !== runtime
-              return h(Fragment, [
-                runtime.googleProject,
-                inactive && h(TooltipTrigger, {
-                  content: 'This billing project has multiple active cloud environments. Only the most recently created one will be used.'
-                }, [icon('warning-standard', { style: { marginLeft: '0.25rem', color: colors.warning() } })])
-              ])
+              const cloudEnvironment = filteredCloudEnvironments[rowIndex]
+              return cloudEnvironment.appName ? renderBillingProjectApp(cloudEnvironment) : renderBillingProjectRuntime(cloudEnvironment)
+            }
+          },
+          {
+            size: { basis: 90, grow: 0 },
+            headerRenderer: () => h(Sortable, { sort, field: 'created', onSort: setSort }, ['Type']),
+            cellRenderer: ({ rowIndex }) => {
+              const cloudEnvironment = filteredCloudEnvironments[rowIndex]
+              console.log(JSON.stringify(cloudEnvironment))
+              // TODO: update return logic once we support more app types (will need a backend change to return appType in list apps endpoint as well)
+              // return Utils.cond(
+              //   [cloudEnvironment.appName, () => 'Galaxy'],
+              //   [cloudEnvironment.runtimeConfig.cloudService === 'DATAPROC', () => 'Dataproc'],
+              //   [cloudEnvironment.runtimeConfig.cloudService === 'GCE', () => cloudEnvironment.runtimeConfig.cloudService]
+              // )
+              return cloudEnvironment.appName ? 'Galaxy' : (cloudEnvironment.runtimeConfig.cloudService === 'DATAPROC' ? 'Dataproc' : cloudEnvironment.runtimeConfig.cloudService)
             }
           },
           {
             size: { basis: 90, grow: 0 },
             headerRenderer: () => 'Details',
             cellRenderer: ({ rowIndex }) => {
-              const { runtimeName, runtimeConfig: { persistentDiskId } } = filteredRuntimes[rowIndex]
-              const disk = _.find({ id: persistentDiskId }, disks)
-              return h(PopupTrigger, {
-                content: div({ style: { padding: '0.5rem' } }, [
-                  div([span({ style: { fontWeight: '600' } }, ['Name: ']), runtimeName]),
-                  disk && div([span({ style: { fontWeight: '600' } }, ['Persistent Disk: ']), disk.name])
-                ])
-              }, [h(Link, ['details'])])
+              const cloudEnvironment = filteredCloudEnvironments[rowIndex]
+              return cloudEnvironment.appName ? renderDetailsApp(cloudEnvironment, disks) : renderDetailsRuntime(cloudEnvironment, disks)
             }
           },
           {
@@ -181,23 +347,19 @@ const Environments = () => {
             field: 'status',
             headerRenderer: () => h(Sortable, { sort, field: 'status', onSort: setSort }, ['Status']),
             cellRenderer: ({ rowIndex }) => {
-              const runtime = filteredRuntimes[rowIndex]
-              return h(Fragment, [
-                runtime.status,
-                runtime.status === 'Error' && h(Clickable, {
-                  tooltip: 'View error',
-                  'aria-label': 'View error',
-                  onClick: () => setErrorRuntimeId(runtime.id)
-                }, [icon('warning-standard', { style: { marginLeft: '0.25rem', color: colors.danger() } })])
-              ])
+              const cloudEnvironment = filteredCloudEnvironments[rowIndex]
+              return cloudEnvironment.appName ? renderErrorApps(cloudEnvironment) : renderErrorRuntimes(cloudEnvironment)
             }
           },
           {
             size: { basis: 120, grow: 0.2 },
             headerRenderer: () => 'Location',
             cellRenderer: ({ rowIndex }) => {
-              const { runtimeConfig: { zone, region } } = filteredRuntimes[rowIndex]
-              return zone || region
+              const cloudEnvironment = filteredCloudEnvironments[rowIndex]
+              // This logic works under the assumption that all Galaxy apps get created in zone 'us-central1-a'
+              const zone = cloudEnvironment.runtimeConfig ? cloudEnvironment.runtimeConfig.zone : 'us-central1-a'
+              const region = cloudEnvironment.runtimeConfig ? cloudEnvironment.runtimeConfig.region : 'us-central1-a'
+              return zone || region || 'us-central1-a'
             }
           },
           {
@@ -205,7 +367,7 @@ const Environments = () => {
             field: 'created',
             headerRenderer: () => h(Sortable, { sort, field: 'created', onSort: setSort }, ['Created']),
             cellRenderer: ({ rowIndex }) => {
-              return makeCompleteDate(filteredRuntimes[rowIndex].auditInfo.createdDate)
+              return makeCompleteDate(filteredCloudEnvironments[rowIndex].auditInfo.createdDate)
             }
           },
           {
@@ -213,7 +375,7 @@ const Environments = () => {
             field: 'accessed',
             headerRenderer: () => h(Sortable, { sort, field: 'accessed', onSort: setSort }, ['Last accessed']),
             cellRenderer: ({ rowIndex }) => {
-              return makeCompleteDate(filteredRuntimes[rowIndex].auditInfo.dateAccessed)
+              return makeCompleteDate(filteredCloudEnvironments[rowIndex].auditInfo.dateAccessed)
             }
           },
           {
@@ -223,20 +385,16 @@ const Environments = () => {
               return h(Sortable, { sort, field: 'cost', onSort: setSort }, [`Cost / hr (${formatUSD(totalCost)} total)`])
             },
             cellRenderer: ({ rowIndex }) => {
-              return formatUSD(runtimeCost(filteredRuntimes[rowIndex]))
+              const cloudEnvironment = filteredCloudEnvironments[rowIndex]
+              return cloudEnvironment.appName ? formatUSD(getGalaxyComputeCost(cloudEnvironment)) : formatUSD(runtimeCost(cloudEnvironment))
             }
           },
           {
             size: { basis: 50, grow: 0 },
             headerRenderer: () => null,
             cellRenderer: ({ rowIndex }) => {
-              const { id, status } = filteredRuntimes[rowIndex]
-              return status !== 'Deleting' && h(Link, {
-                disabled: status === 'Creating',
-                'aria-label': 'Delete cloud environment',
-                tooltip: status === 'Creating' ? 'Cannot delete a cloud environment while it is being created' : 'Delete cloud environment',
-                onClick: () => setDeleteRuntimeId(id)
-              }, [icon('trash')])
+              const cloudEnvironment = filteredCloudEnvironments[rowIndex]
+              return cloudEnvironment.appName ? renderDeleteButtonApps(cloudEnvironment) : renderDeleteButtonRuntimes(cloudEnvironment)
             }
           }
         ]
@@ -252,10 +410,14 @@ const Environments = () => {
             headerRenderer: () => h(Sortable, { sort: diskSort, field: 'project', onSort: setDiskSort }, ['Billing project']),
             cellRenderer: ({ rowIndex }) => {
               const disk = filteredDisks[rowIndex]
-              const multiple = _.remove({ status: 'Deleting' }, disksByProject[disk.googleProject]).length > 1
+              const galaxyDiskNames = _.map(disk => disk.name, galaxyDisks)
+              const runtimeDisks = _.remove(disk => _.includes(disk.name, galaxyDiskNames), disks)
+              const runtimeDiskNames = _.map(disk => disk.name, runtimeDisks)
+              const multipleRuntimeDisks = _.remove(disk => _.includes(disk.name, galaxyDiskNames) || disk.status === 'Deleting', disksByProject[disk.googleProject]).length > 1
+              const multipleGalaxyDisks = _.remove(disk => _.includes(disk.name, runtimeDiskNames) || disk.status === 'DELETING', disksByProject[disk.googleProject]).length > 1
               return h(Fragment, [
                 disk.googleProject,
-                disk.status !== 'Deleting' && multiple && h(TooltipTrigger, {
+                disk.status !== 'Deleting' && (_.includes(disk.name, galaxyDiskNames) ? multipleGalaxyDisks : multipleRuntimeDisks) && h(TooltipTrigger, {
                   content: 'This billing project has multiple active persistent disks. Only one will be used.'
                 }, [icon('warning-standard', { style: { marginLeft: '0.25rem', color: colors.warning() } })])
               ])
@@ -267,10 +429,12 @@ const Environments = () => {
             cellRenderer: ({ rowIndex }) => {
               const { name, id } = filteredDisks[rowIndex]
               const runtime = _.find({ runtimeConfig: { persistentDiskId: id } }, runtimes)
+              const app = _.find({ diskName: name }, apps)
               return h(PopupTrigger, {
                 content: div({ style: { padding: '0.5rem' } }, [
                   div([span({ style: { fontWeight: 600 } }, ['Name: ']), name]),
-                  runtime && div([span({ style: { fontWeight: 600 } }, ['Runtime: ']), runtime.runtimeName])
+                  runtime && div([span({ style: { fontWeight: 600 } }, ['Runtime: ']), runtime.runtimeName]),
+                  app && div([span({ style: { fontWeight: 600 } }, ['Galaxy: ']), app.appName])
                 ])
               }, [h(Link, ['details'])])
             }
@@ -331,10 +495,10 @@ const Environments = () => {
             size: { basis: 50, grow: 0 },
             headerRenderer: () => null,
             cellRenderer: ({ rowIndex }) => {
-              const { id, status } = filteredDisks[rowIndex]
+              const { id, status, name } = filteredDisks[rowIndex]
               const error = cond(
                 [status === 'Creating', () => 'Cannot delete this disk because it is still being created'],
-                [_.some({ runtimeConfig: { persistentDiskId: id } }, runtimes), () => 'Cannot delete this disk because it is attached. You must delete the cloud environment first.']
+                [_.some({ runtimeConfig: { persistentDiskId: id } }, runtimes) || _.some({ diskName:  name}, apps), () => 'Cannot delete this disk because it is attached. You must delete the cloud environment first.']
               )
               return status !== 'Deleting' && h(Link, {
                 'aria-label': 'Delete persistent disk',
@@ -358,11 +522,20 @@ const Environments = () => {
           loadData()
         }
       }),
-      deleteDiskId && h(DeleteDiskModal, {
-        disk: _.find({ id: deleteDiskId }, disks),
-        onDismiss: () => setDeleteDiskId(undefined),
+      deleteDiskId && renderDeleteDiskModal(_.find({ id: deleteDiskId }, disks)),
+      deleteAppId && h(DeleteAppModal, {
+        app: _.find({ appName: deleteAppId }, apps),
+        onDismiss: () => setDeleteAppId(undefined),
         onSuccess: () => {
-          setDeleteDiskId(undefined)
+          setDeleteAppId(undefined)
+          loadData()
+        }
+      }),
+      errorAppId && h(AppErrorModal, {
+        app: _.find({ appName: errorAppId }, apps),
+        onDismiss: () => setErrorAppId(undefined),
+        onSuccess: () => {
+          setErrorAppId(undefined)
           loadData()
         }
       }),

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -122,9 +122,7 @@ const Environments = ({ namespace }) => {
   const [deleteDiskId, setDeleteDiskId] = useState()
   const getDeleteDiskId = useGetter(deleteDiskId)
   const [errorAppId, setErrorAppId] = useState()
-  const getErrorAppId = useGetter(errorAppId)
   const [deleteAppId, setDeleteAppId] = useState()
-  const getDeleteAppId = useGetter(deleteAppId)
   const [sort, setSort] = useState({ field: 'project', direction: 'asc' })
   const [diskSort, setDiskSort] = useState({ field: 'project', direction: 'asc' })
 
@@ -150,10 +148,10 @@ const Environments = ({ namespace }) => {
     if (!_.some({ id: getDeleteDiskId() }, newDisks)) {
       setDeleteDiskId(undefined)
     }
-    if (!_.some({ appName: getErrorAppId() }, newApps)) {
+    if (!_.some({ appName: errorAppId }, newApps)) {
       setErrorAppId(undefined)
     }
-    if (!_.some({ appName: getDeleteAppId() }, newApps)) {
+    if (!_.some({ appName: deleteAppId }, newApps)) {
       setDeleteAppId(undefined)
     }
   })

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -344,9 +344,10 @@ const Environments = ({ namespace }) => {
             headerRenderer: () => 'Location',
             cellRenderer: ({ rowIndex }) => {
               const cloudEnvironment = filteredCloudEnvironments[rowIndex]
+              const zone = cloudEnvironment?.runtimeConfig?.zone
+              const region = cloudEnvironment?.runtimeConfig?.region
               // This logic works under the assumption that all Galaxy apps get created in zone 'us-central1-a'
-              const zone = cloudEnvironment.runtimeConfig ? cloudEnvironment.runtimeConfig.zone : 'us-central1-a'
-              const region = cloudEnvironment.runtimeConfig ? cloudEnvironment.runtimeConfig.region : 'us-central1-a'
+              // if zone or region are not present then cloudEnvironment is a Galaxy app so return 'us-central1-a'
               return zone || region || 'us-central1-a'
             }
           },

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -21,7 +21,7 @@ import { reportError, withErrorReporting } from 'src/libs/error'
 import { versionTag } from 'src/libs/logos'
 import * as Nav from 'src/libs/nav'
 import { notify } from 'src/libs/notifications'
-import { appIsSettingUp, convertedAppStatus, currentApp, currentAttachedDataDisk, currentPersistentDiskIncludingUnattached, getGalaxyCost } from 'src/libs/runtime-utils'
+import { appIsSettingUp, convertedAppStatus, currentApp, currentAttachedDataDisk, getGalaxyCost, isCurrentGalaxyDiskDetaching } from 'src/libs/runtime-utils'
 import { authStore } from 'src/libs/state'
 import * as StateHistory from 'src/libs/state-history'
 import * as Style from 'src/libs/style'
@@ -327,10 +327,6 @@ const Notebooks = _.flow(
         ])
     }
 
-    const isCurrentDiskDetaching = (app, galaxyDataDisks) => {
-      return _.last(currentPersistentDiskIncludingUnattached(apps, galaxyDataDisks))
-    }
-
     return div({
       style: { display: 'flex', marginRight: listView ? undefined : '-2.5rem', alignItems: 'flex-start' }
     }, [
@@ -361,8 +357,8 @@ const Notebooks = _.flow(
             style: {
               ...Style.elements.card.container, height: 125, marginTop: 15
             },
-            disabled: appIsSettingUp(app) || isCurrentDiskDetaching(apps, galaxyDataDisks),
-            tooltip: (appIsSettingUp(app) && 'Galaxy app is being created') || (_.last(currentPersistentDiskIncludingUnattached(apps, galaxyDataDisks)) && 'Your persistent disk is still attached to your previous app; you can create a new app once your previous app finishes deleting, which will take a few minutes.'),
+            disabled: appIsSettingUp(app) || isCurrentGalaxyDiskDetaching(apps),
+            tooltip: (appIsSettingUp(app) && 'Galaxy app is being created') || (isCurrentGalaxyDiskDetaching(apps) && 'Your persistent disk is still attached to your previous app; you can create a new app once your previous app finishes deleting, which will take a few minutes.'),
             onClick: () => setOpenGalaxyConfigDrawer(true)
           }, [
             getGalaxyText(app, galaxyDataDisks)

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -327,6 +327,10 @@ const Notebooks = _.flow(
         ])
     }
 
+    const isCurrentDiskDetaching = (app, galaxyDataDisks) => {
+      return _.last(currentPersistentDiskIncludingUnattached(apps, galaxyDataDisks))
+    }
+
     return div({
       style: { display: 'flex', marginRight: listView ? undefined : '-2.5rem', alignItems: 'flex-start' }
     }, [
@@ -357,7 +361,7 @@ const Notebooks = _.flow(
             style: {
               ...Style.elements.card.container, height: 125, marginTop: 15
             },
-            disabled: appIsSettingUp(app) || _.last(currentPersistentDiskIncludingUnattached(apps, galaxyDataDisks)),
+            disabled: appIsSettingUp(app) || isCurrentDiskDetaching(apps, galaxyDataDisks),
             tooltip: (appIsSettingUp(app) && 'Galaxy app is being created') || (_.last(currentPersistentDiskIncludingUnattached(apps, galaxyDataDisks)) && 'Your persistent disk is still attached to your previous app; you can create a new app once your previous app finishes deleting, which will take a few minutes.'),
             onClick: () => setOpenGalaxyConfigDrawer(true)
           }, [

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -21,7 +21,7 @@ import { reportError, withErrorReporting } from 'src/libs/error'
 import { versionTag } from 'src/libs/logos'
 import * as Nav from 'src/libs/nav'
 import { notify } from 'src/libs/notifications'
-import { appIsSettingUp, convertedAppStatus, currentApp, currentDataDisk, getGalaxyCost } from 'src/libs/runtime-utils'
+import { appIsSettingUp, convertedAppStatus, currentApp, currentAttachedDataDisk, getGalaxyCost } from 'src/libs/runtime-utils'
 import { authStore } from 'src/libs/state'
 import * as StateHistory from 'src/libs/state-history'
 import * as Style from 'src/libs/style'
@@ -310,7 +310,7 @@ const Notebooks = _.flow(
     )(notebooks)
 
     const getGalaxyText = (app, galaxyDataDisks) => {
-      const dataDisk = currentDataDisk(app, galaxyDataDisks)
+      const dataDisk = currentAttachedDataDisk(app, galaxyDataDisks)
       return app ?
         div({ style: { fontSize: 18, lineHeight: '22px', width: 160 } }, [
           div(['Galaxy Interactive']),

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -21,7 +21,7 @@ import { reportError, withErrorReporting } from 'src/libs/error'
 import { versionTag } from 'src/libs/logos'
 import * as Nav from 'src/libs/nav'
 import { notify } from 'src/libs/notifications'
-import { appIsSettingUp, convertedAppStatus, currentApp, currentAttachedDataDisk, getGalaxyCost } from 'src/libs/runtime-utils'
+import { appIsSettingUp, convertedAppStatus, currentApp, currentAttachedDataDisk, currentPersistentDiskIncludingUnattached, getGalaxyCost } from 'src/libs/runtime-utils'
 import { authStore } from 'src/libs/state'
 import * as StateHistory from 'src/libs/state-history'
 import * as Style from 'src/libs/style'
@@ -357,8 +357,8 @@ const Notebooks = _.flow(
             style: {
               ...Style.elements.card.container, height: 125, marginTop: 15
             },
-            disabled: appIsSettingUp(app),
-            tooltip: appIsSettingUp(app) && 'Galaxy app is being created',
+            disabled: appIsSettingUp(app) || _.last(currentPersistentDiskIncludingUnattached(apps, galaxyDataDisks)),
+            tooltip: (appIsSettingUp(app) && 'Galaxy app is being created') || (_.last(currentPersistentDiskIncludingUnattached(apps, galaxyDataDisks)) && 'Your persistent disk is still attached to your previous app; you can create a new app once your previous app finishes deleting, which will take a few minutes.'),
             onClick: () => setOpenGalaxyConfigDrawer(true)
           }, [
             getGalaxyText(app, galaxyDataDisks)


### PR DESCRIPTION
This PR adds two features: Galaxy persistence when creating a Galaxy app and adds Galaxy apps + disks to the "Cloud Environments" page

Galaxy persistence was tested by creating a galaxy app, deleting it, recreating an app and then checking that the data disk and postgres disk from the first app get re-attached to the new app. This PR also disables changing the PD size upon Galaxy creation if the user has an existing persistent disk that is currently detached. When a user goes to delete their Galaxy app they get the following warning screen and get to choose whether or not to keep their persistent disk:
<img width="666" alt="Screen Shot 2021-04-29 at 2 55 46 PM" src="https://user-images.githubusercontent.com/23626109/116603608-1a834400-a8fb-11eb-9c46-b3c2a14502d4.png">
The majority of these code changes live in `NewGalaxyModal.js`

The second part of this PR focuses on the "Cloud Environments" page and was tested by validating that apps now show up in the "Your cloud environments" table and that galaxy disks show up in the "Your persistent disks" table. This PR also adds a column to the "Your cloud environments" table names "Type" which displays what type (GCE, Dataproc, or Galaxy) of cloud environment that row is representing. The changes look like this:
<img width="1786" alt="Screen Shot 2021-04-29 at 2 56 13 PM" src="https://user-images.githubusercontent.com/23626109/116603645-253dd900-a8fb-11eb-8831-eaa85cc64c5c.png">
The majority of these changes live in `Environments.js`

There are still 3 todos that I'm working on that are super minor:
~~1) There's a bug when clicking on the red warning triangle for error'd galaxy apps in the cloud environments page~~ This is fixed. see screenshot below:
![Screen Shot 2021-04-29 at 5 32 18 PM](https://user-images.githubusercontent.com/23626109/116622386-9b9a0580-a912-11eb-935e-4d40c56be3ed.png)

~~2) There's a bug in displaying the yellow warning triangle for having more than one persistent disk in the same billing project. need to get this logic right since a user can now have both a galaxy disk and a GCE VM disk in the same billing project~~ This is fixed, see screenshot below
![Screen Shot 2021-05-04 at 12 02 23 PM](https://user-images.githubusercontent.com/23626109/117033680-99e48f00-acd0-11eb-85d8-973a6ae8d8c0.png)

~~3) I would also like to add a tooltip to the persistent disk size selector in the `NewGalaxyModal` when it's disabled, explaining to users why it's disabled~~ This was implemented and the design was changed based on Joy's feedback. See screenshot below
![Screen Shot 2021-05-04 at 12 04 04 PM](https://user-images.githubusercontent.com/23626109/117033924-d57f5900-acd0-11eb-8e99-082fdf485e2d.png)

I will update this PR description as I work on these 3 todos.
I also need to fix all the indentation warnings