### PR TITLE
log test info without useless stack trace [POL-155]

### DIFF
--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -1,3 +1,4 @@
+const rawConsole = require('console')
 const _ = require('lodash/fp')
 
 const { signIntoTerra } = require('./integration-utils')
@@ -28,7 +29,7 @@ const makeWorkspace = withSignedInPage(async ({ page, billingProject }) => {
     return window.Ajax().Workspaces.create({ namespace: billingProject, name, attributes: {} })
   }, workspaceName, billingProject)
 
-  console.info(`created workspace: ${workspaceName}`)
+  rawConsole.info(`created workspace: ${workspaceName}`)
 
   return workspaceName
 })
@@ -38,7 +39,7 @@ const deleteWorkspace = withSignedInPage(async ({ page, billingProject, workspac
     return window.Ajax().Workspaces.workspace(billingProject, name).delete()
   }, workspaceName, billingProject)
 
-  console.info(`deleted workspace: ${workspaceName}`)
+  rawConsole.info(`deleted workspace: ${workspaceName}`)
 })
 
 const withWorkspace = test => async options => {
@@ -60,7 +61,7 @@ const createEntityInWorkspace = (page, billingProject, workspaceName, testEntity
 const makeUser = async () => {
   const { email } = await fetchLyle('create')
   const { accessToken: token } = await fetchLyle('token', email)
-  console.info(`created a user with token: ...${clipToken(token)}`)
+  rawConsole.info(`created a user with token: ...${clipToken(token)}`)
   return { email, token }
 }
 
@@ -79,7 +80,7 @@ const addUserToBilling = _.flow(withSignedInPage, withUserToken)(async ({ page, 
     return window.Ajax().Billing.addProjectUser(billingProject, ['User'], email)
   }, email, billingProject)
 
-  console.info(`added user to: ${billingProject}`)
+  rawConsole.info(`added user to: ${billingProject}`)
 
   const userList = await page.evaluate(billingProject => {
     return window.Ajax().Billing.listProjectUsers(billingProject)
@@ -87,7 +88,7 @@ const addUserToBilling = _.flow(withSignedInPage, withUserToken)(async ({ page, 
 
   const billingUser = _.find({ email }, userList)
 
-  console.info(`test user was added to the billing project with the role: ${!!billingUser && billingUser.role}`)
+  rawConsole.info(`test user was added to the billing project with the role: ${!!billingUser && billingUser.role}`)
 })
 
 const removeUserFromBilling = _.flow(withSignedInPage, withUserToken)(async ({ page, billingProject, email }) => {
@@ -95,7 +96,7 @@ const removeUserFromBilling = _.flow(withSignedInPage, withUserToken)(async ({ p
     return window.Ajax().Billing.removeProjectUser(billingProject, ['User'], email)
   }, email, billingProject)
 
-  console.info(`removed user from: ${billingProject}`)
+  rawConsole.info(`removed user from: ${billingProject}`)
 })
 
 const withBilling = test => async options => {
@@ -117,12 +118,12 @@ const deleteRuntimes = _.flow(withSignedInPage, withUserToken)(async ({ page, bi
       return runtime.runtimeName
     }, _.remove({ status: 'Deleting' }, runtimes)))
   }, billingProject, email)
-  console.info(`deleted runtimes: ${deletedRuntimes}`)
+  rawConsole.info(`deleted runtimes: ${deletedRuntimes}`)
 })
 
 const registerUser = withSignedInPage(async ({ page, token }) => {
   // TODO: make this available to all puppeteer browser windows
-  console.info(`token of user in registerUser(): ...${clipToken(token)}`)
+  rawConsole.info(`token of user in registerUser(): ...${clipToken(token)}`)
   await page.evaluate(() => {
     window.catchErrorResponse = async fn => {
       try {
@@ -131,7 +132,9 @@ const registerUser = withSignedInPage(async ({ page, token }) => {
         if (e instanceof Response) {
           const text = await e.text()
           const headers = e.headers
-          const headerAuthToken = headers.get('authorization') ? `...${clipToken(headers.get('authorization').toString())}` : headers.get('authorization')
+          const headerAuthToken = headers.get('authorization') ?
+            `...${clipToken(headers.get('authorization').toString())}` :
+            headers.get('authorization')
           throw new Error(`Failed to Ajax: ${e.url} authorization header was: ${headerAuthToken} and status of: ${e.status}: ${text}`)
         } else {
           throw e

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -192,7 +192,7 @@ const logPageConsoleMessages = page => {
 
 const logPageAjaxResponses = page => {
   const handle = res => {
-    rawConsole.log('page.http.res', `${res.status()} ${res.request().method()} ${res.url()}`)
+    rawConsole.log('page.http.res', `${res.status()} ${res.request().method()} \n\x1b[1m${res.url()}\x1b[0m`) // url is bold
   }
   page.on('response', handle)
   return () => page.off('response', handle)

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -1,3 +1,4 @@
+const rawConsole = require('console')
 const _ = require('lodash/fp')
 const { Storage } = require('@google-cloud/storage')
 const { screenshotBucket, screenshotDirPath } = require('../utils/integration-config')
@@ -41,9 +42,9 @@ const clickable = ({ text, textContains }) => {
 }
 
 const clickTableCell = async (page, tableName, row, column, options) => {
-  const tableCellPath = `//*[@role="table" and @aria-label="${tableName}"]//*[@role="row"][${row}]//*[@role="cell"][${column}]`;
+  const tableCellPath = `//*[@role="table" and @aria-label="${tableName}"]//*[@role="row"][${row}]//*[@role="cell"][${column}]`
   const xpath = `${tableCellPath}//*[@role="button" or @role="link" or @role="checkbox"]`
-  return (await page.waitForXPath(xpath, options)).click();
+  return (await page.waitForXPath(xpath, options)).click()
 }
 
 const click = async (page, xpath, options) => {
@@ -170,7 +171,7 @@ const maybeSaveScreenshot = async (page, testName) => {
       }
     }
   } catch (e) {
-    console.error('Failed to capture screenshot', e)
+    rawConsole.error('Failed to capture screenshot', e)
   }
 }
 
@@ -191,7 +192,7 @@ const logPageConsoleMessages = page => {
 
 const logPageAjaxResponses = page => {
   const handle = res => {
-    console.log('page.http.res', `${res.status()} ${res.request().method()} ${res.url()}`)
+    rawConsole.log('page.http.res', `${res.status()} ${res.request().method()} ${res.url()}`)
   }
   page.on('response', handle)
   return () => page.off('response', handle)

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -192,7 +192,7 @@ const logPageConsoleMessages = page => {
 
 const logPageAjaxResponses = page => {
   const handle = res => {
-    rawConsole.log('page.http.res', `${res.status()} ${res.request().method()} \n\x1b[1m${res.url()}\x1b[0m`) // url is bold
+    rawConsole.log('page.http.res', `${res.status()} ${res.request().method()} ${res.url()}`)
   }
   page.on('response', handle)
   return () => page.off('response', handle)


### PR DESCRIPTION
cleans up test logging.

before:
<img width="1920" alt="Screen Shot 2022-01-11 at 14 03 25" src="https://user-images.githubusercontent.com/22642695/149005258-cac17af7-682a-49bf-9222-f50d4457cf95.png">

after:
<img width="1819" alt="Screen Shot 2022-01-11 at 14 03 35" src="https://user-images.githubusercontent.com/22642695/149005274-ff4aef6c-82bb-45ee-a19b-84186a199700.png">

