### PR TITLE
Upgrade dep prismjs [BW-1124]

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "outdated-browser-rework": "^3.0.1",
     "path-to-regexp": "^5.0.0",
     "pluralize": "^8.0.0",
-    "prismjs": "^1.25.0",
+    "prismjs": "^1.27.0",
     "prop-types": "^15.7.2",
     "qs": "^6.10.1",
     "react": "17.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12372,10 +12372,10 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"prismjs@npm:^1.25.0":
-  version: 1.25.0
-  resolution: "prismjs@npm:1.25.0"
-  checksum: 04d8eae9d1b26b76c350bc65621584c8f8cab80ace7da3953f8aef2f9a8dd4b4f71c1d15bc5c67f126ddc90cd5af613919dc1340589a6c57355bed86fa3ac010
+"prismjs@npm:^1.27.0":
+  version: 1.27.0
+  resolution: "prismjs@npm:1.27.0"
+  checksum: 85c7f4a3e999073502cc9e1882af01e3709706369ec254b60bff1149eda701f40d02512acab956012dc7e61cfd61743a3a34c1bd0737e8dbacd79141e5698bbc
   languageName: node
   linkType: hard
 
@@ -14982,7 +14982,7 @@ resolve@^2.0.0-next.3:
     outdated-browser-rework: ^3.0.1
     path-to-regexp: ^5.0.0
     pluralize: ^8.0.0
-    prismjs: ^1.25.0
+    prismjs: ^1.27.0
     prop-types: ^15.7.2
     qs: ^6.10.1
     react: 17.0.1


### PR DESCRIPTION
Dependabot suggests upgrading to `1.27.0` to fix a vulnerability. This is the newest available version.

<!--
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Thanks!
--!>
