### PR TITLE
[SUP-490] Allow billing project users to view billing project details

### DIFF
--- a/integration-tests/jest/billing-projects.integration-test.js
+++ b/integration-tests/jest/billing-projects.integration-test.js
@@ -1,5 +1,7 @@
 const { registerTest } = require('./jest-utils')
-const { testBillingSpendReport } = require('../tests/billing-projects')
+const { testBillingMembers, testBillingSpendReport, testBillingWorkspaces } = require('../tests/billing-projects')
 
 
+registerTest(testBillingMembers)
 registerTest(testBillingSpendReport)
+registerTest(testBillingWorkspaces)

--- a/integration-tests/tests/billing-projects.js
+++ b/integration-tests/tests/billing-projects.js
@@ -250,9 +250,14 @@ const testBillingMembersFn = withUserToken(async ({ page, testUrl, token }) => {
   await billingPage.visit()
   await billingPage.selectProject(ownedBillingProjectName)
   await billingPage.selectMembers()
-  // The billing project members tab should be titled "Members"
+
+  // The test user has the Owner role, so the billing project members tab should be titled "Members"
   await billingPage.assertText('Members')
+
+  // The Owner role should see the Add User button
   await billingPage.assertText('Add User')
+
+  // The test user has the Owner role, so they should see all members
   await billingPage.assertText('testuser1@example.com')
   await billingPage.assertText('testuser3@example.com')
 
@@ -260,9 +265,14 @@ const testBillingMembersFn = withUserToken(async ({ page, testUrl, token }) => {
   await billingPage.visit()
   await billingPage.selectProject(notOwnedBillingProjectName)
   await billingPage.selectOwners()
-  // The billing project members tab should be titled "Owners"
+
+  // The test user has the User role, so the billing project members tab should be titled "Owners"
   await billingPage.assertText('Owners')
+
+  // The User role should not see the Add User button
   await assertTextNotFound(billingPage, 'Add User')
+
+  // The test user has the User role, so they should see members with the Owner role, but not with the User role
   await billingPage.assertText('testuser1@example.com')
   await assertTextNotFound(billingPage, 'testuser3@example.com')
 })

--- a/integration-tests/tests/billing-projects.js
+++ b/integration-tests/tests/billing-projects.js
@@ -144,19 +144,26 @@ const setAjaxMockValues = async (testPage, ownedBillingProjectName, notOwnedBill
   }, spendReturnResult, projectListResult, ownedProjectMembersListResult, notOwnedProjectMembersListResult)
 }
 
-const testBillingSpendReportFn = withUserToken(async ({ page, testUrl, token }) => {
-  // Sign in. This portion of the test is not mocked.
-  await page.goto(testUrl)
-  await signIntoTerra(page, token)
-  await dismissNotifications(page)
+const setUpBillingTest = async (page, testUrl, token) => {
+    // Sign in. This portion of the test is not mocked.
+    await page.goto(testUrl)
+    await signIntoTerra(page, token)
+    await dismissNotifications(page)
 
-  // Interact with the Billing Page via mocked AJAX responses.
-  const ownedBillingProjectName = 'OwnedBillingProject'
-  const notOwnedBillingProjectName = 'NotOwnedBillingProject'
-  await setAjaxMockValues(page, ownedBillingProjectName, notOwnedBillingProjectName, '1110')
+    // Interact with the Billing Page via mocked AJAX responses.
+    const ownedBillingProjectName = 'OwnedBillingProject'
+    const notOwnedBillingProjectName = 'NotOwnedBillingProject'
+    await setAjaxMockValues(page, ownedBillingProjectName, notOwnedBillingProjectName, '1110')
+
+    const billingPage = billingProjectsPage(page, testUrl)
+
+    return { ownedBillingProjectName, notOwnedBillingProjectName, billingPage }
+}
+
+const testBillingSpendReportFn = withUserToken(async ({ page, testUrl, token }) => {
+  const { ownedBillingProjectName, notOwnedBillingProjectName, billingPage } = await setUpBillingTest(page, testUrl, token)
 
   // Select spend report and verify cost for default date ranges
-  const billingPage = billingProjectsPage(page, testUrl)
   await billingPage.visit()
   await billingPage.selectProject(ownedBillingProjectName)
   await billingPage.selectSpendReport()
@@ -197,17 +204,7 @@ const testBillingSpendReport = {
 }
 
 const testBillingWorkspacesFn = withUserToken(async ({ page, testUrl, token }) => {
-  // Sign in. This portion of the test is not mocked.
-  await page.goto(testUrl)
-  await signIntoTerra(page, token)
-  await dismissNotifications(page)
-
-  // Interact with the Billing Page via mocked AJAX responses.
-  const ownedBillingProjectName = 'OwnedBillingProject'
-  const notOwnedBillingProjectName = 'NotOwnedBillingProject'
-  await setAjaxMockValues(page, ownedBillingProjectName, notOwnedBillingProjectName, '0')
-
-  const billingPage = billingProjectsPage(page, testUrl)
+  const { ownedBillingProjectName, notOwnedBillingProjectName, billingPage } = await setUpBillingTest(page, testUrl, token)
 
   // Select a billing project that is owned by the user
   await billingPage.visit()
@@ -236,17 +233,7 @@ const testBillingWorkspaces = {
 }
 
 const testBillingMembersFn = withUserToken(async ({ page, testUrl, token }) => {
-  // Sign in. This portion of the test is not mocked.
-  await page.goto(testUrl)
-  await signIntoTerra(page, token)
-  await dismissNotifications(page)
-
-  // Interact with the Billing Page via mocked AJAX responses.
-  const ownedBillingProjectName = 'OwnedBillingProject'
-  const notOwnedBillingProjectName = 'NotOwnedBillingProject'
-  await setAjaxMockValues(page, ownedBillingProjectName, notOwnedBillingProjectName, '0')
-
-  const billingPage = billingProjectsPage(page, testUrl)
+  const { ownedBillingProjectName, notOwnedBillingProjectName, billingPage } = await setUpBillingTest(page, testUrl, token)
 
   // Select a billing project that is owned by the user
   await billingPage.visit()

--- a/integration-tests/tests/billing-projects.js
+++ b/integration-tests/tests/billing-projects.js
@@ -7,7 +7,7 @@ const billingProjectsPage = (testPage, testUrl) => {
   return {
     visit: async () => await testPage.goto(`${testUrl}/#billing`),
 
-    selectSpendReport: async billingProjectName => {
+    selectSpendReport: async () => {
       await click(testPage, clickable({ text: 'Spend report' }))
     },
 
@@ -123,7 +123,7 @@ const testBillingSpendReportFn = withUserToken(async ({ page, testUrl, token }) 
   const billingPage = billingProjectsPage(page, testUrl)
   await billingPage.visit()
   await billingPage.selectProject(ownedBillingProjectName)
-  await billingPage.selectSpendReport(ownedBillingProjectName)
+  await billingPage.selectSpendReport()
   // Title and cost are in different elements, but check both in same text assert to verify that category is correctly associated to its cost.
   await billingPage.assertText('Total spend$1,110.00')
   await billingPage.assertText('Total compute$999.00')

--- a/integration-tests/tests/billing-projects.js
+++ b/integration-tests/tests/billing-projects.js
@@ -145,19 +145,19 @@ const setAjaxMockValues = async (testPage, ownedBillingProjectName, notOwnedBill
 }
 
 const setUpBillingTest = async (page, testUrl, token) => {
-    // Sign in. This portion of the test is not mocked.
-    await page.goto(testUrl)
-    await signIntoTerra(page, token)
-    await dismissNotifications(page)
+  // Sign in. This portion of the test is not mocked.
+  await page.goto(testUrl)
+  await signIntoTerra(page, token)
+  await dismissNotifications(page)
 
-    // Interact with the Billing Page via mocked AJAX responses.
-    const ownedBillingProjectName = 'OwnedBillingProject'
-    const notOwnedBillingProjectName = 'NotOwnedBillingProject'
-    await setAjaxMockValues(page, ownedBillingProjectName, notOwnedBillingProjectName, '1110')
+  // Interact with the Billing Page via mocked AJAX responses.
+  const ownedBillingProjectName = 'OwnedBillingProject'
+  const notOwnedBillingProjectName = 'NotOwnedBillingProject'
+  await setAjaxMockValues(page, ownedBillingProjectName, notOwnedBillingProjectName, '1110')
 
-    const billingPage = billingProjectsPage(page, testUrl)
+  const billingPage = billingProjectsPage(page, testUrl)
 
-    return { ownedBillingProjectName, notOwnedBillingProjectName, billingPage }
+  return { ownedBillingProjectName, notOwnedBillingProjectName, billingPage }
 }
 
 const testBillingSpendReportFn = withUserToken(async ({ page, testUrl, token }) => {

--- a/integration-tests/tests/billing-projects.js
+++ b/integration-tests/tests/billing-projects.js
@@ -252,7 +252,7 @@ const testBillingMembersFn = withUserToken(async ({ page, testUrl, token }) => {
   await billingPage.selectMembers()
   // The billing project members tab should be titled "Members"
   await billingPage.assertText('Members')
-  await billingPage.assertText("Add User")
+  await billingPage.assertText('Add User')
   await billingPage.assertText('testuser1@example.com')
   await billingPage.assertText('testuser3@example.com')
 
@@ -262,9 +262,9 @@ const testBillingMembersFn = withUserToken(async ({ page, testUrl, token }) => {
   await billingPage.selectOwners()
   // The billing project members tab should be titled "Owners"
   await billingPage.assertText('Owners')
-  await assertTextNotFound(billingPage, "Add User")
+  await assertTextNotFound(billingPage, 'Add User')
   await billingPage.assertText('testuser1@example.com')
-  await assertTextNotFound(billingPage, "testuser3@example.com")
+  await assertTextNotFound(billingPage, 'testuser3@example.com')
 })
 
 const testBillingMembers = {

--- a/integration-tests/tests/billing-projects.js
+++ b/integration-tests/tests/billing-projects.js
@@ -1,5 +1,5 @@
 const _ = require('lodash/fp')
-const { click, clickable, dismissNotifications, findText, noSpinnersAfter, select, signIntoTerra } = require('../utils/integration-utils')
+const { assertTextNotFound, click, clickable, dismissNotifications, findText, noSpinnersAfter, select, signIntoTerra } = require('../utils/integration-utils')
 const { withUserToken } = require('../utils/terra-sa-utils')
 
 
@@ -151,8 +151,8 @@ const testBillingSpendReportFn = withUserToken(async ({ page, testUrl, token }) 
   await billingPage.visit()
   await billingPage.selectProject(notOwnedBillingProjectName)
 
-  //Check that the Spend report tab is not visible in this case
-  await billingPage.assertText("Spend report")
+  //Check that the Spend report tab is not visible on this page
+  await assertTextNotFound(billingPage, 'Spend report')
 })
 
 const testBillingSpendReport = {

--- a/integration-tests/tests/billing-projects.js
+++ b/integration-tests/tests/billing-projects.js
@@ -30,6 +30,8 @@ const billingProjectsPage = (testPage, testUrl) => {
 
     assertText: async expectedText => await findText(testPage, expectedText),
 
+    assertTextNotFound: async unexpectedText => await assertTextNotFound(testPage, unexpectedText),
+
     assertChartValue: async (number, workspaceName, category, cost) => {
       // This checks the accessible text for chart values.
       await testPage.waitForXPath(`(//*[@role="img"])[contains(@aria-label,"${number}. Workspace ${workspaceName}, ${category}: ${cost}.")]`)
@@ -186,7 +188,7 @@ const testBillingSpendReportFn = withUserToken(async ({ page, testUrl, token }) 
   await billingPage.selectProject(notOwnedBillingProjectName)
 
   //Check that the Spend report tab is not visible on this page
-  await assertTextNotFound(billingPage, 'Spend report')
+  await billingPage.assertTextNotFound('Spend report')
 })
 
 const testBillingSpendReport = {
@@ -270,11 +272,11 @@ const testBillingMembersFn = withUserToken(async ({ page, testUrl, token }) => {
   await billingPage.assertText('Owners')
 
   // The User role should not see the Add User button
-  await assertTextNotFound(billingPage, 'Add User')
+  await billingPage.assertTextNotFound('Add User')
 
   // The test user has the User role, so they should see members with the Owner role, but not with the User role
   await billingPage.assertText('testuser1@example.com')
-  await assertTextNotFound(billingPage, 'testuser3@example.com')
+  await billingPage.assertTextNotFound('testuser3@example.com')
 })
 
 const testBillingMembers = {

--- a/integration-tests/tests/billing-projects.js
+++ b/integration-tests/tests/billing-projects.js
@@ -78,6 +78,10 @@ const setAjaxMockValues = async (testPage, ownedBillingProjectName, spendCost, n
   const projectListResult = [{
     projectName: ownedBillingProjectName,
     billingAccount: 'billingAccounts/fake-id', invalidBillingAccount: false, roles: ['Owner'], status: 'Ready'
+  },
+  {
+    projectName: notOwnedBillingProjectName,
+    billingAccount: 'billingAccounts/fake-id', invalidBillingAccount: false, roles: ['User'], status: 'Ready'
   }]
   return await testPage.evaluate((spendReturnResult, projectListResult) => {
     window.ajaxOverridesStore.set([
@@ -108,13 +112,14 @@ const testBillingSpendReportFn = withUserToken(async ({ page, testUrl, token }) 
   await dismissNotifications(page)
 
   // Interact with the Billing Page via mocked AJAX responses.
-  const billingProjectName = 'OwnedBillingProject'
-  await setAjaxMockValues(page, billingProjectName, '1110')
+  const ownedBillingProjectName = 'OwnedBillingProject'
+  const notOwnedBillingProjectName = 'NotOwnedBillingProject'
+  await setAjaxMockValues(page, ownedBillingProjectName, notOwnedBillingProjectName, '1110')
 
   // Select spend report and verify cost for default date ranges
   const billingPage = billingProjectsPage(page, testUrl)
   await billingPage.visit()
-  await billingPage.selectSpendReport(billingProjectName)
+  await billingPage.selectSpendReport(ownedBillingProjectName)
   // Title and cost are in different elements, but check both in same text assert to verify that category is correctly associated to its cost.
   await billingPage.assertText('Total spend$1,110.00')
   await billingPage.assertText('Total compute$999.00')
@@ -131,7 +136,7 @@ const testBillingSpendReportFn = withUserToken(async ({ page, testUrl, token }) 
   await billingPage.assertChartValue(3, 'Third Most Expensive Workspace', 'Storage', '$0.00')
 
   // Change the returned mock cost to mimic different date ranges.
-  await setAjaxMockValues(page, billingProjectName, '1110.17', 20)
+  await setAjaxMockValues(page, ownedBillingProjectName, '1110.17', 20)
   await billingPage.setSpendReportDays(90)
   await billingPage.assertText('Total spend$1,110.17')
   // Check that title updated to reflect truncation.

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -96,7 +96,7 @@ const assertTextNotFound = async (page, text) => {
     found = true
   } catch (e) {}
   if (found) {
-    throw new Error('The specified text was found on the page, but it was not expected')
+    throw new Error(`The specified text ${text} was found on the page, but it was not expected`)
   }
 }
 

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -89,6 +89,17 @@ const findText = (page, textContains, options) => {
   return page.waitForXPath(`//*[contains(normalize-space(.),"${textContains}")]`, options)
 }
 
+const assertTextNotFound = async (page, text) => {
+  let found = false
+  try {
+    await page.assertText(text)
+    found = true
+  } catch (e) {}
+  if (found) {
+    throw new Error('The specified text was found on the page, but it was not expected')
+  }
+}
+
 const input = ({ labelContains, placeholder }) => {
   const base = '(//input | //textarea)'
   if (labelContains) {
@@ -271,6 +282,7 @@ const withPageLogging = fn => options => {
 }
 
 module.exports = {
+  assertTextNotFound,
   checkbox,
   click,
   clickable,

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -92,7 +92,7 @@ const findText = (page, textContains, options) => {
 const assertTextNotFound = async (page, text) => {
   let found = false
   try {
-    await page.assertText(text)
+    await findText(page, text, { timeout: 5 * 1000 })
     found = true
   } catch (e) {}
   if (found) {

--- a/src/components/group-common.js
+++ b/src/components/group-common.js
@@ -77,7 +77,7 @@ export const MemberCardHeaders = memoWithName('MemberCardHeaders', ({ sort, onSo
   ])
 })
 
-export const MemberCard = memoWithName('MemberCard', ({ member: { email, roles }, adminCanEdit, onEdit, onDelete, adminLabel, userLabel }) => {
+export const MemberCard = memoWithName('MemberCard', ({ member: { email, roles }, adminCanEdit, onEdit, onDelete, adminLabel, userLabel, isOwner }) => {
   const canEdit = adminCanEdit || !_.includes(adminLabel, roles)
   const tooltip = !canEdit && `This user is the only ${adminLabel}`
 
@@ -87,7 +87,7 @@ export const MemberCard = memoWithName('MemberCard', ({ member: { email, roles }
   }, [
     div({ role: 'rowheader', style: { flex: '1', whiteSpace: 'nowrap', textOverflow: 'ellipsis', overflow: 'hidden', height: '1rem' } }, [email]),
     div({ role: 'cell', style: { flex: '1', textTransform: 'capitalize', height: '1rem' } }, [_.includes(adminLabel, roles) ? adminLabel : userLabel]),
-    div({ role: 'cell', style: { flex: 'none' } }, [
+    isOwner && div({ role: 'cell', style: { flex: 'none' } }, [
       h(MenuTrigger, {
         side: 'left',
         style: { height: menuCardSize, width: menuCardSize },

--- a/src/pages/billing/List.js
+++ b/src/pages/billing/List.js
@@ -306,6 +306,8 @@ export const BillingList = ({ queryParams: { selectedName } }) => {
     billingProjects
   )
 
+  console.log(projectsOwned)
+
   return h(FooterWrapper, { fixedHeight: true }, [
     h(TopBar, { title: 'Billing' }, [
       !!selectedName && div({ style: Style.breadcrumb.breadcrumb }, [
@@ -387,7 +389,7 @@ export const BillingList = ({ queryParams: { selectedName } }) => {
             authorizeAndLoadAccounts: authorizeAccounts,
             reloadBillingProject: () => reloadBillingProject(billingProject).catch(loadProjects),
             isAlphaSpendReportUser,
-            isOwner: true
+            isOwner: _.find({ projectName: selectedName }, projectsOwned)
           })
         }],
         [!_.isEmpty(projectsOwned) && !selectedName, () => {

--- a/src/pages/billing/List.js
+++ b/src/pages/billing/List.js
@@ -306,8 +306,6 @@ export const BillingList = ({ queryParams: { selectedName } }) => {
     billingProjects
   )
 
-  console.log(projectsOwned)
-
   return h(FooterWrapper, { fixedHeight: true }, [
     h(TopBar, { title: 'Billing' }, [
       !!selectedName && div({ style: Style.breadcrumb.breadcrumb }, [

--- a/src/pages/billing/List.js
+++ b/src/pages/billing/List.js
@@ -67,8 +67,10 @@ const ProjectListItem = ({ project, project: { roles, status }, isActive }) => {
     ])
   }
 
+  const viewerRoles = _.intersection(roles, _.values(billingRoles))
+
   return div({ role: 'listitem' }, [
-    (_.includes(billingRoles.user, roles) || _.includes(billingRoles.owner, roles)) && status === 'Ready' ?
+    !_.isEmpty(viewerRoles) && status === 'Ready' ?
       selectableProject(project, isActive) :
       unselectableProject(project, isActive)
   ])

--- a/src/pages/billing/List.js
+++ b/src/pages/billing/List.js
@@ -68,7 +68,7 @@ const ProjectListItem = ({ project, project: { roles, status }, isActive }) => {
   }
 
   return div({ role: 'listitem' }, [
-    _.includes(billingRoles.user, roles) || _.includes(billingRoles.owner, roles) && status === 'Ready' ?
+    (_.includes(billingRoles.user, roles) || _.includes(billingRoles.owner, roles)) && status === 'Ready' ?
       selectableProject(project, isActive) :
       unselectableProject(project, isActive)
   ])
@@ -387,7 +387,7 @@ export const BillingList = ({ queryParams: { selectedName } }) => {
             authorizeAndLoadAccounts: authorizeAccounts,
             reloadBillingProject: () => reloadBillingProject(billingProject).catch(loadProjects),
             isAlphaSpendReportUser,
-            isOwner: _.includes(billingRoles.owner, roles)
+            isOwner: true
           })
         }],
         [!_.isEmpty(projectsOwned) && !selectedName, () => {

--- a/src/pages/billing/List.js
+++ b/src/pages/billing/List.js
@@ -68,7 +68,7 @@ const ProjectListItem = ({ project, project: { roles, status }, isActive }) => {
   }
 
   return div({ role: 'listitem' }, [
-    _.includes(billingRoles.owner, roles) && status === 'Ready' ?
+    _.includes(billingRoles.user, roles) || _.includes(billingRoles.owner, roles) && status === 'Ready' ?
       selectableProject(project, isActive) :
       unselectableProject(project, isActive)
   ])
@@ -378,7 +378,7 @@ export const BillingList = ({ queryParams: { selectedName } }) => {
               p(['It may not exist, or you may not have access to it.'])
             ])
           ])],
-        [selectedName && _.some({ projectName: selectedName }, projectsOwned), () => {
+        [selectedName && _.some({ projectName: selectedName }, billingProjects), () => {
           const billingProject = _.find({ projectName: selectedName }, billingProjects)
           return h(ProjectDetail, {
             key: selectedName,
@@ -386,7 +386,8 @@ export const BillingList = ({ queryParams: { selectedName } }) => {
             billingAccounts,
             authorizeAndLoadAccounts: authorizeAccounts,
             reloadBillingProject: () => reloadBillingProject(billingProject).catch(loadProjects),
-            isAlphaSpendReportUser
+            isAlphaSpendReportUser,
+            isOwner: _.includes(billingRoles.owner, roles)
           })
         }],
         [!_.isEmpty(projectsOwned) && !selectedName, () => {

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -212,7 +212,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
   const [selectedBilling, setSelectedBilling] = useState()
   const [selectedDatasetProjectName, setSelectedDatasetProjectName] = useState(null)
   const [selectedDatasetName, setSelectedDatasetName] = useState(null)
-  const [tab, setTab] = useState(query.tab || 'workspaces')
+  const [tab, setTab] = useState(query.tab || 'workspace')
   const [expandedWorkspaceName, setExpandedWorkspaceName] = useState()
   const [sort, setSort] = useState({ field: 'email', direction: 'asc' })
   const [workspaceSort, setWorkspaceSort] = useState({ field: 'name', direction: 'asc' })
@@ -226,6 +226,8 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
   const signal = useCancellation()
 
   const adminCanEdit = _.filter(({ roles }) => _.includes(billingRoles.owner, roles), projectUsers).length > 1
+
+  console.log(projectUsers)
 
   const workspacesInProject = useMemo(() => _.filter(
     { namespace: billingProject.projectName },
@@ -300,7 +302,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
   const getBillingAccountStatus = workspace => _.findKey(g => g.has(workspace), groups)
 
   const tabToTable = {
-    workspaces: h(Fragment, [
+    workspaces: adminCanEdit && h(Fragment, [
       h(WorkspaceCardHeaders, {
         needsStatusColumn: billingAccountsOutOfDate,
         sort: workspaceSort,
@@ -344,7 +346,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
         )
       ])
     ]),
-    [spendReportKey]: div({ style: { display: 'grid', rowGap: '1.25rem' } }, [
+    [spendReportKey]: adminCanEdit && div({ style: { display: 'grid', rowGap: '1.25rem' } }, [
       div({ style: { display: 'grid', gridTemplateColumns: 'repeat(4, minmax(max-content, 1fr))', rowGap: '1.25rem', columnGap: '1.25rem' } },
         _.concat(
           div({ style: { gridRowStart: 1, gridColumnStart: 1 } }, [
@@ -527,10 +529,10 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
   return h(Fragment, [
     div({ style: { padding: '1.5rem 0 0', flexGrow: 1, display: 'flex', flexDirection: 'column' } }, [
       div({ style: { color: colors.dark(), fontSize: 18, fontWeight: 600, display: 'flex', alignItems: 'center', marginLeft: '1rem' } }, [billingProject.projectName]),
-      div({ style: { color: colors.dark(), fontSize: 14, display: 'flex', alignItems: 'center', marginTop: '0.5rem', marginLeft: '1rem' } }, [
+       div({ style: { color: colors.dark(), fontSize: 14, display: 'flex', alignItems: 'center', marginTop: '0.5rem', marginLeft: '1rem' } }, [
         !!displayName && span({ style: { flexShrink: 0, fontWeight: 600, fontSize: 14, margin: '0 0.75rem 0 0' } }, 'Billing Account:'),
         !!displayName && span({ style: { flexShrink: 0 } }, displayName),
-        h(Link, {
+        adminCanEdit && h(Link, {
           tooltip: 'Change Billing Account',
           style: { marginLeft: '0.5rem' },
           onClick: async () => {
@@ -542,7 +544,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
             }
           }
         }, [icon('edit', { size: 12 })]),
-        h(Link, {
+        adminCanEdit && h(Link, {
           tooltip: 'Remove Billing Account',
           style: { marginLeft: '0.5rem' },
           // (CA-1586) For some reason the api sometimes returns string null, and sometimes returns no field, and sometimes returns null. This is just to be complete.
@@ -595,7 +597,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
             ['Are you sure you want to remove this billing project\'s billing account?'])
         ])
       ]),
-      div({ style: { color: colors.dark(), fontSize: 14, display: 'flex', alignItems: 'center', margin: '0.5rem 0 0 1rem' } }, [
+      adminCanEdit && div({ style: { color: colors.dark(), fontSize: 14, display: 'flex', alignItems: 'center', margin: '0.5rem 0 0 1rem' } }, [
         span({ style: { flexShrink: 0, fontWeight: 600, fontSize: 14, marginRight: '0.75rem' } }, 'Workflow Spend Report Configuration:'),
         span({ style: { flexShrink: 0 } }, 'Edit'),
         h(Link, {

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -388,7 +388,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
   useEffect(() => {
     // Note: setting undefined so that falsy values don't show up at all
     const newSearch = qs.stringify({
-      ...query, tab: tab === tabs[0].key ? undefined : (tab === 'owners' ? 'members' : tab)
+      ...query, tab: tab === tabs[0].key ? undefined : (tab === 'owners' ? 'members' : tab) //this doesn't quite work, actually
     }, { addQueryPrefix: true })
 
     if (newSearch !== Nav.history.location.search) {

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -322,7 +322,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
         )(workspacesInProject)
       ])
     ]),
-    users: h(Fragment, [
+    members: h(Fragment, [
       isOwner && h(NewUserCard, {
         onClick: () => setAddingUser(true)
       }, [

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -225,7 +225,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
 
   const signal = useCancellation()
 
-  const adminCanEdit = _.filter(({ roles }) => _.includes(billingRoles.owner, roles), projectUsers).length > 1
+  const projectHasMultipleOwners = _.filter(({ roles }) => _.includes(billingRoles.owner, roles), projectUsers).length > 1
 
   const workspacesInProject = useMemo(() => _.filter(
     { namespace: billingProject.projectName },
@@ -337,9 +337,10 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
             adminLabel: billingRoles.owner,
             userLabel: billingRoles.user,
             member,
-            adminCanEdit: (adminCanEdit && isOwner),
+            adminCanEdit: (projectHasMultipleOwners && isOwner),
             onEdit: () => setEditingUser(member),
-            onDelete: () => setDeletingUser(member)
+            onDelete: () => setDeletingUser(member),
+            isOwner
           })
         }, _.orderBy([sort.field], [sort.direction], projectUsers))
         )

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -212,7 +212,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
   const [selectedBilling, setSelectedBilling] = useState()
   const [selectedDatasetProjectName, setSelectedDatasetProjectName] = useState(null)
   const [selectedDatasetName, setSelectedDatasetName] = useState(null)
-  const [tab, setTab] = useState(query.tab || 'workspace')
+  const [tab, setTab] = useState(query.tab || 'workspaces')
   const [expandedWorkspaceName, setExpandedWorkspaceName] = useState()
   const [sort, setSort] = useState({ field: 'email', direction: 'asc' })
   const [workspaceSort, setWorkspaceSort] = useState({ field: 'name', direction: 'asc' })
@@ -226,8 +226,6 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
   const signal = useCancellation()
 
   const adminCanEdit = _.filter(({ roles }) => _.includes(billingRoles.owner, roles), projectUsers).length > 1
-
-  console.log(projectUsers)
 
   const workspacesInProject = useMemo(() => _.filter(
     { namespace: billingProject.projectName },
@@ -338,7 +336,8 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
             key: member.email,
             adminLabel: billingRoles.owner,
             userLabel: billingRoles.user,
-            member, adminCanEdit,
+            member,
+            adminCanEdit: (adminCanEdit && isOwner),
             onEdit: () => setEditingUser(member),
             onDelete: () => setDeletingUser(member)
           })

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -227,8 +227,6 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
 
   const projectHasMultipleOwners = _.filter(({ roles }) => _.includes(billingRoles.owner, roles), projectUsers).length > 1
 
-  const membersKey = isOwner ? 'members' : 'owners'
-
   const workspacesInProject = useMemo(() => _.filter(
     { namespace: billingProject.projectName },
     _.map('workspace', workspaces)
@@ -324,7 +322,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
         )(workspacesInProject)
       ])
     ]),
-    [membersKey]: h(Fragment, [
+    members: h(Fragment, [
       isOwner && h(NewUserCard, {
         onClick: () => setAddingUser(true)
       }, [
@@ -381,7 +379,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
   const tabs = _.map(key => ({
     key,
     title: span({ style: { padding: '0 0.5rem' } }, [
-      _.capitalize(key)
+      _.capitalize(key === 'members' && !isOwner ? 'owners' : key) // Rewrite the 'Members' tab to say 'Owners' if the user has the User role
     ]),
     tableName: _.lowerCase(key)
   }), _.filter(key => (key !== spendReportKey || (isAlphaSpendReportUser && isOwner)), _.keys(tabToTable)))

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -382,7 +382,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
       _.capitalize(key)
     ]),
     tableName: _.lowerCase(key)
-  }), _.filter(key => (key !== spendReportKey || isAlphaSpendReportUser), _.keys(tabToTable)))
+  }), _.filter(key => (key !== spendReportKey || (isAlphaSpendReportUser && isOwner)), _.keys(tabToTable)))
   useEffect(() => {
     // Note: setting undefined so that falsy values don't show up at all
     const newSearch = qs.stringify({

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -227,6 +227,8 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
 
   const projectHasMultipleOwners = _.filter(({ roles }) => _.includes(billingRoles.owner, roles), projectUsers).length > 1
 
+  const membersKey = isOwner ? 'members' : 'owners'
+
   const workspacesInProject = useMemo(() => _.filter(
     { namespace: billingProject.projectName },
     _.map('workspace', workspaces)
@@ -322,7 +324,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
         )(workspacesInProject)
       ])
     ]),
-    members: h(Fragment, [
+    [membersKey]: h(Fragment, [
       isOwner && h(NewUserCard, {
         onClick: () => setAddingUser(true)
       }, [
@@ -386,7 +388,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
   useEffect(() => {
     // Note: setting undefined so that falsy values don't show up at all
     const newSearch = qs.stringify({
-      ...query, tab: tab === tabs[0].key ? undefined : tab
+      ...query, tab: tab === tabs[0].key ? undefined : (tab === 'owners' ? 'members' : tab)
     }, { addQueryPrefix: true })
 
     if (newSearch !== Nav.history.location.search) {

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -325,7 +325,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
       ])
     ]),
     users: h(Fragment, [
-      adminCanEdit && h(NewUserCard, {
+      isOwner && h(NewUserCard, {
         onClick: () => setAddingUser(true)
       }, [
         icon('plus-circle', { size: 14 }),
@@ -346,7 +346,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
         )
       ])
     ]),
-    [spendReportKey]: adminCanEdit && div({ style: { display: 'grid', rowGap: '1.25rem' } }, [
+    [spendReportKey]: div({ style: { display: 'grid', rowGap: '1.25rem' } }, [
       div({ style: { display: 'grid', gridTemplateColumns: 'repeat(4, minmax(max-content, 1fr))', rowGap: '1.25rem', columnGap: '1.25rem' } },
         _.concat(
           div({ style: { gridRowStart: 1, gridColumnStart: 1 } }, [
@@ -532,7 +532,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
       div({ style: { color: colors.dark(), fontSize: 14, display: 'flex', alignItems: 'center', marginTop: '0.5rem', marginLeft: '1rem' } }, [
         !!displayName && span({ style: { flexShrink: 0, fontWeight: 600, fontSize: 14, margin: '0 0.75rem 0 0' } }, 'Billing Account:'),
         !!displayName && span({ style: { flexShrink: 0 } }, displayName),
-        adminCanEdit && h(Link, {
+        isOwner && h(Link, {
           tooltip: 'Change Billing Account',
           style: { marginLeft: '0.5rem' },
           onClick: async () => {
@@ -544,7 +544,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
             }
           }
         }, [icon('edit', { size: 12 })]),
-        adminCanEdit && h(Link, {
+        isOwner && h(Link, {
           tooltip: 'Remove Billing Account',
           style: { marginLeft: '0.5rem' },
           // (CA-1586) For some reason the api sometimes returns string null, and sometimes returns no field, and sometimes returns null. This is just to be complete.
@@ -597,7 +597,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
             ['Are you sure you want to remove this billing project\'s billing account?'])
         ])
       ]),
-      adminCanEdit && div({ style: { color: colors.dark(), fontSize: 14, display: 'flex', alignItems: 'center', margin: '0.5rem 0 0 1rem' } }, [
+      isOwner && div({ style: { color: colors.dark(), fontSize: 14, display: 'flex', alignItems: 'center', margin: '0.5rem 0 0 1rem' } }, [
         span({ style: { flexShrink: 0, fontWeight: 600, fontSize: 14, marginRight: '0.75rem' } }, 'Workflow Spend Report Configuration:'),
         span({ style: { flexShrink: 0 } }, 'Edit'),
         h(Link, {

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -388,7 +388,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
   useEffect(() => {
     // Note: setting undefined so that falsy values don't show up at all
     const newSearch = qs.stringify({
-      ...query, tab: tab === tabs[0].key ? undefined : (tab === 'owners' ? 'members' : tab) //this doesn't quite work, actually
+      ...query, tab: tab === tabs[0].key ? undefined : tab
     }, { addQueryPrefix: true })
 
     if (newSearch !== Nav.history.location.search) {

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -195,7 +195,7 @@ const LazyChart = lazy(() => import('src/components/Chart'))
 const maxWorkspacesInChart = 10
 const spendReportKey = 'spend report'
 
-const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProject, isAlphaSpendReportUser, reloadBillingProject }) => {
+const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProject, isAlphaSpendReportUser, isOwner, reloadBillingProject }) => {
   // State
   const { query } = Nav.useRoute()
   // Rather than using a localized StateHistory store here, we use the existing `workspaceStore` value (via the `useWorkspaces` hook)
@@ -302,7 +302,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
   const getBillingAccountStatus = workspace => _.findKey(g => g.has(workspace), groups)
 
   const tabToTable = {
-    workspaces: adminCanEdit && h(Fragment, [
+    workspaces: h(Fragment, [
       h(WorkspaceCardHeaders, {
         needsStatusColumn: billingAccountsOutOfDate,
         sort: workspaceSort,
@@ -325,7 +325,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
       ])
     ]),
     users: h(Fragment, [
-      h(NewUserCard, {
+      adminCanEdit && h(NewUserCard, {
         onClick: () => setAddingUser(true)
       }, [
         icon('plus-circle', { size: 14 }),
@@ -529,7 +529,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
   return h(Fragment, [
     div({ style: { padding: '1.5rem 0 0', flexGrow: 1, display: 'flex', flexDirection: 'column' } }, [
       div({ style: { color: colors.dark(), fontSize: 18, fontWeight: 600, display: 'flex', alignItems: 'center', marginLeft: '1rem' } }, [billingProject.projectName]),
-       div({ style: { color: colors.dark(), fontSize: 14, display: 'flex', alignItems: 'center', marginTop: '0.5rem', marginLeft: '1rem' } }, [
+      div({ style: { color: colors.dark(), fontSize: 14, display: 'flex', alignItems: 'center', marginTop: '0.5rem', marginLeft: '1rem' } }, [
         !!displayName && span({ style: { flexShrink: 0, fontWeight: 600, fontSize: 14, margin: '0 0.75rem 0 0' } }, 'Billing Account:'),
         !!displayName && span({ style: { flexShrink: 0 } }, displayName),
         adminCanEdit && h(Link, {

--- a/src/pages/groups/Group.js
+++ b/src/pages/groups/Group.js
@@ -113,7 +113,8 @@ const GroupDetails = ({ groupName }) => {
                 userLabel: 'member',
                 member, adminCanEdit,
                 onEdit: () => setEditingUser(member),
-                onDelete: () => setDeletingUser(member)
+                onDelete: () => setDeletingUser(member),
+                isOwner: true
               })
             }, _.orderBy([sort.field], [sort.direction], _.filter(({ email }) => Utils.textMatch(filter, email), members)))
           )


### PR DESCRIPTION
Users can now click on a billing project and see certain details, including the billing account associated with the project, the workspaces that they have access to within the project, and the owners of the project (per these changes [sam](https://github.com/broadinstitute/sam/pull/594), [rawls](https://github.com/broadinstitute/rawls/pull/1676).)


<!--
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Thanks!
--!>
