### PR TITLE
[SU-75] Limit width of data tab sidebar

### DIFF
--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -391,10 +391,8 @@ const DataTypeSection = ({ title, titleExtras, error, retryFunction, children })
 ])
 
 const SidebarSeparator = ({ sidebarWidth, setSidebarWidth }) => {
-  const windowWidth = useRef(window.innerWidth)
-
   const minWidth = 280
-  const getMaxWidth = useCallback(() => _.clamp(minWidth, 1200, windowWidth.current - 200), [])
+  const getMaxWidth = useCallback(() => _.clamp(minWidth, 1200, window.innerWidth - 200), [])
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const onDrag = useCallback(_.throttle(100, e => {
@@ -403,7 +401,6 @@ const SidebarSeparator = ({ sidebarWidth, setSidebarWidth }) => {
 
   useOnMount(() => {
     const onResize = _.throttle(100, () => {
-      windowWidth.current = window.innerWidth
       setSidebarWidth(_.clamp(minWidth, getMaxWidth()))
     })
     window.addEventListener('resize', onResize)

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -391,10 +391,24 @@ const DataTypeSection = ({ title, titleExtras, error, retryFunction, children })
 ])
 
 const SidebarSeparator = ({ sidebarWidth, setSidebarWidth }) => {
+  const windowWidth = useRef(window.innerWidth)
+
+  const minWidth = 280
+  const getMaxWidth = useCallback(() => _.clamp(minWidth, 1200, windowWidth.current - 200), [])
+
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const onDrag = useCallback(_.throttle(100, e => {
-    setSidebarWidth(e.pageX)
+    setSidebarWidth(_.clamp(minWidth, getMaxWidth(), e.pageX))
   }), [setSidebarWidth])
+
+  useOnMount(() => {
+    const onResize = _.throttle(100, () => {
+      windowWidth.current = window.innerWidth
+      setSidebarWidth(_.clamp(minWidth, getMaxWidth()))
+    })
+    window.addEventListener('resize', onResize)
+    return () => window.removeEventListener('resize', onResize)
+  })
 
   return h(DraggableCore, { onDrag }, [
     h(Interactive, {
@@ -402,8 +416,8 @@ const SidebarSeparator = ({ sidebarWidth, setSidebarWidth }) => {
       role: 'separator',
       'aria-label': 'Resize sidebar',
       'aria-valuenow': sidebarWidth,
-      'aria-valuemin': 0,
-      'aria-valuemax': window.innerWidth,
+      'aria-valuemin': minWidth,
+      'aria-valuemax': getMaxWidth(),
       tabIndex: 0,
       className: 'custom-focus-style',
       style: styles.sidebarSeparator,
@@ -412,9 +426,9 @@ const SidebarSeparator = ({ sidebarWidth, setSidebarWidth }) => {
       },
       onKeyDown: e => {
         if (e.key === 'ArrowRight' || e.key === 'ArrowUp') {
-          setSidebarWidth(w => w + 10)
+          setSidebarWidth(w => _.min([w + 10, getMaxWidth()]))
         } else if (e.key === 'ArrowLeft' || e.key === 'ArrowDown') {
-          setSidebarWidth(w => w - 10)
+          setSidebarWidth(w => _.max([w - 10, minWidth]))
         }
       }
     })


### PR DESCRIPTION
This limits the width of the data tab's sidebar based on the browser's window width. This ensures that part of the main content and the sidebar's drag handle are always visible. It also fulfills UX's request for the sidebar width to be limited to 1200px.

## Before
https://user-images.githubusercontent.com/1156625/161556097-e5e66616-e7d0-470e-a781-77c05a7c23da.mov

## After
https://user-images.githubusercontent.com/1156625/161556115-dd087d8c-69ec-408b-8fbb-1e32876d8aaa.mov

