### PR TITLE
[QA-1839] signIntoTerra function minor update

### DIFF
--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -198,12 +198,6 @@ const signIntoTerra = async (page, { token, testUrl }) => {
     await waitForNoSpinners(page)
   }
 
-  const signInWithToken = async () => {
-    await page.evaluate(token => window.forceSignIn(token), token)
-    await dismissNotifications(page)
-    await waitForNoSpinners(page)
-  }
-
   if (!!testUrl) {
     console.log(`Loading page: ${testUrl}`)
     await page.goto(testUrl, waitUntilLoadedOrTimeout())
@@ -218,7 +212,9 @@ const signIntoTerra = async (page, { token, testUrl }) => {
     await waitUtilBannerVisible()
   }
 
-  await signInWithToken()
+  await page.evaluate(token => window.forceSignIn(token), token)
+  await dismissNotifications(page)
+  await waitForNoSpinners(page)
 }
 
 const findElement = (page, xpath, options) => {

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -201,17 +201,18 @@ const waitForSignInPage = async (page, timeout = 30 * 1000) => {
 
 const signIntoTerra = async (page, { token, testUrl }) => {
   if (!!testUrl) {
-    try {
-      console.log(`Loading sign-in page: ${testUrl}`)
-      await page.goto(testUrl, waitUntilLoadedOrTimeout())
-      await waitForSignInPage(page)
-    } catch (err) {
-      console.error(err)
-      console.error(`Error: Page loading timed out during sign in. Reloading URL: "${testUrl}"`)
-      await page.reload({ waitUntil: 'load' })
-    }
+    console.log(`Loading sign-in page: ${testUrl}`)
+    await page.goto(testUrl, waitUntilLoadedOrTimeout())
   }
-  await waitForSignInPage(page)
+  try {
+    await waitForSignInPage(page)
+  } catch (err) {
+    console.error(err)
+    console.error(`Error: Page loading timed out during sign in. Reloading URL: "${testUrl}"`)
+    await page.reload({ waitUntil: 'load' })
+    await waitForSignInPage(page)
+  }
+
   await page.evaluate(token => window.forceSignIn(token), token)
   await dismissNotifications(page)
   await waitForNoSpinners(page)

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -191,31 +191,34 @@ const dismissNotifications = async page => {
   return !!notificationCloseButtons.length && delay(1000) // delayed for alerts to animate off
 }
 
-const waitForSignInPage = async (page, timeout = 30 * 1000) => {
-  await Promise.race([
-    page.waitForXPath('//*[@id="signInButton"]', { visible: true, timeout }),
-    page.waitForXPath('//a[@href="#workspaces"]', { visible: true, timeout })
-  ])
-    .then(() => waitForNoSpinners(page))
-}
-
 const signIntoTerra = async (page, { token, testUrl }) => {
+  const waitUtilBannerVisible = async (timeout = 30 * 1000) => {
+    // Finding visible banner web element first to avoid checking spinner before it renders. It still can happen but chances are smaller.
+    await page.waitForXPath('//*[@id="root"]//*[@role="banner"]', { visible: true, timeout })
+    await waitForNoSpinners(page)
+  }
+
+  const signInWithToken = async () => {
+    await page.evaluate(token => window.forceSignIn(token), token)
+    await dismissNotifications(page)
+    await waitForNoSpinners(page)
+  }
+
   if (!!testUrl) {
-    console.log(`Loading sign-in page: ${testUrl}`)
+    console.log(`Loading page: ${testUrl}`)
     await page.goto(testUrl, waitUntilLoadedOrTimeout())
   }
+
   try {
-    await waitForSignInPage(page)
+    await waitUtilBannerVisible()
   } catch (err) {
     console.error(err)
-    console.error(`Error: Page loading timed out during sign in. Reloading URL: "${testUrl}"`)
+    console.error('Error: Page loading timed out during sign in. Reload page.')
     await page.reload({ waitUntil: 'load' })
-    await waitForSignInPage(page)
+    await waitUtilBannerVisible()
   }
 
-  await page.evaluate(token => window.forceSignIn(token), token)
-  await dismissNotifications(page)
-  await waitForNoSpinners(page)
+  await signInWithToken()
 }
 
 const findElement = (page, xpath, options) => {

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -209,12 +209,9 @@ const signIntoTerra = async (page, { token, testUrl }) => {
       console.error(err)
       console.error(`Error: Page loading timed out during sign in. Reloading URL: "${testUrl}"`)
       await page.reload({ waitUntil: 'load' })
-      await waitForSignInPage(page)
     }
-  } else {
-    await waitForSignInPage(page)
   }
-
+  await waitForSignInPage(page)
   await page.evaluate(token => window.forceSignIn(token), token)
   await dismissNotifications(page)
   await waitForNoSpinners(page)

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -211,6 +211,8 @@ const signIntoTerra = async (page, { token, testUrl }) => {
       await page.reload({ waitUntil: 'load' })
       await waitForSignInPage(page)
     }
+  } else {
+    await waitForSignInPage(page)
   }
 
   await page.evaluate(token => window.forceSignIn(token), token)


### PR DESCRIPTION
Fixing a bug introduced by PR [3021](https://github.com/DataBiosphere/terra-ui/pull/3021)
CircleCI job [failure](https://app.circleci.com/pipelines/github/DataBiosphere/terra-ui/9516/workflows/7ec208d3-60f9-429e-82c9-d2a122a67c2e).

PR 3021 has changed `signIntoTerra` function which has caused few tests to fail due to race condition. Alpha and Staging env are slower than dev env. Updated function fails to wait for Sign-in page ready if optional `testUrl` parameter is not present. Some tests do not pass in `testUrl` to `signIntoTerra` function and do not wait for sign-in page ready.

e.g.

<img width="773" alt="Screen Shot 2022-05-13 at 5 22 58 PM" src="https://user-images.githubusercontent.com/35533885/168391483-2dad5a92-0ba6-46cc-afdb-2698046ae915.png">

