### PR TITLE
[DR-2210] Update page styling

### DIFF
--- a/src/components/input.js
+++ b/src/components/input.js
@@ -230,8 +230,8 @@ const AutocompleteSuggestions = ({ target: targetId, containerProps, children })
 }
 
 const withAutocomplete = WrappedComponent => ({
-  instructions, itemToString, value, onChange, onPick, suggestions: rawSuggestions, style, id, labelId,
-  renderSuggestion = _.identity, openOnFocus = true, suggestionFilter = Utils.textMatch, placeholderText, ...props
+  instructions, itemToString, value, onChange, onPick, suggestions: rawSuggestions, style, id, labelId, inputIcon,
+  iconStyle = {}, renderSuggestion = _.identity, openOnFocus = true, suggestionFilter = Utils.textMatch, placeholderText, ...props
 }) => {
   Utils.useLabelAssert('withAutocomplete', { id, 'aria-labelledby': labelId, ...props, allowId: true })
 
@@ -253,10 +253,14 @@ const withAutocomplete = WrappedComponent => ({
     ({ getInputProps, getMenuProps, getItemProps, isOpen, openMenu, toggleMenu, highlightedIndex }) => {
       return div({
         onFocus: openOnFocus ? openMenu : undefined,
-        style: { width: '100%', display: 'inline-flex' }
+        style: { width: style?.width || '100%', display: 'inline-flex', position: 'relative' }
       }, [
+        inputIcon && icon(inputIcon, {
+          style: { transform: 'translateX(1.5rem)', alignSelf: 'center', color: colors.accent(), position: 'absolute', ...iconStyle },
+          size: 18
+        }),
         h(WrappedComponent, getInputProps({
-          style,
+          style: inputIcon ? { ...style, paddingLeft: '3rem' } : style,
           type: 'search',
           onKeyDown: e => {
             if (e.key === 'Escape') {

--- a/src/components/input.js
+++ b/src/components/input.js
@@ -230,15 +230,17 @@ const AutocompleteSuggestions = ({ target: targetId, containerProps, children })
 }
 
 const withAutocomplete = WrappedComponent => ({
-  instructions, value, onChange, onPick, suggestions: rawSuggestions, style, id, labelId,
-  renderSuggestion = _.identity, openOnFocus = true, placeholderText, ...props
+  instructions, itemToString, value, onChange, onPick, suggestions: rawSuggestions, style, id, labelId,
+  renderSuggestion = _.identity, openOnFocus = true, suggestionFilter = Utils.textMatch, placeholderText, ...props
 }) => {
   Utils.useLabelAssert('withAutocomplete', { id, 'aria-labelledby': labelId, ...props, allowId: true })
 
-  const suggestions = _.filter(Utils.textMatch(value), rawSuggestions)
+  const suggestions = _.filter(suggestionFilter(value), rawSuggestions)
+  const controlProps = itemToString ? { itemToString: v => v ? itemToString(v) : value } : { selectedItem: value }
 
   return h(Downshift, {
-    selectedItem: value,
+    ...controlProps,
+    initialInputValue: value,
     onSelect: v => !!v && onPick?.(v),
     onInputValueChange: newValue => {
       if (newValue !== value) {
@@ -268,6 +270,7 @@ const withAutocomplete = WrappedComponent => ({
               e.nativeEvent.preventDownshiftDefault = true
             } else if (e.key === 'Enter') {
               onPick && onPick(value)
+              toggleMenu()
             }
           },
           nativeOnChange: true,
@@ -283,7 +286,7 @@ const withAutocomplete = WrappedComponent => ({
           }, [placeholderText])]],
           [!_.isEmpty(suggestions), () => _.map(([index, item]) => {
             return div(getItemProps({
-              item, key: item,
+              item, key: index,
               style: styles.suggestion(highlightedIndex === index)
             }), [renderSuggestion(item)])
           }, Utils.toIndexPairs(suggestions))])
@@ -294,6 +297,8 @@ const withAutocomplete = WrappedComponent => ({
 }
 
 export const AutocompleteTextInput = withAutocomplete(TextInput)
+
+export const DelayedAutoCompleteInput = withDebouncedChange(AutocompleteTextInput)
 
 export const TextArea = ({ onChange, autosize = false, nativeOnChange = false, ...props }) => {
   Utils.useLabelAssert('TextArea', { ...props, allowId: true })

--- a/src/pages/library/common.js
+++ b/src/pages/library/common.js
@@ -90,7 +90,6 @@ const Sidebar = ({ onSectionFilter, onTagFilter, sections, selectedSections, sel
 }
 
 const reverseText = _.flow(_.reverse, _.join(''))
-const contextualLength = 80
 
 // truncateLeftWord
 // This will behave like Lodash's _.truncate except it will truncate from the left side of the string.
@@ -104,13 +103,11 @@ const truncateLeftWord = _.curry((options, text) => _.flow(
 )(text))
 
 const getContextualSuggestion = ([leftContext, match, rightContext]) => {
-  const contextLength = Math.floor(contextualLength / 2)
-
   return [
     strong([em(['Description: '])]),
-    truncateLeftWord({ length: contextLength }, leftContext),
+    truncateLeftWord({ length: 40 }, leftContext),
     match,
-    _.truncate({ length: contextLength }, rightContext)
+    _.truncate({ length: 40 }, rightContext)
   ]
 }
 

--- a/src/pages/library/common.js
+++ b/src/pages/library/common.js
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp'
 import * as qs from 'qs'
 import { Fragment, useMemo, useState } from 'react'
-import { div, em, h, label, strong } from 'react-hyperscript-helpers'
+import { div, em, h, label, span, strong } from 'react-hyperscript-helpers'
 import Collapse from 'src/components/Collapse'
 import { Clickable, IdContainer, Link, Select } from 'src/components/common'
 import { DelayedAutoCompleteInput } from 'src/components/input'
@@ -70,7 +70,7 @@ const Sidebar = ({ onSectionFilter, onTagFilter, sections, selectedSections, sel
           style: styles.nav.navSection,
           buttonStyle: styles.nav.title,
           titleFirst: true, initialOpenState: true,
-          title: name
+          title: h(Fragment, [name, span({ style: { marginLeft: '0.5rem', fontWeight: 400 } }, [`(${_.size(labels)})`])])
         }, [_.map(label => {
           const tag = _.toLower(label)
           return h(Clickable, {
@@ -238,7 +238,7 @@ export const SearchAndFilterComponent = ({ fullList, sidebarSections, customSort
         },
         suggestions: filteredData
       }),
-      div({ style: { fontSize: '1rem', fontWeight: 600 } }, [`Results For "${searchFilter}"`]),
+      div({ style: { fontSize: '1rem', fontWeight: 600 } }, [searchFilter ? `Results For "${searchFilter}"` : 'All datasets']),
       !customSort && h(IdContainer, [
         id => h(Fragment, [
           label({ htmlFor: id, style: { margin: '0 0.5rem 0 1rem', whiteSpace: 'nowrap' } }, ['Sort by']),

--- a/src/pages/library/common.js
+++ b/src/pages/library/common.js
@@ -95,12 +95,14 @@ const truncateLeftWord = _.curry((options, text) => _.flow(
   _.replace(/\.\.\.(\S+)/, '...')
 )(text))
 
+const contextualLength = 60
 const getContextualSuggestion = ([leftContext, match, rightContext]) => {
+  const contextLength = Math.floor(contextualLength / 2)
   return [
     strong([em(['Description: '])]),
-    truncateLeftWord({ length: 50 }, leftContext),
+    truncateLeftWord({ length: contextLength }, leftContext),
     match,
-    _.truncate({ length: 50 }, rightContext)
+    _.truncate({ length: contextLength }, rightContext)
   ]
 }
 
@@ -195,7 +197,9 @@ export const SearchAndFilterComponent = ({ fullList, sidebarSections, customSort
         ])
       ]),
       h(DelayedAutoCompleteInput, {
-        style: { flex: 1, marginLeft: '1rem' },
+        style: { borderRadius: 25, width: 800, flex: 1, margin: '1rem' },
+        inputIcon: 'search',
+        iconStyle: { transform: 'translateX(2.5rem)' },
         openOnFocus: true,
         value: searchFilter,
         'aria-label': `Search ${searchType}`,
@@ -208,10 +212,11 @@ export const SearchAndFilterComponent = ({ fullList, sidebarSections, customSort
             _.flow(
               _.split(filterRegex),
               _.map(item => _.toLower(item) === _.toLower(searchFilter) ? strong([item]) : item),
-              match => {
-                return _.size(match) < 2 ?
-                  [...match, div({ style: { lineHeight: '1.5rem', marginLeft: '2rem' } }, [...getContext(suggestion['dct:description'])])] :
-                  match
+              maybeMatch => {
+                return _.size(maybeMatch) < 2 ? [
+                  _.truncate({ length: contextualLength }, _.head(maybeMatch)),
+                  div({ style: { lineHeight: '1.5rem', marginLeft: '2rem' } }, [...getContext(suggestion['dct:description'])])
+                ] : maybeMatch
               }
             )(suggestion['dct:title'])
           )

--- a/src/pages/library/common.js
+++ b/src/pages/library/common.js
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp'
 import * as qs from 'qs'
 import { Fragment, useMemo, useState } from 'react'
-import { div, em, h, label, strong } from 'react-hyperscript-helpers'
+import { div, em, h, h3, label, strong } from 'react-hyperscript-helpers'
 import Collapse from 'src/components/Collapse'
 import { Clickable, IdContainer, Link, Select } from 'src/components/common'
 import { DelayedAutoCompleteInput } from 'src/components/input'
@@ -19,7 +19,7 @@ export const commonStyles = {
 
 const styles = {
   header: {
-    fontSize: 19, color: colors.dark(), fontWeight: 'bold', marginBottom: '1rem'
+    fontSize: '1.5rem', color: colors.dark(), fontWeight: 700
   },
   sidebarRow: {
     display: 'flex', justifyContent: 'space-between', alignItems: 'baseline'
@@ -88,7 +88,7 @@ const Sidebar = ({ onSectionFilter, onTagFilter, sections, selectedSections, sel
 }
 
 const reverseText = _.flow(_.reverse, _.join(''))
-const contextualLength = 60
+const contextualLength = 80
 
 // truncateLeftWord
 // This will behave like Lodash's _.truncate except it will truncate from the left side of the string.
@@ -186,26 +186,33 @@ export const SearchAndFilterComponent = ({ fullList, sidebarSections, customSort
   }
 
   return h(Fragment, [
-    div({ style: { display: 'flex', margin: '1rem 1rem 0', alignItems: 'baseline' } }, [
-      div({ style: { width: '19rem', flex: 'none' } }, [
-        div({ style: styles.sidebarRow }, [
-          div({ style: styles.header }, [`${searchType}`]),
-          div({ style: styles.pill(_.isEmpty(selectedSections) && _.isEmpty(selectedTags)) }, [_.size(filteredData)])
-        ]),
-        div({ style: { display: 'flex', alignItems: 'center', height: '2.5rem' } }, [
-          div({ style: { flex: 1 } }),
-          h(Link, {
-            onClick: () => {
-              setSelectedSections([])
-              setSelectedTags([])
-            }
-          }, ['clear'])
-        ])
+    div({
+      style: {
+        display: 'grid',
+        gridTemplateColumns: '19rem 1fr',
+        gridTemplateRows: 'auto 2rem',
+        gap: '2rem 1rem',
+        gridAutoFlow: 'column',
+        margin: '1rem 1rem 0',
+        alignItems: 'baseline'
+      }
+    }, [
+      div({ style: styles.sidebarRow }, [
+        div({ style: styles.header }, [searchType]),
+        div({ style: styles.pill(_.isEmpty(selectedSections) && _.isEmpty(selectedTags)) }, [_.size(filteredData)])
+      ]),
+      div({ style: { display: 'flex', alignItems: 'baseline' } }, [
+        div({ style: { margin: 0, flex: 1, fontSize: '1.125rem', fontWeight: 600 } }, ['Filters']),
+        h(Link, {
+          onClick: () => {
+            setSelectedSections([])
+            setSelectedTags([])
+          }
+        }, ['clear'])
       ]),
       h(DelayedAutoCompleteInput, {
-        style: { borderRadius: 25, width: 800, flex: 1, margin: '1rem' },
+        style: { borderRadius: 25, width: 800, flex: 1 },
         inputIcon: 'search',
-        iconStyle: { transform: 'translateX(2.5rem)' },
         openOnFocus: true,
         value: searchFilter,
         'aria-label': `Search ${searchType}`,
@@ -220,7 +227,7 @@ export const SearchAndFilterComponent = ({ fullList, sidebarSections, customSort
               _.map(item => _.toLower(item) === _.toLower(searchFilter) ? strong([item]) : item),
               maybeMatch => {
                 return _.size(maybeMatch) < 2 ? [
-                  _.truncate({ length: contextualLength }, _.head(maybeMatch)),
+                  _.truncate({ length: 90 }, _.head(maybeMatch)),
                   div({ style: { lineHeight: '1.5rem', marginLeft: '2rem' } }, [...getContext(suggestion['dct:description'])])
                 ] : maybeMatch
               }
@@ -229,6 +236,7 @@ export const SearchAndFilterComponent = ({ fullList, sidebarSections, customSort
         },
         suggestions: filteredData
       }),
+      div({ style: { fontSize: '1rem', fontWeight: 600 } }, [`Results For "${searchFilter}"`]),
       !customSort && h(IdContainer, [
         id => h(Fragment, [
           label({ htmlFor: id, style: { margin: '0 0.5rem 0 1rem', whiteSpace: 'nowrap' } }, ['Sort by']),

--- a/src/pages/library/common.js
+++ b/src/pages/library/common.js
@@ -81,7 +81,7 @@ const Sidebar = ({ onSectionFilter, onTagFilter, sections, selectedSections, sel
             },
             onClick: () => onTagFilter(tag)
           }, [
-            div({ style: { flex: 1 } }, [...(labelDisplays && labelDisplays[label] ? labelDisplays[label] : label)]),
+            div({ style: { lineHeight: '1.375rem', flex: 1 } }, [...(labelDisplays && labelDisplays[label] ? labelDisplays[label] : label)]),
             div({ style: styles.pill(_.includes(tag, selectedTags)) }, [_.size(listDataByTag[tag])])
           ])
         }, labels)])

--- a/src/pages/library/common.js
+++ b/src/pages/library/common.js
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp'
 import * as qs from 'qs'
 import { Fragment, useMemo, useState } from 'react'
-import { div, em, h, h3, label, strong } from 'react-hyperscript-helpers'
+import { div, em, h, label, strong } from 'react-hyperscript-helpers'
 import Collapse from 'src/components/Collapse'
 import { Clickable, IdContainer, Link, Select } from 'src/components/common'
 import { DelayedAutoCompleteInput } from 'src/components/input'
@@ -26,16 +26,15 @@ const styles = {
   },
   nav: {
     navSection: {
-      alignItems: 'center', flex: 'none', padding: '1.2rem 0',
-      borderTop: `1px solid ${colors.dark(0.35)}`
+      alignItems: 'center', flex: 'none', padding: '0.5rem 0'
     },
-    title: { fontWeight: 700 }
+    title: { color: colors.dark(), fontWeight: 700, borderBottom: `1px solid ${colors.dark(0.3)}`, paddingBottom: '0.75rem' }
   },
   pill: highlight => ({
     width: '4.5rem', padding: '0.25rem', fontWeight: 500, textAlign: 'center',
     border: '1px solid', borderColor: colors.dark(0.25), borderRadius: '1rem',
     backgroundColor: 'white',
-    ...(highlight ? { color: 'white', backgroundColor: colors.accent(), borderColor: colors.accent() } : {})
+    ...(highlight ? { color: 'white', backgroundColor: colors.primary(), borderColor: colors.primary() } : {})
   })
 }
 
@@ -76,7 +75,10 @@ const Sidebar = ({ onSectionFilter, onTagFilter, sections, selectedSections, sel
           const tag = _.toLower(label)
           return h(Clickable, {
             key: label,
-            style: { display: 'flex', alignItems: 'baseline', margin: '0.5rem 0' },
+            style: {
+              display: 'flex', alignItems: 'baseline', margin: '0.5rem 0',
+              paddingBottom: '0.5rem', borderBottom: `1px solid ${colors.dark(0.1)}`
+            },
             onClick: () => onTagFilter(tag)
           }, [
             div({ style: { flex: 1 } }, [...(labelDisplays && labelDisplays[label] ? labelDisplays[label] : label)]),
@@ -190,7 +192,7 @@ export const SearchAndFilterComponent = ({ fullList, sidebarSections, customSort
       style: {
         display: 'grid',
         gridTemplateColumns: '19rem 1fr',
-        gridTemplateRows: 'auto 2rem',
+        gridTemplateRows: 'auto 3rem',
         gap: '2rem 1rem',
         gridAutoFlow: 'column',
         margin: '1rem 1rem 0',
@@ -201,8 +203,8 @@ export const SearchAndFilterComponent = ({ fullList, sidebarSections, customSort
         div({ style: styles.header }, [searchType]),
         div({ style: styles.pill(_.isEmpty(selectedSections) && _.isEmpty(selectedTags)) }, [_.size(filteredData)])
       ]),
-      div({ style: { display: 'flex', alignItems: 'baseline' } }, [
-        div({ style: { margin: 0, flex: 1, fontSize: '1.125rem', fontWeight: 600 } }, ['Filters']),
+      div({ style: { ...styles.nav.title, display: 'flex', alignItems: 'baseline' } }, [
+        div({ style: { flex: 1, fontSize: '1.125rem', fontWeight: 600 } }, ['Filters']),
         h(Link, {
           onClick: () => {
             setSelectedSections([])

--- a/src/pages/library/common.js
+++ b/src/pages/library/common.js
@@ -1,10 +1,12 @@
 import _ from 'lodash/fp'
-import { Fragment, useState } from 'react'
-import { div, h, label } from 'react-hyperscript-helpers'
+import * as qs from 'qs'
+import { Fragment, useMemo, useState } from 'react'
+import { div, em, h, label, strong } from 'react-hyperscript-helpers'
 import Collapse from 'src/components/Collapse'
 import { Clickable, IdContainer, Link, Select } from 'src/components/common'
-import { DelayedSearchInput } from 'src/components/input'
+import { DelayedAutoCompleteInput } from 'src/components/input'
 import colors from 'src/libs/colors'
+import * as Nav from 'src/libs/nav'
 
 
 export const commonStyles = {
@@ -85,11 +87,30 @@ const Sidebar = ({ onSectionFilter, onTagFilter, sections, selectedSections, sel
   ])
 }
 
+const reverseText = _.flow(_.split(''), _.reverse, _.join(''))
+const truncateLeftWord = _.curry((options, text) => _.flow(
+  reverseText,
+  _.truncate(options),
+  reverseText,
+  _.replace(/\.\.\.(\S+)/, '...')
+)(text))
+
+const getContextualSuggestion = ([leftContext, match, rightContext]) => {
+  return [
+    strong([em(['Description: '])]),
+    truncateLeftWord({ length: 50 }, leftContext),
+    match,
+    _.truncate({ length: 50 }, rightContext)
+  ]
+}
+
 export const SearchAndFilterComponent = ({ fullList, sidebarSections, customSort, searchType, children }) => {
+  const { query } = Nav.useRoute()
+  const searchFilter = query.filter || ''
   const [selectedSections, setSelectedSections] = useState([])
   const [selectedTags, setSelectedTags] = useState([])
-  const [searchFilter, setSearchFilter] = useState('')
   const [sort, setSort] = useState({ field: 'created', direction: 'desc' })
+  const filterRegex = new RegExp(`(${searchFilter})`, 'i')
 
   const listDataByTag = _.omitBy(_.isEmpty, groupByFeaturedTags(fullList, sidebarSections))
 
@@ -106,40 +127,62 @@ export const SearchAndFilterComponent = ({ fullList, sidebarSections, customSort
     _.remove(section => _.isEmpty(section.labels))
   )(sidebarSections)
 
-  const filterBySections = listData => {
-    if (_.isEmpty(selectedSections)) {
-      return listData
-    } else {
-      const tags = _.uniqBy(_.flatMap('tags', selectedSections))
-      return _.uniq(_.flatMap(tag => listDataByTag[tag], tags))
-    }
-  }
-  const filterByTags = listData => {
-    if (_.isEmpty(selectedTags)) {
-      return listData
-    } else {
-      return _.reduce(
-        (acc, tag) => _.intersection(listDataByTag[tag], acc),
-        listDataByTag[_.head(selectedTags)],
-        _.tail(selectedTags)
-      )
-    }
-  }
-  const filterByText = _.filter(({ lowerName, lowerDescription }) => _.includes(searchFilter, `${lowerName} ${lowerDescription}`))
+  const getContext = _.flow(
+    _.split(filterRegex),
+    getContextualSuggestion,
+    _.map(item => _.toLower(item) === _.toLower(searchFilter) ? strong([item]) : item)
+  )
 
-  const filteredList = _.flow(
-    filterBySections,
-    filterByTags,
-    filterByText,
-    customSort ? _.orderBy([customSort.field], [customSort.direction]) : _.orderBy([sort.field], [sort.direction])
-  )(fullList)
+  const filteredData = useMemo(() => {
+    const filterByText = _.filter(({ lowerName, lowerDescription }) => _.includes(_.toLower(searchFilter), `${lowerName} ${lowerDescription}`))
+
+    const filterBySections = listData => {
+      if (_.isEmpty(selectedSections)) {
+        return listData
+      } else {
+        const tags = _.uniqBy(_.flatMap('tags', selectedSections))
+        return _.uniq(_.flatMap(tag => listDataByTag[tag], tags))
+      }
+    }
+
+    const filterByTags = listData => {
+      if (_.isEmpty(selectedTags)) {
+        return listData
+      } else {
+        return _.reduce(
+          (acc, tag) => _.intersection(listDataByTag[tag], acc),
+          listDataByTag[_.head(selectedTags)],
+          _.tail(selectedTags)
+        )
+      }
+    }
+
+    return _.flow(
+      filterBySections,
+      filterByTags,
+      filterByText,
+      customSort ? _.orderBy([customSort.field], [customSort.direction]) : _.orderBy([sort.field], [sort.direction])
+    )(fullList)
+  }, [fullList, searchFilter, customSort, sort, listDataByTag, selectedTags, selectedSections])
+
+
+  const onSearchChange = filter => {
+    const newSearch = qs.stringify({
+      ...query,
+      filter: filter || undefined
+    }, { addQueryPrefix: true })
+
+    if (newSearch !== Nav.history.location.search) {
+      Nav.history.replace({ search: newSearch })
+    }
+  }
 
   return h(Fragment, [
     div({ style: { display: 'flex', margin: '1rem 1rem 0', alignItems: 'baseline' } }, [
       div({ style: { width: '19rem', flex: 'none' } }, [
         div({ style: styles.sidebarRow }, [
           div({ style: styles.header }, [`${searchType}`]),
-          div({ style: styles.pill(_.isEmpty(selectedSections) && _.isEmpty(selectedTags)) }, [_.size(filteredList)])
+          div({ style: styles.pill(_.isEmpty(selectedSections) && _.isEmpty(selectedTags)) }, [_.size(filteredData)])
         ]),
         div({ style: { display: 'flex', alignItems: 'center', height: '2.5rem' } }, [
           div({ style: { flex: 1 } }),
@@ -151,12 +194,29 @@ export const SearchAndFilterComponent = ({ fullList, sidebarSections, customSort
           }, ['clear'])
         ])
       ]),
-      h(DelayedSearchInput, {
+      h(DelayedAutoCompleteInput, {
         style: { flex: 1, marginLeft: '1rem' },
+        openOnFocus: true,
+        value: searchFilter,
         'aria-label': `Search ${searchType}`,
         placeholder: 'Search Name or Description',
-        value: searchFilter,
-        onChange: setSearchFilter
+        itemToString: v => v['dct:title'],
+        onChange: onSearchChange,
+        suggestionFilter: _.curry((needle, { lowerName, lowerDescription }) => _.includes(_.toLower(needle), `${lowerName} ${lowerDescription}`)),
+        renderSuggestion: suggestion => {
+          return div({ style: { lineHeight: '1.75rem', padding: '0.375rem 0', borderBottom: `1px dotted ${colors.dark(0.7)}` } },
+            _.flow(
+              _.split(filterRegex),
+              _.map(item => _.toLower(item) === _.toLower(searchFilter) ? strong([item]) : item),
+              match => {
+                return _.size(match) < 2 ?
+                  [...match, div({ style: { lineHeight: '1.5rem', marginLeft: '2rem' } }, [...getContext(suggestion['dct:description'])])] :
+                  match
+              }
+            )(suggestion['dct:title'])
+          )
+        },
+        suggestions: filteredData
       }),
       !customSort && h(IdContainer, [
         id => h(Fragment, [
@@ -184,12 +244,12 @@ export const SearchAndFilterComponent = ({ fullList, sidebarSections, customSort
           sections,
           selectedSections,
           selectedTags,
-          listDataByTag: groupByFeaturedTags(filteredList, sidebarSections)
+          listDataByTag: groupByFeaturedTags(filteredData, sidebarSections)
         })
       ]),
       div({ style: { marginLeft: '1rem', minWidth: 0, width: '100%', height: '100%' } }, [
-        _.isEmpty(filteredList) ? div({ style: { margin: 'auto', textAlign: 'center' } }, ['No Results Found']) :
-          children({ filteredList, sections, selectedTags, setSelectedTags })
+        _.isEmpty(filteredData) ? div({ style: { margin: 'auto', textAlign: 'center' } }, ['No Results Found']) :
+          children({ filteredList: filteredData, sections, selectedTags, setSelectedTags })
       ])
     ])
   ])


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/DR-2210

This change is mostly about updated the styling of the data explorer page to better match the mock:
https://projects.invisionapp.com/d/main#/console/21637590/457826296/inspect

I did make a change to the autocomplete input so it can accept an icon, in this case a search / magnifying glass icon.

## Before
![image](https://user-images.githubusercontent.com/50371603/139283140-d84ed4c1-53f8-4272-a649-e1d3c512edb7.png)

## After
![image](https://user-images.githubusercontent.com/50371603/139282920-4f1e5155-7285-4fc2-857d-35f9e375e2da.png)

