### PR TITLE
[SU-90, SU-54, SU-55] Workspace dashboard sidebar redesign 

### DIFF
--- a/src/libs/style.js
+++ b/src/libs/style.js
@@ -136,12 +136,16 @@ export const dashboard = {
     flex: 1, padding: '0 2rem 2rem 2rem'
   },
   rightBox: {
-    flex: 'none', width: 350, backgroundColor: colors.light(0.4),
-    padding: '0 1rem 2rem'
+    flex: 'none', width: 450, backgroundColor: colors.light(0.4),
+    padding: '1rem 1rem 2rem'
   },
   header: {
     ...elements.sectionHeader, textTransform: 'uppercase',
-    margin: '2.5rem 0 1rem 0', display: 'flex'
+    margin: '2.5rem 1rem 1rem 0', display: 'flex'
+  },
+  newHeader: {
+    ...elements.sectionHeader, color: colors.accent(0.8), textTransform: 'uppercase',
+    margin: '0.5rem', display: 'flex'
   },
   infoTile: {
     backgroundColor: colors.dark(0.15), color: 'black',

--- a/src/libs/style.js
+++ b/src/libs/style.js
@@ -139,6 +139,9 @@ export const dashboard = {
     flex: 'none', width: 450, backgroundColor: colors.light(0.4),
     padding: '1rem 1rem 2rem'
   },
+  rightBoxContainer: {
+    borderRadius: 5, backgroundColor: 'white', padding: '0.5rem'
+  },
   header: {
     ...elements.sectionHeader, textTransform: 'uppercase',
     margin: '2.5rem 0 1rem 0', display: 'flex'

--- a/src/libs/style.js
+++ b/src/libs/style.js
@@ -136,7 +136,7 @@ export const dashboard = {
     flex: 1, padding: '0 2rem 2rem 2rem'
   },
   rightBox: {
-    flex: 'none', width: 450, backgroundColor: colors.light(0.4),
+    flex: 'none', width: 470, backgroundColor: colors.light(0.4),
     padding: '1rem 1rem 2rem'
   },
   rightBoxContainer: {

--- a/src/libs/style.js
+++ b/src/libs/style.js
@@ -146,7 +146,7 @@ export const dashboard = {
     ...elements.sectionHeader, textTransform: 'uppercase',
     margin: '2.5rem 0 1rem 0', display: 'flex'
   },
-  collapsableHeader: {
+  collapsibleHeader: {
     ...elements.sectionHeader, color: colors.accent(), textTransform: 'uppercase',
     margin: '0.5rem 0.5rem 0 0.5rem', display: 'flex', fontSize: 14
   },

--- a/src/libs/style.js
+++ b/src/libs/style.js
@@ -141,9 +141,9 @@ export const dashboard = {
   },
   header: {
     ...elements.sectionHeader, textTransform: 'uppercase',
-    margin: '2.5rem 1rem 1rem 0', display: 'flex'
+    margin: '2.5rem 0 1rem 0', display: 'flex'
   },
-  newHeader: {
+  collapsableHeader: {
     ...elements.sectionHeader, color: colors.accent(), textTransform: 'uppercase',
     margin: '0.5rem 0.5rem 0 0.5rem', display: 'flex', fontSize: 14
   },

--- a/src/libs/style.js
+++ b/src/libs/style.js
@@ -148,7 +148,7 @@ export const dashboard = {
   },
   collapsibleHeader: {
     ...elements.sectionHeader, color: colors.accent(), textTransform: 'uppercase',
-    margin: '0.5rem 0.5rem 0 0.5rem', display: 'flex', fontSize: 14
+    padding: '0.5rem 0.5rem 0 0.5rem', display: 'flex', fontSize: 14
   },
   infoTile: {
     backgroundColor: colors.dark(0.15), color: 'black',

--- a/src/libs/style.js
+++ b/src/libs/style.js
@@ -145,7 +145,7 @@ export const dashboard = {
   },
   newHeader: {
     ...elements.sectionHeader, color: colors.accent(0.8), textTransform: 'uppercase',
-    margin: '0.5rem', display: 'flex'
+    margin: '0.5rem 0.5rem 0 0.5rem', display: 'flex', fontSize: 14
   },
   infoTile: {
     backgroundColor: colors.dark(0.15), color: 'black',

--- a/src/libs/style.js
+++ b/src/libs/style.js
@@ -144,7 +144,7 @@ export const dashboard = {
     margin: '2.5rem 1rem 1rem 0', display: 'flex'
   },
   newHeader: {
-    ...elements.sectionHeader, color: colors.accent(0.8), textTransform: 'uppercase',
+    ...elements.sectionHeader, color: colors.accent(), textTransform: 'uppercase',
     margin: '0.5rem 0.5rem 0 0.5rem', display: 'flex', fontSize: 14
   },
   infoTile: {

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp'
 import { Fragment, useEffect, useImperativeHandle, useState } from 'react'
-import { dd, div, dl, dt, h, h2, i, span } from 'react-hyperscript-helpers'
+import { dd, div, dl, dt, h, h3, i, span } from 'react-hyperscript-helpers'
 import * as breadcrumbs from 'src/components/breadcrumbs'
 import { requesterPaysWrapper, withRequesterPaysHandler } from 'src/components/bucket-utils'
 import Collapse from 'src/components/Collapse'
@@ -112,7 +112,7 @@ const RightBoxSection = ({ title, initialOpenState, onClick, children }) => {
   return div({ style: { paddingTop: '1rem' } }, [
     div({ style: Style.dashboard.rightBoxContainer }, [
       h(Collapse, {
-        title: h2({ style: Style.dashboard.collapsibleHeader }, [title]),
+        title: h3({ style: Style.dashboard.collapsibleHeader }, [title]),
         initialOpenState,
         titleFirst: true,
         onClick

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -308,7 +308,7 @@ const WorkspaceDashboard = _.flow(
       div({ style: { paddingTop: '1rem' } }, [
         div({ style: { borderRadius: 5, backgroundColor: 'white', padding: '0.5rem' } }, [
           h(Collapse, {
-            title: h2({ style: Style.dashboard.newHeader }, ['Workspace information']),
+            title: h2({ style: Style.dashboard.collapsableHeader }, ['Workspace information']),
             initialOpenState: workspaceInfoPanelOpen !== undefined ? workspaceInfoPanelOpen : true,
             titleFirst: true,
             onClick: () => setWorkspaceInfoPanelOpen(workspaceInfoPanelOpen === undefined ? false : !workspaceInfoPanelOpen)
@@ -323,7 +323,7 @@ const WorkspaceDashboard = _.flow(
       div({ style: { paddingTop: '1rem' } }, [
         div({ style: { borderRadius: 5, backgroundColor: 'white', padding: '0.5rem' } }, [
           h(Collapse, {
-            title: h2({ style: Style.dashboard.newHeader }, ['Cloud information']),
+            title: h2({ style: Style.dashboard.collapsableHeader }, ['Cloud information']),
             initialOpenState: cloudInfoPanelOpen,
             titleFirst: true,
             onClick: () => setCloudInfoPanelOpen(!cloudInfoPanelOpen)
@@ -358,7 +358,7 @@ const WorkspaceDashboard = _.flow(
       div({ style: { paddingTop: '1rem' } }, [
         div({ style: { borderRadius: 5, backgroundColor: 'white', padding: '0.5rem' } }, [
           h(Collapse, {
-            title: h2({ style: Style.dashboard.newHeader }, ['Owners']),
+            title: h2({ style: Style.dashboard.collapsableHeader }, ['Owners']),
             initialOpenState: ownersPanelOpen,
             titleFirst: true,
             onClick: () => setOwnersPanelOpen(!ownersPanelOpen)
@@ -375,7 +375,7 @@ const WorkspaceDashboard = _.flow(
       !_.isEmpty(authorizationDomain) && div({ style: { paddingTop: '1rem' } }, [
         div({ style: { borderRadius: 5, backgroundColor: 'white', padding: '0.5rem' } }, [
           h(Collapse, {
-            title: h2({ style: Style.dashboard.newHeader }, ['Authorization domain']),
+            title: h2({ style: Style.dashboard.collapsableHeader }, ['Authorization domain']),
             initialOpenState: authDomainPanelOpen,
             titleFirst: true,
             onClick: () => setAuthDomainPanelOpen(!authDomainPanelOpen)
@@ -395,7 +395,7 @@ const WorkspaceDashboard = _.flow(
       div({ style: { paddingTop: '1rem' } }, [
         div({ style: { borderRadius: 5, backgroundColor: 'white', padding: '0.5rem' } }, [
           h(Collapse, {
-            title: h2({ style: Style.dashboard.newHeader }, ['Tags',
+            title: h2({ style: Style.dashboard.collapsableHeader }, ['Tags',
               h(InfoBox, { style: { marginLeft: '0.25rem' } }, [
                 `${getAppName()} is not intended to host personally identifiable information. Do not use any patient identifier including name,
                 social security number, or medical record number.`

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -51,7 +51,7 @@ const roleString = {
 }
 
 const InfoRow = ({ title, subtitle, children }) => {
-  return dl({ role: 'row', style: { display: 'flex', justifyContent: 'space-between', margin: '1rem 0.5rem' } }, [
+  return div({ style: { display: 'flex', justifyContent: 'space-between', margin: '1rem 0.5rem' } }, [
     dt({ style: { width: 225 } }, [
       div({ style: { fontWeight: 500 } }, [title]),
       subtitle && div({ style: { fontWeight: 400, fontSize: 12 } }, [subtitle])
@@ -325,38 +325,42 @@ const WorkspaceDashboard = _.flow(
         initialOpenState: workspaceInfoPanelOpen !== undefined ? workspaceInfoPanelOpen : true,
         onClick: () => setWorkspaceInfoPanelOpen(workspaceInfoPanelOpen === undefined ? false : !workspaceInfoPanelOpen)
       }, [
-        h(InfoRow, { title: 'Last Updated' }, [new Date(lastModified).toLocaleDateString()]),
-        h(InfoRow, { title: 'Creation Date' }, [new Date(createdDate).toLocaleDateString()]),
-        h(InfoRow, { title: 'Workflow Submissions' }, [submissionsCount]),
-        h(InfoRow, { title: 'Access Level' }, [roleString[accessLevel]])
+        dl({}, [
+          h(InfoRow, { title: 'Last Updated' }, [new Date(lastModified).toLocaleDateString()]),
+          h(InfoRow, { title: 'Creation Date' }, [new Date(createdDate).toLocaleDateString()]),
+          h(InfoRow, { title: 'Workflow Submissions' }, [submissionsCount]),
+          h(InfoRow, { title: 'Access Level' }, [roleString[accessLevel]])
+        ])
       ]),
       h(RightBoxSection, {
         title: 'Cloud information',
         initialOpenState: cloudInfoPanelOpen,
         onClick: () => setCloudInfoPanelOpen(!cloudInfoPanelOpen)
       }, [
-        googleProject && h(InfoRow, { title: 'Cloud Name' }, [
-          h(GcpLogo, { title: 'Google Cloud Platform', role: 'img', style: { height: 16, width: 132, marginLeft: -15 } })
+        dl({}, [
+          googleProject && h(InfoRow, { title: 'Cloud Name' }, [
+            h(GcpLogo, { title: 'Google Cloud Platform', role: 'img', style: { height: 16, width: 132, marginLeft: -15 } })
+          ]),
+          h(InfoRow, { title: 'Location' }, [bucketLocation ? h(Fragment, [
+            h(TooltipCell, [flag, ' ', regionDescription])
+          ]) : 'Loading...']),
+          h(InfoRow, { title: 'Google Project ID' }, [
+            h(TooltipCell, [googleProject]),
+            h(ClipboardButton, { text: googleProject, style: { marginLeft: '0.25rem' } })
+          ]),
+          h(InfoRow, { title: 'Bucket Name' }, [
+            h(TooltipCell, [bucketName]),
+            h(ClipboardButton, { text: bucketName, style: { marginLeft: '0.25rem' } })
+          ]),
+          Utils.canWrite(accessLevel) && h(InfoRow, {
+            title: 'Estimated Storage Cost',
+            subtitle: storageCostEstimate ? `Updated on ${new Date(storageCostEstimateUpdated).toLocaleDateString()}` : 'Loading last updated...'
+          }, [storageCostEstimate || '$ ...']),
+          Utils.canWrite(accessLevel) && h(InfoRow, {
+            title: 'Bucket Size',
+            subtitle: bucketSize ? `Updated on ${new Date(bucketSizeUpdated).toLocaleDateString()}` : 'Loading last updated...'
+          }, [bucketSize])
         ]),
-        h(InfoRow, { title: 'Location' }, [bucketLocation ? h(Fragment, [
-          h(TooltipCell, [flag, ' ', regionDescription])
-        ]) : 'Loading...']),
-        h(InfoRow, { title: 'Google Project ID' }, [
-          h(TooltipCell, [googleProject]),
-          h(ClipboardButton, { text: googleProject, style: { marginLeft: '0.25rem' } })
-        ]),
-        h(InfoRow, { title: 'Bucket Name' }, [
-          h(TooltipCell, [bucketName]),
-          h(ClipboardButton, { text: bucketName, style: { marginLeft: '0.25rem' } })
-        ]),
-        Utils.canWrite(accessLevel) && h(InfoRow, {
-          title: 'Estimated Storage Cost',
-          subtitle: storageCostEstimate ? `Updated on ${new Date(storageCostEstimateUpdated).toLocaleDateString()}` : 'Loading last updated...'
-        }, [storageCostEstimate || '$ ...']),
-        Utils.canWrite(accessLevel) && h(InfoRow, {
-          title: 'Bucket Size',
-          subtitle: bucketSize ? `Updated on ${new Date(bucketSizeUpdated).toLocaleDateString()}` : 'Loading last updated...'
-        }, [bucketSize]),
         div({ style: { paddingBottom: '0.5rem' } }, [h(Link, {
           style: { margin: '1rem 0.5rem' },
           ...Utils.newTabLinkProps,

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -346,11 +346,11 @@ const WorkspaceDashboard = _.flow(
           ]) : 'Loading...']),
           h(InfoRow, { title: 'Google Project ID' }, [
             h(TooltipCell, [googleProject]),
-            h(ClipboardButton, { text: googleProject, style: { marginLeft: '0.25rem' } })
+            h(ClipboardButton, { 'aria-label': 'Copy google project id to clipboard', text: googleProject, style: { marginLeft: '0.25rem' } })
           ]),
           h(InfoRow, { title: 'Bucket Name' }, [
             h(TooltipCell, [bucketName]),
-            h(ClipboardButton, { text: bucketName, style: { marginLeft: '0.25rem' } })
+            h(ClipboardButton, { 'aria-label': 'Copy bucket name to clipboard', text: bucketName, style: { marginLeft: '0.25rem' } })
           ]),
           Utils.canWrite(accessLevel) && h(InfoRow, {
             title: 'Estimated Storage Cost',

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -392,9 +392,11 @@ const WorkspaceDashboard = _.flow(
       ]),
       h(RightBoxSection, {
         title: ['Tags',
-          h(InfoBox, { style: { marginLeft: '0.25rem' } }, [
-            `${getAppName()} is not intended to host personally identifiable information. Do not use any patient identifier including name,
-            social security number, or medical record number.`
+          span({ onClick: e => e.stopPropagation() }, [
+            h(InfoBox, { style: { marginLeft: '0.25rem' } }, [
+              `${getAppName()} is not intended to host personally identifiable information. Do not use any patient identifier including name,
+              social security number, or medical record number.`
+            ])
           ])],
         initialOpenState: tagsPanelOpen,
         onClick: () => setTagsPanelOpen(!tagsPanelOpen)

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -277,10 +277,53 @@ const WorkspaceDashboard = _.flow(
       ])
     ]),
     div({ style: Style.dashboard.rightBox }, [
+      div({ style: { paddingTop: '1rem' }}, [
+        div({ style: { borderRadius: 5, backgroundColor: 'white', padding: '0.5rem' }}, [
+          div({ style: Style.dashboard.newHeader }, ['Workspace information']),
+          'stuff'
+        ]),
+      ]),
+      div({ style: { paddingTop: '1rem' }}, [
+        div({ style: { borderRadius: 5, backgroundColor: 'white', padding: '0.5rem' }}, [
+          div({ style: Style.dashboard.newHeader }, ['Cloud information'])
+        ]),
+      ]),
+      div({ style: { paddingTop: '1rem' }}, [
+        div({ style: { borderRadius: 5, backgroundColor: 'white', padding: '0.5rem' }}, [
+          div({ style: Style.dashboard.newHeader }, ['Owners']),
+          div({ style: { margin: '0.5rem' } },
+          _.map(email => {
+            return div({ key: email, style: { overflow: 'hidden', textOverflow: 'ellipsis', marginBottom: '0.5rem' } }, [
+              h(Link, { href: `mailto:${email}` }, [email])
+            ])
+          }, owners)),
+        ]),
+      ]),
+      !_.isEmpty(authorizationDomain) && div({ style: { paddingTop: '1rem' }}, [
+        div({ style: { borderRadius: 5, backgroundColor: 'white', padding: '0.5rem' }}, [
+          div({ style: Style.dashboard.newHeader }, ['Authorization domains']),
+          div({ style: { margin: '0.5rem 0.5rem 1rem 0.5rem' } }, [
+            'Collaborators must be a member of all of these ',
+            h(Link, {
+              href: Nav.getLink('groups'),
+              ...Utils.newTabLinkProps
+            }, 'groups'),
+            ' to access this workspace.'
+          ]),
+          ..._.map(({ membersGroupName }) => div({ style: { margin: '0.5rem', fontWeight: 500 } }, [membersGroupName]), authorizationDomain)
+        ]),
+      ]),
+      div({ style: { paddingTop: '1rem' }}, [
+        div({ style: { borderRadius: 5, backgroundColor: 'white', padding: '0.5rem' }}, [
+          div({ style: Style.dashboard.newHeader }, ['Tags'])
+        ]),
+      ]),
+    ]),
+    false && div({ style: Style.dashboard.rightBox }, [
       div({ style: Style.dashboard.header }, ['Workspace information']),
       div({ style: { display: 'flex', flexWrap: 'wrap', margin: -4 } }, [
-        h(InfoTile, { title: 'Creation date' }, [new Date(createdDate).toLocaleDateString()]),
         h(InfoTile, { title: 'Last updated' }, [new Date(lastModified).toLocaleDateString()]),
+        h(InfoTile, { title: 'Creation date' }, [new Date(createdDate).toLocaleDateString()]),
         h(InfoTile, { title: 'Submissions' }, [submissionsCount]),
         h(InfoTile, { title: 'Access level' }, [roleString[accessLevel]]),
         Utils.canWrite(accessLevel) && h(InfoTile, { title: 'Est. $/month' }, [

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -308,7 +308,7 @@ const WorkspaceDashboard = _.flow(
       div({ style: { paddingTop: '1rem' } }, [
         div({ style: Style.dashboard.rightBoxContainer }, [
           h(Collapse, {
-            title: h2({ style: Style.dashboard.collapsableHeader }, ['Workspace information']),
+            title: h2({ style: Style.dashboard.collapsibleHeader }, ['Workspace information']),
             initialOpenState: workspaceInfoPanelOpen !== undefined ? workspaceInfoPanelOpen : true,
             titleFirst: true,
             onClick: () => setWorkspaceInfoPanelOpen(workspaceInfoPanelOpen === undefined ? false : !workspaceInfoPanelOpen)
@@ -323,7 +323,7 @@ const WorkspaceDashboard = _.flow(
       div({ style: { paddingTop: '1rem' } }, [
         div({ style: Style.dashboard.rightBoxContainer }, [
           h(Collapse, {
-            title: h2({ style: Style.dashboard.collapsableHeader }, ['Cloud information']),
+            title: h2({ style: Style.dashboard.collapsibleHeader }, ['Cloud information']),
             initialOpenState: cloudInfoPanelOpen,
             titleFirst: true,
             onClick: () => setCloudInfoPanelOpen(!cloudInfoPanelOpen)
@@ -358,7 +358,7 @@ const WorkspaceDashboard = _.flow(
       div({ style: { paddingTop: '1rem' } }, [
         div({ style: Style.dashboard.rightBoxContainer }, [
           h(Collapse, {
-            title: h2({ style: Style.dashboard.collapsableHeader }, ['Owners']),
+            title: h2({ style: Style.dashboard.collapsibleHeader }, ['Owners']),
             initialOpenState: ownersPanelOpen,
             titleFirst: true,
             onClick: () => setOwnersPanelOpen(!ownersPanelOpen)
@@ -375,7 +375,7 @@ const WorkspaceDashboard = _.flow(
       !_.isEmpty(authorizationDomain) && div({ style: { paddingTop: '1rem' } }, [
         div({ style: Style.dashboard.rightBoxContainer }, [
           h(Collapse, {
-            title: h2({ style: Style.dashboard.collapsableHeader }, ['Authorization domain']),
+            title: h2({ style: Style.dashboard.collapsibleHeader }, ['Authorization domain']),
             initialOpenState: authDomainPanelOpen,
             titleFirst: true,
             onClick: () => setAuthDomainPanelOpen(!authDomainPanelOpen)
@@ -395,7 +395,7 @@ const WorkspaceDashboard = _.flow(
       div({ style: { paddingTop: '1rem' } }, [
         div({ style: Style.dashboard.rightBoxContainer }, [
           h(Collapse, {
-            title: h2({ style: Style.dashboard.collapsableHeader }, ['Tags',
+            title: h2({ style: Style.dashboard.collapsibleHeader }, ['Tags',
               h(InfoBox, { style: { marginLeft: '0.25rem' } }, [
                 `${getAppName()} is not intended to host personally identifiable information. Do not use any patient identifier including name,
                 social security number, or medical record number.`

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -109,12 +109,16 @@ const DashboardAuthContainer = props => {
 }
 
 const RightBoxSection = ({ title, initialOpenState, onClick, children }) => {
-  return h(Collapse, {
-    title: h2({ style: Style.dashboard.collapsibleHeader }, [title]),
-    initialOpenState,
-    titleFirst: true,
-    onClick
-  }, [children])
+  return div({ style: { paddingTop: '1rem' } }, [
+    div({ style: Style.dashboard.rightBoxContainer }, [
+      h(Collapse, {
+        title: h2({ style: Style.dashboard.collapsibleHeader }, [title]),
+        initialOpenState,
+        titleFirst: true,
+        onClick
+      }, [children])
+    ])
+  ])
 }
 
 const WorkspaceDashboard = _.flow(
@@ -316,127 +320,107 @@ const WorkspaceDashboard = _.flow(
       ])
     ]),
     div({ style: Style.dashboard.rightBox }, [
-      div({ style: { paddingTop: '1rem' } }, [
-        div({ style: Style.dashboard.rightBoxContainer }, [
-          h(RightBoxSection, {
-            title: 'Workspace information',
-            initialOpenState: workspaceInfoPanelOpen !== undefined ? workspaceInfoPanelOpen : true,
-            onClick: () => setWorkspaceInfoPanelOpen(workspaceInfoPanelOpen === undefined ? false : !workspaceInfoPanelOpen)
-          }, [
-            h(InfoRow, { title: 'Last Updated' }, [new Date(lastModified).toLocaleDateString()]),
-            h(InfoRow, { title: 'Creation Date' }, [new Date(createdDate).toLocaleDateString()]),
-            h(InfoRow, { title: 'Workflow Submissions' }, [submissionsCount]),
-            h(InfoRow, { title: 'Access Level' }, [roleString[accessLevel]])
-          ])
-        ])
+      h(RightBoxSection, {
+        title: 'Workspace information',
+        initialOpenState: workspaceInfoPanelOpen !== undefined ? workspaceInfoPanelOpen : true,
+        onClick: () => setWorkspaceInfoPanelOpen(workspaceInfoPanelOpen === undefined ? false : !workspaceInfoPanelOpen)
+      }, [
+        h(InfoRow, { title: 'Last Updated' }, [new Date(lastModified).toLocaleDateString()]),
+        h(InfoRow, { title: 'Creation Date' }, [new Date(createdDate).toLocaleDateString()]),
+        h(InfoRow, { title: 'Workflow Submissions' }, [submissionsCount]),
+        h(InfoRow, { title: 'Access Level' }, [roleString[accessLevel]])
       ]),
-      div({ style: { paddingTop: '1rem' } }, [
-        div({ style: Style.dashboard.rightBoxContainer }, [
-          h(RightBoxSection, {
-            title: 'Cloud information',
-            initialOpenState: cloudInfoPanelOpen,
-            onClick: () => setCloudInfoPanelOpen(!cloudInfoPanelOpen)
-          }, [
-            googleProject && h(InfoRow, { title: 'Cloud Name' }, [
-              h(GcpLogo, { title: 'Google Cloud Platform', role: 'img', style: { height: 16, width: 132, marginLeft: -15 } })
-            ]),
-            h(InfoRow, { title: 'Location' }, [bucketLocation ? h(Fragment, [
-              h(TooltipCell, [flag, ' ', regionDescription])
-            ]) : 'Loading...']),
-            h(InfoRow, { title: 'Google Project ID' }, [
-              h(TooltipCell, [googleProject]),
-              h(ClipboardButton, { text: googleProject, style: { marginLeft: '0.25rem' } })
-            ]),
-            h(InfoRow, { title: 'Bucket Name' }, [
-              h(TooltipCell, [bucketName]),
-              h(ClipboardButton, { text: bucketName, style: { marginLeft: '0.25rem' } })
-            ]),
-            Utils.canWrite(accessLevel) && h(InfoRow, {
-              title: 'Estimated Storage Cost',
-              subtitle: storageCostEstimate ? `Updated on ${new Date(storageCostEstimateUpdated).toLocaleDateString()}` : 'Loading last updated...'
-            }, [storageCostEstimate || '$ ...']),
-            Utils.canWrite(accessLevel) && h(InfoRow, {
-              title: 'Bucket Size',
-              subtitle: bucketSize ? `Updated on ${new Date(bucketSizeUpdated).toLocaleDateString()}` : 'Loading last updated...'
-            }, [bucketSize]),
-            div({ style: { paddingBottom: '0.5rem' } }, [h(Link, {
-              style: { margin: '1rem 0.5rem' },
-              ...Utils.newTabLinkProps,
-              href: bucketBrowserUrl(bucketName)
-            }, ['Open bucket in browser', icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })])])
-          ])
-        ])
+      h(RightBoxSection, {
+        title: 'Cloud information',
+        initialOpenState: cloudInfoPanelOpen,
+        onClick: () => setCloudInfoPanelOpen(!cloudInfoPanelOpen)
+      }, [
+        googleProject && h(InfoRow, { title: 'Cloud Name' }, [
+          h(GcpLogo, { title: 'Google Cloud Platform', role: 'img', style: { height: 16, width: 132, marginLeft: -15 } })
+        ]),
+        h(InfoRow, { title: 'Location' }, [bucketLocation ? h(Fragment, [
+          h(TooltipCell, [flag, ' ', regionDescription])
+        ]) : 'Loading...']),
+        h(InfoRow, { title: 'Google Project ID' }, [
+          h(TooltipCell, [googleProject]),
+          h(ClipboardButton, { text: googleProject, style: { marginLeft: '0.25rem' } })
+        ]),
+        h(InfoRow, { title: 'Bucket Name' }, [
+          h(TooltipCell, [bucketName]),
+          h(ClipboardButton, { text: bucketName, style: { marginLeft: '0.25rem' } })
+        ]),
+        Utils.canWrite(accessLevel) && h(InfoRow, {
+          title: 'Estimated Storage Cost',
+          subtitle: storageCostEstimate ? `Updated on ${new Date(storageCostEstimateUpdated).toLocaleDateString()}` : 'Loading last updated...'
+        }, [storageCostEstimate || '$ ...']),
+        Utils.canWrite(accessLevel) && h(InfoRow, {
+          title: 'Bucket Size',
+          subtitle: bucketSize ? `Updated on ${new Date(bucketSizeUpdated).toLocaleDateString()}` : 'Loading last updated...'
+        }, [bucketSize]),
+        div({ style: { paddingBottom: '0.5rem' } }, [h(Link, {
+          style: { margin: '1rem 0.5rem' },
+          ...Utils.newTabLinkProps,
+          href: bucketBrowserUrl(bucketName)
+        }, ['Open bucket in browser', icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })])])
       ]),
-      div({ style: { paddingTop: '1rem' } }, [
-        div({ style: Style.dashboard.rightBoxContainer }, [
-          h(RightBoxSection, {
-            title: 'Owners',
-            initialOpenState: ownersPanelOpen,
-            onClick: () => setOwnersPanelOpen(!ownersPanelOpen)
-          }, [
-            div({ style: { margin: '0.5rem' } },
-              _.map(email => {
-                return div({ key: email, style: { overflow: 'hidden', textOverflow: 'ellipsis', marginBottom: '0.5rem' } }, [
-                  h(Link, { href: `mailto:${email}` }, [email])
-                ])
-              }, owners))
-          ])
-        ])
-      ]),
-      !_.isEmpty(authorizationDomain) && div({ style: { paddingTop: '1rem' } }, [
-        div({ style: Style.dashboard.rightBoxContainer }, [
-          h(RightBoxSection, {
-            title: 'Authorization domain',
-            initialOpenState: authDomainPanelOpen,
-            onClick: () => setAuthDomainPanelOpen(!authDomainPanelOpen)
-          }, [
-            div({ style: { margin: '0.5rem 0.5rem 1rem 0.5rem' } }, [
-              'Collaborators must be a member of all of these ',
-              h(Link, {
-                href: Nav.getLink('groups'),
-                ...Utils.newTabLinkProps
-              }, 'groups'),
-              ' to access this workspace.'
-            ]),
-            ..._.map(({ membersGroupName }) => div({ style: { margin: '0.5rem', fontWeight: 500 } }, [membersGroupName]), authorizationDomain)
-          ])
-        ])
-      ]),
-      div({ style: { paddingTop: '1rem' } }, [
-        div({ style: Style.dashboard.rightBoxContainer }, [
-          h(RightBoxSection, {
-            title: ['Tags',
-              h(InfoBox, { style: { marginLeft: '0.25rem' } }, [
-                `${getAppName()} is not intended to host personally identifiable information. Do not use any patient identifier including name,
-                social security number, or medical record number.`
-              ])],
-            initialOpenState: tagsPanelOpen,
-            onClick: () => setTagsPanelOpen(!tagsPanelOpen)
-          }, [
-            div({ style: { margin: '0.5rem' } }, [
-              !Utils.editWorkspaceError(workspace) && div({ style: { marginBottom: '0.5rem' } }, [
-                h(WorkspaceTagSelect, {
-                  value: null,
-                  placeholder: 'Add a tag',
-                  'aria-label': 'Add a tag',
-                  onChange: ({ value }) => addTag(value)
-                })
-              ]),
-              div({ style: { display: 'flex', flexWrap: 'wrap', minHeight: '1.5rem' } }, [
-                _.map(tag => {
-                  return span({ key: tag, style: styles.tag }, [
-                    tag,
-                    !Utils.editWorkspaceError(workspace) && h(Link, {
-                      tooltip: 'Remove tag',
-                      disabled: busy,
-                      onClick: () => deleteTag(tag),
-                      style: { marginLeft: '0.25rem', verticalAlign: 'middle', display: 'inline-block' }
-                    }, [icon('times', { size: 14 })])
-                  ])
-                }, tagsList),
-                !!tagsList && _.isEmpty(tagsList) && i(['No tags yet'])
-              ])
+      h(RightBoxSection, {
+        title: 'Owners',
+        initialOpenState: ownersPanelOpen,
+        onClick: () => setOwnersPanelOpen(!ownersPanelOpen)
+      }, [
+        div({ style: { margin: '0.5rem' } },
+          _.map(email => {
+            return div({ key: email, style: { overflow: 'hidden', textOverflow: 'ellipsis', marginBottom: '0.5rem' } }, [
+              h(Link, { href: `mailto:${email}` }, [email])
             ])
+          }, owners))
+      ]),
+      !_.isEmpty(authorizationDomain) && h(RightBoxSection, {
+        title: 'Authorization domain',
+        initialOpenState: authDomainPanelOpen,
+        onClick: () => setAuthDomainPanelOpen(!authDomainPanelOpen)
+      }, [
+        div({ style: { margin: '0.5rem 0.5rem 1rem 0.5rem' } }, [
+          'Collaborators must be a member of all of these ',
+          h(Link, {
+            href: Nav.getLink('groups'),
+            ...Utils.newTabLinkProps
+          }, 'groups'),
+          ' to access this workspace.'
+        ]),
+        ..._.map(({ membersGroupName }) => div({ style: { margin: '0.5rem', fontWeight: 500 } }, [membersGroupName]), authorizationDomain)
+      ]),
+      h(RightBoxSection, {
+        title: ['Tags',
+          h(InfoBox, { style: { marginLeft: '0.25rem' } }, [
+            `${getAppName()} is not intended to host personally identifiable information. Do not use any patient identifier including name,
+            social security number, or medical record number.`
+          ])],
+        initialOpenState: tagsPanelOpen,
+        onClick: () => setTagsPanelOpen(!tagsPanelOpen)
+      }, [
+        div({ style: { margin: '0.5rem' } }, [
+          !Utils.editWorkspaceError(workspace) && div({ style: { marginBottom: '0.5rem' } }, [
+            h(WorkspaceTagSelect, {
+              value: null,
+              placeholder: 'Add a tag',
+              'aria-label': 'Add a tag',
+              onChange: ({ value }) => addTag(value)
+            })
+          ]),
+          div({ style: { display: 'flex', flexWrap: 'wrap', minHeight: '1.5rem' } }, [
+            _.map(tag => {
+              return span({ key: tag, style: styles.tag }, [
+                tag,
+                !Utils.editWorkspaceError(workspace) && h(Link, {
+                  tooltip: 'Remove tag',
+                  disabled: busy,
+                  onClick: () => deleteTag(tag),
+                  style: { marginLeft: '0.25rem', verticalAlign: 'middle', display: 'inline-block' }
+                }, [icon('times', { size: 14 })])
+              ])
+            }, tagsList),
+            !!tagsList && _.isEmpty(tagsList) && i(['No tags yet'])
           ])
         ])
       ])

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -401,7 +401,7 @@ const WorkspaceDashboard = _.flow(
             `${getAppName()} is not intended to host personally identifiable information. Do not use any patient identifier including name,
             social security number, or medical record number.`
           ]),
-          (busy || !tagsList) && tagsPanelOpen && spinner({ size: '1rem', style: { marginLeft: '0.5rem' } })
+          (busy || !tagsList) && tagsPanelOpen && spinner({ size: '1.5ch', style: { marginLeft: '0.5rem' } })
         ]),
         initialOpenState: tagsPanelOpen,
         onClick: () => setTagsPanelOpen(!tagsPanelOpen)

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -20,6 +20,7 @@ import colors from 'src/libs/colors'
 import { reportError, withErrorReporting } from 'src/libs/error'
 import { getAppName } from 'src/libs/logos'
 import * as Nav from 'src/libs/nav'
+import { getLocalPref, setLocalPref } from 'src/libs/prefs'
 import { forwardRefWithName, useCancellation, useOnMount, useStore } from 'src/libs/react-utils'
 import { authStore } from 'src/libs/state'
 import * as Style from 'src/libs/style'
@@ -140,6 +141,8 @@ const WorkspaceDashboard = _.flow(
   const [bucketLocation, setBucketLocation] = useState(undefined)
   const [bucketLocationType, setBucketLocationType] = useState(undefined)
 
+  const persistenceId = `workspaces/${namespace}/${name}/dashboard`
+
   const signal = useCancellation()
 
   const refresh = () => {
@@ -153,6 +156,15 @@ const WorkspaceDashboard = _.flow(
 
   useImperativeHandle(ref, () => ({ refresh }))
 
+  const [workspacePanelOpen, setWorkspaceInfoPanelOpen] = useState(() => getLocalPref(persistenceId)?.workspaceInfoPanelOpen || true)
+  const [cloudPanelOpen, setCloudInfoPanelOpen] = useState(() => getLocalPref(persistenceId)?.cloudInfoPanelOpen || false)
+  const [ownersPanelOpen, setOwnersPanelOpen] = useState(() => getLocalPref(persistenceId)?.ownersPanelOpen || false)
+  const [authDomainPanelOpen, setAuthDomainPanelOpen] = useState(() => getLocalPref(persistenceId)?.authDomainPanelOpen || false)
+  const [tagsPanelOpen, setTagsPanelOpen] = useState(() => getLocalPref(persistenceId)?.tagsPanelOpen || false)
+
+  useEffect(() => {
+    setLocalPref(persistenceId, { workspaceInfoPanelOpen, cloudInfoPanelOpen, ownersPanelOpen, authDomainPanelOpen, tagsPanelOpen })
+  }, [workspaceInfoPanelOpen, cloudInfoPanelOpen, ownersPanelOpen, authDomainPanelOpen, tagsPanelOpen]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Helpers
   const loadSubmissionCount = withErrorReporting('Error loading submission count data', async () => {
@@ -297,9 +309,9 @@ const WorkspaceDashboard = _.flow(
         div({ style: { borderRadius: 5, backgroundColor: 'white', padding: '0.5rem' } }, [
           h(Collapse, {
             title: h2({ style: Style.dashboard.newHeader }, ['Workspace information']),
-            initialOpenState: true,
+            initialOpenState: workspaceInfoPanelOpen,
             titleFirst: true,
-            style: {}
+            onClick: () => setWorkspaceInfoPanelOpen(!workspaceInfoPanelOpen)
           }, [
             h(InfoRow, { title: 'Last Updated' }, [new Date(lastModified).toLocaleDateString()]),
             h(InfoRow, { title: 'Creation Date' }, [new Date(createdDate).toLocaleDateString()]),
@@ -312,9 +324,9 @@ const WorkspaceDashboard = _.flow(
         div({ style: { borderRadius: 5, backgroundColor: 'white', padding: '0.5rem' } }, [
           h(Collapse, {
             title: h2({ style: Style.dashboard.newHeader }, ['Cloud information']),
-            initialOpenState: true,
+            initialOpenState: cloudInfoPanelOpen,
             titleFirst: true,
-            style: {}
+            onClick: () => setCloudInfoPanelOpen(!cloudInfoPanelOpen)
           }, [
             googleProject && h(InfoRow, { title: 'Cloud Name' }, [
               h(GcpLogo, { title: 'Google Cloud Platform', role: 'img', style: { height: 16, width: 132, marginLeft: -15 } })
@@ -347,9 +359,9 @@ const WorkspaceDashboard = _.flow(
         div({ style: { borderRadius: 5, backgroundColor: 'white', padding: '0.5rem' } }, [
           h(Collapse, {
             title: h2({ style: Style.dashboard.newHeader }, ['Owners']),
-            initialOpenState: false,
+            initialOpenState: ownersPanelOpen,
             titleFirst: true,
-            style: {}
+            onClick: () => setOwnersPanelOpen(!ownersPanelOpen)
           }, [
             div({ style: { margin: '0.5rem' } },
               _.map(email => {
@@ -364,9 +376,9 @@ const WorkspaceDashboard = _.flow(
         div({ style: { borderRadius: 5, backgroundColor: 'white', padding: '0.5rem' } }, [
           h(Collapse, {
             title: h2({ style: Style.dashboard.newHeader }, ['Authorization domain']),
-            initialOpenState: false,
+            initialOpenState: authDomainPanelOpen,
             titleFirst: true,
-            style: {}
+            onClick: () => setAuthDomainPanelOpen(!authDomainPanelOpen)
           }, [
             div({ style: { margin: '0.5rem 0.5rem 1rem 0.5rem' } }, [
               'Collaborators must be a member of all of these ',
@@ -388,9 +400,9 @@ const WorkspaceDashboard = _.flow(
                 `${getAppName()} is not intended to host personally identifiable information. Do not use any patient identifier including name,
                 social security number, or medical record number.`
               ])]),
-            initialOpenState: false,
+            initialOpenState: tagsPanelOpen,
             titleFirst: true,
-            style: {}
+            onClick: () => setTagsPanelOpen(!tagsPanelOpen)
           }, [
             div({ style: { margin: '0.5rem 0.5rem 1rem 0.5rem' } }, [
               !Utils.editWorkspaceError(workspace) && div({ style: { marginBottom: '0.5rem' } }, [

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -348,7 +348,7 @@ const WorkspaceDashboard = _.flow(
             }, [storageCostEstimate || '$ ...']),
             Utils.canWrite(accessLevel) && h(InfoRow, { title: 'Bucket Size' }, [bucketSize]),
             div({ style: { paddingBottom: '0.5rem' } }, [h(Link, {
-              style: { margin: '1rem 0.5rem', paddingBottom: '1rem' },
+              style: { margin: '1rem 0.5rem' },
               ...Utils.newTabLinkProps,
               href: bucketBrowserUrl(bucketName)
             }, ['Open bucket in browser', icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })])])
@@ -404,7 +404,7 @@ const WorkspaceDashboard = _.flow(
             titleFirst: true,
             onClick: () => setTagsPanelOpen(!tagsPanelOpen)
           }, [
-            div({ style: { margin: '0.5rem 0.5rem 1rem 0.5rem' } }, [
+            div({ style: { margin: '0.5rem' } }, [
               !Utils.editWorkspaceError(workspace) && div({ style: { marginBottom: '0.5rem' } }, [
                 h(WorkspaceTagSelect, {
                   value: null,

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -5,7 +5,7 @@ import * as breadcrumbs from 'src/components/breadcrumbs'
 import { requesterPaysWrapper, withRequesterPaysHandler } from 'src/components/bucket-utils'
 import Collapse from 'src/components/Collapse'
 import { ButtonPrimary, ButtonSecondary, ClipboardButton, Link, spinnerOverlay } from 'src/components/common'
-import { centeredSpinner, icon, spinner } from 'src/components/icons'
+import { centeredSpinner, icon } from 'src/components/icons'
 import { MarkdownEditor, MarkdownViewer } from 'src/components/markdown'
 import { InfoBox } from 'src/components/PopupTrigger'
 import { getRegionInfo } from 'src/components/region-common'
@@ -49,9 +49,12 @@ const roleString = {
   PROJECT_OWNER: 'Project Owner'
 }
 
-const InfoRow = ({ title, children }) => {
+const InfoRow = ({ title, subtitle, children }) => {
   return div({ role: 'row', style: { display: 'flex', justifyContent: 'space-between', margin: '1rem 0.5rem' } }, [
-    div({ style: { width: 225, fontWeight: 500 } }, [title]),
+    div({ style: { width: 225 } }, [
+      div({ style: { fontWeight: 500 } }, [title]),
+      subtitle && div({ style: { fontWeight: 400, fontSize: 12 } }, [subtitle])
+    ]),
     div({ style: { width: 225, display: 'flex', overflow: 'hidden' } }, [children])
   ])
 }
@@ -302,7 +305,10 @@ const WorkspaceDashboard = _.flow(
             h(InfoRow, { title: 'Creation Date' }, [new Date(createdDate).toLocaleDateString()]),
             h(InfoRow, { title: 'Workflow Submissions' }, [submissionsCount]),
             h(InfoRow, { title: 'Access Level' }, [roleString[accessLevel]]),
-            h(InfoRow, { title: 'Google Project ID' }, [h(TooltipCell, { style: { overflow: 'hidden', textOverflow: 'ellipsis' } }, [googleProject]), h(ClipboardButton, { text: googleProject, style: { marginLeft: '0.25rem' } })])
+            h(InfoRow, { title: 'Google Project ID' }, [
+              h(TooltipCell, { style: { overflow: 'hidden', textOverflow: 'ellipsis' } }, [googleProject]),
+              h(ClipboardButton, { text: googleProject, style: { marginLeft: '0.25rem' } })
+            ])
           ])
         ])
       ]),
@@ -314,13 +320,20 @@ const WorkspaceDashboard = _.flow(
             titleFirst: true,
             style: {}
           }, [
-            googleProject && h(InfoRow, { title: 'Cloud Name' }, [h(GcpLogo, { title: 'Google Cloud Platform', role: 'img', style: { height: 16, width: 132, marginLeft: -15 } })]),
+            googleProject && h(InfoRow, { title: 'Cloud Name' }, [
+              h(GcpLogo, { title: 'Google Cloud Platform', role: 'img', style: { height: 16, width: 132, marginLeft: -15 } })
+            ]),
             h(InfoRow, { title: 'Location' }, [bucketLocation ? h(Fragment, [
-              div({ style: { marginRight: '0.5rem' } }, [flag]),
-              [h(TooltipCell, { style: { overflow: 'hidden', textOverflow: 'ellipsis' } }, [regionDescription])]
+              div({ style: { marginRight: '0.5rem' } }, [flag]), [h(TooltipCell, { style: { overflow: 'hidden', textOverflow: 'ellipsis' } }, [regionDescription])]
             ]) : 'Loading...']),
-            h(InfoRow, { title: 'Bucket Name' }, [h(TooltipCell, { style: { overflow: 'hidden', textOverflow: 'ellipsis' } }, [bucketName]), h(ClipboardButton, { text: bucketName, style: { marginLeft: '0.25rem' } })]),
-            Utils.canWrite(accessLevel) && h(InfoRow, { title: 'Estimated Storage Cost' }, [storageCostEstimate || '$ ...']),
+            h(InfoRow, { title: 'Bucket Name' }, [
+              h(TooltipCell, { style: { overflow: 'hidden', textOverflow: 'ellipsis' } }, [bucketName]),
+              h(ClipboardButton, { text: bucketName, style: { marginLeft: '0.25rem' } })
+            ]),
+            Utils.canWrite(accessLevel) && h(InfoRow, {
+              title: 'Estimated Storage Cost',
+              subtitle: storageCostEstimate ? `Updated on ${new Date(storageCostEstimateUpdated).toLocaleDateString()}` : 'Loading last updated...'
+            }, [storageCostEstimate || '$ ...']),
             Utils.canWrite(accessLevel) && h(InfoRow, { title: 'Bucket Size' }, [bucketSize]),
             div({ style: { paddingBottom: '0.5rem' } }, [h(Link, {
               style: { margin: '1rem 0.5rem', paddingBottom: '1rem' },

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -7,6 +7,7 @@ import Collapse from 'src/components/Collapse'
 import { ButtonPrimary, ButtonSecondary, ClipboardButton, Link, spinnerOverlay } from 'src/components/common'
 import { centeredSpinner, icon, spinner } from 'src/components/icons'
 import { MarkdownEditor, MarkdownViewer } from 'src/components/markdown'
+import { InfoBox } from 'src/components/PopupTrigger'
 import { getRegionInfo } from 'src/components/region-common'
 import { SimpleTable, TooltipCell } from 'src/components/table'
 import TooltipTrigger from 'src/components/TooltipTrigger'
@@ -403,8 +404,11 @@ const WorkspaceDashboard = _.flow(
       }, [
         div({ style: { margin: '0.5rem' } }, [
           div({ style: { marginBottom: '0.5rem', fontSize: 12 } }, [
-            `${getAppName()} is not intended to host personally identifiable information. Do not use
-             any patient identifier including name, social security number, or medical record number.`
+            `${getAppName()} is not intended to host personally identifiable information.`,
+            h(InfoBox, { style: { marginLeft: '0.25rem' } }, [
+              `${getAppName()} is not intended to host personally identifiable information. Do not use any patient identifier including name,
+              social security number, or medical record number.`
+            ])
           ]),
           !Utils.editWorkspaceError(workspace) && div({ style: { marginBottom: '0.5rem' } }, [
             h(WorkspaceTagSelect, {

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -402,7 +402,7 @@ const WorkspaceDashboard = _.flow(
         onClick: () => setTagsPanelOpen(!tagsPanelOpen)
       }, [
         div({ style: { margin: '0.5rem' } }, [
-          div({ style: { marginBottom: '0.5rem' } }, [
+          div({ style: { marginBottom: '0.5rem', fontSize: 12 } }, [
             `${getAppName()} is not intended to host personally identifiable information. Do not use
              any patient identifier including name, social security number, or medical record number.`
           ]),

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -5,7 +5,7 @@ import * as breadcrumbs from 'src/components/breadcrumbs'
 import { requesterPaysWrapper, withRequesterPaysHandler } from 'src/components/bucket-utils'
 import Collapse from 'src/components/Collapse'
 import { ButtonPrimary, ButtonSecondary, ClipboardButton, Link, spinnerOverlay } from 'src/components/common'
-import { centeredSpinner, icon } from 'src/components/icons'
+import { centeredSpinner, icon, spinner } from 'src/components/icons'
 import { MarkdownEditor, MarkdownViewer } from 'src/components/markdown'
 import { InfoBox } from 'src/components/PopupTrigger'
 import { getRegionInfo } from 'src/components/region-common'
@@ -396,7 +396,8 @@ const WorkspaceDashboard = _.flow(
           h(InfoBox, { style: { marginLeft: '0.25rem' } }, [
             `${getAppName()} is not intended to host personally identifiable information. Do not use any patient identifier including name,
             social security number, or medical record number.`
-          ])
+          ]),
+          (busy || !tagsList) && tagsPanelOpen && spinner({ size: '1rem', style: { marginLeft: '0.5rem' } })
         ]),
         initialOpenState: tagsPanelOpen,
         onClick: () => setTagsPanelOpen(!tagsPanelOpen)

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -108,6 +108,15 @@ const DashboardAuthContainer = props => {
   )
 }
 
+const RightBoxSection = ({ title, initialOpenState, onClick, children }) => {
+  return h(Collapse, {
+    title: h2({ style: Style.dashboard.collapsibleHeader }, [title]),
+    initialOpenState,
+    titleFirst: true,
+    onClick
+  }, [children])
+}
+
 const WorkspaceDashboard = _.flow(
   forwardRefWithName('WorkspaceDashboard'),
   requesterPaysWrapper({ onDismiss: () => Nav.history.goBack() }),
@@ -309,10 +318,9 @@ const WorkspaceDashboard = _.flow(
     div({ style: Style.dashboard.rightBox }, [
       div({ style: { paddingTop: '1rem' } }, [
         div({ style: Style.dashboard.rightBoxContainer }, [
-          h(Collapse, {
-            title: h2({ style: Style.dashboard.collapsibleHeader }, ['Workspace information']),
+          h(RightBoxSection, {
+            title: 'Workspace information',
             initialOpenState: workspaceInfoPanelOpen !== undefined ? workspaceInfoPanelOpen : true,
-            titleFirst: true,
             onClick: () => setWorkspaceInfoPanelOpen(workspaceInfoPanelOpen === undefined ? false : !workspaceInfoPanelOpen)
           }, [
             h(InfoRow, { title: 'Last Updated' }, [new Date(lastModified).toLocaleDateString()]),
@@ -324,10 +332,9 @@ const WorkspaceDashboard = _.flow(
       ]),
       div({ style: { paddingTop: '1rem' } }, [
         div({ style: Style.dashboard.rightBoxContainer }, [
-          h(Collapse, {
-            title: h2({ style: Style.dashboard.collapsibleHeader }, ['Cloud information']),
+          h(RightBoxSection, {
+            title: 'Cloud information',
             initialOpenState: cloudInfoPanelOpen,
-            titleFirst: true,
             onClick: () => setCloudInfoPanelOpen(!cloudInfoPanelOpen)
           }, [
             googleProject && h(InfoRow, { title: 'Cloud Name' }, [
@@ -362,10 +369,9 @@ const WorkspaceDashboard = _.flow(
       ]),
       div({ style: { paddingTop: '1rem' } }, [
         div({ style: Style.dashboard.rightBoxContainer }, [
-          h(Collapse, {
-            title: h2({ style: Style.dashboard.collapsibleHeader }, ['Owners']),
+          h(RightBoxSection, {
+            title: 'Owners',
             initialOpenState: ownersPanelOpen,
-            titleFirst: true,
             onClick: () => setOwnersPanelOpen(!ownersPanelOpen)
           }, [
             div({ style: { margin: '0.5rem' } },
@@ -379,10 +385,9 @@ const WorkspaceDashboard = _.flow(
       ]),
       !_.isEmpty(authorizationDomain) && div({ style: { paddingTop: '1rem' } }, [
         div({ style: Style.dashboard.rightBoxContainer }, [
-          h(Collapse, {
-            title: h2({ style: Style.dashboard.collapsibleHeader }, ['Authorization domain']),
+          h(RightBoxSection, {
+            title: 'Authorization domain',
             initialOpenState: authDomainPanelOpen,
-            titleFirst: true,
             onClick: () => setAuthDomainPanelOpen(!authDomainPanelOpen)
           }, [
             div({ style: { margin: '0.5rem 0.5rem 1rem 0.5rem' } }, [
@@ -399,14 +404,13 @@ const WorkspaceDashboard = _.flow(
       ]),
       div({ style: { paddingTop: '1rem' } }, [
         div({ style: Style.dashboard.rightBoxContainer }, [
-          h(Collapse, {
-            title: h2({ style: Style.dashboard.collapsibleHeader }, ['Tags',
+          h(RightBoxSection, {
+            title: ['Tags',
               h(InfoBox, { style: { marginLeft: '0.25rem' } }, [
                 `${getAppName()} is not intended to host personally identifiable information. Do not use any patient identifier including name,
                 social security number, or medical record number.`
-              ])]),
+              ])],
             initialOpenState: tagsPanelOpen,
-            titleFirst: true,
             onClick: () => setTagsPanelOpen(!tagsPanelOpen)
           }, [
             div({ style: { margin: '0.5rem' } }, [

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp'
 import { Fragment, useEffect, useImperativeHandle, useState } from 'react'
-import { div, h, h2, i, span } from 'react-hyperscript-helpers'
+import { dd, div, dl, dt, h, h2, i, span } from 'react-hyperscript-helpers'
 import * as breadcrumbs from 'src/components/breadcrumbs'
 import { requesterPaysWrapper, withRequesterPaysHandler } from 'src/components/bucket-utils'
 import Collapse from 'src/components/Collapse'
@@ -51,12 +51,12 @@ const roleString = {
 }
 
 const InfoRow = ({ title, subtitle, children }) => {
-  return div({ role: 'row', style: { display: 'flex', justifyContent: 'space-between', margin: '1rem 0.5rem' } }, [
-    div({ style: { width: 225 } }, [
+  return dl({ role: 'row', style: { display: 'flex', justifyContent: 'space-between', margin: '1rem 0.5rem' } }, [
+    dt({ style: { width: 225 } }, [
       div({ style: { fontWeight: 500 } }, [title]),
       subtitle && div({ style: { fontWeight: 400, fontSize: 12 } }, [subtitle])
     ]),
-    div({ style: { width: 225, display: 'flex', overflow: 'hidden' } }, [children])
+    dd({ style: { width: 225, display: 'flex', overflow: 'hidden' } }, [children])
   ])
 }
 

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -304,11 +304,7 @@ const WorkspaceDashboard = _.flow(
             h(InfoRow, { title: 'Last Updated' }, [new Date(lastModified).toLocaleDateString()]),
             h(InfoRow, { title: 'Creation Date' }, [new Date(createdDate).toLocaleDateString()]),
             h(InfoRow, { title: 'Workflow Submissions' }, [submissionsCount]),
-            h(InfoRow, { title: 'Access Level' }, [roleString[accessLevel]]),
-            h(InfoRow, { title: 'Google Project ID' }, [
-              h(TooltipCell, { style: { overflow: 'hidden', textOverflow: 'ellipsis' } }, [googleProject]),
-              h(ClipboardButton, { text: googleProject, style: { marginLeft: '0.25rem' } })
-            ])
+            h(InfoRow, { title: 'Access Level' }, [roleString[accessLevel]])
           ])
         ])
       ]),
@@ -324,10 +320,14 @@ const WorkspaceDashboard = _.flow(
               h(GcpLogo, { title: 'Google Cloud Platform', role: 'img', style: { height: 16, width: 132, marginLeft: -15 } })
             ]),
             h(InfoRow, { title: 'Location' }, [bucketLocation ? h(Fragment, [
-              div({ style: { marginRight: '0.5rem' } }, [flag]), [h(TooltipCell, { style: { overflow: 'hidden', textOverflow: 'ellipsis' } }, [regionDescription])]
+              h(TooltipCell, [flag, ' ', regionDescription])
             ]) : 'Loading...']),
+            h(InfoRow, { title: 'Google Project ID' }, [
+              h(TooltipCell, [googleProject]),
+              h(ClipboardButton, { text: googleProject, style: { marginLeft: '0.25rem' } })
+            ]),
             h(InfoRow, { title: 'Bucket Name' }, [
-              h(TooltipCell, { style: { overflow: 'hidden', textOverflow: 'ellipsis' } }, [bucketName]),
+              h(TooltipCell, [bucketName]),
               h(ClipboardButton, { text: bucketName, style: { marginLeft: '0.25rem' } })
             ]),
             Utils.canWrite(accessLevel) && h(InfoRow, {

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -306,7 +306,7 @@ const WorkspaceDashboard = _.flow(
     ]),
     div({ style: Style.dashboard.rightBox }, [
       div({ style: { paddingTop: '1rem' } }, [
-        div({ style: { borderRadius: 5, backgroundColor: 'white', padding: '0.5rem' } }, [
+        div({ style: Style.dashboard.rightBoxContainer }, [
           h(Collapse, {
             title: h2({ style: Style.dashboard.collapsableHeader }, ['Workspace information']),
             initialOpenState: workspaceInfoPanelOpen !== undefined ? workspaceInfoPanelOpen : true,
@@ -321,7 +321,7 @@ const WorkspaceDashboard = _.flow(
         ])
       ]),
       div({ style: { paddingTop: '1rem' } }, [
-        div({ style: { borderRadius: 5, backgroundColor: 'white', padding: '0.5rem' } }, [
+        div({ style: Style.dashboard.rightBoxContainer }, [
           h(Collapse, {
             title: h2({ style: Style.dashboard.collapsableHeader }, ['Cloud information']),
             initialOpenState: cloudInfoPanelOpen,
@@ -356,7 +356,7 @@ const WorkspaceDashboard = _.flow(
         ])
       ]),
       div({ style: { paddingTop: '1rem' } }, [
-        div({ style: { borderRadius: 5, backgroundColor: 'white', padding: '0.5rem' } }, [
+        div({ style: Style.dashboard.rightBoxContainer }, [
           h(Collapse, {
             title: h2({ style: Style.dashboard.collapsableHeader }, ['Owners']),
             initialOpenState: ownersPanelOpen,
@@ -373,7 +373,7 @@ const WorkspaceDashboard = _.flow(
         ])
       ]),
       !_.isEmpty(authorizationDomain) && div({ style: { paddingTop: '1rem' } }, [
-        div({ style: { borderRadius: 5, backgroundColor: 'white', padding: '0.5rem' } }, [
+        div({ style: Style.dashboard.rightBoxContainer }, [
           h(Collapse, {
             title: h2({ style: Style.dashboard.collapsableHeader }, ['Authorization domain']),
             initialOpenState: authDomainPanelOpen,
@@ -393,7 +393,7 @@ const WorkspaceDashboard = _.flow(
         ])
       ]),
       div({ style: { paddingTop: '1rem' } }, [
-        div({ style: { borderRadius: 5, backgroundColor: 'white', padding: '0.5rem' } }, [
+        div({ style: Style.dashboard.rightBoxContainer }, [
           h(Collapse, {
             title: h2({ style: Style.dashboard.collapsableHeader }, ['Tags',
               h(InfoBox, { style: { marginLeft: '0.25rem' } }, [

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -280,20 +280,42 @@ const WorkspaceDashboard = _.flow(
     div({ style: Style.dashboard.rightBox }, [
       div({ style: { paddingTop: '1rem' } }, [
         div({ style: { borderRadius: 5, backgroundColor: 'white', padding: '0.5rem' } }, [
-          div({ style: Style.dashboard.newHeader }, ['Workspace information']),
-          'stuff'
-        ])
-      ]),
-      div({ style: { paddingTop: '1rem' } }, [
-        div({ style: { borderRadius: 5, backgroundColor: 'white', padding: '0.5rem' } }, [
-          div({ style: Style.dashboard.newHeader }, ['Cloud information'])
-        ])
-      ]),
-      div({ style: { paddingTop: '1rem' } }, [
-        div({ style: { borderRadius: 5, backgroundColor: 'white', padding: '0.5rem' } }, [
-        h(Collapse, {
-            title: h2({ style: Style.dashboard.newHeader }, ['Owners']),
+          h(Collapse, {
+            title: h2({ style: Style.dashboard.newHeader }, ['Workspace information']),
             initialOpenState: true,
+            titleFirst: true,
+            style: {}
+          }, [
+            div({ style: { margin: '1rem 0.5rem' } }, ['Last Updated']),
+            div({ style: { margin: '1rem 0.5rem' } }, ['Creation Date']),
+            div({ style: { margin: '1rem 0.5rem' } }, 'Workflow Submissions'),
+            div({ style: { margin: '1rem 0.5rem' } }, 'Access Level'),
+            div({ style: { margin: '1rem 0.5rem' } }, 'Google Project ID')
+          ])
+        ])
+      ]),
+      div({ style: { paddingTop: '1rem' } }, [
+        div({ style: { borderRadius: 5, backgroundColor: 'white', padding: '0.5rem' } }, [
+          h(Collapse, {
+            title: h2({ style: Style.dashboard.newHeader }, ['Cloud information']),
+            initialOpenState: false,
+            titleFirst: true,
+            style: {}
+          }, [
+            div({ style: { margin: '1rem 0.5rem' } }, 'Cloud Name'),
+            div({ style: { margin: '1rem 0.5rem' } }, 'Location'),
+            div({ style: { margin: '1rem 0.5rem' } }, 'Bucket Last Updated'),
+            div({ style: { margin: '1rem 0.5rem' } }, 'Estimated Storage Cost'),
+            div({ style: { margin: '1rem 0.5rem' } }, 'Bucket Size')
+          ])
+        ])
+      ]),
+      div({ style: { paddingTop: '1rem' } }, [
+        div({ style: { borderRadius: 5, backgroundColor: 'white', padding: '0.5rem' } }, [
+          h(Collapse, {
+            title: h2({ style: Style.dashboard.newHeader }, ['Owners']),
+            initialOpenState: false,
+            titleFirst: true,
             style: {}
           }, [
             div({ style: { margin: '0.5rem' } },
@@ -302,59 +324,64 @@ const WorkspaceDashboard = _.flow(
                   h(Link, { href: `mailto:${email}` }, [email])
                 ])
               }, owners))
-        ])
-//          div({ style: Style.dashboard.newHeader }, ['Owners']),
-//          div({ style: { margin: '0.5rem' } },
-//            _.map(email => {
-//              return div({ key: email, style: { overflow: 'hidden', textOverflow: 'ellipsis', marginBottom: '0.5rem' } }, [
-//                h(Link, { href: `mailto:${email}` }, [email])
-//              ])
-//            }, owners))
+          ])
         ])
       ]),
       !_.isEmpty(authorizationDomain) && div({ style: { paddingTop: '1rem' } }, [
         div({ style: { borderRadius: 5, backgroundColor: 'white', padding: '0.5rem' } }, [
-          div({ style: Style.dashboard.newHeader }, ['Authorization domains']),
-          div({ style: { margin: '0.5rem 0.5rem 1rem 0.5rem' } }, [
-            'Collaborators must be a member of all of these ',
-            h(Link, {
-              href: Nav.getLink('groups'),
-              ...Utils.newTabLinkProps
-            }, 'groups'),
-            ' to access this workspace.'
-          ]),
-          ..._.map(({ membersGroupName }) => div({ style: { margin: '0.5rem', fontWeight: 500 } }, [membersGroupName]), authorizationDomain)
+          h(Collapse, {
+            title: h2({ style: Style.dashboard.newHeader }, ['Authorization domains']),
+            initialOpenState: false,
+            titleFirst: true,
+            style: {}
+          }, [
+            div({ style: { margin: '0.5rem 0.5rem 1rem 0.5rem' } }, [
+              'Collaborators must be a member of all of these ',
+              h(Link, {
+                href: Nav.getLink('groups'),
+                ...Utils.newTabLinkProps
+              }, 'groups'),
+              ' to access this workspace.'
+            ]),
+            ..._.map(({ membersGroupName }) => div({ style: { margin: '0.5rem', fontWeight: 500 } }, [membersGroupName]), authorizationDomain)
+          ])
         ])
       ]),
       div({ style: { paddingTop: '1rem' } }, [
         div({ style: { borderRadius: 5, backgroundColor: 'white', padding: '0.5rem' } }, [
-          div({ style: Style.dashboard.newHeader }, ['Tags',
-            h(InfoBox, { style: { marginLeft: '0.25rem' } }, [
-              `${getAppName()} is not intended to host personally identifiable information. Do not use any patient identifier including name,
-              social security number, or medical record number.`
-            ])]),
-          div({ style: { margin: '0.5rem 0.5rem 1rem 0.5rem' } }, [
-            !Utils.editWorkspaceError(workspace) && div({ style: { marginBottom: '0.5rem' } }, [
-              h(WorkspaceTagSelect, {
-                value: null,
-                placeholder: 'Add a tag',
-                'aria-label': 'Add a tag',
-                onChange: ({ value }) => addTag(value)
-              })
-            ]),
-            div({ style: { display: 'flex', flexWrap: 'wrap', minHeight: '1.5rem' } }, [
-              _.map(tag => {
-                return span({ key: tag, style: styles.tag }, [
-                  tag,
-                  !Utils.editWorkspaceError(workspace) && h(Link, {
-                    tooltip: 'Remove tag',
-                    disabled: busy,
-                    onClick: () => deleteTag(tag),
-                    style: { marginLeft: '0.25rem', verticalAlign: 'middle', display: 'inline-block' }
-                  }, [icon('times', { size: 14 })])
-                ])
-              }, tagsList),
-              !!tagsList && _.isEmpty(tagsList) && i(['No tags yet'])
+          h(Collapse, {
+            title: h2({ style: Style.dashboard.newHeader }, ['Tags',
+              h(InfoBox, { style: { marginLeft: '0.25rem' } }, [
+                `${getAppName()} is not intended to host personally identifiable information. Do not use any patient identifier including name,
+                social security number, or medical record number.`
+              ])]),
+            initialOpenState: false,
+            titleFirst: true,
+            style: {}
+          }, [
+            div({ style: { margin: '0.5rem 0.5rem 1rem 0.5rem' } }, [
+              !Utils.editWorkspaceError(workspace) && div({ style: { marginBottom: '0.5rem' } }, [
+                h(WorkspaceTagSelect, {
+                  value: null,
+                  placeholder: 'Add a tag',
+                  'aria-label': 'Add a tag',
+                  onChange: ({ value }) => addTag(value)
+                })
+              ]),
+              div({ style: { display: 'flex', flexWrap: 'wrap', minHeight: '1.5rem' } }, [
+                _.map(tag => {
+                  return span({ key: tag, style: styles.tag }, [
+                    tag,
+                    !Utils.editWorkspaceError(workspace) && h(Link, {
+                      tooltip: 'Remove tag',
+                      disabled: busy,
+                      onClick: () => deleteTag(tag),
+                      style: { marginLeft: '0.25rem', verticalAlign: 'middle', display: 'inline-block' }
+                    }, [icon('times', { size: 14 })])
+                  ])
+                }, tagsList),
+                !!tagsList && _.isEmpty(tagsList) && i(['No tags yet'])
+              ])
             ])
           ])
         ])

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -7,7 +7,6 @@ import Collapse from 'src/components/Collapse'
 import { ButtonPrimary, ButtonSecondary, ClipboardButton, Link, spinnerOverlay } from 'src/components/common'
 import { centeredSpinner, icon, spinner } from 'src/components/icons'
 import { MarkdownEditor, MarkdownViewer } from 'src/components/markdown'
-import { InfoBox } from 'src/components/PopupTrigger'
 import { getRegionInfo } from 'src/components/region-common'
 import { SimpleTable, TooltipCell } from 'src/components/table'
 import TooltipTrigger from 'src/components/TooltipTrigger'
@@ -396,17 +395,17 @@ const WorkspaceDashboard = _.flow(
       ]),
       h(RightBoxSection, {
         title: 'Tags',
-        info: span({ onClick: e => e.stopPropagation() }, [
-          h(InfoBox, { style: { marginLeft: '0.25rem' } }, [
-            `${getAppName()} is not intended to host personally identifiable information. Do not use any patient identifier including name,
-            social security number, or medical record number.`
-          ]),
-          (busy || !tagsList) && tagsPanelOpen && spinner({ size: '1.5ch', style: { marginLeft: '0.5rem' } })
+        info: span({}, [
+          (busy || !tagsList) && tagsPanelOpen && spinner({ size: '1ch', style: { marginLeft: '0.5rem' } })
         ]),
         initialOpenState: tagsPanelOpen,
         onClick: () => setTagsPanelOpen(!tagsPanelOpen)
       }, [
         div({ style: { margin: '0.5rem' } }, [
+          div({ style: { marginBottom: '0.5rem' } }, [
+            `${getAppName()} is not intended to host personally identifiable information. Do not use
+             any patient identifier including name, social security number, or medical record number.`
+          ]),
           !Utils.editWorkspaceError(workspace) && div({ style: { marginBottom: '0.5rem' } }, [
             h(WorkspaceTagSelect, {
               menuShouldScrollIntoView: false,

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -404,6 +404,7 @@ const WorkspaceDashboard = _.flow(
         div({ style: { margin: '0.5rem' } }, [
           !Utils.editWorkspaceError(workspace) && div({ style: { marginBottom: '0.5rem' } }, [
             h(WorkspaceTagSelect, {
+              menuShouldScrollIntoView: false,
               value: null,
               placeholder: 'Add a tag',
               'aria-label': 'Add a tag',

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -156,7 +156,7 @@ const WorkspaceDashboard = _.flow(
 
   useImperativeHandle(ref, () => ({ refresh }))
 
-  const [workspaceInfoPanelOpen, setWorkspaceInfoPanelOpen] = useState(() => getLocalPref(persistenceId)?.workspaceInfoPanelOpen || true)
+  const [workspaceInfoPanelOpen, setWorkspaceInfoPanelOpen] = useState(() => getLocalPref(persistenceId)?.workspaceInfoPanelOpen)
   const [cloudInfoPanelOpen, setCloudInfoPanelOpen] = useState(() => getLocalPref(persistenceId)?.cloudInfoPanelOpen || false)
   const [ownersPanelOpen, setOwnersPanelOpen] = useState(() => getLocalPref(persistenceId)?.ownersPanelOpen || false)
   const [authDomainPanelOpen, setAuthDomainPanelOpen] = useState(() => getLocalPref(persistenceId)?.authDomainPanelOpen || false)
@@ -309,9 +309,9 @@ const WorkspaceDashboard = _.flow(
         div({ style: { borderRadius: 5, backgroundColor: 'white', padding: '0.5rem' } }, [
           h(Collapse, {
             title: h2({ style: Style.dashboard.newHeader }, ['Workspace information']),
-            initialOpenState: workspaceInfoPanelOpen,
+            initialOpenState: workspaceInfoPanelOpen !== undefined ? workspaceInfoPanelOpen : true,
             titleFirst: true,
-            onClick: () => setWorkspaceInfoPanelOpen(!workspaceInfoPanelOpen)
+            onClick: () => setWorkspaceInfoPanelOpen(workspaceInfoPanelOpen === undefined ? false : !workspaceInfoPanelOpen)
           }, [
             h(InfoRow, { title: 'Last Updated' }, [new Date(lastModified).toLocaleDateString()]),
             h(InfoRow, { title: 'Creation Date' }, [new Date(createdDate).toLocaleDateString()]),

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -156,8 +156,8 @@ const WorkspaceDashboard = _.flow(
 
   useImperativeHandle(ref, () => ({ refresh }))
 
-  const [workspacePanelOpen, setWorkspaceInfoPanelOpen] = useState(() => getLocalPref(persistenceId)?.workspaceInfoPanelOpen || true)
-  const [cloudPanelOpen, setCloudInfoPanelOpen] = useState(() => getLocalPref(persistenceId)?.cloudInfoPanelOpen || false)
+  const [workspaceInfoPanelOpen, setWorkspaceInfoPanelOpen] = useState(() => getLocalPref(persistenceId)?.workspaceInfoPanelOpen || true)
+  const [cloudInfoPanelOpen, setCloudInfoPanelOpen] = useState(() => getLocalPref(persistenceId)?.cloudInfoPanelOpen || false)
   const [ownersPanelOpen, setOwnersPanelOpen] = useState(() => getLocalPref(persistenceId)?.ownersPanelOpen || false)
   const [authDomainPanelOpen, setAuthDomainPanelOpen] = useState(() => getLocalPref(persistenceId)?.authDomainPanelOpen || false)
   const [tagsPanelOpen, setTagsPanelOpen] = useState(() => getLocalPref(persistenceId)?.tagsPanelOpen || false)

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -108,11 +108,11 @@ const DashboardAuthContainer = props => {
   )
 }
 
-const RightBoxSection = ({ title, initialOpenState, onClick, children }) => {
+const RightBoxSection = ({ title, info, initialOpenState, onClick, children }) => {
   return div({ style: { paddingTop: '1rem' } }, [
     div({ style: Style.dashboard.rightBoxContainer }, [
       h(Collapse, {
-        title: h3({ style: Style.dashboard.collapsibleHeader }, [title]),
+        title: h3({ style: Style.dashboard.collapsibleHeader }, [title, info]),
         initialOpenState,
         titleFirst: true,
         onClick
@@ -391,13 +391,13 @@ const WorkspaceDashboard = _.flow(
         ..._.map(({ membersGroupName }) => div({ style: { margin: '0.5rem', fontWeight: 500 } }, [membersGroupName]), authorizationDomain)
       ]),
       h(RightBoxSection, {
-        title: ['Tags',
-          span({ onClick: e => e.stopPropagation() }, [
-            h(InfoBox, { style: { marginLeft: '0.25rem' } }, [
-              `${getAppName()} is not intended to host personally identifiable information. Do not use any patient identifier including name,
-              social security number, or medical record number.`
-            ])
-          ])],
+        title: 'Tags',
+        info: span({ onClick: e => e.stopPropagation() }, [
+          h(InfoBox, { style: { marginLeft: '0.25rem' } }, [
+            `${getAppName()} is not intended to host personally identifiable information. Do not use any patient identifier including name,
+            social security number, or medical record number.`
+          ])
+        ]),
         initialOpenState: tagsPanelOpen,
         onClick: () => setTagsPanelOpen(!tagsPanelOpen)
       }, [

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -133,6 +133,7 @@ const WorkspaceDashboard = _.flow(
   const [storageCostEstimate, setStorageCostEstimate] = useState(undefined)
   const [storageCostEstimateUpdated, setStorageCostEstimateUpdated] = useState(undefined)
   const [bucketSize, setBucketSize] = useState(undefined)
+  const [bucketSizeUpdated, setBucketSizeUpdated] = useState(undefined)
   const [editDescription, setEditDescription] = useState(undefined)
   const [saving, setSaving] = useState(false)
   const [busy, setBusy] = useState(false)
@@ -182,8 +183,9 @@ const WorkspaceDashboard = _.flow(
 
   const loadBucketSize = withErrorReporting('Error loading bucket size.', async () => {
     if (Utils.canWrite(accessLevel)) {
-      const { usageInBytes } = await Ajax(signal).Workspaces.workspace(namespace, name).bucketUsage()
+      const { usageInBytes, lastUpdated } = await Ajax(signal).Workspaces.workspace(namespace, name).bucketUsage()
       setBucketSize(Utils.formatBytes(usageInBytes))
+      setBucketSizeUpdated(lastUpdated)
     }
   })
 
@@ -346,7 +348,10 @@ const WorkspaceDashboard = _.flow(
               title: 'Estimated Storage Cost',
               subtitle: storageCostEstimate ? `Updated on ${new Date(storageCostEstimateUpdated).toLocaleDateString()}` : 'Loading last updated...'
             }, [storageCostEstimate || '$ ...']),
-            Utils.canWrite(accessLevel) && h(InfoRow, { title: 'Bucket Size' }, [bucketSize]),
+            Utils.canWrite(accessLevel) && h(InfoRow, {
+              title: 'Bucket Size',
+              subtitle: bucketSize ? `Updated on ${new Date(bucketSizeUpdated).toLocaleDateString()}` : 'Loading last updated...'
+            }, [bucketSize]),
             div({ style: { paddingBottom: '0.5rem' } }, [h(Link, {
               style: { margin: '1rem 0.5rem' },
               ...Utils.newTabLinkProps,

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -1,8 +1,9 @@
 import _ from 'lodash/fp'
 import { Fragment, useEffect, useImperativeHandle, useState } from 'react'
-import { div, h, i, span } from 'react-hyperscript-helpers'
+import { div, h, h2, i, span } from 'react-hyperscript-helpers'
 import * as breadcrumbs from 'src/components/breadcrumbs'
 import { requesterPaysWrapper, withRequesterPaysHandler } from 'src/components/bucket-utils'
+import Collapse from 'src/components/Collapse'
 import { ButtonPrimary, ButtonSecondary, ClipboardButton, Link, spinnerOverlay } from 'src/components/common'
 import { centeredSpinner, icon, spinner } from 'src/components/icons'
 import { MarkdownEditor, MarkdownViewer } from 'src/components/markdown'
@@ -277,30 +278,42 @@ const WorkspaceDashboard = _.flow(
       ])
     ]),
     div({ style: Style.dashboard.rightBox }, [
-      div({ style: { paddingTop: '1rem' }}, [
-        div({ style: { borderRadius: 5, backgroundColor: 'white', padding: '0.5rem' }}, [
+      div({ style: { paddingTop: '1rem' } }, [
+        div({ style: { borderRadius: 5, backgroundColor: 'white', padding: '0.5rem' } }, [
           div({ style: Style.dashboard.newHeader }, ['Workspace information']),
           'stuff'
-        ]),
+        ])
       ]),
-      div({ style: { paddingTop: '1rem' }}, [
-        div({ style: { borderRadius: 5, backgroundColor: 'white', padding: '0.5rem' }}, [
+      div({ style: { paddingTop: '1rem' } }, [
+        div({ style: { borderRadius: 5, backgroundColor: 'white', padding: '0.5rem' } }, [
           div({ style: Style.dashboard.newHeader }, ['Cloud information'])
-        ]),
+        ])
       ]),
-      div({ style: { paddingTop: '1rem' }}, [
-        div({ style: { borderRadius: 5, backgroundColor: 'white', padding: '0.5rem' }}, [
-          div({ style: Style.dashboard.newHeader }, ['Owners']),
-          div({ style: { margin: '0.5rem' } },
-          _.map(email => {
-            return div({ key: email, style: { overflow: 'hidden', textOverflow: 'ellipsis', marginBottom: '0.5rem' } }, [
-              h(Link, { href: `mailto:${email}` }, [email])
-            ])
-          }, owners)),
-        ]),
+      div({ style: { paddingTop: '1rem' } }, [
+        div({ style: { borderRadius: 5, backgroundColor: 'white', padding: '0.5rem' } }, [
+        h(Collapse, {
+            title: h2({ style: Style.dashboard.newHeader }, ['Owners']),
+            initialOpenState: true,
+            style: {}
+          }, [
+            div({ style: { margin: '0.5rem' } },
+              _.map(email => {
+                return div({ key: email, style: { overflow: 'hidden', textOverflow: 'ellipsis', marginBottom: '0.5rem' } }, [
+                  h(Link, { href: `mailto:${email}` }, [email])
+                ])
+              }, owners))
+        ])
+//          div({ style: Style.dashboard.newHeader }, ['Owners']),
+//          div({ style: { margin: '0.5rem' } },
+//            _.map(email => {
+//              return div({ key: email, style: { overflow: 'hidden', textOverflow: 'ellipsis', marginBottom: '0.5rem' } }, [
+//                h(Link, { href: `mailto:${email}` }, [email])
+//              ])
+//            }, owners))
+        ])
       ]),
-      !_.isEmpty(authorizationDomain) && div({ style: { paddingTop: '1rem' }}, [
-        div({ style: { borderRadius: 5, backgroundColor: 'white', padding: '0.5rem' }}, [
+      !_.isEmpty(authorizationDomain) && div({ style: { paddingTop: '1rem' } }, [
+        div({ style: { borderRadius: 5, backgroundColor: 'white', padding: '0.5rem' } }, [
           div({ style: Style.dashboard.newHeader }, ['Authorization domains']),
           div({ style: { margin: '0.5rem 0.5rem 1rem 0.5rem' } }, [
             'Collaborators must be a member of all of these ',
@@ -311,13 +324,41 @@ const WorkspaceDashboard = _.flow(
             ' to access this workspace.'
           ]),
           ..._.map(({ membersGroupName }) => div({ style: { margin: '0.5rem', fontWeight: 500 } }, [membersGroupName]), authorizationDomain)
-        ]),
+        ])
       ]),
-      div({ style: { paddingTop: '1rem' }}, [
-        div({ style: { borderRadius: 5, backgroundColor: 'white', padding: '0.5rem' }}, [
-          div({ style: Style.dashboard.newHeader }, ['Tags'])
-        ]),
-      ]),
+      div({ style: { paddingTop: '1rem' } }, [
+        div({ style: { borderRadius: 5, backgroundColor: 'white', padding: '0.5rem' } }, [
+          div({ style: Style.dashboard.newHeader }, ['Tags',
+            h(InfoBox, { style: { marginLeft: '0.25rem' } }, [
+              `${getAppName()} is not intended to host personally identifiable information. Do not use any patient identifier including name,
+              social security number, or medical record number.`
+            ])]),
+          div({ style: { margin: '0.5rem 0.5rem 1rem 0.5rem' } }, [
+            !Utils.editWorkspaceError(workspace) && div({ style: { marginBottom: '0.5rem' } }, [
+              h(WorkspaceTagSelect, {
+                value: null,
+                placeholder: 'Add a tag',
+                'aria-label': 'Add a tag',
+                onChange: ({ value }) => addTag(value)
+              })
+            ]),
+            div({ style: { display: 'flex', flexWrap: 'wrap', minHeight: '1.5rem' } }, [
+              _.map(tag => {
+                return span({ key: tag, style: styles.tag }, [
+                  tag,
+                  !Utils.editWorkspaceError(workspace) && h(Link, {
+                    tooltip: 'Remove tag',
+                    disabled: busy,
+                    onClick: () => deleteTag(tag),
+                    style: { marginLeft: '0.25rem', verticalAlign: 'middle', display: 'inline-block' }
+                  }, [icon('times', { size: 14 })])
+                ])
+              }, tagsList),
+              !!tagsList && _.isEmpty(tagsList) && i(['No tags yet'])
+            ])
+          ])
+        ])
+      ])
     ]),
     false && div({ style: Style.dashboard.rightBox }, [
       div({ style: Style.dashboard.header }, ['Workspace information']),


### PR DESCRIPTION
Mocks: https://projects.invisionapp.com/d/main#/projects/prototypes/21986264
Tickets: 
https://broadworkbench.atlassian.net/browse/SU-54
https://broadworkbench.atlassian.net/browse/SU-55
https://broadworkbench.atlassian.net/browse/SU-90

Redesign of the Workspace dashboard sidebar. 

* Obvious restyling per the above mock
* Sections are collapsable
* Browser will remember which sections were open/collapsed if the user leaves the workspace and comes back
* Two smaller SUE tickets included:
  * One to display the total bucket size
  * Another to display the date that the storage cost estimate was last updated

Before:

![Screen Shot 2022-04-14 at 11 58 42 PM](https://user-images.githubusercontent.com/7257391/163516088-a3e11eab-795c-4727-bd6c-7998ce580e6f.png)

After:
<img width="460" alt="Screen Shot 2022-04-15 at 4 05 37 PM" src="https://user-images.githubusercontent.com/7257391/163627024-0c30f15b-5840-4ccc-b6c2-103a0e55d0e7.png">

<img width="464" alt="Screen Shot 2022-04-15 at 4 05 54 PM" src="https://user-images.githubusercontent.com/7257391/163627031-08d955f8-6c7d-4744-accd-cab0feb664e3.png">




<!--
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Also, so if a screen recording [1] and/or screenshots would be a helpful way to communicate context, please consider including some in your PR description.
Thanks!

[1] https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac
--!>
