### PR TITLE
[QA-1839] reload sign-in page once if loading had failed

### DIFF
--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -206,8 +206,9 @@ const signIntoTerra = async (page, { token, testUrl }) => {
 
     try {
       await loadPagePromise
-    } catch (e) {
-      console.log(`Warning: Page loading timed out during sign in. Reloading URL: "${testUrl}"`)
+    } catch (err) {
+      console.error(err)
+      console.log(`Error: Page loading timed out during sign in. Reloading URL: "${testUrl}"`)
       await page.reload({ waitUntil: 'load' })
       await loadPagePromise
     }

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -191,13 +191,10 @@ const dismissNotifications = async page => {
   return !!notificationCloseButtons.length && delay(1000) // delayed for alerts to animate off
 }
 
-const loadSignInPageAndWaitForReady = (page, url, timeout = 30 * 1000) => {
-  return Promise.all([
-    page.goto(url, waitUntilLoadedOrTimeout(timeout)),
-    Promise.race([
-      page.waitForXPath('//*[@id="signInButton"]', { visible: true, timeout }),
-      page.waitForXPath('//a[@href="#workspaces"]', { visible: true, timeout })
-    ])
+const waitForSignInPage = async (page, timeout = 30 * 1000) => {
+  await Promise.race([
+    page.waitForXPath('//*[@id="signInButton"]', { visible: true, timeout }),
+    page.waitForXPath('//a[@href="#workspaces"]', { visible: true, timeout })
   ])
     .then(() => waitForNoSpinners(page))
 }
@@ -205,13 +202,14 @@ const loadSignInPageAndWaitForReady = (page, url, timeout = 30 * 1000) => {
 const signIntoTerra = async (page, { token, testUrl }) => {
   if (!!testUrl) {
     try {
-      console.log(`Loading page: ${testUrl}`)
-      await loadSignInPageAndWaitForReady(page, testUrl)
+      console.log(`Loading sign-in page: ${testUrl}`)
+      await page.goto(testUrl, waitUntilLoadedOrTimeout())
+      await waitForSignInPage(page)
     } catch (err) {
       console.error(err)
       console.error(`Error: Page loading timed out during sign in. Reloading URL: "${testUrl}"`)
       await page.reload({ waitUntil: 'load' })
-      await loadSignInPageAndWaitForReady(page, testUrl)
+      await waitForSignInPage(page)
     }
   }
 

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -208,7 +208,7 @@ const signIntoTerra = async (page, { token, testUrl }) => {
       await loadPagePromise
     } catch (err) {
       console.error(err)
-      console.log(`Error: Page loading timed out during sign in. Reloading URL: "${testUrl}"`)
+      console.error(`Error: Page loading timed out during sign in. Reloading URL: "${testUrl}"`)
       await page.reload({ waitUntil: 'load' })
       await loadPagePromise
     }

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -194,27 +194,22 @@ const dismissNotifications = async page => {
 const signIntoTerra = async (page, { token, testUrl }) => {
   if (!!testUrl) {
     const timeout = 30 * 1000
-    const welcomePagePromise = Promise.all([
-      page.waitForXPath('//a[@href="#workspaces"]', { visible: true, timeout }),
-      page.waitForXPath('//a[@href="#library/showcase"]', { visible: true, timeout }),
-      page.waitForXPath('//a[@href="#library/datasets"]', { visible: true, timeout })
-    ])
-    const pagePromise = Promise.race([
+    const pageLoadedPromise = Promise.race([
       page.waitForXPath('//*[@id="signInButton"]', { visible: true, timeout }),
-      welcomePagePromise
+      page.waitForXPath('//a[@href="#workspaces"]', { visible: true, timeout })
     ])
-    const gotoPromise = Promise.all([
+    const loadPagePromise = Promise.all([
       page.goto(testUrl, waitUntilLoadedOrTimeout(timeout)),
-      pagePromise
+      pageLoadedPromise
     ])
       .then(() => waitForNoSpinners(page))
 
     try {
-      await gotoPromise
+      await loadPagePromise
     } catch (e) {
-      console.log(`Warning: Page loading had timed out. Reload URL: "${testUrl}"`)
-      await page.reload()
-      await gotoPromise
+      console.log(`Warning: Page loading timed out during sign in. Reloading URL: "${testUrl}"`)
+      await page.reload({ waitUntil: 'load' })
+      await loadPagePromise
     }
   }
 

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -194,11 +194,18 @@ const dismissNotifications = async page => {
 const signIntoTerra = async (page, { token, testUrl }) => {
   if (!!testUrl) {
     const timeout = 30 * 1000
-    const gotoPromise = Promise.all([
-      page.goto(testUrl, waitUntilLoadedOrTimeout(timeout)),
+    const welcomePagePromise = Promise.all([
       page.waitForXPath('//a[@href="#workspaces"]', { visible: true, timeout }),
       page.waitForXPath('//a[@href="#library/showcase"]', { visible: true, timeout }),
       page.waitForXPath('//a[@href="#library/datasets"]', { visible: true, timeout })
+    ])
+    const pagePromise = Promise.race([
+      page.waitForXPath('//*[@id="signInButton"]', { visible: true, timeout }),
+      welcomePagePromise
+    ])
+    const gotoPromise = Promise.all([
+      page.goto(testUrl, waitUntilLoadedOrTimeout(timeout)),
+      pagePromise
     ])
       .then(() => waitForNoSpinners(page))
 

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -191,7 +191,7 @@ const dismissNotifications = async page => {
   return !!notificationCloseButtons.length && delay(1000) // delayed for alerts to animate off
 }
 
-const loadSignInPageAndWaitForReady = async (page, url, timeout = 30 * 1000) => {
+const loadSignInPageAndWaitForReady = (page, url, timeout = 30 * 1000) => {
   return Promise.all([
     page.goto(url, waitUntilLoadedOrTimeout(timeout)),
     Promise.race([
@@ -213,7 +213,7 @@ const signIntoTerra = async (page, { token, testUrl }) => {
       await loadSignInPageAndWaitForReady(page, testUrl)
     }
   }
-  
+
   await page.evaluate(token => window.forceSignIn(token), token)
   await dismissNotifications(page)
   await waitForNoSpinners(page)

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -205,6 +205,7 @@ const loadSignInPageAndWaitForReady = (page, url, timeout = 30 * 1000) => {
 const signIntoTerra = async (page, { token, testUrl }) => {
   if (!!testUrl) {
     try {
+      console.log(`Loading page: ${testUrl}`)
       await loadSignInPageAndWaitForReady(page, testUrl)
     } catch (err) {
       console.error(err)

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -206,7 +206,7 @@ const signIntoTerra = async (page, { token, testUrl }) => {
       await gotoPromise
     } catch (e) {
       console.log(`Warning: Page loading had timed out. Reload URL: "${testUrl}"`)
-      await page.reload(waitUntilLoadedOrTimeout(timeout))
+      await page.reload()
       await gotoPromise
     }
   }


### PR DESCRIPTION
Failed [CircleCI](https://app.circleci.com/pipelines/github/DataBiosphere/terra-ui/9416/workflows/e128c57a-4bf5-4763-b18c-e9e83f63bf1a).

Tests still failing when log in immediately after new gcloud deploy. [PR #3004](https://github.com/DataBiosphere/terra-ui/pull/3004) has improved stability but did not fix issue completely.

Attempt again to fix loading issue: Reload page once if opening Terra UI (Home page) had failed.