### PR TITLE
[SU-136] Fix bug with GridTable fixed column positions

### DIFF
--- a/src/components/table.js
+++ b/src/components/table.js
@@ -425,7 +425,7 @@ export const GridTable = forwardRefWithName('GridTable', ({
   const fixedColumns = _.slice(0, numFixedColumns, columns)
   const totalFixedColumnsWidth = _.sum(_.map('width', fixedColumns))
   // The value at index i in this array is a sum of the widths of columns to the left of the column at index i.
-  const fixedColumnOffsets = _.transform((offsets, column) => { offsets.push(column.width) }, [0])(columns)
+  const fixedColumnOffsets = _.transform((offsets, column) => { offsets.push(column.width + _.last(offsets)) }, [0])(fixedColumns)
 
   const unfixedColumns = _.slice(numFixedColumns, _.size(columns), columns)
 


### PR DESCRIPTION
Noticed this bug while looking at #3171. Positions for fixed columns are calculated incorrectly.

This only manifests when there are more than 2 fixed columns in a GridTable, which is not currently the case anywhere in Terra.

Screenshots below show 4 fixed columns.

## Before
![Screen Shot 2022-06-28 at 1 51 30 PM](https://user-images.githubusercontent.com/1156625/176250046-9753d953-f8b2-4587-8084-6885fccabeff.png)

## After
![Screen Shot 2022-06-28 at 1 51 41 PM](https://user-images.githubusercontent.com/1156625/176250063-e6db8dda-313e-4d76-98ef-c33aa44ceb70.png)

