### PR TITLE
[QA-1902] Fix launchWorkflowAndWaitForSuccess test helper

### DIFF
--- a/integration-tests/utils/workflow-utils.js
+++ b/integration-tests/utils/workflow-utils.js
@@ -22,13 +22,18 @@ const launchWorkflowAndWaitForSuccess = async page => {
 
   // Long enough for the submission details to be Running or Failed.
   // Workflows might sit in "Submitted" for a long time if there is a large backlog of workflows in the environment
-  const isRunning = await Promise.race([
-    findInGrid(page, 'Failed', { timeout: 5 * 60 * 1000 }).then(() => false),
-    findInGrid(page, 'Running', { timeout: 5 * 60 * 1000 }).then(() => true)
+  const workflowStatus = await Promise.race([
+    findInGrid(page, 'Succeeded', { timeout: 5 * 60 * 1000 }).then(() => 'Succeeded'),
+    findInGrid(page, 'Failed', { timeout: 5 * 60 * 1000 }).then(() => 'Failed'),
+    findInGrid(page, 'Running', { timeout: 5 * 60 * 1000 }).then(() => 'Running')
   ])
 
+  if (workflowStatus === 'Succeeded') {
+    return
+  }
+
   // If status is not Running, fails test now
-  if (!isRunning) {
+  if (workflowStatus === 'Failed') {
     throw new Error('Workflow has failed')
   }
 


### PR DESCRIPTION
Currently, the `launchWorkflowAndWaitForSuccess` waits for a workflow to enter the "Running" state. However, the job history table polls for workflow status updates every minute, so the test is not guaranteed to see a "Running" state if the workflow starts and completes in between polls. The test handles the case where the workflow fails quickly, but it does not handle the case where the workflow succeeds quickly.

This test is currently frequently failing on dev. Looking at the screenshots shows that the workflow actually succeeded. Examples:
- https://app.circleci.com/pipelines/github/DataBiosphere/terra-ui/9966/workflows/dbafece7-8b97-4954-add3-a58c0dbb0363/jobs/44314/tests
- https://app.circleci.com/pipelines/github/DataBiosphere/terra-ui/9964/workflows/62f0d879-6e0c-43e6-b851-17f362a27376/jobs/44306/tests
- https://app.circleci.com/pipelines/github/DataBiosphere/terra-ui/9963/workflows/545a30fb-ef0e-4831-9470-192b46ef0d53/jobs/44304/tests