### PR TITLE
[SU-38] Use correct prop types for SimpleTabBar in EntityUploader

### DIFF
--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -303,10 +303,10 @@ export const EntityUploader = ({ onSuccess, onDismiss, namespace, name, entityTy
             p(['Data will be saved in location: 🇺🇸 ', span({ style: { fontWeight: 'bold' } }, 'US '), '(Terra-managed).'])]),
         h(SimpleTabBar, {
           'aria-label': 'import type',
-          tabs: [{ title: 'File Import', key: true, width: 121 }, { title: 'Text Import', key: false, width: 127 }],
-          value: isFileImportCurrMode,
+          tabs: [{ title: 'File Import', key: 'file', width: 121 }, { title: 'Text Import', key: 'text', width: 127 }],
+          value: isFileImportCurrMode ? 'file' : 'text',
           onChange: value => {
-            setIsFileImportCurrMode(value)
+            setIsFileImportCurrMode(value === 'file')
             setShowInvalidEntryMethodWarning(false)
           }
         }),


### PR DESCRIPTION
Currently, in development mode, clicking the Upload TSV button throws errors in the console about invalid props. SimpleTabBar expects strings for `value` and `tabs.[].key`, not booleans.

![Screen Shot 2022-02-25 at 10 40 03 AM](https://user-images.githubusercontent.com/1156625/155744897-0e0bc85e-c183-4499-9774-47128753c850.png)
