### PR TITLE
[WOR-332] Dismiss notifications if clicking on workspace menu fails.

### DIFF
--- a/integration-tests/tests/workspace-dashboard.js
+++ b/integration-tests/tests/workspace-dashboard.js
@@ -9,12 +9,22 @@ const { withUserToken } = require('../utils/terra-sa-utils')
 
 const workspaceDashboardPage = (testPage, testUrl, token, workspaceName) => {
   const clickWorkspaceActionMenu = async (testPage) => {
-    try {
-      await click(testPage, clickable({ text: 'Workspace Action Menu' }))
-    } catch (error) {
-      console.log('Unable to click "Workspace Action Menu", dismissing notifications.')
-      await dismissNotifications(testPage)
-      await click(testPage, clickable({ text: 'Workspace Action Menu' }))
+    const clickOrDismiss = async () => {
+      try {
+        await click(testPage, clickable({ text: 'Workspace Action Menu' }))
+        return true
+      } catch (error) {
+        console.log('Unable to click "Workspace Action Menu", dismissing notifications.')
+        await dismissNotifications(testPage)
+        return false
+      }
+    }
+    let clicked = await clickOrDismiss()
+    let counter = 0
+    // Multiple notifications appear, and dismissNotifications has delays to allow animation to happen.
+    while (!clicked && counter < 5) {
+      clicked = await clickOrDismiss()
+      counter = counter + 1
     }
   }
 

--- a/integration-tests/tests/workspace-dashboard.js
+++ b/integration-tests/tests/workspace-dashboard.js
@@ -26,6 +26,9 @@ const workspaceDashboardPage = (testPage, testUrl, token, workspaceName) => {
       clicked = await clickOrDismiss()
       counter = counter + 1
     }
+    if (!clicked) {
+      throw new Error('Was not able to click the "Workspace Action Menu", even after dismissing notifications')
+    }
   }
 
   return {

--- a/integration-tests/tests/workspace-dashboard.js
+++ b/integration-tests/tests/workspace-dashboard.js
@@ -8,7 +8,7 @@ const { withUserToken } = require('../utils/terra-sa-utils')
 
 
 const workspaceDashboardPage = (testPage, testUrl, token, workspaceName) => {
-  const clickWorkspaceActionMenu = async (testPage) => {
+  const clickWorkspaceActionMenu = async testPage => {
     const clickOrDismiss = async () => {
       try {
         await click(testPage, clickable({ text: 'Workspace Action Menu' }))

--- a/integration-tests/tests/workspace-dashboard.js
+++ b/integration-tests/tests/workspace-dashboard.js
@@ -30,7 +30,7 @@ const workspaceDashboardPage = (testPage, testUrl, token, workspaceName) => {
     },
 
     assertWorkspaceMenuItems: async expectedMenuItems => {
-      await dismissNotifications(page)
+      await dismissNotifications(testPage)
       await click(testPage, clickable({ text: 'Workspace Action Menu' }))
       await Promise.all(_.map(async ({ label, tooltip }) => {
         if (!!tooltip) {
@@ -43,20 +43,20 @@ const workspaceDashboardPage = (testPage, testUrl, token, workspaceName) => {
     },
 
     assertLockWorkspace: async () => {
-      await dismissNotifications(page)
+      await dismissNotifications(testPage)
       await assertTextNotFound(testPage, 'Workspace is locked')
       await click(testPage, clickable({ text: 'Workspace Action Menu' }))
       await click(testPage, clickable({ textContains: 'Lock' }))
-      await noSpinnersAfter(testPage, { action: () => click(page, clickable({ textContains: 'Lock Workspace' })) })
+      await noSpinnersAfter(testPage, { action: () => click(testPage, clickable({ text: 'Lock Workspace' })) })
       await findText(testPage, 'Workspace is locked')
     },
 
     assertUnlockWorkspace: async () => {
-      await dismissNotifications(page)
+      await dismissNotifications(testPage)
       await findText(testPage, 'Workspace is locked')
       await click(testPage, clickable({ text: 'Workspace Action Menu' }))
       await click(testPage, clickable({ textContains: 'Unlock' }))
-      await noSpinnersAfter(testPage, { action: () => click(page, clickable({ textContains: 'Unlock Workspace' })) })
+      await noSpinnersAfter(testPage, { action: () => click(testPage, clickable({ text: 'Unlock Workspace' })) })
       await assertTextNotFound(testPage, 'Workspace is locked')
     },
 
@@ -85,7 +85,7 @@ const testGoogleWorkspace = _.flow(
   await dashboard.assertUnlockWorkspace()
 
   // Verify other Workspace menu items are in correct state (all will be enabled).
-  await dashboard.assertWorkspaceMenuItems([{ label: 'Clone' }, { label: 'Share' }, { label: 'Delete' }])
+  await dashboard.assertWorkspaceMenuItems([{ label: 'Clone' }, { label: 'Share' }, { label: 'Delete' }, { label: 'Lock' }])
 
   // Click on each of the expected tabs
   await dashboard.assertTabs(['data', 'notebooks', 'workflows', 'job history'], true)

--- a/integration-tests/tests/workspace-dashboard.js
+++ b/integration-tests/tests/workspace-dashboard.js
@@ -1,7 +1,9 @@
 // This test is owned by the Workspaces Team.
 const _ = require('lodash/fp')
 const { clickNavChildAndLoad, overrideConfig, viewWorkspaceDashboard, withWorkspace } = require('../utils/integration-helpers')
-const { assertNavChildNotFound, assertTextNotFound, click, clickable, findElement, findText, noSpinnersAfter } = require('../utils/integration-utils')
+const {
+  assertNavChildNotFound, assertTextNotFound, click, clickable, dismissNotifications, findElement, findText, noSpinnersAfter
+} = require('../utils/integration-utils')
 const { withUserToken } = require('../utils/terra-sa-utils')
 
 
@@ -28,6 +30,7 @@ const workspaceDashboardPage = (testPage, testUrl, token, workspaceName) => {
     },
 
     assertWorkspaceMenuItems: async expectedMenuItems => {
+      await dismissNotifications(page)
       await click(testPage, clickable({ text: 'Workspace Action Menu' }))
       await Promise.all(_.map(async ({ label, tooltip }) => {
         if (!!tooltip) {
@@ -40,6 +43,7 @@ const workspaceDashboardPage = (testPage, testUrl, token, workspaceName) => {
     },
 
     assertLockWorkspace: async () => {
+      await dismissNotifications(page)
       await assertTextNotFound(testPage, 'Workspace is locked')
       await click(testPage, clickable({ text: 'Workspace Action Menu' }))
       await click(testPage, clickable({ textContains: 'Lock' }))
@@ -48,6 +52,7 @@ const workspaceDashboardPage = (testPage, testUrl, token, workspaceName) => {
     },
 
     assertUnlockWorkspace: async () => {
+      await dismissNotifications(page)
       await findText(testPage, 'Workspace is locked')
       await click(testPage, clickable({ text: 'Workspace Action Menu' }))
       await click(testPage, clickable({ textContains: 'Unlock' }))


### PR DESCRIPTION
On alpha and staging in particular, we are sporadically seeing the workspace menu being obscured by 1 or more notifications.

![image](https://user-images.githubusercontent.com/484484/169426489-da53894c-c142-4068-9336-866de79a5416.png)

We know that the bucket location call can fail, usually because the permissions haven't yet propagated on a new workspace (and sometimes it fails for no good reason… Google advises retrying). For the purposes of this test, we don't need bucket location or storage cost information.

With these changes, test-flakes **passed 200/200 runs** against alpha (and I got many, many failures against alpha without the changes).