### PR TITLE
[AJ-343] Fix alignment of long snapshot table names

### DIFF
--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -63,7 +63,7 @@ const DataTypeButton = ({ selected, entityName, children, entityCount, iconName 
     role: 'listitem'
   }, [
     h(Clickable, {
-      style: { flex: '1 1 auto', maxWidth: 232, ...Style.navList.item(selected), color: colors.accent(1.2), ...buttonStyle },
+      style: { flex: '1 1 auto', maxWidth: '100%', ...Style.navList.item(selected), color: colors.accent(1.2), ...buttonStyle },
       ...(isEntity ? {
         tooltip: entityName ? `${entityName} (${entityCount} row${entityCount === 1 ? '' : 's'})` : undefined,
         tooltipDelay: 250,


### PR DESCRIPTION
When a data table name is too long to fit in the sidebar, the table name is truncated.

![Screen Shot 2022-03-15 at 11 00 21 AM](https://user-images.githubusercontent.com/1156625/158409865-1319d491-4553-48e9-99f4-03afc9cfa210.png)

However, long table names in snapshots are not aligned correctly.

![Screen Shot 2022-03-15 at 11 10 53 AM](https://user-images.githubusercontent.com/1156625/158409992-ce319c28-1da3-4f60-8533-08972fa76737.png)

The issue is that the max width of the row/button is hard coded based on the sidebar width, and does not account for the [left padding added to the list of tables in a snapshot](https://github.com/DataBiosphere/terra-ui/blob/440f3745f9571dd03418792a3af6eed37e896132/src/pages/workspaces/workspace/Data.js#L552). Changing the max width from 232px to 100% makes everything line up.

![Screen Shot 2022-03-15 at 11 11 31 AM](https://user-images.githubusercontent.com/1156625/158410137-7178bbbc-23c8-4448-9be3-68067d4c8933.png)

