### PR TITLE
[DC-207][QA-1706] Fix link-to-new-workspace test

### DIFF
--- a/integration-tests/tests/link-to-new-workspace.js
+++ b/integration-tests/tests/link-to-new-workspace.js
@@ -1,5 +1,5 @@
 const { checkbox, click, clickable, clickTableCell, fillIn, waitForNoSpinners } = require('../utils/integration-utils')
-const { enableDataCatalog, testWorkspaceName } = require('../utils/integration-helpers')
+const { checkBucketAccess, enableDataCatalog, testWorkspaceName } = require('../utils/integration-helpers')
 const { withUserToken } = require('../utils/terra-sa-utils')
 
 
@@ -21,6 +21,8 @@ const testLinkToNewWorkspaceFn = withUserToken(async ({ testUrl, page, token }) 
     await click(page, clickable({ text: `${newWorkspaceBillingAccount}` }))
     await click(page, clickable({ text: 'Create Workspace' }))
     await waitForNoSpinners(page)
+    // Wait for bucket access to avoid sporadic failures
+    await checkBucketAccess(page, newWorkspaceBillingAccount, newWorkspaceName)
     await page.url().includes(newWorkspaceName)
   } finally {
     await page.evaluate((name, billingProject) => {

--- a/integration-tests/tests/link-to-new-workspace.js
+++ b/integration-tests/tests/link-to-new-workspace.js
@@ -1,4 +1,4 @@
-const { checkbox, click, clickable, clickTableCell, fillIn, waitForNoSpinners } = require('../utils/integration-utils')
+const { checkbox, click, clickable, clickTableCell, fillIn, noSpinnersAfter, waitForNoSpinners } = require('../utils/integration-utils')
 const { checkBucketAccess, enableDataCatalog, testWorkspaceName } = require('../utils/integration-helpers')
 const { withUserToken } = require('../utils/terra-sa-utils')
 
@@ -19,8 +19,7 @@ const testLinkToNewWorkspaceFn = withUserToken(async ({ testUrl, page, token }) 
     await fillIn(page, '//*[@placeholder="Enter a name"]', `${newWorkspaceName}`)
     await click(page, clickable({ text: 'Select a billing project' }))
     await click(page, clickable({ text: `${newWorkspaceBillingAccount}` }))
-    await click(page, clickable({ text: 'Create Workspace' }))
-    await waitForNoSpinners(page)
+    await noSpinnersAfter(page, { action: () => click(page, clickable({ textContains: 'Link to a workspace' })) })
     // Wait for bucket access to avoid sporadic failures
     await checkBucketAccess(page, newWorkspaceBillingAccount, newWorkspaceName)
     await page.url().includes(newWorkspaceName)

--- a/integration-tests/tests/link-to-new-workspace.js
+++ b/integration-tests/tests/link-to-new-workspace.js
@@ -9,8 +9,7 @@ const testLinkToNewWorkspaceFn = withUserToken(async ({ testUrl, page, token }) 
 
   await click(page, checkbox({ text: 'Granted', isDescendant: true }))
   await clickTableCell(page, 'dataset list', 2, 2)
-  await click(page, clickable({ textContains: 'Link to a workspace' }))
-  await waitForNoSpinners(page)
+  await noSpinnersAfter(page, { action: () => click(page, clickable({ textContains: 'Link to a workspace' })) })
 
   const newWorkspaceName = testWorkspaceName()
   const newWorkspaceBillingAccount = 'general-dev-billing-account'
@@ -18,7 +17,7 @@ const testLinkToNewWorkspaceFn = withUserToken(async ({ testUrl, page, token }) 
   await fillIn(page, '//*[@placeholder="Enter a name"]', `${newWorkspaceName}`)
   await click(page, clickable({ text: 'Select a billing project' }))
   await click(page, clickable({ text: `${newWorkspaceBillingAccount}` }))
-  await noSpinnersAfter(page, { action: () => click(page, clickable({ textContains: 'Link to a workspace' })) })
+  await noSpinnersAfter(page, { action: () => click(page, clickable({ textContains: 'Create Workspace' })) })
   try {
     // Wait for bucket access to avoid sporadic failures
     await checkBucketAccess(page, newWorkspaceBillingAccount, newWorkspaceName)


### PR DESCRIPTION
This test has failed a few times due to a 403 during workspace creation:
```
page.http.res 403 GET https://storage.googleapis.com/storage/v1/b/fc-9e71db22-ed13-4bdc-82fe-81df090de356?fields=location%2ClocationType
 FAIL  jest/link-to-new-workspace.integration-test.js (44.787 s)
  ● link-to-new-workspace
```

I was not able to reproduce the failure locally, but waiting for the bucket access to propagate might fix the issue (this is what the [run-workflow](https://github.com/DataBiosphere/terra-ui/blob/dev/integration-tests/tests/run-workflow.js#L21) test does)