### PR TITLE
[SU-25] Add option to add a row to a data table

### DIFF
--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -384,7 +384,7 @@ const EntitiesContent = ({
           disabled: !entitiesSelected,
           tooltip: !entitiesSelected && 'Select rows to edit in the table',
           onClick: () => setEditingEntities(true)
-        }, 'Edit attribute'),
+        }, ['Edit attribute']),
         h(MenuButton, {
           disabled: !entitiesSelected,
           tooltip: !entitiesSelected && 'Select rows to delete in the table',
@@ -494,9 +494,7 @@ const EntitiesContent = ({
         entityTypes: _.keys(entityMetadata),
         workspaceId: { namespace, name },
         onDismiss: () => setAddingEntity(false),
-        onSuccess: () => {
-          setRefreshKey(_.add(1))
-        }
+        onSuccess: () => setRefreshKey(_.add(1))
       }),
       editingEntities && h(MultipleEntityEditor, {
         entityType: entityKey,

--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -7,7 +7,7 @@ import { Fragment, useRef, useState } from 'react'
 import { div, form, h, input } from 'react-hyperscript-helpers'
 import { requesterPaysWrapper, withRequesterPaysHandler } from 'src/components/bucket-utils'
 import { ButtonPrimary, ButtonSecondary, Link } from 'src/components/common'
-import { EntityDeleter, ModalToolButton, MultipleEntityEditor, saveScroll } from 'src/components/data/data-utils'
+import { AddEntityModal, EntityDeleter, ModalToolButton, MultipleEntityEditor, saveScroll } from 'src/components/data/data-utils'
 import DataTable from 'src/components/data/DataTable'
 import ExportDataModal from 'src/components/data/ExportDataModal'
 import { icon, spinner } from 'src/components/icons'
@@ -218,6 +218,7 @@ const EntitiesContent = ({
   const [editingEntities, setEditingEntities] = useState(false)
   const [deletingEntities, setDeletingEntities] = useState(false)
   const [copyingEntities, setCopyingEntities] = useState(false)
+  const [addingEntity, setAddingEntity] = useState(false)
   const [nowCopying, setNowCopying] = useState(false)
   const [refreshKey, setRefreshKey] = useState(0)
   const [showToolSelector, setShowToolSelector] = useState(false)
@@ -377,18 +378,24 @@ const EntitiesContent = ({
       closeOnClick: true,
       content: h(Fragment, [
         h(MenuButton, {
-          onClick: () => setEditingEntities(true)
-        }, ['Edit Attribute']),
+          onClick: () => setAddingEntity(true)
+        }, 'Add row'),
         h(MenuButton, {
+          disabled: !entitiesSelected,
+          tooltip: !entitiesSelected && 'Select rows to edit in the table',
+          onClick: () => setEditingEntities(true)
+        }, 'Edit attribute'),
+        h(MenuButton, {
+          disabled: !entitiesSelected,
+          tooltip: !entitiesSelected && 'Select rows to delete in the table',
           onClick: () => setDeletingEntities(true)
         }, 'Delete')
       ])
     }, [h(ButtonSecondary, {
-      disabled: !canEdit || !entitiesSelected,
+      disabled: !canEdit,
       tooltip: Utils.cond(
         [!canEdit, () => editErrorMessage],
-        [!entitiesSelected, () => 'Select rows to edit in the table'],
-        () => 'Edit selected data'
+        () => 'Edit data'
       ),
       style: { marginRight: '1.5rem' }
     }, [icon('edit', { style: { marginRight: '0.5rem' } }), 'Edit'])])
@@ -480,6 +487,16 @@ const EntitiesContent = ({
             renderSelectedRowsMenu(columnSettings)
           ]),
         deleteColumnUpdateMetadata
+      }),
+      addingEntity && h(AddEntityModal, {
+        entityType: entityKey,
+        attributeNames: entityMetadata[entityKey].attributeNames,
+        entityTypes: _.keys(entityMetadata),
+        workspaceId: { namespace, name },
+        onDismiss: () => setAddingEntity(false),
+        onSuccess: () => {
+          setRefreshKey(_.add(1))
+        }
       }),
       editingEntities && h(MultipleEntityEditor, {
         entityType: entityKey,

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -944,10 +944,8 @@ export const AddEntityModal = ({ workspaceId: { namespace, name }, entityType, a
   const [entityName, setEntityName] = useState('')
   const [entityNameInputTouched, setEntityNameInputTouched] = useState(false)
   const [takenNames, setTakenNames] = useState([])
-
   // Default all attribute values to empty strings
   const [attributeValues, setAttributeValues] = useState(_.fromPairs(_.map(attributeName => [attributeName, ''], attributeNames)))
-
   const [isBusy, setIsBusy] = useState(false)
 
   // The data table colum heading shows this as `${entityType}_id`, but `${entityType} ID` works better in a screen reader
@@ -998,7 +996,7 @@ export const AddEntityModal = ({ workspaceId: { namespace, name }, entityType, a
       disabled: !!entityNameErrors,
       tooltip: Utils.summarizeErrors(entityNameErrors),
       onClick: createEntity
-    }, 'Add')
+    }, ['Add'])
   }, [
     label({ htmlFor: 'add-row-entity-name', style: { display: 'block', marginBottom: '0.5rem' } }, entityNameLabel),
     h(ValidatedInput, {


### PR DESCRIPTION
Currently, adding rows to a data table requires uploading or copying and pasting a TSV. This adds the ability to add a row and enter attribute values through the UI.

To try this out, enable the feature flag for the data tab redesign (run `configOverridesStore.set({ isDataTabRedesignEnabled: true })` in the console) and select "Add row" from the "Edit" menu.

![Screen Shot 2022-04-06 at 2 53 00 PM](https://user-images.githubusercontent.com/1156625/162047776-e7cad794-1ae1-4b29-b238-db11583c9a6f.png)