### PR TITLE
[SU-190] Prevent notification content from overflowing

### DIFF
--- a/src/libs/notifications.js
+++ b/src/libs/notifications.js
@@ -105,7 +105,7 @@ const NotificationDisplay = ({ id }) => {
     // content and close button
     div({ style: { display: 'flex', padding: '0.75rem 1rem' } }, [
       // content
-      div({ style: { display: 'flex', flex: 1, flexDirection: 'column' } }, [
+      div({ style: { display: 'flex', flex: 1, flexDirection: 'column', overflow: 'hidden' } }, [
         // icon and title
         div({ style: { display: 'flex' } }, [
           !!iconType && icon(iconType, {
@@ -113,9 +113,9 @@ const NotificationDisplay = ({ id }) => {
             size: 26,
             style: { color: baseColor(), flexShrink: 0, marginRight: '0.5rem' }
           }),
-          div({ id: labelId, style: { fontWeight: 600 } }, [title])
+          div({ id: labelId, style: { fontWeight: 600, overflow: 'hidden', overflowWrap: 'break-word' } }, [title])
         ]),
-        !!message && div({ id: descId, style: { marginTop: '0.5rem' } }, [message]),
+        !!message && div({ id: descId, style: { marginTop: '0.5rem', overflowWrap: 'break-word' } }, [message]),
         div({ style: { display: 'flex' } }, [
           !!detail && h(Clickable, {
             style: { marginTop: '0.25rem', marginRight: '0.5rem', textDecoration: 'underline' },


### PR DESCRIPTION
Currently, notification titles/messages containing long words without a break may overflow the notification container, pushing the dismiss notification button off the screen. This change allows breaking words that would otherwise overflow.

## Before
<img width="384" alt="Screen Shot 2022-08-04 at 8 31 19 AM" src="https://user-images.githubusercontent.com/1156625/182847798-f5977196-2881-4d37-97ef-a4c29a2ce284.png">

## After
<img width="365" alt="Screen Shot 2022-08-04 at 8 30 21 AM" src="https://user-images.githubusercontent.com/1156625/182847811-67117ae0-ab4a-49e4-96e7-3901c1cca3f8.png">

