### PR TITLE
[SU-101] Capitalize Support in share workspace modal

### DIFF
--- a/src/pages/workspaces/workspace/ShareWorkspaceModal.js
+++ b/src/pages/workspaces/workspace/ShareWorkspaceModal.js
@@ -285,7 +285,7 @@ const ShareWorkspaceModal = ({ onDismiss, workspace, workspace: { workspace: { n
           )
         }, [
           label({ htmlFor: id }, [
-            span({ style: { marginRight: '1ch' } }, 'Share with support'),
+            span({ style: { marginRight: '1ch' } }, 'Share with Support'),
             h(Switch, {
               id,
               checked: !!newTerraSupportAccessLevel,


### PR DESCRIPTION
The share workspace modal has an option to share a workspace with the support team. Since "support" here is a proper noun referring to the Terra Support team, it should be capitalized.

![Screen Shot 2022-05-09 at 11 37 53 AM](https://user-images.githubusercontent.com/1156625/167445923-7e47b2f2-b9fe-4136-90be-c7bc0f2d6d61.png)

