### PR TITLE
[SU-51] Data tab redesign

### DIFF
--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -453,7 +453,6 @@ const EntitiesContent = ({
     return !snapshotName && h(ButtonSecondary, {
       disabled: menuDisabled,
       tooltip: menuDisabled ? 'Select rows to open' : 'Open selected data',
-      style: { marginRight: '1.5rem' },
       onClick: () => setShowToolSelector(true)
     }, [icon('expand-arrows-alt', { style: { marginRight: '0.5rem' } }), 'Open with...'])
   }
@@ -481,7 +480,13 @@ const EntitiesContent = ({
           renderImportMenu(),
           renderExportMenu({ columnSettings }),
           renderEditMenu(),
-          renderOpenWithMenu()
+          renderOpenWithMenu(),
+          div({ style: { margin: '0 1.5rem', height: '100%', borderLeft: Style.standardLine } }),
+          div({
+            role: 'status',
+            'aria-atomic': true,
+            style: { marginRight: '0.5rem' }
+          }, [`${selectedLength} row${selectedLength === 1 ? '' : 's'} selected`])
         ] : [
           !snapshotName && renderDownloadButton(columnSettings),
           !_.endsWith('_set', entityKey) && renderCopyButton(entities, columnSettings),

--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -7,7 +7,7 @@ import { Fragment, useRef, useState } from 'react'
 import { div, form, h, input } from 'react-hyperscript-helpers'
 import { requesterPaysWrapper, withRequesterPaysHandler } from 'src/components/bucket-utils'
 import { ButtonPrimary, ButtonSecondary, Link } from 'src/components/common'
-import { EntityDeleter, EntityUploader, ModalToolButton, saveScroll } from 'src/components/data/data-utils'
+import { EntityDeleter, ModalToolButton, saveScroll } from 'src/components/data/data-utils'
 import DataTable from 'src/components/data/DataTable'
 import ExportDataModal from 'src/components/data/ExportDataModal'
 import { icon, spinner } from 'src/components/icons'
@@ -211,11 +211,10 @@ const EntitiesContent = ({
   workspace, workspace: {
     workspace: { namespace, name, googleProject, attributes: { 'workspace-column-defaults': columnDefaults } }, workspaceSubmissionStats: { runningSubmissionsCount }
   },
-  entityKey, entityMetadata, setEntityMetadata, loadMetadata, firstRender, snapshotName, deleteColumnUpdateMetadata, forceRefresh
+  entityKey, entityMetadata, setEntityMetadata, loadMetadata, firstRender, snapshotName, deleteColumnUpdateMetadata
 }) => {
   // State
   const [selectedEntities, setSelectedEntities] = useState({})
-  const [uploadingFile, setUploadingFile] = useState(false)
   const [deletingEntities, setDeletingEntities] = useState(false)
   const [copyingEntities, setCopyingEntities] = useState(false)
   const [nowCopying, setNowCopying] = useState(false)
@@ -363,22 +362,6 @@ const EntitiesContent = ({
   const entitiesSelected = !_.isEmpty(selectedEntities)
   const canEdit = !Utils.editWorkspaceError(workspace)
 
-  const renderImportMenu = () => {
-    return !snapshotName && h(MenuTrigger, {
-      side: 'bottom',
-      closeOnClick: true,
-      content: h(Fragment, [
-        h(MenuButton, {
-          onClick: () => setUploadingFile(true)
-        }, 'Upload TSV')
-      ])
-    }, [h(ButtonSecondary, {
-      disabled: !canEdit,
-      tooltip: canEdit ? 'Import data' : 'You do not have permission to modify this workspace',
-      style: { marginRight: '1.5rem' }
-    }, [icon('plus', { style: { marginRight: '0.5rem' } }), 'Import'])])
-  }
-
   const renderEditMenu = () => {
     return !snapshotName && h(MenuTrigger, {
       side: 'bottom',
@@ -477,7 +460,6 @@ const EntitiesContent = ({
         childrenBefore: ({ entities, columnSettings }) => div({
           style: { display: 'flex', alignItems: 'center', flex: 'none' }
         }, isDataTabRedesignEnabled() ? [
-          renderImportMenu(),
           renderExportMenu({ columnSettings }),
           renderEditMenu(),
           renderOpenWithMenu(),
@@ -499,16 +481,6 @@ const EntitiesContent = ({
           renderSelectedRowsMenu(columnSettings)
         ]),
         deleteColumnUpdateMetadata
-      }),
-      uploadingFile && h(EntityUploader, {
-        onDismiss: () => setUploadingFile(false),
-        onSuccess: () => {
-          setUploadingFile(false)
-          forceRefresh()
-          loadMetadata()
-        },
-        namespace, name,
-        entityTypes: _.keys(entityMetadata)
       }),
       deletingEntities && h(EntityDeleter, {
         onDismiss: () => setDeletingEntities(false),

--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -374,7 +374,7 @@ const EntitiesContent = ({
     }, [h(ButtonSecondary, {
       disabled: !canEdit || !entitiesSelected,
       tooltip: Utils.cond(
-        [!canEdit, () => 'You do not have permission to modify this workspace'],
+        [!canEdit, () => 'You do not have permission to modify this workspace.'],
         [!entitiesSelected, () => 'Select rows to edit'],
         () => 'Edit selected data'
       ),
@@ -392,7 +392,7 @@ const EntitiesContent = ({
       content: h(Fragment, [
         h(MenuButton, {
           disabled: isSetOfSets,
-          tooltip: isSetOfSets && 'Downloading sets of sets as TSV is not supported at this time',
+          tooltip: isSetOfSets && 'Downloading sets of sets as TSV is not supported at this time.',
           onClick: async () => {
             const tsv = buildTSV(columnSettings, selectedEntities)
             isSet ?
@@ -410,14 +410,14 @@ const EntitiesContent = ({
         }, 'Export to workspace'),
         h(MenuButton, {
           disabled: isSetOfSets,
-          tooltip: isSetOfSets && 'Copying sets of sets is not supported at this time',
+          tooltip: isSetOfSets && 'Copying sets of sets is not supported at this time.',
           onClick: _.flow(
-            withErrorReporting('Error copying to clipboard'),
+            withErrorReporting('Error copying to clipboard.'),
             Utils.withBusyState(setNowCopying)
           )(async () => {
             const str = buildTSV(columnSettings, _.values(selectedEntities))
             await clipboard.writeText(str)
-            notify('success', 'Successfully copied to clipboard', { timeout: 3000 })
+            notify('success', 'Successfully copied to clipboard.', { timeout: 3000 })
           })
         }, 'Copy to clipboard')
       ])

--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -384,15 +384,15 @@ const EntitiesContent = ({
 
   const renderExportMenu = ({ columnSettings }) => {
     const isSet = _.endsWith('_set', entityKey)
-    const isSetSet = entityKey.endsWith('_set_set')
+    const isSetOfSets = entityKey.endsWith('_set_set')
 
     return h(MenuTrigger, {
       side: 'bottom',
       closeOnClick: true,
       content: h(Fragment, [
         h(MenuButton, {
-          disabled: isSetSet,
-          tooltip: isSetSet && 'Downloading sets of sets as TSV is not supported at this time',
+          disabled: isSetOfSets,
+          tooltip: isSetOfSets && 'Downloading sets of sets as TSV is not supported at this time',
           onClick: async () => {
             const tsv = buildTSV(columnSettings, selectedEntities)
             isSet ?
@@ -409,8 +409,8 @@ const EntitiesContent = ({
           onClick: () => setCopyingEntities(true)
         }, 'Export to workspace'),
         h(MenuButton, {
-          disabled: isSetSet,
-          tooltip: isSetSet && 'Copying sets of sets is not supported at this time',
+          disabled: isSetOfSets,
+          tooltip: isSetOfSets && 'Copying sets of sets is not supported at this time',
           onClick: _.flow(
             withErrorReporting('Error copying to clipboard'),
             Utils.withBusyState(setNowCopying)

--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -378,7 +378,7 @@ const EntitiesContent = ({
       disabled: !canEdit || !entitiesSelected,
       tooltip: Utils.cond(
         [!canEdit, () => editErrorMessage],
-        [!entitiesSelected, () => 'Select rows to edit'],
+        [!entitiesSelected, () => 'Select rows to edit in the table'],
         () => 'Edit selected data'
       ),
       style: { marginRight: '1.5rem' }
@@ -415,7 +415,7 @@ const EntitiesContent = ({
       ])
     }, [h(ButtonSecondary, {
       disabled: !entitiesSelected,
-      tooltip: entitiesSelected ? 'Export selected data' : 'Select rows to export',
+      tooltip: entitiesSelected ? 'Export selected data' : 'Select rows to export in the table',
       style: { marginRight: '1.5rem' }
     }, [
       icon(nowCopying ? 'loadingSpinner' : 'export', { style: { marginRight: '0.5rem' } }),
@@ -424,10 +424,9 @@ const EntitiesContent = ({
   }
 
   const renderOpenWithMenu = () => {
-    const menuDisabled = _.isEmpty(selectedEntities)
     return !snapshotName && h(ButtonSecondary, {
-      disabled: menuDisabled,
-      tooltip: menuDisabled ? 'Select rows to open' : 'Open selected data',
+      disabled: !entitiesSelected,
+      tooltip: entitiesSelected ? 'Open selected data' : 'Select rows to open in the table',
       onClick: () => setShowToolSelector(true)
     }, [icon('expand-arrows-alt', { style: { marginRight: '0.5rem' } }), 'Open with...'])
   }

--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -477,8 +477,8 @@ const EntitiesContent = ({
           style: { display: 'flex', alignItems: 'center', flex: 'none' }
         }, isDataTabRedesignEnabled() ? [
           renderImportMenu(),
-          renderEditMenu(),
           renderExportMenu({ columnSettings }),
+          renderEditMenu(),
           renderOpenWithMenu()
         ] : [
           !snapshotName && renderDownloadButton(columnSettings),

--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -362,7 +362,8 @@ const EntitiesContent = ({
   }
 
   const entitiesSelected = !_.isEmpty(selectedEntities)
-  const canEdit = !Utils.editWorkspaceError(workspace)
+  const editErrorMessage = Utils.editWorkspaceError(workspace)
+  const canEdit = !editErrorMessage
 
   const renderEditMenu = () => {
     return !snapshotName && h(MenuTrigger, {
@@ -376,7 +377,7 @@ const EntitiesContent = ({
     }, [h(ButtonSecondary, {
       disabled: !canEdit || !entitiesSelected,
       tooltip: Utils.cond(
-        [!canEdit, () => 'You do not have permission to modify this workspace.'],
+        [!canEdit, () => editErrorMessage],
         [!entitiesSelected, () => 'Select rows to edit'],
         () => 'Edit selected data'
       ),

--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -457,29 +457,28 @@ const EntitiesContent = ({
           selected: selectedEntities,
           setSelected: setSelectedEntities
         },
-        childrenBefore: ({ entities, columnSettings }) => div({
-          style: { display: 'flex', alignItems: 'center', flex: 'none' }
-        }, isDataTabRedesignEnabled() ? [
-          renderExportMenu({ columnSettings }),
-          renderEditMenu(),
-          renderOpenWithMenu(),
-          div({ style: { margin: '0 1.5rem', height: '100%', borderLeft: Style.standardLine } }),
-          div({
-            role: 'status',
-            'aria-atomic': true,
-            style: { marginRight: '0.5rem' }
-          }, [`${selectedLength} row${selectedLength === 1 ? '' : 's'} selected`])
-        ] : [
-          !snapshotName && renderDownloadButton(columnSettings),
-          !_.endsWith('_set', entityKey) && renderCopyButton(entities, columnSettings),
-          div({ style: { margin: '0 1.5rem', height: '100%', borderLeft: Style.standardLine } }),
-          div({
-            role: 'status',
-            'aria-atomic': true,
-            style: { marginRight: '0.5rem' }
-          }, [`${selectedLength} row${selectedLength === 1 ? '' : 's'} selected`]),
-          renderSelectedRowsMenu(columnSettings)
-        ]),
+        childrenBefore: ({ entities, columnSettings }) => div({ style: { display: 'flex', alignItems: 'center', flex: 'none' } },
+          isDataTabRedesignEnabled() ? [
+            renderExportMenu({ columnSettings }),
+            renderEditMenu(),
+            renderOpenWithMenu(),
+            div({ style: { margin: '0 1.5rem', height: '100%', borderLeft: Style.standardLine } }),
+            div({
+              role: 'status',
+              'aria-atomic': true,
+              style: { marginRight: '0.5rem' }
+            }, [`${selectedLength} row${selectedLength === 1 ? '' : 's'} selected`])
+          ] : [
+            !snapshotName && renderDownloadButton(columnSettings),
+            !_.endsWith('_set', entityKey) && renderCopyButton(entities, columnSettings),
+            div({ style: { margin: '0 1.5rem', height: '100%', borderLeft: Style.standardLine } }),
+            div({
+              role: 'status',
+              'aria-atomic': true,
+              style: { marginRight: '0.5rem' }
+            }, [`${selectedLength} row${selectedLength === 1 ? '' : 's'} selected`]),
+            renderSelectedRowsMenu(columnSettings)
+          ]),
         deleteColumnUpdateMetadata
       }),
       deletingEntities && h(EntityDeleter, {

--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -426,6 +426,8 @@ const EntitiesContent = ({
           onClick: () => setCopyingEntities(true)
         }, 'Export to workspace'),
         h(MenuButton, {
+          disabled: isSetSet,
+          tooltip: isSetSet && 'Copying sets of sets is not supported at this time',
           onClick: _.flow(
             withErrorReporting('Error copying to clipboard'),
             Utils.withBusyState(setNowCopying)

--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -294,6 +294,19 @@ const EntitiesContent = ({
     }
   }
 
+  const downloadSelectedRows = async columnSettings => {
+    const tsv = buildTSV(columnSettings, selectedEntities)
+    const isSet = _.endsWith('_set', entityKey)
+    isSet ?
+      FileSaver.saveAs(await tsv, `${entityKey}.zip`) :
+      FileSaver.saveAs(new Blob([tsv], { type: 'text/tab-separated-values' }), `${entityKey}.tsv`)
+    Ajax().Metrics.captureEvent(Events.workspaceDataDownloadPartial, {
+      ...extractWorkspaceDetails(workspace.workspace),
+      downloadFrom: 'table data',
+      fileType: '.tsv'
+    })
+  }
+
   const renderCopyButton = (entities, columnSettings) => {
     return h(Fragment, [
       h(ButtonPrimary, {
@@ -315,7 +328,6 @@ const EntitiesContent = ({
   }
 
   const renderSelectedRowsMenu = columnSettings => {
-    const isSet = _.endsWith('_set', entityKey)
     const noEdit = Utils.editWorkspaceError(workspace)
     const disabled = entityKey.endsWith('_set_set')
 
@@ -328,17 +340,7 @@ const EntitiesContent = ({
           tooltip: disabled ?
             'Downloading sets of sets as TSV is not supported at this time' :
             `Download the selected data as a file`,
-          onClick: async () => {
-            const tsv = buildTSV(columnSettings, selectedEntities)
-            isSet ?
-              FileSaver.saveAs(await tsv, `${entityKey}.zip`) :
-              FileSaver.saveAs(new Blob([tsv], { type: 'text/tab-separated-values' }), `${entityKey}.tsv`)
-            Ajax().Metrics.captureEvent(Events.workspaceDataDownloadPartial, {
-              ...extractWorkspaceDetails(workspace.workspace),
-              downloadFrom: 'table data',
-              fileType: '.tsv'
-            })
-          }
+          onClick: () => downloadSelectedRows(columnSettings)
         }, ['Download as TSV']),
         !snapshotName && h(MenuButton, {
           tooltip: 'Open the selected data to work with it',
@@ -383,7 +385,6 @@ const EntitiesContent = ({
   }
 
   const renderExportMenu = ({ columnSettings }) => {
-    const isSet = _.endsWith('_set', entityKey)
     const isSetOfSets = entityKey.endsWith('_set_set')
 
     return h(MenuTrigger, {
@@ -393,17 +394,7 @@ const EntitiesContent = ({
         h(MenuButton, {
           disabled: isSetOfSets,
           tooltip: isSetOfSets && 'Downloading sets of sets as TSV is not supported at this time.',
-          onClick: async () => {
-            const tsv = buildTSV(columnSettings, selectedEntities)
-            isSet ?
-              FileSaver.saveAs(await tsv, `${entityKey}.zip`) :
-              FileSaver.saveAs(new Blob([tsv], { type: 'text/tab-separated-values' }), `${entityKey}.tsv`)
-            Ajax().Metrics.captureEvent(Events.workspaceDataDownloadPartial, {
-              ...extractWorkspaceDetails(workspace.workspace),
-              downloadFrom: 'table data',
-              fileType: '.tsv'
-            })
-          }
+          onClick: () => downloadSelectedRows(columnSettings)
         }, 'Download as TSV'),
         !snapshotName && h(MenuButton, {
           onClick: () => setCopyingEntities(true)

--- a/src/libs/config.js
+++ b/src/libs/config.js
@@ -13,6 +13,7 @@ export const isAnalysisTabVisible = () => getConfig().isAnalysisTabVisible
 export const isCromwellAppVisible = () => getConfig().isCromwellAppVisible
 // configOverridesStore.set({ isDataBrowserVisible: true }) in browser console to enable
 export const isDataBrowserVisible = () => getConfig().isDataBrowserVisible
+export const isDataTabRedesignEnabled = () => getConfig().isDataTabRedesignEnabled
 export const isBaseline = () => (window.location.hostname === 'baseline.terra.bio') || getConfig().isBaseline
 export const isBioDataCatalyst = () => (window.location.hostname.endsWith('.biodatacatalyst.nhlbi.nih.gov')) || getConfig().isBioDataCatalyst
 export const isDatastage = () => (window.location.hostname === 'datastage.terra.bio') || getConfig().isDatastage

--- a/src/libs/icon-dict.js
+++ b/src/libs/icon-dict.js
@@ -3,7 +3,7 @@ import {
 } from '@fortawesome/free-regular-svg-icons'
 import {
   faArrowLeft, faArrowRight, faBan, faCaretDown, faChalkboard, faCheck, faCheckCircle, faCircle, faClock as faClockSolid, faCloud, faCog,
-  faCreditCard, faDownload, faEllipsisV, faExclamationCircle, faExclamationTriangle, faFileInvoiceDollar, faGripHorizontal, faInfoCircle, faLock,
+  faCreditCard, faDownload, faEllipsisV, faExclamationCircle, faExclamationTriangle, faExpandArrowsAlt, faFileInvoiceDollar, faGripHorizontal, faInfoCircle, faLock,
   faLongArrowAltDown, faLongArrowAltUp, faMinusCircle, faMoneyCheckAlt, faPause, faPen, faPlay, faPlus, faPlusCircle, faQuestion, faQuestionCircle,
   faRocket, faSearch, faShareAlt, faSquare as faSquareSolid, faTachometerAlt, faTasks, faTerminal, faTrashAlt, faUnlock, faVirus
 } from '@fortawesome/free-solid-svg-icons'
@@ -72,6 +72,7 @@ const iconDict = {
   'ellipsis-v': fa(faEllipsisV),
   'ellipsis-v-circle': props => fa(faEllipsisV, { mask: faCircle, transform: 'shrink-8', ...props }),
   'error-standard': fa(faExclamationCircle),
+  'expand-arrows-alt': fa(faExpandArrowsAlt),
   export: custom(fileExport),
   eye: fa(faEye),
   fileAlt: fa(faFileAlt),

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -189,7 +189,7 @@ export const entityAttributeText = (value, machineReadable) => {
 export const editWorkspaceError = ({ accessLevel, workspace: { isLocked } }) => {
   return cond(
     [!canWrite(accessLevel), () => 'You do not have permission to modify this workspace.'],
-    [isLocked, () => 'This workspace is locked']
+    [isLocked, () => 'This workspace is locked.']
   )
 }
 
@@ -197,7 +197,7 @@ export const editWorkspaceError = ({ accessLevel, workspace: { isLocked } }) => 
 export const computeWorkspaceError = ({ canCompute, workspace: { isLocked } }) => {
   return cond(
     [!canCompute, () => 'You do not have access to run analyses on this workspace.'],
-    [isLocked, () => 'This workspace is locked']
+    [isLocked, () => 'This workspace is locked.']
   )
 }
 

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -22,6 +22,7 @@ import UriViewer from 'src/components/UriViewer'
 import { SnapshotInfo } from 'src/components/workspace-utils'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
+import { isDataTabRedesignEnabled } from 'src/libs/config'
 import { reportError, withErrorReporting } from 'src/libs/error'
 import Events, { extractWorkspaceDetails } from 'src/libs/events'
 import { forwardRefWithName, useCancellation, useOnMount, useStore, withDisplayName } from 'src/libs/react-utils'
@@ -83,7 +84,7 @@ const DataTypeButton = ({ selected, entityName, children, entityCount, iconName 
       div({ style: { flex: 'none', display: 'flex', width: '1.5rem' } }, [
         icon(iconName, { size: iconSize })
       ]),
-      div({ style: { flex: 1, ...Style.noWrapEllipsis } }, [
+      div({ style: { flex: isDataTabRedesignEnabled() ? '0 1 content' : 1, ...Style.noWrapEllipsis } }, [
         entityName || children
       ]),
       isEntity && div({ style: { flex: 0, paddingLeft: '0.5em' } }, `(${entityCount})`)

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -445,8 +445,8 @@ const DataTableActions = ({ workspace, tableName, rowCount }) => {
         h(MenuButton, {
           disabled: isSetOfSets,
           tooltip: isSetOfSets ?
-            'Downloading sets of sets as TSV is not supported at this time' :
-            'Download a TSV file containing all rows in this table',
+            'Downloading sets of sets as TSV is not supported at this time.' :
+            'Download a TSV file containing all rows in this table.',
           onClick: () => {
             downloadForm.current.submit()
             Ajax().Metrics.captureEvent(Events.workspaceDataDownload, {
@@ -459,7 +459,7 @@ const DataTableActions = ({ workspace, tableName, rowCount }) => {
         h(MenuButton, {
           onClick: _.flow(
             Utils.withBusyState(setLoading),
-            withErrorReporting('Error loading entities')
+            withErrorReporting('Error loading entities.')
           )(async () => {
             const queryResults = await Ajax(signal).Workspaces.workspace(namespace, name).paginatedEntitiesOfType(tableName, { pageSize: rowCount })
             setEntities(_.map(_.get('name'), queryResults.results))

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -770,7 +770,8 @@ const WorkspaceData = _.flow(
             entityKey: selectedDataType,
             loadMetadata,
             firstRender,
-            deleteColumnUpdateMetadata
+            deleteColumnUpdateMetadata,
+            forceRefresh
           })]
         )
       ])

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -420,7 +420,7 @@ const SidebarSeparator = ({ sidebarWidth, setSidebarWidth }) => {
 
 const DataTableActions = ({ workspace, tableName, rowCount }) => {
   const { workspace: { namespace, name }, workspaceSubmissionStats: { runningSubmissionsCount } } = workspace
-  const isSetSet = tableName.endsWith('_set_set')
+  const isSetOfSets = tableName.endsWith('_set_set')
 
   const downloadForm = useRef()
   const signal = useCancellation()
@@ -443,8 +443,8 @@ const DataTableActions = ({ workspace, tableName, rowCount }) => {
           input({ type: 'hidden', name: 'model', value: 'flexible' })
         ]),
         h(MenuButton, {
-          disabled: isSetSet,
-          tooltip: isSetSet ?
+          disabled: isSetOfSets,
+          tooltip: isSetOfSets ?
             'Downloading sets of sets as TSV is not supported at this time' :
             'Download a TSV file containing all rows in this table',
           onClick: () => {


### PR DESCRIPTION
This is behind a future flag so that we can collect feedback and iterate on the new design before releasing. To enable, run `configOverridesStore.set({ isDataTabRedesignEnabled: true })` in the console.

# Data table menu

Add menus to provide a place for additional future functionality.

This also makes the scope of actions more consistent. Currently, the first button downloads the entire table, the second button copies the current page, and the more actions menu operates on the selected rows. With this change, everything under export, edit, and open with operate on the selected rows.

## Before
![Screen Shot 2022-03-24 at 11 25 15 AM](https://user-images.githubusercontent.com/1156625/159951570-dab67617-968e-413a-b811-20c87148fab1.png)

## After
<img width="1217" alt="Screen Shot 2022-03-24 at 4 16 25 PM" src="https://user-images.githubusercontent.com/1156625/160002562-906b9e5d-dd63-4e0a-b9ab-fd78b7fb155c.png">


# Sidebar

Add a menu to take actions on the entire table. Current options are download or export to another workspace.

## Before
![Screen Shot 2022-03-24 at 11 25 26 AM](https://user-images.githubusercontent.com/1156625/159951532-4a94af65-fad1-45d6-b856-bf20074ba9cc.png)

## After
<img width="279" alt="Screen Shot 2022-03-24 at 11 08 42 AM" src="https://user-images.githubusercontent.com/1156625/159949828-79ddb4e7-108b-4cc3-8124-204037411d7e.png">

