### PR TITLE
Bug Fix: Version link causing error when ComputeModal not fully loaded

### DIFF
--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -546,14 +546,17 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
   }
 
   const makeImageInfo = style => {
-    const isTerraSupported = ({ isCommunity = false, id }) => !isCommunity && !(getToolForImage(id) === tools.RStudio.label)
-    const getChangelogUrl = ({ id }) => `https://github.com/DataBiosphere/terra-docker/blob/master/${_.replace('_legacy', '', id)}/CHANGELOG.md`
+    const selectedImage = _.find({ image: selectedLeoImage }, leoImages)
+    const shouldDisable = _.isEmpty(leoImages) ? true : selectedImage.isCommunity || getToolForImage(selectedImage.id) === tools.RStudio.label
+    const changelogUrl = _.isEmpty(leoImages) ?
+      '' :
+      `https://github.com/DataBiosphere/terra-docker/blob/master/${_.replace('_legacy', '', selectedImage.id)}/CHANGELOG.md`
 
     return div({ style: { whiteSpace: 'pre', ...style } }, [
       div({ style: Style.proportionalNumbers }, ['Updated: ', updated ? Utils.makeStandardDate(updated) : null]),
       h(Link, {
-        href: leoImages.length > 0 ? getChangelogUrl(_.find({ image: selectedLeoImage }, leoImages)) : '',
-        disabled: leoImages.length > 0 ? !isTerraSupported(_.find({ image: selectedLeoImage }, leoImages)) : true,
+        href: changelogUrl,
+        disabled: shouldDisable,
         ...Utils.newTabLinkProps
       }, ['Version: ', version || null]),
       h(ClipboardButton, {

--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -545,19 +545,24 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
         existingRuntime.masterMachineType !== desiredRuntime.masterMachineType)
   }
 
-  const makeImageInfo = style => div({ style: { whiteSpace: 'pre', ...style } }, [
-    div({ style: Style.proportionalNumbers }, ['Updated: ', updated ? Utils.makeStandardDate(updated) : null]),
-    h(Link, {
-      href: getChangelogUrl(_.find({ image: selectedLeoImage }, leoImages)),
-      disabled: !isTerraSupported(_.find({ image: selectedLeoImage }, leoImages)),
-      ...Utils.newTabLinkProps
-    }, ['Version: ', version || null]),
-    h(ClipboardButton, {
-      text: selectedLeoImage,
-      style: { marginLeft: '0.5rem' },
-      tooltip: 'Copy the image version'
-    })
-  ])
+  const makeImageInfo = style => {
+    const isTerraSupported = ({ isCommunity = false, id }) => !isCommunity && !(getToolForImage(id) === tools.RStudio.label)
+    const getChangelogUrl = ({ id }) => `https://github.com/DataBiosphere/terra-docker/blob/master/${_.replace('_legacy', '', id)}/CHANGELOG.md`
+
+    return div({ style: { whiteSpace: 'pre', ...style } }, [
+      div({ style: Style.proportionalNumbers }, ['Updated: ', updated ? Utils.makeStandardDate(updated) : null]),
+      h(Link, {
+        href: leoImages.length > 0 ? getChangelogUrl(_.find({ image: selectedLeoImage }, leoImages)) : '',
+        disabled: leoImages.length > 0 ? !isTerraSupported(_.find({ image: selectedLeoImage }, leoImages)) : true,
+        ...Utils.newTabLinkProps
+      }, ['Version: ', version || null]),
+      h(ClipboardButton, {
+        text: selectedLeoImage,
+        style: { marginLeft: '0.5rem' },
+        tooltip: 'Copy the image version'
+      })
+    ])
+  }
 
   const sendCloudEnvironmentMetrics = () => {
     const { runtime: desiredRuntime, persistentDisk: desiredPersistentDisk } = getDesiredEnvironmentConfig()
@@ -632,9 +637,6 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
       return computeConfig.computeRegion !== location
     }
   }
-
-  const isTerraSupported = ({ isCommunity = false, id }) => !isCommunity && !(getToolForImage(id) === tools.RStudio.label)
-  const getChangelogUrl = ({ id }) => `https://github.com/DataBiosphere/terra-docker/blob/master/${_.replace('_legacy', '', id)}/CHANGELOG.md`
 
   const getLocationTooltip = (computeExists, bucketLocation) => Utils.cond(
     [computeExists,


### PR DESCRIPTION
The root issue ended up being that the leoImages array was not fully loaded upon opening the modal, which caused the error. I added checks that the leoImages array is not empty before the id is checked, and moved the isTerraSupported and getChangelogUrl functions into the makeImageInfo function since this is the only place where those functions are used

Tested by:

- Checked that the version link was functional for all images while there was a runtime running, and also if there was not a runtime running
