### PR TITLE
[IA-2656] Create analysis flow additions

### DIFF
--- a/src/components/NewAnalysisModal.js
+++ b/src/components/NewAnalysisModal.js
@@ -1,37 +1,107 @@
 import _ from 'lodash/fp'
 import { Fragment, useState } from 'react'
-import { div, h, hr, img } from 'react-hyperscript-helpers'
-import { spinnerOverlay } from 'src/components/common'
+import { div, h, h2, h3, hr, img } from 'react-hyperscript-helpers'
+import { ButtonPrimary, IdContainer, Select, spinnerOverlay } from 'src/components/common'
 import ModalDrawer from 'src/components/ModalDrawer'
 import { NewGalaxyModalBase } from 'src/components/NewGalaxyModal'
 import { NewRuntimeModalBase } from 'src/components/NewRuntimeModal'
-import { tools } from 'src/components/notebook-utils'
+import {
+  analysisNameInput,
+  analysisNameValidator,
+  getDisplayName,
+  NotebookCreator, notebookData,
+  tools
+} from 'src/components/notebook-utils'
 import TitleBar from 'src/components/TitleBar'
 import galaxyLogo from 'src/images/galaxy-logo.png'
 import jupyterLogoLong from 'src/images/jupyter-logo-long.png'
 import rstudioLogo from 'src/images/rstudio-logo.svg'
+import { Ajax } from 'src/libs/ajax'
+import { getUser } from 'src/libs/auth'
 import colors from 'src/libs/colors'
-import { withErrorReporting } from 'src/libs/error'
+import { reportError, withErrorReporting } from 'src/libs/error'
 import * as Utils from 'src/libs/utils'
+import { getConvertedRuntimeStatus, getCurrentApp, getCurrentRuntime } from 'src/libs/runtime-utils'
+import { FormLabel } from 'src/libs/forms'
+import validate from 'validate.js'
 
 //TODO: title id in titleBar and aria-labelled-by in withModalDrawer
 
 const titleId = 'new-analysis-modal-title'
 
 export const NewAnalysisModal = Utils.withDisplayName('NewAnalysisModal')(
-  ({ isOpen, onDismiss, onSuccess, runtimes, apps, galaxyDataDisks, refreshRuntimes, refreshApps, workspace, persistentDisks, workspace: { workspace: { namespace, bucketName, name: workspaceName } } }) => {
+  ({ isOpen, onDismiss, onSuccess, runtimes, apps, galaxyDataDisks, refreshRuntimes, refreshApps, refreshAnalyses, analyses, workspace, persistentDisks, workspace: { workspace: { namespace, bucketName, name: workspaceName } } }) => {
     const [viewMode, setViewMode] = useState(undefined)
     const [busy, setBusy] = useState()
 
-    const renderNewRuntimeModal = tool => h(NewRuntimeModalBase, {
-      isOpen: viewMode === NEW_JUPYTER_MODE || viewMode === NEW_RSTUDIO_MODE,
+
+    const [notebookKernel, setNotebookKernel] = useState('python3')
+    const [nameTouched, setNameTouched] = useState(false)
+    const [analysisName, setAnalysisName] = useState('')
+    const currentRuntime = getCurrentRuntime(runtimes)
+    const currentRuntimeTool = currentRuntime?.labels?.tool
+    const currentApp = getCurrentApp(apps)
+
+    const [currentTool, setCurrentTool] = useState(undefined)
+
+    const NEW_ANALYSIS_MODE = 'NEW_ARTIFACT'
+    const NEW_ENVIRONMENT_MODE = 'NEW_ENVIRONMENT'
+
+    const resetView = () => {
+      setViewMode(undefined)
+      setCurrentTool(undefined)
+    }
+
+    console.log('viewmode')
+    console.log(viewMode)
+
+    const setNextViewMode = () => {
+      const doesCloudEnvForToolExist = currentRuntimeTool === currentTool || (currentApp && currentTool === tools.galaxy.label)
+
+      console.log('in setNextViewMode, currentTool')
+      console.log(currentTool)
+      return Utils.switchCase(viewMode,
+        [NEW_ANALYSIS_MODE, () => {
+          if (doesCloudEnvForToolExist) {
+            resetView()
+            onSuccess()
+          } else {
+            //TODO, if (current runtime exists && isNotDeletable), if before is true dont take them to new env creation because they cannot create one at this time. Should this be handled in the modal itself?
+            setViewMode(NEW_ENVIRONMENT_MODE)
+          }
+        }],
+        [NEW_ENVIRONMENT_MODE, () => resetView()],
+        [Utils.DEFAULT, () => currentTool === tools.galaxy.label ? setViewMode(NEW_ENVIRONMENT_MODE) : setViewMode(NEW_ANALYSIS_MODE)]
+      )
+    }
+
+    const setPreviousViewMode = () => Utils.switchCase(viewMode,
+      [NEW_ANALYSIS_MODE, () => setViewMode(undefined)],
+      [NEW_ENVIRONMENT_MODE, () => setViewMode(undefined)],
+      [Utils.DEFAULT, () => undefined]
+    )
+
+
+    const getView = () => Utils.switchCase(viewMode,
+      [NEW_ANALYSIS_MODE, renderCreateAnalysis],
+      [NEW_ENVIRONMENT_MODE, getNewEnvironmentView],
+      [Utils.DEFAULT, renderSelectAnalysisBody])
+
+    const getNewEnvironmentView = () => Utils.switchCase(currentTool,
+      [tools.Jupyter.label, renderNewRuntimeModal],
+      [tools.RStudio.label, renderNewRuntimeModal],
+      [tools.galaxy.label, renderNewGalaxyModal]
+    )
+
+    const renderNewRuntimeModal = () => h(NewRuntimeModalBase, {
+      isOpen: currentTool === tools.Jupyter.label || currentTool === tools.RStudio.label,
       isAnalysisMode: true,
       workspace,
-      tool,
+      tool: currentTool,
       runtimes,
       persistentDisks,
       onDismiss: () => {
-        setViewMode(undefined)
+        resetView()
         onDismiss()
       },
       onSuccess: _.flow(
@@ -45,7 +115,7 @@ export const NewAnalysisModal = Utils.withDisplayName('NewAnalysisModal')(
     })
 
     const renderNewGalaxyModal = () => h(NewGalaxyModalBase, {
-      isOpen: viewMode === NEW_GALAXY_MODE,
+      isOpen: viewMode === tools.galaxy.label,
       isAnalysisMode: true,
       workspace,
       apps,
@@ -64,33 +134,86 @@ export const NewAnalysisModal = Utils.withDisplayName('NewAnalysisModal')(
       })
     })
 
-    const NEW_JUPYTER_MODE = tools.Jupyter.label
-    const NEW_RSTUDIO_MODE = tools.RStudio.label
-    const NEW_GALAXY_MODE = tools.galaxy.label
-    const getView = () => Utils.switchCase(viewMode,
-      [NEW_JUPYTER_MODE, () => renderNewRuntimeModal(NEW_JUPYTER_MODE)],
-      [NEW_RSTUDIO_MODE, () => renderNewRuntimeModal(NEW_RSTUDIO_MODE)],
-      [NEW_GALAXY_MODE, renderNewGalaxyModal],
-      [Utils.DEFAULT, renderCreateAnalysisBody]
-    )
-
     const toolCardStyles = { backgroundColor: 'white', borderRadius: 5, padding: '1rem', display: 'inline-block', verticalAlign: 'middle', marginBottom: '1rem', textAlign: 'center', width: '100%', height: 60 }
     const imageStyles = { verticalAlign: 'middle', height: '100%', width: '40%' }
 
     const renderToolButtons = () => div({ style: { display: 'flex', alignItems: 'center', flexDirection: 'column', justifyContent: 'space-between' } }, [
-      div({ style: toolCardStyles, onClick: () => setViewMode(NEW_JUPYTER_MODE) }, [img({ src: jupyterLogoLong, style: _.merge(imageStyles, { width: '30%' }) })]),
-      div({ style: toolCardStyles, onClick: () => setViewMode(NEW_RSTUDIO_MODE) }, [img({ src: rstudioLogo, style: imageStyles })]),
-      div({ style: toolCardStyles, onClick: () => setViewMode(NEW_GALAXY_MODE) }, [img({ src: galaxyLogo, style: _.merge(imageStyles, { width: '30%' }) })])
+      div({ style: toolCardStyles, onClick: async () => { await setCurrentTool(tools.Jupyter.label); await setNextViewMode() } }, [img({ src: jupyterLogoLong, style: _.merge(imageStyles, { width: '30%' }) })]),
+      div({ style: toolCardStyles, onClick: async () => { await setCurrentTool(tools.RStudio.label); await setNextViewMode() } }, [img({ src: rstudioLogo, style: imageStyles })]),
+      div({ style: toolCardStyles, onClick: async () => { await setCurrentTool(tools.galaxy.label); await setNextViewMode() }, disabled: !currentApp, tooltip: !currentApp ? 'You already have a galaxy app' : '' }, [img({ src: galaxyLogo, style: _.merge(imageStyles, { width: '30%' }) })])
     ])
 
-    const renderCreateAnalysisBody = () => div({ style: { display: 'flex', flexDirection: 'column', flex: 1, padding: '.5rem 1.5rem 1.5rem 1.5rem' } }, [
+    const renderSelectAnalysisBody = () => div({ style: { display: 'flex', flexDirection: 'column', flex: 1, padding: '.5rem 1.5rem 1.5rem 1.5rem' } }, [
       renderToolButtons()
     ])
 
+    const getArtifactLabel = toolLabel => Utils.switchCase(toolLabel, [tools.RStudio.label, () => 'R markdown file'],
+      [tools.Jupyter.label, () => 'notebook'],
+      [Utils.DEFAULT, () => console.error(`Should not be calling getArtifactLabel for ${toolLabel}, arteficts not implemented`)])
+
+    const renderCreateAnalysis = () => div({ style: { display: 'flex', flexDirection: 'column', flex: 1, padding: '.5rem 1.5rem 1.5rem 1.5rem' } }, [
+      h2([`Create a new ${getArtifactLabel(currentTool)}`]),
+      renderCreateAnalysisBody(currentTool)
+    ])
+
+    const existingNames = _.map(({ name }) => getDisplayName(name), analyses)
+
+    const errors = validate(
+      { analysisName, notebookKernel },
+      {
+        analysisName: analysisNameValidator(existingNames),
+        notebookKernel: { presence: { allowEmpty: true } }
+      }
+    )
+
+    const renderCreateAnalysisBody = toolLabel => div({ styles: { display: 'flex', flexDirection: 'column', padding: '1.5rem' } }, [
+      // div()
+      h(IdContainer, [id => h(Fragment, [
+        h(FormLabel, { htmlFor: id, required: true }, [`Name of the ${getArtifactLabel(toolLabel)}`]),
+        analysisNameInput({
+          error: Utils.summarizeErrors(nameTouched && errors?.analysisName),
+          inputProps: {
+            id, value: analysisName,
+            onChange: v => {
+              setAnalysisName(v)
+              setNameTouched(true)
+            }
+          }
+        })
+      ])]),
+      toolLabel === tools.Jupyter.label ? h(IdContainer, [id => h(Fragment, [
+        h(FormLabel, { htmlFor: id, required: true }, ['Language']),
+        h(Select, {
+          id, isSearchable: true,
+          placeholder: 'Select a language',
+          getOptionLabel: ({ value }) => _.startCase(value),
+          value: notebookKernel,
+          onChange: ({ value: notebookKernel }) => setNotebookKernel(notebookKernel),
+          options: ['python3', 'r']
+        })
+      ])]) : [],
+      div({ style: { display: 'flex', justifyContent: 'flex-end', marginTop: '1rem' } }, [
+        h(ButtonPrimary, {
+          disabled: errors,
+          tooltip: Utils.summarizeErrors(errors),
+          onClick: async () => {
+            try {
+              const contents = toolLabel === tools.Jupyter.label ? notebookData[notebookKernel] : '# Starter Rmd file'
+              await Ajax().Buckets.analysis(namespace, bucketName, analysisName, toolLabel).create(contents)
+              refreshAnalyses()
+              setNextViewMode()
+            } catch (error) {
+              await reportError('Error creating analysis', error)
+              onDismiss()
+            }
+          }
+        }, 'Create Analysis')
+      ])
+    ])
+
     const width = Utils.switchCase(viewMode,
-      [NEW_JUPYTER_MODE, () => 675],
-      [NEW_RSTUDIO_MODE, () => 675],
-      [NEW_GALAXY_MODE, () => 675],
+      [NEW_ENVIRONMENT_MODE, () => 675],
+      [NEW_ANALYSIS_MODE, () => 450],
       [Utils.DEFAULT, () => 450]
     )
 
@@ -100,8 +223,11 @@ export const NewAnalysisModal = Utils.withDisplayName('NewAnalysisModal')(
         title: 'Select an application',
         titleStyles: _.merge(viewMode === undefined ? {} : { display: 'none' }, { margin: '1.5rem 0 0 1.5rem' }),
         width,
-        onDismiss,
-        onPrevious: !!viewMode ? () => setViewMode(undefined) : undefined
+        onDismiss: () => {
+          resetView()
+          onDismiss()
+        },
+        onPrevious: () => setPreviousViewMode()
       }),
       viewMode !== undefined && hr({ style: { borderTop: '1px solid', width: '100%', color: colors.accent() } }),
       getView(),
@@ -111,7 +237,7 @@ export const NewAnalysisModal = Utils.withDisplayName('NewAnalysisModal')(
     const modalProps = {
       isOpen, width, 'aria-labelledby': titleId,
       onDismiss: () => {
-        setViewMode(undefined)
+        resetView()
         onDismiss()
       }
     }

--- a/src/components/NewAnalysisModal.js
+++ b/src/components/NewAnalysisModal.js
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp'
 import { Fragment, useState } from 'react'
 import { div, h, h2, hr, img, span } from 'react-hyperscript-helpers'
-import { ButtonPrimary, IdContainer, Select, spinnerOverlay, WarningTitle } from 'src/components/common'
+import { ButtonPrimary, Clickable, IdContainer, Select, spinnerOverlay, WarningTitle } from 'src/components/common'
 import Dropzone from 'src/components/Dropzone'
 import { icon } from 'src/components/icons'
 import ModalDrawer from 'src/components/ModalDrawer'
@@ -26,6 +26,7 @@ import { getCurrentApp, getCurrentRuntime, isRuntimeDeletable } from 'src/libs/r
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 import validate from 'validate.js'
+import { WorkspaceMenuTrigger } from 'src/pages/workspaces/workspace/WorkspaceContainer'
 
 const titleId = 'new-analysis-modal-title'
 
@@ -218,9 +219,9 @@ export const NewAnalysisModal = Utils.withDisplayName('NewAnalysisModal')(
         })
       ])]),
       (toolLabel === tools.Jupyter.label || toolLabel === tools.RStudio.label) && (currentRuntime && !isRuntimeDeletable(currentRuntime) && currentRuntimeTool !== toolLabel) && div({ style: { backgroundColor: colors.warning(0.1), margin: '.5rem', padding: '1rem' } }, [
-        h(WarningTitle, { iconSize: 16,
+        h(WarningTitle, { iconSize: 16 },
           [span({ style: { fontWeight: 600 } }, ['Environment Creation'])]
-        }) ,
+        ),
         div({ style: { marginBottom: '.5rem', marginTop: '1rem' } }, ['You have a non-deletable environment associated with another application.']),
         div(['You may create an analysis, but must wait for your current environment to finish processing and get a suitable environment to run it.'])
       ]),

--- a/src/components/NewAnalysisModal.js
+++ b/src/components/NewAnalysisModal.js
@@ -73,7 +73,7 @@ export const NewAnalysisModal = Utils.withDisplayName('NewAnalysisModal')(
           [currentTool === tools.RStudio.label || currentTool === tools.Jupyter.label, () => setViewMode(newAnalysisMode)],
           [currentTool === tools.galaxy.label && !currentApp, () => setViewMode(newEnvironmentMode)],
           [currentTool === tools.galaxy.label && currentApp, () => {
-            console.error('This shouldn\'t be possible, as you aren\'t allowed to create a galaxy analysis when one exists; the button should be disabled')
+            console.error('This shouldn\'t be possible, as you aren\'t allowed to create a galaxy analysis when one exists; the button should be disabled.')
             resetView()
           }]
         )]

--- a/src/components/NewAnalysisModal.js
+++ b/src/components/NewAnalysisModal.js
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp'
 import { Fragment, useState } from 'react'
-import { div, h, h2, hr, img } from 'react-hyperscript-helpers'
-import { ButtonPrimary, IdContainer, Select, spinnerOverlay } from 'src/components/common'
+import { div, h, h2, hr, img, span } from 'react-hyperscript-helpers'
+import { ButtonPrimary, IdContainer, Select, spinnerOverlay, WarningTitle } from 'src/components/common'
 import Dropzone from 'src/components/Dropzone'
 import { icon } from 'src/components/icons'
 import ModalDrawer from 'src/components/ModalDrawer'
@@ -184,7 +184,7 @@ export const NewAnalysisModal = Utils.withDisplayName('NewAnalysisModal')(
       [Utils.DEFAULT, () => console.error(`Should not be calling getArtifactLabel for ${toolLabel}, artifacts not implemented`)])
 
     const renderCreateAnalysis = () => div({ style: { display: 'flex', flexDirection: 'column', flex: 1, padding: '.5rem 1.5rem 1.5rem 1.5rem' } }, [
-      h2([`Create a new ${getArtifactLabel(currentTool)}`]),
+      h2({ style: { fontWeight: 600, marginBottom: 0 } }, [`Create a new ${getArtifactLabel(currentTool)}`]),
       renderCreateAnalysisBody(currentTool)
     ])
 
@@ -198,7 +198,7 @@ export const NewAnalysisModal = Utils.withDisplayName('NewAnalysisModal')(
       }
     )
 
-    const renderCreateAnalysisBody = toolLabel => div({ styles: { display: 'flex', flexDirection: 'column', padding: '1.5rem' } }, [
+    const renderCreateAnalysisBody = toolLabel => div({ style: { display: 'flex', flexDirection: 'column' } }, [
       // div()
       h(IdContainer, [id => h(Fragment, [
         h(FormLabel, { htmlFor: id, required: true }, [`Name of the ${getArtifactLabel(toolLabel)}`]),
@@ -226,8 +226,9 @@ export const NewAnalysisModal = Utils.withDisplayName('NewAnalysisModal')(
       ])]),
       //if runtime
       //and runtime is not deletable
-      (toolLabel === tools.Jupyter.label || toolLabel === tools.RStudio.label) && (currentRuntime && !isRuntimeDeletable(currentRuntime) && currentRuntimeTool !== toolLabel) && div({ style: { backgroundColor: colors.warning(0.1), margin: '.5rem', padding: '.5rem' } }, [
-        div({ style: { marginBottom: '.5rem' } }, ['You have a non-deletable environment associated with another application.']),
+      (toolLabel === tools.Jupyter.label || toolLabel === tools.RStudio.label) && (currentRuntime && !isRuntimeDeletable(currentRuntime) && currentRuntimeTool !== toolLabel) && div({ style: { backgroundColor: colors.warning(0.1), margin: '.5rem', padding: '1rem' } }, [
+        h(WarningTitle, [span({ style: { fontWeight: 600 } }, ['Environment Creation'])]),
+        div({ style: { marginBottom: '.5rem', marginTop: '1rem' } }, ['You have a non-deletable environment associated with another application.']),
         div(['You may create an analysis, but must wait for your current environment to finish processing and get a suitable environment to run it.'])
       ]),
       div({ style: { display: 'flex', justifyContent: 'flex-end', marginTop: '1rem' } }, [

--- a/src/components/NewAnalysisModal.js
+++ b/src/components/NewAnalysisModal.js
@@ -218,7 +218,9 @@ export const NewAnalysisModal = Utils.withDisplayName('NewAnalysisModal')(
         })
       ])]),
       (toolLabel === tools.Jupyter.label || toolLabel === tools.RStudio.label) && (currentRuntime && !isRuntimeDeletable(currentRuntime) && currentRuntimeTool !== toolLabel) && div({ style: { backgroundColor: colors.warning(0.1), margin: '.5rem', padding: '1rem' } }, [
-        h(WarningTitle, [span({ style: { fontWeight: 600 } }, ['Environment Creation'])]),
+        h(WarningTitle, { iconSize: 16,
+          [span({ style: { fontWeight: 600 } }, ['Environment Creation'])]
+        }) ,
         div({ style: { marginBottom: '.5rem', marginTop: '1rem' } }, ['You have a non-deletable environment associated with another application.']),
         div(['You may create an analysis, but must wait for your current environment to finish processing and get a suitable environment to run it.'])
       ]),

--- a/src/components/NewAnalysisModal.js
+++ b/src/components/NewAnalysisModal.js
@@ -141,10 +141,10 @@ export const NewAnalysisModal = Utils.withDisplayName('NewAnalysisModal')(
     const renderToolButtons = () => div({ style: { display: 'flex', alignItems: 'center', flexDirection: 'column', justifyContent: 'space-between' } }, [
       div({ style: styles.toolCard, onClick: () => { setCurrentTool(tools.Jupyter.label); enterNextViewMode(tools.Jupyter.label) } }, [img({ src: jupyterLogoLong, style: _.merge(styles.image, { width: '30%' }) })]),
       div({ style: styles.toolCard, onClick: () => { setCurrentTool(tools.RStudio.label); enterNextViewMode(tools.RStudio.label) } }, [img({ src: rstudioLogo, style: styles.image })]),
-      div({ style: { opacity: currentApp ? '.5' : '1', ...styles.toolCard }, onClick: () => { setCurrentTool(tools.galaxy.label); enterNextViewMode(tools.galaxy.label) }, disabled: !currentApp, title: currentApp ? 'You already have a galaxy environment' : '' }, [img({ src: galaxyLogo, style: _.merge(styles.image, { width: '30%' }) })])
+      div({ style: { opacity: currentApp ? '0.5' : '1', ...styles.toolCard }, onClick: () => { setCurrentTool(tools.galaxy.label); enterNextViewMode(tools.galaxy.label) }, disabled: !currentApp, title: currentApp ? 'You already have a galaxy environment' : '' }, [img({ src: galaxyLogo, style: _.merge(styles.image, { width: '30%' }) })])
     ])
 
-    const renderSelectAnalysisBody = () => div({ style: { display: 'flex', flexDirection: 'column', flex: 1, padding: '.5rem 1.5rem 1.5rem 1.5rem' } }, [
+    const renderSelectAnalysisBody = () => div({ style: { display: 'flex', flexDirection: 'column', flex: 1, padding: '0.5rem 1.5rem 1.5rem 1.5rem' } }, [
       renderToolButtons(),
       h(Dropzone, {
         accept: `.${tools.Jupyter.ext}, .${tools.RStudio.ext}`,
@@ -175,17 +175,15 @@ export const NewAnalysisModal = Utils.withDisplayName('NewAnalysisModal')(
       [tools.Jupyter.label, () => 'notebook'],
       [Utils.DEFAULT, () => console.error(`Should not be calling getArtifactLabel for ${toolLabel}, artifacts not implemented`)])
 
-    const renderCreateAnalysis = () => div({ style: { display: 'flex', flexDirection: 'column', flex: 1, padding: '.5rem 1.5rem 1.5rem 1.5rem' } }, [
+    const renderCreateAnalysis = () => div({ style: { display: 'flex', flexDirection: 'column', flex: 1, padding: '0.5rem 1.5rem 1.5rem 1.5rem' } }, [
       h2({ style: { fontWeight: 600, marginBottom: 0 } }, [`Create a new ${getArtifactLabel(currentTool)}`]),
       renderCreateAnalysisBody(currentTool)
     ])
 
-    const existingNames = _.map(({ name }) => getDisplayName(name), analyses)
-
     const errors = validate(
       { analysisName, notebookKernel },
       {
-        analysisName: analysisNameValidator(existingNames),
+        analysisName: analysisNameValidator(_.map(({ name }) => getDisplayName(name), analyses)),
         notebookKernel: { presence: { allowEmpty: true } }
       }
     )
@@ -217,11 +215,11 @@ export const NewAnalysisModal = Utils.withDisplayName('NewAnalysisModal')(
             options: ['python3', 'r']
           })
         ])]),
-        (isJupyter || toolLabel === tools.RStudio.label) && (currentRuntime && !isRuntimeDeletable(currentRuntime) && currentRuntimeTool !== toolLabel) && div({ style: { backgroundColor: colors.warning(0.1), margin: '.5rem', padding: '1rem' } }, [
+        (isJupyter || toolLabel === tools.RStudio.label) && (currentRuntime && !isRuntimeDeletable(currentRuntime) && currentRuntimeTool !== toolLabel) && div({ style: { backgroundColor: colors.warning(0.1), margin: '0.5rem', padding: '1rem' } }, [
           h(WarningTitle, { iconSize: 16 },
             [span({ style: { fontWeight: 600 } }, ['Environment Creation'])]
           ),
-          div({ style: { marginBottom: '.5rem', marginTop: '1rem' } }, ['You have a non-deletable environment associated with another application.']),
+          div({ style: { marginBottom: '0.5rem', marginTop: '1rem' } }, ['You have a non-deletable environment associated with another application.']),
           div(['You may create an analysis, but must wait for your current environment to finish processing and get a suitable environment to run it.'])
         ]),
         div({ style: { display: 'flex', justifyContent: 'flex-end', marginTop: '1rem' } }, [

--- a/src/components/NewAnalysisModal.js
+++ b/src/components/NewAnalysisModal.js
@@ -27,24 +27,20 @@ import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 import validate from 'validate.js'
 
-//TODO: title id in titleBar and aria-labelled-by in withModalDrawer
-
 const titleId = 'new-analysis-modal-title'
 
 export const NewAnalysisModal = Utils.withDisplayName('NewAnalysisModal')(
   ({ isOpen, onDismiss, onSuccess, uploadFiles, openUploader, runtimes, apps, galaxyDataDisks, refreshRuntimes, refreshApps, refreshAnalyses, analyses, workspace, persistentDisks, workspace: { workspace: { namespace, bucketName, name: workspaceName } } }) => {
     const [viewMode, setViewMode] = useState(undefined)
     const [busy, setBusy] = useState()
-
-
     const [notebookKernel, setNotebookKernel] = useState('python3')
     const [nameTouched, setNameTouched] = useState(false)
     const [analysisName, setAnalysisName] = useState('')
     const currentRuntime = getCurrentRuntime(runtimes)
     const currentRuntimeTool = currentRuntime?.labels?.tool
     const currentApp = getCurrentApp(apps)
-
     const [currentTool, setCurrentTool] = useState(undefined)
+
 
     const NEW_ANALYSIS_MODE = 'NEW_ARTIFACT'
     const NEW_ENVIRONMENT_MODE = 'NEW_ENVIRONMENT'
@@ -89,7 +85,6 @@ export const NewAnalysisModal = Utils.withDisplayName('NewAnalysisModal')(
       [NEW_ENVIRONMENT_MODE, () => resetView()],
       [Utils.DEFAULT, () => undefined]
     )
-
 
     const getView = () => Utils.switchCase(viewMode,
       [NEW_ANALYSIS_MODE, renderCreateAnalysis],
@@ -178,7 +173,6 @@ export const NewAnalysisModal = Utils.withDisplayName('NewAnalysisModal')(
       ])])
     ])
 
-
     const getArtifactLabel = toolLabel => Utils.switchCase(toolLabel, [tools.RStudio.label, () => 'R markdown file'],
       [tools.Jupyter.label, () => 'notebook'],
       [Utils.DEFAULT, () => console.error(`Should not be calling getArtifactLabel for ${toolLabel}, artifacts not implemented`)])
@@ -199,7 +193,6 @@ export const NewAnalysisModal = Utils.withDisplayName('NewAnalysisModal')(
     )
 
     const renderCreateAnalysisBody = toolLabel => div({ style: { display: 'flex', flexDirection: 'column' } }, [
-      // div()
       h(IdContainer, [id => h(Fragment, [
         h(FormLabel, { htmlFor: id, required: true }, [`Name of the ${getArtifactLabel(toolLabel)}`]),
         analysisNameInput({
@@ -224,8 +217,6 @@ export const NewAnalysisModal = Utils.withDisplayName('NewAnalysisModal')(
           options: ['python3', 'r']
         })
       ])]),
-      //if runtime
-      //and runtime is not deletable
       (toolLabel === tools.Jupyter.label || toolLabel === tools.RStudio.label) && (currentRuntime && !isRuntimeDeletable(currentRuntime) && currentRuntimeTool !== toolLabel) && div({ style: { backgroundColor: colors.warning(0.1), margin: '.5rem', padding: '1rem' } }, [
         h(WarningTitle, [span({ style: { fontWeight: 600 } }, ['Environment Creation'])]),
         div({ style: { marginBottom: '.5rem', marginTop: '1rem' } }, ['You have a non-deletable environment associated with another application.']),

--- a/src/components/NewAnalysisModal.js
+++ b/src/components/NewAnalysisModal.js
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp'
 import { Fragment, useState } from 'react'
 import { div, h, h2, hr, img, span } from 'react-hyperscript-helpers'
-import { ButtonPrimary, Clickable, IdContainer, Select, spinnerOverlay, WarningTitle } from 'src/components/common'
+import { ButtonPrimary, IdContainer, Select, spinnerOverlay, WarningTitle } from 'src/components/common'
 import Dropzone from 'src/components/Dropzone'
 import { icon } from 'src/components/icons'
 import ModalDrawer from 'src/components/ModalDrawer'
@@ -26,7 +26,7 @@ import { getCurrentApp, getCurrentRuntime, isRuntimeDeletable } from 'src/libs/r
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 import validate from 'validate.js'
-import { WorkspaceMenuTrigger } from 'src/pages/workspaces/workspace/WorkspaceContainer'
+
 
 const titleId = 'new-analysis-modal-title'
 

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -536,9 +536,9 @@ export const HeroWrapper = ({ showMenu = true, bigSubhead = false, children }) =
   ])
 }
 
-export const WarningTitle = ({ children }) => {
+export const WarningTitle = ({ children, iconSize = 36 }) => {
   return div({ style: { display: 'flex', alignItems: 'center' } }, [
-    icon('warning-standard', { size: 36, style: { color: colors.warning(), marginRight: '0.75rem' } }),
+    icon('warning-standard', { size: iconSize, style: { color: colors.warning(), marginRight: '0.75rem' } }),
     children
   ])
 }

--- a/src/components/notebook-utils.js
+++ b/src/components/notebook-utils.js
@@ -86,7 +86,7 @@ const baseNotebook = {
   ], nbformat: 4, nbformat_minor: 2
 }
 
-const notebookData = {
+export const notebookData = {
   python3: _.merge({
     metadata: {
       kernelspec: { display_name: 'Python 3', language: 'python', name: 'python3' }
@@ -165,6 +165,67 @@ export const NotebookCreator = ({ reloadList, onSuccess, onDismiss, namespace, b
     creating && spinnerOverlay
   ])
 }
+
+// export const AnalysisCreator = ({ reloadAnalyses, onSuccess, onDismiss, namespace, bucketName, existingNames }) => {
+//   const [analysisName, setAnalysisName] = useState('')
+//   const [notebookKernel, setNotebookKernel] = useState(undefined)
+//   const [creating, setCreating] = useState(false)
+//   const [nameTouched, setNameTouched] = useState(false)
+//   const errors = validate(
+//     { analysisName, notebookKernel },
+//     {
+//       notebookName: analysisNameValidator(existingNames),
+//       notebookKernel: { presence: { allowEmpty: true } }
+//     },
+//     { prettify: v => ({ analysisName: 'Name', notebookKernel: 'Language' }[v] || validate.prettify(v)) }
+//   )
+//
+//   return div(, {
+//     onDismiss,
+//     title: 'Create New A',
+//     okButton: h(ButtonPrimary, {
+//       disabled: creating || errors,
+//       tooltip: Utils.summarizeErrors(errors),
+//       onClick: async () => {
+//         setCreating(true)
+//         try {
+//           await Ajax().Buckets.notebook(namespace, bucketName, notebookName).create(notebookData[notebookKernel])
+//           reloadList()
+//           onSuccess(notebookName, notebookKernel)
+//         } catch (error) {
+//           await reportError('Error creating notebook', error)
+//           onDismiss()
+//         }
+//       }
+//     }, 'Create Notebook')
+//   }, [
+//     h(IdContainer, [id => h(Fragment, [
+//       h(FormLabel, { htmlFor: id, required: true }, ['Name']),
+//       analysisNameInput({
+//         error: Utils.summarizeErrors(nameTouched && errors?.notebookName),
+//         inputProps: {
+//           id, value: notebookName,
+//           onChange: v => {
+//             setNotebookName(v)
+//             setNameTouched(true)
+//           }
+//         }
+//       })
+//     ])]),
+//     h(IdContainer, [id => h(Fragment, [
+//       h(FormLabel, { htmlFor: id, required: true }, ['Language']),
+//       h(Select, {
+//         id, isSearchable: true,
+//         placeholder: 'Select a language',
+//         getOptionLabel: ({ value }) => _.startCase(value),
+//         value: notebookKernel,
+//         onChange: ({ value: notebookKernel }) => setNotebookKernel(notebookKernel),
+//         options: ['python3', 'r']
+//       })
+//     ])]),
+//     creating && spinnerOverlay
+//   ])
+// }
 
 export const AnalysisDuplicator = ({ destroyOld = false, fromLauncher = false, printName, toolLabel, wsName, namespace, bucketName, onDismiss, onSuccess }) => {
   const [newName, setNewName] = useState('')

--- a/src/components/notebook-utils.js
+++ b/src/components/notebook-utils.js
@@ -166,67 +166,6 @@ export const NotebookCreator = ({ reloadList, onSuccess, onDismiss, namespace, b
   ])
 }
 
-// export const AnalysisCreator = ({ reloadAnalyses, onSuccess, onDismiss, namespace, bucketName, existingNames }) => {
-//   const [analysisName, setAnalysisName] = useState('')
-//   const [notebookKernel, setNotebookKernel] = useState(undefined)
-//   const [creating, setCreating] = useState(false)
-//   const [nameTouched, setNameTouched] = useState(false)
-//   const errors = validate(
-//     { analysisName, notebookKernel },
-//     {
-//       notebookName: analysisNameValidator(existingNames),
-//       notebookKernel: { presence: { allowEmpty: true } }
-//     },
-//     { prettify: v => ({ analysisName: 'Name', notebookKernel: 'Language' }[v] || validate.prettify(v)) }
-//   )
-//
-//   return div(, {
-//     onDismiss,
-//     title: 'Create New A',
-//     okButton: h(ButtonPrimary, {
-//       disabled: creating || errors,
-//       tooltip: Utils.summarizeErrors(errors),
-//       onClick: async () => {
-//         setCreating(true)
-//         try {
-//           await Ajax().Buckets.notebook(namespace, bucketName, notebookName).create(notebookData[notebookKernel])
-//           reloadList()
-//           onSuccess(notebookName, notebookKernel)
-//         } catch (error) {
-//           await reportError('Error creating notebook', error)
-//           onDismiss()
-//         }
-//       }
-//     }, 'Create Notebook')
-//   }, [
-//     h(IdContainer, [id => h(Fragment, [
-//       h(FormLabel, { htmlFor: id, required: true }, ['Name']),
-//       analysisNameInput({
-//         error: Utils.summarizeErrors(nameTouched && errors?.notebookName),
-//         inputProps: {
-//           id, value: notebookName,
-//           onChange: v => {
-//             setNotebookName(v)
-//             setNameTouched(true)
-//           }
-//         }
-//       })
-//     ])]),
-//     h(IdContainer, [id => h(Fragment, [
-//       h(FormLabel, { htmlFor: id, required: true }, ['Language']),
-//       h(Select, {
-//         id, isSearchable: true,
-//         placeholder: 'Select a language',
-//         getOptionLabel: ({ value }) => _.startCase(value),
-//         value: notebookKernel,
-//         onChange: ({ value: notebookKernel }) => setNotebookKernel(notebookKernel),
-//         options: ['python3', 'r']
-//       })
-//     ])]),
-//     creating && spinnerOverlay
-//   ])
-// }
-
 export const AnalysisDuplicator = ({ destroyOld = false, fromLauncher = false, printName, toolLabel, wsName, namespace, bucketName, onDismiss, onSuccess }) => {
   const [newName, setNewName] = useState('')
   const [existingNames, setExistingNames] = useState([])

--- a/src/libs/runtime-utils.js
+++ b/src/libs/runtime-utils.js
@@ -222,6 +222,8 @@ export const getGalaxyCostTextChildren = (app, galaxyDataDisks) => {
 
 export const isAppDeletable = app => _.includes(app?.status, ['RUNNING', 'ERROR'])
 
+export const isRuntimeDeletable = runtime => _.includes(runtime?.status, ['Unknown', 'Running', 'Updating', 'Error', 'Stopping', 'Stopped', 'Starting'])
+
 export const getConvertedRuntimeStatus = runtime => {
   return runtime && (runtime.patchInProgress ? 'LeoReconfiguring' : runtime.status) // NOTE: preserves null vs undefined
 }

--- a/src/pages/workspaces/workspace/Analyses.js
+++ b/src/pages/workspaces/workspace/Analyses.js
@@ -359,19 +359,6 @@ const Analyses = _.flow(
           icon('plus', { size: 14, style: { color: colors.accent() } }),
           div({ style: { marginLeft: '0.5rem' } }, ['Create'])
         ]),
-        h(ButtonPrimary, {
-          style: {
-            marginLeft: '1rem'
-          },
-          onClick: openUploader,
-          disabled: !Utils.canWrite(accessLevel),
-          tooltip: !Utils.canWrite(accessLevel) ? noWrite : undefined
-        }, [
-          div({ style: { marginBottom: '0.5rem' } }, [
-            icon('upload-cloud', { style: { marginTop: '0.5rem', marginRight: '0.5rem' }, size: 21 }),
-            'Upload'
-          ])
-        ]),
         div({ style: { flex: 2 } }),
         !_.isEmpty(analyses) && h(DelayedSearchInput, {
           'aria-label': 'Search analyses',
@@ -388,10 +375,18 @@ const Analyses = _.flow(
           persistentDisks,
           refreshRuntimes,
           galaxyDataDisks,
+          refreshAnalyses,
+          analyses,
           apps,
           refreshApps,
-          onDismiss: () => setCreating(false),
-          onSuccess: () => setCreating(false)
+          onDismiss: () => {
+            refreshAnalyses()
+            setCreating(false)
+          },
+          onSuccess: () => {
+            refreshAnalyses()
+            setCreating(false)
+          }
         }),
         renamingAnalysisName && h(AnalysisDuplicator, {
           printName: getDisplayName(renamingAnalysisName),

--- a/src/pages/workspaces/workspace/Analyses.js
+++ b/src/pages/workspaces/workspace/Analyses.js
@@ -6,29 +6,12 @@ import { a, div, h, img } from 'react-hyperscript-helpers'
 import * as breadcrumbs from 'src/components/breadcrumbs'
 import { requesterPaysWrapper, withRequesterPaysHandler } from 'src/components/bucket-utils'
 import { withViewToggle } from 'src/components/CardsListToggle'
-import {
-  ButtonOutline,
-  Clickable,
-  HeaderRenderer,
-  Link,
-  PageBox,
-  spinnerOverlay
-} from 'src/components/common'
+import { ButtonOutline, Clickable, HeaderRenderer, Link, PageBox, spinnerOverlay } from 'src/components/common'
 import Dropzone from 'src/components/Dropzone'
 import { icon } from 'src/components/icons'
 import { DelayedSearchInput } from 'src/components/input'
 import { NewAnalysisModal } from 'src/components/NewAnalysisModal'
-import {
-  AnalysisDeleter,
-  AnalysisDuplicator,
-  findPotentialNotebookLockers,
-  getDisplayName,
-  getFileName,
-  getTool,
-  notebookLockHash,
-  stripExtension,
-  tools
-} from 'src/components/notebook-utils'
+import { AnalysisDeleter, AnalysisDuplicator, findPotentialNotebookLockers, getDisplayName, getFileName, getTool, notebookLockHash, stripExtension, tools } from 'src/components/notebook-utils'
 import { makeMenuIcon, MenuButton, MenuTrigger } from 'src/components/PopupTrigger'
 import { ariaSort } from 'src/components/table'
 import TooltipTrigger from 'src/components/TooltipTrigger'

--- a/src/pages/workspaces/workspace/Analyses.js
+++ b/src/pages/workspaces/workspace/Analyses.js
@@ -8,8 +8,8 @@ import { requesterPaysWrapper, withRequesterPaysHandler } from 'src/components/b
 import { withViewToggle } from 'src/components/CardsListToggle'
 import {
   ButtonOutline,
-  ButtonPrimary,
-  Clickable, HeaderRenderer,
+  Clickable,
+  HeaderRenderer,
   Link,
   PageBox,
   spinnerOverlay
@@ -379,6 +379,7 @@ const Analyses = _.flow(
           analyses,
           apps,
           refreshApps,
+          uploadFiles, openUploader,
           onDismiss: () => {
             refreshAnalyses()
             setCreating(false)

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -294,7 +294,6 @@ const Notebooks = _.flow(
     StateHistory.update({ notebooks, sortOrder, filter })
   }, [notebooks, sortOrder, filter])
 
-
   // Render helpers
   const renderNotebooks = openUploader => {
     const { field, direction } = sortOrder


### PR DESCRIPTION
This PR adds some state to NewAnalysisModal to guide users through creating/uploading an artifact for their analysis. It will also prompt the user to create an environment if none exists to run their analysis. If no environment for an analysis (i.e. Jupyter for a notebook) exists  at creation time and they arent able to create one (i.e. they have an Rstudio runtime in a non-deletable status) we will allow them to create the artifact, but warn them they dont have an applicable env to run. 

Initial page
![image](https://user-images.githubusercontent.com/6465084/128913001-b5114fb5-2c87-425e-a3ad-e4eebc588112.png)

Creating a notebook
![image](https://user-images.githubusercontent.com/6465084/128913090-1eef3a33-e994-41f0-a77d-28b9ace7b6c3.png)

Creating an rmd
![image](https://user-images.githubusercontent.com/6465084/128913156-372bfc67-14d5-40c3-85fb-b1161150113c.png)

Creating an rmd when I have a creating (non-deletable) Jupyter env
![image](https://user-images.githubusercontent.com/6465084/128913263-dc54b2eb-1a31-48b2-afe4-4393697053ea.png)

