### PR TITLE
[SUP-499] Refresh billing projects while project is creating

### DIFF
--- a/src/pages/billing/List.js
+++ b/src/pages/billing/List.js
@@ -283,7 +283,7 @@ export const BillingList = ({ queryParams: { selectedName } }) => {
   useEffect(() => {
     const anyProjectsCreating = _.some({ creationStatus: 'Creating' }, billingProjects)
 
-    if (anyProjectsCreating && interval.current) {
+    if (anyProjectsCreating && !interval.current) {
       interval.current = setInterval(loadProjects, 10000)
     } else if (!anyProjectsCreating && interval.current) {
       clearInterval(interval.current)
@@ -292,7 +292,10 @@ export const BillingList = ({ queryParams: { selectedName } }) => {
 
     StateHistory.update({ billingProjects })
 
-    return () => clearInterval(interval.current)
+    return () => {
+      clearInterval(interval.current)
+      interval.current = undefined
+    }
   })
 
   // Render


### PR DESCRIPTION
While a billing project is in the process of being created, the billing project list should periodically refresh to update that billing project's status. However, currently the interval responsible for that is never started. This can lead to a situation where a user creates a billing project and the UI shows the new project's status as "Creating" until the user refreshes the page.