### PR TITLE
[IA-2172] Added links to copy image url and for image changelogs

### DIFF
--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -634,7 +634,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
     }
   }
 
-  const copyImageLinkTooltipText = 'Copy the image version of the runtime'
+  const copyImageLinkTooltipText = 'Copy the image version'
   const isTerraSupported = runtime => (!runtime.isCommunity && !(getToolForImage(runtime.id) === tools.RStudio.label) && !(runtime.id.includes('legacy')))
 
   const getLocationTooltip = (computeExists, bucketLocation) => Utils.cond(

--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -2,7 +2,7 @@ import _ from 'lodash/fp'
 import { Fragment, useState } from 'react'
 import { b, br, code, div, fieldset, h, label, legend, li, p, span, strong, ul } from 'react-hyperscript-helpers'
 import {
-  ButtonOutline, ButtonPrimary, GroupedSelect, IdContainer, LabeledCheckbox, Link, Select, spinnerOverlay, WarningTitle
+  ButtonOutline, ButtonPrimary, ClipboardButton, GroupedSelect, IdContainer, LabeledCheckbox, Link, Select, spinnerOverlay, WarningTitle
 } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import { ImageDepViewer } from 'src/components/ImageDepViewer'
@@ -547,7 +547,14 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
 
   const makeImageInfo = style => div({ style: { whiteSpace: 'pre', ...style } }, [
     div({ style: Style.proportionalNumbers }, ['Updated: ', updated ? Utils.makeStandardDate(updated) : null]),
-    div(['Version: ', version || null])
+    div([h(isTerraSupported(_.find({ image: selectedLeoImage }, leoImages)) ? Link : span, { href: `https://github.com/DataBiosphere/terra-docker/blob/master/${_.find({ image: selectedLeoImage }, leoImages)?.id }/CHANGELOG.md`, ...Utils.newTabLinkProps }, [
+      'Version: ', version || null
+    ]), h(ClipboardButton, {
+      text: selectedLeoImage,
+      style: { marginLeft: '0.5rem' },
+      tooltip: copyImageLinkTooltipText
+    })
+    ])
   ])
 
   const sendCloudEnvironmentMetrics = () => {
@@ -623,6 +630,9 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
       return computeConfig.computeRegion !== location
     }
   }
+
+  const copyImageLinkTooltipText = 'Copy the image version of the runtime'
+  const isTerraSupported = (runtime) => (!runtime.isCommunity && !(getToolForImage(runtime.id) === tools.RStudio.label) && !(runtime.id.includes('legacy')))
 
   const getLocationTooltip = (computeExists, bucketLocation) => Utils.cond(
     [computeExists,
@@ -1516,7 +1526,11 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
               div({ style: { fontSize: 16, fontWeight: 600 } }, ['Use default environment']),
               ul({ style: { paddingLeft: '1rem', marginBottom: 0, lineHeight: 1.5 } }, [
                 li([
-                  div([packageLabel]),
+                  div([packageLabel, h(ClipboardButton, {
+                    text: selectedLeoImage,
+                    style: { marginLeft: '0.5rem' },
+                    tooltip: copyImageLinkTooltipText
+                  })]),
                   h(Link, { onClick: () => setViewMode('packages') }, ['What’s installed on this environment?'])
                 ]),
                 li({ style: { marginTop: '1rem' } }, [

--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -547,17 +547,15 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
 
   const makeImageInfo = style => div({ style: { whiteSpace: 'pre', ...style } }, [
     div({ style: Style.proportionalNumbers }, ['Updated: ', updated ? Utils.makeStandardDate(updated) : null]),
-    div([h(isTerraSupported(_.find({ image: selectedLeoImage }, leoImages)) ? Link : span,
-      {
-        href: getChangelogUrl(_.find({ image: selectedLeoImage }, leoImages)),
-        ...Utils.newTabLinkProps
-      }, [
-        'Version: ', version || null
-      ]), h(ClipboardButton, {
+    div(h(Link, {
+      disabled: !isTerraSupported(_.find({ image: selectedLeoImage }, leoImages).isCommunity, _.find({ image: selectedLeoImage }, leoImages).id),
+      href: getChangelogUrl(_.find({ image: selectedLeoImage }, leoImages)),
+      ...Utils.newTabLinkProps
+    }, ['Version: ', version || null]), h(ClipboardButton, {
       text: selectedLeoImage,
       style: { marginLeft: '0.5rem' },
-      tooltip: copyImageLinkTooltipText
-    })])
+      tooltip: 'Copy the image version'
+    }))
   ])
 
   const sendCloudEnvironmentMetrics = () => {
@@ -1533,7 +1531,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
                   div([packageLabel, h(ClipboardButton, {
                     text: selectedLeoImage,
                     style: { marginLeft: '0.5rem' },
-                    tooltip: copyImageLinkTooltipText
+                    tooltip: 'Copy the image version'
                   })]),
                   h(Link, { onClick: () => setViewMode('packages') }, ['What’s installed on this environment?'])
                 ]),

--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -551,8 +551,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
       href: getChangelogUrl(_.find({ image: selectedLeoImage }, leoImages)),
       disabled: !isTerraSupported(_.find({ image: selectedLeoImage }, leoImages)),
       ...Utils.newTabLinkProps
-    },
-    ['Version: ', version || null]),
+    }, ['Version: ', version || null]),
     h(ClipboardButton, {
       text: selectedLeoImage,
       style: { marginLeft: '0.5rem' },

--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -549,7 +549,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
     div({ style: Style.proportionalNumbers }, ['Updated: ', updated ? Utils.makeStandardDate(updated) : null]),
     div([h(isTerraSupported(_.find({ image: selectedLeoImage }, leoImages)) ? Link : span,
       {
-        href: `https://github.com/DataBiosphere/terra-docker/blob/master/${_.find({ image: selectedLeoImage }, leoImages)?.id}/CHANGELOG.md`,
+        href: getChangelogUrl(_.find({ image: selectedLeoImage }, leoImages)),
         ...Utils.newTabLinkProps
       }, [
         'Version: ', version || null
@@ -635,7 +635,8 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
   }
 
   const copyImageLinkTooltipText = 'Copy the image version'
-  const isTerraSupported = runtime => (!runtime.isCommunity && !(getToolForImage(runtime.id) === tools.RStudio.label) && !(runtime.id.includes('legacy')))
+  const isTerraSupported = runtime => (!runtime.isCommunity && !(getToolForImage(runtime.id) === tools.RStudio.label))
+  const getChangelogUrl = runtime => `https://github.com/DataBiosphere/terra-docker/blob/master/${runtime.id.replace('_legacy', '')}/CHANGELOG.md`
 
   const getLocationTooltip = (computeExists, bucketLocation) => Utils.cond(
     [computeExists,

--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -547,15 +547,17 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
 
   const makeImageInfo = style => div({ style: { whiteSpace: 'pre', ...style } }, [
     div({ style: Style.proportionalNumbers }, ['Updated: ', updated ? Utils.makeStandardDate(updated) : null]),
-    div(h(Link, {
-      disabled: !isTerraSupported(_.find({ image: selectedLeoImage }, leoImages).isCommunity, _.find({ image: selectedLeoImage }, leoImages).id),
+    h(Link, {
       href: getChangelogUrl(_.find({ image: selectedLeoImage }, leoImages)),
+      disabled: !isTerraSupported(_.find({ image: selectedLeoImage }, leoImages)),
       ...Utils.newTabLinkProps
-    }, ['Version: ', version || null]), h(ClipboardButton, {
+    },
+    ['Version: ', version || null]),
+    h(ClipboardButton, {
       text: selectedLeoImage,
       style: { marginLeft: '0.5rem' },
       tooltip: 'Copy the image version'
-    }))
+    })
   ])
 
   const sendCloudEnvironmentMetrics = () => {
@@ -632,9 +634,8 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
     }
   }
 
-  const copyImageLinkTooltipText = 'Copy the image version'
-  const isTerraSupported = runtime => (!runtime.isCommunity && !(getToolForImage(runtime.id) === tools.RStudio.label))
-  const getChangelogUrl = runtime => `https://github.com/DataBiosphere/terra-docker/blob/master/${runtime.id.replace('_legacy', '')}/CHANGELOG.md`
+  const isTerraSupported = ({ isCommunity = false, id }) => !isCommunity && !(getToolForImage(id) === tools.RStudio.label)
+  const getChangelogUrl = ({ id }) => `https://github.com/DataBiosphere/terra-docker/blob/master/${_.replace('_legacy', '', id)}/CHANGELOG.md`
 
   const getLocationTooltip = (computeExists, bucketLocation) => Utils.cond(
     [computeExists,

--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -547,14 +547,17 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
 
   const makeImageInfo = style => div({ style: { whiteSpace: 'pre', ...style } }, [
     div({ style: Style.proportionalNumbers }, ['Updated: ', updated ? Utils.makeStandardDate(updated) : null]),
-    div([h(isTerraSupported(_.find({ image: selectedLeoImage }, leoImages)) ? Link : span, { href: `https://github.com/DataBiosphere/terra-docker/blob/master/${_.find({ image: selectedLeoImage }, leoImages)?.id }/CHANGELOG.md`, ...Utils.newTabLinkProps }, [
-      'Version: ', version || null
-    ]), h(ClipboardButton, {
+    div([h(isTerraSupported(_.find({ image: selectedLeoImage }, leoImages)) ? Link : span,
+      {
+        href: `https://github.com/DataBiosphere/terra-docker/blob/master/${_.find({ image: selectedLeoImage }, leoImages)?.id}/CHANGELOG.md`,
+        ...Utils.newTabLinkProps
+      }, [
+        'Version: ', version || null
+      ]), h(ClipboardButton, {
       text: selectedLeoImage,
       style: { marginLeft: '0.5rem' },
       tooltip: copyImageLinkTooltipText
-    })
-    ])
+    })])
   ])
 
   const sendCloudEnvironmentMetrics = () => {
@@ -632,7 +635,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
   }
 
   const copyImageLinkTooltipText = 'Copy the image version of the runtime'
-  const isTerraSupported = (runtime) => (!runtime.isCommunity && !(getToolForImage(runtime.id) === tools.RStudio.label) && !(runtime.id.includes('legacy')))
+  const isTerraSupported = runtime => (!runtime.isCommunity && !(getToolForImage(runtime.id) === tools.RStudio.label) && !(runtime.id.includes('legacy')))
 
   const getLocationTooltip = (computeExists, bucketLocation) => Utils.cond(
     [computeExists,

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -540,7 +540,7 @@ export const ClipboardButton = ({ text, onClick, children, ...props }) => {
   const [copied, setCopied] = useState(false)
   return h(Link, {
     ...props,
-    tooltip: copied ? 'Copied to clipboard' : 'Copy to clipboard',
+    tooltip: props?.tooltip ?? (copied ? 'Copied to clipboard' : 'Copy to clipboard'),
     onClick: _.flow(
       withErrorReporting('Error copying to clipboard'),
       Utils.withBusyState(setCopied)

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -539,8 +539,8 @@ export const WarningTitle = ({ children, iconSize = 36 }) => {
 export const ClipboardButton = ({ text, onClick, children, ...props }) => {
   const [copied, setCopied] = useState(false)
   return h(Link, {
+    tooltip: copied ? 'Copied to clipboard' : 'Copy to clipboard',
     ...props,
-    tooltip: props?.tooltip ?? (copied ? 'Copied to clipboard' : 'Copy to clipboard'),
     onClick: _.flow(
       withErrorReporting('Error copying to clipboard'),
       Utils.withBusyState(setCopied)


### PR DESCRIPTION
See [IA-2172](https://broadworkbench.atlassian.net/browse/IA-2172) for mockups and details

Changes:
- Added clipboard icon to ComputeModal to copy image url to clipboard (see screenshots for where)
- Clipboard icon has tooltip saying "Copy the image version of the runtime"
- Added links to github changelogs to version info for Terra maintained images

Testing:
- Tested locally by going through each environment config option to make sure that all links worked correctly and correct image url was copied

![Screen Shot 2022-03-02 at 2 39 00 PM](https://user-images.githubusercontent.com/97535660/156436861-d7844bc4-f1db-473d-9a98-0e963dd64874.png)
![Screen Shot 2022-03-02 at 2 39 17 PM](https://user-images.githubusercontent.com/97535660/156436892-a9f01eaf-0ef3-43dc-b1f7-24d4ab1a514d.png)
![Screen Shot 2022-03-02 at 2 39 31 PM](https://user-images.githubusercontent.com/97535660/156436921-128ebc2d-e132-4a67-bb5a-eee97791d4f7.png)

