### PR TITLE
[QA-1895] Integration test: speculative fix for navigation timeout error

### DIFF
--- a/integration-tests/tests/billing-projects.js
+++ b/integration-tests/tests/billing-projects.js
@@ -1,6 +1,6 @@
 // This test is owned by the Workspaces Team.
 const _ = require('lodash/fp')
-const { assertTextNotFound, click, clickable, findText, noSpinnersAfter, select, signIntoTerra, waitForNoSpinners } = require('../utils/integration-utils')
+const { assertTextNotFound, click, clickable, findText, gotoPage, noSpinnersAfter, select, signIntoTerra, waitForNoSpinners } = require('../utils/integration-utils')
 const { registerTest } = require('../utils/jest-utils')
 const { withUserToken } = require('../utils/terra-sa-utils')
 
@@ -10,7 +10,7 @@ const billingProjectsPage = (testPage, testUrl) => {
     visit: async () => {
       // Note: not using noSpinnersAfter because this action changes the page, and
       // noSpinners after checks that a spinner appears and disappear within the same page.
-      await testPage.goto(`${testUrl}/#billing`)
+      await gotoPage(testPage, `${testUrl}/#billing`)
       await findText(testPage, 'Select a Billing Project')
       await waitForNoSpinners(testPage)
     },

--- a/integration-tests/tests/find-workflow.js
+++ b/integration-tests/tests/find-workflow.js
@@ -1,7 +1,7 @@
 const _ = require('lodash/fp')
 const firecloud = require('../utils/firecloud-utils')
 const { withWorkspace } = require('../utils/integration-helpers')
-const { click, clickable, findElement, findText, signIntoTerra } = require('../utils/integration-utils')
+const { click, clickable, findElement, findText, gotoPage, signIntoTerra } = require('../utils/integration-utils')
 const { registerTest } = require('../utils/jest-utils')
 const { withUserToken } = require('../utils/terra-sa-utils')
 
@@ -35,7 +35,7 @@ const testFindWorkflowFn = _.flow(
       const redirectURL = (await page.evaluate(yesButton => yesButton.textContent, yesButtonHrefDetails)).replace(
         'https://bvdp-saturn-dev.appspot.com',
         testUrl)
-      await page.goto(redirectURL)
+      await gotoPage(page, redirectURL)
     } else {
       await click(page, clickable({ textContains: 'Yes' }))
     }

--- a/integration-tests/tests/register-user.js
+++ b/integration-tests/tests/register-user.js
@@ -1,12 +1,11 @@
 const { withUser } = require('../utils/integration-helpers')
 const { fillIn, findText, click, clickable, input, signIntoTerra } = require('../utils/integration-utils')
-const { fillInReplace } = require('../utils/integration-utils')
-const { waitUntilLoadedOrTimeout } = require('../utils/integration-utils')
+const { fillInReplace, gotoPage } = require('../utils/integration-utils')
 const { registerTest } = require('../utils/jest-utils')
 
 
 const testRegisterUserFn = withUser(async ({ page, testUrl, token }) => {
-  await page.goto(testUrl, waitUntilLoadedOrTimeout(60 * 1000))
+  await gotoPage(page, testUrl)
   await click(page, clickable({ textContains: 'View Workspaces' }))
   await signIntoTerra(page, { token })
   await fillInReplace(page, input({ labelContains: 'First Name' }), 'Integration')

--- a/integration-tests/tests/workspace-dashboard.js
+++ b/integration-tests/tests/workspace-dashboard.js
@@ -2,7 +2,7 @@
 const _ = require('lodash/fp')
 const { overrideConfig, viewWorkspaceDashboard, withWorkspace } = require('../utils/integration-helpers')
 const {
-  assertNavChildNotFound, assertTextNotFound, click, clickable, dismissNotifications, findElement, findText, navChild, noSpinnersAfter
+  assertNavChildNotFound, assertTextNotFound, click, clickable, dismissNotifications, findElement, findText, gotoPage, navChild, noSpinnersAfter
 } = require('../utils/integration-utils')
 const { registerTest } = require('../utils/jest-utils')
 const { withUserToken } = require('../utils/terra-sa-utils')
@@ -35,7 +35,7 @@ const workspaceDashboardPage = (testPage, testUrl, token, workspaceName) => {
   return {
     visit: async (loadUrl = true) => {
       if (loadUrl) {
-        await testPage.goto(testUrl)
+        await gotoPage(testPage, testUrl)
       }
       await viewWorkspaceDashboard(testPage, token, workspaceName)
     },
@@ -196,7 +196,7 @@ const testAzureWorkspace = withUserToken(async ({ page, token, testUrl }) => {
   const workspaceName = 'azure-workspace'
 
   // Must load page before setting mock responses.
-  await page.goto(testUrl)
+  await gotoPage(page, testUrl)
   await findText(page, 'View Workspaces')
   await overrideConfig(page, { isAnalysisTabVisible: true })
   await setAjaxMockValues(page, 'azure-workspace-ns', workspaceName, workspaceDescription)

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -33,6 +33,8 @@ const makeWorkspace = withSignedInPage(async ({ page, billingProject }) => {
       try {
         return await window.Ajax().Workspaces.create({ namespace: billingProject, name, attributes: {} })
       } catch (err) {
+        console.error(err)
+        console.error(typeof err)
         const message = await err.text()
         throw message
       }

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -1,11 +1,10 @@
 const _ = require('lodash/fp')
 const uuid = require('uuid')
 const {
-  click, clickable, dismissNotifications, fillIn, findText, input, signIntoTerra, waitForNoSpinners, navChild, noSpinnersAfter
+  click, clickable, dismissNotifications, fillIn, findText, gotoPage, input, signIntoTerra, waitForNoSpinners, navChild, noSpinnersAfter, navOptionNetworkIdle
 } = require('./integration-utils')
 const { fetchLyle } = require('./lyle-utils')
 const { withUserToken } = require('../utils/terra-sa-utils')
-const { waitUntilLoadedOrTimeout } = require('../utils/integration-utils')
 
 
 const defaultTimeout = 5 * 60 * 1000
@@ -196,7 +195,7 @@ const overrideConfig = async (page, configToPassIn) => {
 }
 
 const enableDataCatalog = async (page, testUrl, token) => {
-  await page.goto(testUrl, waitUntilLoadedOrTimeout(60 * 1000))
+  await gotoPage(page, testUrl)
   await waitForNoSpinners(page)
 
   await findText(page, 'Browse Data')
@@ -209,7 +208,7 @@ const enableDataCatalog = async (page, testUrl, token) => {
 const clickNavChildAndLoad = async (page, tab) => {
   // click triggers a page navigation event
   await Promise.all([
-    page.waitForNavigation(waitUntilLoadedOrTimeout()),
+    page.waitForNavigation(navOptionNetworkIdle()),
     noSpinnersAfter(page, { action: () => click(page, navChild(tab)) })
   ])
 }
@@ -223,7 +222,7 @@ const viewWorkspaceDashboard = async (page, token, workspaceName) => {
 }
 
 const performAnalysisTabSetup = async (page, token, testUrl, workspaceName) => {
-  await page.goto(testUrl, waitUntilLoadedOrTimeout(60 * 1000))
+  await gotoPage(page, testUrl)
   await findText(page, 'View Workspaces')
   await overrideConfig(page, { isAnalysisTabVisible: true })
   await viewWorkspaceDashboard(page, token, workspaceName)

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -159,8 +159,8 @@ const select = async (page, labelContains, text) => {
   return click(page, `//div[starts-with(@id, "react-select-") and contains(normalize-space(.),"${text}")]`)
 }
 
-const waitForNoSpinners = async page => {
-  await page.waitForXPath('//*[@data-icon="loadingSpinner"]', { hidden: true })
+const waitForNoSpinners = page => {
+  return page.waitForXPath('//*[@data-icon="loadingSpinner"]', { hidden: true })
 }
 
 // Puppeteer works by internally using MutationObserver. We are setting up the listener before

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -347,7 +347,7 @@ const withPageLogging = fn => async options => {
   return await fn(options)
 }
 
-const navOptionNetworkIdle = (timeout = 60 * 1000) => ({ waitUntil: ['domcontentloaded'], timeout })
+const navOptionNetworkIdle = (timeout = 60 * 1000) => ({ waitUntil: ['networkidle0'], timeout })
 
 const gotoPage = (page, url) => {
   return page.goto(url, navOptionNetworkIdle())

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -159,16 +159,7 @@ const select = async (page, labelContains, text) => {
   return click(page, `//div[starts-with(@id, "react-select-") and contains(normalize-space(.),"${text}")]`)
 }
 
-// Used to prevent checking loadingSpinner while page is blank
-const waitUntilDomContentLoaded = page => {
-  return Promise.all([
-    page.waitForFunction(() => document),
-    page.waitForSelector('div:not(:empty):not([id="root"])')
-  ])
-}
-
 const waitForNoSpinners = async page => {
-  await waitUntilDomContentLoaded(page)
   await page.waitForXPath('//*[@data-icon="loadingSpinner"]', { hidden: true })
 }
 

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -356,8 +356,6 @@ const withPageLogging = fn => async options => {
   return await fn(options)
 }
 
-// The DOMContentLoaded event fires when the initial HTML document has been completely loaded and parsed, without waiting for stylesheets, images, and subframes to finish loading.
-// https://developer.mozilla.org/en-US/docs/Web/API/Window/DOMContentLoaded_event
 const navOptionNetworkIdle = (timeout = 60 * 1000) => ({ waitUntil: ['domcontentloaded'], timeout })
 
 const gotoPage = (page, url) => {


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/QA-1895

Seeing sporadic UI test failures caused by Navigation timeout. 

This was recently added
```
const waitUntilLoadedOrTimeout = timeout => ({ waitUntil: ['load', 'domcontentloaded', 'networkidle0'], timeout })
```

I think it has to do with `waitUntil: load, domcontentloaded` options so I'm going to remove these two.