### PR TITLE
[SU-196] Refactor WorkspaceData component state

### DIFF
--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -368,3 +368,5 @@ export const truncateInteger = integer => {
 
   return `${Math.floor(integer / 1000)}k`
 }
+
+export const enumify = keys => _.flow(_.map(key => [key, key]), _.fromPairs)(keys)

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -369,4 +369,9 @@ export const truncateInteger = integer => {
   return `${Math.floor(integer / 1000)}k`
 }
 
-export const enumify = keys => _.flow(_.map(key => [key, key]), _.fromPairs)(keys)
+/**
+ * Convert a list of keys into an enum object.
+ * @param {string[]} keys
+ * @returns {Object}
+ */
+export const enumify = _.flow(_.map(key => [key, key]), _.fromPairs)

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -387,13 +387,7 @@ const DataTableActions = ({ workspace, tableName, rowCount, entityMetadata, onRe
   ])
 }
 
-const workspaceDataTypes = {
-  entities: 'entities',
-  snapshot: 'snapshot',
-  referenceData: 'referenceData',
-  localVariables: 'localVariables',
-  bucketObjects: 'bucketObjects'
-}
+const workspaceDataTypes = Utils.enumify(['entities', 'snapshot', 'referenceData', 'localVariables', 'bucketObjects'])
 
 const WorkspaceData = _.flow(
   forwardRefWithName('WorkspaceData'),

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -429,13 +429,13 @@ const WorkspaceData = _.flow(
       const entityMetadata = await Ajax(signal).Workspaces.workspace(namespace, name).entityMetadata()
 
       if (selectedData?.type === workspaceDataTypes.entities && !entityMetadata[selectedData.entityType]) {
-        setSelectedData(null)
+        setSelectedData(undefined)
       }
       setEntityMetadata(entityMetadata)
     } catch (error) {
       reportError('Error loading workspace entity data', error)
       setEntityMetadataError(true)
-      setSelectedData(null)
+      setSelectedData(undefined)
       setEntityMetadata({})
     }
   }
@@ -455,7 +455,7 @@ const WorkspaceData = _.flow(
     } catch (error) {
       reportError('Error loading workspace snapshot data', error)
       setSnapshotMetadataError(true)
-      setSelectedData(null)
+      setSelectedData(undefined)
       setSnapshotDetails({})
     }
   }
@@ -620,7 +620,7 @@ const WorkspaceData = _.flow(
                     workspace,
                     onRenameTable: () => loadMetadata(),
                     onDeleteTable: tableName => {
-                      setSelectedData(null)
+                      setSelectedData(undefined)
                       setEntityMetadata(_.unset(tableName))
                     }
                   })
@@ -736,7 +736,7 @@ const WorkspaceData = _.flow(
               onSuccess: () => {
                 setDeletingReference(false)
                 if (selectedData?.type === workspaceDataTypes.referenceData && selectedData.reference === deletingReference) {
-                  setSelectedData(null)
+                  setSelectedData(undefined)
                 }
                 refreshWorkspace()
               },
@@ -815,7 +815,7 @@ const WorkspaceData = _.flow(
             },
             onDelete: async () => {
               await loadSnapshotMetadata()
-              setSelectedData(null)
+              setSelectedData(undefined)
               forceRefresh()
             },
             firstRender


### PR DESCRIPTION
The WorkspaceData component uses a selectedDataType state variable to determine what is shown in the main panel. However, this state variable is overloaded. It may contain an ID for the type of data being shown (“localVariables” or “\_\_bucket_objects__”), an array containing a snapshot name and snapshot table name, a reference dataset ID, or a data table name.

https://github.com/DataBiosphere/terra-ui/blob/24e98a2d8e494093fb78c1f5e0a1a76bcfa5ed25/src/pages/workspaces/workspace/Data.js#L422-L432

This makes it difficult to extend WorkspaceData to support additional data types and I want to add support for a new type of data: data table versions ([SU-180](https://broadworkbench.atlassian.net/browse/SU-180)).

This change replaces selectedDataType with selectedData, which is an object containing a type key and additional identifier keys depending on the type. For example: `{ type: workspaceDataTypes.entities, entityType: 'sample' }`.