### PR TITLE
[PF-1070] Pass in location to ComputeModal so we don't constantly call GCS API

### DIFF
--- a/integration-tests/tests/run-notebook.js
+++ b/integration-tests/tests/run-notebook.js
@@ -25,6 +25,7 @@ const testRunNotebookFn = _.flow(
   await select(page, 'Language', 'Python 3')
   await click(page, clickable({ text: 'Create Notebook' }))
   await click(page, clickable({ textContains: notebookName }))
+  await waitForNoSpinners(page)
   await click(page, clickable({ text: 'Edit' }))
   // There are two separate activities in the UI that could interfere with beginning to interact
   // with the modal for creating a cloud environment:

--- a/src/components/AnalysisModal.js
+++ b/src/components/AnalysisModal.js
@@ -29,7 +29,7 @@ const environmentMode = Symbol('environment')
 export const AnalysisModal = Utils.withDisplayName('AnalysisModal')(
   ({
     isOpen, onDismiss, onSuccess, uploadFiles, openUploader, runtimes, apps, galaxyDataDisks, refreshRuntimes, refreshApps, refreshAnalyses,
-    analyses, workspace, persistentDisks, workspace: { workspace: { googleProject, bucketName } }
+    analyses, workspace, persistentDisks, location, workspace: { workspace: { googleProject, bucketName } }
   }) => {
     const [viewMode, setViewMode] = useState(undefined)
     const [busy, setBusy] = useState()
@@ -103,6 +103,7 @@ export const AnalysisModal = Utils.withDisplayName('AnalysisModal')(
       tool: currentTool,
       runtimes,
       persistentDisks,
+      location,
       onDismiss: () => {
         resetView()
         onDismiss()

--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -161,7 +161,7 @@ const getCurrentPersistentDisk = (runtimes, persistentDisks) => {
 const shouldUsePersistentDisk = (sparkMode, runtimeDetails, upgradeDiskSelected) => !sparkMode &&
   (!runtimeDetails?.runtimeConfig?.diskSize || upgradeDiskSelected)
 
-export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDisks, tool, workspace, isAnalysisMode = false }) => {
+export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDisks, tool, workspace, location, isAnalysisMode = false }) => {
   // State -- begin
   const [showDebugger, setShowDebugger] = useState(false)
   const [loading, setLoading] = useState(false)
@@ -601,7 +601,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
       withErrorReporting('Error loading cloud environment'),
       Utils.withBusyState(setLoading)
     )(async () => {
-      const { bucketName, namespace, googleProject, name } = getWorkspaceObject()
+      const { googleProject } = getWorkspaceObject()
       const currentRuntime = getCurrentRuntime(runtimes)
       const currentPersistentDisk = getCurrentPersistentDisk(runtimes, persistentDisks)
 
@@ -617,9 +617,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
         currentPersistentDisk ? Ajax().Disks.disk(currentPersistentDisk.googleProject, currentPersistentDisk.name).details() : null
       ])
       const filteredNewLeoImages = !!tool ? _.filter(image => _.includes(image.id, tools[tool].imageIds), newLeoImages) : newLeoImages
-
-      const { location } = await Ajax().Workspaces.workspace(namespace, name).checkBucketLocation(googleProject, bucketName)
-
+      //const location = 'us-central1'
       const imageUrl = currentRuntimeDetails ? getImageUrl(currentRuntimeDetails) : _.find({ id: 'terra-jupyter-gatk' }, newLeoImages).image
       const foundImage = _.find({ image: imageUrl }, newLeoImages)
 
@@ -651,6 +649,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
       setCurrentPersistentDiskDetails(currentPersistentDiskDetails)
       setCustomEnvImage(!foundImage ? imageUrl : '')
       setJupyterUserScriptUri(currentRuntimeDetails?.jupyterUserScriptUri || '')
+      console.log('compute modal location', location)
       setBucketLocation(location)
 
       // For initial regionality release, compute zone and region is limited to

--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -617,7 +617,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
         currentPersistentDisk ? Ajax().Disks.disk(currentPersistentDisk.googleProject, currentPersistentDisk.name).details() : null
       ])
       const filteredNewLeoImages = !!tool ? _.filter(image => _.includes(image.id, tools[tool].imageIds), newLeoImages) : newLeoImages
-      //const location = 'us-central1'
+
       const imageUrl = currentRuntimeDetails ? getImageUrl(currentRuntimeDetails) : _.find({ id: 'terra-jupyter-gatk' }, newLeoImages).image
       const foundImage = _.find({ image: imageUrl }, newLeoImages)
 
@@ -649,7 +649,6 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
       setCurrentPersistentDiskDetails(currentPersistentDiskDetails)
       setCustomEnvImage(!foundImage ? imageUrl : '')
       setJupyterUserScriptUri(currentRuntimeDetails?.jupyterUserScriptUri || '')
-      console.log('compute modal location', location)
       setBucketLocation(location)
 
       // For initial regionality release, compute zone and region is limited to

--- a/src/components/ContextBar.js
+++ b/src/components/ContextBar.js
@@ -81,7 +81,6 @@ export const ContextBar = ({ setDeletingWorkspace, setCloningWorkspace, setShari
   return h(Fragment, [
     h(CloudEnvironmentModal, {
       isOpen: isCloudEnvOpen,
-      onSuccess: () => {}, //TODO: I don't know if we want to do anything?
       onDismiss: () => setCloudEnvOpen(false),
       runtimes, apps, galaxyDataDisks, refreshRuntimes, refreshApps,
       workspace,

--- a/src/components/RuntimeManager.js
+++ b/src/components/RuntimeManager.js
@@ -417,6 +417,7 @@ export default class RuntimeManager extends PureComponent {
           workspace,
           runtimes,
           persistentDisks,
+          location,
           onDismiss: () => this.setState({ createModalDrawerOpen: false }),
           onSuccess: _.flow(
             withErrorReporting('Error loading cloud environment'),

--- a/src/pages/workspaces/workspace/applications/AppLauncher.js
+++ b/src/pages/workspaces/workspace/applications/AppLauncher.js
@@ -10,7 +10,7 @@ import { Ajax } from 'src/libs/ajax'
 import { withErrorReporting } from 'src/libs/error'
 import Events from 'src/libs/events'
 import * as Nav from 'src/libs/nav'
-import { getConvertedRuntimeStatus, getCurrentRuntime, usableStatuses } from 'src/libs/runtime-utils'
+import { defaultLocation, getConvertedRuntimeStatus, getCurrentRuntime, usableStatuses } from 'src/libs/runtime-utils'
 import { cookieReadyStore } from 'src/libs/state'
 import * as Utils from 'src/libs/utils'
 import { wrapWorkspace } from 'src/pages/workspaces/workspace/WorkspaceContainer'
@@ -42,6 +42,7 @@ const ApplicationLauncher = _.flow(
   const cookieReady = Utils.useStore(cookieReadyStore)
   const [showCreate, setShowCreate] = useState(false)
   const [busy, setBusy] = useState(false)
+  const [location, setLocation] = useState(defaultLocation)
 
   // We've already init Welder if app is Jupyter.
   // TODO: We are stubbing this to never set up welder until we resolve some backend issues around file syncing
@@ -71,6 +72,19 @@ const ApplicationLauncher = _.flow(
         .setStorageLinks(localBaseDirectory, localSafeModeBaseDirectory, cloudStorageDirectory, `.*\\.Rmd`)
     })
 
+    const loadBucketLocation = _.flow(
+      Utils.withBusyState(setBusy),
+      withErrorReporting('Error loading bucket location')
+    )(async () => {
+      const { location } = await Ajax()
+        .Workspaces
+        .workspace(workspace.namespace, workspace.name)
+        .checkBucketLocation(googleProject, bucketName)
+      setLocation(location)
+    })
+
+
+    loadBucketLocation()
     if (shouldSetupWelder && runtimeStatus === 'Running') {
       setupWelder()
       setShouldSetupWelder(true)
@@ -120,6 +134,7 @@ const ApplicationLauncher = _.flow(
           workspace,
           runtimes,
           persistentDisks,
+          location,
           onDismiss: () => setShowCreate(false),
           onSuccess: _.flow(
             withErrorReporting('Error loading cloud environment'),

--- a/src/pages/workspaces/workspace/applications/AppLauncher.js
+++ b/src/pages/workspaces/workspace/applications/AppLauncher.js
@@ -83,8 +83,8 @@ const ApplicationLauncher = _.flow(
       setLocation(location)
     })
 
-
     loadBucketLocation()
+
     if (shouldSetupWelder && runtimeStatus === 'Running') {
       setupWelder()
       setShouldSetupWelder(true)

--- a/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
@@ -59,6 +59,7 @@ const AnalysisLauncher = _.flow(
     const { mode } = queryParams
     const toolLabel = getTool(analysisName)
     const iframeStyles = { height: '100%', width: '100%' }
+
     useEffect(() => {
       const loadBucketLocation = _.flow(
         Utils.withBusyState(setBusy),

--- a/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
@@ -1,7 +1,7 @@
 import * as clipboard from 'clipboard-polyfill/text'
 import _ from 'lodash/fp'
 import * as qs from 'qs'
-import { Fragment, useRef, useState } from 'react'
+import { Fragment, useEffect, useRef, useState } from 'react'
 import { b, div, h, iframe, p, span } from 'react-hyperscript-helpers'
 import * as breadcrumbs from 'src/components/breadcrumbs'
 import { requesterPaysWrapper, withRequesterPaysHandler } from 'src/components/bucket-utils'
@@ -23,7 +23,7 @@ import Events from 'src/libs/events'
 import * as Nav from 'src/libs/nav'
 import { notify } from 'src/libs/notifications'
 import { getLocalPref, setLocalPref } from 'src/libs/prefs'
-import { getConvertedRuntimeStatus, getCurrentRuntime, usableStatuses } from 'src/libs/runtime-utils'
+import { defaultLocation, getConvertedRuntimeStatus, getCurrentRuntime, usableStatuses } from 'src/libs/runtime-utils'
 import { authStore, cookieReadyStore } from 'src/libs/state'
 import * as Utils from 'src/libs/utils'
 import ExportAnalysisModal from 'src/pages/workspaces/workspace/notebooks/ExportNotebookModal'
@@ -46,7 +46,7 @@ const AnalysisLauncher = _.flow(
   })
 )(
   ({
-    queryParams, analysisName, workspace, workspace: { workspace: { namespace, name }, accessLevel, canCompute }, runtimes, persistentDisks,
+    queryParams, analysisName, workspace, workspace: { workspace: { bucketName, googleProject, namespace, name }, accessLevel, canCompute }, runtimes, persistentDisks,
     refreshRuntimes
   },
   ref) => {
@@ -55,9 +55,24 @@ const AnalysisLauncher = _.flow(
     const { runtimeName, labels } = runtime || {}
     const status = getConvertedRuntimeStatus(runtime)
     const [busy, setBusy] = useState()
+    const [location, setLocation] = useState(defaultLocation)
     const { mode } = queryParams
     const toolLabel = getTool(analysisName)
     const iframeStyles = { height: '100%', width: '100%' }
+    useEffect(() => {
+      const loadBucketLocation = _.flow(
+        Utils.withBusyState(setBusy),
+        withErrorReporting('Error loading bucket location')
+      )(async () => {
+        const { location } = await Ajax()
+          .Workspaces
+          .workspace(namespace, name)
+          .checkBucketLocation(googleProject, bucketName)
+        setLocation(location)
+      })
+      loadBucketLocation()
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [googleProject, bucketName])
 
     return h(Fragment, [
 
@@ -83,6 +98,7 @@ const AnalysisLauncher = _.flow(
           workspace,
           runtimes,
           persistentDisks,
+          location,
           onDismiss: () => {
             chooseMode(undefined)
             setCreateOpen(false)

--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -52,7 +52,6 @@ const NotebookLauncher = _.flow(
     const { mode } = queryParams
     const [location, setLocation] = useState(defaultLocation)
     useEffect(() => {
-      console.log('notebook launcher useEffect!')
       const loadBucketLocation = _.flow(
         Utils.withBusyState(setBusy),
         withErrorReporting('Error loading bucket location')

--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -45,12 +45,14 @@ const NotebookLauncher = _.flow(
   ({ queryParams, notebookName, workspace, workspace: { workspace: { bucketName, googleProject, namespace, name }, accessLevel, canCompute }, runtimes, persistentDisks, refreshRuntimes },
     ref) => {
     const [createOpen, setCreateOpen] = useState(false)
+    const [busy, setBusy] = useState()
+    const [location, setLocation] = useState(defaultLocation)
+
     const runtime = getCurrentRuntime(runtimes)
     const { runtimeName, labels } = runtime || {}
     const status = getConvertedRuntimeStatus(runtime)
-    const [busy, setBusy] = useState()
     const { mode } = queryParams
-    const [location, setLocation] = useState(defaultLocation)
+
     useEffect(() => {
       const loadBucketLocation = _.flow(
         Utils.withBusyState(setBusy),

--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -1,7 +1,7 @@
 import * as clipboard from 'clipboard-polyfill/text'
 import _ from 'lodash/fp'
 import * as qs from 'qs'
-import { Fragment, useRef, useState } from 'react'
+import { Fragment, useEffect, useRef, useState } from 'react'
 import { b, div, h, iframe, p, span } from 'react-hyperscript-helpers'
 import * as breadcrumbs from 'src/components/breadcrumbs'
 import { requesterPaysWrapper, withRequesterPaysHandler } from 'src/components/bucket-utils'
@@ -20,7 +20,7 @@ import Events from 'src/libs/events'
 import * as Nav from 'src/libs/nav'
 import { notify } from 'src/libs/notifications'
 import { getLocalPref, setLocalPref } from 'src/libs/prefs'
-import { getConvertedRuntimeStatus, getCurrentRuntime, usableStatuses } from 'src/libs/runtime-utils'
+import { defaultLocation, getConvertedRuntimeStatus, getCurrentRuntime, usableStatuses } from 'src/libs/runtime-utils'
 import { authStore, cookieReadyStore } from 'src/libs/state'
 import * as Utils from 'src/libs/utils'
 import ExportNotebookModal from 'src/pages/workspaces/workspace/notebooks/ExportNotebookModal'
@@ -42,7 +42,7 @@ const NotebookLauncher = _.flow(
     showTabBar: false
   })
 )(
-  ({ queryParams, notebookName, workspace, workspace: { workspace: { namespace, name }, accessLevel, canCompute }, runtimes, persistentDisks, refreshRuntimes },
+  ({ queryParams, notebookName, workspace, workspace: { workspace: { bucketName, googleProject, namespace, name }, accessLevel, canCompute }, runtimes, persistentDisks, refreshRuntimes },
     ref) => {
     const [createOpen, setCreateOpen] = useState(false)
     const runtime = getCurrentRuntime(runtimes)
@@ -50,6 +50,22 @@ const NotebookLauncher = _.flow(
     const status = getConvertedRuntimeStatus(runtime)
     const [busy, setBusy] = useState()
     const { mode } = queryParams
+    const [location, setLocation] = useState(defaultLocation)
+    useEffect(() => {
+      console.log('notebook launcher useEffect!')
+      const loadBucketLocation = _.flow(
+        Utils.withBusyState(setBusy),
+        withErrorReporting('Error loading bucket location')
+      )(async () => {
+        const { location } = await Ajax()
+          .Workspaces
+          .workspace(namespace, name)
+          .checkBucketLocation(googleProject, bucketName)
+        setLocation(location)
+      })
+      loadBucketLocation()
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [googleProject, bucketName])
 
     return h(Fragment, [
       (Utils.canWrite(accessLevel) && canCompute && !!mode && _.includes(status, usableStatuses) && labels.tool === 'Jupyter') ?
@@ -66,6 +82,7 @@ const NotebookLauncher = _.flow(
         workspace,
         runtimes,
         persistentDisks,
+        location,
         onDismiss: () => {
           chooseMode(undefined)
           setCreateOpen(false)

--- a/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
+++ b/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
@@ -38,8 +38,8 @@ import * as Utils from 'src/libs/utils'
 const titleId = 'cloud-env-modal'
 
 export const CloudEnvironmentModal = ({
-  isOpen, onDismiss, onSuccess, canCompute, runtimes, apps, galaxyDataDisks, refreshRuntimes, refreshApps,
-  workspace, persistentDisks, location, locationType, workspace: { workspace: { namespace, bucketName, name: workspaceName } }
+  isOpen, onDismiss, canCompute, runtimes, apps, galaxyDataDisks, refreshRuntimes, refreshApps,
+  workspace, persistentDisks, location, locationType, workspace: { workspace: { namespace, name: workspaceName } }
 }) => {
   const [viewMode, setViewMode] = useState(undefined)
   const [busy, setBusy] = useState(false)

--- a/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
+++ b/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
@@ -58,6 +58,7 @@ export const CloudEnvironmentModal = ({
     tool,
     runtimes,
     persistentDisks,
+    location,
     onDismiss: () => {
       setViewMode(undefined)
       onDismiss()


### PR DESCRIPTION
This passes in location as a prop to ComputeModal. We move the ajax call to Analyses, NotebookLauncher, AppLauncher, and CloudEnvironmentLauncher.

I tested manually by going to the pages that the launchers are on (like /workspaces/:namespace/:name/analysis/launch/:analysisName)