### PR TITLE
[SU-78] Data uploader file browser does not refresh list of files after upload completes

### DIFF
--- a/src/components/data/FileBrowser.js
+++ b/src/components/data/FileBrowser.js
@@ -101,8 +101,9 @@ export const FileBrowserPanel = _.flow(
 
   useEffect(() => {
     if (!uploadStatus.active) {
-      // If the uploader has completed, count all the files in the bucket
+      // If the uploader has completed, count all the files in the bucket and reload the files list
       count()
+      load(prefix)
     } else {
       // While the uploader is working, refresh the table no more often than every 5 seconds
       const now = Date.now()


### PR DESCRIPTION
If you go to the Data Uploader and use the dropzone to upload files, the list of files does not update afterwards, making it appear as if your file never got uploaded. Uploading a second file will refresh the file list, and you will see the first file, but not the newest file.

Link to data uploader to test current behavior: https://app.terra.bio/#upload

<!--
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Also, so if a screen recording [1] and/or screenshots would be a helpful way to communicate context, please consider including some in your PR description.
Thanks!

[1] https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac
--!>
