### PR TITLE
[TUIM-4] Remove reference to deleted Bueller documentation

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -1,7 +1,5 @@
 # Terra UI Integration Tests
 
-See also: [Bueller](Bueller.md) - service for invoking tests
-
 ### Setup
 
 1. Start by making sure you're running the correct versions of Node and Yarn, as described in the [root README](../README.md).


### PR DESCRIPTION
Still finding the occasional reference to Bueller. Bueller.md was deleted in #3065. This removes a link to it from the integration tests' README.