### PR TITLE
[SUP-666] Added wordBreak: 'break-word' to the table cells.

### DIFF
--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -215,7 +215,7 @@ const Environments = () => {
   const getWorkspaceCell = (namespace, name, appType, shouldWarn) => {
     return !!name ?
       h(Fragment, [
-        h(Link, { href: Nav.getLink('workspace-dashboard', { namespace, name }) }, [name]),
+        h(Link, { href: Nav.getLink('workspace-dashboard', { namespace, name }), style: { wordBreak: 'break-word'} }, [name]),
         shouldWarn && h(TooltipTrigger, {
           content: `This workspace has multiple active cloud environments${forAppText(appType)}. Only the latest one will be used.`
         }, [icon('warning-standard', { style: { marginLeft: '0.25rem', color: colors.warning() } })])
@@ -347,7 +347,7 @@ const Environments = () => {
           {
             size: { basis: 250 },
             field: 'project',
-            headerRenderer: () => h(Sortable, { sort, field: 'project', onSort: setSort }, ['Billing project']),
+            headerRenderer: () => h(Sortable, { sort, field: 'project', onSort: setSort, }, ['Billing project']),
             cellRenderer: ({ rowIndex }) => {
               const { googleProject, labels: { saturnWorkspaceNamespace = googleProject } } = filteredCloudEnvironments[rowIndex]
               return saturnWorkspaceNamespace
@@ -356,6 +356,7 @@ const Environments = () => {
           {
             size: { basis: 250 },
             field: 'workspace',
+            style: { wordBreak: 'break-word' },
             headerRenderer: () => h(Sortable, { sort, field: 'workspace', onSort: setSort }, ['Workspace']),
             cellRenderer: ({ rowIndex }) => {
               const cloudEnvironment = filteredCloudEnvironments[rowIndex]
@@ -467,7 +468,7 @@ const Environments = () => {
               const multipleDisks = multipleDisksError(disksByProject[googleProject], appType)
               return !!saturnWorkspaceName ?
                 h(Fragment, [
-                  h(Link, { href: Nav.getLink('workspace-dashboard', { namespace: saturnWorkspaceNamespace, name: saturnWorkspaceName }) },
+                  h(Link, { href: Nav.getLink('workspace-dashboard', { namespace: saturnWorkspaceNamespace, name: saturnWorkspaceName }), style: { wordBreak: 'break-word' } },
                     [saturnWorkspaceName]),
                   diskStatus !== 'Deleting' && multipleDisks &&
                   h(TooltipTrigger, {

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -215,7 +215,7 @@ const Environments = () => {
   const getWorkspaceCell = (namespace, name, appType, shouldWarn) => {
     return !!name ?
       h(Fragment, [
-        h(Link, { href: Nav.getLink('workspace-dashboard', { namespace, name }), style: { wordBreak: 'break-word'} }, [name]),
+        h(Link, { href: Nav.getLink('workspace-dashboard', { namespace, name }), style: { wordBreak: 'break-word' } }, [name]),
         shouldWarn && h(TooltipTrigger, {
           content: `This workspace has multiple active cloud environments${forAppText(appType)}. Only the latest one will be used.`
         }, [icon('warning-standard', { style: { marginLeft: '0.25rem', color: colors.warning() } })])
@@ -347,7 +347,7 @@ const Environments = () => {
           {
             size: { basis: 250 },
             field: 'project',
-            headerRenderer: () => h(Sortable, { sort, field: 'project', onSort: setSort, }, ['Billing project']),
+            headerRenderer: () => h(Sortable, { sort, field: 'project', onSort: setSort }, ['Billing project']),
             cellRenderer: ({ rowIndex }) => {
               const { googleProject, labels: { saturnWorkspaceNamespace = googleProject } } = filteredCloudEnvironments[rowIndex]
               return saturnWorkspaceNamespace
@@ -356,7 +356,6 @@ const Environments = () => {
           {
             size: { basis: 250 },
             field: 'workspace',
-            style: { wordBreak: 'break-word' },
             headerRenderer: () => h(Sortable, { sort, field: 'workspace', onSort: setSort }, ['Workspace']),
             cellRenderer: ({ rowIndex }) => {
               const cloudEnvironment = filteredCloudEnvironments[rowIndex]


### PR DESCRIPTION
## Description

Workspace names wouldn't overflow when underscores were used.

## Solution

Add word break specifically to the workspace cells.

## Testing

See screenshot

Added very long workspace name using underscores in both tables.



![Screen Shot 2022-05-26 at 2 56 10 PM](https://user-images.githubusercontent.com/11773357/170557462-384ece53-73e8-4a25-8d07-eacef3912d26.png)
 