### PR TITLE
[SU-25] Refactor EntityEditor

### DIFF
--- a/src/components/data/_tests/data-utils.test.js
+++ b/src/components/data/_tests/data-utils.test.js
@@ -72,9 +72,9 @@ describe('getAttributeType', () => {
       entityName: 'thing_one'
     })).toEqual({ type: 'reference', isList: false })
 
-    expect(getAttributeType({ items: ['a', 'b', 'c'] })).toEqual({ type: 'string', isList: true })
-    expect(getAttributeType({ items: [1, 2, 3] })).toEqual({ type: 'number', isList: true })
-    expect(getAttributeType({ items: [true, false] })).toEqual({ type: 'boolean', isList: true })
+    expect(getAttributeType({ items: ['a', 'b', 'c'], itemsType: 'AttributeValue' })).toEqual({ type: 'string', isList: true })
+    expect(getAttributeType({ items: [1, 2, 3], itemsType: 'AttributeValue' })).toEqual({ type: 'number', isList: true })
+    expect(getAttributeType({ items: [true, false], itemsType: 'AttributeValue' })).toEqual({ type: 'boolean', isList: true })
     expect(getAttributeType({
       items: [
         { entityType: 'thing', entityName: 'thing_one' },
@@ -86,8 +86,8 @@ describe('getAttributeType', () => {
 
   it('returns string for null values', () => {
     expect(getAttributeType(null)).toEqual({ type: 'string', isList: false })
-    expect(getAttributeType({ items: [] })).toEqual({ type: 'string', isList: true })
-    expect(getAttributeType({ items: [null] })).toEqual({ type: 'string', isList: true })
+    expect(getAttributeType({ items: [], itemsType: 'AttributeValue' })).toEqual({ type: 'string', isList: true })
+    expect(getAttributeType({ items: [null], itemsType: 'AttributeValue' })).toEqual({ type: 'string', isList: true })
   })
 })
 
@@ -116,7 +116,7 @@ describe('convertAttributeValue', () => {
   })
 
   it('converts each value of lists', () => {
-    expect(convertAttributeValue({ items: ['42', 'value'] }, 'number')).toEqual({ items: [42, 0] })
+    expect(convertAttributeValue({ items: ['42', 'value'], itemsType: 'AttributeValue' }, 'number')).toEqual({ items: [42, 0], itemsType: 'AttributeValue' })
 
     expect(convertAttributeValue({
       items: [
@@ -124,11 +124,11 @@ describe('convertAttributeValue', () => {
         { entityType: 'thing', entityName: 'thing_two' }
       ],
       itemsType: 'EntityReference'
-    }, 'string')).toEqual({ items: ['thing_one', 'thing_two'] })
+    }, 'string')).toEqual({ items: ['thing_one', 'thing_two'], itemsType: 'AttributeValue' })
   })
 
   it('adds itemsType to reference lists', () => {
-    expect(convertAttributeValue({ items: ['thing_one', 'thing_two'] }, 'reference', 'thing')).toEqual({
+    expect(convertAttributeValue({ items: ['thing_one', 'thing_two'], itemsType: 'AttributeValue' }, 'reference', 'thing')).toEqual({
       items: [
         { entityType: 'thing', entityName: 'thing_one' },
         { entityType: 'thing', entityName: 'thing_two' }

--- a/src/components/data/_tests/data-utils.test.js
+++ b/src/components/data/_tests/data-utils.test.js
@@ -1,4 +1,4 @@
-import { concatenateAttributeNames } from 'src/components/data/data-utils.js'
+import { concatenateAttributeNames, convertAttributeValue, getAttributeType } from 'src/components/data/data-utils.js'
 
 
 describe('concatenateAttributeNames', () => {
@@ -59,5 +59,81 @@ describe('concatenateAttributeNames', () => {
     const attrList2 = ['namespace:bbb', 'aaa']
     const expected = ['aaa', 'ddd', 'namespace:aaa', 'namespace:bbb', 'namespace:ccc']
     expect(concatenateAttributeNames(attrList1, attrList2)).toEqual(expected)
+  })
+})
+
+describe('getAttributeType', () => {
+  it('returns type of attribute value', () => {
+    expect(getAttributeType('value')).toEqual({ type: 'string', isList: false })
+    expect(getAttributeType(3)).toEqual({ type: 'number', isList: false })
+    expect(getAttributeType(false)).toEqual({ type: 'boolean', isList: false })
+    expect(getAttributeType({
+      entityType: 'thing',
+      entityName: 'thing_one'
+    })).toEqual({ type: 'reference', isList: false })
+
+    expect(getAttributeType({ items: ['a', 'b', 'c'] })).toEqual({ type: 'string', isList: true })
+    expect(getAttributeType({ items: [1, 2, 3] })).toEqual({ type: 'number', isList: true })
+    expect(getAttributeType({ items: [true, false] })).toEqual({ type: 'boolean', isList: true })
+    expect(getAttributeType({
+      items: [
+        { entityType: 'thing', entityName: 'thing_one' },
+        { entityType: 'thing', entityName: 'thing_two' }
+      ],
+      itemsType: 'EntityReference'
+    })).toEqual({ type: 'reference', isList: true })
+  })
+
+  it('returns string for null values', () => {
+    expect(getAttributeType(null)).toEqual({ type: 'string', isList: false })
+    expect(getAttributeType({ items: [] })).toEqual({ type: 'string', isList: true })
+    expect(getAttributeType({ items: [null] })).toEqual({ type: 'string', isList: true })
+  })
+})
+
+describe('convertAttributeValue', () => {
+  it('converts between different attribute types', () => {
+    expect(convertAttributeValue('42', 'number')).toEqual(42)
+    expect(convertAttributeValue('a_string', 'number')).toEqual(0)
+    expect(convertAttributeValue('a_string', 'boolean')).toEqual(true)
+    expect(convertAttributeValue('a_string', 'reference', 'thing')).toEqual({ entityType: 'thing', entityName: 'a_string' })
+
+    expect(convertAttributeValue(7, 'string')).toEqual('7')
+    expect(convertAttributeValue(7, 'boolean')).toEqual(true)
+    expect(convertAttributeValue(7, 'reference', 'thing')).toEqual({ entityType: 'thing', entityName: '7' })
+
+    expect(convertAttributeValue(true, 'string')).toEqual('true')
+    expect(convertAttributeValue(true, 'number')).toEqual(1)
+    expect(convertAttributeValue(false, 'reference', 'thing')).toEqual({ entityType: 'thing', entityName: 'false' })
+
+    expect(convertAttributeValue({ entityType: 'thing', entityName: 'thing_one' }, 'string')).toEqual('thing_one')
+    expect(convertAttributeValue({ entityType: 'thing', entityName: 'thing_one' }, 'number')).toEqual(0)
+    expect(convertAttributeValue({ entityType: 'thing', entityName: 'thing_one' }, 'boolean')).toEqual(true)
+  })
+
+  it('throws an error if attempting to convert to a reference without an entity type', () => {
+    expect(() => convertAttributeValue('thing_one', 'reference')).toThrowError()
+  })
+
+  it('converts each value of lists', () => {
+    expect(convertAttributeValue({ items: ['42', 'value'] }, 'number')).toEqual({ items: [42, 0] })
+
+    expect(convertAttributeValue({
+      items: [
+        { entityType: 'thing', entityName: 'thing_one' },
+        { entityType: 'thing', entityName: 'thing_two' }
+      ],
+      itemsType: 'EntityReference'
+    }, 'string')).toEqual({ items: ['thing_one', 'thing_two'] })
+  })
+
+  it('adds itemsType to reference lists', () => {
+    expect(convertAttributeValue({ items: ['thing_one', 'thing_two'] }, 'reference', 'thing')).toEqual({
+      items: [
+        { entityType: 'thing', entityName: 'thing_one' },
+        { entityType: 'thing', entityName: 'thing_two' }
+      ],
+      itemsType: 'EntityReference'
+    })
   })
 })

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -512,7 +512,7 @@ export const convertAttributeValue = (attributeValue, newType, referenceEntityTy
   if (isList) {
     return _.flow(
       _.update('items', _.map(convertFn)),
-      newType === 'reference' ? _.set('itemsType', 'EntityReference') : _.omit('itemsType')
+      _.set('itemsType', newType === 'reference' ? 'EntityReference' : 'AttributeValue')
     )(attributeValue)
   }
 
@@ -622,11 +622,9 @@ const AttributeInput = ({ value: attributeValue, onChange, entityTypes = [] }) =
       h(LabeledCheckbox, {
         checked: isList,
         onChange: willBeList => {
-          const newAttributeValue = Utils.cond(
-            [willBeList && attributeType === 'reference', () => ({ items: [attributeValue], itemsType: 'EntityReference' })],
-            [willBeList, () => ({ items: [attributeValue] })],
-            () => attributeValue.items[0]
-          )
+          const newAttributeValue = willBeList ?
+            { items: [attributeValue], itemsType: attributeType === 'reference' ? 'EntityReference' : 'AttributeValue' } :
+            attributeValue.items[0]
           onChange(newAttributeValue)
         }
       }, [

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -535,7 +535,7 @@ const renderInputForAttributeType = _.curry((attributeType, props) => {
       const { value, onChange, ...otherProps } = props
       return h(TextInput, {
         autoFocus: true,
-        placeholder: 'Enter a value',
+        placeholder: `Enter a ${value.entityType}_id`,
         value: value.entityName,
         onChange: v => onChange({ ...value, entityName: _.trim(v) }),
         ...otherProps


### PR DESCRIPTION
The data table allows editing the value of an attribute using the EntityEditor component. This splits up EntityEditor and extracts the form for entering the attribute's value/type so that they can be reused for adding new rows (in a future PR).