### PR TITLE
DC-531: Revert preview dataset and link to workspace

### DIFF
--- a/integration-tests/tests/link-to-new-workspace.js
+++ b/integration-tests/tests/link-to-new-workspace.js
@@ -46,5 +46,6 @@ const testLinkToNewWorkspaceFn = withUserToken(async ({ billingProject, page, te
 registerTest({
   name: 'link-to-new-workspace',
   fn: testLinkToNewWorkspaceFn,
-  timeout: 2 * 60 * 1000
+  timeout: 2 * 60 * 1000,
+  targetEnvironments: []
 })

--- a/integration-tests/tests/preview-dataset.js
+++ b/integration-tests/tests/preview-dataset.js
@@ -26,5 +26,6 @@ const testPreviewDatasetFn = withUserToken(async ({ testUrl, page, token }) => {
 registerTest({
   name: 'preview-dataset',
   fn: testPreviewDatasetFn,
-  timeout: 2 * 60 * 1000
+  timeout: 2 * 60 * 1000,
+  targetEnvironments: []
 })

--- a/integration-tests/tests/run-catalog-workflow.js
+++ b/integration-tests/tests/run-catalog-workflow.js
@@ -21,5 +21,6 @@ const testCatalogFlowFn = _.flow(
 registerTest({
   name: 'run-catalog',
   fn: testCatalogFlowFn,
-  timeout: 2 * 60 * 1000
+  timeout: 2 * 60 * 1000,
+  targetEnvironments: []
 })

--- a/integration-tests/utils/catalog-utils.js
+++ b/integration-tests/utils/catalog-utils.js
@@ -17,7 +17,7 @@ const linkDataToWorkspace = async (page, testUrl, token) => {
   await click(page, checkbox({ text: 'Granted', isDescendant: true }))
   // TODO: add test data with granted access DC-321
   await clickTableCell(page, { tableName: 'dataset list', columnHeader: 'Dataset Name', text: 'Readable Catalog Snapshot 1', isDescendant: true })
-  await noSpinnersAfter(page, { action: () => click(page, clickable({ textContains: 'Prepare for analysis' })) })
+  await noSpinnersAfter(page, { action: () => click(page, clickable({ textContains: 'Link to a workspace' })) })
 }
 
 module.exports = { eitherThrow, linkDataToWorkspace }

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1110,23 +1110,9 @@ const DataRepo = signal => ({
       details: async () => {
         const res = await fetchDataRepo(`repository/v1/snapshots/${snapshotId}`, _.merge(authOpts(), { signal }))
         return res.json()
-      },
-      exportSnapshot: async () => {
-        const res = await fetchDataRepo(`repository/v1/snapshots/${snapshotId}/export?validatePrimaryKeyUniqueness=false`, _.merge(authOpts(), { signal }))
-        return res.json()
       }
     }
-  },
-  job: jobId => ({
-    details: async () => {
-      const res = await fetchDataRepo(`repository/v1/jobs/${jobId}`, _.merge(authOpts(), { signal }))
-      return res.json()
-    },
-    result: async () => {
-      const res = await fetchDataRepo(`repository/v1/jobs/${jobId}/result`, _.merge(authOpts(), { signal }))
-      return res.json()
-    }
-  })
+  }
 })
 
 const AzureStorage = signal => ({

--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -31,7 +31,6 @@ const eventsList = {
   catalogToggle: 'catalog:toggle',
   catalogView: 'catalog:view',
   catalogWorkspaceLink: 'catalog:workspaceLink',
-  catalogWorkspaceLinkExportFinished: 'catalog:workspaceLink:completed',
   datasetLibraryBrowseData: 'library:browseData',
   dataTableSaveColumnSettings: 'dataTable:saveColumnSettings',
   dataTableLoadColumnSettings: 'dataTable:loadColumnSettings',

--- a/src/pages/library/DataBrowserDetails.js
+++ b/src/pages/library/DataBrowserDetails.js
@@ -13,7 +13,7 @@ import Events from 'src/libs/events'
 import * as Nav from 'src/libs/nav'
 import * as Utils from 'src/libs/utils'
 import { commonStyles } from 'src/pages/library/common'
-import { datasetAccessTypes, importDataToWorkspace, uiMessaging, useDataCatalog } from 'src/pages/library/dataBrowser-utils'
+import { datasetAccessTypes, importDataToWorkspace, useDataCatalog } from 'src/pages/library/dataBrowser-utils'
 import { DataBrowserFeedbackModal } from 'src/pages/library/DataBrowserFeedbackModal'
 import { RequestDatasetAccessModal } from 'src/pages/library/RequestDatasetAccessModal'
 
@@ -177,8 +177,8 @@ export const SidebarComponent = ({ dataObj, id }) => {
         ])
       ]),
       h(ButtonOutline, {
-        disabled: dataObj.access !== datasetAccessTypes.GRANTED,
-        tooltip: dataObj.access === datasetAccessTypes.GRANTED ? '' : uiMessaging.controlledFeature_tooltip,
+        disabled: true,
+        tooltip: 'We are currently working on preview dataset and this will be available soon.',
         style: { fontSize: 16, textTransform: 'none', height: 'unset', width: sidebarButtonWidth, marginTop: 20 },
         onClick: () => {
           Ajax().Metrics.captureEvent(`${Events.catalogView}:previewData`, {

--- a/src/pages/library/DataBrowserDetails.js
+++ b/src/pages/library/DataBrowserDetails.js
@@ -1,26 +1,19 @@
 import _ from 'lodash/fp'
-import qs from 'qs'
 import { Fragment, useState } from 'react'
 import { div, h, h1, h2, h3, span, table, tbody, td, tr } from 'react-hyperscript-helpers'
 import { ButtonOutline, ButtonPrimary, ButtonSecondary, Link } from 'src/components/common'
 import FooterWrapper from 'src/components/FooterWrapper'
-import { centeredSpinner, icon, spinner } from 'src/components/icons'
+import { centeredSpinner, icon } from 'src/components/icons'
 import { libraryTopMatter } from 'src/components/library-common'
-import Modal from 'src/components/Modal'
 import { ReactComponent as AzureLogo } from 'src/images/azure.svg'
 import { ReactComponent as GcpLogo } from 'src/images/gcp.svg'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
-import { getConfig } from 'src/libs/config'
-import { withErrorReporting } from 'src/libs/error'
 import Events from 'src/libs/events'
 import * as Nav from 'src/libs/nav'
-import { useCancellation, usePollingEffect } from 'src/libs/react-utils'
 import * as Utils from 'src/libs/utils'
 import { commonStyles } from 'src/pages/library/common'
-import {
-  datasetAccessTypes, isDatarepoSnapshot, isWorkspace, uiMessaging, useDataCatalog
-} from 'src/pages/library/dataBrowser-utils'
+import { datasetAccessTypes, importDataToWorkspace, uiMessaging, useDataCatalog } from 'src/pages/library/dataBrowser-utils'
 import { DataBrowserFeedbackModal } from 'src/pages/library/DataBrowserFeedbackModal'
 import { RequestDatasetAccessModal } from 'src/pages/library/RequestDatasetAccessModal'
 
@@ -116,37 +109,7 @@ export const SidebarComponent = ({ dataObj, id }) => {
   const { access } = dataObj
   const [showRequestAccessModal, setShowRequestAccessModal] = useState(false)
   const [feedbackShowing, setFeedbackShowing] = useState(false)
-  const [datasetNotSupportedForExport, setDatasetNotSupportedForExport] = useState(false)
-  const [snapshotExportJobId, setSnapshotExportJobId] = useState()
-  const [tdrSnapshotPreparePolling, setTdrSnapshotPreparePolling] = useState(false)
   const sidebarButtonWidth = 230
-
-
-  const importDataToWorkspace = dataset => {
-    Ajax().Metrics.captureEvent(`${Events.catalogWorkspaceLink}:detailsView`, {
-      id,
-      title: dataObj['dct:title'],
-      source: dataset['dcat:accessURL']
-    })
-    Utils.cond(
-      [isWorkspace(dataset), () => {
-        Nav.history.push({
-          pathname: Nav.getPath('import-data'),
-          search: qs.stringify({
-            format: 'catalog',
-            snapshotName: dataset['dct:title'],
-            catalogDatasetId: dataset.id
-          })
-        })
-      }],
-      [isDatarepoSnapshot(dataset), async () => {
-        setTdrSnapshotPreparePolling(true)
-        const jobInfo = await withErrorReporting('Error exporting dataset', async () => await Ajax().DataRepo.snapshot(dataset['dct:identifier']).exportSnapshot())()
-        setSnapshotExportJobId(jobInfo.id)
-      }],
-      () => setDatasetNotSupportedForExport(true)
-    )
-  }
 
   return h(Fragment, [
     div({ style: { ...styles.content, width: 300, flexShrink: 0, display: 'flex', flexDirection: 'column', alignItems: 'center' } }, [
@@ -214,10 +177,8 @@ export const SidebarComponent = ({ dataObj, id }) => {
         ])
       ]),
       h(ButtonOutline, {
-        disabled: (isWorkspace(dataObj) || isDatarepoSnapshot(dataObj)) && dataObj.access !== datasetAccessTypes.GRANTED,
-        tooltip: (isWorkspace(dataObj) || isDatarepoSnapshot(dataObj)) ?
-          dataObj.access === datasetAccessTypes.GRANTED ? '' : uiMessaging.controlledFeatureTooltip :
-          uiMessaging.unsupportedDatasetTypeTooltip('preview'),
+        disabled: dataObj.access !== datasetAccessTypes.GRANTED,
+        tooltip: dataObj.access === datasetAccessTypes.GRANTED ? '' : uiMessaging.controlledFeature_tooltip,
         style: { fontSize: 16, textTransform: 'none', height: 'unset', width: sidebarButtonWidth, marginTop: 20 },
         onClick: () => {
           Ajax().Metrics.captureEvent(`${Events.catalogView}:previewData`, {
@@ -233,15 +194,17 @@ export const SidebarComponent = ({ dataObj, id }) => {
         ])
       ]),
       h(ButtonPrimary, {
-        disabled: (isWorkspace(dataObj) || isDatarepoSnapshot(dataObj)) && (dataObj.access !== datasetAccessTypes.GRANTED || tdrSnapshotPreparePolling),
-        tooltip: (isWorkspace(dataObj) || isDatarepoSnapshot(dataObj)) ?
-          dataObj.access === datasetAccessTypes.GRANTED ? '' : uiMessaging.controlledFeatureTooltip :
-          uiMessaging.unsupportedDatasetTypeTooltip('preparing for analysis'),
+        disabled: true,
+        tooltip: 'We are currently working on the link to workspace feature which will be available soon.',
         style: { fontSize: 16, textTransform: 'none', height: 'unset', width: sidebarButtonWidth, marginTop: 20 },
         onClick: () => {
-          importDataToWorkspace(dataObj)
+          Ajax().Metrics.captureEvent(`${Events.catalogWorkspaceLink}:detailsView`, {
+            id,
+            title: dataObj['dct:title']
+          })
+          importDataToWorkspace([dataObj])
         }
-      }, ['Prepare for analysis']),
+      }, ['Link to a workspace']),
       div({ style: { display: 'flex', width: sidebarButtonWidth, marginTop: 20 } }, [
         icon('talk-bubble', { size: 60, style: { width: 60, height: 45 } }),
         div({ style: { marginLeft: 10, lineHeight: '1.3rem' } }, [
@@ -260,78 +223,7 @@ export const SidebarComponent = ({ dataObj, id }) => {
     showRequestAccessModal && h(RequestDatasetAccessModal, {
       datasets: [dataObj],
       onDismiss: () => setShowRequestAccessModal(false)
-    }),
-    datasetNotSupportedForExport && h(Modal, {
-      title: 'Cannot Export Dataset',
-      showCancel: false,
-      onDismiss: () => setDatasetNotSupportedForExport(false)
-    }, ['This dataset is not hosted in a storage system that currently has the ability to export to a research environment.']),
-    !!snapshotExportJobId && h(SnapshotExportModal, {
-      jobId: snapshotExportJobId,
-      dataset: dataObj,
-      onDismiss: () => {
-        setSnapshotExportJobId(undefined)
-        setTdrSnapshotPreparePolling(false)
-      },
-      onFailure: () => {
-        setDatasetNotSupportedForExport(true)
-        setSnapshotExportJobId(undefined)
-        setTdrSnapshotPreparePolling(false)
-      }
     })
-  ])
-}
-
-const SnapshotExportModal = ({ jobId, dataset, onDismiss, onFailure }) => {
-  const signal = useCancellation()
-  const [jobStatus, setJobStatus] = useState('running')
-  const [abortWarningShowing, setAbortWarningShowing] = useState(false)
-
-  usePollingEffect(
-    withErrorReporting('Problem checking status of snapshot import', async () => {
-      jobStatus === 'running' && await checkJobStatus()
-    }), { ms: 1000 })
-
-  const checkJobStatus = async () => {
-    const jobInfo = await Ajax(signal).DataRepo.job(jobId).details()
-    const newJobStatus = jobInfo['job_status']
-    Utils.switchCase(newJobStatus,
-      ['succeeded', async () => {
-        const jobResult = await withErrorReporting('Error getting export result', async () => await Ajax().DataRepo.job(jobId).result())()
-        const jobResultManifest = jobResult?.format?.parquet?.manifest
-        Ajax().Metrics.captureEvent(Events.catalogWorkspaceLinkExportFinished)
-        jobResultManifest ? Nav.history.push({
-          pathname: Nav.getPath('import-data'),
-          search: qs.stringify({
-            url: getConfig().dataRepoUrlRoot, format: 'tdrexport', referrer: 'data-catalog',
-            snapshotId: dataset['dct:identifier'], snapshotName: dataset['dct:title'], tdrmanifest: jobResultManifest
-          })
-        }) : onFailure()
-      }],
-      ['running', () => setJobStatus('running')],
-      [Utils.DEFAULT, onFailure])
-  }
-
-  const buttonStyle = { width: 88, borderRadius: 1 }
-
-  return h(Modal, {
-    title: 'Preparing Dataset for Analysis',
-    onDismiss,
-    showCancel: false,
-    shouldCloseOnOverlayClick: false,
-    shouldCloseOnEsc: false,
-    okButton: abortWarningShowing ? div(
-      { style: { display: 'flex', width: '100%', alignItems: 'center', justifyContent: 'space-between' } },
-      [
-        'Are you sure you want to abort?',
-        h(ButtonOutline, { onClick: () => setAbortWarningShowing(false), style: buttonStyle }, ['No']),
-        h(ButtonOutline, { onClick: onDismiss, style: buttonStyle }, ['Yes'])
-      ]) : h(ButtonOutline, { onClick: () => setAbortWarningShowing(true), style: buttonStyle }, ['Abort'])
-  }, [
-    div({ style: { display: 'flex', alignItems: 'center' } }, [
-      spinner({ size: 100 }),
-      div({ style: { marginLeft: 10 } }, ['Your dataset is being prepared for analysis. This may take a minute or two.'])
-    ])
   ])
 }
 

--- a/src/pages/library/dataBrowser-utils.js
+++ b/src/pages/library/dataBrowser-utils.js
@@ -1,7 +1,10 @@
 import _ from 'lodash/fp'
+import qs from 'qs'
 import { useState } from 'react'
 import { Ajax } from 'src/libs/ajax'
+import { getConfig } from 'src/libs/config'
 import { withErrorReporting } from 'src/libs/error'
+import * as Nav from 'src/libs/nav'
 import { useCancellation, useOnMount, useStore } from 'src/libs/react-utils'
 import { dataCatalogStore } from 'src/libs/state'
 import * as Utils from 'src/libs/utils'
@@ -14,8 +17,7 @@ export const datasetAccessTypes = {
 }
 
 export const uiMessaging = {
-  controlledFeatureTooltip: 'You do not have access to this dataset. Please request access to unlock this feature.',
-  unsupportedDatasetTypeTooltip: action => `The Data Catalog currently does not support ${action} for this dataset.`
+  controlledFeature_tooltip: 'You do not have access to this dataset. Please request access to unlock this feature.'
 }
 
 export const datasetReleasePolicies = {
@@ -35,14 +37,6 @@ export const datasetReleasePolicies = {
   'TerraCore:NPC': { label: 'NPC', desc: 'Not-for-profit use only' },
   'TerraCore:NPC2': { label: 'NPC2', desc: 'Not-for-profit, non-commercial use only' },
   releasepolicy_other: { policy: 'SnapshotReleasePolicy_Other', label: 'Other', desc: 'Misc release policies' }
-}
-
-export const isWorkspace = dataset => {
-  return _.toLower(dataset['dcat:accessURL']).includes('/#workspaces/')
-}
-
-export const isDatarepoSnapshot = dataset => {
-  return _.toLower(dataset['dcat:accessURL']).includes('/snapshots/details/')
 }
 
 const normalizeDataset = dataset => {
@@ -127,4 +121,16 @@ export const useDataCatalog = () => {
     _.isEmpty(dataCatalog) && refresh()
   })
   return { dataCatalog, refresh, loading }
+}
+
+export const importDataToWorkspace = datasets => {
+  // TODO (DC-284): Call data catalog to figure out what the format should be for importing to workspace
+  const format = 'snapshot'
+  Nav.history.push({
+    pathname: Nav.getPath('import-data'),
+    search: qs.stringify({
+      url: getConfig().dataRepoUrlRoot, format, referrer: 'data-catalog',
+      snapshotIds: _.map('dct:identifier', datasets)
+    })
+  })
 }


### PR DESCRIPTION
Reverts DataBiosphere/terra-ui#3334
Reverts DataBiosphere/terra-ui#3317 

We've seen an increasing amount of errors in `link-to-workspace`, `run-catalog-workflow`, and the `preview workspace` feature is also partially broken. This also is blocking Terra release.

- For preview workspace, the data we are getting back from certain workspaces in prod is very different from the ones we have in dev, and this is causing react to crash
- For export to workspace, tests are failing in alpha and staging but not in dev