### PR TITLE
AS-757: Fix editing and deleting entities for entity types that are equivalent when ignoring case

### DIFF
--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -327,7 +327,7 @@ const DataTable = props => {
       onDismiss: () => setViewData(undefined)
     }, [div({ style: { maxHeight: '80vh', overflowY: 'auto' } }, [displayData(viewData)])]),
     renamingEntity !== undefined && h(EntityRenamer, {
-      entityType: _.flow(_.filter(entity => entity.name == renamingEntity), _.first, _.get('entityType'))(entities),
+      entityType: _.flow(_.filter(entity => entity.name === renamingEntity), _.first, _.get('entityType'))(entities),
       entityName: renamingEntity,
       workspaceId,
       onSuccess: () => {

--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -327,7 +327,7 @@ const DataTable = props => {
       onDismiss: () => setViewData(undefined)
     }, [div({ style: { maxHeight: '80vh', overflowY: 'auto' } }, [displayData(viewData)])]),
     renamingEntity !== undefined && h(EntityRenamer, {
-      entityType: _.flow(_.filter(entity => entity.name === renamingEntity), _.first, _.get('entityType'))(entities),
+      entityType: _.find(entity => entity.name === renamingEntity, entities).entityType,
       entityName: renamingEntity,
       workspaceId,
       onSuccess: () => {
@@ -337,7 +337,7 @@ const DataTable = props => {
       onDismiss: () => setRenamingEntity(undefined)
     }),
     !!updatingEntity && h(EntityEditor, {
-      entityType: _.flow(_.filter(entity => entity.name === updatingEntity['entityName']), _.first, _.get('entityType'))(entities),
+      entityType: _.find(entity => entity.name === updatingEntity.entityName, entities).entityType,
       ...updatingEntity,
       entityTypes: _.keys(entityMetadata),
       workspaceId,

--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -337,7 +337,7 @@ const DataTable = props => {
       onDismiss: () => setRenamingEntity(undefined)
     }),
     !!updatingEntity && h(EntityEditor, {
-      entityType: _.flow(_.filter(entity => entity.name == updatingEntity['entityName']), _.first, _.get('entityType'))(entities),
+      entityType: _.flow(_.filter(entity => entity.name === updatingEntity['entityName']), _.first, _.get('entityType'))(entities),
       ...updatingEntity,
       entityTypes: _.keys(entityMetadata),
       workspaceId,

--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -327,7 +327,8 @@ const DataTable = props => {
       onDismiss: () => setViewData(undefined)
     }, [div({ style: { maxHeight: '80vh', overflowY: 'auto' } }, [displayData(viewData)])]),
     renamingEntity !== undefined && h(EntityRenamer, {
-      entityType, entityName: renamingEntity,
+      entityType: _.flow(_.filter(entity => entity.name == renamingEntity), _.first, _.get('entityType'))(entities),
+      entityName: renamingEntity,
       workspaceId,
       onSuccess: () => {
         setRenamingEntity(undefined)
@@ -336,7 +337,8 @@ const DataTable = props => {
       onDismiss: () => setRenamingEntity(undefined)
     }),
     !!updatingEntity && h(EntityEditor, {
-      entityType, ...updatingEntity,
+      entityType: _.flow(_.filter(entity => entity.name == updatingEntity['entityName']), _.first, _.get('entityType'))(entities),
+      ...updatingEntity,
       entityTypes: _.keys(entityMetadata),
       workspaceId,
       onSuccess: () => {

--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -386,7 +386,7 @@ const EntitiesContent = ({
           loadMetadata()
         },
         namespace, name,
-        selectedEntities: selectedKeys, selectedDataType: entityKey, runningSubmissionsCount
+        selectedEntities: selectedEntities, selectedDataType: entityKey, runningSubmissionsCount
       }),
       copyingEntities && h(ExportDataModal, {
         onDismiss: () => setCopyingEntities(false),

--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -386,7 +386,7 @@ const EntitiesContent = ({
           loadMetadata()
         },
         namespace, name,
-        selectedEntities: selectedEntities, selectedDataType: entityKey, runningSubmissionsCount
+        selectedEntities, selectedDataType: entityKey, runningSubmissionsCount
       }),
       copyingEntities && h(ExportDataModal, {
         onDismiss: () => setCopyingEntities(false),

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -155,7 +155,7 @@ export const EntityDeleter = ({ onDismiss, onSuccess, namespace, name, selectedE
   const selectedKeys = _.keys(selectedEntities)
 
   const doDelete = async () => {
-    const entitiesToDelete = _.concat(_.map(entity => ({ entityName: entity['name'], entityType: entity['entityType'] }), selectedEntities), additionalDeletions)
+    const entitiesToDelete = _.concat(_.map(entity => ({ entityName: entity.name, entityType: entity.entityType }), selectedEntities), additionalDeletions)
 
     setDeleting(true)
 

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -155,7 +155,10 @@ export const EntityDeleter = ({ onDismiss, onSuccess, namespace, name, selectedE
   const selectedKeys = _.keys(selectedEntities)
 
   const doDelete = async () => {
-    const entitiesToDelete = _.concat(_.map(entity => ({ entityName: entity.name, entityType: entity.entityType }), selectedEntities), additionalDeletions)
+    const entitiesToDelete = _.flow(
+      _.map(({ name: entityName, entityType }) => ({ entityName, entityType })),
+      entities => _.concat(entities, additionalDeletions)
+    )(selectedEntities)
 
     setDeleting(true)
 

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -152,8 +152,10 @@ export const EntityDeleter = ({ onDismiss, onSuccess, namespace, name, selectedE
   const [additionalDeletions, setAdditionalDeletions] = useState([])
   const [deleting, setDeleting] = useState(false)
 
+  const selectedKeys = _.keys(selectedEntities)
+
   const doDelete = async () => {
-    const entitiesToDelete = _.concat(_.map(entityName => ({ entityName, entityType: selectedDataType }), selectedEntities), additionalDeletions)
+    const entitiesToDelete = _.concat(_.map(entity => ({ entityName: entity['name'], entityType: entity['entityType'] }), selectedEntities), additionalDeletions)
 
     setDeleting(true)
 
@@ -181,7 +183,7 @@ export const EntityDeleter = ({ onDismiss, onSuccess, namespace, name, selectedE
     margin: '0 -1.25rem'
   }
 
-  const total = selectedEntities.length + additionalDeletions.length
+  const total = selectedKeys.length + additionalDeletions.length
   return h(Modal, {
     onDismiss,
     title: 'Confirm Delete',
@@ -205,7 +207,7 @@ export const EntityDeleter = ({ onDismiss, onSuccess, namespace, name, selectedE
         padding: '0.6rem 1.25rem', margin: '0 -1.25rem'
       }
     }, moreToDelete ? `${entity.entityName} (${entity.entityType})` : entity),
-    Utils.toIndexPairs(moreToDelete ? additionalDeletions : selectedEntities)),
+    Utils.toIndexPairs(moreToDelete ? additionalDeletions : selectedKeys)),
     div({
       style: { ...fullWidthWarning, textAlign: 'right' }
     }, [`${total} data ${total > 1 ? 'entries' : 'entry'} to be deleted.`]),


### PR DESCRIPTION
Case sensitivity for entity types is interesting! 

In the rawls db, entity types are saved preserving their case. But entity names have to be unique across entity types ignoring case. Meaning that if I have an entity of type "sample" and name "entity1" already saved, I cannot create another entity of type "sAmple" and name "entity1" - it fails due to a db uniqueness violation. But I _can_ create an entity of type "sAmple" and name "entity2".

The UI fixes here are minimal - just enough to fix the errors the user is seeing without changing expected behavior. The fix involves sending in the entity's actual type (with the correct case) when deleting or editing the entity. 

In the future, we may want to reassess entity type cases - though the backend preserves cases for entity types, the UI does not. For example, an entity of type "sample" and type "sAmple" are shown as the same type in the UI.