### PR TITLE
[IA-2800] Bump Galaxy version to 21.05

### DIFF
--- a/src/components/NewGalaxyModal.js
+++ b/src/components/NewGalaxyModal.js
@@ -414,7 +414,7 @@ export const NewGalaxyModalBase = Utils.withDisplayName('NewGalaxyModal')(
         div({ style: { ...styles.whiteBoxContainer, marginTop: '1rem' } }, [
           div([
             div({ style: styles.headerText }, ['Application configuration']),
-            div({ style: { marginTop: '0.5rem' } }, ['Galaxy version 21.01']),
+            div({ style: { marginTop: '0.5rem' } }, ['Galaxy version 21.05']),
             h(Link, { href: 'https://support.terra.bio/hc/en-us/articles/360050566271', ...Utils.newTabLinkProps }, [
               'Learn more about Galaxy interactive environments',
               icon('pop-out', { size: 12, style: { marginTop: '1rem', marginLeft: '0.25rem' } })


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2800

Friends with https://github.com/DataBiosphere/leonardo/pull/2187

Tested locally, see [comment](https://github.com/DataBiosphere/leonardo/pull/2187#issuecomment-869835630) in Leo PR.

This PR should wait until the Leo PR is deployed to production.
