### PR TITLE
[WX-838] Don't render execution directory link if there's no workflowRoot

### DIFF
--- a/src/pages/workspaces/workspace/jobHistory/WorkflowDashboard.js
+++ b/src/pages/workspaces/workspace/jobHistory/WorkflowDashboard.js
@@ -167,7 +167,7 @@ const WorkflowDashboard = _.flow(
                 style: { display: 'flex', alignItems: 'center' },
                 tooltip: 'Job Manager'
               }, [icon('tasks', { size: 18 }), ' Job Manager']),
-              h(Link, {
+              workflowRoot && h(Link, {
                 ...Utils.newTabLinkProps,
                 href: bucketBrowserUrl(workflowRoot.replace('gs://', '')),
                 style: { display: 'flex', marginLeft: '1rem', alignItems: 'center' },


### PR DESCRIPTION
I found a case where a [failed workflow](https://app.terra.bio/#workspaces/broad-firecloud-dsde/complex-featured-workflow/job_history/55258820-bcec-4db9-9c19-afc458b16126) didn't have a `workflowRoot`. Is this expected or is there some other problem? Not sure this is the right solution or if we should have some sort of fallback.