### PR TITLE
[dc-521] mixpanel debouncing for search

### DIFF
--- a/src/pages/library/common.js
+++ b/src/pages/library/common.js
@@ -316,6 +316,9 @@ const getContextualSuggestion = ([leftContext, match, rightContext]) => {
   ]
 }
 
+const sendSearchEvent = term => Ajax().Metrics.captureEvent(`${Events.catalogFilter}:search`, { term })
+const debounceSearchEvent = _.debounce(5000, sendSearchEvent)
+
 export const SearchAndFilterComponent = ({
   fullList, sidebarSections, customSort, searchType,
   titleField = 'name', descField = 'description', idField = 'lowerName', children
@@ -402,8 +405,6 @@ export const SearchAndFilterComponent = ({
   }, [fullList, searchFilter, customSort, sort, listDataByTag, selectedTags, selectedSections, sidebarSections, idField])
 
 
-  const sendSearchEvent = _.debounce(5000, term => Ajax().Metrics.captureEvent(`${Events.catalogFilter}:search`, { term }))
-
   const onSearchChange = filter => {
     const newSearch = qs.stringify({
       ...query,
@@ -413,7 +414,7 @@ export const SearchAndFilterComponent = ({
     if (filter) {
       // This method is already debounced, but we need to further debounce the event logging to
       // prevent getting all the intermediate filter strings in the event logs.
-      sendSearchEvent(filter)
+      debounceSearchEvent(filter)
     }
 
     if (newSearch !== Nav.history.location.search) {

--- a/src/pages/library/common.js
+++ b/src/pages/library/common.js
@@ -133,7 +133,6 @@ const FilterBar = ({ name, onClear, onFilterByLetter, onFilterBySearchText, onSo
     filterType === filterOptions.input && div({ style: { display: 'flex', alignItems: 'center', flexDirection: 'row' } }, [
       h(DelayedSearchInput, {
         style: { borderRadius: 25, borderColor: colors.dark(0.2), width: '100%', maxWidth: 575, height: '3rem', marginRight: 20 },
-        debounceMs: 25,
         value: filterSearchText,
         'aria-label': `Search for ${name} filter options`,
         placeholder: 'Search keyword',
@@ -403,6 +402,8 @@ export const SearchAndFilterComponent = ({
   }, [fullList, searchFilter, customSort, sort, listDataByTag, selectedTags, selectedSections, sidebarSections, idField])
 
 
+  const sendSearchEvent = _.debounce(5000, term => Ajax().Metrics.captureEvent(`${Events.catalogFilter}:search`, { term }))
+
   const onSearchChange = filter => {
     const newSearch = qs.stringify({
       ...query,
@@ -410,7 +411,9 @@ export const SearchAndFilterComponent = ({
     }, { addQueryPrefix: true })
 
     if (filter) {
-      Ajax().Metrics.captureEvent(`${Events.catalogFilter}:search`, { filter })
+      // This method is already debounced, but we need to further debounce the event logging to
+      // prevent getting all the intermediate filter strings in the event logs.
+      sendSearchEvent(filter)
     }
 
     if (newSearch !== Nav.history.location.search) {
@@ -451,7 +454,6 @@ export const SearchAndFilterComponent = ({
         h(DelayedAutoCompleteInput, {
           style: { borderRadius: 25, flex: '1 1 0' },
           inputIcon: 'search',
-          debounceMs: 250,
           openOnFocus: true,
           value: searchFilter,
           'aria-label': `Search ${searchType}`,

--- a/src/pages/library/common.js
+++ b/src/pages/library/common.js
@@ -451,7 +451,7 @@ export const SearchAndFilterComponent = ({
         h(DelayedAutoCompleteInput, {
           style: { borderRadius: 25, flex: '1 1 0' },
           inputIcon: 'search',
-          debounceMs: 25,
+          debounceMs: 250,
           openOnFocus: true,
           value: searchFilter,
           'aria-label': `Search ${searchType}`,


### PR DESCRIPTION
This adds some extra debouncing to the input event sent to mixpanel, to avoid sending `g` `gt` `gte` `gtex` when a user is searching for `gtex`