### PR TITLE
[QA-1871] Terra-UI google-workspace integration test error: Node is either not clickable or not an HTMLElement

### DIFF
--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -198,7 +198,11 @@ const enableDataCatalog = async (page, testUrl, token) => {
 }
 
 const clickNavChildAndLoad = async (page, tab) => {
-  await noSpinnersAfter(page, { action: () => click(page, navChild(tab)) })
+  // click triggers a page navigation event
+  await Promise.all([
+    page.waitForNavigation(waitUntilLoadedOrTimeout()),
+    noSpinnersAfter(page, { action: () => click(page, navChild(tab)) })
+  ])
 }
 
 const viewWorkspaceDashboard = async (page, token, workspaceName) => {

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -103,7 +103,7 @@ const clickTableCell = async (page, { tableName, columnHeader, textContains, isD
   return (await page.waitForXPath(xpath, options)).click()
 }
 
-const click = async (page, xpath, options) => {
+const click = async (page, xpath, options = { visible: true }) => {
   return (await page.waitForXPath(xpath, options)).click()
 }
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/QA-1871

`google-workspace` test failed in this CircleCi [job](https://app.circleci.com/pipelines/github/DataBiosphere/terra-ui/9569/workflows/4a31f6b5-672e-441e-ab54-f666a4c3a0d4/jobs/42706).

Fixes:

- Set option `visible: true` as default for `waitForXPath` in `click` function. Plainly, an element should be visible before click.
- `clickNavChildAndLoad` function is flaky. Update the function to wait for navigation after click tab.