### PR TITLE
[DC-425] Reenable catalog tests in alpha and staging

### DIFF
--- a/integration-tests/tests/link-to-new-workspace.js
+++ b/integration-tests/tests/link-to-new-workspace.js
@@ -46,6 +46,5 @@ const testLinkToNewWorkspaceFn = withUserToken(async ({ billingProject, page, te
 registerTest({
   name: 'link-to-new-workspace',
   fn: testLinkToNewWorkspaceFn,
-  timeout: 2 * 60 * 1000,
-  targetEnvironments: ['dev', 'local']
+  timeout: 2 * 60 * 1000
 })

--- a/integration-tests/tests/preview-dataset.js
+++ b/integration-tests/tests/preview-dataset.js
@@ -29,6 +29,5 @@ const testPreviewDatasetFn = withUserToken(async ({ testUrl, page, token }) => {
 registerTest({
   name: 'preview-dataset',
   fn: testPreviewDatasetFn,
-  timeout: 2 * 60 * 1000,
-  targetEnvironments: ['dev', 'local']
+  timeout: 2 * 60 * 1000
 })

--- a/integration-tests/tests/run-catalog-workflow.js
+++ b/integration-tests/tests/run-catalog-workflow.js
@@ -21,6 +21,5 @@ const testCatalogFlowFn = _.flow(
 registerTest({
   name: 'run-catalog',
   fn: testCatalogFlowFn,
-  timeout: 2 * 60 * 1000,
-  targetEnvironments: ['dev', 'local']
+  timeout: 2 * 60 * 1000
 })


### PR DESCRIPTION
Tested locally by running:
```
TERRA_SA_KEY=$(vault read --format=json secret/dsde/alpha/common/firecloud-account.pem | jq .data) \
LYLE_SA_KEY=$(vault read --format=json secret/dsde/terra/envs/common/lyle-user-service-account-key | jq .data) \
ENVIRONMENT=alpha yarn test preview-dataset

TERRA_SA_KEY=$(vault read --format=json secret/dsde/alpha/common/firecloud-account.pem | jq .data) \
LYLE_SA_KEY=$(vault read --format=json secret/dsde/terra/envs/common/lyle-user-service-account-key | jq .data) \
ENVIRONMENT=alpha yarn test run-catalog-workflow

TERRA_SA_KEY=$(vault read --format=json secret/dsde/alpha/common/firecloud-account.pem | jq .data) \
LYLE_SA_KEY=$(vault read --format=json secret/dsde/terra/envs/common/lyle-user-service-account-key | jq .data) \
ENVIRONMENT=alpha yarn test link-to-new-workspace
```

All passed and output log messages implying they ran.