### PR TITLE
[IA-2719] Spark master machine type in Terra UI is not reflected in GCP

### DIFF
--- a/src/components/NewRuntimeModal.js
+++ b/src/components/NewRuntimeModal.js
@@ -347,7 +347,7 @@ export const NewRuntimeModal = withModalDrawer({ width: 675 })(class NewRuntimeM
                 diskSize: masterDiskSize
               })
             } : {
-              machineType: masterMachineType || defaultDataprocMachineType,
+              masterMachineType: masterMachineType || defaultDataprocMachineType,
               masterDiskSize,
               numberOfWorkers: desiredNumberOfWorkers,
               ...(desiredNumberOfWorkers && {


### PR DESCRIPTION
See https://broadworkbench.atlassian.net/browse/IA-2719

The fix is to specify `masterMachineType` instead of `machineType` as the key for Dataproc runtimes as that is the key used in the Dataproc case when creating a runtime.

Tested locally by creating Dataproc + GCE runtimes with different settings, and validating the POST request payload.