### PR TITLE
[SU-100] Restyle table panels in data tab

### DIFF
--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -226,7 +226,7 @@ const DataTable = props => {
 
   return h(Fragment, [
     !!entities && h(Fragment, [
-      div({ style: { display: 'flex', marginBottom: '1rem' } }, [
+      div({ style: { display: 'flex', padding: '1rem' } }, [
         childrenBefore && childrenBefore({ entities, columnSettings, showColumnSettingsModal }),
         div({ style: { flexGrow: 1 } }),
         !snapshotName && div({ style: { width: 300 } }, [
@@ -242,7 +242,7 @@ const DataTable = props => {
         ])
       ]),
       div({
-        style: { flex: 1 }
+        style: { flex: 1, margin: '0 1rem' }
       }, [
         h(AutoSizer, [
           ({ width, height }) => {
@@ -368,7 +368,7 @@ const DataTable = props => {
           }
         ])
       ]),
-      !_.isEmpty(entities) && div({ style: { flex: 'none', marginTop: '1rem' } }, [
+      !_.isEmpty(entities) && div({ style: { flex: 'none', margin: '1rem' } }, [
         paginator({
           filteredDataLength: filteredCount,
           unfilteredDataLength: totalRowCount,

--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -12,6 +12,7 @@ import { MenuButton, MenuTrigger } from 'src/components/PopupTrigger'
 import { GridTable, HeaderCell, paginator, Resizable } from 'src/components/table'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
+import { isDataTabRedesignEnabled } from 'src/libs/config'
 import { withErrorReporting } from 'src/libs/error'
 import { getLocalPref, setLocalPref } from 'src/libs/prefs'
 import { useCancellation } from 'src/libs/react-utils'
@@ -226,7 +227,14 @@ const DataTable = props => {
 
   return h(Fragment, [
     !!entities && h(Fragment, [
-      div({ style: { display: 'flex', padding: '1rem' } }, [
+      div({
+        style: {
+          display: 'flex',
+          padding: '1rem',
+          background: isDataTabRedesignEnabled() ? colors.light() : undefined,
+          borderBottom: isDataTabRedesignEnabled() ? `1px solid ${colors.grey(0.4)}` : undefined
+        }
+      }, [
         childrenBefore && childrenBefore({ entities, columnSettings, showColumnSettingsModal }),
         div({ style: { flexGrow: 1 } }),
         !snapshotName && div({ style: { width: 300 } }, [
@@ -242,7 +250,7 @@ const DataTable = props => {
         ])
       ]),
       div({
-        style: { flex: 1, margin: '0 1rem' }
+        style: { flex: 1, margin: isDataTabRedesignEnabled() ? 0 : '0 1rem' }
       }, [
         h(AutoSizer, [
           ({ width, height }) => {
@@ -363,7 +371,8 @@ const DataTable = props => {
               ],
               styleCell: ({ rowIndex }) => {
                 return rowIndex % 2 && { backgroundColor: colors.light(0.2) }
-              }
+              },
+              border: !isDataTabRedesignEnabled()
             })
           }
         ])

--- a/src/components/data/LocalVariablesContent.js
+++ b/src/components/data/LocalVariablesContent.js
@@ -152,7 +152,7 @@ const LocalVariablesContent = ({ workspace, workspace: { workspace: { googleProj
     activeStyle: { backgroundColor: colors.accent(0.2), cursor: 'copy' },
     onDropAccepted: upload
   }, [({ openUploader }) => h(Fragment, [
-    div({ style: { flex: 'none', display: 'flex', alignItems: 'center', marginBottom: '1rem', justifyContent: 'flex-end' } }, [
+    div({ style: { flex: 'none', display: 'flex', alignItems: 'center', padding: '1rem', justifyContent: 'flex-end' } }, [
       h(Link, { onClick: download }, ['Download TSV']),
       !Utils.editWorkspaceError(workspace) && h(Fragment, [
         div({ style: { whiteSpace: 'pre' } }, ['  |  Drag or click to ']),
@@ -166,7 +166,7 @@ const LocalVariablesContent = ({ workspace, workspace: { workspace: { googleProj
         value: textFilter
       })
     ]),
-    div({ style: { flex: 1 } }, [
+    div({ style: { flex: 1, margin: '0 1rem 1rem' } }, [
       h(AutoSizer, [({ width, height }) => h(FlexTable, {
         'aria-label': 'workspace data local variables table',
         width, height, rowCount: amendedAttributes.length,

--- a/src/components/data/LocalVariablesContent.js
+++ b/src/components/data/LocalVariablesContent.js
@@ -12,6 +12,7 @@ import { DelayedSearchInput, TextInput } from 'src/components/input'
 import { FlexTable, HeaderCell } from 'src/components/table'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
+import { isDataTabRedesignEnabled } from 'src/libs/config'
 import { withErrorReporting } from 'src/libs/error'
 import { useCancellation } from 'src/libs/react-utils'
 import * as StateHistory from 'src/libs/state-history'
@@ -152,7 +153,14 @@ const LocalVariablesContent = ({ workspace, workspace: { workspace: { googleProj
     activeStyle: { backgroundColor: colors.accent(0.2), cursor: 'copy' },
     onDropAccepted: upload
   }, [({ openUploader }) => h(Fragment, [
-    div({ style: { flex: 'none', display: 'flex', alignItems: 'center', padding: '1rem', justifyContent: 'flex-end' } }, [
+    div({
+      style: {
+        flex: 'none', display: 'flex', alignItems: 'center', justifyContent: 'flex-end',
+        padding: '1rem',
+        background: isDataTabRedesignEnabled() ? colors.light() : undefined,
+        borderBottom: isDataTabRedesignEnabled() ? `1px solid ${colors.grey(0.4)}` : undefined
+      }
+    }, [
       h(Link, { onClick: download }, ['Download TSV']),
       !Utils.editWorkspaceError(workspace) && h(Fragment, [
         div({ style: { whiteSpace: 'pre' } }, ['  |  Drag or click to ']),
@@ -166,7 +174,7 @@ const LocalVariablesContent = ({ workspace, workspace: { workspace: { googleProj
         value: textFilter
       })
     ]),
-    div({ style: { flex: 1, margin: '0 1rem 1rem' } }, [
+    div({ style: { flex: 1, margin: isDataTabRedesignEnabled() ? '0 0 1rem' : '0 1rem 1rem' } }, [
       h(AutoSizer, [({ width, height }) => h(FlexTable, {
         'aria-label': 'workspace data local variables table',
         width, height, rowCount: amendedAttributes.length,
@@ -174,6 +182,7 @@ const LocalVariablesContent = ({ workspace, workspace: { workspace: { googleProj
         initialY,
         hoverHighlight: true,
         noContentMessage: _.isEmpty(initialAttributes) ? 'No Workspace Data defined' : 'No matching data',
+        border: !isDataTabRedesignEnabled(),
         columns: [{
           size: { basis: 400, grow: 0 },
           headerRenderer: () => h(HeaderCell, ['Key']),

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -118,21 +118,21 @@ const cellStyles = {
 }
 
 const styles = {
-  cell: (col, total) => ({
+  cell: (col, total, { border } = {}) => ({
     ...cellStyles,
     borderBottom: `1px solid ${colors.dark(0.2)}`,
-    borderLeft: `1px solid ${colors.dark(0.2)}`,
-    borderRight: col === total - 1 ? `1px solid ${colors.dark(0.2)}` : undefined
+    borderLeft: !border && col === 0 ? undefined : `1px solid ${colors.dark(0.2)}`,
+    borderRight: border && col === total - 1 ? `1px solid ${colors.dark(0.2)}` : undefined
   }),
-  header: (col, total) => ({
+  header: (col, total, { border } = {}) => ({
     ...cellStyles,
     backgroundColor: colors.light(0.5),
-    borderTop: `1px solid ${colors.dark(0.2)}`,
+    borderTop: border ? `1px solid ${colors.dark(0.2)}` : undefined,
     borderBottom: `1px solid ${colors.dark(0.2)}`,
-    borderLeft: `1px solid ${colors.dark(0.2)}`,
-    borderRight: col === total - 1 ? `1px solid ${colors.dark(0.2)}` : undefined,
-    borderTopLeftRadius: col === 0 ? '5px' : undefined,
-    borderTopRightRadius: col === total - 1 ? '5px' : undefined
+    borderLeft: !border && col === 0 ? undefined : `1px solid ${colors.dark(0.2)}`,
+    borderRight: border && col === total - 1 ? `1px solid ${colors.dark(0.2)}` : undefined,
+    borderTopLeftRadius: border && col === 0 ? '5px' : undefined,
+    borderTopRightRadius: border && col === total - 1 ? '5px' : undefined
   }),
   flexCell: ({ basis = 0, grow = 1, shrink = 1, min = 0, max } = {}) => ({
     flexGrow: grow,
@@ -208,6 +208,7 @@ export const FlexTable = ({
   initialY = 0, width, height, rowCount, variant, columns = [], hoverHighlight = false,
   onScroll = _.noop, noContentMessage, noContentRenderer = _.noop, headerHeight = flexTableDefaultRowHeight, rowHeight = flexTableDefaultRowHeight,
   styleCell = () => ({}), styleHeader = () => ({}), 'aria-label': ariaLabel, sort = null, readOnly = false,
+  border = true,
   ...props
 }) => {
   useLabelAssert('FlexTable', { 'aria-label': ariaLabel, allowLabelledBy: false })
@@ -245,7 +246,7 @@ export const FlexTable = ({
         'aria-sort': ariaSort(sort, field),
         style: {
           ...styles.flexCell(size),
-          ...(variant === 'light' ? {} : styles.header(i * 1, columns.length)),
+          ...(variant === 'light' ? {} : styles.header(i * 1, columns.length, { border })),
           ...(styleHeader ? styleHeader({ columnIndex: i }) : {})
         }
       }, [headerRenderer({ columnIndex: i })])
@@ -284,7 +285,7 @@ export const FlexTable = ({
               className: 'table-cell',
               style: {
                 ...styles.flexCell(size),
-                ...(variant === 'light' ? {} : styles.cell(i * 1, columns.length)),
+                ...(variant === 'light' ? {} : styles.cell(i * 1, columns.length, { border })),
                 ...(styleCell ? styleCell({ ...data, columnIndex: i, rowIndex: data.rowIndex }) : {})
               }
             }, [cellRenderer({ ...data, columnIndex: i, rowIndex: data.rowIndex })])
@@ -337,7 +338,7 @@ FlexTable.propTypes = {
  * A basic table with a header and flexible column widths. Intended for small amounts of data,
  * since it does not provide scrolling. See FlexTable for prop types.
  */
-export const SimpleFlexTable = ({ columns, rowCount, noContentMessage, noContentRenderer = _.noop, hoverHighlight, 'aria-label': ariaLabel, sort = null, readOnly = false }) => {
+export const SimpleFlexTable = ({ columns, rowCount, noContentMessage, noContentRenderer = _.noop, hoverHighlight, 'aria-label': ariaLabel, sort = null, readOnly = false, border = true }) => {
   useLabelAssert('SimpleFlexTable', { 'aria-label': ariaLabel, allowLabelledBy: false })
 
   return div({
@@ -355,7 +356,7 @@ export const SimpleFlexTable = ({ columns, rowCount, noContentMessage, noContent
           key: i,
           role: 'columnheader',
           'aria-sort': ariaSort(sort, field),
-          style: { ...styles.flexCell(size), ...styles.header(i * 1, columns.length) }
+          style: { ...styles.flexCell(size), ...styles.header(i * 1, columns.length, { border }) }
         }, [headerRenderer({ columnIndex: i })])
       }, Utils.toIndexPairs(columns))
     ]),
@@ -373,7 +374,7 @@ export const SimpleFlexTable = ({ columns, rowCount, noContentMessage, noContent
             key: i,
             role: 'cell',
             className: 'table-cell',
-            style: { ...styles.flexCell(size), ...styles.cell(i * 1, columns.length) }
+            style: { ...styles.flexCell(size), ...styles.cell(i * 1, columns.length, { border }) }
           }, [cellRenderer({ columnIndex: i, rowIndex })])
         }, Utils.toIndexPairs(columns))
       ])
@@ -390,7 +391,8 @@ export const GridTable = forwardRefWithName('GridTable', ({
   width, height, initialX = 0, initialY = 0, rowHeight = 48, headerHeight = 48,
   noContentMessage, noContentRenderer = _.noop,
   rowCount, columns, styleCell = () => ({}), styleHeader = () => ({}), onScroll: customOnScroll = _.noop,
-  'aria-label': ariaLabel, sort = null, readOnly = false
+  'aria-label': ariaLabel, sort = null, readOnly = false,
+  border = true
 }, ref) => {
   useLabelAssert('GridTable', { 'aria-label': ariaLabel, allowLabelledBy: false })
 
@@ -456,7 +458,7 @@ export const GridTable = forwardRefWithName('GridTable', ({
               className: 'table-cell',
               style: {
                 ...data.style,
-                ...styles.header(data.columnIndex, columns.length),
+                ...styles.header(data.columnIndex, columns.length, { border }),
                 ...styleHeader(data)
               }
             }, [
@@ -495,7 +497,7 @@ export const GridTable = forwardRefWithName('GridTable', ({
                 className: 'table-cell',
                 style: {
                   ...data.style,
-                  ...styles.cell(data.columnIndex, columns.length),
+                  ...styles.cell(data.columnIndex, columns.length, { border }),
                   backgroundColor: 'white',
                   ...styleCell(data)
                 }

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -58,7 +58,6 @@ const styles = {
   },
   sidebarSeparator: {
     width: '2px',
-    background: colors.light(),
     height: '100%',
     cursor: 'ew-resize'
   },
@@ -130,7 +129,14 @@ const ReferenceDataContent = ({ workspace: { workspace: { googleProject, attribu
   const { initialY } = firstRender ? StateHistory.get() : {}
 
   return h(Fragment, [
-    div({ style: { display: 'flex', justifyContent: 'flex-end', padding: '1rem' } }, [
+    div({
+      style: {
+        display: 'flex', justifyContent: 'flex-end',
+        padding: '1rem',
+        background: isDataTabRedesignEnabled() ? colors.light() : undefined,
+        borderBottom: isDataTabRedesignEnabled() ? `1px solid ${colors.grey(0.4)}` : undefined
+      }
+    }, [
       h(DelayedSearchInput, {
         'aria-label': 'Search',
         style: { width: 300 },
@@ -139,7 +145,7 @@ const ReferenceDataContent = ({ workspace: { workspace: { googleProject, attribu
         value: textFilter
       })
     ]),
-    div({ style: { flex: 1, margin: '0 1rem 1rem' } }, [
+    div({ style: { flex: 1, margin: isDataTabRedesignEnabled() ? '0 0 1rem' : '0 1rem 1rem' } }, [
       h(AutoSizer, [
         ({ width, height }) => h(FlexTable, {
           'aria-label': 'reference data',
@@ -158,7 +164,8 @@ const ReferenceDataContent = ({ workspace: { workspace: { googleProject, attribu
               headerRenderer: () => h(HeaderCell, ['Value']),
               cellRenderer: ({ rowIndex }) => renderDataCell(selectedData[rowIndex].value, googleProject)
             }
-          ]
+          ],
+          border: !isDataTabRedesignEnabled()
         })
       ])
     ])
@@ -445,7 +452,10 @@ const SidebarSeparator = ({ sidebarWidth, setSidebarWidth }) => {
       'aria-valuemax': getMaxWidth(),
       tabIndex: 0,
       className: 'custom-focus-style',
-      style: styles.sidebarSeparator,
+      style: {
+        ...styles.sidebarSeparator,
+        background: isDataTabRedesignEnabled() ? colors.grey(0.4) : colors.light()
+      },
       hover: {
         background: colors.accent(1.2)
       },
@@ -685,7 +695,13 @@ const WorkspaceData = _.flow(
   return div({ style: styles.tableContainer }, [
     !entityMetadata ? spinnerOverlay : h(Fragment, [
       div({ style: { ...styles.sidebarContainer, width: sidebarWidth } }, [
-        isDataTabRedesignEnabled() && div({ style: { display: 'flex', padding: '1rem 1.5rem', backgroundColor: colors.light(0.4) } }, [
+        isDataTabRedesignEnabled() && div({
+          style: {
+            display: 'flex', padding: '1rem 1.5rem',
+            backgroundColor: colors.light(),
+            borderBottom: `1px solid ${colors.grey(0.4)}`
+          }
+        }, [
           h(MenuTrigger, {
             side: 'bottom',
             closeOnClick: true,

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -65,7 +65,6 @@ const styles = {
   tableViewPanel: {
     position: 'relative',
     overflow: 'hidden',
-    padding: '1rem',
     width: '100%',
     flex: 1, display: 'flex', flexDirection: 'column'
   }
@@ -131,14 +130,16 @@ const ReferenceDataContent = ({ workspace: { workspace: { googleProject, attribu
   const { initialY } = firstRender ? StateHistory.get() : {}
 
   return h(Fragment, [
-    h(DelayedSearchInput, {
-      'aria-label': 'Search',
-      style: { width: 300, marginBottom: '1rem', alignSelf: 'flex-end' },
-      placeholder: 'Search',
-      onChange: setTextFilter,
-      value: textFilter
-    }),
-    div({ style: { flex: 1 } }, [
+    div({ style: { display: 'flex', justifyContent: 'flex-end', padding: '1rem' } }, [
+      h(DelayedSearchInput, {
+        'aria-label': 'Search',
+        style: { width: 300 },
+        placeholder: 'Search',
+        onChange: setTextFilter,
+        value: textFilter
+      })
+    ]),
+    div({ style: { flex: 1, margin: '0 1rem 1rem' } }, [
       h(AutoSizer, [
         ({ width, height }) => h(FlexTable, {
           'aria-label': 'reference data',
@@ -258,7 +259,8 @@ const BucketContent = _.flow(
       maxHeight: '100%',
       backgroundColor: 'white',
       border: `1px solid ${colors.dark(0.55)}`,
-      padding: '1rem'
+      padding: '1rem',
+      margin: '1rem'
     },
     activeStyle: { backgroundColor: colors.accent(0.2), cursor: 'copy' },
     onDropAccepted: uploadFiles

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -50,7 +50,6 @@ const styles = {
   },
   sidebarContainer: {
     overflow: 'auto',
-    boxShadow: '0 2px 5px 0 rgba(0,0,0,0.25)',
     transition: 'width 100ms'
   },
   dataTypeSelectionPanel: {
@@ -58,15 +57,16 @@ const styles = {
     backgroundColor: 'white'
   },
   sidebarSeparator: {
-    width: '0.75rem',
+    width: '2px',
+    background: colors.light(),
     height: '100%',
     cursor: 'ew-resize'
   },
   tableViewPanel: {
     position: 'relative',
     overflow: 'hidden',
-    // Left padding is 0.25rem to make room for the sidebar separator
-    padding: '1rem 1rem 1rem 0.25rem', width: '100%',
+    padding: '1rem',
+    width: '100%',
     flex: 1, display: 'flex', flexDirection: 'column'
   }
 }
@@ -445,7 +445,7 @@ const SidebarSeparator = ({ sidebarWidth, setSidebarWidth }) => {
       className: 'custom-focus-style',
       style: styles.sidebarSeparator,
       hover: {
-        background: `linear-gradient(to right, ${colors.accent(1.2)}, transparent 3px)`
+        background: colors.accent(1.2)
       },
       onKeyDown: e => {
         if (e.key === 'ArrowRight' || e.key === 'ArrowUp') {


### PR DESCRIPTION
Update data tab panels based on new designs from UX. This changes tables to span the full width of the panel and gives the header at the top a darker gray background. 

To enable the data tab redesign, use `configOverridesStore.set({ isDataTabRedesignEnabled: true })`.

Without the feature flag, the only effect is on the separator between the sidebar and main content of the data tab. It replaces the box shadow with a solid line and unfortunately makes the hover target for resizing the sidebar smaller.

## Before

Data table
<img width="1442" alt="Screen Shot 2022-05-13 at 2 42 16 PM" src="https://user-images.githubusercontent.com/1156625/168347388-e31d057e-c718-42c9-8245-b535f8ddd3cd.png">

Reference data
<img width="1442" alt="Screen Shot 2022-05-13 at 2 42 19 PM" src="https://user-images.githubusercontent.com/1156625/168347392-1f98f8f8-cda4-484e-b753-965670a306ae.png">

Workspace data
<img width="1442" alt="Screen Shot 2022-05-13 at 2 42 21 PM" src="https://user-images.githubusercontent.com/1156625/168347397-3b41a0db-2571-45a8-b952-8df748899d27.png">

## After

Data table
<img width="1442" alt="Screen Shot 2022-05-13 at 2 42 35 PM" src="https://user-images.githubusercontent.com/1156625/168347445-084565a1-43c6-4cf8-87cc-5303ef6515ff.png">

Reference data
<img width="1442" alt="Screen Shot 2022-05-13 at 2 42 37 PM" src="https://user-images.githubusercontent.com/1156625/168347449-7fd6d2a8-ae2a-4b9f-9476-a039071d1ee4.png">

Workspace data
<img width="1442" alt="Screen Shot 2022-05-13 at 2 42 40 PM" src="https://user-images.githubusercontent.com/1156625/168347455-183fa023-6534-45b6-89e9-f8b7311bb10b.png">


