### PR TITLE
[DC-324] accessing google buckets can fail resulting in error notifications for users

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -65,8 +65,9 @@ const withCancellation = wrappedFetch => async (...args) => {
 // on timeout return the error observed
 
 // Naming - better name for the wrapper - withRetryUntil ?
-const withRetryOnError = ({ ms = 10000 }, wrappedFetch) => async (...args) => {
+const withRetryOnError = _.curry(({ ms = 10000 }, wrappedFetch) => async (...args) => {
   const somePointInTheFuture = Date.now() + ms
+  console.log('somePointInTheFuture', somePointInTheFuture, Date.now() < somePointInTheFuture)
   const maxDelayIncrement = 1500
   const minDelay = 500
 
@@ -82,7 +83,7 @@ const withRetryOnError = ({ ms = 10000 }, wrappedFetch) => async (...args) => {
   }
   console.log('loop timed out')
   return wrappedFetch(...args)
-}
+})
 
 // Converts non-200 responses to exceptions
 const withErrorRejection = wrappedFetch => async (...args) => {

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -160,7 +160,7 @@ export const delay = ms => {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
 
-export const withDelay = _.curry((ms,wrappedFn) => async (...args) => {
+export const withDelay = _.curry((ms, wrappedFn) => async (...args) => {
   await delay(ms)
   return wrappedFn(...args)
 })

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -160,7 +160,7 @@ export const delay = ms => {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
 
-export const withDelay = _.curry((wrappedFn, ms) => async (...args) => {
+export const withDelay = _.curry((ms,wrappedFn) => async (...args) => {
   await delay(ms)
   return wrappedFn(...args)
 })

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -160,6 +160,11 @@ export const delay = ms => {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
 
+export const withDelay = _.curry((wrappedFn, ms) => async (...args) => {
+  await delay(ms)
+  return wrappedFn(...args)
+})
+
 export const onNextTick = (fn, ...args) => setTimeout(() => fn(...args), 0)
 
 // Returns a promise that will never resolve or reject. Useful for cancelling async flows.


### PR DESCRIPTION
When using Terra UI we get a lot of error notifications around google buckets not being accessible.

This can cause [test flakiness](https://broadinstitute.slack.com/archives/C01EHNUM73R/p1644358202261189?thread_ts=1644354756.201859&cid=C01EHNUM73R) and also manifests in production, where users tend to see error notifications.

Google recommends [retry logic ](https://cloud.google.com/storage/docs/retry-strategy#rest-apis)for these requests

Where to Start

Take a look at the [ajax.js](https://github.com/DataBiosphere/terra-ui/blob/c1d969c83e59560d86916ce62b2f166b25e8c7ee/src/libs/ajax.js#L56) file, specifically at some of the wrapper functions. withErrorRejection is a simple example to start with.

Create a wrapper function that will retry a request after failure. A key property of a wrapper function is that it should return a function with the same signature as the function that was passed in (again see withErrorRejection)

This is something that can be done in a standalone fashion, if that makes it easier. You can create a wrapper that retries any function upon receiving an error.

It’s Done when

Our google api calls in ajax.js are wrapped in retry logic.

For testing, you can use the browser dev tools to block access to API’s to simulate a failed request