### PR TITLE
[SU-100] Increase font weight of table headers

### DIFF
--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -358,8 +358,7 @@ const DataTable = props => {
                         ]
                       }, [
                         h(HeaderCell, [
-                          !!columnNamespace && span({ style: { fontStyle: 'italic', color: colors.dark(0.75), paddingRight: '0.2rem' } },
-                            columnNamespace),
+                          !!columnNamespace && span({ style: { fontStyle: 'italic', color: colors.dark(0.75), paddingRight: '0.2rem' } }, [columnNamespace]),
                           columnName
                         ])
                       ])

--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -359,9 +359,9 @@ const DataTable = props => {
                       }, [
                         h(HeaderCell, [
                           !!columnNamespace && span({ style: { fontStyle: 'italic', color: colors.dark(0.75), paddingRight: '0.2rem' } },
-                            columnNamespace)
-                        ]),
-                        [columnName]
+                            columnNamespace),
+                          columnName
+                        ])
                       ])
                     ]),
                     cellRenderer: ({ rowIndex }) => {

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -13,6 +13,7 @@ import Interactive from 'src/components/Interactive'
 import Modal from 'src/components/Modal'
 import TooltipTrigger from 'src/components/TooltipTrigger'
 import colors from 'src/libs/colors'
+import { isDataTabRedesignEnabled } from 'src/libs/config'
 import { forwardRefWithName, useLabelAssert, useOnMount } from 'src/libs/react-utils'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
@@ -626,7 +627,7 @@ export const TooltipCell = ({ children, tooltip, ...props }) => h(TooltipTrigger
 }, [h(TextCell, props, [children])])
 
 export const HeaderCell = props => {
-  return h(TextCell, _.merge({ style: { fontWeight: 500 } }, props))
+  return h(TextCell, _.merge({ style: { fontWeight: isDataTabRedesignEnabled() ? 600 : 500 } }, props))
 }
 
 export const Sortable = ({ sort, field, onSort, children }) => {

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -127,7 +127,7 @@ const WorkflowIOTable = ({ which, inputsOutputs: data, config, errors, onChange,
       {
         size: { basis: 360, grow: 0 },
         field: 'workflowVariable',
-        headerRenderer: () => h(Sortable, { sort, field: 'workflowVariable', onSort: setSort }, ['Variable']),
+        headerRenderer: () => h(Sortable, { sort, field: 'workflowVariable', onSort: setSort }, [h(HeaderCell, ['Variable'])]),
         cellRenderer: ({ rowIndex }) => {
           const io = sortedData[rowIndex]
           return h(TextCell, { style: styles.cell(io.optional) }, [ioVariable(io)])
@@ -143,7 +143,7 @@ const WorkflowIOTable = ({ which, inputsOutputs: data, config, errors, onChange,
       },
       {
         headerRenderer: () => h(Fragment, [
-          div({ style: { fontWeight: 'bold' } }, ['Attribute']),
+          h(HeaderCell, ['Attribute']),
           !readOnly && !isSnapshot && which === 'outputs' && h(Fragment, [
             div({ style: { whiteSpace: 'pre' } }, ['  |  ']),
             h(Link, { onClick: onSetDefaults }, ['Use defaults'])


### PR DESCRIPTION
Requested by UX for new data tab design (enable with `configOverridesStore.set({ isDataTabRedesignEnabled: true })`). I made the change in the base table component so that all tables would be consistent.

## Before
![Screen Shot 2022-05-19 at 4 18 59 PM](https://user-images.githubusercontent.com/1156625/169397537-c9030b75-8d4b-4e3c-be33-f7f470c340ad.png)

## After
![Screen Shot 2022-05-19 at 4 18 45 PM](https://user-images.githubusercontent.com/1156625/169397536-4f34ce4b-485b-4445-ba56-574dcacce0a7.png)

