### PR TITLE
[SU-123] Add tooltip for data table column settings button

### DIFF
--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -387,7 +387,8 @@ const EntitiesContent = ({
           renderExportMenu({ columnSettings }),
           !snapshotName && h(ButtonSecondary, {
             onClick: showColumnSettingsModal,
-            disabled: !!activeCrossTableTextFilter
+            disabled: !!activeCrossTableTextFilter,
+            tooltip: 'Change the order and visibility of columns in the table'
           }, [icon('cog', { style: { marginRight: '0.5rem' } }), 'Settings']),
           div({ style: { margin: '0 1.5rem', height: '100%', borderLeft: Style.standardLine } }),
           div({


### PR DESCRIPTION
The Settings button was the only button in this menu without a tooltip.

![Screen Shot 2022-06-01 at 4 42 43 PM](https://user-images.githubusercontent.com/1156625/171498002-11f7b99b-3a20-4cac-ad81-4f5e8ccb23ce.png)
