### PR TITLE
[SU-66] Prevent removing last list item in attribute editor

### DIFF
--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -647,7 +647,7 @@ const AttributeInput = ({ value: attributeValue, onChange, entityTypes = [] }) =
           }),
           h(Link, {
             'aria-label': `Remove list value ${i + 1}`,
-            disabled: value.length === 1,
+            disabled: attributeValue.items.length === 1,
             onClick: () => {
               const newAttributeValue = _.update('items', _.pullAt(i), attributeValue)
               onChange(newAttributeValue)

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -647,7 +647,7 @@ const AttributeInput = ({ value: attributeValue, onChange, entityTypes = [] }) =
           }),
           h(Link, {
             'aria-label': `Remove list value ${i + 1}`,
-            disabled: attributeValue.items.length === 1,
+            disabled: _.size(attributeValue.items) === 1,
             onClick: () => {
               const newAttributeValue = _.update('items', _.pullAt(i), attributeValue)
               onChange(newAttributeValue)


### PR DESCRIPTION
Another bug from #2895.

The attribute editor should prevent removing the last item in a list. However, the remove item button is currently disabled based on the length of the value for that list item, rather than the length of the attribute's `items` list.

## Before
![Screen Shot 2022-03-28 at 4 35 58 PM](https://user-images.githubusercontent.com/1156625/160482877-107f0ce0-6eec-43b6-9a7d-287b48cc0d08.png)
![Screen Shot 2022-03-28 at 4 35 43 PM](https://user-images.githubusercontent.com/1156625/160482878-0577a195-4416-41a1-b433-ff8d45921c63.png)

## After
![Screen Shot 2022-03-28 at 4 35 02 PM](https://user-images.githubusercontent.com/1156625/160482919-467241d5-c4fb-4623-80cd-dc5ec92c45a1.png)
![Screen Shot 2022-03-28 at 4 35 09 PM](https://user-images.githubusercontent.com/1156625/160482920-d9bbf454-f4ce-4f69-b573-5d6ca5b79ea8.png)

