### PR TITLE
[SUP-641] fix link for support quickstart guide for Terra

### DIFF
--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -235,7 +235,7 @@ const TopBar = ({ showMenu = true, title, href, children }) => {
             isOpened: openSupportMenu
           }, [
             h(DropDownSubItem, {
-              href: window.Appcues ? undefined : 'https://support.terra.bio/hc/en-us/categories/360005881492-Getting-Started',
+              href: window.Appcues ? undefined : 'https://support.terra.bio/hc/en-us/categories/360005881492',
               onClick: () => {
                 hideNav()
                 window.Appcues?.show('-M3lNP6ncNr-42_78TOX')

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -235,7 +235,7 @@ const TopBar = ({ showMenu = true, title, href, children }) => {
             isOpened: openSupportMenu
           }, [
             h(DropDownSubItem, {
-              href: window.Appcues ? undefined : 'https://support.terra.bio/hc/en-us/articles/360042745091',
+              href: window.Appcues ? undefined : 'https://support.terra.bio/hc/en-us/categories/360005881492-Getting-Started',
               onClick: () => {
                 hideNav()
                 window.Appcues?.show('-M3lNP6ncNr-42_78TOX')


### PR DESCRIPTION
Updated link for the Terra support quickstart guide. The link is reachable in the Topbar (top left dropdown) under Support -> Quickstart Guide. The current link in the Terra UI is broken, see this issue: https://support.terra.bio/hc/en-us/community/posts/4873231702683-Broken-link-for-Terra-Quick-Start-guide-in-the-Terra-UI

This PR is a draft pending confirmation from support on the desired end state.
