### PR TITLE
[DC-102] Allow tests to run in specific environments

### DIFF
--- a/integration-tests/jest/jest-utils.js
+++ b/integration-tests/jest/jest-utils.js
@@ -23,10 +23,7 @@ const registerTest = ({ fn, name, timeout = defaultTimeout, targetEnvironments =
     timeout
   ) : test(
     name,
-    () => {
-      console.log(`Skipping ${name} as it is not configured to run on the ${environment} environment`)
-      new Promise(resolve => resolve())
-    },
+    () => console.log(`Skipping ${name} as it is not configured to run on the ${environment} environment`),
     timeout)
 }
 

--- a/integration-tests/jest/jest-utils.js
+++ b/integration-tests/jest/jest-utils.js
@@ -16,12 +16,18 @@ const {
 
 const targetEnvParams = _.merge({ ...envs[environment] }, { billingProject, snapshotColumnName, snapshotId, snapshotTableName, testUrl, workflowName })
 
-const registerTest = ({ fn, name, timeout = defaultTimeout }) => {
-  return test(
+const registerTest = ({ fn, name, timeout = defaultTimeout, targetEnvironments = _.keys(envs) }) => {
+  return _.includes(environment, targetEnvironments) ? test(
     name,
     () => withPageLogging(withScreenshot(name)(fn))({ context, page, ...targetEnvParams }),
     timeout
-  )
+  ) : test(
+    name,
+    () => {
+      console.log(`Skipping ${name} as it is not configured to run on the ${environment} environment`)
+      new Promise(resolve => resolve())
+    },
+    timeout)
 }
 
 module.exports = { registerTest }

--- a/integration-tests/tests/run-catalog-workflow.js
+++ b/integration-tests/tests/run-catalog-workflow.js
@@ -25,7 +25,8 @@ const testCatalogFlowFn = _.flow(
 const testCatalog = {
   name: 'run-catalog',
   fn: testCatalogFlowFn,
-  timeout: 2 * 60 * 1000
+  timeout: 2 * 60 * 1000,
+  targetEnvironments: ['local', 'dev']
 }
 
 module.exports = { testCatalog }


### PR DESCRIPTION
Data explorer is building integration tests, but the application is not flagged to run on production.
This change allows developers to write tests and choose which environments to run the tests on.
Default testing behavior will not change.