### PR TITLE
Attempt waiting for bucket access before trying to launch workflow [QA-1679].

### DIFF
--- a/integration-tests/tests/run-workflow.js
+++ b/integration-tests/tests/run-workflow.js
@@ -1,6 +1,6 @@
 const _ = require('lodash/fp')
 const pRetry = require('p-retry')
-const { withWorkspace, createEntityInWorkspace } = require('../utils/integration-helpers')
+const { checkBucketAccess, withWorkspace, createEntityInWorkspace } = require('../utils/integration-helpers')
 const { click, clickable, dismissNotifications, findElement, fillIn, input, signIntoTerra, waitForNoSpinners, findInGrid, navChild, findInDataTableRow } = require('../utils/integration-utils')
 const { withUserToken } = require('../utils/terra-sa-utils')
 
@@ -17,6 +17,8 @@ const testRunWorkflowFn = _.flow(
   await dismissNotifications(page)
 
   await createEntityInWorkspace(page, billingProject, workspaceName, testEntity)
+  // Wait for bucket access to avoid sporadic failure when launching workflow.
+  await checkBucketAccess(page, billingProject, workspaceName)
 
   await click(page, clickable({ textContains: 'View Workspaces' }))
   await waitForNoSpinners(page)

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -69,7 +69,7 @@ const checkBucketAccess = async (page, billingProject, workspaceName, accessLeve
       await window.Ajax().Workspaces.workspace(billingProject, workspaceName).checkBucketAccess(billingProject, bucketName, accessLevel)
       return true
     } catch (e) { return false }
-  }, { timeout: 60000, polling: 10000 }, billingProject, workspaceName, bucketName, accessLevel)
+  }, { timeout: 60000, polling: 500 }, billingProject, workspaceName, bucketName, accessLevel)
 }
 
 const makeUser = async () => {


### PR DESCRIPTION
Add polling to make sure the user has bucket write location before we try to launch a workflow. Otherwise the launch will fail with a message in the dialog suggesting that they refresh and try again, and that is a difficult thing to work around in the integration test.

<!--
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Thanks!
--!>
