### PR TITLE
[DC-206] Add utility to help expose test flakiness

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -77,5 +77,19 @@ node --inspect-brk node_modules/.bin/jest [test name] --runInBand
 
 Using your IDE you can connect to the debug port and set breakpoints. More info [here](https://jestjs.io/docs/en/troubleshooting).
 
+#### Detecting Flakiness
+You can run: 
+```
+yarn test-flakes [test name]
+```
+By default this will run your test 100 times and display the stack trace of every failure encountered.
+
+You can tweak this with the following settings:
+
+Setting | Default | Description
+--------|-------:|------------|
+RUNS | 100 | The number of test runs you want to execute (Default: 100) 
+CONCURRENCY | 10 | The size of the browser pool / the number of simultaneous tests to run.
+CLUSTER_TIMEOUT_MINUTES | 120 | The number of minutes before the overall test times out. 120 is overkill. If you want to run hundreds over iterations, it is best to overestimate this value
 ### Creating a new environment (e.g., dev, alpha, etc)
 To set up an environment, run `node scripts/initializeEnvironment.js`.

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -90,6 +90,6 @@ Setting | Default | Description
 --------|-------:|------------|
 RUNS | 100 | The number of test runs you want to execute (Default: 100) 
 CONCURRENCY | 10 | The size of the browser pool / the number of simultaneous tests to run.
-CLUSTER_TIMEOUT_MINUTES | 120 | The number of minutes before the overall test times out. 120 is overkill. If you want to run hundreds over iterations, it is best to overestimate this value
+CLUSTER_TIMEOUT_MINUTES | 120 | The number of minutes before the overall test times out. 120 is overkill. If you want to run hundreds of iterations, it is best to overestimate this value
 ### Creating a new environment (e.g., dev, alpha, etc)
 To set up an environment, run `node scripts/initializeEnvironment.js`.

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -89,7 +89,7 @@ You can tweak this with the following settings:
 Setting | Default | Description
 --------|-------:|------------|
 RUNS | 100 | The number of test runs you want to execute (Default: 100) 
-CONCURRENCY | 10 | The size of the browser pool / the number of simultaneous tests to run.
+CONCURRENCY | 10 | The size of the browser pool / the number of simultaneous tests to run. 25 seems to be the upper limit for a mac with an M1 max chip
 CLUSTER_TIMEOUT_MINUTES | 120 | The number of minutes before the overall test times out. 120 is overkill. If you want to run hundreds of iterations, it is best to overestimate this value
 ### Creating a new environment (e.g., dev, alpha, etc)
 To set up an environment, run `node scripts/initializeEnvironment.js`.

--- a/integration-tests/jest/jest-utils.js
+++ b/integration-tests/jest/jest-utils.js
@@ -80,13 +80,14 @@ const flakeShaker = ({ fn, name }) => {
     const runs = _.times(runId => cluster.execute({ taskParams: targetEnvParams, taskFn: fn, runId }), testRuns)
     const results = await Promise.all(runs)
     const errors = _.filter(_.isError, results)
+    const numErrors = _.size(errors)
 
     await cluster.idle()
     await cluster.close()
 
-    if (_.size(errors)) {
-      _.forEach(err => rawConsole.log(err), errors)
-      throw new Error(`${_.size(errors)} failures out of ${testRuns}. See above for specifics.`)
+    if (numErrors) {
+      _.forEach(err => rawConsole.log(err.stack), errors)
+      throw new Error(`${numErrors} failures out of ${testRuns}. See above for specifics.`)
     }
   }
 

--- a/integration-tests/jest/jest-utils.js
+++ b/integration-tests/jest/jest-utils.js
@@ -1,7 +1,9 @@
 const _ = require('lodash/fp')
 const { defaultTimeout } = require('../utils/integration-helpers')
 const { withScreenshot, withPageLogging } = require('../utils/integration-utils')
+const { Cluster } = require('puppeteer-cluster')
 const envs = require('../utils/terra-envs')
+const rawConsole = require('console')
 
 
 const {
@@ -11,7 +13,11 @@ const {
   SNAPSHOT_ID: snapshotId,
   SNAPSHOT_TABLE_NAME: snapshotTableName,
   TEST_URL: testUrl,
-  WORKFLOW_NAME: workflowName = 'echo_to_file'
+  WORKFLOW_NAME: workflowName = 'echo_to_file',
+  FLAKES: flakes = false,
+  RUNS: testRuns = 100,
+  CONCURRENCY: maxConcurrency = 10,
+  CLUSTER_TIMEOUT_MINUTES: clusterTimeout = 10
 } = process.env
 
 const targetEnvParams = _.merge({ ...envs[environment] }, { billingProject, snapshotColumnName, snapshotId, snapshotTableName, testUrl, workflowName })
@@ -27,4 +33,62 @@ const registerTest = ({ fn, name, timeout = defaultTimeout, targetEnvironments =
     timeout)
 }
 
-module.exports = { registerTest }
+const flakeShaker = ({ fn, name, timeout = defaultTimeout }) => {
+  const timeoutMillis = clusterTimeout * 60 * 1000
+  const padding = 100
+  const messages = ['', `Number of times to run this test: ${testRuns} (adjust this by setting RUNS in your environment)`,
+    '',
+    `Number of concurrent test runs: ${maxConcurrency} (adjust this by setting CONCURRENCY in your environment)`,
+    '',
+    `Timeout (minutes): ${clusterTimeout} (if your test times out adjust CLUSTER_TIMEOUT_MINUTES in your environment)`,
+    '']
+
+  rawConsole.log(`\n\x1b[1m${/* bold */ '╔'.padEnd(padding, '═')}╗`)
+  rawConsole.log(`${`║ Running flake shaker on ${name} to flush out test flakiness...`.padEnd(padding)}║`)
+  rawConsole.log(`${'╚'.padEnd(padding, '═')}╝`)
+
+  const message = _.flow(
+    _.map(line => `${`║ ${line}`.padEnd(padding)}║\n`),
+    list => [...list, `${'╚'.padEnd(padding, '═')}╝`],
+    _.join(''))(messages)
+  rawConsole.log(`${message}`)
+
+  const runCluster = async () => {
+    const cluster = await Cluster.launch({
+      concurrency: Cluster.CONCURRENCY_CONTEXT,
+      maxConcurrency: _.toInteger(maxConcurrency),
+      timeout: timeoutMillis,
+      puppeteerOptions: {
+        defaultViewport: { width: 1200, height: 800 }
+      }
+    })
+
+    await cluster.task(async ({ page, data }) => {
+      const { taskFn, taskParams, runId } = data
+      try {
+        const result = await taskFn({ context, page, ...taskParams })
+        rawConsole.log(`Test number ${runId} passed`)
+        return result
+      } catch (e) {
+        rawConsole.log(`Test number ${runId} failed: ${e}`)
+        return e
+      }
+    })
+
+    const runs = _.times(runId => cluster.execute({ taskParams: targetEnvParams, taskFn: fn, runId }), testRuns)
+    const results = await Promise.all(runs)
+    const errors = _.filter(_.isError, results)
+
+    await cluster.idle()
+    await cluster.close()
+
+    if (_.size(errors)) {
+      _.forEach(err => rawConsole.log(err), errors)
+      throw new Error(`${_.size(errors)} failures out of ${testRuns}. See above for specifics.`)
+    }
+  }
+
+  return test(name, runCluster, timeoutMillis)
+}
+
+module.exports = { registerTest: flakes ? flakeShaker : registerTest }

--- a/integration-tests/jest/jest-utils.js
+++ b/integration-tests/jest/jest-utils.js
@@ -35,7 +35,7 @@ const registerTest = ({ fn, name, timeout = defaultTimeout, targetEnvironments =
     timeout)
 }
 
-const flakeShaker = ({ fn, name, timeout = defaultTimeout }) => {
+const flakeShaker = ({ fn, name }) => {
   const timeoutMillis = clusterTimeout * 60 * 1000
   const padding = 100
   const messages = ['', `Number of times to run this test: ${testRuns} (adjust this by setting RUNS in your environment)`,

--- a/integration-tests/jest/jest-utils.js
+++ b/integration-tests/jest/jest-utils.js
@@ -17,7 +17,9 @@ const {
   FLAKES: flakes = false,
   RUNS: testRuns = 100,
   CONCURRENCY: maxConcurrency = 10,
-  CLUSTER_TIMEOUT_MINUTES: clusterTimeout = 10
+  // Most tests should not take this long to complete even when running 100 times
+  // But we want to give this tool enough time to run without a jest timeout
+  CLUSTER_TIMEOUT_MINUTES: clusterTimeout = 120
 } = process.env
 
 const targetEnvParams = _.merge({ ...envs[environment] }, { billingProject, snapshotColumnName, snapshotId, snapshotTableName, testUrl, workflowName })

--- a/integration-tests/jest/jest-utils.js
+++ b/integration-tests/jest/jest-utils.js
@@ -85,7 +85,7 @@ const flakeShaker = ({ fn, name }) => {
     await cluster.idle()
     await cluster.close()
 
-    if (numErrors) {
+    if (!!numErrors) {
       _.forEach(err => rawConsole.log(err.stack), errors)
       throw new Error(`${numErrors} failures out of ${testRuns}. See above for specifics.`)
     }

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "test": "jest",
     "test-local": "TERRA_SA_KEY=$(vault read --format=json secret/dsde/alpha/common/firecloud-account.pem | jq .data) LYLE_SA_KEY=$(vault read --format=json secret/dsde/terra/envs/common/lyle-user-service-account-key | jq .data) yarn test",
+    "test-flakes": "FLAKES=true yarn test-local --runInBand",
     "start": "node src/server.js",
     "start-dev": "nodemon"
   },
@@ -13,7 +14,8 @@
     "jest-junit": "^13.0.0",
     "jest-puppeteer": "^6.0.2",
     "node-fetch": "^2.6.6",
-    "prompts": "^2.4.1"
+    "prompts": "^2.4.1",
+    "puppeteer-cluster": "^0.23.0"
   },
   "jest-junit": {
     "suiteName": "Integration tests",

--- a/integration-tests/tests/run-catalog-filter.js
+++ b/integration-tests/tests/run-catalog-filter.js
@@ -1,5 +1,5 @@
 const _ = require('lodash/fp')
-const { checkbox, click, clickable, waitForNoSpinners, input, fillIn, heading, findHeading } = require('../utils/integration-utils')
+const { checkbox, click, clickable, input, fillIn, heading, findHeading, findText } = require('../utils/integration-utils')
 const { enableDataCatalog } = require('../utils/integration-helpers')
 const { withUserToken } = require('../utils/terra-sa-utils')
 
@@ -15,7 +15,7 @@ const testCatalogFilterFn = withUserToken(async ({ testUrl, page, token }) => {
 
   await enableDataCatalog(page, testUrl, token)
   await click(page, clickable({ textContains: 'browse & explore' }))
-  await waitForNoSpinners(page)
+  await findText(page, 'Controlled')
 
   const totalDatasetSize = await getDatasetCount(page)
 

--- a/integration-tests/yarn.lock
+++ b/integration-tests/yarn.lock
@@ -2015,6 +2015,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"debug@npm:^4.3.3":
+  version: 4.3.3
+  resolution: "debug@npm:4.3.3"
+  dependencies:
+    ms: 2.1.2
+  peerDependenciesMeta:
+    supports-color:
+      optional: true
+  checksum: 14472d56fe4a94dbcfaa6dbed2dd3849f1d72ba78104a1a328047bb564643ca49df0224c3a17fa63533fd11dd3d4c8636cd861191232a2c6735af00cc2d4de16
+  languageName: node
+  linkType: hard
+
 "decimal.js@npm:^10.2.1":
   version: 10.2.1
   resolution: "decimal.js@npm:10.2.1"
@@ -5143,6 +5155,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"puppeteer-cluster@npm:^0.23.0":
+  version: 0.23.0
+  resolution: "puppeteer-cluster@npm:0.23.0"
+  dependencies:
+    debug: ^4.3.3
+  peerDependencies:
+    puppeteer: ">=1.5.0"
+  checksum: 6ce1faca1f98d22a01c1bf3f0b749e1e72a00700a1a6c3340e17f2170a2239f6ffcc04a93ca538bc9aeb7a179fc9736431f8131934cfbaa07611bb5b1736c8f6
+  languageName: node
+  linkType: hard
+
 "puppeteer@npm:^12.0.1":
   version: 12.0.1
   resolution: "puppeteer@npm:12.0.1"
@@ -5952,6 +5975,7 @@ resolve@^1.20.0:
     p-retry: ^4.6.1
     prompts: ^2.4.1
     puppeteer: ^12.0.1
+    puppeteer-cluster: ^0.23.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Overview
This PR does two things
1. Creates a utility to help determine whether a test has flakiness
    1.  The utility will run the tests _n_ number of times with  _i_ tests being run in parallel.
    2. The results of each test is recorded
    3. If any test fails, the test will fail
    4. This utility is meant to be used as a dev tool only - not run with automated tests
2. Corrects an issue with an existing test that was identified as flaky by circle ci

The utility was used to definitively identify where the flake occurred in the run-catalog-filter test

I have run this against a few other tests and have identified some other areas of flakiness around workspace creation and deletion.

This is in an effort to correct for the fact that there have been flaky tests running in this system for years

## Sample Output

### run-notebook
This test failed 34/100 times. This shows the three unique errors that caused failures. The complete output shows the stack trace of all failures
```
TimeoutError: waiting for XPath `(//a | //button | //*[@role="button"] | //*[@role="link"] | //*[@role="combobox"] | //*[@role="option"])[contains(normalize-space(.),"Creating") or contains(@title,"Creating") or contains(@aria-label,"Creating") or @aria-labelledby=//*[contains(normalize-space(.),"Creating")]/@id]` failed: timeout 30000ms exceeded
    at new WaitTask (/Users/psantos/projects/terra-ui/integration-tests/node_modules/puppeteer/src/common/DOMWorld.ts:798:28)
    at DOMWorld.waitForXPath (/Users/psantos/projects/terra-ui/integration-tests/node_modules/puppeteer/src/common/DOMWorld.ts:695:22)
    at Frame.waitForXPath (/Users/psantos/projects/terra-ui/integration-tests/node_modules/puppeteer/src/common/FrameManager.ts:1304:47)
    at Page.waitForXPath (/Users/psantos/projects/terra-ui/integration-tests/node_modules/puppeteer/src/common/Page.ts:3269:29)
    at findElement (/Users/psantos/projects/terra-ui/integration-tests/utils/integration-utils.js:145:15)
    at /Users/psantos/projects/terra-ui/integration-tests/tests/run-notebook.js:46:9
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at /Users/psantos/projects/terra-ui/integration-tests/utils/integration-helpers.js:51:5
    at /Users/psantos/projects/terra-ui/integration-tests/utils/integration-helpers.js:123:5
TimeoutError: waiting for XPath `(//a | //button | //*[@role="button"] | //*[@role="link"] | //*[@role="combobox"] | //*[@role="option"])[normalize-space(.)="Create" or @title="Create" or @aria-label="Create" or @aria-labelledby=//*[normalize-space(.)="Create"]/@id]` failed: timeout 30000ms exceeded
    at new WaitTask (/Users/psantos/projects/terra-ui/integration-tests/node_modules/puppeteer/src/common/DOMWorld.ts:798:28)
    at DOMWorld.waitForXPath (/Users/psantos/projects/terra-ui/integration-tests/node_modules/puppeteer/src/common/DOMWorld.ts:695:22)
    at Frame.waitForXPath (/Users/psantos/projects/terra-ui/integration-tests/node_modules/puppeteer/src/common/FrameManager.ts:1304:47)
    at Page.waitForXPath (/Users/psantos/projects/terra-ui/integration-tests/node_modules/puppeteer/src/common/Page.ts:3269:29)
    at click (/Users/psantos/projects/terra-ui/integration-tests/utils/integration-utils.js:74:22)
    at /Users/psantos/projects/terra-ui/integration-tests/tests/run-notebook.js:45:9
    at /Users/psantos/projects/terra-ui/integration-tests/utils/integration-helpers.js:51:5
    at /Users/psantos/projects/terra-ui/integration-tests/utils/integration-helpers.js:123:5
    at /Users/psantos/projects/terra-ui/integration-tests/utils/integration-helpers.js:172:3
    at /Users/psantos/projects/terra-ui/integration-tests/utils/integration-helpers.js:89:5
Error: Evaluation failed: Response
    at ExecutionContext._evaluateInternal (/Users/psantos/projects/terra-ui/integration-tests/node_modules/puppeteer/src/common/ExecutionContext.ts:273:13)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at ExecutionContext.evaluate (/Users/psantos/projects/terra-ui/integration-tests/node_modules/puppeteer/src/common/ExecutionContext.ts:140:12)
    at /Users/psantos/projects/terra-ui/integration-tests/utils/integration-helpers.js:29:3
    at /Users/psantos/projects/terra-ui/integration-tests/utils/integration-helpers.js:17:12
    at /Users/psantos/projects/terra-ui/integration-tests/utils/integration-helpers.js:48:25
    at /Users/psantos/projects/terra-ui/integration-tests/utils/integration-helpers.js:123:5
    at /Users/psantos/projects/terra-ui/integration-tests/utils/integration-helpers.js:172:3
    at /Users/psantos/projects/terra-ui/integration-tests/utils/integration-helpers.js:89:5
 FAIL  jest/1-run-notebook.integration-test.js (2195.115 s)
  ✕ run-notebook (2194436 ms)

  ● run-notebook

    34 failures out of 100. See above for specifics.

      87 |     if (_.size(errors)) {
      88 |       _.forEach(err => rawConsole.log(err), errors)
    > 89 |       throw new Error(`${_.size(errors)} failures out of ${testRuns}. See above for specifics.`)
         |             ^
      90 |     }
      91 |   }
      92 |

      at Object.runCluster (jest/jest-utils.js:89:13)

Test Suites: 1 failed, 1 total
Tests:       1 failed, 1 total
Snapshots:   0 total
Time:        2195.152 s
Ran all test suites matching /run-notebook/i.
```