### PR TITLE
[SUP-674] Point at a live page

### DIFF
--- a/src/components/workspace-utils.js
+++ b/src/components/workspace-utils.js
@@ -351,7 +351,7 @@ export const NoWorkspacesMessage = ({ onClick }) => {
     div({ style: { marginTop: '1rem', fontSize: 16 } }, [
       h(Link, {
         ...Utils.newTabLinkProps,
-        href: `https://support.terra.bio/hc/en-us/articles/360022716811`
+        href: `https://support.terra.bio/hc/en-us/articles/360024743371`
       }, [`What's a workspace?`])
     ])
   ])

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -656,7 +656,7 @@ const CromIAM = signal => ({
 const Workspaces = signal => ({
   list: async fields => {
     const res = await fetchRawls(`workspaces?${qs.stringify({ fields }, { arrayFormat: 'comma' })}`, _.merge(authOpts(), { signal }))
-    return []; // res.json()
+    return res.json()
   },
 
   create: async body => {

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -656,7 +656,7 @@ const CromIAM = signal => ({
 const Workspaces = signal => ({
   list: async fields => {
     const res = await fetchRawls(`workspaces?${qs.stringify({ fields }, { arrayFormat: 'comma' })}`, _.merge(authOpts(), { signal }))
-    return res.json()
+    return []; // res.json()
   },
 
   create: async body => {


### PR DESCRIPTION
[Relevant ticket](https://broadworkbench.atlassian.net/browse/SUP-674)
The "What's a workspace?" link that displays when a user has no workspaces points at a dead page. This PR updates the link to a [live page](https://support.terra.bio/hc/en-us/articles/360024743371).

**Testing:**
I hardcoded the workspaces list ajax [function](https://github.com/DataBiosphere/terra-ui/blob/7aea4d71421d4ab4d31c999fe4ba0ae1a27b7cb8/src/libs/ajax.js#L657) to return an empty list and verified that the rendered link pointed at the desired page. 

