### PR TITLE
[SU-130][SU-132] Change behavior of cross data table search

### DIFF
--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -79,7 +79,7 @@ const DataTable = props => {
   const [itemsPerPage, setItemsPerPage] = useState(stateHistory.itemsPerPage || 100)
   const [pageNumber, setPageNumber] = useState(stateHistory.pageNumber || 1)
   const [sort, setSort] = useState(stateHistory.sort || { field: 'name', direction: 'asc' })
-  const [activeTextFilter, setActiveTextFilter] = useState(stateHistory.activeTextFilter || '')
+  const [activeTextFilter, setActiveTextFilter] = useState(stateHistory.activeTextFilter || activeCrossTableTextFilter || '')
 
   const [columnWidths, setColumnWidths] = useState(() => getLocalPref(persistenceId)?.columnWidths || {})
   const [columnState, setColumnState] = useState(() => {
@@ -140,7 +140,7 @@ const DataTable = props => {
         page: pageNumber, pageSize: itemsPerPage, sortField: sort.field, sortDirection: sort.direction,
         ...(!!snapshotName ?
           { billingProject: googleProject, dataReference: snapshotName } :
-          { filterTerms: activeCrossTableTextFilter || activeTextFilter, filterOperator })
+          { filterTerms: activeTextFilter, filterOperator })
       }))
     // Find all the unique attribute names contained in the current page of results.
     const attrNamesFromResults = _.uniq(_.flatMap(_.keys, _.map('attributes', results)))
@@ -225,7 +225,7 @@ const DataTable = props => {
     if (persist) {
       StateHistory.update({ itemsPerPage, pageNumber, sort, activeTextFilter })
     }
-  }, [itemsPerPage, pageNumber, sort, activeTextFilter, activeCrossTableTextFilter, filterOperator, refreshKey]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [itemsPerPage, pageNumber, sort, activeTextFilter, filterOperator, refreshKey]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (persist) {
@@ -242,8 +242,7 @@ const DataTable = props => {
 
 
   // Render
-  // If there is an active cross table search, temporarily reset the column settings to show all columns
-  const columnSettings = activeCrossTableTextFilter ? applyColumnSettings([], entityMetadata[entityType].attributeNames) : applyColumnSettings(columnState || [], entityMetadata[entityType].attributeNames)
+  const columnSettings = applyColumnSettings(columnState || [], entityMetadata[entityType].attributeNames)
   const nameWidth = columnWidths['name'] || 150
 
   const showColumnSettingsModal = () => setUpdatingColumnSettings(columnSettings)

--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -388,11 +388,7 @@ const EntitiesContent = ({
           renderExportMenu({ columnSettings }),
           !snapshotName && h(ButtonSecondary, {
             onClick: showColumnSettingsModal,
-            disabled: !!activeCrossTableTextFilter,
-            tooltip: Utils.cond(
-              [!!activeCrossTableTextFilter, () => 'All columns are shown when searching across tables'],
-              () => 'Change the order and visibility of columns in the table'
-            )
+            tooltip: 'Change the order and visibility of columns in the table'
           }, [icon('cog', { style: { marginRight: '0.5rem' } }), 'Settings']),
           div({ style: { margin: '0 1.5rem', height: '100%', borderLeft: Style.standardLine } }),
           div({


### PR DESCRIPTION
Currently, when performing a cross data table search, the cross table search query takes precedence over the single table search query. The table search input is still enabled, but has no effect.

Also, when performing a cross table search, the user's column settings for the table are overridden and all columns are shown. This is not done when performing a single table search though.

This changes the single table search to take priority over the cross table search. The results shown in the table are always based on the single table search query. When a table is opened from cross table search results, the single table search query is initialized with the cross table search query. After that, it can be changed independently.

Since cross table searches are no longer handled differently by DataTable, this also removes the override on column settings. In the future, we can improve searches to show a notice if rows match the search query because of values in hidden columns.

![Screen Shot 2022-06-22 at 8 26 21 AM](https://user-images.githubusercontent.com/1156625/175028691-dbabf718-955f-4389-ad25-5622018e5628.png)


## Before
https://user-images.githubusercontent.com/1156625/175028405-702eba21-8219-4ec6-99e2-332c406b7eab.mov

## After
https://user-images.githubusercontent.com/1156625/175028437-ee43e6d2-f994-4940-83b1-0b122a1963e6.mov


