### PR TITLE
[SU-56] Update confirmation prompts for deleting workspace data

### DIFF
--- a/src/components/data/LocalVariablesContent.js
+++ b/src/components/data/LocalVariablesContent.js
@@ -3,13 +3,12 @@ import _ from 'lodash/fp'
 import { Fragment, useEffect, useState } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
 import { AutoSizer } from 'react-virtualized'
-import { ButtonPrimary, Link, Select, spinnerOverlay } from 'src/components/common'
+import { DeleteConfirmationModal, Link, Select, spinnerOverlay } from 'src/components/common'
 import { renderDataCell, saveScroll } from 'src/components/data/data-utils'
 import Dropzone from 'src/components/Dropzone'
 import FloatingActionButton from 'src/components/FloatingActionButton'
 import { icon } from 'src/components/icons'
 import { DelayedSearchInput, TextInput } from 'src/components/input'
-import Modal from 'src/components/Modal'
 import { FlexTable, HeaderCell } from 'src/components/table'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
@@ -284,22 +283,20 @@ const LocalVariablesContent = ({ workspace, workspace: { workspace: { googleProj
         setEditDescription('')
       }
     }),
-    deleteIndex !== undefined && h(Modal, {
-      onDismiss: () => { setDeleteIndex(undefined) },
-      title: 'Are you sure you wish to delete this variable?',
-      okButton: h(ButtonPrimary, {
-        onClick: _.flow(
-          withErrorReporting('Error deleting workspace variable'),
-          Utils.withBusyState(setBusy)
-        )(async () => {
-          setDeleteIndex()
-          await Ajax().Workspaces.workspace(namespace, name)
-            .deleteAttributes([amendedAttributes[deleteIndex][0], toDescriptionKey(amendedAttributes[deleteIndex][0])])
-          await loadAttributes()
-        })
-      },
-      'Delete Variable')
-    }, ['This will permanently delete the data from Workspace Data.']),
+    deleteIndex !== undefined && h(DeleteConfirmationModal, {
+      objectType: 'variable',
+      objectName: amendedAttributes[deleteIndex][0],
+      onConfirm: _.flow(
+        Utils.withBusyState(setBusy),
+        withErrorReporting('Error deleting workspace variable')
+      )(async () => {
+        setDeleteIndex(undefined)
+        await Ajax().Workspaces.workspace(namespace, name)
+          .deleteAttributes([amendedAttributes[deleteIndex][0], toDescriptionKey(amendedAttributes[deleteIndex][0])])
+        loadAttributes()
+      }),
+      onDismiss: () => setDeleteIndex(undefined)
+    }),
     busy && spinnerOverlay
   ])])
 }

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -131,25 +131,26 @@ export const ReferenceDataImporter = ({ onSuccess, onDismiss, namespace, name })
 export const ReferenceDataDeleter = ({ onSuccess, onDismiss, namespace, name, referenceDataType }) => {
   const [deleting, setDeleting] = useState(false)
 
-  return h(Modal, {
-    onDismiss,
-    title: 'Confirm Delete',
-    okButton: h(ButtonPrimary, {
-      disabled: deleting,
-      onClick: async () => {
-        setDeleting(true)
-        try {
-          await Ajax().Workspaces.workspace(namespace, name).deleteAttributes(
-            _.map(key => `referenceData_${referenceDataType}_${key}`, _.keys(ReferenceData[referenceDataType]))
-          )
-          onSuccess()
-        } catch (error) {
-          await reportError('Error deleting reference data', error)
-          onDismiss()
-        }
+  return h(DeleteConfirmationModal, {
+    objectType: 'reference',
+    objectName: referenceDataType,
+    onConfirm: async () => {
+      setDeleting(true)
+      try {
+        await Ajax().Workspaces.workspace(namespace, name).deleteAttributes(
+          _.map(key => `referenceData_${referenceDataType}_${key}`, _.keys(ReferenceData[referenceDataType]))
+        )
+        onSuccess()
+      } catch (error) {
+        reportError('Error deleting reference data', error)
+        onDismiss()
       }
-    }, ['Delete'])
-  }, [`Are you sure you want to delete ${referenceDataType}?`])
+    },
+    onDismiss
+  }, [
+    div(['Are you sure you want to delete the ', span({ style: { fontWeight: 600 } }, [referenceDataType]), ' reference data?']),
+    deleting && absoluteSpinnerOverlay
+  ])
 }
 
 export const EntityDeleter = ({ onDismiss, onSuccess, namespace, name, selectedEntities, selectedDataType, runningSubmissionsCount }) => {


### PR DESCRIPTION
Use common component for confirming deleting workspace data variables and reference data.

## Before
![Screen Shot 2022-04-12 at 4 23 21 PM](https://user-images.githubusercontent.com/1156625/163047522-3abdb96a-4ba1-426c-b385-ec0394f84e42.png)

![Screen Shot 2022-04-12 at 4 23 31 PM](https://user-images.githubusercontent.com/1156625/163047524-8a67f29a-ac9b-49f7-a443-f40ef6756613.png)

## After
<img width="453" alt="Screen Shot 2022-04-15 at 7 12 42 AM" src="https://user-images.githubusercontent.com/1156625/163564582-4be16540-1a82-4b7f-a5db-0c62a0551192.png">

<img width="460" alt="Screen Shot 2022-04-15 at 7 12 56 AM" src="https://user-images.githubusercontent.com/1156625/163564592-705a1f50-38da-49d6-931d-fcde1f12026b.png">

Workspace data can be deleted from the "Workspace Data" panel of the Data tab. Hover over a table row to see the delete button.

![Screen Shot 2022-04-12 at 4 22 47 PM](https://user-images.githubusercontent.com/1156625/163047665-f042d130-1435-4193-81fb-fb6758d18edf.png)

Reference data can be deleted from the sidebar on the Data tab.

![Screen Shot 2022-04-12 at 4 21 53 PM](https://user-images.githubusercontent.com/1156625/163047803-9d0f5bd1-5d3b-41a0-bfab-8d5109072c77.png)

