### PR TITLE
[SU-181] Persist service alert dismissal when x button is clicked

### DIFF
--- a/src/components/ServiceAlerts.js
+++ b/src/components/ServiceAlerts.js
@@ -32,6 +32,10 @@ export const ServiceAlerts = () => {
       return !dismissal || differenceInDays(parseJSON(dismissal.date), now) >= 1
     }, _.zip(newAlerts, newHashes))
     _.forEach(([{ link: readMoreLink, message, title, 'link-title': linkTitle, severity }, hash]) => {
+      const notificationId = `alert-${hash}`
+      const onDismiss = () => {
+        setDynamic(localStorage, `dismiss-alerts/${hash}`, { date: now })
+      }
       notify(
         severity === 'info' ? 'info' : 'warn',
         h(Fragment, [
@@ -44,15 +48,15 @@ export const ServiceAlerts = () => {
               ]),
               h(Link, {
                 onClick: () => {
-                  clearNotification(`alert-${hash}`)
-                  setDynamic(localStorage, `dismiss-alerts/${hash}`, { date: now })
+                  clearNotification(notificationId)
+                  onDismiss()
                 },
                 style: { marginLeft: 'auto' }
               }, ['Dismiss'])
             ])
           ])
         ]),
-        { id: `alert-${hash}` }
+        { id: notificationId, onDismiss }
       )
     }, newAlertsWithHashes)
   }

--- a/src/libs/notifications.js
+++ b/src/libs/notifications.js
@@ -73,7 +73,7 @@ const NotificationDisplay = ({ id }) => {
   const onFirst = notificationNumber === 0
   const onLast = notificationNumber + 1 === notifications.length
 
-  const { title, message, detail, type, action } = notifications[notificationNumber]
+  const { title, message, detail, type, action, onDismiss } = notifications[notificationNumber]
   const [baseColor, ariaLabel] = Utils.switchCase(type,
     ['success', () => [colors.success, 'success notification']],
     ['info', () => [colors.accent, 'info notification']],
@@ -134,7 +134,10 @@ const NotificationDisplay = ({ id }) => {
         style: { alignSelf: 'start' },
         'aria-label': type ? `Dismiss ${type} notification` : 'Dismiss notification',
         title: 'Dismiss notification',
-        onClick: () => store.removeNotification(id)
+        onClick: () => {
+          store.removeNotification(id)
+          onDismiss?.()
+        }
       }, [icon('times', { size: 20 })])
     ]),
     notifications.length > 1 && div({


### PR DESCRIPTION
Currently, clicking the "Dismiss" button in a service alert notification hides the notification for 24 hours. Clicking the X button, which is also labeled as "Dismiss notification", does not. If a service alert notification is dismissed using the X button, it reappears when the page is reloaded or Terra is opened in a new tab. Some users have complained about the inconsistency. This change makes the X button behave the same as the "Dismiss" button.

## Before
https://user-images.githubusercontent.com/1156625/182876569-30a3c306-b380-48e4-8311-07afdb7db177.mov

## After
https://user-images.githubusercontent.com/1156625/182876600-a45352f3-97f9-49d7-ad22-d290fe5ae41d.mov

## Testing

Since service alerts are fetched when Terra is first loaded, ajaxOverrides can't be used to mock the response (the request is made before there's a chance to set the ajaxOverrides). This can be tested locally by changing the `FirecloudBucket.getServiceAlerts` function in libs/ajax.js.

```js
getServiceAlerts: async () => {
  return Promise.resolve([{
    title: 'Service alert',
    message: 'The systems are down!',
    link: 'https://support.terra.bio'
  }])
}
```