### PR TITLE
[IA-2812] Unique Galaxy disk per workspace

### DIFF
--- a/src/components/CromwellModal.js
+++ b/src/components/CromwellModal.js
@@ -27,7 +27,7 @@ export const CromwellModalBase = withDisplayName('CromwellModal')(
   }) => {
     const app = getCurrentApp(tools.cromwell.appType)(apps)
     const [loading, setLoading] = useState(false)
-    const currentDataDisk = getCurrentPersistentDisk(tools.cromwell.appType, apps, appDataDisks)
+    const currentDataDisk = getCurrentPersistentDisk(tools.cromwell.appType, apps, appDataDisks, workspaceName)
 
     const createCromwell = _.flow(
       Utils.withBusyState(setLoading),

--- a/src/components/GalaxyModal.js
+++ b/src/components/GalaxyModal.js
@@ -46,7 +46,7 @@ export const GalaxyModalBase = withDisplayName('GalaxyModal')(
     const [loading, setLoading] = useState(false)
     const [shouldDeleteDisk, setShouldDeleteDisk] = useState(false)
 
-    const currentDataDisk = getCurrentPersistentDisk(tools.galaxy.appType, apps, appDataDisks)
+    const currentDataDisk = getCurrentPersistentDisk(tools.galaxy.appType, apps, appDataDisks, workspaceName)
 
     const createGalaxy = _.flow(
       Utils.withBusyState(setLoading),

--- a/src/libs/_tests/runtime-utils.test.js
+++ b/src/libs/_tests/runtime-utils.test.js
@@ -1,5 +1,7 @@
 import { tools } from 'src/components/notebook-utils'
-import { getCurrentApp, getCurrentAppIncludingDeleting, getCurrentPersistentDisk, getDiskAppType } from 'src/libs/runtime-utils'
+import {
+  getCurrentApp, getCurrentAppIncludingDeleting, getCurrentPersistentDisk, getDiskAppType, workspaceHasMultipleApps, workspaceHasMultipleDisks
+} from 'src/libs/runtime-utils'
 
 
 const cromwellRunning = {
@@ -66,6 +68,53 @@ const galaxyDeleting = {
 
 const mockApps = [cromwellProvisioning, cromwellRunning, galaxyRunning, galaxyDeleting]
 
+const galaxy1Workspace1 = {
+  appName: 'terra-app-69200c2f-89c3-47db-874c-b770d8de858g',
+  appType: 'GALAXY',
+  auditInfo: {
+    creator: 'cahrens@gmail.com', createdDate: '2021-12-10T20:19:13.162484Z', destroyedDate: null, dateAccessed: '2021-12-11T20:19:13.162484Z'
+  },
+  diskName: 'saturn-pd-026594ac-d829-423d-a8df-87fe07f6b5e8', // galaxyDisk1Workspace1
+  errors: [],
+  googleProject: 'terra-test-e4000484',
+  kubernetesRuntimeConfig: { numNodes: 1, machineType: 'n1-highmem-8', autoscalingEnabled: false },
+  labels: { saturnWorkspaceName: 'test-workspace'},
+  proxyUrls: { galaxy: 'https://leonardo-fiab.dsde-dev.broadinstitute.org/a-app-69200c2f-89c3-47db-874c-b770d8de737f/galaxy' },
+  status: 'RUNNING'
+}
+
+const galaxy2Workspace1 = {
+  appName: 'terra-app-69200c2f-89c3-47db-874c-b770d8de656t',
+  appType: 'GALAXY',
+  auditInfo: {
+    creator: 'cahrens@gmail.com', createdDate: '2021-12-10T20:19:13.162484Z', destroyedDate: null, dateAccessed: '2021-12-11T20:19:13.162484Z'
+  },
+  diskName: 'saturn-pd-026594ac-d829-423d-a8df-98fe18f7b6e9', // galaxyDisk2Workspace1
+  errors: [],
+  googleProject: 'terra-test-e4000484',
+  kubernetesRuntimeConfig: { numNodes: 1, machineType: 'n1-highmem-8', autoscalingEnabled: false },
+  labels: { saturnWorkspaceName: 'test-workspace'},
+  proxyUrls: { galaxy: 'https://leonardo-fiab.dsde-dev.broadinstitute.org/a-app-69200c2f-89c3-47db-874c-b770d8de737f/galaxy' },
+  status: 'RUNNING'
+}
+
+const cromwell1Workspace1 = {
+  appName: 'terra-app-69200c2f-89c3-47db-874c-b770d8de656t',
+  appType: 'GALAXY',
+  auditInfo: {
+    creator: 'cahrens@gmail.com', createdDate: '2021-12-10T20:19:13.162484Z', destroyedDate: null, dateAccessed: '2021-12-11T20:19:13.162484Z'
+  },
+  diskName: 'saturn-pd-026594ac-d829-423d-a8df-55fe36f5b4e8', // cromwellDisk1Workspace1
+  errors: [],
+  googleProject: 'terra-test-e4000484',
+  kubernetesRuntimeConfig: { numNodes: 1, machineType: 'n1-highmem-8', autoscalingEnabled: false },
+  labels: { saturnWorkspaceName: 'test-workspace'},
+  proxyUrls: { galaxy: 'https://leonardo-fiab.dsde-dev.broadinstitute.org/a-app-69200c2f-89c3-47db-874c-b770d8de737f/galaxy' },
+  status: 'RUNNING'
+}
+
+const mockAppsSameWorkspace = [galaxy1Workspace1, galaxy2Workspace1, cromwell1Workspace1]
+
 const galaxyDisk = {
   auditInfo: {
     creator: 'cahrens@gmail.com', createdDate: '2021-11-29T20:19:13.162484Z', destroyedDate: null, dateAccessed: '2021-11-29T20:19:14.114Z'
@@ -74,7 +123,7 @@ const galaxyDisk = {
   diskType: 'pd-standard',
   googleProject: 'terra-test-e4000484',
   id: 10,
-  labels: { saturnApplication: 'galaxy' }, // Note 'galaxy' vs. 'GALAXY', to represent our older naming scheme
+  labels: { saturnApplication: 'galaxy', saturnWorkspaceName: 'test-workspace' }, // Note 'galaxy' vs. 'GALAXY', to represent our older naming scheme
   name: 'saturn-pd-026594ac-d829-423d-a8df-76fe96f5b4e7',
   size: 500,
   status: 'Ready',
@@ -90,7 +139,7 @@ const galaxyDeletingDisk = {
   diskType: 'pd-standard',
   googleProject: 'terra-test-e4000484',
   id: 10,
-  labels: { saturnApplication: 'GALAXY' },
+  labels: { saturnApplication: 'GALAXY', saturnWorkspaceName: 'test-workspace' },
   name: 'saturn-pd-1236594ac-d829-423d-a8df-76fe96f5897',
   size: 500,
   status: 'Deleting',
@@ -105,7 +154,7 @@ const cromwellUnattachedDisk = {
   diskType: 'pd-standard',
   googleProject: 'terra-test-e4000484',
   id: 12,
-  labels: { saturnApplication: 'CROMWELL' },
+  labels: { saturnApplication: 'CROMWELL', saturnWorkspaceName: 'test-workspace' },
   name: 'saturn-pd-7fc0c398-63fe-4441-aea5-1e794c961310',
   size: 500,
   status: 'Ready',
@@ -121,7 +170,7 @@ const cromwellProvisioningDisk = {
   diskType: 'pd-standard',
   googleProject: 'terra-test-e4000484',
   id: 11,
-  labels: { saturnApplication: 'CROMWELL' },
+  labels: { saturnApplication: 'CROMWELL', saturnWorkspaceName: 'test-workspace' },
   name: 'saturn-pd-693a9707-634d-4134-bb3a-cbb73cd5a8ce',
   size: 500,
   status: 'Creating',
@@ -145,6 +194,68 @@ const jupyterDisk = {
 }
 
 const mockAppDisks = [galaxyDisk, galaxyDeletingDisk, cromwellProvisioningDisk, cromwellUnattachedDisk]
+
+const galaxyDisk1Workspace1 = {
+  auditInfo: {
+    creator: 'cahrens@gmail.com', createdDate: '2021-11-30T20:19:13.162484Z', destroyedDate: null, dateAccessed: '2021-12-10T20:19:14.114Z'
+  },
+  blockSize: 4096,
+  diskType: 'pd-standard',
+  googleProject: 'terra-test-e4000484',
+  id: 13,
+  labels: { saturnApplication: 'GALAXY', saturnWorkspaceName: 'test-workspace' },
+  name: 'saturn-pd-026594ac-d829-423d-a8df-87fe07f6b5e8',
+  size: 500,
+  status: 'Ready',
+  zone: 'us-central1-a'
+}
+
+const galaxyDisk2Workspace1 = {
+  auditInfo: {
+    creator: 'cahrens@gmail.com', createdDate: '2021-11-28T20:19:13.162484Z', destroyedDate: null, dateAccessed: '2021-11-29T20:19:14.114Z'
+  },
+  blockSize: 4096,
+  diskType: 'pd-standard',
+  googleProject: 'terra-test-e4000484',
+  id: 14,
+  labels: { saturnApplication: 'GALAXY', saturnWorkspaceName: 'test-workspace' },
+  name: 'saturn-pd-026594ac-d829-423d-a8df-98fe18f7b6e9',
+  size: 500,
+  status: 'Ready',
+  zone: 'us-central1-a'
+}
+
+const galaxyDisk3Workspace2 = {
+  auditInfo: {
+    creator: 'cahrens@gmail.com', createdDate: '2021-11-26T20:19:13.162484Z', destroyedDate: null, dateAccessed: '2021-11-29T20:19:14.114Z'
+  },
+  blockSize: 4096,
+  diskType: 'pd-standard',
+  googleProject: 'terra-test-e4000484',
+  id: 15,
+  labels: { saturnApplication: 'GALAXY', saturnWorkspaceName: 'test-workspace-2' },
+  name: 'saturn-pd-026594ac-d829-423d-a8df-33fe36f5b4e4',
+  size: 500,
+  status: 'Ready',
+  zone: 'us-central1-a'
+}
+
+const cromwellDisk1Workspace1 = {
+  auditInfo: {
+    creator: 'cahrens@gmail.com', createdDate: '2021-11-26T20:19:13.162484Z', destroyedDate: null, dateAccessed: '2021-11-29T20:19:14.114Z'
+  },
+  blockSize: 4096,
+  diskType: 'pd-standard',
+  googleProject: 'terra-test-e4000484',
+  id: 16,
+  labels: { saturnApplication: 'CROMWELL', saturnWorkspaceName: 'test-workspace' },
+  name: 'saturn-pd-026594ac-d829-423d-a8df-55fe36f5b4e8',
+  size: 500,
+  status: 'Ready',
+  zone: 'us-central1-a'
+}
+
+const mockAppDisksSameWorkspace = [galaxyDisk1Workspace1, galaxyDisk2Workspace1, galaxyDisk3Workspace2, cromwellDisk1Workspace1]
 
 describe('getCurrentApp', () => {
   it('returns undefined if no instances of the app exist', () => {
@@ -179,11 +290,33 @@ describe('getCurrentPersistentDisk', () => {
     expect(getCurrentPersistentDisk(tools.galaxy.appType, [cromwellProvisioning], [cromwellProvisioningDisk])).toBeUndefined()
   })
   it('returns the newest attached disk, even if app is deleting', () => {
-    expect(getCurrentPersistentDisk(tools.galaxy.appType, mockApps, mockAppDisks)).toBe(galaxyDeletingDisk)
-    expect(getCurrentPersistentDisk(tools.cromwell.appType, mockApps, mockAppDisks)).toBe(cromwellProvisioningDisk)
+    expect(getCurrentPersistentDisk(tools.galaxy.appType, mockApps, mockAppDisks, 'test-workspace')).toBe(galaxyDeletingDisk)
+    expect(getCurrentPersistentDisk(tools.cromwell.appType, mockApps, mockAppDisks, 'test-workspace')).toBe(cromwellProvisioningDisk)
   })
   it('returns the newest unattached disk that is not deleting if no app instance exists', () => {
-    expect(getCurrentPersistentDisk(tools.galaxy.appType, [], mockAppDisks)).toBe(galaxyDisk)
-    expect(getCurrentPersistentDisk(tools.cromwell.appType, [galaxyRunning], mockAppDisks)).toBe(cromwellUnattachedDisk)
+    expect(getCurrentPersistentDisk(tools.galaxy.appType, [], mockAppDisks, 'test-workspace')).toBe(galaxyDisk)
+    expect(getCurrentPersistentDisk(tools.cromwell.appType, [galaxyRunning], mockAppDisks, 'test-workspace')).toBe(cromwellUnattachedDisk)
+  })
+  it('returns a galaxy disk only if it is in the same workspace as the previous app it was attached to', () => {
+    expect(getCurrentPersistentDisk(tools.galaxy.appType, [], mockAppDisks, 'test-workspace')).toBe(galaxyDisk)
+    expect(getCurrentPersistentDisk(tools.galaxy.appType, [], mockAppDisks, 'incorrect-workspace')).toBeUndefined()
+  })
+})
+
+describe('workspaceHasMultipleApps', () => {
+  it('returns true when there are multiple galaxy apps in the same project and workspace', () => {
+    expect(workspaceHasMultipleApps(mockAppsSameWorkspace, tools.galaxy.appType)).toBe(true)
+  })
+  it('returns false when there is not multiple cromwell apps', () => {
+    expect(workspaceHasMultipleApps(mockAppsSameWorkspace, tools.cromwell.appType)).toBe(false)
+  })
+})
+
+describe('workspaceHasMultipleDisks', () => {
+  it('returns true when there are multiple galaxy disks in the same project and workspace', () => {
+    expect(workspaceHasMultipleDisks(mockAppDisksSameWorkspace, tools.galaxy.appType)).toBe(true)
+  })
+  it('returns false when there is not multiple cromwell disks', () => {
+    expect(workspaceHasMultipleDisks(mockAppDisksSameWorkspace, tools.cromwell.appType)).toBe(false)
   })
 })

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -321,6 +321,8 @@ const Environments = () => {
   }
 
   const multipleDisksError = (disks, appType) => {
+    // appType is undefined for runtimes (ie Jupyter, RStudio) so the first part of the ternary is for processing app
+    // disks. the second part is for processing runtime disks so it filters out app disks
     return !!appType ? workspaceHasMultipleDisks(disks, appType) : _.remove(disk => getDiskAppType(disk) !== appType || disk.status === 'Deleting',
       disks).length > 1
   }

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -220,7 +220,7 @@ const Environments = () => {
   }
   const renderWorkspaceForApps = app => {
     const { appType, labels: { saturnWorkspaceNamespace, saturnWorkspaceName } } = app
-    const multipleApps = workspaceHasMultipleApps(appsByProject[app.googleProject], app.appType)
+    const multipleApps = workspaceHasMultipleApps(appsByProject[app.googleProject], appType)
     return getWorkspaceCell(saturnWorkspaceNamespace, saturnWorkspaceName, appType, multipleApps)
   }
 
@@ -450,7 +450,6 @@ const Environments = () => {
             cellRenderer: ({ rowIndex }) => {
               const { status: diskStatus, googleProject, labels: { saturnWorkspaceNamespace, saturnWorkspaceName } } = filteredDisks[rowIndex]
               const appType = getDiskAppType(filteredDisks[rowIndex])
-              const forAppText = !!appType ? ` for ${_.capitalize(appType)}` : ''
               const multipleDisks = multipleDisksError(disksByProject[googleProject], appType)
               return h(Fragment, [
                 h(Link, { href: Nav.getLink('workspace-dashboard', { namespace: saturnWorkspaceNamespace, name: saturnWorkspaceName }) },

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -19,8 +19,8 @@ import { withErrorIgnoring, withErrorReporting } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
 import { useCancellation, useGetter, useOnMount, usePollingEffect } from 'src/libs/react-utils'
 import {
-  defaultComputeZone, getComputeStatusForDisplay, getCurrentApp, getCurrentRuntime, getDiskAppType, getGalaxyComputeCost, getGalaxyCost,
-  getPersistentDiskCostMonthly, getRegionFromZone, isApp, isComputePausable, isResourceDeletable, runtimeCost
+  defaultComputeZone, getComputeStatusForDisplay, getCurrentRuntime, getDiskAppType, getGalaxyComputeCost, getGalaxyCost,
+  getPersistentDiskCostMonthly, getRegionFromZone, isApp, isComputePausable, isResourceDeletable, runtimeCost, workspaceHasMultipleApps, workspaceHasMultipleDisks
 } from 'src/libs/runtime-utils'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
@@ -219,10 +219,9 @@ const Environments = () => {
     ])
   }
   const renderWorkspaceForApps = app => {
-    const { status, appType, googleProject, labels: { saturnWorkspaceNamespace, saturnWorkspaceName } } = app
-    const shouldWarn = !_.includes(status, ['DELETING', 'ERROR', 'PREDELETING']) &&
-      getCurrentApp(appType)(appsByProject[googleProject]) !== app
-    return getWorkspaceCell(saturnWorkspaceNamespace, saturnWorkspaceName, appType, shouldWarn)
+    const { appType, labels: { saturnWorkspaceNamespace, saturnWorkspaceName } } = app
+    const multipleApps = workspaceHasMultipleApps(appsByProject[app.googleProject], app.appType)
+    return getWorkspaceCell(saturnWorkspaceNamespace, saturnWorkspaceName, appType, multipleApps)
   }
 
   const renderWorkspaceForRuntimes = runtime => {
@@ -319,6 +318,11 @@ const Environments = () => {
         loadData()
       }
     })
+  }
+
+  const multipleDisksError = (disks, appType) => {
+    return !!appType ? workspaceHasMultipleDisks(disks, appType) : _.remove(disk => getDiskAppType(disk) !== appType || disk.status === 'Deleting',
+      disks).length > 1
   }
 
   return h(FooterWrapper, [
@@ -446,12 +450,12 @@ const Environments = () => {
             cellRenderer: ({ rowIndex }) => {
               const { status: diskStatus, googleProject, labels: { saturnWorkspaceNamespace, saturnWorkspaceName } } = filteredDisks[rowIndex]
               const appType = getDiskAppType(filteredDisks[rowIndex])
-              const multipleDisksOfType = _.remove(disk => getDiskAppType(disk) !== appType || disk.status === 'Deleting',
-                disksByProject[googleProject]).length > 1
+              const forAppText = !!appType ? ` for ${_.capitalize(appType)}` : ''
+              const multipleDisks = multipleDisksError(disksByProject[googleProject], appType)
               return h(Fragment, [
                 h(Link, { href: Nav.getLink('workspace-dashboard', { namespace: saturnWorkspaceNamespace, name: saturnWorkspaceName }) },
                   [saturnWorkspaceName]),
-                diskStatus !== 'Deleting' && multipleDisksOfType &&
+                diskStatus !== 'Deleting' && multipleDisks &&
                 h(TooltipTrigger, {
                   content: `This workspace has multiple active persistent disks${forAppText(appType)}. Only the latest one will be used.`
                 }, [icon('warning-standard', { style: { marginLeft: '0.25rem', color: colors.warning() } })])

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -179,7 +179,7 @@ const useCloudEnvironmentPolling = googleProject => {
   const load = async maybeStale => {
     try {
       const [newDisks, newRuntimes] = googleProject ? await Promise.all([
-        Ajax(signal).Disks.list({ googleProject, creator: getUser().email, includeLabels: 'saturnApplication' }),
+        Ajax(signal).Disks.list({ googleProject, creator: getUser().email, includeLabels: 'saturnApplication,saturnWorkspaceName' }),
         Ajax(signal).Runtimes.list({ googleProject, creator: getUser().email })
       ]) : [[], []]
       setRuntimes(newRuntimes)


### PR DESCRIPTION
[Bug](https://broadworkbench.atlassian.net/browse/IA-2812): If a user has workspaces that were created before the PPW migration, it is possible for that user to create galaxy instances in different workspaces but the same google project. [Leonardo does not allow the same disk to exist in 2 different workspaces](https://github.com/DataBiosphere/leonardo/blob/develop/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/http/service/AppServiceInterp.scala#L167). so the UI needs to create a new disk per workspace (if they are in the same project pre PPW migration). 

This PR fixes the bug mentioned. Tested by using two workspaces that were created pre PPW migration: `callisto-dev/gab-test` and `callisto-dev/gab-test copy`.  Created a galaxy in `gab-test`, deleted that galaxy but kept the disk. Then created a galaxy in `gab-test copy` and validated that the UI does not attach the disk from `gab-test` and creates a new disk and validated that Leo no longer throws an error and galaxy created successfully.

<!--
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Thanks!
--!>
