### PR TITLE
[QA-1839] Attempt to fix sporadic timeout failure during login

### DIFF
--- a/integration-tests/tests/billing-projects.js
+++ b/integration-tests/tests/billing-projects.js
@@ -147,8 +147,7 @@ const setAjaxMockValues = async (testPage, ownedBillingProjectName, notOwnedBill
 
 const setUpBillingTest = async (page, testUrl, token) => {
   // Sign in. This portion of the test is not mocked.
-  await page.goto(testUrl)
-  await signIntoTerra(page, token)
+  await signIntoTerra(page, { token, testUrl })
   await dismissNotifications(page)
 
   // Interact with the Billing Page via mocked AJAX responses.

--- a/integration-tests/tests/billing-projects.js
+++ b/integration-tests/tests/billing-projects.js
@@ -1,6 +1,6 @@
 // This test is owned by the Workspaces Team.
 const _ = require('lodash/fp')
-const { assertTextNotFound, click, clickable, dismissNotifications, findText, noSpinnersAfter, select, signIntoTerra } = require('../utils/integration-utils')
+const { assertTextNotFound, click, clickable, findText, noSpinnersAfter, select, signIntoTerra } = require('../utils/integration-utils')
 const { withUserToken } = require('../utils/terra-sa-utils')
 
 
@@ -148,7 +148,6 @@ const setAjaxMockValues = async (testPage, ownedBillingProjectName, notOwnedBill
 const setUpBillingTest = async (page, testUrl, token) => {
   // Sign in. This portion of the test is not mocked.
   await signIntoTerra(page, { token, testUrl })
-  await dismissNotifications(page)
 
   // Interact with the Billing Page via mocked AJAX responses.
   const ownedBillingProjectName = 'OwnedBillingProject'

--- a/integration-tests/tests/find-workflow.js
+++ b/integration-tests/tests/find-workflow.js
@@ -1,7 +1,7 @@
 const _ = require('lodash/fp')
 const firecloud = require('../utils/firecloud-utils')
 const { withWorkspace } = require('../utils/integration-helpers')
-const { click, clickable, dismissNotifications, findElement, findText, signIntoTerra } = require('../utils/integration-utils')
+const { click, clickable, findElement, findText, signIntoTerra } = require('../utils/integration-utils')
 const { withUserToken } = require('../utils/terra-sa-utils')
 
 
@@ -10,7 +10,7 @@ const testFindWorkflowFn = _.flow(
   withUserToken
 )(async ({ billingProject, page, testUrl, token, workflowName, workspaceName }) => {
   await signIntoTerra(page, { token, testUrl })
-  await dismissNotifications(page)
+
   await click(page, clickable({ textContains: 'View Examples' }))
   await click(page, clickable({ textContains: 'code & workflows' }))
   await click(page, clickable({ textContains: workflowName }))

--- a/integration-tests/tests/find-workflow.js
+++ b/integration-tests/tests/find-workflow.js
@@ -9,8 +9,7 @@ const testFindWorkflowFn = _.flow(
   withWorkspace,
   withUserToken
 )(async ({ billingProject, page, testUrl, token, workflowName, workspaceName }) => {
-  await page.goto(testUrl)
-  await signIntoTerra(page, token)
+  await signIntoTerra(page, { token, testUrl })
   await dismissNotifications(page)
   await click(page, clickable({ textContains: 'View Examples' }))
   await click(page, clickable({ textContains: 'code & workflows' }))

--- a/integration-tests/tests/find-workflow.js
+++ b/integration-tests/tests/find-workflow.js
@@ -45,7 +45,7 @@ const testFindWorkflowFn = _.flow(
     backToTerra()
   ])
 
-  await signIntoTerra(page, token)
+  await signIntoTerra(page, { token })
   await findText(page, `${workflowName}-configured`)
   await findText(page, 'inputs')
 })

--- a/integration-tests/tests/import-cohort-data.js
+++ b/integration-tests/tests/import-cohort-data.js
@@ -10,8 +10,7 @@ const testImportCohortDataFn = _.flow(
   withWorkspace,
   withUserToken
 )(async ({ page, testUrl, token, workspaceName }) => {
-  await page.goto(testUrl)
-  await signIntoTerra(page, token)
+  await signIntoTerra(page, { token, testUrl })
   await dismissNotifications(page)
   await click(page, clickable({ textContains: 'Browse Data' }))
   await click(page, clickable({ textContains: '1000 Genomes Low Coverage' }))

--- a/integration-tests/tests/import-cohort-data.js
+++ b/integration-tests/tests/import-cohort-data.js
@@ -1,6 +1,7 @@
 const _ = require('lodash/fp')
 const { withWorkspace } = require('../utils/integration-helpers')
-const { findInGrid, click, clickable, dismissNotifications, fillIn, findIframe, input, signIntoTerra, select, svgText, waitForNoSpinners, findElement } = require('../utils/integration-utils')
+const { findInGrid, click, clickable, fillIn, findIframe, input, signIntoTerra, select, svgText, waitForNoSpinners, findElement } = require(
+  '../utils/integration-utils')
 const { withUserToken } = require('../utils/terra-sa-utils')
 
 
@@ -11,7 +12,7 @@ const testImportCohortDataFn = _.flow(
   withUserToken
 )(async ({ page, testUrl, token, workspaceName }) => {
   await signIntoTerra(page, { token, testUrl })
-  await dismissNotifications(page)
+
   await click(page, clickable({ textContains: 'Browse Data' }))
   await click(page, clickable({ textContains: '1000 Genomes Low Coverage' }))
 

--- a/integration-tests/tests/import-dockstore-workflow.js
+++ b/integration-tests/tests/import-dockstore-workflow.js
@@ -24,7 +24,7 @@ const testImportDockstoreWorkflowFn = _.flow(
   withDockstoreCheck
 )(async ({ page, testUrl, token, workspaceName }) => {
   const url = `${testUrl}/#import-tool/dockstore/${testWorkflowIdentifier}`
-  await signIntoTerra(page, { token, url })
+  await signIntoTerra(page, { token, testUrl: url })
 
   await findText(page, 'workflow TopMedVariantCaller')
   await select(page, 'Select a workspace', workspaceName)

--- a/integration-tests/tests/import-dockstore-workflow.js
+++ b/integration-tests/tests/import-dockstore-workflow.js
@@ -23,8 +23,8 @@ const testImportDockstoreWorkflowFn = _.flow(
   withUserToken,
   withDockstoreCheck
 )(async ({ page, testUrl, token, workspaceName }) => {
-  await page.goto(`${testUrl}/#import-tool/dockstore/${testWorkflowIdentifier}`)
-  await signIntoTerra(page, token)
+  const url = `${testUrl}/#import-tool/dockstore/${testWorkflowIdentifier}`
+  await signIntoTerra(page, { token, url })
   await dismissNotifications(page)
   await findText(page, 'workflow TopMedVariantCaller')
   await select(page, 'Select a workspace', workspaceName)

--- a/integration-tests/tests/import-dockstore-workflow.js
+++ b/integration-tests/tests/import-dockstore-workflow.js
@@ -22,9 +22,9 @@ const testImportDockstoreWorkflowFn = _.flow(
   withWorkspace,
   withUserToken,
   withDockstoreCheck
-)(async ({ page, testUrl, token, workspaceName }) => {
-  const url = `${testUrl}/#import-tool/dockstore/${testWorkflowIdentifier}`
-  await signIntoTerra(page, { token, testUrl: url })
+)(async ({ page, testUrl: testUrlRoot, token, workspaceName }) => {
+  const testUrl = `${testUrlRoot}/#import-tool/dockstore/${testWorkflowIdentifier}`
+  await signIntoTerra(page, { token, testUrl })
 
   await findText(page, 'workflow TopMedVariantCaller')
   await select(page, 'Select a workspace', workspaceName)

--- a/integration-tests/tests/import-dockstore-workflow.js
+++ b/integration-tests/tests/import-dockstore-workflow.js
@@ -1,7 +1,7 @@
 const _ = require('lodash/fp')
 const fetch = require('node-fetch')
 const { withWorkspace } = require('../utils/integration-helpers')
-const { click, clickable, dismissNotifications, findText, select, signIntoTerra } = require('../utils/integration-utils')
+const { click, clickable, findText, select, signIntoTerra } = require('../utils/integration-utils')
 const { withUserToken } = require('../utils/terra-sa-utils')
 
 
@@ -25,7 +25,7 @@ const testImportDockstoreWorkflowFn = _.flow(
 )(async ({ page, testUrl, token, workspaceName }) => {
   const url = `${testUrl}/#import-tool/dockstore/${testWorkflowIdentifier}`
   await signIntoTerra(page, { token, url })
-  await dismissNotifications(page)
+
   await findText(page, 'workflow TopMedVariantCaller')
   await select(page, 'Select a workspace', workspaceName)
   await click(page, clickable({ text: 'Import' }))

--- a/integration-tests/tests/janitor.js
+++ b/integration-tests/tests/janitor.js
@@ -11,8 +11,7 @@ const olderThanDays = 2
 
 const runJanitor = withUserToken(async ({ billingProject, page, testUrl, token }) => {
   // Sign into Terra so we have the correct credentials.
-  await page.goto(testUrl)
-  await signIntoTerra(page, token)
+  await signIntoTerra(page, { token, testUrl })
   await dismissNotifications(page)
 
   // Delete old orphaned workspaces. These can result from local integration test runs where the

--- a/integration-tests/tests/janitor.js
+++ b/integration-tests/tests/janitor.js
@@ -3,7 +3,7 @@ const rawConsole = require('console')
 const dateFns = require('date-fns/fp')
 const _ = require('lodash/fp')
 const { testWorkspaceNamePrefix } = require('../utils/integration-helpers')
-const { dismissNotifications, signIntoTerra } = require('../utils/integration-utils')
+const { signIntoTerra } = require('../utils/integration-utils')
 const { withUserToken } = require('../utils/terra-sa-utils')
 
 
@@ -12,7 +12,6 @@ const olderThanDays = 2
 const runJanitor = withUserToken(async ({ billingProject, page, testUrl, token }) => {
   // Sign into Terra so we have the correct credentials.
   await signIntoTerra(page, { token, testUrl })
-  await dismissNotifications(page)
 
   // Delete old orphaned workspaces. These can result from local integration test runs where the
   // process was prematurely terminated, but a few also appear in alpha and staging indicating that

--- a/integration-tests/tests/preview-drs-uri.js
+++ b/integration-tests/tests/preview-drs-uri.js
@@ -16,8 +16,7 @@ const testPreviewDrsUriFn = _.flow(
     }
   }
 
-  await page.goto(testUrl)
-  await signIntoTerra(page, token)
+  await signIntoTerra(page, { token, testUrl })
   await dismissNotifications(page)
 
   await createEntityInWorkspace(page, billingProject, workspaceName, testEntity)

--- a/integration-tests/tests/preview-drs-uri.js
+++ b/integration-tests/tests/preview-drs-uri.js
@@ -1,7 +1,8 @@
 const _ = require('lodash/fp')
 const { withWorkspace, createEntityInWorkspace } = require('../utils/integration-helpers')
 const { withUserToken } = require('../utils/terra-sa-utils')
-const { findText, navChild, fillIn, click, clickable, elementInDataTableRow, waitForNoSpinners, input, signIntoTerra, dismissNotifications } = require('../utils/integration-utils')
+const { findText, navChild, fillIn, click, clickable, elementInDataTableRow, waitForNoSpinners, input, signIntoTerra } = require(
+  '../utils/integration-utils')
 
 
 const testPreviewDrsUriFn = _.flow(
@@ -17,7 +18,6 @@ const testPreviewDrsUriFn = _.flow(
   }
 
   await signIntoTerra(page, { token, testUrl })
-  await dismissNotifications(page)
 
   await createEntityInWorkspace(page, billingProject, workspaceName, testEntity)
 

--- a/integration-tests/tests/register-user.js
+++ b/integration-tests/tests/register-user.js
@@ -1,10 +1,11 @@
 const { withUser } = require('../utils/integration-helpers')
 const { fillIn, findText, click, clickable, input, signIntoTerra } = require('../utils/integration-utils')
 const { fillInReplace } = require('../utils/integration-utils')
+const { waitUntilLoadedOrTimeout } = require('../utils/integration-utils')
 
 
 const testRegisterUserFn = withUser(async ({ page, testUrl, token }) => {
-  await page.goto(testUrl, { waitUntil: ['load', 'domcontentloaded', 'networkidle0'], timeout: 60 * 1000 })
+  await page.goto(testUrl, waitUntilLoadedOrTimeout(60 * 1000))
   await click(page, clickable({ textContains: 'View Workspaces' }))
   await signIntoTerra(page, { token })
   await fillInReplace(page, input({ labelContains: 'First Name' }), 'Integration')

--- a/integration-tests/tests/register-user.js
+++ b/integration-tests/tests/register-user.js
@@ -1,12 +1,11 @@
 const { withUser } = require('../utils/integration-helpers')
-const { fillIn, findText, click, clickable, input, signIntoTerra, dismissNotifications } = require('../utils/integration-utils')
+const { fillIn, findText, click, clickable, input, signIntoTerra } = require('../utils/integration-utils')
 
 
 const testRegisterUserFn = withUser(async ({ page, testUrl, token }) => {
-  await page.goto(testUrl, { waitUntil: ['load', 'domcontentloaded', 'networkidle0'], timeout: 60 * 1000 })
+  await signIntoTerra(page, { token, testUrl })
+
   await click(page, clickable({ textContains: 'View Workspaces' }))
-  await signIntoTerra(page, token)
-  await dismissNotifications(page)
   await fillIn(page, input({ labelContains: 'First Name' }), 'Integration')
   await fillIn(page, input({ labelContains: 'Last Name' }), 'Test')
   await click(page, clickable({ textContains: 'Register' }))

--- a/integration-tests/tests/register-user.js
+++ b/integration-tests/tests/register-user.js
@@ -1,12 +1,13 @@
 const { withUser } = require('../utils/integration-helpers')
 const { fillIn, findText, click, clickable, input, signIntoTerra } = require('../utils/integration-utils')
+const { fillInReplace } = require('../utils/integration-utils')
 
 
 const testRegisterUserFn = withUser(async ({ page, testUrl, token }) => {
-  await signIntoTerra(page, { token, testUrl })
-
+  await page.goto(testUrl, { waitUntil: ['load', 'domcontentloaded', 'networkidle0'], timeout: 60 * 1000 })
   await click(page, clickable({ textContains: 'View Workspaces' }))
-  await fillIn(page, input({ labelContains: 'First Name' }), 'Integration')
+  await signIntoTerra(page, { token })
+  await fillInReplace(page, input({ labelContains: 'First Name' }), 'Integration')
   await fillIn(page, input({ labelContains: 'Last Name' }), 'Test')
   await click(page, clickable({ textContains: 'Register' }))
   await click(page, clickable({ textContains: 'Accept' }))

--- a/integration-tests/tests/register-user.js
+++ b/integration-tests/tests/register-user.js
@@ -3,7 +3,7 @@ const { fillIn, findText, click, clickable, input, signIntoTerra, dismissNotific
 
 
 const testRegisterUserFn = withUser(async ({ page, testUrl, token }) => {
-  await page.goto(testUrl)
+  await page.goto(testUrl, { waitUntil: ['load', 'domcontentloaded', 'networkidle0'], timeout: 60 * 1000 })
   await click(page, clickable({ textContains: 'View Workspaces' }))
   await signIntoTerra(page, token)
   await dismissNotifications(page)

--- a/integration-tests/tests/run-notebook.js
+++ b/integration-tests/tests/run-notebook.js
@@ -10,12 +10,9 @@ const testRunNotebookFn = _.flow(
   withBilling,
   withRegisteredUser
 )(async ({ workspaceName, page, testUrl, token }) => {
-  await page.goto(testUrl, { waitUntil: ['load', 'domcontentloaded', 'networkidle0'], timeout: 60 * 1000 })
-  await click(page, clickable({ textContains: 'View Workspaces' }))
-  await signIntoTerra(page, token)
-  await dismissNotifications(page)
-  await waitForNoSpinners(page)
+  await signIntoTerra(page, { token, testUrl })
 
+  await click(page, clickable({ textContains: 'View Workspaces' }))
   await noSpinnersAfter(page, { action: () => click(page, clickable({ textContains: workspaceName })), debugMessage: '1' })
   await click(page, navChild('notebooks'))
   await click(page, clickable({ textContains: 'Create a' }))

--- a/integration-tests/tests/run-notebook.js
+++ b/integration-tests/tests/run-notebook.js
@@ -1,6 +1,8 @@
 const _ = require('lodash/fp')
 const { withRegisteredUser, withBilling, withWorkspace } = require('../utils/integration-helpers')
-const { click, clickable, getAnimatedDrawer, signIntoTerra, findElement, navChild, waitForNoSpinners, noSpinnersAfter, select, fillIn, input, findIframe, findText, dismissNotifications } = require('../utils/integration-utils')
+const {
+  click, clickable, getAnimatedDrawer, signIntoTerra, findElement, navChild, noSpinnersAfter, select, fillIn, input, findIframe, findText
+} = require('../utils/integration-utils')
 
 
 const notebookName = 'TestNotebook'

--- a/integration-tests/tests/run-notebook.js
+++ b/integration-tests/tests/run-notebook.js
@@ -10,7 +10,7 @@ const testRunNotebookFn = _.flow(
   withBilling,
   withRegisteredUser
 )(async ({ workspaceName, page, testUrl, token }) => {
-  await page.goto(testUrl)
+  await page.goto(testUrl, { waitUntil: ['load', 'domcontentloaded', 'networkidle0'], timeout: 60 * 1000 })
   await click(page, clickable({ textContains: 'View Workspaces' }))
   await signIntoTerra(page, token)
   await dismissNotifications(page)

--- a/integration-tests/tests/run-workflow-on-snapshot.js
+++ b/integration-tests/tests/run-workflow-on-snapshot.js
@@ -2,7 +2,8 @@ const _ = require('lodash/fp')
 const fetch = require('node-fetch')
 const { launchWorkflowAndWaitForSuccess } = require('./run-workflow')
 const { checkBucketAccess, withWorkspace } = require('../utils/integration-helpers')
-const { click, clickable, dismissNotifications, fillInReplace, findElement, findText, input, select, signIntoTerra, waitForNoSpinners, navChild } = require('../utils/integration-utils')
+const { click, clickable, fillInReplace, findElement, findText, input, select, signIntoTerra, waitForNoSpinners, navChild } = require(
+  '../utils/integration-utils')
 const { withUserToken } = require('../utils/terra-sa-utils')
 
 
@@ -31,8 +32,7 @@ const testRunWorkflowOnSnapshotFn = _.flow(
   // IMPORT SNAPSHOT
   const url = `${testUrl}/#import-data?url=${dataRepoUrlRoot}&snapshotId=${snapshotId}&snapshotName=${snapshotName}&format=snapshot`
   await signIntoTerra(page, { token, url })
-  await dismissNotifications(page)
-  await waitForNoSpinners(page)
+
   await click(page, clickable({ textContains: 'Start with an existing workspace' }))
   await select(page, 'Select a workspace', workspaceName)
   await click(page, clickable({ text: 'Import' }))

--- a/integration-tests/tests/run-workflow-on-snapshot.js
+++ b/integration-tests/tests/run-workflow-on-snapshot.js
@@ -31,7 +31,7 @@ const testRunWorkflowOnSnapshotFn = _.flow(
   }
   // IMPORT SNAPSHOT
   const url = `${testUrl}/#import-data?url=${dataRepoUrlRoot}&snapshotId=${snapshotId}&snapshotName=${snapshotName}&format=snapshot`
-  await signIntoTerra(page, { token, url })
+  await signIntoTerra(page, { token, testUrl: url })
 
   await click(page, clickable({ textContains: 'Start with an existing workspace' }))
   await select(page, 'Select a workspace', workspaceName)

--- a/integration-tests/tests/run-workflow-on-snapshot.js
+++ b/integration-tests/tests/run-workflow-on-snapshot.js
@@ -25,13 +25,15 @@ const testRunWorkflowOnSnapshotFn = _.flow(
   withWorkspace,
   withUserToken,
   withDataRepoCheck
-)(async ({ billingProject, dataRepoUrlRoot, page, testUrl, snapshotColumnName, snapshotId, snapshotTableName, token, workflowName, workspaceName }) => {
+)(async ({
+  billingProject, dataRepoUrlRoot, page, testUrl: testUrlRoot, snapshotColumnName, snapshotId, snapshotTableName, token, workflowName, workspaceName
+}) => {
   if (!snapshotId) {
     return
   }
   // IMPORT SNAPSHOT
-  const url = `${testUrl}/#import-data?url=${dataRepoUrlRoot}&snapshotId=${snapshotId}&snapshotName=${snapshotName}&format=snapshot`
-  await signIntoTerra(page, { token, testUrl: url })
+  const testUrl = `${testUrlRoot}/#import-data?url=${dataRepoUrlRoot}&snapshotId=${snapshotId}&snapshotName=${snapshotName}&format=snapshot`
+  await signIntoTerra(page, { token, testUrl })
 
   await click(page, clickable({ textContains: 'Start with an existing workspace' }))
   await select(page, 'Select a workspace', workspaceName)

--- a/integration-tests/tests/run-workflow-on-snapshot.js
+++ b/integration-tests/tests/run-workflow-on-snapshot.js
@@ -29,8 +29,8 @@ const testRunWorkflowOnSnapshotFn = _.flow(
     return
   }
   // IMPORT SNAPSHOT
-  await page.goto(`${testUrl}/#import-data?url=${dataRepoUrlRoot}&snapshotId=${snapshotId}&snapshotName=${snapshotName}&format=snapshot`)
-  await signIntoTerra(page, token)
+  const url = `${testUrl}/#import-data?url=${dataRepoUrlRoot}&snapshotId=${snapshotId}&snapshotName=${snapshotName}&format=snapshot`
+  await signIntoTerra(page, { token, url })
   await dismissNotifications(page)
   await waitForNoSpinners(page)
   await click(page, clickable({ textContains: 'Start with an existing workspace' }))

--- a/integration-tests/tests/run-workflow.js
+++ b/integration-tests/tests/run-workflow.js
@@ -14,7 +14,6 @@ const testRunWorkflowFn = _.flow(
   withUserToken
 )(async ({ billingProject, page, testUrl, token, workflowName, workspaceName }) => {
   await signIntoTerra(page, { token, testUrl })
-  await dismissNotifications(page)
 
   await createEntityInWorkspace(page, billingProject, workspaceName, testEntity)
   // Wait for bucket access to avoid sporadic failure when launching workflow.

--- a/integration-tests/tests/run-workflow.js
+++ b/integration-tests/tests/run-workflow.js
@@ -2,7 +2,8 @@ const rawConsole = require('console')
 const _ = require('lodash/fp')
 const pRetry = require('p-retry')
 const { checkBucketAccess, withWorkspace, createEntityInWorkspace } = require('../utils/integration-helpers')
-const { click, clickable, dismissNotifications, findElement, fillIn, input, signIntoTerra, waitForNoSpinners, findInGrid, navChild, findInDataTableRow } = require('../utils/integration-utils')
+const { click, clickable, findElement, fillIn, input, signIntoTerra, waitForNoSpinners, findInGrid, navChild, findInDataTableRow } = require(
+  '../utils/integration-utils')
 const { withUserToken } = require('../utils/terra-sa-utils')
 
 

--- a/integration-tests/tests/run-workflow.js
+++ b/integration-tests/tests/run-workflow.js
@@ -13,8 +13,7 @@ const testRunWorkflowFn = _.flow(
   withWorkspace,
   withUserToken
 )(async ({ billingProject, page, testUrl, token, workflowName, workspaceName }) => {
-  await page.goto(testUrl)
-  await signIntoTerra(page, token)
+  await signIntoTerra(page, { token, testUrl })
   await dismissNotifications(page)
 
   await createEntityInWorkspace(page, billingProject, workspaceName, testEntity)

--- a/integration-tests/tests/workspace-dashboard.js
+++ b/integration-tests/tests/workspace-dashboard.js
@@ -9,7 +9,7 @@ const testGoogleWorkspace = _.flow(
   withWorkspace,
   withUserToken
 )(async ({ page, token, testUrl, workspaceName }) => {
-  await page.goto(testUrl)
+  await page.goto(testUrl, { waitUntil: ['load', 'domcontentloaded', 'networkidle0'], timeout: 60 * 1000 })
   await viewWorkspaceDashboard(page, token, workspaceName)
   await findText(page, 'About the workspace')
 

--- a/integration-tests/tests/workspace-dashboard.js
+++ b/integration-tests/tests/workspace-dashboard.js
@@ -3,7 +3,7 @@ const _ = require('lodash/fp')
 const { clickNavChildAndLoad, viewWorkspaceDashboard, withWorkspace } = require('../utils/integration-helpers')
 const { assertNavChildNotFound, click, clickable, findText } = require('../utils/integration-utils')
 const { withUserToken } = require('../utils/terra-sa-utils')
-const { waitUntilLoadedOrTimeout } = require('integration-tests/utils/integration-utils')
+const { waitUntilLoadedOrTimeout } = require('../utils/integration-utils')
 
 
 const testGoogleWorkspace = _.flow(

--- a/integration-tests/tests/workspace-dashboard.js
+++ b/integration-tests/tests/workspace-dashboard.js
@@ -3,13 +3,14 @@ const _ = require('lodash/fp')
 const { clickNavChildAndLoad, viewWorkspaceDashboard, withWorkspace } = require('../utils/integration-helpers')
 const { assertNavChildNotFound, click, clickable, findText } = require('../utils/integration-utils')
 const { withUserToken } = require('../utils/terra-sa-utils')
+const { waitUntilLoadedOrTimeout } = require('integration-tests/utils/integration-utils')
 
 
 const testGoogleWorkspace = _.flow(
   withWorkspace,
   withUserToken
 )(async ({ page, token, testUrl, workspaceName }) => {
-  await page.goto(testUrl, { waitUntil: ['load', 'domcontentloaded', 'networkidle0'], timeout: 60 * 1000 })
+  await page.goto(testUrl, waitUntilLoadedOrTimeout(60 * 1000))
   await viewWorkspaceDashboard(page, token, workspaceName)
   await findText(page, 'About the workspace')
 

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -15,8 +15,7 @@ const withSignedInPage = fn => async options => {
   const { context, testUrl, token } = options
   const page = await context.newPage()
   try {
-    await page.goto(testUrl)
-    await signIntoTerra(page, token)
+    await signIntoTerra(page, { token, testUrl })
     return await fn({ ...options, page })
   } finally {
     await page.close()

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -195,7 +195,7 @@ const enableDataCatalog = async (page, testUrl, token) => {
   await overrideConfig(page, { isDataBrowserVisible: true })
 
   await click(page, clickable({ textContains: 'Browse Data' }))
-  await signIntoTerra(page, token)
+  await signIntoTerra(page, { token })
 }
 
 const clickNavChildAndLoad = async (page, tab) => {
@@ -204,7 +204,7 @@ const clickNavChildAndLoad = async (page, tab) => {
 
 const viewWorkspaceDashboard = async (page, token, workspaceName) => {
   await click(page, clickable({ textContains: 'View Workspaces' }))
-  await signIntoTerra(page, token)
+  await signIntoTerra(page, { token })
   await dismissNotifications(page)
   await fillIn(page, input({ placeholder: 'SEARCH WORKSPACES' }), workspaceName)
   await noSpinnersAfter(page, { action: () => click(page, clickable({ textContains: workspaceName })) })

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -189,7 +189,7 @@ const overrideConfig = async (page, configToPassIn) => {
 }
 
 const enableDataCatalog = async (page, testUrl, token) => {
-  await page.goto(testUrl)
+  await page.goto(testUrl, { waitUntil: ['load', 'domcontentloaded', 'networkidle0'], timeout: 60 * 1000 })
   await waitForNoSpinners(page)
 
   await findText(page, 'Browse Data')
@@ -197,7 +197,6 @@ const enableDataCatalog = async (page, testUrl, token) => {
 
   await click(page, clickable({ textContains: 'Browse Data' }))
   await signIntoTerra(page, token)
-  await dismissNotifications(page)
 }
 
 const clickNavChildAndLoad = async (page, tab) => {
@@ -213,7 +212,7 @@ const viewWorkspaceDashboard = async (page, token, workspaceName) => {
 }
 
 const performAnalysisTabSetup = async (page, token, testUrl, workspaceName) => {
-  await page.goto(testUrl)
+  await page.goto(testUrl, { waitUntil: ['load', 'domcontentloaded', 'networkidle0'], timeout: 60 * 1000 })
   await findText(page, 'View Workspaces')
   await overrideConfig(page, { isAnalysisTabVisible: true })
   await viewWorkspaceDashboard(page, token, workspaceName)

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -7,6 +7,7 @@ const {
 } = require('./integration-utils')
 const { fetchLyle } = require('./lyle-utils')
 const { withUserToken } = require('../utils/terra-sa-utils')
+const { waitUntilLoadedOrTimeout } = require('../utils/integration-utils')
 
 
 const defaultTimeout = 5 * 60 * 1000
@@ -188,7 +189,7 @@ const overrideConfig = async (page, configToPassIn) => {
 }
 
 const enableDataCatalog = async (page, testUrl, token) => {
-  await page.goto(testUrl, { waitUntil: ['load', 'domcontentloaded', 'networkidle0'], timeout: 60 * 1000 })
+  await page.goto(testUrl, waitUntilLoadedOrTimeout(60 * 1000))
   await waitForNoSpinners(page)
 
   await findText(page, 'Browse Data')
@@ -211,7 +212,7 @@ const viewWorkspaceDashboard = async (page, token, workspaceName) => {
 }
 
 const performAnalysisTabSetup = async (page, token, testUrl, workspaceName) => {
-  await page.goto(testUrl, { waitUntil: ['load', 'domcontentloaded', 'networkidle0'], timeout: 60 * 1000 })
+  await page.goto(testUrl, waitUntilLoadedOrTimeout(60 * 1000))
   await findText(page, 'View Workspaces')
   await overrideConfig(page, { isAnalysisTabVisible: true })
   await viewWorkspaceDashboard(page, token, workspaceName)

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -171,7 +171,7 @@ const dismissNotifications = async page => {
 
 const signIntoTerra = async (page, { token, testUrl }) => {
   if (testUrl) {
-    await page.goto(testUrl, { waitUntil: ['load', 'domcontentloaded', 'networkidle0'], timeout: 60 * 1000 })
+    await page.goto(testUrl, waitUntilLoadedOrTimeout(60 * 1000))
   }
   await page.waitForXPath('//*[contains(normalize-space(.),"Loading Terra")]', { hidden: true, timeout: 60 * 1000 })
   await waitForNoSpinners(page)

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -169,9 +169,9 @@ const dismissNotifications = async page => {
   return !!notificationCloseButtons.length && delay(1000) // delayed for alerts to animate off
 }
 
-const signIntoTerra = async (page, { token, url }) => {
-  if (url) {
-    await page.goto(url, { waitUntil: ['load', 'domcontentloaded', 'networkidle0'], timeout: 60 * 1000 })
+const signIntoTerra = async (page, { token, testUrl }) => {
+  if (testUrl) {
+    await page.goto(testUrl, { waitUntil: ['load', 'domcontentloaded', 'networkidle0'], timeout: 60 * 1000 })
   }
   await page.waitForXPath('//*[contains(normalize-space(.),"Loading Terra")]', { hidden: true, timeout: 60 * 1000 })
   await waitForNoSpinners(page)

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -297,6 +297,8 @@ const withPageLogging = fn => options => {
   return fn(options)
 }
 
+const waitUntilLoadedOrTimeout = timeout => ({ waitUntil: ['load', 'domcontentloaded', 'networkidle0'], timeout })
+
 module.exports = {
   assertNavChildNotFound,
   assertTextNotFound,
@@ -332,5 +334,6 @@ module.exports = {
   noSpinnersAfter,
   waitForNoSpinners,
   withPageLogging,
-  openError
+  openError,
+  waitUntilLoadedOrTimeout
 }

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -175,7 +175,9 @@ const signIntoTerra = async (page, { token, url }) => {
   }
   await page.waitForXPath('//*[contains(normalize-space(.),"Loading Terra")]', { hidden: true, timeout: 60 * 1000 })
   await waitForNoSpinners(page)
-  return page.evaluate(token => window.forceSignIn(token), token)
+  await page.evaluate(token => window.forceSignIn(token), token)
+  await dismissNotifications(page)
+  await waitForNoSpinners(page)
 }
 
 const findElement = (page, xpath, options) => {

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -170,9 +170,7 @@ const dismissNotifications = async page => {
 }
 
 const signIntoTerra = async (page, { token, testUrl }) => {
-  if (testUrl) {
-    await page.goto(testUrl, waitUntilLoadedOrTimeout(60 * 1000))
-  }
+  !!testUrl && await page.goto(testUrl, waitUntilLoadedOrTimeout(60 * 1000))
   await page.waitForXPath('//*[contains(normalize-space(.),"Loading Terra")]', { hidden: true, timeout: 60 * 1000 })
   await waitForNoSpinners(page)
   await page.evaluate(token => window.forceSignIn(token), token)

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -169,8 +169,11 @@ const dismissNotifications = async page => {
   return !!notificationCloseButtons.length && delay(1000) // delayed for alerts to animate off
 }
 
-const signIntoTerra = async (page, token) => {
-  await page.waitForXPath('//*[contains(normalize-space(.),"Loading Terra")]', { hidden: true })
+const signIntoTerra = async (page, { token, url }) => {
+  if (url) {
+    await page.goto(url, { waitUntil: ['load', 'domcontentloaded', 'networkidle0'], timeout: 60 * 1000 })
+  }
+  await page.waitForXPath('//*[contains(normalize-space(.),"Loading Terra")]', { hidden: true, timeout: 60 * 1000 })
   await waitForNoSpinners(page)
   return page.evaluate(token => window.forceSignIn(token), token)
 }


### PR DESCRIPTION
Deal with sporadic `Loading Terra` spinner timeout failure, fix by increase the wait `timeout` to 60 seconds from 30 seconds. Also, remove boilerplate code around `signIntoTerra()`.