### PR TITLE
IA-2924 update dataproc machine type and worker disk size

### DIFF
--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -22,7 +22,7 @@ import Events, { extractWorkspaceDetails } from 'src/libs/events'
 import { betaVersionTag } from 'src/libs/logos'
 import * as Nav from 'src/libs/nav'
 import {
-  computeStyles, defaultComputeRegion, defaultComputeZone, defaultDataprocDiskSize, defaultDataprocMachineType, defaultGceBootDiskSize,
+  computeStyles, defaultComputeRegion, defaultComputeZone, defaultDataprocMachineType, defaultDataprocMasterDiskSize, defaultDataprocWorkerDiskSize, defaultGceBootDiskSize,
   defaultGceMachineType, defaultGcePersistentDiskSize, defaultGpuType, defaultLocation, defaultNumDataprocPreemptibleWorkers,
   defaultNumDataprocWorkers, defaultNumGpus, displayNameForGpuType, findMachineType, getCurrentRuntime, getDefaultMachineType,
   getPersistentDiskCostMonthly, getValidGpuTypes, getValidGpuTypesForZone, RadioBlock, runtimeConfigBaseCost, runtimeConfigCost
@@ -183,7 +183,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
     numberOfWorkers: defaultNumDataprocWorkers,
     numberOfPreemptibleWorkers: defaultNumDataprocPreemptibleWorkers,
     workerMachineType: defaultDataprocMachineType,
-    workerDiskSize: defaultDataprocDiskSize,
+    workerDiskSize: defaultDataprocWorkerDiskSize,
     componentGatewayEnabled: true, // We enable web interfaces (aka Spark console) for all new Dataproc clusters.
     gpuEnabled: false,
     hasGpu: false,
@@ -673,12 +673,12 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
         selectedPersistentDiskSize: currentPersistentDiskDetails?.size || defaultGcePersistentDiskSize,
         masterMachineType: runtimeConfig?.masterMachineType || runtimeConfig?.machineType,
         masterDiskSize: runtimeConfig?.masterDiskSize || runtimeConfig?.diskSize ||
-          (isDataproc ? defaultDataprocDiskSize : defaultGceBootDiskSize),
+          (isDataproc ? defaultDataprocMasterDiskSize : defaultGceBootDiskSize),
         numberOfWorkers: runtimeConfig?.numberOfWorkers || 2,
         componentGatewayEnabled: runtimeConfig?.componentGatewayEnabled || !!newSparkMode,
         numberOfPreemptibleWorkers: runtimeConfig?.numberOfPreemptibleWorkers || 0,
         workerMachineType: runtimeConfig?.workerMachineType || defaultDataprocMachineType,
-        workerDiskSize: runtimeConfig?.workerDiskSize || defaultDataprocDiskSize,
+        workerDiskSize: runtimeConfig?.workerDiskSize || defaultDataprocWorkerDiskSize,
         gpuEnabled: (!!gpuConfig && !sparkMode) || false,
         hasGpu: !!gpuConfig,
         gpuType: gpuConfig?.gpuType || defaultGpuType,

--- a/src/libs/runtime-utils.js
+++ b/src/libs/runtime-utils.js
@@ -26,7 +26,7 @@ export const defaultGceBootDiskSize = 100 // GCE boot disk size is not customiza
 export const defaultGcePersistentDiskSize = 50
 
 export const defaultGceMachineType = 'n1-standard-1'
-export const defaultDataprocMachineType = 'n1-standard-2'
+export const defaultDataprocMachineType = 'n1-standard-4'
 export const defaultNumDataprocWorkers = 2
 export const defaultNumDataprocPreemptibleWorkers = 0
 

--- a/src/libs/runtime-utils.js
+++ b/src/libs/runtime-utils.js
@@ -22,7 +22,7 @@ export const computeStyles = {
 }
 
 // Dataproc clusters don't have persistent disks.
-export const defaultDataprocMasterDiskSize = 100 
+export const defaultDataprocMasterDiskSize = 100
 export const defaultDataprocWorkerDiskSize = 150
 export const defaultGceBootDiskSize = 100 // GCE boot disk size is not customizable by users. We use this for cost estimate calculations only.
 export const defaultGcePersistentDiskSize = 50
@@ -86,7 +86,8 @@ export const getValidGpuTypesForZone = zone => {
 
 export const getValidGpuTypes = (numCpus, mem, zone) => {
   const validGpuTypesForZone = getValidGpuTypesForZone(zone)
-  const validGpuTypes = _.filter(({ maxNumCpus, maxMem, type }) => numCpus <= maxNumCpus && mem <= maxMem && validGpuTypesForZone.includes(type), gpuTypes)
+  const validGpuTypes = _.filter(({ maxNumCpus, maxMem, type }) => numCpus <= maxNumCpus && mem <= maxMem && validGpuTypesForZone.includes(type),
+    gpuTypes)
   return validGpuTypes || { name: '?', type: '?', numGpus: '?', maxNumCpus: '?', maxMem: '?', price: NaN, preemptiblePrice: NaN }
 }
 
@@ -128,7 +129,9 @@ export const runtimeConfigBaseCost = config => {
 }
 
 export const runtimeConfigCost = config => {
-  const { cloudService, masterMachineType, numberOfWorkers, numberOfPreemptibleWorkers, workerMachineType, workerDiskSize, computeRegion } = normalizeRuntimeConfig(
+  const {
+    cloudService, masterMachineType, numberOfWorkers, numberOfPreemptibleWorkers, workerMachineType, workerDiskSize, computeRegion
+  } = normalizeRuntimeConfig(
     config)
   const masterPrice = getHourlyCostForMachineType(masterMachineType, computeRegion, false)
   const workerPrice = getHourlyCostForMachineType(workerMachineType, computeRegion, false)

--- a/src/libs/runtime-utils.js
+++ b/src/libs/runtime-utils.js
@@ -21,7 +21,8 @@ export const computeStyles = {
   warningView: { backgroundColor: colors.warning(0.1) }
 }
 
-export const defaultDataprocDiskSize = 100 // For both main and worker machine disks. Dataproc clusters don't have persistent disks.
+export const defaultDataprocMasterDiskSize = 100 // For both main and worker machine disks. Dataproc clusters don't have persistent disks.
+export const defaultDataprocWorkerDiskSize = 150 // For both main and worker machine disks. Dataproc clusters don't have persistent disks.
 export const defaultGceBootDiskSize = 100 // GCE boot disk size is not customizable by users. We use this for cost estimate calculations only.
 export const defaultGcePersistentDiskSize = 50
 
@@ -61,11 +62,11 @@ export const normalizeRuntimeConfig = ({
   return {
     cloudService: cloudService || cloudServices.GCE,
     masterMachineType: masterMachineType || machineType || getDefaultMachineType(isDataproc),
-    masterDiskSize: masterDiskSize || diskSize || (isDataproc ? defaultDataprocDiskSize : defaultGceBootDiskSize),
+    masterDiskSize: masterDiskSize || diskSize || (isDataproc ? defaultDataprocMasterDiskSize : defaultGceBootDiskSize),
     numberOfWorkers: (isDataproc && numberOfWorkers) || 0,
     numberOfPreemptibleWorkers: (isDataproc && numberOfWorkers && numberOfPreemptibleWorkers) || 0,
     workerMachineType: (isDataproc && numberOfWorkers && workerMachineType) || defaultDataprocMachineType,
-    workerDiskSize: (isDataproc && numberOfWorkers && workerDiskSize) || defaultDataprocDiskSize,
+    workerDiskSize: (isDataproc && numberOfWorkers && workerDiskSize) || defaultDataprocWorkerDiskSize,
     // One caveat with using DEFAULT_BOOT_DISK_SIZE here is this over-estimates old GCE runtimes without PD by 1 cent
     // because those runtimes do not have a separate boot disk. But those old GCE runtimes are more than 1 year old if they exist.
     // Hence, we're okay with this caveat.

--- a/src/libs/runtime-utils.js
+++ b/src/libs/runtime-utils.js
@@ -21,8 +21,9 @@ export const computeStyles = {
   warningView: { backgroundColor: colors.warning(0.1) }
 }
 
-export const defaultDataprocMasterDiskSize = 100 // For both main and worker machine disks. Dataproc clusters don't have persistent disks.
-export const defaultDataprocWorkerDiskSize = 150 // For both main and worker machine disks. Dataproc clusters don't have persistent disks.
+// Dataproc clusters don't have persistent disks.
+export const defaultDataprocMasterDiskSize = 100 
+export const defaultDataprocWorkerDiskSize = 150
 export const defaultGceBootDiskSize = 100 // GCE boot disk size is not customizable by users. We use this for cost estimate calculations only.
 export const defaultGcePersistentDiskSize = 50
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2924

With latest dataproc images, we'll need a bit more powerful machine type. `n1-standard-2` will work in a sense the runtime will be able to run, but user won't be able to do much analysis (I tried a simple hail tutorial, and it's really slow on n1-standard-2)

Tested locally
<img width="650" alt="Screen Shot 2021-12-06 at 11 21 50 AM" src="https://user-images.githubusercontent.com/32771737/144883067-21378d5f-971c-4dd4-b854-48c764e18e43.png">


