### PR TITLE
[IA-3493] fix rstudio launch

### DIFF
--- a/src/components/RuntimeManager.js
+++ b/src/components/RuntimeManager.js
@@ -199,14 +199,17 @@ export default class RuntimeManager extends PureComponent {
     const galaxyApp = getCurrentApp(tools.Galaxy.appType)(apps)
     const prevGalaxyApp = getCurrentApp(tools.Galaxy.appType)(prevProps.apps)
 
+    console.log('in runtime manager', runtime.status === 'Running', prevRuntime.status, prevRuntime.status !== 'Running',
+      runtime?.labels?.tool === tools?.RStudio?.label, window.location.hash !== rStudioLaunchLink)
+
     if (runtime.status === 'Error' && prevRuntime.status !== 'Error' && !_.includes(runtime.id, errorNotifiedRuntimes.get())) {
       notify('error', 'Error Creating Cloud Environment', {
         message: h(RuntimeErrorNotification, { runtime })
       })
       errorNotifiedRuntimes.update(Utils.append(runtime.id))
     } else if (
-      runtime.status === 'Running' && prevRuntime.status && prevRuntime.status !== 'Running' &&
-      runtime.labels.tool === 'RStudio' && window.location.hash !== rStudioLaunchLink
+      runtime?.status === 'Running' && prevRuntime?.status && prevRuntime.status !== 'Running' &&
+      runtime?.labels?.tool === tools.RStudio.label && window.location.hash !== rStudioLaunchLink
     ) {
       const rStudioNotificationId = notify('info', 'Your cloud environment is ready.', {
         message: h(ButtonPrimary, {

--- a/src/components/RuntimeManager.js
+++ b/src/components/RuntimeManager.js
@@ -199,9 +199,6 @@ export default class RuntimeManager extends PureComponent {
     const galaxyApp = getCurrentApp(tools.Galaxy.appType)(apps)
     const prevGalaxyApp = getCurrentApp(tools.Galaxy.appType)(prevProps.apps)
 
-    // console.log('in runtime manager', runtime.status === 'Running', prevRuntime.status, prevRuntime.status !== 'Running',
-    //   runtime?.labels?.tool === tools?.RStudio?.label, window.location.hash !== rStudioLaunchLink)
-
     if (runtime.status === 'Error' && prevRuntime.status !== 'Error' && !_.includes(runtime.id, errorNotifiedRuntimes.get())) {
       notify('error', 'Error Creating Cloud Environment', {
         message: h(RuntimeErrorNotification, { runtime })

--- a/src/components/RuntimeManager.js
+++ b/src/components/RuntimeManager.js
@@ -199,8 +199,8 @@ export default class RuntimeManager extends PureComponent {
     const galaxyApp = getCurrentApp(tools.Galaxy.appType)(apps)
     const prevGalaxyApp = getCurrentApp(tools.Galaxy.appType)(prevProps.apps)
 
-    console.log('in runtime manager', runtime.status === 'Running', prevRuntime.status, prevRuntime.status !== 'Running',
-      runtime?.labels?.tool === tools?.RStudio?.label, window.location.hash !== rStudioLaunchLink)
+    // console.log('in runtime manager', runtime.status === 'Running', prevRuntime.status, prevRuntime.status !== 'Running',
+    //   runtime?.labels?.tool === tools?.RStudio?.label, window.location.hash !== rStudioLaunchLink)
 
     if (runtime.status === 'Error' && prevRuntime.status !== 'Error' && !_.includes(runtime.id, errorNotifiedRuntimes.get())) {
       notify('error', 'Error Creating Cloud Environment', {

--- a/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
@@ -226,7 +226,6 @@ const PreviewHeader = ({
   const welderEnabled = runtime && !runtime.labels.welderInstallFailed
   const { mode } = queryParams
   const analysisLink = Nav.getLink(analysisLauncherTabName, { namespace, name, analysisName })
-  const currentRuntimeTool = getToolFromRuntime(runtime)
 
   const checkIfLocked = withErrorReporting('Error checking analysis lock status', async () => {
     const { metadata: { lastLockedBy, lockExpiresAt } = {} } = await Ajax(signal)
@@ -253,7 +252,7 @@ const PreviewHeader = ({
 
   useOnMount(() => { checkIfLocked() })
 
-  console.log('in analysisLauncher', toolLabel)
+  // console.log('in analysisLauncher', toolLabel)
 
   return h(ApplicationHeader, {
     label: 'PREVIEW (READ-ONLY)',
@@ -265,39 +264,36 @@ const PreviewHeader = ({
         makeMenuIcon('export'), 'Copy to another workspace'
       ])],
       [!runtime, () => h(HeaderButton, {
-          onClick: () => setCreateOpen(true)
-        }, [ makeMenuIcon('rocket'), 'Open' ])
-      ],
-      [toolLabel === tools.RStudio.label && _.includes(runtimeStatus, ['Running', 'Stopped', null]), () =>
-        h(HeaderButton, {
-          onClick: () => {
-            if (runtimeStatus === 'Running') {
-              Ajax().Metrics.captureEvent(Events.analysisLaunch,
-                { origin: 'analysisLauncher', source: tools.RStudio.label, application: tools.RStudio.label, workspaceName: name, namespace })
-              Nav.goToPath(appLauncherTabName, { namespace, name, application: 'RStudio' })
-            } else if (runtimeStatus === 'Stopped') {
-              startAndRefresh(refreshRuntimes, Ajax().Runtimes.runtime(googleProject, runtime.runtimeName).start())
-            }
+        onClick: () => setCreateOpen(true)
+      }, [makeMenuIcon('rocket'), 'Open'])],
+      [toolLabel === tools.RStudio.label && _.includes(runtimeStatus, ['Running', 'Stopped', null]), () => h(HeaderButton, {
+        onClick: () => {
+          if (runtimeStatus === 'Running') {
+            Ajax().Metrics.captureEvent(Events.analysisLaunch,
+              { origin: 'analysisLauncher', source: tools.RStudio.label, application: tools.RStudio.label, workspaceName: name, namespace })
+            Nav.goToPath(appLauncherTabName, { namespace, name, application: 'RStudio' })
+          } else if (runtimeStatus === 'Stopped') {
+            startAndRefresh(refreshRuntimes, Ajax().Runtimes.runtime(googleProject, runtime.runtimeName).start())
           }
-        }, [ makeMenuIcon('rocket'), 'Open' ])
-      ],
-      [toolLabel !== tools.RStudio.label && !mode || [null, 'Stopped'].includes(runtimeStatus), () => h(Fragment, [
-          Utils.cond(
-            [runtime && !welderEnabled, () => h(HeaderButton, { onClick: () => setEditModeDisabledOpen(true) }, [
-              makeMenuIcon('warning-standard'), 'Open (Disabled)'
-            ])],
-            [locked, () => h(HeaderButton, { onClick: () => setFileInUseOpen(true) }, [
-              makeMenuIcon('lock'), 'Open (In use)'
-            ])],
-            () => h(HeaderButton, { onClick: () => chooseMode('edit') }, [
-              makeMenuIcon('rocket'), 'Open'
-            ])
-          ),
-          h(HeaderButton, {
-            onClick: () => getLocalPref('hidePlaygroundMessage') ? chooseMode('playground') : setPlaygroundModalOpen(true)
-          }, [
-            makeMenuIcon('chalkboard'), 'Playground mode'
-          ]),
+        }
+      }, [makeMenuIcon('rocket'), 'Open'])],
+      [(toolLabel !== tools.RStudio.label && !mode) || [null, 'Stopped'].includes(runtimeStatus), () => h(Fragment, [
+        Utils.cond(
+          [runtime && !welderEnabled, () => h(HeaderButton, { onClick: () => setEditModeDisabledOpen(true) }, [
+            makeMenuIcon('warning-standard'), 'Open (Disabled)'
+          ])],
+          [locked, () => h(HeaderButton, { onClick: () => setFileInUseOpen(true) }, [
+            makeMenuIcon('lock'), 'Open (In use)'
+          ])],
+          () => h(HeaderButton, { onClick: () => chooseMode('edit') }, [
+            makeMenuIcon('rocket'), 'Open'
+          ])
+        ),
+        h(HeaderButton, {
+          onClick: () => getLocalPref('hidePlaygroundMessage') ? chooseMode('playground') : setPlaygroundModalOpen(true)
+        }, [
+          makeMenuIcon('chalkboard'), 'Playground mode'
+        ])
       ])]
     ),
     // Workspace-level options

--- a/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
+++ b/src/pages/workspaces/workspace/notebooks/AnalysisLauncher.js
@@ -287,7 +287,7 @@ const PreviewHeader = ({
           }
         },
         openMenuIcon)],
-      // Jupyter is slightly different since it interact with editMode and playground mode flags as well
+      // Jupyter is slightly different since it interacts with editMode and playground mode flags as well
       [(toolLabel === tools.Jupyter.label && !mode) || [null, 'Stopped'].includes(runtimeStatus), () => h(Fragment, [
         Utils.cond(
           [runtime && !welderEnabled, () => h(HeaderButton, { onClick: () => setEditModeDisabledOpen(true) }, [

--- a/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
+++ b/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
@@ -63,6 +63,10 @@ export const CloudEnvironmentModal = ({
     onSuccess: () => {
       setViewMode(undefined)
       onSuccess()
+    },
+    onError: () => {
+      setViewMode(undefined)
+      onDismiss()
     }
   })
 


### PR DESCRIPTION
 I highly recommend looking at the file in its current state instead of the github diff view. This code was extremely confusing for me, so I did a fairly large refactor. I split out the app conditionals (and other logic) into separate top-level `Util.conds`, instead of mixing them inside a few very large conditionals.

The issue was that the user would be inappropriately prompted to create a new RStudio when the runtime was not in a launchable status.

I did a lot of testing here, with both Jupyter and RStudio runtimes. Some examples of testing:

- Clicking an RStudio file with a Jupyter runtime and ensuring Open prompts runtime creation
    - Same applies to clicking a Jupyter file with an RStudio Runtime
- Clicking on RStudio/Jupyter files and then Open when the runtime is in Stopped should start the runtime
-  Clicking on RStudio/Jupyter files and then Open when the runtime is in running should launch the tool (means different things for both tools)
- Clicking on a file with no runtime should prompt runtime creation for the appropriate tool
- Workspace-level options should work (the `...` menu)
- Playground mode for Jupyter analyses should work

