### PR TITLE
[CA-1459] Rollback change to google project

### DIFF
--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -84,7 +84,7 @@ const WorkspaceDashboard = _.flow(
     accessLevel,
     owners,
     workspace: {
-      authorizationDomain, createdDate, lastModified, bucketName, googleProjectId,
+      authorizationDomain, createdDate, lastModified, bucketName, googleProject,
       attributes, attributes: { description = '' }
     }
   }
@@ -252,8 +252,8 @@ const WorkspaceDashboard = _.flow(
         ]),
         h(InfoTile, { title: 'Google Project Id' }, [
           div({ style: { display: 'flex' } }, [
-            h(TooltipCell, [googleProjectId]),
-            h(ClipboardButton, { text: googleProjectId, style: { marginLeft: '0.25rem' } })
+            h(TooltipCell, [googleProject]),
+            h(ClipboardButton, { text: googleProject, style: { marginLeft: '0.25rem' } })
           ])
         ])
       ]),


### PR DESCRIPTION
This change was actually due to a backwards incompatible change in rawls. We are going to roll it back here, deprecate the old field in rawls, and make the change after PPW release.

<!--
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Thanks!
--!>
