### PR TITLE
[IA-2679] update text since we rolled out new images

### DIFF
--- a/src/components/NewRuntimeModal.js
+++ b/src/components/NewRuntimeModal.js
@@ -475,7 +475,7 @@ export class NewRuntimeModalBase extends Component {
 
   getCurrentMountDirectory(currentRuntimeDetails) {
     const rstudioMountPoint = '/home/rstudio'
-    const jupyterMountPoint = '/home/jupyter-user/notebooks'
+    const jupyterMountPoint = '/home/jupyter/notebooks'
     const noMountDirectory = `${jupyterMountPoint} for Jupyter environments and ${rstudioMountPoint} for RStudio environments`
     return currentRuntimeDetails?.labels.tool ? (currentRuntimeDetails?.labels.tool === 'RStudio' ? rstudioMountPoint : jupyterMountPoint) : noMountDirectory
   }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2679

Since we rolled out GPU with new stack of images, home directory has changed to `/home/jupyter`