### PR TITLE
[SU-2] Validate collection names in data uploader

### DIFF
--- a/src/pages/Upload.js
+++ b/src/pages/Upload.js
@@ -403,7 +403,7 @@ const CollectionSelectorPanel = _.flow(
     ]),
     isCreating && h(NameModal, {
       thing: 'Collection',
-      validator: /^[^ /#*?\[\]]+$/, // eslint-disable-line no-useless-escape
+      validator: /^[^\s/#*?\[\]]+$/, // eslint-disable-line no-useless-escape
       validationMessage: 'Collection name may not contain spaces, forward slashes, or any of the following characters: # * ? [ ]',
       onDismiss: () => setCreating(false),
       onSuccess: ({ name }) => setCollection(name)

--- a/src/pages/Upload.js
+++ b/src/pages/Upload.js
@@ -403,6 +403,8 @@ const CollectionSelectorPanel = _.flow(
     ]),
     isCreating && h(NameModal, {
       thing: 'Collection',
+      validator: /^[^ /#*?\[\]]+$/, // eslint-disable-line no-useless-escape
+      validationMessage: 'Collection name may not contain spaces, forward slashes, or any of the following characters: # * ? [ ]',
       onDismiss: () => setCreating(false),
       onSuccess: ({ name }) => setCollection(name)
     }),


### PR DESCRIPTION
Collection names in the data uploader (http://localhost:3000/#upload) are used to create "directories" in the workspace's GCS bucket. Thus, some characters cause issues. Forward slashes create nested directories that break Terra's assumptions about collections. Spaces aren't handled by well by Cromwell / workflows. And Google recommends excluding a few other characters (https://cloud.google.com/storage/docs/naming-objects#objectnames).

This adds validation to the collection name input to disallow using those characters. 