### PR TITLE
[SU-117] Change behavior of attribute type buttons in attribute editor

### DIFF
--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -609,7 +609,8 @@ const defaultValueForAttributeType = (attributeType, referenceEntityType) => {
   )
 }
 
-const AttributeInput = ({ autoFocus = false, value: attributeValue, onChange, entityTypes = [], showJsonTypeOption = false }) => {
+const AttributeInput = ({ autoFocus = false, value: attributeValue, initialValue, onChange, entityTypes = [], showJsonTypeOption = false }) => {
+  const [edited, setEdited] = useState(false)
   const { type: attributeType, isList } = getAttributeType(attributeValue)
 
   const renderInput = renderInputForAttributeType(attributeType)
@@ -660,7 +661,11 @@ const AttributeInput = ({ autoFocus = false, value: attributeValue, onChange, en
               name: 'edit-type',
               checked: attributeType === type,
               onChange: () => {
-                const newAttributeValue = convertAttributeValue(attributeValue, type, defaultReferenceEntityType)
+                const newAttributeValue = convertAttributeValue(
+                  initialValue && !edited ? initialValue : attributeValue,
+                  type,
+                  defaultReferenceEntityType
+                )
                 onChange(newAttributeValue)
               },
               labelStyle: { paddingLeft: '0.5rem' }
@@ -712,6 +717,7 @@ const AttributeInput = ({ autoFocus = false, value: attributeValue, onChange, en
             value,
             onChange: v => {
               const newAttributeValue = _.update('items', _.set(i, v), attributeValue)
+              setEdited(true)
               onChange(newAttributeValue)
             }
           }),
@@ -720,6 +726,7 @@ const AttributeInput = ({ autoFocus = false, value: attributeValue, onChange, en
             disabled: _.size(attributeValue.items) === 1,
             onClick: () => {
               const newAttributeValue = _.update('items', _.pullAt(i), attributeValue)
+              setEdited(true)
               onChange(newAttributeValue)
             },
             style: { marginLeft: '0.5rem' }
@@ -732,6 +739,7 @@ const AttributeInput = ({ autoFocus = false, value: attributeValue, onChange, en
           onClick: () => {
             focusLastListItemInput.current = true
             const newAttributeValue = _.update('items', Utils.append(defaultValue), attributeValue)
+            setEdited(true)
             onChange(newAttributeValue)
           }
         }, [icon('plus', { style: { marginRight: '0.5rem' } }), 'Add item'])
@@ -740,7 +748,10 @@ const AttributeInput = ({ autoFocus = false, value: attributeValue, onChange, en
           'aria-label': 'New value',
           autoFocus,
           value: attributeValue,
-          onChange
+          onChange: v => {
+            setEdited(true)
+            onChange(v)
+          }
         })
       ])
   ])
@@ -825,6 +836,7 @@ export const SingleEntityEditor = ({ entityType, entityName, attributeName, attr
           autoFocus: true,
           value: newValue,
           onChange: setNewValue,
+          initialValue: attributeValue,
           entityTypes,
           showJsonTypeOption: originalValueType === 'json'
         }),


### PR DESCRIPTION
When editing an attribute in a data table (hover over a cell and click the pencil button), you can change the type of the attribute (string, list, number, boolean) and the attribute's value will be converted to the selected type. Converting to a different type is a lossy operation: converting a string to a number and back to a string doesn't necessarily end with the same value as you started out with.

This makes a small change to the behavior of the form based on [previous PR feedback](https://github.com/DataBiosphere/terra-ui/pull/3049#issuecomment-1131901280). With this change, until the attribute value is edited, selecting a different attribute type uses the current value of the cell as the input to the type conversion instead of the current value of the form. As described in the original comment, this lets you "play 'what-if' with the radio buttons and then land back where you started without other things changing".

## Before
https://user-images.githubusercontent.com/1156625/172920039-864f0ea7-0184-419e-be89-d30cc7a93965.mov

## After
https://user-images.githubusercontent.com/1156625/172920043-e0609722-4202-42fb-887e-f8a111a4090b.mov

