### PR TITLE
[IA-3077] Context Bar displays refreshed app status upon create/delete

### DIFF
--- a/src/components/ContextBar.js
+++ b/src/components/ContextBar.js
@@ -34,7 +34,10 @@ const contextBarStyles = {
   hover: { backgroundColor: colors.accent(0.4) }
 }
 
-export const ContextBar = ({ setDeletingWorkspace, setCloningWorkspace, setSharingWorkspace, runtimes, apps, appDataDisks, refreshRuntimes, location, locationType, refreshApps, workspace, persistentDisks, workspace: { workspace: { namespace, bucketName, name: workspaceName } } }) => {
+export const ContextBar = ({
+  setDeletingWorkspace, setCloningWorkspace, setSharingWorkspace, runtimes, apps, appDataDisks, refreshRuntimes, location, locationType, refreshApps,
+  workspace, persistentDisks, workspace: { workspace: { namespace, name: workspaceName } }
+}) => {
   const [isCloudEnvOpen, setCloudEnvOpen] = useState(false)
 
   const currentRuntime = getCurrentRuntime(runtimes)
@@ -90,17 +93,14 @@ export const ContextBar = ({ setDeletingWorkspace, setCloningWorkspace, setShari
       onSuccess: async () => {
         setCloudEnvOpen(false)
         await refreshRuntimes(true)
+        await refreshApps()
       },
       onDismiss: async () => {
         setCloudEnvOpen(false)
         await refreshRuntimes(true)
+        await refreshApps()
       },
-      runtimes, apps, appDataDisks, refreshRuntimes, refreshApps,
-      workspace,
-      canCompute,
-      persistentDisks,
-      location,
-      locationType
+      runtimes, apps, appDataDisks, refreshRuntimes, refreshApps, workspace, canCompute, persistentDisks, location, locationType
     }),
     div({ style: Style.elements.contextBarContainer }, [
       div({ style: contextBarStyles.contextBarContainer }, [

--- a/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
+++ b/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
@@ -61,7 +61,7 @@ export const CloudEnvironmentModal = ({
     },
     onSuccess: () => {
       setViewMode(undefined)
-      onDismiss()
+      onSuccess()
     }
   })
 
@@ -77,7 +77,7 @@ export const CloudEnvironmentModal = ({
     },
     onSuccess: () => {
       setViewMode(undefined)
-      onDismiss()
+      onSuccess()
     }
   })
 

--- a/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
+++ b/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
@@ -34,7 +34,7 @@ import * as Utils from 'src/libs/utils'
 const titleId = 'cloud-env-modal'
 
 export const CloudEnvironmentModal = ({
-  isOpen, onDismiss, canCompute, runtimes, apps, appDataDisks, refreshRuntimes, refreshApps,
+  isOpen, onSuccess, onDismiss, canCompute, runtimes, apps, appDataDisks, refreshRuntimes, refreshApps,
   workspace, persistentDisks, location, locationType, workspace: { workspace: { namespace, name: workspaceName } }
 }) => {
   const [viewMode, setViewMode] = useState(undefined)


### PR DESCRIPTION
This PR fixes a bug where upon a user clicking `CREATE` to create an app, Context Bar doesn't refresh app status and as a result it doesn't show up under the cloud icon. The similar behaviour occurs upon deleting an app.

Below is the demo of the buggy (`dev`) behaviour:

https://user-images.githubusercontent.com/5438223/152439754-2704fa47-c6cd-4aaa-8562-70270cce69cc.mov

Below is how the PR'ed version looks:

https://user-images.githubusercontent.com/5438223/152440185-14edd4bd-09f5-4a19-8198-f5dddebed140.mov



