### PR TITLE
[SU-114] Reorder buttons in data table menu

### DIFF
--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -448,6 +448,7 @@ const EntitiesContent = ({
     return !snapshotName && h(ButtonSecondary, {
       disabled: !entitiesSelected,
       tooltip: entitiesSelected ? 'Open selected data' : 'Select rows to open in the table',
+      style: { marginRight: '1.5rem' },
       onClick: () => setShowToolSelector(true)
     }, [icon('expand-arrows-alt', { style: { marginRight: '0.5rem' } }), 'Open with...'])
   }
@@ -471,13 +472,12 @@ const EntitiesContent = ({
         },
         childrenBefore: ({ entities, columnSettings, showColumnSettingsModal }) => div({ style: { display: 'flex', alignItems: 'center', flex: 'none' } },
           isDataTabRedesignEnabled() ? [
-            renderExportMenu({ columnSettings }),
             renderEditMenu(),
+            renderOpenWithMenu(),
+            renderExportMenu({ columnSettings }),
             !snapshotName && h(ButtonSecondary, {
-              style: { marginRight: '1.5rem' },
               onClick: showColumnSettingsModal
             }, [icon('cog', { style: { marginRight: '0.5rem' } }), 'Settings']),
-            renderOpenWithMenu(),
             div({ style: { margin: '0 1.5rem', height: '100%', borderLeft: Style.standardLine } }),
             div({
               role: 'status',


### PR DESCRIPTION
This is part of the new data tab design (enabled with `configOverridesStore.set({ isDataTabRedesignEnabled: true })`).

This reorders the data table's menu buttons to better align with the order of steps in a user's workflow: import data, edit it, analyze it, and export results.

## Before
![Screen Shot 2022-05-19 at 8 09 54 AM](https://user-images.githubusercontent.com/1156625/169290837-d1334771-36dc-433d-b69b-caf9bcfec829.png)

## After
![Screen Shot 2022-05-19 at 8 09 21 AM](https://user-images.githubusercontent.com/1156625/169290841-68ba32b0-d73e-403e-8c51-3433164e2c0b.png)

