### PR TITLE
[SU-104] Store column settings as json

### DIFF
--- a/src/components/data/SavedColumnSettings.js
+++ b/src/components/data/SavedColumnSettings.js
@@ -78,7 +78,6 @@ const useSavedColumnSettings = ({ workspaceId, snapshotName, entityMetadata, ent
   const updateSavedColumnSettings = async allColumnSettings => {
     const { namespace, name } = workspaceId
     await Ajax(signal).Workspaces.workspace(namespace, name).shallowMergeNewAttributes({
-      // Store settings as a string since Rawls expects lists of objects to be entity references
       [savedColumnSettingsWorkspaceAttributeName]: allColumnSettings
     })
   }

--- a/src/components/data/SavedColumnSettings.js
+++ b/src/components/data/SavedColumnSettings.js
@@ -52,12 +52,24 @@ const useSavedColumnSettings = ({ workspaceId, snapshotName, entityMetadata, ent
 
   const signal = useCancellation()
 
+  // Column settings are now stored as JSON in the rawls database (max size 16mb)
+  // In an earlier version of this feature, they were stored as Strings in rawls (max size 64kb)
+  // For backwards-compatibility purposes, we need to support both cases. So we will try to parse
+  // the column settings as a String and if that fails then we will parse it as regular JSON
+  const parseAsStringOrJson = attr => {
+    try {
+      return JSON.parse(attr)
+    } catch (e) {
+      return attr
+    }
+  }
+
   const getAllSavedColumnSettings = async () => {
     const { namespace, name } = workspaceId
     const { workspace: { attributes } } = await Ajax(signal).Workspaces.workspace(namespace, name).details(['workspace.attributes'])
     return _.flow(
       _.getOr('{}', savedColumnSettingsWorkspaceAttributeName),
-      JSON.parse,
+      parseAsStringOrJson,
       // Drop any column settings for entity types that no longer exist
       _.update(baseKey, _.pick(_.keys(entityMetadata)))
     )(attributes)
@@ -67,7 +79,7 @@ const useSavedColumnSettings = ({ workspaceId, snapshotName, entityMetadata, ent
     const { namespace, name } = workspaceId
     await Ajax(signal).Workspaces.workspace(namespace, name).shallowMergeNewAttributes({
       // Store settings as a string since Rawls expects lists of objects to be entity references
-      [savedColumnSettingsWorkspaceAttributeName]: JSON.stringify(allColumnSettings)
+      [savedColumnSettingsWorkspaceAttributeName]: allColumnSettings
     })
   }
 

--- a/src/components/data/SavedColumnSettings.js
+++ b/src/components/data/SavedColumnSettings.js
@@ -52,7 +52,7 @@ const useSavedColumnSettings = ({ workspaceId, snapshotName, entityMetadata, ent
 
   const signal = useCancellation()
 
-  // Column settings are now stored as JSON in the rawls database (max size 16mb)
+  // Column settings are now stored as JSON in the rawls database (max size 4gb)
   // In an earlier version of this feature, they were stored as Strings in rawls (max size 64kb)
   // For backwards-compatibility purposes, we need to support both cases. So we will try to parse
   // the column settings as a String and if that fails then we will parse it as regular JSON


### PR DESCRIPTION
The motivation for this change is that a power-user has reached a point where the JSON string that we use for `columnSettings` has exceeded the 64kb limit for the `value_string` column in the Rawls database (it is a `TEXT` column). This can happen when there are a lot of columns, a lot of tables, a lot of different views saved, or some combination of all of that. In this PR, we coerce the `columnSettings` into a JSON object rather than a JSON string. Rawls stores JSON workspace attributes in a separate column- one that is `LONGTEXT` and able to support up to 4gb of data. 

The best way to test this is:

1) Save a column view for a workspace on dev
2) View that workspace column view on the PR deployment (this verifies that we are backwards compatible with strings)
3) Save a new column view using the PR deployment
4) Ensure that the column view works correctly on the PR deployment

You can manage column settings by clicking the Gear icon visible on the top right of a table in the Data tab of a workspace.

Also see this PR for some screenshots of what the modal looks like: https://github.com/DataBiosphere/terra-ui/pull/2878

<!--
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Also, so if a screen recording [1] and/or screenshots would be a helpful way to communicate context, please consider including some in your PR description.
Thanks!

[1] https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac
--!>
