### PR TITLE
[IA-3487] Change order of disk offerings to be ascending cost top to bottom.

### DIFF
--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -1708,7 +1708,7 @@ export const ComputeModalBase = ({
           options: [
             { label: pdTypes.standard.displayName, value: pdTypes.standard },
             { label: pdTypes.balanced.displayName, value: pdTypes.balanced },
-            { label: pdTypes.ssd.displayName, value: pdTypes.ssd },
+            { label: pdTypes.ssd.displayName, value: pdTypes.ssd }
           ]
         })
       ])

--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -1707,8 +1707,8 @@ export const ComputeModalBase = ({
           menuPlacement: 'auto',
           options: [
             { label: pdTypes.standard.displayName, value: pdTypes.standard },
+            { label: pdTypes.balanced.displayName, value: pdTypes.balanced },
             { label: pdTypes.ssd.displayName, value: pdTypes.ssd },
-            { label: pdTypes.balanced.displayName, value: pdTypes.balanced }
           ]
         })
       ])

--- a/src/components/GalaxyModal.js
+++ b/src/components/GalaxyModal.js
@@ -330,8 +330,8 @@ export const GalaxyModalBase = withDisplayName('GalaxyModal')(
               menuPlacement: 'auto',
               options: [
                 { label: pdTypes.standard.displayName, value: pdTypes.standard },
-                { label: pdTypes.ssd.displayName, value: pdTypes.ssd },
-                { label: pdTypes.balanced.displayName, value: pdTypes.balanced }
+                { label: pdTypes.balanced.displayName, value: pdTypes.balanced },
+                { label: pdTypes.ssd.displayName, value: pdTypes.ssd }
               ]
             })
           ])

--- a/src/libs/runtime-utils.js
+++ b/src/libs/runtime-utils.js
@@ -27,20 +27,20 @@ export const pdTypes = {
     displayName: 'Standard',
     regionToPricesName: 'monthlyStandardDiskPrice'
   },
-  ssd: {
-    label: 'pd-ssd',
-    displayName: 'Solid state drive (SSD)',
-    regionToPricesName: 'monthlySSDDiskPrice'
-  },
   balanced: {
     label: 'pd-balanced',
     displayName: 'Balanced',
     regionToPricesName: 'monthlyBalancedDiskPrice'
   },
+  ssd: {
+    label: 'pd-ssd',
+    displayName: 'Solid state drive (SSD)',
+    regionToPricesName: 'monthlySSDDiskPrice'
+  },
   fromString: str => Utils.switchCase(str,
     [pdTypes.standard.label, () => pdTypes.standard],
-    [pdTypes.ssd.label, () => pdTypes.ssd],
     [pdTypes.balanced.label, () => pdTypes.balanced],
+    [pdTypes.ssd.label, () => pdTypes.ssd],
     [Utils.DEFAULT, () => console.error(`Invalid disk type: Should not be calling pdTypes.fromString for ${str}`)]
   )
 }


### PR DESCRIPTION
## Description

The current persistent disk order feels unnatural being Standard -> SSD -> Balanced, since there is no logic to the order.

## Solution

Order the PD offerings so they have a logical order of ascending price. The new order will be Standard -> Balanced -> SSD.