### PR TITLE
[SUP-611] Add more information to delete workspace confirmation

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -995,6 +995,11 @@ const Workspaces = signal => ({
       accessInstructions: async () => {
         const res = await fetchRawls(`${root}/accessInstructions`, _.merge(authOpts(), { signal }))
         return res.json()
+      },
+
+      bucketUsage: async () => {
+        const res = await fetchRawls(`${root}/bucketUsage`, _.merge(authOpts(), { signal }))
+        return res.json()
       }
     }
   }

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -343,3 +343,18 @@ export const sha256 = async message => {
     _.join('')
   )(new Uint8Array(hashBuffer))
 }
+
+export const formatBytes = bytes => {
+  if (bytes < 2 ** 10) {
+    return `${bytes} B`
+  }
+
+  const [prefix, divisor] = [
+    ['P', 2 ** 50],
+    ['T', 2 ** 40],
+    ['G', 2 ** 30],
+    ['M', 2 ** 20],
+    ['K', 2 ** 10]
+  ].find(([p, d]) => bytes >= d)
+  return `${(bytes / divisor).toPrecision(3)} ${prefix}iB`
+}

--- a/src/pages/workspaces/workspace/DeleteWorkspaceModal.js
+++ b/src/pages/workspaces/workspace/DeleteWorkspaceModal.js
@@ -108,9 +108,12 @@ const DeleteWorkspaceModal = ({ workspace: { workspace: { namespace, name, bucke
     ]),
     collaboratorEmails && collaboratorEmails.length > 0 && div({ style: { marginTop: '1rem' } }, [
       p(`${pluralize('collaborator', collaboratorEmails.length, true)} will lose access to this workspace.`),
-      div(collaboratorEmails.map(
+      div(collaboratorEmails.slice(0, 5).map(
         email => div({ key: email, style: { overflow: 'hidden', textOverflow: 'ellipsis' } }, [h(Link, { href: `mailto:${email}` }, [email])])
-      ))
+      )),
+      collaboratorEmails.length > 5 && (
+        div(`and ${collaboratorEmails.length - 5} more`)
+      )
     ]),
     !isDeleteDisabledFromApps && div({
       style: {

--- a/src/pages/workspaces/workspace/DeleteWorkspaceModal.js
+++ b/src/pages/workspaces/workspace/DeleteWorkspaceModal.js
@@ -119,8 +119,8 @@ const DeleteWorkspaceModal = ({ workspace: { workspace: { namespace, name, bucke
         marginTop: '1rem'
       }
     }, 'This cannot be undone.'),
-    !isDeleteDisabledFromApps && div({ style: { marginTop: '1rem' } }, [
-      label({ htmlFor: 'delete-workspace-confirmation' }, ['Please type \'Delete Workspace\' to continue:']),
+    !isDeleteDisabledFromApps && div({ style: { display: 'flex', flexDirection: 'column', marginTop: '1rem' } }, [
+      label({ htmlFor: 'delete-workspace-confirmation', style: { marginBottom: '0.25rem' } }, ['Please type \'Delete Workspace\' to continue:']),
       h(TextInput, {
         id: 'delete-workspace-confirmation',
         placeholder: 'Delete Workspace',

--- a/src/pages/workspaces/workspace/DeleteWorkspaceModal.js
+++ b/src/pages/workspaces/workspace/DeleteWorkspaceModal.js
@@ -114,6 +114,7 @@ const DeleteWorkspaceModal = ({ workspace: { workspace: { namespace, name, bucke
     ]),
     !isDeleteDisabledFromApps && div({
       style: {
+        color: colors.danger(),
         fontWeight: 500,
         marginTop: '1rem'
       }


### PR DESCRIPTION
To clarify the impact of deleting a workspace, this adds additional information (the size of the workspace bucket and the list of users with access to the workspace) to the delete workspace confirmation prompt.

## Before
![Screen Shot 2022-03-01 at 9 38 39 AM](https://user-images.githubusercontent.com/1156625/156191707-c404fe70-ea58-4eb1-bb20-029159d50b7c.png)

## After
![Screen Shot 2022-03-01 at 9 46 51 AM](https://user-images.githubusercontent.com/1156625/156191711-2352128b-57f5-4aba-ba85-678789277cc7.png)
