### PR TITLE
AJ-341: data table display for arrays-of-objects

### DIFF
--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -180,6 +180,7 @@ export const entityAttributeText = (value, machineReadable) => {
         JSON.stringify(value.items) :
         `${value.items.length} ${label}`
     }],
+    [_.isArray(value) && _.some(_.isObject, value), () => JSON.stringify(value)], // arrays of objects need to be stringified
     () => value
   )
 }


### PR DESCRIPTION
AJ-341: data tables do not properly display attributes that are arrays of objects. This PR makes that better.

Before this PR:
![before](https://user-images.githubusercontent.com/6041577/157730567-3d58ff95-9bbe-41e5-b060-9681b7b63e38.png)

After this PR:
![after](https://user-images.githubusercontent.com/6041577/157730588-9b377ef1-6427-4ec0-95f0-49fb9f5a9e3c.png)

Reproduction steps are in https://broadworkbench.atlassian.net/browse/AJ-341.

Note I have also filed https://broadworkbench.atlassian.net/browse/AJ-342, which is out of scope for this PR