### PR TITLE
[DC-208] Fix run-catalog-workflow test

### DIFF
--- a/integration-tests/tests/link-to-new-workspace.js
+++ b/integration-tests/tests/link-to-new-workspace.js
@@ -1,16 +1,11 @@
-const { checkbox, click, clickable, clickTableCell, fillIn, findText, noSpinnersAfter, select, waitForNoSpinners } = require('../utils/integration-utils')
-const { checkBucketAccess, enableDataCatalog, testWorkspaceName } = require('../utils/integration-helpers')
+const { click, clickable, fillIn, findText, noSpinnersAfter, select } = require('../utils/integration-utils')
+const { checkBucketAccess, enableDataCatalog, goToLinkWorkspacePage, testWorkspaceName } = require('../utils/integration-helpers')
 const { withUserToken } = require('../utils/terra-sa-utils')
 
 
 const testLinkToNewWorkspaceFn = withUserToken(async ({ testUrl, page, token }) => {
   await enableDataCatalog(page, testUrl, token)
-  await click(page, clickable({ textContains: 'browse & explore' }))
-
-  await click(page, checkbox({ text: 'Granted', isDescendant: true }))
-  await clickTableCell(page, 'dataset list', 2, 2)
-  await noSpinnersAfter(page, { action: () => click(page, clickable({ textContains: 'Link to a workspace' })) })
-
+  await goToLinkWorkspacePage(page)
   const newWorkspaceName = testWorkspaceName()
   const newWorkspaceBillingAccount = 'general-dev-billing-account'
   await click(page, clickable({ textContains: 'Start with a new workspace' }))
@@ -21,6 +16,7 @@ const testLinkToNewWorkspaceFn = withUserToken(async ({ testUrl, page, token }) 
     // Wait for bucket access to avoid sporadic failures
     await checkBucketAccess(page, newWorkspaceBillingAccount, newWorkspaceName)
     await findText(page, `${newWorkspaceBillingAccount}/${newWorkspaceName}`)
+    await findText(page, 'Select a data type')
   } finally {
     try {
       await page.evaluate((name, billingProject) => {

--- a/integration-tests/tests/link-to-new-workspace.js
+++ b/integration-tests/tests/link-to-new-workspace.js
@@ -1,11 +1,11 @@
 const { click, clickable, fillIn, findText, noSpinnersAfter, select } = require('../utils/integration-utils')
-const { checkBucketAccess, enableDataCatalog, goToLinkWorkspacePage, testWorkspaceName } = require('../utils/integration-helpers')
+const { checkBucketAccess, testWorkspaceName } = require('../utils/integration-helpers')
 const { withUserToken } = require('../utils/terra-sa-utils')
+const { linkDataToWorkspace } = require('./run-catalog-workflow')
 
 
-const testLinkToNewWorkspaceFn = withUserToken(async ({ testUrl, page, token }) => {
-  await enableDataCatalog(page, testUrl, token)
-  await goToLinkWorkspacePage(page)
+const testLinkToNewWorkspaceFn = withUserToken(async ({ page, testUrl, token }) => {
+  await linkDataToWorkspace(page, testUrl, token)
   const newWorkspaceName = testWorkspaceName()
   const newWorkspaceBillingAccount = 'general-dev-billing-account'
   await click(page, clickable({ textContains: 'Start with a new workspace' }))

--- a/integration-tests/tests/link-to-new-workspace.js
+++ b/integration-tests/tests/link-to-new-workspace.js
@@ -1,20 +1,9 @@
+const { linkDataToWorkspace, eitherThrow } = require('../utils/catalog-utils')
 const { click, clickable, fillIn, findText, noSpinnersAfter, select } = require('../utils/integration-utils')
 const { checkBucketAccess, testWorkspaceName } = require('../utils/integration-helpers')
 const { withUserToken } = require('../utils/terra-sa-utils')
-const { linkDataToWorkspace } = require('./run-catalog-workflow')
 
 
-// Helper
-const eitherThrow = (testFailure, { cleanupFailure, cleanupMessage }) => {
-  if (testFailure) {
-    cleanupFailure && console.error(`${cleanupMessage}: ${cleanupFailure.message}`)
-    throw testFailure
-  } else if (cleanupFailure) {
-    throw new Error(`${cleanupMessage}: ${cleanupFailure.message}`)
-  }
-}
-
-// Test
 const testLinkToNewWorkspaceFn = withUserToken(async ({ page, testUrl, token }) => {
   await linkDataToWorkspace(page, testUrl, token)
   const newWorkspaceName = testWorkspaceName()

--- a/integration-tests/tests/run-catalog-workflow.js
+++ b/integration-tests/tests/run-catalog-workflow.js
@@ -1,32 +1,27 @@
 const _ = require('lodash/fp')
-const { checkbox, click, clickable, clickTableCell, input, waitForNoSpinners } = require('../utils/integration-utils')
-const { enableDataCatalog, withWorkspace } = require('../utils/integration-helpers')
+const { checkbox, click, clickable, clickTableCell, input, noSpinnersAfter, waitForNoSpinners } = require('../utils/integration-utils')
+const { checkBucketAccess, enableDataCatalog, withWorkspace } = require('../utils/integration-helpers')
 const { withUserToken } = require('../utils/terra-sa-utils')
 
 
 const testCatalogFlowFn = _.flow(
   withWorkspace,
   withUserToken
-)(async ({ page, testUrl, token, workspaceName }) => {
+)(async ({ page, testUrl, token, workspaceName, billingProject }) => {
   await enableDataCatalog(page, testUrl, token)
   await click(page, clickable({ textContains: 'browse & explore' }))
-  await waitForNoSpinners(page)
 
   await click(page, checkbox({ text: 'Granted', isDescendant: true }))
   await clickTableCell(page, 'dataset list', 2, 2)
-  await waitForNoSpinners(page)
-  await click(page, clickable({ textContains: 'Link to a workspace' }))
-  await waitForNoSpinners(page)
+  await noSpinnersAfter(page, { action: () => click(page, clickable({ textContains: 'Link to a workspace' })) })
 
   await click(page, clickable({ textContains: 'Start with an existing workspace' }))
   await click(page, input({ labelContains: 'Select a workspace' }))
   await click(page, `//*[@role="combobox"][contains(normalize-space(.), "${workspaceName}")]`)
-  // The click call above is not actually selecting the workspace, so the Import button actually never becomes enabled.
-  // The "page.url().includes(workspaceName)" call returns false, but that doesn't actually fail the test.
-  // Instead of trying to check the URL, the test should check that the correct page loaded by looking for an expected element on the page.
-  // await click(page, clickable({ textContains: 'Import' }))
-  // await waitForNoSpinners(page)
-  // await page.url().includes(workspaceName)
+  await click(page, clickable({ textContains: 'Import' }))
+  await waitForNoSpinners(page)
+  await checkBucketAccess(page, billingProject, workspaceName)
+  await page.url().includes(workspaceName)
 })
 
 const testCatalog = {

--- a/integration-tests/tests/run-catalog-workflow.js
+++ b/integration-tests/tests/run-catalog-workflow.js
@@ -1,24 +1,20 @@
 const _ = require('lodash/fp')
-const { checkbox, click, clickable, clickTableCell, findText, noSpinnersAfter, select } = require('../utils/integration-utils')
-const { enableDataCatalog, withWorkspace } = require('../utils/integration-helpers')
+const { click, clickable, findText, noSpinnersAfter, select } = require('../utils/integration-utils')
+const { enableDataCatalog, goToLinkWorkspacePage, withWorkspace } = require('../utils/integration-helpers')
 const { withUserToken } = require('../utils/terra-sa-utils')
 
 
 const testCatalogFlowFn = _.flow(
   withWorkspace,
   withUserToken
-)(async ({ page, testUrl, token, workspaceName }) => {
+)(async ({ page, testUrl, token, workspaceName, billingProject }) => {
   await enableDataCatalog(page, testUrl, token)
-  await click(page, clickable({ textContains: 'browse & explore' }))
-
-  await click(page, checkbox({ text: 'Granted', isDescendant: true }))
-  await clickTableCell(page, 'dataset list', 2, 2)
-  await noSpinnersAfter(page, { action: () => click(page, clickable({ textContains: 'Link to a workspace' })) })
-
+  await goToLinkWorkspacePage(page)
   await click(page, clickable({ textContains: 'Start with an existing workspace' }))
   await select(page, 'Select a workspace', `${workspaceName}`)
   await noSpinnersAfter(page, { action: () => click(page, clickable({ text: 'Import' })) })
-  await findText(page, workspaceName)
+  await findText(page, `${billingProject}/${workspaceName}`)
+  await findText(page, 'Select a data type')
 })
 
 const testCatalog = {

--- a/integration-tests/tests/run-catalog-workflow.js
+++ b/integration-tests/tests/run-catalog-workflow.js
@@ -1,13 +1,13 @@
 const _ = require('lodash/fp')
-const { checkbox, click, clickable, clickTableCell, input, noSpinnersAfter, waitForNoSpinners } = require('../utils/integration-utils')
-const { checkBucketAccess, enableDataCatalog, withWorkspace } = require('../utils/integration-helpers')
+const { checkbox, click, clickable, clickTableCell, findText, noSpinnersAfter, select } = require('../utils/integration-utils')
+const { enableDataCatalog, withWorkspace } = require('../utils/integration-helpers')
 const { withUserToken } = require('../utils/terra-sa-utils')
 
 
 const testCatalogFlowFn = _.flow(
   withWorkspace,
   withUserToken
-)(async ({ page, testUrl, token, workspaceName, billingProject }) => {
+)(async ({ page, testUrl, token, workspaceName }) => {
   await enableDataCatalog(page, testUrl, token)
   await click(page, clickable({ textContains: 'browse & explore' }))
 
@@ -16,12 +16,9 @@ const testCatalogFlowFn = _.flow(
   await noSpinnersAfter(page, { action: () => click(page, clickable({ textContains: 'Link to a workspace' })) })
 
   await click(page, clickable({ textContains: 'Start with an existing workspace' }))
-  await click(page, input({ labelContains: 'Select a workspace' }))
-  await click(page, `//*[@role="combobox"][contains(normalize-space(.), "${workspaceName}")]`)
-  await click(page, clickable({ textContains: 'Import' }))
-  await waitForNoSpinners(page)
-  await checkBucketAccess(page, billingProject, workspaceName)
-  await page.url().includes(workspaceName)
+  await select(page, 'Select a workspace', `${workspaceName}`)
+  await noSpinnersAfter(page, { action: () => click(page, clickable({ text: 'Import' })) })
+  await findText(page, workspaceName)
 })
 
 const testCatalog = {

--- a/integration-tests/tests/run-catalog-workflow.js
+++ b/integration-tests/tests/run-catalog-workflow.js
@@ -1,15 +1,22 @@
 const _ = require('lodash/fp')
-const { click, clickable, findText, noSpinnersAfter, select } = require('../utils/integration-utils')
-const { enableDataCatalog, goToLinkWorkspacePage, withWorkspace } = require('../utils/integration-helpers')
+const { checkbox, click, clickable, clickTableCell, findText, noSpinnersAfter, select } = require('../utils/integration-utils')
+const { enableDataCatalog, withWorkspace } = require('../utils/integration-helpers')
 const { withUserToken } = require('../utils/terra-sa-utils')
 
+
+const linkDataToWorkspace = async (page, testUrl, token) => {
+  await enableDataCatalog(page, testUrl, token)
+  await click(page, clickable({ textContains: 'browse & explore' }))
+  await click(page, checkbox({ text: 'Granted', isDescendant: true }))
+  await clickTableCell(page, 'dataset list', 2, 2)
+  await noSpinnersAfter(page, { action: () => click(page, clickable({ textContains: 'Link to a workspace' })) })
+}
 
 const testCatalogFlowFn = _.flow(
   withWorkspace,
   withUserToken
-)(async ({ page, testUrl, token, workspaceName, billingProject }) => {
-  await enableDataCatalog(page, testUrl, token)
-  await goToLinkWorkspacePage(page)
+)(async ({ billingProject, page, testUrl, token, workspaceName }) => {
+  await linkDataToWorkspace(page, testUrl, token)
   await click(page, clickable({ textContains: 'Start with an existing workspace' }))
   await select(page, 'Select a workspace', `${workspaceName}`)
   await noSpinnersAfter(page, { action: () => click(page, clickable({ text: 'Import' })) })
@@ -24,4 +31,7 @@ const testCatalog = {
   targetEnvironments: ['local', 'dev']
 }
 
-module.exports = { testCatalog }
+module.exports = {
+  linkDataToWorkspace,
+  testCatalog
+}

--- a/integration-tests/tests/run-catalog-workflow.js
+++ b/integration-tests/tests/run-catalog-workflow.js
@@ -1,16 +1,9 @@
 const _ = require('lodash/fp')
-const { checkbox, click, clickable, clickTableCell, findText, noSpinnersAfter, select } = require('../utils/integration-utils')
-const { enableDataCatalog, withWorkspace } = require('../utils/integration-helpers')
+const { linkDataToWorkspace } = require('../utils/catalog-utils')
+const { click, clickable, findText, noSpinnersAfter, select } = require('../utils/integration-utils')
+const { withWorkspace } = require('../utils/integration-helpers')
 const { withUserToken } = require('../utils/terra-sa-utils')
 
-
-const linkDataToWorkspace = async (page, testUrl, token) => {
-  await enableDataCatalog(page, testUrl, token)
-  await click(page, clickable({ textContains: 'browse & explore' }))
-  await click(page, checkbox({ text: 'Granted', isDescendant: true }))
-  await clickTableCell(page, 'dataset list', 2, 2)
-  await noSpinnersAfter(page, { action: () => click(page, clickable({ textContains: 'Link to a workspace' })) })
-}
 
 const testCatalogFlowFn = _.flow(
   withWorkspace,

--- a/integration-tests/tests/run-catalog-workflow.js
+++ b/integration-tests/tests/run-catalog-workflow.js
@@ -25,6 +25,5 @@ const testCatalog = {
 }
 
 module.exports = {
-  linkDataToWorkspace,
   testCatalog
 }

--- a/integration-tests/utils/catalog-utils.js
+++ b/integration-tests/utils/catalog-utils.js
@@ -1,0 +1,21 @@
+const { enableDataCatalog } = require('../utils/integration-helpers')
+const { click, clickable, checkbox, clickTableCell, noSpinnersAfter } = require('../utils/integration-utils')
+
+const eitherThrow = (testFailure, { cleanupFailure, cleanupMessage }) => {
+  if (testFailure) {
+    cleanupFailure && console.error(`${cleanupMessage}: ${cleanupFailure.message}`)
+    throw testFailure
+  } else if (cleanupFailure) {
+    throw new Error(`${cleanupMessage}: ${cleanupFailure.message}`)
+  }
+}
+
+const linkDataToWorkspace = async (page, testUrl, token) => {
+  await enableDataCatalog(page, testUrl, token)
+  await click(page, clickable({ textContains: 'browse & explore' }))
+  await click(page, checkbox({ text: 'Granted', isDescendant: true }))
+  await clickTableCell(page, 'dataset list', 2, 2)
+  await noSpinnersAfter(page, { action: () => click(page, clickable({ textContains: 'Link to a workspace' })) })
+}
+
+module.exports = { eitherThrow, linkDataToWorkspace }

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -37,11 +37,15 @@ const makeWorkspace = withSignedInPage(async ({ page, billingProject }) => {
 
 
 const deleteWorkspace = withSignedInPage(async ({ page, billingProject, workspaceName }) => {
-  await page.evaluate((name, billingProject) => {
-    return window.Ajax().Workspaces.workspace(billingProject, name).delete()
-  }, workspaceName, billingProject)
+  try {
+    await page.evaluate((name, billingProject) => {
+      return window.Ajax().Workspaces.workspace(billingProject, name).delete()
+    }, workspaceName, billingProject)
 
-  rawConsole.info(`deleted workspace: ${workspaceName}`)
+    rawConsole.info(`deleted workspace: ${workspaceName}`)
+  } catch (e) {
+    console.error(`Failed to delete workspace: ${workspaceName}. Error: ${e.message}`)
+  }
 })
 
 const withWorkspace = test => async options => {

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -1,7 +1,7 @@
 const rawConsole = require('console')
 const _ = require('lodash/fp')
 
-const { checkbox, click, clickable, clickTableCell, dismissNotifications, findText, noSpinnersAfter, signIntoTerra, waitForNoSpinners } = require('./integration-utils')
+const { click, clickable, dismissNotifications, findText, signIntoTerra, waitForNoSpinners } = require('./integration-utils')
 const { fetchLyle } = require('./lyle-utils')
 const { withUserToken } = require('../utils/terra-sa-utils')
 
@@ -192,19 +192,11 @@ const enableDataCatalog = async (page, testUrl, token) => {
   await dismissNotifications(page)
 }
 
-const goToLinkWorkspacePage = async (page) => {
-  await click(page, clickable({ textContains: 'browse & explore' }))
-  await click(page, checkbox({ text: 'Granted', isDescendant: true }))
-  await clickTableCell(page, 'dataset list', 2, 2)
-  await noSpinnersAfter(page, { action: () => click(page, clickable({ textContains: 'Link to a workspace' })) })
-}
-
 module.exports = {
   checkBucketAccess,
   createEntityInWorkspace,
   defaultTimeout,
   enableDataCatalog,
-  goToLinkWorkspacePage,
   testWorkspaceName: getTestWorkspaceName,
   withWorkspace,
   withBilling,

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -1,7 +1,7 @@
 const rawConsole = require('console')
 const _ = require('lodash/fp')
 
-const { click, clickable, dismissNotifications, findText, signIntoTerra, waitForNoSpinners } = require('./integration-utils')
+const { checkbox, click, clickable, clickTableCell, dismissNotifications, findText, noSpinnersAfter, signIntoTerra, waitForNoSpinners } = require('./integration-utils')
 const { fetchLyle } = require('./lyle-utils')
 const { withUserToken } = require('../utils/terra-sa-utils')
 
@@ -31,9 +31,9 @@ const makeWorkspace = withSignedInPage(async ({ page, billingProject }) => {
       return window.Ajax().Workspaces.create({ namespace: billingProject, name, attributes: {} })
     }, workspaceName, billingProject)
 
-    rawConsole.info(`created workspace: ${workspaceName}`)
+    rawConsole.info(`Created workspace: ${workspaceName}`)
   } catch (e) {
-    throw Error(`Failed to create workspace: ${workspaceName}`)
+    throw Error(`Failed to create workspace: ${workspaceName} with billing project ${billingProject}`)
   }
   return workspaceName
 })
@@ -45,9 +45,9 @@ const deleteWorkspace = withSignedInPage(async ({ page, billingProject, workspac
       return window.Ajax().Workspaces.workspace(billingProject, name).delete()
     }, workspaceName, billingProject)
 
-    rawConsole.info(`deleted workspace: ${workspaceName}`)
+    rawConsole.info(`Deleted workspace: ${workspaceName}`)
   } catch (e) {
-    throw Error(`Failed to delete workspace: ${workspaceName}`)
+    throw Error(`Failed to delete workspace: ${workspaceName} with billing project ${billingProject}`)
   }
 })
 
@@ -192,11 +192,19 @@ const enableDataCatalog = async (page, testUrl, token) => {
   await dismissNotifications(page)
 }
 
+const goToLinkWorkspacePage = async (page) => {
+  await click(page, clickable({ textContains: 'browse & explore' }))
+  await click(page, checkbox({ text: 'Granted', isDescendant: true }))
+  await clickTableCell(page, 'dataset list', 2, 2)
+  await noSpinnersAfter(page, { action: () => click(page, clickable({ textContains: 'Link to a workspace' })) })
+}
+
 module.exports = {
   checkBucketAccess,
   createEntityInWorkspace,
   defaultTimeout,
   enableDataCatalog,
+  goToLinkWorkspacePage,
   testWorkspaceName: getTestWorkspaceName,
   withWorkspace,
   withBilling,

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -26,12 +26,15 @@ const getTestWorkspaceName = () => `test-workspace-${Math.floor(Math.random() * 
 
 const makeWorkspace = withSignedInPage(async ({ page, billingProject }) => {
   const workspaceName = getTestWorkspaceName()
-  await page.evaluate((name, billingProject) => {
-    return window.Ajax().Workspaces.create({ namespace: billingProject, name, attributes: {} })
-  }, workspaceName, billingProject)
+  try {
+    await page.evaluate((name, billingProject) => {
+      return window.Ajax().Workspaces.create({ namespace: billingProject, name, attributes: {} })
+    }, workspaceName, billingProject)
 
-  rawConsole.info(`created workspace: ${workspaceName}`)
-
+    rawConsole.info(`created workspace: ${workspaceName}`)
+  } catch (e) {
+    throw Error(`Failed to create workspace: ${workspaceName}`)
+  }
   return workspaceName
 })
 
@@ -44,7 +47,7 @@ const deleteWorkspace = withSignedInPage(async ({ page, billingProject, workspac
 
     rawConsole.info(`deleted workspace: ${workspaceName}`)
   } catch (e) {
-    console.error(`Failed to delete workspace: ${workspaceName}. Error: ${e.message}`)
+    throw Error(`Failed to delete workspace: ${workspaceName}`)
   }
 })
 


### PR DESCRIPTION
Changes:
- Check for text on the workspace page instead of the url
- Fix selecting a workspace
- Throw a more descriptive error when creating and deleting a workspace (otherwise it just says `Evaluation failed: Response` and it's difficult to tell what caused it)