### PR TITLE
[PE-5] Adjust landing page layout

### DIFF
--- a/src/components/common.js
+++ b/src/components/common.js
@@ -505,30 +505,28 @@ export const HeroWrapper = ({ showMenu = true, bigSubhead = false, showDocLink =
         backgroundRepeat: 'no-repeat', backgroundSize: '750px', backgroundPosition: 'right 0 top 0'
       }
     }, [
-      div({ style: { maxWidth: '50%' } }, [
-        h1({ style: { fontSize: 54 } }, [`Welcome to ${getAppName({ longName: isTerra() })}`]),
-        div({ style: { margin: '1rem 0', width: 700, ...(bigSubhead ? { fontSize: 20, lineHeight: '28px' } : { fontSize: 16, lineHeight: 1.5 }) } }, [
-          `${getAppName({ longName: !isTerra(), capitalizeThe: true })} is a ${Utils.cond(
-            [isTerra(), () => 'cloud-native platform'],
-            [isFirecloud(), () => 'NCI Cloud Resource project powered by Terra'],
-            [isProjectSingular(), () => 'project funded by Additional Ventures and powered by Terra'],
-            [isRareX(),
-              () => 'federated data repository of rare disease patient health data, including patient reported outcomes, clinical and molecular information. The platform is powered by Terra'],
-            () => 'project powered by Terra'
-          )} for biomedical researchers to `,
-          heavyWrapper('access data'), ', ', heavyWrapper('run analysis tools'), ', ',
-          span({ style: { whiteSpace: 'nowrap' } }, ['and', heavyWrapper(' collaborate')]),
-          isProjectSingular() && ' to advance research around single ventricle heart disease',
-          '. ',
-          showDocLink ?
-            h(Link, {
-              style: { textDecoration: 'underline' },
-              href: `https://support.terra.bio/hc/en-us`,
-              ...Utils.newTabLinkProps
-            }, ['Learn more about Terra.']) : null
-        ]),
-        children
-      ])
+      h1({ style: { fontSize: 54, width: 'calc(100% - 460px)' } }, [`Welcome to ${getAppName({ longName: isTerra() })}`]),
+      div({ style: { margin: '1rem 0', width: 'calc(100% - 460px)', maxWidth: 700, ...(bigSubhead ? { fontSize: 20, lineHeight: '28px' } : { fontSize: 16, lineHeight: 1.5 }) } }, [
+        `${getAppName({ longName: !isTerra(), capitalizeThe: true })} is a ${Utils.cond(
+          [isTerra(), () => 'cloud-native platform'],
+          [isFirecloud(), () => 'NCI Cloud Resource project powered by Terra'],
+          [isProjectSingular(), () => 'project funded by Additional Ventures and powered by Terra'],
+          [isRareX(),
+            () => 'federated data repository of rare disease patient health data, including patient reported outcomes, clinical and molecular information. The platform is powered by Terra'],
+          () => 'project powered by Terra'
+        )} for biomedical researchers to `,
+        heavyWrapper('access data'), ', ', heavyWrapper('run analysis tools'), ', ',
+        span({ style: { whiteSpace: 'nowrap' } }, ['and', heavyWrapper(' collaborate')]),
+        isProjectSingular() && ' to advance research around single ventricle heart disease',
+        '. ',
+        showDocLink ?
+          h(Link, {
+            style: { textDecoration: 'underline' },
+            href: `https://support.terra.bio/hc/en-us`,
+            ...Utils.newTabLinkProps
+          }, ['Learn more about Terra.']) : null
+      ]),
+      children
     ])
   ])
 }

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -505,6 +505,7 @@ export const HeroWrapper = ({ showMenu = true, bigSubhead = false, showDocLink =
         backgroundRepeat: 'no-repeat', backgroundSize: '750px', backgroundPosition: 'right 0 top 0'
       }
     }, [
+      // width is set to prevent text from overlapping the background image and decreasing legibility
       h1({ style: { fontSize: 54, width: 'calc(100% - 460px)' } }, [`Welcome to ${getAppName({ longName: isTerra() })}`]),
       div({ style: { margin: '1rem 0', width: 'calc(100% - 460px)', maxWidth: 700, ...(bigSubhead ? { fontSize: 20, lineHeight: '28px' } : { fontSize: 16, lineHeight: 1.5 }) } }, [
         `${getAppName({ longName: !isTerra(), capitalizeThe: true })} is a ${Utils.cond(

--- a/src/pages/LandingPage.js
+++ b/src/pages/LandingPage.js
@@ -86,7 +86,7 @@ const getSiteSpecificHyperlinks = () => Utils.cond(
 
 const LandingPage = () => {
   return h(HeroWrapper, { bigSubhead: true }, [
-    div({ style: { maxWidth: '85%' } }, getSiteSpecificHyperlinks()),
+    div({ style: { maxWidth: 'calc(100% - 460px)' } }, getSiteSpecificHyperlinks()),
     div({ style: { display: 'flex', margin: '2rem 0 1rem 0' } }, [
       makeCard('workspaces', 'View Workspaces', [
         'Workspaces connect your data to popular analysis tools powered by the cloud. Use Workspaces to share data, code, and results easily and securely.'

--- a/src/pages/LandingPage.js
+++ b/src/pages/LandingPage.js
@@ -86,6 +86,7 @@ const getSiteSpecificHyperlinks = () => Utils.cond(
 
 const LandingPage = () => {
   return h(HeroWrapper, { bigSubhead: true }, [
+    // width is set to prevent text from overlapping the background image and decreasing legibility
     div({ style: { maxWidth: 'calc(100% - 460px)' } }, getSiteSpecificHyperlinks()),
     div({ style: { display: 'flex', margin: '2rem 0 1rem 0' } }, [
       makeCard('workspaces', 'View Workspaces', [


### PR DESCRIPTION
For some window widths, the text on the cards on the landing page overflows.

The cause of this is a `max-width: 50%` style added in https://github.com/DataBiosphere/terra-ui/pull/3212/files#r918374677 to prevent content from overlapping the background image. This change uses `width: 'calc(100% - <number>px')` individually on the heading, paragraph, and doc link list elements to accomplish that.

## Before

![before_terra_2](https://user-images.githubusercontent.com/1156625/178808776-8c26f699-28b4-4a04-91d3-91813d2a8574.png)

![before_terra](https://user-images.githubusercontent.com/1156625/178808822-b6d70296-14c3-4a85-b1f2-9665b937a5d9.png)

![before_rarex](https://user-images.githubusercontent.com/1156625/178808869-7991e28e-6fbb-473b-8de8-d817fc51ad1a.png)

## After

![after_terra_2](https://user-images.githubusercontent.com/1156625/178808885-224c95df-c087-4fd1-a4cc-e358cf315791.png)

![after_terra](https://user-images.githubusercontent.com/1156625/178808893-078b2030-ee00-4814-bedb-c2c7d42dacae.png)

![after-rarex](https://user-images.githubusercontent.com/1156625/178808909-f4096edb-22da-4473-9e8b-9ce400e28d30.png)

