### PR TITLE
[IA-3473] Fix bug where user incorrectly gets prompted to update their runtime

### DIFF
--- a/src/pages/workspaces/workspace/applications/AppLauncher.js
+++ b/src/pages/workspaces/workspace/applications/AppLauncher.js
@@ -68,7 +68,7 @@ const ApplicationLauncher = _.flow(
 
   const FileOutdatedModal = ({ onDismiss, bucketName }) => {
     const handleChoice = _.flow(
-      withErrorReportingInModal('Error setting up analysis file syncing (test 4)')(onDismiss),
+      withErrorReportingInModal('Error setting up analysis file syncing')(onDismiss),
       Utils.withBusyState(setBusy)
     )(async shouldCopy => {
       // this modal only opens when the state variable outdatedAnalyses is non empty (keeps track of a user's outdated RStudio files). it gives users two options when their files are in use by another user
@@ -157,7 +157,7 @@ const ApplicationLauncher = _.flow(
 
     const setupWelder = _.flow(
       Utils.withBusyState(setBusy),
-      withErrorReporting('Error setting up analysis file syncing (test 1)')
+      withErrorReporting('Error setting up analysis file syncing')
     )(async () => {
       const localBaseDirectory = ``
       const localSafeModeBaseDirectory = ``
@@ -171,7 +171,7 @@ const ApplicationLauncher = _.flow(
 
     const loadBucketLocation = _.flow(
       Utils.withBusyState(setBusy),
-      withErrorReporting('Error loading bucket location (test 2')
+      withErrorReporting('Error loading bucket location')
     )(async () => {
       const { location } = await Ajax()
         .Workspaces

--- a/src/pages/workspaces/workspace/applications/AppLauncher.js
+++ b/src/pages/workspaces/workspace/applications/AppLauncher.js
@@ -68,7 +68,7 @@ const ApplicationLauncher = _.flow(
 
   const FileOutdatedModal = ({ onDismiss, bucketName }) => {
     const handleChoice = _.flow(
-      withErrorReportingInModal('Error setting up analysis file syncing')(onDismiss),
+      withErrorReportingInModal('Error setting up analysis file syncing (test 4)')(onDismiss),
       Utils.withBusyState(setBusy)
     )(async shouldCopy => {
       // this modal only opens when the state variable outdatedAnalyses is non empty (keeps track of a user's outdated RStudio files). it gives users two options when their files are in use by another user
@@ -157,7 +157,7 @@ const ApplicationLauncher = _.flow(
 
     const setupWelder = _.flow(
       Utils.withBusyState(setBusy),
-      withErrorReporting('Error setting up analysis file syncing')
+      withErrorReporting('Error setting up analysis file syncing (test 1)')
     )(async () => {
       const localBaseDirectory = ``
       const localSafeModeBaseDirectory = ``
@@ -171,7 +171,7 @@ const ApplicationLauncher = _.flow(
 
     const loadBucketLocation = _.flow(
       Utils.withBusyState(setBusy),
-      withErrorReporting('Error loading bucket location')
+      withErrorReporting('Error loading bucket location (test 2')
     )(async () => {
       const { location } = await Ajax()
         .Workspaces

--- a/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
@@ -90,7 +90,7 @@ const AnalysisLauncher = _.flow(
               { key: runtimeName, workspace, runtime, analysisName, mode, toolLabel, styles: iframeStyles }) :
             h(Fragment, [
               h(PreviewHeader, {
-                styles: iframeStyles, queryParams, runtime, analysisName, toolLabel, workspace, setCreateOpen,
+                styles: iframeStyles, queryParams, runtime, analysisName, toolLabel, workspace, setCreateOpen, refreshRuntimes,
                 readOnlyAccess: !(Utils.canWrite(accessLevel) && canCompute), onCreateRuntime: () => setCreateOpen(true)
               }),
               h(AnalysisPreviewFrame, { styles: iframeStyles, analysisName, toolLabel, workspace })

--- a/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
@@ -259,12 +259,11 @@ const PreviewHeader = ({
     }
   })
 
-  const startAndRefresh = async (toolLabel, promise) => {
+  const startAndRefresh = async (refreshRuntimes, promise) => {
     try {
       setBusy(true)
       await promise
       await refreshRuntimes(true)
-      console.log('status: ', runtimeStatus)
     } catch (error) {
       reportError('Cloud Environment Error', error)
     } finally {
@@ -306,17 +305,15 @@ const PreviewHeader = ({
           h(HeaderButton, {
             onClick: () => {
               if (runtimeStatus === 'Running' && currentRuntimeTool === toolLabel) {
-                console.log('test 1')
                 Ajax().Metrics.captureEvent(Events.analysisLaunch,
                   { origin: 'analysisLauncher', source: tools.RStudio.label, application: tools.RStudio.label, workspaceName: name, namespace })
                 Nav.goToPath(appLauncherTabName, { namespace, name, application: 'RStudio' })
                 } else if (runtimeStatus === 'Stopped' && currentRuntimeTool === toolLabel) {
                // we make it here because mode is undefined. we don't have modes for rstudio (that i'm aware of)
-                console.log('THIS IS A BAD BUG')
-                startAndRefresh(currentRuntimeTool, Ajax().Runtimes.runtime(googleProject, runtime.runtimeName).start())
+                chooseMode('edit')
+                startAndRefresh(refreshRuntimes, Ajax().Runtimes.runtime(googleProject, runtime.runtimeName).start())
               }
               else {
-                console.log('test 2 in else')
                 setCreateOpen(true)
               }
             }

--- a/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
@@ -290,12 +290,10 @@ const PreviewHeader = ({
             [locked, () => h(HeaderButton, { onClick: () => setFileInUseOpen(true) }, [
               makeMenuIcon('lock'), 'Open (In use)'
             ])],
-            () => h(HeaderButton, { onClick: () => currentRuntimeTool !== tools.Jupyter.label ? () => {
-                chooseMode('edit')
-                setCreateOpen(true)
-              } : chooseMode('edit') }, [
+            () => h(HeaderButton, { onClick: () => currentRuntimeTool !== tools.Jupyter.label ? setCreateOpen(true) : chooseMode('edit') }, [
               makeMenuIcon('rocket'), 'Open'
-            ])),
+            ])
+          ),
           h(HeaderButton, {
             onClick: () => getLocalPref('hidePlaygroundMessage') ? chooseMode('playground') : setPlaygroundModalOpen(true)
           }, [

--- a/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
@@ -233,7 +233,6 @@ const PreviewHeader = ({
   const { user: { email } } = useStore(authStore)
   const [fileInUseOpen, setFileInUseOpen] = useState(false)
   const [editModeDisabledOpen, setEditModeDisabledOpen] = useState(false)
-  const [busy, setBusy] = useState(false)
   const [playgroundModalOpen, setPlaygroundModalOpen] = useState(false)
   const [locked, setLocked] = useState(false)
   const [lockedBy, setLockedBy] = useState(null)
@@ -261,13 +260,10 @@ const PreviewHeader = ({
 
   const startAndRefresh = async (refreshRuntimes, promise) => {
     try {
-      setBusy(true)
       await promise
       await refreshRuntimes(true)
     } catch (error) {
       reportError('Cloud Environment Error', error)
-    } finally {
-      setBusy(false)
     }
   }
 
@@ -306,12 +302,12 @@ const PreviewHeader = ({
                 Ajax().Metrics.captureEvent(Events.analysisLaunch,
                   { origin: 'analysisLauncher', source: tools.RStudio.label, application: tools.RStudio.label, workspaceName: name, namespace })
                 Nav.goToPath(appLauncherTabName, { namespace, name, application: 'RStudio' })
-                } else if (runtimeStatus === 'Stopped' && currentRuntimeTool === toolLabel) {
-               // we make it here because mode is undefined. we don't have modes for rstudio (that i'm aware of)
-                chooseMode('edit')
+              } else if (runtimeStatus === 'Stopped' && currentRuntimeTool === toolLabel) {
+                // we make it here because mode is undefined. we don't have modes for rstudio currently but will be creating a follow up
+                // ticket to address this. Not having modes is causing some bugs in this logic
+                chooseMode('rstudio') // TODO: we don't have mode for rstudio
                 startAndRefresh(refreshRuntimes, Ajax().Runtimes.runtime(googleProject, runtime.runtimeName).start())
-              }
-              else {
+              } else {
                 setCreateOpen(true)
               }
             }
@@ -337,7 +333,7 @@ const PreviewHeader = ({
         ])
       ])],
       [_.includes(runtimeStatus, usableStatuses), () => {
-        console.assert(false, `Expected cloud environment to NOT be one of: [${usableStatuses}]`)
+        console.assert(false, `${runtimeStatus} | Expected cloud environment to NOT be one of: [${usableStatuses}]`)
         return null
       }],
       [runtimeStatus === 'Creating', () => h(StatusMessage, [


### PR DESCRIPTION
This PR fixes a bug where:
- A user has an RStudio runtime that is `Stopped`
- that user navigates to the analyses tab, clicks on an Rmd file and clicks on the "Open" button that opens RStudio and the cloud environment modal opens and prompts the user to update their runtime when clicking this button should instead just start the user's runtime since it's currently paused.
![Screen Shot 2022-06-03 at 12 19 53 AM](https://user-images.githubusercontent.com/23626109/171785425-b9e1d160-d250-49f5-b787-d1ee4e5832ae.png)
![Screen Shot 2022-06-03 at 12 20 28 AM](https://user-images.githubusercontent.com/23626109/171785486-7785f817-8347-4bb9-b390-6d35d117d708.png)

This PR makes it so that when a user has a paused RStudio environment and want to launch an Rmd file, their runtime is started (same behavior as jupyter)
![Screen Shot 2022-06-03 at 10 26 47 AM](https://user-images.githubusercontent.com/23626109/171874037-a675a868-0914-408a-9f82-3fe0722a3bef.png)

We will be creating a follow up ticket to address RStudio modes in the UI - this PR fixes when a runtime is Stopped and a user wants to start it but we still need to address other corner cases


