### PR TITLE
[SU-168] Reset Appcues on sign out

### DIFF
--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -446,6 +446,7 @@ authStore.subscribe((state, oldState) => {
     workspaceStore.reset()
     workspacesStore.reset()
     asyncImportJobStore.reset()
+    window.Appcues?.reset()
   }
 })
 


### PR DESCRIPTION
Currently, Appcues' user ID remains after signing out of Terra. This can result in Appcues showing content like the NPS survey when there is no user logged in.

To see the effect of this change, run `window.Appcues.debug()` and then sign out of Terra (note the "User Identified" section of the "Appcues Status" popup).

See https://docs.appcues.com/article/161-javascript-api for more info on the Appcues API.