### PR TITLE
[SU-44] Allow resizing sidebar in data pane

### DIFF
--- a/src/components/Interactive.js
+++ b/src/components/Interactive.js
@@ -5,7 +5,7 @@ import { forwardRefWithName } from 'src/libs/react-utils'
 import * as Utils from 'src/libs/utils'
 
 
-const allowedHoverVariables = ['backgroundColor', 'border', 'color', 'boxShadow', 'opacity', 'textDecoration']
+const allowedHoverVariables = ['background', 'backgroundColor', 'border', 'color', 'boxShadow', 'opacity', 'textDecoration']
 const pointerTags = ['button', 'area', 'a', 'select']
 const pointerTypes = ['radio', 'checkbox', 'submit', 'button']
 

--- a/src/style.css
+++ b/src/style.css
@@ -8,6 +8,7 @@
 @import-normalize;
 
 .hover-style:hover, .hover-style:focus {
+  --hover-background: var(--app-hover-background);
   --hover-backgroundColor: var(--app-hover-backgroundColor);
   --hover-border: var(--app-hover-border);
   --hover-color: var(--app-hover-color);
@@ -17,6 +18,7 @@
 }
 
 .hover-style:hover .hover-style:not(:hover) {
+  --hover-background: initial;
   --hover-backgroundColor: initial;
   --hover-border: initial;
   --hover-color: initial;
@@ -91,6 +93,11 @@ a {
 .error-style {
   /* Must use important to override default react-interactive focus style */
   border: 1px solid #db3214 !important;
+  outline: none !important;
+}
+
+.custom-focus-style:focus {
+  /* Must use important to override default Interactive focus style */
   outline: none !important;
 }
 


### PR DESCRIPTION
With long table/snapshot names, it can be difficult to see what's in the data pane's sidebar. This allows resizing the sidebar. 

Style and interaction inspired by JIRA. ARIA attributes based on [MDN's article on the separator role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/separator_role#focusable_separator).

Had to add a bit to Interactive.js and styles.css to get the unique hover/focus style to work. Interactive applies an outline and currently the only options for overriding it are a blue border or a red border using using `focus-style` or `error-style` classes.

https://user-images.githubusercontent.com/1156625/159368376-396fed8d-de4e-47d4-bc44-5b4a54d1816b.mov