### PR TITLE
[WOR-172] Do not show Google-specific items in Cloud Information for Azure Workspace

### DIFF
--- a/integration-tests/jest/workspace-dashboard.integration-test.js
+++ b/integration-tests/jest/workspace-dashboard.integration-test.js
@@ -3,4 +3,4 @@ const { googleWorkspaceDashboard, azureWorkspaceDashboard } = require('../tests/
 
 
 registerTest(googleWorkspaceDashboard)
-//registerTest(azureWorkspaceDashboard)
+registerTest(azureWorkspaceDashboard)

--- a/integration-tests/jest/workspace-dashboard.integration-test.js
+++ b/integration-tests/jest/workspace-dashboard.integration-test.js
@@ -3,4 +3,4 @@ const { googleWorkspaceDashboard, azureWorkspaceDashboard } = require('../tests/
 
 
 registerTest(googleWorkspaceDashboard)
-registerTest(azureWorkspaceDashboard)
+//registerTest(azureWorkspaceDashboard)

--- a/integration-tests/tests/workspace-dashboard.js
+++ b/integration-tests/tests/workspace-dashboard.js
@@ -13,10 +13,11 @@ const testGoogleWorkspace = _.flow(
   await viewWorkspaceDashboard(page, token, workspaceName)
   await findText(page, 'About the workspace')
 
-  // Check cloud information
+  // Check selected items in cloud information
+  const currentDate = new Date().toLocaleDateString()
   await click(page, clickable({ text: 'Cloud information' }))
   await findText(page, 'Cloud NameGoogle Cloud Platform')
-  await findText(page, 'Cloud Project ID')
+  await findText(page, `Bucket SizeUpdated on ${currentDate}0 B`)
 
   // Click on each of the expected tabs
   await clickNavChildAndLoad(page, 'data')

--- a/integration-tests/tests/workspace-dashboard.js
+++ b/integration-tests/tests/workspace-dashboard.js
@@ -1,7 +1,7 @@
 // This test is owned by the Workspaces Team.
 const _ = require('lodash/fp')
 const { clickNavChildAndLoad, viewWorkspaceDashboard, withWorkspace } = require('../utils/integration-helpers')
-const { assertNavChildNotFound, findText } = require('../utils/integration-utils')
+const { assertNavChildNotFound, click, clickable, findText } = require('../utils/integration-utils')
 const { withUserToken } = require('../utils/terra-sa-utils')
 
 
@@ -12,6 +12,12 @@ const testGoogleWorkspace = _.flow(
   await page.goto(testUrl)
   await viewWorkspaceDashboard(page, token, workspaceName)
   await findText(page, 'About the workspace')
+
+  // Check cloud information
+  await click(page, clickable({ text: 'Cloud information' }))
+  await findText(page, 'Cloud NameGoogle Cloud Platform')
+  await findText(page, 'Cloud Project ID')
+
   // Click on each of the expected tabs
   await clickNavChildAndLoad(page, 'data')
   await clickNavChildAndLoad(page, 'notebooks')
@@ -101,6 +107,12 @@ const testAzureWorkspace = withUserToken(async ({ page, token, testUrl }) => {
 
   await viewWorkspaceDashboard(page, token, workspaceName)
   await findText(page, workspaceDescription)
+
+  // Check cloud information
+  await click(page, clickable({ text: 'Cloud information' }))
+  await findText(page, 'Cloud NameMicrosoft Azure')
+  await findText(page, 'Resource Group IDdummy-mrg-id')
+
   // Verify tabs that currently depend on Google project ID are not present.
   await assertNavChildNotFound(page, 'data')
   await assertNavChildNotFound(page, 'notebooks')

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -271,7 +271,7 @@ const WorkspaceDashboard = _.flow(
     return !googleProject && !azureContext ? [] : [
       dl({},
         !!googleProject ? [
-          googleProject && h(InfoRow, { title: 'Cloud Name' }, [
+          h(InfoRow, { title: 'Cloud Name' }, [
             h(GcpLogo, { title: 'Google Cloud Platform', role: 'img', style: { height: 16 } })
           ]),
           h(InfoRow, { title: 'Location' }, [bucketLocation ? h(Fragment, [

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -291,7 +291,7 @@ const WorkspaceDashboard = _.flow(
           }, [storageCost?.estimate || '$ ...']),
           Utils.canWrite(accessLevel) && h(InfoRow, {
             title: 'Bucket Size',
-            subtitle: !!bucketSize ? `Updated on ${new Date(bucketSize.updated).toLocaleDateString()}` : 'Loading last updated...'
+            subtitle: !!bucketSize ? `Updated on ${new Date(bucketSize.lastUpdated).toLocaleDateString()}` : 'Loading last updated...'
           }, [bucketSize?.usage])
         ] : [
           h(InfoRow, { title: 'Cloud Name' }, [

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -269,40 +269,38 @@ const WorkspaceDashboard = _.flow(
 
   const getCloudInformation = () => {
     return !googleProject && !azureContext ? [] : [
-      dl({},
-        !!googleProject ? [
-          h(InfoRow, { title: 'Cloud Name' }, [
-            h(GcpLogo, { title: 'Google Cloud Platform', role: 'img', style: { height: 16 } })
-          ]),
-          h(InfoRow, { title: 'Location' }, [bucketLocation ? h(Fragment, [
-            h(TooltipCell, [flag, ' ', regionDescription])
-          ]) : 'Loading...']),
-          h(InfoRow, { title: 'Google Project ID' }, [
-            h(TooltipCell, [googleProject]),
-            h(ClipboardButton, { 'aria-label': 'Copy google project id to clipboard', text: googleProject, style: { marginLeft: '0.25rem' } })
-          ]),
-          h(InfoRow, { title: 'Bucket Name' }, [
-            h(TooltipCell, [bucketName]),
-            h(ClipboardButton, { 'aria-label': 'Copy bucket name to clipboard', text: bucketName, style: { marginLeft: '0.25rem' } })
-          ]),
-          Utils.canWrite(accessLevel) && h(InfoRow, {
-            title: 'Estimated Storage Cost',
-            subtitle: !!storageCost ? `Updated on ${new Date(storageCost.lastUpdated).toLocaleDateString()}` : 'Loading last updated...'
-          }, [storageCost?.estimate || '$ ...']),
-          Utils.canWrite(accessLevel) && h(InfoRow, {
-            title: 'Bucket Size',
-            subtitle: !!bucketSize ? `Updated on ${new Date(bucketSize.lastUpdated).toLocaleDateString()}` : 'Loading last updated...'
-          }, [bucketSize?.usage])
-        ] : [
-          h(InfoRow, { title: 'Cloud Name' }, [
-            h(AzureLogo, { title: 'Microsoft Azure', role: 'img', style: { height: 16 } })
-          ]),
-          h(InfoRow, { title: 'Resource Group ID' }, [
-            h(TooltipCell, [azureContext.managedResourceGroupId]),
-            h(ClipboardButton, { 'aria-label': 'Copy resource group id to clipboard', text: azureContext.managedResourceGroupId, style: { marginLeft: '0.25rem' } })
-          ])
-        ]
-      ),
+      dl(!!googleProject ? [
+        h(InfoRow, { title: 'Cloud Name' }, [
+          h(GcpLogo, { title: 'Google Cloud Platform', role: 'img', style: { height: 16 } })
+        ]),
+        h(InfoRow, { title: 'Location' }, [bucketLocation ? h(Fragment, [
+          h(TooltipCell, [flag, ' ', regionDescription])
+        ]) : 'Loading...']),
+        h(InfoRow, { title: 'Google Project ID' }, [
+          h(TooltipCell, [googleProject]),
+          h(ClipboardButton, { 'aria-label': 'Copy google project id to clipboard', text: googleProject, style: { marginLeft: '0.25rem' } })
+        ]),
+        h(InfoRow, { title: 'Bucket Name' }, [
+          h(TooltipCell, [bucketName]),
+          h(ClipboardButton, { 'aria-label': 'Copy bucket name to clipboard', text: bucketName, style: { marginLeft: '0.25rem' } })
+        ]),
+        Utils.canWrite(accessLevel) && h(InfoRow, {
+          title: 'Estimated Storage Cost',
+          subtitle: !!storageCost ? `Updated on ${new Date(storageCost.lastUpdated).toLocaleDateString()}` : 'Loading last updated...'
+        }, [storageCost?.estimate || '$ ...']),
+        Utils.canWrite(accessLevel) && h(InfoRow, {
+          title: 'Bucket Size',
+          subtitle: !!bucketSize ? `Updated on ${new Date(bucketSize.lastUpdated).toLocaleDateString()}` : 'Loading last updated...'
+        }, [bucketSize?.usage])
+      ] : [
+        h(InfoRow, { title: 'Cloud Name' }, [
+          h(AzureLogo, { title: 'Microsoft Azure', role: 'img', style: { height: 16 } })
+        ]),
+        h(InfoRow, { title: 'Resource Group ID' }, [
+          h(TooltipCell, [azureContext.managedResourceGroupId]),
+          h(ClipboardButton, { 'aria-label': 'Copy resource group id to clipboard', text: azureContext.managedResourceGroupId, style: { marginLeft: '0.25rem' } })
+        ])
+      ]),
       !!googleProject && div({ style: { paddingBottom: '0.5rem' } }, [h(Link, {
         style: { margin: '1rem 0.5rem' },
         ...Utils.newTabLinkProps,


### PR DESCRIPTION
This updates the "Cloud Information" section of the Workspace Dashboard to show Azure vs. GCP information. There should be no user-visible difference for Google workspaces.

Azure workspace:

![image](https://user-images.githubusercontent.com/484484/165171926-32c5237c-ff80-4435-9661-d37c1776a292.png)

Google workspace:

![image](https://user-images.githubusercontent.com/484484/165172035-10bcf1a2-4da2-4665-8d4b-6762a4746cb9.png)

Note that creating an Azure workspace currently requires you to run Rawls locally (and then you use a curl command). I have some Azure workspaces in dev that I created in this manner, but it is not practical for a reviewer to create one.
