### PR TITLE
[IA-3502] Added workspacename to useCloudEnvironmentPolling.

### DIFF
--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -200,7 +200,7 @@ const WorkspaceAccessError = () => {
   ])
 }
 
-const useCloudEnvironmentPolling = (googleProject, workspaceNamespace) => {
+const useCloudEnvironmentPolling = (googleProject, workspaceNamespace, workspaceName) => {
   const signal = useCancellation()
   const timeout = useRef()
   const [runtimes, setRuntimes] = useState()
@@ -215,7 +215,7 @@ const useCloudEnvironmentPolling = (googleProject, workspaceNamespace) => {
     try {
       const [newDisks, newRuntimes] = await Promise.all([
         Ajax(signal).Disks.list({ googleProject, creator: getUser().email, includeLabels: 'saturnApplication,saturnWorkspaceName' }),
-        !!workspaceNamespace ? Ajax(signal).Runtimes.listV2({ creator: getUser().email, saturnWorkspaceNamespace: workspaceNamespace }) : []
+        !!workspaceNamespace ? Ajax(signal).Runtimes.listV2({ creator: getUser().email, saturnWorkspaceNamespace: workspaceNamespace, saturnWorkspaceName: workspaceName }) : []
       ])
 
       setRuntimes(newRuntimes)
@@ -293,7 +293,7 @@ export const wrapWorkspace = ({ breadcrumbs, activeTab, title, topBarContent, sh
     const prevGoogleProject = usePrevious(googleProject)
     const prevAzureContext = usePrevious(azureContext)
 
-    const { runtimes, refreshRuntimes, persistentDisks, appDataDisks } = useCloudEnvironmentPolling(googleProject, workspace?.workspace.namespace)
+    const { runtimes, refreshRuntimes, persistentDisks, appDataDisks } = useCloudEnvironmentPolling(googleProject, workspace?.workspace.namespace, workspace?.workspace.name)
     const { apps, refreshApps } = useAppPolling(googleProject, name)
     const isGoogleWorkspace = !!googleProject
     const isAzureWorkspace = !!azureContext


### PR DESCRIPTION
The v2 workspaces, this bug doesn’t seem to exist, as workspaceNamespace is unique. This bug only exists with v1 workspaces that were created under the same googleProject, as workspaceNamespace = googleProject for those, creating a conflict in the label filtering.