### PR TITLE
QA-1825 Modify fiddly browser/test synchronization for signing in to FireCloud

### DIFF
--- a/integration-tests/utils/firecloud-utils.js
+++ b/integration-tests/utils/firecloud-utils.js
@@ -10,7 +10,6 @@ const signIntoFirecloud = async (page, token) => {
   await page.waitForXPath('//title[text()="FireCloud | Broad Institute"]')
   await findText(page, 'content you are looking for is currently only accessible')
 
-  // console.log('waiting for google auth library to load')
   await page.waitForXPath('//*[@id="sign-in-button"]')
 
   /*

--- a/integration-tests/utils/firecloud-utils.js
+++ b/integration-tests/utils/firecloud-utils.js
@@ -1,4 +1,4 @@
-const { click, findText, waitForNoSpinners } = require('./integration-utils')
+const { click, delay, findText, waitForNoSpinners } = require('./integration-utils')
 
 
 const selectWorkspace = async (page, billingAccount, workspace) => {
@@ -7,6 +7,12 @@ const selectWorkspace = async (page, billingAccount, workspace) => {
 }
 
 const signIntoFirecloud = async (page, token) => {
+  await page.waitForXPath('//title[text()="FireCloud | Broad Institute"]')
+  await findText(page, 'content you are looking for is currently only accessible')
+
+  // console.log('waiting for google auth library to load')
+  await page.waitForXPath('//*[@id="sign-in-button"]')
+
   /*
    * The FireCloud not-signed-in page renders the sign-in button while it is still doing some
    * initialization. If you log the status of the App components state for user-status and auth2
@@ -14,21 +20,27 @@ const signIntoFirecloud = async (page, token) => {
    *   '#{}' ''
    *   '#{}' '[object Object]'
    *   '#{:refresh-token-saved}' '[object Object]'
+   *
    * If the page is used before this is complete (for example window.forceSignedIn adding
    * :signed-in to user-status), bad things happen (for example :signed-in being dropped from
-   * user-status). Instead of reworking the sign-in logic for a case that (for the most part) only
-   * a computer will operate fast enough to encounter, we'll just slow the computer down a little.
+   * user-status). Put another way, if forceSignedIn is called between the 2nd and 3rd render, the
+   * sign-in doesn't work. The visible effect (failure screenshot) is that the test gets stuck on
+   * the FireCloud sign-in page.
+   *
+   * There is no observable evidence that the component has settled into its final state. I (Brian)
+   * believe that watching for the sign-in button (which is also what the FireCloud UI tests did:
+   * https://github.com/broadinstitute/firecloud-ui/blob/ab678610367c8388d70de768db0ad84c6df63997/automation/src/test/scala/org/broadinstitute/dsde/firecloud/page/user/SignInPage.scala#L31) will get us past the 2nd render
+   * but not necessarily the thrid. Therefore, instead of reworking the sign-in logic for a case
+   * that (for the most part) only a computer will operate fast enough to encounter, we'll just slow
+   * the computer down a little with a fixed-length sleep.
+   *
+   * Note that the amount of sleep needed is dependent on CPU load where the browser is running,
+   * which can be affected by CPU speed, memory, and other processes running at the same time
+   * (notably tests running in parallel). The duration below may be overkill in many conditions, but
+   * we want it to always be enough, whether running 10 parallel executions on a developer laptop or
+   * running in a CI server.
    */
-  await page.waitForResponse(response => {
-    return response.url().startsWith('https://accounts.google.com/o/oauth2/iframerpc') &&
-        response.request().method() === 'GET' &&
-        response.status() === 200
-  }, { timeout: 30 * 1000 }
-  )
-
-  await page.waitForXPath('//title[text()="FireCloud | Broad Institute"]')
-  await findText(page, 'content you are looking for is currently only accessible')
-  await waitForNoSpinners(page)
+  await delay(1500)
 
   console.log(`Sign in Firecloud: ${page.url()}`)
   await page.waitForFunction('!!window["forceSignedIn"]')

--- a/integration-tests/utils/firecloud-utils.js
+++ b/integration-tests/utils/firecloud-utils.js
@@ -1,4 +1,4 @@
-const { click, delay, findText, waitForNoSpinners } = require('./integration-utils')
+const { click, delay, findText } = require('./integration-utils')
 
 
 const selectWorkspace = async (page, billingAccount, workspace) => {


### PR DESCRIPTION
Back before Terra, I was involved in the development of the FireCloud UI tests. At that time, I did a bunch of debugging around this exact same problem. The result is [here](https://github.com/broadinstitute/firecloud-ui/blob/ab678610367c8388d70de768db0ad84c6df63997/automation/src/test/scala/org/broadinstitute/dsde/firecloud/page/user/SignInPage.scala#L31). That's the origin of the comment explaining the fixed-duration delay that also made its way into the Terra UI tests (which I was also involved in the development of).

Based on my memory of that and some further experimentation, I've made a couple of changes here, including re-introducing that delay. I expanded on the code comment to try to make it more clear, but I'll also go into further detail here.

FireCloud UI's main `App` component has a funky initialization process where the initial render will update the component's state which will then cause a re-render. There are at least 3 separate render operations in this chain. This might not be a problem except that some UI elements get rendered before the page is fully ready. If you watch closely, you might even be able to see an extra flicker when loading the page. What's happening in the test is that `forceSignedIn` is being called before the final render, but the state change is still getting queued. When that final state change happens, the result is re-rendering the sign-in page (which is what gets captured in the screenshot). Since there's really no observable way to detect that the final render has happened, the only thing I can come up with to do is to add a fixed-duration sleep.

I changed the code to look for the sign in button instead of using `page.waitForResponse`. While I like the idea of using `waitForResponse`, it wasn't working reliably for me. In my manual testing, if I went directly to `https://firecloud.dsde-dev.broadinstitute.org/?return=terra#methods/gatk/echo_to_file/`, I also would not see `iframerpc`. However, if I navigated forward from Terra (like the test does) I _would_ see a request for `iframerpc`. Also, when running the test non-headless, there was never a request for `https://accounts.google.com/o/oauth2/iframerpc` even though the test seemed to work when running headless. Ultimately, it just seems too unreliable to use. The old FireCloud UI tests used the sign-in button as an initial check so I think that'll be fine here too.

In the end, this passed several `CONCURRENCY=10 RUNS=100 yarn test-flakes find-workflow` runs on my laptop so I think this will be a good improvement.