### PR TITLE
[WOR-418] Hardcode a large limit when fetching workspace resources

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1120,7 +1120,7 @@ const AzureStorage = signal => ({
   },
 
   details: async (workspaceId = {}) => {
-    const res = await fetchWorkspaceManager(`workspaces/v1/${workspaceId}/resources?stewardship=CONTROLLED`,
+    const res = await fetchWorkspaceManager(`workspaces/v1/${workspaceId}/resources?stewardship=CONTROLLED&limit=1000`,
       _.merge(authOpts(), { signal })
     )
     const data = await res.json()


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/WOR-418

By default WSM limits the number of workspaces fetched to 10, which can cause problems when we are rendering azure storage info and the needed container information isn't in the first 10 resources.

This PR adds a limit clause of 1000 as a short term fix to hopefully get all resources.

<!--
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Also, so if a screen recording [1] and/or screenshots would be a helpful way to communicate context, please consider including some in your PR description.
Thanks!

[1] https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac
--!>
