### PR TITLE
[IA-3175] Use googleProject when a disk doesn't have workspace namespace defined

### DIFF
--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -457,7 +457,7 @@ const Environments = () => {
             field: 'workspace',
             headerRenderer: () => h(Sortable, { sort: diskSort, field: 'workspace', onSort: setDiskSort }, ['Workspace']),
             cellRenderer: ({ rowIndex }) => {
-              const { status: diskStatus, googleProject, labels: { saturnWorkspaceNamespace, saturnWorkspaceName } } = filteredDisks[rowIndex]
+              const { status: diskStatus, googleProject, labels: { saturnWorkspaceNamespace = googleProject, saturnWorkspaceName } } = filteredDisks[rowIndex]
               const appType = getDiskAppType(filteredDisks[rowIndex])
               const multipleDisks = multipleDisksError(disksByProject[googleProject], appType)
               return !!saturnWorkspaceName ?


### PR DESCRIPTION
The last PRs missed the corner case where a disk does _not_ have workspace _namespace_  defined but _does_ have workspace _name_ defined. 

Currently in this scenario, Cloud Environments page gives the error below:

![image](https://user-images.githubusercontent.com/5438223/150820035-46ce9dd9-689e-4819-9476-fb33e0f58450.png)

With this fix, we'll get the expected page view

![image](https://user-images.githubusercontent.com/5438223/150820209-7856cfe2-3c67-41c0-a96f-f520012e44bd.png)

Reproduced the issue and by manually updating Leonardo's `dev` `LABEL` table and verified the fix on a local deployment.