### PR TITLE
[SU-14] Add option to clear a column

### DIFF
--- a/src/components/common.js
+++ b/src/components/common.js
@@ -9,6 +9,7 @@ import RAsyncCreatableSelect from 'react-select/async-creatable'
 import RSwitch from 'react-switch'
 import FooterWrapper from 'src/components/FooterWrapper'
 import { centeredSpinner, containsUnlabelledIcon, icon } from 'src/components/icons'
+import { TextInput } from 'src/components/input'
 import Interactive from 'src/components/Interactive'
 import Modal from 'src/components/Modal'
 import { MiniSortable } from 'src/components/table'
@@ -555,3 +556,43 @@ export const ClipboardButton = ({ text, onClick, children, ...props }) => {
 export const HeaderRenderer = ({ name, label, sort, onSort, style, ...props }) => h(MiniSortable, { sort, field: name, onSort }, [
   div({ style: { fontWeight: 600, ...style }, ...props }, [label || Utils.normalizeLabel(name)])
 ])
+
+export const DeleteConfirmationModal = ({ title, children, confirmationPrompt = 'Delete', buttonText = 'Delete', onConfirm, onDismiss }) => {
+  const [busy, setBusy] = useState(false)
+  const [confirmation, setConfirmation] = useState('')
+
+  const del = async () => {
+    try {
+      setBusy(true)
+      await onConfirm()
+    } finally {
+      onDismiss()
+    }
+  }
+
+  const isConfirmed = _.toLower(confirmation) === _.toLower(confirmationPrompt)
+
+  return h(Modal, {
+    title,
+    onDismiss,
+    okButton: h(ButtonPrimary, {
+      onClick: del,
+      disabled: !isConfirmed,
+      tooltip: isConfirmed ? undefined : 'You must type the confirmation message'
+    }, buttonText)
+  }, [
+    children,
+    div({ style: { display: 'flex', flexDirection: 'column', marginTop: '1rem' } }, [
+      h(IdContainer, [id => h(Fragment, [
+        label({ htmlFor: id, style: { marginBottom: '0.25rem' } }, [`Type "${confirmationPrompt}" to continue:`]),
+        h(TextInput, {
+          id,
+          placeholder: confirmationPrompt,
+          value: confirmation,
+          onChange: setConfirmation
+        })
+      ])])
+    ]),
+    busy && spinnerOverlay
+  ])
+}

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -1,7 +1,7 @@
 import * as clipboard from 'clipboard-polyfill/text'
 import _ from 'lodash/fp'
 import * as qs from 'qs'
-import { Fragment, useState } from 'react'
+import { Fragment, useRef, useState } from 'react'
 import FocusLock from 'react-focus-lock'
 import { b, div, h, h1, img, input, label, span } from 'react-hyperscript-helpers'
 import RSelect, { components as RSelectComponents } from 'react-select'
@@ -561,6 +561,8 @@ export const DeleteConfirmationModal = ({ title, children, confirmationPrompt = 
   const [busy, setBusy] = useState(false)
   const [confirmation, setConfirmation] = useState('')
 
+  const confirmationInput = useRef()
+
   const del = async () => {
     try {
       setBusy(true)
@@ -579,7 +581,12 @@ export const DeleteConfirmationModal = ({ title, children, confirmationPrompt = 
       onClick: del,
       disabled: !isConfirmed,
       tooltip: isConfirmed ? undefined : 'You must type the confirmation message'
-    }, buttonText)
+    }, buttonText),
+    onAfterOpen: () => {
+      if (confirmationInput.current) {
+        confirmationInput.current.focus()
+      }
+    }
   }, [
     children,
     div({ style: { display: 'flex', flexDirection: 'column', marginTop: '1rem' } }, [
@@ -588,6 +595,7 @@ export const DeleteConfirmationModal = ({ title, children, confirmationPrompt = 
         h(TextInput, {
           id,
           placeholder: confirmationPrompt,
+          ref: confirmationInput,
           value: confirmation,
           onChange: setConfirmation
         })

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -1,7 +1,7 @@
 import * as clipboard from 'clipboard-polyfill/text'
 import _ from 'lodash/fp'
 import * as qs from 'qs'
-import { Fragment, useRef, useState } from 'react'
+import { Fragment, useState } from 'react'
 import FocusLock from 'react-focus-lock'
 import { b, div, h, h1, img, input, label, span } from 'react-hyperscript-helpers'
 import RSelect, { components as RSelectComponents } from 'react-select'
@@ -561,8 +561,6 @@ export const PromptedConfirmationModal = ({ title, children, confirmationPrompt 
   const [busy, setBusy] = useState(false)
   const [confirmation, setConfirmation] = useState('')
 
-  const confirmationInput = useRef()
-
   const del = async () => {
     try {
       setBusy(true)
@@ -581,21 +579,16 @@ export const PromptedConfirmationModal = ({ title, children, confirmationPrompt 
       onClick: del,
       disabled: !isConfirmed,
       tooltip: isConfirmed ? undefined : 'You must type the confirmation message'
-    }, buttonText),
-    onAfterOpen: () => {
-      if (confirmationInput.current) {
-        confirmationInput.current.focus()
-      }
-    }
+    }, buttonText)
   }, [
     children,
     div({ style: { display: 'flex', flexDirection: 'column', marginTop: '1rem' } }, [
       h(IdContainer, [id => h(Fragment, [
         label({ htmlFor: id, style: { marginBottom: '0.25rem' } }, [`Type "${confirmationPrompt}" to continue:`]),
         h(TextInput, {
+          autoFocus: true,
           id,
           placeholder: confirmationPrompt,
-          ref: confirmationInput,
           value: confirmation,
           onChange: setConfirmation
         })

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -561,7 +561,7 @@ export const PromptedConfirmationModal = ({ title, children, confirmationPrompt 
   const [busy, setBusy] = useState(false)
   const [confirmation, setConfirmation] = useState('')
 
-  const del = async () => {
+  const confirm = async () => {
     try {
       setBusy(true)
       await onConfirm()
@@ -576,7 +576,7 @@ export const PromptedConfirmationModal = ({ title, children, confirmationPrompt 
     title,
     onDismiss,
     okButton: h(ButtonPrimary, {
-      onClick: del,
+      onClick: confirm,
       disabled: !isConfirmed,
       tooltip: isConfirmed ? undefined : 'You must type the confirmation message'
     }, buttonText)

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -557,7 +557,7 @@ export const HeaderRenderer = ({ name, label, sort, onSort, style, ...props }) =
   div({ style: { fontWeight: 600, ...style }, ...props }, [label || Utils.normalizeLabel(name)])
 ])
 
-export const DeleteConfirmationModal = ({ title, children, confirmationPrompt = 'Delete', buttonText = 'Delete', onConfirm, onDismiss }) => {
+export const PromptedConfirmationModal = ({ title, children, confirmationPrompt = 'Delete', buttonText = 'Delete', onConfirm, onDismiss }) => {
   const [busy, setBusy] = useState(false)
   const [confirmation, setConfirmation] = useState('')
 

--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -316,8 +316,10 @@ const DataTable = props => {
                       h(HeaderOptions, {
                         sort, field: attributeName, onSort: setSort,
                         extraActions: [
-                          { label: 'Delete Column', onClick: () => setDeletingColumn(attributeName) },
-                          { label: 'Clear Column', onClick: () => setClearingColumn(attributeName) }
+                          // settimeout 0 is needed to delay opening the modaals until after the popup menu closes.
+                          // Without this, autofocus doesn't work in the modals.
+                          { label: 'Delete Column', onClick: () => setTimeout(() => setDeletingColumn(attributeName), 0) },
+                          { label: 'Clear Column', onClick: () => setTimeout(() => setClearingColumn(attributeName), 0) }
                         ]
                       }, [
                         h(HeaderCell, [

--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -139,14 +139,19 @@ const DataTable = props => {
     setEntities(updatedEntities)
   }
 
-  const clearColumn = withErrorReporting('Unable to clear column.')(async attributeName => {
+  const getAllEntities = async () => {
     const params = _.pickBy(_.trim, { pageSize: filteredCount, filterTerms: activeTextFilter })
     const queryResults = await Ajax(signal).Workspaces.workspace(namespace, name).paginatedEntitiesOfType(entityType, params)
+    return queryResults.results
+  }
+
+  const clearColumn = withErrorReporting('Unable to clear column.')(async attributeName => {
+    const allEntities = await getAllEntities()
     const entityUpdates = _.map(entity => ({
       name: entity.name,
       entityType: entity.entityType,
       attributes: { [attributeName]: '' }
-    }), queryResults.results)
+    }), allEntities)
     await Ajax(signal).Workspaces.workspace(namespace, name).upsertEntities(entityUpdates)
   })
 
@@ -154,9 +159,8 @@ const DataTable = props => {
     Utils.withBusyState(setLoading),
     withErrorReporting('Error loading entities')
   )(async () => {
-    const params = _.pickBy(_.trim, { pageSize: filteredCount, filterTerms: activeTextFilter })
-    const queryResults = await Ajax(signal).Workspaces.workspace(namespace, name).paginatedEntitiesOfType(entityType, params)
-    setSelected(entityMap(queryResults.results))
+    const allEntities = await getAllEntities()
+    setSelected(entityMap(allEntities))
   })
 
   const selectPage = () => {

--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -140,7 +140,7 @@ const DataTable = props => {
 
   const deleteColumn = withErrorReporting('Unable to delete column')(async attributeName => {
     await Ajax(signal).Workspaces.workspace(namespace, name).deleteEntityColumn(entityType, attributeName)
-    deleteColumnUpdateMetadata({ entityType, attributeName: deletingColumn })
+    deleteColumnUpdateMetadata({ entityType, attributeName })
 
     const updatedEntities = _.map(entity => {
       return { ...entity, attributes: _.omit([attributeName], entity.attributes) }

--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -268,7 +268,7 @@ const DataTable = props => {
                       setColumnWidths(_.set('name', nameWidth + delta))
                     }
                   }, [
-                    h(HeaderOptions, { sort, field: 'name', onSort: setSort, isEntityName: true },
+                    h(HeaderOptions, { sort, field: 'name', onSort: setSort },
                       [h(HeaderCell, [entityMetadata[entityType].idName])])
                   ]),
                   cellRenderer: ({ rowIndex }) => {
@@ -293,8 +293,8 @@ const DataTable = props => {
                       width: thisWidth, onWidthChange: delta => setColumnWidths(_.set(attributeName, thisWidth + delta))
                     }, [
                       h(HeaderOptions, {
-                        sort, field: attributeName, onSort: setSort, isEntityName: false,
-                        beginDelete: () => setDeletingColumn({ entityType, attributeName })
+                        sort, field: attributeName, onSort: setSort,
+                        extraActions: [{ label: 'Delete Column', onClick: () => setDeletingColumn({ entityType, attributeName }) }]
                       }, [
                         h(HeaderCell, [
                           !!columnNamespace && span({ style: { fontStyle: 'italic', color: colors.dark(0.75), paddingRight: '0.2rem' } },

--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -156,6 +156,9 @@ const DataTable = props => {
       attributes: { [attributeName]: '' }
     }), allEntities)
     await Ajax(signal).Workspaces.workspace(namespace, name).upsertEntities(entityUpdates)
+
+    const updatedEntities = _.map(_.update('attributes', _.set(attributeName, '')), entities)
+    setEntities(updatedEntities)
   })
 
   const selectAll = _.flow(
@@ -420,10 +423,7 @@ const DataTable = props => {
       title: 'Clear Column',
       confirmationPrompt: 'Clear column',
       buttonText: 'Clear column',
-      onConfirm: async () => {
-        await clearColumn(clearingColumn)
-        loadData()
-      },
+      onConfirm: () => clearColumn(clearingColumn),
       onDismiss: () => setClearingColumn(undefined)
     }, [
       div(['Are you sure you want to permanently delete all data in the column ',

--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -2,7 +2,7 @@ import _ from 'lodash/fp'
 import { Fragment, useEffect, useRef, useState } from 'react'
 import { div, h, span } from 'react-hyperscript-helpers'
 import { AutoSizer } from 'react-virtualized'
-import { Checkbox, Clickable, DeleteConfirmationModal, fixedSpinnerOverlay, Link } from 'src/components/common'
+import { Checkbox, Clickable, fixedSpinnerOverlay, Link, PromptedConfirmationModal } from 'src/components/common'
 import { concatenateAttributeNames, EditDataLink, EntityRenamer, HeaderOptions, renderDataCell, SingleEntityEditor } from 'src/components/data/data-utils'
 import { ColumnSettingsWithSavedColumnSettings } from 'src/components/data/SavedColumnSettings'
 import { icon } from 'src/components/icons'
@@ -408,7 +408,7 @@ const DataTable = props => {
       },
       onDismiss: () => setUpdatingEntity(undefined)
     }),
-    !!deletingColumn && h(DeleteConfirmationModal, {
+    !!deletingColumn && h(PromptedConfirmationModal, {
       title: 'Delete Column',
       confirmationPrompt: 'Delete column',
       buttonText: 'Delete column',
@@ -419,7 +419,7 @@ const DataTable = props => {
         span({ style: { fontWeight: 600, wordBreak: 'break-word' } }, deletingColumn), '?']),
       div({ style: { fontWeight: 500, marginTop: '1rem' } }, 'This cannot be undone.')
     ]),
-    !!clearingColumn && h(DeleteConfirmationModal, {
+    !!clearingColumn && h(PromptedConfirmationModal, {
       title: 'Clear Column',
       confirmationPrompt: 'Clear column',
       buttonText: 'Clear column',

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -984,14 +984,14 @@ export const DeleteEntityColumnModal = ({ workspaceId: { namespace, name }, colu
   ])
 }
 
-export const HeaderOptions = ({ sort, field, onSort, isEntityName, beginDelete, children }) => {
+export const HeaderOptions = ({ sort, field, onSort, extraActions, children }) => {
   const columnMenu = h(MenuTrigger, {
     closeOnClick: true,
     side: 'bottom',
     content: h(Fragment, [
       h(MenuButton, { onClick: () => onSort({ field, direction: 'asc' }) }, ['Sort Ascending']),
       h(MenuButton, { onClick: () => onSort({ field, direction: 'desc' }) }, ['Sort Descending']),
-      !isEntityName && h(MenuButton, { onClick: beginDelete }, ['Delete Column'])
+      _.map(({ label, onClick }) => h(MenuButton, { key: label, onClick }, [label]), extraActions)
     ])
   }, [
     h(Link, { 'aria-label': 'Workflow menu', onClick: e => e.stopPropagation() }, [

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -938,52 +938,6 @@ export const ModalToolButton = ({ icon, text, disabled, ...props }) => {
   ])
 }
 
-export const DeleteEntityColumnModal = ({ workspaceId: { namespace, name }, column: { entityType, attributeName }, onDismiss, onSuccess }) => {
-  const [deleting, setDeleting] = useState(false)
-  const [deleteConfirmation, setDeleteConfirmation] = useState('')
-
-  const signal = useCancellation()
-
-  const deleteColumn = async () => {
-    try {
-      setDeleting(true)
-      await Ajax(signal).Workspaces.workspace(namespace, name).deleteEntityColumn(entityType, attributeName)
-      onDismiss()
-      onSuccess()
-    } catch (e) {
-      reportError('Unable to modify column', e)
-      setDeleting(false)
-    }
-  }
-
-  return h(Modal, {
-    title: 'Delete Column',
-    onDismiss,
-    okButton: h(ButtonPrimary, {
-      onClick: deleteColumn,
-      disabled: _.toLower(deleteConfirmation) !== 'delete column',
-      tooltip: _.toLower(deleteConfirmation) !== 'delete column' ? 'You must type the confirmation message' : undefined
-    }, 'Delete column')
-  }, [
-    div(['Are you sure you want to permanently delete the column ',
-      span({ style: { fontWeight: 600, wordBreak: 'break-word' } }, attributeName),
-      '?']),
-    div({
-      style: { fontWeight: 500, marginTop: '1rem' }
-    }, 'This cannot be undone.'),
-    div({ style: { marginTop: '1rem' } }, [
-      label({ htmlFor: 'delete-column-confirmation' }, ['Please type "Delete Column" to continue:']),
-      h(TextInput, {
-        id: 'delete-column-confirmation',
-        placeholder: 'Delete Column',
-        value: deleteConfirmation,
-        onChange: setDeleteConfirmation
-      })
-    ]),
-    deleting && spinnerOverlay
-  ])
-}
-
 export const HeaderOptions = ({ sort, field, onSort, extraActions, children }) => {
   const columnMenu = h(MenuTrigger, {
     closeOnClick: true,


### PR DESCRIPTION
Currently, you can delete a data table column from the menu in the column heading. This adds an option to clear the column, setting its value to an empty string for all rows. This can be useful if users want to erase some data (for example, a workflow output), but preserve the column's place in their view settings for when the column is repopulated later.

https://user-images.githubusercontent.com/1156625/160873281-449643fb-f2f6-4071-8f20-a8b9136193a8.mov


