### PR TITLE
[IA-2919] Label runtimes with workspace namespace value

### DIFF
--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -197,7 +197,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
           } : {
             name: Utils.generatePersistentDiskName(),
             size: desiredPersistentDisk.size,
-            labels: { saturnWorkspaceName: name }
+            labels: { saturnWorkspaceNamespace: namespace, saturnWorkspaceName: name }
           }
         }),
         ...(computeConfig.gpuEnabled && { gpuConfig: { gpuType: computeConfig.gpuType, numOfGpus: computeConfig.numGpus } })
@@ -238,7 +238,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
       await Ajax().Runtimes.runtime(googleProject, Utils.generateRuntimeName()).create({
         runtimeConfig,
         toolDockerImage: desiredRuntime.toolDockerImage,
-        labels: { saturnWorkspaceName: name },
+        labels: { saturnWorkspaceNamespace: namespace, saturnWorkspaceName: name },
         customEnvironmentVariables: customEnvVars,
         ...(desiredRuntime.jupyterUserScriptUri ? { jupyterUserScriptUri: desiredRuntime.jupyterUserScriptUri } : {})
       })

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -245,12 +245,7 @@ export const EntityUploader = ({ onSuccess, onDismiss, namespace, name, entityTy
       if (useFireCloudDataModel) {
         await workspace.importEntitiesFile(file)
       } else {
-        let filesize = Number.MAX_SAFE_INTEGER
-        try {
-          filesize = file.size
-        } catch (err) {
-          // noop
-        }
+        const filesize = file?.size || Number.MAX_SAFE_INTEGER
         if (filesize < 524288) { // 512k
           await workspace.importFlexibleEntitiesFileSynchronous(file)
         } else {
@@ -259,7 +254,6 @@ export const EntityUploader = ({ onSuccess, onDismiss, namespace, name, entityTy
           notifyDataImportProgress(jobId)
         }
       }
-      
       onSuccess()
       Ajax().Metrics.captureEvent(Events.workspaceDataUpload, {
         workspaceNamespace: namespace, workspaceName: name

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -466,20 +466,20 @@ const Environments = () => {
             }
           },
           {
-            size: { basis: 120, grow: 0.2 },
-            headerRenderer: () => 'Location',
-            cellRenderer: ({ rowIndex }) => {
-              const disk = filteredDisks[rowIndex]
-              return disk.zone
-            }
-          },
-          {
             size: { basis: 130, grow: 0 },
             field: 'status',
             headerRenderer: () => h(Sortable, { sort: diskSort, field: 'status', onSort: setDiskSort }, ['Status']),
             cellRenderer: ({ rowIndex }) => {
               const disk = filteredDisks[rowIndex]
               return disk.status
+            }
+          },
+          {
+            size: { basis: 120, grow: 0.2 },
+            headerRenderer: () => 'Location',
+            cellRenderer: ({ rowIndex }) => {
+              const disk = filteredDisks[rowIndex]
+              return disk.zone
             }
           },
           {

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -450,7 +450,7 @@ const WorkspaceData = _.flow(
   const getRunningImportJobs = async () => {
     try {
       const runningJobs = await Ajax(signal).Workspaces.workspace(namespace, name).listImportJobs(true)
-      _.map(job => {
+      _.forEach(job => {
         const jobStatus = _.lowerCase(job.status)
         if (!_.includes(jobStatus, ['success', 'error', 'done'])) {
           asyncImportJobStore.update(Utils.append({ targetWorkspace: { namespace, name }, jobId: job.jobId }))


### PR DESCRIPTION
This is the first PR for the ticket [IA-2919](https://broadworkbench.atlassian.net/browse/IA-2919). There will be another PR for the remainder of the work once the [requisite backend work](https://broadworkbench.atlassian.net/browse/IA-2958) is in place. I wanted to get this PR's changes in so we start capturing `workspace namespace` (aka `billing project`) values for runtimes before the One Project Per Workspace (PPW) work is released to `prod` since `workspace namespace` may no longer be the same as `google project` after that release, which would cause Cloud Environments page to display wrong information in `Billing project` column.

Tested against `dev` using a local UI deploy.