### PR TITLE
tweak integration test signIntoTerra function

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -314,18 +314,8 @@ workflows:
           filters:
             branches:
               only: dev
-      - integration-tests-alpha:
-          requires:
-            - deploy-alpha
-          filters:
-            branches:
-              only: dev
-      - integration-tests-staging:
-          requires:
-            - deploy-staging
-          filters:
-            branches:
-              only: dev
+      - integration-tests-alpha
+      - integration-tests-staging
   nightly-integration-tests:
     triggers:
       - schedule:

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -209,7 +209,7 @@ const signIntoTerra = async (page, { token, testUrl }) => {
     console.error(err)
     console.error('Error: Page loading timed out during sign in.')
     // Save html content for manual issue debugging
-    await saveScreenshotPageContent(page, 'signIntoTerra')
+    await savePageContent(page, 'signIntoTerra')
     // Need a URL if testUrl is undefined for the retry
     const href = await page.evaluate(() => {
       return window.location.href
@@ -291,8 +291,8 @@ const getScreenshotDir = () => {
   return dir
 }
 
-// Save page content to a file. Useful for test failure troubleshooting
-const saveScreenshotPageContent = async (page, testName) => {
+// Save page content to screenshot dir. Useful for test failure troubleshooting
+const savePageContent = async (page, testName) => {
   const dir = getScreenshotDir()
   const htmlContent = await page.content()
   const htmlFile = `${dir}/${testName}-${Date.now()}.html`

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -221,6 +221,7 @@ const signIntoTerra = async (page, { token, testUrl }) => {
     await maybeLoadPage(testUrl ? testUrl : href)
   }
 
+  await page.waitForFunction('window.forceSignIn')
   await page.evaluate(token => window.forceSignIn(token), token)
   await dismissNotifications(page)
   await waitForNoSpinners(page)

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -192,13 +192,13 @@ const dismissNotifications = async page => {
 }
 
 const signIntoTerra = async (page, { token, testUrl }) => {
-  const matchUrl = async (url) => {
+  const matchUrl = async url => {
     await page.waitForFunction(url => {
       return window.location.href.includes(url)
     }, {}, url)
   }
 
-  const maybeLoadPage = async (url) => {
+  const maybeLoadPage = async url => {
     if (!!url) {
       console.log(`Loading page: ${url}`)
       await page.goto(url, waitUntilLoadedOrTimeout())

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -192,33 +192,30 @@ const dismissNotifications = async page => {
 }
 
 const signIntoTerra = async (page, { token, testUrl }) => {
-  const matchUrl = async url => {
-    await page.waitForFunction(url => {
-      return window.location.href.includes(url)
-    }, {}, url)
-  }
-
-  const maybeLoadPage = async url => {
+  const maybeGotoPage = async url => {
     if (!!url) {
       console.log(`Loading page: ${url}`)
       await page.goto(url, waitUntilLoadedOrTimeout())
-      await matchUrl(url)
+      await page.waitForFunction(url => {
+        return window.location.href.includes(url)
+      }, {}, url)
     }
     await waitForNoSpinners(page)
   }
 
   try {
-    await maybeLoadPage(testUrl)
+    await maybeGotoPage(testUrl)
   } catch (err) {
     console.error(err)
     console.error('Error: Page loading timed out during sign in.')
-    const screenshotName = `signIntoTerra-${Date.now()}`
+    // Take screenshot for manual issue debugging
+    const screenshotName = `Terra-SignIn-Error`
     await maybeSaveScreenshot(page, screenshotName)
-    // Need a URL if testUrl is undefined.
+    // Need a URL if testUrl is undefined in retry
     const href = await page.evaluate(() => {
       return window.location.href
     })
-    await maybeLoadPage(testUrl ? testUrl : href)
+    await maybeGotoPage(testUrl ? testUrl : href)
   }
 
   await page.waitForFunction('window.forceSignIn')


### PR DESCRIPTION
CircleCI failed [job](https://app.circleci.com/pipelines/github/DataBiosphere/terra-ui/9950/workflows/b3769fa4-7f7d-45da-aa26-88cd1e5401c2).

I want to collect more information to aid flaky failure investigation by saving page html-content to a file when sign-in has failed (before retry).

