### PR TITLE
[SU-29] Add delete data table button

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -925,6 +925,10 @@ const Workspaces = signal => ({
         return fetchRawls(`${root}/entityTypes/${oldName}`, _.mergeAll([authOpts(), jsonBody(payload), { signal, method: 'PATCH' }]))
       },
 
+      deleteEntitiesOfType: entityType => {
+        return fetchRawls(`${root}/entityTypes/${entityType}`, _.merge(authOpts(), { signal, method: 'DELETE' }))
+      },
+
       deleteEntityAttribute: (type, name, attributeName) => {
         return fetchRawls(`${root}/entities/${type}/${name}`, _.mergeAll([authOpts(), jsonBody([{ op: 'RemoveAttribute', attributeName }]),
           { signal, method: 'PATCH' }]))

--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -66,6 +66,7 @@ const eventsList = {
   workspaceDataUpload: 'workspace:data:upload',
   workspaceDataRenameEntity: 'workspace:data:renameEntity',
   workspaceDataRenameTable: 'workspace:data:rename-table',
+  workspaceDataDeleteTable: 'workspace:data:deleteTable',
   workspaceOpenFromList: 'workspace:open-from-list',
   workspaceSampleTsvDownload: 'workspace:sample-tsv:download',
   workspaceShare: 'workspace:share',

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -8,7 +8,7 @@ import { AutoSizer } from 'react-virtualized'
 import * as breadcrumbs from 'src/components/breadcrumbs'
 import { requesterPaysWrapper, withRequesterPaysHandler } from 'src/components/bucket-utils'
 import Collapse from 'src/components/Collapse'
-import { ButtonOutline, Clickable, Link, spinnerOverlay } from 'src/components/common'
+import { ButtonOutline, Clickable, DeleteConfirmationModal, Link, spinnerOverlay } from 'src/components/common'
 import { EntityUploader, ReferenceDataDeleter, ReferenceDataImporter, renderDataCell, saveScroll } from 'src/components/data/data-utils'
 import EntitiesContent from 'src/components/data/EntitiesContent'
 import ExportDataModal from 'src/components/data/ExportDataModal'
@@ -466,7 +466,7 @@ const SidebarSeparator = ({ sidebarWidth, setSidebarWidth }) => {
   ])
 }
 
-const DataTableActions = ({ workspace, tableName, rowCount, onUpdateSuccess }) => {
+const DataTableActions = ({ workspace, tableName, rowCount, onRenameTable, onDeleteTable }) => {
   const { workspace: { namespace, name }, workspaceSubmissionStats: { runningSubmissionsCount } } = workspace
   const isSetOfSets = tableName.endsWith('_set_set')
 
@@ -479,6 +479,7 @@ const DataTableActions = ({ workspace, tableName, rowCount, onUpdateSuccess }) =
   const [entities, setEntities] = useState([])
   const [exporting, setExporting] = useState(false)
   const [renaming, setRenaming] = useState(false)
+  const [deleting, setDeleting] = useState(false)
 
   return h(Fragment, [
     h(MenuTrigger, {
@@ -523,7 +524,12 @@ const DataTableActions = ({ workspace, tableName, rowCount, onUpdateSuccess }) =
           },
           disabled: !!editWorkspaceErrorMessage,
           tooltip: editWorkspaceErrorMessage || ''
-        }, 'Rename table')
+        }, 'Rename table'),
+        h(MenuButton, {
+          onClick: () => setDeleting(true),
+          disabled: !!editWorkspaceErrorMessage,
+          tooltip: editWorkspaceErrorMessage || ''
+        }, 'Delete table')
       ])
     }, [
       h(Clickable, {
@@ -544,9 +550,25 @@ const DataTableActions = ({ workspace, tableName, rowCount, onUpdateSuccess }) =
     }),
     renaming && h(RenameTableModal, {
       onDismiss: () => setRenaming(false),
-      onUpdateSuccess,
+      onUpdateSuccess: onRenameTable,
       namespace, name,
       selectedDataType: tableName
+    }),
+    deleting && h(DeleteConfirmationModal, {
+      objectType: 'table',
+      objectName: tableName,
+      onDismiss: () => setDeleting(false),
+      onConfirm: async () => {
+        setDeleting(false)
+        setLoading(true)
+        try {
+          await Ajax().Workspaces.workspace(namespace, name).deleteEntitiesOfType(tableName)
+          onDeleteTable(tableName)
+        } catch (err) {
+          reportError(err)
+          setLoading(false)
+        }
+      }
     })
   ])
 }
@@ -779,7 +801,11 @@ const WorkspaceData = _.flow(
                     tableName: type,
                     rowCount: typeDetails.count,
                     workspace,
-                    onUpdateSuccess: () => loadMetadata()
+                    onRenameTable: () => loadMetadata(),
+                    onDeleteTable: tableName => {
+                      setSelectedDataType(undefined)
+                      setEntityMetadata(_.unset(tableName))
+                    }
                   })
                 })
               }, sortedEntityPairs)

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -563,6 +563,9 @@ const DataTableActions = ({ workspace, tableName, rowCount, onRenameTable, onDel
         setLoading(true)
         try {
           await Ajax().Workspaces.workspace(namespace, name).deleteEntitiesOfType(tableName)
+          Ajax().Metrics.captureEvent(Events.workspaceDataDeleteTable, {
+            ...extractWorkspaceDetails(workspace.workspace)
+          })
           onDeleteTable(tableName)
         } catch (err) {
           reportError(err)

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -558,20 +558,16 @@ const DataTableActions = ({ workspace, tableName, rowCount, onRenameTable, onDel
       objectType: 'table',
       objectName: tableName,
       onDismiss: () => setDeleting(false),
-      onConfirm: async () => {
-        setDeleting(false)
-        setLoading(true)
-        try {
-          await Ajax().Workspaces.workspace(namespace, name).deleteEntitiesOfType(tableName)
-          Ajax().Metrics.captureEvent(Events.workspaceDataDeleteTable, {
-            ...extractWorkspaceDetails(workspace.workspace)
-          })
-          onDeleteTable(tableName)
-        } catch (err) {
-          reportError(err)
-          setLoading(false)
-        }
-      }
+      onConfirm: _.flow(
+        Utils.withBusyState(setLoading),
+        withErrorReporting('Error deleting table')
+      )(async () => {
+        await Ajax().Workspaces.workspace(namespace, name).deleteEntitiesOfType(tableName)
+        Ajax().Metrics.captureEvent(Events.workspaceDataDeleteTable, {
+          ...extractWorkspaceDetails(workspace.workspace)
+        })
+        onDeleteTable(tableName)
+      })
     })
   ])
 }


### PR DESCRIPTION
Currently, deleting a data table requires selecting all rows and deleting them. Because of the Rawls API, this requires fetching the IDs of all entities in the table and passing them back to the delete entities endpoint. This adds a button to use a more efficient endpoint that requires only the entity type.

https://user-images.githubusercontent.com/1156625/171656214-3d79659a-0317-42cc-b84d-7e7f6c1b0f56.mov

