### PR TITLE
[SUP-560] Adjust width of billing account and workspace columns in cloud environments table

### DIFF
--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -344,6 +344,7 @@ const Environments = () => {
         rowCount: filteredCloudEnvironments.length,
         columns: [
           {
+            size: { basis: 250 },
             field: 'project',
             headerRenderer: () => h(Sortable, { sort, field: 'project', onSort: setSort }, ['Billing project']),
             cellRenderer: ({ rowIndex }) => {
@@ -352,6 +353,7 @@ const Environments = () => {
             }
           },
           {
+            size: { basis: 250 },
             field: 'workspace',
             headerRenderer: () => h(Sortable, { sort, field: 'workspace', onSort: setSort }, ['Workspace']),
             cellRenderer: ({ rowIndex }) => {
@@ -446,6 +448,7 @@ const Environments = () => {
         rowCount: filteredDisks.length,
         columns: [
           {
+            size: { basis: 250 },
             field: 'project',
             headerRenderer: () => h(Sortable, { sort: diskSort, field: 'project', onSort: setDiskSort }, ['Billing project']),
             cellRenderer: ({ rowIndex }) => {
@@ -454,6 +457,7 @@ const Environments = () => {
             }
           },
           {
+            size: { basis: 250 },
             field: 'workspace',
             headerRenderer: () => h(Sortable, { sort: diskSort, field: 'workspace', onSort: setDiskSort }, ['Workspace']),
             cellRenderer: ({ rowIndex }) => {


### PR DESCRIPTION
Currently, the billing project and workspace columns on the cloud environments page use SimpleFlexTable's default flex basis of 0. Thus, they can be collapsed down to nothing in smaller windows. This adds a flex basis to those columns so that they get some space allocated.

https://github.com/DataBiosphere/terra-ui/blob/d62d5b0ffd1892a5d41ca40dfe06873248cc7b74/src/components/table.js#L137

Before
![Screen Shot 2022-02-18 at 2 48 32 PM](https://user-images.githubusercontent.com/1156625/154752014-e0f5c7f4-d899-4233-a420-b2994339a19f.png)

After
![Screen Shot 2022-02-18 at 2 48 45 PM](https://user-images.githubusercontent.com/1156625/154752018-148f13f0-6432-420f-8417-870df027c813.png)
