### PR TITLE
[CA-1524] Hide Errored Billing Projects In Create Workspace Pane

### DIFF
--- a/src/components/NewWorkspaceModal.js
+++ b/src/components/NewWorkspaceModal.js
@@ -96,16 +96,15 @@ const NewWorkspaceModal = Utils.withDisplayName('NewWorkspaceModal', ({
   const loadProjectsGroups = _.flow(
     withErrorReporting('Error loading data'),
     Utils.withBusyState(setLoading)
-  )(async () => {
-    const [billingProjects, allGroups] = await Promise.all([
-      Ajax(signal).Billing.listProjects(),
-      Ajax(signal).Groups.list()
-    ])
-    setBillingProjects(billingProjects)
-    setAllGroups(allGroups)
-    setNamespace(_.some({ projectName: namespace }, billingProjects) ? namespace : undefined)
-  })
-
+  )(() => Promise.all([
+    Ajax(signal).Billing.listProjects()
+      .then(_.filter({ status: 'Ready' }))
+      .then(projects => {
+        setBillingProjects(projects)
+        setNamespace(_.some({ projectName: namespace }, projects) ? namespace : undefined)
+      }),
+    Ajax(signal).Groups.list().then(setAllGroups)
+  ]))
 
   // Lifecycle
   Utils.useOnMount(() => { loadProjectsGroups() })


### PR DESCRIPTION
RR: https://broadworkbench.atlassian.net/browse/CA-1524

Prevent users trying to create workspaces in errored billing projects by excluding those projects from the billing project list in `NewWorkspaceModal`
Restore unselectable/selectable projects + tooltips in `BillingList`
![Screenshot from 2021-09-23 15-13-38](https://user-images.githubusercontent.com/8223952/134569475-6a597030-cdfd-47a8-bb68-a0e234931770.png)

