### PR TITLE
[IA-2700] Finalize analysis table

### DIFF
--- a/config/dev.json
+++ b/config/dev.json
@@ -2,7 +2,7 @@
   "agoraUrlRoot": "https://agora.dsde-dev.broadinstitute.org",
   "bardRoot": "https://terra-bard-dev.appspot.com",
   "bondUrlRoot": "https://broad-bond-dev.appspot.com",
-  "calhounUrlRoot": "https://terra-calhoun-dev.appspot.com",
+  "calhounUrlRoot": "https://calhoun.dsde-dev.broadinstitute.org",
   "dataRepoUrlRoot": "https://jade.datarepo-dev.broadinstitute.org",
   "devUrlRoot": "https://bvdp-saturn-dev.appspot.com",
   "dockstoreUrlRoot": "https://staging.dockstore.org",

--- a/config/fiab.json
+++ b/config/fiab.json
@@ -2,7 +2,7 @@
   "agoraUrlRoot": "https://agora-fiab.dsde-dev.broadinstitute.org:20443",
   "bardRoot": "https://terra-bard-dev.appspot.com",
   "bondUrlRoot": "https://broad-bond-dev.appspot.com",
-  "calhounUrlRoot": "https://terra-calhoun-dev.appspot.com",
+  "calhounUrlRoot": "https://calhoun.dsde-dev.broadinstitute.org",
   "dataRepoUrlRoot": "https://jade.datarepo-dev.broadinstitute.org",
   "devUrlRoot": "https://bvdp-saturn-dev.appspot.com",
   "dockstoreUrlRoot": "https://staging.dockstore.org",

--- a/src/components/ContextBar.js
+++ b/src/components/ContextBar.js
@@ -16,7 +16,10 @@ const contextBarStyles = {
     padding: '1rem',
     color: colors.accent(),
     backgroundColor: colors.accent(0.2)
-  }
+  },
+  //original hover for reference
+  // hover: { boxShadow: `inset -6px 0px ${colors.accent()}` }
+  hover: { backgroundColor: colors.accent(0.4) }
 }
 
 export const ContextBarButtons = ({ setDeletingWorkspace, setCloningWorkspace, setSharingWorkspace, isOwner, canShare }) => {
@@ -44,21 +47,21 @@ export const ContextBarButtons = ({ setDeletingWorkspace, setCloningWorkspace, s
       h(Clickable, {
         'aria-label': 'Menu',
         style: contextBarStyles.contextBarButton,
-        hover: { boxShadow: `inset -6px 0px ${terraSpecial(0.9)}` },
+        hover: contextBarStyles.hover,
         tooltip: 'Menu',
         tooltipDelay: 100
       }, [icon('ellipsis-v', { size: 24 })])
     ]),
     h(Clickable, {
       style: contextBarStyles.contextBarButton,
-      hover: { boxShadow: `inset -6px 0px ${terraSpecial(0.9)}` },
+      hover: contextBarStyles.hover,
       // TODO: add click handler
       ...{ tooltip: 'Compute Configuration', tooltipDelay: 100 },
       'aria-label': 'Compute Configuration'
     }, [icon('cloudBolt', { size: 24 })]),
     h(Clickable, {
       style: contextBarStyles.contextBarButton,
-      hover: { boxShadow: `inset -6px 0px ${terraSpecial(0.9)}` },
+      hover: contextBarStyles.hover,
       // TODO: add click handler
       tooltip: 'Terminal',
       tooltipDelay: 100,

--- a/src/components/ContextBar.js
+++ b/src/components/ContextBar.js
@@ -3,7 +3,7 @@ import { div, h } from 'react-hyperscript-helpers'
 import { Clickable, comingSoon } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import { makeMenuIcon, MenuButton, MenuTrigger } from 'src/components/PopupTrigger'
-import colors, { terraSpecial } from 'src/libs/colors'
+import colors from 'src/libs/colors'
 
 
 const contextBarStyles = {

--- a/src/components/ContextBar.js
+++ b/src/components/ContextBar.js
@@ -17,8 +17,6 @@ const contextBarStyles = {
     color: colors.accent(),
     backgroundColor: colors.accent(0.2)
   },
-  //original hover for reference
-  // hover: { boxShadow: `inset -6px 0px ${colors.accent()}` }
   hover: { backgroundColor: colors.accent(0.4) }
 }
 
@@ -49,6 +47,7 @@ export const ContextBarButtons = ({ setDeletingWorkspace, setCloningWorkspace, s
         style: contextBarStyles.contextBarButton,
         hover: contextBarStyles.hover,
         tooltip: 'Menu',
+        tooltipSide: 'left',
         tooltipDelay: 100
       }, [icon('ellipsis-v', { size: 24 })])
     ]),
@@ -56,7 +55,9 @@ export const ContextBarButtons = ({ setDeletingWorkspace, setCloningWorkspace, s
       style: contextBarStyles.contextBarButton,
       hover: contextBarStyles.hover,
       // TODO: add click handler
-      ...{ tooltip: 'Compute Configuration', tooltipDelay: 100 },
+      tooltip: 'Compute Configuration',
+      tooltipDelay: 100,
+      tooltipSide: 'left',
       'aria-label': 'Compute Configuration'
     }, [icon('cloudBolt', { size: 24 })]),
     h(Clickable, {
@@ -64,6 +65,7 @@ export const ContextBarButtons = ({ setDeletingWorkspace, setCloningWorkspace, s
       hover: contextBarStyles.hover,
       // TODO: add click handler
       tooltip: 'Terminal',
+      tooltipSide: 'left',
       tooltipDelay: 100,
       'aria-label': 'Terminal'
     }, [icon('terminal', { size: 24 })])

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -939,15 +939,6 @@ const Buckets = signal => ({
     return _.filter(({ name }) => name.endsWith(`.${tools.Jupyter.ext}`), items)
   },
 
-  listRmds: async (namespace, name) => {
-    const res = await fetchBuckets(
-      `storage/v1/b/${name}/o?prefix=notebooks/`,
-      _.merge(authOpts(await saToken(namespace)), { signal })
-    )
-    const { items } = await res.json()
-    return _.filter(({ name }) => name.endsWith(`.${tools.RStudio.ext}`), items)
-  },
-
   listAnalyses: async (namespace, name) => {
     const res = await fetchBuckets(
       `storage/v1/b/${name}/o?prefix=notebooks/`,

--- a/src/libs/style.js
+++ b/src/libs/style.js
@@ -27,7 +27,7 @@ export const elements = {
   },
   sectionHeader: { color: colors.dark(), fontSize: 16, fontWeight: 600, margin: '0.25em 0' },
   pageContentContainer: { position: 'relative', flexGrow: 1, display: 'flex', flexDirection: 'column' },
-  contextBarContainer: { flex: 'none', width: 55, backgroundColor: colors.dark(0.15) }
+  contextBarContainer: { flex: 'none', width: 55, backgroundColor: colors.light(), borderLeft: `1px solid ${colors.accent()}` }
 }
 
 export const tabBar = {

--- a/src/pages/workspaces/workspace/Analyses.js
+++ b/src/pages/workspaces/workspace/Analyses.js
@@ -210,8 +210,6 @@ const Analyses = _.flow(
   const [deletingAnalysisName, setDeletingAnalysisName] = useState(undefined)
   const [exportingAnalysisName, setExportingAnalysisName] = useState(undefined)
   const [sortOrder, setSortOrder] = useState(() => StateHistory.get().sortOrder || defaultSort.value)
-  console.log('sort order')
-  console.log(sortOrder)
   const [filter, setFilter] = useState(() => StateHistory.get().filter || '')
   const [busy, setBusy] = useState(false)
   const [creating, setCreating] = useState(false)

--- a/src/pages/workspaces/workspace/Analyses.js
+++ b/src/pages/workspaces/workspace/Analyses.js
@@ -60,10 +60,10 @@ const analysisContextMenuSize = 18
 
 const AnalysisCardHeaders = Utils.memoWithName('AnalysisCardHeaders', ({ sort, onSort }) => {
   return div({ style: { display: 'flex', justifyContent: 'space-between', marginTop: '1.5rem', padding: '0 1rem', marginBottom: '0.5rem' } }, [
-    div({ 'aria-sort': ariaSort(sort, 'Application'), style: { paddingLeft: '1rem', flex: 1 } }, [
+    div({ 'aria-sort': ariaSort(sort, 'Application'), style: { flex: 1 } }, [
       h(HeaderRenderer, { sort, onSort, name: 'application' })
     ]),
-    div({ 'aria-sort': ariaSort(sort, 'name'), style: { flex: '5 1 5%' } }, [
+    div({ 'aria-sort': ariaSort(sort, 'name'), style: { flex: 5 } }, [
       h(HeaderRenderer, { sort, onSort, name: 'name' })
     ]),
     div({ 'aria-sort': ariaSort(sort, 'lastModified'), style: { flex: 1, justifyContent: 'flex-end', display: 'flex' } }, [

--- a/src/pages/workspaces/workspace/Analyses.js
+++ b/src/pages/workspaces/workspace/Analyses.js
@@ -155,13 +155,14 @@ const AnalysisCard = ({ namespace, name, lastModified, metadata, application, ws
   }, getDisplayName(name))
 
   //the flex values here correspond to the flex values in the header
-  const appIconSrc = Utils.switchCase(application, [tools.Jupyter.label, () => jupyterLogo], [tools.RStudio.label, () => rLogo])
-  const appIcon = div({ style: { marginRight: '1rem' } }, [
-    img({ src: appIconSrc, style: { height: 40, width: 40 } })
+  const toolIconSrc = Utils.switchCase(application, [tools.Jupyter.label, () => jupyterLogo], [tools.RStudio.label, () => rLogo])
+  const toolIcon = div({ style: { marginRight: '1rem' } }, [
+    img({ src: toolIconSrc, style: { height: 40, width: 40 } })
   ])
 
-  const appContainer = div({ style: { display: 'flex', flex: 1, flexDirection: 'row', alignItems: 'center'} }, [
-    appIcon,
+  const toolContainer = div({ style: { display: 'flex', flex: 1, flexDirection: 'row', alignItems: 'center'} }, [
+    toolIcon,
+    // this is the tool name, i.e. 'Jupyter'. It is named identical to the header row to simplify the sorting code at the cost of naming consistency.
     application
   ])
 
@@ -171,7 +172,7 @@ const AnalysisCard = ({ namespace, name, lastModified, metadata, application, ws
       ...Style.cardList.longCardShadowless
     }
   }, [
-    appContainer,
+    toolContainer,
     artefactName,
     div({ style: { flex: 1, display: 'flex', flexDirection: 'row', justifyContent: 'flex-end' } }, [
       locked && h(Clickable, {

--- a/src/pages/workspaces/workspace/Analyses.js
+++ b/src/pages/workspaces/workspace/Analyses.js
@@ -66,13 +66,13 @@ const AnalysisCardHeaders = Utils.memoWithName('AnalysisCardHeaders', ({ sort, o
     div({ 'aria-sort': ariaSort(sort, 'name'), style: { flex: 5 } }, [
       h(HeaderRenderer, { sort, onSort, name: 'name' })
     ]),
-    div({ 'aria-sort': ariaSort(sort, 'lastModified'), style: { flex: 1, justifyContent: 'flex-end', display: 'flex' } }, [
+    div({ 'aria-sort': ariaSort(sort, 'lastModified'), style: { flex: '0 0 10%', justifyContent: 'flex-left', display: 'flex' } }, [
       h(HeaderRenderer, { sort, onSort, name: 'lastModified' })
-    ]),
-    //this is to offset the right-aligned header content by the size of the context menu in the table rows
-    div({ style: { flex: `0 0 ${analysisContextMenuSize}px` } }, [
-      div({ className: 'sr-only' }, ['Expand'])
     ])
+    //this is to offset the right-aligned header content by the size of the context menu in the table rows
+    // div({ style: { flex: `0 0 ${analysisContextMenuSize}px` } }, [
+    //   div({ className: 'sr-only' }, ['Expand'])
+    // ])
   ])
 })
 
@@ -174,14 +174,16 @@ const AnalysisCard = ({ namespace, name, lastModified, metadata, application, ws
   }, [
     toolContainer,
     artefactName,
-    div({ style: { flex: 1, display: 'flex', flexDirection: 'row', justifyContent: 'flex-end' } }, [
-      locked && h(Clickable, {
-        style: { display: 'flex', paddingRight: '1rem', color: colors.dark(0.75) },
-        tooltip: `This analysis is currently being edited by ${lockedBy || 'another user'}`
-      }, [icon('lock')]),
-      h(TooltipTrigger, { content: Utils.makeCompleteDate(lastModified) }, [
-        div({ style: { fontSize: '0.8rem', marginRight: '0.5rem' } },
-          `Last edited: ${Utils.makePrettyDate(lastModified)}`)
+    //The 10% allows for the longest date possible (September XX, XXXX), plus a locked symbol, without text wrapping when the screen is maximized
+    div({ style: { flex: '0 0 10%', display: 'flex', flexDirection: 'row', justifyContent: 'flex-left' } }, [
+      div({ style: { flex: 1, display: 'flex'} }, [
+        locked && h(Clickable, {
+          style: { display: 'flex', paddingRight: '1rem', color: colors.dark(0.75) },
+          tooltip: `This analysis is currently being edited by ${lockedBy || 'another user'}`
+        }, [icon('lock')]),
+        h(TooltipTrigger, { content: Utils.makeCompleteDate(lastModified) }, [
+          div({ style: { fontSize: '0.8rem' } }, [Utils.makePrettyDate(lastModified)])
+        ])
       ]),
       analysisMenu
     ])

--- a/src/pages/workspaces/workspace/Analyses.js
+++ b/src/pages/workspaces/workspace/Analyses.js
@@ -51,15 +51,6 @@ import { wrapWorkspace } from 'src/pages/workspaces/workspace/WorkspaceContainer
 import { ariaSort } from 'src/components/table'
 
 
-const analysisCardCommonStyles = _.merge({ display: 'flex' },
-  {
-    marginBottom: '0.5rem',
-    flexDirection: 'row',
-    alignItems: 'center',
-    width: '100%'
-  }
-)
-
 const noWrite = 'You do not have access to modify this workspace.'
 
 const sortTokens = {
@@ -73,18 +64,18 @@ const sortOptions = [
   { label: 'Reverse Alphabetical', value: { field: 'name', direction: 'desc' } }
 ]
 
-const workspaceLastModifiedWidth = 150
+const workspaceLastModifiedWidth = 133
 const workspaceExpandIconSize = 18
 
 const AnalysisCardHeaders = Utils.memoWithName('AnalysisCardHeaders', ({ sort, onSort }) => {
-  return div({ style: { display: 'flex', flexDirection: 'row', alignItems: 'center', marginTop: '1.5rem', padding: '0 1rem', marginBottom: '0.5rem' } }, [
-    div({ 'aria-sort': ariaSort(sort, 'Application'), style: { flex: 1, paddingLeft: '1rem' } }, [
+  return div({ style: { display: 'flex', justifyContent: 'space-between', marginTop: '1.5rem', padding: '0 1rem', marginBottom: '0.5rem' } }, [
+    div({ 'aria-sort': ariaSort(sort, 'Application'), style: { paddingLeft: '1rem', flex: 1 } }, [
       h(HeaderRenderer, { sort, onSort, name: 'application' })
     ]),
-    div({ 'aria-sort': ariaSort(sort, 'name'), style: { flex: '0 0 400px', marginRight: 20 } }, [
+    div({ 'aria-sort': ariaSort(sort, 'name'), style: { flex: 5 } }, [
       h(HeaderRenderer, { sort, onSort, name: 'name' })
     ]),
-    div({style: { flexGrow: 1}}),
+    div({style: { flexGrow: 2 } }),
     div({ 'aria-sort': ariaSort(sort, 'lastModified'), style: { flex: `0 0 ${workspaceLastModifiedWidth}px` } }, [
       h(HeaderRenderer, { sort, onSort, name: 'lastModified' })
     ]),
@@ -165,11 +156,10 @@ const AnalysisCard = ({ namespace, name, lastModified, metadata, application, ws
     ])
   ])
 
-  const title = div({
+  const artefactName = div({
     title: getDisplayName(name),
     style: {
-      ...Style.elements.card.title, whiteSpace: 'normal', overflowY: 'auto',
-      marginLeft: '1rem', flex: 1
+      ...Style.elements.card.title, whiteSpace: 'normal', overflowY: 'auto', flex: 5, textAlign: 'left'
     }
   }, getDisplayName(name))
 
@@ -178,20 +168,24 @@ const AnalysisCard = ({ namespace, name, lastModified, metadata, application, ws
     img({ src: appIconSrc, style: { height: 40, width: 40 } })
   ])
 
+  const appContainer = div({ style: { display: 'flex', flex: 1, flexDirection: 'row', alignItems: 'center'} }, [
+    appIcon,
+    div({style: {width: '60px'}}, ['test'])
+  ])
+
   console.log('last modified')
   console.log(lastModified)
 
   return a({
     href: analysisLink,
     style: {
-      ...Style.elements.card.container,
-      ...analysisCardCommonStyles,
+      ...Style.cardList.longCardShadowless
     }
   }, [
-    appIcon,
-    application,
-    title,
+    appContainer,
+    artefactName,
     div({ style: { flexGrow: 1 } }),
+    div({ style: { flex: 1, display: 'flex', flexDirection: 'row', alignItems: 'flex-end'}},[
     locked && h(Clickable, {
       style: { display: 'flex', paddingRight: '1rem', color: colors.dark(0.75) },
       tooltip: `This analysis is currently being edited by ${lockedBy || 'another user'}`
@@ -201,6 +195,7 @@ const AnalysisCard = ({ namespace, name, lastModified, metadata, application, ws
         `Last edited: ${Utils.makePrettyDate(lastModified)}`)
     ]),
     analysisMenu
+    ])
   ])
 }
 
@@ -342,7 +337,7 @@ const Analyses = _.flow(
 
     return div({
       style: {
-        ..._.merge({ textAlign: 'center', display: 'flex', justifyContent: 'center' }, _.isEmpty(analyses) ? { alignItems: 'center', height: '80%' } : { flexDirection: 'column'})
+        ..._.merge({ textAlign: 'center', display: 'flex', justifyContent: 'center', backgroundColor: colors.light(), padding: '0 1rem 0 1rem'}, _.isEmpty(analyses) ? { alignItems: 'center', height: '80%' } : { flexDirection: 'column'})
       }
     }, [
       Utils.cond(

--- a/src/pages/workspaces/workspace/Analyses.js
+++ b/src/pages/workspaces/workspace/Analyses.js
@@ -157,7 +157,7 @@ const AnalysisCard = ({ namespace, name, lastModified, metadata, application, ws
   //the flex values here correspond to the flex values in the header
   const toolIconSrc = Utils.switchCase(application, [tools.Jupyter.label, () => jupyterLogo], [tools.RStudio.label, () => rLogo])
   const toolIcon = div({ style: { marginRight: '1rem' } }, [
-    img({ src: toolIconSrc, style: { height: 40, width: 40 } })
+    img({ src: toolIconSrc, style: { height: 40, width: 50 } })
   ])
 
   const toolContainer = div({ style: { display: 'flex', flex: 1, flexDirection: 'row', alignItems: 'center'} }, [

--- a/src/pages/workspaces/workspace/Analyses.js
+++ b/src/pages/workspaces/workspace/Analyses.js
@@ -59,7 +59,7 @@ const defaultSort = { label: 'Most Recently Updated', value: { field: 'lastModif
 const analysisContextMenuSize = 18
 
 const AnalysisCardHeaders = Utils.memoWithName('AnalysisCardHeaders', ({ sort, onSort }) => {
-  return div({ style: { display: 'flex', justifyContent: 'space-between', marginTop: '1.5rem', padding: '0 1rem', marginBottom: '0.5rem' } }, [
+  return div({ style: { display: 'flex', justifyContent: 'space-between', marginTop: '1.5rem', padding: '0 1rem 0 1.5rem', marginBottom: '0.5rem' } }, [
     div({ 'aria-sort': ariaSort(sort, 'Application'), style: { flex: 1 } }, [
       h(HeaderRenderer, { sort, onSort, name: 'application' })
     ]),
@@ -151,7 +151,9 @@ const AnalysisCard = ({ namespace, name, lastModified, metadata, application, ws
     }
   }, [getDisplayName(name)])
 
-  const toolIconSrc = Utils.switchCase(application, [tools.Jupyter.label, () => jupyterLogo], [tools.RStudio.label, () => rLogo])
+  const toolIconSrc = Utils.switchCase(application,
+    [tools.Jupyter.label, () => jupyterLogo],
+    [tools.RStudio.label, () => rLogo])
   const toolIcon = div({ style: { marginRight: '1rem' } }, [
     img({ src: toolIconSrc, style: { height: 40, width: 50 } })
   ])
@@ -164,9 +166,9 @@ const AnalysisCard = ({ namespace, name, lastModified, metadata, application, ws
 
   return a({
     href: analysisLink,
-    style: {
+    style: _.merge({
       ...Style.cardList.longCardShadowless
-    }
+    }, { marginBottom: '.75rem', paddingLeft: '1.5rem' })
   }, [
     toolContainer,
     artefactName,
@@ -178,7 +180,7 @@ const AnalysisCard = ({ namespace, name, lastModified, metadata, application, ws
           tooltip: `This analysis is currently being edited by ${lockedBy || 'another user'}`
         }, [icon('lock')]),
         h(TooltipTrigger, { content: Utils.makeCompleteDate(lastModified) }, [
-          div({ style: { fontSize: '0.8rem' } }, [Utils.makePrettyDate(lastModified)])
+          div({ style: { fontSize: '0.8rem', display: 'flex', alignItems: 'center' } }, [Utils.makePrettyDate(lastModified)])
         ])
       ]),
       analysisMenu

--- a/src/pages/workspaces/workspace/Analyses.js
+++ b/src/pages/workspaces/workspace/Analyses.js
@@ -69,10 +69,6 @@ const AnalysisCardHeaders = Utils.memoWithName('AnalysisCardHeaders', ({ sort, o
     div({ 'aria-sort': ariaSort(sort, 'lastModified'), style: { flex: '0 0 10%', justifyContent: 'flex-left', display: 'flex' } }, [
       h(HeaderRenderer, { sort, onSort, name: 'lastModified' })
     ])
-    //this is to offset the right-aligned header content by the size of the context menu in the table rows
-    // div({ style: { flex: `0 0 ${analysisContextMenuSize}px` } }, [
-    //   div({ className: 'sr-only' }, ['Expand'])
-    // ])
   ])
 })
 
@@ -147,20 +143,20 @@ const AnalysisCard = ({ namespace, name, lastModified, metadata, application, ws
     ])
   ])
 
+  //the flex values for columns here correspond to the flex values in the header
   const artefactName = div({
     title: getDisplayName(name),
     style: {
       ...Style.elements.card.title, whiteSpace: 'normal', overflowY: 'auto', flex: 5, textAlign: 'left'
     }
-  }, getDisplayName(name))
+  }, [getDisplayName(name)])
 
-  //the flex values here correspond to the flex values in the header
   const toolIconSrc = Utils.switchCase(application, [tools.Jupyter.label, () => jupyterLogo], [tools.RStudio.label, () => rLogo])
   const toolIcon = div({ style: { marginRight: '1rem' } }, [
     img({ src: toolIconSrc, style: { height: 40, width: 50 } })
   ])
 
-  const toolContainer = div({ style: { display: 'flex', flex: 1, flexDirection: 'row', alignItems: 'center'} }, [
+  const toolContainer = div({ style: { display: 'flex', flex: 1, flexDirection: 'row', alignItems: 'center' } }, [
     toolIcon,
     // this is the tool name, i.e. 'Jupyter'. It is named identical to the header row to simplify the sorting code at the cost of naming consistency.
     application
@@ -176,7 +172,7 @@ const AnalysisCard = ({ namespace, name, lastModified, metadata, application, ws
     artefactName,
     //The 10% allows for the longest date possible (September XX, XXXX), plus a locked symbol, without text wrapping when the screen is maximized
     div({ style: { flex: '0 0 10%', display: 'flex', flexDirection: 'row', justifyContent: 'flex-left' } }, [
-      div({ style: { flex: 1, display: 'flex'} }, [
+      div({ style: { flex: 1, display: 'flex' } }, [
         locked && h(Clickable, {
           style: { display: 'flex', paddingRight: '1rem', color: colors.dark(0.75) },
           tooltip: `This analysis is currently being edited by ${lockedBy || 'another user'}`
@@ -333,7 +329,7 @@ const Analyses = _.flow(
           return div({ style: { fontStyle: 'italic' } }, ['No matching analyses'])
         }],
         [Utils.DEFAULT, () => h(Fragment, [
-          h(AnalysisCardHeaders, {sort: sortOrder, onSort: setSortOrder }),
+          h(AnalysisCardHeaders, { sort: sortOrder, onSort: setSortOrder }),
           div({ role: 'list', 'aria-label': 'analysis artefacts in workspace', style: { flexGrow: 1, width: '100%' } }, [renderedAnalyses])
         ])]
       )

--- a/src/pages/workspaces/workspace/Analyses.js
+++ b/src/pages/workspaces/workspace/Analyses.js
@@ -342,13 +342,13 @@ const Analyses = _.flow(
   return h(Dropzone, {
     accept: `.${tools.Jupyter.ext}, .${tools.RStudio.ext}`,
     disabled: !Utils.canWrite(accessLevel),
-    style: { flexGrow: 1, backgroundColor: colors.light() },
+    style: { flexGrow: 1, backgroundColor: colors.light(), height: '100%' },
     activeStyle: { backgroundColor: colors.accent(0.2), cursor: 'copy' },
     onDropRejected: () => reportError('Not a valid analysis file',
       'The selected file is not a .ipynb notebook file or an .Rmd rstudio file. Ensure your file has the proper extension.'),
     onDropAccepted: uploadFiles
   }, [({ openUploader }) => h(Fragment, [
-    analyses && h(PageBox, { style: { height: '100%' } }, [
+    analyses && h(PageBox, { style: { height: '100%', margin: '0px', padding: '3rem' } }, [
       div({ style: { display: 'flex', marginBottom: '1rem' } }, [
         div({ style: { color: colors.dark(), fontSize: 24, fontWeight: 600 } }, ['Your Analyses']),
         h(ButtonOutline, {

--- a/src/pages/workspaces/workspace/Analyses.js
+++ b/src/pages/workspaces/workspace/Analyses.js
@@ -319,7 +319,7 @@ const Analyses = _.flow(
 
     return div({
       style: {
-        ..._.merge({ textAlign: 'center', display: 'flex', justifyContent: 'center', backgroundColor: colors.light(), padding: '0 1rem 0 1rem' },
+        ..._.merge({ textAlign: 'center', display: 'flex', justifyContent: 'center', padding: '0 1rem 0 1rem' },
           _.isEmpty(analyses) ? { alignItems: 'center', height: '80%' } : { flexDirection: 'column' })
       }
     }, [
@@ -340,7 +340,7 @@ const Analyses = _.flow(
   return h(Dropzone, {
     accept: `.${tools.Jupyter.ext}, .${tools.RStudio.ext}`,
     disabled: !Utils.canWrite(accessLevel),
-    style: { flexGrow: 1 },
+    style: { flexGrow: 1, backgroundColor: colors.light() },
     activeStyle: { backgroundColor: colors.accent(0.2), cursor: 'copy' },
     onDropRejected: () => reportError('Not a valid analysis file',
       'The selected file is not a .ipynb notebook file or an .Rmd rstudio file. Ensure your file has the proper extension.'),

--- a/src/pages/workspaces/workspace/Analyses.js
+++ b/src/pages/workspaces/workspace/Analyses.js
@@ -205,11 +205,8 @@ const Analyses = _.flow(
   withViewToggle('analysesTab')
 )(({
   apps, name: wsName, namespace, workspace, workspace: { accessLevel, canShare, workspace: { bucketName } },
-  refreshApps, onRequesterPaysError, runtimes,
-  persistentDisks,
-  refreshRuntimes,
-  galaxyDataDisks
-}) => {
+  refreshApps, onRequesterPaysError, runtimes, persistentDisks, refreshRuntimes, galaxyDataDisks
+}, ref) => {
   // State
   const [renamingAnalysisName, setRenamingAnalysisName] = useState(undefined)
   const [copyingAnalysisName, setCopyingAnalysisName] = useState(undefined)

--- a/src/pages/workspaces/workspace/Analyses.js
+++ b/src/pages/workspaces/workspace/Analyses.js
@@ -60,7 +60,7 @@ const analysisContextMenuSize = 16
 const centerColumnFlex = { flex: 5 }
 const endColumnFlex = { flex: '0 0 150px', display: 'flex', justifyContent: 'flex-left', whiteSpace: 'nowrap' }
 
-const AnalysisCardHeaders = Utils.memoWithName('AnalysisCardHeaders', ({ sort, onSort }) => {
+const AnalysisCardHeaders = ({ sort, onSort }) => {
   return div({ style: { display: 'flex', justifyContent: 'space-between', marginTop: '1.5rem', paddingLeft: '1.5rem', marginBottom: '0.5rem' } }, [
     div({ 'aria-sort': ariaSort(sort, 'Application'), style: { flex: 1 } }, [
       h(HeaderRenderer, { sort, onSort, name: 'application' })
@@ -75,7 +75,7 @@ const AnalysisCardHeaders = Utils.memoWithName('AnalysisCardHeaders', ({ sort, o
       div({ className: 'sr-only' }, ['Expand'])
     ])
   ])
-})
+}
 
 const AnalysisCard = ({ namespace, name, lastModified, metadata, application, wsName, onRename, onCopy, onDelete, onExport, canWrite, currentUserHash, potentialLockers }) => {
   const { lockExpiresAt, lastLockedBy } = metadata || {}
@@ -159,6 +159,7 @@ const AnalysisCard = ({ namespace, name, lastModified, metadata, application, ws
   const toolIconSrc = Utils.switchCase(application,
     [tools.Jupyter.label, () => jupyterLogo],
     [tools.RStudio.label, () => rLogo])
+
   const toolIcon = div({ style: { marginRight: '1rem' } }, [
     img({ src: toolIconSrc, style: { height: 40, width: 50 } })
   ])
@@ -236,8 +237,8 @@ const Analyses = _.flow(
     Utils.withBusyState(setBusy)
   )(async () => {
     const rawAnalyses = await Ajax(signal).Buckets.listAnalyses(namespace, bucketName)
-    const notebooks = _.filter(({ name }) => name.endsWith(`.${tools.Jupyter.ext}`), rawAnalyses)
-    const rmds = _.filter(({ name }) => name.endsWith(`.${tools.RStudio.ext}`), rawAnalyses)
+    const notebooks = _.filter(({ name }) => _.endsWith(`.${tools.Jupyter.ext}`, name), rawAnalyses)
+    const rmds = _.filter(({ name }) => _.endsWith(`.${tools.RStudio.ext}`, name), rawAnalyses)
 
     //we map the `toolLabel` and `updated` fields to their corresponding header label, which simplifies the table sorting code
     const enhancedNotebooks = _.map(notebook => _.merge(notebook, { application: tools.Jupyter.label, lastModified: notebook.updated }), notebooks)

--- a/src/pages/workspaces/workspace/Analyses.js
+++ b/src/pages/workspaces/workspace/Analyses.js
@@ -56,18 +56,23 @@ const sortTokens = {
 }
 const defaultSort = { label: 'Most Recently Updated', value: { field: 'lastModified', direction: 'desc' } }
 
-const analysisContextMenuSize = 18
+const analysisContextMenuSize = 16
+const centerColumnFlex = { flex: 5 }
+const endColumnFlex = { flex: '0 0 150px', display: 'flex', justifyContent: 'flex-left', whiteSpace: 'nowrap' }
 
 const AnalysisCardHeaders = Utils.memoWithName('AnalysisCardHeaders', ({ sort, onSort }) => {
-  return div({ style: { display: 'flex', justifyContent: 'space-between', marginTop: '1.5rem', padding: '0 1rem 0 1.5rem', marginBottom: '0.5rem' } }, [
+  return div({ style: { display: 'flex', justifyContent: 'space-between', marginTop: '1.5rem', paddingLeft: '1.5rem', marginBottom: '0.5rem' } }, [
     div({ 'aria-sort': ariaSort(sort, 'Application'), style: { flex: 1 } }, [
       h(HeaderRenderer, { sort, onSort, name: 'application' })
     ]),
-    div({ 'aria-sort': ariaSort(sort, 'name'), style: { flex: 5 } }, [
+    div({ 'aria-sort': ariaSort(sort, 'name'), style: centerColumnFlex }, [
       h(HeaderRenderer, { sort, onSort, name: 'name' })
     ]),
-    div({ 'aria-sort': ariaSort(sort, 'lastModified'), style: { flex: '0 0 10%', justifyContent: 'flex-left', display: 'flex' } }, [
+    div({ 'aria-sort': ariaSort(sort, 'lastModified'), style: { ...endColumnFlex, paddingRight: '1rem' } }, [
       h(HeaderRenderer, { sort, onSort, name: 'lastModified' })
+    ]),
+    div({ style: { flex: `0 0 ${analysisContextMenuSize}px` } }, [
+      div({ className: 'sr-only' }, ['Expand'])
     ])
   ])
 })
@@ -144,10 +149,10 @@ const AnalysisCard = ({ namespace, name, lastModified, metadata, application, ws
   ])
 
   //the flex values for columns here correspond to the flex values in the header
-  const artefactName = div({
+  const artifactName = div({
     title: getDisplayName(name),
     style: {
-      ...Style.elements.card.title, whiteSpace: 'normal', overflowY: 'auto', flex: 5, textAlign: 'left'
+      ...Style.elements.card.title, whiteSpace: 'normal', overflowY: 'auto', textAlign: 'left', ...centerColumnFlex
     }
   }, [getDisplayName(name)])
 
@@ -171,19 +176,19 @@ const AnalysisCard = ({ namespace, name, lastModified, metadata, application, ws
     }, { marginBottom: '.75rem', paddingLeft: '1.5rem' })
   }, [
     toolContainer,
-    artefactName,
+    artifactName,
     //The 10% allows for the longest date possible (September XX, XXXX), plus a locked symbol, without text wrapping when the screen is maximized
-    div({ style: { flex: '0 0 10%', display: 'flex', flexDirection: 'row', justifyContent: 'flex-left' } }, [
+    div({ style: { ...endColumnFlex, flexDirection: 'row' } }, [
       div({ style: { flex: 1, display: 'flex' } }, [
         locked && h(Clickable, {
           style: { display: 'flex', paddingRight: '1rem', color: colors.dark(0.75) },
           tooltip: `This analysis is currently being edited by ${lockedBy || 'another user'}`
         }, [icon('lock')]),
         h(TooltipTrigger, { content: Utils.makeCompleteDate(lastModified) }, [
-          div({ style: { fontSize: '0.8rem', display: 'flex', alignItems: 'center' } }, [Utils.makePrettyDate(lastModified)])
+          div({ style: { fontSize: '0.8rem', display: 'flex', alignItems: 'center', textAlign: 'left' } }, [Utils.makePrettyDate(lastModified)])
         ])
       ]),
-      analysisMenu
+      div({ style: { marginLeft: '1rem' } }, [analysisMenu])
     ])
   ])
 }
@@ -214,7 +219,7 @@ const Analyses = _.flow(
   const [filter, setFilter] = useState(() => StateHistory.get().filter || '')
   const [busy, setBusy] = useState(false)
   const [creating, setCreating] = useState(false)
-  //TODO: add galaxy artefacts to this once we have galaxy artefacts
+  //TODO: add galaxy artifacts to this once we have galaxy artifacts
   const [analyses, setAnalyses] = useState(() => StateHistory.get().analyses || undefined)
   const [currentUserHash, setCurrentUserHash] = useState(undefined)
   const [potentialLockers, setPotentialLockers] = useState(undefined)
@@ -240,7 +245,7 @@ const Analyses = _.flow(
     setAnalyses(_.reverse(_.sortBy('lastModified', analyses)))
   })
 
-  //TODO: eventually load app artefacts
+  //TODO: eventually load app artifacts
   // const doAppRefresh = _.flow(
   //   withErrorReporting('Error loading Apps'),
   //   Utils.withBusyState(setBusy)
@@ -332,7 +337,7 @@ const Analyses = _.flow(
         }],
         [Utils.DEFAULT, () => h(Fragment, [
           h(AnalysisCardHeaders, { sort: sortOrder, onSort: setSortOrder }),
-          div({ role: 'list', 'aria-label': 'analysis artefacts in workspace', style: { flexGrow: 1, width: '100%' } }, [renderedAnalyses])
+          div({ role: 'list', 'aria-label': 'analysis artifacts in workspace', style: { flexGrow: 1, width: '100%' } }, [renderedAnalyses])
         ])]
       )
     ])

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -135,6 +135,9 @@ const WorkspaceContainer = ({ namespace, name, breadcrumbs, topBarContent, title
     showTabBar && h(WorkspaceTabs, { namespace, name, activeTab, refresh, workspace, deletingWorkspace, setDeletingWorkspace, cloningWorkspace, setCloningWorkspace, sharingWorkspace, setSharingWorkspace }),
     div({ role: 'main', style: Style.elements.pageContentContainer },
       // Display the context bar only if the analysis tab is visible, for now
+      // This logic will need to change a bit when we want the analysis tab visible but the context bar visible for only the analysis tab
+      // In particular, the background coloring is applicable for the analysis tab at all times, even when context bar is not visible
+      // proposed solution: the context bar and analysis tab should be housed in one component, and that is what should be references by the router
       (isAnalysisTabVisible() && activeTab === 'analyses' ?
         [div({ style: { flex: 1, display: 'flex' } }, [
           div({ style: { flex: 1 } }, [

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -134,10 +134,7 @@ const WorkspaceContainer = ({ namespace, name, breadcrumbs, topBarContent, title
     ]),
     showTabBar && h(WorkspaceTabs, { namespace, name, activeTab, refresh, workspace, deletingWorkspace, setDeletingWorkspace, cloningWorkspace, setCloningWorkspace, sharingWorkspace, setSharingWorkspace }),
     div({ role: 'main', style: Style.elements.pageContentContainer },
-      // Display the context bar only if the analysis tab is visible, for now
-      // This logic will need to change a bit when we want the analysis tab visible but the context bar visible for only the analysis tab
-      // In particular, the background coloring is applicable for the analysis tab at all times, even when context bar is not visible
-      // proposed solution: the context bar and analysis tab should be housed in one component, and that is what should be references by the router
+      // When we switch this over to all tabs, ensure other workspace tabs look the same when inside these divs
       (isAnalysisTabVisible() && activeTab === 'analyses' ?
         [div({ style: { flex: 1, display: 'flex' } }, [
           div({ style: { flex: 1 } }, [

--- a/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
@@ -69,6 +69,8 @@ const AnalysisLauncher = _.flow(
       mode && h(RuntimeStatusMonitor, { runtime, onRuntimeStoppedRunning: () => chooseMode(undefined) }),
       h(NewRuntimeModal, {
         isOpen: createOpen,
+        tool: toolLabel,
+        isAnalysisMode: true,
         workspace,
         runtimes,
         persistentDisks,


### PR DESCRIPTION
This PR finalizes the table view styling and sort functionality, while removing the old card view (which simplifies the code a good bit).

I still need to do a final styling review with Joy, but I don't expect the code to change much with that. 

I also switched over the dev calhoun URL to the new one deployed on K8s, which supports previewing RMD files. 

![image](https://user-images.githubusercontent.com/6465084/124154857-e398ee00-da63-11eb-8b21-de81f2c204a8.png)
