### PR TITLE
[SU-248] Add option to delete empty cells when importing tsv

### DIFF
--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -382,7 +382,7 @@ export const EntityUploader = ({ onSuccess, onDismiss, namespace, name, entityTy
         }, [
           icon('warning-standard', { size: 19, style: { color: colors.warning(), flex: 'none', marginRight: '0.5rem', marginLeft: '-0.5rem' } }),
           'We have detected empty cells in your TSV. Please choose an option:',
-          div({ style: { paddingTop: '0.5rem' } }, [
+          div({ style: { paddingTop: '0.5rem' }, role: 'radiogroup', 'aria-label': 'We have detected empty cells in your TSV. Please choose an option.' }, [
             h(RadioButton, {
               text: 'Ignore empty cells (default)',
               name: 'ignore-empty-cells',
@@ -394,7 +394,7 @@ export const EntityUploader = ({ onSuccess, onDismiss, namespace, name, entityTy
           div({ style: { paddingTop: '0.5rem' } }, [
             h(RadioButton, {
               text: 'Overwrite existing cells with empty cells',
-              name: 'overwrite-existing-cells',
+              name: 'ignore-empty-cells',
               checked: deleteEmptyValues,
               onChange: () => setDeleteEmptyValues(true),
               labelStyle: { padding: '0.5rem', fontWeight: 'normal' }

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -274,7 +274,7 @@ export const EntityUploader = ({ onSuccess, onDismiss, namespace, name, entityTy
   const isInvalid = isFileImportCurrMode === isFileImportLastUsedMode && file && !match
   const newEntityType = match?.[1]
   const currentFile = isFileImportCurrMode === isFileImportLastUsedMode ? file : undefined
-  const containsNullValues = fileContents.match('\t\t')
+  const containsNullValues = fileContents.match(/^\t|\t\t+|\t$|\n\n+/gm)
 
   return h(Dropzone, {
     multiple: false,

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -253,7 +253,7 @@ export const EntityUploader = ({ onSuccess, onDismiss, namespace, name, entityTy
       } else {
         const filesize = file?.size || Number.MAX_SAFE_INTEGER
         if (filesize < 524288) { // 512k
-          await workspace.importFlexibleEntitiesFileSynchronous(file)
+          await workspace.importFlexibleEntitiesFileSynchronous(file, deleteEmptyValues)
         } else {
           const { jobId } = await workspace.importFlexibleEntitiesFileAsync(file, deleteEmptyValues)
           asyncImportJobStore.update(Utils.append({ targetWorkspace: { namespace, name }, jobId }))
@@ -284,7 +284,6 @@ export const EntityUploader = ({ onSuccess, onDismiss, namespace, name, entityTy
       setFile(file)
       setFileContents(await Utils.readFileAsText(file.slice(0, 1000)))
       setIsFileImportLastUsedMode(true)
-      setDeleteEmptyValues(false)
     }
   }, [
     ({ dragging, openUploader }) => h(Fragment, [
@@ -359,7 +358,6 @@ export const EntityUploader = ({ onSuccess, onDismiss, namespace, name, entityTy
               setFileContents(pastedText)
               setIsFileImportLastUsedMode(false)
               setShowInvalidEntryMethodWarning(false)
-              setDeleteEmptyValues(false)
             },
             onChange: () => setShowInvalidEntryMethodWarning(true),
             value: !isFileImportLastUsedMode ? fileContents : '',
@@ -379,7 +377,7 @@ export const EntityUploader = ({ onSuccess, onDismiss, namespace, name, entityTy
           `Data with the type '${newEntityType}' already exists in this workspace. `,
           'Uploading more data for the same type may overwrite some entries.'
         ]),
-        currentFile && containsNullValues && !!_.includes(_.toLower(newEntityType), entityTypes) && div({
+        currentFile && containsNullValues && _.includes(_.toLower(newEntityType), entityTypes) && div({
           style: { ...warningBoxStyle, margin: '1rem 0 0.5rem' }
         }, [
           icon('warning-standard', { size: 19, style: { color: colors.warning(), flex: 'none', marginRight: '0.5rem', marginLeft: '-0.5rem' } }),

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -382,23 +382,25 @@ export const EntityUploader = ({ onSuccess, onDismiss, namespace, name, entityTy
         }, [
           icon('warning-standard', { size: 19, style: { color: colors.warning(), flex: 'none', marginRight: '0.5rem', marginLeft: '-0.5rem' } }),
           'We have detected empty cells in your TSV. Please choose an option:',
-          div({ style: { paddingTop: '0.5rem' }, role: 'radiogroup', 'aria-label': 'We have detected empty cells in your TSV. Please choose an option.' }, [
-            h(RadioButton, {
-              text: 'Ignore empty cells (default)',
-              name: 'ignore-empty-cells',
-              checked: !deleteEmptyValues,
-              onChange: () => setDeleteEmptyValues(false),
-              labelStyle: { padding: '0.5rem', fontWeight: 'normal' }
-            })
-          ]),
-          div({ style: { paddingTop: '0.5rem' } }, [
-            h(RadioButton, {
-              text: 'Overwrite existing cells with empty cells',
-              name: 'ignore-empty-cells',
-              checked: deleteEmptyValues,
-              onChange: () => setDeleteEmptyValues(true),
-              labelStyle: { padding: '0.5rem', fontWeight: 'normal' }
-            })
+          div({ role: 'radiogroup', 'aria-label': 'we have detected empty cells in your tsv. please choose an option.' }, [
+            div({ style: { paddingTop: '0.5rem' } }, [
+              h(RadioButton, {
+                text: 'Ignore empty cells (default)',
+                name: 'ignore-empty-cells',
+                checked: !deleteEmptyValues,
+                onChange: () => setDeleteEmptyValues(false),
+                labelStyle: { padding: '0.5rem', fontWeight: 'normal' }
+              })
+            ]),
+            div({ style: { paddingTop: '0.5rem' } }, [
+              h(RadioButton, {
+                text: 'Overwrite existing cells with empty cells',
+                name: 'ignore-empty-cells',
+                checked: deleteEmptyValues,
+                onChange: () => setDeleteEmptyValues(true),
+                labelStyle: { padding: '0.5rem', fontWeight: 'normal' }
+              })
+            ])
           ])
         ]),
         currentFile && supportsFireCloudDataModel(newEntityType) && div([

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -242,19 +242,20 @@ export const EntityUploader = ({ onSuccess, onDismiss, namespace, name, entityTy
   const [fileContents, setFileContents] = useState('')
   const [showInvalidEntryMethodWarning, setShowInvalidEntryMethodWarning] = useState(false)
   const [uploading, setUploading] = useState(false)
+  const [deleteEmptyValues, setDeleteEmptyValues] = useState(false)
 
   const doUpload = async () => {
     setUploading(true)
     try {
       const workspace = Ajax().Workspaces.workspace(namespace, name)
       if (useFireCloudDataModel) {
-        await workspace.importEntitiesFile(file)
+        await workspace.importEntitiesFile(file, deleteEmptyValues)
       } else {
         const filesize = file?.size || Number.MAX_SAFE_INTEGER
         if (filesize < 524288) { // 512k
           await workspace.importFlexibleEntitiesFileSynchronous(file)
         } else {
-          const { jobId } = await workspace.importFlexibleEntitiesFileAsync(file)
+          const { jobId } = await workspace.importFlexibleEntitiesFileAsync(file, deleteEmptyValues)
           asyncImportJobStore.update(Utils.append({ targetWorkspace: { namespace, name }, jobId }))
           notifyDataImportProgress(jobId)
         }
@@ -273,6 +274,7 @@ export const EntityUploader = ({ onSuccess, onDismiss, namespace, name, entityTy
   const isInvalid = isFileImportCurrMode === isFileImportLastUsedMode && file && !match
   const newEntityType = match?.[1]
   const currentFile = isFileImportCurrMode === isFileImportLastUsedMode ? file : undefined
+  const containsNullValues = fileContents.match('\t\t')
 
   return h(Dropzone, {
     multiple: false,
@@ -282,6 +284,7 @@ export const EntityUploader = ({ onSuccess, onDismiss, namespace, name, entityTy
       setFile(file)
       setFileContents(await Utils.readFileAsText(file.slice(0, 1000)))
       setIsFileImportLastUsedMode(true)
+      setDeleteEmptyValues(false)
     }
   }, [
     ({ dragging, openUploader }) => h(Fragment, [
@@ -356,6 +359,7 @@ export const EntityUploader = ({ onSuccess, onDismiss, namespace, name, entityTy
               setFileContents(pastedText)
               setIsFileImportLastUsedMode(false)
               setShowInvalidEntryMethodWarning(false)
+              setDeleteEmptyValues(false)
             },
             onChange: () => setShowInvalidEntryMethodWarning(true),
             value: !isFileImportLastUsedMode ? fileContents : '',
@@ -374,6 +378,30 @@ export const EntityUploader = ({ onSuccess, onDismiss, namespace, name, entityTy
           icon('warning-standard', { size: 19, style: { color: colors.warning(), flex: 'none', marginRight: '0.5rem', marginLeft: '-0.5rem' } }),
           `Data with the type '${newEntityType}' already exists in this workspace. `,
           'Uploading more data for the same type may overwrite some entries.'
+        ]),
+        currentFile && containsNullValues && !!_.includes(_.toLower(newEntityType), entityTypes) && div({
+          style: { ...warningBoxStyle, margin: '1rem 0 0.5rem' }
+        }, [
+          icon('warning-standard', { size: 19, style: { color: colors.warning(), flex: 'none', marginRight: '0.5rem', marginLeft: '-0.5rem' } }),
+          'We have detected empty cells in your TSV. Please choose an option:',
+          div({ style: { paddingTop: '0.5rem' } }, [
+            h(RadioButton, {
+              text: 'Ignore empty cells (default)',
+              name: 'ignore-empty-cells',
+              checked: !deleteEmptyValues,
+              onChange: () => setDeleteEmptyValues(false),
+              labelStyle: { padding: '0.5rem', fontWeight: 'normal' }
+            })
+          ]),
+          div({ style: { paddingTop: '0.5rem' } }, [
+            h(RadioButton, {
+              text: 'Overwrite existing cells with empty cells',
+              name: 'overwrite-existing-cells',
+              checked: deleteEmptyValues,
+              onChange: () => setDeleteEmptyValues(true),
+              labelStyle: { padding: '0.5rem', fontWeight: 'normal' }
+            })
+          ])
         ]),
         currentFile && supportsFireCloudDataModel(newEntityType) && div([
           h(LabeledCheckbox, {

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -249,13 +249,13 @@ export const EntityUploader = ({ onSuccess, onDismiss, namespace, name, entityTy
     try {
       const workspace = Ajax().Workspaces.workspace(namespace, name)
       if (useFireCloudDataModel) {
-        await workspace.importEntitiesFile(file, deleteEmptyValues)
+        await workspace.importEntitiesFile(file, { deleteEmptyValues })
       } else {
         const filesize = file?.size || Number.MAX_SAFE_INTEGER
         if (filesize < 524288) { // 512k
-          await workspace.importFlexibleEntitiesFileSynchronous(file, deleteEmptyValues)
+          await workspace.importFlexibleEntitiesFileSynchronous(file, { deleteEmptyValues })
         } else {
-          const { jobId } = await workspace.importFlexibleEntitiesFileAsync(file, deleteEmptyValues)
+          const { jobId } = await workspace.importFlexibleEntitiesFileAsync(file, { deleteEmptyValues })
           asyncImportJobStore.update(Utils.append({ targetWorkspace: { namespace, name }, jobId }))
           notifyDataImportProgress(jobId)
         }

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -964,7 +964,7 @@ const Workspaces = signal => ({
       importFlexibleEntitiesFileSynchronous: async (file, deleteEmptyValues = false) => {
         const formData = new FormData()
         formData.set('entities', file)
-        const res = await fetchOrchestration(`api/${root}/flexibleImportEntities?${qs.stringify({ deleteEmptyValues }, { async: false })}`, _.merge(authOpts(), { body: formData, signal, method: 'POST' }))
+        const res = await fetchOrchestration(`api/${root}/flexibleImportEntities?${qs.stringify({ deleteEmptyValues, async: false })}`, _.merge(authOpts(), { body: formData, signal, method: 'POST' }))
         return res
       },
 
@@ -972,7 +972,7 @@ const Workspaces = signal => ({
         console.log(deleteEmptyValues)
         const formData = new FormData()
         formData.set('entities', file)
-        const res = await fetchOrchestration(`api/${root}/flexibleImportEntities?${qs.stringify({ deleteEmptyValues }, { async: true })}`, _.merge(authOpts(), { body: formData, signal, method: 'POST' }))
+        const res = await fetchOrchestration(`api/${root}/flexibleImportEntities?${qs.stringify({ deleteEmptyValues, async: true })}`, _.merge(authOpts(), { body: formData, signal, method: 'POST' }))
         return res.json()
       },
 

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -955,20 +955,20 @@ const Workspaces = signal => ({
         return upsertEntities(payload)
       },
 
-      importEntitiesFile: (file, deleteEmptyValues = false) => {
+      importEntitiesFile: (file, { deleteEmptyValues = false } = {}) => {
         const formData = new FormData()
         formData.set('entities', file)
         return fetchOrchestration(`api/${root}/importEntities?${qs.stringify({ deleteEmptyValues })}`, _.merge(authOpts(), { body: formData, signal, method: 'POST' }))
       },
 
-      importFlexibleEntitiesFileSynchronous: async (file, deleteEmptyValues = false) => {
+      importFlexibleEntitiesFileSynchronous: async (file, { deleteEmptyValues = false } = {}) => {
         const formData = new FormData()
         formData.set('entities', file)
         const res = await fetchOrchestration(`api/${root}/flexibleImportEntities?${qs.stringify({ deleteEmptyValues, async: false })}`, _.merge(authOpts(), { body: formData, signal, method: 'POST' }))
         return res
       },
 
-      importFlexibleEntitiesFileAsync: async (file, deleteEmptyValues = false) => {
+      importFlexibleEntitiesFileAsync: async (file, { deleteEmptyValues = false } = {}) => {
         const formData = new FormData()
         formData.set('entities', file)
         const res = await fetchOrchestration(`api/${root}/flexibleImportEntities?${qs.stringify({ deleteEmptyValues, async: true })}`, _.merge(authOpts(), { body: formData, signal, method: 'POST' }))

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -969,7 +969,6 @@ const Workspaces = signal => ({
       },
 
       importFlexibleEntitiesFileAsync: async (file, deleteEmptyValues = false) => {
-        console.log(deleteEmptyValues)
         const formData = new FormData()
         formData.set('entities', file)
         const res = await fetchOrchestration(`api/${root}/flexibleImportEntities?${qs.stringify({ deleteEmptyValues, async: true })}`, _.merge(authOpts(), { body: formData, signal, method: 'POST' }))

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -955,23 +955,24 @@ const Workspaces = signal => ({
         return upsertEntities(payload)
       },
 
-      importEntitiesFile: file => {
+      importEntitiesFile: (file, deleteEmptyValues = false) => {
         const formData = new FormData()
         formData.set('entities', file)
-        return fetchOrchestration(`api/${root}/importEntities`, _.merge(authOpts(), { body: formData, signal, method: 'POST' }))
+        return fetchOrchestration(`api/${root}/importEntities?${qs.stringify({ deleteEmptyValues })}`, _.merge(authOpts(), { body: formData, signal, method: 'POST' }))
       },
 
-      importFlexibleEntitiesFileSynchronous: async file => {
+      importFlexibleEntitiesFileSynchronous: async (file, deleteEmptyValues = false) => {
         const formData = new FormData()
         formData.set('entities', file)
-        const res = await fetchOrchestration(`api/${root}/flexibleImportEntities?async=false`, _.merge(authOpts(), { body: formData, signal, method: 'POST' }))
+        const res = await fetchOrchestration(`api/${root}/flexibleImportEntities?${qs.stringify({ deleteEmptyValues }, { async: false })}`, _.merge(authOpts(), { body: formData, signal, method: 'POST' }))
         return res
       },
 
-      importFlexibleEntitiesFileAsync: async file => {
+      importFlexibleEntitiesFileAsync: async (file, deleteEmptyValues = false) => {
+        console.log(deleteEmptyValues)
         const formData = new FormData()
         formData.set('entities', file)
-        const res = await fetchOrchestration(`api/${root}/flexibleImportEntities?async=true`, _.merge(authOpts(), { body: formData, signal, method: 'POST' }))
+        const res = await fetchOrchestration(`api/${root}/flexibleImportEntities?${qs.stringify({ deleteEmptyValues }, { async: true })}`, _.merge(authOpts(), { body: formData, signal, method: 'POST' }))
         return res.json()
       },
 


### PR DESCRIPTION
Permutations tested:

TSV <512k, type doesn't exist yet, no empty cells (don't show new warning, execute sync endpoint)
TSV <512k, type doesn't exist yet, empty cells (don't show new warning, execute sync endpoint)
TSV <512k, type exists, no empty cells (don't show new warning, execute sync endpoint)
TSV <512k, type exists, empty cells (show new warning, execute sync endpoint)
TSV >512k, type doesn't exist yet, no empty cells (don't show new warning, execute async endpoint)
TSV >512k, type doesn't exist yet, empty cells (don't show new warning, execute async endpoint)
TSV >512k, type exists, no empty cells (don't show new warning, execute async endpoint)
TSV >512k, type exists, empty cells (show new warning, execute async endpoint)

Also tested same permutations when checking the 'Create participant, sample, and pair associations' checkbox, which calls the old import endpoint for the FireCloud schema.

![Screen Shot 2022-04-01 at 5 10 28 PM](https://user-images.githubusercontent.com/7257391/161341700-adce5fe6-07f5-4be1-940f-b356432fa72d.png)


<!--
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Thanks!
--!>
