### PR TITLE
add copy RAS passport button [post- POL-143]

### DIFF
--- a/src/components/common.js
+++ b/src/components/common.js
@@ -558,7 +558,7 @@ export const ClipboardButton = ({ text, onClick, children, ...props }) => {
       await clipboard.writeText(text)
       await Utils.delay(1500)
     })
-  }, [children, icon(copied ? 'check' : 'copy-to-clipboard')])
+  }, [children, icon(copied ? 'check' : 'copy-to-clipboard', !!children && { style: { marginLeft: '0.5rem' } })])
 }
 
 export const HeaderRenderer = ({ name, label, sort, onSort, style, ...props }) => h(MiniSortable, { sort, field: name, onSort }, [

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -545,7 +545,7 @@ export const WarningTitle = ({ children, iconSize = 36 }) => {
   ])
 }
 
-export const ClipboardButton = ({ text, onClick, ...props }) => {
+export const ClipboardButton = ({ text, onClick, children, ...props }) => {
   const [copied, setCopied] = useState(false)
   return h(Link, {
     ...props,
@@ -558,7 +558,7 @@ export const ClipboardButton = ({ text, onClick, ...props }) => {
       await clipboard.writeText(text)
       await Utils.delay(1500)
     })
-  }, [icon(copied ? 'check' : 'copy-to-clipboard')])
+  }, [children, icon(copied ? 'check' : 'copy-to-clipboard')])
 }
 
 export const HeaderRenderer = ({ name, label, sort, onSort, style, ...props }) => h(MiniSortable, { sort, field: name, onSort }, [

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -382,6 +382,11 @@ const User = signal => ({
         return res.json()
       },
 
+      getPassport: async () => {
+        const res = await fetchEcm(`${root}/passport`, _.merge(authOpts(), { signal }))
+        return res.json()
+      },
+
       linkAccount: async oauthcode => {
         const res = await fetchEcm(`${root}/oauthcode?${qs.stringify({ ...queryParams, oauthcode }, { indices: false })}`, _.merge(authOpts(), { signal, method: 'POST' }))
         return res.json()

--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -2,10 +2,11 @@ import { addDays, parseJSON } from 'date-fns/fp'
 import _ from 'lodash/fp'
 import * as qs from 'qs'
 import { Fragment, useState } from 'react'
-import { div, h, h2, h3, label, span, textarea } from 'react-hyperscript-helpers'
+import { div, h, h2, h3, label, span } from 'react-hyperscript-helpers'
 import Collapse from 'src/components/Collapse'
 import {
-  ButtonPrimary, FrameworkServiceLink, IdContainer, LabeledCheckbox, Link, RadioButton, ShibbolethLink, spinnerOverlay, UnlinkFenceAccount
+  ButtonPrimary, ClipboardButton, FrameworkServiceLink, IdContainer, LabeledCheckbox, Link, RadioButton, ShibbolethLink, spinnerOverlay,
+  UnlinkFenceAccount
 } from 'src/components/common'
 import FooterWrapper from 'src/components/FooterWrapper'
 import { centeredSpinner, icon, profilePic, spinner } from 'src/components/icons'
@@ -308,10 +309,7 @@ const PassportLinker = ({ queryParams: { state, code } = {}, provider, prettyNam
               span({ style: { margin: '0 0.25rem 0' } }, [' | ']),
               h(Link, { 'aria-label': `Unlink from ${prettyName}`, onClick: unlinkAccount }, ['Unlink'])
             ]),
-            h(Collapse, {
-              title: div({ style: { marginRight: '0.5rem' } }, ['Show Passport']), titleFirst: true,
-              buttonStyle: { flex: '0 0 auto' }
-            }, [textarea({ cols: 60, rows: 20 }, passport)])
+            div([h(ClipboardButton, { text: passport, tooltip: '' }, [span({ style: { marginRight: '0.5rem' } }, ['Copy passport to clipboard'])])])
           ])
         }
       )

--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -265,6 +265,7 @@ const PassportLinker = ({ queryParams: { state, code } = {}, provider, prettyNam
     })
     const linkAccount = withErrorReporting(`Error linking ${prettyName} account`, async code => {
       setAccountInfo(await Ajax().User.externalAccount(provider).linkAccount(code))
+      loadPassport()
     })
 
     loadAuthUrl()

--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -310,7 +310,7 @@ const PassportLinker = ({ queryParams: { state, code } = {}, provider, prettyNam
               span({ style: { margin: '0 0.25rem 0' } }, [' | ']),
               h(Link, { 'aria-label': `Unlink from ${prettyName}`, onClick: unlinkAccount }, ['Unlink'])
             ]),
-            !!passport && div([h(ClipboardButton, { text: passport, tooltip: '' }, [span({ style: { marginRight: '0.5rem' } }, ['Copy passport to clipboard'])])])
+            !!passport && div([h(ClipboardButton, { text: passport }, [span({ style: { marginRight: '0.5rem' } }, ['Copy passport to clipboard'])])])
           ])
         }
       )

--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -2,7 +2,7 @@ import { addDays, parseJSON } from 'date-fns/fp'
 import _ from 'lodash/fp'
 import * as qs from 'qs'
 import { Fragment, useState } from 'react'
-import { div, h, h2, h3, label, span } from 'react-hyperscript-helpers'
+import { div, h, h2, h3, label, span, textarea } from 'react-hyperscript-helpers'
 import Collapse from 'src/components/Collapse'
 import {
   ButtonPrimary, FrameworkServiceLink, IdContainer, LabeledCheckbox, Link, RadioButton, ShibbolethLink, spinnerOverlay, UnlinkFenceAccount
@@ -249,6 +249,7 @@ const FenceLink = ({ provider: { key, name, expiresAfter, short } }) => {
 const PassportLinker = ({ queryParams: { state, code } = {}, provider, prettyName }) => {
   const signal = useCancellation()
   const [accountInfo, setAccountInfo] = useState()
+  const [passport, setPassport] = useState()
   const [authUrl, setAuthUrl] = useState()
 
   useOnMount(() => {
@@ -257,6 +258,9 @@ const PassportLinker = ({ queryParams: { state, code } = {}, provider, prettyNam
     })
     const loadAccount = withErrorReporting(`Error loading ${prettyName} account`, async () => {
       setAccountInfo(await Ajax(signal).User.externalAccount(provider).get())
+    })
+    const loadPassport = withErrorReporting(`Error loading ${prettyName} passport`, async () => {
+      setPassport(await Ajax(signal).User.externalAccount(provider).getPassport())
     })
     const linkAccount = withErrorReporting(`Error linking ${prettyName} account`, async code => {
       setAccountInfo(await Ajax().User.externalAccount(provider).linkAccount(code))
@@ -269,6 +273,7 @@ const PassportLinker = ({ queryParams: { state, code } = {}, provider, prettyNam
       linkAccount(code)
     } else {
       loadAccount()
+      loadPassport()
     }
   })
 
@@ -302,7 +307,11 @@ const PassportLinker = ({ queryParams: { state, code } = {}, provider, prettyNam
               h(Link, { 'aria-label': `Renew your ${prettyName} link`, href: authUrl }, ['Renew']),
               span({ style: { margin: '0 0.25rem 0' } }, [' | ']),
               h(Link, { 'aria-label': `Unlink from ${prettyName}`, onClick: unlinkAccount }, ['Unlink'])
-            ])
+            ]),
+            h(Collapse, {
+              title: div({ style: { marginRight: '0.5rem' } }, ['Show Passport']), titleFirst: true,
+              buttonStyle: { flex: '0 0 auto' }
+            }, [textarea({ cols: 60, rows: 20 }, passport)])
           ])
         }
       )

--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -310,7 +310,7 @@ const PassportLinker = ({ queryParams: { state, code } = {}, provider, prettyNam
               span({ style: { margin: '0 0.25rem 0' } }, [' | ']),
               h(Link, { 'aria-label': `Unlink from ${prettyName}`, onClick: unlinkAccount }, ['Unlink'])
             ]),
-            !!passport && div([h(ClipboardButton, { text: passport }, [span({ style: { marginRight: '0.5rem' } }, ['Copy passport to clipboard'])])])
+            !!passport && div([h(ClipboardButton, { text: passport }, ['Copy passport to clipboard'])])
           ])
         }
       )

--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -310,7 +310,7 @@ const PassportLinker = ({ queryParams: { state, code } = {}, provider, prettyNam
               span({ style: { margin: '0 0.25rem 0' } }, [' | ']),
               h(Link, { 'aria-label': `Unlink from ${prettyName}`, onClick: unlinkAccount }, ['Unlink'])
             ]),
-            div([h(ClipboardButton, { text: passport, tooltip: '' }, [span({ style: { marginRight: '0.5rem' } }, ['Copy passport to clipboard'])])])
+            !!passport && div([h(ClipboardButton, { text: passport, tooltip: '' }, [span({ style: { marginRight: '0.5rem' } }, ['Copy passport to clipboard'])])])
           ])
         }
       )


### PR DESCRIPTION
This loads the passport of a user who has linked a ras account and adds a button to copy it to the clipboard on the profile page. Again, this is only for devs to use; it won't be there once this makes it to real users.