### PR TITLE
[SUP-449] Remove requirement to enter 3 characters to search workspace tags

### DIFF
--- a/src/components/workspace-utils.js
+++ b/src/components/workspace-utils.js
@@ -296,17 +296,13 @@ export const WorkspaceImporter = _.flow(
 export const WorkspaceTagSelect = props => {
   const signal = useCancellation()
   const getTagSuggestions = useInstance(() => debouncePromise(withErrorReporting('Error loading tags', async text => {
-    if (text.length > 2) {
-      return _.map(({ tag, count }) => {
-        return { value: tag, label: `${tag} (${count})` }
-      }, _.take(10, await Ajax(signal).Workspaces.getTags(text)))
-    } else {
-      return []
-    }
+    return _.map(({ tag, count }) => {
+      return { value: tag, label: `${tag} (${count})` }
+    }, await Ajax(signal).Workspaces.getTags(text, 10))
   }), 250))
   return h(AsyncCreatableSelect, {
-    noOptionsMessage: () => 'Enter at least 3 characters to search',
     allowCreateWhileLoading: true,
+    defaultOptions: true,
     loadOptions: getTagSuggestions,
     ...props
   })

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -669,8 +669,12 @@ const Workspaces = signal => ({
     return res.json()
   },
 
-  getTags: async tag => {
-    const res = await fetchRawls(`workspaces/tags?${qs.stringify({ q: tag })}`, _.merge(authOpts(), { signal }))
+  getTags: async (tag, limit) => {
+    const params = { q: tag }
+    if (limit) {
+      params.limit = limit
+    }
+    const res = await fetchRawls(`workspaces/tags?${qs.stringify(params)}`, _.merge(authOpts(), { signal }))
     return res.json()
   },
 


### PR DESCRIPTION
Currently, workspace tags menu do not show any options until at least 3 characters are entered. This removes that requirement, and shows tag options when the user first clicks on the menu.