### PR TITLE
[SU-100] Restore style of data table in workflow data selection

### DIFF
--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -58,7 +58,9 @@ const DataTable = props => {
     editable,
     persist, refreshKey, firstRender,
     snapshotName,
-    deleteColumnUpdateMetadata
+    deleteColumnUpdateMetadata,
+    headerStyle,
+    border = true
   } = props
 
   const persistenceId = `${namespace}/${name}/${entityType}`
@@ -231,8 +233,7 @@ const DataTable = props => {
         style: {
           display: 'flex',
           padding: '1rem',
-          background: isDataTabRedesignEnabled() ? colors.light() : undefined,
-          borderBottom: isDataTabRedesignEnabled() ? `1px solid ${colors.grey(0.4)}` : undefined
+          ...headerStyle
         }
       }, [
         childrenBefore && childrenBefore({ entities, columnSettings, showColumnSettingsModal }),
@@ -372,7 +373,7 @@ const DataTable = props => {
               styleCell: ({ rowIndex }) => {
                 return rowIndex % 2 && { backgroundColor: colors.light(0.2) }
               },
-              border: !isDataTabRedesignEnabled()
+              border
             })
           }
         ])

--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -59,7 +59,7 @@ const DataTable = props => {
     persist, refreshKey, firstRender,
     snapshotName,
     deleteColumnUpdateMetadata,
-    headerStyle,
+    controlPanelStyle,
     border = true
   } = props
 
@@ -233,7 +233,7 @@ const DataTable = props => {
         style: {
           display: 'flex',
           padding: '1rem',
-          ...headerStyle
+          ...controlPanelStyle
         }
       }, [
         childrenBefore && childrenBefore({ entities, columnSettings, showColumnSettingsModal }),

--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -498,7 +498,12 @@ const EntitiesContent = ({
             }, [`${selectedLength} row${selectedLength === 1 ? '' : 's'} selected`]),
             renderSelectedRowsMenu(columnSettings)
           ]),
-        deleteColumnUpdateMetadata
+        deleteColumnUpdateMetadata,
+        headerStyle: isDataTabRedesignEnabled() ? {
+          background: colors.light(),
+          borderBottom: `1px solid ${colors.grey(0.4)}`
+        } : {},
+        border: !isDataTabRedesignEnabled()
       }),
       addingEntity && h(AddEntityModal, {
         entityType: entityKey,

--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -499,7 +499,7 @@ const EntitiesContent = ({
             renderSelectedRowsMenu(columnSettings)
           ]),
         deleteColumnUpdateMetadata,
-        headerStyle: isDataTabRedesignEnabled() ? {
+        controlPanelStyle: isDataTabRedesignEnabled() ? {
           background: colors.light(),
           borderBottom: `1px solid ${colors.grey(0.4)}`
         } : {},


### PR DESCRIPTION
Fixup for #3033. The data table should only be restyled in the data tab, not when selecting data for a workflow.

To enable the data tab redesign, use `configOverridesStore.set({ isDataTabRedesignEnabled: true })`.

## Before
![Screen Shot 2022-05-17 at 4 15 03 PM](https://user-images.githubusercontent.com/1156625/168902949-811325a4-c3a5-4786-8751-3f9a141cbf47.png)

## After
![Screen Shot 2022-05-17 at 4 13 51 PM](https://user-images.githubusercontent.com/1156625/168902945-c6b602ec-5dc6-4c4d-bb3a-7965956ebcfd.png)

