### PR TITLE
[TUIM-22] Add helper for mocking successful API responses

### DIFF
--- a/integration-tests/tests/billing-projects.js
+++ b/integration-tests/tests/billing-projects.js
@@ -147,23 +147,23 @@ const setAjaxMockValues = async (testPage, ownedBillingProjectName, notOwnedBill
     window.ajaxOverridesStore.set([
       {
         filter: { url: /api\/billing\/v2$/ },
-        fn: () => () => Promise.resolve(new Response(JSON.stringify(projectListResult), { status: 200 }))
+        fn: window.ajaxOverrideUtils.makeSuccess(projectListResult)
       },
       {
         filter: { url: /Alpha_Spend_Report_Users\/action\/use/ },
-        fn: () => () => Promise.resolve(new Response(JSON.stringify(true), { status: 200 }))
+        fn: window.ajaxOverrideUtils.makeSuccess(true)
       },
       {
         filter: { url: /api\/billing\/v2(.*)\/members$/ },
-        fn: () => () => Promise.resolve(new Response('[]', { status: 200 }))
+        fn: () => () => window.ajaxOverrideUtils.makeSuccess([])
       },
       {
         filter: { url: ownedMembersUrl },
-        fn: () => () => Promise.resolve(new Response(JSON.stringify(ownedProjectMembersListResult), { status: 200 }))
+        fn: window.ajaxOverrideUtils.makeSuccess(ownedProjectMembersListResult)
       },
       {
         filter: { url: notOwnedMembersUrl },
-        fn: () => () => Promise.resolve(new Response(JSON.stringify(notOwnedProjectMembersListResult), { status: 200 }))
+        fn: window.ajaxOverrideUtils.makeSuccess(notOwnedProjectMembersListResult)
       },
       {
         filter: { url: erroredBillingProjectUrl, method: 'DELETE' },
@@ -171,7 +171,7 @@ const setAjaxMockValues = async (testPage, ownedBillingProjectName, notOwnedBill
       },
       {
         filter: { url: /api\/billing(.*)\/spendReport(.*)/ },
-        fn: () => () => Promise.resolve(new Response(JSON.stringify(spendReturnResult), { status: 200 }))
+        fn: window.ajaxOverrideUtils.makeSuccess(spendReturnResult)
       }
     ])
   }, spendReturnResult, projectListResult, ownedProjectMembersListResult, notOwnedProjectMembersListResult,

--- a/integration-tests/tests/workspace-dashboard.js
+++ b/integration-tests/tests/workspace-dashboard.js
@@ -70,13 +70,11 @@ const setGcpAjaxMockValues = async (testPage, namespace, name) => {
     window.ajaxOverridesStore.set([
       {
         filter: { url: storageCostEstimateUrl },
-        fn: () => () => Promise.resolve(
-          new Response(JSON.stringify({ estimate: 'Fake Estimate', lastUpdated: Date.now() }), { status: 200 })
-        )
+        fn: window.ajaxOverrideUtils.makeSuccess({ estimate: 'Fake Estimate', lastUpdated: Date.now() })
       },
       {
         filter: { url: /storage\/v1\/b(.*)/ }, // Bucket location response
-        fn: () => () => Promise.resolve(new Response(JSON.stringify({}), { status: 200 }))
+        fn: window.ajaxOverrideUtils.makeSuccess({})
       }
     ])
   }, namespace, name)

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -24,7 +24,8 @@ window.ajaxOverrideUtils = {
     return Math.random() < frequency ?
       Promise.resolve(new Response('Instrumented error', { status })) :
       wrappedFetch(...args)
-  })
+  }),
+  makeSuccess: body => _wrappedFetch => () => Promise.resolve(new Response(JSON.stringify(body), { status: 200 }))
 }
 
 const authOpts = (token = getUser().token) => ({ headers: { Authorization: `Bearer ${token}` } })


### PR DESCRIPTION
We have a helper for mocking error responses. This adds one for mocking success responses.

https://github.com/DataBiosphere/terra-ui/blob/a1e96f8374b277f4f926132fa8f7e2148e044688/src/libs/ajax.js#L23-L27