### PR TITLE
[SU-164] Improve IGV file selection

### DIFF
--- a/src/components/IGVFileSelector.js
+++ b/src/components/IGVFileSelector.js
@@ -4,6 +4,7 @@ import { div, h } from 'react-hyperscript-helpers'
 import { AutoSizer, List } from 'react-virtualized'
 import ButtonBar from 'src/components/ButtonBar'
 import { ButtonPrimary, LabeledCheckbox, Link } from 'src/components/common'
+import { parseGsUri } from 'src/components/data/data-utils'
 import IGVReferenceSelector, { addIgvRecentlyUsedReference, defaultIgvReference } from 'src/components/IGVReferenceSelector'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
@@ -21,7 +22,7 @@ export const getValidIgvFiles = values => {
   return _.flatMap(value => {
     const possibleFile = /(.+)\.([^.]+)$/.exec(value)
 
-    if (!possibleFile) {
+    if (_.isEmpty(parseGsUri(value)) || !possibleFile) {
       return []
     }
 

--- a/src/components/IGVFileSelector.js
+++ b/src/components/IGVFileSelector.js
@@ -12,9 +12,36 @@ import * as Utils from 'src/libs/utils'
 const getStrings = v => {
   return Utils.cond(
     [_.isString(v), () => [v]],
-    [!!v?.items, () => _.map(getStrings, v.items)],
+    [!!v?.items, () => _.flatMap(getStrings, v.items)],
     () => []
   )
+}
+
+export const getValidIgvFiles = values => {
+  return _.flatMap(value => {
+    const possibleFile = /(.+)\.([^.]+)$/.exec(value)
+
+    if (!possibleFile) {
+      return []
+    }
+
+    const [, base, extension] = possibleFile
+
+    const matchingIndexFilePath = Utils.switchCase(extension,
+      ['cram', () => _.find(v => _.includes(v, [`${base}.crai`, `${base}.cram.crai`]), values)],
+      ['bam', () => _.find(v => _.includes(v, [`${base}.bai`, `${base}.bam.bai`]), values)],
+      ['vcf', () => _.find(v => _.includes(v, [`${base}.idx`, `${base}.vcf.idx`, `${base}.tbi`, `${base}.vcf.tbi`]), values)],
+      ['bed', () => false],
+      [Utils.DEFAULT, () => undefined]
+    )
+
+    return matchingIndexFilePath !== undefined ? [{ filePath: value, indexFilePath: matchingIndexFilePath }] : []
+  }, values)
+}
+
+export const getValidIgvFilesFromAttributeValues = attributeValues => {
+  const allAttributeStrings = _.flatMap(getStrings, attributeValues)
+  return getValidIgvFiles(allAttributeStrings)
 }
 
 const IGVFileSelector = ({ selectedEntities, onSuccess }) => {
@@ -22,28 +49,8 @@ const IGVFileSelector = ({ selectedEntities, onSuccess }) => {
   const isRefGenomeValid = Boolean(_.get('genome', refGenome) || _.get('reference.fastaURL', refGenome))
 
   const [selections, setSelections] = useState(() => {
-    const allAttributeStrings = _.flow(
-      _.flatMap(row => _.flatMap(getStrings, row.attributes)),
-      _.uniq
-    )(selectedEntities)
-
-    return _.flatMap(filePath => {
-      const possibleFile = /(.+)\.([^.]+)$/.exec(filePath)
-
-      if (!possibleFile) return []
-
-      const [, base, extension] = possibleFile
-
-      const matchingIndexFilePath = Utils.switchCase(extension,
-        ['cram', () => _.find(v => _.includes(v, [`${base}.crai`, `${base}.cram.crai`]), allAttributeStrings)],
-        ['bam', () => _.find(v => _.includes(v, [`${base}.bai`, `${base}.bam.bai`]), allAttributeStrings)],
-        ['vcf', () => _.find(v => _.includes(v, [`${base}.idx`, `${base}.vcf.idx`, `${base}.tbi`, `${base}.vcf.tbi`]), allAttributeStrings)],
-        ['bed', () => false],
-        [Utils.DEFAULT, () => undefined]
-      )
-
-      return matchingIndexFilePath !== undefined ? [{ filePath, indexFilePath: matchingIndexFilePath }] : []
-    }, allAttributeStrings)
+    const allAttributeValues = _.flatMap(_.flow(_.get('attributes'), _.values), selectedEntities)
+    return getValidIgvFilesFromAttributeValues(allAttributeValues)
   })
 
   const toggleSelected = index => setSelections(_.update([index, 'isSelected'], v => !v))

--- a/src/components/IGVFileSelector.test.js
+++ b/src/components/IGVFileSelector.test.js
@@ -81,6 +81,18 @@ describe('getValidIgvFiles', () => {
       }
     ])
   })
+
+  it('requires GCS URLs', () => {
+    expect(getValidIgvFiles([
+      'gs://bucket/test.bed',
+      'test.bed'
+    ])).toEqual([
+      {
+        filePath: 'gs://bucket/test.bed',
+        indexFilePath: false
+      }
+    ])
+  })
 })
 
 describe('getValidIgvFilesFromAttributeValues', () => {

--- a/src/components/IGVFileSelector.test.js
+++ b/src/components/IGVFileSelector.test.js
@@ -1,0 +1,112 @@
+import { getValidIgvFiles, getValidIgvFilesFromAttributeValues } from 'src/components/IGVFileSelector'
+
+
+describe('getValidIgvFiles', () => {
+  it('allows BAM files with indices', () => {
+    expect(getValidIgvFiles([
+      'gs://bucket/test1.bam',
+      'gs://bucket/test2.bam',
+      'gs://bucket/test2.bai',
+      'gs://bucket/test3.bam',
+      'gs://bucket/test3.bam.bai'
+    ])).toEqual([
+      {
+        filePath: 'gs://bucket/test2.bam',
+        indexFilePath: 'gs://bucket/test2.bai'
+      },
+      {
+        filePath: 'gs://bucket/test3.bam',
+        indexFilePath: 'gs://bucket/test3.bam.bai'
+      }
+    ])
+  })
+
+  it('allows CRAM files with indices', () => {
+    expect(getValidIgvFiles([
+      'gs://bucket/test1.cram',
+      'gs://bucket/test2.cram',
+      'gs://bucket/test2.crai',
+      'gs://bucket/test3.cram',
+      'gs://bucket/test3.cram.crai'
+    ])).toEqual([
+      {
+        filePath: 'gs://bucket/test2.cram',
+        indexFilePath: 'gs://bucket/test2.crai'
+      },
+      {
+        filePath: 'gs://bucket/test3.cram',
+        indexFilePath: 'gs://bucket/test3.cram.crai'
+      }
+    ])
+  })
+
+  it('allows VCF files with indices', () => {
+    expect(getValidIgvFiles([
+      'gs://bucket/test1.vcf',
+      'gs://bucket/test2.vcf',
+      'gs://bucket/test2.idx',
+      'gs://bucket/test3.vcf',
+      'gs://bucket/test3.vcf.idx',
+      'gs://bucket/test4.vcf',
+      'gs://bucket/test4.tbi',
+      'gs://bucket/test5.vcf',
+      'gs://bucket/test5.vcf.tbi'
+    ])).toEqual([
+      {
+        filePath: 'gs://bucket/test2.vcf',
+        indexFilePath: 'gs://bucket/test2.idx'
+      },
+      {
+        filePath: 'gs://bucket/test3.vcf',
+        indexFilePath: 'gs://bucket/test3.vcf.idx'
+      },
+      {
+        filePath: 'gs://bucket/test4.vcf',
+        indexFilePath: 'gs://bucket/test4.tbi'
+      },
+      {
+        filePath: 'gs://bucket/test5.vcf',
+        indexFilePath: 'gs://bucket/test5.vcf.tbi'
+      }
+    ])
+  })
+
+  it('allows BED files', () => {
+    expect(getValidIgvFiles([
+      'gs://bucket/test.bed'
+    ])).toEqual([
+      {
+        filePath: 'gs://bucket/test.bed',
+        indexFilePath: false
+      }
+    ])
+  })
+})
+
+describe('getValidIgvFilesFromAttributeValues', () => {
+  it('gets all valid files from lists', () => {
+    expect(getValidIgvFilesFromAttributeValues([
+      {
+        itemsType: 'AttributeValue',
+        items: [
+          'gs://bucket/test1.bed',
+          'gs://bucket/test2.bed',
+          'gs://bucket/test3.bed'
+        ]
+      }
+    ])).toEqual([
+      {
+        filePath: 'gs://bucket/test1.bed',
+        indexFilePath: false
+      },
+      {
+        filePath: 'gs://bucket/test2.bed',
+        indexFilePath: false
+      },
+      {
+        filePath: 'gs://bucket/test3.bed',
+        indexFilePath: false
+      }
+    ])
+  })
+})


### PR DESCRIPTION
When opening data table rows in IGV, Terra looks through all attribute values in the selected rows to find files viewable in IGV. It then allows the user to select which of those files to view. Currently, the way it does identifies files is based on file extension (it looks for a `.bam`, `.cram`, `.vcf` or `.bed` file extension). For some file extensions, it also looks for a related index file (a matching `.bai` for a `.bam` file, etc).

https://github.com/DataBiosphere/terra-ui/blob/fee26014a657de6a9bef68856584fd90711d292c/src/components/IGVFileSelector.js#L30-L47

This method also selects values that are not GCS URLs. For example, if an attribute value contains a file name or path instead of a URL (`test.bed` instead of `gs://workspace-bucket/test.bed`), Terra will include that file name in the list of viewable files.

The IGVBrowser component that those selected files are passed to expects GCS URLs and it parses selected files as such.

https://github.com/DataBiosphere/terra-ui/blob/752e98114d4b5c9c9143fed0f69672ab1b6b5c45/src/components/IGVBrowser.js#L28

Thus, selecting a value that is not a URL to view in IGV causes IGV to fail to load and Terra to display an infinite spinner.

With this change, IGVFileSelector will only show files from URL values that IGVBrowser can handle.

## Before
https://user-images.githubusercontent.com/1156625/179816650-1d1c1b12-1fd6-4e13-978b-cad6f5568e45.mov

## After
https://user-images.githubusercontent.com/1156625/179816681-827b0cb3-9d2a-4817-9fd5-e7fb1222f702.mov

---

This also fixes another bug found while testing this change. Currently, Terra cannot handle list values when opening data in IGV. Attempting to open a row containing a list in IGV crashes Terra.

## Before
https://user-images.githubusercontent.com/1156625/179816978-59eb07f9-d920-488f-976d-12cbbefac2c9.mov

## After
https://user-images.githubusercontent.com/1156625/179817007-de17bd3e-6755-4d0d-94a1-738957574b87.mov

