### PR TITLE
[BW-1060] Apply "nosniff" to all files.

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -6,6 +6,8 @@ handlers:
   static_files: build/\1
   upload: build/(.*)
   secure: always
+  http_headers:
+    X-Content-Type-Options: "nosniff"
 - url: /.*
   static_files: build/index.html
   upload: build/index.html

--- a/app.yaml
+++ b/app.yaml
@@ -2,12 +2,7 @@ runtime: nodejs16
 default_expiration: "2m"
 
 handlers:
-- url: /(.*\.(ico|jpg|jpeg|png|svg))
-  static_files: build/\1
-  upload: build/(.*)
-  secure: always
-  # IE has had issues with image files and the X-Content-Type-Options header value, so do not add it to those files.
-- url: /(.*\.(css|eot|gz|html|js|json|map|otf|ttf|woff|woff2))
+- url: /(.*\.(css|eot|gz|html|ico|jpg|jpeg|js|json|map|png|svg|otf|ttf|woff|woff2))
   static_files: build/\1
   upload: build/(.*)
   secure: always

--- a/app.yaml
+++ b/app.yaml
@@ -2,7 +2,12 @@ runtime: nodejs16
 default_expiration: "2m"
 
 handlers:
-- url: /(.*\.(css|eot|gz|html|ico|jpg|jpeg|js|json|map|png|svg|otf|ttf|woff|woff2))
+- url: /(.*\.(ico|jpg|jpeg|png|svg))
+  static_files: build/\1
+  upload: build/(.*)
+  secure: always
+  # IE has had issues with image files and the X-Content-Type-Options header value, so do not add it to those files.
+- url: /(.*\.(css|eot|gz|html|js|json|map|otf|ttf|woff|woff2))
   static_files: build/\1
   upload: build/(.*)
   secure: always


### PR DESCRIPTION
Our ZAP scanning flagged this issue, which is required for FedRAMP compliance. 

To test: 

- Use the [PR deployment](https://pr-7-dot-bvdp-saturn-dev.appspot.com/). This cannot be tested running locally.
- While viewing Terra, open Developer tools and select "Disable Cache". Then force a reload of the page (Cmd-Shift-R on Mac).
- View headers for files we serve up (for example, the "chunk" JS and CSS files)

![image](https://user-images.githubusercontent.com/484484/152395035-4cac2ace-7231-49b7-9314-b310e4defb6f.png)
