### PR TITLE
[SU-89] Allow creating a set from the data table UI

### DIFF
--- a/src/components/PopupTrigger.js
+++ b/src/components/PopupTrigger.js
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp'
 import { Children, cloneElement, Fragment, useEffect, useImperativeHandle, useRef, useState } from 'react'
-import { div, h } from 'react-hyperscript-helpers'
+import { div, h, hr } from 'react-hyperscript-helpers'
 import onClickOutside from 'react-onclickoutside'
 import { Clickable, FocusTrapper } from 'src/components/common'
 import { icon } from 'src/components/icons'
@@ -130,6 +130,13 @@ export const MenuButton = forwardRefWithName('MenuButton', ({ disabled, children
       hover: !disabled ? { backgroundColor: colors.light(0.4), color: colors.accent() } : undefined
     }, props), [children])
   ])
+})
+
+export const MenuDivider = () => hr({
+  style: {
+    borderWidth: '0 0 1px', borderStyle: 'solid', borderColor: colors.dark(0.55),
+    margin: '0.25rem 0'
+  }
 })
 
 export const MenuTrigger = ({ children, content, popupProps = {}, ...props }) => {

--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -7,7 +7,7 @@ import { Fragment, useRef, useState } from 'react'
 import { div, form, h, input } from 'react-hyperscript-helpers'
 import { requesterPaysWrapper, withRequesterPaysHandler } from 'src/components/bucket-utils'
 import { ButtonPrimary, ButtonSecondary, Link } from 'src/components/common'
-import { AddColumnModal, AddEntityModal, EntityDeleter, ModalToolButton, MultipleEntityEditor, saveScroll } from 'src/components/data/data-utils'
+import { AddColumnModal, AddEntityModal, CreateEntitySetModal, EntityDeleter, ModalToolButton, MultipleEntityEditor, saveScroll } from 'src/components/data/data-utils'
 import DataTable from 'src/components/data/DataTable'
 import ExportDataModal from 'src/components/data/ExportDataModal'
 import { icon, spinner } from 'src/components/icons'
@@ -15,7 +15,7 @@ import IGVBrowser from 'src/components/IGVBrowser'
 import IGVFileSelector from 'src/components/IGVFileSelector'
 import { withModalDrawer } from 'src/components/ModalDrawer'
 import { cohortNotebook, cohortRNotebook, NotebookCreator } from 'src/components/notebook-utils'
-import { MenuButton, MenuTrigger } from 'src/components/PopupTrigger'
+import { MenuButton, MenuDivider, MenuTrigger } from 'src/components/PopupTrigger'
 import TitleBar from 'src/components/TitleBar'
 import WorkflowSelector from 'src/components/WorkflowSelector'
 import datasets from 'src/data/datasets'
@@ -220,6 +220,7 @@ const EntitiesContent = ({
   const [copyingEntities, setCopyingEntities] = useState(false)
   const [addingEntity, setAddingEntity] = useState(false)
   const [addingColumn, setAddingColumn] = useState(false)
+  const [creatingSet, setCreatingSet] = useState(false)
   const [nowCopying, setNowCopying] = useState(false)
   const [refreshKey, setRefreshKey] = useState(0)
   const [showToolSelector, setShowToolSelector] = useState(false)
@@ -385,11 +386,17 @@ const EntitiesContent = ({
         h(MenuButton, {
           onClick: () => setAddingColumn(true)
         }, ['Add column']),
+        h(MenuDivider),
         h(MenuButton, {
           disabled: !entitiesSelected,
           tooltip: !entitiesSelected && 'Select rows to edit in the table',
           onClick: () => setEditingEntities(true)
         }, ['Edit selected rows']),
+        h(MenuButton, {
+          disabled: !entitiesSelected,
+          tooltip: !entitiesSelected && 'Select rows to create set',
+          onClick: () => setCreatingSet(true)
+        }, ['Create set with selected rows']),
         h(MenuButton, {
           disabled: !entitiesSelected,
           tooltip: !entitiesSelected && 'Select rows to delete in the table',
@@ -528,6 +535,16 @@ const EntitiesContent = ({
         onSuccess: () => {
           setEditingEntities(false)
           setRefreshKey(_.add(1))
+        }
+      }),
+      creatingSet && h(CreateEntitySetModal, {
+        entityType: entityKey,
+        entityNames: _.keys(selectedEntities),
+        workspaceId: { namespace, name },
+        onDismiss: () => setCreatingSet(false),
+        onSuccess: () => {
+          setCreatingSet(false)
+          loadMetadata()
         }
       }),
       deletingEntities && h(EntityDeleter, {

--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -394,14 +394,15 @@ const EntitiesContent = ({
         }, ['Edit selected rows']),
         h(MenuButton, {
           disabled: !entitiesSelected,
-          tooltip: !entitiesSelected && 'Select rows to create set',
-          onClick: () => setCreatingSet(true)
-        }, ['Create set with selected rows']),
-        h(MenuButton, {
-          disabled: !entitiesSelected,
           tooltip: !entitiesSelected && 'Select rows to delete in the table',
           onClick: () => setDeletingEntities(true)
-        }, 'Delete selected rows')
+        }, 'Delete selected rows'),
+        h(MenuDivider),
+        h(MenuButton, {
+          disabled: !entitiesSelected,
+          tooltip: !entitiesSelected && 'Select rows to save as set',
+          onClick: () => setCreatingSet(true)
+        }, ['Save selection as set'])
       ])
     }, [h(ButtonSecondary, {
       disabled: !canEdit,

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -948,9 +948,8 @@ export const CreateEntitySetModal = ({ entityType, entityNames, workspaceId: { n
   const [isBusy, setIsBusy] = useState()
 
   const createSet = async () => {
+    setIsBusy(true)
     try {
-      setIsBusy(true)
-
       await Ajax()
         .Workspaces
         .workspace(namespace, workspaceName)

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -937,6 +937,90 @@ export const MultipleEntityEditor = ({ entityType, entityNames, attributeNames, 
   ])
 }
 
+export const CreateEntitySetModal = ({ entityType, entityNames, workspaceId: { namespace, name: workspaceName }, onDismiss, onSuccess }) => {
+  const [name, setName] = useState('')
+  const [nameInputTouched, setNameInputTouched] = useState(false)
+  const nameError = nameInputTouched && Utils.cond(
+    [!name, () => 'A name for the set is required.'],
+    [!/^[A-Za-z0-9_-]+$/.test(name), () => 'Set name may only contain alphanumeric characters, underscores, dashes, and periods.']
+  )
+
+  const [isBusy, setIsBusy] = useState()
+
+  const createSet = async () => {
+    try {
+      setIsBusy(true)
+
+      await Ajax()
+        .Workspaces
+        .workspace(namespace, workspaceName)
+        .createEntity({
+          name,
+          entityType: `${entityType}_set`,
+          attributes: {
+            [`${entityType}s`]: {
+              itemsType: 'EntityReference',
+              items: _.map(entityName => ({ entityType, entityName }), entityNames)
+            }
+          }
+        })
+      onSuccess()
+    } catch (e) {
+      onDismiss()
+      reportError('Unable to create set.', e)
+    }
+  }
+
+  return h(Modal, {
+    title: `Create a ${entityType} set`,
+    onDismiss,
+    okButton: h(ButtonPrimary, {
+      disabled: !name || nameError,
+      tooltip: nameError,
+      onClick: createSet
+    }, ['Save'])
+  }, [
+    div({ style: { display: 'flex', flexDirection: 'column', marginBottom: '1rem' } }, [
+      h(IdContainer, [
+        id => h(Fragment, [
+          label({ htmlFor: id, style: { fontWeight: 'bold', marginBottom: '0.5rem' } }, 'Set name (required)'),
+          div({ style: { position: 'relative', display: 'flex', alignItems: 'center' } }, [
+            h(TextInput, {
+              id,
+              value: name,
+              placeholder: 'Enter a name for the set',
+              style: nameError ? {
+                paddingRight: '2.25rem',
+                border: `1px solid ${colors.danger()}`
+              } : undefined,
+              onChange: value => {
+                setName(value)
+                setNameInputTouched(true)
+              }
+            }),
+            nameError && icon('error-standard', {
+              size: 24,
+              style: {
+                position: 'absolute', right: '0.5rem',
+                color: colors.danger()
+              }
+            })
+          ]),
+          nameError && div({
+            'aria-live': 'assertive',
+            'aria-relevant': 'all',
+            style: {
+              marginTop: '0.5rem',
+              color: colors.danger()
+            }
+          }, nameError)
+        ])
+      ])
+    ]),
+    isBusy && spinnerOverlay
+  ])
+}
+
 export const AddColumnModal = ({ entityType, entityMetadata, workspaceId: { namespace, name }, onDismiss, onSuccess }) => {
   const [columnName, setColumnName] = useState('')
   const [columnNameTouched, setColumnNameTouched] = useState(false)


### PR DESCRIPTION
Running a workflow on rows of a data table creates a set containing those rows. Users can also create a set by [uploading a membership TSV](https://support.terra.bio/hc/en-us/articles/360059242671-Adding-data-to-a-workspace-with-a-template#h_01F39ED3V80RE659R0B9934CKA).

Since creating and uploading a membership TSV is a cumbersome process, users will sometimes work around it by starting a workflow and immediately cancelling it just to create a set.

This adds the ability to create a set by selecting rows in the data table UI.

This is part of the new data tab design (enabled with `configOverridesStore.set({ isDataTabRedesignEnabled: true })`).

https://user-images.githubusercontent.com/1156625/169078271-3fb26d1b-3345-471f-93b1-10d8eebe946d.mov


