### PR TITLE
[SU-93] Resolve axe warnings about select components

### DIFF
--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -157,7 +157,7 @@ const fillInReplace = async (page, xpath, text) => {
 
 const select = async (page, labelContains, text) => {
   await click(page, input({ labelContains }))
-  return click(page, `//div[starts-with(@id, "react-select-") and contains(normalize-space(.),"${text}")]`)
+  return click(page, `//div[starts-with(@id, "react-select-") and @role="option" and contains(normalize-space(.),"${text}")]`)
 }
 
 const waitForNoSpinners = page => {

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -253,25 +253,11 @@ const commonSelectProps = {
         props.isSelected && icon('check', { size: 14, style: { flex: 'none', marginLeft: '0.5rem', color: colors.dark(0.5) } })
       ])
     ]),
-    SelectContainer: ({ children, selectProps, ...props }) => h(RSelectComponents.SelectContainer, _.merge(props, {
-      selectProps,
-      innerProps: {
-        role: 'combobox',
-        'aria-haspopup': 'listbox',
-        'aria-expanded': selectProps.menuIsOpen
-      }
-    }), [children]),
-    Input: ({ children, selectProps, ...props }) => h(RSelectComponents.Input, _.merge(props, {
-      selectProps,
-      role: 'textbox',
-      'aria-multiline': false,
-      'aria-controls': selectProps.menuIsOpen ? selectProps.menuId : undefined
-    }), [children]),
     Menu: ({ children, selectProps, ...props }) => h(RSelectComponents.Menu, _.merge(props, {
       selectProps,
       innerProps: {
-        id: selectProps.menuId,
         role: 'listbox',
+        'aria-label': 'Options',
         'aria-multiselectable': selectProps.isMulti
       }
     }), [children])
@@ -291,13 +277,11 @@ const formatGroupLabel = group => (
 
 const BaseSelect = ({ value, newOptions, id, findValue, ...props }) => {
   const newValue = props.isMulti ? _.map(findValue, value) : findValue(value)
-  const menuId = useUniqueId()
   const myId = useUniqueId()
   const inputId = id || myId
 
   return h(RSelect, _.merge({
     inputId,
-    menuId,
     ...commonSelectProps,
     getOptionLabel: ({ value, label }) => label || value.toString(),
     value: newValue || null, // need null instead of undefined to clear the select
@@ -337,9 +321,7 @@ export const GroupedSelect = ({ value, options, ...props }) => {
 }
 
 export const AsyncCreatableSelect = props => {
-  const menuId = useUniqueId()
   return h(RAsyncCreatableSelect, {
-    menuId,
     ...commonSelectProps,
     ...props
   })


### PR DESCRIPTION
axe devtools shows this warning about the tag menu on the workspace dashboard.

```
Elements must only use allowed ARIA attributes
1 of 1
[more info](https://dequeuniversity.com/rules/axe/4.4/aria-allowed-attr?application=AxeChrome)
Impact:
critical
Found on:
4/20/2022 at 9:35 AM
Found:
Automatically
Issue Tags:
cat.aria
wcag2a
wcag412
Issue Description
Ensures ARIA attributes are allowed for an element's role

Element location
#react-select-2-input
Element source
<input class="" autocapitalize="none" autocomplete="off" autocorrect="off" id="react-select-2-input" spellcheck="false" tabindex="0" type="text" aria-autocomplete="list" aria-expanded="false" aria-haspopup="true" aria-controls="react-select-2-listbox" aria-owns="react-select-2-listbox" aria-label="Add a tag" role="textbox" aria-describedby="react-select-2-placeholder" aria-multiline="false" value="" style="color: inherit; background: 0px center; opacity: 1; width: 100%; grid-area: 1 / 2 / auto / auto; font: inherit; min-width: 2px; border: 0px; margin: 0px; outline: 0px; padding: 0px;">
To solve this issue, you need to...
Fix the following:
ARIA attribute is not allowed: aria-expanded="false"
```


`aria-expanded` is not a valid attribute for elements with the `textbox` role.
https://www.w3.org/TR/wai-aria-1.2/#textbox

However, the input element only has the `textbox` role because we override the role and some ARIA attributes that react-select applies to it. Removing those overrides results in the input element having the `combobox` role, for which `aria-expanded` is valid. The role and attributes applied by react-select match those in the ARIA authoring practices for an "Editable Combobox With List Autocomplete" (https://w3c.github.io/aria-practices/examples/combobox/combobox-autocomplete-list.html).

The custom roles and ARIA attributes were added in #2513. I'm assuming they later became an issue when we upgraded react-select in #2882. The v4 to v5 notes in react-select's upgrade guide mention "Improve screen reader experience".

## Before
![Screen Shot 2022-07-07 at 9 48 08 AM](https://user-images.githubusercontent.com/1156625/177791458-c5bf85e2-464d-4666-8ec7-11c60b01873a.png)

## After
![Screen Shot 2022-07-07 at 9 47 27 AM](https://user-images.githubusercontent.com/1156625/177791488-2705ed84-ee0c-4764-86a8-737b8383afc5.png)

