### PR TITLE
[SU-11] Limit the height of the confirmation modal for deleting rows from data tables

### DIFF
--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -206,7 +206,9 @@ export const EntityDeleter = ({ onDismiss, onSuccess, namespace, name, selectedE
       icon('warning-standard', { size: 36, style: { flex: 'none', marginRight: '0.5rem' } }),
       'In order to delete the selected data entries, the following entries that reference them must also be deleted.'
     ]),
-    div({ style: { maxHeight: 550, overflowY: 'auto', margin: '0 -1.25rem' } },
+    // Size the scroll container to cut off the last row to hint that there's more content to be scrolled into view
+    // Row height calculation is font size * line height + padding + border
+    div({ style: { maxHeight: 'calc((1em * 1.15 + 1.2rem + 1px) * 10.5)', overflowY: 'auto', margin: '0 -1.25rem' } },
       _.map(([i, entity]) => div({
         style: {
           borderTop: (i === 0 && runningSubmissionsCount === 0) ? undefined : Style.standardLine,

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -206,13 +206,15 @@ export const EntityDeleter = ({ onDismiss, onSuccess, namespace, name, selectedE
       icon('warning-standard', { size: 36, style: { flex: 'none', marginRight: '0.5rem' } }),
       'In order to delete the selected data entries, the following entries that reference them must also be deleted.'
     ]),
-    ..._.map(([i, entity]) => div({
-      style: {
-        borderTop: (i === 0 && runningSubmissionsCount === 0) ? undefined : Style.standardLine,
-        padding: '0.6rem 1.25rem', margin: '0 -1.25rem'
-      }
-    }, moreToDelete ? `${entity.entityName} (${entity.entityType})` : entity),
-    Utils.toIndexPairs(moreToDelete ? additionalDeletions : selectedKeys)),
+    div({ style: { maxHeight: 550, overflowY: 'auto', margin: '0 -1.25rem' } },
+      _.map(([i, entity]) => div({
+        style: {
+          borderTop: (i === 0 && runningSubmissionsCount === 0) ? undefined : Style.standardLine,
+          padding: '0.6rem 1.25rem'
+        }
+      }, moreToDelete ? `${entity.entityName} (${entity.entityType})` : entity),
+      Utils.toIndexPairs(moreToDelete ? additionalDeletions : selectedKeys))
+    ),
     div({
       style: { ...fullWidthWarning, textAlign: 'right' }
     }, [`${total} data ${total > 1 ? 'entries' : 'entry'} to be deleted.`]),


### PR DESCRIPTION
Currently, when deleting rows from a data table, the confirmation modal displays the entity IDs for all rows being deleted. The modal expands to fit the full list, so when deleting hundreds or thousands of rows, users have to scroll far down to find the Delete button.

This limits the height of the list of entity IDs, so that the list can be scrolled within the modal body without moving the Delete button out of the viewport. This is consistent with how the Share Workspace modal works with a long list of collaborators.

Before:
![Screen Shot 2022-02-18 at 1 25 00 PM](https://user-images.githubusercontent.com/1156625/154742523-a014250a-15c5-4b08-9159-7c120a15dda9.png)

After:
![Screen Shot 2022-02-18 at 1 12 23 PM](https://user-images.githubusercontent.com/1156625/154742536-9ea1afbc-2fe9-45ac-a812-e2035e0b93a8.png)

