### PR TITLE
[IA-3175] Use Google project if workspace namespace label is undefined

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,11 +55,13 @@ commands:
             - run:
                 name: Update Github deployment status
                 command: |
+                  set +e -x # don't allow a failure here to fail the job, print steps when running them
                   <<# parameters.pr >>
                   PR_SLUG="pr-$(expr "${CIRCLE_PR_NUMBER:-${CIRCLE_PULL_REQUEST##*/}}" % $NUM_PR_SITES)-dot-"
                   <</ parameters.pr >>
-                  gh api "repos/databiosphere/terra-ui/deployments/$(cat /tmp/build_num)/statuses" -H "Authorization: token $GITHUB_TOKEN" \
-                    -F state=success -F environment_url="https://${PR_SLUG}bvdp-saturn-<< parameters.env >>.appspot.com" -F log_url="$CIRCLE_BUILD_URL"
+                  RESPONSE=$(gh api "repos/databiosphere/terra-ui/deployments/$(cat /tmp/build_num)/statuses" -H "Authorization: token $GITHUB_TOKEN" \
+                    -F state=success -F environment_url="https://${PR_SLUG}bvdp-saturn-<< parameters.env >>.appspot.com" -F log_url="$CIRCLE_BUILD_URL")
+                  echo $RESPONSE
             - run:
                 name: Update Github deployment status
                 when: on_fail

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -345,8 +345,8 @@ const Environments = () => {
             field: 'project',
             headerRenderer: () => h(Sortable, { sort, field: 'project', onSort: setSort }, ['Billing project']),
             cellRenderer: ({ rowIndex }) => {
-              const cloudEnvironment = filteredCloudEnvironments[rowIndex]
-              return cloudEnvironment.labels.saturnWorkspaceNamespace
+              const { googleProject, labels: { saturnWorkspaceNamespace = googleProject } } = filteredCloudEnvironments[rowIndex]
+              return saturnWorkspaceNamespace
             }
           },
           {

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -112,8 +112,11 @@ const DeleteAppModal = ({ app: { googleProject, appName, diskName, appType }, on
 }
 
 const addNamespaceLabelIfAbsent = resource => {
+  const { googleProject, labels: { saturnWorkspaceNamespace } } = resource
   // Use googleProject if workspace namespace label is not defined
-  return _.merge({ labels: { saturnWorkspaceNamespace: resource.googleProject } }, resource)
+  return !!saturnWorkspaceNamespace ?
+    resource :
+    _.set(['labels', 'saturnWorkspaceNamespace'], googleProject, resource)
 }
 
 const Environments = () => {


### PR DESCRIPTION
This PR is to fix the bug I introduced with #2759. 

Older apps, runtimes and disks may not have the label `saturnWorkspaceNamespace` defined, which was causing the Cloud Environments (#clusters) page to give error and not load:

![image](https://user-images.githubusercontent.com/5438223/150198482-0cc41f2e-71fa-4edf-9064-83140b2bd5ef.png)

The fix is to post-process those resources retrieved from API calls to add the missing label using `googleProject` value. When such resources were created, `googleProject` used to be synonymous with `workspace namespace` (a.k.a. `billing project`).

### Testing
The issue can be reproduced on [dev Terra UI #clusters page](https://bvdp-saturn-dev.appspot.com/#clusters) when logged in as `hermione.owner@test.firecloud.org`.