### PR TITLE
show reference data when only one is added [AS-816]

### DIFF
--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -354,7 +354,7 @@ const DataTypeSection = ({ title, titleExtras, error, retryFunction, children })
       tooltip: 'Error loading, click to retry.'
     }, [icon('sync', { size: 18 })]) : titleExtras
   ]),
-  children?.length && div({
+  !!children?.length && div({
     style: { display: 'flex', flexDirection: 'column', width: '100%' },
     role: 'list'
   }, [children])
@@ -573,7 +573,7 @@ const WorkspaceData = _.flow(
               onClick: () => setImportingReference(true),
               'aria-haspopup': 'dialog'
             }, [icon('plus-circle', { size: 21 })])
-          }, _.map(type => h(DataTypeButton, {
+          }, [_.map(type => h(DataTypeButton, {
             key: type,
             selected: selectedDataType === type,
             onClick: () => {
@@ -590,7 +590,7 @@ const WorkspaceData = _.flow(
               }
             }, [icon('minus-circle', { size: 16 })])
           }, [type]), _.keys(referenceData)
-          )),
+          )]),
           importingReference && h(ReferenceDataImporter, {
             onDismiss: () => setImportingReference(false),
             onSuccess: () => {


### PR DESCRIPTION
[AS-816](https://broadworkbench.atlassian.net/browse/AS-816):

> When I start with a new Workspace and add Reference Data, nothing appears until I have selected 2 Reference Data items, at which point both appear.
> 
> Repro steps:
> 1) Create a new Workspace
> 2) Under Data, Reference Data, choose B37Human. It does not appear under Data (even if you refresh the page)
> 3) Add Reference Data hg38.
> 4) Now both Reference Data entries appear.
> 5) If you delete one, they both disappear again from view.