### PR TITLE
[QA-1876] Terra UI test log createWorkspace and deleteWorkspace errors

### DIFF
--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -36,7 +36,8 @@ const makeWorkspace = withSignedInPage(async ({ page, billingProject }) => {
 
     console.info(`Created workspace: ${workspaceName}`)
   } catch (e) {
-    throw Error(`Failed to create workspace: ${workspaceName} with billing project ${billingProject}`)
+    console.error(`Failed to create workspace: ${workspaceName} with billing project: ${billingProject}`, e)
+    throw e
   }
   return workspaceName
 })
@@ -49,7 +50,8 @@ const deleteWorkspace = withSignedInPage(async ({ page, billingProject, workspac
 
     console.info(`Deleted workspace: ${workspaceName}`)
   } catch (e) {
-    throw Error(`Failed to delete workspace: ${workspaceName} with billing project ${billingProject}`)
+    console.error(`Failed to delete workspace: ${workspaceName} with billing project: ${billingProject}`, e)
+    throw e
   }
 })
 

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -32,24 +32,19 @@ const makeWorkspace = withSignedInPage(async ({ page, billingProject }) => {
   const workspaceName = getTestWorkspaceName()
   billingProject = 'terra-dev-01867dda'
   try {
-    const response = await page.evaluate(async (name, billingProject) => {
-      try {
-        return new Promise(async (resolve, reject) => {
-          return window.Ajax().Workspaces.create({ namespace: billingProject, name, attributes: {} })
-            .then(resp => resolve(resp))
-            .catch(async err => reject(err))
-        })
-      } catch (e) {
-        console.error(e)
-        throw e
-      }
+    const response = await page.evaluate((name, billingProject) => {
+      return new Promise(async (resolve, reject) => {
+        return await window.Ajax().Workspaces.create({ namespace: billingProject, name, attributes: {} })
+          .then(resp => resolve(resp))
+          .catch(async err => reject(await err.text()))
+      })
     }, workspaceName, billingProject)
 
     console.info(`Created workspace: ${workspaceName}`)
     console.info(response)
   } catch (e) {
     console.error(`Failed to create workspace: ${workspaceName} with billing project: ${billingProject}`)
-    console.log(e.Response)
+    console.error(e)
     throw e
   }
   return workspaceName
@@ -58,10 +53,10 @@ const makeWorkspace = withSignedInPage(async ({ page, billingProject }) => {
 
 const deleteWorkspace = withSignedInPage(async ({ page, billingProject, workspaceName }) => {
   try {
-    const response = await page.evaluate(async (name, billingProject) => {
+    const response = await page.evaluate((name, billingProject) => {
       return new Promise(async (resolve, reject) => {
         return await window.Ajax().Workspaces.workspace(billingProject, name).delete()
-          .then(resp => resolve(resp.text()))
+          .then(async resp => resolve(await resp.text()))
           .catch(err => reject(err))
       })
     }, workspaceName, billingProject)


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/QA-1876

Error like this is not useful for troubleshooting failure.
```
Tests Summary
----------------------------------------------
Test: preview-drs-uri
Status: failed
Failure message: Error: Failed to create workspace: terra-ui-test-workspace-1e538e53-e2f1-4780-ac2f-69131ea3232a with billing project saturn-integration-test-dev
    at /mnt/ramdisk/integration-tests/utils/integration-helpers.js:39:11
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at /mnt/ramdisk/integration-tests/utils/integration-helpers.js:19:12
    at /mnt/ramdisk/integration-tests/utils/integration-helpers.js:57:25
    at /mnt/ramdisk/integration-tests/utils/integration-utils.js:317:12
    at /mnt/ramdisk/integration-tests/utils/integration-utils.js:350:10
```


Fix `makeWorkspace` and `deleteWorkspace` function to log response body.

Example of test log that shows why when `makeWorkspace` has failed:

```
Tests Summary
----------------------------------------------
Test: analysis-context-bar
Status: failed
Failure message: Error: Evaluation failed: {"causes":[],"message":"Billing Project terra-dev-01867dda does not exist","source":"rawls","stackTrace":[],"statusCode":400}
    at ExecutionContext._evaluateInternal (/Users/bweng/projects/terra-ui/.yarn/unplugged/puppeteer-npm-13.5.1-231e586c7a/node_modules/puppeteer/src/common/ExecutionContext.ts:273:13)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at ExecutionContext.evaluate (/Users/bweng/projects/terra-ui/.yarn/unplugged/puppeteer-npm-13.5.1-231e586c7a/node_modules/puppeteer/src/common/ExecutionContext.ts:140:12)
    at /Users/bweng/projects/terra-ui/integration-tests/utils/integration-helpers.js:35:22
    at /Users/bweng/projects/terra-ui/integration-tests/utils/integration-helpers.js:19:12
    at /Users/bweng/projects/terra-ui/integration-tests/utils/integration-helpers.js:75:25
    at /Users/bweng/projects/terra-ui/integration-tests/utils/integration-helpers.js:152:5
    at /Users/bweng/projects/terra-ui/integration-tests/utils/integration-helpers.js:201:3
    at /Users/bweng/projects/terra-ui/integration-tests/utils/integration-helpers.js:117:5
    at /Users/bweng/projects/terra-ui/integration-tests/utils/integration-utils.js:313:12
```

Example of test log that shows response body when `makeWorkspace` and `deleteWorkspace` have succeeded:

<img width="648" alt="Screen Shot 2022-05-18 at 9 34 45 PM" src="https://user-images.githubusercontent.com/35533885/169187879-d69d4f03-27e5-4232-adb4-080b74d23e77.png">

<img width="637" alt="Screen Shot 2022-05-18 at 9 35 17 PM" src="https://user-images.githubusercontent.com/35533885/169187882-1298df44-cce9-4942-bbee-147c395787ae.png">


