### PR TITLE
[IA-3269] allow scrolling in igv viewer

### DIFF
--- a/src/components/IGVBrowser.js
+++ b/src/components/IGVBrowser.js
@@ -9,6 +9,7 @@ import { Ajax, saToken } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { reportError } from 'src/libs/error'
 import { useCancellation, useOnMount, withDisplayName } from 'src/libs/react-utils'
+import { autopauseDisabledValue } from 'src/libs/runtime-utils'
 import { knownBucketRequesterPaysStatuses, requesterPaysProjectStore } from 'src/libs/state'
 import * as Utils from 'src/libs/utils'
 
@@ -86,6 +87,7 @@ const IGVBrowser = _.flow(
     div({
       ref: containerRef,
       style: {
+        overflowY: 'auto',
         padding: '10px 0',
         margin: 8,
         border: `1px solid ${colors.dark(0.25)}`

--- a/src/components/IGVBrowser.js
+++ b/src/components/IGVBrowser.js
@@ -9,7 +9,6 @@ import { Ajax, saToken } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { reportError } from 'src/libs/error'
 import { useCancellation, useOnMount, withDisplayName } from 'src/libs/react-utils'
-import { autopauseDisabledValue } from 'src/libs/runtime-utils'
 import { knownBucketRequesterPaysStatuses, requesterPaysProjectStore } from 'src/libs/state'
 import * as Utils from 'src/libs/utils'
 

--- a/src/components/IGVBrowser.js
+++ b/src/components/IGVBrowser.js
@@ -9,6 +9,7 @@ import { Ajax, saToken } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { reportError } from 'src/libs/error'
 import { useCancellation, useOnMount, withDisplayName } from 'src/libs/react-utils'
+import { autopauseDisabledValue } from 'src/libs/runtime-utils'
 import { knownBucketRequesterPaysStatuses, requesterPaysProjectStore } from 'src/libs/state'
 import * as Utils from 'src/libs/utils'
 


### PR DESCRIPTION
For viewing IGVs with multiple sequence files, since there's no scrolling in the igv viewer, it's not currently possible to scroll down and view all the sequence files. This change adds y-scrolling.


https://user-images.githubusercontent.com/8800717/160001114-55602c7e-d0d8-4712-81e5-684970c34420.mov


