### PR TITLE
[SU-41] Display notice in Notebooks tab when notebooks are actively being copied over

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1029,6 +1029,11 @@ const Workspaces = signal => ({
       bucketUsage: async () => {
         const res = await fetchRawls(`${root}/bucketUsage`, _.merge(authOpts(), { signal }))
         return res.json()
+      },
+
+      listFileTransfers: async () => {
+        const res = await fetchRawls(`${root}/fileTransfers`, _.merge(authOpts(), { signal }))
+        return res.json()
       }
     }
   }

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1031,7 +1031,7 @@ const Workspaces = signal => ({
         return res.json()
       },
 
-      listFileTransfers: async () => {
+      listActiveFileTransfers: async () => {
         const res = await fetchRawls(`${root}/fileTransfers`, _.merge(authOpts(), { signal }))
         return res.json()
       }

--- a/src/pages/workspaces/workspace/Analyses.js
+++ b/src/pages/workspaces/workspace/Analyses.js
@@ -344,7 +344,7 @@ const Analyses = _.flow(
       { backgroundColor: colors.warning(0.15), flexDirection: 'none', justifyContent: 'start', alignItems: 'center' })
   }, [
     icon('warning-standard', { size: 19, style: { color: colors.warning(), flex: 'none', marginRight: '1rem' } }),
-    'Copying 1 or more analysis files from another workspace.',
+    'Copying 1 or more interactive analysis files from another workspace.',
     span({ style: { fontWeight: 'bold', marginLeft: '0.5ch' } }, ['This may take a few minutes.'])
   ])
 

--- a/src/pages/workspaces/workspace/Analyses.js
+++ b/src/pages/workspaces/workspace/Analyses.js
@@ -344,7 +344,7 @@ const Analyses = _.flow(
       { backgroundColor: colors.warning(0.15), flexDirection: 'none', justifyContent: 'start', alignItems: 'center' })
   }, [
     icon('warning-standard', { size: 19, style: { color: colors.warning(), flex: 'none', marginRight: '1rem' } }),
-    'Copying 1 or more notebooks from another workspace.',
+    'Copying 1 or more analysis files from another workspace.',
     span({ style: { fontWeight: 'bold', marginLeft: '0.5ch' } }, ['This may take a few minutes.'])
   ])
 

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -69,7 +69,7 @@ const noNotebooksMessage = div({ style: { fontSize: 20 } }, [
   div([
     'To get started, click ', span({ style: { fontWeight: 600 } }, ['Create a New Notebook'])
   ]),
-  div({ style: { marginTop: '1rem', fontSize: 16 } }, [
+  div({ style: { margin: '1rem 0 1rem 0', fontSize: 16 } }, [
     h(Link, {
       ...Utils.newTabLinkProps,
       href: `https://support.terra.bio/hc/en-us/sections/360004143932`
@@ -77,11 +77,13 @@ const noNotebooksMessage = div({ style: { fontSize: 20 } }, [
   ])
 ])
 
-const activeFileTransferMessage = div({ style: { fontSize: 20 } }, [
-  div([
-    'The'
+const activeFileTransferMessage = div({ style: { display: 'flex',
+                                                 borderRadius: 5, padding: '1rem',
+                                                 backgroundColor: colors.warning(0.15),
+                                                 boxShadow: '0 2px 5px 0 rgba(0,0,0,0.35), 0 3px 2px 0 rgba(0,0,0,0.12)' } }, [
+    icon('warning-standard', { size: 19, style: { color: colors.warning(), flex: 'none', marginRight: '0.5rem', marginLeft: '-0.5rem' } }),
+    'Copying 1 or more notebooks from another workspace. ', span({ style: { fontWeight: 'bold' } }, ['This may take a few minutes.'])
   ])
-])
 
 const NotebookCard = ({
   namespace, name, updated, metadata, listView, wsName, onRename, onCopy, onDelete, onExport, canWrite, currentUserHash,
@@ -402,15 +404,17 @@ const Notebooks = _.flow(
           ])
         ])
       ]),
-      Utils.cond(
-//        [!activeFileTransfer, () => activeFileTransferMessage],
-        [_.isEmpty(notebooks), () => noNotebooksMessage],
-        [!_.isEmpty(notebooks) && _.isEmpty(renderedNotebooks), () => {
-          return div({ style: { fontStyle: 'italic' } }, ['No matching notebooks'])
-        }],
-        [listView, () => div({ style: { flex: 1 } }, [renderedNotebooks])],
-        () => div({ style: { display: 'flex', flexWrap: 'wrap' } }, renderedNotebooks)
-      )
+      div({ style: { flexGrow: 1 } }, [
+        Utils.cond(
+          [_.isEmpty(notebooks), () => noNotebooksMessage],
+          [!_.isEmpty(notebooks) && _.isEmpty(renderedNotebooks), () => {
+            return div({ style: { fontStyle: 'italic' } }, ['No matching notebooks'])
+          }],
+          [listView, () => div({ style: { flex: 1 } }, [renderedNotebooks])],
+          () => div({ style: { display: 'flex', flexWrap: 'wrap' } }, renderedNotebooks)
+        ),
+        !activeFileTransfer && activeFileTransferMessage
+      ])
     ])
   }
 

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -69,7 +69,7 @@ const noNotebooksMessage = div({ style: { fontSize: 20 } }, [
   div([
     'To get started, click ', span({ style: { fontWeight: 600 } }, ['Create a New Notebook'])
   ]),
-  div({ style: { margin: '1rem 0 1rem 0', fontSize: 16 } }, [
+  div({ style: { margin: '1rem 0', fontSize: 16 } }, [
     h(Link, {
       ...Utils.newTabLinkProps,
       href: `https://support.terra.bio/hc/en-us/sections/360004143932`
@@ -80,11 +80,11 @@ const noNotebooksMessage = div({ style: { fontSize: 20 } }, [
 const activeFileTransferMessage = div({
   style: _.merge(
     Style.elements.card.container,
-    { backgroundColor: colors.warning(0.15), flexDirection: 'none', justifyContent: 'start' })
+    { backgroundColor: colors.warning(0.15), flexDirection: 'none', justifyContent: 'start', alignItems: 'center' })
 }, [
   icon('warning-standard', { size: 19, style: { color: colors.warning(), flex: 'none', marginRight: '1rem' } }),
   'Copying 1 or more notebooks from another workspace.',
-  span({ style: { fontWeight: 'bold', marginLeft: '1ch' } }, ['This may take a few minutes.'])
+  span({ style: { fontWeight: 'bold', marginLeft: '0.5ch' } }, ['This may take a few minutes.'])
 ])
 
 const NotebookCard = ({
@@ -257,7 +257,7 @@ const Notebooks = _.flow(
 
   const refreshNotebooks = _.flow(
     withRequesterPaysHandler(onRequesterPaysError),
-    withErrorReporting('Error loading notebooks'),
+    withErrorReporting('Error loading notebooks.'),
     Utils.withBusyState(setBusy)
   )(async () => {
     const notebooks = await Ajax(signal).Buckets.listNotebooks(googleProject, bucketName)
@@ -265,7 +265,7 @@ const Notebooks = _.flow(
   })
 
   const getActiveFileTransfers = _.flow(
-    withErrorReporting('Error loading file transfer status'),
+    withErrorReporting('Error loading file transfer status for notebooks in the workspace.'),
     Utils.withBusyState(setBusy)
   )(async () => {
     const fileTransfers = await Ajax(signal).Workspaces.workspace(namespace, wsName).listActiveFileTransfers()
@@ -273,7 +273,7 @@ const Notebooks = _.flow(
   })
 
   const doAppRefresh = _.flow(
-    withErrorReporting('Error loading Apps'),
+    withErrorReporting('Error loading Apps.'),
     Utils.withBusyState(setBusy)
   )(refreshApps)
 

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -77,13 +77,14 @@ const noNotebooksMessage = div({ style: { fontSize: 20 } }, [
   ])
 ])
 
-const activeFileTransferMessage = div({ style: { display: 'flex',
-                                                 borderRadius: 5, padding: '1rem',
-                                                 backgroundColor: colors.warning(0.15),
-                                                 boxShadow: '0 2px 5px 0 rgba(0,0,0,0.35), 0 3px 2px 0 rgba(0,0,0,0.12)' } }, [
-    icon('warning-standard', { size: 19, style: { color: colors.warning(), flex: 'none', marginRight: '0.5rem', marginLeft: '-0.5rem' } }),
-    'Copying 1 or more notebooks from another workspace. ', span({ style: { fontWeight: 'bold' } }, ['This may take a few minutes.'])
-  ])
+const activeFileTransferMessage = div({
+  style: _.merge(
+    Style.elements.card.container,
+    { backgroundColor: colors.warning(0.15), flexDirection: 'none', justifyContent: 'start' })
+}, [
+  icon('warning-standard', { size: 19, style: { color: colors.warning(), flex: 'none', marginRight: '0.5rem', marginLeft: '-0.5rem' } }),
+  'Copying 1 or more notebooks from another workspace. ', span({ style: { fontWeight: 'bold' } }, ['This may take a few minutes.'])
+])
 
 const NotebookCard = ({
   namespace, name, updated, metadata, listView, wsName, onRename, onCopy, onDelete, onExport, canWrite, currentUserHash,
@@ -267,7 +268,7 @@ const Notebooks = _.flow(
     withErrorReporting('Error loading file transfer status'),
     Utils.withBusyState(setBusy)
   )(async () => {
-    const fileTransfers = await Ajax(signal).Workspaces.workspace(namespace, wsName).listFileTransfers()
+    const fileTransfers = await Ajax(signal).Workspaces.workspace(namespace, wsName).listActiveFileTransfers()
     setActiveFileTransfer(!_.isEmpty(fileTransfers))
   })
 

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -82,8 +82,9 @@ const activeFileTransferMessage = div({
     Style.elements.card.container,
     { backgroundColor: colors.warning(0.15), flexDirection: 'none', justifyContent: 'start' })
 }, [
-  icon('warning-standard', { size: 19, style: { color: colors.warning(), flex: 'none', marginRight: '0.5rem', marginLeft: '-0.5rem' } }),
-  'Copying 1 or more notebooks from another workspace. ', span({ style: { fontWeight: 'bold' } }, ['This may take a few minutes.'])
+  icon('warning-standard', { size: 19, style: { color: colors.warning(), flex: 'none', marginRight: '1rem' } }),
+  'Copying 1 or more notebooks from another workspace.',
+  span({ style: { fontWeight: 'bold', marginLeft: '1ch' } }, ['This may take a few minutes.'])
 ])
 
 const NotebookCard = ({

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -79,7 +79,7 @@ const noNotebooksMessage = div({ style: { fontSize: 20 } }, [
 
 const activeFileTransferMessage = div({ style: { fontSize: 20 } }, [
   div([
-    'Your notebooks are still in the process of being copied over.'
+    'The'
   ])
 ])
 
@@ -403,7 +403,7 @@ const Notebooks = _.flow(
         ])
       ]),
       Utils.cond(
-        [activeFileTransfer, () => activeFileTransferMessage],
+//        [!activeFileTransfer, () => activeFileTransferMessage],
         [_.isEmpty(notebooks), () => noNotebooksMessage],
         [!_.isEmpty(notebooks) && _.isEmpty(renderedNotebooks), () => {
           return div({ style: { fontStyle: 'italic' } }, ['No matching notebooks'])

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -264,7 +264,6 @@ const Notebooks = _.flow(
   })
 
   const getActiveFileTransfer = _.flow(
-    withRequesterPaysHandler(onRequesterPaysError),
     withErrorReporting('Error loading file transfer status'),
     Utils.withBusyState(setBusy)
   )(async () => {

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -414,7 +414,7 @@ const Notebooks = _.flow(
           [listView, () => div({ style: { flex: 1 } }, [renderedNotebooks])],
           () => div({ style: { display: 'flex', flexWrap: 'wrap' } }, renderedNotebooks)
         ),
-        !activeFileTransfer && activeFileTransferMessage
+        activeFileTransfer && activeFileTransferMessage
       ])
     ])
   }

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -245,7 +245,7 @@ const Notebooks = _.flow(
   const [currentUserHash, setCurrentUserHash] = useState(undefined)
   const [potentialLockers, setPotentialLockers] = useState(undefined)
   const [openGalaxyConfigDrawer, setOpenGalaxyConfigDrawer] = useState(false)
-  const [activeFileTransfer, setActiveFileTransfer] = useState(false)
+  const [activeFileTransfers, setActiveFileTransfers] = useState(false)
 
   const authState = useStore(authStore)
   const signal = useCancellation()
@@ -263,12 +263,12 @@ const Notebooks = _.flow(
     setNotebooks(_.reverse(_.sortBy('updated', notebooks)))
   })
 
-  const getActiveFileTransfer = _.flow(
+  const getActiveFileTransfers = _.flow(
     withErrorReporting('Error loading file transfer status'),
     Utils.withBusyState(setBusy)
   )(async () => {
     const fileTransfers = await Ajax(signal).Workspaces.workspace(namespace, wsName).listActiveFileTransfers()
-    setActiveFileTransfer(!_.isEmpty(fileTransfers))
+    setActiveFileTransfers(!_.isEmpty(fileTransfers))
   })
 
   const doAppRefresh = _.flow(
@@ -305,7 +305,7 @@ const Notebooks = _.flow(
         [notebookLockHash(bucketName, authState.user.email), findPotentialNotebookLockers({ canShare, namespace, wsName, bucketName })])
       setCurrentUserHash(currentUserHash)
       setPotentialLockers(potentialLockers)
-      getActiveFileTransfer()
+      getActiveFileTransfers()
       refreshNotebooks()
     }
 
@@ -413,7 +413,7 @@ const Notebooks = _.flow(
           [listView, () => div({ style: { flex: 1 } }, [renderedNotebooks])],
           () => div({ style: { display: 'flex', flexWrap: 'wrap' } }, renderedNotebooks)
         ),
-        activeFileTransfer && activeFileTransferMessage
+        activeFileTransfers && activeFileTransferMessage
       ])
     ])
   }


### PR DESCRIPTION
<img width="1454" alt="Screen Shot 2022-04-06 at 6 10 31 PM" src="https://user-images.githubusercontent.com/7257391/162080665-865a4337-5e60-4622-8201-d55620641692.png">


Also plays nicely with the page if you happen to create a notebook before the transfer is complete:

<img width="1451" alt="Screen Shot 2022-04-06 at 6 06 32 PM" src="https://user-images.githubusercontent.com/7257391/162080499-35316813-4683-44db-bef1-1a3abbae1ca4.png">


<!--
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Thanks!
--!>
