### PR TITLE
[IA-3405] Fixes a notification bug

### DIFF
--- a/src/pages/workspaces/workspace/applications/AppLauncher.js
+++ b/src/pages/workspaces/workspace/applications/AppLauncher.js
@@ -187,16 +187,18 @@ const ApplicationLauncher = _.flow(
       setShouldSetupWelder(true)
     }
 
-    const findOutdatedAnalyses = withErrorReporting('Error loading outdated analyses', async () => {
+    const findOutdatedAnalyses = withErrorReporting('Error loading outdated analyses (test 3!)', async () => {
       const outdatedRAnalyses = await checkForOutdatedAnalyses({ googleProject, bucketName })
       setOutdatedAnalyses(outdatedRAnalyses)
       !_.isEmpty(outdatedRAnalyses) && setFileOutdatedOpen(true)
     })
 
-    !!googleProject && findOutdatedAnalyses()
+    if (runtimeStatus === 'Running') {
+      !!googleProject && findOutdatedAnalyses()
 
-    // periodically check for outdated R analyses
-    interval.current = !!googleProject && setInterval(findOutdatedAnalyses, 10000)
+      // periodically check for outdated R analyses
+      interval.current = !!googleProject && setInterval(findOutdatedAnalyses, 10000)
+    }
 
     return () => {
       clearInterval(interval.current)

--- a/src/pages/workspaces/workspace/applications/AppLauncher.js
+++ b/src/pages/workspaces/workspace/applications/AppLauncher.js
@@ -187,7 +187,7 @@ const ApplicationLauncher = _.flow(
       setShouldSetupWelder(true)
     }
 
-    const findOutdatedAnalyses = withErrorReporting('Error loading outdated analyses (test 3!)', async () => {
+    const findOutdatedAnalyses = withErrorReporting('Error loading outdated analyses', async () => {
       const outdatedRAnalyses = await checkForOutdatedAnalyses({ googleProject, bucketName })
       setOutdatedAnalyses(outdatedRAnalyses)
       !_.isEmpty(outdatedRAnalyses) && setFileOutdatedOpen(true)

--- a/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
@@ -90,7 +90,7 @@ const AnalysisLauncher = _.flow(
               { key: runtimeName, workspace, runtime, analysisName, mode, toolLabel, styles: iframeStyles }) :
             h(Fragment, [
               h(PreviewHeader, {
-                styles: iframeStyles, queryParams, runtime, analysisName, toolLabel, workspace, setCreateOpen,
+                styles: iframeStyles, queryParams, runtime, analysisName, toolLabel, workspace, setCreateOpen, refreshRuntimes,
                 readOnlyAccess: !(Utils.canWrite(accessLevel) && canCompute), onCreateRuntime: () => setCreateOpen(true)
               }),
               h(AnalysisPreviewFrame, { styles: iframeStyles, analysisName, toolLabel, workspace })

--- a/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
@@ -90,7 +90,7 @@ const AnalysisLauncher = _.flow(
               { key: runtimeName, workspace, runtime, analysisName, mode, toolLabel, styles: iframeStyles }) :
             h(Fragment, [
               h(PreviewHeader, {
-                styles: iframeStyles, queryParams, runtime, analysisName, toolLabel, workspace, setCreateOpen, refreshRuntimes,
+                styles: iframeStyles, queryParams, runtime, analysisName, toolLabel, workspace, setCreateOpen,
                 readOnlyAccess: !(Utils.canWrite(accessLevel) && canCompute), onCreateRuntime: () => setCreateOpen(true)
               }),
               h(AnalysisPreviewFrame, { styles: iframeStyles, analysisName, toolLabel, workspace })


### PR DESCRIPTION
Users have been reporting they are receiving "Error loading outdated analyses" when leaving their RStudio runtime idle for a while and then returning to it they get a bunch of notifications.

This PR adds logic to only check for outdated analyses if the runtime is `Running`

I tested this by creating an rstudio runtime with a really short autopause threshold (2min), leaving the runtime idle and then coming back to it
