### PR TITLE
[IA-3152] Add one more PR site

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,6 @@ commands:
                 command: |
                   apk add github-cli --no-progress --repository=https://dl-cdn.alpinelinux.org/alpine/latest-stable/community/
                   <<# parameters.pr >>
-                  NUM_PR_SITES=11
                   VERSION="pr-$(expr "${CIRCLE_PR_NUMBER:-${CIRCLE_PULL_REQUEST##*/}}" % $NUM_PR_SITES)"
                   <</ parameters.pr >><<^ parameters.pr >>
                   VERSION="<< parameters.env >>"
@@ -54,7 +53,6 @@ commands:
                 name: Update Github deployment status
                 command: |
                   <<# parameters.pr >>
-                  NUM_PR_SITES=11
                   PR_SLUG="pr-$(expr "${CIRCLE_PR_NUMBER:-${CIRCLE_PULL_REQUEST##*/}}" % $NUM_PR_SITES)-dot-"
                   <</ parameters.pr >>
                   gh api "repos/databiosphere/terra-ui/deployments/$(cat /tmp/build_num)/statuses" -H "Authorization: token $GITHUB_TOKEN" \
@@ -103,7 +101,6 @@ commands:
                 command: |
                   CIRCLE_PR_NUMBER="${CIRCLE_PR_NUMBER:-${CIRCLE_PULL_REQUEST##*/}}"
                   if [[ ! -z "$CIRCLE_PR_NUMBER" ]]; then
-                    NUM_PR_SITES=11
                     gcloud app deploy --project=bvdp-saturn-<< parameters.env >> \
                       --version="pr-$(expr "$CIRCLE_PR_NUMBER" % $NUM_PR_SITES)" --no-promote --quiet
                   fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,8 @@ commands:
                 command: |
                   apk add github-cli --no-progress --repository=https://dl-cdn.alpinelinux.org/alpine/latest-stable/community/
                   <<# parameters.pr >>
-                  VERSION="pr-$(expr "${CIRCLE_PR_NUMBER:-${CIRCLE_PULL_REQUEST##*/}}" % 10)"
+                  NUM_PR_SITES=11
+                  VERSION="pr-$(expr "${CIRCLE_PR_NUMBER:-${CIRCLE_PULL_REQUEST##*/}}" % $NUM_PR_SITES)"
                   <</ parameters.pr >><<^ parameters.pr >>
                   VERSION="<< parameters.env >>"
                   <</ parameters.pr >>
@@ -53,7 +54,8 @@ commands:
                 name: Update Github deployment status
                 command: |
                   <<# parameters.pr >>
-                  PR_SLUG="pr-$(expr "${CIRCLE_PR_NUMBER:-${CIRCLE_PULL_REQUEST##*/}}" % 10)-dot-"
+                  NUM_PR_SITES=11
+                  PR_SLUG="pr-$(expr "${CIRCLE_PR_NUMBER:-${CIRCLE_PULL_REQUEST##*/}}" % $NUM_PR_SITES)-dot-"
                   <</ parameters.pr >>
                   gh api "repos/databiosphere/terra-ui/deployments/$(cat /tmp/build_num)/statuses" -H "Authorization: token $GITHUB_TOKEN" \
                     -F state=success -F environment_url="https://${PR_SLUG}bvdp-saturn-<< parameters.env >>.appspot.com" -F log_url="$CIRCLE_BUILD_URL"
@@ -101,8 +103,9 @@ commands:
                 command: |
                   CIRCLE_PR_NUMBER="${CIRCLE_PR_NUMBER:-${CIRCLE_PULL_REQUEST##*/}}"
                   if [[ ! -z "$CIRCLE_PR_NUMBER" ]]; then
+                    NUM_PR_SITES=11
                     gcloud app deploy --project=bvdp-saturn-<< parameters.env >> \
-                      --version="pr-$(expr "$CIRCLE_PR_NUMBER" % 10)" --no-promote --quiet
+                      --version="pr-$(expr "$CIRCLE_PR_NUMBER" % $NUM_PR_SITES)" --no-promote --quiet
                   fi
       - unless:
           condition: << parameters.pr >>


### PR DESCRIPTION
Circle configuration updated to add NUM_PR_SITES as an environment variable. Usage of that variable is added in this PR. Any change to that variable would need a corresponding change in the web client authorized JavaScript origins:
https://console.cloud.google.com/apis/credentials/oauthclient/500025638838-s2v23ar3spugtd5t2v1vgfa2sp7ppg0d.apps.googleusercontent.com?project=bvdp-saturn-dev