### PR TITLE
[IA-3080] First set of usability testing changes from UX review

### DIFF
--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -1503,7 +1503,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
         h(TitleBar, {
           id: titleId,
           style: { marginBottom: '0.5rem' },
-          title: 'Cloud Environment',
+          title: isAnalysisMode ? `${tool} Cloud Environment` : 'Cloud Environment',
           hideCloseButton: isAnalysisMode,
           onDismiss
         }),

--- a/src/components/ContextBar.js
+++ b/src/components/ContextBar.js
@@ -35,7 +35,7 @@ const contextBarStyles = {
 }
 
 export const ContextBar = ({
-  setDeletingWorkspace, setCloningWorkspace, setSharingWorkspace, runtimes, apps, appDataDisks, refreshRuntimes, location, locationType, refreshApps,
+  runtimes, apps, appDataDisks, refreshRuntimes, location, locationType, refreshApps,
   workspace, persistentDisks, workspace: { workspace: { namespace, name: workspaceName } }
 }) => {
   const [isCloudEnvOpen, setCloudEnvOpen] = useState(false)

--- a/src/components/ContextBar.js
+++ b/src/components/ContextBar.js
@@ -18,7 +18,6 @@ import { getCurrentApp, getCurrentRuntime } from 'src/libs/runtime-utils'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 import { CloudEnvironmentModal } from 'src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal'
-import { WorkspaceMenuTrigger } from 'src/pages/workspaces/workspace/WorkspaceContainer'
 
 
 const contextBarStyles = {
@@ -45,8 +44,6 @@ export const ContextBar = ({
   const currentRuntimeTool = currentRuntime?.labels?.tool
   const isTerminalEnabled = currentRuntimeTool === tools.Jupyter.label && currentRuntime && currentRuntime.status !== 'Error'
   const terminalLaunchLink = Nav.getLink(appLauncherTabName, { namespace, name: workspaceName, application: 'terminal' })
-  const isOwner = workspace && Utils.isOwner(workspace.accessLevel)
-  const canShare = !!workspace?.canShare
   const canCompute = !!(workspace?.canCompute || runtimes?.length)
 
   const startCurrentRuntime = () => {

--- a/src/components/ContextBar.js
+++ b/src/components/ContextBar.js
@@ -105,16 +105,6 @@ export const ContextBar = ({
     }),
     div({ style: Style.elements.contextBarContainer }, [
       div({ style: contextBarStyles.contextBarContainer }, [
-        h(WorkspaceMenuTrigger, { canShare, isOwner, setCloningWorkspace, setSharingWorkspace, setDeletingWorkspace }, [
-          h(Clickable, {
-            style: contextBarStyles.contextBarButton,
-            hover: contextBarStyles.hover,
-            tooltipSide: 'left',
-            tooltip: 'Workspace menu',
-            tooltipDelay: 100,
-            useTooltipAsLabel: true
-          }, [icon('ellipsis-v', { size: 24 })])
-        ]),
         h(Clickable, {
           style: { ...contextBarStyles.contextBarButton, flexDirection: 'column', justifyContent: 'center', padding: '.75rem' },
           hover: contextBarStyles.hover,

--- a/src/components/GalaxyModal.js
+++ b/src/components/GalaxyModal.js
@@ -152,7 +152,7 @@ export const GalaxyModalBase = withDisplayName('GalaxyModal')(
       return div({ style: computeStyles.drawerContent }, [
         h(TitleBar, {
           id: titleId,
-          title: 'Cloud Environment',
+          title: 'Galaxy Cloud Environment',
           style: { marginBottom: '0.5rem' },
           hideCloseButton: isAnalysisMode,
           onDismiss,
@@ -387,7 +387,7 @@ export const GalaxyModalBase = withDisplayName('GalaxyModal')(
       return div({ style: computeStyles.drawerContent }, [
         h(TitleBar, {
           id: titleId,
-          title: 'Cloud Environment',
+          title: 'Galaxy Cloud Environment',
           hideCloseButton: isAnalysisMode,
           style: { marginBottom: '0.5rem' },
           onDismiss,

--- a/src/components/notebook-utils.js
+++ b/src/components/notebook-utils.js
@@ -77,7 +77,7 @@ export const tools = {
   jupyterTerminal: { label: 'terminal' },
   spark: { label: 'spark' },
   galaxy: { label: 'Galaxy', appType: 'GALAXY' },
-  cromwell: { label: 'cromwell', appType: 'CROMWELL', isAppHidden: !isCromwellAppVisible(), isPauseUnsupported: true }
+  cromwell: { label: 'Cromwell', appType: 'CROMWELL', isAppHidden: !isCromwellAppVisible(), isPauseUnsupported: true }
 }
 
 // Returns the tools in the order that they should be displayed for Cloud Environment tools

--- a/src/components/notebook-utils.js
+++ b/src/components/notebook-utils.js
@@ -76,7 +76,7 @@ export const tools = {
   Jupyter: { label: 'Jupyter', ext: 'ipynb', imageIds: ['terra-jupyter-bioconductor', 'terra-jupyter-bioconductor_legacy', 'terra-jupyter-hail', 'terra-jupyter-python', 'terra-jupyter-gatk', 'Pegasus', 'terra-jupyter-gatk_legacy'], defaultImageId: 'terra-jupyter-gatk' },
   jupyterTerminal: { label: 'terminal' },
   spark: { label: 'spark' },
-  galaxy: { label: 'galaxy', appType: 'GALAXY' },
+  galaxy: { label: 'Galaxy', appType: 'GALAXY' },
   cromwell: { label: 'cromwell', appType: 'CROMWELL', isAppHidden: !isCromwellAppVisible(), isPauseUnsupported: true }
 }
 

--- a/src/libs/colors.js
+++ b/src/libs/colors.js
@@ -4,7 +4,7 @@ import { isAnvil, isBaseline, isBioDataCatalyst, isDatastage, isElwazi, isFirecl
 import * as Utils from 'src/libs/utils'
 
 
-const ALL_COLORS = ['primary', 'secondary', 'accent', 'success', 'warning', 'danger', 'light', 'dark']
+const ALL_COLORS = ['primary', 'secondary', 'accent', 'success', 'warning', 'danger', 'light', 'dark', 'grey']
 
 const baseColors = {
   primary: '#4d72aa', // Used as accent on header, loading spinner, background of beta version tag and some buttons
@@ -14,7 +14,8 @@ const baseColors = {
   warning: '#f7981c',
   danger: '#db3214',
   light: '#e9ecef', // Used as header background color, lightened for background of cells, panels, etc.
-  dark: '#333f52' // Used as text color, menu background (lightened), selected background (lightened)
+  dark: '#333f52', // Used as text color, menu background (lightened), selected background (lightened)
+  grey: '#808080'
 }
 
 const colorPalette = Utils.cond(

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -61,7 +61,7 @@ const WorkspaceTabs = ({
       tabNames: _.map('name', tabs),
       getHref: currentTab => Nav.getLink(_.find({ name: currentTab }, tabs).link, { namespace, name })
     }, [
-      isAnalysisTabVisible() ? h(Fragment) : h(WorkspaceMenuTrigger, {
+      h(WorkspaceMenuTrigger, {
         canShare, isLocked, namespace, name, isOwner, setCloningWorkspace, setSharingWorkspace,
         setShowLockWorkspaceModal, setDeletingWorkspace
       }, [

--- a/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
+++ b/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
@@ -125,7 +125,7 @@ export const CloudEnvironmentModal = ({
       'aria-label': `${toolLabel} Status`,
       hover: disabled ? {} : { backgroundColor: colors.accent(0.2) },
       // css takes the last thing if there are duplicate fields, the order here is important because all three things can specify color
-      style: { ...toolButtonStyles, color: onClick && !disabled ? colors.accent() : colors.dark(0.3), ...style },
+      style: { ...toolButtonStyles, color: onClick && !disabled ? colors.accent() : colors.dark(0.3), borderColor: !disabled ? 'grey' : colors.dark(0.3), ...style },
       onClick, disabled, ...props
     }, [
       icon(shape, { size: 20 }),
@@ -287,7 +287,8 @@ export const CloudEnvironmentModal = ({
       disabled: isDisabled,
       style: {
         ...toolButtonStyles,
-        color: isDisabled ? colors.dark(0.3) : colors.accent()
+        color: isDisabled ? colors.dark(0.3) : colors.accent(),
+        borderColor: isDisabled ? colors.dark(0.3) : 'grey'
       },
       hover: isDisabled ? {} : { backgroundColor: colors.accent(0.2) },
       tooltip: Utils.cond(

--- a/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
+++ b/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
@@ -104,7 +104,8 @@ export const CloudEnvironmentModal = ({
     maxWidth: 105,
     display: 'flex',
     flexDirection: 'column',
-    border: '.5px solid grey',
+    border: '.5px solid',
+    borderColor: colors.grey(),
     borderRadius: 16,
     padding: '.5rem .75rem',
     alignItems: 'center',
@@ -125,7 +126,7 @@ export const CloudEnvironmentModal = ({
       'aria-label': `${toolLabel} Status`,
       hover: disabled ? {} : { backgroundColor: colors.accent(0.2) },
       // css takes the last thing if there are duplicate fields, the order here is important because all three things can specify color
-      style: { ...toolButtonStyles, color: onClick && !disabled ? colors.accent() : colors.dark(0.3), borderColor: !disabled ? 'grey' : colors.dark(0.3), ...style },
+      style: { ...toolButtonStyles, color: onClick && !disabled ? colors.accent() : colors.dark(0.3), ...style },
       onClick, disabled, ...props
     }, [
       icon(shape, { size: 20 }),
@@ -170,7 +171,8 @@ export const CloudEnvironmentModal = ({
     disabled: true,
     messageChildren: [span('Pause'),
       span('Environment')],
-    tooltip: 'No Environment found'
+    tooltip: 'No Environment found',
+    style: { borderColor: colors.dark(0.3) }
   })
 
   const renderStatusClickable = toolLabel => Utils.cond(
@@ -219,7 +221,8 @@ export const CloudEnvironmentModal = ({
           toolLabel,
           disabled: true,
           tooltip: 'Environment update in progress',
-          messageChildren: [span('Environment'), span(getComputeStatusForDisplay(status))]
+          messageChildren: [span('Environment'), span(getComputeStatusForDisplay(status))],
+          style: { color: colors.dark(0.7) }
         })
       case 'Error':
         return h(RuntimeIcon, {
@@ -288,7 +291,7 @@ export const CloudEnvironmentModal = ({
       style: {
         ...toolButtonStyles,
         color: isDisabled ? colors.dark(0.3) : colors.accent(),
-        borderColor: isDisabled ? colors.dark(0.3) : 'grey'
+        borderColor: isDisabled ? colors.dark(0.3) : colors.grey()
       },
       hover: isDisabled ? {} : { backgroundColor: colors.accent(0.2) },
       tooltip: Utils.cond(

--- a/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
+++ b/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
@@ -125,7 +125,7 @@ export const CloudEnvironmentModal = ({
       'aria-label': `${toolLabel} Status`,
       hover: disabled ? {} : { backgroundColor: colors.accent(0.2) },
       // css takes the last thing if there are duplicate fields, the order here is important because all three things can specify color
-      style: { ...toolButtonStyles, color: onClick && !disabled ? colors.accent() : colors.dark(0.7), ...style },
+      style: { ...toolButtonStyles, color: onClick && !disabled ? colors.accent() : colors.dark(0.3), ...style },
       onClick, disabled, ...props
     }, [
       icon(shape, { size: 20 }),
@@ -287,7 +287,7 @@ export const CloudEnvironmentModal = ({
       disabled: isDisabled,
       style: {
         ...toolButtonStyles,
-        color: isDisabled ? colors.dark(0.7) : colors.accent()
+        color: isDisabled ? colors.dark(0.3) : colors.accent()
       },
       hover: isDisabled ? {} : { backgroundColor: colors.accent(0.2) },
       tooltip: Utils.cond(
@@ -379,7 +379,7 @@ export const CloudEnvironmentModal = ({
           h(Clickable, { ...getToolLaunchClickableProps(toolLabel) }, [
             icon('rocket', { size: 20 }),
             span('Launch'),
-            span(_.capitalize(toolLabel))
+            span(toolLabel)
           ])
         ])
       ])


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3080
The changes included in this PR:

- The workspace menu (3 vertical dots) needs to be removed from the side panel and moved to its previous location
- Blue and grey button contrast in Cloud Env Modal is too “weak” and hard to differentiate - Reduce grey color shade or any other change that makes the contrast more obvious, and also makes it more clear that grey buttons are NOT usable at the time. I added logic to fade the borders when the button is not clickable. I had to hard code the 'grey' color in some areas. Is there a better way to do this?
- Change the name of each Cloud Env Page so that it mentions the app itself (Ex. Jupyter Notebook Cloud Environment, RStudio Cloud Environment, etc) - After clicking on Environment Settings button
- Capitalize S in RStudio (in the RStudio Launch button)
<!--
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Thanks!
--!>
