### PR TITLE
[PF-693] For alpha users, make all regions available for workspace bucket location

### DIFF
--- a/config/alpha.json
+++ b/config/alpha.json
@@ -24,5 +24,6 @@
     "apiKey": "AQEBBAEkx4iE2KxNyI7Wx08EwU1ycTM7E4FMSmaibbMUQxNU6uQvuAJt7fyABAtFYSYfgEE"
   },
   "tosUrlRoot": "https://us-central1-broad-workbench-tos-alpha.cloudfunctions.net/tos",
-  "alphaSpendReportGroup": "Alpha_Spend_Report_Users"
+  "alphaSpendReportGroup": "Alpha_Spend_Report_Users",
+  "alphaRegionalityGroup": "Alpha_Regionality_Users"
 }

--- a/config/dev.json
+++ b/config/dev.json
@@ -24,5 +24,6 @@
     "apiKey": "AQEBBAEkx4iE2KxNyI7Wx08EwU1ycTM7E4FMSmaibbMUQxNU6uQvuAJt7fyABAtFYSYfgEE"
   },
   "tosUrlRoot": "https://us-central1-broad-workbench-tos-dev.cloudfunctions.net/tos",
-  "alphaSpendReportGroup": "Alpha_Spend_Report_Users"
+  "alphaSpendReportGroup": "Alpha_Spend_Report_Users",
+  "alphaRegionalityGroup": "Alpha_Regionality_Users"
 }

--- a/config/fiab.json
+++ b/config/fiab.json
@@ -23,5 +23,6 @@
     "apiKey": "AQEBBAEkx4iE2KxNyI7Wx08EwU1ycTM7E4FMSmaibbMUQxNU6uQvuAJt7fyABAtFYSYfgEE"
   },
   "tosUrlRoot": "https://us-central1-broad-workbench-tos-dev.cloudfunctions.net/tos",
-  "alphaSpendReportGroup": "Alpha_Spend_Report_Users"
+  "alphaSpendReportGroup": "Alpha_Spend_Report_Users",
+  "alphaRegionalityGroup": "Alpha_Regionality_Users"
 }

--- a/config/perf.json
+++ b/config/perf.json
@@ -24,5 +24,6 @@
     "apiKey": "AQEBBAEkx4iE2KxNyI7Wx08EwU1ycTM7E4FMSmaibbMUQxNU6uQvuAJt7fyABAtFYSYfgEE"
   },
   "tosUrlRoot": "https://us-central1-broad-workbench-tos-perf.cloudfunctions.net/tos",
-  "alphaSpendReportGroup": "Alpha_Spend_Report_Users"
+  "alphaSpendReportGroup": "Alpha_Spend_Report_Users",
+  "alphaRegionalityGroup": "Alpha_Regionality_Users"
 }

--- a/config/prod.json
+++ b/config/prod.json
@@ -22,5 +22,6 @@
     "apiKey": "AQEBBAEGP2gTM2pIdJAQOIeNrm8dcTM7E4FMSmaibbMUQxNU6qy6nLPOBK8QfSvPFSsX8PQ"
   },
   "tosUrlRoot": "https://us-central1-broad-workbench-tos-prod.cloudfunctions.net/tos",
-  "alphaSpendReportGroup": "Alpha_Spend_Report_Users"
+  "alphaSpendReportGroup": "Alpha_Spend_Report_Users",
+  "alphaRegionalityGroup": "Alpha_Regionality_Users"
 }

--- a/config/staging.json
+++ b/config/staging.json
@@ -23,5 +23,6 @@
     "apiKey": "AQEBBAEkx4iE2KxNyI7Wx08EwU1ycTM7E4FMSmaibbMUQxNU6uQvuAJt7fyABAtFYSYfgEE"
   },
   "tosUrlRoot": "https://us-central1-broad-workbench-tos-staging.cloudfunctions.net/tos",
-  "alphaSpendReportGroup": "Alpha_Spend_Report_Users"
+  "alphaSpendReportGroup": "Alpha_Spend_Report_Users",
+  "alphaRegionalityGroup": "Alpha_Regionality_Users"
 }

--- a/src/components/NewWorkspaceModal.js
+++ b/src/components/NewWorkspaceModal.js
@@ -71,7 +71,7 @@ const NewWorkspaceModal = withDisplayName('NewWorkspaceModal', ({
     ...(requiredAuthDomain ? [requiredAuthDomain] : [])
   ])
 
-  const loadAlphaRegionalityUser = reportErrorAndRethrow('Error loading user group membership')(async () => {
+  const loadAlphaRegionalityUser = reportErrorAndRethrow('Error loading regionality group membership')(async () => {
     setIsAlphaRegionalityUser(await Ajax(signal).Groups.group(getConfig().alphaRegionalityGroup).isMember())
   })
 

--- a/src/components/NewWorkspaceModal.js
+++ b/src/components/NewWorkspaceModal.js
@@ -6,11 +6,12 @@ import { icon } from 'src/components/icons'
 import { TextArea, ValidatedInput } from 'src/components/input'
 import Modal from 'src/components/Modal'
 import { InfoBox } from 'src/components/PopupTrigger'
-import { availableBucketRegions, getRegionInfo, isSupportedBucketLocation, locationTypes } from 'src/components/region-common'
+import { allRegions, availableBucketRegions, getRegionInfo, isSupportedBucketLocation, locationTypes } from 'src/components/region-common'
 import TooltipTrigger from 'src/components/TooltipTrigger'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
-import { withErrorReporting } from 'src/libs/error'
+import { getConfig } from 'src/libs/config'
+import { reportErrorAndRethrow, withErrorReporting } from 'src/libs/error'
 import Events from 'src/libs/events'
 import { FormLabel } from 'src/libs/forms'
 import * as Nav from 'src/libs/nav'
@@ -60,6 +61,7 @@ const NewWorkspaceModal = withDisplayName('NewWorkspaceModal', ({
   const [createError, setCreateError] = useState()
   const [bucketLocation, setBucketLocation] = useState(defaultLocation)
   const [sourceWorkspaceLocation, setSourceWorkspaceLocation] = useState(defaultLocation)
+  const [isAlphaRegionalityUser, setIsAlphaRegionalityUser] = useState(false)
   const signal = useCancellation()
 
 
@@ -68,6 +70,10 @@ const NewWorkspaceModal = withDisplayName('NewWorkspaceModal', ({
     ...(cloneWorkspace ? _.map('membersGroupName', cloneWorkspace.workspace.authorizationDomain) : []),
     ...(requiredAuthDomain ? [requiredAuthDomain] : [])
   ])
+
+  const loadAlphaRegionalityUser = reportErrorAndRethrow('Error loading user group membership')(async () => {
+    setIsAlphaRegionalityUser(await Ajax(signal).Groups.group(getConfig().alphaRegionalityGroup).isMember())
+  })
 
   const create = async () => {
     try {
@@ -132,6 +138,7 @@ const NewWorkspaceModal = withDisplayName('NewWorkspaceModal', ({
   // Lifecycle
   useOnMount(() => {
     loadData()
+    loadAlphaRegionalityUser()
   })
 
 
@@ -221,7 +228,7 @@ const NewWorkspaceModal = withDisplayName('NewWorkspaceModal', ({
           id,
           value: bucketLocation,
           onChange: ({ value }) => setBucketLocation(value),
-          options: _.sortBy('label', availableBucketRegions)
+          options: _.sortBy('label', isAlphaRegionalityUser ? allRegions : availableBucketRegions)
         })
       ])]),
       shouldShowDifferentRegionWarning() && div({ style: { ...warningStyle } }, [

--- a/src/components/region-common.js
+++ b/src/components/region-common.js
@@ -62,7 +62,7 @@ export const locationTypes = {
   default: 'multi-region'
 }
 
-const allRegions = [
+export const allRegions = [
   // In this list, us-east*, us-west*, northamerica-northeast2 and asia-northeast2 have purposefully been removed.
   // This is to avoid creating within-country silos of life sciences community data.
   // So for US, Canada and Japan, we are restricting to one region.


### PR DESCRIPTION
This makes all regions available as an option for workspace bucket location When a user is part of the Alpha group (named Alpha_Regionality_Users). When a user is NOT a part of the Alpha group, there is no change. This is a part of "Phase 3" of regionality - where [Phase 2](https://github.com/DataBiosphere/terra-ui/pull/2680) previously added Montreal as an available region. 

![image](https://user-images.githubusercontent.com/6879774/156847948-04c0ee9e-33bc-49f8-b540-a25e795e832c.png)
