### PR TITLE
[SU-121] Fix alignment of menu buttons in data tab sidebar

### DIFF
--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -89,7 +89,7 @@ const DataTypeButton = ({ selected, entityName, children, entityCount, iconName 
     role: 'listitem'
   }, [
     h(Clickable, {
-      style: { flex: '1 1 auto', maxWidth: '100%', ...Style.navList.item(selected), color: colors.accent(1.2), ...buttonStyle },
+      style: { ...Style.navList.item(selected), flex: '1 1 auto', minWidth: 0, color: colors.accent(1.2), ...buttonStyle },
       ...(isEntity ? {
         tooltip: entityName ? `${entityName} (${entityCount} row${entityCount === 1 ? '' : 's'}${activeCrossTableTextFilter ? `, ${filteredCount} visible` : ''})` : undefined,
         tooltipDelay: 250,
@@ -100,15 +100,15 @@ const DataTypeButton = ({ selected, entityName, children, entityCount, iconName 
     }, [
       activeCrossTableTextFilter !== '' && isEntity ?
         SearchResultsPill({ filteredCount, searching: crossTableSearchInProgress }) :
-        div({ style: { flex: 'none', display: 'flex', width: '1.5rem' } }, [
+        div({ style: { flex: 'none', width: '1.5rem' } }, [
           icon(iconName, { size: iconSize })
         ]),
-      div({ style: { flex: isDataTabRedesignEnabled() ? '0 1 content' : 1, ...Style.noWrapEllipsis } }, [
+      div({ style: { ...Style.noWrapEllipsis } }, [
         entityName || children
       ]),
-      isEntity && div({ style: { flex: 0, paddingLeft: '0.5em' } }, `(${entityCount})`)
+      isEntity && div({ style: { marginLeft: '1ch' } }, `(${entityCount})`)
     ]),
-    after
+    after && div({ style: { marginLeft: '1ch' } }, [after])
   ])
 }
 


### PR DESCRIPTION
This applies to the new data tab design (enable with `window.configOverridesStore.set({ isDataTabRedesignEnabled: true })`). Currently, long table names push the table menu buttons out of alignment.

After some failed attempts to fix this, I discovered `min-width: 0` is the key to truncating the text as desired here. See https://css-tricks.com/flexbox-truncated-text/ for more information.

This also tidies up some unnecessary styles and ensures there's some spacing between elements.

## Before
<img width="285" alt="Screen Shot 2022-05-26 at 5 38 33 PM" src="https://user-images.githubusercontent.com/1156625/171182336-399fc746-c484-4bef-b003-4519ffd3a06c.png">

## After
![Screen Shot 2022-05-31 at 9 14 40 AM](https://user-images.githubusercontent.com/1156625/171182354-c79fc742-c67d-4b6c-b31b-9281599e3f89.png)

