### PR TITLE
[WOR-69] Add mix panel events when tabs of SimpleTabBar are clicked

### DIFF
--- a/src/components/tabBars.js
+++ b/src/components/tabBars.js
@@ -134,13 +134,13 @@ export const SimpleTabBar = ({
   useLabelAssert('SimpleTabBar', props)
   const tabIds = _.map(useUniqueId, _.range(0, tabs.length))
   const panelRef = useRef()
-  const emitViewMetric = key => {
+  const maybeEmitViewMetric = key => {
     !!metricsPrefix && Ajax().Metrics.captureEvent(`${metricsPrefix}:view:${_.replace(/\s/g, '-', key)}`, metricsData)
   }
 
   // Determine the index of the selected tab, or choose the first one
   const selectedId = Math.max(0, _.findIndex(({ key }) => key === value, tabs))
-  useOnMount(() => { emitViewMetric(tabs[selectedId].key) })
+  useOnMount(() => { maybeEmitViewMetric(tabs[selectedId].key) })
 
   return h(Fragment, [
     h(HorizontalNavigation, {
@@ -163,7 +163,7 @@ export const SimpleTabBar = ({
           // This most efficiently lets keyboard users interact with the tabs and find the content they care about.
           children && panelRef.current?.focus()
           onChange && onChange(key)
-          emitViewMetric(key)
+          maybeEmitViewMetric(key)
         },
         ...tabProps
       }, [title])

--- a/src/components/tabBars.js
+++ b/src/components/tabBars.js
@@ -6,7 +6,7 @@ import { Clickable } from 'src/components/common'
 import { HorizontalNavigation } from 'src/components/keyboard-nav'
 import { Ajax } from 'src/libs/ajax'
 import { terraSpecial } from 'src/libs/colors'
-import { useLabelAssert, useUniqueId } from 'src/libs/react-utils'
+import { useLabelAssert, useOnMount, useUniqueId } from 'src/libs/react-utils'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 
@@ -124,7 +124,7 @@ TabBar.propTypes = {
  * @param tabStyle Optionally, additional styles to add to each tab
  * @param children Children, which will be appended to teh end of the tab bar
  * @param props Any additional properties to add to the container menu element
- * @param metricsPrefix Optionally, if present a metrics event will be fired with this prefix and the name of the tab whenever a tab is clicked on.
+ * @param metricsPrefix Optionally, a metrics event will be fired with this prefix and the name of the tab whenever the given tab is viewed.
  *    The form of the event name will be <metricsPrefix>:view:<tabName> (any spaces in tabName will be replaced with "-").
  * @param metricsData Optionally, if metricsPrefix is supplied then this data object will be included with the event that is fired.
  */
@@ -132,12 +132,15 @@ export const SimpleTabBar = ({
   value, onChange, tabs, tabProps = {}, panelProps = {}, style = {}, tabStyle = {}, metricsPrefix = undefined, metricsData = {}, children, ...props
 }) => {
   useLabelAssert('SimpleTabBar', props)
-
   const tabIds = _.map(useUniqueId, _.range(0, tabs.length))
   const panelRef = useRef()
+  const emitViewMetric = key => {
+    !!metricsPrefix && Ajax().Metrics.captureEvent(`${metricsPrefix}:view:${_.replace(/\s/g, '-', key)}`, metricsData)
+  }
 
   // Determine the index of the selected tab, or choose the first one
   const selectedId = Math.max(0, _.findIndex(({ key }) => key === value, tabs))
+  useOnMount(() => { emitViewMetric(tabs[selectedId].key) })
 
   return h(Fragment, [
     h(HorizontalNavigation, {
@@ -160,7 +163,7 @@ export const SimpleTabBar = ({
           // This most efficiently lets keyboard users interact with the tabs and find the content they care about.
           children && panelRef.current?.focus()
           onChange && onChange(key)
-          metricsPrefix && Ajax().Metrics.captureEvent(`${metricsPrefix}:view:${_.replace(/\s/g, '-', key)}`, metricsData)
+          emitViewMetric(key)
         },
         ...tabProps
       }, [title])

--- a/src/components/tabBars.js
+++ b/src/components/tabBars.js
@@ -4,6 +4,7 @@ import { Fragment, useRef } from 'react'
 import { div, h, span } from 'react-hyperscript-helpers'
 import { Clickable } from 'src/components/common'
 import { HorizontalNavigation } from 'src/components/keyboard-nav'
+import { Ajax } from 'src/libs/ajax'
 import { terraSpecial } from 'src/libs/colors'
 import { useLabelAssert, useUniqueId } from 'src/libs/react-utils'
 import * as Style from 'src/libs/style'
@@ -123,9 +124,12 @@ TabBar.propTypes = {
  * @param tabStyle Optionally, additional styles to add to each tab
  * @param children Children, which will be appended to teh end of the tab bar
  * @param props Any additional properties to add to the container menu element
+ * @param metricsPrefix Optionally, if present a metrics event will be fired with this prefix and the name of the tab whenever a tab is clicked on.
+ *    The form of the event name will be <metricsPrefix>:view:<tabName> (any spaces in tabName will be replaced with "-").
+ * @param metricsData Optionally, if metricsPrefix is supplied then this data object will be included with the event that is fired.
  */
 export const SimpleTabBar = ({
-  value, onChange, tabs, tabProps = {}, panelProps = {}, style = {}, tabStyle = {}, children, ...props
+  value, onChange, tabs, tabProps = {}, panelProps = {}, style = {}, tabStyle = {}, metricsPrefix = undefined, metricsData = {}, children, ...props
 }) => {
   useLabelAssert('SimpleTabBar', props)
 
@@ -156,6 +160,7 @@ export const SimpleTabBar = ({
           // This most efficiently lets keyboard users interact with the tabs and find the content they care about.
           children && panelRef.current?.focus()
           onChange && onChange(key)
+          metricsPrefix && Ajax().Metrics.captureEvent(`${metricsPrefix}:view:${_.replace(/\s/g, '-', key)}`, metricsData)
         },
         ...tabProps
       }, [title])
@@ -181,5 +186,7 @@ SimpleTabBar.propTypes = {
   tabProps: PropTypes.object,
   panelProps: PropTypes.object,
   style: PropTypes.object,
-  tabStyle: PropTypes.object
+  tabStyle: PropTypes.object,
+  metricsPrefix: PropTypes.string,
+  metricsData: PropTypes.object
 }

--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -15,6 +15,7 @@ const eventsList = {
   billingProjectExpandWorkspace: 'billing:project:workspace:expand',
   billingProjectGoToWorkspace: 'billing:project:workspace:navigate',
   billingProjectOpenFromList: 'billing:project:open-from-list',
+  billingProjectSelectTab: 'billing:project:tab',
   changeBillingAccount: 'billing:project:account:update',
   cloudEnvironmentConfigOpen: 'cloudEnvironment:config:open',
   cloudEnvironmentCreate: 'cloudEnvironment:create',

--- a/src/pages/billing/List.js
+++ b/src/pages/billing/List.js
@@ -233,9 +233,7 @@ export const BillingList = ({ queryParams: { selectedName } }) => {
     Utils.withBusyState(setIsLoadingProjects)
   )(async () => setBillingProjects(_.sortBy('projectName', await Ajax(signal).Billing.listProjects())))
 
-  const loadAlphaSpendReportMember = _.flow(
-    reportErrorAndRethrow('Error loading user group membership')
-  )(async () => {
+  const loadAlphaSpendReportMember = reportErrorAndRethrow('Error loading user group membership')(async () => {
     setIsAlphaSpendReportUser(await Ajax(signal).Groups.group(getConfig().alphaSpendReportGroup).isMember())
   })
 

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -485,6 +485,8 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
       ]),
       h(SimpleTabBar, {
         'aria-label': 'project details',
+        metricsPrefix: Events.billingProjectSelectTab,
+        metricsData: { billingProjectName: billingProject.projectName },
         style: { marginTop: '2rem', textTransform: 'none', padding: '0 1rem', height: '1.5rem' },
         tabStyle: { borderBottomWidth: 4 },
         value: tab,


### PR DESCRIPTION
This is in support of the "Spend report" that will be under development/testing. But I thought it was good to make this more general and allow any user of SimpleTabBar to opt-in.

To see the event for the "Spend report" you need to log in as hermione (since that is the only account currently in the alpha testers group in dev). However, you can see the event when clicking between Workspaces and Users for any account that owns a billing project (for example, dumbledore).

![image](https://user-images.githubusercontent.com/484484/154344196-0b520483-83fb-4907-b52c-a2b718dfa3dc.png)

Example of new event:

![image](https://user-images.githubusercontent.com/484484/154343829-d8ac1841-bd6d-4da6-aa6c-25868aafdaab.png)
