### PR TITLE
[IA-3080] ux feedback

### DIFF
--- a/src/components/AnalysisModal.js
+++ b/src/components/AnalysisModal.js
@@ -108,6 +108,7 @@ export const AnalysisModal = withDisplayName('AnalysisModal')(
     const renderComputeModal = () => h(ComputeModalBase, {
       isOpen: currentTool === tools.Jupyter.label || currentTool === tools.RStudio.label,
       isAnalysisMode: true,
+      shouldHideCloseButton: true,
       workspace,
       tool: currentTool,
       runtimes,
@@ -125,7 +126,7 @@ export const AnalysisModal = withDisplayName('AnalysisModal')(
 
     const renderAppModal = (appModalBase, toolLabel) => h(appModalBase, {
       isOpen: viewMode === toolLabel,
-      isAnalysisMode: true,
+      shouldHideCloseButton: true,
       workspace,
       apps,
       appDataDisks,

--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -26,8 +26,8 @@ import {
   computeStyles, defaultAutopauseThreshold, defaultComputeRegion, defaultComputeZone, defaultDataprocMachineType, defaultDataprocMasterDiskSize,
   defaultDataprocWorkerDiskSize, defaultGceBootDiskSize, defaultGceMachineType, defaultGcePersistentDiskSize, defaultGpuType, defaultLocation,
   defaultNumDataprocPreemptibleWorkers, defaultNumDataprocWorkers, defaultNumGpus, displayNameForGpuType, findMachineType, getAutopauseThreshold,
-  getCurrentRuntime, getDefaultMachineType, getPersistentDiskCostMonthly, getValidGpuTypes, getValidGpuTypesForZone, isAutopauseEnabled, RadioBlock,
-  runtimeConfigBaseCost, runtimeConfigCost
+  getCurrentRuntime, getDefaultMachineType, getIsRuntimeBusy, getPersistentDiskCostMonthly, getValidGpuTypes, getValidGpuTypesForZone,
+  isAutopauseEnabled, RadioBlock, runtimeConfigBaseCost, runtimeConfigCost
 } from 'src/libs/runtime-utils'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
@@ -149,7 +149,7 @@ const SparkInterface = ({ sparkInterface, namespace, name, onDismiss }) => {
               style: { marginRight: 'auto' },
               onClick: onDismiss,
               ...Utils.newTabLinkProps
-            }, ['Launch', icon('pop-out', { size: 12, style: { marginLeft: '0.5rem' } })])
+            }, ['Open', icon('pop-out', { size: 12, style: { marginLeft: '0.5rem' } })])
           ])
         ])
       ])
@@ -182,7 +182,7 @@ const shouldUsePersistentDisk = (runtimeType, runtimeDetails, upgradeDiskSelecte
   (!runtimeDetails?.runtimeConfig?.diskSize || upgradeDiskSelected)
 // Auxiliary functions -- end
 
-export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDisks, tool, workspace, location, isAnalysisMode = false }) => {
+export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDisks, tool, workspace, location, isAnalysisMode = false, shouldHideCloseButton = isAnalysisMode }) => {
   // State -- begin
   const [showDebugger, setShowDebugger] = useState(false)
   const [loading, setLoading] = useState(false)
@@ -748,7 +748,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
         id: titleId,
         style: computeStyles.titleBar,
         title: 'About persistent disk',
-        hideCloseButton: isAnalysisMode,
+        hideCloseButton: shouldHideCloseButton,
         onDismiss,
         onPrevious: () => setViewMode()
       }),
@@ -783,6 +783,9 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
       ],
       () => ({ disabled: !hasChanges() || !!errors, tooltip: Utils.summarizeErrors(errors) })
     )
+
+    const isChangeDisabled = getIsRuntimeBusy(currentRuntimeDetails)
+
     const canShowWarning = viewMode === undefined
     const canShowEnvironmentWarning = _.includes(viewMode, [undefined, 'customImageWarning'])
     return Utils.cond([
@@ -802,7 +805,10 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
         ...commonButtonProps,
         onClick: () => {
           applyChanges()
-        }
+        },
+        disabled: isChangeDisabled,
+        tooltipSide: 'left',
+        tooltip: isChangeDisabled ? `Cannot perform change on environment in status ( ${currentRuntimeDetails.status} )` : 'Update Environment'
       }, [
         Utils.cond(
           [viewMode === 'deleteEnvironment', () => 'Delete'],
@@ -1162,7 +1168,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
     return div({ style: { ...computeStyles.drawerContent, ...computeStyles.warningView } }, [
       h(TitleBar, {
         id: titleId,
-        hideCloseButton: isAnalysisMode,
+        hideCloseButton: shouldHideCloseButton,
         style: computeStyles.titleBar,
         title: h(WarningTitle, ['Unverified Docker image']),
         onDismiss,
@@ -1188,7 +1194,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
     return div({ style: { ...computeStyles.drawerContent, ...computeStyles.warningView } }, [
       h(TitleBar, {
         id: titleId,
-        hideCloseButton: isAnalysisMode,
+        hideCloseButton: shouldHideCloseButton,
         style: computeStyles.titleBar,
         title: h(WarningTitle, ['Compute location differs from workspace bucket location']),
         onDismiss,
@@ -1220,7 +1226,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
     return div({ style: { ...computeStyles.drawerContent, ...computeStyles.warningView } }, [
       h(TitleBar, {
         id: titleId,
-        hideCloseButton: isAnalysisMode,
+        hideCloseButton: shouldHideCloseButton,
         style: computeStyles.titleBar,
         title: h(WarningTitle, ['Non-US Compute Location']),
         onDismiss,
@@ -1311,7 +1317,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
         id: titleId,
         style: computeStyles.titleBar,
         title: h(WarningTitle, ['Delete environment']),
-        hideCloseButton: isAnalysisMode,
+        hideCloseButton: shouldHideCloseButton,
         onDismiss,
         onPrevious: () => {
           setViewMode(undefined)
@@ -1396,7 +1402,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
       h(TitleBar, {
         id: titleId,
         style: computeStyles.titleBar,
-        hideCloseButton: isAnalysisMode,
+        hideCloseButton: shouldHideCloseButton,
         title: h(WarningTitle, [
           Utils.cond(
             [willDetachPersistentDisk(), () => 'Replace application configuration and cloud compute profile for Spark'],
@@ -1504,7 +1510,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
           id: titleId,
           style: { marginBottom: '0.5rem' },
           title: 'Cloud Environment',
-          hideCloseButton: isAnalysisMode,
+          hideCloseButton: shouldHideCloseButton,
           onDismiss
         }),
         div(['A cloud environment consists of application configuration, cloud compute and persistent disk(s).'])
@@ -1612,7 +1618,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
         id: titleId,
         style: computeStyles.titleBar,
         title: 'Installed packages',
-        hideCloseButton: isAnalysisMode,
+        hideCloseButton: shouldHideCloseButton,
         onDismiss,
         onPrevious: () => setViewMode(undefined)
       }),
@@ -1630,7 +1636,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
         id: titleId,
         title: 'Spark Console',
         style: { marginBottom: '0.5rem' },
-        hideCloseButton: isAnalysisMode,
+        hideCloseButton: shouldHideCloseButton,
         onDismiss,
         onPrevious: () => setViewMode(undefined)
       }),

--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -784,7 +784,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
       () => ({ disabled: !hasChanges() || !!errors, tooltip: Utils.summarizeErrors(errors) })
     )
 
-    const isChangeDisabled = getIsRuntimeBusy(currentRuntimeDetails)
+    const isUpdateDisabled = getIsRuntimeBusy(currentRuntimeDetails)
 
     const canShowWarning = viewMode === undefined
     const canShowEnvironmentWarning = _.includes(viewMode, [undefined, 'customImageWarning'])
@@ -806,9 +806,9 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
         onClick: () => {
           applyChanges()
         },
-        disabled: isChangeDisabled,
+        disabled: isUpdateDisabled,
         tooltipSide: 'left',
-        tooltip: isChangeDisabled ? `Cannot perform change on environment in status ( ${currentRuntimeDetails.status} )` : 'Update Environment'
+        tooltip: isUpdateDisabled ? `Cannot perform change on environment in status ( ${currentRuntimeDetails.status} )` : 'Update Environment'
       }, [
         Utils.cond(
           [viewMode === 'deleteEnvironment', () => 'Delete'],

--- a/src/components/ContextBar.js
+++ b/src/components/ContextBar.js
@@ -2,9 +2,13 @@ import _ from 'lodash/fp'
 import { Fragment, useState } from 'react'
 import { div, h, img } from 'react-hyperscript-helpers'
 import { Clickable } from 'src/components/common'
+import { ComputeModal } from 'src/components/ComputeModal'
+import { CromwellModal } from 'src/components/CromwellModal'
+import { GalaxyModal } from 'src/components/GalaxyModal'
 import { icon } from 'src/components/icons'
-import { tools } from 'src/components/notebook-utils'
+import { getAppType, isToolAnApp, tools } from 'src/components/notebook-utils'
 import { appLauncherTabName } from 'src/components/runtime-common'
+import { AppErrorModal, RuntimeErrorModal } from 'src/components/RuntimeManager'
 import cloudIcon from 'src/icons/cloud-compute.svg'
 import cromwellImg from 'src/images/cromwell-logo.png' // To be replaced by something square
 import galaxyLogo from 'src/images/galaxy-logo.png'
@@ -12,9 +16,10 @@ import jupyterLogo from 'src/images/jupyter-logo.svg'
 import rstudioSquareLogo from 'src/images/rstudio-logo-square.png'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
+import { withErrorReporting } from 'src/libs/error'
 import Events from 'src/libs/events'
 import * as Nav from 'src/libs/nav'
-import { getCurrentApp, getCurrentRuntime } from 'src/libs/runtime-utils'
+import { getComputeStatusForDisplay, getCurrentApp, getCurrentRuntime } from 'src/libs/runtime-utils'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 import { CloudEnvironmentModal } from 'src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal'
@@ -27,8 +32,11 @@ const contextBarStyles = {
   },
   contextBarButton: {
     display: 'flex',
+    justifyContent: 'center',
+    width: 70,
     borderBottom: `1px solid ${colors.accent()}`,
-    padding: '1rem',
+    padding: '.75rem',
+    height: 70,
     color: colors.accent(),
     backgroundColor: colors.accent(0.2)
   },
@@ -40,6 +48,12 @@ export const ContextBar = ({
   workspace, persistentDisks, workspace: { workspace: { namespace, name: workspaceName } }
 }) => {
   const [isCloudEnvOpen, setCloudEnvOpen] = useState(false)
+  const [isComputeModalOpen, setComputeModalOpen] = useState(false)
+  const [isGalaxyModalOpen, setGalaxyModalOpen] = useState(false)
+  const [isCromwellModalOpen, setCromwellModalOpen] = useState(false)
+  const [selectedToolIcon, setSelectedToolIcon] = useState(null)
+  const [errorRuntimeId, setErrorRuntimeId] = useState(undefined)
+  const [errorAppId, setErrorAppId] = useState(undefined)
 
   const currentRuntime = getCurrentRuntime(runtimes)
   const currentRuntimeTool = currentRuntime?.labels?.tool
@@ -55,10 +69,10 @@ export const ContextBar = ({
   }
 
   const getImgForTool = toolLabel => Utils.switchCase(toolLabel,
-    [tools.Jupyter.label, () => img({ src: jupyterLogo, style: { height: 30, width: 30 } })],
-    [tools.galaxy.label, () => img({ src: galaxyLogo, style: { height: 12, width: 35 } })],
-    [tools.cromwell.label, () => img({ src: cromwellImg, style: { width: 30 } })],
-    [tools.RStudio.label, () => img({ src: rstudioSquareLogo, style: { height: 30, width: 30 } })]
+    [tools.Jupyter.label, () => img({ src: jupyterLogo, style: { height: 45, width: 45 } })],
+    [tools.galaxy.label, () => img({ src: galaxyLogo, style: { height: 14, width: 45 } })],
+    [tools.cromwell.label, () => img({ src: cromwellImg, style: { width: 45 } })],
+    [tools.RStudio.label, () => img({ src: rstudioSquareLogo, style: { height: 45, width: 45 } })]
   )
 
   const getColorForStatus = status => Utils.cond(
@@ -67,12 +81,38 @@ export const ContextBar = ({
     [_.includes('ING', _.upperCase(status)), () => colors.accent()],
     [Utils.DEFAULT, () => colors.warning()])
 
+  const currentApp = toolLabel => getCurrentApp(getAppType(toolLabel))(apps)
+
+
   const getIconForTool = (toolLabel, status) => {
-    return div({ style: { display: 'flex', flexDirection: 'column' } }, [
-      div({ style: { display: 'flex', justifyContent: 'center', alignItems: 'center', marginTop: '1rem' } }, [
+    return h(Clickable, {
+      style: { display: 'flex', flexDirection: 'column', justifyContent: 'center', ...contextBarStyles.contextBarButton, borderBottom: '0px' },
+      hover: contextBarStyles.hover,
+      onClick: () => { // onclick displays an error message if the tool is in error, otherwise, if the tool is editable, opens the config modal (I.e. ComputeModal or GalaxyModal)
+        if (_.toLower(status) === 'error') {
+          Utils.cond(
+            [isToolAnApp(toolLabel), () => setErrorAppId(currentApp(toolLabel)?.appName)],
+            [Utils.DEFAULT, () => setErrorRuntimeId(currentRuntime?.id)]
+          )
+        } else {
+          Utils.switchCase(toolLabel,
+            [tools.galaxy.label, () => setGalaxyModalOpen(true)],
+            [tools.cromwell.label, () => setCromwellModalOpen(true)],
+            [Utils.DEFAULT, () => {
+              setSelectedToolIcon(toolLabel)
+              setComputeModalOpen(true)
+            }])
+        }
+      },
+      tooltipSide: 'left',
+      tooltip: `${toolLabel} environment ( ${getComputeStatusForDisplay(status)} )`,
+      tooltipDelay: 100,
+      useTooltipAsLabel: true
+    }, [
+      div({ style: { display: 'flex', justifyContent: 'center', alignItems: 'center' } }, [
         getImgForTool(toolLabel)
       ]),
-      div({ style: { display: 'flex', justifyContent: 'flex-end', color: getColorForStatus(status) } }, [
+      div({ style: { justifyContent: 'flex-end', display: 'flex', color: getColorForStatus(status) } }, [
         icon('circle', { style: { border: '1px solid white', borderRadius: '50%' }, size: 12 })
       ])
     ])
@@ -103,7 +143,58 @@ export const ContextBar = ({
       },
       runtimes, apps, appDataDisks, refreshRuntimes, refreshApps, workspace, canCompute, persistentDisks, location, locationType
     }),
-    div({ style: Style.elements.contextBarContainer }, [
+    h(ComputeModal, {
+      isOpen: isComputeModalOpen,
+      isAnalysisMode: true,
+      tool: selectedToolIcon,
+      workspace,
+      runtimes,
+      persistentDisks,
+      location,
+      onDismiss: () => setComputeModalOpen(false),
+      onSuccess: _.flow(
+        withErrorReporting('Error loading cloud environment'),
+        Utils.withBusyState(v => this.setState({ busy: v }))
+      )(async () => {
+        setComputeModalOpen(false)
+        await refreshRuntimes(true)
+      })
+    }),
+    h(GalaxyModal, {
+      workspace,
+      apps,
+      appDataDisks,
+      isOpen: isGalaxyModalOpen,
+      onDismiss: () => setGalaxyModalOpen(false),
+      onSuccess: () => {
+        withErrorReporting('Error loading galaxy environment')(
+          setGalaxyModalOpen(false),
+          refreshApps()
+        )
+      }
+    }),
+    h(CromwellModal, {
+      workspace,
+      apps,
+      appDataDisks,
+      isOpen: isCromwellModalOpen,
+      onDismiss: () => setCromwellModalOpen(false),
+      onSuccess: () => {
+        withErrorReporting('Error loading galaxy environment')(
+          setCromwellModalOpen(false),
+          refreshApps()
+        )
+      }
+    }),
+    errorAppId && h(AppErrorModal, {
+      app: _.find({ appName: errorAppId }, apps),
+      onDismiss: () => setErrorAppId(undefined)
+    }),
+    errorRuntimeId && h(RuntimeErrorModal, {
+      runtime: _.find({ id: errorRuntimeId }, runtimes),
+      onDismiss: () => setErrorRuntimeId(undefined)
+    }),
+    div({ style: { ...Style.elements.contextBarContainer, width: 70 } }, [
       div({ style: contextBarStyles.contextBarContainer }, [
         h(WorkspaceMenuTrigger, { canShare, isOwner, setCloningWorkspace, setSharingWorkspace, setDeletingWorkspace }, [
           h(Clickable, {
@@ -115,21 +206,23 @@ export const ContextBar = ({
             useTooltipAsLabel: true
           }, [icon('ellipsis-v', { size: 24 })])
         ]),
-        h(Clickable, {
-          style: { ...contextBarStyles.contextBarButton, flexDirection: 'column', justifyContent: 'center', padding: '.75rem' },
-          hover: contextBarStyles.hover,
-          tooltipSide: 'left',
-          onClick: () => setCloudEnvOpen(!isCloudEnvOpen),
-          tooltip: 'Environment Configuration',
-          tooltipDelay: 100,
-          useTooltipAsLabel: true
-        }, [
-          img({ src: cloudIcon, style: { display: 'flex', margin: 'auto', height: 26, width: 26 } }),
+        h(Fragment, [
+          h(Clickable, {
+            style: { flexDirection: 'column', justifyContent: 'center', padding: '.75rem', ...contextBarStyles.contextBarButton, borderBottom: '0px' },
+            hover: contextBarStyles.hover,
+            tooltipSide: 'left',
+            onClick: () => setCloudEnvOpen(!isCloudEnvOpen),
+            tooltip: 'Environment Configuration',
+            tooltipDelay: 100,
+            useTooltipAsLabel: true
+          }, [
+            img({ src: cloudIcon, style: { display: 'flex', margin: 'auto', height: 40, width: 40 } })
+          ]),
           getEnvironmentStatusIcons()
         ]),
         h(Clickable, {
           'aria-label': 'Terminal button',
-          style: { ...contextBarStyles.contextBarButton, color: !isTerminalEnabled ? colors.dark(0.7) : contextBarStyles.contextBarButton.color },
+          style: { borderTop: `1px solid ${colors.accent()}`, paddingLeft: '1rem', alignItems: 'center', ...contextBarStyles.contextBarButton, color: !isTerminalEnabled ? colors.dark(0.7) : contextBarStyles.contextBarButton.color },
           hover: contextBarStyles.hover,
           tooltipSide: 'left',
           disabled: !isTerminalEnabled,
@@ -145,7 +238,7 @@ export const ContextBar = ({
           tooltipDelay: 100,
           useTooltipAsLabel: false,
           ...Utils.newTabLinkProps
-        }, [icon('terminal', { size: 24 })])
+        }, [icon('terminal', { size: 40 })])
       ])
     ])
   ])

--- a/src/components/ContextBar.js
+++ b/src/components/ContextBar.js
@@ -88,7 +88,7 @@ export const ContextBar = ({
     return h(Clickable, {
       style: { display: 'flex', flexDirection: 'column', justifyContent: 'center', ...contextBarStyles.contextBarButton, borderBottom: '0px' },
       hover: contextBarStyles.hover,
-      onClick: () => { // onclick displays an error message if the tool is in error, otherwise, if the tool is editable, opens the config modal (I.e. ComputeModal or GalaxyModal)
+      onClick: () => { // onclick displays an error message if the tool is in error, otherwise opens the config modal (I.e. ComputeModal or GalaxyModal)
         if (_.toLower(status) === 'error') {
           Utils.cond(
             [isToolAnApp(toolLabel), () => setErrorAppId(currentApp(toolLabel)?.appName)],

--- a/src/components/CromwellModal.js
+++ b/src/components/CromwellModal.js
@@ -23,7 +23,7 @@ const titleId = 'cromwell-modal-title'
 export const CromwellModalBase = withDisplayName('CromwellModal')(
   ({
     onDismiss, onSuccess, apps, appDataDisks, workspace, workspace: { workspace: { namespace, bucketName, name: workspaceName, googleProject } },
-    isAnalysisMode = false
+    shouldHideCloseButton
   }) => {
     const app = getCurrentApp(tools.cromwell.appType)(apps)
     const [loading, setLoading] = useState(false)
@@ -69,7 +69,7 @@ export const CromwellModalBase = withDisplayName('CromwellModal')(
         h(TitleBar, {
           id: titleId,
           title: 'Cromwell Cloud Environment',
-          hideCloseButton: isAnalysisMode,
+          hideCloseButton: shouldHideCloseButton,
           style: { marginBottom: '0.5rem' },
           onDismiss,
           onPrevious: undefined

--- a/src/components/CromwellModal.js
+++ b/src/components/CromwellModal.js
@@ -23,7 +23,7 @@ const titleId = 'cromwell-modal-title'
 export const CromwellModalBase = withDisplayName('CromwellModal')(
   ({
     onDismiss, onSuccess, apps, appDataDisks, workspace, workspace: { workspace: { namespace, bucketName, name: workspaceName, googleProject } },
-    shouldHideCloseButton
+    shouldHideCloseButton = false
   }) => {
     const app = getCurrentApp(tools.cromwell.appType)(apps)
     const [loading, setLoading] = useState(false)

--- a/src/components/GalaxyModal.js
+++ b/src/components/GalaxyModal.js
@@ -33,8 +33,7 @@ const titleId = 'galaxy-modal-title'
 
 export const GalaxyModalBase = withDisplayName('GalaxyModal')(
   ({
-    onDismiss, onSuccess, apps, appDataDisks, workspace, workspace: { workspace: { namespace, bucketName, name: workspaceName, googleProject } },
-    isAnalysisMode = false
+    onDismiss, onSuccess, apps, appDataDisks, workspace, workspace: { workspace: { namespace, bucketName, name: workspaceName, googleProject } }, shouldHideCloseButton
   }) => {
     // Assumption: If there is an app defined, there must be a data disk corresponding to it.
     const app = getCurrentApp(tools.galaxy.appType)(apps)
@@ -115,7 +114,7 @@ export const GalaxyModalBase = withDisplayName('GalaxyModal')(
             ['RUNNING', () => h(Fragment, [
               deleteButton,
               pauseButton,
-              h(ButtonPrimary, { disabled: false, onClick: () => setViewMode('launchWarn') }, ['Launch Galaxy'])
+              h(ButtonPrimary, { disabled: false, onClick: () => setViewMode('launchWarn') }, ['Open Galaxy'])
             ])],
             ['STOPPED', () => h(Fragment, [
               h(ButtonOutline, {
@@ -126,7 +125,7 @@ export const GalaxyModalBase = withDisplayName('GalaxyModal')(
             ])],
             ['ERROR', () => deleteButton],
             [Utils.DEFAULT, () => {
-              return h(Fragment, { tooltip: 'Cloud Compute must be resumed first.' }, [
+              return h(Fragment, [
                 h(ButtonOutline, {
                   disabled: true, style: { marginRight: 'auto' }, tooltip: 'Cloud Compute must be running.', onClick: () => setViewMode('deleteWarn')
                 }, ['Delete Environment']),
@@ -154,7 +153,7 @@ export const GalaxyModalBase = withDisplayName('GalaxyModal')(
           id: titleId,
           title: 'Cloud Environment',
           style: { marginBottom: '0.5rem' },
-          hideCloseButton: isAnalysisMode,
+          hideCloseButton: shouldHideCloseButton,
           onDismiss,
           onPrevious: !!viewMode ? () => setViewMode(undefined) : undefined
         }),
@@ -206,8 +205,8 @@ export const GalaxyModalBase = withDisplayName('GalaxyModal')(
       return div({ style: computeStyles.drawerContent }, [
         h(TitleBar, {
           id: titleId,
-          title: h(WarningTitle, ['Launch Galaxy']),
-          hideCloseButton: isAnalysisMode,
+          title: h(WarningTitle, ['Open Galaxy']),
+          hideCloseButton: shouldHideCloseButton,
           style: { marginBottom: '0.5rem' },
           onDismiss,
           onPrevious: !!viewMode ? () => setViewMode(undefined) : undefined
@@ -334,7 +333,7 @@ export const GalaxyModalBase = withDisplayName('GalaxyModal')(
         h(TitleBar, {
           id: titleId,
           style: computeStyles.titleBar,
-          hideCloseButton: isAnalysisMode,
+          hideCloseButton: shouldHideCloseButton,
           title: h(WarningTitle, ['Delete environment']),
           onDismiss,
           onPrevious: () => {
@@ -388,7 +387,7 @@ export const GalaxyModalBase = withDisplayName('GalaxyModal')(
         h(TitleBar, {
           id: titleId,
           title: 'Cloud Environment',
-          hideCloseButton: isAnalysisMode,
+          hideCloseButton: shouldHideCloseButton,
           style: { marginBottom: '0.5rem' },
           onDismiss,
           onPrevious: !!viewMode ? () => setViewMode(undefined) : undefined

--- a/src/components/GalaxyModal.js
+++ b/src/components/GalaxyModal.js
@@ -33,7 +33,7 @@ const titleId = 'galaxy-modal-title'
 
 export const GalaxyModalBase = withDisplayName('GalaxyModal')(
   ({
-    onDismiss, onSuccess, apps, appDataDisks, workspace, workspace: { workspace: { namespace, bucketName, name: workspaceName, googleProject } }, shouldHideCloseButton
+    onDismiss, onSuccess, apps, appDataDisks, workspace, workspace: { workspace: { namespace, bucketName, name: workspaceName, googleProject } }, shouldHideCloseButton = false
   }) => {
     // Assumption: If there is an app defined, there must be a data disk corresponding to it.
     const app = getCurrentApp(tools.galaxy.appType)(apps)

--- a/src/components/RuntimeManager.js
+++ b/src/components/RuntimeManager.js
@@ -81,14 +81,14 @@ export const RuntimeErrorModal = ({ runtime, onDismiss }) => {
           .then(res => res.text()))
       setUserscriptError(true)
     } else {
-      setError(runtimeErrors[0].errorMessage)
+      setError(runtimeErrors[0]?.errorMessage)
     }
   })
 
   useOnMount(() => { loadRuntimeError() })
 
   return h(Modal, {
-    title: `Cloud Environment Creation Failed${userscriptError ? ' due to Userscript Error' : ''}`,
+    title: `Cloud Environment is in error state${userscriptError ? ' due to Userscript Error' : ''}`,
     showCancel: false,
     onDismiss
   }, [
@@ -132,7 +132,7 @@ export const AppErrorModal = ({ app, onDismiss }) => {
   useOnMount(() => { loadAppError() })
 
   return h(Modal, {
-    title: `Galaxy App Creation Failed`,
+    title: `Galaxy App is in error state`,
     showCancel: false,
     onDismiss
   }, [
@@ -209,7 +209,7 @@ export default class RuntimeManager extends PureComponent {
         message: h(ButtonPrimary, {
           href: rStudioLaunchLink,
           onClick: () => clearNotification(rStudioNotificationId)
-        }, 'Launch Cloud Environment')
+        }, 'Open RStudio')
       })
     } else if (isAfter(createdDate, welderCutOff) && !isToday(dateNotified)) { // TODO: remove this notification some time after the data syncing release
       setDynamic(sessionStorage, `notifiedOutdatedRuntime${runtime.id}`, Date.now())
@@ -376,7 +376,7 @@ export default class RuntimeManager extends PureComponent {
           tooltip: 'Multiple cloud environments found in this billing project. Click to select which to delete.'
         }, [icon('warning-standard', { size: 24, style: { color: colors.danger() } })]),
         h(Link, {
-          'aria-label': 'Launch app',
+          'aria-label': 'Open application',
           href: applicationLaunchLink,
           onClick: window.location.hash === applicationLaunchLink && currentStatus === 'Stopped' ? () => this.startRuntime() : undefined,
           tooltip: canCompute ? `Open ${applicationName}` : noCompute,

--- a/src/components/runtime-common.js
+++ b/src/components/runtime-common.js
@@ -174,7 +174,7 @@ export const GalaxyLaunchButton = ({ app, key = app.status, onClick, ...props })
     },
     ...Utils.newTabLinkPropsWithReferrer, // Galaxy needs the referrer to be present so we can validate it, otherwise we fail with 401
     ...props
-  }, ['Launch Galaxy'])
+  }, ['Open Galaxy'])
 }
 
 export const appLauncherTabName = 'workspace-application-launch'

--- a/src/libs/runtime-utils.js
+++ b/src/libs/runtime-utils.js
@@ -382,7 +382,7 @@ export const RadioBlock = ({ labelText, children, name, checked, onChange, style
 
 export const getIsAppBusy = app => app?.status !== 'RUNNING' && _.includes('ING', app?.status)
 export const getIsRuntimeBusy = runtime => {
-  const { Creating: creating, Updating: updating, LeoReconfiguring: reconfiguring } = _.countBy(getConvertedRuntimeStatus, [runtime])
-  return creating || updating || reconfiguring
+  const { Creating: creating, Updating: updating, LeoReconfiguring: reconfiguring, Stopping: stopping, Starting: starting } = _.countBy(getConvertedRuntimeStatus, [runtime])
+  return creating || updating || reconfiguring || stopping || starting
 }
 

--- a/src/pages/workspaces/workspace/Analyses.js
+++ b/src/pages/workspaces/workspace/Analyses.js
@@ -104,7 +104,7 @@ const AnalysisCard = ({
           tooltip: Utils.cond([!canWrite, () => noWrite],
             [currentRuntimeTool === tools.RStudio.label, () => 'You must have a runtime with Jupyter to edit.']),
           tooltipSide: 'left'
-        }, locked ? [makeMenuIcon('lock'), 'Edit (In Use)'] : [makeMenuIcon('edit'), 'Edit']),
+        }, locked ? [makeMenuIcon('lock'), 'Open (In Use)'] : [makeMenuIcon('edit'), 'Edit']),
         h(MenuButton, {
           'aria-label': `Playground`,
           href: analysisPlaygroundLink,
@@ -119,7 +119,7 @@ const AnalysisCard = ({
           tooltip: Utils.cond([!canWrite, () => noWrite],
             [currentRuntimeTool === tools.RStudio.label, () => 'You must have a runtime with RStudio to launch.']),
           tooltipSide: 'left'
-        }, [makeMenuIcon('rocket'), 'Launch'])
+        }, [makeMenuIcon('rocket'), 'Open'])
       ]),
       h(MenuButton, {
         'aria-label': `Copy`,

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -104,7 +104,7 @@ const NotebookCard = ({
         disabled: locked || !canWrite,
         tooltip: !canWrite && noWrite,
         tooltipSide: 'left'
-      }, locked ? [makeMenuIcon('lock'), 'Edit (In Use)'] : [makeMenuIcon('edit'), 'Edit']),
+      }, locked ? [makeMenuIcon('lock'), 'Open (In Use)'] : [makeMenuIcon('rocket'), 'Open']),
       h(MenuButton, {
         href: notebookPlaygroundLink,
         tooltip: canWrite && 'Open in playground mode',

--- a/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
@@ -99,6 +99,7 @@ const AnalysisLauncher = _.flow(
           isOpen: createOpen,
           tool: toolLabel,
           isAnalysisMode: true,
+          shouldHideCloseButton: true,
           workspace,
           runtimes,
           persistentDisks,
@@ -268,13 +269,13 @@ const PreviewHeader = ({
         ...(toolLabel === tools.Jupyter.label ? [
           Utils.cond(
             [runtime && !welderEnabled, () => h(HeaderButton, { onClick: () => setEditModeDisabledOpen(true) }, [
-              makeMenuIcon('warning-standard'), 'Edit (Disabled)'
+              makeMenuIcon('warning-standard'), 'Open (Disabled)'
             ])],
             [locked, () => h(HeaderButton, { onClick: () => setFileInUseOpen(true) }, [
-              makeMenuIcon('lock'), 'Edit (In use)'
+              makeMenuIcon('lock'), 'Open (In use)'
             ])],
             () => h(HeaderButton, { onClick: () => currentRuntimeTool !== tools.Jupyter.label ? setCreateOpen(true) : chooseMode('edit') }, [
-              makeMenuIcon('edit'), 'Edit'
+              makeMenuIcon('rocket'), 'Open'
             ])
           ),
           h(HeaderButton, {
@@ -294,7 +295,7 @@ const PreviewHeader = ({
               }
             }
           }, [
-            makeMenuIcon('rocket'), 'Launch'
+            makeMenuIcon('rocket'), 'Open'
           ])
         ]),
         h(MenuTrigger, {

--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -237,13 +237,13 @@ const PreviewHeader = ({ queryParams, runtime, readOnlyAccess, onCreateRuntime, 
         Utils.cond(
           [runtime && !welderEnabled, () => h(HeaderButton, {
             onClick: () => setEditModeDisabledOpen(true)
-          }, [makeMenuIcon('warning-standard'), 'Edit (Disabled)'])],
+          }, [makeMenuIcon('warning-standard'), 'Open (Disabled)'])],
           [locked, () => h(HeaderButton, {
             onClick: () => setFileInUseOpen(true)
-          }, [makeMenuIcon('lock'), 'Edit (In use)'])],
+          }, [makeMenuIcon('lock'), 'Open (In use)'])],
           () => h(HeaderButton, {
             onClick: () => chooseMode('edit')
-          }, [makeMenuIcon('edit'), 'Edit'])
+          }, [makeMenuIcon('rocket'), 'Open'])
         ),
         h(HeaderButton, {
           onClick: () => getLocalPref('hidePlaygroundMessage') ? chooseMode('playground') : setPlaygroundModalOpen(true)

--- a/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
+++ b/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
@@ -49,6 +49,7 @@ export const CloudEnvironmentModal = ({
   const renderComputeModal = tool => h(ComputeModalBase, {
     isOpen: viewMode === NEW_JUPYTER_MODE || viewMode === NEW_RSTUDIO_MODE,
     isAnalysisMode: true,
+    shouldHideCloseButton: true,
     workspace,
     tool,
     runtimes,
@@ -66,7 +67,7 @@ export const CloudEnvironmentModal = ({
 
   const renderAppModal = (appModalBase, appMode) => h(appModalBase, {
     isOpen: viewMode === appMode,
-    isAnalysisMode: true,
+    shouldHideCloseButton: true,
     workspace,
     apps,
     appDataDisks,

--- a/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
+++ b/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
@@ -269,9 +269,13 @@ export const CloudEnvironmentModal = ({
     [isToolAnApp(toolLabel), () => !canCompute || busy || (toolLabel === tools.galaxy.label && isCurrentGalaxyDiskDetaching(apps)) || getIsAppBusy(currentApp(toolLabel))],
     [Utils.DEFAULT, () => {
       const runtime = getRuntimeForTool(toolLabel)
-      return runtime ?
-        !canCompute || busy || getIsRuntimeBusy(runtime) :
-        !canCompute || busy || getIsRuntimeBusy(currentRuntime) //TODO: multiple runtimes: change this to not have the last check in the or
+      console.log(toolLabel, runtime)
+      // This asks 'does this tool have a runtime'
+      //  if yes, then we allow cloud env modal to open (and ComputeModal determines if it should be read-only mode)
+      //  if no, then we want to disallow the cloud env modal opening if the other tool's runtime is busy
+      //  this check is not needed if we allow multiple runtimes, and cloud env modal will never be disabled in this case
+      return runtime ? false :
+        !canCompute || busy || getIsRuntimeBusy(currentRuntime)
     }]
   )
 


### PR DESCRIPTION
The PR addresses the following bullet points in this ticket https://broadworkbench.atlassian.net/browse/IA-3080
- We need to add messaging for the individual hovers during different states when env creation or resume (ex. Precreating, starting, running, etc. See “Env status tooltip” screenshot attached
<img width="653" alt="Env status tooltip" src="https://user-images.githubusercontent.com/6465084/160000824-d1fa8fd4-e303-46f2-868a-250327c71e51.png">

- Update side panel icons so that they get highlighted when hovering, individual hovers for each app env icon (so that they look like buttons)
- Clicking on each app icon brings up only its corresponding cloud env page only, and if user clicks on the cloud icon itself, then it will bring up the entire cloud env modal with all apps displayed
- Make side panel icons slightly bigger to improve usability
- Change the “Launch ______” name to “Open ______” (Note: this exists in the edit notebook view, also “do you want to launch” prompt, Context bar change only?)
- Change the name of Launch button with .rmd files to Open, and also the .ipynb from Edit to Open so that they both match
- Also change from Launch to Open when creating RStudio and Galaxy instances (pop up window at the right hand side of the page) - “Open X” where X = Galaxy, RStudio or other future apps