### PR TITLE
Add janitor "test" to delete orphaned workspaces (WOR-210).

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -18940,6 +18940,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@google-cloud/firestore", "npm:4.15.1"],\
             ["@google-cloud/secret-manager", "npm:3.11.0"],\
             ["@google-cloud/storage", "npm:5.18.2"],\
+            ["date-fns", "npm:2.24.0"],\
             ["express", "npm:4.17.1"],\
             ["google-auth-library", "npm:7.14.1"],\
             ["googleapis", "npm:87.0.0"],\

--- a/integration-tests/jest/janitor.integration-test.js
+++ b/integration-tests/jest/janitor.integration-test.js
@@ -1,0 +1,5 @@
+const { registerTest } = require('./jest-utils')
+const { janitor } = require('../tests/janitor')
+
+
+registerTest(janitor)

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -26,6 +26,7 @@
     "@google-cloud/firestore": "^4.15.1",
     "@google-cloud/secret-manager": "^3.10.1",
     "@google-cloud/storage": "^5.14.2",
+    "date-fns": "^2.24.0",
     "express": "^4.17.1",
     "google-auth-library": "^7.9.2",
     "googleapis": "^87.0.0",

--- a/integration-tests/tests/janitor.js
+++ b/integration-tests/tests/janitor.js
@@ -5,7 +5,7 @@ const { dismissNotifications, signIntoTerra } = require('../utils/integration-ut
 const { withUserToken } = require('../utils/terra-sa-utils')
 
 
-const olderThanDays = 200
+const olderThanDays = 100
 const workspacePrefix = 'test-workspace-' // TODO: share with other location
 
 const runJanitor = withUserToken(async ({ billingProject, page, testUrl, token }) => {
@@ -30,7 +30,7 @@ const runJanitor = withUserToken(async ({ billingProject, page, testUrl, token }
       await page.evaluate((namespace, name) => window.Ajax().Workspaces.workspace(namespace, name).delete(), namespace, name)
       rawConsole.info(`Deleted old workspace: ${name}`)
     } catch (e) {
-      throw Error(`Failed to delete old workspace: ${name} with billing project ${namespace}`)
+      rawConsole.info(`Failed to delete old workspace: ${name} with billing project ${namespace}`)
     }
   }, oldWorkspaces))
 })

--- a/integration-tests/tests/janitor.js
+++ b/integration-tests/tests/janitor.js
@@ -6,7 +6,7 @@ const { dismissNotifications, signIntoTerra } = require('../utils/integration-ut
 const { withUserToken } = require('../utils/terra-sa-utils')
 
 
-const olderThanDays = 0
+const olderThanDays = 2
 
 const runJanitor = withUserToken(async ({ billingProject, page, testUrl, token }) => {
   // Sign into Terra so we have the correct credentials.
@@ -15,7 +15,8 @@ const runJanitor = withUserToken(async ({ billingProject, page, testUrl, token }
   await dismissNotifications(page)
 
   // Delete old orphaned workspaces. These can result from local integration test runs where the
-  // process was prematurely terminated.
+  // process was prematurely terminated, but a few also appear in alpha and staging indicating that
+  // ci test runs also sometimes leak workspaces.
   const workspaces = await page.evaluate(async () => await window.Ajax().Workspaces.list())
   const oldWorkspaces = _.filter(({ workspace: { namespace, name, createdDate } }) => {
     const age = dateFns.differenceInDays(new Date(createdDate), new Date())

--- a/integration-tests/tests/janitor.js
+++ b/integration-tests/tests/janitor.js
@@ -4,6 +4,7 @@ const _ = require('lodash/fp')
 const { dismissNotifications, signIntoTerra } = require('../utils/integration-utils')
 const { withUserToken } = require('../utils/terra-sa-utils')
 
+
 const olderThanDays = 365
 const workspacePrefix = 'test-workspace-' // TODO: share with other location
 
@@ -16,8 +17,8 @@ const runJanitor = withUserToken(async ({ billingProject, page, testUrl, token }
   // Delete old orphaned workspaces. These can result from local integration test runs where the
   // process was prematurely terminated.
   const workspaces = await page.evaluate(async () => await window.Ajax().Workspaces.list())
-  const oldWorkspaces = _.filter( ( { workspace: {namespace, name, lastModified} } ) => {
-      return namespace === billingProject &&
+  const oldWorkspaces = _.filter(({ workspace: { namespace, name, lastModified } }) => {
+    return namespace === billingProject &&
       _.startsWith(workspacePrefix, name) &&
       dateFns.differenceInDays(new Date(lastModified), new Date()) > olderThanDays
   }, workspaces)

--- a/integration-tests/tests/janitor.js
+++ b/integration-tests/tests/janitor.js
@@ -1,12 +1,12 @@
 const rawConsole = require('console')
 const dateFns = require('date-fns/fp')
 const _ = require('lodash/fp')
+const { testWorkspaceNamePrefix } = require('../utils/integration-helpers')
 const { dismissNotifications, signIntoTerra } = require('../utils/integration-utils')
 const { withUserToken } = require('../utils/terra-sa-utils')
 
 
-const olderThanDays = 100
-const workspacePrefix = 'test-workspace-' // TODO: share with other location
+const olderThanDays = 0
 
 const runJanitor = withUserToken(async ({ billingProject, page, testUrl, token }) => {
   // Sign into Terra so we have the correct credentials.
@@ -17,22 +17,22 @@ const runJanitor = withUserToken(async ({ billingProject, page, testUrl, token }
   // Delete old orphaned workspaces. These can result from local integration test runs where the
   // process was prematurely terminated.
   const workspaces = await page.evaluate(async () => await window.Ajax().Workspaces.list())
-  const oldWorkspaces = _.filter(({ workspace: { namespace, name, lastModified } }) => {
-    return namespace === billingProject &&
-      _.startsWith(workspacePrefix, name) &&
-      dateFns.differenceInDays(new Date(lastModified), new Date()) > olderThanDays
+  const oldWorkspaces = _.filter(({ workspace: { namespace, name, createdDate } }) => {
+    const age = dateFns.differenceInDays(new Date(createdDate), new Date())
+    rawConsole.info(`${namespace} ${name}, age ${age} days`)
+    return namespace === billingProject && _.startsWith(testWorkspaceNamePrefix, name) && age > olderThanDays
   }, workspaces)
 
-  rawConsole.log(`Deleting ${oldWorkspaces.length} workspaces with prefix "${workspacePrefix}" unmodified for more than ${olderThanDays} days.`)
+  rawConsole.log(`Deleting ${oldWorkspaces.length} workspaces with prefix "${testWorkspaceNamePrefix}" created more than ${olderThanDays} days ago.`)
 
-  return Promise.all(_.map(async ({ workspace: { namespace, name } }) => {
-    try {
-      await page.evaluate((namespace, name) => window.Ajax().Workspaces.workspace(namespace, name).delete(), namespace, name)
-      rawConsole.info(`Deleted old workspace: ${name}`)
-    } catch (e) {
-      rawConsole.info(`Failed to delete old workspace: ${name} with billing project ${namespace}`)
-    }
-  }, oldWorkspaces))
+  // return Promise.all(_.map(async ({ workspace: { namespace, name } }) => {
+  //   try {
+  //     await page.evaluate((namespace, name) => window.Ajax().Workspaces.workspace(namespace, name).delete(), namespace, name)
+  //     rawConsole.info(`Deleted old workspace: ${name}`)
+  //   } catch (e) {
+  //     rawConsole.info(`Failed to delete old workspace: ${name} with billing project ${namespace}`)
+  //   }
+  // }, oldWorkspaces))
 })
 
 const janitor = {

--- a/integration-tests/tests/janitor.js
+++ b/integration-tests/tests/janitor.js
@@ -5,7 +5,7 @@ const { dismissNotifications, signIntoTerra } = require('../utils/integration-ut
 const { withUserToken } = require('../utils/terra-sa-utils')
 
 
-const olderThanDays = 365
+const olderThanDays = 200
 const workspacePrefix = 'test-workspace-' // TODO: share with other location
 
 const runJanitor = withUserToken(async ({ billingProject, page, testUrl, token }) => {

--- a/integration-tests/tests/janitor.js
+++ b/integration-tests/tests/janitor.js
@@ -19,20 +19,20 @@ const runJanitor = withUserToken(async ({ billingProject, page, testUrl, token }
   const workspaces = await page.evaluate(async () => await window.Ajax().Workspaces.list())
   const oldWorkspaces = _.filter(({ workspace: { namespace, name, createdDate } }) => {
     const age = dateFns.differenceInDays(new Date(createdDate), new Date())
-    rawConsole.info(`${namespace} ${name}, age ${age} days`)
+    // rawConsole.info(`${namespace} ${name}, age ${age} days`)
     return namespace === billingProject && _.startsWith(testWorkspaceNamePrefix, name) && age > olderThanDays
   }, workspaces)
 
   rawConsole.log(`Deleting ${oldWorkspaces.length} workspaces with prefix "${testWorkspaceNamePrefix}" created more than ${olderThanDays} days ago.`)
 
-  // return Promise.all(_.map(async ({ workspace: { namespace, name } }) => {
-  //   try {
-  //     await page.evaluate((namespace, name) => window.Ajax().Workspaces.workspace(namespace, name).delete(), namespace, name)
-  //     rawConsole.info(`Deleted old workspace: ${name}`)
-  //   } catch (e) {
-  //     rawConsole.info(`Failed to delete old workspace: ${name} with billing project ${namespace}`)
-  //   }
-  // }, oldWorkspaces))
+  return Promise.all(_.map(async ({ workspace: { namespace, name } }) => {
+    try {
+      await page.evaluate((namespace, name) => window.Ajax().Workspaces.workspace(namespace, name).delete(), namespace, name)
+      rawConsole.info(`Deleted old workspace: ${name}`)
+    } catch (e) {
+      rawConsole.info(`Failed to delete old workspace: ${name} with billing project ${namespace}`)
+    }
+  }, oldWorkspaces))
 })
 
 const janitor = {

--- a/integration-tests/tests/janitor.js
+++ b/integration-tests/tests/janitor.js
@@ -1,0 +1,42 @@
+const rawConsole = require('console')
+const dateFns = require('date-fns/fp')
+const _ = require('lodash/fp')
+const { dismissNotifications, signIntoTerra } = require('../utils/integration-utils')
+const { withUserToken } = require('../utils/terra-sa-utils')
+
+const olderThanDays = 365
+const workspacePrefix = 'test-workspace-' // TODO: share with other location
+
+const runJanitor = withUserToken(async ({ billingProject, page, testUrl, token }) => {
+  // Sign into Terra so we have the correct credentials.
+  await page.goto(testUrl)
+  await signIntoTerra(page, token)
+  await dismissNotifications(page)
+
+  // Delete old orphaned workspaces. These can result from local integration test runs where the
+  // process was prematurely terminated.
+  const workspaces = await page.evaluate(async () => await window.Ajax().Workspaces.list())
+  const oldWorkspaces = _.filter( ( { workspace: {namespace, name, lastModified} } ) => {
+      return namespace === billingProject &&
+      _.startsWith(workspacePrefix, name) &&
+      dateFns.differenceInDays(new Date(lastModified), new Date()) > olderThanDays
+  }, workspaces)
+
+  rawConsole.log(`Deleting ${oldWorkspaces.length} workspaces with prefix "${workspacePrefix}" unmodified for more than ${olderThanDays} days.`)
+
+  return Promise.all(_.map(async ({ workspace: { namespace, name } }) => {
+    try {
+      await page.evaluate((namespace, name) => window.Ajax().Workspaces.workspace(namespace, name).delete(), namespace, name)
+      rawConsole.info(`Deleted old workspace: ${name}`)
+    } catch (e) {
+      throw Error(`Failed to delete old workspace: ${name} with billing project ${namespace}`)
+    }
+  }, oldWorkspaces))
+})
+
+const janitor = {
+  name: 'janitor',
+  fn: runJanitor
+}
+
+module.exports = { janitor }

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -23,7 +23,8 @@ const withSignedInPage = fn => async options => {
 
 const clipToken = str => str.toString().substr(-10, 10)
 
-const getTestWorkspaceName = () => `terra-ui-test-workspace-${uuid.v4()}`
+const testWorkspaceNamePrefix = 'terra-ui-test-workspace-'
+const getTestWorkspaceName = () => `${testWorkspaceNamePrefix}${uuid.v4()}`
 
 const makeWorkspace = withSignedInPage(async ({ page, billingProject }) => {
   const workspaceName = getTestWorkspaceName()
@@ -203,6 +204,7 @@ module.exports = {
   createEntityInWorkspace,
   defaultTimeout,
   enableDataCatalog,
+  testWorkspaceNamePrefix,
   overrideConfig,
   testWorkspaceName: getTestWorkspaceName,
   withWorkspace,

--- a/yarn.lock
+++ b/yarn.lock
@@ -14030,6 +14030,7 @@ resolve@^2.0.0-next.3:
     "@google-cloud/firestore": ^4.15.1
     "@google-cloud/secret-manager": ^3.10.1
     "@google-cloud/storage": ^5.14.2
+    date-fns: ^2.24.0
     express: ^4.17.1
     google-auth-library: ^7.9.2
     googleapis: ^87.0.0


### PR DESCRIPTION
This adds a janitor "test" to the integration test suite so that we can clean up leaked resources. I am using it to delete workspaces created over 2 days ago that were generated by running integration tests.

Workspaces can be leaked by when tests are killed prematurely, for example when folks run the tests locally and kill the running process (something I've certainly been known to do!!). They also apparently happen on occasion when ci runs tests, as evidenced by the fact that we have a small number in both the alpha and staging environments (I will be cleaning them up soon… ones with the new name prefix will automatically get cleaned up when this test runs in alpha/staging, and ones with the [older name prefix](https://github.com/DataBiosphere/terra-ui/pull/2903) I will clean up by running a modified version of the test directly against those environments). More details are available in https://broadworkbench.atlassian.net/browse/WOR-210.

When I first starting deleting large numbers of workspaces (700ish), I was hitting problems with delete workspace returning an error. It turns out that we were receiving 404s from Sam's deleteResource method (due to database contention/timing out/retries), and the Rawls delete workspace method considered that an error. Therefore I held this PR [until that issue was fixed](https://github.com/broadinstitute/rawls/pull/1673), to prevent introducing more flakiness to our tests.