### PR TITLE
[QA-1905] Change button text in runtime manager error notifications

### DIFF
--- a/src/components/RuntimeManager.js
+++ b/src/components/RuntimeManager.js
@@ -112,7 +112,7 @@ const RuntimeErrorNotification = ({ runtime }) => {
         textDecoration: 'underline',
         fontWeight: 'bold'
       }
-    }, ['SEE LOG INFO']),
+    }, ['Details']),
     modalOpen && h(RuntimeErrorModal, {
       runtime,
       onDismiss: () => setModalOpen(false)
@@ -157,7 +157,7 @@ const AppErrorNotification = ({ app }) => {
         textDecoration: 'underline',
         fontWeight: 'bold'
       }
-    }, ['SEE LOG INFO']),
+    }, ['Details']),
     modalOpen && h(AppErrorModal, {
       app,
       onDismiss: () => setModalOpen(false)


### PR DESCRIPTION
When a cloud environment fails to start in integration tests, we would like to get more information about the error. [Slack thread for context](https://broadinstitute.slack.com/archives/C01EHNUM73R/p1654625184893469).

When a terra-ui integration test fails, it will take a screenshot of the page.

https://github.com/DataBiosphere/terra-ui/blob/a8969e58d20dff8652e955d96c6d27d1e8b9babf/integration-tests/jest-circus-environment.js#L16-L18

If there are any error notifications present, it will also expand those notifications and take a screenshot of the details modal.

https://github.com/DataBiosphere/terra-ui/blob/a8969e58d20dff8652e955d96c6d27d1e8b9babf/integration-tests/utils/integration-utils.js#L300-L304

To expand the notification, the tests look for a button labeled "Details".

https://github.com/DataBiosphere/terra-ui/blob/a8969e58d20dff8652e955d96c6d27d1e8b9babf/integration-tests/utils/integration-utils.js#L272-L281

This is based on the notifications shown by the shared `reportError` helper.

https://github.com/DataBiosphere/terra-ui/blob/a8969e58d20dff8652e955d96c6d27d1e8b9babf/src/libs/error.js#L11

https://github.com/DataBiosphere/terra-ui/blob/a8969e58d20dff8652e955d96c6d27d1e8b9babf/src/libs/notifications.js#L91-L94

However, the runtime manager's error notifications do not use this helper. They show a notification that behaves similarly: it has a button that opens a modal with details about the error. But the button is labeled "SEE LOG INFO". The tests don't recognize this button, so we don't get a screenshot of the error details.

This changes the button label to "Details" to make these error notifications work with the integration tests. Though this is a test issue, I think it's reasonable to make this change in the UI since it makes these error notifications consistent with others in the app.