### PR TITLE
[SUP-701] Add new AMP PD filtering labels to Featured Workspaces page

### DIFF
--- a/src/pages/library/Showcase.js
+++ b/src/pages/library/Showcase.js
@@ -35,17 +35,17 @@ const sidebarSections = [{
   labels: ['10x analysis', 'Bisulfate Sequencing']
 }, {
   name: 'Scientific Domain',
-  labels: ['Cancer', 'Infectious Diseases', 'MPG', 'Single-cell', 'Immunology']
+  labels: ['Cancer', 'Infectious Diseases', 'MPG', 'Single-cell', 'Immunology', 'Neurodegenerative Diseases']
 }, {
   name: 'Datasets',
   labels: ['AnVIL', 'CMG', 'CCDG', 'TopMed', 'HCA', 'TARGET', 'ENCODE', 'BioData Catalyst', 'TCGA', '1000 Genomes', 'BRAIN Initiative',
-    'gnomAD', 'NCI', 'COVID-19']
+    'gnomAD', 'NCI', 'COVID-19', 'AMP PD']
 }, {
   name: 'Utilities',
   labels: ['Format Conversion', 'Developer Tools']
 }, {
   name: 'Projects',
-  labels: ['HCA', 'AnVIL', 'BRAIN Initiative', 'BioData Catalyst', 'NCI']
+  labels: ['HCA', 'AnVIL', 'BRAIN Initiative', 'BioData Catalyst', 'NCI', 'AMP PD']
 }]
 
 const WorkspaceCard = ({ workspace }) => {


### PR DESCRIPTION
[Jira ticket](https://broadworkbench.atlassian.net/browse/SUP-701)

In order to increase discoverability of the upcoming AMP PD featured workspace in Terra, I have added new filter labels to the following categories:

- Scientific Domain: “Neurodegenerative Diseases”

- Datasets: "AMP PD"

- Projects: "AMP PD" 

Because the UI does not display a given filter label until a workspace exists with that label, I do not have a screenshot that shows the change. I can provide one once the AMP PD featured workspace is listed and tagged with these labels.
