### PR TITLE
CA-1232 + CA-1233: Support updating spend report configurations

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -451,6 +451,24 @@ const Billing = signal => ({
     return res
   },
 
+  changeBillingAccount: async ({ billingProjectName, newBillingAccountName }) => {
+    const res = await fetchOrchestration(`api/billing/v2/${billingProjectName}/billingAccount`,
+      _.mergeAll([
+        authOpts(), { signal, method: 'PUT' },
+        jsonBody({ billingAccount: newBillingAccountName })
+      ]))
+    return res
+  },
+
+  updateSpendConfiguration: async ({ billingProjectName, datasetGoogleProject, datasetName }) => {
+    const res = await fetchOrchestration(`api/billing/v2/${billingProjectName}/spendReportConfiguration`,
+      _.mergeAll([
+        authOpts(), { signal, method: 'PUT' },
+        jsonBody({ datasetGoogleProject, datasetName })
+      ]))
+    return res
+  },
+
   project: projectName => {
     const root = `billing/${projectName}`
 

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -5,6 +5,7 @@ import { div, h, span } from 'react-hyperscript-helpers'
 import { ButtonPrimary, HeaderRenderer, IdContainer, Link, Select, spinnerOverlay } from 'src/components/common'
 import { DeleteUserModal, EditUserModal, MemberCard, MemberCardHeaders, NewUserCard, NewUserModal } from 'src/components/group-common'
 import { icon, spinner } from 'src/components/icons'
+import { TextInput } from 'src/components/input'
 import Modal from 'src/components/Modal'
 import { SimpleTabBar } from 'src/components/tabBars'
 import { ariaSort } from 'src/components/table'
@@ -131,7 +132,10 @@ const ProjectDetail = ({ project, project: { projectName, creationStatus }, bill
   const [loadingBillingInfo, setLoadingBillingInfo] = useState(false)
   const [billingAccountName, setBillingAccountName] = useState(null)
   const [showBillingModal, setShowBillingModal] = useState(false)
+  const [showSpendReportConfigurationModal, setShowSpendReportConfigurationModal] = useState(false)
   const [selectedBilling, setSelectedBilling] = useState()
+  const [selectedDatasetProjectName, setSelectedDatasetProjectName] = useState(null)
+  const [selectedDatasetName, setSelectedDatasetName] = useState(null)
   const [tab, setTab] = useState(query.tab || 'workspaces')
   const [expandedWorkspaceName, setExpandedWorkspaceName] = useState()
   const [sort, setSort] = useState({ field: 'email', direction: 'asc' })
@@ -213,8 +217,8 @@ const ProjectDetail = ({ project, project: { projectName, creationStatus }, bill
       newName: newAccountName,
       billingProjectName: projectName
     })
-    const { newBillingAccountName } = await Ajax(signal).GoogleBilling.changeBillingAccount({ projectId: projectName, newAccountName })
-    setBillingAccountName(newBillingAccountName)
+    await Ajax(signal).Billing.changeBillingAccount({ billingProjectName: projectName, newBillingAccountName: newAccountName })
+    setBillingAccountName(newAccountName)
   })
 
   const loadBillingInfo = _.flow(
@@ -225,6 +229,13 @@ const ProjectDetail = ({ project, project: { projectName, creationStatus }, bill
       const { billingAccountName } = await Ajax(signal).GoogleBilling.getBillingInfo(projectName)
       setBillingAccountName(billingAccountName)
     }
+  })
+
+  const updateSpendConfiguration = _.flow(
+    withErrorReporting('Error updating spend report configuration'),
+    Utils.withBusyState(setUpdating)
+  )(async () => {
+    await Ajax(signal).Billing.updateSpendConfiguration({ billingProjectName: projectName, datasetGoogleProject: selectedDatasetProjectName, datasetName: selectedDatasetName })
   })
 
   const refresh = _.flow(
@@ -308,7 +319,56 @@ const ProjectDetail = ({ project, project: { projectName, creationStatus }, bill
               isClearable: false,
               options: _.map(({ displayName, accountName }) => ({ label: displayName, value: accountName }), billingAccounts),
               onChange: ({ value: newAccountName }) => setSelectedBilling(newAccountName)
+            }),
+            div({ style: { marginTop: '1rem' } }, ['Note: Changing the billing account for this ' +
+            'billing project will clear the spend report configuration.'])
+          ])])
+        ])
+      ]),
+      div({ style: { color: colors.dark(), fontSize: 14, display: 'flex', alignItems: 'center', marginTop: '0.5rem', marginLeft: '1rem' } }, [
+        span({ style: { flexShrink: 0, fontWeight: 600, fontSize: 14, margin: '0 0.75rem 0 0' } }, 'Spend Report Configuration:'),
+        span({ style: { flexShrink: 0 } }, 'Edit'),
+        h(Link, {
+          tooltip: 'Configure Spend Reporting',
+          style: { marginLeft: '0.5rem' },
+          onClick: async () => {
+            if (Auth.hasBillingScope()) {
+              setShowSpendReportConfigurationModal(true)
+            } else {
+              await authorizeAndLoadAccounts()
+              setShowSpendReportConfigurationModal(Auth.hasBillingScope())
+            }
+          }
+        }, [icon('edit', { size: 12 })]),
+        showSpendReportConfigurationModal && h(Modal, {
+          title: 'Configure Spend Reporting',
+          onDismiss: () => setShowSpendReportConfigurationModal(false),
+          okButton: h(ButtonPrimary, {
+            disabled: !selectedDatasetProjectName || !selectedDatasetName,
+            onClick: async () => {
+              setShowSpendReportConfigurationModal(false)
+              await updateSpendConfiguration(projectName, selectedDatasetProjectName, selectedDatasetName)
+            }
+          }, ['Ok'])
+        }, [
+          h(IdContainer, [id => h(Fragment, [
+            h(FormLabel, { htmlFor: id, required: true }, ['Dataset Project Name']),
+            h(TextInput, {
+              id,
+              onChange: v => setSelectedDatasetProjectName(v)
             })
+          ])]),
+          h(IdContainer, [id => h(Fragment, [
+            h(FormLabel, { htmlFor: id, required: true }, ['Dataset Name']),
+            h(TextInput, {
+              id,
+              onChange: v => setSelectedDatasetName(v)
+            }),
+            div({ style: { marginTop: '1rem' } }, [
+              ['See '],
+              h(Link, { href: 'https://support.terra.bio/hc/en-us/articles/4402636420763', ...Utils.newTabLinkProps }, ['our documentation']),
+              [' for details on configuring spend reporting for billing projects.']
+            ])
           ])])
         ])
       ]),

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -325,7 +325,7 @@ const ProjectDetail = ({ project, project: { projectName, creationStatus }, bill
           ])])
         ])
       ]),
-      div({ style: { color: colors.dark(), fontSize: 14, display: 'flex', alignItems: 'center', marginTop: '0.5rem', marginLeft: '1rem' } }, [
+      div({ style: { color: colors.dark(), fontSize: 14, display: 'flex', alignItems: 'center', margin: '0.5rem 0 0 1rem' } }, [
         span({ style: { flexShrink: 0, fontWeight: 600, fontSize: 14, marginRight: '0.75rem' } }, 'Workflow Spend Report Configuration:'),
         span({ style: { flexShrink: 0 } }, 'Edit'),
         h(Link, {

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -326,7 +326,7 @@ const ProjectDetail = ({ project, project: { projectName, creationStatus }, bill
         ])
       ]),
       div({ style: { color: colors.dark(), fontSize: 14, display: 'flex', alignItems: 'center', marginTop: '0.5rem', marginLeft: '1rem' } }, [
-        span({ style: { flexShrink: 0, fontWeight: 600, fontSize: 14, margin: '0 0.75rem 0 0' } }, 'Workflow Spend Report Configuration:'),
+        span({ style: { flexShrink: 0, fontWeight: 600, fontSize: 14, marginRight: '0.75rem' } }, 'Workflow Spend Report Configuration:'),
         span({ style: { flexShrink: 0 } }, 'Edit'),
         h(Link, {
           tooltip: 'Configure Workflow Spend Reporting',

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -321,7 +321,7 @@ const ProjectDetail = ({ project, project: { projectName, creationStatus }, bill
               onChange: ({ value: newAccountName }) => setSelectedBilling(newAccountName)
             }),
             div({ style: { marginTop: '1rem' } },
-              ['Note: Changing the billing account for this billing project will clear the spend report configuration.'])
+              ['Note: Changing the billing account for this billing project will clear the workflow spend report configuration.'])
           ])])
         ])
       ]),

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -362,7 +362,7 @@ const ProjectDetail = ({ project, project: { projectName, creationStatus }, bill
             h(FormLabel, { htmlFor: id, required: true }, ['Dataset Name']),
             h(TextInput, {
               id,
-              onChange: v => setSelectedDatasetName(v)
+              onChange: setSelectedDatasetName
             }),
             div({ style: { marginTop: '1rem' } }, [
               ['See '],

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -355,7 +355,7 @@ const ProjectDetail = ({ project, project: { projectName, creationStatus }, bill
             h(FormLabel, { htmlFor: id, required: true }, ['Dataset Project Name']),
             h(TextInput, {
               id,
-              onChange: v => setSelectedDatasetProjectName(v)
+              onChange: setSelectedDatasetProjectName
             })
           ])]),
           h(IdContainer, [id => h(Fragment, [

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -232,7 +232,7 @@ const ProjectDetail = ({ project, project: { projectName, creationStatus }, bill
   })
 
   const updateSpendConfiguration = _.flow(
-    withErrorReporting('Error updating spend report configuration'),
+    withErrorReporting('Error updating workflow spend report configuration'),
     Utils.withBusyState(setUpdating)
   )(async () => {
     await Ajax(signal).Billing.updateSpendConfiguration({ billingProjectName: projectName, datasetGoogleProject: selectedDatasetProjectName, datasetName: selectedDatasetName })
@@ -326,10 +326,10 @@ const ProjectDetail = ({ project, project: { projectName, creationStatus }, bill
         ])
       ]),
       div({ style: { color: colors.dark(), fontSize: 14, display: 'flex', alignItems: 'center', marginTop: '0.5rem', marginLeft: '1rem' } }, [
-        span({ style: { flexShrink: 0, fontWeight: 600, fontSize: 14, margin: '0 0.75rem 0 0' } }, 'Spend Report Configuration:'),
+        span({ style: { flexShrink: 0, fontWeight: 600, fontSize: 14, margin: '0 0.75rem 0 0' } }, 'Workflow Spend Report Configuration:'),
         span({ style: { flexShrink: 0 } }, 'Edit'),
         h(Link, {
-          tooltip: 'Configure Spend Reporting',
+          tooltip: 'Configure Workflow Spend Reporting',
           style: { marginLeft: '0.5rem' },
           onClick: async () => {
             if (Auth.hasBillingScope()) {
@@ -341,7 +341,7 @@ const ProjectDetail = ({ project, project: { projectName, creationStatus }, bill
           }
         }, [icon('edit', { size: 12 })]),
         showSpendReportConfigurationModal && h(Modal, {
-          title: 'Configure Spend Reporting',
+          title: 'Configure Workflow Spend Reporting',
           onDismiss: () => setShowSpendReportConfigurationModal(false),
           okButton: h(ButtonPrimary, {
             disabled: !selectedDatasetProjectName || !selectedDatasetName,
@@ -366,8 +366,8 @@ const ProjectDetail = ({ project, project: { projectName, creationStatus }, bill
             }),
             div({ style: { marginTop: '1rem' } }, [
               ['See '],
-              h(Link, { href: 'https://support.terra.bio/hc/en-us/articles/4402636420763', ...Utils.newTabLinkProps }, ['our documentation']),
-              [' for details on configuring spend reporting for billing projects.']
+              h(Link, { href: 'https://support.terra.bio/hc/en-us/articles/360037862771', ...Utils.newTabLinkProps }, ['our documentation']),
+              [' for details on configuring workflow spend reporting for billing projects.']
             ])
           ])])
         ])

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -320,8 +320,8 @@ const ProjectDetail = ({ project, project: { projectName, creationStatus }, bill
               options: _.map(({ displayName, accountName }) => ({ label: displayName, value: accountName }), billingAccounts),
               onChange: ({ value: newAccountName }) => setSelectedBilling(newAccountName)
             }),
-            div({ style: { marginTop: '1rem' } }, ['Note: Changing the billing account for this ' +
-            'billing project will clear the spend report configuration.'])
+            div({ style: { marginTop: '1rem' } },
+              ['Note: Changing the billing account for this billing project will clear the spend report configuration.'])
           ])])
         ])
       ]),


### PR DESCRIPTION
Updates to the project view page:
![Screen Shot 2021-06-28 at 1 53 38 PM](https://user-images.githubusercontent.com/7257391/123681889-5a41ab80-d818-11eb-9e5b-aa5f801fc532.png)

Visual updates to when you change the billing account (this now also calls orch instead of GCP directly):

![Screen Shot 2021-06-28 at 1 53 55 PM](https://user-images.githubusercontent.com/7257391/123681918-60378c80-d818-11eb-81d4-ef8c4ee3229a.png)

What you see when you click "Edit":

![Screen Shot 2021-06-28 at 1 53 45 PM](https://user-images.githubusercontent.com/7257391/123681877-56158e00-d818-11eb-848c-98fb800bc2d5.png)


I've tested valid cases and cases that will produce errors (i.e. project or dataset not existing or permission not being correctly granted)

You'll probably want to use b.adm.firec if you want to test this yourself since there's the ole "untrusted app" issue when requiring the billing scopes