### PR TITLE
[WOR-481] Filter storage containers to avoid application private container

### DIFF
--- a/integration-tests/tests/workspace-dashboard.js
+++ b/integration-tests/tests/workspace-dashboard.js
@@ -157,7 +157,15 @@ const setAzureAjaxMockValues = async (testPage, namespace, name, workspaceDescri
       },
       {
         metadata: {
-          resourceType: 'AZURE_STORAGE_CONTAINER'
+          resourceType: 'AZURE_STORAGE_CONTAINER',
+          controlledResourceMetadata: { accessScope: 'PRIVATE_ACCESS' }
+        },
+        resourceAttributes: { azureStorageContainer: { storageAccountId: 'dummy-sa-resource-id', storageContainerName: 'private-sc-name' } }
+      },
+      {
+        metadata: {
+          resourceType: 'AZURE_STORAGE_CONTAINER',
+          controlledResourceMetadata: { accessScope: 'SHARED_ACCESS' }
         },
         resourceAttributes: { azureStorageContainer: { storageAccountId: 'dummy-sa-resource-id', storageContainerName: 'sc-name' } }
       }

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1138,7 +1138,7 @@ const AzureStorage = signal => ({
     } else {
       const container = _.find(
         {
-          metadata: { resourceType: 'AZURE_STORAGE_CONTAINER' },
+          metadata: { resourceType: 'AZURE_STORAGE_CONTAINER', controlledResourceMetadata: { accessScope: 'SHARED_ACCESS' } },
           resourceAttributes: { azureStorageContainer: { storageAccountId: storageAccount.metadata.resourceId } }
         },
         data.resources


### PR DESCRIPTION
Fixes a bug where we showed the Leonardo PRIVATE_ACCESS container on the Workspace Dashboard, and the SAS token was for that container instead of the workspace public container.

If we end up having multiple SHARED_ACCESS containers at some point, requiring us find a way to mark "the" workspace container. However, we aren't confident yet about the best way to do that, so we are going to wait to see if it truly becomes necessary.

To test:
1) Create an Azure workspace (must be in Azure alpha group).
2) Create a Jupyter notebook in that workspace
3) Note the storage container name (ls-saturn is for "leonardo", sc is "the" workspace bucket).
4) You can also check that the SAS tokens are different (the container name is used in the request to get the SAS token).

Before:
![image](https://user-images.githubusercontent.com/484484/188889942-c5e26921-3dc2-44e0-905c-3d96a1ef682b.png)

After:
![image](https://user-images.githubusercontent.com/484484/188889843-40385655-d869-4ef2-9b74-c9753cbdd4a3.png)
