### PR TITLE
[DC-100] Add 'see more' filtering UX

### DIFF
--- a/src/pages/library/DataBrowser.js
+++ b/src/pages/library/DataBrowser.js
@@ -151,10 +151,16 @@ const makeDataBrowserTableComponent = ({ sort, setSort, selectedData, toggleSele
                 h(LabeledCheckbox, {
                   style: { marginRight: 10 },
                   'aria-label': tag,
-                  checked: _.includes(tag.toLowerCase(), selectedTags),
+                  checked: _.some({ lowerTag: tag.toLowerCase() }, selectedTags),
                   onChange: () => {
                     Ajax().Metrics.captureEvent(`${Events.catalogFilter}:tableHeader`, { tag })
-                    setSelectedTags(_.xor([tag.toLowerCase()]))
+                    const invertSelection = _.flow(
+                      _.find(({ label }) => _.includes(label, sections[1].labels)),
+                      _.concat([{ label: tag, lowerTag: tag.toLowerCase() }]),
+                      _.compact,
+                      _.xorBy('lowerTag')
+                    )(selectedTags)
+                    setSelectedTags(invertSelection)
                   }
                 }, [tag])
               ])

--- a/src/pages/library/common.js
+++ b/src/pages/library/common.js
@@ -112,8 +112,9 @@ const Sidebar = ({ onSectionFilter, onTagFilter, sections, selectedSections, sel
           buttonStyle: styles.nav.title,
           titleFirst: true, initialOpenState: true,
           title: h(Fragment, [name, span({ style: { marginLeft: '0.5rem', fontWeight: 400 } }, [`(${_.size(labels)})`])])
-        }, [h(FilterSection, { onTagFilter, selectedTags, labelRenderer, listDataByTag, labels })]
-        )
+        }, [
+          h(FilterSection, { onTagFilter, selectedTags, labelRenderer, listDataByTag, labels })
+        ])
     }, sections)
   ])
 }

--- a/src/pages/library/common.js
+++ b/src/pages/library/common.js
@@ -301,7 +301,6 @@ export const SearchAndFilterComponent = ({
           onSectionFilter: section => setSelectedSections(_.xor([section])),
           onTagFilter: ({ lowerTag, label }) => {
             Ajax().Metrics.captureEvent(`${Events.catalogFilter}:sidebar`, { tag: lowerTag })
-            console.log('Selecting: ', lowerTag, label)
             setSelectedTags(_.xorBy('lowerTag', [{ lowerTag, label }]))
           },
           sections,

--- a/src/pages/library/common.js
+++ b/src/pages/library/common.js
@@ -48,6 +48,44 @@ const groupByFeaturedTags = (workspaces, sidebarSections) => _.flow(
   _.fromPairs
 )(sidebarSections)
 
+const numLabelsToRender = 5
+// Takes the top n labels and appends any labels selected by the user to the list
+// When filter options are hidden (e.g. long lists), this will keep user selected items in view
+const computeLabels = (allLabels, selectedLabels) => _.flow(
+  _.intersection(allLabels),
+  _.concat(_.take(numLabelsToRender, allLabels)),
+  _.uniq
+)(selectedLabels)
+
+const FilterSection = ({ onTagFilter, labels, selectedTags, labelRenderer, listDataByTag }) => {
+  // State
+  const [showAll, setShowAll] = useState(false)
+  const lowerSelectedTags = _.map('lowerTag', selectedTags)
+  const labelsToDisplay = showAll ? labels : computeLabels(labels, _.map('label', selectedTags))
+
+  //Render
+  return h(Fragment, [
+    _.map(label => {
+      const lowerTag = _.toLower(label)
+      return h(Clickable, {
+        key: label,
+        style: {
+          display: 'flex', alignItems: 'baseline', margin: '0.5rem 0',
+          paddingBottom: '0.5rem', borderBottom: `1px solid ${colors.dark(0.1)}`
+        },
+        onClick: () => onTagFilter({ lowerTag, label })
+      }, [
+        div({ style: { lineHeight: '1.375rem', flex: 1 } }, [...(labelRenderer ? labelRenderer(label) : label)]),
+        div({ style: styles.pill(_.includes(lowerTag, lowerSelectedTags)) }, [_.size(listDataByTag[lowerTag])])
+      ])
+    }, labelsToDisplay),
+    _.size(labels) > numLabelsToRender && h(Link, {
+      style: { display: 'block', textAlign: 'center' },
+      onClick: () => setShowAll(!showAll)
+    }, [`See ${showAll ? 'less' : 'more'}`])
+  ])
+}
+
 const Sidebar = ({ onSectionFilter, onTagFilter, sections, selectedSections, selectedTags, listDataByTag }) => {
   const unionSectionWorkspacesCount = ({ tags }) => _.flow(
     _.flatMap(tag => listDataByTag[tag]),
@@ -74,20 +112,8 @@ const Sidebar = ({ onSectionFilter, onTagFilter, sections, selectedSections, sel
           buttonStyle: styles.nav.title,
           titleFirst: true, initialOpenState: true,
           title: h(Fragment, [name, span({ style: { marginLeft: '0.5rem', fontWeight: 400 } }, [`(${_.size(labels)})`])])
-        }, [_.map(label => {
-          const tag = _.toLower(label)
-          return h(Clickable, {
-            key: label,
-            style: {
-              display: 'flex', alignItems: 'baseline', margin: '0.5rem 0',
-              paddingBottom: '0.5rem', borderBottom: `1px solid ${colors.dark(0.1)}`
-            },
-            onClick: () => onTagFilter(tag)
-          }, [
-            div({ style: { lineHeight: '1.375rem', flex: 1 } }, [...(labelRenderer ? labelRenderer(label) : label)]),
-            div({ style: styles.pill(_.includes(tag, selectedTags)) }, [_.size(listDataByTag[tag])])
-          ])
-        }, labels)])
+        }, [h(FilterSection, { onTagFilter, selectedTags, labelRenderer, listDataByTag, labels })]
+        )
     }, sections)
   ])
 }
@@ -163,8 +189,8 @@ export const SearchAndFilterComponent = ({
         return listData
       } else {
         return _.reduce(
-          (acc, tag) => _.intersection(listDataByTag[tag], acc),
-          listDataByTag[_.head(selectedTags)],
+          (acc, { lowerTag }) => _.intersection(listDataByTag[lowerTag], acc),
+          listDataByTag[_.head(selectedTags).lowerTag],
           _.tail(selectedTags)
         )
       }
@@ -273,9 +299,10 @@ export const SearchAndFilterComponent = ({
       div({ style: { width: '19rem', flex: 'none' } }, [
         h(Sidebar, {
           onSectionFilter: section => setSelectedSections(_.xor([section])),
-          onTagFilter: tag => {
-            Ajax().Metrics.captureEvent(`${Events.catalogFilter}:sidebar`, { tag })
-            setSelectedTags(_.xor([tag]))
+          onTagFilter: ({ lowerTag, label }) => {
+            Ajax().Metrics.captureEvent(`${Events.catalogFilter}:sidebar`, { tag: lowerTag })
+            console.log('Selecting: ', lowerTag, label)
+            setSelectedTags(_.xorBy('lowerTag', [{ lowerTag, label }]))
           },
           sections,
           selectedSections,


### PR DESCRIPTION
## Overview
Data Catalog generates its filtering options and they can be numerous, taking up a lot of screen real estate. This change limits the number of filter items that are visible on the page and adds 'See more' buttons to show all available filters.

This is the first change in a series of enhancements we will be making to the filters

## Testing
Tested in data catalog and Featured Workspaces

## Screens
### Before

![dc-filter-before](https://user-images.githubusercontent.com/50371603/146600879-baa87f1f-f3ae-4265-ad4d-1380c90d4a0d.gif)

### After
![dc-filter-see-more-after](https://user-images.githubusercontent.com/50371603/146601310-8cd4c223-3cce-4e31-8eb1-4e8498de5500.gif)

