### PR TITLE
fix value copied for data repo dataset id

### DIFF
--- a/src/components/workspace-utils.js
+++ b/src/components/workspace-utils.js
@@ -212,7 +212,7 @@ export const SnapshotInfo = ({
               title: 'Data Repo Dataset Id:', text: [h(Link, {
                 href: `${getConfig().dataRepoUrlRoot}/datasets/${id}`, target: '_blank',
                 'aria-label': 'Go to the dataset in a new tab'
-              }, [id]), h(ClipboardButton, { 'aria-label': 'Copy data repo dataset id to clipboard', text: snapshotId, style: { marginLeft: '0.25rem' } })]
+              }, [id]), h(ClipboardButton, { 'aria-label': 'Copy data repo dataset id to clipboard', text: id, style: { marginLeft: '0.25rem' } })]
             })
           ])
         }, source)


### PR DESCRIPTION
[AJ-550](https://broadworkbench.atlassian.net/browse/AJ-550) Copying source dataset repo id instead copies snapshot id 
#3007 (from [AJ-345](https://broadworkbench.atlassian.net/browse/AJ-345)) added the linked data repo snapshot id and source data repo dataset id to the snapshot info page for snapshot-by-reference, including the ability to copy these ids with the clipboard icon.  Both clipboard icons, however, copy the same value.  This apparently went unnoticed for several months; fixing it now.