### PR TITLE
[SU-81] "File Import" text on tab in the TSV import modal should fit on one line

### DIFF
--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -304,7 +304,7 @@ export const EntityUploader = ({ onSuccess, onDismiss, namespace, name, entityTy
             p(['Data will be saved in location: 🇺🇸 ', span({ style: { fontWeight: 'bold' } }, 'US '), '(Terra-managed).'])]),
         h(SimpleTabBar, {
           'aria-label': 'import type',
-          tabs: [{ title: 'File Import', key: 'file', width: 121 }, { title: 'Text Import', key: 'text', width: 127 }],
+          tabs: [{ title: 'File Import', key: 'file', width: 127 }, { title: 'Text Import', key: 'text', width: 127 }],
           value: isFileImportCurrMode ? 'file' : 'text',
           onChange: value => {
             setIsFileImportCurrMode(value === 'file')


### PR DESCRIPTION
While updating the TSV modal for https://github.com/DataBiosphere/terra-ui/pull/2928, it was bothering me that this text was split onto two lines

Before:
![Screen Shot 2022-04-04 at 11 21 12 AM](https://user-images.githubusercontent.com/7257391/161577317-15eb2086-d57d-4b12-a495-6e4ac7235870.png)

After:
![Screen Shot 2022-04-04 at 11 20 55 AM](https://user-images.githubusercontent.com/7257391/161577355-efc17812-d109-4068-94d8-583df6db727f.png)

<!--
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Thanks!
--!>
