### PR TITLE
[WOR-64] add alpha spend report group to config

### DIFF
--- a/config/alpha.json
+++ b/config/alpha.json
@@ -24,5 +24,5 @@
     "apiKey": "AQEBBAEkx4iE2KxNyI7Wx08EwU1ycTM7E4FMSmaibbMUQxNU6uQvuAJt7fyABAtFYSYfgEE"
   },
   "tosUrlRoot": "https://us-central1-broad-workbench-tos-alpha.cloudfunctions.net/tos",
-  "alphaSpendReportGroup": "Alpha_Spend_Report_Users@alpha.test.firecloud.org"
+  "alphaSpendReportGroup": "Alpha_Spend_Report_Users"
 }

--- a/config/alpha.json
+++ b/config/alpha.json
@@ -23,5 +23,6 @@
     "appId": "saturnnonprod-O9lUP",
     "apiKey": "AQEBBAEkx4iE2KxNyI7Wx08EwU1ycTM7E4FMSmaibbMUQxNU6uQvuAJt7fyABAtFYSYfgEE"
   },
-  "tosUrlRoot": "https://us-central1-broad-workbench-tos-alpha.cloudfunctions.net/tos"
+  "tosUrlRoot": "https://us-central1-broad-workbench-tos-alpha.cloudfunctions.net/tos",
+  "alphaSpendReportGroup": "Alpha_Spend_Report_Users@alpha.test.firecloud.org"
 }

--- a/config/dev.json
+++ b/config/dev.json
@@ -23,5 +23,6 @@
     "appId": "saturnnonprod-O9lUP",
     "apiKey": "AQEBBAEkx4iE2KxNyI7Wx08EwU1ycTM7E4FMSmaibbMUQxNU6uQvuAJt7fyABAtFYSYfgEE"
   },
-  "tosUrlRoot": "https://us-central1-broad-workbench-tos-dev.cloudfunctions.net/tos"
+  "tosUrlRoot": "https://us-central1-broad-workbench-tos-dev.cloudfunctions.net/tos",
+  "alphaSpendReportGroup": "Alpha_Spend_Report_Users@dev.test.firecloud.org"
 }

--- a/config/dev.json
+++ b/config/dev.json
@@ -24,5 +24,5 @@
     "apiKey": "AQEBBAEkx4iE2KxNyI7Wx08EwU1ycTM7E4FMSmaibbMUQxNU6uQvuAJt7fyABAtFYSYfgEE"
   },
   "tosUrlRoot": "https://us-central1-broad-workbench-tos-dev.cloudfunctions.net/tos",
-  "alphaSpendReportGroup": "Alpha_Spend_Report_Users@dev.test.firecloud.org"
+  "alphaSpendReportGroup": "Alpha_Spend_Report_Users"
 }

--- a/config/fiab.json
+++ b/config/fiab.json
@@ -22,5 +22,6 @@
     "appId": "saturnnonprod-O9lUP",
     "apiKey": "AQEBBAEkx4iE2KxNyI7Wx08EwU1ycTM7E4FMSmaibbMUQxNU6uQvuAJt7fyABAtFYSYfgEE"
   },
-  "tosUrlRoot": "https://us-central1-broad-workbench-tos-dev.cloudfunctions.net/tos"
+  "tosUrlRoot": "https://us-central1-broad-workbench-tos-dev.cloudfunctions.net/tos",
+  "alphaSpendReportGroup": "Alpha_Spend_Report_Users"
 }

--- a/config/perf.json
+++ b/config/perf.json
@@ -23,5 +23,6 @@
     "appId": "saturnnonprod-O9lUP",
     "apiKey": "AQEBBAEkx4iE2KxNyI7Wx08EwU1ycTM7E4FMSmaibbMUQxNU6uQvuAJt7fyABAtFYSYfgEE"
   },
-  "tosUrlRoot": "https://us-central1-broad-workbench-tos-perf.cloudfunctions.net/tos"
+  "tosUrlRoot": "https://us-central1-broad-workbench-tos-perf.cloudfunctions.net/tos",
+  "alphaSpendReportGroup": "Alpha_Spend_Report_Users@perf.test.firecloud.org"
 }

--- a/config/perf.json
+++ b/config/perf.json
@@ -24,5 +24,5 @@
     "apiKey": "AQEBBAEkx4iE2KxNyI7Wx08EwU1ycTM7E4FMSmaibbMUQxNU6uQvuAJt7fyABAtFYSYfgEE"
   },
   "tosUrlRoot": "https://us-central1-broad-workbench-tos-perf.cloudfunctions.net/tos",
-  "alphaSpendReportGroup": "Alpha_Spend_Report_Users@perf.test.firecloud.org"
+  "alphaSpendReportGroup": "Alpha_Spend_Report_Users"
 }

--- a/config/prod.json
+++ b/config/prod.json
@@ -21,5 +21,6 @@
     "appId": "saturnprod-VuHKy",
     "apiKey": "AQEBBAEGP2gTM2pIdJAQOIeNrm8dcTM7E4FMSmaibbMUQxNU6qy6nLPOBK8QfSvPFSsX8PQ"
   },
-  "tosUrlRoot": "https://us-central1-broad-workbench-tos-prod.cloudfunctions.net/tos"
+  "tosUrlRoot": "https://us-central1-broad-workbench-tos-prod.cloudfunctions.net/tos",
+  "alphaSpendReportGroup": "Alpha_Spend_Report_Users@firecloud.org"
 }

--- a/config/prod.json
+++ b/config/prod.json
@@ -22,5 +22,5 @@
     "apiKey": "AQEBBAEGP2gTM2pIdJAQOIeNrm8dcTM7E4FMSmaibbMUQxNU6qy6nLPOBK8QfSvPFSsX8PQ"
   },
   "tosUrlRoot": "https://us-central1-broad-workbench-tos-prod.cloudfunctions.net/tos",
-  "alphaSpendReportGroup": "Alpha_Spend_Report_Users@firecloud.org"
+  "alphaSpendReportGroup": "Alpha_Spend_Report_Users"
 }

--- a/config/staging.json
+++ b/config/staging.json
@@ -22,5 +22,6 @@
     "appId": "saturnnonprod-O9lUP",
     "apiKey": "AQEBBAEkx4iE2KxNyI7Wx08EwU1ycTM7E4FMSmaibbMUQxNU6uQvuAJt7fyABAtFYSYfgEE"
   },
-  "tosUrlRoot": "https://us-central1-broad-workbench-tos-staging.cloudfunctions.net/tos"
+  "tosUrlRoot": "https://us-central1-broad-workbench-tos-staging.cloudfunctions.net/tos",
+  "alphaSpendReportGroup": "Alpha_Spend_Report_Users@staging.test.firecloud.org"
 }

--- a/config/staging.json
+++ b/config/staging.json
@@ -23,5 +23,5 @@
     "apiKey": "AQEBBAEkx4iE2KxNyI7Wx08EwU1ycTM7E4FMSmaibbMUQxNU6uQvuAJt7fyABAtFYSYfgEE"
   },
   "tosUrlRoot": "https://us-central1-broad-workbench-tos-staging.cloudfunctions.net/tos",
-  "alphaSpendReportGroup": "Alpha_Spend_Report_Users@staging.test.firecloud.org"
+  "alphaSpendReportGroup": "Alpha_Spend_Report_Users"
 }


### PR DESCRIPTION
Ticket: [WOR-64](https://broadworkbench.atlassian.net/browse/WOR-64)
* Sam groups by this name have already been created in all Terra envs (except fiabs)
* these groups are unused at the moment, but will be used along with https://github.com/DataBiosphere/terra-ui/pull/2782 to determine whether a user will see spend reports while they are in alpha