### PR TITLE
[SUP-687] Rewrite column_grabber.svg to remove IDs

### DIFF
--- a/src/icons/column_grabber.svg
+++ b/src/icons/column_grabber.svg
@@ -1,14 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="6" height="22" viewBox="0 0 6 22">
-  <defs>
-    <path id="column_grabber-a" d="M9,5 L10,5 L10,6 L9,6 L9,5 Z M6,5 L7,5 L7,6 L6,6 L6,5 Z M3,5 L4,5 L4,6 L3,6 L3,5 Z M0,5 L1,5 L1,6 L0,6 L0,5 Z M9,2.5 L10,2.5 L10,3.5 L9,3.5 L9,2.5 Z M6,2.5 L7,2.5 L7,3.5 L6,3.5 L6,2.5 Z M3,2.5 L4,2.5 L4,3.5 L3,3.5 L3,2.5 Z M0,2.5 L1,2.5 L1,3.5 L0,3.5 L0,2.5 Z M9,0 L10,0 L10,1 L9,1 L9,0 Z M6,0 L7,0 L7,1 L6,1 L6,0 Z M3,0 L4,0 L4,1 L3,1 L3,0 Z M0,0 L1,0 L1,1 L0,1 L0,0 Z"/>
-    <path id="column_grabber-b" d="M9,5 L10,5 L10,6 L9,6 L9,5 Z M6,5 L7,5 L7,6 L6,6 L6,5 Z M3,5 L4,5 L4,6 L3,6 L3,5 Z M0,5 L1,5 L1,6 L0,6 L0,5 Z M9,2.5 L10,2.5 L10,3.5 L9,3.5 L9,2.5 Z M6,2.5 L7,2.5 L7,3.5 L6,3.5 L6,2.5 Z M3,2.5 L4,2.5 L4,3.5 L3,3.5 L3,2.5 Z M0,2.5 L1,2.5 L1,3.5 L0,3.5 L0,2.5 Z M9,0 L10,0 L10,1 L9,1 L9,0 Z M6,0 L7,0 L7,1 L6,1 L6,0 Z M3,0 L4,0 L4,1 L3,1 L3,0 Z M0,0 L1,0 L1,1 L0,1 L0,0 Z"/>
-  </defs>
-  <g fill="none" fill-rule="evenodd">
-    <g transform="rotate(90 -3 9)">
-      <use fill="#4A4A4A" fill-rule="nonzero" xlink:href="#column_grabber-a"/>
-    </g>
-    <g transform="rotate(90 3 3)">
-      <use fill="#4A4A4A" fill-rule="nonzero" xlink:href="#column_grabber-b"/>
-    </g>
-  </g>
+<svg xmlns="http://www.w3.org/2000/svg" width="6" height="22" viewBox="0 0 6 22">
+  <path transform="rotate(90 -3 9)" fill="#4A4A4A" d="M9,5 L10,5 L10,6 L9,6 L9,5 Z M6,5 L7,5 L7,6 L6,6 L6,5 Z M3,5 L4,5 L4,6 L3,6 L3,5 Z M0,5 L1,5 L1,6 L0,6 L0,5 Z M9,2.5 L10,2.5 L10,3.5 L9,3.5 L9,2.5 Z M6,2.5 L7,2.5 L7,3.5 L6,3.5 L6,2.5 Z M3,2.5 L4,2.5 L4,3.5 L3,3.5 L3,2.5 Z M0,2.5 L1,2.5 L1,3.5 L0,3.5 L0,2.5 Z M9,0 L10,0 L10,1 L9,1 L9,0 Z M6,0 L7,0 L7,1 L6,1 L6,0 Z M3,0 L4,0 L4,1 L3,1 L3,0 Z M0,0 L1,0 L1,1 L0,1 L0,0 Z"/>
+  <path transform="rotate(90 3 3)" fill="#4A4A4A" d="M9,5 L10,5 L10,6 L9,6 L9,5 Z M6,5 L7,5 L7,6 L6,6 L6,5 Z M3,5 L4,5 L4,6 L3,6 L3,5 Z M0,5 L1,5 L1,6 L0,6 L0,5 Z M9,2.5 L10,2.5 L10,3.5 L9,3.5 L9,2.5 Z M6,2.5 L7,2.5 L7,3.5 L6,3.5 L6,2.5 Z M3,2.5 L4,2.5 L4,3.5 L3,3.5 L3,2.5 Z M0,2.5 L1,2.5 L1,3.5 L0,3.5 L0,2.5 Z M9,0 L10,0 L10,1 L9,1 L9,0 Z M6,0 L7,0 L7,1 L6,1 L6,0 Z M3,0 L4,0 L4,1 L3,1 L3,0 Z M0,0 L1,0 L1,1 L0,1 L0,0 Z"/>
 </svg>


### PR DESCRIPTION
Some SVG files used for icons contain ID attributes. When one of those icons appears multiple times on the same page, axe warns about non-unique IDs: https://dequeuniversity.com/rules/axe/3.5/duplicate-id.

One instance of this occurs in the data table with the column grabber icon. column_grabber.svg contains two path elements that are referenced by ID by [use](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/use) elements. Since each path is referenced only once, they can be inlined instead.

This also removes an unnecessary group element and `fill-rule` attributes.

Note: the `d` attribute of the two paths is duplicated. I suspect the intention here was to have one path element that was referenced twice.