### PR TITLE
[IA-3483] Add integration test for running a notebook in a non-US region

### DIFF
--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -26,12 +26,12 @@ const testWorkspaceNamePrefix = 'terra-ui-test-workspace-'
 const getTestWorkspaceName = () => `${testWorkspaceNamePrefix}${uuid.v4()}`
 
 
-const makeWorkspace = withSignedInPage(async ({ page, billingProject }) => {
+const makeWorkspace = withSignedInPage(async ({ page, billingProject, bucketLocation }) => {
   const workspaceName = getTestWorkspaceName()
   try {
-    const response = await page.evaluate(async (name, billingProject) => {
+    const response = await page.evaluate(async (name, billingProject, bucketLocation) => {
       try {
-        return await window.Ajax().Workspaces.create({ namespace: billingProject, name, attributes: {} })
+        return await window.Ajax().Workspaces.create({ namespace: billingProject, name, bucketLocation, attributes: {} })
       } catch (err) {
         console.error(err)
         console.error(typeof err)


### PR DESCRIPTION
Followup from #3115.
Generally tests the regionality features, which was added in #2680 and #2709 