### PR TITLE
[CA-1587] Paint Icon for Status of Billing Account Change

### DIFF
--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -26,10 +26,17 @@ import { billingRoles } from 'src/pages/billing/List'
 const workspaceLastModifiedWidth = 150
 const workspaceExpandIconSize = 20
 
+const workspaceBillingStatusIcon = (() => {
+  const size = 16
+  const blank = div({ style: { width: size } },
+    [div({ className: 'sr-only' }, ['Status'])])
+  return shape => shape ? icon(shape, { size }) : blank
+})()
+
 const WorkspaceCardHeaders = Utils.memoWithName('WorkspaceCardHeaders', ({ sort, onSort }) => {
   return div({ style: { display: 'flex', justifyContent: 'space-between', marginTop: '1.5rem', padding: '0 1rem', marginBottom: '0.5rem' } }, [
-    // extra left-padding for workspace billing account status icons
-    div({ 'aria-sort': ariaSort(sort, 'name'), style: { flex: 1, paddingLeft: '2rem' } }, [
+    workspaceBillingStatusIcon(null),
+    div({ 'aria-sort': ariaSort(sort, 'name'), style: { flex: 1, paddingLeft: '1rem' } }, [
       h(HeaderRenderer, { sort, onSort, name: 'name' })
     ]),
     div({ 'aria-sort': ariaSort(sort, 'createdBy'), style: { flex: 1 } }, [
@@ -74,8 +81,8 @@ const WorkspaceCard = Utils.memoWithName('WorkspaceCard', ({ workspace, billingA
   return div({ role: 'listitem', style: { ...Style.cardList.longCardShadowless, flexDirection: 'column' } }, [
     h(IdContainer, [id => h(Fragment, [
       div({ style: workspaceCardStyles.row }, [
-        billingAccountStatusIcon && icon(billingAccountStatusIcon, { size: 16 }),
-        div({ style: { ...workspaceCardStyles.field, display: 'flex', alignItems: 'center', paddingLeft: billingAccountStatusIcon ? '1rem' : '2rem' } }, [
+        workspaceBillingStatusIcon(billingAccountStatusIcon),
+        div({ style: { ...workspaceCardStyles.field, display: 'flex', alignItems: 'center', paddingLeft: '1rem' } }, [
           h(Link, {
             style: Style.noWrapEllipsis,
             href: Nav.getLink('workspace-dashboard', { namespace, name }),

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -22,12 +22,17 @@ import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 import { billingRoles } from 'src/pages/billing/List'
 
-
+const workspaceStatusIconWidth = 16
 const workspaceLastModifiedWidth = 150
 const workspaceExpandIconSize = 20
 
+const paddingForWorkspaceStatusIcon =
+  div({ style: { width: workspaceStatusIconWidth } },
+  [div({ className: 'sr-only' }, ['Status'])])
+
 const WorkspaceCardHeaders = Utils.memoWithName('WorkspaceCardHeaders', ({ sort, onSort }) => {
   return div({ style: { display: 'flex', justifyContent: 'space-between', marginTop: '1.5rem', padding: '0 1rem', marginBottom: '0.5rem' } }, [
+    paddingForWorkspaceStatusIcon,
     div({ 'aria-sort': ariaSort(sort, 'name'), style: { flex: 1, paddingLeft: '1rem' } }, [
       h(HeaderRenderer, { sort, onSort, name: 'name' })
     ]),
@@ -60,6 +65,10 @@ const ExpandedInfoRow = Utils.memoWithName('ExpandedInfoRow', ({ title, details,
   ])
 })
 
+const statusIcon = () => {
+  return paddingForWorkspaceStatusIcon
+}
+
 const WorkspaceCard = Utils.memoWithName('WorkspaceCard', ({ workspace, isExpanded, onExpand }) => {
   const { namespace, name, createdBy, lastModified, googleProject, billingAccountName } = workspace
   const workspaceCardStyles = {
@@ -73,6 +82,7 @@ const WorkspaceCard = Utils.memoWithName('WorkspaceCard', ({ workspace, isExpand
   return div({ role: 'listitem', style: { ...Style.cardList.longCardShadowless, flexDirection: 'column' } }, [
     h(IdContainer, [id => h(Fragment, [
       div({ style: workspaceCardStyles.row }, [
+        statusIcon(),
         div({ style: { ...workspaceCardStyles.field, display: 'flex', alignItems: 'center', paddingLeft: '1rem' } }, [
           h(Link, {
             style: Style.noWrapEllipsis,

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -33,8 +33,7 @@ const paddingForWorkspaceStatusIcon =
 
 const WorkspaceCardHeaders = Utils.memoWithName('WorkspaceCardHeaders', ({ sort, onSort }) => {
   return div({ style: { display: 'flex', justifyContent: 'space-between', marginTop: '1.5rem', padding: '0 1rem', marginBottom: '0.5rem' } }, [
-    paddingForWorkspaceStatusIcon,
-    div({ 'aria-sort': ariaSort(sort, 'name'), style: { flex: 1, paddingLeft: '1rem' } }, [
+    div({ 'aria-sort': ariaSort(sort, 'name'), style: { flex: 1, paddingLeft: '2rem' } }, [
       h(HeaderRenderer, { sort, onSort, name: 'name' })
     ]),
     div({ 'aria-sort': ariaSort(sort, 'createdBy'), style: { flex: 1 } }, [

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -23,16 +23,12 @@ import * as Utils from 'src/libs/utils'
 import { billingRoles } from 'src/pages/billing/List'
 
 
-const workspaceStatusIconWidth = 16
 const workspaceLastModifiedWidth = 150
 const workspaceExpandIconSize = 20
 
-const paddingForWorkspaceStatusIcon =
-  div({ style: { width: workspaceStatusIconWidth } },
-    [div({ className: 'sr-only' }, ['Status'])])
-
 const WorkspaceCardHeaders = Utils.memoWithName('WorkspaceCardHeaders', ({ sort, onSort }) => {
   return div({ style: { display: 'flex', justifyContent: 'space-between', marginTop: '1.5rem', padding: '0 1rem', marginBottom: '0.5rem' } }, [
+    // extra left-padding for workspace billing account status icons
     div({ 'aria-sort': ariaSort(sort, 'name'), style: { flex: 1, paddingLeft: '2rem' } }, [
       h(HeaderRenderer, { sort, onSort, name: 'name' })
     ]),
@@ -158,12 +154,16 @@ const ProjectDetail = ({ project, project: { projectName, creationStatus }, bill
 
   const getBillingAccountStatusIcon = (() => {
     const allWorkspacesHaveCorrectBillingAccount =
-      _.isEmpty(_.remove({ billingAccount: billingAccountName }, workspacesInProject))
-    const getIcon = shape => icon(shape, { size: workspaceStatusIconWidth })
-    return workspace => allWorkspacesHaveCorrectBillingAccount ? paddingForWorkspaceStatusIcon :
-      billingAccountName === workspace.billingAccount ? getIcon('success-standard') :
-        'billingAccountErrorMessage' in workspace ? getIcon('error-standard') :
-          getIcon('loadingSpinner')
+      _.every({ billingAccount: billingAccountName }, workspacesInProject)
+    const iconWidth = 16
+    const noIcon = div({ style: { width: iconWidth } },
+      [div({ className: 'sr-only' }, ['Status'])])
+    const getIcon = shape => icon(shape, { size: iconWidth })
+    return workspace => Utils.cond(
+      [allWorkspacesHaveCorrectBillingAccount, () => noIcon],
+      [billingAccountName === workspace.billingAccount, () => getIcon('success-standard')],
+      ['billingAccountErrorMessage' in workspace, () => getIcon('error-standard')],
+      [Utils.DEFAULT, () => getIcon('loadingSpinner')])
   })()
 
   const tabToTable = {

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp'
 import * as qs from 'qs'
-import { Fragment, useEffect, useState } from 'react'
+import { Fragment, useEffect, useMemo, useState } from 'react'
 import { div, h, span } from 'react-hyperscript-helpers'
 import { ButtonPrimary, HeaderRenderer, IdContainer, Link, Select, spinnerOverlay } from 'src/components/common'
 import { DeleteUserModal, EditUserModal, MemberCard, MemberCardHeaders, NewUserCard, NewUserModal } from 'src/components/group-common'
@@ -152,12 +152,10 @@ const ProjectDetail = ({ project, project: { projectName, creationStatus }, bill
 
   const adminCanEdit = _.filter(({ roles }) => _.includes(billingRoles.owner, roles), projectUsers).length > 1
 
-  // TODO (Post PPW): Remove billing account name here, and move back to just returning workspace.
-  // This is for a seamless transition to PPW, where `billingAccountName` should be a field on the workspace.
-  const workspacesInProject = _.flow(
+  const workspacesInProject = useMemo(() => _.flow(
     _.map(({ workspace }) => workspace),
     _.filter({ namespace: projectName })
-  )(workspaces)
+  )(workspaces), [workspaces, projectName])
 
   const getBillingAccountStatusIcon = (() => {
     const allWorkspacesHaveCorrectBillingAccount =

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -61,7 +61,7 @@ const ExpandedInfoRow = Utils.memoWithName('ExpandedInfoRow', ({ title, details,
   ])
 })
 
-const WorkspaceCard = Utils.memoWithName('WorkspaceCard', ({ workspace, statusIcon, isExpanded, onExpand }) => {
+const WorkspaceCard = Utils.memoWithName('WorkspaceCard', ({ workspace, billingAccountStatusIcon, isExpanded, onExpand }) => {
   const { namespace, name, createdBy, lastModified, googleProject, billingAccountName } = workspace
   const workspaceCardStyles = {
     field: {
@@ -74,8 +74,8 @@ const WorkspaceCard = Utils.memoWithName('WorkspaceCard', ({ workspace, statusIc
   return div({ role: 'listitem', style: { ...Style.cardList.longCardShadowless, flexDirection: 'column' } }, [
     h(IdContainer, [id => h(Fragment, [
       div({ style: workspaceCardStyles.row }, [
-        statusIcon,
-        div({ style: { ...workspaceCardStyles.field, display: 'flex', alignItems: 'center', paddingLeft: '1rem' } }, [
+        billingAccountStatusIcon && icon(billingAccountStatusIcon, { size: 16 }),
+        div({ style: { ...workspaceCardStyles.field, display: 'flex', alignItems: 'center', paddingLeft: billingAccountStatusIcon ? '1rem' : '2rem' } }, [
           h(Link, {
             style: Style.noWrapEllipsis,
             href: Nav.getLink('workspace-dashboard', { namespace, name }),
@@ -155,15 +155,11 @@ const ProjectDetail = ({ project, project: { projectName, creationStatus }, bill
   const getBillingAccountStatusIcon = (() => {
     const allWorkspacesHaveCorrectBillingAccount =
       _.every({ billingAccount: billingAccountName }, workspacesInProject)
-    const iconWidth = 16
-    const noIcon = div({ style: { width: iconWidth } },
-      [div({ className: 'sr-only' }, ['Status'])])
-    const getIcon = shape => icon(shape, { size: iconWidth })
     return workspace => Utils.cond(
-      [allWorkspacesHaveCorrectBillingAccount, () => noIcon],
-      [billingAccountName === workspace.billingAccount, () => getIcon('success-standard')],
-      ['billingAccountErrorMessage' in workspace, () => getIcon('error-standard')],
-      [Utils.DEFAULT, () => getIcon('loadingSpinner')])
+      [allWorkspacesHaveCorrectBillingAccount, () => null],
+      [billingAccountName === workspace.billingAccount, () => 'success-standard'],
+      ['billingAccountErrorMessage' in workspace, () => 'error-standard'],
+      [Utils.DEFAULT, () => 'loadingSpinner'])
   })()
 
   const tabToTable = {
@@ -176,7 +172,7 @@ const ProjectDetail = ({ project, project: { projectName, creationStatus }, bill
             const isExpanded = expandedWorkspaceName === workspace.name
             return h(WorkspaceCard, {
               workspace,
-              statusIcon: getBillingAccountStatusIcon(workspace),
+              billingAccountStatusIcon: getBillingAccountStatusIcon(workspace),
               key: workspace.workspaceId,
               isExpanded,
               onExpand: () => setExpandedWorkspaceName(isExpanded ? undefined : workspace.name)

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -26,7 +26,7 @@ import { billingRoles } from 'src/pages/billing/List'
 const workspaceLastModifiedWidth = 150
 const workspaceExpandIconSize = 20
 
-const workspaceBillingStatusIcon = (() => {
+const workspaceBillingStatusIconOrEmpty = (() => {
   const size = 16
   const blank = div({ style: { width: size } },
     [div({ className: 'sr-only' }, ['Status'])])
@@ -35,7 +35,7 @@ const workspaceBillingStatusIcon = (() => {
 
 const WorkspaceCardHeaders = Utils.memoWithName('WorkspaceCardHeaders', ({ sort, onSort }) => {
   return div({ style: { display: 'flex', justifyContent: 'space-between', marginTop: '1.5rem', padding: '0 1rem', marginBottom: '0.5rem' } }, [
-    workspaceBillingStatusIcon(null),
+    workspaceBillingStatusIconOrEmpty(null),
     div({ 'aria-sort': ariaSort(sort, 'name'), style: { flex: 1, paddingLeft: '1rem' } }, [
       h(HeaderRenderer, { sort, onSort, name: 'name' })
     ]),
@@ -81,7 +81,7 @@ const WorkspaceCard = Utils.memoWithName('WorkspaceCard', ({ workspace, billingA
   return div({ role: 'listitem', style: { ...Style.cardList.longCardShadowless, flexDirection: 'column' } }, [
     h(IdContainer, [id => h(Fragment, [
       div({ style: workspaceCardStyles.row }, [
-        workspaceBillingStatusIcon(billingAccountStatusIcon),
+        workspaceBillingStatusIconOrEmpty(billingAccountStatusIcon),
         div({ style: { ...workspaceCardStyles.field, display: 'flex', alignItems: 'center', paddingLeft: '1rem' } }, [
           h(Link, {
             style: Style.noWrapEllipsis,


### PR DESCRIPTION
RR: https://broadworkbench.atlassian.net/browse/CA-1487

When a user changes the Google Billing Account associated with a Terra Billing Project, Rawls updates the Billing Accounts of the Billing Project's Workspaces' Google Projects asynchronously.
While a user waits for these changes to be made, we will paint an icon next to each workspace that best matches the status of the change. See the mock-up in the ticket for more information.

In this change:
- Add padding to the Billing Project's Workspace table headings for an icon beside each workspace
- Conditionally add an icon beside each workspace based upon the status of the update. If all workspaces have been updated successfully, don't draw any icon.

![before](https://user-images.githubusercontent.com/8223952/131180279-9d708574-bd41-4a0f-95a9-940e8081c3ac.png)
![after](https://user-images.githubusercontent.com/8223952/131180375-610470ad-52be-486e-a4e2-eb0454b4d6e9.png)

