### PR TITLE
[AJ-345] Add snapshot ID to by-reference snapshot display

### DIFF
--- a/src/components/workspace-utils.js
+++ b/src/components/workspace-utils.js
@@ -187,7 +187,8 @@ export const SnapshotInfo = ({
         div([sourceDescription]),
         h(SnapshotLabeledInfo, {
           title: 'Data Repo Snapshot Id:', text: [h(Link, {
-            href: `${getConfig().dataRepoUrlRoot}/snapshots/${snapshotId}`, target: '_blank'
+            href: `${getConfig().dataRepoUrlRoot}/snapshots/${snapshotId}`, target: '_blank',
+            'aria-label': 'Go to the snapshot in a new tab'
           }, [snapshotId]), h(ClipboardButton, { 'aria-label': 'Copy data repo snapshot id to clipboard', text: snapshotId, style: { marginLeft: '0.25rem' } })]
         }),
         div({ style: Style.dashboard.header }, [`Source Data Repo Dataset${source.length > 1 ? 's' : ''}`]),
@@ -202,7 +203,8 @@ export const SnapshotInfo = ({
             div([datasetDescription]),
             h(SnapshotLabeledInfo, {
               title: 'Data Repo Dataset Id:', text: [h(Link, {
-                href: `${getConfig().dataRepoUrlRoot}/datasets/${id}`, target: '_blank'
+                href: `${getConfig().dataRepoUrlRoot}/datasets/${id}`, target: '_blank',
+                'aria-label': 'Go to the dataset in a new tab'
               }, [id]), h(ClipboardButton, { 'aria-label': 'Copy data repo dataset id to clipboard', text: snapshotId, style: { marginLeft: '0.25rem' } })]
             })
           ])

--- a/src/components/workspace-utils.js
+++ b/src/components/workspace-utils.js
@@ -2,8 +2,7 @@ import debouncePromise from 'debounce-promise'
 import _ from 'lodash/fp'
 import { Fragment, useState } from 'react'
 import { b, div, h, p } from 'react-hyperscript-helpers'
-import {
-  AsyncCreatableSelect, ButtonPrimary, ButtonSecondary, ClipboardButton, IdContainer, Link, Select, spinnerOverlay
+import { AsyncCreatableSelect, ButtonPrimary, ButtonSecondary, ClipboardButton, IdContainer, Link, Select, spinnerOverlay
 } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import { ValidatedInput } from 'src/components/input'

--- a/src/components/workspace-utils.js
+++ b/src/components/workspace-utils.js
@@ -2,8 +2,7 @@ import debouncePromise from 'debounce-promise'
 import _ from 'lodash/fp'
 import { Fragment, useState } from 'react'
 import { b, div, h, p } from 'react-hyperscript-helpers'
-import { AsyncCreatableSelect, ButtonPrimary, ButtonSecondary, ClipboardButton, IdContainer, Link, Select, spinnerOverlay
-} from 'src/components/common'
+import { AsyncCreatableSelect, ButtonPrimary, ButtonSecondary, ClipboardButton, IdContainer, Link, Select, spinnerOverlay } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import { ValidatedInput } from 'src/components/input'
 import { MarkdownEditor, MarkdownViewer } from 'src/components/markdown'
@@ -182,26 +181,30 @@ export const SnapshotInfo = ({
       ]),
       div({ style: { paddingLeft: '1rem' } }, [
         div({ style: Style.dashboard.header }, ['Linked Data Repo Snapshot']),
-        h(SnapshotLabeledInfo, {
-          title: 'Data Repo Id:', text: [h(Link, {
-            href: `${getConfig().dataRepoUrlRoot}/snapshots/${snapshotId}`
-          }, [snapshotId]), h(ClipboardButton, { 'aria-label': 'Copy data repo id to clipboard', text: snapshotId, style: { marginLeft: '0.25rem' } })]
-        }),
         h(SnapshotLabeledInfo, { title: 'Name:', text: sourceName }),
         h(SnapshotLabeledInfo, { title: 'Creation Date:', text: Utils.makeCompleteDate(createdDate) }),
         div({ style: { ...Style.elements.sectionHeader, marginBottom: '0.2rem' } }, ['Description:']),
         div([sourceDescription]),
+        h(SnapshotLabeledInfo, {
+          title: 'Data Repo Snapshot Id:', text: [h(Link, {
+            href: `${getConfig().dataRepoUrlRoot}/snapshots/${snapshotId}`, target: '_blank'
+          }, [snapshotId]), h(ClipboardButton, { 'aria-label': 'Copy data repo snapshot id to clipboard', text: snapshotId, style: { marginLeft: '0.25rem' } })]
+        }),
         div({ style: Style.dashboard.header }, [`Source Data Repo Dataset${source.length > 1 ? 's' : ''}`]),
         _.map(({ dataset: { id, name: datasetName, description: datasetDescription, createdDate: datasetCreatedDate } }) => {
           return div({
             key: id,
             style: { marginBottom: '1rem' }
           }, [
-            h(SnapshotLabeledInfo, { title: 'Source Data Repo Id:', text: [id, h(ClipboardButton, { 'aria-label': 'Copy source data repo id to clipboard', text: id, style: { marginLeft: '0.25rem' } })] }),
             h(SnapshotLabeledInfo, { title: 'Name:', text: datasetName }),
             h(SnapshotLabeledInfo, { title: 'Creation Date:', text: Utils.makeCompleteDate(datasetCreatedDate) }),
             div({ style: { ...Style.elements.sectionHeader, marginBottom: '0.2rem' } }, ['Description:']),
-            div([datasetDescription])
+            div([datasetDescription]),
+            h(SnapshotLabeledInfo, {
+              title: 'Data Repo Dataset Id:', text: [h(Link, {
+                href: `${getConfig().dataRepoUrlRoot}/datasets/${id}`, target: '_blank'
+              }, [id]), h(ClipboardButton, { 'aria-label': 'Copy data repo dataset id to clipboard', text: snapshotId, style: { marginLeft: '0.25rem' } })]
+            })
           ])
         }, source)
       ]),

--- a/src/components/workspace-utils.js
+++ b/src/components/workspace-utils.js
@@ -2,13 +2,16 @@ import debouncePromise from 'debounce-promise'
 import _ from 'lodash/fp'
 import { Fragment, useState } from 'react'
 import { b, div, h, p } from 'react-hyperscript-helpers'
-import { AsyncCreatableSelect, ButtonPrimary, ButtonSecondary, IdContainer, Link, Select, spinnerOverlay } from 'src/components/common'
+import {
+  AsyncCreatableSelect, ButtonPrimary, ButtonSecondary, ClipboardButton, IdContainer, Link, Select, spinnerOverlay
+} from 'src/components/common'
 import { icon } from 'src/components/icons'
 import { ValidatedInput } from 'src/components/input'
 import { MarkdownEditor, MarkdownViewer } from 'src/components/markdown'
 import Modal from 'src/components/Modal'
 import NewWorkspaceModal from 'src/components/NewWorkspaceModal'
 import { Ajax } from 'src/libs/ajax'
+import { getConfig } from 'src/libs/config'
 import { reportError, withErrorReporting } from 'src/libs/error'
 import Events, { extractWorkspaceDetails } from 'src/libs/events'
 import { FormLabel } from 'src/libs/forms'
@@ -180,6 +183,11 @@ export const SnapshotInfo = ({
       ]),
       div({ style: { paddingLeft: '1rem' } }, [
         div({ style: Style.dashboard.header }, ['Linked Data Repo Snapshot']),
+        h(SnapshotLabeledInfo, {
+          title: 'Data Repo Id:', text: [h(Link, {
+            href: `${getConfig().dataRepoUrlRoot}/snapshots/${snapshotId}`
+          }, [snapshotId]), h(ClipboardButton, { 'aria-label': 'Copy data repo id to clipboard', text: snapshotId, style: { marginLeft: '0.25rem' } })]
+        }),
         h(SnapshotLabeledInfo, { title: 'Name:', text: sourceName }),
         h(SnapshotLabeledInfo, { title: 'Creation Date:', text: Utils.makeCompleteDate(createdDate) }),
         div({ style: { ...Style.elements.sectionHeader, marginBottom: '0.2rem' } }, ['Description:']),
@@ -190,6 +198,7 @@ export const SnapshotInfo = ({
             key: id,
             style: { marginBottom: '1rem' }
           }, [
+            h(SnapshotLabeledInfo, { title: 'Source Data Repo Id:', text: [id, h(ClipboardButton, { 'aria-label': 'Copy source data repo id to clipboard', text: id, style: { marginLeft: '0.25rem' } })] }),
             h(SnapshotLabeledInfo, { title: 'Name:', text: datasetName }),
             h(SnapshotLabeledInfo, { title: 'Creation Date:', text: Utils.makeCompleteDate(datasetCreatedDate) }),
             div({ style: { ...Style.elements.sectionHeader, marginBottom: '0.2rem' } }, ['Description:']),


### PR DESCRIPTION
[Jira Ticket](https://broadworkbench.atlassian.net/browse/AJ-345)
Add dataset uuids to snapshot-by-reference info page with clipboard copy icons.

To see:
Add a snapshot reference to a workspace through api/workspaces/{workspaceNamespace}/{workspaceName}/snapshots/v2.
Go to the data tab of the workspace.
<img width="1512" alt="Screen Shot 2022-05-10 at 9 50 18 AM" src="https://user-images.githubusercontent.com/5884792/167647778-5e5559e3-fcc6-4128-89b7-8c4361efb499.png">
Click the 'i' next to your snapshot. 
