### PR TITLE
[SU-96] Support filterOperator in data table search

### DIFF
--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -2,7 +2,7 @@ import _ from 'lodash/fp'
 import { Fragment, useEffect, useRef, useState } from 'react'
 import { b, div, h, span } from 'react-hyperscript-helpers'
 import { AutoSizer } from 'react-virtualized'
-import { ButtonPrimary, Checkbox, Clickable, DeleteConfirmationModal, fixedSpinnerOverlay, Link } from 'src/components/common'
+import { ButtonPrimary, ButtonSecondary, Checkbox, Clickable, DeleteConfirmationModal, fixedSpinnerOverlay, Link, RadioButton } from 'src/components/common'
 import { concatenateAttributeNames, EditDataLink, EntityRenamer, HeaderOptions, renderDataCell, SingleEntityEditor } from 'src/components/data/data-utils'
 import { allSavedColumnSettingsEntityTypeKey, allSavedColumnSettingsInWorkspace, ColumnSettingsWithSavedColumnSettings, decodeColumnSettings } from 'src/components/data/SavedColumnSettings'
 import { icon } from 'src/components/icons'
@@ -12,7 +12,7 @@ import { MenuButton, MenuTrigger } from 'src/components/PopupTrigger'
 import { GridTable, HeaderCell, paginator, Resizable } from 'src/components/table'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
-import { isDataTabRedesignEnabled } from 'src/libs/config'
+import { isDataTabRedesignEnabled, isSearchAwesomeNow } from 'src/libs/config'
 import { withErrorReporting } from 'src/libs/error'
 import Events, { extractWorkspaceDetails } from 'src/libs/events'
 import { getLocalPref, setLocalPref } from 'src/libs/prefs'
@@ -121,6 +121,8 @@ const DataTable = props => {
   const [deletingColumn, setDeletingColumn] = useState()
   const [clearingColumn, setClearingColumn] = useState()
 
+  const [useAndOperatorForSearch, setUseAndOperatorForSearch] = useState(true)
+
   const noEdit = Utils.editWorkspaceError(workspace)
 
   const table = useRef()
@@ -136,7 +138,7 @@ const DataTable = props => {
         page: pageNumber, pageSize: itemsPerPage, sortField: sort.field, sortDirection: sort.direction,
         ...(!!snapshotName ?
           { billingProject: googleProject, dataReference: snapshotName } :
-          { filterTerms: activeCrossTableTextFilter || activeTextFilter })
+          { filterTerms: activeCrossTableTextFilter || activeTextFilter, filterOperator: useAndOperatorForSearch ? 'and' : 'or' })
       }))
     // Find all the unique attribute names contained in the current page of results.
     const attrNamesFromResults = _.uniq(_.flatMap(_.keys, _.map('attributes', results)))
@@ -219,9 +221,9 @@ const DataTable = props => {
   useEffect(() => {
     loadData()
     if (persist) {
-      StateHistory.update({ itemsPerPage, pageNumber, sort, activeTextFilter })
+      StateHistory.update({ itemsPerPage, pageNumber, sort, activeTextFilter, useAndOperatorForSearch })
     }
-  }, [itemsPerPage, pageNumber, sort, activeTextFilter, activeCrossTableTextFilter, refreshKey]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [itemsPerPage, pageNumber, sort, activeTextFilter, activeCrossTableTextFilter, useAndOperatorForSearch, refreshKey]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (persist) {
@@ -255,6 +257,39 @@ const DataTable = props => {
       }, [
         childrenBefore && childrenBefore({ entities, columnSettings, showColumnSettingsModal }),
         div({ style: { flexGrow: 1 } }),
+        isSearchAwesomeNow && h(MenuTrigger, {
+          side: 'bottom',
+          closeOnClick: false,
+          // Make the width of the dropdown menu match the width of the button.
+          popupProps: { style: { width: 250 } },
+          content: h(Fragment, [
+            div({ style: { padding: '1rem' } }, [
+              div({ style: { fontWeight: 600 } }, ['Search logic']),
+              div({ role: 'radiogroup', 'aria-label': 'please choose the operator for the advanced search' }, [
+                div({ style: { paddingTop: '0.5rem' } }, [
+                  h(RadioButton, {
+                    text: 'AND (rows with all terms)',
+                    name: 'advanced-search-operator',
+                    checked: useAndOperatorForSearch,
+                    onChange: () => setUseAndOperatorForSearch(true),
+                    labelStyle: { padding: '0.5rem', fontWeight: 'normal' }
+                  })
+                ]),
+                div({ style: { paddingTop: '0.5rem' } }, [
+                  h(RadioButton, {
+                    text: 'OR (rows with any term)',
+                    name: 'advanced-search-operator',
+                    checked: !useAndOperatorForSearch,
+                    onChange: () => setUseAndOperatorForSearch(false),
+                    labelStyle: { padding: '0.5rem', fontWeight: 'normal' }
+                  })
+                ])
+              ])
+            ])
+          ])
+        }, [h(ButtonSecondary, {
+          style: { margin: '0rem 1.5rem' }
+        }, [icon('bars', { style: { marginRight: '0.5rem' } }), 'Advanced search'])]),
         !snapshotName && div({ style: { width: 300 } }, [
           h(ConfirmedSearchInput, {
             'aria-label': 'Search',

--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -278,7 +278,7 @@ const DataTable = props => {
                   h(RadioButton, {
                     text: 'OR (rows with any term)',
                     name: 'advanced-search-operator',
-                    checked: filterOperator !== 'AND',
+                    checked: filterOperator === 'OR',
                     onChange: () => setFilterOperator('OR'),
                     labelStyle: { padding: '0.5rem', fontWeight: 'normal' }
                   })

--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -260,12 +260,11 @@ const DataTable = props => {
         isSearchAwesomeNow && h(MenuTrigger, {
           side: 'bottom',
           closeOnClick: false,
-          // Make the width of the dropdown menu match the width of the button.
           popupProps: { style: { width: 250 } },
           content: h(Fragment, [
             div({ style: { padding: '1rem' } }, [
               div({ style: { fontWeight: 600 } }, ['Search logic']),
-              div({ role: 'radiogroup', 'aria-label': 'please choose the operator for the advanced search' }, [
+              div({ role: 'radiogroup', 'aria-label': 'choose an operator to use for advanced search' }, [
                 div({ style: { paddingTop: '0.5rem' } }, [
                   h(RadioButton, {
                     text: 'AND (rows with all terms)',

--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -257,7 +257,7 @@ const DataTable = props => {
       }, [
         childrenBefore && childrenBefore({ entities, columnSettings, showColumnSettingsModal }),
         div({ style: { flexGrow: 1 } }),
-        isSearchAwesomeNow && h(MenuTrigger, {
+        isSearchAwesomeNow() && h(MenuTrigger, {
           side: 'bottom',
           closeOnClick: false,
           popupProps: { style: { width: 250 } },

--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -223,7 +223,7 @@ const DataTable = props => {
     if (persist) {
       StateHistory.update({ itemsPerPage, pageNumber, sort, activeTextFilter })
     }
-  }, [itemsPerPage, pageNumber, sort, activeTextFilter, activeCrossTableTextFilter, refreshKey]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [itemsPerPage, pageNumber, sort, activeTextFilter, activeCrossTableTextFilter, filterOperator, refreshKey]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (persist) {

--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -121,7 +121,7 @@ const DataTable = props => {
   const [deletingColumn, setDeletingColumn] = useState()
   const [clearingColumn, setClearingColumn] = useState()
 
-  const [useAndOperatorForSearch, setUseAndOperatorForSearch] = useState(true)
+  const [filterOperator, setFilterOperator] = useState('AND')
 
   const noEdit = Utils.editWorkspaceError(workspace)
 
@@ -138,7 +138,7 @@ const DataTable = props => {
         page: pageNumber, pageSize: itemsPerPage, sortField: sort.field, sortDirection: sort.direction,
         ...(!!snapshotName ?
           { billingProject: googleProject, dataReference: snapshotName } :
-          { filterTerms: activeCrossTableTextFilter || activeTextFilter, filterOperator: useAndOperatorForSearch ? 'and' : 'or' })
+          { filterTerms: activeCrossTableTextFilter || activeTextFilter, filterOperator })
       }))
     // Find all the unique attribute names contained in the current page of results.
     const attrNamesFromResults = _.uniq(_.flatMap(_.keys, _.map('attributes', results)))
@@ -221,9 +221,9 @@ const DataTable = props => {
   useEffect(() => {
     loadData()
     if (persist) {
-      StateHistory.update({ itemsPerPage, pageNumber, sort, activeTextFilter, useAndOperatorForSearch })
+      StateHistory.update({ itemsPerPage, pageNumber, sort, activeTextFilter })
     }
-  }, [itemsPerPage, pageNumber, sort, activeTextFilter, activeCrossTableTextFilter, useAndOperatorForSearch, refreshKey]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [itemsPerPage, pageNumber, sort, activeTextFilter, activeCrossTableTextFilter, refreshKey]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (persist) {
@@ -269,8 +269,8 @@ const DataTable = props => {
                   h(RadioButton, {
                     text: 'AND (rows with all terms)',
                     name: 'advanced-search-operator',
-                    checked: useAndOperatorForSearch,
-                    onChange: () => setUseAndOperatorForSearch(true),
+                    checked: filterOperator === 'AND',
+                    onChange: () => setFilterOperator('AND'),
                     labelStyle: { padding: '0.5rem', fontWeight: 'normal' }
                   })
                 ]),
@@ -278,8 +278,8 @@ const DataTable = props => {
                   h(RadioButton, {
                     text: 'OR (rows with any term)',
                     name: 'advanced-search-operator',
-                    checked: !useAndOperatorForSearch,
-                    onChange: () => setUseAndOperatorForSearch(false),
+                    checked: filterOperator !== 'AND',
+                    onChange: () => setFilterOperator('OR'),
                     labelStyle: { padding: '0.5rem', fontWeight: 'normal' }
                   })
                 ])


### PR DESCRIPTION
UI support for the new filter operators introduced in https://github.com/broadinstitute/rawls/pull/1795

Hidden behind a feature flag. Enable with `configOverridesStore.set({ isSearchAwesomeNow: true })`

<img width="602" alt="Screen Shot 2022-05-26 at 10 40 35 AM" src="https://user-images.githubusercontent.com/7257391/170511234-250f7378-eee1-4c36-9c5a-2c503f79bdb2.png">


<!--
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Also, so if a screen recording [1] and/or screenshots would be a helpful way to communicate context, please consider including some in your PR description.
Thanks!

[1] https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac
--!>
