### PR TITLE
AJ-313: handle stale metadata

### DIFF
--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -122,7 +122,7 @@ const DataTable = props => {
     // For the time being, the uniquness check MUST be case-insensitive (e.g. { sensitivity: 'accent' })
     // in order to prevent case-divergent columns from being displayed, as that would expose some other bugs
     const newAttrsForThisType = concatenateAttributeNames(entityMetadata[entityType]?.attributeNames, attrNamesFromResults)
-    if (newAttrsForThisType !== entityMetadata[entityType].attributeNames) {
+    if (!_.isEqual(newAttrsForThisType, entityMetadata[entityType].attributeNames)) {
       const newMetadata = _.cloneDeep(entityMetadata)
       newMetadata[entityType].attributeNames = newAttrsForThisType
       setEntityMetadata(newMetadata)

--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -3,7 +3,7 @@ import { Fragment, useEffect, useRef, useState } from 'react'
 import { div, h, span } from 'react-hyperscript-helpers'
 import { AutoSizer } from 'react-virtualized'
 import { Checkbox, Clickable, fixedSpinnerOverlay, Link } from 'src/components/common'
-import { DeleteEntityColumnModal, EditDataLink, EntityEditor, EntityRenamer, HeaderOptions, renderDataCell } from 'src/components/data/data-utils'
+import { concatenateAttributeNames, DeleteEntityColumnModal, EditDataLink, EntityEditor, EntityRenamer, HeaderOptions, renderDataCell } from 'src/components/data/data-utils'
 import { icon } from 'src/components/icons'
 import { ConfirmedSearchInput } from 'src/components/input'
 import Modal from 'src/components/Modal'
@@ -116,16 +116,17 @@ const DataTable = props => {
           { filterTerms: activeTextFilter })
       }))
     // find all the unique attribute names contained in the current page of results
-    const allAttrNames = _.uniq(_.flatMap(_.keys, _.map('attributes', results)))
+    const attrNamesFromResults = _.uniq(_.flatMap(_.keys, _.map('attributes', results)))
     // add any attribute names from the current page of results to those found in metadata.
     // This allows for the stale metadata (e.g. the metadata cache is out of date).
     // For the time being, the uniquness check MUST be case-insensitive (e.g. { sensitivity: 'accent' })
     // in order to prevent case-divergent columns from being displayed, as that would expose some other bugs
-    const newAttrsForThisType = _.uniqWith((left, right) => !left.localeCompare(right, undefined, { sensitivity: 'accent' }),
-      _.concat(entityMetadata[entityType].attributeNames, allAttrNames)).sort()
-    const newMetadata = _.cloneDeep(entityMetadata)
-    newMetadata[entityType].attributeNames = newAttrsForThisType
-    setEntityMetadata(newMetadata)
+    const newAttrsForThisType = concatenateAttributeNames(entityMetadata[entityType]?.attributeNames, attrNamesFromResults)
+    if (newAttrsForThisType !== entityMetadata[entityType].attributeNames) {
+      const newMetadata = _.cloneDeep(entityMetadata)
+      newMetadata[entityType].attributeNames = newAttrsForThisType
+      setEntityMetadata(newMetadata)
+    }
     setEntities(results)
     setFilteredCount(filteredCount)
     setTotalRowCount(unfilteredCount)

--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -123,9 +123,7 @@ const DataTable = props => {
     // in order to prevent case-divergent columns from being displayed, as that would expose some other bugs
     const newAttrsForThisType = concatenateAttributeNames(entityMetadata[entityType]?.attributeNames, attrNamesFromResults)
     if (!_.isEqual(newAttrsForThisType, entityMetadata[entityType].attributeNames)) {
-      const newMetadata = _.cloneDeep(entityMetadata)
-      newMetadata[entityType].attributeNames = newAttrsForThisType
-      setEntityMetadata(newMetadata)
+      setEntityMetadata(_.set([entityType, 'attributeNames'], newAttrsForThisType))
     }
     setEntities(results)
     setFilteredCount(filteredCount)

--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -49,7 +49,7 @@ const displayData = ({ itemsType, items }) => {
 
 const DataTable = props => {
   const {
-    entityType, entityMetadata, workspaceId, googleProject, workspaceId: { namespace, name },
+    entityType, initialEntityMetadata, workspaceId, googleProject, workspaceId: { namespace, name },
     onScroll, initialX, initialY,
     selectionModel: { selected, setSelected },
     childrenBefore,
@@ -68,6 +68,7 @@ const DataTable = props => {
   const [entities, setEntities] = useState()
   const [filteredCount, setFilteredCount] = useState(0)
   const [totalRowCount, setTotalRowCount] = useState(0)
+  const [entityMetadata, setEntityMetadata] = useState(initialEntityMetadata)
 
   const stateHistory = firstRender ? StateHistory.get() : {}
   const [itemsPerPage, setItemsPerPage] = useState(stateHistory.itemsPerPage || 100)
@@ -114,6 +115,17 @@ const DataTable = props => {
           { billingProject: googleProject, dataReference: snapshotName } :
           { filterTerms: activeTextFilter })
       }))
+    // find all the unique attribute names contained in the current page of results
+    const allAttrNames = _.uniq(_.flatMap(_.keys, _.map('attributes', results)))
+    // add any attribute names from the current page of results to those found in metadata.
+    // This allows for the stale metadata (e.g. the metadata cache is out of date).
+    // For the time being, the uniquness check MUST be case-insensitive (e.g. { sensitivity: 'accent' })
+    // in order to prevent case-divergent columns from being displayed, as that would expose some other bugs
+    const newAttrsForThisType = _.uniqWith((left, right) => !left.localeCompare(right, undefined, { sensitivity: 'accent' }),
+      _.concat(entityMetadata[entityType].attributeNames, allAttrNames)).sort()
+    const newMetadata = _.cloneDeep(entityMetadata)
+    newMetadata[entityType].attributeNames = newAttrsForThisType
+    setEntityMetadata(newMetadata)
     setEntities(results)
     setFilteredCount(filteredCount)
     setTotalRowCount(unfilteredCount)

--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -369,7 +369,7 @@ const EntitiesContent = ({
     h(Fragment, [
       h(DataTable, {
         persist: true, firstRender, refreshKey, editable: !snapshotName && !Utils.editWorkspaceError(workspace),
-        entityType: entityKey, entityMetadata, columnDefaults, googleProject, workspaceId: { namespace, name },
+        entityType: entityKey, initialEntityMetadata: entityMetadata, columnDefaults, googleProject, workspaceId: { namespace, name },
         onScroll: saveScroll, initialX, initialY,
         snapshotName,
         selectionModel: {

--- a/src/components/data/_tests/data-utils.test.js
+++ b/src/components/data/_tests/data-utils.test.js
@@ -1,0 +1,63 @@
+import { concatenateAttributeNames } from 'src/components/data/data-utils.js'
+
+
+describe('concatenateAttributeNames', () => {
+  it('works with two empty arrays', () => {
+    const attrList1 = []
+    const attrList2 = []
+    const expected = []
+    expect(concatenateAttributeNames(attrList1, attrList2)).toEqual(expected)
+  })
+  it('works with left empty array', () => {
+    const attrList1 = []
+    const attrList2 = ['aaa', 'bbb']
+    const expected = ['aaa', 'bbb']
+    expect(concatenateAttributeNames(attrList1, attrList2)).toEqual(expected)
+  })
+  it('works with right empty array', () => {
+    const attrList1 = ['aaa', 'bbb']
+    const attrList2 = []
+    const expected = ['aaa', 'bbb']
+    expect(concatenateAttributeNames(attrList1, attrList2)).toEqual(expected)
+  })
+  it('returns only unique attribute names', () => {
+    const attrList1 = ['namespace:aaa', 'namespace:bbb']
+    const attrList2 = ['namespace:bbb', 'namespace:ccc']
+    const expected = ['namespace:aaa', 'namespace:bbb', 'namespace:ccc']
+    expect(concatenateAttributeNames(attrList1, attrList2)).toEqual(expected)
+  })
+  it('works when arrays are equal', () => {
+    const attrList1 = ['aaa', 'bbb', 'ccc', 'ddd']
+    const attrList2 = ['aaa', 'bbb', 'ccc', 'ddd']
+    const expected = ['aaa', 'bbb', 'ccc', 'ddd']
+    expect(concatenateAttributeNames(attrList1, attrList2)).toEqual(expected)
+  })
+  it('uniqueifies in a case-insensitive manner', () => {
+    const attrList1 = ['CASE']
+    const attrList2 = ['case', 'foo']
+    const expected = ['CASE', 'foo']
+    expect(concatenateAttributeNames(attrList1, attrList2)).toEqual(expected)
+  })
+  it('prefers the leftmost instance of a case-insensitive uniqification', () => {
+    // note that 'CASE' will sort earlier than 'case', so putting 'case' first in this
+    // test proves that we prefer the leftmost instance
+    const attrList1 = ['case']
+    const attrList2 = ['CASE', 'foo']
+    const expected = ['case', 'foo']
+    expect(concatenateAttributeNames(attrList1, attrList2)).toEqual(expected)
+  })
+  it('handles case divergence within a single array', () => {
+    // note that 'CASE' will sort earlier than 'case', so putting 'case' first in this
+    // test proves that we prefer the leftmost instance
+    const attrList1 = ['case', 'CASE', 'Case']
+    const attrList2 = ['CASE', 'foo']
+    const expected = ['case', 'foo']
+    expect(concatenateAttributeNames(attrList1, attrList2)).toEqual(expected)
+  })
+  it('sorts attribute names', () => {
+    const attrList1 = ['namespace:ccc', 'namespace:aaa', 'ddd']
+    const attrList2 = ['namespace:bbb', 'aaa']
+    const expected = ['aaa', 'ddd', 'namespace:aaa', 'namespace:bbb', 'namespace:ccc']
+    expect(concatenateAttributeNames(attrList1, attrList2)).toEqual(expected)
+  })
+})

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -777,3 +777,10 @@ export const HeaderOptions = ({ sort, field, onSort, isEntityName, beginDelete, 
 export const saveScroll = _.throttle(100, (initialX, initialY) => {
   StateHistory.update({ initialX, initialY })
 })
+
+// Accepts two arrays of attribute names. Concatenates, uniquifies, and sorts those attribute names, returning
+// the resultant array. Uniqification is case-insensitive but case-preserving, to mirror backend behavior of the
+// entity type metadata API. Uniqification prefers the leftmost attribute.
+export const concatenateAttributeNames = (attrList1, attrList2) => {
+  return _.uniqWith((left, right) => !left.localeCompare(right, undefined, { sensitivity: 'accent' }), _.concat(attrList1, attrList2)).sort()
+}

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -288,7 +288,7 @@ const BucketContent = _.flow(
       )
     ]),
     div({ style: { margin: '1rem -1rem 1rem -1rem', borderBottom: `1px solid ${colors.dark(0.25)}` } }),
-    div({ style: { flex: '1 1 0', overflow: 'auto' }}, [
+    div({ style: { flex: '1 1 0', overflow: 'auto' } }, [
       h(SimpleTable, {
         'aria-label': 'file browser',
         columns: [

--- a/src/pages/workspaces/workspace/workflows/DataStepContent.js
+++ b/src/pages/workspaces/workspace/workflows/DataStepContent.js
@@ -118,7 +118,7 @@ const DataStepContent = ({
             [chooseRootType, () => rootEntityType],
             [chooseSetType, () => entitySetType]
           ),
-          entityMetadata, googleProject, workspaceId: { namespace, name }, columnDefaults,
+          initialEntityMetadata: entityMetadata, googleProject, workspaceId: { namespace, name }, columnDefaults,
           selectionModel: {
             selected: selectedEntities, setSelected: setSelectedEntities
           }


### PR DESCRIPTION
Recent perf/scaling work has enabled - on a per-workspace feature-flag basis - caching for entity type metadata. This results in the possibility that metadata is stale.

The biggest UX impact of stale metadata we've discovered so far is missing columns from a data table. The use case is:
* start with a workspace that has one data table "participant"
* enable the "alwaysCacheAttributes" feature flag for this workspace
* upload a TSV to create a new "sample" table; this TSV has 10 columns in it
* navigate to the "sample" table, note that it only displays "sample_id" and no other columns

This happens because in the first ~2 minutes after the TSV upload, the cache is stale. Since the cache previously knew nothing about the "sample" table, it returns no attributeNames for this table.

This PR changes the behavior of the data table so that it inspects the current page of results, finds all the attributes in that page of results, and adds any attributes it finds in the results to the metadata. This should prevent stale cache from hiding columns that exist in the page of results.

Impact to end user:
* if the feature flag is not enabled (the default), no change in behavior
* if the feature flag *is* enabled, data tables are more resilient to stale cache

Tested by running locally and manually modifying the backend Rawls db's cache entries for my workspace to be missing some columns. Verified that those columns do not display before this PR, but do display after this PR.

**UPDATE:** I did the back end tweaking to set up a workspace to demonstrate this PR. LMK if you'd like me to add you to the workspace.
https://bvdp-saturn-dev.appspot.com/#workspaces/general-dev-billing-account/da-invalid-cache/data is missing entries in its cache for the "sample" type. It does not display the proper columns for samples.
https://pr-2-dot-bvdp-saturn-dev.appspot.com/#workspaces/general-dev-billing-account/da-invalid-cache/data (the PR site for this PR) does display the proper columns for samples.

Dev:
![Screenshot (4)](https://user-images.githubusercontent.com/6041577/157480611-47d7ce53-0bc1-4421-9143-6a0020117343.png)

PR Site:
![Screenshot (5)](https://user-images.githubusercontent.com/6041577/157480631-c5efa4a9-3556-46eb-8583-c59279ed8a90.png)

