### PR TITLE
[WOR-409] Filter out Google billing accounts that Terra doesn't have access to

### DIFF
--- a/src/pages/billing/List.js
+++ b/src/pages/billing/List.js
@@ -309,6 +309,7 @@ export const BillingList = ({ queryParams: { selectedName } }) => {
   )(() => {
     if (Auth.hasBillingScope()) {
       return Ajax(signal).Billing.listAccounts()
+        .then(_.filter('firecloudHasAccess'))
         .then(_.keyBy('accountName'))
         .then(setBillingAccounts)
     }


### PR DESCRIPTION
Ticket: [WOR-409](https://broadworkbench.atlassian.net/browse/WOR-409)
* Users that have access to many Google billing accounts have a difficult time creating Terra billing projects because the drop down to select a Google billing account is clogged up with extra billing accounts that can't be used (Terra has no permission on them). This change makes it so we will only show Google billing accounts that Rawls has determined Terra has access to.
* Tested by pointing to a [locally running Rawls on a branch](https://github.com/broadinstitute/rawls/tree/mtalbott-invalid-ba) that will inject a fake billing account with `firecloudHasAccess` set to false on all `listBillingAccounts` responses. Confirmed that the dropdown works as expected and does not show billing accounts that Terra cannot access.

<!--
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Also, so if a screen recording [1] and/or screenshots would be a helpful way to communicate context, please consider including some in your PR description.
Thanks!

[1] https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac
--!>
