### PR TITLE
[AJ-325] Updated banner for complete data import

### DIFF
--- a/src/components/ImportStatus.js
+++ b/src/components/ImportStatus.js
@@ -53,8 +53,9 @@ const ImportStatusItem = ({ job: { targetWorkspace, jobId }, onDone }) => {
     const successNotify = () => notify('success', 'Data imported successfully.', {
       message: h(Fragment, [
         p([`Data import to workspace "${namespace} / ${name}" is complete. Please refresh the Data view.`]),
-        p([`When data is imported from external sources, like PFB or TDR, prefixes ("pfb:" or "tdr:", respectively)
-            will be prepended to column names. Prefix values must be included in attribute references as described `,
+        p([`If data is imported from external sources like PFB or TDR, prefixes ("pfb:" or tdr:" respectively)
+        may be prepended to column names. If present, prefix values must be included in workflow configuration
+        attribute references as described `,
         h(Link, {
           'aria-label': 'Support article',
           href: 'https://support.terra.bio/hc/en-us/articles/360051722371-Data-table-attribute-namespace-support-pfb-prefix-#h_01ENT95Y0KM48QFRMJ44DEXS7S',


### PR DESCRIPTION
This PR adjusts the content of the banner displayed when users finish importing a snapshot-by-copy to a workspace. The rules regarding prefixing the column names are outdated, and the new message reflects the updated criteria. Tested locally in browser.