### PR TITLE
DC-488: remove footer from Browser (catalog) component

### DIFF
--- a/src/pages/library/DataBrowser.js
+++ b/src/pages/library/DataBrowser.js
@@ -2,7 +2,6 @@ import _ from 'lodash/fp'
 import { useState } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
 import { ButtonOutline, ButtonPrimary, ButtonSecondary, Checkbox, Link, spinnerOverlay } from 'src/components/common'
-import FooterWrapper from 'src/components/FooterWrapper'
 import { icon } from 'src/components/icons'
 import { MiniSortable, SimpleTable } from 'src/components/table'
 import TooltipTrigger from 'src/components/TooltipTrigger'
@@ -217,7 +216,7 @@ export const Browser = () => {
 
   const toggleSelectedData = data => setSelectedData(_.xor([data]))
 
-  return h(FooterWrapper, { alwaysShow: true }, [
+  return [
     h(SearchAndFilterComponent, {
       fullList: dataCatalog, sidebarSections: extractCatalogFilters(dataCatalog),
       customSort: sort,
@@ -232,5 +231,5 @@ export const Browser = () => {
       onDismiss: () => setRequestDatasetAccessList()
     }),
     loading && spinnerOverlay
-  ])
+  ]
 }

--- a/src/pages/library/DataBrowser.js
+++ b/src/pages/library/DataBrowser.js
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp'
-import { useState } from 'react'
+import { Fragment, useState } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
 import { ButtonOutline, ButtonPrimary, ButtonSecondary, Checkbox, Link, spinnerOverlay } from 'src/components/common'
 import { icon } from 'src/components/icons'
@@ -216,7 +216,7 @@ export const Browser = () => {
 
   const toggleSelectedData = data => setSelectedData(_.xor([data]))
 
-  return [
+  return h(Fragment, [
     h(SearchAndFilterComponent, {
       fullList: dataCatalog, sidebarSections: extractCatalogFilters(dataCatalog),
       customSort: sort,
@@ -231,5 +231,5 @@ export const Browser = () => {
       onDismiss: () => setRequestDatasetAccessList()
     }),
     loading && spinnerOverlay
-  ]
+  ])
 }


### PR DESCRIPTION
Now that Browser is a component embedded in another page, it no longer needs to include the footer element. This change was missed when the catalog code was refactored to share the same route as the existing library data page.

![image](https://user-images.githubusercontent.com/1799360/181072991-7c28f9a4-619f-4d7b-b63a-435a93caf71e.png)
