### PR TITLE
[SU-136] Fix position of data table ID column

### DIFF
--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -316,6 +316,7 @@ const DataTable = props => {
               initialX,
               initialY,
               sort,
+              numFixedColumns: 2,
               columns: [
                 {
                   width: 70,

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -590,6 +590,8 @@ export const GridTable = forwardRefWithName('GridTable', ({
             } = data
 
             // Group the cells into rows to support a11y
+            // Elements with role "cell" are required to be nested in an element with role "row".
+            // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/cell_role
             return _.flow(
               _.groupBy('rowIndex'),
               Utils.toIndexPairs,


### PR DESCRIPTION
The first column (besides the checkbox) in a data table contains the name of the entity displayed in that row. When horizontally scrolling through a table with many columns, that column scrolls out of view. This makes it easy to lose track of which row you are currently looking at. This fixes the checkbox and name columns in place so that they are always visible when horizontally scrolling the table. This is similar to how the header row is fixed in place when vertically scrolling the table.

## Before
https://user-images.githubusercontent.com/1156625/174343432-7203064f-1c3f-401f-8cfe-02e7e9be4ef7.mov

## After
https://user-images.githubusercontent.com/1156625/174343449-e43895d6-37ef-4e0f-935e-426bd5e42221.mov


A challenge here was that, for accessibility, the cell elements must be rendered inside the row elements. This requires rendering them inside RVGrid's inner scroll container (where the row elements are rendered). However, they cannot be rendered like most cells in the RVGrid, because RVGrid does not render cells it thinks have been scrolled out of view. Thus, RVGrid is only told about the other (unfixed) columns and its [`cellRangeRenderer`](https://github.com/bvaughn/react-virtualized/blob/master/docs/Grid.md#cellrangerenderer), which is already customized to render row elements, is further customized to always render the fixed columns in each visible row.

To position the cells in fixed columns correctly and avoid having them scroll out of view like other cells in RVGrid's inner scroll container, the cells are styled with `position: fixed` GridTable's root element with `contain: strict`. This makes the root element of GridTable act as a [containing block](https://developer.mozilla.org/en-US/docs/Web/CSS/Containing_block#identifying_the_containing_block) for `position: fixed` descendants.

However, RVGrid sets `will-change: transform` on its root element, which would make it the containing block for the fixed columns' cells. To prevent this, RVGrid's default style is overridden with `willChange: 'auto'`.

I'm unsure of the performance implications of removing `will-change: transform`. There was a comment in react-virtualized's code explaining it:
> Without this property, Chrome repaints the entire Grid any time a new row or column is added.
> Firefox only repaints the new row or column (regardless of this property).
> Safari and IE don't support the property at all.

I didn't notice any degradation in scrolling with this change. Even if there is, I'll claim that this may change may be worth it if it avoids the need to scroll back and forth to see row IDs. `contain: strict` on GridTable's root element should at least prevent any impact on the rest of the page. In both current dev and this branch, scrolling the data table in the workflow data selection seem smoother than scrolling the data table in the workspace data tab.