### PR TITLE
[WOR-182] Use UUID on workspace name to help avoid collisions with existing wor…

### DIFF
--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -1,5 +1,6 @@
 const rawConsole = require('console')
 const _ = require('lodash/fp')
+const uuid = require('uuid')
 
 const { click, clickable, dismissNotifications, findText, signIntoTerra, waitForNoSpinners } = require('./integration-utils')
 const { fetchLyle } = require('./lyle-utils')
@@ -22,7 +23,7 @@ const withSignedInPage = fn => async options => {
 
 const clipToken = str => str.toString().substr(-10, 10)
 
-const getTestWorkspaceName = () => `test-workspace-${Math.floor(Math.random() * 100000)}`
+const getTestWorkspaceName = () => `int-test-workspace-${uuid.v4()}`
 
 const makeWorkspace = withSignedInPage(async ({ page, billingProject }) => {
   const workspaceName = getTestWorkspaceName()

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -23,7 +23,7 @@ const withSignedInPage = fn => async options => {
 
 const clipToken = str => str.toString().substr(-10, 10)
 
-const getTestWorkspaceName = () => `int-test-workspace-${uuid.v4()}`
+const getTestWorkspaceName = () => `terra-ui-test-workspace-${uuid.v4()}`
 
 const makeWorkspace = withSignedInPage(async ({ page, billingProject }) => {
   const workspaceName = getTestWorkspaceName()


### PR DESCRIPTION
We have been seeing sporadic integration tests failures due to the inability to create a workspace. Looking in kibana, this is happening because the workspace we are attempting to create already exists. It seems that we are "leaking" workspaces, and our logic for getting a random workspace name was pretty weak.

`message:[ERROR] [13:26:54.249] [scala-execution-context-global-74] o.b.d.r.dataaccess.SlickDataSource - Transaction with temporary tables failed for (Workspace). Message: ErrorReport(rawls,Workspace saturn-integration-test-dev/test-workspace-77212 already exists,Some(409 Conflict),List(),List(),None)`

Switching to a UUID to alleviate the immediate issue, but we also need to clean up existing old workspaces and find a way to avoid this issue in the future. It is possible that people running the "test-flaky" in the last few months have exacerbated this problem-- I know that I often kill a running test process, and I imagine workspaces don't get cleaned up in that case.

````
MySQL [rawls]> select concat(extract(year from created_date),'/', extract(month from created_date)) as dt, count(*) from WORKSPACE where name like 'test-workspace-%' group by dt order by dt desc;
+---------+----------+
| dt      | count(*) |
+---------+----------+
| 2022/3  |      252 |
| 2022/2  |      381 |
| 2022/1  |      183 |
| 2021/9  |       54 |
| 2021/8  |       31 |
| 2021/7  |       17 |
| 2021/6  |       27 |
| 2021/5  |       31 |
| 2021/4  |       23 |
| 2021/3  |       18 |
| 2021/2  |       16 |
| 2021/12 |      105 |
| 2021/11 |       15 |
| 2021/10 |       35 |
| 2021/1  |       31 |
| 2020/9  |       53 |
| 2020/8  |       12 |
| 2020/7  |        9 |
| 2020/6  |       12 |
| 2020/5  |       18 |
| 2020/4  |        1 |
| 2020/3  |       13 |
| 2020/2  |       43 |
| 2020/12 |       29 |
| 2020/11 |        5 |
| 2020/10 |        7 |
| 2020/1  |       79 |
| 2019/12 |       20 |
| 2019/11 |       18 |
| 2019/10 |        1 |
+---------+----------+


