### PR TITLE
[IA-3507] wait for workspaceName before listing disks and runtimes in leo

### DIFF
--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -224,7 +224,6 @@ const useCloudEnvironmentPolling = (googleProject, workspace) => {
       setRuntimes(newRuntimes)
       setAppDataDisks(_.remove(disk => _.isUndefined(getDiskAppType(disk)), newDisks))
       setPersistentDisks(mapToPdTypes(_.filter(disk => _.isUndefined(getDiskAppType(disk)), newDisks)))
-      console.log('newDisks: ', newDisks)
 
       const runtime = getCurrentRuntime(newRuntimes)
       reschedule(maybeStale || _.includes(getConvertedRuntimeStatus(runtime), ['Creating', 'Starting', 'Stopping', 'Updating', 'LeoReconfiguring']) ?

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -207,8 +207,8 @@ const useCloudEnvironmentPolling = (googleProject, workspace) => {
   const [persistentDisks, setPersistentDisks] = useState()
   const [appDataDisks, setAppDataDisks] = useState()
 
-  const workspaceNamespace = workspace?.workspace.namespace
-  const workspaceName = workspace?.workspace.name
+  const saturnWorkspaceNamespace = workspace?.workspace.namespace
+  const saturnWorkspaceName = workspace?.workspace.name
 
   const reschedule = ms => {
     clearTimeout(timeout.current)
@@ -217,8 +217,8 @@ const useCloudEnvironmentPolling = (googleProject, workspace) => {
   const load = async maybeStale => {
     try {
       const [newDisks, newRuntimes] = !!workspace ? await Promise.all([
-        Ajax(signal).Disks.list({ googleProject, creator: getUser().email, includeLabels: 'saturnApplication,saturnWorkspaceName', saturnWorkspaceName: workspaceName }),
-        Ajax(signal).Runtimes.listV2({ creator: getUser().email, saturnWorkspaceNamespace: workspaceNamespace, saturnWorkspaceName: workspaceName })
+        Ajax(signal).Disks.list({ googleProject, creator: getUser().email, includeLabels: 'saturnApplication,saturnWorkspaceName', saturnWorkspaceName }),
+        Ajax(signal).Runtimes.listV2({ creator: getUser().email, saturnWorkspaceNamespace, saturnWorkspaceName })
       ]) : [[], []]
 
       setRuntimes(newRuntimes)


### PR DESCRIPTION
This PR ensures that `workspaceName` is defined before making API calls to leo for listDisks and listRuntimes. This was causing a bug where listDisks was returning every disk a user had since workspaceName was not defined. It is only not defined on initial load. So now we wait for `workspaceName` to be defined before listing disks and runtimes

Users may have seen the error icon in the Cloud Environment widget as a result of this bug and had to navigate away and then come back for the error icon to go away. This makes it so the icon is not incorrectly displayed
