### PR TITLE
[QA-1840] Create individual test log file that contains all console logs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,6 +127,9 @@ commands:
       env:
         type: string
         default: local
+      log_dir:
+        type: string
+        default: "/tmp"
     steps:
       - checkout
       - attach_workspace:
@@ -148,8 +151,9 @@ commands:
       - run:
           working_directory: integration-tests
           environment:
-            JEST_JUNIT_OUTPUT_DIR: "/tmp/test-results/integration-test-results.xml"
-            SCREENSHOT_DIR: "/tmp/failure-screenshots"
+            LOG_DIR: "<< parameters.log_dir >>/<< parameters.env >>/test-results"
+            JEST_JUNIT_OUTPUT_DIR: "<< parameters.log_dir >>/<< parameters.env >>/test-results/junit"
+            SCREENSHOT_DIR: "<< parameters.log_dir >>/<< parameters.env >>/test-results/failure-screenshots"
             ENVIRONMENT: << parameters.env >>
           no_output_timeout: 16m
           command: |
@@ -157,9 +161,10 @@ commands:
             TESTS_TO_RUN=$(circleci tests glob "jest/**.integration-test.js" | circleci tests split --split-by=timings)
             yarn test $TESTS_TO_RUN --maxWorkers=2
       - store_test_results:
-          path: /tmp/test-results
+          path: << parameters.log_dir >>/<< parameters.env >>/test-results/junit
       - store_artifacts:
-          path: /tmp/failure-screenshots
+          path: << parameters.log_dir >>/<< parameters.env >>/test-results
+          destination: results
   notify-qa:
     parameters:
       channel:

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ saturn-ui.iml
 /integration-tests/failures
 /integration-tests/results
 /integration-tests/screenshots
+/integration-tests/junit.xml
 
 .yarn/*
 !.yarn/cache

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -17,29 +17,29 @@ TERRA_SA_KEY=[full key json] LYLE_SA_KEY=[full key json] yarn test
 The following environment variables are parsed by the tests:
 
 - Service account credentials **(required)**:
-    - Both of:
-        - `TERRA_SA_KEY`: service account key for creating access tokens for test user.  
-            Can be found in vault at `secret/dsde/alpha/common/firecloud-account.pem`
-        - `LYLE_SA_KEY`: service account key to access Lyle.  
-            Can be found in vault at `secret/dsde/terra/envs/common/lyle-user-service-account-key`
-    - Or both of:
-        - `GCP_PROJECT`: GCP project containing the above secrets in Secret Manager, i.e. `terra-bueller`
-        - `GOOGLE_APPLICATION_CREDENTIALS`: key file for Google App Engine default service account for `GCP_PROJECT`
-- `ENVIRONMENT`: Terra UI instance to test.  
-    Options: `local`, `dev`, `alpha`, `perf`, `staging`
-    * _Default `local`_, which sets:
-        - `BILLING_PROJECT`: used for workspace creation.
-            * _Default `saturn-integration-test-dev`_
-        - `TEST_URL`: URL for the ui.
-            * _Default `localhost:3000`_
-        - `WORKFLOW_NAME`: workflow/method used for tests.  
-           Expects published config named `[name]-configured`.
-            * _Default `echo_to_file`_
+  - Both of:
+    - `TERRA_SA_KEY`: service account key for creating access tokens for test user. Can be found in vault
+      at `secret/dsde/alpha/common/firecloud-account.pem`
+    - `LYLE_SA_KEY`: service account key to access Lyle. Can be found in vault
+      at `secret/dsde/terra/envs/common/lyle-user-service-account-key`
+  - Or both of:
+    - `GCP_PROJECT`: GCP project containing the above secrets in Secret Manager, i.e. `terra-bueller`
+    - `GOOGLE_APPLICATION_CREDENTIALS`: key file for Google App Engine default service account for `GCP_PROJECT`
+- `ENVIRONMENT`: Terra UI instance to test. Options: `local`, `dev`, `alpha`, `perf`, `staging`
+  * _Default `local`_, which sets:
+    - `BILLING_PROJECT`: used for workspace creation.
+      * _Default `saturn-integration-test-dev`_
+    - `TEST_URL`: URL for the ui.
+      * _Default `localhost:3000`_
+    - `WORKFLOW_NAME`: workflow/method used for tests. Expects published config named `[name]-configured`.
+      * _Default `echo_to_file`_
 - `LYLE_URL`: URL for the service account allocator.
-    * _Default `https://terra-lyle.appspot.com`_
+  * _Default `https://terra-lyle.appspot.com`_
 - `SCREENSHOT_DIR`: without this, screenshots won't be saved on test failure.
+- `LOG_DIR`: Directory where to save test logs.
+  * _Default_ `/tmp/test-results`
 - `TERRA_USER_EMAIL`: account that already has access to `BILLING_PROJECT`
-    * _Default `Scarlett.Flowerpicker@test.firecloud.org`_
+  * _Default `Scarlett.Flowerpicker@test.firecloud.org`_
 
 #### Convenient one-liner:
 
@@ -75,20 +75,24 @@ LYLE_SA_KEY=$(vault read --format=json secret/dsde/terra/envs/common/lyle-user-s
 node --inspect-brk node_modules/.bin/jest [test name] --runInBand
 ```
 
-Using your IDE you can connect to the debug port and set breakpoints. More info [here](https://jestjs.io/docs/en/troubleshooting).
+Using your IDE you can connect to the debug port and set breakpoints. More
+info [here](https://jestjs.io/docs/en/troubleshooting).
 
 #### Detecting Flakiness
-You can run: 
+
+You can run:
+
 ```
 yarn test-flakes [test name]
 ```
+
 By default this will run your test 100 times and display the stack trace of every failure encountered.
 
 You can tweak this with the following settings:
 
 Setting | Default | Description
 --------|-------:|------------|
-RUNS | 100 | The number of test runs you want to execute (Default: 100) 
+RUNS | 100 | The number of test runs you want to execute (Default: 100)
 CONCURRENCY | 10 | The size of the browser pool / the number of simultaneous tests to run. 25 seems to be the upper limit for a mac with an M1 max chip
 CLUSTER_TIMEOUT_MINUTES | 120 | The number of minutes before the overall test times out. 120 is overkill. If you want to run hundreds of iterations, it is best to overestimate this value
 ### Creating a new environment (e.g., dev, alpha, etc)

--- a/integration-tests/jest-reporter.js
+++ b/integration-tests/jest-reporter.js
@@ -28,8 +28,7 @@ module.exports = class JestReporter {
       console.error(err)
       throw err
     }
-
-
+    
     const writableStream = createWriteStream(logFileName)
     writableStream.on('error', ({ message }) => console.error(`Error occurred while writing Console logs to ${logFileName}.\n${message}`))
 

--- a/integration-tests/jest-reporter.js
+++ b/integration-tests/jest-reporter.js
@@ -10,7 +10,7 @@ module.exports = class JestReporter {
 
   onTestStart(test) {
     const { path } = test
-    console.info(`\n**  Running ${parse(path).name} at ${this.timeNow()}\n`)
+    console.info(`**  Running ${parse(path).name} at ${this.timeNow()}`)
   }
 
   onTestResult(_testRunConfig, testResult, _runResults) {
@@ -22,9 +22,7 @@ module.exports = class JestReporter {
     !existsSync(logDir) && mkdirSync(logDir, { recursive: true })
 
     const writableStream = createWriteStream(logFileName)
-    writableStream.on('error', ({ message }) => {
-      console.error(`Error occurred while writing Console logs to ${logFileName}.\n${message}`)
-    })
+    writableStream.on('error', ({ message }) => console.error(`Error occurred while writing Console logs to ${logFileName}.\n${message}`))
 
     _.forEach(({ message }) => writableStream.write(`${message}\n`), testResult.console)
 
@@ -40,9 +38,7 @@ module.exports = class JestReporter {
     }, testResults)
 
     writableStream.end()
-    writableStream.on('finish', () => {
-      console.log(`Finished writing logs to ${logFileName}`)
-    })
+    writableStream.on('finish', () => console.log(`Finished writing logs to ${logFileName}`))
   }
 
   timeNow() {

--- a/integration-tests/jest-reporter.js
+++ b/integration-tests/jest-reporter.js
@@ -1,6 +1,6 @@
 const _ = require('lodash/fp')
 const { parse } = require('path')
-const { createWriteStream, existsSync, mkdirSync } = require('fs')
+const { createWriteStream, mkdirSync } = require('fs')
 
 
 module.exports = class JestReporter {
@@ -28,7 +28,7 @@ module.exports = class JestReporter {
       console.error(err)
       throw err
     }
-    
+
     const writableStream = createWriteStream(logFileName)
     writableStream.on('error', ({ message }) => console.error(`Error occurred while writing Console logs to ${logFileName}.\n${message}`))
 

--- a/integration-tests/jest-reporter.js
+++ b/integration-tests/jest-reporter.js
@@ -25,7 +25,7 @@ module.exports = class JestReporter {
     try {
       mkdirSync(logDir, { recursive: true })
     } catch (err) {
-      console.error(e)
+      console.error(err)
       throw err
     }
 

--- a/integration-tests/jest-reporter.js
+++ b/integration-tests/jest-reporter.js
@@ -19,7 +19,16 @@ module.exports = class JestReporter {
     const hasFailure = _.some(({ status }) => status === 'failed', testResults)
     const logDir = `${this.logRootDir}/${hasFailure ? 'failures' : 'successes'}`
     const logFileName = `${logDir}/${testName}-${Date.now()}.log`
-    !existsSync(logDir) && mkdirSync(logDir, { recursive: true })
+
+    // Since Node 10, mkdirSync knows to not do anything if the dir exists (https://stackoverflow.com/a/71767385/2851999) so not checking explicitly
+    // We may want to specify what to do if an error occurs. Not sure if throwing is what we'd want.
+    try {
+      mkdirSync(logDir, { recursive: true })
+    } catch (err) {
+      console.error(e)
+      throw err
+    }
+
 
     const writableStream = createWriteStream(logFileName)
     writableStream.on('error', ({ message }) => console.error(`Error occurred while writing Console logs to ${logFileName}.\n${message}`))

--- a/integration-tests/jest-reporter.js
+++ b/integration-tests/jest-reporter.js
@@ -1,0 +1,54 @@
+const _ = require('lodash/fp')
+const { parse } = require('path')
+const { createWriteStream, existsSync, mkdirSync } = require('fs')
+
+
+module.exports = class JestReporter {
+  constructor(_globalConfig, _options) {
+    this.logRootDir = process.env.LOG_DIR || '/tmp/test-results'
+  }
+
+  onTestStart(test) {
+    const { path } = test
+    console.info(`\n**  Running ${parse(path).name} at ${this.timeNow()}\n`)
+  }
+
+  onTestResult(_testRunConfig, testResult, _runResults) {
+    const { testFilePath, testResults } = testResult
+    const { name: testName } = parse(testFilePath)
+    const hasFailure = _.some(({ status }) => status === 'failed', testResults)
+    const logDir = `${this.logRootDir}/${hasFailure ? 'failures' : 'successes'}`
+    const logFileName = `${logDir}/${testName}-${Date.now()}.log`
+    !existsSync(logDir) && mkdirSync(logDir, { recursive: true })
+
+    const writableStream = createWriteStream(logFileName)
+    writableStream.on('error', ({ message }) => {
+      console.error(`Error occurred while writing Console logs to ${logFileName}.\n${message}`)
+    })
+
+    _.forEach(({ message }) => writableStream.write(`${message}\n`), testResult.console)
+
+    // Write pass/failure summaries
+    writableStream.write('\n\nTests Summary\n')
+    _.forEach(result => {
+      writableStream.write('----------------------------------------------\n')
+      writableStream.write(`Test: ${result.title}\n`)
+      writableStream.write(`Status: ${result.status}\n`)
+      const { failureMessages = [] } = result
+      !_.isEmpty(failureMessages) && writableStream.write(`Failure message: ${failureMessages}\n`)
+      writableStream.write('\n')
+    }, testResults)
+
+    writableStream.end()
+    writableStream.on('finish', () => {
+      console.log(`Finished writing logs to ${logFileName}`)
+    })
+  }
+
+  timeNow() {
+    return new Date().toLocaleString('en-US', {
+      timeZone: 'America/New_York',
+      hour12: false
+    })
+  }
+}

--- a/integration-tests/jest.config.js
+++ b/integration-tests/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
   testRegex: '\\.integration-test\\.js$',
   reporters: [
     'default',
+    '<rootDir>/jest-reporter.js',
     [
       'jest-junit',
       {

--- a/integration-tests/tests/janitor.js
+++ b/integration-tests/tests/janitor.js
@@ -1,5 +1,4 @@
 // This test is owned by the Workspaces Team.
-const rawConsole = require('console')
 const dateFns = require('date-fns/fp')
 const _ = require('lodash/fp')
 const { testWorkspaceNamePrefix } = require('../utils/integration-helpers')
@@ -19,18 +18,18 @@ const runJanitor = withUserToken(async ({ billingProject, page, testUrl, token }
   const workspaces = await page.evaluate(async () => await window.Ajax().Workspaces.list())
   const oldWorkspaces = _.filter(({ workspace: { namespace, name, createdDate } }) => {
     const age = dateFns.differenceInDays(new Date(createdDate), new Date())
-    // rawConsole.info(`${namespace} ${name}, age ${age} days`)
+    // console.info(`${namespace} ${name}, age ${age} days`)
     return namespace === billingProject && _.startsWith(testWorkspaceNamePrefix, name) && age > olderThanDays
   }, workspaces)
 
-  rawConsole.log(`Deleting ${oldWorkspaces.length} workspaces with prefix "${testWorkspaceNamePrefix}" created more than ${olderThanDays} days ago.`)
+  console.log(`Deleting ${oldWorkspaces.length} workspaces with prefix "${testWorkspaceNamePrefix}" created more than ${olderThanDays} days ago.`)
 
   return Promise.all(_.map(async ({ workspace: { namespace, name } }) => {
     try {
       await page.evaluate((namespace, name) => window.Ajax().Workspaces.workspace(namespace, name).delete(), namespace, name)
-      rawConsole.info(`Deleted old workspace: ${name}`)
+      console.info(`Deleted old workspace: ${name}`)
     } catch (e) {
-      rawConsole.info(`Failed to delete old workspace: ${name} with billing project ${namespace}`)
+      console.info(`Failed to delete old workspace: ${name} with billing project ${namespace}`)
     }
   }, oldWorkspaces))
 })

--- a/integration-tests/tests/run-workflow.js
+++ b/integration-tests/tests/run-workflow.js
@@ -1,4 +1,3 @@
-const rawConsole = require('console')
 const _ = require('lodash/fp')
 const pRetry = require('p-retry')
 const { checkBucketAccess, withWorkspace, createEntityInWorkspace } = require('../utils/integration-helpers')
@@ -65,9 +64,9 @@ const launchWorkflowAndWaitForSuccess = async page => {
     } catch (e) {
       try {
         await findInGrid(page, 'Running', { timeout: 1000 })
-        rawConsole.info(`Workflow is running, elapsed time (minutes): ${(Date.now() - start) / (1000 * 60)}`)
+        console.info(`Workflow is running, elapsed time (minutes): ${(Date.now() - start) / (1000 * 60)}`)
       } catch (e) {
-        rawConsole.info(`Workflow not yet running, elapsed time (minutes): ${(Date.now() - start) / (1000 * 60)}`)
+        console.info(`Workflow not yet running, elapsed time (minutes): ${(Date.now() - start) / (1000 * 60)}`)
       }
       throw new Error(e)
     }

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -1,4 +1,3 @@
-const rawConsole = require('console')
 const _ = require('lodash/fp')
 const uuid = require('uuid')
 
@@ -35,7 +34,7 @@ const makeWorkspace = withSignedInPage(async ({ page, billingProject }) => {
       return window.Ajax().Workspaces.create({ namespace: billingProject, name, attributes: {} })
     }, workspaceName, billingProject)
 
-    rawConsole.info(`Created workspace: ${workspaceName}`)
+    console.info(`Created workspace: ${workspaceName}`)
   } catch (e) {
     throw Error(`Failed to create workspace: ${workspaceName} with billing project ${billingProject}`)
   }
@@ -48,7 +47,7 @@ const deleteWorkspace = withSignedInPage(async ({ page, billingProject, workspac
       return window.Ajax().Workspaces.workspace(billingProject, name).delete()
     }, workspaceName, billingProject)
 
-    rawConsole.info(`Deleted workspace: ${workspaceName}`)
+    console.info(`Deleted workspace: ${workspaceName}`)
   } catch (e) {
     throw Error(`Failed to delete workspace: ${workspaceName} with billing project ${billingProject}`)
   }
@@ -75,7 +74,7 @@ const checkBucketAccess = async (page, billingProject, workspaceName, accessLeve
     return window.Ajax().Workspaces.workspace(billingProject, workspaceName).details()
   }, billingProject, workspaceName)
   const bucketName = details.workspace.bucketName
-  rawConsole.info(`Checking workspace access for ${billingProject}, ${workspaceName}, ${bucketName}.`)
+  console.info(`Checking workspace access for ${billingProject}, ${workspaceName}, ${bucketName}.`)
   // Try polling for workspace bucket access to be available.
   await page.waitForFunction(async (billingProject, workspaceName, bucketName, accessLevel) => {
     try {
@@ -88,7 +87,7 @@ const checkBucketAccess = async (page, billingProject, workspaceName, accessLeve
 const makeUser = async () => {
   const { email } = await fetchLyle('create')
   const { accessToken: token } = await fetchLyle('token', email)
-  rawConsole.info(`created a user with token: ...${clipToken(token)}`)
+  console.info(`created a user "${email}" with token: ...${clipToken(token)}`)
   return { email, token }
 }
 
@@ -107,7 +106,7 @@ const addUserToBilling = _.flow(withSignedInPage, withUserToken)(async ({ page, 
     return window.Ajax().Billing.addProjectUser(billingProject, ['User'], email)
   }, email, billingProject)
 
-  rawConsole.info(`added user to: ${billingProject}`)
+  console.info(`added user to: ${billingProject}`)
 
   const userList = await page.evaluate(billingProject => {
     return window.Ajax().Billing.listProjectUsers(billingProject)
@@ -115,7 +114,7 @@ const addUserToBilling = _.flow(withSignedInPage, withUserToken)(async ({ page, 
 
   const billingUser = _.find({ email }, userList)
 
-  rawConsole.info(`test user was added to the billing project with the role: ${!!billingUser && billingUser.role}`)
+  console.info(`test user was added to the billing project with the role: ${!!billingUser && billingUser.role}`)
 })
 
 const removeUserFromBilling = _.flow(withSignedInPage, withUserToken)(async ({ page, billingProject, email }) => {
@@ -123,7 +122,7 @@ const removeUserFromBilling = _.flow(withSignedInPage, withUserToken)(async ({ p
     return window.Ajax().Billing.removeProjectUser(billingProject, ['User'], email)
   }, email, billingProject)
 
-  rawConsole.info(`removed user from: ${billingProject}`)
+  console.info(`removed user from: ${billingProject}`)
 })
 
 const withBilling = test => async options => {
@@ -145,12 +144,12 @@ const deleteRuntimes = _.flow(withSignedInPage, withUserToken)(async ({ page, bi
       return runtime.runtimeName
     }, _.remove({ status: 'Deleting' }, runtimes)))
   }, billingProject, email)
-  rawConsole.info(`deleted runtimes: ${deletedRuntimes}`)
+  console.info(`deleted runtimes: ${deletedRuntimes}`)
 })
 
 const registerUser = withSignedInPage(async ({ page, token }) => {
   // TODO: make this available to all puppeteer browser windows
-  rawConsole.info(`token of user in registerUser(): ...${clipToken(token)}`)
+  console.info(`token of user in registerUser(): ...${clipToken(token)}`)
   await page.evaluate(() => {
     window.catchErrorResponse = async fn => {
       try {


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/QA-1840

Improve terra-ui integration test logging, to make test failure investigation just a bit easier.
Create individual test log file when test has finished (passed or failed). Log files are viewable in the ARTIFACTS tab in CircleCI. Or in env `LOG_DIR` if running tests locally.


<img width="691" alt="Screen Shot 2022-04-29 at 3 37 27 PM" src="https://user-images.githubusercontent.com/35533885/166058477-c6aee057-9bd6-46f5-9435-1b248f48aebc.png">

