### PR TITLE
[QA-1973] Integration tests: Identify tests and Slack channels for automated notification

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -5,6 +5,10 @@
 1. Start by making sure you're running the correct versions of Node and Yarn, as described in the [root README](../README.md).
 2. Run `yarn install` in this directory.
 
+### Creating a test
+
+1. Update `slack-notify-channels.json` in `slack/` directory: Add new test name and Slack channel for test result notification.
+
 ### Running the tests
 
 ```sh

--- a/integration-tests/slack/slack-notify-channels.json
+++ b/integration-tests/slack/slack-notify-channels.json
@@ -8,66 +8,7 @@
   "fail": [
     {
       "name": "dsde-qa",
-      "id": "C53JYBV9A",
-      "tests": [
-        {
-          "name": "analysis-context-bar"
-        },
-        {
-          "name": "billing-projects"
-        },
-        {
-          "name": "find-workflow"
-        },
-        {
-          "name": "import-cohort-data"
-        },
-        {
-          "name": "import-dockstore-workflow"
-        },
-        {
-          "name": "janitor"
-        },
-        {
-          "name": "link-to-new-workspace"
-        },
-        {
-          "name": "preview-dataset"
-        },
-        {
-          "name": "preview-drs-uri"
-        },
-        {
-          "name": "register-user"
-        },
-        {
-          "name": "request-access"
-        },
-        {
-          "name": "run-analysis"
-        },
-        {
-          "name": "run-catalog-filter"
-        },
-        {
-          "name": "run-catalog-workflow"
-        },
-        {
-          "name": "run-notebook"
-        },
-        {
-          "name": "run-rstudio"
-        },
-        {
-          "name": "run-workflow"
-        },
-        {
-          "name": "run-workflow-on-snapshot"
-        },
-        {
-          "name": "workspace-dashboard"
-        }
-      ]
+      "id": "C53JYBV9A"
     },
     {
       "name": "dsp-interactive-analysis",

--- a/integration-tests/slack/slack-notify-channels.json
+++ b/integration-tests/slack/slack-notify-channels.json
@@ -50,7 +50,7 @@
       ]
     },
     {
-      "name": "dsp-workspaces",
+      "name": "dsp-workspaces-test-alerts",
       "id": "C03F21QEWV7",
       "tests": [
         {

--- a/integration-tests/slack/slack-notify-channels.json
+++ b/integration-tests/slack/slack-notify-channels.json
@@ -51,7 +51,7 @@
     },
     {
       "name": "dsp-workspaces",
-      "id": "C02LMB1PQ6R",
+      "id": "C03F21QEWV7",
       "tests": [
         {
           "name": "billing-projects"

--- a/integration-tests/slack/slack-notify-channels.json
+++ b/integration-tests/slack/slack-notify-channels.json
@@ -1,0 +1,157 @@
+{
+  "pass": [
+    {
+      "name": "dsde-qa",
+      "id": "C53JYBV9A"
+    }
+  ],
+  "fail": [
+    {
+      "name": "dsde-qa",
+      "id": "C53JYBV9A",
+      "tests": [
+        {
+          "name": "analysis-context-bar"
+        },
+        {
+          "name": "billing-projects"
+        },
+        {
+          "name": "find-workflow"
+        },
+        {
+          "name": "import-cohort-data"
+        },
+        {
+          "name": "import-dockstore-workflow"
+        },
+        {
+          "name": "janitor"
+        },
+        {
+          "name": "link-to-new-workspace"
+        },
+        {
+          "name": "preview-dataset"
+        },
+        {
+          "name": "preview-drs-uri"
+        },
+        {
+          "name": "register-user"
+        },
+        {
+          "name": "request-access"
+        },
+        {
+          "name": "run-analysis"
+        },
+        {
+          "name": "run-catalog-filter"
+        },
+        {
+          "name": "run-catalog-workflow"
+        },
+        {
+          "name": "run-notebook"
+        },
+        {
+          "name": "run-rstudio"
+        },
+        {
+          "name": "run-workflow"
+        },
+        {
+          "name": "run-workflow-on-snapshot"
+        },
+        {
+          "name": "workspace-dashboard"
+        }
+      ]
+    },
+    {
+      "name": "dsp-interactive-analysis",
+      "id": "CA3NP1733",
+      "tests": [
+        {
+          "name": "run-analysis"
+        },
+        {
+          "name": "run-rstudio"
+        },
+        {
+          "name": "analysis-context-bar"
+        },
+        {
+          "name": "run-notebook"
+        }
+      ]
+    },
+    {
+      "name": "dsp-batch",
+      "id": "C1EH66VCM",
+      "tests": [
+        {
+          "name": "find-workflow"
+        },
+        {
+          "name": "import-dockstore-workflow"
+        },
+        {
+          "name": "run-workflow"
+        },
+        {
+          "name": "run-workflow-on-snapshot"
+        },
+        {
+          "name": "run-catalog-workflow"
+        }
+      ]
+    },
+    {
+      "name": "dsp-workspaces",
+      "id": "C02LMB1PQ6R",
+      "tests": [
+        {
+          "name": "billing-projects"
+        },
+        {
+          "name": "janitor"
+        },
+        {
+          "name": "link-to-new-workspace"
+        },
+        {
+          "name": "register-user"
+        },
+        {
+          "name": "request-access"
+        },
+        {
+          "name": "workspace-dashboard"
+        }
+      ]
+    },
+    {
+      "name": "jade-data-explorer",
+      "id": "C01TU3W2AL9",
+      "tests": [
+        {
+          "name": "import-cohort-data"
+        },
+        {
+          "name": "preview-dataset"
+        },
+        {
+          "name": "preview-drs-uri"
+        },
+        {
+          "name": "run-catalog-filter"
+        },
+        {
+          "name": "run-catalog-workflow"
+        }
+      ]
+    }
+  ]
+}

--- a/integration-tests/slack/slack-notify-channels.json
+++ b/integration-tests/slack/slack-notify-channels.json
@@ -119,15 +119,6 @@
           "name": "janitor"
         },
         {
-          "name": "link-to-new-workspace"
-        },
-        {
-          "name": "register-user"
-        },
-        {
-          "name": "request-access"
-        },
-        {
           "name": "workspace-dashboard"
         }
       ]
@@ -136,9 +127,6 @@
       "name": "jade-data-explorer",
       "id": "C01TU3W2AL9",
       "tests": [
-        {
-          "name": "import-cohort-data"
-        },
         {
           "name": "preview-dataset"
         },
@@ -150,6 +138,33 @@
         },
         {
           "name": "run-catalog-workflow"
+        },
+        {
+          "name": "link-to-new-workspace"
+        }
+      ]
+    },
+    {
+      "name": "dsp-identiteam",
+      "id": "C03GMG4DUSE",
+      "tests": [
+        {
+          "name": "register-user"
+        },
+        {
+          "name": "request-access"
+        }
+      ]
+    },
+    {
+      "name": "dsp-analysis-journeys",
+      "id": "C02T8G2FJCQ",
+      "tests": [
+        {
+          "name": "import-cohort-data"
+        },
+        {
+          "name": "request-access"
         }
       ]
     }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/QA-1973

Reason for choosing JSON format is because it's easier for parsing programmatically. 
This JSON contains Slack channel name and id for automated notification. Slack channel id is used to send Slack mesage. Slack name is for read for users, human-readable.
Note, any one test failure notification can be notified to multiple Slack channels.