### PR TITLE
[SUP-655] Handle requester pays errors from getting bucket location workspace dashboard

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -62,6 +62,14 @@ const withRetryOnError = _.curry(wrappedFetch => async (...args) => {
     try {
       return await Utils.withDelay(until, wrappedFetch)(...args)
     } catch (error) {
+      // requesterPaysError may be set on responses from requests to the GCS API that are wrapped in withRequesterPays.
+      // requesterPaysError is true if the request requires a user project for billing the request to. Such errors
+      // are not transient and the request should not be retried.
+      const shouldRetry = !error.requesterPaysError
+
+      if (!shouldRetry) {
+        throw error
+      }
       // ignore error will retry
     }
   }

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -1,14 +1,15 @@
 import _ from 'lodash/fp'
-import { Fragment, useEffect, useImperativeHandle, useState } from 'react'
+import { Fragment, useCallback, useEffect, useImperativeHandle, useState } from 'react'
 import { dd, div, dl, dt, h, h3, i, span } from 'react-hyperscript-helpers'
 import * as breadcrumbs from 'src/components/breadcrumbs'
-import { requesterPaysWrapper, withRequesterPaysHandler } from 'src/components/bucket-utils'
+import { requesterPaysWrapper } from 'src/components/bucket-utils'
 import Collapse from 'src/components/Collapse'
 import { ButtonPrimary, ButtonSecondary, ClipboardButton, Link, spinnerOverlay } from 'src/components/common'
 import { centeredSpinner, icon, spinner } from 'src/components/icons'
 import { MarkdownEditor, MarkdownViewer } from 'src/components/markdown'
 import { InfoBox } from 'src/components/PopupTrigger'
 import { getRegionInfo } from 'src/components/region-common'
+import RequesterPaysModal from 'src/components/RequesterPaysModal'
 import { SimpleTable, TooltipCell } from 'src/components/table'
 import TooltipTrigger from 'src/components/TooltipTrigger'
 import { WorkspaceTagSelect } from 'src/components/workspace-utils'
@@ -23,7 +24,7 @@ import { getAppName } from 'src/libs/logos'
 import * as Nav from 'src/libs/nav'
 import { getLocalPref, setLocalPref } from 'src/libs/prefs'
 import { forwardRefWithName, useCancellation, useOnMount, useStore } from 'src/libs/react-utils'
-import { authStore } from 'src/libs/state'
+import { authStore, requesterPaysProjectStore } from 'src/libs/state'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 import SignIn from 'src/pages/SignIn'
@@ -122,9 +123,71 @@ const RightBoxSection = ({ title, info, initialOpenState, onClick, children }) =
   ])
 }
 
+const BucketLocation = requesterPaysWrapper({ onDismiss: _.noop })(({ workspace }) => {
+  const isGoogleWorkspace = !!workspace?.workspace?.googleProject
+
+  const [loading, setLoading] = useState(true)
+  const [{ location, locationType }, setBucketLocation] = useState({ location: undefined, locationType: undefined })
+  const [needsRequesterPaysProject, setNeedsRequesterPaysProject] = useState(false)
+  const [showRequesterPaysModal, setShowRequesterPaysModal] = useState(false)
+
+  const signal = useCancellation()
+  const loadBucketLocation = useCallback(async () => {
+    setLoading(true)
+    try {
+      const { namespace, name, workspace: { googleProject, bucketName } } = workspace
+      const response = await Ajax(signal).Workspaces.workspace(namespace, name).checkBucketLocation(googleProject, bucketName)
+      setBucketLocation(response)
+    } catch (error) {
+      if (error.requesterPaysError) {
+        setNeedsRequesterPaysProject(true)
+      } else {
+        reportError('Unable to get bucket location.', error)
+      }
+    } finally {
+      setLoading(false)
+    }
+  }, [workspace, signal])
+
+  useEffect(() => {
+    if (isGoogleWorkspace) {
+      loadBucketLocation()
+    }
+  }, [isGoogleWorkspace, loadBucketLocation])
+
+  if (!isGoogleWorkspace) {
+    return null
+  }
+
+  if (loading) {
+    return 'Loading'
+  }
+
+  if (!location) {
+    return h(Fragment, [
+      'Unknown',
+      needsRequesterPaysProject && h(ButtonSecondary, {
+        tooltip: 'This workspace\'s bucket is requester pays. Click to choose a workspace to bill requests to and get the bucket\'s location.',
+        style: { height: '1rem', marginLeft: '1ch' },
+        onClick: () => setShowRequesterPaysModal(true)
+      }, [icon('sync')]),
+      showRequesterPaysModal && h(RequesterPaysModal, {
+        onDismiss: () => setShowRequesterPaysModal(false),
+        onSuccess: selectedGoogleProject => {
+          requesterPaysProjectStore.set(selectedGoogleProject)
+          setShowRequesterPaysModal(false)
+          loadBucketLocation()
+        }
+      })
+    ])
+  }
+
+  const { flag, regionDescription } = getRegionInfo(location, locationType)
+  return h(TooltipCell, [flag, ' ', regionDescription])
+})
+
 const WorkspaceDashboard = _.flow(
   forwardRefWithName('WorkspaceDashboard'),
-  requesterPaysWrapper({ onDismiss: () => Nav.history.goBack() }),
   wrapWorkspace({
     breadcrumbs: () => breadcrumbs.commonPaths.workspaceList(),
     activeTab: 'dashboard'
@@ -140,8 +203,7 @@ const WorkspaceDashboard = _.flow(
       authorizationDomain, createdDate, lastModified, bucketName, googleProject,
       attributes, attributes: { description = '' }
     }
-  },
-  onRequesterPaysError
+  }
 }, ref) => {
   // State
   const [submissionsCount, setSubmissionsCount] = useState(undefined)
@@ -152,8 +214,6 @@ const WorkspaceDashboard = _.flow(
   const [busy, setBusy] = useState(false)
   const [consentStatus, setConsentStatus] = useState(undefined)
   const [tagsList, setTagsList] = useState(undefined)
-  const [bucketLocation, setBucketLocation] = useState(undefined)
-  const [bucketLocationType, setBucketLocationType] = useState(undefined)
 
   const persistenceId = `workspaces/${namespace}/${name}/dashboard`
 
@@ -165,7 +225,6 @@ const WorkspaceDashboard = _.flow(
     loadWsTags()
     if (!azureContext) {
       loadStorageCost()
-      loadBucketLocation()
       loadBucketSize()
     }
   }
@@ -200,15 +259,6 @@ const WorkspaceDashboard = _.flow(
       const { usageInBytes, lastUpdated } = await Ajax(signal).Workspaces.workspace(namespace, name).bucketUsage()
       setBucketSize({ usage: Utils.formatBytes(usageInBytes), lastUpdated })
     }
-  })
-
-  const loadBucketLocation = _.flow(
-    withRequesterPaysHandler(onRequesterPaysError),
-    withErrorReporting('Error loading bucket location data')
-  )(async () => {
-    const { location, locationType } = await Ajax(signal).Workspaces.workspace(namespace, name).checkBucketLocation(googleProject, bucketName)
-    setBucketLocation(location)
-    setBucketLocationType(locationType)
   })
 
   const loadConsent = withErrorReporting('Error loading data', async () => {
@@ -273,9 +323,7 @@ const WorkspaceDashboard = _.flow(
         h(InfoRow, { title: 'Cloud Name' }, [
           h(GcpLogo, { title: 'Google Cloud Platform', role: 'img', style: { height: 16 } })
         ]),
-        h(InfoRow, { title: 'Location' }, [bucketLocation ? h(Fragment, [
-          h(TooltipCell, [flag, ' ', regionDescription])
-        ]) : 'Loading...']),
+        h(InfoRow, { title: 'Location' }, [h(BucketLocation, { workspace })]),
         h(InfoRow, { title: 'Google Project ID' }, [
           h(TooltipCell, [googleProject]),
           h(ClipboardButton, { 'aria-label': 'Copy google project id to clipboard', text: googleProject, style: { marginLeft: '0.25rem' } })
@@ -312,7 +360,6 @@ const WorkspaceDashboard = _.flow(
 
   // Render
   const isEditing = _.isString(editDescription)
-  const { flag, regionDescription } = getRegionInfo(bucketLocation, bucketLocationType)
 
   return div({ style: { flex: 1, display: 'flex' } }, [
     div({ style: Style.dashboard.leftBox }, [

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -125,6 +125,7 @@ const RightBoxSection = ({ title, info, initialOpenState, onClick, children }) =
 
 const BucketLocation = requesterPaysWrapper({ onDismiss: _.noop })(({ workspace }) => {
   const isGoogleWorkspace = !!workspace?.workspace?.googleProject
+  console.assert(isGoogleWorkspace, 'BucketLocation expects a Google workspace')
 
   const [loading, setLoading] = useState(true)
   const [{ location, locationType }, setBucketLocation] = useState({ location: undefined, locationType: undefined })
@@ -150,14 +151,8 @@ const BucketLocation = requesterPaysWrapper({ onDismiss: _.noop })(({ workspace 
   }, [workspace, signal])
 
   useEffect(() => {
-    if (isGoogleWorkspace) {
-      loadBucketLocation()
-    }
-  }, [isGoogleWorkspace, loadBucketLocation])
-
-  if (!isGoogleWorkspace) {
-    return null
-  }
+    loadBucketLocation()
+  }, [loadBucketLocation])
 
   if (loading) {
     return 'Loading'

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -162,6 +162,7 @@ const BucketLocation = requesterPaysWrapper({ onDismiss: _.noop })(({ workspace 
     return h(Fragment, [
       'Unknown',
       needsRequesterPaysProject && h(ButtonSecondary, {
+        'aria-label': 'Load bucket location',
         tooltip: 'This workspace\'s bucket is requester pays. Click to choose a workspace to bill requests to and get the bucket\'s location.',
         style: { height: '1rem', marginLeft: '1ch' },
         onClick: () => setShowRequesterPaysModal(true)


### PR DESCRIPTION
The workspace dashboard makes a request to the GCS API to get the location of the workspace's bucket. For workspaces with a requester pays bucket where the user only has reader access to the workspace, this requires selecting a workspace to bill the request to. This is most likely to occur with public/featured workspaces.

Currently, when viewing the dashboard for such a workspace, a modal pops up prompting for a workspace to bill to. This presents a barrier to browsing information about public/featured workspaces. The user may not care about the bucket location, but clicking cancel in the modal navigates back, preventing them from viewing any information about the workspace. In some cases, a user may not even have a workspace they could select to bill requests to. 

https://user-images.githubusercontent.com/1156625/168826639-d2e5dafe-17b0-42e6-a6d1-e2003d8e5c0c.mov

With this change, if the request for bucket location fails because of a requester pays error, the bucket location will show as "Unknown" and a button will be shown that prompts the user to choose a workspace to bill to and load the bucket location. Dismissing the modal will stay on the workspace dashboard page and leave the bucket location as "Unknown".

https://user-images.githubusercontent.com/1156625/168828064-9ed164de-71a0-4dad-99d9-9329e1a30c9e.mov



