### PR TITLE
[SU-36] Allow for data tables to be renamed

### DIFF
--- a/src/components/data/RenameTableModal.js
+++ b/src/components/data/RenameTableModal.js
@@ -1,0 +1,25 @@
+import { useState } from 'react'
+import { h } from 'react-hyperscript-helpers'
+import { ButtonPrimary } from 'src/components/common'
+import Modal from 'src/components/Modal'
+import { Ajax } from 'src/libs/ajax'
+import colors from 'src/libs/colors'
+import { reportError } from 'src/libs/error'
+import * as Utils from 'src/libs/utils'
+
+
+const RenameTableModal = ({ onDismiss, selectedDataType, workspace }) => {
+  // State
+  const [renaming, setRenaming] = useState(false)
+
+  return h(Modal, {
+    onDismiss,
+    title: 'Rename Data Table',
+    okButton: h(ButtonPrimary, {
+      disabled: renaming,
+      onClick: console.log(selectedDataType)
+    }, ['Copy'])
+  }, [])
+}
+
+export default RenameTableModal

--- a/src/components/data/RenameTableModal.js
+++ b/src/components/data/RenameTableModal.js
@@ -34,7 +34,7 @@ const RenameTableModal = ({ onDismiss, onUpdateSuccess, namespace, name, selecte
         withErrorReporting('Error renaming data table.'),
         Utils.withBusyState(setRenaming)
       )(async () => {
-        Ajax().Metrics.captureEvent(Events.workspaceDataRenameTable, { oldName: selectedDataType, newName })
+        await Ajax().Metrics.captureEvent(Events.workspaceDataRenameTable, { oldName: selectedDataType, newName })
         await Ajax().Workspaces.workspace(namespace, name).renameEntityType(selectedDataType, newName)
         onUpdateSuccess()
       })

--- a/src/components/data/RenameTableModal.js
+++ b/src/components/data/RenameTableModal.js
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp'
 import { Fragment, useState } from 'react'
-import { h } from 'react-hyperscript-helpers'
+import { div, h } from 'react-hyperscript-helpers'
 import { ButtonPrimary, IdContainer, spinnerOverlay } from 'src/components/common'
 import { ValidatedInput } from 'src/components/input'
 import Modal from 'src/components/Modal'
@@ -40,6 +40,7 @@ const RenameTableModal = ({ onDismiss, onUpdateSuccess, namespace, name, selecte
       })
     }, ['Rename'])
   }, [h(IdContainer, [id => h(Fragment, [
+    div('Workflow configurations that reference the current table name will need to be updated manually.'),
     h(FormLabel, { htmlFor: id, required: true }, ['New Name']),
     tableNameInput({
       inputProps: {

--- a/src/components/data/RenameTableModal.js
+++ b/src/components/data/RenameTableModal.js
@@ -4,7 +4,9 @@ import { ButtonPrimary, IdContainer } from 'src/components/common'
 import { ValidatedInput } from 'src/components/input'
 import Modal from 'src/components/Modal'
 import { Ajax } from 'src/libs/ajax'
+import { reportError } from 'src/libs/error'
 import { FormLabel } from 'src/libs/forms'
+import { useCancellation } from 'src/libs/react-utils'
 import * as Utils from 'src/libs/utils'
 
 
@@ -17,17 +19,25 @@ export const tableNameInput = ({ inputProps, ...props }) => h(ValidatedInput, {
   }
 })
 
-const RenameTableModal = ({ onDismiss, selectedDataType, workspace }) => {
+const RenameTableModal = ({ onDismiss, namespace, name, selectedDataType }) => {
   // State
   const [newName, setNewName] = useState('')
   const [renaming, setRenaming] = useState(false)
+
+  const signal = useCancellation()
 
   return h(Modal, {
     onDismiss,
     title: 'Rename Data Table',
     okButton: h(ButtonPrimary, {
       disabled: renaming,
-      onClick: console.log(workspace)
+      onClick: async () => {
+        try {
+          await Ajax(signal).Workspaces.workspace(namespace, name).renameEntityType(selectedDataType, newName)
+        } catch (err) {
+          reportError('Error renaming data table.', err)
+        }
+      }
     }, ['Rename'])
   }, [h(IdContainer, [id => h(Fragment, [
     h(FormLabel, { htmlFor: id, required: true }, ['New Name']),
@@ -35,7 +45,7 @@ const RenameTableModal = ({ onDismiss, selectedDataType, workspace }) => {
       inputProps: {
         id, value: newName,
         onChange: v => {
-          console.log(v)
+          setNewName(v)
         }
       }
     })

--- a/src/components/data/RenameTableModal.js
+++ b/src/components/data/RenameTableModal.js
@@ -31,10 +31,10 @@ const RenameTableModal = ({ onDismiss, onUpdateSuccess, namespace, name, selecte
     okButton: h(ButtonPrimary, {
       disabled: renaming,
       onClick: _.flow(
-        Utils.withBusyState(setRenaming),
-        withErrorReporting('Error renaming data table.')
+        withErrorReporting('Error renaming data table.'),
+        Utils.withBusyState(setRenaming)
       )(async () => {
-        await Ajax().Metrics.captureEvent(Events.workspaceDataRenameTable, { oldName: selectedDataType, newName })
+        Ajax().Metrics.captureEvent(Events.workspaceDataRenameTable, { oldName: selectedDataType, newName })
         await Ajax().Workspaces.workspace(namespace, name).renameEntityType(selectedDataType, newName)
         onUpdateSuccess()
       })

--- a/src/components/data/RenameTableModal.js
+++ b/src/components/data/RenameTableModal.js
@@ -1,13 +1,12 @@
 import { Fragment, useState } from 'react'
 import { h } from 'react-hyperscript-helpers'
-import { ButtonPrimary, IdContainer } from 'src/components/common'
+import { ButtonPrimary, IdContainer, spinnerOverlay } from 'src/components/common'
 import { ValidatedInput } from 'src/components/input'
 import Modal from 'src/components/Modal'
 import { Ajax } from 'src/libs/ajax'
 import { reportError } from 'src/libs/error'
 import { FormLabel } from 'src/libs/forms'
 import { useCancellation } from 'src/libs/react-utils'
-import * as Utils from 'src/libs/utils'
 
 
 export const tableNameInput = ({ inputProps, ...props }) => h(ValidatedInput, {
@@ -19,7 +18,7 @@ export const tableNameInput = ({ inputProps, ...props }) => h(ValidatedInput, {
   }
 })
 
-const RenameTableModal = ({ onDismiss, namespace, name, selectedDataType }) => {
+const RenameTableModal = ({ onDismiss, onSuccess, namespace, name, selectedDataType }) => {
   // State
   const [newName, setNewName] = useState('')
   const [renaming, setRenaming] = useState(false)
@@ -32,11 +31,15 @@ const RenameTableModal = ({ onDismiss, namespace, name, selectedDataType }) => {
     okButton: h(ButtonPrimary, {
       disabled: renaming,
       onClick: async () => {
+        setRenaming(true)
         try {
           await Ajax(signal).Workspaces.workspace(namespace, name).renameEntityType(selectedDataType, newName)
+          onSuccess()
         } catch (err) {
           reportError('Error renaming data table.', err)
         }
+        setRenaming(false)
+        onDismiss()
       }
     }, ['Rename'])
   }, [h(IdContainer, [id => h(Fragment, [
@@ -48,7 +51,8 @@ const RenameTableModal = ({ onDismiss, namespace, name, selectedDataType }) => {
           setNewName(v)
         }
       }
-    })
+    }),
+    renaming && spinnerOverlay
   ])])])
 }
 

--- a/src/components/data/RenameTableModal.js
+++ b/src/components/data/RenameTableModal.js
@@ -8,7 +8,6 @@ import { Ajax } from 'src/libs/ajax'
 import { withErrorReporting } from 'src/libs/error'
 import Events from 'src/libs/events'
 import { FormLabel } from 'src/libs/forms'
-import { useCancellation } from 'src/libs/react-utils'
 import * as Utils from 'src/libs/utils'
 
 
@@ -26,8 +25,6 @@ const RenameTableModal = ({ onDismiss, onSuccess, namespace, name, selectedDataT
   const [newName, setNewName] = useState('')
   const [renaming, setRenaming] = useState(false)
 
-  const signal = useCancellation()
-
   return h(Modal, {
     onDismiss,
     title: 'Rename Data Table',
@@ -38,7 +35,7 @@ const RenameTableModal = ({ onDismiss, onSuccess, namespace, name, selectedDataT
         withErrorReporting('Error renaming data table.')
       )(async () => {
         await Ajax().Metrics.captureEvent(Events.workspaceDataRenameTable, { oldName: selectedDataType, newName })
-        await Ajax(signal).Workspaces.workspace(namespace, name).renameEntityType(selectedDataType, newName)
+        await Ajax().Workspaces.workspace(namespace, name).renameEntityType(selectedDataType, newName)
         onSuccess()
       })
     }, ['Rename'])

--- a/src/components/data/RenameTableModal.js
+++ b/src/components/data/RenameTableModal.js
@@ -1,15 +1,25 @@
-import { useState } from 'react'
+import { Fragment, useState } from 'react'
 import { h } from 'react-hyperscript-helpers'
-import { ButtonPrimary } from 'src/components/common'
+import { ButtonPrimary, IdContainer } from 'src/components/common'
+import { ValidatedInput } from 'src/components/input'
 import Modal from 'src/components/Modal'
 import { Ajax } from 'src/libs/ajax'
-import colors from 'src/libs/colors'
-import { reportError } from 'src/libs/error'
+import { FormLabel } from 'src/libs/forms'
 import * as Utils from 'src/libs/utils'
 
 
+export const tableNameInput = ({ inputProps, ...props }) => h(ValidatedInput, {
+  ...props,
+  inputProps: {
+    ...inputProps,
+    autoFocus: true,
+    placeholder: 'Enter a name'
+  }
+})
+
 const RenameTableModal = ({ onDismiss, selectedDataType, workspace }) => {
   // State
+  const [newName, setNewName] = useState('')
   const [renaming, setRenaming] = useState(false)
 
   return h(Modal, {
@@ -17,9 +27,19 @@ const RenameTableModal = ({ onDismiss, selectedDataType, workspace }) => {
     title: 'Rename Data Table',
     okButton: h(ButtonPrimary, {
       disabled: renaming,
-      onClick: console.log(selectedDataType)
-    }, ['Copy'])
-  }, [])
+      onClick: console.log(workspace)
+    }, ['Rename'])
+  }, [h(IdContainer, [id => h(Fragment, [
+    h(FormLabel, { htmlFor: id, required: true }, ['New Name']),
+    tableNameInput({
+      inputProps: {
+        id, value: newName,
+        onChange: v => {
+          console.log(v)
+        }
+      }
+    })
+  ])])])
 }
 
 export default RenameTableModal

--- a/src/components/data/RenameTableModal.js
+++ b/src/components/data/RenameTableModal.js
@@ -20,7 +20,7 @@ export const tableNameInput = ({ inputProps, ...props }) => h(ValidatedInput, {
   }
 })
 
-const RenameTableModal = ({ onDismiss, onSuccess, namespace, name, selectedDataType }) => {
+const RenameTableModal = ({ onDismiss, onUpdateSuccess, namespace, name, selectedDataType }) => {
   // State
   const [newName, setNewName] = useState('')
   const [renaming, setRenaming] = useState(false)
@@ -36,7 +36,7 @@ const RenameTableModal = ({ onDismiss, onSuccess, namespace, name, selectedDataT
       )(async () => {
         await Ajax().Metrics.captureEvent(Events.workspaceDataRenameTable, { oldName: selectedDataType, newName })
         await Ajax().Workspaces.workspace(namespace, name).renameEntityType(selectedDataType, newName)
-        onSuccess()
+        onUpdateSuccess()
       })
     }, ['Rename'])
   }, [h(IdContainer, [id => h(Fragment, [

--- a/src/components/data/RenameTableModal.js
+++ b/src/components/data/RenameTableModal.js
@@ -19,8 +19,6 @@ export const tableNameInput = ({ inputProps, ...props }) => h(ValidatedInput, {
   }
 })
 
-const captureTableRenameEvent = (oldName, newName) => Ajax().Metrics.captureEvent(Events.workspaceDataRenameTable, { oldName, newName })
-
 const RenameTableModal = ({ onDismiss, onSuccess, namespace, name, selectedDataType }) => {
   // State
   const [newName, setNewName] = useState('')
@@ -35,7 +33,7 @@ const RenameTableModal = ({ onDismiss, onSuccess, namespace, name, selectedDataT
       disabled: renaming,
       onClick: async () => {
         setRenaming(true)
-        captureTableRenameEvent(selectedDataType, newName)
+        Ajax().Metrics.captureEvent(Events.workspaceDataRenameTable, { oldName: selectedDataType, newName })
         try {
           await Ajax(signal).Workspaces.workspace(namespace, name).renameEntityType(selectedDataType, newName)
           onSuccess()

--- a/src/components/data/RenameTableModal.js
+++ b/src/components/data/RenameTableModal.js
@@ -5,6 +5,7 @@ import { ValidatedInput } from 'src/components/input'
 import Modal from 'src/components/Modal'
 import { Ajax } from 'src/libs/ajax'
 import { reportError } from 'src/libs/error'
+import Events from 'src/libs/events'
 import { FormLabel } from 'src/libs/forms'
 import { useCancellation } from 'src/libs/react-utils'
 
@@ -17,6 +18,8 @@ export const tableNameInput = ({ inputProps, ...props }) => h(ValidatedInput, {
     placeholder: 'Enter a name'
   }
 })
+
+const captureTableRenameEvent = (oldName, newName) => Ajax().Metrics.captureEvent(Events.workspaceDataRenameTable, { oldName, newName })
 
 const RenameTableModal = ({ onDismiss, onSuccess, namespace, name, selectedDataType }) => {
   // State
@@ -32,6 +35,7 @@ const RenameTableModal = ({ onDismiss, onSuccess, namespace, name, selectedDataT
       disabled: renaming,
       onClick: async () => {
         setRenaming(true)
+        captureTableRenameEvent(selectedDataType, newName)
         try {
           await Ajax(signal).Workspaces.workspace(namespace, name).renameEntityType(selectedDataType, newName)
           onSuccess()

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -901,6 +901,12 @@ const Workspaces = signal => ({
           { signal, method: 'POST' }]))
       },
 
+      renameEntityType: (oldName, newName) => {
+        const payload = { oldName, newName }
+
+        return fetchRawls(`${root}/entities/renameEntityType`, _.mergeAll([authOpts(), jsonBody(payload), { signal, method: 'POST' }]))
+      },
+
       deleteEntityAttribute: (type, name, attributeName) => {
         return fetchRawls(`${root}/entities/${type}/${name}`, _.mergeAll([authOpts(), jsonBody([{ op: 'RemoveAttribute', attributeName }]),
           { signal, method: 'PATCH' }]))

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -902,9 +902,9 @@ const Workspaces = signal => ({
       },
 
       renameEntityType: (oldName, newName) => {
-        const payload = { oldName, newName }
+        const payload = { newName }
 
-        return fetchRawls(`${root}/entities/renameEntityType`, _.mergeAll([authOpts(), jsonBody(payload), { signal, method: 'POST' }]))
+        return fetchRawls(`${root}/entityTypes/${oldName}`, _.mergeAll([authOpts(), jsonBody(payload), { signal, method: 'PATCH' }]))
       },
 
       deleteEntityAttribute: (type, name, attributeName) => {

--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -53,7 +53,7 @@ const eventsList = {
   workspaceDataOpenWithNotebook: 'workspace:data:notebook',
   workspaceDataImport: 'workspace:data:import',
   workspaceDataUpload: 'workspace:data:upload',
-  workspaceDataRenameTable: 'workspace:data:renametable',
+  workspaceDataRenameTable: 'workspace:data:rename-table',
   workspaceOpenFromList: 'workspace:open-from-list',
   workspaceSampleTsvDownload: 'workspace:sample-tsv:download',
   workspaceShare: 'workspace:share',

--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -53,6 +53,7 @@ const eventsList = {
   workspaceDataOpenWithNotebook: 'workspace:data:notebook',
   workspaceDataImport: 'workspace:data:import',
   workspaceDataUpload: 'workspace:data:upload',
+  workspaceDataRenameTable: 'workspace:data:renametable',
   workspaceOpenFromList: 'workspace:open-from-list',
   workspaceSampleTsvDownload: 'workspace:sample-tsv:download',
   workspaceShare: 'workspace:share',

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -462,6 +462,8 @@ const DataTableActions = ({ workspace, tableName, rowCount }) => {
   const { workspace: { namespace, name }, workspaceSubmissionStats: { runningSubmissionsCount } } = workspace
   const isSetOfSets = tableName.endsWith('_set_set')
 
+  const editWorkspaceErrorMessage = Utils.editWorkspaceError(workspace)
+
   const downloadForm = useRef()
   const signal = useCancellation()
 
@@ -510,7 +512,9 @@ const DataTableActions = ({ workspace, tableName, rowCount }) => {
         h(MenuButton, {
           onClick: () => {
             setRenaming(true)
-          }
+          },
+          disabled: !!editWorkspaceErrorMessage,
+          tooltip: editWorkspaceErrorMessage || ''
         }, 'Rename table')
       ])
     }, [

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -14,6 +14,7 @@ import EntitiesContent from 'src/components/data/EntitiesContent'
 import ExportDataModal from 'src/components/data/ExportDataModal'
 import { DeleteObjectConfirmationModal } from 'src/components/data/FileBrowser'
 import LocalVariablesContent from 'src/components/data/LocalVariablesContent'
+import RenameTableModal from 'src/components/data/RenameTableModal'
 import Dropzone from 'src/components/Dropzone'
 import FloatingActionButton from 'src/components/FloatingActionButton'
 import { icon, spinner } from 'src/components/icons'
@@ -467,6 +468,7 @@ const DataTableActions = ({ workspace, tableName, rowCount }) => {
   const [loading, setLoading] = useState(false)
   const [entities, setEntities] = useState([])
   const [exporting, setExporting] = useState(false)
+  const [renaming, setRenaming] = useState(false)
 
   return h(Fragment, [
     h(MenuTrigger, {
@@ -504,7 +506,12 @@ const DataTableActions = ({ workspace, tableName, rowCount }) => {
             setEntities(_.map(_.get('name'), queryResults.results))
             setExporting(true)
           })
-        }, 'Export to workspace')
+        }, 'Export to workspace'),
+        h(MenuButton, {
+          onClick: () => {
+            setRenaming(true)
+          }
+        }, 'Rename table')
       ])
     }, [
       h(Clickable, {
@@ -522,6 +529,11 @@ const DataTableActions = ({ workspace, tableName, rowCount }) => {
       selectedDataType: tableName,
       selectedEntities: entities,
       runningSubmissionsCount
+    }),
+    renaming && h(RenameTableModal, {
+      onDismiss: () => setRenaming(false),
+      workspace,
+      selectedDataType: tableName
     })
   ])
 }

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -458,7 +458,7 @@ const SidebarSeparator = ({ sidebarWidth, setSidebarWidth }) => {
   ])
 }
 
-const DataTableActions = ({ workspace, tableName, rowCount }) => {
+const DataTableActions = ({ workspace, tableName, rowCount, onSuccess }) => {
   const { workspace: { namespace, name }, workspaceSubmissionStats: { runningSubmissionsCount } } = workspace
   const isSetOfSets = tableName.endsWith('_set_set')
 
@@ -536,6 +536,7 @@ const DataTableActions = ({ workspace, tableName, rowCount }) => {
     }),
     renaming && h(RenameTableModal, {
       onDismiss: () => setRenaming(false),
+      onSuccess,
       namespace, name,
       selectedDataType: tableName
     })
@@ -732,7 +733,8 @@ const WorkspaceData = _.flow(
                   after: isDataTabRedesignEnabled() && h(DataTableActions, {
                     tableName: type,
                     rowCount: typeDetails.count,
-                    workspace
+                    workspace,
+                    onSuccess: () => loadMetadata()
                   })
                 })
               }, sortedEntityPairs)

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -458,7 +458,7 @@ const SidebarSeparator = ({ sidebarWidth, setSidebarWidth }) => {
   ])
 }
 
-const DataTableActions = ({ workspace, tableName, rowCount, onSuccess }) => {
+const DataTableActions = ({ workspace, tableName, rowCount, onUpdateSuccess }) => {
   const { workspace: { namespace, name }, workspaceSubmissionStats: { runningSubmissionsCount } } = workspace
   const isSetOfSets = tableName.endsWith('_set_set')
 
@@ -536,7 +536,7 @@ const DataTableActions = ({ workspace, tableName, rowCount, onSuccess }) => {
     }),
     renaming && h(RenameTableModal, {
       onDismiss: () => setRenaming(false),
-      onSuccess,
+      onUpdateSuccess,
       namespace, name,
       selectedDataType: tableName
     })
@@ -734,7 +734,7 @@ const WorkspaceData = _.flow(
                     tableName: type,
                     rowCount: typeDetails.count,
                     workspace,
-                    onSuccess: () => loadMetadata()
+                    onUpdateSuccess: () => loadMetadata()
                   })
                 })
               }, sortedEntityPairs)

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -532,7 +532,7 @@ const DataTableActions = ({ workspace, tableName, rowCount }) => {
     }),
     renaming && h(RenameTableModal, {
       onDismiss: () => setRenaming(false),
-      workspace,
+      namespace, name,
       selectedDataType: tableName
     })
   ])


### PR DESCRIPTION
New menu option "Rename table":
<img width="342" alt="Screen Shot 2022-05-04 at 3 59 12 PM" src="https://user-images.githubusercontent.com/7257391/166816168-a58edc75-3a3f-4f16-9b58-6d094ee4e850.png">


New modal:

<img width="465" alt="Screen Shot 2022-05-04 at 3 59 03 PM" src="https://user-images.githubusercontent.com/7257391/166816160-6e3c2251-4bd4-4be8-90ee-4d0ca1b9f347.png">

https://broadworkbench.atlassian.net/browse/SU-36

<!--
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Also, so if a screen recording [1] and/or screenshots would be a helpful way to communicate context, please consider including some in your PR description.
Thanks!

[1] https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac
--!>
