### PR TITLE
[DC-257] Fixed "Link to new workspace" integration test being flakey

### DIFF
--- a/integration-tests/tests/link-to-new-workspace.js
+++ b/integration-tests/tests/link-to-new-workspace.js
@@ -25,9 +25,9 @@ const testLinkToNewWorkspaceFn = withUserToken(async ({ page, testUrl, token }) 
 
   const cleanupFn = async () => {
     try {
-      await page.evaluate((name, billingProject) => {
-        return window.Ajax().Workspaces.workspace(billingProject, name).delete()
-      }, `${newWorkspaceName}`, `${newWorkspaceBillingAccount}`)
+      await page.evaluate(async (name, billingProject) => {
+        return await window.Ajax().Workspaces.workspace(billingProject, name).delete()
+      }, newWorkspaceName, newWorkspaceBillingAccount)
     } catch (error) {
       return error
     }


### PR DESCRIPTION
I think I found the problem - Narrowed it down to the cleanup method, and the page.evaluate method. I think the problem is that the delete method was not being awaited on, and was possibly ending after the test was, causing issues.

At the very least, I am making this PR after running it locally 10 times without error. Here's to hoping it wasn't just weird timing issues!

To test, I ran it locally using
`yarn test-local link-to-new-workspace`