### PR TITLE
[IA-2856] Make ContextBar visible in AnalysisLauncher

### DIFF
--- a/src/components/ContextBar.js
+++ b/src/components/ContextBar.js
@@ -1,10 +1,9 @@
 import _ from 'lodash/fp'
 import { Fragment, useState } from 'react'
 import { div, h, img } from 'react-hyperscript-helpers'
-import { Clickable, comingSoon } from 'src/components/common'
+import { Clickable } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import { tools } from 'src/components/notebook-utils'
-import { makeMenuIcon, MenuButton, MenuTrigger } from 'src/components/PopupTrigger'
 import cloudIcon from 'src/icons/cloud-compute.svg'
 import galaxyLogo from 'src/images/galaxy-logo.png'
 import jupyterLogo from 'src/images/jupyter-logo.svg'
@@ -12,10 +11,7 @@ import rstudioSquareLogo from 'src/images/rstudio-logo-square.png'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import * as Nav from 'src/libs/nav'
-import {
-  getCurrentApp,
-  getCurrentRuntime
-} from 'src/libs/runtime-utils'
+import { getCurrentApp, getCurrentRuntime } from 'src/libs/runtime-utils'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 import { CloudEnvironmentModal } from 'src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal'

--- a/src/components/ContextBar.js
+++ b/src/components/ContextBar.js
@@ -32,14 +32,18 @@ const contextBarStyles = {
   hover: { backgroundColor: colors.accent(0.4) }
 }
 
-export const ContextBar = ({ setDeletingWorkspace, setCloningWorkspace, setSharingWorkspace, isOwner, canShare, canCompute, runtimes, apps, galaxyDataDisks, refreshRuntimes, refreshApps, workspace, persistentDisks, workspace: { workspace: { namespace, bucketName, name: workspaceName } } }) => {
+export const ContextBar = ({ setDeletingWorkspace, setCloningWorkspace, setSharingWorkspace, runtimes, apps, galaxyDataDisks, refreshRuntimes, refreshApps, workspace, persistentDisks, workspace: { workspace: { namespace, bucketName, name: workspaceName } } }) => {
   const [isCloudEnvOpen, setCloudEnvOpen] = useState(false)
+
+
   const currentRuntime = getCurrentRuntime(runtimes)
   const currentApp = getCurrentApp(apps)
   const currentRuntimeTool = currentRuntime?.labels?.tool
-
   const isTerminalEnabled = currentRuntimeTool === tools.Jupyter.label && currentRuntime && currentRuntime.status !== 'Error'
   const terminalLaunchLink = Nav.getLink('workspace-application-launch', { namespace, name: workspaceName, application: 'terminal' })
+  const isOwner = workspace && Utils.isOwner(workspace.accessLevel)
+  const canShare = !!workspace?.canShare
+  const canCompute = !!(workspace?.canCompute || runtimes?.length)
 
   const startCurrentRuntime = () => {
     const { googleProject, runtimeName } = currentRuntime
@@ -87,17 +91,16 @@ export const ContextBar = ({ setDeletingWorkspace, setCloningWorkspace, setShari
     }),
     div({ style: Style.elements.contextBarContainer }, [
       div({ style: contextBarStyles.contextBarContainer }, [
-        h(WorkspaceMenuTrigger, { canShare, isOwner, setCloningWorkspace, setSharingWorkspace, setDeletingWorkspace },
-          [
-            h(Clickable, {
-              'aria-label': 'Menu',
-              style: contextBarStyles.contextBarButton,
-              hover: contextBarStyles.hover,
-              tooltipSide: 'left',
-              tooltip: 'Menu',
-              tooltipDelay: 100
-            }, [icon('ellipsis-v', { size: 24 })])
-          ]),
+        h(WorkspaceMenuTrigger, { canShare, isOwner, setCloningWorkspace, setSharingWorkspace, setDeletingWorkspace }, [
+          h(Clickable, {
+            'aria-label': 'Menu',
+            style: contextBarStyles.contextBarButton,
+            hover: contextBarStyles.hover,
+            tooltipSide: 'left',
+            tooltip: 'Menu',
+            tooltipDelay: 100
+          }, [icon('ellipsis-v', { size: 24 })])
+        ]),
         h(Clickable, {
           style: { ...contextBarStyles.contextBarButton, flexDirection: 'column', justifyContent: 'center', padding: '.75rem' },
           hover: contextBarStyles.hover,

--- a/src/components/ContextBar.js
+++ b/src/components/ContextBar.js
@@ -19,6 +19,7 @@ import {
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 import { CloudEnvironmentModal } from 'src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal'
+import { WorkspaceMenuTrigger } from 'src/pages/workspaces/workspace/WorkspaceContainer'
 
 
 const contextBarStyles = {
@@ -90,35 +91,17 @@ export const ContextBar = ({ setDeletingWorkspace, setCloningWorkspace, setShari
     }),
     div({ style: Style.elements.contextBarContainer }, [
       div({ style: contextBarStyles.contextBarContainer }, [
-        h(MenuTrigger, {
-          closeOnClick: true,
-          content: h(Fragment, [
-            h(MenuButton, { onClick: () => setCloningWorkspace(true) }, [makeMenuIcon('copy'), 'Clone']),
-            h(MenuButton, {
-              disabled: !canShare,
-              tooltip: !canShare && 'You have not been granted permission to share this workspace',
+        h(WorkspaceMenuTrigger, { canShare, isOwner, setCloningWorkspace, setSharingWorkspace, setDeletingWorkspace },
+          [
+            h(Clickable, {
+              'aria-label': 'Menu',
+              style: contextBarStyles.contextBarButton,
+              hover: contextBarStyles.hover,
               tooltipSide: 'left',
-              onClick: () => setSharingWorkspace(true)
-            }, [makeMenuIcon('share'), 'Share']),
-            h(MenuButton, { disabled: true }, [makeMenuIcon('export'), 'Publish', comingSoon]),
-            h(MenuButton, {
-              disabled: !isOwner,
-              tooltip: !isOwner && 'You must be an owner of this workspace or the underlying billing project',
-              tooltipSide: 'left',
-              onClick: () => setDeletingWorkspace(true)
-            }, [makeMenuIcon('trash'), 'Delete Workspace'])
+              tooltip: 'Menu',
+              tooltipDelay: 100
+            }, [icon('ellipsis-v', { size: 24 })])
           ]),
-          side: 'bottom'
-        }, [
-          h(Clickable, {
-            'aria-label': 'Menu',
-            style: contextBarStyles.contextBarButton,
-            hover: contextBarStyles.hover,
-            tooltipSide: 'left',
-            tooltip: 'Menu',
-            tooltipDelay: 100
-          }, [icon('ellipsis-v', { size: 24 })])
-        ]),
         h(Clickable, {
           style: { ...contextBarStyles.contextBarButton, flexDirection: 'column', justifyContent: 'center', padding: '.75rem' },
           hover: contextBarStyles.hover,

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -56,43 +56,12 @@ const WorkspaceTabs = ({
       tabNames: _.map('name', tabs),
       getHref: currentTab => Nav.getLink(_.find({ name: currentTab }, tabs).link, { namespace, name })
     }, [
-      h(MenuTrigger, {
-        closeOnClick: true,
-        content: h(Fragment, [
-          h(MenuButton, { onClick: () => setCloningWorkspace(true) }, [makeMenuIcon('copy'), 'Clone']),
-          h(MenuButton, {
-            disabled: !canShare,
-            tooltip: !canShare && 'You have not been granted permission to share this workspace',
-            tooltipSide: 'left',
-            onClick: () => setSharingWorkspace(true)
-          }, [makeMenuIcon('share'), 'Share']),
-          h(MenuButton, { disabled: true }, [makeMenuIcon('export'), 'Publish', comingSoon]),
-          h(MenuButton, {
-            disabled: !isOwner,
-            tooltip: !isOwner && 'You must be an owner of this workspace or the underlying billing project',
-            tooltipSide: 'left',
-            onClick: () => setDeletingWorkspace(true)
-          }, [makeMenuIcon('trash'), 'Delete Workspace'])
-        ]),
-        side: 'bottom'
-      }, [
-        h(Clickable, { 'aria-label': 'Workspace menu', ...navIconProps }, [icon('cardMenuIcon', { size: 27 })])
-      ])
-    ]),
-    deletingWorkspace && h(DeleteWorkspaceModal, {
-      workspace,
-      onDismiss: () => setDeletingWorkspace(false),
-      onSuccess: () => Nav.goToPath('workspaces')
-    }),
-    cloningWorkspace && h(NewWorkspaceModal, {
-      cloneWorkspace: workspace,
-      onDismiss: () => setCloningWorkspace(false),
-      onSuccess: ({ namespace, name }) => Nav.goToPath('workspace-dashboard', { namespace, name })
-    }),
-    sharingWorkspace && h(ShareWorkspaceModal, {
-      workspace,
-      onDismiss: () => setSharingWorkspace(false)
-    })
+      h(WorkspaceMenuTrigger, { canShare, isOwner, setCloningWorkspace, setSharingWorkspace, setDeletingWorkspace },
+        [
+          h(Clickable, { 'aria-label': 'Workspace menu', ...navIconProps }, [icon('cardMenuIcon', { size: 27 })])
+        ]
+      )
+    ])
   ])
 }
 
@@ -151,7 +120,21 @@ const WorkspaceContainer = ({
             workspace, refreshApps, refreshRuntimes,
             runtimes, persistentDisks, galaxyDataDisks, apps
           })
-        ])] : [children]))
+        ])] : [children])),
+    deletingWorkspace && h(DeleteWorkspaceModal, {
+      workspace,
+      onDismiss: () => setDeletingWorkspace(false),
+      onSuccess: () => Nav.goToPath('workspaces')
+    }),
+    cloningWorkspace && h(NewWorkspaceModal, {
+      cloneWorkspace: workspace,
+      onDismiss: () => setCloningWorkspace(false),
+      onSuccess: ({ namespace, name }) => Nav.goToPath('workspace-dashboard', { namespace, name })
+    }),
+    sharingWorkspace && h(ShareWorkspaceModal, {
+      workspace,
+      onDismiss: () => setSharingWorkspace(false)
+    })
   ])
 }
 
@@ -343,3 +326,24 @@ export const wrapWorkspace = ({ breadcrumbs, activeTab, title, topBarContent, sh
   }
   return Utils.withDisplayName('wrapWorkspace', Wrapper)
 }
+
+export const WorkspaceMenuTrigger = ({ children, canShare, isOwner, setCloningWorkspace, setSharingWorkspace, setDeletingWorkspace}) => h(MenuTrigger, {
+  closeOnClick: true,
+  content: h(Fragment, [
+    h(MenuButton, { onClick: () => setCloningWorkspace(true) }, [makeMenuIcon('copy'), 'Clone']),
+    h(MenuButton, {
+      disabled: !canShare,
+      tooltip: !canShare && 'You have not been granted permission to share this workspace',
+      tooltipSide: 'left',
+      onClick: () => setSharingWorkspace(true)
+    }, [makeMenuIcon('share'), 'Share']),
+    h(MenuButton, { disabled: true }, [makeMenuIcon('export'), 'Publish', comingSoon]),
+    h(MenuButton, {
+      disabled: !isOwner,
+      tooltip: !isOwner && 'You must be an owner of this workspace or the underlying billing project',
+      tooltipSide: 'left',
+      onClick: () => setDeletingWorkspace(true)
+    }, [makeMenuIcon('trash'), 'Delete Workspace'])
+  ]),
+  side: 'bottom'
+}, [children])

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -96,10 +96,10 @@ const WorkspaceTabs = ({
   ])
 }
 
-const WorkspaceContainer = ({ namespace, name, breadcrumbs, topBarContent, title, activeTab, showTabBar = true, refresh, refreshRuntimes, workspace, runtimes, persistentDisks, galaxyDataDisks, apps, refreshApps, children }) => {
-  const [deletingWorkspace, setDeletingWorkspace] = useState(false)
-  const [cloningWorkspace, setCloningWorkspace] = useState(false)
-  const [sharingWorkspace, setSharingWorkspace] = useState(false)
+const WorkspaceContainer = ({
+  namespace, name, breadcrumbs, topBarContent, title, activeTab, showTabBar = true, refresh, refreshRuntimes, workspace, runtimes, persistentDisks, galaxyDataDisks, apps, refreshApps, children,
+  setDeletingWorkspace, setCloningWorkspace, setSharingWorkspace, deletingWorkspace, cloningWorkspace, sharingWorkspace
+}) => {
   const isOwner = workspace && Utils.isOwner(workspace.accessLevel)
 
   const canShare = !!workspace?.canShare
@@ -256,6 +256,9 @@ export const wrapWorkspace = ({ breadcrumbs, activeTab, title, topBarContent, sh
     const accessNotificationId = useRef()
     const cachedWorkspace = Utils.useStore(workspaceStore)
     const [loadingWorkspace, setLoadingWorkspace] = useState(false)
+    const [deletingWorkspace, setDeletingWorkspace] = useState(false)
+    const [cloningWorkspace, setCloningWorkspace] = useState(false)
+    const [sharingWorkspace, setSharingWorkspace] = useState(false)
     const { runtimes, refreshRuntimes, persistentDisks, galaxyDataDisks } = useCloudEnvironmentPolling(namespace)
     const { apps, refreshApps } = useAppPolling(namespace, name)
     const workspace = cachedWorkspace && _.isEqual({ namespace, name }, _.pick(['namespace', 'name'], cachedWorkspace.workspace)) ?
@@ -315,6 +318,7 @@ export const wrapWorkspace = ({ breadcrumbs, activeTab, title, topBarContent, sh
     } else {
       return h(WorkspaceContainer, {
         namespace, name, activeTab, showTabBar, workspace, runtimes, persistentDisks, galaxyDataDisks, apps, refreshApps,
+        setDeletingWorkspace, setCloningWorkspace, setSharingWorkspace, deletingWorkspace, cloningWorkspace, sharingWorkspace,
         title: _.isFunction(title) ? title(props) : title,
         breadcrumbs: breadcrumbs(props),
         topBarContent: topBarContent && topBarContent({ workspace, ...props }),
@@ -330,6 +334,7 @@ export const wrapWorkspace = ({ breadcrumbs, activeTab, title, topBarContent, sh
           ref: child,
           workspace, refreshWorkspace, refreshApps, refreshRuntimes,
           runtimes, persistentDisks, galaxyDataDisks, apps,
+          setDeletingWorkspace, setCloningWorkspace, setSharingWorkspace,
           ...props
         }),
         loadingWorkspace && spinnerOverlay

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -56,10 +56,9 @@ const WorkspaceTabs = ({
       tabNames: _.map('name', tabs),
       getHref: currentTab => Nav.getLink(_.find({ name: currentTab }, tabs).link, { namespace, name })
     }, [
-      h(WorkspaceMenuTrigger, { canShare, isOwner, setCloningWorkspace, setSharingWorkspace, setDeletingWorkspace },
-        [
-          h(Clickable, { 'aria-label': 'Workspace menu', ...navIconProps }, [icon('cardMenuIcon', { size: 27 })])
-        ]
+      h(WorkspaceMenuTrigger, { canShare, isOwner, setCloningWorkspace, setSharingWorkspace, setDeletingWorkspace }, [
+        h(Clickable, { 'aria-label': 'Workspace menu', ...navIconProps }, [icon('cardMenuIcon', { size: 27 })])
+      ]
       )
     ])
   ])
@@ -71,9 +70,6 @@ const WorkspaceContainer = ({
   const [deletingWorkspace, setDeletingWorkspace] = useState(false)
   const [cloningWorkspace, setCloningWorkspace] = useState(false)
   const [sharingWorkspace, setSharingWorkspace] = useState(false)
-
-  const isOwner = workspace && Utils.isOwner(workspace.accessLevel)
-  const canShare = !!workspace?.canShare
 
   return h(FooterWrapper, [
     h(TopBar, { title: 'Workspaces', href: Nav.getLink('workspaces') }, [
@@ -114,8 +110,7 @@ const WorkspaceContainer = ({
             children
           ]),
           workspace && h(ContextBar, {
-            workspace, isOwner, canShare, setDeletingWorkspace, setCloningWorkspace, setSharingWorkspace,
-            canCompute: !!(workspace?.canCompute || runtimes?.length),
+            workspace, setDeletingWorkspace, setCloningWorkspace, setSharingWorkspace,
             apps, galaxyDataDisks, refreshApps,
             runtimes, persistentDisks, refreshRuntimes
           })

--- a/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
@@ -6,6 +6,7 @@ import { b, div, h, iframe, p, span } from 'react-hyperscript-helpers'
 import * as breadcrumbs from 'src/components/breadcrumbs'
 import { requesterPaysWrapper, withRequesterPaysHandler } from 'src/components/bucket-utils'
 import { ButtonPrimary, ButtonSecondary, Clickable, LabeledCheckbox, Link, spinnerOverlay } from 'src/components/common'
+import { ContextBar } from 'src/components/ContextBar'
 import { icon } from 'src/components/icons'
 import Modal from 'src/components/Modal'
 import { NewRuntimeModal } from 'src/components/NewRuntimeModal'
@@ -47,7 +48,7 @@ const AnalysisLauncher = _.flow(
     showTabBar: false
   })
 )(
-  ({ queryParams, analysisName, workspace, workspace: { workspace: { namespace, name }, accessLevel, canCompute }, runtimes, persistentDisks, refreshRuntimes },
+  ({ queryParams, analysisName, workspace, workspace: { workspace: { namespace, name }, accessLevel, canCompute }, runtimes, persistentDisks, refreshRuntimes, refreshApps, galaxyDataDisks, apps, setDeletingWorkspace, setCloningWorkspace, setSharingWorkspace },
     ref) => {
     const [createOpen, setCreateOpen] = useState(false)
     const runtime = getCurrentRuntime(runtimes)
@@ -56,37 +57,55 @@ const AnalysisLauncher = _.flow(
     const [busy, setBusy] = useState()
     const { mode } = queryParams
     const toolLabel = getTool(analysisName)
+    const isOwner = workspace && Utils.isOwner(workspace.accessLevel)
+    const canShare = !!workspace?.canShare
+    const iframeStyles = { height: '100%', width: '100%' }
 
     return h(Fragment, [
-      (Utils.canWrite(accessLevel) && canCompute && !!mode && _.includes(status, usableStatuses) && labels.tool === 'Jupyter') ?
-        h(labels.welderInstallFailed ? WelderDisabledNotebookEditorFrame : AnalysisEditorFrame,
-          { key: runtimeName, workspace, runtime, analysisName, mode, toolLabel }) :
-        h(Fragment, [
-          h(PreviewHeader, { queryParams, runtime, analysisName, toolLabel, workspace, readOnlyAccess: !(Utils.canWrite(accessLevel) && canCompute), onCreateRuntime: () => setCreateOpen(true) }),
-          h(AnalysisPreviewFrame, { analysisName, toolLabel, workspace })
+
+      div({ style: { flex: 1, display: 'flex' } }, [
+        div({ style: { flex: 1 } }, [
+          (Utils.canWrite(accessLevel) && canCompute && !!mode && _.includes(status, usableStatuses) && labels.tool === 'Jupyter') ?
+            h(labels.welderInstallFailed ? WelderDisabledNotebookEditorFrame : AnalysisEditorFrame,
+              { key: runtimeName, workspace, runtime, analysisName, mode, toolLabel, styles: iframeStyles }) :
+            h(Fragment, [
+              h(PreviewHeader, { styles: iframeStyles, queryParams, runtime, analysisName, toolLabel, workspace, readOnlyAccess: !(Utils.canWrite(accessLevel) && canCompute), onCreateRuntime: () => setCreateOpen(true) }),
+              h(AnalysisPreviewFrame, { styles: iframeStyles, analysisName, toolLabel, workspace })
+            ])
         ]),
-      mode && h(RuntimeKicker, { runtime, refreshRuntimes, onNullRuntime: () => setCreateOpen(true) }),
-      mode && h(RuntimeStatusMonitor, { runtime, onRuntimeStoppedRunning: () => chooseMode(undefined) }),
-      h(NewRuntimeModal, {
-        isOpen: createOpen,
-        tool: toolLabel,
-        isAnalysisMode: true,
-        workspace,
-        runtimes,
-        persistentDisks,
-        onDismiss: () => {
-          chooseMode(undefined)
-          setCreateOpen(false)
-        },
-        onSuccess: _.flow(
-          withErrorReporting('Error creating runtime'),
-          Utils.withBusyState(setBusy)
-        )(async () => {
-          setCreateOpen(false)
-          await refreshRuntimes(true)
-        })
-      }),
-      busy && spinnerOverlay
+        workspace && h(ContextBar, {
+          setDeletingWorkspace,
+          setCloningWorkspace,
+          setSharingWorkspace,
+          isOwner,
+          canShare,
+          canCompute: !!(workspace?.canCompute || runtimes?.length),
+          workspace, refreshApps, refreshRuntimes,
+          runtimes, persistentDisks, galaxyDataDisks, apps
+        }),
+        mode && h(RuntimeKicker, { runtime, refreshRuntimes, onNullRuntime: () => setCreateOpen(true) }),
+        mode && h(RuntimeStatusMonitor, { runtime, onRuntimeStoppedRunning: () => chooseMode(undefined) }),
+        h(NewRuntimeModal, {
+          isOpen: createOpen,
+          tool: toolLabel,
+          isAnalysisMode: true,
+          workspace,
+          runtimes,
+          persistentDisks,
+          onDismiss: () => {
+            chooseMode(undefined)
+            setCreateOpen(false)
+          },
+          onSuccess: _.flow(
+            withErrorReporting('Error creating runtime'),
+            Utils.withBusyState(setBusy)
+          )(async () => {
+            setCreateOpen(false)
+            await refreshRuntimes(true)
+          })
+        }),
+        busy && spinnerOverlay
+      ])
     ])
   })
 
@@ -329,7 +348,7 @@ const PreviewHeader = ({ queryParams, runtime, readOnlyAccess, onCreateRuntime, 
   ])
 }
 
-const AnalysisPreviewFrame = ({ analysisName, toolLabel, workspace: { workspace: { namespace, bucketName } }, onRequesterPaysError }) => {
+const AnalysisPreviewFrame = ({ analysisName, toolLabel, workspace: { workspace: { namespace, bucketName } }, onRequesterPaysError, styles }) => {
   const signal = Utils.useCancellation()
   const [busy, setBusy] = useState(false)
   const [preview, setPreview] = useState()
@@ -356,7 +375,7 @@ const AnalysisPreviewFrame = ({ analysisName, toolLabel, workspace: { workspace:
           doc.head.appendChild(Utils.createHtmlElement(doc, 'base', Utils.newTabLinkProps))
           doc.addEventListener('mousedown', () => window.document.dispatchEvent(new MouseEvent('mousedown')))
         },
-        style: { border: 'none', flex: 1 },
+        style: { border: 'none', flex: 1, ...styles },
         srcDoc: preview,
         title: 'Preview for analysis'
       })
@@ -411,7 +430,7 @@ const copyingAnalysisMessage = div({ style: { paddingTop: '2rem' } }, [
   h(StatusMessage, ['Copying analysis to cloud environment, almost ready...'])
 ])
 
-const AnalysisEditorFrame = ({ mode, analysisName, toolLabel, workspace: { workspace: { namespace, name, bucketName } }, runtime: { runtimeName, proxyUrl, status, labels } }) => {
+const AnalysisEditorFrame = ({ styles, mode, analysisName, toolLabel, workspace: { workspace: { namespace, name, bucketName } }, runtime: { runtimeName, proxyUrl, status, labels } }) => {
   console.assert(_.includes(status, usableStatuses), `Expected cloud environment to be one of: [${usableStatuses}]`)
   console.assert(!labels.welderInstallFailed, 'Expected cloud environment to have Welder')
   const frameRef = useRef()
@@ -458,7 +477,7 @@ const AnalysisEditorFrame = ({ mode, analysisName, toolLabel, workspace: { works
       iframe({
         //TODO: this may vary based on tool.
         src: `${proxyUrl}/notebooks/${mode === 'edit' ? localBaseDirectory : localSafeModeBaseDirectory}/${analysisName}`,
-        style: { border: 'none', flex: 1 },
+        style: { border: 'none', flex: 1, ...styles },
         ref: frameRef
       }),
       //TODO: this frame will most likely vary based on tool. See comment attached to `JupyterFrameManager`
@@ -475,7 +494,7 @@ const AnalysisEditorFrame = ({ mode, analysisName, toolLabel, workspace: { works
 //TODO: this originally was designed to handle VMs that didn't have welder deployed on them
 // do we need this anymore? (can be queried in prod DB to see if there are any VMs with welderEnabled=false with a `recent` dateAccessed
 // do we need to support this for rstudio? I don't think so because welder predates RStudio support, but not 100%
-const WelderDisabledNotebookEditorFrame = ({ mode, notebookName, workspace: { workspace: { namespace, name, bucketName } }, runtime: { runtimeName, proxyUrl, status, labels } }) => {
+const WelderDisabledNotebookEditorFrame = ({ styles, mode, notebookName, workspace: { workspace: { namespace, name, bucketName } }, runtime: { runtimeName, proxyUrl, status, labels } }) => {
   console.assert(status === 'Running', 'Expected cloud environment to be running')
   console.assert(!!labels.welderInstallFailed, 'Expected cloud environment to not have Welder')
   const frameRef = useRef()
@@ -524,7 +543,7 @@ const WelderDisabledNotebookEditorFrame = ({ mode, notebookName, workspace: { wo
       iframe({
         //TODO: does this link need to change?
         src: `${proxyUrl}/notebooks/${name}/${notebookName}`,
-        style: { border: 'none', flex: 1 },
+        style: { border: 'none', flex: 1, ...styles },
         ref: frameRef
       }),
       h(JupyterFrameManager, {

--- a/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
@@ -6,16 +6,10 @@ import { b, div, h, iframe, p, span } from 'react-hyperscript-helpers'
 import * as breadcrumbs from 'src/components/breadcrumbs'
 import { requesterPaysWrapper, withRequesterPaysHandler } from 'src/components/bucket-utils'
 import { ButtonPrimary, ButtonSecondary, Clickable, LabeledCheckbox, Link, spinnerOverlay } from 'src/components/common'
-import { ContextBar } from 'src/components/ContextBar'
 import { icon } from 'src/components/icons'
 import Modal from 'src/components/Modal'
 import { NewRuntimeModal } from 'src/components/NewRuntimeModal'
-import {
-  AnalysisDuplicator,
-  findPotentialNotebookLockers,
-  getDisplayName,
-  getTool, notebookLockHash
-} from 'src/components/notebook-utils'
+import { AnalysisDuplicator, findPotentialNotebookLockers, getDisplayName, getTool, notebookLockHash } from 'src/components/notebook-utils'
 import { makeMenuIcon, MenuButton, MenuTrigger } from 'src/components/PopupTrigger'
 import { ApplicationHeader, PlaygroundHeader, RuntimeKicker, RuntimeStatusMonitor, StatusMessage } from 'src/components/runtime-common'
 import { dataSyncingDocUrl } from 'src/data/machines'
@@ -48,7 +42,7 @@ const AnalysisLauncher = _.flow(
     showTabBar: false
   })
 )(
-  ({ queryParams, analysisName, workspace, workspace: { workspace: { namespace, name }, accessLevel, canCompute }, runtimes, persistentDisks, refreshRuntimes, refreshApps, galaxyDataDisks, apps, setDeletingWorkspace, setCloningWorkspace, setSharingWorkspace },
+  ({ queryParams, analysisName, workspace, workspace: { workspace: { namespace, name }, accessLevel, canCompute }, runtimes, persistentDisks, refreshRuntimes },
     ref) => {
     const [createOpen, setCreateOpen] = useState(false)
     const runtime = getCurrentRuntime(runtimes)
@@ -57,8 +51,6 @@ const AnalysisLauncher = _.flow(
     const [busy, setBusy] = useState()
     const { mode } = queryParams
     const toolLabel = getTool(analysisName)
-    const isOwner = workspace && Utils.isOwner(workspace.accessLevel)
-    const canShare = !!workspace?.canShare
     const iframeStyles = { height: '100%', width: '100%' }
 
     return h(Fragment, [
@@ -73,16 +65,6 @@ const AnalysisLauncher = _.flow(
               h(AnalysisPreviewFrame, { styles: iframeStyles, analysisName, toolLabel, workspace })
             ])
         ]),
-        workspace && h(ContextBar, {
-          setDeletingWorkspace,
-          setCloningWorkspace,
-          setSharingWorkspace,
-          isOwner,
-          canShare,
-          canCompute: !!(workspace?.canCompute || runtimes?.length),
-          workspace, refreshApps, refreshRuntimes,
-          runtimes, persistentDisks, galaxyDataDisks, apps
-        }),
         mode && h(RuntimeKicker, { runtime, refreshRuntimes, onNullRuntime: () => setCreateOpen(true) }),
         mode && h(RuntimeStatusMonitor, { runtime, onRuntimeStoppedRunning: () => chooseMode(undefined) }),
         h(NewRuntimeModal, {


### PR DESCRIPTION
Makes the context bar visible in the analysis launcher view. This view is currently not in use. It is used when a user clicks an artefact (.rmd or .ipynb file) on the analaysis tab. It does this by modifying the workspace wrapper to pass the necessary functions for the context bar at a higher layer, and adding some flexbox styling in the launcher page to struture the context bar and iframe content. Fairly simple change overall.
