### PR TITLE
[QA-1978] integration test: Handle loading spinner in gotoPage function

### DIFF
--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -427,6 +427,7 @@ const gotoPage = async (page, url) => {
 
   console.log(`Loading URL: ${url}`)
   await pRetry(() => load(url), retryOptions)
+  await waitForNoSpinners(page)
 }
 
 module.exports = {

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -218,7 +218,7 @@ const signIntoTerra = async (page, { token, testUrl }) => {
   if (!!testUrl) {
     await gotoPage(page, testUrl)
   } else {
-    await page.waitForXPath('//*[contains(normalize-space(.),"Loading Terra")]', { hidden: true, timeout: 60 * 1000 })
+    await page.waitForXPath('//*[contains(normalize-space(.),"Loading Terra")]', { hidden: true })
   }
 
   await waitForNoSpinners(page)

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -417,7 +417,7 @@ const gotoPage = async (page, url) => {
       if (httpResponse && !(httpResponse.ok() || httpResponse.status() === 304)) {
         throw new Error(`Error loading URL: ${url}. Http response status: ${httpResponse.statusText()}`)
       }
-      await page.waitForXPath('//*[contains(normalize-space(.),"Loading Terra")]', { hidden: true, timeout: 60 * 1000 })
+      await page.waitForXPath('//*[contains(normalize-space(.),"Loading Terra")]', { hidden: true })
     } catch (e) {
       console.error(e)
       // Stop page loading, as if you hit "X" in the browser. ignore exception.

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -414,11 +414,12 @@ const gotoPage = async (page, url) => {
   const load = async url => {
     try {
       const httpResponse = await page.goto(url, navOptionNetworkIdle())
-      if (!(httpResponse.ok() || httpResponse.status() === 304)) {
+      if (httpResponse && !(httpResponse.ok() || httpResponse.status() === 304)) {
         throw new Error(`Error loading URL: ${url}. Http response status: ${httpResponse.statusText()}`)
       }
       await page.waitForXPath('//*[contains(normalize-space(.),"Loading Terra")]', { hidden: true, timeout: 60 * 1000 })
     } catch (e) {
+      console.error(e)
       // Stop page loading, as if you hit "X" in the browser. ignore exception.
       await page._client.send('Page.stopLoading').catch(err => void err)
       throw new Error(e)

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -215,38 +215,10 @@ const dismissNPSSurvey = async page => {
 // Test workaround: Retry loading of Terra UI if fails first time. This issue often happens after new deploy to Staging/Alpha.
 const signIntoTerra = async (page, { token, testUrl }) => {
   console.log('signIntoTerra ...')
-
-  const retryOptions = {
-    factor: 1,
-    minTimeout: 1000, // This is min wait time between retries
-    onFailedAttempt: error => {
-      console.error(
-        `Sign in to Terra attempt ${error.attemptNumber} failed. There are ${error.retriesLeft} retries left.`
-      )
-    },
-    retries: 2
-  }
-
-  const timeout = 60 * 1000
-  const run = async url => {
-    try {
-      const httpResponse = await gotoPage(page, url)
-      if (!(httpResponse.ok() || httpResponse.status() === 304)) {
-        throw new Error(`Error loading URL: ${url}. Http response status: ${httpResponse.statusText()}`)
-      }
-      await page.waitForXPath('//*[contains(normalize-space(.),"Loading Terra")]', { hidden: true, timeout })
-    } catch (e) {
-      // Stop page loading, as if you hit "X" in the browser. ignore exception.
-      await page._client.send('Page.stopLoading').catch(err => void err)
-      throw new Error(e)
-    }
-  }
-
   if (!!testUrl) {
-    console.log(`Loading URL: ${testUrl}`)
-    await pRetry(() => run(testUrl), retryOptions)
+    await gotoPage(page, testUrl)
   } else {
-    await page.waitForXPath('//*[contains(normalize-space(.),"Loading Terra")]', { hidden: true, timeout })
+    await page.waitForXPath('//*[contains(normalize-space(.),"Loading Terra")]', { hidden: true, timeout: 60 * 1000 })
   }
 
   await waitForNoSpinners(page)
@@ -428,8 +400,33 @@ const withPageLogging = fn => async options => {
 
 const navOptionNetworkIdle = (timeout = 60 * 1000) => ({ waitUntil: ['networkidle0'], timeout })
 
-const gotoPage = (page, url) => {
-  return page.goto(url, navOptionNetworkIdle())
+const gotoPage = async (page, url) => {
+  const retryOptions = {
+    factor: 1,
+    onFailedAttempt: error => {
+      console.error(
+        `Loading url attempt ${error.attemptNumber} failed. There are ${error.retriesLeft} retries left.`
+      )
+    },
+    retries: 2
+  }
+
+  const load = async url => {
+    try {
+      const httpResponse = await page.goto(url, navOptionNetworkIdle())
+      if (!(httpResponse.ok() || httpResponse.status() === 304)) {
+        throw new Error(`Error loading URL: ${url}. Http response status: ${httpResponse.statusText()}`)
+      }
+      await page.waitForXPath('//*[contains(normalize-space(.),"Loading Terra")]', { hidden: true, timeout: 60 * 1000 })
+    } catch (e) {
+      // Stop page loading, as if you hit "X" in the browser. ignore exception.
+      await page._client.send('Page.stopLoading').catch(err => void err)
+      throw new Error(e)
+    }
+  }
+
+  console.log(`Loading URL: ${url}`)
+  await pRetry(() => load(url), retryOptions)
 }
 
 module.exports = {


### PR DESCRIPTION
[QA-1978](https://broadworkbench.atlassian.net/browse/QA-1978)

`google-workspace.js` test failed on CirlcleCI yesterday.

Finding: 

```
page.http GET 404 https://bvdp-saturn-alpha.appspot.com/static/js/main.2ad4b313.js
page.console Failed to load resource: the server responded with a status of 404 ()
```
Failed UI page load request, related to old static files after a new deploy to appengine.

Few tests do not start with a call to `signIntoTerra()` which handles the issue. These tests start with a call to `gotoPage()` to load the terra UI. Tests break if they're the first ones (selected randomly by CircleCI parallel runs algorithm)) to run after new deploy because `gotoPage()` does not handles loading issue.

