### PR TITLE
[QA-1872] Terra-UI analysis-context-bar integration test: increase test timeout to 15 min

### DIFF
--- a/integration-tests/tests/analysis-context-bar.js
+++ b/integration-tests/tests/analysis-context-bar.js
@@ -32,7 +32,7 @@ const testAnalysisContextBarFn = _.flow(
   await click(page, clickable({ textContains: 'Close' }))
 
   // Environment should eventually be running and the terminal icon should be enabled once the environment is running
-  await findElement(page, clickable({ textContains: 'Jupyter Environment ( Running )' }), { timeout: 10 * 60000 })
+  await findElement(page, clickable({ textContains: 'Jupyter Environment ( Running )' }), { timeout: 10 * 60 * 1000 })
   await findElement(page, clickable({ textContains: 'Terminal' }))
 
   // The environment should now be pausable, and the UI should display its pausing
@@ -48,7 +48,8 @@ const testAnalysisContextBarFn = _.flow(
 
 const testAnalysisContextBar = {
   name: 'analysis-context-bar',
-  fn: testAnalysisContextBarFn
+  fn: testAnalysisContextBarFn,
+  timeout: 15 * 60 * 1000
 }
 
 module.exports = { testAnalysisContextBar }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/QA-1872

Fix an issue that cause `analysis-context-bar` test flaky.

<img width="1225" alt="Screen Shot 2022-05-16 at 8 55 09 PM" src="https://user-images.githubusercontent.com/35533885/168705776-c9893be3-fc8e-4219-9aef-2d607c590e95.png">

