### PR TITLE
[SU-163] Add default props for FileBrowser

### DIFF
--- a/src/components/data/FileBrowser.js
+++ b/src/components/data/FileBrowser.js
@@ -263,7 +263,7 @@ const BucketBrowser = (({
   showNewFolderButton = true,
   extraMenuItems,
   style, controlPanelStyle,
-  onUploadFiles, onDeleteFiles
+  onUploadFiles = _.noop, onDeleteFiles = _.noop
 }) => {
   // Normalize base prefix to have a trailing slash.
   const basePrefix = Utils.cond(


### PR DESCRIPTION
Currently, uploading or deleting a file using the file browser in the workspace Data tab throws an error in the browser console. This is because the FileBrowser component calls its `onUploadFiles` and `onDeleteFiles` callbacks without checking if those props were defined. This adds default values for those props.