### PR TITLE
Use ram disk for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,7 @@ commands:
                 name: Deploy << parameters.env >>
                 command: gcloud app deploy --project=bvdp-saturn-<< parameters.env >> --promote --quiet
   integration-tests:
+    working_directory: /mnt/ramdisk
     parameters:
       local:
         type: boolean
@@ -113,6 +114,7 @@ commands:
 jobs:
   build:
     executor: node
+    working_directory: /mnt/ramdisk
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,14 +65,14 @@ commands:
           at: .
       - restore_cache:
           keys:
-            - test-deps6-{{ checksum "integration-tests/package.json" }}-{{ checksum "integration-tests/yarn.lock" }}
-            - test-deps6-{{ checksum "integration-tests/package.json" }}-
-            - test-deps6-
+            - test-deps7-{{ checksum "integration-tests/package.json" }}-{{ checksum "integration-tests/yarn.lock" }}
+            - test-deps7-{{ checksum "integration-tests/package.json" }}-
+            - test-deps7-
       - run:
           working_directory: integration-tests
           command: yarn install --frozen-lockfile
       - save_cache:
-          key: test-deps6-{{ checksum "integration-tests/package.json" }}-{{ checksum "integration-tests/yarn.lock" }}
+          key: test-deps7-{{ checksum "integration-tests/package.json" }}-{{ checksum "integration-tests/yarn.lock" }}
           paths:
             - integration-tests/node_modules
       - when:
@@ -118,12 +118,12 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - deps5-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
-            - deps5-{{ checksum "package.json" }}-
-            - deps5-
+            - deps6-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
+            - deps6-{{ checksum "package.json" }}-
+            - deps6-
       - run: yarn install --frozen-lockfile
       - save_cache:
-          key: deps5-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
+          key: deps6-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
           paths:
             - node_modules
       - run: yarn test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,10 +5,12 @@ orbs:
 
 executors:
   node:
+    working_directory: /mnt/ramdisk
     docker:
       - image: node:12
         user: node
   puppeteer:
+    working_directory: /mnt/ramdisk
     docker:
       - image: circleci/node:12-browsers
   gcloud:
@@ -113,7 +115,6 @@ commands:
 jobs:
   build:
     executor: node
-    working_directory: /mnt/ramdisk
     steps:
       - checkout
       - restore_cache:
@@ -171,21 +172,18 @@ jobs:
           channel: "C7H40L71D" # dsde-qa-notify
   integration-tests-branch-against-dev:
     executor: puppeteer
-    working_directory: /mnt/ramdisk
     steps:
       - integration-tests:
           local: true
           env: local
   integration-tests-alpha:
     executor: puppeteer
-    working_directory: /mnt/ramdisk
     steps:
       - integration-tests:
           env: alpha
       - notify-qa
   integration-tests-staging:
     executor: puppeteer
-    working_directory: /mnt/ramdisk
     steps:
       - integration-tests:
           env: staging

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,6 @@ commands:
                 name: Deploy << parameters.env >>
                 command: gcloud app deploy --project=bvdp-saturn-<< parameters.env >> --promote --quiet
   integration-tests:
-    working_directory: /mnt/ramdisk
     parameters:
       local:
         type: boolean
@@ -172,18 +171,21 @@ jobs:
           channel: "C7H40L71D" # dsde-qa-notify
   integration-tests-branch-against-dev:
     executor: puppeteer
+    working_directory: /mnt/ramdisk
     steps:
       - integration-tests:
           local: true
           env: local
   integration-tests-alpha:
     executor: puppeteer
+    working_directory: /mnt/ramdisk
     steps:
       - integration-tests:
           env: alpha
       - notify-qa
   integration-tests-staging:
     executor: puppeteer
+    working_directory: /mnt/ramdisk
     steps:
       - integration-tests:
           env: staging

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ executors:
     docker:
       - image: circleci/node:12-browsers
   gcloud:
+    working_directory: /mnt/ramdisk
     docker:
       - image: google/cloud-sdk:alpine
 


### PR DESCRIPTION
This switches jobs on circle to run in the ram disk that they attach to all docker executors. This makes disk-intensive steps complete in the same amount of time every run.