### PR TITLE
[DC-60] Correct the behavior of hitting escape on autocomplete dropdown

### DIFF
--- a/src/components/input.js
+++ b/src/components/input.js
@@ -280,7 +280,6 @@ const withAutocomplete = WrappedComponent => ({
                 e.nativeEvent.preventDownshiftDefault = true
                 e.preventDefault()
               }
-              toggleMenu()
             } else if (_.includes(e.key, ['ArrowUp', 'ArrowDown']) && !suggestions.length) {
               e.nativeEvent.preventDownshiftDefault = true
             } else if (e.key === 'Enter') {

--- a/src/components/input.js
+++ b/src/components/input.js
@@ -248,8 +248,14 @@ const withAutocomplete = WrappedComponent => ({
     })
   })
 
+  // Unused param denoted as _u
+  const stateReducer = (_u, action) => {
+    return action.type === Downshift.stateChangeTypes.keyDownEscape ? { isOpen: false } : action
+  }
+
   return h(Downshift, {
     ...controlProps,
+    stateReducer,
     initialInputValue: value,
     onSelect: v => !!v && onPick?.(v),
     onInputValueChange: newValue => {

--- a/src/components/input.js
+++ b/src/components/input.js
@@ -248,8 +248,7 @@ const withAutocomplete = WrappedComponent => ({
     })
   })
 
-  // Unused param denoted as _u
-  const stateReducer = (_u, action) => {
+  const stateReducer = (_unused, action) => {
     return action.type === Downshift.stateChangeTypes.keyDownEscape ? { isOpen: false } : action
   }
 


### PR DESCRIPTION
Prior to this change, when hitting the escape key the suggestions in the autocomplete field would not dismiss the drop down or clear the text. This fix adjusts the behavior as follows:

1. When the user hits the escape key it dismisses the drop down

