### PR TITLE
[TUIM-27] Collect coverage from unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,7 +205,7 @@ jobs:
             - deps-{{ .Branch }}-{{ checksum ".pnp.cjs" }}
       - run: yarn install --immutable-cache
       - run: yarn eslint --max-warnings=0 .
-      - run: yarn test --maxWorkers=2
+      - run: yarn test --coverage --maxWorkers=2
       - run: DISABLE_ESLINT_PLUGIN=true yarn build # already linted above
       - save_cache:
           key: deps-{{ .Branch }}-{{ checksum ".pnp.cjs" }}
@@ -215,6 +215,8 @@ jobs:
       - run: tar -czf build.tgz .gcloudignore app.yaml build config
       - store_artifacts:
           path: build.tgz
+      - store_artifacts:
+          path: coverage
       - persist_to_workspace:
           root: .
           paths:


### PR DESCRIPTION
We would like to improve Terra UI's unit test coverage. Before we can improve it, we must measure it. This collects coverage information when running unit tests and uploads it to CircleCI. The coverage report can be viewed on the artifacts page of the build job (view the `coverage/lcov-report/index.html` file).

It would be nice if the artifacts page was more organized, but I don't think CircleCI supports hiding artifacts. I just followed the instructions at https://circleci.com/docs/code-coverage#javascript.

For example, on this PR:
- [build job artifacts](https://app.circleci.com/pipelines/github/DataBiosphere/terra-ui/11318/workflows/896ef0c6-37d3-4d46-a237-9268a6fe30a3/jobs/48728/artifacts)
- [lcov-report/index.html](https://output.circle-artifacts.com/output/job/0dcd3d93-e8d0-4e92-b127-3bd79f7bcdea/artifacts/0/coverage/lcov-report/index.html)

To be safe,the find-build script in the production deploy repo should probably be updated before this is merged. It currently assumes that the build bundle is the only artifact of the build job.
https://github.com/DataBiosphere/saturn-ui-prod-deploy/blob/1a70277588a3fb9307e832ca9870c44b9f55d805/src/find-build.js#L17-L18