### PR TITLE
DC-430: Ensure that the oldest PR cannot be deleted

### DIFF
--- a/scripts/delete-old-app-engine-versions.sh
+++ b/scripts/delete-old-app-engine-versions.sh
@@ -75,8 +75,9 @@ set_dev_deletion_date() {
 
     printf "${INFO} ${GRN}%s${RST} is the oldest PR and was deployed on ${GRN}%s${RST}\n" "${OLDEST_PR_NAME}" "${OLDEST_PR_DATE}"
 
-    if [ "${DELETION_TIME}" -gt "${OLDEST_PR_TIME}" ]; then
-        DELETION_DATE=$(echo "${OLDEST_PR_TIME}" | jq -r '. - (24 * 60 * 60) | strftime("%Y-%m-%d")') # 1 day
+    OLDEST_PR_DELETION_TIME=$(echo "${OLDEST_PR_TIME}" | jq -r '. - (24 * 60 * 60)') # 1 day
+    if [ "${DELETION_TIME}" -gt "${OLDEST_PR_DELETION_TIME}" ]; then
+        DELETION_DATE=$(unix_epoch_to_date "${OLDEST_PR_DELETION_TIME}")
     fi
 }
 


### PR DESCRIPTION
Fixes a bug where if the deletion date is the same date as the oldest PR the oldest PR deployment could accidentally be deleted. Set the deletion PR time to 24h before the oldest PR and do that comparison instead.

<img width="469" alt="terminal" src="https://user-images.githubusercontent.com/16434376/177389836-12de47f7-009f-4039-82b4-948d54a3b8bf.png">