### PR TITLE
[IA-2871] Increase default disk size to 60GB for both GCE and Dataproc

### DIFF
--- a/src/components/NewRuntimeModal.js
+++ b/src/components/NewRuntimeModal.js
@@ -92,7 +92,7 @@ const DiskSelector = ({ value, onChange }) => {
       label({ htmlFor: id, style: styles.label }, ['Disk size (GB)']),
       h(NumberInput, {
         id,
-        min: 10,
+        min: 60, // sizes below this are too small for images
         max: 64000,
         isClearable: false,
         onlyInteger: true,
@@ -963,7 +963,7 @@ export class NewRuntimeModalBase extends Component {
             ]),
             h(NumberInput, {
               id,
-              min: 10,
+              min: 60,
               max: 64000,
               isClearable: false,
               onlyInteger: true,

--- a/src/components/NewRuntimeModal.js
+++ b/src/components/NewRuntimeModal.js
@@ -21,15 +21,10 @@ import { withErrorReporting } from 'src/libs/error'
 import Events, { extractWorkspaceDetails } from 'src/libs/events'
 import { versionTag } from 'src/libs/logos'
 import {
-  currentRuntime, DEFAULT_DATAPROC_DISK_SIZE, DEFAULT_GCE_BOOT_DISK_SIZE, DEFAULT_GCE_PERSISTENT_DISK_SIZE, DEFAULT_GPU_TYPE, DEFAULT_NUM_GPUS,
-  defaultDataprocMachineType,
-  defaultGceMachineType,
-  displayNameForGpuType,
-  findMachineType,
-  getDefaultMachineType, getValidGpuTypes,
-  persistentDiskCostMonthly,
-  RadioBlock,
-  runtimeConfigBaseCost, runtimeConfigCost
+  currentRuntime, DEFAULT_DATAPROC_DISK_SIZE, DEFAULT_GCE_BOOT_DISK_SIZE, DEFAULT_GCE_PERSISTENT_DISK_SIZE,
+  DEFAULT_GPU_TYPE, DEFAULT_NUM_GPUS, defaultDataprocMachineType, defaultGceMachineType,
+  displayNameForGpuType, findMachineType, getDefaultMachineType, getValidGpuTypes,
+  persistentDiskCostMonthly, RadioBlock, runtimeConfigBaseCost, runtimeConfigCost
 } from 'src/libs/runtime-utils'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'

--- a/src/libs/runtime-utils.js
+++ b/src/libs/runtime-utils.js
@@ -10,7 +10,7 @@ import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 
 
-export const DEFAULT_DISK_SIZE = 50
+export const DEFAULT_DISK_SIZE = 60
 export const DEFAULT_BOOT_DISK_SIZE = 50
 
 export const DEFAULT_GPU_TYPE = 'nvidia-tesla-t4'

--- a/src/libs/runtime-utils.js
+++ b/src/libs/runtime-utils.js
@@ -70,8 +70,9 @@ export const runtimeConfigBaseCost = config => {
 
   return _.sum([
     (masterDiskSize + numberOfWorkers * workerDiskSize) * storagePrice,
-    isDataproc && (dataprocCost(masterMachineType, 1) + dataprocCost(workerMachineType, numberOfWorkers)),
-    !isDataproc && (bootDiskSize * storagePrice)
+    isDataproc ?
+      (dataprocCost(masterMachineType, 1) + dataprocCost(workerMachineType, numberOfWorkers)) :
+      (bootDiskSize * storagePrice)
   ])
 }
 

--- a/src/libs/runtime-utils.js
+++ b/src/libs/runtime-utils.js
@@ -10,8 +10,9 @@ import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 
 
-export const DEFAULT_DISK_SIZE = 60
-export const DEFAULT_BOOT_DISK_SIZE = 50
+export const DEFAULT_DATAPROC_DISK_SIZE = 60 // For both main and worker machine disks. Dataproc clusters don't have persistent disks.
+export const DEFAULT_GCE_BOOT_DISK_SIZE = 70 // GCE boot disk size is not customizable by users. We use this for cost estimate calculations only.
+export const DEFAULT_GCE_PERSISTENT_DISK_SIZE = 50
 
 export const DEFAULT_GPU_TYPE = 'nvidia-tesla-t4'
 export const DEFAULT_NUM_GPUS = 1
@@ -31,15 +32,15 @@ export const normalizeRuntimeConfig = ({
   return {
     cloudService: cloudService || cloudServices.GCE,
     masterMachineType: masterMachineType || machineType || getDefaultMachineType(isDataproc),
-    masterDiskSize: masterDiskSize || diskSize || DEFAULT_DISK_SIZE,
+    masterDiskSize: masterDiskSize || diskSize || (isDataproc ? DEFAULT_DATAPROC_DISK_SIZE : DEFAULT_GCE_BOOT_DISK_SIZE),
     numberOfWorkers: (isDataproc && numberOfWorkers) || 0,
     numberOfPreemptibleWorkers: (isDataproc && numberOfWorkers && numberOfPreemptibleWorkers) || 0,
     workerMachineType: (isDataproc && numberOfWorkers && workerMachineType) || defaultDataprocMachineType,
-    workerDiskSize: (isDataproc && numberOfWorkers && workerDiskSize) || DEFAULT_DISK_SIZE,
+    workerDiskSize: (isDataproc && numberOfWorkers && workerDiskSize) || DEFAULT_DATAPROC_DISK_SIZE,
     // One caveat with using DEFAULT_BOOT_DISK_SIZE here is this over-estimates old GCE runtimes without PD by 1 cent
     // because those runtimes do not have a separate boot disk. But those old GCE runtimes are more than 1 year old if they exist.
     // Hence, we're okay with this caveat.
-    bootDiskSize: bootDiskSize || DEFAULT_BOOT_DISK_SIZE
+    bootDiskSize: bootDiskSize || DEFAULT_GCE_BOOT_DISK_SIZE
   }
 }
 
@@ -63,13 +64,14 @@ const dataprocCost = (machineType, numInstances) => {
 export const runtimeConfigBaseCost = config => {
   const {
     cloudService, masterMachineType, masterDiskSize, numberOfWorkers, workerMachineType, workerDiskSize, bootDiskSize
-  } = normalizeRuntimeConfig(
-    config)
+  } = normalizeRuntimeConfig(config)
+
+  const isDataproc = cloudService === cloudServices.DATAPROC
 
   return _.sum([
     (masterDiskSize + numberOfWorkers * workerDiskSize) * storagePrice,
-    cloudService === cloudServices.DATAPROC && (dataprocCost(masterMachineType, 1) + dataprocCost(workerMachineType, numberOfWorkers)),
-    bootDiskSize * storagePrice
+    isDataproc && (dataprocCost(masterMachineType, 1) + dataprocCost(workerMachineType, numberOfWorkers)),
+    !isDataproc && (bootDiskSize * storagePrice)
   ])
 }
 


### PR DESCRIPTION
Dataproc main and worker machines' disk sizes need to be 60GB at the minimum or they fail to be created. Please see [IA-2871](https://broadworkbench.atlassian.net/browse/IA-2871) for more details.

This PR
- sets the default disk size for Dataproc main and worker machines to 60GB (instead of 50GB)
- doesn't allow selection of less than 60GB for Dataproc main and worker machines
- doesn't change anything for GCE VMs
- fixes a bug where we were over-estimating the cost of Dataproc clusters (see [inline comment](https://github.com/DataBiosphere/terra-ui/pull/2567/files#r674416045))
- renames some of the constants and a component to clarify their usage

Tested by checking that the following are correct for a GCE VM, a Dataproc cluster with a single node and a Dataproc cluster with two workers:

1. the default persistent and non-persistent disk sizes are as expected when no cloud compute exists
2. upon creation of those computes, the UI displays the expected values on the modal
3. the Leo DB has the expected values