### PR TITLE
[WOR-263] Changes for ToS enforcement (WOR-263).

### DIFF
--- a/src/components/NpsSurvey.js
+++ b/src/components/NpsSurvey.js
@@ -27,7 +27,7 @@ const NpsSurvey = () => {
   const [reasonComment, setReasonComment] = useState('')
   const [changeComment, setChangeComment] = useState('')
 
-  const { registrationStatus } = useStore(authStore)
+  const { registrationStatus, acceptedTos } = useStore(authStore)
 
   const loadStatus = async () => {
     const lastResponseTimestamp = (await Ajax().User.lastNpsResponse()).timestamp
@@ -42,12 +42,12 @@ const NpsSurvey = () => {
   }
 
   useEffect(() => {
-    if (registrationStatus === 'registered') {
+    if (registrationStatus === 'registered' && acceptedTos) {
       loadStatus()
     } else {
       setRequestable(false)
     }
-  }, [registrationStatus])
+  }, [registrationStatus, acceptedTos])
 
   const goAway = shouldSubmit => () => {
     setRequestable(false)

--- a/src/components/NpsSurvey.js
+++ b/src/components/NpsSurvey.js
@@ -30,18 +30,18 @@ const NpsSurvey = () => {
 
   const { registrationStatus, acceptedTos } = useStore(authStore)
 
-  const loadStatus = withErrorIgnoring(async () => {
-    const lastResponseTimestamp = (await Ajax().User.lastNpsResponse()).timestamp
-    // Behavior of the following logic: When a user first accesses Terra, wait 7 days to show the NPS survey.
-    // Once user has interacted with the NPS survey, wait 90 days to show the survey.
-    const askTheUser = !!lastResponseTimestamp ?
-      differenceInCalendarDays(parseJSON(lastResponseTimestamp), Date.now()) >= 90 :
-      differenceInCalendarDays(parseJSON((await Ajax().User.firstTimestamp()).timestamp), Date.now()) >= 7
-    setRequestable(askTheUser)
-  })
-
   useEffect(() => {
     if (registrationStatus === 'registered' && acceptedTos) {
+      const loadStatus = withErrorIgnoring(async () => {
+        const lastResponseTimestamp = (await Ajax().User.lastNpsResponse()).timestamp
+        // Behavior of the following logic: When a user first accesses Terra, wait 7 days to show the NPS survey.
+        // Once user has interacted with the NPS survey, wait 90 days to show the survey.
+        const askTheUser = !!lastResponseTimestamp ?
+          differenceInCalendarDays(parseJSON(lastResponseTimestamp), Date.now()) >= 90 :
+          differenceInCalendarDays(parseJSON((await Ajax().User.firstTimestamp()).timestamp), Date.now()) >= 7
+        setRequestable(askTheUser)
+      })
+
       loadStatus()
     } else {
       setRequestable(false)

--- a/src/components/NpsSurvey.js
+++ b/src/components/NpsSurvey.js
@@ -8,6 +8,7 @@ import { TextArea } from 'src/components/input'
 import Interactive from 'src/components/Interactive'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
+import { withErrorIgnoring } from 'src/libs/error'
 import { getAppName } from 'src/libs/logos'
 import { useStore } from 'src/libs/react-utils'
 import { authStore } from 'src/libs/state'
@@ -29,17 +30,15 @@ const NpsSurvey = () => {
 
   const { registrationStatus, acceptedTos } = useStore(authStore)
 
-  const loadStatus = async () => {
+  const loadStatus = withErrorIgnoring(async () => {
     const lastResponseTimestamp = (await Ajax().User.lastNpsResponse()).timestamp
-
     // Behavior of the following logic: When a user first accesses Terra, wait 7 days to show the NPS survey.
     // Once user has interacted with the NPS survey, wait 90 days to show the survey.
     const askTheUser = !!lastResponseTimestamp ?
       differenceInCalendarDays(parseJSON(lastResponseTimestamp), Date.now()) >= 90 :
       differenceInCalendarDays(parseJSON((await Ajax().User.firstTimestamp()).timestamp), Date.now()) >= 7
-
     setRequestable(askTheUser)
-  }
+  })
 
   useEffect(() => {
     if (registrationStatus === 'registered' && acceptedTos) {

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -37,6 +37,10 @@ export const hasBillingScope = () => {
   return getAuthInstance().currentUser.get().hasGrantedScopes('https://www.googleapis.com/auth/cloud-billing')
 }
 
+const registeredAndAcceptedTos = (oldState, state) => {
+  return (oldState.registrationStatus !== 'registered' && state.registrationStatus === 'registered' && state.acceptedTos) ||
+    (state.registrationStatus === 'registered' && state.acceptedTos && !oldState.acceptedTos)
+}
 /*
  * Request Google Cloud Billing scope if necessary.
  *
@@ -210,7 +214,7 @@ authStore.subscribe(state => {
 })
 
 authStore.subscribe(withErrorReporting('Error checking groups for timeout status', async (state, oldState) => {
-  if (oldState.registrationStatus !== 'registered' && state.registrationStatus === 'registered') {
+  if (registeredAndAcceptedTos(oldState, state)) {
     const isTimeoutEnabled = _.some({ groupName: 'session_timeout' }, await Ajax().Groups.list())
     authStore.update(state => ({ ...state, isTimeoutEnabled }))
   }
@@ -228,20 +232,20 @@ authStore.subscribe(withErrorReporting('Error loading user profile', async (stat
 }))
 
 authStore.subscribe(withErrorReporting('Error loading NIH account link status', async (state, oldState) => {
-  if (oldState.registrationStatus !== 'registered' && state.registrationStatus === 'registered') {
+  if (registeredAndAcceptedTos(oldState, state)) {
     const nihStatus = await Ajax().User.getNihStatus()
     authStore.update(state => ({ ...state, nihStatus }))
   }
 }))
 
 authStore.subscribe(async (state, oldState) => {
-  if (oldState.registrationStatus !== 'registered' && state.registrationStatus === 'registered') {
+  if (registeredAndAcceptedTos(oldState, state)) {
     await Ajax().Metrics.syncProfile()
   }
 })
 
 authStore.subscribe(async (state, oldState) => {
-  if (oldState.registrationStatus !== 'registered' && state.registrationStatus === 'registered') {
+  if (registeredAndAcceptedTos(oldState, state)) {
     if (state.anonymousId) {
       return await Ajax().Metrics.identify(state.anonymousId)
     }
@@ -274,7 +278,7 @@ authStore.subscribe((state, oldState) => {
 })
 
 authStore.subscribe(withErrorReporting('Error loading Framework Services account status', async (state, oldState) => {
-  if (oldState.registrationStatus !== 'registered' && state.registrationStatus === 'registered') {
+  if (registeredAndAcceptedTos(oldState, state)) {
     await Promise.all(_.map(async ({ key }) => {
       const status = await Ajax().User.getFenceStatus(key)
       authStore.update(_.set(['fenceStatus', key], status))


### PR DESCRIPTION
Don't call server APIs that require ToS to be accepted until the user has actually accepted the ToS.

We will likely do a follow-up PR after auditing all usages of "registrationStatus" to ensure that ToS status is also taken into account if necessary. This may involve changing the definition of "registered" in Terra-ui to include verifying ToS acceptance. But we would like to go ahead and merge this initial change to get `register-user` passing again on dev.

I ran the test against both integration and staging, and it passed there as well.