### PR TITLE
[SU-45] Move data table column settings button to header

### DIFF
--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -2,14 +2,14 @@ import _ from 'lodash/fp'
 import { Fragment, useEffect, useRef, useState } from 'react'
 import { b, div, h, span } from 'react-hyperscript-helpers'
 import { AutoSizer } from 'react-virtualized'
-import { Checkbox, Clickable, DeleteConfirmationModal, fixedSpinnerOverlay, Link } from 'src/components/common'
+import { ButtonPrimary, Checkbox, Clickable, DeleteConfirmationModal, fixedSpinnerOverlay, Link } from 'src/components/common'
 import { concatenateAttributeNames, EditDataLink, EntityRenamer, HeaderOptions, renderDataCell, SingleEntityEditor } from 'src/components/data/data-utils'
 import { ColumnSettingsWithSavedColumnSettings } from 'src/components/data/SavedColumnSettings'
 import { icon } from 'src/components/icons'
 import { ConfirmedSearchInput } from 'src/components/input'
 import Modal from 'src/components/Modal'
 import { MenuButton, MenuTrigger } from 'src/components/PopupTrigger'
-import { ColumnSelector, GridTable, HeaderCell, paginator, Resizable } from 'src/components/table'
+import { GridTable, HeaderCell, paginator, Resizable } from 'src/components/table'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { withErrorReporting } from 'src/libs/error'
@@ -96,6 +96,7 @@ const DataTable = props => {
     return columnDefaults?.[entityType] ? convertColumnDefaults(columnDefaults[entityType]) : []
   })
 
+  const [updatingColumnSettings, setUpdatingColumnSettings] = useState()
   const [renamingEntity, setRenamingEntity] = useState()
   const [updatingEntity, setUpdatingEntity] = useState()
   const [deletingColumn, setDeletingColumn] = useState()
@@ -221,10 +222,12 @@ const DataTable = props => {
   const columnSettings = applyColumnSettings(columnState || [], entityMetadata[entityType].attributeNames)
   const nameWidth = columnWidths['name'] || 150
 
+  const showColumnSettingsModal = () => setUpdatingColumnSettings(columnSettings)
+
   return h(Fragment, [
     !!entities && h(Fragment, [
       div({ style: { display: 'flex', marginBottom: '1rem' } }, [
-        childrenBefore && childrenBefore({ entities, columnSettings }),
+        childrenBefore && childrenBefore({ entities, columnSettings, showColumnSettingsModal }),
         div({ style: { flexGrow: 1 } }),
         !snapshotName && div({ style: { width: 300 } }, [
           h(ConfirmedSearchInput, {
@@ -363,19 +366,7 @@ const DataTable = props => {
               }
             })
           }
-        ]),
-        // Enable saved column settings only for data tables, not snapshots
-        h(ColumnSelector, _.merge(snapshotName ? {} : {
-          columnSettingsComponent: ColumnSettingsWithSavedColumnSettings,
-          entityMetadata,
-          entityType,
-          snapshotName,
-          workspace,
-          modalWidth: 800
-        }, {
-          columnSettings,
-          onSave: setColumnState
-        }))
+        ])
       ]),
       !_.isEmpty(entities) && div({ style: { flex: 'none', marginTop: '1rem' } }, [
         paginator({
@@ -398,6 +389,26 @@ const DataTable = props => {
       showX: true,
       onDismiss: () => setViewData(undefined)
     }, [div({ style: { maxHeight: '80vh', overflowY: 'auto' } }, [displayData(viewData)])]),
+    updatingColumnSettings && h(Modal, {
+      title: 'Select columns',
+      width: 800,
+      onDismiss: () => setUpdatingColumnSettings(undefined),
+      okButton: h(ButtonPrimary, {
+        onClick: () => {
+          setColumnState(updatingColumnSettings)
+          setUpdatingColumnSettings(undefined)
+        }
+      }, ['Done'])
+    }, [
+      h(ColumnSettingsWithSavedColumnSettings, {
+        entityMetadata,
+        entityType,
+        snapshotName,
+        workspace,
+        columnSettings: updatingColumnSettings,
+        onChange: setUpdatingColumnSettings
+      })
+    ]),
     renamingEntity !== undefined && h(EntityRenamer, {
       entityType: _.find(entity => entity.name === renamingEntity, entities).entityType,
       entityName: renamingEntity,

--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -313,6 +313,7 @@ const EntitiesContent = ({
   const renderCopyButton = (entities, columnSettings) => {
     return h(Fragment, [
       h(ButtonPrimary, {
+        style: { marginRight: '1rem' },
         tooltip: `Copy only the ${entityKey}s visible on the current page to the clipboard in .tsv format`,
         onClick: _.flow(
           withErrorReporting('Error copying to clipboard'),
@@ -468,10 +469,14 @@ const EntitiesContent = ({
           selected: selectedEntities,
           setSelected: setSelectedEntities
         },
-        childrenBefore: ({ entities, columnSettings }) => div({ style: { display: 'flex', alignItems: 'center', flex: 'none' } },
+        childrenBefore: ({ entities, columnSettings, showColumnSettingsModal }) => div({ style: { display: 'flex', alignItems: 'center', flex: 'none' } },
           isDataTabRedesignEnabled() ? [
             renderExportMenu({ columnSettings }),
             renderEditMenu(),
+            !snapshotName && h(ButtonSecondary, {
+              style: { marginRight: '1.5rem' },
+              onClick: showColumnSettingsModal
+            }, [icon('cog', { style: { marginRight: '0.5rem' } }), 'Settings']),
             renderOpenWithMenu(),
             div({ style: { margin: '0 1.5rem', height: '100%', borderLeft: Style.standardLine } }),
             div({
@@ -482,6 +487,9 @@ const EntitiesContent = ({
           ] : [
             !snapshotName && renderDownloadButton(columnSettings),
             !_.endsWith('_set', entityKey) && renderCopyButton(entities, columnSettings),
+            !snapshotName && h(ButtonPrimary, {
+              onClick: showColumnSettingsModal
+            }, [icon('cog', { style: { marginRight: '0.5rem' } }), 'Settings']),
             div({ style: { margin: '0 1.5rem', height: '100%', borderLeft: Style.standardLine } }),
             div({
               role: 'status',

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -785,7 +785,7 @@ export const ColumnSettings = ({ columnSettings, onChange }) => {
  * @param {Object} style - style override for the button
  * @param {function(Object[])} onSave - called with modified settings when user saves
  */
-export const ColumnSelector = ({ onSave, columnSettings, columnSettingsComponent = ColumnSettings, modalWidth = 600, style, ...otherProps }) => {
+export const ColumnSelector = ({ onSave, columnSettings, modalWidth = 600, style }) => {
   const [open, setOpen] = useState(false)
   const [modifiedColumnSettings, setModifiedColumnSettings] = useState(undefined)
 
@@ -811,8 +811,7 @@ export const ColumnSelector = ({ onSave, columnSettings, columnSettingsComponent
         }
       }, ['Done'])
     }, [
-      h(columnSettingsComponent, {
-        ...otherProps,
+      h(ColumnSettings, {
         columnSettings: modifiedColumnSettings,
         onChange: setModifiedColumnSettings
       })

--- a/src/pages/workspaces/workspace/workflows/DataStepContent.js
+++ b/src/pages/workspaces/workspace/workflows/DataStepContent.js
@@ -3,8 +3,9 @@ import pluralize from 'pluralize'
 import PropTypes from 'prop-types'
 import { useState } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
-import { ButtonPrimary, IdContainer, RadioButton } from 'src/components/common'
+import { ButtonPrimary, ButtonSecondary, IdContainer, RadioButton } from 'src/components/common'
 import DataTable from 'src/components/data/DataTable'
+import { icon } from 'src/components/icons'
 import { ValidatedInput } from 'src/components/input'
 import Modal from 'src/components/Modal'
 import { FormLabel } from 'src/libs/forms'
@@ -100,7 +101,7 @@ const DataStepContent = ({
       }, [
         h(DataTable, {
           key: type.description,
-          childrenBefore: () => div({ style: { display: 'flex', alignItems: 'center' } }, [
+          childrenBefore: ({ showColumnSettingsModal }) => div({ style: { display: 'flex', alignItems: 'center' } }, [
             div({ style: Style.elements.sectionHeader }, [
               Utils.switchCase(type,
                 [chooseSetType, () => `Select one or more ${entitySetType}s to combine and process`],
@@ -108,6 +109,10 @@ const DataStepContent = ({
                 [chooseBaseType, () => `Select ${baseEntityType}s to create a new ${rootEntityType} to process`]
               )
             ]),
+            h(ButtonSecondary, {
+              style: { marginLeft: '1.5rem' },
+              onClick: showColumnSettingsModal
+            }, [icon('cog', { style: { marginRight: '0.5rem' } }), 'Settings']),
             div({ style: { margin: '0 1.5rem', height: '100%', borderLeft: Style.standardLine } }),
             div({
               role: 'status',


### PR DESCRIPTION
Currently, the button for changing data table column settings (which columns are displayed and in what order) floats in the top right of the data table.

<img width="1130" alt="Screen Shot 2022-05-12 at 10 22 34 AM" src="https://user-images.githubusercontent.com/1156625/168098987-c3c4a382-5af3-45bb-b065-9e200ad5b65c.png">

Besides being inconsistent with other table controls, which appear in a row above the table, this also blocks access to the last column's controls when the table is wider than the window.

This moves the button to the heading above the table.

Dat table:
<img width="1141" alt="Screen Shot 2022-05-12 at 10 23 25 AM" src="https://user-images.githubusercontent.com/1156625/168099270-5660b978-6671-4c6d-84c2-dc53ecc7c883.png">

Redesigned data table (enable with `configOverridesStore.set({ isDataTabRedesignEnabled: true })`):
<img width="1142" alt="Screen Shot 2022-05-12 at 10 23 16 AM" src="https://user-images.githubusercontent.com/1156625/168099318-3a1e0cc8-0187-4e02-b36f-d5886960c20e.png">

Selecting data for a workflow:
<img width="1356" alt="Screen Shot 2022-05-12 at 10 24 22 AM" src="https://user-images.githubusercontent.com/1156625/168099294-b674a901-485f-4805-a435-9029dcfb981a.png">


While column state is managed by the DataTable component, the header is controlled by its parent component (EntitiesContent or DataStepContent) through DataTable's `childrenBefore` prop. DataTable exposes some of its state by passing arguments to `childrenBefore`.