### PR TITLE
Remove delays in run-notebook test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ saturn-ui.iml
 .vscode/
 
 /integration-tests/failures
+/integration-tests/screenshots
 
 **/.yarn/*
 !**/.yarn/patches

--- a/integration-tests/jest/jest-utils.js
+++ b/integration-tests/jest/jest-utils.js
@@ -4,6 +4,7 @@ const { withScreenshot, withPageLogging } = require('../utils/integration-utils'
 const { Cluster } = require('puppeteer-cluster')
 const envs = require('../utils/terra-envs')
 const rawConsole = require('console')
+const { mkdirSync } = require('fs')
 
 
 const {
@@ -36,6 +37,7 @@ const registerTest = ({ fn, name, timeout = defaultTimeout, targetEnvironments =
 }
 
 const flakeShaker = ({ fn, name }) => {
+  const screenshotDir = './screenshots'
   const timeoutMillis = clusterTimeout * 60 * 1000
   const padding = 100
   const messages = ['', `Number of times to run this test: ${testRuns} (adjust this by setting RUNS in your environment)`,
@@ -55,6 +57,8 @@ const flakeShaker = ({ fn, name }) => {
     _.join(''))(messages)
   rawConsole.log(`${message}`)
 
+  mkdirSync(screenshotDir)
+
   const runCluster = async () => {
     const cluster = await Cluster.launch({
       concurrency: Cluster.CONCURRENCY_CONTEXT,
@@ -72,6 +76,7 @@ const flakeShaker = ({ fn, name }) => {
         rawConsole.log(`Test number ${runId} passed`)
         return result
       } catch (e) {
+        await page.screenshot({ path: `${screenshotDir}/${runId}.jpg`, fullPage: true })
         rawConsole.log(`Test number ${runId} failed: ${e}`)
         return e
       }

--- a/integration-tests/jest/jest-utils.js
+++ b/integration-tests/jest/jest-utils.js
@@ -4,7 +4,7 @@ const { withScreenshot, withPageLogging } = require('../utils/integration-utils'
 const { Cluster } = require('puppeteer-cluster')
 const envs = require('../utils/terra-envs')
 const rawConsole = require('console')
-const { mkdirSync } = require('fs')
+const { mkdirSync, existsSync } = require('fs')
 
 
 const {
@@ -57,7 +57,7 @@ const flakeShaker = ({ fn, name }) => {
     _.join(''))(messages)
   rawConsole.log(`${message}`)
 
-  mkdirSync(screenshotDir)
+  !existsSync(screenshotDir) && mkdirSync(screenshotDir)
 
   const runCluster = async () => {
     const cluster = await Cluster.launch({

--- a/integration-tests/tests/run-notebook.js
+++ b/integration-tests/tests/run-notebook.js
@@ -1,6 +1,6 @@
 const _ = require('lodash/fp')
 const { withRegisteredUser, withBilling, withWorkspace } = require('../utils/integration-helpers')
-const { click, clickable, getAnimatedDrawer, signIntoTerra, findElement, navChild, waitForNoSpinners, waitForNoSpinnersAfterAction, select, fillIn, input, findIframe, findText, dismissNotifications } = require('../utils/integration-utils')
+const { click, clickable, getAnimatedDrawer, signIntoTerra, findElement, navChild, waitForNoSpinners, noSpinnersAfter, select, fillIn, input, findIframe, findText, dismissNotifications } = require('../utils/integration-utils')
 
 
 const notebookName = 'TestNotebook'
@@ -16,15 +16,15 @@ const testRunNotebookFn = _.flow(
   await dismissNotifications(page)
   await waitForNoSpinners(page)
 
-  await waitForNoSpinnersAfterAction(page, () => click(page, clickable({ textContains: workspaceName })))
+  await noSpinnersAfter(page, { action: () => click(page, clickable({ textContains: workspaceName })) })
   await click(page, navChild('notebooks'))
   await click(page, clickable({ textContains: 'Create a' }))
   await fillIn(page, input({ placeholder: 'Enter a name' }), notebookName)
   await select(page, 'Language', 'Python 3')
 
-  await waitForNoSpinnersAfterAction(page, () => click(page, clickable({ text: 'Create Notebook' })))
-  await waitForNoSpinnersAfterAction(page, () => click(page, clickable({ textContains: notebookName })))
-  await waitForNoSpinnersAfterAction(page, () => click(page, clickable({ text: 'Edit' })))
+  await noSpinnersAfter(page, { action: () => click(page, clickable({ text: 'Create Notebook' })) })
+  await noSpinnersAfter(page, { action: () => click(page, clickable({ textContains: notebookName })) })
+  await noSpinnersAfter(page, { action: () => click(page, clickable({ text: 'Edit' })) })
 
   await findElement(page, getAnimatedDrawer('Cloud Environment'))
   await click(page, clickable({ text: 'Create' }))

--- a/integration-tests/tests/run-notebook.js
+++ b/integration-tests/tests/run-notebook.js
@@ -1,6 +1,6 @@
 const _ = require('lodash/fp')
 const { withRegisteredUser, withBilling, withWorkspace } = require('../utils/integration-helpers')
-const { click, clickable, delay, signIntoTerra, findElement, navChild, waitForNoSpinners, select, fillIn, input, findIframe, findText, dismissNotifications } = require('../utils/integration-utils')
+const { click, clickable, getAnimatedDrawer, signIntoTerra, findElement, navChild, waitForNoSpinners, waitForNoSpinnersAfterAction, select, fillIn, input, findIframe, findText, dismissNotifications } = require('../utils/integration-utils')
 
 
 const notebookName = 'TestNotebook'
@@ -14,37 +14,19 @@ const testRunNotebookFn = _.flow(
   await click(page, clickable({ textContains: 'View Workspaces' }))
   await signIntoTerra(page, token)
   await dismissNotifications(page)
-  await findElement(page, clickable({ textContains: workspaceName }))
   await waitForNoSpinners(page)
-  await click(page, clickable({ textContains: workspaceName }))
-  await delay(5000)
+
+  await waitForNoSpinnersAfterAction(page, () => click(page, clickable({ textContains: workspaceName })))
   await click(page, navChild('notebooks'))
-  await waitForNoSpinners(page)
   await click(page, clickable({ textContains: 'Create a' }))
   await fillIn(page, input({ placeholder: 'Enter a name' }), notebookName)
   await select(page, 'Language', 'Python 3')
-  await click(page, clickable({ text: 'Create Notebook' }))
-  await click(page, clickable({ textContains: notebookName }))
-  // We are adding a short micro sleep to make sure that the spinner is
-  // rendered by the time we start waiting for the spinner to go away.
-  await delay(500)
-  await waitForNoSpinners(page)
-  await click(page, clickable({ text: 'Edit' }))
-  // There are two separate activities in the UI that could interfere with beginning to interact
-  // with the modal for creating a cloud environment:
-  //   1. AJAX calls to load cloud environment details and available docker images
-  //      - renders a spinner overlay on top of UI elements
-  //   2. The drawer slide-in animation
-  //      - causes UI elements to move before puppeteer clicks on them
-  // Experimentation has shown that there's enough of a gap between clicking 'Edit' and the AJAX
-  // spinner being rendered that simply waiting for no spinners does not work; the test recognizes
-  // that there aren't any spinners before the spinner has a chance to render. Additionally, even
-  // though the slide-in animation is supposedly only 200ms, experimentation has shown that even a
-  // 500ms delay in the test is not enough to guarantee that the UI elements have finished moving.
-  // Therefore, we start with a 2000ms delay, then make sure there are no spinners just in case the
-  // AJAX calls are unexpectedly slow.
-  await delay(2000)
-  waitForNoSpinners(page)
+
+  await waitForNoSpinnersAfterAction(page, () => click(page, clickable({ text: 'Create Notebook' })))
+  await waitForNoSpinnersAfterAction(page, () => click(page, clickable({ textContains: notebookName })))
+  await waitForNoSpinnersAfterAction(page, () => click(page, clickable({ text: 'Edit' })))
+
+  await findElement(page, getAnimatedDrawer('Cloud Environment'))
   await click(page, clickable({ text: 'Create' }))
   await findElement(page, clickable({ textContains: 'Creating' }))
   await findElement(page, clickable({ textContains: 'Running' }), { timeout: 10 * 60 * 1000 })

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -32,7 +32,7 @@ const findInGrid = (page, textContains, options) => {
   return page.waitForXPath(`//*[@role="table"][contains(normalize-space(.),"${textContains}")]`, options)
 }
 
-const getClickablePath = (path, text, textContains, isDescendant=false) => {
+const getClickablePath = (path, text, textContains, isDescendant = false) => {
   const base = `${path}${isDescendant ? '//*' : ''}`
   if (text) {
     return `${base}[normalize-space(.)="${text}" or @title="${text}" or @aria-label="${text}" or @aria-labelledby=//*[normalize-space(.)="${text}"]/@id]`
@@ -41,12 +41,16 @@ const getClickablePath = (path, text, textContains, isDescendant=false) => {
   }
 }
 
-const clickable = ({ text, textContains, isDescendant = false}) => {
+const getAnimatedDrawer = textContains => {
+  return `//*[@role="dialog" and @aria-hidden="false"][contains(normalize-space(.), "${textContains}") or contains(@aria-label,"${textContains}") or @aria-labelledby=//*[contains(normalize-space(.),"${textContains}")]]`
+}
+
+const clickable = ({ text, textContains, isDescendant = false }) => {
   const base = `(//a | //button | //*[@role="button"] | //*[@role="link"] | //*[@role="combobox"] | //*[@role="option"])`
   return getClickablePath(base, text, textContains, isDescendant)
 }
 
-const checkbox = ({ text, textContains, isDescendant = false}) => {
+const checkbox = ({ text, textContains, isDescendant = false }) => {
   const base = `(//input[@type="checkbox"] | //*[@role="checkbox"])`
   return getClickablePath(base, text, textContains, isDescendant)
 }
@@ -116,6 +120,16 @@ const select = async (page, labelContains, text) => {
 }
 
 const waitForNoSpinners = page => {
+  return page.waitForXPath('//*[@data-icon="loadingSpinner"]', { hidden: true })
+}
+
+// waitForNoSpinnersAfterAction
+// This takes advantage of the mutationObserver in puppeteer by initializing the wait before taking an action.
+// This helps us guarantee that we will catch the spinner before it disappears
+const waitForNoSpinnersAfterAction = async (page, action) => {
+  const foundSpinner = page.waitForXPath('//*[@data-icon="loadingSpinner"]')
+  const completeAction = action()
+  await Promise.all([foundSpinner, completeAction])
   return page.waitForXPath('//*[@data-icon="loadingSpinner"]', { hidden: true })
 }
 
@@ -261,13 +275,13 @@ module.exports = {
   fillIn,
   fillInReplace,
   findTableCellText,
+  getAnimatedDrawer,
   getTableCellPath,
   getTableHeaderPath,
   heading,
   input,
   select,
   svgText,
-  waitForNoSpinners,
   delay,
   signIntoTerra,
   navChild,
@@ -276,6 +290,8 @@ module.exports = {
   withScreenshot,
   logPageConsoleMessages,
   logPageAjaxResponses,
+  waitForNoSpinners,
+  waitForNoSpinnersAfterAction,
   withPageLogging,
   openError
 }

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -123,13 +123,13 @@ const waitForNoSpinners = page => {
   return page.waitForXPath('//*[@data-icon="loadingSpinner"]', { hidden: true })
 }
 
-// waitForNoSpinnersAfterAction
-// This takes advantage of the mutationObserver in puppeteer by initializing the wait before taking an action.
-// This helps us guarantee that we will catch the spinner before it disappears
-const waitForNoSpinnersAfterAction = async (page, action) => {
+// Puppeteer works by internally using MutationObserver. We are setting up the listener before
+// the action to ensure that the spinner rendering is captured by the observer, followed by
+// waiting for the spinner to be removed
+const noSpinnersAfter = async (page, { action }) => {
   const foundSpinner = page.waitForXPath('//*[@data-icon="loadingSpinner"]')
   await Promise.all([foundSpinner, action()])
-  return page.waitForXPath('//*[@data-icon="loadingSpinner"]', { hidden: true })
+  return waitForNoSpinners(page)
 }
 
 const delay = ms => {
@@ -289,8 +289,8 @@ module.exports = {
   withScreenshot,
   logPageConsoleMessages,
   logPageAjaxResponses,
+  noSpinnersAfter,
   waitForNoSpinners,
-  waitForNoSpinnersAfterAction,
   withPageLogging,
   openError
 }

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -128,8 +128,7 @@ const waitForNoSpinners = page => {
 // This helps us guarantee that we will catch the spinner before it disappears
 const waitForNoSpinnersAfterAction = async (page, action) => {
   const foundSpinner = page.waitForXPath('//*[@data-icon="loadingSpinner"]')
-  const completeAction = action()
-  await Promise.all([foundSpinner, completeAction])
+  await Promise.all([foundSpinner, action()])
   return page.waitForXPath('//*[@data-icon="loadingSpinner"]', { hidden: true })
 }
 

--- a/src/components/ModalDrawer.js
+++ b/src/components/ModalDrawer.js
@@ -34,7 +34,7 @@ const ModalDrawer = ({ isOpen, onDismiss, width = 450, children, ...props }) => 
     mountOnEnter: true,
     unmountOnExit: true
   }, [transitionState => h(RModal, {
-    aria: { label: props['aria-label'], labelledby: props['aria-labelledby'], modal: true },
+    aria: { label: props['aria-label'], labelledby: props['aria-labelledby'], modal: true, hidden: transitionState !== 'entered' },
     ariaHideApp: false,
     parentSelector: () => document.getElementById('modal-root'),
     isOpen: true,


### PR DESCRIPTION
## Overview
This PR removes the delay's from the `run-notebook` test.
In order to achieve this I did the following:

1. Created a utility that better handle's waiting on busy spinners
2. Added a small improvement to the a11y of the slide in drawer
3. Added a test utility to utilize this a11y improvement to detect when the drawer is open

I ran this test using the flake check, running the test over 100 times. The only issues I saw were related to actual system instability rather than flakiness with puppeteer.

## Results
In the last set of 100 the failures I saw were (all failures I saw on other runs were of these signatures): 

### Error checking TOS - not puppeteer related (2 errors)
1. The error thrown was: ` waiting for XPath `//*[@data-icon="loadingSpinner"]` to be hidden failed: timeout 30000ms exceeded`
    1. I consider this is an accurate description of the error. Along with the screenshot it shows the problem
![76](https://user-images.githubusercontent.com/50371603/152187970-492169de-1627-4682-8774-3a4fd3634961.jpg)

### Error Checking Registration - not puppeteer related (1 error)
1. The error thrown was: ` waiting for XPath `//*[@data-icon="loadingSpinner"]` to be hidden failed: timeout 30000ms exceeded`
    1. Again, I consider this is an accurate description of the error. Along with the screenshot it shows the problem
![21](https://user-images.githubusercontent.com/50371603/152188410-53299d7b-457a-4590-bfe7-71cbd82fd839.jpg)

### Blank page - app didn't load
1. The error thrown was: `Error: Evaluation failed: Response`
    1. I will see if I can improve the logging on this within the flake checker in a future PR
    2. From seeing this before, I believe the workspace was not created, preventing the test from getting off the launchpad
 
![96](https://user-images.githubusercontent.com/50371603/152188912-92137af3-8ab9-41b9-9b0a-2e481b205c8f.jpg)

