### PR TITLE
[SU-43] Allow collapsing sections in data tab sidebar

### DIFF
--- a/src/components/Collapse.js
+++ b/src/components/Collapse.js
@@ -7,7 +7,7 @@ import { useUniqueId } from 'src/libs/react-utils'
 import * as Style from 'src/libs/style'
 
 
-const Collapse = ({ title, buttonStyle, buttonProps = {}, initialOpenState, children, titleFirst, afterToggle, onFirstOpen = () => {}, noTitleWrap, ...props }) => {
+const Collapse = ({ title, buttonStyle, buttonProps = {}, summaryStyle, detailsStyle, initialOpenState, children, titleFirst, afterToggle, onFirstOpen = () => {}, noTitleWrap, ...props }) => {
   const [isOpened, setIsOpened] = useState(initialOpenState)
   const angleIcon = icon(isOpened ? 'angle-down' : 'angle-right', { style: { marginRight: '0.25rem', flexShrink: 0 } })
 
@@ -21,7 +21,7 @@ const Collapse = ({ title, buttonStyle, buttonProps = {}, initialOpenState, chil
   }, [firstOpenRef, isOpened])
 
   return div(props, [
-    div({ style: { display: 'flex', alignItems: 'center' } }, [
+    div({ style: { display: 'flex', alignItems: 'center', ...summaryStyle } }, [
       h(Link, {
         'aria-expanded': isOpened,
         'aria-controls': isOpened ? id : undefined,
@@ -36,7 +36,7 @@ const Collapse = ({ title, buttonStyle, buttonProps = {}, initialOpenState, chil
       ]),
       afterToggle
     ]),
-    isOpened && div({ id }, [children])
+    isOpened && div({ id, style: detailsStyle }, [children])
   ])
 }
 

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -392,6 +392,7 @@ const DataTypeSection = ({ title, titleExtras, error, retryFunction, children })
   }
 
   return h(Collapse, {
+    role: 'listitem',
     title: h3({
       style: {
         margin: 0,

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -374,21 +374,54 @@ const BucketContent = _.flow(
   ])])
 })
 
-const DataTypeSection = ({ title, titleExtras, error, retryFunction, children }) => div({
-  role: 'listitem'
-}, [
-  h3({ style: Style.navList.heading }, [
-    title,
-    error ? h(Link, {
+const DataTypeSection = ({ title, titleExtras, error, retryFunction, children }) => {
+  if (!isDataTabRedesignEnabled()) {
+    return div({ role: 'listitem' }, [
+      h3({ style: Style.navList.heading }, [
+        title,
+        error ? h(Link, {
+          onClick: retryFunction,
+          tooltip: 'Error loading, click to retry.'
+        }, [icon('sync', { size: 18 })]) : titleExtras
+      ]),
+      !!children?.length && div({
+        style: { display: 'flex', flexDirection: 'column', width: '100%' },
+        role: 'list'
+      }, [children])
+    ])
+  }
+
+  return h(Collapse, {
+    title: h3({
+      style: {
+        margin: 0,
+        fontSize: 16,
+        textTransform: 'uppercase'
+      }
+    }, title),
+    titleFirst: true,
+    initialOpenState: true,
+    summaryStyle: {
+      paddingRight: error ? '1rem' : 0,
+      borderBottom: `0.5px solid ${colors.dark(0.2)}`,
+      backgroundColor: colors.light(0.4),
+      fontSize: 16
+    },
+    buttonStyle: {
+      padding: `1.125rem ${error ? '1rem' : '1.5rem'} 1.25rem 1.5rem`,
+      marginBottom: 0
+    },
+    afterToggle: error && h(Link, {
       onClick: retryFunction,
       tooltip: 'Error loading, click to retry.'
-    }, [icon('sync', { size: 18 })]) : titleExtras
-  ]),
-  !!children?.length && div({
-    style: { display: 'flex', flexDirection: 'column', width: '100%' },
-    role: 'list'
-  }, [children])
-])
+    }, [icon('sync', { size: 18 })])
+  }, [
+    !!children?.length && div({
+      style: { display: 'flex', flexDirection: 'column', width: '100%' },
+      role: 'list'
+    }, [children])
+  ])
+}
 
 const SidebarSeparator = ({ sidebarWidth, setSidebarWidth }) => {
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -408,9 +408,15 @@ const DataTypeSection = ({ title, titleExtras, error, retryFunction, children })
       backgroundColor: colors.light(0.4),
       fontSize: 16
     },
+    buttonProps: {
+      hover: {
+        color: colors.dark(0.9)
+      }
+    },
     buttonStyle: {
       padding: `1.125rem ${error ? '1rem' : '1.5rem'} 1.25rem 1.5rem`,
-      marginBottom: 0
+      marginBottom: 0,
+      color: colors.dark()
     },
     afterToggle: error && h(Link, {
       onClick: retryFunction,


### PR DESCRIPTION
Continues on data tab redesign from #2907 and #2923. To enable the feature flag, run `configOverridesStore.set({ isDataTabRedesignEnabled: true })` in the console.

Currently, when a workspace has many tables and/or snapshots, users have to scroll all the way down the sidebar to access other sections (workspace data, files, etc). This allows collapsing each section to more easily navigate the sidebar.

## Before
![Screen Shot 2022-04-01 at 4 09 40 PM](https://user-images.githubusercontent.com/1156625/161334651-70ace609-7a46-4d4b-a712-b27d096eb3f9.png)

## After
![Screen Shot 2022-04-01 at 4 09 14 PM](https://user-images.githubusercontent.com/1156625/161334666-054ca2a3-b6c4-4539-89b1-01bb157db493.png)
![Screen Shot 2022-04-01 at 4 09 18 PM](https://user-images.githubusercontent.com/1156625/161334668-5c5b6432-2d6f-48fc-a0f7-e0ede5a59bf3.png)

