### PR TITLE
BT-655 Add Mixpanel event for opening Job Manager

### DIFF
--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -32,6 +32,8 @@ const eventsList = {
   datasetLibraryBrowseData: 'library:browseData',
   dataTableSaveColumnSettings: 'dataTable:saveColumnSettings',
   dataTableLoadColumnSettings: 'dataTable:loadColumnSettings',
+  // Note: "external" refers to the common Job Manager deployment, not a Job Manager bundled in CromwellApp
+  jobManagerOpenExternal: 'job-manager:open-external',
   notebookLaunch: 'notebook:launch',
   notebookRename: 'notebook:rename',
   notebookCopy: 'notebook:copy',

--- a/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
+++ b/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
@@ -18,6 +18,7 @@ import { bucketBrowserUrl } from 'src/libs/auth'
 import colors from 'src/libs/colors'
 import { getConfig } from 'src/libs/config'
 import { withErrorReporting } from 'src/libs/error'
+import Events, { extractWorkspaceDetails } from 'src/libs/events'
 import * as Nav from 'src/libs/nav'
 import { forwardRefWithName, useCancellation } from 'src/libs/react-utils'
 import * as Style from 'src/libs/style'
@@ -35,7 +36,7 @@ const SubmissionDetails = _.flow(
     title: 'Job History', activeTab: 'job history'
   })
 )((props, _ref) => {
-  const { namespace, name, submissionId, workspace: { workspace: { bucketName } } } = props
+  const { namespace, name, submissionId, workspace, workspace: { workspace: { bucketName } } } = props
 
   /*
    * State setup
@@ -322,6 +323,11 @@ const SubmissionDetails = _.flow(
                       key: 'manager',
                       ...Utils.newTabLinkProps,
                       href: `${getConfig().jobManagerUrlRoot}/${workflowId}`,
+                      onClick: () => Ajax().Metrics.captureEvent(Events.jobManagerOpenExternal, {
+                        workflowId,
+                        from: 'workspace-submission-details',
+                        ...extractWorkspaceDetails(workspace.workspace)
+                      }),
                       style: { margin: '0.5rem', display: 'flex' },
                       tooltip: 'Job Manager',
                       'aria-label': `Job Manager (for workflow ID ${workflowId})`

--- a/src/pages/workspaces/workspace/jobHistory/WorkflowDashboard.js
+++ b/src/pages/workspaces/workspace/jobHistory/WorkflowDashboard.js
@@ -14,6 +14,7 @@ import WDLViewer from 'src/components/WDLViewer'
 import { Ajax } from 'src/libs/ajax'
 import { bucketBrowserUrl } from 'src/libs/auth'
 import { getConfig } from 'src/libs/config'
+import Events, { extractWorkspaceDetails } from 'src/libs/events'
 import { forwardRefWithName, useCancellation, useOnMount } from 'src/libs/react-utils'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
@@ -63,7 +64,7 @@ const WorkflowDashboard = _.flow(
     title: 'Job History', activeTab: 'job history'
   })
 )((props, _ref) => {
-  const { namespace, name, submissionId, workflowId, workspace: { workspace: { googleProject, bucketName } } } = props
+  const { namespace, name, submissionId, workflowId, workspace, workspace: { workspace: { googleProject, bucketName } } } = props
 
   /*
    * State setup
@@ -160,6 +161,11 @@ const WorkflowDashboard = _.flow(
               h(Link, {
                 ...Utils.newTabLinkProps,
                 href: `${getConfig().jobManagerUrlRoot}/${workflowId}`,
+                onClick: () => Ajax().Metrics.captureEvent(Events.jobManagerOpenExternal, {
+                  workflowId,
+                  from: 'workspace-workflow-dashboard',
+                  ...extractWorkspaceDetails(workspace.workspace)
+                }),
                 style: { display: 'flex', alignItems: 'center' },
                 tooltip: 'Job Manager'
               }, [icon('tasks', { size: 18 }), ' Job Manager']),


### PR DESCRIPTION
This is so we have something to compare usage against the existing Workflow Dashboard (alpha) page view. Example Mixpanel report: https://mixpanel.com/s/1lGEVl
![Screen Shot 2022-05-19 at 8 15 00 AM](https://user-images.githubusercontent.com/19228696/169292666-9c3a1246-43e4-454b-87ab-5bb596013237.png)
Note: I added a "from" attribute (demonstrated in the screenshot above, which is why there are 3 colors) to differentiate between the two places where we link out to Job Manager. This may not be necessary because it would probably be inferred using Mixpanel flows, but I figured it didn't hurt to capture this data. I also included the workflow ID in case it's helpful for retrospectively studying what types of workflows people tend to use the different views for.
