### PR TITLE
[DR-2182] Add autocompletion

### DIFF
--- a/src/components/input.js
+++ b/src/components/input.js
@@ -230,15 +230,17 @@ const AutocompleteSuggestions = ({ target: targetId, containerProps, children })
 }
 
 const withAutocomplete = WrappedComponent => ({
-  instructions, value, onChange, onPick, suggestions: rawSuggestions, style, id, labelId,
-  renderSuggestion = _.identity, openOnFocus = true, placeholderText, ...props
+  instructions, itemToString, value, onChange, onPick, suggestions: rawSuggestions, style, id, labelId,
+  renderSuggestion = _.identity, openOnFocus = true, suggestionFilter = Utils.textMatch, placeholderText, ...props
 }) => {
   Utils.useLabelAssert('withAutocomplete', { id, 'aria-labelledby': labelId, ...props, allowId: true })
 
-  const suggestions = _.filter(Utils.textMatch(value), rawSuggestions)
+  const suggestions = _.filter(suggestionFilter(value), rawSuggestions)
+  const controlProps = itemToString ? { itemToString: v => v ? itemToString(v) : value } : { selectedItem: value }
 
   return h(Downshift, {
-    selectedItem: value,
+    ...controlProps,
+    initialInputValue: value,
     onSelect: v => !!v && onPick?.(v),
     onInputValueChange: newValue => {
       if (newValue !== value) {
@@ -267,7 +269,7 @@ const withAutocomplete = WrappedComponent => ({
             } else if (_.includes(e.key, ['ArrowUp', 'ArrowDown']) && !suggestions.length) {
               e.nativeEvent.preventDownshiftDefault = true
             } else if (e.key === 'Enter') {
-              onPick && onPick(value)
+              onPick ? onPick(value) : toggleMenu()
             }
           },
           nativeOnChange: true,
@@ -283,7 +285,7 @@ const withAutocomplete = WrappedComponent => ({
           }, [placeholderText])]],
           [!_.isEmpty(suggestions), () => _.map(([index, item]) => {
             return div(getItemProps({
-              item, key: item,
+              item, key: index,
               style: styles.suggestion(highlightedIndex === index)
             }), [renderSuggestion(item)])
           }, Utils.toIndexPairs(suggestions))])
@@ -294,6 +296,8 @@ const withAutocomplete = WrappedComponent => ({
 }
 
 export const AutocompleteTextInput = withAutocomplete(TextInput)
+
+export const DelayedAutoCompleteInput = withDebouncedChange(AutocompleteTextInput)
 
 export const TextArea = ({ onChange, autosize = false, nativeOnChange = false, ...props }) => {
   Utils.useLabelAssert('TextArea', { ...props, allowId: true })

--- a/src/components/input.js
+++ b/src/components/input.js
@@ -269,7 +269,8 @@ const withAutocomplete = WrappedComponent => ({
             } else if (_.includes(e.key, ['ArrowUp', 'ArrowDown']) && !suggestions.length) {
               e.nativeEvent.preventDownshiftDefault = true
             } else if (e.key === 'Enter') {
-              onPick ? onPick(value) : toggleMenu()
+              onPick && onPick(value)
+              toggleMenu()
             }
           },
           nativeOnChange: true,

--- a/src/components/input.js
+++ b/src/components/input.js
@@ -236,7 +236,9 @@ const withAutocomplete = WrappedComponent => ({
   Utils.useLabelAssert('withAutocomplete', { id, 'aria-labelledby': labelId, ...props, allowId: true })
 
   const suggestions = _.filter(suggestionFilter(value), rawSuggestions)
-  const controlProps = itemToString ? { itemToString: v => v ? itemToString(v) : value } : { selectedItem: value }
+  const controlProps = itemToString ?
+    { itemToString: v => v ? itemToString(v) : value } :
+    { selectedItem: value }
 
   return h(Downshift, {
     ...controlProps,

--- a/src/pages/library/common.js
+++ b/src/pages/library/common.js
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp'
 import * as qs from 'qs'
 import { Fragment, useMemo, useState } from 'react'
-import { div, h, i, label, strong } from 'react-hyperscript-helpers'
+import { div, em, h, label, strong } from 'react-hyperscript-helpers'
 import Collapse from 'src/components/Collapse'
 import { Clickable, IdContainer, Link, Select } from 'src/components/common'
 import { DelayedAutoCompleteInput } from 'src/components/input'
@@ -97,7 +97,7 @@ const truncateLeftWord = _.curry((options, text) => _.flow(
 
 const getContextualSuggestion = ([leftContext, match, rightContext]) => {
   return [
-    strong([i(['Description: '])]),
+    strong([em(['Description: '])]),
     truncateLeftWord({ length: 50 }, leftContext),
     match,
     _.truncate({ length: 50 }, rightContext)

--- a/src/pages/library/common.js
+++ b/src/pages/library/common.js
@@ -87,7 +87,7 @@ const Sidebar = ({ onSectionFilter, onTagFilter, sections, selectedSections, sel
   ])
 }
 
-const reverseText = _.flow(_.split(''), _.reverse, _.join(''))
+const reverseText = _.flow(_.reverse, _.join(''))
 const truncateLeftWord = _.curry((options, text) => _.flow(
   reverseText,
   _.truncate(options),

--- a/src/pages/library/common.js
+++ b/src/pages/library/common.js
@@ -167,7 +167,6 @@ export const SearchAndFilterComponent = ({ fullList, sidebarSections, customSort
 
 
   const onSearchChange = filter => {
-    // Note: setting undefined so that falsy values don't show up at all
     const newSearch = qs.stringify({
       ...query,
       filter: filter || undefined
@@ -211,7 +210,7 @@ export const SearchAndFilterComponent = ({ fullList, sidebarSections, customSort
             match => _.size(match) < 2 ? [...match, div({ style: { marginLeft: '2rem' } }, [...getContext(suggestion['dct:description'])])] : match
           )(suggestion['dct:title']))
         },
-        suggestions: fullList
+        suggestions: filteredData
       }),
       !customSort && h(IdContainer, [
         id => h(Fragment, [

--- a/src/pages/library/common.js
+++ b/src/pages/library/common.js
@@ -1,10 +1,12 @@
 import _ from 'lodash/fp'
-import { Fragment, useState } from 'react'
-import { div, h, label } from 'react-hyperscript-helpers'
+import * as qs from 'qs'
+import { Fragment, useMemo, useState } from 'react'
+import { div, h, i, label, strong } from 'react-hyperscript-helpers'
 import Collapse from 'src/components/Collapse'
 import { Clickable, IdContainer, Link, Select } from 'src/components/common'
-import { DelayedSearchInput } from 'src/components/input'
+import { DelayedAutoCompleteInput } from 'src/components/input'
 import colors from 'src/libs/colors'
+import * as Nav from 'src/libs/nav'
 
 
 export const commonStyles = {
@@ -85,11 +87,30 @@ const Sidebar = ({ onSectionFilter, onTagFilter, sections, selectedSections, sel
   ])
 }
 
+const reverseText = _.flow(_.split(''), _.reverse, _.join(''))
+const truncateLeftWord = _.curry((options, text) => _.flow(
+  reverseText,
+  _.truncate(options),
+  reverseText,
+  _.replace(/\.\.\.(\S+)/, '...')
+)(text))
+
+const getContextualSuggestion = ([leftContext, match, rightContext]) => {
+  return [
+    strong([i(['Description: '])]),
+    truncateLeftWord({ length: 50 }, leftContext),
+    match,
+    _.truncate({ length: 50 }, rightContext)
+  ]
+}
+
 export const SearchAndFilterComponent = ({ fullList, sidebarSections, customSort, searchType, children }) => {
+  const { query } = Nav.useRoute()
+  const searchFilter = query.filter || ''
   const [selectedSections, setSelectedSections] = useState([])
   const [selectedTags, setSelectedTags] = useState([])
-  const [searchFilter, setSearchFilter] = useState('')
   const [sort, setSort] = useState({ field: 'created', direction: 'desc' })
+  const filterRegex = new RegExp(`(${searchFilter})`, 'i')
 
   const listDataByTag = _.omitBy(_.isEmpty, groupByFeaturedTags(fullList, sidebarSections))
 
@@ -106,40 +127,63 @@ export const SearchAndFilterComponent = ({ fullList, sidebarSections, customSort
     _.remove(section => _.isEmpty(section.labels))
   )(sidebarSections)
 
-  const filterBySections = listData => {
-    if (_.isEmpty(selectedSections)) {
-      return listData
-    } else {
-      const tags = _.uniqBy(_.flatMap('tags', selectedSections))
-      return _.uniq(_.flatMap(tag => listDataByTag[tag], tags))
-    }
-  }
-  const filterByTags = listData => {
-    if (_.isEmpty(selectedTags)) {
-      return listData
-    } else {
-      return _.reduce(
-        (acc, tag) => _.intersection(listDataByTag[tag], acc),
-        listDataByTag[_.head(selectedTags)],
-        _.tail(selectedTags)
-      )
-    }
-  }
-  const filterByText = _.filter(({ lowerName, lowerDescription }) => _.includes(searchFilter, `${lowerName} ${lowerDescription}`))
+  const getContext = _.flow(
+    _.split(filterRegex),
+    getContextualSuggestion,
+    _.map(item => _.toLower(item) === _.toLower(searchFilter) ? strong([item]) : item)
+  )
 
-  const filteredList = _.flow(
-    filterBySections,
-    filterByTags,
-    filterByText,
-    customSort ? _.orderBy([customSort.field], [customSort.direction]) : _.orderBy([sort.field], [sort.direction])
-  )(fullList)
+  const filteredData = useMemo(() => {
+    const filterByText = _.filter(({ lowerName, lowerDescription }) => _.includes(_.toLower(searchFilter), `${lowerName} ${lowerDescription}`))
+
+    const filterBySections = listData => {
+      if (_.isEmpty(selectedSections)) {
+        return listData
+      } else {
+        const tags = _.uniqBy(_.flatMap('tags', selectedSections))
+        return _.uniq(_.flatMap(tag => listDataByTag[tag], tags))
+      }
+    }
+
+    const filterByTags = listData => {
+      if (_.isEmpty(selectedTags)) {
+        return listData
+      } else {
+        return _.reduce(
+          (acc, tag) => _.intersection(listDataByTag[tag], acc),
+          listDataByTag[_.head(selectedTags)],
+          _.tail(selectedTags)
+        )
+      }
+    }
+
+    return _.flow(
+      filterBySections,
+      filterByTags,
+      filterByText,
+      customSort ? _.orderBy([customSort.field], [customSort.direction]) : _.orderBy([sort.field], [sort.direction])
+    )(fullList)
+  }, [fullList, searchFilter, customSort, sort, listDataByTag, selectedTags, selectedSections])
+
+
+  const onSearchChange = filter => {
+    // Note: setting undefined so that falsy values don't show up at all
+    const newSearch = qs.stringify({
+      ...query,
+      filter: filter || undefined
+    }, { addQueryPrefix: true })
+
+    if (newSearch !== Nav.history.location.search) {
+      Nav.history.replace({ search: newSearch })
+    }
+  }
 
   return h(Fragment, [
     div({ style: { display: 'flex', margin: '1rem 1rem 0', alignItems: 'baseline' } }, [
       div({ style: { width: '19rem', flex: 'none' } }, [
         div({ style: styles.sidebarRow }, [
           div({ style: styles.header }, [`${searchType}`]),
-          div({ style: styles.pill(_.isEmpty(selectedSections) && _.isEmpty(selectedTags)) }, [_.size(filteredList)])
+          div({ style: styles.pill(_.isEmpty(selectedSections) && _.isEmpty(selectedTags)) }, [_.size(filteredData)])
         ]),
         div({ style: { display: 'flex', alignItems: 'center', height: '2.5rem' } }, [
           div({ style: { flex: 1 } }),
@@ -151,12 +195,23 @@ export const SearchAndFilterComponent = ({ fullList, sidebarSections, customSort
           }, ['clear'])
         ])
       ]),
-      h(DelayedSearchInput, {
+      h(DelayedAutoCompleteInput, {
         style: { flex: 1, marginLeft: '1rem' },
+        openOnFocus: true,
+        value: searchFilter,
         'aria-label': `Search ${searchType}`,
         placeholder: 'Search Name or Description',
-        value: searchFilter,
-        onChange: setSearchFilter
+        itemToString: v => v['dct:title'],
+        onChange: onSearchChange,
+        suggestionFilter: _.curry((needle, { lowerName, lowerDescription }) => _.includes(_.toLower(needle), `${lowerName} ${lowerDescription}`)),
+        renderSuggestion: suggestion => {
+          return div(_.flow(
+            _.split(filterRegex),
+            _.map(item => _.toLower(item) === _.toLower(searchFilter) ? strong([item]) : item),
+            match => _.size(match) < 2 ? [...match, div({ style: { marginLeft: '2rem' } }, [...getContext(suggestion['dct:description'])])] : match
+          )(suggestion['dct:title']))
+        },
+        suggestions: fullList
       }),
       !customSort && h(IdContainer, [
         id => h(Fragment, [
@@ -184,12 +239,12 @@ export const SearchAndFilterComponent = ({ fullList, sidebarSections, customSort
           sections,
           selectedSections,
           selectedTags,
-          listDataByTag: groupByFeaturedTags(filteredList, sidebarSections)
+          listDataByTag: groupByFeaturedTags(filteredData, sidebarSections)
         })
       ]),
       div({ style: { marginLeft: '1rem', minWidth: 0, width: '100%', height: '100%' } }, [
-        _.isEmpty(filteredList) ? div({ style: { margin: 'auto', textAlign: 'center' } }, ['No Results Found']) :
-          children({ filteredList, sections, selectedTags, setSelectedTags })
+        _.isEmpty(filteredData) ? div({ style: { margin: 'auto', textAlign: 'center' } }, ['No Results Found']) :
+          children({ filteredList: filteredData, sections, selectedTags, setSelectedTags })
       ])
     ])
   ])

--- a/src/pages/library/common.js
+++ b/src/pages/library/common.js
@@ -204,11 +204,17 @@ export const SearchAndFilterComponent = ({ fullList, sidebarSections, customSort
         onChange: onSearchChange,
         suggestionFilter: _.curry((needle, { lowerName, lowerDescription }) => _.includes(_.toLower(needle), `${lowerName} ${lowerDescription}`)),
         renderSuggestion: suggestion => {
-          return div(_.flow(
-            _.split(filterRegex),
-            _.map(item => _.toLower(item) === _.toLower(searchFilter) ? strong([item]) : item),
-            match => _.size(match) < 2 ? [...match, div({ style: { marginLeft: '2rem' } }, [...getContext(suggestion['dct:description'])])] : match
-          )(suggestion['dct:title']))
+          return div({ style: { lineHeight: '1.75rem', padding: '0.375rem 0', borderBottom: `1px dotted ${colors.dark(0.7)}` } },
+            _.flow(
+              _.split(filterRegex),
+              _.map(item => _.toLower(item) === _.toLower(searchFilter) ? strong([item]) : item),
+              match => {
+                return _.size(match) < 2 ?
+                  [...match, div({ style: { lineHeight: '1.5rem', marginLeft: '2rem' } }, [...getContext(suggestion['dct:description'])])] :
+                  match
+              }
+            )(suggestion['dct:title'])
+          )
         },
         suggestions: filteredData
       }),

--- a/src/pages/library/common.js
+++ b/src/pages/library/common.js
@@ -88,11 +88,16 @@ const Sidebar = ({ onSectionFilter, onTagFilter, sections, selectedSections, sel
 }
 
 const reverseText = _.flow(_.reverse, _.join(''))
+
+// truncateLeftWord
+// This will behave like Lodash's _.truncate except it will truncate from the left side of the string.
+// This function will also truncate at a word, so the beginning of the text is fully readable.
+// Example: truncateLeftWord({length: 14}, 'this is my string') -> '...my string' - the ellipses are part of the string length
 const truncateLeftWord = _.curry((options, text) => _.flow(
-  reverseText,
+  reverseText, // reverses the text so we can perform a truncate
   _.truncate(options),
-  reverseText,
-  _.replace(/\.\.\.(\S+)/, '...')
+  reverseText, // puts the text back in its original order
+  _.replace(/\.\.\.(\S+)/, '...') // Removes the first partial word
 )(text))
 
 const getContextualSuggestion = ([leftContext, match, rightContext]) => {


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2182

This change adds the ability to populate the data explorer filter with auto completion.
Our current AutoComplete component was designed to be used with a list of strings. In this case the filter is looking at other properties on an object of values.

Some changes were made to the component to be able to support object filtering.

The other changes were to add rendering logic to highlight where the match was found.

This PR was reviewed by UX. I will be making[ follow up changes](https://broadworkbench.atlassian.net/browse/DR-2210) for styling

![image](https://user-images.githubusercontent.com/50371603/138471527-9bb2ce3f-9051-4f6c-b3ef-42a74792c591.png)

