### PR TITLE
[SU-156] Add notice for shared workspaces with one owner

### DIFF
--- a/src/components/Collapse.js
+++ b/src/components/Collapse.js
@@ -8,7 +8,7 @@ import { useUniqueId } from 'src/libs/react-utils'
 import * as Style from 'src/libs/style'
 
 
-const Collapse = ({ title, hover, tooltip, tooltipDelay, summaryStyle, detailsStyle, initialOpenState, children, titleFirst, afterToggle, onFirstOpen = () => {}, noTitleWrap, ...props }) => {
+const Collapse = ({ title, hover, tooltip, tooltipDelay, summaryStyle, detailsStyle, initialOpenState, children, titleFirst, afterTitle, onFirstOpen = () => {}, noTitleWrap, ...props }) => {
   const [isOpened, setIsOpened] = useState(initialOpenState)
   const angleIcon = icon(isOpened ? 'angle-down' : 'angle-right', {
     style: {
@@ -55,11 +55,11 @@ const Collapse = ({ title, hover, tooltip, tooltipDelay, summaryStyle, detailsSt
         }),
         title
       ]),
-      // zIndex: 2 lifts afterToggle controls above the absolutely positioned div in Link so that they can be clicked.
-      // display: flex and flex: 1 causes this div to fill available space. This makes it easy to position afterToggle
+      // zIndex: 2 lifts afterTitle controls above the absolutely positioned div in Link so that they can be clicked.
+      // display: flex and flex: 1 causes this div to fill available space. This makes it easy to position afterTitle
       // controls just after the summary text or at the right edge of the summary section. height: 0 prevents the unused
       // space in this div from blocking clicks on the summary section.
-      afterToggle && div({ style: { display: 'flex', flex: 1, alignItems: 'center', height: 0, margin: '0 1ch', zIndex: 2 } }, [afterToggle]),
+      afterTitle && div({ style: { display: 'flex', flex: 1, alignItems: 'center', height: 0, margin: '0 1ch', zIndex: 2 } }, [afterTitle]),
       titleFirst && angleIcon
     ]),
     isOpened && div({ id, style: detailsStyle }, [children])

--- a/src/libs/style.js
+++ b/src/libs/style.js
@@ -148,7 +148,7 @@ export const dashboard = {
   },
   collapsibleHeader: {
     ...elements.sectionHeader, color: colors.accent(), textTransform: 'uppercase',
-    padding: '0.5rem', display: 'flex', fontSize: 14
+    padding: '0.5rem 0 0.5rem 0.5rem', display: 'flex', fontSize: 14
   },
   infoTile: {
     backgroundColor: colors.dark(0.15), color: 'black',

--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -177,7 +177,7 @@ const NihLink = ({ nihToken }) => {
       !_.isEmpty(unauthorizedDatasets) && h(Collapse, {
         style: { marginTop: '1rem' },
         title: 'Not authorized', titleFirst: true,
-        afterToggle: h(InfoBox, [
+        afterTitle: h(InfoBox, [
           'Your account was linked, but you are not authorized to view these controlled datasets. ',
           'If you think you should have access, please ',
           h(Link, {

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -350,7 +350,7 @@ const WorkspaceDashboard = _.flow(
 
   const oneOwnerNotice = Utils.cond(
     // No warning if there are multiple owners.
-    [_.size(owners) > 1, () => null],
+    [_.size(owners) !== 1, () => null],
     // If the current user does not own the workspace, then then workspace must be shared.
     [!Utils.isOwner(accessLevel), () => h(Fragment, [
       'This shared workspace has only one owner. Consider requesting ',

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -111,7 +111,7 @@ const DashboardAuthContainer = props => {
   )
 }
 
-const RightBoxSection = ({ title, info, initialOpenState, onClick, children }) => {
+const RightBoxSection = ({ title, info, initialOpenState, afterToggle, onClick, children }) => {
   return div({ style: { paddingTop: '1rem' } }, [
     div({ style: Style.dashboard.rightBoxContainer }, [
       h(Collapse, {
@@ -119,6 +119,7 @@ const RightBoxSection = ({ title, info, initialOpenState, onClick, children }) =
         summaryStyle: { color: colors.accent() },
         initialOpenState,
         titleFirst: true,
+        afterToggle,
         onClick
       }, [children])
     ])
@@ -213,6 +214,7 @@ const WorkspaceDashboard = _.flow(
   const [busy, setBusy] = useState(false)
   const [consentStatus, setConsentStatus] = useState(undefined)
   const [tagsList, setTagsList] = useState(undefined)
+  const [acl, setAcl] = useState(undefined)
 
   const persistenceId = `workspaces/${namespace}/${name}/dashboard`
 
@@ -223,6 +225,12 @@ const WorkspaceDashboard = _.flow(
     loadSubmissionCount()
     loadConsent()
     loadWsTags()
+
+    // If the current user is the only owner of the workspace, load the ACL to check if the workspace is shared.
+    if (Utils.isOwner(accessLevel) && _.size(owners) === 1) {
+      loadAcl()
+    }
+
     if (!azureContext) {
       loadStorageCost()
       loadBucketSize()
@@ -318,6 +326,11 @@ const WorkspaceDashboard = _.flow(
     setTagsList(await Ajax().Workspaces.workspace(namespace, name).deleteTag(tag))
   })
 
+  const loadAcl = withErrorReporting('Error loading ACL', async () => {
+    const { acl } = await Ajax(signal).Workspaces.workspace(namespace, name).getAcl()
+    setAcl(acl)
+  })
+
   const save = Utils.withBusyState(setSaving, async () => {
     try {
       await Ajax().Workspaces.workspace(namespace, name).shallowMergeNewAttributes({ description: editDescription })
@@ -334,6 +347,19 @@ const WorkspaceDashboard = _.flow(
   useOnMount(() => {
     refresh()
   })
+
+  const oneOwnerNotice = Utils.cond(
+    // No warning if there are multiple owners.
+    [_.size(owners) > 1, () => null],
+    // If the current user does not own the workspace, then then workspace must be shared.
+    [!Utils.isOwner(accessLevel), () => h(Fragment, [
+      'This shared workspace has only one owner. Consider requesting ',
+      h(Link, { mailto: owners[0] }, [owners[0]]),
+      ' to add another owner to ensure someone is able to manage the workspace in case they lose access to their account.'
+    ])],
+    // If the current user is the only owner of the workspace, check if the workspace is shared.
+    [_.size(acl) > 1, () => 'You are the only owner of this shared workspace. Consider adding another owner to ensure someone is able to manage the workspace in case you lose access to your account.']
+  )
 
   const getCloudInformation = () => {
     return !googleProject && !azureContext ? [] : [
@@ -464,6 +490,10 @@ const WorkspaceDashboard = _.flow(
       h(RightBoxSection, {
         title: 'Owners',
         initialOpenState: ownersPanelOpen,
+        afterToggle: oneOwnerNotice && h(InfoBox, {
+          iconOverride: 'error-standard',
+          style: { color: colors.accent() }
+        }, [oneOwnerNotice]),
         onClick: () => setOwnersPanelOpen(!ownersPanelOpen)
       }, [
         div({ style: { margin: '0.5rem' } },

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -111,7 +111,7 @@ const DashboardAuthContainer = props => {
   )
 }
 
-const RightBoxSection = ({ title, info, initialOpenState, afterToggle, onClick, children }) => {
+const RightBoxSection = ({ title, info, initialOpenState, afterTitle, onClick, children }) => {
   return div({ style: { paddingTop: '1rem' } }, [
     div({ style: Style.dashboard.rightBoxContainer }, [
       h(Collapse, {
@@ -119,7 +119,7 @@ const RightBoxSection = ({ title, info, initialOpenState, afterToggle, onClick, 
         summaryStyle: { color: colors.accent() },
         initialOpenState,
         titleFirst: true,
-        afterToggle,
+        afterTitle,
         onClick
       }, [children])
     ])
@@ -490,7 +490,7 @@ const WorkspaceDashboard = _.flow(
       h(RightBoxSection, {
         title: 'Owners',
         initialOpenState: ownersPanelOpen,
-        afterToggle: oneOwnerNotice && h(InfoBox, {
+        afterTitle: oneOwnerNotice && h(InfoBox, {
           iconOverride: 'error-standard',
           style: { color: colors.accent() }
         }, [oneOwnerNotice]),

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -217,7 +217,7 @@ const DataTypeSection = ({ title, error, retryFunction, children }) => {
     hover: {
       color: colors.dark(0.9)
     },
-    afterToggle: error && h(Link, {
+    afterTitle: error && h(Link, {
       onClick: retryFunction,
       tooltip: 'Error loading, click to retry.'
     }, [icon('sync', { size: 18 })])
@@ -650,7 +650,7 @@ const WorkspaceData = _.flow(
                   style: { fontSize: 14, paddingLeft: '1.5rem', borderBottom: `1px solid ${colors.dark(0.2)}` },
                   title: snapshotName,
                   role: 'listitem',
-                  afterToggle: h(Link, {
+                  afterTitle: h(Link, {
                     style: { marginLeft: 'auto' },
                     tooltip: 'Snapshot Info',
                     onClick: () => {


### PR DESCRIPTION
If a Terra workspace or billing project with one owner and that person loses access to their account (leaves their organization, etc), the associated resources can no longer be fully managed through Terra. Due to security policy, Terra Support is generally unable to add owners to workspaces or billing projects. Thus, we want to encourage having multiple owners for workspaces and billing projects. This adds a notice to the workspace dashboard has multiple users but only one owner.

Related to #3238

<img width="455" alt="Screen Shot 2022-07-21 at 9 58 48 AM" src="https://user-images.githubusercontent.com/1156625/180232819-459aa096-b372-44d7-8460-774dc4e00834.png">
<img width="437" alt="Screen Shot 2022-07-21 at 9 59 15 AM" src="https://user-images.githubusercontent.com/1156625/180232820-7a0be709-97b7-4f4f-9ee7-d04295ffd16a.png">


