### PR TITLE
[QA-2003] Remove integration tests against alpha from build-deploy workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -314,10 +314,6 @@ workflows:
           <<: *filter-dev-branch
           requires:
             - build
-      - integration-tests-alpha:
-          <<: *filter-dev-branch
-          requires:
-            - deploy-alpha
       - integration-tests-staging:
           <<: *filter-dev-branch
           requires:


### PR DESCRIPTION
Release automation in [saturn-ui-prod-deploy](https://github.com/DataBiosphere/saturn-ui-prod-deploy) deploys the latest commit where the build-deploy workflow passed (see [find-build.js](https://github.com/DataBiosphere/saturn-ui-prod-deploy/blob/dev/src/find-build.js)).

Currently, that workflow deploys the UI. to all environments and runs integration tests against alpha and staging.
https://github.com/DataBiosphere/terra-ui/blob/8dc9b12b573be11d631ec06e6e9111b38291e05a/.circleci/config.yml#L290-L324

However, if tests pass against staging but fail against alpha, that's more suggestive of a backend issue in the alpha environment rather than a UI issue in the dev branch. Thus, it doesn't make sense to block Terra UI releases for tests failing only against alpha.

Tests against alpha make more sense in the nightly job, which is run after a backend deployment to alpha.
https://github.com/DataBiosphere/terra-ui/blob/8dc9b12b573be11d631ec06e6e9111b38291e05a/.circleci/config.yml#L325-L331