### PR TITLE
[SU-70] Prevent sorting data table when clicking an option in column menu

### DIFF
--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -1071,17 +1071,19 @@ export const ModalToolButton = ({ icon, text, disabled, ...props }) => {
 }
 
 export const HeaderOptions = ({ sort, field, onSort, extraActions, children }) => {
-  const columnMenu = h(MenuTrigger, {
-    closeOnClick: true,
-    side: 'bottom',
-    content: h(Fragment, [
-      h(MenuButton, { onClick: () => onSort({ field, direction: 'asc' }) }, ['Sort Ascending']),
-      h(MenuButton, { onClick: () => onSort({ field, direction: 'desc' }) }, ['Sort Descending']),
-      _.map(({ label, onClick }) => h(MenuButton, { key: label, onClick }, [label]), extraActions)
-    ])
-  }, [
-    h(Link, { 'aria-label': 'Workflow menu', onClick: e => e.stopPropagation() }, [
-      icon('cardMenuIcon', { size: 16 })
+  const columnMenu = span({ onClick: e => e.stopPropagation() }, [
+    h(MenuTrigger, {
+      closeOnClick: true,
+      side: 'bottom',
+      content: h(Fragment, [
+        h(MenuButton, { onClick: () => onSort({ field, direction: 'asc' }) }, ['Sort Ascending']),
+        h(MenuButton, { onClick: () => onSort({ field, direction: 'desc' }) }, ['Sort Descending']),
+        _.map(({ label, onClick }) => h(MenuButton, { key: label, onClick }, [label]), extraActions)
+      ])
+    }, [
+      h(Link, { 'aria-label': 'Column menu' }, [
+        icon('cardMenuIcon', { size: 16 })
+      ])
     ])
   ])
 


### PR DESCRIPTION
Currently, when an option in a data table column's menu is clicked, the event bubbles up to the Sortable containing the MenuTrigger and causes an extra sort. This causes the table to be sorted when the delete or clear column options are clicked and can also cause the table to be sorted in the wrong order when one of the sort options is clicked.

This wraps the MenuTrigger in a span that stops the event from bubbling up any further.

Alternatively, Popup's onClick handler could stop propagation, but there are so many instances of PopupTrigger in the app that something may be relying on the current behavior.
https://github.com/DataBiosphere/terra-ui/blob/efa941e577f804ffb2d13f3c3534010f0276262b/src/components/PopupTrigger.js#L84

For reviewers, the diff is smaller when [ignoring whitespace](https://github.com/DataBiosphere/terra-ui/pull/2959/files?w=1).

## Before
https://user-images.githubusercontent.com/1156625/163479284-9ad3a67d-ec55-4716-81c7-f6f0d3f0ecce.mov

## After
https://user-images.githubusercontent.com/1156625/163479298-04cd4395-abf3-4231-942a-c8bc54d370e5.mov
