### PR TITLE
[SATURN-1901] Allow metadata files with a .txt extension, in addition to .tsv, in the uploader

### DIFF
--- a/src/pages/Upload.js
+++ b/src/pages/Upload.js
@@ -635,7 +635,7 @@ const MetadataUploadPanel = _.flow(
       activeStyle: { backgroundColor: colors.accent(0.2), cursor: 'copy' },
       multiple: false,
       maxFiles: 1,
-      accept: '.tsv',
+      accept: '.tsv, .txt',
       onDropAccepted: ([file]) => {
         setMetadataFile(file)
       },
@@ -652,7 +652,7 @@ const MetadataUploadPanel = _.flow(
             color: colors.dark(0.75), width: '100%', margin: '2rem 0', textAlign: 'center',
             fontSize: '1.5em'
           }
-        }, ['Drag and drop your metadata .tsv file here']),
+        }, ['Drag and drop your metadata .tsv or .txt file here']),
         !Utils.editWorkspaceError(workspace) && h(FloatingActionButton, {
           label: 'UPLOAD',
           iconShape: 'plus',


### PR DESCRIPTION
My understanding is that both `.tsv` and `.txt` files have the same format; only the extension is different.

---

*Note*: until Broad finishes setting up my Github access, I am still submitting these PRs from a fork. Consequently, the CircleCI integration tests won't run, for security reasons. In order to merge this a Broad employee will need to either run the CI tests manually, or merge this PR into a branch you create so CircleCI can do it's thing.