### PR TITLE
[IA-3544] Added app label back into open button.

### DIFF
--- a/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
+++ b/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
@@ -404,7 +404,8 @@ export const CloudEnvironmentModal = ({
           // Launch
           h(Clickable, { ...getToolLaunchClickableProps(toolLabel) }, [
             icon('rocket', { size: 20 }),
-            span('Open')
+            span('Open'),
+            span(toolLabel)
           ])
         ])
       ])


### PR DESCRIPTION
## Description

The app name is missing from the "Open" button.

## Solution

Add back in the tool label that was removed.


![Screen Shot 2022-07-06 at 9 34 48 AM](https://user-images.githubusercontent.com/11773357/177570477-5cc8b5ec-1d54-4dfb-bdd1-28d70081d4fe.png)