### PR TITLE
[QA-1946] integration-test: Update noSpinnerAfter function

### DIFF
--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -171,9 +171,9 @@ const noSpinnersAfter = async (page, { action, debugMessage }) => {
   if (debugMessage) {
     console.log(`About to perform an action and wait for spinners. \n\tDebug message: ${debugMessage}`)
   }
-  const foundSpinner = page.waitForXPath('//*[@data-icon="loadingSpinner"]')
+  const foundSpinner = page.waitForXPath('//*[@data-icon="loadingSpinner"]', { timeout: 5000 })
   await Promise.all([
-    // loadingSpinner is not always visible. Ignore but log error if loadingSpinner is not found
+    // loadingSpinner is not always visible. Log but ignore error if loadingSpinner is not found
     foundSpinner.catch(e => { console.error(e) }),
     action()
   ])

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -172,7 +172,11 @@ const noSpinnersAfter = async (page, { action, debugMessage }) => {
     console.log(`About to perform an action and wait for spinners. \n\tDebug message: ${debugMessage}`)
   }
   const foundSpinner = page.waitForXPath('//*[@data-icon="loadingSpinner"]')
-  await Promise.all([foundSpinner, action()])
+  await Promise.all([
+    // loadingSpinner is not always visible. Ignore but log error if loadingSpinner is not found
+    foundSpinner.catch(e => { console.error(e) }),
+    action()
+  ])
   return waitForNoSpinners(page)
 }
 

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -174,7 +174,7 @@ const noSpinnersAfter = async (page, { action, debugMessage }) => {
   const foundSpinner = page.waitForXPath('//*[@data-icon="loadingSpinner"]', { timeout: 5000 })
   await Promise.all([
     // loadingSpinner is not always visible. Log but ignore error if loadingSpinner is not found
-    foundSpinner.catch(e => { console.error(e) }),
+    foundSpinner.catch(e => console.error(e)),
     action()
   ])
   return waitForNoSpinners(page)


### PR DESCRIPTION
[QA-1946](https://broadworkbench.atlassian.net/browse/QA-1946)

noSpinnerAfter function assumes that a spinner will always be shown. But if UI does not show a spinner, the test function fails.

I had a meeting with Pete S. this afternoon to talk in details about `noSpinnerAfter` function. This PR summaries changes we agreed to.