### PR TITLE
[SU-8] Easily share workspace with support

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -10,7 +10,7 @@ import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 
 
-const styles = {
+export const styles = {
   overlay: {
     backgroundColor: 'rgba(0, 0, 0, 0.5)', padding: '2rem 1rem',
     display: 'flex', justifyContent: 'center', alignItems: 'flex-start',

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -477,22 +477,22 @@ export const CromwellVersionLink = props => {
     'Cromwell version loading...'
 }
 
-const SwitchLabel = ({ isOn }) => div({
+const SwitchLabel = ({ isOn, onLabel, offLabel }) => div({
   style: {
     display: 'flex', justifyContent: isOn ? 'flex-start' : 'flex-end',
     fontSize: 15, fontWeight: 'bold', color: 'white',
     height: '100%', lineHeight: '28px',
     ...(isOn ? { marginLeft: '0.75rem' } : { marginRight: '0.5rem' })
   }
-}, [isOn ? 'True' : 'False'])
+}, [isOn ? onLabel : offLabel])
 
-export const Switch = ({ onChange, ...props }) => {
+export const Switch = ({ onChange, onLabel = 'True', offLabel = 'False', ...props }) => {
   return h(RSwitch, {
     onChange: value => onChange(value),
     offColor: colors.dark(0.5),
     onColor: colors.success(1.2),
-    checkedIcon: h(SwitchLabel, { isOn: true }),
-    uncheckedIcon: h(SwitchLabel, { isOn: false }),
+    checkedIcon: h(SwitchLabel, { isOn: true, onLabel, offLabel }),
+    uncheckedIcon: h(SwitchLabel, { isOn: false, onLabel, offLabel }),
     width: 80,
     ...props
   })

--- a/src/pages/workspaces/workspace/ShareWorkspaceModal.js
+++ b/src/pages/workspaces/workspace/ShareWorkspaceModal.js
@@ -260,7 +260,11 @@ const ShareWorkspaceModal = ({ onDismiss, workspace, workspace: { workspace: { n
     searchValueValid && !searchHasFocus && p(addUserReminder),
     h2({ style: { ...Style.elements.sectionHeader, margin: '1rem 0 0.5rem 0' } }, ['Current Collaborators']),
     div({ ref: list, role: 'list', style: styles.currentCollaboratorsArea }, [
-      h(Fragment, _.map(renderCollaborator, Utils.toIndexPairs(acl))),
+      h(Fragment, _.flow(
+        _.remove(aclEntryIsTerraSupport),
+        Utils.toIndexPairs,
+        _.map(renderCollaborator)
+      )(acl)),
       !loaded && centeredSpinner()
     ]),
     updateError && div({ style: { marginTop: '1rem' } }, [

--- a/src/pages/workspaces/workspace/ShareWorkspaceModal.js
+++ b/src/pages/workspaces/workspace/ShareWorkspaceModal.js
@@ -5,6 +5,7 @@ import { ButtonPrimary, ButtonSecondary, IdContainer, LabeledCheckbox, Link, Sel
 import { centeredSpinner, icon } from 'src/components/icons'
 import { AutocompleteTextInput } from 'src/components/input'
 import Modal, { styles as modalStyles } from 'src/components/Modal'
+import TooltipTrigger from 'src/components/TooltipTrigger'
 import { Ajax } from 'src/libs/ajax'
 import { getUser } from 'src/libs/auth'
 import colors from 'src/libs/colors'
@@ -218,7 +219,7 @@ const ShareWorkspaceModal = ({ onDismiss, workspace, workspace: { workspace: { n
   // The email they entered will appear in the ACL stored in this component's state until updates are saved.
   // We want the share with support switch to function with any variation of the support email.
   const aclEntryIsTerraSupport = ({ email }) => _.toLower(email) === _.toLower(terraSupportEmail)
-  const isTerraSupportInAcl = !!_.find(aclEntryIsTerraSupport, acl)
+  const terraSupportAccess = _.find(aclEntryIsTerraSupport, acl)
   const addTerraSupportToAcl = () => addCollaborator(terraSupportEmail)
   const removeTerraSupportFromAcl = () => setAcl(_.remove(aclEntryIsTerraSupport))
 
@@ -273,19 +274,25 @@ const ShareWorkspaceModal = ({ onDismiss, workspace, workspace: { workspace: { n
     ]),
     div({ style: { ...modalStyles.buttonRow, justifyContent: 'space-between' } }, [
       h(IdContainer, [
-        id => label({ htmlFor: id }, [
-          h(Switch, {
-            id,
-            checked: isTerraSupportInAcl,
-            onChange: checked => {
-              if (checked) {
-                addTerraSupportToAcl()
-              } else {
-                removeTerraSupportFromAcl()
+        id => h(TooltipTrigger, {
+          content: terraSupportAccess ?
+            `Terra Support has ${_.toLower(terraSupportAccess.accessLevel)} access to this workspace` :
+            'Grant Terra Support reader access to this workspace'
+        }, [
+          label({ htmlFor: id }, [
+            h(Switch, {
+              id,
+              checked: !!terraSupportAccess,
+              onChange: checked => {
+                if (checked) {
+                  addTerraSupportToAcl()
+                } else {
+                  removeTerraSupportFromAcl()
+                }
               }
-            }
-          }),
-          span({ style: { marginLeft: '1ch' } }, 'Share with support')
+            }),
+            span({ style: { marginLeft: '1ch' } }, 'Share with support')
+          ])
         ])
       ]),
       span([

--- a/src/pages/workspaces/workspace/ShareWorkspaceModal.js
+++ b/src/pages/workspaces/workspace/ShareWorkspaceModal.js
@@ -284,6 +284,9 @@ const ShareWorkspaceModal = ({ onDismiss, workspace, workspace: { workspace: { n
             h(Switch, {
               id,
               checked: !!terraSupportAccess,
+              onLabel: 'Yes',
+              offLabel: 'No',
+              width: 70,
               onChange: checked => {
                 if (checked) {
                   addTerraSupportToAcl()

--- a/src/pages/workspaces/workspace/ShareWorkspaceModal.js
+++ b/src/pages/workspaces/workspace/ShareWorkspaceModal.js
@@ -280,6 +280,7 @@ const ShareWorkspaceModal = ({ onDismiss, workspace, workspace: { workspace: { n
             'Grant Terra Support reader access to this workspace'
         }, [
           label({ htmlFor: id }, [
+            span({ style: { marginRight: '1ch' } }, 'Share with support'),
             h(Switch, {
               id,
               checked: !!terraSupportAccess,
@@ -290,8 +291,7 @@ const ShareWorkspaceModal = ({ onDismiss, workspace, workspace: { workspace: { n
                   removeTerraSupportFromAcl()
                 }
               }
-            }),
-            span({ style: { marginLeft: '1ch' } }, 'Share with support')
+            })
           ])
         ])
       ]),

--- a/src/pages/workspaces/workspace/ShareWorkspaceModal.js
+++ b/src/pages/workspaces/workspace/ShareWorkspaceModal.js
@@ -219,7 +219,8 @@ const ShareWorkspaceModal = ({ onDismiss, workspace, workspace: { workspace: { n
   // The email they entered will appear in the ACL stored in this component's state until updates are saved.
   // We want the share with support switch to function with any variation of the support email.
   const aclEntryIsTerraSupport = ({ email }) => _.toLower(email) === _.toLower(terraSupportEmail)
-  const terraSupportAccess = _.find(aclEntryIsTerraSupport, acl)
+  const currentTerraSupportAccessLevel = _.find(aclEntryIsTerraSupport, originalAcl)?.accessLevel
+  const newTerraSupportAccessLevel = _.find(aclEntryIsTerraSupport, acl)?.accessLevel
   const addTerraSupportToAcl = () => addCollaborator(terraSupportEmail)
   const removeTerraSupportFromAcl = () => setAcl(_.remove(aclEntryIsTerraSupport))
 
@@ -275,15 +276,19 @@ const ShareWorkspaceModal = ({ onDismiss, workspace, workspace: { workspace: { n
     div({ style: { ...modalStyles.buttonRow, justifyContent: 'space-between' } }, [
       h(IdContainer, [
         id => h(TooltipTrigger, {
-          content: terraSupportAccess ?
-            `Terra Support has ${_.toLower(terraSupportAccess.accessLevel)} access to this workspace` :
-            'Grant Terra Support reader access to this workspace'
+          content: Utils.cond(
+            [!currentTerraSupportAccessLevel && !newTerraSupportAccessLevel, () => 'Allow Terra Support to view this workspace'],
+            [!currentTerraSupportAccessLevel && newTerraSupportAccessLevel, () => `Saving will grant Terra Support ${_.toLower(newTerraSupportAccessLevel)} access to this workspace`],
+            [currentTerraSupportAccessLevel && !newTerraSupportAccessLevel, () => `Saving will remove Terra Support's access to this workspace`],
+            [currentTerraSupportAccessLevel !== newTerraSupportAccessLevel, () => `Saving will change Terra Support's level of access to this workspace from ${_.toLower(currentTerraSupportAccessLevel)} to ${_.toLower(newTerraSupportAccessLevel)}`],
+            [currentTerraSupportAccessLevel === newTerraSupportAccessLevel, () => `Terra Support has ${_.toLower(newTerraSupportAccessLevel)} access to this workspace`]
+          )
         }, [
           label({ htmlFor: id }, [
             span({ style: { marginRight: '1ch' } }, 'Share with support'),
             h(Switch, {
               id,
-              checked: !!terraSupportAccess,
+              checked: !!newTerraSupportAccessLevel,
               onLabel: 'Yes',
               offLabel: 'No',
               width: 70,

--- a/src/pages/workspaces/workspace/ShareWorkspaceModal.js
+++ b/src/pages/workspaces/workspace/ShareWorkspaceModal.js
@@ -1,10 +1,10 @@
 import _ from 'lodash/fp'
 import { Fragment, useLayoutEffect, useRef, useState } from 'react'
 import { div, h, h2, p } from 'react-hyperscript-helpers'
-import { ButtonPrimary, IdContainer, LabeledCheckbox, Link, Select, spinnerOverlay } from 'src/components/common'
+import { ButtonPrimary, ButtonSecondary, IdContainer, LabeledCheckbox, Link, Select, spinnerOverlay } from 'src/components/common'
 import { centeredSpinner, icon } from 'src/components/icons'
 import { AutocompleteTextInput } from 'src/components/input'
-import Modal from 'src/components/Modal'
+import Modal, { styles as modalStyles } from 'src/components/Modal'
 import { Ajax } from 'src/libs/ajax'
 import { getUser } from 'src/libs/auth'
 import colors from 'src/libs/colors'
@@ -214,11 +214,7 @@ const ShareWorkspaceModal = ({ onDismiss, workspace, workspace: { workspace: { n
   return h(Modal, {
     title: 'Share Workspace',
     width: 550,
-    okButton: h(ButtonPrimary, {
-      disabled: searchValueValid,
-      tooltip: searchValueValid && addUserReminder,
-      onClick: save
-    }, ['Save']),
+    showButtons: false,
     onDismiss
   }, [
     div({ style: { display: 'flex', alignItems: 'flex-end' } }, [
@@ -259,6 +255,17 @@ const ShareWorkspaceModal = ({ onDismiss, workspace, workspace: { workspace: { n
     updateError && div({ style: { marginTop: '1rem' } }, [
       div(['An error occurred:']),
       updateError
+    ]),
+    div({ style: modalStyles.buttonRow }, [
+      h(ButtonSecondary, {
+        style: { marginRight: '1rem' },
+        onClick: onDismiss
+      }, 'Cancel'),
+      h(ButtonPrimary, {
+        disabled: searchValueValid,
+        tooltip: searchValueValid && addUserReminder,
+        onClick: save
+      }, 'Save')
     ]),
     working && spinnerOverlay
   ])


### PR DESCRIPTION
Currently, it's not obvious how to share a workspace with Terra Support. They need to know the Terra Support email. Sharing a workspace is frequently the first step after a user contacts Support, and currently Support has to spend time explaining how to share the workspace.

This adds a "Share with support" switch to the share workspace modal.

Potentially controversial... this removes Terra Support from the collaborators list in the share workspace modal, which prevents a user from seeing or modifying Support's level of access to the workspace. The plan is discourage granting the Support team higher than read access. In cases where they do need additional access, the user will be asked to add an individual Support team member to the workspace.

For cases where Support already has additional access to a workspace or additional access has been granted through an API request, etc. the "Share with support" switch has a tooltip that includes the level of access granted to Support.

![Screen Shot 2022-03-23 at 8 59 56 AM](https://user-images.githubusercontent.com/1156625/159706514-0a562a73-a50e-4d64-9f74-a270a5b47987.png)

![Screen Shot 2022-03-23 at 9 04 16 AM](https://user-images.githubusercontent.com/1156625/159706537-3abd8e0e-8b9b-492d-87c1-f8657ca5755a.png)


