### PR TITLE
[SU-136] Set overflow x and y separately to avoid React warning

### DIFF
--- a/src/components/table.js
+++ b/src/components/table.js
@@ -545,7 +545,12 @@ export const GridTable = forwardRefWithName('GridTable', ({
             outline: 'none',
             // overflow: hidden prevents additional scrollbars from appearing in the header row
             // while scrolling the grid.
-            overflow: 'hidden',
+            // overflowX and overflowY must be set separately because RVGrid also sets them.
+            // Using the overflow: hidden shorthand results in a React warning:
+            // "Updating a style property during rerender (overflowX) when a conflicting property
+            // is set (overflow) can lead to styling bugs"
+            overflowX: 'hidden',
+            overflowY: 'hidden',
             // Override will-change: transform set in RVGrid. This allows positioning fixed columns
             // relative to GridTable's container instead of the RVGrid's inner scroll container.
             willChange: 'auto'


### PR DESCRIPTION
Fixup for #3152.

If the window is wide enough that the entire data table can be shown, React warns:
> Warning: Updating a style property during rerender (overflowX) when a conflicting property is set (overflow) can lead to styling bugs. To avoid this, don't mix shorthand and non-shorthand properties for the same value; instead, replace the shorthand with separate values.

Replacing `overflow: 'hidden'` with `overflowX: 'hidden'` and `overflowY: 'hidden'` resolves this warning.

Missed this in #3152 because for that change I was always testing horizontal scrolling with data tables wider than the window.