### PR TITLE
[SU-64] Allow typing spaces in attribute editor

### DIFF
--- a/src/components/data/_tests/data-utils.test.js
+++ b/src/components/data/_tests/data-utils.test.js
@@ -1,4 +1,4 @@
-import { concatenateAttributeNames, convertAttributeValue, getAttributeType } from 'src/components/data/data-utils.js'
+import { concatenateAttributeNames, convertAttributeValue, getAttributeType, prepareAttributeForUpload } from 'src/components/data/data-utils.js'
 
 
 describe('concatenateAttributeNames', () => {
@@ -134,6 +134,62 @@ describe('convertAttributeValue', () => {
         { entityType: 'thing', entityName: 'thing_two' }
       ],
       itemsType: 'EntityReference'
+    })
+  })
+})
+
+describe('prepareAttributeForUpload', () => {
+  it('trims string values', () => {
+    expect(prepareAttributeForUpload('foo ')).toEqual('foo')
+    expect(prepareAttributeForUpload({
+      items: [' foo', ' bar '],
+      itemsType: 'AttributeValue'
+    })).toEqual({
+      items: ['foo', 'bar'],
+      itemsType: 'AttributeValue'
+    })
+  })
+
+  it('trims entity names in references', () => {
+    expect(prepareAttributeForUpload({
+      entityType: 'thing',
+      entityName: 'thing_one '
+    })).toEqual({
+      entityType: 'thing',
+      entityName: 'thing_one'
+    })
+    expect(prepareAttributeForUpload({
+      items: [
+        { entityType: 'thing', entityName: 'thing_one ' },
+        { entityType: 'thing', entityName: ' thing_two' }
+      ],
+      itemsType: 'EntityReference'
+    })).toEqual({
+      items: [
+        { entityType: 'thing', entityName: 'thing_one' },
+        { entityType: 'thing', entityName: 'thing_two' }
+      ],
+      itemsType: 'EntityReference'
+    })
+  })
+
+  it('leaves other types unchanged', () => {
+    expect(prepareAttributeForUpload(false)).toEqual(false)
+    expect(prepareAttributeForUpload({
+      items: [true, false],
+      itemsType: 'AttributeValue'
+    })).toEqual({
+      items: [true, false],
+      itemsType: 'AttributeValue'
+    })
+
+    expect(prepareAttributeForUpload(42)).toEqual(42)
+    expect(prepareAttributeForUpload({
+      items: [1, 2, 3],
+      itemsType: 'AttributeValue'
+    })).toEqual({
+      items: [1, 2, 3],
+      itemsType: 'AttributeValue'
     })
   })
 })


### PR DESCRIPTION
This fixes a bug introduced in #2895.

When editing attributes, string values and entity names for references need to be trimmed after editing is finished. Currently, they are trimmed in the input's onChange handler, which makes typing a value that includes a space difficult.

https://user-images.githubusercontent.com/1156625/160475145-dde95f75-102d-45de-a4e9-9368d37ec356.mov


