### PR TITLE
[SU-71] Use select instead of radio buttons to choose change attribute types

### DIFF
--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp'
 import pluralize from 'pluralize'
 import { Fragment, useEffect, useRef, useState } from 'react'
-import { div, fieldset, h, img, label, legend, li, p, span, ul } from 'react-hyperscript-helpers'
+import { div, fieldset, h, img, label, li, p, span, ul } from 'react-hyperscript-helpers'
 import Collapse from 'src/components/Collapse'
 import {
   absoluteSpinnerOverlay, ButtonOutline, ButtonPrimary, ButtonSecondary, Clickable, DeleteConfirmationModal, IdContainer, LabeledCheckbox, Link, RadioButton, Select, spinnerOverlay, Switch
@@ -615,32 +615,32 @@ const AttributeInput = ({ autoFocus = false, value: attributeValue, onChange, en
   return h(Fragment, [
     div({ style: { marginBottom: '1rem' } }, [
       fieldset({ style: { border: 'none', margin: 0, padding: 0 } }, [
-        legend({ style: { marginBottom: '0.5rem' } }, [isList ? 'List item type:' : 'Attribute type:']),
-        h(Fragment, _.map(({ type, tooltip }) => h(TooltipTrigger, { content: tooltip }, [
-          span({ style: { marginRight: '1.2rem' } }, [
-            h(RadioButton, {
-              text: _.startCase(type),
-              name: 'edit-type',
-              checked: attributeType === type,
-              onChange: () => {
-                const newAttributeValue = convertAttributeValue(attributeValue, type, defaultReferenceEntityType)
-                onChange(newAttributeValue)
-              },
-              labelStyle: { paddingLeft: '0.5rem' }
-            })
-          ])
-        ]),
-        [
-          { type: 'string' },
-          { type: 'reference', tooltip: 'A link to another entity' },
-          { type: 'number' },
-          { type: 'boolean' }
-        ])
-        )
+        h(IdContainer, [id => h(Fragment, [
+          label({ htmlFor: id, style: { display: 'block', marginBottom: '0.5rem' } }, [
+            isList ? 'List item type:' : 'Attribute type:'
+          ]),
+          h(Select, {
+            id,
+            value: attributeType,
+            options: _.map(
+              ({ type, description }) => ({ value: type, label: description ? `${_.startCase(type)} (${description})` : _.startCase(type) }),
+              [
+                { type: 'string' },
+                { type: 'reference', description: 'A link to another entity' },
+                { type: 'number' },
+                { type: 'boolean' }
+              ]
+            ),
+            onChange: ({ value: newType }) => {
+              const newAttributeValue = convertAttributeValue(attributeValue, newType, defaultReferenceEntityType)
+              onChange(newAttributeValue)
+            }
+          })
+        ])])
       ]),
       attributeType === 'reference' && div({ style: { marginTop: '0.5rem' } }, [
         h(IdContainer, [id => h(Fragment, [
-          label({ htmlFor: id, style: { marginBottom: '0.5rem' } }, 'Referenced entity type:'),
+          label({ htmlFor: id, style: { display: 'block', marginBottom: '0.5rem' } }, 'Referenced entity type:'),
           h(Select, {
             id,
             value: defaultReferenceEntityType,


### PR DESCRIPTION
Use a select menu instead of radio buttons to change the type of an attribute in a data table. This was requested by UX. It also avoids having to find space for another radio button when we add support for editing JSON attributes in the UI (SU-57).

## Before
![Screen Shot 2022-04-15 at 4 56 09 PM](https://user-images.githubusercontent.com/1156625/163631217-2edea28f-bda7-43ed-9a76-c6145813bed2.png)

## After
![Screen Shot 2022-04-15 at 4 55 34 PM](https://user-images.githubusercontent.com/1156625/163631222-9cdba3d5-4b02-4d6b-8305-cb6ce09db550.png)

To get to this modal, hover over a cell in a data table and click the edit button.
![Screen Shot 2022-04-15 at 4 58 25 PM](https://user-images.githubusercontent.com/1156625/163631379-7e2cd066-36b5-4279-982f-7b65f5c7901c.png)

