### PR TITLE
[WOR-81] Delete Azure workspaces

### DIFF
--- a/src/pages/workspaces/workspace/DeleteWorkspaceModal.js
+++ b/src/pages/workspaces/workspace/DeleteWorkspaceModal.js
@@ -16,7 +16,7 @@ import { isResourceDeletable } from 'src/libs/runtime-utils'
 import * as Utils from 'src/libs/utils'
 
 
-const DeleteWorkspaceModal = ({ workspace: { workspace: { namespace, name, bucketName } }, onDismiss, onSuccess }) => {
+const DeleteWorkspaceModal = ({ workspace: { workspace: { namespace, name, bucketName, googleProject } }, onDismiss, onSuccess }) => {
   const [deleting, setDeleting] = useState(false)
   const [deleteConfirmation, setDeleteConfirmation] = useState('')
   const [loading, setLoading] = useState(false)
@@ -96,7 +96,7 @@ const DeleteWorkspaceModal = ({ workspace: { workspace: { namespace, name, bucke
     div(['Are you sure you want to permanently delete the workspace ',
       span({ style: { fontWeight: 600, wordBreak: 'break-word' } }, name),
       '?']),
-    div({ style: { marginTop: '1rem' } }, [
+    !!googleProject && div({ style: { marginTop: '1rem' } }, [
       'Deleting it will delete the associated ',
       h(Link, {
         ...Utils.newTabLinkProps,

--- a/src/pages/workspaces/workspace/DeleteWorkspaceModal.js
+++ b/src/pages/workspaces/workspace/DeleteWorkspaceModal.js
@@ -45,6 +45,20 @@ const DeleteWorkspaceModal = ({ workspace: { workspace: { namespace, name, bucke
 
   const [deletableApps, nonDeletableApps] = _.partition(isResourceDeletable('app'), apps)
 
+  const getStorageDeletionMessage = () => {
+    return div({ style: { marginTop: '1rem' } }, [
+      'Deleting it will delete the associated ',
+      isGoogleWorkspace ? h(Link, {
+        ...Utils.newTabLinkProps,
+        href: bucketBrowserUrl(bucketName)
+      }, ['Google Cloud Bucket']) :
+        'Azure Storage Container',
+      ' and all its data',
+      workspaceBucketUsageInBytes !== undefined && span({ style: { fontWeight: 600 } }, ` (${Utils.formatBytes(workspaceBucketUsageInBytes)})`),
+      '.'
+    ])
+  }
+
   const getAppDeletionMessage = () => {
     return !_.isEmpty(nonDeletableApps) ?
       div({ style: { ...warningBoxStyle, fontSize: 14, display: 'flex', flexDirection: 'column' } }, [
@@ -101,16 +115,7 @@ const DeleteWorkspaceModal = ({ workspace: { workspace: { namespace, name, bucke
     div(['Are you sure you want to permanently delete the workspace ',
       span({ style: { fontWeight: 600, wordBreak: 'break-word' } }, name),
       '?']),
-    isGoogleWorkspace && div({ style: { marginTop: '1rem' } }, [
-      'Deleting it will delete the associated ',
-      h(Link, {
-        ...Utils.newTabLinkProps,
-        href: bucketBrowserUrl(bucketName)
-      }, ['Google Cloud Bucket']),
-      ' and all its data',
-      workspaceBucketUsageInBytes !== undefined && span({ style: { fontWeight: 600 } }, ` (${Utils.formatBytes(workspaceBucketUsageInBytes)})`),
-      '.'
-    ]),
+    getStorageDeletionMessage(),
     hasApps() && div({ style: { marginTop: '1rem' } }, [
       p(['Deleting it will also delete any associated applications:']),
       getAppDeletionMessage()


### PR DESCRIPTION
Ticket: [WOR-81](https://broadworkbench.atlassian.net/browse/WOR-81)
* Skip ajax calls that will fail for an Azure workspace
* Don't display information about Google bucket when deleting an Azure workspace

Modal when deleting Google workspace
![Screen Shot 2022-05-23 at 2 09 06 PM](https://user-images.githubusercontent.com/19961550/169880902-d7a18410-0137-449f-a032-4dffb1457ec2.png)

Modal when deleting Azure workspace
<img width="446" alt="Screen Shot 2022-05-23 at 4 01 57 PM" src="https://user-images.githubusercontent.com/19961550/169897184-1509d293-27d3-4b01-bf22-b9f97f699170.png">


<!--
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Also, so if a screen recording [1] and/or screenshots would be a helpful way to communicate context, please consider including some in your PR description.
Thanks!

[1] https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac
--!>
