### PR TITLE
Remove duplicate state to avoid re-renders [SATURN-1903]

### DIFF
--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -58,9 +58,7 @@ const input = ({ labelContains, placeholder }) => {
 }
 
 const fillIn = async (page, xpath, text) => {
-  const input = await page.waitForXPath(xpath)
-  await input.type(text, { delay: 20 })
-  return delay(250)
+  return (await page.waitForXPath(xpath)).type(text, { delay: 20 })
 }
 
 // Replace pre-existing value

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -58,9 +58,8 @@ const input = ({ labelContains, placeholder }) => {
 }
 
 const fillIn = async (page, xpath, text) => {
-  (await page.waitForXPath(xpath)).type(text, { delay: 20 })
-  return delay(2000)
-  // return (await page.waitForXPath(xpath)).type(text, { delay: 20 })
+  await (await page.waitForXPath(xpath)).type(text, { delay: 20 })
+  return delay(500)
 }
 
 // Replace pre-existing value

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -58,8 +58,9 @@ const input = ({ labelContains, placeholder }) => {
 }
 
 const fillIn = async (page, xpath, text) => {
-  await (await page.waitForXPath(xpath)).type(text, { delay: 20 })
-  return delay(500)
+  const input = await page.waitForXPath(xpath)
+  await input.type(text, { delay: 20 })
+  return delay(250)
 }
 
 // Replace pre-existing value

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -58,7 +58,9 @@ const input = ({ labelContains, placeholder }) => {
 }
 
 const fillIn = async (page, xpath, text) => {
-  return (await page.waitForXPath(xpath)).type(text, { delay: 20 })
+  (await page.waitForXPath(xpath)).type(text, { delay: 20 })
+  return delay(500)
+  // return (await page.waitForXPath(xpath)).type(text, { delay: 20 })
 }
 
 // Replace pre-existing value

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -59,7 +59,7 @@ const input = ({ labelContains, placeholder }) => {
 
 const fillIn = async (page, xpath, text) => {
   (await page.waitForXPath(xpath)).type(text, { delay: 20 })
-  return delay(500)
+  return delay(2000)
   // return (await page.waitForXPath(xpath)).type(text, { delay: 20 })
 }
 

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -1,7 +1,7 @@
 import { isAfter, parseJSON } from 'date-fns/fp'
 import _ from 'lodash/fp'
 import * as qs from 'qs'
-import { Fragment, useEffect, useMemo, useState } from 'react'
+import { Fragment, useMemo, useState } from 'react'
 import { div, h, span } from 'react-hyperscript-helpers'
 import { AutoSizer } from 'react-virtualized'
 import { HeaderRenderer, Link, Select, topSpinnerOverlay, transparentSpinnerOverlay } from 'src/components/common'

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -86,7 +86,7 @@ export const WorkspaceList = () => {
   const [featuredList, setFeaturedList] = useState()
 
   const { query } = Nav.useRoute()
-  const [filter, setFilter] = useState(query.filter || '')
+  const filter = query.filter || ''
   const [accessLevelsFilter, setAccessLevelsFilter] = useState(query.accessLevelsFilter || [])
   const [projectsFilter, setProjectsFilter] = useState(query.projectsFilter || undefined)
   const [submissionsFilter, setSubmissionsFilter] = useState(query.submissionsFilter || [])
@@ -109,7 +109,7 @@ export const WorkspaceList = () => {
     loadFeatured()
   })
 
-  useEffect(() => {
+  const onSearchChange = filter => {
     // Note: setting undefined so that falsy values don't show up at all
     const newSearch = qs.stringify({
       ...query, filter: filter || undefined, accessLevelsFilter, projectsFilter, tagsFilter, submissionsFilter,
@@ -119,7 +119,7 @@ export const WorkspaceList = () => {
     if (newSearch !== Nav.history.location.search) {
       Nav.history.replace({ search: newSearch })
     }
-  })
+  }
 
   const getWorkspace = id => _.find({ workspace: { workspaceId: id } }, workspaces)
 
@@ -306,7 +306,7 @@ export const WorkspaceList = () => {
         style: { marginLeft: '2rem', width: 500 },
         placeholder: 'SEARCH WORKSPACES',
         'aria-label': 'Search workspaces',
-        onChange: setFilter,
+        onChange: onSearchChange,
         value: filter
       })
     ]),


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/SATURN-1903

Discovered during investigation for https://broadworkbench.atlassian.net/browse/QA-1484

I had a theory that the test code was locating an element to click on but that the element was being re-rendered before the click actually happened. My plan was to add a small sleep after entering the search text to give react a chance to settle down. However, I could not reliably reproduce the error locally, so I had no confidence that the fix was working. The closest I got was one case where puppeteer reported: "Node is detached from document" which seemed consistent with my theory.

I took a step back and analyzed `WorkspaceList` render patterns and found that it was rendering twice for every change in the search input: once from changing state with `setFilter` and once in reaction to `Nav.history.replace`. My conclusion is that the filter state was duplicated between the component state in `WorkspaceList` and the value in the query string.

The solution here removes the component state and relies only on the value in the query string.

This was not the only source of extra rendering, so it does not fix QA-1484, but I thought it might be worth doing anyway, though I don't know if there are any downsides to this. If it looks okay to folks, I'll create a Jira ticket for it.