### PR TITLE
Wait for workspace list to load when testing

### DIFF
--- a/integration-tests/tests/preview-drs-uri.js
+++ b/integration-tests/tests/preview-drs-uri.js
@@ -23,6 +23,7 @@ const testPreviewDrsUriFn = _.flow(
   await createEntityInWorkspace(page, billingProject, workspaceName, testEntity)
 
   await click(page, clickable({ textContains: 'View Workspaces' }))
+  await waitForNoSpinners(page)
   await fillIn(page, input({ placeholder: 'SEARCH WORKSPACES' }), workspaceName)
   await click(page, clickable({ textContains: workspaceName }))
 

--- a/integration-tests/tests/run-workflow.js
+++ b/integration-tests/tests/run-workflow.js
@@ -19,6 +19,7 @@ const testRunWorkflowFn = _.flow(
   await createEntityInWorkspace(page, billingProject, workspaceName, testEntity)
 
   await click(page, clickable({ textContains: 'View Workspaces' }))
+  await waitForNoSpinners(page)
   await fillIn(page, input({ placeholder: 'SEARCH WORKSPACES' }), workspaceName)
   await click(page, clickable({ textContains: workspaceName }))
 


### PR DESCRIPTION
I noticed that one difference between these tests, which often fail because they don't actually open the workspace when they think they've clicked it in the list, and those that _don't_ have this problem, is that they actually wait to make sure there's no spinners...