### PR TITLE
[SU-156] Restructure Collapse component

### DIFF
--- a/src/components/Collapse.js
+++ b/src/components/Collapse.js
@@ -56,7 +56,10 @@ const Collapse = ({ title, hover, tooltip, tooltipDelay, summaryStyle, detailsSt
         title
       ]),
       // zIndex: 2 lifts afterToggle controls above the absolutely positioned div in Link so that they can be clicked.
-      afterToggle && div({ style: { display: 'flex', flex: 1, margin: '0 1ch', zIndex: 2 } }, [afterToggle]),
+      // display: flex and flex: 1 causes this div to fill available space. This makes it easy to position afterToggle
+      // controls just after the summary text or at the right edge of the summary section. height: 0 prevents the unused
+      // space in this div from blocking clicks on the summary section.
+      afterToggle && div({ style: { display: 'flex', flex: 1, alignItems: 'center', height: 0, margin: '0 1ch', zIndex: 2 } }, [afterToggle]),
       titleFirst && angleIcon
     ]),
     isOpened && div({ id, style: detailsStyle }, [children])

--- a/src/components/Collapse.js
+++ b/src/components/Collapse.js
@@ -50,10 +50,12 @@ const Collapse = ({ title, hover, tooltip, tooltipDelay, summaryStyle, detailsSt
       }, [
         div({
           'aria-hidden': true,
+          // zIndex: 1 lifts this element above angleIcon, so that clicking on the icon will toggle the Collapse.
           style: { position: 'absolute', top: 0, left: 0, bottom: 0, right: 0, zIndex: 1 }
         }),
         title
       ]),
+      // zIndex: 2 lifts afterToggle controls above the absolutely positioned div in Link so that they can be clicked.
       afterToggle && div({ style: { display: 'flex', flex: 1, margin: '0 1ch', zIndex: 2 } }, [afterToggle]),
       titleFirst && angleIcon
     ]),

--- a/src/components/Collapse.js
+++ b/src/components/Collapse.js
@@ -3,13 +3,20 @@ import { useEffect, useRef, useState } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
 import { Link } from 'src/components/common'
 import { icon } from 'src/components/icons'
+import colors from 'src/libs/colors'
 import { useUniqueId } from 'src/libs/react-utils'
 import * as Style from 'src/libs/style'
 
 
-const Collapse = ({ title, buttonStyle, buttonProps = {}, summaryStyle, detailsStyle, initialOpenState, children, titleFirst, afterToggle, onFirstOpen = () => {}, noTitleWrap, ...props }) => {
+const Collapse = ({ title, hover, tooltip, tooltipDelay, summaryStyle, detailsStyle, initialOpenState, children, titleFirst, afterToggle, onFirstOpen = () => {}, noTitleWrap, ...props }) => {
   const [isOpened, setIsOpened] = useState(initialOpenState)
-  const angleIcon = icon(isOpened ? 'angle-down' : 'angle-right', { style: { marginRight: '0.25rem', flexShrink: 0 } })
+  const angleIcon = icon(isOpened ? 'angle-down' : 'angle-right', {
+    style: {
+      flexShrink: 0,
+      marginLeft: titleFirst ? 'auto' : undefined,
+      marginRight: titleFirst ? undefined : '0.25rem'
+    }
+  })
 
   const firstOpenRef = useRef(_.once(onFirstOpen))
   const id = useUniqueId()
@@ -21,19 +28,34 @@ const Collapse = ({ title, buttonStyle, buttonProps = {}, summaryStyle, detailsS
   }, [firstOpenRef, isOpened])
 
   return div(props, [
-    div({ style: { display: 'flex', alignItems: 'center', ...summaryStyle } }, [
+    div({
+      style: {
+        position: 'relative',
+        display: 'flex', alignItems: 'center',
+        ...summaryStyle
+      }
+    }, [
+      !titleFirst && angleIcon,
       h(Link, {
         'aria-expanded': isOpened,
         'aria-controls': isOpened ? id : undefined,
-        style: { display: 'flex', flex: 1, alignItems: 'center', marginBottom: '0.5rem', ...buttonStyle },
+        style: {
+          color: colors.dark(),
+          ...(noTitleWrap ? Style.noWrapEllipsis : {})
+        },
         onClick: () => setIsOpened(!isOpened),
-        ...buttonProps
+        hover,
+        tooltip,
+        tooltipDelay
       }, [
-        titleFirst && div({ style: { flexGrow: 1, ...(noTitleWrap ? Style.noWrapEllipsis : {}) } }, [title]),
-        angleIcon,
-        !titleFirst && title
+        div({
+          'aria-hidden': true,
+          style: { position: 'absolute', top: 0, left: 0, bottom: 0, right: 0, zIndex: 1 }
+        }),
+        title
       ]),
-      afterToggle
+      afterToggle && div({ style: { display: 'flex', flex: 1, margin: '0 1ch', zIndex: 2 } }, [afterToggle]),
+      titleFirst && angleIcon
     ]),
     isOpened && div({ id, style: detailsStyle }, [children])
   ])

--- a/src/components/UriViewer.js
+++ b/src/components/UriViewer.js
@@ -214,7 +214,7 @@ const UriViewer = _.flow(
           'Error loading data. This file does not exist or you do not have permission to view it.'
         ]),
         h(Collapse, { title: 'Details' }, [
-          div({ style: { whiteSpace: 'pre-wrap', fontFamily: 'monospace', overflowWrap: 'break-word' } }, [
+          div({ style: { marginTop: '0.5rem', whiteSpace: 'pre-wrap', fontFamily: 'monospace', overflowWrap: 'break-word' } }, [
             JSON.stringify(loadingError, null, 2)
           ])
         ])
@@ -251,7 +251,8 @@ const UriViewer = _.flow(
         ]),
         (timeCreated || updated) && h(Collapse, {
           title: 'More Information',
-          style: { marginTop: '2rem' }
+          style: { marginTop: '2rem' },
+          summaryStyle: { marginBottom: '0.5rem' }
         }, [
           timeCreated && els.cell([
             els.label('Created'),

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -1285,14 +1285,9 @@ export const AddEntityModal = ({ workspaceId: { namespace, name }, entityType, a
         }
       }, [
         h(Collapse, {
-          title: span({ style: { ...Style.noWrapEllipsis } }, [
-            `${attributeName}: ${entityAttributeText(attributeValues[attributeName], false)}`
-          ]),
-          buttonStyle: {
-            maxWidth: '100%',
-            padding: '0.5rem 0',
-            marginBottom: 0
-          }
+          title: `${attributeName}: ${entityAttributeText(attributeValues[attributeName], false)}`,
+          noTitleWrap: true,
+          summaryStyle: { margin: '0.5rem 0' }
         }, [
           div({ style: { margin: '0.5rem 0' } }, [
             h(AttributeInput, {

--- a/src/libs/style.js
+++ b/src/libs/style.js
@@ -148,7 +148,7 @@ export const dashboard = {
   },
   collapsibleHeader: {
     ...elements.sectionHeader, color: colors.accent(), textTransform: 'uppercase',
-    padding: '0.5rem 0.5rem 0 0.5rem', display: 'flex', fontSize: 14
+    padding: '0.5rem', display: 'flex', fontSize: 14
   },
   infoTile: {
     backgroundColor: colors.dark(0.15), color: 'black',

--- a/src/pages/ImportData.js
+++ b/src/pages/ImportData.js
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp'
 import { Fragment, useState } from 'react'
-import { div, h, h2, img, li, p, strong, ul } from 'react-hyperscript-helpers'
+import { div, h, h2, img, li, p, span, strong, ul } from 'react-hyperscript-helpers'
 import Collapse from 'src/components/Collapse'
 import { backgroundLogo, ButtonPrimary, ButtonSecondary, Clickable, IdContainer, RadioButton, spinnerOverlay } from 'src/components/common'
 import { notifyDataImportProgress } from 'src/components/data/data-utils'
@@ -270,10 +270,9 @@ const ImportData = () => {
                       checked: isSelected,
                       onChange: () => setSelectedTemplateWorkspaceKey({ namespace, name }),
                       text: h(Collapse, {
-                        buttonStyle: { color: colors.dark(), fontWeight: 600 },
                         style: { fontSize: 14, marginLeft: '0.5rem' },
-                        title: h(Fragment, [
-                          name,
+                        title: span({ style: { display: 'flex', alignItems: 'center' } }, [
+                          span({ style: { fontWeight: 600 } }, [name]),
                           hasNotebooks && img({ src: jupyterLogo, style: { height: 23, width: 23, marginLeft: '0.5rem' } }),
                           hasWorkflows &&
                             wdlIcon({ style: { height: 23, width: 23, marginLeft: '0.5rem', borderRadius: 3, padding: '8px 4px 7px 4px' } })

--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -165,19 +165,19 @@ const NihLink = ({ nihToken }) => {
       )
     ]),
     isLinked && div({ style: styles.idLink.linkContentBottom }, [
-      h3({ style: { fontWeight: 500, marginTop: 0 } }, ['Resources']),
+      h3({ style: { fontWeight: 500, margin: 0 } }, ['Resources']),
       !_.isEmpty(authorizedDatasets) && h(Collapse, {
-        title: div({ style: { marginRight: '0.5rem' } }, ['Authorized to access']), titleFirst: true,
-        buttonStyle: { flex: '0 0 auto' }
+        style: { marginTop: '1rem' },
+        title: 'Authorized to access', titleFirst: true
       }, [
-        div({ style: { marginBottom: _.isEmpty(unauthorizedDatasets) ? 0 : '1rem' } }, [
+        div({ style: { marginTop: '0.5rem' } }, [
           _.map(({ name }) => div({ key: name, style: { lineHeight: '24px' } }, [name]), authorizedDatasets)
         ])
       ]),
       !_.isEmpty(unauthorizedDatasets) && h(Collapse, {
-        title: div({ style: { marginRight: '0.5rem' } }, ['Not authorized']), titleFirst: true,
-        buttonStyle: { flex: '0 0 auto' },
-        afterToggle: h(InfoBox, { style: { marginBottom: '0.5rem' } }, [
+        style: { marginTop: '1rem' },
+        title: 'Not authorized', titleFirst: true,
+        afterToggle: h(InfoBox, [
           'Your account was linked, but you are not authorized to view these controlled datasets. ',
           'If you think you should have access, please ',
           h(Link, {
@@ -190,7 +190,9 @@ const NihLink = ({ nihToken }) => {
           '.'
         ])
       }, [
-        _.map(({ name }) => div({ key: name, style: { lineHeight: '24px' } }, [name]), unauthorizedDatasets)
+        div({ style: { marginTop: '0.5rem' } }, [
+          _.map(({ name }) => div({ key: name, style: { lineHeight: '24px' } }, [name]), unauthorizedDatasets)
+        ])
       ])
     ]),
     isConfirmUnlinkModalOpen && h(Modal, {

--- a/src/pages/billing/List.js
+++ b/src/pages/billing/List.js
@@ -147,10 +147,10 @@ const noBillingMessage = onClick => div({ style: { fontSize: 20, margin: '2rem' 
 ])
 
 const BillingProjectSubheader = ({ title, children }) => h(Collapse, {
-  title,
+  title: span({ style: { fontWeight: 'bold' } }, [title]),
   initialOpenState: true,
   titleFirst: true,
-  buttonStyle: { padding: '1rem 1rem 1rem 2rem', color: colors.dark(), fontWeight: 'bold' }
+  summaryStyle: { padding: '1rem 1rem 1rem 2rem' }
 }, [children])
 
 const NewBillingProjectModal = ({ onSuccess, onDismiss, billingAccounts, loadAccounts }) => {

--- a/src/pages/library/common.js
+++ b/src/pages/library/common.js
@@ -36,7 +36,7 @@ const styles = {
     navSection: {
       alignItems: 'center', flex: 'none', padding: '0.5rem 0'
     },
-    title: { color: colors.dark(), fontWeight: 700, borderBottom: `1px solid ${colors.dark(0.3)}`, paddingBottom: '0.75rem' }
+    title: { borderBottom: `1px solid ${colors.dark(0.3)}`, paddingBottom: '0.75rem', marginBottom: '1rem' }
   },
   pill: highlight => ({
     width: '4.5rem', padding: '0.25rem', fontWeight: 500, textAlign: 'center',
@@ -284,9 +284,12 @@ const Sidebar = ({ onSectionFilter, onTagFilter, sections, selectedSections, sel
         h(Collapse, {
           key: name,
           style: styles.nav.navSection,
-          buttonStyle: styles.nav.title,
+          summaryStyle: styles.nav.title,
           titleFirst: true, initialOpenState: true,
-          title: h(Fragment, [name, span({ style: { marginLeft: '0.5rem', fontWeight: 400 } }, [`(${_.size(labels)})`])])
+          title: h(Fragment, [
+            span({ style: { fontWeight: 700 } }, [name]),
+            span({ style: { marginLeft: '0.5rem', fontWeight: 400 } }, [`(${_.size(labels)})`])
+          ])
         }, [
           h(FilterSection, { name, onTagFilter, selectedTags, labelRenderer, listDataByTag, labels, filteredData })
         ])

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -116,6 +116,7 @@ const RightBoxSection = ({ title, info, initialOpenState, onClick, children }) =
     div({ style: Style.dashboard.rightBoxContainer }, [
       h(Collapse, {
         title: h3({ style: Style.dashboard.collapsibleHeader }, [title, info]),
+        summaryStyle: { color: colors.accent() },
         initialOpenState,
         titleFirst: true,
         onClick

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -202,26 +202,20 @@ const DataTypeSection = ({ title, error, retryFunction, children }) => {
       style: {
         margin: 0,
         fontSize: 16,
+        color: colors.dark(),
         textTransform: 'uppercase'
       }
     }, title),
     titleFirst: true,
     initialOpenState: true,
     summaryStyle: {
-      paddingRight: error ? '1rem' : 0,
+      padding: `1.125rem 1.5rem`,
       borderBottom: `0.5px solid ${colors.dark(0.2)}`,
       backgroundColor: colors.light(0.4),
       fontSize: 16
     },
-    buttonProps: {
-      hover: {
-        color: colors.dark(0.9)
-      }
-    },
-    buttonStyle: {
-      padding: `1.125rem ${error ? '1rem' : '1.5rem'} 1.25rem 1.5rem`,
-      marginBottom: 0,
-      color: colors.dark()
+    hover: {
+      color: colors.dark(0.9)
     },
     afterToggle: error && h(Link, {
       onClick: retryFunction,
@@ -649,13 +643,15 @@ const WorkspaceData = _.flow(
                 return h(Collapse, {
                   key: snapshotName,
                   titleFirst: true,
-                  buttonStyle: { height: 50, color: colors.dark(), fontWeight: 600, marginBottom: 0, overflow: 'hidden' },
-                  buttonProps: { tooltip: snapshotName, tooltipDelay: 250 },
+                  noTitleWrap: true,
+                  summaryStyle: { height: 50, paddingRight: '0.5rem', fontWeight: 600 },
+                  tooltip: snapshotName,
+                  tooltipDelay: 250,
                   style: { fontSize: 14, paddingLeft: '1.5rem', borderBottom: `1px solid ${colors.dark(0.2)}` },
-                  title: snapshotName, noTitleWrap: true,
+                  title: snapshotName,
                   role: 'listitem',
                   afterToggle: h(Link, {
-                    style: { marginRight: '0.5rem' },
+                    style: { marginLeft: 'auto' },
                     tooltip: 'Snapshot Info',
                     onClick: () => {
                       setSelectedDataType([snapshotName])


### PR DESCRIPTION
I want to add a warning icon with a tooltip to a collapsible section in the workspace dashboard. Something like this:

<img width="450" alt="goal" src="https://user-images.githubusercontent.com/1156625/179526497-126541ea-b272-41d9-b5ee-50f3599d0675.png">

However, with the current structure of the Collapse component, this would require adding it to the Collapse's title and would result in an accessibility issue (nested interactive elements) because the tooltip trigger would be inside the Collapse's button element.

Currently, the button element covers entire "summary" section of the Collapse.

<img width="911" alt="structure" src="https://user-images.githubusercontent.com/1156625/179526734-34e8a2f3-25c2-4b62-80db-07c0ead6559e.png">

Currently the only option to add interactive elements is to place them after the button, as in the Data tab sidebar.

<img width="280" alt="alternative" src="https://user-images.githubusercontent.com/1156625/179526983-99016015-9134-4b16-b2ff-83243b834a3c.png">


This restructures Collapse's summary section so that the button no longer covers the entire width. It uses an absolutely positioned child element to make it so that clicking anywhere in the summary section still toggles the Collapse. This is based on the "Accessible Card" in https://kittygiraudel.com/2022/04/02/accessible-cards/.

It also moves the `afterToggle` prop from after the icon / at the far right of the summary section to after the button.

<img width="919" alt="new_structure" src="https://user-images.githubusercontent.com/1156625/179527057-442a8f9f-9866-4e10-a19e-97adcfb8b63d.png">

This does not add the icon/tooltip to the Owners section in the workspace dashboard.


Collapse is used several places in the app and with several different styles. Many of those had to be adapted for the new structure.

## Workflow dashboard
Before
<img width="451" alt="workspace dashboard before" src="https://user-images.githubusercontent.com/1156625/179527452-bc61765d-f50c-4468-9fcc-51f1162105b8.png">
After
<img width="460" alt="workspace dashboard after" src="https://user-images.githubusercontent.com/1156625/179527454-0a3308ab-6b36-4dbd-b5f4-71989c4cd30b.png">

## Data tab sidebar
Before
<img width="281" alt="data sidebar before" src="https://user-images.githubusercontent.com/1156625/179527457-72da2036-31f9-49da-87b8-42a25ce2f476.png">
After
<img width="285" alt="data sidebar after" src="https://user-images.githubusercontent.com/1156625/179527458-bc5e605c-d84f-42cc-b364-d8be7bace3e9.png">

## Snapshots
Reversed the order of info button and arrow icon.

Before
<img width="284" alt="snapshot before" src="https://user-images.githubusercontent.com/1156625/179527461-8ef85b33-f301-47cc-8be0-58f10bfaacf9.png">
After
<img width="281" alt="snapshot after" src="https://user-images.githubusercontent.com/1156625/179527463-8ae1647f-75ff-4744-8255-723273bbfaa1.png">

## URL viewer
Before
<img width="454" alt="uri viewer before" src="https://user-images.githubusercontent.com/1156625/179527478-cfee6095-6b89-45fc-8fb4-bc35944f5f60.png">
After
<img width="455" alt="add row after" src="https://user-images.githubusercontent.com/1156625/179527481-7394c17e-e55a-4643-9b05-1aef2af409fb.png">

## Add row modal
Before
<img width="456" alt="add row before" src="https://user-images.githubusercontent.com/1156625/179527484-7dd4d1aa-cc93-4978-aae2-7ea56fb29161.png">
After
<img width="451" alt="uri viewer after" src="https://user-images.githubusercontent.com/1156625/179527487-3df0e33f-c8c5-4b24-8f41-70ef6acb7783.png">

## Workflow dashboard
Before
<img width="1436" alt="workflow dashboard before" src="https://user-images.githubusercontent.com/1156625/179527488-19dbb784-52e8-490a-8287-c629971a45ae.png">
After
<img width="1441" alt="workflow dashboard after" src="https://user-images.githubusercontent.com/1156625/179527489-f02e731a-e373-4367-bbc0-d422eaf23966.png">

## Profile
Before
<img width="444" alt="profile before" src="https://user-images.githubusercontent.com/1156625/179527519-b3554305-5492-4570-a4ff-2d7b49b6270d.png">
After
<img width="456" alt="profile after" src="https://user-images.githubusercontent.com/1156625/179527521-f635dd5a-853b-4876-a83c-4f6c0df448aa.png">

## Billing projects
Before
<img width="335" alt="billing projects before" src="https://user-images.githubusercontent.com/1156625/179527525-4feb73d8-9c80-436d-8c16-af6dbd406003.png">
After
<img width="328" alt="billing projects after" src="https://user-images.githubusercontent.com/1156625/179527527-426aaca1-db26-4fa1-b43b-f52f46635455.png">

## Featured workspaces
Before
<img width="325" alt="feature workspaces before" src="https://user-images.githubusercontent.com/1156625/179527528-b48112a4-9bc9-4f9b-8759-27e107344f92.png">
After
<img width="329" alt="featured workspaces after" src="https://user-images.githubusercontent.com/1156625/179527530-8712c607-f7e4-4370-a7c0-52a33b86b04c.png">



