### PR TITLE
[WOR-74] Add BDC HHS responsible disclosure link

### DIFF
--- a/config/dev.json
+++ b/config/dev.json
@@ -10,6 +10,7 @@
   "firecloudBucketRoot": "https://storage.googleapis.com/firecloud-alerts-dev",
   "firecloudUrlRoot": "https://firecloud.dsde-dev.broadinstitute.org",
   "googleClientId": "500025638838-s2v23ar3spugtd5t2v1vgfa2sp7ppg0d.apps.googleusercontent.com",
+  "isBioDataCatalyst": true,
   "isProd": false,
   "jobManagerUrlRoot": "https://job-manager.dsde-dev.broadinstitute.org/jobs",
   "leoUrlRoot": "https://leonardo.dsde-dev.broadinstitute.org",

--- a/config/dev.json
+++ b/config/dev.json
@@ -10,7 +10,6 @@
   "firecloudBucketRoot": "https://storage.googleapis.com/firecloud-alerts-dev",
   "firecloudUrlRoot": "https://firecloud.dsde-dev.broadinstitute.org",
   "googleClientId": "500025638838-s2v23ar3spugtd5t2v1vgfa2sp7ppg0d.apps.googleusercontent.com",
-  "isBioDataCatalyst": true,
   "isProd": false,
   "jobManagerUrlRoot": "https://job-manager.dsde-dev.broadinstitute.org/jobs",
   "leoUrlRoot": "https://leonardo.dsde-dev.broadinstitute.org",

--- a/src/components/FooterWrapper.js
+++ b/src/components/FooterWrapper.js
@@ -56,7 +56,8 @@ const FooterWrapper = ({ children, alwaysShow, fixedHeight }) => {
     a({ href: 'https://www.nih.gov/', ...Utils.newTabLinkProps }, 'National Institutes of Health'),
     a({ href: 'https://www.usa.gov/', ...Utils.newTabLinkProps }, 'USA.gov'),
     a({ href: 'https://www.nhlbi.nih.gov/', ...Utils.newTabLinkProps },
-      'National Heart, Lung, and Blood Institute')
+      'National Heart, Lung, and Blood Institute'),
+    a({ href: 'https://hhs.responsibledisclosure.com/hc/en-us', ...Utils.newTabLinkProps }, 'HHS Responsible Disclosure')
   ])
 
   const standardFooterContent = h(Fragment, [


### PR DESCRIPTION
## Context
[Related ticket](https://broadworkbench.atlassian.net/browse/WOR-74)
The NIH is requiring us to add the HHS Responsible Disclosure link to the footer of all Terra NHLBI BioData Catalyst sites. They are requiring this to be completed by 1/31/2022.

## This PR
* Adds the responsible disclosure link to the BDC footer

**Before:**
<img width="1114" alt="Screen Shot 2022-01-25 at 4 43 00 PM" src="https://user-images.githubusercontent.com/74209955/151064656-95ad2520-90e1-49bd-bcfe-62984b081f26.png">

**After:**
<img width="1114" alt="Screen Shot 2022-01-25 at 4 43 59 PM" src="https://user-images.githubusercontent.com/74209955/151064766-ebd8ae95-8b80-4ac0-a3c3-97e38fbb042f.png">


