### PR TITLE
[WOR-174] Resubmit Add category breakdown to spend report

### DIFF
--- a/integration-tests/tests/billing-projects.js
+++ b/integration-tests/tests/billing-projects.js
@@ -19,9 +19,9 @@ const billingProjectsPage = (testPage, testUrl) => {
 
     assertText: async expectedText => await findText(testPage, expectedText),
 
-    assertChartValue: async (expectedNumber, expectedText) => {
+    assertChartValue: async (number, workspaceName, category, cost) => {
       // This checks the accessible text for chart values.
-      await testPage.waitForXPath(`(//*[@role="img"])[contains(@aria-label,"${expectedNumber}. ${expectedText}")]`)
+      await testPage.waitForXPath(`(//*[@role="img"])[contains(@aria-label,"${number}. Workspace ${workspaceName}, ${category}: ${cost}.")]`)
     }
   }
 }
@@ -31,18 +31,48 @@ const setAjaxMockValues = async (testPage, ownedBillingProjectName, spendCost, n
     spendSummary: {
       cost: spendCost, credits: '2.50', currency: 'USD', endTime: '2022-03-04T00:00:00.000Z', startTime: '2022-02-02T00:00:00.000Z'
     },
-    spendDetails: [{
-      aggregationKey: 'Workspace',
-      spendData: [
-        { cost: '100', workspace: { name: 'Second Most Expensive Workspace' } },
-        { cost: '1000', workspace: { name: 'Most Expensive Workspace' } },
-        { cost: '10', workspace: { name: 'Third Most Expensive Workspace' } }
-      ]
-    }]
+    spendDetails: [
+      {
+        aggregationKey: 'Workspace',
+        spendData: [
+          {
+            cost: '100', workspace: { name: 'Second Most Expensive Workspace' },
+            subAggregation: {
+              aggregationKey: 'Category',
+              spendData: [{ cost: '90', category: 'Compute' }, { cost: '2', category: 'Storage' }, { cost: '8', category: 'Other' }]
+            }
+          },
+          {
+            cost: '1000', workspace: { name: 'Most Expensive Workspace' },
+            subAggregation: {
+              aggregationKey: 'Category',
+              spendData: [{ cost: '900', category: 'Compute' }, { cost: '20', category: 'Storage' }, { cost: '80', category: 'Other' }]
+            }
+          },
+          {
+            cost: '10', workspace: { name: 'Third Most Expensive Workspace' },
+            subAggregation: {
+              aggregationKey: 'Category',
+              spendData: [{ cost: '9', category: 'Compute' }, { cost: '0', category: 'Storage' }, { cost: '1', category: 'Other' }]
+            }
+          }
+        ]
+      },
+      {
+        aggregationKey: 'Category',
+        spendData: [{ cost: '999', category: 'Compute' }, { cost: '22', category: 'Storage' }, { cost: '89', category: 'Other' }]
+      }
+    ]
   }
 
   _.forEach(() => {
-    spendReturnResult.spendDetails[0].spendData.push({ cost: '0.01', workspace: { name: 'Extra Inexpensive Workspace' } })
+    spendReturnResult.spendDetails[0].spendData.push({
+      cost: '0.01', workspace: { name: 'Extra Inexpensive Workspace' },
+      subAggregation: {
+        aggregationKey: 'Category',
+        spendData: [{ cost: '0.01', category: 'Compute' }, { cost: '0.00', category: 'Storage' }, { cost: '0.00', category: 'Other' }]
+      }
+    })
   }, _.range(0, numExtraWorkspaces))
 
   const projectListResult = [{
@@ -79,26 +109,34 @@ const testBillingSpendReportFn = withUserToken(async ({ page, testUrl, token }) 
 
   // Interact with the Billing Page via mocked AJAX responses.
   const billingProjectName = 'OwnedBillingProject'
-  await setAjaxMockValues(page, billingProjectName, '90.13')
+  await setAjaxMockValues(page, billingProjectName, '1110')
 
   // Select spend report and verify cost for default date ranges
   const billingPage = billingProjectsPage(page, testUrl)
   await billingPage.visit()
   await billingPage.selectSpendReport(billingProjectName)
-  await billingPage.assertText('$90.13')
+  // Title and cost are in different elements, but check both in same text assert to verify that category is correctly associated to its cost.
+  await billingPage.assertText('Total spend$1,110.00')
+  await billingPage.assertText('Total compute$999.00')
+  await billingPage.assertText('Total storage$22.00')
+  await billingPage.assertText('Total other$89.00')
   // Check that chart loaded, and workspaces are sorted by cost.
   await billingPage.assertText('Spend By Workspace')
-  await billingPage.assertChartValue(1, 'Most Expensive Workspace, $1,000')
-  await billingPage.assertChartValue(2, 'Second Most Expensive Workspace, $100')
-  await billingPage.assertChartValue(3, 'Third Most Expensive Workspace, $10')
+  // Verify all series values of the most expensive workspace.
+  await billingPage.assertChartValue(1, 'Most Expensive Workspace', 'Compute', '$900.00')
+  await billingPage.assertChartValue(1, 'Most Expensive Workspace', 'Other', '$80.00')
+  await billingPage.assertChartValue(1, 'Most Expensive Workspace', 'Storage', '$20.00')
+  // Spot-check other 2 workspaces.
+  await billingPage.assertChartValue(2, 'Second Most Expensive Workspace', 'Compute', '$90.00')
+  await billingPage.assertChartValue(3, 'Third Most Expensive Workspace', 'Storage', '$0.00')
 
   // Change the returned mock cost to mimic different date ranges.
-  await setAjaxMockValues(page, billingProjectName, '135', 20)
+  await setAjaxMockValues(page, billingProjectName, '1110.17', 20)
   await billingPage.setSpendReportDays(90)
-  await billingPage.assertText('$135.00')
+  await billingPage.assertText('Total spend$1,110.17')
   // Check that title updated to reflect truncation.
   await billingPage.assertText('Top 10 Spending Workspaces')
-  await billingPage.assertChartValue(10, 'Extra Inexpensive Workspace')
+  await billingPage.assertChartValue(10, 'Extra Inexpensive Workspace', 'Compute', '$0.01')
 })
 
 const testBillingSpendReport = {

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -575,7 +575,7 @@ const Billing = signal => ({
    */
   getSpendReport: async ({ billingProjectName, startDate, endDate }) => {
     const res = await fetchRawls(
-      `billing/v2/${billingProjectName}/spendReport?${qs.stringify({ startDate, endDate, aggregationKey: 'Workspace' })}`,
+      `billing/v2/${billingProjectName}/spendReport?${qs.stringify({ startDate, endDate, aggregationKey: 'Workspace~Category' })}&${qs.stringify({ aggregationKey: 'Category' })}`,
       _.merge(authOpts(), { signal })
     )
     return res.json()

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -1,3 +1,4 @@
+import { subDays } from 'date-fns/fp'
 import _ from 'lodash/fp'
 import * as qs from 'qs'
 import { Fragment, lazy, Suspense, useEffect, useMemo, useState } from 'react'
@@ -215,9 +216,11 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
   const [expandedWorkspaceName, setExpandedWorkspaceName] = useState()
   const [sort, setSort] = useState({ field: 'email', direction: 'asc' })
   const [workspaceSort, setWorkspaceSort] = useState({ field: 'name', direction: 'asc' })
-  const [totalCost, setTotalCost] = useState(null)
-  const [costPerWorkspace, setCostPerWorkspace] = useState({ workspaceNames: [], workspaceCosts: [], numWorkspaces: 0 })
-  const [updatingTotalCost, setUpdatingTotalCost] = useState(false)
+  const [projectCost, setProjectCost] = useState(null)
+  const [costPerWorkspace, setCostPerWorkspace] = useState(
+    { workspaceNames: [], computeCosts: [], otherCosts: [], storageCosts: [], numWorkspaces: 0, costFormatter: null }
+  )
+  const [updatingProjectCost, setUpdatingProjectCost] = useState(false)
   const [spendReportLengthInDays, setSpendReportLengthInDays] = useState(30)
 
   const signal = useCancellation()
@@ -228,24 +231,48 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
     { namespace: billingProject.projectName },
     _.map('workspace', workspaces)
   ), [billingProject, workspaces])
+
   const spendChartOptions = {
-    chart: { type: 'bar', style: { fontFamily: 'inherit' } },
+    chart: { marginTop: 50, spacingLeft: 20, style: { fontFamily: 'inherit' }, type: 'bar' },
     credits: { enabled: false },
-    legend: { enabled: false },
-    series: [{ name: 'Total Cost', data: costPerWorkspace.workspaceCosts }],
+    legend: { reversed: true },
+    plotOptions: { series: { stacking: 'normal' } },
+    series: [
+      { name: 'Compute', data: costPerWorkspace.computeCosts },
+      { name: 'Storage', data: costPerWorkspace.storageCosts },
+      { name: 'Other', data: costPerWorkspace.otherCosts }
+    ],
     title: {
+      align: 'left', style: { fontSize: '16px' }, y: 25,
       text: costPerWorkspace.numWorkspaces > maxWorkspacesInChart ? `Top ${maxWorkspacesInChart} Spending Workspaces` : 'Spend By Workspace'
     },
-    tooltip: { valuePrefix: '$' },
+    tooltip: {
+      followPointer: true,
+      shared: true,
+      headerFormat: '{point.key}',
+      pointFormatter: function() { // eslint-disable-line object-shorthand
+        return `<br/><span style="color:${this.color}">\u25CF</span> ${this.series.name}: ${costPerWorkspace.costFormatter.format(this.y)}`
+      }
+    },
     xAxis: {
       categories: costPerWorkspace.workspaceNames, crosshair: true,
       labels: { style: { fontSize: '12px' } }
     },
     yAxis: {
       crosshair: true, min: 0,
-      labels: { format: `\${value:.2f}`, style: { fontSize: '12px' } },
-      title: { text: 'Total Cost' },
+      labels: {
+        formatter: function() { return costPerWorkspace.costFormatter.format(this.value) }, // eslint-disable-line object-shorthand
+        style: { fontSize: '12px' }
+      },
+      title: { enabled: false },
       width: '96%'
+    },
+    accessibility: {
+      point: {
+        descriptionFormatter: point => {
+          return `${point.index + 1}. Workspace ${point.category}, ${point.series.name}: ${costPerWorkspace.costFormatter.format(point.y)}.`
+        }
+      }
     },
     exporting: { buttons: { contextButton: { x: -15 } } }
   }
@@ -261,7 +288,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
         gridRowStart: 2
       }
     }, [
-      div({ style: { flex: 'none', padding: '0.625rem 1.25rem' }, 'aria-live': totalCost !== null ? 'polite' : 'off', 'aria-atomic': true }, [
+      div({ style: { flex: 'none', padding: '0.625rem 1.25rem' }, 'aria-live': projectCost !== null ? 'polite' : 'off', 'aria-atomic': true }, [
         h3({ style: { fontSize: 16, color: colors.accent(), margin: '0.25rem 0.0rem', fontWeight: 'normal' } }, title),
         div({ style: { fontSize: 32, height: 40, fontWeight: 'bold', gridRowStart: '2' } }, [amount])
       ])
@@ -318,24 +345,29 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
       ])
     ]),
     [spendReportKey]: div({ style: { display: 'grid', rowGap: '1.25rem' } }, [
-      div({ style: { display: 'grid', gridTemplateColumns: 'minmax(15.625rem, max-content)', rowGap: '1.25rem' } }, [
-        div({ style: { gridRowStart: 1, gridColumnStart: 1 } }, [h(IdContainer, [id => h(Fragment, [
-          h(FormLabel, { htmlFor: id }, ['Date range']),
-          h(Select, {
-            id,
-            value: spendReportLengthInDays,
-            options: _.map(days => ({
-              label: `Last ${days} days`,
-              value: days
-            }), [7, 30, 90]),
-            onChange: ({ value: selectedDays }) => {
-              setSpendReportLengthInDays(selectedDays)
-              setTotalCost(null)
-            }
-          })
-        ])])]),
-        CostCard({ title: 'Total spend', amount: (totalCost !== null ? totalCost : '$__.__') })
-      ]),
+      div({ style: { display: 'grid', gridTemplateColumns: 'repeat(4, minmax(max-content, 1fr))', rowGap: '1.25rem', columnGap: '1.25rem' } },
+        _.concat(
+          div({ style: { gridRowStart: 1, gridColumnStart: 1 } }, [
+            h(IdContainer, [id => h(Fragment, [
+              h(FormLabel, { htmlFor: id }, ['Date range']),
+              h(Select, {
+                id,
+                value: spendReportLengthInDays,
+                options: _.map(days => ({
+                  label: `Last ${days} days`,
+                  value: days
+                }), [7, 30, 90]),
+                onChange: ({ value: selectedDays }) => {
+                  setSpendReportLengthInDays(selectedDays)
+                  setProjectCost(null)
+                }
+              })
+            ])])
+          ])
+        )(_.map(name => CostCard({ title: `Total ${name}`, amount: (projectCost === null ? '...' : projectCost[name]) }),
+          ['spend', 'compute', 'storage', 'other'])
+        )
+      ),
       costPerWorkspace.numWorkspaces > 0 && div({ style: { gridRowStart: 2, minWidth: 500 } }, [ // Set minWidth so chart will shrink on resize
         h(Suspense, { fallback: null }, [h(LazyChart, { options: spendChartOptions })])
       ])
@@ -423,17 +455,35 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
   useEffect(() => { StateHistory.update({ projectUsers }) }, [projectUsers])
   // Update cost data only if report date range changes, or if spend report tab was selected.
   useEffect(() => {
-    const maybeLoadTotalCost = _.flow(
+    const maybeLoadProjectCost = _.flow(
       reportErrorAndRethrow('Unable to retrieve spend report data'),
       Utils.withBusyState(setUpdating)
     )(async () => {
-      if (!updatingTotalCost && totalCost === null && tab === spendReportKey) {
-        setUpdatingTotalCost(true)
+      if (!updatingProjectCost && projectCost === null && tab === spendReportKey) {
+        setUpdatingProjectCost(true)
         const endDate = new Date().toISOString().slice(0, 10)
-        const startDate = new Date((Date.now() - spendReportLengthInDays * 24 * 60 * 60 * 1000)).toISOString().slice(0, 10)
+        const startDate = subDays(spendReportLengthInDays, new Date()).toISOString().slice(0, 10)
         const spend = await Ajax(signal).Billing.getSpendReport({ billingProjectName: billingProject.projectName, startDate, endDate })
         const costFormatter = new Intl.NumberFormat(navigator.language, { style: 'currency', currency: spend.spendSummary.currency })
-        setTotalCost(costFormatter.format(spend.spendSummary.cost))
+        const categoryDetails = _.find(details => details.aggregationKey === 'Category')(spend.spendDetails)
+        console.assert(categoryDetails !== undefined, 'Spend report details do not include aggregation by Category')
+        const getCategoryCosts = (categorySpendData, asFloat) => {
+          const costDict = {}
+          _.forEach(type => {
+            const costAsString = _.find(['category', type])(categorySpendData)?.cost ?? 0
+            costDict[type] = asFloat ? parseFloat(costAsString) : costFormatter.format(costAsString)
+          }, ['Compute', 'Storage', 'Other'])
+          return costDict
+        }
+        const costDict = getCategoryCosts(categoryDetails.spendData, false)
+        const totalCosts = {
+          spend: costFormatter.format(spend.spendSummary.cost),
+          compute: costDict.Compute,
+          storage: costDict.Storage,
+          other: costDict.Other
+        }
+
+        setProjectCost(totalCosts)
 
         const workspaceDetails = _.find(details => details.aggregationKey === 'Workspace')(spend.spendDetails)
         console.assert(workspaceDetails !== undefined, 'Spend report details do not include aggregation by Workspace')
@@ -444,17 +494,23 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
           _.slice(0, maxWorkspacesInChart)
         )(workspaceDetails?.spendData)
         // Pull out names and costs.
-        const costsPerWorkspace = { workspaceNames: [], workspaceCosts: [], numWorkspaces: workspaceDetails?.spendData.length }
+        const costPerWorkspace = {
+          workspaceNames: [], computeCosts: [], storageCosts: [], otherCosts: [], costFormatter, numWorkspaces: workspaceDetails?.spendData.length
+        }
         _.forEach(workspaceCostData => {
-          costsPerWorkspace.workspaceNames.push(workspaceCostData.workspace.name)
-          costsPerWorkspace.workspaceCosts.push(parseFloat(workspaceCostData.cost))
+          costPerWorkspace.workspaceNames.push(workspaceCostData.workspace.name)
+          const categoryDetails = workspaceCostData.subAggregation
+          console.assert(categoryDetails.key !== 'Category', 'Workspace spend report details do not include sub-aggregation by Category')
+          const costDict = getCategoryCosts(categoryDetails.spendData, true)
+          costPerWorkspace.computeCosts.push(costDict.Compute)
+          costPerWorkspace.storageCosts.push(costDict.Storage)
+          costPerWorkspace.otherCosts.push(costDict.Other)
         })(mostExpensiveWorkspaces)
-        setCostPerWorkspace(costsPerWorkspace)
-
-        setUpdatingTotalCost(false)
+        setCostPerWorkspace(costPerWorkspace)
+        setUpdatingProjectCost(false)
       }
     })
-    maybeLoadTotalCost()
+    maybeLoadProjectCost()
   }, [spendReportLengthInDays, tab]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // usePollingEffect calls the "effect" in a while-loop and binds references once on mount.


### PR DESCRIPTION
Reverts DataBiosphere/terra-ui#2898

This reintroduces the changes in https://github.com/DataBiosphere/terra-ui/pull/2892. I accidentally merged that PR ahead of when the monolith release actually went out (and my change depends on new functionality in the rawls billing API).

I promise to not merge this one until the release is out. :)