### PR TITLE
[QA-1988] UI Integration Test: Slack message templates

### DIFF
--- a/integration-tests/slack/message-templates.js
+++ b/integration-tests/slack/message-templates.js
@@ -53,9 +53,18 @@ const getTestsListBlock = testNames => {
 }
 
 // any non-zero number to indicate test(s) has failed in circleci job
-const getMessageBlockTemplate = (numFailedTests = 0) => [
-  getHeaderBlock(numFailedTests),
-  getJobDetailBlock()
-]
+const getMessageBlockTemplate = testNames => {
+  const size = testNames.length
 
-module.exports = { getMessageBlockTemplate, getTestsListBlock }
+  const blocksArray = [
+    getHeaderBlock(size),
+    getJobDetailBlock()
+  ]
+
+  if (size === 0) {
+    return blocksArray
+  } else {
+    return blocksArray.concat(getTestsListBlock(testNames))
+  }
+}
+module.exports = { getMessageBlockTemplate }

--- a/integration-tests/slack/message-templates.js
+++ b/integration-tests/slack/message-templates.js
@@ -40,10 +40,22 @@ const getJobDetailBlock = () => {
   }
 }
 
+const getTestsListBlock = testNames => {
+  return {
+    type: 'section',
+    fields: [
+      {
+        type: 'mrkdwn',
+        text: `*  ${testNames.join('\n*  ')}`
+      }
+    ]
+  }
+}
+
 // any non-zero number to indicate test(s) has failed in circleci job
 const getMessageBlockTemplate = (numFailedTests = 0) => [
   getHeaderBlock(numFailedTests),
   getJobDetailBlock()
 ]
 
-module.exports = { getMessageBlockTemplate }
+module.exports = { getMessageBlockTemplate, getTestsListBlock }

--- a/integration-tests/slack/message-templates.js
+++ b/integration-tests/slack/message-templates.js
@@ -24,8 +24,8 @@ const getHeaderBlock = numFailedTests => {
   }
 }
 
-const getJobDetailBlock = () => {
-  return {
+const getJobDetailBlock = () => (
+  {
     type: 'section',
     fields: [
       {
@@ -38,10 +38,10 @@ const getJobDetailBlock = () => {
       }
     ]
   }
-}
+)
 
-const getTestsListBlock = testNames => {
-  return {
+const getTestsListBlock = testNames => (
+  {
     type: 'section',
     fields: [
       {
@@ -50,10 +50,10 @@ const getTestsListBlock = testNames => {
       }
     ]
   }
-}
+)
 
-const getMessageBlockTemplate = testNames => {
-  const size = testNames.length
+const getMessageBlockTemplate = failedTestNames => {
+  const size = failedTestNames.length
 
   const blocksArray = [
     getHeaderBlock(size),
@@ -63,7 +63,7 @@ const getMessageBlockTemplate = testNames => {
   if (size === 0) {
     return blocksArray
   } else {
-    return blocksArray.concat(getTestsListBlock(testNames))
+    return blocksArray.concat(getTestsListBlock(failedTestNames))
   }
 }
 module.exports = { getMessageBlockTemplate }

--- a/integration-tests/slack/message-templates.js
+++ b/integration-tests/slack/message-templates.js
@@ -1,0 +1,49 @@
+const {
+  CIRCLE_JOB,
+  CIRCLE_BUILD_NUM,
+  CIRCLE_SHA1
+} = process.env
+
+const getHeaderBlock = numFailedTests => {
+  if (numFailedTests === 0) {
+    return {
+      type: 'header',
+      text: {
+        type: 'plain_text',
+        text: ':circleci-pass:  Terra-UI Test has Passed on CircleCI'
+      }
+    }
+  }
+
+  return {
+    type: 'header',
+    text: {
+      type: 'plain_text',
+      text: ':circleci-fail:  Terra-UI Test has Failed on CircleCI'
+    }
+  }
+}
+
+const getJobDetailBlock = () => {
+  return {
+    type: 'section',
+    fields: [
+      {
+        type: 'mrkdwn',
+        text: `*Job ${CIRCLE_BUILD_NUM}*: <https://circleci.com/gh/DataBiosphere/terra-ui/${CIRCLE_BUILD_NUM} | ${CIRCLE_JOB}>`
+      },
+      {
+        type: 'mrkdwn',
+        text: `*Commit*: <https://github.com/DataBiosphere/terra-ui/commit/${CIRCLE_SHA1} | ${`${CIRCLE_SHA1}`.slice(0, 7)}>`
+      }
+    ]
+  }
+}
+
+// any non-zero number to indicate test(s) has failed in circleci job
+const getMessageBlockTemplate = (numFailedTests = 0) => [
+  getHeaderBlock(numFailedTests),
+  getJobDetailBlock()
+]
+
+module.exports = { getMessageBlockTemplate }

--- a/integration-tests/slack/message-templates.js
+++ b/integration-tests/slack/message-templates.js
@@ -60,10 +60,6 @@ const getMessageBlockTemplate = failedTestNames => {
     getJobDetailBlock()
   ]
 
-  if (size === 0) {
-    return blocksArray
-  } else {
-    return blocksArray.concat(getTestsListBlock(failedTestNames))
-  }
+  return size === 0 ? blocksArray : blocksArray.concat(getTestsListBlock(failedTestNames))
 }
 module.exports = { getMessageBlockTemplate }

--- a/integration-tests/slack/message-templates.js
+++ b/integration-tests/slack/message-templates.js
@@ -52,7 +52,6 @@ const getTestsListBlock = testNames => {
   }
 }
 
-// any non-zero number to indicate test(s) has failed in circleci job
 const getMessageBlockTemplate = testNames => {
   const size = testNames.length
 

--- a/integration-tests/slack/message-templates.js
+++ b/integration-tests/slack/message-templates.js
@@ -62,4 +62,5 @@ const getMessageBlockTemplate = failedTestNames => {
 
   return size === 0 ? blocksArray : blocksArray.concat(getTestsListBlock(failedTestNames))
 }
+
 module.exports = { getMessageBlockTemplate }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/QA-1988

Avoid clutter code, make Slack message format and contents easier to read and update.
Let me know if there are other CircleCI env variables which may be useful to have in notification.

Fields:
- Title
- `Job [BUILD_NUM`: Link to CircleCI job
- `Commit`: Link to Github commit hash that triggered CircleCI job

screenshots (from mock CircleCI env variables):

- Test job succeded

   <img width="467" alt="Screen Shot 2022-08-08 at 3 11 01 PM" src="https://user-images.githubusercontent.com/35533885/183496987-d379e622-cdbd-4b90-a51f-78c4c0630d78.png">

- Test job failed (two failed tests in list)

   <img width="486" alt="Screen Shot 2022-08-08 at 3 09 57 PM" src="https://user-images.githubusercontent.com/35533885/183497000-2182c067-a731-44da-85f9-5db838e20b2c.png">

