### PR TITLE
[SU-20] Fix cancel button in delete workspace data confirmation modal

### DIFF
--- a/src/components/data/LocalVariablesContent.js
+++ b/src/components/data/LocalVariablesContent.js
@@ -285,9 +285,7 @@ const LocalVariablesContent = ({ workspace, workspace: { workspace: { googleProj
       }
     }),
     deleteIndex !== undefined && h(Modal, {
-      onDismiss: () => {
-        setDeleteIndex(undefined)
-      },
+      onDismiss: () => { setDeleteIndex(undefined) },
       title: 'Are you sure you wish to delete this variable?',
       okButton: h(ButtonPrimary, {
         onClick: _.flow(

--- a/src/components/data/LocalVariablesContent.js
+++ b/src/components/data/LocalVariablesContent.js
@@ -285,7 +285,9 @@ const LocalVariablesContent = ({ workspace, workspace: { workspace: { googleProj
       }
     }),
     deleteIndex !== undefined && h(Modal, {
-      onDismiss: setDeleteIndex,
+      onDismiss: () => {
+        setDeleteIndex(undefined)
+      },
       title: 'Are you sure you wish to delete this variable?',
       okButton: h(ButtonPrimary, {
         onClick: _.flow(


### PR DESCRIPTION
Currently, the confirmation modal shown when deleting a variable from Workspace Data cannot be dismissed.

![Screen Shot 2022-02-17 at 11 37 11 AM](https://user-images.githubusercontent.com/1156625/154527778-e919c034-4956-4463-a816-1876599db2c9.png)

This is because `setDeleteIndex` is called with the event that triggers the `onDismiss` callback instead of `undefined`.