### PR TITLE
[TOAZ-15 follow up] Prevent displaying error messages for sign out requests

### DIFF
--- a/src/components/AuthStoreSetter.js
+++ b/src/components/AuthStoreSetter.js
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp'
 import { useEffect } from 'react'
 import { useAuth } from 'react-oidc-context'
-import { processUser, reloadAuthToken } from 'src/libs/auth'
+import { handleSilentRenewError, processUser } from 'src/libs/auth'
 import { useOnMount } from 'src/libs/react-utils'
 import { authStore } from 'src/libs/state'
 
@@ -10,12 +10,11 @@ const AuthStoreSetter = () => {
   const auth = useAuth()
 
   useOnMount(() => authStore.update(_.set(['authContext'], auth)))
-
   useEffect(() => {
     const cleanupFns = [
-      auth.events.addAccessTokenExpiring(reloadAuthToken),
-      auth.events.addUserLoaded(processUser),
-      auth.events.addUserUnloaded(processUser)
+      auth.events.addUserLoaded(user => processUser(user, true)),
+      auth.events.addUserUnloaded(user => processUser(user, false)),
+      auth.events.addSilentRenewError(handleSilentRenewError)
     ]
     return _.over(cleanupFns)
   }, [auth])

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -33,7 +33,8 @@ export const getOidcConfig = () => {
       token_endpoint: `${getConfig().orchestrationUrlRoot}/oauth2/token`
     },
     userStore: new WebStorageStateStore({ store: window.localStorage }),
-    accessTokenExpiringNotificationTimeInSeconds: 120,
+    accessTokenExpiringNotificationTimeInSeconds: 300,
+    automaticSilentRenew: true,
     includeIdTokenInSilentRenew: true
   }
 }
@@ -69,6 +70,18 @@ export const signIn = (includeBillingScope = false) => {
 export const reloadAuthToken = (includeBillingScope = false) => {
   const args = getSigninArgs(includeBillingScope)
   return getAuthInstance().signinSilent(args).catch(() => false)
+}
+
+export const handleSilentRenewError = error => {
+  if (error.name !== 'ErrorResponse') {
+    setTimeout(() => {
+      const auth = getAuthInstance()
+      if (auth.user && !auth.user.expired) {
+        auth.stopSilentRenew()
+        auth.startSilentRenew()
+      }
+    }, 5 * 1000)
+  }
 }
 
 export const hasBillingScope = () => {
@@ -132,14 +145,14 @@ export const bucketBrowserUrl = id => {
   return `https://console.cloud.google.com/storage/browser/${id}?authuser=${getUser().email}`
 }
 
-export const processUser = user => {
+export const processUser = (user, isSignIn) => {
   return authStore.update(state => {
     const isSignedIn = !_.isNil(user)
     const profile = user?.profile
     const userId = profile?.sub
 
     // The following few lines of code are to handle sign-in failures due to privacy tools.
-    if (state.isSignedIn === false && isSignedIn === false) {
+    if (isSignIn === true && state.isSignedIn === false && isSignedIn === false) {
       //if both of these values are false, it means that the user was initially not signed in (state.isSignedIn === false),
       //tried to sign in (invoking processUser) and was still not signed in (isSignedIn === false).
       notify('error', 'Could not sign in', {

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -145,14 +145,14 @@ export const bucketBrowserUrl = id => {
   return `https://console.cloud.google.com/storage/browser/${id}?authuser=${getUser().email}`
 }
 
-export const processUser = (user, isSignIn) => {
+export const processUser = (user, isSignInEvent) => {
   return authStore.update(state => {
     const isSignedIn = !_.isNil(user)
     const profile = user?.profile
     const userId = profile?.sub
 
     // The following few lines of code are to handle sign-in failures due to privacy tools.
-    if (isSignIn === true && state.isSignedIn === false && isSignedIn === false) {
+    if (isSignInEvent === true && state.isSignedIn === false && isSignedIn === false) {
       //if both of these values are false, it means that the user was initially not signed in (state.isSignedIn === false),
       //tried to sign in (invoking processUser) and was still not signed in (isSignedIn === false).
       notify('error', 'Could not sign in', {


### PR DESCRIPTION
Before when the access token expired we would see errors:
![image](https://user-images.githubusercontent.com/5368863/168885726-5c52ee08-21c4-4678-914d-dc2baf3e99dd.png)

Now the errors don't popup when this happens. Also make silent refresh a little more robust hopefully.

Testing by logging in waiting:
- If computer is on my access token gets refreshed silently 5m before expiration
- If computer goes to sleep, my access token can expire.
   * It's hard to reproduce though -- e.g. silent refresh still worked for me with a closed laptop
   * In that case I see "session timed out" with no additional errors:
   <img width="1744" alt="image" src="https://user-images.githubusercontent.com/5368863/168828355-29557e4d-0b6b-4989-b8ed-3d777aaa819a.png">
   * Looking into how we can handle going to sleep better (https://github.com/authts/oidc-client-ts/issues/251). Any ideas from reviewers?

<!--
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Also, so if a screen recording [1] and/or screenshots would be a helpful way to communicate context, please consider including some in your PR description.
Thanks!

[1] https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac
--!>
