### PR TITLE
[BW-1015] Display "Waiting for Cloud Quota" status for tasks within a workflow

### DIFF
--- a/src/components/job-common.js
+++ b/src/components/job-common.js
@@ -89,7 +89,7 @@ export const collapseCromwellStatus = (executionStatus, backendStatus) => {
     case 'Running':
       return backendStatus === 'AwaitingCloudQuota' ? statusType.waitingForCloudQuota : statusType.running
     default:
-      return `Unexpected status (${status})`
+      return statusType.unknown
   }
 }
 

--- a/src/components/job-common.js
+++ b/src/components/job-common.js
@@ -16,27 +16,27 @@ export const addCountSuffix = (label, count = undefined) => {
 export const statusType = {
   succeeded: {
     id: 'succeeded',
-    label: _ => 'Succeeded',
+    label: () => 'Succeeded',
     icon: style => icon('check', { size: iconSize, style: { color: colors.success(), ...style } })
   },
   failed: {
     id: 'failed',
-    label: _ => 'Failed',
+    label: () => 'Failed',
     icon: style => icon('warning-standard', { size: iconSize, style: { color: colors.danger(), ...style } })
   },
   running: {
     id: 'running',
-    label: _ => 'Running',
+    label: () => 'Running',
     icon: style => icon('sync', { size: iconSize, style: { color: colors.dark(), ...style } })
   },
   submitted: {
     id: 'submitted',
-    label: _ => 'Submitted',
+    label: () => 'Submitted',
     icon: style => icon('clock', { size: iconSize, style: { color: colors.dark(), ...style } })
   },
   waitingForCloudQuota: {
     id: 'waitingForQuota',
-    label: _ => 'Submitted, Awaiting Cloud Quota',
+    label: () => 'Submitted, Awaiting Cloud Quota',
     icon: style => icon('error-standard', { size: iconSize, style: { color: colors.warning(), ...style } }),
     moreInfoLink: 'https://support.terra.bio/hc/en-us/articles/360029071251',
     moreInfoLabel: 'Learn more about cloud quota',
@@ -94,7 +94,7 @@ export const collapseCromwellStatus = (executionStatus, backendStatus) => {
 }
 
 /**
- * Returns the icon for display with workflow or submission status.
+ * Returns the icon for display with workflow or submission status, using `collapseStatus` to determine the appropriate icon.
  */
 export const statusIcon = (status, style) => {
   return collapseStatus(status).icon(style)

--- a/src/components/job-common.js
+++ b/src/components/job-common.js
@@ -43,7 +43,7 @@ export const statusType = {
   },
   unknown: {
     id: 'unknown',
-    label: rawStatus => `Unexpected status (${rawStatus})`,
+    label: executionStatus => `Unexpected status (${executionStatus})`,
     icon: style => icon('question', { size: iconSize, style: { color: colors.dark(), ...style } })
   }
 }

--- a/src/components/job-common.js
+++ b/src/components/job-common.js
@@ -39,6 +39,7 @@ export const statusType = {
     label: _ => 'Submitted, Awaiting Cloud Quota',
     icon: style => icon('error-standard', { size: iconSize, style: { color: colors.warning(), ...style } }),
     moreInfoLink: 'https://support.terra.bio/hc/en-us/articles/360029071251',
+    moreInfoLabel: 'Learn more about cloud quota',
     tooltip: 'Delayed by Google Cloud Platform (GCP) quota limits. Contact Terra Support to request a quota increase.'
   },
   unknown: {
@@ -103,7 +104,7 @@ export const statusIcon = (status, style) => {
  * Returns the rendered status line, based on icon function, label, and style.
  */
 export const makeStatusLine = (iconFn, label, style) => div(
-  { style: { display: 'flex', alignItems: 'center', fontSize: 14, textTransform: 'capitalize', ...style } },
+  { style: { display: 'flex', alignItems: 'center', fontSize: 14, ...style } },
   [iconFn({ marginRight: '0.5rem' }), label]
 )
 
@@ -112,7 +113,7 @@ export const makeStatusLine = (iconFn, label, style) => div(
  */
 export const makeCromwellStatusLine = (executionStatus, backendStatus) => {
   const collapsedStatus = collapseCromwellStatus(executionStatus, backendStatus)
-  return h(TooltipCell, { tooltip: collapsedStatus.tooltip },
+  return h(TooltipCell, { tooltip: collapsedStatus.tooltip }, // Note that if the tooltip is undefined, a default will be shown
     [makeStatusLine(style => collapsedStatus.icon(style), collapsedStatus.label(executionStatus), { marginLeft: '0.5rem' }
     )]
   )

--- a/src/components/job-common.js
+++ b/src/components/job-common.js
@@ -14,38 +14,37 @@ export const addCountSuffix = (label, count = undefined) => {
 }
 
 export const statusType = {
-  // TODO: We probably don't need the aria labels (if the icon is always used beside text). They should be aria-hidden.
   succeeded: {
     id: 'succeeded',
     label: _ => 'Succeeded',
-    icon: style => icon('check', { size: iconSize, style: { color: colors.success(), ...style }, 'aria-label': 'success' })
+    icon: style => icon('check', { size: iconSize, style: { color: colors.success(), ...style } })
   },
   failed: {
     id: 'failed',
     label: _ => 'Failed',
-    icon: style => icon('warning-standard', { size: iconSize, style: { color: colors.danger(), ...style }, 'aria-label': 'failed' })
+    icon: style => icon('warning-standard', { size: iconSize, style: { color: colors.danger(), ...style } })
   },
   running: {
     id: 'running',
     label: _ => 'Running',
-    icon: style => icon('sync', { size: iconSize, style: { color: colors.dark(), ...style }, 'aria-label': 'running' })
+    icon: style => icon('sync', { size: iconSize, style: { color: colors.dark(), ...style } })
   },
   submitted: {
     id: 'submitted',
     label: _ => 'Submitted',
-    icon: style => icon('clock', { size: iconSize, style: { color: colors.dark(), ...style }, 'aria-label': 'submitted' })
+    icon: style => icon('clock', { size: iconSize, style: { color: colors.dark(), ...style } })
   },
   waitingForCloudQuota: {
     id: 'waitingForQuota',
     label: _ => 'Submitted, Awaiting Cloud Quota',
-    icon: style => icon('error-standard', { size: iconSize, style: { color: colors.warning(), ...style }, 'aria-label': 'waiting for cloud quota' }),
+    icon: style => icon('error-standard', { size: iconSize, style: { color: colors.warning(), ...style } }),
     moreInfoLink: 'https://support.terra.bio/hc/en-us/articles/360029071251-Google-Cloud-quotas-What-are-they-and-how-do-you-request-more-',
     tooltip: 'Delayed by Google Cloud Platform (GCP) quota limits. Contact Terra Support to request a quota increase.'
   },
   unknown: {
     id: 'unknown',
     label: rawStatus => `Unexpected status (${rawStatus})`,
-    icon: style => icon('question', { size: iconSize, style: { color: colors.dark(), ...style }, 'aria-label': 'unknown' })
+    icon: style => icon('question', { size: iconSize, style: { color: colors.dark(), ...style } })
   }
 }
 

--- a/src/components/job-common.js
+++ b/src/components/job-common.js
@@ -38,7 +38,7 @@ export const statusType = {
     id: 'waitingForQuota',
     label: _ => 'Submitted, Awaiting Cloud Quota',
     icon: style => icon('error-standard', { size: iconSize, style: { color: colors.warning(), ...style } }),
-    moreInfoLink: 'https://support.terra.bio/hc/en-us/articles/360029071251-Google-Cloud-quotas-What-are-they-and-how-do-you-request-more-',
+    moreInfoLink: 'https://support.terra.bio/hc/en-us/articles/360029071251',
     tooltip: 'Delayed by Google Cloud Platform (GCP) quota limits. Contact Terra Support to request a quota increase.'
   },
   unknown: {

--- a/src/components/job-common.js
+++ b/src/components/job-common.js
@@ -94,13 +94,6 @@ export const collapseCromwellStatus = (executionStatus, backendStatus) => {
 }
 
 /**
- * Returns the icon for display with workflow or submission status, using `collapseStatus` to determine the appropriate icon.
- */
-export const statusIcon = (status, style) => {
-  return collapseStatus(status).icon(style)
-}
-
-/**
  * Returns the rendered status line, based on icon function, label, and style.
  */
 export const makeStatusLine = (iconFn, label, style) => div(

--- a/src/pages/workspaces/workspace/JobHistory.js
+++ b/src/pages/workspaces/workspace/JobHistory.js
@@ -6,7 +6,7 @@ import * as breadcrumbs from 'src/components/breadcrumbs'
 import { Clickable, HeaderRenderer, Link, spinnerOverlay } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import { DelayedSearchInput } from 'src/components/input'
-import { collapseStatus, failedIcon, runningIcon, submittedIcon, successIcon } from 'src/components/job-common'
+import { collapseStatus, statusType } from 'src/components/job-common'
 import Modal from 'src/components/Modal'
 import { MenuButton, MenuTrigger } from 'src/components/PopupTrigger'
 import { FlexTable, TextCell, TooltipCell } from 'src/components/table'
@@ -46,7 +46,7 @@ const isTerminal = submissionStatus => submissionStatus === 'Aborted' || submiss
 
 const collapsedStatuses = _.flow(
   _.toPairs,
-  _.map(([status, count]) => ({ [collapseStatus(status)]: count })),
+  _.map(([status, count]) => ({ [collapseStatus(status).id]: count })),
   _.reduce(_.mergeWith(_.add), {})
 )
 
@@ -66,10 +66,10 @@ const statusCell = (workflowStatuses, status) => {
     content: table({ style: { margin: '0.5rem' } }, [
       tbody({}, [
         tr({}, [
-          td(styles.statusDetailCell, [successIcon()]),
-          td(styles.statusDetailCell, [failedIcon()]),
-          td(styles.statusDetailCell, [runningIcon()]),
-          td(styles.statusDetailCell, [submittedIcon()])
+          td(styles.statusDetailCell, [statusType.succeeded.icon()]),
+          td(styles.statusDetailCell, [statusType.failed.icon()]),
+          td(styles.statusDetailCell, [statusType.running.icon()]),
+          td(styles.statusDetailCell, [statusType.submitted.icon()])
         ]),
         tr({}, [
           td(styles.statusDetailCell, [succeeded || 0]),
@@ -86,10 +86,10 @@ const statusCell = (workflowStatuses, status) => {
         role: 'note',
         'aria-label': summary
       }, [
-        succeeded && successIcon(),
-        failed && failedIcon(),
-        running && runningIcon(),
-        submitted && submittedIcon()
+        succeeded && statusType.succeeded.icon(),
+        failed && statusType.failed.icon(),
+        running && statusType.running.icon(),
+        submitted && statusType.submitted.icon()
       ]),
       _.keys(collapsedStatuses(workflowStatuses)).length === 1 && span({
         style: { marginLeft: '0.5em' }

--- a/src/pages/workspaces/workspace/jobHistory/CallTable.js
+++ b/src/pages/workspaces/workspace/jobHistory/CallTable.js
@@ -92,17 +92,15 @@ const CallTable = ({ namespace, name, submissionId, workflowId, callName, callOb
             cellRenderer: ({ rowIndex }) => {
               const { failures, shardIndex: index, attempt } = callObjects[rowIndex]
               const failureCount = _.size(failures)
-              return failures ? [
-                h(Link, {
-                  style: { marginLeft: '0.5rem' },
-                  onClick: () => setFailuresModalParams({ index, attempt, failures })
-                }, [
-                  div({ style: { display: 'flex', alignItems: 'center' } }, [
-                    icon('warning-standard', { size: 18, style: { color: colors.warning(), marginRight: '0.5rem' } }),
-                    `${failureCount} Message${failureCount > 1 ? 's' : ''}`
-                  ])
+              return !!failureCount && h(Link, {
+                style: { marginLeft: '0.5rem' },
+                onClick: () => setFailuresModalParams({ index, attempt, failures })
+              }, [
+                div({ style: { display: 'flex', alignItems: 'center' } }, [
+                  icon('warning-standard', { size: 18, style: { color: colors.warning(), marginRight: '0.5rem' } }),
+                  `${failureCount} Message${failureCount > 1 ? 's' : ''}`
                 ])
-              ] : undefined
+              ])
             }
           }
         ]

--- a/src/pages/workspaces/workspace/jobHistory/CallTable.js
+++ b/src/pages/workspaces/workspace/jobHistory/CallTable.js
@@ -43,8 +43,8 @@ const CallTable = ({ namespace, name, submissionId, workflowId, callName, callOb
             size: { basis: 200, grow: 2 },
             headerRenderer: () => 'Status',
             cellRenderer: ({ rowIndex }) => {
-              const { executionStatus } = callObjects[rowIndex]
-              return h(TooltipCell, [makeCromwellStatusLine(executionStatus)])
+              const { executionStatus, backendStatus } = callObjects[rowIndex]
+              return makeCromwellStatusLine(executionStatus, backendStatus)
             }
           }, {
             size: { basis: 200, grow: 2 },

--- a/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
+++ b/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
@@ -8,7 +8,7 @@ import { ButtonSecondary, ClipboardButton, Link, Select } from 'src/components/c
 import { centeredSpinner, icon } from 'src/components/icons'
 import { DelayedSearchInput } from 'src/components/input'
 import {
-  collapseStatus, failedIcon, makeSection, makeStatusLine, runningIcon, statusIcon, submissionDetailsBreadcrumbSubtitle, submittedIcon, successIcon
+  addCountSuffix, collapseStatus, makeSection, makeStatusLine, statusIcon, statusType, submissionDetailsBreadcrumbSubtitle
 } from 'src/components/job-common'
 import { InfoBox } from 'src/components/PopupTrigger'
 import { FlexTable, Sortable, TextCell, TooltipCell } from 'src/components/table'
@@ -55,7 +55,7 @@ const SubmissionDetails = _.flow(
   useEffect(() => {
     const initialize = withErrorReporting('Unable to fetch submission details',
       async () => {
-        if (_.isEmpty(submission) || _.some(({ status }) => _.includes(collapseStatus(status), ['running', 'submitted']), submission.workflows)) {
+        if (_.isEmpty(submission) || _.some(({ status }) => _.includes(collapseStatus(status), [statusType.running, statusType.submitted]), submission.workflows)) {
           if (!_.isEmpty(submission)) {
             await Utils.delay(60000)
           }
@@ -116,7 +116,8 @@ const SubmissionDetails = _.flow(
     sort.direction === 'asc' ? _.identity : _.reverse
   )(workflows)
 
-  const { succeeded, failed, running, submitted } = _.groupBy(wf => collapseStatus(wf.status), workflows)
+  // Note: these variable names match the id values of statusType.
+  const { succeeded, failed, running, submitted } = _.groupBy(wf => collapseStatus(wf.status).id, workflows)
 
   // Note: This 'deletionDelayYears' value should reflect the current 'deletion-delay' value configured for PROD in firecloud-develop's
   // 'cromwell.conf.ctmpl' file:
@@ -160,10 +161,10 @@ const SubmissionDetails = _.flow(
       div({ style: { display: 'grid', gridTemplateColumns: '1fr 4fr' } }, [
         div({ style: { display: 'grid', gridTemplateRows: '1fr auto' } }, [
           makeSection('Workflow Statuses', [
-            succeeded && makeStatusLine(successIcon, `Succeeded: ${succeeded.length}`, { marginTop: '0.5rem' }),
-            failed && makeStatusLine(failedIcon, `Failed: ${failed.length}`, { marginTop: '0.5rem' }),
-            running && makeStatusLine(runningIcon, `Running: ${running.length}`, { marginTop: '0.5rem' }),
-            submitted && makeStatusLine(submittedIcon, `Submitted: ${submitted.length}`, { marginTop: '0.5rem' })
+            succeeded && makeStatusLine(statusType.succeeded.icon, addCountSuffix(statusType.succeeded.label(), succeeded.length), { marginTop: '0.5rem' }),
+            failed && makeStatusLine(statusType.failed.icon, addCountSuffix(statusType.failed.label(), failed.length), { marginTop: '0.5rem' }),
+            running && makeStatusLine(statusType.running.icon, addCountSuffix(statusType.running.label(), running.length), { marginTop: '0.5rem' }),
+            submitted && makeStatusLine(statusType.submitted.icon, addCountSuffix(statusType.submitted.label(), submitted.length), { marginTop: '0.5rem' })
           ]),
           div({
             style: { padding: '0 0.5rem 0.5rem', marginTop: '1.0rem', whiteSpace: 'pre', overflow: 'hidden' }

--- a/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
+++ b/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
@@ -8,7 +8,7 @@ import { ButtonSecondary, ClipboardButton, Link, Select } from 'src/components/c
 import { centeredSpinner, icon } from 'src/components/icons'
 import { DelayedSearchInput } from 'src/components/input'
 import {
-  addCountSuffix, collapseStatus, makeSection, makeStatusLine, statusIcon, statusType, submissionDetailsBreadcrumbSubtitle
+  addCountSuffix, collapseStatus, makeSection, makeStatusLine, statusType, submissionDetailsBreadcrumbSubtitle
 } from 'src/components/job-common'
 import { InfoBox } from 'src/components/PopupTrigger'
 import { FlexTable, Sortable, TextCell, TooltipCell } from 'src/components/table'
@@ -272,7 +272,7 @@ const SubmissionDetails = _.flow(
               headerRenderer: () => h(Sortable, { sort, field: 'status', onSort: setSort }, ['Status']),
               cellRenderer: ({ rowIndex }) => {
                 const { status } = filteredWorkflows[rowIndex]
-                return div({ style: { display: 'flex' } }, [statusIcon(status, { marginRight: '0.5rem' }), status])
+                return div({ style: { display: 'flex' } }, [collapseStatus(status).icon({ marginRight: '0.5rem' }), status])
               }
             }, {
               size: { basis: 125, grow: 0 },

--- a/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
+++ b/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
@@ -116,8 +116,7 @@ const SubmissionDetails = _.flow(
     sort.direction === 'asc' ? _.identity : _.reverse
   )(workflows)
 
-  // Note: these variable names match the id values of statusType.
-  const { succeeded, failed, running, submitted } = _.groupBy(wf => collapseStatus(wf.status).id, workflows)
+  const statusGroups = _.groupBy(wf => collapseStatus(wf.status).id, workflows)
 
   // Note: This 'deletionDelayYears' value should reflect the current 'deletion-delay' value configured for PROD in firecloud-develop's
   // 'cromwell.conf.ctmpl' file:
@@ -160,12 +159,10 @@ const SubmissionDetails = _.flow(
     _.isEmpty(submission) ? centeredSpinner() : h(Fragment, [
       div({ style: { display: 'grid', gridTemplateColumns: '1fr 4fr' } }, [
         div({ style: { display: 'grid', gridTemplateRows: '1fr auto' } }, [
-          makeSection('Workflow Statuses', [
-            succeeded && makeStatusLine(statusType.succeeded.icon, addCountSuffix(statusType.succeeded.label(), succeeded.length), { marginTop: '0.5rem' }),
-            failed && makeStatusLine(statusType.failed.icon, addCountSuffix(statusType.failed.label(), failed.length), { marginTop: '0.5rem' }),
-            running && makeStatusLine(statusType.running.icon, addCountSuffix(statusType.running.label(), running.length), { marginTop: '0.5rem' }),
-            submitted && makeStatusLine(statusType.submitted.icon, addCountSuffix(statusType.submitted.label(), submitted.length), { marginTop: '0.5rem' })
-          ]),
+          makeSection('Workflow Statuses',
+            [statusType.succeeded.id, statusType.failed.id, statusType.running.id, statusType.submitted.id].filter(s => statusGroups[s]).map(
+              s => makeStatusLine(statusType[s].icon, addCountSuffix(statusType[s].label(), statusGroups[s].length), { marginTop: '0.5rem' })
+            )),
           div({
             style: { padding: '0 0.5rem 0.5rem', marginTop: '1.0rem', whiteSpace: 'pre', overflow: 'hidden' }
           }, [

--- a/src/pages/workspaces/workspace/jobHistory/WorkflowDashboard.js
+++ b/src/pages/workspaces/workspace/jobHistory/WorkflowDashboard.js
@@ -7,7 +7,7 @@ import Collapse from 'src/components/Collapse'
 import { ClipboardButton, Link } from 'src/components/common'
 import { centeredSpinner, icon } from 'src/components/icons'
 import {
-  collapseCromwellStatus, collapseStatus, makeSection, makeStatusLine, statusIcon, statusType, workflowDetailsBreadcrumbSubtitle
+  collapseCromwellStatus, collapseStatus, makeSection, makeStatusLine, statusType, workflowDetailsBreadcrumbSubtitle
 } from 'src/components/job-common'
 import UriViewer from 'src/components/UriViewer'
 import WDLViewer from 'src/components/WDLViewer'
@@ -147,7 +147,7 @@ const WorkflowDashboard = _.flow(
         div({ style: { fontStyle: 'italic', marginBottom: '1rem' } }, [`Workflow metadata fetched in ${fetchTime}ms`]),
         div({ style: { display: 'flex', flexWrap: 'wrap' } }, [
           makeSection('Workflow Status', [
-            div({ style: { lineHeight: '24px', marginTop: '0.5rem' } }, [makeStatusLine(style => statusIcon(status, style), status)])
+            div({ style: { lineHeight: '24px', marginTop: '0.5rem' } }, [makeStatusLine(style => collapseStatus(status).icon(style), status)])
           ]),
           makeSection('Workflow Timing', [
             div({ style: { marginTop: '0.5rem', display: 'grid', gridTemplateColumns: 'auto 1fr', gap: '0.5rem' } }, [

--- a/src/pages/workspaces/workspace/jobHistory/WorkflowDashboard.js
+++ b/src/pages/workspaces/workspace/jobHistory/WorkflowDashboard.js
@@ -42,8 +42,9 @@ const statusCell = ({ calls }) => {
   const makeRow = (count, status, labelOverride) => {
     const seeMore = !!status.moreInfoLink ? h(Link, {
       href: status.moreInfoLink,
+      style: { marginLeft: '0.50rem' },
       ...Utils.newTabLinkProps
-    }, [' (learn more ', icon('pop-out', { size: 12 }), ' )']) : ''
+    }, ['Learn more about cloud quota', icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })]) : ''
     return !!count && div({ style: { display: 'flex', alignItems: 'center', marginTop: '0.25rem' } }, [
       status.icon(),
       ` ${count} ${!!labelOverride ? labelOverride : status.label()}`,

--- a/src/pages/workspaces/workspace/jobHistory/WorkflowDashboard.js
+++ b/src/pages/workspaces/workspace/jobHistory/WorkflowDashboard.js
@@ -41,7 +41,7 @@ const statusCell = ({ calls }) => {
 
   const makeRow = (count, status, labelOverride) => {
     const seeMore = !!status.moreInfoLink ? h(Link, { href: status.moreInfoLink, style: { marginLeft: '0.50rem' }, ...Utils.newTabLinkProps },
-      ['Learn more about cloud quota', icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })]) : ''
+      [status.moreInfoLabel, icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })]) : ''
     return !!count && div({ style: { display: 'flex', alignItems: 'center', marginTop: '0.25rem' } }, [
       status.icon(),
       ` ${count} ${!!labelOverride ? labelOverride : status.label()}`,

--- a/src/pages/workspaces/workspace/jobHistory/WorkflowDashboard.js
+++ b/src/pages/workspaces/workspace/jobHistory/WorkflowDashboard.js
@@ -36,8 +36,9 @@ const groupCallStatuses = _.flow(
 )
 
 const statusCell = ({ calls }) => {
-  // Note: these variable names match the id values of statusType (except for others, which will be the labels for unknown statuses).
-  const { succeeded, failed, running, submitted, waitingForQuota, ...others } = groupCallStatuses(calls)
+  const statusGroups = groupCallStatuses(calls)
+  // Note: these variable names match the id values of statusType (except for unknownStatuses, which will be their labels).
+  const { succeeded, failed, running, submitted, waitingForQuota, ...unknownStatuses } = statusGroups
 
   const makeRow = (count, status, labelOverride) => {
     const seeMore = !!status.moreInfoLink ? h(Link, { href: status.moreInfoLink, style: { marginLeft: '0.50rem' }, ...Utils.newTabLinkProps },
@@ -48,15 +49,11 @@ const statusCell = ({ calls }) => {
       seeMore
     ])
   }
-
-  return h(Fragment, [
-    makeRow(submitted, statusType.submitted),
-    makeRow(waitingForQuota, statusType.waitingForCloudQuota),
-    makeRow(running, statusType.running),
-    makeRow(succeeded, statusType.succeeded),
-    makeRow(failed, statusType.failed),
-    h(Fragment, _.map(([label, count]) => makeRow(count, statusType.unknown, label), _.toPairs(others)))
-  ])
+  return h(Fragment, _.concat(
+    [statusType.submitted.id, statusType.waitingForCloudQuota.id, statusType.running.id, statusType.succeeded.id, statusType.failed.id].filter(
+      s => statusGroups[s]).map(s => makeRow(statusGroups[s], statusType[s])),
+    _.map(([label, count]) => makeRow(count, statusType.unknown, label), _.toPairs(unknownStatuses)))
+  )
 }
 
 const WorkflowDashboard = _.flow(

--- a/src/pages/workspaces/workspace/jobHistory/WorkflowDashboard.js
+++ b/src/pages/workspaces/workspace/jobHistory/WorkflowDashboard.js
@@ -40,11 +40,8 @@ const statusCell = ({ calls }) => {
   const { succeeded, failed, running, submitted, waitingForQuota, ...others } = groupCallStatuses(calls)
 
   const makeRow = (count, status, labelOverride) => {
-    const seeMore = !!status.moreInfoLink ? h(Link, {
-      href: status.moreInfoLink,
-      style: { marginLeft: '0.50rem' },
-      ...Utils.newTabLinkProps
-    }, ['Learn more about cloud quota', icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })]) : ''
+    const seeMore = !!status.moreInfoLink ? h(Link, { href: status.moreInfoLink, style: { marginLeft: '0.50rem' }, ...Utils.newTabLinkProps },
+      ['Learn more about cloud quota', icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })]) : ''
     return !!count && div({ style: { display: 'flex', alignItems: 'center', marginTop: '0.25rem' } }, [
       status.icon(),
       ` ${count} ${!!labelOverride ? labelOverride : status.label()}`,

--- a/src/pages/workspaces/workspace/jobHistory/WorkflowDashboard.js
+++ b/src/pages/workspaces/workspace/jobHistory/WorkflowDashboard.js
@@ -55,7 +55,7 @@ const statusCell = ({ calls }) => {
     makeRow(running, statusType.running),
     makeRow(succeeded, statusType.succeeded),
     makeRow(failed, statusType.failed),
-    _.map(([label, count]) => makeRow(count, statusType.unknown, label), _.toPairs(others))
+    h(Fragment, _.map(([label, count]) => makeRow(count, statusType.unknown, label), _.toPairs(others)))
   ])
 }
 


### PR DESCRIPTION
This exposes "Awaiting Cloud Quota" as a Cromwell task status on the Workflows Dashboard (only). Previously this would be displayed as "Running", which was not helpful for users who wondered why tasks appeared to be "stuck". Example display (CPU limit has been reduced in a specific region that this test WDL is set to run on):

![image](https://user-images.githubusercontent.com/484484/151879699-aa6806bd-1fc6-4f2d-b28a-e1fda3d4d99b.png)

Things to note: 

1) There is a "learn more" link that should go to https://support.terra.bio/hc/en-us/articles/360029071251
2) There is a unique tooltip in the table for this status. A tooltip was already being shown, but just duplicating the cell content.

To test:
1) I can share a workspace/WDL that will hit the cloud quota issue (CPU quota has been reduced to 1 in a particular zone). 
2) cromwell-dev has to be set to develop, as the new version of Cromwell supporting this hasn't yet been released.