### PR TITLE
[SUP-698] Create placeholder objects for folders in GCS

### DIFF
--- a/src/components/data/FileBrowser.js
+++ b/src/components/data/FileBrowser.js
@@ -409,7 +409,8 @@ const BucketBrowser = (({
 
                 // Since prefixes have a trailing slash, the last item in the split array will be an empty string.
                 // Dropping the last two items returns the parent "folder".
-                setPrefix(_.flow(_.split('/'), _.dropRight(2), _.join('/'))(prefix))
+                const parentPrefix = _.flow(_.split('/'), _.dropRight(2), _.join('/'))(prefix)
+                setPrefix(parentPrefix === '' ? '' : `${parentPrefix}/`)
               })
             }, ['Delete this folder'])
           ])],

--- a/src/components/data/FileBrowser.js
+++ b/src/components/data/FileBrowser.js
@@ -395,9 +395,7 @@ const BucketBrowser = (({
             noObjectsMessage,
             h(ButtonOutline, {
               style: { marginTop: '1rem', textTransform: 'none' },
-              onClick: async () => {
-                setBusy(true)
-
+              onClick: Utils.withBusyState(setBusy, async () => {
                 // Attempt to delete folder placeholder object.
                 // A placeholder object may not exist for the prefix being viewed, so do not an report error for 404 responses.
                 // See https://cloud.google.com/storage/docs/folders for more information on placeholder objects.
@@ -409,12 +407,10 @@ const BucketBrowser = (({
                   }
                 }
 
-                setBusy(false)
-
                 // Since prefixes have a trailing slash, the last item in the split array will be an empty string.
                 // Dropping the last two items returns the parent "folder".
                 setPrefix(_.flow(_.split('/'), _.dropRight(2), _.join('/'))(prefix))
-              }
+              })
             }, ['Delete this folder'])
           ])],
           () => noObjectsMessage

--- a/src/components/data/FileBrowser.js
+++ b/src/components/data/FileBrowser.js
@@ -451,14 +451,22 @@ const BucketBrowser = (({
       creatingNewFolder && h(NameModal, {
         thing: 'New folder',
         onDismiss: () => setCreatingNewFolder(false),
-        onSuccess: ({ name }) => {
+        onSuccess: async ({ name }) => {
           setCreatingNewFolder(false)
-          setPrefix(`${prefix}${name}/`)
 
-          // Create a placeholder object for the new folder.
-          // See https://cloud.google.com/storage/docs/folders for more information.
-          const placeholderObject = new File([''], `${name}/`, { type: 'text/plain' })
-          Ajax().Buckets.upload(googleProject, bucketName, prefix, placeholderObject)
+          setBusy(true)
+          try {
+            // Create a placeholder object for the new folder.
+            // See https://cloud.google.com/storage/docs/folders for more information.
+            const placeholderObject = new File([''], `${name}/`, { type: 'text/plain' })
+            await Ajax().Buckets.upload(googleProject, bucketName, prefix, placeholderObject)
+
+            setBusy(false)
+            setPrefix(`${prefix}${name}/`)
+          } catch (error) {
+            setBusy(false)
+            reportError('Error creating folder', error)
+          }
         }
       }),
 

--- a/src/pages/Upload.js
+++ b/src/pages/Upload.js
@@ -436,7 +436,7 @@ const DataUploadPanel = ({ workspace, collection, setNumFiles, children }) => {
     h(FileBrowser, {
       style: { flex: '1 1 auto', minHeight: '30rem', border: `1px solid ${colors.grey(0.4)}`, borderRadius: '0.5rem', overflow: 'hidden' },
       workspace, basePrefix,
-      showNewFolderButton: false,
+      allowEditingFolders: false,
       onUploadFiles: countFiles,
       onDeleteFiles: countFiles
     })


### PR DESCRIPTION
Multiple users have said that it's surprising that folders created in the Files tab do not persist unless a file is uploaded to the folder. This happens because GCS doesn't actually have folders and the folder hierarchy is constructed from object names.

With this change, Terra will create a placeholder object `gs://my-bucket/path/to/folder/` so that the folder appears even if no files are uploaded into it. This mimics the Cloud Console's behavior. See https://cloud.google.com/storage/docs/folders for more information.

This required a few other changes... the placeholder object would show up as a blank row in the files table. This change filters it out. This also improves Terra's handling of folders created through the Cloud Console. This also adds a button to delete empty folders, which will delete the placeholder object.

## Before
https://user-images.githubusercontent.com/1156625/180019272-13fcfc81-b8a2-46e6-a3cb-2b291eaa4cfc.mov

## After
https://user-images.githubusercontent.com/1156625/180019211-508344ee-9c9c-467e-945f-aa174f033273.mov
