### PR TITLE
[SU-184] Separate attribute type input

### DIFF
--- a/src/components/data/_tests/data-utils.test.js
+++ b/src/components/data/_tests/data-utils.test.js
@@ -479,7 +479,7 @@ describe('AttributeTypeInput', () => {
       expect(entityTypeInput.getAttribute('role')).toBe('combobox')
     })
 
-    it('selecting reference type uses the default reference entity type is one is provided', () => {
+    it('selecting reference type uses the default reference entity type if one is provided', () => {
       const onChange = jest.fn()
       const { getByLabelText } = render(h(AttributeTypeInput, {
         value: { type: 'string' },

--- a/src/components/data/_tests/data-utils.test.js
+++ b/src/components/data/_tests/data-utils.test.js
@@ -1,8 +1,9 @@
 import '@testing-library/jest-dom'
 
-import { render } from '@testing-library/react'
+import { fireEvent, render } from '@testing-library/react'
 import _ from 'lodash/fp'
-import { concatenateAttributeNames, convertAttributeValue, entityAttributeText, getAttributeType, prepareAttributeForUpload, renderDataCell } from 'src/components/data/data-utils'
+import { h } from 'react-hyperscript-helpers'
+import { AttributeInput, concatenateAttributeNames, convertAttributeValue, entityAttributeText, getAttributeType, prepareAttributeForUpload, renderDataCell } from 'src/components/data/data-utils'
 import * as Utils from 'src/libs/utils'
 
 
@@ -425,6 +426,229 @@ describe('prepareAttributeForUpload', () => {
     })).toEqual({
       items: [1, 2, 3],
       itemsType: 'AttributeValue'
+    })
+  })
+})
+
+describe('AttributeInput', () => {
+  describe('type buttons', () => {
+    it('renders radio buttons for available types', () => {
+      const { getAllByRole } = render(h(AttributeInput, {
+        onChange: jest.fn()
+      }))
+
+      const radioButtons = getAllByRole('radio')
+      const labels = Array.from(radioButtons).map(el => el.labels[0].textContent)
+
+      expect(radioButtons.length).toBe(4)
+      expect(labels).toEqual(['String', 'Reference', 'Number', 'Boolean'])
+    })
+
+    it('renders an entity types menu for reference values', () => {
+      const { getByLabelText } = render(h(AttributeInput, {
+        value: { entityType: 'foo', entityName: 'foo_1' },
+        entityTypes: ['foo', 'bar', 'baz'],
+        onChange: jest.fn()
+      }))
+
+      const entityTypeInput = getByLabelText('Referenced entity type:')
+      expect(entityTypeInput.getAttribute('role')).toBe('combobox')
+    })
+
+    it('renders a radio button for JSON type for JSON values', () => {
+      const { queryByLabelText } = render(h(AttributeInput, {
+        value: { key: 'value' },
+        onChange: jest.fn()
+      }))
+
+      const jsonRadioButton = queryByLabelText('JSON')
+      expect(jsonRadioButton).not.toBeNull()
+    })
+
+    it('renders a radio button for JSON type if requested', () => {
+      const { queryByLabelText } = render(h(AttributeInput, {
+        onChange: jest.fn(),
+        showJsonTypeOption: true
+      }))
+
+      const jsonRadioButton = queryByLabelText('JSON')
+      expect(jsonRadioButton).not.toBeNull()
+    })
+  })
+
+  describe('selecting a type', () => {
+    it('converts value to the selected type', () => {
+      const onChange = jest.fn()
+      const { getByLabelText } = render(h(AttributeInput, {
+        value: '123',
+        onChange
+      }))
+
+      fireEvent.click(getByLabelText('Number'))
+
+      expect(onChange).toHaveBeenCalledWith(123)
+    })
+
+    it('if an initial value is provided, converts initial value to the selected type', () => {
+      // When editing an attribute, this allows previewing the effect of a type change without
+      // performing the lossy conversion.
+      const onChange = jest.fn()
+      const { getByLabelText } = render(h(AttributeInput, {
+        value: '123',
+        initialValue: '456',
+        onChange
+      }))
+
+      fireEvent.click(getByLabelText('Number'))
+
+      expect(onChange).toHaveBeenCalledWith(456)
+    })
+  })
+
+  describe('renders a value input based on the attribute type', () => {
+    it('renders a text input for string attributes', () => {
+      const onChange = jest.fn()
+      const { getByLabelText } = render(h(AttributeInput, {
+        value: 'value',
+        onChange
+      }))
+      const valueInput = getByLabelText('New value')
+
+      expect(valueInput.tagName).toBe('INPUT')
+      expect(valueInput.type).toBe('text')
+      expect(valueInput.value).toBe('value')
+
+      fireEvent.change(valueInput, { target: { value: 'newvalue' } })
+      expect(onChange).toHaveBeenCalledWith('newvalue')
+    })
+
+    it('renders a text input for reference attributes', () => {
+      const onChange = jest.fn()
+      const { getByLabelText } = render(h(AttributeInput, {
+        value: { entityType: 'thing', entityName: 'thing_one' },
+        onChange
+      }))
+      const valueInput = getByLabelText('New value')
+
+      expect(valueInput.tagName).toBe('INPUT')
+      expect(valueInput.type).toBe('text')
+      expect(valueInput.value).toBe('thing_one')
+
+      fireEvent.change(valueInput, { target: { value: 'thing_two' } })
+      expect(onChange).toHaveBeenCalledWith({ entityType: 'thing', entityName: 'thing_two' })
+    })
+
+    it('renders a number input for number attributes', () => {
+      const onChange = jest.fn()
+      const { getByLabelText } = render(h(AttributeInput, {
+        value: 123,
+        onChange
+      }))
+      const valueInput = getByLabelText('New value')
+
+      expect(valueInput.tagName).toBe('INPUT')
+      expect(valueInput.type).toBe('number')
+      expect(valueInput.value).toBe('123')
+
+      fireEvent.change(valueInput, { target: { value: '456' } })
+      expect(onChange).toHaveBeenCalledWith(456)
+    })
+
+    it('renders a switch for boolean attributes', () => {
+      const onChange = jest.fn()
+      const { getByLabelText } = render(h(AttributeInput, {
+        value: true,
+        onChange
+      }))
+      const valueInput = getByLabelText('New value')
+
+      expect(valueInput.tagName).toBe('INPUT')
+      expect(valueInput.type).toBe('checkbox')
+      expect(valueInput.checked).toBe(true)
+
+      fireEvent.click(valueInput)
+      expect(onChange).toHaveBeenCalledWith(false)
+    })
+  })
+
+  describe('lists', () => {
+    it('renders a checkbox for list status', () => {
+      const { getByLabelText } = render(h(AttributeInput, {
+        value: { itemsType: 'AttributeValue', items: ['foo', 'bar', 'baz'] },
+        onChange: jest.fn()
+      }))
+
+      const listCheckbox = getByLabelText('Value is a list')
+      expect(listCheckbox.getAttribute('role')).toBe('checkbox')
+      expect(listCheckbox.getAttribute('aria-checked')).toBe('true')
+    })
+
+    it('it converts single value to a list when list checkbox is checked', () => {
+      const onChange = jest.fn()
+      const { getByLabelText } = render(h(AttributeInput, {
+        value: 'foo',
+        onChange
+      }))
+
+      const listCheckbox = getByLabelText('Value is a list')
+      fireEvent.click(listCheckbox)
+
+      expect(onChange).toHaveBeenCalledWith({ itemsType: 'AttributeValue', items: ['foo'] })
+    })
+
+    it('it converts list to a single value when list checkbox is unchecked', () => {
+      const onChange = jest.fn()
+      const { getByLabelText } = render(h(AttributeInput, {
+        value: { itemsType: 'AttributeValue', items: ['foo', 'bar', 'baz'] },
+        onChange
+      }))
+
+      const listCheckbox = getByLabelText('Value is a list')
+      fireEvent.click(listCheckbox)
+
+      expect(onChange).toHaveBeenCalledWith('foo')
+    })
+
+    it('renders an input for each list item', () => {
+      const onChange = jest.fn()
+      const { getAllByLabelText } = render(h(AttributeInput, {
+        value: { itemsType: 'AttributeValue', items: ['foo', 'bar', 'baz'] },
+        onChange
+      }))
+
+      const valueInputs = getAllByLabelText(/^List value \d+/)
+      expect(valueInputs.length).toBe(3)
+      expect(Array.from(valueInputs).map(el => el.value)).toEqual(['foo', 'bar', 'baz'])
+
+      fireEvent.change(valueInputs[1], { target: { value: 'qux' } })
+      expect(onChange).toHaveBeenCalledWith({ itemsType: 'AttributeValue', items: ['foo', 'qux', 'baz'] })
+    })
+
+    it('renders buttons to remove items from list', () => {
+      const onChange = jest.fn()
+      const { getAllByLabelText } = render(h(AttributeInput, {
+        value: { itemsType: 'AttributeValue', items: ['foo', 'bar', 'baz'] },
+        onChange
+      }))
+
+      const removeButtons = getAllByLabelText(/^Remove list value \d+/)
+      expect(removeButtons.length).toBe(3)
+
+      fireEvent.click(removeButtons[1])
+      expect(onChange).toHaveBeenCalledWith({ itemsType: 'AttributeValue', items: ['foo', 'baz'] })
+    })
+
+    it('renders button to add item to list', () => {
+      const onChange = jest.fn()
+      const { getByText } = render(h(AttributeInput, {
+        value: { itemsType: 'AttributeValue', items: ['foo', 'bar', 'baz'] },
+        onChange
+      }))
+
+      const addButton = getByText('Add item')
+      fireEvent.click(addButton)
+
+      expect(onChange).toHaveBeenCalledWith({ itemsType: 'AttributeValue', items: ['foo', 'bar', 'baz', ''] })
     })
   })
 })

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -686,7 +686,7 @@ const defaultValueForAttributeType = (attributeType, referenceEntityType) => {
   )
 }
 
-const AttributeInput = ({ autoFocus = false, value: attributeValue, initialValue, onChange, entityTypes = [], showJsonTypeOption = false }) => {
+export const AttributeInput = ({ autoFocus = false, value: attributeValue, initialValue, onChange, entityTypes = [], showJsonTypeOption = false }) => {
   const [edited, setEdited] = useState(false)
   const { type: attributeType, isList } = getAttributeType(attributeValue)
 

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -590,7 +590,7 @@ export const AttributeTypeInput = ({ label: labelText = 'Type', value, onChange,
 
   const typeOptions = [
     { type: 'string' },
-    { type: 'reference', tooltip: 'A link to another entity' },
+    { type: 'reference', tooltip: 'A link to another row' },
     { type: 'number' },
     { type: 'boolean' }
   ]


### PR DESCRIPTION
We allow editing an attribute for multiple rows in a data table at once. However, currently the only option is to set the attribute to the same value in every row. We would like to add the option to change the type of the attribute, converting each row's value to the new type individually.

Currently, there is a component (AttributeInput) for editing an attribute value, including its type. This separates the type inputs out so they can be used without the value inputs.

<img width="453" alt="Screen Shot 2022-08-10 at 4 29 13 PM" src="https://user-images.githubusercontent.com/1156625/184014489-4917935f-01f0-4d97-99bc-95e52bc47e7f.png">