### PR TITLE
[DC-46] Allow filter data to persist when navigating pages

### DIFF
--- a/src/pages/library/common.js
+++ b/src/pages/library/common.js
@@ -9,6 +9,7 @@ import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import Events from 'src/libs/events'
 import * as Nav from 'src/libs/nav'
+import * as StateHistory from 'src/libs/state-history'
 
 
 export const commonStyles = {
@@ -117,7 +118,7 @@ export const SearchAndFilterComponent = ({ fullList, sidebarSections, customSort
   const { query } = Nav.useRoute()
   const searchFilter = query.filter || ''
   const [selectedSections, setSelectedSections] = useState([])
-  const [selectedTags, setSelectedTags] = useState(query.tags || [])
+  const [selectedTags, setSelectedTags] = useState(StateHistory.get().selectedTags || [])
   const [sort, setSort] = useState({ field: 'created', direction: 'desc' })
   const filterRegex = new RegExp(`(${searchFilter})`, 'i')
 
@@ -191,15 +192,8 @@ export const SearchAndFilterComponent = ({ fullList, sidebarSections, customSort
   }
 
   useEffect(() => {
-    const newTags = qs.stringify({
-      ...query,
-      tags: selectedTags || undefined
-    }, { addQueryPrefix: true })
-
-    if (newTags !== Nav.history.location.search) {
-      Nav.history.replace({ search: newTags })
-    }
-  }, [query, selectedTags])
+    StateHistory.update({ selectedTags })
+  }, [selectedTags])
 
   return h(Fragment, [
     div({

--- a/src/pages/library/common.js
+++ b/src/pages/library/common.js
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp'
 import * as qs from 'qs'
-import { Fragment, useMemo, useState } from 'react'
+import { Fragment, useEffect, useMemo, useState } from 'react'
 import { div, em, h, label, span, strong } from 'react-hyperscript-helpers'
 import Collapse from 'src/components/Collapse'
 import { Clickable, IdContainer, Link, Select } from 'src/components/common'
@@ -117,7 +117,7 @@ export const SearchAndFilterComponent = ({ fullList, sidebarSections, customSort
   const { query } = Nav.useRoute()
   const searchFilter = query.filter || ''
   const [selectedSections, setSelectedSections] = useState([])
-  const [selectedTags, setSelectedTags] = useState([])
+  const [selectedTags, setSelectedTags] = useState(query.tags || [])
   const [sort, setSort] = useState({ field: 'created', direction: 'desc' })
   const filterRegex = new RegExp(`(${searchFilter})`, 'i')
 
@@ -189,6 +189,17 @@ export const SearchAndFilterComponent = ({ fullList, sidebarSections, customSort
       Nav.history.replace({ search: newSearch })
     }
   }
+
+  useEffect(() => {
+    const newTags = qs.stringify({
+      ...query,
+      tags: selectedTags || undefined
+    }, { addQueryPrefix: true })
+
+    if (newTags !== Nav.history.location.search) {
+      Nav.history.replace({ search: newTags })
+    }
+  }, [query, selectedTags])
 
   return h(Fragment, [
     div({


### PR DESCRIPTION
This change allows the filters to be preserved when navigating between pages.
For instance: A user filters the catalog down to the data they are interested in and browses to the details page. When they go back, they will lose their filters. This change fixes this
