### PR TITLE
[DC-310] Update how we access table cells in UI tests

### DIFF
--- a/integration-tests/tests/preview-dataset.js
+++ b/integration-tests/tests/preview-dataset.js
@@ -19,7 +19,7 @@ const testPreviewDatasetFn = withUserToken(async ({ testUrl, page, token }) => {
   const tableName = 'Participant Preview Data'
   await assertRowMatches(page, {
     tableName,
-    expectedColumnValues: [['age', 36], ['biological_sex', 'male']],
+    expectedColumnValues: [['age', 36],['biological_sex', 'male']],
     withKey: { column: 'participant_id', textContains: 'participant1' }
   })
 

--- a/integration-tests/tests/preview-dataset.js
+++ b/integration-tests/tests/preview-dataset.js
@@ -1,4 +1,4 @@
-const { checkbox, click, clickable, findText, waitForNoSpinners, findTableTextWithinColumn } = require('../utils/integration-utils')
+const { checkbox, click, clickable, findText, waitForNoSpinners, getTableCellPath, findTableTextWithinColumn } = require('../utils/integration-utils')
 const { enableDataCatalog } = require('../utils/integration-helpers')
 const { withUserToken } = require('../utils/terra-sa-utils')
 
@@ -19,7 +19,7 @@ const testPreviewDatasetFn = withUserToken(async ({ testUrl, page, token }) => {
   const tableName = 'Participant Preview Data'
   await findTableTextWithinColumn(page, { tableName, columnHeader: 'participant_id', textContains: 'participant1' })
   await findTableTextWithinColumn(page, { tableName, columnHeader: 'biological_sex', textContains: 'male' })
-  await getTableCellPath( page, { row: 2 , column: getTableColIndex(page, {tableName, columnHeader: 'age' }) })
+  await getTableCellPath(page, { row: 2 , column: getTableColIndex(page, {tableName, columnHeader: 'age' }) })
   await findTableTextWithinColumn(page, { tableName, columnHeader: 'age', textContains: '36' })
 })
 

--- a/integration-tests/tests/preview-dataset.js
+++ b/integration-tests/tests/preview-dataset.js
@@ -1,4 +1,4 @@
-const { checkbox, click, clickable, findText, waitForNoSpinners, assertRowMatches } = require('../utils/integration-utils')
+const { checkbox, click, clickable, findText, waitForNoSpinners, assertRowHas } = require('../utils/integration-utils')
 const { enableDataCatalog } = require('../utils/integration-helpers')
 const { withUserToken } = require('../utils/terra-sa-utils')
 
@@ -17,7 +17,7 @@ const testPreviewDatasetFn = withUserToken(async ({ testUrl, page, token }) => {
   await waitForNoSpinners(page)
 
   const tableName = 'Participant Preview Data'
-  await assertRowMatches(page, {
+  await assertRowHas(page, {
     tableName,
     expectedColumnValues: [['age', 36], ['biological_sex', 'male']],
     withKey: { column: 'participant_id', textContains: 'participant1' }

--- a/integration-tests/tests/preview-dataset.js
+++ b/integration-tests/tests/preview-dataset.js
@@ -5,7 +5,7 @@ const { withUserToken } = require('../utils/terra-sa-utils')
 
 const datasetName = 'Readable Catalog Snapshot 1'
 
-const testPreviewDatasetFn = withUserToken(async ({testUrl, page, token}) => {
+const testPreviewDatasetFn = withUserToken(async ({ testUrl, page, token }) => {
   await enableDataCatalog(page, testUrl, token)
   await click(page, clickable({ textContains: 'browse & explore' }))
   await waitForNoSpinners(page)
@@ -17,9 +17,9 @@ const testPreviewDatasetFn = withUserToken(async ({testUrl, page, token}) => {
   await waitForNoSpinners(page)
 
   const tableName = 'Participant Preview Data'
-  await findTableTextWithinColumn(page, { tableName, column: 'participant_id', textContains: 'participant1' })
-  await findTableTextWithinColumn(page, { tableName, column: 'biological_sex', textContains: 'male' })
-  await findTableTextWithinColumn(page, { tableName, column: 'age', textContains: '36' })
+  await findTableTextWithinColumn(page, { tableName, columnText: 'participant_id', textContains: 'participant1' })
+  await findTableTextWithinColumn(page, { tableName, columnText: 'biological_sex', textContains: 'male' })
+  await findTableTextWithinColumn(page, { tableName, columnText: 'age', textContains: '36' })
 })
 
 const testPreviewDataset = {

--- a/integration-tests/tests/preview-dataset.js
+++ b/integration-tests/tests/preview-dataset.js
@@ -5,7 +5,7 @@ const { withUserToken } = require('../utils/terra-sa-utils')
 
 const datasetName = 'Readable Catalog Snapshot 1'
 
-const testPreviewDatasetFn = withUserToken(async ( { testUrl, page, token } ) => {
+const testPreviewDatasetFn = withUserToken(async ({testUrl, page, token}) => {
   await enableDataCatalog(page, testUrl, token)
   await click(page, clickable({ textContains: 'browse & explore' }))
   await waitForNoSpinners(page)
@@ -17,9 +17,9 @@ const testPreviewDatasetFn = withUserToken(async ( { testUrl, page, token } ) =>
   await waitForNoSpinners(page)
 
   const tableName = 'Participant Preview Data'
-  await findTableTextWithinColumn(page, { tableName, column: 'participant_id', textContains: 'participant1'} )
-  await findTableTextWithinColumn(page, { tableName, column: 'biological_sex', textContains: 'male'} )
-  await findTableTextWithinColumn(page, { tableName, column: 'age', textContains: '36'} )
+  await findTableTextWithinColumn(page, { tableName, column: 'participant_id', textContains: 'participant1' })
+  await findTableTextWithinColumn(page, { tableName, column: 'biological_sex', textContains: 'male' })
+  await findTableTextWithinColumn(page, { tableName, column: 'age', textContains: '36' })
 })
 
 const testPreviewDataset = {

--- a/integration-tests/tests/preview-dataset.js
+++ b/integration-tests/tests/preview-dataset.js
@@ -1,4 +1,4 @@
-const { checkbox, click, clickable, findText, waitForNoSpinners, getTableCellPath, getTableColIndex findTableTextWithinColumn } = require('../utils/integration-utils')
+const { checkbox, click, clickable, findText, waitForNoSpinners, getTableCellPath, getTableColIndex, findTableTextWithinColumn } = require('../utils/integration-utils')
 const { enableDataCatalog } = require('../utils/integration-helpers')
 const { withUserToken } = require('../utils/terra-sa-utils')
 

--- a/integration-tests/tests/preview-dataset.js
+++ b/integration-tests/tests/preview-dataset.js
@@ -19,6 +19,7 @@ const testPreviewDatasetFn = withUserToken(async ({ testUrl, page, token }) => {
   const tableName = 'Participant Preview Data'
   await findTableTextWithinColumn(page, { tableName, columnHeader: 'participant_id', textContains: 'participant1' })
   await findTableTextWithinColumn(page, { tableName, columnHeader: 'biological_sex', textContains: 'male' })
+  await getTableCellPath( page, { row: 2 , column: getTableColIndex(page, {tableName, columnHeader: 'age' }) })
   await findTableTextWithinColumn(page, { tableName, columnHeader: 'age', textContains: '36' })
 })
 

--- a/integration-tests/tests/preview-dataset.js
+++ b/integration-tests/tests/preview-dataset.js
@@ -1,4 +1,4 @@
-const { checkbox, click, clickable, findText, waitForNoSpinners, getTableRowIndex, assertRowMatches, findTableTextWithinColumn } = require('../utils/integration-utils')
+const { checkbox, click, clickable, findText, waitForNoSpinners, assertRowMatches } = require('../utils/integration-utils')
 const { enableDataCatalog } = require('../utils/integration-helpers')
 const { withUserToken } = require('../utils/terra-sa-utils')
 
@@ -17,15 +17,12 @@ const testPreviewDatasetFn = withUserToken(async ({ testUrl, page, token }) => {
   await waitForNoSpinners(page)
 
   const tableName = 'Participant Preview Data'
+  await assertRowMatches(page, {
+    tableName,
+    expectedColumnValues: [['age', 36], ['biological_sex', 'male']],
+    withKey: { column: 'participant_id', textContains: 'participant1' }
+  })
 
-  await findTableTextWithinColumn(page, { tableName, columnHeader: 'participant_id', textContains: 'participant1' })
-  await findTableTextWithinColumn(page, { tableName, columnHeader: 'biological_sex', textContains: 'male' })
-  //  await getTableCellPath(page, 2, getTableColIndex(page, { tableName, columnHeader: 'age' }))
-  const row = await getTableRowIndex(page, { tableName, columnHeader: 'participant_id', textContains: 'participant1' })
-  console.log(row)
-  const matchRow = await assertRowMatches(page, { tableName, expectedColumnValues: { age: 36, biological_sex: 'male' }, forRowContaining: { column: 'participant_id', textContains: 'participant1' } })
-  console.log('assertRowMatches', matchRow)
-  await findTableTextWithinColumn(page, { tableName, columnHeader: 'age', textContains: '36' })
 })
 
 const testPreviewDataset = {

--- a/integration-tests/tests/preview-dataset.js
+++ b/integration-tests/tests/preview-dataset.js
@@ -19,10 +19,9 @@ const testPreviewDatasetFn = withUserToken(async ({ testUrl, page, token }) => {
   const tableName = 'Participant Preview Data'
   await assertRowMatches(page, {
     tableName,
-    expectedColumnValues: [['age', 36],['biological_sex', 'male']],
+    expectedColumnValues: [['age', 36], ['biological_sex', 'male']],
     withKey: { column: 'participant_id', textContains: 'participant1' }
   })
-
 })
 
 const testPreviewDataset = {

--- a/integration-tests/tests/preview-dataset.js
+++ b/integration-tests/tests/preview-dataset.js
@@ -19,7 +19,7 @@ const testPreviewDatasetFn = withUserToken(async ({ testUrl, page, token }) => {
   const tableName = 'Participant Preview Data'
   await findTableTextWithinColumn(page, { tableName, columnHeader: 'participant_id', textContains: 'participant1' })
   await findTableTextWithinColumn(page, { tableName, columnHeader: 'biological_sex', textContains: 'male' })
-  await getTableCellPath(page, { row: 2, column: getTableColIndex(page, { tableName, columnHeader: 'age' }) })
+  await getTableCellPath(page, 2, getTableColIndex(page, { tableName, columnHeader: 'age' }) )
   await findTableTextWithinColumn(page, { tableName, columnHeader: 'age', textContains: '36' })
 })
 

--- a/integration-tests/tests/preview-dataset.js
+++ b/integration-tests/tests/preview-dataset.js
@@ -18,19 +18,13 @@ const testPreviewDatasetFn = withUserToken(async ({ testUrl, page, token }) => {
 
   const tableName = 'Participant Preview Data'
 
-//  const getcellPath = await getTableCellPath(page, 2, getTableColIndex(page, { tableName, columnHeader: 'age' }))
-//  console.log(getcellPath)
-//  const readcellPath = page.waitForXPath(getcellPath)
-//  console.log(getcellPath)
-
-
   await findTableTextWithinColumn(page, { tableName, columnHeader: 'participant_id', textContains: 'participant1' })
   await findTableTextWithinColumn(page, { tableName, columnHeader: 'biological_sex', textContains: 'male' })
-//  await getTableCellPath(page, 2, getTableColIndex(page, { tableName, columnHeader: 'age' }))
+  //  await getTableCellPath(page, 2, getTableColIndex(page, { tableName, columnHeader: 'age' }))
   const row = await getTableRowIndex(page, { tableName, columnHeader: 'participant_id', textContains: 'participant1' })
   console.log(row)
-  const matchRow = await assertRowMatches(page, { tableName, expectedColumnValues: {age: 36, biological_sex: 'male'}, forRowContaining: {column: 'participant_id', textContains:'participant1'}})
-  //console.log('assertRowMatches', matchRow)
+  const matchRow = await assertRowMatches(page, { tableName, expectedColumnValues: { age: 36, biological_sex: 'male' }, forRowContaining: { column: 'participant_id', textContains: 'participant1' } })
+  console.log('assertRowMatches', matchRow)
   await findTableTextWithinColumn(page, { tableName, columnHeader: 'age', textContains: '36' })
 })
 

--- a/integration-tests/tests/preview-dataset.js
+++ b/integration-tests/tests/preview-dataset.js
@@ -19,7 +19,7 @@ const testPreviewDatasetFn = withUserToken(async ({ testUrl, page, token }) => {
   const tableName = 'Participant Preview Data'
   await findTableTextWithinColumn(page, { tableName, columnHeader: 'participant_id', textContains: 'participant1' })
   await findTableTextWithinColumn(page, { tableName, columnHeader: 'biological_sex', textContains: 'male' })
-  await getTableCellPath(page, 2, getTableColIndex(page, { tableName, columnHeader: 'age' }) )
+  await getTableCellPath(page, 2, getTableColIndex(page, { tableName, columnHeader: 'age' }))
   await findTableTextWithinColumn(page, { tableName, columnHeader: 'age', textContains: '36' })
 })
 

--- a/integration-tests/tests/preview-dataset.js
+++ b/integration-tests/tests/preview-dataset.js
@@ -1,4 +1,4 @@
-const { checkbox, click, clickable, findText, waitForNoSpinners, getTableCellPath, findTableTextWithinColumn } = require('../utils/integration-utils')
+const { checkbox, click, clickable, findText, waitForNoSpinners, getTableCellPath, getTableColIndex findTableTextWithinColumn } = require('../utils/integration-utils')
 const { enableDataCatalog } = require('../utils/integration-helpers')
 const { withUserToken } = require('../utils/terra-sa-utils')
 
@@ -19,7 +19,7 @@ const testPreviewDatasetFn = withUserToken(async ({ testUrl, page, token }) => {
   const tableName = 'Participant Preview Data'
   await findTableTextWithinColumn(page, { tableName, columnHeader: 'participant_id', textContains: 'participant1' })
   await findTableTextWithinColumn(page, { tableName, columnHeader: 'biological_sex', textContains: 'male' })
-  await getTableCellPath(page, { row: 2 , column: getTableColIndex(page, {tableName, columnHeader: 'age' }) })
+  await getTableCellPath(page, { row: 2, column: getTableColIndex(page, { tableName, columnHeader: 'age' }) })
   await findTableTextWithinColumn(page, { tableName, columnHeader: 'age', textContains: '36' })
 })
 

--- a/integration-tests/tests/preview-dataset.js
+++ b/integration-tests/tests/preview-dataset.js
@@ -5,7 +5,7 @@ const { withUserToken } = require('../utils/terra-sa-utils')
 
 const datasetName = 'Readable Catalog Snapshot 1'
 
-const testPreviewDatasetFn = withUserToken(async ({ testUrl, page, token }) => {
+const testPreviewDatasetFn = withUserToken(async ( { testUrl, page, token } ) => {
   await enableDataCatalog(page, testUrl, token)
   await click(page, clickable({ textContains: 'browse & explore' }))
   await waitForNoSpinners(page)
@@ -17,9 +17,9 @@ const testPreviewDatasetFn = withUserToken(async ({ testUrl, page, token }) => {
   await waitForNoSpinners(page)
 
   const tableName = 'Participant Preview Data'
-  await findTableTextWithinColumn(page, {tableName, column:'participant_id', textContains: 'participant1'})
-  await findTableTextWithinColumn(page, {tableName, column:'biological_sex', textContains: 'male'})
-  await findTableTextWithinColumn(page, {tableName, column:'age', textContains: '36'})
+  await findTableTextWithinColumn(page, { tableName, column: 'participant_id', textContains: 'participant1'} )
+  await findTableTextWithinColumn(page, { tableName, column: 'biological_sex', textContains: 'male'} )
+  await findTableTextWithinColumn(page, { tableName, column: 'age', textContains: '36'} )
 })
 
 const testPreviewDataset = {

--- a/integration-tests/tests/preview-dataset.js
+++ b/integration-tests/tests/preview-dataset.js
@@ -17,14 +17,9 @@ const testPreviewDatasetFn = withUserToken(async ({ testUrl, page, token }) => {
   await waitForNoSpinners(page)
 
   const tableName = 'Participant Preview Data'
-  // findText(page, getTableColumn({tableName, column}))
   await findTableTextWithinColumn(page, {tableName, column:'participant_id', textContains: 'participant1'})
   await findTableTextWithinColumn(page, {tableName, column:'biological_sex', textContains: 'male'})
   await findTableTextWithinColumn(page, {tableName, column:'age', textContains: '36'})
-
-//   await findElement(page, getTableCellWithinColumn(page, {tableName, column:'participant_id', textContains: 'participant1'}))
-//    await findElement(page, getTableCellWithinColumn(page, {tableName, column:'biological_sex', textContains: 'male'}))
-//    await findElement(page, getTableCellWithinColumn(page, {tableName, column:'age', textContains: '36'}))
 })
 
 const testPreviewDataset = {

--- a/integration-tests/tests/preview-dataset.js
+++ b/integration-tests/tests/preview-dataset.js
@@ -17,9 +17,9 @@ const testPreviewDatasetFn = withUserToken(async ({ testUrl, page, token }) => {
   await waitForNoSpinners(page)
 
   const tableName = 'Participant Preview Data'
-  await findTableTextWithinColumn(page, { tableName, columnText: 'participant_id', textContains: 'participant1' })
-  await findTableTextWithinColumn(page, { tableName, columnText: 'biological_sex', textContains: 'male' })
-  await findTableTextWithinColumn(page, { tableName, columnText: 'age', textContains: '36' })
+  await findTableTextWithinColumn(page, { tableName, columnHeader: 'participant_id', textContains: 'participant1' })
+  await findTableTextWithinColumn(page, { tableName, columnHeader: 'biological_sex', textContains: 'male' })
+  await findTableTextWithinColumn(page, { tableName, columnHeader: 'age', textContains: '36' })
 })
 
 const testPreviewDataset = {

--- a/integration-tests/tests/preview-dataset.js
+++ b/integration-tests/tests/preview-dataset.js
@@ -1,4 +1,4 @@
-const { checkbox, click, clickable, findText, findTableCellText, getTableCellPath, getTableHeaderPath, waitForNoSpinners } = require('../utils/integration-utils')
+const { checkbox, click, clickable, findText, findTableCellText, getTableCellPath, getTableHeaderPath, waitForNoSpinners, getTableRowNumber } = require('../utils/integration-utils')
 const { enableDataCatalog } = require('../utils/integration-helpers')
 const { withUserToken } = require('../utils/terra-sa-utils')
 
@@ -17,6 +17,10 @@ const testPreviewDatasetFn = withUserToken(async ({ testUrl, page, token }) => {
   await waitForNoSpinners(page)
 
   const previewTableName = 'Participant Preview Data'
+
+  const rownum = await getTableRowNumber(previewTableName, 'participant_id')
+  console.log(rownum)
+
   await findTableCellText(page, getTableHeaderPath(previewTableName, 1), 'participant_id')
   await findTableCellText(page, getTableHeaderPath(previewTableName, 2), 'biological_sex')
   await findTableCellText(page, getTableHeaderPath(previewTableName, 3), 'age')

--- a/integration-tests/tests/preview-dataset.js
+++ b/integration-tests/tests/preview-dataset.js
@@ -1,4 +1,4 @@
-const { checkbox, click, clickable, findText, waitForNoSpinners, getTableCellPath, getTableColIndex, findTableTextWithinColumn } = require('../utils/integration-utils')
+const { checkbox, click, clickable, findText, waitForNoSpinners, getTableRowIndex, assertRowMatches, findTableTextWithinColumn } = require('../utils/integration-utils')
 const { enableDataCatalog } = require('../utils/integration-helpers')
 const { withUserToken } = require('../utils/terra-sa-utils')
 
@@ -17,9 +17,20 @@ const testPreviewDatasetFn = withUserToken(async ({ testUrl, page, token }) => {
   await waitForNoSpinners(page)
 
   const tableName = 'Participant Preview Data'
+
+//  const getcellPath = await getTableCellPath(page, 2, getTableColIndex(page, { tableName, columnHeader: 'age' }))
+//  console.log(getcellPath)
+//  const readcellPath = page.waitForXPath(getcellPath)
+//  console.log(getcellPath)
+
+
   await findTableTextWithinColumn(page, { tableName, columnHeader: 'participant_id', textContains: 'participant1' })
   await findTableTextWithinColumn(page, { tableName, columnHeader: 'biological_sex', textContains: 'male' })
-  await getTableCellPath(page, 2, getTableColIndex(page, { tableName, columnHeader: 'age' }))
+//  await getTableCellPath(page, 2, getTableColIndex(page, { tableName, columnHeader: 'age' }))
+  const row = await getTableRowIndex(page, { tableName, columnHeader: 'participant_id', textContains: 'participant1' })
+  console.log(row)
+  const matchRow = await assertRowMatches(page, { tableName, expectedColumnValues: {age: 36, biological_sex: 'male'}, forRowContaining: {column: 'participant_id', textContains:'participant1'}})
+  //console.log('assertRowMatches', matchRow)
   await findTableTextWithinColumn(page, { tableName, columnHeader: 'age', textContains: '36' })
 })
 

--- a/integration-tests/tests/preview-dataset.js
+++ b/integration-tests/tests/preview-dataset.js
@@ -1,4 +1,4 @@
-const { checkbox, click, clickable, findText, findTableCellText, getTableCellPath, getTableHeaderPath, waitForNoSpinners, getTableRowNumber } = require('../utils/integration-utils')
+const { checkbox, click, clickable, findText, waitForNoSpinners, findTableTextWithinColumn } = require('../utils/integration-utils')
 const { enableDataCatalog } = require('../utils/integration-helpers')
 const { withUserToken } = require('../utils/terra-sa-utils')
 
@@ -16,17 +16,15 @@ const testPreviewDatasetFn = withUserToken(async ({ testUrl, page, token }) => {
   await click(page, clickable({ textContains: 'Preview data' }))
   await waitForNoSpinners(page)
 
-  const previewTableName = 'Participant Preview Data'
+  const tableName = 'Participant Preview Data'
+  // findText(page, getTableColumn({tableName, column}))
+  await findTableTextWithinColumn(page, {tableName, column:'participant_id', textContains: 'participant1'})
+  await findTableTextWithinColumn(page, {tableName, column:'biological_sex', textContains: 'male'})
+  await findTableTextWithinColumn(page, {tableName, column:'age', textContains: '36'})
 
-  const rownum = await getTableRowNumber(previewTableName, 'participant_id')
-  console.log(rownum)
-
-  await findTableCellText(page, getTableHeaderPath(previewTableName, 1), 'participant_id')
-  await findTableCellText(page, getTableHeaderPath(previewTableName, 2), 'biological_sex')
-  await findTableCellText(page, getTableHeaderPath(previewTableName, 3), 'age')
-  await findTableCellText(page, getTableCellPath(previewTableName, 2, 1), 'participant1')
-  await findTableCellText(page, getTableCellPath(previewTableName, 2, 2), 'male')
-  await findTableCellText(page, getTableCellPath(previewTableName, 2, 3), '36')
+//   await findElement(page, getTableCellWithinColumn(page, {tableName, column:'participant_id', textContains: 'participant1'}))
+//    await findElement(page, getTableCellWithinColumn(page, {tableName, column:'biological_sex', textContains: 'male'}))
+//    await findElement(page, getTableCellWithinColumn(page, {tableName, column:'age', textContains: '36'}))
 })
 
 const testPreviewDataset = {

--- a/integration-tests/tests/request-access.js
+++ b/integration-tests/tests/request-access.js
@@ -15,7 +15,7 @@ const testRequestAccessFn = withUserToken(async ({ testUrl, page, token }) => {
   await click(page, clickable({ textContains: 'Close modal' }))
 
   // Request access from the dataset details page
-  await clickTableCell (page, {tableName:'dataset list', column:'Dataset Name', textContains:'Discoverable Catalog Snapshot 1'})
+  await clickTableCell (page, { tableName:'dataset list', column: 'Dataset Name', textContains: 'Discoverable Catalog Snapshot 1' })
   await waitForNoSpinners(page)
   await click(page, clickable({ textContains: 'Request Access' }))
   await findText(page, 'Request Access')

--- a/integration-tests/tests/request-access.js
+++ b/integration-tests/tests/request-access.js
@@ -15,7 +15,7 @@ const testRequestAccessFn = withUserToken(async ({ testUrl, page, token }) => {
   await click(page, clickable({ textContains: 'Close modal' }))
 
   // Request access from the dataset details page
-  await clickTableCell (page, { tableName:'dataset list', column: 'Dataset Name', textContains: 'Discoverable Catalog Snapshot 1' })
+  await clickTableCell(page, { tableName: 'dataset list', columnText: 'Dataset Name', textContains: 'Discoverable Catalog Snapshot 1' })
   await waitForNoSpinners(page)
   await click(page, clickable({ textContains: 'Request Access' }))
   await findText(page, 'Request Access')

--- a/integration-tests/tests/request-access.js
+++ b/integration-tests/tests/request-access.js
@@ -15,7 +15,7 @@ const testRequestAccessFn = withUserToken(async ({ testUrl, page, token }) => {
   await click(page, clickable({ textContains: 'Close modal' }))
 
   // Request access from the dataset details page
-  await clickTableCell(page, 'dataset list', 2, 2)
+  await clickTableCell (page, {tableName:'dataset list', column:'Dataset Name', textContains:'Discoverable Catalog Snapshot 1'})
   await waitForNoSpinners(page)
   await click(page, clickable({ textContains: 'Request Access' }))
   await findText(page, 'Request Access')

--- a/integration-tests/tests/request-access.js
+++ b/integration-tests/tests/request-access.js
@@ -15,7 +15,7 @@ const testRequestAccessFn = withUserToken(async ({ testUrl, page, token }) => {
   await click(page, clickable({ textContains: 'Close modal' }))
 
   // Request access from the dataset details page
-  await clickTableCell(page, { tableName: 'dataset list', columnText: 'Dataset Name', textContains: 'Discoverable Catalog Snapshot 1' })
+  await clickTableCell(page, { tableName: 'dataset list', columnHeader: 'Dataset Name', textContains: 'Discoverable Catalog Snapshot 1' })
   await waitForNoSpinners(page)
   await click(page, clickable({ textContains: 'Request Access' }))
   await findText(page, 'Request Access')

--- a/integration-tests/utils/catalog-utils.js
+++ b/integration-tests/utils/catalog-utils.js
@@ -10,7 +10,6 @@ const eitherThrow = (testFailure, { cleanupFailure, cleanupMessage }) => {
     throw new Error(`${cleanupMessage}: ${cleanupFailure.message}`)
   }
 }
-//Transcriptomic and clonal characterization of T cells in the human central nervous system.
 const linkDataToWorkspace = async (page, testUrl, token) => {
   await enableDataCatalog(page, testUrl, token)
   await click(page, clickable({ textContains: 'browse & explore' }))

--- a/integration-tests/utils/catalog-utils.js
+++ b/integration-tests/utils/catalog-utils.js
@@ -15,7 +15,7 @@ const linkDataToWorkspace = async (page, testUrl, token) => {
   await enableDataCatalog(page, testUrl, token)
   await click(page, clickable({ textContains: 'browse & explore' }))
   await click(page, checkbox({ text: 'Granted', isDescendant: true }))
-  await clickTableCell(page, 'dataset list', 2, 2)
+  await clickTableCell(page, { tableName: 'dataset list', columnHeader: 'Dataset Name', textContains: 'Discoverable Catalog Snapshot 1' })
   await noSpinnersAfter(page, { action: () => click(page, clickable({ textContains: 'Link to a workspace' })) })
 }
 

--- a/integration-tests/utils/catalog-utils.js
+++ b/integration-tests/utils/catalog-utils.js
@@ -10,6 +10,7 @@ const eitherThrow = (testFailure, { cleanupFailure, cleanupMessage }) => {
     throw new Error(`${cleanupMessage}: ${cleanupFailure.message}`)
   }
 }
+
 const linkDataToWorkspace = async (page, testUrl, token) => {
   await enableDataCatalog(page, testUrl, token)
   await click(page, clickable({ textContains: 'browse & explore' }))

--- a/integration-tests/utils/catalog-utils.js
+++ b/integration-tests/utils/catalog-utils.js
@@ -10,12 +10,13 @@ const eitherThrow = (testFailure, { cleanupFailure, cleanupMessage }) => {
     throw new Error(`${cleanupMessage}: ${cleanupFailure.message}`)
   }
 }
-
+//Transcriptomic and clonal characterization of T cells in the human central nervous system.
 const linkDataToWorkspace = async (page, testUrl, token) => {
   await enableDataCatalog(page, testUrl, token)
   await click(page, clickable({ textContains: 'browse & explore' }))
   await click(page, checkbox({ text: 'Granted', isDescendant: true }))
-  await clickTableCell(page, { tableName: 'dataset list', columnHeader: 'Dataset Name', textContains: 'Discoverable Catalog Snapshot 1' })
+  // TODO: add test data with granted access DC-321
+  await clickTableCell(page, { tableName: 'dataset list', columnHeader: 'Dataset Name', textContains: 'Transcriptomic and clonal characterization of T cells in the human central nervous system.' })
   await noSpinnersAfter(page, { action: () => click(page, clickable({ textContains: 'Link to a workspace' })) })
 }
 

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -66,7 +66,7 @@ const getTableCellPath = (tableName, row, column) => {
   return `//*[@role="table" and @aria-label="${tableName}"]//*[@role="row"][${row}]//*[@role="cell"][${column}]`
 }
 
-const getTableColIndex = async (page, {tableName, textContains}) => {
+const getTableColIndex = async (page, { tableName, textContains }) => {
    const colHeaderNode = await findElement(page, `//*[@role="table" and @aria-label="${tableName}"]//*[@role="columnheader" and @aria-colindex and contains(normalize-space(.),"${textContains}")]`)
    return page.evaluate(node => node.getAttribute("aria-colindex"), colHeaderNode)
 }
@@ -83,7 +83,7 @@ const getTableTextWithinColumn = async (page, { tableName, column, textContains,
   return xpath
 }
 
-const findTableTextWithinColumn = async (page, {tableName, column, textContains}, options) => {
+const findTableTextWithinColumn = async (page, { tableName, column, textContains }, options) => {
   const xpath = await getTableTextWithinColumn(page, {tableName, column, textContains})
   return page.waitForXPath(xpath, options)
 }

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -71,20 +71,20 @@ const getTableColIndex = async (page, { tableName, columnText }) => {
   return page.evaluate(node => node.getAttribute('aria-colindex'), colHeaderNode)
 }
 
-const getTableTextWithinColumn = async (page, { tableName, columnText, textContains, isDescendant=false }, options) => {
+const getTableTextWithinColumn = async (page, { tableName, columnText, textContains, isDescendant = false }) => {
   const colIndex = await getTableColIndex( page,{ tableName, columnText })
   const baseXpath = `//*[@role="table" and @aria-label="${tableName}"]//*[@role="row"]//*[@role="cell" and @aria-colindex = "${colIndex}"]`
   const xpath = `${baseXpath}${isDescendant ? '//*' : ''}[contains(normalize-space(.),"${textContains}")]`
   return xpath
 }
 
-const findTableTextWithinColumn = async (page, { tableName, columnText, textContains }, options) => {
-  const xpath = await getTableTextWithinColumn(page, { tableName, columnText, textContains })
+const findTableTextWithinColumn = async (page, { tableName, columnText, textContains, isDescendant = false }, options) => {
+  const xpath = await getTableTextWithinColumn(page, { tableName, columnText, textContains, isDescendant })
   return page.waitForXPath(xpath, options)
 }
 
-const clickTableCell = async (page, { tableName, columnText, textContains }, options) =>{
-  const tableCellPath = await getTableTextWithinColumn(page, { tableName, columnText, textContains })
+const clickTableCell = async (page, { tableName, columnText, textContains, isDescendant = false }, options) => {
+  const tableCellPath = await getTableTextWithinColumn(page, { tableName, columnText, textContains, isDescendant })
   const xpath = `${tableCellPath}//*[@role="button" or @role="link" or @role="checkbox"]`
   return (await page.waitForXPath(xpath, options)).click()
 }

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -78,6 +78,12 @@ const getTableTextWithinColumn = async (page, { tableName, columnHeader, textCon
   return xpath
 }
 
+const getTableRowIndex = async (page, { tableName, columnHeader, textContains, isDescendant = false }) => {
+  const colXPath = await getTableTextWithinColumn(page, { tableName, columnHeader, textContains, isDescendant })
+  const findCol = await findElement(page, colXPath)
+  return page.evaluate(node => node.getAttribute('aria-rowindex'), findCol)
+}
+
 const assertRowHas = async (page, { tableName, expectedColumnValues, withKey: { column, textContains } }) => {
   const rowIndex = await getTableRowIndex(page, { tableName, columnHeader: column, textContains })
 
@@ -88,12 +94,6 @@ const assertRowHas = async (page, { tableName, expectedColumnValues, withKey: { 
   }
 
   await Promise.all(_.map(findTextInColumn, expectedColumnValues))
-}
-
-const getTableRowIndex = async (page, { tableName, columnHeader, textContains, isDescendant = false }) => {
-  const colXPath = await getTableTextWithinColumn(page, { tableName, columnHeader, textContains, isDescendant })
-  const findCol = await findElement(page, colXPath)
-  return page.evaluate(node => node.getAttribute('aria-rowindex'), findCol)
 }
 
 const clickTableCell = async (page, { tableName, columnHeader, textContains, isDescendant = false }, options) => {

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -72,7 +72,7 @@ const getTableColIndex = async (page, { tableName, columnText }) => {
 }
 
 const getTableTextWithinColumn = async (page, { tableName, columnText, textContains, isDescendant = false }) => {
-  const colIndex = await getTableColIndex( page,{ tableName, columnText })
+  const colIndex = await getTableColIndex(page, { tableName, columnText })
   const baseXpath = `//*[@role="table" and @aria-label="${tableName}"]//*[@role="row"]//*[@role="cell" and @aria-colindex = "${colIndex}"]`
   const xpath = `${baseXpath}${isDescendant ? '//*' : ''}[contains(normalize-space(.),"${textContains}")]`
   return xpath
@@ -323,6 +323,5 @@ module.exports = {
   withPageLogging,
   openError,
   getTableColIndex,
-  findTableTextWithinColumn,
-  clickTableCell
+  findTableTextWithinColumn
 }

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -87,7 +87,7 @@ const assertRowMatches = async (page, { tableName, expectedColumnValues, withKey
     return await findElement(page, xPath, { timeout: 5000 })
   }
 
-  return Promise.all(_.map(findTextInColumn, expectedColumnValues))
+await Promise.all(_.map(findTextInColumn, expectedColumnValues))
 }
 
 const getTableRowIndex = async (page, { tableName, columnHeader, textContains, isDescendant = false }) => {

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -70,6 +70,16 @@ const getTableHeaderPath = (tableName, column) => {
   return `//*[@role="table" and @aria-label="${tableName}"]//*[@role="row"][1]//*[@role="columnheader"][${column}]`
 }
 
+const getTableRowNumber = (tableName, text) => {
+  return `//*[@role="table" and @aria-label="${tableName}"]//*[@role="columnheader" and contains(.,"${text}")]/@aria-colindex`
+}
+ //[@role="row"][${row}]//*[contains(.,"${text}")]`
+ ////*[@role="table" and @aria-label="Participant Preview Data"]//*[@role="columnheader" and contains(.,"age")]/@aria-colindex`
+
+const getTableRowColumnNumber = (tableName, row, text) => {
+  return `//*[@role="table"] and @aria-label="${tableName}"]//*[@role="row"][${row}]//*[count([contains(.,"${text}")]/preceding-sibling::div)+1]`
+}
+
 const findTableCellText = async (page, path, textContains, options) => {
   const xpath = `${path}[contains(normalize-space(.),"${textContains}")]`
   return (await page.waitForXPath(xpath, options))
@@ -315,5 +325,6 @@ module.exports = {
   noSpinnersAfter,
   waitForNoSpinners,
   withPageLogging,
-  openError
+  openError,
+  getTableRowNumber
 }

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -66,25 +66,25 @@ const getTableCellPath = (tableName, row, column) => {
   return `//*[@role="table" and @aria-label="${tableName}"]//*[@role="row"][${row}]//*[@role="cell"][${column}]`
 }
 
-const getTableColIndex = async (page, { tableName, columnText }) => {
-  const colHeaderNode = await findElement(page, `//*[@role="table" and @aria-label="${tableName}"]//*[@role="columnheader" and @aria-colindex and contains(normalize-space(.),"${columnText}")]`)
+const getTableColIndex = async (page, { tableName, columnHeader }) => {
+  const colHeaderNode = await findElement(page, `//*[@role="table" and @aria-label="${tableName}"]//*[@role="columnheader" and @aria-colindex and contains(normalize-space(.),"${columnHeader}")]`)
   return page.evaluate(node => node.getAttribute('aria-colindex'), colHeaderNode)
 }
 
-const getTableTextWithinColumn = async (page, { tableName, columnText, textContains, isDescendant = false }) => {
-  const colIndex = await getTableColIndex(page, { tableName, columnText })
+const getTableTextWithinColumn = async (page, { tableName, columnHeader, textContains, isDescendant = false }) => {
+  const colIndex = await getTableColIndex(page, { tableName, columnHeader })
   const baseXpath = `//*[@role="table" and @aria-label="${tableName}"]//*[@role="row"]//*[@role="cell" and @aria-colindex = "${colIndex}"]`
   const xpath = `${baseXpath}${isDescendant ? '//*' : ''}[contains(normalize-space(.),"${textContains}")]`
   return xpath
 }
 
-const findTableTextWithinColumn = async (page, { tableName, columnText, textContains, isDescendant = false }, options) => {
-  const xpath = await getTableTextWithinColumn(page, { tableName, columnText, textContains, isDescendant })
+const findTableTextWithinColumn = async (page, { tableName, columnHeader, textContains, isDescendant = false }, options) => {
+  const xpath = await getTableTextWithinColumn(page, { tableName, columnHeader, textContains, isDescendant })
   return page.waitForXPath(xpath, options)
 }
 
-const clickTableCell = async (page, { tableName, columnText, textContains, isDescendant = false }, options) => {
-  const tableCellPath = await getTableTextWithinColumn(page, { tableName, columnText, textContains, isDescendant })
+const clickTableCell = async (page, { tableName, columnHeader, textContains, isDescendant = false }, options) => {
+  const tableCellPath = await getTableTextWithinColumn(page, { tableName, columnHeader, textContains, isDescendant })
   const xpath = `${tableCellPath}//*[@role="button" or @role="link" or @role="checkbox"]`
   return (await page.waitForXPath(xpath, options)).click()
 }

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -76,8 +76,8 @@ const getTableColIndex = async (page, {tableName, textContains}) => {
 // 4. Update request-access
 // 5. remove clickTableCell function
 
-const getTableTextWithinColumn = async (page, {tableName, column, textContains, isDescendant=false}, options) => {
-  const colIndex = await getTableColIndex(page,{tableName,textContains:column})
+const getTableTextWithinColumn = async (page, { tableName, column, textContains, isDescendant=false }, options) => {
+  const colIndex = await getTableColIndex( page,{ tableName,textContains:column } )
   const baseXpath = `//*[@role="table" and @aria-label="${tableName}"]//*[@role="row"]//*[@role="cell" and @aria-colindex = "${colIndex}"]`
   const xpath = `${baseXpath}${isDescendant ? '//*' : ''}[contains(normalize-space(.),"${textContains}")]`
   return xpath
@@ -88,8 +88,8 @@ const findTableTextWithinColumn = async (page, {tableName, column, textContains}
   return page.waitForXPath(xpath, options)
 }
 
-const clickTableCell = async (page, {tableName, column, textContains}, options) =>{
-  const tableCellPath = await getTableTextWithinColumn(page, {tableName, column, textContains})
+const clickTableCell = async (page, { tableName, column, textContains }, options) =>{
+  const tableCellPath = await getTableTextWithinColumn(page, { tableName, column, textContains })
   const xpath = `${tableCellPath}//*[@role="button" or @role="link" or @role="checkbox"]`
   return (await page.waitForXPath(xpath, options)).click()
 }

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -91,7 +91,7 @@ const assertRowMatches = async (page, { tableName, expectedColumnValues, forRowC
     const colIndex = await getTableColIndex(page, { tableName, columnHeader })
     const baseXpath = `//*[@role="table" and @aria-label="${tableName}"]//*[@role="row"]//*[@role="cell" and @aria-rowindex = "${rowIndex}" and @aria-colindex = "${colIndex}"]`
     const colXPath = `${baseXpath}${isDescendant ? '//*' : ''}[contains(normalize-space(.),"${text}")]`
-    return await findElement(page, colXPath, { timeout:5000 })
+    return await findElement(page, colXPath, { timeout: 5000 })
   }
 
   // this flow will return an array of promises you can use Promise.all to resolve

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -78,7 +78,7 @@ const getTableTextWithinColumn = async (page, { tableName, columnHeader, textCon
   return xpath
 }
 
-const assertRowMatches = async (page, { tableName, expectedColumnValues, withKey: { column, textContains } }) => {
+const assertRowHas = async (page, { tableName, expectedColumnValues, withKey: { column, textContains } }) => {
   const rowIndex = await getTableRowIndex(page, { tableName, columnHeader: column, textContains })
 
   const findTextInColumn = async ([columnHeader, text]) => {
@@ -304,7 +304,7 @@ const withPageLogging = fn => options => {
 
 module.exports = {
   assertTextNotFound,
-  assertRowMatches,
+  assertRowHas,
   checkbox,
   click,
   clickable,

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -78,8 +78,8 @@ const getTableTextWithinColumn = async (page, { tableName, columnHeader, textCon
   return xpath
 }
 
-const assertRowMatches = async (page, { tableName, expectedColumnValues, forRowContaining:{ column, textContains }, isDescendant = false }) => {
-  const rowIndex = await getTableRowIndex(page, { tableName, columnHeader:column, textContains })
+const assertRowMatches = async (page, { tableName, expectedColumnValues, forRowContaining: { column, textContains }, isDescendant = false }) => {
+  const rowIndex = await getTableRowIndex(page, { tableName, columnHeader: column, textContains })
   console.log('expectedColumnValues', expectedColumnValues)
 
   //const trace = message => value => {
@@ -91,7 +91,7 @@ const assertRowMatches = async (page, { tableName, expectedColumnValues, forRowC
     const colIndex = await getTableColIndex(page, { tableName, columnHeader })
     const baseXpath = `//*[@role="table" and @aria-label="${tableName}"]//*[@role="row"]//*[@role="cell" and @aria-rowindex = "${rowIndex}" and @aria-colindex = "${colIndex}"]`
     const colXPath = `${baseXpath}${isDescendant ? '//*' : ''}[contains(normalize-space(.),"${text}")]`
-    return await findElement(page, colXPath, {timeout:5000})
+    return await findElement(page, colXPath, { timeout:5000 })
   }
 
   // this flow will return an array of promises you can use Promise.all to resolve

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -66,30 +66,25 @@ const getTableCellPath = (tableName, row, column) => {
   return `//*[@role="table" and @aria-label="${tableName}"]//*[@role="row"][${row}]//*[@role="cell"][${column}]`
 }
 
-const getTableColIndex = async (page, { tableName, textContains }) => {
-   const colHeaderNode = await findElement(page, `//*[@role="table" and @aria-label="${tableName}"]//*[@role="columnheader" and @aria-colindex and contains(normalize-space(.),"${textContains}")]`)
-   return page.evaluate(node => node.getAttribute("aria-colindex"), colHeaderNode)
+const getTableColIndex = async (page, { tableName, columnText }) => {
+  const colHeaderNode = await findElement(page, `//*[@role="table" and @aria-label="${tableName}"]//*[@role="columnheader" and @aria-colindex and contains(normalize-space(.),"${columnText}")]`)
+  return page.evaluate(node => node.getAttribute('aria-colindex'), colHeaderNode)
 }
 
-// 2. [Option 1] Write a clickElement(elementHandle) - can be invoked like clickElement(findTableTextWithinColumn(...))
-// 3. [Option 2] Implement the two functions below
-// 4. Update request-access
-// 5. remove clickTableCell function
-
-const getTableTextWithinColumn = async (page, { tableName, column, textContains, isDescendant=false }, options) => {
-  const colIndex = await getTableColIndex( page,{ tableName,textContains:column } )
+const getTableTextWithinColumn = async (page, { tableName, columnText, textContains, isDescendant=false }, options) => {
+  const colIndex = await getTableColIndex( page,{ tableName, columnText })
   const baseXpath = `//*[@role="table" and @aria-label="${tableName}"]//*[@role="row"]//*[@role="cell" and @aria-colindex = "${colIndex}"]`
   const xpath = `${baseXpath}${isDescendant ? '//*' : ''}[contains(normalize-space(.),"${textContains}")]`
   return xpath
 }
 
-const findTableTextWithinColumn = async (page, { tableName, column, textContains }, options) => {
-  const xpath = await getTableTextWithinColumn(page, {tableName, column, textContains})
+const findTableTextWithinColumn = async (page, { tableName, columnText, textContains }, options) => {
+  const xpath = await getTableTextWithinColumn(page, { tableName, columnText, textContains })
   return page.waitForXPath(xpath, options)
 }
 
-const clickTableCell = async (page, { tableName, column, textContains }, options) =>{
-  const tableCellPath = await getTableTextWithinColumn(page, { tableName, column, textContains })
+const clickTableCell = async (page, { tableName, columnText, textContains }, options) =>{
+  const tableCellPath = await getTableTextWithinColumn(page, { tableName, columnText, textContains })
   const xpath = `${tableCellPath}//*[@role="button" or @role="link" or @role="checkbox"]`
   return (await page.waitForXPath(xpath, options)).click()
 }

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -300,11 +300,13 @@ module.exports = {
   findInGrid,
   findElement,
   findHeading,
+  findTableTextWithinColumn,
   findText,
   fillIn,
   fillInReplace,
   getAnimatedDrawer,
   getTableCellPath,
+  getTableColIndex,
   heading,
   image,
   input,
@@ -321,7 +323,5 @@ module.exports = {
   noSpinnersAfter,
   waitForNoSpinners,
   withPageLogging,
-  openError,
-  getTableColIndex,
-  findTableTextWithinColumn
+  openError
 }

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -87,7 +87,7 @@ const assertRowHas = async (page, { tableName, expectedColumnValues, withKey: { 
     return await findElement(page, xPath, { timeout: 5000 })
   }
 
-await Promise.all(_.map(findTextInColumn, expectedColumnValues))
+  await Promise.all(_.map(findTextInColumn, expectedColumnValues))
 }
 
 const getTableRowIndex = async (page, { tableName, columnHeader, textContains, isDescendant = false }) => {

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -595,17 +595,19 @@ export const SimpleTable = ({
         hover: useHover && { backgroundColor: colors.light(0.4) }
       }, [
         div({ style: { display: 'flex' } }, [
-          _.map(({ key, size }) => {
+          _.map(([colindex, { key, size }]) => {
             return div({
               key,
               role: 'cell',
+              'aria-rowindex': i + 2,
+              'aria-colindex': colindex + 1, // The first column is 1
               className: 'table-cell',
               style: {
                 borderTop: `1px solid ${colors.dark(0.2)}`,
                 ...cellStyles, ...styles.flexCell(size)
               }
             }, [row[key]])
-          }, columns)
+          }, Utils.toIndexPairs(columns))
         ]),
         underRowKey && row[underRowKey]
       ])

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -576,7 +576,7 @@ export const SimpleTable = ({
     'aria-label': ariaLabel
   }, [
     !_.isEmpty(columns) && div({ role: 'row', style: { display: 'flex', alignItems: 'center', ...headerRowStyle } }, [
-      _.map(([i,{ key, header, size }]) => {
+      _.map(([i, { key, header, size }]) => {
         return div({
           key,
           role: 'columnheader',

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -576,13 +576,15 @@ export const SimpleTable = ({
     'aria-label': ariaLabel
   }, [
     !_.isEmpty(columns) && div({ role: 'row', style: { display: 'flex', alignItems: 'center', ...headerRowStyle } }, [
-      _.map(({ key, header, size }) => {
+      _.map(([i,{ key, header, size }]) => {
         return div({
           key,
           role: 'columnheader',
+          'aria-rowindex': 1, // The header row is 1
+          'aria-colindex': i + 1, // The first column is 1
           style: { ...cellStyles, ...styles.flexCell(size) }
         }, [header])
-      }, columns)
+      }, Utils.toIndexPairs(columns))
     ]),
     _.map(([i, row]) => {
       return h(Interactive, {

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -599,7 +599,7 @@ export const SimpleTable = ({
             return div({
               key,
               role: 'cell',
-              'aria-rowindex': i + 2,
+              'aria-rowindex': i + 2, // The first row of data is 2
               'aria-colindex': colindex + 1, // The first column is 1
               className: 'table-cell',
               style: {


### PR DESCRIPTION
Determining the column index via the header information and “scanning” the rows of a table to find the correct data we are looking for in a given column.
