### PR TITLE
[IA-3567] Fix 'choppy' modal dismiss animation

### DIFF
--- a/src/components/AnalysisModal.js
+++ b/src/components/AnalysisModal.js
@@ -66,7 +66,7 @@ export const AnalysisModal = withDisplayName('AnalysisModal')(
 
       Utils.switchCase(baseViewMode,
         [analysisMode, () => Utils.cond(
-          [doesCloudEnvForToolExist, () => onSuccess],
+          [doesCloudEnvForToolExist, onSuccess],
           [!doesCloudEnvForToolExist && currentRuntime && isResourceDeletable('runtime', currentRuntime), () => setViewMode(environmentMode)],
           [!doesCloudEnvForToolExist && !currentRuntime, () => setViewMode(environmentMode)],
           [!doesCloudEnvForToolExist && currentRuntime && !isResourceDeletable('runtime', currentRuntime), onSuccess]

--- a/src/components/AnalysisModal.js
+++ b/src/components/AnalysisModal.js
@@ -56,21 +56,21 @@ export const AnalysisModal = withDisplayName('AnalysisModal')(
       setNotebookKernel('python3')
     }
 
-    const onDismissModal = (timeout = 0) => {
+    const onDismissModal = () => {
       onDismiss()
       setTimeout(() => {
         resetView()
-      }, timeout)
+      }, Style.DEFAULT_TRANSITION_DURATION)
     }
 
     const onSuccessModal = () => {
       onSuccess()
-      resetView()
+      onDismissModal()
     }
 
     const onErrorModal = () => {
       onError()
-      resetView()
+      onDismissModal()
     }
 
     /**

--- a/src/components/AnalysisModal.js
+++ b/src/components/AnalysisModal.js
@@ -56,23 +56,6 @@ export const AnalysisModal = withDisplayName('AnalysisModal')(
       setNotebookKernel('python3')
     }
 
-    const onDismissModal = () => {
-      onDismiss()
-      setTimeout(() => {
-        resetView()
-      }, Style.DEFAULT_TRANSITION_DURATION)
-    }
-
-    const onSuccessModal = () => {
-      onSuccess()
-      onDismissModal()
-    }
-
-    const onErrorModal = () => {
-      onError()
-      onDismissModal()
-    }
-
     /**
      * The intended flow is to call this without a viewMode, and have it intelligently figure out the next
      * step for you. Passing a viewMode is a way to force your next modal.
@@ -83,12 +66,12 @@ export const AnalysisModal = withDisplayName('AnalysisModal')(
 
       Utils.switchCase(baseViewMode,
         [analysisMode, () => Utils.cond(
-          [doesCloudEnvForToolExist, () => onSuccessModal],
+          [doesCloudEnvForToolExist, () => onSuccess],
           [!doesCloudEnvForToolExist && currentRuntime && isResourceDeletable('runtime', currentRuntime), () => setViewMode(environmentMode)],
           [!doesCloudEnvForToolExist && !currentRuntime, () => setViewMode(environmentMode)],
-          [!doesCloudEnvForToolExist && currentRuntime && !isResourceDeletable('runtime', currentRuntime), onSuccessModal]
+          [!doesCloudEnvForToolExist && currentRuntime && !isResourceDeletable('runtime', currentRuntime), onSuccess]
         )],
-        [environmentMode, onSuccessModal],
+        [environmentMode, onSuccess],
         [Utils.DEFAULT, () => Utils.cond(
           [currentTool === tools.RStudio.label || currentTool === tools.Jupyter.label, () => setViewMode(analysisMode)],
           [isToolAnApp(currentTool) && !app, () => setViewMode(environmentMode)],
@@ -122,9 +105,9 @@ export const AnalysisModal = withDisplayName('AnalysisModal')(
       tool: currentTool,
       runtimes,
       persistentDisks,
-      onDismiss: onDismissModal,
-      onError: onErrorModal,
-      onSuccess: onSuccessModal
+      onDismiss,
+      onError,
+      onSuccess
     })
 
     const renderAppModal = (appModalBase, toolLabel) => h(appModalBase, {
@@ -132,9 +115,9 @@ export const AnalysisModal = withDisplayName('AnalysisModal')(
       workspace,
       apps,
       appDataDisks,
-      onDismiss: onDismissModal,
-      onError: onErrorModal,
-      onSuccess: onSuccessModal
+      onDismiss,
+      onError,
+      onSuccess
     })
 
     const styles = {
@@ -207,7 +190,7 @@ export const AnalysisModal = withDisplayName('AnalysisModal')(
         }
       }, [() => h(Clickable, {
         onClick: () => {
-          onSuccessModal()
+          onSuccess()
           openUploader()
         }, style: {
           marginTop: '1rem', fontSize: 16, lineHeight: '20px', ...Style.elements.card.container, alignItems: 'center', width: '100%', height: 150,
@@ -325,7 +308,7 @@ export const AnalysisModal = withDisplayName('AnalysisModal')(
         title: 'Select an application',
         titleStyles: { margin: '1.5rem 0 0 1.5rem', display: !!viewMode ? 'none' : undefined },
         width,
-        onDismiss: onDismissModal,
+        onDismiss,
         onPrevious: !!viewMode ? () => resetView() : undefined
       }),
       viewMode !== undefined && hr({ style: { borderTop: '1px solid', width: '100%', color: colors.accent() } }),
@@ -334,7 +317,8 @@ export const AnalysisModal = withDisplayName('AnalysisModal')(
 
     const modalProps = {
       isOpen, width, 'aria-labelledby': titleId,
-      onDismiss: onDismissModal
+      onDismiss,
+      onExited: resetView
     }
 
     return h(ModalDrawer, { ...modalProps, children: modalBody })

--- a/src/components/AnalysisModal.js
+++ b/src/components/AnalysisModal.js
@@ -56,9 +56,11 @@ export const AnalysisModal = withDisplayName('AnalysisModal')(
       setNotebookKernel('python3')
     }
 
-    const onDismissModal = () => {
+    const onDismissModal = (timeout = 0) => {
       onDismiss()
-      resetView()
+      setTimeout(() => {
+        resetView()
+      }, timeout)
     }
 
     const onSuccessModal = () => {

--- a/src/components/ModalDrawer.js
+++ b/src/components/ModalDrawer.js
@@ -6,6 +6,8 @@ import colors from 'src/libs/colors'
 import { useLabelAssert } from 'src/libs/react-utils'
 
 
+const TRANSITION_DURATION = 200
+
 const drawer = {
   overlay: transitionState => transitionState === 'entering' || transitionState === 'entered' ? {
     backgroundColor: 'rgba(0, 0, 0, 0.5)', padding: '2rem 1rem',
@@ -29,7 +31,7 @@ const ModalDrawer = ({ isOpen, onDismiss, width = 450, children, ...props }) => 
 
   return h(Transition, {
     in: isOpen,
-    timeout: { exit: 200 },
+    timeout: { exit: TRANSITION_DURATION },
     appear: true,
     mountOnEnter: true,
     unmountOnExit: true
@@ -38,7 +40,7 @@ const ModalDrawer = ({ isOpen, onDismiss, width = 450, children, ...props }) => 
     ariaHideApp: false,
     parentSelector: () => document.getElementById('modal-root'),
     isOpen: true,
-    onRequestClose: onDismiss,
+    onRequestClose: () => onDismiss(TRANSITION_DURATION),
     style: { overlay: drawer.overlay(transitionState), content: { ...drawer.container(transitionState), width } },
     ...props
   }, [children])])

--- a/src/components/ModalDrawer.js
+++ b/src/components/ModalDrawer.js
@@ -4,9 +4,8 @@ import RModal from 'react-modal'
 import { Transition } from 'react-transition-group'
 import colors from 'src/libs/colors'
 import { useLabelAssert } from 'src/libs/react-utils'
+import { DEFAULT_TRANSITION_DURATION } from 'src/libs/style'
 
-
-const TRANSITION_DURATION = 200
 
 const drawer = {
   overlay: transitionState => transitionState === 'entering' || transitionState === 'entered' ? {
@@ -31,7 +30,7 @@ const ModalDrawer = ({ isOpen, onDismiss, width = 450, children, ...props }) => 
 
   return h(Transition, {
     in: isOpen,
-    timeout: { exit: TRANSITION_DURATION },
+    timeout: { exit: DEFAULT_TRANSITION_DURATION },
     appear: true,
     mountOnEnter: true,
     unmountOnExit: true
@@ -40,7 +39,7 @@ const ModalDrawer = ({ isOpen, onDismiss, width = 450, children, ...props }) => 
     ariaHideApp: false,
     parentSelector: () => document.getElementById('modal-root'),
     isOpen: true,
-    onRequestClose: () => onDismiss(TRANSITION_DURATION),
+    onRequestClose: onDismiss,
     style: { overlay: drawer.overlay(transitionState), content: { ...drawer.container(transitionState), width } },
     ...props
   }, [children])])

--- a/src/components/ModalDrawer.js
+++ b/src/components/ModalDrawer.js
@@ -4,7 +4,6 @@ import RModal from 'react-modal'
 import { Transition } from 'react-transition-group'
 import colors from 'src/libs/colors'
 import { useLabelAssert } from 'src/libs/react-utils'
-import { DEFAULT_TRANSITION_DURATION } from 'src/libs/style'
 
 
 const drawer = {
@@ -25,15 +24,16 @@ const drawer = {
   })
 }
 
-const ModalDrawer = ({ isOpen, onDismiss, width = 450, children, ...props }) => {
+const ModalDrawer = ({ isOpen, onDismiss, width = 450, children, onExited, ...props }) => {
   useLabelAssert('ModalDrawer', props)
 
   return h(Transition, {
     in: isOpen,
-    timeout: { exit: DEFAULT_TRANSITION_DURATION },
+    timeout: { exit: 200 },
     appear: true,
     mountOnEnter: true,
-    unmountOnExit: true
+    unmountOnExit: true,
+    onExited
   }, [transitionState => h(RModal, {
     aria: { label: props['aria-label'], labelledby: props['aria-labelledby'], modal: true, hidden: transitionState !== 'entered' },
     ariaHideApp: false,
@@ -46,8 +46,8 @@ const ModalDrawer = ({ isOpen, onDismiss, width = 450, children, ...props }) => 
 }
 
 export const withModalDrawer = ({ width, ...modalProps } = {}) => WrappedComponent => {
-  const Wrapper = ({ isOpen, onDismiss, ...props }) => {
-    return h(ModalDrawer, { isOpen, width, onDismiss, ...modalProps }, [
+  const Wrapper = ({ isOpen, onDismiss, onExited, ...props }) => {
+    return h(ModalDrawer, { isOpen, width, onDismiss, onExited, ...modalProps }, [
       isOpen && h(WrappedComponent, { onDismiss, ...props })
     ])
   }

--- a/src/libs/style.js
+++ b/src/libs/style.js
@@ -170,3 +170,5 @@ export const errorStyle = {
   border: `1px solid ${colors.danger(0.8)}`,
   backgroundColor: colors.danger(0.15)
 }
+
+export const DEFAULT_TRANSITION_DURATION = 200

--- a/src/libs/style.js
+++ b/src/libs/style.js
@@ -171,4 +171,3 @@ export const errorStyle = {
   backgroundColor: colors.danger(0.15)
 }
 
-export const DEFAULT_TRANSITION_DURATION = 200

--- a/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
+++ b/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
@@ -27,6 +27,7 @@ import {
   getPersistentDiskCostHourly, isCurrentGalaxyDiskDetaching, runtimeCost
 } from 'src/libs/runtime-utils'
 import { cookieReadyStore } from 'src/libs/state'
+import { DEFAULT_TRANSITION_DURATION } from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 import { AzureComputeModalBase } from 'src/pages/workspaces/workspace/analysis/AzureComputeModal'
 
@@ -48,6 +49,10 @@ export const CloudEnvironmentModal = ({
 
   const noCompute = 'You do not have access to run analyses on this workspace.'
 
+  const resetModalView = () => setTimeout(() => {
+    setViewMode(undefined)
+  }, DEFAULT_TRANSITION_DURATION)
+
   const renderComputeModal = tool => h(ComputeModalBase, {
     isOpen: viewMode === NEW_JUPYTER_MODE || viewMode === NEW_RSTUDIO_MODE,
     isAnalysisMode: true,
@@ -57,16 +62,16 @@ export const CloudEnvironmentModal = ({
     persistentDisks,
     location,
     onDismiss: () => {
-      setViewMode(undefined)
       onDismiss()
+      resetModalView()
     },
     onSuccess: () => {
-      setViewMode(undefined)
       onSuccess()
+      resetModalView()
     },
     onError: () => {
-      setViewMode(undefined)
       onDismiss()
+      resetModalView()
     }
   })
 
@@ -76,12 +81,12 @@ export const CloudEnvironmentModal = ({
     workspace,
     runtimes,
     onDismiss: () => {
-      setViewMode(undefined)
       onDismiss()
+      resetModalView()
     },
     onSuccess: () => {
-      setViewMode(undefined)
       onSuccess()
+      resetModalView()
     }
   })
 
@@ -91,12 +96,12 @@ export const CloudEnvironmentModal = ({
     apps,
     appDataDisks,
     onDismiss: () => {
-      setViewMode(undefined)
       onDismiss()
+      resetModalView()
     },
     onSuccess: () => {
-      setViewMode(undefined)
       onSuccess()
+      resetModalView()
     }
   })
 
@@ -446,8 +451,8 @@ export const CloudEnvironmentModal = ({
       titleStyles: _.merge(viewMode === undefined ? {} : { display: 'none' }, { margin: '1.5rem 0 .5rem 1rem' }),
       width,
       onDismiss: () => {
-        setViewMode(undefined)
         onDismiss()
+        resetModalView()
       },
       onPrevious: !!viewMode ? () => setViewMode(undefined) : undefined
     }),
@@ -466,11 +471,9 @@ export const CloudEnvironmentModal = ({
 
   const modalProps = {
     'aria-labelledby': titleId, isOpen, width,
-    onDismiss: (timeout = 0) => {
+    onDismiss: () => {
       onDismiss()
-      setTimeout(() => {
-        setViewMode(undefined)
-      }, timeout)
+      resetModalView()
     }
   }
   return h(ModalDrawer, { ...modalProps, children: modalBody })

--- a/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
+++ b/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
@@ -462,9 +462,11 @@ export const CloudEnvironmentModal = ({
 
   const modalProps = {
     'aria-labelledby': titleId, isOpen, width,
-    onDismiss: () => {
-      setViewMode(undefined)
+    onDismiss: (timeout = 0) => {
       onDismiss()
+      setTimeout(() => {
+        setViewMode(undefined)
+      }, timeout)
     }
   }
   return h(ModalDrawer, { ...modalProps, children: modalBody })

--- a/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
+++ b/src/pages/workspaces/workspace/notebooks/modals/CloudEnvironmentModal.js
@@ -27,7 +27,6 @@ import {
   getPersistentDiskCostHourly, isCurrentGalaxyDiskDetaching, runtimeCost
 } from 'src/libs/runtime-utils'
 import { cookieReadyStore } from 'src/libs/state'
-import { DEFAULT_TRANSITION_DURATION } from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 import { AzureComputeModalBase } from 'src/pages/workspaces/workspace/analysis/AzureComputeModal'
 
@@ -49,9 +48,7 @@ export const CloudEnvironmentModal = ({
 
   const noCompute = 'You do not have access to run analyses on this workspace.'
 
-  const resetModalView = () => setTimeout(() => {
-    setViewMode(undefined)
-  }, DEFAULT_TRANSITION_DURATION)
+  const resetView = () => setViewMode(undefined)
 
   const renderComputeModal = tool => h(ComputeModalBase, {
     isOpen: viewMode === NEW_JUPYTER_MODE || viewMode === NEW_RSTUDIO_MODE,
@@ -61,18 +58,9 @@ export const CloudEnvironmentModal = ({
     runtimes,
     persistentDisks,
     location,
-    onDismiss: () => {
-      onDismiss()
-      resetModalView()
-    },
-    onSuccess: () => {
-      onSuccess()
-      resetModalView()
-    },
-    onError: () => {
-      onDismiss()
-      resetModalView()
-    }
+    onDismiss,
+    onSuccess,
+    onError: onDismiss
   })
 
   const renderAzureModal = () => h(AzureComputeModalBase, {
@@ -80,14 +68,8 @@ export const CloudEnvironmentModal = ({
     hideCloseButton: true,
     workspace,
     runtimes,
-    onDismiss: () => {
-      onDismiss()
-      resetModalView()
-    },
-    onSuccess: () => {
-      onSuccess()
-      resetModalView()
-    }
+    onDismiss,
+    onSuccess
   })
 
   const renderAppModal = (appModalBase, appMode) => h(appModalBase, {
@@ -95,14 +77,8 @@ export const CloudEnvironmentModal = ({
     workspace,
     apps,
     appDataDisks,
-    onDismiss: () => {
-      onDismiss()
-      resetModalView()
-    },
-    onSuccess: () => {
-      onSuccess()
-      resetModalView()
-    }
+    onDismiss,
+    onSuccess
   })
 
   const renderDefaultPage = () => div({ style: { display: 'flex', flexDirection: 'column', flex: 1 } },
@@ -450,10 +426,7 @@ export const CloudEnvironmentModal = ({
       title: filterForTool ? `${filterForTool} Environment Details` : 'Cloud Environment Details',
       titleStyles: _.merge(viewMode === undefined ? {} : { display: 'none' }, { margin: '1.5rem 0 .5rem 1rem' }),
       width,
-      onDismiss: () => {
-        onDismiss()
-        resetModalView()
-      },
+      onDismiss,
       onPrevious: !!viewMode ? () => setViewMode(undefined) : undefined
     }),
     viewMode !== undefined && hr({ style: { borderTop: '1px solid', width: '100%', color: colors.accent() } }),
@@ -471,10 +444,8 @@ export const CloudEnvironmentModal = ({
 
   const modalProps = {
     'aria-labelledby': titleId, isOpen, width,
-    onDismiss: () => {
-      onDismiss()
-      resetModalView()
-    }
+    onDismiss,
+    onExited: resetView
   }
   return h(ModalDrawer, { ...modalProps, children: modalBody })
 }


### PR DESCRIPTION
# Description

When closing the CloudEnvironmentModal or AnalysisModal after navigating within the modal, the view would reset to the default screen before finishing the closing animation.


# Solution

Fixed CloudEnvironmentModal and AnalysisModal so that we delay the transition back to the default screen for the same duration as the closing animation.

The implementation takes advantage of the onExited callback within the Transition component. The resetView method will be passed in to the onExited callback, so the higher order components don't have to worry about animation timing.

# Testing

Ensured that current implementation of onDismiss doesn't break with the new method argument

Ensured the transition is smooth when closing a modal.

# Video

The first is current live app - the second is with my fix.

https://user-images.githubusercontent.com/11773357/179776157-e364fbcb-fd8c-40d0-a242-bf24b1bd055c.mov


