### PR TITLE
[SU-122] Update row count after adding row to a data table

### DIFF
--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -524,6 +524,7 @@ const EntitiesContent = ({
         onSuccess: () => {
           Ajax().Metrics.captureEvent(Events.workspaceDataAddRow, extractWorkspaceDetails(workspace.workspace))
           setRefreshKey(_.add(1))
+          setEntityMetadata(_.update(`${entityKey}.count`, _.add(1)))
         }
       }),
       addingColumn && h(AddColumnModal, {


### PR DESCRIPTION
This applies to the new data tab design (enable with `window.configOverridesStore.set({ isDataTabRedesignEnabled: true })`). Currently, when adding a row to a table, the table's row count in the sidebar does not update to include the new row.

This increments the table's row count in the currently loaded entity metadata to save a network request to reload metadata.

## Before
https://user-images.githubusercontent.com/1156625/171413073-65cff674-43ee-45ad-b38e-55892f08c798.mov

## After
https://user-images.githubusercontent.com/1156625/171413087-68bd2b67-814e-422b-9e0e-0f8a93d49ca9.mov


