### PR TITLE
Fix for issue with id not matching the actual variable name (BW-1078).

### DIFF
--- a/src/components/job-common.js
+++ b/src/components/job-common.js
@@ -15,27 +15,27 @@ export const addCountSuffix = (label, count = undefined) => {
 
 export const statusType = {
   succeeded: {
-    id: 'succeeded',
+    id: 'succeeded', // Must match variable name for collection unpacking.
     label: () => 'Succeeded',
     icon: style => icon('check', { size: iconSize, style: { color: colors.success(), ...style } })
   },
   failed: {
-    id: 'failed',
+    id: 'failed', // Must match variable name for collection unpacking.
     label: () => 'Failed',
     icon: style => icon('warning-standard', { size: iconSize, style: { color: colors.danger(), ...style } })
   },
   running: {
-    id: 'running',
+    id: 'running', // Must match variable name for collection unpacking.
     label: () => 'Running',
     icon: style => icon('sync', { size: iconSize, style: { color: colors.dark(), ...style } })
   },
   submitted: {
-    id: 'submitted',
+    id: 'submitted', // Must match variable name for collection unpacking.
     label: () => 'Submitted',
     icon: style => icon('clock', { size: iconSize, style: { color: colors.dark(), ...style } })
   },
   waitingForQuota: {
-    id: 'waitingForQuota',
+    id: 'waitingForQuota', // Must match variable name for collection unpacking.
     label: () => 'Submitted, Awaiting Cloud Quota',
     icon: style => icon('error-standard', { size: iconSize, style: { color: colors.warning(), ...style } }),
     moreInfoLink: 'https://support.terra.bio/hc/en-us/articles/360029071251',
@@ -43,7 +43,7 @@ export const statusType = {
     tooltip: 'Delayed by Google Cloud Platform (GCP) quota limits. Contact Terra Support to request a quota increase.'
   },
   unknown: {
-    id: 'unknown',
+    id: 'unknown', // Must match variable name for collection unpacking.
     label: executionStatus => `Unexpected status (${executionStatus})`,
     icon: style => icon('question', { size: iconSize, style: { color: colors.dark(), ...style } })
   }

--- a/src/components/job-common.js
+++ b/src/components/job-common.js
@@ -34,7 +34,7 @@ export const statusType = {
     label: () => 'Submitted',
     icon: style => icon('clock', { size: iconSize, style: { color: colors.dark(), ...style } })
   },
-  waitingForCloudQuota: {
+  waitingForQuota: {
     id: 'waitingForQuota',
     label: () => 'Submitted, Awaiting Cloud Quota',
     icon: style => icon('error-standard', { size: iconSize, style: { color: colors.warning(), ...style } }),
@@ -76,7 +76,7 @@ export const collapseStatus = rawStatus => {
  *
  * @param {string} executionStatus from metadata
  * @param {string} backendStatus from metadata
- * @returns {Object} one of `statusType.succeeded`, `statusType.failed`, `statusType.running`, `statusType.waitingForCloudQuota`, or `statusType.unknown`
+ * @returns {Object} one of `statusType.succeeded`, `statusType.failed`, `statusType.running`, `statusType.waitingForQuota`, or `statusType.unknown`
  */
 export const collapseCromwellStatus = (executionStatus, backendStatus) => {
   switch (executionStatus) {
@@ -87,7 +87,7 @@ export const collapseCromwellStatus = (executionStatus, backendStatus) => {
     case 'Failed':
       return statusType.failed
     case 'Running':
-      return backendStatus === 'AwaitingCloudQuota' ? statusType.waitingForCloudQuota : statusType.running
+      return backendStatus === 'AwaitingCloudQuota' ? statusType.waitingForQuota : statusType.running
     default:
       return statusType.unknown
   }

--- a/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
+++ b/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
@@ -160,7 +160,7 @@ const SubmissionDetails = _.flow(
       div({ style: { display: 'grid', gridTemplateColumns: '1fr 4fr' } }, [
         div({ style: { display: 'grid', gridTemplateRows: '1fr auto' } }, [
           makeSection('Workflow Statuses',
-            [statusType.succeeded.id, statusType.failed.id, statusType.running.id, statusType.submitted.id].filter(s => statusGroups[s]).map(
+            ['succeeded', 'failed', 'running', 'submitted'].filter(s => statusGroups[s]).map(
               s => makeStatusLine(statusType[s].icon, addCountSuffix(statusType[s].label(), statusGroups[s].length), { marginTop: '0.5rem' })
             )),
           div({

--- a/src/pages/workspaces/workspace/jobHistory/WorkflowDashboard.js
+++ b/src/pages/workspaces/workspace/jobHistory/WorkflowDashboard.js
@@ -50,7 +50,7 @@ const statusCell = ({ calls }) => {
     ])
   }
   return h(Fragment, _.concat(
-    [statusType.submitted.id, statusType.waitingForCloudQuota.id, statusType.running.id, statusType.succeeded.id, statusType.failed.id].filter(
+    ['submitted', 'waitingForQuota', 'running', 'succeeded', 'failed'].filter(
       s => statusGroups[s]).map(s => makeRow(statusGroups[s], statusType[s])),
     _.map(([label, count]) => makeRow(count, statusType.unknown, label), _.toPairs(unknownStatuses)))
   )


### PR DESCRIPTION
In [this code review commit](https://github.com/DataBiosphere/terra-ui/pull/2794/commits/9e63392c1b41f11f7abd2c5b12659dc9b337073f) I collapsed some code that was explicitly listing every possible status type with indexing into statusTypes. Somewhat unfortunately, this means that the `id` value of statusType must now match its variable name. There was only one statusType where this was not the case, and of course that was the one that I didn't test after I made the code change….

I really don't love the fact that the `id` has to match the variable name, but I did love the code that I deleted in the cleanup commit. So I am inclined to fix this bug by changing the one variable name (and adding comments to hopefully avoid introducing this bug in the future). However, I could be talked into restoring the previous code (as long as I can do it in time to get in tomorrow's terra-ui release, when this bug becomes customer-visible).

Screenshot showing the problematic status:
![image](https://user-images.githubusercontent.com/484484/152875120-710ad411-047f-4e85-a881-ed63cc6d27d6.png)
