### PR TITLE
[SU-137] Visual updates to workspaces list heading and filters

### DIFF
--- a/integration-tests/tests/preview-drs-uri.js
+++ b/integration-tests/tests/preview-drs-uri.js
@@ -24,7 +24,7 @@ const testPreviewDrsUriFn = _.flow(
 
   await click(page, clickable({ textContains: 'View Workspaces' }))
   await waitForNoSpinners(page)
-  await fillIn(page, input({ placeholder: 'SEARCH WORKSPACES' }), workspaceName)
+  await fillIn(page, input({ placeholder: 'Search by keyword' }), workspaceName)
   await click(page, clickable({ textContains: workspaceName }))
 
   await click(page, navChild('data'))

--- a/integration-tests/tests/run-workflow.js
+++ b/integration-tests/tests/run-workflow.js
@@ -18,7 +18,7 @@ const testRunWorkflowFn = _.flow(
   await createEntityInWorkspace(page, billingProject, workspaceName, testEntity)
   await click(page, clickable({ textContains: 'View Workspaces' }))
   await waitForNoSpinners(page)
-  await fillIn(page, input({ placeholder: 'SEARCH WORKSPACES' }), workspaceName)
+  await fillIn(page, input({ placeholder: 'Search by keyword' }), workspaceName)
   await click(page, clickable({ textContains: workspaceName }))
 
   await click(page, navChild('workflows'))

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -204,7 +204,7 @@ const viewWorkspaceDashboard = async (page, token, workspaceName) => {
   await signIntoTerra(page, { token })
   await click(page, clickable({ textContains: 'View Workspaces' }))
   await dismissNotifications(page)
-  await fillIn(page, input({ placeholder: 'SEARCH WORKSPACES' }), workspaceName)
+  await fillIn(page, input({ placeholder: 'Search by keyword' }), workspaceName)
   await noSpinnersAfter(page, { action: () => click(page, clickable({ textContains: workspaceName })) })
 }
 

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -36,7 +36,7 @@ const styles = {
   tableCellContent: {
     height: '50%', display: 'flex', alignItems: 'center'
   },
-  filter: { marginRight: '1rem', flex: '1 0 300px', minWidth: 0 }
+  filter: { marginRight: '1rem', flex: '1 1 0', minWidth: 'max-content' }
 }
 
 const useWorkspacesWithSubmissionStats = () => {
@@ -297,15 +297,7 @@ export const WorkspaceList = () => {
 
 
   return h(FooterWrapper, [
-    h(TopBar, { title: 'Workspaces' }, [
-      h(DelayedSearchInput, {
-        style: { marginLeft: '2rem', width: 500 },
-        placeholder: 'SEARCH WORKSPACES',
-        'aria-label': 'Search workspaces',
-        onChange: newFilter => Nav.updateSearch({ ...query, filter: newFilter || undefined }),
-        value: filter
-      })
-    ]),
+    h(TopBar, { title: 'Workspaces' }),
     div({ role: 'main', style: { padding: '1.5rem', flex: 1, display: 'flex', flexDirection: 'column' } }, [
       div({ style: { display: 'flex', alignItems: 'center', marginBottom: '1rem' } }, [
         div({ style: { ...Style.elements.sectionHeader, textTransform: 'uppercase' } }, ['Workspaces']),
@@ -317,6 +309,14 @@ export const WorkspaceList = () => {
         [icon('lighter-plus-circle', { size: 24 })])
       ]),
       div({ style: { display: 'flex', marginBottom: '1rem' } }, [
+        div({ style: { ...styles.filter, flexGrow: 1.5 } }, [
+          h(DelayedSearchInput, {
+            placeholder: 'Search by keyword',
+            'aria-label': 'Search workspaces',
+            onChange: newFilter => Nav.updateSearch({ ...query, filter: newFilter || undefined }),
+            value: filter
+          })
+        ]),
         div({ style: styles.filter }, [
           h(WorkspaceTagSelect, {
             isClearable: true,
@@ -328,7 +328,7 @@ export const WorkspaceList = () => {
             onChange: data => Nav.updateSearch({ ...query, tagsFilter: _.map('value', data) })
           })
         ]),
-        div({ style: { ...styles.filter, flexBasis: '250px' } }, [
+        div({ style: styles.filter }, [
           h(Select, {
             isClearable: true,
             isMulti: true,
@@ -357,7 +357,7 @@ export const WorkspaceList = () => {
             )(workspaces)
           })
         ]),
-        div({ style: { ...styles.filter, flexBasis: '220px', marginRight: '' } }, [
+        div({ style: { ...styles.filter, marginRight: 0 } }, [
           h(Select, {
             isClearable: true,
             isMulti: true,

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -319,7 +319,7 @@ export const WorkspaceList = () => {
         div({ style: { ...styles.filter, flexGrow: 1.5 } }, [
           h(DelayedSearchInput, {
             placeholder: 'Search by keyword',
-            'aria-label': 'Search workspaces',
+            'aria-label': 'Search workspaces by keyword',
             onChange: newFilter => Nav.updateSearch({ ...query, filter: newFilter || undefined }),
             value: filter
           })

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -1,7 +1,7 @@
 import { isAfter, parseJSON } from 'date-fns/fp'
 import _ from 'lodash/fp'
 import { useEffect, useMemo, useState } from 'react'
-import { div, h, span } from 'react-hyperscript-helpers'
+import { div, h, p, span } from 'react-hyperscript-helpers'
 import { AutoSizer } from 'react-virtualized'
 import { DelayedRender, HeaderRenderer, Link, Select, topSpinnerOverlay, transparentSpinnerOverlay } from 'src/components/common'
 import FooterWrapper from 'src/components/FooterWrapper'
@@ -299,14 +299,21 @@ export const WorkspaceList = () => {
   return h(FooterWrapper, [
     h(TopBar, { title: 'Workspaces' }),
     div({ role: 'main', style: { padding: '1.5rem', flex: 1, display: 'flex', flexDirection: 'column' } }, [
-      div({ style: { display: 'flex', alignItems: 'center', marginBottom: '1rem' } }, [
-        div({ style: { ...Style.elements.sectionHeader, textTransform: 'uppercase' } }, ['Workspaces']),
+      div({ style: { display: 'flex', alignItems: 'center', marginBottom: '0.5rem' } }, [
+        div({ style: { ...Style.elements.sectionHeader, fontSize: '1.5rem' } }, ['Workspaces']),
         h(Link, {
           onClick: () => setCreatingNewWorkspace(true),
           style: { marginLeft: '0.5rem' },
           tooltip: 'Create a new workspace'
         },
         [icon('lighter-plus-circle', { size: 24 })])
+      ]),
+      p({ style: { margin: '0 0 1rem' } }, [
+        'Dedicated spaces for you and your collaborators to access and analyze data together. ',
+        h(Link, {
+          ...Utils.newTabLinkProps,
+          href: 'https://support.terra.bio/hc/en-us/articles/360024743371-Working-with-workspaces'
+        }, ['Learn more about workspaces.'])
       ]),
       div({ style: { display: 'flex', marginBottom: '1rem' } }, [
         div({ style: { ...styles.filter, flexGrow: 1.5 } }, [


### PR DESCRIPTION
A few visual updates to the workspaces list:
- Increase the font size of the page heading.
- Add a note describing workspaces and linking to a support article.
- Move the search workspaces input inline with the rest of the filter controls.

## Before
![Screen Shot 2022-06-29 at 9 15 41 AM](https://user-images.githubusercontent.com/1156625/176445781-d3cf95c8-db23-45ff-8a54-dc212769de25.png)

## After
![Screen Shot 2022-06-29 at 9 14 40 AM](https://user-images.githubusercontent.com/1156625/176445788-1e85e620-758e-4c34-a642-509ef07d2533.png)
