### PR TITLE
[QA-1865] fetch Lyle request err handling

### DIFF
--- a/integration-tests/utils/lyle-utils.js
+++ b/integration-tests/utils/lyle-utils.js
@@ -25,7 +25,7 @@ const fetchLyle = async (path, email) => {
       headers: { 'Content-Type': 'application/json', ...(await authClient.getRequestHeaders(url)) },
       body: JSON.stringify({ email })
     })
-    console.log(`fetchLyle: ${res.status}, ${url}`)
+    console.log(`fetchLyle: POST ${res.status} ${url}`)
     if (res.ok) {
       // response.status >= 200 && response.status < 300
       return res.json()

--- a/integration-tests/utils/lyle-utils.js
+++ b/integration-tests/utils/lyle-utils.js
@@ -24,12 +24,14 @@ const fetchLyle = async (path, email) => {
     headers: { 'Content-Type': 'application/json', ...(await authClient.getRequestHeaders(url)) },
     body: JSON.stringify({ email })
   })
-    .then(resp => {
+    .then(async resp => {
       if (resp.ok) {
         // response.status >= 200 && response.status < 300
         return resp.json()
       }
-      throw Error(`fetch Lyle response: ${resp.text()}`)
+      const respText = await resp.text()
+      console.error(`fetch Lyle response: ${respText}`)
+      return respText
     })
     .catch(async err => {
       console.error(err)

--- a/integration-tests/utils/lyle-utils.js
+++ b/integration-tests/utils/lyle-utils.js
@@ -27,13 +27,10 @@ const fetchLyle = async (path, email) => {
     })
     console.log(`fetchLyle: POST ${res.status} ${url}`)
     if (res.ok) {
-      // response.status >= 200 && response.status < 300
       return res.json()
     }
     // delegate non-2xx response to enclosing try/catch
-    const error = new Error()
-    Object.assign(error, { response: res })
-    throw error
+    throw _.set('response', res, new Error())
   } catch (err) {
     console.error(err)
     const errorBody = await err.response.text()

--- a/integration-tests/utils/lyle-utils.js
+++ b/integration-tests/utils/lyle-utils.js
@@ -19,13 +19,24 @@ const fetchLyle = async (path, email) => {
   const url = `${lyleUrl}/api/${path}`
   const authClient = await makeAuthClient()
 
-  const res = await fetch(url, {
+  return await fetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', ...(await authClient.getRequestHeaders(url)) },
     body: JSON.stringify({ email })
   })
-
-  return res.json()
+    .then(resp => {
+      if (resp.ok) {
+        // response.status >= 200 && response.status < 300
+        return resp.json()
+      }
+      throw Error(`fetch Lyle response: ${resp.text()}`)
+    })
+    .catch(async err => {
+      console.error(err)
+      const errorBody = await err.response.text()
+      console.error(`fetch Lyle request response body: ${errorBody}`)
+      throw err
+    })
 }
 
 module.exports = {

--- a/integration-tests/utils/lyle-utils.js
+++ b/integration-tests/utils/lyle-utils.js
@@ -19,26 +19,24 @@ const fetchLyle = async (path, email) => {
   const url = `${lyleUrl}/api/${path}`
   const authClient = await makeAuthClient()
 
-  return await fetch(url, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...(await authClient.getRequestHeaders(url)) },
-    body: JSON.stringify({ email })
-  })
-    .then(async resp => {
-      if (resp.ok) {
-        // response.status >= 200 && response.status < 300
-        return resp.json()
-      }
-      const respText = await resp.text()
-      console.error(`fetch Lyle response: ${respText}`)
-      return respText
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...(await authClient.getRequestHeaders(url)) },
+      body: JSON.stringify({ email })
     })
-    .catch(async err => {
-      console.error(err)
-      const errorBody = await err.response.text()
-      console.error(`fetch Lyle request response body: ${errorBody}`)
-      throw err
-    })
+    if (res.ok) {
+      // response.status >= 200 && response.status < 300
+      return res.json()
+    }
+    // delegate non-2xx response to enclosing try/catch
+    throw { response: res, status: res.status }
+  } catch (err) {
+    console.error(err)
+    const errorBody = await err.response.text()
+    console.error(`fetch Lyle response: ${errorBody}`)
+    throw err
+  }
 }
 
 module.exports = {

--- a/integration-tests/utils/lyle-utils.js
+++ b/integration-tests/utils/lyle-utils.js
@@ -25,16 +25,19 @@ const fetchLyle = async (path, email) => {
       headers: { 'Content-Type': 'application/json', ...(await authClient.getRequestHeaders(url)) },
       body: JSON.stringify({ email })
     })
+    console.log(`fetchLyle: ${res.status}, ${url}`)
     if (res.ok) {
       // response.status >= 200 && response.status < 300
       return res.json()
     }
     // delegate non-2xx response to enclosing try/catch
-    throw { response: res, status: res.status }
+    const error = new Error()
+    Object.assign(error, { response: res })
+    throw error
   } catch (err) {
     console.error(err)
     const errorBody = await err.response.text()
-    console.error(`fetch Lyle response: ${errorBody}`)
+    console.error(`fetchLyle response: ${errorBody}`)
     throw err
   }
 }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/QA-1865

`fetchLyle()` can fail sometimes. We want to understand why by seeing response body if it fails next time.

CircleCI [job](https://app.circleci.com/pipelines/github/DataBiosphere/terra-ui/9451/workflows/ebef13e3-c33c-4560-9e5a-a495d4a49d4f/jobs/42285)

Error signature:
```
FetchError: invalid json response body at https://terra-lyle.appspot.com/api/delete reason: Unexpected token E in JSON at position 0

       98 |     await test({ ...args, email, token })
       99 |   } finally {
    > 100 |     await fetchLyle('delete', email)
          |     ^
      101 |   }
      102 | }
      103 |

      at ../.yarn/__virtual__/node-fetch-virtual-10f4bc17d9/0/cache/node-fetch-npm-2.6.7-777aa2a6df-8d816ffd1e.zip/node_modules/node-fetch/lib/index.js:273:32
          at runMicrotasks (<anonymous>)
      at utils/integration-helpers.js:100:5
      at utils/integration-utils.js:289:12
 ```