### PR TITLE
Add status information for cause of failure [QA-1679, BW-977].

### DIFF
--- a/integration-tests/tests/run-workflow.js
+++ b/integration-tests/tests/run-workflow.js
@@ -39,6 +39,10 @@ const testRunWorkflowFn = _.flow(
   await click(page, clickable({ text: 'OK' }))
   await click(page, clickable({ text: 'Run analysis' }))
 
+  // Get request status for sporadically failing checkBucketAccess call.
+  page.on('response', request => {
+    console.log(`${request.url()} : ${request.status()} : ${request.statusText()}`)
+  })
   await Promise.all([
     page.waitForNavigation(),
     click(page, clickable({ text: 'Launch' }))

--- a/integration-tests/tests/run-workflow.js
+++ b/integration-tests/tests/run-workflow.js
@@ -40,13 +40,15 @@ const testRunWorkflowFn = _.flow(
   await click(page, clickable({ text: 'Run analysis' }))
 
   // Get request status for sporadically failing checkBucketAccess call.
-  page.on('response', request => {
+  const handler = request => {
     console.log(`${request.url()} : ${request.status()} : ${request.statusText()}`)
-  })
+  }
+  page.on('response', handler)
   await Promise.all([
     page.waitForNavigation(),
     click(page, clickable({ text: 'Launch' }))
   ])
+  page.off('response', handler)
 
   await pRetry(async () => {
     try {

--- a/src/libs/analysis.js
+++ b/src/libs/analysis.js
@@ -27,7 +27,8 @@ export const launch = async ({
   try {
     await Ajax().Workspaces.workspace(namespace, name).checkBucketAccess(googleProject, bucketName, accessLevel)
   } catch (error) {
-    throw new Error('Error confirming workspace bucket access. This may be a transient problem. Please try again in a few minutes. If the problem persists, please contact support.')
+    console.error(error)
+    throw new Error(`Error confirming workspace bucket access. This may be a transient problem, please try again in a few minutes. If the problem persists, please contact support and provide this information: status ${error.status}, status text '${error.statusText}'.`)
   }
   const { entityName, processSet = false } = await Utils.cond(
     [isSnapshot || (selectedEntityType === undefined), () => ({})],

--- a/src/libs/analysis.js
+++ b/src/libs/analysis.js
@@ -27,8 +27,7 @@ export const launch = async ({
   try {
     await Ajax().Workspaces.workspace(namespace, name).checkBucketAccess(googleProject, bucketName, accessLevel)
   } catch (error) {
-    console.error(error)
-    throw new Error(`Error confirming workspace bucket access. This may be a transient problem, please try again in a few minutes. If the problem persists, please contact support and provide this information: status ${error.status}, status text '${error.statusText}'.`)
+    throw new Error('Error confirming workspace bucket access. This may be a transient problem. Please try again in a few minutes. If the problem persists, please contact support.')
   }
   const { entityName, processSet = false } = await Utils.cond(
     [isSnapshot || (selectedEntityType === undefined), () => ({})],


### PR DESCRIPTION
The run-workflow test has been failing often recently nightly integration runs because the call to Workspace's `checkBucketAccess` method fails (as we can see in the test screenshot). However, the message displayed is static text, with no information about the actual cause. I am attempting to get more information about the cause of the failure.

Example of how this looks when the URL is incorrect (which I do **not** expect is the cause of the actual problem!).

![image](https://user-images.githubusercontent.com/484484/146581081-0e8dc37e-775e-4d70-92c9-24f1074e2087.png)

Note also that these failures are not terribly new… the oldest I found was 25 days ago. However, the frequency with which they have been seen recently has increased dramatically.