### PR TITLE
[TOAZ-146] [B2C] Use separate policy for sensitive scopes from Terra UI

### DIFF
--- a/config/alpha.json
+++ b/config/alpha.json
@@ -26,5 +26,6 @@
   "alphaSpendReportGroup": "Alpha_Spend_Report_Users",
   "alphaRegionalityGroup": "Alpha_Regionality_Users",
   "terraDockerVersionsFile": "terra-docker-versions-alpha.json",
-  "terraDockerImageBucket": "terra-docker-image-documentation-alpha"
+  "terraDockerImageBucket": "terra-docker-image-documentation-alpha",
+  "b2cBillingPolicy": "b2c_1a_signup_signin_billing_alpha"
 }

--- a/config/dev.json
+++ b/config/dev.json
@@ -26,5 +26,6 @@
   "alphaSpendReportGroup": "Alpha_Spend_Report_Users",
   "alphaRegionalityGroup": "Alpha_Regionality_Users",
   "terraDockerVersionsFile": "terra-docker-versions-dev.json",
-  "terraDockerImageBucket": "terra-docker-image-documentation-dev"
+  "terraDockerImageBucket": "terra-docker-image-documentation-dev",
+  "b2cBillingPolicy": "b2c_1a_signup_signin_billing_dev"
 }

--- a/config/fiab.json
+++ b/config/fiab.json
@@ -25,5 +25,6 @@
   "alphaSpendReportGroup": "Alpha_Spend_Report_Users",
   "alphaRegionalityGroup": "Alpha_Regionality_Users",
   "terraDockerVersionsFile": "terra-docker-versions-dev.json",
-  "terraDockerImageBucket": "terra-docker-image-documentation-dev"
+  "terraDockerImageBucket": "terra-docker-image-documentation-dev",
+  "b2cBillingPolicy": "b2c_1a_signup_signin_billing_dev"
 }

--- a/config/perf.json
+++ b/config/perf.json
@@ -26,5 +26,6 @@
   "alphaSpendReportGroup": "Alpha_Spend_Report_Users",
   "alphaRegionalityGroup": "Alpha_Regionality_Users",
   "terraDockerVersionsFile": "terra-docker-versions-perf.json",
-  "terraDockerImageBucket": "terra-docker-image-documentation-perf"
+  "terraDockerImageBucket": "terra-docker-image-documentation-perf",
+  "b2cBillingPolicy": "b2c_1a_signup_signin_billing_perf"
 }

--- a/config/staging.json
+++ b/config/staging.json
@@ -25,5 +25,6 @@
   "alphaSpendReportGroup": "Alpha_Spend_Report_Users",
   "alphaRegionalityGroup": "Alpha_Regionality_Users",
   "terraDockerVersionsFile": "terra-docker-versions-staging.json",
-  "terraDockerImageBucket": "terra-docker-image-documentation-staging"
+  "terraDockerImageBucket": "terra-docker-image-documentation-staging",
+  "b2cBillingPolicy": "b2c_1a_signup_signin_billing_staging"
 }

--- a/src/components/SignInButton.js
+++ b/src/components/SignInButton.js
@@ -13,7 +13,7 @@ const SignInButton = () => {
 
   return !isAuthInitialized ? spinner() : h(ButtonPrimary, {
     id: 'signInButton',
-    onClick: signIn,
+    onClick: () => signIn(false),
     style: { marginTop: '0.875rem', width: '9.4rem', height: '3.2rem', fontSize: '1rem' }
   }, ['log in'])
 }

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -187,7 +187,7 @@ const TopBar = ({ showMenu = true, title, href, children }) => {
               role: 'listitem'
             }, [
               h(Clickable, {
-                ...(isDatastage() || isBioDataCatalyst()) ? { href: Nav.getLink('workspaces') } : { onClick: signIn },
+                ...(isDatastage() || isBioDataCatalyst()) ? { href: Nav.getLink('workspaces') } : { onClick: () => signIn(false) },
                 style: {
                   backgroundColor: 'white', fontSize: 18, fontWeight: 500, color: colors.accent(),
                   borderRadius: 5, boxShadow: '0 2px 4px 0 rgba(0,0,0,.25)',

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -115,7 +115,9 @@ export const reloadAuthToken = (includeBillingScope = false) => {
 
 export const hasBillingScope = () => {
   return Utils.cond(
+    // For Google check the scope directly on the user object.
     [isGoogleAuthority(), () => _.includes('https://www.googleapis.com/auth/cloud-billing', getUser().scope)],
+    // For B2C check the hasGcpBillingScopeThroughB2C field in the auth store.
     () => authStore.get().hasGcpBillingScopeThroughB2C === true
   )
 }

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -84,10 +84,9 @@ const revokeTokens = async () => {
 const getSigninArgs = includeBillingScope => {
   return Utils.cond(
     [includeBillingScope === false, () => {}],
-    // If the login authority is Google, just append the scope to the signin args.
+    // For Google just append the scope to the signin args.
     [isGoogleAuthority(), () => ({ scope: 'openid email profile https://www.googleapis.com/auth/cloud-billing' })],
-    // If the login authority is B2C, switch to a dedicated policy endpoint configured
-    // for the GCP cloud-billing scope.
+    // For B2C switch to a dedicated policy endpoint configured for the GCP cloud-billing scope.
     () => ({
       extraQueryParams: { access_type: 'offline', p: getConfig().b2cBillingPolicy },
       extraTokenParams: { p: getConfig().b2cBillingPolicy }
@@ -99,8 +98,9 @@ export const signIn = async (includeBillingScope = false) => {
   const args = getSigninArgs(includeBillingScope)
   const user = await getAuthInstance().signinPopup(args)
 
-  // For B2C record whether we requested the GCP cloud-billing scope in the auth store.
-  // We don't need to do this for Google since we can inspect the scope directly in the user object.
+  // For B2C record in the auth store whether we requested the GCP cloud-billing scope since there
+  // is no way to determine it after the fact.
+  // For Google we don't need to do this since we can inspect the scope directly in the user object.
   if (!isGoogleAuthority()) {
     authStore.update(state => ({ ...state, hasGcpBillingScopeThroughB2C: includeBillingScope }))
   }

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -83,7 +83,7 @@ const revokeTokens = async () => {
 
 const getSigninArgs = includeBillingScope => {
   return Utils.cond(
-    [includeBillingScope === false, () => {}],
+    [includeBillingScope === false, () => ({})],
     // For Google just append the scope to the signin args.
     [isGoogleAuthority(), () => ({ scope: 'openid email profile https://www.googleapis.com/auth/cloud-billing' })],
     // For B2C switch to a dedicated policy endpoint configured for the GCP cloud-billing scope.

--- a/src/libs/error.js
+++ b/src/libs/error.js
@@ -4,9 +4,12 @@ import { notify, sessionTimeoutProps } from 'src/libs/notifications'
 
 
 export const reportError = async (title, obj) => {
-  if (obj instanceof Response && obj.status === 401 && !(await reloadAuthToken())) {
-    notify('info', 'Session timed out', sessionTimeoutProps)
-    signOut()
+  if (obj instanceof Response && obj.status === 401) {
+    if (!await reloadAuthToken()) {
+      notify('info', 'Session timed out', sessionTimeoutProps)
+      signOut()
+    }
+    // Don't report an error if we've successfully reloaded the auth token
   } else {
     notify('error', title, { detail: await (obj instanceof Response ? obj.text() : obj) })
   }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/TOAZ-146

Handle billing scope elevation for Google logins through B2C. Note there should be no change in behavior for direct Google logins as a result of this PR.

For B2C we have a similar flow: initially only request minimal Google scopes; if the user navigates to the billing page we request the `cloud-billing` scope via a custom policy.

I tested against a fiab with both B2C enabled and disabled, and it seems to work. For reviewers: please test signin/signout flow and the billing page works as expected.

Also attempted to fix an issue @nawatts reported where we get spurious error notifications if the token expires, even when the refresh token handshake works.