### PR TITLE
[DC-281] Update circle puppeteer image to non-deprecated next-gen image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ executors:
   puppeteer:
     working_directory: /mnt/ramdisk
     docker:
-      - image: cimg/node:16-browsers
+      - image: cimg/node:16.14-browsers
   gcloud:
     working_directory: /mnt/ramdisk
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ executors:
   node:
     working_directory: /mnt/ramdisk
     docker:
-      - image: node:16
+      - image: cimg/node:16.14
         user: node
   puppeteer:
     working_directory: /mnt/ramdisk

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,6 @@ executors:
     working_directory: /mnt/ramdisk
     docker:
       - image: cimg/node:16.14
-        user: node
   puppeteer:
     working_directory: /mnt/ramdisk
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ executors:
   puppeteer:
     working_directory: /mnt/ramdisk
     docker:
-      - image: circleci/node:16-browsers
+      - image: cimg/node:16-browsers
   gcloud:
     working_directory: /mnt/ramdisk
     docker:


### PR DESCRIPTION
Our current circle config is using a deprecated convenience image:
https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034

This PR updates the image to a supported image.
