### PR TITLE
[SU-52] Improve support for long column names in column settings modal

### DIFF
--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -362,7 +362,8 @@ const DataTable = props => {
           entityMetadata,
           entityType,
           snapshotName,
-          workspace
+          workspace,
+          modalWidth: 800
         }, {
           columnSettings,
           onSave: setColumnState

--- a/src/components/data/SavedColumnSettings.js
+++ b/src/components/data/SavedColumnSettings.js
@@ -267,13 +267,13 @@ const SavedColumnSettings = ({ workspace, snapshotName, entityType, entityMetada
 
 export const ColumnSettingsWithSavedColumnSettings = ({ columnSettings, onChange, ...otherProps }) => {
   return div({ style: { display: 'flex', justifyContent: 'space-between' } }, [
-    div({ style: { width: 'calc(50% - 1rem)' } }, [
+    div({ style: { flex: '1 1 0' } }, [
       h(ColumnSettings, {
         columnSettings,
         onChange
       })
     ]),
-    div({ style: { width: 'calc(50% - 1rem)', marginTop: '2rem' } }, [
+    div({ style: { flex: '0 0 265px', marginLeft: '1rem', marginTop: '2rem' } }, [
       h(SavedColumnSettings, {
         ...otherProps,
         columnSettings,

--- a/src/components/data/SavedColumnSettings.js
+++ b/src/components/data/SavedColumnSettings.js
@@ -222,9 +222,8 @@ const SavedColumnSettings = ({ workspace, snapshotName, entityType, entityMetada
       }, 'Save this column selection')
     ]),
 
-    hr({ style: { margin: '1rem 0' } }),
-
     _.size(savedColumnSettings) > 0 && h(Fragment, [
+      hr({ style: { margin: '1rem 0' } }),
       p({ style: { marginTop: 0 } }, 'Your saved column selections:'),
       div({ style: { flex: '1 1 0', overflow: 'auto', paddingRight: '1rem' } }, [
         ul({ style: { padding: 0, margin: 0 } }, [

--- a/src/components/data/SavedColumnSettings.js
+++ b/src/components/data/SavedColumnSettings.js
@@ -273,7 +273,15 @@ export const ColumnSettingsWithSavedColumnSettings = ({ columnSettings, onChange
         onChange
       })
     ]),
-    div({ style: { flex: '0 0 265px', marginLeft: '1rem', marginTop: '2rem' } }, [
+    div({
+      style: {
+        width: '275px',
+        paddingLeft: '1rem',
+        borderLeft: `1px solid ${colors.light()}`,
+        marginLeft: '1rem',
+        marginTop: '2rem'
+      }
+    }, [
       h(SavedColumnSettings, {
         ...otherProps,
         columnSettings,

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -3,7 +3,7 @@ import _ from 'lodash/fp'
 import PropTypes from 'prop-types'
 import { Fragment, useImperativeHandle, useRef, useState } from 'react'
 import Draggable from 'react-draggable'
-import { button, div, h, label, option, select } from 'react-hyperscript-helpers'
+import { button, div, h, label, option, select, span } from 'react-hyperscript-helpers'
 import Pagination from 'react-paginating'
 import { SortableContainer, SortableElement, SortableHandle } from 'react-sortable-hoc'
 import { AutoSizer, defaultCellRangeRenderer, Grid as RVGrid, List, ScrollSync as RVScrollSync } from 'react-virtualized'
@@ -742,20 +742,27 @@ export const ColumnSettings = ({ columnSettings, onChange }) => {
                 icon('columnGrabber', { style: { transform: 'rotate(90deg)' } })
               ]),
               h(IdContainer, [id => h(Fragment, [
-                label({
-                  htmlFor: id,
-                  style: {
-                    lineHeight: '30px', // match rowHeight of SortableList
-                    ...Style.noWrapEllipsis
-                  }
+                h(TooltipTrigger, {
+                  // Since entity names don't contain spaces, word-break: break-all is necessary to
+                  // wrap the entity name instead of truncating it when the tooltip reaches its
+                  // max width of 400px.
+                  content: span({ style: { wordBreak: 'break-all' } }, name)
                 }, [
-                  h(Checkbox, {
-                    id,
-                    checked: visible,
-                    onChange: () => toggleVisibility(index)
-                  }),
-                  ' ',
-                  name
+                  label({
+                    htmlFor: id,
+                    style: {
+                      lineHeight: '30px', // match rowHeight of SortableList
+                      ...Style.noWrapEllipsis
+                    }
+                  }, [
+                    h(Checkbox, {
+                      id,
+                      checked: visible,
+                      onChange: () => toggleVisibility(index)
+                    }),
+                    ' ',
+                    name
+                  ])
                 ])
               ])])
             ])

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -7,7 +7,7 @@ import { button, div, h, label, option, select } from 'react-hyperscript-helpers
 import Pagination from 'react-paginating'
 import { SortableContainer, SortableElement, SortableHandle } from 'react-sortable-hoc'
 import { AutoSizer, defaultCellRangeRenderer, Grid as RVGrid, List, ScrollSync as RVScrollSync } from 'react-virtualized'
-import { ButtonPrimary, Clickable, IdContainer, LabeledCheckbox, Link } from 'src/components/common'
+import { ButtonPrimary, Checkbox, Clickable, IdContainer, Link } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import Interactive from 'src/components/Interactive'
 import Modal from 'src/components/Modal'
@@ -147,11 +147,6 @@ const styles = {
     color: colors.accent(), backgroundColor: colors.light(0.4),
     border: `1px solid ${colors.dark(0.2)}`,
     borderRadius: 5
-  },
-  columnName: {
-    paddingLeft: '0.25rem',
-    flex: 1, display: 'flex', alignItems: 'center',
-    ...Style.noWrapEllipsis
   },
   columnHandle: {
     paddingRight: '0.25rem', cursor: 'move',
@@ -746,16 +741,23 @@ export const ColumnSettings = ({ columnSettings, onChange }) => {
               h(SortableHandleDiv, { style: styles.columnHandle }, [
                 icon('columnGrabber', { style: { transform: 'rotate(90deg)' } })
               ]),
-              div({ style: { display: 'flex', alignItems: 'center' } }, [
-                h(LabeledCheckbox, {
-                  checked: visible,
-                  onChange: () => toggleVisibility(index)
+              h(IdContainer, [id => h(Fragment, [
+                label({
+                  htmlFor: id,
+                  style: {
+                    lineHeight: '30px', // match rowHeight of SortableList
+                    ...Style.noWrapEllipsis
+                  }
                 }, [
-                  h(Clickable, {
-                    style: styles.columnName
-                  }, [name])
+                  h(Checkbox, {
+                    id,
+                    checked: visible,
+                    onChange: () => toggleVisibility(index)
+                  }),
+                  ' ',
+                  name
                 ])
-              ])
+              ])])
             ])
           },
           onSortEnd: v => reorder(v)

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -743,8 +743,8 @@ export const ColumnSettings = ({ columnSettings, onChange }) => {
               ]),
               h(IdContainer, [id => h(Fragment, [
                 h(TooltipTrigger, {
-                  // Since entity names don't contain spaces, word-break: break-all is necessary to
-                  // wrap the entity name instead of truncating it when the tooltip reaches its
+                  // Since attribute names don't contain spaces, word-break: break-all is necessary to
+                  // wrap the attribute name instead of truncating it when the tooltip reaches its
                   // max width of 400px.
                   content: span({ style: { wordBreak: 'break-all' } }, name)
                 }, [

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -781,7 +781,7 @@ export const ColumnSettings = ({ columnSettings, onChange }) => {
  * @param {Object} style - style override for the button
  * @param {function(Object[])} onSave - called with modified settings when user saves
  */
-export const ColumnSelector = ({ onSave, columnSettings, columnSettingsComponent = ColumnSettings, style, ...otherProps }) => {
+export const ColumnSelector = ({ onSave, columnSettings, columnSettingsComponent = ColumnSettings, modalWidth = 600, style, ...otherProps }) => {
   const [open, setOpen] = useState(false)
   const [modifiedColumnSettings, setModifiedColumnSettings] = useState(undefined)
 
@@ -798,7 +798,7 @@ export const ColumnSelector = ({ onSave, columnSettings, columnSettingsComponent
     }, [icon('cog', { size: 20 })]),
     open && h(Modal, {
       title: 'Select columns',
-      width: 600,
+      width: modalWidth,
       onDismiss: () => setOpen(false),
       okButton: h(ButtonPrimary, {
         onClick: () => {


### PR DESCRIPTION
Currently, the data table's column settings modal does not handle long attribute names very well. In the list of columns on the left, the column names are truncated (with no indication that they are) and there's no way to view the full column name.

This makes a few improvements:
- Use text-overflow: ellipsis to indicate when column names are truncated
- Add tooltips to view the full column name
- Widen the column settings modal
- Reduce the width used for the saved column settings

## Before
![Screen Shot 2022-04-07 at 2 00 52 PM](https://user-images.githubusercontent.com/1156625/162267953-b9c7553d-cdcd-457e-977a-5caea2603f0b.png)

## After
![Screen Shot 2022-04-07 at 2 01 33 PM](https://user-images.githubusercontent.com/1156625/162267964-a6fedb32-d0b9-4c79-860e-2a3db63f1a0d.png)


