### PR TITLE
[SU-57] Allowing editing JSON attributes

### DIFF
--- a/src/components/data/_tests/data-utils.test.js
+++ b/src/components/data/_tests/data-utils.test.js
@@ -117,9 +117,10 @@ describe('convertAttributeValue', () => {
     expect(convertAttributeValue({ entityType: 'thing', entityName: 'thing_one' }, 'number')).toEqual(0)
     expect(convertAttributeValue({ entityType: 'thing', entityName: 'thing_one' }, 'boolean')).toEqual(true)
 
-    expect(convertAttributeValue({ key: 'value' }, 'string')).toEqual('{"key":"value"}')
+    expect(convertAttributeValue({ key: 'value' }, 'string')).toEqual('')
     expect(convertAttributeValue({ key: 'value' }, 'number')).toEqual(0)
     expect(convertAttributeValue({ key: 'value' }, 'boolean')).toEqual(true)
+    expect(convertAttributeValue({ key: 'value' }, 'reference', 'thing')).toEqual({ entityType: 'thing', entityName: '' })
     expect(convertAttributeValue({ key: 'value' }, 'json')).toEqual({ key: 'value' })
 
     expect(() => convertAttributeValue('abc', 'notatype')).toThrow('Invalid attribute type "notatype"')

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -609,7 +609,7 @@ const defaultValueForAttributeType = (attributeType, referenceEntityType) => {
   )
 }
 
-const AttributeInput = ({ autoFocus = false, value: attributeValue, onChange, entityTypes = [] }) => {
+const AttributeInput = ({ autoFocus = false, value: attributeValue, onChange, entityTypes = [], showJsonTypeOption = false }) => {
   const { type: attributeType, isList } = getAttributeType(attributeValue)
 
   const renderInput = renderInputForAttributeType(attributeType)
@@ -633,12 +633,28 @@ const AttributeInput = ({ autoFocus = false, value: attributeValue, onChange, en
     }
   }, [attributeValue, isList])
 
+  const typeOptions = [
+    { type: 'string' },
+    { type: 'reference', tooltip: 'A link to another entity' },
+    { type: 'number' },
+    { type: 'boolean' }
+  ]
+
+  if (attributeType === 'json' || showJsonTypeOption) {
+    typeOptions.push({ type: 'json', label: 'JSON' })
+  }
+
   return h(Fragment, [
     div({ style: { marginBottom: '1rem' } }, [
       fieldset({ style: { border: 'none', margin: 0, padding: 0 } }, [
         legend({ style: { marginBottom: '0.5rem' } }, [isList ? 'List item type:' : 'Type:']),
-        div({ style: { columns: 3 } }, _.map(({ label, type, tooltip }) => h(TooltipTrigger, { content: tooltip }, [
-          span({ style: { display: 'inline-block', width: '100%', marginBottom: '0.5rem' } }, [
+        div({
+          style: {
+            display: 'flex', flexFlow: 'row', justifyContent: 'space-between',
+            marginBottom: '0.5rem'
+          }
+        }, _.map(({ label, type, tooltip }) => h(TooltipTrigger, { content: tooltip }, [
+          span({ style: { display: 'inline-block', whiteSpace: 'nowrap' } }, [
             h(RadioButton, {
               text: label || _.startCase(type),
               name: 'edit-type',
@@ -651,13 +667,7 @@ const AttributeInput = ({ autoFocus = false, value: attributeValue, onChange, en
             })
           ])
         ]),
-        [
-          { type: 'string' },
-          { type: 'reference', tooltip: 'A link to another entity' },
-          { type: 'number' },
-          { type: 'boolean' },
-          { type: 'json', label: 'JSON' }
-        ])
+        typeOptions)
         )
       ]),
       attributeType === 'reference' && div({ style: { marginTop: '0.5rem' } }, [
@@ -751,6 +761,7 @@ export const prepareAttributeForUpload = attributeValue => {
 }
 
 export const SingleEntityEditor = ({ entityType, entityName, attributeName, attributeValue, entityTypes, workspaceId: { namespace, name }, onDismiss, onSuccess }) => {
+  const { type: originalValueType } = getAttributeType(attributeValue)
   const [newValue, setNewValue] = useState(attributeValue)
   const isUnchanged = _.isEqual(attributeValue, newValue)
 
@@ -814,7 +825,8 @@ export const SingleEntityEditor = ({ entityType, entityName, attributeName, attr
           autoFocus: true,
           value: newValue,
           onChange: setNewValue,
-          entityTypes
+          entityTypes,
+          showJsonTypeOption: originalValueType === 'json'
         }),
         div({ style: { marginTop: '2rem', display: 'flex', alignItems: 'baseline' } }, [
           h(ButtonOutline, { onClick: () => setConsideringDelete(true) }, ['Delete']),

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -74,7 +74,7 @@ export const renderDataCell = (data, googleProject) => {
 
   const renderArray = items => {
     return _.map(([i, v]) => h(Fragment, { key: i }, [
-      renderCell(v.toString()), i < (items.length - 1) && div({ style: { marginRight: '0.5rem', color: colors.dark(0.85) } }, ',')
+      renderCell(v?.toString()), i < (items.length - 1) && div({ style: { marginRight: '0.5rem', color: colors.dark(0.85) } }, ',')
     ]), Utils.toIndexPairs(items))
   }
 

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -523,7 +523,7 @@ export const convertAttributeValue = (attributeValue, newType, referenceEntityTy
     ['string', () => _.toString],
     ['reference', () => value => ({
       entityType: referenceEntityType,
-      entityName: _.toString(value) // eslint-disable-line lodash-fp/preferred-alias
+      entityName: type === 'json' ? '' : _.toString(value) // eslint-disable-line lodash-fp/preferred-alias
     })],
     ['number', () => value => {
       const numberVal = _.toNumber(value)
@@ -545,7 +545,7 @@ export const convertAttributeValue = (attributeValue, newType, referenceEntityTy
       items: _.map(convertFn, attributeValue),
       itemsType: newType === 'reference' ? 'EntityReference' : 'AttributeValue'
     })],
-    [type === 'json' && newType === 'string', () => JSON.stringify(attributeValue)],
+    [type === 'json' && newType === 'string', () => ''],
     () => convertFn(attributeValue)
   )
 }


### PR DESCRIPTION
In addition to the string, number, boolean, and list types that the UI currently supports, data table cells can contain arbitrary JSON values.

For example, an entity with JSON attributes can be created using Rawl's [create entity endpoint](https://rawls.dsde-dev.broadinstitute.org/#/entities/create_entity).
```
{
  "name": "json-attributes",
  "entityType": "test_entity",
  "attributes": {
    "obj": { "key": "value" },
    "objarray": [{ "key1": "value1" }, { "key2": "value2" }, { "key3": "value3" } ],
    "array": ["one", "two", "three"]
  }
}
```

Currently, there is no way to edit such an attribute in the UI.

https://user-images.githubusercontent.com/1156625/168911260-29733ef6-b31e-41b4-9aa3-ac3c68686631.mov

This adds support for editing JSON attributes using the [react-json-view](https://www.npmjs.com/package/react-json-view) library, which is already used in a few places in Terra. It also adds support for converting attributes to/from JSON when selecting one of the type radio buttons.

https://user-images.githubusercontent.com/1156625/168911404-dcbdc7ca-06a9-4bf5-89b4-e468061945b3.mov


