### PR TITLE
[SUP-501] Ensure that a submission's workflows table is visible

### DIFF
--- a/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
+++ b/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
@@ -242,6 +242,7 @@ const SubmissionDetails = _.flow(
           })
         ])
       ]),
+      // 48px is based on the default row height of FlexTable
       div({ style: { flex: `1 0 calc(${1 + Math.min(filteredWorkflows.length, 5.5)} * 48px)` } }, [
         h(AutoSizer, [({ width, height }) => h(FlexTable, {
           'aria-label': 'submission details',

--- a/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
+++ b/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
@@ -243,7 +243,7 @@ const SubmissionDetails = _.flow(
         ])
       ]),
       // 48px is based on the default row height of FlexTable
-      div({ style: { flex: `1 0 calc(${1 + Math.min(filteredWorkflows.length, 5.5)} * 48px)` } }, [
+      div({ style: { flex: `1 0 ${(1 + Math.min(filteredWorkflows.length, 5.5)) * 48}px` } }, [
         h(AutoSizer, [({ width, height }) => h(FlexTable, {
           'aria-label': 'submission details',
           width, height, sort,

--- a/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
+++ b/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
@@ -242,7 +242,7 @@ const SubmissionDetails = _.flow(
           })
         ])
       ]),
-      div({ style: { flex: 1 } }, [
+      div({ style: { flex: `1 0 calc(${1 + Math.min(filteredWorkflows.length, 5.5)} * 48px)` } }, [
         h(AutoSizer, [({ width, height }) => h(FlexTable, {
           'aria-label': 'submission details',
           width, height, sort,

--- a/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
+++ b/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
@@ -243,7 +243,7 @@ const SubmissionDetails = _.flow(
         ])
       ]),
       // 48px is based on the default row height of FlexTable
-      div({ style: { flex: `1 0 ${(1 + Math.min(filteredWorkflows.length, 5.5)) * 48}px` } }, [
+      div({ style: { flex: `1 0 ${(1 + _.min([filteredWorkflows.length, 5.5])) * 48}px` } }, [
         h(AutoSizer, [({ width, height }) => h(FlexTable, {
           'aria-label': 'submission details',
           width, height, sort,


### PR DESCRIPTION
Currently, when viewing a submission in the Job History tab, the table of workflows in the submission can be cut off if the window is not tall enough. This is because the workflows table is auto sized based on the amount of space available after the other submission information. If the window is just tall enough to fit the submission information, there is no space for the workflows table.

This reserves enough space for a table with 5.5 rows, or one row per workflow if there are fewer than 6 workflows.

![Screen Shot 2022-02-25 at 4 11 57 PM](https://user-images.githubusercontent.com/1156625/155803711-e0afd42d-5382-41bd-bcb5-3c2e35028e3c.png)

