### PR TITLE
[SUP-565] Sort list of packages installed in cloud environments

### DIFF
--- a/src/components/ImageDepViewer.js
+++ b/src/components/ImageDepViewer.js
@@ -56,12 +56,16 @@ export const ImageDepViewer = ({ packageLink }) => {
           ])
         ]),
         tbody(
-          _.map(({ name, version }) => {
-            return tr({ key: name }, [
-              td({ style: { paddingRight: '1rem' } }, [name]),
-              td([version])
-            ])
-          }, _.filter({ tool: selectedTool }, packages))
+          _.flow(
+            _.filter({ tool: selectedTool }),
+            _.sortBy(({ name }) => _.toLower(name)),
+            _.map(({ name, version }) => {
+              return tr({ key: name }, [
+                td({ style: { paddingRight: '1rem' } }, [name]),
+                td([version])
+              ])
+            })
+          )(packages)
         )
       ])
     ])


### PR DESCRIPTION
Currently, the list of packages shown in the "What’s installed on this environment?" panel when creating a cloud environment are not sorted. Some environments do happen to have a sorted list of packages, but an example of an unordered list can be seen with the Python packages for the Legacy GATK environment. This makes it difficult to scan the list and determine whether or not a package is available.

This sorts the list of packages installed in the environment by package name.

