### PR TITLE
[SU-187] Show notice and disable editing when viewing table versions in file browser

### DIFF
--- a/src/libs/data-table-versions.js
+++ b/src/libs/data-table-versions.js
@@ -8,7 +8,7 @@ import { useCancellation } from 'src/libs/react-utils'
 import * as Utils from 'src/libs/utils'
 
 
-const dataTableVersionsPathRoot = '.data-table-versions'
+export const dataTableVersionsPathRoot = '.data-table-versions'
 
 export const saveDataTableVersion = async (workspace, entityType, { description = null } = {}) => {
   const { workspace: { namespace, name, googleProject, bucketName } } = workspace

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -24,7 +24,7 @@ import { Ajax } from 'src/libs/ajax'
 import { getUser } from 'src/libs/auth'
 import colors from 'src/libs/colors'
 import { getConfig, isDataTableVersioningEnabled } from 'src/libs/config'
-import { useDataTableVersions } from 'src/libs/data-table-versions'
+import { dataTableVersionsPathRoot, useDataTableVersions } from 'src/libs/data-table-versions'
 import { reportError, withErrorReporting } from 'src/libs/error'
 import Events, { extractWorkspaceDetails } from 'src/libs/events'
 import * as Nav from 'src/libs/nav'
@@ -827,7 +827,11 @@ const WorkspaceData = _.flow(
             extraMenuItems: h(Link, {
               href: `https://seqr.broadinstitute.org/workspace/${namespace}/${name}`,
               style: { padding: '0.5rem' }
-            }, [icon('pop-out'), ' Analyze in Seqr'])
+            }, [icon('pop-out'), ' Analyze in Seqr']),
+            noticeForPrefix: prefix => prefix.startsWith(`${dataTableVersionsPathRoot}/`) ?
+              'Files in this folder are managed via data table versioning.' :
+              null,
+            shouldDisableEditForPrefix: prefix => prefix.startsWith(`${dataTableVersionsPathRoot}/`)
           })],
           [workspaceDataTypes.snapshot, () => h(SnapshotContent, {
             key: refreshKey,


### PR DESCRIPTION
Follow on to #3325. Data table versions are stored in a specific prefix in the workspace bucket. To discourage users from directly editing those files, this shows a notice and disables upload/delete controls when viewing that prefix in the workspace files browser.

<img width="1624" alt="Screen Shot 2022-08-24 at 11 55 22 AM" src="https://user-images.githubusercontent.com/1156625/186467660-2bb5f1a6-87a4-4ce4-a712-02e2d91d61b5.png">

To enable data table versioning, run `window.configOverridesStore.set({ isDataTableVersioningEnabled: true })` in the console and reload Terra. To create a version, select "Save version" from the data table actions menu in the sidebar of the Data tab (see the video on #3325).