### PR TITLE
[AJ-481] update fixed columns logic to allow for empty tables in the UI

### DIFF
--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -318,7 +318,7 @@ const DataTable = props => {
               initialX,
               initialY,
               sort,
-              numFixedColumns: visibleColumns.length > 2 ? 2 : 0,
+              numFixedColumns: visibleColumns.length > 0 ? 2 : 0,
               columns: [
                 {
                   width: 70,

--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -306,6 +306,8 @@ const DataTable = props => {
       div({ style: { flex: 1 } }, [
         h(AutoSizer, [
           ({ width, height }) => {
+            const visibleColumns = _.filter('visible', columnSettings)
+
             return h(GridTable, {
               ref: table,
               'aria-label': `${entityType} data table, page ${pageNumber} of ${Math.ceil(totalRowCount / itemsPerPage)}`,
@@ -316,7 +318,7 @@ const DataTable = props => {
               initialX,
               initialY,
               sort,
-              numFixedColumns: 2,
+              numFixedColumns: visibleColumns.length > 2 ? 2 : 0,
               columns: [
                 {
                   width: 70,
@@ -427,7 +429,7 @@ const DataTable = props => {
                       }
                     }
                   }
-                }, _.filter('visible', columnSettings))
+                }, visibleColumns)
               ],
               styleCell: ({ rowIndex }) => {
                 return rowIndex % 2 && { backgroundColor: colors.light(0.2) }


### PR DESCRIPTION
In Terra UI, when uploading an empty table, the table view page crashes due to an error in the DataGrid. The problem is that the first 2 columns are set to "fixed", so the DataGrid works with 0 unfixed columns. The component can't handle this case, and crashes with an IndexOutOfBoundsException when trying to compute the width of the unfixed part of the table. This fix addresses that by only fixing 2 columns if we have more than 2.
<!--
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Also, so if a screen recording [1] and/or screenshots would be a helpful way to communicate context, please consider including some in your PR description.
Thanks!

[1] https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac
--!>
