### PR TITLE
Allow some calls to not have start dates [BW-712]

### DIFF
--- a/src/pages/workspaces/workspace/jobHistory/WorkflowDashboard.js
+++ b/src/pages/workspaces/workspace/jobHistory/WorkflowDashboard.js
@@ -118,7 +118,11 @@ const WorkflowDashboard = _.flow(
     }), simplifiedFailures)
   }
 
-  const callNames = _.sortBy(callName => _.minBy('start', calls[callName]).start, _.keys(calls))
+  const getFirstStart = callName => {
+    const earliestCall = _.minBy('start', calls[callName])
+    return earliestCall ? earliestCall.start : new Date()
+  }
+  const callNames = _.sortBy(getFirstStart, _.keys(calls))
 
   return div({ style: { padding: '1rem 2rem 2rem', flex: 1, display: 'flex', flexDirection: 'column' } }, [
     workflowDetailsBreadcrumbSubtitle(namespace, name, submissionId, workflowId),

--- a/src/pages/workspaces/workspace/jobHistory/WorkflowDashboard.js
+++ b/src/pages/workspaces/workspace/jobHistory/WorkflowDashboard.js
@@ -118,11 +118,7 @@ const WorkflowDashboard = _.flow(
     }), simplifiedFailures)
   }
 
-  const getFirstStart = callName => {
-    const earliestCall = _.minBy('start', calls[callName])
-    return earliestCall ? earliestCall.start : new Date()
-  }
-  const callNames = _.sortBy(getFirstStart, _.keys(calls))
+  const callNames = _.sortBy(callName => _.min(_.map('start', calls[callName])), _.keys(calls))
 
   return div({ style: { padding: '1rem 2rem 2rem', flex: 1, display: 'flex', flexDirection: 'column' } }, [
     workflowDetailsBreadcrumbSubtitle(namespace, name, submissionId, workflowId),


### PR DESCRIPTION
Tested locally with a "recreation" workflow on `dev`: http://localhost:3000/#workspaces/general-dev-billing-account/cjl_test_workspace/job_history/0236a12b-0af0-46c1-a8f7-8f5d5cc1b99a/74d8ac0f-024e-4950-b93a-de447b44829c