### PR TITLE
[QA-1948] Integration test SignIn failure

### DIFF
--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -220,7 +220,7 @@ const signIntoTerra = async (page, { token, testUrl }) => {
     minTimeout: 1000, // This is min wait time between retries
     onFailedAttempt: error => {
       console.error(
-        `Sign in to Terra attempt ${error.attemptNumber} failed. There are ${error.retriesLeft} retries left.`
+        `Sign in to Terra attempt ${error.attemptNumber} failed. ${error.retriesLeft} retries left.`
       )
     },
     retries: 2
@@ -238,6 +238,8 @@ const signIntoTerra = async (page, { token, testUrl }) => {
       await page.waitForXPath('//*[contains(normalize-space(.),"Loading Terra")]', { hidden: true, timeout: 60 * 1000 })
     } catch (e) {
       console.error(e)
+      // Stop page loading, as if you hit "X" in the browser. ignore exception.
+      await page._client.send('Page.stopLoading').catch(err => void err)
       throw new Error(e)
     }
   }

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -212,7 +212,7 @@ const dismissNPSSurvey = async page => {
   }
 }
 
-// Test workaround with one retry: Loading of Terra UI does not work sometimes after new deploy to Staging/Alpha.
+// Test workaround: Retry loading of Terra UI if fails first time. This issue often happens after new deploy to Staging/Alpha.
 const signIntoTerra = async (page, { token, testUrl }) => {
   console.log('signIntoTerra ...')
 

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -230,7 +230,7 @@ const signIntoTerra = async (page, { token, testUrl }) => {
   const timeout = 60 * 1000
   const run = async url => {
     try {
-      const httpResponse = await page.goto(url, { waitUntil: ['networkidle0', 'domcontentloaded'], timeout })
+      const httpResponse = await gotoPage(page, url)
       if (!(httpResponse.ok() || httpResponse.status() === 304)) {
         throw new Error(`Error loading URL: ${url}. Http response status: ${httpResponse.statusText()}`)
       }

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -212,6 +212,7 @@ const dismissNPSSurvey = async page => {
   }
 }
 
+// Test workaround with one retry: Loading of Terra UI does not work sometimes after new deploy to Staging/Alpha.
 const signIntoTerra = async (page, { token, testUrl }) => {
   console.log('signIntoTerra ...')
 

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -220,22 +220,23 @@ const signIntoTerra = async (page, { token, testUrl }) => {
     minTimeout: 1000, // This is min wait time between retries
     onFailedAttempt: error => {
       console.error(
-        `Sign in to Terra attempt ${error.attemptNumber} failed. ${error.retriesLeft} retries left.`
+        `Sign in to Terra attempt ${error.attemptNumber} failed. There are ${error.retriesLeft} retries left.`
       )
     },
     retries: 2
   }
 
+  const timeout = 60 * 1000
   const run = async url => {
     try {
-      const httpResponse = await page.goto(url, { waitUntil: ['networkidle0', 'domcontentloaded'], timeout: 60 * 1000 })
+      const httpResponse = await page.goto(url, { waitUntil: ['networkidle0', 'domcontentloaded'], timeout })
       if (httpResponse.status() >= 400) {
         throw new Error(`Error loading URL: ${url}. Http response status: ${httpResponse.statusText()}`)
       }
       await page.waitForFunction(url => {
         return window.location.href.includes(url)
       }, {}, url)
-      await page.waitForXPath('//*[contains(normalize-space(.),"Loading Terra")]', { hidden: true, timeout: 60 * 1000 })
+      await page.waitForXPath('//*[contains(normalize-space(.),"Loading Terra")]', { hidden: true, timeout })
     } catch (e) {
       console.error(e)
       // Stop page loading, as if you hit "X" in the browser. ignore exception.
@@ -248,7 +249,7 @@ const signIntoTerra = async (page, { token, testUrl }) => {
     console.log(`Loading URL: ${testUrl}`)
     await pRetry(() => run(testUrl), retryOptions)
   }
-  await page.waitForXPath('//*[contains(normalize-space(.),"Loading Terra")]', { hidden: true, timeout: 60 * 1000 })
+  await page.waitForXPath('//*[contains(normalize-space(.),"Loading Terra")]', { hidden: true, timeout })
   await waitForNoSpinners(page)
 
   await page.waitForFunction('!!window["forceSignIn"]')


### PR DESCRIPTION
**Sign In** still fails after new deploy. I want to add a retry if fails to see it helps. I'll make a PR to revert in future if this workaround does not help to resolve the issue.

A number of PRs have been merged to address the issue with Sign In after new gcloud deploy (e.g. to Staging env), but nothing seems to make any difference.

For example, failed CircleCI `integration-tests-staging` [job](https://app.circleci.com/pipelines/github/DataBiosphere/terra-ui/10488/workflows/a35846e2-dd85-4743-a3e7-2598d7af93a1).

`billing-projects` test is one of two started first. Test failed with following stacktrace.

```
Error reading historical timing data: file does not exist
Requested weighting by historical based timing, but they are not present. Falling back to weighting by name.
**  Running billing-projects at 7/5/2022, 11:18:41
**  Running workspace-dashboard at 7/5/2022, 11:18:41
Captured screenshot: /tmp/staging/test-results/failure-screenshots/failure-1657034388288-billing-projects.png
Saved screenshot page content: /tmp/staging/test-results/failure-screenshots/failure-1657034391417-billing-projects.html
```

```
page.http GET 200 https://bvdp-saturn-staging.appspot.com/
page.http GET 200 https://bvdp-saturn-staging.appspot.com/logo-grey.svg
page.http GET 200 https://bvdp-saturn-staging.appspot.com/static/css/main.34135f2a.css
page.http GET 200 https://bvdp-saturn-staging.appspot.com/static/js/main.ae1969ee.js
page.http GET 200 https://bvdp-saturn-staging.appspot.com/loading-spinner.svg
page.http GET 200 https://bvdp-saturn-staging.appspot.com/config.json
page.http GET 404 https://bvdp-saturn-staging.appspot.com/static/js/688.97cab371.chunk.js
page.console Failed to load resource: the server responded with a status of 404 ()
page.pageerror [Error: ChunkLoadError: Loading chunk 688 failed.
(error: https://bvdp-saturn-staging.appspot.com/static/js/688.97cab371.chunk.js)
    at Object.r.f.j (https://bvdp-saturn-staging.appspot.com/static/js/main.ae1969ee.js:1:42175)
    at https://bvdp-saturn-staging.appspot.com/static/js/main.ae1969ee.js:1:39349
    at Array.reduce (<anonymous>)
    at Function.r.e (https://bvdp-saturn-staging.appspot.com/static/js/main.ae1969ee.js:1:39314)
    at https://bvdp-saturn-staging.appspot.com/static/js/main.ae1969ee.js:1:43692
    at c (https://bvdp-saturn-staging.appspot.com/static/js/main.ae1969ee.js:1:4985)
    at Generator._invoke (https://bvdp-saturn-staging.appspot.com/static/js/main.ae1969ee.js:1:4773)
    at Generator.next (https://bvdp-saturn-staging.appspot.com/static/js/main.ae1969ee.js:1:5414)
    at o (https://bvdp-saturn-staging.appspot.com/static/js/main.ae1969ee.js:1:25838)
    at s (https://bvdp-saturn-staging.appspot.com/static/js/main.ae1969ee.js:1:26041)]
```

Another example,

```
withWorkspace ...
page.http GET 200 https://bvdp-saturn-staging.appspot.com/
page.http GET 200 https://bvdp-saturn-staging.appspot.com/loading-spinner.svg
page.http GET 200 https://bvdp-saturn-staging.appspot.com/logo-grey.svg
page.http GET 404 https://bvdp-saturn-staging.appspot.com/static/js/main.09c38c86.js
page.console Failed to load resource: the server responded with a status of 404 ()
page.http GET 200 https://bvdp-saturn-staging.appspot.com/static/css/main.34135f2a.css
Captured screenshot: /tmp/staging/test-results/failure-screenshots/failure-1657547372003-google-workspace.png
```

[QA-1948](https://broadworkbench.atlassian.net/browse/QA-1948)