### PR TITLE
[SU-165] Fix viewing BED files in IGV

### DIFF
--- a/src/components/IGVBrowser.js
+++ b/src/components/IGVBrowser.js
@@ -63,7 +63,7 @@ const IGVBrowser = _.flow(
               return {
                 name: `${_.last(filePath.split('/'))} (${filePath})`,
                 url: Utils.mergeQueryParams(userProjectParam, filePath),
-                indexURL: Utils.mergeQueryParams(userProjectParam, indexFilePath)
+                indexURL: !!indexFilePath ? Utils.mergeQueryParams(userProjectParam, indexFilePath) : undefined
               }
             }, selectedFiles))
           }


### PR DESCRIPTION
Currently, Terra fails to load BED files in IGV.

Create a data table containing a URL to a BED file (located in the workspace bucket) in one attribute. Select the row and open in IGV. Select the BED file and launch IGV.

Terra shows an error message “Error loading IGV.js”. Clicking on the details button shows “Failed to construct 'URL': Invalid URL”.

This is because Terra attempts to add query parameters to the selected file’s URL and its index’s URL. However, in the case of BED files, there is no index URL.

https://github.com/DataBiosphere/terra-ui/blob/752e98114d4b5c9c9143fed0f69672ab1b6b5c45/src/components/IGVBrowser.js#L63-L67

https://github.com/DataBiosphere/terra-ui/blob/752e98114d4b5c9c9143fed0f69672ab1b6b5c45/src/components/IGVFileSelector.js#L37-L43

This change checks for the existence of an index URL before attempting to add query parameters.