### PR TITLE
[DC-210] Added ability to manually add entry to data catalog

### DIFF
--- a/src/pages/library/DataBrowser.js
+++ b/src/pages/library/DataBrowser.js
@@ -216,11 +216,11 @@ const makeDataBrowserTableComponent = ({ sort, setSort, selectedData, toggleSele
   return DataBrowserTable
 }
 
-const Browser = () => {
+const Browser = (props) => {
   const [sort, setSort] = useState({ field: 'created', direction: 'desc' })
   const [selectedData, setSelectedData] = useState([])
   const [requestDatasetAccessList, setRequestDatasetAccessList] = useState()
-  const { dataCatalog, loading } = useDataCatalog()
+  const { dataCatalog, loading } = useDataCatalog(props.queryParams)
   const acknowledged = useStore(acknowledgmentStore) || {}
   const { user: { id } } = useStore(authStore)
 

--- a/src/pages/library/DataBrowser.js
+++ b/src/pages/library/DataBrowser.js
@@ -216,7 +216,7 @@ const makeDataBrowserTableComponent = ({ sort, setSort, selectedData, toggleSele
   return DataBrowserTable
 }
 
-const Browser = (props) => {
+const Browser = props => {
   const [sort, setSort] = useState({ field: 'created', direction: 'desc' })
   const [selectedData, setSelectedData] = useState([])
   const [requestDatasetAccessList, setRequestDatasetAccessList] = useState()

--- a/src/pages/library/dataBrowser-utils.js
+++ b/src/pages/library/dataBrowser-utils.js
@@ -118,7 +118,7 @@ export const useDataCatalog = (params = {}) => {
     withErrorReporting('Error loading data catalog'),
     Utils.withBusyState(setLoading)
   )(async () => {
-    const datasets = !isDataBrowserVisible() ? {} : await Ajax(signal).Catalog.getDatasets()
+    const datasets = !isDataBrowserVisible() ? { result: [] } : await Ajax(signal).Catalog.getDatasets()
     if (params && params.externalWorkspace && datasets.result) {
       datasets.result.push(JSON.parse(params.externalWorkspace))
     }

--- a/src/pages/library/dataBrowser-utils.js
+++ b/src/pages/library/dataBrowser-utils.js
@@ -109,7 +109,7 @@ export const getDatasetsPath = ({ user: { id } }) => {
     'library-browser' : 'library-datasets'
 }
 
-export const useDataCatalog = () => {
+export const useDataCatalog = (params = {}) => {
   const signal = useCancellation()
   const [loading, setLoading] = useState(false)
   const dataCatalog = useStore(dataCatalogStore)
@@ -119,6 +119,9 @@ export const useDataCatalog = () => {
     Utils.withBusyState(setLoading)
   )(async () => {
     const datasets = !isDataBrowserVisible() ? {} : await Ajax(signal).Catalog.getDatasets()
+    if (params && params.externalWorkspace && datasets.result) {
+      datasets.result.push(JSON.parse(params.externalWorkspace))
+    }
     const normList = _.map(dataset => {
       const normalizedDataset = normalizeDataset(dataset)
       return _.set(['tags'], extractTags(normalizedDataset), normalizedDataset)


### PR DESCRIPTION
This was made to allow users to check the output of their scripts / preview what adding their data would look like, but otherwise does not affect the code.

- General gist of what we do is pass the json of the workspace in as a query parameter, and then manually push it into the request result
