### PR TITLE
import-data landing page for TDR-by-copy [AS-1045]

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -862,8 +862,8 @@ const Workspaces = signal => ({
         return res.json()
       },
 
-      importPFB: async url => {
-        const res = await fetchOrchestration(`api/${root}/importJob`, _.mergeAll([authOpts(), jsonBody({ url, filetype: 'pfb' }), { signal, method: 'POST' }]))
+      importJob: async (url, filetype) => {
+        const res = await fetchOrchestration(`api/${root}/importJob`, _.mergeAll([authOpts(), jsonBody({ url, filetype }), { signal, method: 'POST' }]))
         return res.json()
       },
 

--- a/src/pages/ImportData.js
+++ b/src/pages/ImportData.js
@@ -91,7 +91,7 @@ const ImportData = () => {
   )(dataCatalog)
   const [snapshotResponses, setSnapshotResponses] = useState()
 
-  const isDataset = format !== 'snapshot' && format !== 'tdrexport'
+  const isDataset = !_.includes(format, ['snapshot', 'tdrexport'])
   const noteMessage = 'Note that the import process may take some time after you are redirected into your destination workspace.'
   const [title, header] = Utils.cond(
     [referrer === 'data-catalog', () => ['Catalog', 'Linking data to a workspace']],

--- a/src/pages/ImportData.js
+++ b/src/pages/ImportData.js
@@ -76,7 +76,7 @@ const ResponseFragment = ({ title, snapshotResponses, responseIndex }) => {
 const ImportData = () => {
   const { workspaces, refresh: refreshWorkspaces, loading: loadingWorkspaces } = useWorkspaces()
   const [isImporting, setIsImporting] = useState(false)
-  const { query: { url, format, ad, wid, template, snapshotId, snapshotName, snapshotIds, referrer } } = Nav.useRoute()
+  const { query: { url, format, ad, wid, template, snapshotId, snapshotName, snapshotIds, referrer, tdrmanifest } } = Nav.useRoute()
   const [mode, setMode] = useState(wid ? 'existing' : undefined)
   const [isCreateOpen, setIsCreateOpen] = useState(false)
   const [isCloneOpen, setIsCloneOpen] = useState(false)
@@ -91,7 +91,7 @@ const ImportData = () => {
   )(dataCatalog)
   const [snapshotResponses, setSnapshotResponses] = useState()
 
-  const isDataset = format !== 'snapshot'
+  const isDataset = format !== 'snapshot' && format !== 'tdrexport'
   const noteMessage = 'Note that the import process may take some time after you are redirected into your destination workspace.'
   const [title, header] = Utils.cond(
     [referrer === 'data-catalog', () => ['Catalog', 'Linking data to a workspace']],
@@ -125,13 +125,18 @@ const ImportData = () => {
 
     await Utils.switchCase(format,
       ['PFB', async () => {
-        const { jobId } = await Ajax().Workspaces.workspace(namespace, name).importPFB(url)
+        const { jobId } = await Ajax().Workspaces.workspace(namespace, name).importJob(url, 'pfb')
         asyncImportJobStore.update(Utils.append({ targetWorkspace: { namespace, name }, jobId }))
         notifyDataImportProgress(jobId)
       }],
       ['entitiesJson', async () => {
         await Ajax().Workspaces.workspace(namespace, name).importJSON(url)
         notify('success', 'Data imported successfully.', { timeout: 3000 })
+      }],
+      ['tdrexport', async () => {
+        const { jobId } = await Ajax().Workspaces.workspace(namespace, name).importJob(tdrmanifest, 'tdrexport')
+        asyncImportJobStore.update(Utils.append({ targetWorkspace: { namespace, name }, jobId }))
+        notifyDataImportProgress(jobId)
       }],
       ['snapshot', async () => {
         if (!_.isEmpty(snapshots)) {


### PR DESCRIPTION
Adds support to the #import-data landing page for TDR import-by-copy.

The URL syntax for import-by-copy is:
```
#import-data?url={datarepourl}&snapshotId={snapshotuuid}&format=tdrexport&snapshotName={snapshotname}&tdrmanifest={tdrmanifestjson}
```

(order of query params does not matter.)

tested by running locally and verifying both PFB imports and TDR import-by-copy