### PR TITLE
[SUP-546] Add provenance for files written by workflows

### DIFF
--- a/src/components/UriViewer.js
+++ b/src/components/UriViewer.js
@@ -5,6 +5,7 @@ import { div, h, img, input } from 'react-hyperscript-helpers'
 import { requesterPaysWrapper, withRequesterPaysHandler } from 'src/components/bucket-utils'
 import Collapse from 'src/components/Collapse'
 import { ButtonPrimary, ClipboardButton, Link } from 'src/components/common'
+import { FileProvenance } from 'src/components/data/data-table-provenance'
 import { getDownloadCommand, getUserProjectForWorkspace, parseGsUri } from 'src/components/data/data-utils'
 import { spinner } from 'src/components/icons'
 import Modal from 'src/components/Modal'
@@ -12,6 +13,7 @@ import DownloadPrices from 'src/data/download-prices'
 import { Ajax } from 'src/libs/ajax'
 import { bucketBrowserUrl } from 'src/libs/auth'
 import colors from 'src/libs/colors'
+import { isDataTableProvenanceEnabled } from 'src/libs/config'
 import Events, { extractWorkspaceDetails } from 'src/libs/events'
 import { useCancellation, useOnMount, withDisplayName } from 'src/libs/react-utils'
 import { knownBucketRequesterPaysStatuses, workspaceStore } from 'src/libs/state'
@@ -267,7 +269,11 @@ const UriViewer = _.flow(
             els.data(new Date(updated).toLocaleString())
           ])
         ]),
-        div({ style: { fontSize: 10 } }, ['* Estimated. Download cost may be higher in China or Australia.'])
+        div({ style: { fontSize: 10 } }, ['* Estimated. Download cost may be higher in China or Australia.']),
+        isDataTableProvenanceEnabled() && h(Fragment, [
+          div({ style: { margin: '2rem 0 0.5rem', fontWeight: 500 } }, ['Where did this file come from?']),
+          h(FileProvenance, { workspace, fileUrl: uri })
+        ])
       ])],
       () => h(Fragment, [
         isGs(uri) ? 'Loading metadata...' : 'Resolving DOS object...',

--- a/src/components/UriViewer.js
+++ b/src/components/UriViewer.js
@@ -164,7 +164,9 @@ const DownloadButton = ({ uri, metadata: { bucket, name, fileName, size }, acces
 const UriViewer = _.flow(
   withDisplayName('UriViewer'),
   requesterPaysWrapper({ onDismiss: ({ onDismiss }) => onDismiss() })
-)(({ googleProject, uri, onDismiss, onRequesterPaysError }) => {
+)(({ workspace, uri, onDismiss, onRequesterPaysError }) => {
+  const { workspace: { googleProject } } = workspace
+
   const signal = useCancellation()
   const [metadata, setMetadata] = useState()
   const [loadingError, setLoadingError] = useState()
@@ -275,7 +277,7 @@ const UriViewer = _.flow(
   ])
 })
 
-export const UriViewerLink = ({ uri, googleProject }) => {
+export const UriViewerLink = ({ uri, workspace }) => {
   const [modalOpen, setModalOpen] = useState(false)
   return h(Fragment, [
     h(Link, {
@@ -288,7 +290,7 @@ export const UriViewerLink = ({ uri, googleProject }) => {
     }, [isGs(uri) ? _.last(uri.split(/\/\b/)) : uri]),
     modalOpen && h(UriViewer, {
       onDismiss: () => setModalOpen(false),
-      uri, googleProject
+      uri, workspace
     })
   ])
 }

--- a/src/components/UriViewer.js
+++ b/src/components/UriViewer.js
@@ -267,13 +267,13 @@ const UriViewer = _.flow(
           updated && els.cell([
             els.label('Updated'),
             els.data(new Date(updated).toLocaleString())
+          ]),
+          isDataTableProvenanceEnabled() && els.cell([
+            els.label('Where did this file come from?'),
+            els.data([h(FileProvenance, { workspace, fileUrl: uri })])
           ])
         ]),
-        div({ style: { fontSize: 10 } }, ['* Estimated. Download cost may be higher in China or Australia.']),
-        isDataTableProvenanceEnabled() && h(Fragment, [
-          div({ style: { margin: '2rem 0 0.5rem', fontWeight: 500 } }, ['Where did this file come from?']),
-          h(FileProvenance, { workspace, fileUrl: uri })
-        ])
+        div({ style: { fontSize: 10 } }, ['* Estimated. Download cost may be higher in China or Australia.'])
       ])],
       () => h(Fragment, [
         isGs(uri) ? 'Loading metadata...' : 'Resolving DOS object...',

--- a/src/components/data/FileBrowser.js
+++ b/src/components/data/FileBrowser.js
@@ -459,7 +459,7 @@ const BucketBrowser = (({
       ]),
 
       viewingObject && h(UriViewer, {
-        googleProject,
+        workspace,
         uri: `gs://${bucketName}/${viewingObject.name}`,
         onDismiss: () => setViewingObject(null)
       }),

--- a/src/components/data/data-table-provenance.js
+++ b/src/components/data/data-table-provenance.js
@@ -52,6 +52,7 @@ export const FileProvenance = ({ workspace, fileUrl }) => {
       [fileProvenanceTypes.maybeSubmission, () => span([
         'Unknown. This file may be associated with submission ',
         h(Link, {
+          'aria-label': 'possible parent submission',
           href: Nav.getLink('workspace-submission-details', {
             namespace, name,
             submissionId: fileProvenance.submissionId
@@ -62,6 +63,7 @@ export const FileProvenance = ({ workspace, fileUrl }) => {
       [fileProvenanceTypes.workflowOutput, () => span([
         'This file is an output of workflow ',
         h(Link, {
+          'aria-label': 'parent workflow',
           href: Nav.getLink('workspace-workflow-dashboard', {
             namespace, name,
             submissionId: fileProvenance.submissionId,
@@ -70,6 +72,7 @@ export const FileProvenance = ({ workspace, fileUrl }) => {
         }, [fileProvenance.workflowId]),
         ' (part of submission ',
         h(Link, {
+          'aria-label': 'parent submission',
           href: Nav.getLink('workspace-submission-details', {
             namespace, name,
             submissionId: fileProvenance.submissionId
@@ -80,6 +83,7 @@ export const FileProvenance = ({ workspace, fileUrl }) => {
       [fileProvenanceTypes.workflowLog, () => span([
         'This file is a log from workflow ',
         h(Link, {
+          'aria-label': 'parent workflow',
           href: Nav.getLink('workspace-workflow-dashboard', {
             namespace, name,
             submissionId: fileProvenance.submissionId,
@@ -88,6 +92,7 @@ export const FileProvenance = ({ workspace, fileUrl }) => {
         }, [fileProvenance.workflowId]),
         ' (part of submission ',
         h(Link, {
+          'aria-label': 'parent submission',
           href: Nav.getLink('workspace-submission-details', {
             namespace, name,
             submissionId: fileProvenance.submissionId

--- a/src/components/data/data-table-provenance.js
+++ b/src/components/data/data-table-provenance.js
@@ -67,7 +67,7 @@ export const FileProvenance = ({ workspace, fileUrl }) => {
             submissionId: fileProvenance.submissionId,
             workflowId: fileProvenance.workflowId
           })
-        }, [fileProvenance.submissionId]),
+        }, [fileProvenance.workflowId]),
         ' (part of submission ',
         h(Link, {
           href: Nav.getLink('workspace-submission-details', {
@@ -85,7 +85,7 @@ export const FileProvenance = ({ workspace, fileUrl }) => {
             submissionId: fileProvenance.submissionId,
             workflowId: fileProvenance.workflowId
           })
-        }, [fileProvenance.submissionId]),
+        }, [fileProvenance.workflowId]),
         ' (part of submission ',
         h(Link, {
           href: Nav.getLink('workspace-submission-details', {

--- a/src/components/data/data-table-provenance.js
+++ b/src/components/data/data-table-provenance.js
@@ -2,7 +2,7 @@ import _ from 'lodash/fp'
 import { Fragment } from 'react'
 import { div, h, li, ol, p, span } from 'react-hyperscript-helpers'
 import { Link } from 'src/components/common'
-import { maxSubmissionsQueriedForProvenance } from 'src/libs/data-table-provenance'
+import { fileProvenanceTypes, maxSubmissionsQueriedForProvenance, useFileProvenance } from 'src/libs/data-table-provenance'
 import * as Nav from 'src/libs/nav'
 import * as Utils from 'src/libs/utils'
 
@@ -37,4 +37,64 @@ export const DataTableColumnProvenance = ({ workspace, column, provenance }) => 
       }, provenance)
     ])
   ])
+}
+
+export const FileProvenance = ({ workspace, fileUrl }) => {
+  const { workspace: { namespace, name } } = workspace
+  const { fileProvenance, loading, error } = useFileProvenance(workspace, fileUrl)
+
+  return Utils.cond(
+    [loading, () => 'Loading provenance...'],
+    [error, () => 'Unable to load provenance information.'],
+    () => Utils.switchCase(fileProvenance.type,
+      [fileProvenanceTypes.externalFile, () => 'Unknown. Provenance information is only available for files in the workspace bucket.'],
+      [fileProvenanceTypes.unknown, () => 'Unknown. This file does not appear to be associated with a submission.'],
+      [fileProvenanceTypes.maybeSubmission, () => span([
+        'Unknown. This file may be associated with submission ',
+        h(Link, {
+          href: Nav.getLink('workspace-submission-details', {
+            namespace, name,
+            submissionId: fileProvenance.submissionId
+          })
+        }, [fileProvenance.submissionId]),
+        ', but it was not found in workflow outputs.'
+      ])],
+      [fileProvenanceTypes.workflowOutput, () => span([
+        'This file is an output of workflow ',
+        h(Link, {
+          href: Nav.getLink('workspace-workflow-dashboard', {
+            namespace, name,
+            submissionId: fileProvenance.submissionId,
+            workflowId: fileProvenance.workflowId
+          })
+        }, [fileProvenance.submissionId]),
+        ' (part of submission ',
+        h(Link, {
+          href: Nav.getLink('workspace-submission-details', {
+            namespace, name,
+            submissionId: fileProvenance.submissionId
+          })
+        }, [fileProvenance.submissionId]),
+        ').'
+      ])],
+      [fileProvenanceTypes.workflowLog, () => span([
+        'This file is a log from workflow ',
+        h(Link, {
+          href: Nav.getLink('workspace-workflow-dashboard', {
+            namespace, name,
+            submissionId: fileProvenance.submissionId,
+            workflowId: fileProvenance.workflowId
+          })
+        }, [fileProvenance.submissionId]),
+        ' (part of submission ',
+        h(Link, {
+          href: Nav.getLink('workspace-submission-details', {
+            namespace, name,
+            submissionId: fileProvenance.submissionId
+          })
+        }, [fileProvenance.submissionId]),
+        ').'
+      ])]
+    )
+  )
 }

--- a/src/components/data/data-table-provenance.test.js
+++ b/src/components/data/data-table-provenance.test.js
@@ -41,10 +41,6 @@ describe('FileProvenance', () => {
     ]
   ]
 
-  afterEach(() => {
-    jest.restoreAllMocks()
-  })
-
   _.forEach(([fileProvenance, expectedMessage]) => {
     it(`renders ${fileProvenance.type} provenance`, () => {
       useFileProvenance.mockReturnValue({ fileProvenance, error: null, loading: false })

--- a/src/components/data/data-table-provenance.test.js
+++ b/src/components/data/data-table-provenance.test.js
@@ -1,0 +1,58 @@
+import '@testing-library/jest-dom'
+
+import { render } from '@testing-library/react'
+import _ from 'lodash/fp'
+import { h } from 'react-hyperscript-helpers'
+import { FileProvenance } from 'src/components/data/data-table-provenance'
+import { fileProvenanceTypes, useFileProvenance } from 'src/libs/data-table-provenance'
+
+
+jest.mock('src/libs/nav', () => ({
+  ...jest.requireActual('src/libs/nav'),
+  getLink: () => ''
+}))
+
+jest.mock('src/libs/data-table-provenance', () => ({
+  ...jest.requireActual('src/libs/data-table-provenance'),
+  useFileProvenance: jest.fn()
+}))
+
+describe('FileProvenance', () => {
+  const testCases = [
+    [
+      { type: fileProvenanceTypes.externalFile },
+      'Unknown. Provenance information is only available for files in the workspace bucket.'
+    ],
+    [
+      { type: fileProvenanceTypes.unknown },
+      'Unknown. This file does not appear to be associated with a submission.'
+    ],
+    [
+      { type: fileProvenanceTypes.maybeSubmission, submissionId: '842371e3-2cea-4929-94f4-dda074e6fd71' },
+      'Unknown. This file may be associated with submission 842371e3-2cea-4929-94f4-dda074e6fd71, but it was not found in workflow outputs.'
+    ],
+    [
+      { type: fileProvenanceTypes.workflowOutput, submissionId: '842371e3-2cea-4929-94f4-dda074e6fd71', workflowId: 'e8e3447c-10c7-4265-b812-e6a5183e99a5' },
+      'This file is an output of workflow e8e3447c-10c7-4265-b812-e6a5183e99a5 (part of submission 842371e3-2cea-4929-94f4-dda074e6fd71).'
+    ],
+    [
+      { type: fileProvenanceTypes.workflowLog, submissionId: '842371e3-2cea-4929-94f4-dda074e6fd71', workflowId: 'e8e3447c-10c7-4265-b812-e6a5183e99a5' },
+      'This file is a log from workflow e8e3447c-10c7-4265-b812-e6a5183e99a5 (part of submission 842371e3-2cea-4929-94f4-dda074e6fd71).'
+    ]
+  ]
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  _.forEach(([fileProvenance, expectedMessage]) => {
+    it(`renders ${fileProvenance.type} provenance`, () => {
+      useFileProvenance.mockReturnValue({ fileProvenance, error: null, loading: false })
+
+      const workspace = { workspace: { namespace: 'test', name: 'test' } }
+      const { container } = render(h(FileProvenance, { workspace, fileUrl: 'gs://my-bucket/file.txt' }))
+
+      expect(container).toHaveTextContent(expectedMessage)
+    })
+  }, testCases)
+})

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -103,12 +103,12 @@ const renderDataCellTooltip = attributeValue => {
 }
 
 export const renderDataCell = (attributeValue, workspace) => {
-  const { workspace: { bucketName: workspaceBucket, googleProject } } = workspace
+  const { workspace: { bucketName: workspaceBucket } } = workspace
 
   const renderCell = datum => {
     const stringDatum = Utils.convertValue('string', datum)
 
-    return isUri(datum) ? h(UriViewerLink, { uri: datum, googleProject }) : stringDatum
+    return isUri(datum) ? h(UriViewerLink, { uri: datum, workspace }) : stringDatum
   }
 
   const renderArray = items => {

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -888,7 +888,9 @@ const Workspaces = signal => ({
                   excludeKey
                 }, { arrayFormat: 'repeat' })}`, _.merge(authOpts(), { signal }))
                 return res.json()
-              }
+              },
+
+              outputs: () => fetchRawls(`${submissionPath}/workflows/${workflowId}/outputs`, _.merge(authOpts(), { signal })).then(r => r.json())
             }
           }
         }

--- a/src/libs/data-table-provenance.js
+++ b/src/libs/data-table-provenance.js
@@ -101,7 +101,7 @@ const isOutput = (url, task) => _.some(
   task.outputs
 )
 
-const getFileProvenance = async (workspace, fileUrl, { signal } = {}) => {
+export const getFileProvenance = async (workspace, fileUrl, { signal } = {}) => {
   const { workspace: { namespace, name, bucketName: workspaceBucket } } = workspace
 
   const [bucket, path] = parseGsUri(fileUrl)

--- a/src/libs/data-table-provenance.test.js
+++ b/src/libs/data-table-provenance.test.js
@@ -1,0 +1,86 @@
+import { Ajax } from 'src/libs/ajax'
+import { fileProvenanceTypes, getFileProvenance } from 'src/libs/data-table-provenance'
+
+
+jest.mock('src/libs/ajax')
+
+describe('getFileProvenance', () => {
+  const workspace = { workspace: { namespace: 'test', name: 'test', bucketName: 'workspace-bucket' } }
+
+  beforeEach(() => {
+    Ajax.mockImplementation(() => ({
+      Workspaces: {
+        workspace: () => ({
+          submission: () => ({
+            workflow: () => ({
+              outputs: jest.fn().mockReturnValue(Promise.resolve({
+                tasks: {
+                  workflow: {
+                    outputs: {
+                      'workflow.output1': 'Hello world',
+                      'workflow.output2': 'gs://workspace-bucket/submissions/8d79470f-7042-4e79-bf67-971adf4e5a4a/workflow/78f61618-30e6-4405-baf3-2ef2e576a3a3/task1/file.txt'
+                    }
+                  },
+                  'workflow.task1': {
+                    logs: [
+                      {
+                        backendLogs: {
+                          log: 'gs://workspace-bucket/submissions/8d79470f-7042-4e79-bf67-971adf4e5a4a/workflow/78f61618-30e6-4405-baf3-2ef2e576a3a3/task1/task1.log'
+                        },
+                        stderr: 'gs://workspace-bucket/submissions/8d79470f-7042-4e79-bf67-971adf4e5a4a/workflow/78f61618-30e6-4405-baf3-2ef2e576a3a3/task1/stderr',
+                        stdout: 'gs://workspace-bucket/submissions/8d79470f-7042-4e79-bf67-971adf4e5a4a/workflow/78f61618-30e6-4405-baf3-2ef2e576a3a3/task1/stdout'
+                      }
+                    ]
+                  },
+                  'workflow.task2': {
+                    logs: [
+                      {
+                        backendLogs: {
+                          log: 'gs://workspace-bucket/submissions/8d79470f-7042-4e79-bf67-971adf4e5a4a/workflow/78f61618-30e6-4405-baf3-2ef2e576a3a3/task2/task2.log'
+                        },
+                        stderr: 'gs://workspace-bucket/submissions/8d79470f-7042-4e79-bf67-971adf4e5a4a/workflow/78f61618-30e6-4405-baf3-2ef2e576a3a3/task2/stderr',
+                        stdout: 'gs://workspace-bucket/submissions/8d79470f-7042-4e79-bf67-971adf4e5a4a/workflow/78f61618-30e6-4405-baf3-2ef2e576a3a3/task2/stdout'
+                      }
+                    ]
+                  }
+                },
+                workflowId: '78f61618-30e6-4405-baf3-2ef2e576a3a3'
+              }))
+            })
+          })
+        })
+      }
+    }))
+  })
+
+  it('returns external for files outside the workspace bucket', async () => {
+    expect(await getFileProvenance(workspace, 'gs://other-bucket/file.txt'))
+      .toEqual({ type: fileProvenanceTypes.externalFile })
+  })
+
+  it('returns unknown for files outside a submission directory', async () => {
+    expect(await getFileProvenance(workspace, 'gs://workspace-bucket/folder/file.txt'))
+      .toEqual({ type: fileProvenanceTypes.unknown })
+  })
+
+  it('returns maybeSubmission for files in a submission directory that are not workflow outputs', async () => {
+    expect(await getFileProvenance(workspace, 'gs://workspace-bucket/submissions/8d79470f-7042-4e79-bf67-971adf4e5a4a/file.txt'))
+      .toEqual({ type: fileProvenanceTypes.maybeSubmission, submissionId: '8d79470f-7042-4e79-bf67-971adf4e5a4a' })
+
+    expect(await getFileProvenance(workspace, 'gs://workspace-bucket/submissions/8d79470f-7042-4e79-bf67-971adf4e5a4a/workflow/e8e3447c-10c7-4265-b812-e6a5183e99a5/task/file.txt'))
+      .toEqual({ type: fileProvenanceTypes.maybeSubmission, submissionId: '8d79470f-7042-4e79-bf67-971adf4e5a4a' })
+  })
+
+  it('returns workflowLog for workflow logs', async () => {
+    expect(await getFileProvenance(workspace, 'gs://workspace-bucket/submissions/8d79470f-7042-4e79-bf67-971adf4e5a4a/workflow/78f61618-30e6-4405-baf3-2ef2e576a3a3/task1/task1.log'))
+      .toEqual({ type: fileProvenanceTypes.workflowLog, submissionId: '8d79470f-7042-4e79-bf67-971adf4e5a4a', workflowId: '78f61618-30e6-4405-baf3-2ef2e576a3a3' })
+
+    expect(await getFileProvenance(workspace, 'gs://workspace-bucket/submissions/8d79470f-7042-4e79-bf67-971adf4e5a4a/workflow/78f61618-30e6-4405-baf3-2ef2e576a3a3/task2/stdout'))
+      .toEqual({ type: fileProvenanceTypes.workflowLog, submissionId: '8d79470f-7042-4e79-bf67-971adf4e5a4a', workflowId: '78f61618-30e6-4405-baf3-2ef2e576a3a3' })
+  })
+
+  it('returns workflowOutput for workflow outputs', async () => {
+    expect(await getFileProvenance(workspace, 'gs://workspace-bucket/submissions/8d79470f-7042-4e79-bf67-971adf4e5a4a/workflow/78f61618-30e6-4405-baf3-2ef2e576a3a3/task1/file.txt'))
+      .toEqual({ type: fileProvenanceTypes.workflowOutput, submissionId: '8d79470f-7042-4e79-bf67-971adf4e5a4a', workflowId: '78f61618-30e6-4405-baf3-2ef2e576a3a3' })
+  })
+})

--- a/src/pages/workspaces/workspace/jobHistory/WorkflowDashboard.js
+++ b/src/pages/workspaces/workspace/jobHistory/WorkflowDashboard.js
@@ -63,9 +63,7 @@ const WorkflowDashboard = _.flow(
     breadcrumbs: props => breadcrumbs.commonPaths.workspaceDashboard(props),
     title: 'Job History', activeTab: 'job history'
   })
-)((props, _ref) => {
-  const { namespace, name, submissionId, workflowId, workspace, workspace: { workspace: { googleProject } } } = props
-
+)(({ namespace, name, submissionId, workflowId, workspace }, _ref) => {
   /*
    * State setup
    */
@@ -232,7 +230,7 @@ const WorkflowDashboard = _.flow(
         wdl && h(Collapse, {
           title: div({ style: Style.elements.sectionHeader }, ['Submitted workflow script'])
         }, [h(WDLViewer, { wdl })]),
-        showLog && h(UriViewer, { googleProject, uri: workflowLog, onDismiss: () => setShowLog(false) })
+        showLog && h(UriViewer, { workspace, uri: workflowLog, onDismiss: () => setShowLog(false) })
       ])
     )
   ])


### PR DESCRIPTION
This adds a "Where did this file come from?" section to the modal shown when viewing a file from a data table or the workspace files browser.

For files that are workflow outputs, it shows a link to the workflow and submission.

<img width="473" alt="Screen Shot 2022-09-06 at 10 54 10 AM" src="https://user-images.githubusercontent.com/1156625/188668316-4b85c782-f57d-4cbb-8a86-99967e264feb.png">

This is behind a feature flag. To enable it, run `window.configOverridesStore.set({ isDataTableProvenanceEnabled: true })` in the console and reload.