### PR TITLE
[SUP-693] Fix opening a cohort in a notebook

### DIFF
--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -14,7 +14,7 @@ import { icon } from 'src/components/icons'
 import IGVBrowser from 'src/components/IGVBrowser'
 import IGVFileSelector from 'src/components/IGVFileSelector'
 import { withModalDrawer } from 'src/components/ModalDrawer'
-import { cohortNotebook, cohortRNotebook, NotebookCreator } from 'src/components/notebook-utils'
+import { cohortNotebook, cohortRNotebook, NotebookCreator, tools } from 'src/components/notebook-utils'
 import { MenuButton, MenuDivider, MenuTrigger } from 'src/components/PopupTrigger'
 import TitleBar from 'src/components/TitleBar'
 import WorkflowSelector from 'src/components/WorkflowSelector'
@@ -117,7 +117,7 @@ const ToolDrawer = _.flow(
         onSuccess: async (notebookName, notebookKernel) => {
           const cohortName = _.values(selectedEntities)[0].name
           const contents = notebookKernel === 'r' ? cohortRNotebook(cohortName) : cohortNotebook(cohortName)
-          await Buckets.notebook(googleProject, bucketName, notebookName).create(JSON.parse(contents))
+          await Buckets.notebook(googleProject, bucketName, `${notebookName}.${tools.Jupyter.defaultExt}`).create(JSON.parse(contents))
           Ajax().Metrics.captureEvent(Events.workspaceDataOpenWithNotebook, extractWorkspaceDetails(workspace.workspace))
           Nav.goToPath('workspace-notebook-launch', { namespace, name: wsName, notebookName: `${notebookName}.ipynb` })
         },


### PR DESCRIPTION
Opening a cohort created in the Data Explorer in a Notebook is supposed to create a notebook from a template.
https://support.terra.bio/hc/en-us/articles/360034954811-Accessing-and-analyzing-custom-cohorts-with-Data-Explorer

However, it currently opens a blank notebook. This is because the notebook file created from the template is created without the `.ipynb` extension, so when opening the notebook, Terra looks for the file in the wrong place and creates a new (blank) notebook.

## Before
https://user-images.githubusercontent.com/1156625/178351220-62a98c32-7458-4f02-9ad8-8c0d456a6fa4.mov

## After
https://user-images.githubusercontent.com/1156625/178351238-bcfa546b-446d-4a00-b914-3de5b16ef48f.mov
