### PR TITLE
[SU-56] Update style of delete confirmation modals

### DIFF
--- a/src/components/common.js
+++ b/src/components/common.js
@@ -596,9 +596,8 @@ export const DeleteConfirmationModal = ({
     styles: { modal: { backgroundColor: colors.warning(0.1) } }
   }, [
     children || h(Fragment, [
-      div([`Are you sure you want to delete the ${objectType} `,
-        span({ style: { fontWeight: 600, wordBreak: 'break-word' } }, [objectName]), '?']),
-      div({ style: { fontWeight: 500, marginTop: '1rem' } }, 'This cannot be undone.')
+      div([`Are you sure you want to delete the ${objectType} `, b({ style: { wordBreak: 'break-word' } }, [objectName]), '?']),
+      b({ style: { display: 'block', marginTop: '1rem' } }, 'This cannot be undone.')
     ]),
     confirmationPrompt && div({ style: { display: 'flex', flexDirection: 'column', marginTop: '1rem' } }, [
       h(IdContainer, [id => h(Fragment, [

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -583,13 +583,17 @@ export const DeleteConfirmationModal = ({
   const isConfirmed = !confirmationPrompt || _.toLower(confirmation) === _.toLower(confirmationPrompt)
 
   return h(Modal, {
-    title,
+    title: span({ style: { display: 'flex', alignItems: 'center' } }, [
+      icon('warning-standard', { size: 24, color: colors.warning() }),
+      span({ style: { marginLeft: '1ch' } }, [title])
+    ]),
     onDismiss,
     okButton: h(ButtonPrimary, {
       onClick: onConfirm,
       disabled: !isConfirmed,
       tooltip: isConfirmed ? undefined : 'You must type the confirmation message'
-    }, buttonText)
+    }, buttonText),
+    styles: { modal: { backgroundColor: colors.warning(0.1) } }
   }, [
     children || h(Fragment, [
       div([`Are you sure you want to delete the ${objectType} `,

--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp'
 import { Fragment, useEffect, useRef, useState } from 'react'
-import { div, h, span } from 'react-hyperscript-helpers'
+import { b, div, h, span } from 'react-hyperscript-helpers'
 import { AutoSizer } from 'react-virtualized'
 import { Checkbox, Clickable, DeleteConfirmationModal, fixedSpinnerOverlay, Link } from 'src/components/common'
 import { concatenateAttributeNames, EditDataLink, EntityRenamer, HeaderOptions, renderDataCell, SingleEntityEditor } from 'src/components/data/data-utils'
@@ -436,8 +436,8 @@ const DataTable = props => {
       onDismiss: () => setClearingColumn(undefined)
     }, [
       div(['Are you sure you want to permanently delete all data in the column ',
-        span({ style: { fontWeight: 600, wordBreak: 'break-word' } }, clearingColumn), '?']),
-      div({ style: { fontWeight: 500, marginTop: '1rem' } }, 'This cannot be undone.')
+        b({ style: { wordBreak: 'break-word' } }, clearingColumn), '?']),
+      b({ style: { display: 'block', marginTop: '1rem' } }, 'This cannot be undone.')
     ]),
     loading && fixedSpinnerOverlay
   ])

--- a/src/components/data/FileBrowser.js
+++ b/src/components/data/FileBrowser.js
@@ -1,7 +1,7 @@
 import filesize from 'filesize'
 import _ from 'lodash/fp'
 import { Fragment, useEffect, useRef, useState } from 'react'
-import { div, h, span } from 'react-hyperscript-helpers'
+import { b, div, h, span } from 'react-hyperscript-helpers'
 import { AutoSizer } from 'react-virtualized'
 import { requesterPaysWrapper, withRequesterPaysHandler } from 'src/components/bucket-utils'
 import { DeleteConfirmationModal, Link, topSpinnerOverlay } from 'src/components/common'
@@ -29,12 +29,11 @@ export const DeleteObjectConfirmationModal = ({ object, ...props }) => {
     objectType: 'file',
     objectName: object.name
   }, [
-    div(['Are you sure you want to delete the file ',
-      span({ style: { fontWeight: 600, wordBreak: 'break-word' } }, [object.name]), '?']),
+    div(['Are you sure you want to delete the file ', b({ style: { wordBreak: 'break-word' } }, [object.name]), '?']),
     !_.isNaN(objectSize) && div({ style: { marginTop: '1rem' } }, [
       `File size: ${Utils.formatBytes(objectSize)}`
     ]),
-    div({ style: { fontWeight: 500, marginTop: '1rem' } }, 'This cannot be undone.')
+    b({ style: { display: 'block', marginTop: '1rem' } }, 'This cannot be undone.')
   ])
 }
 

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -185,12 +185,6 @@ export const EntityDeleter = ({ onDismiss, onSuccess, namespace, name, selectedE
 
   const moreToDelete = !!additionalDeletions.length
 
-  const fullWidthWarning = {
-    ...warningBoxStyle,
-    borderLeft: 'none', borderRight: 'none',
-    margin: '0 -1.25rem'
-  }
-
   const total = selectedKeys.length + additionalDeletions.length
   return h(DeleteConfirmationModal, {
     objectType: 'data',
@@ -198,13 +192,11 @@ export const EntityDeleter = ({ onDismiss, onSuccess, namespace, name, selectedE
     onConfirm: doDelete,
     onDismiss
   }, [
-    runningSubmissionsCount > 0 && div({ style: { ...fullWidthWarning, display: 'flex', alignItems: 'center' } }, [
-      icon('warning-standard', { size: 36, style: { flex: 'none', marginRight: '0.5rem' } }),
+    runningSubmissionsCount > 0 && div({ style: { margin: '1rem 0', fontWeight: 600 } }, [
       `WARNING: ${runningSubmissionsCount} workflows are currently running in this workspace. ` +
       'Deleting the following data could cause failures if a workflow is using this data.'
     ]),
-    moreToDelete && div({ style: { ...fullWidthWarning, display: 'flex', alignItems: 'center' } }, [
-      icon('warning-standard', { size: 36, style: { flex: 'none', marginRight: '0.5rem' } }),
+    moreToDelete && div({ style: { margin: '1rem 0', fontWeight: 600 } }, [
       'In order to delete the selected data entries, the following entries that reference them must also be deleted.'
     ]),
     // Size the scroll container to cut off the last row to hint that there's more content to be scrolled into view

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp'
 import pluralize from 'pluralize'
 import { Fragment, useEffect, useRef, useState } from 'react'
-import { div, fieldset, h, img, label, legend, li, p, span, ul } from 'react-hyperscript-helpers'
+import { b, div, fieldset, h, img, label, legend, li, p, span, ul } from 'react-hyperscript-helpers'
 import Collapse from 'src/components/Collapse'
 import {
   absoluteSpinnerOverlay, ButtonOutline, ButtonPrimary, ButtonSecondary, Clickable, DeleteConfirmationModal, IdContainer, LabeledCheckbox, Link, RadioButton, Select, spinnerOverlay, Switch
@@ -148,7 +148,7 @@ export const ReferenceDataDeleter = ({ onSuccess, onDismiss, namespace, name, re
     },
     onDismiss
   }, [
-    div(['Are you sure you want to delete the ', span({ style: { fontWeight: 600 } }, [referenceDataType]), ' reference data?']),
+    div(['Are you sure you want to delete the ', b([referenceDataType]), ' reference data?']),
     deleting && absoluteSpinnerOverlay
   ])
 }
@@ -192,11 +192,11 @@ export const EntityDeleter = ({ onDismiss, onSuccess, namespace, name, selectedE
     onConfirm: doDelete,
     onDismiss
   }, [
-    runningSubmissionsCount > 0 && div({ style: { margin: '1rem 0', fontWeight: 600 } }, [
+    runningSubmissionsCount > 0 && b({ style: { display: 'block', margin: '1rem 0' } }, [
       `WARNING: ${runningSubmissionsCount} workflows are currently running in this workspace. ` +
       'Deleting the following data could cause failures if a workflow is using this data.'
     ]),
-    moreToDelete && div({ style: { margin: '1rem 0', fontWeight: 600 } }, [
+    moreToDelete && b({ style: { display: 'block', margin: '1rem 0' } }, [
       'In order to delete the selected data entries, the following entries that reference them must also be deleted.'
     ]),
     // Size the scroll container to cut off the last row to hint that there's more content to be scrolled into view

--- a/src/pages/workspaces/workspace/DeleteWorkspaceModal.js
+++ b/src/pages/workspaces/workspace/DeleteWorkspaceModal.js
@@ -78,7 +78,10 @@ const DeleteWorkspaceModal = ({ workspace: { workspace: { namespace, name, bucke
   const isDeleteDisabledFromApps = hasApps() && !_.isEmpty(nonDeletableApps)
 
   return h(Modal, {
-    title: 'Delete workspace',
+    title: span({ style: { display: 'flex', alignItems: 'center' } }, [
+      icon('warning-standard', { size: 24, color: colors.warning() }),
+      span({ style: { marginLeft: '1ch' } }, ['Delete workspace'])
+    ]),
     onDismiss,
     okButton: h(ButtonPrimary, {
       disabled: _.toLower(deleteConfirmation) !== 'delete workspace' || isDeleteDisabledFromApps,
@@ -87,7 +90,8 @@ const DeleteWorkspaceModal = ({ workspace: { workspace: { namespace, name, bucke
         [isDeleteDisabledFromApps, () => 'You must ensure all apps in this workspace are deletable'],
         [_.toLower(deleteConfirmation) !== 'delete workspace', () => 'You must type the confirmation message'],
         () => 'Delete Workspace')
-    }, 'Delete workspace')
+    }, 'Delete workspace'),
+    styles: { modal: { background: colors.warning(0.1) } }
   }, [
     div(['Are you sure you want to permanently delete the workspace ',
       span({ style: { fontWeight: 600, wordBreak: 'break-word' } }, name),
@@ -115,13 +119,7 @@ const DeleteWorkspaceModal = ({ workspace: { workspace: { namespace, name, bucke
         div(`and ${collaboratorEmails.length - 5} more`)
       )
     ]),
-    !isDeleteDisabledFromApps && div({
-      style: {
-        color: colors.danger(),
-        fontWeight: 500,
-        marginTop: '1rem'
-      }
-    }, 'This cannot be undone.'),
+    !isDeleteDisabledFromApps && div({ style: { marginTop: '1rem', fontWeight: 500 } }, 'This cannot be undone.'),
     !isDeleteDisabledFromApps && div({ style: { display: 'flex', flexDirection: 'column', marginTop: '1rem' } }, [
       label({ htmlFor: 'delete-workspace-confirmation', style: { marginBottom: '0.25rem' } }, ['Please type \'Delete Workspace\' to continue:']),
       h(TextInput, {

--- a/src/pages/workspaces/workspace/DeleteWorkspaceModal.js
+++ b/src/pages/workspaces/workspace/DeleteWorkspaceModal.js
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp'
 import pluralize from 'pluralize'
 import { useState } from 'react'
-import { div, h, label, p, span } from 'react-hyperscript-helpers'
+import { b, div, h, label, p, span } from 'react-hyperscript-helpers'
 import { ButtonPrimary, Link, spinnerOverlay } from 'src/components/common'
 import { warningBoxStyle } from 'src/components/data/data-utils'
 import { icon } from 'src/components/icons'
@@ -119,7 +119,7 @@ const DeleteWorkspaceModal = ({ workspace: { workspace: { namespace, name, bucke
         div(`and ${collaboratorEmails.length - 5} more`)
       )
     ]),
-    !isDeleteDisabledFromApps && div({ style: { marginTop: '1rem', fontWeight: 500 } }, 'This cannot be undone.'),
+    !isDeleteDisabledFromApps && b({ style: { display: 'block', marginTop: '1rem' } }, 'This cannot be undone.'),
     !isDeleteDisabledFromApps && div({ style: { display: 'flex', flexDirection: 'column', marginTop: '1rem' } }, [
       label({ htmlFor: 'delete-workspace-confirmation', style: { marginBottom: '0.25rem' } }, ['Please type \'Delete Workspace\' to continue:']),
       h(TextInput, {

--- a/src/pages/workspaces/workspace/workflows/DeleteWorkflowConfirmationModal.js
+++ b/src/pages/workspaces/workspace/workflows/DeleteWorkflowConfirmationModal.js
@@ -1,4 +1,4 @@
-import { div, h, span } from 'react-hyperscript-helpers'
+import { b, div, h } from 'react-hyperscript-helpers'
 import { DeleteConfirmationModal } from 'src/components/common'
 
 
@@ -8,8 +8,7 @@ const DeleteWorkflowConfirmationModal = ({ methodConfig: { name }, ...props }) =
     objectType: 'workflow',
     objectName: name
   }, [
-    div([`Are you sure you want to delete the workflow `,
-      span({ style: { fontWeight: 600, wordBreak: 'break-word' } }, [name]), '?']),
+    div([`Are you sure you want to delete the workflow `, b({ style: { wordBreak: 'break-word' } }, [name]), '?']),
     div({ style: { marginTop: '1rem' } }, [
       'The workflow can be re-added to the workspace, but changes to workflow configuration will be lost.'
     ])


### PR DESCRIPTION
After all delete confirmations have been switched to a common component (once #2951 and #2961 are merged), update the style of delete confirmation modals to have a yellow/warning color background and a warning icon in the title.

## Delete notebook
### Before
![Screen Shot 2022-04-15 at 9 31 09 AM](https://user-images.githubusercontent.com/1156625/163578673-edb807d5-36db-4ed0-8ea9-92a9714424b3.png)
### After
![Screen Shot 2022-04-15 at 9 30 48 AM](https://user-images.githubusercontent.com/1156625/163578686-aa391aa6-8691-403c-9e95-468ce480bb46.png)

## Delete rows from data table
This modal can show a few additional warnings and the styles of those are also updated. These screenshots show the modal after attempting to delete rows referenced by another row.
### Before
![Screen Shot 2022-04-15 at 9 31 25 AM](https://user-images.githubusercontent.com/1156625/163578790-ea9c84fb-9fa4-4724-8b37-a77e212c1351.png)
### After
![Screen Shot 2022-04-15 at 9 31 37 AM](https://user-images.githubusercontent.com/1156625/163578795-af7a8fc3-1164-4adc-b425-3bd86702fde8.png)

## Delete workspace
This modal currently does not use the common component because it has some additional logic for disabling the delete button.
### Before
![Screen Shot 2022-04-15 at 9 31 48 AM](https://user-images.githubusercontent.com/1156625/163578827-c7df2e42-3009-4571-ab3c-5c25c4f53e07.png)
### After
![Screen Shot 2022-04-15 at 9 32 02 AM](https://user-images.githubusercontent.com/1156625/163578833-2565b5ec-e0b8-49b2-9924-485b1125ccde.png)

