### PR TITLE
[AS-998] don't poll for the same import job twice

### DIFF
--- a/src/components/ImportStatus.js
+++ b/src/components/ImportStatus.js
@@ -15,7 +15,7 @@ const ImportStatus = () => {
     onDone: () => {
       asyncImportJobStore.update(_.reject({ jobId: job.jobId }))
     }
-  }), jobs))
+  }), _.uniq(jobs)))
 }
 
 const ImportStatusItem = ({ job: { targetWorkspace, jobId }, onDone }) => {

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -453,7 +453,7 @@ const WorkspaceData = _.flow(
       const currentJobIds = _.map('jobId', asyncImportJobStore.get())
       _.forEach(job => {
         const jobStatus = _.lowerCase(job.status)
-        if (!_.includes(jobStatus, ['success', 'error', 'done']) && _.indexOf(job.jobId, currentJobIds) === -1) {
+        if (!_.includes(jobStatus, ['success', 'error', 'done']) && !_.includes(job.jobId, currentJobIds)) {
           asyncImportJobStore.update(Utils.append({ targetWorkspace: { namespace, name }, jobId: job.jobId }))
         }
       }, runningJobs)

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -450,7 +450,7 @@ const WorkspaceData = _.flow(
   const getRunningImportJobs = async () => {
     try {
       const runningJobs = await Ajax(signal).Workspaces.workspace(namespace, name).listImportJobs(true)
-      const currentJobIds = _.map( 'jobId', asyncImportJobStore.get())
+      const currentJobIds = _.map('jobId', asyncImportJobStore.get())
       _.forEach(job => {
         const jobStatus = _.lowerCase(job.status)
         if (!_.includes(jobStatus, ['success', 'error', 'done']) && _.indexOf(job.jobId, currentJobIds) === -1) {

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -450,9 +450,10 @@ const WorkspaceData = _.flow(
   const getRunningImportJobs = async () => {
     try {
       const runningJobs = await Ajax(signal).Workspaces.workspace(namespace, name).listImportJobs(true)
+      const currentJobIds = _.map( 'jobId', asyncImportJobStore.get())
       _.forEach(job => {
         const jobStatus = _.lowerCase(job.status)
-        if (!_.includes(jobStatus, ['success', 'error', 'done'])) {
+        if (!_.includes(jobStatus, ['success', 'error', 'done']) && _.indexOf(job.jobId, currentJobIds) === -1) {
           asyncImportJobStore.update(Utils.append({ targetWorkspace: { namespace, name }, jobId: job.jobId }))
         }
       }, runningJobs)


### PR DESCRIPTION
[AS-998](https://broadworkbench.atlassian.net/browse/AS-998). Tested locally via dev tools.

* when entering a workspace and finding outstanding import jobs, only add those jobs to the `asyncImportJobStore` if they don't already exist in `asyncImportJobStore`
* when creating the polling jobs, run `_.uniq` on `asyncImportJobStore` for safety. This shouldn't be necessary but exists as a safeguard in case some future code also adds duplicate jobs to `asyncImportJobStore`.