### PR TITLE
No multiple runners for overnight tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,14 +181,12 @@ jobs:
           env: local
   integration-tests-alpha:
     executor: puppeteer
-    parallelism: 4
     steps:
       - integration-tests:
           env: alpha
       - notify-qa
   integration-tests-staging:
     executor: puppeteer
-    parallelism: 4
     steps:
       - integration-tests:
           env: staging


### PR DESCRIPTION
Multiple runners for the overnight tests were reporting multiple times to slack. Since it doesn't matter if the overnight tests take a bit longer, remove them.