### PR TITLE
[AS-997] Disable snapshot data tables for readers

### DIFF
--- a/src/components/workspace-utils.js
+++ b/src/components/workspace-utils.js
@@ -73,7 +73,7 @@ const SnapshotLabeledInfo = ({ title, text }) => {
 }
 
 export const SnapshotInfo = ({
-  workspace: { workspace, workspace: { namespace, name } }, resource: { resourceId, description, snapshotId }, snapshotName,
+  workspace: { canCompute, workspace, workspace: { namespace, name } }, resource: { resourceId, description, snapshotId }, snapshotName,
   onUpdate, onDelete
 }) => {
   // State
@@ -132,7 +132,7 @@ export const SnapshotInfo = ({
           }
         }, [
           snapshotName,
-          !editingDescription && h(Link, {
+          canCompute && !editingName && h(Link, {
             style: { marginLeft: '0.5rem' },
             onClick: () => setEditingName(true),
             tooltip: 'Edit snapshot name'
@@ -140,7 +140,7 @@ export const SnapshotInfo = ({
         ]),
         div({ style: { ...Style.elements.sectionHeader, marginBottom: '0.2rem' } }, [
           'Description:',
-          !editingDescription && h(Link, {
+          canCompute && !editingDescription && h(Link, {
             style: { marginLeft: '0.5rem' },
             onClick: () => setNewDescription(description || ''), // description is null for newly-added snapshot references
             tooltip: 'Edit description'
@@ -177,7 +177,7 @@ export const SnapshotInfo = ({
           ])
         }, source)
       ]),
-      div({ style: { marginTop: '2rem' } }, [
+      canCompute && div({ style: { marginTop: '2rem' } }, [
         h(ButtonSecondary, { onClick: () => setDeleting(true) }, ['Delete snapshot from workspace'])
       ]),
       editingName && h(Modal, {

--- a/src/components/workspace-utils.js
+++ b/src/components/workspace-utils.js
@@ -73,7 +73,7 @@ const SnapshotLabeledInfo = ({ title, text }) => {
 }
 
 export const SnapshotInfo = ({
-  workspace: { canCompute, workspace, workspace: { namespace, name } }, resource: { resourceId, description, snapshotId }, snapshotName,
+  workspace: { accessLevel, workspace, workspace: { namespace, name } }, resource: { resourceId, description, snapshotId }, snapshotName,
   onUpdate, onDelete
 }) => {
   // State
@@ -132,7 +132,7 @@ export const SnapshotInfo = ({
           }
         }, [
           snapshotName,
-          canCompute && !editingName && h(Link, {
+          Utils.canWrite(accessLevel) && !editingName && h(Link, {
             style: { marginLeft: '0.5rem' },
             onClick: () => setEditingName(true),
             tooltip: 'Edit snapshot name'
@@ -140,7 +140,7 @@ export const SnapshotInfo = ({
         ]),
         div({ style: { ...Style.elements.sectionHeader, marginBottom: '0.2rem' } }, [
           'Description:',
-          canCompute && !editingDescription && h(Link, {
+          Utils.canWrite(accessLevel) && !editingDescription && h(Link, {
             style: { marginLeft: '0.5rem' },
             onClick: () => setNewDescription(description || ''), // description is null for newly-added snapshot references
             tooltip: 'Edit description'
@@ -177,7 +177,7 @@ export const SnapshotInfo = ({
           ])
         }, source)
       ]),
-      canCompute && div({ style: { marginTop: '2rem' } }, [
+      Utils.canWrite(accessLevel) && div({ style: { marginTop: '2rem' } }, [
         h(ButtonSecondary, { onClick: () => setDeleting(true) }, ['Delete snapshot from workspace'])
       ]),
       editingName && h(Modal, {

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -561,8 +561,8 @@ const WorkspaceData = _.flow(
                     return h(DataTypeButton, {
                       buttonStyle: canCompute ? { borderBottom: 0, height: 40 } : { borderBottom: 0, height: 40, color: colors.dark(0.25) },
                       tooltip: canCompute ? (tableName ? `${tableName} (${count} row${count === 1 ? '' : 's'})` : undefined) :
-                        'You must be an owner, or a writer with compute permission, to view this snapshot. ' +
-                        'Contact the owner of this workspace in order to change your permissions.',
+                        [h(div, { style: { whiteSpace: 'pre-wrap' } }, 'You must be an owner, or a writer with compute permission, to view this snapshot.\n\n' +
+                        'Contact the owner of this workspace in order to change your permissions.')],
                       tooltipSide: canCompute ? 'bottom' : 'left',
                       key: `${snapshotName}_${tableName}`,
                       selected: _.isEqual(selectedDataType, [snapshotName, tableName]),

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -561,7 +561,8 @@ const WorkspaceData = _.flow(
                     return h(DataTypeButton, {
                       buttonStyle: canCompute ? { borderBottom: 0, height: 40 } : { borderBottom: 0, height: 40, color: colors.dark(0.25) },
                       tooltip: canCompute ? (tableName ? `${tableName} (${count} row${count === 1 ? '' : 's'})` : undefined) :
-                        'You must have Can Compute, Owner, or Project Owner permission on this workspace to view snapshot table contents.',
+                        'You must be an owner, or a writer with compute permission, to view this snapshot. ' +
+                        'Contact the owner of this workspace in order to change your permissions.',
                       key: `${snapshotName}_${tableName}`,
                       selected: _.isEqual(selectedDataType, [snapshotName, tableName]),
                       entityName: tableName,

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -562,8 +562,6 @@ const WorkspaceData = _.flow(
                       buttonStyle: canCompute ? { borderBottom: 0, height: 40 } : { borderBottom: 0, height: 40, color: colors.dark(0.25) },
                       tooltip: canCompute ? (tableName ? `${tableName} (${count} row${count === 1 ? '' : 's'})` : undefined) :
                         'You must have Can Compute, Owner, or Project Owner permission on this workspace to view snapshot table contents.',
-                      tooltipDelay: 250,
-                      useTooltipAsLabel: true,
                       key: `${snapshotName}_${tableName}`,
                       selected: _.isEqual(selectedDataType, [snapshotName, tableName]),
                       entityName: tableName,

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -559,7 +559,7 @@ const WorkspaceData = _.flow(
                   _.map(([tableName, { count }]) => {
                     const canCompute = !!(workspace?.canCompute)
                     return h(DataTypeButton, {
-                      buttonStyle: canCompute ? { borderBottom: 0, height: 40 } : { borderBottom: 0, height: 40, color: colors.dark(0.25) },
+                      buttonStyle: { borderBottom: 0, height: 40, ...(canCompute ? {} : {color: colors.dark(0.25)}) },
                       tooltip: canCompute ?
                         tableName ? `${tableName} (${count} row${count === 1 ? '' : 's'})` : undefined :
                         [div({ key: `${tableName}-tooltip`, style: { whiteSpace: 'pre-wrap' } }, 'You must be an owner, or a writer with compute permission, to view this snapshot.\n\n' +

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -560,7 +560,8 @@ const WorkspaceData = _.flow(
                     const canCompute = !!(workspace?.canCompute)
                     return h(DataTypeButton, {
                       buttonStyle: canCompute ? { borderBottom: 0, height: 40 } : { borderBottom: 0, height: 40, color: colors.dark(0.25) },
-                      tooltip: canCompute ? (tableName ? `${tableName} (${count} row${count === 1 ? '' : 's'})` : undefined) :
+                      tooltip: canCompute ?
+                        tableName ? `${tableName} (${count} row${count === 1 ? '' : 's'})` : undefined :
                         [h(div, { style: { whiteSpace: 'pre-wrap' } }, 'You must be an owner, or a writer with compute permission, to view this snapshot.\n\n' +
                         'Contact the owner of this workspace in order to change your permissions.')],
                       tooltipSide: canCompute ? 'bottom' : 'left',

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -562,7 +562,7 @@ const WorkspaceData = _.flow(
                       buttonStyle: canCompute ? { borderBottom: 0, height: 40 } : { borderBottom: 0, height: 40, color: colors.dark(0.25) },
                       tooltip: canCompute ?
                         tableName ? `${tableName} (${count} row${count === 1 ? '' : 's'})` : undefined :
-                        [div({ style: { whiteSpace: 'pre-wrap' } }, 'You must be an owner, or a writer with compute permission, to view this snapshot.\n\n' +
+                        [div({ key: `${tableName}-tooltip`, style: { whiteSpace: 'pre-wrap' } }, 'You must be an owner, or a writer with compute permission, to view this snapshot.\n\n' +
                         'Contact the owner of this workspace in order to change your permissions.')],
                       tooltipSide: canCompute ? 'bottom' : 'left',
                       key: `${snapshotName}_${tableName}`,

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -563,7 +563,7 @@ const WorkspaceData = _.flow(
                       tooltip: canCompute ?
                         tableName ? `${tableName} (${count} row${count === 1 ? '' : 's'})` : undefined :
                         [div({ key: `${tableName}-tooltip`, style: { whiteSpace: 'pre-wrap' } }, 'You must be an owner, or a writer with compute permission, to view this snapshot.\n\n' +
-                        'Contact the owner of this workspace in order to change your permissions.')],
+                        'Contact the owner of this workspace to change your permissions.')],
                       tooltipSide: canCompute ? 'bottom' : 'left',
                       key: `${snapshotName}_${tableName}`,
                       selected: _.isEqual(selectedDataType, [snapshotName, tableName]),

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -563,6 +563,7 @@ const WorkspaceData = _.flow(
                       tooltip: canCompute ? (tableName ? `${tableName} (${count} row${count === 1 ? '' : 's'})` : undefined) :
                         'You must be an owner, or a writer with compute permission, to view this snapshot. ' +
                         'Contact the owner of this workspace in order to change your permissions.',
+                      tooltipSide: canCompute ? 'bottom' : 'left',
                       key: `${snapshotName}_${tableName}`,
                       selected: _.isEqual(selectedDataType, [snapshotName, tableName]),
                       entityName: tableName,

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -561,8 +561,8 @@ const WorkspaceData = _.flow(
                     const canCompute = !!(workspace?.canCompute)
                     return h(DataTypeButton, {
                       // TODO: if reader, should be greyed out. What's the right color style? Any other styling?
-                      buttonStyle: canCompute ? { borderBottom: 0, height: 40 } : { borderBottom: 0, height: 40, color: '#ddd'},
-                      // TODO: how to override the tooltip only if the user doesn't have compute? If user does have compute, we want to 
+                      buttonStyle: canCompute ? { borderBottom: 0, height: 40 } : { borderBottom: 0, height: 40, color: '#ddd' },
+                      // TODO: how to override the tooltip only if the user doesn't have compute? If user does have compute, we want to
                       // use the default tooltip.
                       tooltip: canCompute ? (tableName ? `${tableName} (${count} row${count === 1 ? '' : 's'})` : undefined) : 'You must have compute',
                       tooltipDelay: 250,

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -564,7 +564,8 @@ const WorkspaceData = _.flow(
                       buttonStyle: canCompute ? { borderBottom: 0, height: 40 } : { borderBottom: 0, height: 40, color: '#ddd' },
                       // TODO: how to override the tooltip only if the user doesn't have compute? If user does have compute, we want to
                       // use the default tooltip.
-                      tooltip: canCompute ? (tableName ? `${tableName} (${count} row${count === 1 ? '' : 's'})` : undefined) : 'You must have compute',
+                      tooltip: canCompute ? (tableName ? `${tableName} (${count} row${count === 1 ? '' : 's'})` : undefined) :
+                        'You must have Can Compute, Owner, or Project Owner permission on this workspace to view snapshot table contents.',
                       tooltipDelay: 250,
                       useTooltipAsLabel: true,
                       key: `${snapshotName}_${tableName}`,

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -557,21 +557,32 @@ const WorkspaceData = _.flow(
                 ])],
                 () => div({ role: 'list', style: { fontSize: 14, lineHeight: '1.5' } }, [
                   _.map(([tableName, { count }]) => {
+                    // TODO: is this the correct permission to check? Is this reliable?
+                    const canCompute = !!(workspace?.canCompute)
                     return h(DataTypeButton, {
-                      buttonStyle: { borderBottom: 0, height: 40 },
+                      // TODO: if reader, should be greyed out. What's the right color style? Any other styling?
+                      buttonStyle: canCompute ? { borderBottom: 0, height: 40 } : { borderBottom: 0, height: 40, color: '#ddd'},
+                      // TODO: how to override the tooltip only if the user doesn't have compute? If user does have compute, we want to 
+                      // use the default tooltip.
+                      tooltip: canCompute ? (tableName ? `${tableName} (${count} row${count === 1 ? '' : 's'})` : undefined) : 'You must have compute',
+                      tooltipDelay: 250,
+                      useTooltipAsLabel: true,
                       key: `${snapshotName}_${tableName}`,
                       selected: _.isEqual(selectedDataType, [snapshotName, tableName]),
                       entityName: tableName,
                       entityCount: count,
                       onClick: () => {
-                        setSelectedDataType([snapshotName, tableName])
-                        Ajax().Metrics.captureEvent(Events.workspaceSnapshotContentsView, {
-                          ...extractWorkspaceDetails(workspace.workspace),
-                          resourceId,
-                          snapshotId,
-                          entityType: tableName
-                        })
-                        forceRefresh()
+                        // TODO: if reader, click should do nothing. Should the click instead pop up an error message?
+                        if (canCompute) {
+                          setSelectedDataType([snapshotName, tableName])
+                          Ajax().Metrics.captureEvent(Events.workspaceSnapshotContentsView, {
+                            ...extractWorkspaceDetails(workspace.workspace),
+                            resourceId,
+                            snapshotId,
+                            entityType: tableName
+                          })
+                          forceRefresh()
+                        }
                       }
                     }, [`${tableName} (${count})`])
                   }, snapshotTablePairs)

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -557,13 +557,9 @@ const WorkspaceData = _.flow(
                 ])],
                 () => div({ role: 'list', style: { fontSize: 14, lineHeight: '1.5' } }, [
                   _.map(([tableName, { count }]) => {
-                    // TODO: is this the correct permission to check? Is this reliable?
                     const canCompute = !!(workspace?.canCompute)
                     return h(DataTypeButton, {
-                      // TODO: if reader, should be greyed out. What's the right color style? Any other styling?
-                      buttonStyle: canCompute ? { borderBottom: 0, height: 40 } : { borderBottom: 0, height: 40, color: '#ddd' },
-                      // TODO: how to override the tooltip only if the user doesn't have compute? If user does have compute, we want to
-                      // use the default tooltip.
+                      buttonStyle: canCompute ? { borderBottom: 0, height: 40 } : { borderBottom: 0, height: 40, color: colors.dark(0.25) },
                       tooltip: canCompute ? (tableName ? `${tableName} (${count} row${count === 1 ? '' : 's'})` : undefined) :
                         'You must have Can Compute, Owner, or Project Owner permission on this workspace to view snapshot table contents.',
                       tooltipDelay: 250,
@@ -573,7 +569,6 @@ const WorkspaceData = _.flow(
                       entityName: tableName,
                       entityCount: count,
                       onClick: () => {
-                        // TODO: if reader, click should do nothing. Should the click instead pop up an error message?
                         if (canCompute) {
                           setSelectedDataType([snapshotName, tableName])
                           Ajax().Metrics.captureEvent(Events.workspaceSnapshotContentsView, {

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -562,7 +562,7 @@ const WorkspaceData = _.flow(
                       buttonStyle: canCompute ? { borderBottom: 0, height: 40 } : { borderBottom: 0, height: 40, color: colors.dark(0.25) },
                       tooltip: canCompute ?
                         tableName ? `${tableName} (${count} row${count === 1 ? '' : 's'})` : undefined :
-                        [h(div, { style: { whiteSpace: 'pre-wrap' } }, 'You must be an owner, or a writer with compute permission, to view this snapshot.\n\n' +
+                        [div({ style: { whiteSpace: 'pre-wrap' } }, 'You must be an owner, or a writer with compute permission, to view this snapshot.\n\n' +
                         'Contact the owner of this workspace in order to change your permissions.')],
                       tooltipSide: canCompute ? 'bottom' : 'left',
                       key: `${snapshotName}_${tableName}`,

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -559,7 +559,7 @@ const WorkspaceData = _.flow(
                   _.map(([tableName, { count }]) => {
                     const canCompute = !!(workspace?.canCompute)
                     return h(DataTypeButton, {
-                      buttonStyle: { borderBottom: 0, height: 40, ...(canCompute ? {} : {color: colors.dark(0.25)}) },
+                      buttonStyle: { borderBottom: 0, height: 40, ...(canCompute ? {} : { color: colors.dark(0.25) }) },
                       tooltip: canCompute ?
                         tableName ? `${tableName} (${count} row${count === 1 ? '' : 's'})` : undefined :
                         [div({ key: `${tableName}-tooltip`, style: { whiteSpace: 'pre-wrap' } }, 'You must be an owner, or a writer with compute permission, to view this snapshot.\n\n' +


### PR DESCRIPTION
PR site https://pr-9-dot-bvdp-saturn-dev.appspot.com/ shows this in action!


Changes in this PR:
* for users who currently do not have permissions (`bigquery.jobs.create`) to view snapshot contents, disable the snapshot tables and provide a helpful tooltip instead
    * Users who have `bigquery.jobs.create` are: Writers with CanCompute, Owners, and Project Owners
* for users who currently do not have write permissions on the workspace, disable editing of the snapshot name/description and remove the link to delete the snapshot from the workspace

Tested manually on a workspace to which I added dev accounts at every permission level.

PO approval: 👍 
UX approval: 👍 

Behavior for Project Owners, Owners, and Writers with can-compute (this behavior is unchanged):
![Screenshot - snap compute](https://user-images.githubusercontent.com/6041577/137017434-27f21648-26a8-4a24-aaec-6ae9b29092e9.png)

**_OLD_** Behavior for Readers and Writers without can-compute - we allowed users to click on a snapshot table; that click led to an error:
![Screenshot - snap no compute OLD](https://user-images.githubusercontent.com/6041577/137149398-e009e8ee-d738-4095-91a7-af0a9e888162.png)

**_NEW_** Behavior for Readers and Writers without can-compute - we disable clicks on snapshot tables and show a tooltip instead:
![Screen Shot 2021-10-15 at 12 52 44 PM](https://user-images.githubusercontent.com/6041577/137524551-ad5e0d37-5a66-449d-ad93-cbef21543958.png)


