### PR TITLE
[SU-129] Add option to unlink NIH account

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -352,6 +352,10 @@ const User = signal => ({
     return res.json()
   },
 
+  unlinkNihAccount: async () => {
+    await fetchOrchestration('api/nih/account', _.mergeAll([authOpts(), { signal, method: 'DELETE' }]))
+  },
+
   getFenceStatus: async provider => {
     try {
       const res = await fetchBond(`api/link/v1/${provider}`, _.merge(authOpts(), { signal }))


### PR DESCRIPTION
Add an option to unlink your NIH account. This matches the unlink option provided for other external services that are managed through Bond (NHLBI, etc).

To test this, you can simulate a linked NIH account in dev by clicking "Log in to NIH", entering any text for a username, and clicking the return URL.

## Before
![Screen Shot 2022-06-14 at 5 57 22 PM](https://user-images.githubusercontent.com/1156625/173696301-e60b4bd2-84d4-49b1-8b7d-1072b8b054cd.png)

## After
![Screen Shot 2022-06-14 at 5 57 28 PM](https://user-images.githubusercontent.com/1156625/173696354-f4b0ea46-6e6b-4d67-9312-69233268bc3c.png)

