### PR TITLE
[SU-47] Add missing import

### DIFF
--- a/integration-tests/tests/billing-projects.js
+++ b/integration-tests/tests/billing-projects.js
@@ -1,3 +1,4 @@
+const _ = require('lodash/fp')
 const { click, clickable, dismissNotifications, findText, noSpinnersAfter, select, signIntoTerra } = require('../utils/integration-utils')
 const { withUserToken } = require('../utils/terra-sa-utils')
 


### PR DESCRIPTION
This previously unused import was removed in #2873, while code that uses it was added in #2869.

Looks like tests passed on #2873 before #2869 was merged.