### PR TITLE
[SU-140] Show column actions menu only when data table is editable

### DIFF
--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -387,7 +387,7 @@ const DataTable = props => {
                     }, [
                       h(HeaderOptions, {
                         sort, field: attributeName, onSort: setSort,
-                        extraActions: [
+                        extraActions: editable && [
                           // settimeout 0 is needed to delay opening the modaals until after the popup menu closes.
                           // Without this, autofocus doesn't work in the modals.
                           { label: 'Rename Column', disabled: !!noEdit, tooltip: noEdit || '', onClick: () => setTimeout(() => setRenamingColumn(attributeName), 0) },


### PR DESCRIPTION
The DataTable component has an `editable` prop that controls whether or not the controls like the edit attribute or rename entity buttons are shown. The DataTable is editable when shown in the workspace data tab and not editable when shown to select data for a workflow. Currently, the column actions menu (rename, clear, and delete column) does not respect the `editable` prop and is shown when selecting data for a workflow.

## Before
![Screen Shot 2022-06-22 at 8 38 42 AM](https://user-images.githubusercontent.com/1156625/175032846-adf83c02-ac6c-4eec-ac60-6038a54d9128.png)

## After
![Screen Shot 2022-06-22 at 8 38 15 AM](https://user-images.githubusercontent.com/1156625/175032792-9738b466-e6ae-47e3-8579-edd8f44a9c1b.png)


