### PR TITLE
[SU-185] Allow muting notifications for expired/expiring fence links

### DIFF
--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -443,7 +443,15 @@ export const updateFenceLinkExpirationNotification = (provider, status) => {
       ' your access or ',
       h(UnlinkFenceAccount, { linkText: 'unlink ', provider: { key, name } }),
       ' your account.'
-    ]), { id: notificationId })
+    ]), {
+      id: notificationId,
+      action: {
+        label: 'Do not remind me again',
+        callback: () => {
+          muteNotification(notificationId)
+        }
+      }
+    })
   }
 }
 

--- a/src/libs/auth.test.js
+++ b/src/libs/auth.test.js
@@ -1,0 +1,108 @@
+import '@testing-library/jest-dom'
+
+import { render } from '@testing-library/react'
+import { addDays } from 'date-fns/fp'
+import { updateFenceLinkExpirationNotification } from 'src/libs/auth'
+import * as Nav from 'src/libs/nav'
+import * as Notifications from 'src/libs/notifications'
+import * as Preferences from 'src/libs/prefs'
+
+
+jest.mock('react-notifications-component', () => {
+  return {
+    store: {
+      addNotification: jest.fn(),
+      removeNotification: jest.fn()
+    }
+  }
+})
+
+describe('updateFenceLinkExpirationNotification', () => {
+  beforeAll(() => {
+    jest.useFakeTimers()
+  })
+
+  afterAll(() => {
+    jest.useRealTimers()
+  })
+
+  beforeEach(() => {
+    jest.spyOn(Nav, 'getLink').mockReturnValue('fence-callback')
+    jest.spyOn(Notifications, 'notify')
+    jest.spyOn(Notifications, 'clearMatchingNotifications')
+    jest.spyOn(Preferences, 'getLocalPref')
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  const testProvider = {
+    key: 'anvil',
+    name: 'NHGRI AnVIL Data Commons Framework Services',
+    expiresAfter: 30,
+    short: 'NHGRI'
+  }
+
+  it('clears any existing notifications', () => {
+    updateFenceLinkExpirationNotification(testProvider, {
+      username: 'user@example.com',
+      issued_at: (new Date()).toISOString()
+    })
+
+    expect(Notifications.clearMatchingNotifications).toHaveBeenCalledWith('fence-link-expiration/anvil/')
+  })
+
+  it('shows notification if link has expired', () => {
+    const issueDate = addDays(-90, new Date())
+    const expirationDate = addDays(testProvider.expiresAfter, issueDate)
+
+    updateFenceLinkExpirationNotification(testProvider, {
+      username: 'user@example.com',
+      issued_at: issueDate.toISOString()
+    })
+
+    expect(Notifications.notify).toHaveBeenCalledWith(
+      'info',
+      expect.anything(),
+      expect.objectContaining({
+        id: `fence-link-expiration/anvil/${expirationDate.getTime()}/expired`
+      })
+    )
+
+    const notificationContent = Notifications.notify.mock.calls[0][1]
+    const { container } = render(notificationContent)
+    expect(container).toHaveTextContent('Your access to NHGRI AnVIL Data Commons Framework Services has expired. Log in to restore your access or unlink your account.')
+  })
+
+  it('shows notification if link will expire within the next 5 days', () => {
+    const issueDate = addDays(-27, new Date())
+    const expirationDate = addDays(testProvider.expiresAfter, issueDate)
+
+    updateFenceLinkExpirationNotification(testProvider, {
+      username: 'user@example.com',
+      issued_at: issueDate.toISOString()
+    })
+
+    expect(Notifications.notify).toHaveBeenCalledWith(
+      'info',
+      expect.anything(),
+      expect.objectContaining({
+        id: `fence-link-expiration/anvil/${expirationDate.getTime()}/expiring`
+      })
+    )
+
+    const notificationContent = Notifications.notify.mock.calls[0][1]
+    const { container } = render(notificationContent)
+    expect(container).toHaveTextContent('Your access to NHGRI AnVIL Data Commons Framework Services will expire in 3 day(s). Log in to renew your access or unlink your account.')
+  })
+
+  it('does not show notification if link will not expire within the next 5 days', () => {
+    updateFenceLinkExpirationNotification(testProvider, {
+      username: 'user@example.com',
+      issued_at: (new Date()).toISOString()
+    })
+
+    expect(Notifications.notify).not.toHaveBeenCalled()
+  })
+})

--- a/src/libs/notifications.js
+++ b/src/libs/notifications.js
@@ -38,6 +38,16 @@ export const notify = (type, title, props) => {
 
 export const clearNotification = id => store.removeNotification(id)
 
+export const clearMatchingNotifications = idPrefix => {
+  const matchingNotificationIds = _.flow(
+    _.map(_.get('id')),
+    _.filter(_.startsWith(idPrefix))
+  )(notificationStore.get())
+  matchingNotificationIds.forEach(id => {
+    store.removeNotification(id)
+  })
+}
+
 const muteNotificationPreferenceKey = id => `mute-notification/${id}`
 
 export const isNotificationMuted = id => {

--- a/src/libs/notifications.test.js
+++ b/src/libs/notifications.test.js
@@ -1,0 +1,116 @@
+import { addDays } from 'date-fns/fp'
+import { store } from 'react-notifications-component'
+import * as Notifications from 'src/libs/notifications'
+import * as Preferences from 'src/libs/prefs'
+import { notificationStore } from 'src/libs/state'
+
+
+jest.mock('react-notifications-component', () => {
+  return {
+    store: {
+      addNotification: jest.fn(),
+      removeNotification: jest.fn()
+    }
+  }
+})
+
+beforeAll(() => {
+  jest.useFakeTimers()
+})
+
+afterAll(() => {
+  jest.useRealTimers()
+})
+
+beforeEach(() => {
+  jest.spyOn(Preferences, 'getLocalPref')
+})
+
+afterEach(() => {
+  jest.restoreAllMocks()
+  notificationStore.reset()
+})
+
+describe('notify', () => {
+  it('adds notification to stores', () => {
+    Notifications.notify('info', 'Test notification', {
+      id: 'test-notification',
+      message: 'This is only a test'
+    })
+    expect(notificationStore.get()).toEqual([
+      expect.objectContaining({
+        id: 'test-notification',
+        type: 'info',
+        title: 'Test notification',
+        message: 'This is only a test'
+      })
+    ])
+    expect(store.addNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'test-notification' })
+    )
+  })
+
+  it('does not add notification to store if notification is muted', () => {
+    Preferences.getLocalPref.mockImplementation(key => {
+      return key === 'mute-notification/test-notification' ? Date.now() + 1 : undefined
+    })
+    Notifications.notify('info', 'Test notification', { id: 'test-notification' })
+    expect(notificationStore.get()).toEqual([])
+    expect(store.addNotification).not.toHaveBeenCalled()
+  })
+})
+
+describe('clearNotification', () => {
+  it('removes notification from react-notifications-component store', () => {
+    Notifications.clearNotification('test-notification')
+    expect(store.removeNotification).toHaveBeenCalledWith('test-notification')
+  })
+})
+
+describe('isNotificationMuted', () => {
+  it('reads mute preference', () => {
+    Notifications.isNotificationMuted('test-notification')
+    expect(Preferences.getLocalPref).toHaveBeenCalledWith('mute-notification/test-notification')
+  })
+
+  it('returns false if no mute preference is set', () => {
+    Preferences.getLocalPref.mockReturnValue(undefined)
+    const isMuted = Notifications.isNotificationMuted('test-notification')
+    expect(isMuted).toBe(false)
+  })
+
+  it('returns true if mute preference is set to -1', () => {
+    Preferences.getLocalPref.mockReturnValue(-1)
+    const isMuted = Notifications.isNotificationMuted('test-notification')
+    expect(isMuted).toBe(true)
+  })
+
+  it('returns false if mute preference is before current time', () => {
+    Preferences.getLocalPref.mockReturnValue(Date.now() - 1)
+    const isMuted = Notifications.isNotificationMuted('test-notification')
+    expect(isMuted).toBe(false)
+  })
+
+  it('returns true if mute preference is after current time', () => {
+    Preferences.getLocalPref.mockReturnValue(Date.now() + 1)
+    const isMuted = Notifications.isNotificationMuted('test-notification')
+    expect(isMuted).toBe(true)
+  })
+})
+
+describe('muteNotification', () => {
+  beforeEach(() => {
+    jest.spyOn(Preferences, 'setLocalPref')
+  })
+
+  it('sets preference', () => {
+    const tomorrow = addDays(1, new Date()).getTime()
+    Notifications.muteNotification('test-notification', tomorrow)
+    expect(Preferences.setLocalPref).toHaveBeenCalledWith('mute-notification/test-notification', tomorrow)
+  })
+
+  it('defaults to -1 if no until argument is provided', () => {
+    Notifications.muteNotification('test-notification')
+    expect(Preferences.setLocalPref).toHaveBeenCalledWith('mute-notification/test-notification', -1)
+  })
+})

--- a/src/libs/notifications.test.js
+++ b/src/libs/notifications.test.js
@@ -67,6 +67,18 @@ describe('clearNotification', () => {
   })
 })
 
+describe('clearMatchingNotifications', () => {
+  it('clears all notifications in store with IDs matching prefix', () => {
+    notificationStore.set([
+      { id: 'category1/foo' },
+      { id: 'category1/bar' },
+      { id: 'category2/foo' }
+    ])
+    Notifications.clearMatchingNotifications('category1/')
+    expect(store.removeNotification.mock.calls).toEqual([['category1/foo'], ['category1/bar']])
+  })
+})
+
 describe('isNotificationMuted', () => {
   it('reads mute preference', () => {
     Notifications.isNotificationMuted('test-notification')


### PR DESCRIPTION
In order to gain access to some datasets, users can link other types of accounts (NHLBI BioData Catalyst Framework Services, NCI CRDC Framework Services, NHGRI AnVIL Data Commons Framework Services, Kids First DRC Framework Services) to their Terra account using the Bond service. Those links expire after some time (usually 30 days). When they are expiring soon (within the next 5 days) or have expired, Terra shows a notification.

Users have complained about the same notification popping up every time they open Terra and have asked for a way to permanently dismiss it. This adds a "Do not remind me again" button to these notifications which prevents showing the notification again (until the account is re-linked).

<img width="369" alt="Screen Shot 2022-08-02 at 2 23 21 PM" src="https://user-images.githubusercontent.com/1156625/182446649-3f80f667-5427-4a9a-9504-3338b82c3997.png">

This is similar to what #3068 did for linked NIH accounts. While #3068's approach was specific to NIH link notifications, this adds a more generic option to mute notifications. `notify` now checks if a local preference `mute-notification/${notificationId}` is set. If that preference contains a timestamp later than the current time or a -1 (for mute forever), the notification will not be shown. This also updates the NIH link notifications to use this new method.

This also fixes a bug. Currently, the notification code assumes that all fence links expire after 30 days. However, NCI links expire after only 15 days. Expiration times for different account types are specified in [libs/providers](https://github.com/DataBiosphere/terra-ui/blob/dev/src/libs/providers.js).

## Testing

NIH and fence link statuses are fetched when a user signs in. To manually test this, set AJAX overrides before signing into Terra.

AnVIL
```js
window.ajaxOverridesStore.set([
  {
    filter: { url: /\/api\/link\/v1\/anvil$/ },
    fn: window.ajaxOverrideUtils.makeSuccess({
      issued_at: (new Date(Date.now() - 90 * 24 * 3600 * 1000)).toISOString(),
      username: 'user@example.com'
    })
  }
])
```

NIH
```js
window.ajaxOverridesStore.set([
  {
    filter: { url: /\/api\/nih\/status$/ },
    fn: window.ajaxOverrideUtils.makeSuccess({
      linkedNihUsername: 'user@example.com',
      datasetPermissions: [],
      linkExpireTime: Math.floor(Date.now() / 1000) - 24 * 3600
    })
  }
])
```