### PR TITLE
Download via accessUrl if found BT-196

### DIFF
--- a/src/components/UriViewer.js
+++ b/src/components/UriViewer.js
@@ -120,7 +120,7 @@ const DownloadButton = ({ uri, metadata: { bucket, name, fileName, size }, acces
         const { url } = await Ajax(signal).Martha.getSignedUrl({
           bucket,
           object: name,
-          dataObjectUri: isDrs(uri) ? uri : null
+          dataObjectUri: isDrs(uri) ? uri : undefined
         })
         const workspace = workspaceStore.get()
         const userProject = await getUserProjectForWorkspace(workspace)

--- a/src/components/UriViewer.js
+++ b/src/components/UriViewer.js
@@ -1,5 +1,3 @@
-// noinspection RegExpUnnecessaryNonCapturingGroup
-
 import filesize from 'filesize'
 import _ from 'lodash/fp'
 import { Fragment, useState } from 'react'
@@ -107,7 +105,7 @@ const DownloadButton = ({ uri, metadata: { bucket, name, fileName, size }, acces
   const signal = Utils.useCancellation()
   const [url, setUrl] = useState()
   const getUrl = async () => {
-    if (accessUrl && accessUrl.url) {
+    if (accessUrl?.url) {
       /*
       NOTE: Not supporting downloading using `accessUrl.headers`:
       - https://ga4gh.github.io/data-repository-service-schemas/preview/release/drs-1.1.0/docs/#_accessurl
@@ -122,7 +120,7 @@ const DownloadButton = ({ uri, metadata: { bucket, name, fileName, size }, acces
         const { url } = await Ajax(signal).Martha.getSignedUrl({
           bucket,
           object: name,
-          dataObjectUri: isDrs(uri) && uri
+          dataObjectUri: isDrs(uri) ? uri : null
         })
         const workspace = workspaceStore.get()
         const userProject = await getUserProjectForWorkspace(workspace)
@@ -206,7 +204,7 @@ const UriViewer = _.flow(
 
   const { size, timeCreated, updated, bucket, name, fileName, accessUrl } = metadata || {}
   const gsUri = `gs://${bucket}/${name}`
-  const downloadCommand = getDownloadCommand(fileName, gsUri, accessUrl)
+  const downloadCommand = getDownloadCommand(_.pickBy(_.identity, ({ fileName, gsUri, accessUrl })))
   return h(Modal, {
     onDismiss,
     title: 'File Details',

--- a/src/components/UriViewer.js
+++ b/src/components/UriViewer.js
@@ -204,7 +204,7 @@ const UriViewer = _.flow(
 
   const { size, timeCreated, updated, bucket, name, fileName, accessUrl } = metadata || {}
   const gsUri = `gs://${bucket}/${name}`
-  const downloadCommand = getDownloadCommand(_.pickBy(_.identity, ({ fileName, gsUri, accessUrl })))
+  const downloadCommand = getDownloadCommand(fileName, gsUri, accessUrl)
   return h(Modal, {
     onDismiss,
     title: 'File Details',

--- a/src/components/UriViewer.js
+++ b/src/components/UriViewer.js
@@ -230,7 +230,7 @@ const UriViewer = _.flow(
         ]),
         h(PreviewContent, { uri, metadata, googleProject }),
         els.cell([els.label('File size'), els.data(filesize(size))]),
-        !accessUrl && gsUri && els.cell([
+        !accessUrl && !!gsUri && els.cell([
           h(Link, {
             ...Utils.newTabLinkProps,
             href: bucketBrowserUrl(gsUri.match(/gs:\/\/(.+)\//)[1])

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -38,6 +38,7 @@ export const parseGsUri = uri => _.drop(1, /gs:[/][/]([^/]+)[/](.+)/.exec(uri))
 
 export const getDownloadCommand = (fileName, gsUri, accessUrl) => {
   const { url: httpUrl, headers: httpHeaders } = accessUrl || {}
+
   if (httpUrl) {
     const headers = _.flow(
       _.toPairs,
@@ -46,6 +47,7 @@ export const getDownloadCommand = (fileName, gsUri, accessUrl) => {
     const output = fileName ? `-o '${fileName}' ` : '-O '
     return `curl ${headers}${output}'${httpUrl}'`
   }
+
   if (gsUri) {
     return `gsutil cp ${gsUri} ${fileName || '.'}`
   }

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -36,8 +36,17 @@ const errorTextStyle = { color: colors.danger(), fontWeight: 'bold', fontSize: 1
 
 export const parseGsUri = uri => _.drop(1, /gs:[/][/]([^/]+)[/](.+)/.exec(uri))
 
-export const getDownloadCommand = (fileName, gsUri, accessUrl) => {
-  if (accessUrl && accessUrl.url) {
+export const getDownloadCommand = (
+  {
+    fileName,
+    gsUri,
+    accessUrl: {
+      url: httpUrl = null,
+      headers: httpHeaders = null
+    } = {}
+  }
+) => {
+  if (httpUrl) {
     const headers = _.flow(
       _.toPairs,
       _.reduce(
@@ -46,9 +55,9 @@ export const getDownloadCommand = (fileName, gsUri, accessUrl) => {
         },
         ''
       )
-    )(accessUrl.headers || {})
+    )(httpHeaders)
     const output = fileName ? `-O '${fileName}' ` : ''
-    return `wget ${headers}${output}'${accessUrl.url}'`
+    return `wget ${headers}${output}'${httpUrl}'`
   }
   if (gsUri) {
     return `gsutil cp ${gsUri} ${fileName || '.'}`

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -36,6 +36,25 @@ const errorTextStyle = { color: colors.danger(), fontWeight: 'bold', fontSize: 1
 
 export const parseGsUri = uri => _.drop(1, /gs:[/][/]([^/]+)[/](.+)/.exec(uri))
 
+export const getDownloadCommand = (fileName, gsUri, accessUrl) => {
+  if (accessUrl && accessUrl.url) {
+    const headers = _.flow(
+      _.toPairs,
+      _.reduce(
+        (headers, [header, value]) => {
+          return `${headers}--header='${header}: ${value}' `
+        },
+        ''
+      )
+    )(accessUrl.headers || {})
+    const output = fileName ? `-O '${fileName}' ` : ''
+    return `wget ${headers}${output}'${accessUrl.url}'`
+  }
+  if (gsUri) {
+    return `gsutil cp ${gsUri} ${fileName || '.'}`
+  }
+}
+
 export const getUserProjectForWorkspace = async workspace => (workspace && await canUseWorkspaceProject(workspace)) ?
   workspace.workspace.namespace :
   requesterPaysProjectStore.get()

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -36,28 +36,15 @@ const errorTextStyle = { color: colors.danger(), fontWeight: 'bold', fontSize: 1
 
 export const parseGsUri = uri => _.drop(1, /gs:[/][/]([^/]+)[/](.+)/.exec(uri))
 
-export const getDownloadCommand = (
-  {
-    fileName,
-    gsUri,
-    accessUrl: {
-      url: httpUrl = null,
-      headers: httpHeaders = null
-    } = {}
-  }
-) => {
+export const getDownloadCommand = (fileName, gsUri, accessUrl) => {
+  const { url: httpUrl, headers: httpHeaders } = accessUrl || {}
   if (httpUrl) {
     const headers = _.flow(
       _.toPairs,
-      _.reduce(
-        (headers, [header, value]) => {
-          return `${headers}--header='${header}: ${value}' `
-        },
-        ''
-      )
+      _.reduce((acc, [header, value]) => `${acc}-H '${header}: ${value}' `, '')
     )(httpHeaders)
-    const output = fileName ? `-O '${fileName}' ` : ''
-    return `wget ${headers}${output}'${httpUrl}'`
+    const output = fileName ? `-o '${fileName}' ` : '-O '
+    return `curl ${headers}${output}'${httpUrl}'`
   }
   if (gsUri) {
     return `gsutil cp ${gsUri} ${fileName || '.'}`


### PR DESCRIPTION
Checked functionality in my local Chrome browser using a combo of `yarn start`, terra-dev, and a hacked-up local copy of `getSignedUrlv1` and `martha_v3`. The latter cloud function was repeatedly modified to returned various `accessUrl` entries w/ and w/o [headers](https://ga4gh.github.io/data-repository-service-schemas/preview/release/drs-1.1.0/docs/#_accessurl).

<!--
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Thanks!
--!>
