### PR TITLE
[WOR-47] Accept both forms of tos until phase-out is complete

### DIFF
--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -169,6 +169,7 @@ const registerUser = withSignedInPage(async ({ page, token }) => {
   await page.evaluate(async () => {
     await window.catchErrorResponse(async () => {
       await window.Ajax().User.profile.set({ firstName: 'Integration', lastName: 'Test', contactEmail: 'me@example.com' })
+      await window.Ajax().User.acceptTos()
       await window.Ajax().User.acceptSamTos()
     })
   })


### PR DESCRIPTION
Explanation: we're currently in the middle of a pretty complicated rollout that moves Terms of Service enforcement from a Cloud Function into Sam.

Terra UI itself was designed to be backwards/forwards compatible with both the old ToS CF as well as the new Sam ToS APIs. If the Sam ToS APIs are live, Terra UI will automatically detect that and start using them. If not, it will defer to the CF ToS. This part of the rollout has been smooth and works as expected.

Unfortunately, we did not realize that the integration tests do things a little bit differently until the rollout was already underway. The integration tests call the APIs directly rather than relying on Terra UIs logic to detect which source of ToS to use.

This change takes care of the problem by accepting the ToS for both sources, so tests will work regardless of where we are in the rollout of the new ToS changes.

Currently alpha has the new ToS code, but staging does not. For staging tests to pass, they need to accept the old-style ToS.