### PR TITLE
[IA-3301] Update yarn config after IGV downgrade

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -68,7 +68,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["html-webpack-plugin", "virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#npm:5.5.0"],\
             ["husky", "npm:7.0.2"],\
             ["iframe-resizer", "npm:4.3.2"],\
-            ["igv", "npm:2.11.2"],\
+            ["igv", "npm:2.3.5"],\
             ["jszip", "npm:3.7.1"],\
             ["lodash", "npm:4.17.21"],\
             ["marked", "npm:4.0.10"],\
@@ -10967,10 +10967,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]\
       ]],\
       ["igv", [\
-        ["npm:2.11.2", {\
-          "packageLocation": "./.yarn/cache/igv-npm-2.11.2-ecb88934b3-d389340bf6.zip/node_modules/igv/",\
+        ["npm:2.3.5", {\
+          "packageLocation": "./.yarn/cache/igv-npm-2.3.5-cb11a352d2-529591bd68.zip/node_modules/igv/",\
           "packageDependencies": [\
-            ["igv", "npm:2.11.2"]\
+            ["igv", "npm:2.3.5"]\
           ],\
           "linkType": "HARD"\
         }]\
@@ -18839,7 +18839,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["html-webpack-plugin", "virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#npm:5.5.0"],\
             ["husky", "npm:7.0.2"],\
             ["iframe-resizer", "npm:4.3.2"],\
-            ["igv", "npm:2.11.2"],\
+            ["igv", "npm:2.3.5"],\
             ["jszip", "npm:3.7.1"],\
             ["lodash", "npm:4.17.21"],\
             ["marked", "npm:4.0.10"],\


### PR DESCRIPTION
Related to #2932

Currently, `yarn start` throws an error:

```
ERROR in ./src/components/IGVBrowser.js 127:23-36
Module not found: Error: Can't resolve 'igv' in '/Users/nwatts/workspace/terra-ui/src/components'
resolve 'igv' in '/Users/nwatts/workspace/terra-ui/src/components'
  Parsed request is a module
  using description file: /Users/nwatts/workspace/terra-ui/package.json (relative path: ./src/components)
    Field 'browser' doesn't contain a valid alias configuration
    resolve as module
      resolved by pnp to /Users/nwatts/workspace/terra-ui/.yarn/cache/igv-npm-2.11.2-ecb88934b3-d389340bf6.zip/node_modules/igv/
        using description file: /Users/nwatts/workspace/terra-ui/package.json (relative path: ./.yarn/cache/igv-npm-2.11.2-ecb88934b3-d389340bf6.zip/node_modules/igv/)
          using description file: /Users/nwatts/workspace/terra-ui/package.json (relative path: ./.yarn/cache/igv-npm-2.11.2-ecb88934b3-d389340bf6.zip/node_modules/igv)
            no extension
              Field 'browser' doesn't contain a valid alias configuration
              /Users/nwatts/workspace/terra-ui/.yarn/cache/igv-npm-2.11.2-ecb88934b3-d389340bf6.zip/node_modules/igv doesn't exist
            .web.mjs
              Field 'browser' doesn't contain a valid alias configuration
              /Users/nwatts/workspace/terra-ui/.yarn/cache/igv-npm-2.11.2-ecb88934b3-d389340bf6.zip/node_modules/igv.web.mjs doesn't exist
            .mjs
              Field 'browser' doesn't contain a valid alias configuration
              /Users/nwatts/workspace/terra-ui/.yarn/cache/igv-npm-2.11.2-ecb88934b3-d389340bf6.zip/node_modules/igv.mjs doesn't exist
            .web.js
              Field 'browser' doesn't contain a valid alias configuration
              /Users/nwatts/workspace/terra-ui/.yarn/cache/igv-npm-2.11.2-ecb88934b3-d389340bf6.zip/node_modules/igv.web.js doesn't exist
            .js
              Field 'browser' doesn't contain a valid alias configuration
              /Users/nwatts/workspace/terra-ui/.yarn/cache/igv-npm-2.11.2-ecb88934b3-d389340bf6.zip/node_modules/igv.js doesn't exist
            .json
              Field 'browser' doesn't contain a valid alias configuration
              /Users/nwatts/workspace/terra-ui/.yarn/cache/igv-npm-2.11.2-ecb88934b3-d389340bf6.zip/node_modules/igv.json doesn't exist
            .web.jsx
              Field 'browser' doesn't contain a valid alias configuration
              /Users/nwatts/workspace/terra-ui/.yarn/cache/igv-npm-2.11.2-ecb88934b3-d389340bf6.zip/node_modules/igv.web.jsx doesn't exist
            .jsx
              Field 'browser' doesn't contain a valid alias configuration
              /Users/nwatts/workspace/terra-ui/.yarn/cache/igv-npm-2.11.2-ecb88934b3-d389340bf6.zip/node_modules/igv.jsx doesn't exist
            as directory
              /Users/nwatts/workspace/terra-ui/.yarn/cache/igv-npm-2.11.2-ecb88934b3-d389340bf6.zip/node_modules/igv doesn't exist
 @ ./src/components/data/EntitiesContent.js 25:0-51 701:22-32
 @ ./src/pages/workspaces/workspace/Data.js 31:0-66 287:13-28 1593:13-28
 @ ./src/libs/routes.js 36:0-60 46:203-216
 @ ./src/pages/Main.js 3:0-25
 @ ./src/appLoader.js 10:0-34 19:18-22
 @ ./src/index.js 25:12-35

webpack 5.70.0 compiled with 1 error in 329 ms
```

Running `yarn` makes these changes to `.pnp.cjs`, after which `yarn start` runs without errors.