### PR TITLE
[WOR-44] Show most expensive workspaces in Spend Report

### DIFF
--- a/ATTRIBUTIONS.txt
+++ b/ATTRIBUTIONS.txt
@@ -1,0 +1,22 @@
+attributions:
+- name: Highcharts
+  link: https://www.highcharts.com/
+  copyright: Copyright (c) Highsoft AS. All rights reserved.
+  license:
+    Highsoft
+    Non-Commercial License Statement
+
+    This email constitutes as your license statement.
+    Date of issue: [February 16, 2022]
+
+    License holder:
+      Christina Roberts
+      The Broad Institute of MIT and Harvard
+
+    This license is valid for:
+      Not-for-Profit usage of the following product(s):
+      Highcharts.
+
+    This software is released under Creative Commons Attribution-NonCommercial 3.0
+  licenseLink: https://creativecommons.org/licenses/by-nc/3.0/us/
+  licenseName: Creative Commons Attribution-NonCommercial 3.0

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "file-saver": "^2.0.5",
     "filesize": "^7.0.0",
     "github-markdown-css": "^4.0.0",
+    "highcharts": "^9.3.3",
+    "highcharts-react-official": "^3.1.0",
     "history": "^4.10.1",
     "iframe-resizer": "^4.3.2",
     "igv": "2.3.5",

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -565,7 +565,9 @@ const Billing = signal => ({
   },
 
   /**
-   * Returns the spend report for the given billing project, from 12 AM on the startDate to 11:59 PM on the endDate (UTC).
+   * Returns the spend report for the given billing project, from 12 AM on the startDate to 11:59 PM on the endDate (UTC). Spend details by
+   * Workspace are included.
+   *
    * @param billingProjectName
    * @param startDate, a string of the format YYYY-MM-DD, representing the start date of the report.
    * @param endDate a string of the format YYYY-MM-DD, representing the end date of the report.
@@ -573,7 +575,7 @@ const Billing = signal => ({
    */
   getSpendReport: async ({ billingProjectName, startDate, endDate }) => {
     const res = await fetchRawls(
-      `billing/v2/${billingProjectName}/spendReport?${qs.stringify({ startDate, endDate })}`,
+      `billing/v2/${billingProjectName}/spendReport?${qs.stringify({ startDate, endDate, aggregationKey: 'Workspace' })}`,
       _.merge(authOpts(), { signal })
     )
     return res.json()

--- a/src/pages/billing/List.js
+++ b/src/pages/billing/List.js
@@ -233,7 +233,7 @@ export const BillingList = ({ queryParams: { selectedName } }) => {
     Utils.withBusyState(setIsLoadingProjects)
   )(async () => setBillingProjects(_.sortBy('projectName', await Ajax(signal).Billing.listProjects())))
 
-  const loadAlphaSpendReportMember = reportErrorAndRethrow('Error loading user group membership')(async () => {
+  const loadAlphaSpendReportMember = reportErrorAndRethrow('Error loading spend report group membership')(async () => {
     setIsAlphaSpendReportUser(await Ajax(signal).Groups.group(getConfig().alphaSpendReportGroup).isMember())
   })
 

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -263,15 +263,16 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
       const costFormatter = new Intl.NumberFormat(navigator.language, { style: 'currency', currency: spend.spendSummary.currency })
       setTotalCost(costFormatter.format(spend.spendSummary.cost))
 
+      const workspaceDetails = _.find(details => details.aggregationKey === 'Workspace')(spend.spendDetails)
+      console.assert(workspaceDetails !== undefined, 'Spend report details do not include aggregation by Workspace')
       // Get the most expensive workspaces, sorted from most to least expensive.
       const mostExpensiveWorkspaces = _.flow(
         _.sortBy(({ cost }) => { return parseFloat(cost) }),
         _.reverse,
         _.slice(0, maxWorkspacesInChart)
-      )(spend.spendDetails[0].spendData)
-
+      )(workspaceDetails?.spendData)
       // Pull out names and costs.
-      const costsPerWorkspace = { workspaceNames: [], workspaceCosts: [], numWorkspaces: spend.spendDetails[0].spendData.length }
+      const costsPerWorkspace = { workspaceNames: [], workspaceCosts: [], numWorkspaces: workspaceDetails?.spendData.length }
       _.forEach(workspaceCostData => {
         costsPerWorkspace.workspaceNames.push(workspaceCostData.workspace.name)
         costsPerWorkspace.workspaceCosts.push(parseFloat(workspaceCostData.cost))

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -1,3 +1,7 @@
+import Highcharts from 'highcharts'
+import highchartsAccessibility from 'highcharts/modules/accessibility'
+import highchartsExporting from 'highcharts/modules/exporting'
+import HighchartsReact from 'highcharts-react-official'
 import _ from 'lodash/fp'
 import * as qs from 'qs'
 import { Fragment, useEffect, useMemo, useState } from 'react'
@@ -212,6 +216,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
   const [sort, setSort] = useState({ field: 'email', direction: 'asc' })
   const [workspaceSort, setWorkspaceSort] = useState({ field: 'name', direction: 'asc' })
   const [totalCost, setTotalCost] = useState(null)
+  const [costPerWorkspace, setCostPerWorkspace] = useState({ workspaceNames: [], workspaceCosts: [], numWorkspaces: 0 })
   const [updatingTotalCost, setUpdatingTotalCost] = useState(false)
   const [spendReportLengthInDays, setSpendReportLengthInDays] = useState(30)
 
@@ -224,6 +229,36 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
     _.map('workspace', workspaces)
   ), [billingProject, workspaces])
 
+  highchartsAccessibility(Highcharts)
+  highchartsExporting(Highcharts)
+  const maxWorkspacesInChart = 10
+  const spendChartOptions = {
+    chart: {
+      type: 'bar', events: {
+        load() { this.showLoading() },
+        redraw() { this.hideLoading() }
+      },
+      spacingRight: '4'
+    },
+    credits: { enabled: false },
+    legend: { enabled: false },
+    series: [{ name: 'Total Cost', data: costPerWorkspace.workspaceCosts }],
+    title: {
+      text: costPerWorkspace.numWorkspaces > maxWorkspacesInChart ? `Top ${maxWorkspacesInChart} Spending Workspaces` : 'Spend By Workspace',
+      fontFamily: 'sans-serif'
+    },
+    tooltip: { valuePrefix: '$' },
+    xAxis: {
+      categories: costPerWorkspace.workspaceNames, crosshair: true,
+      labels: { style: { fontSize: '12px' } }
+    },
+    yAxis: {
+      crosshair: true, min: 0,
+      labels: { format: `\${value:.2f}`, style: { fontSize: '12px' } },
+      title: { text: 'Total Cost' }
+    }
+  }
+
   const spendReportKey = 'spend report'
   const maybeLoadTotalCost = reportErrorAndRethrow('Unable to retrieve spend report data')(async () => {
     if (!updatingTotalCost && totalCost === null && tab === spendReportKey) {
@@ -233,6 +268,22 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
       const spend = await Ajax(signal).Billing.getSpendReport({ billingProjectName: billingProject.projectName, startDate, endDate })
       const costFormatter = new Intl.NumberFormat(navigator.language, { style: 'currency', currency: spend.spendSummary.currency })
       setTotalCost(costFormatter.format(spend.spendSummary.cost))
+
+      // Get the most expensive workspaces, sorted from most to least expensive.
+      const mostExpensiveWorkspaces = _.flow(
+        _.sortBy(({ cost }) => { return parseFloat(cost) }),
+        _.reverse,
+        _.slice(0, maxWorkspacesInChart)
+      )(spend.spendDetails[0].spendData)
+
+      // Pull out names and costs.
+      const costsPerWorkspace = { workspaceNames: [], workspaceCosts: [], numWorkspaces: spend.spendDetails[0].spendData.length }
+      _.forEach(workspaceCostData => {
+        costsPerWorkspace.workspaceNames.push(workspaceCostData.workspace.name)
+        costsPerWorkspace.workspaceCosts.push(parseFloat(workspaceCostData.cost))
+      })(mostExpensiveWorkspaces)
+      setCostPerWorkspace(costsPerWorkspace)
+
       setUpdatingTotalCost(false)
     }
   })
@@ -305,23 +356,26 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
         )
       ])
     ]),
-    [spendReportKey]: div({ style: { display: 'grid', gridTemplateColumns: 'minmax(15.625rem, max-content)', rowGap: '1.25rem' } }, [
-      div({ style: { gridRowStart: 1, gridColumnStart: 1 } }, [h(IdContainer, [id => h(Fragment, [
-        h(FormLabel, { htmlFor: id }, ['Date range']),
-        h(Select, {
-          id,
-          value: spendReportLengthInDays,
-          options: _.map(days => ({
-            label: `Last ${days} days`,
-            value: days
-          }), [7, 30, 90]),
-          onChange: ({ value: selectedDays }) => {
-            setSpendReportLengthInDays(selectedDays)
-            setTotalCost(null) // This will force the report to be recalculated based on selectedDays
-          }
-        })
-      ])])]),
-      CostCard({ title: 'Total spend', amount: (!!totalCost ? totalCost : '$__.__') })
+    [spendReportKey]: div({ style: { display: 'grid', rowGap: '1.25rem' } }, [
+      div({ style: { display: 'grid', gridTemplateColumns: 'minmax(15.625rem, max-content)', rowGap: '1.25rem' } }, [
+        div({ style: { gridRowStart: 1, gridColumnStart: 1 } }, [h(IdContainer, [id => h(Fragment, [
+          h(FormLabel, { htmlFor: id }, ['Date range']),
+          h(Select, {
+            id,
+            value: spendReportLengthInDays,
+            options: _.map(days => ({
+              label: `Last ${days} days`,
+              value: days
+            }), [7, 30, 90]),
+            onChange: ({ value: selectedDays }) => {
+              setSpendReportLengthInDays(selectedDays)
+              setTotalCost(null) // This will force the report to be recalculated based on selectedDays
+            }
+          })
+        ])])]),
+        CostCard({ title: 'Total spend', amount: (!!totalCost ? totalCost : '$__.__') })
+      ]),
+      div({ style: { gridRowStart: 2 } }, [h(HighchartsReact, { highcharts: Highcharts, options: spendChartOptions })])
     ])
   }
 

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -233,13 +233,12 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
   highchartsExporting(Highcharts)
   const maxWorkspacesInChart = 10
   const spendChartOptions = {
-    chart: { spacingRight: '4', type: 'bar' },
+    chart: { type: 'bar', style: { fontFamily: 'inherit' } },
     credits: { enabled: false },
     legend: { enabled: false },
     series: [{ name: 'Total Cost', data: costPerWorkspace.workspaceCosts }],
     title: {
-      text: costPerWorkspace.numWorkspaces > maxWorkspacesInChart ? `Top ${maxWorkspacesInChart} Spending Workspaces` : 'Spend By Workspace',
-      fontFamily: 'sans-serif'
+      text: costPerWorkspace.numWorkspaces > maxWorkspacesInChart ? `Top ${maxWorkspacesInChart} Spending Workspaces` : 'Spend By Workspace'
     },
     tooltip: { valuePrefix: '$' },
     xAxis: {
@@ -249,8 +248,10 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
     yAxis: {
       crosshair: true, min: 0,
       labels: { format: `\${value:.2f}`, style: { fontSize: '12px' } },
-      title: { text: 'Total Cost' }
-    }
+      title: { text: 'Total Cost' },
+      width: '96%'
+    },
+    exporting: { buttons: { contextButton: { x: -15 } } }
   }
 
   const spendReportKey = 'spend report'

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -1,7 +1,7 @@
-import Highcharts from 'highcharts'
-import HighchartsReact from 'highcharts-react-official'
+import Highcharts from 'highcharts' // Highcharts is being used under the Creative Commons Attribution-NonCommercial 3.0 license
 import highchartsAccessibility from 'highcharts/modules/accessibility'
 import highchartsExporting from 'highcharts/modules/exporting'
+import HighchartsReact from 'highcharts-react-official'
 import _ from 'lodash/fp'
 import * as qs from 'qs'
 import { Fragment, useEffect, useMemo, useState } from 'react'

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -370,7 +370,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
         ])])]),
         CostCard({ title: 'Total spend', amount: (!!totalCost ? totalCost : '$__.__') })
       ]),
-      costPerWorkspace.numWorkspaces > 0 && div({ style: { gridRowStart: 2 } },
+      costPerWorkspace.numWorkspaces > 0 && div({ style: { gridRowStart: 2, minWidth: '500px' } }, // Set minWidth so chart will shrink on resize
         [h(HighchartsReact, { highcharts: Highcharts, options: spendChartOptions })]
       )
     ])

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -1,7 +1,7 @@
 import Highcharts from 'highcharts'
+import HighchartsReact from 'highcharts-react-official'
 import highchartsAccessibility from 'highcharts/modules/accessibility'
 import highchartsExporting from 'highcharts/modules/exporting'
-import HighchartsReact from 'highcharts-react-official'
 import _ from 'lodash/fp'
 import * as qs from 'qs'
 import { Fragment, useEffect, useMemo, useState } from 'react'
@@ -233,13 +233,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
   highchartsExporting(Highcharts)
   const maxWorkspacesInChart = 10
   const spendChartOptions = {
-    chart: {
-      type: 'bar', events: {
-        load() { this.showLoading() },
-        redraw() { this.hideLoading() }
-      },
-      spacingRight: '4'
-    },
+    chart: { spacingRight: '4', type: 'bar' },
     credits: { enabled: false },
     legend: { enabled: false },
     series: [{ name: 'Total Cost', data: costPerWorkspace.workspaceCosts }],
@@ -375,7 +369,9 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
         ])])]),
         CostCard({ title: 'Total spend', amount: (!!totalCost ? totalCost : '$__.__') })
       ]),
-      div({ style: { gridRowStart: 2 } }, [h(HighchartsReact, { highcharts: Highcharts, options: spendChartOptions })])
+      costPerWorkspace.numWorkspaces > 0 && div({ style: { gridRowStart: 2 } },
+        [h(HighchartsReact, { highcharts: Highcharts, options: spendChartOptions })]
+      )
     ])
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7792,6 +7792,23 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"highcharts-react-official@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "highcharts-react-official@npm:3.1.0"
+  peerDependencies:
+    highcharts: ">=6.0.0"
+    react: ">=16.8.0"
+  checksum: 13ea12e8f778d4b7dac735082b6f36ed3c852b7c31823812ba42ea78e72ce21b90e62daf0a2bc35bb6db07705a9f19cf7b21c03455c6f3fb14e7cab8d35b0ecf
+  languageName: node
+  linkType: hard
+
+"highcharts@npm:^9.3.3":
+  version: 9.3.3
+  resolution: "highcharts@npm:9.3.3"
+  checksum: bd952eafcf7b1c136ab1e20d6b58172f9aeab9381c13e3d67f08b10eb6b2c1f96e62a8d276f29b1e92ef0a8cbc6d1696cd0e554691063a5183235e820b42404b
+  languageName: node
+  linkType: hard
+
 "history@npm:^4.10.1":
   version: 4.10.1
   resolution: "history@npm:4.10.1"
@@ -14972,6 +14989,8 @@ resolve@^2.0.0-next.3:
     file-saver: ^2.0.5
     filesize: ^7.0.0
     github-markdown-css: ^4.0.0
+    highcharts: ^9.3.3
+    highcharts-react-official: ^3.1.0
     history: ^4.10.1
     husky: ^7.0.2
     iframe-resizer: ^4.3.2


### PR DESCRIPTION
This total spend by workspace (for 10 most expensive workspaces) for a billing project under the following conditions:

1. User is billing project owner
2. User is part of the alpha spending group. "hermione.owner" is a member in dev.
3. The billing project has spend data stored. `galaxy-anvil-dev` is a good one to look at. http://localhost:3000/#billing?selectedName=galaxy-anvil-dev&type=project&tab=spend%20report

Also adds Highcharts attribution per WOR-141.

![image](https://user-images.githubusercontent.com/484484/157700592-bae8d7c1-499e-4ac8-b424-8cf61cec3387.png)

