### PR TITLE
[IA-3010] Fix compute type drop-down default

### DIFF
--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -623,7 +623,8 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
         const gpuConfig = runtimeConfig?.gpuConfig
         const newSparkMode = Utils.switchCase(runtimeConfig?.cloudService,
           [cloudServices.DATAPROC, () => runtimeConfig.numberOfWorkers === 0 ? 'master' : 'cluster'],
-          [cloudServices.GCE, () => false]
+          [cloudServices.GCE, () => false],
+          [undefined, () => false] // for when there's no existing runtime
         )
         const isDataproc = !sparkMode && !runtimeConfig?.diskSize
 

--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -624,7 +624,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
         const newSparkMode = Utils.switchCase(runtimeConfig?.cloudService,
           [cloudServices.DATAPROC, () => runtimeConfig.numberOfWorkers === 0 ? 'master' : 'cluster'],
           [cloudServices.GCE, () => false],
-          [undefined, () => false] // for when there's no existing runtime
+          [Utils.DEFAULT, () => false] // for when there's no existing runtime
         )
         const isDataproc = !sparkMode && !runtimeConfig?.diskSize
 


### PR DESCRIPTION
This PR fixes the bug I introduced with the [Spark UI PR](https://github.com/DataBiosphere/terra-ui/pull/2643) such that 

![Screen Shot 2021-10-19 at 5 54 48 PM](https://user-images.githubusercontent.com/5438223/137997084-31f7ec68-d829-4ad8-a5de-dec7cf577813.jpg)

looks like

![Screen Shot 2021-10-19 at 5 55 40 PM](https://user-images.githubusercontent.com/5438223/137997102-f7f4d90b-7f5b-4bec-b846-c05d499c4f0e.jpg)

again.

Tested locally.
