### PR TITLE
[SU-88][SU-118] Sync workspaces list query parameters and filter state

### DIFF
--- a/src/libs/nav.js
+++ b/src/libs/nav.js
@@ -106,7 +106,7 @@ export const Router = () => {
 }
 
 export const updateSearch = params => {
-  const newSearch = qs.stringify(params, { addQueryPrefix: true })
+  const newSearch = qs.stringify(params, { addQueryPrefix: true, arrayFormat: 'brackets' })
 
   if (newSearch !== history.location.search) {
     history.replace({ search: newSearch })

--- a/src/libs/nav.js
+++ b/src/libs/nav.js
@@ -105,10 +105,8 @@ export const Router = () => {
   ])
 }
 
-export const updateSearch = (query, params) => {
-  const newSearch = qs.stringify({
-    ...query, ...params
-  }, { addQueryPrefix: true })
+export const updateSearch = params => {
+  const newSearch = qs.stringify(params, { addQueryPrefix: true })
 
   if (newSearch !== history.location.search) {
     history.replace({ search: newSearch })

--- a/src/pages/Upload.js
+++ b/src/pages/Upload.js
@@ -753,7 +753,7 @@ const UploadData = _.flow( // eslint-disable-line lodash-fp/no-single-compositio
   const [tableMetadata, setTableMetadata] = useState(StateHistory.get().tableMetadata)
 
   useEffect(() => {
-    Nav.updateSearch(query, { workspace: workspaceId, collection })
+    Nav.updateSearch({ ...query, workspace: workspaceId, collection })
   }, [workspaceId, collection]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {


### PR DESCRIPTION
The workspaces list initializes the selected tab and filter state from URL query parameters. However, it only updates the query parameters when the "Search workspaces" filter text is changed.

Thus, it's easy to get into a state where the page does not match the query parameters. For example, if you go to a tab, enter something in the search box, and go to a different tab. If you then refresh the page, the selected tab will change.

The root of the issue is duplicated state. The tab and filter state is stored in both component state and query parameters, and the component attempts to sync the two. This removes the duplication so that the query parameters are the source of truth for the selected tab and filter state. This way, the page content always matches the query parameters.