### PR TITLE
[SU-162] Fix TSV download for JSON attributes

### DIFF
--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -7,7 +7,7 @@ import { Fragment, useState } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
 import { requesterPaysWrapper, withRequesterPaysHandler } from 'src/components/bucket-utils'
 import { ButtonSecondary } from 'src/components/common'
-import { AddColumnModal, AddEntityModal, CreateEntitySetModal, EntityDeleter, ModalToolButton, MultipleEntityEditor, saveScroll } from 'src/components/data/data-utils'
+import { AddColumnModal, AddEntityModal, CreateEntitySetModal, entityAttributeText, EntityDeleter, ModalToolButton, MultipleEntityEditor, saveScroll } from 'src/components/data/data-utils'
 import DataTable from 'src/components/data/DataTable'
 import ExportDataModal from 'src/components/data/ExportDataModal'
 import { icon } from 'src/components/icons'
@@ -238,7 +238,7 @@ const EntitiesContent = ({
     const entityTsv = Utils.makeTSV([
       [`entity:${entityKey}_id`, ...attributeNames],
       ..._.map(({ name, attributes }) => {
-        return [name, ..._.map(attribute => Utils.entityAttributeText(attributes[attribute], true), attributeNames)]
+        return [name, ..._.map(attribute => entityAttributeText(attributes[attribute], true), attributeNames)]
       }, sortedEntities)
     ])
 

--- a/src/components/data/_tests/data-utils.test.js
+++ b/src/components/data/_tests/data-utils.test.js
@@ -107,13 +107,13 @@ describe('entityAttributeText', () => {
     })
 
     it('returns stringified value for numbers', () => {
-      expect(entityAttributeText(42)).toEqual(42)
+      expect(entityAttributeText(42)).toEqual('42')
       expect(entityAttributeText({ items: [1, 2, 3], itemsType: 'AttributeValue' })).toEqual('1, 2, 3')
     })
 
     it('returns stringified value for booleans', () => {
-      expect(entityAttributeText(true)).toEqual(true)
-      expect(entityAttributeText(false)).toEqual(false)
+      expect(entityAttributeText(true)).toEqual('true')
+      expect(entityAttributeText(false)).toEqual('false')
       expect(entityAttributeText({ items: [true, false], itemsType: 'AttributeValue' })).toEqual('true, false')
     })
 
@@ -127,6 +127,10 @@ describe('entityAttributeText', () => {
         itemsType: 'EntityReference'
       })).toEqual('thing_one, thing_two')
     })
+  })
+
+  it('formats missing values', () => {
+    expect(entityAttributeText(undefined)).toEqual('')
   })
 
   it('formats empty lists', () => {
@@ -146,12 +150,24 @@ describe('entityAttributeText', () => {
   })
 
   describe('JSON values', () => {
+    it('formats arrays containing basic data types', () => {
+      expect(entityAttributeText(['one', 'two', 'three'])).toEqual('one, two, three')
+    })
+
+    it('formats empty arrays', () => {
+      expect(entityAttributeText([])).toEqual('')
+    })
+
     it('stringifies arrays of objects', () => {
       expect(entityAttributeText([
         { key1: 'value1' },
         { key2: 'value2' },
         { key3: 'value3' }
       ])).toEqual('[{"key1":"value1"},{"key2":"value2"},{"key3":"value3"}]')
+    })
+
+    it('stringifies objects', () => {
+      expect(entityAttributeText({ key: 'value' })).toEqual('{"key":"value"}')
     })
   })
 })

--- a/src/components/data/_tests/data-utils.test.js
+++ b/src/components/data/_tests/data-utils.test.js
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom'
 
 import { render } from '@testing-library/react'
 import _ from 'lodash/fp'
-import { concatenateAttributeNames, convertAttributeValue, getAttributeType, prepareAttributeForUpload, renderDataCell } from 'src/components/data/data-utils.js'
+import { concatenateAttributeNames, convertAttributeValue, entityAttributeText, getAttributeType, prepareAttributeForUpload, renderDataCell } from 'src/components/data/data-utils'
 
 
 describe('concatenateAttributeNames', () => {
@@ -96,6 +96,63 @@ describe('getAttributeType', () => {
     expect(getAttributeType(null)).toEqual({ type: 'string', isList: false })
     expect(getAttributeType({ items: [], itemsType: 'AttributeValue' })).toEqual({ type: 'string', isList: true })
     expect(getAttributeType({ items: [null], itemsType: 'AttributeValue' })).toEqual({ type: 'string', isList: true })
+  })
+})
+
+describe('entityAttributeText', () => {
+  describe('basic data types', () => {
+    it('returns value for strings', () => {
+      expect(entityAttributeText('abc')).toEqual('abc')
+      expect(entityAttributeText({ items: ['a', 'b', 'c'], itemsType: 'AttributeValue' })).toEqual('a, b, c')
+    })
+
+    it('returns stringified value for numbers', () => {
+      expect(entityAttributeText(42)).toEqual(42)
+      expect(entityAttributeText({ items: [1, 2, 3], itemsType: 'AttributeValue' })).toEqual('1, 2, 3')
+    })
+
+    it('returns stringified value for booleans', () => {
+      expect(entityAttributeText(true)).toEqual(true)
+      expect(entityAttributeText(false)).toEqual(false)
+      expect(entityAttributeText({ items: [true, false], itemsType: 'AttributeValue' })).toEqual('true, false')
+    })
+
+    it('returns entity name for references', () => {
+      expect(entityAttributeText({ entityType: 'thing', entityName: 'thing_one' })).toEqual('thing_one')
+      expect(entityAttributeText({
+        items: [
+          { entityType: 'thing', entityName: 'thing_one' },
+          { entityType: 'thing', entityName: 'thing_two' }
+        ],
+        itemsType: 'EntityReference'
+      })).toEqual('thing_one, thing_two')
+    })
+  })
+
+  it('formats empty lists', () => {
+    expect(entityAttributeText({ items: [], itemsType: 'AttributeValue' })).toEqual('')
+  })
+
+  it('can return JSON encoded list items', () => {
+    expect(entityAttributeText({ items: ['a', 'b', 'c'], itemsType: 'AttributeValue' }, true)).toEqual('["a","b","c"]')
+    expect(entityAttributeText({ items: [1, 2, 3], itemsType: 'AttributeValue' }, true)).toEqual('[1,2,3]')
+    expect(entityAttributeText({
+      items: [
+        { entityType: 'thing', entityName: 'thing_one' },
+        { entityType: 'thing', entityName: 'thing_two' }
+      ],
+      itemsType: 'EntityReference'
+    }, true)).toEqual('[{"entityType":"thing","entityName":"thing_one"},{"entityType":"thing","entityName":"thing_two"}]')
+  })
+
+  describe('JSON values', () => {
+    it('stringifies arrays of objects', () => {
+      expect(entityAttributeText([
+        { key1: 'value1' },
+        { key2: 'value2' },
+        { key3: 'value3' }
+      ])).toEqual('[{"key1":"value1"},{"key2":"value2"},{"key3":"value3"}]')
+    })
   })
 })
 

--- a/src/components/data/_tests/data-utils.test.js
+++ b/src/components/data/_tests/data-utils.test.js
@@ -150,12 +150,12 @@ describe('entityAttributeText', () => {
   })
 
   describe('JSON values', () => {
-    it('formats arrays containing basic data types', () => {
-      expect(entityAttributeText(['one', 'two', 'three'])).toEqual('one, two, three')
+    it('stringifies arrays containing basic data types', () => {
+      expect(entityAttributeText(['one', 'two', 'three'])).toEqual('["one","two","three"]')
     })
 
-    it('formats empty arrays', () => {
-      expect(entityAttributeText([])).toEqual('')
+    it('stringifies empty arrays', () => {
+      expect(entityAttributeText([])).toEqual('[]')
     })
 
     it('stringifies arrays of objects', () => {

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -64,6 +64,19 @@ export const getUserProjectForWorkspace = async workspace => (workspace && await
 
 const isUri = datum => _.startsWith('gs://', datum) || _.startsWith('dos://', datum) || _.startsWith('drs://', datum)
 
+export const entityAttributeText = (value, machineReadable) => {
+  return Utils.cond(
+    [_.has('entityName', value), () => value.entityName],
+    [_.has('items', value), () => {
+      return machineReadable ?
+        JSON.stringify(value.items) :
+        _.map(entityAttributeText, value.items).join(', ')
+    }],
+    [_.isArray(value) && _.some(_.isObject, value), () => JSON.stringify(value)], // arrays of objects need to be stringified
+    () => value
+  )
+}
+
 export const renderDataCell = (attributeValue, googleProject) => {
   const renderCell = datum => {
     const stringDatum = Utils.convertValue('string', datum)
@@ -1272,7 +1285,7 @@ export const AddEntityModal = ({ workspaceId: { namespace, name }, entityType, a
       }, [
         h(Collapse, {
           title: span({ style: { ...Style.noWrapEllipsis } }, [
-            `${attributeName}: ${Utils.entityAttributeText(attributeValues[attributeName], false)}`
+            `${attributeName}: ${entityAttributeText(attributeValues[attributeName], false)}`
           ]),
           buttonStyle: {
             maxWidth: '100%',

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -69,7 +69,6 @@ export const entityAttributeText = (attributeValue, machineReadable) => {
 
   return Utils.cond(
     [_.isNil(attributeValue), () => ''],
-    [type === 'json' && _.isArray(attributeValue) && !_.some(_.isObject, attributeValue), () => _.join(', ', attributeValue)],
     [type === 'json', () => JSON.stringify(attributeValue)],
     [isList && machineReadable, () => JSON.stringify(attributeValue.items)],
     [type === 'reference' && isList, () => _.join(', ', _.map('entityName', attributeValue.items))],

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -180,19 +180,6 @@ export const generatePersistentDiskName = () => `saturn-pd-${uuid()}`
 
 export const waitOneTick = () => new Promise(setImmediate)
 
-export const entityAttributeText = (value, machineReadable) => {
-  return cond(
-    [_.has('entityName', value), () => value.entityName],
-    [_.has('items', value), () => {
-      return machineReadable ?
-        JSON.stringify(value.items) :
-        _.map(entityAttributeText, value.items).join(', ')
-    }],
-    [_.isArray(value) && _.some(_.isObject, value), () => JSON.stringify(value)], // arrays of objects need to be stringified
-    () => value
-  )
-}
-
 // Returns a message explaining that the desired snapshot reference could not be found by name
 export const snapshotReferenceMissingError = snapshotReferenceName => {
   return `The requested snapshot reference '${snapshotReferenceName}' could not be found in this workspace.`


### PR DESCRIPTION
Currently, JSON attribute values in data tables are rendered in downloaded TSVs as `[object Object]`.

To reproduce this, use Rawls' [create entity endpoint](https://rawls.dsde-dev.broadinstitute.org/#/entities/create_entity) to create an entity with a JSON object attribute:
```
{
  "name": "test-1",
  "entityType": "test_entity",
  "attributes": {
    "object": {
       "key": "value"
    }
  }
}
```

When downloading selected rows as a TSV from the Export menu, the TSV is generated in the UI using the `Utils.entityAttributeText` function.
https://github.com/DataBiosphere/terra-ui/blob/9045a42b031d4c3426f6fcd9ef0f6bb4f776fee9/src/components/data/EntitiesContent.js#L238-L243

However, `entityAttributeText` does not return a string for some attribute types. In those cases, the text rendered in the TSV is the result of calling `toString` on the value returned from `entityAttributeText`. For attributes containing JSON objects, this results in the TSV containing `[object Object]`.

Added tests for the existing behavior of `entityTextAttribute` in 63cd32c535c42001c93df058f0551292b8c74f1c. Changes in behavior can be seen in b004e43323a814853df04c6cd4c7a1f7d786153a.