### PR TITLE
[IA-3260][IA-3265] IA Azure UI kickoff

### DIFF
--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -309,18 +309,16 @@ export const ComputeModalBase = ({
       }
       if (shouldCreateRuntime) {
         const diskConfig = Utils.cond(
-          [desiredRuntime.cloudService === cloudServices.DATAPROC, () => { return {} }],
-          [existingPersistentDisk && !shouldDeletePersistentDisk, () => { return { persistentDisk: { name: currentPersistentDiskDetails.name } } }],
-          [Utils.DEFAULT, () => {
-            return {
-              persistentDisk: {
-                name: Utils.generatePersistentDiskName(),
-                size: desiredPersistentDisk.size,
-                diskType: desiredPersistentDisk.diskType.label,
-                labels: { saturnWorkspaceNamespace: namespace, saturnWorkspaceName: name }
-              }
+          [desiredRuntime.cloudService === cloudServices.DATAPROC, () => ({})],
+          [existingPersistentDisk && !shouldDeletePersistentDisk, () => ({ persistentDisk: { name: currentPersistentDiskDetails.name } })],
+          [Utils.DEFAULT, () => ({
+            persistentDisk: {
+              name: Utils.generatePersistentDiskName(),
+              size: desiredPersistentDisk.size,
+              diskType: desiredPersistentDisk.diskType.label,
+              labels: { saturnWorkspaceNamespace: namespace, saturnWorkspaceName: name }
             }
-          }]
+          })]
         )
 
         const createRuntimeConfig = { ...runtimeConfig, ...diskConfig }

--- a/src/components/ContextBar.js
+++ b/src/components/ContextBar.js
@@ -126,9 +126,7 @@ export const ContextBar = ({
             style: { flexDirection: 'column', justifyContent: 'center', padding: '.75rem', ...contextBarStyles.contextBarButton, borderBottom: '0px' },
             hover: contextBarStyles.hover,
             tooltipSide: 'left',
-            onClick: () => {
-              setCloudEnvOpen(!isCloudEnvOpen)
-            },
+            onClick: () => setCloudEnvOpen(true),
             tooltip: 'Environment Configuration',
             tooltipDelay: 100,
             useTooltipAsLabel: true

--- a/src/components/ContextBar.js
+++ b/src/components/ContextBar.js
@@ -39,7 +39,7 @@ const contextBarStyles = {
 
 export const ContextBar = ({
   runtimes, apps, appDataDisks, refreshRuntimes, location, locationType, refreshApps,
-  workspace, persistentDisks, workspace: { workspace: { namespace, name: workspaceName } }
+  workspace, persistentDisks, workspace: { workspace: { namespace, name: workspaceName, googleProject } }
 }) => {
   const [isCloudEnvOpen, setCloudEnvOpen] = useState(false)
   const [selectedToolIcon, setSelectedToolIcon] = useState(undefined)
@@ -59,7 +59,8 @@ export const ContextBar = ({
     [tools.Jupyter.label, () => img({ src: jupyterLogo, style: { height: 45, width: 45 }, alt: '' })],
     [tools.Galaxy.label, () => img({ src: galaxyLogo, style: { height: 14, width: 45 }, alt: '' })],
     [tools.Cromwell.label, () => img({ src: cromwellImg, style: { width: 45 }, alt: '' })],
-    [tools.RStudio.label, () => img({ src: rstudioSquareLogo, style: { height: 45, width: 45 }, alt: '' })]
+    [tools.RStudio.label, () => img({ src: rstudioSquareLogo, style: { height: 45, width: 45 }, alt: '' })],
+    [tools.Azure.label, () => img({ src: jupyterLogo, style: { height: 45, width: 45 }, alt: '' })]
   )
 
   const getColorForStatus = status => Utils.cond(
@@ -125,7 +126,12 @@ export const ContextBar = ({
             style: { flexDirection: 'column', justifyContent: 'center', padding: '.75rem', ...contextBarStyles.contextBarButton, borderBottom: '0px' },
             hover: contextBarStyles.hover,
             tooltipSide: 'left',
-            onClick: () => setCloudEnvOpen(!isCloudEnvOpen),
+            onClick: () => {
+              setCloudEnvOpen(!isCloudEnvOpen)
+              if (!googleProject) {
+                setSelectedToolIcon(tools.Azure.label)
+              }
+            },
             tooltip: 'Environment Configuration',
             tooltipDelay: 100,
             useTooltipAsLabel: true

--- a/src/components/ContextBar.js
+++ b/src/components/ContextBar.js
@@ -39,7 +39,7 @@ const contextBarStyles = {
 
 export const ContextBar = ({
   runtimes, apps, appDataDisks, refreshRuntimes, location, locationType, refreshApps,
-  workspace, persistentDisks, workspace: { workspace: { namespace, name: workspaceName, googleProject } }
+  workspace, persistentDisks, workspace: { workspace: { namespace, name: workspaceName } }
 }) => {
   const [isCloudEnvOpen, setCloudEnvOpen] = useState(false)
   const [selectedToolIcon, setSelectedToolIcon] = useState(undefined)
@@ -128,9 +128,6 @@ export const ContextBar = ({
             tooltipSide: 'left',
             onClick: () => {
               setCloudEnvOpen(!isCloudEnvOpen)
-              if (!googleProject) {
-                setSelectedToolIcon(tools.Azure.label)
-              }
             },
             tooltip: 'Environment Configuration',
             tooltipDelay: 100,

--- a/src/components/RuntimeManager.js
+++ b/src/components/RuntimeManager.js
@@ -24,7 +24,8 @@ import * as Nav from 'src/libs/nav'
 import { clearNotification, notify } from 'src/libs/notifications'
 import { useOnMount } from 'src/libs/react-utils'
 import {
-  appIsSettingUp, getComputeStatusForDisplay, getConvertedRuntimeStatus, getCurrentApp, getCurrentRuntime, getPersistentDiskCostHourly, runtimeCost,
+  appIsSettingUp, cloudProviders, getComputeStatusForDisplay, getConvertedRuntimeStatus, getCurrentApp, getCurrentRuntime,
+  getPersistentDiskCostHourly, runtimeCost,
   trimRuntimesOldestFirst
 } from 'src/libs/runtime-utils'
 import { errorNotifiedApps, errorNotifiedRuntimes } from 'src/libs/state'
@@ -72,7 +73,9 @@ export const RuntimeErrorModal = ({ runtime, onDismiss }) => {
     withErrorReporting('Error loading cloud environment details'),
     Utils.withBusyState(setLoadingRuntimeDetails)
   )(async () => {
-    const { errors: runtimeErrors } = await Ajax().Runtimes.runtime(runtime.googleProject, runtime.runtimeName).details()
+    console.log('in loadRuntimeError', runtime, _.lowerCase(runtime.cloudContext.cloudProvider))
+    const { errors: runtimeErrors } = _.lowerCase(runtime.cloudContext.cloudProvider) === cloudProviders.azure.label ? await Ajax().Runtimes.runtimeV2(runtime.workspaceId, runtime.runtimeName).details() :
+      await Ajax().Runtimes.runtime(runtime.googleProject, runtime.runtimeName).details()
     if (_.some(({ errorMessage }) => errorMessage.includes('Userscript failed'), runtimeErrors)) {
       setError(
         await Ajax()

--- a/src/components/RuntimeManager.js
+++ b/src/components/RuntimeManager.js
@@ -288,7 +288,7 @@ export default class RuntimeManager extends PureComponent {
     const { namespace, name, runtimes, refreshRuntimes, canCompute, persistentDisks, apps, appDataDisks, refreshApps, location, locationType, workspace } = this.props
     const { busy, createModalDrawerOpen, errorModalOpen, galaxyDrawerOpen } = this.state
     const { computeRegion } = getRegionInfo(location, locationType)
-    if (!runtimes || !apps || !workspace?.workspace.googleProject) {
+    if (!runtimes || !apps) {
       return null
     }
     const currentRuntime = this.getCurrentRuntime()

--- a/src/components/RuntimeManager.js
+++ b/src/components/RuntimeManager.js
@@ -70,7 +70,7 @@ export const RuntimeErrorModal = ({ runtime, onDismiss }) => {
   const [loadingRuntimeDetails, setLoadingRuntimeDetails] = useState(false)
 
   const loadRuntimeError = _.flow(
-    withErrorReporting('Could Not Retrieve Cloud Environment Log Info'),
+    withErrorReporting('Could Not Retrieve Cloud Environment Error Info'),
     Utils.withBusyState(setLoadingRuntimeDetails)
   )(async () => {
     const { errors: runtimeErrors } = _.lowerCase(runtime.cloudContext.cloudProvider) === cloudProviders.azure.label ?

--- a/src/components/RuntimeManager.js
+++ b/src/components/RuntimeManager.js
@@ -70,10 +70,11 @@ export const RuntimeErrorModal = ({ runtime, onDismiss }) => {
   const [loadingRuntimeDetails, setLoadingRuntimeDetails] = useState(false)
 
   const loadRuntimeError = _.flow(
-    withErrorReporting('Error loading cloud environment details'),
+    withErrorReporting('Could Not Retrieve Cloud Environment Log Info'),
     Utils.withBusyState(setLoadingRuntimeDetails)
   )(async () => {
-    const { errors: runtimeErrors } = _.lowerCase(runtime.cloudContext.cloudProvider) === cloudProviders.azure.label ? await Ajax().Runtimes.runtimeV2(runtime.workspaceId, runtime.runtimeName).details() :
+    const { errors: runtimeErrors } = _.lowerCase(runtime.cloudContext.cloudProvider) === cloudProviders.azure.label ?
+      await Ajax().Runtimes.runtimeV2(runtime.workspaceId, runtime.runtimeName).details() :
       await Ajax().Runtimes.runtime(runtime.googleProject, runtime.runtimeName).details()
     if (_.some(({ errorMessage }) => errorMessage.includes('Userscript failed'), runtimeErrors)) {
       setError(

--- a/src/components/RuntimeManager.js
+++ b/src/components/RuntimeManager.js
@@ -73,7 +73,6 @@ export const RuntimeErrorModal = ({ runtime, onDismiss }) => {
     withErrorReporting('Error loading cloud environment details'),
     Utils.withBusyState(setLoadingRuntimeDetails)
   )(async () => {
-    console.log('in loadRuntimeError', runtime, _.lowerCase(runtime.cloudContext.cloudProvider))
     const { errors: runtimeErrors } = _.lowerCase(runtime.cloudContext.cloudProvider) === cloudProviders.azure.label ? await Ajax().Runtimes.runtimeV2(runtime.workspaceId, runtime.runtimeName).details() :
       await Ajax().Runtimes.runtime(runtime.googleProject, runtime.runtimeName).details()
     if (_.some(({ errorMessage }) => errorMessage.includes('Userscript failed'), runtimeErrors)) {
@@ -289,7 +288,7 @@ export default class RuntimeManager extends PureComponent {
     const { namespace, name, runtimes, refreshRuntimes, canCompute, persistentDisks, apps, appDataDisks, refreshApps, location, locationType, workspace } = this.props
     const { busy, createModalDrawerOpen, errorModalOpen, galaxyDrawerOpen } = this.state
     const { computeRegion } = getRegionInfo(location, locationType)
-    if (!runtimes || !apps) {
+    if (!runtimes || !apps || !workspace?.workspace.googleProject) {
       return null
     }
     const currentRuntime = this.getCurrentRuntime()

--- a/src/components/notebook-utils.js
+++ b/src/components/notebook-utils.js
@@ -77,7 +77,8 @@ export const tools = {
   jupyterTerminal: { label: 'terminal' },
   spark: { label: 'spark' },
   Galaxy: { label: 'Galaxy', appType: 'GALAXY' },
-  Cromwell: { label: 'Cromwell', appType: 'CROMWELL', isAppHidden: !isCromwellAppVisible(), isPauseUnsupported: true }
+  Cromwell: { label: 'Cromwell', appType: 'CROMWELL', isAppHidden: !isCromwellAppVisible(), isPauseUnsupported: true },
+  Azure: { label: 'Azure' }
 }
 
 // Returns the tools in the order that they should be displayed for Cloud Environment tools

--- a/src/components/notebook-utils.js
+++ b/src/components/notebook-utils.js
@@ -84,9 +84,8 @@ export const tools = {
 // Returns the tools in the order that they should be displayed for Cloud Environment tools
 export const getToolsToDisplay = isAzureWorkspace => _.flow(
   _.remove(tool => tool.isAppHidden),
-  isAzureWorkspace ? _.remove(tool => !tool.isAzureCompatible) : _.remove(tool => tool.isAzureCompatible))(
-  [tools.Jupyter, tools.RStudio, tools.Galaxy, tools.Cromwell, tools.Azure]
-)
+  _.filter(tool => tool.isAzureCompatible === isAzureWorkspace)
+)([tools.Jupyter, tools.RStudio, tools.Galaxy, tools.Cromwell, tools.Azure])
 
 const toolToExtensionMap = { [tools.RStudio.label]: tools.RStudio.ext, [tools.Jupyter.label]: tools.Jupyter.ext }
 

--- a/src/components/notebook-utils.js
+++ b/src/components/notebook-utils.js
@@ -84,7 +84,7 @@ export const tools = {
 // Returns the tools in the order that they should be displayed for Cloud Environment tools
 export const getToolsToDisplay = isAzureWorkspace => _.flow(
   _.remove(tool => tool.isAppHidden),
-  _.filter(tool => tool.isAzureCompatible === isAzureWorkspace)
+  _.filter(tool => !!tool.isAzureCompatible === !!isAzureWorkspace)
 )([tools.Jupyter, tools.RStudio, tools.Galaxy, tools.Cromwell, tools.Azure])
 
 const toolToExtensionMap = { [tools.RStudio.label]: tools.RStudio.ext, [tools.Jupyter.label]: tools.Jupyter.ext }

--- a/src/components/notebook-utils.js
+++ b/src/components/notebook-utils.js
@@ -73,16 +73,20 @@ export const analysisNameInput = ({ inputProps, ...props }) => h(ValidatedInput,
 
 export const tools = {
   RStudio: { label: 'RStudio', ext: 'Rmd', imageIds: ['RStudio'], defaultImageId: 'RStudio' },
-  Jupyter: { label: 'Jupyter', ext: 'ipynb', imageIds: ['terra-jupyter-bioconductor', 'terra-jupyter-bioconductor_legacy', 'terra-jupyter-hail', 'terra-jupyter-python', 'terra-jupyter-gatk', 'Pegasus', 'terra-jupyter-gatk_legacy'], defaultImageId: 'terra-jupyter-gatk' },
+  Jupyter: { label: 'Jupyter', ext: 'ipynb', imageIds: ['terra-jupyter-bioconductor', 'terra-jupyter-bioconductor_legacy', 'terra-jupyter-hail', 'terra-jupyter-python', 'terra-jupyter-gatk', 'Pegasus', 'terra-jupyter-gatk_legacy'], defaultImageId: 'terra-jupyter-gatk', isLaunchUnsupported: false },
   jupyterTerminal: { label: 'terminal' },
   spark: { label: 'spark' },
   Galaxy: { label: 'Galaxy', appType: 'GALAXY' },
   Cromwell: { label: 'Cromwell', appType: 'CROMWELL', isAppHidden: !isCromwellAppVisible(), isPauseUnsupported: true },
-  Azure: { label: 'Azure' }
+  Azure: { label: 'Azure', isAzureCompatible: true, isPauseUnsupported: true, isLaunchUnsupported: true }
 }
 
 // Returns the tools in the order that they should be displayed for Cloud Environment tools
-export const getToolsToDisplay = _.remove(tool => tool.isAppHidden)([tools.Jupyter, tools.RStudio, tools.Galaxy, tools.Cromwell])
+export const getToolsToDisplay = isAzureWorkspace => _.flow(
+  _.remove(tool => tool.isAppHidden),
+  isAzureWorkspace ? _.remove(tool => !tool.isAzureCompatible) : _.remove(tool => tool.isAzureCompatible))(
+  [tools.Jupyter, tools.RStudio, tools.Galaxy, tools.Cromwell, tools.Azure]
+)
 
 const toolToExtensionMap = { [tools.RStudio.label]: tools.RStudio.ext, [tools.Jupyter.label]: tools.Jupyter.ext }
 

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1487,6 +1487,48 @@ const Runtimes = signal => ({
     }
   },
 
+  listV2: async (labels = {}) => {
+    const res = await fetchLeo(`api/v2/runtimes?${qs.stringify({ saturnAutoCreated: true, ...labels })}`,
+      _.mergeAll([authOpts(), appIdentifier, { signal }]))
+    return res.json()
+  },
+
+  listV2WithWorkspace: async (workspaceId, labels = {}) => {
+    const res = await fetchLeo(`api/v2/runtimes/${workspaceId}?${qs.stringify({ saturnAutoCreated: true, ...labels })}`,
+      _.mergeAll([authOpts(), appIdentifier, { signal }]))
+    return res.json()
+  },
+
+  listV2AzureWithWorkspace: async (workspaceId, labels = {}) => {
+    const res = await fetchLeo(`api/v2/runtimes/${workspaceId}/azure?${qs.stringify({ saturnAutoCreated: true, ...labels })}`,
+      _.mergeAll([authOpts(), appIdentifier, { signal }]))
+    return res.json()
+  },
+
+  runtimeV2: (workspaceId, name, cloudProvider = "azure") => {
+    const root = `api/v2/runtimes/${workspaceId}/${cloudProvider}/${name}`
+
+    return {
+
+      details: async () => {
+        const res = await fetchLeo(root, _.mergeAll([authOpts(), { signal }, appIdentifier]))
+        return res.json()
+      },
+
+      create: options => {
+        const body = _.merge(options, {
+          labels: { saturnAutoCreated: 'true', saturnVersion: version },
+        })
+        return fetchLeo(root, _.mergeAll([authOpts(), jsonBody(body), { signal, method: 'POST' }, appIdentifier]))
+      },
+
+      delete: (deleteDisk = true) => {
+        return fetchLeo(`${root}${qs.stringify({ deleteDisk }, { addQueryPrefix: true })}`,
+          _.mergeAll([authOpts(), { signal, method: 'DELETE' }, appIdentifier]))
+      }
+    }
+  },
+
   fileSyncing: (project, name) => {
     const root = `proxy/${project}/${name}`
 

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1505,7 +1505,7 @@ const Runtimes = signal => ({
     return res.json()
   },
 
-  runtimeV2: (workspaceId, name, cloudProvider = "azure") => {
+  runtimeV2: (workspaceId, name, cloudProvider = 'azure') => {
     const root = `api/v2/runtimes/${workspaceId}/${cloudProvider}/${name}`
 
     return {
@@ -1517,7 +1517,7 @@ const Runtimes = signal => ({
 
       create: options => {
         const body = _.merge(options, {
-          labels: { saturnAutoCreated: 'true', saturnVersion: version },
+          labels: { saturnAutoCreated: 'true', saturnVersion: version }
         })
         return fetchLeo(root, _.mergeAll([authOpts(), jsonBody(body), { signal, method: 'POST' }, appIdentifier]))
       },

--- a/src/libs/azure-utils.js
+++ b/src/libs/azure-utils.js
@@ -13,8 +13,8 @@ export const defaultAzureComputeConfig = {
 
 //TODO: this should be fleshed out once azure region isn't limited to workspace region
 export const azureRegions = { eastus: { label: 'East US' } }
-export const getRegionLabel = label => _.has(label, azureRegions) ? azureRegions[label].label : 'Unknown azure region'
+export const getRegionLabel = key => _.has(key, azureRegions) ? azureRegions[key].label : 'Unknown azure region'
 
 export const azureMachineTypes = { Standard_DS1_v2: { cpu: 1, ramInGb: 3.5 }, Standard_DS2_v2: { cpu: 2, ramInGb: 7 }, Standard_DS3_v2: { cpu: 4, ramInGb: 14 }, Standard_DS4_v2: { cpu: 8, ramInGb: 28 }, Standard_DS5_v2: { cpu: 16, ramInGb: 56 } }
-export const getMachineTypeLabel = label => _.has(label, azureMachineTypes) ? `${label}, ${azureMachineTypes[label].cpu} CPU(s), ${azureMachineTypes[label].ramInGb} GBs` : 'Unknown machine type'
+export const getMachineTypeLabel = key => _.has(key, azureMachineTypes) ? `${key}, ${azureMachineTypes[key].cpu} CPU(s), ${azureMachineTypes[key].ramInGb} GBs` : 'Unknown machine type'
 

--- a/src/libs/azure-utils.js
+++ b/src/libs/azure-utils.js
@@ -1,0 +1,11 @@
+import * as Utils from 'src/libs/utils'
+import _ from 'lodash/fp'
+
+export const defaultAzureMachineType = 'Standard_DS1_v2'
+export const defaultAzureDiskSize = 50
+export const defaultAzureRegion = 'eastus'
+//TODO: this should be fleshed out once azure region isn't limitted to workspace region
+export const azureRegions =  { 'eastus': { label: 'East US' } }
+export const azureMachineTypes = { Standard_DS1_v2: { cpu: 1, ramInGb: 7.75 } }
+export const getMachineTypeLabel = label => _.has(label, azureMachineTypes) ? `${label}, ${azureMachineTypes[label].cpu} CPU(s), ${azureMachineTypes[label].ramInGb} GBs` : 'Unknown machine type'
+export const getRegionLabel = label => _.has(label, azureRegions) ? azureRegions[label].label : 'Unknown azure region'

--- a/src/libs/azure-utils.js
+++ b/src/libs/azure-utils.js
@@ -1,12 +1,20 @@
 import _ from 'lodash/fp'
-import * as Utils from 'src/libs/utils'
 
 
 export const defaultAzureMachineType = 'Standard_DS1_v2'
 export const defaultAzureDiskSize = 50
 export const defaultAzureRegion = 'eastus'
-//TODO: this should be fleshed out once azure region isn't limitted to workspace region
+
+export const defaultAzureComputeConfig = {
+  machineType: defaultAzureMachineType,
+  diskSize: defaultAzureDiskSize,
+  region: defaultAzureRegion
+}
+
+//TODO: this should be fleshed out once azure region isn't limited to workspace region
 export const azureRegions = { eastus: { label: 'East US' } }
+export const getRegionLabel = label => _.has(label, azureRegions) ? azureRegions[label].label : 'Unknown azure region'
+
 export const azureMachineTypes = { Standard_DS1_v2: { cpu: 1, ramInGb: 3.5 }, Standard_DS2_v2: { cpu: 2, ramInGb: 7 }, Standard_DS3_v2: { cpu: 4, ramInGb: 14 }, Standard_DS4_v2: { cpu: 8, ramInGb: 28 }, Standard_DS5_v2: { cpu: 16, ramInGb: 56 } }
 export const getMachineTypeLabel = label => _.has(label, azureMachineTypes) ? `${label}, ${azureMachineTypes[label].cpu} CPU(s), ${azureMachineTypes[label].ramInGb} GBs` : 'Unknown machine type'
-export const getRegionLabel = label => _.has(label, azureRegions) ? azureRegions[label].label : 'Unknown azure region'
+

--- a/src/libs/azure-utils.js
+++ b/src/libs/azure-utils.js
@@ -1,11 +1,12 @@
-import * as Utils from 'src/libs/utils'
 import _ from 'lodash/fp'
+import * as Utils from 'src/libs/utils'
+
 
 export const defaultAzureMachineType = 'Standard_DS1_v2'
 export const defaultAzureDiskSize = 50
 export const defaultAzureRegion = 'eastus'
 //TODO: this should be fleshed out once azure region isn't limitted to workspace region
-export const azureRegions =  { 'eastus': { label: 'East US' } }
-export const azureMachineTypes = { Standard_DS1_v2: { cpu: 1, ramInGb: 7.75 } }
+export const azureRegions = { eastus: { label: 'East US' } }
+export const azureMachineTypes = { Standard_DS1_v2: { cpu: 1, ramInGb: 3.5 }, Standard_DS2_v2: { cpu: 2, ramInGb: 7 }, Standard_DS3_v2: { cpu: 4, ramInGb: 14 }, Standard_DS4_v2: { cpu: 8, ramInGb: 28 }, Standard_DS5_v2: { cpu: 16, ramInGb: 56 } }
 export const getMachineTypeLabel = label => _.has(label, azureMachineTypes) ? `${label}, ${azureMachineTypes[label].cpu} CPU(s), ${azureMachineTypes[label].ramInGb} GBs` : 'Unknown machine type'
 export const getRegionLabel = label => _.has(label, azureRegions) ? azureRegions[label].label : 'Unknown azure region'

--- a/src/libs/runtime-utils.js
+++ b/src/libs/runtime-utils.js
@@ -128,9 +128,9 @@ const dataprocCost = (machineType, numInstances) => {
 }
 
 const getHourlyCostForMachineType = (machineTypeName, region, isPreemptible) => {
-  const { cpu, memory } = _.find({ name: machineTypeName }, machineTypes)
+  const { cpu, memory } = _.find({ name: machineTypeName }, machineTypes) || {}
   const { n1HourlyCpuPrice, preemptibleN1HourlyCpuPrice, n1HourlyGBRamPrice, preemptibleN1HourlyGBRamPrice } = _.find({ name: _.toUpper(region) },
-    regionToPrices)
+    regionToPrices) || {}
   return isPreemptible ?
     (cpu * preemptibleN1HourlyCpuPrice) + (memory * preemptibleN1HourlyGBRamPrice) :
     (cpu * n1HourlyCpuPrice) + (memory * n1HourlyGBRamPrice)

--- a/src/libs/runtime-utils.js
+++ b/src/libs/runtime-utils.js
@@ -64,9 +64,9 @@ export const defaultComputeZone = 'US-CENTRAL1-A'
 export const defaultComputeRegion = 'US-CENTRAL1'
 
 export const defaultAutopauseThreshold = 30
+// Leonardo considers autopause disabled when the threshold is set to 0
 export const autopauseDisabledValue = 0
 
-// Leonardo considers autopause disabled when the threshold is set to 0
 export const isAutopauseEnabled = threshold => threshold > autopauseDisabledValue
 export const getAutopauseThreshold = isEnabled => isEnabled ? defaultAutopauseThreshold : autopauseDisabledValue
 

--- a/src/libs/runtime-utils.js
+++ b/src/libs/runtime-utils.js
@@ -7,7 +7,6 @@ import {
   cloudServices, dataprocCpuPrice, ephemeralExternalIpAddressPrice, gpuTypes, machineTypes, regionToPrices, zonesToGpus
 } from 'src/data/machines'
 import colors from 'src/libs/colors'
-import { isCromwellAppVisible } from 'src/libs/config'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 
@@ -66,18 +65,6 @@ export const defaultComputeRegion = 'US-CENTRAL1'
 
 export const defaultAutopauseThreshold = 30
 export const autopauseDisabledValue = 0
-
-export const defaultAzureMachineType = 'DS1_v2'
-export const azureMachineTypes = { DS1_v2: { label: 'DS1v2', cpu: 1, ramInGb: 7.75 } }
-
-// export const tools = {
-//   RStudio: { label: 'RStudio', ext: 'Rmd', imageIds: ['RStudio'], defaultImageId: 'RStudio' },
-//   Jupyter: { label: 'Jupyter', ext: 'ipynb', imageIds: ['terra-jupyter-bioconductor', 'terra-jupyter-bioconductor_legacy', 'terra-jupyter-hail', 'terra-jupyter-python', 'terra-jupyter-gatk', 'Pegasus', 'terra-jupyter-gatk_legacy'], defaultImageId: 'terra-jupyter-gatk' },
-//   jupyterTerminal: { label: 'terminal' },
-//   spark: { label: 'spark' },
-//   Galaxy: { label: 'Galaxy', appType: 'GALAXY' },
-//   Cromwell: { label: 'Cromwell', appType: 'CROMWELL', isAppHidden: !isCromwellAppVisible(), isPauseUnsupported: true }
-// }
 
 // Leonardo considers autopause disabled when the threshold is set to 0
 export const isAutopauseEnabled = threshold => threshold > autopauseDisabledValue
@@ -168,36 +155,6 @@ export const runtimeConfigBaseCost = config => {
     isDataproc ?
       (dataprocCost(masterMachineType, 1) + dataprocCost(workerMachineType, numberOfWorkers)) :
       (bootDiskSize * getPersistentDiskPriceForRegionHourly(computeRegion, pdTypes.standard))
-  ])
-}
-
-export const renderCostBreakdown = () => {
-  return div({
-    style: {
-      backgroundColor: colors.accent(0.2),
-      display: 'flex',
-      borderRadius: 5,
-      padding: '0.5rem 1rem',
-      marginTop: '1rem'
-    }
-  }, [
-    _.map(({ cost, label, unitLabel }) => {
-      return div({ key: label, style: { flex: 1, ...computeStyles.label } }, [
-        div({ style: { fontSize: 10 } }, [label]),
-        div({ style: { color: colors.accent(1.1), marginTop: '0.25rem' } }, [
-          span({ style: { fontSize: 20 } }, [cost]),
-          span([' ', unitLabel])
-        ])
-      ])
-    }, [
-      { label: 'Running cloud compute cost', cost: Utils.formatUSD(runtimeConfigCost(getPendingRuntimeConfig())), unitLabel: 'per hr' },
-      { label: 'Paused cloud compute cost', cost: Utils.formatUSD(runtimeConfigBaseCost(getPendingRuntimeConfig())), unitLabel: 'per hr' },
-      {
-        label: 'Persistent disk cost',
-        cost: isPersistentDisk ? Utils.formatUSD(getPersistentDiskCostMonthly(getPendingDisk(), computeConfig.computeRegion)) : 'N/A',
-        unitLabel: isPersistentDisk ? 'per month' : ''
-      }
-    ])
   ])
 }
 

--- a/src/libs/runtime-utils.js
+++ b/src/libs/runtime-utils.js
@@ -422,3 +422,5 @@ export const getIsRuntimeBusy = runtime => {
   return creating || updating || reconfiguring || stopping || starting
 }
 
+export const cloudProviders = { azure: { label: 'azure' }, gcp: {} }
+

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -363,7 +363,7 @@ const Environments = () => {
             }
           },
           {
-            size: { basis: 100, grow: 0 },
+            size: { basis: 125, grow: 0 },
             headerRenderer: () => h(Sortable, { sort, field: 'created', onSort: setSort }, ['Type']),
             cellRenderer: ({ rowIndex }) => {
               const cloudEnvironment = filteredCloudEnvironments[rowIndex]

--- a/src/pages/workspaces/workspace/Analyses.js
+++ b/src/pages/workspaces/workspace/Analyses.js
@@ -312,20 +312,20 @@ const Analyses = _.flow(
   }) : () => {}
 
   // Lifecycle
-  useOnMount(() => {
-    const load = async () => {
-      const [currentUserHash, potentialLockers] = !!googleProject ?
-        await Promise.all([notebookLockHash(bucketName, authState.user.email), findPotentialNotebookLockers({ canShare, namespace, wsName, bucketName })]) :
-        await Promise.all([Promise.resolve(undefined), Promise.resolve(undefined)])
-      setCurrentUserHash(currentUserHash)
-      setPotentialLockers(potentialLockers)
-      getActiveFileTransfers()
-      await refreshAnalyses()
-      await refreshRuntimes()
-    }
-
-    load()
+  useOnMount(_.flow(
+    withErrorReporting('Error loading analyses'),
+    Utils.withBusyState(setBusy)
+  )(async () => {
+    const [currentUserHash, potentialLockers] = !!googleProject ?
+      await Promise.all([notebookLockHash(bucketName, authState.user.email), findPotentialNotebookLockers({ canShare, namespace, wsName, bucketName })]) :
+      await Promise.all([Promise.resolve(undefined), Promise.resolve(undefined)])
+    setCurrentUserHash(currentUserHash)
+    setPotentialLockers(potentialLockers)
+    getActiveFileTransfers()
+    await refreshAnalyses()
+    await refreshRuntimes()
   })
+  )
 
   useEffect(() => {
     StateHistory.update({ analyses, sortOrder, filter })

--- a/src/pages/workspaces/workspace/Analyses.js
+++ b/src/pages/workspaces/workspace/Analyses.js
@@ -225,11 +225,10 @@ const Analyses = _.flow(
   }),
   withViewToggle('analysesTab')
 )(({
-  name: wsName, namespace, workspace, workspace: { accessLevel, canShare, workspace: { googleProject, bucketName, azureContext } },
+  name: wsName, namespace, workspace, workspace: { accessLevel, canShare, workspace: { googleProject, bucketName } },
   analysesData: { apps, refreshApps, runtimes, refreshRuntimes, appDataDisks, persistentDisks },
   onRequesterPaysError
 }, _ref) => {
-  // State
   //TODO: revert after testing
   var googleProject = false
   const [renamingAnalysisName, setRenamingAnalysisName] = useState(undefined)

--- a/src/pages/workspaces/workspace/Analyses.js
+++ b/src/pages/workspaces/workspace/Analyses.js
@@ -225,13 +225,13 @@ const Analyses = _.flow(
   }),
   withViewToggle('analysesTab')
 )(({
-  name: wsName, namespace, workspace, workspace: { accessLevel, canShare, workspace: { /*googleProject,*/ bucketName, azureContext } },
+  name: wsName, namespace, workspace, workspace: { accessLevel, canShare, workspace: { googleProject, bucketName, azureContext } },
   analysesData: { apps, refreshApps, runtimes, refreshRuntimes, appDataDisks, persistentDisks },
   onRequesterPaysError
 }, _ref) => {
   // State
-  //TODO: this is for testing azure functionality, delete soon
-  const googleProject = false
+  //TODO: revert after testing
+  var googleProject = false
   const [renamingAnalysisName, setRenamingAnalysisName] = useState(undefined)
   const [copyingAnalysisName, setCopyingAnalysisName] = useState(undefined)
   const [deletingAnalysisName, setDeletingAnalysisName] = useState(undefined)
@@ -277,7 +277,7 @@ const Analyses = _.flow(
     const analyses = _.concat(enhancedNotebooks, enhancedRmd)
     setLocation(location)
     setAnalyses(_.reverse(_.sortBy('lastModified', analyses)))
-  }): () => setAnalyses([])
+  }) : () => setAnalyses([])
 
   const getActiveFileTransfers = _.flow(
     withErrorReporting('Error loading file transfer status for notebooks in the workspace.'),
@@ -329,16 +329,15 @@ const Analyses = _.flow(
     StateHistory.update({ analyses, sortOrder, filter })
   }, [analyses, sortOrder, filter])
 
-  //TODO: fix for azure in this PR
   const noAnalysisBanner = div([
     div({ style: { fontSize: 48 } }, ['A place for all your analyses ']),
-    div({ style: { display: 'flex', flexDirection: 'row', justifyContent: 'center', alignItems: 'center' } }, [
+    !!googleProject ? div({ style: { display: 'flex', flexDirection: 'row', justifyContent: 'center', alignItems: 'center' } }, [
       img({ src: jupyterLogo, style: { height: 120, width: 80, marginRight: '5rem' } }),
       img({ src: rstudioBioLogo, style: { width: 400, marginRight: '5rem' } }),
       div([
         img({ src: galaxyLogo, style: { height: 60, width: 208 } })
       ])
-    ]),
+    ]) : undefined,
     div({ style: { marginTop: '1rem', fontSize: 20 } }, [
       `Click the button above to create an analysis.`
     ])

--- a/src/pages/workspaces/workspace/Analyses.js
+++ b/src/pages/workspaces/workspace/Analyses.js
@@ -285,7 +285,10 @@ const Analyses = _.flow(
   })
 
   //TODO: define update function for azure
-  const uploadFiles = !!googleProject ? Utils.withBusyState(setBusy, async files => {
+  const uploadFiles = !!googleProject ? _.flow(
+    withErrorReporting('Error uploading files'),
+    Utils.withBusyState(setBusy)
+  )(async files => {
     try {
       await Promise.all(_.map(async file => {
         const name = stripExtension(file.name)

--- a/src/pages/workspaces/workspace/Analyses.js
+++ b/src/pages/workspaces/workspace/Analyses.js
@@ -229,8 +229,6 @@ const Analyses = _.flow(
   analysesData: { apps, refreshApps, runtimes, refreshRuntimes, appDataDisks, persistentDisks },
   onRequesterPaysError
 }, _ref) => {
-  // TODO: revert after testing
-  // var googleProject = false
   const [renamingAnalysisName, setRenamingAnalysisName] = useState(undefined)
   const [copyingAnalysisName, setCopyingAnalysisName] = useState(undefined)
   const [deletingAnalysisName, setDeletingAnalysisName] = useState(undefined)
@@ -313,12 +311,14 @@ const Analyses = _.flow(
   // Lifecycle
   useOnMount(() => {
     const load = async () => {
-      const [currentUserHash, potentialLockers] = await Promise.all(
-        [notebookLockHash(bucketName, authState.user.email), findPotentialNotebookLockers({ canShare, namespace, wsName, bucketName })])
+      const [currentUserHash, potentialLockers] = !!googleProject ?
+        await Promise.all([notebookLockHash(bucketName, authState.user.email), findPotentialNotebookLockers({ canShare, namespace, wsName, bucketName })]) :
+        await Promise.all([Promise.resolve(undefined), Promise.resolve(undefined)])
       setCurrentUserHash(currentUserHash)
       setPotentialLockers(potentialLockers)
       getActiveFileTransfers()
-      refreshAnalyses()
+      await refreshAnalyses()
+      await refreshRuntimes()
     }
 
     load()

--- a/src/pages/workspaces/workspace/Analyses.js
+++ b/src/pages/workspaces/workspace/Analyses.js
@@ -229,8 +229,8 @@ const Analyses = _.flow(
   analysesData: { apps, refreshApps, runtimes, refreshRuntimes, appDataDisks, persistentDisks },
   onRequesterPaysError
 }, _ref) => {
-  //TODO: revert after testing
-  var googleProject = false
+  // TODO: revert after testing
+  // var googleProject = false
   const [renamingAnalysisName, setRenamingAnalysisName] = useState(undefined)
   const [copyingAnalysisName, setCopyingAnalysisName] = useState(undefined)
   const [deletingAnalysisName, setDeletingAnalysisName] = useState(undefined)
@@ -330,13 +330,14 @@ const Analyses = _.flow(
 
   const noAnalysisBanner = div([
     div({ style: { fontSize: 48 } }, ['A place for all your analyses ']),
-    !!googleProject ? div({ style: { display: 'flex', flexDirection: 'row', justifyContent: 'center', alignItems: 'center' } }, [
-      img({ src: jupyterLogo, style: { height: 120, width: 80, marginRight: '5rem' } }),
-      img({ src: rstudioBioLogo, style: { width: 400, marginRight: '5rem' } }),
+    div({ style: { display: 'flex', flexDirection: 'row', justifyContent: 'space-evenly', alignItems: 'center', columnGap: '5rem' } }, _.dropRight(!!googleProject ? 0 : 2, [
+      img({ src: jupyterLogo, style: { height: 120, width: 80 } }),
+      img({ src: rstudioBioLogo, style: { width: 400 } }),
       div([
         img({ src: galaxyLogo, style: { height: 60, width: 208 } })
       ])
-    ]) : undefined,
+    ])
+    ),
     div({ style: { marginTop: '1rem', fontSize: 20 } }, [
       `Click the button above to create an analysis.`
     ])

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -148,8 +148,7 @@ const WorkspaceContainer = ({
       setSharingWorkspace, setShowLockWorkspaceModal, isGoogleWorkspace
     }),
     div({ role: 'main', style: Style.elements.pageContentContainer },
-      //TODO: handle in IA-3265
-      (isGoogleWorkspace && isAnalysisTabVisible() ?
+      (isAnalysisTabVisible() ?
         [div({ style: { flex: 1, display: 'flex' } }, [
           div({ style: { flex: 1, display: 'flex', flexDirection: 'column' } }, [
             children

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -116,7 +116,6 @@ const WorkspaceContainer = ({
   // and not the empty string, we know that we have a Google workspace.
   //TODO: revert before merging testing
   const isGoogleWorkspace = !!workspace?.workspace.googleProject
-  console.log('is googleWorkspace in workspaceContainer', isGoogleWorkspace)
 
   return h(FooterWrapper, [
     h(TopBar, { title: 'Workspaces', href: Nav.getLink('workspaces') }, [
@@ -300,7 +299,6 @@ export const wrapWorkspace = ({ breadcrumbs, activeTab, title, topBarContent, sh
     const [{ location, locationType }, setBucketLocation] = useState({ location: defaultLocation, locationType: locationTypes.default })
 
     const prevGoogleProject = usePrevious(googleProject)
-    console.log('before cloudenv polling, {workspace}', workspace, googleProject)
     //TODO: revert before merge, used for testing
     const { runtimes, refreshRuntimes, persistentDisks, appDataDisks } = useCloudEnvironmentPolling(null, workspace?.workspace.workspaceId)
     const { apps, refreshApps } = useAppPolling(googleProject, name)

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -114,7 +114,9 @@ const WorkspaceContainer = ({
 
   // If googleProject is not undefined (server info not yet loaded)
   // and not the empty string, we know that we have a Google workspace.
+  //TODO: revert before merging testing
   const isGoogleWorkspace = !!workspace?.workspace.googleProject
+  console.log('is googleWorkspace in workspaceContainer', isGoogleWorkspace)
 
   return h(FooterWrapper, [
     h(TopBar, { title: 'Workspaces', href: Nav.getLink('workspaces') }, [
@@ -136,7 +138,7 @@ const WorkspaceContainer = ({
         icon('virus', { size: 24, style: { marginRight: '0.5rem' } }),
         div({ style: { fontSize: 12, color: colors.dark() } }, ['COVID-19', br(), 'Data & Tools'])
       ]),
-      isGoogleWorkspace && h(RuntimeManager, {
+      h(RuntimeManager, {
         namespace, name, runtimes, persistentDisks, refreshRuntimes,
         canCompute: !!(workspace?.canCompute || runtimes?.length),
         apps, appDataDisks, workspace, refreshApps, location, locationType
@@ -210,6 +212,8 @@ const useCloudEnvironmentPolling = (googleProject, workspaceId) => {
   const [runtimes, setRuntimes] = useState()
   const [persistentDisks, setPersistentDisks] = useState()
   const [appDataDisks, setAppDataDisks] = useState()
+  //TODO: revert before merging
+  var workspaceId = '1aa85f64-5717-4562-b3fc-2c963f66afa6'
 
   const reschedule = ms => {
     clearTimeout(timeout.current)
@@ -221,9 +225,9 @@ const useCloudEnvironmentPolling = (googleProject, workspaceId) => {
         Ajax(signal).Disks.list({ googleProject, creator: getUser().email, includeLabels: 'saturnApplication,saturnWorkspaceName' }),
         Ajax(signal).Runtimes.list({ googleProject, creator: getUser().email })
       ]) : await Promise.all([
-          Promise.resolve([]),
-          workspaceId ? Ajax(signal).Runtimes.listV2AzureWithWorkspace(workspaceId, { creator: getUser().email} ) : Promise.resolve([])
-        ])
+        Promise.resolve([]),
+        workspaceId ? Ajax(signal).Runtimes.listV2AzureWithWorkspace(workspaceId, { creator: getUser().email }) : Promise.resolve([])
+      ])
       setRuntimes(newRuntimes)
       setAppDataDisks(_.remove(disk => _.isUndefined(getDiskAppType(disk)), newDisks))
       setPersistentDisks(mapToPdTypes(_.filter(disk => _.isUndefined(getDiskAppType(disk)), newDisks)))

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -114,7 +114,6 @@ const WorkspaceContainer = ({
 
   // If googleProject is not undefined (server info not yet loaded)
   // and not the empty string, we know that we have a Google workspace.
-  //TODO: revert before merging testing
   const isGoogleWorkspace = !!workspace?.workspace.googleProject
 
   return h(FooterWrapper, [
@@ -210,8 +209,6 @@ const useCloudEnvironmentPolling = (googleProject, workspaceId) => {
   const [runtimes, setRuntimes] = useState()
   const [persistentDisks, setPersistentDisks] = useState()
   const [appDataDisks, setAppDataDisks] = useState()
-  //TODO: revert before merging
-  // var workspaceId = '1aa85f64-5717-4562-b3fc-2c963f66afa6'
 
   const reschedule = ms => {
     clearTimeout(timeout.current)
@@ -298,7 +295,6 @@ export const wrapWorkspace = ({ breadcrumbs, activeTab, title, topBarContent, sh
     const [{ location, locationType }, setBucketLocation] = useState({ location: defaultLocation, locationType: locationTypes.default })
 
     const prevGoogleProject = usePrevious(googleProject)
-    // TODO: revert before merge, used for testing
     const { runtimes, refreshRuntimes, persistentDisks, appDataDisks } = useCloudEnvironmentPolling(googleProject, workspace?.workspace.workspaceId)
     const { apps, refreshApps } = useAppPolling(googleProject, name)
     const isGoogleWorkspace = !!googleProject

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -211,7 +211,7 @@ const useCloudEnvironmentPolling = (googleProject, workspaceId) => {
   const [persistentDisks, setPersistentDisks] = useState()
   const [appDataDisks, setAppDataDisks] = useState()
   //TODO: revert before merging
-  var workspaceId = '1aa85f64-5717-4562-b3fc-2c963f66afa6'
+  // var workspaceId = '1aa85f64-5717-4562-b3fc-2c963f66afa6'
 
   const reschedule = ms => {
     clearTimeout(timeout.current)
@@ -224,7 +224,7 @@ const useCloudEnvironmentPolling = (googleProject, workspaceId) => {
         Ajax(signal).Runtimes.list({ googleProject, creator: getUser().email })
       ]) : await Promise.all([
         Promise.resolve([]),
-        workspaceId ? Ajax(signal).Runtimes.listV2AzureWithWorkspace(workspaceId, { creator: getUser().email }) : Promise.resolve([])
+        !!workspaceId ? Ajax(signal).Runtimes.listV2AzureWithWorkspace(workspaceId, { creator: getUser().email }) : Promise.resolve([])
       ])
       setRuntimes(newRuntimes)
       setAppDataDisks(_.remove(disk => _.isUndefined(getDiskAppType(disk)), newDisks))
@@ -298,8 +298,8 @@ export const wrapWorkspace = ({ breadcrumbs, activeTab, title, topBarContent, sh
     const [{ location, locationType }, setBucketLocation] = useState({ location: defaultLocation, locationType: locationTypes.default })
 
     const prevGoogleProject = usePrevious(googleProject)
-    //TODO: revert before merge, used for testing
-    const { runtimes, refreshRuntimes, persistentDisks, appDataDisks } = useCloudEnvironmentPolling(null, workspace?.workspace.workspaceId)
+    // TODO: revert before merge, used for testing
+    const { runtimes, refreshRuntimes, persistentDisks, appDataDisks } = useCloudEnvironmentPolling(googleProject, workspace?.workspace.workspaceId)
     const { apps, refreshApps } = useAppPolling(googleProject, name)
     const isGoogleWorkspace = !!googleProject
     if (googleProject !== prevGoogleProject && isGoogleWorkspace) {

--- a/src/pages/workspaces/workspace/analysis/AzureComputeModal.js
+++ b/src/pages/workspaces/workspace/analysis/AzureComputeModal.js
@@ -1,45 +1,46 @@
-import { ButtonOutline, ButtonPrimary, IdContainer, Select, spinnerOverlay } from 'src/components/common'
-import { ComputeModalBase } from 'src/components/ComputeModal'
+import _ from 'lodash/fp'
+import { ButtonOutline, ButtonPrimary, IdContainer, Link, Select, spinnerOverlay, WarningTitle } from 'src/components/common'
+import { icon } from 'src/components/icons'
+import { NumberInput } from 'src/components/input'
 import { withModalDrawer } from 'src/components/ModalDrawer'
-import { isUSLocation } from 'src/components/region-common'
+import { div, p, span, h, label } from 'react-hyperscript-helpers'
+import { tools } from 'src/components/notebook-utils'
+import { InfoBox } from 'src/components/PopupTrigger'
 import TitleBar from 'src/components/TitleBar'
 import { Fragment, useState } from 'react'
 import { Ajax } from 'src/libs/ajax'
+import {
+  azureMachineTypes, azureRegions, defaultAzureDiskSize, defaultAzureMachineType, defaultAzureRegion, getMachineTypeLabel, getRegionLabel
+} from 'src/libs/azure-utils'
 import colors from 'src/libs/colors'
 import { withErrorReporting, withErrorReportingInModal } from 'src/libs/error'
 import { useOnMount } from 'src/libs/react-utils'
 import {
-  azureMachineTypes,
-  computeStyles, defaultAutopauseThreshold, defaultAzureMachineType, defaultComputeRegion, defaultComputeZone, defaultDataprocMachineType,
-  defaultDataprocWorkerDiskSize,
-  defaultGceBootDiskSize,
-  defaultGceMachineType,
-  defaultGcePersistentDiskSize, defaultGpuType,
-  defaultNumDataprocPreemptibleWorkers,
-  defaultNumDataprocWorkers, defaultNumGpus, getCurrentRuntime, getIsRuntimeBusy, getValidGpuTypesForZone, renderCostBreakdown
+  computeStyles, getCurrentRuntime, getIsRuntimeBusy
 } from 'src/libs/runtime-utils'
-import { div, h, label } from 'react-hyperscript-helpers'
 import * as Utils from 'src/libs/utils'
 
 
 // Change to true to enable a debugging panel (intended for dev mode only)
-const showDebugPanel = false
 const titleId = 'azure-compute-modal-title'
 
 export const AzureComputeModalBase = ({
-  onDismiss, onSuccess, runtimes, workspace, workspace: { workspace: { namespace, name: workspaceName, workspaceId } }, location, isAnalysisMode = false, shouldHideCloseButton = isAnalysisMode
+  onDismiss, onSuccess, workspace, workspace: { workspace: { namespace, name: workspaceName, workspaceId } }, runtimes
 }) => {
   const [loading, setLoading] = useState(false)
+  const [azureRuntimes, setAzureRuntimes] = useState()
+  const [viewMode, setViewMode] = useState(undefined)
   const [currentRuntimeDetails, setCurrentRuntimeDetails] = useState(() => getCurrentRuntime(runtimes))
 
   //TODO: move to utils
   const defaultAzureComputeConfig = {
     machineType: defaultAzureMachineType,
-    masterDiskSize: defaultGceBootDiskSize,
-    computeZone: defaultComputeZone
+    diskSize: defaultAzureDiskSize,
+    region: defaultAzureRegion
   }
+
   const [computeConfig, setComputeConfig] = useState(defaultAzureComputeConfig)
-  const updateComputeConfig = _.curry((key, value) => setComputeConfig(_.set(key, value)))
+  const updateComputeConfig = (key, value) => setComputeConfig(_.set(key, value, computeConfig))
 
   // Lifecycle
   useOnMount(() => {
@@ -48,12 +49,13 @@ export const AzureComputeModalBase = ({
       withErrorReporting('Error loading cloud environment'),
       Utils.withBusyState(setLoading)
     )(async () => {
-      //TODO get azure runtime
       const currentRuntime = getCurrentRuntime(runtimes)
-      setCurrentRuntimeDetails(currentRuntime ? Ajax().Runtimes.runtime(currentRuntime.googleProject, currentRuntime.runtimeName).details() : null)
+      setCurrentRuntimeDetails(currentRuntime ? await Ajax().Runtimes.runtimeV2(workspaceId, currentRuntime.runtimeName).details() : null)
 
-      currentRuntime ? setComputeConfig({
-
+      setComputeConfig({
+        machineType: currentRuntimeDetails?.runtimeConfig?.machineType || defaultAzureMachineType,
+        diskSize:  currentRuntimeDetails?.diskConfig?.size || defaultAzureDiskSize,
+        region: currentRuntime?.runtimeConfig?.region || defaultAzureRegion
       })
     })
 
@@ -66,7 +68,6 @@ export const AzureComputeModalBase = ({
         id: titleId,
         style: { marginBottom: '0.5rem' },
         title: 'Azure Cloud Environment',
-        hideCloseButton: shouldHideCloseButton,
         onDismiss
       }),
       div(['A cloud environment consists of application configuration, cloud compute and persistent disk(s).'])
@@ -75,14 +76,9 @@ export const AzureComputeModalBase = ({
 
   const renderBottomButtons = () => {
     return div({ style: { display: 'flex', marginTop: '2rem' } }, [
-      !!existingRuntime && h(ButtonOutline, {
+      doesRuntimeExist() && h(ButtonOutline, {
         onClick: () => setViewMode('deleteEnvironment')
-      }, [
-        Utils.cond(
-          [!!existingRuntime, () => 'Delete Runtime'],
-          () => 'Delete Environment'
-        )
-      ]),
+      }, ['Delete Environment']),
       div({ style: { flex: 1 } }),
       renderActionButton()
     ])
@@ -90,118 +86,131 @@ export const AzureComputeModalBase = ({
 
   const renderApplicationConfigurationSection = () => {
     return div({ style: computeStyles.whiteBoxContainer }, [
-      div({ style: { marginBottom: '0.5rem' } }, [
-        label({ htmlFor: id, style: computeStyles.label }, ['Application configuration'])
+      h(IdContainer, [
+        id => h(Fragment, [
+          div({ style: { marginBottom: '1rem' } }, [
+            label({ htmlFor: id, style: computeStyles.label }, ['Application configuration']),
+            h(InfoBox, { style: { marginLeft: '0.5rem' } }, [
+              'Currently, the azure vm is pre-configured. '
+            ])
+          ]),
+          p({ style: { marginBottom: '2rem' } }, ['Azure Data Science Virtual Machine']),
+          div([
+            //TODO: add documentation
+            h(Link, { href: '', ...Utils.newTabLinkProps }, [
+              'Learn more about this Azure Data Science VMs',
+              icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })
+            ]),
+          ])
+        ])
       ])
     ])
   }
 
   const renderComputeProfileSection = () => {
-    const gridStyle = { display: 'grid', gridGap: '1.3rem', alignItems: 'center', marginTop: '1rem' }
+    console.log('compute config machine type', computeConfig)
+    console.log('currentRuntimeDetails', currentRuntimeDetails)
 
-    return div({ style: { ...computeStyles.whiteBoxContainer, marginTop: '1rem' } }, [
-      div({ style: { fontSize: '0.875rem', fontWeight: 600 } }, ['Cloud compute profile']),
-      div([
-        div({ style: { ...gridStyle, gridTemplateColumns: '0.25fr 5rem 1fr 6rem 1fr 5rem' } }, [
-          h(IdContainer, [
-            id => h(Fragment, [
-              label({ htmlFor: id, style: computeStyles.label }, ['Machine Type']),
-              div([
-                h(Select, {
-                  id,
-                  isSearchable: false,
-                  value: computeConfig.machineType,
-                  onChange: ({ value }) => {
-                    updateComputeConfig('machineType', value)
-                  },
-                  options: _.keys(azureMachineTypes)
-                })
-              ])
+    return div({ style: { ...computeStyles.whiteBoxContainer, marginTop: '1rem'} }, [
+      div({ style: { marginBottom: '2rem' } }, [
+        h(IdContainer, [
+          id => h(Fragment, [
+            div({ htmlFor: id, style: { marginBottom: '.5rem', ...computeStyles.label  } }, ['Cloud compute profile']),
+            div({ style: { width: 400 } }, [
+              h(Select, {
+                id,
+                isSearchable: false,
+                isClearable: false,
+                value: computeConfig.machineType,
+                onChange: v => updateComputeConfig('machineType', v),
+                options: _.keys(azureMachineTypes),
+                getOptionLabel: ({ value }) => getMachineTypeLabel(value),
+                styles: { width: '400' }
+              })
             ])
+          ])
+        ]),
+        div({ style: { display: 'flex', marginTop: '.5rem' } }, [
+          h(Link, { href: 'https://azure.microsoft.com/en-us/pricing/details/virtual-machines/series/', ...Utils.newTabLinkProps }, [
+            'Learn more about cloud compute profiles',
+            icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })
           ]),
         ])
-
-
+      ]),
+      div({ style: { marginBottom: '2rem' } }, [
+        h(IdContainer, [
+          id => h(Fragment, [
+            div({ htmlFor: id, style: { marginBottom: '.5rem', ...computeStyles.label  } }, ['Location']),
+            div({ style: { width: 400 } }, [
+              h(Select, {
+                id,
+                isSearchable: false,
+                isClearable: false,
+                value: computeConfig.region,
+                isDisabled: true, //this is currently locked to workspace locatio
+                onChange: v => updateComputeConfig('region', v),
+                options: _.keys(azureRegions),
+                getOptionLabel: ({ value }) => getRegionLabel(value)
+              })
+            ])
+          ])
+        ])
+      ]),
+      div({ style: { marginBottom: '2rem' } }, [
+        h(IdContainer, [
+          id => h(Fragment, [
+            div({ htmlFor: id, style: { marginBottom: '.5rem', ...computeStyles.label  } }, ['Disk Size (GB)']),
+            div({ style: { width: 75 } }, [
+              h(NumberInput, {
+                id,
+                min: 50,
+                max: 64000,
+                isClearable: false,
+                onlyInteger: true,
+                value: computeConfig.diskSize,
+                onChange: v => updateComputeConfig('diskSize', v),
+              })
+            ])
+          ])
+        ])
       ])
     ])
-    // CPU & Memory Selection
+  }
+
+  const adaptRuntimeDetailsToFormConfig = () => {
+    return currentRuntimeDetails ? {
+      machineType: currentRuntimeDetails.runtimeConfig?.machineType || defaultAzureMachineType,
+      diskSize:  currentRuntimeDetails.diskConfig?.size || defaultAzureDiskSize,
+      region: currentRuntimeDetails.runtimeConfig?.region || defaultAzureRegion
+    } : {}
   }
 
   const hasChanges = () => {
-    const existingConfig = getExistingEnvironmentConfig()
+    const existingConfig = adaptRuntimeDetailsToFormConfig()
 
     return !_.isEqual(existingConfig, computeConfig)
   }
 
-  const canUpdateRuntime = () => {
-    const { runtime: existingRuntime } = getExistingEnvironmentConfig()
-    return !(
-      !existingRuntime ||
-        computeConfig.masterDiskSize < computeConfig.masterDiskSize ||
-        computeConfig.machineType !== computeConfig.machineType
-    )
-  }
+  const doesRuntimeExist = () => !!currentRuntimeDetails
 
-  const getExistingEnvironmentConfig = () => {
-    return {
-      runtime: currentRuntimeDetails ? {
-        computeConfig
-      } : undefined
-    }
-  }
-
-
-  //TODO
   const renderActionButton = () => {
-    const { runtime: existingRuntime, hasGpu } = getExistingEnvironmentConfig()
-    const commonButtonProps = Utils.cond([
-        hasGpu && viewMode !== 'deleteEnvironment',
-        () => ({ disabled: true, tooltip: 'Cloud compute with GPU(s) cannot be updated. Please delete it and create a new one.' })
-      ], [
-        computeConfig.gpuEnabled && _.isEmpty(getValidGpuTypesForZone(computeConfig.computeZone)) && viewMode !== 'deleteEnvironmentOptions',
-        () => ({ disabled: true, tooltip: 'GPUs not available in this location.' })
-      ], [
-        !!currentPersistentDiskDetails && currentPersistentDiskDetails.zone.toUpperCase() !== computeConfig.computeZone && viewMode !==
-        'deleteEnvironment',
-        () => ({ disabled: true, tooltip: 'Cannot create environment in location differing from existing persistent disk location.' })
-      ],
-      () => ({ disabled: !hasChanges() || !!errors, tooltip: Utils.summarizeErrors(errors) })
-    )
+    const commonButtonProps = { tooltipSide: 'left',
+      disabled: Utils.cond([viewMode === 'deleteEnvironment', () => getIsRuntimeBusy(currentRuntimeDetails)],
+        () => doesRuntimeExist()),
+      tooltip: Utils.cond([viewMode === 'deleteEnvironment', () => getIsRuntimeBusy(currentRuntimeDetails) ? 'Cannot delete a runtime while it is busy' : undefined],
+        [doesRuntimeExist(), () => 'Update not supported for azure runtimes'],
+        () => undefined) }
 
-    const isRuntimeError = existingRuntime?.status === 'Error'
-    const shouldErrorDisableUpdate = existingRuntime?.toolDockerImage === desiredRuntime?.toolDockerImage
-    const isUpdateDisabled = getIsRuntimeBusy(currentRuntimeDetails) || (shouldErrorDisableUpdate && isRuntimeError)
-
-    const canShowWarning = viewMode === undefined
-    const canShowEnvironmentWarning = _.includes(viewMode, [undefined, 'customImageWarning'])
-    return Utils.cond([
-        canShowWarning && isCustomImage && existingRuntime?.toolDockerImage !== desiredRuntime?.toolDockerImage,
-        () => h(ButtonPrimary, { ...commonButtonProps, onClick: () => setViewMode('customImageWarning') }, ['Next'])
-      ], [
-        canShowEnvironmentWarning && (willDeleteBuiltinDisk() || willDeletePersistentDisk() || willRequireDowntime() || willDetachPersistentDisk()),
-        () => h(ButtonPrimary, { ...commonButtonProps, onClick: () => setViewMode('environmentWarning') }, ['Next'])
-      ], [
-        canShowWarning && isDifferentLocation(),
-        () => h(ButtonPrimary, { ...commonButtonProps, onClick: () => setViewMode('differentLocationWarning') }, ['Next'])
-      ], [
-        canShowWarning && !isUSLocation(computeConfig.computeRegion),
-        () => h(ButtonPrimary, { ...commonButtonProps, onClick: () => setViewMode('nonUSLocationWarning') }, ['Next'])
-      ],
-      () => h(ButtonPrimary, {
+    return h(ButtonPrimary, {
         ...commonButtonProps,
-        onClick: () => {
-          applyChanges()
-        },
-        disabled: isUpdateDisabled,
-        tooltipSide: 'left',
-        tooltip: isUpdateDisabled ? `Cannot perform change on environment in (${currentRuntimeDetails.status}) status` : 'Update Environment'
+        onClick: () => applyChanges(),
       }, [
         Utils.cond(
           [viewMode === 'deleteEnvironment', () => 'Delete'],
-          [existingRuntime, () => 'Update'],
+          [doesRuntimeExist(), () => 'Update'],
           () => 'Create'
         )
-      ])
+      ]
     )
   }
 
@@ -210,18 +219,36 @@ export const AzureComputeModalBase = ({
     Utils.withBusyState(setLoading),
     withErrorReportingInModal('Error modifying cloud environment', onDismiss)
   )(async () => {
-    const { runtime: existingRuntime } = getExistingEnvironmentConfig()
-    const shouldUpdateRuntime = canUpdateRuntime() && !_.isEqual(computeConfig, existingRuntime)
-    const shouldDeleteRuntime = existingRuntime && !canUpdateRuntime()
-    const shouldCreateRuntime = !canUpdateRuntime() && computeConfig
 
     //TODO: metrics onclick
-    sendCloudEnvironmentMetrics()
+    //sendCloudEnvironmentMetrics()
 
+    //each branch of the cond should return a promise
+    await Utils.cond([viewMode === 'deleteEnvironment', () => Ajax().Runtimes.runtimeV2(workspaceId, currentRuntimeDetails.runtimeName).delete() ], //delete runtime
+      [Utils.DEFAULT, () => {
+        const disk = {
+          size: computeConfig.diskSize,
+          //We do not currently support re-attaching azure disks
+          name: Utils.generatePersistentDiskName(),
+          labels: { saturnWorkspaceNamespace: namespace, saturnWorkspaceName: workspaceName }
+        }
+
+        return Ajax().Runtimes.runtimeV2(workspaceId, Utils.generateRuntimeName()).create({
+          region: computeConfig.region,
+          machineSize: computeConfig.machineType,
+          labels: {
+            saturnWorkspaceNamespace: namespace,
+            saturnWorkspaceName: workspaceName,
+          },
+          disk
+        })
+      }]
+    )
+
+    onSuccess()
   })
 
   const renderMainForm = () => {
-    const { runtime: existingRuntime } = getExistingEnvironmentConfig()
     return h(Fragment, [
       div({ style: { padding: '1.5rem', borderBottom: `1px solid ${colors.dark(0.4)}` } }, [
         renderTitleAndTagline(),
@@ -235,19 +262,72 @@ export const AzureComputeModalBase = ({
     ])
   }
 
+  //TODO this does not actually compute cost as is, see IA-3348
+  //It is possible that once we compute the cost, we would like to parameterize this and make it a shared function between the equivalent in ComputeModal
+  const renderCostBreakdown = () => {
+    return div({
+      style: {
+        backgroundColor: colors.accent(0.2),
+        display: 'flex',
+        borderRadius: 5,
+        padding: '0.5rem 1rem',
+        marginTop: '1rem'
+      }
+    }, [
+      _.map(({ cost, label, unitLabel }) => {
+        return div({ key: label, style: { flex: 1, ...computeStyles.label } }, [
+          div({ style: { fontSize: 10 } }, [label]),
+          div({ style: { color: colors.accent(1.1), marginTop: '0.25rem' } }, [
+            span({ style: { fontSize: 20 } }, [cost]),
+            span([' ', unitLabel])
+          ])
+        ])
+      }, [
+        { label: 'Running cloud compute cost', cost: Utils.formatUSD(0), unitLabel: 'per hr' },
+        { label: 'Paused cloud compute cost', cost: Utils.formatUSD(0), unitLabel: 'per hr' },
+        {
+          label: 'Persistent disk cost',
+          cost: Utils.formatUSD(0),
+          unitLabel: 'per month'
+        }
+      ])
+    ])
+  }
+
+  const renderDeleteEnvironment = () => {
+    return div({ style: { ...computeStyles.drawerContent, ...computeStyles.warningView } }, [
+      h(TitleBar, {
+        id: titleId,
+        style: computeStyles.titleBar,
+        title: h(WarningTitle, ['Delete environment']),
+        onDismiss,
+        onPrevious: () => {
+          setViewMode(undefined)
+        }
+      }),
+      div({ style: { lineHeight: '1.5rem' } }, [
+        p([
+          'Deleting your application configuration and cloud compute profile will also ',
+          span({ style: { fontWeight: 600 } }, ['delete all files on the built-in hard disk.'])
+        ])
+      ]),
+      div({ style: { display: 'flex', justifyContent: 'flex-end', marginTop: '1rem' } }, [
+        renderActionButton()
+      ])
+    ])
+  }
+
   return h(Fragment, [
     Utils.switchCase(viewMode,
       ['deleteEnvironment', renderDeleteEnvironment],
       [Utils.DEFAULT, renderMainForm]
-    )
+    ),
     loading && spinnerOverlay
   ])
 
 
 }
 
-
-
 export const AzureComputeModal = withModalDrawer({ width: 675, 'aria-labelledby': titleId })(
-  ComputeModalBase
+  AzureComputeModalBase
 )

--- a/src/pages/workspaces/workspace/analysis/AzureComputeModal.js
+++ b/src/pages/workspaces/workspace/analysis/AzureComputeModal.js
@@ -1,0 +1,253 @@
+import { ButtonOutline, ButtonPrimary, IdContainer, Select, spinnerOverlay } from 'src/components/common'
+import { ComputeModalBase } from 'src/components/ComputeModal'
+import { withModalDrawer } from 'src/components/ModalDrawer'
+import { isUSLocation } from 'src/components/region-common'
+import TitleBar from 'src/components/TitleBar'
+import { Fragment, useState } from 'react'
+import { Ajax } from 'src/libs/ajax'
+import colors from 'src/libs/colors'
+import { withErrorReporting, withErrorReportingInModal } from 'src/libs/error'
+import { useOnMount } from 'src/libs/react-utils'
+import {
+  azureMachineTypes,
+  computeStyles, defaultAutopauseThreshold, defaultAzureMachineType, defaultComputeRegion, defaultComputeZone, defaultDataprocMachineType,
+  defaultDataprocWorkerDiskSize,
+  defaultGceBootDiskSize,
+  defaultGceMachineType,
+  defaultGcePersistentDiskSize, defaultGpuType,
+  defaultNumDataprocPreemptibleWorkers,
+  defaultNumDataprocWorkers, defaultNumGpus, getCurrentRuntime, getIsRuntimeBusy, getValidGpuTypesForZone, renderCostBreakdown
+} from 'src/libs/runtime-utils'
+import { div, h, label } from 'react-hyperscript-helpers'
+import * as Utils from 'src/libs/utils'
+
+
+// Change to true to enable a debugging panel (intended for dev mode only)
+const showDebugPanel = false
+const titleId = 'azure-compute-modal-title'
+
+export const AzureComputeModalBase = ({
+  onDismiss, onSuccess, runtimes, workspace, workspace: { workspace: { namespace, name: workspaceName, workspaceId } }, location, isAnalysisMode = false, shouldHideCloseButton = isAnalysisMode
+}) => {
+  const [loading, setLoading] = useState(false)
+  const [currentRuntimeDetails, setCurrentRuntimeDetails] = useState(() => getCurrentRuntime(runtimes))
+
+  //TODO: move to utils
+  const defaultAzureComputeConfig = {
+    machineType: defaultAzureMachineType,
+    masterDiskSize: defaultGceBootDiskSize,
+    computeZone: defaultComputeZone
+  }
+  const [computeConfig, setComputeConfig] = useState(defaultAzureComputeConfig)
+  const updateComputeConfig = _.curry((key, value) => setComputeConfig(_.set(key, value)))
+
+  // Lifecycle
+  useOnMount(() => {
+    // Can't pass an async function into useEffect so we define the function in the body and then call it
+    const doUseOnMount = _.flow(
+      withErrorReporting('Error loading cloud environment'),
+      Utils.withBusyState(setLoading)
+    )(async () => {
+      //TODO get azure runtime
+      const currentRuntime = getCurrentRuntime(runtimes)
+      setCurrentRuntimeDetails(currentRuntime ? Ajax().Runtimes.runtime(currentRuntime.googleProject, currentRuntime.runtimeName).details() : null)
+
+      currentRuntime ? setComputeConfig({
+
+      })
+    })
+
+    doUseOnMount()
+  })
+
+  const renderTitleAndTagline = () => {
+    return h(Fragment, [
+      h(TitleBar, {
+        id: titleId,
+        style: { marginBottom: '0.5rem' },
+        title: 'Azure Cloud Environment',
+        hideCloseButton: shouldHideCloseButton,
+        onDismiss
+      }),
+      div(['A cloud environment consists of application configuration, cloud compute and persistent disk(s).'])
+    ])
+  }
+
+  const renderBottomButtons = () => {
+    return div({ style: { display: 'flex', marginTop: '2rem' } }, [
+      !!existingRuntime && h(ButtonOutline, {
+        onClick: () => setViewMode('deleteEnvironment')
+      }, [
+        Utils.cond(
+          [!!existingRuntime, () => 'Delete Runtime'],
+          () => 'Delete Environment'
+        )
+      ]),
+      div({ style: { flex: 1 } }),
+      renderActionButton()
+    ])
+  }
+
+  const renderApplicationConfigurationSection = () => {
+    return div({ style: computeStyles.whiteBoxContainer }, [
+      div({ style: { marginBottom: '0.5rem' } }, [
+        label({ htmlFor: id, style: computeStyles.label }, ['Application configuration'])
+      ])
+    ])
+  }
+
+  const renderComputeProfileSection = () => {
+    const gridStyle = { display: 'grid', gridGap: '1.3rem', alignItems: 'center', marginTop: '1rem' }
+
+    return div({ style: { ...computeStyles.whiteBoxContainer, marginTop: '1rem' } }, [
+      div({ style: { fontSize: '0.875rem', fontWeight: 600 } }, ['Cloud compute profile']),
+      div([
+        div({ style: { ...gridStyle, gridTemplateColumns: '0.25fr 5rem 1fr 6rem 1fr 5rem' } }, [
+          h(IdContainer, [
+            id => h(Fragment, [
+              label({ htmlFor: id, style: computeStyles.label }, ['Machine Type']),
+              div([
+                h(Select, {
+                  id,
+                  isSearchable: false,
+                  value: computeConfig.machineType,
+                  onChange: ({ value }) => {
+                    updateComputeConfig('machineType', value)
+                  },
+                  options: _.keys(azureMachineTypes)
+                })
+              ])
+            ])
+          ]),
+        ])
+
+
+      ])
+    ])
+    // CPU & Memory Selection
+  }
+
+  const hasChanges = () => {
+    const existingConfig = getExistingEnvironmentConfig()
+
+    return !_.isEqual(existingConfig, computeConfig)
+  }
+
+  const canUpdateRuntime = () => {
+    const { runtime: existingRuntime } = getExistingEnvironmentConfig()
+    return !(
+      !existingRuntime ||
+        computeConfig.masterDiskSize < computeConfig.masterDiskSize ||
+        computeConfig.machineType !== computeConfig.machineType
+    )
+  }
+
+  const getExistingEnvironmentConfig = () => {
+    return {
+      runtime: currentRuntimeDetails ? {
+        computeConfig
+      } : undefined
+    }
+  }
+
+
+  //TODO
+  const renderActionButton = () => {
+    const { runtime: existingRuntime, hasGpu } = getExistingEnvironmentConfig()
+    const commonButtonProps = Utils.cond([
+        hasGpu && viewMode !== 'deleteEnvironment',
+        () => ({ disabled: true, tooltip: 'Cloud compute with GPU(s) cannot be updated. Please delete it and create a new one.' })
+      ], [
+        computeConfig.gpuEnabled && _.isEmpty(getValidGpuTypesForZone(computeConfig.computeZone)) && viewMode !== 'deleteEnvironmentOptions',
+        () => ({ disabled: true, tooltip: 'GPUs not available in this location.' })
+      ], [
+        !!currentPersistentDiskDetails && currentPersistentDiskDetails.zone.toUpperCase() !== computeConfig.computeZone && viewMode !==
+        'deleteEnvironment',
+        () => ({ disabled: true, tooltip: 'Cannot create environment in location differing from existing persistent disk location.' })
+      ],
+      () => ({ disabled: !hasChanges() || !!errors, tooltip: Utils.summarizeErrors(errors) })
+    )
+
+    const isRuntimeError = existingRuntime?.status === 'Error'
+    const shouldErrorDisableUpdate = existingRuntime?.toolDockerImage === desiredRuntime?.toolDockerImage
+    const isUpdateDisabled = getIsRuntimeBusy(currentRuntimeDetails) || (shouldErrorDisableUpdate && isRuntimeError)
+
+    const canShowWarning = viewMode === undefined
+    const canShowEnvironmentWarning = _.includes(viewMode, [undefined, 'customImageWarning'])
+    return Utils.cond([
+        canShowWarning && isCustomImage && existingRuntime?.toolDockerImage !== desiredRuntime?.toolDockerImage,
+        () => h(ButtonPrimary, { ...commonButtonProps, onClick: () => setViewMode('customImageWarning') }, ['Next'])
+      ], [
+        canShowEnvironmentWarning && (willDeleteBuiltinDisk() || willDeletePersistentDisk() || willRequireDowntime() || willDetachPersistentDisk()),
+        () => h(ButtonPrimary, { ...commonButtonProps, onClick: () => setViewMode('environmentWarning') }, ['Next'])
+      ], [
+        canShowWarning && isDifferentLocation(),
+        () => h(ButtonPrimary, { ...commonButtonProps, onClick: () => setViewMode('differentLocationWarning') }, ['Next'])
+      ], [
+        canShowWarning && !isUSLocation(computeConfig.computeRegion),
+        () => h(ButtonPrimary, { ...commonButtonProps, onClick: () => setViewMode('nonUSLocationWarning') }, ['Next'])
+      ],
+      () => h(ButtonPrimary, {
+        ...commonButtonProps,
+        onClick: () => {
+          applyChanges()
+        },
+        disabled: isUpdateDisabled,
+        tooltipSide: 'left',
+        tooltip: isUpdateDisabled ? `Cannot perform change on environment in (${currentRuntimeDetails.status}) status` : 'Update Environment'
+      }, [
+        Utils.cond(
+          [viewMode === 'deleteEnvironment', () => 'Delete'],
+          [existingRuntime, () => 'Update'],
+          () => 'Create'
+        )
+      ])
+    )
+  }
+
+  // Helper functions -- begin
+  const applyChanges = _.flow(
+    Utils.withBusyState(setLoading),
+    withErrorReportingInModal('Error modifying cloud environment', onDismiss)
+  )(async () => {
+    const { runtime: existingRuntime } = getExistingEnvironmentConfig()
+    const shouldUpdateRuntime = canUpdateRuntime() && !_.isEqual(computeConfig, existingRuntime)
+    const shouldDeleteRuntime = existingRuntime && !canUpdateRuntime()
+    const shouldCreateRuntime = !canUpdateRuntime() && computeConfig
+
+    //TODO: metrics onclick
+    sendCloudEnvironmentMetrics()
+
+  })
+
+  const renderMainForm = () => {
+    const { runtime: existingRuntime } = getExistingEnvironmentConfig()
+    return h(Fragment, [
+      div({ style: { padding: '1.5rem', borderBottom: `1px solid ${colors.dark(0.4)}` } }, [
+        renderTitleAndTagline(),
+        renderCostBreakdown()
+      ]),
+      div({ style: { padding: '1.5rem', overflowY: 'auto', flex: 'auto' } }, [
+        renderApplicationConfigurationSection(),
+        renderComputeProfileSection(),
+        renderBottomButtons()
+      ])
+    ])
+  }
+
+  return h(Fragment, [
+    Utils.switchCase(viewMode,
+      ['deleteEnvironment', renderDeleteEnvironment],
+      [Utils.DEFAULT, renderMainForm]
+    )
+    loading && spinnerOverlay
+  ])
+
+
+}
+
+
+
+export const AzureComputeModal = withModalDrawer({ width: 675, 'aria-labelledby': titleId })(
+  ComputeModalBase
+)

--- a/src/pages/workspaces/workspace/analysis/AzureComputeModal.js
+++ b/src/pages/workspaces/workspace/analysis/AzureComputeModal.js
@@ -25,14 +25,14 @@ import * as Utils from 'src/libs/utils'
 const titleId = 'azure-compute-modal-title'
 
 export const AzureComputeModalBase = ({
-  onDismiss, onSuccess, workspace: { workspace: { namespace, name: workspaceName, workspaceId } }, runtimes
+  onDismiss, onSuccess, workspace: { workspace: { namespace, name: workspaceName, workspaceId } }, runtimes, shouldHideCloseButton = false
 }) => {
   const [loading, setLoading] = useState(false)
   const [viewMode, setViewMode] = useState(undefined)
   const [currentRuntimeDetails, setCurrentRuntimeDetails] = useState(() => getCurrentRuntime(runtimes))
 
-  //TODO: revert before merging
-  var workspaceId = '1aa85f64-5717-4562-b3fc-2c963f66afa6'
+  // //TODO: revert before merging
+  // var workspaceId = '1aa85f64-5717-4562-b3fc-2c963f66afa6'
 
   const [computeConfig, setComputeConfig] = useState(defaultAzureComputeConfig)
   const updateComputeConfig = (key, value) => setComputeConfig(_.set(key, value, computeConfig))
@@ -61,6 +61,7 @@ export const AzureComputeModalBase = ({
     return h(Fragment, [
       h(TitleBar, {
         id: titleId,
+        shouldHideCloseButton,
         style: { marginBottom: '0.5rem' },
         title: 'Azure Cloud Environment',
         onDismiss
@@ -89,7 +90,7 @@ export const AzureComputeModalBase = ({
               'Currently, the azure vm is pre-configured. '
             ])
           ]),
-          p({ style: { marginBottom: '2rem' } }, ['Azure Data Science Virtual Machine']),
+          p({ style: { marginBottom: '1.5rem' } }, ['Azure Data Science Virtual Machine']),
           div([
             h(Link, { href: 'https://azure.microsoft.com/en-us/services/virtual-machines/data-science-virtual-machines/#product-overview', ...Utils.newTabLinkProps }, [
               'Learn more about this Azure Data Science VMs',
@@ -102,11 +103,13 @@ export const AzureComputeModalBase = ({
   }
 
   const renderComputeProfileSection = () => {
-    return div({ style: { ...computeStyles.whiteBoxContainer, marginTop: '1rem' } }, [
+    return div({ style: { ...computeStyles.whiteBoxContainer, marginTop: '1.5rem' } }, [
       div({ style: { marginBottom: '2rem' } }, [
         h(IdContainer, [
           id => h(Fragment, [
-            div({ htmlFor: id, style: { marginBottom: '.5rem', ...computeStyles.label } }, ['Cloud compute profile']),
+            div({ style: { marginBottom: '1rem' } }, [
+              label({ htmlFor: id, style: computeStyles.label }, ['Cloud compute profile'])
+            ]),
             div({ style: { width: 400 } }, [
               h(Select, {
                 id,
@@ -131,7 +134,9 @@ export const AzureComputeModalBase = ({
       div({ style: { marginBottom: '2rem' } }, [
         h(IdContainer, [
           id => h(Fragment, [
-            div({ htmlFor: id, style: { marginBottom: '.5rem', ...computeStyles.label } }, ['Location']),
+            div({ style: { marginBottom: '.5rem' } }, [
+              label({ htmlFor: id, style: computeStyles.label }, ['Location'])
+            ]),
             div({ style: { width: 400 } }, [
               h(Select, {
                 id,
@@ -150,7 +155,9 @@ export const AzureComputeModalBase = ({
       div({ style: { marginBottom: '2rem' } }, [
         h(IdContainer, [
           id => h(Fragment, [
-            div({ htmlFor: id, style: { marginBottom: '.5rem', ...computeStyles.label } }, ['Disk Size (GB)']),
+            div({ style: { marginBottom: '.5rem' } }, [
+              label({ htmlFor: id, style: computeStyles.label }, ['Disk Size (GB)'])
+            ]),
             div({ style: { width: 75 } }, [
               h(NumberInput, {
                 id,
@@ -217,8 +224,8 @@ export const AzureComputeModalBase = ({
     //sendCloudEnvironmentMetrics()
 
     //each branch of the cond should return a promise
-    await Utils.cond([viewMode === 'deleteEnvironment', () => Ajax().Runtimes.runtimeV2(workspaceId, currentRuntimeDetails.runtimeName).delete()], //delete runtime
-      [Utils.DEFAULT, () => {
+    await Utils.cond([viewMode === 'deleteEnvironment', async () => await Ajax().Runtimes.runtimeV2(workspaceId, currentRuntimeDetails.runtimeName).delete()], //delete runtime
+      [Utils.DEFAULT, async () => {
         const disk = {
           size: computeConfig.diskSize,
           //We do not currently support re-attaching azure disks
@@ -226,7 +233,7 @@ export const AzureComputeModalBase = ({
           labels: { saturnWorkspaceNamespace: namespace, saturnWorkspaceName: workspaceName }
         }
 
-        return Ajax().Runtimes.runtimeV2(workspaceId, Utils.generateRuntimeName()).create({
+        await Ajax().Runtimes.runtimeV2(workspaceId, Utils.generateRuntimeName()).create({
           region: computeConfig.region,
           machineSize: computeConfig.machineType,
           labels: {
@@ -291,6 +298,7 @@ export const AzureComputeModalBase = ({
     return div({ style: { ...computeStyles.drawerContent, ...computeStyles.warningView } }, [
       h(TitleBar, {
         id: titleId,
+        shouldHideCloseButton,
         style: computeStyles.titleBar,
         title: h(WarningTitle, ['Delete environment']),
         onDismiss,

--- a/src/pages/workspaces/workspace/analysis/AzureComputeModal.js
+++ b/src/pages/workspaces/workspace/analysis/AzureComputeModal.js
@@ -24,7 +24,7 @@ import * as Utils from 'src/libs/utils'
 const titleId = 'azure-compute-modal-title'
 
 export const AzureComputeModalBase = ({
-  onDismiss, onSuccess, workspace: { workspace: { namespace, name: workspaceName, workspaceId } }, runtimes, shouldHideCloseButton = false
+  onDismiss, onSuccess, workspace: { workspace: { namespace, name: workspaceName, workspaceId } }, runtimes, hideCloseButton = false
 }) => {
   const [loading, setLoading] = useState(false)
   const [viewMode, setViewMode] = useState(undefined)
@@ -52,7 +52,7 @@ export const AzureComputeModalBase = ({
     return h(Fragment, [
       h(TitleBar, {
         id: titleId,
-        shouldHideCloseButton,
+        hideCloseButton,
         style: { marginBottom: '0.5rem' },
         title: 'Azure Cloud Environment',
         onDismiss
@@ -78,7 +78,7 @@ export const AzureComputeModalBase = ({
           div({ style: { marginBottom: '1rem' } }, [
             label({ htmlFor: id, style: computeStyles.label }, ['Application configuration']),
             h(InfoBox, { style: { marginLeft: '0.5rem' } }, [
-              'Currently, the azure vm is pre-configured. '
+              'Currently, the Azure VM is pre-configured. '
             ])
           ]),
           p({ style: { marginBottom: '1.5rem' } }, ['Azure Data Science Virtual Machine']),
@@ -292,7 +292,7 @@ export const AzureComputeModalBase = ({
     return div({ style: { ...computeStyles.drawerContent, ...computeStyles.warningView } }, [
       h(TitleBar, {
         id: titleId,
-        shouldHideCloseButton,
+        hideCloseButton,
         style: computeStyles.titleBar,
         title: h(WarningTitle, ['Delete environment']),
         onDismiss,

--- a/src/pages/workspaces/workspace/analysis/AzureComputeModal.js
+++ b/src/pages/workspaces/workspace/analysis/AzureComputeModal.js
@@ -1,13 +1,13 @@
 import _ from 'lodash/fp'
+import { Fragment, useState } from 'react'
+import { div, h, label, p, span } from 'react-hyperscript-helpers'
 import { ButtonOutline, ButtonPrimary, IdContainer, Link, Select, spinnerOverlay, WarningTitle } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import { NumberInput } from 'src/components/input'
 import { withModalDrawer } from 'src/components/ModalDrawer'
-import { div, p, span, h, label } from 'react-hyperscript-helpers'
 import { tools } from 'src/components/notebook-utils'
 import { InfoBox } from 'src/components/PopupTrigger'
 import TitleBar from 'src/components/TitleBar'
-import { Fragment, useState } from 'react'
 import { Ajax } from 'src/libs/ajax'
 import {
   azureMachineTypes, azureRegions, defaultAzureDiskSize, defaultAzureMachineType, defaultAzureRegion, getMachineTypeLabel, getRegionLabel
@@ -32,6 +32,8 @@ export const AzureComputeModalBase = ({
   const [viewMode, setViewMode] = useState(undefined)
   const [currentRuntimeDetails, setCurrentRuntimeDetails] = useState(() => getCurrentRuntime(runtimes))
 
+  //TODO: revert before merging
+  var workspaceId = '1aa85f64-5717-4562-b3fc-2c963f66afa6'
   //TODO: move to utils
   const defaultAzureComputeConfig = {
     machineType: defaultAzureMachineType,
@@ -54,7 +56,7 @@ export const AzureComputeModalBase = ({
 
       setComputeConfig({
         machineType: currentRuntimeDetails?.runtimeConfig?.machineType || defaultAzureMachineType,
-        diskSize:  currentRuntimeDetails?.diskConfig?.size || defaultAzureDiskSize,
+        diskSize: currentRuntimeDetails?.diskConfig?.size || defaultAzureDiskSize,
         region: currentRuntime?.runtimeConfig?.region || defaultAzureRegion
       })
     })
@@ -96,11 +98,10 @@ export const AzureComputeModalBase = ({
           ]),
           p({ style: { marginBottom: '2rem' } }, ['Azure Data Science Virtual Machine']),
           div([
-            //TODO: add documentation
-            h(Link, { href: '', ...Utils.newTabLinkProps }, [
+            h(Link, { href: 'https://azure.microsoft.com/en-us/services/virtual-machines/data-science-virtual-machines/#product-overview', ...Utils.newTabLinkProps }, [
               'Learn more about this Azure Data Science VMs',
               icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })
-            ]),
+            ])
           ])
         ])
       ])
@@ -111,18 +112,18 @@ export const AzureComputeModalBase = ({
     console.log('compute config machine type', computeConfig)
     console.log('currentRuntimeDetails', currentRuntimeDetails)
 
-    return div({ style: { ...computeStyles.whiteBoxContainer, marginTop: '1rem'} }, [
+    return div({ style: { ...computeStyles.whiteBoxContainer, marginTop: '1rem' } }, [
       div({ style: { marginBottom: '2rem' } }, [
         h(IdContainer, [
           id => h(Fragment, [
-            div({ htmlFor: id, style: { marginBottom: '.5rem', ...computeStyles.label  } }, ['Cloud compute profile']),
+            div({ htmlFor: id, style: { marginBottom: '.5rem', ...computeStyles.label } }, ['Cloud compute profile']),
             div({ style: { width: 400 } }, [
               h(Select, {
                 id,
                 isSearchable: false,
                 isClearable: false,
                 value: computeConfig.machineType,
-                onChange: v => updateComputeConfig('machineType', v),
+                onChange: ({ value }) => updateComputeConfig('machineType', value),
                 options: _.keys(azureMachineTypes),
                 getOptionLabel: ({ value }) => getMachineTypeLabel(value),
                 styles: { width: '400' }
@@ -134,21 +135,21 @@ export const AzureComputeModalBase = ({
           h(Link, { href: 'https://azure.microsoft.com/en-us/pricing/details/virtual-machines/series/', ...Utils.newTabLinkProps }, [
             'Learn more about cloud compute profiles',
             icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })
-          ]),
+          ])
         ])
       ]),
       div({ style: { marginBottom: '2rem' } }, [
         h(IdContainer, [
           id => h(Fragment, [
-            div({ htmlFor: id, style: { marginBottom: '.5rem', ...computeStyles.label  } }, ['Location']),
+            div({ htmlFor: id, style: { marginBottom: '.5rem', ...computeStyles.label } }, ['Location']),
             div({ style: { width: 400 } }, [
               h(Select, {
                 id,
                 isSearchable: false,
                 isClearable: false,
                 value: computeConfig.region,
-                isDisabled: true, //this is currently locked to workspace locatio
-                onChange: v => updateComputeConfig('region', v),
+                isDisabled: true, //this is currently locked to workspace location
+                onChange: ({ value }) => updateComputeConfig('region', value),
                 options: _.keys(azureRegions),
                 getOptionLabel: ({ value }) => getRegionLabel(value)
               })
@@ -159,7 +160,7 @@ export const AzureComputeModalBase = ({
       div({ style: { marginBottom: '2rem' } }, [
         h(IdContainer, [
           id => h(Fragment, [
-            div({ htmlFor: id, style: { marginBottom: '.5rem', ...computeStyles.label  } }, ['Disk Size (GB)']),
+            div({ htmlFor: id, style: { marginBottom: '.5rem', ...computeStyles.label } }, ['Disk Size (GB)']),
             div({ style: { width: 75 } }, [
               h(NumberInput, {
                 id,
@@ -168,7 +169,7 @@ export const AzureComputeModalBase = ({
                 isClearable: false,
                 onlyInteger: true,
                 value: computeConfig.diskSize,
-                onChange: v => updateComputeConfig('diskSize', v),
+                onChange: v => updateComputeConfig('diskSize', v)
               })
             ])
           ])
@@ -180,7 +181,7 @@ export const AzureComputeModalBase = ({
   const adaptRuntimeDetailsToFormConfig = () => {
     return currentRuntimeDetails ? {
       machineType: currentRuntimeDetails.runtimeConfig?.machineType || defaultAzureMachineType,
-      diskSize:  currentRuntimeDetails.diskConfig?.size || defaultAzureDiskSize,
+      diskSize: currentRuntimeDetails.diskConfig?.size || defaultAzureDiskSize,
       region: currentRuntimeDetails.runtimeConfig?.region || defaultAzureRegion
     } : {}
   }
@@ -194,23 +195,25 @@ export const AzureComputeModalBase = ({
   const doesRuntimeExist = () => !!currentRuntimeDetails
 
   const renderActionButton = () => {
-    const commonButtonProps = { tooltipSide: 'left',
+    const commonButtonProps = {
+      tooltipSide: 'left',
       disabled: Utils.cond([viewMode === 'deleteEnvironment', () => getIsRuntimeBusy(currentRuntimeDetails)],
         () => doesRuntimeExist()),
       tooltip: Utils.cond([viewMode === 'deleteEnvironment', () => getIsRuntimeBusy(currentRuntimeDetails) ? 'Cannot delete a runtime while it is busy' : undefined],
         [doesRuntimeExist(), () => 'Update not supported for azure runtimes'],
-        () => undefined) }
+        () => undefined)
+    }
 
     return h(ButtonPrimary, {
-        ...commonButtonProps,
-        onClick: () => applyChanges(),
-      }, [
-        Utils.cond(
-          [viewMode === 'deleteEnvironment', () => 'Delete'],
-          [doesRuntimeExist(), () => 'Update'],
-          () => 'Create'
-        )
-      ]
+      ...commonButtonProps,
+      onClick: () => applyChanges()
+    }, [
+      Utils.cond(
+        [viewMode === 'deleteEnvironment', () => 'Delete'],
+        [doesRuntimeExist(), () => 'Update'],
+        () => 'Create'
+      )
+    ]
     )
   }
 
@@ -219,12 +222,11 @@ export const AzureComputeModalBase = ({
     Utils.withBusyState(setLoading),
     withErrorReportingInModal('Error modifying cloud environment', onDismiss)
   )(async () => {
-
     //TODO: metrics onclick
     //sendCloudEnvironmentMetrics()
 
     //each branch of the cond should return a promise
-    await Utils.cond([viewMode === 'deleteEnvironment', () => Ajax().Runtimes.runtimeV2(workspaceId, currentRuntimeDetails.runtimeName).delete() ], //delete runtime
+    await Utils.cond([viewMode === 'deleteEnvironment', () => Ajax().Runtimes.runtimeV2(workspaceId, currentRuntimeDetails.runtimeName).delete()], //delete runtime
       [Utils.DEFAULT, () => {
         const disk = {
           size: computeConfig.diskSize,
@@ -238,7 +240,7 @@ export const AzureComputeModalBase = ({
           machineSize: computeConfig.machineType,
           labels: {
             saturnWorkspaceNamespace: namespace,
-            saturnWorkspaceName: workspaceName,
+            saturnWorkspaceName: workspaceName
           },
           disk
         })
@@ -324,8 +326,6 @@ export const AzureComputeModalBase = ({
     ),
     loading && spinnerOverlay
   ])
-
-
 }
 
 export const AzureComputeModal = withModalDrawer({ width: 675, 'aria-labelledby': titleId })(

--- a/src/pages/workspaces/workspace/analysis/AzureComputeModal.js
+++ b/src/pages/workspaces/workspace/analysis/AzureComputeModal.js
@@ -5,12 +5,12 @@ import { ButtonOutline, ButtonPrimary, IdContainer, Link, Select, spinnerOverlay
 import { icon } from 'src/components/icons'
 import { NumberInput } from 'src/components/input'
 import { withModalDrawer } from 'src/components/ModalDrawer'
-import { tools } from 'src/components/notebook-utils'
 import { InfoBox } from 'src/components/PopupTrigger'
 import TitleBar from 'src/components/TitleBar'
 import { Ajax } from 'src/libs/ajax'
 import {
-  azureMachineTypes, azureRegions, defaultAzureDiskSize, defaultAzureMachineType, defaultAzureRegion, getMachineTypeLabel, getRegionLabel
+  azureMachineTypes, azureRegions, defaultAzureComputeConfig, defaultAzureDiskSize, defaultAzureMachineType, defaultAzureRegion, getMachineTypeLabel,
+  getRegionLabel
 } from 'src/libs/azure-utils'
 import colors from 'src/libs/colors'
 import { withErrorReporting, withErrorReportingInModal } from 'src/libs/error'
@@ -25,21 +25,14 @@ import * as Utils from 'src/libs/utils'
 const titleId = 'azure-compute-modal-title'
 
 export const AzureComputeModalBase = ({
-  onDismiss, onSuccess, workspace, workspace: { workspace: { namespace, name: workspaceName, workspaceId } }, runtimes
+  onDismiss, onSuccess, workspace: { workspace: { namespace, name: workspaceName, workspaceId } }, runtimes
 }) => {
   const [loading, setLoading] = useState(false)
-  const [azureRuntimes, setAzureRuntimes] = useState()
   const [viewMode, setViewMode] = useState(undefined)
   const [currentRuntimeDetails, setCurrentRuntimeDetails] = useState(() => getCurrentRuntime(runtimes))
 
   //TODO: revert before merging
   var workspaceId = '1aa85f64-5717-4562-b3fc-2c963f66afa6'
-  //TODO: move to utils
-  const defaultAzureComputeConfig = {
-    machineType: defaultAzureMachineType,
-    diskSize: defaultAzureDiskSize,
-    region: defaultAzureRegion
-  }
 
   const [computeConfig, setComputeConfig] = useState(defaultAzureComputeConfig)
   const updateComputeConfig = (key, value) => setComputeConfig(_.set(key, value, computeConfig))
@@ -109,9 +102,6 @@ export const AzureComputeModalBase = ({
   }
 
   const renderComputeProfileSection = () => {
-    console.log('compute config machine type', computeConfig)
-    console.log('currentRuntimeDetails', currentRuntimeDetails)
-
     return div({ style: { ...computeStyles.whiteBoxContainer, marginTop: '1rem' } }, [
       div({ style: { marginBottom: '2rem' } }, [
         h(IdContainer, [
@@ -178,19 +168,20 @@ export const AzureComputeModalBase = ({
     ])
   }
 
-  const adaptRuntimeDetailsToFormConfig = () => {
-    return currentRuntimeDetails ? {
-      machineType: currentRuntimeDetails.runtimeConfig?.machineType || defaultAzureMachineType,
-      diskSize: currentRuntimeDetails.diskConfig?.size || defaultAzureDiskSize,
-      region: currentRuntimeDetails.runtimeConfig?.region || defaultAzureRegion
-    } : {}
-  }
-
-  const hasChanges = () => {
-    const existingConfig = adaptRuntimeDetailsToFormConfig()
-
-    return !_.isEqual(existingConfig, computeConfig)
-  }
+  // Will be used once we support update
+  // const hasChanges = () => {
+  //   const existingConfig = adaptRuntimeDetailsToFormConfig()
+  //
+  //   return !_.isEqual(existingConfig, computeConfig)
+  // }
+  //
+  // const adaptRuntimeDetailsToFormConfig = () => {
+  //   return currentRuntimeDetails ? {
+  //     machineType: currentRuntimeDetails.runtimeConfig?.machineType || defaultAzureMachineType,
+  //     diskSize: currentRuntimeDetails.diskConfig?.size || defaultAzureDiskSize,
+  //     region: currentRuntimeDetails.runtimeConfig?.region || defaultAzureRegion
+  //   } : {}
+  // }
 
   const doesRuntimeExist = () => !!currentRuntimeDetails
 

--- a/src/pages/workspaces/workspace/applications/AppLauncher.js
+++ b/src/pages/workspaces/workspace/applications/AppLauncher.js
@@ -180,7 +180,7 @@ const ApplicationLauncher = _.flow(
       setLocation(location)
     })
 
-    loadBucketLocation()
+    !!googleProject && loadBucketLocation()
 
     if (shouldSetupWelder && runtimeStatus === 'Running') {
       setupWelder()
@@ -193,10 +193,10 @@ const ApplicationLauncher = _.flow(
       !_.isEmpty(outdatedRAnalyses) && setFileOutdatedOpen(true)
     })
 
-    findOutdatedAnalyses()
+    !!googleProject && findOutdatedAnalyses()
 
     // periodically check for outdated R analyses
-    interval.current = setInterval(findOutdatedAnalyses, 10000)
+    interval.current = !!googleProject && setInterval(findOutdatedAnalyses, 10000)
 
     return () => {
       clearInterval(interval.current)

--- a/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
+++ b/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
@@ -97,7 +97,7 @@ export const CloudEnvironmentModal = ({
   })
 
   const renderDefaultPage = () => div({ style: { display: 'flex', flexDirection: 'column', flex: 1 } },
-    _.map(tool => renderToolButtons(tool.label))(filterForTool ? [tools[filterForTool]] : getToolsToDisplay(!!azureContext))
+    _.map(tool => renderToolButtons(tool.label))(filterForTool ? [tools[filterForTool]] : getToolsToDisplay(azureContext))
   )
 
   const toolPanelStyles = {

--- a/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
+++ b/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
@@ -68,7 +68,7 @@ export const CloudEnvironmentModal = ({
 
   const renderAzureModal = () => h(AzureComputeModalBase, {
     isOpen: viewMode === NEW_AZURE_MODE,
-    shouldHideCloseButton: true,
+    hideCloseButton: true,
     workspace,
     runtimes,
     onDismiss: () => {
@@ -306,7 +306,7 @@ export const CloudEnvironmentModal = ({
     const isToolBusy = isToolAnApp(toolLabel) ?
       getIsAppBusy(app) || app?.status === 'STOPPED' || app?.status === 'ERROR' :
       currentRuntime?.status === 'Error'
-    const isDisabled = !doesCloudEnvForToolExist || !cookieReady || !canCompute || busy || isToolBusy || isLaunchSupported(toolLabel)
+    const isDisabled = !doesCloudEnvForToolExist || !cookieReady || !canCompute || busy || isToolBusy || !isLaunchSupported(toolLabel)
     const baseProps = {
       'aria-label': `Launch ${toolLabel}`,
       disabled: isDisabled,

--- a/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
+++ b/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
@@ -35,7 +35,7 @@ const titleId = 'cloud-env-modal'
 
 export const CloudEnvironmentModal = ({
   isOpen, onSuccess, onDismiss, canCompute, runtimes, apps, appDataDisks, refreshRuntimes, refreshApps,
-  workspace, persistentDisks, location, locationType, workspace: { workspace: { namespace, name: workspaceName, azureContext } },
+  workspace, persistentDisks, location, locationType, workspace: { azureContext, workspace: { namespace, name: workspaceName } },
   filterForTool = undefined
 }) => {
   const [viewMode, setViewMode] = useState(undefined)
@@ -97,7 +97,7 @@ export const CloudEnvironmentModal = ({
   })
 
   const renderDefaultPage = () => div({ style: { display: 'flex', flexDirection: 'column', flex: 1 } },
-    _.map(tool => renderToolButtons(tool.label))(filterForTool ? [tools[filterForTool]] : getToolsToDisplay(azureContext))
+    _.map(tool => renderToolButtons(tool.label))(filterForTool ? [tools[filterForTool]] : getToolsToDisplay(!!azureContext))
   )
 
   const toolPanelStyles = {

--- a/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
+++ b/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
@@ -318,9 +318,9 @@ export const CloudEnvironmentModal = ({
       hover: isDisabled ? {} : { backgroundColor: colors.accent(0.2) },
       tooltip: Utils.cond(
         [doesCloudEnvForToolExist && !isDisabled, () => 'Open'],
-        [doesCloudEnvForToolExist && isDisabled && toolLabel !== tools.Jupyter.label, () => `Please wait until ${toolLabel} is running`],
-        [doesCloudEnvForToolExist && isDisabled && toolLabel === tools.Jupyter.label,
-          () => 'Select or create a notebook in the analyses tab to open Jupyter'],
+        [doesCloudEnvForToolExist && isDisabled && isLaunchSupported(toolLabel), () => `Please wait until ${toolLabel} is running`],
+        [doesCloudEnvForToolExist && isDisabled && !isLaunchSupported(toolLabel),
+          () => `Select or create an analysis in the analyses tab to open ${toolLabel}`],
         [Utils.DEFAULT, () => 'No Environment found']
       )
     }


### PR DESCRIPTION
This is a first pass at adding azure support for analysis components, with a lot of TODOs and future tickets to come.

So testing for this is a bit all over the place. There are various variables I had to hardcode to trick the pages into thinking the workspace is an azure workspace since rawls support for MC workspaces isn't in dev yet, which I'll leave for reviewer convenience until this is merged. Additionally, I had to manually create the workspace as described below. You also can't use the workspace I did since there's no easy way (I know of) to add people to an MC workspace.

1. `gcloud auth login` on the terminal as the user I use in the UI
2. `gcloud auth print-access-token` to get a token
3. call createWorkspace on workspace manager dev with the token from #2, which can be done here https://workspace.dsde-dev.broadinstitute.org/swagger-ui.html#/Workspace/createWorkspace. You need to change the ID to something unique, and set `"stage": "MC_WORKSPACE"`. Write the id down somewhere, it will be needed.
4. create an azure cloud context in WSM here https://workspace.dsde-dev.broadinstitute.org/swagger-ui.html#/Workspace/createCloudContext with the payload below
```
{
  "cloudPlatform": "AZURE",
  "jobControl": {
    "id": "uniqueid1"
  },
  "azureContext": {
    "tenantId": "fad90753-2022-4456-9b0a-c7e5b934e408",
    "subscriptionId": "3efc5bdf-be0e-44e7-b1d7-c08931e3c16c",
    "resourceGroupId": "mrg-terra-integration-test-20211118"
  }
}
```
6. Go to line 215 in WorkspaceContainer.js and set workspaceId to the workspace you created.

Also note several behavior is not yet developed for azure. Rather than stubbing a bunch of things, I just leave it in an undefined (and non-erroring) state since this will not be user facing any time soon.

Additionally, runtime creation is currently bugged in the backend due to some unrelated changes, so all runtimes created will result in errored runtimes. However, the create call itself is accepted by the backend and succeeds. It also errors in such a way that the GET call 404s after. As such, I have provided verification below that the individual calls succeed with the proper backend state.

The base analysis page in azure mode:
![image](https://user-images.githubusercontent.com/6465084/165588869-52c340be-a83c-4e44-a1b5-58aa69d45e28.png)

The start button modal in azure mode:
![image](https://user-images.githubusercontent.com/6465084/165646097-a4bf4643-8308-480a-80d7-862a835062b6.png)

The get azure call which is populating the modal when I have an existing runtime succeeding:
<img width="1023" alt="image" src="https://user-images.githubusercontent.com/6465084/165603625-11251559-f4f5-4ea0-bb9d-8d9f2ac97803.png">

The delete call succeeding
![image](https://user-images.githubusercontent.com/6465084/165642654-4c15d507-7685-47e6-ae43-cb3e33252382.png)

The create call succeeding:
![image](https://user-images.githubusercontent.com/6465084/165642966-a134d4d7-8b2b-4ea9-bda9-9a6eac373b53.png)

The default create payload succeeding
![image](https://user-images.githubusercontent.com/6465084/165643018-c6a4e733-1aef-4ff7-a42b-45d55001bcac.png)

Create payload with all fields changed in modal:
![image](https://user-images.githubusercontent.com/6465084/165643231-2b71b1ee-d2dc-45d8-8fe9-04255e860d69.png)

Interactions/display for azure also works in the context bar. Everything but creating an azure runtime is grayed out when accessing the context bar in a valid workspace. Additionally, the runtime status/error is properly display in the side bar/details modal respectively.






