### PR TITLE
DC-396: App Engine cleanup script improvements

### DIFF
--- a/scripts/delete-old-app-engine-versions.sh
+++ b/scripts/delete-old-app-engine-versions.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Deletes old Google App Engine deployments of Terra UI in an environment. You
-# MUST have GNU date installed to be able to use this script.
+# MUST have jq installed to be able to use this script.
 #
 # USAGE: ./delete-old-app-engine-versions.sh ENV
 #   ENV must be one of dev, alpha, staging, or perf

--- a/scripts/delete-old-app-engine-versions.sh
+++ b/scripts/delete-old-app-engine-versions.sh
@@ -101,8 +101,8 @@ check_deletion_items() {
     DELETE_LIST_COUNT="${#DELETE_LIST_ITEMS[@]}"
     if [ "${DELETE_LIST_COUNT}" -lt 1 ]; then
         abort "no deployments to delete"
-    elif [ "${DELETE_LIST_COUNT}" -lt 30 ]; then
-        abort "less than 30 deployments to delete"
+    elif [ "${DELETE_LIST_COUNT}" -lt 10 ]; then
+        abort "less than 10 deployments to delete"
     fi
 }
 

--- a/scripts/delete-old-app-engine-versions.sh
+++ b/scripts/delete-old-app-engine-versions.sh
@@ -75,7 +75,7 @@ set_dev_deletion_date() {
     printf "${INFO} ${GRN}%s${RST} is the oldest PR and was deployed on ${GRN}%s${RST}\n" "${OLDEST_PR_NAME}" "${OLDEST_PR_DATE}"
 
     if [ "${DELETION_TIME}" -gt "${OLDEST_PR_TIME}" ]; then
-        DELETION_DATE=$(echo "${OLDEST_PR_TIME}" | jq -r '. - 86400 | strftime("%Y-%m-%d")') # 86400 seconds = 1 day
+        DELETION_DATE=$(echo "${OLDEST_PR_TIME}" | jq -r '. - (24 * 60 * 60) | strftime("%Y-%m-%d")') # 1 day
     fi
 }
 
@@ -145,7 +145,7 @@ printf "${INFO} Selected project ${GRN}%s${RST}\n" "${NEW_PROJECT}"
 
 check_user_permissions
 
-DELETION_TIME=$(jq -n 'now - 604800') # 604800 seconds = 7 days
+DELETION_TIME=$(jq -n 'now - (7 * 24 * 60 * 60)') # 7 days
 DELETION_DATE=$(unix_epoch_to_date "${DELETION_TIME}")
 if [ "$1" == "dev" ]; then
     set_dev_deletion_date

--- a/scripts/delete-old-app-engine-versions.sh
+++ b/scripts/delete-old-app-engine-versions.sh
@@ -48,7 +48,7 @@ abort() {
 # ensure that jq is installed
 check_jq_installed() {
     if ! jq --version 1>/dev/null 2>&1; then
-        echo "jq v1.6 or above is required"
+        abort "jq v1.6 or above is required; install using brew install jq"
     fi
 }
 

--- a/scripts/delete-old-app-engine-versions.sh
+++ b/scripts/delete-old-app-engine-versions.sh
@@ -68,7 +68,7 @@ unix_epoch_to_date() {
 # ensure that the deletion date is always older than the oldest pr date
 set_dev_deletion_date() {
     OLDEST_PR=$(gcloud app versions list --filter="pr-" --project="${NEW_PROJECT}" --format=json | jq '. |= sort_by(.last_deployed_time.datetime) | first')
-    OLDEST_PR_NAME=$(echo "${OLDEST_PR}" | jq -r .id)
+    OLDEST_PR_NAME=$(echo "${OLDEST_PR}" | jq -r '.id')
     OLDEST_PR_TIME=$(echo "${OLDEST_PR}" | jq -r '.last_deployed_time.datetime | sub(":00$";"00") | strptime("%Y-%m-%d %H:%M:%S%z") | mktime')
     OLDEST_PR_DATE=$(unix_epoch_to_date "${OLDEST_PR_TIME}")
 
@@ -140,7 +140,6 @@ case $1 in
 esac
 
 NEW_PROJECT="bvdp-saturn-$1"
-ENV_TO_EXEC="$1"
 
 printf "${INFO} Selected project ${GRN}%s${RST}\n" "${NEW_PROJECT}"
 

--- a/scripts/delete-old-app-engine-versions.sh
+++ b/scripts/delete-old-app-engine-versions.sh
@@ -120,18 +120,8 @@ deletion_preflight_summary() {
 
 # actually execute the deletion process
 execute_delete() {
-    gcloud app versions delete "${DELETE_LIST_ITEMS[@]}" --project="${NEW_PROJECT}"
-}
-
-# ensure that a deletion phrase must be entered correctly before continuing
-enter_deletion_phrase() {
-    DELETION_PHRASE="yes delete ${DELETE_LIST_COUNT} deployments in ${ENV_TO_EXEC}"
     printf "${RED}THIS OPERATION WILL IRREVERSIBLY DELETE ${DELETE_LIST_COUNT} DEPLOYMENTS FROM %s AND EARLIER IN THE ${NEW_PROJECT} PROJECT.${RST}\n" "${DELETION_DATE}"
-    printf "${INFO} To continue with the deletion process, type: ${BLD}%s${RST}\n" "${DELETION_PHRASE}"
-    read -r ACTUAL_PHRASE
-    if [ "${ACTUAL_PHRASE}" != "${DELETION_PHRASE}" ]; then
-        abort "mistyped phrase"
-    fi
+    gcloud app versions delete "${DELETE_LIST_ITEMS[@]}" --project="${NEW_PROJECT}"
 }
 
 check_color_support
@@ -165,7 +155,5 @@ printf "${INFO} Set the deletion date to ${RED}%s and earlier${RST}\n" "${DELETI
 
 deletion_preflight_checks
 deletion_preflight_summary
-
-enter_deletion_phrase
 
 execute_delete


### PR DESCRIPTION
v2 of the App Engine deletion script:

- All operations which would have been done by `tail`, `head`, `awk`, `sed`, `cut`, `tr`, and `date` now directly use `jq` instead
- The deletion phrase has been removed, as gcloud asks you to confirm deletion anyways