### PR TITLE
Add first browser-based test for spend reports (WOR-142, WOR-179).

### DIFF
--- a/integration-tests/jest/billing-projects.integration-test.js
+++ b/integration-tests/jest/billing-projects.integration-test.js
@@ -1,0 +1,5 @@
+const { registerTest } = require('./jest-utils')
+const { testBillingSpendReport } = require('../tests/billing-projects')
+
+
+registerTest(testBillingSpendReport)

--- a/integration-tests/tests/billing-projects.js
+++ b/integration-tests/tests/billing-projects.js
@@ -21,7 +21,7 @@ class BillingProjectsPage {
       projectName: this.mockValues.ownedBillingProjectName,
       billingAccount: 'billingAccounts/fake-id', invalidBillingAccount: false, roles: ['Owner'], status: 'Ready'
     }]
-    const setAjaxMock = async () => {
+    const setAjaxOverrides = async () => {
       await this.testPage.evaluate((spendReturnResult, projectListResult) => {
         window.ajaxOverridesStore.set([
           {
@@ -43,7 +43,7 @@ class BillingProjectsPage {
         ])
       }, spendReturnResult, projectListResult)
     }
-    await setAjaxMock()
+    await setAjaxOverrides()
   }
 
   async visit() {

--- a/integration-tests/tests/billing-projects.js
+++ b/integration-tests/tests/billing-projects.js
@@ -3,7 +3,7 @@ const { click, clickable, dismissNotifications, findText, noSpinnersAfter, selec
 const { withUserToken } = require('../utils/terra-sa-utils')
 
 
-class BillingAccountPage {
+class BillingProjectsPage {
   constructor(testPage, testUrl) {
     this.testPage = testPage
     this.testUrl = testUrl
@@ -74,7 +74,7 @@ const testBillingSpendReportFn = withUserToken(async ({ page, testUrl, token }) 
   await dismissNotifications(page)
 
   // Interact with the Billing Page via mocked AJAX responses.
-  const billingPage = new BillingAccountPage(page, testUrl)
+  const billingPage = new BillingProjectsPage(page, testUrl)
   await billingPage.setAjaxMock({ ownedBillingProjectName: 'OwnedBillingProject', spendCost: '90.13' })
   await billingPage.visit()
   await billingPage.selectSpendReport()

--- a/integration-tests/tests/billing-projects.js
+++ b/integration-tests/tests/billing-projects.js
@@ -3,68 +3,54 @@ const { click, clickable, dismissNotifications, findText, noSpinnersAfter, selec
 const { withUserToken } = require('../utils/terra-sa-utils')
 
 
-class BillingProjectsPage {
-  constructor(testPage, testUrl) {
-    this.testPage = testPage
-    this.testUrl = testUrl
-    this.mockValues = {}
-  }
+const billingProjectsPage = (testPage, testUrl) => {
+  return {
+    visit: async () => await testPage.goto(`${testUrl}/#billing`),
 
-  async setAjaxMock(mockValues) {
-    this.mockValues = _.assign(this.mockValues, mockValues)
-    const spendReturnResult = {
-      spendSummary: {
-        cost: this.mockValues.spendCost, credits: '2.50', currency: 'USD', endTime: '2022-03-04T00:00:00.000Z', startTime: '2022-02-02T00:00:00.000Z'
+    selectSpendReport: async billingProjectName => {
+      await noSpinnersAfter(
+        testPage,
+        { action: () => click(testPage, clickable({ text: billingProjectName })) }
+      )
+      await click(testPage, clickable({ text: 'Spend report' }))
+    },
+
+    setSpendReportDays: async days => await select(testPage, 'Date range', `Last ${days} days`),
+
+    assertText: async expectedText => await findText(testPage, expectedText)
+  }
+}
+
+const setAjaxMockValues = async (testPage, ownedBillingProjectName, spendCost) => {
+  const spendReturnResult = {
+    spendSummary: {
+      cost: spendCost, credits: '2.50', currency: 'USD', endTime: '2022-03-04T00:00:00.000Z', startTime: '2022-02-02T00:00:00.000Z'
+    }
+  }
+  const projectListResult = [{
+    projectName: ownedBillingProjectName,
+    billingAccount: 'billingAccounts/fake-id', invalidBillingAccount: false, roles: ['Owner'], status: 'Ready'
+  }]
+  return await testPage.evaluate((spendReturnResult, projectListResult) => {
+    window.ajaxOverridesStore.set([
+      {
+        filter: { url: /api\/billing\/v2$/ },
+        fn: () => async () => { return new Response(JSON.stringify(projectListResult), { status: 200 }) }
+      },
+      {
+        filter: { url: /Alpha_Spend_Report_Users\/action\/use/ },
+        fn: () => async () => { return new Response(JSON.stringify(true), { status: 200 }) }
+      },
+      {
+        filter: { url: /api\/billing\/v2(.*)\/members$/ },
+        fn: () => async () => { return new Response('[]', { status: 200 }) }
+      },
+      {
+        filter: { url: /api\/billing(.*)\/spendReport(.*)/ },
+        fn: () => async () => { return new Response(JSON.stringify(spendReturnResult), { status: 200 }) }
       }
-    }
-    const projectListResult = [{
-      projectName: this.mockValues.ownedBillingProjectName,
-      billingAccount: 'billingAccounts/fake-id', invalidBillingAccount: false, roles: ['Owner'], status: 'Ready'
-    }]
-    const setAjaxOverrides = async () => {
-      await this.testPage.evaluate((spendReturnResult, projectListResult) => {
-        window.ajaxOverridesStore.set([
-          {
-            filter: { url: /api\/billing\/v2$/ },
-            fn: () => async () => { return new Response(JSON.stringify(projectListResult), { status: 200 }) }
-          },
-          {
-            filter: { url: /Alpha_Spend_Report_Users\/action\/use/ },
-            fn: () => async () => { return new Response(JSON.stringify(true), { status: 200 }) }
-          },
-          {
-            filter: { url: /api\/billing\/v2(.*)\/members$/ },
-            fn: () => async () => { return new Response('[]', { status: 200 }) }
-          },
-          {
-            filter: { url: /api\/billing(.*)\/spendReport(.*)/ },
-            fn: () => async () => { return new Response(JSON.stringify(spendReturnResult), { status: 200 }) }
-          }
-        ])
-      }, spendReturnResult, projectListResult)
-    }
-    await setAjaxOverrides()
-  }
-
-  async visit() {
-    await this.testPage.goto(`${this.testUrl}/#billing`)
-  }
-
-  async selectSpendReport() {
-    await noSpinnersAfter(
-      this.testPage,
-      { action: () => click(this.testPage, clickable({ text: this.mockValues.ownedBillingProjectName })) }
-    )
-    await click(this.testPage, clickable({ text: 'Spend report' }))
-  }
-
-  async setSpendReportDays(days) {
-    await select(this.testPage, 'Date range', `Last ${days} days`)
-  }
-
-  async assertText(expectedText) {
-    await findText(this.testPage, expectedText)
-  }
+    ])
+  }, spendReturnResult, projectListResult)
 }
 
 const testBillingSpendReportFn = withUserToken(async ({ page, testUrl, token }) => {
@@ -74,12 +60,17 @@ const testBillingSpendReportFn = withUserToken(async ({ page, testUrl, token }) 
   await dismissNotifications(page)
 
   // Interact with the Billing Page via mocked AJAX responses.
-  const billingPage = new BillingProjectsPage(page, testUrl)
-  await billingPage.setAjaxMock({ ownedBillingProjectName: 'OwnedBillingProject', spendCost: '90.13' })
+  const billingProjectName = 'OwnedBillingProject'
+  await setAjaxMockValues(page, billingProjectName, '90.13')
+
+  // Select spend report and verify cost for default date ranges
+  const billingPage = billingProjectsPage(page, testUrl)
   await billingPage.visit()
-  await billingPage.selectSpendReport()
+  await billingPage.selectSpendReport(billingProjectName)
   await billingPage.assertText('$90.13')
-  await billingPage.setAjaxMock({ spendCost: '135' })
+
+  // Change the returned mock cost to mimic different date ranges
+  await setAjaxMockValues(page, billingProjectName, '135')
   await billingPage.setSpendReportDays(90)
   await billingPage.assertText('$135.00')
 })

--- a/integration-tests/tests/billing-projects.js
+++ b/integration-tests/tests/billing-projects.js
@@ -1,0 +1,92 @@
+const _ = require('lodash/fp')
+const { click, clickable, dismissNotifications, findText, noSpinnersAfter, select, signIntoTerra } = require('../utils/integration-utils')
+const { withUserToken } = require('../utils/terra-sa-utils')
+
+
+class BillingAccountPage {
+  constructor(testPage, testUrl) {
+    this.testPage = testPage
+    this.testUrl = testUrl
+    this.mockValues = {}
+  }
+
+  async setAjaxMock(mockValues) {
+    this.mockValues = _.assign(this.mockValues, mockValues)
+    const spendReturnResult = {
+      spendSummary: {
+        cost: this.mockValues.spendCost, credits: '2.50', currency: 'USD', endTime: '2022-03-04T00:00:00.000Z', startTime: '2022-02-02T00:00:00.000Z'
+      }
+    }
+    const projectListResult = [{
+      projectName: this.mockValues.ownedBillingProjectName,
+      billingAccount: 'billingAccounts/fake-id', invalidBillingAccount: false, roles: ['Owner'], status: 'Ready'
+    }]
+    const setAjaxMock = async () => {
+      await this.testPage.evaluate((spendReturnResult, projectListResult) => {
+        window.ajaxOverridesStore.set([
+          {
+            filter: { url: /api\/billing\/v2$/ },
+            fn: () => async () => { return new Response(JSON.stringify(projectListResult), { status: 200 }) }
+          },
+          {
+            filter: { url: /Alpha_Spend_Report_Users\/action\/use/ },
+            fn: () => async () => { return new Response(JSON.stringify(true), { status: 200 }) }
+          },
+          {
+            filter: { url: /api\/billing\/v2(.*)\/members$/ },
+            fn: () => async () => { return new Response('[]', { status: 200 }) }
+          },
+          {
+            filter: { url: /api\/billing(.*)\/spendReport(.*)/ },
+            fn: () => async () => { return new Response(JSON.stringify(spendReturnResult), { status: 200 }) }
+          }
+        ])
+      }, spendReturnResult, projectListResult)
+    }
+    await setAjaxMock()
+  }
+
+  async visit() {
+    await this.testPage.goto(`${this.testUrl}/#billing`)
+  }
+
+  async selectSpendReport() {
+    await noSpinnersAfter(
+      this.testPage,
+      { action: () => click(this.testPage, clickable({ text: this.mockValues.ownedBillingProjectName })) }
+    )
+    await click(this.testPage, clickable({ text: 'Spend report' }))
+  }
+
+  async setSpendReportDays(days) {
+    await select(this.testPage, 'Date range', `Last ${days} days`)
+  }
+
+  async assertText(expectedText) {
+    await findText(this.testPage, expectedText)
+  }
+}
+
+const testBillingSpendReportFn = withUserToken(async ({ page, testUrl, token }) => {
+  // Sign in. This portion of the test is not mocked.
+  await page.goto(testUrl)
+  await signIntoTerra(page, token)
+  await dismissNotifications(page)
+
+  // Interact with the Billing Page via mocked AJAX responses.
+  const billingPage = new BillingAccountPage(page, testUrl)
+  await billingPage.setAjaxMock({ ownedBillingProjectName: 'OwnedBillingProject', spendCost: '90.13' })
+  await billingPage.visit()
+  await billingPage.selectSpendReport()
+  await billingPage.assertText('$90.13')
+  await billingPage.setAjaxMock({ spendCost: '135' })
+  await billingPage.setSpendReportDays(90)
+  await billingPage.assertText('$135.00')
+})
+
+const testBillingSpendReport = {
+  name: 'billing-spend-report',
+  fn: testBillingSpendReportFn
+}
+
+module.exports = { testBillingSpendReport }

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -48,7 +48,7 @@ const getAnimatedDrawer = textContains => {
 // Note: isEnabled is not fully supported for native anchor and button elements (only aria-disabled is examined).
 const clickable = ({ text, textContains, isDescendant = false, isEnabled = true }) => {
   const checkEnabled = isEnabled === false ? '[@aria-disabled="true"]' : '[not(@aria-disabled="true")]'
-  const base = `(//a | //button | //*[@role="button"] | //*[@role="link"] | //*[@role="combobox"] | //*[@role="option"])${checkEnabled}`
+  const base = `(//a | //button | //*[@role="button"] | //*[@role="link"] | //*[@role="combobox"] | //*[@role="option"] | //*[@role="tab"])${checkEnabled}`
   return getClickablePath(base, text, textContains, isDescendant)
 }
 


### PR DESCRIPTION
This adds a browser-based test that is a hybrid of running against actual services and mocked AJAX responses. Specifically, I log a user in with existing integration utility methods, but then my interactions with the Billing Projects page to test the new "Spend report" (which is only accessible to users in the alpha group) are completely mocked.

This test passed 200 times with the flaky test runner.
