### PR TITLE
[DC-310] update how we access table cells in UI tests

### DIFF
--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -73,7 +73,7 @@ const getTableColIndex = async (page, { tableName, columnHeader }) => {
 const getTableCellByContents = async (page, { tableName, columnHeader, textContains, isDescendant = false }) => {
   const colIndex = await getTableColIndex(page, { tableName, columnHeader })
   const baseXpath = `//*[@role="table" and @aria-label="${tableName}"]//*[@role="row"]//*[@role="cell" and @aria-colindex = "${colIndex}"]`
-  const xpath = `${baseXpath}${isDescendant ? '//*' : ''}[text() = "${textContains}"]`
+  const xpath = `${baseXpath}${isDescendant ? '//*' : ''}[contains(normalize-space(.),"${textContains}")]`
   return xpath
 }
 

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -70,7 +70,7 @@ const getTableColIndex = async (page, { tableName, columnHeader }) => {
   return page.evaluate(node => node.getAttribute('aria-colindex'), colHeaderNode)
 }
 
-const getTableTextWithinColumn = async (page, { tableName, columnHeader, textContains, isDescendant = false }) => {
+const getTableCellByContents = async (page, { tableName, columnHeader, textContains, isDescendant = false }) => {
   const colIndex = await getTableColIndex(page, { tableName, columnHeader })
   const baseXpath = `//*[@role="table" and @aria-label="${tableName}"]//*[@role="row"]//*[@role="cell" and @aria-colindex = "${colIndex}"]`
   const xpath = `${baseXpath}${isDescendant ? '//*' : ''}[text() = "${textContains}"]`
@@ -78,7 +78,7 @@ const getTableTextWithinColumn = async (page, { tableName, columnHeader, textCon
 }
 
 const getTableRowIndex = async (page, { tableName, columnHeader, textContains, isDescendant = false }) => {
-  const colXPath = await getTableTextWithinColumn(page, { tableName, columnHeader, textContains, isDescendant })
+  const colXPath = await getTableCellByContents(page, { tableName, columnHeader, textContains, isDescendant })
   const findCol = await findElement(page, colXPath)
   return page.evaluate(node => node.getAttribute('aria-rowindex'), findCol)
 }
@@ -96,7 +96,7 @@ const assertRowHas = async (page, { tableName, expectedColumnValues, withKey: { 
 }
 
 const clickTableCell = async (page, { tableName, columnHeader, textContains, isDescendant = false }, options) => {
-  const tableCellPath = await getTableTextWithinColumn(page, { tableName, columnHeader, textContains, isDescendant })
+  const tableCellPath = await getTableCellByContents(page, { tableName, columnHeader, textContains, isDescendant })
   const xpath = `${tableCellPath}//*[@role="button" or @role="link" or @role="checkbox"]`
   return (await page.waitForXPath(xpath, options)).click()
 }

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -66,14 +66,14 @@ const getTableCellPath = (tableName, row, column) => {
 }
 
 const getTableColIndex = async (page, { tableName, columnHeader }) => {
-  const colHeaderNode = await findElement(page, `//*[@role="table" and @aria-label="${tableName}"]//*[@role="columnheader" and @aria-colindex and contains(normalize-space(.),"${columnHeader}")]`)
+  const colHeaderNode = await findElement(page, `//*[@role="table" and @aria-label="${tableName}"]//*[@role="columnheader" and @aria-colindex][descendant-or-self::text() = "${columnHeader}"]`)
   return page.evaluate(node => node.getAttribute('aria-colindex'), colHeaderNode)
 }
 
 const getTableTextWithinColumn = async (page, { tableName, columnHeader, textContains, isDescendant = false }) => {
   const colIndex = await getTableColIndex(page, { tableName, columnHeader })
   const baseXpath = `//*[@role="table" and @aria-label="${tableName}"]//*[@role="row"]//*[@role="cell" and @aria-colindex = "${colIndex}"]`
-  const xpath = `${baseXpath}${isDescendant ? '//*' : ''}[contains(normalize-space(.),"${textContains}")]`
+  const xpath = `${baseXpath}${isDescendant ? '//*' : ''}[text() = "${textContains}"]`
   return xpath
 }
 
@@ -88,7 +88,7 @@ const assertRowHas = async (page, { tableName, expectedColumnValues, withKey: { 
 
   const findTextInColumn = async ([columnHeader, text]) => {
     const colIndex = await getTableColIndex(page, { tableName, columnHeader })
-    const xPath = `//*[@role="table" and @aria-label="${tableName}"]//*[@role="row"]//*[@role="cell" and @aria-rowindex = "${rowIndex}" and @aria-colindex = "${colIndex}" and contains(normalize-space(.),"${text}")]`
+    const xPath = `//*[@role="table" and @aria-label="${tableName}"]//*[@role="row"]//*[@role="cell" and @aria-rowindex = "${rowIndex}" and @aria-colindex = "${colIndex}"][text() = "${text}"]`
     return await findElement(page, xPath, { timeout: 5000 })
   }
 


### PR DESCRIPTION
Determining the column index via the header information and “scanning” the rows of a table to find the correct data we are looking for in a given column.

Fix matching bug 