### PR TITLE
[DC-68] Added link to data catalog to the nav bar

### DIFF
--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -17,7 +17,7 @@ import headerRightHexes from 'src/images/header-right-hexes.svg'
 import { Ajax } from 'src/libs/ajax'
 import { signOut } from 'src/libs/auth'
 import colors from 'src/libs/colors'
-import { getConfig, isBaseline, isBioDataCatalyst, isDatastage, isFirecloud, isTerra } from 'src/libs/config'
+import { getConfig, isBaseline, isBioDataCatalyst, isDataBrowserVisible, isDatastage, isFirecloud, isTerra } from 'src/libs/config'
 import { withErrorReporting } from 'src/libs/error'
 import { FormLabel } from 'src/libs/forms'
 import { topBarLogo, versionTag } from 'src/libs/logos'
@@ -220,6 +220,10 @@ const TopBar = ({ showMenu = true, title, href, children }) => {
               href: Nav.getLink('library-showcase'),
               onClick: hideNav
             }, ['Showcase']),
+            isDataBrowserVisible() && h(DropDownSubItem, {
+              href: Nav.getLink('library-browser'),
+              onClick: hideNav
+            }, ['Catalog']),
             h(DropDownSubItem, {
               href: Nav.getLink('library-code'),
               onClick: hideNav


### PR DESCRIPTION
Before
<img width="837" alt="screen_shot_2021-11-12_at_4 57 42_pm" src="https://user-images.githubusercontent.com/10501914/141539479-0aa32362-8cf1-4cde-8304-41b47aadc8dd.png">

After
<img width="836" alt="screen_shot_2021-11-12_at_4 57 12_pm" src="https://user-images.githubusercontent.com/10501914/141539468-1f2bf00a-423d-4144-9830-d425ab38a136.png">


