### PR TITLE
[DC-290] Fixed Cookie banner so it flickers IN instead of OUT

### DIFF
--- a/src/components/CookieWarning.js
+++ b/src/components/CookieWarning.js
@@ -23,7 +23,11 @@ const CookieWarning = () => {
   const rejectCookies = async () => {
     const cookies = document.cookie.split(';')
     acceptCookies(false)
-    await Ajax(signal).Runtimes.invalidateCookie()
+    try {
+      await Ajax(signal).Runtimes.invalidateCookie()
+    } catch (err) {
+      // Do Nothing
+    }
     // Expire all cookies
     _.forEach(cookie => {
       // Find an equals sign and uses it to grab the substring of the cookie that is its name
@@ -33,7 +37,7 @@ const CookieWarning = () => {
     }, cookies)
     signOut()
   }
-  return !cookiesAccepted && aside({
+  return cookiesAccepted === false && aside({
     'aria-label': 'cookie consent banner',
     style: {
       flex: 0, height: 100, width: '100%',

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -110,7 +110,7 @@ export const initializeAuth = _.memoize(async () => {
         fenceStatus: isSignedIn ? state.fenceStatus : {},
         // Load whether a user has input a cookie acceptance in a previous session on this system,
         // or whether they input cookie acceptance previously in this session
-        cookiesAccepted: isSignedIn ? state.cookiesAccepted || getLocalPrefForUserId(user.getId(), cookiesAcceptedKey) : undefined,
+        cookiesAccepted: isSignedIn ? state.cookiesAccepted || getLocalPrefForUserId(user.getId(), cookiesAcceptedKey) : false,
         isTimeoutEnabled: isSignedIn ? state.isTimeoutEnabled : undefined,
         user: {
           token: authResponse ? authResponse.access_token : undefined,


### PR DESCRIPTION
Not sure if this is an okay solution. The problem was that when you refresh the page as a logged in user, the "Accept / Reject Cookies?" banner would flicker for a second before remembering who you were and disappearing. Now, the banner will be gone, but will pop in on top if you havent accepted it instead.

I think this works better, and would like to restyle the banner if that's okay too, so it's a pop over on existing content - I think this would make the banner appearing after a second feel better to the user. Wanted to get some opinions first tho!