### PR TITLE
Revert [QA-1839] Revert reload sign-in page once

### DIFF
--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -193,27 +193,10 @@ const dismissNotifications = async page => {
 }
 
 const signIntoTerra = async (page, { token, testUrl }) => {
-  console.log('signIntoTerra ...')
-  const waitUtilBannerVisible = async (timeout = 30 * 1000) => {
-    // Finding visible banner web element first to avoid checking spinner before it renders. It still can happen but chances are smaller.
-    await page.waitForXPath('//*[@id="root"]//*[@role="banner"]', defaultToVisibleTrue({ timeout }))
-    await waitForNoSpinners(page)
-  }
-
-  if (!!testUrl) {
-    console.log(`Loading page: ${testUrl}`)
-    await gotoPage(page, testUrl)
-  }
-
-  try {
-    await waitUtilBannerVisible()
-  } catch (err) {
-    console.error(err)
-    console.error('Error: Page loading timed out during sign in. Reload page.')
-    await page.reload(navOptionNetworkIdle())
-    await waitUtilBannerVisible()
-  }
-
+  !!testUrl && await page.goto(testUrl, navOptionNetworkIdle())
+  await page.waitForXPath('//*[contains(normalize-space(.),"Loading Terra")]', { hidden: true, timeout: 60 * 1000 })
+  await waitForNoSpinners(page)
+  await page.waitForFunction('!!window["forceSignIn"]')
   await page.evaluate(token => window.forceSignIn(token), token)
   await dismissNotifications(page)
   await waitForNoSpinners(page)


### PR DESCRIPTION
Revert https://github.com/DataBiosphere/terra-ui/pull/3021 because reload fails to help resolve issue with `Loading Terra ...` spinner.
