### PR TITLE
[SU-91] Enable data tab redesign

### DIFF
--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -12,7 +12,7 @@ import { MenuButton, MenuTrigger } from 'src/components/PopupTrigger'
 import { GridTable, HeaderCell, paginator, Resizable } from 'src/components/table'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
-import { isDataTabRedesignEnabled, isSearchAwesomeNow } from 'src/libs/config'
+import { isSearchAwesomeNow } from 'src/libs/config'
 import { withErrorReporting } from 'src/libs/error'
 import Events, { extractWorkspaceDetails } from 'src/libs/events'
 import { getLocalPref, setLocalPref } from 'src/libs/prefs'
@@ -301,9 +301,7 @@ const DataTable = props => {
           })
         ])
       ]),
-      div({
-        style: { flex: 1, margin: isDataTabRedesignEnabled() ? 0 : '0 1rem' }
-      }, [
+      div({ style: { flex: 1 } }, [
         h(AutoSizer, [
           ({ width, height }) => {
             return h(GridTable, {

--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -3,14 +3,14 @@ import FileSaver from 'file-saver'
 import JSZip from 'jszip'
 import _ from 'lodash/fp'
 import * as qs from 'qs'
-import { Fragment, useRef, useState } from 'react'
-import { div, form, h, input } from 'react-hyperscript-helpers'
+import { Fragment, useState } from 'react'
+import { div, h } from 'react-hyperscript-helpers'
 import { requesterPaysWrapper, withRequesterPaysHandler } from 'src/components/bucket-utils'
-import { ButtonPrimary, ButtonSecondary, Link } from 'src/components/common'
+import { ButtonSecondary } from 'src/components/common'
 import { AddColumnModal, AddEntityModal, CreateEntitySetModal, EntityDeleter, ModalToolButton, MultipleEntityEditor, saveScroll } from 'src/components/data/data-utils'
 import DataTable from 'src/components/data/DataTable'
 import ExportDataModal from 'src/components/data/ExportDataModal'
-import { icon, spinner } from 'src/components/icons'
+import { icon } from 'src/components/icons'
 import IGVBrowser from 'src/components/IGVBrowser'
 import IGVFileSelector from 'src/components/IGVFileSelector'
 import { withModalDrawer } from 'src/components/ModalDrawer'
@@ -24,9 +24,7 @@ import igvLogo from 'src/images/igv-logo.png'
 import jupyterLogo from 'src/images/jupyter-logo.svg'
 import wdlLogo from 'src/images/wdl-logo.png'
 import { Ajax } from 'src/libs/ajax'
-import { getUser } from 'src/libs/auth'
 import colors from 'src/libs/colors'
-import { getConfig, isDataTabRedesignEnabled } from 'src/libs/config'
 import { withErrorReporting } from 'src/libs/error'
 import Events, { extractWorkspaceDetails } from 'src/libs/events'
 import * as Nav from 'src/libs/nav'
@@ -227,42 +225,6 @@ const EntitiesContent = ({
   const [igvFiles, setIgvFiles] = useState(undefined)
   const [igvRefGenome, setIgvRefGenome] = useState('')
 
-  const downloadForm = useRef()
-
-  // Render helpers
-  const renderDownloadButton = columnSettings => {
-    const disabled = entityKey.endsWith('_set_set')
-    return h(Fragment, [
-      form({
-        ref: downloadForm,
-        action: `${getConfig().orchestrationUrlRoot}/cookie-authed/workspaces/${namespace}/${name}/entities/${entityKey}/tsv`,
-        method: 'POST'
-      }, [
-        input({ type: 'hidden', name: 'FCtoken', value: getUser().token }),
-        input({ type: 'hidden', name: 'attributeNames', value: _.map('name', _.filter('visible', columnSettings)).join(',') }),
-        input({ type: 'hidden', name: 'model', value: 'flexible' })
-      ]),
-      h(ButtonPrimary, {
-        style: { marginRight: '1rem' },
-        disabled,
-        tooltip: disabled ?
-          'Downloading sets of sets as TSV is not supported at this time' :
-          `Download a .tsv file containing all the ${entityKey}s in this table`,
-        onClick: () => {
-          downloadForm.current.submit()
-          Ajax().Metrics.captureEvent(Events.workspaceDataDownload, {
-            ...extractWorkspaceDetails(workspace.workspace),
-            downloadFrom: 'all rows',
-            fileType: '.tsv'
-          })
-        }
-      }, [
-        icon('download', { style: { marginRight: '0.5rem' } }),
-        'Download all Rows'
-      ])
-    ])
-  }
-
   const buildTSV = (columnSettings, entities) => {
     const sortedEntities = _.sortBy('name', entities)
     const isSet = _.endsWith('_set', entityKey)
@@ -309,66 +271,6 @@ const EntitiesContent = ({
       downloadFrom: 'table data',
       fileType: '.tsv'
     })
-  }
-
-  const renderCopyButton = (entities, columnSettings) => {
-    return h(Fragment, [
-      h(ButtonPrimary, {
-        style: { marginRight: '1rem' },
-        tooltip: `Copy only the ${entityKey}s visible on the current page to the clipboard in .tsv format`,
-        onClick: _.flow(
-          withErrorReporting('Error copying to clipboard'),
-          Utils.withBusyState(setNowCopying)
-        )(async () => {
-          const str = buildTSV(columnSettings, entities)
-          await clipboard.writeText(str)
-          notify('success', 'Successfully copied to clipboard', { timeout: 3000 })
-        })
-      }, [
-        icon('copy-to-clipboard', { style: { marginRight: '0.5rem' } }),
-        'Copy Page to Clipboard'
-      ]),
-      nowCopying && spinner()
-    ])
-  }
-
-  const renderSelectedRowsMenu = columnSettings => {
-    const noEdit = Utils.editWorkspaceError(workspace)
-    const disabled = entityKey.endsWith('_set_set')
-
-    return !_.isEmpty(selectedEntities) && h(MenuTrigger, {
-      side: 'bottom',
-      closeOnClick: true,
-      content: h(Fragment, [
-        h(MenuButton, {
-          disabled,
-          tooltip: disabled ?
-            'Downloading sets of sets as TSV is not supported at this time' :
-            `Download the selected data as a file`,
-          onClick: () => downloadSelectedRows(columnSettings)
-        }, ['Download as TSV']),
-        !snapshotName && h(MenuButton, {
-          disabled: noEdit,
-          tooltip: noEdit ? 'You don\'t have permission to modify this workspace.' : 'Edit a field of the selected rows',
-          onClick: () => setEditingEntities(true)
-        }, ['Edit']),
-        !snapshotName && h(MenuButton, {
-          tooltip: 'Open the selected data to work with it',
-          onClick: () => setShowToolSelector(true)
-        }, ['Open with...']),
-        !snapshotName && h(MenuButton, {
-          tooltip: 'Send the selected data to another workspace',
-          onClick: () => setCopyingEntities(true)
-        }, ['Export to Workspace']),
-        !snapshotName && h(MenuButton, {
-          tooltip: noEdit ? 'You don\'t have permission to modify this workspace' : 'Permanently delete the selected data',
-          disabled: noEdit,
-          onClick: () => setDeletingEntities(true)
-        }, ['Delete Data'])
-      ])
-    }, [h(Link, { style: { marginRight: '1rem' } }, [
-      icon('ellipsis-v-circle', { size: 24, 'aria-label': 'selection menu' })
-    ])])
   }
 
   const entitiesSelected = !_.isEmpty(selectedEntities)
@@ -479,41 +381,27 @@ const EntitiesContent = ({
           selected: selectedEntities,
           setSelected: setSelectedEntities
         },
-        childrenBefore: ({ entities, columnSettings, showColumnSettingsModal }) => div({ style: { display: 'flex', alignItems: 'center', flex: 'none' } },
-          isDataTabRedesignEnabled() ? [
-            renderEditMenu(),
-            renderOpenWithMenu(),
-            renderExportMenu({ columnSettings }),
-            !snapshotName && h(ButtonSecondary, {
-              onClick: showColumnSettingsModal,
-              disabled: !!activeCrossTableTextFilter
-            }, [icon('cog', { style: { marginRight: '0.5rem' } }), 'Settings']),
-            div({ style: { margin: '0 1.5rem', height: '100%', borderLeft: Style.standardLine } }),
-            div({
-              role: 'status',
-              'aria-atomic': true,
-              style: { marginRight: '0.5rem' }
-            }, [`${selectedLength} row${selectedLength === 1 ? '' : 's'} selected`])
-          ] : [
-            !snapshotName && renderDownloadButton(columnSettings),
-            !_.endsWith('_set', entityKey) && renderCopyButton(entities, columnSettings),
-            !snapshotName && h(ButtonPrimary, {
-              onClick: showColumnSettingsModal
-            }, [icon('cog', { style: { marginRight: '0.5rem' } }), 'Settings']),
-            div({ style: { margin: '0 1.5rem', height: '100%', borderLeft: Style.standardLine } }),
-            div({
-              role: 'status',
-              'aria-atomic': true,
-              style: { marginRight: '0.5rem' }
-            }, [`${selectedLength} row${selectedLength === 1 ? '' : 's'} selected`]),
-            renderSelectedRowsMenu(columnSettings)
-          ]),
+        childrenBefore: ({ columnSettings, showColumnSettingsModal }) => div({ style: { display: 'flex', alignItems: 'center', flex: 'none' } }, [
+          renderEditMenu(),
+          renderOpenWithMenu(),
+          renderExportMenu({ columnSettings }),
+          !snapshotName && h(ButtonSecondary, {
+            onClick: showColumnSettingsModal,
+            disabled: !!activeCrossTableTextFilter
+          }, [icon('cog', { style: { marginRight: '0.5rem' } }), 'Settings']),
+          div({ style: { margin: '0 1.5rem', height: '100%', borderLeft: Style.standardLine } }),
+          div({
+            role: 'status',
+            'aria-atomic': true,
+            style: { marginRight: '0.5rem' }
+          }, [`${selectedLength} row${selectedLength === 1 ? '' : 's'} selected`])
+        ]),
         deleteColumnUpdateMetadata,
-        controlPanelStyle: isDataTabRedesignEnabled() ? {
+        controlPanelStyle: {
           background: colors.light(),
           borderBottom: `1px solid ${colors.grey(0.4)}`
-        } : {},
-        border: !isDataTabRedesignEnabled()
+        },
+        border: false
       }),
       addingEntity && h(AddEntityModal, {
         entityType: entityKey,

--- a/src/components/data/LocalVariablesContent.js
+++ b/src/components/data/LocalVariablesContent.js
@@ -12,7 +12,6 @@ import { DelayedSearchInput, TextInput } from 'src/components/input'
 import { FlexTable, HeaderCell } from 'src/components/table'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
-import { isDataTabRedesignEnabled } from 'src/libs/config'
 import { withErrorReporting } from 'src/libs/error'
 import { useCancellation } from 'src/libs/react-utils'
 import * as StateHistory from 'src/libs/state-history'
@@ -157,8 +156,8 @@ const LocalVariablesContent = ({ workspace, workspace: { workspace: { googleProj
       style: {
         flex: 'none', display: 'flex', alignItems: 'center', justifyContent: 'flex-end',
         padding: '1rem',
-        background: isDataTabRedesignEnabled() ? colors.light() : undefined,
-        borderBottom: isDataTabRedesignEnabled() ? `1px solid ${colors.grey(0.4)}` : undefined
+        background: colors.light(),
+        borderBottom: `1px solid ${colors.grey(0.4)}`
       }
     }, [
       h(Link, { onClick: download }, ['Download TSV']),
@@ -174,7 +173,7 @@ const LocalVariablesContent = ({ workspace, workspace: { workspace: { googleProj
         value: textFilter
       })
     ]),
-    div({ style: { flex: 1, margin: isDataTabRedesignEnabled() ? '0 0 1rem' : '0 1rem 1rem' } }, [
+    div({ style: { flex: 1, margin: '0 0 1rem' } }, [
       h(AutoSizer, [({ width, height }) => h(FlexTable, {
         'aria-label': 'workspace data local variables table',
         width, height, rowCount: amendedAttributes.length,
@@ -182,7 +181,7 @@ const LocalVariablesContent = ({ workspace, workspace: { workspace: { googleProj
         initialY,
         hoverHighlight: true,
         noContentMessage: _.isEmpty(initialAttributes) ? 'No Workspace Data defined' : 'No matching data',
-        border: !isDataTabRedesignEnabled(),
+        border: false,
         columns: [{
           size: { basis: 400, grow: 0 },
           headerRenderer: () => h(HeaderCell, ['Key']),

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -13,7 +13,6 @@ import Interactive from 'src/components/Interactive'
 import Modal from 'src/components/Modal'
 import TooltipTrigger from 'src/components/TooltipTrigger'
 import colors from 'src/libs/colors'
-import { isDataTabRedesignEnabled } from 'src/libs/config'
 import { forwardRefWithName, useLabelAssert, useOnMount } from 'src/libs/react-utils'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
@@ -627,7 +626,7 @@ export const TooltipCell = ({ children, tooltip, ...props }) => h(TooltipTrigger
 }, [h(TextCell, props, [children])])
 
 export const HeaderCell = props => {
-  return h(TextCell, _.merge({ style: { fontWeight: isDataTabRedesignEnabled() ? 600 : 500 } }, props))
+  return h(TextCell, _.merge({ style: { fontWeight: 600 } }, props))
 }
 
 export const Sortable = ({ sort, field, onSort, children }) => {

--- a/src/libs/config.js
+++ b/src/libs/config.js
@@ -13,7 +13,6 @@ export const isAnalysisTabVisible = () => getConfig().isAnalysisTabVisible
 export const isCromwellAppVisible = () => getConfig().isCromwellAppVisible
 // configOverridesStore.set({ isDataBrowserVisible: true }) in browser console to enable
 export const isDataBrowserVisible = () => getConfig().isDataBrowserVisible
-export const isDataTabRedesignEnabled = () => getConfig().isDataTabRedesignEnabled || getConfig().isSearchAwesomeNow
 export const isSearchAwesomeNow = () => getConfig().isSearchAwesomeNow
 export const isBaseline = () => (window.location.hostname === 'baseline.terra.bio') || getConfig().isBaseline
 export const isBioDataCatalyst = () => (window.location.hostname.endsWith('.biodatacatalyst.nhlbi.nih.gov')) || getConfig().isBioDataCatalyst

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -27,7 +27,7 @@ import { SnapshotInfo } from 'src/components/workspace-utils'
 import { Ajax } from 'src/libs/ajax'
 import { getUser } from 'src/libs/auth'
 import colors from 'src/libs/colors'
-import { getConfig, isDataTabRedesignEnabled, isSearchAwesomeNow } from 'src/libs/config'
+import { getConfig, isSearchAwesomeNow } from 'src/libs/config'
 import { reportError, withErrorReporting } from 'src/libs/error'
 import Events, { extractWorkspaceDetails } from 'src/libs/events'
 import * as Nav from 'src/libs/nav'
@@ -145,8 +145,8 @@ const ReferenceDataContent = ({ workspace: { workspace: { googleProject, attribu
       style: {
         display: 'flex', justifyContent: 'flex-end',
         padding: '1rem',
-        background: isDataTabRedesignEnabled() ? colors.light() : undefined,
-        borderBottom: isDataTabRedesignEnabled() ? `1px solid ${colors.grey(0.4)}` : undefined
+        background: colors.light(),
+        borderBottom: `1px solid ${colors.grey(0.4)}`
       }
     }, [
       h(DelayedSearchInput, {
@@ -157,7 +157,7 @@ const ReferenceDataContent = ({ workspace: { workspace: { googleProject, attribu
         value: textFilter
       })
     ]),
-    div({ style: { flex: 1, margin: isDataTabRedesignEnabled() ? '0 0 1rem' : '0 1rem 1rem' } }, [
+    div({ style: { flex: 1, margin: '0 0 1rem' } }, [
       h(AutoSizer, [
         ({ width, height }) => h(FlexTable, {
           'aria-label': 'reference data',
@@ -177,7 +177,7 @@ const ReferenceDataContent = ({ workspace: { workspace: { googleProject, attribu
               cellRenderer: ({ rowIndex }) => renderDataCell(selectedData[rowIndex].value, googleProject)
             }
           ],
-          border: !isDataTabRedesignEnabled()
+          border: false
         })
       ])
     ])
@@ -381,23 +381,7 @@ const BucketContent = _.flow(
   ])])
 })
 
-const DataTypeSection = ({ title, titleExtras, error, retryFunction, children }) => {
-  if (!isDataTabRedesignEnabled()) {
-    return div({ role: 'listitem' }, [
-      h3({ style: Style.navList.heading }, [
-        title,
-        error ? h(Link, {
-          onClick: retryFunction,
-          tooltip: 'Error loading, click to retry.'
-        }, [icon('sync', { size: 18 })]) : titleExtras
-      ]),
-      !!children?.length && div({
-        style: { display: 'flex', flexDirection: 'column', width: '100%' },
-        role: 'list'
-      }, [children])
-    ])
-  }
-
+const DataTypeSection = ({ title, error, retryFunction, children }) => {
   return h(Collapse, {
     role: 'listitem',
     title: h3({
@@ -466,7 +450,7 @@ const SidebarSeparator = ({ sidebarWidth, setSidebarWidth }) => {
       className: 'custom-focus-style',
       style: {
         ...styles.sidebarSeparator,
-        background: isDataTabRedesignEnabled() ? colors.grey(0.4) : colors.light()
+        background: colors.grey(0.4)
       },
       hover: {
         background: colors.accent(1.2)
@@ -724,7 +708,7 @@ const WorkspaceData = _.flow(
   return div({ style: styles.tableContainer }, [
     !entityMetadata ? spinnerOverlay : h(Fragment, [
       div({ style: { ...styles.sidebarContainer, width: sidebarWidth } }, [
-        isDataTabRedesignEnabled() && div({
+        div({
           style: {
             display: 'flex', padding: '1rem 1.5rem',
             backgroundColor: colors.light(),
@@ -759,12 +743,6 @@ const WorkspaceData = _.flow(
           div({ role: 'list' }, [
             h(DataTypeSection, {
               title: 'Tables',
-              titleExtras: isDataTabRedesignEnabled() ? null : h(Link, {
-                disabled: !!Utils.editWorkspaceError(workspace),
-                tooltip: Utils.editWorkspaceError(workspace) || 'Upload .tsv',
-                onClick: () => setUploadingFile(true),
-                'aria-haspopup': 'dialog'
-              }, [icon('plus-circle', { size: 21 })]),
               error: entityMetadataError,
               retryFunction: loadEntityMetadata
             }, [
@@ -797,7 +775,7 @@ const WorkspaceData = _.flow(
                     setSelectedDataType(type)
                     forceRefresh()
                   },
-                  after: isDataTabRedesignEnabled() && h(DataTableActions, {
+                  after: h(DataTableActions, {
                     tableName: type,
                     rowCount: typeDetails.count,
                     workspace,
@@ -881,13 +859,7 @@ const WorkspaceData = _.flow(
               }, sortedSnapshotPairs)
             ]),
             h(DataTypeSection, {
-              title: 'Reference Data',
-              titleExtras: isDataTabRedesignEnabled() ? null : h(Link, {
-                disabled: !!Utils.editWorkspaceError(workspace),
-                tooltip: Utils.editWorkspaceError(workspace) || 'Add reference data',
-                onClick: () => setImportingReference(true),
-                'aria-haspopup': 'dialog'
-              }, [icon('plus-circle', { size: 21 })])
+              title: 'Reference Data'
             }, [_.map(type => h(DataTypeButton, {
               key: type,
               selected: selectedDataType === type,


### PR DESCRIPTION
Remove the feature flag for the data tab redesign and enable it for all users.

We're coordinating with the User Education team and currently plan to release this on Thursday.

## Before
![Screen Shot 2022-05-31 at 2 15 33 PM](https://user-images.githubusercontent.com/1156625/171257199-b98a1694-b888-4588-80ad-c3b7a5944e34.png)

## After
![Screen Shot 2022-05-31 at 2 15 12 PM](https://user-images.githubusercontent.com/1156625/171257198-93420c6e-5024-4588-9fad-015f72e19d94.png)


