### PR TITLE
Entering a special character on search no longer crashes app

### DIFF
--- a/src/pages/library/common.js
+++ b/src/pages/library/common.js
@@ -120,7 +120,7 @@ export const SearchAndFilterComponent = ({ fullList, sidebarSections, customSort
   const [selectedSections, setSelectedSections] = useState([])
   const [selectedTags, setSelectedTags] = useState(StateHistory.get().selectedTags || [])
   const [sort, setSort] = useState({ field: 'created', direction: 'desc' })
-  const filterRegex = new RegExp(`(${searchFilter})`, 'i')
+  const filterRegex = new RegExp(`(${_.escapeRegExp(searchFilter)})`, 'i')
 
   const listDataByTag = _.omitBy(_.isEmpty, groupByFeaturedTags(fullList, sidebarSections))
 


### PR DESCRIPTION
Fixes a bug where entering a character like `\` will crash the app.
This is the result of an unescaped regex.