### PR TITLE
[SU-155] Preserve column settings when renaming a table

### DIFF
--- a/src/components/data/RenameTableModal.js
+++ b/src/components/data/RenameTableModal.js
@@ -2,6 +2,7 @@ import _ from 'lodash/fp'
 import { Fragment, useState } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
 import { ButtonPrimary, IdContainer, spinnerOverlay } from 'src/components/common'
+import { allSavedColumnSettingsEntityTypeKey, useSavedColumnSettings } from 'src/components/data/SavedColumnSettings'
 import { ValidatedInput } from 'src/components/input'
 import Modal from 'src/components/Modal'
 import { Ajax } from 'src/libs/ajax'
@@ -11,10 +12,15 @@ import { FormLabel } from 'src/libs/forms'
 import * as Utils from 'src/libs/utils'
 
 
-const RenameTableModal = ({ onDismiss, onUpdateSuccess, namespace, name, selectedDataType }) => {
+const RenameTableModal = ({ onDismiss, onUpdateSuccess, namespace, name, selectedDataType, entityMetadata }) => {
   // State
   const [newName, setNewName] = useState('')
   const [renaming, setRenaming] = useState(false)
+
+  const {
+    getAllSavedColumnSettings,
+    updateAllSavedColumnSettings
+  } = useSavedColumnSettings({ workspaceId: { namespace, name }, entityType: selectedDataType, entityMetadata })
 
   return h(Modal, {
     onDismiss,
@@ -27,6 +33,19 @@ const RenameTableModal = ({ onDismiss, onUpdateSuccess, namespace, name, selecte
       )(async () => {
         await Ajax().Metrics.captureEvent(Events.workspaceDataRenameTable, { oldName: selectedDataType, newName })
         await Ajax().Workspaces.workspace(namespace, name).renameEntityType(selectedDataType, newName)
+
+        // Move column settings to new table
+        const oldTableColumnSettingsKey = allSavedColumnSettingsEntityTypeKey({ entityType: selectedDataType })
+        const newTableColumnSettingsKey = allSavedColumnSettingsEntityTypeKey({ entityType: newName })
+        const allColumnSettings = await getAllSavedColumnSettings()
+        const tableColumnSettings = _.get(oldTableColumnSettingsKey, allColumnSettings)
+        if (tableColumnSettings) {
+          await updateAllSavedColumnSettings(_.flow(
+            _.set(newTableColumnSettingsKey, tableColumnSettings),
+            _.unset(oldTableColumnSettingsKey)
+          )(allColumnSettings))
+        }
+
         onUpdateSuccess()
       })
     }, ['Rename'])

--- a/src/components/data/SavedColumnSettings.js
+++ b/src/components/data/SavedColumnSettings.js
@@ -52,7 +52,7 @@ export const allSavedColumnSettingsEntityTypeKey = ({ snapshotName, entityType }
   return entityTypeKey
 }
 
-const useSavedColumnSettings = ({ workspaceId, snapshotName, entityMetadata, entityType }) => {
+export const useSavedColumnSettings = ({ workspaceId, snapshotName, entityMetadata, entityType }) => {
   // Saved column settings for all tables are stored in the same attribute in the format:
   // {
   //   snapshots: {
@@ -88,9 +88,9 @@ const useSavedColumnSettings = ({ workspaceId, snapshotName, entityMetadata, ent
     )(workspace)
   }
 
-  const updateSavedColumnSettings = async allColumnSettings => {
+  const updateAllSavedColumnSettings = async allColumnSettings => {
     const { namespace, name } = workspaceId
-    await Ajax(signal).Workspaces.workspace(namespace, name).shallowMergeNewAttributes({
+    await Ajax().Workspaces.workspace(namespace, name).shallowMergeNewAttributes({
       [savedColumnSettingsWorkspaceAttributeName]: allColumnSettings
     })
   }
@@ -127,17 +127,19 @@ const useSavedColumnSettings = ({ workspaceId, snapshotName, entityMetadata, ent
       encodeColumnSettings(columnSettings),
       allColumnSettings
     )
-    await updateSavedColumnSettings(newColumnSettings)
+    await updateAllSavedColumnSettings(newColumnSettings)
   }
 
   const deleteSavedColumnSettings = async columnSettingsName => {
     // Re-fetch column settings to reduce the chances of overwriting changes made by other users since we first loaded settings.
     const allColumnSettings = await getAllSavedColumnSettings()
     const newColumnSettings = _.omit(`${entityTypeKey}.${columnSettingsName}`, allColumnSettings)
-    await updateSavedColumnSettings(newColumnSettings)
+    await updateAllSavedColumnSettings(newColumnSettings)
   }
 
   return {
+    getAllSavedColumnSettings,
+    updateAllSavedColumnSettings,
     getSavedColumnSettings,
     saveColumnSettings,
     deleteSavedColumnSettings

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -280,7 +280,7 @@ const SidebarSeparator = ({ sidebarWidth, setSidebarWidth }) => {
   ])
 }
 
-const DataTableActions = ({ workspace, tableName, rowCount, onRenameTable, onDeleteTable }) => {
+const DataTableActions = ({ workspace, tableName, rowCount, entityMetadata, onRenameTable, onDeleteTable }) => {
   const { workspace: { namespace, name }, workspaceSubmissionStats: { runningSubmissionsCount } } = workspace
   const isSetOfSets = tableName.endsWith('_set_set')
 
@@ -366,7 +366,8 @@ const DataTableActions = ({ workspace, tableName, rowCount, onRenameTable, onDel
       onDismiss: () => setRenaming(false),
       onUpdateSuccess: onRenameTable,
       namespace, name,
-      selectedDataType: tableName
+      selectedDataType: tableName,
+      entityMetadata
     }),
     deleting && h(DeleteConfirmationModal, {
       objectType: 'table',
@@ -627,6 +628,7 @@ const WorkspaceData = _.flow(
                   after: h(DataTableActions, {
                     tableName: type,
                     rowCount: typeDetails.count,
+                    entityMetadata,
                     workspace,
                     onRenameTable: () => loadMetadata(),
                     onDeleteTable: tableName => {


### PR DESCRIPTION
Currently, when a table is renamed, any saved column settings for that table are lost. This changes adds a step to the rename process to update the workspace attribute containing saved column settings.

## Before
https://user-images.githubusercontent.com/1156625/177814289-e1fe32b0-dc7a-422b-9c73-0093e1f2f539.mov

## After
https://user-images.githubusercontent.com/1156625/177814244-f94bafcb-63b3-4425-bd4d-41b16fc71b4a.mov


