### PR TITLE
[IA-3483] Fix for location not being set correctly in WorkspaceContainer

### DIFF
--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -310,7 +310,7 @@ export const wrapWorkspace = ({ breadcrumbs, activeTab, title, topBarContent, sh
     }
 
     const loadBucketLocation = async (googleProject, bucketName) => {
-      if (isGoogleWorkspace) {
+      if (!!googleProject) {
         const bucketLocation = await Ajax(signal).Workspaces.workspace(namespace, name).checkBucketLocation(googleProject, bucketName)
         setBucketLocation(bucketLocation)
       }


### PR DESCRIPTION
There is currently a bug where we're Unable to create cloud environments outside of US even when the workspace bucket is outside of US.

To reproduce:
1) Create/Load a workspace that has a bucket outside of the US (Montreal for example).
2) Attempt to create a cloud environment in this workspace. Click customize
3)  Notice that the dropdown to choose a location is stuck on US.
Expectation: Location dropdown should be set to Montreal, with the option to change to US. 

This happens because the `isGoogleWorkspace` prop doesn't get set properly when we first try to call `loadBucketLocation`. However, the googleProject is, so we can use that to determine that we are not an Azure workspace and can safely attempt to load the bucket location.