### PR TITLE
[IA-2930][IA-2701] Implement R file syncing and proper RStudio analysis preview/launch flow

### DIFF
--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -614,7 +614,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
         p(['Terra attaches a persistent disk (PD) to your cloud compute in order to provide an option to keep the data on the disk after you delete your compute. PDs also act as a safeguard to protect your data in the case that something goes wrong with the compute.']),
         p(['A minimal cost per hour is associated with maintaining the disk even when the cloud compute is paused or deleted.']),
         p(['If you delete your cloud compute, but keep your PD, the PD will be reattached when creating the next cloud compute.']),
-        h(Link, { href: 'https://support.terra.bio/hc/en-us/articles/360047318551', ...Utils.newTabLinkProps }, [
+        h(Link, { 'aria-label': `Disk doc`, href: 'https://support.terra.bio/hc/en-us/articles/360047318551', ...Utils.newTabLinkProps }, [
           'Learn more about persistent disks',
           icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })
         ])
@@ -687,14 +687,14 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
             ]),
             div([
               'Custom environments ', b(['must ']), 'be based off one of the ',
-              h(Link, { href: terraBaseImages, ...Utils.newTabLinkProps }, ['Terra Jupyter Notebook base images'])
+              h(Link, { 'aria-label': `Terra base images`, href: terraBaseImages, ...Utils.newTabLinkProps }, ['Terra Jupyter Notebook base images'])
             ])
           ])
         }],
         [Utils.DEFAULT, () => {
           return h(Fragment, [
             div({ style: { display: 'flex' } }, [
-              h(Link, { onClick: () => setViewMode('packages') }, ['What’s installed on this environment?']),
+              h(Link, { 'aria-label': `Image packages`, onClick: () => setViewMode('packages') }, ['What’s installed on this environment?']),
               makeImageInfo({ marginLeft: 'auto' })
             ])
           ])
@@ -771,6 +771,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
                 enableGpusSpan
             ]),
             h(Link, {
+              'aria-label': `GPU doc`,
               style: { marginLeft: '1rem', verticalAlign: 'top' },
               href: 'https://support.terra.bio/hc/en-us/articles/4403006001947', ...Utils.newTabLinkProps
             }, [
@@ -934,10 +935,10 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
         p([
           'You are about to create a virtual machine using an unverified Docker image. ',
           'Please make sure that it was created by you or someone you trust, using one of our ',
-          h(Link, { href: terraBaseImages, ...Utils.newTabLinkProps }, ['base images.']),
+          h(Link, { 'aria-label': `Terra base images`, href: terraBaseImages, ...Utils.newTabLinkProps }, ['base images.']),
           ' Custom Docker images could potentially cause serious security issues.'
         ]),
-        h(Link, { href: safeImageDocumentation, ...Utils.newTabLinkProps }, ['Learn more about creating safe and secure custom Docker images.']),
+        h(Link, { 'aria-label': `Safe image doc`, href: safeImageDocumentation, ...Utils.newTabLinkProps }, ['Learn more about creating safe and secure custom Docker images.']),
         p(['If you\'re confident that your image is safe, you may continue using it. Otherwise, go back to select another image.'])
       ]),
       div({ style: { display: 'flex', justifyContent: 'flex-end', marginTop: '1rem' } }, [
@@ -951,7 +952,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
     const makeJSON = value => div({ style: { whiteSpace: 'pre-wrap', fontFamily: 'Menlo, monospace' } }, [JSON.stringify(value, null, 2)])
     return showDebugger ?
       div({ style: { position: 'fixed', top: 0, left: 0, bottom: 0, right: '50vw', backgroundColor: 'white', padding: '1rem', overflowY: 'auto' } }, [
-        h(Link, { onClick: () => setShowDebugger(false), style: { position: 'absolute', top: 0, right: 0 } }, ['x']),
+        h(Link, { 'aria-label': `Show debugger`, onClick: () => setShowDebugger(false), style: { position: 'absolute', top: 0, right: 0 } }, ['x']),
         makeHeader('Old Environment Config'),
         makeJSON(getExistingEnvironmentConfig()),
         makeHeader('New Environment Config'),
@@ -964,7 +965,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
           willRequireDowntime: !!willRequireDowntime()
         })
       ]) :
-      h(Link, { onClick: () => setShowDebugger(true), style: { position: 'fixed', top: 0, left: 0, color: 'white' } }, ['D'])
+      h(Link, { 'aria-label': `Show debugger`, onClick: () => setShowDebugger(true), style: { position: 'fixed', top: 0, left: 0, color: 'white' } }, ['D'])
   }
 
   const renderDeleteDiskChoices = () => {
@@ -1227,7 +1228,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
               ul({ style: { paddingLeft: '1rem', marginBottom: 0, lineHeight: 1.5 } }, [
                 li([
                   div([packageLabel]),
-                  h(Link, { onClick: () => setViewMode('packages') }, ['What’s installed on this environment?'])
+                  h(Link, { 'aria-label': `Packages`, onClick: () => setViewMode('packages') }, ['What’s installed on this environment?'])
                 ]),
                 li({ style: { marginTop: '1rem' } }, [
                   'Default compute size of ', span({ style: { fontWeight: 600 } }, [cpu, ' CPU(s)']), ', ',
@@ -1237,7 +1238,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
                     h(Fragment, ['a ', renderDiskText(), ' to keep your data even after you delete your compute'])
                 ]),
                 li({ style: { marginTop: '1rem' } }, [
-                  h(Link, { onClick: handleLearnMoreAboutPersistentDisk }, ['Learn more about Persistent disks and where your disk is mounted'])
+                  h(Link, { 'aria-label': `Disk doc`, onClick: handleLearnMoreAboutPersistentDisk }, ['Learn more about Persistent disks and where your disk is mounted'])
                 ])
               ])
             ]),
@@ -1265,7 +1266,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
           !sparkMode && !isPersistentDisk && div({ style: { ...styles.whiteBoxContainer, marginTop: '1rem' } }, [
             div([
               'Time to upgrade your cloud environment. Terra’s new persistent disk feature will safeguard your work and data. ',
-              h(Link, { onClick: handleLearnMoreAboutPersistentDisk }, ['Learn more about Persistent disks and where your disk is mounted'])
+              h(Link, { 'aria-label': `Disk doc`, onClick: handleLearnMoreAboutPersistentDisk }, ['Learn more about Persistent disks and where your disk is mounted'])
             ]),
             h(ButtonOutline, {
               style: { marginTop: '1rem' },
@@ -1301,7 +1302,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
           label({ htmlFor: id, style: styles.label }, ['Persistent disk size (GB)']),
           div({ style: { marginTop: '0.5rem' } }, [
             'Persistent disks store analysis data. ',
-            h(Link, { onClick: handleLearnMoreAboutPersistentDisk }, ['Learn more about persistent disks and where your disk is mounted.'])
+            h(Link, { 'aria-label': `Disk doc`, onClick: handleLearnMoreAboutPersistentDisk }, ['Learn more about persistent disks and where your disk is mounted.'])
           ]),
           h(NumberInput, {
             id,

--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -934,7 +934,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
         p([
           'You are about to create a virtual machine using an unverified Docker image. ',
           'Please make sure that it was created by you or someone you trust, using one of our ',
-          h(Link, { 'aria-label': 'Terra base images', href: terraBaseImages, ...Utils.newTabLinkProps }, ['base images.']),
+          h(Link, { href: terraBaseImages, ...Utils.newTabLinkProps }, ['Terra base images.']),
           ' Custom Docker images could potentially cause serious security issues.'
         ]),
         h(Link, { href: safeImageDocumentation, ...Utils.newTabLinkProps }, ['Learn more about creating safe and secure custom Docker images.']),

--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -951,7 +951,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
     const makeJSON = value => div({ style: { whiteSpace: 'pre-wrap', fontFamily: 'Menlo, monospace' } }, [JSON.stringify(value, null, 2)])
     return showDebugger ?
       div({ style: { position: 'fixed', top: 0, left: 0, bottom: 0, right: '50vw', backgroundColor: 'white', padding: '1rem', overflowY: 'auto' } }, [
-        h(Link, { 'aria-label': 'Show debugger', onClick: () => setShowDebugger(false), style: { position: 'absolute', top: 0, right: 0 } }, ['x']),
+        h(Link, { 'aria-label': 'Hide debugger', onClick: () => setShowDebugger(false), style: { position: 'absolute', top: 0, right: 0 } }, ['x']),
         makeHeader('Old Environment Config'),
         makeJSON(getExistingEnvironmentConfig()),
         makeHeader('New Environment Config'),

--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -614,7 +614,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
         p(['Terra attaches a persistent disk (PD) to your cloud compute in order to provide an option to keep the data on the disk after you delete your compute. PDs also act as a safeguard to protect your data in the case that something goes wrong with the compute.']),
         p(['A minimal cost per hour is associated with maintaining the disk even when the cloud compute is paused or deleted.']),
         p(['If you delete your cloud compute, but keep your PD, the PD will be reattached when creating the next cloud compute.']),
-        h(Link, { 'aria-label': `Disk doc`, href: 'https://support.terra.bio/hc/en-us/articles/360047318551', ...Utils.newTabLinkProps }, [
+        h(Link, { 'aria-label': 'Disk doc', href: 'https://support.terra.bio/hc/en-us/articles/360047318551', ...Utils.newTabLinkProps }, [
           'Learn more about persistent disks',
           icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })
         ])
@@ -687,14 +687,14 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
             ]),
             div([
               'Custom environments ', b(['must ']), 'be based off one of the ',
-              h(Link, { 'aria-label': `Terra base images`, href: terraBaseImages, ...Utils.newTabLinkProps }, ['Terra Jupyter Notebook base images'])
+              h(Link, { 'aria-label': 'Terra base images', href: terraBaseImages, ...Utils.newTabLinkProps }, ['Terra Jupyter Notebook base images'])
             ])
           ])
         }],
         [Utils.DEFAULT, () => {
           return h(Fragment, [
             div({ style: { display: 'flex' } }, [
-              h(Link, { 'aria-label': `Image packages`, onClick: () => setViewMode('packages') }, ['What’s installed on this environment?']),
+              h(Link, { 'aria-label': 'Image packages', onClick: () => setViewMode('packages') }, ['What’s installed on this environment?']),
               makeImageInfo({ marginLeft: 'auto' })
             ])
           ])
@@ -771,7 +771,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
                 enableGpusSpan
             ]),
             h(Link, {
-              'aria-label': `GPU doc`,
+              'aria-label': 'GPU doc',
               style: { marginLeft: '1rem', verticalAlign: 'top' },
               href: 'https://support.terra.bio/hc/en-us/articles/4403006001947', ...Utils.newTabLinkProps
             }, [
@@ -935,10 +935,10 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
         p([
           'You are about to create a virtual machine using an unverified Docker image. ',
           'Please make sure that it was created by you or someone you trust, using one of our ',
-          h(Link, { 'aria-label': `Terra base images`, href: terraBaseImages, ...Utils.newTabLinkProps }, ['base images.']),
+          h(Link, { 'aria-label': 'Terra base images', href: terraBaseImages, ...Utils.newTabLinkProps }, ['base images.']),
           ' Custom Docker images could potentially cause serious security issues.'
         ]),
-        h(Link, { 'aria-label': `Safe image doc`, href: safeImageDocumentation, ...Utils.newTabLinkProps }, ['Learn more about creating safe and secure custom Docker images.']),
+        h(Link, { 'aria-label': 'Safe image doc', href: safeImageDocumentation, ...Utils.newTabLinkProps }, ['Learn more about creating safe and secure custom Docker images.']),
         p(['If you\'re confident that your image is safe, you may continue using it. Otherwise, go back to select another image.'])
       ]),
       div({ style: { display: 'flex', justifyContent: 'flex-end', marginTop: '1rem' } }, [
@@ -952,7 +952,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
     const makeJSON = value => div({ style: { whiteSpace: 'pre-wrap', fontFamily: 'Menlo, monospace' } }, [JSON.stringify(value, null, 2)])
     return showDebugger ?
       div({ style: { position: 'fixed', top: 0, left: 0, bottom: 0, right: '50vw', backgroundColor: 'white', padding: '1rem', overflowY: 'auto' } }, [
-        h(Link, { 'aria-label': `Show debugger`, onClick: () => setShowDebugger(false), style: { position: 'absolute', top: 0, right: 0 } }, ['x']),
+        h(Link, { 'aria-label': 'Show debugger', onClick: () => setShowDebugger(false), style: { position: 'absolute', top: 0, right: 0 } }, ['x']),
         makeHeader('Old Environment Config'),
         makeJSON(getExistingEnvironmentConfig()),
         makeHeader('New Environment Config'),
@@ -965,7 +965,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
           willRequireDowntime: !!willRequireDowntime()
         })
       ]) :
-      h(Link, { 'aria-label': `Show debugger`, onClick: () => setShowDebugger(true), style: { position: 'fixed', top: 0, left: 0, color: 'white' } }, ['D'])
+      h(Link, { 'aria-label': 'Show debugger', onClick: () => setShowDebugger(true), style: { position: 'fixed', top: 0, left: 0, color: 'white' } }, ['D'])
   }
 
   const renderDeleteDiskChoices = () => {
@@ -1228,7 +1228,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
               ul({ style: { paddingLeft: '1rem', marginBottom: 0, lineHeight: 1.5 } }, [
                 li([
                   div([packageLabel]),
-                  h(Link, { 'aria-label': `Packages`, onClick: () => setViewMode('packages') }, ['What’s installed on this environment?'])
+                  h(Link, { 'aria-label': 'Packages', onClick: () => setViewMode('packages') }, ['What’s installed on this environment?'])
                 ]),
                 li({ style: { marginTop: '1rem' } }, [
                   'Default compute size of ', span({ style: { fontWeight: 600 } }, [cpu, ' CPU(s)']), ', ',
@@ -1238,7 +1238,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
                     h(Fragment, ['a ', renderDiskText(), ' to keep your data even after you delete your compute'])
                 ]),
                 li({ style: { marginTop: '1rem' } }, [
-                  h(Link, { 'aria-label': `Disk doc`, onClick: handleLearnMoreAboutPersistentDisk }, ['Learn more about Persistent disks and where your disk is mounted'])
+                  h(Link, { 'aria-label': 'Disk doc', onClick: handleLearnMoreAboutPersistentDisk }, ['Learn more about Persistent disks and where your disk is mounted'])
                 ])
               ])
             ]),
@@ -1266,7 +1266,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
           !sparkMode && !isPersistentDisk && div({ style: { ...styles.whiteBoxContainer, marginTop: '1rem' } }, [
             div([
               'Time to upgrade your cloud environment. Terra’s new persistent disk feature will safeguard your work and data. ',
-              h(Link, { 'aria-label': `Disk doc`, onClick: handleLearnMoreAboutPersistentDisk }, ['Learn more about Persistent disks and where your disk is mounted'])
+              h(Link, { 'aria-label': 'Disk doc', onClick: handleLearnMoreAboutPersistentDisk }, ['Learn more about Persistent disks and where your disk is mounted'])
             ]),
             h(ButtonOutline, {
               style: { marginTop: '1rem' },

--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -1301,7 +1301,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
           label({ htmlFor: id, style: styles.label }, ['Persistent disk size (GB)']),
           div({ style: { marginTop: '0.5rem' } }, [
             'Persistent disks store analysis data. ',
-            h(Link, { 'aria-label': `Disk doc`, onClick: handleLearnMoreAboutPersistentDisk }, ['Learn more about persistent disks and where your disk is mounted.'])
+            h(Link, { onClick: handleLearnMoreAboutPersistentDisk }, ['Learn more about persistent disks and where your disk is mounted.'])
           ]),
           h(NumberInput, {
             id,

--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -614,7 +614,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
         p(['Terra attaches a persistent disk (PD) to your cloud compute in order to provide an option to keep the data on the disk after you delete your compute. PDs also act as a safeguard to protect your data in the case that something goes wrong with the compute.']),
         p(['A minimal cost per hour is associated with maintaining the disk even when the cloud compute is paused or deleted.']),
         p(['If you delete your cloud compute, but keep your PD, the PD will be reattached when creating the next cloud compute.']),
-        h(Link, { 'aria-label': 'Disk doc', href: 'https://support.terra.bio/hc/en-us/articles/360047318551', ...Utils.newTabLinkProps }, [
+        h(Link, { href: 'https://support.terra.bio/hc/en-us/articles/360047318551', ...Utils.newTabLinkProps }, [
           'Learn more about persistent disks',
           icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })
         ])
@@ -694,7 +694,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
         [Utils.DEFAULT, () => {
           return h(Fragment, [
             div({ style: { display: 'flex' } }, [
-              h(Link, { 'aria-label': 'Image packages', onClick: () => setViewMode('packages') }, ['What’s installed on this environment?']),
+              h(Link, { onClick: () => setViewMode('packages') }, ['What’s installed on this environment?']),
               makeImageInfo({ marginLeft: 'auto' })
             ])
           ])
@@ -771,7 +771,6 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
                 enableGpusSpan
             ]),
             h(Link, {
-              'aria-label': 'GPU doc',
               style: { marginLeft: '1rem', verticalAlign: 'top' },
               href: 'https://support.terra.bio/hc/en-us/articles/4403006001947', ...Utils.newTabLinkProps
             }, [
@@ -938,7 +937,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
           h(Link, { 'aria-label': 'Terra base images', href: terraBaseImages, ...Utils.newTabLinkProps }, ['base images.']),
           ' Custom Docker images could potentially cause serious security issues.'
         ]),
-        h(Link, { 'aria-label': 'Safe image doc', href: safeImageDocumentation, ...Utils.newTabLinkProps }, ['Learn more about creating safe and secure custom Docker images.']),
+        h(Link, { href: safeImageDocumentation, ...Utils.newTabLinkProps }, ['Learn more about creating safe and secure custom Docker images.']),
         p(['If you\'re confident that your image is safe, you may continue using it. Otherwise, go back to select another image.'])
       ]),
       div({ style: { display: 'flex', justifyContent: 'flex-end', marginTop: '1rem' } }, [
@@ -1228,7 +1227,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
               ul({ style: { paddingLeft: '1rem', marginBottom: 0, lineHeight: 1.5 } }, [
                 li([
                   div([packageLabel]),
-                  h(Link, { 'aria-label': 'Packages', onClick: () => setViewMode('packages') }, ['What’s installed on this environment?'])
+                  h(Link, { onClick: () => setViewMode('packages') }, ['What’s installed on this environment?'])
                 ]),
                 li({ style: { marginTop: '1rem' } }, [
                   'Default compute size of ', span({ style: { fontWeight: 600 } }, [cpu, ' CPU(s)']), ', ',
@@ -1238,7 +1237,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
                     h(Fragment, ['a ', renderDiskText(), ' to keep your data even after you delete your compute'])
                 ]),
                 li({ style: { marginTop: '1rem' } }, [
-                  h(Link, { 'aria-label': 'Disk doc', onClick: handleLearnMoreAboutPersistentDisk }, ['Learn more about Persistent disks and where your disk is mounted'])
+                  h(Link, { onClick: handleLearnMoreAboutPersistentDisk }, ['Learn more about Persistent disks and where your disk is mounted'])
                 ])
               ])
             ]),
@@ -1266,7 +1265,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
           !sparkMode && !isPersistentDisk && div({ style: { ...styles.whiteBoxContainer, marginTop: '1rem' } }, [
             div([
               'Time to upgrade your cloud environment. Terra’s new persistent disk feature will safeguard your work and data. ',
-              h(Link, { 'aria-label': 'Disk doc', onClick: handleLearnMoreAboutPersistentDisk }, ['Learn more about Persistent disks and where your disk is mounted'])
+              h(Link, { onClick: handleLearnMoreAboutPersistentDisk }, ['Learn more about Persistent disks and where your disk is mounted'])
             ]),
             h(ButtonOutline, {
               style: { marginTop: '1rem' },

--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -687,7 +687,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
             ]),
             div([
               'Custom environments ', b(['must ']), 'be based off one of the ',
-              h(Link, { 'aria-label': 'Terra base images', href: terraBaseImages, ...Utils.newTabLinkProps }, ['Terra Jupyter Notebook base images'])
+              h(Link, { href: terraBaseImages, ...Utils.newTabLinkProps }, ['Terra Jupyter Notebook base images'])
             ])
           ])
         }],

--- a/src/components/ContextBar.js
+++ b/src/components/ContextBar.js
@@ -102,7 +102,7 @@ export const ContextBar = ({ setDeletingWorkspace, setCloningWorkspace, setShari
           }, [icon('ellipsis-v', { size: 24 })])
         ]),
         h(Clickable, {
-          'aria-label': `Cloud env config`,
+          'aria-label': 'Cloud env config',
           style: { ...contextBarStyles.contextBarButton, flexDirection: 'column', justifyContent: 'center', padding: '.75rem' },
           hover: contextBarStyles.hover,
           tooltipSide: 'left',
@@ -115,7 +115,7 @@ export const ContextBar = ({ setDeletingWorkspace, setCloningWorkspace, setShari
           getEnvironmentStatusIcons()
         ]),
         h(Clickable, {
-          'aria-label': `Terminal button`,
+          'aria-label': 'Terminal button',
           style: { ...contextBarStyles.contextBarButton, color: !isTerminalEnabled ? colors.dark(0.7) : contextBarStyles.contextBarButton.color },
           hover: contextBarStyles.hover,
           tooltipSide: 'left',

--- a/src/components/ContextBar.js
+++ b/src/components/ContextBar.js
@@ -93,7 +93,7 @@ export const ContextBar = ({ setDeletingWorkspace, setCloningWorkspace, setShari
       div({ style: contextBarStyles.contextBarContainer }, [
         h(WorkspaceMenuTrigger, { canShare, isOwner, setCloningWorkspace, setSharingWorkspace, setDeletingWorkspace }, [
           h(Clickable, {
-            'aria-label': 'Menu',
+            'aria-label': 'Workspace menu',
             style: contextBarStyles.contextBarButton,
             hover: contextBarStyles.hover,
             tooltipSide: 'left',
@@ -102,6 +102,7 @@ export const ContextBar = ({ setDeletingWorkspace, setCloningWorkspace, setShari
           }, [icon('ellipsis-v', { size: 24 })])
         ]),
         h(Clickable, {
+          'aria-label': `Cloud env config`,
           style: { ...contextBarStyles.contextBarButton, flexDirection: 'column', justifyContent: 'center', padding: '.75rem' },
           hover: contextBarStyles.hover,
           tooltipSide: 'left',
@@ -114,6 +115,7 @@ export const ContextBar = ({ setDeletingWorkspace, setCloningWorkspace, setShari
           getEnvironmentStatusIcons()
         ]),
         h(Clickable, {
+          'aria-label': `Terminal button`,
           style: { ...contextBarStyles.contextBarButton, color: !isTerminalEnabled ? colors.dark(0.7) : contextBarStyles.contextBarButton.color },
           hover: contextBarStyles.hover,
           tooltipSide: 'left',

--- a/src/components/RuntimeManager.js
+++ b/src/components/RuntimeManager.js
@@ -59,6 +59,7 @@ const styles = {
 
 const RuntimeIcon = ({ shape, onClick, disabled, style, ...props }) => {
   return h(Clickable, {
+    'aria-label': `Runtime icon`,
     style: { color: onClick && !disabled ? colors.accent() : colors.dark(0.7), ...styles.verticalCenter, ...style },
     onClick, disabled, ...props
   }, [icon(shape, { size: 20 })])
@@ -103,6 +104,7 @@ const RuntimeErrorNotification = ({ runtime }) => {
 
   return h(Fragment, [
     h(Clickable, {
+      'aria-label': `Runtime error notification`,
       onClick: () => setModalOpen(true),
       style: {
         marginTop: '1rem',
@@ -147,6 +149,7 @@ const AppErrorNotification = ({ app }) => {
 
   return h(Fragment, [
     h(Clickable, {
+      'aria-label': `App error notification`,
       onClick: () => setModalOpen(true),
       style: {
         marginTop: '1rem',
@@ -215,7 +218,7 @@ export default class RuntimeManager extends PureComponent {
       notify('warn', 'Please Update Your Cloud Environment', {
         message: h(Fragment, [
           p(['Last year, we introduced important updates to Terra that are not compatible with the older cloud environment associated with this workspace. You are no longer able to save new changes to notebooks using this older cloud environment.']),
-          h(Link, { href: dataSyncingDocUrl, ...Utils.newTabLinkProps }, ['Read here for more details.'])
+          h(Link, { 'aria-label': `Welder cutoff link`, href: dataSyncingDocUrl, ...Utils.newTabLinkProps }, ['Read here for more details.'])
         ])
       })
     } else if (isAfter(createdDate, twoMonthsAgo) && !isToday(dateNotified)) {
@@ -348,6 +351,7 @@ export default class RuntimeManager extends PureComponent {
     return h(Fragment, [
       app && div({ style: { ...styles.container, borderRadius: 5, marginRight: '1.5rem' } }, [
         h(Clickable, {
+          'aria-label': `Galaxy clickable`,
           style: { display: 'flex' },
           disabled: appIsSettingUp(app),
           tooltip: appIsSettingUp(app) ?
@@ -366,11 +370,13 @@ export default class RuntimeManager extends PureComponent {
       ]),
       div({ style: styles.container }, [
         (activeRuntimes.length > 1 || activeDisks.length > 1) && h(Link, {
+          'aria-label': `Multiple cloud env warning`,
           style: { marginRight: '1rem' },
           href: Nav.getLink('environments'),
           tooltip: 'Multiple cloud environments found in this billing project. Click to select which to delete.'
         }, [icon('warning-standard', { size: 24, style: { color: colors.danger() } })]),
         h(Link, {
+          'aria-label': `Launch app`,
           href: applicationLaunchLink,
           onClick: window.location.hash === applicationLaunchLink && currentStatus === 'Stopped' ? () => this.startRuntime() : undefined,
           tooltip: canCompute ? `Open ${applicationName}` : noCompute,
@@ -382,6 +388,7 @@ export default class RuntimeManager extends PureComponent {
         h(IdContainer, [id => h(Fragment, [
           h(Clickable, {
             id,
+            'aria-label': `Create runtime clickable`,
             style: styles.button(isDisabled),
             tooltip: Utils.cond(
               [!canCompute, () => noCompute],

--- a/src/components/RuntimeManager.js
+++ b/src/components/RuntimeManager.js
@@ -59,7 +59,7 @@ const styles = {
 
 const RuntimeIcon = ({ shape, onClick, disabled, style, ...props }) => {
   return h(Clickable, {
-    'aria-label': `Runtime icon`,
+    'aria-label': 'Runtime icon',
     style: { color: onClick && !disabled ? colors.accent() : colors.dark(0.7), ...styles.verticalCenter, ...style },
     onClick, disabled, ...props
   }, [icon(shape, { size: 20 })])
@@ -104,7 +104,7 @@ const RuntimeErrorNotification = ({ runtime }) => {
 
   return h(Fragment, [
     h(Clickable, {
-      'aria-label': `Runtime error notification`,
+      'aria-label': 'Runtime error notification',
       onClick: () => setModalOpen(true),
       style: {
         marginTop: '1rem',
@@ -149,7 +149,7 @@ const AppErrorNotification = ({ app }) => {
 
   return h(Fragment, [
     h(Clickable, {
-      'aria-label': `App error notification`,
+      'aria-label': 'App error notification',
       onClick: () => setModalOpen(true),
       style: {
         marginTop: '1rem',
@@ -351,7 +351,7 @@ export default class RuntimeManager extends PureComponent {
     return h(Fragment, [
       app && div({ style: { ...styles.container, borderRadius: 5, marginRight: '1.5rem' } }, [
         h(Clickable, {
-          'aria-label': `Galaxy clickable`,
+          'aria-label': 'Galaxy clickable',
           style: { display: 'flex' },
           disabled: appIsSettingUp(app),
           tooltip: appIsSettingUp(app) ?
@@ -370,13 +370,13 @@ export default class RuntimeManager extends PureComponent {
       ]),
       div({ style: styles.container }, [
         (activeRuntimes.length > 1 || activeDisks.length > 1) && h(Link, {
-          'aria-label': `Multiple cloud env warning`,
+          'aria-label': 'Multiple cloud env warning',
           style: { marginRight: '1rem' },
           href: Nav.getLink('environments'),
           tooltip: 'Multiple cloud environments found in this billing project. Click to select which to delete.'
         }, [icon('warning-standard', { size: 24, style: { color: colors.danger() } })]),
         h(Link, {
-          'aria-label': `Launch app`,
+          'aria-label': 'Launch app',
           href: applicationLaunchLink,
           onClick: window.location.hash === applicationLaunchLink && currentStatus === 'Stopped' ? () => this.startRuntime() : undefined,
           tooltip: canCompute ? `Open ${applicationName}` : noCompute,
@@ -388,7 +388,7 @@ export default class RuntimeManager extends PureComponent {
         h(IdContainer, [id => h(Fragment, [
           h(Clickable, {
             id,
-            'aria-label': `Create runtime clickable`,
+            'aria-label': 'Create runtime clickable',
             style: styles.button(isDisabled),
             tooltip: Utils.cond(
               [!canCompute, () => noCompute],

--- a/src/components/notebook-utils.js
+++ b/src/components/notebook-utils.js
@@ -77,6 +77,7 @@ export const tools = {
 const toolToExtensionMap = { [tools.RStudio.label]: tools.RStudio.ext, [tools.Jupyter.label]: tools.Jupyter.ext }
 
 export const getTool = fileName => _.invert(toolToExtensionMap)[getExtension(fileName)]
+export const getToolFromRuntime = _.get(['labels', 'tool'])
 
 export const getAnalysisFileExtension = toolLabel => toolToExtensionMap[toolLabel]
 

--- a/src/components/runtime-common.js
+++ b/src/components/runtime-common.js
@@ -115,6 +115,7 @@ export const SaveFilesHelp = (isGalaxyDisk = false) => {
     p([
       'If you want to save some files permanently, such as input data, analysis outputs, or installed packages, ',
       h(Link, {
+        'aria-label': `Save file help`,
         href: 'https://support.terra.bio/hc/en-us/articles/360026639112',
         ...Utils.newTabLinkProps
       }, ['move them to the workspace bucket.'])
@@ -128,6 +129,7 @@ export const SaveFilesHelpRStudio = () => {
     p([
       'If you want to save files permanently, including input data, analysis outputs, installed packages or code in your session, ',
       h(Link, {
+        'aria-label': `RStudio save help`,
         href: 'https://support.terra.bio/hc/en-us/articles/360026639112',
         ...Utils.newTabLinkProps
       }, ['move them to the workspace bucket.'])
@@ -145,6 +147,7 @@ export const SaveFilesHelpGalaxy = () => {
     ]),
     p(['If you want to save some files permanently, such as input data, analysis outputs, or installed packages, ',
       h(Link, {
+        'aria-label': `Galaxy save help`,
         href: 'https://support.terra.bio/hc/en-us/articles/360026639112',
         ...Utils.newTabLinkProps
       }, ['move them to the workspace bucket.'])])
@@ -172,3 +175,5 @@ export const GalaxyLaunchButton = ({ app, key = app.status, onClick, ...props })
     ...props
   }, ['Launch Galaxy'])
 }
+
+export const appLauncherTabName = 'appLauncher'

--- a/src/components/runtime-common.js
+++ b/src/components/runtime-common.js
@@ -115,7 +115,7 @@ export const SaveFilesHelp = (isGalaxyDisk = false) => {
     p([
       'If you want to save some files permanently, such as input data, analysis outputs, or installed packages, ',
       h(Link, {
-        'aria-label': `Save file help`,
+        'aria-label': 'Save file help',
         href: 'https://support.terra.bio/hc/en-us/articles/360026639112',
         ...Utils.newTabLinkProps
       }, ['move them to the workspace bucket.'])
@@ -129,7 +129,7 @@ export const SaveFilesHelpRStudio = () => {
     p([
       'If you want to save files permanently, including input data, analysis outputs, installed packages or code in your session, ',
       h(Link, {
-        'aria-label': `RStudio save help`,
+        'aria-label': 'RStudio save help',
         href: 'https://support.terra.bio/hc/en-us/articles/360026639112',
         ...Utils.newTabLinkProps
       }, ['move them to the workspace bucket.'])
@@ -147,7 +147,7 @@ export const SaveFilesHelpGalaxy = () => {
     ]),
     p(['If you want to save some files permanently, such as input data, analysis outputs, or installed packages, ',
       h(Link, {
-        'aria-label': `Galaxy save help`,
+        'aria-label': 'Galaxy save help',
         href: 'https://support.terra.bio/hc/en-us/articles/360026639112',
         ...Utils.newTabLinkProps
       }, ['move them to the workspace bucket.'])])

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1324,7 +1324,7 @@ const Runtimes = signal => ({
     }
   },
 
-  notebooks: (project, name) => {
+  fileSyncing: (project, name) => {
     const root = `proxy/${project}/${name}`
 
     return {

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -336,7 +336,7 @@ export const WorkspaceMenuTrigger = ({ children, canShare, isOwner, setCloningWo
     closeOnClick: true,
     'aria-label': 'Workspace menu',
     content: h(Fragment, [
-      h(MenuButton, { 'aria-label': 'Workspace copy', onClick: () => setCloningWorkspace(true) }, [makeMenuIcon('copy'), 'Clone']),
+      h(MenuButton, { onClick: () => setCloningWorkspace(true) }, [makeMenuIcon('copy'), 'Clone']),
       h(MenuButton, {
         disabled: !canShare,
         tooltip: !canShare && 'You have not been granted permission to share this workspace',

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -334,19 +334,19 @@ export const wrapWorkspace = ({ breadcrumbs, activeTab, title, topBarContent, sh
 export const WorkspaceMenuTrigger = ({ children, canShare, isOwner, setCloningWorkspace, setSharingWorkspace, setDeletingWorkspace }) => h(
   MenuTrigger, {
     closeOnClick: true,
-    'aria-label': `Workspace menu`,
+    'aria-label': 'Workspace menu',
     content: h(Fragment, [
-      h(MenuButton, { 'aria-label': `Workspace copy`, onClick: () => setCloningWorkspace(true) }, [makeMenuIcon('copy'), 'Clone']),
+      h(MenuButton, { 'aria-label': 'Workspace copy', onClick: () => setCloningWorkspace(true) }, [makeMenuIcon('copy'), 'Clone']),
       h(MenuButton, {
-        'aria-label': `Workspace share`,
+        'aria-label': 'Workspace share',
         disabled: !canShare,
         tooltip: !canShare && 'You have not been granted permission to share this workspace',
         tooltipSide: 'left',
         onClick: () => setSharingWorkspace(true)
       }, [makeMenuIcon('share'), 'Share']),
-      h(MenuButton, { 'aria-label': `Workspace publish`, disabled: true }, [makeMenuIcon('export'), 'Publish', comingSoon]),
+      h(MenuButton, { 'aria-label': 'Workspace publish', disabled: true }, [makeMenuIcon('export'), 'Publish', comingSoon]),
       h(MenuButton, {
-        'aria-label': `Workspace delete`,
+        'aria-label': 'Workspace delete',
         disabled: !isOwner,
         tooltip: !isOwner && 'You must be an owner of this workspace or the underlying billing project',
         tooltipSide: 'left',

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -8,6 +8,7 @@ import FooterWrapper from 'src/components/FooterWrapper'
 import { icon } from 'src/components/icons'
 import NewWorkspaceModal from 'src/components/NewWorkspaceModal'
 import { makeMenuIcon, MenuButton, MenuTrigger } from 'src/components/PopupTrigger'
+import { appLauncherTabName } from 'src/components/runtime-common'
 import RuntimeManager from 'src/components/RuntimeManager'
 import { TabBar } from 'src/components/tabBars'
 import TopBar from 'src/components/TopBar'
@@ -108,7 +109,7 @@ const WorkspaceContainer = ({
     div({ role: 'main', style: Style.elements.pageContentContainer },
 
       // TODO: When we switch this over to all tabs, ensure other workspace tabs look the same when inside these divs
-      (isAnalysisTabVisible() && (activeTab === 'analyses' || activeTab === undefined) ?
+      (isAnalysisTabVisible() && (activeTab === 'analyses' || activeTab === appLauncherTabName) ?
         [div({ style: { flex: 1, display: 'flex' } }, [
           div({ style: { flex: 1, display: 'flex', flexDirection: 'column' } }, [
             children
@@ -333,16 +334,19 @@ export const wrapWorkspace = ({ breadcrumbs, activeTab, title, topBarContent, sh
 export const WorkspaceMenuTrigger = ({ children, canShare, isOwner, setCloningWorkspace, setSharingWorkspace, setDeletingWorkspace }) => h(
   MenuTrigger, {
     closeOnClick: true,
+    'aria-label': `Workspace menu`,
     content: h(Fragment, [
-      h(MenuButton, { onClick: () => setCloningWorkspace(true) }, [makeMenuIcon('copy'), 'Clone']),
+      h(MenuButton, { 'aria-label': `Workspace copy`, onClick: () => setCloningWorkspace(true) }, [makeMenuIcon('copy'), 'Clone']),
       h(MenuButton, {
+        'aria-label': `Workspace share`,
         disabled: !canShare,
         tooltip: !canShare && 'You have not been granted permission to share this workspace',
         tooltipSide: 'left',
         onClick: () => setSharingWorkspace(true)
       }, [makeMenuIcon('share'), 'Share']),
-      h(MenuButton, { disabled: true }, [makeMenuIcon('export'), 'Publish', comingSoon]),
+      h(MenuButton, { 'aria-label': `Workspace publish`, disabled: true }, [makeMenuIcon('export'), 'Publish', comingSoon]),
       h(MenuButton, {
+        'aria-label': `Workspace delete`,
         disabled: !isOwner,
         tooltip: !isOwner && 'You must be an owner of this workspace or the underlying billing project',
         tooltipSide: 'left',

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -338,7 +338,6 @@ export const WorkspaceMenuTrigger = ({ children, canShare, isOwner, setCloningWo
     content: h(Fragment, [
       h(MenuButton, { 'aria-label': 'Workspace copy', onClick: () => setCloningWorkspace(true) }, [makeMenuIcon('copy'), 'Clone']),
       h(MenuButton, {
-        'aria-label': 'Workspace share',
         disabled: !canShare,
         tooltip: !canShare && 'You have not been granted permission to share this workspace',
         tooltipSide: 'left',

--- a/src/pages/workspaces/workspace/applications/AppLauncher.js
+++ b/src/pages/workspaces/workspace/applications/AppLauncher.js
@@ -1,10 +1,11 @@
 import _ from 'lodash/fp'
-import { Fragment, useState } from 'react'
+import { Fragment, useEffect, useState } from 'react'
 import { div, h, iframe } from 'react-hyperscript-helpers'
 import * as breadcrumbs from 'src/components/breadcrumbs'
 import { spinnerOverlay } from 'src/components/common'
 import { ComputeModal } from 'src/components/ComputeModal'
-import { RuntimeKicker, RuntimeStatusMonitor, StatusMessage } from 'src/components/runtime-common'
+import { tools } from 'src/components/notebook-utils'
+import { appLauncherTabName, RuntimeKicker, RuntimeStatusMonitor, StatusMessage } from 'src/components/runtime-common'
 import { Ajax } from 'src/libs/ajax'
 import { withErrorReporting } from 'src/libs/error'
 import Events from 'src/libs/events'
@@ -19,15 +20,43 @@ const ApplicationLauncher = _.flow(
   Utils.forwardRefWithName('ApplicationLauncher'),
   wrapWorkspace({
     breadcrumbs: props => breadcrumbs.commonPaths.workspaceDashboard(props),
-    title: _.get('application')
+    title: _.get('application'),
+    activeTab: appLauncherTabName
   })
-)(({ namespace, name, refreshRuntimes, runtimes, persistentDisks, application, workspace }, ref) => {
+)(({ name: workspaceName, refreshRuntimes, runtimes, persistentDisks, application, workspace, workspace: { workspace: { googleProject, bucketName } } }, ref) => {
   const cookieReady = Utils.useStore(cookieReadyStore)
   const [showCreate, setShowCreate] = useState(false)
   const [busy, setBusy] = useState(false)
+  // We've already init Welder if app is Jupyter.
+  const [shouldSetupWelder, setShouldSetupWelder] = useState(application !== tools.RStudio.label)
 
   const runtime = getCurrentRuntime(runtimes)
   const runtimeStatus = getConvertedRuntimeStatus(runtime) // preserve null vs undefined
+
+  useEffect(() => {
+    const runtime = getCurrentRuntime(runtimes)
+    const runtimeStatus = getConvertedRuntimeStatus(runtime)
+
+    const setupWelder = _.flow(
+      Utils.withBusyState(setBusy),
+      withErrorReporting('Error setting up analysis file syncing')
+    )(async () => {
+      const localBaseDirectory = ``
+      const localSafeModeBaseDirectory = ``
+      const cloudStorageDirectory = `gs://${bucketName}/notebooks`
+
+      await Ajax()
+        .Runtimes
+        .fileSyncing(googleProject, runtime.runtimeName)
+        .setStorageLinks(localBaseDirectory, localSafeModeBaseDirectory, cloudStorageDirectory, `.*\\.Rmd`)
+    })
+
+    if (!shouldSetupWelder && runtimeStatus === 'Running') {
+      setupWelder()
+      setShouldSetupWelder(true)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [googleProject, workspaceName, runtimes, bucketName])
 
   return h(Fragment, [
     h(RuntimeStatusMonitor, {

--- a/src/pages/workspaces/workspace/applications/AppLauncher.js
+++ b/src/pages/workspaces/workspace/applications/AppLauncher.js
@@ -4,7 +4,6 @@ import { div, h, iframe } from 'react-hyperscript-helpers'
 import * as breadcrumbs from 'src/components/breadcrumbs'
 import { spinnerOverlay } from 'src/components/common'
 import { ComputeModal } from 'src/components/ComputeModal'
-import { tools } from 'src/components/notebook-utils'
 import { appLauncherTabName, RuntimeKicker, RuntimeStatusMonitor, StatusMessage } from 'src/components/runtime-common'
 import { Ajax } from 'src/libs/ajax'
 import { withErrorReporting } from 'src/libs/error'
@@ -27,8 +26,13 @@ const ApplicationLauncher = _.flow(
   const cookieReady = Utils.useStore(cookieReadyStore)
   const [showCreate, setShowCreate] = useState(false)
   const [busy, setBusy] = useState(false)
+
   // We've already init Welder if app is Jupyter.
-  const [shouldSetupWelder, setShouldSetupWelder] = useState(application !== tools.RStudio.label)
+  // TODO: We are stubbing this to never set up welder until we resolve some backend issues around file syncing
+  // See following tickets for status (both parts needed):
+  // PT1 - https://broadworkbench.atlassian.net/browse/IA-2991
+  // PT2 - https://broadworkbench.atlassian.net/browse/IA-2990
+  const [shouldSetupWelder, setShouldSetupWelder] = useState(false) // useState(application == tools.RStudio.label)
 
   const runtime = getCurrentRuntime(runtimes)
   const runtimeStatus = getConvertedRuntimeStatus(runtime) // preserve null vs undefined
@@ -51,7 +55,7 @@ const ApplicationLauncher = _.flow(
         .setStorageLinks(localBaseDirectory, localSafeModeBaseDirectory, cloudStorageDirectory, `.*\\.Rmd`)
     })
 
-    if (!shouldSetupWelder && runtimeStatus === 'Running') {
+    if (shouldSetupWelder && runtimeStatus === 'Running') {
       setupWelder()
       setShouldSetupWelder(true)
     }

--- a/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
@@ -550,7 +550,7 @@ const WelderDisabledNotebookEditorFrame = ({
       notify('error', 'Cannot Edit Notebook', {
         message: h(Fragment, [
           p(['Recent updates to Terra are not compatible with the older cloud environment in this workspace. Please recreate your cloud environment in order to access Edit Mode for this notebook.']),
-          h(Link, { 'aria-label': 'Data syncing doc', href: dataSyncingDocUrl, ...Utils.newTabLinkProps }, ['Read here for more details.'])
+          h(Link, { href: dataSyncingDocUrl, ...Utils.newTabLinkProps }, ['Read here for more details.'])
         ])
       })
       chooseMode(undefined)

--- a/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
@@ -481,8 +481,8 @@ const AnalysisEditorFrame = ({
     const cloudStorageDirectory = `gs://${bucketName}/notebooks`
 
     const pattern = Utils.switchCase(toolLabel,
-      [tools.RStudio.label, () => `.*\\.Rmd`],
-      [tools.Jupyter.label, () => `.*\\.ipynb`]
+      [tools.RStudio.label, () => '.*\\.Rmd'],
+      [tools.Jupyter.label, () => '.*\\.ipynb']
     )
 
     const setUpAnalysis = _.flow(

--- a/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
@@ -283,7 +283,6 @@ const PreviewHeader = ({
             h(MenuButton, { 'aria-label': `Copy analysis`, onClick: () => setCopyingAnalysis(true) }, ['Make a Copy']),
             h(MenuButton, { 'aria-label': `Export analysis`, onClick: () => setExportingAnalysis(true) }, ['Copy to another workspace']),
             h(MenuButton, {
-              'aria-label': `Copy to clipboard`,
               onClick: withErrorReporting('Error copying to clipboard', async () => {
                 await clipboard.writeText(`${window.location.host}/${analysisLink}`)
                 notify('success', 'Successfully copied URL to clipboard', { timeout: 3000 })

--- a/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
@@ -572,7 +572,6 @@ const WelderDisabledNotebookEditorFrame = ({
       b(['NOT ']),
       'being saved to the workspace. To save your changes, download the notebook using the file menu.',
       h(Link, {
-        'aria-label': 'Data syncing doc',
         style: { marginLeft: '0.5rem' },
         href: dataSyncingDocUrl,
         ...Utils.newTabLinkProps

--- a/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
@@ -68,7 +68,6 @@ const AnalysisLauncher = _.flow(
               { key: runtimeName, workspace, runtime, analysisName, mode, toolLabel, styles: iframeStyles }) :
             h(Fragment, [
               h(PreviewHeader, {
-                'aria-label': `Preview header`,
                 styles: iframeStyles, queryParams, runtime, analysisName, toolLabel, workspace, setCreateOpen,
                 readOnlyAccess: !(Utils.canWrite(accessLevel) && canCompute), onCreateRuntime: () => setCreateOpen(true)
               }),
@@ -149,18 +148,18 @@ const EditModeDisabledModal = ({ onDismiss, onRecreateRuntime, onPlayground }) =
     p('We’ve released important updates that are not compatible with the older cloud environment associated with this workspace. To enable Edit Mode, please delete your existing cloud environment and create a new cloud environment.'),
     p('If you have any files on your old cloud environment that you want to keep, you can access your old cloud environment using the Playground Mode option.'),
     h(Link, {
-      'aria-label': `Data syncing doc`,
+      'aria-label': 'Data syncing doc',
       href: dataSyncingDocUrl,
       ...Utils.newTabLinkProps
     }, ['Read here for more details.']),
     div({ style: { marginTop: '2rem' } }, [
       h(ButtonSecondary, {
-        'aria-label': `Launcher dismiss`,
+        'aria-label': 'Launcher dismiss',
         style: { padding: '0 1rem' },
         onClick: () => onDismiss()
       }, ['Cancel']),
       h(ButtonSecondary, {
-        'aria-label': `Launcher playground`,
+        'aria-label': 'Launcher playground',
         style: { padding: '0 1rem', marginLeft: '1rem' },
         onClick: () => onPlayground()
       }, ['Run in playground mode']),
@@ -551,7 +550,7 @@ const WelderDisabledNotebookEditorFrame = ({
       notify('error', 'Cannot Edit Notebook', {
         message: h(Fragment, [
           p(['Recent updates to Terra are not compatible with the older cloud environment in this workspace. Please recreate your cloud environment in order to access Edit Mode for this notebook.']),
-          h(Link, { 'aria-label': `Data syncing doc`, href: dataSyncingDocUrl, ...Utils.newTabLinkProps }, ['Read here for more details.'])
+          h(Link, { 'aria-label': 'Data syncing doc', href: dataSyncingDocUrl, ...Utils.newTabLinkProps }, ['Read here for more details.'])
         ])
       })
       chooseMode(undefined)
@@ -573,7 +572,7 @@ const WelderDisabledNotebookEditorFrame = ({
       b(['NOT ']),
       'being saved to the workspace. To save your changes, download the notebook using the file menu.',
       h(Link, {
-        'aria-label': `Data syncing doc`,
+        'aria-label': 'Data syncing doc',
         style: { marginLeft: '0.5rem' },
         href: dataSyncingDocUrl,
         ...Utils.newTabLinkProps

--- a/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
@@ -281,7 +281,7 @@ const PreviewHeader = ({
           closeOnClick: true,
           content: h(Fragment, [
             h(MenuButton, { 'aria-label': `Copy analysis`, onClick: () => setCopyingAnalysis(true) }, ['Make a Copy']),
-            h(MenuButton, { 'aria-label': `Export analysis`, onClick: () => setExportingAnalysis(true) }, ['Copy to another workspace']),
+            h(MenuButton, { onClick: () => setExportingAnalysis(true) }, ['Copy to another workspace']),
             h(MenuButton, {
               onClick: withErrorReporting('Error copying to clipboard', async () => {
                 await clipboard.writeText(`${window.location.host}/${analysisLink}`)

--- a/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
@@ -9,7 +9,10 @@ import { ButtonPrimary, ButtonSecondary, Clickable, LabeledCheckbox, Link, spinn
 import { ComputeModal } from 'src/components/ComputeModal'
 import { icon } from 'src/components/icons'
 import Modal from 'src/components/Modal'
-import { AnalysisDuplicator, findPotentialNotebookLockers, getDisplayName, getTool, notebookLockHash } from 'src/components/notebook-utils'
+import {
+  AnalysisDuplicator, findPotentialNotebookLockers, getDisplayName, getTool,
+  getToolFromRuntime, notebookLockHash, tools
+} from 'src/components/notebook-utils'
 import { makeMenuIcon, MenuButton, MenuTrigger } from 'src/components/PopupTrigger'
 import { ApplicationHeader, PlaygroundHeader, RuntimeKicker, RuntimeStatusMonitor, StatusMessage } from 'src/components/runtime-common'
 import { dataSyncingDocUrl } from 'src/data/machines'
@@ -65,7 +68,8 @@ const AnalysisLauncher = _.flow(
               { key: runtimeName, workspace, runtime, analysisName, mode, toolLabel, styles: iframeStyles }) :
             h(Fragment, [
               h(PreviewHeader, {
-                styles: iframeStyles, queryParams, runtime, analysisName, toolLabel, workspace,
+                'aria-label': `Preview header`,
+                styles: iframeStyles, queryParams, runtime, analysisName, toolLabel, workspace, setCreateOpen,
                 readOnlyAccess: !(Utils.canWrite(accessLevel) && canCompute), onCreateRuntime: () => setCreateOpen(true)
               }),
               h(AnalysisPreviewFrame, { styles: iframeStyles, analysisName, toolLabel, workspace })
@@ -145,19 +149,23 @@ const EditModeDisabledModal = ({ onDismiss, onRecreateRuntime, onPlayground }) =
     p('We’ve released important updates that are not compatible with the older cloud environment associated with this workspace. To enable Edit Mode, please delete your existing cloud environment and create a new cloud environment.'),
     p('If you have any files on your old cloud environment that you want to keep, you can access your old cloud environment using the Playground Mode option.'),
     h(Link, {
+      'aria-label': `Data syncing doc`,
       href: dataSyncingDocUrl,
       ...Utils.newTabLinkProps
     }, ['Read here for more details.']),
     div({ style: { marginTop: '2rem' } }, [
       h(ButtonSecondary, {
+        'aria-label': `Launcher dismiss`,
         style: { padding: '0 1rem' },
         onClick: () => onDismiss()
       }, ['Cancel']),
       h(ButtonSecondary, {
+        'aria-label': `Launcher playground`,
         style: { padding: '0 1rem', marginLeft: '1rem' },
         onClick: () => onPlayground()
       }, ['Run in playground mode']),
       h(ButtonPrimary, {
+        'aria-label': `Launcher create`,
         style: { padding: '0 1rem', marginLeft: '2rem' },
         onClick: () => onRecreateRuntime()
       }, ['Recreate cloud environment'])
@@ -190,11 +198,12 @@ const PlaygroundModal = ({ onDismiss, onPlayground }) => {
 }
 
 const HeaderButton = ({ children, ...props }) => h(ButtonSecondary, {
+  'aria-label': `analysis header button`,
   style: { padding: '1rem', backgroundColor: colors.dark(0.1), height: '100%', marginRight: 2 }, ...props
 }, [children])
 
 const PreviewHeader = ({
-  queryParams, runtime, readOnlyAccess, onCreateRuntime, analysisName, toolLabel, workspace,
+  queryParams, runtime, readOnlyAccess, onCreateRuntime, analysisName, toolLabel, workspace, setCreateOpen,
   workspace: { canShare, workspace: { namespace, name, bucketName, googleProject } }
 }) => {
   const signal = Utils.useCancellation()
@@ -210,6 +219,7 @@ const PreviewHeader = ({
   const welderEnabled = runtime && !runtime.labels.welderInstallFailed
   const { mode } = queryParams
   const analysisLink = Nav.getLink('workspace-analysis-launch', { namespace, name, analysisName })
+  const currentRuntimeTool = getToolFromRuntime(runtime)
 
   const checkIfLocked = withErrorReporting('Error checking analysis lock status', async () => {
     const { metadata: { lastLockedBy, lockExpiresAt } = {} } = await Ajax(signal)
@@ -232,34 +242,49 @@ const PreviewHeader = ({
     labelBgColor: colors.dark(0.2)
   }, [
     Utils.cond(
-      [readOnlyAccess, () => h(HeaderButton, { onClick: () => setExportingAnalysis(true) },
-        [makeMenuIcon('export'), 'Copy to another workspace']
-      )],
-      //TODO: THIS CONDITIONAL should look for Jupyter or Rstudio
-      [!!runtimeStatus && runtime.labels.tool !== 'Jupyter', () => h(StatusMessage, { hideSpinner: true }, [
-        'Your cloud compute doesn\'t appear to be running Jupyter. Create a new cloud environment with Jupyter on it to edit this notebook.'
+      [readOnlyAccess, () => h(HeaderButton, { onClick: () => setExportingAnalysis(true) }, [
+        makeMenuIcon('export'), 'Copy to another workspace'
       ])],
       [!mode || [null, 'Stopped'].includes(runtimeStatus), () => h(Fragment, [
-        Utils.cond(
-          [runtime && !welderEnabled, () => h(HeaderButton, {
-            onClick: () => setEditModeDisabledOpen(true)
-          }, [makeMenuIcon('warning-standard'), 'Edit (Disabled)'])],
-          [locked, () => h(HeaderButton, {
-            onClick: () => setFileInUseOpen(true)
-          }, [makeMenuIcon('lock'), 'Edit (In use)'])],
-          () => h(HeaderButton, {
-            onClick: () => chooseMode('edit')
-          }, [makeMenuIcon('edit'), 'Edit'])
-        ),
-        h(HeaderButton, {
-          onClick: () => getLocalPref('hidePlaygroundMessage') ? chooseMode('playground') : setPlaygroundModalOpen(true)
-        }, [makeMenuIcon('chalkboard'), 'Playground mode']),
+        ...(toolLabel === tools.Jupyter.label ? [
+          Utils.cond(
+            [runtime && !welderEnabled, () => h(HeaderButton, { onClick: () => setEditModeDisabledOpen(true) }, [
+              makeMenuIcon('warning-standard'), 'Edit (Disabled)'
+            ])],
+            [locked, () => h(HeaderButton, { onClick: () => setFileInUseOpen(true) }, [
+              makeMenuIcon('lock'), 'Edit (In use)'
+            ])],
+            () => h(HeaderButton, { onClick: () => currentRuntimeTool !== tools.Jupyter.label ? setCreateOpen(true) : chooseMode('edit') }, [
+              makeMenuIcon('edit'), 'Edit'
+            ])
+          ),
+          h(HeaderButton, {
+            onClick: () => getLocalPref('hidePlaygroundMessage') ? chooseMode('playground') : setPlaygroundModalOpen(true)
+          }, [
+            makeMenuIcon('chalkboard'), 'Playground mode'
+          ])
+        ] : [
+          h(HeaderButton, {
+            onClick: () => {
+              if (currentRuntimeTool !== tools.RStudio.label) {
+                setCreateOpen(true)
+              } else {
+                Nav.goToPath('workspace-application-launch', { namespace, name, application: 'RStudio' })
+              }
+            },
+            disabled: runtimeStatus !== 'Running',
+            tooltip: runtimeStatus !== 'Running' ? 'You must have a running cloud environment.' : ''
+          }, [
+            makeMenuIcon('rocket'), 'Launch'
+          ])
+        ]),
         h(MenuTrigger, {
           closeOnClick: true,
           content: h(Fragment, [
-            h(MenuButton, { onClick: () => setCopyingAnalysis(true) }, ['Make a Copy']),
-            h(MenuButton, { onClick: () => setExportingAnalysis(true) }, ['Copy to another workspace']),
+            h(MenuButton, { 'aria-label': `Copy analysis`, onClick: () => setCopyingAnalysis(true) }, ['Make a Copy']),
+            h(MenuButton, { 'aria-label': `Export analysis`, onClick: () => setExportingAnalysis(true) }, ['Copy to another workspace']),
             h(MenuButton, {
+              'aria-label': `Copy to clipboard`,
               onClick: withErrorReporting('Error copying to clipboard', async () => {
                 await clipboard.writeText(`${window.location.host}/${analysisLink}`)
                 notify('success', 'Successfully copied URL to clipboard', { timeout: 3000 })
@@ -356,7 +381,6 @@ const AnalysisPreviewFrame = ({ analysisName, toolLabel, workspace: { workspace:
     withRequesterPaysHandler(onRequesterPaysError),
     withErrorReporting('Error previewing analysis')
   )(async () => {
-    //TODO: this call may not be right, ensure file extension/toolLabel is correct
     setPreview(await Ajax(signal).Buckets.analysis(googleProject, bucketName, analysisName, toolLabel).preview())
   })
   Utils.useOnMount(() => {
@@ -381,7 +405,8 @@ const AnalysisPreviewFrame = ({ analysisName, toolLabel, workspace: { workspace:
   ])
 }
 
-//TODO: this ensures that navigating away from the Jupyter iframe results in a save via a custom extension located in `jupyter-iframe-extension`
+// TODO: this ensures that navigating away from the Jupyter iframe results in a save via a custom extension located in `jupyter-iframe-extension`
+// See this ticket for RStudio impl discussion: https://broadworkbench.atlassian.net/browse/IA-2947
 const JupyterFrameManager = ({ onClose, frameRef, details = {} }) => {
   Utils.useOnMount(() => {
     Ajax()
@@ -441,52 +466,58 @@ const AnalysisEditorFrame = ({
   console.assert(!labels.welderInstallFailed, 'Expected cloud environment to have Welder')
   const frameRef = useRef()
   const [busy, setBusy] = useState(false)
-  const [notebookSetupComplete, setNotebookSetupComplete] = useState(false)
+  const [analysisSetupComplete, setAnalysisSetupComplete] = useState(false)
   const cookieReady = Utils.useStore(cookieReadyStore)
 
-  const localBaseDirectory = `${name}/edit`
-  const localSafeModeBaseDirectory = `${name}/safe`
-  //TODO: should this vary on toolLabel? (As of right now, the answer is no because the VM path will be `/home/rstudio`, but the bucket path for all analyses will be `/notebooks`, but design still WIP)
-  const cloudStorageDirectory = `gs://${bucketName}/notebooks`
+  const localBaseDirectory = Utils.switchCase(toolLabel,
+    [tools.Jupyter.label, () => `${name}/edit`],
+    [tools.RStudio.label, () => ''])
 
-  //TODO: see inline TODOs, may require call-site change too
-  const setUpNotebook = _.flow(
-    Utils.withBusyState(setBusy),
-    withErrorReporting('Error setting up analysis')
-  )(async () => {
-    await Ajax()
-      //TODO: use proper welder calls
-      .Runtimes
-      .notebooks(googleProject, runtimeName)
-      .setStorageLinks(localBaseDirectory, localSafeModeBaseDirectory, cloudStorageDirectory, `.*\\.ipynb`)
-    if (mode === 'edit' && !(await Ajax().Runtimes.notebooks(googleProject, runtimeName).lock(`${localBaseDirectory}/${analysisName}`))) {
-      notify('error', 'Unable to Edit Analysis', {
-        message: 'Another user is currently editing this analysis. You can run it in Playground Mode or make a copy.'
-      })
-      chooseMode(undefined)
-    } else {
-      //TODO use proper welder calls
-      await Ajax().Runtimes.notebooks(googleProject, runtimeName).localize([{
-        sourceUri: `${cloudStorageDirectory}/${analysisName}`,
-        localDestinationPath: mode === 'edit' ? `${localBaseDirectory}/${analysisName}` : `${localSafeModeBaseDirectory}/${analysisName}`
-      }])
-      setNotebookSetupComplete(true)
-    }
-  })
+  const localSafeModeBaseDirectory = Utils.switchCase(toolLabel,
+    [tools.Jupyter.label, () => `${name}/safe`],
+    [tools.RStudio.label, () => '']
+  )
 
   Utils.useOnMount(() => {
-    setUpNotebook()
+    const cloudStorageDirectory = `gs://${bucketName}/notebooks`
+
+    const pattern = Utils.switchCase(toolLabel,
+      [tools.RStudio.label, () => `.*\\.Rmd`],
+      [tools.Jupyter.label, () => `.*\\.ipynb`]
+    )
+
+    const setUpAnalysis = _.flow(
+      Utils.withBusyState(setBusy),
+      withErrorReporting('Error setting up analysis')
+    )(async () => {
+      await Ajax()
+        .Runtimes
+        .fileSyncing(googleProject, runtimeName)
+        .setStorageLinks(localBaseDirectory, localSafeModeBaseDirectory, cloudStorageDirectory, pattern)
+      if (mode === 'edit' && !(await Ajax().Runtimes.fileSyncing(googleProject, runtimeName).lock(`${localBaseDirectory}/${analysisName}`))) {
+        notify('error', 'Unable to Edit Analysis', {
+          message: 'Another user is currently editing this analysis. You can run it in Playground Mode or make a copy.'
+        })
+        chooseMode(undefined)
+      } else {
+        await Ajax().Runtimes.fileSyncing(googleProject, runtimeName).localize([{
+          sourceUri: `${cloudStorageDirectory}/${analysisName}`,
+          localDestinationPath: mode === 'edit' ? `${localBaseDirectory}/${analysisName}` : `${localSafeModeBaseDirectory}/${analysisName}`
+        }])
+        setAnalysisSetupComplete(true)
+      }
+    })
+
+    setUpAnalysis()
   })
 
   return h(Fragment, [
-    notebookSetupComplete && cookieReady && h(Fragment, [
+    analysisSetupComplete && cookieReady && h(Fragment, [
       iframe({
-        //TODO: this may vary based on tool.
         src: `${proxyUrl}/notebooks/${mode === 'edit' ? localBaseDirectory : localSafeModeBaseDirectory}/${analysisName}`,
         style: { border: 'none', flex: 1, ...styles },
         ref: frameRef
       }),
-      //TODO: this frame will most likely vary based on tool. See comment attached to `JupyterFrameManager`
       h(JupyterFrameManager, {
         frameRef,
         onClose: () => Nav.goToPath('workspace-analyses', { namespace, name }),
@@ -520,13 +551,12 @@ const WelderDisabledNotebookEditorFrame = ({
       notify('error', 'Cannot Edit Notebook', {
         message: h(Fragment, [
           p(['Recent updates to Terra are not compatible with the older cloud environment in this workspace. Please recreate your cloud environment in order to access Edit Mode for this notebook.']),
-          h(Link, { href: dataSyncingDocUrl, ...Utils.newTabLinkProps }, ['Read here for more details.'])
+          h(Link, { 'aria-label': `Data syncing doc`, href: dataSyncingDocUrl, ...Utils.newTabLinkProps }, ['Read here for more details.'])
         ])
       })
       chooseMode(undefined)
     } else {
-      //TODO: does this link need to change?
-      await Ajax(signal).Runtimes.notebooks(googleProject, runtimeName).oldLocalize({
+      await Ajax(signal).Runtimes.fileSyncing(googleProject, runtimeName).oldLocalize({
         [`~/${name}/${notebookName}`]: `gs://${bucketName}/notebooks/${notebookName}`
       })
       setLocalized(true)
@@ -543,6 +573,7 @@ const WelderDisabledNotebookEditorFrame = ({
       b(['NOT ']),
       'being saved to the workspace. To save your changes, download the notebook using the file menu.',
       h(Link, {
+        'aria-label': `Data syncing doc`,
         style: { marginLeft: '0.5rem' },
         href: dataSyncingDocUrl,
         ...Utils.newTabLinkProps
@@ -550,7 +581,6 @@ const WelderDisabledNotebookEditorFrame = ({
     ]),
     localized && cookieReady && h(Fragment, [
       iframe({
-        //TODO: does this link need to change?
         src: `${proxyUrl}/notebooks/${name}/${notebookName}`,
         style: { border: 'none', flex: 1, ...styles },
         ref: frameRef

--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -415,15 +415,15 @@ const NotebookEditorFrame = ({ mode, notebookName, workspace: { workspace: { nam
   )(async () => {
     await Ajax()
       .Runtimes
-      .notebooks(googleProject, runtimeName)
+      .fileSyncing(googleProject, runtimeName)
       .setStorageLinks(localBaseDirectory, localSafeModeBaseDirectory, cloudStorageDirectory, `.*\\.ipynb`)
-    if (mode === 'edit' && !(await Ajax().Runtimes.notebooks(googleProject, runtimeName).lock(`${localBaseDirectory}/${notebookName}`))) {
+    if (mode === 'edit' && !(await Ajax().Runtimes.fileSyncing(googleProject, runtimeName).lock(`${localBaseDirectory}/${notebookName}`))) {
       notify('error', 'Unable to Edit Notebook', {
         message: 'Another user is currently editing this notebook. You can run it in Playground Mode or make a copy.'
       })
       chooseMode(undefined)
     } else {
-      await Ajax().Runtimes.notebooks(googleProject, runtimeName).localize([{
+      await Ajax().Runtimes.fileSyncing(googleProject, runtimeName).localize([{
         sourceUri: `${cloudStorageDirectory}/${notebookName}`,
         localDestinationPath: mode === 'edit' ? `${localBaseDirectory}/${notebookName}` : `${localSafeModeBaseDirectory}/${notebookName}`
       }])
@@ -474,7 +474,7 @@ const WelderDisabledNotebookEditorFrame = ({ mode, notebookName, workspace: { wo
       })
       chooseMode(undefined)
     } else {
-      await Ajax(signal).Runtimes.notebooks(googleProject, runtimeName).oldLocalize({
+      await Ajax(signal).Runtimes.fileSyncing(googleProject, runtimeName).oldLocalize({
         [`~/${name}/${notebookName}`]: `gs://${bucketName}/notebooks/${notebookName}`
       })
       setLocalized(true)


### PR DESCRIPTION
Testing this PR depends on manually updating leo conf file to point to a newer welder hash than exists in dev, and hotswapping it to your fiab (see linked PR for necessary code change). This means this PR **cannot be merged** until [this](https://github.com/DataBiosphere/leonardo/pull/2295/files) is.

This PR ensures storageLinks is called on RStudio application launch, which results in any `.Rmd` files in the users bucket in the `notebooks/` folder being localized for editing. Any files saved in the RStudio editor will then be delocalized back to the bucket.

Today, the only way to create and interact with .Rmd files is the RStudio editor. With the analysis tab, we will also support Rmd preview and launching from the preview page, where we also interface with localization. This PR updates this, and touches up the buttons to reflect that RStudio does not launch the editor with a particular file in mind, where as Jupyter does. See screenshots below.

RStudio Preview:
![image](https://user-images.githubusercontent.com/6465084/133304274-34e3651e-470c-4635-b76b-c84095a35e7d.png)

RStudio with files localized:
![image](https://user-images.githubusercontent.com/6465084/133304236-3d2e0265-aa21-4b20-bf72-b67e307041bb.png)

