### PR TITLE
[PE-4] Landing page text update for Project Singular

### DIFF
--- a/src/components/common.js
+++ b/src/components/common.js
@@ -54,39 +54,40 @@ const styles = {
   }
 }
 
-export const Clickable = forwardRefWithName('Clickable', ({ href, as = (!!href ? 'a' : 'div'), disabled, tooltip, tooltipSide, tooltipDelay, useTooltipAsLabel, onClick, children, ...props }, ref) => {
-  const child = h(Interactive, {
-    'aria-disabled': !!disabled,
-    as, disabled, ref,
-    onClick: (...args) => onClick && !disabled && onClick(...args),
-    href: !disabled ? href : undefined,
-    tabIndex: disabled ? '-1' : '0',
-    ...props
-  }, [children])
+export const Clickable = forwardRefWithName('Clickable',
+  ({ href, as = (!!href ? 'a' : 'div'), disabled, tooltip, tooltipSide, tooltipDelay, useTooltipAsLabel, onClick, children, ...props }, ref) => {
+    const child = h(Interactive, {
+      'aria-disabled': !!disabled,
+      as, disabled, ref,
+      onClick: (...args) => onClick && !disabled && onClick(...args),
+      href: !disabled ? href : undefined,
+      tabIndex: disabled ? '-1' : '0',
+      ...props
+    }, [children])
 
-  // To support accessibility, every link must have a label or contain text or a labeled child.
-  // If an unlabeled link contains just a single unlabeled icon, then we should use the tooltip as the label,
-  // rather than as the description as we otherwise would.
-  //
-  // If the auto-detection can't make the proper determination, for example, because the icon is wrapped in other elements,
-  // you can explicitly pass in a boolean as `useTooltipAsLabel` to force the correct behavior.
-  //
-  // Note that TooltipTrigger does this same check with its own children, but since we'll be passing it an
-  // Interactive element, we need to do the check here instead.
-  const useAsLabel = _.isNil(useTooltipAsLabel) ? containsUnlabelledIcon({ children, ...props }) : useTooltipAsLabel
+    // To support accessibility, every link must have a label or contain text or a labeled child.
+    // If an unlabeled link contains just a single unlabeled icon, then we should use the tooltip as the label,
+    // rather than as the description as we otherwise would.
+    //
+    // If the auto-detection can't make the proper determination, for example, because the icon is wrapped in other elements,
+    // you can explicitly pass in a boolean as `useTooltipAsLabel` to force the correct behavior.
+    //
+    // Note that TooltipTrigger does this same check with its own children, but since we'll be passing it an
+    // Interactive element, we need to do the check here instead.
+    const useAsLabel = _.isNil(useTooltipAsLabel) ? containsUnlabelledIcon({ children, ...props }) : useTooltipAsLabel
 
-  // If we determined that we need to use the tooltip as a label, assert that we have a tooltip.
-  // Do the check here and pass empty properties, to bypass the check logic in useLabelAssert() which doesn't take into account the icon's properties.
-  if (useAsLabel && !tooltip) {
-    useLabelAssert('Clickable', { allowTooltip: true, allowContent: true })
-  }
+    // If we determined that we need to use the tooltip as a label, assert that we have a tooltip.
+    // Do the check here and pass empty properties, to bypass the check logic in useLabelAssert() which doesn't take into account the icon's properties.
+    if (useAsLabel && !tooltip) {
+      useLabelAssert('Clickable', { allowTooltip: true, allowContent: true })
+    }
 
-  if (tooltip) {
-    return h(TooltipTrigger, { content: tooltip, side: tooltipSide, delay: tooltipDelay, useTooltipAsLabel: useAsLabel }, [child])
-  } else {
-    return child
-  }
-})
+    if (tooltip) {
+      return h(TooltipTrigger, { content: tooltip, side: tooltipSide, delay: tooltipDelay, useTooltipAsLabel: useAsLabel }, [child])
+    } else {
+      return child
+    }
+  })
 
 export const Link = forwardRefWithName('Link', ({ disabled, variant, children, baseColor = colors.accent, ...props }, ref) => {
   return h(Clickable, _.merge({
@@ -423,8 +424,7 @@ export const UnlinkFenceAccount = ({ linkText, provider }) => {
             message: `Successfully unlinked your account from ${provider.name}`,
             timeout: 30000
           })
-        }
-        )
+        })
       }, 'OK')
     }, [
       div([`Are you sure you want to unlink from ${provider.name}?`]),
@@ -510,6 +510,11 @@ export const Switch = forwardRefWithName('Switch', ({ onChange, onLabel = 'True'
 export const HeroWrapper = ({ showMenu = true, bigSubhead = false, children }) => {
   const heavyWrapper = text => bigSubhead ? b({ style: { whiteSpace: 'nowrap' } }, [text]) : text
 
+  const endText = Utils.cond(
+    [isProjectSingular(), () => div(['and ', heavyWrapper('collaborate'), ' to advance research around single ventricle heart disease.'])],
+    () => span({ style: { whiteSpace: 'nowrap' } }, ['and', heavyWrapper(' collaborate'), '.'])
+  )
+
   return h(FooterWrapper, { alwaysShow: true }, [
     h(TopBar, { showMenu }),
     div({
@@ -532,7 +537,7 @@ export const HeroWrapper = ({ showMenu = true, bigSubhead = false, children }) =
           () => 'project powered by Terra'
         )} for biomedical researchers to `,
         heavyWrapper('access data'), ', ', heavyWrapper('run analysis tools'), ', ',
-        span({ style: { whiteSpace: 'nowrap' } }, ['and', heavyWrapper(' collaborate'), '.'])
+        endText
       ]),
       children
     ])

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -3,7 +3,7 @@ import _ from 'lodash/fp'
 import * as qs from 'qs'
 import { Fragment, useEffect, useState } from 'react'
 import FocusLock from 'react-focus-lock'
-import { b, div, h, h1, img, input, label, span } from 'react-hyperscript-helpers'
+import { b, div, h, h1, img, input, label, span, strong } from 'react-hyperscript-helpers'
 import RSelect, { components as RSelectComponents } from 'react-select'
 import RAsyncCreatableSelect from 'react-select/async-creatable'
 import RSwitch from 'react-switch'
@@ -508,10 +508,10 @@ export const Switch = forwardRefWithName('Switch', ({ onChange, onLabel = 'True'
 })
 
 export const HeroWrapper = ({ showMenu = true, bigSubhead = false, children }) => {
-  const heavyWrapper = text => bigSubhead ? b({ style: { whiteSpace: 'nowrap' } }, [text]) : text
+  const heavyWrapper = text => bigSubhead ? strong({ style: { whiteSpace: 'nowrap' } }, [text]) : text
 
   const endText = Utils.cond(
-    [isProjectSingular(), () => div(['and ', heavyWrapper('collaborate'), ' to advance research around single ventricle heart disease.'])],
+    [isProjectSingular(), () => div(['and ', strong(['collaborate']), ' to advance research around single ventricle heart disease.'])],
     () => span({ style: { whiteSpace: 'nowrap' } }, ['and', heavyWrapper(' collaborate'), '.'])
   )
 

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -19,7 +19,7 @@ import landingPageHero from 'src/images/landing-page-hero.jpg'
 import scienceBackground from 'src/images/science-background.jpg'
 import { Ajax } from 'src/libs/ajax'
 import colors, { terraSpecial } from 'src/libs/colors'
-import { getConfig, isFirecloud, isTerra } from 'src/libs/config'
+import { getConfig, isFirecloud, isProjectSingular, isTerra } from 'src/libs/config'
 import { withErrorReporting } from 'src/libs/error'
 import { getAppName, returnParam } from 'src/libs/logos'
 import * as Nav from 'src/libs/nav'
@@ -528,6 +528,7 @@ export const HeroWrapper = ({ showMenu = true, bigSubhead = false, children }) =
         `${getAppName(true)} is a ${Utils.cond(
           [isTerra(), () => 'cloud-native platform'],
           [isFirecloud(), () => 'NCI Cloud Resource project powered by Terra'],
+          [isProjectSingular(), () => 'project funded by Additional Ventures and powered by Terra'],
           () => 'project powered by Terra'
         )} for biomedical researchers to `,
         heavyWrapper('access data'), ', ', heavyWrapper('run analysis tools'), ', ',

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -532,8 +532,9 @@ export const HeroWrapper = ({ showMenu = true, bigSubhead = false, children }) =
           () => 'project powered by Terra'
         )} for biomedical researchers to `,
         heavyWrapper('access data'), ', ', heavyWrapper('run analysis tools'), ', ',
-        h(Fragment, [span({ style: { whiteSpace: 'nowrap' } }, ['and', strong([' collaborate'])]),
-          isProjectSingular() && ' to advance research around single ventricle heart disease', '.'])
+        span({ style: { whiteSpace: 'nowrap' } }, ['and', strong([' collaborate'])]),
+        isProjectSingular() && ' to advance research around single ventricle heart disease',
+        '.'
       ]),
       children
     ])

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -510,11 +510,6 @@ export const Switch = forwardRefWithName('Switch', ({ onChange, onLabel = 'True'
 export const HeroWrapper = ({ showMenu = true, bigSubhead = false, children }) => {
   const heavyWrapper = text => bigSubhead ? strong({ style: { whiteSpace: 'nowrap' } }, [text]) : text
 
-  const endText = Utils.cond(
-    [isProjectSingular(), () => h(Fragment, ['and ', strong(['collaborate']), ' to advance research around single ventricle heart disease.'])],
-    () => span({ style: { whiteSpace: 'nowrap' } }, ['and', heavyWrapper(' collaborate'), '.'])
-  )
-
   return h(FooterWrapper, { alwaysShow: true }, [
     h(TopBar, { showMenu }),
     div({
@@ -537,7 +532,8 @@ export const HeroWrapper = ({ showMenu = true, bigSubhead = false, children }) =
           () => 'project powered by Terra'
         )} for biomedical researchers to `,
         heavyWrapper('access data'), ', ', heavyWrapper('run analysis tools'), ', ',
-        endText
+        h(Fragment, [span({ style: { whiteSpace: 'nowrap' } }, ['and', strong([' collaborate'])]),
+          isProjectSingular() && ' to advance research around single ventricle heart disease', '.'])
       ]),
       children
     ])

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -511,7 +511,7 @@ export const HeroWrapper = ({ showMenu = true, bigSubhead = false, children }) =
   const heavyWrapper = text => bigSubhead ? strong({ style: { whiteSpace: 'nowrap' } }, [text]) : text
 
   const endText = Utils.cond(
-    [isProjectSingular(), () => div(['and ', strong(['collaborate']), ' to advance research around single ventricle heart disease.'])],
+    [isProjectSingular(), () => h(Fragment, ['and ', strong(['collaborate']), ' to advance research around single ventricle heart disease.'])],
     () => span({ style: { whiteSpace: 'nowrap' } }, ['and', heavyWrapper(' collaborate'), '.'])
   )
 


### PR DESCRIPTION
The PR changes
- involve no functional changes;
- add the text highlighted on the screenshot below;
- can be enabled via `isProjectSingular: true` flag while running locally.

![image](https://user-images.githubusercontent.com/5438223/173386421-ba2c3232-6bab-4d0b-9dc6-a350a481e675.png)

**EDIT:** I had somehow missed half of the requested changes :( The latest looks like the following:

![image](https://user-images.githubusercontent.com/5438223/173409172-4057a615-995a-43b5-b210-ad721f4da05e.png)
