### PR TITLE
[IA-3336] fix hail option in image select

### DIFF
--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -496,7 +496,7 @@ export const ComputeModalBase = ({
    */
   const getPendingDisk = () => {
     const { persistentDisk: desiredPersistentDisk } = getDesiredEnvironmentConfig()
-    return { size: desiredPersistentDisk.size, status: 'Ready', diskType: desiredPersistentDisk.diskType }
+    return { size: desiredPersistentDisk ? desiredPersistentDisk.size : 0, status: 'Ready', diskType: desiredPersistentDisk ? desiredPersistentDisk.diskType : pdTypes.standard }
   }
 
   /**

--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -495,8 +495,8 @@ export const ComputeModalBase = ({
    * is necessary to compute the cost for potential new disk configurations.
    */
   const getPendingDisk = () => {
-    const { persistentDisk: desiredPersistentDisk } = getDesiredEnvironmentConfig()
-    return { size: desiredPersistentDisk ? desiredPersistentDisk.size : 0, status: 'Ready', diskType: desiredPersistentDisk ? desiredPersistentDisk.diskType : pdTypes.standard }
+    const { persistentDisk: { size = 0, diskType = pdTypes.standard } } = getDesiredEnvironmentConfig()
+    return { size, status: 'Ready', diskType }
   }
 
   /**


### PR DESCRIPTION
This fixes an issue that caused the UI to stacktrace and crash when the option for hail is selected in the compute modal dropdown.

This isn't as simple as checking if its undefined, we need to provide intelligent default so the compute modal appropriately displays cost when a user is creating a hail runtime, as so (hail runtimes don't have persistent disks. I verified that this is being handled properly for runtime creation as well):
![image](https://user-images.githubusercontent.com/6465084/164308321-e6708680-a9bd-47c0-8f74-c3dfa4f3de7f.png)

 