### PR TITLE
[CA-1495] Poll for Billing Account Changes in Billing Project Page

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -467,6 +467,12 @@ const Billing = signal => ({
     return res
   },
 
+  billingProject: async projectName => {
+    const route = `billing/v2/${projectName}`
+    const res = await fetchRawls(route, _.merge(authOpts(), { signal, method: 'GET' }))
+    return res.json()
+  },
+
   project: projectName => {
     const root = `billing/v2/${projectName}/members`
 

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -165,7 +165,7 @@ const ProjectDetail = ({ project, billingAccounts, authorizeAndLoadAccounts }) =
       h(WorkspaceCardHeaders, { sort: workspaceSort, onSort: setWorkspaceSort }),
       div({ role: 'list', 'aria-label': `workspaces in billing project ${billingProject.projectName}`, style: { flexGrow: 1, width: '100%' } }, [
         _.flow(
-          _.map(({ workspace }) => workspace),
+          _.map('workspace'),
           _.filter({ namespace: billingProject.projectName }),
           _.orderBy([workspaceSort.field], [workspaceSort.direction]),
           _.map(workspace => {


### PR DESCRIPTION
RR: https://broadworkbench.atlassian.net/browse/CA-1495
When a user changes the billing account of a billing project, the billing account on the project's workspaces is updated asynchronously. We need to poll Rawls for changes to the billing account until all changes have been applied. Note that polling is disabled when the change billing modal is being displayed as this causes nasty UI jumping sadness.