### PR TITLE
[QA-1825] Terra UI find-workflow test failure due to flaky signIntoFirecloud function

### DIFF
--- a/integration-tests/utils/firecloud-utils.js
+++ b/integration-tests/utils/firecloud-utils.js
@@ -39,7 +39,8 @@ const signIntoFirecloud = async (page, token) => {
   await page.evaluate(token => window.forceSignedIn(token), token)
 
   // Check whether redirect happened automatically after forceSignedIn
-  const pageRedirected = page => {
+  const pageRedirected = async page => {
+    await page.waitForTimeout(500)
     return Promise.all([
       page.waitForFunction(url => {
         return window.location.href !== url
@@ -48,11 +49,10 @@ const signIntoFirecloud = async (page, token) => {
     ])
   }
 
-  await page.waitForTimeout(1000)
   try {
     await pageRedirected(page)
   } catch (err) {
-    console.log(`Retry Firecloud forceSignedIn because page redirect did not happen`)
+    console.warn(`Retry forceSignedIn because page redirect did not happen`)
     await page.evaluate(token => window.forceSignedIn(token), token)
     await pageRedirected(page)
   }

--- a/integration-tests/utils/firecloud-utils.js
+++ b/integration-tests/utils/firecloud-utils.js
@@ -39,9 +39,9 @@ const signIntoFirecloud = async (page, token) => {
   await page.evaluate(token => window.forceSignedIn(token), token)
 
   // Check whether redirect happened automatically after forceSignedIn
-  const pageRedirected = async page => {
+  const redirect = async page => {
     await page.waitForTimeout(500)
-    return Promise.all([
+    await Promise.all([
       page.waitForFunction(url => {
         return window.location.href !== url
       }, {}, signInPageUrl),
@@ -50,11 +50,11 @@ const signIntoFirecloud = async (page, token) => {
   }
 
   try {
-    await pageRedirected(page)
+    await redirect(page)
   } catch (err) {
     console.warn(`Retry forceSignedIn because page redirect did not happen`)
     await page.evaluate(token => window.forceSignedIn(token), token)
-    await pageRedirected(page)
+    await redirect(page)
   }
 }
 


### PR DESCRIPTION
Address an issue with integration test `signIntoFirecloud` function: log into Firecloud continues to fail randomly after [terra-ui/pull/3036](https://github.com/DataBiosphere/terra-ui/pull/3036).

Because `signIntoFirecloud` function is in deprecated Firecloud UI and used for automation tests only, I'm going to provide a workaround in test code instead of asking someone to fix the problematic function.

https://broadworkbench.atlassian.net/browse/QA-1825

CircleCI failed [job](https://app.circleci.com/pipelines/github/DataBiosphere/terra-ui/9807/workflows/338e7ccb-db53-4932-9b1d-baef95c6a9d6).

Error:

```
Test: find-workflow
Status: failed
Failure message: TimeoutError: waiting for XPath `//*[contains(normalize-space(.),"echo_to_file")]` failed: timeout 30000ms exceeded
```

Tested in CircleCI, retry has prevented false failure ([integration-tests-staging](https://app.circleci.com/pipelines/github/DataBiosphere/terra-ui/9841/workflows/4755d656-0c04-412e-a1c9-1d80560da705))

```
Retry Firecloud forceSignedIn
page.http GET	200  https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=ya29.a0ARrdaM8VJkelPW3noVS8u0S8h1CVmFr9hYsDVaxPGZohY7x-lav6auZV8elKFdS0kTfVQMyTLorkKRQoVheD6ZtPTI429Jhja_WExb5DWNPeI049vClC0n6Z0pKIFwRwbckmeY7964JAVRbb7OTJlKM3dYYan90-ijnJqpvb4pSiXpdgwPrB9j44rQMuzb5Ab1zwu4OZE32tLp8
page.console ConsoleMessage {
  _type: 'warning',
  _text: 'force-signed-in: <true> {\n' +
    '  "azp": "115856234180227002025",\n' +
    '  "aud": "115856234180227002025",\n' +
    '  "sub": "114925642006220098835",\n' +
    '  "scope": "https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email openid",\n' +
    '  "exp": "1654049988",\n' +
    '  "expires_in": "3548",\n' +
    '  "email": "scarlett.flowerpicker@test.firecloud.org",\n' +
    '  "email_verified": "true",\n' +
    '  "access_type": "offline"\n' +
    '}\n',
  _args: [
    JSHandle {
      _disposed: false,
      _context: [ExecutionContext],
      _client: [CDPSession],
      _remoteObject: [Object]
    }
  ],
  _stackTraceLocations: [
    {
      url: 'https://firecloud.dsde-alpha.broadinstitute.org/base-deps.bundle.js?t=1652471276059',
      lineNumber: 69,
      columnNumber: 2839545
    },
    {
      url: 'https://firecloud.dsde-alpha.broadinstitute.org/base-deps.bundle.js?t=1652471276059',
      lineNumber: 69,
      columnNumber: 1692133
    }
  ]
}
page.http OPTIONS	204  https://firecloud-orchestration.dsde-alpha.broadinstitute.org/register/profile
page.http GET	200  https://firecloud-orchestration.dsde-alpha.broadinstitute.org/register/profile
page.http OPTIONS	204  https://sam.dsde-alpha.broadinstitute.org/register/user/v1/termsofservice/status
page.http GET	200  https://storage.googleapis.com/firecloud-alerts-alpha/trial.json
page.http GET	200  https://sam.dsde-alpha.broadinstitute.org/register/user/v1/termsofservice/status
page.http GET	404  https://firecloud-orchestration.dsde-alpha.broadinstitute.org/api/nih/status
page.console ConsoleMessage {
  _type: 'error',
  _text: 'Failed to load resource: the server responded with a status of 404 ()',
  _args: [],
  _stackTraceLocations: [
    {
      url: 'https://firecloud-orchestration.dsde-alpha.broadinstitute.org/api/nih/status',
      lineNumber: undefined
    }
  ]
}
page.http OPTIONS	204  https://firecloud-orchestration.dsde-alpha.broadinstitute.org/api/methods?namespace=gatk&name=echo_to_file
page.http GET	200  https://firecloud-orchestration.dsde-alpha.broadinstitute.org/api/methods?namespace=gatk&name=echo_to_file
page.http OPTIONS	204  https://firecloud-orchestration.dsde-alpha.broadinstitute.org/api/methods/gatk/echo_to_file/9
page.http GET	200  https://firecloud-orchestration.dsde-alpha.broadinstitute.org/api/methods/gatk/echo_to_file/9
page.http OPTIONS	204  https://firecloud-orchestration.dsde-alpha.broadinstitute.org/api/methods/gatk/echo_to_file/configurations
page.http OPTIONS	204  https://firecloud-orchestration.dsde-alpha.broadinstitute.org/api/methods/gatk/echo_to_file/9/configurations
page.http GET	200  https://firecloud-orchestration.dsde-alpha.broadinstitute.org/api/methods/gatk/echo_to_file/configurations
page.http GET	200  https://firecloud-orchestration.dsde-alpha.broadinstitute.org/api/methods/gatk/echo_to_file/9/configurations
page.http OPTIONS	204  https://firecloud-orchestration.dsde-alpha.broadinstitute.org/api/configurations/gatk/echo_to_file-configured/1?payloadAsObject=true
page.http GET	200  https://firecloud-orchestration.dsde-alpha.broadinstitute.org/api/configurations/gatk/echo_to_file-configured/1?payloadAsObject=true
page.http OPTIONS	204  https://firecloud-orchestration.dsde-alpha.broadinstitute.org/api/inputsOutputs
page.http OPTIONS	204  https://firecloud-orchestration.dsde-alpha.broadinstitute.org/api/workspaces
page.http GET	200  https://firecloud-orchestration.dsde-alpha.broadinstitute.org/api/workspaces
page.http OPTIONS	204  https://firecloud-orchestration.dsde-alpha.broadinstitute.org/api/profile/billing
page.http OPTIONS	204  https://firecloud-orchestration.dsde-alpha.broadinstitute.org/api/groups
page.http POST	200  https://firecloud-orchestration.dsde-alpha.broadinstitute.org/api/inputsOutputs
page.http GET	200  https://firecloud-orchestration.dsde-alpha.broadinstitute.org/api/groups
page.http OPTIONS	204  https://firecloud-orchestration.dsde-alpha.broadinstitute.org/api/workspaces/saturn-integration-test-alpha/terra-ui-test-workspace-e8509e6c-f1d3-4cc0-a618-0606b3cb38bf/methodconfigs
page.http GET	200  https://firecloud-orchestration.dsde-alpha.broadinstitute.org/api/profile/billing


Tests Summary
----------------------------------------------
Test: find-workflow
Status: passed
```