### PR TITLE
[SU-51] Data tab redesign part 2

### DIFF
--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -654,7 +654,7 @@ const WorkspaceData = _.flow(
           div({ role: 'list' }, [
             h(DataTypeSection, {
               title: 'Tables',
-              titleExtras: h(Link, {
+              titleExtras: isDataTabRedesignEnabled() ? null : h(Link, {
                 disabled: !!Utils.editWorkspaceError(workspace),
                 tooltip: Utils.editWorkspaceError(workspace) || 'Upload .tsv',
                 onClick: () => setUploadingFile(true),
@@ -758,7 +758,7 @@ const WorkspaceData = _.flow(
             ]),
             h(DataTypeSection, {
               title: 'Reference Data',
-              titleExtras: h(Link, {
+              titleExtras: isDataTabRedesignEnabled() ? null : h(Link, {
                 disabled: !!Utils.editWorkspaceError(workspace),
                 tooltip: Utils.editWorkspaceError(workspace) || 'Add reference data',
                 onClick: () => setImportingReference(true),

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -2,12 +2,12 @@ import filesize from 'filesize'
 import _ from 'lodash/fp'
 import { Fragment, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react'
 import { DraggableCore } from 'react-draggable'
-import { div, form, h, h3, input } from 'react-hyperscript-helpers'
+import { div, form, h, h3, input, span } from 'react-hyperscript-helpers'
 import { AutoSizer } from 'react-virtualized'
 import * as breadcrumbs from 'src/components/breadcrumbs'
 import { requesterPaysWrapper, withRequesterPaysHandler } from 'src/components/bucket-utils'
 import Collapse from 'src/components/Collapse'
-import { Clickable, Link, spinnerOverlay } from 'src/components/common'
+import { ButtonOutline, Clickable, Link, spinnerOverlay } from 'src/components/common'
 import { EntityUploader, ReferenceDataDeleter, ReferenceDataImporter, renderDataCell, saveScroll } from 'src/components/data/data-utils'
 import EntitiesContent from 'src/components/data/EntitiesContent'
 import ExportDataModal from 'src/components/data/ExportDataModal'
@@ -624,9 +624,32 @@ const WorkspaceData = _.flow(
   const sortedEntityPairs = toSortedPairs(entityMetadata)
   const sortedSnapshotPairs = toSortedPairs(snapshotDetails)
 
+  const editWorkspaceErrorMessage = Utils.editWorkspaceError(workspace)
+  const canEditWorkspace = !editWorkspaceErrorMessage
+
   return div({ style: styles.tableContainer }, [
     !entityMetadata ? spinnerOverlay : h(Fragment, [
       div({ style: { ...styles.sidebarContainer, width: sidebarWidth } }, [
+        isDataTabRedesignEnabled() && div({ style: { display: 'flex', padding: '1rem 1.5rem', backgroundColor: colors.light(0.4) } }, [
+          h(MenuTrigger, {
+            side: 'bottom',
+            closeOnClick: true,
+            content: h(Fragment, [
+              h(MenuButton, {
+                'aria-haspopup': 'dialog',
+                onClick: () => setUploadingFile(true)
+              }, 'Upload TSV'),
+              h(MenuButton, {
+                'aria-haspopup': 'dialog',
+                onClick: () => setImportingReference(true)
+              }, 'Add reference data')
+            ])
+          }, [h(ButtonOutline, {
+            disabled: !canEditWorkspace,
+            tooltip: canEditWorkspace ? 'Add data to this workspace' : editWorkspaceErrorMessage,
+            style: { flex: 1 }
+          }, [span([icon('plus-circle', { style: { marginRight: '1ch' } }), 'Import data'])])])
+        ]),
         div({ style: styles.dataTypeSelectionPanel, role: 'navigation', 'aria-label': 'data in this workspace' }, [
           div({ role: 'list' }, [
             h(DataTypeSection, {


### PR DESCRIPTION
Continuing from #2907, this moves the current "Upload .tsv" and "Add reference data" buttons in the data tab sidebar into a single "Import data" button at the top of the sidebar. This prepares for adding additional import options (the "data uploader") and making the sidebar sections collapsible.

To enable the feature flag, run `configOverridesStore.set({ isDataTabRedesignEnabled: true })` in the console.

## Before
<img width="1343" alt="Screen Shot 2022-03-31 at 3 55 48 PM" src="https://user-images.githubusercontent.com/1156625/161156753-823fe1e5-5e5b-4143-b75b-31e30d636ae3.png">

## After
<img width="1343" alt="Screen Shot 2022-03-31 at 3 55 30 PM" src="https://user-images.githubusercontent.com/1156625/161156756-42d0c30f-246b-4ef7-afa2-f6451d094424.png">
<img width="1343" alt="Screen Shot 2022-03-31 at 3 55 33 PM" src="https://user-images.githubusercontent.com/1156625/161156758-cac0d9c3-8391-454b-ba8e-daa3c9966bcc.png">

