### PR TITLE
[WOR-103] Change HHS Responsible Disclosure link.

### DIFF
--- a/src/components/FooterWrapper.js
+++ b/src/components/FooterWrapper.js
@@ -57,7 +57,7 @@ const FooterWrapper = ({ children, alwaysShow, fixedHeight }) => {
     a({ href: 'https://www.usa.gov/', ...Utils.newTabLinkProps }, 'USA.gov'),
     a({ href: 'https://www.nhlbi.nih.gov/', ...Utils.newTabLinkProps },
       'National Heart, Lung, and Blood Institute'),
-    a({ href: 'https://hhs.responsibledisclosure.com/hc/en-us', ...Utils.newTabLinkProps }, 'HHS Responsible Disclosure')
+    a({ href: 'https://www.hhs.gov/vulnerability-disclosure-policy/index.html', ...Utils.newTabLinkProps }, 'HHS Vulnerability Disclosure')
   ])
 
   const standardFooterContent = h(Fragment, [


### PR DESCRIPTION
I used this feature flag to view the page: `configOverridesStore.set({ isBioDataCatalyst: true })`

This is a follow-up PR to https://github.com/DataBiosphere/terra-ui/pull/2788

After:
![image](https://user-images.githubusercontent.com/484484/153083526-7b675242-a5a1-4904-9d76-7c1ee84acc2d.png)
