### PR TITLE
[IA-3663] Updated defaultDataprocWorkerDiskSize from 120 to 150.

### DIFF
--- a/src/libs/runtime-utils.js
+++ b/src/libs/runtime-utils.js
@@ -49,7 +49,7 @@ export const mapToPdTypes = _.map(updatePdType)
 
 // Dataproc clusters don't have persistent disks.
 export const defaultDataprocMasterDiskSize = 150
-export const defaultDataprocWorkerDiskSize = 120
+export const defaultDataprocWorkerDiskSize = 150
 // Since Leonardo started supporting persistent disks (PDs) for GCE VMs, boot disk size for a GCE VM
 // with a PD has been non-user-customizable. Terra UI uses the value below for cost estimate calculations only.
 export const defaultGceBootDiskSize = 120


### PR DESCRIPTION
## Description

Currently there is a UI bug where 120 is shown as the default and lowest value for worker dataproc disk sizes. However, when a user goes to change that value to anything under 150, it will "jump" to 150.

Additionally, the runtimeDefault in Leonardo is set to 150. This will fix the "jump" issue and simultaneously synchronize default values with Leonardo.

## Implementation

Update the default dataproc disk size to 150.

TODO: Fix the "jump" issue if dataProc diskSize is set to less than 150 (future proofing)

## Testing

Go to create a cluster for a runtime, confirm that 150 is the minimum.