### PR TITLE
[SUP-585] Increase GCE VM boot disk size

### DIFF
--- a/src/libs/runtime-utils.js
+++ b/src/libs/runtime-utils.js
@@ -21,7 +21,7 @@ export const computeStyles = {
 }
 
 export const defaultDataprocDiskSize = 100 // For both main and worker machine disks. Dataproc clusters don't have persistent disks.
-export const defaultGceBootDiskSize = 85 // GCE boot disk size is not customizable by users. We use this for cost estimate calculations only.
+export const defaultGceBootDiskSize = 100 // GCE boot disk size is not customizable by users. We use this for cost estimate calculations only.
 export const defaultGcePersistentDiskSize = 50
 
 export const defaultGceMachineType = 'n1-standard-1'


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/SUP-585

This UI change is for cost estimate display purposes only by reflecting the fix for the Leo prod issue where GPU VM creation fails due to insufficient boot disk size.
