### PR TITLE
[SUP-660] Support Dockstore workflows on the featured workflows page

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1686,10 +1686,8 @@ const Dockstore = signal => ({
     return res.json()
   },
 
-  listTools: async (params = {}) => {
-    const response = await fetchDockstore(`api/ga4gh/v1/tools?${qs.stringify(params)}`)
-    return response.json()
-  }
+  listTools: (params = {}) =>
+    fetchDockstore(`api/ga4gh/v1/tools?${qs.stringify(params)}`).then(r => r.json())
 })
 
 

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1684,6 +1684,11 @@ const Dockstore = signal => ({
   getVersions: async ({ path, isTool }) => {
     const res = await fetchDockstore(dockstoreMethodPath({ path, isTool }), { signal })
     return res.json()
+  },
+
+  listTools: async (params = {}) => {
+    const response = await fetchDockstore(`api/ga4gh/v1/tools?${qs.stringify(params)}`)
+    return response.json()
   }
 })
 

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1686,8 +1686,7 @@ const Dockstore = signal => ({
     return res.json()
   },
 
-  listTools: (params = {}) =>
-    fetchDockstore(`api/ga4gh/v1/tools?${qs.stringify(params)}`).then(r => r.json())
+  listTools: (params = {}) => fetchDockstore(`api/ga4gh/v1/tools?${qs.stringify(params)}`).then(r => r.json())
 })
 
 

--- a/src/pages/library/Code.js
+++ b/src/pages/library/Code.js
@@ -97,7 +97,7 @@ const getFeaturedMethods = async signal => {
   ])
 
   const methodsRepoMethodDetails = _.flow(
-    _.groupBy(method => `${method.namespace}/${method.name}`),
+    _.groupBy(({ namespace, name }) => `${namespace}/${name}`),
     _.mapValues(_.maxBy('snapshotId'))
   )(methodsRepoMethodsList)
 
@@ -135,7 +135,7 @@ const Code = () => {
           div({ style: { display: 'flex', flexWrap: 'wrap' } }, [
             _.map(method => {
               const { namespace, name, id } = method
-              const isMethodsRepoMethod = namespace && name
+              const isMethodsRepoMethod = !!(namespace && name)
               const href = isMethodsRepoMethod ?
                 `${getConfig().firecloudUrlRoot}/?return=${returnParam()}#methods/${namespace}/${name}/` :
                 `${getConfig().dockstoreUrlRoot}/workflows/${id.replace(/^#workflow\//, '')}`


### PR DESCRIPTION
The featured workflows page (https://app.terra.bio/#library/code) fetches a list of featured workflows (identified by namespace and name) from a JSON file stored in the `firecloud-alerts` bucket. It also fetches information about those workflows from the Methods Repository and uses that to display a description of the workflow. This adds support for displaying featured workflows from Dockstore.

Dockstore workflows from the [gatk-workflows organization](https://dockstore.org/search?organization=gatk-workflows&entryType=workflows&searchMode=files) can be added to the featured workflows list by adding an entry containing the workflow's TRS ID.

For example:
```
{ "id": "#workflow/github.com/gatk-workflows/seq-format-conversion/BAM-to-Unmapped-BAM" }
```

The TRS ID can be found on the workflow page on Dockstore.

https://dockstore.org/workflows/github.com/gatk-workflows/seq-format-conversion/BAM-to-Unmapped-BAM:3.0.0?tab=info

![Screen Shot 2022-06-09 at 5 46 19 PM](https://user-images.githubusercontent.com/1156625/172950833-47567f7c-f9a1-4630-bc75-f25d5aa460b8.png)

