### PR TITLE
Update AMP PD dataset to point to Featured Workspace

### DIFF
--- a/src/pages/library/Datasets.js
+++ b/src/pages/library/Datasets.js
@@ -188,16 +188,11 @@ const amppd = () => h(Participant, {
   sizeText: 'Participants: 10,772'
 }, [
   h(ButtonPrimary, {
-    'aria-label': 'Browse AMP-PD Tier 1 data',
-    style: { marginBottom: '1rem' },
-    href: Nav.getLink('data-explorer-private', { dataset: 'AMP PD Clinical - 2020_v2release_1218' }),
-    onClick: () => captureBrowseDataEvent('AMP PD Clinical - 2020_v2release_1218')
-  }, ['Browse Tier 1 Data']),
-  h(ButtonPrimary, {
-    'aria-label': 'Browse AMP-PD Tier 2 data',
-    href: Nav.getLink('data-explorer-private', { dataset: 'AMP PD - 2020_v2release_1218' }),
-    onClick: () => captureBrowseDataEvent('AMP PD - 2020_v2release_1218')
-  }, ['Browse Tier 2 Data'])
+    'aria-label': 'Learn about AMP PD data',
+    tooltip: 'Visit the Featured Workspace',
+    href: 'https://app.terra.bio/#workspaces/amp-pd-public/AMP-PD-In-Terra',
+    onClick: () => captureBrowseDataEvent('AMP PD Featured Workspace')
+  }, ['Explore AMP PD'])
 ])
 
 const baseline = () => h(Participant, {


### PR DESCRIPTION
Remove both existing "Browse Data" buttons on Terra datasets page and
add new "Explore AMP PD" button which points to the new AMP PD
Featured Workspace. This increases discoverability of the new "home" for AMP PD resources in Terra, since all viewers with Terra accounts (not just those with AMP PD access) can view the AMP PD Featured Workspace. [Note: images shows tooltip when mouse hovering.]

![image](https://user-images.githubusercontent.com/12503013/187745286-e842f149-25e4-4950-ac19-b29514e235ed.png)
