### PR TITLE
[AS-944] importPFB -> importJob for listing

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -863,7 +863,7 @@ const Workspaces = signal => ({
       },
 
       importPFB: async url => {
-        const res = await fetchOrchestration(`api/${root}/importPFB`, _.mergeAll([authOpts(), jsonBody({ url }), { signal, method: 'POST' }]))
+        const res = await fetchOrchestration(`api/${root}/importJob`, _.mergeAll([authOpts(), jsonBody({ url, filetype: 'pfb' }), { signal, method: 'POST' }]))
         return res.json()
       },
 

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -874,7 +874,7 @@ const Workspaces = signal => ({
 
       listImportJobs: async isRunning => {
         // ToDo: This endpoint should be deprecated in favor of more generic "importJob" endpoint
-        const res = await fetchOrchestration(`api/${root}/importPFB?running_only=${isRunning}`, _.merge(authOpts(), { signal }))
+        const res = await fetchOrchestration(`api/${root}/importJob?running_only=${isRunning}`, _.merge(authOpts(), { signal }))
         return res.json()
       },
 


### PR DESCRIPTION
per broadinstitute/firecloud-orchestration#904, the `GET /api/workspaces/{workspaceNamespace}/{workspaceName}/importPFB` API is deprecated and replaced with `GET /api/workspaces/{workspaceNamespace}/{workspaceName}/importJob`.

This PR updates the UI to use the not-deprecated endpoint.

Do not merge this until broadinstitute/firecloud-orchestration#904 is released to prod!

Tested manually by running a local UI. The API call in question occurs when entering the Data tab of a workspace.

N.B. even though the `POST /api/workspaces/{workspaceNamespace}/{workspaceName}/importPFB` is not deprecated, it may be soon, so I've updated that ajax call as well.