### PR TITLE
[QA-2000] UI integration test failed with Error: Node is detached from document

### DIFF
--- a/integration-tests/tests/import-cohort-data.js
+++ b/integration-tests/tests/import-cohort-data.js
@@ -1,8 +1,7 @@
 const _ = require('lodash/fp')
 const { withWorkspace } = require('../utils/integration-helpers')
 const {
-  findInGrid, click, clickable, fillIn, findIframe, input, signIntoTerra, select, svgText, waitForNoSpinners, findElement,
-  navOptionNetworkIdle, noSpinnersAfter
+  findInGrid, click, clickable, fillIn, findIframe, input, signIntoTerra, select, svgText, waitForNoSpinners, findElement, navOptionNetworkIdle
 } = require('../utils/integration-utils')
 const { registerTest } = require('../utils/jest-utils')
 const { withUserToken } = require('../utils/terra-sa-utils')
@@ -20,7 +19,7 @@ const testImportCohortDataFn = _.flow(
 
   await Promise.all([
     page.waitForNavigation(navOptionNetworkIdle()),
-    noSpinnersAfter(page, { action: () => click(page, clickable({ textContains: '1000 Genomes Low Coverage' })) })
+    click(page, clickable({ textContains: '1000 Genomes Low Coverage' }))
   ])
 
   const frame = await findIframe(page)

--- a/integration-tests/tests/import-cohort-data.js
+++ b/integration-tests/tests/import-cohort-data.js
@@ -1,7 +1,9 @@
 const _ = require('lodash/fp')
 const { withWorkspace } = require('../utils/integration-helpers')
-const { findInGrid, click, clickable, fillIn, findIframe, input, signIntoTerra, select, svgText, waitForNoSpinners, findElement } = require(
-  '../utils/integration-utils')
+const {
+  findInGrid, click, clickable, fillIn, findIframe, input, signIntoTerra, select, svgText, waitForNoSpinners, findElement,
+  navOptionNetworkIdle, noSpinnersAfter
+} = require('../utils/integration-utils')
 const { registerTest } = require('../utils/jest-utils')
 const { withUserToken } = require('../utils/terra-sa-utils')
 
@@ -15,7 +17,11 @@ const testImportCohortDataFn = _.flow(
   await signIntoTerra(page, { token, testUrl })
 
   await click(page, clickable({ textContains: 'Browse Data' }))
-  await click(page, clickable({ textContains: '1000 Genomes Low Coverage' }))
+
+  await Promise.all([
+    page.waitForNavigation(navOptionNetworkIdle()),
+    noSpinnersAfter(page, { action: () => click(page, clickable({ textContains: '1000 Genomes Low Coverage' })) })
+  ])
 
   const frame = await findIframe(page)
   await click(frame, svgText({ textContains: 'Has WGS Low' }))

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -109,11 +109,7 @@ const click = async (page, xpath, options) => {
   try {
     return (await page.waitForXPath(xpath, defaultToVisibleTrue(options))).click()
   } catch (e) {
-    // Handle Error: Node is detached from document
-    //   at ElementHandle._scrollIntoViewIfNeeded (/mnt/ramdisk/.yarn/unplugged/puppeteer-npm-13.5.1-231e586c7a/node_modules/puppeteer/src/common/JSHandle.ts:475:22)
-    //   at processTicksAndRejections (node:internal/process/task_queues:96:5)
-    //   at ElementHandle.click (/mnt/ramdisk/.yarn/unplugged/puppeteer-npm-13.5.1-231e586c7a/node_modules/puppeteer/src/common/JSHandle.ts:617:5)
-    if (e instanceof Error && e.message?.includes('Node is detached from document')) {
+    if (e.message.includes('Node is detached from document')) {
       return (await page.waitForXPath(xpath, defaultToVisibleTrue(options))).click()
     }
     throw e

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -106,7 +106,19 @@ const clickTableCell = async (page, { tableName, columnHeader, text, isDescendan
 }
 
 const click = async (page, xpath, options) => {
-  return (await page.waitForXPath(xpath, defaultToVisibleTrue(options))).click()
+  const element = await page.waitForXPath(xpath, defaultToVisibleTrue(options))
+  try {
+    return element.click()
+  } catch (e) {
+    // Handle Error: Node is detached from document
+    //   at ElementHandle._scrollIntoViewIfNeeded (/mnt/ramdisk/.yarn/unplugged/puppeteer-npm-13.5.1-231e586c7a/node_modules/puppeteer/src/common/JSHandle.ts:475:22)
+    //   at processTicksAndRejections (node:internal/process/task_queues:96:5)
+    //   at ElementHandle.click (/mnt/ramdisk/.yarn/unplugged/puppeteer-npm-13.5.1-231e586c7a/node_modules/puppeteer/src/common/JSHandle.ts:617:5)
+    if (e instanceof Error && e.message?.includes('Node is detached from document')) {
+      return (await page.waitForXPath(xpath, defaultToVisibleTrue(options))).click()
+    }
+    throw e
+  }
 }
 
 const findText = (page, textContains, options) => {

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -106,9 +106,8 @@ const clickTableCell = async (page, { tableName, columnHeader, text, isDescendan
 }
 
 const click = async (page, xpath, options) => {
-  const element = await page.waitForXPath(xpath, defaultToVisibleTrue(options))
   try {
-    return element.click()
+    return (await page.waitForXPath(xpath, defaultToVisibleTrue(options))).click()
   } catch (e) {
     // Handle Error: Node is detached from document
     //   at ElementHandle._scrollIntoViewIfNeeded (/mnt/ramdisk/.yarn/unplugged/puppeteer-npm-13.5.1-231e586c7a/node_modules/puppeteer/src/common/JSHandle.ts:475:22)


### PR DESCRIPTION
[QA-2000](https://broadworkbench.atlassian.net/browse/QA-2000)

Flaky test fix: In `Click()` function, add one retry in `try/catch` block. This PR handles `Node is detached from document` only.

CircleCI `integration-tests-staging` [job](https://app.circleci.com/pipelines/github/DataBiosphere/terra-ui/11562/workflows/57e79d0e-8e4a-48bd-a5f5-cfc5e7e53fbf/jobs/49486).
```

Tests Summary
----------------------------------------------
Test: import-cohort-data
Status: failed
Failure messages: Error: Node is detached from document
    at ElementHandle._scrollIntoViewIfNeeded (/mnt/ramdisk/.yarn/unplugged/puppeteer-npm-13.5.1-231e586c7a/node_modules/puppeteer/src/common/JSHandle.ts:475:22)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at ElementHandle.click (/mnt/ramdisk/.yarn/unplugged/puppeteer-npm-13.5.1-231e586c7a/node_modules/puppeteer/src/common/JSHandle.ts:617:5)
    at /mnt/ramdisk/integration-tests/tests/import-cohort-data.js:21:3
    at /mnt/ramdisk/integration-tests/utils/integration-helpers.js:64:5
    at /mnt/ramdisk/integration-tests/utils/integration-utils.js:344:12
    at /mnt/ramdisk/integration-tests/utils/integration-utils.js:398:10
Failure details: [
  {}
]
```

`Error: Node is detached from document` happens when the referenced web element is no longer attached to the DOM when clicking.