### PR TITLE
[SU-13] Change default sort order of workspaces list

### DIFF
--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -103,7 +103,7 @@ export const WorkspaceList = () => {
   const [sharingWorkspaceId, setSharingWorkspaceId] = useState()
   const [requestingAccessWorkspaceId, setRequestingAccessWorkspaceId] = useState()
 
-  const [sort, setSort] = useState({ field: 'name', direction: 'asc' })
+  const [sort, setSort] = useState({ field: 'lastModified', direction: 'desc' })
 
   useOnMount(() => {
     const loadFeatured = async () => {


### PR DESCRIPTION
Currently, the workspaces list is sorted alphabetically by name by default. This changes it to be sorted by last modified date in descending order so that the most recently modified workspaces are at the beginning of the list.