### PR TITLE
[QA-1899] Test failure tool: Save page's content to file when test fails

### DIFF
--- a/integration-tests/jest-circus-environment.js
+++ b/integration-tests/jest-circus-environment.js
@@ -1,5 +1,5 @@
 const PuppeteerEnvironment = require('jest-environment-puppeteer')
-const { maybeSaveScreenshot } = require('./utils/integration-utils')
+const { maybeSaveScreenshot, savePageContent } = require('./utils/integration-utils')
 const { parse } = require('path')
 
 
@@ -16,6 +16,7 @@ class JestCircusEnvironment extends PuppeteerEnvironment {
     if (['hook_failure', 'test_fn_failure'].includes(name)) {
       const [activePage] = (await this.global.browser.pages()).slice(-1)
       await maybeSaveScreenshot(activePage, this.testName)
+      await savePageContent(activePage, this.testName)
     }
     if (super.handleTestEvent) {
       await super.handleTestEvent(event, state)

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -1,5 +1,5 @@
 const _ = require('lodash/fp')
-const { mkdirSync } = require('fs')
+const { mkdirSync, writeFileSync } = require('fs')
 const { resolve } = require('path')
 const { Storage } = require('@google-cloud/storage')
 const { screenshotBucket, screenshotDirPath } = require('../utils/integration-config')
@@ -278,11 +278,16 @@ const openError = async page => {
   return !!errorDetails.length
 }
 
-const maybeSaveScreenshot = async (page, testName) => {
+const getScreenshotDir = () => {
   const dir = screenshotDirPath ?
     screenshotDirPath :
     process.env.SCREENSHOT_DIR || process.env.LOG_DIR || resolve(__dirname, '../test-results/screenshots')
+  mkdirSync(dir, { recursive: true })
+  return dir
+}
 
+const maybeSaveScreenshot = async (page, testName) => {
+  const dir = getScreenshotDir()
   try {
     mkdirSync(dir, { recursive: true })
     const path = `${dir}/failure-${Date.now()}-${testName}.png`
@@ -309,11 +314,27 @@ const maybeSaveScreenshot = async (page, testName) => {
   }
 }
 
+// Save page content to screenshot dir. Useful for test failure troubleshooting
+const savePageContent = async (page, testName) => {
+  const dir = getScreenshotDir()
+  const htmlContent = await page.content()
+  const htmlFile = `${dir}/failure-${Date.now()}-${testName}.html`
+  try {
+    writeFileSync(htmlFile, htmlContent, { encoding: 'utf8' })
+    console.log(`Saved screenshot page content: ${htmlFile}`)
+  } catch (e) {
+    console.error('Failed to save screenshot page content')
+    console.error(e)
+    // Let test continue
+  }
+}
+
 const withScreenshot = _.curry((testName, fn) => async options => {
   try {
     return await fn(options)
   } catch (e) {
     await maybeSaveScreenshot(options.page, testName)
+    await savePageContent(options.page, testName)
     throw e
   }
 })

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -289,7 +289,6 @@ const getScreenshotDir = () => {
 const maybeSaveScreenshot = async (page, testName) => {
   const dir = getScreenshotDir()
   try {
-    mkdirSync(dir, { recursive: true })
     const path = `${dir}/failure-${Date.now()}-${testName}.png`
     const failureNotificationDetailsPath = `${dir}/failureDetails-${Date.now()}-${testName}.png`
 
@@ -334,7 +333,6 @@ const withScreenshot = _.curry((testName, fn) => async options => {
     return await fn(options)
   } catch (e) {
     await maybeSaveScreenshot(options.page, testName)
-    await savePageContent(options.page, testName)
     throw e
   }
 })
@@ -412,5 +410,6 @@ module.exports = {
   openError,
   navOptionNetworkIdle,
   maybeSaveScreenshot,
-  gotoPage
+  gotoPage,
+  savePageContent
 }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/QA-1899

Save page's content to a .html file along with screenshot to help with test failure troubleshooting.