### PR TITLE
[QA-1946] Fix integration-test noSpinnerAfter function

### DIFF
--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -172,7 +172,11 @@ const noSpinnersAfter = async (page, { action, debugMessage }) => {
     console.log(`About to perform an action and wait for spinners. \n\tDebug message: ${debugMessage}`)
   }
   const foundSpinner = page.waitForXPath('//*[@data-icon="loadingSpinner"]')
-  await Promise.all([foundSpinner, action()])
+  await Promise.all([
+    // loadingSpinner is not always visible. Ignore but log error if loadingSpinner is not found
+    foundSpinner.catch(e => { console.error(e) }),
+    action()
+  ])
   return waitForNoSpinners(page)
 }
 


### PR DESCRIPTION
[QA-1946](https://broadworkbench.atlassian.net/browse/QA-1946)

`noSpinnerAfter` function assumes that a spinner will always be shown. A test can fail if network requests triggered by a click event doesn’t take long time for UI to show a spinner.