### PR TITLE
[PROD-732] Renaming analyses deletes the file instead of renaming.

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1301,7 +1301,7 @@ const Buckets = signal => ({
 
       rename: async newName => {
         await copy(newName, bucket, false)
-        await doDelete()
+        return doDelete()
       }
     }
   },

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -55,6 +55,26 @@ const withCancellation = wrappedFetch => async (...args) => {
   }
 }
 
+const withRetryOnError = _.curry((shouldNotRetryFn, wrappedFetch) => async (...args) => {
+  const timeout = 5000
+  const somePointInTheFuture = Date.now() + timeout
+  const maxDelayIncrement = 1500
+  const minDelay = 500
+
+  while (Date.now() < somePointInTheFuture) {
+    const until = Math.random() * maxDelayIncrement + minDelay
+    try {
+      return await Utils.withDelay(until, wrappedFetch)(...args)
+    } catch (error) {
+      if (shouldNotRetryFn(error)) {
+        throw error
+      }
+      // ignore error will retry
+    }
+  }
+  return wrappedFetch(...args)
+})
+
 // Converts non-200 responses to exceptions
 const withErrorRejection = wrappedFetch => async (...args) => {
   const res = await wrappedFetch(...args)
@@ -136,7 +156,7 @@ const fetchSam = _.flow(withUrlPrefix(`${getConfig().samUrlRoot}/`), withAppIden
 // requesterPaysError may be set on responses from requests to the GCS API that are wrapped in withRequesterPays.
 // requesterPaysError is true if the request requires a user project for billing the request to. Such errors
 // are not transient and the request should not be retried.
-const fetchBuckets = _.flow(withRequesterPays, withUrlPrefix('https://storage.googleapis.com/'))(fetchOk)
+const fetchBuckets = _.flow(withRequesterPays, withRetryOnError(error => Boolean(error.requesterPaysError)), withUrlPrefix('https://storage.googleapis.com/'))(fetchOk)
 const fetchRawls = _.flow(withUrlPrefix(`${getConfig().rawlsUrlRoot}/api/`), withAppIdentifier)(fetchOk)
 const fetchWorkspaceManager = _.flow(withUrlPrefix(`${getConfig().workspaceManagerUrlRoot}/api/`), withAppIdentifier)(fetchOk)
 const fetchCatalog = withUrlPrefix(`${getConfig().catalogUrlRoot}/api/`, fetchOk)

--- a/src/pages/workspaces/workspace/Analyses.js
+++ b/src/pages/workspaces/workspace/Analyses.js
@@ -153,7 +153,7 @@ const AnalysisCard = ({
       }, [makeMenuIcon('copy-to-clipboard'), 'Copy analysis URL to clipboard']),
       h(MenuButton, {
         'aria-label': `Rename`,
-        disabled: true,
+        disabled: !canWrite,
         tooltip: !canWrite && noWrite,
         tooltipSide: 'left',
         onClick: () => onRename()


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/PROD-732

## Issue:

When a user went to rename a file on the analyses tab, the file would instead get deleted.

## Root cause:
The async functions that handle copying and deleting weren't running sequentially - the delete function would be fired immediately after the copyTo (rename) funciton, when it SHOULD have been after copyTo completed.

## Solution
Removed function that incorrectly attempts retries. 
Fixed async/await would function properly.

Re-enabled rename button.
