### PR TITLE
[SU-19] Support for toggling workspace locks

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -723,6 +723,14 @@ const Workspaces = signal => ({
         return res.json()
       },
 
+      lock: async () => {
+        return await fetchRawls(`${root}/lock`, _.merge(authOpts(), { signal, method: 'PUT' }))
+      },
+
+      unlock: async () => {
+        return await fetchRawls(`${root}/unlock`, _.merge(authOpts(), { signal, method: 'PUT' }))
+      },
+
       listMethodConfigs: async (allRepos = true) => {
         const res = await fetchRawls(`${mcPath}?allRepos=${allRepos}`, _.merge(authOpts(), { signal }))
         return res.json()

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -319,7 +319,7 @@ const WorkspaceDashboard = _.flow(
         _.map(tag => {
           return span({ key: tag, style: styles.tag }, [
             tag,
-            Utils.canWrite(accessLevel) && h(Link, {
+            !Utils.editWorkspaceError(workspace) && h(Link, {
               tooltip: Utils.editWorkspaceError(workspace) || 'Remove tag',
               disabled: busy || Utils.editWorkspaceError(workspace),
               onClick: () => deleteTag(tag),

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -320,7 +320,7 @@ const WorkspaceDashboard = _.flow(
           return span({ key: tag, style: styles.tag }, [
             tag,
             Utils.canWrite(accessLevel) && h(Link, {
-              tooltip: 'Remove tag',
+              tooltip: Utils.editWorkspaceError(workspace) || 'Remove tag',
               disabled: busy || Utils.editWorkspaceError(workspace),
               onClick: () => deleteTag(tag),
               style: { marginLeft: '0.25rem', verticalAlign: 'middle', display: 'inline-block' }

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -320,8 +320,8 @@ const WorkspaceDashboard = _.flow(
           return span({ key: tag, style: styles.tag }, [
             tag,
             !Utils.editWorkspaceError(workspace) && h(Link, {
-              tooltip: Utils.editWorkspaceError(workspace) || 'Remove tag',
-              disabled: busy || Utils.editWorkspaceError(workspace),
+              tooltip: 'Remove tag',
+              disabled: busy,
               onClick: () => deleteTag(tag),
               style: { marginLeft: '0.25rem', verticalAlign: 'middle', display: 'inline-block' }
             }, [icon('times', { size: 14 })])

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -307,7 +307,7 @@ const WorkspaceDashboard = _.flow(
         ]),
         (busy || !tagsList) && spinner({ size: '1rem', style: { marginLeft: '0.5rem' } })
       ]),
-      Utils.canWrite(accessLevel) && div({ style: { marginBottom: '0.5rem' } }, [
+      Utils.canWrite(accessLevel) && !Utils.editWorkspaceError(workspace) && div({ style: { marginBottom: '0.5rem' } }, [
         h(WorkspaceTagSelect, {
           value: null,
           placeholder: 'Add a tag',
@@ -321,7 +321,7 @@ const WorkspaceDashboard = _.flow(
             tag,
             Utils.canWrite(accessLevel) && h(Link, {
               tooltip: 'Remove tag',
-              disabled: busy,
+              disabled: busy || Utils.editWorkspaceError(workspace),
               onClick: () => deleteTag(tag),
               style: { marginLeft: '0.25rem', verticalAlign: 'middle', display: 'inline-block' }
             }, [icon('times', { size: 14 })])

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -307,7 +307,7 @@ const WorkspaceDashboard = _.flow(
         ]),
         (busy || !tagsList) && spinner({ size: '1rem', style: { marginLeft: '0.5rem' } })
       ]),
-      Utils.canWrite(accessLevel) && !Utils.editWorkspaceError(workspace) && div({ style: { marginBottom: '0.5rem' } }, [
+      !Utils.editWorkspaceError(workspace) && div({ style: { marginBottom: '0.5rem' } }, [
         h(WorkspaceTagSelect, {
           value: null,
           placeholder: 'Add a tag',

--- a/src/pages/workspaces/workspace/LockWorkspaceModal.js
+++ b/src/pages/workspaces/workspace/LockWorkspaceModal.js
@@ -8,7 +8,6 @@ import { reportError } from 'src/libs/error'
 
 const LockWorkspaceModal = ({ workspace: { workspace: { namespace, name, isLocked } }, onDismiss, onSuccess }) => {
   const [locking, setLocking] = useState(false)
-  const [loading, setLoading] = useState(false)
   const titleText = isLocked ? 'Unlock Workspace' : 'Lock Workspace'
 
   const toggleWorkspaceLock = async () => {
@@ -33,7 +32,7 @@ const LockWorkspaceModal = ({ workspace: { workspace: { namespace, name, isLocke
     div(['Are you sure you want to lock the workspace ',
       span({ style: { fontWeight: 600, wordBreak: 'break-word' } }, name),
       '?']),
-    (locking || loading) && spinnerOverlay
+    locking && spinnerOverlay
   ])
 }
 

--- a/src/pages/workspaces/workspace/LockWorkspaceModal.js
+++ b/src/pages/workspaces/workspace/LockWorkspaceModal.js
@@ -1,0 +1,40 @@
+import { useState } from 'react'
+import { div, h, span } from 'react-hyperscript-helpers'
+import { ButtonPrimary, spinnerOverlay } from 'src/components/common'
+import Modal from 'src/components/Modal'
+import { Ajax } from 'src/libs/ajax'
+import { reportError } from 'src/libs/error'
+
+
+const LockWorkspaceModal = ({ workspace: { workspace: { namespace, name, isLocked } }, onDismiss, onSuccess }) => {
+  const [locking, setLocking] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const titleText = isLocked ? 'Unlock Workspace' : 'Lock Workspace'
+
+  const toggleWorkspaceLock = async () => {
+    try {
+      setLocking(true)
+      isLocked ? await Ajax().Workspaces.workspace(namespace, name).unlock() : await Ajax().Workspaces.workspace(namespace, name).lock()
+      onDismiss()
+      onSuccess()
+    } catch (error) {
+      reportError('Error toggling workspace lock', error)
+      setLocking(false)
+    }
+  }
+  return h(Modal, {
+    title: titleText,
+    onDismiss,
+    okButton: h(ButtonPrimary, {
+      onClick: toggleWorkspaceLock,
+      tooltip: titleText
+    }, titleText)
+  }, [
+    div(['Are you sure you want to lock the workspace ',
+      span({ style: { fontWeight: 600, wordBreak: 'break-word' } }, name),
+      '?']),
+    (locking || loading) && spinnerOverlay
+  ])
+}
+
+export default LockWorkspaceModal

--- a/src/pages/workspaces/workspace/LockWorkspaceModal.js
+++ b/src/pages/workspaces/workspace/LockWorkspaceModal.js
@@ -3,7 +3,7 @@ import { div, h } from 'react-hyperscript-helpers'
 import { ButtonPrimary, spinnerOverlay } from 'src/components/common'
 import Modal from 'src/components/Modal'
 import { Ajax } from 'src/libs/ajax'
-import { reportError } from 'src/libs/error'
+import { withErrorReportingInModal } from 'src/libs/error'
 
 
 const LockWorkspaceModal = ({ workspace: { workspace: { namespace, name, isLocked } }, onDismiss, onSuccess }) => {

--- a/src/pages/workspaces/workspace/LockWorkspaceModal.js
+++ b/src/pages/workspaces/workspace/LockWorkspaceModal.js
@@ -8,7 +8,7 @@ import { reportError } from 'src/libs/error'
 
 const LockWorkspaceModal = ({ workspace: { workspace: { namespace, name, isLocked } }, onDismiss, onSuccess }) => {
   const [togglingLock, setTogglingLock] = useState(false)
-  const titleText = isLocked ? 'Unlock Workspace' : 'Lock Workspace'
+  const helpText = isLocked ? 'Unlock Workspace' : 'Lock Workspace'
 
   const toggleWorkspaceLock = async () => {
     try {
@@ -22,15 +22,15 @@ const LockWorkspaceModal = ({ workspace: { workspace: { namespace, name, isLocke
     }
   }
   return h(Modal, {
-    title: titleText,
+    title: helpText,
     onDismiss,
     okButton: h(ButtonPrimary, {
       onClick: toggleWorkspaceLock,
-      tooltip: titleText
-    }, titleText)
+      tooltip: helpText
+    }, helpText)
   }, [
     isLocked ?
-      div(['Are you sure you want to unlock this workspace? Collaborators will be able to modify the workspace while it is unlocked.']) :
+      div(['Are you sure you want to unlock this workspace? Collaborators will be able to modify the workspace after it is unlocked.']) :
       div(['Are you sure you want to lock this workspace? Collaborators will not be able to modify the workspace while it is locked.']),
     togglingLock && spinnerOverlay
   ])

--- a/src/pages/workspaces/workspace/LockWorkspaceModal.js
+++ b/src/pages/workspaces/workspace/LockWorkspaceModal.js
@@ -30,8 +30,10 @@ const LockWorkspaceModal = ({ workspace: { workspace: { namespace, name, isLocke
     }, helpText)
   }, [
     isLocked ?
-      div(['Are you sure you want to unlock this workspace? Collaborators will be able to modify the workspace after it is unlocked.']) :
-      div(['Are you sure you want to lock this workspace? Collaborators will not be able to modify the workspace while it is locked.']),
+      div(['Are you sure you want to unlock this workspace? ',
+        'Collaborators will be able to modify the workspace after it is unlocked.']) :
+      div(['Are you sure you want to lock this workspace? ',
+        'Collaborators will not be able to modify the workspace while it is locked.']),
     togglingLock && spinnerOverlay
   ])
 }

--- a/src/pages/workspaces/workspace/LockWorkspaceModal.js
+++ b/src/pages/workspaces/workspace/LockWorkspaceModal.js
@@ -10,17 +10,17 @@ const LockWorkspaceModal = ({ workspace: { workspace: { namespace, name, isLocke
   const [togglingLock, setTogglingLock] = useState(false)
   const helpText = isLocked ? 'Unlock Workspace' : 'Lock Workspace'
 
-  const toggleWorkspaceLock = async () => {
-    try {
-      setTogglingLock(true)
-      isLocked ? await Ajax().Workspaces.workspace(namespace, name).unlock() : await Ajax().Workspaces.workspace(namespace, name).lock()
-      onDismiss()
-      onSuccess()
-    } catch (error) {
-      reportError('Error toggling workspace lock', error)
-      setTogglingLock(false)
-    }
+  const onFailureDismiss = () => {
+    setTogglingLock(false)
+    onDismiss()
   }
+
+  const toggleWorkspaceLock = withErrorReportingInModal('Error toggling workspace lock', onFailureDismiss, async () => {
+    setTogglingLock(true)
+    isLocked ? await Ajax().Workspaces.workspace(namespace, name).unlock() : await Ajax().Workspaces.workspace(namespace, name).lock()
+    onDismiss()
+    onSuccess()
+  })
   return h(Modal, {
     title: helpText,
     onDismiss,

--- a/src/pages/workspaces/workspace/LockWorkspaceModal.js
+++ b/src/pages/workspaces/workspace/LockWorkspaceModal.js
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { div, h, span } from 'react-hyperscript-helpers'
+import { div, h } from 'react-hyperscript-helpers'
 import { ButtonPrimary, spinnerOverlay } from 'src/components/common'
 import Modal from 'src/components/Modal'
 import { Ajax } from 'src/libs/ajax'
@@ -7,18 +7,18 @@ import { reportError } from 'src/libs/error'
 
 
 const LockWorkspaceModal = ({ workspace: { workspace: { namespace, name, isLocked } }, onDismiss, onSuccess }) => {
-  const [locking, setLocking] = useState(false)
+  const [togglingLock, setTogglingLock] = useState(false)
   const titleText = isLocked ? 'Unlock Workspace' : 'Lock Workspace'
 
   const toggleWorkspaceLock = async () => {
     try {
-      setLocking(true)
+      setTogglingLock(true)
       isLocked ? await Ajax().Workspaces.workspace(namespace, name).unlock() : await Ajax().Workspaces.workspace(namespace, name).lock()
       onDismiss()
       onSuccess()
     } catch (error) {
       reportError('Error toggling workspace lock', error)
-      setLocking(false)
+      setTogglingLock(false)
     }
   }
   return h(Modal, {
@@ -29,10 +29,10 @@ const LockWorkspaceModal = ({ workspace: { workspace: { namespace, name, isLocke
       tooltip: titleText
     }, titleText)
   }, [
-    div(['Are you sure you want to lock the workspace ',
-      span({ style: { fontWeight: 600, wordBreak: 'break-word' } }, name),
-      '?']),
-    locking && spinnerOverlay
+    isLocked ?
+      div(['Are you sure you want to unlock this workspace? Collaborators will be able to modify the workspace while it is unlocked.']) :
+      div(['Are you sure you want to lock this workspace? Collaborators will not be able to modify the workspace while it is locked.']),
+    togglingLock && spinnerOverlay
   ])
 }
 

--- a/src/pages/workspaces/workspace/LockWorkspaceModal.js
+++ b/src/pages/workspaces/workspace/LockWorkspaceModal.js
@@ -25,8 +25,7 @@ const LockWorkspaceModal = ({ workspace: { workspace: { namespace, name, isLocke
     title: helpText,
     onDismiss,
     okButton: h(ButtonPrimary, {
-      onClick: toggleWorkspaceLock,
-      tooltip: helpText
+      onClick: toggleWorkspaceLock
     }, helpText)
   }, [
     isLocked ?

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -72,7 +72,7 @@ const WorkspaceTabs = ({
 
 const WorkspaceContainer = ({
   namespace, name, breadcrumbs, topBarContent, title, activeTab, showTabBar = true, refresh, refreshRuntimes, workspace,
-  runtimes, persistentDisks, appDataDisks, apps, refreshApps, location, locationType, children
+  refreshWorkspace, runtimes, persistentDisks, appDataDisks, apps, refreshApps, location, locationType, children
 }) => {
   const [deletingWorkspace, setDeletingWorkspace] = useState(false)
   const [cloningWorkspace, setCloningWorkspace] = useState(false)
@@ -138,8 +138,8 @@ const WorkspaceContainer = ({
     }),
     togglingWorkspaceLock && h(LockWorkspaceModal, {
       workspace,
-      onDismiss: () => setTogglingWorkspaceLock(false)
-//      onSuccess: ({ namespace, name }) => Nav.goToPath('workspace-dashboard', { namespace, name })
+      onDismiss: () => setTogglingWorkspaceLock(false),
+      onSuccess: () => refreshWorkspace()
     }),
     sharingWorkspace && h(ShareWorkspaceModal, {
       workspace,
@@ -332,7 +332,7 @@ export const wrapWorkspace = ({ breadcrumbs, activeTab, title, topBarContent, sh
       return h(FooterWrapper, [h(TopBar), h(WorkspaceAccessError)])
     } else {
       return h(WorkspaceContainer, {
-        namespace, name, activeTab, showTabBar, workspace, runtimes, persistentDisks, appDataDisks, apps, refreshApps, location, locationType,
+        namespace, name, activeTab, showTabBar, workspace, refreshWorkspace, runtimes, persistentDisks, appDataDisks, apps, refreshApps, location, locationType,
         title: _.isFunction(title) ? title(props) : title,
         breadcrumbs: breadcrumbs(props),
         topBarContent: topBarContent && topBarContent({ workspace, ...props }),

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -371,7 +371,7 @@ export const WorkspaceMenuTrigger = ({ children, canShare, isLocked, namespace, 
       }, [makeMenuIcon('share'), 'Share']),
       h(MenuButton, {
         disabled: !isOwner,
-        tooltip: !isOwner && 'You have not been granted permission to toggle the lock for this workspace',
+        tooltip: !isOwner && ['You have not been granted permission to ', isLocked ? 'unlock' : 'lock', ' this workspace'],
         tooltipSide: 'left',
         onClick: () => setTogglingWorkspaceLock(true)
       }, isLocked ? [makeMenuIcon('unlock'), 'Unlock'] : [makeMenuIcon('lock'), 'Lock']),

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -110,8 +110,8 @@ const WorkspaceContainer = ({
       })
     ]),
     showTabBar && h(WorkspaceTabs, {
-      namespace, name, activeTab, refresh, workspace, deletingWorkspace, setDeletingWorkspace, cloningWorkspace, setCloningWorkspace,
-      sharingWorkspace, setSharingWorkspace, togglingWorkspaceLock, setTogglingWorkspaceLock
+      namespace, name, activeTab, refresh, workspace, setDeletingWorkspace, setCloningWorkspace,
+      setSharingWorkspace, setTogglingWorkspaceLock
     }),
     div({ role: 'main', style: Style.elements.pageContentContainer },
 

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -360,7 +360,7 @@ export const wrapWorkspace = ({ breadcrumbs, activeTab, title, topBarContent, sh
   return withDisplayName('wrapWorkspace', Wrapper)
 }
 
-export const WorkspaceMenuTrigger = ({ children, canShare, isLocked, namespace, name, isOwner, setCloningWorkspace, setSharingWorkspace, setDeletingWorkspace, setTogglingWorkspaceLock }) => h(
+export const WorkspaceMenuTrigger = ({ children, canShare, isLocked, isOwner, setCloningWorkspace, setSharingWorkspace, setDeletingWorkspace, setTogglingWorkspaceLock }) => h(
   MenuTrigger, {
     closeOnClick: true,
     'aria-label': 'Workspace menu',

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -85,7 +85,8 @@ const WorkspaceContainer = ({
         div({ style: Style.noWrapEllipsis }, breadcrumbs),
         h2({ style: Style.breadcrumb.textUnderBreadcrumb }, [
           title || `${namespace}/${name}`,
-          workspace && !Utils.canWrite(workspace.accessLevel) && span({ style: { paddingLeft: '0.5rem', color: colors.dark(0.85) } }, '(read only)')
+          workspace && !Utils.canWrite(workspace.accessLevel) && span({ style: { paddingLeft: '0.5rem', color: colors.dark(0.85) } }, '(read only)'),
+          workspace && workspace.workspace.isLocked && span({ style: { paddingLeft: '0.5rem', color: colors.dark(0.85) } }, '(locked)')
         ])
       ]),
       topBarContent,

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -38,8 +38,7 @@ const navIconProps = {
 
 const WorkspaceTabs = ({
   namespace, name, workspace, activeTab, refresh,
-  deletingWorkspace, setDeletingWorkspace, cloningWorkspace, setCloningWorkspace,
-  sharingWorkspace, setSharingWorkspace, showLockWorkspaceModal, setShowLockWorkspaceModal
+  setDeletingWorkspace, setCloningWorkspace, setSharingWorkspace, setShowLockWorkspaceModal
 }) => {
   const isOwner = workspace && Utils.isOwner(workspace.accessLevel)
   const canShare = workspace?.canShare

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -39,7 +39,7 @@ const navIconProps = {
 const WorkspaceTabs = ({
   namespace, name, workspace, activeTab, refresh,
   deletingWorkspace, setDeletingWorkspace, cloningWorkspace, setCloningWorkspace,
-  sharingWorkspace, setSharingWorkspace, togglingWorkspaceLock, setTogglingWorkspaceLock
+  sharingWorkspace, setSharingWorkspace, showLockWorkspaceModal, setShowLockWorkspaceModal
 }) => {
   const isOwner = workspace && Utils.isOwner(workspace.accessLevel)
   const canShare = workspace?.canShare
@@ -64,7 +64,7 @@ const WorkspaceTabs = ({
     }, [
       isAnalysisTabVisible() ? h(Fragment) : h(WorkspaceMenuTrigger, {
         canShare, isLocked, namespace, name, isOwner, setCloningWorkspace, setSharingWorkspace,
-        setTogglingWorkspaceLock, setDeletingWorkspace
+        setShowLockWorkspaceModal, setDeletingWorkspace
       }, [
         h(Clickable, { 'aria-label': 'Workspace menu', ...navIconProps }, [icon('cardMenuIcon', { size: 27 })])
       ]
@@ -80,7 +80,7 @@ const WorkspaceContainer = ({
   const [deletingWorkspace, setDeletingWorkspace] = useState(false)
   const [cloningWorkspace, setCloningWorkspace] = useState(false)
   const [sharingWorkspace, setSharingWorkspace] = useState(false)
-  const [togglingWorkspaceLock, setTogglingWorkspaceLock] = useState(false)
+  const [showLockWorkspaceModal, setShowLockWorkspaceModal] = useState(false)
 
   return h(FooterWrapper, [
     h(TopBar, { title: 'Workspaces', href: Nav.getLink('workspaces') }, [
@@ -114,7 +114,7 @@ const WorkspaceContainer = ({
     ]),
     showTabBar && h(WorkspaceTabs, {
       namespace, name, activeTab, refresh, workspace, setDeletingWorkspace, setCloningWorkspace,
-      setSharingWorkspace, setTogglingWorkspaceLock
+      setSharingWorkspace, setShowLockWorkspaceModal
     }),
     div({ role: 'main', style: Style.elements.pageContentContainer },
 
@@ -126,7 +126,7 @@ const WorkspaceContainer = ({
           ]),
           workspace && h(ContextBar, {
             workspace, setDeletingWorkspace, setCloningWorkspace, setSharingWorkspace,
-            setTogglingWorkspaceLock, apps, appDataDisks, refreshApps,
+            setShowLockWorkspaceModal, apps, appDataDisks, refreshApps,
             runtimes, persistentDisks, refreshRuntimes, location, locationType
           })
         ])] : [children])),
@@ -140,9 +140,9 @@ const WorkspaceContainer = ({
       onDismiss: () => setCloningWorkspace(false),
       onSuccess: ({ namespace, name }) => Nav.goToPath('workspace-dashboard', { namespace, name })
     }),
-    togglingWorkspaceLock && h(LockWorkspaceModal, {
+    showLockWorkspaceModal && h(LockWorkspaceModal, {
       workspace,
-      onDismiss: () => setTogglingWorkspaceLock(false),
+      onDismiss: () => setShowLockWorkspaceModal(false),
       onSuccess: () => refreshWorkspace()
     }),
     sharingWorkspace && h(ShareWorkspaceModal, {
@@ -360,7 +360,7 @@ export const wrapWorkspace = ({ breadcrumbs, activeTab, title, topBarContent, sh
   return withDisplayName('wrapWorkspace', Wrapper)
 }
 
-export const WorkspaceMenuTrigger = ({ children, canShare, isLocked, isOwner, setCloningWorkspace, setSharingWorkspace, setDeletingWorkspace, setTogglingWorkspaceLock }) => h(
+export const WorkspaceMenuTrigger = ({ children, canShare, isLocked, isOwner, setCloningWorkspace, setSharingWorkspace, setDeletingWorkspace, setShowLockWorkspaceModal }) => h(
   MenuTrigger, {
     closeOnClick: true,
     'aria-label': 'Workspace menu',
@@ -376,7 +376,7 @@ export const WorkspaceMenuTrigger = ({ children, canShare, isLocked, isOwner, se
         disabled: !isOwner,
         tooltip: !isOwner && ['You have not been granted permission to ', isLocked ? 'unlock' : 'lock', ' this workspace'],
         tooltipSide: 'left',
-        onClick: () => setTogglingWorkspaceLock(true)
+        onClick: () => setShowLockWorkspaceModal(true)
       }, isLocked ? [makeMenuIcon('unlock'), 'Unlock'] : [makeMenuIcon('lock'), 'Lock']),
       h(MenuButton, {
         'aria-label': 'Workspace delete',

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -376,7 +376,7 @@ export const WorkspaceMenuTrigger = ({ children, canShare, isLocked, namespace, 
       }, isLocked ? [makeMenuIcon('unlock'), 'Unlock'] : [makeMenuIcon('lock'), 'Lock']),
       h(MenuButton, {
         'aria-label': 'Workspace delete',
-        disabled: !isOwner,
+        disabled: !isOwner || isLocked,
         tooltip: !isOwner && 'You must be an owner of this workspace or the underlying billing project',
         tooltipSide: 'left',
         onClick: () => setDeletingWorkspace(true)

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -370,7 +370,7 @@ export const WorkspaceMenuTrigger = ({ children, canShare, isLocked, namespace, 
       }, [makeMenuIcon('share'), 'Share']),
       h(MenuButton, {
         disabled: !isOwner,
-        tooltip: !isOwner && 'You have not been granted permission to lock or unlock this workspace',
+        tooltip: !isOwner && 'You have not been granted permission to toggle the lock for this workspace',
         tooltipSide: 'left',
         onClick: () => setTogglingWorkspaceLock(true)
       }, isLocked ? [makeMenuIcon('unlock'), 'Unlock'] : [makeMenuIcon('lock'), 'Lock']),

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -62,7 +62,10 @@ const WorkspaceTabs = ({
       tabNames: _.map('name', tabs),
       getHref: currentTab => Nav.getLink(_.find({ name: currentTab }, tabs).link, { namespace, name })
     }, [
-      isAnalysisTabVisible() ? h(Fragment) : h(WorkspaceMenuTrigger, { canShare, isLocked, namespace, name, isOwner, setCloningWorkspace, setSharingWorkspace, setTogglingWorkspaceLock, setDeletingWorkspace }, [
+      isAnalysisTabVisible() ? h(Fragment) : h(WorkspaceMenuTrigger, {
+        canShare, isLocked, namespace, name, isOwner, setCloningWorkspace, setSharingWorkspace,
+        setTogglingWorkspaceLock, setDeletingWorkspace
+      }, [
         h(Clickable, { 'aria-label': 'Workspace menu', ...navIconProps }, [icon('cardMenuIcon', { size: 27 })])
       ]
       )


### PR DESCRIPTION
This closes another feature gap between FireCloud UI and Terra UI. Previously users would have to lock their workspaces either via API or by going to FireCloud UI.

Interestingly, there was already a good amount of code in Terra UI to handle disabling certain actions if a workspace had been locked outside of Terra UI. This PR adds the ability to lock and unlock a workspace in the dashboard, and also disables the add/remove tags actions if the workspace is locked.

Lock:
<img width="170" alt="Screen Shot 2022-03-07 at 4 51 48 PM" src="https://user-images.githubusercontent.com/7257391/157124106-5432242d-9830-4473-b6cc-044e352cff54.png">
<img width="474" alt="Screen Shot 2022-03-07 at 4 51 54 PM" src="https://user-images.githubusercontent.com/7257391/157124115-d2190c3b-8fd5-49f2-bada-a441fae3677f.png">

Unlock:
<img width="168" alt="Screen Shot 2022-03-08 at 11 39 34 AM" src="https://user-images.githubusercontent.com/7257391/157283654-f7c1cf1c-4a3b-4ed6-84b1-34a13c1671f5.png">
<img width="470" alt="Screen Shot 2022-03-07 at 4 51 40 PM" src="https://user-images.githubusercontent.com/7257391/157124166-98a74063-799f-4d9c-9223-e814f3ce3938.png">

Locked workspace notice:
<img width="1077" alt="Screen Shot 2022-03-08 at 1 08 23 PM" src="https://user-images.githubusercontent.com/7257391/157299209-caea6b11-9efe-4304-93e5-0df22746528f.png">


<!--
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Thanks!
--!>

