### PR TITLE
[IA-2746] Update Calhoun URLs to k8

### DIFF
--- a/config/alpha.json
+++ b/config/alpha.json
@@ -2,7 +2,7 @@
   "agoraUrlRoot": "https://agora.dsde-alpha.broadinstitute.org",
   "bardRoot": "https://terra-bard-alpha.appspot.com",
   "bondUrlRoot": "https://broad-bond-alpha.appspot.com",
-  "calhounUrlRoot": "https://terra-calhoun-alpha.appspot.com",
+  "calhounUrlRoot": "https://calhoun.dsde-alpha.broadinstitute.org",
   "dataRepoUrlRoot": "https://data.alpha.envs-terra.bio",
   "devUrlRoot": "https://bvdp-saturn-alpha.appspot.com",
   "dockstoreUrlRoot": "https://staging.dockstore.org",

--- a/config/perf.json
+++ b/config/perf.json
@@ -2,7 +2,7 @@
   "agoraUrlRoot": "https://agora.dsde-perf.broadinstitute.org",
   "bardRoot": "https://terra-bard-perf.appspot.com",
   "bondUrlRoot": "https://broad-bond-perf.appspot.com",
-  "calhounUrlRoot": "https://terra-calhoun-perf.appspot.com",
+  "calhounUrlRoot": "https://calhoun.dsde-perf.broadinstitute.org",
   "dataRepoUrlRoot": "https://jade-perf.datarepo-perf.broadinstitute.org",
   "devUrlRoot": "https://bvdp-saturn-perf.appspot.com",
   "dockstoreUrlRoot": "https://staging.dockstore.org",

--- a/config/prod.json
+++ b/config/prod.json
@@ -2,7 +2,7 @@
   "agoraUrlRoot": "https://agora.dsde-prod.broadinstitute.org",
   "bardRoot": "https://terra-bard-prod.appspot.com",
   "bondUrlRoot": "https://broad-bond-prod.appspot.com",
-  "calhounUrlRoot": "https://terra-calhoun-prod.appspot.com",
+  "calhounUrlRoot": "https://calhoun.dsde-prod.broadinstitute.org",
   "dataRepoUrlRoot": "https://data.terra.bio",
   "dockstoreUrlRoot": "https://dockstore.org",
   "firecloudBucketRoot": "https://storage.googleapis.com/firecloud-alerts",

--- a/config/staging.json
+++ b/config/staging.json
@@ -2,7 +2,7 @@
   "agoraUrlRoot": "https://agora.dsde-staging.broadinstitute.org",
   "bardRoot": "https://terra-bard-staging.appspot.com",
   "bondUrlRoot": "https://broad-bond-staging.appspot.com",
-  "calhounUrlRoot": "https://terra-calhoun-staging.appspot.com",
+  "calhounUrlRoot": "https://calhoun.dsde-staging.broadinstitute.org",
   "dataRepoUrlRoot": "https://data.staging.envs-terra.bio",
   "devUrlRoot": "https://bvdp-saturn-staging.appspot.com",
   "dockstoreUrlRoot": "https://staging.dockstore.org",


### PR DESCRIPTION
These changes **cannot be merged** until there is a monolith release

Calhoun now lives in the terra k8s cluster, as opposed to google app engine.

https://ap-argocd.dsp-devops.broadinstitute.org/applications?search=calhoun

These changes work in dev (if you swap the value of `calhounUrlRoot` in `public/config.json` to the value in `config/dev.json`, you can verify)

