### PR TITLE
[SU-124] Defer loading submission statuses on workspaces list

### DIFF
--- a/src/components/common.js
+++ b/src/components/common.js
@@ -1,7 +1,7 @@
 import * as clipboard from 'clipboard-polyfill/text'
 import _ from 'lodash/fp'
 import * as qs from 'qs'
-import { Fragment, useState } from 'react'
+import { Fragment, useEffect, useState } from 'react'
 import FocusLock from 'react-focus-lock'
 import { b, div, h, h1, img, input, label, span } from 'react-hyperscript-helpers'
 import RSelect, { components as RSelectComponents } from 'react-select'
@@ -612,4 +612,14 @@ export const DeleteConfirmationModal = ({
       ])])
     ])
   ])
+}
+
+export const DelayedRender = ({ children = null, delay = 1000 }) => {
+  const [shouldRender, setShouldRender] = useState(false)
+  useEffect(() => {
+    const timeout = setTimeout(() => setShouldRender(true), delay)
+    return () => clearTimeout(timeout)
+  }, [delay])
+
+  return shouldRender && children
 }

--- a/src/components/workspace-utils.js
+++ b/src/components/workspace-utils.js
@@ -29,7 +29,7 @@ export const useWorkspaces = () => {
     Utils.withBusyState(setLoading)
   )(async () => {
     const ws = await Ajax(signal).Workspaces.list([
-      'accessLevel', 'public', 'workspace', 'workspaceSubmissionStats', 'workspace.attributes.description', 'workspace.attributes.tag:tags'
+      'accessLevel', 'public', 'workspace', 'workspace.attributes.description', 'workspace.attributes.tag:tags'
     ])
     workspacesStore.set(ws)
   })

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -4,7 +4,7 @@ import * as qs from 'qs'
 import { useEffect, useMemo, useState } from 'react'
 import { div, h, span } from 'react-hyperscript-helpers'
 import { AutoSizer } from 'react-virtualized'
-import { HeaderRenderer, Link, Select, topSpinnerOverlay, transparentSpinnerOverlay } from 'src/components/common'
+import { DelayedRender, HeaderRenderer, Link, Select, topSpinnerOverlay, transparentSpinnerOverlay } from 'src/components/common'
 import FooterWrapper from 'src/components/FooterWrapper'
 import { icon, spinner } from 'src/components/icons'
 import { DelayedSearchInput } from 'src/components/input'
@@ -277,10 +277,12 @@ export const WorkspaceList = () => {
                 })
               ]),
               div({ style: styles.tableCellContent }, [
-                loadingSubmissionStats && h(TooltipTrigger, {
-                  content: 'Loading submission status',
-                  side: 'left'
-                }, [spinner({ size: 20 })]),
+                loadingSubmissionStats && h(DelayedRender, [
+                  h(TooltipTrigger, {
+                    content: 'Loading submission status',
+                    side: 'left'
+                  }, [spinner({ size: 20 })])
+                ]),
                 !!lastRunStatus && h(TooltipTrigger, {
                   content: span(['Last submitted workflow status: ', span({ style: { fontWeight: 600 } }, [_.startCase(lastRunStatus)])]),
                   side: 'left'


### PR DESCRIPTION
Some users, have reported that the workspaces list page is slow to the point of being unusable (10s of seconds to load). This is particularly true for the Field Engineering team, who have hundreds to thousands of workspaces.

@MatthewBemis investigated and found that removing the `workspaceSubmissionStats` field from the list workspaces request reduced the time required for that request by as much as 90%.

We can't drop `workspaceSubmissionStats` entirely, since it is used to display the status of the last submitted workflow for each workspace and the list can also be filtered on submission status.

This changes the workspaces list page to make an initial request for the workspaces list without the `workspaceSubmissionStats` and then make a second request for `workspaceSubmissionStats` in the background. This lets us render the workspace list without waiting for the slow request. If it takes more than a second to load `workspaceSubmissionStats`, spinners are shown in place of the status icons. And if a user attempts to filter by submission status before submission statuses are loaded, "Loading submission statuses" is shown in place of a no results message.

The screen recording here uses an artificial delay for loading submission statuses since my account doesn't have enough workspaces/workflows to noticeably slow down this request.

https://user-images.githubusercontent.com/1156625/171487551-b92502ed-802f-4885-88a6-cf58aef89ada.mov

As a bonus, many places throughout the UI are using the `useWorkspaces` hook to populate a menu for selecting a workspace. For example, importing data, exporting data to a workspace, etc. prompt for a workspace. Removing the `workspaceSubmissionStats` field from the `useWorkspaces` hook should speed up all of those as well.
