### PR TITLE
Add UI control for retrying a task with more memory, BW-290.

### DIFF
--- a/src/libs/analysis.js
+++ b/src/libs/analysis.js
@@ -8,7 +8,7 @@ export const launch = async ({
   workspace: { workspace: { namespace, name, bucketName }, accessLevel },
   config: { namespace: configNamespace, name: configName, rootEntityType },
   selectedEntityType, selectedEntityNames, newSetName, useCallCache = true, deleteIntermediateOutputFiles, useReferenceDisks,
-  onProgress
+  memoryRetryMultiplier, onProgress
 }) => {
   const createSet = () => {
     onProgress('createSet')
@@ -59,6 +59,6 @@ export const launch = async ({
     ),
     entityName,
     expression: processSet ? `this.${rootEntityType}s` : undefined,
-    useCallCache, deleteIntermediateOutputFiles, useReferenceDisks
+    useCallCache, deleteIntermediateOutputFiles, useReferenceDisks, memoryRetryMultiplier
   })
 }

--- a/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
+++ b/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
@@ -96,7 +96,8 @@ const SubmissionDetails = _.flow(
    */
   const {
     cost, methodConfigurationName: workflowName, methodConfigurationNamespace: workflowNamespace, submissionDate,
-    submissionEntity: { entityType, entityName } = {}, submitter, useCallCache, deleteIntermediateOutputFiles, useReferenceDisks, workflows = []
+    submissionEntity: { entityType, entityName } = {}, submitter, useCallCache, deleteIntermediateOutputFiles,
+    useReferenceDisks, memoryRetryMultiplier, workflows = []
   } = submission
 
   const filteredWorkflows = _.flow(
@@ -186,7 +187,8 @@ const SubmissionDetails = _.flow(
           )]),
           makeSection('Call Caching', [useCallCache ? 'Enabled' : 'Disabled']),
           makeSection('Delete Intermediate Outputs', [deleteIntermediateOutputFiles ? 'Enabled' : 'Disabled']),
-          makeSection('Use Reference Disks', [useReferenceDisks ? 'Enabled' : 'Disabled'])
+          makeSection('Use Reference Disks', [useReferenceDisks ? 'Enabled' : 'Disabled']),
+          makeSection('Increase Memory on Retries', [memoryRetryMultiplier !== 1 ? `Enabled with factor ${memoryRetryMultiplier}` : 'Disabled'])
         ])
       ]),
       div({ style: { margin: '1rem 0', display: 'flex', alignItems: 'center' } }, [

--- a/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
+++ b/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
@@ -188,7 +188,7 @@ const SubmissionDetails = _.flow(
           makeSection('Call Caching', [useCallCache ? 'Enabled' : 'Disabled']),
           makeSection('Delete Intermediate Outputs', [deleteIntermediateOutputFiles ? 'Enabled' : 'Disabled']),
           makeSection('Use Reference Disks', [useReferenceDisks ? 'Enabled' : 'Disabled']),
-          makeSection('Increase Memory on Retries', [memoryRetryMultiplier !== 1 ? `Enabled with factor ${memoryRetryMultiplier}` : 'Disabled'])
+          makeSection('Retry with More Memory', [memoryRetryMultiplier !== 1 ? `Enabled with factor ${memoryRetryMultiplier}` : 'Disabled'])
         ])
       ]),
       div({ style: { margin: '1rem 0', display: 'flex', alignItems: 'center' } }, [

--- a/src/pages/workspaces/workspace/workflows/FailureRerunner.js
+++ b/src/pages/workspaces/workspace/workflows/FailureRerunner.js
@@ -27,7 +27,7 @@ export const rerunFailures = async ({ workspace, workspace: { workspace: { names
   const eventData = { ...extractWorkspaceDetails(workspace), configNamespace, configName }
 
   try {
-    const [{ workflows, useCallCache, deleteIntermediateOutputFiles, useReferenceDisks }, config] = await Promise.all([
+    const [{ workflows, useCallCache, deleteIntermediateOutputFiles, useReferenceDisks, memoryRetryMultiplier }, config] = await Promise.all([
       Ajax().Workspaces.workspace(namespace, name).submission(submissionId).get(),
       Ajax().Workspaces.workspace(namespace, name).methodConfig(configNamespace, configName).get()
     ])
@@ -40,7 +40,7 @@ export const rerunFailures = async ({ workspace, workspace: { workspace: { names
         _.map('workflowEntity.entityName')
       )(workflows),
       newSetName: Utils.sanitizeEntityName(`${configName}-resubmission-${new Date().toISOString().slice(0, -5)}`),
-      useCallCache, deleteIntermediateOutputFiles, useReferenceDisks,
+      useCallCache, deleteIntermediateOutputFiles, useReferenceDisks, memoryRetryMultiplier,
       onProgress: stage => {
         rerunFailuresStatus.set({ text: { createSet: 'Creating set from failures...', launch: 'Launching new job...', checkBucketAccess: 'Checking bucket access...' }[stage] })
       }

--- a/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
+++ b/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
@@ -19,7 +19,8 @@ const LaunchAnalysisModal = ({
   onDismiss, entityMetadata,
   workspace, workspace: { workspace: { namespace, name: workspaceName, bucketName } }, processSingle,
   entitySelectionModel: { type, selectedEntities, newSetName },
-  config, config: { rootEntityType }, useCallCache, deleteIntermediateOutputFiles, useReferenceDisks, onSuccess
+  config, config: { rootEntityType }, useCallCache, deleteIntermediateOutputFiles, useReferenceDisks,
+  retryWithMoreMemory, retryMemoryFactor, onSuccess
 }) => {
   const [launching, setLaunching] = useState(undefined)
   const [message, setMessage] = useState(undefined)
@@ -53,6 +54,7 @@ const LaunchAnalysisModal = ({
       const { submissionId } = await launch({
         isSnapshot: type === processSnapshotTable,
         workspace, config, selectedEntityType, selectedEntityNames, newSetName, useCallCache, deleteIntermediateOutputFiles, useReferenceDisks,
+        memoryRetryMultiplier: retryWithMoreMemory ? retryMemoryFactor : undefined,
         onProgress: stage => {
           setMessage({ createSet: 'Creating set...', launch: 'Launching analysis...', checkBucketAccess: 'Checking bucket access...' }[stage])
         }

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -8,7 +8,7 @@ import {
 } from 'src/components/common'
 import Dropzone from 'src/components/Dropzone'
 import { centeredSpinner, icon } from 'src/components/icons'
-import { DelayedAutocompleteTextArea, DelayedSearchInput } from 'src/components/input'
+import { DelayedAutocompleteTextArea, DelayedSearchInput, NumberInput } from 'src/components/input'
 import { MarkdownViewer } from 'src/components/markdown'
 import Modal from 'src/components/Modal'
 import { InfoBox, makeMenuIcon, MenuButton, MenuTrigger } from 'src/components/PopupTrigger'
@@ -316,6 +316,8 @@ const WorkflowView = _.flow(
       useCallCache: true,
       deleteIntermediateOutputFiles: false,
       useReferenceDisks: false,
+      retryWithMoreMemory: false,
+      retryMemoryFactor: 1.2,
       includeOptionalInputs: true,
       filter: '',
       errors: { inputs: {}, outputs: {} },
@@ -350,6 +352,15 @@ const WorkflowView = _.flow(
     })
   }
 
+  /** Returns the href link for the specified article. */
+  getSupportLink(article) { return `https://support.terra.bio/hc/en-us/articles/${article}` }
+
+  /** Returns true if the increasing memory on retries is enabled */
+  isMemoryIncreasedOnRetries() { return this.state.retryWithMoreMemory }
+
+  /** Returns true if the memory retry factor is outside the expected range */
+  warnMemoryFactor() { return this.state.retryMemoryFactor > 2 }
+
   render() {
     // isFreshData: controls spinnerOverlay on initial load
     // variableSelected: field of focus for bucket file browser
@@ -357,7 +368,8 @@ const WorkflowView = _.flow(
     // modifiedConfig: active data, potentially unsaved
     const {
       isFreshData, savedConfig, launching, activeTab, useCallCache, deleteIntermediateOutputFiles, useReferenceDisks,
-      entitySelectionModel, variableSelected, modifiedConfig, updatingConfig, selectedSnapshotEntityMetadata, availableSnapshots
+      retryWithMoreMemory, retryMemoryFactor, entitySelectionModel, variableSelected, modifiedConfig, updatingConfig,
+      selectedSnapshotEntityMetadata, availableSnapshots
     } = this.state
     const { namespace, name, workspace } = this.props
     const workspaceId = { namespace, name }
@@ -373,7 +385,8 @@ const WorkflowView = _.flow(
         launching && h(LaunchAnalysisModal, {
           workspace, config: savedConfig, entityMetadata: selectedSnapshotEntityMetadata,
           accessLevel: workspace.accessLevel, bucketName: workspace.workspace.bucketName,
-          processSingle: this.isSingle(), entitySelectionModel, useCallCache, deleteIntermediateOutputFiles, useReferenceDisks,
+          processSingle: this.isSingle(), entitySelectionModel, useCallCache, deleteIntermediateOutputFiles,
+          useReferenceDisks, retryWithMoreMemory, retryMemoryFactor,
           onDismiss: () => this.setState({ launching: false }),
           onSuccess: submissionId => {
             const { methodRepoMethod: { methodVersion, methodNamespace, methodName, methodPath, sourceRepo } } = modifiedConfig
@@ -569,7 +582,7 @@ const WorkflowView = _.flow(
     const {
       modifiedConfig, savedConfig, saving, saved, exporting, copying, deleting, selectingData, activeTab, errors, synopsis, documentation,
       availableSnapshots, selectedSnapshotEntityMetadata, selectedEntityType, entityMetadata, entitySelectionModel, versionIds = [], useCallCache,
-      deleteIntermediateOutputFiles, useReferenceDisks, currentSnapRedacted, savedSnapRedacted, wdl
+      deleteIntermediateOutputFiles, useReferenceDisks, retryWithMoreMemory, retryMemoryFactor, currentSnapRedacted, savedSnapRedacted, wdl
     } = this.state
     const { name, methodRepoMethod: { methodPath, methodVersion, methodNamespace, methodName, sourceRepo }, rootEntityType } = modifiedConfig
     const entityTypes = _.keys(entityMetadata)
@@ -596,6 +609,9 @@ const WorkflowView = _.flow(
     const inputsValid = _.isEmpty(errors.inputs)
     const outputsValid = _.isEmpty(errors.outputs)
     const sourceDisplay = sourceRepo === 'agora' ? `${methodNamespace}/${methodName}/${methodVersion}` : `${methodPath}:${methodVersion}`
+    const checkBoxSpanMargins = { margin: '0 0.5rem 0 1rem' }
+    const checkBoxLeftMargin = { marginLeft: '1rem' }
+    const clickToLearnMore = 'Click here to learn more.'
     return div({
       style: {
         position: 'relative',
@@ -762,39 +778,86 @@ const WorkflowView = _.flow(
                 ])
             ])
           ]),
-          div({ style: { marginTop: '1rem' } }, [
-            h(LabeledCheckbox, {
-              disabled: currentSnapRedacted || !!Utils.computeWorkspaceError(ws),
-              checked: useCallCache,
-              onChange: v => this.setState({ useCallCache: v })
-            }, [' Use call caching']),
-            span({ style: { margin: '0 0.5rem 0 1rem' } }, [
+          div([
+            // Because the retries numeric input is not always visible, and will be taller than the other components
+            // on this line, wrap the components that are always visible with a div and add top/bottom margins to
+            // avoid vertical resizing when the numeric input is rendered.
+            div({ style: { display: 'inline-block', marginTop: '0.5rem', marginBottom: '0.5rem' } }, [
               h(LabeledCheckbox, {
-                checked: deleteIntermediateOutputFiles,
-                onChange: v => this.setState({ deleteIntermediateOutputFiles: v }),
-                style: { marginLeft: '1rem' }
-              }, [' Delete intermediate outputs'])
+                disabled: currentSnapRedacted || !!Utils.computeWorkspaceError(ws),
+                checked: useCallCache,
+                onChange: v => this.setState({ useCallCache: v })
+              }, [' Use call caching']),
+              span({ style: checkBoxSpanMargins }, [
+                h(LabeledCheckbox, {
+                  checked: deleteIntermediateOutputFiles,
+                  onChange: v => this.setState({ deleteIntermediateOutputFiles: v }),
+                  style: checkBoxLeftMargin
+                }, [' Delete intermediate outputs'])
+              ]),
+              h(InfoBox, [
+                'If the workflow succeeds, only the final output will be saved. Subsequently, call caching cannot be used as the intermediate steps will be not available. ',
+                h(Link, { href: this.getSupportLink('360039681632'), ...Utils.newTabLinkProps },
+                  [clickToLearnMore])
+              ]),
+              span({ style: checkBoxSpanMargins }, [
+                h(LabeledCheckbox, {
+                  checked: useReferenceDisks,
+                  onChange: v => this.setState({ useReferenceDisks: v }),
+                  style: checkBoxLeftMargin
+                }, [' Use reference disks'])
+              ]),
+              h(InfoBox, [
+                'Use a reference disk image if available rather than localizing reference inputs. ',
+                h(Link, { href: this.getSupportLink('360056384631'), ...Utils.newTabLinkProps },
+                  [clickToLearnMore])
+              ]),
+              span({ style: checkBoxSpanMargins }, [
+                h(LabeledCheckbox, {
+                  checked: retryWithMoreMemory,
+                  onChange: v => this.setState({ retryWithMoreMemory: v }),
+                  style: checkBoxLeftMargin
+                }, [' Retry with more memory'])
+              ])
             ]),
-            h(InfoBox, [
-              'If the workflow succeeds, only the final output will be saved. Subsequently, call caching cannot be used as the intermediate steps will be not available. ',
-              h(Link, {
-                href: 'https://support.terra.bio/hc/en-us/articles/360039681632',
-                ...Utils.newTabLinkProps
-              }, ['Click here to learn more.'])
-            ]),
-            span({ style: { margin: '0 0.5rem 0 1rem' } }, [
-              h(LabeledCheckbox, {
-                checked: useReferenceDisks,
-                onChange: v => this.setState({ useReferenceDisks: v }),
-                style: { marginLeft: '1rem' }
-              }, [' Use reference disks'])
-            ]),
-            h(InfoBox, [
-              'Use a reference disk image if available rather than localizing reference inputs. ',
-              h(Link, {
-                href: 'https://support.terra.bio/hc/en-us/articles/360056384631',
-                ...Utils.newTabLinkProps
-              }, ['Click here to learn more.'])
+            div({ style: { display: 'inline-block' } }, [
+              this.isMemoryIncreasedOnRetries() && span({ style: { margin: '0 0.5rem 0 0.5rem' } }, [
+                h(IdContainer, [
+                  id => h(Fragment, [
+                    label({
+                      htmlFor: id,
+                      style: { ...styles.label, verticalAlign: 'middle' }
+                    }, ['Memory retry factor:']),
+                    div({ style: { display: 'inline-block', marginLeft: '0.25rem' } }, [
+                      h(NumberInput, {
+                        id,
+                        min: 1.1,
+                        max: 10,
+                        step: 0.1,
+                        isClearable: false,
+                        onlyInteger: false,
+                        value: retryMemoryFactor,
+                        style: { width: '5rem' },
+                        onChange: v => this.setState({ retryMemoryFactor: v })
+                      })
+                    ])
+                  ])
+                ])
+              ]),
+              // We show either an info message or a warning, based on whether increasing memory on retries is
+              // enabled and the value of the retry multiplier.
+              (!this.isMemoryIncreasedOnRetries() || !this.warnMemoryFactor()) && h(InfoBox,
+                [
+                  'If a task in your workflow fails only because it ran out of memory, and the maxRetries property is defined on your task, retry it with more memory. ',
+                  h(Link, { href: this.getSupportLink('4403215299355'), ...Utils.newTabLinkProps },
+                    [clickToLearnMore])
+                ]),
+              this.isMemoryIncreasedOnRetries() && this.warnMemoryFactor() && h(InfoBox,
+                { style: { color: colors.warning() }, iconOverride: 'warning-standard' }, [
+                  'Because the retry factor is multiplicative and compounding, values greater than 2 may quickly exceed your available memory. ',
+                  h(Link, { href: this.getSupportLink('4403215299355'), ...Utils.newTabLinkProps },
+                    [clickToLearnMore])
+                ])
             ])
           ]),
           h(StepButtons, {

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -776,16 +776,16 @@ const WorkflowView = _.flow(
                 ])
             ])
           ]),
-          div([
-            // Because the retries numeric input is not always visible, and will be taller than the other components
-            // on this line, wrap the components that are always visible with a div and add top/bottom margins to
-            // avoid vertical resizing when the numeric input is rendered.
-            div({ style: { display: 'inline-block', marginTop: '0.5rem', marginBottom: '0.5rem' } }, [
-              h(LabeledCheckbox, {
-                disabled: currentSnapRedacted || !!Utils.computeWorkspaceError(ws),
-                checked: useCallCache,
-                onChange: v => this.setState({ useCallCache: v })
-              }, [' Use call caching']),
+          div({ style: { display: 'flex', alignItems: 'baseline', minWidth: 'max-content' } }, [
+            // This span is to prevent vertical resizing when the memory retry multiplier input is visible.
+            span({ style: { marginTop: '0.5rem', marginBottom: '0.5rem' } }, [
+              span([
+                h(LabeledCheckbox, {
+                  disabled: currentSnapRedacted || !!Utils.computeWorkspaceError(ws),
+                  checked: useCallCache,
+                  onChange: v => this.setState({ useCallCache: v })
+                }, [' Use call caching'])
+              ]),
               span({ style: styles.checkBoxSpanMargins }, [
                 h(LabeledCheckbox, {
                   checked: deleteIntermediateOutputFiles,
@@ -818,46 +818,44 @@ const WorkflowView = _.flow(
                 }, [' Retry with more memory'])
               ])
             ]),
-            div({ style: { display: 'inline-block' } }, [
-              retryWithMoreMemory && span({ style: { margin: '0 0.5rem 0 0.5rem' } }, [
-                h(IdContainer, [
-                  id => h(Fragment, [
-                    label({
-                      htmlFor: id,
-                      style: { ...styles.label, verticalAlign: 'middle' }
-                    }, ['Memory retry factor:']),
-                    div({ style: { display: 'inline-block', marginLeft: '0.25rem' } }, [
-                      h(NumberInput, {
-                        id,
-                        min: 1.1,
-                        max: 10,
-                        step: 0.1,
-                        isClearable: false,
-                        onlyInteger: false,
-                        value: retryMemoryFactor,
-                        style: { width: '5rem' },
-                        onChange: v => this.setState({ retryMemoryFactor: v })
-                      })
-                    ])
+            retryWithMoreMemory && span({ style: { margin: '0 0.5rem 0 0.5rem' } }, [
+              h(IdContainer, [
+                id => h(Fragment, [
+                  label({
+                    htmlFor: id,
+                    style: { ...styles.label, verticalAlign: 'middle' }
+                  }, ['Memory retry factor:']),
+                  div({ style: { display: 'inline-block', marginLeft: '0.25rem' } }, [
+                    h(NumberInput, {
+                      id,
+                      min: 1.1,
+                      max: 10,
+                      step: 0.1,
+                      isClearable: false,
+                      onlyInteger: false,
+                      value: retryMemoryFactor,
+                      style: { width: '5rem' },
+                      onChange: v => this.setState({ retryMemoryFactor: v })
+                    })
                   ])
                 ])
-              ]),
-              // We show either an info message or a warning, based on whether increasing memory on retries is
-              // enabled and the value of the retry multiplier.
-              (retryWithMoreMemory && retryMemoryFactor > 2 ?
-                h(InfoBox,
-                  { style: { color: colors.warning() }, iconOverride: 'warning-standard' }, [
-                    'Retry factors above 2 are not recommended. The retry factor compounds and may substantially increase costs. ',
-                    h(Link, { href: this.getSupportLink('4403215299355'), ...Utils.newTabLinkProps },
-                      [clickToLearnMore])
-                  ]) :
-                h(InfoBox, [
-                  'If a task has a maxRetries value greater than zero and fails because it ran out of memory, retry it with more memory. ',
+              ])
+            ]),
+            // We show either an info message or a warning, based on whether increasing memory on retries is
+            // enabled and the value of the retry multiplier.
+            (retryWithMoreMemory && retryMemoryFactor > 2 ?
+              h(InfoBox,
+                { style: { color: colors.warning() }, iconOverride: 'warning-standard' }, [
+                  'Retry factors above 2 are not recommended. The retry factor compounds and may substantially increase costs. ',
                   h(Link, { href: this.getSupportLink('4403215299355'), ...Utils.newTabLinkProps },
                     [clickToLearnMore])
-                ])
-              )
-            ])
+                ]) :
+              h(InfoBox, [
+                'If a task has a maxRetries value greater than zero and fails because it ran out of memory, retry it with more memory. ',
+                h(Link, { href: this.getSupportLink('4403215299355'), ...Utils.newTabLinkProps },
+                  [clickToLearnMore])
+              ])
+            )
           ]),
           h(StepButtons, {
             tabs: [

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -70,6 +70,12 @@ const styles = {
   },
   placeholder: {
     fontStyle: 'italic'
+  },
+  checkBoxSpanMargins: {
+    margin: '0 0.5rem 0 1rem'
+  },
+  checkBoxLeftMargin: {
+    marginLeft: '1rem'
   }
 }
 
@@ -355,12 +361,6 @@ const WorkflowView = _.flow(
   /** Returns the href link for the specified article. */
   getSupportLink(article) { return `https://support.terra.bio/hc/en-us/articles/${article}` }
 
-  /** Returns true if the increasing memory on retries is enabled */
-  isMemoryIncreasedOnRetries() { return this.state.retryWithMoreMemory }
-
-  /** Returns true if the memory retry factor is outside the expected range */
-  warnMemoryFactor() { return this.state.retryMemoryFactor > 2 }
-
   render() {
     // isFreshData: controls spinnerOverlay on initial load
     // variableSelected: field of focus for bucket file browser
@@ -609,8 +609,6 @@ const WorkflowView = _.flow(
     const inputsValid = _.isEmpty(errors.inputs)
     const outputsValid = _.isEmpty(errors.outputs)
     const sourceDisplay = sourceRepo === 'agora' ? `${methodNamespace}/${methodName}/${methodVersion}` : `${methodPath}:${methodVersion}`
-    const checkBoxSpanMargins = { margin: '0 0.5rem 0 1rem' }
-    const checkBoxLeftMargin = { marginLeft: '1rem' }
     const clickToLearnMore = 'Click here to learn more.'
     return div({
       style: {
@@ -788,11 +786,11 @@ const WorkflowView = _.flow(
                 checked: useCallCache,
                 onChange: v => this.setState({ useCallCache: v })
               }, [' Use call caching']),
-              span({ style: checkBoxSpanMargins }, [
+              span({ style: styles.checkBoxSpanMargins }, [
                 h(LabeledCheckbox, {
                   checked: deleteIntermediateOutputFiles,
                   onChange: v => this.setState({ deleteIntermediateOutputFiles: v }),
-                  style: checkBoxLeftMargin
+                  style: styles.checkBoxLeftMargin
                 }, [' Delete intermediate outputs'])
               ]),
               h(InfoBox, [
@@ -800,11 +798,11 @@ const WorkflowView = _.flow(
                 h(Link, { href: this.getSupportLink('360039681632'), ...Utils.newTabLinkProps },
                   [clickToLearnMore])
               ]),
-              span({ style: checkBoxSpanMargins }, [
+              span({ style: styles.checkBoxSpanMargins }, [
                 h(LabeledCheckbox, {
                   checked: useReferenceDisks,
                   onChange: v => this.setState({ useReferenceDisks: v }),
-                  style: checkBoxLeftMargin
+                  style: styles.checkBoxLeftMargin
                 }, [' Use reference disks'])
               ]),
               h(InfoBox, [
@@ -812,16 +810,16 @@ const WorkflowView = _.flow(
                 h(Link, { href: this.getSupportLink('360056384631'), ...Utils.newTabLinkProps },
                   [clickToLearnMore])
               ]),
-              span({ style: checkBoxSpanMargins }, [
+              span({ style: styles.checkBoxSpanMargins }, [
                 h(LabeledCheckbox, {
                   checked: retryWithMoreMemory,
                   onChange: v => this.setState({ retryWithMoreMemory: v }),
-                  style: checkBoxLeftMargin
+                  style: styles.checkBoxLeftMargin
                 }, [' Retry with more memory'])
               ])
             ]),
             div({ style: { display: 'inline-block' } }, [
-              this.isMemoryIncreasedOnRetries() && span({ style: { margin: '0 0.5rem 0 0.5rem' } }, [
+              retryWithMoreMemory && span({ style: { margin: '0 0.5rem 0 0.5rem' } }, [
                 h(IdContainer, [
                   id => h(Fragment, [
                     label({
@@ -846,18 +844,19 @@ const WorkflowView = _.flow(
               ]),
               // We show either an info message or a warning, based on whether increasing memory on retries is
               // enabled and the value of the retry multiplier.
-              (!this.isMemoryIncreasedOnRetries() || !this.warnMemoryFactor()) && h(InfoBox,
-                [
+              (retryWithMoreMemory && retryMemoryFactor > 2 ?
+                h(InfoBox,
+                  { style: { color: colors.warning() }, iconOverride: 'warning-standard' }, [
+                    'Retry factors above 2 are not recommended. The retry factor compounds and may substantially increase costs. ',
+                    h(Link, { href: this.getSupportLink('4403215299355'), ...Utils.newTabLinkProps },
+                      [clickToLearnMore])
+                  ]) :
+                h(InfoBox, [
                   'If a task has a maxRetries value greater than zero and fails because it ran out of memory, retry it with more memory. ',
                   h(Link, { href: this.getSupportLink('4403215299355'), ...Utils.newTabLinkProps },
                     [clickToLearnMore])
-                ]),
-              this.isMemoryIncreasedOnRetries() && this.warnMemoryFactor() && h(InfoBox,
-                { style: { color: colors.warning() }, iconOverride: 'warning-standard' }, [
-                  'Retry factors above 2 are not recommended. The retry factor compounds and may substantially increase costs. ',
-                  h(Link, { href: this.getSupportLink('4403215299355'), ...Utils.newTabLinkProps },
-                    [clickToLearnMore])
                 ])
+              )
             ])
           ]),
           h(StepButtons, {

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -848,13 +848,13 @@ const WorkflowView = _.flow(
               // enabled and the value of the retry multiplier.
               (!this.isMemoryIncreasedOnRetries() || !this.warnMemoryFactor()) && h(InfoBox,
                 [
-                  'If a task in your workflow fails only because it ran out of memory, and the maxRetries property is defined on your task, retry it with more memory. ',
+                  'If a task has a maxRetries value greater than zero and fails because it ran out of memory, retry it with more memory. ',
                   h(Link, { href: this.getSupportLink('4403215299355'), ...Utils.newTabLinkProps },
                     [clickToLearnMore])
                 ]),
               this.isMemoryIncreasedOnRetries() && this.warnMemoryFactor() && h(InfoBox,
                 { style: { color: colors.warning() }, iconOverride: 'warning-standard' }, [
-                  'Because the retry factor is multiplicative and compounding, values greater than 2 may quickly exceed your available memory. ',
+                  'Retry factors above 2 are not recommended. The retry factor compounds and may substantially increase costs. ',
                   h(Link, { href: this.getSupportLink('4403215299355'), ...Utils.newTabLinkProps },
                     [clickToLearnMore])
                 ])


### PR DESCRIPTION
This exposes the "retry with more memory" feature for Workflows. When a task has maxRetries > 1, this option allows the machine memory to be increased on each retry, if the task fails only for memory reasons.

I have tested this against dev, using this WDL: https://github.com/broadinstitute/cromwell/blob/develop/centaur/src/main/resources/standardTestCases/retry_with_more_memory/retry_with_more_memory.wdl

For details of how to confirm that the machine size was increased on each retry, see https://broadworkbench.atlassian.net/browse/BW-749.
