### PR TITLE
ID-204 Make Identiteam's tests go to identiteam-alerts slack channel

### DIFF
--- a/integration-tests/slack/slack-notify-channels.json
+++ b/integration-tests/slack/slack-notify-channels.json
@@ -83,8 +83,8 @@
       ]
     },
     {
-      "name": "dsp-identiteam",
-      "id": "C03GMG4DUSE",
+      "name": "identiteam-alerts",
+      "id": "C03HV2AD20N",
       "tests": [
         {
           "name": "register-user"


### PR DESCRIPTION
Just updating the slack notification channel for `register-user` and `request-access` tests.