### PR TITLE
[SU-183] Disable file browser controls in read only workspaces

### DIFF
--- a/src/components/data/FileBrowser.js
+++ b/src/components/data/FileBrowser.js
@@ -308,7 +308,8 @@ const BucketBrowser = (({
   const [deletingSelectedObjects, setDeletingSelectedObjects] = useState(false)
   const [busy, setBusy] = useState(false)
 
-  const canEditWorkspace = !Utils.editWorkspaceError(workspace)
+  const editWorkspaceError = Utils.editWorkspaceError(workspace)
+  const canEditWorkspace = !editWorkspaceError
 
   const numPrefixes = _.size(prefixes)
   const numObjects = _.size(objects)
@@ -364,18 +365,26 @@ const BucketBrowser = (({
         div({ style: { flex: '1 1 auto' } }),
 
         h(ButtonPrimary, {
+          disabled: !canEditWorkspace,
+          tooltip: editWorkspaceError,
           style: { padding: '0.5rem', marginRight: '0.5rem' },
           onClick: openUploader
         }, [icon('upload-cloud', { style: { marginRight: '1ch' } }), ' Upload']),
 
         allowEditingFolders && h(Link, {
+          disabled: !canEditWorkspace,
+          tooltip: editWorkspaceError,
           style: { padding: '0.5rem' },
           onClick: () => setCreatingNewFolder(true)
         }, [icon('folder'), ' New folder']),
 
         h(Link, {
-          disabled: _.isEmpty(selectedObjects),
-          tooltip: _.isEmpty(selectedObjects) ? 'Select files to delete' : 'Delete selected files',
+          disabled: !canEditWorkspace || _.isEmpty(selectedObjects),
+          tooltip: Utils.cond(
+            [!canEditWorkspace, () => editWorkspaceError],
+            [_.isEmpty(selectedObjects), () => 'Select files to delete'],
+            () => 'Delete selected files'
+          ),
           style: { padding: '0.5rem' },
           onClick: () => setDeletingSelectedObjects(true)
         }, [icon('trash'), ' Delete']),


### PR DESCRIPTION
Currently, the "Upload", "New Folder", and "Delete" buttons in the Files panel of the workspace Data tab are enabled in read only workspaces, where the user does not have permission to perform those actions. This disables those buttons when the user does not have permission to modify the workspace.

## Before
![Screen Shot 2022-07-27 at 4 22 02 PM](https://user-images.githubusercontent.com/1156625/181365367-fe72bd99-6aaf-4441-a6c6-633a98a38428.png)

## After
![Screen Shot 2022-07-27 at 4 18 02 PM](https://user-images.githubusercontent.com/1156625/181365371-e2276a28-4c1b-4251-8b81-3143aa785821.png)

