### PR TITLE
[IA-2919] Enhancements to Cloud Environments (#clusters) page

### DIFF
--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -212,7 +212,7 @@ const Environments = () => {
 
   const getWorkspaceCell = (namespace, name, appType, shouldWarn) => {
     return h(Fragment, [
-      h(Link, { onClick: () => Nav.goToPath('workspace-notebooks', { namespace, name }) }, [name]),
+      h(Link, { href: Nav.getLink('workspace-dashboard', { namespace, name }) }, [name]),
       shouldWarn && h(TooltipTrigger, {
         content: `This workspace has multiple active cloud environments${forAppText(appType)}. Only the latest one will be used.`
       }, [icon('warning-standard', { style: { marginLeft: '0.25rem', color: colors.warning() } })])
@@ -224,6 +224,7 @@ const Environments = () => {
       getCurrentApp(appType)(appsByProject[googleProject]) !== app
     return getWorkspaceCell(saturnWorkspaceNamespace, saturnWorkspaceName, appType, shouldWarn)
   }
+
   const renderWorkspaceForRuntimes = runtime => {
     const { status, googleProject, labels: { saturnWorkspaceNamespace, saturnWorkspaceName } } = runtime
     const shouldWarn = !_.includes(status, ['Deleting', 'Error']) &&
@@ -236,7 +237,7 @@ const Environments = () => {
       content: div({ style: { padding: '0.5rem' } }, [
         div([strong(['Name: ']), cloudEnvName]),
         div([strong(['Google Project: ']), googleProject]),
-        disk && div([strong(['Persistent Disk: ']), disk.name])
+        !!disk && div([strong(['Persistent Disk: ']), disk.name])
       ])
     }, [h(Link, ['view'])])
   }
@@ -447,13 +448,14 @@ const Environments = () => {
               const appType = getDiskAppType(filteredDisks[rowIndex])
               const multipleDisksOfType = _.remove(disk => getDiskAppType(disk) !== appType || disk.status === 'Deleting',
                 disksByProject[googleProject]).length > 1
-              return h(Fragment,
-                [h(Link, { onClick: () => Nav.goToPath('workspace-notebooks', { namespace: saturnWorkspaceNamespace, name: saturnWorkspaceName }) },
+              return h(Fragment, [
+                h(Link, { href: Nav.getLink('workspace-dashboard', { namespace: saturnWorkspaceNamespace, name: saturnWorkspaceName }) },
                   [saturnWorkspaceName]),
                 diskStatus !== 'Deleting' && multipleDisksOfType &&
-                  h(TooltipTrigger, {
-                    content: `This workspace has multiple active persistent disks${forAppText(appType)}. Only the latest one will be used.`
-                  }, [icon('warning-standard', { style: { marginLeft: '0.25rem', color: colors.warning() } })])])
+                h(TooltipTrigger, {
+                  content: `This workspace has multiple active persistent disks${forAppText(appType)}. Only the latest one will be used.`
+                }, [icon('warning-standard', { style: { marginLeft: '0.25rem', color: colors.warning() } })])
+              ])
             }
           },
           {

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -441,17 +441,17 @@ const Environments = () => {
             field: 'workspace',
             headerRenderer: () => h(Sortable, { sort: diskSort, field: 'workspace', onSort: setDiskSort }, ['Workspace']),
             cellRenderer: ({ rowIndex }) => {
-              const { status: diskStatus, googleProject, labels: { saturnWorkspaceName } } = filteredDisks[rowIndex]
+              const { status: diskStatus, googleProject, labels: { saturnWorkspaceNamespace, saturnWorkspaceName } } = filteredDisks[rowIndex]
               const appType = getDiskAppType(filteredDisks[rowIndex])
               const multipleDisksOfType = _.remove(disk => getDiskAppType(disk) !== appType || disk.status === 'Deleting',
                 disksByProject[googleProject]).length > 1
-              return h(Fragment, [
-                saturnWorkspaceName,
+              return h(Fragment,
+                [h(Link, { onClick: () => Nav.goToPath('workspace-notebooks', { namespace: saturnWorkspaceNamespace, name: saturnWorkspaceName }) },
+                  [saturnWorkspaceName]),
                 diskStatus !== 'Deleting' && multipleDisksOfType &&
-                h(TooltipTrigger, {
-                  content: `This workspace has multiple active persistent disks ${forAppText(appType)}. Only the latest one will be used.`
-                }, [icon('warning-standard', { style: { marginLeft: '0.25rem', color: colors.warning() } })])
-              ])
+                  h(TooltipTrigger, {
+                    content: `This workspace has multiple active persistent disks ${forAppText(appType)}. Only the latest one will be used.`
+                  }, [icon('warning-standard', { style: { marginLeft: '0.25rem', color: colors.warning() } })])])
             }
           },
           {

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -206,13 +206,15 @@ const Environments = () => {
   const disksByProject = _.groupBy('googleProject', disks)
   const appsByProject = _.groupBy('googleProject', apps)
 
-  const forAppText = appType => !!appType ? `for ${_.capitalize(appType)}` : ''
+  // We start the first output string with an empty space because empty space would
+  // not apply to the case where appType is not defined (e.g. Jupyter, RStudio).
+  const forAppText = appType => !!appType ? ` for ${_.capitalize(appType)}` : ''
 
   const getWorkspaceCell = (namespace, name, appType, shouldWarn) => {
     return h(Fragment, [
       h(Link, { onClick: () => Nav.goToPath('workspace-notebooks', { namespace, name }) }, [name]),
       shouldWarn && h(TooltipTrigger, {
-        content: `This workspace has multiple active cloud environments ${forAppText(appType)}. Only the latest one will be used.`
+        content: `This workspace has multiple active cloud environments${forAppText(appType)}. Only the latest one will be used.`
       }, [icon('warning-standard', { style: { marginLeft: '0.25rem', color: colors.warning() } })])
     ])
   }
@@ -226,7 +228,7 @@ const Environments = () => {
     const { status, googleProject, labels: { saturnWorkspaceNamespace, saturnWorkspaceName } } = runtime
     const shouldWarn = !_.includes(status, ['Deleting', 'Error']) &&
       getCurrentRuntime(runtimesByProject[googleProject]) !== runtime
-    return getWorkspaceCell(saturnWorkspaceNamespace, saturnWorkspaceName, shouldWarn)
+    return getWorkspaceCell(saturnWorkspaceNamespace, saturnWorkspaceName, null, shouldWarn)
   }
 
   const getDetailsPopup = (cloudEnvName, googleProject, disk) => {
@@ -450,7 +452,7 @@ const Environments = () => {
                   [saturnWorkspaceName]),
                 diskStatus !== 'Deleting' && multipleDisksOfType &&
                   h(TooltipTrigger, {
-                    content: `This workspace has multiple active persistent disks ${forAppText(appType)}. Only the latest one will be used.`
+                    content: `This workspace has multiple active persistent disks${forAppText(appType)}. Only the latest one will be used.`
                   }, [icon('warning-standard', { style: { marginLeft: '0.25rem', color: colors.warning() } })])])
             }
           },

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -420,29 +420,29 @@ const Environments = () => {
         rowCount: filteredDisks.length,
         columns: [
           {
-            field: 'workspace-namespace',
-            headerRenderer: () => h(Sortable, { sort: diskSort, field: 'workspace-namespace', onSort: setDiskSort }, ['Billing project']),
+            field: 'billing-project',
+            headerRenderer: () => h(Sortable, { sort: diskSort, field: 'billing-project', onSort: setDiskSort }, ['Billing project']),
             cellRenderer: ({ rowIndex }) => {
-              const { labels: { saturnWorkspaceNamespace } } = filteredDisks[rowIndex]
-              return h(Fragment, [saturnWorkspaceNamespace])
-            }
-          },
-          {
-            field: 'workspace-name',
-            headerRenderer: () => h(Sortable, { sort: diskSort, field: 'workspace-name', onSort: setDiskSort }, ['Workspace']),
-            cellRenderer: ({ rowIndex }) => {
-              const { status: diskStatus, googleProject, labels: { saturnWorkspaceName } } = filteredDisks[rowIndex]
+              const { status: diskStatus, googleProject, labels: { saturnWorkspaceNamespace } } = filteredDisks[rowIndex]
               const appType = getDiskAppType(filteredDisks[rowIndex])
               const multipleDisksOfType = _.remove(disk => getDiskAppType(disk) !== appType || disk.status === 'Deleting',
                 disksByProject[googleProject]).length > 1
-              const forAppText = !!appType ? ` for ${_.capitalize(appType)}` : ''
+              const forAppText = !!appType ? `for ${_.capitalize(appType)}` : ''
               return h(Fragment, [
-                saturnWorkspaceName,
+                saturnWorkspaceNamespace,
                 diskStatus !== 'Deleting' && multipleDisksOfType &&
                 h(TooltipTrigger, {
-                  content: `This workspace has multiple active persistent disks${forAppText}. Only the latest one will be used.`
+                  content: `This billing project has multiple active persistent disks ${forAppText}. Only the latest one will be used.`
                 }, [icon('warning-standard', { style: { marginLeft: '0.25rem', color: colors.warning() } })])
               ])
+            }
+          },
+          {
+            field: 'workspace',
+            headerRenderer: () => h(Sortable, { sort: diskSort, field: 'workspace', onSort: setDiskSort }, ['Workspace']),
+            cellRenderer: ({ rowIndex }) => {
+              const { labels: { saturnWorkspaceName } } = filteredDisks[rowIndex]
+              return h(Fragment, [saturnWorkspaceName])
             }
           },
           {

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -208,7 +208,7 @@ const Environments = () => {
     return h(Fragment, [
       app.googleProject,
       inactive && h(TooltipTrigger, {
-        content: 'This billing project has multiple active cloud environments. Only the most recently created one will be used.'
+        content: 'This workspace has multiple active cloud environments. Only the most recently created one will be used.'
       }, [icon('warning-standard', { style: { marginLeft: '0.25rem', color: colors.warning() } })])
     ])
   }
@@ -219,7 +219,7 @@ const Environments = () => {
     return h(Fragment, [
       runtime.googleProject,
       inactive && h(TooltipTrigger, {
-        content: 'This billing project has multiple active cloud environments. Only the most recently created one will be used.'
+        content: 'This workspace has multiple active cloud environments. Only the most recently created one will be used.'
       }, [icon('warning-standard', { style: { marginLeft: '0.25rem', color: colors.warning() } })])
     ])
   }
@@ -324,7 +324,7 @@ const Environments = () => {
         columns: [
           {
             field: 'project',
-            headerRenderer: () => h(Sortable, { sort, field: 'project', onSort: setSort }, ['Billing project']),
+            headerRenderer: () => h(Sortable, { sort, field: 'project', onSort: setSort }, ['Workspace namespace']),
             cellRenderer: ({ rowIndex }) => {
               const cloudEnvironment = filteredCloudEnvironments[rowIndex]
               return cloudEnvironment.appName ? renderBillingProjectApp(cloudEnvironment) : renderBillingProjectRuntime(cloudEnvironment)
@@ -418,7 +418,7 @@ const Environments = () => {
         columns: [
           {
             field: 'project',
-            headerRenderer: () => h(Sortable, { sort: diskSort, field: 'project', onSort: setDiskSort }, ['Billing project']),
+            headerRenderer: () => h(Sortable, { sort: diskSort, field: 'project', onSort: setDiskSort }, ['Workspace namespace']),
             cellRenderer: ({ rowIndex }) => {
               const { status: diskStatus, googleProject } = filteredDisks[rowIndex]
               const appType = getDiskAppType(filteredDisks[rowIndex])
@@ -429,7 +429,7 @@ const Environments = () => {
                 googleProject,
                 diskStatus !== 'Deleting' && multipleDisksOfType &&
                 h(TooltipTrigger, {
-                  content: `This billing project has multiple active persistent disks${forAppText}. Only the latest one will be used.`
+                  content: `This workspace has multiple active persistent disks${forAppText}. Only the latest one will be used.`
                 }, [icon('warning-standard', { style: { marginLeft: '0.25rem', color: colors.warning() } })])
               ])
             }

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -373,7 +373,7 @@ const Environments = () => {
             }
           },
           {
-            size: { basis: 250, grow: 0 },
+            size: { basis: 220, grow: 0 },
             field: 'created',
             headerRenderer: () => h(Sortable, { sort, field: 'created', onSort: setSort }, ['Created']),
             cellRenderer: ({ rowIndex }) => {
@@ -381,7 +381,7 @@ const Environments = () => {
             }
           },
           {
-            size: { basis: 250, grow: 0 },
+            size: { basis: 220, grow: 0 },
             field: 'accessed',
             headerRenderer: () => h(Sortable, { sort, field: 'accessed', onSort: setSort }, ['Last accessed']),
             cellRenderer: ({ rowIndex }) => {
@@ -492,7 +492,7 @@ const Environments = () => {
             }
           },
           {
-            size: { basis: 240, grow: 0 },
+            size: { basis: 220, grow: 0 },
             field: 'created',
             headerRenderer: () => h(Sortable, { sort: diskSort, field: 'created', onSort: setDiskSort }, ['Created']),
             cellRenderer: ({ rowIndex }) => {
@@ -500,7 +500,7 @@ const Environments = () => {
             }
           },
           {
-            size: { basis: 240, grow: 0 },
+            size: { basis: 220, grow: 0 },
             field: 'accessed',
             headerRenderer: () => h(Sortable, { sort: diskSort, field: 'accessed', onSort: setDiskSort }, ['Last accessed']),
             cellRenderer: ({ rowIndex }) => {

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -449,18 +449,15 @@ const Environments = () => {
             size: { basis: 90, grow: 0 },
             headerRenderer: () => 'Details',
             cellRenderer: ({ rowIndex }) => {
-              const { name, id } = filteredDisks[rowIndex]
+              const { name, id, googleProject } = filteredDisks[rowIndex]
               const runtime = _.find({ runtimeConfig: { persistentDiskId: id } }, runtimes)
               const app = _.find({ diskName: name }, apps)
               return h(PopupTrigger, {
                 content: div({ style: { padding: '0.5rem' } }, [
-                  div([span({ style: { fontWeight: 600 } }, ['Name: ']), name]),
-                  runtime && div([span({ style: { fontWeight: 600 } }, ['Runtime: ']), runtime.runtimeName]),
-                  app && div([
-                    span({ style: { fontWeight: 600 } },
-                      [`${_.capitalize(app.appType)}: `]
-                    ), app.appName
-                  ])
+                  div([strong(['Name: ']), name]),
+                  div([strong(['Google Project: ']), googleProject]),
+                  runtime && div([strong(['Runtime: ']), runtime.runtimeName]),
+                  app && div([strong([`${_.capitalize(app.appType)}: `]), app.appName])
                 ])
               }, [h(Link, ['view'])])
             }

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -16,6 +16,7 @@ import { Ajax } from 'src/libs/ajax'
 import { getUser } from 'src/libs/auth'
 import colors from 'src/libs/colors'
 import { withErrorIgnoring, withErrorReporting } from 'src/libs/error'
+import * as Nav from 'src/libs/nav'
 import { useCancellation, useGetter, useOnMount, usePollingEffect } from 'src/libs/react-utils'
 import {
   defaultComputeZone, getComputeStatusForDisplay, getCurrentApp, getCurrentRuntime, getDiskAppType, getGalaxyComputeCost, getGalaxyCost,
@@ -207,24 +208,25 @@ const Environments = () => {
 
   const forAppText = appType => !!appType ? `for ${_.capitalize(appType)}` : ''
 
-  const getWorkspaceCell = (workspace, appType, shouldWarn) => {
+  const getWorkspaceCell = (namespace, name, appType, shouldWarn) => {
     return h(Fragment, [
-      workspace,
+      h(Link, { onClick: () => Nav.goToPath('workspace-notebooks', { namespace, name }) }, [name]),
       shouldWarn && h(TooltipTrigger, {
         content: `This workspace has multiple active cloud environments ${forAppText(appType)}. Only the latest one will be used.`
       }, [icon('warning-standard', { style: { marginLeft: '0.25rem', color: colors.warning() } })])
     ])
   }
   const renderWorkspaceForApps = app => {
-    const { status, appType, googleProject, labels: { saturnWorkspaceName } } = app
+    const { status, appType, googleProject, labels: { saturnWorkspaceNamespace, saturnWorkspaceName } } = app
     const shouldWarn = !_.includes(status, ['DELETING', 'ERROR', 'PREDELETING']) &&
       getCurrentApp(appType)(appsByProject[googleProject]) !== app
-    return getWorkspaceCell(saturnWorkspaceName, appType, shouldWarn)
+    return getWorkspaceCell(saturnWorkspaceNamespace, saturnWorkspaceName, appType, shouldWarn)
   }
   const renderWorkspaceForRuntimes = runtime => {
-    const shouldWarn = !_.includes(runtime.status, ['Deleting', 'Error']) &&
-      getCurrentRuntime(runtimesByProject[runtime.googleProject]) !== runtime
-    return getWorkspaceCell(runtime.labels.saturnWorkspaceName, shouldWarn)
+    const { status, googleProject, labels: { saturnWorkspaceNamespace, saturnWorkspaceName } } = runtime
+    const shouldWarn = !_.includes(status, ['Deleting', 'Error']) &&
+      getCurrentRuntime(runtimesByProject[googleProject]) !== runtime
+    return getWorkspaceCell(saturnWorkspaceNamespace, saturnWorkspaceName, shouldWarn)
   }
 
   const getDetailsPopup = (cloudEnvName, googleProject, disk) => {

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -230,11 +230,13 @@ const Environments = () => {
       ])
     }, [h(Link, ['view'])])
   }
+
   const renderDetailsApp = (app, disks) => {
     const { appName, diskName, googleProject } = app
     const disk = _.find({ name: diskName }, disks)
     return getDetailsPopup(appName, googleProject, disk)
   }
+
   const renderDetailsRuntime = (runtime, disks) => {
     const { runtimeName, googleProject, runtimeConfig: { persistentDiskId } } = runtime
     const disk = _.find({ id: persistentDiskId }, disks)

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -168,6 +168,7 @@ const Environments = () => {
 
   const filteredRuntimes = _.orderBy([{
     project: 'googleProject',
+    workspace: 'labels.saturnWorkspaceName',
     status: 'status',
     created: 'auditInfo.createdDate',
     accessed: 'auditInfo.dateAccessed',
@@ -176,6 +177,7 @@ const Environments = () => {
 
   const filteredDisks = _.orderBy([{
     project: 'googleProject',
+    workspace: 'labels.saturnWorkspaceName',
     status: 'status',
     created: 'auditInfo.createdDate',
     accessed: 'auditInfo.dateAccessed',
@@ -185,6 +187,7 @@ const Environments = () => {
 
   const filteredApps = _.orderBy([{
     project: 'googleProject',
+    workspace: 'labels.saturnWorkspaceName',
     status: 'status',
     created: 'auditInfo.createdDate',
     accessed: 'auditInfo.dateAccessed',
@@ -323,8 +326,8 @@ const Environments = () => {
         rowCount: filteredCloudEnvironments.length,
         columns: [
           {
-            field: 'billing-project',
-            headerRenderer: () => h(Sortable, { sort, field: 'billing-project', onSort: setSort }, ['Billing project']),
+            field: 'project',
+            headerRenderer: () => h(Sortable, { sort, field: 'project', onSort: setSort }, ['Billing project']),
             cellRenderer: ({ rowIndex }) => {
               const cloudEnvironment = filteredCloudEnvironments[rowIndex]
               return cloudEnvironment.labels.saturnWorkspaceNamespace
@@ -425,8 +428,8 @@ const Environments = () => {
         rowCount: filteredDisks.length,
         columns: [
           {
-            field: 'billing-project',
-            headerRenderer: () => h(Sortable, { sort: diskSort, field: 'billing-project', onSort: setDiskSort }, ['Billing project']),
+            field: 'project',
+            headerRenderer: () => h(Sortable, { sort: diskSort, field: 'project', onSort: setDiskSort }, ['Billing project']),
             cellRenderer: ({ rowIndex }) => {
               const { labels: { saturnWorkspaceNamespace } } = filteredDisks[rowIndex]
               return saturnWorkspaceNamespace

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -224,29 +224,24 @@ const Environments = () => {
     ])
   }
 
-  const renderDetailsApp = (app, disks) => {
-    const { appName, diskName, googleProject } = app
-    const disk = _.find({ name: diskName }, disks)
+  const getDetailsPopup = (envName, googleProject, disk) => {
     return h(PopupTrigger, {
       content: div({ style: { padding: '0.5rem' } }, [
-        div([strong(['Name: ']), appName]),
-        div([span({ style: { fontWeight: '600' } }, ['Google Project: ']), googleProject]),
-        disk && div([span({ style: { fontWeight: '600' } }, ['Persistent Disk: ']), disk.name])
+        div([strong(['Name: ']), envName]),
+        div([strong(['Google Project: ']), googleProject]),
+        disk && div([strong(['Persistent Disk: ']), disk.name])
       ])
     }, [h(Link, ['view'])])
   }
-
+  const renderDetailsApp = (app, disks) => {
+    const { appName, diskName, googleProject } = app
+    const disk = _.find({ name: diskName }, disks)
+    return getDetailsPopup(appName, googleProject, disk)
+  }
   const renderDetailsRuntime = (runtime, disks) => {
-    console.log('runtime: ', runtime)
     const { runtimeName, googleProject, runtimeConfig: { persistentDiskId } } = runtime
     const disk = _.find({ id: persistentDiskId }, disks)
-    return h(PopupTrigger, {
-      content: div({ style: { padding: '0.5rem' } }, [
-        div([span({ style: { fontWeight: '600' } }, ['Name: ']), runtimeName]),
-        div([span({ style: { fontWeight: '600' } }, ['Google Project: ']), googleProject]),
-        disk && div([span({ style: { fontWeight: '600' } }, ['Persistent Disk: ']), disk.name])
-      ])
-    }, [h(Link, ['view'])])
+    return getDetailsPopup(runtimeName, googleProject, disk)
   }
 
   const renderDeleteButton = (resourceType, resource) => {
@@ -327,10 +322,9 @@ const Environments = () => {
         columns: [
           {
             field: 'workspace-namespace',
-            headerRenderer: () => h(Sortable, { sort, field: 'workspace-namespace', onSort: setSort }, ['Workspace namespace']),
+            headerRenderer: () => h(Sortable, { sort, field: 'workspace-namespace', onSort: setSort }, ['Billing project']),
             cellRenderer: ({ rowIndex }) => {
               const cloudEnvironment = filteredCloudEnvironments[rowIndex]
-              console.log('cloudEnvironment: ', cloudEnvironment)
               return cloudEnvironment.labels.saturnWorkspaceNamespace
             }
           },
@@ -430,7 +424,7 @@ const Environments = () => {
         columns: [
           {
             field: 'workspace-namespace',
-            headerRenderer: () => h(Sortable, { sort: diskSort, field: 'workspace-namespace', onSort: setDiskSort }, ['Workspace namespace']),
+            headerRenderer: () => h(Sortable, { sort: diskSort, field: 'workspace-namespace', onSort: setDiskSort }, ['Billing project']),
             cellRenderer: ({ rowIndex }) => {
               const { labels: { saturnWorkspaceNamespace } } = filteredDisks[rowIndex]
               return h(Fragment, [saturnWorkspaceNamespace])

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -179,7 +179,7 @@ const useCloudEnvironmentPolling = googleProject => {
   const load = async maybeStale => {
     try {
       const [newDisks, newRuntimes] = googleProject ? await Promise.all([
-        Ajax(signal).Disks.list({ googleProject, creator: getUser().email, includeLabels: 'saturnApplication,saturnWorkspaceNamespace,saturnWorkspaceName' }),
+        Ajax(signal).Disks.list({ googleProject, creator: getUser().email, includeLabels: 'saturnApplication' }),
         Ajax(signal).Runtimes.list({ googleProject, creator: getUser().email })
       ]) : [[], []]
       setRuntimes(newRuntimes)

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -179,7 +179,7 @@ const useCloudEnvironmentPolling = googleProject => {
   const load = async maybeStale => {
     try {
       const [newDisks, newRuntimes] = googleProject ? await Promise.all([
-        Ajax(signal).Disks.list({ googleProject, creator: getUser().email, includeLabels: 'saturnApplication' }),
+        Ajax(signal).Disks.list({ googleProject, creator: getUser().email, includeLabels: 'saturnApplication,saturnWorkspaceNamespace,saturnWorkspaceName' }),
         Ajax(signal).Runtimes.list({ googleProject, creator: getUser().email })
       ]) : [[], []]
       setRuntimes(newRuntimes)


### PR DESCRIPTION
This is the part-2 PR for [IA-2919](https://broadworkbench.atlassian.net/browse/IA-2919). The part-1 PR is [here](https://github.com/DataBiosphere/terra-ui/pull/2628).

### Glossary
**Workspace namespace:**
- Terra term
- parent of a `workspace`
- holds billing information and other metadata (e.g. security perimeters)
- not user-facing
- used primarily in backend services

**Billing project:**
- Terra term
- synonymous with _workspace namespace_
- user-facing

**Google project:**
- Google Cloud Platform (GCP) term
- user-facing 

### Changes
- Add `Workspace` column to both (`YOUR CLOUD ENVIRONMENTS` and `YOUR PERSISTENT DISKS`) tables on `Cloud Environments` page.
- Made `Workspace` values link to `Notebooks` tabs of corresponding workspaces for users to more easily navigate.
- Shrink widths of `Created` and `Last accessed` to allow more room to the user-input fields of `Billing project` and `Workspace` columns.
- Add `Google Project` info to `view` pop-ups in `Details` columns for both tables.
- Use `strong` consistently instead of custom-styled `span`s.
- Factored out some duplicated code

### Screenshots
#### Before
![image](https://user-images.githubusercontent.com/5438223/148645130-5ecd11b6-3d0e-4983-9e2b-beaa87b65b58.png)

![image](https://user-images.githubusercontent.com/5438223/148645083-b1478e04-8740-4079-87a8-08f627f28cae.png)

#### After
![image](https://user-images.githubusercontent.com/5438223/148644751-a714269b-559e-4eb5-8543-8607b5dbe6ea.png)

![image](https://user-images.githubusercontent.com/5438223/148645050-a6137179-08e7-4ec0-89c7-cd46bf9fdb7a.png)


