### PR TITLE
Add a small delay after typing text into an input field [QA-1484]

### DIFF
--- a/integration-tests/tests/preview-drs-uri.js
+++ b/integration-tests/tests/preview-drs-uri.js
@@ -1,7 +1,7 @@
 const _ = require('lodash/fp')
 const { withWorkspace, createEntityInWorkspace } = require('../utils/integration-helpers')
 const { withUserToken } = require('../utils/terra-sa-utils')
-const { findText, navChild, fillIn, click, clickable, elementInDataTableRow, waitForNoSpinners, input, signIntoTerra, dismissNotifications, delay } = require('../utils/integration-utils')
+const { findText, navChild, fillIn, click, clickable, elementInDataTableRow, waitForNoSpinners, input, signIntoTerra, dismissNotifications } = require('../utils/integration-utils')
 
 
 const testPreviewDrsUriFn = _.flow(
@@ -24,20 +24,6 @@ const testPreviewDrsUriFn = _.flow(
 
   await click(page, clickable({ textContains: 'View Workspaces' }))
   await waitForNoSpinners(page)
-
-  for (let i = 0; i < 50; i++) {
-    // console.log(`Attempt #${i}...`)
-    await fillIn(page, input({ placeholder: 'SEARCH WORKSPACES' }), workspaceName)
-    await click(page, clickable({ textContains: workspaceName }))
-
-    await findText(page, 'About the workspace')
-    // await delay(1000)
-    await page.reload()
-    await signIntoTerra(page, token)
-    await click(page, clickable({ text: 'Workspaces' }))
-    await waitForNoSpinners(page)
-  }
-
   await fillIn(page, input({ placeholder: 'SEARCH WORKSPACES' }), workspaceName)
   await click(page, clickable({ textContains: workspaceName }))
 

--- a/integration-tests/tests/preview-drs-uri.js
+++ b/integration-tests/tests/preview-drs-uri.js
@@ -1,7 +1,7 @@
 const _ = require('lodash/fp')
 const { withWorkspace, createEntityInWorkspace } = require('../utils/integration-helpers')
 const { withUserToken } = require('../utils/terra-sa-utils')
-const { findText, navChild, fillIn, click, clickable, elementInDataTableRow, waitForNoSpinners, input, signIntoTerra, dismissNotifications } = require('../utils/integration-utils')
+const { findText, navChild, fillIn, click, clickable, elementInDataTableRow, waitForNoSpinners, input, signIntoTerra, dismissNotifications, delay } = require('../utils/integration-utils')
 
 
 const testPreviewDrsUriFn = _.flow(
@@ -24,6 +24,20 @@ const testPreviewDrsUriFn = _.flow(
 
   await click(page, clickable({ textContains: 'View Workspaces' }))
   await waitForNoSpinners(page)
+
+  for (let i = 0; i < 50; i++) {
+    // console.log(`Attempt #${i}...`)
+    await fillIn(page, input({ placeholder: 'SEARCH WORKSPACES' }), workspaceName)
+    await click(page, clickable({ textContains: workspaceName }))
+
+    await findText(page, 'About the workspace')
+    // await delay(1000)
+    await page.reload()
+    await signIntoTerra(page, token)
+    await click(page, clickable({ text: 'Workspaces' }))
+    await waitForNoSpinners(page)
+  }
+
   await fillIn(page, input({ placeholder: 'SEARCH WORKSPACES' }), workspaceName)
   await click(page, clickable({ textContains: workspaceName }))
 

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -58,7 +58,20 @@ const input = ({ labelContains, placeholder }) => {
 }
 
 const fillIn = async (page, xpath, text) => {
-  return (await page.waitForXPath(xpath)).type(text, { delay: 20 })
+  const input = await page.waitForXPath(xpath)
+  await input.type(text, { delay: 20 })
+  // There are several places (e.g. workspace list search) where the page responds dynamically to
+  // typed input. That behavior could involve extra renders as component state settles. We strive to
+  // avoid the kinds of complex, multi-stage state transitions that can result in extra renders.
+  // But we aren't perfect.
+  //
+  // The impact on these tests is that elements found in the DOM immediately after typing text might
+  // get re-rendered (effectively going away) before the test can interact with them, leading to
+  // frustrating intermittent test failures. This test suite is _not_ intended to guard against
+  // unnecessary renders. It is to check that some specific critical paths through the application
+  // (Critical User Journeys) are not broken. Therefore, we'll delay briefly here instead of
+  // charging forward at a super-human pace.
+  return delay(250)
 }
 
 // Replace pre-existing value

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -71,7 +71,7 @@ const fillIn = async (page, xpath, text) => {
   // unnecessary renders. It is to check that some specific critical paths through the application
   // (Critical User Journeys) are not broken. Therefore, we'll delay briefly here instead of
   // charging forward at a super-human pace.
-  return delay(250)
+  return delay(300) // withDebouncedChange in input.js specifies 250ms, so waiting longer than that
 }
 
 // Replace pre-existing value


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/QA-1484

See the code comment for the high-level what and why.

In this case, I found at least 2 causes of extra renders on the workspace list page as state was settling.

1. `WorkspaceList` is being rendered twice for each debounced keystroke. The first render results from calling `setFilter` to update component state. The second render is in response to `Nav.history.replace` to put the search filter in the query string.
2. When the workspace list goes from more than a page to all fitting on a page, the scrollbar is no longer necessary. This changes the `Grid`s calculated width which results in an extra call to `cellRenderer`.

#1 is something that we can fix (and I will have a PR for shortly... though I don't know if there are downsides so I haven't created a ticket for it yet). #2 is less in our control. Maybe we could change something to prevent things from shifting around depending on whether or not there is a scrollbar. However, I argue that these are not the kinds of errors that these tests are supposed to identify. Therefore, this PR proposes a more general solution to the problem of pages that automatically update when text is typed into an input field.

I've had CircleCI run the tests against this branch several times and have not see the QA-1484 error.