### PR TITLE
[IA-3080] UX feedback

### DIFF
--- a/integration-tests/tests/run-notebook.js
+++ b/integration-tests/tests/run-notebook.js
@@ -2,7 +2,6 @@ const _ = require('lodash/fp')
 const { withRegisteredUser, withBilling, withWorkspace } = require('../utils/integration-helpers')
 const { click, clickable, getAnimatedDrawer, signIntoTerra, findElement, navChild, waitForNoSpinners, noSpinnersAfter, select, fillIn, input, findIframe, findText, dismissNotifications } = require('../utils/integration-utils')
 
-
 const notebookName = 'TestNotebook'
 
 const testRunNotebookFn = _.flow(
@@ -16,15 +15,15 @@ const testRunNotebookFn = _.flow(
   await dismissNotifications(page)
   await waitForNoSpinners(page)
 
-  await noSpinnersAfter(page, { action: () => click(page, clickable({ textContains: workspaceName })) })
+  await noSpinnersAfter(page, { action: () => click(page, clickable({ textContains: workspaceName })), debugMessage: '1'})
   await click(page, navChild('notebooks'))
   await click(page, clickable({ textContains: 'Create a' }))
   await fillIn(page, input({ placeholder: 'Enter a name' }), notebookName)
   await select(page, 'Language', 'Python 3')
 
-  await noSpinnersAfter(page, { action: () => click(page, clickable({ text: 'Create Notebook' })) })
-  await noSpinnersAfter(page, { action: () => click(page, clickable({ textContains: notebookName })) })
-  await noSpinnersAfter(page, { action: () => click(page, clickable({ text: 'Edit' })) })
+  await noSpinnersAfter(page, { action: () => click(page, clickable({ text: 'Create Notebook' })), debugMessage: '2' })
+  await noSpinnersAfter(page, { action: () => click(page, clickable({ textContains: notebookName })), debugMessage: '3'})
+  await noSpinnersAfter(page, { action: () => click(page, clickable({ text: 'Open' })), debugMessage: '4'})
 
   await findElement(page, getAnimatedDrawer('Cloud Environment'))
   await click(page, clickable({ text: 'Create' }))
@@ -32,10 +31,12 @@ const testRunNotebookFn = _.flow(
   await findElement(page, clickable({ textContains: 'Running' }), { timeout: 10 * 60 * 1000 })
 
   const frame = await findIframe(page)
+
   await findElement(frame, '//*[@title="Kernel Idle"]')
   await fillIn(frame, '//textarea', 'print(123456789099876543210990+9876543219)')
   await click(frame, clickable({ text: 'Run' }))
   await findText(frame, '123456789099886419754209')
+
   // Save notebook to avoid "unsaved changes" modal when test tear-down tries to close the window
   await click(frame, clickable({ text: 'Save and Checkpoint' }))
 })

--- a/integration-tests/tests/run-notebook.js
+++ b/integration-tests/tests/run-notebook.js
@@ -2,6 +2,7 @@ const _ = require('lodash/fp')
 const { withRegisteredUser, withBilling, withWorkspace } = require('../utils/integration-helpers')
 const { click, clickable, getAnimatedDrawer, signIntoTerra, findElement, navChild, waitForNoSpinners, noSpinnersAfter, select, fillIn, input, findIframe, findText, dismissNotifications } = require('../utils/integration-utils')
 
+
 const notebookName = 'TestNotebook'
 
 const testRunNotebookFn = _.flow(
@@ -15,15 +16,15 @@ const testRunNotebookFn = _.flow(
   await dismissNotifications(page)
   await waitForNoSpinners(page)
 
-  await noSpinnersAfter(page, { action: () => click(page, clickable({ textContains: workspaceName })), debugMessage: '1'})
+  await noSpinnersAfter(page, { action: () => click(page, clickable({ textContains: workspaceName })), debugMessage: '1' })
   await click(page, navChild('notebooks'))
   await click(page, clickable({ textContains: 'Create a' }))
   await fillIn(page, input({ placeholder: 'Enter a name' }), notebookName)
   await select(page, 'Language', 'Python 3')
 
   await noSpinnersAfter(page, { action: () => click(page, clickable({ text: 'Create Notebook' })), debugMessage: '2' })
-  await noSpinnersAfter(page, { action: () => click(page, clickable({ textContains: notebookName })), debugMessage: '3'})
-  await noSpinnersAfter(page, { action: () => click(page, clickable({ text: 'Open' })), debugMessage: '4'})
+  await noSpinnersAfter(page, { action: () => click(page, clickable({ textContains: notebookName })), debugMessage: '3' })
+  await noSpinnersAfter(page, { action: () => click(page, clickable({ text: 'Open' })), debugMessage: '4' })
 
   await findElement(page, getAnimatedDrawer('Cloud Environment'))
   await click(page, clickable({ text: 'Create' }))

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -133,7 +133,10 @@ const waitForNoSpinners = page => {
 // Puppeteer works by internally using MutationObserver. We are setting up the listener before
 // the action to ensure that the spinner rendering is captured by the observer, followed by
 // waiting for the spinner to be removed
-const noSpinnersAfter = async (page, { action }) => {
+const noSpinnersAfter = async (page, { action, debugMessage }) => {
+  if (debugMessage) {
+    rawConsole.log(`About to perform an action and wait for spinners. \n\tDebug message: ${debugMessage}`)
+  }
   const foundSpinner = page.waitForXPath('//*[@data-icon="loadingSpinner"]')
   await Promise.all([foundSpinner, action()])
   return waitForNoSpinners(page)

--- a/src/components/AnalysisModal.js
+++ b/src/components/AnalysisModal.js
@@ -108,7 +108,6 @@ export const AnalysisModal = withDisplayName('AnalysisModal')(
     const renderComputeModal = () => h(ComputeModalBase, {
       isOpen: currentTool === tools.Jupyter.label || currentTool === tools.RStudio.label,
       isAnalysisMode: true,
-      shouldHideCloseButton: true,
       workspace,
       tool: currentTool,
       runtimes,
@@ -126,7 +125,6 @@ export const AnalysisModal = withDisplayName('AnalysisModal')(
 
     const renderAppModal = (appModalBase, toolLabel) => h(appModalBase, {
       isOpen: viewMode === toolLabel,
-      shouldHideCloseButton: true,
       workspace,
       apps,
       appDataDisks,

--- a/src/components/AnalysisModal.js
+++ b/src/components/AnalysisModal.js
@@ -101,13 +101,14 @@ export const AnalysisModal = withDisplayName('AnalysisModal')(
     const getEnvironmentView = () => Utils.switchCase(currentTool,
       [tools.Jupyter.label, renderComputeModal],
       [tools.RStudio.label, renderComputeModal],
-      [tools.galaxy.label, () => renderAppModal(GalaxyModalBase, tools.galaxy.label)],
-      [tools.cromwell.label, () => renderAppModal(CromwellModalBase, tools.cromwell.label)]
+      [tools.Galaxy.label, () => renderAppModal(GalaxyModalBase, tools.Galaxy.label)],
+      [tools.Cromwell.label, () => renderAppModal(CromwellModalBase, tools.Cromwell.label)]
     )
 
     const renderComputeModal = () => h(ComputeModalBase, {
       isOpen: currentTool === tools.Jupyter.label || currentTool === tools.RStudio.label,
       isAnalysisMode: true,
+      shouldHideCloseButton: true,
       workspace,
       tool: currentTool,
       runtimes,
@@ -125,7 +126,7 @@ export const AnalysisModal = withDisplayName('AnalysisModal')(
 
     const renderAppModal = (appModalBase, toolLabel) => h(appModalBase, {
       isOpen: viewMode === toolLabel,
-      isAnalysisMode: true,
+      shouldHideCloseButton: true,
       workspace,
       apps,
       appDataDisks,
@@ -148,8 +149,8 @@ export const AnalysisModal = withDisplayName('AnalysisModal')(
       hover: { backgroundColor: colors.accent(0.3) }
     }
 
-    const galaxyApp = currentApp(tools.galaxy.label)
-    const cromwellApp = currentApp(tools.cromwell.label)
+    const galaxyApp = currentApp(tools.Galaxy.label)
+    const cromwellApp = currentApp(tools.Cromwell.label)
 
     // TODO: Try to move app/tool-specific info into tools (in notebook-utils.js) so the function below can just iterate over tools instead of duplicating logic
     const renderToolButtons = () => div({
@@ -171,16 +172,16 @@ export const AnalysisModal = withDisplayName('AnalysisModal')(
       }, [img({ src: rstudioBioLogo, alt: 'Create new R markdown file', style: styles.image })]),
       h(Clickable, {
         style: { opacity: galaxyApp ? '0.5' : '1', ...styles.toolCard }, onClick: () => {
-          setCurrentTool(tools.galaxy.label)
-          enterNextViewMode(tools.galaxy.label)
+          setCurrentTool(tools.Galaxy.label)
+          enterNextViewMode(tools.Galaxy.label)
         },
         hover: !galaxyApp ? styles.hover : undefined,
         disabled: !!galaxyApp, tooltip: galaxyApp ? 'You already have a galaxy environment' : ''
       }, [img({ src: galaxyLogo, alt: 'Create new Galaxy app', style: _.merge(styles.image, { width: '30%' }) })]),
-      !tools.cromwell.isAppHidden && h(Clickable, {
+      !tools.Cromwell.isAppHidden && h(Clickable, {
         style: { opacity: cromwellApp ? '0.5' : '1', ...styles.toolCard }, onClick: () => {
-          setCurrentTool(tools.cromwell.label)
-          enterNextViewMode(tools.cromwell.label)
+          setCurrentTool(tools.Cromwell.label)
+          enterNextViewMode(tools.Cromwell.label)
         },
         hover: !cromwellApp ? styles.hover : undefined,
         disabled: !!cromwellApp, tooltip: cromwellApp ? 'You already have a Cromwell instance' : ''

--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -784,7 +784,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
       () => ({ disabled: !hasChanges() || !!errors, tooltip: Utils.summarizeErrors(errors) })
     )
 
-    const isUpdateDisabled = getIsRuntimeBusy(currentRuntimeDetails)
+    const isUpdateDisabled = getIsRuntimeBusy(currentRuntimeDetails, existingRuntime?.toolDockerImage === desiredRuntime?.toolDockerImage)
 
     const canShowWarning = viewMode === undefined
     const canShowEnvironmentWarning = _.includes(viewMode, [undefined, 'customImageWarning'])

--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -659,6 +659,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
       const { googleProject } = getWorkspaceObject()
       const currentRuntime = getCurrentRuntime(runtimes)
       const currentPersistentDisk = getCurrentPersistentDisk(runtimes, persistentDisks)
+      console.log('currentPersistentDisk', currentPersistentDisk)
 
       Ajax().Metrics.captureEvent(Events.cloudEnvironmentConfigOpen, {
         existingConfig: !!currentRuntime, ...extractWorkspaceDetails(getWorkspaceObject())
@@ -784,7 +785,9 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
       () => ({ disabled: !hasChanges() || !!errors, tooltip: Utils.summarizeErrors(errors) })
     )
 
-    const isUpdateDisabled = getIsRuntimeBusy(currentRuntimeDetails, existingRuntime?.toolDockerImage === desiredRuntime?.toolDockerImage)
+    const isRuntimeError = existingRuntime?.status === 'Error'
+    const shouldErrorDisableUpdate = existingRuntime?.toolDockerImage === desiredRuntime?.toolDockerImage
+    const isUpdateDisabled = getIsRuntimeBusy(currentRuntimeDetails) || (shouldErrorDisableUpdate && isRuntimeError)
 
     const canShowWarning = viewMode === undefined
     const canShowEnvironmentWarning = _.includes(viewMode, [undefined, 'customImageWarning'])
@@ -808,7 +811,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
         },
         disabled: isUpdateDisabled,
         tooltipSide: 'left',
-        tooltip: isUpdateDisabled ? `Cannot perform change on environment in status ( ${currentRuntimeDetails.status} )` : 'Update Environment'
+        tooltip: isUpdateDisabled ? `Cannot perform change on environment in ( ${currentRuntimeDetails.status} ) status` : 'Update Environment'
       }, [
         Utils.cond(
           [viewMode === 'deleteEnvironment', () => 'Delete'],

--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -26,8 +26,8 @@ import {
   computeStyles, defaultAutopauseThreshold, defaultComputeRegion, defaultComputeZone, defaultDataprocMachineType, defaultDataprocMasterDiskSize,
   defaultDataprocWorkerDiskSize, defaultGceBootDiskSize, defaultGceMachineType, defaultGcePersistentDiskSize, defaultGpuType, defaultLocation,
   defaultNumDataprocPreemptibleWorkers, defaultNumDataprocWorkers, defaultNumGpus, displayNameForGpuType, findMachineType, getAutopauseThreshold,
-  getCurrentRuntime, getDefaultMachineType, getPersistentDiskCostMonthly, getValidGpuTypes, getValidGpuTypesForZone, isAutopauseEnabled, RadioBlock,
-  runtimeConfigBaseCost, runtimeConfigCost
+  getCurrentRuntime, getDefaultMachineType, getIsRuntimeBusy, getPersistentDiskCostMonthly, getValidGpuTypes, getValidGpuTypesForZone,
+  isAutopauseEnabled, RadioBlock, runtimeConfigBaseCost, runtimeConfigCost
 } from 'src/libs/runtime-utils'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
@@ -149,7 +149,7 @@ const SparkInterface = ({ sparkInterface, namespace, name, onDismiss }) => {
               style: { marginRight: 'auto' },
               onClick: onDismiss,
               ...Utils.newTabLinkProps
-            }, ['Launch', icon('pop-out', { size: 12, style: { marginLeft: '0.5rem' } })])
+            }, ['Open', icon('pop-out', { size: 12, style: { marginLeft: '0.5rem' } })])
           ])
         ])
       ])
@@ -182,7 +182,7 @@ const shouldUsePersistentDisk = (runtimeType, runtimeDetails, upgradeDiskSelecte
   (!runtimeDetails?.runtimeConfig?.diskSize || upgradeDiskSelected)
 // Auxiliary functions -- end
 
-export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDisks, tool, workspace, location, isAnalysisMode = false }) => {
+export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDisks, tool, workspace, location, isAnalysisMode = false, shouldHideCloseButton = isAnalysisMode }) => {
   // State -- begin
   const [showDebugger, setShowDebugger] = useState(false)
   const [loading, setLoading] = useState(false)
@@ -748,7 +748,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
         id: titleId,
         style: computeStyles.titleBar,
         title: 'About persistent disk',
-        hideCloseButton: isAnalysisMode,
+        hideCloseButton: shouldHideCloseButton,
         onDismiss,
         onPrevious: () => setViewMode()
       }),
@@ -783,6 +783,9 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
       ],
       () => ({ disabled: !hasChanges() || !!errors, tooltip: Utils.summarizeErrors(errors) })
     )
+
+    const isChangeDisabled = getIsRuntimeBusy(currentRuntimeDetails)
+
     const canShowWarning = viewMode === undefined
     const canShowEnvironmentWarning = _.includes(viewMode, [undefined, 'customImageWarning'])
     return Utils.cond([
@@ -802,7 +805,10 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
         ...commonButtonProps,
         onClick: () => {
           applyChanges()
-        }
+        },
+        disabled: isChangeDisabled,
+        tooltipSide: 'left',
+        tooltip: isChangeDisabled ? `Cannot perform change on environment in status ( ${currentRuntimeDetails.status} )` : 'Update Environment'
       }, [
         Utils.cond(
           [viewMode === 'deleteEnvironment', () => 'Delete'],
@@ -1162,7 +1168,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
     return div({ style: { ...computeStyles.drawerContent, ...computeStyles.warningView } }, [
       h(TitleBar, {
         id: titleId,
-        hideCloseButton: isAnalysisMode,
+        hideCloseButton: shouldHideCloseButton,
         style: computeStyles.titleBar,
         title: h(WarningTitle, ['Unverified Docker image']),
         onDismiss,
@@ -1188,7 +1194,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
     return div({ style: { ...computeStyles.drawerContent, ...computeStyles.warningView } }, [
       h(TitleBar, {
         id: titleId,
-        hideCloseButton: isAnalysisMode,
+        hideCloseButton: shouldHideCloseButton,
         style: computeStyles.titleBar,
         title: h(WarningTitle, ['Compute location differs from workspace bucket location']),
         onDismiss,
@@ -1220,7 +1226,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
     return div({ style: { ...computeStyles.drawerContent, ...computeStyles.warningView } }, [
       h(TitleBar, {
         id: titleId,
-        hideCloseButton: isAnalysisMode,
+        hideCloseButton: shouldHideCloseButton,
         style: computeStyles.titleBar,
         title: h(WarningTitle, ['Non-US Compute Location']),
         onDismiss,
@@ -1311,7 +1317,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
         id: titleId,
         style: computeStyles.titleBar,
         title: h(WarningTitle, ['Delete environment']),
-        hideCloseButton: isAnalysisMode,
+        hideCloseButton: shouldHideCloseButton,
         onDismiss,
         onPrevious: () => {
           setViewMode(undefined)
@@ -1396,7 +1402,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
       h(TitleBar, {
         id: titleId,
         style: computeStyles.titleBar,
-        hideCloseButton: isAnalysisMode,
+        hideCloseButton: shouldHideCloseButton,
         title: h(WarningTitle, [
           Utils.cond(
             [willDetachPersistentDisk(), () => 'Replace application configuration and cloud compute profile for Spark'],
@@ -1504,7 +1510,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
           id: titleId,
           style: { marginBottom: '0.5rem' },
           title: isAnalysisMode ? `${tool} Cloud Environment` : 'Cloud Environment',
-          hideCloseButton: isAnalysisMode,
+          hideCloseButton: shouldHideCloseButton,
           onDismiss
         }),
         div(['A cloud environment consists of application configuration, cloud compute and persistent disk(s).'])
@@ -1612,7 +1618,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
         id: titleId,
         style: computeStyles.titleBar,
         title: 'Installed packages',
-        hideCloseButton: isAnalysisMode,
+        hideCloseButton: shouldHideCloseButton,
         onDismiss,
         onPrevious: () => setViewMode(undefined)
       }),
@@ -1630,7 +1636,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
         id: titleId,
         title: 'Spark Console',
         style: { marginBottom: '0.5rem' },
-        hideCloseButton: isAnalysisMode,
+        hideCloseButton: shouldHideCloseButton,
         onDismiss,
         onPrevious: () => setViewMode(undefined)
       }),

--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -784,7 +784,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
       () => ({ disabled: !hasChanges() || !!errors, tooltip: Utils.summarizeErrors(errors) })
     )
 
-    const isChangeDisabled = getIsRuntimeBusy(currentRuntimeDetails)
+    const isUpdateDisabled = getIsRuntimeBusy(currentRuntimeDetails)
 
     const canShowWarning = viewMode === undefined
     const canShowEnvironmentWarning = _.includes(viewMode, [undefined, 'customImageWarning'])
@@ -806,9 +806,9 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
         onClick: () => {
           applyChanges()
         },
-        disabled: isChangeDisabled,
+        disabled: isUpdateDisabled,
         tooltipSide: 'left',
-        tooltip: isChangeDisabled ? `Cannot perform change on environment in status ( ${currentRuntimeDetails.status} )` : 'Update Environment'
+        tooltip: isUpdateDisabled ? `Cannot perform change on environment in status ( ${currentRuntimeDetails.status} )` : 'Update Environment'
       }, [
         Utils.cond(
           [viewMode === 'deleteEnvironment', () => 'Delete'],

--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -659,7 +659,6 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
       const { googleProject } = getWorkspaceObject()
       const currentRuntime = getCurrentRuntime(runtimes)
       const currentPersistentDisk = getCurrentPersistentDisk(runtimes, persistentDisks)
-      console.log('currentPersistentDisk', currentPersistentDisk)
 
       Ajax().Metrics.captureEvent(Events.cloudEnvironmentConfigOpen, {
         existingConfig: !!currentRuntime, ...extractWorkspaceDetails(getWorkspaceObject())
@@ -811,7 +810,7 @@ export const ComputeModalBase = ({ onDismiss, onSuccess, runtimes, persistentDis
         },
         disabled: isUpdateDisabled,
         tooltipSide: 'left',
-        tooltip: isUpdateDisabled ? `Cannot perform change on environment in ( ${currentRuntimeDetails.status} ) status` : 'Update Environment'
+        tooltip: isUpdateDisabled ? `Cannot perform change on environment in (${currentRuntimeDetails.status}) status` : 'Update Environment'
       }, [
         Utils.cond(
           [viewMode === 'deleteEnvironment', () => 'Delete'],

--- a/src/components/ContextBar.js
+++ b/src/components/ContextBar.js
@@ -2,9 +2,13 @@ import _ from 'lodash/fp'
 import { Fragment, useState } from 'react'
 import { div, h, img } from 'react-hyperscript-helpers'
 import { Clickable } from 'src/components/common'
+import { ComputeModal } from 'src/components/ComputeModal'
+import { CromwellModal } from 'src/components/CromwellModal'
+import { GalaxyModal } from 'src/components/GalaxyModal'
 import { icon } from 'src/components/icons'
-import { tools } from 'src/components/notebook-utils'
+import { getAppType, isToolAnApp, tools } from 'src/components/notebook-utils'
 import { appLauncherTabName } from 'src/components/runtime-common'
+import { AppErrorModal, RuntimeErrorModal } from 'src/components/RuntimeManager'
 import cloudIcon from 'src/icons/cloud-compute.svg'
 import cromwellImg from 'src/images/cromwell-logo.png' // To be replaced by something square
 import galaxyLogo from 'src/images/galaxy-logo.png'
@@ -12,9 +16,10 @@ import jupyterLogo from 'src/images/jupyter-logo.svg'
 import rstudioSquareLogo from 'src/images/rstudio-logo-square.png'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
+import { withErrorReporting } from 'src/libs/error'
 import Events from 'src/libs/events'
 import * as Nav from 'src/libs/nav'
-import { getCurrentApp, getCurrentRuntime } from 'src/libs/runtime-utils'
+import { getComputeStatusForDisplay, getCurrentApp, getCurrentRuntime } from 'src/libs/runtime-utils'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 import { CloudEnvironmentModal } from 'src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal'
@@ -26,8 +31,11 @@ const contextBarStyles = {
   },
   contextBarButton: {
     display: 'flex',
+    justifyContent: 'center',
+    width: 70,
     borderBottom: `1px solid ${colors.accent()}`,
-    padding: '1rem',
+    padding: '.75rem',
+    height: 70,
     color: colors.accent(),
     backgroundColor: colors.accent(0.2)
   },
@@ -39,6 +47,12 @@ export const ContextBar = ({
   workspace, persistentDisks, workspace: { workspace: { namespace, name: workspaceName } }
 }) => {
   const [isCloudEnvOpen, setCloudEnvOpen] = useState(false)
+  const [isComputeModalOpen, setComputeModalOpen] = useState(false)
+  const [isGalaxyModalOpen, setGalaxyModalOpen] = useState(false)
+  const [isCromwellModalOpen, setCromwellModalOpen] = useState(false)
+  const [selectedToolIcon, setSelectedToolIcon] = useState(null)
+  const [errorRuntimeId, setErrorRuntimeId] = useState(undefined)
+  const [errorAppId, setErrorAppId] = useState(undefined)
 
   const currentRuntime = getCurrentRuntime(runtimes)
   const currentRuntimeTool = currentRuntime?.labels?.tool
@@ -52,10 +66,10 @@ export const ContextBar = ({
   }
 
   const getImgForTool = toolLabel => Utils.switchCase(toolLabel,
-    [tools.Jupyter.label, () => img({ src: jupyterLogo, style: { height: 30, width: 30 } })],
-    [tools.galaxy.label, () => img({ src: galaxyLogo, style: { height: 12, width: 35 } })],
-    [tools.cromwell.label, () => img({ src: cromwellImg, style: { width: 30 } })],
-    [tools.RStudio.label, () => img({ src: rstudioSquareLogo, style: { height: 30, width: 30 } })]
+    [tools.Jupyter.label, () => img({ src: jupyterLogo, style: { height: 45, width: 45 } })],
+    [tools.Galaxy.label, () => img({ src: galaxyLogo, style: { height: 14, width: 45 } })],
+    [tools.Cromwell.label, () => img({ src: cromwellImg, style: { width: 45 } })],
+    [tools.RStudio.label, () => img({ src: rstudioSquareLogo, style: { height: 45, width: 45 } })]
   )
 
   const getColorForStatus = status => Utils.cond(
@@ -64,24 +78,50 @@ export const ContextBar = ({
     [_.includes('ING', _.upperCase(status)), () => colors.accent()],
     [Utils.DEFAULT, () => colors.warning()])
 
+  const currentApp = toolLabel => getCurrentApp(getAppType(toolLabel))(apps)
+
+
   const getIconForTool = (toolLabel, status) => {
-    return div({ style: { display: 'flex', flexDirection: 'column' } }, [
-      div({ style: { display: 'flex', justifyContent: 'center', alignItems: 'center', marginTop: '1rem' } }, [
+    return h(Clickable, {
+      style: { display: 'flex', flexDirection: 'column', justifyContent: 'center', ...contextBarStyles.contextBarButton, borderBottom: '0px' },
+      hover: contextBarStyles.hover,
+      onClick: () => { // onclick displays an error message if the tool is in error, otherwise, if the tool is editable, opens the config modal (I.e. ComputeModal or GalaxyModal)
+        if (_.toLower(status) === 'error') {
+          Utils.cond(
+            [isToolAnApp(toolLabel), () => setErrorAppId(currentApp(toolLabel)?.appName)],
+            [Utils.DEFAULT, () => setErrorRuntimeId(currentRuntime?.id)]
+          )
+        } else {
+          Utils.switchCase(toolLabel,
+            [tools.Galaxy.label, () => setGalaxyModalOpen(true)],
+            [tools.Cromwell.label, () => setCromwellModalOpen(true)],
+            [Utils.DEFAULT, () => {
+              setSelectedToolIcon(toolLabel)
+              setComputeModalOpen(true)
+            }])
+        }
+      },
+      tooltipSide: 'left',
+      tooltip: `${toolLabel} environment ( ${getComputeStatusForDisplay(status)} )`,
+      tooltipDelay: 100,
+      useTooltipAsLabel: true
+    }, [
+      div({ style: { display: 'flex', justifyContent: 'center', alignItems: 'center' } }, [
         getImgForTool(toolLabel)
       ]),
-      div({ style: { display: 'flex', justifyContent: 'flex-end', color: getColorForStatus(status) } }, [
+      div({ style: { justifyContent: 'flex-end', display: 'flex', color: getColorForStatus(status) } }, [
         icon('circle', { style: { border: '1px solid white', borderRadius: '50%' }, size: 12 })
       ])
     ])
   }
 
   const getEnvironmentStatusIcons = () => {
-    const galaxyApp = getCurrentApp(tools.galaxy.appType)(apps)
-    const cromwellApp = !tools.cromwell.isAppHidden && getCurrentApp(tools.cromwell.appType)(apps)
+    const galaxyApp = getCurrentApp(tools.Galaxy.appType)(apps)
+    const cromwellApp = !tools.Cromwell.isAppHidden && getCurrentApp(tools.Cromwell.appType)(apps)
     return h(Fragment, [
       ...(currentRuntime ? [getIconForTool(currentRuntimeTool, currentRuntime.status)] : []),
-      ...(galaxyApp ? [getIconForTool(tools.galaxy.label, galaxyApp.status)] : []),
-      ...(cromwellApp ? [getIconForTool(tools.cromwell.label, cromwellApp.status)] : [])
+      ...(galaxyApp ? [getIconForTool(tools.Galaxy.label, galaxyApp.status)] : []),
+      ...(cromwellApp ? [getIconForTool(tools.Cromwell.label, cromwellApp.status)] : [])
     ])
   }
 
@@ -100,23 +140,76 @@ export const ContextBar = ({
       },
       runtimes, apps, appDataDisks, refreshRuntimes, refreshApps, workspace, canCompute, persistentDisks, location, locationType
     }),
-    div({ style: Style.elements.contextBarContainer }, [
+    h(ComputeModal, {
+      isOpen: isComputeModalOpen,
+      isAnalysisMode: true,
+      tool: selectedToolIcon,
+      workspace,
+      runtimes,
+      persistentDisks,
+      location,
+      onDismiss: () => setComputeModalOpen(false),
+      onSuccess: _.flow(
+        withErrorReporting('Error loading cloud environment'),
+        Utils.withBusyState(v => this.setState({ busy: v }))
+      )(async () => {
+        setComputeModalOpen(false)
+        await refreshRuntimes(true)
+      })
+    }),
+    h(GalaxyModal, {
+      workspace,
+      apps,
+      appDataDisks,
+      isOpen: isGalaxyModalOpen,
+      onDismiss: () => setGalaxyModalOpen(false),
+      onSuccess: () => {
+        withErrorReporting('Error loading galaxy environment')(
+          setGalaxyModalOpen(false),
+          refreshApps()
+        )
+      }
+    }),
+    h(CromwellModal, {
+      workspace,
+      apps,
+      appDataDisks,
+      isOpen: isCromwellModalOpen,
+      onDismiss: () => setCromwellModalOpen(false),
+      onSuccess: () => {
+        withErrorReporting('Error loading galaxy environment')(
+          setCromwellModalOpen(false),
+          refreshApps()
+        )
+      }
+    }),
+    errorAppId && h(AppErrorModal, {
+      app: _.find({ appName: errorAppId }, apps),
+      onDismiss: () => setErrorAppId(undefined)
+    }),
+    errorRuntimeId && h(RuntimeErrorModal, {
+      runtime: _.find({ id: errorRuntimeId }, runtimes),
+      onDismiss: () => setErrorRuntimeId(undefined)
+    }),
+    div({ style: { ...Style.elements.contextBarContainer, width: 70 } }, [
       div({ style: contextBarStyles.contextBarContainer }, [
-        h(Clickable, {
-          style: { ...contextBarStyles.contextBarButton, flexDirection: 'column', justifyContent: 'center', padding: '.75rem' },
-          hover: contextBarStyles.hover,
-          tooltipSide: 'left',
-          onClick: () => setCloudEnvOpen(!isCloudEnvOpen),
-          tooltip: 'Environment Configuration',
-          tooltipDelay: 100,
-          useTooltipAsLabel: true
-        }, [
-          img({ src: cloudIcon, style: { display: 'flex', margin: 'auto', height: 26, width: 26 } }),
+        h(Fragment, [
+          h(Clickable, {
+            style: { flexDirection: 'column', justifyContent: 'center', padding: '.75rem', ...contextBarStyles.contextBarButton, borderBottom: '0px' },
+            hover: contextBarStyles.hover,
+            tooltipSide: 'left',
+            onClick: () => setCloudEnvOpen(!isCloudEnvOpen),
+            tooltip: 'Environment Configuration',
+            tooltipDelay: 100,
+            useTooltipAsLabel: true
+          }, [
+            img({ src: cloudIcon, style: { display: 'flex', margin: 'auto', height: 40, width: 40 } })
+          ]),
           getEnvironmentStatusIcons()
         ]),
         h(Clickable, {
           'aria-label': 'Terminal button',
-          style: { ...contextBarStyles.contextBarButton, color: !isTerminalEnabled ? colors.dark(0.7) : contextBarStyles.contextBarButton.color },
+          style: { borderTop: `1px solid ${colors.accent()}`, paddingLeft: '1rem', alignItems: 'center', ...contextBarStyles.contextBarButton, color: !isTerminalEnabled ? colors.dark(0.7) : contextBarStyles.contextBarButton.color },
           hover: contextBarStyles.hover,
           tooltipSide: 'left',
           disabled: !isTerminalEnabled,
@@ -132,7 +225,7 @@ export const ContextBar = ({
           tooltipDelay: 100,
           useTooltipAsLabel: false,
           ...Utils.newTabLinkProps
-        }, [icon('terminal', { size: 24 })])
+        }, [icon('terminal', { size: 40 })])
       ])
     ])
   ])

--- a/src/components/ContextBar.js
+++ b/src/components/ContextBar.js
@@ -56,10 +56,10 @@ export const ContextBar = ({
   }
 
   const getImgForTool = toolLabel => Utils.switchCase(toolLabel,
-    [tools.Jupyter.label, () => img({ src: jupyterLogo, style: { height: 45, width: 45 } })],
-    [tools.Galaxy.label, () => img({ src: galaxyLogo, style: { height: 14, width: 45 } })],
-    [tools.Cromwell.label, () => img({ src: cromwellImg, style: { width: 45 } })],
-    [tools.RStudio.label, () => img({ src: rstudioSquareLogo, style: { height: 45, width: 45 } })]
+    [tools.Jupyter.label, () => img({ src: jupyterLogo, style: { height: 45, width: 45 }, alt: '' })],
+    [tools.Galaxy.label, () => img({ src: galaxyLogo, style: { height: 14, width: 45 }, alt: '' })],
+    [tools.Cromwell.label, () => img({ src: cromwellImg, style: { width: 45 }, alt: '' })],
+    [tools.RStudio.label, () => img({ src: rstudioSquareLogo, style: { height: 45, width: 45 }, alt: '' })]
   )
 
   const getColorForStatus = status => Utils.cond(
@@ -130,7 +130,7 @@ export const ContextBar = ({
             tooltipDelay: 100,
             useTooltipAsLabel: true
           }, [
-            img({ src: cloudIcon, style: { display: 'flex', margin: 'auto', height: 40, width: 40 } })
+            img({ src: cloudIcon, style: { display: 'flex', margin: 'auto', height: 40, width: 40 }, alt: '' })
           ]),
           getEnvironmentStatusIcons()
         ]),

--- a/src/components/ContextBar.js
+++ b/src/components/ContextBar.js
@@ -38,9 +38,8 @@ const contextBarStyles = {
 }
 
 export const ContextBar = ({
-runtimes, apps, appDataDisks, refreshRuntimes, location, locationType, refreshApps,
-  workspace, persistentDisks, workspace: { workspace: { namespace, name: workspaceName } },
-  filterForTool = undefined
+  runtimes, apps, appDataDisks, refreshRuntimes, location, locationType, refreshApps,
+  workspace, persistentDisks, workspace: { workspace: { namespace, name: workspaceName } }
 }) => {
   const [isCloudEnvOpen, setCloudEnvOpen] = useState(false)
   const [selectedToolIcon, setSelectedToolIcon] = useState(undefined)

--- a/src/components/ContextBar.js
+++ b/src/components/ContextBar.js
@@ -85,7 +85,7 @@ export const ContextBar = ({
     return h(Clickable, {
       style: { display: 'flex', flexDirection: 'column', justifyContent: 'center', ...contextBarStyles.contextBarButton, borderBottom: '0px' },
       hover: contextBarStyles.hover,
-      onClick: () => { // onclick displays an error message if the tool is in error, otherwise, if the tool is editable, opens the config modal (I.e. ComputeModal or GalaxyModal)
+      onClick: () => { // onclick displays an error message if the tool is in error, otherwise opens the config modal (I.e. ComputeModal or GalaxyModal)
         if (_.toLower(status) === 'error') {
           Utils.cond(
             [isToolAnApp(toolLabel), () => setErrorAppId(currentApp(toolLabel)?.appName)],

--- a/src/components/CromwellModal.js
+++ b/src/components/CromwellModal.js
@@ -23,7 +23,7 @@ const titleId = 'cromwell-modal-title'
 export const CromwellModalBase = withDisplayName('CromwellModal')(
   ({
     onDismiss, onSuccess, apps, appDataDisks, workspace, workspace: { workspace: { namespace, bucketName, name: workspaceName, googleProject } },
-    shouldHideCloseButton
+    shouldHideCloseButton = false
   }) => {
     const app = getCurrentApp(tools.Cromwell.appType)(apps)
     const [loading, setLoading] = useState(false)

--- a/src/components/CromwellModal.js
+++ b/src/components/CromwellModal.js
@@ -23,11 +23,11 @@ const titleId = 'cromwell-modal-title'
 export const CromwellModalBase = withDisplayName('CromwellModal')(
   ({
     onDismiss, onSuccess, apps, appDataDisks, workspace, workspace: { workspace: { namespace, bucketName, name: workspaceName, googleProject } },
-    isAnalysisMode = false
+    shouldHideCloseButton
   }) => {
-    const app = getCurrentApp(tools.cromwell.appType)(apps)
+    const app = getCurrentApp(tools.Cromwell.appType)(apps)
     const [loading, setLoading] = useState(false)
-    const currentDataDisk = getCurrentPersistentDisk(tools.cromwell.appType, apps, appDataDisks, workspaceName)
+    const currentDataDisk = getCurrentPersistentDisk(tools.Cromwell.appType, apps, appDataDisks, workspaceName)
 
     const createCromwell = _.flow(
       Utils.withBusyState(setLoading),
@@ -35,9 +35,9 @@ export const CromwellModalBase = withDisplayName('CromwellModal')(
     )(async () => {
       await Ajax().Apps.app(googleProject, Utils.generateAppName()).create({
         defaultKubernetesRuntimeConfig, diskName: !!currentDataDisk ? currentDataDisk.name : Utils.generatePersistentDiskName(), diskSize: defaultDataDiskSize,
-        appType: tools.cromwell.appType, namespace, bucketName, workspaceName
+        appType: tools.Cromwell.appType, namespace, bucketName, workspaceName
       })
-      Ajax().Metrics.captureEvent(Events.applicationCreate, { app: tools.cromwell.appType, ...extractWorkspaceDetails(workspace) })
+      Ajax().Metrics.captureEvent(Events.applicationCreate, { app: tools.Cromwell.appType, ...extractWorkspaceDetails(workspace) })
       return onSuccess()
     })
 
@@ -69,7 +69,7 @@ export const CromwellModalBase = withDisplayName('CromwellModal')(
         h(TitleBar, {
           id: titleId,
           title: 'Cromwell Cloud Environment',
-          hideCloseButton: isAnalysisMode,
+          hideCloseButton: shouldHideCloseButton,
           style: { marginBottom: '0.5rem' },
           onDismiss,
           onPrevious: undefined

--- a/src/components/CromwellModal.js
+++ b/src/components/CromwellModal.js
@@ -23,7 +23,7 @@ const titleId = 'cromwell-modal-title'
 export const CromwellModalBase = withDisplayName('CromwellModal')(
   ({
     onDismiss, onSuccess, apps, appDataDisks, workspace, workspace: { workspace: { namespace, bucketName, name: workspaceName, googleProject } },
-    shouldHideCloseButton = false
+    shouldHideCloseButton = true
   }) => {
     const app = getCurrentApp(tools.Cromwell.appType)(apps)
     const [loading, setLoading] = useState(false)

--- a/src/components/GalaxyModal.js
+++ b/src/components/GalaxyModal.js
@@ -33,11 +33,10 @@ const titleId = 'galaxy-modal-title'
 
 export const GalaxyModalBase = withDisplayName('GalaxyModal')(
   ({
-    onDismiss, onSuccess, apps, appDataDisks, workspace, workspace: { workspace: { namespace, bucketName, name: workspaceName, googleProject } },
-    isAnalysisMode = false
+    onDismiss, onSuccess, apps, appDataDisks, workspace, workspace: { workspace: { namespace, bucketName, name: workspaceName, googleProject } }, shouldHideCloseButton
   }) => {
     // Assumption: If there is an app defined, there must be a data disk corresponding to it.
-    const app = getCurrentApp(tools.galaxy.appType)(apps)
+    const app = getCurrentApp(tools.Galaxy.appType)(apps)
     const attachedDataDisk = getCurrentAttachedDataDisk(app, appDataDisks)
 
     const [dataDiskSize, setDataDiskSize] = useState(attachedDataDisk?.size || defaultDataDiskSize)
@@ -46,7 +45,7 @@ export const GalaxyModalBase = withDisplayName('GalaxyModal')(
     const [loading, setLoading] = useState(false)
     const [shouldDeleteDisk, setShouldDeleteDisk] = useState(false)
 
-    const currentDataDisk = getCurrentPersistentDisk(tools.galaxy.appType, apps, appDataDisks, workspaceName)
+    const currentDataDisk = getCurrentPersistentDisk(tools.Galaxy.appType, apps, appDataDisks, workspaceName)
 
     const createGalaxy = _.flow(
       Utils.withBusyState(setLoading),
@@ -54,7 +53,7 @@ export const GalaxyModalBase = withDisplayName('GalaxyModal')(
     )(async () => {
       await Ajax().Apps.app(googleProject, Utils.generateAppName()).create({
         kubernetesRuntimeConfig, diskName: !!currentDataDisk ? currentDataDisk.name : Utils.generatePersistentDiskName(), diskSize: dataDiskSize,
-        appType: tools.galaxy.appType, namespace, bucketName, workspaceName
+        appType: tools.Galaxy.appType, namespace, bucketName, workspaceName
       })
       Ajax().Metrics.captureEvent(Events.applicationCreate, { app: 'Galaxy', ...extractWorkspaceDetails(workspace) })
       return onSuccess()
@@ -115,7 +114,7 @@ export const GalaxyModalBase = withDisplayName('GalaxyModal')(
             ['RUNNING', () => h(Fragment, [
               deleteButton,
               pauseButton,
-              h(ButtonPrimary, { disabled: false, onClick: () => setViewMode('launchWarn') }, ['Launch Galaxy'])
+              h(ButtonPrimary, { disabled: false, onClick: () => setViewMode('launchWarn') }, ['Open Galaxy'])
             ])],
             ['STOPPED', () => h(Fragment, [
               h(ButtonOutline, {
@@ -126,7 +125,7 @@ export const GalaxyModalBase = withDisplayName('GalaxyModal')(
             ])],
             ['ERROR', () => deleteButton],
             [Utils.DEFAULT, () => {
-              return h(Fragment, { tooltip: 'Cloud Compute must be resumed first.' }, [
+              return h(Fragment, [
                 h(ButtonOutline, {
                   disabled: true, style: { marginRight: 'auto' }, tooltip: 'Cloud Compute must be running.', onClick: () => setViewMode('deleteWarn')
                 }, ['Delete Environment']),
@@ -154,7 +153,7 @@ export const GalaxyModalBase = withDisplayName('GalaxyModal')(
           id: titleId,
           title: 'Galaxy Cloud Environment',
           style: { marginBottom: '0.5rem' },
-          hideCloseButton: isAnalysisMode,
+          hideCloseButton: shouldHideCloseButton,
           onDismiss,
           onPrevious: !!viewMode ? () => setViewMode(undefined) : undefined
         }),
@@ -206,8 +205,8 @@ export const GalaxyModalBase = withDisplayName('GalaxyModal')(
       return div({ style: computeStyles.drawerContent }, [
         h(TitleBar, {
           id: titleId,
-          title: h(WarningTitle, ['Launch Galaxy']),
-          hideCloseButton: isAnalysisMode,
+          title: h(WarningTitle, ['Open Galaxy']),
+          hideCloseButton: shouldHideCloseButton,
           style: { marginBottom: '0.5rem' },
           onDismiss,
           onPrevious: !!viewMode ? () => setViewMode(undefined) : undefined
@@ -334,7 +333,7 @@ export const GalaxyModalBase = withDisplayName('GalaxyModal')(
         h(TitleBar, {
           id: titleId,
           style: computeStyles.titleBar,
-          hideCloseButton: isAnalysisMode,
+          hideCloseButton: shouldHideCloseButton,
           title: h(WarningTitle, ['Delete environment']),
           onDismiss,
           onPrevious: () => {
@@ -388,7 +387,7 @@ export const GalaxyModalBase = withDisplayName('GalaxyModal')(
         h(TitleBar, {
           id: titleId,
           title: 'Galaxy Cloud Environment',
-          hideCloseButton: isAnalysisMode,
+          hideCloseButton: shouldHideCloseButton,
           style: { marginBottom: '0.5rem' },
           onDismiss,
           onPrevious: !!viewMode ? () => setViewMode(undefined) : undefined

--- a/src/components/GalaxyModal.js
+++ b/src/components/GalaxyModal.js
@@ -33,7 +33,7 @@ const titleId = 'galaxy-modal-title'
 
 export const GalaxyModalBase = withDisplayName('GalaxyModal')(
   ({
-    onDismiss, onSuccess, apps, appDataDisks, workspace, workspace: { workspace: { namespace, bucketName, name: workspaceName, googleProject } }, shouldHideCloseButton
+    onDismiss, onSuccess, apps, appDataDisks, workspace, workspace: { workspace: { namespace, bucketName, name: workspaceName, googleProject } }, shouldHideCloseButton = false
   }) => {
     // Assumption: If there is an app defined, there must be a data disk corresponding to it.
     const app = getCurrentApp(tools.Galaxy.appType)(apps)

--- a/src/components/GalaxyModal.js
+++ b/src/components/GalaxyModal.js
@@ -33,7 +33,7 @@ const titleId = 'galaxy-modal-title'
 
 export const GalaxyModalBase = withDisplayName('GalaxyModal')(
   ({
-    onDismiss, onSuccess, apps, appDataDisks, workspace, workspace: { workspace: { namespace, bucketName, name: workspaceName, googleProject } }, shouldHideCloseButton = false
+    onDismiss, onSuccess, apps, appDataDisks, workspace, workspace: { workspace: { namespace, bucketName, name: workspaceName, googleProject } }, shouldHideCloseButton = true
   }) => {
     // Assumption: If there is an app defined, there must be a data disk corresponding to it.
     const app = getCurrentApp(tools.Galaxy.appType)(apps)

--- a/src/components/RuntimeManager.js
+++ b/src/components/RuntimeManager.js
@@ -81,14 +81,14 @@ export const RuntimeErrorModal = ({ runtime, onDismiss }) => {
           .then(res => res.text()))
       setUserscriptError(true)
     } else {
-      setError(runtimeErrors[0].errorMessage)
+      setError(runtimeErrors[0]?.errorMessage)
     }
   })
 
   useOnMount(() => { loadRuntimeError() })
 
   return h(Modal, {
-    title: `Cloud Environment Creation Failed${userscriptError ? ' due to Userscript Error' : ''}`,
+    title: `Cloud Environment is in error state${userscriptError ? ' due to Userscript Error' : ''}`,
     showCancel: false,
     onDismiss
   }, [
@@ -132,7 +132,7 @@ export const AppErrorModal = ({ app, onDismiss }) => {
   useOnMount(() => { loadAppError() })
 
   return h(Modal, {
-    title: `Galaxy App Creation Failed`,
+    title: `Galaxy App is in error state`,
     showCancel: false,
     onDismiss
   }, [
@@ -193,8 +193,8 @@ export default class RuntimeManager extends PureComponent {
     const createdDate = new Date(runtime.createdDate)
     const dateNotified = getDynamic(sessionStorage, `notifiedOutdatedRuntime${runtime.id}`) || {}
     const rStudioLaunchLink = Nav.getLink(appLauncherTabName, { namespace, name, application: 'RStudio' })
-    const galaxyApp = getCurrentApp(tools.galaxy.appType)(apps)
-    const prevGalaxyApp = getCurrentApp(tools.galaxy.appType)(prevProps.apps)
+    const galaxyApp = getCurrentApp(tools.Galaxy.appType)(apps)
+    const prevGalaxyApp = getCurrentApp(tools.Galaxy.appType)(prevProps.apps)
 
     if (runtime.status === 'Error' && prevRuntime.status !== 'Error' && !_.includes(runtime.id, errorNotifiedRuntimes.get())) {
       notify('error', 'Error Creating Cloud Environment', {
@@ -209,7 +209,7 @@ export default class RuntimeManager extends PureComponent {
         message: h(ButtonPrimary, {
           href: rStudioLaunchLink,
           onClick: () => clearNotification(rStudioNotificationId)
-        }, 'Launch Cloud Environment')
+        }, 'Open RStudio')
       })
     } else if (isAfter(createdDate, welderCutOff) && !isToday(dateNotified)) { // TODO: remove this notification some time after the data syncing release
       setDynamic(sessionStorage, `notifiedOutdatedRuntime${runtime.id}`, Date.now())
@@ -346,7 +346,7 @@ export default class RuntimeManager extends PureComponent {
     const applicationName = isRStudioImage ? 'RStudio' : 'terminal'
     const applicationLaunchLink = Nav.getLink(appLauncherTabName, { namespace, name, application: applicationName })
 
-    const galaxyApp = getCurrentApp(tools.galaxy.appType)(apps)
+    const galaxyApp = getCurrentApp(tools.Galaxy.appType)(apps)
 
     return isAnalysisTabVisible() ? null : h(Fragment, [
       galaxyApp && div({ style: { ...styles.container, borderRadius: 5, marginRight: '1.5rem' } }, [
@@ -376,7 +376,7 @@ export default class RuntimeManager extends PureComponent {
           tooltip: 'Multiple cloud environments found in this billing project. Click to select which to delete.'
         }, [icon('warning-standard', { size: 24, style: { color: colors.danger() } })]),
         h(Link, {
-          'aria-label': 'Launch app',
+          'aria-label': 'Open application',
           href: applicationLaunchLink,
           onClick: window.location.hash === applicationLaunchLink && currentStatus === 'Stopped' ? () => this.startRuntime() : undefined,
           tooltip: canCompute ? `Open ${applicationName}` : noCompute,

--- a/src/components/RuntimeManager.js
+++ b/src/components/RuntimeManager.js
@@ -81,7 +81,7 @@ export const RuntimeErrorModal = ({ runtime, onDismiss }) => {
           .then(res => res.text()))
       setUserscriptError(true)
     } else {
-      setError(runtimeErrors[0]?.errorMessage)
+      setError(runtimeErrors && runtimeErrors.length > 0 ? runtimeErrors[0].errorMessage : 'An unknown error has occurred with the runtime')
     }
   })
 
@@ -429,6 +429,7 @@ export default class RuntimeManager extends PureComponent {
           apps,
           appDataDisks,
           isOpen: galaxyDrawerOpen,
+          shouldHideCloseButton: false,
           onDismiss: () => this.setState({ galaxyDrawerOpen: false }),
           onSuccess: () => {
             withErrorReporting('Error loading galaxy environment')(

--- a/src/components/_tests/notebook-utils.test.js
+++ b/src/components/_tests/notebook-utils.test.js
@@ -3,10 +3,10 @@ import { allAppTypes, isToolAnApp, tools } from 'src/components/notebook-utils'
 
 describe('getAllAppTypes and isToolAnApp', () => {
   it('getAllAppTypes includes tools with a defined appType', () => {
-    expect(allAppTypes.sort).toBe([tools.galaxy.appType, tools.cromwell.appType].sort)
+    expect(allAppTypes.sort).toBe([tools.Galaxy.appType, tools.Cromwell.appType].sort)
   })
   it('isToolAnApp returns if a tool label corresponds to an app', () => {
-    expect(isToolAnApp(tools.cromwell.label)).toBeTruthy()
+    expect(isToolAnApp(tools.Cromwell.label)).toBeTruthy()
     expect(isToolAnApp(tools.Jupyter.label)).toBeFalsy()
   })
 })

--- a/src/components/notebook-utils.js
+++ b/src/components/notebook-utils.js
@@ -76,12 +76,12 @@ export const tools = {
   Jupyter: { label: 'Jupyter', ext: 'ipynb', imageIds: ['terra-jupyter-bioconductor', 'terra-jupyter-bioconductor_legacy', 'terra-jupyter-hail', 'terra-jupyter-python', 'terra-jupyter-gatk', 'Pegasus', 'terra-jupyter-gatk_legacy'], defaultImageId: 'terra-jupyter-gatk' },
   jupyterTerminal: { label: 'terminal' },
   spark: { label: 'spark' },
-  galaxy: { label: 'Galaxy', appType: 'GALAXY' },
-  cromwell: { label: 'Cromwell', appType: 'CROMWELL', isAppHidden: !isCromwellAppVisible(), isPauseUnsupported: true }
+  Galaxy: { label: 'Galaxy', appType: 'GALAXY' },
+  Cromwell: { label: 'Cromwell', appType: 'CROMWELL', isAppHidden: !isCromwellAppVisible(), isPauseUnsupported: true }
 }
 
 // Returns the tools in the order that they should be displayed for Cloud Environment tools
-export const getToolsToDisplay = _.remove(tool => tool.isAppHidden)([tools.Jupyter, tools.RStudio, tools.galaxy, tools.cromwell])
+export const getToolsToDisplay = _.remove(tool => tool.isAppHidden)([tools.Jupyter, tools.RStudio, tools.Galaxy, tools.Cromwell])
 
 const toolToExtensionMap = { [tools.RStudio.label]: tools.RStudio.ext, [tools.Jupyter.label]: tools.Jupyter.ext }
 

--- a/src/components/runtime-common.js
+++ b/src/components/runtime-common.js
@@ -174,7 +174,7 @@ export const GalaxyLaunchButton = ({ app, onClick, ...props }) => {
     },
     ...Utils.newTabLinkPropsWithReferrer, // Galaxy needs the referrer to be present so we can validate it, otherwise we fail with 401
     ...props
-  }, ['Launch Galaxy'])
+  }, ['Open Galaxy'])
 }
 
 export const appLauncherTabName = 'workspace-application-launch'

--- a/src/libs/_tests/runtime-utils.test.js
+++ b/src/libs/_tests/runtime-utils.test.js
@@ -259,26 +259,26 @@ const mockAppDisksSameWorkspace = [galaxyDisk1Workspace1, galaxyDisk2Workspace1,
 
 describe('getCurrentApp', () => {
   it('returns undefined if no instances of the app exist', () => {
-    expect(getCurrentApp(tools.galaxy.appType)([])).toBeUndefined()
-    expect(getCurrentApp(tools.cromwell.appType)([galaxyRunning])).toBeUndefined()
+    expect(getCurrentApp(tools.Galaxy.appType)([])).toBeUndefined()
+    expect(getCurrentApp(tools.Cromwell.appType)([galaxyRunning])).toBeUndefined()
   })
   it('returns the most recent app for the given type (that is not deleting)', () => {
-    expect(getCurrentApp(tools.galaxy.appType)(mockApps)).toBe(galaxyRunning)
-    expect(getCurrentApp(tools.cromwell.appType)(mockApps)).toBe(cromwellProvisioning)
+    expect(getCurrentApp(tools.Galaxy.appType)(mockApps)).toBe(galaxyRunning)
+    expect(getCurrentApp(tools.Cromwell.appType)(mockApps)).toBe(cromwellProvisioning)
   })
 })
 
 describe('getCurrentAppIncludingDeleting', () => {
   it('does not filter out deleting', () => {
-    expect(getCurrentAppIncludingDeleting(tools.galaxy.appType)(mockApps)).toBe(galaxyDeleting)
-    expect(getCurrentAppIncludingDeleting(tools.cromwell.appType)(mockApps)).toBe(cromwellProvisioning)
+    expect(getCurrentAppIncludingDeleting(tools.Galaxy.appType)(mockApps)).toBe(galaxyDeleting)
+    expect(getCurrentAppIncludingDeleting(tools.Cromwell.appType)(mockApps)).toBe(cromwellProvisioning)
   })
 })
 
 describe('getDiskAppType', () => {
   it('returns the appType for disks attached to apps', () => {
-    expect(getDiskAppType(galaxyDeletingDisk)).toBe(tools.galaxy.appType)
-    expect(getDiskAppType(cromwellProvisioningDisk)).toBe(tools.cromwell.appType)
+    expect(getDiskAppType(galaxyDeletingDisk)).toBe(tools.Galaxy.appType)
+    expect(getDiskAppType(cromwellProvisioningDisk)).toBe(tools.Cromwell.appType)
   })
   it('returns undefined for runtime disks', () => {
     expect(getDiskAppType(jupyterDisk)).toBeUndefined()
@@ -287,36 +287,36 @@ describe('getDiskAppType', () => {
 
 describe('getCurrentPersistentDisk', () => {
   it('returns undefined if no disk exists for the given app type', () => {
-    expect(getCurrentPersistentDisk(tools.galaxy.appType, [cromwellProvisioning], [cromwellProvisioningDisk])).toBeUndefined()
+    expect(getCurrentPersistentDisk(tools.Galaxy.appType, [cromwellProvisioning], [cromwellProvisioningDisk])).toBeUndefined()
   })
   it('returns the newest attached disk, even if app is deleting', () => {
-    expect(getCurrentPersistentDisk(tools.galaxy.appType, mockApps, mockAppDisks, 'test-workspace')).toBe(galaxyDeletingDisk)
-    expect(getCurrentPersistentDisk(tools.cromwell.appType, mockApps, mockAppDisks, 'test-workspace')).toBe(cromwellProvisioningDisk)
+    expect(getCurrentPersistentDisk(tools.Galaxy.appType, mockApps, mockAppDisks, 'test-workspace')).toBe(galaxyDeletingDisk)
+    expect(getCurrentPersistentDisk(tools.Cromwell.appType, mockApps, mockAppDisks, 'test-workspace')).toBe(cromwellProvisioningDisk)
   })
   it('returns the newest unattached disk that is not deleting if no app instance exists', () => {
-    expect(getCurrentPersistentDisk(tools.galaxy.appType, [], mockAppDisks, 'test-workspace')).toBe(galaxyDisk)
-    expect(getCurrentPersistentDisk(tools.cromwell.appType, [galaxyRunning], mockAppDisks, 'test-workspace')).toBe(cromwellUnattachedDisk)
+    expect(getCurrentPersistentDisk(tools.Galaxy.appType, [], mockAppDisks, 'test-workspace')).toBe(galaxyDisk)
+    expect(getCurrentPersistentDisk(tools.Cromwell.appType, [galaxyRunning], mockAppDisks, 'test-workspace')).toBe(cromwellUnattachedDisk)
   })
   it('returns a galaxy disk only if it is in the same workspace as the previous app it was attached to', () => {
-    expect(getCurrentPersistentDisk(tools.galaxy.appType, [], mockAppDisks, 'test-workspace')).toBe(galaxyDisk)
-    expect(getCurrentPersistentDisk(tools.galaxy.appType, [], mockAppDisks, 'incorrect-workspace')).toBeUndefined()
+    expect(getCurrentPersistentDisk(tools.Galaxy.appType, [], mockAppDisks, 'test-workspace')).toBe(galaxyDisk)
+    expect(getCurrentPersistentDisk(tools.Galaxy.appType, [], mockAppDisks, 'incorrect-workspace')).toBeUndefined()
   })
 })
 
 describe('workspaceHasMultipleApps', () => {
   it('returns true when there are multiple galaxy apps in the same project and workspace', () => {
-    expect(workspaceHasMultipleApps(mockAppsSameWorkspace, tools.galaxy.appType)).toBe(true)
+    expect(workspaceHasMultipleApps(mockAppsSameWorkspace, tools.Galaxy.appType)).toBe(true)
   })
   it('returns false when there is not multiple cromwell apps', () => {
-    expect(workspaceHasMultipleApps(mockAppsSameWorkspace, tools.cromwell.appType)).toBe(false)
+    expect(workspaceHasMultipleApps(mockAppsSameWorkspace, tools.Cromwell.appType)).toBe(false)
   })
 })
 
 describe('workspaceHasMultipleDisks', () => {
   it('returns true when there are multiple galaxy disks in the same project and workspace', () => {
-    expect(workspaceHasMultipleDisks(mockAppDisksSameWorkspace, tools.galaxy.appType)).toBe(true)
+    expect(workspaceHasMultipleDisks(mockAppDisksSameWorkspace, tools.Galaxy.appType)).toBe(true)
   })
   it('returns false when there is not multiple cromwell disks', () => {
-    expect(workspaceHasMultipleDisks(mockAppDisksSameWorkspace, tools.cromwell.appType)).toBe(false)
+    expect(workspaceHasMultipleDisks(mockAppDisksSameWorkspace, tools.Cromwell.appType)).toBe(false)
   })
 })

--- a/src/libs/runtime-utils.js
+++ b/src/libs/runtime-utils.js
@@ -167,9 +167,9 @@ const getPersistentDiskPriceForRegionMonthly = computeRegion => {
 const numberOfHoursPerMonth = 730
 const getPersistentDiskPriceForRegionHourly = computeRegion => getPersistentDiskPriceForRegionMonthly(computeRegion) / numberOfHoursPerMonth
 
-export const getPersistentDiskCostMonthly = ({ size, status }, computeRegion) => {
+export const getPersistentDiskCostMonthly = (currentPersistentDiskDetails, computeRegion) => {
   const price = getPersistentDiskPriceForRegionMonthly(computeRegion)
-  return _.includes(status, ['Deleting', 'Failed']) ? 0.0 : size * price
+  return _.includes(currentPersistentDiskDetails?.status, ['Deleting', 'Failed']) ? 0.0 : currentPersistentDiskDetails?.size * price
 }
 export const getPersistentDiskCostHourly = ({ size, status }, computeRegion) => {
   const price = getPersistentDiskPriceForRegionHourly(computeRegion)
@@ -381,8 +381,8 @@ export const RadioBlock = ({ labelText, children, name, checked, onChange, style
 }
 
 export const getIsAppBusy = app => app?.status !== 'RUNNING' && _.includes('ING', app?.status)
-export const getIsRuntimeBusy = (runtime, isErrorBusy = false) => {
-  const { Creating: creating, Updating: updating, LeoReconfiguring: reconfiguring, Stopping: stopping, Starting: starting, Error: error } = _.countBy(getConvertedRuntimeStatus, [runtime])
-  return creating || updating || reconfiguring || stopping || starting || (isErrorBusy && error)
+export const getIsRuntimeBusy = (runtime) => {
+  const { Creating: creating, Updating: updating, LeoReconfiguring: reconfiguring, Stopping: stopping, Starting: starting} = _.countBy(getConvertedRuntimeStatus, [runtime])
+  return creating || updating || reconfiguring || stopping || starting
 }
 

--- a/src/libs/runtime-utils.js
+++ b/src/libs/runtime-utils.js
@@ -381,8 +381,8 @@ export const RadioBlock = ({ labelText, children, name, checked, onChange, style
 }
 
 export const getIsAppBusy = app => app?.status !== 'RUNNING' && _.includes('ING', app?.status)
-export const getIsRuntimeBusy = (runtime) => {
-  const { Creating: creating, Updating: updating, LeoReconfiguring: reconfiguring, Stopping: stopping, Starting: starting} = _.countBy(getConvertedRuntimeStatus, [runtime])
+export const getIsRuntimeBusy = runtime => {
+  const { Creating: creating, Updating: updating, LeoReconfiguring: reconfiguring, Stopping: stopping, Starting: starting } = _.countBy(getConvertedRuntimeStatus, [runtime])
   return creating || updating || reconfiguring || stopping || starting
 }
 

--- a/src/libs/runtime-utils.js
+++ b/src/libs/runtime-utils.js
@@ -310,7 +310,7 @@ export const getCurrentPersistentDisk = (appType, apps, appDataDisks, workspaceN
 }
 
 export const isCurrentGalaxyDiskDetaching = apps => {
-  const currentGalaxyApp = getCurrentAppIncludingDeleting(tools.galaxy.appType)(apps)
+  const currentGalaxyApp = getCurrentAppIncludingDeleting(tools.Galaxy.appType)(apps)
   return currentGalaxyApp && _.includes(currentGalaxyApp.status, ['DELETING', 'PREDELETING'])
 }
 
@@ -382,7 +382,7 @@ export const RadioBlock = ({ labelText, children, name, checked, onChange, style
 
 export const getIsAppBusy = app => app?.status !== 'RUNNING' && _.includes('ING', app?.status)
 export const getIsRuntimeBusy = runtime => {
-  const { Creating: creating, Updating: updating, LeoReconfiguring: reconfiguring } = _.countBy(getConvertedRuntimeStatus, [runtime])
-  return creating || updating || reconfiguring
+  const { Creating: creating, Updating: updating, LeoReconfiguring: reconfiguring, Stopping: stopping, Starting: starting } = _.countBy(getConvertedRuntimeStatus, [runtime])
+  return creating || updating || reconfiguring || stopping || starting
 }
 

--- a/src/libs/runtime-utils.js
+++ b/src/libs/runtime-utils.js
@@ -381,8 +381,8 @@ export const RadioBlock = ({ labelText, children, name, checked, onChange, style
 }
 
 export const getIsAppBusy = app => app?.status !== 'RUNNING' && _.includes('ING', app?.status)
-export const getIsRuntimeBusy = runtime => {
-  const { Creating: creating, Updating: updating, LeoReconfiguring: reconfiguring, Stopping: stopping, Starting: starting } = _.countBy(getConvertedRuntimeStatus, [runtime])
-  return creating || updating || reconfiguring || stopping || starting
+export const getIsRuntimeBusy = (runtime, isErrorBusy = false) => {
+  const { Creating: creating, Updating: updating, LeoReconfiguring: reconfiguring, Stopping: stopping, Starting: starting, Error: error } = _.countBy(getConvertedRuntimeStatus, [runtime])
+  return creating || updating || reconfiguring || stopping || starting || (isErrorBusy && error)
 }
 

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -105,7 +105,7 @@ const DeleteAppModal = ({ app: { googleProject, appName, diskName, appType }, on
         p([
           'Deleting this cloud environment will also ', span({ style: { fontWeight: 600 } }, ['delete any files on the associated hard disk.'])
         ]),
-      appType === tools.galaxy.appType && h(SaveFilesHelpGalaxy)
+      appType === tools.Galaxy.appType && h(SaveFilesHelpGalaxy)
     ]),
     deleting && spinnerOverlay
   ])
@@ -318,7 +318,7 @@ const Environments = () => {
   const renderDeleteDiskModal = disk => {
     return h(DeleteDiskModal, {
       disk,
-      isGalaxyDisk: getDiskAppType(disk) === tools.galaxy.appType,
+      isGalaxyDisk: getDiskAppType(disk) === tools.Galaxy.appType,
       onDismiss: () => setDeleteDiskId(undefined),
       onSuccess: () => {
         setDeleteDiskId(undefined)

--- a/src/pages/workspaces/workspace/Analyses.js
+++ b/src/pages/workspaces/workspace/Analyses.js
@@ -104,7 +104,7 @@ const AnalysisCard = ({
           tooltip: Utils.cond([!canWrite, () => noWrite],
             [currentRuntimeTool === tools.RStudio.label, () => 'You must have a runtime with Jupyter to edit.']),
           tooltipSide: 'left'
-        }, locked ? [makeMenuIcon('lock'), 'Edit (In Use)'] : [makeMenuIcon('edit'), 'Edit']),
+        }, locked ? [makeMenuIcon('lock'), 'Open (In Use)'] : [makeMenuIcon('edit'), 'Edit']),
         h(MenuButton, {
           'aria-label': `Playground`,
           href: analysisPlaygroundLink,
@@ -119,7 +119,7 @@ const AnalysisCard = ({
           tooltip: Utils.cond([!canWrite, () => noWrite],
             [currentRuntimeTool === tools.RStudio.label, () => 'You must have a runtime with RStudio to launch.']),
           tooltipSide: 'left'
-        }, [makeMenuIcon('rocket'), 'Launch'])
+        }, [makeMenuIcon('rocket'), 'Open'])
       ]),
       h(MenuButton, {
         'aria-label': `Copy`,

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -502,6 +502,7 @@ const Notebooks = _.flow(
         }),
         h(GalaxyModal, {
           isOpen: openGalaxyConfigDrawer,
+          shouldHideCloseButton: false,
           workspace,
           apps,
           appDataDisks,

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -104,7 +104,7 @@ const NotebookCard = ({
         disabled: locked || !canWrite,
         tooltip: !canWrite && noWrite,
         tooltipSide: 'left'
-      }, locked ? [makeMenuIcon('lock'), 'Edit (In Use)'] : [makeMenuIcon('edit'), 'Edit']),
+      }, locked ? [makeMenuIcon('lock'), 'Open (In Use)'] : [makeMenuIcon('rocket'), 'Open']),
       h(MenuButton, {
         href: notebookPlaygroundLink,
         tooltip: canWrite && 'Open in playground mode',
@@ -300,7 +300,7 @@ const Notebooks = _.flow(
   // Render helpers
   const renderNotebooks = openUploader => {
     const { field, direction } = sortOrder
-    const galaxyApp = getCurrentApp(tools.galaxy.appType)(apps)
+    const galaxyApp = getCurrentApp(tools.Galaxy.appType)(apps)
     const canWrite = Utils.canWrite(accessLevel)
     const renderedNotebooks = _.flow(
       _.filter(({ name }) => Utils.textMatch(filter, printName(name))),

--- a/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
@@ -99,6 +99,7 @@ const AnalysisLauncher = _.flow(
           isOpen: createOpen,
           tool: toolLabel,
           isAnalysisMode: true,
+          shouldHideCloseButton: true,
           workspace,
           runtimes,
           persistentDisks,
@@ -268,13 +269,13 @@ const PreviewHeader = ({
         ...(toolLabel === tools.Jupyter.label ? [
           Utils.cond(
             [runtime && !welderEnabled, () => h(HeaderButton, { onClick: () => setEditModeDisabledOpen(true) }, [
-              makeMenuIcon('warning-standard'), 'Edit (Disabled)'
+              makeMenuIcon('warning-standard'), 'Open (Disabled)'
             ])],
             [locked, () => h(HeaderButton, { onClick: () => setFileInUseOpen(true) }, [
-              makeMenuIcon('lock'), 'Edit (In use)'
+              makeMenuIcon('lock'), 'Open (In use)'
             ])],
             () => h(HeaderButton, { onClick: () => currentRuntimeTool !== tools.Jupyter.label ? setCreateOpen(true) : chooseMode('edit') }, [
-              makeMenuIcon('edit'), 'Edit'
+              makeMenuIcon('rocket'), 'Open'
             ])
           ),
           h(HeaderButton, {
@@ -294,7 +295,7 @@ const PreviewHeader = ({
               }
             }
           }, [
-            makeMenuIcon('rocket'), 'Launch'
+            makeMenuIcon('rocket'), 'Open'
           ])
         ]),
         h(MenuTrigger, {

--- a/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
@@ -99,7 +99,6 @@ const AnalysisLauncher = _.flow(
           isOpen: createOpen,
           tool: toolLabel,
           isAnalysisMode: true,
-          shouldHideCloseButton: true,
           workspace,
           runtimes,
           persistentDisks,

--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -237,13 +237,13 @@ const PreviewHeader = ({ queryParams, runtime, readOnlyAccess, onCreateRuntime, 
         Utils.cond(
           [runtime && !welderEnabled, () => h(HeaderButton, {
             onClick: () => setEditModeDisabledOpen(true)
-          }, [makeMenuIcon('warning-standard'), 'Edit (Disabled)'])],
+          }, [makeMenuIcon('warning-standard'), 'Open (Disabled)'])],
           [locked, () => h(HeaderButton, {
             onClick: () => setFileInUseOpen(true)
-          }, [makeMenuIcon('lock'), 'Edit (In use)'])],
+          }, [makeMenuIcon('lock'), 'Open (In use)'])],
           () => h(HeaderButton, {
             onClick: () => chooseMode('edit')
-          }, [makeMenuIcon('edit'), 'Edit'])
+          }, [makeMenuIcon('rocket'), 'Open'])
         ),
         h(HeaderButton, {
           onClick: () => getLocalPref('hidePlaygroundMessage') ? chooseMode('playground') : setPlaygroundModalOpen(true)

--- a/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
+++ b/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
@@ -34,7 +34,8 @@ const titleId = 'cloud-env-modal'
 
 export const CloudEnvironmentModal = ({
   isOpen, onSuccess, onDismiss, canCompute, runtimes, apps, appDataDisks, refreshRuntimes, refreshApps,
-  workspace, persistentDisks, location, locationType, workspace: { workspace: { namespace, name: workspaceName } }
+  workspace, persistentDisks, location, locationType, workspace: { workspace: { namespace, name: workspaceName } },
+  filterForTool = undefined
 }) => {
   const [viewMode, setViewMode] = useState(undefined)
   const [busy, setBusy] = useState(false)
@@ -82,7 +83,7 @@ export const CloudEnvironmentModal = ({
   })
 
   const renderDefaultPage = () => div({ style: { display: 'flex', flexDirection: 'column', flex: 1 } },
-    _.map(tool => renderToolButtons(tool.label))(getToolsToDisplay)
+    _.map(tool => renderToolButtons(tool.label))(filterForTool ? [tools[filterForTool]] : getToolsToDisplay)
   )
 
   const toolPanelStyles = {
@@ -272,7 +273,6 @@ export const CloudEnvironmentModal = ({
     [isToolAnApp(toolLabel), () => !canCompute || busy || (toolLabel === tools.Galaxy.label && isCurrentGalaxyDiskDetaching(apps)) || getIsAppBusy(currentApp(toolLabel))],
     [Utils.DEFAULT, () => {
       const runtime = getRuntimeForTool(toolLabel)
-      console.log(toolLabel, runtime)
       // This asks 'does this tool have a runtime'
       //  if yes, then we allow cloud env modal to open (and ComputeModal determines if it should be read-only mode)
       //  if no, then we want to disallow the cloud env modal opening if the other tool's runtime is busy
@@ -350,6 +350,7 @@ export const CloudEnvironmentModal = ({
   }
 
   const renderToolButtons = toolLabel => {
+    console.log('label in renderTolButtons', toolLabel)
     const app = currentApp(toolLabel)
     const doesCloudEnvForToolExist = currentRuntimeTool === toolLabel || app
     const isCloudEnvForToolDisabled = isCloudEnvModalDisabled(toolLabel)

--- a/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
+++ b/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
@@ -272,9 +272,13 @@ export const CloudEnvironmentModal = ({
     [isToolAnApp(toolLabel), () => !canCompute || busy || (toolLabel === tools.Galaxy.label && isCurrentGalaxyDiskDetaching(apps)) || getIsAppBusy(currentApp(toolLabel))],
     [Utils.DEFAULT, () => {
       const runtime = getRuntimeForTool(toolLabel)
-      return runtime ?
-        !canCompute || busy || getIsRuntimeBusy(runtime) :
-        !canCompute || busy || getIsRuntimeBusy(currentRuntime) //TODO: multiple runtimes: change this to not have the last check in the or
+      console.log(toolLabel, runtime)
+      // This asks 'does this tool have a runtime'
+      //  if yes, then we allow cloud env modal to open (and ComputeModal determines if it should be read-only mode)
+      //  if no, then we want to disallow the cloud env modal opening if the other tool's runtime is busy
+      //  this check is not needed if we allow multiple runtimes, and cloud env modal will never be disabled in this case
+      return runtime ? false :
+        !canCompute || busy || getIsRuntimeBusy(currentRuntime)
     }]
   )
 

--- a/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
+++ b/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
@@ -50,7 +50,6 @@ export const CloudEnvironmentModal = ({
   const renderComputeModal = tool => h(ComputeModalBase, {
     isOpen: viewMode === NEW_JUPYTER_MODE || viewMode === NEW_RSTUDIO_MODE,
     isAnalysisMode: true,
-    shouldHideCloseButton: true,
     workspace,
     tool,
     runtimes,
@@ -68,7 +67,6 @@ export const CloudEnvironmentModal = ({
 
   const renderAppModal = (appModalBase, appMode) => h(appModalBase, {
     isOpen: viewMode === appMode,
-    shouldHideCloseButton: true,
     workspace,
     apps,
     appDataDisks,
@@ -300,10 +298,10 @@ export const CloudEnvironmentModal = ({
       },
       hover: isDisabled ? {} : { backgroundColor: colors.accent(0.2) },
       tooltip: Utils.cond(
-        [doesCloudEnvForToolExist && !isDisabled, () => 'Launch'],
+        [doesCloudEnvForToolExist && !isDisabled, () => 'Open'],
         [doesCloudEnvForToolExist && isDisabled && toolLabel !== tools.Jupyter.label, () => `Please wait until ${toolLabel} is running`],
         [doesCloudEnvForToolExist && isDisabled && toolLabel === tools.Jupyter.label,
-          () => 'Select or create a notebook in the analyses tab to launch Jupyter'],
+          () => 'Select or create a notebook in the analyses tab to open Jupyter'],
         [Utils.DEFAULT, () => 'No Environment found']
       )
     }
@@ -360,7 +358,7 @@ export const CloudEnvironmentModal = ({
           img({
             src: getToolIcon(toolLabel),
             style: { height: 20 },
-            alt: `${toolLabel} image`
+            alt: `${toolLabel}`
           }),
           getCostForTool(toolLabel)
         ]),
@@ -388,7 +386,7 @@ export const CloudEnvironmentModal = ({
           // Launch
           h(Clickable, { ...getToolLaunchClickableProps(toolLabel) }, [
             icon('rocket', { size: 20 }),
-            span('Launch'),
+            span('Open'),
             span(toolLabel)
           ])
         ])
@@ -420,7 +418,7 @@ export const CloudEnvironmentModal = ({
   const modalBody = h(Fragment, [
     h(TitleBar, {
       id: titleId,
-      title: 'Cloud Environment Details',
+      title: filterForTool ? `${filterForTool} Environment Details` : 'Cloud Environment Details',
       titleStyles: _.merge(viewMode === undefined ? {} : { display: 'none' }, { margin: '1.5rem 0 .5rem 1rem' }),
       width,
       onDismiss: () => {

--- a/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
+++ b/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
@@ -359,7 +359,8 @@ export const CloudEnvironmentModal = ({
         div({ style: toolLabelStyles }, [
           img({
             src: getToolIcon(toolLabel),
-            style: { height: 20 }
+            style: { height: 20 },
+            alt: `${toolLabel} image`
           }),
           getCostForTool(toolLabel)
         ]),

--- a/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
+++ b/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
@@ -49,6 +49,7 @@ export const CloudEnvironmentModal = ({
   const renderComputeModal = tool => h(ComputeModalBase, {
     isOpen: viewMode === NEW_JUPYTER_MODE || viewMode === NEW_RSTUDIO_MODE,
     isAnalysisMode: true,
+    shouldHideCloseButton: true,
     workspace,
     tool,
     runtimes,
@@ -66,7 +67,7 @@ export const CloudEnvironmentModal = ({
 
   const renderAppModal = (appModalBase, appMode) => h(appModalBase, {
     isOpen: viewMode === appMode,
-    isAnalysisMode: true,
+    shouldHideCloseButton: true,
     workspace,
     apps,
     appDataDisks,
@@ -251,14 +252,14 @@ export const CloudEnvironmentModal = ({
 
   const getToolIcon = toolLabel => Utils.switchCase(toolLabel,
     [tools.Jupyter.label, () => jupyterLogo],
-    [tools.galaxy.label, () => galaxyLogo],
+    [tools.Galaxy.label, () => galaxyLogo],
     [tools.RStudio.label, () => rstudioBioLogo],
-    [tools.cromwell.label, () => cromwellImg])
+    [tools.Cromwell.label, () => cromwellImg])
 
   // TODO: multiple runtime: this is a good example of how the code should look when multiple runtimes are allowed, over a tool-centric approach
   const getCostForTool = toolLabel => Utils.cond(
-    [toolLabel === tools.galaxy.label, () => getGalaxyCostTextChildren(currentApp(toolLabel), appDataDisks)],
-    [toolLabel === tools.cromwell.label, () => ''], // We will determine what to put here later
+    [toolLabel === tools.Galaxy.label, () => getGalaxyCostTextChildren(currentApp(toolLabel), appDataDisks)],
+    [toolLabel === tools.Cromwell.label, () => ''], // We will determine what to put here later
     [getRuntimeForTool(toolLabel), () => {
       const runtime = getRuntimeForTool(toolLabel)
       const totalCost = runtimeCost(runtime) + _.sum(_.map(disk => getPersistentDiskCostHourly(disk, computeRegion), persistentDisks))
@@ -268,7 +269,7 @@ export const CloudEnvironmentModal = ({
   )
 
   const isCloudEnvModalDisabled = toolLabel => Utils.cond(
-    [isToolAnApp(toolLabel), () => !canCompute || busy || (toolLabel === tools.galaxy.label && isCurrentGalaxyDiskDetaching(apps)) || getIsAppBusy(currentApp(toolLabel))],
+    [isToolAnApp(toolLabel), () => !canCompute || busy || (toolLabel === tools.Galaxy.label && isCurrentGalaxyDiskDetaching(apps)) || getIsAppBusy(currentApp(toolLabel))],
     [Utils.DEFAULT, () => {
       const runtime = getRuntimeForTool(toolLabel)
       return runtime ?
@@ -303,7 +304,7 @@ export const CloudEnvironmentModal = ({
       )
     }
     return Utils.switchCase(toolLabel,
-      [tools.galaxy.label, () => {
+      [tools.Galaxy.label, () => {
         return {
           ...baseProps,
           href: app?.proxyUrls?.galaxy,
@@ -314,13 +315,13 @@ export const CloudEnvironmentModal = ({
           ...Utils.newTabLinkPropsWithReferrer
         }
       }],
-      [tools.cromwell.label, () => {
+      [tools.Cromwell.label, () => {
         return {
           ...baseProps,
           href: app?.proxyUrls['cromwell-service'],
           onClick: () => {
             onDismiss()
-            Ajax().Metrics.captureEvent(Events.applicationLaunch, { app: tools.cromwell.appType })
+            Ajax().Metrics.captureEvent(Events.applicationLaunch, { app: tools.Cromwell.appType })
           },
           ...Utils.newTabLinkPropsWithReferrer
         }
@@ -392,8 +393,8 @@ export const CloudEnvironmentModal = ({
 
   const NEW_JUPYTER_MODE = tools.Jupyter.label
   const NEW_RSTUDIO_MODE = tools.RStudio.label
-  const NEW_GALAXY_MODE = tools.galaxy.label
-  const NEW_CROMWELL_MODE = tools.cromwell.label
+  const NEW_GALAXY_MODE = tools.Galaxy.label
+  const NEW_CROMWELL_MODE = tools.Cromwell.label
 
   const getView = () => Utils.switchCase(viewMode,
     [NEW_JUPYTER_MODE, () => renderComputeModal(NEW_JUPYTER_MODE)],

--- a/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
+++ b/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
@@ -350,7 +350,6 @@ export const CloudEnvironmentModal = ({
   }
 
   const renderToolButtons = toolLabel => {
-    console.log('label in renderTolButtons', toolLabel)
     const app = currentApp(toolLabel)
     const doesCloudEnvForToolExist = currentRuntimeTool === toolLabel || app
     const isCloudEnvForToolDisabled = isCloudEnvModalDisabled(toolLabel)
@@ -423,7 +422,10 @@ export const CloudEnvironmentModal = ({
       title: 'Cloud Environment Details',
       titleStyles: _.merge(viewMode === undefined ? {} : { display: 'none' }, { margin: '1.5rem 0 .5rem 1rem' }),
       width,
-      onDismiss,
+      onDismiss: () => {
+        setViewMode(undefined)
+        onDismiss()
+      },
       onPrevious: !!viewMode ? () => setViewMode(undefined) : undefined
     }),
     viewMode !== undefined && hr({ style: { borderTop: '1px solid', width: '100%', color: colors.accent() } }),


### PR DESCRIPTION
I had to re-create this because I rebased the branch... It wouldn't let me re-open the old PR for some reason

The PR addresses the following bullet points in this ticket https://broadworkbench.atlassian.net/browse/IA-3080
- We need to add messaging for the individual hovers during different states when env creation or resume (ex. Precreating, starting, running, etc. See “Env status tooltip” screenshot attached
<img width="653" alt="Env status tooltip" src="https://user-images.githubusercontent.com/6465084/160000824-d1fa8fd4-e303-46f2-868a-250327c71e51.png">

- Update side panel icons so that they get highlighted when hovering, individual hovers for each app env icon (so that they look like buttons)
- Clicking on each app icon brings up only its corresponding cloud env page only, and if user clicks on the cloud icon itself, then it will bring up the entire cloud env modal with all apps displayed
- Make side panel icons slightly bigger to improve usability
- Change the “Launch ______” name to “Open ______” (Note: this exists in the edit notebook view, also “do you want to launch” prompt, Context bar change only?)
- Change the name of Launch button with .rmd files to Open, and also the .ipynb from Edit to Open so that they both match
- Also change from Launch to Open when creating RStudio and Galaxy instances (pop up window at the right hand side of the page) - “Open X” where X = Galaxy, RStudio or other future apps