### PR TITLE
[SUP-688] Fix nested interactive controls in data table column headers

### DIFF
--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -1433,27 +1433,28 @@ export const ModalToolButton = ({ icon, text, disabled, ...props }) => {
 }
 
 export const HeaderOptions = ({ sort, field, onSort, extraActions, children }) => {
-  const columnMenu = span({ onClick: e => e.stopPropagation() }, [
-    h(MenuTrigger, {
-      closeOnClick: true,
-      side: 'bottom',
-      content: h(Fragment, [
-        h(MenuButton, { onClick: () => onSort({ field, direction: 'asc' }) }, ['Sort Ascending']),
-        h(MenuButton, { onClick: () => onSort({ field, direction: 'desc' }) }, ['Sort Descending']),
-        _.map(({ label, disabled, tooltip, onClick }) => h(MenuButton, { key: label, disabled, tooltip, onClick }, [label]), extraActions)
-      ])
-    }, [
-      h(Link, { 'aria-label': 'Column menu' }, [
-        icon('cardMenuIcon', { size: 16 })
-      ])
+  const columnMenu = h(MenuTrigger, {
+    closeOnClick: true,
+    side: 'bottom',
+    content: h(Fragment, [
+      h(MenuButton, { onClick: () => onSort({ field, direction: 'asc' }) }, ['Sort Ascending']),
+      h(MenuButton, { onClick: () => onSort({ field, direction: 'desc' }) }, ['Sort Descending']),
+      _.map(({ label, disabled, tooltip, onClick }) => h(MenuButton, { key: label, disabled, tooltip, onClick }, [label]), extraActions)
+    ])
+  }, [
+    h(Link, { 'aria-label': 'Column menu' }, [
+      icon('cardMenuIcon', { size: 16 })
     ])
   ])
 
-  return h(Sortable, {
-    sort, field, onSort, columnMenu
-  }, [
-    children,
-    div({ style: { marginRight: '0.5rem', marginLeft: 'auto' } })
+  return h(Fragment, [
+    h(Sortable, {
+      sort, field, onSort
+    }, [
+      children,
+      div({ style: { marginRight: '0.5rem', marginLeft: 'auto' } })
+    ]),
+    columnMenu
   ])
 }
 

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -755,7 +755,7 @@ export const Sortable = ({ sort, field, onSort, children }) => {
   const [hovered, setHovered] = useState(false)
 
   return h(IdContainer, [id => h(Clickable, {
-    style: { flex: 1, display: 'flex', alignItems: 'center', cursor: 'pointer', width: '100%', height: '100%' },
+    style: { flex: 1, display: 'flex', alignItems: 'center', cursor: 'pointer', width: '100%', height: '100%', overflow: 'hidden' },
     onMouseEnter: () => { setHovered(true) },
     onMouseLeave: () => { setHovered(false) },
     onFocus: () => { setHovered(true) },

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -751,7 +751,7 @@ const getSortIcon = (sort, field, hovered) => {
   )
 }
 
-export const Sortable = ({ sort, field, onSort, children, columnMenu }) => {
+export const Sortable = ({ sort, field, onSort, children }) => {
   const [hovered, setHovered] = useState(false)
 
   return h(IdContainer, [id => h(Clickable, {
@@ -768,8 +768,7 @@ export const Sortable = ({ sort, field, onSort, children, columnMenu }) => {
       { style: { color: colors.accent(), marginLeft: '0.1rem' } },
       [getSortIcon(sort, field, hovered)]
     ),
-    div({ id, style: { display: 'none' } }, ['Click to sort by this column']),
-    columnMenu
+    div({ id, style: { display: 'none' } }, ['Click to sort by this column'])
   ])])
 }
 


### PR DESCRIPTION
Currently, axe dev tools warn about nested interactive controls when viewing a data table. This is because, in the column heading, button to show the column actions menu is nested inside a button to sort the table by that column. Moving the menu button outside of the sort button fixes the issue.