### PR TITLE
[IA-3111] Change text color of PD information to comply with a11y specifications.

### DIFF
--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -1187,7 +1187,7 @@ export const ComputeModalBase = ({
       _.map(({ cost, label, unitLabel }) => {
         return div({ key: label, style: { flex: 1, ...computeStyles.label } }, [
           div({ style: { fontSize: 10 } }, [label]),
-          div({ style: { color: colors.accent(1.1), marginTop: '0.25rem' } }, [
+          div({ style: { color: colors.dark(), marginTop: '0.25rem' } }, [
             span({ style: { fontSize: 20 } }, [cost]),
             span([' ', unitLabel])
           ])


### PR DESCRIPTION
## Description

The cost descriptions in blue have insufficient color contrast for WCAG 2 AA compliance. 

## Solution

Text color should be changed to #333F52 (default dark text color) for better contrast