### PR TITLE
[WOR-244] Workspace menu cleanup

### DIFF
--- a/integration-tests/tests/workspace-dashboard.js
+++ b/integration-tests/tests/workspace-dashboard.js
@@ -23,6 +23,10 @@ const workspaceDashboardPage = (testPage, testUrl, token, workspaceName) => {
       await Promise.all(_.map(async item => await findText(testPage, item), expectedTextItems))
     },
 
+    assertReadOnly: async () => {
+      await findText(testPage, 'Workspace is read only')
+    },
+
     assertWorkspaceMenuItems: async expectedMenuItems => {
       await click(testPage, clickable({ text: 'Workspace Action Menu' }))
       await Promise.all(_.map(async ({ label, tooltip }) => {
@@ -106,7 +110,7 @@ const setAjaxMockValues = async (testPage, namespace, name, workspaceDescription
     workspaceVersion: 'v2'
   }
   const azureWorkspacesListResult = [{
-    accessLevel: 'WRITER',
+    accessLevel: 'READER',
     public: false,
     workspace: workspaceInfo,
     workspaceSubmissionStats: { runningSubmissionsCount: 0 }
@@ -119,7 +123,7 @@ const setAjaxMockValues = async (testPage, namespace, name, workspaceDescription
       tenantId: 'dummy-tenant-id'
     },
     workspaceSubmissionStats: { runningSubmissionsCount: 0 },
-    accessLevel: 'WRITER',
+    accessLevel: 'READER',
     owners: ['dummy@email.comm'],
     workspace: workspaceInfo,
     canShare: true,
@@ -177,7 +181,10 @@ const testAzureWorkspace = withUserToken(async ({ page, token, testUrl }) => {
   // Check cloud information
   await dashboard.assertCloudInformation(['Cloud NameMicrosoft Azure', 'Resource Group IDdummy-mrg-id'])
 
-  // Verify workspace tooltips on Workspace menu items (all will be disabled, WRITER permissions only).
+  // READER permissions only
+  await dashboard.assertReadOnly()
+
+  // Verify workspace tooltips on Workspace menu items (all will be disabled due to Azure workspace + READER permissions).
   await dashboard.assertWorkspaceMenuItems([
     { label: 'Clone', tooltip: 'Cloning is not supported on Azure Workspaces' },
     { label: 'Share', tooltip: 'Sharing is not supported on Azure Workspaces' },

--- a/integration-tests/tests/workspace-dashboard.js
+++ b/integration-tests/tests/workspace-dashboard.js
@@ -20,7 +20,7 @@ const workspaceDashboardPage = (testPage, testUrl, token, workspaceName) => {
 
     assertCloudInformation: async expectedTextItems => {
       await click(testPage, clickable({ text: 'Cloud information' }))
-      await Promise.all(_.map(async (item) => await findText(testPage, item), expectedTextItems))
+      await Promise.all(_.map(async item => await findText(testPage, item), expectedTextItems))
     },
 
     assertWorkspaceMenuItems: async expectedMenuItems => {
@@ -52,7 +52,7 @@ const workspaceDashboardPage = (testPage, testUrl, token, workspaceName) => {
     },
 
     assertTabs: async (expectedTabs, enabled) => {
-      await Promise.all(_.map(async (tab) => {
+      await Promise.all(_.map(async tab => {
         await (enabled ? clickNavChildAndLoad(testPage, tab) : assertNavChildNotFound(testPage, tab))
       }, expectedTabs))
     }

--- a/integration-tests/tests/workspace-dashboard.js
+++ b/integration-tests/tests/workspace-dashboard.js
@@ -1,30 +1,89 @@
 // This test is owned by the Workspaces Team.
 const _ = require('lodash/fp')
-const { clickNavChildAndLoad, viewWorkspaceDashboard, withWorkspace } = require('../utils/integration-helpers')
-const { assertNavChildNotFound, click, clickable, findText } = require('../utils/integration-utils')
+const { clickNavChildAndLoad, overrideConfig, viewWorkspaceDashboard, withWorkspace } = require('../utils/integration-helpers')
+const { assertNavChildNotFound, assertTextNotFound, click, clickable, findElement, findText, noSpinnersAfter } = require('../utils/integration-utils')
 const { withUserToken } = require('../utils/terra-sa-utils')
-const { waitUntilLoadedOrTimeout } = require('../utils/integration-utils')
 
+
+const workspaceDashboardPage = (testPage, testUrl, token, workspaceName) => {
+  return {
+    visit: async (loadUrl = true) => {
+      if (loadUrl) {
+        await testPage.goto(testUrl)
+      }
+      await viewWorkspaceDashboard(testPage, token, workspaceName)
+    },
+
+    assertDescription: async expectedDescription => {
+      await findText(testPage, expectedDescription)
+    },
+
+    assertCloudInformation: async expectedTextItems => {
+      await click(testPage, clickable({ text: 'Cloud information' }))
+      await Promise.all(_.map( async(item) => await findText(testPage, item), expectedTextItems ))
+    },
+
+    assertWorkspaceMenuItems: async expectedMenuItems => {
+      await click(testPage, clickable({ text: 'Workspace Action Menu' }))
+      await Promise.all(_.map( async({ label, tooltip }) => {
+        if (!!tooltip) {
+          await findElement(testPage, clickable({ textContains: label, isEnabled: false }))
+          await findText(testPage, tooltip)
+        }
+        else {
+          await findElement(testPage, clickable({ textContains: label }))
+        }
+      }, expectedMenuItems ))
+    },
+
+    assertLockWorkspace: async () => {
+      await assertTextNotFound(testPage, 'Workspace is locked')
+      await click(testPage, clickable({ text: 'Workspace Action Menu' }))
+      await click(testPage, clickable({ textContains: 'Lock' }))
+      await noSpinnersAfter(testPage, { action: () => click(page, clickable({ textContains: 'Lock Workspace' })) })
+      await findText(testPage, 'Workspace is locked')
+    },
+
+    assertUnlockWorkspace: async () => {
+      await findText(testPage, 'Workspace is locked')
+      await click(testPage, clickable({ text: 'Workspace Action Menu' }))
+      await click(testPage, clickable({ textContains: 'Unlock' }))
+      await noSpinnersAfter(testPage, { action: () => click(page, clickable({ textContains: 'Unlock Workspace' })) })
+      await assertTextNotFound(testPage, 'Workspace is locked')
+    },
+
+    assertTabs: async(expectedTabs, enabled) => {
+      await Promise.all(_.map( async(tab) => {
+        await (enabled ? clickNavChildAndLoad(testPage, tab) : assertNavChildNotFound(testPage, tab))
+      }, expectedTabs))
+    },
+  }
+}
 
 const testGoogleWorkspace = _.flow(
   withWorkspace,
   withUserToken
 )(async ({ page, token, testUrl, workspaceName }) => {
-  await page.goto(testUrl, waitUntilLoadedOrTimeout(60 * 1000))
-  await viewWorkspaceDashboard(page, token, workspaceName)
-  await findText(page, 'About the workspace')
+  const dashboard = workspaceDashboardPage(page, testUrl, token, workspaceName)
+  await dashboard.visit()
+  await dashboard.assertDescription('About the workspace')
 
   // Check selected items in cloud information
   const currentDate = new Date().toLocaleDateString()
-  await click(page, clickable({ text: 'Cloud information' }))
-  await findText(page, 'Cloud NameGoogle Cloud Platform')
-  await findText(page, `Bucket SizeUpdated on ${currentDate}0 B`)
+  await dashboard.assertCloudInformation(['Cloud NameGoogle Cloud Platform', `Bucket SizeUpdated on ${currentDate}0 B`])
+
+  // Test locking and unlocking the workspace
+  await dashboard.assertLockWorkspace()
+  await dashboard.assertUnlockWorkspace()
+
+  // Verify other Workspace menu items are in correct state (all will be enabled).
+  await dashboard.assertWorkspaceMenuItems([{ label: 'Clone'}, { label: 'Share'}, { label: 'Delete'}])
 
   // Click on each of the expected tabs
-  await clickNavChildAndLoad(page, 'data')
-  await clickNavChildAndLoad(page, 'notebooks')
-  await clickNavChildAndLoad(page, 'workflows')
-  await clickNavChildAndLoad(page, 'job history')
+  await dashboard.assertTabs(['data', 'notebooks', 'workflows', 'job history'], true)
+
+  // Verify Analyses tab not present (config override is not set)
+  await dashboard.assertTabs(['analyses'], false)
 })
 
 const googleWorkspaceDashboard = {
@@ -48,7 +107,7 @@ const setAjaxMockValues = async (testPage, namespace, name, workspaceDescription
     workspaceVersion: 'v2'
   }
   const azureWorkspacesListResult = [{
-    accessLevel: 'OWNER',
+    accessLevel: 'WRITER',
     public: false,
     workspace: workspaceInfo,
     workspaceSubmissionStats: { runningSubmissionsCount: 0 }
@@ -61,7 +120,7 @@ const setAjaxMockValues = async (testPage, namespace, name, workspaceDescription
       tenantId: 'dummy-tenant-id'
     },
     workspaceSubmissionStats: { runningSubmissionsCount: 0 },
-    accessLevel: 'OWNER',
+    accessLevel: 'WRITER',
     owners: ['dummy@email.comm'],
     workspace: workspaceInfo,
     canShare: true,
@@ -93,6 +152,10 @@ const setAjaxMockValues = async (testPage, namespace, name, workspaceDescription
       {
         filter: { url: /api\/workspaces[^/](.*)/ },
         fn: () => () => Promise.resolve(new Response(JSON.stringify(azureWorkspacesListResult), { status: 200 }))
+      },
+      {
+        filter: { url: /api\/v2\/runtimes(.*)/ },  // Needed to prevent errors from the Runtime (IA) component that will be going away.
+        fn: () => () => Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
       }
     ])
   }, azureWorkspacesListResult, azureWorkspaceDetailsResult, namespace, name)
@@ -105,21 +168,30 @@ const testAzureWorkspace = withUserToken(async ({ page, token, testUrl }) => {
   // Must load page before setting mock responses.
   await page.goto(testUrl)
   await findText(page, 'View Workspaces')
+  await overrideConfig(page, { isAnalysisTabVisible: true })
   await setAjaxMockValues(page, 'azure-workspace-ns', workspaceName, workspaceDescription)
 
-  await viewWorkspaceDashboard(page, token, workspaceName)
-  await findText(page, workspaceDescription)
+  const dashboard = workspaceDashboardPage(page, testUrl, token, workspaceName)
+  await dashboard.visit(false)
+  await dashboard.assertDescription(workspaceDescription)
 
   // Check cloud information
-  await click(page, clickable({ text: 'Cloud information' }))
-  await findText(page, 'Cloud NameMicrosoft Azure')
-  await findText(page, 'Resource Group IDdummy-mrg-id')
+  await dashboard.assertCloudInformation(['Cloud NameMicrosoft Azure', 'Resource Group IDdummy-mrg-id'])
+
+  // Verify workspace tooltips on Workspace menu items (all will be disabled, WRITER permissions only).
+  await dashboard.assertWorkspaceMenuItems([
+    { label: 'Clone', tooltip: 'Cloning is not supported on Azure Workspaces' },
+    { label: 'Share', tooltip: 'Sharing is not supported on Azure Workspaces' },
+    { label: 'Lock', tooltip: 'You have not been granted permission to lock this workspace' },
+    { label: 'Delete', tooltip: 'You have not been granted permission to lock this workspace' }
+  ])
 
   // Verify tabs that currently depend on Google project ID are not present.
-  await assertNavChildNotFound(page, 'data')
-  await assertNavChildNotFound(page, 'notebooks')
-  await assertNavChildNotFound(page, 'workflows')
-  await assertNavChildNotFound(page, 'job history')
+  await dashboard.assertTabs(['data', 'notebooks', 'workflows', 'job history'], false)
+
+  // Verify Analyses tab is present (config override is set)
+  await dashboard.assertTabs(['analyses'], true)
+
 })
 
 const azureWorkspaceDashboard = {

--- a/integration-tests/tests/workspace-dashboard.js
+++ b/integration-tests/tests/workspace-dashboard.js
@@ -186,8 +186,8 @@ const testAzureWorkspace = withUserToken(async ({ page, token, testUrl }) => {
 
   // Verify workspace tooltips on Workspace menu items (all will be disabled due to Azure workspace + READER permissions).
   await dashboard.assertWorkspaceMenuItems([
-    { label: 'Clone', tooltip: 'Cloning is not supported on Azure Workspaces' },
-    { label: 'Share', tooltip: 'Sharing is not supported on Azure Workspaces' },
+    { label: 'Clone', tooltip: 'Cloning is not currently supported on Azure Workspaces' },
+    { label: 'Share', tooltip: 'Sharing is not currently supported on Azure Workspaces' },
     { label: 'Lock', tooltip: 'You have not been granted permission to lock this workspace' },
     { label: 'Delete', tooltip: 'You have not been granted permission to lock this workspace' }
   ])

--- a/integration-tests/tests/workspace-dashboard.js
+++ b/integration-tests/tests/workspace-dashboard.js
@@ -20,20 +20,19 @@ const workspaceDashboardPage = (testPage, testUrl, token, workspaceName) => {
 
     assertCloudInformation: async expectedTextItems => {
       await click(testPage, clickable({ text: 'Cloud information' }))
-      await Promise.all(_.map( async(item) => await findText(testPage, item), expectedTextItems ))
+      await Promise.all(_.map(async (item) => await findText(testPage, item), expectedTextItems))
     },
 
     assertWorkspaceMenuItems: async expectedMenuItems => {
       await click(testPage, clickable({ text: 'Workspace Action Menu' }))
-      await Promise.all(_.map( async({ label, tooltip }) => {
+      await Promise.all(_.map(async ({ label, tooltip }) => {
         if (!!tooltip) {
           await findElement(testPage, clickable({ textContains: label, isEnabled: false }))
           await findText(testPage, tooltip)
-        }
-        else {
+        } else {
           await findElement(testPage, clickable({ textContains: label }))
         }
-      }, expectedMenuItems ))
+      }, expectedMenuItems))
     },
 
     assertLockWorkspace: async () => {
@@ -52,11 +51,11 @@ const workspaceDashboardPage = (testPage, testUrl, token, workspaceName) => {
       await assertTextNotFound(testPage, 'Workspace is locked')
     },
 
-    assertTabs: async(expectedTabs, enabled) => {
-      await Promise.all(_.map( async(tab) => {
+    assertTabs: async (expectedTabs, enabled) => {
+      await Promise.all(_.map(async (tab) => {
         await (enabled ? clickNavChildAndLoad(testPage, tab) : assertNavChildNotFound(testPage, tab))
       }, expectedTabs))
-    },
+    }
   }
 }
 
@@ -77,7 +76,7 @@ const testGoogleWorkspace = _.flow(
   await dashboard.assertUnlockWorkspace()
 
   // Verify other Workspace menu items are in correct state (all will be enabled).
-  await dashboard.assertWorkspaceMenuItems([{ label: 'Clone'}, { label: 'Share'}, { label: 'Delete'}])
+  await dashboard.assertWorkspaceMenuItems([{ label: 'Clone' }, { label: 'Share' }, { label: 'Delete' }])
 
   // Click on each of the expected tabs
   await dashboard.assertTabs(['data', 'notebooks', 'workflows', 'job history'], true)
@@ -154,7 +153,7 @@ const setAjaxMockValues = async (testPage, namespace, name, workspaceDescription
         fn: () => () => Promise.resolve(new Response(JSON.stringify(azureWorkspacesListResult), { status: 200 }))
       },
       {
-        filter: { url: /api\/v2\/runtimes(.*)/ },  // Needed to prevent errors from the Runtime (IA) component that will be going away.
+        filter: { url: /api\/v2\/runtimes(.*)/ }, // Needed to prevent errors from the Runtime (IA) component that will be going away.
         fn: () => () => Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
       }
     ])
@@ -191,7 +190,6 @@ const testAzureWorkspace = withUserToken(async ({ page, token, testUrl }) => {
 
   // Verify Analyses tab is present (config override is set)
   await dashboard.assertTabs(['analyses'], true)
-
 })
 
 const azureWorkspaceDashboard = {

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -1,7 +1,7 @@
 import { isAfter, parseJSON } from 'date-fns/fp'
 import _ from 'lodash/fp'
 import * as qs from 'qs'
-import { Fragment, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { div, h, span } from 'react-hyperscript-helpers'
 import { AutoSizer } from 'react-virtualized'
 import { HeaderRenderer, Link, Select, topSpinnerOverlay, transparentSpinnerOverlay } from 'src/components/common'
@@ -9,7 +9,6 @@ import FooterWrapper from 'src/components/FooterWrapper'
 import { icon } from 'src/components/icons'
 import { DelayedSearchInput } from 'src/components/input'
 import NewWorkspaceModal from 'src/components/NewWorkspaceModal'
-import { makeMenuIcon, MenuButton, MenuTrigger } from 'src/components/PopupTrigger'
 import { SimpleTabBar } from 'src/components/tabBars'
 import { FlexTable } from 'src/components/table'
 import TooltipTrigger from 'src/components/TooltipTrigger'
@@ -26,6 +25,7 @@ import DeleteWorkspaceModal from 'src/pages/workspaces/workspace/DeleteWorkspace
 import LockWorkspaceModal from 'src/pages/workspaces/workspace/LockWorkspaceModal'
 import { RequestAccessModal } from 'src/pages/workspaces/workspace/RequestAccessModal'
 import ShareWorkspaceModal from 'src/pages/workspaces/workspace/ShareWorkspaceModal'
+import { WorkspaceMenuContent, WorkspaceMenuTrigger } from 'src/pages/workspaces/workspace/WorkspaceMenu'
 
 
 const styles = {
@@ -47,38 +47,13 @@ const workspaceSubmissionStatus = ({ workspaceSubmissionStats: { runningSubmissi
   )
 }
 
-const WorkspaceMenuContent = ({ namespace, name, onClone, onShare, onDelete, onLock }) => {
-  const { workspace } = useWorkspaceDetails({ namespace, name }, ['accessLevel', 'canShare', 'workspace.isLocked'])
-  const canRead = workspace && Utils.canRead(workspace.accessLevel)
+const WorkspaceMenuItems = ({ namespace, name, onClone, onShare, onDelete, onLock }) => {
+  const { workspace } = useWorkspaceDetails({ namespace, name }, ['accessLevel', 'azureContext', 'canShare', 'workspace.isLocked'])
   const canShare = workspace?.canShare
   const isOwner = workspace && Utils.isOwner(workspace.accessLevel)
   const isLocked = workspace?.workspace.isLocked
-  return h(Fragment, [
-    h(MenuButton, {
-      disabled: !canRead,
-      tooltip: workspace && !canRead && 'You do not have access to the workspace Authorization Domain',
-      tooltipSide: 'left',
-      onClick: onClone
-    }, [makeMenuIcon('copy'), 'Clone']),
-    h(MenuButton, {
-      disabled: !canShare,
-      tooltip: workspace && !canShare && 'You have not been granted permission to share this workspace',
-      tooltipSide: 'left',
-      onClick: onShare
-    }, [makeMenuIcon('share'), 'Share']),
-    h(MenuButton, {
-      disabled: !isOwner,
-      tooltip: !isOwner && ['You have not been granted permission to ', isLocked ? 'unlock' : 'lock', ' this workspace'],
-      tooltipSide: 'left',
-      onClick: onLock
-    }, isLocked ? [makeMenuIcon('unlock'), 'Unlock'] : [makeMenuIcon('lock'), 'Lock']),
-    h(MenuButton, {
-      disabled: !isOwner,
-      tooltip: workspace && !isOwner && 'You must be an owner of this workspace or the underlying billing project',
-      tooltipSide: 'left',
-      onClick: onDelete
-    }, [makeMenuIcon('trash'), 'Delete'])
-  ])
+  const isAzureWorkspace = !!workspace?.azureContext
+  return WorkspaceMenuContent({ canShare, isAzureWorkspace, isLocked, isOwner, onClone, onShare, onLock, onDelete, workspaceLoaded: !!workspace })
 }
 
 export const WorkspaceList = () => {
@@ -260,7 +235,8 @@ export const WorkspaceList = () => {
           cellRenderer: ({ rowIndex }) => {
             const { accessLevel, workspace: { workspaceId, namespace, name }, ...workspace } = sortedWorkspaces[rowIndex]
             if (!Utils.canRead(accessLevel)) {
-              return
+              // No menu shown if user does not have read acccess.
+              return null
             }
             const onClone = () => setCloningWorkspaceId(workspaceId)
             const onDelete = () => setDeletingWorkspaceId(workspaceId)
@@ -270,17 +246,11 @@ export const WorkspaceList = () => {
 
             return div({ style: { ...styles.tableCellContainer, paddingRight: 0 } }, [
               div({ style: styles.tableCellContent }, [
-                h(MenuTrigger, {
-                  side: 'left',
-                  closeOnClick: true,
-                  content: h(WorkspaceMenuContent, { namespace, name, onShare, onClone, onDelete, onLock })
-                }, [
-                  h(Link, {
-                    'aria-label': `Menu for Workspace: ${name}`,
-                    'aria-haspopup': 'menu'
-                  }, [icon('cardMenuIcon', { size: 20 })])
-                ])
-              ]),
+                h(WorkspaceMenuTrigger,{
+                  iconSize: 20, popupLocation: 'left', workspaceName: name,
+                  menuContent: h(WorkspaceMenuItems, { namespace, name, onShare, onClone, onDelete, onLock }),
+                })]
+              ),
               div({ style: styles.tableCellContent }, [
                 !!lastRunStatus && h(TooltipTrigger, {
                   content: span(['Last submitted workflow status: ', span({ style: { fontWeight: 600 } }, [_.startCase(lastRunStatus)])]),

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -246,11 +246,11 @@ export const WorkspaceList = () => {
 
             return div({ style: { ...styles.tableCellContainer, paddingRight: 0 } }, [
               div({ style: styles.tableCellContent }, [
-                h(WorkspaceMenuTrigger,{
+                h(WorkspaceMenuTrigger, {
                   iconSize: 20, popupLocation: 'left', workspaceName: name,
-                  menuContent: h(WorkspaceMenuItems, { namespace, name, onShare, onClone, onDelete, onLock }),
-                })]
-              ),
+                  menuContent: h(WorkspaceMenuItems, { namespace, name, onShare, onClone, onDelete, onLock })
+                })
+              ]),
               div({ style: styles.tableCellContent }, [
                 !!lastRunStatus && h(TooltipTrigger, {
                   content: span(['Last submitted workflow status: ', span({ style: { fontWeight: 600 } }, [_.startCase(lastRunStatus)])]),

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -13,7 +13,7 @@ import { SimpleTabBar } from 'src/components/tabBars'
 import { FlexTable } from 'src/components/table'
 import TooltipTrigger from 'src/components/TooltipTrigger'
 import TopBar from 'src/components/TopBar'
-import { NoWorkspacesMessage, useWorkspaceDetails, useWorkspaces, WorkspaceTagSelect } from 'src/components/workspace-utils'
+import { NoWorkspacesMessage, useWorkspaces, WorkspaceTagSelect } from 'src/components/workspace-utils'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import Events from 'src/libs/events'
@@ -25,7 +25,7 @@ import DeleteWorkspaceModal from 'src/pages/workspaces/workspace/DeleteWorkspace
 import LockWorkspaceModal from 'src/pages/workspaces/workspace/LockWorkspaceModal'
 import { RequestAccessModal } from 'src/pages/workspaces/workspace/RequestAccessModal'
 import ShareWorkspaceModal from 'src/pages/workspaces/workspace/ShareWorkspaceModal'
-import { WorkspaceMenuContent, WorkspaceMenuTrigger } from 'src/pages/workspaces/workspace/WorkspaceMenu'
+import WorkspaceMenu from 'src/pages/workspaces/workspace/WorkspaceMenu'
 
 
 const styles = {
@@ -45,15 +45,6 @@ const workspaceSubmissionStatus = ({ workspaceSubmissionStats: { runningSubmissi
     [lastSuccessDate && (!lastFailureDate || isAfter(parseJSON(lastFailureDate), parseJSON(lastSuccessDate))), () => 'success'],
     [lastFailureDate, () => 'failure']
   )
-}
-
-const WorkspaceMenuItems = ({ namespace, name, onClone, onShare, onDelete, onLock }) => {
-  const { workspace } = useWorkspaceDetails({ namespace, name }, ['accessLevel', 'azureContext', 'canShare', 'workspace.isLocked'])
-  const canShare = workspace?.canShare
-  const isOwner = workspace && Utils.isOwner(workspace.accessLevel)
-  const isLocked = workspace?.workspace.isLocked
-  const isAzureWorkspace = !!workspace?.azureContext
-  return WorkspaceMenuContent({ canShare, isAzureWorkspace, isLocked, isOwner, onClone, onShare, onLock, onDelete, workspaceLoaded: !!workspace })
 }
 
 export const WorkspaceList = () => {
@@ -246,9 +237,10 @@ export const WorkspaceList = () => {
 
             return div({ style: { ...styles.tableCellContainer, paddingRight: 0 } }, [
               div({ style: styles.tableCellContent }, [
-                h(WorkspaceMenuTrigger, {
-                  iconSize: 20, popupLocation: 'left', workspaceName: name,
-                  menuContent: h(WorkspaceMenuItems, { namespace, name, onShare, onClone, onDelete, onLock })
+                h(WorkspaceMenu, {
+                  iconSize: 20, popupLocation: 'left',
+                  callbacks: { onClone, onShare, onLock, onDelete },
+                  workspaceInfo: { namespace, name }
                 })
               ]),
               div({ style: styles.tableCellContent }, [

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -28,7 +28,7 @@ import * as Utils from 'src/libs/utils'
 import DeleteWorkspaceModal from 'src/pages/workspaces/workspace/DeleteWorkspaceModal'
 import LockWorkspaceModal from 'src/pages/workspaces/workspace/LockWorkspaceModal'
 import ShareWorkspaceModal from 'src/pages/workspaces/workspace/ShareWorkspaceModal'
-import { WorkspaceMenuContent, WorkspaceMenuTrigger } from 'src/pages/workspaces/workspace/WorkspaceMenu'
+import WorkspaceMenu from 'src/pages/workspaces/workspace/WorkspaceMenu'
 
 
 const WorkspacePermissionNotice = ({ workspace }) => {
@@ -90,9 +90,10 @@ const WorkspaceTabs = ({
       getHref: currentTab => Nav.getLink(_.find({ name: currentTab }, tabs).link, { namespace, name })
     }, [
       workspace && h(WorkspacePermissionNotice, { workspace }),
-      h(WorkspaceMenuTrigger, {
+      h(WorkspaceMenu, {
         iconSize: 27, popupLocation: 'bottom',
-        menuContent: h(WorkspaceMenuContent, { canShare, isAzureWorkspace, isLocked, isOwner, onClone, onShare, onLock, onDelete })
+        callbacks: { onClone, onShare, onLock, onDelete },
+        workspaceInfo: { canShare, isAzureWorkspace, isLocked, isOwner }
       })
     ])
   ])

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -90,11 +90,12 @@ const WorkspaceTabs = ({
       getHref: currentTab => Nav.getLink(_.find({ name: currentTab }, tabs).link, { namespace, name })
     }, [
       workspace && h(WorkspacePermissionNotice, { workspace }),
-      h(WorkspaceMenuTrigger,{
+      h(WorkspaceMenuTrigger, {
         iconSize: 27, popupLocation: 'bottom',
-        menuContent: h(WorkspaceMenuContent, { canShare, isAzureWorkspace, isLocked, isOwner, onClone, onShare, onLock, onDelete }),
-      })]
-    )])
+        menuContent: h(WorkspaceMenuContent, { canShare, isAzureWorkspace, isLocked, isOwner, onClone, onShare, onLock, onDelete })
+      })
+    ])
+  ])
 }
 
 const WorkspaceContainer = ({

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -2,13 +2,12 @@ import { differenceInSeconds, parseJSON } from 'date-fns/fp'
 import _ from 'lodash/fp'
 import { Fragment, useRef, useState } from 'react'
 import { br, div, h, h2, p, span } from 'react-hyperscript-helpers'
-import { ButtonPrimary, Clickable, Link, spinnerOverlay } from 'src/components/common'
+import { ButtonPrimary, Link, spinnerOverlay } from 'src/components/common'
 import { ContextBar } from 'src/components/ContextBar'
 import FooterWrapper from 'src/components/FooterWrapper'
 import { icon } from 'src/components/icons'
 import NewWorkspaceModal from 'src/components/NewWorkspaceModal'
 import { tools } from 'src/components/notebook-utils'
-import { makeMenuIcon, MenuButton, MenuTrigger } from 'src/components/PopupTrigger'
 import { locationTypes } from 'src/components/region-common'
 import { analysisTabName } from 'src/components/runtime-common'
 import RuntimeManager from 'src/components/RuntimeManager'
@@ -22,21 +21,15 @@ import { withErrorIgnoring, withErrorReporting } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
 import { clearNotification, notify } from 'src/libs/notifications'
 import { useCancellation, useOnMount, usePrevious, useStore, withDisplayName } from 'src/libs/react-utils'
-import {
-  defaultLocation, getConvertedRuntimeStatus, getCurrentApp, getCurrentRuntime, getDiskAppType, mapToPdTypes
-} from 'src/libs/runtime-utils'
+import { defaultLocation, getConvertedRuntimeStatus, getCurrentApp, getCurrentRuntime, getDiskAppType, mapToPdTypes } from 'src/libs/runtime-utils'
 import { workspaceStore } from 'src/libs/state'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 import DeleteWorkspaceModal from 'src/pages/workspaces/workspace/DeleteWorkspaceModal'
 import LockWorkspaceModal from 'src/pages/workspaces/workspace/LockWorkspaceModal'
 import ShareWorkspaceModal from 'src/pages/workspaces/workspace/ShareWorkspaceModal'
+import { WorkspaceMenuContent, WorkspaceMenuTrigger } from 'src/pages/workspaces/workspace/WorkspaceMenu'
 
-
-const navIconProps = {
-  style: { opacity: 0.65, marginRight: '1rem' },
-  hover: { opacity: 1 }, focus: 'hover'
-}
 
 const WorkspacePermissionNotice = ({ workspace }) => {
   const isReadOnly = !Utils.canWrite(workspace.accessLevel)
@@ -72,6 +65,12 @@ const WorkspaceTabs = ({
   const isOwner = workspace && Utils.isOwner(workspace.accessLevel)
   const canShare = workspace?.canShare
   const isLocked = workspace?.workspace.isLocked
+  const isAzureWorkspace = !isGoogleWorkspace
+
+  const onClone = () => setCloningWorkspace(true)
+  const onDelete = () => setDeletingWorkspace(true)
+  const onLock = () => setShowLockWorkspaceModal(true)
+  const onShare = () => setSharingWorkspace(true)
 
   const tabs = [
     { name: 'dashboard', link: 'workspace-dashboard' },
@@ -85,21 +84,17 @@ const WorkspaceTabs = ({
   ]
   return h(Fragment, [
     h(TabBar, {
-      'aria-label': 'workspace menu',
+      'aria-label': 'Workspace Navigation Tabs',
       activeTab, refresh,
       tabNames: _.map('name', tabs),
       getHref: currentTab => Nav.getLink(_.find({ name: currentTab }, tabs).link, { namespace, name })
     }, [
       workspace && h(WorkspacePermissionNotice, { workspace }),
-      h(WorkspaceMenuTrigger, {
-        canShare, isLocked, namespace, name, isOwner, setCloningWorkspace, setSharingWorkspace,
-        setShowLockWorkspaceModal, setDeletingWorkspace
-      }, [
-        h(Clickable, { 'aria-label': 'Workspace menu', ...navIconProps }, [icon('cardMenuIcon', { size: 27 })])
-      ]
-      )
-    ])
-  ])
+      h(WorkspaceMenuTrigger,{
+        iconSize: 27, popupLocation: 'bottom',
+        menuContent: h(WorkspaceMenuContent, { canShare, isAzureWorkspace, isLocked, isOwner, onClone, onShare, onLock, onDelete }),
+      })]
+    )])
 }
 
 const WorkspaceContainer = ({
@@ -401,32 +396,3 @@ export const wrapWorkspace = ({ breadcrumbs, activeTab, title, topBarContent, sh
   }
   return withDisplayName('wrapWorkspace', Wrapper)
 }
-
-export const WorkspaceMenuTrigger = ({ children, canShare, isLocked, isOwner, setCloningWorkspace, setSharingWorkspace, setDeletingWorkspace, setShowLockWorkspaceModal }) => h(
-  MenuTrigger, {
-    closeOnClick: true,
-    'aria-label': 'Workspace menu',
-    content: h(Fragment, [
-      h(MenuButton, { onClick: () => setCloningWorkspace(true) }, [makeMenuIcon('copy'), 'Clone']),
-      h(MenuButton, {
-        disabled: !canShare,
-        tooltip: !canShare && 'You have not been granted permission to share this workspace',
-        tooltipSide: 'left',
-        onClick: () => setSharingWorkspace(true)
-      }, [makeMenuIcon('share'), 'Share']),
-      h(MenuButton, {
-        disabled: !isOwner,
-        tooltip: !isOwner && ['You have not been granted permission to ', isLocked ? 'unlock' : 'lock', ' this workspace'],
-        tooltipSide: 'left',
-        onClick: () => setShowLockWorkspaceModal(true)
-      }, isLocked ? [makeMenuIcon('unlock'), 'Unlock'] : [makeMenuIcon('lock'), 'Lock']),
-      h(MenuButton, {
-        'aria-label': 'Workspace delete',
-        disabled: !isOwner || isLocked,
-        tooltip: !isOwner && 'You must be an owner of this workspace or the underlying billing project',
-        tooltipSide: 'left',
-        onClick: () => setDeletingWorkspace(true)
-      }, [makeMenuIcon('trash'), 'Delete Workspace'])
-    ]),
-    side: 'bottom'
-  }, [children])

--- a/src/pages/workspaces/workspace/WorkspaceMenu.js
+++ b/src/pages/workspaces/workspace/WorkspaceMenu.js
@@ -61,7 +61,7 @@ export const WorkspaceMenuContent = ({ canShare, isAzureWorkspace, isLocked, isO
       tooltip: deleteTooltip,
       tooltipSide: 'left',
       onClick: onDelete
-    }, [makeMenuIcon('trash'), 'Delete'])  // TODO: check if aria-label should be Workspace delete
+    }, [makeMenuIcon('trash'), 'Delete']) // before check-in test if aria-label should be Workspace delete
   ])
 }
 

--- a/src/pages/workspaces/workspace/WorkspaceMenu.js
+++ b/src/pages/workspaces/workspace/WorkspaceMenu.js
@@ -83,7 +83,7 @@ const WorkspaceMenuContent = ({ canShare, isAzureWorkspace, isLocked, isOwner, o
       tooltip: deleteTooltip,
       tooltipSide: 'left',
       onClick: onDelete
-    }, [makeMenuIcon('trash'), 'Delete']) // before check-in test if aria-label should be Workspace delete
+    }, [makeMenuIcon('trash'), 'Delete'])
   ])
 }
 

--- a/src/pages/workspaces/workspace/WorkspaceMenu.js
+++ b/src/pages/workspaces/workspace/WorkspaceMenu.js
@@ -49,7 +49,7 @@ const DynamicWorkspaceMenuContent = ({ namespace, name, onClone, onShare, onDele
 
 const WorkspaceMenuContent = ({ canShare, isAzureWorkspace, isLocked, isOwner, onClone, onShare, onLock, onDelete, workspaceLoaded = true }) => {
   const shareTooltip = Utils.cond(
-    [isAzureWorkspace, () => 'Sharing is not supported on Azure Workspaces'],
+    [isAzureWorkspace, () => 'Sharing is not currently supported on Azure Workspaces'],
     [workspaceLoaded && !canShare, () => 'You have not been granted permission to share this workspace'],
     [Utils.DEFAULT, () => '']
   )
@@ -62,7 +62,7 @@ const WorkspaceMenuContent = ({ canShare, isAzureWorkspace, isLocked, isOwner, o
   return h(Fragment, [
     h(MenuButton, {
       disabled: isAzureWorkspace,
-      tooltip: workspaceLoaded && isAzureWorkspace && 'Cloning is not supported on Azure Workspaces',
+      tooltip: workspaceLoaded && isAzureWorkspace && 'Cloning is not currently supported on Azure Workspaces',
       tooltipSide: 'left',
       onClick: onClone
     }, [makeMenuIcon('copy'), 'Clone']),

--- a/src/pages/workspaces/workspace/WorkspaceMenu.js
+++ b/src/pages/workspaces/workspace/WorkspaceMenu.js
@@ -1,0 +1,67 @@
+import { Fragment } from 'react'
+import { h } from 'react-hyperscript-helpers'
+import { Clickable } from 'src/components/common'
+import { icon } from 'src/components/icons'
+import { makeMenuIcon, MenuButton, MenuTrigger } from 'src/components/PopupTrigger'
+import * as Utils from 'src/libs/utils'
+
+
+export const WorkspaceMenuTrigger = ({ iconSize, menuContent, popupLocation, workspaceName }) => {
+  const navIconProps = {
+    style: { opacity: 0.65, marginRight: '1rem' },
+    hover: { opacity: 1 }, focus: 'hover'
+  }
+
+  return h(MenuTrigger, {
+    side: popupLocation,
+    closeOnClick: true,
+    content: menuContent
+  }, [
+    h(Clickable, {
+      'aria-label': !!workspaceName ? `Action Menu for Workspace: ${workspaceName}` : 'Workspace Action Menu',
+      'aria-haspopup': 'menu',
+      ...navIconProps
+    }, [icon('cardMenuIcon', { size: iconSize })])
+  ])
+}
+
+export const WorkspaceMenuContent = ({ canShare, isAzureWorkspace, isLocked, isOwner, onClone, onShare, onLock, onDelete, workspaceLoaded = true }) => {
+  const shareTooltip = Utils.cond(
+    [isAzureWorkspace, () => 'Sharing is not supported on Azure Workspaces'],
+    [workspaceLoaded && !canShare, () => 'You have not been granted permission to share this workspace'],
+    [Utils.DEFAULT, () => '']
+  )
+  const deleteTooltip = Utils.cond(
+    [workspaceLoaded && isLocked, () => 'You cannot delete a locked workspace'],
+    [workspaceLoaded && !isOwner, () => 'You must be an owner of this workspace or the underlying billing project'],
+    [Utils.DEFAULT, () => '']
+  )
+
+  return h(Fragment, [
+    h(MenuButton, {
+      disabled: isAzureWorkspace,
+      tooltip: workspaceLoaded && isAzureWorkspace && 'Cloning is not supported on Azure Workspaces',
+      tooltipSide: 'left',
+      onClick: onClone
+    }, [makeMenuIcon('copy'), 'Clone']),
+    h(MenuButton, {
+      disabled: !canShare || isAzureWorkspace,
+      tooltip: shareTooltip,
+      tooltipSide: 'left',
+      onClick: onShare
+    }, [makeMenuIcon('share'), 'Share']),
+    h(MenuButton, {
+      disabled: !isOwner,
+      tooltip: workspaceLoaded && !isOwner && ['You have not been granted permission to ', isLocked ? 'unlock' : 'lock', ' this workspace'],
+      tooltipSide: 'left',
+      onClick: onLock
+    }, isLocked ? [makeMenuIcon('unlock'), 'Unlock'] : [makeMenuIcon('lock'), 'Lock']),
+    h(MenuButton, {
+      disabled: !isOwner || isLocked,
+      tooltip: deleteTooltip,
+      tooltipSide: 'left',
+      onClick: onDelete
+    }, [makeMenuIcon('trash'), 'Delete'])  // TODO: check if aria-label should be Workspace delete
+  ])
+}
+

--- a/src/pages/workspaces/workspace/WorkspaceMenu.js
+++ b/src/pages/workspaces/workspace/WorkspaceMenu.js
@@ -3,14 +3,25 @@ import { h } from 'react-hyperscript-helpers'
 import { Clickable } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import { makeMenuIcon, MenuButton, MenuTrigger } from 'src/components/PopupTrigger'
+import { useWorkspaceDetails } from 'src/components/workspace-utils'
 import * as Utils from 'src/libs/utils'
 
 
-export const WorkspaceMenuTrigger = ({ iconSize, menuContent, popupLocation, workspaceName }) => {
+// In `workspaceInfo`, specify either `name and namespace` to fetch the Workspace details,
+// or `canShare, isAzureWorkspace, isLocked, and isOwner` to use previously fetched details.
+const WorkspaceMenu = ({
+  iconSize, popupLocation,
+  callbacks: { onClone, onShare, onLock, onDelete },
+  workspaceInfo: { name, namespace, canShare, isAzureWorkspace, isLocked, isOwner }
+}) => {
   const navIconProps = {
     style: { opacity: 0.65, marginRight: '1rem' },
     hover: { opacity: 1 }, focus: 'hover'
   }
+
+  const menuContent = !!namespace ?
+    h(DynamicWorkspaceMenuContent, { namespace, name, onShare, onClone, onDelete, onLock }) :
+    h(WorkspaceMenuContent, { canShare, isAzureWorkspace, isLocked, isOwner, onClone, onShare, onLock, onDelete })
 
   return h(MenuTrigger, {
     side: popupLocation,
@@ -18,14 +29,25 @@ export const WorkspaceMenuTrigger = ({ iconSize, menuContent, popupLocation, wor
     content: menuContent
   }, [
     h(Clickable, {
-      'aria-label': !!workspaceName ? `Action Menu for Workspace: ${workspaceName}` : 'Workspace Action Menu',
+      'aria-label': !!name ? `Action Menu for Workspace: ${name}` : 'Workspace Action Menu',
       'aria-haspopup': 'menu',
       ...navIconProps
     }, [icon('cardMenuIcon', { size: iconSize })])
   ])
 }
 
-export const WorkspaceMenuContent = ({ canShare, isAzureWorkspace, isLocked, isOwner, onClone, onShare, onLock, onDelete, workspaceLoaded = true }) => {
+const DynamicWorkspaceMenuContent = ({ namespace, name, onClone, onShare, onDelete, onLock }) => {
+  const { workspace } = useWorkspaceDetails({ namespace, name }, ['accessLevel', 'azureContext', 'canShare', 'workspace.isLocked'])
+  const canShare = workspace?.canShare
+  const isOwner = workspace && Utils.isOwner(workspace.accessLevel)
+  const isLocked = workspace?.workspace.isLocked
+  const isAzureWorkspace = !!workspace?.azureContext
+  return WorkspaceMenuContent({
+    canShare, isAzureWorkspace, isLocked, isOwner, onClone, onShare, onLock, onDelete, workspaceLoaded: !!workspace
+  })
+}
+
+const WorkspaceMenuContent = ({ canShare, isAzureWorkspace, isLocked, isOwner, onClone, onShare, onLock, onDelete, workspaceLoaded = true }) => {
   const shareTooltip = Utils.cond(
     [isAzureWorkspace, () => 'Sharing is not supported on Azure Workspaces'],
     [workspaceLoaded && !canShare, () => 'You have not been granted permission to share this workspace'],
@@ -65,3 +87,4 @@ export const WorkspaceMenuContent = ({ canShare, isAzureWorkspace, isLocked, isO
   ])
 }
 
+export default WorkspaceMenu


### PR DESCRIPTION
This removes the workspace menu duplication, fixes some bugs, and adds disabling of Clone/Share for Azure workspaces (this functionality won't be built out until Q3). Some test coverage is added of the menu enable/disable state and tooltips, but it is not exhaustive (and Azure workspace is mocked).

Things to test:
1. On Workspaces List, try the options for Workspaces with different access levels/cloud contexts. **NOTE**: Delete is not yet implemented for Azure workspaces, so it is not recommended that you try deleting one. 

On the Workspaces List, the workspace details are not fetched until the menu is triggered, so you will see menu item text change or disable. This is consistent with the existing behavior in production, and it is done to avoid fetching the details for all workspaces upfront (which would be a performance issue for users with access to lots of workspaces).

2. Select various Workspaces from the list and view the menu on the Workspace Container/Dashboard. 