### PR TITLE
[CA-1308] A11y: Library pages

### DIFF
--- a/src/pages/library/Code.js
+++ b/src/pages/library/Code.js
@@ -36,9 +36,9 @@ export const MethodCard = ({ method: { name, synopsis }, ...props }) => {
       position: 'relative'
     }
   }, [
-    div({ style: { flex: 1, padding: '15px 20px' } }, [
+    div({ style: { flex: 'none', padding: '15px 20px', height: 140 } }, [
       div({ style: { color: colors.accent(), fontSize: 16, lineHeight: '20px', height: 40, marginBottom: 7 } }, [name]),
-      div({ style: { lineHeight: '20px', height: 100, whiteSpace: 'pre-wrap', overflow: 'hidden' } }, [synopsis])
+      div({ style: { lineHeight: '20px', ...Style.noWrapEllipsis, whiteSpace: 'pre-wrap', height: 60 } }, [synopsis])
     ]),
     wdlIcon({ style: { position: 'absolute', top: 0, right: 8 } })
   ])
@@ -61,7 +61,10 @@ export const DockstoreTile = () => {
   return div({ style: { display: 'flex' } }, [
     h(LogoTile, { logoFile: dockstoreLogo, style: { backgroundColor: 'white' } }),
     div([
-      h(Link, { href: `${getConfig().dockstoreUrlRoot}/search?_type=workflow&descriptorType=WDL&searchMode=files` }, 'Dockstore'),
+      h(Link, {
+        href: `${getConfig().dockstoreUrlRoot}/search?_type=workflow&descriptorType=WDL&searchMode=files`,
+        style: { color: colors.accent(1.1) } // For a11y, we need at least 4.5:1 contrast against the gray background
+      }, 'Dockstore'),
       div(['Browse WDL workflows in Dockstore, an open platform used by the GA4GH for sharing Docker-based workflows'])
     ])
   ])
@@ -71,7 +74,10 @@ export const MethodRepoTile = () => {
   return div({ style: { display: 'flex' } }, [
     h(LogoTile, { logoFile: broadSquare, style: { backgroundSize: 37 } }),
     div([
-      h(Link, { href: `${getConfig().firecloudUrlRoot}/?return=${returnParam()}#methods` }, 'Broad Methods Repository'),
+      h(Link, {
+        href: `${getConfig().firecloudUrlRoot}/?return=${returnParam()}#methods`,
+        style: { color: colors.accent(1.1) } // For a11y, we need at least 4.5:1 contrast agaisnst the gray background
+      }, 'Broad Methods Repository'),
       div([`Use Broad workflows in ${getAppName()}. Share your own, or choose from > 700 public workflows`])
     ])
   ])

--- a/src/pages/library/Datasets.js
+++ b/src/pages/library/Datasets.js
@@ -117,7 +117,8 @@ const thousandGenomesHighCoverage = () => h(Participant, {
 }, [
   h(ButtonPrimary, {
     href: Nav.getLink('workspace-dashboard', { namespace: 'anvil-datastorage', name: '1000G-high-coverage-2019' }),
-    tooltip: 'Visit the workspace'
+    tooltip: 'Visit the workspace',
+    'aria-label': 'Browse 1000 Genomes High Coverage data'
   }, ['Browse data'])
 ])
 
@@ -135,7 +136,7 @@ const thousandGenomesLowCoverage = () => h(Participant, {
   h(ButtonPrimary, {
     href: Nav.getLink('data-explorer-public', { dataset: '1000 Genomes' }),
     tooltip: browseTooltip,
-    'aria-label': 'Browse 1000 Genomes Low Coverage'
+    'aria-label': 'Browse 1000 Genomes Low Coverage data'
   }, ['Browse data'])
 ])
 
@@ -168,10 +169,12 @@ const amppd = () => h(Participant, {
 }, [
   h(ButtonPrimary, {
     style: { marginBottom: '1rem' },
-    href: Nav.getLink('data-explorer-private', { dataset: 'AMP PD Clinical - 2020_v2release_1218' })
+    href: Nav.getLink('data-explorer-private', { dataset: 'AMP PD Clinical - 2020_v2release_1218' }),
+    'aria-label': 'Browse AMP-PD Tier 1 data'
   }, ['Browse Tier 1 Data']),
   h(ButtonPrimary, {
-    href: Nav.getLink('data-explorer-private', { dataset: 'AMP PD - 2020_v2release_1218' })
+    href: Nav.getLink('data-explorer-private', { dataset: 'AMP PD - 2020_v2release_1218' }),
+    'aria-label': 'Browse AMP-PD Tier 2 data'
   }, ['Browse Tier 2 Data'])
 ])
 
@@ -188,7 +191,8 @@ const baseline = () => h(Participant, {
   sizeText: 'Participants: > 2,500'
 }, [
   h(ButtonPrimary, {
-    href: Nav.getLink('data-explorer-private', { dataset: 'Baseline Health Study' })
+    href: Nav.getLink('data-explorer-private', { dataset: 'Baseline Health Study' }),
+    'aria-label': 'Browse Baseline Health Study data'
   }, ['Browse Data'])
 ])
 
@@ -202,7 +206,8 @@ const ccdg = () => h(Participant, {
   h(ButtonPrimary, {
     href: `${getConfig().firecloudUrlRoot}/?return=${returnParam()}&project=AnVIL CCDG&project=AnVIL CCDG CVD#library`,
     ...Utils.newTabLinkProps,
-    tooltip: browseTooltip
+    tooltip: browseTooltip,
+    'aria-label': 'Browse CCDG data'
   }, ['Browse data'])
 ])
 
@@ -216,7 +221,8 @@ const cmg = () => h(Participant, {
   h(ButtonPrimary, {
     href: `${getConfig().firecloudUrlRoot}/?return=${returnParam()}&project=AnVIL CMG#library`,
     ...Utils.newTabLinkProps,
-    tooltip: browseTooltip
+    tooltip: browseTooltip,
+    'aria-label': 'Browse CMG data'
   }, ['Browse Data'])
 ])
 
@@ -234,7 +240,8 @@ const encode = () => h(Participant, {
   h(ButtonPrimary, {
     href: 'https://broad-gdr-encode.appspot.com/',
     ...Utils.newTabLinkProps,
-    tooltip: browseTooltip
+    tooltip: browseTooltip,
+    'aria-label': 'Browse ENCODE data'
   }, ['Browse Data'])
 ])
 
@@ -248,7 +255,8 @@ const fcDataLib = () => h(Participant, {
   h(ButtonPrimary, {
     href: `${getConfig().firecloudUrlRoot}/?return=${returnParam()}#library`,
     ...Utils.newTabLinkProps,
-    tooltip: 'Search for dataset workspaces'
+    tooltip: 'Search for dataset workspaces',
+    'aria-label': 'Browse Broad Institute datasets'
   }, ['Browse Datasets'])
 ])
 
@@ -267,7 +275,8 @@ const framingham = () => h(Participant, {
 }, [
   h(ButtonPrimary, {
     href: Nav.getLink('data-explorer-public', { dataset: 'Framingham Heart Study Teaching Dataset' }),
-    tooltip: browseTooltip
+    tooltip: browseTooltip,
+    'aria-label': 'Browse Framingham Heart Study dataset'
   }, ['Browse data'])
 ])
 
@@ -281,7 +290,8 @@ const hca = () => h(Participant, {
   h(ButtonPrimary, {
     href: 'https://data.humancellatlas.org/explore/projects',
     ...Utils.newTabLinkProps,
-    tooltip: 'Look for the Export Selected Data button to export data from this provider.'
+    tooltip: 'Look for the Export Selected Data button to export data from this provider.',
+    'aria-label': 'Browse Human Cell Atlas data'
   }, ['Browse Data'])
 ])
 
@@ -296,7 +306,8 @@ const nemo = () => h(Participant, {
   h(ButtonPrimary, {
     href: 'http://portal.nemoarchive.org/',
     ...Utils.newTabLinkProps,
-    tooltip: 'Look for the Export to Terra option in the Download Cart to export data.'
+    tooltip: 'Look for the Export to Terra option in the Download Cart to export data.',
+    'aria-label': 'Browse Neuroscience Multi-Omic Archive data'
   }, ['Browse Data'])
 ])
 
@@ -311,7 +322,8 @@ const target = () => h(Participant, {
   sizeText: 'Participants: 1,324'
 }, [h(ButtonPrimary, {
   href: `${getConfig().firecloudUrlRoot}/?return=${returnParam()}&project=TARGET#library`,
-  ...Utils.newTabLinkProps
+  ...Utils.newTabLinkProps,
+  'aria-label': 'Browse TARGET data'
 }, ['Browse Data'])])
 
 
@@ -329,7 +341,8 @@ const tcga = () => h(Participant, {
 }, [
   h(ButtonPrimary, {
     href: `${getConfig().firecloudUrlRoot}/?return=${returnParam()}&project=TCGA#library`,
-    ...Utils.newTabLinkProps
+    ...Utils.newTabLinkProps,
+    'aria-label': 'Browse Cancer Genome Atlas data'
   }, ['Browse Data'])
 ])
 
@@ -344,7 +357,8 @@ const topMed = () => h(Participant, {
   h(ButtonPrimary, {
     href: 'https://gen3.biodatacatalyst.nhlbi.nih.gov/explorer',
     ...Utils.newTabLinkProps,
-    tooltip: browseTooltip
+    tooltip: browseTooltip,
+    'aria-label': 'Browse TopMed data'
   }, ['Browse Data'])
 ])
 
@@ -360,7 +374,8 @@ const ukb = () => h(Participant, {
   sizeText: 'Participants: > 500,000'
 }, [
   h(ButtonPrimary, {
-    href: Nav.getLink('data-explorer-private', { dataset: 'UK Biobank' })
+    href: Nav.getLink('data-explorer-private', { dataset: 'UK Biobank' }),
+    'aria-label': 'Browse UK BioBank data'
   }, ['Browse Data'])
 ])
 

--- a/src/pages/library/Datasets.js
+++ b/src/pages/library/Datasets.js
@@ -116,9 +116,9 @@ const thousandGenomesHighCoverage = () => h(Participant, {
   sizeText: 'Participants: 2,504'
 }, [
   h(ButtonPrimary, {
-    href: Nav.getLink('workspace-dashboard', { namespace: 'anvil-datastorage', name: '1000G-high-coverage-2019' }),
+    'aria-label': 'Browse 1000 Genomes High Coverage data',
     tooltip: 'Visit the workspace',
-    'aria-label': 'Browse 1000 Genomes High Coverage data'
+    href: Nav.getLink('workspace-dashboard', { namespace: 'anvil-datastorage', name: '1000G-high-coverage-2019' })
   }, ['Browse data'])
 ])
 
@@ -134,9 +134,9 @@ const thousandGenomesLowCoverage = () => h(Participant, {
   sizeText: 'Participants: 3,500'
 }, [
   h(ButtonPrimary, {
-    href: Nav.getLink('data-explorer-public', { dataset: '1000 Genomes' }),
+    'aria-label': 'Browse 1000 Genomes Low Coverage data',
     tooltip: browseTooltip,
-    'aria-label': 'Browse 1000 Genomes Low Coverage data'
+    href: Nav.getLink('data-explorer-public', { dataset: '1000 Genomes' })
   }, ['Browse data'])
 ])
 
@@ -168,13 +168,13 @@ const amppd = () => h(Participant, {
   sizeText: 'Participants: 10,247'
 }, [
   h(ButtonPrimary, {
+    'aria-label': 'Browse AMP-PD Tier 1 data',
     style: { marginBottom: '1rem' },
-    href: Nav.getLink('data-explorer-private', { dataset: 'AMP PD Clinical - 2020_v2release_1218' }),
-    'aria-label': 'Browse AMP-PD Tier 1 data'
+    href: Nav.getLink('data-explorer-private', { dataset: 'AMP PD Clinical - 2020_v2release_1218' })
   }, ['Browse Tier 1 Data']),
   h(ButtonPrimary, {
-    href: Nav.getLink('data-explorer-private', { dataset: 'AMP PD - 2020_v2release_1218' }),
-    'aria-label': 'Browse AMP-PD Tier 2 data'
+    'aria-label': 'Browse AMP-PD Tier 2 data',
+    href: Nav.getLink('data-explorer-private', { dataset: 'AMP PD - 2020_v2release_1218' })
   }, ['Browse Tier 2 Data'])
 ])
 
@@ -191,8 +191,8 @@ const baseline = () => h(Participant, {
   sizeText: 'Participants: > 2,500'
 }, [
   h(ButtonPrimary, {
-    href: Nav.getLink('data-explorer-private', { dataset: 'Baseline Health Study' }),
-    'aria-label': 'Browse Baseline Health Study data'
+    'aria-label': 'Browse Baseline Health Study data',
+    href: Nav.getLink('data-explorer-private', { dataset: 'Baseline Health Study' })
   }, ['Browse Data'])
 ])
 
@@ -204,10 +204,10 @@ const ccdg = () => h(Participant, {
   sizeText: 'Participants: > 65,000'
 }, [
   h(ButtonPrimary, {
-    href: `${getConfig().firecloudUrlRoot}/?return=${returnParam()}&project=AnVIL CCDG&project=AnVIL CCDG CVD#library`,
-    ...Utils.newTabLinkProps,
+    'aria-label': 'Browse CCDG data',
     tooltip: browseTooltip,
-    'aria-label': 'Browse CCDG data'
+    href: `${getConfig().firecloudUrlRoot}/?return=${returnParam()}&project=AnVIL CCDG&project=AnVIL CCDG CVD#library`,
+    ...Utils.newTabLinkProps
   }, ['Browse data'])
 ])
 
@@ -219,10 +219,10 @@ const cmg = () => h(Participant, {
   sizeText: 'Participants: > 5,000'
 }, [
   h(ButtonPrimary, {
-    href: `${getConfig().firecloudUrlRoot}/?return=${returnParam()}&project=AnVIL CMG#library`,
-    ...Utils.newTabLinkProps,
+    'aria-label': 'Browse CMG data',
     tooltip: browseTooltip,
-    'aria-label': 'Browse CMG data'
+    href: `${getConfig().firecloudUrlRoot}/?return=${returnParam()}&project=AnVIL CMG#library`,
+    ...Utils.newTabLinkProps
   }, ['Browse Data'])
 ])
 
@@ -238,10 +238,10 @@ const encode = () => h(Participant, {
   sizeText: 'Donors: > 650 ; Files: > 158,000'
 }, [
   h(ButtonPrimary, {
-    href: 'https://broad-gdr-encode.appspot.com/',
-    ...Utils.newTabLinkProps,
+    'aria-label': 'Browse ENCODE data',
     tooltip: browseTooltip,
-    'aria-label': 'Browse ENCODE data'
+    href: 'https://broad-gdr-encode.appspot.com/',
+    ...Utils.newTabLinkProps
   }, ['Browse Data'])
 ])
 
@@ -253,10 +253,10 @@ const fcDataLib = () => h(Participant, {
   sizeText: h(TooltipTrigger, { content: 'As of October 2018' }, [span('Samples: > 158,629')])
 }, [
   h(ButtonPrimary, {
-    href: `${getConfig().firecloudUrlRoot}/?return=${returnParam()}#library`,
-    ...Utils.newTabLinkProps,
+    'aria-label': 'Browse Broad Institute datasets',
     tooltip: 'Search for dataset workspaces',
-    'aria-label': 'Browse Broad Institute datasets'
+    href: `${getConfig().firecloudUrlRoot}/?return=${returnParam()}#library`,
+    ...Utils.newTabLinkProps
   }, ['Browse Datasets'])
 ])
 
@@ -274,9 +274,9 @@ const framingham = () => h(Participant, {
   sizeText: 'Participants: 4,400'
 }, [
   h(ButtonPrimary, {
-    href: Nav.getLink('data-explorer-public', { dataset: 'Framingham Heart Study Teaching Dataset' }),
+    'aria-label': 'Browse Framingham Heart Study dataset',
     tooltip: browseTooltip,
-    'aria-label': 'Browse Framingham Heart Study dataset'
+    href: Nav.getLink('data-explorer-public', { dataset: 'Framingham Heart Study Teaching Dataset' })
   }, ['Browse data'])
 ])
 
@@ -288,10 +288,10 @@ const hca = () => h(Participant, {
   monitoring, and treating disease.`
 }, [
   h(ButtonPrimary, {
-    href: 'https://data.humancellatlas.org/explore/projects',
-    ...Utils.newTabLinkProps,
+    'aria-label': 'Browse Human Cell Atlas data',
     tooltip: 'Look for the Export Selected Data button to export data from this provider.',
-    'aria-label': 'Browse Human Cell Atlas data'
+    href: 'https://data.humancellatlas.org/explore/projects',
+    ...Utils.newTabLinkProps
   }, ['Browse Data'])
 ])
 
@@ -304,10 +304,10 @@ const nemo = () => h(Participant, {
   sizeText: h(TooltipTrigger, { content: 'As of March 2019' }, [span('Files: >= 210,000; Projects >= 5; Species >= 3')])
 }, [
   h(ButtonPrimary, {
-    href: 'http://portal.nemoarchive.org/',
-    ...Utils.newTabLinkProps,
+    'aria-label': 'Browse Neuroscience Multi-Omic Archive data',
     tooltip: 'Look for the Export to Terra option in the Download Cart to export data.',
-    'aria-label': 'Browse Neuroscience Multi-Omic Archive data'
+    href: 'http://portal.nemoarchive.org/',
+    ...Utils.newTabLinkProps
   }, ['Browse Data'])
 ])
 
@@ -321,9 +321,9 @@ const target = () => h(Participant, {
   more effective treatment strategies can be developed and applied.`,
   sizeText: 'Participants: 1,324'
 }, [h(ButtonPrimary, {
+  'aria-label': 'Browse TARGET data',
   href: `${getConfig().firecloudUrlRoot}/?return=${returnParam()}&project=TARGET#library`,
-  ...Utils.newTabLinkProps,
-  'aria-label': 'Browse TARGET data'
+  ...Utils.newTabLinkProps
 }, ['Browse Data'])])
 
 
@@ -340,9 +340,9 @@ const tcga = () => h(Participant, {
   sizeText: 'Participants: 11,000'
 }, [
   h(ButtonPrimary, {
+    'aria-label': 'Browse Cancer Genome Atlas data',
     href: `${getConfig().firecloudUrlRoot}/?return=${returnParam()}&project=TCGA#library`,
-    ...Utils.newTabLinkProps,
-    'aria-label': 'Browse Cancer Genome Atlas data'
+    ...Utils.newTabLinkProps
   }, ['Browse Data'])
 ])
 
@@ -355,10 +355,10 @@ const topMed = () => h(Participant, {
   sizeText: h(TooltipTrigger, { content: 'As of November 2016' }, [span('Participants: > 54,000')])
 }, [
   h(ButtonPrimary, {
-    href: 'https://gen3.biodatacatalyst.nhlbi.nih.gov/explorer',
-    ...Utils.newTabLinkProps,
+    'aria-label': 'Browse TopMed data',
     tooltip: browseTooltip,
-    'aria-label': 'Browse TopMed data'
+    href: 'https://gen3.biodatacatalyst.nhlbi.nih.gov/explorer',
+    ...Utils.newTabLinkProps
   }, ['Browse Data'])
 ])
 
@@ -374,8 +374,8 @@ const ukb = () => h(Participant, {
   sizeText: 'Participants: > 500,000'
 }, [
   h(ButtonPrimary, {
-    href: Nav.getLink('data-explorer-private', { dataset: 'UK Biobank' }),
-    'aria-label': 'Browse UK BioBank data'
+    'aria-label': 'Browse UK BioBank data',
+    href: Nav.getLink('data-explorer-private', { dataset: 'UK Biobank' })
   }, ['Browse Data'])
 ])
 


### PR DESCRIPTION
The library pages didn't have much to do to ensure accessibility. All I did was resolve the explicitly enumerated issues from https://broadworkbench.atlassian.net/browse/CA-1308 on the "Datasets" and "Code" pages.

"Code & Workflows" page:
* Increased color contrast of links in right sidebar
* Changed styles applied to cards to make the overflow regions work with aXe so it didn't detect overlapping regions (no visual impact)

"Datasets" page:
* Added `aria-label`s to every button, in order to ensure each button has a unique name. I kinda made these labels up based on the names of each dataset, but stripping out info I thought may be extraneous. But feel free to pick them apart and suggest better labels. :)

I did not make any changes on the "Showcase & Tutorials" page. aXe appears to have detected links with the same name, but since these are entirely dynamic this can't be resolved in code.