### PR TITLE
[IA-3384][IA-3313] implement cloud env page changes

### DIFF
--- a/src/components/RuntimeManager.js
+++ b/src/components/RuntimeManager.js
@@ -73,7 +73,7 @@ export const RuntimeErrorModal = ({ runtime, onDismiss }) => {
     withErrorReporting('Could Not Retrieve Cloud Environment Error Info'),
     Utils.withBusyState(setLoadingRuntimeDetails)
   )(async () => {
-    const { errors: runtimeErrors } = _.lowerCase(runtime.cloudContext.cloudProvider) === cloudProviders.azure.label ?
+    const { errors: runtimeErrors } = runtime.cloudContext.cloudProvider === cloudProviders.azure.label ?
       await Ajax().Runtimes.runtimeV2(runtime.workspaceId, runtime.runtimeName).details() :
       await Ajax().Runtimes.runtime(runtime.googleProject, runtime.runtimeName).details()
     if (_.some(({ errorMessage }) => errorMessage.includes('Userscript failed'), runtimeErrors)) {

--- a/src/components/notebook-utils.js
+++ b/src/components/notebook-utils.js
@@ -103,6 +103,7 @@ export const allAppTypes = _.flow(_.map('appType'), _.compact)(tools)
 
 export const getTool = fileName => _.invert(toolToExtensionMap)[getExtension(fileName)]
 export const getToolFromRuntime = _.get(['labels', 'tool'])
+export const isPauseSupported = toolLabel => !_.find(tool => tool.label === toolLabel)(tools).isPauseUnsupported
 
 export const getAnalysisFileExtension = toolLabel => toolToExtensionMap[toolLabel]
 

--- a/src/libs/runtime-utils.js
+++ b/src/libs/runtime-utils.js
@@ -223,6 +223,8 @@ export const runtimeCost = ({ runtimeConfig, status }) => {
 
 export const isApp = cloudEnvironment => !!cloudEnvironment?.appName
 
+export const getAppCost = (app, dataDisk) => app.appType === tools.Galaxy.appType ? getGalaxyCost(app, dataDisk) : 0
+
 export const getGalaxyCost = (app, dataDisk) => {
   return getGalaxyDiskCost(dataDisk) + getGalaxyComputeCost(app)
 }
@@ -426,5 +428,5 @@ export const getIsRuntimeBusy = runtime => {
   return creating || updating || reconfiguring || stopping || starting
 }
 
-export const cloudProviders = { azure: { label: 'azure' }, gcp: {} }
+export const cloudProviders = { azure: { label: 'AZURE' }, gcp: { label: 'GCP' } }
 

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -380,17 +380,12 @@ const Environments = () => {
           {
             size: { basis: 125, grow: 0 },
             headerRenderer: () => h(Sortable, { sort, field: 'type', onSort: setSort }, ['Type']),
-            cellRenderer: ({ rowIndex }) => {
-              return getCloudProvider(filteredCloudEnvironments[rowIndex])
-            }
+            cellRenderer: ({ rowIndex }) => getCloudProvider(filteredCloudEnvironments[rowIndex])
           },
           {
             size: { basis: 125, grow: 0 },
             headerRenderer: () => h(Sortable, { sort, field: 'tool', onSort: setSort }, ['Tool']),
-            cellRenderer: ({ rowIndex }) => {
-              const cloudEnvironment = filteredCloudEnvironments[rowIndex]
-              return getCloudEnvTool(cloudEnvironment)
-            }
+            cellRenderer: ({ rowIndex }) => getCloudEnvTool(filteredCloudEnvironments[rowIndex])
           },
           {
             size: { basis: 90, grow: 0 },

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -20,7 +20,7 @@ import * as Nav from 'src/libs/nav'
 import { useCancellation, useGetter, useOnMount, usePollingEffect } from 'src/libs/react-utils'
 import {
   cloudProviders,
-  defaultComputeZone, getAppCost, getComputeStatusForDisplay, getCurrentRuntime, getDiskAppType, getGalaxyComputeCost, getGalaxyCost,
+  defaultComputeZone, getAppCost, getComputeStatusForDisplay, getCurrentRuntime, getDiskAppType, getGalaxyComputeCost,
   getPersistentDiskCostMonthly, getRegionFromZone, isApp, isComputePausable, isResourceDeletable, mapToPdTypes, runtimeCost,
   workspaceHasMultipleApps,
   workspaceHasMultipleDisks

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -5,7 +5,7 @@ import { Clickable, LabeledCheckbox, Link, spinnerOverlay } from 'src/components
 import FooterWrapper from 'src/components/FooterWrapper'
 import { icon } from 'src/components/icons'
 import Modal from 'src/components/Modal'
-import { tools } from 'src/components/notebook-utils'
+import { getToolFromRuntime, isPauseSupported, tools } from 'src/components/notebook-utils'
 import PopupTrigger, { makeMenuIcon } from 'src/components/PopupTrigger'
 import { SaveFilesHelp, SaveFilesHelpGalaxy } from 'src/components/runtime-common'
 import { AppErrorModal, RuntimeErrorModal } from 'src/components/RuntimeManager'
@@ -19,7 +19,8 @@ import { withErrorIgnoring, withErrorReporting } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
 import { useCancellation, useGetter, useOnMount, usePollingEffect } from 'src/libs/react-utils'
 import {
-  defaultComputeZone, getComputeStatusForDisplay, getCurrentRuntime, getDiskAppType, getGalaxyComputeCost, getGalaxyCost,
+  cloudProviders,
+  defaultComputeZone, getAppCost, getComputeStatusForDisplay, getCurrentRuntime, getDiskAppType, getGalaxyComputeCost, getGalaxyCost,
   getPersistentDiskCostMonthly, getRegionFromZone, isApp, isComputePausable, isResourceDeletable, mapToPdTypes, runtimeCost,
   workspaceHasMultipleApps,
   workspaceHasMultipleDisks
@@ -28,14 +29,16 @@ import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 
 
-const DeleteRuntimeModal = ({ runtime: { googleProject, runtimeName, runtimeConfig: { persistentDiskId } }, onDismiss, onSuccess }) => {
+const DeleteRuntimeModal = ({ runtime: { cloudContext: { cloudProvider }, googleProject, runtimeName, runtimeConfig: { persistentDiskId }, workspaceId }, onDismiss, onSuccess }) => {
   const [deleteDisk, setDeleteDisk] = useState(false)
   const [deleting, setDeleting] = useState()
   const deleteRuntime = _.flow(
     Utils.withBusyState(setDeleting),
     withErrorReporting('Error deleting cloud environment')
   )(async () => {
-    await Ajax().Runtimes.runtime(googleProject, runtimeName).delete(deleteDisk)
+    cloudProvider === cloudProviders.gcp.label ?
+      await Ajax().Runtimes.runtime(googleProject, runtimeName).delete(deleteDisk) :
+      await Ajax().Runtimes.runtimeV2(workspaceId, runtimeName).delete(deleteDisk)
     onSuccess()
   })
   return h(Modal, {
@@ -128,11 +131,12 @@ const Environments = () => {
   const [deleteAppId, setDeleteAppId] = useState()
   const [sort, setSort] = useState({ field: 'project', direction: 'asc' })
   const [diskSort, setDiskSort] = useState({ field: 'project', direction: 'asc' })
+  const [shouldFilterRuntimesByCreator, setShouldFilterRuntimesByCreator] = useState(true)
 
   const refreshData = Utils.withBusyState(setLoading, async () => {
     const creator = getUser().email
     const [newRuntimes, newDisks, newApps] = await Promise.all([
-      Ajax(signal).Runtimes.list({ creator }),
+      Ajax(signal).Runtimes.listV2(shouldFilterRuntimesByCreator ? { creator } : {}),
       Ajax(signal).Disks.list({ creator, includeLabels: 'saturnApplication,saturnWorkspaceNamespace,saturnWorkspaceName' }),
       Ajax(signal).Apps.listWithoutProject({ creator, includeLabels: 'saturnWorkspaceNamespace,saturnWorkspaceName' })
     ])
@@ -169,9 +173,14 @@ const Environments = () => {
   useOnMount(() => { loadData() })
   usePollingEffect(withErrorIgnoring(refreshData), { ms: 30000 })
 
+  const getCloudProvider = cloudEnvironment => isApp(cloudEnvironment) ? 'Kubernetes' : cloudEnvironment.runtimeConfig.cloudService === 'DATAPROC' ? 'Dataproc' : cloudEnvironment.runtimeConfig.cloudService
+  const getCloudEnvTool = cloudEnvironment => isApp(cloudEnvironment) ? _.capitalize(cloudEnvironment.appType) : _.capitalize(cloudEnvironment.labels.tool)
+
   const filteredRuntimes = _.orderBy([{
-    project: 'googleProject',
+    project: 'labels.saturnWorkspaceNamespace',
     workspace: 'labels.saturnWorkspaceName',
+    type: getCloudProvider,
+    tool: getCloudEnvTool,
     status: 'status',
     created: 'auditInfo.createdDate',
     accessed: 'auditInfo.dateAccessed',
@@ -194,7 +203,7 @@ const Environments = () => {
     status: 'status',
     created: 'auditInfo.createdDate',
     accessed: 'auditInfo.dateAccessed',
-    cost: getGalaxyCost
+    cost: getAppCost
   }[sort.field]], [sort.direction], apps)
 
   const filteredCloudEnvironments = _.concat(filteredRuntimes, filteredApps)
@@ -239,11 +248,12 @@ const Environments = () => {
     return getWorkspaceCell(saturnWorkspaceNamespace, saturnWorkspaceName, null, shouldWarn)
   }
 
-  const getDetailsPopup = (cloudEnvName, googleProject, disk) => {
+  const getDetailsPopup = (cloudEnvName, billingId, disk, creator) => {
     return h(PopupTrigger, {
       content: div({ style: { padding: '0.5rem' } }, [
         div([strong(['Name: ']), cloudEnvName]),
-        div([strong(['Google Project: ']), googleProject]),
+        div([strong(['Billing Id: ']), billingId]),
+        !shouldFilterRuntimesByCreator && div([strong(['Creator: ']), creator]),
         !!disk && div([strong(['Persistent Disk: ']), disk.name])
       ])
     }, [h(Link, ['view'])])
@@ -256,9 +266,9 @@ const Environments = () => {
   }
 
   const renderDetailsRuntime = (runtime, disks) => {
-    const { runtimeName, googleProject, runtimeConfig: { persistentDiskId } } = runtime
+    const { runtimeName, cloudContext, runtimeConfig: { persistentDiskId }, auditInfo: { creator } } = runtime
     const disk = _.find({ id: persistentDiskId }, disks)
-    return getDetailsPopup(runtimeName, googleProject, disk)
+    return getDetailsPopup(runtimeName, cloudContext.cloudResource, disk, creator)
   }
 
   const renderDeleteButton = (resourceType, resource) => {
@@ -281,13 +291,15 @@ const Environments = () => {
 
   const renderPauseButton = (computeType, compute) => {
     const { status } = compute
-    const isPausable = isComputePausable(computeType, compute)
-    const app = _.find(tool => tool.appType && tool.appType === compute.appType)(tools)
 
-    return !app?.isPauseUnsupported && h(Link, {
+    const shouldShowPauseButton = isApp(compute) ?
+      !_.find(tool => tool.appType && tool.appType === compute.appType)(tools)?.isPauseUnsupported :
+      isPauseSupported(getToolFromRuntime(compute))
+
+    return shouldShowPauseButton && h(Link, {
       style: { marginRight: '1rem' },
-      disabled: !isPausable,
-      tooltip: isPausable ?
+      disabled: !isComputePausable(computeType, compute),
+      tooltip: isComputePausable(computeType, compute) ?
         'Pause cloud environment' :
         `Cannot pause a cloud environment while in status ${_.upperCase(getComputeStatusForDisplay(status))}.`,
       onClick: () => pauseComputeAndRefresh(computeType, compute)
@@ -339,6 +351,9 @@ const Environments = () => {
     h(TopBar, { title: 'Cloud Environments' }),
     div({ role: 'main', style: { padding: '1rem', flexGrow: 1 } }, [
       h2({ style: { ...Style.elements.sectionHeader, textTransform: 'uppercase', margin: '0 0 1rem 0', padding: 0 } }, ['Your cloud environments']),
+      h(LabeledCheckbox, { checked: shouldFilterRuntimesByCreator, onChange: setShouldFilterRuntimesByCreator }, [
+        span({ style: { fontWeight: 600 } }, [' Hide cloud environments you have access to but didn\'t create'])
+      ]),
       runtimes && h(SimpleFlexTable, {
         'aria-label': 'cloud environments',
         sort,
@@ -364,12 +379,17 @@ const Environments = () => {
           },
           {
             size: { basis: 125, grow: 0 },
-            headerRenderer: () => h(Sortable, { sort, field: 'created', onSort: setSort }, ['Type']),
+            headerRenderer: () => h(Sortable, { sort, field: 'type', onSort: setSort }, ['Type']),
+            cellRenderer: ({ rowIndex }) => {
+              return getCloudProvider(filteredCloudEnvironments[rowIndex])
+            }
+          },
+          {
+            size: { basis: 125, grow: 0 },
+            headerRenderer: () => h(Sortable, { sort, field: 'tool', onSort: setSort }, ['Tool']),
             cellRenderer: ({ rowIndex }) => {
               const cloudEnvironment = filteredCloudEnvironments[rowIndex]
-              return isApp(cloudEnvironment) ?
-                _.capitalize(cloudEnvironment.appType) :
-                (cloudEnvironment.runtimeConfig.cloudService === 'DATAPROC' ? 'Dataproc' : cloudEnvironment.runtimeConfig.cloudService)
+              return getCloudEnvTool(cloudEnvironment)
             }
           },
           {
@@ -481,13 +501,13 @@ const Environments = () => {
             size: { basis: 90, grow: 0 },
             headerRenderer: () => 'Details',
             cellRenderer: ({ rowIndex }) => {
-              const { name, id, googleProject } = filteredDisks[rowIndex]
+              const { name, id, cloudContext } = filteredDisks[rowIndex]
               const runtime = _.find({ runtimeConfig: { persistentDiskId: id } }, runtimes)
               const app = _.find({ diskName: name }, apps)
               return h(PopupTrigger, {
                 content: div({ style: { padding: '0.5rem' } }, [
                   div([strong(['Name: ']), name]),
-                  div([strong(['Google Project: ']), googleProject]),
+                  div([strong(['Billing Id: ']), cloudContext.cloudResource]),
                   runtime && div([strong(['Runtime: ']), runtime.runtimeName]),
                   app && div([strong([`${_.capitalize(app.appType)}: `]), app.appName])
                 ])

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -173,8 +173,14 @@ const Environments = () => {
   useOnMount(() => { loadData() })
   usePollingEffect(withErrorIgnoring(refreshData), { ms: 30000 })
 
-  const getCloudProvider = cloudEnvironment => isApp(cloudEnvironment) ? 'Kubernetes' : cloudEnvironment.runtimeConfig.cloudService === 'DATAPROC' ? 'Dataproc' : cloudEnvironment.runtimeConfig.cloudService
-  const getCloudEnvTool = cloudEnvironment => isApp(cloudEnvironment) ? _.capitalize(cloudEnvironment.appType) : _.capitalize(cloudEnvironment.labels.tool)
+  const getCloudProvider = cloudEnvironment => Utils.cond(
+    [isApp(cloudEnvironment), () => 'Kubernetes'],
+    [cloudEnvironment.runtimeConfig.cloudService === 'DATAPROC', () => 'Dataproc'],
+    [Utils.DEFAULT, () => cloudEnvironment.runtimeConfig.cloudService])
+
+  const getCloudEnvTool = cloudEnvironment => isApp(cloudEnvironment) ?
+    _.capitalize(cloudEnvironment.appType) :
+    _.capitalize(cloudEnvironment.labels.tool)
 
   const filteredRuntimes = _.orderBy([{
     project: 'labels.saturnWorkspaceNamespace',

--- a/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
+++ b/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
@@ -7,7 +7,7 @@ import { CromwellModalBase } from 'src/components/CromwellModal'
 import { GalaxyModalBase } from 'src/components/GalaxyModal'
 import { icon } from 'src/components/icons'
 import ModalDrawer from 'src/components/ModalDrawer'
-import { getAppType, getToolsToDisplay, isToolAnApp, tools } from 'src/components/notebook-utils'
+import { getAppType, getToolsToDisplay, isPauseSupported, isToolAnApp, tools } from 'src/components/notebook-utils'
 import { getRegionInfo } from 'src/components/region-common'
 import { appLauncherTabName } from 'src/components/runtime-common'
 import { AppErrorModal, RuntimeErrorModal } from 'src/components/RuntimeManager'
@@ -135,7 +135,6 @@ export const CloudEnvironmentModal = ({
   const currentRuntimeTool = currentRuntime?.labels?.tool
 
   const currentApp = toolLabel => getCurrentApp(getAppType(toolLabel))(apps)
-  const isPauseSupported = toolLabel => !_.find(tool => tool.label === toolLabel)(tools).isPauseUnsupported
   const isLaunchSupported = toolLabel => !_.find(tool => tool.label === toolLabel)(tools).isLaunchUnsupported
 
   const RuntimeIcon = ({ shape, onClick, disabled, messageChildren, toolLabel, style, ...props }) => {


### PR DESCRIPTION
This makes a laundry list of improvements captured in these tickets.
https://broadworkbench.atlassian.net/browse/IA-3313
https://broadworkbench.atlassian.net/browse/IA-3384

 Namely, it adds azure support to the Cloud environment (first table) portion of the `Environments` page. This does not add persistent disk support, pending Azure disk route refactoring in this ticket https://broadworkbench.atlassian.net/browse/IA-3213.

It also adds a checkbox to allow users to modify some filtering on the runtime environments displayed.

Some wording is still pending UX, but the logic should be fairly stable at this point.
 
<img width="1677" alt="image" src="https://user-images.githubusercontent.com/6465084/174148256-4493028c-c580-48cd-8aec-4b5e8c82cc8e.png">
