### PR TITLE
Ensure Workflow Status on Job Submission Details is fully visible BW-806

### DIFF
--- a/src/pages/workspaces/workspace/JobHistory.js
+++ b/src/pages/workspaces/workspace/JobHistory.js
@@ -33,6 +33,9 @@ const styles = {
   statusDetailCell: {
     align: 'center',
     style: { padding: '0.5rem' }
+  },
+  multiLineCellText: {
+    fontSize: 12
   }
 }
 
@@ -300,13 +303,13 @@ const JobHistory = _.flow(
               }
             },
             {
-              size: { basis: 170, grow: 0 },
+              size: { basis: 150, grow: 0 },
               field: 'submissionDate',
               headerRenderer: makeHeaderRenderer('submissionDate', 'Submitted'),
               cellRenderer: ({ rowIndex }) => {
                 const { submissionDate } = sortedSubmissions[rowIndex]
                 const dateParts = Utils.makeCompleteDateParts(submissionDate)
-                return div([
+                return div({ style: styles.multiLineCellText }, [
                   div([dateParts[0]]),
                   div([dateParts[1]])
                 ])
@@ -320,7 +323,7 @@ const JobHistory = _.flow(
               cellRenderer: ({ rowIndex }) => {
                 const { submissionId } = sortedSubmissions[rowIndex]
                 return h(Link, {
-                  style: { fontSize: 12 },
+                  style: styles.multiLineCellText,
                   ...Utils.newTabLinkProps,
                   href: bucketBrowserUrl(`${bucketName}/${submissionId}`)
                 }, [submissionId])

--- a/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
+++ b/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
@@ -158,7 +158,7 @@ const SubmissionDetails = _.flow(
     submissionDetailsBreadcrumbSubtitle(namespace, name, submissionId),
     _.isEmpty(submission) ? centeredSpinner() : h(Fragment, [
       div({ style: { display: 'grid', gridTemplateColumns: '1fr 4fr' } }, [
-        div({ style: { display: 'grid', gridAutoRows: 'min-content' } }, [
+        div({ style: { display: 'grid', gridTemplateRows: '1fr auto' } }, [
           makeSection('Workflow Statuses', [
             succeeded && makeStatusLine(successIcon, `Succeeded: ${succeeded.length}`, { marginTop: '0.5rem' }),
             failed && makeStatusLine(failedIcon, `Failed: ${failed.length}`, { marginTop: '0.5rem' }),
@@ -166,17 +166,19 @@ const SubmissionDetails = _.flow(
             submitted && makeStatusLine(submittedIcon, `Submitted: ${submitted.length}`, { marginTop: '0.5rem' })
           ]),
           div({
-            style: { padding: '0 0.5rem 0.5rem', marginTop: '0.5rem', whiteSpace: 'pre', overflow: 'hidden' }
+            style: { padding: '0 0.5rem 0.5rem', marginTop: '1.0rem', whiteSpace: 'pre', overflow: 'hidden' }
           }, [
             h4({ style: Style.elements.sectionHeader }, [
               'Comment',
               h(ButtonSecondary, {
-                style: { marginLeft: '0.50em', height: '1.0em' },
+                style: { marginLeft: '0.50rem', height: '1.0rem' },
                 tooltip: 'Edit Comment',
                 onClick: () => setUpdatingComment(true)
               }, [icon('edit')])
             ]),
-            div({ style: { textOverflow: 'ellipsis', overflow: 'hidden' } }, [firstLine(userComment)])
+            div({ style: { height: '1.0rem', textOverflow: 'ellipsis', overflow: 'hidden' } },
+              [firstLine(userComment)]
+            )
           ]),
           updatingComment && h(UpdateUserCommentModal, {
             workspace: { name, namespace }, submissionId, userComment,

--- a/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
+++ b/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
@@ -150,7 +150,7 @@ const SubmissionDetails = _.flow(
     submissionDetailsBreadcrumbSubtitle(namespace, name, submissionId),
     _.isEmpty(submission) ? centeredSpinner() : h(Fragment, [
       div({ style: { display: 'grid', gridTemplateColumns: '1fr 4fr' } }, [
-        div({ style: { display: 'grid', gridTemplateRows: 'repeat(3, 33%)' } }, [
+        div({ style: { display: 'grid', gridAutoRows: 'min-content'} }, [
           makeSection('Workflow Statuses', [
             succeeded && makeStatusLine(successIcon, `Succeeded: ${succeeded.length}`, { marginTop: '0.5rem' }),
             failed && makeStatusLine(failedIcon, `Failed: ${failed.length}`, { marginTop: '0.5rem', marginBottom: '0.5rem' }),
@@ -158,10 +158,7 @@ const SubmissionDetails = _.flow(
             submitted && makeStatusLine(submittedIcon, `Submitted: ${submitted.length}`, { marginTop: '0.5rem' })
           ]),
           div({
-            style: {
-              padding: '0 0.5rem 0.5rem', marginTop: '1rem',
-              whiteSpace: 'pre', overflow: 'hidden', gridRow: '2 / 4'
-            }
+            style: { padding: '0 0.5rem 0.5rem', whiteSpace: 'pre', overflow: 'hidden' }
           }, [
             h4({ style: Style.elements.sectionHeader }, [
               'Comment',

--- a/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
+++ b/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
@@ -143,6 +143,14 @@ const SubmissionDetails = _.flow(
     ])
   }
 
+  /**
+   * If the text has multiple lines, return just the first line of text with ellipses to indicate truncation.
+   */
+  const firstLine = text => {
+    const lines = text ? text.split('\n') : []
+    return lines.length > 1 ? `${lines[0]} ...` : lines.length > 0 ? lines[0] : undefined
+  }
+
   /*
    * Page render
    */
@@ -150,25 +158,25 @@ const SubmissionDetails = _.flow(
     submissionDetailsBreadcrumbSubtitle(namespace, name, submissionId),
     _.isEmpty(submission) ? centeredSpinner() : h(Fragment, [
       div({ style: { display: 'grid', gridTemplateColumns: '1fr 4fr' } }, [
-        div({ style: { display: 'grid', gridAutoRows: 'min-content'} }, [
+        div({ style: { display: 'grid', gridAutoRows: 'min-content' } }, [
           makeSection('Workflow Statuses', [
             succeeded && makeStatusLine(successIcon, `Succeeded: ${succeeded.length}`, { marginTop: '0.5rem' }),
-            failed && makeStatusLine(failedIcon, `Failed: ${failed.length}`, { marginTop: '0.5rem', marginBottom: '0.5rem' }),
+            failed && makeStatusLine(failedIcon, `Failed: ${failed.length}`, { marginTop: '0.5rem' }),
             running && makeStatusLine(runningIcon, `Running: ${running.length}`, { marginTop: '0.5rem' }),
             submitted && makeStatusLine(submittedIcon, `Submitted: ${submitted.length}`, { marginTop: '0.5rem' })
           ]),
           div({
-            style: { padding: '0 0.5rem 0.5rem', whiteSpace: 'pre', overflow: 'hidden' }
+            style: { padding: '0 0.5rem 0.5rem', marginTop: '0.5rem', whiteSpace: 'pre', overflow: 'hidden' }
           }, [
             h4({ style: Style.elements.sectionHeader }, [
               'Comment',
               h(ButtonSecondary, {
-                style: { marginLeft: '0.50em' },
+                style: { marginLeft: '0.50em', height: '1.0em' },
                 tooltip: 'Edit Comment',
                 onClick: () => setUpdatingComment(true)
               }, [icon('edit')])
             ]),
-            div({ style: { textOverflow: 'ellipsis', overflow: 'hidden' } }, [userComment])
+            div({ style: { textOverflow: 'ellipsis', overflow: 'hidden' } }, [firstLine(userComment)])
           ]),
           updatingComment && h(UpdateUserCommentModal, {
             workspace: { name, namespace }, submissionId, userComment,

--- a/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
+++ b/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
@@ -146,10 +146,10 @@ const SubmissionDetails = _.flow(
   /**
    * If the text has multiple lines, return just the first line of text with ellipses to indicate truncation.
    */
-  const firstLine = text => {
-    const lines = text ? text.split('\n') : []
-    return lines.length > 1 ? `${lines[0]} ...` : lines.length > 0 ? lines[0] : undefined
-  }
+  const firstLine = _.flow(
+    _.split('\n'),
+    lines => lines.length > 1 ? `${lines[0]} ...` : lines[0]
+  )
 
   /*
    * Page render


### PR DESCRIPTION
This is a cleanup MR related to https://github.com/DataBiosphere/terra-ui/pull/2599. It addresses 2 things.

1) I was not aware that the Workflow Status could be more than 1 line. Consequently, when I made the Comments area on the Submission Details page line up with the other entries to its right, it meant that multi-line Workflow Status gets cut off/obscured. I have changed the layout to allow the Workflow Status to take as much room as necessary. This means that long, multi-line (with newline characters) comments may make the top portion of the Submission Details page grow, but given that the field is limited to 1000 characters it will not grow indefinitely. Here are some screen shots of how it looks for different data:

![image](https://user-images.githubusercontent.com/484484/133089692-b1eff66e-1e94-4598-a541-78864e4ada1c.png)
_______________

![image](https://user-images.githubusercontent.com/484484/133089802-6d6304ae-65f4-46c4-8bdc-df264ac717b0.png)

_______________

![image](https://user-images.githubusercontent.com/484484/133089920-7307a192-003e-4e0c-9b8d-08bbc1307dfe.png)

2) Although I didn't change the submission date column on the Job History page, the space taken by the new comment column means that the submission date moves to 3 lines sooner for smaller browser sizes. In that case, the lack of vertical padding between rows makes the text difficult to read. So similar to what we did for the submission ID field (which is typically 3 lines), I reduced the text size to 12 points (and made the default size consistent with the submission ID field).

![image](https://user-images.githubusercontent.com/484484/133090525-33708056-2b47-44e2-837f-3dcc4c8d3768.png)

_______________

![image](https://user-images.githubusercontent.com/484484/133091419-3bdf7bd0-4e57-4f49-b5d3-e4522e9c816b.png)
