### PR TITLE
[AS-975] 'select all in filter' for data tables

### DIFF
--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -120,7 +120,7 @@ const DataTable = props => {
     Utils.withBusyState(setLoading),
     withErrorReporting('Error loading entities')
   )(async () => {
-    const params = _.merge({pageSize: filteredCount}, activeTextFilter ? {filterTerms: activeTextFilter} : {})
+    const params = _.merge({ pageSize: filteredCount }, activeTextFilter ? { filterTerms: activeTextFilter } : {})
     const queryResults = await Ajax(signal).Workspaces.workspace(namespace, name).paginatedEntitiesOfType(entityType, params)
     setSelected(entityMap(queryResults.results))
   })
@@ -217,7 +217,7 @@ const DataTable = props => {
                         content: h(Fragment, [
                           h(MenuButton, { onClick: selectPage }, ['Page']),
                           h(MenuButton, { onClick: selectAll },
-                            ((totalRowCount == filteredCount) ? [`All (${filteredCount})`] : [`Filtered (${filteredCount})`])),
+                            ((totalRowCount === filteredCount) ? [`All (${filteredCount})`] : [`Filtered (${filteredCount})`])),
                           h(MenuButton, { onClick: selectNone }, ['None'])
                         ]),
                         side: 'bottom'

--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -216,8 +216,8 @@ const DataTable = props => {
                         closeOnClick: true,
                         content: h(Fragment, [
                           h(MenuButton, { onClick: selectPage }, ['Page']),
-                          h(MenuButton, { onClick: selectAll },
-                            ((totalRowCount === filteredCount) ? [`All (${filteredCount})`] : [`Filtered (${filteredCount})`])),
+                          !!filteredCount && (h(MenuButton, { onClick: selectAll },
+                            ((totalRowCount === filteredCount) ? [`All (${filteredCount})`] : [`Filtered (${filteredCount})`]))),
                           h(MenuButton, { onClick: selectNone }, ['None'])
                         ]),
                         side: 'bottom'

--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -105,12 +105,12 @@ const DataTable = props => {
     withErrorReporting('Error loading entities')
   )(async () => {
     const { results, resultMetadata: { filteredCount, unfilteredCount } } = await Ajax(signal).Workspaces.workspace(namespace, name)
-      .paginatedEntitiesOfType(entityType, {
+      .paginatedEntitiesOfType(entityType, _.pickBy(_.trim, {
         page: pageNumber, pageSize: itemsPerPage, sortField: sort.field, sortDirection: sort.direction,
         ...(!!snapshotName ?
           { billingProject: googleProject, dataReference: snapshotName } :
           { filterTerms: activeTextFilter })
-      })
+      }))
     setEntities(results)
     setFilteredCount(filteredCount)
     setTotalRowCount(unfilteredCount)
@@ -120,7 +120,7 @@ const DataTable = props => {
     Utils.withBusyState(setLoading),
     withErrorReporting('Error loading entities')
   )(async () => {
-    const params = _.merge({ pageSize: filteredCount }, activeTextFilter ? { filterTerms: activeTextFilter } : {})
+    const params = _.pickBy(_.trim, { pageSize: filteredCount, filterTerms: activeTextFilter })
     const queryResults = await Ajax(signal).Workspaces.workspace(namespace, name).paginatedEntitiesOfType(entityType, params)
     setSelected(entityMap(queryResults.results))
   })

--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -120,8 +120,9 @@ const DataTable = props => {
     Utils.withBusyState(setLoading),
     withErrorReporting('Error loading entities')
   )(async () => {
-    const results = await Ajax(signal).Workspaces.workspace(namespace, name).entitiesOfType(entityType)
-    setSelected(entityMap(results))
+    const params = _.merge({pageSize: filteredCount}, activeTextFilter ? {filterTerms: activeTextFilter} : {})
+    const queryResults = await Ajax(signal).Workspaces.workspace(namespace, name).paginatedEntitiesOfType(entityType, params)
+    setSelected(entityMap(queryResults.results))
   })
 
   const selectPage = () => {
@@ -215,7 +216,8 @@ const DataTable = props => {
                         closeOnClick: true,
                         content: h(Fragment, [
                           h(MenuButton, { onClick: selectPage }, ['Page']),
-                          h(MenuButton, { onClick: selectAll }, [`All (${totalRowCount})`]),
+                          h(MenuButton, { onClick: selectAll },
+                            ((totalRowCount == filteredCount) ? [`All (${filteredCount})`] : [`Filtered (${filteredCount})`])),
                           h(MenuButton, { onClick: selectNone }, ['None'])
                         ]),
                         side: 'bottom'

--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -179,7 +179,7 @@ const DataTable = props => {
             'aria-label': 'Search',
             placeholder: 'Search',
             onChange: v => {
-              setActiveTextFilter(v)
+              setActiveTextFilter(v.toString().trim())
               setPageNumber(1)
             },
             defaultValue: activeTextFilter

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -795,11 +795,6 @@ const Workspaces = signal => ({
 
       upsertEntities,
 
-      entitiesOfType: async type => {
-        const res = await fetchRawls(`${root}/entities/${type}`, _.merge(authOpts(), { signal }))
-        return res.json()
-      },
-
       paginatedEntitiesOfType: async (type, parameters) => {
         const res = await fetchRawls(`${root}/entityQuery/${type}?${qs.stringify(parameters)}`, _.merge(authOpts(), { signal }))
         return res.json()


### PR DESCRIPTION
We have UX approval for this! All set as-is.

PR site https://pr-8-dot-bvdp-saturn-dev.appspot.com/ shows this in action!

-----

This PR changes the "select all" feature of a data table to follow the text filter currently in use. When there is no text filter, the "select all" says "All (nnn)" and selects all rows of that type:
![Screenshot-nofilter](https://user-images.githubusercontent.com/6041577/136462185-22f33642-d805-46e3-bf0f-6507a02743aa.png)

When there is a text filter, the menu item says "Filtered (nnn)" and selects only those rows that match the user's current filter:
![Screenshot-filtered](https://user-images.githubusercontent.com/6041577/136462190-89cef898-5571-4fa3-a646-26104db19b5c.png)

Additionally, I've changed the backend API call powering this menu item away from the to-be-deprecated list-all-entities API, and instead it now uses the paginated-entities API … but specifying a page size that still returns all entities. Using the paginated API is necessary to support the text filter.

AS-956 tracks further optimizations for this feature, such as not needing to make an API call at all.

