### PR TITLE
[IA-3245] Disabled GPU checkbox for RStudio

### DIFF
--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -872,7 +872,8 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
       _.head(validGpuNames)
     const validNumGpusOptions = _.flow(_.filter({ name: validGpuName }), _.map('numGpus'))(validGpuOptions)
     const validNumGpus = _.includes(computeConfig.numGpus, validNumGpusOptions) ? computeConfig.numGpus : _.head(validNumGpusOptions)
-    const gpuCheckboxDisabled = computeExists ? !computeConfig.gpuEnabled : isDataproc(runtimeType)
+    const isRStudio = getToolForImage(_.find({ image: selectedLeoImage }, leoImages)?.id) === tools.RStudio.label
+    const gpuCheckboxDisabled = computeExists ? !computeConfig.gpuEnabled : isDataproc(runtimeType) || isRStudio
     const enableGpusSpan = span(
       ['Enable GPUs ', betaVersionTag])
     const autoPauseCheckboxEnabled = true
@@ -929,7 +930,8 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
           }, [
             span({ style: { marginLeft: '0.5rem', ...computeStyles.label, verticalAlign: 'top' } }, [
               gpuCheckboxDisabled ?
-                h(TooltipTrigger, { content: ['GPUs can be added only to Standard VM compute at creation time.'], side: 'right' }, [enableGpusSpan]) :
+                h(TooltipTrigger, { content: [isRStudio? 'GPUs are not currently supported for the selected configuration'
+                    : 'GPUs can be added only to Standard VM compute at creation time.'], side: 'right' }, [enableGpusSpan]) :
                 enableGpusSpan
             ]),
             h(Link, {

--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -328,7 +328,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
     onSuccess()
   })
 
-  const requiresGCE = () => getToolForImage(_.find({ image: selectedLeoImage }, leoImages)?.id) === tools.RStudio.label
+  const isRStudioImage = getToolForImage(_.find({ image: selectedLeoImage }, leoImages)?.id) === tools.RStudio.label
 
   const canUpdateRuntime = () => {
     const { runtime: existingRuntime, autopauseThreshold: existingAutopauseThreshold } = getExistingEnvironmentConfig()
@@ -872,10 +872,8 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
       _.head(validGpuNames)
     const validNumGpusOptions = _.flow(_.filter({ name: validGpuName }), _.map('numGpus'))(validGpuOptions)
     const validNumGpus = _.includes(computeConfig.numGpus, validNumGpusOptions) ? computeConfig.numGpus : _.head(validNumGpusOptions)
-    const isRStudio = getToolForImage(_.find({ image: selectedLeoImage }, leoImages)?.id) === tools.RStudio.label
-    const gpuCheckboxDisabled = computeExists ? !computeConfig.gpuEnabled : isDataproc(runtimeType) || isRStudio
-    const enableGpusSpan = span(
-      ['Enable GPUs ', betaVersionTag])
+    const gpuCheckboxDisabled = computeExists ? !computeConfig.gpuEnabled : isDataproc(runtimeType) || isRStudioImage
+    const enableGpusSpan = span(['Enable GPUs ', betaVersionTag])
     const autoPauseCheckboxEnabled = true
     const enableAutopauseSpan = span(['Enable autopause'])
     const gridStyle = { display: 'grid', gridGap: '1.3rem', alignItems: 'center', marginTop: '1rem' }
@@ -930,9 +928,12 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
           }, [
             span({ style: { marginLeft: '0.5rem', ...computeStyles.label, verticalAlign: 'top' } }, [
               gpuCheckboxDisabled ?
-                h(TooltipTrigger, { content: [isRStudio? 'GPUs are not currently supported for the selected configuration'
-                    : 'GPUs can be added only to Standard VM compute at creation time.'], side: 'right' }, [enableGpusSpan]) :
-                enableGpusSpan
+                h(TooltipTrigger, {
+                  content: isRStudioImage ?
+                    'GPUs are not currently supported for the selected application configuration.' :
+                    'GPUs can be added only to Standard VM compute at creation time.',
+                  side: 'right'
+                }, [enableGpusSpan]) : enableGpusSpan
             ]),
             h(Link, {
               style: { marginLeft: '1rem', verticalAlign: 'top' },
@@ -995,7 +996,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
           h(IdContainer, [
             id => div({ style: { gridColumnEnd: 'span 4', marginTop: '0.5rem' } }, [
               label({ htmlFor: id, style: computeStyles.label }, ['Compute type']),
-              (requiresGCE() || requiresSpark) && h(InfoBox, { style: { marginLeft: '0.5rem' } }, [
+              (isRStudioImage || requiresSpark) && h(InfoBox, { style: { marginLeft: '0.5rem' } }, [
                 'Only the compute types compatible with the selected application configuration are made available below.'
               ]),
               div({ style: { display: 'flex', alignItems: 'center', marginTop: '0.5rem' } }, [
@@ -1010,8 +1011,8 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
                     },
                     options: [
                       { value: runtimeTypes.gceVm, isDisabled: requiresSpark },
-                      { value: runtimeTypes.dataprocSingleNode, isDisabled: requiresGCE() },
-                      { value: runtimeTypes.dataprocCluster, isDisabled: requiresGCE() }
+                      { value: runtimeTypes.dataprocSingleNode, isDisabled: isRStudioImage },
+                      { value: runtimeTypes.dataprocCluster, isDisabled: isRStudioImage }
                     ]
                   })
                 ]),
@@ -1034,7 +1035,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
           onChange: v => updateComputeConfig('autopauseThreshold', getAutopauseThreshold(v))
         }, [
           span({ style: { marginLeft: '0.5rem', ...computeStyles.label, verticalAlign: 'top' } }, [
-              enableAutopauseSpan
+            enableAutopauseSpan
           ]),
           h(Link, {
             style: { marginLeft: '1rem', verticalAlign: 'top' },


### PR DESCRIPTION
Modified the value of `gpuCheckboxDisabled` so that it is true if RStudio is selected, and modified the tooltip wording for this case as it did not match the previous language.

Tested by selecting multiple environment options during runtime creation to make sure that the GPU checkbox was disabled for RStudio and enabled for all others. Also tested creating an RStudio environment and checked that the checkbox remained disabled for all environments.

Before (GPU not disabled for RStudio):
![Screen Shot 2022-03-18 at 9 30 15 AM](https://user-images.githubusercontent.com/97535660/159011701-51ae0610-fe0d-4f2a-8770-db239c095c03.png)

After:
![Screen Shot 2022-03-17 at 3 00 31 PM](https://user-images.githubusercontent.com/97535660/159011389-039303af-2352-42ea-aba5-04de5b7c869a.png)