### PR TITLE
[TUIM-29] Preserve exit status in Yarn plugin

### DIFF
--- a/.hooks/plugin-warning-logger.js
+++ b/.hooks/plugin-warning-logger.js
@@ -18,12 +18,13 @@ module.exports = {
       wrapScriptExecution(executor, project, locator, scriptName) {
         if (scriptName === 'build' && !process.env.CI) {
           return async () => {
-            await executor()
+            const status = await executor()
             console.warn('\x1b[1m' /* bold */ + '╔'.padEnd(79, '═') + '╗')
             console.warn('║ Be sure to copy a config/xxx.json to build/config.json if you\'re planning to'.padEnd(79) + '║')
             console.warn('║ deploy this build.'.padEnd(79) + '║')
             console.warn('╚'.padEnd(79, '═') + '╝')
             console.warn('\x1b[0m' /* not-bold */)
+            return status
           }
         } else {
           return executor


### PR DESCRIPTION
Discovered this while working on the TypeScript branch. With our custom Yarn plugin, `yarn build` always exits successfully even if the build failed. This is because the [`wrapScriptExecution`](https://yarnpkg.com/advanced/plugin-tutorial#hook-wrapScriptExecution) plugin ignores the return value of the wrapped script.

Steps to reproduce:
- Introduce a syntax error in Terra UI code
- Run `yarn build`
- Run `echo $?` to show the exit status of yarn build
- If the build failed because of a syntax error, yarn build should exit with an error

This does not affect builds on CircleCI because CircleCI sets the `CI` environment variable.