### PR TITLE
Fail CI on ESLint warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,7 +195,7 @@ jobs:
           paths:
             - node_modules
             - .yarn/cache
-      - run: yarn eslint src
+      - run: yarn eslint --max-warnings=0 src
       - run: yarn test
       - run: DISABLE_ESLINT_PLUGIN=true yarn build # already linted above
       - run: tar -czf build.tgz .gcloudignore app.yaml build config

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "scripts": {
     "analyze": "yarn build && source-map-explorer 'build/static/js/*.js' --gzip",
     "build": "env $(yarn setenv) react-app-rewired build && rm build/config.json",
-    "lint": "eslint src --fix",
+    "lint": "eslint src --fix --max-warnings=0",
     "optimize-image-svgs": "svgo --enable=inlineStyles,prefixIds --config '{ \"plugins\": [ { \"inlineStyles\": { \"onlyMatchedOnce\": false } }] }' --pretty -f src/images -r -p 1 --multipass",
     "preinstall": "node .hooks/check-engine-light.js",
     "setenv": "echo REACT_APP_VERSION=$(git rev-parse HEAD) REACT_APP_BUILD_TIMESTAMP=$(date -u \"+%s000\")",

--- a/src/libs/_tests/runtime-utils.test.js
+++ b/src/libs/_tests/runtime-utils.test.js
@@ -78,7 +78,7 @@ const galaxy1Workspace1 = {
   errors: [],
   googleProject: 'terra-test-e4000484',
   kubernetesRuntimeConfig: { numNodes: 1, machineType: 'n1-highmem-8', autoscalingEnabled: false },
-  labels: { saturnWorkspaceName: 'test-workspace'},
+  labels: { saturnWorkspaceName: 'test-workspace' },
   proxyUrls: { galaxy: 'https://leonardo-fiab.dsde-dev.broadinstitute.org/a-app-69200c2f-89c3-47db-874c-b770d8de737f/galaxy' },
   status: 'RUNNING'
 }
@@ -93,7 +93,7 @@ const galaxy2Workspace1 = {
   errors: [],
   googleProject: 'terra-test-e4000484',
   kubernetesRuntimeConfig: { numNodes: 1, machineType: 'n1-highmem-8', autoscalingEnabled: false },
-  labels: { saturnWorkspaceName: 'test-workspace'},
+  labels: { saturnWorkspaceName: 'test-workspace' },
   proxyUrls: { galaxy: 'https://leonardo-fiab.dsde-dev.broadinstitute.org/a-app-69200c2f-89c3-47db-874c-b770d8de737f/galaxy' },
   status: 'RUNNING'
 }
@@ -108,7 +108,7 @@ const cromwell1Workspace1 = {
   errors: [],
   googleProject: 'terra-test-e4000484',
   kubernetesRuntimeConfig: { numNodes: 1, machineType: 'n1-highmem-8', autoscalingEnabled: false },
-  labels: { saturnWorkspaceName: 'test-workspace'},
+  labels: { saturnWorkspaceName: 'test-workspace' },
   proxyUrls: { galaxy: 'https://leonardo-fiab.dsde-dev.broadinstitute.org/a-app-69200c2f-89c3-47db-874c-b770d8de737f/galaxy' },
   status: 'RUNNING'
 }

--- a/src/pages/library/Datasets.js
+++ b/src/pages/library/Datasets.js
@@ -19,11 +19,11 @@ import nemoLogo from 'src/images/library/datasets/nemo-logo.svg'
 import targetLogo from 'src/images/library/datasets/target_logo.jpeg'
 import tcgaLogo from 'src/images/library/datasets/TCGALogo.jpg'
 import topMedLogo from 'src/images/library/datasets/TopMed@2x.png'
+import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { getConfig } from 'src/libs/config'
-import { returnParam } from 'src/libs/logos'
-import { Ajax } from 'src/libs/ajax'
 import Events from 'src/libs/events'
+import { returnParam } from 'src/libs/logos'
 import * as Nav from 'src/libs/nav'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
@@ -109,8 +109,7 @@ const Participant = ({ logo, title, shortDescription, description, sizeText, mod
 
 const browseTooltip = 'Look for the Export to Terra icon to export data from this provider.'
 
-const captureBrowseDataEvent = datasetName =>
-  Ajax().Metrics.captureEvent(Events.datasetLibraryBrowseData, {datasetName})
+const captureBrowseDataEvent = datasetName => Ajax().Metrics.captureEvent(Events.datasetLibraryBrowseData, { datasetName })
 
 const thousandGenomesHighCoverage = () => h(Participant, {
   logo: { src: thousandGenomesAnvil, alt: '1000 Genomes and AnVIL', height: '55%' },
@@ -328,7 +327,7 @@ const gp2 = () => h(Participant, {
     style: { marginBottom: '1rem' },
     tooltip: 'Visit the workspace',
     href: Nav.getLink('workspace-dashboard', { namespace: 'cardterra', name: 'GP2_Tier1' }),
-    onClick: () => captureBrowseDataEvent('GP2 Tier 1 data'),
+    onClick: () => captureBrowseDataEvent('GP2 Tier 1 data')
   }, ['Browse Tier 1 Data']),
   h(ButtonPrimary, {
     'aria-label': 'Browse GP2 Tier 2 data',

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -288,7 +288,7 @@ const BucketContent = _.flow(
       )
     ]),
     div({ style: { margin: '1rem -1rem 1rem -1rem', borderBottom: `1px solid ${colors.dark(0.25)}` } }),
-    div({ style: { flex: '1 1 0', overflow: 'auto' }}, [
+    div({ style: { flex: '1 1 0', overflow: 'auto' } }, [
       h(SimpleTable, {
         'aria-label': 'file browser',
         columns: [


### PR DESCRIPTION
Currently, our custom ESLint rules are configured as warnings instead of errors.

https://github.com/DataBiosphere/terra-ui/blob/6af15805aeed7adc03be7101867d5eb501654b42/.eslintrc.js#L5-L94

Thus, violations of these rules can still be committed because ESLint run in CI only fails on errors. This can add unrelated churn to PRs when other devs notice the warnings and resolve them (for example: https://github.com/DataBiosphere/terra-ui/pull/2862#discussion_r822077233, https://github.com/DataBiosphere/terra-ui/pull/2848#discussion_r823743234).