### PR TITLE
[QA-1913] Terra UI tests: additional logging for troubleshooting test failures

### DIFF
--- a/integration-tests/jest-reporter.js
+++ b/integration-tests/jest-reporter.js
@@ -10,7 +10,7 @@ module.exports = class JestReporter {
 
   onTestStart(test) {
     const { path } = test
-    console.info(`**  Running ${parse(path).name} at ${this.timeNow()}`)
+    console.log(`**  Running ${parse(path).name} at ${this.timeNow()}`)
   }
 
   onTestResult(_testRunConfig, testResult, _runResults) {
@@ -30,7 +30,6 @@ module.exports = class JestReporter {
       writableStream.write('----------------------------------------------\n')
       writableStream.write(`Test: ${title}\n`)
       writableStream.write(`Status: ${status}\n`)
-      console.log(`failureMessages: ${failureMessages}`)
       if (!_.isEmpty(failureMessages)) {
         writableStream.write(`Failure messages: ${failureMessages}\n`)
       }
@@ -50,7 +49,7 @@ module.exports = class JestReporter {
     const logDir = this.getLogPath(runResults)
     const summaryFile = `tests-summary.json`
     writeFileSync(`${logDir}/${summaryFile}`, JSON.stringify(runResults, null, 2))
-    console.info(`**  Saved all tests summary: ${logDir}/${summaryFile}`)
+    console.log(`**  Saved all tests summary: ${logDir}/${summaryFile}`)
     return runResults
   }
 

--- a/integration-tests/jest-reporter.js
+++ b/integration-tests/jest-reporter.js
@@ -45,7 +45,7 @@ module.exports = class JestReporter {
         writableStream.write(`Failure messages: ${failureMessages}\n`)
       }
       if (!_.isEmpty(failureDetails)) {
-        writableStream.write(`Failure details: ${failureDetails}\n`)
+        writableStream.write(`Failure details: ${JSON.stringify(failureDetails, null, 2)}\n`)
       }
       writableStream.write('\n')
     }, testResults)

--- a/integration-tests/jest-reporter.js
+++ b/integration-tests/jest-reporter.js
@@ -27,7 +27,7 @@ module.exports = class JestReporter {
 
     // Write pass/failure summaries
     writableStream.write('\n\nTests Summary\n')
-    _.forEach(({ result }) => {
+    _.forEach(result => {
       const { title, status, failureMessages, failureDetails } = result
       writableStream.write('----------------------------------------------\n')
       writableStream.write(`Test: ${title}\n`)

--- a/integration-tests/jest-reporter.js
+++ b/integration-tests/jest-reporter.js
@@ -15,8 +15,19 @@ module.exports = class JestReporter {
 
   onTestResult(_testRunConfig, testResult, _runResults) {
     const { testFilePath, testResults } = testResult
-    const { name } = parse(testFilePath)
-    const logFileName = `${this.getLogPath(testResults)}/${name}-${Date.now()}.log`
+    const { name: testName } = parse(testFilePath)
+    const hasFailure = _.some(({ status }) => status === 'failed', testResults)
+    const logDir = `${this.logRootDir}/${hasFailure ? 'failures' : 'successes'}`
+    const logFileName = `${logDir}/${testName}-${Date.now()}.log`
+
+    // Since Node 10, mkdirSync knows to not do anything if the dir exists (https://stackoverflow.com/a/71767385/2851999) so not checking explicitly
+    // We may want to specify what to do if an error occurs. Not sure if throwing is what we'd want.
+    try {
+      mkdirSync(logDir, { recursive: true })
+    } catch (err) {
+      console.error(err)
+      throw err
+    }
 
     const writableStream = createWriteStream(logFileName)
     writableStream.on('error', ({ message }) => console.error(`Error occurred while writing Console logs to ${logFileName}.\n${message}`))
@@ -40,34 +51,15 @@ module.exports = class JestReporter {
     }, testResults)
 
     writableStream.end()
-    writableStream.on('finish', () => console.log(`**  Saved ${name} results: ${logFileName}`))
+    writableStream.on('finish', () => console.log(`**  Saved ${testName} results: ${logFileName}`))
   }
 
   // Called after all tests have completed
   onRunComplete(_test, runResults) {
     // Save run summary to a file.
-    const logDir = this.getLogPath(runResults)
     const summaryFile = `tests-summary.json`
-    writeFileSync(`${logDir}/${summaryFile}`, JSON.stringify(runResults, null, 2))
-    console.log(`**  Saved all tests summary: ${logDir}/${summaryFile}`)
-    return runResults
-  }
-
-  getLogPath(result) {
-    const { testResults } = result
-    const hasFailure = _.some(({ status }) => status === 'failed', testResults)
-    const logDir = `${this.logRootDir}/${hasFailure ? 'failures' : 'successes'}`
-
-    // Since Node 10, mkdirSync knows to not do anything if the dir exists (https://stackoverflow.com/a/71767385/2851999) so not checking explicitly
-    // We may want to specify what to do if an error occurs. Not sure if throwing is what we'd want.
-    try {
-      mkdirSync(logDir, { recursive: true })
-    } catch (err) {
-      console.error(err)
-      throw err
-    }
-
-    return logDir
+    writeFileSync(`${this.logRootDir}/${summaryFile}`, JSON.stringify(runResults, null, 2))
+    console.log(`**  Saved all tests summary: ${this.logRootDir}/${summaryFile}`)
   }
 
   timeNow() {

--- a/integration-tests/jest-reporter.js
+++ b/integration-tests/jest-reporter.js
@@ -1,24 +1,65 @@
 const _ = require('lodash/fp')
 const { parse } = require('path')
-const { createWriteStream, mkdirSync } = require('fs')
+const { createWriteStream, mkdirSync, writeFileSync } = require('fs')
 
 
 module.exports = class JestReporter {
+  name
+
   constructor(_globalConfig, _options) {
     this.logRootDir = process.env.LOG_DIR || '/tmp/test-results'
   }
 
   onTestStart(test) {
     const { path } = test
-    console.info(`**  Running ${parse(path).name} at ${this.timeNow()}`)
+    this.name = parse(path).name
+    console.info(`**  Running ${this.name} at ${this.timeNow()}`)
   }
 
   onTestResult(_testRunConfig, testResult, _runResults) {
-    const { testFilePath, testResults } = testResult
-    const { name: testName } = parse(testFilePath)
+    const { testResults } = testResult
+    const logFileName = `${this.getLogPath(testResults)}/${this.name}-${Date.now()}.log`
+
+    const writableStream = createWriteStream(logFileName)
+    writableStream.on('error', ({ message }) => console.error(`Error occurred while writing Console logs to ${logFileName}.\n${message}`))
+
+    _.forEach(({ message }) => { writableStream.write(`${message}\n`) }, testResult?.console)
+
+    // Write pass/failure summaries
+    writableStream.write('\n\nTests Summary\n')
+    _.forEach(({ result }) => {
+      const { title, status, failureMessages, failureDetails } = result
+      writableStream.write('----------------------------------------------\n')
+      writableStream.write(`Test: ${title}\n`)
+      writableStream.write(`Status: ${status}\n`)
+      console.log(`failureMessages: ${failureMessages}`)
+      if (!_.isEmpty(failureMessages)) {
+        writableStream.write(`Failure messages: ${failureMessages}\n`)
+      }
+      if (!_.isEmpty(failureDetails)) {
+        writableStream.write(`Failure details: ${failureDetails}\n`)
+      }
+      writableStream.write('\n')
+    }, testResults)
+
+    writableStream.end()
+    writableStream.on('finish', () => console.log(`**  Saved ${this.name} results: ${logFileName}`))
+  }
+
+  // Called after all tests have completed
+  onRunComplete(_test, runResults) {
+    // Save run summary to a file.
+    const logDir = this.getLogPath(runResults)
+    const summaryFile = `${this.name}-summary.json`
+    writeFileSync(`${logDir}/${summaryFile}`, JSON.stringify(runResults, null, 2))
+    console.info(`**  Saved ${this.name} summary: ${logDir}/${summaryFile}`)
+    return runResults
+  }
+
+  getLogPath(result) {
+    const { testResults } = result
     const hasFailure = _.some(({ status }) => status === 'failed', testResults)
     const logDir = `${this.logRootDir}/${hasFailure ? 'failures' : 'successes'}`
-    const logFileName = `${logDir}/${testName}-${Date.now()}.log`
 
     // Since Node 10, mkdirSync knows to not do anything if the dir exists (https://stackoverflow.com/a/71767385/2851999) so not checking explicitly
     // We may want to specify what to do if an error occurs. Not sure if throwing is what we'd want.
@@ -29,24 +70,7 @@ module.exports = class JestReporter {
       throw err
     }
 
-    const writableStream = createWriteStream(logFileName)
-    writableStream.on('error', ({ message }) => console.error(`Error occurred while writing Console logs to ${logFileName}.\n${message}`))
-
-    _.forEach(({ message }) => { writableStream.write(`${message}\n`) }, testResult?.console)
-
-    // Write pass/failure summaries
-    writableStream.write('\n\nTests Summary\n')
-    _.forEach(result => {
-      writableStream.write('----------------------------------------------\n')
-      writableStream.write(`Test: ${result.title}\n`)
-      writableStream.write(`Status: ${result.status}\n`)
-      const { failureMessages = [] } = result
-      !_.isEmpty(failureMessages) && writableStream.write(`Failure message: ${failureMessages}\n`)
-      writableStream.write('\n')
-    }, testResults)
-
-    writableStream.end()
-    writableStream.on('finish', () => console.log(`Finished writing logs to ${logFileName}`))
+    return logDir
   }
 
   timeNow() {

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -319,6 +319,20 @@ const withScreenshot = _.curry((testName, fn) => async options => {
   }
 })
 
+// Emitted when the page crashes
+const logError = page => {
+  const handle = msg => console.error('page.error', msg)
+  page.on('error', handle)
+  return () => page.off('error', handle)
+}
+
+// Emitted when an uncaught exception happens within the page
+const logPageError = page => {
+  const handle = msg => console.error('page.error', msg)
+  page.on('pageerror', handle)
+  return () => page.off('pageerror', handle)
+}
+
 const logPageConsoleMessages = page => {
   const handle = msg => console.log('page.console', msg)
   page.on('console', handle)
@@ -345,6 +359,8 @@ const withPageLogging = fn => async options => {
   const { page } = options
   logPageAjaxResponses(page)
   logPageConsoleMessages(page)
+  logPageError(page)
+  logError(page)
   return await fn(options)
 }
 

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -328,7 +328,7 @@ const logError = page => {
 
 // Emitted when an uncaught exception happens within the page
 const logPageError = page => {
-  const handle = msg => console.error('page.error', msg)
+  const handle = msg => console.error('page.pageerror', msg)
   page.on('pageerror', handle)
   return () => page.off('pageerror', handle)
 }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/QA-1913

Capture all page errors and write summary of all test results to `tests-summary.json` file. Because sometimes a UI test marked as failed but there was no failure messages in test log. A summary of test results may be helpful to determine what has happened.

Example:
`import-dockstore-workflow` failed but failure messages field is blank in test log.
[CircleCI](https://app.circleci.com/pipelines/github/DataBiosphere/terra-ui/10117/workflows/b71b8ab1-c50b-40e0-bc47-7c234f4d8422)

One `tests-summary.json` in every CirlcleCI VM:

<img width="477" alt="Screen Shot 2022-06-13 at 8 46 25 PM" src="https://user-images.githubusercontent.com/35533885/173470334-2f8f002a-42bc-425a-b957-038139a4b115.png">

