### PR TITLE
Upgrade tmpl (BW-1063).

### DIFF
--- a/integration-tests/yarn.lock
+++ b/integration-tests/yarn.lock
@@ -6005,9 +6005,9 @@ resolve@^1.20.0:
   linkType: hard
 
 "tmpl@npm:1.0.x":
-  version: 1.0.4
-  resolution: "tmpl@npm:1.0.4"
-  checksum: 72c93335044b5b8771207d2e9cf71e8c26b110d0f0f924f6d6c06b509d89552c7c0e4086a574ce4f05110ac40c1faf6277ecba7221afeb57ebbab70d8de39cc4
+  version: 1.0.5
+  resolution: "tmpl@npm:1.0.5"
+  checksum: cd922d9b853c00fe414c5a774817be65b058d54a2d01ebb415840960406c669a0fc632f66df885e24cb022ec812739199ccbdb8d1164c3e513f85bfca5ab2873
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -15146,9 +15146,9 @@ resolve@^2.0.0-next.3:
   linkType: hard
 
 "tmpl@npm:1.0.x":
-  version: 1.0.4
-  resolution: "tmpl@npm:1.0.4"
-  checksum: 72c93335044b5b8771207d2e9cf71e8c26b110d0f0f924f6d6c06b509d89552c7c0e4086a574ce4f05110ac40c1faf6277ecba7221afeb57ebbab70d8de39cc4
+  version: 1.0.5
+  resolution: "tmpl@npm:1.0.5"
+  checksum: cd922d9b853c00fe414c5a774817be65b058d54a2d01ebb415840960406c669a0fc632f66df885e24cb022ec812739199ccbdb8d1164c3e513f85bfca5ab2873
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This is a JavaScript template library that I doubt anything actually in Terra actually uses (but it is a transitive dependency). It hasn't been under active deployment for about 7 years… https://www.npmjs.com/package/tmpl

Security vulnerability update: 

Remediation
Upgrade tmpl to version 1.0.5 or later. For example:

tmpl@^1.0.5:
  version "1.0.5"
Always verify the validity and compatibility of suggestions with your codebase.

Details
CVE-2021-3777
Moderate severity
Vulnerable versions: < 1.0.5
Patched version: 1.0.5
nodejs-tmpl is vulnerable to Inefficient Regular Expression Complexity which may lead to resource exhaustion.