### PR TITLE
[DC-342] Add writer and add to-lower to role definitions

### DIFF
--- a/src/pages/library/dataBrowser-utils.js
+++ b/src/pages/library/dataBrowser-utils.js
@@ -80,7 +80,7 @@ const normalizeDataset = dataset => {
     dataReleasePolicy,
     contacts, curators, contributorNames,
     dataType, dataModality,
-    access: _.intersection(dataset.roles, ['reader', 'owner']).length > 0 ? datasetAccessTypes.GRANTED : datasetAccessTypes.CONTROLLED
+    access: _.intersection(_.map(role => _.toLower(role), dataset.roles), ['reader', 'writer', 'owner']).length > 0 ? datasetAccessTypes.GRANTED : datasetAccessTypes.CONTROLLED
   }
 }
 

--- a/src/pages/library/dataBrowser-utils.js
+++ b/src/pages/library/dataBrowser-utils.js
@@ -80,7 +80,7 @@ const normalizeDataset = dataset => {
     dataReleasePolicy,
     contacts, curators, contributorNames,
     dataType, dataModality,
-    access: _.intersection(_.map(role => _.toLower(role), dataset.roles), ['reader', 'writer', 'owner']).length > 0 ? datasetAccessTypes.GRANTED : datasetAccessTypes.CONTROLLED
+    access: _.intersection(_.map(role => _.toLower(role), dataset.roles), ['reader', 'owner']).length > 0 ? datasetAccessTypes.GRANTED : datasetAccessTypes.CONTROLLED
   }
 }
 

--- a/src/pages/library/dataBrowser-utils.js
+++ b/src/pages/library/dataBrowser-utils.js
@@ -80,7 +80,7 @@ const normalizeDataset = dataset => {
     dataReleasePolicy,
     contacts, curators, contributorNames,
     dataType, dataModality,
-    access: _.intersection(_.map(role => _.toLower(role), dataset.roles), ['reader', 'writer', 'owner']).length > 0 ? datasetAccessTypes.GRANTED : datasetAccessTypes.CONTROLLED
+    access: _.intersection(_.map(_.toLower, dataset.roles), ['reader', 'writer', 'owner']).length > 0 ? datasetAccessTypes.GRANTED : datasetAccessTypes.CONTROLLED
   }
 }
 


### PR DESCRIPTION
This is in preparation for role changes being done to the catalog. toLower is included in order for us to match both the old definitions and the new ones, and `writer` is added to our list in order to give a more granular approach to role permissioning.
