### PR TITLE
[TUIM-6] Add CSP header

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -24,6 +24,7 @@ handlers:
   expiration: 0s
   secure: always
   http_headers:
+    Content-Security-Policy: "base-uri 'self'; object-src 'none'; script-src 'self' https://fast.appcues.com https://us.jsagent.tcell.insight.rapid7.com https://cdnjs.cloudflare.com; style-src * 'unsafe-inline'"
     X-Frame-Options: "SAMEORIGIN"
     Strict-Transport-Security: "max-age=31536000; includeSubdomains; preload"
     X-Content-Type-Options: "nosniff"


### PR DESCRIPTION
Currently, we use a webpack plugin to add a `meta` element containing a [content security policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP).

https://github.com/DataBiosphere/terra-ui/blob/5de7c1eaf024bbc9981ef1842c5ffd35ba51a3bb/config-overrides.js#L17-L32

This adds a [`Content-Security-Policy` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy) as well. This policy was copied from `view-source:https://app.terra.bio/`.

One thing that the webpack plugin added that is not included in this static header is a few [nonce sources](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources). Currently, the CSP generated by the webpack plugin is:
```
base-uri 'self'; object-src 'none'; script-src 'self' https://fast.appcues.com https://us.jsagent.tcell.insight.rapid7.com https://cdnjs.cloudflare.com 'nonce-2q2A4++7GPOTeXsiBSy9IA==' 'nonce-Av7aa2wd7e2J1bC0etU3Jg=='; style-src * 'unsafe-inline'
```
Those two nonce sources correspond to `https://fast.appcues.com/49767.js` and the main JS bundle generated by webpack. Those files should be covered by `https://fast.appcues.com` and `'self'` in the `script-src` directive, so I don't think the nonce sources were necessary.