### PR TITLE
[SU-56] Add confirmation prompt for deleting analyses/notebooks

### DIFF
--- a/src/components/common.js
+++ b/src/components/common.js
@@ -557,7 +557,20 @@ export const HeaderRenderer = ({ name, label, sort, onSort, style, ...props }) =
   div({ style: { fontWeight: 600, ...style }, ...props }, [label || Utils.normalizeLabel(name)])
 ])
 
-export const PromptedConfirmationModal = ({ title, children, confirmationPrompt = 'Confirm', buttonText = 'Confirm', onConfirm, onDismiss }) => {
+export const DeleteConfirmationModal = ({
+  objectType,
+  objectName,
+  title: titleProp,
+  children,
+  confirmationPrompt: confirmationPromptProp,
+  buttonText: buttonTextProp,
+  onConfirm,
+  onDismiss
+}) => {
+  const title = titleProp || `Delete ${objectType}`
+  const confirmationPrompt = confirmationPromptProp || `Delete ${objectType}`
+  const buttonText = buttonTextProp || `Delete ${objectType}`
+
   const [busy, setBusy] = useState(false)
   const [confirmation, setConfirmation] = useState('')
 
@@ -581,7 +594,11 @@ export const PromptedConfirmationModal = ({ title, children, confirmationPrompt 
       tooltip: isConfirmed ? undefined : 'You must type the confirmation message'
     }, buttonText)
   }, [
-    children,
+    children || h(Fragment, [
+      div([`Are you sure you want to delete the ${objectType} `,
+        span({ style: { fontWeight: 600, wordBreak: 'break-word' } }, [objectName]), '?']),
+      div({ style: { fontWeight: 500, marginTop: '1rem' } }, 'This cannot be undone.')
+    ]),
     div({ style: { display: 'flex', flexDirection: 'column', marginTop: '1rem' } }, [
       h(IdContainer, [id => h(Fragment, [
         label({ htmlFor: id, style: { marginBottom: '0.25rem' } }, [`Type "${confirmationPrompt}" to continue:`]),
@@ -595,20 +612,5 @@ export const PromptedConfirmationModal = ({ title, children, confirmationPrompt 
       ])])
     ]),
     busy && spinnerOverlay
-  ])
-}
-
-export const DeleteConfirmationModal = ({ objectName, objectType, children, ...props }) => {
-  return h(PromptedConfirmationModal, {
-    title: `Delete ${objectType}`,
-    confirmationPrompt: `Delete ${objectType}`,
-    buttonText: `Delete ${objectType}`,
-    ...props
-  }, [
-    children || h(Fragment, [
-      div([`Are you sure you want to delete the ${objectType} `,
-        span({ style: { fontWeight: 600, wordBreak: 'break-word' } }, [objectName]), '?']),
-      div({ style: { fontWeight: 500, marginTop: '1rem' } }, 'This cannot be undone.')
-    ])
   ])
 }

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -606,7 +606,7 @@ export const DeleteConfirmationModal = ({ objectName, objectType, children, ...p
     ...props
   }, [
     children || h(Fragment, [
-      div(['Are you sure you want to delete ',
+      div(['Are you sure you want to delete the ', objectType, ' ',
         span({ style: { fontWeight: 600, wordBreak: 'break-word' } }, [objectName]), '?']),
       div({ style: { fontWeight: 500, marginTop: '1rem' } }, 'This cannot be undone.')
     ])

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -557,7 +557,7 @@ export const HeaderRenderer = ({ name, label, sort, onSort, style, ...props }) =
   div({ style: { fontWeight: 600, ...style }, ...props }, [label || Utils.normalizeLabel(name)])
 ])
 
-export const PromptedConfirmationModal = ({ title, children, confirmationPrompt = 'Delete', buttonText = 'Delete', onConfirm, onDismiss }) => {
+export const PromptedConfirmationModal = ({ title, children, confirmationPrompt = 'Confirm', buttonText = 'Confirm', onConfirm, onDismiss }) => {
   const [busy, setBusy] = useState(false)
   const [confirmation, setConfirmation] = useState('')
 
@@ -595,5 +595,20 @@ export const PromptedConfirmationModal = ({ title, children, confirmationPrompt 
       ])])
     ]),
     busy && spinnerOverlay
+  ])
+}
+
+export const DeleteConfirmationModal = ({ objectName, objectType, children, ...props }) => {
+  return h(PromptedConfirmationModal, {
+    title: `Delete ${objectType}`,
+    confirmationPrompt: `Delete ${objectType}`,
+    buttonText: `Delete ${objectType}`,
+    ...props
+  }, [
+    children || h(Fragment, [
+      div(['Are you sure you want to delete ',
+        span({ style: { fontWeight: 600, wordBreak: 'break-word' } }, [objectName]), '?']),
+      div({ style: { fontWeight: 500, marginTop: '1rem' } }, 'This cannot be undone.')
+    ])
   ])
 }

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -606,7 +606,7 @@ export const DeleteConfirmationModal = ({ objectName, objectType, children, ...p
     ...props
   }, [
     children || h(Fragment, [
-      div(['Are you sure you want to delete the ', objectType, ' ',
+      div([`Are you sure you want to delete the ${objectType} `,
         span({ style: { fontWeight: 600, wordBreak: 'break-word' } }, [objectName]), '?']),
       div({ style: { fontWeight: 500, marginTop: '1rem' } }, 'This cannot be undone.')
     ])

--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -2,7 +2,7 @@ import _ from 'lodash/fp'
 import { Fragment, useEffect, useRef, useState } from 'react'
 import { div, h, span } from 'react-hyperscript-helpers'
 import { AutoSizer } from 'react-virtualized'
-import { Checkbox, Clickable, DeleteConfirmationModal, fixedSpinnerOverlay, Link, PromptedConfirmationModal } from 'src/components/common'
+import { Checkbox, Clickable, DeleteConfirmationModal, fixedSpinnerOverlay, Link } from 'src/components/common'
 import { concatenateAttributeNames, EditDataLink, EntityRenamer, HeaderOptions, renderDataCell, SingleEntityEditor } from 'src/components/data/data-utils'
 import { ColumnSettingsWithSavedColumnSettings } from 'src/components/data/SavedColumnSettings'
 import { icon } from 'src/components/icons'
@@ -416,7 +416,7 @@ const DataTable = props => {
       onConfirm: () => deleteColumn(deletingColumn),
       onDismiss: () => setDeletingColumn(undefined)
     }),
-    !!clearingColumn && h(PromptedConfirmationModal, {
+    !!clearingColumn && h(DeleteConfirmationModal, {
       title: 'Clear Column',
       confirmationPrompt: 'Clear column',
       buttonText: 'Clear column',

--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -2,7 +2,7 @@ import _ from 'lodash/fp'
 import { Fragment, useEffect, useRef, useState } from 'react'
 import { div, h, span } from 'react-hyperscript-helpers'
 import { AutoSizer } from 'react-virtualized'
-import { Checkbox, Clickable, fixedSpinnerOverlay, Link, PromptedConfirmationModal } from 'src/components/common'
+import { Checkbox, Clickable, DeleteConfirmationModal, fixedSpinnerOverlay, Link, PromptedConfirmationModal } from 'src/components/common'
 import { concatenateAttributeNames, EditDataLink, EntityRenamer, HeaderOptions, renderDataCell, SingleEntityEditor } from 'src/components/data/data-utils'
 import { ColumnSettingsWithSavedColumnSettings } from 'src/components/data/SavedColumnSettings'
 import { icon } from 'src/components/icons'
@@ -410,17 +410,12 @@ const DataTable = props => {
       },
       onDismiss: () => setUpdatingEntity(undefined)
     }),
-    !!deletingColumn && h(PromptedConfirmationModal, {
-      title: 'Delete Column',
-      confirmationPrompt: 'Delete column',
-      buttonText: 'Delete column',
+    !!deletingColumn && h(DeleteConfirmationModal, {
+      objectType: 'column',
+      objectName: deletingColumn,
       onConfirm: () => deleteColumn(deletingColumn),
       onDismiss: () => setDeletingColumn(undefined)
-    }, [
-      div(['Are you sure you want to permanently delete the column ',
-        span({ style: { fontWeight: 600, wordBreak: 'break-word' } }, deletingColumn), '?']),
-      div({ style: { fontWeight: 500, marginTop: '1rem' } }, 'This cannot be undone.')
-    ]),
+    }),
     !!clearingColumn && h(PromptedConfirmationModal, {
       title: 'Clear Column',
       confirmationPrompt: 'Clear column',

--- a/src/components/notebook-utils.js
+++ b/src/components/notebook-utils.js
@@ -360,67 +360,6 @@ export const NotebookDuplicator = ({ destroyOld = false, fromLauncher = false, p
   ))
 }
 
-export const AnalysisDeleter = ({ printName, toolLabel, googleProject, bucketName, onDismiss, onSuccess }) => {
-  const [processing, setProcessing] = useState(false)
-
-  return h(Modal, {
-    onDismiss,
-    title: `Delete "${printName}"`,
-    okButton: h(ButtonPrimary, {
-      disabled: processing,
-      onClick: () => {
-        setProcessing(true)
-        Ajax().Buckets.analysis(googleProject, bucketName, printName, toolLabel).delete().then(
-          onSuccess,
-          error => reportError('Error deleting analysis', error)
-        )
-      }
-    }, 'Delete Analysis')
-  },
-  Utils.cond(
-    [processing, () => [centeredSpinner()]],
-    () => [
-      div({ style: { fontSize: '1rem', flexGrow: 1 } },
-        [
-          `Are you sure you want to delete "${printName}"?`,
-          div({ style: { fontWeight: 500, lineHeight: '2rem' } }, 'This cannot be undone.')
-        ]
-      )
-    ]
-  ))
-}
-
-//TODO: deprecate once notebooks tab is removed
-export const NotebookDeleter = ({ printName, googleProject, bucketName, onDismiss, onSuccess }) => {
-  const [processing, setProcessing] = useState(false)
-
-  return h(Modal, {
-    onDismiss,
-    title: `Delete "${printName}"`,
-    okButton: h(ButtonPrimary, {
-      disabled: processing,
-      onClick: () => {
-        setProcessing(true)
-        Ajax().Buckets.notebook(googleProject, bucketName, printName).delete().then(
-          onSuccess,
-          error => reportError('Error deleting notebook', error)
-        )
-      }
-    }, 'Delete Notebook')
-  },
-  Utils.cond(
-    [processing, () => [centeredSpinner()]],
-    () => [
-      div({ style: { fontSize: '1rem', flexGrow: 1 } },
-        [
-          `Are you sure you want to delete "${printName}"?`,
-          div({ style: { fontWeight: 500, lineHeight: '2rem' } }, 'This cannot be undone.')
-        ]
-      )
-    ]
-  ))
-}
-
 // In Python notebook, use ' instead of " in code cells, to avoid formatting problems.
 // Changes from raw .ipynb:
 // - In notebook cells, change \n to \\n

--- a/src/pages/workspaces/workspace/Analyses.js
+++ b/src/pages/workspaces/workspace/Analyses.js
@@ -478,10 +478,10 @@ const Analyses = _.flow(
           onDismiss: () => setExportingAnalysisName(undefined)
         }),
         deletingAnalysisName && h(DeleteConfirmationModal, {
-          title: getTool(deletingAnalysisName) ? `Delete ${getTool(deletingAnalysisName)} analysis` : 'Delete analysis',
+          objectType: getTool(deletingAnalysisName) ? `${getTool(deletingAnalysisName)} analysis` : 'analysis',
+          objectName: getDisplayName(deletingAnalysisName),
           confirmationPrompt: 'Delete analysis',
           buttonText: 'Delete analysis',
-          objectName: getDisplayName(deletingAnalysisName),
           onConfirm: async () => {
             try {
               await Ajax().Buckets.analysis(

--- a/src/pages/workspaces/workspace/Analyses.js
+++ b/src/pages/workspaces/workspace/Analyses.js
@@ -478,7 +478,9 @@ const Analyses = _.flow(
           onDismiss: () => setExportingAnalysisName(undefined)
         }),
         deletingAnalysisName && h(DeleteConfirmationModal, {
-          objectType: 'analysis',
+          title: getTool(deletingAnalysisName) ? `Delete ${getTool(deletingAnalysisName)} analysis` : 'Delete analysis',
+          confirmationPrompt: 'Delete analysis',
+          buttonText: 'Delete analysis',
           objectName: getDisplayName(deletingAnalysisName),
           onConfirm: async () => {
             try {

--- a/src/pages/workspaces/workspace/Analyses.js
+++ b/src/pages/workspaces/workspace/Analyses.js
@@ -7,12 +7,12 @@ import { AnalysisModal } from 'src/components/AnalysisModal'
 import * as breadcrumbs from 'src/components/breadcrumbs'
 import { requesterPaysWrapper, withRequesterPaysHandler } from 'src/components/bucket-utils'
 import { withViewToggle } from 'src/components/CardsListToggle'
-import { ButtonOutline, ButtonPrimary, Clickable, HeaderRenderer, Link, PageBox, spinnerOverlay } from 'src/components/common'
+import { ButtonOutline, ButtonPrimary, Clickable, DeleteConfirmationModal, HeaderRenderer, Link, PageBox, spinnerOverlay } from 'src/components/common'
 import Dropzone from 'src/components/Dropzone'
 import { icon } from 'src/components/icons'
 import { DelayedSearchInput } from 'src/components/input'
 import {
-  AnalysisDeleter, AnalysisDuplicator, findPotentialNotebookLockers, getDisplayName, getFileName, getTool, getToolFromRuntime, notebookLockHash,
+  AnalysisDuplicator, findPotentialNotebookLockers, getDisplayName, getFileName, getTool, getToolFromRuntime, notebookLockHash,
   stripExtension, tools
 } from 'src/components/notebook-utils'
 import { makeMenuIcon, MenuButton, MenuTrigger } from 'src/components/PopupTrigger'
@@ -477,14 +477,23 @@ const Analyses = _.flow(
           workspace,
           onDismiss: () => setExportingAnalysisName(undefined)
         }),
-        deletingAnalysisName && h(AnalysisDeleter, {
-          printName: getDisplayName(deletingAnalysisName), googleProject, bucketName,
-          toolLabel: getTool(deletingAnalysisName),
-          onDismiss: () => setDeletingAnalysisName(undefined),
-          onSuccess: () => {
-            setDeletingAnalysisName(undefined)
-            refreshAnalyses()
-          }
+        deletingAnalysisName && h(DeleteConfirmationModal, {
+          objectType: 'analysis',
+          objectName: getDisplayName(deletingAnalysisName),
+          onConfirm: async () => {
+            try {
+              await Ajax().Buckets.analysis(
+                googleProject,
+                bucketName,
+                getDisplayName(deletingAnalysisName),
+                getTool(deletingAnalysisName)
+              ).delete()
+              refreshAnalyses()
+            } catch (err) {
+              reportError('Error deleting analysis.', err)
+            }
+          },
+          onDismiss: () => setDeletingAnalysisName(undefined)
         })
       ]),
       renderAnalyses()

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -6,13 +6,13 @@ import { a, div, h, label, span } from 'react-hyperscript-helpers'
 import * as breadcrumbs from 'src/components/breadcrumbs'
 import { requesterPaysWrapper, withRequesterPaysHandler } from 'src/components/bucket-utils'
 import { ViewToggleButtons, withViewToggle } from 'src/components/CardsListToggle'
-import { ButtonPrimary, Clickable, IdContainer, Link, PageBox, Select, spinnerOverlay } from 'src/components/common'
+import { ButtonPrimary, Clickable, DeleteConfirmationModal, IdContainer, Link, PageBox, Select, spinnerOverlay } from 'src/components/common'
 import Dropzone from 'src/components/Dropzone'
 import { GalaxyModal } from 'src/components/GalaxyModal'
 import { icon } from 'src/components/icons'
 import { DelayedSearchInput } from 'src/components/input'
 import {
-  findPotentialNotebookLockers, NotebookCreator, NotebookDeleter, NotebookDuplicator, notebookLockHash, tools
+  findPotentialNotebookLockers, NotebookCreator, NotebookDuplicator, notebookLockHash, tools
 } from 'src/components/notebook-utils'
 import { makeMenuIcon, MenuButton, MenuTrigger } from 'src/components/PopupTrigger'
 import { analysisTabName } from 'src/components/runtime-common'
@@ -492,13 +492,18 @@ const Notebooks = _.flow(
           printName: printName(exportingNotebookName), workspace,
           onDismiss: () => setExportingNotebookName(undefined)
         }),
-        deletingNotebookName && h(NotebookDeleter, {
-          printName: printName(deletingNotebookName), googleProject, bucketName,
-          onDismiss: () => setDeletingNotebookName(undefined),
-          onSuccess: () => {
-            setDeletingNotebookName(undefined)
-            refreshNotebooks()
-          }
+        deletingNotebookName && h(DeleteConfirmationModal, {
+          objectType: 'notebook',
+          objectName: printName(deletingNotebookName),
+          onConfirm: async () => {
+            try {
+              await Ajax().Buckets.notebook(googleProject, bucketName, printName(deletingNotebookName)).delete()
+              refreshNotebooks()
+            } catch (err) {
+              reportError('Error deleting notebook.', err)
+            }
+          },
+          onDismiss: () => setDeletingNotebookName(undefined)
         }),
         h(GalaxyModal, {
           isOpen: openGalaxyConfigDrawer,


### PR DESCRIPTION
This adds a prompt to type a confirmation before deleting an analysis/notebook. Eventually, all delete confirmations will be moved to this pattern.

## Before
![Screen Shot 2022-04-07 at 5 38 49 PM](https://user-images.githubusercontent.com/1156625/162324452-04caba10-4b36-401e-b292-91f10adb6039.png)

## After
![Screen Shot 2022-04-07 at 5 37 50 PM](https://user-images.githubusercontent.com/1156625/162324455-58ec4fec-00e3-45e5-8630-65ae1724c49a.png)
