### PR TITLE
[ID-119] Port Terra UI to use DrsHub instead of Martha in Dev

### DIFF
--- a/config/alpha.json
+++ b/config/alpha.json
@@ -7,6 +7,7 @@
   "dataRepoUrlRoot": "https://data.alpha.envs-terra.bio",
   "devUrlRoot": "https://bvdp-saturn-alpha.appspot.com",
   "dockstoreUrlRoot": "https://staging.dockstore.org",
+  "drsHubUrlRoot": "https://us-central1-broad-dsde-alpha.cloudfunctions.net",
   "externalCredsUrlRoot": "https://externalcreds.dsde-alpha.broadinstitute.org",
   "firecloudBucketRoot": "https://storage.googleapis.com/firecloud-alerts-alpha",
   "firecloudUrlRoot": "https://firecloud.dsde-alpha.broadinstitute.org",

--- a/config/alpha.json
+++ b/config/alpha.json
@@ -7,7 +7,7 @@
   "dataRepoUrlRoot": "https://data.alpha.envs-terra.bio",
   "devUrlRoot": "https://bvdp-saturn-alpha.appspot.com",
   "dockstoreUrlRoot": "https://staging.dockstore.org",
-  "drsHubUrlRoot": "https://drshub.dsde-dev.broadinstitute.org",
+  "drsHubUrlRoot": "https://drshub.dsde-alpha.broadinstitute.org",
   "externalCredsUrlRoot": "https://externalcreds.dsde-alpha.broadinstitute.org",
   "firecloudBucketRoot": "https://storage.googleapis.com/firecloud-alerts-alpha",
   "firecloudUrlRoot": "https://firecloud.dsde-alpha.broadinstitute.org",

--- a/config/alpha.json
+++ b/config/alpha.json
@@ -7,7 +7,7 @@
   "dataRepoUrlRoot": "https://data.alpha.envs-terra.bio",
   "devUrlRoot": "https://bvdp-saturn-alpha.appspot.com",
   "dockstoreUrlRoot": "https://staging.dockstore.org",
-  "drsHubUrlRoot": "https://us-central1-broad-dsde-alpha.cloudfunctions.net",
+  "drsHubUrlRoot": "https://drshub.dsde-dev.broadinstitute.org",
   "externalCredsUrlRoot": "https://externalcreds.dsde-alpha.broadinstitute.org",
   "firecloudBucketRoot": "https://storage.googleapis.com/firecloud-alerts-alpha",
   "firecloudUrlRoot": "https://firecloud.dsde-alpha.broadinstitute.org",

--- a/config/alpha.json
+++ b/config/alpha.json
@@ -20,6 +20,7 @@
   "rexUrlRoot": "https://terra-rex-alpha.appspot.com",
   "samUrlRoot": "https://sam.dsde-alpha.broadinstitute.org",
   "shibbolethUrlRoot": "https://broad-shibboleth-prod.appspot.com/dev",
+  "shouldUseDrsHub": false,
   "workspaceManagerUrlRoot": "https://workspace.dsde-alpha.broadinstitute.org",
   "tCell": {
     "appId": "saturnnonprod-O9lUP",

--- a/config/dev.json
+++ b/config/dev.json
@@ -7,6 +7,7 @@
   "dataRepoUrlRoot": "https://jade.datarepo-dev.broadinstitute.org",
   "devUrlRoot": "https://bvdp-saturn-dev.appspot.com",
   "dockstoreUrlRoot": "https://staging.dockstore.org",
+  "drsHubUrlRoot": "https://drshub.dsde-dev.broadinstitute.org",
   "externalCredsUrlRoot": "https://externalcreds.dsde-dev.broadinstitute.org",
   "firecloudBucketRoot": "https://storage.googleapis.com/firecloud-alerts-dev",
   "firecloudUrlRoot": "https://firecloud.dsde-dev.broadinstitute.org",

--- a/config/dev.json
+++ b/config/dev.json
@@ -20,6 +20,7 @@
   "rexUrlRoot": "https://terra-rex-dev.appspot.com",
   "samUrlRoot": "https://sam.dsde-dev.broadinstitute.org",
   "shibbolethUrlRoot": "https://broad-shibboleth-prod.appspot.com/dev",
+  "shouldUseDrsHub": true,
   "workspaceManagerUrlRoot": "https://workspace.dsde-dev.broadinstitute.org",
   "tCell": {
     "appId": "saturnnonprod-O9lUP",

--- a/config/fiab.json
+++ b/config/fiab.json
@@ -7,7 +7,7 @@
   "dataRepoUrlRoot": "https://jade.datarepo-dev.broadinstitute.org",
   "devUrlRoot": "https://bvdp-saturn-dev.appspot.com",
   "dockstoreUrlRoot": "https://staging.dockstore.org",
-  "drsHubUrlRoot": "https://martha-fiab.dsde-dev.broadinstitute.org:32443",
+  "drsHubUrlRoot": "https://drshub.dsde-dev.broadinstitute.org",
   "externalCredsUrlRoot": "https://externalcreds.dsde-dev.broadinstitute.org",
   "firecloudBucketRoot": "https://storage.googleapis.com/firecloud-alerts-dev",
   "firecloudUrlRoot": "https://firecloud-fiab.dsde-dev.broadinstitute.org",

--- a/config/fiab.json
+++ b/config/fiab.json
@@ -19,6 +19,7 @@
   "rexUrlRoot": "https://terra-rex-dev.appspot.com",
   "samUrlRoot": "https://sam-fiab.dsde-dev.broadinstitute.org:29443",
   "shibbolethUrlRoot": "https://broad-shibboleth-prod.appspot.com/dev",
+  "shouldUseDrsHub": false,
   "workspaceManagerUrlRoot": "https://workspace.dsde-dev.broadinstitute.org",
   "tCell": {
     "appId": "saturnnonprod-O9lUP",

--- a/config/fiab.json
+++ b/config/fiab.json
@@ -7,6 +7,7 @@
   "dataRepoUrlRoot": "https://jade.datarepo-dev.broadinstitute.org",
   "devUrlRoot": "https://bvdp-saturn-dev.appspot.com",
   "dockstoreUrlRoot": "https://staging.dockstore.org",
+  "drsHubUrlRoot": "https://martha-fiab.dsde-dev.broadinstitute.org:32443",
   "externalCredsUrlRoot": "https://externalcreds.dsde-dev.broadinstitute.org",
   "firecloudBucketRoot": "https://storage.googleapis.com/firecloud-alerts-dev",
   "firecloudUrlRoot": "https://firecloud-fiab.dsde-dev.broadinstitute.org",

--- a/config/perf.json
+++ b/config/perf.json
@@ -7,7 +7,7 @@
   "dataRepoUrlRoot": "https://jade-perf.datarepo-perf.broadinstitute.org",
   "devUrlRoot": "https://bvdp-saturn-perf.appspot.com",
   "dockstoreUrlRoot": "https://staging.dockstore.org",
-  "drsHubUrlRoot": "https://us-central1-broad-dsde-perf.cloudfunctions.net",
+  "drsHubUrlRoot": "https://drshub.dsde-dev.broadinstitute.org",
   "externalCredsUrlRoot": "https://externalcreds.dsde-perf.broadinstitute.org",
   "firecloudBucketRoot": "https://storage.googleapis.com/firecloud-alerts-perf",
   "firecloudUrlRoot": "https://firecloud.dsde-perf.broadinstitute.org",

--- a/config/perf.json
+++ b/config/perf.json
@@ -20,6 +20,7 @@
   "rexUrlRoot": "https://terra-rex-perf.appspot.com",
   "samUrlRoot": "https://sam.dsde-perf.broadinstitute.org",
   "shibbolethUrlRoot": "https://broad-shibboleth-prod.appspot.com/dev",
+  "shouldUseDrsHub": false,
   "workspaceManagerUrlRoot": "https://workspace.dsde-perf.broadinstitute.org",
   "tCell": {
     "appId": "saturnnonprod-O9lUP",

--- a/config/perf.json
+++ b/config/perf.json
@@ -7,6 +7,7 @@
   "dataRepoUrlRoot": "https://jade-perf.datarepo-perf.broadinstitute.org",
   "devUrlRoot": "https://bvdp-saturn-perf.appspot.com",
   "dockstoreUrlRoot": "https://staging.dockstore.org",
+  "drsHubUrlRoot": "https://us-central1-broad-dsde-perf.cloudfunctions.net",
   "externalCredsUrlRoot": "https://externalcreds.dsde-perf.broadinstitute.org",
   "firecloudBucketRoot": "https://storage.googleapis.com/firecloud-alerts-perf",
   "firecloudUrlRoot": "https://firecloud.dsde-perf.broadinstitute.org",

--- a/config/perf.json
+++ b/config/perf.json
@@ -7,7 +7,7 @@
   "dataRepoUrlRoot": "https://jade-perf.datarepo-perf.broadinstitute.org",
   "devUrlRoot": "https://bvdp-saturn-perf.appspot.com",
   "dockstoreUrlRoot": "https://staging.dockstore.org",
-  "drsHubUrlRoot": "https://drshub.dsde-dev.broadinstitute.org",
+  "drsHubUrlRoot": "https://drshub.dsde-perf.broadinstitute.org",
   "externalCredsUrlRoot": "https://externalcreds.dsde-perf.broadinstitute.org",
   "firecloudBucketRoot": "https://storage.googleapis.com/firecloud-alerts-perf",
   "firecloudUrlRoot": "https://firecloud.dsde-perf.broadinstitute.org",

--- a/config/prod.json
+++ b/config/prod.json
@@ -6,6 +6,7 @@
   "catalogUrlRoot": "https://catalog.dsde-prod.broadinstitute.org",
   "dataRepoUrlRoot": "https://data.terra.bio",
   "dockstoreUrlRoot": "https://dockstore.org",
+  "drsHubUrlRoot": "https://us-central1-broad-dsde-prod.cloudfunctions.net",
   "firecloudBucketRoot": "https://storage.googleapis.com/firecloud-alerts",
   "firecloudUrlRoot": "https://portal.firecloud.org",
   "isProd": true,

--- a/config/prod.json
+++ b/config/prod.json
@@ -18,6 +18,7 @@
   "rexUrlRoot": "https://terra-rex-prod.appspot.com",
   "samUrlRoot": "https://sam.dsde-prod.broadinstitute.org",
   "shibbolethUrlRoot": "https://broad-shibboleth-prod.appspot.com",
+  "shouldUseDrsHub": false,
   "workspaceManagerUrlRoot": "https://workspace.dsde-prod.broadinstitute.org",
   "tCell": {
     "appId": "saturnprod-VuHKy",

--- a/config/prod.json
+++ b/config/prod.json
@@ -6,7 +6,7 @@
   "catalogUrlRoot": "https://catalog.dsde-prod.broadinstitute.org",
   "dataRepoUrlRoot": "https://data.terra.bio",
   "dockstoreUrlRoot": "https://dockstore.org",
-  "drsHubUrlRoot": "https://drshub.dsde-dev.broadinstitute.org",
+  "drsHubUrlRoot": "https://drshub.dsde-prod.broadinstitute.org",
   "firecloudBucketRoot": "https://storage.googleapis.com/firecloud-alerts",
   "firecloudUrlRoot": "https://portal.firecloud.org",
   "isProd": true,

--- a/config/prod.json
+++ b/config/prod.json
@@ -6,7 +6,7 @@
   "catalogUrlRoot": "https://catalog.dsde-prod.broadinstitute.org",
   "dataRepoUrlRoot": "https://data.terra.bio",
   "dockstoreUrlRoot": "https://dockstore.org",
-  "drsHubUrlRoot": "https://us-central1-broad-dsde-prod.cloudfunctions.net",
+  "drsHubUrlRoot": "https://drshub.dsde-dev.broadinstitute.org",
   "firecloudBucketRoot": "https://storage.googleapis.com/firecloud-alerts",
   "firecloudUrlRoot": "https://portal.firecloud.org",
   "isProd": true,

--- a/config/staging.json
+++ b/config/staging.json
@@ -7,6 +7,7 @@
   "dataRepoUrlRoot": "https://data.staging.envs-terra.bio",
   "devUrlRoot": "https://bvdp-saturn-staging.appspot.com",
   "dockstoreUrlRoot": "https://staging.dockstore.org",
+  "drsHubUrlRoot": "https://us-central1-broad-dsde-staging.cloudfunctions.net",
   "firecloudBucketRoot": "https://storage.googleapis.com/firecloud-alerts-staging",
   "firecloudUrlRoot": "https://firecloud.dsde-staging.broadinstitute.org",
   "isProd": true,

--- a/config/staging.json
+++ b/config/staging.json
@@ -7,7 +7,7 @@
   "dataRepoUrlRoot": "https://data.staging.envs-terra.bio",
   "devUrlRoot": "https://bvdp-saturn-staging.appspot.com",
   "dockstoreUrlRoot": "https://staging.dockstore.org",
-  "drsHubUrlRoot": "https://us-central1-broad-dsde-staging.cloudfunctions.net",
+  "drsHubUrlRoot": "https://drshub.dsde-dev.broadinstitute.org",
   "firecloudBucketRoot": "https://storage.googleapis.com/firecloud-alerts-staging",
   "firecloudUrlRoot": "https://firecloud.dsde-staging.broadinstitute.org",
   "isProd": true,

--- a/config/staging.json
+++ b/config/staging.json
@@ -7,7 +7,7 @@
   "dataRepoUrlRoot": "https://data.staging.envs-terra.bio",
   "devUrlRoot": "https://bvdp-saturn-staging.appspot.com",
   "dockstoreUrlRoot": "https://staging.dockstore.org",
-  "drsHubUrlRoot": "https://drshub.dsde-dev.broadinstitute.org",
+  "drsHubUrlRoot": "https://drshub.dsde-staging.broadinstitute.org",
   "firecloudBucketRoot": "https://storage.googleapis.com/firecloud-alerts-staging",
   "firecloudUrlRoot": "https://firecloud.dsde-staging.broadinstitute.org",
   "isProd": true,

--- a/config/staging.json
+++ b/config/staging.json
@@ -19,6 +19,7 @@
   "rexUrlRoot": "https://terra-rex-staging.appspot.com",
   "samUrlRoot": "https://sam.dsde-staging.broadinstitute.org",
   "shibbolethUrlRoot": "https://broad-shibboleth-prod.appspot.com/dev",
+  "shouldUseDrsHub": false,
   "workspaceManagerUrlRoot": "https://workspace.dsde-staging.broadinstitute.org",
   "tCell": {
     "appId": "saturnnonprod-O9lUP",

--- a/src/components/UriViewer.js
+++ b/src/components/UriViewer.js
@@ -113,7 +113,7 @@ const DownloadButton = ({ uri, metadata: { bucket, name, fileName, size }, acces
       setUrl(_.isEmpty(accessUrl.headers) ? accessUrl.url : null)
     } else {
       try {
-        // This is still using Martha instead of DrsHub becuase DrsHub has not yet implemented signed URLs
+        // This is still using Martha instead of DrsHub because DrsHub has not yet implemented signed URLs
         const { url } = await Ajax(signal).Martha.getSignedUrl({
           bucket,
           object: name,

--- a/src/components/UriViewer.js
+++ b/src/components/UriViewer.js
@@ -179,7 +179,7 @@ const UriViewer = _.flow(
         const metadata = await loadObject(googleProject, bucket, name)
         setMetadata(metadata)
       } else {
-        // TODO: change below comment after switch to DRSHub is complete
+        // TODO: change below comment after switch to DRSHub is complete, tracked in ticket [ID-170]
         // Fields are mapped from the martha_v3 fields to those used by google
         // https://github.com/broadinstitute/martha#martha-v3
         // https://cloud.google.com/storage/docs/json_api/v1/objects#resource-representations

--- a/src/components/UriViewer.js
+++ b/src/components/UriViewer.js
@@ -114,7 +114,7 @@ const DownloadButton = ({ uri, metadata: { bucket, name, fileName, size }, acces
     } else {
       try {
         // This is still using Martha instead of DrsHub because DrsHub has not yet implemented signed URLs
-        const { url } = await Ajax(signal).Martha.getSignedUrl({
+        const { url } = await Ajax(signal).DrsUriResolver.getSignedUrl({
           bucket,
           object: name,
           dataObjectUri: isDrs(uri) ? uri : undefined
@@ -179,13 +179,13 @@ const UriViewer = _.flow(
         const metadata = await loadObject(googleProject, bucket, name)
         setMetadata(metadata)
       } else {
-        // TODO: change below comment after switch to drshub is complete
+        // TODO: change below comment after switch to DRSHub is complete
         // Fields are mapped from the martha_v3 fields to those used by google
         // https://github.com/broadinstitute/martha#martha-v3
         // https://cloud.google.com/storage/docs/json_api/v1/objects#resource-representations
         // The time formats returned are in ISO 8601 vs. RFC 3339 but should be ok for parsing by `new Date()`
         const { bucket, name, size, timeCreated, timeUpdated: updated, fileName, accessUrl } =
-          await Ajax(signal).DrsHub.getDataObjectMetadata(
+          await Ajax(signal).DrsUriResolver.getDataObjectMetadata(
             uri,
             ['bucket', 'name', 'size', 'timeCreated', 'timeUpdated', 'fileName', 'accessUrl']
           )

--- a/src/components/UriViewer.js
+++ b/src/components/UriViewer.js
@@ -113,6 +113,7 @@ const DownloadButton = ({ uri, metadata: { bucket, name, fileName, size }, acces
       setUrl(_.isEmpty(accessUrl.headers) ? accessUrl.url : null)
     } else {
       try {
+        // This is still using Martha instead of DrsHub becuase DrsHub has not yet implemented signed URLs
         const { url } = await Ajax(signal).Martha.getSignedUrl({
           bucket,
           object: name,

--- a/src/components/UriViewer.js
+++ b/src/components/UriViewer.js
@@ -178,12 +178,13 @@ const UriViewer = _.flow(
         const metadata = await loadObject(googleProject, bucket, name)
         setMetadata(metadata)
       } else {
+        // TODO: change below comment after switch to drshub is complete
         // Fields are mapped from the martha_v3 fields to those used by google
         // https://github.com/broadinstitute/martha#martha-v3
         // https://cloud.google.com/storage/docs/json_api/v1/objects#resource-representations
         // The time formats returned are in ISO 8601 vs. RFC 3339 but should be ok for parsing by `new Date()`
         const { bucket, name, size, timeCreated, timeUpdated: updated, fileName, accessUrl } =
-          await Ajax(signal).Martha.getDataObjectMetadata(
+          await Ajax(signal).DrsHub.getDataObjectMetadata(
             uri,
             ['bucket', 'name', 'size', 'timeCreated', 'timeUpdated', 'fileName', 'accessUrl']
           )

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -170,6 +170,7 @@ const fetchOrchestration = _.flow(withUrlPrefix(`${getConfig().orchestrationUrlR
 const fetchRex = withUrlPrefix(`${getConfig().rexUrlRoot}/api/`, fetchOk)
 const fetchBond = withUrlPrefix(`${getConfig().bondUrlRoot}/`, fetchOk)
 const fetchMartha = withUrlPrefix(`${getConfig().marthaUrlRoot}/`, fetchOk)
+const fetchDrsHub = withUrlPrefix(`${getConfig().drsHubUrlRoot}/`, fetchOk)
 const fetchBard = withUrlPrefix(`${getConfig().bardRoot}/`, fetchOk)
 const fetchEcm = withUrlPrefix(`${getConfig().externalCredsUrlRoot}/`, fetchOk)
 const fetchGoogleForms = withUrlPrefix('https://docs.google.com/forms/u/0/d/e/', fetchOk)
@@ -1760,6 +1761,16 @@ const Martha = signal => ({
   }
 })
 
+// TODO: test this and make sure it works
+const DrsHub = signal => ({
+  getDataObjectMetadata: async (url, fields) => {
+    const res = await fetchDrsHub(
+      _.mergeAll([jsonBody({ url, fields }), authOpts(), appIdentifier, { signal, method: 'POST' }])
+    )
+    return res.json()
+  }
+})
+
 
 const Duos = signal => ({
   getConsent: async orspId => {
@@ -1832,6 +1843,7 @@ export const Ajax = signal => {
     Apps: Apps(signal),
     Dockstore: Dockstore(signal),
     Martha: Martha(signal),
+    DrsHub: DrsHub(signal),
     Duos: Duos(signal),
     Metrics: Metrics(signal),
     Disks: Disks(signal),

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1755,7 +1755,8 @@ const Martha = signal => ({
   },
 
   getSignedUrl: async ({ bucket, object, dataObjectUri }) => {
-    const res = await fetchMartha('getSignedUrlV1',
+    const res = await fetchMartha(
+      'getSignedUrlV1',
       _.mergeAll([jsonBody({ bucket, object, dataObjectUri }), authOpts(), appIdentifier, { signal, method: 'POST' }]))
     return res.json()
   }
@@ -1764,7 +1765,8 @@ const Martha = signal => ({
 // TODO: test this and make sure it works
 const DrsHub = signal => ({
   getDataObjectMetadata: async (url, fields) => {
-    const res = await fetchDrsHub('/api/v4/drs/resolve',
+    const res = await fetchDrsHub(
+      '/api/v4/drs/resolve',
       _.mergeAll([jsonBody({ url, fields }), authOpts(), appIdentifier, { signal, method: 'POST' }])
     )
     return res.json()

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1764,7 +1764,7 @@ const Martha = signal => ({
 // TODO: test this and make sure it works
 const DrsHub = signal => ({
   getDataObjectMetadata: async (url, fields) => {
-    const res = await fetchDrsHub(
+    const res = await fetchDrsHub('/api/v4/drs/resolve',
       _.mergeAll([jsonBody({ url, fields }), authOpts(), appIdentifier, { signal, method: 'POST' }])
     )
     return res.json()

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -171,7 +171,6 @@ const fetchRex = withUrlPrefix(`${getConfig().rexUrlRoot}/api/`, fetchOk)
 const fetchBond = withUrlPrefix(`${getConfig().bondUrlRoot}/`, fetchOk)
 const fetchMartha = withUrlPrefix(`${getConfig().marthaUrlRoot}/`, fetchOk)
 const fetchDrsHub = withUrlPrefix(`${getConfig().drsHubUrlRoot}/`, fetchOk)
-const fetchShouldUseDrsHub = withUrlPrefix(`${getConfig().shouldUseDrsHub}/`, fetchOk)
 const fetchBard = withUrlPrefix(`${getConfig().bardRoot}/`, fetchOk)
 const fetchEcm = withUrlPrefix(`${getConfig().externalCredsUrlRoot}/`, fetchOk)
 const fetchGoogleForms = withUrlPrefix('https://docs.google.com/forms/u/0/d/e/', fetchOk)
@@ -1745,7 +1744,7 @@ const Dockstore = signal => ({
   listTools: (params = {}) => fetchDockstore(`api/ga4gh/v1/tools?${qs.stringify(params)}`).then(r => r.json())
 })
 
-const shouldUseDrsHub = !!fetchShouldUseDrsHub()
+const shouldUseDrsHub = !!getConfig().shouldUseDrsHub
 
 const DrsUriResolver = signal => ({
   //Currently only Martha and not DRSHub can get a signed URL

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1762,7 +1762,6 @@ const Martha = signal => ({
   }
 })
 
-// TODO: test this and make sure it works
 const DrsHub = signal => ({
   getDataObjectMetadata: async (url, fields) => {
     const res = await fetchDrsHub(


### PR DESCRIPTION
This is part of the process to getting DrsHub to Prod. This PR is only to transition Dev Terra to use DrsHub instead of Martha, later PRs will transition the rest of the environments as well. To make that easy, I have added a DrsHub config to all envs which currently points to Martha everywhere except dev, and will be updated in each config as we get DrsHub running in other envs. 

There is one usage of Martha in `UriViewer` to get signed URLs that is not being ported yet - that will be a later enhancement for DrsHub. 

Tested locally with this DRS URI: `drs://dg.4DFC:011a6a54-1bfe-4df9-ae24-990b12a812d3`
