### PR TITLE
[IA-3536] Fix notebookName in notebooks tab when checking lock status

### DIFF
--- a/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/NotebookLauncher.js
@@ -196,7 +196,7 @@ const PreviewHeader = ({ queryParams, runtime, readOnlyAccess, onCreateRuntime, 
   const notebookLink = Nav.getLink('workspace-notebook-launch', { namespace, name, notebookName })
 
   const checkIfLocked = withErrorReporting('Error checking notebook lock status', async () => {
-    const { metadata: { lastLockedBy, lockExpiresAt } = {} } = await Ajax(signal).Buckets.notebook(googleProject, bucketName, notebookName.slice(0, -6)).getObject()
+    const { metadata: { lastLockedBy, lockExpiresAt } = {} } = await Ajax(signal).Buckets.notebook(googleProject, bucketName, notebookName).getObject()
     const hashedUser = await notebookLockHash(bucketName, email)
     const lockExpirationDate = new Date(parseInt(lockExpiresAt))
 


### PR DESCRIPTION
Fixes a bug caught in staging 

<img width="1180" alt="Screen Shot 2022-06-28 at 11 35 25 AM" src="https://user-images.githubusercontent.com/23626109/176250069-90465364-f61d-4339-9dd2-4f2129924be7.png">

<img width="1021" alt="Screen Shot 2022-06-28 at 11 35 19 AM" src="https://user-images.githubusercontent.com/23626109/176250031-c1bea0ec-a029-4926-b48b-f1dcbfdd449e.png">

This PR passes the correct notebookName including the fileExtension

