### PR TITLE
Set 'deletionDelayYears' to 3 years [BW-581]

### DIFF
--- a/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
+++ b/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
@@ -115,7 +115,7 @@ const SubmissionDetails = _.flow(
 
   // Note: This 'deleteLimitYears' value should reflect the current 'deletion-delay' value configured for PROD in firecloud-develop's
   // 'cromwell.conf.ctmpl' file:
-  const deletionDelayYears = 6
+  const deletionDelayYears = 3
   const deletionDelayString = `${deletionDelayYears} year${deletionDelayYears > 1 ? 's' : ''}`
   const isDeleted = statusLastChangedDate => differenceInDays(parseISO(statusLastChangedDate), Date.now()) > (deletionDelayYears * 365)
 

--- a/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
+++ b/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
@@ -113,7 +113,7 @@ const SubmissionDetails = _.flow(
 
   const { succeeded, failed, running, submitted } = _.groupBy(wf => collapseStatus(wf.status), workflows)
 
-  // Note: This 'deleteLimitYears' value should reflect the current 'deletion-delay' value configured for PROD in firecloud-develop's
+  // Note: This 'deletionDelayYears' value should reflect the current 'deletion-delay' value configured for PROD in firecloud-develop's
   // 'cromwell.conf.ctmpl' file:
   const deletionDelayYears = 3
   const deletionDelayString = `${deletionDelayYears} year${deletionDelayYears > 1 ? 's' : ''}`


### PR DESCRIPTION
To test this, I updated the limit to 1 year and tested against alpha environment (this is because I don't know of workflows that ran 3 years ago in test envs that can be used for this)

user: dumbledore.admin@test.firecloud.org
workspace: cromwell-tests-workspace
submission id: ef5b6712-58a2-4bbe-80f2-9b7fb9cdf33d
status last updated: Mar 18, 2020, 1:37 PM


![Screen Shot 2021-06-01 at 11 23 22 AM](https://user-images.githubusercontent.com/16748522/120349133-d7d2d400-c2cb-11eb-9f55-e594065e30e2.png)


![Screen Shot 2021-06-01 at 11 23 40 AM](https://user-images.githubusercontent.com/16748522/120349117-d4d7e380-c2cb-11eb-931e-dc00abfd751b.png)
