### PR TITLE
BUGFIX: Resolved a bug in icon label assertion

### DIFF
--- a/src/components/TooltipTrigger.js
+++ b/src/components/TooltipTrigger.js
@@ -99,7 +99,7 @@ const TooltipTrigger = ({ children, content, useTooltipAsLabel, ...props }) => {
   //
   // If the auto-detection can't make the proper determination, for example, because the icon is wrapped in other elements,
   // you can explicitly pass in a boolean as `useTooltipAsLabel` to force the correct behavior.
-  const useAsLabel = _.isNil(useTooltipAsLabel) ? containsUnlabelledIcon({ children, props }) : useTooltipAsLabel
+  const useAsLabel = _.isNil(useTooltipAsLabel) ? containsUnlabelledIcon({ children, ...props }) : useTooltipAsLabel
 
   return h(Fragment, [
     cloneElement(child, {

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -71,7 +71,7 @@ export const Clickable = Utils.forwardRefWithName('Clickable', ({ href, as = (!!
   //
   // Note that TooltipTrigger does this same check with its own children, but since we'll be passing it an
   // Interactive element, we need to do the check here instead.
-  const useAsLabel = _.isNil(useTooltipAsLabel) ? containsUnlabelledIcon({ children, props }) : useTooltipAsLabel
+  const useAsLabel = _.isNil(useTooltipAsLabel) ? containsUnlabelledIcon({ children, ...props }) : useTooltipAsLabel
 
   // If we determined that we need to use the tooltip as a label, assert that we have a tooltip
   Utils.useConsoleAssert(!useAsLabel || tooltip, 'In order to be accessible, Clickable or the icon contained within it needs an accessible label or tooltip')


### PR DESCRIPTION
This bug, introduced by #2525, was causing unnecessary console log messages indicating icons had no labels, when in fact their parents were properly labeled.
