### PR TITLE
[SU-87] Fix auto focus on last item in list in attribute editor

### DIFF
--- a/src/components/common.js
+++ b/src/components/common.js
@@ -487,7 +487,7 @@ const SwitchLabel = ({ isOn, onLabel, offLabel }) => div({
   }
 }, [isOn ? onLabel : offLabel])
 
-export const Switch = ({ onChange, onLabel = 'True', offLabel = 'False', ...props }) => {
+export const Switch = forwardRefWithName('Switch', ({ onChange, onLabel = 'True', offLabel = 'False', ...props }, ref) => {
   return h(RSwitch, {
     onChange: value => onChange(value),
     offColor: colors.dark(0.5),
@@ -495,9 +495,17 @@ export const Switch = ({ onChange, onLabel = 'True', offLabel = 'False', ...prop
     checkedIcon: h(SwitchLabel, { isOn: true, onLabel, offLabel }),
     uncheckedIcon: h(SwitchLabel, { isOn: false, onLabel, offLabel }),
     width: 80,
-    ...props
+    ...props,
+    ref: rSwitch => {
+      const inputEl = rSwitch ? rSwitch.$inputRef : null
+      if (_.has('current', ref)) {
+        ref.current = inputEl
+      } else if (_.isFunction(ref)) {
+        ref(inputEl)
+      }
+    }
   })
-}
+})
 
 export const HeroWrapper = ({ showMenu = true, bigSubhead = false, children }) => {
   const heavyWrapper = text => bigSubhead ? b({ style: { whiteSpace: 'nowrap' } }, [text]) : text

--- a/src/components/input.js
+++ b/src/components/input.js
@@ -146,44 +146,48 @@ export const SearchInput = ({ value, onChange, ...props }) => {
 
 export const DelayedSearchInput = withDebouncedChange(SearchInput)
 
-export const NumberInput = ({ onChange, onBlur, min = -Infinity, max = Infinity, onlyInteger = false, isClearable = true, tooltip, value, ...props }) => {
+export const NumberInput = forwardRefWithName('NumberInput', ({ onChange, onBlur, min = -Infinity, max = Infinity, onlyInteger = false, isClearable = true, tooltip, value, ...props }, ref) => {
   // If the user provided a tooltip but no other label, use the tooltip as the label for the input
   useLabelAssert('NumberInput', { tooltip, ...props, allowId: true, allowTooltip: true })
 
   const [internalValue, setInternalValue] = useState()
 
-  const numberInputChild = div([input(_.merge({
-    type: 'number',
-    'aria-label': Utils.getAriaLabelOrTooltip({ tooltip, ...props }),
-    className: 'focus-style',
-    min, max,
-    value: internalValue !== undefined ? internalValue : _.toString(value), // eslint-disable-line lodash-fp/preferred-alias
-    onChange: ({ target: { value: newValue } }) => {
-      setInternalValue(newValue)
-      // note: floor and clamp implicitly convert the value to a number
-      onChange(newValue === '' && isClearable ? null : _.clamp(min, max, onlyInteger ? _.floor(newValue) : newValue))
-    },
-    onBlur: (...args) => {
-      onBlur && onBlur(...args)
-      setInternalValue(undefined)
-    },
-    style: {
-      ...styles.input,
-      width: '100%',
-      paddingLeft: '1rem',
-      paddingRight: '0.25rem',
-      fontWeight: 400,
-      fontSize: 14,
-      backgroundColor: props.disabled ? colors.dark(0.25) : undefined
-    }
-  }, props))])
+  const numberInputChild = div([input({
+    ..._.merge({
+      type: 'number',
+      'aria-label': Utils.getAriaLabelOrTooltip({ tooltip, ...props }),
+      className: 'focus-style',
+      min, max,
+      value: internalValue !== undefined ? internalValue : _.toString(value), // eslint-disable-line lodash-fp/preferred-alias
+      onChange: ({ target: { value: newValue } }) => {
+        setInternalValue(newValue)
+        // note: floor and clamp implicitly convert the value to a number
+        onChange(newValue === '' && isClearable ? null : _.clamp(min, max, onlyInteger ? _.floor(newValue) : newValue))
+      },
+      onBlur: (...args) => {
+        onBlur && onBlur(...args)
+        setInternalValue(undefined)
+      },
+      style: {
+        ...styles.input,
+        width: '100%',
+        paddingLeft: '1rem',
+        paddingRight: '0.25rem',
+        fontWeight: 400,
+        fontSize: 14,
+        backgroundColor: props.disabled ? colors.dark(0.25) : undefined
+      }
+    }, props),
+    // _.merge merges recursively, and thus does not set ref correctly.
+    ref
+  })])
 
   if (tooltip) {
     return h(TooltipTrigger, { content: tooltip, side: 'right' }, [numberInputChild])
   } else {
     return numberInputChild
   }
-}
+})
 
 /**
  * @param {object} props.inputProps


### PR DESCRIPTION
When editing an attribute in a data table, if the attribute is a list, clicking the "Add item" button should add another input and focus on that element.

![Screen Shot 2022-04-11 at 9 19 01 AM](https://user-images.githubusercontent.com/1156625/162748321-a81f203e-93ec-4249-99fd-e2df1c69d81e.png)

The AttributeInput component attaches a ref to the last input in the list and calls `focus` on it.

https://github.com/DataBiosphere/terra-ui/blob/f1ad9fbaafb4c8f6513bb5fe1485895679ab868f/src/components/data/data-utils.js#L683

https://github.com/DataBiosphere/terra-ui/blob/f1ad9fbaafb4c8f6513bb5fe1485895679ab868f/src/components/data/data-utils.js#L613-L616

Currently, this only works for string and reference attributes. The TextInput component used for those attribute types forwards its ref to the underlying `input` element. For number and boolean attributes, it causes an error because the `lastListItemInput ` ref references an instance of the `NumberInput` or `Switch` component, which do not expose a `focus` method.

This updates `NumberInput` and `Switch` to forward refs to their underlying `input` elements. This is straightforward for `NumberInput`. For `Switch`, we have to first get a reference to the `ReactSwitch` component instance and then grab the reference to the input element that it stores in `$inputRef`.