### PR TITLE
Show "Spend report" tab under Billing for alpha users only (WOR-42).

### DIFF
--- a/src/pages/billing/List.js
+++ b/src/pages/billing/List.js
@@ -13,6 +13,7 @@ import TopBar from 'src/components/TopBar'
 import { Ajax } from 'src/libs/ajax'
 import * as Auth from 'src/libs/auth'
 import colors from 'src/libs/colors'
+import { getConfig } from 'src/libs/config'
 import { reportErrorAndRethrow } from 'src/libs/error'
 import Events from 'src/libs/events'
 import { formHint, FormLabel } from 'src/libs/forms'
@@ -221,6 +222,7 @@ export const BillingList = ({ queryParams: { selectedName } }) => {
   const [isLoadingProjects, setIsLoadingProjects] = useState(false)
   const [isAuthorizing, setIsAuthorizing] = useState(false)
   const [isLoadingAccounts, setIsLoadingAccounts] = useState(false)
+  const [isAlphaSpendReportUser, setIsAlphaSpendReportUser] = useState(false)
 
   const signal = useCancellation()
   const interval = useRef()
@@ -230,6 +232,12 @@ export const BillingList = ({ queryParams: { selectedName } }) => {
     reportErrorAndRethrow('Error loading billing projects list'),
     Utils.withBusyState(setIsLoadingProjects)
   )(async () => setBillingProjects(_.sortBy('projectName', await Ajax(signal).Billing.listProjects())))
+
+  const loadAlphaSpendReportMember = _.flow(
+    reportErrorAndRethrow('Error loading user group membership')
+  )(async () => {
+    setIsAlphaSpendReportUser(await Ajax(signal).Groups.group(getConfig().alphaSpendReportGroup).isMember())
+  })
 
   const reloadBillingProject = _.flow(
     reportErrorAndRethrow('Error loading billing project'),
@@ -271,6 +279,7 @@ export const BillingList = ({ queryParams: { selectedName } }) => {
   useOnMount(() => {
     loadProjects()
     loadAccounts()
+    loadAlphaSpendReportMember()
   })
 
   useEffect(() => {
@@ -375,7 +384,8 @@ export const BillingList = ({ queryParams: { selectedName } }) => {
             billingProject,
             billingAccounts,
             authorizeAndLoadAccounts: authorizeAccounts,
-            reloadBillingProject: () => reloadBillingProject(billingProject).catch(loadProjects)
+            reloadBillingProject: () => reloadBillingProject(billingProject).catch(loadProjects),
+            isAlphaSpendReportUser
           })
         }],
         [!_.isEmpty(projectsOwned) && !selectedName, () => {

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -190,7 +190,7 @@ const groupByBillingAccountStatus = (billingProject, workspaces) => {
   return _.mapValues(ws => new Set(ws), _.groupBy(group, workspaces))
 }
 
-const ProjectDetail = ({ billingProject, reloadBillingProject, billingAccounts, authorizeAndLoadAccounts }) => {
+const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProject, isAlphaSpendReportUser, reloadBillingProject }) => {
   // State
   const { query } = Nav.useRoute()
   // Rather than using a localized StateHistory store here, we use the existing `workspaceStore` value (via the `useWorkspaces` hook)
@@ -224,6 +224,7 @@ const ProjectDetail = ({ billingProject, reloadBillingProject, billingAccounts, 
   const groups = groupByBillingAccountStatus(billingProject, workspacesInProject)
   const billingAccountsOutOfDate = !(_.isEmpty(groups.error) && _.isEmpty(groups.updating))
   const getBillingAccountStatus = workspace => _.findKey(g => g.has(workspace), groups)
+  const spendReportKey = 'spend report'
 
   const tabToTable = {
     workspaces: h(Fragment, [
@@ -269,7 +270,8 @@ const ProjectDetail = ({ billingProject, reloadBillingProject, billingAccounts, 
         }, _.orderBy([sort.field], [sort.direction], projectUsers))
         )
       ])
-    ])
+    ]),
+    [spendReportKey]: h(Fragment, [])
   }
 
   const tabs = _.map(key => ({
@@ -278,8 +280,7 @@ const ProjectDetail = ({ billingProject, reloadBillingProject, billingAccounts, 
       _.capitalize(key)
     ]),
     tableName: _.lowerCase(key)
-  }), _.keys(tabToTable))
-
+  }), _.filter(key => (key !== spendReportKey || isAlphaSpendReportUser), _.keys(tabToTable)))
   useEffect(() => {
     // Note: setting undefined so that falsy values don't show up at all
     const newSearch = qs.stringify({
@@ -487,6 +488,7 @@ const ProjectDetail = ({ billingProject, reloadBillingProject, billingAccounts, 
         style: { marginTop: '2rem', textTransform: 'none', padding: '0 1rem', height: '1.5rem' },
         tabStyle: { borderBottomWidth: 4 },
         value: tab,
+        key: `tabBarKey${isAlphaSpendReportUser}`, // The Spend report tab is only present for alpha users, so force recreation.
         onChange: newTab => {
           if (newTab === tab) {
             reloadBillingProjectUsers()


### PR DESCRIPTION
This adds an (empty) `Spend report` tab in Billing for billing projects owned by the current user iff the user is a member of the alpha testing group.

To test:
1. Log in with hermione.owner and you should see the tab.
2. Log in with dumbledore.admin and you should not see the tab.

![image](https://user-images.githubusercontent.com/484484/153958174-3bf4f1a9-aeec-4b35-add4-40c637cd7210.png)
