### PR TITLE
[IA-3387] Azure Jupyter Lab support completed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ saturn-ui.iml
 /integration-tests/results
 /integration-tests/screenshots
 /integration-tests/junit.xml
+/integration-tests/test-results
 
 .yarn/*
 !.yarn/cache

--- a/src/components/ContextBar.js
+++ b/src/components/ContextBar.js
@@ -149,7 +149,7 @@ export const ContextBar = ({
               startCurrentRuntime()
             }
           },
-          tooltip: !isTerminalEnabled ? 'Terminal can only be launched for Jupyter environments' : 'Terminal',
+          tooltip: !isTerminalEnabled ? 'Terminal can only be launched from here for Google Jupyter environments.' : 'Terminal',
           tooltipDelay: 100,
           useTooltipAsLabel: false,
           ...Utils.newTabLinkProps

--- a/src/components/CookieWarning.js
+++ b/src/components/CookieWarning.js
@@ -46,6 +46,7 @@ const CookieWarning = () => {
   const rejectCookies = async () => {
     const cookies = document.cookie.split(';')
     acceptCookies(false)
+    //TODO: call azure invalidate cookie once endpoint exists, https://broadworkbench.atlassian.net/browse/IA-3498
     await Ajax(signal).Runtimes.invalidateCookie().catch(() => {})
     // Expire all cookies
     _.forEach(cookie => {

--- a/src/components/CookieWarning.js
+++ b/src/components/CookieWarning.js
@@ -8,7 +8,7 @@ import colors from 'src/libs/colors'
 import { getAppName } from 'src/libs/logos'
 import * as Nav from 'src/libs/nav'
 import { useCancellation, useStore } from 'src/libs/react-utils'
-import { authStore, cookieReadyStore } from 'src/libs/state'
+import { authStore, azureCookieReadyStore, cookieReadyStore } from 'src/libs/state'
 
 
 export const cookiesAcceptedKey = 'cookiesAccepted'
@@ -56,6 +56,7 @@ const CookieWarning = () => {
     }, cookies)
 
     cookieReadyStore.reset()
+    azureCookieReadyStore.reset()
     sessionStorage.clear()
   }
 

--- a/src/components/runtime-common.js
+++ b/src/components/runtime-common.js
@@ -110,7 +110,6 @@ export const PeriodicCookieSetter = () => {
 }
 
 export const PeriodicAzureCookieSetter = ({ proxyUrl }) => {
-  console.log('using periodic cookie setter')
   const signal = useCancellation()
   usePollingEffect(
     withErrorIgnoring(async () => {

--- a/src/components/runtime-common.js
+++ b/src/components/runtime-common.js
@@ -11,7 +11,7 @@ import Events from 'src/libs/events'
 import { getLocalPref } from 'src/libs/prefs'
 import { useCancellation, useGetter, useOnMount, usePollingEffect, usePrevious, useStore } from 'src/libs/react-utils'
 import { getConvertedRuntimeStatus, usableStatuses } from 'src/libs/runtime-utils'
-import { authStore, cookieReadyStore, userStatus } from 'src/libs/state'
+import { authStore, azureCookieReadyStore, cookieReadyStore, userStatus } from 'src/libs/state'
 import * as Utils from 'src/libs/utils'
 
 
@@ -101,7 +101,22 @@ export const PeriodicCookieSetter = () => {
   usePollingEffect(
     withErrorIgnoring(async () => {
       await Ajax(signal).Runtimes.setCookie()
+
       cookieReadyStore.set(true)
+    }),
+    { ms: 5 * 60 * 1000, leading: true }
+  )
+  return null
+}
+
+export const PeriodicAzureCookieSetter = ({ proxyUrl }) => {
+  console.log('using periodic cookie setter')
+  const signal = useCancellation()
+  usePollingEffect(
+    withErrorIgnoring(async () => {
+      await Ajax(signal).Runtimes.setAzureCookie(proxyUrl)
+      //TODO: use store properly
+      azureCookieReadyStore.set(true)
     }),
     { ms: 5 * 60 * 1000, leading: true }
   )

--- a/src/components/runtime-common.js
+++ b/src/components/runtime-common.js
@@ -101,7 +101,6 @@ export const PeriodicCookieSetter = () => {
   usePollingEffect(
     withErrorIgnoring(async () => {
       await Ajax(signal).Runtimes.setCookie()
-
       cookieReadyStore.set(true)
     }),
     { ms: 5 * 60 * 1000, leading: true }
@@ -114,7 +113,6 @@ export const PeriodicAzureCookieSetter = ({ proxyUrl }) => {
   usePollingEffect(
     withErrorIgnoring(async () => {
       await Ajax(signal).Runtimes.setAzureCookie(proxyUrl)
-      //TODO: use store properly
       azureCookieReadyStore.set(true)
     }),
     { ms: 5 * 60 * 1000, leading: true }

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1463,6 +1463,10 @@ const Runtimes = signal => ({
     return fetchLeo('proxy/invalidateToken', _.merge(authOpts(), { signal }))
   },
 
+  setAzureCookie: proxyUrl => {
+    return fetchOk(`${proxyUrl}/setCookie`, _.merge(authOpts(), { signal, credentials: 'include' }))
+  },
+
   setCookie: () => {
     return fetchLeo('proxy/setCookie', _.merge(authOpts(), { signal, credentials: 'include' }))
   },

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -15,7 +15,7 @@ import { clearNotification, notify, sessionTimeoutProps } from 'src/libs/notific
 import { getLocalPref, getLocalPrefForUserId, setLocalPref } from 'src/libs/prefs'
 import allProviders from 'src/libs/providers'
 import {
-  asyncImportJobStore, authStore, cookieReadyStore, requesterPaysProjectStore, userStatus, workspacesStore, workspaceStore
+  asyncImportJobStore, authStore, azureCookieReadyStore, cookieReadyStore, requesterPaysProjectStore, userStatus, workspacesStore, workspaceStore
 } from 'src/libs/state'
 import * as Utils from 'src/libs/utils'
 
@@ -57,6 +57,7 @@ export const signOut = () => {
   // Note: Ideally, we'd actually clear the Leo proxy cookie here, but there's not currently an endpoint to do that.
   // When IA-2236 is done, add that call here.
   cookieReadyStore.reset()
+  azureCookieReadyStore.reset()
   sessionStorage.clear()
   const auth = getAuthInstance()
   revokeTokens()

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -54,8 +54,7 @@ const getAuthInstance = () => {
 }
 
 export const signOut = () => {
-  // Note: Ideally, we'd actually clear the Leo proxy cookie here, but there's not currently an endpoint to do that.
-  // When IA-2236 is done, add that call here.
+  // TODO: invalidate runtime cookies https://broadworkbench.atlassian.net/browse/IA-3498
   cookieReadyStore.reset()
   azureCookieReadyStore.reset()
   sessionStorage.clear()

--- a/src/libs/state.js
+++ b/src/libs/state.js
@@ -25,6 +25,7 @@ export const userStatus = {
 }
 
 export const cookieReadyStore = Utils.atom(false)
+export const azureCookieReadyStore = Utils.atom(false)
 
 export const lastActiveTimeStore = staticStorageSlot(localStorage, 'idleTimeout')
 lastActiveTimeStore.update(v => v || {})

--- a/src/pages/workspaces/workspace/applications/AppLauncher.js
+++ b/src/pages/workspaces/workspace/applications/AppLauncher.js
@@ -38,9 +38,7 @@ const ApplicationLauncher = _.flow(
 
   const leoCookieReady = useStore(cookieReadyStore)
   const azureCookieReady = useStore(azureCookieReadyStore)
-  console.log('googleProject in appLauncher', !!googleProject)
   const cookieReady = !!googleProject ? leoCookieReady : azureCookieReady
-  console.log('cookieReady in appLauncher', cookieReady)
   const signal = useCancellation()
   const interval = useRef()
   const { user: { email } } = useStore(authStore)
@@ -211,7 +209,8 @@ const ApplicationLauncher = _.flow(
       }
     }),
     h(RuntimeKicker, { runtime, refreshRuntimes }),
-    !!azureContext && getConvertedRuntimeStatus(runtime) === 'Running'  ? h(PeriodicAzureCookieSetter, { proxyUrl: runtime.proxyUrl }) : null,
+    // We cannot attach the periodic cookie setter until we have a running runtime for azure, because the relay is not guaranteed to be ready until then
+    !!azureContext && getConvertedRuntimeStatus(runtime) === 'Running' ? h(PeriodicAzureCookieSetter, { proxyUrl: runtime.proxyUrl }) : null,
     fileOutdatedOpen && h(FileOutdatedModal, { onDismiss: () => setFileOutdatedOpen(false), bucketName }),
     _.includes(runtimeStatus, usableStatuses) && cookieReady ?
       h(Fragment, [

--- a/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
+++ b/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
@@ -404,8 +404,7 @@ export const CloudEnvironmentModal = ({
           // Launch
           h(Clickable, { ...getToolLaunchClickableProps(toolLabel) }, [
             icon('rocket', { size: 20 }),
-            span('Open'),
-            span(toolLabel)
+            span('Open')
           ])
         ])
       ])


### PR DESCRIPTION
This completes the iframe support for accessing Jupyter lab hosted in an azure instance

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/6465084/173620126-5041da00-06b3-4433-8b0e-88bf0b544f32.png">

To test this, you need to have an azure workspace. This leverages the existing create azure runtime flow, and then adds cookie support. The iframe proxyUrl is computed in `appLauncher` in a previous PR, and leveraged here.

One thing to note is the `setCookie` call itself takes ~30seconds, and then the jupyter lab UI takes another ~30secs to render.... not sure entirely why, though I'm fairly confident that it is a backend issue. This is being investigated, but I don't think it should block merging this work since this **will not be** user facing as of this PR.