### PR TITLE
[WOR-436] Move ACL check into Google-specific condition

### DIFF
--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -226,14 +226,15 @@ const WorkspaceDashboard = _.flow(
     loadConsent()
     loadWsTags()
 
-    // If the current user is the only owner of the workspace, load the ACL to check if the workspace is shared.
-    if (Utils.isOwner(accessLevel) && _.size(owners) === 1) {
-      loadAcl()
-    }
-
     if (!azureContext) {
       loadStorageCost()
       loadBucketSize()
+
+      // If the current user is the only owner of the workspace, load the ACL to check if the workspace is shared.
+      // Azure workspaces do not yet support can-share, so only doing this for Google workspaces.
+      if (Utils.isOwner(accessLevel) && _.size(owners) === 1) {
+        loadAcl()
+      }
     } else {
       loadAzureStorage()
 


### PR DESCRIPTION
The call errors for Azure workspaces because the `share-reader` property does not work. Note that the Sharing menu item is currently disabled for Azure workpaces.

![image](https://user-images.githubusercontent.com/484484/180854026-a73f1b28-f2e8-4b67-8fe0-b65e96f830f1.png)
