### PR TITLE
[WOR-377] Add clipboard copy link for Azure container SAS URL

### DIFF
--- a/config/dev.json
+++ b/config/dev.json
@@ -27,5 +27,6 @@
   "alphaRegionalityGroup": "Alpha_Regionality_Users",
   "terraDockerVersionsFile": "terra-docker-versions-dev.json",
   "terraDockerImageBucket": "terra-docker-image-documentation-dev",
-  "b2cBillingPolicy": "b2c_1a_signup_signin_billing_dev"
+  "b2cBillingPolicy": "b2c_1a_signup_signin_billing_dev",
+  "workspaceManagerUrlRoot": "https://workspace.dsde-dev.broadinstitute.org"
 }

--- a/integration-tests/tests/workspace-dashboard.js
+++ b/integration-tests/tests/workspace-dashboard.js
@@ -174,6 +174,7 @@ const setAzureAjaxMockValues = async (testPage, namespace, name, workspaceDescri
     const submissionsUrl = new RegExp(`api/workspaces/${namespace}/${name}/submissions(.*)`, 'g')
     const tagsUrl = new RegExp(`api/workspaces/${namespace}/${name}/tags(.*)`, 'g')
     const workspaceResourcesUrl = new RegExp(`api/workspaces/v1/${workspaceId}/resources(.*)`, 'g')
+    const workspaceSasTokenUrl = new RegExp(`api/workspaces/v1/${workspaceId}/resources/controlled/azure/storageContainer/(.*)/getSasToken`)
 
     window.ajaxOverridesStore.set([
       {
@@ -195,6 +196,10 @@ const setAzureAjaxMockValues = async (testPage, namespace, name, workspaceDescri
       {
         filter: { url: workspaceResourcesUrl },
         fn: () => () => Promise.resolve(new Response(JSON.stringify(azureWorkspaceResourcesResult), { status: 200 }))
+      },
+      {
+        filter: { url: workspaceSasTokenUrl },
+        fn: () => () => Promise.resolve(new Response(JSON.stringify({ sasToken: 'fake_token', url: 'http://example.com' }), { status: 200 }))
       },
       {
         filter: { url: /api\/workspaces[^/](.*)/ },
@@ -227,7 +232,8 @@ const testAzureWorkspace = withUserToken(async ({ page, token, testUrl }) => {
     'Cloud NameMicrosoft Azure',
     'Resource Group IDdummy-mrg-id',
     'Storage Container Namesc-name',
-    'Location🇺🇸 East US'
+    'Location🇺🇸 East US',
+    'SAS URLhttp://example.com'
   ])
 
   // READER permissions only

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1122,7 +1122,8 @@ const AzureStorage = signal => ({
     if (storageAccount === undefined) { // Internal users may have early workspaces with no storage account.
       return {
         location: 'Unknown',
-        storageContainerName: 'None'
+        storageContainerName: 'None',
+        sasUrl: 'None'
       }
     } else {
       const container = _.find(

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -228,6 +228,9 @@ const WorkspaceDashboard = _.flow(
     } else {
       loadAzureStorage()
       loadSasToken(workspace.workspace.workspaceId)
+
+      // sas tokens expire after 1 hour
+      setInterval(loadSasToken, Utils.durationToMillis({ minutes: 59 }), workspace.workspace.workspaceId)
     }
   }
 

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -244,12 +244,14 @@ const WorkspaceDashboard = _.flow(
 
   useEffect(() => {
     setLocalPref(persistenceId, { workspaceInfoPanelOpen, cloudInfoPanelOpen, ownersPanelOpen, authDomainPanelOpen, tagsPanelOpen })
+  }, [workspaceInfoPanelOpen, cloudInfoPanelOpen, ownersPanelOpen, authDomainPanelOpen, tagsPanelOpen]) // eslint-disable-line react-hooks/exhaustive-deps
 
+  useEffect(() => {
     return () => {
       clearInterval(sasTokenRefreshInterval.current)
       sasTokenRefreshInterval.current = undefined
     }
-  }, [workspaceInfoPanelOpen, cloudInfoPanelOpen, ownersPanelOpen, authDomainPanelOpen, tagsPanelOpen]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [sasTokenRefreshInterval])
 
   // Helpers
   const loadSubmissionCount = withErrorReporting('Error loading submission count data', async () => {

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -308,8 +308,8 @@ const WorkspaceDashboard = _.flow(
   })
 
   const loadSasToken = withErrorReporting('Error loading SAS token', async workspaceId => {
-    await Ajax().AzureStorage.sasToken(workspaceId)
-    setSasToken('FAKE TBD')
+    const sas = await Ajax().AzureStorage.sasToken(workspaceId)
+    setSasToken(sas.url)
   })
 
   const save = Utils.withBusyState(setSaving, async () => {


### PR DESCRIPTION
## Context
[Relevant ticket](https://broadworkbench.atlassian.net/browse/WOR-377)
We want to surface Azure container SAS URls for usage in other tooling like Azure storage explorer.

## This PR
* Threads in the SAS URL from the WSM `getSasToken` response ([related PR](https://github.com/DataBiosphere/terra-workspace-manager/pull/711)) and places it in the Azure storage info box, as a clipboard copyable item.
   * I've added a `setInterval` call that will refresh the token every 59 minutes to help guard against stale tokens
* Updates the workspace dashboard integration test

![Screen Shot 2022-07-07 at 2 54 22 PM](https://user-images.githubusercontent.com/74209955/177850646-77306d3e-3e90-4642-98a6-205923327284.png)


<!--

Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Also, so if a screen recording [1] and/or screenshots would be a helpful way to communicate context, please consider including some in your PR description.
Thanks!

[1] https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac
--!>
