### PR TITLE
[SU-109] Rewrite file browser

### DIFF
--- a/src/components/ProgressBar.js
+++ b/src/components/ProgressBar.js
@@ -1,4 +1,6 @@
 import filesize from 'filesize'
+import _ from 'lodash/fp'
+import { Fragment } from 'react'
 import { dd, div, dl, dt, h, p, strong } from 'react-hyperscript-helpers'
 import { ButtonPrimary } from 'src/components/common'
 import Modal from 'src/components/Modal'
@@ -79,17 +81,19 @@ export const UploadProgressModal = ({ status: { totalFiles, totalBytes, uploaded
         style: { margin: '0.4rem 0 1rem 0', fontWeight: 600 }
       }, [filesize(currentFile.size, { round: 1 })])
     ]),
-    h(ProgressBar, {
-      max: totalBytes,
-      now: uploadedBytes
-    }),
-    p({}, [
-      'Transferred ',
-      strong([filesize(uploadedBytes, { round: 1 })]),
-      ' of ',
-      strong([filesize(totalBytes, { round: 1 })]),
-      ' ',
-      strong(['(', (uploadedBytes / totalBytes * 100).toFixed(0), '%)'])
+    _.size(totalFiles) > 1 && h(Fragment, [
+      h(ProgressBar, {
+        max: totalBytes,
+        now: uploadedBytes
+      }),
+      p({}, [
+        'Transferred ',
+        strong([filesize(uploadedBytes, { round: 1 })]),
+        ' of ',
+        strong([filesize(totalBytes, { round: 1 })]),
+        ' ',
+        strong(['(', (uploadedBytes / totalBytes * 100).toFixed(0), '%)'])
+      ])
     ])
   ])
 }

--- a/src/components/ProgressBar.js
+++ b/src/components/ProgressBar.js
@@ -86,7 +86,7 @@ export const UploadProgressModal = ({ status: { totalFiles, totalBytes, uploaded
         max: totalBytes,
         now: uploadedBytes
       }),
-      p({}, [
+      p([
         'Transferred ',
         strong([filesize(uploadedBytes, { round: 1 })]),
         ' of ',

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1140,9 +1140,9 @@ const Buckets = signal => ({
     return _.filter(({ name }) => name.endsWith(`.${tools.RStudio.ext}`) || name.endsWith(`.${tools.Jupyter.ext}`), items)
   },
 
-  list: async (googleProject, bucket, prefix) => {
+  list: async (googleProject, bucket, prefix, options = {}) => {
     const res = await fetchBuckets(
-      `storage/v1/b/${bucket}/o?${qs.stringify({ prefix, delimiter: '/' })}`,
+      `storage/v1/b/${bucket}/o?${qs.stringify({ delimiter: '/', ...options, prefix })}`,
       _.merge(authOpts(await saToken(googleProject)), { signal })
     )
     return res.json()

--- a/src/pages/Upload.js
+++ b/src/pages/Upload.js
@@ -1,9 +1,8 @@
 import _ from 'lodash/fp'
 import { Fragment, useEffect, useMemo, useRef, useState } from 'react'
 import { code, div, h, h2, h3, li, p, span, strong, ul } from 'react-hyperscript-helpers'
-import { requesterPaysWrapper, withRequesterPaysHandler } from 'src/components/bucket-utils'
 import { ButtonPrimary, Link, Select, topSpinnerOverlay, transparentSpinnerOverlay } from 'src/components/common'
-import { FileBrowserPanel } from 'src/components/data/FileBrowser'
+import FileBrowser from 'src/components/data/FileBrowser'
 import UploadPreviewTable from 'src/components/data/UploadPreviewTable'
 import Dropzone from 'src/components/Dropzone'
 import FloatingActionButton from 'src/components/FloatingActionButton'
@@ -18,7 +17,7 @@ import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { reportError, withErrorReporting } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
-import { forwardRefWithName, useCancellation, useOnMount, withDisplayName } from 'src/libs/react-utils'
+import { forwardRefWithName, useCancellation, useOnMount } from 'src/libs/react-utils'
 import * as StateHistory from 'src/libs/state-history'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
@@ -310,11 +309,8 @@ const WorkspaceSelectorPanel = ({
   ])
 }
 
-const CollectionSelectorPanel = _.flow(
-  withDisplayName('CollectionSelectorPanel'),
-  requesterPaysWrapper({ onDismiss: ({ onClose }) => onClose() })
-)(({
-  workspace: { workspace: { googleProject, bucketName } }, onRequesterPaysError, selectedCollection, setCollection, children, ...props
+const CollectionSelectorPanel = ({
+  workspace: { workspace: { googleProject, bucketName } }, selectedCollection, setCollection, children, ...props
 }) => {
   // State
   const [collections, setCollections] = useState(undefined)
@@ -331,7 +327,6 @@ const CollectionSelectorPanel = _.flow(
 
   // Helpers
   const load = _.flow(
-    withRequesterPaysHandler(onRequesterPaysError),
     withErrorReporting('Error loading bucket data'),
     Utils.withBusyState(setLoading)
   )(async () => {
@@ -402,18 +397,26 @@ const CollectionSelectorPanel = _.flow(
     }),
     isLoading && topSpinnerOverlay
   ])
-})
+}
 
-const DataUploadPanel = _.flow(
-  withDisplayName('DataUploadPanel'),
-  requesterPaysWrapper({ onDismiss: ({ onClose }) => onClose() })
-)(({ workspace, onRequesterPaysError, collection, setNumFiles, children }) => {
+const DataUploadPanel = ({ workspace, collection, setNumFiles, children }) => {
+  const { workspace: { googleProject, bucketName } } = workspace
   const basePrefix = `${rootPrefix}${collection}/`
 
   // Move the focus to the header the first time this panel is rendered
   const header = useRef()
   useOnMount(() => {
     header.current?.focus()
+  })
+
+  const signal = useCancellation()
+  const countFiles = async () => {
+    const { items } = await Ajax(signal).Buckets.listAll(googleProject, bucketName, { prefix: basePrefix })
+    setNumFiles(items.length)
+  }
+
+  useOnMount(() => {
+    countFiles()
   })
 
   return div({ style: { display: 'flex', flexFlow: 'column nowrap', height: '100%' } }, [
@@ -430,19 +433,19 @@ const DataUploadPanel = _.flow(
         ' You may upload as many files as you wish, but each filename must be unique.'
       ])
     ]),
-    h(FileBrowserPanel, {
-      style: { flex: '1 1 auto' },
-      workspace, onRequesterPaysError, setNumFiles, basePrefix, collection, allowNewFolders: false
+    h(FileBrowser, {
+      style: { flex: '1 1 auto', minHeight: '30rem', border: `1px solid ${colors.grey(0.4)}`, borderRadius: '0.5rem', overflow: 'hidden' },
+      workspace, basePrefix,
+      showNewFolderButton: false,
+      onUploadFiles: countFiles,
+      onDeleteFiles: countFiles
     })
   ])
-})
+}
 
-const MetadataUploadPanel = _.flow(
-  withDisplayName('MetadataUploadPanel'),
-  requesterPaysWrapper({ onDismiss: ({ onClose }) => onClose() })
-)(({
+const MetadataUploadPanel = ({
   workspace, workspace: { workspace: { namespace, googleProject, bucketName, name } },
-  onRequesterPaysError, onSuccess, collection, children
+  onSuccess, collection, children
 }) => {
   const basePrefix = `${rootPrefix}${collection}/`
   const [filesLoading, setFilesLoading] = useState(false)
@@ -470,7 +473,6 @@ const MetadataUploadPanel = _.flow(
   // Get every filename in the bucket, so we can do substitutions
   useEffect(() => {
     const loadFiles = _.flow(
-      withRequesterPaysHandler(onRequesterPaysError),
       withErrorReporting('Error loading bucket data'),
       Utils.withBusyState(setFilesLoading)
     )(async () => {
@@ -679,7 +681,7 @@ const MetadataUploadPanel = _.flow(
     }),
     (filesLoading || uploading) && topSpinnerOverlay
   ])
-})
+}
 
 const DonePanel = ({ workspace, workspace: { workspace: { namespace, name } }, tableName, collection, setCurrentStep }) => {
   // Move the focus to the header the first time this panel is rendered


### PR DESCRIPTION
Apologies for the large PR. There were enough changes to the file browser needed that it seemed easier to start from scratch and make them all at once.

This change updates the file browser component to...
- [x] Share code between data tab and uploader
- [x] Load one page of results at a time ([SU-119](https://broadworkbench.atlassian.net/browse/SU-119))
  - The easiest way to test this is to change the default value of the `pageSize` prop to something small (like 5 or 10).
- [x] Allow uploading multiple files at once ([SUP-677](https://broadworkbench.atlassian.net/browse/SUP-677))
- [x] Allow selecting and deleting multiple files at once ([SU-110](https://broadworkbench.atlassian.net/browse/SU-110))
- [x] Allow creating new "folders"
- [x] Match the new data tab style ([SU-109](https://broadworkbench.atlassian.net/browse/SU-109))
- [x] Refactor useUploader hook
- [x] Fix cancelling uploads

This affects the Files panel on the workspace Data tab and the file upload part of the Upload page.