### PR TITLE
[QA-1864] Integration logs handler jest-reporter fails to write out all logs

### DIFF
--- a/integration-tests/jest-reporter.js
+++ b/integration-tests/jest-reporter.js
@@ -31,8 +31,8 @@ module.exports = class JestReporter {
 
     const writableStream = createWriteStream(logFileName)
     writableStream.on('error', ({ message }) => console.error(`Error occurred while writing Console logs to ${logFileName}.\n${message}`))
-
-    testResult.console.forEach(({ message }) => writableStream.write(`${message}\n`))
+    
+    _.forEach(({ message }) => { writableStream.write(`${message}\n`) }, testResult?.console)
 
     // Write pass/failure summaries
     writableStream.write('\n\nTests Summary\n')

--- a/integration-tests/jest-reporter.js
+++ b/integration-tests/jest-reporter.js
@@ -32,7 +32,7 @@ module.exports = class JestReporter {
     const writableStream = createWriteStream(logFileName)
     writableStream.on('error', ({ message }) => console.error(`Error occurred while writing Console logs to ${logFileName}.\n${message}`))
 
-    _.forEach(({ message }) => writableStream.write(`${message}\n`), testResult?.console)
+    testResult.console.forEach(({ message }) => writableStream.write(`${message}\n`))
 
     // Write pass/failure summaries
     writableStream.write('\n\nTests Summary\n')

--- a/integration-tests/jest-reporter.js
+++ b/integration-tests/jest-reporter.js
@@ -31,7 +31,7 @@ module.exports = class JestReporter {
 
     const writableStream = createWriteStream(logFileName)
     writableStream.on('error', ({ message }) => console.error(`Error occurred while writing Console logs to ${logFileName}.\n${message}`))
-    
+
     _.forEach(({ message }) => { writableStream.write(`${message}\n`) }, testResult?.console)
 
     // Write pass/failure summaries


### PR DESCRIPTION
Repeat fix made in https://github.com/DataBiosphere/terra-ui/pull/3024 because it was broken by https://github.com/DataBiosphere/terra-ui/pull/3032.