### PR TITLE
[IA-3587] Display default location in location select

### DIFF
--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -1162,7 +1162,7 @@ export const ComputeModalBase = ({
                 isSearchable: false,
                 value: computeConfig.computeRegion,
                 onChange: ({ value, locationType }) => updateComputeLocation(value, locationType),
-                options: _.sortBy('label', getAvailableComputeRegions(location))
+                options: getAvailableComputeRegions(location)
               })
             ])
           ])

--- a/src/components/ComputeModal.js
+++ b/src/components/ComputeModal.js
@@ -1162,7 +1162,7 @@ export const ComputeModalBase = ({
                 isSearchable: false,
                 value: computeConfig.computeRegion,
                 onChange: ({ value, locationType }) => updateComputeLocation(value, locationType),
-                options: _.flow(_.filter(l => l.value !== defaultLocation), _.sortBy('label'))(getAvailableComputeRegions(location))
+                options: _.sortBy('label', getAvailableComputeRegions(location))
               })
             ])
           ])

--- a/src/components/region-common.js
+++ b/src/components/region-common.js
@@ -101,7 +101,7 @@ export const availableBucketRegions = _.filter(({ value }) => isSupportedBucketL
 // and the same region as your workspace bucket.
 export const getAvailableComputeRegions = location => {
   const usCentralRegion = _.find({ value: defaultComputeRegion }, allRegions)
-  return isUSLocation(location) ? [usCentralRegion] : [usCentralRegion, _.find({ value: location }, allRegions)]
+  return isUSLocation(location) ? [usCentralRegion] : [_.find({ value: location }, allRegions), usCentralRegion]
 }
 
 export const isUSLocation = location => {

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -374,6 +374,8 @@ export const wrapWorkspace = ({ breadcrumbs, activeTab, title, topBarContent, sh
     useOnMount(() => {
       if (!workspace) {
         refreshWorkspace()
+      } else {
+        loadBucketLocation(googleProject, workspace.workspace.bucketName)
       }
     })
 


### PR DESCRIPTION
## Description

Users would like to be able to explicitly see the location in the select component instead of the current "Select..."

## Testing

Tested on the 3 available regions to me, US multiregional, US, and Montreal.

Screenshot from creating Jupyter notebook in default US space and US multiregional.

![Screen Shot 2022-07-29 at 3 22 50 PM](https://user-images.githubusercontent.com/11773357/181830024-b39f1063-1900-49ba-a926-ed78bcffaac0.png)

Screenshot from creating a Jupyter Notebook in a Montreal located workspace. 
Is this the expected outcome?

![Screen Shot 2022-07-29 at 3 21 14 PM](https://user-images.githubusercontent.com/11773357/181829824-a0681db7-53e4-4bdc-bce1-c923421b8971.png))