### PR TITLE
[DC-111] Hide/show button/checkbox based off of access status

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -27,7 +27,7 @@ const styles = {
   }
 }
 
-const Modal = ({ onDismiss, title, titleExtras, children, width = 450, showCancel = true, cancelText = 'Cancel', showX, showButtons = true, okButton, danger = false, ...props }) => {
+const Modal = ({ onDismiss, title, titleExtras, children, width = 450, showCancel = true, cancelText = 'Cancel', showX, xIcon = 'times-circle', showButtons = true, okButton, danger = false, ...props }) => {
   const titleId = useUniqueId()
   const modalNode = useRef()
   const previouslyFocusedNode = useRef()
@@ -65,7 +65,7 @@ const Modal = ({ onDismiss, title, titleExtras, children, width = 450, showCance
         'aria-label': 'Close modal',
         style: { alignSelf: 'flex-start', marginLeft: 'auto' },
         onClick: onDismiss
-      }, [icon('times-circle')])
+      }, [icon(xIcon)])
     ]),
     children,
     showButtons && div({ style: styles.buttonRow }, [

--- a/src/pages/library/DataBrowser.js
+++ b/src/pages/library/DataBrowser.js
@@ -189,6 +189,7 @@ const makeDataBrowserTableComponent = ({ sort, setSort, selectedData, toggleSele
         return {
           checkbox: h(Checkbox, {
             'aria-label': datum['dct:title'],
+            disabled: datum.access !== snapshotAccessTypes.GRANTED,
             checked: _.includes(datum, selectedData),
             onChange: () => toggleSelectedData(datum)
           }),

--- a/src/pages/library/DataBrowser.js
+++ b/src/pages/library/DataBrowser.js
@@ -6,6 +6,7 @@ import FooterWrapper from 'src/components/FooterWrapper'
 import { icon } from 'src/components/icons'
 import { libraryTopMatter } from 'src/components/library-common'
 import { MiniSortable, SimpleTable } from 'src/components/table'
+import TooltipTrigger from 'src/components/TooltipTrigger'
 import { Ajax } from 'src/libs/ajax'
 import { staticStorageSlot } from 'src/libs/browser-storage'
 import colors from 'src/libs/colors'
@@ -15,7 +16,7 @@ import { useStore } from 'src/libs/react-utils'
 import { authStore } from 'src/libs/state'
 import * as Utils from 'src/libs/utils'
 import { commonStyles, SearchAndFilterComponent } from 'src/pages/library/common'
-import { importDataToWorkspace, snapshotAccessTypes, snapshotReleasePolicies, useDataCatalog } from 'src/pages/library/dataBrowser-utils'
+import { importDataToWorkspace, snapshotAccessTypes, snapshotReleasePolicies, uiMessaging, useDataCatalog } from 'src/pages/library/dataBrowser-utils'
 import { RequestDatasetAccessModal } from 'src/pages/library/RequestDatasetAccessModal'
 
 
@@ -187,12 +188,14 @@ const makeDataBrowserTableComponent = ({ sort, setSort, selectedData, toggleSele
         const { project, dataType, access } = datum
 
         return {
-          checkbox: h(Checkbox, {
+          checkbox: h(TooltipTrigger, {
+            ...(datum.access !== snapshotAccessTypes.GRANTED && { content: [uiMessaging.controlledFeature_tooltip] })
+          }, [h(Checkbox, {
             'aria-label': datum['dct:title'],
             disabled: datum.access !== snapshotAccessTypes.GRANTED,
             checked: _.includes(datum, selectedData),
             onChange: () => toggleSelectedData(datum)
-          }),
+          })]),
           name: h(Link,
             {
               onClick: () => {

--- a/src/pages/library/DataBrowserDetails.js
+++ b/src/pages/library/DataBrowserDetails.js
@@ -168,7 +168,7 @@ const Sidebar = ({ snapshot, id, setShowRequestAccessModal }) => {
         'Preview data'
       ])
     ]),
-    h(ButtonPrimary, {
+    snapshot.access === snapshotAccessTypes.GRANTED && h(ButtonPrimary, {
       style: { fontSize: 16, textTransform: 'none', height: 'unset', width: 230, marginTop: 20 },
       onClick: () => {
         Ajax().Metrics.captureEvent(`${Events.catalogWorkspaceLink}:detailsView`, {

--- a/src/pages/library/DataBrowserDetails.js
+++ b/src/pages/library/DataBrowserDetails.js
@@ -153,7 +153,7 @@ const Sidebar = ({ snapshot, id, setShowRequestAccessModal }) => {
         ])
       ])
     ]),
-    h(ButtonOutline, {
+    snapshot.access === snapshotAccessTypes.GRANTED && h(ButtonOutline, {
       style: { fontSize: 16, textTransform: 'none', height: 'unset', width: 230, marginTop: 20 },
       onClick: () => {
         Ajax().Metrics.captureEvent(`${Events.catalogView}:previewData`, {

--- a/src/pages/library/DataBrowserDetails.js
+++ b/src/pages/library/DataBrowserDetails.js
@@ -153,7 +153,9 @@ const Sidebar = ({ snapshot, id, setShowRequestAccessModal }) => {
         ])
       ])
     ]),
-    snapshot.access === snapshotAccessTypes.GRANTED && h(ButtonOutline, {
+    h(ButtonOutline, {
+      disabled: snapshot.access !== snapshotAccessTypes.GRANTED,
+      tooltip: snapshot.access === snapshotAccessTypes.GRANTED ? '' : 'You do not have access to this dataset. Please request access to unlock this feature.',
       style: { fontSize: 16, textTransform: 'none', height: 'unset', width: 230, marginTop: 20 },
       onClick: () => {
         Ajax().Metrics.captureEvent(`${Events.catalogView}:previewData`, {
@@ -168,7 +170,9 @@ const Sidebar = ({ snapshot, id, setShowRequestAccessModal }) => {
         'Preview data'
       ])
     ]),
-    snapshot.access === snapshotAccessTypes.GRANTED && h(ButtonPrimary, {
+    h(ButtonPrimary, {
+      disabled: snapshot.access !== snapshotAccessTypes.GRANTED,
+      tooltip: snapshot.access === snapshotAccessTypes.GRANTED ? '' : 'You do not have access to this dataset. Please request access to unlock this feature.',
       style: { fontSize: 16, textTransform: 'none', height: 'unset', width: 230, marginTop: 20 },
       onClick: () => {
         Ajax().Metrics.captureEvent(`${Events.catalogWorkspaceLink}:detailsView`, {

--- a/src/pages/library/DataBrowserPreview.js
+++ b/src/pages/library/DataBrowserPreview.js
@@ -11,7 +11,6 @@ import { ColumnSelector, SimpleTable } from 'src/components/table'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { withErrorReporting } from 'src/libs/error'
-import Events from 'src/libs/events'
 import { useCancellation, useOnMount } from 'src/libs/react-utils'
 import * as Utils from 'src/libs/utils'
 import { commonStyles } from 'src/pages/library/common'
@@ -49,9 +48,6 @@ const DataBrowserPreview = ({ id }) => {
   const { dataCatalog } = useDataCatalog()
   const dataMap = _.keyBy('dct:identifier', dataCatalog)
   const snapshot = dataMap[id]
-
-  // Variables when you do not have access
-  const [showRequestAccessModal, setShowRequestAccessModal] = useState()
 
   // Snapshot access granted
   const [tables, setTables] = useState()
@@ -148,16 +144,10 @@ const DataBrowserPreview = ({ id }) => {
           div([
             div(['This dataset is controlled access only.']),
             div(['To see more data, please request access.']),
-            h(ButtonPrimary, {
-              style: { fontSize: 16, textTransform: 'none', marginTop: 15 },
-              onClick: () => {
-                setShowRequestAccessModal(true)
-                Ajax().Metrics.captureEvent(`${Events.catalogRequestAccess}:popUp`, {
-                  snapshotId: _.get('dct:identifier', snapshot),
-                  snapshotName: snapshot['dct:title']
-                })
-              }
-            }, ['Request access'])
+            h(RequestDatasetAccessModal, {
+              datasets: [snapshot],
+              onDismiss: () => {}
+            })
           ])
         ]),
         snapshot.access === snapshotAccessTypes.GRANTED && div({
@@ -203,10 +193,6 @@ const DataBrowserPreview = ({ id }) => {
           src: viewJSON.cellData
         })
       ])
-    }),
-    showRequestAccessModal && h(RequestDatasetAccessModal, {
-      datasets: [snapshot],
-      onDismiss: () => setShowRequestAccessModal(false)
     })
   ])
 }

--- a/src/pages/library/DataBrowserPreview.js
+++ b/src/pages/library/DataBrowserPreview.js
@@ -134,11 +134,11 @@ const DataBrowserPreview = ({ id }) => {
         div({ style: { display: 'flex', flexDirection: 'row', alignItems: 'top', justifyContent: 'space-between', width: '100%', lineHeight: '26px' } }, [
           h1([snapshot['dct:title']]),
           h(Link, {
-            onClick: () => { Nav.goToPath('library-details', { id: Nav.getCurrentRoute().params.id }) },
+            href: Nav.getLink('library-details', { id: Nav.getCurrentRoute().params.id }),
             'aria-label': 'Close',
             style: { marginTop: '1rem' }
           }, [
-            icon('times', { size: 30, style: { color: colors.primary('light') } })
+            icon('times', { size: 30 })
           ])
         ]),
         div({ style: { display: 'flex', flexDirection: 'row', alignItems: 'center', width: '100%', marginBottom: 30 } }, [

--- a/src/pages/library/DataBrowserPreview.js
+++ b/src/pages/library/DataBrowserPreview.js
@@ -2,15 +2,16 @@ import _ from 'lodash/fp'
 import { useState } from 'react'
 import { div, h, h1, h2 } from 'react-hyperscript-helpers'
 import ReactJson from 'react-json-view'
-import { ButtonPrimary, Select } from 'src/components/common'
+import { ButtonPrimary, Link, Select } from 'src/components/common'
 import FooterWrapper from 'src/components/FooterWrapper'
-import { centeredSpinner, spinner } from 'src/components/icons'
+import { centeredSpinner, icon, spinner } from 'src/components/icons'
 import { libraryTopMatter } from 'src/components/library-common'
 import ModalDrawer from 'src/components/ModalDrawer'
 import { ColumnSelector, SimpleTable } from 'src/components/table'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { withErrorReporting } from 'src/libs/error'
+import * as Nav from 'src/libs/nav'
 import { useCancellation, useOnMount } from 'src/libs/react-utils'
 import * as Utils from 'src/libs/utils'
 import { useDataCatalog } from 'src/pages/library/dataBrowser-utils'
@@ -130,8 +131,15 @@ const DataBrowserPreview = ({ id }) => {
     !snapshot ?
       centeredSpinner() :
       div({ style: { padding: 20 } }, [
-        div({ style: { display: 'flex', flexDirection: 'row', alignItems: 'top', width: '100%', lineHeight: '26px' } }, [
-          h1([snapshot['dct:title']])
+        div({ style: { display: 'flex', flexDirection: 'row', alignItems: 'top', justifyContent: 'space-between', width: '100%', lineHeight: '26px' } }, [
+          h1([snapshot['dct:title']]),
+          h(Link, {
+            onClick: () => { Nav.goToPath('library-details', { id: Nav.getCurrentRoute().params.id }) },
+            'aria-label': 'Close',
+            style: { marginTop: '1rem' }
+          }, [
+            icon('times', { size: 30, style: { color: colors.primary('light') } })
+          ])
         ]),
         div({ style: { display: 'flex', flexDirection: 'row', alignItems: 'center', width: '100%', marginBottom: 30 } }, [
           h(Select, {

--- a/src/pages/library/RequestDatasetAccessModal.js
+++ b/src/pages/library/RequestDatasetAccessModal.js
@@ -45,6 +45,7 @@ export const RequestDatasetAccessModal = ({ onDismiss, datasets }) => {
       width: '40rem',
       showButtons: false,
       showX: true,
+      xIcon: 'times',
       onDismiss
     }, [
       div([


### PR DESCRIPTION
**BEFORE**
<img width="1440" alt="Screen Shot 2022-01-04 at 2 51 21 PM" src="https://user-images.githubusercontent.com/10501914/148115802-d5dc7529-1774-45c1-9c41-1da43943aa05.png">
<img width="1440" alt="Screen Shot 2022-01-04 at 2 51 29 PM" src="https://user-images.githubusercontent.com/10501914/148115877-eb89f69b-6e01-4307-b085-7a9508f22965.png">


**AFTER**
<img width="1440" alt="Screen Shot 2022-01-04 at 2 50 52 PM" src="https://user-images.githubusercontent.com/10501914/148115767-e90ec4d4-f5e6-49d7-b02a-5f9fcf8f7cd1.png">
<img width="1440" alt="Screen Shot 2022-01-04 at 2 50 44 PM" src="https://user-images.githubusercontent.com/10501914/148115781-8abbca4f-fcee-49c6-9425-64f044bb3cc3.png">

If the user tries to link to the workspace without access, it should error for hte user. This PR disables the checkbox and hides the "Link to Workspace" link on the details page