### PR TITLE
[SU-151] Add a maxWidth to the recently viewed workspace cards

### DIFF
--- a/src/components/workspace-utils.js
+++ b/src/components/workspace-utils.js
@@ -446,7 +446,7 @@ export const RecentlyViewedWorkspaceCard = ({ workspace, submissionStatus, loadi
   const dateViewed = Utils.makeCompleteDate(new Date(parseInt(timestamp)).toString())
 
   return h(Clickable, {
-    style: { ...Style.elements.card.container, margin: '0 0.25rem', lineHeight: '1.5rem', flex: '0 1 calc(25% - 10px)' },
+    style: { ...Style.elements.card.container, maxWidth: 'calc(25% - 10px)', margin: '0 0.25rem', lineHeight: '1.5rem', flex: '0 1 calc(25% - 10px)' },
     href: Nav.getLink('workspace-dashboard', { namespace, name })
   }, [
     div({ style: { flex: 'none' } }, [


### PR DESCRIPTION
A very long workspace name can cause the card to take up too much space and overflow.

Before
<img width="1792" alt="Screen Shot 2022-08-11 at 12 59 59 PM" src="https://user-images.githubusercontent.com/7257391/184191545-987a6bdb-0679-4636-8035-eb517787528f.png">

After
<img width="1792" alt="Screen Shot 2022-08-11 at 1 00 09 PM" src="https://user-images.githubusercontent.com/7257391/184191560-0840eaec-bc2f-4739-b264-c7cacbb83974.png">



<!--
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Also, so if a screen recording [1] and/or screenshots would be a helpful way to communicate context, please consider including some in your PR description.
Thanks!

[1] https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac
--!>
