### PR TITLE
AJ-433 filter ids to prevent duplication

### DIFF
--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -478,7 +478,7 @@ const WorkspaceData = _.flow(
       setSnapshotDetails(_.set([snapshotName, 'error'], false))
       const entities = await Ajax(signal).Workspaces.workspace(namespace, name).snapshotEntityMetadata(googleProject, snapshotName)
       //Prevent duplicate id columns
-      const entitiesWithoutIds = _.mapValues(entity => _.update(['attributeNames'], _.without([entity.idName]), value), entities)
+      const entitiesWithoutIds = _.mapValues(entity => _.update(['attributeNames'], _.without([entity.idName]), entity), entities)
       setSnapshotDetails(_.set([snapshotName, 'entityMetadata'], entitiesWithoutIds))
     } catch (error) {
       reportError(`Error loading entities in snapshot ${snapshotName}`, error)

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -477,6 +477,10 @@ const WorkspaceData = _.flow(
     try {
       setSnapshotDetails(_.set([snapshotName, 'error'], false))
       const entities = await Ajax(signal).Workspaces.workspace(namespace, name).snapshotEntityMetadata(googleProject, snapshotName)
+      //Prevent duplicate id columns
+      Object.keys(entities).forEach( key => {
+        entities[key].attributeNames = entities[key].attributeNames.filter(attr => attr != entities[key].idName)
+      })
       setSnapshotDetails(_.set([snapshotName, 'entityMetadata'], entities))
     } catch (error) {
       reportError(`Error loading entities in snapshot ${snapshotName}`, error)

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -478,7 +478,7 @@ const WorkspaceData = _.flow(
       setSnapshotDetails(_.set([snapshotName, 'error'], false))
       const entities = await Ajax(signal).Workspaces.workspace(namespace, name).snapshotEntityMetadata(googleProject, snapshotName)
       //Prevent duplicate id columns
-      const entitiesWithoutIds = _.mapValues(value => _.update(['attributeNames'], _.without([value.idName]), value), entities)
+      const entitiesWithoutIds = _.mapValues(entity => _.update(['attributeNames'], _.without([entity.idName]), value), entities)
       setSnapshotDetails(_.set([snapshotName, 'entityMetadata'], entitiesWithoutIds))
     } catch (error) {
       reportError(`Error loading entities in snapshot ${snapshotName}`, error)

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -478,7 +478,7 @@ const WorkspaceData = _.flow(
       setSnapshotDetails(_.set([snapshotName, 'error'], false))
       const entities = await Ajax(signal).Workspaces.workspace(namespace, name).snapshotEntityMetadata(googleProject, snapshotName)
       //Prevent duplicate id columns
-      const entitiesWithoutIds = _.mapValues( value => _.update(['attributeNames'], ans => _.without([value.idName], ans), value), entities)
+      const entitiesWithoutIds = _.mapValues(value => _.update(['attributeNames'], _.without([value.idName]), value), entities)
       setSnapshotDetails(_.set([snapshotName, 'entityMetadata'], entitiesWithoutIds))
     } catch (error) {
       reportError(`Error loading entities in snapshot ${snapshotName}`, error)

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -478,10 +478,8 @@ const WorkspaceData = _.flow(
       setSnapshotDetails(_.set([snapshotName, 'error'], false))
       const entities = await Ajax(signal).Workspaces.workspace(namespace, name).snapshotEntityMetadata(googleProject, snapshotName)
       //Prevent duplicate id columns
-      Object.keys(entities).forEach(key => {
-        entities[key].attributeNames = entities[key].attributeNames.filter(attr => attr !== entities[key].idName)
-      })
-      setSnapshotDetails(_.set([snapshotName, 'entityMetadata'], entities))
+      const entitiesWithoutIds = _.mapValues( value => _.update(['attributeNames'], ans => _.without([value.idName], ans), value), entities)
+      setSnapshotDetails(_.set([snapshotName, 'entityMetadata'], entitiesWithoutIds))
     } catch (error) {
       reportError(`Error loading entities in snapshot ${snapshotName}`, error)
       setSnapshotDetails(_.set([snapshotName, 'error'], true))

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -478,8 +478,8 @@ const WorkspaceData = _.flow(
       setSnapshotDetails(_.set([snapshotName, 'error'], false))
       const entities = await Ajax(signal).Workspaces.workspace(namespace, name).snapshotEntityMetadata(googleProject, snapshotName)
       //Prevent duplicate id columns
-      Object.keys(entities).forEach( key => {
-        entities[key].attributeNames = entities[key].attributeNames.filter(attr => attr != entities[key].idName)
+      Object.keys(entities).forEach(key => {
+        entities[key].attributeNames = entities[key].attributeNames.filter(attr => attr !== entities[key].idName)
       })
       setSnapshotDetails(_.set([snapshotName, 'entityMetadata'], entities))
     } catch (error) {


### PR DESCRIPTION
[AJ-433](https://broadworkbench.atlassian.net/browse/AJ-433)
If a column of a snapshot-by-reference is also the id, then it will display twice in the table - once as the id, once as an attribute.  This filters out ids when loading the metadata.  Should only affect snapshots whose id is also a column.