### PR TITLE
[IA-3203] Add sars-cov-2 reference to igv.js

### DIFF
--- a/src/components/IGVFileSelector.js
+++ b/src/components/IGVFileSelector.js
@@ -55,7 +55,7 @@ const IGVFileSelector = ({ selectedEntities, onSuccess }) => {
       div({ style: { display: 'inline-block', marginLeft: '0.25rem', marginBottom: '1rem', minWidth: 125 } }, [
         h(Select, {
           id,
-          options: ['hg38', 'hg19', 'hg18', 'mm10', 'panTro4', 'panPan2', 'susScr11', 'bosTau8', 'canFam3', 'rn6', 'danRer10', 'dm6', 'sacCer3'],
+          options: ['hg38', 'hg19', 'hg18', 'ASM985889v3', 'mm10', 'panTro4', 'panPan2', 'susScr11', 'bosTau8', 'canFam3', 'rn6', 'danRer10', 'dm6', 'sacCer3'],
           value: refGenome,
           onChange: ({ value }) => setRefGenome(value)
         })


### PR DESCRIPTION
adds ASM985889v3 - the sars-cov-2 reference - to our embedded IGV.js.

This does not upgrade IGV.js, which we really should do too, but that's out of scope of this PR.

Tested by running locally:
![Screenshot (12)](https://user-images.githubusercontent.com/6041577/159780089-dee96518-dcf0-42f0-98a3-71360b086647.png)

I can't vouch for the science, but I see a genome showing up.