### PR TITLE
[SU-112] Allow providing your own reference for IGV

### DIFF
--- a/src/components/IGVBrowser.js
+++ b/src/components/IGVBrowser.js
@@ -13,19 +13,11 @@ import { knownBucketRequesterPaysStatuses, requesterPaysProjectStore } from 'src
 import * as Utils from 'src/libs/utils'
 
 
-// Additional references supported by Terra that are not included in IGV
-const customReferences = {
-  'MN908947.3': {
-    id: 'sarsCov2RefId.3', indexed: false,
-    fastaURL: 'https://storage.googleapis.com/gcp-public-data--broad-references/sars-cov-2/MN908947.3/nCoV-2019.reference.fasta'
-  }
-}
-
 // format for selectedFiles prop: [{ filePath, indexFilePath } }]
 const IGVBrowser = _.flow(
   withDisplayName('IGVBrowser'),
   requesterPaysWrapper({ onDismiss: ({ onDismiss }) => onDismiss() })
-)(({ selectedFiles, refGenome, workspace, onDismiss, onRequesterPaysError }) => {
+)(({ selectedFiles, refGenome: { genome, reference }, workspace, onDismiss, onRequesterPaysError }) => {
   const containerRef = useRef()
   const signal = useCancellation()
   const [loadingIgv, setLoadingIgv] = useState(true)
@@ -61,11 +53,9 @@ const IGVBrowser = _.flow(
           const { default: igv } = await import('igv')
           igvLibrary.current = igv
 
-          const customReference = customReferences[refGenome]
-
           const options = {
-            genome: refGenome,
-            reference: customReference,
+            genome,
+            reference,
             tracks: await Promise.all(_.map(async ({ filePath, indexFilePath }) => {
               const [bucket] = parseGsUri(filePath)
               const userProjectParam = { userProject: knownBucketRequesterPaysStatuses.get()[bucket] ? await getUserProjectForWorkspace(workspace) : undefined }

--- a/src/components/IGVFileSelector.js
+++ b/src/components/IGVFileSelector.js
@@ -4,7 +4,7 @@ import { div, h } from 'react-hyperscript-helpers'
 import { AutoSizer, List } from 'react-virtualized'
 import ButtonBar from 'src/components/ButtonBar'
 import { ButtonPrimary, LabeledCheckbox, Link } from 'src/components/common'
-import IGVReferenceSelector, { defaultIgvReference, igvAvailableReferences, igvCustomReferencesPreferenceKey } from 'src/components/IGVReferenceSelector'
+import IGVReferenceSelector, { defaultIgvReference, igvRecentlyUsedReferencesPreferenceKey } from 'src/components/IGVReferenceSelector'
 import { getLocalPref, setLocalPref } from 'src/libs/prefs'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
@@ -95,16 +95,13 @@ const IGVFileSelector = ({ selectedEntities, onSuccess }) => {
           [!isRefGenomeValid, () => 'Select a reference genome']
         ),
         onClick: () => {
-          const isCustomReference = !_.find({ value: refGenome }, igvAvailableReferences)
-          if (isCustomReference) {
-            setLocalPref(
-              igvCustomReferencesPreferenceKey,
-              [
-                refGenome,
-                ..._.remove(refGenome, getLocalPref(igvCustomReferencesPreferenceKey) || [])
-              ]
-            )
-          }
+          setLocalPref(
+            igvRecentlyUsedReferencesPreferenceKey,
+            [
+              refGenome,
+              ..._.remove(refGenome, getLocalPref(igvRecentlyUsedReferencesPreferenceKey) || [])
+            ].slice(0, 3)
+          )
 
           onSuccess({ selectedFiles: _.filter('isSelected', selections), refGenome })
         }

--- a/src/components/IGVFileSelector.js
+++ b/src/components/IGVFileSelector.js
@@ -1,9 +1,10 @@
 import _ from 'lodash/fp'
 import { useState } from 'react'
-import { div, h, label } from 'react-hyperscript-helpers'
+import { div, h } from 'react-hyperscript-helpers'
 import { AutoSizer, List } from 'react-virtualized'
 import ButtonBar from 'src/components/ButtonBar'
-import { ButtonPrimary, IdContainer, LabeledCheckbox, Link, Select } from 'src/components/common'
+import { ButtonPrimary, LabeledCheckbox, Link } from 'src/components/common'
+import IGVReferenceSelector, { defaultIgvReference } from 'src/components/IGVReferenceSelector'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 
@@ -17,7 +18,7 @@ const getStrings = v => {
 }
 
 const IGVFileSelector = ({ selectedEntities, onSuccess }) => {
-  const [refGenome, setRefGenome] = useState('hg38')
+  const [refGenome, setRefGenome] = useState(defaultIgvReference)
   const [selections, setSelections] = useState(() => {
     const allAttributeStrings = _.flow(
       _.flatMap(row => _.flatMap(getStrings, row.attributes)),
@@ -48,17 +49,10 @@ const IGVFileSelector = ({ selectedEntities, onSuccess }) => {
   const isSelectionValid = !!numSelected
 
   return div({ style: Style.modalDrawer.content }, [
-    h(IdContainer, [id => div({ style: { fontWeight: 500 } }, [
-      label({ htmlFor: id }, ['Reference genome: ']),
-      div({ style: { display: 'inline-block', marginLeft: '0.25rem', marginBottom: '1rem', minWidth: 125 } }, [
-        h(Select, {
-          id,
-          options: ['hg38', 'hg19', 'hg18', 'MN908947.3', 'ASM985889v3', 'mm10', 'panTro4', 'panPan2', 'susScr11', 'bosTau8', 'canFam3', 'rn6', 'danRer10', 'dm6', 'sacCer3'],
-          value: refGenome,
-          onChange: ({ value }) => setRefGenome(value)
-        })
-      ])
-    ])]),
+    h(IGVReferenceSelector, {
+      value: refGenome,
+      onChange: setRefGenome
+    }),
     div({ style: { marginBottom: '1rem', display: 'flex' } }, [
       div({ style: { fontWeight: 500 } }, ['Select:']),
       h(Link, { style: { padding: '0 0.5rem' }, onClick: () => setSelections(_.map(_.set('isSelected', true))) }, ['all']),

--- a/src/components/IGVFileSelector.js
+++ b/src/components/IGVFileSelector.js
@@ -19,6 +19,8 @@ const getStrings = v => {
 
 const IGVFileSelector = ({ selectedEntities, onSuccess }) => {
   const [refGenome, setRefGenome] = useState(defaultIgvReference)
+  const isRefGenomeValid = Boolean(_.get('genome', refGenome) || _.get('reference.fastaURL', refGenome))
+
   const [selections, setSelections] = useState(() => {
     const allAttributeStrings = _.flow(
       _.flatMap(row => _.flatMap(getStrings, row.attributes)),
@@ -86,8 +88,11 @@ const IGVFileSelector = ({ selectedEntities, onSuccess }) => {
     h(ButtonBar, {
       style: Style.modalDrawer.buttonBar,
       okButton: h(ButtonPrimary, {
-        disabled: !isSelectionValid,
-        tooltip: !isSelectionValid && 'Select at least one file',
+        disabled: !isSelectionValid || !isRefGenomeValid,
+        tooltip: Utils.cond(
+          [!isSelectionValid, () => 'Select at least one file'],
+          [!isRefGenomeValid, () => 'Select a reference genome']
+        ),
         onClick: () => onSuccess({ selectedFiles: _.filter('isSelected', selections), refGenome })
       }, ['Launch IGV'])
     })

--- a/src/components/IGVFileSelector.js
+++ b/src/components/IGVFileSelector.js
@@ -4,8 +4,7 @@ import { div, h } from 'react-hyperscript-helpers'
 import { AutoSizer, List } from 'react-virtualized'
 import ButtonBar from 'src/components/ButtonBar'
 import { ButtonPrimary, LabeledCheckbox, Link } from 'src/components/common'
-import IGVReferenceSelector, { defaultIgvReference, igvRecentlyUsedReferencesPreferenceKey } from 'src/components/IGVReferenceSelector'
-import { getLocalPref, setLocalPref } from 'src/libs/prefs'
+import IGVReferenceSelector, { addIgvRecentlyUsedReference, defaultIgvReference } from 'src/components/IGVReferenceSelector'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 
@@ -95,14 +94,7 @@ const IGVFileSelector = ({ selectedEntities, onSuccess }) => {
           [!isRefGenomeValid, () => 'Select a reference genome']
         ),
         onClick: () => {
-          setLocalPref(
-            igvRecentlyUsedReferencesPreferenceKey,
-            [
-              refGenome,
-              ..._.remove(refGenome, getLocalPref(igvRecentlyUsedReferencesPreferenceKey) || [])
-            ].slice(0, 3)
-          )
-
+          addIgvRecentlyUsedReference(refGenome)
           onSuccess({ selectedFiles: _.filter('isSelected', selections), refGenome })
         }
       }, ['Launch IGV'])

--- a/src/components/IGVFileSelector.js
+++ b/src/components/IGVFileSelector.js
@@ -4,7 +4,8 @@ import { div, h } from 'react-hyperscript-helpers'
 import { AutoSizer, List } from 'react-virtualized'
 import ButtonBar from 'src/components/ButtonBar'
 import { ButtonPrimary, LabeledCheckbox, Link } from 'src/components/common'
-import IGVReferenceSelector, { defaultIgvReference } from 'src/components/IGVReferenceSelector'
+import IGVReferenceSelector, { defaultIgvReference, igvAvailableReferences, igvCustomReferencesPreferenceKey } from 'src/components/IGVReferenceSelector'
+import { getLocalPref, setLocalPref } from 'src/libs/prefs'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 
@@ -93,7 +94,20 @@ const IGVFileSelector = ({ selectedEntities, onSuccess }) => {
           [!isSelectionValid, () => 'Select at least one file'],
           [!isRefGenomeValid, () => 'Select a reference genome']
         ),
-        onClick: () => onSuccess({ selectedFiles: _.filter('isSelected', selections), refGenome })
+        onClick: () => {
+          const isCustomReference = !_.find({ value: refGenome }, igvAvailableReferences)
+          if (isCustomReference) {
+            setLocalPref(
+              igvCustomReferencesPreferenceKey,
+              [
+                refGenome,
+                ..._.remove(refGenome, getLocalPref(igvCustomReferencesPreferenceKey) || [])
+              ]
+            )
+          }
+
+          onSuccess({ selectedFiles: _.filter('isSelected', selections), refGenome })
+        }
       }, ['Launch IGV'])
     })
   ])

--- a/src/components/IGVReferenceSelector.js
+++ b/src/components/IGVReferenceSelector.js
@@ -1,0 +1,57 @@
+import _ from 'lodash/fp'
+import { div, h, label } from 'react-hyperscript-helpers'
+import { IdContainer, Select } from 'src/components/common'
+
+// Additional references supported by Terra that are not included in IGV
+const terraReferences = {
+  'MN908947.3': {
+    id: 'sarsCov2RefId.3', indexed: false,
+    fastaURL: 'https://storage.googleapis.com/gcp-public-data--broad-references/sars-cov-2/MN908947.3/nCoV-2019.reference.fasta'
+  }
+}
+
+// The reference genome can be specified using either a 'reference' object or,
+// for IGV-hosted references, a 'genome' ID.
+// https://github.com/igvteam/igv.js/wiki/Reference-Genome
+const igvAvailableReferences = _.map(
+  id => {
+    return _.has(id, terraReferences) ?
+      { label: id, value: { reference: terraReferences[id] } } :
+      { label: id, value: { genome: id } }
+  },
+  [
+    'hg38',
+    'hg19',
+    'hg18',
+    'MN908947.3',
+    'ASM985889v3',
+    'mm10',
+    'panTro4',
+    'panPan2',
+    'susScr11',
+    'bosTau8',
+    'canFam3',
+    'rn6',
+    'danRer10',
+    'dm6',
+    'sacCer3'
+  ]
+)
+
+export const defaultIgvReference = { genome: 'hg38' }
+
+const IGVReferenceSelector = ({ value, onChange }) => {
+  return h(IdContainer, [id => div([
+    label({ htmlFor: id, style: { fontWeight: 500 } }, ['Reference genome: ']),
+    div({ style: { display: 'inline-block', marginLeft: '0.25rem', marginBottom: '1rem', minWidth: 125 } }, [
+      h(Select, {
+        id,
+        options: igvAvailableReferences,
+        value,
+        onChange: ({ value }) => onChange(value)
+      })
+    ])
+  ])])
+}
+
+export default IGVReferenceSelector

--- a/src/components/IGVReferenceSelector.js
+++ b/src/components/IGVReferenceSelector.js
@@ -21,7 +21,7 @@ const terraReferences = {
 const igvAvailableReferences = _.map(
   id => {
     return _.has(id, terraReferences) ?
-      { label: id, value: { reference: terraReferences[id] } } :
+      { label: id, value: { reference: { name: id, ...terraReferences[id] } } } :
       { label: id, value: { genome: id } }
   },
   [

--- a/src/components/IGVReferenceSelector.js
+++ b/src/components/IGVReferenceSelector.js
@@ -18,7 +18,7 @@ const terraReferences = {
 // The reference genome can be specified using either a 'reference' object or,
 // for IGV-hosted references, a 'genome' ID.
 // https://github.com/igvteam/igv.js/wiki/Reference-Genome
-export const igvAvailableReferences = _.map(
+const igvAvailableReferences = _.map(
   id => {
     return _.has(id, terraReferences) ?
       { label: id, value: { reference: terraReferences[id] } } :
@@ -45,22 +45,25 @@ export const igvAvailableReferences = _.map(
 
 export const defaultIgvReference = { genome: 'hg38' }
 
-export const igvCustomReferencesPreferenceKey = 'igv-custom-references'
+export const igvRecentlyUsedReferencesPreferenceKey = 'igv-recently-used-references'
 
-const IGVCustomReferences = ({ onSelect }) => {
+const IGVRecentlyUsedReferences = ({ onSelect }) => {
   const [customReferences, setCustomReferences] = useState(() => {
-    return getLocalPref(igvCustomReferencesPreferenceKey) || []
+    return getLocalPref(igvRecentlyUsedReferencesPreferenceKey) || []
   })
   useEffect(() => {
-    setLocalPref(igvCustomReferencesPreferenceKey, customReferences)
+    setLocalPref(igvRecentlyUsedReferencesPreferenceKey, customReferences)
   }, [customReferences])
 
   return !_.isEmpty(customReferences) && h(IdContainer, [id => h(Fragment, [
-    p({ id }, ['Previously used custom references']),
-    ul({ 'aria-labelledby': id, style: { padding: 0, margin: 0, listStyleType: 'none' } },
+    p({ id, style: { margin: '0 0 0.5rem' } }, ['Recently used references']),
+    ul({ 'aria-labelledby': id, style: { padding: 0, margin: '0 0 1rem', listStyleType: 'none' } },
       _.map(
         reference => {
-          const label = _.get('reference.name', reference) || _.flow(_.get('reference.fastaURL'), _.split('/'), _.last)(reference)
+          const label = _.get('genome', reference) ||
+            _.get('reference.name', reference) ||
+            _.flow(_.get('reference.fastaURL'), _.split('/'), _.last)(reference)
+
           return li({
             key: _.get('reference.fastaURL', reference),
             style: { display: 'flex', padding: '0.125rem 0' }
@@ -70,7 +73,7 @@ const IGVCustomReferences = ({ onSelect }) => {
               onClick: () => onSelect(reference)
             }, [label]),
             h(Clickable, {
-              tooltip: 'Remove from this list',
+              tooltip: `Remove ${label} from this list`,
               style: { marginLeft: '1ch' },
               onClick: () => setCustomReferences(_.remove(reference))
             }, [icon('times')])
@@ -154,10 +157,10 @@ const IGVReferenceSelector = ({ value, onChange }) => {
           )
           onChange(_.update('reference', update, value))
         }
-      }),
+      })
+    ]),
 
-      h(IGVCustomReferences, { onSelect: onChange })
-    ])
+    h(IGVRecentlyUsedReferences, { onSelect: onChange })
   ])])
 }
 

--- a/src/components/IGVReferenceSelector.js
+++ b/src/components/IGVReferenceSelector.js
@@ -45,7 +45,18 @@ const igvAvailableReferences = _.map(
 
 export const defaultIgvReference = { genome: 'hg38' }
 
-export const igvRecentlyUsedReferencesPreferenceKey = 'igv-recently-used-references'
+const igvRecentlyUsedReferencesPreferenceKey = 'igv-recently-used-references'
+
+export const addIgvRecentlyUsedReference = reference => {
+  // Store the last 3 references used
+  setLocalPref(
+    igvRecentlyUsedReferencesPreferenceKey,
+    [
+      reference,
+      ..._.remove(reference, getLocalPref(igvRecentlyUsedReferencesPreferenceKey) || [])
+    ].slice(0, 3)
+  )
+}
 
 const IGVRecentlyUsedReferences = ({ onSelect }) => {
   const [customReferences, setCustomReferences] = useState(() => {


### PR DESCRIPTION
Currently, IGV in Terra provides a list of reference genomes to choose from. If a user needs a different reference genome (for example, for another species), currently their only option is to file a support request. That happened recently for the MN908947.3 SARS-CoV2 reference genome (#2995).

This adds the option for users to provide a URL for a reference genome instead of choosing from the pre-defined list. Since IGV.js makes authenticated requests to GCS, this can be a URL to a file in the workspace's bucket.

This also stores the 3 most recently used reference genomes in local storage and shows them below the reference genome menu. This spares users from having to enter their custom reference URL each time they use IGV.

https://user-images.githubusercontent.com/1156625/171421376-443d20f2-6b04-48a1-941c-5c3c49b1452b.mov

