### PR TITLE
[WOR-245, 246] Viewing Workspace dashboard for Azure workspace

### DIFF
--- a/integration-tests/jest/workspace-dashboard.integration-test.js
+++ b/integration-tests/jest/workspace-dashboard.integration-test.js
@@ -1,0 +1,6 @@
+const { registerTest } = require('./jest-utils')
+const { googleWorkspaceDashboard, azureWorkspaceDashboard } = require('../tests/workspace-dashboard')
+
+
+registerTest(googleWorkspaceDashboard)
+registerTest(azureWorkspaceDashboard)

--- a/integration-tests/tests/billing-projects.js
+++ b/integration-tests/tests/billing-projects.js
@@ -1,3 +1,4 @@
+// This test is owned by the Workspaces Team.
 const _ = require('lodash/fp')
 const { assertTextNotFound, click, clickable, dismissNotifications, findText, noSpinnersAfter, select, signIntoTerra } = require('../utils/integration-utils')
 const { withUserToken } = require('../utils/terra-sa-utils')

--- a/integration-tests/tests/janitor.js
+++ b/integration-tests/tests/janitor.js
@@ -1,3 +1,4 @@
+// This test is owned by the Workspaces Team.
 const rawConsole = require('console')
 const dateFns = require('date-fns/fp')
 const _ = require('lodash/fp')

--- a/integration-tests/tests/workspace-dashboard.js
+++ b/integration-tests/tests/workspace-dashboard.js
@@ -1,0 +1,116 @@
+// This test is owned by the Workspaces Team.
+const _ = require('lodash/fp')
+const { clickNavChildAndLoad, viewWorkspaceDashboard, withWorkspace } = require('../utils/integration-helpers')
+const { assertNavChildNotFound, findText } = require('../utils/integration-utils')
+const { withUserToken } = require('../utils/terra-sa-utils')
+
+
+const testGoogleWorkspace = _.flow(
+  withWorkspace,
+  withUserToken
+)(async ({ page, token, testUrl, workspaceName }) => {
+  await page.goto(testUrl)
+  await viewWorkspaceDashboard(page, token, workspaceName)
+  await findText(page, 'About the workspace')
+  // Click on each of the expected tabs
+  await clickNavChildAndLoad(page, 'data')
+  await clickNavChildAndLoad(page, 'notebooks')
+  await clickNavChildAndLoad(page, 'workflows')
+  await clickNavChildAndLoad(page, 'job history')
+})
+
+const googleWorkspaceDashboard = {
+  name: 'google-workspace',
+  fn: testGoogleWorkspace
+}
+
+const setAjaxMockValues = async (testPage, namespace, name, workspaceDescription) => {
+  const workspaceInfo = {
+    attributes: { description: workspaceDescription },
+    authorizationDomain: [],
+    bucketName: '',
+    createdBy: 'dummy@email.com',
+    createdDate: '2022-04-12T18:12:25.912Z',
+    googleProject: '',
+    isLocked: false,
+    lastModified: '2022-04-12T18:12:26.199Z',
+    name,
+    namespace,
+    workspaceId: '95accxxx-4c68-4e60-9c2e-c0863af11xxx',
+    workspaceVersion: 'v2'
+  }
+  const azureWorkspacesListResult = [{
+    accessLevel: 'OWNER',
+    public: false,
+    workspace: workspaceInfo,
+    workspaceSubmissionStats: { runningSubmissionsCount: 0 }
+  }]
+
+  const azureWorkspaceDetailsResult = {
+    azureContext: {
+      managedResourceGroupId: 'dummy-mrg-id',
+      subscriptionId: 'dummy-subscription-id',
+      tenantId: 'dummy-tenant-id'
+    },
+    workspaceSubmissionStats: { runningSubmissionsCount: 0 },
+    accessLevel: 'OWNER',
+    owners: ['dummy@email.comm'],
+    workspace: workspaceInfo,
+    canShare: true,
+    canCompute: true
+  }
+
+  return await testPage.evaluate((azureWorkspacesListResult, azureWorkspaceDetailsResult, namespace, name) => {
+    const detailsUrl = new RegExp(`api/workspaces/${namespace}/${name}[^/](.*)`, 'g')
+    const submissionsUrl = new RegExp(`api/workspaces/${namespace}/${name}/submissions(.*)`, 'g')
+    const tagsUrl = new RegExp(`api/workspaces/${namespace}/${name}/tags(.*)`, 'g')
+
+    window.ajaxOverridesStore.set([
+      {
+        filter: { url: /api\/workspaces\/saturn-integration-test-dev(.*)/ },
+        fn: () => () => Promise.resolve(new Response(JSON.stringify([azureWorkspaceDetailsResult]), { status: 200 }))
+      },
+      {
+        filter: { url: tagsUrl },
+        fn: () => () => Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
+      },
+      {
+        filter: { url: submissionsUrl },
+        fn: () => () => Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
+      },
+      {
+        filter: { url: detailsUrl },
+        fn: () => () => Promise.resolve(new Response(JSON.stringify(azureWorkspaceDetailsResult), { status: 200 }))
+      },
+      {
+        filter: { url: /api\/workspaces[^/](.*)/ },
+        fn: () => () => Promise.resolve(new Response(JSON.stringify(azureWorkspacesListResult), { status: 200 }))
+      }
+    ])
+  }, azureWorkspacesListResult, azureWorkspaceDetailsResult, namespace, name)
+}
+
+const testAzureWorkspace = withUserToken(async ({ page, token, testUrl }) => {
+  const workspaceDescription = 'azure workspace description'
+  const workspaceName = 'azure-workspace'
+
+  // Must load page before setting mock responses.
+  await page.goto(testUrl)
+  await findText(page, 'View Workspaces')
+  await setAjaxMockValues(page, 'azure-workspace-ns', workspaceName, workspaceDescription)
+
+  await viewWorkspaceDashboard(page, token, workspaceName)
+  await findText(page, workspaceDescription)
+  // Verify tabs that currently depend on Google project ID are not present.
+  await assertNavChildNotFound(page, 'data')
+  await assertNavChildNotFound(page, 'notebooks')
+  await assertNavChildNotFound(page, 'workflows')
+  await assertNavChildNotFound(page, 'job history')
+})
+
+const azureWorkspaceDashboard = {
+  name: 'azure-workspace',
+  fn: testAzureWorkspace
+}
+
+module.exports = { googleWorkspaceDashboard, azureWorkspaceDashboard }

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -96,7 +96,7 @@ const assertTextNotFound = async (page, text) => {
     found = true
   } catch (e) {}
   if (found) {
-    throw new Error(`The specified text ${text} was found on the page, but it was not expected`)
+    throw new Error(`The specified text '${text}' was found on the page, but it was not expected`)
   }
 }
 
@@ -205,6 +205,17 @@ const navChild = text => {
   return `//*[@role="navigation"]//a[contains(normalize-space(.),"${text}")]`
 }
 
+const assertNavChildNotFound = async (page, text) => {
+  let found = false
+  try {
+    await page.waitForXPath(navChild(text), { timeout: 5 * 1000 })
+    found = true
+  } catch (e) {}
+  if (found) {
+    throw new Error(`The specified nav child '${text}' was found on the page, but it was not expected`)
+  }
+}
+
 const elementInDataTableRow = (entityName, text) => {
   return `//*[@role="table"]//*[contains(.,"${entityName}")]/following-sibling::*[contains(.,"${text}")]`
 }
@@ -282,6 +293,7 @@ const withPageLogging = fn => options => {
 }
 
 module.exports = {
+  assertNavChildNotFound,
   assertTextNotFound,
   checkbox,
   click,

--- a/src/components/FooterWrapper.js
+++ b/src/components/FooterWrapper.js
@@ -43,7 +43,7 @@ const FooterWrapper = ({ children, alwaysShow, fixedHeight }) => {
   })
 
   const popoutItem = ({ link, displayName }) => {
-    return [
+    return h(Fragment, [
       div({ style: styles.item }, '|'),
       a({
         href: link, ...Utils.newTabLinkProps,
@@ -51,7 +51,7 @@ const FooterWrapper = ({ children, alwaysShow, fixedHeight }) => {
       }, [
         displayName, icon('pop-out', { size: 12, style: { marginLeft: '0.5rem' } })
       ])
-    ]
+    ])
   }
 
   const expandedFooterHeight = 60

--- a/src/pages/workspaces/workspace/Analyses.js
+++ b/src/pages/workspaces/workspace/Analyses.js
@@ -224,8 +224,9 @@ const Analyses = _.flow(
   }),
   withViewToggle('analysesTab')
 )(({
-  apps, name: wsName, namespace, workspace, workspace: { accessLevel, canShare, workspace: { googleProject, bucketName } },
-  refreshApps, onRequesterPaysError, runtimes, persistentDisks, refreshRuntimes, appDataDisks
+  name: wsName, namespace, workspace, workspace: { accessLevel, canShare, workspace: { googleProject, bucketName } },
+  analysesData: { apps, refreshApps, runtimes, refreshRuntimes, appDataDisks, persistentDisks },
+  onRequesterPaysError
 }, _ref) => {
   // State
   const [renamingAnalysisName, setRenamingAnalysisName] = useState(undefined)

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -133,6 +133,7 @@ const WorkspaceDashboard = _.flow(
   refreshWorkspace,
   workspace, workspace: {
     accessLevel,
+    azureContext,
     owners,
     workspace: {
       authorizationDomain, createdDate, lastModified, bucketName, googleProject,
@@ -161,11 +162,13 @@ const WorkspaceDashboard = _.flow(
 
   const refresh = () => {
     loadSubmissionCount()
-    loadStorageCost()
-    loadBucketSize()
     loadConsent()
     loadWsTags()
-    loadBucketLocation()
+    if (!azureContext) {
+      loadStorageCost()
+      loadBucketLocation()
+      loadBucketSize()
+    }
   }
 
   useImperativeHandle(ref, () => ({ refresh }))

--- a/src/pages/workspaces/workspace/Notebooks.js
+++ b/src/pages/workspaces/workspace/Notebooks.js
@@ -230,8 +230,9 @@ const Notebooks = _.flow(
   }),
   withViewToggle('notebooksTab')
 )(({
-  apps, appDataDisks, name: wsName, namespace, workspace, workspace: { accessLevel, canShare, workspace: { googleProject, bucketName } },
-  refreshApps, onRequesterPaysError, listView, setListView
+  analysesData: { apps, refreshApps, appDataDisks }, name: wsName, namespace, workspace,
+  workspace: { accessLevel, canShare, workspace: { googleProject, bucketName } },
+  onRequesterPaysError, listView, setListView
 }, _ref) => {
   // State
   const [renamingNotebookName, setRenamingNotebookName] = useState(undefined)

--- a/src/pages/workspaces/workspace/applications/AppLauncher.js
+++ b/src/pages/workspaces/workspace/applications/AppLauncher.js
@@ -40,7 +40,10 @@ const ApplicationLauncher = _.flow(
     title: _.get('application'),
     activeTab: appLauncherTabName
   }) // TODO: Check if name: workspaceName could be moved into the other workspace deconstruction
-)(({ name: workspaceName, sparkInterface, refreshRuntimes, runtimes, persistentDisks, application, workspace, workspace: { workspace: { googleProject, bucketName } } }, _ref) => {
+)(({
+  name: workspaceName, sparkInterface, analysesData: { runtimes, refreshRuntimes, persistentDisks },
+  application, workspace, workspace: { workspace: { googleProject, bucketName } }
+}, _ref) => {
   const [showCreate, setShowCreate] = useState(false)
   const [busy, setBusy] = useState(false)
   const [location, setLocation] = useState(defaultLocation)

--- a/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
@@ -49,10 +49,9 @@ const AnalysisLauncher = _.flow(
   })
 )(
   ({
-    queryParams, analysisName, workspace, workspace: { workspace: { bucketName, googleProject, namespace, name }, accessLevel, canCompute }, runtimes, persistentDisks,
-    refreshRuntimes
-  },
-  _ref) => {
+    queryParams, analysisName, workspace, workspace: { workspace: { bucketName, googleProject, namespace, name }, accessLevel, canCompute },
+    analysesData: { runtimes, refreshRuntimes, persistentDisks }
+  }, _ref) => {
     const [createOpen, setCreateOpen] = useState(false)
     const runtime = getCurrentRuntime(runtimes)
     const { runtimeName, labels } = runtime || {}

--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -43,8 +43,10 @@ const NotebookLauncher = _.flow(
     showTabBar: false
   })
 )(
-  ({ queryParams, notebookName, workspace, workspace: { workspace: { bucketName, googleProject, namespace, name }, accessLevel, canCompute }, runtimes, persistentDisks, refreshRuntimes },
-    _ref) => {
+  ({
+    queryParams, notebookName, workspace, workspace: { workspace: { bucketName, googleProject, namespace, name }, accessLevel, canCompute },
+    analysesData: { runtimes, refreshRuntimes, persistentDisks }
+  }, _ref) => {
     const [createOpen, setCreateOpen] = useState(false)
     const [busy, setBusy] = useState()
     const [location, setLocation] = useState(defaultLocation)


### PR DESCRIPTION
This allows the Workspace Dashboard to be viewed for Azure workspaces (which currently can only be created by running Rawls locally against dev and using curl commands). Components created in WorkspaceContainer that require Google projects IDs or bucket locations are not instantiated, and all tabs except the Workspace Dashboard tab are not displayed (as currently they all depend on the Google project ID).

There are still things on the Workspace Dashboard that do not render with information because of the missing Google project ID, but those will be addressed in subsequent tickets.

![image](https://user-images.githubusercontent.com/484484/164736044-25c8bffd-5de2-4b95-ac1d-1f6cfca2cd4c.png)


