### PR TITLE
[CA-1398] A11Y: Ensure that Select comboboxes have a label

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -54,6 +54,7 @@ const Modal = ({ onDismiss, title, titleExtras, children, width = 450, showCance
     },
     style: { overlay: styles.overlay, content: { ...styles.modal, width } },
     aria: { labelledby: titleId, modal: true },
+    ariaHideApp: false,
     ...props
   }, [
     title && div({ style: { display: 'flex', alignItems: 'baseline', marginBottom: '1rem', flex: 'none' } }, [

--- a/src/components/RequesterPaysModal.js
+++ b/src/components/RequesterPaysModal.js
@@ -1,7 +1,7 @@
 import * as _ from 'lodash/fp'
-import { useState } from 'react'
+import { Fragment, useState } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
-import { ButtonPrimary, Link, Select, spinnerOverlay } from 'src/components/common'
+import { ButtonPrimary, IdContainer, Link, Select, spinnerOverlay } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import Modal from 'src/components/Modal'
 import { Ajax } from 'src/libs/ajax'
@@ -56,15 +56,18 @@ const RequesterPaysModal = ({ onDismiss, onSuccess }) => {
       }, ['Ok'])
     }, [
       'This data is in a requester pays bucket. Choose a billing project to continue:',
-      h(FormLabel, { required: true }, ['Billing Project']),
-      h(Select, {
-        isClearable: false,
-        value: selectedBilling,
-        placeholder: 'Select a billing project',
-        onChange: ({ value }) => setSelectedBilling(value),
-        options: _.uniq(_.map('projectName', billingList)).sort()
-      }),
-      billingHelpInfo
+      h(IdContainer, [id => h(Fragment, [
+        h(FormLabel, { htmlFor: id, required: true }, ['Billing Project']),
+        h(Select, {
+          id,
+          isClearable: false,
+          value: selectedBilling,
+          placeholder: 'Select a billing project',
+          onChange: ({ value }) => setSelectedBilling(value),
+          options: _.uniq(_.map('projectName', billingList)).sort()
+        }),
+        billingHelpInfo
+      ])])
     ])],
     () => h(Modal, {
       title: 'Cannot access data',

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -362,6 +362,8 @@ const BaseSelect = ({ value, newOptions, id, findValue, maxHeight, ...props }) =
  * @param props.id - The HTML ID to give the form element
  */
 export const Select = ({ value, options, id, ...props }) => {
+  Utils.useConsoleAssert(props.id || props['aria-label'] || props['aria-labelledby'], 'In order to be accessible, Select needs a label')
+
   const newOptions = options && !_.isObject(options[0]) ? _.map(value => ({ value }), options) : options
   const findValue = target => _.find({ value: target }, newOptions)
 
@@ -375,6 +377,8 @@ export const Select = ({ value, options, id, ...props }) => {
  * @param props.id - The HTML ID to give the form element
  */
 export const GroupedSelect = ({ value, options, id, ...props }) => {
+  Utils.useConsoleAssert(props.id || props['aria-label'] || props['aria-labelledby'], 'In order to be accessible, GroupedSelect needs a label')
+
   const flattenedOptions = _.flatMap('options', options)
   const findValue = target => _.find({ value: target }, flattenedOptions)
 

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp'
 import { Fragment, useState } from 'react'
-import { div, fieldset, h, img, legend, span } from 'react-hyperscript-helpers'
+import { div, fieldset, h, img, label, legend, span } from 'react-hyperscript-helpers'
 import {
   ButtonOutline, ButtonPrimary, ButtonSecondary, Clickable, IdContainer, LabeledCheckbox, Link, RadioButton, Select, SimpleTabBar, spinnerOverlay,
   Switch
@@ -585,12 +585,15 @@ export const EntityEditor = ({ entityType, entityName, attributeName, attributeV
             ]))
           ]),
           editType === 'reference' && div({ style: { marginTop: '0.5rem' } }, [
-            div({ style: { marginBottom: '0.5rem' } }, 'Referenced entity type:'),
-            h(Select, {
-              value: linkedEntityType,
-              options: entityTypes,
-              onChange: ({ value }) => setLinkedEntityType(value)
-            })
+            h(IdContainer, [id => h(Fragment, [
+              label({ htmlFor: id, style: { marginBottom: '0.5rem' } }, 'Referenced entity type:'),
+              h(Select, {
+                id,
+                value: linkedEntityType,
+                options: entityTypes,
+                onChange: ({ value }) => setLinkedEntityType(value)
+              })
+            ])])
           ])
         ]),
         div({ style: { marginBottom: '0.5rem' } }, [

--- a/src/components/workspace-utils.js
+++ b/src/components/workspace-utils.js
@@ -49,10 +49,11 @@ export const withWorkspaces = WrappedComponent => {
   })
 }
 
-export const WorkspaceSelector = ({ workspaces, value, onChange, ...props }) => {
+export const WorkspaceSelector = ({ workspaces, value, onChange, id, 'aria-label': ariaLabel, ...props }) => {
   return h(Select, {
+    id,
+    'aria-label': ariaLabel || 'Select a workspace',
     placeholder: 'Select a workspace',
-    'aria-label': 'Select a workspace',
     disabled: !workspaces,
     value,
     onChange: ({ value }) => onChange(value),

--- a/src/pages/billing/NewAccountModal.js
+++ b/src/pages/billing/NewAccountModal.js
@@ -213,6 +213,7 @@ const NewAccountModal = ({ onDismiss }) => {
           'Notify me when the amount remaining reaches'
         ]),
         h(Select, {
+          'aria-label': 'the amount to notify on',
           onChange: ({ value }) => {
             updateAccount('alertPolicy', value)
             updateAccount('alertsOn', true)

--- a/src/pages/workspaces/workspace/ShareWorkspaceModal.js
+++ b/src/pages/workspaces/workspace/ShareWorkspaceModal.js
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp'
 import { Fragment, useLayoutEffect, useRef, useState } from 'react'
-import { div, h } from 'react-hyperscript-helpers'
+import { div, h, h2 } from 'react-hyperscript-helpers'
 import { ButtonPrimary, IdContainer, LabeledCheckbox, Link, Select, spinnerOverlay } from 'src/components/common'
 import { centeredSpinner, icon } from 'src/components/icons'
 import { AutocompleteTextInput } from 'src/components/input'
@@ -31,7 +31,7 @@ const styles = {
   }
 }
 
-const AclInput = ({ value, onChange, disabled, maxAccessLevel, autoFocus }) => {
+const AclInput = ({ value, onChange, disabled, maxAccessLevel, autoFocus, ...props }) => {
   const { accessLevel, canShare, canCompute } = value
   return div({ style: { display: 'flex', marginTop: '0.25rem' } }, [
     div({ style: { width: 200 } }, [
@@ -52,7 +52,8 @@ const AclInput = ({ value, onChange, disabled, maxAccessLevel, autoFocus }) => {
           )
         }),
         options: accessLevel === 'PROJECT_OWNER' ? ['PROJECT_OWNER'] : ['READER', 'WRITER', 'OWNER'],
-        menuPortalTarget: document.getElementById('modal-root')
+        menuPortalTarget: document.getElementById('modal-root'),
+        ...props
       })
     ]),
     div({ style: { marginLeft: '1rem' } }, [
@@ -122,6 +123,7 @@ const ShareWorkspaceModal = ({ onDismiss, workspace, workspace: { workspace: { n
     const isOld = _.find({ email }, originalAcl)
 
     return div({
+      role: 'listitem',
       style: {
         display: 'flex', alignItems: 'center', borderRadius: 5,
         padding: '0.5rem 0.75rem', marginBottom: 10,
@@ -133,6 +135,7 @@ const ShareWorkspaceModal = ({ onDismiss, workspace, workspace: { workspace: { n
         email,
         pending && div({ style: styles.pending }, ['Pending']),
         h(AclInput, {
+          'aria-label': `permissions for ${email}`,
           autoFocus: email === lastAddedEmail,
           value: aclItem,
           onChange: v => setAcl(_.set([index], v)),
@@ -141,6 +144,7 @@ const ShareWorkspaceModal = ({ onDismiss, workspace, workspace: { workspace: { n
         })
       ]),
       !disabled && h(Link, {
+        tooltip: 'Remove',
         onClick: () => setAcl(_.remove({ email }))
       }, [icon('times', { size: 20, style: { marginRight: '0.5rem' } })])
     ])
@@ -227,8 +231,8 @@ const ShareWorkspaceModal = ({ onDismiss, workspace, workspace: { workspace: { n
         style: { fontSize: 16 }
       })
     ])]),
-    div({ style: { ...Style.elements.sectionHeader, marginTop: '1rem' } }, ['Current Collaborators']),
-    div({ ref: list, style: styles.currentCollaboratorsArea }, [
+    h2({ style: { ...Style.elements.sectionHeader, margin: '1rem 0 0.5rem 0' } }, ['Current Collaborators']),
+    div({ ref: list, role: 'list', style: styles.currentCollaboratorsArea }, [
       h(Fragment, _.map(renderCollaborator, Utils.toIndexPairs(acl))),
       !loaded && centeredSpinner()
     ]),


### PR DESCRIPTION
In this PR, I did a search through the code for all usages of `Select` and `GroupedSelect` to ensure they are labeled properly. Most were, but this PR fixes the few remaining ones that weren't. In addition, I added an assertion to alert developers if they're on a page with an improperly labeled `Select` component.

In addition, I disabled the logic in `react-modal` which marks the whole page as `aria-hidden` whenever a modal is open. Since the modal now properly sets `aria-modal="true"`, this is unnecessary since screen readers will ignore the rest of the page anyway. Instead it just results in false positives in aXe and other a11y testing tools, which incorrectly indicate the `main` role and `h1` are missing whenever a modal is open.
