### PR TITLE
[SU-106] Add option to silence expiring NIH access notification

### DIFF
--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -270,9 +270,10 @@ authStore.subscribe((state, oldState) => {
       // notification.
       const notificationId = hasExpired ? 'nih-link-expired' : 'nih-link-expires-soon'
 
-      // If/when the notification is muted, the current expiration time of the NIH link is stored in local preferences.
+      // If/when the notification is muted, the expiration time of the current NIH link is stored in local preferences.
       // This lets us apply the mute preference only to the current NIH link. If the user re-links their NIH account
-      // after muting notifications, we want to show these notifications the next time the link will expire.
+      // after muting notifications, we want to show these notifications when the new link will expire. In that case,
+      // the new link will have an expiration time greater than the time stored in the mute preference.
       const muteNotificationPreferenceKey = `mute-nih-notification/${notificationId}`
       const muteNotificationUntil = getLocalPref(muteNotificationPreferenceKey)
       if (muteNotificationUntil && muteNotificationUntil >= expireTime) {

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -264,16 +264,22 @@ authStore.subscribe((state, oldState) => {
     const shouldNotify = expireTime && now > expireTime - (1000 * 60 * 60 * 24)
     if (shouldNotify) {
       const hasExpired = now >= expireTime
-      const notificationId = hasExpired ? 'nih-link-expired' : 'nih-link-expires-soon'
-      const expireStatus = hasExpired ? 'has expired' : 'will expire soon'
 
+      // There are separate notification IDs for expired and expires soon so that mute preferences can be stored
+      // individually for each. If a user mutes the expires soon notification, we still want to show them the expired
+      // notification.
+      const notificationId = hasExpired ? 'nih-link-expired' : 'nih-link-expires-soon'
+
+      // If/when the notification is muted, the current expiration time of the NIH link is stored in local preferences.
+      // This lets us apply the mute preference only to the current NIH link. If the user re-links their NIH account
+      // after muting notifications, we want to show these notifications the next time the link will expire.
       const muteNotificationPreferenceKey = `mute-nih-notification/${notificationId}`
       const muteNotificationUntil = getLocalPref(muteNotificationPreferenceKey)
       if (muteNotificationUntil && muteNotificationUntil >= expireTime) {
         return
       }
 
-      notify('info', `Your access to NIH Controlled Access workspaces and data ${expireStatus}.`, {
+      notify('info', `Your access to NIH Controlled Access workspaces and data ${hasExpired ? 'has expired' : 'will expire soon'}.`, {
         id: notificationId,
         message: h(Fragment, [
           'To regain access, ',

--- a/src/libs/notifications.js
+++ b/src/libs/notifications.js
@@ -44,7 +44,7 @@ const NotificationDisplay = ({ id }) => {
   const onFirst = notificationNumber === 0
   const onLast = notificationNumber + 1 === notifications.length
 
-  const { title, message, detail, type } = notifications[notificationNumber]
+  const { title, message, detail, type, action } = notifications[notificationNumber]
   const [baseColor, ariaLabel] = Utils.switchCase(type,
     ['success', () => [colors.success, 'success notification']],
     ['info', () => [colors.accent, 'info notification']],
@@ -87,10 +87,19 @@ const NotificationDisplay = ({ id }) => {
           div({ id: labelId, style: { fontWeight: 600 } }, [title])
         ]),
         !!message && div({ id: descId, style: { marginTop: '0.5rem' } }, [message]),
-        !!detail && h(Clickable, {
-          style: { marginTop: '0.25rem', textDecoration: 'underline' },
-          onClick: () => setModal(true)
-        }, ['Details'])
+        div({ style: { display: 'flex' } }, [
+          !!detail && h(Clickable, {
+            style: { marginTop: '0.25rem', marginRight: '0.5rem', textDecoration: 'underline' },
+            onClick: () => setModal(true)
+          }, ['Details']),
+          !!action && h(Clickable, {
+            style: { marginTop: '0.25rem', textDecoration: 'underline' },
+            onClick: () => {
+              action.callback()
+              store.removeNotification(id)
+            }
+          }, [action.label])
+        ])
       ]),
       h(Link, {
         style: { alignSelf: 'start' },


### PR DESCRIPTION
To access some controlled datasets/workspaces, you can link an NIH account to Terra.

This link expires after 30 days. Starting 24 hours before the link expires, we show a notification that the link is about to expire or has expired every time Terra loads (every new tab, every refresh, etc). Feedback from users has been that the frequency of the notification is annoying, especially considering that we don't currently provide an option to un-link an NIH account to stop the notifications after the link has expired.

This adds a "Do not remind me again" button to these notifications which prevents showing the notification again (unless an NIH account is re-linked and the expiration time changes).

![Screen Shot 2022-05-23 at 4 13 16 PM](https://user-images.githubusercontent.com/1156625/169899342-03ccb72e-576f-46e1-bc09-fbf465bdb2b2.png)

To mock an expiring link, edit these lines in auth.js:

https://github.com/DataBiosphere/terra-ui/blob/610c415f43526eb5dd36645abcdde11946d36605/src/libs/auth.js#L241-L242

```js
authStore.update(state => ({
  ...state,
  nihStatus: {
    linkExpireTime: 1653337361,
    linkedNihUsername: 'me@example.com'
  }
}))
```

The `linkExpireTime` is an epoch timestamp. For example, to mock an NIH link expiring in 12 hours, `linkExpireTime` would be set to the result of `Math.floor(Date.now() / 1000) + 12 * 3600`.



