### PR TITLE
[CA-1497] Add Billing Account Summary Panel to Billing Project

### DIFF
--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -141,45 +141,44 @@ const BillingAccountSummaryPanel = (() => {
 
   return Utils.memoWithName('BillingAccountSummaryPanel', ({
     billingProject: {
-        workspacesWithCorrectBillingAccount,
-        workspacesWithIncorrectBillingAccount
-      }
-    }) => {
-      const [done, errors, updating] = _.flow(
-        _.partition(_.has('billingAccountErrorMessage')),
-        _.concat([workspacesWithCorrectBillingAccount]),
-        _.map(_.size)
-      )(workspacesWithIncorrectBillingAccount)
+      workspacesWithCorrectBillingAccount,
+      workspacesWithIncorrectBillingAccount
+    }
+  }) => {
+    const [done, errors, updating] = _.flow(
+      _.partition(_.has('billingAccountErrorMessage')),
+      _.concat([workspacesWithCorrectBillingAccount]),
+      _.map(_.size)
+    )(workspacesWithIncorrectBillingAccount)
 
     const maybeAddFlex = (icon, status, count) => count > 0 && div({ style: { marginRight: '2rem' } },
       [h(StatusAndCount, { icon, status, count })])
 
-      return div({
-        style: {
-          padding: '0.5rem 2rem',
-          position: 'fixed',
-          top: topBarHeight,
-          right: '3rem',
-          width: '30rem',
-          backgroundColor: colors.light(0.5),
-          boxShadow: '0 2px 5px 0 rgba(0,0,0,0.25)'
-        }
-      }, [
-        div({ style: { padding: '1rem 0' } }, 'Your billing account is updating...'),
-        div({ style: { display: 'flex', justifyContent: 'flex-start' } }, [
-          maybeAddFlex(BillingAccountStatusIcon.Updating, 'updating', updating),
-          maybeAddFlex(BillingAccountStatusIcon.Done, 'done', done),
-          maybeAddFlex(BillingAccountStatusIcon.Error, 'error', errors)
-        ]),
-        div({ style: { padding: '1rem 0' } }, [
-          'Try again or ',
-          h(Link, { onClick: () => contactUsActive.set(true) },
-            ['contact us regarding unresolved errors']),
-          '.'
-        ])
+    return div({
+      style: {
+        padding: '0.5rem 2rem',
+        position: 'fixed',
+        top: topBarHeight,
+        right: '3rem',
+        width: '30rem',
+        backgroundColor: colors.light(0.5),
+        boxShadow: '0 2px 5px 0 rgba(0,0,0,0.25)'
+      }
+    }, [
+      div({ style: { padding: '1rem 0' } }, 'Your billing account is updating...'),
+      div({ style: { display: 'flex', justifyContent: 'flex-start' } }, [
+        maybeAddFlex(BillingAccountStatusIcon.Updating, 'updating', updating),
+        maybeAddFlex(BillingAccountStatusIcon.Done, 'done', done),
+        maybeAddFlex(BillingAccountStatusIcon.Error, 'error', errors)
+      ]),
+      div({ style: { padding: '1rem 0' } }, [
+        'Try again or ',
+        h(Link, { onClick: () => contactUsActive.set(true) },
+          ['contact us regarding unresolved errors']),
+        '.'
       ])
-    }
-  )
+    ])
+  })
 })()
 
 const ProjectDetail = ({ project, billingAccounts, authorizeAndLoadAccounts }) => {

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp'
 import * as qs from 'qs'
 import { Fragment, useEffect, useState } from 'react'
-import { div, h, p, span } from 'react-hyperscript-helpers'
+import { div, h, span } from 'react-hyperscript-helpers'
 import { ButtonPrimary, HeaderRenderer, IdContainer, Link, Select, spinnerOverlay } from 'src/components/common'
 import { DeleteUserModal, EditUserModal, MemberCard, MemberCardHeaders, NewUserCard, NewUserModal } from 'src/components/group-common'
 import { icon } from 'src/components/icons'
@@ -17,7 +17,9 @@ import { withErrorReporting } from 'src/libs/error'
 import Events from 'src/libs/events'
 import { FormLabel } from 'src/libs/forms'
 import * as Nav from 'src/libs/nav'
+import { contactUsActive } from 'src/libs/state'
 import * as StateHistory from 'src/libs/state-history'
+import { topBarHeight } from 'src/libs/style'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 import { billingRoles } from 'src/pages/billing/List'
@@ -132,15 +134,10 @@ const WorkspaceCard = Utils.memoWithName('WorkspaceCard', ({ workspace, billingA
 })
 
 const BillingAccountSummaryPanel = (() => {
-
-  const StatusAndCount = ({ icon, status, count }) => h(Fragment, [
-    div({ style: { marginLeft: '0.5rem', float: 'left' } }, [getBillingAccountStatusIconOrEmpty(icon)]),
-    div({ style: { marginLeft: '1rem', float: 'left' } }, [`${status} (${count})`])
+  const StatusAndCount = ({ icon, status, count }) => div({ style: { display: 'float' } }, [
+    div({ style: { float: 'left' } }, [getBillingAccountStatusIconOrEmpty(icon)]),
+    div({ style: { float: 'left', marginLeft: '0.5rem' } }, [`${status} (${count})`])
   ])
-
-  const maybeSummarize = (icon, status, count) => count > 0 &&
-    div({ style: { float: 'left', marginLeft: '1rem' } },
-      [h(StatusAndCount, { icon, status, count })])
 
   return Utils.memoWithName('BillingAccountSummaryPanel', ({
     billingProject: {
@@ -154,14 +151,32 @@ const BillingAccountSummaryPanel = (() => {
         _.map(_.size)
       )(workspacesWithIncorrectBillingAccount)
 
-      return div({ style: { padding: '1rem' } }, [
-        p('Your billing account is updating...'),
-        h(Fragment, [
-          maybeSummarize(BillingAccountStatusIcon.Error, 'error', errors),
-          maybeSummarize(BillingAccountStatusIcon.Updating, 'updating', updating),
-          maybeSummarize(BillingAccountStatusIcon.Done, 'done', done)
+    const maybeAddFlex = (icon, status, count) => count > 0 && div({ style: { marginRight: '2rem' } },
+      [h(StatusAndCount, { icon, status, count })])
+
+      return div({
+        style: {
+          padding: '0.5rem 2rem',
+          position: 'fixed',
+          top: topBarHeight,
+          right: '3rem',
+          width: '30rem',
+          backgroundColor: colors.light(0.5),
+          boxShadow: '0 2px 5px 0 rgba(0,0,0,0.25)'
+        }
+      }, [
+        div({ style: { padding: '1rem 0' } }, 'Your billing account is updating...'),
+        div({ style: { display: 'flex', justifyContent: 'flex-start' } }, [
+          maybeAddFlex(BillingAccountStatusIcon.Updating, 'updating', updating),
+          maybeAddFlex(BillingAccountStatusIcon.Done, 'done', done),
+          maybeAddFlex(BillingAccountStatusIcon.Error, 'error', errors)
         ]),
-        p('Try again or '),
+        div({ style: { padding: '1rem 0' } }, [
+          'Try again or ',
+          h(Link, { onClick: () => contactUsActive.set(true) },
+            ['contact us regarding unresolved errors']),
+          '.'
+        ])
       ])
     }
   )

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -145,7 +145,7 @@ const BillingAccountSummaryPanel = (() => {
     'BillingAccountSummaryPanel',
     ({ counts: { done, error, updating } }) => div({
       style: {
-        padding: '0.5rem 2rem',
+        padding: '0.5rem 2rem 1rem',
         position: 'fixed',
         top: topBarHeight,
         right: '3rem',
@@ -160,7 +160,7 @@ const BillingAccountSummaryPanel = (() => {
         maybeAddStatus('done', done),
         maybeAddStatus('error', error)
       ]),
-      div({ style: { padding: '1rem 0' } }, [
+      error > 0 && div({ style: { padding: '1rem 0 0' } }, [
         'Try again or ',
         h(Link, { onClick: () => contactUsActive.set(true) },
           ['contact us regarding unresolved errors']),


### PR DESCRIPTION
RR: https://broadworkbench.atlassian.net/browse/CA-1497
Add workspace billing account summary panel to billing project page. This panel summarises the status of the billing account changes applied to each workspace in the billing project. When there are errors, a link appears to contact support.
Mock-up here: https://www.sketch.com/s/59da26e3-a1a4-48f4-9a35-f39e2de22da9/a/bgaxn85
![screenshot](https://user-images.githubusercontent.com/8223952/132417041-54f5843b-e6d7-4ab9-a2e6-77f6acb5b2f7.png)
(yes - I'm aware it's meant to be fizzbuzz :D )