### PR TITLE
[SU-4] Limit height of data table page and scroll data selection list

### DIFF
--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -36,10 +36,13 @@ const bucketObjects = '__bucket_objects__'
 
 const styles = {
   tableContainer: {
-    display: 'flex', flex: 1
+    display: 'flex', flex: 1, flexBasis: '15rem',
+    maxHeight: '100%',
+    overflow: 'hidden'
   },
   dataTypeSelectionPanel: {
     flex: 'none', width: 280, backgroundColor: 'white',
+    overflow: 'auto',
     boxShadow: '0 2px 5px 0 rgba(0,0,0,0.25)'
   },
   tableViewPanel: {


### PR DESCRIPTION
Currently, when a workspace has many data tables or snapshots, the selected table's horizontal scroll bar and pagination controls are pushed to the bottom of the data selection list.

This limits the height of the page so that the scroll bar and pagination controls are visible in the window and makes the data selection list independently scrollable.

## Before

Have to scroll the window to see the horizontal scroll bar and pagination controls. When those are scrolled into view, column headers and controls not visible.

![Screen Shot 2022-02-25 at 7 56 57 AM](https://user-images.githubusercontent.com/1156625/155725351-3cf03505-8351-4977-ba22-6d1f3b89a8d9.png)

![Screen Shot 2022-02-25 at 7 57 06 AM](https://user-images.githubusercontent.com/1156625/155725361-81ec3633-2eb2-43f0-998c-bc58721b3b5f.png)

## After

Horizontal scroll bar and pagination controls are always visible.

![Screen Shot 2022-02-25 at 7 58 33 AM](https://user-images.githubusercontent.com/1156625/155725563-ced0d3e3-6c3e-4068-8a78-c64b69485345.png)

![Screen Shot 2022-02-25 at 7 59 40 AM](https://user-images.githubusercontent.com/1156625/155725565-7c1d0e99-0b99-4352-8fd3-1596c3e8217d.png)

Data selection list scrolls independently.

![Screen Shot 2022-02-25 at 7 59 43 AM](https://user-images.githubusercontent.com/1156625/155725659-ed3beee9-03e6-41ad-a210-33bd5ff19ab8.png)

