### PR TITLE
[IA-3042] adding environment key into config files and update dropdown logic

### DIFF
--- a/config/alpha.json
+++ b/config/alpha.json
@@ -26,5 +26,6 @@
   },
   "alphaSpendReportGroup": "Alpha_Spend_Report_Users",
   "alphaRegionalityGroup": "Alpha_Regionality_Users",
-  "terraDockerVersionsFile": "terra-docker-versions-alpha.json"
+  "terraDockerVersionsFile": "terra-docker-versions-alpha.json",
+  "terraDockerImageBucket": "terra-docker-image-documentation-alpha"
 }

--- a/config/alpha.json
+++ b/config/alpha.json
@@ -26,5 +26,5 @@
   },
   "alphaSpendReportGroup": "Alpha_Spend_Report_Users",
   "alphaRegionalityGroup": "Alpha_Regionality_Users",
-  "environmentKey": "alpha"
+  "terraDockerVersionsFile": "terra-docker-versions-alpha.json"
 }

--- a/config/alpha.json
+++ b/config/alpha.json
@@ -25,5 +25,6 @@
     "apiKey": "AQEBBAEkx4iE2KxNyI7Wx08EwU1ycTM7E4FMSmaibbMUQxNU6uQvuAJt7fyABAtFYSYfgEE"
   },
   "alphaSpendReportGroup": "Alpha_Spend_Report_Users",
-  "alphaRegionalityGroup": "Alpha_Regionality_Users"
+  "alphaRegionalityGroup": "Alpha_Regionality_Users",
+  "environmentKey": "alpha"
 }

--- a/config/dev.json
+++ b/config/dev.json
@@ -26,5 +26,6 @@
   },
   "alphaSpendReportGroup": "Alpha_Spend_Report_Users",
   "alphaRegionalityGroup": "Alpha_Regionality_Users",
-  "terraDockerVersionsFile": "terra-docker-versions-dev.json"
+  "terraDockerVersionsFile": "terra-docker-versions-dev.json",
+  "terraDockerImageBucket": "terra-docker-image-documentation-dev"
 }

--- a/config/dev.json
+++ b/config/dev.json
@@ -25,5 +25,6 @@
     "apiKey": "AQEBBAEkx4iE2KxNyI7Wx08EwU1ycTM7E4FMSmaibbMUQxNU6uQvuAJt7fyABAtFYSYfgEE"
   },
   "alphaSpendReportGroup": "Alpha_Spend_Report_Users",
-  "alphaRegionalityGroup": "Alpha_Regionality_Users"
+  "alphaRegionalityGroup": "Alpha_Regionality_Users",
+  "environmentKey": "dev"
 }

--- a/config/dev.json
+++ b/config/dev.json
@@ -26,5 +26,5 @@
   },
   "alphaSpendReportGroup": "Alpha_Spend_Report_Users",
   "alphaRegionalityGroup": "Alpha_Regionality_Users",
-  "terraDockerVersionsFile": "terra-docker-versions-staging.json"
+  "terraDockerVersionsFile": "terra-docker-versions-dev.json"
 }

--- a/config/dev.json
+++ b/config/dev.json
@@ -26,5 +26,5 @@
   },
   "alphaSpendReportGroup": "Alpha_Spend_Report_Users",
   "alphaRegionalityGroup": "Alpha_Regionality_Users",
-  "environmentKey": "dev"
+  "terraDockerVersionsFile": "terra-docker-versions-staging.json"
 }

--- a/config/fiab.json
+++ b/config/fiab.json
@@ -25,5 +25,6 @@
   },
   "alphaSpendReportGroup": "Alpha_Spend_Report_Users",
   "alphaRegionalityGroup": "Alpha_Regionality_Users",
-  "terraDockerVersionsFile": "terra-docker-versions-dev.json"
+  "terraDockerVersionsFile": "terra-docker-versions-dev.json",
+  "terraDockerImageBucket": "terra-docker-image-documentation-dev"
 }

--- a/config/fiab.json
+++ b/config/fiab.json
@@ -24,5 +24,6 @@
     "apiKey": "AQEBBAEkx4iE2KxNyI7Wx08EwU1ycTM7E4FMSmaibbMUQxNU6uQvuAJt7fyABAtFYSYfgEE"
   },
   "alphaSpendReportGroup": "Alpha_Spend_Report_Users",
-  "alphaRegionalityGroup": "Alpha_Regionality_Users"
+  "alphaRegionalityGroup": "Alpha_Regionality_Users",
+  "environmentKey": "dev"
 }

--- a/config/fiab.json
+++ b/config/fiab.json
@@ -25,5 +25,5 @@
   },
   "alphaSpendReportGroup": "Alpha_Spend_Report_Users",
   "alphaRegionalityGroup": "Alpha_Regionality_Users",
-  "environmentKey": "dev"
+  "terraDockerVersionsFile": "terra-docker-versions-dev.json"
 }

--- a/config/perf.json
+++ b/config/perf.json
@@ -26,5 +26,5 @@
   },
   "alphaSpendReportGroup": "Alpha_Spend_Report_Users",
   "alphaRegionalityGroup": "Alpha_Regionality_Users",
-  "environmentKey": "dev"
+  "terraDockerVersionsFile": "terra-docker-versions-dev.json"
 }

--- a/config/perf.json
+++ b/config/perf.json
@@ -25,5 +25,6 @@
     "apiKey": "AQEBBAEkx4iE2KxNyI7Wx08EwU1ycTM7E4FMSmaibbMUQxNU6uQvuAJt7fyABAtFYSYfgEE"
   },
   "alphaSpendReportGroup": "Alpha_Spend_Report_Users",
-  "alphaRegionalityGroup": "Alpha_Regionality_Users"
+  "alphaRegionalityGroup": "Alpha_Regionality_Users",
+  "environmentKey": "dev"
 }

--- a/config/perf.json
+++ b/config/perf.json
@@ -26,5 +26,5 @@
   },
   "alphaSpendReportGroup": "Alpha_Spend_Report_Users",
   "alphaRegionalityGroup": "Alpha_Regionality_Users",
-  "terraDockerVersionsFile": "terra-docker-versions-dev.json"
+  "terraDockerVersionsFile": "terra-docker-versions-perf.json"
 }

--- a/config/perf.json
+++ b/config/perf.json
@@ -26,5 +26,6 @@
   },
   "alphaSpendReportGroup": "Alpha_Spend_Report_Users",
   "alphaRegionalityGroup": "Alpha_Regionality_Users",
-  "terraDockerVersionsFile": "terra-docker-versions-perf.json"
+  "terraDockerVersionsFile": "terra-docker-versions-perf.json",
+  "terraDockerImageBucket": "terra-docker-image-documentation-perf"
 }

--- a/config/prod.json
+++ b/config/prod.json
@@ -24,5 +24,6 @@
   },
   "alphaSpendReportGroup": "Alpha_Spend_Report_Users",
   "alphaRegionalityGroup": "Alpha_Regionality_Users",
-  "terraDockerVersionsFile": "terra-docker-versions-prod.json"
+  "terraDockerVersionsFile": "terra-docker-versions-prod.json",
+  "terraDockerImageBucket": "terra-docker-image-documentation-prod"
 }

--- a/config/prod.json
+++ b/config/prod.json
@@ -23,5 +23,6 @@
     "apiKey": "AQEBBAEGP2gTM2pIdJAQOIeNrm8dcTM7E4FMSmaibbMUQxNU6qy6nLPOBK8QfSvPFSsX8PQ"
   },
   "alphaSpendReportGroup": "Alpha_Spend_Report_Users",
-  "alphaRegionalityGroup": "Alpha_Regionality_Users"
+  "alphaRegionalityGroup": "Alpha_Regionality_Users",
+  "environmentKey": "prod"
 }

--- a/config/prod.json
+++ b/config/prod.json
@@ -24,5 +24,5 @@
   },
   "alphaSpendReportGroup": "Alpha_Spend_Report_Users",
   "alphaRegionalityGroup": "Alpha_Regionality_Users",
-  "environmentKey": "prod"
+  "terraDockerVersionsFile": "terra-docker-versions-prod.json"
 }

--- a/config/staging.json
+++ b/config/staging.json
@@ -25,5 +25,6 @@
   },
   "alphaSpendReportGroup": "Alpha_Spend_Report_Users",
   "alphaRegionalityGroup": "Alpha_Regionality_Users",
-  "terraDockerVersionsFile": "terra-docker-versions-staging.json"
+  "terraDockerVersionsFile": "terra-docker-versions-staging.json",
+  "terraDockerImageBucket": "terra-docker-image-documentation-staging"
 }

--- a/config/staging.json
+++ b/config/staging.json
@@ -24,5 +24,6 @@
     "apiKey": "AQEBBAEkx4iE2KxNyI7Wx08EwU1ycTM7E4FMSmaibbMUQxNU6uQvuAJt7fyABAtFYSYfgEE"
   },
   "alphaSpendReportGroup": "Alpha_Spend_Report_Users",
-  "alphaRegionalityGroup": "Alpha_Regionality_Users"
+  "alphaRegionalityGroup": "Alpha_Regionality_Users",
+  "environmentKey": "staging"
 }

--- a/config/staging.json
+++ b/config/staging.json
@@ -25,5 +25,5 @@
   },
   "alphaSpendReportGroup": "Alpha_Spend_Report_Users",
   "alphaRegionalityGroup": "Alpha_Regionality_Users",
-  "environmentKey": "staging"
+  "terraDockerVersionsFile": "terra-docker-versions-staging.json"
 }

--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -17,6 +17,7 @@ import TooltipTrigger from 'src/components/TooltipTrigger'
 import { cloudServices, machineTypes } from 'src/data/machines'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
+import { getConfig } from 'src/libs/config'
 import { withErrorReporting, withErrorReportingInModal } from 'src/libs/error'
 import Events, { extractWorkspaceDetails } from 'src/libs/events'
 import { betaVersionTag } from 'src/libs/logos'
@@ -689,6 +690,7 @@ export const ComputeModalBase = ({
       const { googleProject } = getWorkspaceObject()
       const currentRuntime = getCurrentRuntime(runtimes)
       const currentPersistentDisk = getCurrentPersistentDisk(runtimes, persistentDisks)
+      const envKey = getConfig().environmentKey
 
       Ajax().Metrics.captureEvent(Events.cloudEnvironmentConfigOpen, {
         existingConfig: !!currentRuntime, ...extractWorkspaceDetails(getWorkspaceObject())
@@ -697,7 +699,7 @@ export const ComputeModalBase = ({
         currentRuntime ? Ajax().Runtimes.runtime(currentRuntime.googleProject, currentRuntime.runtimeName).details() : null,
         Ajax()
           .Buckets
-          .getObjectPreview(googleProject, 'terra-docker-image-documentation', 'terra-docker-versions.json', true)
+          .getObjectPreview(googleProject, 'terra-docker-image-documentation', `terra-docker-versions-${envKey}.json`, true)
           .then(res => res.json()),
         currentPersistentDisk ? Ajax().Disks.disk(currentPersistentDisk.googleProject, currentPersistentDisk.name).details() : null
       ])

--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -698,7 +698,7 @@ export const ComputeModalBase = ({
         currentRuntime ? Ajax().Runtimes.runtime(currentRuntime.googleProject, currentRuntime.runtimeName).details() : null,
         Ajax()
           .Buckets
-          .getObjectPreview(googleProject, 'terra-docker-image-documentation', getConfig().terraDockerVersionsFile, true)
+          .getObjectPreview(googleProject, getConfig().terraDockerImageBucket, getConfig().terraDockerVersionsFile, true)
           .then(res => res.json()),
         currentPersistentDisk ? Ajax().Disks.disk(currentPersistentDisk.googleProject, currentPersistentDisk.name).details() : null
       ])

--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -690,7 +690,6 @@ export const ComputeModalBase = ({
       const { googleProject } = getWorkspaceObject()
       const currentRuntime = getCurrentRuntime(runtimes)
       const currentPersistentDisk = getCurrentPersistentDisk(runtimes, persistentDisks)
-      const envKey = getConfig().environmentKey
 
       Ajax().Metrics.captureEvent(Events.cloudEnvironmentConfigOpen, {
         existingConfig: !!currentRuntime, ...extractWorkspaceDetails(getWorkspaceObject())
@@ -699,7 +698,7 @@ export const ComputeModalBase = ({
         currentRuntime ? Ajax().Runtimes.runtime(currentRuntime.googleProject, currentRuntime.runtimeName).details() : null,
         Ajax()
           .Buckets
-          .getObjectPreview(googleProject, 'terra-docker-image-documentation', `terra-docker-versions-${envKey}.json`, true)
+          .getObjectPreview(googleProject, 'terra-docker-image-documentation', getConfig().terraDockerVersionsFile, true)
           .then(res => res.json()),
         currentPersistentDisk ? Ajax().Disks.disk(currentPersistentDisk.googleProject, currentPersistentDisk.name).details() : null
       ])


### PR DESCRIPTION
This PR is to address an underlying issue that we have been running into when we update the Leo Cache images.

At the moment, we only have one config file with the list of images for all environments. This means when we update Leo code on dev through a PR merge, we will cause issues with the dev UI environment because the dropdown will be referencing images that are no longer cached. While this had not been an issue in the past, a recent Google behavior change has caused non-cached images to fail, which exposed this problem.

The code here is relatively straightforward. You can test this locally by adjusting the environmentKey variable in the config.json file, which will change the versions of the images in the dropdown when creating a custom environment. 

<img width="657" alt="Screen Shot 2022-06-02 at 9 27 13 AM" src="https://user-images.githubusercontent.com/62293969/171639948-de01c8e1-c643-4cc7-abe1-0778af3aebfa.png">

We have created 4 files in the terra-docker-image-documentation bucket: 

terra-docker-versions-dev.json, terra-docker-versions-alpha.json, terra-docker-versions-staging.json, terra-docker-versions-prod.json

I will be making a companion PR in terra-docker to update the readme so we are aware of this new workflow. These will be replacing the current terra-docker-versions-new.json and terra-docker-versions.json files we have now.

The way I anticipate this working would be: User merges new leo cached images to dev on Leonardo > User updates -dev file, alpha gets promoted overnight > We update the -alpha file when we can to avoid too many failures.

During release, we update -staging when staging is promoted. When Prod is released, we update -prod.

The only worry I have is the alpha overnight promotion timing, since that will mean we will have failures on the UI tests. Not sure if there's a clean way to have it done in the same job(?)

For sake of testing, I manually altered the json files to have different versions of the Default GATK image for testing purposes. Before this is merged, I will change these files to be the same as the most updated version.

<!--
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Also, so if a screen recording [1] and/or screenshots would be a helpful way to communicate context, please consider including some in your PR description.
Thanks!

[1] https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac
--!>
