### PR TITLE
add google auth file for bdc

### DIFF
--- a/public/google04dfa0c4e6a35632.html
+++ b/public/google04dfa0c4e6a35632.html
@@ -1,0 +1,1 @@
+google-site-verification: google04dfa0c4e6a35632.html


### PR DESCRIPTION
This adds a file that confirms to Google that we're really hosted at the biodatacatalyst URL, https://terra.biodatacatalyst.nhlbi.nih.gov. Since it's not our DNS record, we can't do the DNS verification, so this is how we confirm it.