### PR TITLE
[WOR-373] Remove notification workarounds that don't actually work, mock problematic Ajax calls.

### DIFF
--- a/integration-tests/tests/janitor.js
+++ b/integration-tests/tests/janitor.js
@@ -27,6 +27,8 @@ const runJanitor = withUserToken(async ({ billingProject, page, testUrl, token }
 
   return Promise.all(_.map(async ({ workspace: { namespace, name } }) => {
     try {
+      // Unlock the workspace in case it was left in a locked state during a test (locked workspaces can't be deleted).
+      await page.evaluate((namespace, name) => window.Ajax().Workspaces.workspace(namespace, name).unlock(), namespace, name)
       await page.evaluate((namespace, name) => window.Ajax().Workspaces.workspace(namespace, name).delete(), namespace, name)
       console.info(`Deleted old workspace: ${name}`)
     } catch (e) {

--- a/integration-tests/tests/workspace-dashboard.js
+++ b/integration-tests/tests/workspace-dashboard.js
@@ -7,8 +7,8 @@ const {
 const { registerTest } = require('../utils/jest-utils')
 const { withUserToken } = require('../utils/terra-sa-utils')
 
-const workspaceDashboardPage = (testPage, token, workspaceName) => {
 
+const workspaceDashboardPage = (testPage, token, workspaceName) => {
   return {
     visit: async () => {
       await viewWorkspaceDashboard(testPage, token, workspaceName)

--- a/integration-tests/tests/workspace-dashboard.js
+++ b/integration-tests/tests/workspace-dashboard.js
@@ -7,8 +7,7 @@ const {
 const { registerTest } = require('../utils/jest-utils')
 const { withUserToken } = require('../utils/terra-sa-utils')
 
-
-const workspaceDashboardPage = (testPage, testUrl, token, workspaceName) => {
+const workspaceDashboardPage = (testPage, token, workspaceName) => {
 
   return {
     visit: async () => {
@@ -65,7 +64,6 @@ const workspaceDashboardPage = (testPage, testUrl, token, workspaceName) => {
 }
 
 const setGcpAjaxMockValues = async (testPage, namespace, name) => {
-
   return await testPage.evaluate((namespace, name) => {
     const storageCostEstimateUrl = new RegExp(`api/workspaces/${namespace}/${name}/storageCostEstimate(.*)`, 'g')
 
@@ -79,7 +77,7 @@ const setGcpAjaxMockValues = async (testPage, namespace, name) => {
       {
         filter: { url: /storage\/v1\/b(.*)/ }, // Bucket location response
         fn: () => () => Promise.resolve(new Response(JSON.stringify({}), { status: 200 }))
-      },
+      }
     ])
   }, namespace, name)
 }
@@ -90,7 +88,7 @@ const testGoogleWorkspace = _.flow(
 )(async ({ page, token, testUrl, billingProject, workspaceName }) => {
   await gotoPage(page, testUrl)
   await setGcpAjaxMockValues(page, billingProject, workspaceName)
-  const dashboard = workspaceDashboardPage(page, testUrl, token, workspaceName)
+  const dashboard = workspaceDashboardPage(page, token, workspaceName)
   await dashboard.visit()
   await dashboard.assertDescription('About the workspace')
 
@@ -197,7 +195,7 @@ const testAzureWorkspace = withUserToken(async ({ page, token, testUrl }) => {
   await overrideConfig(page, { isAnalysisTabVisible: true })
   await setAzureAjaxMockValues(page, 'azure-workspace-ns', workspaceName, workspaceDescription)
 
-  const dashboard = workspaceDashboardPage(page, testUrl, token, workspaceName)
+  const dashboard = workspaceDashboardPage(page, token, workspaceName)
   await dashboard.visit()
   await dashboard.assertDescription(workspaceDescription)
 
@@ -223,6 +221,6 @@ const testAzureWorkspace = withUserToken(async ({ page, token, testUrl }) => {
 })
 
 registerTest({
-name: 'azure-workspace',
-fn: testAzureWorkspace
+  name: 'azure-workspace',
+  fn: testAzureWorkspace
 })

--- a/integration-tests/tests/workspace-dashboard.js
+++ b/integration-tests/tests/workspace-dashboard.js
@@ -2,41 +2,16 @@
 const _ = require('lodash/fp')
 const { overrideConfig, viewWorkspaceDashboard, withWorkspace } = require('../utils/integration-helpers')
 const {
-  assertNavChildNotFound, assertTextNotFound, click, clickable, dismissNotifications, findElement, findText, gotoPage, navChild, noSpinnersAfter
+  assertNavChildNotFound, assertTextNotFound, click, clickable, findElement, findText, gotoPage, navChild, noSpinnersAfter
 } = require('../utils/integration-utils')
 const { registerTest } = require('../utils/jest-utils')
 const { withUserToken } = require('../utils/terra-sa-utils')
 
 
 const workspaceDashboardPage = (testPage, testUrl, token, workspaceName) => {
-  const clickWorkspaceActionMenu = async testPage => {
-    const clickOrDismiss = async () => {
-      try {
-        await click(testPage, clickable({ text: 'Workspace Action Menu' }))
-        return true
-      } catch (error) {
-        console.log('Unable to click "Workspace Action Menu", dismissing notifications.')
-        await dismissNotifications(testPage)
-        return false
-      }
-    }
-    let clicked = await clickOrDismiss()
-    let counter = 0
-    // Multiple notifications appear, and dismissNotifications has delays to allow animation to happen.
-    while (!clicked && counter < 5) {
-      clicked = await clickOrDismiss()
-      counter = counter + 1
-    }
-    if (!clicked) {
-      throw new Error('Was not able to click the "Workspace Action Menu", even after dismissing notifications')
-    }
-  }
 
   return {
-    visit: async (loadUrl = true) => {
-      if (loadUrl) {
-        await gotoPage(testPage, testUrl)
-      }
+    visit: async () => {
       await viewWorkspaceDashboard(testPage, token, workspaceName)
     },
 
@@ -54,7 +29,7 @@ const workspaceDashboardPage = (testPage, testUrl, token, workspaceName) => {
     },
 
     assertWorkspaceMenuItems: async expectedMenuItems => {
-      await clickWorkspaceActionMenu(testPage)
+      await click(testPage, clickable({ text: 'Workspace Action Menu' }))
       await Promise.all(_.map(async ({ label, tooltip }) => {
         if (!!tooltip) {
           await findElement(testPage, clickable({ textContains: label, isEnabled: false }))
@@ -67,16 +42,15 @@ const workspaceDashboardPage = (testPage, testUrl, token, workspaceName) => {
 
     assertLockWorkspace: async () => {
       await assertTextNotFound(testPage, 'Workspace is locked')
-      await clickWorkspaceActionMenu(testPage)
+      await click(testPage, clickable({ text: 'Workspace Action Menu' }))
       await click(testPage, clickable({ textContains: 'Lock' }))
       await noSpinnersAfter(testPage, { action: () => click(testPage, clickable({ text: 'Lock Workspace' })) })
       await findText(testPage, 'Workspace is locked')
     },
 
     assertUnlockWorkspace: async () => {
-      await dismissNotifications(testPage)
       await findText(testPage, 'Workspace is locked')
-      await clickWorkspaceActionMenu(testPage)
+      await click(testPage, clickable({ text: 'Workspace Action Menu' }))
       await click(testPage, clickable({ textContains: 'Unlock' }))
       await noSpinnersAfter(testPage, { action: () => click(testPage, clickable({ text: 'Unlock Workspace' })) })
       await assertTextNotFound(testPage, 'Workspace is locked')
@@ -90,10 +64,32 @@ const workspaceDashboardPage = (testPage, testUrl, token, workspaceName) => {
   }
 }
 
+const setGcpAjaxMockValues = async (testPage, namespace, name) => {
+
+  return await testPage.evaluate((namespace, name) => {
+    const storageCostEstimateUrl = new RegExp(`api/workspaces/${namespace}/${name}/storageCostEstimate(.*)`, 'g')
+
+    window.ajaxOverridesStore.set([
+      {
+        filter: { url: storageCostEstimateUrl },
+        fn: () => () => Promise.resolve(
+          new Response(JSON.stringify({ estimate: 'Fake Estimate', lastUpdated: Date.now() }), { status: 200 })
+        )
+      },
+      {
+        filter: { url: /storage\/v1\/b(.*)/ }, // Bucket location response
+        fn: () => () => Promise.resolve(new Response(JSON.stringify({}), { status: 200 }))
+      },
+    ])
+  }, namespace, name)
+}
+
 const testGoogleWorkspace = _.flow(
   withWorkspace,
   withUserToken
-)(async ({ page, token, testUrl, workspaceName }) => {
+)(async ({ page, token, testUrl, billingProject, workspaceName }) => {
+  await gotoPage(page, testUrl)
+  await setGcpAjaxMockValues(page, billingProject, workspaceName)
   const dashboard = workspaceDashboardPage(page, testUrl, token, workspaceName)
   await dashboard.visit()
   await dashboard.assertDescription('About the workspace')
@@ -121,7 +117,7 @@ registerTest({
   fn: testGoogleWorkspace
 })
 
-const setAjaxMockValues = async (testPage, namespace, name, workspaceDescription) => {
+const setAzureAjaxMockValues = async (testPage, namespace, name, workspaceDescription) => {
   const workspaceInfo = {
     attributes: { description: workspaceDescription },
     authorizationDomain: [],
@@ -199,10 +195,10 @@ const testAzureWorkspace = withUserToken(async ({ page, token, testUrl }) => {
   await gotoPage(page, testUrl)
   await findText(page, 'View Workspaces')
   await overrideConfig(page, { isAnalysisTabVisible: true })
-  await setAjaxMockValues(page, 'azure-workspace-ns', workspaceName, workspaceDescription)
+  await setAzureAjaxMockValues(page, 'azure-workspace-ns', workspaceName, workspaceDescription)
 
   const dashboard = workspaceDashboardPage(page, testUrl, token, workspaceName)
-  await dashboard.visit(false)
+  await dashboard.visit()
   await dashboard.assertDescription(workspaceDescription)
 
   // Check cloud information
@@ -227,6 +223,6 @@ const testAzureWorkspace = withUserToken(async ({ page, token, testUrl }) => {
 })
 
 registerTest({
-  name: 'azure-workspace',
-  fn: testAzureWorkspace
+name: 'azure-workspace',
+fn: testAzureWorkspace
 })


### PR DESCRIPTION
We were seeing problems on alpha a while ago where notifications blocked the workspace menu. The attempt to click it seemed to throw an error about the menu not being present. As an attempt to fix that, I added code to dismiss notifications… and I also changed some of the behavior around switching tabs. Running flakes against alpha showed massive improvement, but I now think that the improvement was due to the tab logic I changed and not at all the dismiss notifications code. The recent Bond failures showed that:

1) `dismissNotifications` does actually dismiss errors-- only info dialogs.
2) The call to click the workspace menu doesn't error… it just doesn't actually open the menu. My guess is that the previous errors I had seen were related to the wrong tab being selected, not the notification being present.

In addition, I recently saw another [case](https://circleci-tasks-prod.s3.us-east-1.amazonaws.com/storage/artifacts/1c1bde7e-0f01-4eef-b2bc-01f4b12ed651/5a794fe0-a356-44ef-888d-5302e1cc4c43/0/results/failure-screenshots/failure-1654720370765-google-workspace.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAQVFQINEOIABWVWXV%2F20220610%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20220610T141715Z&X-Amz-Expires=60&X-Amz-Security-Token=IQoJb3JpZ2luX2VjECcaCXVzLWVhc3QtMSJHMEUCIHvrUtCXCJmGIvRU2TojsjkSADcLgNJF8NxrSU5m6jDWAiEAqWZfjguur%2FV7g8y48GG%2B3YSpMRHwdvatW2znpRNP96QqqwIILxACGgwwNDU0NjY4MDY1NTYiDIh4JouXzSC%2BXkfodSqIAqNQjvYy2VAZyGqEHv7%2BOMd1fI3SgUt1mJ0IxxMQfGZUQDog%2BBJ0vJsC6qX52iV8XhGIaQ4wPokdEyH5zbwfCn4rqHT1b%2Bccwj2lk9KpV0VYuPFPtI03e0bCwM5F5n4OH3eR0G3HvRhokE%2FchpaMQp6KGiBBZLOQ9WYs%2FowF1OWPL7xcvrrX9DpP1Emw28NakfekF3ZzVlhLUgJP01pLReb4EYCwiJyfWYVOCdcOSizgAb5Wp2S3JgQ3tkuT7umvvSNhSblkbQ4GXJy18GTtZFkfq80DkaCpSKN5%2B3syp6nytQV6yN7e1wqEsZXNkiGF%2BMv7mg1QWfXpUzb%2BdLgjd6ZzkUwTqafuqzCUoI2VBjqdAeH9hviTe9NDkRDOq9%2FGVQHvYrM9Bu80a5thEmlagNJ236Gr4yrgtTVtz9geP9nugqvlHV2wzpBaHjB%2BdPslKxghqaP%2BiNBv1sFKEpoLpCevDJdhN2%2BuzVsBwBF%2BKDxkgS3dzjBrOqjSGHY3XONnFYiEZ9%2FcWD2P2XnB5kfApFuTHRI9yaoT2UeO5qYV%2F8OCpHtbLZ3Zy0JukvJ%2BxC8%3D&X-Amz-SignedHeaders=host&x-id=GetObject&X-Amz-Signature=2792ce3276039d3ed588f3aed872d54cdc8abc61999bc96cdbccf658c61e2fab) where the storage cost call produced an error… this was one of the 2 error dialogs that we had seen in the past. Since the point of my test is to check the items in the workspace menu and a few select things on the dashboard, and not to verify anything about these 2 specific items that are known to occasionally be flaky, I am just mocking out the Ajax calls to prevent the error dialogs from obscuring the menu. 

![image](https://user-images.githubusercontent.com/484484/173087191-4a6df795-6709-42e8-8ed8-4a8b59dfabb8.png)
