### PR TITLE
[DC-93] Test link to workspace page

### DIFF
--- a/integration-tests/tests/run-catalog-workflow.js
+++ b/integration-tests/tests/run-catalog-workflow.js
@@ -37,6 +37,8 @@ const testCatalogFlowFn = _.flow(
   await click(page, input({ labelContains: 'Select a workspace' }))
   await click(page, `//*[@role="combobox"][contains(normalize-space(.), "${workspaceName}")]`)
   await click(page, clickable({ textContains: 'Import' }))
+  await waitForNoSpinners(page)
+  await page.url().includes(workspaceName)
 })
 
 const testCatalog = {

--- a/integration-tests/tests/run-catalog-workflow.js
+++ b/integration-tests/tests/run-catalog-workflow.js
@@ -1,12 +1,14 @@
 const _ = require('lodash/fp')
-const { signIntoTerra, click, clickable, clickTableCell, waitForNoSpinners, findText } = require('../utils/integration-utils')
+const { signIntoTerra, click, clickable, clickTableCell, findText, input, waitForNoSpinners } = require('../utils/integration-utils')
+const { withWorkspace } = require('../utils/integration-helpers')
 const { withUserToken } = require('../utils/terra-sa-utils')
 const { dismissNotifications } = require('../utils/integration-utils')
 
 
 const testCatalogFlowFn = _.flow(
+  withWorkspace,
   withUserToken
-)(async ({ testUrl, page, token }) => {
+)(async ({ testUrl, page, token, workspaceName }) => {
   await page.goto(testUrl)
   await waitForNoSpinners(page)
 
@@ -27,14 +29,14 @@ const testCatalogFlowFn = _.flow(
   await click(page, clickable({ textContains: 'Link to a workspace' }))
   await waitForNoSpinners(page)
 
-  await click(page, clickable({ textContains: 'Start with an existing workspace' }))
-  await findText(page, 'Select a workspace')
-  await click(page, clickable({ textContains: 'Back' }))
-
   await click(page, clickable({ textContains: 'Start with a new workspace' }))
   await findText(page, 'Create a New Workspace')
   await click(page, clickable({ textContains: 'Cancel' }))
 
+  await click(page, clickable({ textContains: 'Start with an existing workspace' }))
+  await click(page, input({ labelContains: 'Select a workspace' }))
+  await click(page, `//*[@role="combobox"][contains(normalize-space(.), "${workspaceName}")]`)
+  await click(page, clickable({ textContains: 'Import' }))
 })
 
 const testCatalog = {

--- a/integration-tests/tests/run-catalog-workflow.js
+++ b/integration-tests/tests/run-catalog-workflow.js
@@ -1,5 +1,5 @@
 const _ = require('lodash/fp')
-const { signIntoTerra, click, clickable, waitForNoSpinners, findText } = require('../utils/integration-utils')
+const { signIntoTerra, click, clickable, clickTableCell, waitForNoSpinners, findText } = require('../utils/integration-utils')
 const { withUserToken } = require('../utils/terra-sa-utils')
 const { dismissNotifications } = require('../utils/integration-utils')
 
@@ -20,6 +20,21 @@ const testCatalogFlowFn = _.flow(
   await dismissNotifications(page)
 
   await click(page, clickable({ textContains: 'browse & explore' }))
+  await waitForNoSpinners(page)
+  await click(page, clickable({ textContains: 'Granted' }))
+  await clickTableCell(page, "dataset list", 2, 2)
+  await waitForNoSpinners(page)
+  await click(page, clickable({ textContains: 'Link to a workspace' }))
+  await waitForNoSpinners(page)
+
+  await click(page, clickable({ textContains: 'Start with an existing workspace' }))
+  await findText(page, 'Select a workspace')
+  await click(page, clickable({ textContains: 'Back' }))
+
+  await click(page, clickable({ textContains: 'Start with a new workspace' }))
+  await findText(page, 'Create a New Workspace')
+  await click(page, clickable({ textContains: 'Cancel' }))
+
 })
 
 const testCatalog = {

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -40,6 +40,12 @@ const clickable = ({ text, textContains }) => {
   }
 }
 
+const clickTableCell = async (page, tableName, row, column, options) => {
+  const tableCellPath = `//*[@role="table" and @aria-label="${tableName}"]//*[@role="row"][${row}]//*[@role="cell"][${column}]`;
+  const xpath = `${tableCellPath}//*[@role="button" or @role="link" or @role="checkbox"]`
+  return (await page.waitForXPath(xpath, options)).click();
+}
+
 const click = async (page, xpath, options) => {
   return (await page.waitForXPath(xpath, options)).click()
 }
@@ -202,6 +208,7 @@ const withPageLogging = fn => options => {
 module.exports = {
   click,
   clickable,
+  clickTableCell,
   dismissNotifications,
   findIframe,
   findInGrid,


### PR DESCRIPTION
Update the `run-catalog-workflow.js` puppeteer test to click on the first item in the dataset list and then click "Link to a workspace." From there, it checks that both options (start with an existing workspace and a new workspace) look as expected.