### PR TITLE
AS-521: don't break on lists-of-nulls

### DIFF
--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -71,7 +71,7 @@ export const renderDataCell = (data, googleProject) => {
 
   const renderArray = items => {
     return _.map(([i, v]) => h(Fragment, { key: i }, [
-      renderCell(v.toString()), i < (items.length - 1) && div({ style: { marginRight: '0.5rem', color: colors.dark(0.85) } }, ',')
+      renderCell(v?.toString()), i < (items.length - 1) && div({ style: { marginRight: '0.5rem', color: colors.dark(0.85) } }, ',')
     ]), Utils.toIndexPairs(items))
   }
 
@@ -473,7 +473,9 @@ export const EntityEditor = ({ entityType, entityName, attributeName, attributeV
   const initialIsList = _.isObject(attributeValue) && attributeValue.items
   const initialType = Utils.cond(
     [initialIsReference, () => 'reference'],
-    [(initialIsList ? attributeValue.items[0] : attributeValue) === undefined, () => 'string'],
+    // explicit double-equal to check for null and undefined, since entity attribute lists can contain nulls
+    // eslint-disable-next-line eqeqeq
+    [(initialIsList ? attributeValue.items[0] : attributeValue) == undefined, () => 'string'],
     [initialIsList, () => typeof attributeValue.items[0]],
     () => typeof attributeValue
   )
@@ -491,7 +493,9 @@ export const EntityEditor = ({ entityType, entityName, attributeName, attributeV
   ))
   const [editType, setEditType] = useState(() => Utils.cond(
     [initialIsReference, () => 'reference'],
-    [(initialIsList ? attributeValue.items[0] : attributeValue) === undefined, () => 'string'],
+    // explicit double-equal to check for null and undefined, since entity attribute lists can contain nulls
+    // eslint-disable-next-line eqeqeq
+    [(initialIsList ? attributeValue.items[0] : attributeValue) == undefined, () => 'string'],
     [initialIsList, () => typeof attributeValue.items[0]],
     () => typeof attributeValue
   ))

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -71,7 +71,7 @@ export const renderDataCell = (data, googleProject) => {
 
   const renderArray = items => {
     return _.map(([i, v]) => h(Fragment, { key: i }, [
-      renderCell(v?.toString()), i < (items.length - 1) && div({ style: { marginRight: '0.5rem', color: colors.dark(0.85) } }, ',')
+      renderCell(v.toString()), i < (items.length - 1) && div({ style: { marginRight: '0.5rem', color: colors.dark(0.85) } }, ',')
     ]), Utils.toIndexPairs(items))
   }
 


### PR DESCRIPTION
[AS-521](https://broadworkbench.atlassian.net/browse/AS-521)

if an entity attribute is an AttributeValueList containing only AttributeNulls, don't break the entire UI when attempting to edit that attribute.

viewing the attribute works ok, both before and after this PR:
![view](https://user-images.githubusercontent.com/6041577/148417778-0ae2a214-f64c-43f7-891b-9ace7b80b616.png)

attempting to edit the attribute breaks before this PR:
![before](https://user-images.githubusercontent.com/6041577/148417866-725db5ab-ea67-4ac3-a55b-f7c7127bafd7.png)

and does not break after this PR:
![after](https://user-images.githubusercontent.com/6041577/148417894-77516556-da95-491a-8472-cddc3b931c0e.png)

Note that the edit functionality is not ideal - simply editing the attribute and clicking save will translate it into a list of empty strings instead of a list of nulls. However, this feels like positive forward movement, better off than we were before, so I'm submitting this as-is.
