### PR TITLE
[TOAZ-129] A few more fixes prior to B2C enablement in dev

### DIFF
--- a/config/alpha.json
+++ b/config/alpha.json
@@ -10,7 +10,6 @@
   "externalCredsUrlRoot": "https://externalcreds.dsde-alpha.broadinstitute.org",
   "firecloudBucketRoot": "https://storage.googleapis.com/firecloud-alerts-alpha",
   "firecloudUrlRoot": "https://firecloud.dsde-alpha.broadinstitute.org",
-  "oidcClientId": "589295024008-4i4s4l2cfjgckmc6moqs23te2tn6qkke.apps.googleusercontent.com",
   "isProd": true,
   "jobManagerUrlRoot": "https://job-manager.dsde-alpha.broadinstitute.org/jobs",
   "leoUrlRoot": "https://leonardo.dsde-alpha.broadinstitute.org",

--- a/config/dev.json
+++ b/config/dev.json
@@ -10,7 +10,6 @@
   "externalCredsUrlRoot": "https://externalcreds.dsde-dev.broadinstitute.org",
   "firecloudBucketRoot": "https://storage.googleapis.com/firecloud-alerts-dev",
   "firecloudUrlRoot": "https://firecloud.dsde-dev.broadinstitute.org",
-  "oidcClientId": "500025638838-s2v23ar3spugtd5t2v1vgfa2sp7ppg0d.apps.googleusercontent.com",
   "isProd": false,
   "jobManagerUrlRoot": "https://job-manager.dsde-dev.broadinstitute.org/jobs",
   "leoUrlRoot": "https://leonardo.dsde-dev.broadinstitute.org",

--- a/config/fiab.json
+++ b/config/fiab.json
@@ -10,7 +10,6 @@
   "externalCredsUrlRoot": "https://externalcreds.dsde-dev.broadinstitute.org",
   "firecloudBucketRoot": "https://storage.googleapis.com/firecloud-alerts-dev",
   "firecloudUrlRoot": "https://firecloud-fiab.dsde-dev.broadinstitute.org",
-  "oidcClientId": "500025638838-s2v23ar3spugtd5t2v1vgfa2sp7ppg0d.apps.googleusercontent.com",
   "jobManagerUrlRoot": "https://job-manager.dsde-dev.broadinstitute.org/jobs",
   "leoUrlRoot": "https://leonardo-fiab.dsde-dev.broadinstitute.org:30443",
   "marthaUrlRoot": "https://martha-fiab.dsde-dev.broadinstitute.org:32443",

--- a/config/fiab.json
+++ b/config/fiab.json
@@ -1,7 +1,7 @@
 {
   "agoraUrlRoot": "https://agora-fiab.dsde-dev.broadinstitute.org:20443",
   "bardRoot": "https://terra-bard-dev.appspot.com",
-  "bondUrlRoot": "https://broad-bond-dev.appspot.com",
+  "bondUrlRoot": "https://bond-fiab.dsde-dev.broadinstitute.org:31443",
   "calhounUrlRoot": "https://calhoun.dsde-dev.broadinstitute.org",
   "catalogUrlRoot": "https://catalog.dsde-dev.broadinstitute.org",
   "dataRepoUrlRoot": "https://jade.datarepo-dev.broadinstitute.org",

--- a/config/perf.json
+++ b/config/perf.json
@@ -10,7 +10,6 @@
   "externalCredsUrlRoot": "https://externalcreds.dsde-perf.broadinstitute.org",
   "firecloudBucketRoot": "https://storage.googleapis.com/firecloud-alerts-perf",
   "firecloudUrlRoot": "https://firecloud.dsde-perf.broadinstitute.org",
-  "oidcClientId": "1007916553388-94ubmcv4nrg23758of2n826me1th59m1.apps.googleusercontent.com",
   "isProd": true,
   "jobManagerUrlRoot": "https://job-manager.dsde-perf.broadinstitute.org/jobs",
   "leoUrlRoot": "https://leonardo.dsde-perf.broadinstitute.org",

--- a/config/prod.json
+++ b/config/prod.json
@@ -8,7 +8,6 @@
   "dockstoreUrlRoot": "https://dockstore.org",
   "firecloudBucketRoot": "https://storage.googleapis.com/firecloud-alerts",
   "firecloudUrlRoot": "https://portal.firecloud.org",
-  "oidcClientId": "424501080111-b3bt4p1vo4gbo4m0573nvi4d49784bp8.apps.googleusercontent.com",
   "isProd": true,
   "jobManagerUrlRoot": "https://job-manager.dsde-prod.broadinstitute.org/jobs",
   "leoUrlRoot": "https://notebooks.firecloud.org",

--- a/config/staging.json
+++ b/config/staging.json
@@ -9,7 +9,6 @@
   "dockstoreUrlRoot": "https://staging.dockstore.org",
   "firecloudBucketRoot": "https://storage.googleapis.com/firecloud-alerts-staging",
   "firecloudUrlRoot": "https://firecloud.dsde-staging.broadinstitute.org",
-  "oidcClientId": "480750596605-ljlp6lpopl4su6qa2vhtfon2047ckml3.apps.googleusercontent.com",
   "isProd": true,
   "jobManagerUrlRoot": "https://job-manager.dsde-staging.broadinstitute.org/jobs",
   "leoUrlRoot": "https://leonardo.dsde-staging.broadinstitute.org",

--- a/src/appLoader.js
+++ b/src/appLoader.js
@@ -4,7 +4,7 @@ import _ from 'lodash/fp'
 import ReactDOM from 'react-dom'
 import { h } from 'react-hyperscript-helpers'
 import RModal from 'react-modal'
-import { initializeAuth } from 'src/libs/auth'
+import { initializeAuth, initializeClientId } from 'src/libs/auth'
 import { initializeTCell } from 'src/libs/tcell'
 import Main from 'src/pages/Main'
 
@@ -17,6 +17,8 @@ window.SATURN_VERSION = process.env.REACT_APP_VERSION
 
 window._ = _
 
-ReactDOM.render(h(Main), appRoot)
-initializeAuth()
-initializeTCell()
+initializeClientId().then(() => {
+  ReactDOM.render(h(Main), appRoot)
+  initializeAuth()
+  initializeTCell()
+})

--- a/src/components/icons.js
+++ b/src/components/icons.js
@@ -60,14 +60,20 @@ export const centeredSpinner = ({ size = 48, ...props } = {}) => spinner(_.merge
   }
 }, props))
 
-export const profilePic = ({ size, style, ...props } = {}) => img({
-  alt: 'Google profile image',
-  src: getUser().imageUrl,
-  height: size, width: size,
-  style: { borderRadius: '100%', ...style },
-  referrerPolicy: 'no-referrer',
-  ...props
-})
+export const profilePic = ({ size, style, ...props } = {}) => {
+  // Note Azure logins don't currently have an imageUrl.
+  // For now, don't render anything. In the future, investigate auto-generating a
+  // picture in the UI or adding this capability to B2C.
+  const imageUrl = getUser().imageUrl
+  return imageUrl && img({
+    alt: 'Google profile image',
+    src: imageUrl,
+    height: size, width: size,
+    style: { borderRadius: '100%', ...style },
+    referrerPolicy: 'no-referrer',
+    ...props
+  })
+}
 
 export const wdlIcon = ({ style = {}, ...props } = {}) => div({
   style: {

--- a/src/components/icons.js
+++ b/src/components/icons.js
@@ -61,9 +61,8 @@ export const centeredSpinner = ({ size = 48, ...props } = {}) => spinner(_.merge
 }, props))
 
 export const profilePic = ({ size, style, ...props } = {}) => {
-  // Note Azure logins don't currently have an imageUrl.
-  // For now, don't render anything. In the future, investigate auto-generating a
-  // picture in the UI or adding this capability to B2C.
+  // Note Azure logins don't currently have an imageUrl, so don't render anything.
+  // See TOAZ-147 to support this in the future.
   const imageUrl = getUser().imageUrl
   return imageUrl && img({
     alt: 'Google profile image',

--- a/src/index.js
+++ b/src/index.js
@@ -10,4 +10,6 @@ const loadApp = async () => {
   import('src/appLoader')
 }
 
-loadApp()
+const loadOauthRedirect = () => import('src/oauthRedirectLoader')
+
+window.location.pathname.startsWith('/redirect-from-oauth') ? loadOauthRedirect() : loadApp()

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1740,6 +1740,13 @@ const Metrics = signal => ({
   })
 })
 
+const OAuth2 = signal => ({
+  getConfiguration: async () => {
+    const res = await fetchOrchestration(`/oauth2/configuration`, _.merge(authOpts(), { signal }))
+    return res.json()
+  }
+})
+
 export const Ajax = signal => {
   return {
     User: User(signal),
@@ -1759,7 +1766,8 @@ export const Ajax = signal => {
     Metrics: Metrics(signal),
     Disks: Disks(signal),
     CromIAM: CromIAM(signal),
-    FirecloudBucket: FirecloudBucket(signal)
+    FirecloudBucket: FirecloudBucket(signal),
+    OAuth2: OAuth2(signal)
   }
 }
 

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -40,7 +40,7 @@ export const getOidcConfig = () => {
 }
 
 const isB2C = () => {
-  return !authStore.get().oidcConfig.authorityEndpoint === 'https://accounts.google.com'
+  return authStore.get().oidcConfig.authorityEndpoint !== 'https://accounts.google.com'
 }
 
 const getAuthInstance = () => {

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -95,7 +95,7 @@ export const hasBillingScope = () => {
   // For now B2C always requests the cloud-billing scope from the get-go, so assume the scope is present.
   // Note this is safe to do for Azure login through B2C as well.
   //
-  // TOAZ-XYZ is open to create a separate B2C policy with the sensitive scope, at which point this logic
+  // TOAZ-146 is open to create a separate B2C policy with the sensitive scope, at which point this logic
   // should be updated.
   return isB2C() || _.includes('https://www.googleapis.com/auth/cloud-billing', scope)
 }

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -87,7 +87,13 @@ export const handleSilentRenewError = error => {
 
 export const hasBillingScope = () => {
   const scope = getUser().scope
-  return scope && scope.includes('https://www.googleapis.com/auth/cloud-billing')
+
+  // For now B2C always requests the cloud-billing scope from the get-go, so assume the scope is present.
+  // Note this is safe to do for Azure login through B2C as well.
+  //
+  // TOAZ-XYZ is open to create a separate B2C policy with the sensitive scope, at which point this logic
+  // should be updated.
+  return isUserSignedIntoB2C() || _.includes('https://www.googleapis.com/auth/cloud-billing', scope)
 }
 
 /*
@@ -140,6 +146,10 @@ export const ensureAuthSettled = () => {
 
 export const getUser = () => {
   return authStore.get().user
+}
+
+const isUserSignedIntoB2C = () => {
+  return _.includes(getConfig().oidcClientId, getUser.scope)
 }
 
 export const bucketBrowserUrl = id => {

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -40,7 +40,7 @@ export const getOidcConfig = () => {
 }
 
 const isB2C = () => {
-  return authStore.get().oidcConfig.authorityEndpoint !== 'https://accounts.google.com'
+  return _.includes('b2clogin.com', authStore.get().oidcConfig.authorityEndpoint)
 }
 
 const getAuthInstance = () => {
@@ -92,11 +92,9 @@ export const handleSilentRenewError = error => {
 export const hasBillingScope = () => {
   const scope = getUser().scope
 
-  // For now B2C always requests the cloud-billing scope from the get-go, so assume the scope is present.
-  // Note this is safe to do for Azure login through B2C as well.
-  //
-  // TOAZ-146 is open to create a separate B2C policy with the sensitive scope, at which point this logic
-  // should be updated.
+  // For now B2C always requests the cloud-billing scope from the get-go.
+  // TOAZ-146 is open to create a separate B2C policy with the sensitive scope
+  // which can be elevated on demand.
   return isB2C() || _.includes('https://www.googleapis.com/auth/cloud-billing', scope)
 }
 

--- a/src/libs/state.js
+++ b/src/libs/state.js
@@ -13,7 +13,8 @@ export const authStore = Utils.atom({
   profile: {},
   fenceStatus: {},
   cookiesAccepted: undefined,
-  authContext: undefined
+  authContext: undefined,
+  oidcConfig: {}
 })
 
 export const userStatus = {

--- a/src/oauthRedirectLoader.js
+++ b/src/oauthRedirectLoader.js
@@ -1,0 +1,8 @@
+import ReactDOM from 'react-dom'
+import { h } from 'react-hyperscript-helpers'
+import RedirectFromOAuth from 'src/pages/RedirectFromOAuth'
+
+
+const appRoot = document.getElementById('root')
+
+ReactDOM.render(h(RedirectFromOAuth), appRoot)

--- a/src/pages/RedirectFromOAuth.js
+++ b/src/pages/RedirectFromOAuth.js
@@ -1,16 +1,31 @@
 import { UserManager } from 'oidc-client-ts'
-import { div, h } from 'react-hyperscript-helpers'
-import { centeredSpinner } from 'src/components/icons'
-import { getOidcConfig } from 'src/libs/auth'
+import { div, img } from 'react-hyperscript-helpers'
 import { useOnMount } from 'src/libs/react-utils'
 
 
-const RedirectFromOAuth = silent => {
-  const userManager = new UserManager(getOidcConfig())
+const RedirectFromOAuth = (silent = false) => {
+  const userManager = new UserManager({
+    popup_redirect_uri: `${window.origin}/redirect-from-oauth`,
+    silent_redirect_uri: `${window.origin}/redirect-from-oauth-silent`
+  })
   const url = window.location.href.replace('#', '')
   useOnMount(() => silent === true ? userManager.signinSilentCallback(url) : userManager.signinPopupCallback(url))
-  return div({ role: 'main' }, [
-    h(centeredSpinner, { style: { position: 'fixed' } })
+
+  const spinnerSize = 54
+  return div({ role: 'main', style: { position: 'absolute', top: 0, left: 0, height: '100%', width: '100%' } }, [
+    img({
+      src: 'loading-spinner.svg',
+      style: {
+        width: spinnerSize,
+        height: spinnerSize,
+        display: 'block',
+        position: 'sticky',
+        top: `calc(50% - ${spinnerSize / 2}px)`,
+        bottom: `calc(50% - ${spinnerSize / 2}px)`,
+        left: `calc(50% - ${spinnerSize / 2}px)`,
+        right: `calc(50% - ${spinnerSize / 2}px)`
+      }
+    })
   ])
 }
 
@@ -30,3 +45,5 @@ export const navPaths = [
     title: 'Redirect From OAuth'
   }
 ]
+
+export default RedirectFromOAuth


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/TOAZ-129

1. Fix billing scope elevation for the B2C case. No change in behavior for the Google case.

2. For now Azure logins through B2C don't have a profile picture, so don't render a broken link. There's a ticket to address this better.

3. Make Terra UI source the `oidcClientId` from the backend (Orch), and move it out of UI config. We were already using the backend to redirect to the appropriate authority endpoint (see context [here](https://docs.google.com/document/d/1Z2AlIsg2InYJhSC4jssIXTWnh1mmpUw6qMKxx6vPnH8/edit)). This put us in an awkward situation where it would have required a coupled UI+backend release to update the client+authority. Now, we can control B2C vs Google in backend conf.

4. Fix the `/redirect-from-oauth` to not render the full app in the pop-up and not make any backend calls.