### PR TITLE
[IA-3040] Change EU multi-region default zone/region to europe-north1

### DIFF
--- a/src/components/region-common.js
+++ b/src/components/region-common.js
@@ -17,7 +17,7 @@ export const getRegionInfo = (location, locationType) => {
   return Utils.switchCase(locationType,
     ['multi-region', () => Utils.switchCase(location,
       ['US', () => ({ flag: '🇺🇸', regionDescription, computeZone: 'US-CENTRAL1-A', computeRegion: 'US-CENTRAL1' })],
-      ['EU', () => ({ flag: '🇪🇺', regionDescription, computeZone: 'EUROPE-CENTRAL2-A', computeRegion: 'EUROPE-CENTRAL2' })],
+      ['EU', () => ({ flag: '🇪🇺', regionDescription, computeZone: 'EUROPE-NORTH1-A', computeRegion: 'EUROPE-NORTH1' })],
       ['ASIA', () => ({ flag: '🌏', regionDescription, computeZone: 'ASIA-EAST1-A', computeRegion: 'ASIA-EAST1' })],
       [Utils.DEFAULT, () => ({ flag: unknownRegionFlag, regionDescription, computeZone: 'UNKNOWN', computeRegion: 'UNKNOWN' })]
     )],


### PR DESCRIPTION
EUROPE-CENTRAL2 is a relatively new GCP region, so change it to an older one with more support across Terra infra. 

This is a very low-impact change, as it is not possible to create EU multi-regional workspace buckets atm. 
