### PR TITLE
WOR-264 De-emphasize Other Costs

### DIFF
--- a/integration-tests/tests/billing-projects.js
+++ b/integration-tests/tests/billing-projects.js
@@ -204,12 +204,11 @@ const testBillingSpendReportFn = withUserToken(async ({ page, testUrl, token }) 
   await billingPage.assertText('Total spend$1,110.00')
   await billingPage.assertText('Total compute$999.00')
   await billingPage.assertText('Total storage$22.00')
-  await billingPage.assertText('Total other$89.00')
+  await billingPage.assertText('Total spend includes $89.00 in other infrastructure or query costs related to the general operations of Terra.')
   // Check that chart loaded, and workspaces are sorted by cost.
   await billingPage.assertText('Spend By Workspace')
   // Verify all series values of the most expensive workspace.
   await billingPage.assertChartValue(1, 'Most Expensive Workspace', 'Compute', '$900.00')
-  await billingPage.assertChartValue(1, 'Most Expensive Workspace', 'Other', '$80.00')
   await billingPage.assertChartValue(1, 'Most Expensive Workspace', 'Storage', '$20.00')
   // Spot-check other 2 workspaces.
   await billingPage.assertChartValue(2, 'Second Most Expensive Workspace', 'Compute', '$90.00')

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -304,7 +304,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
       div(
         {
           style: { flex: 'none', padding: '0.625rem 1.25rem' },
-          'aria-live': projectCost !== null ? 'polite' : 'off',
+          'aria-live': isProjectCostReady ? 'polite' : 'off',
           'aria-atomic': true
         },
         [

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -375,13 +375,13 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
         )
       ])
     ]),
-    [spendReportKey]: div({ style: { display: 'grid', rowGap: '1.66rem' } }, [
+    [spendReportKey]: div({ style: { display: 'grid', rowGap: '0.5rem' } }, [
       div(
         {
           style: {
             display: 'grid',
             gridTemplateColumns: 'repeat(3, minmax(max-content, 1fr))',
-            rowGap: '1.25rem',
+            rowGap: '1.66rem',
             columnGap: '1.25rem'
           }
         }, [
@@ -415,7 +415,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
       h(OtherMessaging, { cost: isProjectCostReady ? projectCost['other'] : null }),
       costPerWorkspace.numWorkspaces > 0 && div(
         {
-          style: { minWidth: 500 }
+          style: { minWidth: 500, marginTop: '1rem' }
         }, [ // Set minWidth so chart will shrink on resize
           h(Suspense, { fallback: null }, [h(LazyChart, { options: spendChartOptions })])
         ]

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -195,6 +195,7 @@ const groupByBillingAccountStatus = (billingProject, workspaces) => {
 const LazyChart = lazy(() => import('src/components/Chart'))
 const maxWorkspacesInChart = 10
 const spendReportKey = 'spend report'
+const otherCostsDomId = 'billing-other-costs'
 const otherMessaging = cost => `Total spend includes ${cost} in other infrastructure or query costs related to the general operations of Terra.`
 
 const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProject, isAlphaSpendReportUser, isOwner, reloadBillingProject }) => {
@@ -375,13 +376,14 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
           ...(_.map(name => CostCard({
             title: `Total ${name}`,
             amount: (projectCost === null ? '...' : projectCost[name]),
-            showAsterisk: name === 'spend'
+            showAsterisk: name === 'spend',
+            'aria-describedby': name === 'spend' ? otherCostsDomId : undefined
           }),
           ['spend', 'compute', 'storage'])
           )
         ]
       ),
-      div({ style: { gridRowStart: 2 }, 'aria-live': projectCost !== null ? 'polite' : 'off' }, [
+      div({ style: { gridRowStart: 2 }, id: otherCostsDomId }, [
         span(['*']),
         ' ',
         otherMessaging(projectCost === null ? '...' : projectCost['other'])

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -2,7 +2,7 @@ import { subDays } from 'date-fns/fp'
 import _ from 'lodash/fp'
 import * as qs from 'qs'
 import { Fragment, lazy, Suspense, useEffect, useMemo, useState } from 'react'
-import { div, h, h3, span } from 'react-hyperscript-helpers'
+import { div, h, span } from 'react-hyperscript-helpers'
 import { absoluteSpinnerOverlay, ButtonPrimary, HeaderRenderer, IdContainer, Link, Select } from 'src/components/common'
 import { DeleteUserModal, EditUserModal, MemberCard, MemberCardHeaders, NewUserCard, NewUserModal } from 'src/components/group-common'
 import { icon } from 'src/components/icons'
@@ -301,7 +301,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
       }
     }, [
       div({ style: { flex: 'none', padding: '0.625rem 1.25rem' } }, [
-        h3({ style: { fontSize: 16, color: colors.accent(), margin: '0.25rem 0.0rem', fontWeight: 'normal' } }, title),
+        div({ style: { fontSize: 16, color: colors.accent(), margin: '0.25rem 0.0rem', fontWeight: 'normal' } }, [title]),
         div({ style: { fontSize: 32, height: 40, fontWeight: 'bold', gridRowStart: '2' } }, [
           amount,
           (!!showAsterisk && isProjectCostReady) ? span(
@@ -422,14 +422,14 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
               )
             ]
           ),
-          h(OtherMessaging, { cost: isProjectCostReady ? projectCost['other'] : null }),
-          isProjectCostReady && costPerWorkspace.numWorkspaces > 0 && div(
-            {
-              style: { minWidth: 500 }
-            }, [ // Set minWidth so chart will shrink on resize
-              h(Suspense, { fallback: null }, [h(LazyChart, { options: spendChartOptions })])
-            ]
-          )
+          h(OtherMessaging, { cost: isProjectCostReady ? projectCost['other'] : null })
+        ]
+      ),
+      isProjectCostReady && costPerWorkspace.numWorkspaces > 0 && div(
+        {
+          style: { minWidth: 500 }
+        }, [ // Set minWidth so chart will shrink on resize
+          h(Suspense, { fallback: null }, [h(LazyChart, { options: spendChartOptions })])
         ]
       )
     ])

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -200,7 +200,7 @@ const OtherMessaging = ({ cost }) => {
   const msg = cost !== null ?
     `Total spend includes ${cost} in other infrastructure or query costs related to the general operations of Terra.` :
     'Total spend includes infrastructure or query costs related to the general operations of Terra'
-  return div([
+  return div({ 'aria-live': cost !== null ? 'polite' : 'off', 'aria-atomic': true }, [
     span({ 'aria-hidden': true }, ['*']),
     '',
     msg
@@ -297,22 +297,30 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
         ...Style.elements.card.container,
         backgroundColor: 'white',
         padding: undefined,
-        boxShadow: undefined
+        boxShadow: undefined,
+        gridRowStart: '2'
       }
     }, [
-      div({ style: { flex: 'none', padding: '0.625rem 1.25rem' } }, [
-        div({ style: { fontSize: 16, color: colors.accent(), margin: '0.25rem 0.0rem', fontWeight: 'normal' } }, [title]),
-        div({ style: { fontSize: 32, height: 40, fontWeight: 'bold', gridRowStart: '2' } }, [
-          amount,
-          (!!showAsterisk && isProjectCostReady) ? span(
-            {
-              style: { fontSize: 16, fontWeight: 'normal', verticalAlign: 'super' },
-              'aria-hidden': true
-            },
-            ['*']
-          ) : null
-        ])
-      ])
+      div(
+        {
+          style: { flex: 'none', padding: '0.625rem 1.25rem' },
+          'aria-live': projectCost !== null ? 'polite' : 'off',
+          'aria-atomic': true
+        },
+        [
+          div({ style: { fontSize: 16, color: colors.accent(), margin: '0.25rem 0.0rem', fontWeight: 'normal' } }, [title]),
+          div({ style: { fontSize: 32, height: 40, fontWeight: 'bold', gridRowStart: '2' } }, [
+            amount,
+            (!!showAsterisk && isProjectCostReady) ? span(
+              {
+                style: { fontSize: 16, fontWeight: 'normal', verticalAlign: 'super' },
+                'aria-hidden': true
+              },
+              ['*']
+            ) : null
+          ])
+        ]
+      )
     ])
   }
 
@@ -393,39 +401,19 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
                 }
               })
             ])])
-          ])
+          ]),
+          ...(_.map(name => CostCard({
+            title: `Total ${name}`,
+            amount: (!isProjectCostReady ? '...' : projectCost[name]),
+            showAsterisk: name === 'spend',
+            key: name
+          }),
+          ['spend', 'compute', 'storage'])
+          )
         ]
       ),
-      div(
-        {
-          style: { display: 'grid', rowGap: '1.25rem' },
-          'aria-atomic': true,
-          'aria-live': 'polite',
-          'aria-busy': !isProjectCostReady
-        }, [
-          div(
-            {
-              style: {
-                display: 'grid',
-                gridTemplateColumns: 'repeat(3, minmax(max-content, 1fr))',
-                columnGap: '1.25rem'
-              }
-            },
-            [
-              ...(_.map(name => h(CostCard, {
-                title: `Total ${name}`,
-                amount: (!isProjectCostReady ? '...' : projectCost[name]),
-                showAsterisk: name === 'spend',
-                key: name
-              }),
-              ['spend', 'compute', 'storage'])
-              )
-            ]
-          ),
-          h(OtherMessaging, { cost: isProjectCostReady ? projectCost['other'] : null })
-        ]
-      ),
-      isProjectCostReady && costPerWorkspace.numWorkspaces > 0 && div(
+      h(OtherMessaging, { cost: isProjectCostReady ? projectCost['other'] : null }),
+      costPerWorkspace.numWorkspaces > 0 && div(
         {
           style: { minWidth: 500 }
         }, [ // Set minWidth so chart will shrink on resize

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -396,8 +396,10 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
                   value: days
                 }), [7, 30, 90]),
                 onChange: ({ value: selectedDays }) => {
-                  setSpendReportLengthInDays(selectedDays)
-                  setProjectCost(null)
+                  if (selectedDays !== spendReportLengthInDays) {
+                    setSpendReportLengthInDays(selectedDays)
+                    setProjectCost(null)
+                  }
                 }
               })
             ])])

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -404,7 +404,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
               })
             ])])
           ]),
-          ...(_.map(name => CostCard({
+          ...(_.map(name => h(CostCard, {
             title: `Total ${name}`,
             amount: (!isProjectCostReady ? '...' : projectCost[name]),
             showAsterisk: name === 'spend',

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -196,6 +196,40 @@ const LazyChart = lazy(() => import('src/components/Chart'))
 const maxWorkspacesInChart = 10
 const spendReportKey = 'spend report'
 
+const CostCard = ({ title, amount, isProjectCostReady, showAsterisk, ...props }) => {
+  return div({
+    ...props,
+    style: {
+      ...Style.elements.card.container,
+      backgroundColor: 'white',
+      padding: undefined,
+      boxShadow: undefined,
+      gridRowStart: '2'
+    }
+  }, [
+    div(
+      {
+        style: { flex: 'none', padding: '0.625rem 1.25rem' },
+        'aria-live': isProjectCostReady ? 'polite' : 'off',
+        'aria-atomic': true
+      },
+      [
+        div({ style: { fontSize: 16, color: colors.accent(), margin: '0.25rem 0.0rem', fontWeight: 'normal' } }, [title]),
+        div({ style: { fontSize: 32, height: 40, fontWeight: 'bold', gridRowStart: '2' } }, [
+          amount,
+          (!!showAsterisk && isProjectCostReady) ? span(
+            {
+              style: { fontSize: 16, fontWeight: 'normal', verticalAlign: 'super' },
+              'aria-hidden': true
+            },
+            ['*']
+          ) : null
+        ])
+      ]
+    )
+  ])
+}
+
 const OtherMessaging = ({ cost }) => {
   const msg = cost !== null ?
     `Total spend includes ${cost} in other infrastructure or query costs related to the general operations of Terra.` :
@@ -290,40 +324,6 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
 
   const isProjectCostReady = projectCost !== null
 
-  const CostCard = ({ title, amount, showAsterisk, ...props }) => {
-    return div({
-      ...props,
-      style: {
-        ...Style.elements.card.container,
-        backgroundColor: 'white',
-        padding: undefined,
-        boxShadow: undefined,
-        gridRowStart: '2'
-      }
-    }, [
-      div(
-        {
-          style: { flex: 'none', padding: '0.625rem 1.25rem' },
-          'aria-live': isProjectCostReady ? 'polite' : 'off',
-          'aria-atomic': true
-        },
-        [
-          div({ style: { fontSize: 16, color: colors.accent(), margin: '0.25rem 0.0rem', fontWeight: 'normal' } }, [title]),
-          div({ style: { fontSize: 32, height: 40, fontWeight: 'bold', gridRowStart: '2' } }, [
-            amount,
-            (!!showAsterisk && isProjectCostReady) ? span(
-              {
-                style: { fontSize: 16, fontWeight: 'normal', verticalAlign: 'super' },
-                'aria-hidden': true
-              },
-              ['*']
-            ) : null
-          ])
-        ]
-      )
-    ])
-  }
-
   const groups = groupByBillingAccountStatus(billingProject, workspacesInProject)
   const billingAccountsOutOfDate = !(_.isEmpty(groups.error) && _.isEmpty(groups.updating))
   const getBillingAccountStatus = workspace => _.findKey(g => g.has(workspace), groups)
@@ -407,6 +407,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
           ...(_.map(name => h(CostCard, {
             title: `Total ${name}`,
             amount: (!isProjectCostReady ? '...' : projectCost[name]),
+            isProjectCostReady,
             showAsterisk: name === 'spend',
             key: name
           }),


### PR DESCRIPTION
- Billing report now shows "other costs" in a footnote, and removes the card, leaving only 3 cost cards in summary area.
- updated end2end integration test.
- visual testing done locally.
---

aria-live region fixes
- screen reader announcement on report render is now consistent with content being announced in order.
- changed over to a single larger aria-live region for the entire report content, which is marked with aria-busy when loading to cut down on screen-reader noise.
- promoted a couple of sub-controls to be full React.FC components instead of just rendering sub-routines.  This looks to enable React rendering optimizations better, and help a great deal with removing some screen reader repetition of the entire live region content for a single report refresh.
- KNOWN ISSUE: still seeing initial announcement of the cost card headers place-holder content on initial load and hard tab switches (like switching projects.  I suspect this may be related to aria-controls prop not being implemented in our Tabs control/usage.  I will file a seperate ticket for that fix.
---
![image](https://user-images.githubusercontent.com/108079391/179776847-a6695f8c-feaf-4c45-add5-c43ca0f3e98f.png)

