### PR TITLE
Add redirect for RAS [POL-106]

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import { loadedConfigStore } from 'src/configStore'
 
 
 const loadApp = async () => {
-  const res = await fetch('/config.json')
+  const res = await fetch(`${process.env.PUBLIC_URL}/config.json`)
   loadedConfigStore.current = await res.json()
 
   import('src/appLoader')

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import { loadedConfigStore } from 'src/configStore'
 
 
 const loadApp = async () => {
-  const res = await fetch('config.json')
+  const res = await fetch('/config.json')
   loadedConfigStore.current = await res.json()
 
   import('src/appLoader')

--- a/src/libs/nav.js
+++ b/src/libs/nav.js
@@ -118,9 +118,10 @@ export const updateSearch = (query, params) => {
 export const PathHashInserter = () => {
   Utils.useOnMount(() => {
     const loc = window.location
-    if (loc.pathname !== process.env.PUBLIC_URL) {
+    const desiredPath = `${process.env.PUBLIC_URL}/`
+    if (loc.pathname !== desiredPath) {
       history.replace({ pathname: loc.pathname.substr(1), search: loc.search })
-      window.history.replaceState({}, '', process.env.PUBLIC_URL)
+      window.history.replaceState({}, '', desiredPath)
     }
   })
   return null

--- a/src/libs/nav.js
+++ b/src/libs/nav.js
@@ -118,9 +118,9 @@ export const updateSearch = (query, params) => {
 export const PathHashInserter = () => {
   Utils.useOnMount(() => {
     const loc = window.location
-    if (loc.pathname !== '/') {
+    if (loc.pathname !== process.env.PUBLIC_URL) {
       history.replace({ pathname: loc.pathname.substr(1), search: loc.search })
-      window.history.replaceState({}, '', '/')
+      window.history.replaceState({}, '', process.env.PUBLIC_URL)
     }
   })
   return null

--- a/src/libs/nav.js
+++ b/src/libs/nav.js
@@ -5,6 +5,7 @@ import { createContext, useContext, useEffect, useState } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
 import { getAppName } from 'src/libs/logos'
 import { routeHandlersStore } from 'src/libs/state'
+import * as Utils from 'src/libs/utils'
 import { atom, cond, useOnMount, useStore } from 'src/libs/utils'
 
 
@@ -112,4 +113,15 @@ export const updateSearch = (query, params) => {
   if (newSearch !== history.location.search) {
     history.replace({ search: newSearch })
   }
+}
+
+export const PathHashInserter = () => {
+  Utils.useOnMount(() => {
+    const loc = window.location
+    if (loc.pathname !== '/') {
+      history.replace({ pathname: loc.pathname.substr(1), search: loc.search })
+      window.history.replaceState({}, '', '/')
+    }
+  })
+  return null
 }

--- a/src/pages/Main.js
+++ b/src/pages/Main.js
@@ -21,6 +21,7 @@ import { LocationProvider, PathHashInserter, Router, TitleManager } from 'src/li
 
 const Main = () => {
   return h(LocationProvider, [
+    h(PathHashInserter),
     h(CookieWarning),
     h(ReactNotification),
     h(ImportStatus),
@@ -28,7 +29,6 @@ const Main = () => {
     h(Favicon),
     h(IdleStatusMonitor),
     h(ErrorWrapper, [
-      h(PathHashInserter),
       h(TitleManager),
       h(FirecloudNotification),
       h(AuthenticatedCookieSetter),

--- a/src/pages/Main.js
+++ b/src/pages/Main.js
@@ -16,7 +16,7 @@ import { AuthenticatedCookieSetter } from 'src/components/runtime-common'
 import ServiceAlerts from 'src/components/ServiceAlerts'
 import SupportRequest from 'src/components/SupportRequest'
 import { PageViewReporter } from 'src/libs/events'
-import { LocationProvider, Router, TitleManager } from 'src/libs/nav'
+import { LocationProvider, PathHashInserter, Router, TitleManager } from 'src/libs/nav'
 
 
 const Main = () => {
@@ -28,6 +28,7 @@ const Main = () => {
     h(Favicon),
     h(IdleStatusMonitor),
     h(ErrorWrapper, [
+      h(PathHashInserter),
       h(TitleManager),
       h(FirecloudNotification),
       h(AuthenticatedCookieSetter),

--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -435,8 +435,8 @@ export const navPaths = [
     title: 'Profile'
   },
   {
-    name: 'ras-callback',
-    path: '/ras-callback',
+    name: 'ecm-callback',
+    path: '/ecm-callback',
     component: Profile,
     title: 'Profile'
   }

--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -433,5 +433,11 @@ export const navPaths = [
     path: '/fence-callback',
     component: Profile,
     title: 'Profile'
+  },
+  {
+    name: 'ras-callback',
+    path: '/ras-callback',
+    component: Profile,
+    title: 'Profile'
   }
 ]


### PR DESCRIPTION
This isn't used yet. However!

**N.B. This changes routing behavior!**
If you go to **any** path that doesn't start with a hash, instead of the current behavior of unhelpfully dumping you to the landing page (or any hash path, if there also is one), it'll now go to the hash of that path, preserving the search if present.