### PR TITLE
[SU-161] Allow adding tracks to IGV

### DIFF
--- a/src/components/IGVAddTrackModal.js
+++ b/src/components/IGVAddTrackModal.js
@@ -23,7 +23,7 @@ const IGVAddTrackModal = ({ onDismiss, onSubmitTrack }) => {
     () => null
   )
 
-  const isTrackValid = !urlError
+  const isTrackValid = _.isNull(urlError)
 
   const submit = () => {
     const track = {

--- a/src/components/IGVAddTrackModal.js
+++ b/src/components/IGVAddTrackModal.js
@@ -1,0 +1,104 @@
+import _ from 'lodash/fp'
+import { Fragment, useState } from 'react'
+import { form, h, label } from 'react-hyperscript-helpers'
+import { ButtonPrimary, IdContainer } from 'src/components/common'
+import { parseGsUri } from 'src/components/data/data-utils'
+import { TextInput, ValidatedInput } from 'src/components/input'
+import Modal from 'src/components/Modal'
+import * as Utils from 'src/libs/utils'
+
+
+const IGVAddTrackModal = ({ onDismiss, onSubmitTrack }) => {
+  const [value, setValue] = useState({
+    name: '',
+    url: '',
+    indexUrl: ''
+  })
+
+  const [urlInputTouched, setUrlInputTouched] = useState(false)
+
+  const urlError = Utils.cond(
+    [!value.url, () => 'A URL is required'],
+    [_.isEmpty(parseGsUri(value.url)), () => 'A gs:// URL is required'],
+    () => null
+  )
+
+  const isTrackValid = !urlError
+
+  const submit = () => {
+    const track = {
+      name: value.name || value.url,
+      url: value.url
+    }
+    if (value.indexUrl) {
+      track.indexURL = value.indexUrl
+    } else {
+      track.indexed = false
+    }
+
+    onSubmitTrack(track)
+  }
+
+  return h(Modal, {
+    title: 'Add track',
+    okButton: h(ButtonPrimary, {
+      disabled: !isTrackValid,
+      onClick: submit
+    }, ['Add track']),
+    onDismiss
+  }, [
+    form({
+      onSubmit: e => {
+        e.preventDefault()
+        submit()
+      }
+    }, [
+      h(IdContainer, [id => h(Fragment, [
+        label({
+          htmlFor: id,
+          style: { display: 'block', margin: '0.5rem 0 0.25rem' }
+        }, ['Name (optional)']),
+        h(TextInput, {
+          id,
+          placeholder: 'My track',
+          value: value.name,
+          onChange: name => setValue(_.set('name', name))
+        })
+      ])]),
+
+      h(IdContainer, [id => h(Fragment, [
+        label({
+          htmlFor: id,
+          style: { display: 'block', margin: '0.5rem 0 0.25rem' }
+        }, ['URL (required)']),
+        h(ValidatedInput, {
+          inputProps: {
+            id,
+            placeholder: 'gs://my-bucket/file.bam',
+            value: value.url,
+            onChange: url => {
+              setValue(_.set('url', url))
+              setUrlInputTouched(true)
+            }
+          },
+          error: urlInputTouched && urlError
+        })
+      ])]),
+
+      h(IdContainer, [id => h(Fragment, [
+        label({
+          htmlFor: id,
+          style: { display: 'block', margin: '0.5rem 0 0.25rem' }
+        }, ['Index URL (optional)']),
+        h(TextInput, {
+          id,
+          placeholder: 'gs://my-bucket/file.bai',
+          value: value.indexUrl,
+          onChange: indexUrl => setValue(_.set('indexUrl', indexUrl))
+        })
+      ])])
+    ])
+  ])
+}
+
+export default IGVAddTrackModal

--- a/src/components/IGVBrowser.js
+++ b/src/components/IGVBrowser.js
@@ -16,13 +16,13 @@ import * as Utils from 'src/libs/utils'
 
 // format for selectedFiles prop: [{ filePath, indexFilePath } }]
 const IGVBrowser = ({ selectedFiles, refGenome: { genome, reference }, workspace, onDismiss }) => {
-  const containerRef = useRef()
-  const signal = useCancellation()
   const [loadingIgv, setLoadingIgv] = useState(true)
-  const igvLibrary = useRef()
-  const igvBrowser = useRef()
   const [requesterPaysModal, setRequesterPaysModal] = useState(null)
   const [showAddTrackModal, setShowAddTrackModal] = useState(false)
+  const containerRef = useRef()
+  const igvLibrary = useRef()
+  const igvBrowser = useRef()
+  const signal = useCancellation()
 
   const addTracks = withErrorReporting('Unable to add tracks', async tracks => {
     // Select one file per each bucket represented in the tracks list.


### PR DESCRIPTION
Currently, to view files using IGV in Terra, the file URLs must be in a data table and only files from a single data table can be viewed together. This adds an option to add arbitrary GCS files as tracks in the IGV browser. This can be useful for things like reference data.

This required refactoring how IGVBrowser handles requester pays files. Currently, IGVBrowser assumes that all files will be specified when the component is created. It uses [`requesterPaysWrapper` from components/bucket-utils](https://github.com/DataBiosphere/terra-ui/blob/6d8a86c1b583eb5672aa2121d31a41064c610d08/src/components/bucket-utils.js#L23-L41) which, if a requester pays error is encountered, will unmount IGVBrowser, prompt for a workspace to bill to, and re-mount IGVBrowser. This method is not viable if we want to preserve the state of tracks in IGV while prompting for a workspace to bill requester pays requests to. Thus, [3bd984e](https://github.com/DataBiosphere/terra-ui/pull/3282/commits/3bd984e331a30c66b228e743e5262e86f8e80742) adds an `addTracks` function to IGVBrowser that can handle requester pays files and makes IGVBrowser handle showing the RequesterPaysModal.

If testing in a read only workspace with a requester pays bucket, ToolDrawer will prompt for a billing workspace before IGVBrowser is shown. To get to IGVBrowser's requester pays error handling, comment out [`loadNotebookNames()` in ToolDrawer](https://github.com/DataBiosphere/terra-ui/blob/6d8a86c1b583eb5672aa2121d31a41064c610d08/src/components/data/EntitiesContent.js#L79).

Also, currently [IGVBrowser calls `getUserProjectForWorkspace` once for each file viewed](https://github.com/DataBiosphere/terra-ui/blob/6d8a86c1b583eb5672aa2121d31a41064c610d08/src/components/IGVBrowser.js#L61). When viewing files in a requester pays bucket in a read-only workspace, this results in a call to the list billing projects API for each file. This changes IGVBrowser to call `getUserProjectForWorkspace` only once per set of tracks added.

https://user-images.githubusercontent.com/1156625/182165689-29dbf5b6-a41e-44e2-8100-b754a27c441d.mov


