### PR TITLE
[SU-25][SU-14] Allow editing attribute for multiple rows at once

### DIFF
--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -3,7 +3,7 @@ import { Fragment, useEffect, useRef, useState } from 'react'
 import { div, h, span } from 'react-hyperscript-helpers'
 import { AutoSizer } from 'react-virtualized'
 import { Checkbox, Clickable, fixedSpinnerOverlay, Link } from 'src/components/common'
-import { concatenateAttributeNames, DeleteEntityColumnModal, EditDataLink, EntityEditor, EntityRenamer, HeaderOptions, renderDataCell } from 'src/components/data/data-utils'
+import { concatenateAttributeNames, DeleteEntityColumnModal, EditDataLink, EntityRenamer, HeaderOptions, renderDataCell, SingleEntityEditor } from 'src/components/data/data-utils'
 import { ColumnSettingsWithSavedColumnSettings } from 'src/components/data/SavedColumnSettings'
 import { icon } from 'src/components/icons'
 import { ConfirmedSearchInput } from 'src/components/input'
@@ -373,7 +373,7 @@ const DataTable = props => {
       },
       onDismiss: () => setRenamingEntity(undefined)
     }),
-    !!updatingEntity && h(EntityEditor, {
+    !!updatingEntity && h(SingleEntityEditor, {
       entityType: _.find(entity => entity.name === updatingEntity.entityName, entities).entityType,
       ...updatingEntity,
       entityTypes: _.keys(entityMetadata),

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -688,7 +688,7 @@ export const prepareAttributeForUpload = attributeValue => {
     transform(attributeValue)
 }
 
-export const EntityEditor = ({ entityType, entityName, attributeName, attributeValue, entityTypes, workspaceId: { namespace, name }, onDismiss, onSuccess }) => {
+export const SingleEntityEditor = ({ entityType, entityName, attributeName, attributeValue, entityTypes, workspaceId: { namespace, name }, onDismiss, onSuccess }) => {
   const [newValue, setNewValue] = useState(attributeValue)
   const isUnchanged = _.isEqual(attributeValue, newValue)
 

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -906,6 +906,14 @@ const Workspaces = signal => ({
           { signal, method: 'PATCH' }]))
       },
 
+      deleteAttributeFromEntities: (entityType, attributeName, entityNames) => {
+        const body = _.map(name => ({
+          entityType, name, operations: [{ op: 'RemoveAttribute', attributeName }]
+        }), entityNames)
+
+        return fetchRawls(`${root}/entities/batchUpsert`, _.mergeAll([authOpts(), jsonBody(body), { signal, method: 'POST' }]))
+      },
+
       deleteEntityColumn: (type, attributeName) => {
         return fetchRawls(`${root}/entities/${type}?attributeNames=${attributeName}`, _.mergeAll([authOpts(), { signal, method: 'DELETE' }]))
       },


### PR DESCRIPTION
Currently, a single attribute can be edited by hovering over a cell in a data table and clicking the edit button.

This allows editing an attribute for multiple rows at once using an interface similar to the existing attribute editor. It also allows adding a new column to the data table (by entering a new attribute name instead of selecting an existing one) and clearing a range of cells (by selecting rows and setting an attribute to an empty string).

https://user-images.githubusercontent.com/1156625/160714104-2fbd839f-32bf-4c44-b8fa-224b3e3169bc.mov


