### PR TITLE
[SU-197] Remove broken state history from data tab

### DIFF
--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -58,7 +58,7 @@ const DataTable = props => {
     childrenBefore,
     editable,
     activeCrossTableTextFilter,
-    persist, refreshKey, firstRender,
+    persist, refreshKey,
     snapshotName,
     deleteColumnUpdateMetadata,
     controlPanelStyle,
@@ -75,11 +75,10 @@ const DataTable = props => {
   const [filteredCount, setFilteredCount] = useState(0)
   const [totalRowCount, setTotalRowCount] = useState(0)
 
-  const stateHistory = firstRender ? StateHistory.get() : {}
-  const [itemsPerPage, setItemsPerPage] = useState(stateHistory.itemsPerPage || 100)
-  const [pageNumber, setPageNumber] = useState(stateHistory.pageNumber || 1)
-  const [sort, setSort] = useState(stateHistory.sort || { field: 'name', direction: 'asc' })
-  const [activeTextFilter, setActiveTextFilter] = useState(stateHistory.activeTextFilter || activeCrossTableTextFilter || '')
+  const [itemsPerPage, setItemsPerPage] = useState(100)
+  const [pageNumber, setPageNumber] = useState(1)
+  const [sort, setSort] = useState({ field: 'name', direction: 'asc' })
+  const [activeTextFilter, setActiveTextFilter] = useState(activeCrossTableTextFilter || '')
 
   const [columnWidths, setColumnWidths] = useState(() => getLocalPref(persistenceId)?.columnWidths || {})
   const [columnState, setColumnState] = useState(() => {

--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -7,7 +7,7 @@ import { Fragment, useState } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
 import { requesterPaysWrapper, withRequesterPaysHandler } from 'src/components/bucket-utils'
 import { ButtonSecondary } from 'src/components/common'
-import { AddColumnModal, AddEntityModal, CreateEntitySetModal, entityAttributeText, EntityDeleter, ModalToolButton, MultipleEntityEditor, saveScroll } from 'src/components/data/data-utils'
+import { AddColumnModal, AddEntityModal, CreateEntitySetModal, entityAttributeText, EntityDeleter, ModalToolButton, MultipleEntityEditor } from 'src/components/data/data-utils'
 import DataTable from 'src/components/data/DataTable'
 import ExportDataModal from 'src/components/data/ExportDataModal'
 import { icon } from 'src/components/icons'
@@ -31,7 +31,6 @@ import Events, { extractWorkspaceDetails } from 'src/libs/events'
 import * as Nav from 'src/libs/nav'
 import { notify } from 'src/libs/notifications'
 import { useCancellation, useOnMount, withDisplayName } from 'src/libs/react-utils'
-import * as StateHistory from 'src/libs/state-history'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 
@@ -210,7 +209,7 @@ const EntitiesContent = ({
   workspace, workspace: {
     workspace: { namespace, name, googleProject }, workspaceSubmissionStats: { runningSubmissionsCount }
   },
-  entityKey, activeCrossTableTextFilter, entityMetadata, setEntityMetadata, loadMetadata, firstRender, snapshotName, deleteColumnUpdateMetadata
+  entityKey, activeCrossTableTextFilter, entityMetadata, setEntityMetadata, loadMetadata, snapshotName, deleteColumnUpdateMetadata
 }) => {
   // State
   const [selectedEntities, setSelectedEntities] = useState({})
@@ -366,7 +365,6 @@ const EntitiesContent = ({
   }
 
   // Render
-  const { initialX, initialY } = firstRender ? StateHistory.get() : {}
   const selectedKeys = _.keys(selectedEntities)
   const selectedLength = selectedKeys.length
 
@@ -374,9 +372,8 @@ const EntitiesContent = ({
     h(IGVBrowser, { selectedFiles: igvFiles, refGenome: igvRefGenome, workspace, onDismiss: () => setIgvFiles(undefined) }) :
     h(Fragment, [
       h(DataTable, {
-        persist: true, firstRender, refreshKey, editable: !snapshotName && !Utils.editWorkspaceError(workspace),
+        persist: true, refreshKey, editable: !snapshotName && !Utils.editWorkspaceError(workspace),
         entityType: entityKey, activeCrossTableTextFilter, entityMetadata, setEntityMetadata, googleProject, workspaceId: { namespace, name }, workspace,
-        onScroll: saveScroll, initialX, initialY,
         loadMetadata,
         snapshotName,
         selectionModel: {

--- a/src/components/data/LocalVariablesContent.js
+++ b/src/components/data/LocalVariablesContent.js
@@ -4,7 +4,7 @@ import { Fragment, useEffect, useState } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
 import { AutoSizer } from 'react-virtualized'
 import { DeleteConfirmationModal, Link, Select, spinnerOverlay } from 'src/components/common'
-import { renderDataCell, saveScroll } from 'src/components/data/data-utils'
+import { renderDataCell } from 'src/components/data/data-utils'
 import Dropzone from 'src/components/Dropzone'
 import FloatingActionButton from 'src/components/FloatingActionButton'
 import { icon } from 'src/components/icons'
@@ -14,7 +14,6 @@ import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { withErrorReporting } from 'src/libs/error'
 import { useCancellation } from 'src/libs/react-utils'
-import * as StateHistory from 'src/libs/state-history'
 import * as Utils from 'src/libs/utils'
 
 
@@ -40,7 +39,7 @@ export const convertInitialAttributes = _.flow(
   _.sortBy(_.first)
 )
 
-const LocalVariablesContent = ({ workspace, workspace: { workspace: { namespace, name } }, firstRender, refreshKey }) => {
+const LocalVariablesContent = ({ workspace, workspace: { workspace: { namespace, name } }, refreshKey }) => {
   const signal = useCancellation()
 
   const [editIndex, setEditIndex] = useState()
@@ -145,7 +144,6 @@ const LocalVariablesContent = ({ workspace, workspace: { workspace: { namespace,
     FileSaver.saveAs(blob, `${name}-workspace-attributes.tsv`)
   })
 
-  const { initialY } = firstRender ? StateHistory.get() : {}
   return h(Dropzone, {
     disabled: !!Utils.editWorkspaceError(workspace),
     style: { flex: 1, display: 'flex', flexDirection: 'column' },
@@ -177,8 +175,6 @@ const LocalVariablesContent = ({ workspace, workspace: { workspace: { namespace,
       h(AutoSizer, [({ width, height }) => h(FlexTable, {
         'aria-label': 'workspace data local variables table',
         width, height, rowCount: amendedAttributes.length,
-        onScroll: y => saveScroll(0, y),
-        initialY,
         hoverHighlight: true,
         noContentMessage: _.isEmpty(initialAttributes) ? 'No Workspace Data defined' : 'No matching data',
         border: false,

--- a/src/components/data/UploadPreviewTable.js
+++ b/src/components/data/UploadPreviewTable.js
@@ -3,7 +3,7 @@ import { Fragment, useEffect, useMemo, useRef, useState } from 'react'
 import { code, div, em, h, h3, p, span, strong } from 'react-hyperscript-helpers'
 import { AutoSizer } from 'react-virtualized'
 import { ButtonPrimary, ButtonSecondary, fixedSpinnerOverlay } from 'src/components/common'
-import { renderDataCell, saveScroll } from 'src/components/data/data-utils'
+import { renderDataCell } from 'src/components/data/data-utils'
 import { icon } from 'src/components/icons'
 import { NameModal } from 'src/components/NameModal'
 import { GridTable, HeaderCell, Resizable, Sortable } from 'src/components/table'
@@ -13,7 +13,6 @@ import colors from 'src/libs/colors'
 import { withErrorReporting } from 'src/libs/error'
 import { getLocalPref } from 'src/libs/prefs'
 import { useCancellation, useOnMount } from 'src/libs/react-utils'
-import * as StateHistory from 'src/libs/state-history'
 import * as Utils from 'src/libs/utils'
 
 
@@ -32,11 +31,10 @@ const UploadDataTable = props => {
   const [metadata, setMetadata] = useState(null)
   const [metadataLoading, setMetadataLoading] = useState(false)
 
-  const [sort, setSort] = useState(StateHistory.get().sort || { field: 'name', direction: 'asc' })
+  const [sort, setSort] = useState({ field: 'name', direction: 'asc' })
   const [renamingTable, setRenamingTable] = useState(false)
 
   const [columnWidths, setColumnWidths] = useState(() => getLocalPref(persistenceId)?.columnWidths || {})
-  const { initialX, initialY } = StateHistory.get() || {}
 
   const table = useRef()
   const signal = useCancellation()
@@ -89,10 +87,6 @@ const UploadDataTable = props => {
   useEffect(() => {
     table.current?.recomputeColumnSizes()
   }, [columnWidths])
-
-  useEffect(() => {
-    StateHistory.update({ sort })
-  }, [sort])
 
   // Move the focus to the header the first time this panel is rendered
   const header = useRef()
@@ -214,7 +208,7 @@ const UploadDataTable = props => {
               width, height,
               rowCount: sortedRows.length,
               noContentMessage: `No ${entityType}s to display.`,
-              onScroll: saveScroll, initialX, initialY, sort,
+              sort,
               columns: [
                 ..._.map(name => {
                   const thisWidth = columnWidths[name] || 300

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -25,7 +25,6 @@ import Events from 'src/libs/events'
 import { FormLabel } from 'src/libs/forms'
 import { notify } from 'src/libs/notifications'
 import { asyncImportJobStore, requesterPaysProjectStore } from 'src/libs/state'
-import * as StateHistory from 'src/libs/state-history'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 import validate from 'validate.js'
@@ -1457,10 +1456,6 @@ export const HeaderOptions = ({ sort, field, onSort, extraActions, children }) =
     div({ style: { marginRight: '0.5rem', marginLeft: 'auto' } })
   ])
 }
-
-export const saveScroll = _.throttle(100, (initialX, initialY) => {
-  StateHistory.update({ initialX, initialY })
-})
 
 // Accepts two arrays of attribute names. Concatenates, uniquifies, and sorts those attribute names, returning
 // the resultant array. This is broken out into this helper method so as to easily control the criteria for uniqueness


### PR DESCRIPTION
Several components on the data tab read information from state history (scroll position, current page, etc). However, no data they read this way is ever visible to a user.

Some children of WorkspaceData read from state history on their first render `firstRender`:
https://github.com/DataBiosphere/terra-ui/blob/86327f299540fe87d0570c7e9e2dcff597492f28/src/components/data/EntitiesContent.js#L369

`firstRender` is a state variable in WorkspaceData and passed down to children:
https://github.com/DataBiosphere/terra-ui/blob/86327f299540fe87d0570c7e9e2dcff597492f28/src/pages/workspaces/workspace/Data.js#L393-L401

On mount, WorkspaceData loads metadata:
https://github.com/DataBiosphere/terra-ui/blob/86327f299540fe87d0570c7e9e2dcff597492f28/src/pages/workspaces/workspace/Data.js#L528-L531

Which clears entityMetadata state:
https://github.com/DataBiosphere/terra-ui/blob/86327f299540fe87d0570c7e9e2dcff597492f28/src/pages/workspaces/workspace/Data.js#L434-L436

While entity metadata is loading, a spinner is the only child rendered. Other children are unmounted:
https://github.com/DataBiosphere/terra-ui/blob/86327f299540fe87d0570c7e9e2dcff597492f28/src/pages/workspaces/workspace/Data.js#L553-L555

Thus, by the time children such as EntitiesContent are mounted, firstRender will be false and they will not use anything from state history.


I could attempt to make this work correctly. However, the WorkspaceData component is messy enough that I'd rather clear out broken functionality and reduce complexity before attempting a refactor.

Also, currently, using state history in the data tab is complicated by having multiple pages (data tables, snapshots, reference data, files, etc) all share the same URL (`<namespace>/<name>/data`). Thus, they also share the same state history entry, which is what necessitated reading state history based on `firstRender`. This functionality will be much easier to restore in a possible future where all of those pages have their own URLs and their own entries in state history.


This also removes state history from UploadPreviewTable. There, any restored state is useless without the table data itself, which is ephemeral.