### PR TITLE
DC-74: For the beta test, artificially mark some snapshots as controlled access

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -926,9 +926,15 @@ const Workspaces = signal => ({
 
 
 const DataRepo = signal => ({
-  getMetadata: async () => {
+  getSnapshots: async () => {
     const res = await fetchDataRepo('repository/v1/search/metadata', _.merge(authOpts(), { signal }))
-    return res.json()
+    //  For beta test: if the title length is even, pretend that this is a controlled snapshot.
+    return _.map(snapshot => snapshot['dct:title'].length % 2 === 0 ?
+      {
+        ...snapshot,
+        roles: ['discoverer'],
+        'TerraDCAT_ap:hasDataUsePermission': 'TerraCore:CC'
+      } : snapshot, (await res.json())?.result)
   },
 
   snapshot: snapshotId => {

--- a/src/pages/library/dataBrowser-utils.js
+++ b/src/pages/library/dataBrowser-utils.js
@@ -57,12 +57,6 @@ const normalizeSnapshot = snapshot => {
     _.uniqBy(_.toLower)
   )(snapshot['prov:wasGeneratedBy'])
 
-  //  For beta test: if the title length is even, pretend that this is a controlled snapshot.
-  if (snapshot['dct:title'].length % 2 === 0) {
-    snapshot.roles = ['discoverer']
-    snapshot['TerraDCAT_ap:hasDataUsePermission'] = 'TerraCore:CC'
-  }
-
   const dataReleasePolicy = _.has(snapshot['TerraDCAT_ap:hasDataUsePermission'], snapshotReleasePolicies) ?
     { ...snapshotReleasePolicies[snapshot['TerraDCAT_ap:hasDataUsePermission']], policy: snapshot['TerraDCAT_ap:hasDataUsePermission'] } :
     {
@@ -110,11 +104,11 @@ export const useDataCatalog = () => {
     withErrorReporting('Error loading data catalog'),
     Utils.withBusyState(setLoading)
   )(async () => {
-    const metadata = !isDataBrowserVisible() ? {} : await Ajax(signal).DataRepo.getMetadata()
+    const snapshots = !isDataBrowserVisible() ? {} : await Ajax(signal).DataRepo.getSnapshots()
     const normList = _.map(snapshot => {
       const normalizedSnapshot = normalizeSnapshot(snapshot)
       return _.set(['tags'], extractTags(normalizedSnapshot), normalizedSnapshot)
-    }, metadata?.result)
+    }, snapshots)
 
     dataCatalogStore.set(normList)
   })

--- a/src/pages/library/dataBrowser-utils.js
+++ b/src/pages/library/dataBrowser-utils.js
@@ -57,6 +57,12 @@ const normalizeSnapshot = snapshot => {
     _.uniqBy(_.toLower)
   )(snapshot['prov:wasGeneratedBy'])
 
+  //  For beta test: if the title length is even, pretend that this is a controlled snapshot.
+  if (snapshot['dct:title'].length % 2 === 0) {
+    snapshot.roles = ['discoverer']
+    snapshot['TerraDCAT_ap:hasDataUsePermission'] = 'TerraCore:CC'
+  }
+
   const dataReleasePolicy = _.has(snapshot['TerraDCAT_ap:hasDataUsePermission'], snapshotReleasePolicies) ?
     { ...snapshotReleasePolicies[snapshot['TerraDCAT_ap:hasDataUsePermission']], policy: snapshot['TerraDCAT_ap:hasDataUsePermission'] } :
     {


### PR DESCRIPTION
All snapshots in our current test set are public, and we can't modify their permissions in TDR. This change modifies snapshots in memory so any snapshot with an even number of characters in its title will be shown as controlled access in the UI.

Once the beta test cycle is complete this change will be reverted.