### PR TITLE
[SU-50] Load initial data table column settings from saved column settings

### DIFF
--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -4,7 +4,7 @@ import { b, div, h, span } from 'react-hyperscript-helpers'
 import { AutoSizer } from 'react-virtualized'
 import { ButtonPrimary, Checkbox, Clickable, DeleteConfirmationModal, fixedSpinnerOverlay, Link } from 'src/components/common'
 import { concatenateAttributeNames, EditDataLink, EntityRenamer, HeaderOptions, renderDataCell, SingleEntityEditor } from 'src/components/data/data-utils'
-import { ColumnSettingsWithSavedColumnSettings } from 'src/components/data/SavedColumnSettings'
+import { allSavedColumnSettingsEntityTypeKey, allSavedColumnSettingsInWorkspace, ColumnSettingsWithSavedColumnSettings, decodeColumnSettings } from 'src/components/data/SavedColumnSettings'
 import { icon } from 'src/components/icons'
 import { ConfirmedSearchInput } from 'src/components/input'
 import Modal from 'src/components/Modal'
@@ -79,21 +79,37 @@ const DataTable = props => {
 
   const [columnWidths, setColumnWidths] = useState(() => getLocalPref(persistenceId)?.columnWidths || {})
   const [columnState, setColumnState] = useState(() => {
-    const localColumnPref = getLocalPref(persistenceId)?.columnState
+    // Load initial column settings from:
+    // 1. local storage (last settings for this table)
+    // 2. workspace-column-defaults workspace attribute
+    // 3. saved column settings named "Default" for this table
 
+    const localColumnPref = getLocalPref(persistenceId)?.columnState
     if (!!localColumnPref) {
       return localColumnPref
     }
 
     const { workspace: { attributes: { 'workspace-column-defaults': columnDefaultsString } } } = workspace
     const columnDefaults = Utils.maybeParseJSON(columnDefaultsString)
+    if (columnDefaults?.[entityType]) {
+      const convertColumnDefaults = ({ shown = [], hidden = [] }) => [
+        ..._.map(name => ({ name, visible: true }), shown),
+        ..._.map(name => ({ name, visible: false }), hidden),
+        ..._.map(name => ({ name, visible: true }), _.without([...shown, ...hidden], entityMetadata[entityType].attributeNames))
+      ]
+      return convertColumnDefaults(columnDefaults[entityType])
+    }
 
-    const convertColumnDefaults = ({ shown = [], hidden = [] }) => [
-      ..._.map(name => ({ name, visible: true }), shown),
-      ..._.map(name => ({ name, visible: false }), hidden),
-      ..._.map(name => ({ name, visible: true }), _.without([...shown, ...hidden], entityMetadata[entityType].attributeNames))
-    ]
-    return columnDefaults?.[entityType] ? convertColumnDefaults(columnDefaults[entityType]) : []
+    const savedColumnSettings = _.flow(
+      allSavedColumnSettingsInWorkspace,
+      _.getOr({}, allSavedColumnSettingsEntityTypeKey({ snapshotName, entityType }))
+    )(workspace)
+    const defaultColumnSettingsName = 'Default'
+    if (savedColumnSettings[defaultColumnSettingsName]) {
+      return decodeColumnSettings(savedColumnSettings[defaultColumnSettingsName])
+    }
+
+    return []
   })
 
   const [updatingColumnSettings, setUpdatingColumnSettings] = useState()

--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -85,8 +85,7 @@ const DataTable = props => {
       return localColumnPref
     }
 
-    const { columnDefaults: columnDefaultsString, entityType, entityMetadata } = props
-
+    const { workspace: { attributes: { 'workspace-column-defaults': columnDefaultsString } } } = workspace
     const columnDefaults = Utils.maybeParseJSON(columnDefaultsString)
 
     const convertColumnDefaults = ({ shown = [], hidden = [] }) => [

--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -209,7 +209,7 @@ const ToolDrawer = _.flow(
 
 const EntitiesContent = ({
   workspace, workspace: {
-    workspace: { namespace, name, googleProject, attributes: { 'workspace-column-defaults': columnDefaults } }, workspaceSubmissionStats: { runningSubmissionsCount }
+    workspace: { namespace, name, googleProject }, workspaceSubmissionStats: { runningSubmissionsCount }
   },
   entityKey, entityMetadata, setEntityMetadata, loadMetadata, firstRender, snapshotName, deleteColumnUpdateMetadata
 }) => {
@@ -462,7 +462,7 @@ const EntitiesContent = ({
     h(Fragment, [
       h(DataTable, {
         persist: true, firstRender, refreshKey, editable: !snapshotName && !Utils.editWorkspaceError(workspace),
-        entityType: entityKey, entityMetadata, setEntityMetadata, columnDefaults, googleProject, workspaceId: { namespace, name }, workspace,
+        entityType: entityKey, entityMetadata, setEntityMetadata, googleProject, workspaceId: { namespace, name }, workspace,
         onScroll: saveScroll, initialX, initialY,
         snapshotName,
         selectionModel: {

--- a/src/components/data/SavedColumnSettings.js
+++ b/src/components/data/SavedColumnSettings.js
@@ -21,7 +21,7 @@ const savedColumnSettingsWorkspaceAttributeName = 'system:columnSettings'
 
 // Compress settings to avoid storing 'name' and 'visible' keys many times
 const encodeColumnSettings = _.flatMap(({ name, visible }) => [name, visible])
-const decodeColumnSettings = _.flow(
+export const decodeColumnSettings = _.flow(
   _.chunk(2),
   _.map(([name, visible]) => ({ name, visible }))
 )
@@ -38,7 +38,7 @@ const parseAsStringOrJson = attr => {
   }
 }
 
-const allSavedColumnSettingsInWorkspace = workspace => {
+export const allSavedColumnSettingsInWorkspace = workspace => {
   return _.flow(
     _.get('workspace.attributes'),
     _.getOr('{}', savedColumnSettingsWorkspaceAttributeName),
@@ -46,7 +46,7 @@ const allSavedColumnSettingsInWorkspace = workspace => {
   )(workspace)
 }
 
-const allSavedColumnSettingsEntityTypeKey = ({ snapshotName, entityType }) => {
+export const allSavedColumnSettingsEntityTypeKey = ({ snapshotName, entityType }) => {
   const baseKey = snapshotName ? `snapshots.${snapshotName}` : 'tables'
   const entityTypeKey = `${baseKey}.${entityType}`
   return entityTypeKey

--- a/src/pages/workspaces/workspace/workflows/DataStepContent.js
+++ b/src/pages/workspaces/workspace/workflows/DataStepContent.js
@@ -20,7 +20,7 @@ const DataStepContent = ({
   entityMetadata, rootEntityType,
   workspace
 }) => {
-  const { workspace: { namespace, name, googleProject, attributes: { 'workspace-column-defaults': columnDefaults } } } = workspace
+  const { workspace: { namespace, name, googleProject } } = workspace
   // State
   const [type, setType] = useState(entitySelectionModel.type)
   const [selectedEntities, setSelectedEntities] = useState(entitySelectionModel.selectedEntities)
@@ -124,7 +124,7 @@ const DataStepContent = ({
             [chooseRootType, () => rootEntityType],
             [chooseSetType, () => entitySetType]
           ),
-          entityMetadata, setEntityMetadata: () => {}, googleProject, workspaceId: { namespace, name }, workspace, columnDefaults,
+          entityMetadata, setEntityMetadata: () => {}, googleProject, workspaceId: { namespace, name }, workspace,
           selectionModel: {
             selected: selectedEntities, setSelected: setSelectedEntities
           }


### PR DESCRIPTION
Currently, when you view a data table, the initial column settings (which columns are visible and in what order) are loaded from local storage so that changes persist across sessions. If you're viewing the table for the first time, all columns are shown in alphabetical order.

There's a use case that's important to some groups where one person (Editor) uploads data and prepares it before handing it off to another person (Viewer), who looks at the table only after Editor is done with it. Viewer wants to see a specific set of columns in a specific order.

Currently, this can be done by setting a `workspace-column-defaults` workspace attribute with a JSON encoded object:
```
{
  "tableName": {
    "shown": ["columnA", "columnB"],
    "hidden": ["columnC"]
  },
  ...
}
```

However, it's not convenient to set/edit that attribute and workspaces with many tables or tables with many columns may exceed the maximum size of a string attribute.

We have the ability to save column settings in the UI (the gear button at the top right of the data table). So Editor could save column settings which Viewer could then load.

To streamline this and make it so that Viewer does not have to load column settings, this looks for saved column settings named "Default" and uses that for initial column settings if it exists.


To replicate viewing a data table for the first time, clear column settings from local storage using:
```
userId = localStorage.getItem('apc_user_id')
localStorage.removeItem(`dynamic-storage/${userId}/${workspaceNamespace}/${workspaceName}/${entityType`)
```