### PR TITLE
[DC-94] Added "view json" drawer view on the preview data

### DIFF
--- a/src/pages/library/DataBrowserPreview.js
+++ b/src/pages/library/DataBrowserPreview.js
@@ -1,10 +1,11 @@
 import _ from 'lodash/fp'
 import { useState } from 'react'
 import { div, h, h1 } from 'react-hyperscript-helpers'
-import { Select } from 'src/components/common'
+import { ButtonPrimary, Select } from 'src/components/common'
 import FooterWrapper from 'src/components/FooterWrapper'
 import { centeredSpinner, spinner } from 'src/components/icons'
 import { libraryTopMatter } from 'src/components/library-common'
+import ModalDrawer from 'src/components/ModalDrawer'
 import { ColumnSelector, SimpleTable } from 'src/components/table'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
@@ -35,6 +36,7 @@ const DataBrowserPreview = ({ id }) => {
   const [selectedTable, setSelectedTable] = useState('')
   const [previewData, setPreviewData] = useState()
   const [columnSettings, setColumnSettings] = useState([])
+  const [viewJSON, setViewJSON] = useState()
 
   const tableMap = _.keyBy('name', tables)
   const tableNames = _.map('name', tables)
@@ -49,13 +51,26 @@ const DataBrowserPreview = ({ id }) => {
         id, limit: 50, offset: 0,
         table: value
       })
-      setPreviewData(previewTableData?.result || [])
+
+      const columnNames = _.map('name', tableMap[selectedTable]?.columns)
+
+      setPreviewData(_.flow([
+        _.getOr([], 'result'),
+        _.map(row => {
+          return _.reduce((obj, param) => {
+            obj[param] = formatTableCell(row[param])
+            return obj
+          }, {}, columnNames)
+        })
+      ])(previewTableData))
 
       setColumnSettings(
         _.flow([
           _.toPairs,
           _.map(([index, col]) => {
             return {
+              // name field is used in the column selector
+              // key field is used in the Simple Table
               name: col.name, key: col.name,
               visible: index < 6,
               header: div({ style: styles.table.header }, [col.name])
@@ -65,6 +80,21 @@ const DataBrowserPreview = ({ id }) => {
       )
     })
     loadTable()
+  }
+
+  const formatTableCell = cellContent => {
+    return Utils.cond(
+      [!Utils.cantBeNumber(cellContent), () => cellContent],
+      [Utils.maybeParseJSON(cellContent), () => {
+        const contentAsJSON = Utils.maybeParseJSON(cellContent)
+        const contentAsPrettyString = JSON.stringify(contentAsJSON, null, 4)
+        return h(ButtonPrimary, {
+          style: { fontSize: 16, textTransform: 'none', height: 'unset' },
+          onClick: () => { setViewJSON(contentAsPrettyString) }
+        }, ['View JSON'])
+      }],
+      [Utils.DEFAULT, () => cellContent]
+    )
   }
 
   Utils.useOnMount(() => {
@@ -108,7 +138,18 @@ const DataBrowserPreview = ({ id }) => {
           columnSettings.length > 0 && h(ColumnSelector, { onSave: setColumnSettings, columnSettings })
         ]),
         previewData?.length === 0 && div({ style: { width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' } }, ['(No Data)'])
-      ])
+      ]),
+    viewJSON && h(ModalDrawer, {
+      'aria-label': 'View Json', isOpen: true, width: 675,
+      onDismiss: () => { setViewJSON() },
+      children: div({
+        style: {
+          margin: 25, padding: 25,
+          backgroundColor: 'white', borderRadius: 3,
+          wordBreak: 'break-word', whiteSpace: 'pre-wrap'
+        }
+      }, [viewJSON])
+    })
   ])
 }
 

--- a/src/pages/library/DataBrowserPreview.js
+++ b/src/pages/library/DataBrowserPreview.js
@@ -5,7 +5,7 @@ import { Select } from 'src/components/common'
 import FooterWrapper from 'src/components/FooterWrapper'
 import { centeredSpinner, spinner } from 'src/components/icons'
 import { libraryTopMatter } from 'src/components/library-common'
-import { SimpleTable } from 'src/components/table'
+import { ColumnSelector, SimpleTable } from 'src/components/table'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { withErrorReporting } from 'src/libs/error'
@@ -34,6 +34,7 @@ const DataBrowserPreview = ({ id }) => {
   const [tables, setTables] = useState()
   const [selectedTable, setSelectedTable] = useState('')
   const [previewData, setPreviewData] = useState()
+  const [columnSettings, setColumnSettings] = useState([])
 
   const tableMap = _.keyBy('name', tables)
   const tableNames = _.map('name', tables)
@@ -49,6 +50,19 @@ const DataBrowserPreview = ({ id }) => {
         table: value
       })
       setPreviewData(previewTableData?.result || [])
+
+      setColumnSettings(
+        _.flow([
+          _.toPairs,
+          _.map(([index, col]) => {
+            return {
+              name: col.name, key: col.name,
+              visible: index < 6,
+              header: div({ style: styles.table.header }, [col.name])
+            }
+          })
+        ])(tableMap[selectedTable]?.columns)
+      )
     })
     loadTable()
   }
@@ -83,18 +97,16 @@ const DataBrowserPreview = ({ id }) => {
           }),
           loading && spinner({ style: { marginLeft: '1rem' } })
         ]),
-        tableMap && tableMap[selectedTable] && h(SimpleTable, {
-          'aria-label': `${_.startCase(selectedTable)} Preview Data`,
-          columns: _.map(col => {
-            return {
-              header: div({ style: styles.table.header }, [col.name]),
-              key: col.name
-            }
-          }, tableMap[selectedTable].columns),
-          cellStyle: { border: 'none', paddingRight: 15, wordBreak: 'break-all' },
-          useHover: false,
-          rows: previewData
-        }),
+        tableMap && tableMap[selectedTable] && div({ style: { position: 'relative' } }, [
+          h(SimpleTable, {
+            'aria-label': `${_.startCase(selectedTable)} Preview Data`,
+            columns: _.filter('visible', columnSettings),
+            cellStyle: { border: 'none', paddingRight: 15, wordBreak: 'break-all' },
+            useHover: false,
+            rows: previewData
+          }),
+          h(ColumnSelector, { onSave: setColumnSettings, columnSettings })
+        ]),
         previewData?.length === 0 && div({ style: { width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' } }, ['(No Data)'])
       ])
   ])

--- a/src/pages/library/DataBrowserPreview.js
+++ b/src/pages/library/DataBrowserPreview.js
@@ -85,12 +85,13 @@ const DataBrowserPreview = ({ id }) => {
   }
 
   const formatTableCell = ({ cellKey, cellContent, rowIndex, table }) => {
+    const maybeJSON = Utils.maybeParseJSON(cellContent)
     return Utils.cond(
       [!Utils.cantBeNumber(cellContent), () => cellContent],
-      [Utils.maybeParseJSON(cellContent), () => {
+      [maybeJSON, () => {
         const contentAsJSON = {
           title: `${table}, Row ${rowIndex} - ${cellKey}`,
-          cellData: Utils.maybeParseJSON(cellContent)
+          cellData: maybeJSON
         }
 
         return h(ButtonPrimary, {

--- a/src/pages/library/DataBrowserPreview.js
+++ b/src/pages/library/DataBrowserPreview.js
@@ -105,7 +105,7 @@ const DataBrowserPreview = ({ id }) => {
             useHover: false,
             rows: previewData
           }),
-          h(ColumnSelector, { onSave: setColumnSettings, columnSettings })
+          columnSettings.length > 0 && h(ColumnSelector, { onSave: setColumnSettings, columnSettings })
         ]),
         previewData?.length === 0 && div({ style: { width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' } }, ['(No Data)'])
       ])


### PR DESCRIPTION
<img width="1440" alt="Screen Shot 2021-12-14 at 6 15 21 PM" src="https://user-images.githubusercontent.com/10501914/146094455-8744e218-4849-4fcb-bc33-68bf4f0b27d1.png">
<img width="1440" alt="Screen Shot 2021-12-14 at 6 15 27 PM" src="https://user-images.githubusercontent.com/10501914/146094467-e6e3db43-6e73-4a60-8980-16abcfddfe21.png">

I might want to change how the drawers work (or add config settings), so you can continue interacting with the page behind it.