### PR TITLE
[SU-65] Improve visual indication of read only and locked workspaces

### DIFF
--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -36,6 +36,33 @@ const navIconProps = {
   hover: { opacity: 1 }, focus: 'hover'
 }
 
+const WorkspacePermissionNotice = ({ workspace }) => {
+  const isReadOnly = !Utils.canWrite(workspace.accessLevel)
+  const isLocked = workspace.workspace.isLocked
+
+  return (isReadOnly || isLocked) && span({
+    style: {
+      display: 'inline-flex',
+      alignItems: 'center',
+      height: '2rem',
+      padding: '0 1rem',
+      borderRadius: '1rem',
+      marginRight: '2rem',
+      backgroundColor: colors.dark(0.15),
+      textTransform: 'none'
+    }
+  }, [
+    isLocked ? icon('lock', { size: 16 }) : icon('eye', { size: 20 }),
+    span({ style: { marginLeft: '1ch' } }, [
+      Utils.cond(
+        [isLocked && isReadOnly, () => 'Workspace is locked and read only'],
+        [isLocked, () => 'Workspace is locked'],
+        [isReadOnly, () => 'Workspace is read only']
+      )
+    ])
+  ])
+}
+
 const WorkspaceTabs = ({
   namespace, name, workspace, activeTab, refresh,
   setDeletingWorkspace, setCloningWorkspace, setSharingWorkspace, setShowLockWorkspaceModal
@@ -61,6 +88,7 @@ const WorkspaceTabs = ({
       tabNames: _.map('name', tabs),
       getHref: currentTab => Nav.getLink(_.find({ name: currentTab }, tabs).link, { namespace, name })
     }, [
+      workspace && h(WorkspacePermissionNotice, { workspace }),
       h(WorkspaceMenuTrigger, {
         canShare, isLocked, namespace, name, isOwner, setCloningWorkspace, setSharingWorkspace,
         setShowLockWorkspaceModal, setDeletingWorkspace
@@ -85,11 +113,7 @@ const WorkspaceContainer = ({
     h(TopBar, { title: 'Workspaces', href: Nav.getLink('workspaces') }, [
       div({ style: Style.breadcrumb.breadcrumb }, [
         div({ style: Style.noWrapEllipsis }, breadcrumbs),
-        h2({ style: Style.breadcrumb.textUnderBreadcrumb }, [
-          title || `${namespace}/${name}`,
-          workspace && !Utils.canWrite(workspace.accessLevel) && span({ style: { paddingLeft: '0.5rem' } }, '(read only)'),
-          workspace && workspace.workspace.isLocked && span({ style: { paddingLeft: '0.5rem' } }, '(locked)')
-        ])
+        h2({ style: Style.breadcrumb.textUnderBreadcrumb }, [title || `${namespace}/${name}`])
       ]),
       topBarContent,
       div({ style: { flexGrow: 1 } }),


### PR DESCRIPTION
Currently, when a workspace is read only or locked, that status is displayed in the top bar next to the workspace name. If the workspace name is long enough, it will be hidden. This moves the status indicator to the tab bar next to the workspace menu.

## Before
![Screen Shot 2022-04-01 at 9 24 11 AM](https://user-images.githubusercontent.com/1156625/161274428-8e755119-76c2-4880-836f-770e0976333f.png)
![Screen Shot 2022-04-01 at 9 24 23 AM](https://user-images.githubusercontent.com/1156625/161274430-13e696e8-a777-46e8-9cca-8fd104635be4.png)

## After
![Screen Shot 2022-04-01 at 9 31 26 AM](https://user-images.githubusercontent.com/1156625/161274448-2b2c6af2-aca5-43c4-a89a-afe1d7bbc5ec.png)
![Screen Shot 2022-04-01 at 9 31 36 AM](https://user-images.githubusercontent.com/1156625/161274450-f5b3b01c-ebb7-403b-b78c-ba03920aba81.png)

