### PR TITLE
[SU-56] Update confirmation prompt for deleting files

### DIFF
--- a/src/components/data/FileBrowser.js
+++ b/src/components/data/FileBrowser.js
@@ -282,11 +282,11 @@ export const FileBrowserPanel = _.flow(
         abort: abortUpload
       }),
       deletingName && h(DeleteConfirmationModal, {
-        objectType: 'object',
+        objectType: 'file',
         objectName: deletingName,
         onConfirm: _.flow(
           Utils.withBusyState(setLoading),
-          withErrorReporting('Error deleting object')
+          withErrorReporting('Error deleting file')
         )(async () => {
           setDeletingName(undefined)
           await Ajax().Buckets.delete(googleProject, bucketName, deletingName)

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -8,10 +8,11 @@ import { AutoSizer } from 'react-virtualized'
 import * as breadcrumbs from 'src/components/breadcrumbs'
 import { requesterPaysWrapper, withRequesterPaysHandler } from 'src/components/bucket-utils'
 import Collapse from 'src/components/Collapse'
-import { ButtonOutline, Clickable, DeleteConfirmationModal, Link, spinnerOverlay } from 'src/components/common'
+import { ButtonOutline, Clickable, Link, spinnerOverlay } from 'src/components/common'
 import { EntityUploader, ReferenceDataDeleter, ReferenceDataImporter, renderDataCell, saveScroll } from 'src/components/data/data-utils'
 import EntitiesContent from 'src/components/data/EntitiesContent'
 import ExportDataModal from 'src/components/data/ExportDataModal'
+import { DeleteObjectConfirmationModal } from 'src/components/data/FileBrowser'
 import LocalVariablesContent from 'src/components/data/LocalVariablesContent'
 import Dropzone from 'src/components/Dropzone'
 import FloatingActionButton from 'src/components/FloatingActionButton'
@@ -190,7 +191,7 @@ const BucketContent = _.flow(
   const [objects, setObjects] = useState(() => firstRender ? StateHistory.get().objects : undefined)
   const [loading, setLoading] = useState(false)
   const [uploading, setUploading] = useState(false)
-  const [deletingName, setDeletingName] = useState(undefined)
+  const [deletingObject, setDeletingObject] = useState(undefined)
   const [viewingName, setViewingName] = useState(undefined)
 
   const signal = useCancellation()
@@ -308,10 +309,11 @@ const BucketContent = _.flow(
               ])
             }
           }, prefixes),
-          ..._.map(({ name, size, updated }) => {
+          ..._.map(object => {
+            const { name, size, updated } = object
             return {
               button: h(Link, {
-                style: { display: 'flex' }, onClick: () => setDeletingName(name),
+                style: { display: 'flex' }, onClick: () => setDeletingObject(object),
                 tooltip: 'Delete file'
               }, [
                 icon('trash', { size: 16, className: 'hover-only' })
@@ -332,18 +334,17 @@ const BucketContent = _.flow(
         ]
       })
     ]),
-    deletingName && h(DeleteConfirmationModal, {
-      objectType: 'file',
-      objectName: deletingName,
+    deletingObject && h(DeleteObjectConfirmationModal, {
+      object: deletingObject,
       onConfirm: _.flow(
         Utils.withBusyState(setLoading),
         withErrorReporting('Error deleting file')
       )(async () => {
-        setDeletingName(undefined)
-        await Ajax().Buckets.delete(googleProject, bucketName, deletingName)
+        setDeletingObject(undefined)
+        await Ajax().Buckets.delete(googleProject, bucketName, deletingObject.name)
         load()
       }),
-      onDismiss: () => setDeletingName(undefined)
+      onDismiss: () => setDeletingObject(undefined)
     }),
     viewingName && h(UriViewer, {
       googleProject, uri: `gs://${bucketName}/${viewingName}`,

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -333,11 +333,11 @@ const BucketContent = _.flow(
       })
     ]),
     deletingName && h(DeleteConfirmationModal, {
-      objectType: 'object',
+      objectType: 'file',
       objectName: deletingName,
       onConfirm: _.flow(
         Utils.withBusyState(setLoading),
-        withErrorReporting('Error deleting object')
+        withErrorReporting('Error deleting file')
       )(async () => {
         setDeletingName(undefined)
         await Ajax().Buckets.delete(googleProject, bucketName, deletingName)


### PR DESCRIPTION
Use common component to confirm deleting objects from workspace bucket.

This is used in two places: one in the Files panel of a workspace's Data tab and the other in the data uploader (http://localhost:3000/#upload). If testing the data uploader, note that there's a bug ([SU-78](https://broadworkbench.atlassian.net/browse/SU-78)) where files don't immediately show up when they're uploaded.

This also fixes a bug. Currently, the delete object confirmation modal in the data uploader cannot be dismissed.

## Before
<img width="457" alt="Screen Shot 2022-04-15 at 7 17 43 AM" src="https://user-images.githubusercontent.com/1156625/163564901-b71e97c2-5c02-418d-942b-1a5251daf45c.png">

## After
![Screen Shot 2022-04-15 at 12 59 21 PM](https://user-images.githubusercontent.com/1156625/163599298-5358a3e3-a9ac-4ad6-b44a-342a73bef7de.png)



