### PR TITLE
[SUP-732] Disabled rename button.

### DIFF
--- a/src/pages/workspaces/workspace/Analyses.js
+++ b/src/pages/workspaces/workspace/Analyses.js
@@ -153,7 +153,7 @@ const AnalysisCard = ({
       }, [makeMenuIcon('copy-to-clipboard'), 'Copy analysis URL to clipboard']),
       h(MenuButton, {
         'aria-label': `Rename`,
-        disabled: !canWrite,
+        disabled: true,
         tooltip: !canWrite && noWrite,
         tooltipSide: 'left',
         onClick: () => onRename()


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/SUP-732

## Description

There is a prod incident with renaming .ipynb files. This disables the button to prevent further issues.