### PR TITLE
[SUP-366] Clarify process for sharing a workspace

### DIFF
--- a/src/pages/workspaces/workspace/ShareWorkspaceModal.js
+++ b/src/pages/workspaces/workspace/ShareWorkspaceModal.js
@@ -200,10 +200,16 @@ const ShareWorkspaceModal = ({ onDismiss, workspace, workspace: { workspace: { n
 
   const remainingSuggestions = _.difference(suggestions, _.map('email', acl))
 
+  const addUserReminder = `Did you mean to add ${searchValue} as a collaborator? Add them or clear the "User email" field to save changes.`
+
   return h(Modal, {
     title: 'Share Workspace',
     width: 550,
-    okButton: h(ButtonPrimary, { onClick: save }, ['Save']),
+    okButton: h(ButtonPrimary, {
+      disabled: searchValueValid,
+      tooltip: searchValueValid && addUserReminder,
+      onClick: save
+    }, ['Save']),
     onDismiss
   }, [
     h(IdContainer, [id => h(Fragment, [

--- a/src/pages/workspaces/workspace/ShareWorkspaceModal.js
+++ b/src/pages/workspaces/workspace/ShareWorkspaceModal.js
@@ -250,7 +250,7 @@ const ShareWorkspaceModal = ({ onDismiss, workspace, workspace: { workspace: { n
         onClick: () => { addCollaborator(searchValue) }
       }, ['Add'])
     ]),
-    searchValueValid && !searchHasFocus && p({ style: { color: colors.danger() } }, addUserReminder),
+    searchValueValid && !searchHasFocus && p(addUserReminder),
     h2({ style: { ...Style.elements.sectionHeader, margin: '1rem 0 0.5rem 0' } }, ['Current Collaborators']),
     div({ ref: list, role: 'list', style: styles.currentCollaboratorsArea }, [
       h(Fragment, _.map(renderCollaborator, Utils.toIndexPairs(acl))),

--- a/src/pages/workspaces/workspace/ShareWorkspaceModal.js
+++ b/src/pages/workspaces/workspace/ShareWorkspaceModal.js
@@ -213,7 +213,7 @@ const ShareWorkspaceModal = ({ onDismiss, workspace, workspace: { workspace: { n
         openOnFocus: true,
         placeholderText: _.includes(searchValue, aclEmails) ?
           'This email has already been added to the list' :
-          'Enter an email address',
+          'Type an email address and press "Enter" or "Return"',
         onPick: value => {
           if (!validate.single(value, { email: true, exclusion: aclEmails })) {
             setSearchValue('')

--- a/src/pages/workspaces/workspace/ShareWorkspaceModal.js
+++ b/src/pages/workspaces/workspace/ShareWorkspaceModal.js
@@ -203,6 +203,14 @@ const ShareWorkspaceModal = ({ onDismiss, workspace, workspace: { workspace: { n
 
   const addUserReminder = `Did you mean to add ${searchValue} as a collaborator? Add them or clear the "User email" field to save changes.`
 
+  const addCollaborator = collaboratorEmail => {
+    if (!validate.single(collaboratorEmail, { email: true, exclusion: aclEmails })) {
+      setSearchValue('')
+      setAcl(Utils.append({ email: collaboratorEmail, accessLevel: 'READER' }))
+      setLastAddedEmail(collaboratorEmail)
+    }
+  }
+
   return h(Modal, {
     title: 'Share Workspace',
     width: 550,
@@ -213,34 +221,35 @@ const ShareWorkspaceModal = ({ onDismiss, workspace, workspace: { workspace: { n
     }, ['Save']),
     onDismiss
   }, [
-    h(IdContainer, [id => h(Fragment, [
-      h(FormLabel, { htmlFor: id }, ['User email']),
-      h(AutocompleteTextInput, {
-        id,
-        openOnFocus: true,
-        placeholderText: _.includes(searchValue, aclEmails) ?
-          'This email has already been added to the list' :
-          'Type an email address and press "Enter" or "Return"',
-        onPick: value => {
-          if (!validate.single(value, { email: true, exclusion: aclEmails })) {
-            setSearchValue('')
-            setAcl(Utils.append({ email: value, accessLevel: 'READER' }))
-            setLastAddedEmail(value)
-          }
-        },
-        placeholder: 'Add people or groups',
-        value: searchValue,
-        onFocus: () => { setSearchHasFocus(true) },
-        onBlur: () => { setSearchHasFocus(false) },
-        onChange: setSearchValue,
-        suggestions: Utils.cond(
-          [searchValueValid && !_.includes(searchValue, aclEmails), () => [searchValue]],
-          [remainingSuggestions.length, () => remainingSuggestions],
-          () => []
-        ),
-        style: { fontSize: 16 }
-      })
-    ])]),
+    div({ style: { display: 'flex', alignItems: 'flex-end' } }, [
+      h(IdContainer, [id => div({ style: { flexGrow: 1, marginRight: '1rem' } }, [
+        h(FormLabel, { htmlFor: id }, ['User email']),
+        h(AutocompleteTextInput, {
+          id,
+          openOnFocus: true,
+          placeholderText: _.includes(searchValue, aclEmails) ?
+            'This email has already been added to the list' :
+            'Type an email address and press "Enter" or "Return"',
+          onPick: addCollaborator,
+          placeholder: 'Add people or groups',
+          value: searchValue,
+          onFocus: () => { setSearchHasFocus(true) },
+          onBlur: () => { setSearchHasFocus(false) },
+          onChange: setSearchValue,
+          suggestions: Utils.cond(
+            [searchValueValid && !_.includes(searchValue, aclEmails), () => [searchValue]],
+            [remainingSuggestions.length, () => remainingSuggestions],
+            () => []
+          ),
+          style: { fontSize: 16 }
+        })
+      ])]),
+      h(ButtonPrimary, {
+        disabled: !searchValueValid,
+        tooltip: !searchValueValid && 'Enter an email address to add a collaborator',
+        onClick: () => { addCollaborator(searchValue) }
+      }, ['Add'])
+    ]),
     searchValueValid && !searchHasFocus && p({ style: { color: colors.danger() } }, addUserReminder),
     h2({ style: { ...Style.elements.sectionHeader, margin: '1rem 0 0.5rem 0' } }, ['Current Collaborators']),
     div({ ref: list, role: 'list', style: styles.currentCollaboratorsArea }, [

--- a/src/pages/workspaces/workspace/ShareWorkspaceModal.js
+++ b/src/pages/workspaces/workspace/ShareWorkspaceModal.js
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp'
 import { Fragment, useLayoutEffect, useRef, useState } from 'react'
-import { div, h, h2 } from 'react-hyperscript-helpers'
+import { div, h, h2, p } from 'react-hyperscript-helpers'
 import { ButtonPrimary, IdContainer, LabeledCheckbox, Link, Select, spinnerOverlay } from 'src/components/common'
 import { centeredSpinner, icon } from 'src/components/icons'
 import { AutocompleteTextInput } from 'src/components/input'
@@ -87,6 +87,7 @@ const ShareWorkspaceModal = ({ onDismiss, workspace, workspace: { workspace: { n
   const [working, setWorking] = useState(false)
   const [updateError, setUpdateError] = useState(undefined)
   const [lastAddedEmail, setLastAddedEmail] = useState(undefined)
+  const [searchHasFocus, setSearchHasFocus] = useState(true)
 
   const list = useRef()
   const signal = useCancellation()
@@ -229,6 +230,8 @@ const ShareWorkspaceModal = ({ onDismiss, workspace, workspace: { workspace: { n
         },
         placeholder: 'Add people or groups',
         value: searchValue,
+        onFocus: () => { setSearchHasFocus(true) },
+        onBlur: () => { setSearchHasFocus(false) },
         onChange: setSearchValue,
         suggestions: Utils.cond(
           [searchValueValid && !_.includes(searchValue, aclEmails), () => [searchValue]],
@@ -238,6 +241,7 @@ const ShareWorkspaceModal = ({ onDismiss, workspace, workspace: { workspace: { n
         style: { fontSize: 16 }
       })
     ])]),
+    searchValueValid && !searchHasFocus && p({ style: { color: colors.danger() } }, addUserReminder),
     h2({ style: { ...Style.elements.sectionHeader, margin: '1rem 0 0.5rem 0' } }, ['Current Collaborators']),
     div({ ref: list, role: 'list', style: styles.currentCollaboratorsArea }, [
       h(Fragment, _.map(renderCollaborator, Utils.toIndexPairs(acl))),


### PR DESCRIPTION
Currently, users sometimes fail to share a workspace because they enter a collaborator's email in the "User email" field and click save.

![Screen Shot 2022-03-01 at 11 42 17 AM](https://user-images.githubusercontent.com/1156625/156211298-ae151251-80d6-48af-a1f3-50430df3ed67.png)

However, sharing a workspace is actually a two step process. They must either press "Enter" in the "User email" field or click the collaborator's email in the combobox's drop down list. This makes a few changes to clarify that:

Show a hint to press "enter" after entering the email while typing an email address. And add an "Add" button for a more obvious interaction to enter the email address.

![Screen Shot 2022-03-01 at 11 41 40 AM](https://user-images.githubusercontent.com/1156625/156211806-91681def-61f2-43c1-a3e0-be65d63d8552.png)

When a valid email address is entered in the "User email" field, disable the "Save" button and show a message.

![Screen Shot 2022-03-01 at 11 41 26 AM](https://user-images.githubusercontent.com/1156625/156213185-e723a4be-ab9b-478e-88f0-e55748e237de.png)

