### PR TITLE
Support more than just Galaxy apps [BW-891]

### DIFF
--- a/src/libs/runtime-utils.js
+++ b/src/libs/runtime-utils.js
@@ -154,6 +154,8 @@ export const runtimeCost = ({ runtimeConfig, status }) => {
   }
 }
 
+export const isApp = cloudEnvironment => !!cloudEnvironment?.appName
+
 export const getGalaxyCost = (app, dataDiskSize) => {
   return getGalaxyDiskCost(dataDiskSize) + getGalaxyComputeCost(app)
 }

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -17,8 +17,8 @@ import colors from 'src/libs/colors'
 import { withErrorIgnoring, withErrorReporting } from 'src/libs/error'
 import {
   defaultComputeRegion,
-  defaultComputeZone, getComputeStatusForDisplay, getCurrentApp, getCurrentRuntime, getGalaxyComputeCost, getGalaxyCost, getPersistentDiskCostMonthly, isComputePausable,
-  isResourceDeletable, runtimeCost
+  defaultComputeZone, getComputeStatusForDisplay, getCurrentApp, getCurrentRuntime, getGalaxyComputeCost, getGalaxyCost, getPersistentDiskCostMonthly,
+  isApp, isComputePausable, isResourceDeletable, runtimeCost
 } from 'src/libs/runtime-utils'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
@@ -338,7 +338,7 @@ const Environments = () => {
             headerRenderer: () => h(Sortable, { sort, field: 'created', onSort: setSort }, ['Type']),
             cellRenderer: ({ rowIndex }) => {
               const cloudEnvironment = filteredCloudEnvironments[rowIndex]
-              return cloudEnvironment.appName ?
+              return isApp(cloudEnvironment) ?
                 (cloudEnvironment.appType ? _.capitalize(cloudEnvironment.appType) : 'Galaxy') :
                 (cloudEnvironment.runtimeConfig.cloudService === 'DATAPROC' ? 'Dataproc' : cloudEnvironment.runtimeConfig.cloudService)
             }

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -454,8 +454,8 @@ const Environments = () => {
                   app && div([
                     span({ style: { fontWeight: 600 } },
                       [app.appType ? `${_.capitalize(app.appType)}: ` : 'Galaxy: ']
-                    ), app.appName]
-                  )
+                    ), app.appName
+                  ])
                 ])
               }, [h(Link, ['view'])])
             }

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -334,13 +334,12 @@ const Environments = () => {
             }
           },
           {
-            size: { basis: 90, grow: 0 },
+            size: { basis: 100, grow: 0 },
             headerRenderer: () => h(Sortable, { sort, field: 'created', onSort: setSort }, ['Type']),
             cellRenderer: ({ rowIndex }) => {
               const cloudEnvironment = filteredCloudEnvironments[rowIndex]
-              // TODO: update return logic once we support more app types (will need a backend change to return appType in list apps endpoint as well)
               return cloudEnvironment.appName ?
-                'Galaxy' :
+                (cloudEnvironment.appType ? _.capitalize(cloudEnvironment.appType) : 'Galaxy') :
                 (cloudEnvironment.runtimeConfig.cloudService === 'DATAPROC' ? 'Dataproc' : cloudEnvironment.runtimeConfig.cloudService)
             }
           },

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -451,7 +451,11 @@ const Environments = () => {
                 content: div({ style: { padding: '0.5rem' } }, [
                   div([span({ style: { fontWeight: 600 } }, ['Name: ']), name]),
                   runtime && div([span({ style: { fontWeight: 600 } }, ['Runtime: ']), runtime.runtimeName]),
-                  app && div([span({ style: { fontWeight: 600 } }, ['Galaxy: ']), app.appName])
+                  app && div([
+                    span({ style: { fontWeight: 600 } },
+                      [app.appType ? `${_.capitalize(app.appType)}: ` : 'Galaxy: ']
+                    ), app.appName]
+                  )
                 ])
               }, [h(Link, ['view'])])
             }


### PR DESCRIPTION
I am adding appType to the listApps API method (and getApp). To make this change not have to wait for the Leo code to merge, I am checking whether or not appType is present.

Example with a Cromwell App:

![image](https://user-images.githubusercontent.com/484484/139745881-42b7a984-8fdb-437f-8921-f25029b11d16.png)

