### PR TITLE
[QA-1700] Saving twice results in flakiness related to the Save button enabling after second edit.

### DIFF
--- a/integration-tests/tests/run-workflow-on-snapshot.js
+++ b/integration-tests/tests/run-workflow-on-snapshot.js
@@ -2,7 +2,7 @@ const _ = require('lodash/fp')
 const fetch = require('node-fetch')
 const { launchWorkflowAndWaitForSuccess } = require('./run-workflow')
 const { withWorkspace } = require('../utils/integration-helpers')
-const { click, clickable, delay, dismissNotifications, fillInReplace, findElement, findText, input, select, signIntoTerra, waitForNoSpinners, navChild } = require('../utils/integration-utils')
+const { click, clickable, dismissNotifications, enabledClickable, fillInReplace, findElement, findText, input, select, signIntoTerra, waitForNoSpinners, navChild } = require('../utils/integration-utils')
 const { withUserToken } = require('../utils/terra-sa-utils')
 
 
@@ -58,9 +58,8 @@ const testRunWorkflowOnSnapshotFn = _.flow(
   await fillInReplace(page, input({ labelContains: 'echo_to_file out attribute' }), 'workspace.result')
 
   await click(page, clickable({ text: 'Save' }))
-
-  // TODO: change this to wait for the button to become enabled.
-  await delay(5000) // The Run Analysis button (launchWorkflowAndWaitForSuccess) requires time to become enabled after hitting the save button
+  // Wait for "Run Analysis" to become enabled.
+  await page.waitForXPath(enabledClickable({ text: 'Run analysis' }))
 
   await launchWorkflowAndWaitForSuccess(page)
 

--- a/integration-tests/tests/run-workflow-on-snapshot.js
+++ b/integration-tests/tests/run-workflow-on-snapshot.js
@@ -53,12 +53,10 @@ const testRunWorkflowOnSnapshotFn = _.flow(
 
   await click(page, clickable({ textContains: 'Inputs' }))
   await fillInReplace(page, input({ labelContains: 'echo_to_file input1 attribute' }), `this.${snapshotColumnName}`)
-  await delay(1000) // Without this delay, the input field sometimes reverts back to its default value
-  await click(page, clickable({ text: 'Save' }))
 
   await click(page, clickable({ textContains: 'Outputs' }))
   await fillInReplace(page, input({ labelContains: 'echo_to_file out attribute' }), 'workspace.result')
-  await delay(1000) // Without this delay, the input field sometimes reverts back to its default value
+
   await click(page, clickable({ text: 'Save' }))
 
   await delay(1000) // The Run Analysis button (launchWorkflowAndWaitForSuccess) requires time to become enabled after hitting the save button

--- a/integration-tests/tests/run-workflow-on-snapshot.js
+++ b/integration-tests/tests/run-workflow-on-snapshot.js
@@ -59,7 +59,8 @@ const testRunWorkflowOnSnapshotFn = _.flow(
 
   await click(page, clickable({ text: 'Save' }))
 
-  await delay(1000) // The Run Analysis button (launchWorkflowAndWaitForSuccess) requires time to become enabled after hitting the save button
+  // TODO: change this to wait for the button to become enabled.
+  await delay(5000) // The Run Analysis button (launchWorkflowAndWaitForSuccess) requires time to become enabled after hitting the save button
 
   await launchWorkflowAndWaitForSuccess(page)
 

--- a/integration-tests/tests/run-workflow-on-snapshot.js
+++ b/integration-tests/tests/run-workflow-on-snapshot.js
@@ -32,6 +32,7 @@ const testRunWorkflowOnSnapshotFn = _.flow(
   await page.goto(`${testUrl}/#import-data?url=${dataRepoUrlRoot}&snapshotId=${snapshotId}&snapshotName=${snapshotName}&format=snapshot`)
   await signIntoTerra(page, token)
   await dismissNotifications(page)
+  await waitForNoSpinners(page)
   await click(page, clickable({ textContains: 'Start with an existing workspace' }))
   await select(page, 'Select a workspace', workspaceName)
   await click(page, clickable({ text: 'Import' }))

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -50,6 +50,11 @@ const clickable = ({ text, textContains, isDescendant = false }) => {
   return getClickablePath(base, text, textContains, isDescendant)
 }
 
+const enabledClickable = ({ text, textContains, isDescendant = false }) => {
+  const base = `(//a[@aria-disabled="false"] | //button[@aria-disabled="false"] | //*[@role="button" and @aria-disabled="false"] | //*[@role="link" and @aria-disabled="false"] | //*[@role="combobox" and @aria-disabled="false"] | //*[@role="option" and @aria-disabled="false"])`
+  return getClickablePath(base, text, textContains, isDescendant)
+}
+
 const checkbox = ({ text, textContains, isDescendant = false }) => {
   const base = `(//input[@type="checkbox"] | //*[@role="checkbox"])`
   return getClickablePath(base, text, textContains, isDescendant)
@@ -265,6 +270,7 @@ module.exports = {
   click,
   clickable,
   clickTableCell,
+  enabledClickable,
   dismissNotifications,
   findIframe,
   findInGrid,


### PR DESCRIPTION
This does not address all causes of failure for this test, but it does address the most commonly seen one (Save button not being present after second edit operation). I would like this to be merged while the other issues continue to be investigated.

In 200 runs locally (with the portion of the test after the Save disabled), the "Save" button never caused a failure with this change.

I do periodically see this failure (especially when running locally), so it will need future investigation:

TimeoutError: waiting for XPath `(//input | //textarea)[contains(@aria-label,"Select a workspace") or @id=//label[contains(normalize-space(.),"Select a workspace")]/@for or @aria-labelledby=//*[contains(normalize-space(.),"Select a workspace")]/@id]` failed: timeout 30000ms exceeded
