### PR TITLE
[IA-3530] Add cloud env page loading metrics 

### DIFF
--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -25,6 +25,7 @@ const eventsList = {
   cloudEnvironmentCreate: 'cloudEnvironment:create',
   cloudEnvironmentDelete: 'cloudEnvironment:delete',
   cloudEnvironmentUpdate: 'cloudEnvironment:update',
+  cloudEnvironmentDetailsLoad: 'analysis:details:load',
   catalogFilter: 'catalog:filter',
   catalogRequestAccess: 'catalog:requestAccess',
   catalogView: 'catalog:view',

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -137,15 +137,15 @@ const Environments = () => {
   const refreshData = Utils.withBusyState(setLoading, async () => {
     const creator = getUser().email
 
-    const startTimeForLeoCallsEpochMs = new Date().getTime()
+    const startTimeForLeoCallsEpochMs = Date.now()
     const [newRuntimes, newDisks, newApps] = await Promise.all([
       Ajax(signal).Runtimes.listV2(shouldFilterRuntimesByCreator ? { creator, includeLabels: 'saturnWorkspaceNamespace,saturnWorkspaceName' } : { includeLabels: 'saturnWorkspaceNamespace,saturnWorkspaceName' }),
       Ajax(signal).Disks.list({ creator, includeLabels: 'saturnApplication,saturnWorkspaceNamespace,saturnWorkspaceName' }),
       Ajax(signal).Apps.listWithoutProject({ creator, includeLabels: 'saturnWorkspaceNamespace,saturnWorkspaceName' })
     ])
-    const endTimeForLeoCallsEpochMs = new Date().getTime()
+    const endTimeForLeoCallsEpochMs = Date.now()
 
-    const startTimeForRawlsCallsEpochMs = new Date().getTime()
+    const startTimeForRawlsCallsEpochMs = Date.now()
     const decorateLabeledCloudObjWithWorkspaceId = withErrorIgnoring(async cloudObject => {
       const { labels: { saturnWorkspaceNamespace, saturnWorkspaceName } } = cloudObject
       const details = !!saturnWorkspaceNamespace && !!saturnWorkspaceName ? await Ajax(signal).Workspaces.workspace(saturnWorkspaceNamespace, saturnWorkspaceName).details(['workspace']).catch(_ => undefined) : undefined
@@ -158,7 +158,7 @@ const Environments = () => {
       Promise.all(_.map(decorateLabeledCloudObjWithWorkspaceId, newDisks)),
       Promise.all(_.map(decorateLabeledCloudObjWithWorkspaceId, newApps))
     ])
-    const endTimeForRawlsCallsEpochMs = new Date().getTime()
+    const endTimeForRawlsCallsEpochMs = Date.now()
 
     const leoCallTimeTotalMs = endTimeForLeoCallsEpochMs - startTimeForLeoCallsEpochMs
     const rawlsCallTimeTotalMs = endTimeForRawlsCallsEpochMs - startTimeForRawlsCallsEpochMs


### PR DESCRIPTION
This is a small PR to time how long API calls take. Usually this is done server-side, but this particular timing involves multiple calls, and the interesting part is the user-specific summation of the return of these calls.

I.e., it is possible for a particular user to have a lot of resources and this call could take a while. 