### PR TITLE
[ID-204] Update channel for Identiteam test failure notifications

### DIFF
--- a/integration-tests/slack/slack-notify-channels.json
+++ b/integration-tests/slack/slack-notify-channels.json
@@ -86,7 +86,7 @@
       ]
     },
     {
-      "name": "dsp-identiteam-alerts",
+      "name": "identiteam-alerts",
       "id": "C03HV2AD20N",
       "tests": [
         {

--- a/integration-tests/slack/slack-notify-channels.json
+++ b/integration-tests/slack/slack-notify-channels.json
@@ -86,8 +86,8 @@
       ]
     },
     {
-      "name": "dsp-identiteam",
-      "id": "C03GMG4DUSE",
+      "name": "dsp-identiteam-alerts",
+      "id": "C03HV2AD20N",
       "tests": [
         {
           "name": "register-user"


### PR DESCRIPTION
Send notifications to identiteam-alerts instead of dsp-identiteam.

https://broadinstitute.slack.com/archives/C03GMG4DUSE/p1660832441277579