### PR TITLE
[WOR-276] Cleanup of registration status, Ajax call error handling (WOR-276).

### DIFF
--- a/src/components/AuthContainer.js
+++ b/src/components/AuthContainer.js
@@ -3,7 +3,7 @@ import { h } from 'react-hyperscript-helpers'
 import { centeredSpinner } from 'src/components/icons'
 import { useRoute } from 'src/libs/nav'
 import { useStore } from 'src/libs/react-utils'
-import { authStore } from 'src/libs/state'
+import { authStore, userStatus } from 'src/libs/state'
 import * as Utils from 'src/libs/utils'
 import { Disabled } from 'src/pages/Disabled'
 import Register from 'src/pages/Register'
@@ -20,10 +20,10 @@ const AuthContainer = ({ children }) => {
     [isSignedIn === undefined && !isPublic, authspinner],
     [isSignedIn === false && !isPublic, () => h(SignIn)],
     [registrationStatus === undefined && !isPublic, authspinner],
-    [registrationStatus === 'unregistered', () => h(Register)],
+    [registrationStatus === userStatus.unregistered, () => h(Register)],
     [acceptedTos === undefined && !isPublic, authspinner],
     [acceptedTos === false && name !== 'privacy', () => h(TermsOfService)],
-    [registrationStatus === 'disabled', () => h(Disabled)],
+    [registrationStatus === userStatus.disabled, () => h(Disabled)],
     [_.isEmpty(profile) && !isPublic, authspinner],
     () => children
   )

--- a/src/components/NpsSurvey.js
+++ b/src/components/NpsSurvey.js
@@ -11,7 +11,7 @@ import colors from 'src/libs/colors'
 import { withErrorIgnoring } from 'src/libs/error'
 import { getAppName } from 'src/libs/logos'
 import { useStore } from 'src/libs/react-utils'
-import { authStore } from 'src/libs/state'
+import { authStore, userStatus } from 'src/libs/state'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 
@@ -28,10 +28,10 @@ const NpsSurvey = () => {
   const [reasonComment, setReasonComment] = useState('')
   const [changeComment, setChangeComment] = useState('')
 
-  const { registrationStatus, acceptedTos } = useStore(authStore)
+  const { registrationStatus } = useStore(authStore)
 
   useEffect(() => {
-    if (registrationStatus === 'registered' && acceptedTos) {
+    if (registrationStatus === userStatus.registeredWithTos) {
       const loadStatus = withErrorIgnoring(async () => {
         const lastResponseTimestamp = (await Ajax().User.lastNpsResponse()).timestamp
         // Behavior of the following logic: When a user first accesses Terra, wait 7 days to show the NPS survey.
@@ -46,7 +46,7 @@ const NpsSurvey = () => {
     } else {
       setRequestable(false)
     }
-  }, [registrationStatus, acceptedTos])
+  }, [registrationStatus])
 
   const goAway = shouldSubmit => () => {
     setRequestable(false)

--- a/src/components/runtime-common.js
+++ b/src/components/runtime-common.js
@@ -11,7 +11,7 @@ import Events from 'src/libs/events'
 import { getLocalPref } from 'src/libs/prefs'
 import { useCancellation, useGetter, useOnMount, usePollingEffect, usePrevious, useStore } from 'src/libs/react-utils'
 import { getConvertedRuntimeStatus, usableStatuses } from 'src/libs/runtime-utils'
-import { authStore, cookieReadyStore } from 'src/libs/state'
+import { authStore, cookieReadyStore, userStatus } from 'src/libs/state'
 import * as Utils from 'src/libs/utils'
 
 
@@ -96,7 +96,7 @@ export const RuntimeStatusMonitor = ({ runtime, onRuntimeStoppedRunning = _.noop
 
 export const AuthenticatedCookieSetter = () => {
   const { registrationStatus } = useStore(authStore)
-  return registrationStatus === 'registered' && getLocalPref(cookiesAcceptedKey) !== false ? h(PeriodicCookieSetter) : null
+  return registrationStatus === userStatus.registeredWithTos && getLocalPref(cookiesAcceptedKey) !== false ? h(PeriodicCookieSetter) : null
 }
 
 export const PeriodicCookieSetter = () => {

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -7,7 +7,7 @@ import { ensureAuthSettled, getUser } from 'src/libs/auth'
 import { getConfig } from 'src/libs/config'
 import { withErrorIgnoring } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
-import { ajaxOverridesStore, authStore, knownBucketRequesterPaysStatuses, requesterPaysProjectStore, workspaceStore } from 'src/libs/state'
+import { ajaxOverridesStore, authStore, knownBucketRequesterPaysStatuses, requesterPaysProjectStore, userStatus, workspaceStore } from 'src/libs/state'
 import * as Utils from 'src/libs/utils'
 import { v4 as uuid } from 'uuid'
 
@@ -1657,7 +1657,7 @@ const Metrics = signal => ({
   captureEvent: withErrorIgnoring(async (event, details = {}) => {
     await ensureAuthSettled()
     const { isSignedIn, registrationStatus } = authStore.get() // NOTE: This is intentionally read after ensureAuthSettled
-    const isRegistered = isSignedIn && registrationStatus === 'registered'
+    const isRegistered = isSignedIn && registrationStatus === userStatus.registeredWithTos
     if (!isRegistered) {
       authStore.update(_.update('anonymousId', id => {
         return id || uuid()

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -169,6 +169,8 @@ authStore.subscribe(withErrorReporting('Error checking registration', async (sta
     try {
       const { enabled } = await Ajax().User.getStatus()
       if (enabled) {
+        // Once the ToS grace period has ended in production, if Sam returns `enabled` above, `acceptedTos` should also be true.
+        // At that point, we can add an assertion here.
         return state.acceptedTos ? userStatus.registeredWithTos : userStatus.registeredWithoutTos
       } else {
         return userStatus.disabled

--- a/src/libs/state.js
+++ b/src/libs/state.js
@@ -15,6 +15,14 @@ export const authStore = Utils.atom({
   cookiesAccepted: undefined
 })
 
+export const userStatus = {
+  unregistered: 'unregistered',
+  createdProfile: 'createdProfile',
+  registeredWithoutTos: 'registeredWithoutTos',
+  registeredWithTos: 'registered',
+  disabled: 'disabled'
+}
+
 export const cookieReadyStore = Utils.atom(false)
 
 export const lastActiveTimeStore = staticStorageSlot(localStorage, 'idleTimeout')

--- a/src/libs/state.js
+++ b/src/libs/state.js
@@ -17,7 +17,6 @@ export const authStore = Utils.atom({
 
 export const userStatus = {
   unregistered: 'unregistered',
-  createdProfile: 'createdProfile',
   registeredWithoutTos: 'registeredWithoutTos',
   registeredWithTos: 'registered',
   disabled: 'disabled'

--- a/src/pages/Register.js
+++ b/src/pages/Register.js
@@ -10,7 +10,7 @@ import colors from 'src/libs/colors'
 import { reportError } from 'src/libs/error'
 import Events from 'src/libs/events'
 import { registrationLogo } from 'src/libs/logos'
-import { authStore } from 'src/libs/state'
+import { authStore, userStatus } from 'src/libs/state'
 import validate from 'validate.js'
 
 
@@ -35,7 +35,7 @@ const Register = () => {
         lastName: familyName,
         contactEmail: email
       })
-      authStore.update(state => ({ ...state, registrationStatus: 'registered' }))
+      authStore.update(state => ({ ...state, registrationStatus: userStatus.createdProfile }))
       await refreshTerraProfile()
       Ajax().Metrics.captureEvent(Events.userRegister)
     } catch (error) {

--- a/src/pages/Register.js
+++ b/src/pages/Register.js
@@ -35,7 +35,7 @@ const Register = () => {
         lastName: familyName,
         contactEmail: email
       })
-      authStore.update(state => ({ ...state, registrationStatus: userStatus.createdProfile }))
+      authStore.update(state => ({ ...state, registrationStatus: userStatus.registeredWithoutTos }))
       await refreshTerraProfile()
       Ajax().Metrics.captureEvent(Events.userRegister)
     } catch (error) {


### PR DESCRIPTION
This is a follow-up PR to https://github.com/DataBiosphere/terra-ui/pull/2990 (which I wanted to merge as soon as possible to get the `register_user` test passing again).

Now that I've had time to better understand the code and talk with @marctalbott, I am modifying my previous solution to be more explicit and to better address the root issue. Before the ToS rollout (currently on dev only), being "registered" was enough to call most of our server methods. Now you must be both "registered" (have created a user profile) and have "accepted the ToS". 