### PR TITLE
[SU-186] Preparation for new profile page

### DIFF
--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -467,7 +467,7 @@ const Profile = ({ queryParams }) => {
             ]),
             div({ style: { margin: '1rem' } }, [proxyGroup]),
 
-            sectionTitle('Program Info'),
+            sectionTitle('Location'),
 
             line([
               textField('programLocationCity', 'City'),

--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -5,7 +5,7 @@ import { Fragment, useState } from 'react'
 import { div, h, h2, h3, label, span } from 'react-hyperscript-helpers'
 import Collapse from 'src/components/Collapse'
 import {
-  ButtonPrimary, ClipboardButton, FrameworkServiceLink, IdContainer, LabeledCheckbox, Link, RadioButton, ShibbolethLink, spinnerOverlay,
+  ButtonPrimary, ClipboardButton, FrameworkServiceLink, IdContainer, LabeledCheckbox, Link, ShibbolethLink, spinnerOverlay,
   UnlinkFenceAccount
 } from 'src/components/common'
 import FooterWrapper from 'src/components/FooterWrapper'
@@ -391,12 +391,6 @@ const Profile = ({ queryParams }) => {
       })
   ])])
 
-  const radioButton = (key, value) => h(RadioButton, {
-    text: value, name: key, checked: profileInfo[key] === value,
-    labelStyle: { margin: '0 2rem 0 0.25rem' },
-    onChange: () => assignValue(key, value)
-  })
-
   const checkbox = (key, title) => div({ style: styles.form.checkboxLine }, [
     h(LabeledCheckbox, {
       checked: profileInfo[key] === 'true',
@@ -458,8 +452,7 @@ const Profile = ({ queryParams }) => {
               textField('contactEmail', 'Contact Email for Notifications (if different)', { placeholder: profileInfo.email })
             ]),
             line([
-              textField('institute', 'Institution'),
-              textField('institutionalProgram', 'Institutional Program')
+              textField('institute', 'Institution')
             ]),
 
             div({ style: styles.form.title }, [
@@ -476,18 +469,6 @@ const Profile = ({ queryParams }) => {
 
             sectionTitle('Program Info'),
 
-            h(IdContainer, [id => div({
-              role: 'radiogroup', 'aria-labelledby': id
-            }, [
-              span({ id, style: styles.form.title }, ['Non-Profit Status']),
-              div({ style: { margin: '1rem' } }, [
-                radioButton('nonProfitStatus', 'Profit'),
-                radioButton('nonProfitStatus', 'Non-Profit')
-              ])
-            ])]),
-            line([
-              textField('pi', 'Principal Investigator/Program Lead')
-            ]),
             line([
               textField('programLocationCity', 'City'),
               textField('programLocationState', 'State')


### PR DESCRIPTION
Once https://github.com/broadinstitute/firecloud-orchestration/pull/992 goes live, we will no longer bother to collect the PI, Non-Profit status, and institutional program values. This won't be a critical breaking change but it would be better to avoid the temporary state where Terra UI accepts values for these fields and throws them away.

[SU-160](https://broadworkbench.atlassian.net/browse/SU-160) will redesign the profile page entirely but it is easier to not try to time the merge of that with the Orch PR mentioned above.

Before

<img width="1067" alt="Screen Shot 2022-08-22 at 11 42 38 AM" src="https://user-images.githubusercontent.com/7257391/185962491-29c832fb-4495-45d3-b215-0fc7328a27c5.png">


After


<img width="1112" alt="Screen Shot 2022-08-22 at 11 42 21 AM" src="https://user-images.githubusercontent.com/7257391/185962511-48e2ee1e-8d43-4274-9649-88b0ca6a4d32.png">

<!--
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Also, so if a screen recording [1] and/or screenshots would be a helpful way to communicate context, please consider including some in your PR description.
Thanks!

[1] https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac
--!>
