### PR TITLE
[AJ-234] Fixed support article link

### DIFF
--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -382,7 +382,7 @@ export const EntityUploader = ({ onSuccess, onDismiss, namespace, name, entityTy
           }, [' Create participant, sample, and pair associations']),
           h(Link, {
             style: { marginLeft: '1rem', verticalAlign: 'middle' },
-            href: 'https://software.broadinstitute.org/firecloud/documentation/article?id=10738',
+            href: 'https://support.terra.bio/hc/en-us/articles/360033913771-Understanding-entity-types-and-the-standard-genomic-data-model#h_01EN5PCAEDPX020T2EFGN8TJD6',
             ...Utils.newTabLinkProps
           }, ['Learn more ', icon('pop-out', { size: 12 })])
         ]),


### PR DESCRIPTION
In the Import Table Data menu in the Data tab, the `Learn More` link referencing the `Create participant, sample and pair associations` checkbox routed to the support homepage. The [updated link](https://support.terra.bio/hc/en-us/articles/360033913771-Understanding-entity-types-and-the-standard-genomic-data-model#h_01EN5PCAEDPX020T2EFGN8TJD6) now contains the relevant information and is anchored at the relevant header. Tested locally in browser.