### PR TITLE
[AJ-156] Missing snapshot

### DIFF
--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -193,6 +193,11 @@ export const entityAttributeText = (value, machineReadable) => {
   )
 }
 
+// Returns a message explaining that the desired snapshot reference could not be found by name
+export const snapshotReferenceMissingError = snapshotReferenceName => {
+  return `The requested snapshot reference '${snapshotReferenceName}' could not be found in this workspace.`
+}
+
 // Returns a message explaining why the user can't edit the workspace, or undefined if they can
 export const editWorkspaceError = ({ accessLevel, workspace: { isLocked } }) => {
   return cond(

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -476,12 +476,13 @@ const WorkflowView = _.flow(
         !isRedacted ? filterConfigIO(inputsOutputs) : _.identity
       )(config)
 
-      let selectedSnapshotEntityMetadata = undefined
-      if (modifiedConfig.dataReferenceName) {
-        try {
-          selectedSnapshotEntityMetadata = await Ajax(signal).Workspaces.workspace(namespace, name).snapshotEntityMetadata(googleProject, modifiedConfig.dataReferenceName)
-        } catch (error) {
-          // noop
+      const selectedSnapshotEntityMetadata = async () => {
+        if (modifiedConfig.dataReferenceName) {
+          try {
+            return await Ajax(signal).Workspaces.workspace(namespace, name).snapshotEntityMetadata(googleProject, modifiedConfig.dataReferenceName)
+          } catch (error) {
+            return undefined
+          }
         }
       }
 

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -785,7 +785,7 @@ const WorkflowView = _.flow(
                   isDisabled: !!Utils.editWorkspaceError(ws) || !!snapshotReferenceError,
                   'aria-label': 'Snapshot table selector',
                   isClearable: false,
-                  value: modifiedConfig.dataReferenceName && !!!snapshotReferenceError ? modifiedConfig.rootEntityType : undefined,
+                  value: modifiedConfig.dataReferenceName && !snapshotReferenceError ? modifiedConfig.rootEntityType : undefined,
                   onChange: ({ value }) => {
                     this.setState(_.set(['modifiedConfig', 'rootEntityType'], value))
                     this.setState(_.unset(['modifiedConfig', 'entityName']))

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -782,10 +782,10 @@ const WorkflowView = _.flow(
               ]),
               entitySelectionModel.type === processSnapshotTable ? div({ style: { margin: '2rem 0 0 2rem' } }, [
                 h(Select, {
-                  isDisabled: !!Utils.editWorkspaceError(ws),
+                  isDisabled: !!Utils.editWorkspaceError(ws) || !!snapshotReferenceError,
                   'aria-label': 'Snapshot table selector',
                   isClearable: false,
-                  value: modifiedConfig.dataReferenceName ? modifiedConfig.rootEntityType : undefined,
+                  value: modifiedConfig.dataReferenceName && !!!snapshotReferenceError ? modifiedConfig.rootEntityType : undefined,
                   onChange: ({ value }) => {
                     this.setState(_.set(['modifiedConfig', 'rootEntityType'], value))
                     this.setState(_.unset(['modifiedConfig', 'entityName']))

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -152,8 +152,8 @@ const WorkflowIOTable = ({ which, inputsOutputs: data, config, errors, onChange,
         cellRenderer: ({ rowIndex }) => {
           const io = sortedData[rowIndex]
           const { name, optional, inputType } = io
-          const value = config[which][name] || ''
-          const error = errors[which][name]
+          const value = _.get([which, name], config) || ''
+          const error = _.get([which, name], errors)
           const isFile = (inputType === 'File') || (inputType === 'File?')
           const formattedValue = JSON.stringify(Utils.maybeParseJSON(value), null, 2)
           return div({ style: { display: 'flex', alignItems: 'center', width: '100%', paddingTop: '0.5rem', paddingBottom: '0.5rem' } }, [

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -899,7 +899,7 @@ const WorkflowView = _.flow(
             onChangeTab: v => this.setState({ activeTab: v, filter: '' }),
             finalStep: h(ButtonPrimary, {
               style: { marginLeft: '1rem' },
-              disabled: !!Utils.computeWorkspaceError(ws) || !!noLaunchReason || currentSnapRedacted,
+              disabled: !!Utils.computeWorkspaceError(ws) || !!noLaunchReason || currentSnapRedacted || !!snapshotReferenceError,
               tooltip: Utils.computeWorkspaceError(ws) || noLaunchReason || (currentSnapRedacted && 'Workflow version was redacted.'),
               onClick: () => this.setState({ launching: true })
             }, ['Run analysis'])

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -487,7 +487,8 @@ const WorkflowView = _.flow(
       )(config)
 
       const selectedSnapshotEntityMetadata = modifiedConfig.dataReferenceName ?
-        await this.safeGetSnapshotEntityMetadata(googleProject, modifiedConfig) : undefined
+        await this.safeGetSnapshotEntityMetadata(googleProject, modifiedConfig) :
+        undefined
 
       this.setState({
         savedConfig: config, modifiedConfig,

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -152,8 +152,8 @@ const WorkflowIOTable = ({ which, inputsOutputs: data, config, errors, onChange,
         cellRenderer: ({ rowIndex }) => {
           const io = sortedData[rowIndex]
           const { name, optional, inputType } = io
-          const value = _.get([which, name], config) || ''
-          const error = _.get([which, name], errors)
+          const value = config?.[which]?.[name] || ''
+          const error = errors?.[which]?.[name]
           const isFile = (inputType === 'File') || (inputType === 'File?')
           const formattedValue = JSON.stringify(Utils.maybeParseJSON(value), null, 2)
           return div({ style: { display: 'flex', alignItems: 'center', width: '100%', paddingTop: '0.5rem', paddingBottom: '0.5rem' } }, [

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -442,7 +442,7 @@ const WorkflowView = _.flow(
     }
   }
 
-  async safeGetSnapshotEntityMetadata(googleProject, modifiedConfig) {
+  async maybeGetSnapshotEntityMetadata(googleProject, modifiedConfig) {
     const { namespace, name, signal } = this.props
 
     try {
@@ -488,7 +488,7 @@ const WorkflowView = _.flow(
       )(config)
 
       const selectedSnapshotEntityMetadata = modifiedConfig.dataReferenceName ?
-        await this.safeGetSnapshotEntityMetadata(googleProject, modifiedConfig) :
+        await this.maybeGetSnapshotEntityMetadata(googleProject, modifiedConfig) :
         undefined
 
       this.setState({

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -441,6 +441,16 @@ const WorkflowView = _.flow(
     }
   }
 
+  async safeGetSnapshotEntityMetadata(googleProject, modifiedConfig) {
+    const { namespace, name, signal } = this.props
+
+    try {
+      return await Ajax(signal).Workspaces.workspace(namespace, name).snapshotEntityMetadata(googleProject, modifiedConfig.dataReferenceName)
+    } catch (error) {
+      return undefined
+    }
+  }
+
   async componentDidMount() {
     const {
       namespace, name, workflowNamespace, workflowName,
@@ -476,15 +486,8 @@ const WorkflowView = _.flow(
         !isRedacted ? filterConfigIO(inputsOutputs) : _.identity
       )(config)
 
-      const selectedSnapshotEntityMetadata = async () => {
-        if (modifiedConfig.dataReferenceName) {
-          try {
-            return await Ajax(signal).Workspaces.workspace(namespace, name).snapshotEntityMetadata(googleProject, modifiedConfig.dataReferenceName)
-          } catch (error) {
-            return undefined
-          }
-        }
-      }
+      const selectedSnapshotEntityMetadata = modifiedConfig.dataReferenceName ?
+        await this.safeGetSnapshotEntityMetadata(googleProject, modifiedConfig) : undefined
 
       this.setState({
         savedConfig: config, modifiedConfig,


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-156

To cause the error:
1. Add a TDR snapshot-by-reference to your workspace
2. Bind a workflow (method config) to that snapshot-by-reference
3. In the Data tab, rename the snapshot-by-reference
4. Attempt to view the workflow.

Before this PR:
![Screenshot (13)](https://user-images.githubusercontent.com/6041577/164787875-a6aa247b-8583-4b49-b837-495df058c05e.png)

After this PR:
![Screenshot (15)](https://user-images.githubusercontent.com/6041577/164788096-5083487c-b48a-4421-a858-a6bb6cce87a9.png)
![Screenshot (14)](https://user-images.githubusercontent.com/6041577/164788117-6d05a2ba-962d-4ca3-98ba-037cbe663c7f.png)

Snapshot-by-references are identified by their reference name, which is editable in the UI. The error happened because there are two ajax calls that return errors if the snapshot-by-reference's name isn't found. This PR adds error-handling around both of those ajax calls, as well as some state manipulation and UI error messaging to the end user.