### PR TITLE
[SU-156] Add warning for shared billing project with one owner

### DIFF
--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -203,6 +203,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
   const { workspaces, refresh: refreshWorkspaces } = useWorkspaces()
 
   const [projectUsers, setProjectUsers] = useState(() => StateHistory.get().projectUsers || [])
+  const projectOwners = _.filter(_.flow(_.get('roles'), _.includes(billingRoles.owner)), projectUsers)
   const [addingUser, setAddingUser] = useState(false)
   const [editingUser, setEditingUser] = useState(false)
   const [deletingUser, setDeletingUser] = useState(false)
@@ -662,6 +663,28 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
         h(Link, {
           onClick: authorizeAndLoadAccounts
         }, ['View billing account'])
+      ]),
+      _.size(projectUsers) > 1 && _.size(projectOwners) === 1 && div({
+        style: {
+          display: 'flex',
+          alignItems: 'center',
+          margin: '1rem 1rem 0',
+          padding: '1rem',
+          border: `1px solid ${colors.warning()}`,
+          backgroundColor: colors.warning(0.15)
+        }
+      }, [
+        icon('warning-standard', { style: { color: colors.warning(), marginRight: '1ch' } }),
+        span(isOwner ? [
+          'You are the only owner of this shared billing project. Consider adding another owner to ensure someone is able to manage the billing project in case you lose access to your account. ',
+          h(Link, { href: 'https://support.terra.bio/hc/en-us/articles/360047235151-Best-practices-for-managing-shared-funding#h_01EFCZSY6K1CEEBJDH7BCG8RBK', ...Utils.newTabLinkProps }, [
+            'More information about managing shared billing projects.'
+          ])
+        ] : [
+          'This shared billing project has only one owner. Consider requesting ',
+          h(Link, { mailto: projectOwners[0].email }, [projectOwners[0].email]),
+          ' to add another owner to ensure someone is able to manage the billing project in case they lose access to their account.'
+        ])
       ]),
       h(SimpleTabBar, {
         'aria-label': 'project details',


### PR DESCRIPTION
If a Terra workspace or billing project with one owner and that person loses access to their account (leaves their organization, etc), the associated resources can no longer be fully managed through Terra. Due to security policy, Terra Support is generally unable to add owners to workspaces or billing projects. Thus, we want to encourage having multiple owners for workspaces and billing projects. This adds a warning to the billing project page if the billing project has multiple users but only one owner.

What the billing project owner sees:
<img width="1172" alt="Screen Shot 2022-07-15 at 10 25 23 AM" src="https://user-images.githubusercontent.com/1156625/179250338-6c9cd11b-3f59-4f75-a151-eb3e504ac1de.png">

What other users of the billing project see:
<img width="1169" alt="Screen Shot 2022-07-15 at 10 27 14 AM" src="https://user-images.githubusercontent.com/1156625/179250343-025aa50a-c5d6-436f-ad17-004d43f309fb.png">


