### PR TITLE
[WOR-192] Change default GCP storage location to us-central1

### DIFF
--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -6,7 +6,6 @@ const {
 } = require('./integration-utils')
 const { fetchLyle } = require('./lyle-utils')
 const { withUserToken } = require('../utils/terra-sa-utils')
-const { defaultLocation } = require('../../src/libs/runtime-utils')
 
 
 const defaultTimeout = 5 * 60 * 1000
@@ -34,7 +33,7 @@ const makeWorkspace = withSignedInPage(async ({ page, billingProject }) => {
     const response = await page.evaluate(async (name, billingProject) => {
       try {
         // explicitly setting us-central1 in this call until rawls defaults to us-central1 as well
-        return await window.Ajax().Workspaces.create({ namespace: billingProject, name, attributes: {}, bucketLocation: defaultLocation })
+        return await window.Ajax().Workspaces.create({ namespace: billingProject, name, attributes: {}, bucketLocation: 'us-central1' })
       } catch (err) {
         console.error(err)
         console.error(typeof err)

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -6,7 +6,6 @@ const {
 } = require('./integration-utils')
 const { fetchLyle } = require('./lyle-utils')
 const { withUserToken } = require('../utils/terra-sa-utils')
-const { defaultLocation } = require('src/libs/runtime-utils')
 
 
 const defaultTimeout = 5 * 60 * 1000
@@ -33,7 +32,7 @@ const makeWorkspace = withSignedInPage(async ({ page, billingProject }) => {
   try {
     const response = await page.evaluate(async (name, billingProject) => {
       try {
-        return await window.Ajax().Workspaces.create({ namespace: billingProject, name, attributes: {}, bucketLocation: defaultLocation })
+        return await window.Ajax().Workspaces.create({ namespace: billingProject, name, attributes: {}, bucketLocation: 'us-central1' })
       } catch (err) {
         console.error(err)
         console.error(typeof err)

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -32,7 +32,7 @@ const makeWorkspace = withSignedInPage(async ({ page, billingProject }) => {
   try {
     const response = await page.evaluate(async (name, billingProject) => {
       try {
-        return await window.Ajax().Workspaces.create({ namespace: billingProject, name, attributes: {}, bucketLocation: 'us-central1' })
+        return await window.Ajax().Workspaces.create({ namespace: billingProject, name, attributes: {} })
       } catch (err) {
         console.error(err)
         console.error(typeof err)

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -32,6 +32,7 @@ const makeWorkspace = withSignedInPage(async ({ page, billingProject }) => {
   try {
     const response = await page.evaluate(async (name, billingProject) => {
       try {
+        // explicitly setting us-central1 in this call until rawls defaults to us-central1 as well
         return await window.Ajax().Workspaces.create({ namespace: billingProject, name, attributes: {}, bucketLocation: 'us-central1' })
       } catch (err) {
         console.error(err)

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -32,7 +32,7 @@ const makeWorkspace = withSignedInPage(async ({ page, billingProject }) => {
   try {
     const response = await page.evaluate(async (name, billingProject) => {
       try {
-        return await window.Ajax().Workspaces.create({ namespace: billingProject, name, attributes: {} })
+        return await window.Ajax().Workspaces.create({ namespace: billingProject, name, attributes: {}, bucketLocation: 'us-central1' })
       } catch (err) {
         console.error(err)
         console.error(typeof err)

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -6,6 +6,7 @@ const {
 } = require('./integration-utils')
 const { fetchLyle } = require('./lyle-utils')
 const { withUserToken } = require('../utils/terra-sa-utils')
+const { defaultLocation } = require('../../src/libs/runtime-utils')
 
 
 const defaultTimeout = 5 * 60 * 1000
@@ -33,7 +34,7 @@ const makeWorkspace = withSignedInPage(async ({ page, billingProject }) => {
     const response = await page.evaluate(async (name, billingProject) => {
       try {
         // explicitly setting us-central1 in this call until rawls defaults to us-central1 as well
-        return await window.Ajax().Workspaces.create({ namespace: billingProject, name, attributes: {}, bucketLocation: 'us-central1' })
+        return await window.Ajax().Workspaces.create({ namespace: billingProject, name, attributes: {}, bucketLocation: defaultLocation })
       } catch (err) {
         console.error(err)
         console.error(typeof err)

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -1,7 +1,8 @@
 const _ = require('lodash/fp')
 const uuid = require('uuid')
 const {
-  click, clickable, dismissNotifications, fillIn, findText, gotoPage, input, signIntoTerra, waitForNoSpinners, navChild, noSpinnersAfter, navOptionNetworkIdle
+  click, clickable, dismissNotifications, fillIn, findText, gotoPage, input, signIntoTerra, waitForNoSpinners, navChild, noSpinnersAfter,
+  navOptionNetworkIdle
 } = require('./integration-utils')
 const { fetchLyle } = require('./lyle-utils')
 const { withUserToken } = require('../utils/terra-sa-utils')
@@ -31,7 +32,7 @@ const makeWorkspace = withSignedInPage(async ({ page, billingProject }) => {
   try {
     const response = await page.evaluate(async (name, billingProject) => {
       try {
-        return await window.Ajax().Workspaces.create({ namespace: billingProject, name, attributes: {} })
+        return await window.Ajax().Workspaces.create({ namespace: billingProject, name, attributes: {}, bucketLocation: 'us-central1' })
       } catch (err) {
         console.error(err)
         console.error(typeof err)

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -6,6 +6,7 @@ const {
 } = require('./integration-utils')
 const { fetchLyle } = require('./lyle-utils')
 const { withUserToken } = require('../utils/terra-sa-utils')
+const { defaultLocation } = require('src/libs/runtime-utils')
 
 
 const defaultTimeout = 5 * 60 * 1000
@@ -32,7 +33,7 @@ const makeWorkspace = withSignedInPage(async ({ page, billingProject }) => {
   try {
     const response = await page.evaluate(async (name, billingProject) => {
       try {
-        return await window.Ajax().Workspaces.create({ namespace: billingProject, name, attributes: {}, bucketLocation: 'us-central1' })
+        return await window.Ajax().Workspaces.create({ namespace: billingProject, name, attributes: {}, bucketLocation: defaultLocation })
       } catch (err) {
         console.error(err)
         console.error(typeof err)

--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -830,8 +830,8 @@ export const ComputeModalBase = ({
         canShowEnvironmentWarning && (willDeleteBuiltinDisk() || willDeletePersistentDisk() || willRequireDowntime() || willDetachPersistentDisk()),
         () => h(ButtonPrimary, { ...commonButtonProps, onClick: () => setViewMode('environmentWarning') }, ['Next'])
       ], [
-        canShowWarning && isDifferentLocation(location, computeConfig.computeRegion),
-        () => h(ButtonPrimary, { ...commonButtonProps, onClick: () => setViewMode('differentLocationWarning') }, ['Next'])
+        canShowWarning && isDifferentLocation(),
+        ( => h(ButtonPrimary, { ...commonButtonProps, onClick: () => setViewMode('differentLocationWarning') }, ['Next'])
       ], [
         canShowWarning && !isUSLocation(computeConfig.computeRegion),
         () => h(ButtonPrimary, { ...commonButtonProps, onClick: () => setViewMode('nonUSLocationWarning') }, ['Next'])

--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -10,7 +10,7 @@ import { NumberInput, TextInput, ValidatedInput } from 'src/components/input'
 import { withModalDrawer } from 'src/components/ModalDrawer'
 import { getToolForImage, tools } from 'src/components/notebook-utils'
 import { InfoBox } from 'src/components/PopupTrigger'
-import { getAvailableComputeRegions, getRegionInfo, isUSLocation, locationTypes } from 'src/components/region-common'
+import { getAvailableComputeRegions, getLocationType, getRegionInfo, isUSLocation } from 'src/components/region-common'
 import { SaveFilesHelp, SaveFilesHelpRStudio } from 'src/components/runtime-common'
 import TitleBar from 'src/components/TitleBar'
 import TooltipTrigger from 'src/components/TooltipTrigger'
@@ -736,7 +736,7 @@ export const ComputeModalBase = ({
       setCustomEnvImage(!foundImage ? imageUrl : '')
       setJupyterUserScriptUri(currentRuntimeDetails?.jupyterUserScriptUri || '')
 
-      const locationType = location === defaultLocation ? locationTypes.default : locationTypes.region
+      const locationType = getLocationType(location)
       const { computeZone, computeRegion } = getRegionInfo(location || defaultLocation, locationType)
       const runtimeConfig = currentRuntimeDetails?.runtimeConfig
       const gpuConfig = runtimeConfig?.gpuConfig
@@ -829,7 +829,7 @@ export const ComputeModalBase = ({
         canShowEnvironmentWarning && (willDeleteBuiltinDisk() || willDeletePersistentDisk() || willRequireDowntime() || willDetachPersistentDisk()),
         () => h(ButtonPrimary, { ...commonButtonProps, onClick: () => setViewMode('environmentWarning') }, ['Next'])
       ], [
-        canShowWarning && isDifferentLocation(),
+        canShowWarning && isDifferentLocation(location, computeConfig.computeRegion),
         () => h(ButtonPrimary, { ...commonButtonProps, onClick: () => setViewMode('differentLocationWarning') }, ['Next'])
       ], [
         canShowWarning && !isUSLocation(computeConfig.computeRegion),

--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -831,7 +831,7 @@ export const ComputeModalBase = ({
         () => h(ButtonPrimary, { ...commonButtonProps, onClick: () => setViewMode('environmentWarning') }, ['Next'])
       ], [
         canShowWarning && isDifferentLocation(),
-        ( => h(ButtonPrimary, { ...commonButtonProps, onClick: () => setViewMode('differentLocationWarning') }, ['Next'])
+        () => h(ButtonPrimary, { ...commonButtonProps, onClick: () => setViewMode('differentLocationWarning') }, ['Next'])
       ], [
         canShowWarning && !isUSLocation(computeConfig.computeRegion),
         () => h(ButtonPrimary, { ...commonButtonProps, onClick: () => setViewMode('nonUSLocationWarning') }, ['Next'])

--- a/src/components/NewWorkspaceModal.js
+++ b/src/components/NewWorkspaceModal.js
@@ -259,7 +259,7 @@ const NewWorkspaceModal = withDisplayName('NewWorkspaceModal', ({
               `Unless you require geo-redundancy for maximum availabity for your data, you should choose a single region bucket location.`,
               h(Link, { href: 'https://terra.bio/moving-away-from-multi-regional-storage-buckets', ...Utils.newTabLinkProps },
                 [
-                  ` For more information see this read the documentation.`,
+                  ` For more information see blog post.`,
                   icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })
                 ]
               )

--- a/src/components/NewWorkspaceModal.js
+++ b/src/components/NewWorkspaceModal.js
@@ -254,7 +254,17 @@ const NewWorkspaceModal = withDisplayName('NewWorkspaceModal', ({
         div({ style: { flex: 1 } }, [
           `Effective October 1, 2022, Google Cloud will charge egress fees on data stored in multi-region storage buckets.`,
           p(`Choosing a multi-region bucket location may result in additional storage costs for your workspace.`),
-          p(`Unless you require geo-redundancy for maximum availabity for your data, you should choose a single region bucket location. For more information see <LINK TO BLOG POST>.`)
+          p(
+            [
+              `Unless you require geo-redundancy for maximum availabity for your data, you should choose a single region bucket location.`,
+              h(Link, { href: 'https://terra.bio/moving-away-from-multi-regional-storage-buckets', ...Utils.newTabLinkProps },
+                [
+                  ` For more information see this read the documentation.`,
+                  icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })
+                ]
+              )
+            ]
+          )
         ])
       ]),
       shouldShowDifferentRegionWarning() && div({ style: { ...warningStyle } }, [

--- a/src/components/NewWorkspaceModal.js
+++ b/src/components/NewWorkspaceModal.js
@@ -6,7 +6,7 @@ import { icon } from 'src/components/icons'
 import { TextArea, ValidatedInput } from 'src/components/input'
 import Modal from 'src/components/Modal'
 import { InfoBox } from 'src/components/PopupTrigger'
-import { allRegions, availableBucketRegions, getRegionInfo, isLocationMultiRegion, isSupportedBucketLocation, locationTypes } from 'src/components/region-common'
+import { allRegions, availableBucketRegions, getLocationType, getRegionInfo, isLocationMultiRegion, isSupportedBucketLocation } from 'src/components/region-common'
 import TooltipTrigger from 'src/components/TooltipTrigger'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
@@ -167,8 +167,8 @@ const NewWorkspaceModal = withDisplayName('NewWorkspaceModal', ({
     prettify: v => ({ namespace: 'Billing project', name: 'Name' }[v] || validate.prettify(v))
   })
 
-  const sourceLocationType = sourceWorkspaceLocation === defaultLocation ? locationTypes.default : locationTypes.region
-  const destLocationType = bucketLocation === defaultLocation ? locationTypes.default : locationTypes.region
+  const sourceLocationType = getLocationType(sourceWorkspaceLocation)
+  const destLocationType = getLocationType(bucketLocation)
 
   return Utils.cond(
     [loading || billingProjects === undefined, () => spinnerOverlay],

--- a/src/components/NewWorkspaceModal.js
+++ b/src/components/NewWorkspaceModal.js
@@ -6,7 +6,7 @@ import { icon } from 'src/components/icons'
 import { TextArea, ValidatedInput } from 'src/components/input'
 import Modal from 'src/components/Modal'
 import { InfoBox } from 'src/components/PopupTrigger'
-import { allRegions, availableBucketRegions, getRegionInfo, isSupportedBucketLocation, locationTypes } from 'src/components/region-common'
+import { allRegions, availableBucketRegions, getRegionInfo, isLocationMultiRegion, isSupportedBucketLocation, locationTypes } from 'src/components/region-common'
 import TooltipTrigger from 'src/components/TooltipTrigger'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
@@ -249,6 +249,14 @@ const NewWorkspaceModal = withDisplayName('NewWorkspaceModal', ({
           options: _.sortBy('label', isAlphaRegionalityUser ? allRegions : availableBucketRegions)
         })
       ])]),
+      isLocationMultiRegion(bucketLocation) && div({ style: { ...warningStyle } }, [
+        icon('warning-standard', { size: 24, style: { color: colors.warning(), flex: 'none', marginRight: '0.5rem' } }),
+        div({ style: { flex: 1 } }, [
+          `Effective October 1, 2022, Google Cloud will charge egress fees on data stored in multi-region storage buckets.`,
+          p(`Choosing a multi-region bucket location may result in additional storage costs for your workspace.`),
+          p(`Unless you require geo-redundancy for maximum availabity for your data, you should choose a single region bucket location. For more information see <LINK TO BLOG POST>.`)
+        ])
+      ]),
       shouldShowDifferentRegionWarning() && div({ style: { ...warningStyle } }, [
         icon('warning-standard', { size: 24, style: { color: colors.warning(), flex: 'none', marginRight: '0.5rem' } }),
         div({ style: { flex: 1 } }, [

--- a/src/components/NewWorkspaceModal.js
+++ b/src/components/NewWorkspaceModal.js
@@ -246,7 +246,7 @@ const NewWorkspaceModal = withDisplayName('NewWorkspaceModal', ({
           id,
           value: bucketLocation,
           onChange: ({ value }) => setBucketLocation(value),
-          options: _.sortBy('label', isAlphaRegionalityUser ? allRegions : availableBucketRegions)
+          options: isAlphaRegionalityUser ? allRegions : availableBucketRegions
         })
       ])]),
       isLocationMultiRegion(bucketLocation) && div({ style: { ...warningStyle } }, [
@@ -259,7 +259,7 @@ const NewWorkspaceModal = withDisplayName('NewWorkspaceModal', ({
               `Unless you require geo-redundancy for maximum availabity for your data, you should choose a single region bucket location.`,
               h(Link, { href: 'https://terra.bio/moving-away-from-multi-regional-storage-buckets', ...Utils.newTabLinkProps },
                 [
-                  ` For more information see blog post.`,
+                  ` For more information see this blog post.`,
                   icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })
                 ]
               )

--- a/src/components/_tests/region-common.test.js
+++ b/src/components/_tests/region-common.test.js
@@ -19,7 +19,7 @@ const montreal = {
   value: 'NORTHAMERICA-NORTHEAST1'
 }
 
-const mockAvailableBucketRegions = [us, usCentral, montreal]
+const mockAvailableBucketRegions = [usCentral, us, montreal]
 
 describe('getRegionInfo', () => {
   it('gets a { flag: ..., countryName: ... } object representing a google locationType/location input.', () => {

--- a/src/components/_tests/region-common.test.js
+++ b/src/components/_tests/region-common.test.js
@@ -1,14 +1,14 @@
-import { availableBucketRegions, getRegionInfo, isSupportedBucketLocation, locationTypes } from 'src/components/region-common'
+import { availableBucketRegions, getLocationType, getRegionInfo, isLocationMultiRegion, isSupportedBucketLocation, locationTypes } from 'src/components/region-common'
 
 
 const us = {
-  label: 'US multi-regional (default)',
+  label: 'US multi-regional',
   locationType: 'multi-region',
   value: 'US'
 }
 
 const usCentral = {
-  label: 'us-central1 (Iowa)',
+  label: 'us-central1 (Iowa) (default)',
   locationType: 'region',
   value: 'US-CENTRAL1'
 }
@@ -48,5 +48,20 @@ describe('isSupportedBucketLocation', () => {
   })
   it('Australia is NOT yet supported as a bucket location', () => {
     expect(isSupportedBucketLocation('AUSTRALIA-SOUTHEAST1')).toBeFalsy()
+  })
+})
+
+describe('isLocationMultiRegion', () => {
+  it('return true for a multiregion location', () => {
+    expect(isLocationMultiRegion('US')).toBeTruthy()
+  })
+  it('return false for a single region location', () => {
+    expect(isLocationMultiRegion('US-CENTRAL1')).toBeFalsy()
+  })
+})
+
+describe('getLocationType', () => {
+  it('return location information', () => {
+    expect(getLocationType('US')).toStrictEqual(locationTypes.multiRegion)
   })
 })

--- a/src/components/region-common.js
+++ b/src/components/region-common.js
@@ -59,7 +59,7 @@ export const getRegionInfo = (location, locationType) => {
 export const locationTypes = {
   region: 'region',
   multiRegion: 'multi-region',
-  default: 'multi-region'
+  default: 'region'
 }
 
 export const allRegions = [

--- a/src/components/region-common.js
+++ b/src/components/region-common.js
@@ -67,8 +67,8 @@ export const allRegions = [
   // This is to avoid creating within-country silos of life sciences community data.
   // So for US, Canada and Japan, we are restricting to one region.
   // For more information, see https://support.terra.bio/hc/en-us/articles/360060777272-US-regional-versus-Multi-regional-US-buckets-trade-offs
-  { value: 'US', label: 'US multi-regional', locationType: locationTypes.multiRegion },
   { value: 'US-CENTRAL1', label: 'us-central1 (Iowa) (default)', locationType: locationTypes.region },
+  { value: 'US', label: 'US multi-regional', locationType: locationTypes.multiRegion },
   { value: 'NORTHAMERICA-NORTHEAST1', label: 'northamerica-northeast1 (Montreal)', locationType: locationTypes.region },
   { value: 'SOUTHAMERICA-EAST1', label: 'southamerica-east1 (Sao Paulo)', locationType: locationTypes.region },
   { value: 'EUROPE-CENTRAL2', label: 'europe-central2 (Warsaw)', locationType: locationTypes.region },

--- a/src/components/region-common.js
+++ b/src/components/region-common.js
@@ -67,8 +67,8 @@ export const allRegions = [
   // This is to avoid creating within-country silos of life sciences community data.
   // So for US, Canada and Japan, we are restricting to one region.
   // For more information, see https://support.terra.bio/hc/en-us/articles/360060777272-US-regional-versus-Multi-regional-US-buckets-trade-offs
-  { value: 'US', label: 'US multi-regional (default)', locationType: locationTypes.multiRegion },
-  { value: 'US-CENTRAL1', label: 'us-central1 (Iowa)', locationType: locationTypes.region },
+  { value: 'US', label: 'US multi-regional', locationType: locationTypes.multiRegion },
+  { value: 'US-CENTRAL1', label: 'us-central1 (Iowa) (default)', locationType: locationTypes.region },
   { value: 'NORTHAMERICA-NORTHEAST1', label: 'northamerica-northeast1 (Montreal)', locationType: locationTypes.region },
   { value: 'SOUTHAMERICA-EAST1', label: 'southamerica-east1 (Sao Paulo)', locationType: locationTypes.region },
   { value: 'EUROPE-CENTRAL2', label: 'europe-central2 (Warsaw)', locationType: locationTypes.region },
@@ -87,6 +87,10 @@ export const allRegions = [
   { value: 'ASIA-SOUTHEAST2', label: 'asia-southeast2 (Jakarta)', locationType: locationTypes.region },
   { value: 'AUSTRALIA-SOUTHEAST1', label: 'australia-southeast1 (Sydney)', locationType: locationTypes.region }
 ]
+
+export const getLocationInfo = location => _.find({ value: location.toUpperCase() }, allRegions)
+export const getLocationType = location => getLocationInfo(location).locationType
+export const isLocationMultiRegion = location => getLocationType(location) === locationTypes.multiRegion
 
 // For current phased release of regionality only supporting US, US-CENTRAL1, NORTHAMERICA-NORTHEAST1 buckets.
 const supportedBucketLocations = ['US', 'US-CENTRAL1', 'NORTHAMERICA-NORTHEAST1']

--- a/src/libs/runtime-utils.js
+++ b/src/libs/runtime-utils.js
@@ -64,7 +64,7 @@ export const defaultNumDataprocPreemptibleWorkers = 0
 export const defaultGpuType = 'nvidia-tesla-t4'
 export const defaultNumGpus = 1
 
-export const defaultLocation = 'US'
+export const defaultLocation = 'US-CENTRAL1'
 
 export const defaultComputeZone = 'US-CENTRAL1-A'
 export const defaultComputeRegion = 'US-CENTRAL1'


### PR DESCRIPTION
## Context
[Relevant ticket](https://broadworkbench.atlassian.net/browse/WOR-192)
Google is changing it's pricing policy; movement between multiregion and "regular" regions will no longer be free as of 2022-10-01. 

## This PR
* Changes the default location to `us-central1` for new workspaces
* Adds a warning to the create workspace modal that will notify users of the impending pricing change if they choose the `US` multiregion
* Fixes an issue with the notebooks ComputeModal where `unknown` would display for the location
