### PR TITLE
[CA-1141] Add the ability to remove billing account and clean up

### DIFF
--- a/src/components/common.js
+++ b/src/components/common.js
@@ -86,15 +86,15 @@ export const Clickable = Utils.forwardRefWithName('Clickable', ({ href, as = (!!
   }
 })
 
-export const Link = Utils.forwardRefWithName('Link', ({ disabled, variant, children, ...props }, ref) => {
+export const Link = Utils.forwardRefWithName('Link', ({ disabled, variant, children, baseColor = colors.accent, ...props }, ref) => {
   return h(Clickable, _.merge({
     ref,
     style: { // 0.72 is the min to meet ANDI's contrast requirement
-      color: disabled ? colors.dark(0.72) : colors.accent(variant === 'light' ? 0.3 : 1),
+      color: disabled ? colors.dark(0.72) : baseColor(variant === 'light' ? 0.3 : 1),
       cursor: disabled ? 'not-allowed' : 'pointer',
       fontWeight: 500, display: 'inline'
     },
-    hover: disabled ? undefined : { color: colors.accent(variant === 'light' ? 0.1 : 0.8) },
+    hover: disabled ? undefined : { color: baseColor(variant === 'light' ? 0.1 : 0.8) },
     disabled
   }, props), [children])
 })

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -468,6 +468,12 @@ const Billing = signal => ({
     return res
   },
 
+  removeBillingAccount: async ({ billingProjectName }) => {
+    const res = await fetchOrchestration(`api/billing/v2/${billingProjectName}/billingAccount`,
+      _.merge(authOpts(), { signal, method: 'DELETE' }))
+    return res
+  },
+
   updateSpendConfiguration: async ({ billingProjectName, datasetGoogleProject, datasetName }) => {
     const res = await fetchOrchestration(`api/billing/v2/${billingProjectName}/spendReportConfiguration`,
       _.mergeAll([
@@ -1166,19 +1172,6 @@ const GoogleBilling = signal => ({
     const response = await fetchGoogleBilling(`${billingAccountName}/projects`, _.merge(authOpts(), { signal }))
     const json = await response.json()
     return _.map('projectId', json.projectBillingInfo)
-  },
-  getBillingInfo: async project => {
-    const response = await fetchGoogleBilling(`projects/${project}/billingInfo`, _.merge(authOpts(), { signal }))
-    return response.json()
-  },
-  changeBillingAccount: async ({ projectId, newAccountName }) => {
-    const name = `projects/${projectId}/billingInfo`
-    const response = await fetchGoogleBilling(name,
-      _.mergeAll([
-        authOpts(), { signal, method: 'PUT' },
-        jsonBody({ billingEnabled: true, billingAccountName: newAccountName, name, projectId })
-      ]))
-    return response.json()
   }
 })
 

--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -24,6 +24,7 @@ const eventsList = {
   notebookRename: 'notebook:rename',
   notebookCopy: 'notebook:copy',
   pageView: 'page:view',
+  removeBillingAccount: 'billing:project:account:remove',
   userRegister: 'user:register',
   workflowImport: 'workflow:import',
   workflowLaunch: 'workflow:launch',

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -384,6 +384,7 @@ const ProjectDetail = ({ billingProject, reloadBillingProject, billingAccounts, 
         h(Link, {
           tooltip: 'Remove Billing Account',
           style: { marginLeft: '0.5rem' },
+          disabled: billingProject.billingAccount === 'null',
           baseColor: colors.danger,
           onClick: async () => {
             if (Auth.hasBillingScope()) {
@@ -423,7 +424,7 @@ const ProjectDetail = ({ billingProject, reloadBillingProject, billingAccounts, 
           onDismiss: () => setShowBillingRemovalModal(false),
           okButton: h(ButtonPrimary, {
             onClick: () => {
-              setShowBillingModal(false)
+              setShowBillingRemovalModal(false)
               removeBillingAccount(selectedBilling).then(reloadBillingProject)
             }
           }, ['Ok'])

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -384,7 +384,8 @@ const ProjectDetail = ({ billingProject, reloadBillingProject, billingAccounts, 
         h(Link, {
           tooltip: 'Remove Billing Account',
           style: { marginLeft: '0.5rem' },
-          disabled: billingProject.billingAccount === 'null',
+          // For some reason the api sometimes returns string null, and sometimes returns no field, and soemtimes returns null. This is just to be complete.
+          disabled: billingProject.billingAccount === 'null' || billingProject.billingAccount === undefined || billingProject.billingAccount === null,
           baseColor: colors.danger,
           onClick: async () => {
             if (Auth.hasBillingScope()) {

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -393,7 +393,7 @@ const ProjectDetail = ({ billingProject, reloadBillingProject, billingAccounts, 
               setShowBillingRemovalModal(Auth.hasBillingScope())
             }
           }
-        }, [icon('trash', { size: 12 })]),
+        }, [icon('times-circle', { size: 12 })]),
         showBillingModal && h(Modal, {
           title: 'Change Billing Account',
           onDismiss: () => setShowBillingModal(false),


### PR DESCRIPTION
Hi! I wanted to get this in given the Prod incident that happened, this should make it a lot easier for our billing project owners to re-remove their billing accounts, which seems like something that given the prod incident we should fix. This adds a red icon as shown. I have not run it by UX, but it seems in line with what we are already doing, so I figure we can try this and UX can weigh in with follow ups. (Just so this goes ASAP)
<img width="448" alt="Screen Shot 2021-10-29 at 11 53 45 AM" src="https://user-images.githubusercontent.com/15351021/139473449-22fe8628-e38e-487a-a05b-a1698152e464.png">
