### PR TITLE
[SUP-588] Truncate long versions in workflows list

### DIFF
--- a/src/pages/workspaces/workspace/Workflows.js
+++ b/src/pages/workspaces/workspace/Workflows.js
@@ -135,7 +135,7 @@ const WorkflowCard = memoWithName('WorkflowCard', ({ listView, name, namespace, 
       div({ style: { ...styles.innerContent, display: 'flex', alignItems: 'center' } }, [
         div({ style: { marginRight: '1rem' } }, [workflowCardMenu]),
         div({ style: { ...styles.longTitle } }, [workflowName]),
-        div({ style: { ...styles.longMethodVersion, display: 'flex', alignItems: 'center' } }, [
+        div({ style: { ...styles.longMethodVersion } }, [
           `V. ${methodVersion}`
         ]),
         div({ style: { flex: 'none', width: 130 } }, ['Source: ', repoLink])
@@ -146,10 +146,8 @@ const WorkflowCard = memoWithName('WorkflowCard', ({ listView, name, namespace, 
       div({ style: { ...styles.innerContent, display: 'flex', flexDirection: 'column', justifyContent: 'space-between', height: '100%' } }, [
         div({ style: { ...styles.shortTitle } }, [workflowName]),
         div({ style: { display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end' } }, [
-          div([
-            div({ style: { display: 'flex', alignItems: 'center' } }, [
-              `V. ${methodVersion}`
-            ]),
+          div({ style: { minWidth: 100, marginRight: '1ch' } }, [
+            div({ style: { ...Style.noWrapEllipsis } }, `V. ${methodVersion}`),
             'Source: ', repoLink
           ]), workflowCardMenu
         ])


### PR DESCRIPTION
Currently, when viewing workspaces in card view, long workflow versions may overflow the workflow card. Also, in the list view, truncated versions do not have an ellipsis.

## Card view
### Before
![Screen Shot 2022-02-23 at 1 07 03 PM](https://user-images.githubusercontent.com/1156625/155380551-970e1aea-f284-44f9-808f-8252ba42495a.png)

### After
![Screen Shot 2022-02-23 at 1 04 49 PM](https://user-images.githubusercontent.com/1156625/155380722-e1a8a813-f7ef-4348-bc1d-703a2fb93f8d.png)

## List view
### Before
![Screen Shot 2022-02-23 at 1 07 08 PM](https://user-images.githubusercontent.com/1156625/155380555-3568636c-5f8d-474e-9a44-ddc510960d02.png)

### After
![Screen Shot 2022-02-23 at 1 04 57 PM](https://user-images.githubusercontent.com/1156625/155380723-448f7371-d5b2-4353-9b39-40a6965b1852.png)

