### PR TITLE
[SU-92] Improve screen reader output for collapse component

### DIFF
--- a/src/components/Collapse.js
+++ b/src/components/Collapse.js
@@ -25,7 +25,6 @@ const Collapse = ({ title, buttonStyle, buttonProps = {}, summaryStyle, detailsS
       h(Link, {
         'aria-expanded': isOpened,
         'aria-controls': isOpened ? id : undefined,
-        'aria-owns': isOpened ? id : undefined,
         style: { display: 'flex', flex: 1, alignItems: 'center', marginBottom: '0.5rem', ...buttonStyle },
         onClick: () => setIsOpened(!isOpened),
         ...buttonProps


### PR DESCRIPTION
Currently, when tabbing to one of the headings in the workspace dashboard sidebar, VoiceOver reads out the entire content of that section. This is because the button has an [`aria-owns`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-owns) attribute telling VoiceOver that the main content of the Collapse component is a child of the button in the heading. After removing that attribute, VoiceOver only reads out the button text.

Removing `aria-owns` and leaving `aria-expanded` and `aria-controls` aligns with the ARIA Authoring Practices Guide's recommendations for a disclosure: https://w3c.github.io/aria-practices/#disclosure.

![Screen Shot 2022-07-11 at 2 29 24 PM](https://user-images.githubusercontent.com/1156625/178333239-ae8fbb49-511a-4a87-bb5a-ce281b1d9707.png)

## Before
![Screen Shot 2022-07-11 at 2 30 15 PM](https://user-images.githubusercontent.com/1156625/178333489-a1f3024d-e924-4021-b798-61afeaae1378.png)

## After
![Screen Shot 2022-07-11 at 2 30 39 PM](https://user-images.githubusercontent.com/1156625/178333492-f7db18f3-4a27-40e8-8e44-258e1ae9ab43.png)