### PR TITLE
[TOAZ-150] Clear session storage upon logout

### DIFF
--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -49,6 +49,7 @@ export const signOut = () => {
   cookieReadyStore.reset()
   sessionStorage.clear()
   getAuthInstance().removeUser()
+  getAuthInstance().clearStaleState()
 }
 
 const getSigninArgs = includeBillingScope => {


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/TOAZ-150

Tested locally that all my `oidc.*` storage entries disappeared upon logout.