### PR TITLE
[SU-142] Visually hide edit attribute buttons instead of using display none

### DIFF
--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -369,7 +369,7 @@ const DataTable = props => {
                       renderDataCell(entityName, googleProject),
                       div({ style: { flexGrow: 1 } }),
                       editable && h(EditDataLink, {
-                        'aria-label': 'Rename entity',
+                        'aria-label': `Rename ${entityType} ${entityName}`,
                         onClick: () => setRenamingEntity(entityName)
                       })
                     ])

--- a/src/style.css
+++ b/src/style.css
@@ -81,7 +81,13 @@ a {
 }
 
 .table-row:not(:hover, :focus-within) .hover-only, .table-cell:not(:hover, :focus-within) .cell-hover-only {
-  display: none !important;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
 }
 
 .focus-style:focus {


### PR DESCRIPTION
Currently, edit attribute buttons in data tables are styled with `display: none` unless the table cell is hovered or focus is within it. This means that the edit attribute buttons are only keyboard accessible in cells that have another interactive element, such as cells that contain list values.

https://github.com/DataBiosphere/terra-ui/blob/1659356eaf46de58c3d0aab7e70a7027b3a143e0/src/style.css#L83-L85

This changes the way the edit attribute buttons are hidden such that they are only visually hidden and still appear in the tab order (visually hidden styles taken from https://css-tricks.com/inclusively-hidden/).

This also affects edit/delete buttons in the Workspace Data panel. 

## Before
https://user-images.githubusercontent.com/1156625/174883565-87201eca-b8de-44ca-998b-39ad4e6d2246.mov

## After
https://user-images.githubusercontent.com/1156625/174883561-007727e6-79d7-456a-b012-e8de013505ea.mov




