### PR TITLE
[AS-643] Always treat workspace description as a string

### DIFF
--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -213,7 +213,7 @@ export const WorkspaceList = () => {
               ]),
               div({ style: styles.tableCellContent }, [
                 span({ style: { ...Style.noWrapEllipsis, color: !!description ? undefined : colors.dark(0.75) } }, [
-                  description?.split('\n')[0] || 'No description added'
+                  description?.toString().split('\n')[0] || 'No description added'
                 ])
               ])
             ])

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -230,7 +230,7 @@ const WorkspaceDashboard = _.flow(
           style: { marginLeft: '0.5rem' },
           disabled: !!Utils.editWorkspaceError(workspace),
           tooltip: Utils.editWorkspaceError(workspace) || 'Edit description',
-          onClick: () => setEditDescription(description)
+          onClick: () => setEditDescription(description?.toString())
         }, [icon('edit')])
       ]),
       Utils.cond(
@@ -248,7 +248,7 @@ const WorkspaceDashboard = _.flow(
             saving && spinnerOverlay
           ])
         ],
-        [!!description, () => h(MarkdownViewer, [description])],
+        [!!description, () => h(MarkdownViewer, [description?.toString()])],
         () => div({ style: { fontStyle: 'italic' } }, ['No description added'])),
       _.some(_.startsWith('library:'), _.keys(attributes)) && h(Fragment, [
         div({ style: Style.dashboard.header }, ['Dataset Attributes']),


### PR DESCRIPTION
[AS-643](https://broadworkbench.atlassian.net/browse/AS-643)

It is possible, by calling APIs directly, to create or edit a workspace such that its description attribute is not a string (it could be an array, or a number, etc).

In these cases, the UI broke in the workspace list and workspace dashboard.

These are now fixed.

Tested manually by running a local UI.