### PR TITLE
WIP [CA-1388] A11y: added @axe-core/react package for Accessibility linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
+    "@axe-core/react": "^4.2.1",
     "@databiosphere/bard-client": "^0.1.0",
     "@fortawesome/fontawesome-svg-core": "^1.2.35",
     "@fortawesome/free-regular-svg-icons": "^5.15.3",

--- a/src/appLoader.js
+++ b/src/appLoader.js
@@ -1,6 +1,7 @@
 import 'src/style.css'
 
 import _ from 'lodash/fp'
+import React from 'react'
 import ReactDOM from 'react-dom'
 import { h } from 'react-hyperscript-helpers'
 import RModal from 'react-modal'
@@ -20,3 +21,8 @@ window._ = _
 ReactDOM.render(h(Main), appRoot)
 initializeAuth()
 initializeTCell()
+
+if (process.env.NODE_ENV !== 'production') {
+  const axe = require('@axe-core/react')
+  axe(React, ReactDOM, 1000)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,14 @@
 # yarn lockfile v1
 
 
+"@axe-core/react@^4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@axe-core/react/-/react-4.2.1.tgz#bc96a3d454f3561483cc6e13c71ffe5e6fb3ed0c"
+  integrity sha512-g12GaW60emfQzedVCNlmr1OM2VXWwuGzoiv2zblxwjwN5DTL8LzDwqRoazo5FlxvOQ8re5k2/wXE7GFVxrYDwg==
+  dependencies:
+    axe-core "^4.2.1"
+    requestidlecallback "^0.3.0"
+
 "@babel/code-frame@7.10.4":
   version "7.10.4"
   resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz"
@@ -2619,6 +2627,11 @@ axe-core@^4.0.2:
   version "4.1.4"
   resolved "https://registry.npmjs.org/axe-core/-/axe-core-4.1.4.tgz"
   integrity sha512-Pdgfv6iP0gNx9ejRGa3zE7Xgkj/iclXqLfe7BnatdZz0QnLZ3jrRHUVH8wNSdN68w05Sk3ShGTb3ydktMTooig==
+
+axe-core@^4.2.1:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.2.2.tgz#0c987d82c8b82b4b9b7a945f1b5ef0d8fed586ed"
+  integrity sha512-OKRkKM4ojMEZRJ5UNJHmq9tht7cEnRnqKG6KyB/trYws00Xtkv12mHtlJ0SK7cmuNbrU8dPUova3ELTuilfBbw==
 
 axobject-query@^2.2.0:
   version "2.2.0"
@@ -10134,6 +10147,11 @@ request@^2.88.2:
     tough-cookie "~2.5.0"
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
+
+requestidlecallback@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/requestidlecallback/-/requestidlecallback-0.3.0.tgz#6fb74e0733f90df3faa4838f9f6a2a5f9b742ac5"
+  integrity sha1-b7dOBzP5DfP6pIOPn2oqX5t0KsU=
 
 require-directory@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
This is a work-in-progress PR, to be taken over by the Broad team.

It installs the `axe-core/react` plugin, which, once configured properly, should be able to identify whenever a rendered page is not in compliance with [WCAG's accessibility guidelines](https://www.w3.org/WAI/standards-guidelines/wcag/). It does this by writing warnings to the console which include the severity of the violation.

Ideally, this would be hooked into the CircleCI integration tests process, to let developers know when they must make accessibility changes to their features.

This plugin does NOT identify places where enhancements semantics would benefit users but are not strictly required. These determinations must still be made by developers. For example:
* given an arbitrary set of links, aXe can't determine whether they function semantically as tabs, menus, a list of links or something else.
* given a button which causes another component to be drawn or not, aXe can't determine that it's actually a collapsible region and that the button should have an `aria-expanded` state to indicate this to users
* given an element with role `tablist`, aXe can't determine whether the widget supports navigating the tabs with the arrow keys.

## June 10 status

aXe is running on every page, but there seems to be a timing issue causing some false positives. It tells me "Document should have one main landmark" and "Page should contain a level-one heading", before the page has finished rendering. I expect this will turn out to just need some adjustment with when exactly in React's rendering cycles the plugin is called.