### PR TITLE
[SU-184] Allow changing attribute type for multiple rows

### DIFF
--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -430,7 +430,7 @@ const EntitiesContent = ({
       }),
       editingEntities && h(MultipleEntityEditor, {
         entityType: entityKey,
-        entityNames: _.keys(selectedEntities),
+        entities: _.values(selectedEntities),
         attributeNames: entityMetadata[entityKey].attributeNames,
         entityTypes: _.keys(entityMetadata),
         workspaceId: { namespace, name },

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -949,7 +949,7 @@ export const SingleEntityEditor = ({ entityType, entityName, attributeName, attr
   ])
 }
 
-export const MultipleEntityEditor = ({ entityType, entityNames, attributeNames, entityTypes, workspaceId: { namespace, name }, onDismiss, onSuccess }) => {
+export const MultipleEntityEditor = ({ entityType, entities, attributeNames, entityTypes, workspaceId: { namespace, name }, onDismiss, onSuccess }) => {
   const [attributeToEdit, setAttributeToEdit] = useState('')
   const [attributeToEditTouched, setAttributeToEditTouched] = useState(false)
   const attributeToEditError = attributeToEditTouched && Utils.cond(
@@ -967,15 +967,15 @@ export const MultipleEntityEditor = ({ entityType, entityNames, attributeNames, 
     try {
       setIsBusy(true)
 
-      const entityUpdates = _.map(entityName => ({
+      const entityUpdates = _.map(entity => ({
         entityType,
-        name: entityName,
+        name: entity.name,
         operations: [{
           op: 'AddUpdateAttribute',
           attributeName: attributeToEdit,
           addUpdateAttribute: prepareAttributeForUpload(newValue)
         }]
-      }), entityNames)
+      }), entities)
 
       await Ajax(signal)
         .Workspaces
@@ -991,7 +991,7 @@ export const MultipleEntityEditor = ({ entityType, entityNames, attributeNames, 
   const doDelete = async () => {
     try {
       setIsBusy(true)
-      await Ajax(signal).Workspaces.workspace(namespace, name).deleteAttributeFromEntities(entityType, attributeToEdit, entityNames)
+      await Ajax(signal).Workspaces.workspace(namespace, name).deleteAttributeFromEntities(entityType, attributeToEdit, _.map('name', entities))
       onSuccess()
     } catch (e) {
       onDismiss()
@@ -1002,14 +1002,14 @@ export const MultipleEntityEditor = ({ entityType, entityNames, attributeNames, 
   const boldish = text => span({ style: { fontWeight: 600 } }, [text])
 
   return h(Modal, {
-    title: `Edit fields in ${pluralize('row', entityNames.length, true)}`,
+    title: `Edit fields in ${pluralize('row', entities.length, true)}`,
     onDismiss,
     showButtons: false
   }, [
     consideringDelete ?
       h(Fragment, [
         'Are you sure you want to delete the value ', boldish(attributeToEdit),
-        ' from ', boldish(`${entityNames.length} ${entityType}s`), '?',
+        ' from ', boldish(`${entities.length} ${entityType}s`), '?',
         div({ style: { marginTop: '1rem' } }, [boldish('This cannot be undone.')]),
         div({ style: { marginTop: '1rem', display: 'flex', alignItems: 'baseline' } }, [
           div({ style: { flexGrow: 1 } }),

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -1058,27 +1058,29 @@ export const MultipleEntityEditor = ({ entityType, entities, attributeNames, ent
           ])
         ]),
         attributeToEditTouched ? h(Fragment, [
-          div({ style: { display: 'flex', flexDirection: 'column', marginBottom: '1rem' } }, [
-            h(IdContainer, [id => h(Fragment, [
-              label({ htmlFor: id, style: { marginBottom: '0.5rem', fontWeight: 'bold' } }, 'Operation'),
-              h(Select, {
-                id,
-                options: [
-                  { label: 'Set value', value: Operation.setValue },
-                  { label: 'Convert type', value: Operation.convertType }
-                ],
-                value: operation,
-                onChange: ({ value: newOperation }) => {
-                  setOperation(newOperation)
-                  if (newOperation === Operation.setValue) {
-                    setNewValue('')
-                  }
-                  if (newOperation === Operation.convertType) {
-                    setNewType({ type: 'string' })
-                  }
-                }
-              })
-            ])])
+          div({ style: { marginBottom: '1rem' } }, [
+            fieldset({ style: { border: 'none', margin: 0, padding: 0 } }, [
+              legend({ style: { marginBottom: '0.5rem', fontWeight: 'bold' } }, ['Operation']),
+              div({ style: { display: 'flex', flexDirection: 'row', marginBottom: '0.5rem' } }, [
+                _.map(({ operation: operationOption, label }) => span({
+                  key: operationOption,
+                  style: { display: 'inline-block', marginRight: '1ch', whiteSpace: 'nowrap' }
+                }, [
+                  h(RadioButton, {
+                    text: label,
+                    name: 'operation',
+                    checked: operation === operationOption,
+                    onChange: () => {
+                      setOperation(operationOption)
+                    },
+                    labelStyle: { paddingLeft: '0.5rem' }
+                  })
+                ]), [
+                  { operation: Operation.setValue, label: 'Set value' },
+                  { operation: Operation.convertType, label: 'Convert type' }
+                ])
+              ])
+            ])
           ]),
           Utils.cond(
             [operation === Operation.setValue, () => h(Fragment, [

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -956,7 +956,11 @@ export const MultipleEntityEditor = ({ entityType, entities, attributeNames, ent
     [!_.includes(attributeToEdit, attributeNames), () => 'The selected attribute does not exist.']
   )
 
-  const [operation, setOperation] = useState('setValue')
+  const Operation = {
+    setValue: 'setValue',
+    convertType: 'convertType'
+  }
+  const [operation, setOperation] = useState(Operation.setValue)
 
   const [newValue, setNewValue] = useState('')
   const [newType, setNewType] = useState({ type: 'string' })
@@ -983,8 +987,8 @@ export const MultipleEntityEditor = ({ entityType, entities, attributeNames, ent
         op: 'AddUpdateAttribute',
         attributeName: attributeToEdit,
         addUpdateAttribute: Utils.switchCase(operation,
-          ['setValue', () => prepareAttributeForUpload(newValue)],
-          ['convertType', () => convertAttributeValue(entity.attributes[attributeToEdit], newType.type, newType.entityType)]
+          [Operation.setValue, () => prepareAttributeForUpload(newValue)],
+          [Operation.convertType, () => convertAttributeValue(entity.attributes[attributeToEdit], newType.type, newType.entityType)]
         )
       }]
     }), entities)
@@ -1060,16 +1064,16 @@ export const MultipleEntityEditor = ({ entityType, entities, attributeNames, ent
               h(Select, {
                 id,
                 options: [
-                  { label: 'Set value', value: 'setValue' },
-                  { label: 'Convert type', value: 'convertType' }
+                  { label: 'Set value', value: Operation.setValue },
+                  { label: 'Convert type', value: Operation.convertType }
                 ],
                 value: operation,
                 onChange: ({ value: newOperation }) => {
                   setOperation(newOperation)
-                  if (newOperation === 'setValue') {
+                  if (newOperation === Operation.setValue) {
                     setNewValue('')
                   }
-                  if (newOperation === 'convertType') {
+                  if (newOperation === Operation.convertType) {
                     setNewType({ type: 'string' })
                   }
                 }
@@ -1077,7 +1081,7 @@ export const MultipleEntityEditor = ({ entityType, entities, attributeNames, ent
             ])])
           ]),
           Utils.cond(
-            [operation === 'setValue', () => h(Fragment, [
+            [operation === Operation.setValue, () => h(Fragment, [
               p({ style: { fontWeight: 'bold' } }, ['Set selected values to:']),
               h(AttributeInput, {
                 value: newValue,
@@ -1085,7 +1089,7 @@ export const MultipleEntityEditor = ({ entityType, entities, attributeNames, ent
                 entityTypes
               })
             ])],
-            [operation === 'convertType', () => h(Fragment, [
+            [operation === Operation.convertType, () => h(Fragment, [
               p({ style: { fontWeight: 'bold' } }, ['Convert selected values to:']),
               h(AttributeTypeInput, {
                 value: newType,


### PR DESCRIPTION
Currently, Terra UI allows editing a column in multiple rows of a data table at once. However, the only option when doing so is to set the field to the same value in all selected rows. Some users have requested the ability to, instead of overwriting the field in the selected rows, convert the field's value to a different type. This change adds that capability. With this change, when editing multiple rows, users can choose between "Set value" and "Convert type" operations.

## Before
<img width="460" alt="Screen Shot 2022-08-12 at 6 10 17 PM" src="https://user-images.githubusercontent.com/1156625/184451235-a7bbbd9b-1232-4592-85c8-4c051a40964d.png">

## After

https://user-images.githubusercontent.com/1156625/184451255-a8c428ce-86c4-4689-991e-628e2a4e159b.mov


