### PR TITLE
[CA-1310] A11y: Import Pages

### DIFF
--- a/src/components/workspace-utils.js
+++ b/src/components/workspace-utils.js
@@ -249,7 +249,7 @@ export const SnapshotInfo = ({
 export const WorkspaceImporter = _.flow(
   Utils.withDisplayName('WorkspaceImporter'),
   withWorkspaces
-)(({ workspaces, refreshWorkspaces, onImport, authorizationDomain: ad, selectedWorkspaceId: initialWs, additionalErrors }) => {
+)(({ workspaces, refreshWorkspaces, onImport, authorizationDomain: ad, selectedWorkspaceId: initialWs, additionalErrors, ...props }) => {
   const [selectedWorkspaceId, setSelectedWorkspaceId] = useState(initialWs)
   const [creatingWorkspace, setCreatingWorkspace] = useState(false)
 
@@ -262,7 +262,8 @@ export const WorkspaceImporter = _.flow(
           (!ad || _.some({ membersGroupName: ad }, ws.workspace.authorizationDomain))
       }, workspaces),
       value: selectedWorkspaceId,
-      onChange: setSelectedWorkspaceId
+      onChange: setSelectedWorkspaceId,
+      ...props
     }),
     div({ style: { display: 'flex', alignItems: 'center', marginTop: '1rem' } }, [
       h(ButtonPrimary, {

--- a/src/pages/ImportData.js
+++ b/src/pages/ImportData.js
@@ -1,8 +1,8 @@
 import _ from 'lodash/fp'
 import { Fragment, useState } from 'react'
-import { div, h, img, p } from 'react-hyperscript-helpers'
+import { div, h, h2, img, p } from 'react-hyperscript-helpers'
 import Collapse from 'src/components/Collapse'
-import { backgroundLogo, ButtonPrimary, ButtonSecondary, Clickable, RadioButton, spinnerOverlay } from 'src/components/common'
+import { backgroundLogo, ButtonPrimary, ButtonSecondary, Clickable, IdContainer, RadioButton, spinnerOverlay } from 'src/components/common'
 import FooterWrapper from 'src/components/FooterWrapper'
 import { icon, wdlIcon } from 'src/components/icons'
 import NewWorkspaceModal from 'src/components/NewWorkspaceModal'
@@ -14,6 +14,7 @@ import colors from 'src/libs/colors'
 import { getConfig } from 'src/libs/config'
 import { withErrorReporting } from 'src/libs/error'
 import Events, { extractWorkspaceDetails } from 'src/libs/events'
+import { FormLabel } from 'src/libs/forms'
 import * as Nav from 'src/libs/nav'
 import { notify } from 'src/libs/notifications'
 import { pfbImportJobStore } from 'src/libs/state'
@@ -27,7 +28,7 @@ const styles = {
     position: 'relative', padding: '2rem'
   },
   title: {
-    fontSize: 24, fontWeight: 600, color: colors.dark(), marginBottom: '1rem'
+    fontSize: 24, fontWeight: 600, color: colors.dark(), margin: '0 0 1rem 0'
   },
   card: {
     borderRadius: 5, backgroundColor: 'white', padding: '2rem',
@@ -120,11 +121,11 @@ const ImportData = () => {
   })
 
   return h(FooterWrapper, [
-    backgroundLogo,
     h(TopBar, { title: `Import ${isDataset ? 'Data' : 'Snapshot'}` }),
     div({ role: 'main', style: styles.container }, [
+      backgroundLogo,
       div({ style: styles.card }, [
-        div({ style: styles.title }, [`Importing ${isDataset ? 'Data' : `Snapshot ${snapshotName}`}`]),
+        h2({ style: styles.title }, [`Importing ${isDataset ? 'Data' : `Snapshot ${snapshotName}`}`]),
         div({ style: { fontSize: 16 } }, ['From: ', new URL(url).hostname]),
         div({ style: { marginTop: '1rem' } }, [
           `The ${isDataset ? 'dataset' : 'snapshot'}(s) you just chose to import to Terra will be made available to you `,
@@ -135,16 +136,19 @@ const ImportData = () => {
         Utils.switchCase(mode,
           ['existing', () => {
             return h(Fragment, [
-              div({ style: styles.title }, ['Start with an existing workspace']),
-              div({ style: { fontWeight: 600, marginBottom: '0.25rem' } }, ['Select one of your workspaces']),
-              h(WorkspaceSelector, {
-                workspaces: _.filter(ws => {
-                  return Utils.canWrite(ws.accessLevel) &&
-                    (!ad || _.some({ membersGroupName: ad }, ws.workspace.authorizationDomain))
-                }, workspaces),
-                value: selectedWorkspaceId,
-                onChange: setSelectedWorkspaceId
-              }),
+              h2({ style: styles.title }, ['Start with an existing workspace']),
+              h(IdContainer, [id => h(Fragment, [
+                h(FormLabel, { htmlFor: id, style: { marginBottom: '0.25rem' } }, ['Select one of your workspaces']),
+                h(WorkspaceSelector, {
+                  id,
+                  workspaces: _.filter(ws => {
+                    return Utils.canWrite(ws.accessLevel) &&
+                      (!ad || _.some({ membersGroupName: ad }, ws.workspace.authorizationDomain))
+                  }, workspaces),
+                  value: selectedWorkspaceId,
+                  onChange: setSelectedWorkspaceId
+                })
+              ])]),
               isDataset && div({ style: { marginTop: '0.5rem', lineHeight: '1.5' } }, [noteMessage]),
               div({ style: { display: 'flex', alignItems: 'center', marginTop: '1rem' } }, [
                 h(ButtonSecondary, { onClick: setMode, style: { marginLeft: 'auto' } }, ['Back']),
@@ -158,9 +162,13 @@ const ImportData = () => {
           }],
           ['template', () => {
             return h(Fragment, [
-              div({ style: styles.title }, ['Start with a template']),
+              h2({ style: styles.title }, ['Start with a template']),
               isDataset && div({ style: { marginBottom: '1rem', lineHeight: '1.5' } }, [noteMessage]),
-              div({ style: { overflow: 'auto', maxHeight: '25rem' } }, [
+              div({
+                role: 'radiogroup',
+                'aria-label': 'choose a template',
+                style: { overflow: 'auto', maxHeight: '25rem' }
+              }, [
                 _.map(([i, ws]) => {
                   const { name, namespace, description, hasNotebooks, hasWorkflows } = ws
                   const isSelected = _.isEqual({ name, namespace }, selectedTemplateWorkspaceKey)
@@ -204,7 +212,7 @@ const ImportData = () => {
           }],
           [Utils.DEFAULT, () => {
             return h(Fragment, [
-              div({ style: styles.title }, ['Destination Workspace']),
+              h2({ style: styles.title }, ['Destination Workspace']),
               div({ style: { marginTop: '0.5rem' } }, ['Choose the option below that best suits your needs.']),
               !!filteredTemplates.length && h(ChoiceButton, {
                 onClick: () => setMode('template'),
@@ -222,7 +230,8 @@ const ImportData = () => {
                 onClick: () => setIsCreateOpen(true),
                 iconName: 'plus-circle',
                 title: 'Start with a new workspace',
-                detail: 'Set up an empty workspace that you will configure for analysis'
+                detail: 'Set up an empty workspace that you will configure for analysis',
+                'aria-haspopup': 'dialog'
               }),
               isCreateOpen && h(NewWorkspaceModal, {
                 requiredAuthDomain: ad,

--- a/src/pages/ImportWorkflow.js
+++ b/src/pages/ImportWorkflow.js
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp'
 import { Fragment, useState } from 'react'
-import { div, h, label } from 'react-hyperscript-helpers'
+import { div, h, h2, label } from 'react-hyperscript-helpers'
 import { IdContainer, spinnerOverlay } from 'src/components/common'
 import FooterWrapper from 'src/components/FooterWrapper'
 import { icon } from 'src/components/icons'
@@ -28,7 +28,7 @@ const styles = {
     position: 'relative', padding: '2rem'
   },
   title: {
-    fontSize: 24, fontWeight: 600, color: colors.dark(), marginBottom: '2rem'
+    fontSize: 24, fontWeight: 600, color: colors.dark(), margin: '0 0 1rem 0'
   },
   card: {
     ...Style.elements.card.container, borderRadius: 8, padding: '2rem', flex: 1, minWidth: 0,
@@ -84,13 +84,13 @@ const DockstoreImporter = ({ path, version, source }) => {
 
   return div({ style: styles.container }, [
     div({ style: { ...styles.card, maxWidth: 740 } }, [
-      div({ style: styles.title }, ['Importing from Dockstore']),
+      h2({ style: styles.title }, ['Importing from Dockstore']),
       div({ style: { fontSize: 18 } }, [path]),
       div({ style: { fontSize: 13, color: colors.dark() } }, [`V. ${version}`]),
       div({
         style: {
           display: 'flex', alignItems: 'center',
-          margin: '1rem 0', color: colors.warning()
+          margin: '1rem 0', color: colors.warning(2.35) // Just barely 4.5:1 contrast
         }
       }, [
         icon('warning-standard', { title: 'Warning', size: 32, style: { marginRight: '0.5rem', flex: 'none' } }),
@@ -102,19 +102,23 @@ const DockstoreImporter = ({ path, version, source }) => {
     div({ style: { ...styles.card, margin: '0 2.5rem', maxWidth: 430 } }, [
       h(IdContainer, [
         id => h(Fragment, [
-          div([label({ htmlFor: id, style: { ...styles.title } }, 'Workflow Name')]),
-          div({ style: { marginTop: '2rem' } }, [h(ValidatedInput, {
+          label({ htmlFor: id, style: { ...styles.title } }, 'Workflow Name'),
+          h(ValidatedInput, {
             inputProps: {
               id,
               onChange: setWorkflowName,
               value: workflowName
             },
             error: Utils.summarizeErrors(errors)
-          })])
+          })
         ])
       ]),
-      div({ style: { ...styles.title, paddingTop: '2rem' } }, ['Destination Workspace']),
-      h(WorkspaceImporter, { onImport: doImport, additionalErrors: errors }),
+      h(IdContainer, [
+        id => h(Fragment, [
+          label({ htmlFor: id, style: { ...styles.title, paddingTop: '2rem' } }, ['Destination Workspace']),
+          h(WorkspaceImporter, { id, onImport: doImport, additionalErrors: errors })
+        ])
+      ]),
       isBusy && spinnerOverlay
     ])
   ])


### PR DESCRIPTION
Addressed accessibility on the import-data and import-workflow pages.

I tested with the following: 
* http://localhost:3000/#import-data?url=https://jade.datarepo-dev.broadinstitute.org&snapshotId=f90f5d7f-c507-4e56-abfc-b965a66023fb&snapshotName=testsnapshot&format=snapshot
* http://localhost:3000/#import-workflow/dockstore/github.com/DataBiosphere/topmed-workflows/UM_variant_caller_wdl:1.32.0

### Changes in this PR

* Added h2 headers as appropriate
* Ensured Select elements are properly linked to labels
* Increased contrast of warning text
* Moved background image into the main section so it's not floating off by itself
* Surrounded radio buttons into a radiogroup

I also noticed that many instances of Select combobox components do not have `aria-label`s or linked `label`s, even after #2513 has been merged. I'll need to address that in another PR.