### PR TITLE
[SU-172] Add provenance information for data table columns

### DIFF
--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -394,13 +394,15 @@ const DataTable = props => {
                     }, [
                       h(HeaderOptions, {
                         sort, field: attributeName, onSort: setSort,
-                        extraActions: _.concat(editable && [
-                          // settimeout 0 is needed to delay opening the modaals until after the popup menu closes.
-                          // Without this, autofocus doesn't work in the modals.
-                          { label: 'Rename Column', disabled: !!noEdit, tooltip: noEdit || '', onClick: () => setTimeout(() => setRenamingColumn(attributeName), 0) },
-                          { label: 'Delete Column', disabled: !!noEdit, tooltip: noEdit || '', onClick: () => setTimeout(() => setDeletingColumn(attributeName), 0) },
-                          { label: 'Clear Column', disabled: !!noEdit, tooltip: noEdit || '', onClick: () => setTimeout(() => setClearingColumn(attributeName), 0) }
-                        ], extraColumnActions ? extraColumnActions(attributeName) : [])
+                        extraActions: _.concat(
+                          editable ? [
+                            // settimeout 0 is needed to delay opening the modaals until after the popup menu closes.
+                            // Without this, autofocus doesn't work in the modals.
+                            { label: 'Rename Column', disabled: !!noEdit, tooltip: noEdit || '', onClick: () => setTimeout(() => setRenamingColumn(attributeName), 0) },
+                            { label: 'Delete Column', disabled: !!noEdit, tooltip: noEdit || '', onClick: () => setTimeout(() => setDeletingColumn(attributeName), 0) },
+                            { label: 'Clear Column', disabled: !!noEdit, tooltip: noEdit || '', onClick: () => setTimeout(() => setClearingColumn(attributeName), 0) }
+                          ] : [],
+                          extraColumnActions ? extraColumnActions(attributeName) : [])
                       }, [
                         h(HeaderCell, [
                           !!columnNamespace && span({ style: { fontStyle: 'italic', color: colors.dark(0.75), paddingRight: '0.2rem' } }, [columnNamespace]),

--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -62,7 +62,8 @@ const DataTable = props => {
     snapshotName,
     deleteColumnUpdateMetadata,
     controlPanelStyle,
-    border = true
+    border = true,
+    extraColumnActions
   } = props
 
   const persistenceId = `${namespace}/${name}/${entityType}`
@@ -393,13 +394,13 @@ const DataTable = props => {
                     }, [
                       h(HeaderOptions, {
                         sort, field: attributeName, onSort: setSort,
-                        extraActions: editable && [
+                        extraActions: _.concat(editable && [
                           // settimeout 0 is needed to delay opening the modaals until after the popup menu closes.
                           // Without this, autofocus doesn't work in the modals.
                           { label: 'Rename Column', disabled: !!noEdit, tooltip: noEdit || '', onClick: () => setTimeout(() => setRenamingColumn(attributeName), 0) },
                           { label: 'Delete Column', disabled: !!noEdit, tooltip: noEdit || '', onClick: () => setTimeout(() => setDeletingColumn(attributeName), 0) },
                           { label: 'Clear Column', disabled: !!noEdit, tooltip: noEdit || '', onClick: () => setTimeout(() => setClearingColumn(attributeName), 0) }
-                        ]
+                        ], extraColumnActions ? extraColumnActions(attributeName) : [])
                       }, [
                         h(HeaderCell, [
                           !!columnNamespace && span({ style: { fontStyle: 'italic', color: colors.dark(0.75), paddingRight: '0.2rem' } }, [columnNamespace]),

--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -231,7 +231,8 @@ const EntitiesContent = ({
   const {
     columnProvenance,
     loading: loadingColumnProvenance,
-    error: columnProvenanceError
+    error: columnProvenanceError,
+    loadColumnProvenance
   } = useColumnProvenance(workspace, entityKey)
   const [showColumnProvenance, setShowColumnProvenance] = useState(undefined)
 
@@ -412,7 +413,15 @@ const EntitiesContent = ({
         },
         border: false,
         extraColumnActions: isDataTableProvenanceEnabled() ?
-          columnName => [{ label: 'Show Provenance', onClick: () => setShowColumnProvenance(columnName) }] :
+          columnName => [{
+            label: 'Show Provenance',
+            onClick: () => {
+              if (!(loadingColumnProvenance || columnProvenance)) {
+                loadColumnProvenance()
+              }
+              setShowColumnProvenance(columnName)
+            }
+          }] :
           undefined
       }),
       addingEntity && h(AddEntityModal, {

--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -490,6 +490,7 @@ const EntitiesContent = ({
       }),
       showColumnProvenance && h(Modal, {
         title: 'Column Provenance',
+        showCancel: false,
         onDismiss: () => setShowColumnProvenance(undefined)
       }, [
         Utils.cond(

--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -28,6 +28,7 @@ import wdlLogo from 'src/images/wdl-logo.png'
 import { Ajax } from 'src/libs/ajax'
 import { isRadX } from 'src/libs/brand-utils'
 import colors from 'src/libs/colors'
+import { isDataTableProvenanceEnabled } from 'src/libs/config'
 import { useColumnProvenance } from 'src/libs/data-table-provenance'
 import { withErrorReporting } from 'src/libs/error'
 import Events, { extractWorkspaceDetails } from 'src/libs/events'
@@ -410,7 +411,9 @@ const EntitiesContent = ({
           borderBottom: `1px solid ${colors.grey(0.4)}`
         },
         border: false,
-        extraColumnActions: columnName => [{ label: 'Show Provenance', onClick: () => setShowColumnProvenance(columnName) }]
+        extraColumnActions: isDataTableProvenanceEnabled() ?
+          columnName => [{ label: 'Show Provenance', onClick: () => setShowColumnProvenance(columnName) }] :
+          undefined
       }),
       addingEntity && h(AddEntityModal, {
         entityType: entityKey,

--- a/src/components/data/data-table-provenance.js
+++ b/src/components/data/data-table-provenance.js
@@ -1,0 +1,40 @@
+import _ from 'lodash/fp'
+import { Fragment } from 'react'
+import { div, h, li, ol, p, span } from 'react-hyperscript-helpers'
+import { Link } from 'src/components/common'
+import { maxSubmissionsQueriedForProvenance } from 'src/libs/data-table-provenance'
+import * as Nav from 'src/libs/nav'
+import * as Utils from 'src/libs/utils'
+
+
+export const DataTableColumnProvenance = ({ workspace, column, provenance }) => {
+  const { workspace: { namespace, name } } = workspace
+
+  if (!provenance) {
+    return p([
+      'No provenance information available for column ',
+      span({ style: { fontWeight: 600 } }, [column]), '. ',
+      `It was not configured as an output in any of the last ${maxSubmissionsQueriedForProvenance} workflows run on this data type.`
+    ])
+  }
+
+  return h(Fragment, [
+    p([
+      span({ style: { fontWeight: 600 } }, [column]),
+      ' was configured as an output for the following submissions:'
+    ]),
+    ol({ style: { margin: 0, padding: 0, listStyleType: 'none' } }, [
+      _.map(({ submissionId, submissionDate, configuration, output }) => {
+        return li({ key: submissionId, style: { marginBottom: '0.75rem' } }, [
+          div({ style: { marginBottom: '0.25rem' } }, [
+            h(Link, {
+              href: Nav.getLink('workspace-submission-details', { namespace, name, submissionId })
+            }, [configuration.name])
+          ]),
+          div({ style: { marginBottom: '0.25rem' } }, [Utils.makeCompleteDate(submissionDate)]),
+          div({ style: { marginBottom: '0.25rem' } }, [output])
+        ])
+      }, provenance)
+    ])
+  ])
+}

--- a/src/components/icons.js
+++ b/src/components/icons.js
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp'
 import { Children, Fragment } from 'react'
-import { div, h, img } from 'react-hyperscript-helpers'
+import { div, h, img, span } from 'react-hyperscript-helpers'
 import DelayedRender from 'src/components/DelayedRender'
 import { getUser } from 'src/libs/auth'
 import colors from 'src/libs/colors'
@@ -50,7 +50,7 @@ export const icon = (shape, { size = 16, ...props } = {}) => {
 
 export const spinner = ({ message = 'Loading', ...props } = {}) => h(Fragment, [
   icon('loadingSpinner', _.merge({ size: 24, style: { color: colors.primary() } }, props)),
-  h(DelayedRender, { delay: 150 }, [div({ className: 'sr-only', role: 'alert' }, [message])])
+  h(DelayedRender, { delay: 150 }, [span({ className: 'sr-only', role: 'alert' }, [message])])
 ])
 
 export const centeredSpinner = ({ size = 48, ...props } = {}) => spinner(_.merge({

--- a/src/libs/config.js
+++ b/src/libs/config.js
@@ -13,4 +13,5 @@ export const getConfig = () => {
  */
 export const isCromwellAppVisible = () => getConfig().isCromwellAppVisible
 export const isDataBrowserFrontPage = () => false
+export const isDataTableProvenanceEnabled = () => getConfig().isDataTableProvenanceEnabled
 export const isDataTableVersioningEnabled = () => getConfig().isDataTableVersioningEnabled

--- a/src/libs/data-table-provenance.js
+++ b/src/libs/data-table-provenance.js
@@ -1,6 +1,7 @@
 import _ from 'lodash/fp'
 import { useEffect, useState } from 'react'
 import { Ajax } from 'src/libs/ajax'
+import { isDataTableProvenanceEnabled } from 'src/libs/config'
 import { reportError } from 'src/libs/error'
 import { useCancellation } from 'src/libs/react-utils'
 import * as Utils from 'src/libs/utils'
@@ -82,7 +83,9 @@ export const useColumnProvenance = (workspace, entityType) => {
       }
     }
 
-    loadColumnProvenance()
+    if (isDataTableProvenanceEnabled()) {
+      loadColumnProvenance()
+    }
   }, [workspace, entityType, signal])
 
   return { columnProvenance, loading, error }

--- a/src/libs/data-table-provenance.js
+++ b/src/libs/data-table-provenance.js
@@ -52,9 +52,9 @@ const getColumnProvenance = async (workspace, entityType, { signal } = {}) => {
   const submissions = await getSubmissionsWithRootEntityType(workspace, entityType, { signal })
 
   return _.flow(
-    _.flatMap(({ submission, configuration }) => _.map(([output, expression]) => ({ submission, configuration, output, expression }), _.toPairs(configuration.outputs))),
-    _.map(({ submission, configuration, output, expression }) => ({ submission, configuration, output, column: getColumnFromOutputExpression(expression) })),
-    _.filter(({ column }) => !!column),
+    _.flatMap(submission => _.map(([output, expression]) => ({ ...submission, output, expression }), _.toPairs(submission.configuration.outputs))),
+    _.map(output => ({ ..._.omit(['expression'], output), column: getColumnFromOutputExpression(output.expression) })),
+    _.filter(output => !!output.column),
     _.reduce((acc, { submission, configuration, output, column }) => {
       const provenanceEntry = { submissionId: submission.submissionId, submissionDate: submission.submissionDate, configuration, output }
       return _.update(column, _.flow(_.defaultTo([]), Utils.append(provenanceEntry)), acc)

--- a/src/libs/data-table-provenance.js
+++ b/src/libs/data-table-provenance.js
@@ -53,7 +53,7 @@ const getColumnProvenance = async (workspace, entityType, { signal } = {}) => {
 
   return _.flow(
     _.flatMap(submission => _.map(([output, expression]) => ({ ...submission, output, expression }), _.toPairs(submission.configuration.outputs))),
-    _.map(output => ({ ..._.omit(['expression'], output), column: getColumnFromOutputExpression(output.expression) })),
+    _.map(({ expression, ...output }) => ({ ...output, column: getColumnFromOutputExpression(expression) })),
     _.filter(output => !!output.column),
     _.reduce((acc, { submission, configuration, output, column }) => {
       const provenanceEntry = { submissionId: submission.submissionId, submissionDate: submission.submissionDate, configuration, output }

--- a/src/libs/data-table-provenance.js
+++ b/src/libs/data-table-provenance.js
@@ -1,0 +1,89 @@
+import _ from 'lodash/fp'
+import { useEffect, useState } from 'react'
+import { Ajax } from 'src/libs/ajax'
+import { reportError } from 'src/libs/error'
+import { useCancellation } from 'src/libs/react-utils'
+import * as Utils from 'src/libs/utils'
+
+
+export const maxSubmissionsQueriedForProvenance = 25
+
+const getSubmissionsWithRootEntityType = async (workspace, entityType, { signal } = {}) => {
+  const { workspace: { namespace, name } } = workspace
+
+  // The root entity type is stored on method configurations, not submissions. To avoid fetching
+  // every submission's configuration, first use the list submissions endpoint and filter by
+  // submission entity type.
+  //
+  // If a workflow is run on a single entity, the submission entity type will be the root entity type.
+  // If a workflow is run on multiple entities, the submission entity type will be a set of the root entity type.
+  //
+  // After fetching method configurations, another filter is required remove submissions whose root entity type
+  // was a set of the desired entity type.
+  const allSubmissions = await Ajax(signal).Workspaces.workspace(namespace, name).listSubmissions()
+  const submissionsMaybeUsingEntityType = _.flow(
+    _.filter(submission => {
+      const submissionEntityType = submission.submissionEntity.entityType
+      return submissionEntityType === entityType || submissionEntityType === `${entityType}_set`
+    }),
+    _.slice(0, maxSubmissionsQueriedForProvenance)
+  )(allSubmissions)
+
+  const submissionConfigurations = await Promise.all(
+    _.map(
+      submission => Ajax(signal).Workspaces.workspace(namespace, name).submission(submission.submissionId).getConfiguration(),
+      submissionsMaybeUsingEntityType
+    )
+  )
+
+  return _.flow(
+    _.map(([submission, configuration]) => ({ submission, configuration })),
+    _.filter(({ configuration }) => configuration.rootEntityType === entityType),
+    _.orderBy(({ submission }) => new Date(submission.submissionDate), 'desc')
+  )(_.zip(submissionsMaybeUsingEntityType, submissionConfigurations))
+}
+
+const getColumnFromOutputExpression = expr => {
+  const match = /^this\.([^.]+)$/.exec(expr)
+  return match ? match[1] : null
+}
+
+const getColumnProvenance = async (workspace, entityType, { signal } = {}) => {
+  const submissions = await getSubmissionsWithRootEntityType(workspace, entityType, { signal })
+
+  return _.flow(
+    _.flatMap(({ submission, configuration }) => _.map(([output, expression]) => ({ submission, configuration, output, expression }), _.toPairs(configuration.outputs))),
+    _.map(({ submission, configuration, output, expression }) => ({ submission, configuration, output, column: getColumnFromOutputExpression(expression) })),
+    _.filter(({ column }) => !!column),
+    _.reduce((acc, { submission, configuration, output, column }) => {
+      const provenanceEntry = { submissionId: submission.submissionId, submissionDate: submission.submissionDate, configuration, output }
+      return _.update(column, _.flow(_.defaultTo([]), Utils.append(provenanceEntry)), acc)
+    }, {})
+  )(submissions)
+}
+
+export const useColumnProvenance = (workspace, entityType) => {
+  const signal = useCancellation()
+  const [loading, setLoading] = useState(true)
+  const [columnProvenance, setColumnProvenance] = useState({})
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    const loadColumnProvenance = async () => {
+      setError(null)
+      setLoading(true)
+      try {
+        setColumnProvenance(await getColumnProvenance(workspace, entityType, { signal }))
+      } catch (error) {
+        setError(error)
+        reportError('Error loading column provenance', error)
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    loadColumnProvenance()
+  }, [workspace, entityType, signal])
+
+  return { columnProvenance, loading, error }
+}


### PR DESCRIPTION
This is a proof of concept for adding provenance information for data table columns. It shows which submissions used the selected column as an output. This is intended as a prototype to collect feedback from some users.

Currently, it is limited to checking the last 25 submissions that used the data table as the root entity type. This is done to limit the number of submission configurations that are individually fetched from the API. If we decide to make something like this generally available, we would likely add a new API endpoint or change existing ones to make fetching the provenance data more efficient.

This is behind a feature flag. To enable it, run `window.configOverridesStore.set({ isDataTableProvenanceEnabled: true })` in the console.

<img width="1624" alt="Screen Shot 2022-08-23 at 11 19 06 AM" src="https://user-images.githubusercontent.com/1156625/186197428-9b01f90a-a744-4d61-8e90-6fcebc98b82e.png">

<img width="1624" alt="Screen Shot 2022-08-23 at 11 19 08 AM" src="https://user-images.githubusercontent.com/1156625/186197433-25e8590c-bee1-438c-ba63-8a2457e063d5.png">