### PR TITLE
[SU-6][SU-7] Add larger page size options for data tables and increase default page size

### DIFF
--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -70,7 +70,7 @@ const DataTable = props => {
   const [totalRowCount, setTotalRowCount] = useState(0)
 
   const stateHistory = firstRender ? StateHistory.get() : {}
-  const [itemsPerPage, setItemsPerPage] = useState(stateHistory.itemsPerPage || 25)
+  const [itemsPerPage, setItemsPerPage] = useState(stateHistory.itemsPerPage || 100)
   const [pageNumber, setPageNumber] = useState(stateHistory.pageNumber || 1)
   const [sort, setSort] = useState(stateHistory.sort || { field: 'name', direction: 'asc' })
   const [activeTextFilter, setActiveTextFilter] = useState(stateHistory.activeTextFilter || '')
@@ -333,7 +333,8 @@ const DataTable = props => {
           setItemsPerPage: v => {
             setPageNumber(1)
             setItemsPerPage(v)
-          }
+          },
+          itemsPerPageOptions: [10, 25, 50, 100, 250, 500, 1000]
         })
       ])
     ]),


### PR DESCRIPTION
Currently, data tables allow selecting page sizes of 10, 25, 50, or 100 rows per page and default to 25 rows per page.

This adds additional options for 250, 500, and 1000 rows per page and changes the default to 100 rows per page.