### PR TITLE
[CA-1539] Update `BillingList` when user changes project billing account

### DIFF
--- a/src/libs/error.js
+++ b/src/libs/error.js
@@ -12,17 +12,10 @@ export const reportError = async (title, obj) => {
   }
 }
 
-// Transforms an async function so that it catches and reports errors using the provided text
-export const withErrorReporting = _.curry((title, fn) => async (...args) => {
-  try {
-    return await fn(...args)
-  } catch (error) {
-    await reportError(title, error)
-    throw error
-  }
-})
-
-// Transforms an async function so that it catches and ignores errors
+/**
+ * Return a Promise to the result of evaluating the async `fn` with `...args` or undefined if
+ * evaluation fails.
+ */
 export const withErrorIgnoring = fn => async (...args) => {
   try {
     return await fn(...args)
@@ -30,3 +23,24 @@ export const withErrorIgnoring = fn => async (...args) => {
     // ignore error
   }
 }
+
+/**
+ * Return a Promise to the result of evaluating the async `fn` with `...args`. If evaluation fails,
+ * report the error to the user with `title` as a side effect.
+ */
+export const reportErrorAndRethrow = _.curry((title, fn) => async (...args) => {
+  try {
+    return await fn(...args)
+  } catch (error) {
+    reportError(title, error)
+    throw error
+  }
+})
+
+/**
+ * Return a Promise to the result of evaluating the async `fn` with `...args` or undefined if
+ * evaluation fails. If evaluation fails, report the error to the user with `title`.
+ */
+export const withErrorReporting = _.curry((title, fn) => {
+  return withErrorIgnoring(reportErrorAndRethrow(title)(fn))
+})

--- a/src/libs/error.js
+++ b/src/libs/error.js
@@ -17,7 +17,8 @@ export const withErrorReporting = _.curry((title, fn) => async (...args) => {
   try {
     return await fn(...args)
   } catch (error) {
-    reportError(title, error)
+    await reportError(title, error)
+    throw error
   }
 })
 

--- a/src/pages/billing/List.js
+++ b/src/pages/billing/List.js
@@ -13,7 +13,7 @@ import TopBar from 'src/components/TopBar'
 import { Ajax } from 'src/libs/ajax'
 import * as Auth from 'src/libs/auth'
 import colors from 'src/libs/colors'
-import { withErrorReporting } from 'src/libs/error'
+import { reportErrorAndRethrow } from 'src/libs/error'
 import Events from 'src/libs/events'
 import { formHint, FormLabel } from 'src/libs/forms'
 import * as Nav from 'src/libs/nav'
@@ -113,7 +113,7 @@ const NewBillingProjectModal = ({ onSuccess, onDismiss, billingAccounts, loadAcc
   const [chosenBillingAccount, setChosenBillingAccount] = useState('')
 
   const submit = _.flow(
-    withErrorReporting('Error creating billing project'),
+    reportErrorAndRethrow('Error creating billing project'),
     Utils.withBusyState(setIsBusy)
   )(async () => {
     try {
@@ -226,12 +226,12 @@ export const BillingList = ({ queryParams: { selectedName } }) => {
 
   // Helpers
   const loadProjects = _.flow(
-    withErrorReporting('Error loading billing projects list'),
+    reportErrorAndRethrow('Error loading billing projects list'),
     Utils.withBusyState(setIsLoadingProjects)
   )(async () => setBillingProjects(_.sortBy('projectName', await Ajax(signal).Billing.listProjects())))
 
   const reloadBillingProject = _.flow(
-    withErrorReporting('Error loading billing project'),
+    reportErrorAndRethrow('Error loading billing project'),
     Utils.withBusyState(setIsLoadingProjects)
   )(async ({ projectName }) => {
     // evaluate first to error if project doesn't exist/user can't access
@@ -241,12 +241,12 @@ export const BillingList = ({ queryParams: { selectedName } }) => {
   })
 
   const authorizeAccounts = _.flow(
-    withErrorReporting('Error setting up authorization'),
+    reportErrorAndRethrow('Error setting up authorization'),
     Utils.withBusyState(setIsAuthorizing)
   )(Auth.ensureBillingScope)
 
   const loadAccounts = _.flow(
-    withErrorReporting('Error loading billing accounts'),
+    reportErrorAndRethrow('Error loading billing accounts'),
     Utils.withBusyState(setIsLoadingAccounts)
   )(() => {
     if (Auth.hasBillingScope()) {

--- a/src/pages/billing/List.js
+++ b/src/pages/billing/List.js
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp'
 import * as qs from 'qs'
-import { Fragment, useCallback, useEffect, useRef, useState } from 'react'
+import { Fragment, useEffect, useRef, useState } from 'react'
 import { div, h, h2, p, span } from 'react-hyperscript-helpers'
 import Collapse from 'src/components/Collapse'
 import { ButtonOutline, ButtonPrimary, Clickable, IdContainer, Link, Select, spinnerOverlay } from 'src/components/common'

--- a/src/pages/billing/List.js
+++ b/src/pages/billing/List.js
@@ -360,13 +360,20 @@ export const BillingList = ({ queryParams: { selectedName } }) => {
               p(['It may not exist, or you may not have access to it.'])
             ])
           ])],
-        [selectedName && hasBillingProjects, () => h(ProjectDetail, {
-          key: selectedName,
-          billingProject: _.find({ projectName: selectedName }, billingProjects),
-          billingAccounts,
-          authorizeAndLoadAccounts,
-          invalidateProjectAndReload: loadProjects
-        })],
+        [selectedName && hasBillingProjects, () => {
+          const index = _.findIndex({ projectName: selectedName }, billingProjects)
+          return h(ProjectDetail, {
+            key: selectedName,
+            billingProject: billingProjects[index],
+            billingAccounts,
+            authorizeAndLoadAccounts,
+            invalidateProjectAndReload: async () => {
+              const projects = billingProjects.slice()
+              projects[index] = await Ajax(signal).Billing.billingProject(selectedName)
+              setBillingProjects(projects)
+            }
+          })
+        }],
         [!_.isEmpty(projectsOwned) && !selectedName && hasBillingProjects, () => div(
           { style: { margin: '1rem auto 0 auto' } }, [
             'Select a Billing Project'

--- a/src/pages/billing/List.js
+++ b/src/pages/billing/List.js
@@ -367,7 +367,7 @@ export const BillingList = ({ queryParams: { selectedName } }) => {
             billingProject: billingProjects[index],
             billingAccounts,
             authorizeAndLoadAccounts,
-            invalidateProjectAndReload: async () => {
+            updateProjectAndReload: async () => {
               const projects = billingProjects.slice()
               projects[index] = await Ajax(signal).Billing.billingProject(selectedName)
               setBillingProjects(projects)

--- a/src/pages/billing/List.js
+++ b/src/pages/billing/List.js
@@ -362,9 +362,10 @@ export const BillingList = ({ queryParams: { selectedName } }) => {
           ])],
         [selectedName && hasBillingProjects, () => h(ProjectDetail, {
           key: selectedName,
-          project: _.find({ projectName: selectedName }, billingProjects),
+          billingProject: _.find({ projectName: selectedName }, billingProjects),
           billingAccounts,
-          authorizeAndLoadAccounts
+          authorizeAndLoadAccounts,
+          invalidateProjectAndReload: loadProjects
         })],
         [!_.isEmpty(projectsOwned) && !selectedName && hasBillingProjects, () => div(
           { style: { margin: '1rem auto 0 auto' } }, [

--- a/src/pages/billing/List.js
+++ b/src/pages/billing/List.js
@@ -366,7 +366,7 @@ export const BillingList = ({ queryParams: { selectedName } }) => {
             billingProject: billingProjects[index],
             billingAccounts,
             authorizeAndLoadAccounts,
-            updateProject: _.flow(
+            updateBillingProject: _.flow(
               withErrorReporting('Error updating billing project'),
               Utils.withBusyState(setIsLoadingProjects)
             )(async () => {

--- a/src/pages/billing/List.js
+++ b/src/pages/billing/List.js
@@ -366,7 +366,10 @@ export const BillingList = ({ queryParams: { selectedName } }) => {
             billingProject: billingProjects[index],
             billingAccounts,
             authorizeAndLoadAccounts,
-            updateProject: async () => {
+            updateProject: _.flow(
+              withErrorReporting('Error updating billing project'),
+              Utils.withBusyState(setIsLoadingProjects)
+            )(async () => {
               try {
                 const projects = billingProjects.slice()
                 projects[index] = await Ajax(signal).Billing.billingProject(selectedName)
@@ -374,7 +377,7 @@ export const BillingList = ({ queryParams: { selectedName } }) => {
               } catch (_) {
                 loadProjects()
               }
-            }
+            })
           })
         }],
         [!_.isEmpty(projectsOwned) && !selectedName, () => {

--- a/src/pages/billing/List.js
+++ b/src/pages/billing/List.js
@@ -375,7 +375,7 @@ export const BillingList = ({ queryParams: { selectedName } }) => {
                 projects[index] = await Ajax(signal).Billing.billingProject(selectedName)
                 setBillingProjects(projects)
               } catch (_) {
-                loadProjects()
+                await loadProjects()
               }
             })
           })

--- a/src/pages/billing/List.js
+++ b/src/pages/billing/List.js
@@ -241,11 +241,11 @@ export const BillingList = ({ queryParams: { selectedName } }) => {
   const loadAccounts = _.flow(
     withErrorReporting('Error loading billing accounts'),
     Utils.withBusyState(setIsLoadingAccounts)
-  )(async () => {
+  )(() => {
     if (Auth.hasBillingScope()) {
-      const accounts = await Ajax(signal).Billing.listAccounts()
-      const byAccountName = Object.fromEntries(_.map(acc => [acc.accountName, acc], accounts))
-      setBillingAccounts(byAccountName)
+      return Ajax(signal).Billing.listAccounts()
+        .then(_.keyBy('accountName'))
+        .then(setBillingAccounts)
     }
   })
 
@@ -374,10 +374,9 @@ export const BillingList = ({ queryParams: { selectedName } }) => {
             }
           })
         }],
-        [!_.isEmpty(projectsOwned) && !selectedName && hasBillingProjects, () => div(
-          { style: { margin: '1rem auto 0 auto' } }, [
-            'Select a Billing Project'
-          ]
+        [!_.isEmpty(projectsOwned) && !selectedName && hasBillingProjects, () => div({
+          style: { margin: '1rem auto 0 auto' }
+        }, ['Select a Billing Project']
         )],
         [!hasBillingProjects, () => noBillingMessage(showCreateProjectModal)]
       )]),

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -13,7 +13,7 @@ import { useWorkspaces } from 'src/components/workspace-utils'
 import { Ajax } from 'src/libs/ajax'
 import * as Auth from 'src/libs/auth'
 import colors from 'src/libs/colors'
-import { withErrorReporting } from 'src/libs/error'
+import { reportErrorAndRethrow } from 'src/libs/error'
 import Events from 'src/libs/events'
 import { FormLabel } from 'src/libs/forms'
 import * as Nav from 'src/libs/nav'
@@ -287,7 +287,7 @@ const ProjectDetail = ({ billingProject, reloadBillingProject, billingAccounts, 
 
   // Helpers
   const setBillingAccount = _.flow(
-    withErrorReporting('Error updating billing account'),
+    reportErrorAndRethrow('Error updating billing account'),
     Utils.withBusyState(setUpdating)
   )(newAccountName => {
     Ajax().Metrics.captureEvent(Events.changeBillingAccount, {
@@ -302,7 +302,7 @@ const ProjectDetail = ({ billingProject, reloadBillingProject, billingAccounts, 
   })
 
   const updateSpendConfiguration = _.flow(
-    withErrorReporting('Error updating workflow spend report configuration'),
+    reportErrorAndRethrow('Error updating workflow spend report configuration'),
     Utils.withBusyState(setUpdating)
   )(() => Ajax(signal).Billing.updateSpendConfiguration({
     billingProjectName: billingProject.projectName,
@@ -318,7 +318,7 @@ const ProjectDetail = ({ billingProject, reloadBillingProject, billingAccounts, 
   )
 
   const reloadBillingProjectUsers = _.flow(
-    withErrorReporting('Error loading billing project users list'),
+    reportErrorAndRethrow('Error loading billing project users list'),
     Utils.withBusyState(setUpdating)
   )(() => Ajax(signal).Billing.project(billingProject.projectName).listUsers()
     .then(collectUserRoles)
@@ -326,7 +326,7 @@ const ProjectDetail = ({ billingProject, reloadBillingProject, billingAccounts, 
   )
 
   const removeUserFromBillingProject = _.flow(
-    withErrorReporting('Error removing member from billing project'),
+    reportErrorAndRethrow('Error removing member from billing project'),
     Utils.withBusyState(setUpdating)
   )(Ajax().Billing.project(billingProject.projectName).removeUser)
 

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -185,7 +185,7 @@ const groupByBillingAccountStatus = (billingProject, workspaces) => {
   return _.mapValues(ws => new Set(ws), _.groupBy(group, workspaces))
 }
 
-const ProjectDetail = ({ billingProject, billingAccounts, authorizeAndLoadAccounts, updateProject }) => {
+const ProjectDetail = ({ billingProject, updateBillingProject, billingAccounts, authorizeAndLoadAccounts }) => {
   // State
   const { query } = Nav.useRoute()
   // Rather than using a localized StateHistory store here, we use the existing `workspaceStore` value (via the `useWorkspaces` hook)
@@ -310,7 +310,7 @@ const ProjectDetail = ({ billingProject, billingAccounts, authorizeAndLoadAccoun
     datasetName: selectedDatasetName
   }))
 
-  const updateProjectUsers = _.flow(
+  const updateBillingProjectUsers = _.flow(
     withErrorReporting('Error loading billing project users list'),
     Utils.withBusyState(setRefreshing)
   )(() => Ajax(signal).Billing.project(billingProject.projectName).listUsers()
@@ -322,7 +322,7 @@ const ProjectDetail = ({ billingProject, billingAccounts, authorizeAndLoadAccoun
     .then(setProjectUsers))
 
   // Lifecycle
-  Utils.useOnMount(() => { updateProjectUsers() })
+  Utils.useOnMount(() => { updateBillingProjectUsers() })
 
   useEffect(() => { StateHistory.update({ projectUsers }) }, [projectUsers])
 
@@ -362,7 +362,7 @@ const ProjectDetail = ({ billingProject, billingAccounts, authorizeAndLoadAccoun
             disabled: !selectedBilling || billingProject.billingAccount === selectedBilling,
             onClick: () => {
               setShowBillingModal(false)
-              setBillingAccount(selectedBilling).then(updateProject)
+              setBillingAccount(selectedBilling).then(updateBillingProject)
             }
           }, ['Ok'])
         }, [
@@ -434,7 +434,7 @@ const ProjectDetail = ({ billingProject, billingAccounts, authorizeAndLoadAccoun
         value: tab,
         onChange: newTab => {
           if (newTab === tab) {
-            updateProjectUsers()
+            updateBillingProjectUsers()
           } else {
             setTab(newTab)
           }
@@ -461,7 +461,7 @@ const ProjectDetail = ({ billingProject, billingAccounts, authorizeAndLoadAccoun
       onDismiss: () => setAddingUser(false),
       onSuccess: () => {
         setAddingUser(false)
-        updateProjectUsers()
+        updateBillingProjectUsers()
       }
     }),
     editingUser && h(EditUserModal, {
@@ -472,8 +472,8 @@ const ProjectDetail = ({ billingProject, billingAccounts, authorizeAndLoadAccoun
       onDismiss: () => setEditingUser(false),
       onSuccess: () => {
         setEditingUser(false)
-        updateProject()
-        updateProjectUsers()
+        updateBillingProject()
+        updateBillingProjectUsers()
       }
     }),
     !!deletingUser && h(DeleteUserModal, {
@@ -485,8 +485,8 @@ const ProjectDetail = ({ billingProject, billingAccounts, authorizeAndLoadAccoun
           Utils.withBusyState(setUpdating)
         )(() => Ajax().Billing.project(billingProject.projectName).removeUser(deletingUser.roles, deletingUser.email))()
         setDeletingUser(false)
-        updateProject()
-        updateProjectUsers()
+        updateBillingProject()
+        updateBillingProjectUsers()
       }
     }),
     billingAccountsOutOfDate && h(BillingAccountSummaryPanel, { counts: _.mapValues(_.size, groups) }),

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -185,7 +185,7 @@ const groupByBillingAccountStatus = (billingProject, workspaces) => {
   return _.mapValues(ws => new Set(ws), _.groupBy(group, workspaces))
 }
 
-const ProjectDetail = ({ billingProject, billingAccounts, authorizeAndLoadAccounts, invalidateProjectAndReload }) => {
+const ProjectDetail = ({ billingProject, billingAccounts, authorizeAndLoadAccounts, updateProjectAndReload }) => {
   // State
   const { query } = Nav.useRoute()
   // Rather than using a localized StateHistory store here, we use the existing `workspaceStore` value (via the `useWorkspaces` hook)
@@ -298,7 +298,7 @@ const ProjectDetail = ({ billingProject, billingAccounts, authorizeAndLoadAccoun
         billingProjectName: billingProject.projectName,
         newBillingAccountName: newAccountName
       })
-      invalidateProjectAndReload()
+      updateProjectAndReload()
     }
   )
 

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -310,7 +310,7 @@ const ProjectDetail = ({ billingProject, billingAccounts, authorizeAndLoadAccoun
     datasetName: selectedDatasetName
   }))
 
-  const refreshUsers = _.flow(
+  const updateProjectUsers = _.flow(
     withErrorReporting('Error loading billing project users list'),
     Utils.withBusyState(setRefreshing)
   )(() => Ajax(signal).Billing.project(billingProject.projectName).listUsers()
@@ -322,7 +322,7 @@ const ProjectDetail = ({ billingProject, billingAccounts, authorizeAndLoadAccoun
     .then(setProjectUsers))
 
   // Lifecycle
-  Utils.useOnMount(() => { refreshUsers() })
+  Utils.useOnMount(() => { updateProjectUsers() })
 
   useEffect(() => { StateHistory.update({ projectUsers }) }, [projectUsers])
 
@@ -434,7 +434,7 @@ const ProjectDetail = ({ billingProject, billingAccounts, authorizeAndLoadAccoun
         value: tab,
         onChange: newTab => {
           if (newTab === tab) {
-            refreshUsers()
+            updateProjectUsers()
           } else {
             setTab(newTab)
           }
@@ -461,7 +461,7 @@ const ProjectDetail = ({ billingProject, billingAccounts, authorizeAndLoadAccoun
       onDismiss: () => setAddingUser(false),
       onSuccess: () => {
         setAddingUser(false)
-        refreshUsers()
+        updateProjectUsers()
       }
     }),
     editingUser && h(EditUserModal, {
@@ -473,7 +473,7 @@ const ProjectDetail = ({ billingProject, billingAccounts, authorizeAndLoadAccoun
       onSuccess: () => {
         setEditingUser(false)
         updateProject()
-        refreshUsers()
+        updateProjectUsers()
       }
     }),
     !!deletingUser && h(DeleteUserModal, {
@@ -486,7 +486,7 @@ const ProjectDetail = ({ billingProject, billingAccounts, authorizeAndLoadAccoun
         )(() => Ajax().Billing.project(billingProject.projectName).removeUser(deletingUser.roles, deletingUser.email))()
         setDeletingUser(false)
         updateProject()
-        refreshUsers()
+        updateProjectUsers()
       }
     }),
     billingAccountsOutOfDate && h(BillingAccountSummaryPanel, { counts: _.mapValues(_.size, groups) }),


### PR DESCRIPTION
RR: https://broadworkbench.atlassian.net/browse/CA-1539
Introduce `updateBillingProject` callback triggered when billing
account is changed. This updates the parent component's state (ie
billing project list) and redraws the `ProjectDetail` component.

Prevent users from seeing a specified billing project when they're not a billing project owner.

Add `reportErrorsAndRethrow` utility to preserve failed
state of Promises. `withErrorReporting` reports the error then returns a successful
promise. This breaks processing sequences like the following where
successive operations should only be performed if the previous succeeds:

```javascript
async () => {
    await doSomethingDangerous()
    await shouldNotBeCalledIfPreviousOperationFails()
}
```

By returning a failed promise in `reportErrorsAndRethrow` the intended
effect is restored. 