### PR TITLE
[DC-177] Make filter items accessible

### DIFF
--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -32,7 +32,7 @@ const findInGrid = (page, textContains, options) => {
 }
 
 const clickable = ({ text, textContains, isDescendant = false }) => {
-  const base = `(//a | //button | //*[@role="button"] | //*[@role="link"])${isDescendant ? '//*' : ''}`
+  const base = `(//a | //button | //input[@type="checkbox"] | //*[@role="button" or @role="checkbox"] | //*[@role="link"])${isDescendant ? '//*' : ''}`
   if (text) {
     return `${base}[normalize-space(.)="${text}" or @title="${text}" or @aria-label="${text}" or @aria-labelledby=//*[normalize-space(.)="${text}"]/@id]`
   } else if (textContains) {
@@ -41,9 +41,9 @@ const clickable = ({ text, textContains, isDescendant = false }) => {
 }
 
 const clickTableCell = async (page, tableName, row, column, options) => {
-  const tableCellPath = `//*[@role="table" and @aria-label="${tableName}"]//*[@role="row"][${row}]//*[@role="cell"][${column}]`;
+  const tableCellPath = `//*[@role="table" and @aria-label="${tableName}"]//*[@role="row"][${row}]//*[@role="cell"][${column}]`
   const xpath = `${tableCellPath}//*[@role="button" or @role="link" or @role="checkbox"]`
-  return (await page.waitForXPath(xpath, options)).click();
+  return (await page.waitForXPath(xpath, options)).click()
 }
 
 const click = async (page, xpath, options) => {

--- a/src/pages/library/common.js
+++ b/src/pages/library/common.js
@@ -68,7 +68,11 @@ const FilterSection = ({ onTagFilter, labels, selectedTags, labelRenderer, listD
   return h(Fragment, [
     _.map(label => {
       const lowerTag = _.toLower(label)
+      const checked = _.includes(lowerTag, lowerSelectedTags)
+      const numMatches = _.size(listDataByTag[lowerTag])
       return h(Clickable, {
+        'aria-checked': checked,
+        role: 'checkbox',
         key: label,
         style: {
           display: 'flex', alignItems: 'baseline', margin: '0.5rem 0',
@@ -77,7 +81,7 @@ const FilterSection = ({ onTagFilter, labels, selectedTags, labelRenderer, listD
         onClick: () => onTagFilter({ lowerTag, label })
       }, [
         div({ style: { lineHeight: '1.375rem', flex: 1 } }, [...(labelRenderer ? labelRenderer(label) : label)]),
-        div({ style: styles.pill(_.includes(lowerTag, lowerSelectedTags)) }, [_.size(listDataByTag[lowerTag])])
+        div({ 'aria-label': `${numMatches} matches`, style: styles.pill(checked) }, [numMatches])
       ])
     }, labelsToDisplay),
     _.size(labels) > numLabelsToRender && h(Link, {

--- a/src/pages/library/common.js
+++ b/src/pages/library/common.js
@@ -68,10 +68,10 @@ const FilterSection = ({ onTagFilter, labels, selectedTags, labelRenderer, listD
   return h(Fragment, [
     _.map(label => {
       const lowerTag = _.toLower(label)
-      const checked = _.includes(lowerTag, lowerSelectedTags)
+      const isChecked = _.includes(lowerTag, lowerSelectedTags)
       const numMatches = _.size(listDataByTag[lowerTag])
       return h(Clickable, {
-        'aria-checked': checked,
+        'aria-checked': isChecked,
         role: 'checkbox',
         key: label,
         style: {
@@ -81,7 +81,7 @@ const FilterSection = ({ onTagFilter, labels, selectedTags, labelRenderer, listD
         onClick: () => onTagFilter({ lowerTag, label })
       }, [
         div({ style: { lineHeight: '1.375rem', flex: 1 } }, [...(labelRenderer ? labelRenderer(label) : label)]),
-        div({ 'aria-label': `${numMatches} matches`, style: styles.pill(checked) }, [numMatches])
+        div({ 'aria-label': `${numMatches} matches`, style: styles.pill(isChecked) }, [numMatches])
       ])
     }, labelsToDisplay),
     _.size(labels) > numLabelsToRender && h(Link, {


### PR DESCRIPTION
No visible change. This changes the filter items to have a role of `checkbox` as this is closer to what the application is doing and will announce to a screen reader whether a filtered item has been selected.