### PR TITLE
[SU-3] Add link to data uploader from workspace data tab

### DIFF
--- a/src/pages/Upload.js
+++ b/src/pages/Upload.js
@@ -739,9 +739,21 @@ const UploadData = _.flow( // eslint-disable-line lodash-fp/no-single-compositio
 
   // State
   const { query } = Nav.useRoute()
-  const [currentStep, setCurrentStep] = useState(StateHistory.get().currentStep || 'workspaces')
   const [workspaceId, setWorkspaceId] = useState(query.workspace)
   const [collection, setCollection] = useState(query.collection)
+  const [currentStep, setCurrentStep] = useState(() => {
+    if (StateHistory.get().currentStep) {
+      return StateHistory.get().currentStep
+    }
+    // If workspace and/or collection were provided in the URL, start at a later step
+    if (workspaceId) {
+      if (collection) {
+        return 'data'
+      }
+      return 'collection'
+    }
+    return 'workspaces'
+  })
   const [creatingNewWorkspace, setCreatingNewWorkspace] = useState(false)
   const [numFiles, setNumFiles] = useState(StateHistory.get().numFiles)
   const [tableName, setTableName] = useState(StateHistory.get().tableName)
@@ -775,7 +787,7 @@ const UploadData = _.flow( // eslint-disable-line lodash-fp/no-single-compositio
 
   // Make sure we have a valid step once the workspaces have finished loading
   useEffect(() => {
-    if (!stepIsEnabled(currentStep) && !loadingWorkspaces) {
+    if (!stepIsEnabled(currentStep) && workspaces) {
       let last = steps[0]
       for (const step of steps) {
         if (!step.test()) {

--- a/src/pages/Upload.js
+++ b/src/pages/Upload.js
@@ -741,19 +741,12 @@ const UploadData = _.flow( // eslint-disable-line lodash-fp/no-single-compositio
   const { query } = Nav.useRoute()
   const [workspaceId, setWorkspaceId] = useState(query.workspace)
   const [collection, setCollection] = useState(query.collection)
-  const [currentStep, setCurrentStep] = useState(() => {
-    if (StateHistory.get().currentStep) {
-      return StateHistory.get().currentStep
-    }
-    // If workspace and/or collection were provided in the URL, start at a later step
-    if (workspaceId) {
-      if (collection) {
-        return 'data'
-      }
-      return 'collection'
-    }
-    return 'workspaces'
-  })
+  const [currentStep, setCurrentStep] = useState(Utils.cond(
+    [!!StateHistory.get().currentStep, () => StateHistory.get().currentStep],
+    [!!workspaceId && !!collection, () => 'data'],
+    [!!workspaceId && !collection, () => 'collection'],
+    () => 'workspaces'
+  ))
   const [creatingNewWorkspace, setCreatingNewWorkspace] = useState(false)
   const [numFiles, setNumFiles] = useState(StateHistory.get().numFiles)
   const [tableName, setTableName] = useState(StateHistory.get().tableName)

--- a/src/pages/Upload.js
+++ b/src/pages/Upload.js
@@ -787,7 +787,7 @@ const UploadData = _.flow( // eslint-disable-line lodash-fp/no-single-compositio
 
   // Make sure we have a valid step once the workspaces have finished loading
   useEffect(() => {
-    if (!stepIsEnabled(currentStep) && workspaces) {
+    if (!stepIsEnabled(currentStep) && !!workspaces) {
       let last = steps[0]
       for (const step of steps) {
         if (!step.test()) {

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -694,7 +694,7 @@ const WorkspaceData = _.flow(
               }, 'Upload TSV'),
               h(MenuButton, {
                 href: `${Nav.getLink('upload')}?${qs.stringify({ workspace: workspaceId })}`
-              }, 'Open data uploader'),
+              }, ['Open data uploader']),
               h(MenuButton, {
                 'aria-haspopup': 'dialog',
                 onClick: () => setImportingReference(true)

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -1,5 +1,6 @@
 import filesize from 'filesize'
 import _ from 'lodash/fp'
+import * as qs from 'qs'
 import { Fragment, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react'
 import { DraggableCore } from 'react-draggable'
 import { div, form, h, h3, input, span } from 'react-hyperscript-helpers'
@@ -28,6 +29,7 @@ import colors from 'src/libs/colors'
 import { getConfig, isDataTabRedesignEnabled } from 'src/libs/config'
 import { reportError, withErrorReporting } from 'src/libs/error'
 import Events, { extractWorkspaceDetails } from 'src/libs/events'
+import * as Nav from 'src/libs/nav'
 import { forwardRefWithName, useCancellation, useOnMount, useStore, withDisplayName } from 'src/libs/react-utils'
 import { asyncImportJobStore } from 'src/libs/state'
 import * as StateHistory from 'src/libs/state-history'
@@ -547,7 +549,7 @@ const WorkspaceData = _.flow(
     breadcrumbs: props => breadcrumbs.commonPaths.workspaceDashboard(props),
     title: 'Data', activeTab: 'data'
   })
-)(({ namespace, name, workspace, workspace: { workspace: { googleProject, attributes } }, refreshWorkspace }, ref) => {
+)(({ namespace, name, workspace, workspace: { workspace: { googleProject, attributes, workspaceId } }, refreshWorkspace }, ref) => {
   // State
   const [firstRender, setFirstRender] = useState(true)
   const [refreshKey, setRefreshKey] = useState(0)
@@ -690,6 +692,9 @@ const WorkspaceData = _.flow(
                 'aria-haspopup': 'dialog',
                 onClick: () => setUploadingFile(true)
               }, 'Upload TSV'),
+              h(MenuButton, {
+                href: `${Nav.getLink('upload')}?${qs.stringify({ workspace: workspaceId })}`
+              }, 'Open data uploader'),
               h(MenuButton, {
                 'aria-haspopup': 'dialog',
                 onClick: () => setImportingReference(true)


### PR DESCRIPTION
This adds a link to the data uploader (https://app.terra.bio/#upload) to the workspace data tab.

This is part of the data tab redesign from #2907 and #2923. To see the new design, run `configOverridesStore.set({ isDataTabRedesignEnabled: true })` in the console and refresh.

![Screen Shot 2022-04-11 at 11 39 36 AM](https://user-images.githubusercontent.com/1156625/162778470-3c0ca921-9744-4d83-a647-13843c260105.png)

The data uploader is a multi-step process, where the user is prompted to select a workspace, then a "collection", then upload files, and finally upload metadata for those files. Since this is linking from a workspace's data tab, we want to be able to skip the select workspace step. While the `UploadData` component can accept an initial selection for workspace and collection via query parameters, it currently always starts out on the select workspaces step. This also updates `UploadData`'s initial state to start at a later step if some data is already provided through query parameters.