### PR TITLE
[SU-99] Add column to a data table

### DIFF
--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -7,7 +7,7 @@ import { Fragment, useRef, useState } from 'react'
 import { div, form, h, input } from 'react-hyperscript-helpers'
 import { requesterPaysWrapper, withRequesterPaysHandler } from 'src/components/bucket-utils'
 import { ButtonPrimary, ButtonSecondary, Link } from 'src/components/common'
-import { AddEntityModal, EntityDeleter, ModalToolButton, MultipleEntityEditor, saveScroll } from 'src/components/data/data-utils'
+import { AddColumnModal, AddEntityModal, EntityDeleter, ModalToolButton, MultipleEntityEditor, saveScroll } from 'src/components/data/data-utils'
 import DataTable from 'src/components/data/DataTable'
 import ExportDataModal from 'src/components/data/ExportDataModal'
 import { icon, spinner } from 'src/components/icons'
@@ -219,6 +219,7 @@ const EntitiesContent = ({
   const [deletingEntities, setDeletingEntities] = useState(false)
   const [copyingEntities, setCopyingEntities] = useState(false)
   const [addingEntity, setAddingEntity] = useState(false)
+  const [addingColumn, setAddingColumn] = useState(false)
   const [nowCopying, setNowCopying] = useState(false)
   const [refreshKey, setRefreshKey] = useState(0)
   const [showToolSelector, setShowToolSelector] = useState(false)
@@ -381,6 +382,9 @@ const EntitiesContent = ({
           onClick: () => setAddingEntity(true)
         }, 'Add row'),
         h(MenuButton, {
+          onClick: () => setAddingColumn(true)
+        }, ['Add column']),
+        h(MenuButton, {
           disabled: !entitiesSelected,
           tooltip: !entitiesSelected && 'Select rows to edit in the table',
           onClick: () => setEditingEntities(true)
@@ -495,6 +499,16 @@ const EntitiesContent = ({
         workspaceId: { namespace, name },
         onDismiss: () => setAddingEntity(false),
         onSuccess: () => setRefreshKey(_.add(1))
+      }),
+      addingColumn && h(AddColumnModal, {
+        entityType: entityKey,
+        entityMetadata,
+        workspaceId: { namespace, name },
+        onDismiss: () => setAddingColumn(false),
+        onSuccess: () => {
+          setAddingColumn(false)
+          setRefreshKey(_.add(1))
+        }
       }),
       editingEntities && h(MultipleEntityEditor, {
         entityType: entityKey,

--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -347,9 +347,9 @@ const EntitiesContent = ({
         }, ['Download as TSV']),
         !snapshotName && h(MenuButton, {
           disabled: noEdit,
-          tooltip: noEdit ? 'You don\'t have permission to modify this workspace.' : 'Edit an attribute of the selected rows',
+          tooltip: noEdit ? 'You don\'t have permission to modify this workspace.' : 'Edit a field of the selected rows',
           onClick: () => setEditingEntities(true)
-        }, ['Edit Attribute']),
+        }, ['Edit']),
         !snapshotName && h(MenuButton, {
           tooltip: 'Open the selected data to work with it',
           onClick: () => setShowToolSelector(true)
@@ -388,12 +388,12 @@ const EntitiesContent = ({
           disabled: !entitiesSelected,
           tooltip: !entitiesSelected && 'Select rows to edit in the table',
           onClick: () => setEditingEntities(true)
-        }, ['Edit attribute']),
+        }, ['Edit selected rows']),
         h(MenuButton, {
           disabled: !entitiesSelected,
           tooltip: !entitiesSelected && 'Select rows to delete in the table',
           onClick: () => setDeletingEntities(true)
-        }, 'Delete')
+        }, 'Delete selected rows')
       ])
     }, [h(ButtonSecondary, {
       disabled: !canEdit,

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -607,7 +607,7 @@ const AttributeInput = ({ autoFocus = false, value: attributeValue, onChange, en
   return h(Fragment, [
     div({ style: { marginBottom: '1rem' } }, [
       fieldset({ style: { border: 'none', margin: 0, padding: 0 } }, [
-        legend({ style: { marginBottom: '0.5rem' } }, [isList ? 'List item type:' : 'Attribute type:']),
+        legend({ style: { marginBottom: '0.5rem' } }, [isList ? 'List item type:' : 'Type:']),
         h(Fragment, _.map(({ type, tooltip }) => h(TooltipTrigger, { content: tooltip }, [
           span({ style: { marginRight: '1.2rem' } }, [
             h(RadioButton, {
@@ -657,7 +657,7 @@ const AttributeInput = ({ autoFocus = false, value: attributeValue, onChange, en
           onChange(newAttributeValue)
         }
       }, [
-        span({ style: { marginLeft: '0.5rem' } }, ['Attribute is a list'])
+        span({ style: { marginLeft: '0.5rem' } }, ['Value is a list'])
       ])
     ]),
     isList ?
@@ -759,19 +759,19 @@ export const SingleEntityEditor = ({ entityType, entityName, attributeName, attr
   const boldish = text => span({ style: { fontWeight: 600 } }, [text])
 
   return h(Modal, {
-    title: 'Modify Attribute',
+    title: 'Edit value',
     onDismiss,
     showButtons: false
   }, [
     consideringDelete ?
       h(Fragment, [
-        'Are you sure you want to delete the attribute ', boldish(attributeName),
+        'Are you sure you want to delete the field ', boldish(attributeName),
         ' from the ', boldish(entityType), ' called ', boldish(entityName), '?',
         div({ style: { marginTop: '1rem' } }, [boldish('This cannot be undone.')]),
         div({ style: { marginTop: '1rem', display: 'flex', alignItems: 'baseline' } }, [
           div({ style: { flexGrow: 1 } }),
           h(ButtonSecondary, { style: { marginRight: '1rem' }, onClick: () => setConsideringDelete(false) }, ['Back to editing']),
-          h(ButtonPrimary, { onClick: doDelete }, ['Delete Attribute'])
+          h(ButtonPrimary, { onClick: doDelete }, ['Delete field'])
         ])
       ]) :
       h(Fragment, [
@@ -845,32 +845,32 @@ export const MultipleEntityEditor = ({ entityType, entityNames, attributeNames, 
   const boldish = text => span({ style: { fontWeight: 600 } }, [text])
 
   return h(Modal, {
-    title: `Modify attribute on ${pluralize(entityType, entityNames.length, true)}`,
+    title: `Edit fields in ${pluralize('row', entityNames.length, true)}`,
     onDismiss,
     showButtons: false
   }, [
     consideringDelete ?
       h(Fragment, [
-        'Are you sure you want to delete the attribute ', boldish(attributeToEdit),
+        'Are you sure you want to delete the field ', boldish(attributeToEdit),
         ' from ', boldish(`${entityNames.length} ${entityType}s`), '?',
         div({ style: { marginTop: '1rem' } }, [boldish('This cannot be undone.')]),
         div({ style: { marginTop: '1rem', display: 'flex', alignItems: 'baseline' } }, [
           div({ style: { flexGrow: 1 } }),
           h(ButtonSecondary, { style: { marginRight: '1rem' }, onClick: () => setConsideringDelete(false) }, ['Back to editing']),
-          h(ButtonPrimary, { onClick: doDelete }, ['Delete Attribute'])
+          h(ButtonPrimary, { onClick: doDelete }, ['Delete field'])
         ])
       ]) :
       h(Fragment, [
         div({ style: { display: 'flex', flexDirection: 'column', marginBottom: '1rem' } }, [
           h(IdContainer, [
             id => h(Fragment, [
-              label({ htmlFor: id, style: { marginBottom: '0.5rem' } }, 'Select an attribute'),
+              label({ htmlFor: id, style: { marginBottom: '0.5rem', fontWeight: 'bold' } }, 'Select a column to edit'),
               div({ style: { position: 'relative', display: 'flex', alignItems: 'center' } }, [
                 h(AutocompleteTextInput, {
                   id,
                   value: attributeToEdit,
                   suggestions: attributeNames,
-                  placeholder: 'Attribute name',
+                  placeholder: 'Column name',
                   style: attributeToEditError ? {
                     paddingRight: '2.25rem',
                     border: `1px solid ${colors.danger()}`
@@ -900,6 +900,7 @@ export const MultipleEntityEditor = ({ entityType, entityNames, attributeNames, 
           ])
         ]),
         attributeToEditTouched ? h(Fragment, [
+          p({ style: { fontWeight: 'bold' } }, ['Change selected fields to:']),
           h(AttributeInput, {
             value: newValue,
             onChange: setNewValue,
@@ -1076,7 +1077,7 @@ export const AddEntityModal = ({ workspaceId: { namespace, name }, entityType, a
 
   return h(Modal, {
     onDismiss,
-    title: `Add ${entityType}`,
+    title: 'Add a new row',
     okButton: h(ButtonPrimary, {
       disabled: !!entityNameErrors,
       tooltip: Utils.summarizeErrors(entityNameErrors),
@@ -1087,6 +1088,7 @@ export const AddEntityModal = ({ workspaceId: { namespace, name }, entityType, a
     h(ValidatedInput, {
       inputProps: {
         id: 'add-row-entity-name',
+        placeholder: 'Enter a value (required)',
         value: entityName,
         onChange: value => {
           setEntityName(value)
@@ -1095,7 +1097,7 @@ export const AddEntityModal = ({ workspaceId: { namespace, name }, entityType, a
       },
       error: entityNameInputTouched && Utils.summarizeErrors(entityNameErrors)
     }),
-    p({ id: 'add-row-attributes-label' }, 'Expand each attribute to edit its value.'),
+    p({ id: 'add-row-attributes-label' }, 'Expand each field to edit its value.'),
     ul({ 'aria-labelledby': 'add-row-attributes-label', style: { padding: 0, margin: 0 } }, [
       _.map(([i, attributeName]) => li({
         key: attributeName,

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -799,8 +799,10 @@ export const SingleEntityEditor = ({ entityType, entityName, attributeName, attr
 export const MultipleEntityEditor = ({ entityType, entityNames, attributeNames, entityTypes, workspaceId: { namespace, name }, onDismiss, onSuccess }) => {
   const [attributeToEdit, setAttributeToEdit] = useState('')
   const [attributeToEditTouched, setAttributeToEditTouched] = useState(false)
-  const attributeToEditError = attributeToEditTouched && !attributeToEdit ? 'An attribute name is required.' : null
-  const isNewAttribute = !_.includes(attributeToEdit, attributeNames)
+  const attributeToEditError = attributeToEditTouched && Utils.cond(
+    [!attributeToEdit, () => 'An attribute name is required.'],
+    [!_.includes(attributeToEdit, attributeNames), () => 'The selected attribute does not exist.']
+  )
 
   const [newValue, setNewValue] = useState('')
 
@@ -862,12 +864,12 @@ export const MultipleEntityEditor = ({ entityType, entityNames, attributeNames, 
         div({ style: { display: 'flex', flexDirection: 'column', marginBottom: '1rem' } }, [
           h(IdContainer, [
             id => h(Fragment, [
-              label({ htmlFor: id, style: { marginBottom: '0.5rem' } }, 'Select an attribute or enter a new attribute'),
+              label({ htmlFor: id, style: { marginBottom: '0.5rem' } }, 'Select an attribute'),
               div({ style: { position: 'relative', display: 'flex', alignItems: 'center' } }, [
                 h(AutocompleteTextInput, {
                   id,
                   value: attributeToEdit,
-                  suggestions: _.uniq(_.concat(attributeNames, attributeToEdit)),
+                  suggestions: attributeNames,
                   placeholder: 'Attribute name',
                   style: attributeToEditError ? {
                     paddingRight: '2.25rem',
@@ -905,11 +907,8 @@ export const MultipleEntityEditor = ({ entityType, entityNames, attributeNames, 
           }),
           div({ style: { marginTop: '2rem', display: 'flex', alignItems: 'baseline' } }, [
             h(ButtonOutline, {
-              disabled: attributeToEditError || isNewAttribute,
-              tooltip: Utils.cond(
-                [attributeToEditError, () => attributeToEditError],
-                [isNewAttribute, () => 'The selected attribute does not exist.']
-              ),
+              disabled: !!attributeToEditError,
+              tooltip: attributeToEditError,
               onClick: () => setConsideringDelete(true)
             }, ['Delete']),
             div({ style: { flexGrow: 1 } }),
@@ -918,7 +917,7 @@ export const MultipleEntityEditor = ({ entityType, entityNames, attributeNames, 
               disabled: attributeToEditError,
               tooltip: attributeToEditError,
               onClick: doEdit
-            }, [isNewAttribute ? 'Add attribute' : 'Save changes'])
+            }, ['Save edits'])
           ])
         ]) : div({ style: { display: 'flex', justifyContent: 'flex-end', alignItems: 'baseline' } }, [
           h(ButtonSecondary, { onClick: onDismiss }, ['Cancel'])

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -928,6 +928,104 @@ export const MultipleEntityEditor = ({ entityType, entityNames, attributeNames, 
   ])
 }
 
+export const AddColumnModal = ({ entityType, entityMetadata, workspaceId: { namespace, name }, onDismiss, onSuccess }) => {
+  const [columnName, setColumnName] = useState('')
+  const [columnNameTouched, setColumnNameTouched] = useState(false)
+  const columnNameError = columnNameTouched && Utils.cond(
+    [!columnName, () => 'A column name is required.'],
+    [_.includes(columnName, entityMetadata[entityType].attributeNames), () => 'This column already exists.']
+  )
+
+  const [value, setValue] = useState('')
+
+  const [isBusy, setIsBusy] = useState()
+
+  const addColumn = async () => {
+    try {
+      setIsBusy(true)
+
+      const queryResults = await Ajax().Workspaces.workspace(namespace, name).paginatedEntitiesOfType(entityType, {
+        pageSize: entityMetadata[entityType].count,
+        fields: ''
+      })
+      const allEntityNames = _.map(_.get('name'), queryResults.results)
+
+      const entityUpdates = _.map(entityName => ({
+        entityType,
+        name: entityName,
+        attributes: { [columnName]: prepareAttributeForUpload(value) }
+      }), allEntityNames)
+
+      await Ajax()
+        .Workspaces
+        .workspace(namespace, name)
+        .upsertEntities(entityUpdates)
+      onSuccess()
+    } catch (e) {
+      onDismiss()
+      reportError('Unable to add column.', e)
+    }
+  }
+
+  return h(Modal, {
+    title: 'Add a new column',
+    onDismiss,
+    okButton: h(ButtonPrimary, {
+      disabled: !columnName || columnNameError,
+      tooltip: columnNameError,
+      onClick: addColumn
+    }, ['Save'])
+  }, [
+    div({ style: { display: 'flex', flexDirection: 'column', marginBottom: '1rem' } }, [
+      h(IdContainer, [
+        id => h(Fragment, [
+          label({ htmlFor: id, style: { fontWeight: 'bold', marginBottom: '0.5rem' } }, 'Column name'),
+          div({ style: { position: 'relative', display: 'flex', alignItems: 'center' } }, [
+            h(TextInput, {
+              id,
+              value: columnName,
+              placeholder: 'Enter a name (required)',
+              style: columnNameError ? {
+                paddingRight: '2.25rem',
+                border: `1px solid ${colors.danger()}`
+              } : undefined,
+              onChange: value => {
+                setColumnName(value)
+                setColumnNameTouched(true)
+              }
+            }),
+            columnNameError && icon('error-standard', {
+              size: 24,
+              style: {
+                position: 'absolute', right: '0.5rem',
+                color: colors.danger()
+              }
+            })
+          ]),
+          columnNameError && div({
+            'aria-live': 'assertive',
+            'aria-relevant': 'all',
+            style: {
+              marginTop: '0.5rem',
+              color: colors.danger()
+            }
+          }, columnNameError)
+        ])
+      ])
+    ]),
+    p([
+      span({ style: { fontWeight: 'bold' } }, ['Default value']),
+      ' (will be entered for all rows)'
+    ]),
+    h(AttributeInput, {
+      value,
+      onChange: setValue,
+      entityTypes: _.keys(entityMetadata)
+    }),
+    isBusy && spinnerOverlay
+  ])
+}
+
 export const AddEntityModal = ({ workspaceId: { namespace, name }, entityType, attributeNames, entityTypes, onDismiss, onSuccess }) => {
   const [entityName, setEntityName] = useState('')
   const [entityNameInputTouched, setEntityNameInputTouched] = useState(false)

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -765,13 +765,13 @@ export const SingleEntityEditor = ({ entityType, entityName, attributeName, attr
   }, [
     consideringDelete ?
       h(Fragment, [
-        'Are you sure you want to delete the field ', boldish(attributeName),
+        'Are you sure you want to delete the value ', boldish(attributeName),
         ' from the ', boldish(entityType), ' called ', boldish(entityName), '?',
         div({ style: { marginTop: '1rem' } }, [boldish('This cannot be undone.')]),
         div({ style: { marginTop: '1rem', display: 'flex', alignItems: 'baseline' } }, [
           div({ style: { flexGrow: 1 } }),
           h(ButtonSecondary, { style: { marginRight: '1rem' }, onClick: () => setConsideringDelete(false) }, ['Back to editing']),
-          h(ButtonPrimary, { onClick: doDelete }, ['Delete field'])
+          h(ButtonPrimary, { onClick: doDelete }, ['Delete'])
         ])
       ]) :
       h(Fragment, [
@@ -851,13 +851,13 @@ export const MultipleEntityEditor = ({ entityType, entityNames, attributeNames, 
   }, [
     consideringDelete ?
       h(Fragment, [
-        'Are you sure you want to delete the field ', boldish(attributeToEdit),
+        'Are you sure you want to delete the value ', boldish(attributeToEdit),
         ' from ', boldish(`${entityNames.length} ${entityType}s`), '?',
         div({ style: { marginTop: '1rem' } }, [boldish('This cannot be undone.')]),
         div({ style: { marginTop: '1rem', display: 'flex', alignItems: 'baseline' } }, [
           div({ style: { flexGrow: 1 } }),
           h(ButtonSecondary, { style: { marginRight: '1rem' }, onClick: () => setConsideringDelete(false) }, ['Back to editing']),
-          h(ButtonPrimary, { onClick: doDelete }, ['Delete field'])
+          h(ButtonPrimary, { onClick: doDelete }, ['Delete'])
         ])
       ]) :
       h(Fragment, [
@@ -900,7 +900,7 @@ export const MultipleEntityEditor = ({ entityType, entityNames, attributeNames, 
           ])
         ]),
         attributeToEditTouched ? h(Fragment, [
-          p({ style: { fontWeight: 'bold' } }, ['Change selected fields to:']),
+          p({ style: { fontWeight: 'bold' } }, ['Change selected values to:']),
           h(AttributeInput, {
             value: newValue,
             onChange: setNewValue,
@@ -1097,7 +1097,7 @@ export const AddEntityModal = ({ workspaceId: { namespace, name }, entityType, a
       },
       error: entityNameInputTouched && Utils.summarizeErrors(entityNameErrors)
     }),
-    p({ id: 'add-row-attributes-label' }, 'Expand each field to edit its value.'),
+    p({ id: 'add-row-attributes-label' }, 'Expand each value to edit.'),
     ul({ 'aria-labelledby': 'add-row-attributes-label', style: { padding: 0, margin: 0 } }, [
       _.map(([i, attributeName]) => li({
         key: attributeName,

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -1015,7 +1015,7 @@ export const AddColumnModal = ({ entityType, entityMetadata, workspaceId: { name
     ]),
     p([
       span({ style: { fontWeight: 'bold' } }, ['Default value']),
-      ' (will be entered for all rows)'
+      ' (optional, will be entered for all rows)'
     ]),
     h(AttributeInput, {
       value,


### PR DESCRIPTION
This relates to the new data tab design, enabled with `configOverridesStore.set({ isDataTabRedesignEnabled: true })`.

## Before

Currently, it's possible to add a column to selected rows in a data table by selecting some rows, clicking "Edit attribute" from the Edit menu, and entering a column name that doesn't already exist.

https://user-images.githubusercontent.com/1156625/167699515-0fc3d16e-f708-4085-a419-41d5f266175b.mov

## After

Feedback from users was that it's not clear what "Edit attribute" does and, generally, what is an attribute?

This adds a separate menu option to "Add column", which applies to all rows in the table (no need to select rows).

https://user-images.githubusercontent.com/1156625/167699883-298ab254-545b-4662-bd90-bddbe1f11d2d.mov

It also removes the option to add a new attribute when editing, requiring an existing attribute to be selected.

https://user-images.githubusercontent.com/1156625/167699991-4d46e0c8-4e75-469a-98ff-242df12e14a3.mov

It also changes wording in several modals and buttons, mostly replacing "attribute" with "value" or "field" and replacing entity types with a generic "row".