### PR TITLE
[SU-24] Remove workspace data descriptions from workflow input menu

### DIFF
--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -487,8 +487,9 @@ const WorkflowView = _.flow(
           entityMetadata, !!modifiedConfig.dataReferenceName
         ),
         workspaceAttributes: _.flow(
-          _.without(['description']),
-          _.remove(s => s.includes(':'))
+          _.without(['description']), // workspace description
+          _.remove(s => s.includes(':')), // library, tags
+          _.remove(s => s.startsWith('__DESCRIPTION__')) // workspace data variable descriptions
         )(_.keys(attributes))
       })
 


### PR DESCRIPTION
Currently, if a workspace data variable has a description, an extra option appears in the attribute menu for workflow inputs. This `__DESCRIPTION__<key>` attribute contains the variable's description.

![Screen Shot 2022-02-16 at 5 02 46 PM](https://user-images.githubusercontent.com/1156625/154366254-1131252d-b1d3-4114-8f8d-1aac44ab50f9.png)

This removes those description attributes from the workflow inputs attribute menu.