### PR TITLE
[TUIM-8] Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,78 +1,18 @@
-### Submit an issue [here](https://broadworkbench.atlassian.net/secure/CreateIssueDetails!init.jspa?pid=10023&issuetype=10004&priority=2)
-
-------------------------
-
 # Terra UI
 Web user interface for the Terra platform.
 
 ------------------------
 ### Links:
-[Support](https://support.terra.bio/hc/en-us)
-[Email an issue](mailto:terra-support@broadinstitute.zendesk.com)
-[Board and backlog](https://broadworkbench.atlassian.net/projects/SATURN/issues?filter=allopenissues&orderby=status%20DESC)
+- [Terra Support](https://support.terra.bio/hc/en-us)
+- [Terra Courses](https://leanpub.com/universities/terra)
 
------------------------
+### Bug Reports and Feature Requests
 
-This project was bootstrapped with [Create React App](https://github.com/facebookincubator/create-react-app).
+Bug reports and feature requests can be submitted to Terra Support.
 
-Guide [here](https://github.com/facebook/create-react-app/blob/master/packages/cra-template/template/README.md).
-
-Builds/deploying handled by CircleCI.
-
-### Feature requests
-Requests related to the funtionality or usability of the UI can be submitted as issues on this repo. However, as features often impact multiple components of the Terra platform, we recommend users submit feature requests through the main Terra feature request [page](https://support.terra.bio/hc/en-us/community/topics/360000500452). See this [article](https://support.terra.bio/hc/en-us/community/posts/360040112171) for more details.
-
-### Developing
-
-1. We use Node 16 (the current LTS) and Yarn. On Darwin with Homebrew:
-
-    ```sh
-    brew install node@16 yarn; brew link node@16 --force --overwrite
-    ```
-2. Install deps:
-
-    ```sh
-    yarn install
-    ```
-3. Start development server, which will report any lint violations as well:
-
-    ```sh
-    yarn start
-    ```
-
-    If you get an error that resembles:
-
-    ```
-    Failed to compile.
-
-    ./node_modules/react-dev-utils/webpackHotDevClient.js
-    Error: [BABEL] /Users/.../terra-ui/node_modules/react-scripts/node_modules/react-dev-utils/webpackHotDevClient.js: Cannot find module '...'
-    Require stack:
-    - ...
-    - ...
-    - ... (While processing: "...js")
-    ```
-
-    try:
-
-    ```sh
-    rm -rf node_modules
-    yarn install
-    yarn start
-    ```
-4. Testing:
-
-    ```sh
-    yarn test
-    ```
-6. Code style and linting:
-    * On command line within the repo's root dir: `yarn lint`
-      * Eslint will fix as many violations as possible. It will report any that it can't fix itself.
-    * In an IDE other than IntelliJ (VS Code, etc): install the eslint plugin from your package manager, and there should be a command to fix issues at any time.
-    * In IntelliJ:
-        * Styles should be automatically applied by [.editorconfig](.editorconfig); make sure you've also [turned on eslint](https://www.jetbrains.com/help/idea/eslint.html#ws_js_eslint_automatic_configuration).
-        * In order to correctly format a file at any time, run the IntelliJ `Reformat Code` action, and then right-click in a window and click `Fix ESLint Problems`. You could also create an IntelliJ macro to do this for you as explained [here](https://www.jetbrains.com/help/idea/using-macros-in-the-editor.html#reformat_on_save), and map running of the macro to a keyboard shortcut for convenience.
-
+- [Submit a Support request](https://support.terra.bio/hc/en-us/requests/new).
+- [Email support@terra.bio](mailto:support@terra.bio)
+- [Active feature requests](https://support.terra.bio/hc/en-us/community/topics/360000500452).
 
 ### Additional Documentation
-See [the wiki](https://github.com/DataBiosphere/terra-ui/wiki).
+See the [terra-ui wiki](https://github.com/DataBiosphere/terra-ui/wiki) for developer and other documentation.


### PR DESCRIPTION
README.md currently contains some outdated information. It has a few links to the now unused SATURN board and part of the "Developing" section is devoted to troubleshooting node_modules, which is no longer relevant with Yarn PnP.

This updates README.md to be more user (vs developer) centered and moves developer documentation to the [wiki](https://github.com/DataBiosphere/terra-ui/wiki) (the former contents of the "Developing" section are in a new ["Getting started"](https://github.com/DataBiosphere/terra-ui/wiki/Getting-started) page), where it's easier to update.