### PR TITLE
[DC-235] Fixed bug with filtering on the workspace page

### DIFF
--- a/src/pages/library/DataBrowser.js
+++ b/src/pages/library/DataBrowser.js
@@ -247,7 +247,8 @@ const Browser = () => {
       customSort: sort,
       searchType: 'Datasets',
       titleField: 'dct:title',
-      descField: 'dct:description'
+      descField: 'dct:description',
+      idField: 'dct:identifier'
     }, [makeDataBrowserTableComponent({ sort, setSort, selectedData, toggleSelectedData, setRequestDatasetAccessList })]),
     h(SelectedItemsDisplay, { selectedData, setSelectedData }, []),
     !!requestDatasetAccessList && h(RequestDatasetAccessModal, {

--- a/src/pages/library/common.js
+++ b/src/pages/library/common.js
@@ -316,7 +316,7 @@ const getContextualSuggestion = ([leftContext, match, rightContext]) => {
 
 export const SearchAndFilterComponent = ({
   fullList, sidebarSections, customSort, searchType,
-  titleField = 'name', descField = 'description', children
+  titleField = 'name', descField = 'description', idField = 'lowerName', children
 }) => {
   const { query } = Nav.useRoute()
   const searchFilter = query.filter || ''
@@ -364,13 +364,13 @@ export const SearchAndFilterComponent = ({
       } else {
         const selectedDataByTag = _.map(
           _.flow(
-            _.flatMap(({ lowerTag }) => _.intersectionBy('dct:identifier', listData, listDataByTag[lowerTag])),
-            _.uniqBy('dct:identifier')
+            _.flatMap(({ lowerTag }) => _.intersectionBy(idField, listData, listDataByTag[lowerTag])),
+            _.uniqBy(idField)
           ), tags
         )
 
         return _.reduce(
-          (acc, iter) => _.intersectionBy('dct:identifier', acc, iter),
+          (acc, iter) => _.intersectionBy(idField, acc, iter),
           _.head(selectedDataByTag),
           _.tail(selectedDataByTag)
         )
@@ -397,7 +397,7 @@ export const SearchAndFilterComponent = ({
         _.fromPairs
       )(selectedTags)
     }
-  }, [fullList, searchFilter, customSort, sort, listDataByTag, selectedTags, selectedSections, sidebarSections])
+  }, [fullList, searchFilter, customSort, sort, listDataByTag, selectedTags, selectedSections, sidebarSections, idField])
 
 
   const onSearchChange = filter => {


### PR DESCRIPTION
The problem was the unique identifier field did not exist for all data types, added parameter to allow this to work for everyone using the common code!

No screenshots this time, cause it just shows the filters working the way you'd think they would. :P Before, the workspace filtering only ever showed a single value - because it was uniqueing the objects on a field that doesnt exist (and uniqueBy all null values meant we only ever got one result!)
