### PR TITLE
[IA-3175] Cloud Environments page can handle unavailable workspace name info

### DIFF
--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -212,12 +212,14 @@ const Environments = () => {
   const forAppText = appType => !!appType ? ` for ${_.capitalize(appType)}` : ''
 
   const getWorkspaceCell = (namespace, name, appType, shouldWarn) => {
-    return h(Fragment, [
-      h(Link, { href: Nav.getLink('workspace-dashboard', { namespace, name }) }, [name]),
-      shouldWarn && h(TooltipTrigger, {
-        content: `This workspace has multiple active cloud environments${forAppText(appType)}. Only the latest one will be used.`
-      }, [icon('warning-standard', { style: { marginLeft: '0.25rem', color: colors.warning() } })])
-    ])
+    return !!name ?
+      h(Fragment, [
+        h(Link, { href: Nav.getLink('workspace-dashboard', { namespace, name }) }, [name]),
+        shouldWarn && h(TooltipTrigger, {
+          content: `This workspace has multiple active cloud environments${forAppText(appType)}. Only the latest one will be used.`
+        }, [icon('warning-standard', { style: { marginLeft: '0.25rem', color: colors.warning() } })])
+      ]) :
+      'information unavailable'
   }
 
   // Old apps, runtimes and disks may not have 'saturnWorkspaceNamespace' label defined. When they were
@@ -458,14 +460,16 @@ const Environments = () => {
               const { status: diskStatus, googleProject, labels: { saturnWorkspaceNamespace, saturnWorkspaceName } } = filteredDisks[rowIndex]
               const appType = getDiskAppType(filteredDisks[rowIndex])
               const multipleDisks = multipleDisksError(disksByProject[googleProject], appType)
-              return h(Fragment, [
-                h(Link, { href: Nav.getLink('workspace-dashboard', { namespace: saturnWorkspaceNamespace, name: saturnWorkspaceName }) },
-                  [saturnWorkspaceName]),
-                diskStatus !== 'Deleting' && multipleDisks &&
-                h(TooltipTrigger, {
-                  content: `This workspace has multiple active persistent disks${forAppText(appType)}. Only the latest one will be used.`
-                }, [icon('warning-standard', { style: { marginLeft: '0.25rem', color: colors.warning() } })])
-              ])
+              return !!saturnWorkspaceName ?
+                h(Fragment, [
+                  h(Link, { href: Nav.getLink('workspace-dashboard', { namespace: saturnWorkspaceNamespace, name: saturnWorkspaceName }) },
+                    [saturnWorkspaceName]),
+                  diskStatus !== 'Deleting' && multipleDisks &&
+                  h(TooltipTrigger, {
+                    content: `This workspace has multiple active persistent disks${forAppText(appType)}. Only the latest one will be used.`
+                  }, [icon('warning-standard', { style: { marginLeft: '0.25rem', color: colors.warning() } })])
+                ]) :
+                'information unavailable'
             }
           },
           {


### PR DESCRIPTION
It turns out, (similarly to #2772), old apps/runtimes/disks may not have a `workspace name` label, in which case the Cloud Environments (#clusters) page gives the error below:

![image](https://user-images.githubusercontent.com/5438223/150536784-19b0a193-1ad9-4a4b-9a5e-80a458ea2241.png)

This PR will make it look like below instead:

![image](https://user-images.githubusercontent.com/5438223/150536624-456f84b4-9046-4a23-9cb9-cc299ffea213.png)

Testing is challenging unless you have compute/disks that are more than a year old. I had to modify the Leonardo dev DB to reproduce the error.