### PR TITLE
[AJ-157] Validate snapshot reference name at point of import into workspace

### DIFF
--- a/src/pages/ImportData.js
+++ b/src/pages/ImportData.js
@@ -108,6 +108,15 @@ const ImportData = () => {
       _.filter(({ name, namespace }) => _.some({ workspace: { namespace, name } }, workspaces))
     )(_.castArray(template))
 
+  // Normalize the snapshot name:
+  // Importing snapshot will throw an "enum" error if the name has any spaces or special characters
+  // Replace all whitespace characters with _
+  // Then replace all non alphanumeric characters with nothing
+  const normalizeSnapshotName = input => _.flow(
+    _.replace(/\s/g, '_'),
+    _.replace(/[^A-Za-z0-9-_]/g, '')
+  )(input)
+
   useOnMount(() => {
     const loadTemplateWorkspaces = _.flow(
       Utils.withBusyState(setIsImporting),
@@ -140,19 +149,10 @@ const ImportData = () => {
         notifyDataImportProgress(jobId)
       }],
       ['snapshot', async () => {
-        // Normalize the title:
-        // Importing snapshot will throw an "enum" error if the title has any spaces or special characters
-        // Replace all whitespace characters with _
-        // Then replace all non alphanumeric characters with nothing
-        const normalizedTitle = _.flow(
-          _.replace(/\s/g, '_'),
-          _.replace(/[^A-Za-z0-9-_]/g, '')
-        )(snapshotName)
-
         if (!_.isEmpty(snapshots)) {
           const responses = await Promise.allSettled(
             _.map(({ title, id, description }) => {
-              return Ajax().Workspaces.workspace(namespace, name).importSnapshot(id, normalizedTitle, description)
+              return Ajax().Workspaces.workspace(namespace, name).importSnapshot(id, normalizeSnapshotName(title), description)
             }, snapshots)
           )
 
@@ -172,7 +172,7 @@ const ImportData = () => {
             throw new Error(`${numFailures} snapshot${numFailures > 1 ? 's' : ''} failed to import. See details in the "Linking to Workspace" section`)
           }
         } else {
-          await Ajax().Workspaces.workspace(namespace, name).importSnapshot(snapshotId, normalizedTitle)
+          await Ajax().Workspaces.workspace(namespace, name).importSnapshot(snapshotId, normalizeSnapshotName(snapshotName))
           notify('success', 'Snapshot imported successfully.', { timeout: 3000 })
         }
       }],


### PR DESCRIPTION
As per AJ-157, creating a snapshot reference via the #import-data landing page allows you to form an illegal name for the reference. Any illegal names for a snapshot reference are only detected once the snapshot's name is edited from within the workspace (i.e. not changing any values marks the name as illegal). This PR uses the pre-existing regular expressions to automatically clean the snapshot reference names upon import. One case involving various prohibited characters, `snapshotName=t3st%09%2B%0A%60%20%2E%0Band-_break`, is shown below, having been imported after this PR's changes. Tested locally within browser.

<img width="896" alt="Screen Shot 2022-03-16 at 9 13 07 AM" src="https://user-images.githubusercontent.com/58094419/158600061-602b0061-5df4-4c0c-a86f-f21e3f68fa47.png">

<img width="896" alt="Screen Shot 2022-03-16 at 9 16 22 AM" src="https://user-images.githubusercontent.com/58094419/158600104-4b6766f7-5ac5-47bb-905b-372f6acf1dc2.png">

