### PR TITLE
[SU-169] Limit number of list items rendered in data table cells

### DIFF
--- a/src/components/data/_tests/data-utils.test.js
+++ b/src/components/data/_tests/data-utils.test.js
@@ -3,6 +3,7 @@ import '@testing-library/jest-dom'
 import { render } from '@testing-library/react'
 import _ from 'lodash/fp'
 import { concatenateAttributeNames, convertAttributeValue, entityAttributeText, getAttributeType, prepareAttributeForUpload, renderDataCell } from 'src/components/data/data-utils'
+import * as Utils from 'src/libs/utils'
 
 
 describe('concatenateAttributeNames', () => {
@@ -204,6 +205,19 @@ describe('renderDataCell', () => {
 
   it('renders empty lists', () => {
     expect(render(renderDataCell({ items: [], itemsType: 'AttributeValue' })).container).toHaveTextContent('')
+  })
+
+  it('limits the number of list items rendered', () => {
+    expect(render(renderDataCell({
+      items: _.map(_.toString, _.range(0, 1000)),
+      itemsType: 'AttributeValue'
+    })).container).toHaveTextContent(
+      _.flow(
+        _.map(_.toString),
+        Utils.append('and 900 more'),
+        _.join(',')
+      )(_.range(0, 100))
+    )
   })
 
   it('renders missing values', () => {

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -78,6 +78,8 @@ export const entityAttributeText = (attributeValue, machineReadable) => {
   )
 }
 
+const maxListItemsRendered = 100
+
 export const renderDataCell = (attributeValue, googleProject) => {
   const renderCell = datum => {
     const stringDatum = Utils.convertValue('string', datum)
@@ -86,9 +88,17 @@ export const renderDataCell = (attributeValue, googleProject) => {
   }
 
   const renderArray = items => {
-    return _.map(([i, v]) => h(Fragment, { key: i }, [
-      renderCell(v), i < (items.length - 1) && span({ style: { marginRight: '0.5rem', color: colors.dark(0.85) } }, ',')
-    ]), Utils.toIndexPairs(items))
+    return _.flow(
+      _.slice(0, maxListItemsRendered),
+      items.length > maxListItemsRendered ?
+        Utils.append(`and ${items.length - maxListItemsRendered} more`) :
+        _.identity,
+      Utils.toIndexPairs,
+      _.flatMap(([i, v]) => h(Fragment, { key: i }, [
+        i > 0 && span({ style: { marginRight: '0.5rem', color: colors.dark(0.85) } }, ','),
+        renderCell(v)
+      ]))
+    )(items)
   }
 
   const { type, isList } = getAttributeType(attributeValue)


### PR DESCRIPTION
Data table cells containing lists render elements for each list item.

https://github.com/DataBiosphere/terra-ui/blob/ca57072ff8692c147c2d9511a5ffd0d751a4508f/src/components/data/data-utils.js#L88-L92

When a data table has many long lists, this makes the data table slow to render.

This became more of an issue after #3187 (specifically https://github.com/DataBiosphere/terra-ui/pull/3187/files#diff-967b453c8b03379166f3e719046b3a65574bddf955e95e14d115bea19185ae3bL407-R407). Before that, we converted lists to strings before rendering data table cells.

This change limits data table cells to render at most 100 items from lists. If a list has more items, an "and [N] more" message is added. Users can still view all items in the list by clicking the "[N] entities/items" button. 100 seemed low enough to improve performance and high enough that there would be no visible change to many tables.

## Before
20 sets with 10,000 items each. Note the loading spinner stops and the browser freezes.

https://user-images.githubusercontent.com/1156625/179835227-8568f011-c99f-4cd9-9dfb-b8642be29fd6.mov

## After
https://user-images.githubusercontent.com/1156625/179835291-723218b8-9483-43af-9992-f7ff59ed411f.mov

