### PR TITLE
[SUP-710] Use server-side filtering of list billingAccounts.

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -544,7 +544,7 @@ const Billing = signal => ({
   },
 
   listAccounts: async () => {
-    const res = await fetchRawls('user/billingAccounts', _.merge(authOpts(), { signal }))
+    const res = await fetchRawls('user/billingAccounts?firecloudHasAccess=true', _.merge(authOpts(), { signal }))
     return res.json()
   },
 

--- a/src/pages/billing/List.js
+++ b/src/pages/billing/List.js
@@ -309,7 +309,6 @@ export const BillingList = ({ queryParams: { selectedName } }) => {
   )(() => {
     if (Auth.hasBillingScope()) {
       return Ajax(signal).Billing.listAccounts()
-        .then(_.filter('firecloudHasAccess'))
         .then(_.keyBy('accountName'))
         .then(setBillingAccounts)
     }


### PR DESCRIPTION
Server-side filtering was added in https://broadworkbench.atlassian.net/browse/SUP-708, and this changes the front-end code to take advantage of it.

For testing, make sure that you can view Google billing accounts for appropriate users (like Hermione):

![image](https://user-images.githubusercontent.com/484484/181843610-cedb16e0-718c-4a18-a25a-f6e16d44ee5e.png)

