### PR TITLE
[POL-86] Add parallelism for nightly tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,12 +181,14 @@ jobs:
           env: local
   integration-tests-alpha:
     executor: puppeteer
+    parallelism: 4
     steps:
       - integration-tests:
           env: alpha
       - notify-qa
   integration-tests-staging:
     executor: puppeteer
+    parallelism: 4
     steps:
       - integration-tests:
           env: staging


### PR DESCRIPTION
This brings the nightly tests into line with the dev tests.