### PR TITLE
[QA-1864] UI test logger fails to write out all console logs

### DIFF
--- a/integration-tests/jest-reporter.js
+++ b/integration-tests/jest-reporter.js
@@ -32,7 +32,8 @@ module.exports = class JestReporter {
     const writableStream = createWriteStream(logFileName)
     writableStream.on('error', ({ message }) => console.error(`Error occurred while writing Console logs to ${logFileName}.\n${message}`))
 
-    _.forEach(({ message }) => { writableStream.write(`${message}\n`) }, testResult?.console)
+    // Do not change to lodash _.forEach here because it doesn't work here!!
+    testResult.console.forEach(({ message }) => writableStream.write(`${message}\n`))
 
     // Write pass/failure summaries
     writableStream.write('\n\nTests Summary\n')


### PR DESCRIPTION
Third try: Lodash `.forEach` function does not work for `testResult.console` json object.

CircleCI [job](https://app.circleci.com/pipelines/github/DataBiosphere/terra-ui/10286/workflows/1c8f824b-5adc-484c-912a-e4b71474ad25/jobs/45429/artifacts). Failed test was `workspace-dashboard` test.
`workspace-dashboard-1655910711665.log` was missing a lot of logs when compared to the logs found in CircleCI Console window. 