### PR TITLE
[DC-199] Remove empty tables from dataset preview combobox

### DIFF
--- a/integration-tests/tests/preview-dataset.js
+++ b/integration-tests/tests/preview-dataset.js
@@ -28,12 +28,6 @@ const testPreviewDatasetFn = _.flow(
   await click(page, clickable({ textContains: 'View JSON'  }))
   await findText(page, 'describedBy')
   await page.keyboard.press('Escape')
-
-  // Click on a table with no data
-  await click(page, clickable({ text: 'data type', isDescendant: true }))
-  await click(page, clickable({ text: 'Analysis File'}))
-  await waitForNoSpinners(page)
-  await findText(page, 'No Data')
 })
 
 const testPreviewDataset = {

--- a/src/pages/library/DataBrowserPreview.js
+++ b/src/pages/library/DataBrowserPreview.js
@@ -57,17 +57,17 @@ const DataBrowserPreview = ({ id }) => {
     const loadData = async () => {
       const { tables: newTables } = await Ajax(signal).DataRepo.getPreviewMetadata(id)
 
-      const [hasRows, noRows] = _.flow(
+      const hasRows = _.flow(
         _.sortBy('name'),
         _.map(({ name, rowCount }) => ({ value: name, rowCount })),
-        _.partition(({ rowCount }) => rowCount > 0)
+        _.filter(({ rowCount }) => rowCount > 0)
       )(newTables)
 
-      const newSelectOptions = [{ label: '', options: hasRows }, { label: 'Tables without data', options: noRows }]
+      const newSelectOptions = [{ label: '', options: hasRows }]
 
       setTables(newTables)
       setSelectOptions(newSelectOptions)
-      setSelectedTable(hasRows[0]?.value || noRows[0]?.value)
+      setSelectedTable(hasRows[0]?.value)
     }
 
     loadData()
@@ -157,7 +157,7 @@ const DataBrowserPreview = ({ id }) => {
           isSearchable: true,
           isClearable: false,
           value: selectedTable,
-          getOptionLabel: ({ rowCount, value }) => div({ style: { color: colors.dark(!!rowCount ? 1 : 0.5) } }, [_.startCase(value)]),
+          getOptionLabel: ({ value }) => div({ style: { color: colors.dark(1) } }, [_.startCase(value)]),
           formatGroupLabel: ({ label }) => {
             return !!label && div({
               style: { marginTop: 5, paddingTop: 15, borderTop: `1px solid ${colors.dark(0.5)}`, color: colors.dark(0.8) }
@@ -180,10 +180,7 @@ const DataBrowserPreview = ({ id }) => {
             !_.isEmpty(columns) && h(ColumnSelector, {
               onSave: setColumns, columnSettings: columns,
               style: { backgroundColor: 'unset', height: '2.5rem', width: '2.5rem', border: 0, right: 15 }
-            }),
-            _.isEmpty(previewRows) && div({
-              style: { width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' }
-            }, ['(No Data)'])
+            })
           ])
       ]),
     !!viewJSON && h(ModalDrawer, {


### PR DESCRIPTION
Before: There were two groups of tables (with and without data) listed in the dataset preview combobox
<img width="701" alt="Screen Shot 2022-01-25 at 2 01 29 PM" src="https://user-images.githubusercontent.com/6414394/151041864-620587f6-a56a-40db-90bf-9adb8bdb004c.png">

After: Only tables with data are listed
<img width="702" alt="Screen Shot 2022-01-25 at 2 00 59 PM" src="https://user-images.githubusercontent.com/6414394/151041987-9f53b005-2608-436d-9335-dbf7f8becd23.png">


