### PR TITLE
[IA-3340] Fixed issue causing incorrect CPU number to be passed on update

### DIFF
--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -1516,6 +1516,7 @@ export const ComputeModalBase = ({
         setCustomEnvImage('')
         setRuntimeType(newRuntimeType)
         updateComputeConfig('componentGatewayEnabled', isDataproc(newRuntimeType))
+        updateComputeConfig('masterMachineType', isDataproc(newRuntimeType) ? defaultDataprocMachineType : defaultGceMachineType)
       },
       isSearchable: true,
       isClearable: false,


### PR DESCRIPTION
Originally, when a user would create a GCE runtime and then try to update it to a Dataproc one, they would get an error because the incorrect value was being passed in the update for the `masterMachineType`. This line fixes this by updating the `masterMachineType` to the default value when the application configuration is changed, which mirrors what the CPUs dropdown value changes to when the application configuration is changed.

Testing:

- Created a default runtime and then updated it to a Hail runtime and saw no issues and verified that the network calls showed the correct `masterMachineType` value
- Updated the CPUs value and verified that the network calls showed the expected values
- Updated a Hail runtime to a default runtime and verified that the network calls showed as expected with no errors
