### PR TITLE
[SU-115] Add Mixpanel event for cross table search

### DIFF
--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -52,6 +52,7 @@ const eventsList = {
   workspaceDataCopy: 'workspace:data:copy',
   workspaceDataCopyToClipboard: 'workspace:data:copyToClipboard',
   workspaceDataCreateSet: 'workspace:data:createSet',
+  workspaceDataCrossTableSearch: 'workspace:data:crossTableSearch',
   workspaceDataDelete: 'workspace:data:delete',
   workspaceDataDeleteColumn: 'workspace:data:deleteColumn',
   workspaceDataDownload: 'workspace:data:download',

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -673,6 +673,10 @@ const WorkspaceData = _.flow(
         return { typeName, filteredCount }
       }, typeNames))
       setCrossTableResultCounts(results)
+      Ajax().Metrics.captureEvent(Events.workspaceDataCrossTableSearch, {
+        ...extractWorkspaceDetails(workspace.workspace),
+        numTables: _.size(typeNames)
+      })
     } catch (error) {
       reportError('Error searching across tables', error)
     }


### PR DESCRIPTION
To enable cross-table search, use `window.configOverridesStore.set({ isSearchAwesomeNow: true })`. Then enter a query in the search box in the sidebar.

![Screen Shot 2022-06-02 at 1 14 00 PM](https://user-images.githubusercontent.com/1156625/171686545-05db6a0c-1d97-473f-9af7-5153c6ee34e7.png)
