### PR TITLE
[SU-57] Refactor upsertEntities Ajax method

### DIFF
--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -161,7 +161,7 @@ const DataTable = props => {
     const entityUpdates = _.map(entity => ({
       name: entity.name,
       entityType: entity.entityType,
-      attributes: { [attributeName]: '' }
+      operations: [{ op: 'AddUpdateAttribute', attributeName, addUpdateAttribute: '' }]
     }), allEntities)
     await Ajax(signal).Workspaces.workspace(namespace, name).upsertEntities(entityUpdates)
 

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -735,8 +735,13 @@ export const SingleEntityEditor = ({ entityType, entityName, attributeName, attr
         .Workspaces
         .workspace(namespace, name)
         .upsertEntities([{
-          name: entityName, entityType,
-          attributes: { [attributeName]: prepareAttributeForUpload(newValue) }
+          entityType,
+          name: entityName,
+          operations: [{
+            op: 'AddUpdateAttribute',
+            attributeName,
+            addUpdateAttribute: prepareAttributeForUpload(newValue)
+          }]
         }])
       onSuccess()
     } catch (e) {
@@ -817,7 +822,11 @@ export const MultipleEntityEditor = ({ entityType, entityNames, attributeNames, 
       const entityUpdates = _.map(entityName => ({
         entityType,
         name: entityName,
-        attributes: { [attributeToEdit]: prepareAttributeForUpload(newValue) }
+        operations: [{
+          op: 'AddUpdateAttribute',
+          attributeName: attributeToEdit,
+          addUpdateAttribute: prepareAttributeForUpload(newValue)
+        }]
       }), entityNames)
 
       await Ajax(signal)
@@ -953,7 +962,11 @@ export const AddColumnModal = ({ entityType, entityMetadata, workspaceId: { name
       const entityUpdates = _.map(entityName => ({
         entityType,
         name: entityName,
-        attributes: { [columnName]: prepareAttributeForUpload(value) }
+        operations: [{
+          op: 'AddUpdateAttribute',
+          attributeName: columnName,
+          addUpdateAttribute: prepareAttributeForUpload(value)
+        }]
       }), allEntityNames)
 
       await Ajax()


### PR DESCRIPTION
Several UI features for editing values in data tables (editing one or more cells in a table and adding/clearing a column) use the `upsertEntities` method to send changes to Rawls' [batch upsert entities](https://rawls.dsde-prod.broadinstitute.org/#/entities/batch_upsert_entities) endpoint.

Entities in data tables can have attributes of multiple types: strings, numbers, booleans, lists, and JSON (arrays or objects). Note that lists are different from JSON arrays.

Currently, setting JSON values cannot be done through the UI.

One obstacle to that is how the `upsertEntities` method accepts parameters. It accepts a list of objects `{ entityType, name, attributes: { attributeName: attributeValue, ... }` and converts the `attributes` object into a list of operations for the Rawls endpoint.

https://github.com/DataBiosphere/terra-ui/blob/f4b5658dbeaa275a8599fa855e5d696e5a163ed6/src/libs/ajax.js#L691-L697

https://github.com/DataBiosphere/terra-ui/blob/f4b5658dbeaa275a8599fa855e5d696e5a163ed6/src/libs/ajax.js#L622-L636

Since `attributesUpdateOps` converts array values into create list / add list item operations, `upsertEntities` cannot currently be used to set an a JSON array value for an attribute.

However, since #2895, we no longer need the behavior provided by `attributesUpdateOps`. We now set list attribute values with something like:
```
operations: [{
  op: "AddUpdateValue",
  attributeName: "attributeName",
  addUpdateAttribute: {
    itemsType: "AttributeValue",
    items: ["foo", "bar", "baz"]
  }
}]
```
Rawls handles this and and stores the value as a list.
https://broadinstitute.slack.com/archives/C02T8G2FJCQ/p1652220052756079?thread_ts=1650480934.910629&cid=C02T8G2FJCQ

This removes `attributesUpdateOps` from `upsertEntities`, which now takes lists of operations. This allows for finer-grained control over the attribute values set and will allow setting JSON array values through `upsertEntities`.