### PR TITLE
[CA-1255] UX Improvement ideas on workspace list

### DIFF
--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -34,7 +34,7 @@ const WorkspaceCardHeaders = Utils.memoWithName('WorkspaceCardHeaders', ({ sort,
     div({ 'aria-sort': ariaSort(sort, 'lastModified'), style: { flex: `0 0 ${workspaceLastModifiedWidth}px` } }, [
       h(HeaderRenderer, { sort, onSort, name: 'lastModified' })
     ]),
-    div({ role: 'columnheader', style: { flex: `0 0 ${workspaceExpandIconSize}px` } }, [
+    div({ style: { flex: `0 0 ${workspaceExpandIconSize}px` } }, [
       div({ className: 'sr-only' }, ['Expand'])
     ])
   ])

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -21,10 +21,11 @@ import { billingRoles } from 'src/pages/billing/List'
 
 
 const workspaceLastModifiedWidth = 150
+const workspaceExpandIconSize = 20
 
 const WorkspaceCardHeaders = Utils.memoWithName('WorkspaceCardHeaders', ({ sort, onSort }) => {
   return div({ style: { display: 'flex', justifyContent: 'space-between', marginTop: '1.5rem', padding: '0 1rem', marginBottom: '0.5rem' } }, [
-    div({ 'aria-sort': ariaSort(sort, 'name'), style: { flex: 1 } }, [
+    div({ 'aria-sort': ariaSort(sort, 'name'), style: { flex: 1, paddingLeft: '1rem' } }, [
       h(HeaderRenderer, { sort, onSort, name: 'name' })
     ]),
     div({ 'aria-sort': ariaSort(sort, 'createdBy'), style: { flex: 1 } }, [
@@ -32,6 +33,9 @@ const WorkspaceCardHeaders = Utils.memoWithName('WorkspaceCardHeaders', ({ sort,
     ]),
     div({ 'aria-sort': ariaSort(sort, 'lastModified'), style: { flex: `0 0 ${workspaceLastModifiedWidth}px` } }, [
       h(HeaderRenderer, { sort, onSort, name: 'lastModified' })
+    ]),
+    div({ role: 'columnheader', style: { flex: `0 0 ${workspaceExpandIconSize}px` } }, [
+      div({ className: 'sr-only' }, ['Expand'])
     ])
   ])
 })
@@ -55,10 +59,9 @@ const ExpandedInfoRow = Utils.memoWithName('ExpandedInfoRow', ({ title, details,
 
 const WorkspaceCard = Utils.memoWithName('WorkspaceCard', ({ workspace, isExpanded, onExpand }) => {
   const { namespace, name, createdBy, lastModified, googleProject, billingAccountName } = workspace
-  const workspaceExpandIconSize = 20
   const workspaceCardStyles = {
     field: {
-      ...Style.noWrapEllipsis, flex: 1, height: '1rem', width: `calc(50% - ${workspaceLastModifiedWidth / 2}px)`, paddingRight: '1rem'
+      ...Style.noWrapEllipsis, flex: 1, height: '1rem', width: `calc(50% - ${(workspaceLastModifiedWidth + workspaceExpandIconSize) / 2}px)`, paddingRight: '1rem'
     },
     row: rowBase,
     expandedInfoContainer: { display: 'flex', flexDirection: 'column', width: '100%' }
@@ -66,22 +69,24 @@ const WorkspaceCard = Utils.memoWithName('WorkspaceCard', ({ workspace, isExpand
 
   return div({ role: 'listitem', style: { ...Style.cardList.longCardShadowless, flexDirection: 'column' } }, [
     div({ style: workspaceCardStyles.row }, [
-      div({ style: { ...workspaceCardStyles.field, display: 'flex', alignItems: 'center' } }, [
+      div({ style: { ...workspaceCardStyles.field, display: 'flex', alignItems: 'center', paddingLeft: '1rem' } }, [
         h(Link, {
-          style: { fontWeight: 600, fontSize: 16, ...Style.noWrapEllipsis },
+          style: { ...Style.noWrapEllipsis },
           href: Nav.getLink('workspace-dashboard', { namespace, name })
-        }, [name]),
+        }, [name])
+      ]),
+      div({ style: workspaceCardStyles.field }, [createdBy]),
+      div({ style: { height: '1rem', flex: `0 0 ${workspaceLastModifiedWidth}px` } }, [Utils.makeStandardDate(lastModified)]),
+      div({ style: { flex: `0 0 ${workspaceExpandIconSize}px` } }, [
         h(Link, {
           'aria-expanded': isExpanded,
-          style: { display: 'flex', alignItems: 'center', marginLeft: '1rem' },
+          style: { display: 'flex', alignItems: 'center' },
           onClick: onExpand,
           'aria-label': 'expand workspace'
         }, [
-          icon(isExpanded ? 'angle-up' : 'angle-down', { size: workspaceExpandIconSize, style: { marginLeft: '1rem' } })
+          icon(isExpanded ? 'angle-up' : 'angle-down', { size: workspaceExpandIconSize })
         ])
-      ]),
-      div({ style: workspaceCardStyles.field }, [createdBy]),
-      div({ style: { height: '1rem', flex: `0 0 ${workspaceLastModifiedWidth}px` } }, [Utils.makeStandardDate(lastModified)])
+      ])
     ]),
     isExpanded && div({ style: workspaceCardStyles.row }, [
       div({ style: workspaceCardStyles.expandedInfoContainer }, [

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -71,7 +71,7 @@ const WorkspaceCard = Utils.memoWithName('WorkspaceCard', ({ workspace, isExpand
     div({ style: workspaceCardStyles.row }, [
       div({ style: { ...workspaceCardStyles.field, display: 'flex', alignItems: 'center', paddingLeft: '1rem' } }, [
         h(Link, {
-          style: { ...Style.noWrapEllipsis },
+          style: Style.noWrapEllipsis,
           href: Nav.getLink('workspace-dashboard', { namespace, name })
         }, [name])
       ]),


### PR DESCRIPTION
This PR addresses some issues Andrew Marcus and I found with the workspace list on the billing page. Specifically, with the larger font-size for the workspace links, it was removing some of the focus rings around that and the expand button. It also looked cleaner to have the expand button move to the right side, since it is a different affordance from the link to the workspace, and reduces the chance of accidental wrong clicks.

Old: (Importantly, the highlight bars are cut off on the expand button and the link to workspace)
<img width="1073" alt="Screen Shot 2021-06-10 at 4 07 57 PM" src="https://user-images.githubusercontent.com/15351021/121590195-0bb5a400-ca06-11eb-933d-f26fd0582ec2.png">

New:
<img width="1085" alt="Screen Shot 2021-06-10 at 4 06 53 PM" src="https://user-images.githubusercontent.com/15351021/121590252-1e2fdd80-ca06-11eb-8649-bffe67553071.png">

