### PR TITLE
[QA-1825] Integration test: Rework flaky signIntoFirecloud function

### DIFF
--- a/integration-tests/utils/firecloud-utils.js
+++ b/integration-tests/utils/firecloud-utils.js
@@ -20,8 +20,11 @@ const signIntoFirecloud = async (page, token) => {
    * a computer will operate fast enough to encounter, we'll just slow the computer down a little.
    */
   await page.waitForResponse(response => {
-    return response.url().startsWith('https://accounts.google.com/o/oauth2/') && response.request().method() === 'GET'
-  }, { timeout: 30 * 1000 }
+      console.log(response.url())
+      return response.url().startsWith('https://accounts.google.com/o/oauth2/iframerpc')
+        && response.request().method() === 'GET'
+        && response.status() === 200
+    }, { timeout: 30 * 1000 }
   )
 
   await page.waitForXPath('//title[text()="FireCloud | Broad Institute"]')

--- a/integration-tests/utils/firecloud-utils.js
+++ b/integration-tests/utils/firecloud-utils.js
@@ -7,8 +7,6 @@ const selectWorkspace = async (page, billingAccount, workspace) => {
 }
 
 const signIntoFirecloud = async (page, token) => {
-  await waitForNoSpinners(page)
-  await findText(page, 'content you are looking for is currently only accessible')
   /*
    * The FireCloud not-signed-in page renders the sign-in button while it is still doing some
    * initialization. If you log the status of the App components state for user-status and auth2
@@ -21,7 +19,19 @@ const signIntoFirecloud = async (page, token) => {
    * user-status). Instead of reworking the sign-in logic for a case that (for the most part) only
    * a computer will operate fast enough to encounter, we'll just slow the computer down a little.
    */
+  await page.waitForResponse(response => {
+      return response.url().startsWith('https://accounts.google.com/o/oauth2/') && response.request().method() === 'GET'
+    }, { timeout: 30 * 1000 }
+  )
+
+  await page.waitForXPath('//title[text()="FireCloud | Broad Institute"]')
+  await findText(page, 'content you are looking for is currently only accessible')
+  await waitForNoSpinners(page)
+
   await delay(1000) // wait a second for full load not accounted for by spinners
+
+  console.log(`Sign in Firecloud: ${page.url()}`)
+  await page.waitForFunction('!!window["forceSignedIn"]')
   await page.evaluate(token => window.forceSignedIn(token), token) // Note: function for Fire Cloud is forceSignedIn() while Terra is forceSignIn()
 }
 

--- a/integration-tests/utils/firecloud-utils.js
+++ b/integration-tests/utils/firecloud-utils.js
@@ -1,4 +1,4 @@
-const { click, findText, waitForNoSpinners, delay } = require('./integration-utils')
+const { click, findText, waitForNoSpinners } = require('./integration-utils')
 
 
 const selectWorkspace = async (page, billingAccount, workspace) => {
@@ -27,8 +27,6 @@ const signIntoFirecloud = async (page, token) => {
   await page.waitForXPath('//title[text()="FireCloud | Broad Institute"]')
   await findText(page, 'content you are looking for is currently only accessible')
   await waitForNoSpinners(page)
-
-  await delay(1000) // wait a second for full load not accounted for by spinners
 
   console.log(`Sign in Firecloud: ${page.url()}`)
   await page.waitForFunction('!!window["forceSignedIn"]')

--- a/integration-tests/utils/firecloud-utils.js
+++ b/integration-tests/utils/firecloud-utils.js
@@ -20,7 +20,6 @@ const signIntoFirecloud = async (page, token) => {
    * a computer will operate fast enough to encounter, we'll just slow the computer down a little.
    */
   await page.waitForResponse(response => {
-    console.log(response.url())
     return response.url().startsWith('https://accounts.google.com/o/oauth2/iframerpc') &&
         response.request().method() === 'GET' &&
         response.status() === 200

--- a/integration-tests/utils/firecloud-utils.js
+++ b/integration-tests/utils/firecloud-utils.js
@@ -20,11 +20,11 @@ const signIntoFirecloud = async (page, token) => {
    * a computer will operate fast enough to encounter, we'll just slow the computer down a little.
    */
   await page.waitForResponse(response => {
-      console.log(response.url())
-      return response.url().startsWith('https://accounts.google.com/o/oauth2/iframerpc')
-        && response.request().method() === 'GET'
-        && response.status() === 200
-    }, { timeout: 30 * 1000 }
+    console.log(response.url())
+    return response.url().startsWith('https://accounts.google.com/o/oauth2/iframerpc') &&
+        response.request().method() === 'GET' &&
+        response.status() === 200
+  }, { timeout: 30 * 1000 }
   )
 
   await page.waitForXPath('//title[text()="FireCloud | Broad Institute"]')

--- a/integration-tests/utils/firecloud-utils.js
+++ b/integration-tests/utils/firecloud-utils.js
@@ -2,7 +2,7 @@ const { click, findText, waitForNoSpinners } = require('./integration-utils')
 
 
 const selectWorkspace = async (page, billingAccount, workspace) => {
-  await click(page, `//*[@data-test-id="workspace-selector"]`)
+  await click(page, '//*[@data-test-id="workspace-selector"]')
   return click(page, `//ul/li[contains(normalize-space(.),"${billingAccount}/${workspace}")]`)
 }
 

--- a/integration-tests/utils/firecloud-utils.js
+++ b/integration-tests/utils/firecloud-utils.js
@@ -20,8 +20,8 @@ const signIntoFirecloud = async (page, token) => {
    * a computer will operate fast enough to encounter, we'll just slow the computer down a little.
    */
   await page.waitForResponse(response => {
-      return response.url().startsWith('https://accounts.google.com/o/oauth2/') && response.request().method() === 'GET'
-    }, { timeout: 30 * 1000 }
+    return response.url().startsWith('https://accounts.google.com/o/oauth2/') && response.request().method() === 'GET'
+  }, { timeout: 30 * 1000 }
   )
 
   await page.waitForXPath('//title[text()="FireCloud | Broad Institute"]')


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/QA-1825

`signIntoFirecloud` function fails randomly. Caused by race condition when `forceSignedIn` call executed before Google oauth request.
