### PR TITLE
[SU-79] Disable Clear Column and Delete Column buttons when workspace is read-only/locked

### DIFF
--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -326,8 +326,8 @@ const DataTable = props => {
                         extraActions: [
                           // settimeout 0 is needed to delay opening the modaals until after the popup menu closes.
                           // Without this, autofocus doesn't work in the modals.
-                          { label: 'Delete Column', disabled: noEdit, tooltip: noEdit ? 'You don\'t have permission to modify this workspace.' : '', onClick: () => setTimeout(() => setDeletingColumn(attributeName), 0) },
-                          { label: 'Clear Column', disabled: noEdit, tooltip: noEdit ? 'You don\'t have permission to modify this workspace.' : '', onClick: () => setTimeout(() => setClearingColumn(attributeName), 0) }
+                          { label: 'Delete Column', disabled: !!noEdit, tooltip: noEdit || '', onClick: () => setTimeout(() => setDeletingColumn(attributeName), 0) },
+                          { label: 'Clear Column', disabled: !!noEdit, tooltip: noEdit || '', onClick: () => setTimeout(() => setClearingColumn(attributeName), 0) }
                         ]
                       }, [
                         h(HeaderCell, [

--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -101,6 +101,8 @@ const DataTable = props => {
   const [deletingColumn, setDeletingColumn] = useState()
   const [clearingColumn, setClearingColumn] = useState()
 
+  const noEdit = Utils.editWorkspaceError(workspace)
+
   const table = useRef()
   const signal = useCancellation()
 
@@ -324,8 +326,8 @@ const DataTable = props => {
                         extraActions: [
                           // settimeout 0 is needed to delay opening the modaals until after the popup menu closes.
                           // Without this, autofocus doesn't work in the modals.
-                          { label: 'Delete Column', disabled: true, onClick: () => setTimeout(() => setDeletingColumn(attributeName), 0) },
-                          { label: 'Clear Column', disabled: true, onClick: () => setTimeout(() => setClearingColumn(attributeName), 0) }
+                          { label: 'Delete Column', disabled: noEdit, tooltip: noEdit ? 'You don\'t have permission to modify this workspace.' : '', onClick: () => setTimeout(() => setDeletingColumn(attributeName), 0) },
+                          { label: 'Clear Column', disabled: noEdit, tooltip: noEdit ? 'You don\'t have permission to modify this workspace.' : '', onClick: () => setTimeout(() => setClearingColumn(attributeName), 0) }
                         ]
                       }, [
                         h(HeaderCell, [

--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -324,8 +324,8 @@ const DataTable = props => {
                         extraActions: [
                           // settimeout 0 is needed to delay opening the modaals until after the popup menu closes.
                           // Without this, autofocus doesn't work in the modals.
-                          { label: 'Delete Column', onClick: () => setTimeout(() => setDeletingColumn(attributeName), 0) },
-                          { label: 'Clear Column', onClick: () => setTimeout(() => setClearingColumn(attributeName), 0) }
+                          { label: 'Delete Column', disabled: true, onClick: () => setTimeout(() => setDeletingColumn(attributeName), 0) },
+                          { label: 'Clear Column', disabled: true, onClick: () => setTimeout(() => setClearingColumn(attributeName), 0) }
                         ]
                       }, [
                         h(HeaderCell, [

--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -348,7 +348,7 @@ const EntitiesContent = ({
           disabled: noEdit,
           tooltip: noEdit ? 'You don\'t have permission to modify this workspace.' : 'Edit an attribute of the selected rows',
           onClick: () => setEditingEntities(true)
-        }, ['Edit Attributez']),
+        }, ['Edit Attribute']),
         !snapshotName && h(MenuButton, {
           tooltip: 'Open the selected data to work with it',
           onClick: () => setShowToolSelector(true)

--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -348,7 +348,7 @@ const EntitiesContent = ({
           disabled: noEdit,
           tooltip: noEdit ? 'You don\'t have permission to modify this workspace.' : 'Edit an attribute of the selected rows',
           onClick: () => setEditingEntities(true)
-        }, ['Edit Attribute']),
+        }, ['Edit Attributez']),
         !snapshotName && h(MenuButton, {
           tooltip: 'Open the selected data to work with it',
           onClick: () => setShowToolSelector(true)

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -1066,7 +1066,7 @@ export const HeaderOptions = ({ sort, field, onSort, extraActions, children }) =
       content: h(Fragment, [
         h(MenuButton, { onClick: () => onSort({ field, direction: 'asc' }) }, ['Sort Ascending']),
         h(MenuButton, { onClick: () => onSort({ field, direction: 'desc' }) }, ['Sort Descending']),
-        _.map(({ label, disabled, onClick }) => h(MenuButton, { key: label, disabled, onClick }, [label]), extraActions)
+        _.map(({ label, disabled, tooltip, onClick }) => h(MenuButton, { key: label, disabled, tooltip, onClick }, [label]), extraActions)
       ])
     }, [
       h(Link, { 'aria-label': 'Column menu' }, [

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -1066,7 +1066,7 @@ export const HeaderOptions = ({ sort, field, onSort, extraActions, children }) =
       content: h(Fragment, [
         h(MenuButton, { onClick: () => onSort({ field, direction: 'asc' }) }, ['Sort Ascending']),
         h(MenuButton, { onClick: () => onSort({ field, direction: 'desc' }) }, ['Sort Descending']),
-        _.map(({ label, onClick }) => h(MenuButton, { key: label, onClick }, [label]), extraActions)
+        _.map(({ label, disabled, onClick }) => h(MenuButton, { key: label, disabled, onClick }, [label]), extraActions)
       ])
     }, [
       h(Link, { 'aria-label': 'Column menu' }, [


### PR DESCRIPTION
These options did not take into account the locked status of the workspace or the user's access level.

**Before**
<img width="472" alt="Screen Shot 2022-04-26 at 3 03 57 PM" src="https://user-images.githubusercontent.com/7257391/165373878-3b956a99-4366-4397-a763-04277ad26b6f.png">


**After**
<img width="456" alt="Screen Shot 2022-04-26 at 3 03 31 PM" src="https://user-images.githubusercontent.com/7257391/165373887-8d31f1b4-f206-4853-9817-a92c69f01add.png">
<img width="539" alt="Screen Shot 2022-04-26 at 3 03 41 PM" src="https://user-images.githubusercontent.com/7257391/165373894-84583259-a287-43f4-9d88-d35ce88fcc74.png">



<!--
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Also, so if a screen recording [1] and/or screenshots would be a helpful way to communicate context, please consider including some in your PR description.
Thanks!

[1] https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac
--!>
