### PR TITLE
Upgrade nanoid (BW-1045).

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -10477,11 +10477,11 @@ fsevents@^1.2.7:
   linkType: hard
 
 "nanoid@npm:^3.1.23":
-  version: 3.1.23
-  resolution: "nanoid@npm:3.1.23"
+  version: 3.2.0
+  resolution: "nanoid@npm:3.2.0"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 8fa8dc3283a4fa159700a36cb22f61197547c8155831cb74f1b9c51fbc29ea80c136fd91001468d147a31d3a77f884958aec6c1beabac903c89780acacca9327
+  checksum: 3d1d5a69fea84e538057cf64106e713931c4ef32af344068ecff153ff91252f39b0f2b472e09b0dfff43ac3cf520c92938d90e6455121fe93976e23660f4fccc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Poked around in terra-ui and didn't see any CSS isssues.

roberts@wm365-d20 terra-ui % yarn why nanoid        
└─ postcss@npm:8.3.6
   └─ nanoid@npm:3.2.0 (via npm:^3.1.23)