### PR TITLE
[SU-139] Render first paragraph of featured workspace descriptions

### DIFF
--- a/src/components/markdown.js
+++ b/src/components/markdown.js
@@ -41,6 +41,35 @@ export const MarkdownViewer = ({ children, renderers, ...props }) => {
   })
 }
 
+export const FirstParagraphMarkdownViewer = ({ children, renderers, ...props }) => {
+  let renderedFirstParagraph = false
+  return h(MarkdownViewer, {
+    ...props,
+    renderers: {
+      // See https://marked.js.org/using_pro#renderer for list of renderer methods.
+      blockquote: () => '',
+      checkbox: () => '',
+      code: () => '',
+      heading: () => '',
+      hr: () => '',
+      image: () => '',
+      list: () => '',
+      listitem: () => '',
+      paragraph: text => {
+        if (!renderedFirstParagraph) {
+          renderedFirstParagraph = true
+          return `<p>${text}</p>`
+        }
+        return ''
+      },
+      table: () => '',
+      tablerow: () => '',
+      tablecell: () => '',
+      ...renderers
+    }
+  }, [children])
+}
+
 export const newWindowLinkRenderer = (href, title, text) => {
   return `<a href="${href}" ${(title ? `title=${title}` : '')} target="_blank">${text}</a>`
 }

--- a/src/pages/library/Showcase.js
+++ b/src/pages/library/Showcase.js
@@ -79,7 +79,7 @@ const WorkspaceCard = ({ workspace }) => {
       ]),
       h(FirstParagraphMarkdownViewer, {
         style: { fontSize: '14px', lineHeight: '20px', height: 100, overflow: 'hidden' }
-      }, [description])
+      }, [description?.toString()])
     ])
   ])
 }

--- a/src/pages/library/Showcase.js
+++ b/src/pages/library/Showcase.js
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import { a, div, h } from 'react-hyperscript-helpers'
 import FooterWrapper from 'src/components/FooterWrapper'
 import { libraryTopMatter } from 'src/components/library-common'
+import { FirstParagraphMarkdownViewer } from 'src/components/markdown'
 import covidBg from 'src/images/library/showcase/covid-19.jpg'
 import featuredBg from 'src/images/library/showcase/featured-workspace.svg'
 import gatkLogo from 'src/images/library/showcase/gatk-logo-light.svg'
@@ -76,8 +77,9 @@ const WorkspaceCard = ({ workspace }) => {
         div({ style: { flex: 1, color: colors.accent(), fontSize: 16, lineHeight: '20px', height: 40, marginBottom: 7 } }, [name]),
         created && div([Utils.makeStandardDate(created)])
       ]),
-      div({ style: { lineHeight: '20px', height: 100, whiteSpace: 'pre-wrap', overflow: 'hidden' } }, [description])
-      // h(MarkdownViewer, [description]) // TODO: should we render this as markdown?
+      h(FirstParagraphMarkdownViewer, {
+        style: { fontSize: '14px', lineHeight: '20px', height: 100, overflow: 'hidden' }
+      }, [description])
     ])
   ])
 }


### PR DESCRIPTION
Currently, the [featured workspaces page](https://app.terra.bio/#library/showcase) displays the unrendered Markdown source for workspaces' description.

![Screen Shot 2022-06-21 at 7 44 16 AM](https://user-images.githubusercontent.com/1156625/174791983-d2af1cc2-36ef-4888-b6f4-3c83872f5333.png)

Simply rendering the description isn't a great alternative though. The first line of many workspaces' description is a header repeating the workspace name.

![Screen Shot 2022-06-21 at 7 45 22 AM](https://user-images.githubusercontent.com/1156625/174792392-03cc44ba-2035-408a-b003-fc8beba27255.png)

A decent compromise seems to be rendering only the first paragraph of the description.

![Screen Shot 2022-06-21 at 7 45 44 AM](https://user-images.githubusercontent.com/1156625/174792483-03190d17-4564-43dd-be80-713ab515a1fd.png)

