### PR TITLE
Reduce motion of Terra banners [BW-755][hackathon]

### DIFF
--- a/src/components/NpsSurvey.js
+++ b/src/components/NpsSurvey.js
@@ -83,7 +83,7 @@ const NpsSurvey = () => {
   _.range(0, 11))
 
   return requestable && div({
-    className: 'animate__animated animate__slideInRight',
+    className: 'animate__animated animate__fadeIn',
     style: {
       position: 'fixed', bottom: '1.5rem', right: expanded ? '1.5rem' : 0,
       transition: 'right 0.2s linear',

--- a/src/libs/notifications.js
+++ b/src/libs/notifications.js
@@ -147,8 +147,9 @@ const showNotification = ({ id, timeout }) => {
     ]),
     container: 'top-right',
     dismiss: { duration: !!timeout ? timeout : 0, click: false, touch: false },
-    animationIn: ['animate__animated', 'animate__slideInRight'],
-    animationOut: ['animate__animated', 'animate__slideOutRight'],
+    animationIn: ['animate__animated', 'animate__fadeIn'],
+    animationOut: ['animate__animated', 'animate__fadeOut'],
+    insert: "bottom",
     width: 350
   })
 }

--- a/src/libs/notifications.js
+++ b/src/libs/notifications.js
@@ -149,7 +149,7 @@ const showNotification = ({ id, timeout }) => {
     dismiss: { duration: !!timeout ? timeout : 0, click: false, touch: false },
     animationIn: ['animate__animated', 'animate__fadeIn'],
     animationOut: ['animate__animated', 'animate__fadeOut'],
-    insert: "bottom",
+    insert: 'bottom',
     width: 350
   })
 }


### PR DESCRIPTION
Replace slide-in animation with a subtle fade. This is an [accessibility measure](https://a11y-101.com/development/reduced-motion) that helps users who have trouble concentrating in the face of distraction (like me!).

*Before:*

![Jul-14-2021 15-37-05](https://user-images.githubusercontent.com/1087943/125682569-cf5564b8-5af0-4339-9930-06c4e6a5cf0b.gif)

*After:*

![Jul-14-2021 15-37-12](https://user-images.githubusercontent.com/1087943/125682593-5779c7e6-4465-4857-a187-3590e94bf253.gif)

You may have come across this similar setting in iOS:

![IMG_5103](https://user-images.githubusercontent.com/1087943/125682631-06644642-03ab-4aa8-90d6-7db0d353a194.PNG)

In this case I did not elect to make it a setting because I don't think the absence of sliding will impair anyone from noticing the banners, and it would be hard to make the setting discoverable.