### PR TITLE
[SU-53] Consolidate billing account management options, per UX

### DIFF
--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -562,7 +562,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
             }, ['Remove Billing Account'])
           ])
         }, [
-          h(Link, { 'aria-label': 'Column menu' }, [
+          h(Link, { 'aria-label': 'Billing account menu' }, [
             icon('cardMenuIcon', { size: 16 })
           ])
         ]),

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -562,7 +562,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
             }, ['Remove Billing Account'])
           ])
         }, [
-          h(Link, { 'aria-label': 'Billing account menu' }, [
+          h(Link, { 'aria-label': 'Billing account menu', style: { display: 'flex', alignItems: 'center' } }, [
             icon('cardMenuIcon', { size: 16 })
           ])
         ]),

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -533,7 +533,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
       div({ style: { color: colors.dark(), fontSize: 14, display: 'flex', alignItems: 'center', marginTop: '0.5rem', marginLeft: '1rem' } }, [
         !!displayName && span({ style: { flexShrink: 0, fontWeight: 600, fontSize: 14, margin: '0 0.75rem 0 0' } }, 'Billing Account:'),
         !!displayName && span({ style: { flexShrink: 0, marginRight: '0.5rem' } }, displayName),
-        h(MenuTrigger, {
+        isOwner && h(MenuTrigger, {
           closeOnClick: true,
           side: 'bottom',
           style: { marginLeft: '0.5rem' },

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -563,7 +563,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
           ])
         }, [
           h(Link, { 'aria-label': 'Billing account menu', style: { display: 'flex', alignItems: 'center' } }, [
-            icon('cardMenuIcon', { size: 16 })
+            icon('cardMenuIcon', { size: 16, 'aria-haspopup': 'menu' })
           ])
         ]),
         showBillingModal && h(Modal, {

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -558,7 +558,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
                 }
               },
               // (CA-1586) For some reason the api sometimes returns string null, and sometimes returns no field, and sometimes returns null. This is just to be complete.
-              disabled: billingProject.billingAccount === 'null' || billingProject.billingAccount === undefined || billingProject.billingAccount === null
+              disabled: billingProject.billingAccount === 'null' || _.isNil(billingProject.billingAccount)
             }, ['Remove Billing Account'])
           ])
         }, [

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -8,6 +8,7 @@ import { DeleteUserModal, EditUserModal, MemberCard, MemberCardHeaders, NewUserC
 import { icon } from 'src/components/icons'
 import { TextInput } from 'src/components/input'
 import Modal from 'src/components/Modal'
+import { MenuButton, MenuTrigger } from 'src/components/PopupTrigger'
 import { SimpleTabBar } from 'src/components/tabBars'
 import { ariaSort } from 'src/components/table'
 import { useWorkspaces } from 'src/components/workspace-utils'
@@ -531,34 +532,40 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
       div({ style: { color: colors.dark(), fontSize: 18, fontWeight: 600, display: 'flex', alignItems: 'center', marginLeft: '1rem' } }, [billingProject.projectName]),
       div({ style: { color: colors.dark(), fontSize: 14, display: 'flex', alignItems: 'center', marginTop: '0.5rem', marginLeft: '1rem' } }, [
         !!displayName && span({ style: { flexShrink: 0, fontWeight: 600, fontSize: 14, margin: '0 0.75rem 0 0' } }, 'Billing Account:'),
-        !!displayName && span({ style: { flexShrink: 0 } }, displayName),
-        isOwner && h(Link, {
-          tooltip: 'Change Billing Account',
+        !!displayName && span({ style: { flexShrink: 0, marginRight: '0.5rem' } }, displayName),
+        h(MenuTrigger, {
+          closeOnClick: true,
+          side: 'bottom',
           style: { marginLeft: '0.5rem' },
-          onClick: async () => {
-            if (Auth.hasBillingScope()) {
-              setShowBillingModal(true)
-            } else {
-              await authorizeAndLoadAccounts()
-              setShowBillingModal(Auth.hasBillingScope())
-            }
-          }
-        }, [icon('edit', { size: 12 })]),
-        isOwner && h(Link, {
-          tooltip: 'Remove Billing Account',
-          style: { marginLeft: '0.5rem' },
-          // (CA-1586) For some reason the api sometimes returns string null, and sometimes returns no field, and sometimes returns null. This is just to be complete.
-          disabled: billingProject.billingAccount === 'null' || billingProject.billingAccount === undefined || billingProject.billingAccount === null,
-          baseColor: colors.danger,
-          onClick: async () => {
-            if (Auth.hasBillingScope()) {
-              setShowBillingRemovalModal(true)
-            } else {
-              await authorizeAndLoadAccounts()
-              setShowBillingRemovalModal(Auth.hasBillingScope())
-            }
-          }
-        }, [icon('times-circle', { size: 12 })]),
+          content: h(Fragment, [
+            h(MenuButton, {
+              onClick: async () => {
+                if (Auth.hasBillingScope()) {
+                  setShowBillingModal(true)
+                } else {
+                  await authorizeAndLoadAccounts()
+                  setShowBillingModal(Auth.hasBillingScope())
+                }
+              }
+            }, ['Change Billing Account']),
+            h(MenuButton, {
+              onClick: async () => {
+                if (Auth.hasBillingScope()) {
+                  setShowBillingRemovalModal(true)
+                } else {
+                  await authorizeAndLoadAccounts()
+                  setShowBillingRemovalModal(Auth.hasBillingScope())
+                }
+              },
+              // (CA-1586) For some reason the api sometimes returns string null, and sometimes returns no field, and sometimes returns null. This is just to be complete.
+              disabled: billingProject.billingAccount === 'null' || billingProject.billingAccount === undefined || billingProject.billingAccount === null
+            }, ['Remove Billing Account'])
+          ])
+        }, [
+          h(Link, { 'aria-label': 'Column menu' }, [
+            icon('cardMenuIcon', { size: 16 })
+          ])
+        ]),
         showBillingModal && h(Modal, {
           title: 'Change Billing Account',
           onDismiss: () => setShowBillingModal(false),


### PR DESCRIPTION
UX has provided a few small tweaks that they'd like us to implement for the billing project page. This is the first one, which consolidates the two icons for changing or removing a billing account into a three-dot dropdown menu.

See [SU-53](https://broadworkbench.atlassian.net/browse/SU-53) comments for additional details.


### Before
<img width="436" alt="Screen Shot 2022-04-25 at 8 35 47 AM" src="https://user-images.githubusercontent.com/7257391/165090071-60044616-4193-4e5a-96c4-15db3c49928b.png">

### After
<img width="441" alt="Screen Shot 2022-04-25 at 8 30 56 AM" src="https://user-images.githubusercontent.com/7257391/165089974-2d39ef52-2146-4c0f-a7e1-5d6bc97e839a.png">

<img width="500" alt="Screen Shot 2022-04-25 at 8 31 01 AM" src="https://user-images.githubusercontent.com/7257391/165089985-df638f84-7f76-4c15-a550-0cce9d41a260.png">


<!--
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Also, so if a screen recording [1] and/or screenshots would be a helpful way to communicate context, please consider including some in your PR description.
Thanks!

[1] https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac
--!>
