### PR TITLE
[SUP-592] Distinguish no billing account from no access to billing account

### DIFF
--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -525,14 +525,22 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
     { ms: 5000 }
   )
 
-  const { displayName = null } = _.find({ accountName: billingProject.billingAccount }, billingAccounts) || { displayName: 'No Access' }
+  // (CA-1586) For some reason the api sometimes returns string null, and sometimes returns no field, and sometimes returns null. This is just to be complete.
+  const billingProjectHasBillingAccount = !(billingProject.billingAccount === 'null' || _.isNil(billingProject.billingAccount))
+  const billingAccount = billingProjectHasBillingAccount ? _.find({ accountName: billingProject.billingAccount }, billingAccounts) : undefined
+
+  const billingAccountDisplayText = Utils.cond(
+    [!billingProjectHasBillingAccount, () => 'No linked billing account'],
+    [!billingAccount, () => 'No access to linked billing account'],
+    () => billingAccount.displayName || billingAccount.accountName
+  )
 
   return h(Fragment, [
     div({ style: { padding: '1.5rem 0 0', flexGrow: 1, display: 'flex', flexDirection: 'column' } }, [
       div({ style: { color: colors.dark(), fontSize: 18, fontWeight: 600, display: 'flex', alignItems: 'center', marginLeft: '1rem' } }, [billingProject.projectName]),
       Auth.hasBillingScope() && div({ style: { color: colors.dark(), fontSize: 14, display: 'flex', alignItems: 'center', marginTop: '0.5rem', marginLeft: '1rem' } }, [
-        !!displayName && span({ style: { flexShrink: 0, fontWeight: 600, fontSize: 14, margin: '0 0.75rem 0 0' } }, 'Billing Account:'),
-        !!displayName && span({ style: { flexShrink: 0, marginRight: '0.5rem' } }, displayName),
+        span({ style: { flexShrink: 0, fontWeight: 600, fontSize: 14, margin: '0 0.75rem 0 0' } }, 'Billing Account:'),
+        span({ style: { flexShrink: 0, marginRight: '0.5rem' } }, billingAccountDisplayText),
         isOwner && h(MenuTrigger, {
           closeOnClick: true,
           side: 'bottom',
@@ -557,8 +565,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
                   setShowBillingRemovalModal(Auth.hasBillingScope())
                 }
               },
-              // (CA-1586) For some reason the api sometimes returns string null, and sometimes returns no field, and sometimes returns null. This is just to be complete.
-              disabled: billingProject.billingAccount === 'null' || _.isNil(billingProject.billingAccount)
+              disabled: !billingProjectHasBillingAccount
             }, ['Remove Billing Account'])
           ])
         }, [


### PR DESCRIPTION
When viewing a billing project, currently "Billing Account: No Access" is displayed in two different cases:
- When the user does not have access to the billing project's billing account
- When the billing project has no billing account associated with it

This distinguishes those two cases by changing the text to either "No access to linked billing account" or "No linked billing account".

The path for the billing page is `#billing`. Or it can be reached from the main sidebar (expand the user menu).