### PR TITLE
[WOR-153] Remove calls to cloud function ToS methods

### DIFF
--- a/config/alpha.json
+++ b/config/alpha.json
@@ -24,7 +24,6 @@
     "appId": "saturnnonprod-O9lUP",
     "apiKey": "AQEBBAEkx4iE2KxNyI7Wx08EwU1ycTM7E4FMSmaibbMUQxNU6uQvuAJt7fyABAtFYSYfgEE"
   },
-  "tosUrlRoot": "https://us-central1-broad-workbench-tos-alpha.cloudfunctions.net/tos",
   "alphaSpendReportGroup": "Alpha_Spend_Report_Users",
   "alphaRegionalityGroup": "Alpha_Regionality_Users"
 }

--- a/config/dev.json
+++ b/config/dev.json
@@ -24,7 +24,6 @@
     "appId": "saturnnonprod-O9lUP",
     "apiKey": "AQEBBAEkx4iE2KxNyI7Wx08EwU1ycTM7E4FMSmaibbMUQxNU6uQvuAJt7fyABAtFYSYfgEE"
   },
-  "tosUrlRoot": "https://us-central1-broad-workbench-tos-dev.cloudfunctions.net/tos",
   "alphaSpendReportGroup": "Alpha_Spend_Report_Users",
   "alphaRegionalityGroup": "Alpha_Regionality_Users"
 }

--- a/config/fiab.json
+++ b/config/fiab.json
@@ -23,7 +23,6 @@
     "appId": "saturnnonprod-O9lUP",
     "apiKey": "AQEBBAEkx4iE2KxNyI7Wx08EwU1ycTM7E4FMSmaibbMUQxNU6uQvuAJt7fyABAtFYSYfgEE"
   },
-  "tosUrlRoot": "https://us-central1-broad-workbench-tos-dev.cloudfunctions.net/tos",
   "alphaSpendReportGroup": "Alpha_Spend_Report_Users",
   "alphaRegionalityGroup": "Alpha_Regionality_Users"
 }

--- a/config/perf.json
+++ b/config/perf.json
@@ -24,7 +24,6 @@
     "appId": "saturnnonprod-O9lUP",
     "apiKey": "AQEBBAEkx4iE2KxNyI7Wx08EwU1ycTM7E4FMSmaibbMUQxNU6uQvuAJt7fyABAtFYSYfgEE"
   },
-  "tosUrlRoot": "https://us-central1-broad-workbench-tos-perf.cloudfunctions.net/tos",
   "alphaSpendReportGroup": "Alpha_Spend_Report_Users",
   "alphaRegionalityGroup": "Alpha_Regionality_Users"
 }

--- a/config/prod.json
+++ b/config/prod.json
@@ -22,7 +22,6 @@
     "appId": "saturnprod-VuHKy",
     "apiKey": "AQEBBAEGP2gTM2pIdJAQOIeNrm8dcTM7E4FMSmaibbMUQxNU6qy6nLPOBK8QfSvPFSsX8PQ"
   },
-  "tosUrlRoot": "https://us-central1-broad-workbench-tos-prod.cloudfunctions.net/tos",
   "alphaSpendReportGroup": "Alpha_Spend_Report_Users",
   "alphaRegionalityGroup": "Alpha_Regionality_Users"
 }

--- a/config/staging.json
+++ b/config/staging.json
@@ -23,7 +23,6 @@
     "appId": "saturnnonprod-O9lUP",
     "apiKey": "AQEBBAEkx4iE2KxNyI7Wx08EwU1ycTM7E4FMSmaibbMUQxNU6uQvuAJt7fyABAtFYSYfgEE"
   },
-  "tosUrlRoot": "https://us-central1-broad-workbench-tos-staging.cloudfunctions.net/tos",
   "alphaSpendReportGroup": "Alpha_Spend_Report_Users",
   "alphaRegionalityGroup": "Alpha_Regionality_Users"
 }

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -172,7 +172,6 @@ const registerUser = withSignedInPage(async ({ page, token }) => {
     await window.catchErrorResponse(async () => {
       await window.Ajax().User.profile.set({ firstName: 'Integration', lastName: 'Test', contactEmail: 'me@example.com' })
       await window.Ajax().User.acceptTos()
-      await window.Ajax().User.acceptSamTos()
     })
   })
 })

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -27,7 +27,6 @@ window.ajaxOverrideUtils = {
 const authOpts = (token = getUser().token) => ({ headers: { Authorization: `Bearer ${token}` } })
 const jsonBody = body => ({ body: JSON.stringify(body), headers: { 'Content-Type': 'application/json' } })
 const appIdentifier = { headers: { 'X-App-ID': 'Saturn' } }
-const tosData = { appid: 'Saturn', tosversion: 6 }
 
 // Allows use of ajaxOverrideStore to stub responses for testing
 const withInstrumentation = wrappedFetch => (...args) => {

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -222,21 +222,6 @@ const User = signal => ({
   },
 
   getTosAccepted: async () => {
-    const url = `${getConfig().tosUrlRoot}/user/response?${qs.stringify(tosData)}`
-    try {
-      const res = await fetchOk(url, _.merge(authOpts(), { signal }))
-      const { accepted } = await res.json()
-      return accepted
-    } catch (error) {
-      if (error.status === 403 || error.status === 404) {
-        return false
-      } else {
-        throw error
-      }
-    }
-  },
-
-  getSamTosAccepted: async () => {
     try {
       const res = await fetchSam('register/user/v1/termsofservice/status', _.merge(authOpts(), { signal }))
       return res.json()
@@ -257,13 +242,6 @@ const User = signal => ({
   },
 
   acceptTos: async () => {
-    await fetchOk(
-      `${getConfig().tosUrlRoot}/user/response`,
-      _.mergeAll([authOpts(), { signal, method: 'POST' }, jsonBody({ ...tosData, accepted: true })])
-    )
-  },
-
-  acceptSamTos: async () => {
     try {
       await fetchSam(
         'register/user/v1/termsofservice',

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -192,9 +192,7 @@ authStore.subscribe(withErrorReporting('Error checking registration', async (sta
 
 authStore.subscribe(withErrorReporting('Error checking TOS', async (state, oldState) => {
   if (!oldState.isSignedIn && state.isSignedIn) {
-    const acceptedCloudFunctionTos = await Ajax().User.getTosAccepted()
-    const acceptedSamTos = await Ajax().User.getSamTosAccepted()
-    const acceptedTos = acceptedSamTos === null ? acceptedCloudFunctionTos : acceptedSamTos
+    const acceptedTos = await Ajax().User.getTosAccepted()
     authStore.update(state => ({ ...state, acceptedTos }))
   }
 }))

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -169,8 +169,8 @@ authStore.subscribe(withErrorReporting('Error checking registration', async (sta
     try {
       const { enabled } = await Ajax().User.getStatus()
       if (enabled) {
-        // Once the ToS grace period has ended in production, if Sam returns `enabled` above, `acceptedTos` should also be true.
-        // At that point, we can add an assertion here.
+        // While initial state is first loading, state.acceptedTos will be undefined (it will then be `true` on the
+        // second execution of this code, which is still part of the initial rendering).
         return state.acceptedTos ? userStatus.registeredWithTos : userStatus.registeredWithoutTos
       } else {
         return userStatus.disabled
@@ -186,6 +186,7 @@ authStore.subscribe(withErrorReporting('Error checking registration', async (sta
   if ((!oldState.isSignedIn && state.isSignedIn) || (!oldState.acceptedTos && state.acceptedTos)) {
     clearNotification(sessionTimeoutProps.id)
     const registrationStatus = await getRegistrationStatus()
+    debugger
     authStore.update(state => ({ ...state, registrationStatus }))
   }
 }))

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -186,7 +186,6 @@ authStore.subscribe(withErrorReporting('Error checking registration', async (sta
   if ((!oldState.isSignedIn && state.isSignedIn) || (!oldState.acceptedTos && state.acceptedTos)) {
     clearNotification(sessionTimeoutProps.id)
     const registrationStatus = await getRegistrationStatus()
-    debugger
     authStore.update(state => ({ ...state, registrationStatus }))
   }
 }))

--- a/src/pages/TermsOfService.js
+++ b/src/pages/TermsOfService.js
@@ -34,7 +34,6 @@ const TermsOfServicePage = () => {
     try {
       setBusy(true)
       await Ajax().User.acceptTos()
-      await Ajax().User.acceptSamTos()
       authStore.update(state => ({ ...state, acceptedTos: true }))
     } catch (error) {
       reportError('Error accepting TOS', error)


### PR DESCRIPTION
We have been calling both the old cloud function ToS methods and the new Sam ones. Remove the cloud function methods now that the Sam API is working. Terra-ui has always enforced accepting the ToS, although the server API calls have not (and still are not because we are in an extended "grace period").