### PR TITLE
handle null snapshot reference descriptions in markdown editor [AS-799]

### DIFF
--- a/src/components/workspace-utils.js
+++ b/src/components/workspace-utils.js
@@ -142,7 +142,7 @@ export const SnapshotInfo = ({
           'Description:',
           !editingDescription && h(Link, {
             style: { marginLeft: '0.5rem' },
-            onClick: () => setNewDescription(description),
+            onClick: () => setNewDescription(description || ''), // description is null for newly-added snapshot references
             tooltip: 'Edit description'
           }, [icon('edit')])
         ]),
@@ -156,7 +156,7 @@ export const SnapshotInfo = ({
             h(ButtonSecondary, { onClick: () => setNewDescription(undefined) }, 'Cancel'),
             h(ButtonPrimary, { style: { marginLeft: '1rem' }, onClick: save }, 'Save')
           ])
-        ]) : h(MarkdownViewer, [description])
+        ]) : h(MarkdownViewer, [description || '']) // description is null for newly-added snapshot references
       ]),
       div({ style: { paddingLeft: '1rem' } }, [
         div({ style: Style.dashboard.header }, ['Linked Data Repo Snapshot']),


### PR DESCRIPTION
Fixes a full-page crash when attempting to view the details of a snapshot reference inside a workspace. This only happened for snapshot references that had a null description; if you had previously given the reference a description, the bug did not happen. Unfortunately, descriptions are null for all newly-added snapshot references.

The error in question is in the markdown editor/viewer:
<img width="1319" alt="Screen Shot 2021-06-14 at 8 40 01 AM" src="https://user-images.githubusercontent.com/6041577/122295274-01445000-cec7-11eb-8d96-943e8f0a2768.png">

This PR fixes the issue by sending the empty string to the markdown editor/viewer in cases where the underlying value is null.

I personally smoke-tested locally, but not comprehensively; @ungwudik did comprehensive testing as noted in comments below.