### PR TITLE
[SU-200] Render workspace descriptions in workspaces list

### DIFF
--- a/src/components/markdown.js
+++ b/src/components/markdown.js
@@ -52,6 +52,7 @@ export const FirstParagraphMarkdownViewer = ({ children, renderers, ...props }) 
       code: () => '',
       heading: () => '',
       hr: () => '',
+      html: () => '',
       image: () => '',
       list: () => '',
       listitem: () => '',

--- a/src/components/markdown.js
+++ b/src/components/markdown.js
@@ -25,8 +25,6 @@ const renderAndSanitizeMarkdown = (text, renderers = {}) => DOMPurify.sanitize(m
 }))
 
 /**
- * WARNING: Be very careful when using custom renderers because they may override marked's built-in
- * content sanitization.
  * @param {string} children - markdown content
  * @param {Object} renderers - element-specific renderers
  * @param {Object} props - properties for wrapper div

--- a/src/components/markdown.js
+++ b/src/components/markdown.js
@@ -2,7 +2,7 @@ import DOMPurify from 'dompurify'
 import _ from 'lodash/fp'
 import { marked } from 'marked'
 import { lazy, Suspense, useMemo } from 'react'
-import { div, h } from 'react-hyperscript-helpers'
+import { div, h, p } from 'react-hyperscript-helpers'
 import { centeredSpinner } from 'src/components/icons'
 
 
@@ -43,32 +43,35 @@ export const MarkdownViewer = ({ children, renderers, ...props }) => {
 
 export const FirstParagraphMarkdownViewer = ({ children, renderers, ...props }) => {
   let renderedFirstParagraph = false
-  return h(MarkdownViewer, {
+  const content = renderAndSanitizeMarkdown(children, {
+    // See https://marked.js.org/using_pro#renderer for list of renderer methods.
+    blockquote: () => '',
+    checkbox: () => '',
+    code: () => '',
+    heading: () => '',
+    hr: () => '',
+    html: () => '',
+    image: () => '',
+    list: () => '',
+    listitem: () => '',
+    paragraph: text => {
+      if (!renderedFirstParagraph) {
+        renderedFirstParagraph = true
+        return text
+      }
+      return ''
+    },
+    table: () => '',
+    tablerow: () => '',
+    tablecell: () => '',
+    ...renderers
+  })
+
+  return p({
+    className: 'markdown-body',
     ...props,
-    renderers: {
-      // See https://marked.js.org/using_pro#renderer for list of renderer methods.
-      blockquote: () => '',
-      checkbox: () => '',
-      code: () => '',
-      heading: () => '',
-      hr: () => '',
-      html: () => '',
-      image: () => '',
-      list: () => '',
-      listitem: () => '',
-      paragraph: text => {
-        if (!renderedFirstParagraph) {
-          renderedFirstParagraph = true
-          return `<p>${text}</p>`
-        }
-        return ''
-      },
-      table: () => '',
-      tablerow: () => '',
-      tablecell: () => '',
-      ...renderers
-    }
-  }, [children])
+    dangerouslySetInnerHTML: { __html: content }
+  })
 }
 
 export const newWindowLinkRenderer = (href, title, text) => {

--- a/src/pages/library/Showcase.js
+++ b/src/pages/library/Showcase.js
@@ -77,7 +77,7 @@ const WorkspaceCard = ({ workspace }) => {
         created && div([Utils.makeStandardDate(created)])
       ]),
       h(FirstParagraphMarkdownViewer, {
-        style: { fontSize: '14px', lineHeight: '20px', height: 100, overflow: 'hidden' }
+        style: { margin: 0, fontSize: '14px', lineHeight: '20px', height: 100, overflow: 'hidden' }
       }, [description?.toString()])
     ])
   ])

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -7,6 +7,7 @@ import { HeaderRenderer, Link, Select, topSpinnerOverlay, transparentSpinnerOver
 import FooterWrapper from 'src/components/FooterWrapper'
 import { icon } from 'src/components/icons'
 import { DelayedSearchInput } from 'src/components/input'
+import { FirstParagraphMarkdownViewer } from 'src/components/markdown'
 import NewWorkspaceModal from 'src/components/NewWorkspaceModal'
 import { SimpleTabBar } from 'src/components/tabBars'
 import { FlexTable } from 'src/components/table'
@@ -235,10 +236,10 @@ export const WorkspaceList = () => {
                   tooltipSide: 'right'
                 }, [name])
               ]),
-              div({ style: styles.tableCellContent }, [
-                span({ style: { ...Style.noWrapEllipsis, color: !!description ? undefined : colors.dark(0.75) } }, [
-                  description?.toString().split('\n')[0] || 'No description added'
-                ])
+              div({ style: { ...styles.tableCellContent } }, [
+                h(FirstParagraphMarkdownViewer, {
+                  style: { ...Style.noWrapEllipsis, margin: 0, color: !!description ? undefined : colors.dark(0.75), fontSize: '14px' }
+                }, [description?.toString() || 'No description added'])
               ])
             ])
           },

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -238,7 +238,7 @@ export const WorkspaceList = () => {
               ]),
               div({ style: { ...styles.tableCellContent } }, [
                 h(FirstParagraphMarkdownViewer, {
-                  style: { ...Style.noWrapEllipsis, margin: 0, color: !!description ? undefined : colors.dark(0.75), fontSize: '14px' }
+                  style: { ...Style.noWrapEllipsis, margin: 0, color: !!description ? undefined : colors.dark(0.75), fontSize: 14 }
                 }, [description?.toString() || 'No description added'])
               ])
             ])


### PR DESCRIPTION
Currently, the first line of the Markdown source is shown in the workspaces list.
https://github.com/DataBiosphere/terra-ui/blob/67f1f26ad84dd4c8b5bb7e4285e7fd94a209f8c3/src/pages/workspaces/List.js#L239-L241

This sometimes leads to useless descriptions such as:
<img width="640" alt="Screen Shot 2022-09-06 at 12 32 49 PM" src="https://user-images.githubusercontent.com/1156625/188688970-19e5140b-3bc4-4dc2-be16-bd567eb67846.png">

This renders the first paragraph of the workspace description using the same approach used for featured workspaces in #3155.

<img width="638" alt="Screen Shot 2022-09-06 at 12 32 28 PM" src="https://user-images.githubusercontent.com/1156625/188689170-357216f7-8982-4219-ac20-59d974cd59d5.png">

This also makes a few changes to FirstParagraphMarkdownViewer. https://github.com/DataBiosphere/terra-ui/pull/3355/commits/26d1d04b98c3712feb798b7a62528cf3e8a1ece9 adds a custom `html` renderer to prevent images from showing up in the workspace descriptions (as can be seen in the Featured Workspaces page on production).

<img width="1175" alt="Screen Shot 2022-09-06 at 12 36 49 PM" src="https://user-images.githubusercontent.com/1156625/188689517-78a895f6-93ee-475f-93c8-cc3ccadd521f.png">

Also, currently FirstParagraphMarkdownViewer renders a div with React and sets its content to be the output of the Markdown renderer. Thus, it currently renders a paragraph inside a div. https://github.com/DataBiosphere/terra-ui/pull/3355/commits/da4efe996126b522d94b97dae08ca1915665fbb1 removes the div wrapper and uses React to render the paragraph tag. This allows applying styles to the paragraph tag, which was necessary to add text-overflow: ellipsis to the description on the workspaces list.
