### PR TITLE
POL-179 Support oauth state for ecm

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -387,8 +387,7 @@ const User = signal => ({
     const root = `api/oidc/v1/${provider}`
     const queryParams = {
       scopes: ['openid', 'email', 'ga4gh_passport_v1'],
-      redirectUri: `${window.location.hostname === 'localhost' ? getConfig().devUrlRoot : window.location.origin}/ecm-callback`,
-      state: btoa(JSON.stringify({ provider }))
+      redirectUri: `${window.location.hostname === 'localhost' ? getConfig().devUrlRoot : window.location.origin}/ecm-callback`
     }
 
     return {
@@ -415,8 +414,8 @@ const User = signal => ({
         return res.json()
       },
 
-      linkAccount: async oauthcode => {
-        const res = await fetchEcm(`${root}/oauthcode?${qs.stringify({ ...queryParams, oauthcode }, { indices: false })}`, _.merge(authOpts(), { signal, method: 'POST' }))
+      linkAccount: async (oauthcode, state) => {
+        const res = await fetchEcm(`${root}/oauthcode?${qs.stringify({ ...queryParams, oauthcode, state }, { indices: false })}`, _.merge(authOpts(), { signal, method: 'POST' }))
         return res.json()
       },
 

--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -263,8 +263,8 @@ const PassportLinker = ({ queryParams: { state, code } = {}, provider, prettyNam
     const loadPassport = withErrorReporting(`Error loading ${prettyName} passport`, async () => {
       setPassport(await Ajax(signal).User.externalAccount(provider).getPassport())
     })
-    const linkAccount = withErrorReporting(`Error linking ${prettyName} account`, async code => {
-      setAccountInfo(await Ajax().User.externalAccount(provider).linkAccount(code))
+    const linkAccount = withErrorReporting(`Error linking ${prettyName} account`, async (code, state) => {
+      setAccountInfo(await Ajax().User.externalAccount(provider).linkAccount(code, state))
       loadPassport()
     })
 
@@ -272,7 +272,7 @@ const PassportLinker = ({ queryParams: { state, code } = {}, provider, prettyNam
 
     if (Nav.getCurrentRoute().name === 'ecm-callback' && JSON.parse(atob(state)).provider === provider) {
       window.history.replaceState({}, '', `/${Nav.getLink('profile')}`)
-      linkAccount(code)
+      linkAccount(code, state)
     } else {
       loadAccount()
       loadPassport()


### PR DESCRIPTION
In support of https://broadworkbench.atlassian.net/browse/POL-179

To test locally, change your `/etc/hosts` to have the entry

```127.0.0.1 bvdp-saturn-dev.appspot.com```

Start the Terra ui locally then link RAS account and authenticate. Then the redirect back will show an error. Change the URL, replace `https://bvdp-saturn-dev.appspot.com` with `http://localhost:3000` 

The change that took place is that no longer does the Terra UI generate a state parameter and pass that to ecm. ECM creates the state (it is passed back embedded in the auth url) and it must receive it back correctly when the account is linked.
<!--
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Thanks!
--!>
