### PR TITLE
[DO NOT MERGE] Wire bucketLocation through workspace creation

### DIFF
--- a/integration-tests/tests/find-workflow.js
+++ b/integration-tests/tests/find-workflow.js
@@ -7,7 +7,7 @@ const { withUserToken } = require('../utils/terra-sa-utils')
 
 
 const testFindWorkflowFn = _.flow(
-  withWorkspace(),
+  withWorkspace,
   withUserToken
 )(async ({ billingProject, page, testUrl, token, workflowName, workspaceName }) => {
   await signIntoTerra(page, { token, testUrl })

--- a/integration-tests/tests/find-workflow.js
+++ b/integration-tests/tests/find-workflow.js
@@ -7,7 +7,7 @@ const { withUserToken } = require('../utils/terra-sa-utils')
 
 
 const testFindWorkflowFn = _.flow(
-  withWorkspace,
+  withWorkspace(),
   withUserToken
 )(async ({ billingProject, page, testUrl, token, workflowName, workspaceName }) => {
   await signIntoTerra(page, { token, testUrl })

--- a/integration-tests/tests/run-notebook.js
+++ b/integration-tests/tests/run-notebook.js
@@ -1,5 +1,5 @@
 const _ = require('lodash/fp')
-const { withRegisteredUser, withBilling, withWorkspace } = require('../utils/integration-helpers')
+const { withRegisteredUser, withBilling, withWorkspaceAndBucketLocation } = require('../utils/integration-helpers')
 const {
   click, clickable, getAnimatedDrawer, signIntoTerra, findElement, navChild, noSpinnersAfter, select, fillIn, input, findIframe, findText
 } = require('../utils/integration-utils')
@@ -10,7 +10,7 @@ const notebookName = 'TestNotebook'
 const bucketLocation = 'US-EAST1'
 
 const testRunNotebookFn = _.flow(
-  withWorkspace(bucketLocation),
+  withWorkspaceAndBucketLocation(bucketLocation),
   withBilling,
   withRegisteredUser
 )(async ({ workspaceName, page, testUrl, token }) => {

--- a/integration-tests/tests/run-notebook.js
+++ b/integration-tests/tests/run-notebook.js
@@ -7,9 +7,10 @@ const { registerTest } = require('../utils/jest-utils')
 
 
 const notebookName = 'TestNotebook'
+const bucketLocation = 'US-EAST1'
 
 const testRunNotebookFn = _.flow(
-  withWorkspace,
+  withWorkspace(bucketLocation),
   withBilling,
   withRegisteredUser
 )(async ({ workspaceName, page, testUrl, token }) => {

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -73,8 +73,8 @@ const deleteWorkspace = withSignedInPage(async ({ page, billingProject, workspac
   }
 })
 
-const withWorkspace = bucketLocation => test => async options => {
-  console.log('withWorkspace in location ', bucketLocation ?? 'default ...' )
+const withWorkspaceAndBucketLocation = bucketLocation => test => async options => {
+  console.log(`withWorkspace in ${bucketLocation ?? 'default'} location`)
   const workspaceName = await makeWorkspace(_.set('bucketLocation', bucketLocation, options))
 
   try {
@@ -84,6 +84,8 @@ const withWorkspace = bucketLocation => test => async options => {
     await deleteWorkspace({ ...options, workspaceName })
   }
 }
+
+const withWorkspace = withWorkspaceAndBucketLocation()
 
 const createEntityInWorkspace = (page, billingProject, workspaceName, testEntity) => {
   return page.evaluate((billingProject, workspaceName, testEntity) => {

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -26,12 +26,13 @@ const testWorkspaceNamePrefix = 'terra-ui-test-workspace-'
 const getTestWorkspaceName = () => `${testWorkspaceNamePrefix}${uuid.v4()}`
 
 
-const makeWorkspace = withSignedInPage(async ({ page, billingProject }) => {
+const makeWorkspace = withSignedInPage(async ({ page, billingProject, bucketLocation }) => {
   const workspaceName = getTestWorkspaceName()
   try {
     const response = await page.evaluate(async (name, billingProject) => {
       try {
-        return await window.Ajax().Workspaces.create({ namespace: billingProject, name, attributes: {} })
+        return await window.Ajax().Workspaces.create(
+          { namespace: billingProject, name, ...(bucketLocation ? { bucketLocation } : {}), attributes: {} })
       } catch (err) {
         console.error(err)
         console.error(typeof err)
@@ -72,9 +73,9 @@ const deleteWorkspace = withSignedInPage(async ({ page, billingProject, workspac
   }
 })
 
-const withWorkspace = test => async options => {
-  console.log('withWorkspace ...')
-  const workspaceName = await makeWorkspace(options)
+const withWorkspace = bucketLocation => test => async options => {
+  console.log('withWorkspace in location ', bucketLocation ?? 'default ...' )
+  const workspaceName = await makeWorkspace(_.set('bucketLocation', bucketLocation, options))
 
   try {
     await test({ ...options, workspaceName })


### PR DESCRIPTION
**Note: Opening for illustrative purposes only.** 

Currently, `withWorkspace` wrapper creates a workspace in a default region. These changes aim for it to be optionally customizable by a test.

Didn't test end-to-end.

One thing I don't like is that the changes aren't backwards-compatible and require existing tests calling `withWorkspace` to be modified (even though it's just a two-char change, i.e. `withWorkspace()` instead of `withWorkspace`).