### PR TITLE
[WOR-174] Add category breakdown to spend report

### DIFF
--- a/integration-tests/tests/billing-projects.js
+++ b/integration-tests/tests/billing-projects.js
@@ -115,18 +115,18 @@ const testBillingSpendReportFn = withUserToken(async ({ page, testUrl, token }) 
   const billingPage = billingProjectsPage(page, testUrl)
   await billingPage.visit()
   await billingPage.selectSpendReport(billingProjectName)
-  // Title and cost are in different elements, but checking both in same text assert to verify that category is correctly associated to cost.
+  // Title and cost are in different elements, but check both in same text assert to verify that category is correctly associated to its cost.
   await billingPage.assertText('Total spend$1,110.00')
   await billingPage.assertText('Total compute$999.00')
   await billingPage.assertText('Total storage$22.00')
   await billingPage.assertText('Total other$89.00')
   // Check that chart loaded, and workspaces are sorted by cost.
   await billingPage.assertText('Spend By Workspace')
-  // Verify all series values of the most expensive workspace
+  // Verify all series values of the most expensive workspace.
   await billingPage.assertChartValue(1, 'Most Expensive Workspace', 'Compute', '$900.00')
   await billingPage.assertChartValue(1, 'Most Expensive Workspace', 'Other', '$80.00')
   await billingPage.assertChartValue(1, 'Most Expensive Workspace', 'Storage', '$20.00')
-  // Spot check other 2 workspaces
+  // Spot-check other 2 workspaces.
   await billingPage.assertChartValue(2, 'Second Most Expensive Workspace', 'Compute', '$90.00')
   await billingPage.assertChartValue(3, 'Third Most Expensive Workspace', 'Storage', '$0.00')
 

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -33,7 +33,7 @@ const makeWorkspace = withSignedInPage(async ({ page, billingProject }) => {
 
     rawConsole.info(`Created workspace: ${workspaceName}`)
   } catch (e) {
-    throw Error(`Failed to create workspace: ${workspaceName} with billing project ${billingProject}. Error: ${e}.`)
+    throw Error(`Failed to create workspace: ${workspaceName} with billing project ${billingProject}`)
   }
   return workspaceName
 })
@@ -47,7 +47,7 @@ const deleteWorkspace = withSignedInPage(async ({ page, billingProject, workspac
 
     rawConsole.info(`Deleted workspace: ${workspaceName}`)
   } catch (e) {
-    throw Error(`Failed to delete workspace: ${workspaceName} with billing project ${billingProject}. Error: ${e}.`)
+    throw Error(`Failed to delete workspace: ${workspaceName} with billing project ${billingProject}`)
   }
 })
 

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -33,7 +33,7 @@ const makeWorkspace = withSignedInPage(async ({ page, billingProject }) => {
 
     rawConsole.info(`Created workspace: ${workspaceName}`)
   } catch (e) {
-    throw Error(`Failed to create workspace: ${workspaceName} with billing project ${billingProject}`)
+    throw Error(`Failed to create workspace: ${workspaceName} with billing project ${billingProject}. Error: ${e}.`)
   }
   return workspaceName
 })
@@ -47,7 +47,7 @@ const deleteWorkspace = withSignedInPage(async ({ page, billingProject, workspac
 
     rawConsole.info(`Deleted workspace: ${workspaceName}`)
   } catch (e) {
-    throw Error(`Failed to delete workspace: ${workspaceName} with billing project ${billingProject}`)
+    throw Error(`Failed to delete workspace: ${workspaceName} with billing project ${billingProject}. Error: ${e}.`)
   }
 })
 

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -575,7 +575,7 @@ const Billing = signal => ({
    */
   getSpendReport: async ({ billingProjectName, startDate, endDate }) => {
     const res = await fetchRawls(
-      `billing/v2/${billingProjectName}/spendReport?${qs.stringify({ startDate, endDate, aggregationKey: 'Workspace' })}`,
+      `billing/v2/${billingProjectName}/spendReport?${qs.stringify({ startDate, endDate, aggregationKey: 'Workspace~Category' })}&${qs.stringify({ aggregationKey: 'Category' })}`,
       _.merge(authOpts(), { signal })
     )
     return res.json()

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -1,3 +1,4 @@
+import { addDays } from 'date-fns/fp'
 import _ from 'lodash/fp'
 import * as qs from 'qs'
 import { Fragment, lazy, Suspense, useEffect, useMemo, useState } from 'react'
@@ -460,7 +461,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
       if (!updatingProjectCost && projectCost === null && tab === spendReportKey) {
         setUpdatingProjectCost(true)
         const endDate = new Date().toISOString().slice(0, 10)
-        const startDate = new Date((Date.now() - spendReportLengthInDays * 24 * 60 * 60 * 1000)).toISOString().slice(0, 10)
+        const startDate = addDays(-1 * spendReportLengthInDays, new Date()).toISOString().slice(0, 10)
         const spend = await Ajax(signal).Billing.getSpendReport({ billingProjectName: billingProject.projectName, startDate, endDate })
         const costFormatter = new Intl.NumberFormat(navigator.language, { style: 'currency', currency: spend.spendSummary.currency })
         const categoryDetails = _.find(details => details.aggregationKey === 'Category')(spend.spendDetails)

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -493,7 +493,6 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
           _.slice(0, maxWorkspacesInChart)
         )(workspaceDetails?.spendData)
         // Pull out names and costs.
-
         const costPerWorkspace = {
           workspaceNames: [], workspaceCosts: [], computeCosts: [], storageCosts: [], otherCosts: [],
           costFormatter, numWorkspaces: workspaceDetails?.spendData.length

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -230,6 +230,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
     { namespace: billingProject.projectName },
     _.map('workspace', workspaces)
   ), [billingProject, workspaces])
+
   const spendChartOptions = {
     chart: { type: 'bar', style: { fontFamily: 'inherit' } },
     credits: { enabled: false },

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -264,6 +264,13 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
       title: { enabled: false },
       width: '96%'
     },
+    accessibility: {
+      point: {
+        descriptionFormatter: point => {
+          return `${point.index + 1}. Workspace ${point.category}, ${point.series.name}: ${costPerWorkspace.costFormatter.format(point.y)}.`
+        }
+      }
+    },
     exporting: { buttons: { contextButton: { x: -15 } } }
   }
 
@@ -457,7 +464,6 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
         const costFormatter = new Intl.NumberFormat(navigator.language, { style: 'currency', currency: spend.spendSummary.currency })
         const categoryDetails = _.find(details => details.aggregationKey === 'Category')(spend.spendDetails)
         console.assert(categoryDetails !== undefined, 'Spend report details do not include aggregation by Category')
-
         const getCategoryCosts = (categorySpendData, asFloat) => {
           const costDict = {}
           _.forEach(type => {

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -247,7 +247,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
       followPointer: true,
       shared: true,
       headerFormat: '{point.key}',
-      pointFormatter: function() {
+      pointFormatter: function() { // eslint-disable-line object-shorthand
         return `<br/><span style="color:${this.color}">\u25CF</span> ${this.series.name}: ${costPerWorkspace.costFormatter.format(this.y)}`
       }
     },
@@ -258,7 +258,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
     yAxis: {
       crosshair: true, min: 0,
       labels: {
-        formatter: function() { return costPerWorkspace.costFormatter.format(this.value) },
+        formatter: function() { return costPerWorkspace.costFormatter.format(this.value) }, // eslint-disable-line object-shorthand
         style: { fontSize: '12px' }
       },
       title: { enabled: false },
@@ -488,7 +488,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
 
         const costPerWorkspace = {
           workspaceNames: [], workspaceCosts: [], computeCosts: [], storageCosts: [], otherCosts: [],
-          costFormatter: costFormatter, numWorkspaces: workspaceDetails?.spendData.length
+          costFormatter, numWorkspaces: workspaceDetails?.spendData.length
         }
         _.forEach(workspaceCostData => {
           costPerWorkspace.workspaceNames.push(workspaceCostData.workspace.name)

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -218,7 +218,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
   const [workspaceSort, setWorkspaceSort] = useState({ field: 'name', direction: 'asc' })
   const [projectCost, setProjectCost] = useState(null)
   const [costPerWorkspace, setCostPerWorkspace] = useState(
-    { workspaceNames: [], workspaceCosts: [], computeCosts: [], otherCosts: [], storageCosts: [], numWorkspaces: 0, costFormatter: null }
+    { workspaceNames: [], computeCosts: [], otherCosts: [], storageCosts: [], numWorkspaces: 0, costFormatter: null }
   )
   const [updatingProjectCost, setUpdatingProjectCost] = useState(false)
   const [spendReportLengthInDays, setSpendReportLengthInDays] = useState(30)
@@ -494,12 +494,10 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
         )(workspaceDetails?.spendData)
         // Pull out names and costs.
         const costPerWorkspace = {
-          workspaceNames: [], workspaceCosts: [], computeCosts: [], storageCosts: [], otherCosts: [],
-          costFormatter, numWorkspaces: workspaceDetails?.spendData.length
+          workspaceNames: [], computeCosts: [], storageCosts: [], otherCosts: [], costFormatter, numWorkspaces: workspaceDetails?.spendData.length
         }
         _.forEach(workspaceCostData => {
           costPerWorkspace.workspaceNames.push(workspaceCostData.workspace.name)
-          costPerWorkspace.workspaceCosts.push(parseFloat(workspaceCostData.cost))
           const categoryDetails = workspaceCostData.subAggregation
           console.assert(categoryDetails.key !== 'Category', 'Workspace spend report details do not include sub-aggregation by Category')
           const costDict = getCategoryCosts(categoryDetails.spendData, true)

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -233,7 +233,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
   ), [billingProject, workspaces])
 
   const spendChartOptions = {
-    chart: { type: 'bar', style: { fontFamily: 'inherit' } },
+    chart: { marginTop: 50, spacingLeft: 20, style: { fontFamily: 'inherit' }, type: 'bar' },
     credits: { enabled: false },
     legend: { reversed: true },
     plotOptions: { series: { stacking: 'normal' } },
@@ -243,6 +243,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
       { name: 'Other', data: costPerWorkspace.otherCosts }
     ],
     title: {
+      align: 'left', style: { fontSize: '16px' }, y: 25,
       text: costPerWorkspace.numWorkspaces > maxWorkspacesInChart ? `Top ${maxWorkspacesInChart} Spending Workspaces` : 'Spend By Workspace'
     },
     tooltip: {

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -1,4 +1,4 @@
-import { addDays } from 'date-fns/fp'
+import { subDays } from 'date-fns/fp'
 import _ from 'lodash/fp'
 import * as qs from 'qs'
 import { Fragment, lazy, Suspense, useEffect, useMemo, useState } from 'react'
@@ -462,7 +462,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
       if (!updatingProjectCost && projectCost === null && tab === spendReportKey) {
         setUpdatingProjectCost(true)
         const endDate = new Date().toISOString().slice(0, 10)
-        const startDate = addDays(-1 * spendReportLengthInDays, new Date()).toISOString().slice(0, 10)
+        const startDate = subDays(spendReportLengthInDays, new Date()).toISOString().slice(0, 10)
         const spend = await Ajax(signal).Billing.getSpendReport({ billingProjectName: billingProject.projectName, startDate, endDate })
         const costFormatter = new Intl.NumberFormat(navigator.language, { style: 'currency', currency: spend.spendSummary.currency })
         const categoryDetails = _.find(details => details.aggregationKey === 'Category')(spend.spendDetails)


### PR DESCRIPTION
This builds on top of https://github.com/DataBiosphere/terra-ui/pull/2891 to add breakdown by category. The ticket is [WOR-174](https://broadworkbench.atlassian.net/browse/WOR-174) (I got the wrong ticket number when I created the branch… I will update the commit message when merging the PR).

To test:
1. Log in as "hermione.owner" (must be billing report owner, and must be in the alpha testing group).
2. Select `galaxy-anvil-dev` billing project. http://localhost:3000/#billing?selectedName=galaxy-anvil-dev&type=project&tab=spend%20report

![image](https://user-images.githubusercontent.com/484484/159190039-b9880658-26c7-40d6-b8da-fca947ba7d53.png)
