### PR TITLE
[SUP-501] Refactor the row height of a submission's workflows table

### DIFF
--- a/src/components/table.js
+++ b/src/components/table.js
@@ -203,13 +203,15 @@ const NoContentRow = ({ noContentMessage, noContentRenderer = _.noop, numColumns
   ])
 ])
 
+export const FLEX_TABLE_DEFAULT_ROW_HEIGHT = 48
+
 /**
  * A virtual table with a fixed header and flexible column widths. Intended to take up the full
  * available container width, without horizontal scrolling.
  */
 export const FlexTable = ({
   initialY = 0, width, height, rowCount, variant, columns = [], hoverHighlight = false,
-  onScroll = _.noop, noContentMessage, noContentRenderer = _.noop, headerHeight = 48, rowHeight = 48,
+  onScroll = _.noop, noContentMessage, noContentRenderer = _.noop, headerHeight = FLEX_TABLE_DEFAULT_ROW_HEIGHT, rowHeight = FLEX_TABLE_DEFAULT_ROW_HEIGHT,
   styleCell = () => ({}), styleHeader = () => ({}), 'aria-label': ariaLabel, sort = null, readOnly = false,
   ...props
 }) => {

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -203,7 +203,7 @@ const NoContentRow = ({ noContentMessage, noContentRenderer = _.noop, numColumns
   ])
 ])
 
-export const FLEX_TABLE_DEFAULT_ROW_HEIGHT = 48
+export const flexTableDefaultRowHeight = 48
 
 /**
  * A virtual table with a fixed header and flexible column widths. Intended to take up the full
@@ -211,7 +211,7 @@ export const FLEX_TABLE_DEFAULT_ROW_HEIGHT = 48
  */
 export const FlexTable = ({
   initialY = 0, width, height, rowCount, variant, columns = [], hoverHighlight = false,
-  onScroll = _.noop, noContentMessage, noContentRenderer = _.noop, headerHeight = FLEX_TABLE_DEFAULT_ROW_HEIGHT, rowHeight = FLEX_TABLE_DEFAULT_ROW_HEIGHT,
+  onScroll = _.noop, noContentMessage, noContentRenderer = _.noop, headerHeight = flexTableDefaultRowHeight, rowHeight = flexTableDefaultRowHeight,
   styleCell = () => ({}), styleHeader = () => ({}), 'aria-label': ariaLabel, sort = null, readOnly = false,
   ...props
 }) => {

--- a/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
+++ b/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
@@ -11,7 +11,7 @@ import {
   addCountSuffix, collapseStatus, makeSection, makeStatusLine, statusType, submissionDetailsBreadcrumbSubtitle
 } from 'src/components/job-common'
 import { InfoBox } from 'src/components/PopupTrigger'
-import { FlexTable, Sortable, TextCell, TooltipCell } from 'src/components/table'
+import { FLEX_TABLE_DEFAULT_ROW_HEIGHT, FlexTable, Sortable, TextCell, TooltipCell } from 'src/components/table'
 import TooltipTrigger from 'src/components/TooltipTrigger'
 import { Ajax } from 'src/libs/ajax'
 import { bucketBrowserUrl } from 'src/libs/auth'
@@ -25,6 +25,8 @@ import * as Utils from 'src/libs/utils'
 import UpdateUserCommentModal from 'src/pages/workspaces/workspace/jobHistory/UpdateUserCommentModal'
 import { wrapWorkspace } from 'src/pages/workspaces/workspace/WorkspaceContainer'
 
+
+const WORKFLOWS_TABLE_ROW_HEIGHT = FLEX_TABLE_DEFAULT_ROW_HEIGHT
 
 const SubmissionDetails = _.flow(
   forwardRefWithName('SubmissionDetails'),
@@ -243,10 +245,12 @@ const SubmissionDetails = _.flow(
         ])
       ]),
       // 48px is based on the default row height of FlexTable
-      div({ style: { flex: `1 0 ${(1 + _.min([filteredWorkflows.length, 5.5])) * 48}px` } }, [
+      div({ style: { flex: `1 0 ${(1 + _.min([filteredWorkflows.length, 5.5])) * WORKFLOWS_TABLE_ROW_HEIGHT}px` } }, [
         h(AutoSizer, [({ width, height }) => h(FlexTable, {
           'aria-label': 'submission details',
           width, height, sort,
+          headerHeight: WORKFLOWS_TABLE_ROW_HEIGHT,
+          rowHeight: WORKFLOWS_TABLE_ROW_HEIGHT,
           rowCount: filteredWorkflows.length,
           noContentMessage: 'No matching workflows',
           columns: [

--- a/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
+++ b/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
@@ -11,7 +11,7 @@ import {
   addCountSuffix, collapseStatus, makeSection, makeStatusLine, statusType, submissionDetailsBreadcrumbSubtitle
 } from 'src/components/job-common'
 import { InfoBox } from 'src/components/PopupTrigger'
-import { FLEX_TABLE_DEFAULT_ROW_HEIGHT, FlexTable, Sortable, TextCell, TooltipCell } from 'src/components/table'
+import { FlexTable, flexTableDefaultRowHeight, Sortable, TextCell, TooltipCell } from 'src/components/table'
 import TooltipTrigger from 'src/components/TooltipTrigger'
 import { Ajax } from 'src/libs/ajax'
 import { bucketBrowserUrl } from 'src/libs/auth'
@@ -26,7 +26,7 @@ import UpdateUserCommentModal from 'src/pages/workspaces/workspace/jobHistory/Up
 import { wrapWorkspace } from 'src/pages/workspaces/workspace/WorkspaceContainer'
 
 
-const WORKFLOWS_TABLE_ROW_HEIGHT = FLEX_TABLE_DEFAULT_ROW_HEIGHT
+const workflowsTableRowHeight = flexTableDefaultRowHeight
 
 const SubmissionDetails = _.flow(
   forwardRefWithName('SubmissionDetails'),
@@ -245,12 +245,12 @@ const SubmissionDetails = _.flow(
         ])
       ]),
       // 48px is based on the default row height of FlexTable
-      div({ style: { flex: `1 0 ${(1 + _.min([filteredWorkflows.length, 5.5])) * WORKFLOWS_TABLE_ROW_HEIGHT}px` } }, [
+      div({ style: { flex: `1 0 ${(1 + _.min([filteredWorkflows.length, 5.5])) * workflowsTableRowHeight}px` } }, [
         h(AutoSizer, [({ width, height }) => h(FlexTable, {
           'aria-label': 'submission details',
           width, height, sort,
-          headerHeight: WORKFLOWS_TABLE_ROW_HEIGHT,
-          rowHeight: WORKFLOWS_TABLE_ROW_HEIGHT,
+          headerHeight: workflowsTableRowHeight,
+          rowHeight: workflowsTableRowHeight,
           rowCount: filteredWorkflows.length,
           noContentMessage: 'No matching workflows',
           columns: [


### PR DESCRIPTION
Follow on to https://github.com/DataBiosphere/terra-ui/pull/2840 based on [this review](https://github.com/DataBiosphere/terra-ui/pull/2840#discussion_r816258205).

Use constants to link the row height for the workflows table and the row height used to calculate the flex basis of the table's container.