### PR TITLE
[SUP-525] Remove Publish button from workspace menu

### DIFF
--- a/src/components/common.js
+++ b/src/components/common.js
@@ -210,15 +210,6 @@ export const transparentSpinnerOverlay = makeBaseSpinner({ innerStyles: { backgr
 
 export const topSpinnerOverlay = makeBaseSpinner({ innerStyles: { marginTop: 150 } })
 
-export const comingSoon = span({
-  style: {
-    margin: '0.5rem', padding: 3, borderRadius: 2,
-    backgroundColor: colors.dark(0.2), color: colors.dark(),
-    fontSize: '75%', textTransform: 'uppercase', fontWeight: 500,
-    whiteSpace: 'nowrap', lineHeight: 1
-  }
-}, ['coming soon'])
-
 const commonSelectProps = {
   theme: base => _.merge(base, {
     colors: {

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -2,7 +2,7 @@ import { differenceInSeconds, parseJSON } from 'date-fns/fp'
 import _ from 'lodash/fp'
 import { Fragment, useRef, useState } from 'react'
 import { br, div, h, h2, p, span } from 'react-hyperscript-helpers'
-import { ButtonPrimary, Clickable, comingSoon, Link, spinnerOverlay } from 'src/components/common'
+import { ButtonPrimary, Clickable, Link, spinnerOverlay } from 'src/components/common'
 import { ContextBar } from 'src/components/ContextBar'
 import FooterWrapper from 'src/components/FooterWrapper'
 import { icon } from 'src/components/icons'
@@ -360,7 +360,6 @@ export const WorkspaceMenuTrigger = ({ children, canShare, isOwner, setCloningWo
         tooltipSide: 'left',
         onClick: () => setSharingWorkspace(true)
       }, [makeMenuIcon('share'), 'Share']),
-      h(MenuButton, { 'aria-label': 'Workspace publish', disabled: true }, [makeMenuIcon('export'), 'Publish', comingSoon]),
       h(MenuButton, {
         'aria-label': 'Workspace delete',
         disabled: !isOwner,


### PR DESCRIPTION
This button has been marked as "Coming Soon" for 4 years, but it's not actually coming at all so we're getting rid of the button to avoid causing any more confusion.

Before
<img width="335" alt="Screen Shot 2022-02-18 at 4 33 22 PM" src="https://user-images.githubusercontent.com/7257391/154764413-2e3521c9-ddc9-4b53-97d3-b151db7695c1.png">

After
<img width="291" alt="Screen Shot 2022-02-18 at 4 33 35 PM" src="https://user-images.githubusercontent.com/7257391/154764421-4ccad14b-e492-4078-bf96-0a24a8562145.png">

