### PR TITLE
[SUP-462] Indicate when files in a data table are located outside the workspace bucket

### DIFF
--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -368,7 +368,7 @@ const DataTable = props => {
                   cellRenderer: ({ rowIndex }) => {
                     const { name: entityName } = entities[rowIndex]
                     return h(Fragment, [
-                      renderDataCell(entityName, googleProject),
+                      renderDataCell(entityName, workspace),
                       div({ style: { flexGrow: 1 } }),
                       editable && h(EditDataLink, {
                         'aria-label': `Rename ${entityType} ${entityName}`,
@@ -404,7 +404,7 @@ const DataTable = props => {
                     ]),
                     cellRenderer: ({ rowIndex }) => {
                       const { attributes: { [attributeName]: dataInfo }, name: entityName } = entities[rowIndex]
-                      const dataCell = renderDataCell(dataInfo, googleProject)
+                      const dataCell = renderDataCell(dataInfo, workspace)
                       const divider = div({ style: { flexGrow: 1 } })
                       const editLink = editable && h(EditDataLink, {
                         'aria-label': `Edit attribute ${attributeName} of ${entityType} ${entityName}`,

--- a/src/components/data/LocalVariablesContent.js
+++ b/src/components/data/LocalVariablesContent.js
@@ -40,7 +40,7 @@ export const convertInitialAttributes = _.flow(
   _.sortBy(_.first)
 )
 
-const LocalVariablesContent = ({ workspace, workspace: { workspace: { googleProject, namespace, name } }, firstRender, refreshKey }) => {
+const LocalVariablesContent = ({ workspace, workspace: { workspace: { namespace, name } }, firstRender, refreshKey }) => {
   const signal = useCancellation()
 
   const [editIndex, setEditIndex] = useState()
@@ -192,7 +192,7 @@ const LocalVariablesContent = ({ workspace, workspace: { workspace: { googleProj
               value: editKey,
               onChange: setEditKey
             }) :
-            renderDataCell(amendedAttributes[rowIndex][0], googleProject)
+            renderDataCell(amendedAttributes[rowIndex][0], workspace)
         }, {
           size: { grow: 1 },
           headerRenderer: () => h(HeaderCell, ['Value']),
@@ -207,7 +207,7 @@ const LocalVariablesContent = ({ workspace, workspace: { workspace: { googleProj
                     value: editValue,
                     onChange: setEditValue
                   }) :
-                  renderDataCell(originalValue, googleProject)
+                  renderDataCell(originalValue, workspace)
               ]),
               editIndex === rowIndex && h(Fragment, [
                 h(Select, {
@@ -238,7 +238,7 @@ const LocalVariablesContent = ({ workspace, workspace: { workspace: { googleProj
                     value: editDescription,
                     onChange: setEditDescription
                   }) :
-                  renderDataCell(originalDescription, googleProject)
+                  renderDataCell(originalDescription, workspace)
               ]),
               editIndex === rowIndex ?
                 h(Fragment, [

--- a/src/components/data/UploadPreviewTable.js
+++ b/src/components/data/UploadPreviewTable.js
@@ -19,10 +19,10 @@ import * as Utils from 'src/libs/utils'
 
 const UploadDataTable = props => {
   const {
-    workspace: { workspace: { googleProject, namespace, name } },
-    metadataTable, metadataTable: { entityType, rows, columns, idName },
+    workspace, metadataTable, metadataTable: { entityType, rows, columns, idName },
     onConfirm, onCancel, onRename, refreshKey
   } = props
+  const { workspace: { namespace, name } } = workspace
 
   const persistenceId = `${namespace}/${name}/${entityType}`
   const nonIdColumns = _.drop(1, columns)
@@ -232,7 +232,7 @@ const UploadDataTable = props => {
                     ]),
                     cellRenderer: ({ rowIndex, columnIndex }) => {
                       const value = sortedRows[rowIndex][columnIndex]
-                      return renderDataCell(value, googleProject)
+                      return renderDataCell(value, workspace)
                     }
                   }
                 }, columns)

--- a/src/components/data/_tests/data-utils.test.js
+++ b/src/components/data/_tests/data-utils.test.js
@@ -174,44 +174,46 @@ describe('entityAttributeText', () => {
 })
 
 describe('renderDataCell', () => {
+  const testWorkspace = { workspace: { googleProject: 'test-project' } }
+
   describe('basic data types', () => {
     it('renders strings', () => {
-      expect(render(renderDataCell('abc')).container).toHaveTextContent('abc')
-      expect(render(renderDataCell({ items: ['a', 'b', 'c'], itemsType: 'AttributeValue' })).container).toHaveTextContent('a,b,c')
+      expect(render(renderDataCell('abc', testWorkspace)).container).toHaveTextContent('abc')
+      expect(render(renderDataCell({ items: ['a', 'b', 'c'], itemsType: 'AttributeValue' }, testWorkspace)).container).toHaveTextContent('a,b,c')
     })
 
     it('renders numbers', () => {
-      expect(render(renderDataCell(42)).container).toHaveTextContent('42')
-      expect(render(renderDataCell({ items: [1, 2, 3], itemsType: 'AttributeValue' })).container).toHaveTextContent('1,2,3')
+      expect(render(renderDataCell(42, testWorkspace)).container).toHaveTextContent('42')
+      expect(render(renderDataCell({ items: [1, 2, 3], itemsType: 'AttributeValue' }, testWorkspace)).container).toHaveTextContent('1,2,3')
     })
 
     it('renders booleans', () => {
-      expect(render(renderDataCell(true)).container).toHaveTextContent('true')
-      expect(render(renderDataCell(false)).container).toHaveTextContent('false')
-      expect(render(renderDataCell({ items: [true, false], itemsType: 'AttributeValue' })).container).toHaveTextContent('true,false')
+      expect(render(renderDataCell(true, testWorkspace)).container).toHaveTextContent('true')
+      expect(render(renderDataCell(false, testWorkspace)).container).toHaveTextContent('false')
+      expect(render(renderDataCell({ items: [true, false], itemsType: 'AttributeValue' }, testWorkspace)).container).toHaveTextContent('true,false')
     })
 
     it('renders entity name for references', () => {
-      expect(render(renderDataCell({ entityType: 'thing', entityName: 'thing_one' })).container).toHaveTextContent('thing_one')
+      expect(render(renderDataCell({ entityType: 'thing', entityName: 'thing_one' }, testWorkspace)).container).toHaveTextContent('thing_one')
       expect(render(renderDataCell({
         items: [
           { entityType: 'thing', entityName: 'thing_one' },
           { entityType: 'thing', entityName: 'thing_two' }
         ],
         itemsType: 'EntityReference'
-      })).container).toHaveTextContent('thing_one,thing_two')
+      }, testWorkspace)).container).toHaveTextContent('thing_one,thing_two')
     })
   })
 
   it('renders empty lists', () => {
-    expect(render(renderDataCell({ items: [], itemsType: 'AttributeValue' })).container).toHaveTextContent('')
+    expect(render(renderDataCell({ items: [], itemsType: 'AttributeValue' }, testWorkspace)).container).toHaveTextContent('')
   })
 
   it('limits the number of list items rendered', () => {
     expect(render(renderDataCell({
       items: _.map(_.toString, _.range(0, 1000)),
       itemsType: 'AttributeValue'
-    })).container).toHaveTextContent(
+    }, testWorkspace)).container).toHaveTextContent(
       _.flow(
         _.map(_.toString),
         Utils.append('and 900 more'),
@@ -221,12 +223,12 @@ describe('renderDataCell', () => {
   })
 
   it('renders missing values', () => {
-    expect(render(renderDataCell(undefined)).container).toHaveTextContent('')
+    expect(render(renderDataCell(undefined, testWorkspace)).container).toHaveTextContent('')
   })
 
   describe('JSON values', () => {
     it('renders each item of arrays containing basic data types', () => {
-      expect(render(renderDataCell(['one', 'two', 'three'])).container).toHaveTextContent('one,two,three')
+      expect(render(renderDataCell(['one', 'two', 'three'], testWorkspace)).container).toHaveTextContent('one,two,three')
     })
 
     it('renders JSON for arrays of objects', () => {
@@ -234,21 +236,21 @@ describe('renderDataCell', () => {
         { key1: 'value1' },
         { key2: 'value2' },
         { key3: 'value3' }
-      ])).container).toHaveTextContent('[ { "key1": "value1" }, { "key2": "value2" }, { "key3": "value3" } ]')
+      ], testWorkspace)).container).toHaveTextContent('[ { "key1": "value1" }, { "key2": "value2" }, { "key3": "value3" } ]')
     })
 
     it('renders empty arrays', () => {
-      expect(render(renderDataCell([])).container).toHaveTextContent('')
+      expect(render(renderDataCell([], testWorkspace)).container).toHaveTextContent('')
     })
 
     it('renders JSON for other values', () => {
-      expect(render(renderDataCell({ key: 'value' })).container).toHaveTextContent('{ "key": "value" }')
+      expect(render(renderDataCell({ key: 'value' }, testWorkspace)).container).toHaveTextContent('{ "key": "value" }')
     })
   })
 
   describe('URLs', () => {
     it('renders links to GCS URLs', () => {
-      const { container, getByRole } = render(renderDataCell('gs://bucket/file.txt'))
+      const { container, getByRole } = render(renderDataCell('gs://bucket/file.txt', testWorkspace))
       expect(container).toHaveTextContent('file.txt')
       const link = getByRole('link')
       expect(link).toHaveAttribute('href', 'gs://bucket/file.txt')
@@ -258,14 +260,14 @@ describe('renderDataCell', () => {
       const { getAllByRole } = render(renderDataCell({
         itemsType: 'AttributeValue',
         items: ['gs://bucket/file1.txt', 'gs://bucket/file2.txt', 'gs://bucket/file3.txt']
-      }))
+      }, testWorkspace))
       const links = getAllByRole('link')
       expect(_.map('textContent', links)).toEqual(['file1.txt', 'file2.txt', 'file3.txt'])
       expect(_.map('href', links)).toEqual(['gs://bucket/file1.txt', 'gs://bucket/file2.txt', 'gs://bucket/file3.txt'])
     })
 
     it('renders links to DRS URLs', () => {
-      const { container, getByRole } = render(renderDataCell('drs://example.data.service.org/6cbffaae-fc48-4829-9419-1a2ef0ca98ce'))
+      const { container, getByRole } = render(renderDataCell('drs://example.data.service.org/6cbffaae-fc48-4829-9419-1a2ef0ca98ce', testWorkspace))
       expect(container).toHaveTextContent('drs://example.data.service.org/6cbffaae-fc48-4829-9419-1a2ef0ca98ce')
       const link = getByRole('link')
       expect(link).toHaveAttribute('href', 'drs://example.data.service.org/6cbffaae-fc48-4829-9419-1a2ef0ca98ce')

--- a/src/components/data/_tests/data-utils.test.js
+++ b/src/components/data/_tests/data-utils.test.js
@@ -174,7 +174,7 @@ describe('entityAttributeText', () => {
 })
 
 describe('renderDataCell', () => {
-  const testWorkspace = { workspace: { googleProject: 'test-project' } }
+  const testWorkspace = { workspace: { bucketName: 'test-bucket', googleProject: 'test-project' } }
 
   describe('basic data types', () => {
     it('renders strings', () => {
@@ -254,6 +254,16 @@ describe('renderDataCell', () => {
       expect(container).toHaveTextContent('file.txt')
       const link = getByRole('link')
       expect(link).toHaveAttribute('href', 'gs://bucket/file.txt')
+    })
+
+    it('renders a warning for GCS URLs outside the workspace bucket', () => {
+      const { getByText } = render(renderDataCell('gs://other-bucket/file.txt', testWorkspace))
+      expect(getByText('Some files are located outside of the current workspace')).toBeTruthy()
+    })
+
+    it('does not render a warning for GCS URLs in the workspace bucket', () => {
+      const { queryByText } = render(renderDataCell('gs://test-bucket/file.txt', testWorkspace))
+      expect(queryByText('Some files are located outside of the current workspace')).toBeNull()
     })
 
     it('renders lists of GCS URLs', () => {

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -103,7 +103,9 @@ const renderDataCellTooltip = attributeValue => {
   )
 }
 
-export const renderDataCell = (attributeValue, googleProject) => {
+export const renderDataCell = (attributeValue, workspace) => {
+  const { workspace: { googleProject } } = workspace
+
   const renderCell = datum => {
     const stringDatum = Utils.convertValue('string', datum)
 

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -144,7 +144,7 @@ export const renderDataCell = (attributeValue, workspace) => {
 
   return h(Fragment, [
     hasOtherBucketUrls && h(TooltipTrigger, { content: 'Some files are located outside of the current workspace' }, [
-      icon('error-standard', { style: { flexShrink: 0, marginRight: '1ch', color: colors.accent(), cursor: 'help' } })
+      icon('warning-info', { size: 20, style: { flexShrink: 0, marginRight: '1ch', color: colors.accent(), cursor: 'help' } })
     ]),
     h(TextCell, { title: tooltip }, [
       Utils.cond(

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -10,6 +10,7 @@ import {
 import Dropzone from 'src/components/Dropzone'
 import { icon } from 'src/components/icons'
 import { AutocompleteTextInput, NumberInput, PasteOnlyInput, TextInput, ValidatedInput } from 'src/components/input'
+import Interactive from 'src/components/Interactive'
 import Modal from 'src/components/Modal'
 import { MenuButton, MenuTrigger } from 'src/components/PopupTrigger'
 import { SimpleTabBar } from 'src/components/tabBars'
@@ -144,7 +145,9 @@ export const renderDataCell = (attributeValue, workspace) => {
 
   return h(Fragment, [
     hasOtherBucketUrls && h(TooltipTrigger, { content: 'Some files are located outside of the current workspace' }, [
-      icon('warning-info', { size: 20, style: { flexShrink: 0, marginRight: '1ch', color: colors.accent(), cursor: 'help' } })
+      h(Interactive, { as: 'span', tabIndex: 0, style: { marginRight: '1ch' } }, [
+        icon('warning-info', { size: 20, style: { color: colors.accent(), cursor: 'help' } })
+      ])
     ]),
     h(TextCell, { title: tooltip }, [
       Utils.cond(

--- a/src/icons/warning-info.svg
+++ b/src/icons/warning-info.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 23 23" xmlns="http://www.w3.org/2000/svg">
+    <rect fill="currentColor" transform="rotate(45 12 12)" x="3.3" y="3.3" width="16" height="16" rx="2"/>
+    <path fill="#fff" d="M11.8 9.6a1.4 1.4 0 110-2.7 1.4 1.4 0 010 2.7zm1.4 5.8h-2.8a.4.4 0 01-.4-.4v-.7c0-.2.2-.4.4-.4h.4v-2h-.4a.4.4 0 01-.4-.5v-.7c0-.3.2-.4.4-.4h2c.3 0 .4.1.4.4v3.2h.4c.2 0 .4.2.4.4v.7c0 .3-.2.4-.4.4z"/>
+</svg>

--- a/src/libs/icon-dict.js
+++ b/src/libs/icon-dict.js
@@ -33,6 +33,7 @@ import { ReactComponent as squareLight } from 'src/icons/square-light.svg'
 import { ReactComponent as syncAlt } from 'src/icons/sync-alt-regular.svg'
 import { ReactComponent as talkBubble } from 'src/icons/talk-bubble.svg'
 import { ReactComponent as times } from 'src/icons/times-light.svg'
+import { ReactComponent as warningInfo } from 'src/icons/warning-info.svg'
 
 
 const fa = _.curry((shape, { size, ...props }) => h(FontAwesomeIcon, _.merge({ icon: shape, style: { height: size, width: size } }, props)))
@@ -121,6 +122,7 @@ const iconDict = {
   'view-cards': fa(faGripHorizontal),
   'view-list': custom(list),
   virus: fa(faVirus),
+  'warning-info': custom(warningInfo),
   'warning-standard': fa(faExclamationTriangle)
 }
 

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -127,7 +127,8 @@ const getReferenceData = _.flow(
   _.groupBy('datum')
 )
 
-const ReferenceDataContent = ({ workspace: { workspace: { googleProject, attributes } }, referenceKey, firstRender }) => {
+const ReferenceDataContent = ({ workspace, referenceKey, firstRender }) => {
+  const { workspace: { attributes } } = workspace
   const [textFilter, setTextFilter] = useState('')
 
   const selectedData = _.flow(
@@ -165,12 +166,12 @@ const ReferenceDataContent = ({ workspace: { workspace: { googleProject, attribu
             {
               size: { basis: 400, grow: 0 },
               headerRenderer: () => h(HeaderCell, ['Key']),
-              cellRenderer: ({ rowIndex }) => renderDataCell(selectedData[rowIndex].key, googleProject)
+              cellRenderer: ({ rowIndex }) => renderDataCell(selectedData[rowIndex].key, workspace)
             },
             {
               size: { grow: 1 },
               headerRenderer: () => h(HeaderCell, ['Value']),
-              cellRenderer: ({ rowIndex }) => renderDataCell(selectedData[rowIndex].value, googleProject)
+              cellRenderer: ({ rowIndex }) => renderDataCell(selectedData[rowIndex].value, workspace)
             }
           ],
           border: false


### PR DESCRIPTION
When working with files outside of the workspace bucket users, users are more likely to encounter access/permissions issues. This adds an icon/message to call attention to files in data tables that are outside the workspace bucket.

![Screen Shot 2022-07-26 at 3 39 28 PM](https://user-images.githubusercontent.com/1156625/181097796-6a3c6ccf-6f8a-469e-b1a0-de03e8aaf7d9.png)
