### PR TITLE
[QA-1990] UI integration test slack notification from circleci

### DIFF
--- a/integration-tests/slack/circleci-utils.js
+++ b/integration-tests/slack/circleci-utils.js
@@ -4,10 +4,10 @@ const { parse } = require('path')
 
 
 /**
- * Fetch CircleCI artifact links to tests summary JSON files (were created in onRunComplete() in jest-reporter.js)
- * @param { string } token
- * @param { string } buildNum
- * @returns { Promise<Array[string]> } URL to tests-summary-[0-9].json
+ * Fetch CircleCI artifact links to tests summary JSON files (created in onRunComplete() in jest-reporter.js)
+ * @param {string} token
+ * @param {string} buildNum
+ * @returns {Promise<Array[string]>} URL to tests-summary-[0-9].json
  */
 const fetchJobArtifacts = async ({ buildNum = process.env.CIRCLE_BUILD_NUM } = {}) => {
   if (!buildNum) {
@@ -30,8 +30,8 @@ const fetchJobArtifacts = async ({ buildNum = process.env.CIRCLE_BUILD_NUM } = {
 
 /**
  *
- * @param { string } aggregatedResults A JSON object
- * @returns { Array[string] }
+ * @param {@link https://github.com/facebook/jest/blob/240587bde5dae1467ced0fdeee2e668e01caf896/packages/jest-test-result/src/types.ts#L77 AggregatedResult} Results from the test run.
+ * @returns {Array[string]}
  */
 const getFailedTestNames = aggregatedResults => {
   return _.flow(
@@ -41,12 +41,11 @@ const getFailedTestNames = aggregatedResults => {
 }
 
 /**
- *
- * @returns { Promise<Array[string]> }
+ * Parse all tests-summary JSON to look for failed test names
+ * @returns {Promise<Array[string]>}
  */
 const getFailedTestNamesFromArtifacts = async () => {
   const tests = []
-  // Parse all tests-summary JSON to look for failed test names
   const urls = await fetchJobArtifacts()
   await Promise.all(_.map(async url => {
     try {

--- a/integration-tests/slack/circleci-utils.js
+++ b/integration-tests/slack/circleci-utils.js
@@ -21,7 +21,7 @@ const fetchJobArtifacts = async ({ buildNum = process.env.CIRCLE_BUILD_NUM } = {
     const response = await fetch(`${apiUrlRoot}/${buildNum}/artifacts`)
     const { items } = await response.json()
     const testSummaryArtifacts = _.filter(_.flow(_.get('path'), _.includes('tests-summary')), items)
-    return _.map(_.get('url'), testSummaryArtifacts)
+    return _.map('url', testSummaryArtifacts)
   } catch (e) {
     console.error(`**  ERROR: Encountered error when getting CircleCI JOB_BUILD_NUM: ${buildNum} artifacts.`, e)
     throw e
@@ -45,20 +45,16 @@ const getFailedTestNames = aggregatedResults => {
  * @returns {Promise<Array[string]>}
  */
 const getFailedTestNamesFromArtifacts = async () => {
-  const tests = []
   const urls = await fetchJobArtifacts()
-  await Promise.all(_.map(async url => {
+  return _.flatten(await Promise.all(_.map(async url => {
     try {
       const response = await fetch(url)
-      const failedTests = getFailedTestNames(await response.json())
-      tests.push(...failedTests)
+      return getFailedTestNames(await response.json())
     } catch (e) {
       console.error(`**  ERROR: Encountered error when getting CircleCI artifacts tests-summary.json: ${url}.`, e)
       throw e
     }
-  }, urls))
-
-  return tests
+  }, urls)))
 }
 
 module.exports = {

--- a/integration-tests/slack/circleci-utils.js
+++ b/integration-tests/slack/circleci-utils.js
@@ -1,0 +1,67 @@
+const _ = require('lodash/fp')
+const fetch = require('node-fetch')
+const { parse } = require('path')
+
+
+/**
+ * Fetch CircleCI artifact links to tests summary JSON files (were created in onRunComplete() in jest-reporter.js)
+ * @param { string } token
+ * @param { string } buildNum
+ * @returns { Promise<Array[string]> } URL to tests-summary-[0-9].json
+ */
+const fetchJobArtifacts = async ({ buildNum = process.env.CIRCLE_BUILD_NUM } = {}) => {
+  if (!buildNum) {
+    throw new Error(`**  ERROR: Missing CircleCI build number. Failed to fetch CircleCI job artifacts.`)
+  }
+
+  // For more arguments and details of the response, see: https://circleci.com/docs/api/v2/index.html#operation/getJobArtifacts
+  const apiUrlRoot = 'https://circleci.com/api/v2/project/github/DataBiosphere/terra-ui'
+  try {
+    // Because terra-ui is a public repository on GitHub, API token is not required. See: https://circleci.com/docs/oss#security
+    const response = await fetch(`${apiUrlRoot}/${buildNum}/artifacts`)
+    const { items } = await response.json()
+    const testSummaryArtifacts = _.filter(_.flow(_.get('path'), _.includes('tests-summary')), items)
+    return _.map(_.get('url'), testSummaryArtifacts)
+  } catch (e) {
+    console.error(`**  ERROR: Encountered error when getting CircleCI JOB_BUILD_NUM: ${buildNum} artifacts.`, e)
+    throw e
+  }
+}
+
+/**
+ *
+ * @param { string } aggregatedResults A JSON object
+ * @returns { Array[string] }
+ */
+const getFailedTestNames = aggregatedResults => {
+  return _.flow(
+    _.filter(testResult => testResult.numFailingTests > 0),
+    _.map(testResult => parse(testResult.testFilePath).name)
+  )(aggregatedResults.testResults)
+}
+
+/**
+ *
+ * @returns { Promise<Array[string]> }
+ */
+const getFailedTestNamesFromArtifacts = async () => {
+  const tests = []
+  // Parse all tests-summary JSON to look for failed test names
+  const urls = await fetchJobArtifacts()
+  await Promise.all(_.map(async url => {
+    try {
+      const response = await fetch(url)
+      const failedTests = getFailedTestNames(await response.json())
+      tests.push(...failedTests)
+    } catch (e) {
+      console.error(`**  ERROR: Encountered error when getting CircleCI artifacts tests-summary.json: ${url}.`, e)
+      throw e
+    }
+  }, urls))
+
+  return tests
+}
+
+module.exports = {
+  getFailedTestNamesFromArtifacts
+}

--- a/integration-tests/slack/notify-circleci-test-results.js
+++ b/integration-tests/slack/notify-circleci-test-results.js
@@ -21,7 +21,6 @@ const getAllSlackChannelsForFailedJob = () => {
   const allChannelsAndTests = new Map()
   _.forEach(item => {
     const channelId = _.get('id', item)
-    // const { tests } = item
     const testNames = _.map(test => test.name, item.tests)
     allChannelsAndTests.set(channelId, testNames)
   }, testsInfo.fail)
@@ -61,7 +60,6 @@ const notifyCircleCITestResults = async () => {
   if (failedTestNames.length === 0) {
     // Slack notification: CircleCI job succeeded
     const channelIDs = getAllSlackChannelsForPassedJob()
-    console.log('channelIDs:', channelIDs)
     const messageBlocks = getMessageBlockTemplate(failedTestNames)
     // Using _.forEach to post same message to each Slack channels separately because a Slack issue: No way to post the same message to multiple channels at once.
     // See: https://github.com/slackapi/bolt-js/issues/696

--- a/integration-tests/slack/notify-circleci-test-results.js
+++ b/integration-tests/slack/notify-circleci-test-results.js
@@ -1,0 +1,71 @@
+const fs = require('fs')
+const _ = require('lodash/fp')
+const { getFailedTestNamesFromArtifacts } = require('./circleci-utils')
+const { getMessageBlockTemplate } = require('./message-templates')
+const { postMessage } = require('./post-message')
+
+
+/**
+ * Get a map object of Slack channel IDs and array of test names for failed tests notification
+ * @param { Array[string] } failedTests
+ * @returns { Map<string, Array[string]> } A map object where key is channel_id, value is test_names array
+ */
+const getFailedTestsAndChannelIDs = failedTests => {
+  const { fail: jsonBlock } = JSON.parse(fs.readFileSync('./slack/slack-notify-channels.json', 'utf8'))
+  const idsAndNames = new Map() // Map<string, Array[string]>
+  _.forEach(item => {
+    const channelId = _.get('id', item)
+    const { tests } = item
+    const testNames = _.map(test => test.name, tests)
+    idsAndNames.set(channelId, testNames)
+  }, jsonBlock)
+
+  const filteredIDsAndNames = new Map() // Map<string, Array[string]>
+  _.forEach(test => {
+    const channelIdsForFailedTest = Array.from(idsAndNames.keys())
+      .filter(key => idsAndNames.get(key).includes(test) || idsAndNames.get(key).length === 0)
+    if (channelIdsForFailedTest.length === 0) {
+      throw new Error(`Test: ${test} was not found in slack-notify-channels.json`)
+    }
+    _.forEach(channelId => filteredIDsAndNames.has(channelId) ? filteredIDsAndNames.get(channelId).push(test) : filteredIDsAndNames.set(channelId, new Array(test)),
+      channelIdsForFailedTest
+    )
+  }, failedTests)
+
+  return filteredIDsAndNames
+}
+
+/**
+ * Get array of Slack channel IDs for succeeded job notification
+ * @returns { Array[string] }
+ */
+const getSlackChannelIDsForPassedTests = () => {
+  const { pass: jsonBlock } = JSON.parse(fs.readFileSync('./slack/slack-notify-channels.json', 'utf8'))
+  return _.map(_.get('id'), jsonBlock)
+}
+
+// Post CircleCI UI test report to Slack channels
+const notifyCircleCITestResults = async () => {
+  const failedTestNames = await getFailedTestNamesFromArtifacts()
+
+  if (failedTestNames.length === 0) {
+    // Slack notification: CircleCI job succeeded
+    const channelIDs = getSlackChannelIDsForPassedTests()
+    const messageBlocks = getMessageBlockTemplate(failedTestNames)
+    // Post same message blocks for all Slack channels
+    _.forEach(async channelId => await postMessage({ channel: channelId, blocks: messageBlocks }), channelIDs)
+    return
+  }
+
+  // Slack notification: CircleCI job failed. Message contains list of failed test names.
+  const channelIDsAndNames = getFailedTestsAndChannelIDs(failedTestNames)
+  // Slack issue: No way to post the same message to multiple channels at once. https://github.com/slackapi/bolt-js/issues/696
+  _.forEach(async ([channelId, testNames]) => {
+    const messageBlocks = getMessageBlockTemplate(testNames)
+    await postMessage({ channel: channelId, blocks: messageBlocks })
+  }, _.toPairs(channelIDsAndNames))
+}
+
+(async () => {
+  await notifyCircleCITestResults()
+})()

--- a/integration-tests/slack/notify-circleci-test-results.js
+++ b/integration-tests/slack/notify-circleci-test-results.js
@@ -10,7 +10,7 @@ const testsInfo = require('./slack-notify-channels.json')
  * @returns {Array[string]}
  */
 const getAllSlackChannelsForPassedJob = () => {
-  return _.map(_.get('id'), testsInfo.pass)
+  return _.map('id', testsInfo.pass)
 }
 
 /**
@@ -60,8 +60,7 @@ const notifyCircleCITestResults = async () => {
     const messageBlocks = getMessageBlockTemplate(failedTestNames)
     // Using _.forEach to post same message to each Slack channels separately because a Slack issue: No way to post the same message to multiple channels at once.
     // See: https://github.com/slackapi/bolt-js/issues/696
-    _.forEach(async channelId => await postMessage({ channel: channelId, blocks: messageBlocks }), channelIDs)
-    return
+    return _.forEach(async channelId => await postMessage({ channel: channelId, blocks: messageBlocks }), channelIDs)
   }
 
   // Slack notification: CircleCI job failed. Message contains list of failed test names.

--- a/integration-tests/slack/notify-circleci-test-results.js
+++ b/integration-tests/slack/notify-circleci-test-results.js
@@ -39,9 +39,6 @@ const getFailedTestsAndChannelIDs = failedTests => {
   _.forEach(test => {
     const channelIdsForFailedTest = Array.from(allChannelsAndTests.keys())
       .filter(key => allChannelsAndTests.get(key).includes(test) || allChannelsAndTests.get(key).length === 0) // A channel without a list of tests means notify that channel for any failing test
-    if (channelIdsForFailedTest.length === 0) {
-      throw new Error(`Test: ${test} was not found in slack-notify-channels.json`)
-    }
     _.forEach(channelId => {
       if (!filteredIncludeOnlyFailedTests.has(channelId)) {
         filteredIncludeOnlyFailedTests.set(channelId, [])

--- a/integration-tests/slack/notify-circleci-test-results.js
+++ b/integration-tests/slack/notify-circleci-test-results.js
@@ -36,19 +36,22 @@ const getAllSlackChannelsForFailedJob = () => {
 const getFailedTestsAndChannelIDs = failedTests => {
   const allChannelsAndTests = getAllSlackChannelsForFailedJob()
 
-  const includeFailedTests = new Map() // Map<string, Array[string]>
+  const filteredIncludeOnlyFailedTests = new Map() // Map<string, Array[string]>
   _.forEach(test => {
     const channelIdsForFailedTest = Array.from(allChannelsAndTests.keys())
       .filter(key => allChannelsAndTests.get(key).includes(test) || allChannelsAndTests.get(key).length === 0) // A channel without a list of tests means notify that channel for any failing test
     if (channelIdsForFailedTest.length === 0) {
       throw new Error(`Test: ${test} was not found in slack-notify-channels.json`)
     }
-    _.forEach(channelId => includeFailedTests.has(channelId) ? includeFailedTests.get(channelId).push(test) : includeFailedTests.set(channelId, new Array(test)),
-      channelIdsForFailedTest
-    )
+    _.forEach(channelId => {
+      if (!filteredIncludeOnlyFailedTests.has(channelId)) {
+        filteredIncludeOnlyFailedTests.set(channelId, [])
+      }
+      filteredIncludeOnlyFailedTests.get(channelId).push(test)
+    }, channelIdsForFailedTest)
   }, failedTests)
 
-  return includeFailedTests
+  return filteredIncludeOnlyFailedTests
 }
 
 // Post CircleCI UI test report to Slack channels

--- a/integration-tests/slack/notify-circleci-test-results.js
+++ b/integration-tests/slack/notify-circleci-test-results.js
@@ -1,47 +1,54 @@
-const fs = require('fs')
 const _ = require('lodash/fp')
 const { getFailedTestNamesFromArtifacts } = require('./circleci-utils')
 const { getMessageBlockTemplate } = require('./message-templates')
 const { postMessage } = require('./post-message')
+const testsInfo = require('./slack-notify-channels.json')
 
 
 /**
- * Get a map object of Slack channel IDs and array of test names for failed tests notification
- * @param { Array[string] } failedTests
- * @returns { Map<string, Array[string]> } A map object where key is channel_id, value is test_names array
+ * Get array of Slack channel IDs for succeeded job notification
+ * @returns {Array[string]}
  */
-const getFailedTestsAndChannelIDs = failedTests => {
-  const { fail: jsonBlock } = JSON.parse(fs.readFileSync('./slack/slack-notify-channels.json', 'utf8'))
-  const idsAndNames = new Map() // Map<string, Array[string]>
+const getAllSlackChannelsForPassedJob = () => {
+  return _.map(_.get('id'), testsInfo.pass)
+}
+
+/**
+ * Get all Slack channel IDs and test names for failed job notification
+ * @returns {Map<string, Array[string]>}
+ */
+const getAllSlackChannelsForFailedJob = () => {
+  const allChannelsAndTests = new Map()
   _.forEach(item => {
     const channelId = _.get('id', item)
-    const { tests } = item
-    const testNames = _.map(test => test.name, tests)
-    idsAndNames.set(channelId, testNames)
-  }, jsonBlock)
+    // const { tests } = item
+    const testNames = _.map(test => test.name, item.tests)
+    allChannelsAndTests.set(channelId, testNames)
+  }, testsInfo.fail)
+  return allChannelsAndTests
+}
 
-  const filteredIDsAndNames = new Map() // Map<string, Array[string]>
+/**
+ * Get a map object of Slack channel IDs and array of test names for failed tests notification
+ * @param {Array[string]} failedTests
+ * @returns {Map<string, Array[string]>} A map object where key is channel_id, value is test_names array
+ */
+const getFailedTestsAndChannelIDs = failedTests => {
+  const allChannelsAndTests = getAllSlackChannelsForFailedJob()
+
+  const includeFailedTests = new Map() // Map<string, Array[string]>
   _.forEach(test => {
-    const channelIdsForFailedTest = Array.from(idsAndNames.keys())
-      .filter(key => idsAndNames.get(key).includes(test) || idsAndNames.get(key).length === 0)
+    const channelIdsForFailedTest = Array.from(allChannelsAndTests.keys())
+      .filter(key => allChannelsAndTests.get(key).includes(test) || allChannelsAndTests.get(key).length === 0) // A channel without a list of tests means notify that channel for any failing test
     if (channelIdsForFailedTest.length === 0) {
       throw new Error(`Test: ${test} was not found in slack-notify-channels.json`)
     }
-    _.forEach(channelId => filteredIDsAndNames.has(channelId) ? filteredIDsAndNames.get(channelId).push(test) : filteredIDsAndNames.set(channelId, new Array(test)),
+    _.forEach(channelId => includeFailedTests.has(channelId) ? includeFailedTests.get(channelId).push(test) : includeFailedTests.set(channelId, new Array(test)),
       channelIdsForFailedTest
     )
   }, failedTests)
 
-  return filteredIDsAndNames
-}
-
-/**
- * Get array of Slack channel IDs for succeeded job notification
- * @returns { Array[string] }
- */
-const getSlackChannelIDsForPassedTests = () => {
-  const { pass: jsonBlock } = JSON.parse(fs.readFileSync('./slack/slack-notify-channels.json', 'utf8'))
-  return _.map(_.get('id'), jsonBlock)
+  return includeFailedTests
 }
 
 // Post CircleCI UI test report to Slack channels
@@ -50,16 +57,17 @@ const notifyCircleCITestResults = async () => {
 
   if (failedTestNames.length === 0) {
     // Slack notification: CircleCI job succeeded
-    const channelIDs = getSlackChannelIDsForPassedTests()
+    const channelIDs = getAllSlackChannelsForPassedJob()
+    console.log('channelIDs:', channelIDs)
     const messageBlocks = getMessageBlockTemplate(failedTestNames)
-    // Post same message blocks for all Slack channels
+    // Using _.forEach to post same message to each Slack channels separately because a Slack issue: No way to post the same message to multiple channels at once.
+    // See: https://github.com/slackapi/bolt-js/issues/696
     _.forEach(async channelId => await postMessage({ channel: channelId, blocks: messageBlocks }), channelIDs)
     return
   }
 
   // Slack notification: CircleCI job failed. Message contains list of failed test names.
   const channelIDsAndNames = getFailedTestsAndChannelIDs(failedTestNames)
-  // Slack issue: No way to post the same message to multiple channels at once. https://github.com/slackapi/bolt-js/issues/696
   _.forEach(async ([channelId, testNames]) => {
     const messageBlocks = getMessageBlockTemplate(testNames)
     await postMessage({ channel: channelId, blocks: messageBlocks })


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/QA-1990

(For context, this is split from https://github.com/DataBiosphere/terra-ui/pull/3287)

Changes:
- Retreive CircleCI job artifacts
- Process Jest test summary JSON files to retrieve tests information
- Compose and send Slack message when test job is finished
- Provide a way to run JS code in Terminal window so it can be launched in a CircleCI step (not included in this PR)

To test this:

- Set `CIRCLE_BUILD_NUM` and `SLACK_BOT_TOKEN` env variables
- From `integration-tests` dir, cmd to invoke script: `node --require ../.pnp.cjs ./slack/notify-circleci-test-results.js` 

Example: this notification was posted to `dsp-workspaces-test-alerts` today.

<img width="731" alt="Screen Shot 2022-08-09 at 3 14 25 PM" src="https://user-images.githubusercontent.com/35533885/183742614-9ffa2277-94bd-4c89-81b4-b74cf3c87fa4.png">

