### PR TITLE
[SU-47] Run ESLint on code outside of src

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,7 +195,7 @@ jobs:
           paths:
             - node_modules
             - .yarn/cache
-      - run: yarn eslint --max-warnings=0 src
+      - run: yarn eslint --max-warnings=0 .
       - run: yarn test
       - run: DISABLE_ESLINT_PLUGIN=true yarn build # already linted above
       - run: tar -czf build.tgz .gcloudignore app.yaml build config

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+.yarn
+node_modules
+*.min.js

--- a/integration-tests/tests/billing-projects.js
+++ b/integration-tests/tests/billing-projects.js
@@ -1,4 +1,3 @@
-const _ = require('lodash/fp')
 const { click, clickable, dismissNotifications, findText, noSpinnersAfter, select, signIntoTerra } = require('../utils/integration-utils')
 const { withUserToken } = require('../utils/terra-sa-utils')
 
@@ -35,19 +34,19 @@ const setAjaxMockValues = async (testPage, ownedBillingProjectName, spendCost) =
     window.ajaxOverridesStore.set([
       {
         filter: { url: /api\/billing\/v2$/ },
-        fn: () => async () => { return new Response(JSON.stringify(projectListResult), { status: 200 }) }
+        fn: () => () => Promise.resolve(new Response(JSON.stringify(projectListResult), { status: 200 }))
       },
       {
         filter: { url: /Alpha_Spend_Report_Users\/action\/use/ },
-        fn: () => async () => { return new Response(JSON.stringify(true), { status: 200 }) }
+        fn: () => () => Promise.resolve(new Response(JSON.stringify(true), { status: 200 }))
       },
       {
         filter: { url: /api\/billing\/v2(.*)\/members$/ },
-        fn: () => async () => { return new Response('[]', { status: 200 }) }
+        fn: () => () => Promise.resolve(new Response('[]', { status: 200 }))
       },
       {
         filter: { url: /api\/billing(.*)\/spendReport(.*)/ },
-        fn: () => async () => { return new Response(JSON.stringify(spendReturnResult), { status: 200 }) }
+        fn: () => () => Promise.resolve(new Response(JSON.stringify(spendReturnResult), { status: 200 }))
       }
     ])
   }, spendReturnResult, projectListResult)

--- a/integration-tests/tests/preview-dataset.js
+++ b/integration-tests/tests/preview-dataset.js
@@ -1,4 +1,3 @@
-const _ = require('lodash/fp')
 const { checkbox, click, clickable, findText, findTableCellText, getTableCellPath, getTableHeaderPath, waitForNoSpinners } = require('../utils/integration-utils')
 const { enableDataCatalog } = require('../utils/integration-helpers')
 const { withUserToken } = require('../utils/terra-sa-utils')
@@ -6,9 +5,7 @@ const { withUserToken } = require('../utils/terra-sa-utils')
 
 const datasetName = 'Cell hashing with barcoded antibodies enables multiplexing and doublet detection for single cell genomics'
 
-const testPreviewDatasetFn = _.flow(
-  withUserToken
-)(async ({ testUrl, page, token }) => {
+const testPreviewDatasetFn = withUserToken(async ({ testUrl, page, token }) => {
   await enableDataCatalog(page, testUrl, token)
   await click(page, clickable({ textContains: 'browse & explore' }))
   await waitForNoSpinners(page)

--- a/integration-tests/tests/preview-dataset.js
+++ b/integration-tests/tests/preview-dataset.js
@@ -3,6 +3,7 @@ const { checkbox, click, clickable, findText, findTableCellText, getTableCellPat
 const { enableDataCatalog } = require('../utils/integration-helpers')
 const { withUserToken } = require('../utils/terra-sa-utils')
 
+
 const datasetName = 'Cell hashing with barcoded antibodies enables multiplexing and doublet detection for single cell genomics'
 
 const testPreviewDatasetFn = _.flow(
@@ -11,7 +12,7 @@ const testPreviewDatasetFn = _.flow(
   await enableDataCatalog(page, testUrl, token)
   await click(page, clickable({ textContains: 'browse & explore' }))
   await waitForNoSpinners(page)
-  await click(page, checkbox({ text: 'Granted', isDescendant: true}))
+  await click(page, checkbox({ text: 'Granted', isDescendant: true }))
   await click(page, clickable({ textContains: `${datasetName}` }))
   await waitForNoSpinners(page)
   await findText(page, 'Contributors')
@@ -25,7 +26,7 @@ const testPreviewDatasetFn = _.flow(
   await findTableCellText(page, getTableCellPath(previewTableName, 2, 1), 'f0caec4a-2a37-4895-8304-83d0fd0da588')
   await findTableCellText(page, getTableCellPath(previewTableName, 2, 2), '1558104905.862')
   await findTableCellText(page, getTableCellPath(previewTableName, 2, 3), 'View JSON')
-  await click(page, clickable({ textContains: 'View JSON'  }))
+  await click(page, clickable({ textContains: 'View JSON' }))
   await findText(page, 'describedBy')
   await page.keyboard.press('Escape')
 })

--- a/integration-tests/tests/request-access.js
+++ b/integration-tests/tests/request-access.js
@@ -1,12 +1,9 @@
-const _ = require('lodash/fp')
 const { checkbox, click, clickable, clickTableCell, findText, waitForNoSpinners } = require('../utils/integration-utils')
 const { enableDataCatalog } = require('../utils/integration-helpers')
 const { withUserToken } = require('../utils/terra-sa-utils')
 
 
-const testRequestAccessFn = _.flow(
-  withUserToken
-)(async ({ testUrl, page, token }) => {
+const testRequestAccessFn = withUserToken(async ({ testUrl, page, token }) => {
   await enableDataCatalog(page, testUrl, token)
   await click(page, clickable({ textContains: 'browse & explore' }))
   await waitForNoSpinners(page)

--- a/integration-tests/tests/request-access.js
+++ b/integration-tests/tests/request-access.js
@@ -22,13 +22,12 @@ const testRequestAccessFn = _.flow(
   await waitForNoSpinners(page)
   await click(page, clickable({ textContains: 'Request Access' }))
   await findText(page, 'Request Access')
-
 })
 
 const testRequestAccess = {
   name: 'request-access',
   fn: testRequestAccessFn,
-  timeout: 2 * 60 * 1000,  // 2 min timeout
+  timeout: 2 * 60 * 1000, // 2 min timeout
   targetEnvironments: ['local', 'dev']
 }
 

--- a/integration-tests/utils/catalog-utils.js
+++ b/integration-tests/utils/catalog-utils.js
@@ -1,6 +1,7 @@
 const { enableDataCatalog } = require('../utils/integration-helpers')
 const { click, clickable, checkbox, clickTableCell, noSpinnersAfter } = require('../utils/integration-utils')
 
+
 const eitherThrow = (testFailure, { cleanupFailure, cleanupMessage }) => {
   if (testFailure) {
     cleanupFailure && console.error(`${cleanupMessage}: ${cleanupFailure.message}`)

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "scripts": {
     "analyze": "yarn build && source-map-explorer 'build/static/js/*.js' --gzip",
     "build": "env $(yarn setenv) react-app-rewired build && rm build/config.json",
-    "lint": "eslint src --fix --max-warnings=0",
+    "lint": "eslint --fix --max-warnings=0 .",
     "optimize-image-svgs": "svgo --enable=inlineStyles,prefixIds --config '{ \"plugins\": [ { \"inlineStyles\": { \"onlyMatchedOnce\": false } }] }' --pretty -f src/images -r -p 1 --multipass",
     "preinstall": "node .hooks/check-engine-light.js",
     "setenv": "echo REACT_APP_VERSION=$(git rev-parse HEAD) REACT_APP_BUILD_TIMESTAMP=$(date -u \"+%s000\")",

--- a/public/jupyter-iframe-extension.js
+++ b/public/jupyter-iframe-extension.js
@@ -1,3 +1,5 @@
+/* eslint-disable import/no-amd */
+/* global $, define */
 define([
   'base/js/namespace',
   'base/js/promises'
@@ -5,12 +7,12 @@ define([
   Jupyter,
   promises
 ) => {
-  function close_notebook() {
+  function closeNotebook() {
     Jupyter.notebook.shutdown_kernel({ confirm: false })
     window.parent.postMessage('close', '*')
   }
 
-  function load_ipython_extension() {
+  function loadIpythonExtension() {
     // hide header
     // $('#header-container').hide() // NOTE: disabled until we have better solutions for displaying save-status
 
@@ -21,7 +23,7 @@ define([
     $('#toggle_header').remove()
 
     // override close menu action
-    $('#close_and_halt').on('click', close_notebook)
+    $('#close_and_halt').on('click', closeNotebook)
 
     // add close button
     $('#menubar-container > div').wrapAll('<div style="max-width: calc(100% - 40px)">')
@@ -43,7 +45,7 @@ define([
         '</a>'
       )
 
-    $('#menubar-close-button').on('click', close_notebook)
+    $('#menubar-close-button').on('click', closeNotebook)
 
     // frequent autosave
     promises.notebook_loaded.then(() => {
@@ -64,6 +66,6 @@ define([
   }
 
   return {
-    load_ipython_extension
+    load_ipython_extension: loadIpythonExtension
   }
 })

--- a/public/jupyter-iframe-extension.js
+++ b/public/jupyter-iframe-extension.js
@@ -1,10 +1,10 @@
 define([
   'base/js/namespace',
   'base/js/promises'
-], function(
+], (
   Jupyter,
   promises
-) {
+) => {
   function close_notebook() {
     Jupyter.notebook.shutdown_kernel({ confirm: false })
     window.parent.postMessage('close', '*')
@@ -46,9 +46,9 @@ define([
     $('#menubar-close-button').on('click', close_notebook)
 
     // frequent autosave
-    promises.notebook_loaded.then(function() {
-      Jupyter.notebook.set_autosave_interval(15000);
-    });
+    promises.notebook_loaded.then(() => {
+      Jupyter.notebook.set_autosave_interval(15000)
+    })
 
     // listen for explicit save command
     window.addEventListener('message', e => {
@@ -58,13 +58,12 @@ define([
     })
 
     // report save status up
-    Jupyter.notebook.save_widget.events.on('set_dirty.Notebook', function (event, data) {
+    Jupyter.notebook.save_widget.events.on('set_dirty.Notebook', (event, data) => {
       window.parent.postMessage(data.value ? 'dirty' : 'saved', '*')
     })
-
   }
 
   return {
-    load_ipython_extension: load_ipython_extension
+    load_ipython_extension
   }
 })

--- a/public/outdated-browser-message.js
+++ b/public/outdated-browser-message.js
@@ -3,7 +3,7 @@ outdatedBrowserRework({
     Chrome: 67, // Includes Chrome for mobile devices
     Edge: 40,
     Safari: false,
-    "Mobile Safari": 10,
+    'Mobile Safari': 10,
     Opera: 54,
     Firefox: 60,
     Vivaldi: 1,
@@ -12,15 +12,15 @@ outdatedBrowserRework({
   isUnknownBrowserOK: true,
   messages: {
     en: {
-      outOfDate: "Terra may not function correctly in this browser.",
+      outOfDate: 'Terra may not function correctly in this browser.',
       update: {
-        web: "If you experience issues, please try " + (!!window.chrome ? "updating" : "using") + " Google Chrome.",
-        googlePlay: "Please install Chrome from Google Play",
-        appStore: "Please update iOS from the Settings App"
+        web: `If you experience issues, please try ${!!window.chrome ? 'updating' : 'using'} Google Chrome.`,
+        googlePlay: 'Please install Chrome from Google Play',
+        appStore: 'Please update iOS from the Settings App'
       },
-      url: "https://www.google.com/chrome/",
-      callToAction: (!!window.chrome ? "Update" : "Download") + " Chrome now",
-      close: "Close"
+      url: 'https://www.google.com/chrome/',
+      callToAction: `${!!window.chrome ? 'Update' : 'Download'} Chrome now`,
+      close: 'Close'
     }
   }
 })

--- a/public/outdated-browser-message.js
+++ b/public/outdated-browser-message.js
@@ -1,3 +1,4 @@
+/* global outdatedBrowserRework */
 outdatedBrowserRework({
   browserSupport: {
     Chrome: 67, // Includes Chrome for mobile devices


### PR DESCRIPTION
Currently, in CI, we only run ESLint on the contents of the `src` directory. This change runs ESLint on all our code (a `.eslintignore` file is added to exclude node_modules, yarn, and minified files).