### PR TITLE
[SU-179][SU-182] Add ability to save and view data table versions

### DIFF
--- a/src/components/data/data-table-versions.js
+++ b/src/components/data/data-table-versions.js
@@ -1,0 +1,134 @@
+import _ from 'lodash/fp'
+import { Fragment, useEffect, useState } from 'react'
+import { div, h, h1, li, ol, p } from 'react-hyperscript-helpers'
+import { ButtonPrimary, ButtonSecondary, DeleteConfirmationModal, IdContainer, spinnerOverlay } from 'src/components/common'
+import { parseGsUri } from 'src/components/data/data-utils'
+import { icon, spinner } from 'src/components/icons'
+import { TextInput } from 'src/components/input'
+import Modal from 'src/components/Modal'
+import { Ajax } from 'src/libs/ajax'
+import colors from 'src/libs/colors'
+import { FormLabel } from 'src/libs/forms'
+import { useCancellation } from 'src/libs/react-utils'
+import * as Style from 'src/libs/style'
+import * as Utils from 'src/libs/utils'
+
+
+const DownloadVersionButton = ({ url }) => {
+  const signal = useCancellation()
+  const [downloadUrl, setDownloadUrl] = useState()
+
+  useEffect(() => {
+    const loadUrl = async () => {
+      try {
+        setDownloadUrl(null)
+        const [bucket, object] = parseGsUri(url)
+        const { url: signedUrl } = await Ajax(signal).DrsUriResolver.getSignedUrl({ bucket, object })
+        setDownloadUrl(signedUrl)
+      } catch (error) {
+        setDownloadUrl(null)
+      }
+    }
+    loadUrl()
+  }, [signal, url])
+
+  return h(ButtonPrimary, {
+    disabled: !downloadUrl,
+    href: downloadUrl
+  }, [
+    !downloadUrl && icon('loadingSpinner', { size: 12, style: { marginRight: '1ch' } }),
+    'Download TSV'
+  ])
+}
+
+export const DataTableVersion = ({ version, onDelete }) => {
+  const { entityType, timestamp, description } = version
+
+  const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+
+  return div({ style: { padding: '1rem' } }, [
+    h1({
+      style: {
+        ...Style.elements.sectionHeader, fontSize: 20,
+        paddingBottom: '0.5rem', borderBottom: Style.standardLine, marginBottom: '1rem'
+      }
+    }, [
+      `${entityType} (${Utils.makeCompleteDate(timestamp)})`
+    ]),
+    p([description || 'No description']),
+    div({ style: { marginBottom: '1rem' } }, [
+      h(DownloadVersionButton, { url: version.url })
+    ]),
+    div({ style: { marginBottom: '1rem' } }, [
+      h(ButtonPrimary, {
+        danger: true,
+        disabled: deleting,
+        onClick: () => setShowDeleteConfirmation(true)
+      }, ['Delete'])
+    ]),
+    showDeleteConfirmation && h(DeleteConfirmationModal, {
+      objectType: 'version',
+      objectName: Utils.makeCompleteDate(timestamp),
+      onConfirm: async () => {
+        setShowDeleteConfirmation(false)
+        try {
+          setDeleting(true)
+          await onDelete()
+        } catch (err) {
+          setDeleting(false)
+        }
+      },
+      onDismiss: () => {
+        setShowDeleteConfirmation(false)
+      }
+    }),
+    deleting && spinnerOverlay
+  ])
+}
+
+export const DataTableVersions = ({ loading, error, versions, onClickVersion }) => {
+  return div({ style: { padding: '1rem 0.5rem 1rem 1.5rem', borderBottom: `1px solid ${colors.dark(0.2)}` } }, [
+    Utils.cond(
+      [loading, () => div({ style: { display: 'flex', alignItems: 'center' } }, [
+        spinner({ size: 16, style: { marginRight: '1ch' } }),
+        'Loading version history'
+      ])],
+      [error, () => div({ style: { display: 'flex', alignItems: 'center' } }, [
+        // spinner({ size: 16, style: { marginRight: '1ch' } }),
+        'Error loading version history'
+      ])],
+      [_.isEmpty(versions), () => 'No versions saved'],
+      () => h(IdContainer, [id => h(Fragment, [
+        div({ id, style: { marginBottom: '0.5rem' } }, ['Version history']),
+        ol({ 'aria-labelledby': id, style: { margin: 0, padding: 0, listStyleType: 'none' } }, [
+          _.map(version => {
+            return li({ key: version.url }, [
+              h(ButtonSecondary, { onClick: () => onClickVersion(version) }, [Utils.makeCompleteDate(version.timestamp)])
+            ])
+          }, versions)
+        ])
+      ])])
+    )
+  ])
+}
+
+export const DataTableSaveVersionModal = ({ entityType, onDismiss, onSubmit }) => {
+  const [description, setDescription] = useState('')
+
+  return h(Modal, {
+    onDismiss,
+    title: `Save version of ${entityType}`,
+    okButton: h(ButtonPrimary, { onClick: () => onSubmit({ description }) }, ['Save'])
+  }, [
+    h(IdContainer, [id => h(Fragment, [
+      h(FormLabel, { htmlFor: id }, ['Description']),
+      h(TextInput, {
+        id,
+        placeholder: 'Enter a description',
+        value: description,
+        onChange: setDescription
+      })
+    ])])
+  ])
+}

--- a/src/components/data/data-table-versions.js
+++ b/src/components/data/data-table-versions.js
@@ -56,6 +56,7 @@ export const DataTableVersion = ({ version, onDelete }) => {
     }, [
       `${entityType} (${Utils.makeCompleteDate(timestamp)})`
     ]),
+    version.createdBy && p([`Created by: ${version.createdBy}`]),
     p([description || 'No description']),
     div({ style: { marginBottom: '1rem' } }, [
       h(DownloadVersionButton, { url: version.url })

--- a/src/components/data/data-table-versions.js
+++ b/src/components/data/data-table-versions.js
@@ -17,26 +17,30 @@ import * as Utils from 'src/libs/utils'
 const DownloadVersionButton = ({ url }) => {
   const signal = useCancellation()
   const [downloadUrl, setDownloadUrl] = useState()
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(false)
 
   useEffect(() => {
-    const loadUrl = async () => {
+    const loadUrl = Utils.withBusyState(setLoading, async () => {
       try {
         setDownloadUrl(null)
+        setError(false)
         const [bucket, object] = parseGsUri(url)
         const { url: signedUrl } = await Ajax(signal).DrsUriResolver.getSignedUrl({ bucket, object })
         setDownloadUrl(signedUrl)
       } catch (error) {
-        setDownloadUrl(null)
+        setError(true)
       }
-    }
+    })
     loadUrl()
   }, [signal, url])
 
   return h(ButtonPrimary, {
     disabled: !downloadUrl,
-    href: downloadUrl
+    href: downloadUrl,
+    tooltip: !!error && 'Error generating download URL'
   }, [
-    !downloadUrl && icon('loadingSpinner', { size: 12, style: { marginRight: '1ch' } }),
+    loading && icon('loadingSpinner', { size: 12, style: { marginRight: '1ch' } }),
     'Download TSV'
   ])
 }

--- a/src/components/data/data-table-versions.js
+++ b/src/components/data/data-table-versions.js
@@ -105,11 +105,12 @@ export const DataTableVersions = ({ loading, error, versions, savingNewVersion, 
           'Saving new version'
         ]),
         ol({ 'aria-labelledby': id, style: { margin: 0, padding: 0, listStyleType: 'none' } }, [
-          _.map(version => {
-            return li({ key: version.url }, [
-              h(ButtonSecondary, { onClick: () => onClickVersion(version) }, [Utils.makeCompleteDate(version.timestamp)])
+          _.map(([index, version]) => {
+            return li({ key: version.url, style: { marginBottom: index < versions.length - 1 ? '0.5rem' : 0 } }, [
+              h(ButtonSecondary, { style: { height: 'auto' }, onClick: () => onClickVersion(version) }, [Utils.makeCompleteDate(version.timestamp)]),
+              div({ style: { ...Style.noWrapEllipsis } }, [version.description || 'No description'])
             ])
-          }, versions)
+          }, Utils.toIndexPairs(versions))
         ])
       ])])
     )

--- a/src/components/data/data-table-versions.js
+++ b/src/components/data/data-table-versions.js
@@ -87,7 +87,7 @@ export const DataTableVersion = ({ version, onDelete }) => {
   ])
 }
 
-export const DataTableVersions = ({ loading, error, versions, onClickVersion }) => {
+export const DataTableVersions = ({ loading, error, versions, savingNewVersion, onClickVersion }) => {
   return div({ style: { padding: '1rem 0.5rem 1rem 1.5rem', borderBottom: `1px solid ${colors.dark(0.2)}` } }, [
     Utils.cond(
       [loading, () => div({ style: { display: 'flex', alignItems: 'center' } }, [
@@ -95,12 +95,15 @@ export const DataTableVersions = ({ loading, error, versions, onClickVersion }) 
         'Loading version history'
       ])],
       [error, () => div({ style: { display: 'flex', alignItems: 'center' } }, [
-        // spinner({ size: 16, style: { marginRight: '1ch' } }),
         'Error loading version history'
       ])],
-      [_.isEmpty(versions), () => 'No versions saved'],
+      [_.isEmpty(versions) && !savingNewVersion, () => 'No versions saved'],
       () => h(IdContainer, [id => h(Fragment, [
         div({ id, style: { marginBottom: '0.5rem' } }, ['Version history']),
+        savingNewVersion && div({ style: { display: 'flex', alignItems: 'center' } }, [
+          spinner({ size: 16, style: { marginRight: '1ch' } }),
+          'Saving new version'
+        ]),
         ol({ 'aria-labelledby': id, style: { margin: 0, padding: 0, listStyleType: 'none' } }, [
           _.map(version => {
             return li({ key: version.url }, [

--- a/src/components/icons.js
+++ b/src/components/icons.js
@@ -48,7 +48,7 @@ export const icon = (shape, { size = 16, ...props } = {}) => {
   return _.invokeArgs(shape, [{ size, 'data-icon': shape, ...props }], iconDict)
 }
 
-export const spinner = ({ message = 'Loading', ...props }) => h(Fragment, [
+export const spinner = ({ message = 'Loading', ...props } = {}) => h(Fragment, [
   icon('loadingSpinner', _.merge({ size: 24, style: { color: colors.primary() } }, props)),
   h(DelayedRender, { delay: 150 }, [div({ className: 'sr-only', role: 'alert' }, [message])])
 ])

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -961,6 +961,8 @@ const Workspaces = signal => ({
         return fetchRawls(`${root}/entities/delete`, _.mergeAll([authOpts(), jsonBody(entities), { signal, method: 'POST' }]))
       },
 
+      getEntitiesTsv: entityType => fetchOrchestration(`api/workspaces/${namespace}/${name}/entities/${entityType}/tsv?model=flexible`, _.mergeAll([authOpts(), { signal }])).then(r => r.text()),
+
       copyEntities: async (destNamespace, destName, entityType, entities, link) => {
         const payload = {
           sourceWorkspace: { namespace, name },

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1245,6 +1245,13 @@ const Buckets = signal => ({
     )
   },
 
+  patch: async (googleProject, bucket, name, metadata) => {
+    return fetchBuckets(
+      `storage/v1/b/${bucket}/o/${encodeURIComponent(name)}`,
+      _.mergeAll([authOpts(await saToken(googleProject)), jsonBody(metadata), { signal, method: 'PATCH' }])
+    )
+  },
+
   //TODO: this should be deprecated in favor of the smarter `analysis` set of functions
   notebook: (googleProject, bucket, name) => {
     const bucketUrl = `storage/v1/b/${bucket}/o`

--- a/src/libs/config.js
+++ b/src/libs/config.js
@@ -13,3 +13,4 @@ export const getConfig = () => {
  */
 export const isCromwellAppVisible = () => getConfig().isCromwellAppVisible
 export const isDataBrowserFrontPage = () => false
+export const isDataTableVersioningEnabled = () => getConfig().isDataTableVersioningEnabled

--- a/src/libs/data-table-versions.js
+++ b/src/libs/data-table-versions.js
@@ -8,7 +8,7 @@ import { useCancellation } from 'src/libs/react-utils'
 import * as Utils from 'src/libs/utils'
 
 
-export const dataTableVersionsRoot = '.data-table-versions'
+const dataTableVersionsPathRoot = '.data-table-versions'
 
 export const saveDataTableVersion = async (workspace, entityType, { description = null } = {}) => {
   const { workspace: { namespace, name, googleProject, bucketName } } = workspace
@@ -19,9 +19,9 @@ export const saveDataTableVersion = async (workspace, entityType, { description 
   const tsvContent = await Ajax().Workspaces.workspace(namespace, name).getEntitiesTsv(entityType)
 
   const tsvFile = new File([tsvContent], versionName, { type: 'text/tab-separated-values' })
-  await Ajax().Buckets.upload(googleProject, bucketName, `${dataTableVersionsRoot}/${entityType}/`, tsvFile)
+  await Ajax().Buckets.upload(googleProject, bucketName, `${dataTableVersionsPathRoot}/${entityType}/`, tsvFile)
 
-  const objectName = `${dataTableVersionsRoot}/${entityType}/${versionName}`
+  const objectName = `${dataTableVersionsPathRoot}/${entityType}/${versionName}`
   const createdBy = getUser().email
   await Ajax().Buckets.patch(googleProject, bucketName, objectName, {
     metadata: { createdBy, entityType, timestamp, description }
@@ -39,7 +39,7 @@ export const saveDataTableVersion = async (workspace, entityType, { description 
 export const listDataTableVersions = async (workspace, entityType, { signal } = {}) => {
   const { workspace: { googleProject, bucketName } } = workspace
 
-  const prefix = `${dataTableVersionsRoot}/${entityType}/`
+  const prefix = `${dataTableVersionsPathRoot}/${entityType}/`
   const { items } = await Ajax(signal).Buckets.listAll(googleProject, bucketName, { prefix })
 
   return _.flow(

--- a/src/libs/data-table-versions.js
+++ b/src/libs/data-table-versions.js
@@ -2,6 +2,7 @@ import _ from 'lodash/fp'
 import { useState } from 'react'
 import { parseGsUri } from 'src/components/data/data-utils'
 import { Ajax } from 'src/libs/ajax'
+import { getUser } from 'src/libs/auth'
 import { notify } from 'src/libs/notifications'
 import { useCancellation } from 'src/libs/react-utils'
 import * as Utils from 'src/libs/utils'
@@ -21,8 +22,10 @@ export const saveDataTableVersion = async (workspace, entityType, { description 
   await Ajax().Buckets.upload(googleProject, bucketName, `${dataTableVersionsRoot}/${entityType}/`, tsvFile)
 
   const objectName = `${dataTableVersionsRoot}/${entityType}/${versionName}`
+  const createdBy = getUser().email
   await Ajax().Buckets.patch(googleProject, bucketName, objectName, {
     metadata: {
+      createdBy,
       entityType,
       timestamp,
       description
@@ -31,6 +34,7 @@ export const saveDataTableVersion = async (workspace, entityType, { description 
 
   return {
     url: `gs://${bucketName}/${objectName}`,
+    createdBy,
     entityType,
     timestamp,
     description
@@ -47,6 +51,7 @@ export const listDataTableVersions = async (workspace, entityType, { signal } = 
     _.filter(item => item.metadata?.entityType && item.metadata?.timestamp),
     _.map(item => ({
       url: `gs://${item.bucket}/${item.name}`,
+      createdBy: item.metadata.createdBy,
       entityType,
       timestamp: parseInt(item.metadata.timestamp),
       description: item.metadata.description

--- a/src/libs/data-table-versions.js
+++ b/src/libs/data-table-versions.js
@@ -24,12 +24,7 @@ export const saveDataTableVersion = async (workspace, entityType, { description 
   const objectName = `${dataTableVersionsRoot}/${entityType}/${versionName}`
   const createdBy = getUser().email
   await Ajax().Buckets.patch(googleProject, bucketName, objectName, {
-    metadata: {
-      createdBy,
-      entityType,
-      timestamp,
-      description
-    }
+    metadata: { createdBy, entityType, timestamp, description }
   })
 
   return {

--- a/src/libs/data-table-versions.js
+++ b/src/libs/data-table-versions.js
@@ -1,0 +1,99 @@
+import _ from 'lodash/fp'
+import { useState } from 'react'
+import { parseGsUri } from 'src/components/data/data-utils'
+import { Ajax } from 'src/libs/ajax'
+import { notify } from 'src/libs/notifications'
+import { useCancellation } from 'src/libs/react-utils'
+import * as Utils from 'src/libs/utils'
+
+
+export const dataTableVersionsRoot = '.data-table-versions'
+
+export const saveDataTableVersion = async (workspace, entityType, { description = null } = {}) => {
+  const { workspace: { namespace, name, googleProject, bucketName } } = workspace
+
+  const timestamp = (new Date()).getTime()
+  const versionName = `${entityType}.v${timestamp}`
+
+  const tsvContent = await Ajax().Workspaces.workspace(namespace, name).getEntitiesTsv(entityType)
+
+  const tsvFile = new File([tsvContent], versionName, { type: 'text/tab-separated-values' })
+  await Ajax().Buckets.upload(googleProject, bucketName, `${dataTableVersionsRoot}/${entityType}/`, tsvFile)
+
+  const objectName = `${dataTableVersionsRoot}/${entityType}/${versionName}`
+  await Ajax().Buckets.patch(googleProject, bucketName, objectName, {
+    metadata: {
+      entityType,
+      timestamp,
+      description
+    }
+  })
+
+  return {
+    url: `gs://${bucketName}/${objectName}`,
+    entityType,
+    timestamp,
+    description
+  }
+}
+
+export const listDataTableVersions = async (workspace, entityType, { signal } = {}) => {
+  const { workspace: { googleProject, bucketName } } = workspace
+
+  const prefix = `${dataTableVersionsRoot}/${entityType}/`
+  const { items } = await Ajax(signal).Buckets.listAll(googleProject, bucketName, { prefix })
+
+  return _.flow(
+    _.filter(item => item.metadata?.entityType && item.metadata?.timestamp),
+    _.map(item => ({
+      url: `gs://${item.bucket}/${item.name}`,
+      entityType,
+      timestamp: parseInt(item.metadata.timestamp),
+      description: item.metadata.description
+    })),
+    _.sortBy(version => -version.timestamp)
+  )(items)
+}
+
+export const deleteDataTableVersion = async (workspace, version) => {
+  const { workspace: { googleProject, bucketName } } = workspace
+
+  const [, objectName] = parseGsUri(version.url)
+  await Ajax().Buckets.delete(googleProject, bucketName, objectName)
+}
+
+export const useDataTableVersions = workspace => {
+  const signal = useCancellation()
+  // { [entityType: string]: { loading: boolean, error: boolean, versions: Version[] }
+  const [dataTableVersions, setDataTableVersions] = useState({})
+
+  return {
+    dataTableVersions,
+
+    loadDataTableVersions: async entityType => {
+      setDataTableVersions(_.update(entityType, _.flow(_.set('loading', true), _.set('error', false))))
+      try {
+        const versions = await listDataTableVersions(workspace, entityType, { signal })
+        setDataTableVersions(_.update(entityType, _.set('versions', versions)))
+      } catch (err) {
+        setDataTableVersions(_.update(entityType, _.set('error', true)))
+        throw err
+      } finally {
+        setDataTableVersions(_.update(entityType, _.set('loading', false)))
+      }
+    },
+
+    saveDataTableVersion: async (entityType, { description = null } = {}) => {
+      const newVersion = await saveDataTableVersion(workspace, entityType, { description })
+      notify('success', `Saved version of ${entityType}`, { timeout: 3000 })
+      setDataTableVersions(_.update([entityType, 'versions'],
+        _.flow(_.defaultTo([]), Utils.append(newVersion), _.sortBy(version => -version.timestamp))
+      ))
+    },
+
+    deleteDataTableVersion: async version => {
+      await deleteDataTableVersion(workspace, version)
+      setDataTableVersions(_.update([version.entityType, 'versions'], _.remove({ timestamp: version.timestamp })))
+    }
+  }
+}

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -634,7 +634,10 @@ const WorkspaceData = _.flow(
                         setEntityMetadata(_.unset(tableName))
                       },
                       isShowingVersionHistory,
-                      onSaveVersion: withErrorReporting('Error saving version', versionOpts => saveDataTableVersion(type, versionOpts)),
+                      onSaveVersion: withErrorReporting('Error saving version', versionOpts => {
+                        setShowDataTableVersionHistory(_.set(type, true))
+                        return saveDataTableVersion(type, versionOpts)
+                      }),
                       onToggleVersionHistory: withErrorReporting('Error loading version history', showVersionHistory => {
                         setShowDataTableVersionHistory(_.set(type, showVersionHistory))
                         if (showVersionHistory) {

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -23,7 +23,7 @@ import { SnapshotInfo } from 'src/components/workspace-utils'
 import { Ajax } from 'src/libs/ajax'
 import { getUser } from 'src/libs/auth'
 import colors from 'src/libs/colors'
-import { getConfig } from 'src/libs/config'
+import { getConfig, isDataTableVersioningEnabled } from 'src/libs/config'
 import { useDataTableVersions } from 'src/libs/data-table-versions'
 import { reportError, withErrorReporting } from 'src/libs/error'
 import Events, { extractWorkspaceDetails } from 'src/libs/events'
@@ -335,9 +335,11 @@ const DataTableActions = ({ workspace, tableName, rowCount, entityMetadata, onRe
           disabled: !!editWorkspaceErrorMessage,
           tooltip: editWorkspaceErrorMessage || ''
         }, 'Delete table'),
-        h(MenuDivider),
-        h(MenuButton, { onClick: () => setSavingVersion(true) }, ['Save version']),
-        h(MenuButton, { onClick: () => onToggleVersionHistory(!isShowingVersionHistory) }, [`${isShowingVersionHistory ? 'Hide' : 'Show'} version history`])
+        isDataTableVersioningEnabled() && h(Fragment, [
+          h(MenuDivider),
+          h(MenuButton, { onClick: () => setSavingVersion(true) }, ['Save version']),
+          h(MenuButton, { onClick: () => onToggleVersionHistory(!isShowingVersionHistory) }, [`${isShowingVersionHistory ? 'Hide' : 'Show'} version history`])
+        ])
       ])
     }, [
       h(Clickable, {

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -72,14 +72,14 @@ const SearchResultsPill = ({ filteredCount, searching }) => {
   searching ? [icon('loadingSpinner', { size: 13, color: 'white' })] : `${Utils.truncateInteger(filteredCount)}`)
 }
 
-const DataTypeButton = ({ selected, entityName, children, entityCount, iconName = 'listAlt', iconSize = 14, buttonStyle, filteredCount, crossTableSearchInProgress, activeCrossTableTextFilter, after, ...props }) => {
+const DataTypeButton = ({ selected, entityName, children, entityCount, iconName = 'listAlt', iconSize = 14, buttonStyle, filteredCount, crossTableSearchInProgress, activeCrossTableTextFilter, after, wrapperProps, ...props }) => {
   const isEntity = entityName !== undefined
 
   return h(Interactive, {
+    ...wrapperProps,
     style: { ...Style.navList.itemContainer(selected), backgroundColor: selected ? colors.dark(0.1) : 'white' },
     hover: Style.navList.itemHover(selected),
-    as: 'div',
-    role: 'listitem'
+    as: 'div'
   }, [
     h(Clickable, {
       style: { ...Style.navList.item(selected), flex: '1 1 auto', minWidth: 0, color: colors.accent(1.2), ...buttonStyle },
@@ -591,6 +591,7 @@ const WorkspaceData = _.flow(
               _.map(([type, typeDetails]) => {
                 return h(DataTypeButton, {
                   key: type,
+                  wrapperProps: { role: 'listitem' },
                   selected: selectedData?.type === workspaceDataTypes.entities && selectedData.entityType === type,
                   entityName: type,
                   entityCount: typeDetails.count,
@@ -662,6 +663,7 @@ const WorkspaceData = _.flow(
                     _.map(([tableName, { count }]) => {
                       const canCompute = !!(workspace?.canCompute)
                       return h(DataTypeButton, {
+                        wrapperProps: { role: 'listitem' },
                         buttonStyle: { borderBottom: 0, height: 40, ...(canCompute ? {} : { color: colors.dark(0.25) }) },
                         tooltip: canCompute ?
                           tableName ? `${tableName} (${count} row${count === 1 ? '' : 's'})` : undefined :
@@ -695,6 +697,7 @@ const WorkspaceData = _.flow(
               title: 'Reference Data'
             }, [_.map(type => h(DataTypeButton, {
               key: type,
+              wrapperProps: { role: 'listitem' },
               selected: selectedData?.type === workspaceDataTypes.referenceData && selectedData.reference === type,
               onClick: () => {
                 setSelectedData({ type: workspaceDataTypes.referenceData, reference: type })
@@ -744,6 +747,7 @@ const WorkspaceData = _.flow(
               title: 'Other Data'
             }, [
               h(DataTypeButton, {
+                wrapperProps: { role: 'listitem' },
                 selected: selectedData?.type === workspaceDataTypes.localVariables,
                 onClick: () => {
                   setSelectedData({ type: workspaceDataTypes.localVariables })
@@ -751,6 +755,7 @@ const WorkspaceData = _.flow(
                 }
               }, ['Workspace Data']),
               h(DataTypeButton, {
+                wrapperProps: { role: 'listitem' },
                 iconName: 'folder', iconSize: 18,
                 selected: selectedData?.type === workspaceDataTypes.bucketObjects,
                 onClick: () => {


### PR DESCRIPTION
This allows users to save "versions" of a data table. Currently, saving a version downloads the data table as a TSV and saves it in the workspace bucket. Version TSVs are saved under a specific prefix and have some metadata attached. This is not necessarily the final way that versions will be stored and it does have its limitations (users can alter the version files in the workspace bucket), but we think it's ok for a proof of concept that will let us try out the UI and workflow with users.

Saved versions can be viewed by clicking the "Show version history" button in the table menu in the data tab sidebar. Selecting a version in that list shows options to download or delete the version.

This is behind a feature flag. To enable it, run `window.configOverridesStore.set({ isDataTableVersioningEnabled: true })` in the console and reload Terra.

https://user-images.githubusercontent.com/1156625/185674007-8e945b62-89c8-4f49-9147-48fe990c2be2.mov

More information about entity versioning is available in the doc linked from the tickets ([SU-179](https://broadworkbench.atlassian.net/browse/SU-179) and [SU-182](https://broadworkbench.atlassian.net/browse/SU-182)).