### PR TITLE
[SU-5] Disable save column settings if workspace is read only or locked

### DIFF
--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -336,7 +336,6 @@ const DataTable = props => {
           entityMetadata,
           entityType,
           snapshotName,
-          workspaceId,
           workspace
         }, {
           columnSettings,

--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -50,7 +50,7 @@ const displayData = ({ itemsType, items }) => {
 
 const DataTable = props => {
   const {
-    entityType, entityMetadata, setEntityMetadata, workspaceId, googleProject, workspaceId: { namespace, name },
+    entityType, entityMetadata, setEntityMetadata, workspaceId, workspace, googleProject, workspaceId: { namespace, name },
     onScroll, initialX, initialY,
     selectionModel: { selected, setSelected },
     childrenBefore,
@@ -336,7 +336,8 @@ const DataTable = props => {
           entityMetadata,
           entityType,
           snapshotName,
-          workspaceId
+          workspaceId,
+          workspace
         }, {
           columnSettings,
           onSave: setColumnState

--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -369,7 +369,7 @@ const EntitiesContent = ({
     h(Fragment, [
       h(DataTable, {
         persist: true, firstRender, refreshKey, editable: !snapshotName && !Utils.editWorkspaceError(workspace),
-        entityType: entityKey, entityMetadata, setEntityMetadata, columnDefaults, googleProject, workspaceId: { namespace, name },
+        entityType: entityKey, entityMetadata, setEntityMetadata, columnDefaults, googleProject, workspaceId: { namespace, name }, workspace,
         onScroll: saveScroll, initialX, initialY,
         snapshotName,
         selectionModel: {

--- a/src/components/data/SavedColumnSettings.js
+++ b/src/components/data/SavedColumnSettings.js
@@ -178,6 +178,7 @@ const SavedColumnSettings = ({ workspaceId, snapshotName, entityType, entityMeta
 
   const selectedSettingsNameExists = _.has(selectedSettingsName, savedColumnSettings)
   const editWorkspaceErrorMessage = workspace ? editWorkspaceError(workspace) : undefined
+  const canSaveSettings = workspace && !editWorkspaceErrorMessage
 
   return div({ style: { display: 'flex', flexDirection: 'column', height: '100%' } }, [
     div(showSaveForm ? [
@@ -216,7 +217,7 @@ const SavedColumnSettings = ({ workspaceId, snapshotName, entityType, entityMeta
       }, selectedSettingsNameExists ? 'Update' : 'Save')
     ] : [
       h(ButtonOutline, {
-        disabled: Boolean(editWorkspaceErrorMessage),
+        disabled: !canSaveSettings,
         tooltip: editWorkspaceErrorMessage,
         onClick: () => { setShowSaveForm(true) }
       }, 'Save this column selection')

--- a/src/components/data/SavedColumnSettings.js
+++ b/src/components/data/SavedColumnSettings.js
@@ -120,7 +120,8 @@ const useSavedColumnSettings = ({ workspaceId, snapshotName, entityMetadata, ent
   }
 }
 
-const SavedColumnSettings = ({ workspaceId, workspace, snapshotName, entityType, entityMetadata, columnSettings, onLoad }) => {
+const SavedColumnSettings = ({ workspace, snapshotName, entityType, entityMetadata, columnSettings, onLoad }) => {
+  const { workspace: { namespace, name } } = workspace
   const [loading, setLoading] = useState(true)
   const [savedColumnSettings, setSavedColumnSettings] = useState([])
 
@@ -128,7 +129,7 @@ const SavedColumnSettings = ({ workspaceId, workspace, snapshotName, entityType,
     getSavedColumnSettings,
     saveColumnSettings,
     deleteSavedColumnSettings
-  } = useSavedColumnSettings({ workspaceId, snapshotName, entityType, entityMetadata })
+  } = useSavedColumnSettings({ workspaceId: { namespace, name }, snapshotName, entityType, entityMetadata })
 
   useOnMount(() => {
     const loadSavedColumnSettings = _.flow(

--- a/src/components/data/SavedColumnSettings.js
+++ b/src/components/data/SavedColumnSettings.js
@@ -7,6 +7,7 @@ import { AutocompleteTextInput } from 'src/components/input'
 import { MenuButton, MenuTrigger } from 'src/components/PopupTrigger'
 import { ColumnSettings } from 'src/components/table'
 import TooltipTrigger from 'src/components/TooltipTrigger'
+import { useWorkspaceDetails } from 'src/components/workspace-utils'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { withErrorReporting } from 'src/libs/error'
@@ -14,7 +15,7 @@ import Events from 'src/libs/events'
 import { FormLabel } from 'src/libs/forms'
 import { useCancellation, useOnMount } from 'src/libs/react-utils'
 import { noWrapEllipsis } from 'src/libs/style'
-import { cond, withBusyState } from 'src/libs/utils'
+import { cond, editWorkspaceError, withBusyState } from 'src/libs/utils'
 
 
 const savedColumnSettingsWorkspaceAttributeName = 'system:columnSettings'
@@ -123,6 +124,7 @@ const useSavedColumnSettings = ({ workspaceId, snapshotName, entityMetadata, ent
 const SavedColumnSettings = ({ workspaceId, snapshotName, entityType, entityMetadata, columnSettings, onLoad }) => {
   const [loading, setLoading] = useState(true)
   const [savedColumnSettings, setSavedColumnSettings] = useState([])
+  const { workspace, loading: loadingWorkspace } = useWorkspaceDetails(workspaceId, ['accessLevel', 'workspace.isLocked'])
 
   const {
     getSavedColumnSettings,
@@ -175,6 +177,7 @@ const SavedColumnSettings = ({ workspaceId, snapshotName, entityType, entityMeta
   })
 
   const selectedSettingsNameExists = _.has(selectedSettingsName, savedColumnSettings)
+  const editWorkspaceErrorMessage = workspace ? editWorkspaceError(workspace) : undefined
 
   return div({ style: { display: 'flex', flexDirection: 'column', height: '100%' } }, [
     div(showSaveForm ? [
@@ -213,6 +216,8 @@ const SavedColumnSettings = ({ workspaceId, snapshotName, entityType, entityMeta
       }, selectedSettingsNameExists ? 'Update' : 'Save')
     ] : [
       h(ButtonOutline, {
+        disabled: Boolean(editWorkspaceErrorMessage),
+        tooltip: editWorkspaceErrorMessage,
         onClick: () => { setShowSaveForm(true) }
       }, 'Save this column selection')
     ]),
@@ -257,7 +262,7 @@ const SavedColumnSettings = ({ workspaceId, snapshotName, entityType, entityMeta
       ])
     ]),
 
-    loading && spinnerOverlay
+    (loading || loadingWorkspace) && spinnerOverlay
   ])
 }
 

--- a/src/components/data/SavedColumnSettings.js
+++ b/src/components/data/SavedColumnSettings.js
@@ -7,7 +7,6 @@ import { AutocompleteTextInput } from 'src/components/input'
 import { MenuButton, MenuTrigger } from 'src/components/PopupTrigger'
 import { ColumnSettings } from 'src/components/table'
 import TooltipTrigger from 'src/components/TooltipTrigger'
-import { useWorkspaceDetails } from 'src/components/workspace-utils'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { withErrorReporting } from 'src/libs/error'
@@ -121,10 +120,9 @@ const useSavedColumnSettings = ({ workspaceId, snapshotName, entityMetadata, ent
   }
 }
 
-const SavedColumnSettings = ({ workspaceId, snapshotName, entityType, entityMetadata, columnSettings, onLoad }) => {
+const SavedColumnSettings = ({ workspaceId, workspace, snapshotName, entityType, entityMetadata, columnSettings, onLoad }) => {
   const [loading, setLoading] = useState(true)
   const [savedColumnSettings, setSavedColumnSettings] = useState([])
-  const { workspace, loading: loadingWorkspace } = useWorkspaceDetails(workspaceId, ['accessLevel', 'workspace.isLocked'])
 
   const {
     getSavedColumnSettings,
@@ -263,7 +261,7 @@ const SavedColumnSettings = ({ workspaceId, snapshotName, entityType, entityMeta
       ])
     ]),
 
-    (loading || loadingWorkspace) && spinnerOverlay
+    loading && spinnerOverlay
   ])
 }
 

--- a/src/components/workspace-utils.js
+++ b/src/components/workspace-utils.js
@@ -38,6 +38,25 @@ export const useWorkspaces = () => {
   return { workspaces, refresh, loading }
 }
 
+export const useWorkspaceDetails = ({ namespace, name }, fields) => {
+  const [workspace, setWorkspace] = useState()
+
+  const [loading, setLoading] = useState(true)
+  const signal = useCancellation()
+
+  const refresh = _.flow(
+    withErrorReporting('Error loading workspace'),
+    Utils.withBusyState(setLoading)
+  )(async () => {
+    const ws = await Ajax(signal).Workspaces.workspace(namespace, name).details(fields)
+    setWorkspace(ws)
+  })
+
+  useOnMount(refresh)
+
+  return { workspace, refresh, loading }
+}
+
 export const withWorkspaces = WrappedComponent => {
   return withDisplayName('withWorkspaces', props => {
     const { workspaces, refresh, loading } = useWorkspaces()

--- a/src/components/workspace-utils.js
+++ b/src/components/workspace-utils.js
@@ -45,7 +45,7 @@ export const useWorkspaceDetails = ({ namespace, name }, fields) => {
   const signal = useCancellation()
 
   const refresh = _.flow(
-    withErrorReporting('Error loading workspace'),
+    withErrorReporting('Error loading workspace details'),
     Utils.withBusyState(setLoading)
   )(async () => {
     const ws = await Ajax(signal).Workspaces.workspace(namespace, name).details(fields)

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -14,13 +14,12 @@ import { SimpleTabBar } from 'src/components/tabBars'
 import { FlexTable } from 'src/components/table'
 import TooltipTrigger from 'src/components/TooltipTrigger'
 import TopBar from 'src/components/TopBar'
-import { NoWorkspacesMessage, useWorkspaces, WorkspaceTagSelect } from 'src/components/workspace-utils'
+import { NoWorkspacesMessage, useWorkspaceDetails, useWorkspaces, WorkspaceTagSelect } from 'src/components/workspace-utils'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
-import { withErrorReporting } from 'src/libs/error'
 import Events from 'src/libs/events'
 import * as Nav from 'src/libs/nav'
-import { useCancellation, useOnMount } from 'src/libs/react-utils'
+import { useOnMount } from 'src/libs/react-utils'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 import DeleteWorkspaceModal from 'src/pages/workspaces/workspace/DeleteWorkspaceModal'
@@ -49,15 +48,7 @@ const workspaceSubmissionStatus = ({ workspaceSubmissionStats: { runningSubmissi
 }
 
 const WorkspaceMenuContent = ({ namespace, name, onClone, onShare, onDelete, onLock }) => {
-  const [workspace, setWorkspace] = useState(undefined)
-  const signal = useCancellation()
-  const loadWorkspace = withErrorReporting('Error loading workspace', async () => {
-    setWorkspace(await Ajax(signal).Workspaces.workspace(namespace, name).details(['accessLevel', 'canShare', 'workspace.isLocked']))
-  })
-  useOnMount(() => {
-    loadWorkspace()
-  })
-
+  const { workspace } = useWorkspaceDetails({ namespace, name }, ['accessLevel', 'canShare', 'workspace.isLocked'])
   const canRead = workspace && Utils.canRead(workspace.accessLevel)
   const canShare = workspace?.canShare
   const isOwner = workspace && Utils.isOwner(workspace.accessLevel)

--- a/src/pages/workspaces/workspace/workflows/DataStepContent.js
+++ b/src/pages/workspaces/workspace/workflows/DataStepContent.js
@@ -17,8 +17,9 @@ import validate from 'validate.js'
 const DataStepContent = ({
   entitySelectionModel, onDismiss, onSuccess,
   entityMetadata, rootEntityType,
-  workspace, workspace: { workspace: { namespace, name, googleProject, attributes: { 'workspace-column-defaults': columnDefaults } } }
+  workspace
 }) => {
+  const { workspace: { namespace, name, googleProject, attributes: { 'workspace-column-defaults': columnDefaults } } } = workspace
   // State
   const [type, setType] = useState(entitySelectionModel.type)
   const [selectedEntities, setSelectedEntities] = useState(entitySelectionModel.selectedEntities)

--- a/src/pages/workspaces/workspace/workflows/DataStepContent.js
+++ b/src/pages/workspaces/workspace/workflows/DataStepContent.js
@@ -17,7 +17,7 @@ import validate from 'validate.js'
 const DataStepContent = ({
   entitySelectionModel, onDismiss, onSuccess,
   entityMetadata, rootEntityType,
-  workspace: { namespace, name, googleProject, attributes: { 'workspace-column-defaults': columnDefaults } }
+  workspace, workspace: { workspace: { namespace, name, googleProject, attributes: { 'workspace-column-defaults': columnDefaults } } }
 }) => {
   // State
   const [type, setType] = useState(entitySelectionModel.type)
@@ -118,7 +118,7 @@ const DataStepContent = ({
             [chooseRootType, () => rootEntityType],
             [chooseSetType, () => entitySetType]
           ),
-          entityMetadata, setEntityMetadata: () => {}, googleProject, workspaceId: { namespace, name }, columnDefaults,
+          entityMetadata, setEntityMetadata: () => {}, googleProject, workspaceId: { namespace, name }, workspace, columnDefaults,
           selectionModel: {
             selected: selectedEntities, setSelected: setSelectedEntities
           }

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -930,7 +930,7 @@ const WorkflowView = _.flow(
           this.setState({ selectingData: false })
         },
         onSuccess: model => this.setState({ entitySelectionModel: model, selectingData: false }),
-        workspace,
+        workspace: ws,
         rootEntityType: modifiedConfig.rootEntityType
       })
     ])


### PR DESCRIPTION
Fixup for #2878.

Saving column settings requires updating workspace attributes. If the user does not have write access to the workspace or the workspace is locked, that API request will fail. This disables the save button and adds a tooltip for those cases.

![Screen Shot 2022-03-16 at 11 33 00 AM](https://user-images.githubusercontent.com/1156625/158627878-a68d8a6b-7e1d-4a0e-a354-683863831276.png)