### PR TITLE
[TUB-19] Add HTTP response logging to integration tests

### DIFF
--- a/integration-tests/jest/jest-utils.js
+++ b/integration-tests/jest/jest-utils.js
@@ -1,6 +1,6 @@
 const _ = require('lodash/fp')
 const { defaultTimeout } = require('../utils/integration-helpers')
-const { withScreenshot } = require('../utils/integration-utils')
+const { withScreenshot, withPageLogging } = require('../utils/integration-utils')
 const envs = require('../utils/terra-envs')
 
 
@@ -17,7 +17,11 @@ const {
 const targetEnvParams = _.merge({ ...envs[environment] }, { billingProject, snapshotColumnName, snapshotId, snapshotTableName, testUrl, workflowName })
 
 const registerTest = ({ fn, name, timeout = defaultTimeout }) => {
-  return test(name, () => withScreenshot(name)(fn)({ context, page, ...targetEnvParams }), timeout)
+  return test(
+    name,
+    () => withPageLogging(withScreenshot(name)(fn))({ context, page, ...targetEnvParams }),
+    timeout
+  )
 }
 
 module.exports = { registerTest }

--- a/integration-tests/tests/run-workflow.js
+++ b/integration-tests/tests/run-workflow.js
@@ -39,16 +39,13 @@ const testRunWorkflowFn = _.flow(
   await click(page, clickable({ text: 'OK' }))
   await click(page, clickable({ text: 'Run analysis' }))
 
-  // Get request status for sporadically failing checkBucketAccess call.
-  const handler = request => {
-    console.log(`${request.url()} : ${request.status()} : ${request.statusText()}`)
-  }
-  page.on('response', handler)
+  // Uncomment the following to get request status for sporadically failing checkBucketAccess call.
+  // const stopLoggingPageAjaxResponses = logPageAjaxResponses(page)
   await Promise.all([
     page.waitForNavigation(),
     click(page, clickable({ text: 'Launch' }))
   ])
-  page.off('response', handler)
+  // stopLoggingPageAjaxResponses()
 
   await pRetry(async () => {
     try {

--- a/integration-tests/tests/run-workflow.js
+++ b/integration-tests/tests/run-workflow.js
@@ -39,7 +39,8 @@ const testRunWorkflowFn = _.flow(
   await click(page, clickable({ text: 'OK' }))
   await click(page, clickable({ text: 'Run analysis' }))
 
-  // Uncomment the following to get request status for sporadically failing checkBucketAccess call.
+  // If general ajax logging is disabled, uncomment the following to debug the sporadically failing
+  // checkBucketAccess call.
   // const stopLoggingPageAjaxResponses = logPageAjaxResponses(page)
   await Promise.all([
     page.waitForNavigation(),

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -174,6 +174,28 @@ const withScreenshot = _.curry((testName, fn) => async options => {
   }
 })
 
+const logPageConsoleMessages = page => {
+  const handle = msg => console.log('page.console', msg.text(), msg)
+  page.on('console', handle)
+  return () => page.off('console', handle)
+}
+
+const logPageAjaxResponses = page => {
+  const handle = res => {
+    console.log('page.http.res', `${res.status()} ${res.request().method()} ${res.url()}`)
+  }
+  page.on('response', handle)
+  return () => page.off('response', handle)
+}
+
+const withPageLogging = fn => options => {
+  const { page } = options
+  logPageAjaxResponses(page)
+  // Leaving console logging off for now since it is mostly request failures already logged above.
+  // logPageConsoleMessages(page)
+  return fn(options)
+}
+
 module.exports = {
   click,
   clickable,
@@ -194,5 +216,8 @@ module.exports = {
   elementInDataTableRow,
   findInDataTableRow,
   withScreenshot,
+  logPageConsoleMessages,
+  logPageAjaxResponses,
+  withPageLogging,
   openError
 }


### PR DESCRIPTION
While tests are flaky, it might be helpful to log all HTTP responses.