### PR TITLE
[WOR-62] Add call to Sam to check that user is member of given group

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -479,6 +479,10 @@ const Groups = signal => ({
 
       setPolicy: (policyName, value) => {
         return fetchSam(`${resourceRoot}/policies/${policyName}/public`, _.mergeAll([authOpts(), { signal, method: 'PUT' }, jsonBody(value)]))
+      },
+
+      isMember: async () => {
+        await fetchSam(`${resourceRoot}/action/use`, _.merge(authOpts(), { signal }))
       }
     }
   }

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -482,7 +482,8 @@ const Groups = signal => ({
       },
 
       isMember: async () => {
-        await fetchSam(`${resourceRoot}/action/use`, _.merge(authOpts(), { signal }))
+        const res = await fetchSam(`${resourceRoot}/action/use`, _.merge(authOpts(), { signal }))
+        return res.json()
       }
     }
   }


### PR DESCRIPTION
Ticket: [WOR-62](https://broadworkbench.atlassian.net/browse/WOR-62)
* We will be restricting access to alpha spend reports to a subset of users that will be members of a specific Sam group. We'll use `isMember` to conditionally display spend reports to users depending on if they're in the Sam group in question. The group that the UI checks will be specified in config (which will be added in a separate PR)
