### PR TITLE
[IA-2902] Increase boot disk to 80G for GCE and Dataproc

### DIFF
--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -90,7 +90,7 @@ const DataprocDiskSelector = ({ value, onChange }) => {
       label({ htmlFor: id, style: styles.label }, ['Disk size (GB)']),
       h(NumberInput, {
         id,
-        min: 60, // less than this size causes failures in cluster creation
+        min: 80, // less than this size causes failures in cluster creation
         max: 64000,
         isClearable: false,
         onlyInteger: true,

--- a/src/libs/runtime-utils.js
+++ b/src/libs/runtime-utils.js
@@ -10,8 +10,8 @@ import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 
 
-export const defaultDataprocDiskSize = 60 // For both main and worker machine disks. Dataproc clusters don't have persistent disks.
-export const defaultGceBootDiskSize = 70 // GCE boot disk size is not customizable by users. We use this for cost estimate calculations only.
+export const defaultDataprocDiskSize = 80 // For both main and worker machine disks. Dataproc clusters don't have persistent disks.
+export const defaultGceBootDiskSize = 80 // GCE boot disk size is not customizable by users. We use this for cost estimate calculations only.
 export const defaultGcePersistentDiskSize = 50
 
 export const defaultGceMachineType = 'n1-standard-1'


### PR DESCRIPTION
We are adding some extra Docker caching to the Leo image, so we need to increase the boot disk slightly for GCE and Dataproc.

See https://github.com/DataBiosphere/leonardo/pull/2271. This PR should go out before the Leo PR.