### PR TITLE
[IA-3271] fix memory leak in igv viewer

### DIFF
--- a/src/components/IGVBrowser.js
+++ b/src/components/IGVBrowser.js
@@ -20,7 +20,7 @@ const IGVBrowser = _.flow(
   const containerRef = useRef()
   const signal = useCancellation()
   const [loadingIgv, setLoadingIgv] = useState(true)
-  const [igvLibrary, setIgvLibrary] = useState(null)
+  const igvLibrary = useRef()
 
   useOnMount(() => {
     const igvSetup = async () => {
@@ -50,7 +50,7 @@ const IGVBrowser = _.flow(
       } else {
         try {
           const { default: igv } = await import('igv')
-          setIgvLibrary(igv)
+          igvLibrary.current = igv
 
           const options = {
             genome: refGenome,
@@ -77,14 +77,13 @@ const IGVBrowser = _.flow(
     }
 
     igvSetup()
+
+    return () => igvLibrary.current.removeAllBrowsers()
   })
 
   return h(Fragment, [
     h(Link, {
-      onClick: () => {
-        igvLibrary?.removeAllBrowsers()
-        onDismiss()
-      },
+      onClick: onDismiss,
       style: { alignSelf: 'flex-start', display: 'flex', alignItems: 'center', padding: '6.5px 8px' }
     }, [icon('arrowLeft', { style: { marginRight: '0.5rem' } }), 'Back to data table']),
     div({

--- a/src/components/IGVBrowser.js
+++ b/src/components/IGVBrowser.js
@@ -20,6 +20,7 @@ const IGVBrowser = _.flow(
   const containerRef = useRef()
   const signal = useCancellation()
   const [loadingIgv, setLoadingIgv] = useState(true)
+  const [igvLibrary, setIgvLibrary] = useState(null)
 
   useOnMount(() => {
     const igvSetup = async () => {
@@ -49,6 +50,7 @@ const IGVBrowser = _.flow(
       } else {
         try {
           const { default: igv } = await import('igv')
+          setIgvLibrary(igv)
 
           const options = {
             genome: refGenome,
@@ -77,10 +79,12 @@ const IGVBrowser = _.flow(
     igvSetup()
   })
 
-
   return h(Fragment, [
     h(Link, {
-      onClick: onDismiss,
+      onClick: () => {
+        igvLibrary?.removeAllBrowsers()
+        onDismiss()
+      },
       style: { alignSelf: 'flex-start', display: 'flex', alignItems: 'center', padding: '6.5px 8px' }
     }, [icon('arrowLeft', { style: { marginRight: '0.5rem' } }), 'Back to data table']),
     div({


### PR DESCRIPTION
Fixed a memory leak coming in and out of the IGV viewer page.

### Before (3 visits to IGV viewer create 3 allocation for IGV lib, about 10 MB each time)
![Screen Shot 2022-03-24 at 4 50 37 PM](https://user-images.githubusercontent.com/8800717/160010213-3ce9bf61-e3a3-4d38-8bdf-9a3a418fe2e7.png)

### After (3 visits to the IGV viewer, no allocations left after the viewer is exited each time)
![Screen Shot 2022-03-24 at 4 51 01 PM](https://user-images.githubusercontent.com/8800717/160010230-3e69572f-0d48-4693-80e6-3d0c6edcf48b.png)

