### PR TITLE
[SU-27] Show number of rows selected in select workflow data modal

### DIFF
--- a/src/pages/workspaces/workspace/workflows/DataStepContent.js
+++ b/src/pages/workspaces/workspace/workflows/DataStepContent.js
@@ -1,4 +1,5 @@
 import _ from 'lodash/fp'
+import pluralize from 'pluralize'
 import PropTypes from 'prop-types'
 import { useState } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
@@ -98,12 +99,19 @@ const DataStepContent = ({
       }, [
         h(DataTable, {
           key: type.description,
-          childrenBefore: () => div({ style: Style.elements.sectionHeader }, [
-            Utils.switchCase(type,
-              [chooseSetType, () => `Select one or more ${entitySetType}s to combine and process`],
-              [chooseRootType, () => `Select ${rootEntityType}s to process`],
-              [chooseBaseType, () => `Select ${baseEntityType}s to create a new ${rootEntityType} to process`]
-            )
+          childrenBefore: () => div({ style: { display: 'flex', alignItems: 'center' } }, [
+            div({ style: Style.elements.sectionHeader }, [
+              Utils.switchCase(type,
+                [chooseSetType, () => `Select one or more ${entitySetType}s to combine and process`],
+                [chooseRootType, () => `Select ${rootEntityType}s to process`],
+                [chooseBaseType, () => `Select ${baseEntityType}s to create a new ${rootEntityType} to process`]
+              )
+            ]),
+            div({ style: { margin: '0 1.5rem', height: '100%', borderLeft: Style.standardLine } }),
+            div({
+              role: 'status',
+              'aria-atomic': true
+            }, [`${pluralize('row', _.size(selectedEntities), true)} selected`])
           ]),
           entityType: Utils.switchCase(type,
             [chooseBaseType, () => baseEntityType],


### PR DESCRIPTION
Currently, the number of rows selected is not shown when selecting data for a workflow. Since rows can be selected from multiple pages, it can be difficult to keep track of how many rows you have selected.

This adds the number of rows selected.

![Screen Shot 2022-02-18 at 10 38 26 AM](https://user-images.githubusercontent.com/1156625/154715060-14d0eb6b-b978-4c93-acf3-338a92e7f402.png)
