### PR TITLE
[SU-5] Add option to save multiple column settings for data tables

### DIFF
--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -4,6 +4,7 @@ import { div, h, span } from 'react-hyperscript-helpers'
 import { AutoSizer } from 'react-virtualized'
 import { Checkbox, Clickable, fixedSpinnerOverlay, Link } from 'src/components/common'
 import { concatenateAttributeNames, DeleteEntityColumnModal, EditDataLink, EntityEditor, EntityRenamer, HeaderOptions, renderDataCell } from 'src/components/data/data-utils'
+import { ColumnSettingsWithSavedColumnSettings } from 'src/components/data/SavedColumnSettings'
 import { icon } from 'src/components/icons'
 import { ConfirmedSearchInput } from 'src/components/input'
 import Modal from 'src/components/Modal'
@@ -329,10 +330,17 @@ const DataTable = props => {
             })
           }
         ]),
-        h(ColumnSelector, {
+        // Enable saved column settings only for data tables, not snapshots
+        h(ColumnSelector, _.merge(snapshotName ? {} : {
+          columnSettingsComponent: ColumnSettingsWithSavedColumnSettings,
+          entityMetadata,
+          entityType,
+          snapshotName,
+          workspaceId
+        }, {
           columnSettings,
           onSave: setColumnState
-        })
+        }))
       ]),
       !_.isEmpty(entities) && div({ style: { flex: 'none', marginTop: '1rem' } }, [
         paginator({

--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -12,6 +12,7 @@ import { MenuButton, MenuTrigger } from 'src/components/PopupTrigger'
 import { ColumnSelector, GridTable, HeaderCell, paginator, Resizable } from 'src/components/table'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
+import { isDataTableSavedColumnSettingsEnabled } from 'src/libs/config'
 import { withErrorReporting } from 'src/libs/error'
 import { getLocalPref, setLocalPref } from 'src/libs/prefs'
 import { useCancellation } from 'src/libs/react-utils'
@@ -331,7 +332,7 @@ const DataTable = props => {
           }
         ]),
         // Enable saved column settings only for data tables, not snapshots
-        h(ColumnSelector, _.merge(snapshotName ? {} : {
+        h(ColumnSelector, _.merge(snapshotName || !isDataTableSavedColumnSettingsEnabled() ? {} : {
           columnSettingsComponent: ColumnSettingsWithSavedColumnSettings,
           entityMetadata,
           entityType,

--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -12,7 +12,6 @@ import { MenuButton, MenuTrigger } from 'src/components/PopupTrigger'
 import { ColumnSelector, GridTable, HeaderCell, paginator, Resizable } from 'src/components/table'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
-import { isDataTableSavedColumnSettingsEnabled } from 'src/libs/config'
 import { withErrorReporting } from 'src/libs/error'
 import { getLocalPref, setLocalPref } from 'src/libs/prefs'
 import { useCancellation } from 'src/libs/react-utils'
@@ -332,7 +331,7 @@ const DataTable = props => {
           }
         ]),
         // Enable saved column settings only for data tables, not snapshots
-        h(ColumnSelector, _.merge(snapshotName || !isDataTableSavedColumnSettingsEnabled() ? {} : {
+        h(ColumnSelector, _.merge(snapshotName ? {} : {
           columnSettingsComponent: ColumnSettingsWithSavedColumnSettings,
           entityMetadata,
           entityType,

--- a/src/components/data/SavedColumnSettings.js
+++ b/src/components/data/SavedColumnSettings.js
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp'
 import { Fragment, useEffect, useRef, useState } from 'react'
 import { div, h, hr, li, p, span, ul } from 'react-hyperscript-helpers'
-import { ButtonPrimary, Clickable, IdContainer, spinnerOverlay } from 'src/components/common'
+import { ButtonOutline, Clickable, IdContainer, spinnerOverlay } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import { AutocompleteTextInput } from 'src/components/input'
 import { MenuButton, MenuTrigger } from 'src/components/PopupTrigger'
@@ -199,7 +199,7 @@ const SavedColumnSettings = ({ workspaceId, snapshotName, entityType, entityMeta
         })
       ])]),
       p({ style: { marginTop: 0 } }, 'This column selection will be shared with all users of this workspace.'),
-      h(ButtonPrimary, {
+      h(ButtonOutline, {
         disabled: !selectedSettingsName,
         tooltip: cond(
           [!selectedSettingsName, () => 'Enter a name to save column selection'],
@@ -211,7 +211,7 @@ const SavedColumnSettings = ({ workspaceId, snapshotName, entityType, entityMeta
         }
       }, selectedSettingsNameExists ? 'Update' : 'Save')
     ] : [
-      h(ButtonPrimary, {
+      h(ButtonOutline, {
         onClick: () => { setShowSaveForm(true) }
       }, 'Save this column selection')
     ]),

--- a/src/components/data/SavedColumnSettings.js
+++ b/src/components/data/SavedColumnSettings.js
@@ -96,7 +96,7 @@ const useSavedColumnSettings = ({ workspaceId, snapshotName, entityMetadata, ent
   }
 
   const saveColumnSettings = async (columnSettingsName, columnSettings) => {
-    // Re-fetch column settings to avoid overwriting changes made by other users since we first loaded settings.
+    // Re-fetch column settings to reduce the chances of overwriting changes made by other users since we first loaded settings.
     const allColumnSettings = await getAllSavedColumnSettings()
     const newColumnSettings = _.set(
       `${entityTypeKey}.${columnSettingsName}`,
@@ -107,7 +107,7 @@ const useSavedColumnSettings = ({ workspaceId, snapshotName, entityMetadata, ent
   }
 
   const deleteSavedColumnSettings = async columnSettingsName => {
-    // Re-fetch column settings to avoid overwriting changes made by other users since we first loaded settings.
+    // Re-fetch column settings to reduce the chances of overwriting changes made by other users since we first loaded settings.
     const allColumnSettings = await getAllSavedColumnSettings()
     const newColumnSettings = _.omit(`${entityTypeKey}.${columnSettingsName}`, allColumnSettings)
     await updateSavedColumnSettings(newColumnSettings)

--- a/src/components/data/SavedColumnSettings.js
+++ b/src/components/data/SavedColumnSettings.js
@@ -9,6 +9,7 @@ import { ColumnSettings } from 'src/components/table'
 import TooltipTrigger from 'src/components/TooltipTrigger'
 import { Ajax } from 'src/libs/ajax'
 import { withErrorReporting } from 'src/libs/error'
+import Events from 'src/libs/events'
 import { FormLabel } from 'src/libs/forms'
 import { useCancellation, useOnMount } from 'src/libs/react-utils'
 import { noWrapEllipsis } from 'src/libs/style'
@@ -154,11 +155,13 @@ const SavedColumnSettings = ({ workspaceId, snapshotName, entityType, entityMeta
   )(async settingsName => {
     await saveColumnSettings(settingsName, columnSettings)
     setSavedColumnSettings(_.set(settingsName, columnSettings))
+    Ajax().Metrics.captureEvent(Events.dataTableSaveColumnSettings)
   })
 
   const load = settingsName => {
     onLoad(savedColumnSettings[settingsName])
     setSelectedSettingsName(settingsName)
+    Ajax().Metrics.captureEvent(Events.dataTableLoadColumnSettings)
   }
 
   const del = _.flow(

--- a/src/components/data/SavedColumnSettings.js
+++ b/src/components/data/SavedColumnSettings.js
@@ -1,0 +1,276 @@
+import _ from 'lodash/fp'
+import { Fragment, useEffect, useRef, useState } from 'react'
+import { div, h, hr, li, p, span, ul } from 'react-hyperscript-helpers'
+import { ButtonPrimary, Clickable, IdContainer, spinnerOverlay } from 'src/components/common'
+import { icon } from 'src/components/icons'
+import { AutocompleteTextInput } from 'src/components/input'
+import { MenuButton, MenuTrigger } from 'src/components/PopupTrigger'
+import { ColumnSettings } from 'src/components/table'
+import TooltipTrigger from 'src/components/TooltipTrigger'
+import { Ajax } from 'src/libs/ajax'
+import { withErrorReporting } from 'src/libs/error'
+import { FormLabel } from 'src/libs/forms'
+import { useCancellation, useOnMount } from 'src/libs/react-utils'
+import { noWrapEllipsis } from 'src/libs/style'
+import { cond, withBusyState } from 'src/libs/utils'
+
+
+const savedColumnSettingsWorkspaceAttributeName = 'system:columnSettings'
+
+// Compress settings to avoid storing 'name' and 'visible' keys many times
+const encodeColumnSettings = _.flatMap(({ name, visible }) => [name, visible])
+const decodeColumnSettings = _.flow(
+  _.chunk(2),
+  _.map(([name, visible]) => ({ name, visible }))
+)
+
+const useSavedColumnSettings = ({ workspaceId, snapshotName, entityMetadata, entityType }) => {
+  // Saved column settings for all tables are stored in the same attribute in the format:
+  // {
+  //   snapshots: {
+  //      snapshot_name: {
+  //        table_name: {
+  //          settings_name: settings,
+  //          ...
+  //        },
+  //        ...
+  //      },
+  //      ...
+  //    },
+  //    tables: {
+  //      table_name: {
+  //        settings_name: settings,
+  //        ...
+  //      },
+  //      ...
+  //    }
+  // }
+  const baseKey = snapshotName ? `snapshots.${snapshotName}` : 'tables'
+  const entityTypeKey = `${baseKey}.${entityType}`
+
+  const signal = useCancellation()
+
+  const getAllSavedColumnSettings = async () => {
+    const { namespace, name } = workspaceId
+    const { workspace: { attributes } } = await Ajax(signal).Workspaces.workspace(namespace, name).details(['workspace.attributes'])
+    return _.flow(
+      _.getOr('{}', savedColumnSettingsWorkspaceAttributeName),
+      JSON.parse,
+      // Drop any column settings for entity types that no longer exist
+      _.update(baseKey, _.pick(_.keys(entityMetadata)))
+    )(attributes)
+  }
+
+  const updateSavedColumnSettings = async allColumnSettings => {
+    const { namespace, name } = workspaceId
+    await Ajax(signal).Workspaces.workspace(namespace, name).shallowMergeNewAttributes({
+      // Store settings as a string since Rawls expects lists of objects to be entity references
+      [savedColumnSettingsWorkspaceAttributeName]: JSON.stringify(allColumnSettings)
+    })
+  }
+
+  const getSavedColumnSettings = async () => {
+    const allSavedColumnSettings = await getAllSavedColumnSettings()
+    const columnSettingsForEntityType = _.getOr({}, entityTypeKey, allSavedColumnSettings)
+    const entityTypeAttributes = entityMetadata[entityType].attributeNames
+
+    return _.flow(
+      _.mapValues(decodeColumnSettings),
+      // Reconcile saved settings with any changes to entity type attributes
+      _.mapValues(columnSettings => {
+        return _.concat(
+          // Remove columns that no longer exist on the entity type from settings
+          _.filter(({ name }) => _.includes(name, entityTypeAttributes), columnSettings),
+          // Add columns that were not in the saved settings
+          _.flow(
+            _.without(_.map(_.get('name'), columnSettings)),
+            _.map(name => ({ name, visible: false }))
+          )(entityTypeAttributes)
+        )
+      }),
+      // Remove any settings that do not contain any existing columns
+      _.pickBy(columnSettings => _.size(columnSettings) > 0)
+    )(columnSettingsForEntityType)
+  }
+
+  const saveColumnSettings = async (columnSettingsName, columnSettings) => {
+    // Re-fetch column settings to avoid overwriting changes made by other users since we first loaded settings.
+    const allColumnSettings = await getAllSavedColumnSettings()
+    const newColumnSettings = _.set(
+      `${entityTypeKey}.${columnSettingsName}`,
+      encodeColumnSettings(columnSettings),
+      allColumnSettings
+    )
+    await updateSavedColumnSettings(newColumnSettings)
+  }
+
+  const deleteSavedColumnSettings = async columnSettingsName => {
+    // Re-fetch column settings to avoid overwriting changes made by other users since we first loaded settings.
+    const allColumnSettings = await getAllSavedColumnSettings()
+    const newColumnSettings = _.omit(`${entityTypeKey}.${columnSettingsName}`, allColumnSettings)
+    await updateSavedColumnSettings(newColumnSettings)
+  }
+
+  return {
+    getSavedColumnSettings,
+    saveColumnSettings,
+    deleteSavedColumnSettings
+  }
+}
+
+const SavedColumnSettings = ({ workspaceId, snapshotName, entityType, entityMetadata, columnSettings, onLoad }) => {
+  const [loading, setLoading] = useState(true)
+  const [savedColumnSettings, setSavedColumnSettings] = useState([])
+
+  const {
+    getSavedColumnSettings,
+    saveColumnSettings,
+    deleteSavedColumnSettings
+  } = useSavedColumnSettings({ workspaceId, snapshotName, entityType, entityMetadata })
+
+  useOnMount(() => {
+    const loadSavedColumnSettings = _.flow(
+      withErrorReporting('Error loading saved column settings'),
+      withBusyState(setLoading)
+    )(async () => {
+      const savedColumnSettings = await getSavedColumnSettings()
+      setSavedColumnSettings(savedColumnSettings)
+    })
+    loadSavedColumnSettings()
+  })
+
+  const [showSaveForm, setShowSaveForm] = useState(false)
+  const settingsNameInput = useRef()
+  useEffect(() => {
+    if (showSaveForm) {
+      settingsNameInput.current.focus()
+    }
+  }, [showSaveForm])
+  const [selectedSettingsName, setSelectedSettingsName] = useState('')
+
+  const save = _.flow(
+    withErrorReporting('Error saving column settings'),
+    withBusyState(setLoading)
+  )(async settingsName => {
+    await saveColumnSettings(settingsName, columnSettings)
+    setSavedColumnSettings(_.set(settingsName, columnSettings))
+  })
+
+  const load = settingsName => {
+    onLoad(savedColumnSettings[settingsName])
+    setSelectedSettingsName(settingsName)
+  }
+
+  const del = _.flow(
+    withErrorReporting('Error deleting column settings'),
+    withBusyState(setLoading)
+  )(async settingsName => {
+    await deleteSavedColumnSettings(settingsName)
+    setSavedColumnSettings(_.omit(settingsName))
+    setSelectedSettingsName('')
+  })
+
+  const selectedSettingsNameExists = _.has(selectedSettingsName, savedColumnSettings)
+
+  return div({ style: { display: 'flex', flexDirection: 'column', height: '100%' } }, [
+    div(showSaveForm ? [
+      p({ style: { marginTop: 0 } }, 'Save this column selection'),
+      h(IdContainer, [id => h(Fragment, [
+        h(FormLabel, { htmlFor: id }, 'Column selection name'),
+        h(AutocompleteTextInput, {
+          ref: settingsNameInput,
+          id,
+          openOnFocus: true,
+          placeholderText: 'Enter a name for selection',
+          onPick: setSelectedSettingsName,
+          placeholder: 'Enter a name for selection',
+          value: selectedSettingsName,
+          onChange: setSelectedSettingsName,
+          suggestions: _.flow(
+            _.keys,
+            selectedSettingsName ? _.concat(selectedSettingsName) : _.identity,
+            _.sortBy(_.identity),
+            _.sortedUniq
+          )(savedColumnSettings),
+          style: { fontSize: 16, marginBottom: '1rem' }
+        })
+      ])]),
+      p({ style: { marginTop: 0 } }, 'This column selection will be shared with all users of this workspace.'),
+      h(ButtonPrimary, {
+        disabled: !selectedSettingsName,
+        tooltip: cond(
+          [!selectedSettingsName, () => 'Enter a name to save column selection'],
+          [selectedSettingsNameExists, () => 'Update this column selection'],
+          () => 'Save this column selection'
+        ),
+        onClick: () => {
+          save(selectedSettingsName)
+        }
+      }, selectedSettingsNameExists ? 'Update' : 'Save')
+    ] : [
+      h(ButtonPrimary, {
+        onClick: () => { setShowSaveForm(true) }
+      }, 'Save this column selection')
+    ]),
+
+    hr({ style: { margin: '1rem 0' } }),
+
+    _.size(savedColumnSettings) > 0 && h(Fragment, [
+      p({ style: { marginTop: 0 } }, 'Your saved column selections:'),
+      div({ style: { flex: '1 1 0', overflow: 'auto', paddingRight: '1rem' } }, [
+        ul({ style: { padding: 0, margin: 0 } }, [
+          _.flow(
+            _.keys,
+            _.sortBy(_.identity),
+            _.map(settingsName => {
+              return li({
+                key: settingsName,
+                style: { listStyleType: 'none', marginBottom: '0.5rem' }
+              }, [
+                span({ style: { display: 'inline-flex', width: '100%' } }, [
+                  h(TooltipTrigger, { content: settingsName }, [
+                    span({ style: { ...noWrapEllipsis } }, settingsName)
+                  ]),
+                  h(MenuTrigger, {
+                    closeOnClick: true,
+                    'aria-label': 'Column selection menu',
+                    content: h(Fragment, [
+                      h(MenuButton, { onClick: () => { load(settingsName) } }, 'Load'),
+                      h(MenuButton, { onClick: () => { del(settingsName) } }, 'Delete')
+                    ]),
+                    side: 'bottom'
+                  }, [
+                    h(Clickable, {
+                      'aria-label': 'Column selection menu',
+                      style: { marginLeft: '1ch' }
+                    }, [icon('cardMenuIcon')])
+                  ])
+                ])
+              ])
+            })
+          )(savedColumnSettings)
+        ])
+      ])
+    ]),
+
+    loading && spinnerOverlay
+  ])
+}
+
+export const ColumnSettingsWithSavedColumnSettings = ({ columnSettings, onChange, ...otherProps }) => {
+  return div({ style: { display: 'flex', justifyContent: 'space-between' } }, [
+    div({ style: { width: 'calc(50% - 1rem)' } }, [
+      h(ColumnSettings, {
+        columnSettings,
+        onChange
+      })
+    ]),
+    div({ style: { width: 'calc(50% - 1rem)', marginTop: '2rem' } }, [
+      h(SavedColumnSettings, {
+        ...otherProps,
+        columnSettings,
+        onLoad: onChange
+      })
+    ])
+  ])
+}

--- a/src/components/data/SavedColumnSettings.js
+++ b/src/components/data/SavedColumnSettings.js
@@ -8,6 +8,7 @@ import { MenuButton, MenuTrigger } from 'src/components/PopupTrigger'
 import { ColumnSettings } from 'src/components/table'
 import TooltipTrigger from 'src/components/TooltipTrigger'
 import { Ajax } from 'src/libs/ajax'
+import colors from 'src/libs/colors'
 import { withErrorReporting } from 'src/libs/error'
 import Events from 'src/libs/events'
 import { FormLabel } from 'src/libs/forms'
@@ -245,7 +246,7 @@ const SavedColumnSettings = ({ workspaceId, snapshotName, entityType, entityMeta
                   }, [
                     h(Clickable, {
                       'aria-label': 'Column selection menu',
-                      style: { marginLeft: '1ch' }
+                      style: { color: colors.accent(), marginLeft: '1ch' }
                     }, [icon('cardMenuIcon')])
                   ])
                 ])

--- a/src/components/input.js
+++ b/src/components/input.js
@@ -8,7 +8,7 @@ import { icon } from 'src/components/icons'
 import { PopupPortal, useDynamicPosition } from 'src/components/popup-utils'
 import TooltipTrigger from 'src/components/TooltipTrigger'
 import colors from 'src/libs/colors'
-import { forwardRefWithName, useGetter, useInstance, useLabelAssert, useOnMount } from 'src/libs/react-utils'
+import { combineRefs, forwardRefWithName, useGetter, useInstance, useLabelAssert, useOnMount } from 'src/libs/react-utils'
 import * as Utils from 'src/libs/utils'
 
 
@@ -230,10 +230,10 @@ const AutocompleteSuggestions = ({ target: targetId, containerProps, children })
   ])
 }
 
-const withAutocomplete = WrappedComponent => ({
+const withAutocomplete = WrappedComponent => forwardRefWithName(`withAutocomplete(${WrappedComponent.displayName || WrappedComponent.name || 'Component'})`, ({
   instructions, itemToString, value, onChange, onPick, suggestions: rawSuggestions, style, id, labelId, inputIcon, iconStyle,
   renderSuggestion = _.identity, openOnFocus = true, suggestionFilter = Utils.textMatch, placeholderText, ...props
-}) => {
+}, ref) => {
   useLabelAssert('withAutocomplete', { id, 'aria-labelledby': labelId, ...props, allowId: true })
 
   const suggestions = _.filter(suggestionFilter(value), rawSuggestions)
@@ -298,7 +298,7 @@ const withAutocomplete = WrappedComponent => ({
           },
           nativeOnChange: true,
           ...props,
-          ref: inputEl
+          ref: combineRefs([inputEl, ref])
         })),
         isOpen && h(AutocompleteSuggestions, {
           target: getInputProps().id,
@@ -318,7 +318,7 @@ const withAutocomplete = WrappedComponent => ({
       ])
     }
   ])
-}
+})
 
 export const AutocompleteTextInput = withAutocomplete(TextInput)
 

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -705,7 +705,7 @@ const SortableDiv = SortableElement(props => div(props))
 const SortableList = SortableContainer(props => h(List, props))
 const SortableHandleDiv = SortableHandle(props => div(props))
 
-const ColumnSettings = ({ columnSettings, onChange }) => {
+export const ColumnSettings = ({ columnSettings, onChange }) => {
   const toggleVisibility = index => {
     onChange(_.update([index, 'visible'], b => !b)(columnSettings))
   }
@@ -789,6 +789,7 @@ export const ColumnSelector = ({ onSave, columnSettings, columnSettingsComponent
     }, [icon('cog', { size: 20 })]),
     open && h(Modal, {
       title: 'Select columns',
+      width: 600,
       onDismiss: () => setOpen(false),
       okButton: h(ButtonPrimary, {
         onClick: () => {

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -772,7 +772,7 @@ const ColumnSettings = ({ columnSettings, onChange }) => {
  * @param {Object} style - style override for the button
  * @param {function(Object[])} onSave - called with modified settings when user saves
  */
-export const ColumnSelector = ({ onSave, columnSettings, style }) => {
+export const ColumnSelector = ({ onSave, columnSettings, columnSettingsComponent = ColumnSettings, style, ...otherProps }) => {
   const [open, setOpen] = useState(false)
   const [modifiedColumnSettings, setModifiedColumnSettings] = useState(undefined)
 
@@ -797,7 +797,8 @@ export const ColumnSelector = ({ onSave, columnSettings, style }) => {
         }
       }, ['Done'])
     }, [
-      h(ColumnSettings, {
+      h(columnSettingsComponent, {
+        ...otherProps,
         columnSettings: modifiedColumnSettings,
         onChange: setModifiedColumnSettings
       })

--- a/src/libs/config.js
+++ b/src/libs/config.js
@@ -13,6 +13,7 @@ export const isAnalysisTabVisible = () => getConfig().isAnalysisTabVisible
 export const isCromwellAppVisible = () => getConfig().isCromwellAppVisible
 // configOverridesStore.set({ isDataBrowserVisible: true }) in browser console to enable
 export const isDataBrowserVisible = () => getConfig().isDataBrowserVisible
+export const isDataTableSavedColumnSettingsEnabled = () => getConfig().isDataTableSavedColumnSettingsEnabled
 export const isBaseline = () => (window.location.hostname === 'baseline.terra.bio') || getConfig().isBaseline
 export const isBioDataCatalyst = () => (window.location.hostname.endsWith('.biodatacatalyst.nhlbi.nih.gov')) || getConfig().isBioDataCatalyst
 export const isDatastage = () => (window.location.hostname === 'datastage.terra.bio') || getConfig().isDatastage

--- a/src/libs/config.js
+++ b/src/libs/config.js
@@ -13,7 +13,6 @@ export const isAnalysisTabVisible = () => getConfig().isAnalysisTabVisible
 export const isCromwellAppVisible = () => getConfig().isCromwellAppVisible
 // configOverridesStore.set({ isDataBrowserVisible: true }) in browser console to enable
 export const isDataBrowserVisible = () => getConfig().isDataBrowserVisible
-export const isDataTableSavedColumnSettingsEnabled = () => getConfig().isDataTableSavedColumnSettingsEnabled
 export const isBaseline = () => (window.location.hostname === 'baseline.terra.bio') || getConfig().isBaseline
 export const isBioDataCatalyst = () => (window.location.hostname.endsWith('.biodatacatalyst.nhlbi.nih.gov')) || getConfig().isBioDataCatalyst
 export const isDatastage = () => (window.location.hostname === 'datastage.terra.bio') || getConfig().isDatastage

--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -30,6 +30,8 @@ const eventsList = {
   catalogView: 'catalog:view',
   catalogWorkspaceLink: 'catalog:workspaceLink',
   datasetLibraryBrowseData: 'library:browseData',
+  dataTableSaveColumnSettings: 'dataTable:saveColumnSettings',
+  dataTableLoadColumnSettings: 'dataTable:loadColumnSettings',
   notebookLaunch: 'notebook:launch',
   notebookRename: 'notebook:rename',
   notebookCopy: 'notebook:copy',

--- a/src/libs/react-utils.js
+++ b/src/libs/react-utils.js
@@ -83,6 +83,18 @@ export const withDisplayName = _.curry((name, WrappedComponent) => {
   return WrappedComponent
 })
 
+export const combineRefs = refs => {
+  return value => {
+    for (const ref of refs) {
+      if (_.has('current', ref)) {
+        ref.current = value
+      } else if (_.isFunction(ref)) {
+        ref(value)
+      }
+    }
+  }
+}
+
 export const forwardRefWithName = _.curry((name, WrappedComponent) => {
   return withDisplayName(name, forwardRef(WrappedComponent))
 })


### PR DESCRIPTION
Currently, changes the order and visibility of columns in data tables are only stored in the browser's local storage. This provides the option for users to create multiple column configurations that are persisted in workspace attributes and shared between all users of the workspace.

![Screen Shot 2022-03-14 at 9 25 57 AM](https://user-images.githubusercontent.com/1156625/158181211-bd3009fa-6288-4189-aa76-00b2330be06a.png)

![Screen Shot 2022-03-14 at 9 26 12 AM](https://user-images.githubusercontent.com/1156625/158181213-9bcc263a-fec3-44d9-ba93-576a4a25a168.png)


