### PR TITLE
[SU-100] Make the width of the import data dropdown match the button width

### DIFF
--- a/src/components/PopupTrigger.js
+++ b/src/components/PopupTrigger.js
@@ -37,12 +37,13 @@ export const Popup = onClickOutside(function({ id, side = 'right', target: targe
       'aria-modal': true,
       onClick,
       ref: elementRef,
+      ...popupProps,
       style: {
         transform: `translate(${position.left}px, ${position.top}px)`,
         visibility: !viewport.width ? 'hidden' : undefined,
-        ...styles.popup
-      },
-      ...popupProps
+        ...styles.popup,
+        ...popupProps.style
+      }
     }, [children])
   ])
 })

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -687,6 +687,8 @@ const WorkspaceData = _.flow(
           h(MenuTrigger, {
             side: 'bottom',
             closeOnClick: true,
+            // Make the width of the dropdown menu match the width of the button.
+            popupProps: { style: { width: `calc(${sidebarWidth}px - 3rem` } },
             content: h(Fragment, [
               h(MenuButton, {
                 'aria-haspopup': 'dialog',


### PR DESCRIPTION
This button is part of the data tab redesign. Enable with `configOverridesStore.set({ isDataTabRedesignEnabled: true })`.

## Before
![Screen Shot 2022-05-10 at 3 56 51 PM](https://user-images.githubusercontent.com/1156625/167711624-ebe5eb01-45dd-4bc3-8ba7-e5c1abf6fd19.png)

## After
![Screen Shot 2022-05-10 at 3 54 59 PM](https://user-images.githubusercontent.com/1156625/167711634-2bf6cf89-6b48-47e4-9015-dfaaa52d86eb.png)

