### PR TITLE
[CA-1407] A11y: Ensure all components have accessible labels

### DIFF
--- a/src/components/PopupTrigger.js
+++ b/src/components/PopupTrigger.js
@@ -25,7 +25,7 @@ const styles = {
 export const Popup = onClickOutside(function({ id, side = 'right', target: targetId, onClick, children, popupProps = {} }) {
   // We're passing popupProps here rather than just props, because ...props also includes lots of internal onClickOutside properties which
   // aren't valid to be dropped on a DOM element.
-  Utils.useConsoleAssert(popupProps['aria-label'] || popupProps['aria-labelledby'], 'In order to be accessible, Popup needs a label')
+  Utils.useLabelAssert('Popup', { ...popupProps })
 
   const elementRef = useRef()
   const [target, element, viewport] = useDynamicPosition([{ id: targetId }, { ref: elementRef }, { viewport: true }])

--- a/src/components/PopupTrigger.js
+++ b/src/components/PopupTrigger.js
@@ -25,7 +25,7 @@ const styles = {
 export const Popup = onClickOutside(function({ id, side = 'right', target: targetId, onClick, children, popupProps = {} }) {
   // We're passing popupProps here rather than just props, because ...props also includes lots of internal onClickOutside properties which
   // aren't valid to be dropped on a DOM element.
-  Utils.useLabelAssert('Popup', { ...popupProps })
+  Utils.useLabelAssert('Popup', popupProps)
 
   const elementRef = useRef()
   const [target, element, viewport] = useDynamicPosition([{ id: targetId }, { ref: elementRef }, { viewport: true }])

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -76,7 +76,7 @@ export const Clickable = Utils.forwardRefWithName('Clickable', ({ href, as = (!!
   // If we determined that we need to use the tooltip as a label, assert that we have a tooltip.
   // Do the check here and pass empty properties, to bypass the check logic in useLabelAssert() which doesn't take into account the icon's properties.
   if (useAsLabel && !tooltip) {
-    Utils.useLabelAssert('Clickable', { allowTooltip: true })
+    Utils.useLabelAssert('Clickable', { allowTooltip: true, allowNonIconContent: true })
   }
 
   if (tooltip) {

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -73,8 +73,11 @@ export const Clickable = Utils.forwardRefWithName('Clickable', ({ href, as = (!!
   // Interactive element, we need to do the check here instead.
   const useAsLabel = _.isNil(useTooltipAsLabel) ? containsUnlabelledIcon({ children, ...props }) : useTooltipAsLabel
 
-  // If we determined that we need to use the tooltip as a label, assert that we have a tooltip
-  Utils.useConsoleAssert(!useAsLabel || tooltip, 'In order to be accessible, Clickable or the icon contained within it needs an accessible label or tooltip')
+  // If we determined that we need to use the tooltip as a label, assert that we have a tooltip.
+  // Do the check here and pass empty properties, to bypass the check logic in useLabelAssert() which doesn't take into account the icon's properties.
+  if (useAsLabel && !tooltip) {
+    Utils.useLabelAssert('Clickable', { allowTooltip: true })
+  }
 
   if (tooltip) {
     return h(TooltipTrigger, { content: tooltip, side: tooltipSide, delay: tooltipDelay, useTooltipAsLabel: useAsLabel }, [child])
@@ -313,13 +316,13 @@ const BaseSelect = ({ value, newOptions, id, findValue, maxHeight, ...props }) =
  * @param {Array} props.options - can be of any type; if objects, they should each contain a value and label, unless defining getOptionLabel
  * @param props.id - The HTML ID to give the form element
  */
-export const Select = ({ value, options, id, ...props }) => {
-  Utils.useConsoleAssert(props.id || props['aria-label'] || props['aria-labelledby'], 'In order to be accessible, Select needs a label')
+export const Select = ({ value, options, ...props }) => {
+  Utils.useLabelAssert('Select', { ...props, allowId: true })
 
   const newOptions = options && !_.isObject(options[0]) ? _.map(value => ({ value }), options) : options
   const findValue = target => _.find({ value: target }, newOptions)
 
-  return h(BaseSelect, { value, newOptions, id, findValue, ...props })
+  return h(BaseSelect, { value, newOptions, findValue, ...props })
 }
 
 /**
@@ -328,13 +331,13 @@ export const Select = ({ value, options, id, ...props }) => {
  * @param {Array} props.options - an object with toplevel pairs of label:options where label is a group label and options is an array of objects containing value:label pairs
  * @param props.id - The HTML ID to give the form element
  */
-export const GroupedSelect = ({ value, options, id, ...props }) => {
-  Utils.useConsoleAssert(props.id || props['aria-label'] || props['aria-labelledby'], 'In order to be accessible, GroupedSelect needs a label')
+export const GroupedSelect = ({ value, options, ...props }) => {
+  Utils.useLabelAssert('GroupedSelect', { ...props, allowId: true })
 
   const flattenedOptions = _.flatMap('options', options)
   const findValue = target => _.find({ value: target }, flattenedOptions)
 
-  return h(BaseSelect, { value, newOptions: options, id, findValue, ...props })
+  return h(BaseSelect, { value, newOptions: options, findValue, ...props })
 }
 
 export const AsyncCreatableSelect = props => {

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -76,7 +76,7 @@ export const Clickable = Utils.forwardRefWithName('Clickable', ({ href, as = (!!
   // If we determined that we need to use the tooltip as a label, assert that we have a tooltip.
   // Do the check here and pass empty properties, to bypass the check logic in useLabelAssert() which doesn't take into account the icon's properties.
   if (useAsLabel && !tooltip) {
-    Utils.useLabelAssert('Clickable', { allowTooltip: true, allowNonIconContent: true })
+    Utils.useLabelAssert('Clickable', { allowTooltip: true, allowContent: true })
   }
 
   if (tooltip) {

--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -192,9 +192,9 @@ const DataTable = props => {
           ({ width, height }) => {
             return h(GridTable, {
               ref: table,
+              'aria-label': `${entityType} data table, page ${pageNumber} of ${Math.ceil(totalRowCount / itemsPerPage)}`,
               width, height,
               rowCount: entities.length,
-              tableName: `${entityType} data table, page ${pageNumber} of ${Math.ceil(totalRowCount / itemsPerPage)}`,
               noContentMessage: `No ${entityType}s to display.`,
               onScroll,
               initialX,

--- a/src/components/data/FileBrowser.js
+++ b/src/components/data/FileBrowser.js
@@ -192,10 +192,10 @@ export const FileBrowserPanel = _.flow(
         h(AutoSizer, {}, [
           ({ width, height }) => h(FlexTable, {
             ref: table,
+            'aria-label': 'file browser',
             width,
             height,
             rowCount: numPrefixes + numObjects,
-            tableName: 'file browser',
             noContentMessage: 'No files have been uploaded yet',
             onScroll: saveScroll,
             initialY,

--- a/src/components/data/LocalVariablesContent.js
+++ b/src/components/data/LocalVariablesContent.js
@@ -134,11 +134,11 @@ const LocalVariablesContent = ({ workspace, workspace: { workspace: { namespace,
     ]),
     div({ style: { flex: 1 } }, [
       h(AutoSizer, [({ width, height }) => h(FlexTable, {
+        'aria-label': 'workspace data local variables table',
         width, height, rowCount: amendedAttributes.length,
         onScroll: y => saveScroll(0, y),
         initialY,
         hoverHighlight: true,
-        tableName: 'workspace data local variables table',
         noContentMessage: _.isEmpty(initialAttributes) ? 'No Workspace Data defined' : 'No matching data',
         columns: [{
           size: { basis: 400, grow: 0 },

--- a/src/components/data/UploadPreviewTable.js
+++ b/src/components/data/UploadPreviewTable.js
@@ -209,9 +209,9 @@ const UploadDataTable = props => {
           ({ width, height }) => {
             return h(GridTable, {
               ref: table,
+              'aria-label': `metadata preview table`,
               width, height,
               rowCount: sortedRows.length,
-              tableName: `metadata preview table`,
               noContentMessage: `No ${entityType}s to display.`,
               onScroll: saveScroll, initialX, initialY, sort,
               columns: [

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -278,6 +278,7 @@ export const EntityUploader = ({ onSuccess, onDismiss, namespace, name, entityTy
               href: 'https://support.terra.bio/hc/en-us/articles/360025758392'
             }, ['Click here for more info on the table.'])]),
         h(SimpleTabBar, {
+          'aria-label': 'import type',
           tabs: [{ title: 'File Import', key: true, width: 121 }, { title: 'Text Import', key: false, width: 127 }],
           value: isFileImportCurrMode,
           onChange: value => {

--- a/src/components/icons.js
+++ b/src/components/icons.js
@@ -17,13 +17,9 @@ import iconDict from 'src/libs/icon-dict'
  * If the container element has an 'aria-label` or `aria-labelledby`, or if the icon itself
  * has `aria-label` or `aria-labelledby`, or if the icon is accompanied by other child elements, then we can
  * assume the icon is labeled and no further label is needed.
- *
- * @param children
- * @param props
- * @returns {boolean}
  */
-export const containsUnlabelledIcon = ({ children, ...props }) => {
-  if (!props['aria-label'] && !props['aria-labelledby'] && Children.count(children) === 1 && typeof children !== 'string') {
+export const containsUnlabelledIcon = ({ children, 'aria-label': ariaLabel, 'aria-labelledby': ariaLabelledBy }) => {
+  if (!ariaLabel && !ariaLabelledBy && Children.count(children) === 1 && typeof children !== 'string') {
     try {
       const onlyChild = Children.only(children)
 

--- a/src/components/input.js
+++ b/src/components/input.js
@@ -67,7 +67,7 @@ export const withDebouncedChange = WrappedComponent => {
 }
 
 export const TextInput = Utils.forwardRefWithName('TextInput', ({ onChange, nativeOnChange = false, ...props }, ref) => {
-  Utils.useConsoleAssert(props.id || props['aria-label'], 'In order to be accessible, TextInput needs a label')
+  Utils.useLabelAssert('TextInput', { ...props, allowId: true })
 
   return input({
     ..._.merge({
@@ -146,11 +146,14 @@ export const SearchInput = ({ value, onChange, ...props }) => {
 export const DelayedSearchInput = withDebouncedChange(SearchInput)
 
 export const NumberInput = ({ onChange, onBlur, min = -Infinity, max = Infinity, onlyInteger = false, isClearable = true, tooltip, value, ...props }) => {
-  Utils.useConsoleAssert(props.id || props['aria-label'], 'In order to be accessible, NumberInput needs a label')
+  // If the user provided a tooltip but no other label, use the tooltip as the label for the input
+  Utils.useLabelAssert('NumberInput', { tooltip, ...props, allowTooltip: true })
+
   const [internalValue, setInternalValue] = useState()
 
   const numberInputChild = div([input(_.merge({
     type: 'number',
+    'aria-label': Utils.useAriaLabelOrTooltip({ tooltip, ...props }),
     className: 'focus-style',
     min, max,
     value: internalValue !== undefined ? internalValue : _.toString(value), // eslint-disable-line lodash-fp/preferred-alias
@@ -226,7 +229,8 @@ const withAutocomplete = WrappedComponent => ({
   instructions, value, onChange, onPick, suggestions: rawSuggestions, style, id, labelId,
   renderSuggestion = _.identity, openOnFocus = true, placeholderText, ...props
 }) => {
-  Utils.useConsoleAssert(id || labelId, 'In order to be accessible, AutoComplete needs a label')
+  Utils.useLabelAssert('withAutocomplete', { id, 'aria-labelledby': labelId, ...props, allowId: true })
+
   const suggestions = _.filter(Utils.textMatch(value), rawSuggestions)
 
   return h(Downshift, {
@@ -288,7 +292,7 @@ const withAutocomplete = WrappedComponent => ({
 export const AutocompleteTextInput = withAutocomplete(TextInput)
 
 export const TextArea = ({ onChange, autosize = false, nativeOnChange = false, ...props }) => {
-  Utils.useConsoleAssert(props.id || props['aria-label'] || props['aria-labelledby'], 'In order to be accessible, TextArea needs a label')
+  Utils.useLabelAssert('TextArea', { ...props, allowId: true })
 
   return h(autosize ? TextAreaAutosize : 'textarea', _.merge({
     className: 'focus-style',
@@ -300,7 +304,7 @@ export const TextArea = ({ onChange, autosize = false, nativeOnChange = false, .
 export const DelayedAutocompleteTextArea = withDebouncedChange(withAutocomplete(TextArea))
 
 export const PasteOnlyInput = ({ onPaste, ...props }) => {
-  Utils.useConsoleAssert(props.id || props['aria-label'], 'In order to be accessible, PasteOnlyInput needs a label')
+  Utils.useLabelAssert('PasteOnlyInput', { ...props, allowId: true })
 
   return textarea(_.merge({
     className: 'focus-style',

--- a/src/components/input.js
+++ b/src/components/input.js
@@ -153,7 +153,7 @@ export const NumberInput = ({ onChange, onBlur, min = -Infinity, max = Infinity,
 
   const numberInputChild = div([input(_.merge({
     type: 'number',
-    'aria-label': Utils.useAriaLabelOrTooltip({ tooltip, ...props }),
+    'aria-label': Utils.getAriaLabelOrTooltip({ tooltip, ...props }),
     className: 'focus-style',
     min, max,
     value: internalValue !== undefined ? internalValue : _.toString(value), // eslint-disable-line lodash-fp/preferred-alias

--- a/src/components/library-common.js
+++ b/src/components/library-common.js
@@ -11,8 +11,8 @@ const TAB_LINKS = { datasets: 'library-datasets', 'showcase & tutorials': 'libra
 export const libraryTopMatter = activeTab => h(Fragment, [
   h(TopBar, { title: 'Library', href: Nav.getLink('root') }),
   h(TabBar, {
+    'aria-label': 'library menu',
     activeTab,
-    label: 'library menu',
     tabNames: _.keys(TAB_LINKS),
     getHref: currentTab => Nav.getLink(TAB_LINKS[currentTab])
   })

--- a/src/components/tabBars.js
+++ b/src/components/tabBars.js
@@ -39,16 +39,16 @@ const styles = {
  * @param refresh If provided, a function to refresh the current tab
  * @param getHref A function to get the href for a given tab
  * @param getOnClick An optional click handler function, given the current tab
- * @param label The ARIA label for the menu, which is required for accessibility
+ * @param aria-label The ARIA label for the menu, which is required for accessibility
  * @param tabProps Optionally, properties to add to each tab
  * @param children Children, which will be appended to teh end of the tab bar
  * @param props Any additional properties to add to the container menu element
  */
 export const TabBar = ({
   activeTab, tabNames, displayNames = {}, refresh = _.noop, getHref,
-  getOnClick = _.noop, label, tabProps = {}, children, ...props
+  getOnClick = _.noop, tabProps = {}, children, ...props
 }) => {
-  Utils.useConsoleAssert(!!label, 'You must provide an accessible label for this tab bar')
+  Utils.useLabelAssert('TabBar', props)
 
   const navTab = (i, currentTab) => {
     const selected = currentTab === activeTab
@@ -75,10 +75,13 @@ export const TabBar = ({
     ])
   }
 
-  return div({ role: 'navigation', 'aria-label': label }, [
+  return div({
+    role: 'navigation',
+    'aria-label': props['aria-label'], // duplicate the menu's label on the navigation element
+    'aria-labelledby': props['aria-labelledby']
+  }, [
     h(HorizontalNavigation, {
       role: 'menu',
-      'aria-label': label,
       'aria-orientation': 'horizontal',
       style: Style.tabBar.container,
       ...props
@@ -93,7 +96,6 @@ TabBar.propTypes = {
   activeTab: PropTypes.string.isRequired,
   tabNames: PropTypes.arrayOf(PropTypes.string).isRequired,
   displayNames: PropTypes.arrayOf(PropTypes.string),
-  label: PropTypes.string.isRequired,
   refresh: PropTypes.func,
   getHref: PropTypes.func,
   getOnClick: PropTypes.func,
@@ -113,7 +115,7 @@ TabBar.propTypes = {
  * @param tabs[].key The key of the tab
  * @param tabs[].title The display name of the tab
  * @param tabs[].width Optionally the width at which to render the tab
- * @param label The ARIA label for the menu, which is required for accessibility
+ * @param aria-label The ARIA label for the menu, which is required for accessibility
  * @param tabProps Optionally, properties to add to each tab
  * @param panelProps Optionally, properties to add to the tabpanel element
  * @param style Optionally, additional styles to add to the tab container
@@ -122,9 +124,9 @@ TabBar.propTypes = {
  * @param props Any additional properties to add to the container menu element
  */
 export const SimpleTabBar = ({
-  value, onChange, tabs, label, tabProps = {}, panelProps = {}, style = {}, tabStyle = {}, children, ...props
+  value, onChange, tabs, tabProps = {}, panelProps = {}, style = {}, tabStyle = {}, children, ...props
 }) => {
-  Utils.useConsoleAssert(!!label, 'You must provide an accessible label for this tab bar')
+  Utils.useLabelAssert('SimpleTabBar', props)
 
   const tabIds = _.map(Utils.useUniqueId, _.range(0, tabs.length))
   const panelRef = useRef()
@@ -135,7 +137,6 @@ export const SimpleTabBar = ({
   return h(Fragment, [
     h(HorizontalNavigation, {
       role: 'tablist',
-      'aria-label': label,
       style: { ...styles.tabBar.container, flex: 0, ...style },
       ...props
     }, _.map(([i, { key, title, width }]) => {
@@ -176,7 +177,6 @@ SimpleTabBar.propTypes = {
     title: PropTypes.node.isRequired,
     width: PropTypes.number
   })).isRequired,
-  label: PropTypes.string.isRequired,
   tabProps: PropTypes.object,
   panelProps: PropTypes.object,
   style: PropTypes.object,

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -208,9 +208,11 @@ const NoContentRow = ({ noContentMessage, noContentRenderer = _.noop, numColumns
 export const FlexTable = ({
   initialY = 0, width, height, rowCount, variant, columns = [], hoverHighlight = false,
   onScroll = _.noop, noContentMessage, noContentRenderer = _.noop, headerHeight = 48, rowHeight = 48,
-  styleCell = () => ({}), styleHeader = () => ({}), tableName, sort = null, readOnly = false,
+  styleCell = () => ({}), styleHeader = () => ({}), 'aria-label': ariaLabel, sort = null, readOnly = false,
   ...props
 }) => {
+  Utils.useLabelAssert('FlexTable', { 'aria-label': ariaLabel, allowLabelledBy: false })
+
   const [scrollbarSize, setScrollbarSize] = useState(0)
   const body = useRef()
 
@@ -222,7 +224,7 @@ export const FlexTable = ({
     role: 'table',
     'aria-rowcount': rowCount + 1, // count the header row too
     'aria-colcount': columns.length,
-    'aria-label': tableName,
+    'aria-label': ariaLabel,
     'aria-readonly': readOnly || undefined,
     className: 'flex-table'
   }, [
@@ -257,7 +259,7 @@ export const FlexTable = ({
       rowCount,
       columnCount: 1,
       'aria-readonly': null, // Clear out ARIA properties which should be at the table level, not here
-      'aria-label': `${tableName} content`, // The whole table is a tab stop so it needs a label
+      'aria-label': `${ariaLabel} content`, // The whole table is a tab stop so it needs a label
       role: 'rowgroup',
       containerRole: 'presentation', // Clear out unnecessary ARIA roles
       onScrollbarPresenceChange: ({ vertical, size }) => {
@@ -323,7 +325,7 @@ FlexTable.propTypes = {
   rowHeight: PropTypes.number,
   styleHeader: PropTypes.func,
   styleCell: PropTypes.func,
-  tableName: PropTypes.string.isRequired,
+  'aria-label': PropTypes.string.isRequired,
   sort: PropTypes.shape({
     field: PropTypes.string,
     direction: PropTypes.string
@@ -335,10 +337,12 @@ FlexTable.propTypes = {
  * A basic table with a header and flexible column widths. Intended for small amounts of data,
  * since it does not provide scrolling. See FlexTable for prop types.
  */
-export const SimpleFlexTable = ({ columns, rowCount, noContentMessage, noContentRenderer = _.noop, hoverHighlight, tableName, sort = null, readOnly = false }) => {
+export const SimpleFlexTable = ({ columns, rowCount, noContentMessage, noContentRenderer = _.noop, hoverHighlight, 'aria-label': ariaLabel, sort = null, readOnly = false }) => {
+  Utils.useLabelAssert('SimpleFlexTable', { 'aria-label': ariaLabel, allowLabelledBy: false })
+
   return div({
     role: 'table',
-    'aria-label': tableName,
+    'aria-label': ariaLabel,
     'aria-readonly': readOnly || undefined,
     className: 'simple-flex-table'
   }, [
@@ -386,8 +390,10 @@ export const GridTable = Utils.forwardRefWithName('GridTable', ({
   width, height, initialX = 0, initialY = 0, rowHeight = 48, headerHeight = 48,
   noContentMessage, noContentRenderer = _.noop,
   rowCount, columns, styleCell = () => ({}), styleHeader = () => ({}), onScroll: customOnScroll = _.noop,
-  tableName, sort = null, readOnly = false
+  'aria-label': ariaLabel, sort = null, readOnly = false
 }, ref) => {
+  Utils.useLabelAssert('GridTable', { 'aria-label': ariaLabel, allowLabelledBy: false })
+
   const [scrollbarSize, setScrollbarSize] = useState(0)
   const header = useRef()
   const body = useRef()
@@ -422,7 +428,7 @@ export const GridTable = Utils.forwardRefWithName('GridTable', ({
         role: 'table',
         'aria-rowcount': rowCount + 1, // count the header row too
         'aria-colcount': columns.length,
-        'aria-label': tableName,
+        'aria-label': ariaLabel,
         'aria-readonly': readOnly || undefined,
         className: 'grid-table'
       }, [
@@ -437,7 +443,7 @@ export const GridTable = Utils.forwardRefWithName('GridTable', ({
           role: 'rowgroup',
           containerRole: 'row',
           'aria-readonly': null, // Clear out ARIA properties which have been moved one level up
-          'aria-label': `${tableName} header row`, // The whole table is a tab stop so it needs a label
+          'aria-label': `${ariaLabel} header row`, // The whole table is a tab stop so it needs a label
           cellRenderer: data => {
             const field = columns[data.columnIndex].field
             return div({
@@ -472,7 +478,7 @@ export const GridTable = Utils.forwardRefWithName('GridTable', ({
           role: 'rowgroup',
           containerRole: 'presentation',
           'aria-readonly': null, // Clear out ARIA properties which have been moved one level up
-          'aria-label': `${tableName} content`, // The whole table is a tab stop so it needs a label
+          'aria-label': `${ariaLabel} content`, // The whole table is a tab stop so it needs a label
           onScrollbarPresenceChange: ({ vertical, size }) => {
             setScrollbarSize(vertical ? size : 0)
           },
@@ -547,7 +553,7 @@ GridTable.propTypes = {
   onScroll: PropTypes.func,
   headerHeight: PropTypes.number,
   rowHeight: PropTypes.number,
-  tableName: PropTypes.string.isRequired,
+  'aria-label': PropTypes.string.isRequired,
   sort: PropTypes.shape({
     field: PropTypes.string,
     direction: PropTypes.string
@@ -555,11 +561,13 @@ GridTable.propTypes = {
   readOnly: PropTypes.bool
 }
 
-export const SimpleTable = ({ columns, rows, tableName }) => {
+export const SimpleTable = ({ columns, rows, 'aria-label': ariaLabel }) => {
+  Utils.useLabelAssert('SimpleTable', { 'aria-label': ariaLabel, allowLabelledBy: false })
+
   const cellStyles = { paddingTop: '0.25rem', paddingBottom: '0.25rem' }
   return h(div, {
     role: 'table',
-    'aria-label': tableName
+    'aria-label': ariaLabel
   }, [
     div({ role: 'row', style: { display: 'flex' } }, [
       _.map(({ key, header, size }) => {

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -67,6 +67,7 @@ export const paginator = ({
             _.map(num => paginatorButton(
               _.merge({
                 key: num,
+                'aria-current': currentPage === num ? 'page' : undefined,
                 style: {
                   minWidth: '2rem',
                   backgroundColor: currentPage === num ? colors.accent() : undefined,
@@ -252,36 +253,36 @@ export const FlexTable = ({
     }, Utils.toIndexPairs(columns))),
     h(RVGrid, {
       ref: body,
+      role: 'rowgroup',
+      containerRole: 'presentation', // Clear out unnecessary ARIA roles
+      'aria-label': `${ariaLabel} content`, // The whole table is a tab stop so it needs a label
+      'aria-readonly': null, // Clear out ARIA properties which should be at the table level, not here
       width,
       height: height - headerHeight,
       columnWidth: width - scrollbarSize,
       rowHeight,
       rowCount,
       columnCount: 1,
-      'aria-readonly': null, // Clear out ARIA properties which should be at the table level, not here
-      'aria-label': `${ariaLabel} content`, // The whole table is a tab stop so it needs a label
-      role: 'rowgroup',
-      containerRole: 'presentation', // Clear out unnecessary ARIA roles
       onScrollbarPresenceChange: ({ vertical, size }) => {
         setScrollbarSize(vertical ? size : 0)
       },
       cellRenderer: data => {
         return h(Interactive, {
           key: data.key,
+          role: 'row',
           as: 'div',
           className: 'table-row',
-          role: 'row',
           style: { ...data.style, backgroundColor: 'white', display: 'flex' },
           hover: hoverHighlight ? { backgroundColor: colors.light(0.4) } : undefined
         }, [
           _.map(([i, { size, cellRenderer }]) => {
             return div({
               key: i,
-              className: 'table-cell',
               role: 'cell',
               // ARIA row and column indexes start with 1 https://www.digitala11y.com/aria-colindexproperties/
               'aria-rowindex': data.rowIndex + 2, // The header row is 1, so the first body row is 2
               'aria-colindex': i + 1, // The first column is 1
+              className: 'table-cell',
               style: {
                 ...styles.flexCell(size),
                 ...(variant === 'light' ? {} : styles.cell(i * 1, columns.length)),
@@ -347,32 +348,32 @@ export const SimpleFlexTable = ({ columns, rowCount, noContentMessage, noContent
     className: 'simple-flex-table'
   }, [
     div({
-      style: { height: 48, display: 'flex' },
-      role: 'row'
+      role: 'row',
+      style: { height: 48, display: 'flex' }
     }, [
       _.map(([i, { size, headerRenderer, field }]) => {
         return div({
           key: i,
-          style: { ...styles.flexCell(size), ...styles.header(i * 1, columns.length) },
           role: 'columnheader',
-          'aria-sort': ariaSort(sort, field)
+          'aria-sort': ariaSort(sort, field),
+          style: { ...styles.flexCell(size), ...styles.header(i * 1, columns.length) }
         }, [headerRenderer({ columnIndex: i })])
       }, Utils.toIndexPairs(columns))
     ]),
     _.map(rowIndex => {
       return h(Interactive, {
         key: rowIndex,
+        role: 'row',
         as: 'div',
         className: 'table-row',
-        role: 'row',
         style: { backgroundColor: 'white', display: 'flex', minHeight: 48 },
         hover: hoverHighlight ? { backgroundColor: colors.light(0.4) } : undefined
       }, [
         _.map(([i, { size, cellRenderer }]) => {
           return div({
             key: i,
-            className: 'table-cell',
             role: 'cell',
+            className: 'table-cell',
             style: { ...styles.flexCell(size), ...styles.cell(i * 1, columns.length) }
           }, [cellRenderer({ columnIndex: i, rowIndex })])
         }, Utils.toIndexPairs(columns))
@@ -426,34 +427,34 @@ export const GridTable = Utils.forwardRefWithName('GridTable', ({
     ({ onScroll, scrollLeft }) => {
       return div({
         role: 'table',
+        'aria-label': ariaLabel,
         'aria-rowcount': rowCount + 1, // count the header row too
         'aria-colcount': columns.length,
-        'aria-label': ariaLabel,
         'aria-readonly': readOnly || undefined,
         className: 'grid-table'
       }, [
         h(RVGrid, {
           ref: header,
+          role: 'rowgroup',
+          containerRole: 'row',
+          'aria-label': `${ariaLabel} header row`, // The whole table is a tab stop so it needs a label
+          'aria-readonly': null, // Clear out ARIA properties which have been moved one level up
           width: width - scrollbarSize,
           height: headerHeight,
           columnWidth: ({ index }) => columns[index].width,
           rowHeight: headerHeight,
           rowCount: 1,
           columnCount: columns.length,
-          role: 'rowgroup',
-          containerRole: 'row',
-          'aria-readonly': null, // Clear out ARIA properties which have been moved one level up
-          'aria-label': `${ariaLabel} header row`, // The whole table is a tab stop so it needs a label
           cellRenderer: data => {
             const field = columns[data.columnIndex].field
             return div({
               key: data.key,
-              className: 'table-cell',
               role: 'columnheader',
               // ARIA row and column indexes start with 1 rather than 0 https://www.digitala11y.com/aria-colindexproperties/
               'aria-rowindex': 1, // The header row is 1
               'aria-colindex': data.columnIndex + 1, // The first column is 1
               'aria-sort': ariaSort(sort, field),
+              className: 'table-cell',
               style: {
                 ...data.style,
                 ...styles.header(data.columnIndex, columns.length),
@@ -469,16 +470,16 @@ export const GridTable = Utils.forwardRefWithName('GridTable', ({
         }),
         h(RVGrid, {
           ref: body,
+          role: 'rowgroup',
+          containerRole: 'presentation',
+          'aria-label': `${ariaLabel} content`, // The whole table is a tab stop so it needs a label
+          'aria-readonly': null, // Clear out ARIA properties which have been moved one level up
           width,
           height: height - headerHeight,
           columnWidth: ({ index }) => columns[index].width,
           rowHeight,
           rowCount,
           columnCount: columns.length,
-          role: 'rowgroup',
-          containerRole: 'presentation',
-          'aria-readonly': null, // Clear out ARIA properties which have been moved one level up
-          'aria-label': `${ariaLabel} content`, // The whole table is a tab stop so it needs a label
           onScrollbarPresenceChange: ({ vertical, size }) => {
             setScrollbarSize(vertical ? size : 0)
           },
@@ -488,11 +489,11 @@ export const GridTable = Utils.forwardRefWithName('GridTable', ({
               rowIndex: data.rowIndex,
               cell: div({
                 key: data.key,
-                className: 'table-cell',
                 role: 'cell',
                 // ARIA row and column indexes start with 1 rather than 0 https://www.digitala11y.com/aria-colindexproperties/
                 'aria-rowindex': data.rowIndex + 2, // The header row is 1, so the first body row is 2
                 'aria-colindex': data.columnIndex + 1, // The first column is 1
+                className: 'table-cell',
                 style: {
                   ...data.style,
                   ...styles.cell(data.columnIndex, columns.length),
@@ -581,8 +582,8 @@ export const SimpleTable = ({ columns, rows, 'aria-label': ariaLabel }) => {
     _.map(([i, row]) => {
       return h(Interactive, {
         key: i,
-        as: 'div',
         role: 'row',
+        as: 'div',
         style: { display: 'flex' }, className: 'table-row',
         hover: { backgroundColor: colors.light(0.4) }
       }, [
@@ -717,10 +718,10 @@ export const ColumnSelector = ({ onSave, columnSettings }) => {
 
   return h(Fragment, [
     h(Clickable, {
-      style: styles.columnSelector,
-      tooltip: 'Select columns',
       'aria-haspopup': 'dialog',
       'aria-expanded': open,
+      style: styles.columnSelector,
+      tooltip: 'Select columns',
       onClick: () => {
         setOpen(true)
         setModifiedColumnSettings(columnSettings)

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -403,11 +403,10 @@ export const useLabelAssert = (componentName, { allowLabelledBy = true, allowId 
       printed.current = true
 
       console.warn(`For accessibility, ${componentName} needs a label. Resolve this by doing any of the following: 
-  * add an aria-label property to this component
-  ${allowLabelledBy ? '* add an aria-labelledby property referencing the id on another component containing the label' : ''}
-  ${allowTooltip ? '* add a tooltip property to this component, which will also be used as the aria-label' : ''}
-  ${allowId ? '* create a label and point its htmlFor property to this component\'s id' : ''}
-      `)
+  * add an aria-label property to this component${allowLabelledBy ? `
+  * add an aria-labelledby property referencing the id of another component containing the label` : ''}${allowTooltip ? `
+  * add a tooltip property to this component, which will also be used as the aria-label` : ''}${allowId ? `
+  * create a label and point its htmlFor property to this component's id` : ''}`)
     }
   }
 }

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -382,22 +382,45 @@ export const useConsoleAssert = (condition, message) => {
   }
 }
 
-export const useLabelAssert = (componentName, { allowId = false, allowTooltip = false, ...props }) => {
+/**
+ * Asserts that a component has an accessible label, and alerts the developer how to fix it if it doesn't.
+ *
+ * @param componentName The name of the component, which will be printed to the console if there's an alert.
+ * @param allowLabelledBy If true (default), the component can have an aria-labelledby linked to another element. Set to false to only allow aria-label.
+ * @param allowId If true, the component can have an id linked to a label using htmlFor. This is true for form elements.
+ * @param allowTooltip If true, the component can have a tooltip which will be used if needed as the label.
+ * @param ariaLabel Optional: The label provided to the component
+ * @param ariaLabelledBy Optional: The ID of the label provided to the component
+ * @param id: Optional: The ID of the component if allowId is true
+ * @param tooltip Optional: The tooltip provided to the component if allowTooltip is true
+ */
+export const useLabelAssert = (componentName, { allowLabelledBy = true, allowId = false, allowTooltip = false, 'aria-label': ariaLabel, 'aria-labelledby': ariaLabelledBy, id, tooltip }) => {
   const printed = useRef(false)
 
   if (!printed.current) {
     // Ensure that the properties contain a label
-    if (!props['aria-label'] && !props['aria-labelledby'] && (!allowId || !props.id) && (!allowTooltip || !props.tooltip)) {
+    if (!ariaLabel && (!allowLabelledBy || !ariaLabelledBy) && (!allowId || !id) && (!allowTooltip || !tooltip)) {
       printed.current = true
 
       console.warn(`For accessibility, ${componentName} needs a label. Resolve this by doing any of the following: 
   * add an aria-label property to this component
-  * add an aria-labelledby property referencing the id on another component containing the label
+  ${allowLabelledBy ? '* add an aria-labelledby property referencing the id on another component containing the label' : ''}
   ${allowTooltip ? '* add a tooltip property to this component, which will also be used as the aria-label' : ''}
   ${allowId ? '* create a label and point its htmlFor property to this component\'s id' : ''}
       `)
     }
   }
+}
+
+/**
+ * Returns the aria-label to use for a component if applicable.
+ *
+ * If aria-label was provided, it will be returned
+ * If aria-labelledby was provided, or an id was provided and allowId is true, then this will return nothing because the component is already labeled
+ * If a tooltip was provided without any of the other attributes, it will be returned to be used as the aria-label
+ */
+export const useAriaLabelOrTooltip = ({ allowId = false, 'aria-label': ariaLabel, 'aria-labelledby': ariaLabelledBy, id, tooltip }) => {
+  return ariaLabel || ariaLabelledBy || (allowId && id) ? ariaLabel : tooltip
 }
 
 export const useCancelable = () => {

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -386,17 +386,17 @@ export const useConsoleAssert = (condition, message) => {
  * Asserts that a component has an accessible label, and alerts the developer how to fix it if it doesn't.
  *
  * @param componentName The name of the component, which will be printed to the console if there's an alert.
- * @param allowLabelledBy If true (default), the component can have an aria-labelledby linked to another element. Set to false to only allow aria-label.
- * @param allowId If true, the component can have an id linked to a label using htmlFor. This is true for form elements.
- * @param allowTooltip If true, the component can have a tooltip which will be used if needed as the label.
- * @param allowNonIconContent If true, the component can used nested textual content as its label, as long as it's not a single unlabelled icon
- * @param ariaLabel Optional: The label provided to the component
- * @param ariaLabelledBy Optional: The ID of the label provided to the component
- * @param id: Optional: The ID of the component if allowId is true
- * @param tooltip Optional: The tooltip provided to the component if allowTooltip is true
+ * @param [allowLabelledBy] If true (default), the component can have an aria-labelledby linked to another element. Set to false to only allow aria-label.
+ * @param [allowId] If true, the component can have an id linked to a label using htmlFor. This is true for form elements.
+ * @param [allowTooltip] If true, the component can have a tooltip which will be used if needed as the label.
+ * @param [allowContent] If true, the component can used nested textual content as its label, as long as it's not a single unlabelled icon
+ * @param [ariaLabel] Optional: The label provided to the component
+ * @param [ariaLabelledBy] Optional: The ID of the label provided to the component
+ * @param [id]: Optional: The ID of the component if allowId is true
+ * @param [tooltip] Optional: The tooltip provided to the component if allowTooltip is true
  */
 export const useLabelAssert = (componentName, {
-  allowLabelledBy = true, allowId = false, allowTooltip = false, allowNonIconContent = false,
+  allowLabelledBy = true, allowId = false, allowTooltip = false, allowContent = false,
   'aria-label': ariaLabel, 'aria-labelledby': ariaLabelledBy, id, tooltip
 }) => {
   const printed = useRef(false)
@@ -409,7 +409,7 @@ export const useLabelAssert = (componentName, {
     )) {
       printed.current = true
 
-      console.warn(`For accessibility, ${componentName} needs a label. Resolve this by doing any of the following: ${allowNonIconContent ? `
+      console.warn(`For accessibility, ${componentName} needs a label. Resolve this by doing any of the following: ${allowContent ? `
   * add a child component with textual content or a label
   * if the child is an icon, add a label to it` : ''}${allowTooltip ? `
   * add a tooltip property to this component, which will also be used as the aria-label` : ''}

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -427,7 +427,7 @@ export const useLabelAssert = (componentName, {
  * If aria-labelledby was provided, or an id was provided and allowId is true, then this will return nothing because the component is already labeled
  * If a tooltip was provided without any of the other attributes, it will be returned to be used as the aria-label
  */
-export const useAriaLabelOrTooltip = ({ allowId = false, 'aria-label': ariaLabel, 'aria-labelledby': ariaLabelledBy, id, tooltip }) => {
+export const getAriaLabelOrTooltip = ({ allowId = false, 'aria-label': ariaLabel, 'aria-labelledby': ariaLabelledBy, id, tooltip }) => {
   return (ariaLabel || ariaLabelledBy || (allowId && id)) ? ariaLabel : tooltip
 }
 

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -389,24 +389,33 @@ export const useConsoleAssert = (condition, message) => {
  * @param allowLabelledBy If true (default), the component can have an aria-labelledby linked to another element. Set to false to only allow aria-label.
  * @param allowId If true, the component can have an id linked to a label using htmlFor. This is true for form elements.
  * @param allowTooltip If true, the component can have a tooltip which will be used if needed as the label.
+ * @param allowNonIconContent If true, the component can used nested textual content as its label, as long as it's not a single unlabelled icon
  * @param ariaLabel Optional: The label provided to the component
  * @param ariaLabelledBy Optional: The ID of the label provided to the component
  * @param id: Optional: The ID of the component if allowId is true
  * @param tooltip Optional: The tooltip provided to the component if allowTooltip is true
  */
-export const useLabelAssert = (componentName, { allowLabelledBy = true, allowId = false, allowTooltip = false, 'aria-label': ariaLabel, 'aria-labelledby': ariaLabelledBy, id, tooltip }) => {
+export const useLabelAssert = (componentName, {
+  allowLabelledBy = true, allowId = false, allowTooltip = false, allowNonIconContent = false,
+  'aria-label': ariaLabel, 'aria-labelledby': ariaLabelledBy, id, tooltip
+}) => {
   const printed = useRef(false)
 
   if (!printed.current) {
     // Ensure that the properties contain a label
-    if (!ariaLabel && (!allowLabelledBy || !ariaLabelledBy) && (!allowId || !id) && (!allowTooltip || !tooltip)) {
+    if (!(ariaLabel ||
+      (allowLabelledBy && ariaLabelledBy) ||
+      (allowId && id) || (allowTooltip && tooltip)
+    )) {
       printed.current = true
 
-      console.warn(`For accessibility, ${componentName} needs a label. Resolve this by doing any of the following: 
+      console.warn(`For accessibility, ${componentName} needs a label. Resolve this by doing any of the following: ${allowNonIconContent ? `
+  * add a child component with textual content or a label
+  * if the child is an icon, add a label to it` : ''}${allowTooltip ? `
+  * add a tooltip property to this component, which will also be used as the aria-label` : ''}
   * add an aria-label property to this component${allowLabelledBy ? `
-  * add an aria-labelledby property referencing the id of another component containing the label` : ''}${allowTooltip ? `
-  * add a tooltip property to this component, which will also be used as the aria-label` : ''}${allowId ? `
-  * create a label and point its htmlFor property to this component's id` : ''}`)
+  * add an aria-labelledby property referencing the id of another component containing the label` : ''}${allowId ? `
+  * create a label component and point its htmlFor property to this component's id` : ''}`)
     }
   }
 }

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -428,7 +428,7 @@ export const useLabelAssert = (componentName, {
  * If a tooltip was provided without any of the other attributes, it will be returned to be used as the aria-label
  */
 export const useAriaLabelOrTooltip = ({ allowId = false, 'aria-label': ariaLabel, 'aria-labelledby': ariaLabelledBy, id, tooltip }) => {
-  return ariaLabel || ariaLabelledBy || (allowId && id) ? ariaLabel : tooltip
+  return (ariaLabel || ariaLabelledBy || (allowId && id)) ? ariaLabel : tooltip
 }
 
 export const useCancelable = () => {

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -382,6 +382,24 @@ export const useConsoleAssert = (condition, message) => {
   }
 }
 
+export const useLabelAssert = (componentName, { allowId = false, allowTooltip = false, ...props }) => {
+  const printed = useRef(false)
+
+  if (!printed.current) {
+    // Ensure that the properties contain a label
+    if (!props['aria-label'] && !props['aria-labelledby'] && (!allowId || !props.id) && (!allowTooltip || !props.tooltip)) {
+      printed.current = true
+
+      console.warn(`For accessibility, ${componentName} needs a label. Resolve this by doing any of the following: 
+  * add an aria-label property to this component
+  * add an aria-labelledby property referencing the id on another component containing the label
+  ${allowTooltip ? '* add a tooltip property to this component, which will also be used as the aria-label' : ''}
+  ${allowId ? '* create a label and point its htmlFor property to this component\'s id' : ''}
+      `)
+    }
+  }
+}
+
 export const useCancelable = () => {
   const [controller, setController] = useState(new window.AbortController())
 

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -297,8 +297,8 @@ const Environments = ({ namespace }) => {
     div({ role: 'main', style: { padding: '1rem', flexGrow: 1 } }, [
       h2({ style: { ...Style.elements.sectionHeader, textTransform: 'uppercase', margin: '0 0 1rem 0', padding: 0 } }, ['Your cloud environments']),
       runtimes && h(SimpleFlexTable, {
+        'aria-label': 'cloud environments',
         sort,
-        tableName: 'cloud environments',
         rowCount: filteredCloudEnvironments.length,
         columns: [
           {
@@ -386,8 +386,8 @@ const Environments = ({ namespace }) => {
       }),
       h2({ style: { ...Style.elements.sectionHeader, textTransform: 'uppercase', margin: '1rem 0', padding: 0 } }, ['Your persistent disks']),
       disks && h(SimpleFlexTable, {
+        'aria-label': 'persistent disks',
         sort: diskSort,
-        tableName: 'persistent disks',
         rowCount: filteredDisks.length,
         columns: [
           {

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -295,7 +295,7 @@ const ProjectDetail = ({ project, project: { projectName, creationStatus }, bill
         ])
       ]),
       h(SimpleTabBar, {
-        label: 'project details',
+        'aria-label': 'project details',
         style: { marginTop: '2rem', textTransform: 'none', padding: '0 1rem', height: '1.5rem' },
         tabStyle: { borderBottomWidth: 4 },
         value: tab,

--- a/src/pages/workflows/List.js
+++ b/src/pages/workflows/List.js
@@ -78,7 +78,7 @@ const WorkflowList = ({ queryParams: { tab, filter = '', ...query } }) => {
       })
     ]),
     h(TabBar, {
-      label: 'workflows menu',
+      'aria-label': 'workflows menu',
       activeTab: tabName,
       tabNames: Object.keys(tabs),
       displayNames: tabs,
@@ -92,8 +92,8 @@ const WorkflowList = ({ queryParams: { tab, filter = '', ...query } }) => {
       div({ style: { flex: 1 } }, [
         workflows && h(AutoSizer, [
           ({ width, height }) => h(FlexTable, {
+            'aria-label': tabs[tabName],
             width, height, sort,
-            tableName: tabs[tabName],
             rowCount: sortedWorkflows.length,
             columns: [
               {

--- a/src/pages/workflows/workflow/WorkflowDetails.js
+++ b/src/pages/workflows/workflow/WorkflowDetails.js
@@ -94,7 +94,7 @@ const SnapshotWrapper = ({ namespace, name, snapshotId, tabName, children }) => 
 
   return h(Fragment, [
     h(TabBar, {
-      label: 'workflow menu',
+      'aria-label': 'workflow menu',
       activeTab: tabName,
       tabNames: ['dashboard', 'wdl', 'configs'],
       displayNames: { configs: 'configurations' },
@@ -211,7 +211,7 @@ const WorkflowConfigs = () => {
       h(AutoSizer, [
         ({ width, height }) => h(FlexTable, {
           width, height,
-          tableName: 'workflow configuration',
+          'aria-label': 'workflow configuration',
           rowCount: allConfigs.length,
           columns: [
             {

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -171,9 +171,9 @@ export const WorkspaceList = () => {
 
   const renderedWorkspaces = div({ style: { flex: 1, backgroundColor: 'white', padding: '0 1rem' } }, [h(AutoSizer, [
     ({ width, height }) => h(FlexTable, {
+      'aria-label': currentTab?.tableName || 'workspaces',
       width, height,
       rowCount: sortedWorkspaces.length,
-      tableName: currentTab?.tableName || 'workspaces',
       noContentRenderer: () => Utils.cond(
         [loadingWorkspaces, () => 'Loading...'],
         [_.isEmpty(initialFiltered.myWorkspaces) && tab === 'myWorkspaces', () => NoWorkspacesMessage({
@@ -377,7 +377,7 @@ export const WorkspaceList = () => {
         ])
       ]),
       h(SimpleTabBar, {
-        label: 'choose a workspace collection',
+        'aria-label': 'choose a workspace collection',
         value: tab,
         onChange: newTab => {
           if (newTab === tab) {

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -224,7 +224,7 @@ const WorkspaceDashboard = _.flow(
       _.some(_.startsWith('library:'), _.keys(attributes)) && h(Fragment, [
         div({ style: Style.dashboard.header }, ['Dataset Attributes']),
         h(SimpleTable, {
-          tableName: 'dataset attributes table',
+          'aria-label': 'dataset attributes table',
           rows: _.flow(
             _.map(({ key, title }) => ({ name: title, value: displayAttributeValue(attributes[key]) })),
             Utils.append({

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -119,10 +119,10 @@ const ReferenceDataContent = ({ workspace: { workspace: { namespace, attributes 
     div({ style: { flex: 1 } }, [
       h(AutoSizer, [
         ({ width, height }) => h(FlexTable, {
+          'aria-label': 'reference data',
           width, height, rowCount: selectedData.length,
           onScroll: y => saveScroll(0, y),
           initialY,
-          tableName: 'reference data',
           noContentMessage: 'No matching data',
           columns: [
             {
@@ -277,7 +277,7 @@ const BucketContent = _.flow(
     ]),
     div({ style: { margin: '1rem -1rem 1rem -1rem', borderBottom: `1px solid ${colors.dark(0.25)}` } }),
     h(SimpleTable, {
-      tableName: 'file browser',
+      'aria-label': 'file browser',
       columns: [
         { header: div({ className: 'sr-only' }, ['Actions']), size: { basis: 24, grow: 0 }, key: 'button' },
         { header: h(HeaderCell, ['Name']), size: { grow: 1 }, key: 'name' },

--- a/src/pages/workspaces/workspace/JobHistory.js
+++ b/src/pages/workspaces/workspace/JobHistory.js
@@ -186,9 +186,9 @@ const JobHistory = _.flow(
     div({ style: styles.submissionsTable }, [
       hasJobs && h(AutoSizer, [
         ({ width, height }) => h(FlexTable, {
+          'aria-label': 'job history',
           width, height, rowCount: filteredSubmissions.length,
           hoverHighlight: true,
-          tableName: 'job history',
           noContentMessage: 'No matching jobs',
           columns: [
             {

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -49,7 +49,7 @@ const WorkspaceTabs = ({ namespace, name, workspace, activeTab, refresh }) => {
   ]
   return h(Fragment, [
     h(TabBar, {
-      label: 'workspace menu',
+      'aria-label': 'workspace menu',
       activeTab, refresh,
       tabNames: _.map('name', tabs),
       getHref: currentTab => Nav.getLink(_.find({ name: currentTab }, tabs).link, { namespace, name })

--- a/src/pages/workspaces/workspace/jobHistory/CallTable.js
+++ b/src/pages/workspaces/workspace/jobHistory/CallTable.js
@@ -19,10 +19,10 @@ const CallTable = ({ namespace, name, submissionId, workflowId, callName, callOb
   return div([
     h(AutoSizer, { disableHeight: true }, [
       ({ width }) => h(FlexTable, {
+        'aria-label': 'call table',
         height: tableHeight({ actualRows: callObjects.length, maxRows: 10.5 }), // The half-row here hints at there being extra rows if scrolled
         width,
         rowCount: callObjects.length,
-        tableName: 'call table',
         noContentMessage: 'No matching calls',
         columns: [
           {

--- a/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
+++ b/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
@@ -212,9 +212,9 @@ const SubmissionDetails = _.flow(
       ]),
       div({ style: { flex: 1 } }, [
         h(AutoSizer, [({ width, height }) => h(FlexTable, {
+          'aria-label': 'submission details',
           width, height, sort,
           rowCount: filteredWorkflows.length,
-          tableName: 'submission details',
           noContentMessage: 'No matching workflows',
           columns: [
             {

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -97,8 +97,8 @@ const WorkflowIOTable = ({ which, inputsOutputs: data, config, errors, onChange,
   )
 
   return h(SimpleFlexTable, {
+    'aria-label': `workflow ${which}`,
     rowCount: sortedData.length,
-    tableName: `workflow ${which}`,
     noContentMessage: `No matching ${which}.`,
     sort, readOnly,
     columns: [
@@ -236,7 +236,7 @@ const BucketContentModal = ({ workspace: { workspace: { namespace, bucketName } 
     ]),
     div({ style: { margin: '1rem -1rem 1rem -1rem', borderBottom: `1px solid ${colors.light(0.4)}` } }),
     h(SimpleTable, {
-      tableName: 'file browser',
+      'aria-label': 'file browser',
       columns: [
         { header: h(HeaderCell, ['Name']), size: { grow: 1 }, key: 'name' }
       ],


### PR DESCRIPTION
This PR standardizes the way labels are enforced across all components. It provides an actionable warning in the console if a component is missing a label that it should have.

It accepts labels in any of the following formats:
* `aria-label` containing the text
* `aria-labelledby` linking to the `id` of a component with the text (except for tables which need the text directly)
* `id` linked to by a label with a `for` property (for form elements)
* `tooltip` containing the text (for `Clickable` and `NumberInput` components)

This PR also renames the `tableName` property in tables and `label` property in TabBars to just use `aria-label` like everything else. This change affected everywhere where these components where used, which is why this PR is large.