### PR TITLE
[DC-241] Add mixpanel events for the Data Library page

### DIFF
--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -29,6 +29,7 @@ const eventsList = {
   catalogRequestAccess: 'catalog:requestAccess',
   catalogView: 'catalog:view',
   catalogWorkspaceLink: 'catalog:workspaceLink',
+  datasetLibraryBrowseData: 'library:browseData',
   notebookLaunch: 'notebook:launch',
   notebookRename: 'notebook:rename',
   notebookCopy: 'notebook:copy',

--- a/src/pages/library/Datasets.js
+++ b/src/pages/library/Datasets.js
@@ -109,9 +109,13 @@ const Participant = ({ logo, title, shortDescription, description, sizeText, mod
 
 const browseTooltip = 'Look for the Export to Terra icon to export data from this provider.'
 
-const captureEventOnClick = (datasetName) => {
+const captureEventMetrics = (eventName, metrics) => {
+  Ajax().Metrics.captureEvent(eventName, metrics)
+}
+
+const captureBrowseDataEvent = (datasetName) => {
   const eventName = `${Events.datasetLibraryBrowseData}`
-  Ajax().Metrics.captureEvent(eventName, {
+  captureEventMetrics(eventName, {
     datasetName: datasetName
   })
 }
@@ -127,7 +131,7 @@ const thousandGenomesHighCoverage = () => h(Participant, {
     'aria-label': 'Browse 1000 Genomes High Coverage data',
     tooltip: 'Visit the workspace',
     href: Nav.getLink('workspace-dashboard', { namespace: 'anvil-datastorage', name: '1000G-high-coverage-2019' }),
-    onClick: () => captureEventOnClick('1000G-high-coverage-2019')
+    onClick: () => captureBrowseDataEvent('1000G-high-coverage-2019')
   }, ['Browse data'])
 ])
 
@@ -146,7 +150,7 @@ const thousandGenomesLowCoverage = () => h(Participant, {
     'aria-label': 'Browse 1000 Genomes Low Coverage data',
     tooltip: browseTooltip,
     href: Nav.getLink('data-explorer-public', { dataset: '1000 Genomes' }),
-    onClick: () => captureEventOnClick('1000 Genomes')
+    onClick: () => captureBrowseDataEvent('1000 Genomes')
   }, ['Browse data'])
 ])
 
@@ -192,12 +196,12 @@ const amppd = () => h(Participant, {
     'aria-label': 'Browse AMP-PD Tier 1 data',
     style: { marginBottom: '1rem' },
     href: Nav.getLink('data-explorer-private', { dataset: 'AMP PD Clinical - 2020_v2release_1218' }),
-    onClick: () => captureEventOnClick('AMP PD Clinical - 2020_v2release_1218')
+    onClick: () => captureBrowseDataEvent('AMP PD Clinical - 2020_v2release_1218')
   }, ['Browse Tier 1 Data']),
   h(ButtonPrimary, {
     'aria-label': 'Browse AMP-PD Tier 2 data',
     href: Nav.getLink('data-explorer-private', { dataset: 'AMP PD - 2020_v2release_1218' }),
-    onClick: () => captureEventOnClick('AMP PD - 2020_v2release_1218')
+    onClick: () => captureBrowseDataEvent('AMP PD - 2020_v2release_1218')
   }, ['Browse Tier 2 Data'])
 ])
 
@@ -216,7 +220,7 @@ const baseline = () => h(Participant, {
   h(ButtonPrimary, {
     'aria-label': 'Browse Baseline Health Study data',
     href: Nav.getLink('data-explorer-private', { dataset: 'Baseline Health Study' }),
-    onClick: () => captureEventOnClick('Baseline Health Study')
+    onClick: () => captureBrowseDataEvent('Baseline Health Study')
   }, ['Browse Data'])
 ])
 
@@ -231,7 +235,7 @@ const ccdg = () => h(Participant, {
     'aria-label': 'Browse CCDG data',
     tooltip: browseTooltip,
     href: `${getConfig().firecloudUrlRoot}/?return=${returnParam()}&project=AnVIL CCDG&project=AnVIL CCDG CVD#library`,
-    onClick: () => captureEventOnClick('CCDG'),
+    onClick: () => captureBrowseDataEvent('CCDG'),
     ...Utils.newTabLinkProps
   }, ['Browse data'])
 ])
@@ -247,7 +251,7 @@ const cmg = () => h(Participant, {
     'aria-label': 'Browse CMG data',
     tooltip: browseTooltip,
     href: `${getConfig().firecloudUrlRoot}/?return=${returnParam()}&project=AnVIL CMG#library`,
-    onClick: () => captureEventOnClick('CMG'),
+    onClick: () => captureBrowseDataEvent('CMG'),
     ...Utils.newTabLinkProps
   }, ['Browse Data'])
 ])
@@ -267,7 +271,7 @@ const encode = () => h(Participant, {
     'aria-label': 'Browse ENCODE data',
     tooltip: browseTooltip,
     href: 'https://broad-gdr-encode.appspot.com/',
-    onClick: () => captureEventOnClick('ENCODE'),
+    onClick: () => captureBrowseDataEvent('ENCODE'),
     ...Utils.newTabLinkProps
   }, ['Browse Data'])
 ])
@@ -283,7 +287,7 @@ const fcDataLib = () => h(Participant, {
     'aria-label': 'Browse Broad Institute datasets',
     tooltip: 'Search for dataset workspaces',
     href: `${getConfig().firecloudUrlRoot}/?return=${returnParam()}#library`,
-    onClick: () => captureEventOnClick('Broad Institute Datasets'),
+    onClick: () => captureBrowseDataEvent('Broad Institute Datasets'),
     ...Utils.newTabLinkProps
   }, ['Browse Datasets'])
 ])
@@ -305,7 +309,7 @@ const framingham = () => h(Participant, {
     'aria-label': 'Browse Framingham Heart Study dataset',
     tooltip: browseTooltip,
     href: Nav.getLink('data-explorer-public', { dataset: 'Framingham Heart Study Teaching Dataset' }),
-    onClick: () => captureEventOnClick('Framingham Heart Study')
+    onClick: () => captureBrowseDataEvent('Framingham Heart Study')
   }, ['Browse data'])
 ])
 
@@ -332,13 +336,13 @@ const gp2 = () => h(Participant, {
     style: { marginBottom: '1rem' },
     tooltip: 'Visit the workspace',
     href: Nav.getLink('workspace-dashboard', { namespace: 'cardterra', name: 'GP2_Tier1' }),
-    onClick: () => captureEventOnClick('GP2 Tier 1 data'),
+    onClick: () => captureBrowseDataEvent('GP2 Tier 1 data'),
   }, ['Browse Tier 1 Data']),
   h(ButtonPrimary, {
     'aria-label': 'Browse GP2 Tier 2 data',
     tooltip: 'Visit the workspace',
     href: Nav.getLink('workspace-dashboard', { namespace: 'cardterra', name: 'GP2_Tier2' }),
-    onClick: () => captureEventOnClick('GP2 Tier 2 data')
+    onClick: () => captureBrowseDataEvent('GP2 Tier 2 data')
   }, ['Browse Tier 2 Data'])
 ])
 
@@ -353,7 +357,7 @@ const hca = () => h(Participant, {
     'aria-label': 'Browse Human Cell Atlas data',
     tooltip: 'Look for the Export Selected Data button to export data from this provider.',
     href: 'https://data.humancellatlas.org/explore/projects',
-    onClick: () => captureEventOnClick('Human Cell Atlas'),
+    onClick: () => captureBrowseDataEvent('Human Cell Atlas'),
     ...Utils.newTabLinkProps
   }, ['Browse Data'])
 ])
@@ -370,7 +374,7 @@ const nemo = () => h(Participant, {
     'aria-label': 'Browse Neuroscience Multi-Omic Archive data',
     tooltip: 'Look for the Export to Terra option in the Download Cart to export data.',
     href: 'http://portal.nemoarchive.org/',
-    onClick: () => captureEventOnClick('Nemo Archive'),
+    onClick: () => captureBrowseDataEvent('Nemo Archive'),
     ...Utils.newTabLinkProps
   }, ['Browse Data'])
 ])
@@ -387,7 +391,7 @@ const target = () => h(Participant, {
 }, [h(ButtonPrimary, {
   'aria-label': 'Browse TARGET data',
   href: `${getConfig().firecloudUrlRoot}/?return=${returnParam()}&project=TARGET#library`,
-  onClick: () => captureEventOnClick('TARGET'),
+  onClick: () => captureBrowseDataEvent('TARGET'),
   ...Utils.newTabLinkProps
 }, ['Browse Data'])])
 
@@ -407,7 +411,7 @@ const tcga = () => h(Participant, {
   h(ButtonPrimary, {
     'aria-label': 'Browse Cancer Genome Atlas data',
     href: `${getConfig().firecloudUrlRoot}/?return=${returnParam()}&project=TCGA#library`,
-    onClick: () => captureEventOnClick('Cancer Genome Atlas'),
+    onClick: () => captureBrowseDataEvent('Cancer Genome Atlas'),
     ...Utils.newTabLinkProps
   }, ['Browse Data'])
 ])
@@ -424,7 +428,7 @@ const topMed = () => h(Participant, {
     'aria-label': 'Browse TopMed data',
     tooltip: browseTooltip,
     href: 'https://gen3.biodatacatalyst.nhlbi.nih.gov/explorer',
-    onClick: () => captureEventOnClick('TopMed'),
+    onClick: () => captureBrowseDataEvent('TopMed'),
     ...Utils.newTabLinkProps
   }, ['Browse Data'])
 ])

--- a/src/pages/library/Datasets.js
+++ b/src/pages/library/Datasets.js
@@ -22,6 +22,8 @@ import topMedLogo from 'src/images/library/datasets/TopMed@2x.png'
 import colors from 'src/libs/colors'
 import { getConfig } from 'src/libs/config'
 import { returnParam } from 'src/libs/logos'
+import { Ajax } from 'src/libs/ajax'
+import Events from 'src/libs/events'
 import * as Nav from 'src/libs/nav'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
@@ -107,6 +109,12 @@ const Participant = ({ logo, title, shortDescription, description, sizeText, mod
 
 const browseTooltip = 'Look for the Export to Terra icon to export data from this provider.'
 
+const captureEventOnClick = (datasetName) => {
+  const eventName = `${Events.datasetLibraryBrowseData}`
+  Ajax().Metrics.captureEvent(eventName, {
+    datasetName: datasetName
+  })
+}
 
 const thousandGenomesHighCoverage = () => h(Participant, {
   logo: { src: thousandGenomesAnvil, alt: '1000 Genomes and AnVIL', height: '55%' },
@@ -118,7 +126,8 @@ const thousandGenomesHighCoverage = () => h(Participant, {
   h(ButtonPrimary, {
     'aria-label': 'Browse 1000 Genomes High Coverage data',
     tooltip: 'Visit the workspace',
-    href: Nav.getLink('workspace-dashboard', { namespace: 'anvil-datastorage', name: '1000G-high-coverage-2019' })
+    href: Nav.getLink('workspace-dashboard', { namespace: 'anvil-datastorage', name: '1000G-high-coverage-2019' }),
+    onClick: () => captureEventOnClick('1000G-high-coverage-2019')
   }, ['Browse data'])
 ])
 
@@ -136,7 +145,8 @@ const thousandGenomesLowCoverage = () => h(Participant, {
   h(ButtonPrimary, {
     'aria-label': 'Browse 1000 Genomes Low Coverage data',
     tooltip: browseTooltip,
-    href: Nav.getLink('data-explorer-public', { dataset: '1000 Genomes' })
+    href: Nav.getLink('data-explorer-public', { dataset: '1000 Genomes' }),
+    onClick: () => captureEventOnClick('1000 Genomes')
   }, ['Browse data'])
 ])
 
@@ -181,11 +191,13 @@ const amppd = () => h(Participant, {
   h(ButtonPrimary, {
     'aria-label': 'Browse AMP-PD Tier 1 data',
     style: { marginBottom: '1rem' },
-    href: Nav.getLink('data-explorer-private', { dataset: 'AMP PD Clinical - 2020_v2release_1218' })
+    href: Nav.getLink('data-explorer-private', { dataset: 'AMP PD Clinical - 2020_v2release_1218' }),
+    onClick: () => captureEventOnClick('AMP PD Clinical - 2020_v2release_1218')
   }, ['Browse Tier 1 Data']),
   h(ButtonPrimary, {
     'aria-label': 'Browse AMP-PD Tier 2 data',
-    href: Nav.getLink('data-explorer-private', { dataset: 'AMP PD - 2020_v2release_1218' })
+    href: Nav.getLink('data-explorer-private', { dataset: 'AMP PD - 2020_v2release_1218' }),
+    onClick: () => captureEventOnClick('AMP PD - 2020_v2release_1218')
   }, ['Browse Tier 2 Data'])
 ])
 
@@ -203,7 +215,8 @@ const baseline = () => h(Participant, {
 }, [
   h(ButtonPrimary, {
     'aria-label': 'Browse Baseline Health Study data',
-    href: Nav.getLink('data-explorer-private', { dataset: 'Baseline Health Study' })
+    href: Nav.getLink('data-explorer-private', { dataset: 'Baseline Health Study' }),
+    onClick: () => captureEventOnClick('Baseline Health Study')
   }, ['Browse Data'])
 ])
 
@@ -218,6 +231,7 @@ const ccdg = () => h(Participant, {
     'aria-label': 'Browse CCDG data',
     tooltip: browseTooltip,
     href: `${getConfig().firecloudUrlRoot}/?return=${returnParam()}&project=AnVIL CCDG&project=AnVIL CCDG CVD#library`,
+    onClick: () => captureEventOnClick('CCDG'),
     ...Utils.newTabLinkProps
   }, ['Browse data'])
 ])
@@ -233,6 +247,7 @@ const cmg = () => h(Participant, {
     'aria-label': 'Browse CMG data',
     tooltip: browseTooltip,
     href: `${getConfig().firecloudUrlRoot}/?return=${returnParam()}&project=AnVIL CMG#library`,
+    onClick: () => captureEventOnClick('CMG'),
     ...Utils.newTabLinkProps
   }, ['Browse Data'])
 ])
@@ -252,6 +267,7 @@ const encode = () => h(Participant, {
     'aria-label': 'Browse ENCODE data',
     tooltip: browseTooltip,
     href: 'https://broad-gdr-encode.appspot.com/',
+    onClick: () => captureEventOnClick('ENCODE'),
     ...Utils.newTabLinkProps
   }, ['Browse Data'])
 ])
@@ -267,6 +283,7 @@ const fcDataLib = () => h(Participant, {
     'aria-label': 'Browse Broad Institute datasets',
     tooltip: 'Search for dataset workspaces',
     href: `${getConfig().firecloudUrlRoot}/?return=${returnParam()}#library`,
+    onClick: () => captureEventOnClick('Broad Institute Datasets'),
     ...Utils.newTabLinkProps
   }, ['Browse Datasets'])
 ])
@@ -287,7 +304,8 @@ const framingham = () => h(Participant, {
   h(ButtonPrimary, {
     'aria-label': 'Browse Framingham Heart Study dataset',
     tooltip: browseTooltip,
-    href: Nav.getLink('data-explorer-public', { dataset: 'Framingham Heart Study Teaching Dataset' })
+    href: Nav.getLink('data-explorer-public', { dataset: 'Framingham Heart Study Teaching Dataset' }),
+    onClick: () => captureEventOnClick('Framingham Heart Study')
   }, ['Browse data'])
 ])
 
@@ -295,17 +313,17 @@ const gp2 = () => h(Participant, {
   logo: { src: gp2Logo, alt: 'GP2 logo', height: '40%' },
   modalLogoHeight: 100,
   title: `GP2`,
-  shortDescription: `The Global Parkinson's Genetics Program (GP2) aims to transform our understanding 
-    of the genetic basis of Parkinson’s disease (PD) across diverse populations, including those 
+  shortDescription: `The Global Parkinson's Genetics Program (GP2) aims to transform our understanding
+    of the genetic basis of Parkinson’s disease (PD) across diverse populations, including those
     underserved in biomedical...`,
   description: p([
-    `The Global Parkinson's Genetics Program (GP2) aims to transform our understanding of the genetic 
-    basis of Parkinson’s disease (PD) across diverse populations, including those underserved in 
-    biomedical research. This program includes targeted collection and analysis of data and samples 
-    from Africa, Asia, Europe and the Americas toward genetic insights that will broaden biomarker and 
-    therapeutic discovery and development. GP2 is a resource of the Aligning Science Across 
-    Parkinson’s (ASAP) initiative, which has developed an ambitious roadmap to tackle key scientific 
-    challenges in PD by supporting meaningful, multidisciplinary collaboration; generating 
+    `The Global Parkinson's Genetics Program (GP2) aims to transform our understanding of the genetic
+    basis of Parkinson’s disease (PD) across diverse populations, including those underserved in
+    biomedical research. This program includes targeted collection and analysis of data and samples
+    from Africa, Asia, Europe and the Americas toward genetic insights that will broaden biomarker and
+    therapeutic discovery and development. GP2 is a resource of the Aligning Science Across
+    Parkinson’s (ASAP) initiative, which has developed an ambitious roadmap to tackle key scientific
+    challenges in PD by supporting meaningful, multidisciplinary collaboration; generating
     research-enabling resources; and sharing data.`
   ])
 }, [
@@ -313,12 +331,14 @@ const gp2 = () => h(Participant, {
     'aria-label': 'Browse GP2 Tier 1 data',
     style: { marginBottom: '1rem' },
     tooltip: 'Visit the workspace',
-    href: Nav.getLink('workspace-dashboard', { namespace: 'cardterra', name: 'GP2_Tier1' })
+    href: Nav.getLink('workspace-dashboard', { namespace: 'cardterra', name: 'GP2_Tier1' }),
+    onClick: () => captureEventOnClick('GP2 Tier 1 data'),
   }, ['Browse Tier 1 Data']),
   h(ButtonPrimary, {
     'aria-label': 'Browse GP2 Tier 2 data',
     tooltip: 'Visit the workspace',
-    href: Nav.getLink('workspace-dashboard', { namespace: 'cardterra', name: 'GP2_Tier2' })
+    href: Nav.getLink('workspace-dashboard', { namespace: 'cardterra', name: 'GP2_Tier2' }),
+    onClick: () => captureEventOnClick('GP2 Tier 2 data')
   }, ['Browse Tier 2 Data'])
 ])
 
@@ -333,6 +353,7 @@ const hca = () => h(Participant, {
     'aria-label': 'Browse Human Cell Atlas data',
     tooltip: 'Look for the Export Selected Data button to export data from this provider.',
     href: 'https://data.humancellatlas.org/explore/projects',
+    onClick: () => captureEventOnClick('Human Cell Atlas'),
     ...Utils.newTabLinkProps
   }, ['Browse Data'])
 ])
@@ -349,6 +370,7 @@ const nemo = () => h(Participant, {
     'aria-label': 'Browse Neuroscience Multi-Omic Archive data',
     tooltip: 'Look for the Export to Terra option in the Download Cart to export data.',
     href: 'http://portal.nemoarchive.org/',
+    onClick: () => captureEventOnClick('Nemo Archive'),
     ...Utils.newTabLinkProps
   }, ['Browse Data'])
 ])
@@ -365,6 +387,7 @@ const target = () => h(Participant, {
 }, [h(ButtonPrimary, {
   'aria-label': 'Browse TARGET data',
   href: `${getConfig().firecloudUrlRoot}/?return=${returnParam()}&project=TARGET#library`,
+  onClick: () => captureEventOnClick('TARGET'),
   ...Utils.newTabLinkProps
 }, ['Browse Data'])])
 
@@ -384,6 +407,7 @@ const tcga = () => h(Participant, {
   h(ButtonPrimary, {
     'aria-label': 'Browse Cancer Genome Atlas data',
     href: `${getConfig().firecloudUrlRoot}/?return=${returnParam()}&project=TCGA#library`,
+    onClick: () => captureEventOnClick('Cancer Genome Atlas'),
     ...Utils.newTabLinkProps
   }, ['Browse Data'])
 ])
@@ -400,6 +424,7 @@ const topMed = () => h(Participant, {
     'aria-label': 'Browse TopMed data',
     tooltip: browseTooltip,
     href: 'https://gen3.biodatacatalyst.nhlbi.nih.gov/explorer',
+    onClick: () => captureEventOnClick('TopMed'),
     ...Utils.newTabLinkProps
   }, ['Browse Data'])
 ])

--- a/src/pages/library/Datasets.js
+++ b/src/pages/library/Datasets.js
@@ -123,7 +123,7 @@ const thousandGenomesHighCoverage = () => h(Participant, {
     'aria-label': 'Browse 1000 Genomes High Coverage data',
     tooltip: 'Visit the workspace',
     href: Nav.getLink('workspace-dashboard', { namespace: 'anvil-datastorage', name: '1000G-high-coverage-2019' }),
-    onClick: () => captureBrowseDataEvent('1000G-high-coverage-2019')
+    onClick: () => captureBrowseDataEvent('1000 Genomes High Coverage')
   }, ['Browse data'])
 ])
 
@@ -142,7 +142,7 @@ const thousandGenomesLowCoverage = () => h(Participant, {
     'aria-label': 'Browse 1000 Genomes Low Coverage data',
     tooltip: browseTooltip,
     href: Nav.getLink('data-explorer-public', { dataset: '1000 Genomes' }),
-    onClick: () => captureBrowseDataEvent('1000 Genomes')
+    onClick: () => captureBrowseDataEvent('1000 Genomes Low Coverage')
   }, ['Browse data'])
 ])
 

--- a/src/pages/library/Datasets.js
+++ b/src/pages/library/Datasets.js
@@ -109,16 +109,8 @@ const Participant = ({ logo, title, shortDescription, description, sizeText, mod
 
 const browseTooltip = 'Look for the Export to Terra icon to export data from this provider.'
 
-const captureEventMetrics = (eventName, metrics) => {
-  Ajax().Metrics.captureEvent(eventName, metrics)
-}
-
-const captureBrowseDataEvent = (datasetName) => {
-  const eventName = `${Events.datasetLibraryBrowseData}`
-  captureEventMetrics(eventName, {
-    datasetName: datasetName
-  })
-}
+const captureBrowseDataEvent = datasetName =>
+  Ajax().Metrics.captureEvent(Events.datasetLibraryBrowseData, {datasetName})
 
 const thousandGenomesHighCoverage = () => h(Participant, {
   logo: { src: thousandGenomesAnvil, alt: '1000 Genomes and AnVIL', height: '55%' },


### PR DESCRIPTION
Record an event in mixpanel when a user clicks any of the "browse data" buttons on the [dataset library page](https://app.terra.bio/#library/datasets). I verified that the events appear in the [dev mixpanel](https://mixpanel.com/project/2085496/view/19055/app/events#~(dateRange~(from~'!start_of_current_day~to~'!end_of_current_day~type~'between)~entries~(~(aggregationOperator~'total~aggregationOperatorPerUser~null~dataGroupId~null~event~(label~'library*3abrowseData~value~'library*3abrowseData~tags~(~)~isRecentlyUsed~true)~filters~(~)~filtersOperator~'and~property~null~type~'event))~filters~(~)~search~'~colWidths~(*2524event_name~203~*2524time~203~*2524distinct_id~203~*2524city~203~mp_country_code~203~*2524os~203)~selectedProperties~(~(value~'!event_name~resourceType~'event~label~'Event*20Name~type~'string~propertyDefaultType~'string)~(value~'!time~resourceType~'event~label~'!time~type~'string~propertyDefaultType~'string)~(value~'!distinct_id~resourceType~'event~label~'Distinct*20ID~type~'string~propertyDefaultType~'string)~(value~'!city~resourceType~'event~label~'City~type~'string~propertyDefaultType~'string)~(value~'mp_country_code~resourceType~'event~label~'Country~type~'string~propertyDefaultType~'string)~(value~'!os~resourceType~'event~label~'Operating*20System~type~'string~propertyDefaultType~'string))~showQueryBuilder~true)). 

