### PR TITLE
[SU-94] Don't show search pill in sidebar when filter is undefined

### DIFF
--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -98,7 +98,7 @@ const DataTypeButton = ({ selected, entityName, children, entityCount, iconName 
       'aria-current': selected,
       ...props
     }, [
-      activeCrossTableTextFilter !== '' && isEntity ?
+      activeCrossTableTextFilter !== '' && activeCrossTableTextFilter !== undefined && isEntity ?
         SearchResultsPill({ filteredCount, searching: crossTableSearchInProgress }) :
         div({ style: { flex: 'none', display: 'flex', width: '1.5rem' } }, [
           icon(iconName, { size: iconSize })

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -98,7 +98,7 @@ const DataTypeButton = ({ selected, entityName, children, entityCount, iconName 
       'aria-current': selected,
       ...props
     }, [
-      activeCrossTableTextFilter !== '' && activeCrossTableTextFilter !== undefined && isEntity ?
+      activeCrossTableTextFilter && isEntity ?
         SearchResultsPill({ filteredCount, searching: crossTableSearchInProgress }) :
         div({ style: { flex: 'none', display: 'flex', width: '1.5rem' } }, [
           icon(iconName, { size: iconSize })


### PR DESCRIPTION
No longer visible in old data tab:
<img width="285" alt="Screen Shot 2022-05-31 at 11 19 21 AM" src="https://user-images.githubusercontent.com/7257391/171209605-35b178a1-ee16-4ea7-ac69-3afd5cde4a43.png">

Not visible in new data tab with an active search:
<img width="306" alt="Screen Shot 2022-05-31 at 11 19 43 AM" src="https://user-images.githubusercontent.com/7257391/171209617-de9fe914-d2db-42ed-89d2-570d9ad1582c.png">

