### PR TITLE
[DC-211] Fix back button on data browser details page

### DIFF
--- a/src/pages/library/DataBrowserPreview.js
+++ b/src/pages/library/DataBrowserPreview.js
@@ -136,7 +136,7 @@ const DataBrowserPreview = ({ id }) => {
         div({ style: { display: 'flex', flexDirection: 'row', alignItems: 'top', justifyContent: 'space-between', width: '100%', lineHeight: '26px' } }, [
           h1([snapshot['dct:title']]),
           h(Link, {
-            href: Nav.getLink('library-details', { id: Nav.getCurrentRoute().params.id }),
+            onClick: Nav.history.goBack,
             'aria-label': 'Close',
             style: { marginTop: '1rem' }
           }, [


### PR DESCRIPTION
Fix behavior of the back button on the data browser details page so that it navigates back to the list of datasets after visiting the preview page.

Previous behavior:
![navBug](https://user-images.githubusercontent.com/6414394/154158468-afa448c9-adc8-4dc9-9bc3-94c6269983e5.gif)

New behavior:
![fixedNav](https://user-images.githubusercontent.com/6414394/154159273-b2146b84-bac9-46cd-a73c-c70f86161b78.gif)

