### PR TITLE
[WOR-230] Refactor firecloud bucket code.

### DIFF
--- a/src/components/NewWorkspaceModal.js
+++ b/src/components/NewWorkspaceModal.js
@@ -91,7 +91,7 @@ const NewWorkspaceModal = withDisplayName('NewWorkspaceModal', ({
       onSuccess(await Utils.cond(
         [cloneWorkspace, async () => {
           const workspace = await Ajax().Workspaces.workspace(cloneWorkspace.workspace.namespace, cloneWorkspace.workspace.name).clone(body)
-          const featuredList = await Ajax().Buckets.getFeaturedWorkspaces()
+          const featuredList = await Ajax().FirecloudBucket.getFeaturedWorkspaces()
           Ajax().Metrics.captureEvent(Events.workspaceClone, {
             public: cloneWorkspace.public,
             featured: _.some({ namespace: cloneWorkspace.workspace.namespace, name: cloneWorkspace.workspace.name }, featuredList),

--- a/src/components/ServiceAlerts.js
+++ b/src/components/ServiceAlerts.js
@@ -20,7 +20,7 @@ export const ServiceAlerts = () => {
   const prevAlerts = usePrevious(alerts)
 
   usePollingEffect(withErrorIgnoring(
-    async () => setAlerts(_.uniqWith(_.isEqual, await Ajax().Buckets.getServiceAlerts()))
+    async () => setAlerts(_.uniqWith(_.isEqual, await Ajax().FirecloudBucket.getServiceAlerts()))
   ), { ms: 60000, leading: true })
 
   const displayNewAlerts = async () => {

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1119,21 +1119,6 @@ const Buckets = signal => ({
     )
   },
 
-  getServiceAlerts: async () => {
-    const res = await fetchOk(`${getConfig().firecloudBucketRoot}/alerts.json`, { signal })
-    return res.json()
-  },
-
-  getFeaturedWorkspaces: async () => {
-    const res = await fetchOk(`${getConfig().firecloudBucketRoot}/featured-workspaces.json`, { signal })
-    return res.json()
-  },
-
-  getShowcaseWorkspaces: async () => {
-    const res = await fetchOk(`${getConfig().firecloudBucketRoot}/showcase.json`, { signal })
-    return res.json()
-  },
-
   listNotebooks: async (googleProject, name) => {
     const res = await fetchBuckets(
       `storage/v1/b/${name}/o?prefix=notebooks/`,
@@ -1334,6 +1319,35 @@ const Buckets = signal => ({
         return doDelete()
       }
     }
+  }
+})
+
+
+const FirecloudBucket = signal => ({
+  getServiceAlerts: async () => {
+    const res = await fetchOk(`${getConfig().firecloudBucketRoot}/alerts.json`, { signal })
+    debugger
+    return res.json()
+  },
+
+  getFeaturedWorkspaces: async () => {
+    const res = await fetchOk(`${getConfig().firecloudBucketRoot}/featured-workspaces.json`, { signal })
+    return res.json()
+  },
+
+  getShowcaseWorkspaces: async () => {
+    const res = await fetchOk(`${getConfig().firecloudBucketRoot}/showcase.json`, { signal })
+    return res.json()
+  },
+
+  getFeaturedMethods: async () => {
+    const res = await fetchOk(`${getConfig().firecloudBucketRoot}/featured-methods.json`, { signal })
+    return res.json()
+  },
+
+  getTemplateWorkspaces: async () => {
+    const res = await fetchOk(`${getConfig().firecloudBucketRoot}/template-workspaces.json`, { signal })
+    return res.json()
   }
 })
 
@@ -1695,7 +1709,8 @@ export const Ajax = signal => {
     Duos: Duos(signal),
     Metrics: Metrics(signal),
     Disks: Disks(signal),
-    CromIAM: CromIAM(signal)
+    CromIAM: CromIAM(signal),
+    FirecloudBucket: FirecloudBucket(signal)
   }
 }
 

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1326,7 +1326,6 @@ const Buckets = signal => ({
 const FirecloudBucket = signal => ({
   getServiceAlerts: async () => {
     const res = await fetchOk(`${getConfig().firecloudBucketRoot}/alerts.json`, { signal })
-    debugger
     return res.json()
   },
 

--- a/src/pages/ImportData.js
+++ b/src/pages/ImportData.js
@@ -12,7 +12,6 @@ import { useWorkspaces, WorkspaceSelector } from 'src/components/workspace-utils
 import jupyterLogo from 'src/images/jupyter-logo.svg'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
-import { getConfig } from 'src/libs/config'
 import { withErrorReporting } from 'src/libs/error'
 import Events, { extractWorkspaceDetails } from 'src/libs/events'
 import { FormLabel } from 'src/libs/forms'
@@ -122,7 +121,7 @@ const ImportData = () => {
       Utils.withBusyState(setIsImporting),
       withErrorReporting('Error loading templates')
     )(async () => {
-      setAllTemplates(await fetch(`${getConfig().firecloudBucketRoot}/template-workspaces.json`).then(res => res.json()))
+      setAllTemplates(await Ajax().FirecloudBucket.getTemplateWorkspaces())
     })
     loadTemplateWorkspaces()
   })

--- a/src/pages/library/Code.js
+++ b/src/pages/library/Code.js
@@ -96,7 +96,7 @@ const Code = () => {
       withBusyState(setLoading)
     )(async () => {
       const [newFeaturedList, newMethods] = await Promise.all([
-        fetch(`${getConfig().firecloudBucketRoot}/featured-methods.json`, { signal }).then(res => res.json()),
+        Ajax(signal).FirecloudBucket.getFeaturedMethods(),
         Ajax(signal).Methods.list({ namespace: 'gatk' })
       ])
       setFeaturedList(newFeaturedList)

--- a/src/pages/library/Showcase.js
+++ b/src/pages/library/Showcase.js
@@ -85,7 +85,7 @@ const Showcase = () => {
 
   useOnMount(() => {
     const loadData = async () => {
-      const showcase = await Ajax().Buckets.getShowcaseWorkspaces()
+      const showcase = await Ajax().FirecloudBucket.getShowcaseWorkspaces()
 
       // Immediately lowercase the workspace tags so we don't have to think about it again.
       // Also pre-compute lower name and description.

--- a/src/pages/workflows/List.js
+++ b/src/pages/workflows/List.js
@@ -11,7 +11,6 @@ import { FlexTable, HeaderCell, Sortable, TooltipCell } from 'src/components/tab
 import TopBar from 'src/components/TopBar'
 import { Ajax } from 'src/libs/ajax'
 import { getUser } from 'src/libs/auth'
-import { getConfig } from 'src/libs/config'
 import * as Nav from 'src/libs/nav'
 import { useCancellation, useOnMount } from 'src/libs/react-utils'
 import * as Utils from 'src/libs/utils'
@@ -47,7 +46,7 @@ const WorkflowList = ({ queryParams: { tab, filter = '', ...query } }) => {
     const loadWorkflows = async () => {
       const [allWorkflows, featuredList] = await Promise.all([
         Ajax(signal).Methods.definitions(),
-        fetch(`${getConfig().firecloudBucketRoot}/featured-methods.json`, { signal }).then(res => res.json())
+        Ajax(signal).FirecloudBucket.getFeaturedMethods()
       ])
 
       setWorkflows({

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -104,7 +104,7 @@ export const WorkspaceList = () => {
 
   useOnMount(() => {
     const loadFeatured = async () => {
-      setFeaturedList(await Ajax().Buckets.getFeaturedWorkspaces())
+      setFeaturedList(await Ajax().FirecloudBucket.getFeaturedWorkspaces())
     }
 
     loadFeatured()

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -85,7 +85,7 @@ const DashboardAuthContainer = props => {
 
   useEffect(() => {
     const fetchData = async () => {
-      setFeaturedWorkspaces(await Ajax().Buckets.getFeaturedWorkspaces())
+      setFeaturedWorkspaces(await Ajax().FirecloudBucket.getFeaturedWorkspaces())
     }
     if (isSignedIn === false) {
       fetchData()

--- a/src/pages/workspaces/workspace/DashboardPublic.js
+++ b/src/pages/workspaces/workspace/DashboardPublic.js
@@ -30,8 +30,7 @@ const DashboardPublic = ({ namespace, name }) => {
 
   useOnMount(() => {
     const loadData = async () => {
-      const showcaseList = await Ajax().Buckets.getShowcaseWorkspaces()
-
+      const showcaseList = await Ajax().FirecloudBucket.getShowcaseWorkspaces()
       setShowcaseList(showcaseList)
       StateHistory.update({ showcaseList })
     }

--- a/src/pages/workspaces/workspace/Workflows.js
+++ b/src/pages/workspaces/workspace/Workflows.js
@@ -11,7 +11,6 @@ import Modal from 'src/components/Modal'
 import { makeMenuIcon, MenuButton, MenuTrigger } from 'src/components/PopupTrigger'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
-import { getConfig } from 'src/libs/config'
 import { reportError, withErrorReporting } from 'src/libs/error'
 import Events, { extractWorkspaceDetails } from 'src/libs/events'
 import * as Nav from 'src/libs/nav'
@@ -170,7 +169,7 @@ const FindWorkflowModal = ({ namespace, name, ws, onDismiss }) => {
   useOnMount(() => {
     const load = async () => {
       const [featuredList, methods] = await Promise.all([
-        fetch(`${getConfig().firecloudBucketRoot}/featured-methods.json`).then(res => res.json()),
+        Ajax(signal).FirecloudBucket.getFeaturedMethods(),
         Ajax(signal).Methods.list({ namespace: 'gatk' })
       ])
 


### PR DESCRIPTION
Some Friday afternoon refactoring while I was looking over our code to understand how much depends on the Google Project ID (in preparation for Azure work).

I manually tested as many of these usages as possible… a couple were difficult to access or don't return anything meaningful in dev.

Rational: all of the other methods in “Buckets” require the Google Project ID (for the service account token), and they will not work with Azure workspaces. However, these firecloudBucketRoot methods do not require the Google Project ID.

I have moved all the firecloudBucketRoot JSON object methods into a new Ajax object, called FirecloudBucket to consolidate them and make it clearer that they do not depend on a Google Project ID.
