### PR TITLE
DC-415: If a workspace URL is present for a dataset, show it in the details page

### DIFF
--- a/src/libs/icon-dict.js
+++ b/src/libs/icon-dict.js
@@ -3,9 +3,10 @@ import {
 } from '@fortawesome/free-regular-svg-icons'
 import {
   faArrowLeft, faArrowRight, faBan, faCaretDown, faChalkboard, faCheck, faCheckCircle, faCircle, faClock as faClockSolid, faCloud, faCog,
-  faCreditCard, faDownload, faEllipsisV, faExclamationCircle, faExclamationTriangle, faExpandArrowsAlt, faFileInvoiceDollar, faGripHorizontal, faInfoCircle, faLock,
-  faLongArrowAltDown, faLongArrowAltUp, faMinusCircle, faMoneyCheckAlt, faPause, faPen, faPlay, faPlus, faPlusCircle, faQuestion, faQuestionCircle,
-  faRocket, faSearch, faShareAlt, faSquare as faSquareSolid, faTachometerAlt, faTasks, faTerminal, faTrashAlt, faUnlock, faVirus
+  faCreditCard, faDownload, faEllipsisV, faExclamationCircle, faExclamationTriangle, faExpandArrowsAlt, faFileInvoiceDollar,
+  faFolder as faFolderSolid, faGripHorizontal, faInfoCircle, faLock, faLongArrowAltDown, faLongArrowAltUp, faMinusCircle, faMoneyCheckAlt, faPause,
+  faPen, faPlay, faPlus, faPlusCircle, faQuestion, faQuestionCircle, faRocket, faSearch, faShareAlt, faSquare as faSquareSolid, faTachometerAlt,
+  faTasks, faTerminal, faTrashAlt, faUnlock, faVirus
 } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import _ from 'lodash/fp'
@@ -79,6 +80,7 @@ const iconDict = {
   fileAlt: fa(faFileAlt),
   fileSearchSolid: custom(fileSearchSolid),
   folder: fa(faFolder),
+  folderSolid: fa(faFolderSolid),
   'folder-open': fa(faFolderOpen),
   help: fa(faQuestionCircle),
   'info-circle': fa(faInfoCircle),

--- a/src/pages/library/DataBrowserDetails.js
+++ b/src/pages/library/DataBrowserDetails.js
@@ -113,8 +113,8 @@ const MainContent = ({ dataObj }) => {
   const workspaceName = accessURL?.includes('/#workspaces/') && accessURL.substring(accessURL.lastIndexOf('/') + 1)
   return div({ style: { ...styles.content, width: '100%', marginTop: 0 } }, [
     h1({ style: { lineHeight: '1.5em' } }, [dataObj['dct:title']]),
-    workspaceName && div({ style: { marginBottom: '1rem' } }, [
-      `This data is from the Terra workspace:`,
+    !!workspaceName && div({ style: { marginBottom: '1rem' } }, [
+      'This data is from the Terra workspace:',
       h(Link, {
         style: { fontSize: 16, textDecoration: 'underline', textTransform: 'none', height: 'unset', display: 'block' },
         href: accessURL

--- a/src/pages/library/DataBrowserDetails.js
+++ b/src/pages/library/DataBrowserDetails.js
@@ -116,10 +116,10 @@ const MainContent = ({ dataObj }) => {
     workspaceName && div({ style: { marginBottom: '1rem' } }, [
       `This data is from the Terra workspace:`,
       h(Link, {
-        style: { fontSize: 16, textTransform: 'none', height: 'unset', display: 'block' },
+        style: { fontSize: 16, textDecoration: 'underline', textTransform: 'none', height: 'unset', display: 'block' },
         href: accessURL
       }, [
-        icon('folder', { size: 18, style: { marginRight: 10, color: styles.access.controlled } }),
+        icon('folderSolid', { size: 18, style: { marginRight: 10, color: styles.access.controlled } }),
         workspaceName
       ])
     ]),

--- a/src/pages/library/DataBrowserDetails.js
+++ b/src/pages/library/DataBrowserDetails.js
@@ -109,18 +109,18 @@ const LegacyAttributesComponent = ({ dataObj }) => {
 }
 
 const MainContent = ({ dataObj }) => {
+  const accessURL = dataObj['dcat:accessURL']
+  const workspaceName = accessURL?.includes('/#workspaces/') && accessURL.substring(accessURL.lastIndexOf('/') + 1)
   return div({ style: { ...styles.content, width: '100%', marginTop: 0 } }, [
     h1({ style: { lineHeight: '1.5em' } }, [dataObj['dct:title']]),
-    dataObj.dataSource && div({ style: { marginBottom: '1rem' } }, [
-      `This data is from ${dataObj.dataSource.storageSystemName}:`,
-      h(ButtonSecondary, {
+    workspaceName && div({ style: { marginBottom: '1rem' } }, [
+      `This data is from the Terra workspace:`,
+      h(Link, {
         style: { fontSize: 16, textTransform: 'none', height: 'unset', display: 'block' },
-        onClick: () => {
-          // TODO: fill out this link
-        }
+        href: accessURL
       }, [
         icon('folder', { size: 18, style: { marginRight: 10, color: styles.access.controlled } }),
-        dataObj.dataSource.storageSourceName
+        workspaceName
       ])
     ]),
     dataObj['dct:description'],


### PR DESCRIPTION
If a workspace URL is present for a dataset, show it in the details page. A test dataset with a workspace link in `dev` is here `<terra-url>/#library/browser/ed432009-e89d-4ca0-a70f-abe30752da93`

UI mock: https://projects.invisionapp.com/d/main?origin=v7#/console/21881322/463567476/preview?scrollOffset=0
Terra UI screenshot: 
![image](https://user-images.githubusercontent.com/1799360/176005628-57b61355-eac8-45da-8045-3f6e0396e002.png)

The hyperlink points at the workspace URL for the dataset

 If no link is present, or if the link isn't a workspace link, the text and link aren't aren't shown: 

![image](https://user-images.githubusercontent.com/1799360/176006126-da13fad7-feef-4b46-a735-9cba3a7a978a.png)
