### PR TITLE
[QA-1837] Move jest-junit config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,7 +155,7 @@ commands:
           command: |
             mkdir -p ${SCREENSHOT_DIR}
             TESTS_TO_RUN=$(circleci tests glob "jest/**.integration-test.js" | circleci tests split --split-by=timings)
-            yarn test $TESTS_TO_RUN --maxWorkers=2 --reporters=default --reporters=jest-junit
+            yarn test $TESTS_TO_RUN --maxWorkers=2
       - store_test_results:
           path: /tmp/test-results
       - store_artifacts:

--- a/integration-tests/jest.config.js
+++ b/integration-tests/jest.config.js
@@ -8,7 +8,7 @@ module.exports = {
       'jest-junit',
       {
         suiteName: 'Integration tests',
-        addFileAttribute: true,
+        addFileAttribute: 'true',
         includeConsoleOutput: true
       }
     ]

--- a/integration-tests/jest.config.js
+++ b/integration-tests/jest.config.js
@@ -1,4 +1,16 @@
 module.exports = {
+  verbose: false,
   preset: 'jest-puppeteer',
-  testRegex: '\\.integration-test\\.js$'
+  testRegex: '\\.integration-test\\.js$',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        suiteName: 'Integration tests',
+        addFileAttribute: true,
+        includeConsoleOutput: true
+      }
+    ]
+  ]
 }

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -17,11 +17,6 @@
     "prompts": "^2.4.1",
     "puppeteer-cluster": "^0.23.0"
   },
-  "jest-junit": {
-    "suiteName": "Integration tests",
-    "addFileAttribute": "true",
-    "includeConsoleOutput": true
-  },
   "dependencies": {
     "@google-cloud/firestore": "^4.15.1",
     "@google-cloud/secret-manager": "^3.10.1",


### PR DESCRIPTION
Jest's configuration are defined in the `package.json` file and `jest.config.js` file. Either file is fine but I feel it's wrong to be in  both files. 
Clean up `package.json`, move `jest-junit` config to `jest.config.js`.

https://broadworkbench.atlassian.net/browse/QA-1837