### PR TITLE
[IA-3420][IA-3526] fix bug and add workspaceId to details

### DIFF
--- a/src/components/notebook-utils.js
+++ b/src/components/notebook-utils.js
@@ -71,6 +71,7 @@ export const analysisNameInput = ({ inputProps, ...props }) => h(ValidatedInput,
   }
 })
 
+// The label here matches the leonardo `tool` label for runtimes
 export const tools = {
   RStudio: { label: 'RStudio', ext: ['Rmd', 'R'], imageIds: ['RStudio'], defaultImageId: 'RStudio', defaultExt: 'Rmd' },
   Jupyter: { label: 'Jupyter', ext: ['ipynb'], imageIds: ['terra-jupyter-bioconductor', 'terra-jupyter-bioconductor_legacy', 'terra-jupyter-hail', 'terra-jupyter-python', 'terra-jupyter-gatk', 'Pegasus', 'terra-jupyter-gatk_legacy'], defaultImageId: 'terra-jupyter-gatk', isLaunchUnsupported: true, defaultExt: 'ipynb' },

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -269,6 +269,7 @@ const Environments = () => {
   const renderDetailsApp = (app, disks) => {
     const { appName, diskName, googleProject, auditInfo: { creator } } = app
     const disk = _.find({ name: diskName }, disks)
+    // There's no current plans for workspaceId to be defined for apps
     return getDetailsPopup(appName, googleProject, disk, creator, undefined)
   }
 

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -175,8 +175,8 @@ const Environments = () => {
 
   const getCloudProvider = cloudEnvironment => Utils.cond(
     [isApp(cloudEnvironment), () => 'Kubernetes'],
-    [cloudEnvironment.runtimeConfig.cloudService === 'DATAPROC', () => 'Dataproc'],
-    [Utils.DEFAULT, () => cloudEnvironment.runtimeConfig.cloudService])
+    [cloudEnvironment?.runtimeConfig?.cloudService === 'DATAPROC', () => 'Dataproc'],
+    [Utils.DEFAULT, () => cloudEnvironment?.runtimeConfig?.cloudService])
 
   const getCloudEnvTool = cloudEnvironment => isApp(cloudEnvironment) ?
     _.capitalize(cloudEnvironment.appType) :
@@ -254,11 +254,12 @@ const Environments = () => {
     return getWorkspaceCell(saturnWorkspaceNamespace, saturnWorkspaceName, null, shouldWarn)
   }
 
-  const getDetailsPopup = (cloudEnvName, billingId, disk, creator) => {
+  const getDetailsPopup = (cloudEnvName, billingId, disk, creator, workspaceId) => {
     return h(PopupTrigger, {
       content: div({ style: { padding: '0.5rem' } }, [
         div([strong(['Name: ']), cloudEnvName]),
-        div([strong(['Billing Id: ']), billingId]),
+        div([strong(['Billing ID: ']), billingId]),
+        !!workspaceId && div([strong(['Workspace ID: ']), workspaceId]),
         !shouldFilterRuntimesByCreator && div([strong(['Creator: ']), creator]),
         !!disk && div([strong(['Persistent Disk: ']), disk.name])
       ])
@@ -266,15 +267,15 @@ const Environments = () => {
   }
 
   const renderDetailsApp = (app, disks) => {
-    const { appName, diskName, googleProject } = app
+    const { appName, diskName, googleProject, auditInfo: { creator } } = app
     const disk = _.find({ name: diskName }, disks)
-    return getDetailsPopup(appName, googleProject, disk)
+    return getDetailsPopup(appName, googleProject, disk, creator, undefined)
   }
 
   const renderDetailsRuntime = (runtime, disks) => {
-    const { runtimeName, cloudContext, runtimeConfig: { persistentDiskId }, auditInfo: { creator } } = runtime
+    const { runtimeName, cloudContext, runtimeConfig: { persistentDiskId }, auditInfo: { creator }, workspaceId } = runtime
     const disk = _.find({ id: persistentDiskId }, disks)
-    return getDetailsPopup(runtimeName, cloudContext.cloudResource, disk, creator)
+    return getDetailsPopup(runtimeName, cloudContext?.cloudResource, disk, creator, workspaceId)
   }
 
   const renderDeleteButton = (resourceType, resource) => {

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -141,12 +141,12 @@ const Environments = () => {
       Ajax(signal).Apps.listWithoutProject({ creator, includeLabels: 'saturnWorkspaceNamespace,saturnWorkspaceName' })
     ])
 
-    const decorateLabeledCloudObjWithWorkspaceId = async cloudObject => {
+    const decorateLabeledCloudObjWithWorkspaceId = withErrorIgnoring(async cloudObject => {
       const { labels: { saturnWorkspaceNamespace, saturnWorkspaceName } } = cloudObject
-      const details = !!saturnWorkspaceNamespace && !!saturnWorkspaceName ? await Ajax(signal).Workspaces.workspace(saturnWorkspaceNamespace, saturnWorkspaceName).details(['workspace']) : undefined
+      const details = !!saturnWorkspaceNamespace && !!saturnWorkspaceName ? await Ajax(signal).Workspaces.workspace(saturnWorkspaceNamespace, saturnWorkspaceName).details(['workspace']).catch(_ => undefined) : undefined
       const workspaceId = details?.workspace?.workspaceId
       return { ...cloudObject, workspaceId }
-    }
+    })
 
     const [decoratedRuntimes, decoratedDisks, decoratedApps] = [
       await Promise.all(_.map(decorateLabeledCloudObjWithWorkspaceId, newRuntimes)),

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -143,8 +143,8 @@ const Environments = () => {
 
     const decorateLabeledCloudObjWithWorkspaceId = async cloudObject => {
       const { labels: { saturnWorkspaceNamespace, saturnWorkspaceName } } = cloudObject
-      const details = await Ajax(signal).Workspaces.workspace(saturnWorkspaceNamespace, saturnWorkspaceName).details(['workspace'])
-      const workspaceId = details.workspace.workspaceId
+      const details = !!saturnWorkspaceNamespace && !!saturnWorkspaceName ? await Ajax(signal).Workspaces.workspace(saturnWorkspaceNamespace, saturnWorkspaceName).details(['workspace']) : undefined
+      const workspaceId = details?.workspace?.workspaceId
       return { ...cloudObject, workspaceId }
     }
 
@@ -274,7 +274,7 @@ const Environments = () => {
       content: div({ style: { padding: '0.5rem' } }, [
         div([strong(['Name: ']), cloudEnvName]),
         div([strong(['Billing ID: ']), billingId]),
-        div([strong(['Workspace ID: ']), workspaceId]),
+        workspaceId && div([strong(['Workspace ID: ']), workspaceId]),
         !shouldFilterRuntimesByCreator && div([strong(['Creator: ']), creator]),
         !!disk && div([strong(['Persistent Disk: ']), disk.name])
       ])
@@ -525,7 +525,7 @@ const Environments = () => {
                 content: div({ style: { padding: '0.5rem' } }, [
                   div([strong(['Name: ']), name]),
                   div([strong(['Billing ID: ']), cloudContext.cloudResource]),
-                  div([strong(['Workspace ID: ']), workspaceId]),
+                  workspaceId && div([strong(['Workspace ID: ']), workspaceId]),
                   runtime && div([strong(['Runtime: ']), runtime.runtimeName]),
                   app && div([strong([`${_.capitalize(app.appType)}: `]), app.appName])
                 ])

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -373,8 +373,10 @@ const Environments = () => {
     h(TopBar, { title: 'Cloud Environments' }),
     div({ role: 'main', style: { padding: '1rem', flexGrow: 1 } }, [
       h2({ style: { ...Style.elements.sectionHeader, textTransform: 'uppercase', margin: '0 0 1rem 0', padding: 0 } }, ['Your cloud environments']),
-      h(LabeledCheckbox, { checked: shouldFilterRuntimesByCreator, onChange: setShouldFilterRuntimesByCreator }, [
-        span({ style: { fontWeight: 600 } }, [' Hide cloud environments you have access to but didn\'t create'])
+      div({ style: { marginBottom: '.5rem' } }, [
+        h(LabeledCheckbox, { checked: shouldFilterRuntimesByCreator, onChange: setShouldFilterRuntimesByCreator }, [
+          span({ style: { fontWeight: 600 } }, [' Hide cloud environments you have access to but didn\'t create'])
+        ])
       ]),
       runtimes && h(SimpleFlexTable, {
         'aria-label': 'cloud environments',


### PR DESCRIPTION
Fixes a bug where the page would not load due to cloudService not being defined for a runtime, and adds workspaceId to the details pop-up where relevant.

Unfortunately, leo only has this information for runtimes through runtimes created with the V2 API. For backwards compatibility, we must ask rawls for the workspaceId using runtime labels.