### PR TITLE
[WOR-401] Azure billing project cleanup

### DIFF
--- a/integration-tests/tests/billing-projects.js
+++ b/integration-tests/tests/billing-projects.js
@@ -59,9 +59,8 @@ const billingProjectsPage = (testPage, testUrl) => {
       await testPage.waitForXPath(`(//*[@role="img"])[contains(@aria-label,"${number}. Workspace ${workspaceName}, ${category}: ${cost}.")]`)
     },
 
-    showWorkspaceDetails: async name => {
-      await click(testPage, clickable({ text: `expand workspace ${name}` }))
-    }
+    showWorkspaceDetails: name =>
+      click(testPage, clickable({ text: `expand workspace ${name}` }))
   }
 }
 

--- a/integration-tests/tests/billing-projects.js
+++ b/integration-tests/tests/billing-projects.js
@@ -4,8 +4,10 @@ const { assertTextNotFound, click, clickable, findText, gotoPage, noSpinnersAfte
 const { userEmail } = require('../utils/integration-config')
 const { registerTest } = require('../utils/jest-utils')
 const { withUserToken } = require('../utils/terra-sa-utils')
-const { cloudProviders } = require('src/libs/runtime-utils')
 
+
+const AZURE = 'AZURE'
+const GCP = 'GCP'
 
 const billingProjectsPage = (testPage, testUrl) => {
   return {
@@ -29,8 +31,8 @@ const billingProjectsPage = (testPage, testUrl) => {
       await click(testPage, clickable({ text: 'Owners' }))
     },
 
-    selectProject: async (billingProjectName, cloudPlatform = cloudProviders.gcp) => {
-      const text = cloudPlatform === cloudProviders.gcp ? `Google Cloud Platform${billingProjectName}` : `Microsoft Azure${billingProjectName}`
+    selectProject: async (billingProjectName, cloudPlatform = GCP) => {
+      const text = cloudPlatform === GCP ? `Google Cloud Platform${billingProjectName}` : `Microsoft Azure${billingProjectName}`
       await noSpinnersAfter(testPage, { action: () => click(testPage, clickable({ text })) })
     },
 
@@ -274,7 +276,7 @@ const testBillingSpendReportFn = withUserToken(async ({ page, testUrl, token }) 
 
   // Select an Azure billing project and check that neither the Spend report tab nor the spend report configuration is visible
   await billingPage.visit()
-  await billingPage.selectProject(azureBillingProjectName, cloudProviders.azure)
+  await billingPage.selectProject(azureBillingProjectName, AZURE)
   await billingPage.assertTextNotFound('Spend report')
   await billingPage.assertTextNotFound('View billing account')
 })
@@ -310,7 +312,7 @@ const testBillingWorkspacesFn = withUserToken(async ({ page, testUrl, token }) =
 
   // Select Azure billing project and verify workspace tab details
   await billingPage.visit()
-  await billingPage.selectProject(azureBillingProjectName, cloudProviders.azure)
+  await billingPage.selectProject(azureBillingProjectName, AZURE)
   await verifyWorkspaceControls()
   await billingPage.showWorkspaceDetails()
   await billingPage.assertText(`Resource Group ID${azureBillingProjectName}_mrg`)

--- a/integration-tests/tests/billing-projects.js
+++ b/integration-tests/tests/billing-projects.js
@@ -31,9 +31,9 @@ const billingProjectsPage = (testPage, testUrl) => {
       await click(testPage, clickable({ text: 'Owners' }))
     },
 
-    selectProject: async (billingProjectName, cloudPlatform = GCP) => {
+    selectProject: (billingProjectName, cloudPlatform = GCP) => {
       const text = cloudPlatform === GCP ? `Google Cloud Platform${billingProjectName}` : `Microsoft Azure${billingProjectName}`
-      await noSpinnersAfter(testPage, { action: () => click(testPage, clickable({ text })) })
+      return noSpinnersAfter(testPage, { action: () => click(testPage, clickable({ text })) })
     },
 
     selectProjectMenu: async () => {

--- a/integration-tests/tests/billing-projects.js
+++ b/integration-tests/tests/billing-projects.js
@@ -59,8 +59,8 @@ const billingProjectsPage = (testPage, testUrl) => {
       await testPage.waitForXPath(`(//*[@role="img"])[contains(@aria-label,"${number}. Workspace ${workspaceName}, ${category}: ${cost}.")]`)
     },
 
-    showWorkspaceDetails: async () => {
-      await click(testPage, clickable({ text: 'expand workspace' }))
+    showWorkspaceDetails: async name => {
+      await click(testPage, clickable({ text: `expand workspace ${name}` }))
     }
   }
 }
@@ -302,7 +302,7 @@ const testBillingWorkspacesFn = withUserToken(async ({ page, testUrl, token }) =
 
   // Check that the Workspaces tab is visible on this page
   await verifyWorkspaceControls()
-  await billingPage.showWorkspaceDetails()
+  await billingPage.showWorkspaceDetails(`${ownedBillingProjectName}_ws`)
   await billingPage.assertText(`Google Project${ownedBillingProjectName}_project`)
 
   // Select a billing project that is not owned by the user and verify workspace tab is visible
@@ -314,7 +314,7 @@ const testBillingWorkspacesFn = withUserToken(async ({ page, testUrl, token }) =
   await billingPage.visit()
   await billingPage.selectProject(azureBillingProjectName, AZURE)
   await verifyWorkspaceControls()
-  await billingPage.showWorkspaceDetails()
+  await billingPage.showWorkspaceDetails(`${azureBillingProjectName}_ws`)
   await billingPage.assertText(`Resource Group ID${azureBillingProjectName}_mrg`)
 })
 

--- a/integration-tests/tests/billing-projects.js
+++ b/integration-tests/tests/billing-projects.js
@@ -4,6 +4,7 @@ const { assertTextNotFound, click, clickable, findText, gotoPage, noSpinnersAfte
 const { userEmail } = require('../utils/integration-config')
 const { registerTest } = require('../utils/jest-utils')
 const { withUserToken } = require('../utils/terra-sa-utils')
+const { cloudProviders } = require('src/libs/runtime-utils')
 
 
 const billingProjectsPage = (testPage, testUrl) => {
@@ -28,11 +29,9 @@ const billingProjectsPage = (testPage, testUrl) => {
       await click(testPage, clickable({ text: 'Owners' }))
     },
 
-    selectProject: async billingProjectName => {
-      await noSpinnersAfter(
-        testPage,
-        { action: () => click(testPage, clickable({ text: billingProjectName })) }
-      )
+    selectProject: async (billingProjectName, cloudPlatform = cloudProviders.gcp) => {
+      const text = cloudPlatform === cloudProviders.gcp ? `Google Cloud Platform${billingProjectName}` : `Microsoft Azure${billingProjectName}`
+      await noSpinnersAfter(testPage, { action: () => click(testPage, clickable({ text })) })
     },
 
     selectProjectMenu: async () => {
@@ -275,7 +274,7 @@ const testBillingSpendReportFn = withUserToken(async ({ page, testUrl, token }) 
 
   // Select an Azure billing project and check that neither the Spend report tab nor the spend report configuration is visible
   await billingPage.visit()
-  await billingPage.selectProject(azureBillingProjectName)
+  await billingPage.selectProject(azureBillingProjectName, cloudProviders.azure)
   await billingPage.assertTextNotFound('Spend report')
   await billingPage.assertTextNotFound('View billing account')
 })
@@ -311,7 +310,7 @@ const testBillingWorkspacesFn = withUserToken(async ({ page, testUrl, token }) =
 
   // Select Azure billing project and verify workspace tab details
   await billingPage.visit()
-  await billingPage.selectProject(azureBillingProjectName)
+  await billingPage.selectProject(azureBillingProjectName, cloudProviders.azure)
   await verifyWorkspaceControls()
   await billingPage.showWorkspaceDetails()
   await billingPage.assertText(`Resource Group ID${azureBillingProjectName}_mrg`)

--- a/integration-tests/tests/billing-projects.js
+++ b/integration-tests/tests/billing-projects.js
@@ -56,11 +56,15 @@ const billingProjectsPage = (testPage, testUrl) => {
     assertChartValue: async (number, workspaceName, category, cost) => {
       // This checks the accessible text for chart values.
       await testPage.waitForXPath(`(//*[@role="img"])[contains(@aria-label,"${number}. Workspace ${workspaceName}, ${category}: ${cost}.")]`)
+    },
+
+    showWorkspaceDetails: async () => {
+      await click(testPage, clickable({ text: 'expand workspace' }))
     }
   }
 }
 
-const setAjaxMockValues = async (testPage, ownedBillingProjectName, notOwnedBillingProjectName, erroredBillingProjectName, erroredProjectVisible, spendCost, numExtraWorkspaces = 0) => {
+const setAjaxMockValues = async (testPage, ownedBillingProjectName, notOwnedBillingProjectName, erroredBillingProjectName, azureBillingProjectName, erroredProjectVisible, spendCost, numExtraWorkspaces = 0) => {
   const spendReturnResult = {
     spendSummary: {
       cost: spendCost, credits: '2.50', currency: 'USD', endTime: '2022-03-04T00:00:00.000Z', startTime: '2022-02-02T00:00:00.000Z'
@@ -111,15 +115,20 @@ const setAjaxMockValues = async (testPage, ownedBillingProjectName, notOwnedBill
 
   const projectListResult = _.compact([{
     projectName: ownedBillingProjectName,
-    billingAccount: 'billingAccounts/fake-id', invalidBillingAccount: false, roles: ['Owner'], status: 'Ready'
+    billingAccount: 'billingAccounts/fake-id', invalidBillingAccount: false, roles: ['Owner'], status: 'Ready', cloudPlatform: 'GCP'
   },
   erroredProjectVisible && {
     projectName: erroredBillingProjectName,
-    billingAccount: 'billingAccounts/fake-id', invalidBillingAccount: false, roles: ['Owner'], status: 'Error'
+    billingAccount: 'billingAccounts/fake-id', invalidBillingAccount: false, roles: ['Owner'], status: 'Error', cloudPlatform: 'GCP'
   },
   {
     projectName: notOwnedBillingProjectName,
-    billingAccount: 'billingAccounts/fake-id', invalidBillingAccount: false, roles: ['User'], status: 'Ready'
+    billingAccount: 'billingAccounts/fake-id', invalidBillingAccount: false, roles: ['User'], status: 'Ready', cloudPlatform: 'GCP'
+  },
+  {
+    projectName: azureBillingProjectName,
+    managedAppCoordinates: { managedResourceGroupId: `${azureBillingProjectName}_mrg`, subscriptionId: 'subId', tenantId: 'tenantId' },
+    invalidBillingAccount: false, roles: ['Owner'], status: 'Ready', cloudPlatform: 'AZURE'
   }])
 
   const ownedProjectMembersListResult = [{
@@ -139,11 +148,34 @@ const setAjaxMockValues = async (testPage, ownedBillingProjectName, notOwnedBill
     email: 'testuser2@example.com', role: 'Owner'
   }]
 
+  const listWorkspacesResult = [
+    {
+      workspace: {
+        attributes: { description: '' }, authorizationDomain: [], bucketName: '', cloudPlatform: 'Azure', createdBy: 'cahrens@gmail.com',
+        createdDate: '2022-09-06T12:38:49.626Z', googleProject: '', isLocked: false, lastModified: '2022-09-06T12:38:49.643Z',
+        name: `${azureBillingProjectName}_ws`, namespace: azureBillingProjectName, workspaceId: '00bcd838-a08d-4984-88ab-5a8070fe3139',
+        workspaceType: 'mc', workspaceVersion: 'v2'
+      }, accessLevel: 'OWNER', public: false
+    },
+    {
+      workspace: {
+        attributes: { description: '' }, authorizationDomain: [], billingAccount: 'billingAccounts/fake-id', bucketName: 'fake-bucket',
+        cloudPlatform: 'Gcp', createdBy: 'cahrens@gmail.com',
+        createdDate: '2022-09-06T12:38:49.626Z', googleProject: `${ownedBillingProjectName}_project`, isLocked: false,
+        googleProjectNumber: '938723513660', lastModified: '2022-09-06T12:38:49.643Z',
+        name: `${ownedBillingProjectName}_ws`, namespace: ownedBillingProjectName, workflowCollectionName: 'collection-id',
+        workspaceId: 'fake-workspace-id',
+        workspaceType: 'rawls', workspaceVersion: 'v2'
+      }, accessLevel: 'PROJECT_OWNER', public: false
+    }
+  ]
+
   return await testPage.evaluate((spendReturnResult, projectListResult, ownedProjectMembersListResult, notOwnedProjectMembersListResult,
-    ownedBillingProjectName, notOwnedBillingProjectName, erroredBillingProjectName) => {
+    ownedBillingProjectName, notOwnedBillingProjectName, erroredBillingProjectName, azureBillingProjectName, listWorkspacesResult) => {
     const ownedMembersUrl = new RegExp(`api/billing/v2/${ownedBillingProjectName}/members`, 'g')
     const notOwnedMembersUrl = new RegExp(`api/billing/v2/${notOwnedBillingProjectName}/members`, 'g')
     const erroredBillingProjectUrl = new RegExp(`api/billing/v2/${erroredBillingProjectName}$`, 'g')
+    const azureMembersUrl = new RegExp(`api/billing/v2/${azureBillingProjectName}/members`, 'g')
 
     window.ajaxOverridesStore.set([
       {
@@ -167,16 +199,24 @@ const setAjaxMockValues = async (testPage, ownedBillingProjectName, notOwnedBill
         fn: window.ajaxOverrideUtils.makeSuccess(notOwnedProjectMembersListResult)
       },
       {
+        filter: { url: azureMembersUrl },
+        fn: window.ajaxOverrideUtils.makeSuccess(ownedProjectMembersListResult)
+      },
+      {
         filter: { url: erroredBillingProjectUrl, method: 'DELETE' },
         fn: () => () => Promise.resolve(new Response({ status: 204 }))
       },
       {
         filter: { url: /api\/billing(.*)\/spendReport(.*)/ },
         fn: window.ajaxOverrideUtils.makeSuccess(spendReturnResult)
+      },
+      {
+        filter: { url: /api\/workspaces(.*)/ }, // TODO: tighten
+        fn: window.ajaxOverrideUtils.makeSuccess(listWorkspacesResult)
       }
     ])
   }, spendReturnResult, projectListResult, ownedProjectMembersListResult, notOwnedProjectMembersListResult,
-  ownedBillingProjectName, notOwnedBillingProjectName, erroredBillingProjectName)
+  ownedBillingProjectName, notOwnedBillingProjectName, erroredBillingProjectName, azureBillingProjectName, listWorkspacesResult)
 }
 
 const setUpBillingTest = async (page, testUrl, token) => {
@@ -187,15 +227,17 @@ const setUpBillingTest = async (page, testUrl, token) => {
   const ownedBillingProjectName = 'OwnedBillingProject'
   const notOwnedBillingProjectName = 'NotOwnedBillingProject'
   const erroredBillingProjectName = 'ErroredBillingProject'
-  await setAjaxMockValues(page, ownedBillingProjectName, notOwnedBillingProjectName, erroredBillingProjectName, true, '1110')
+  const azureBillingProjectName = 'AzureBillingProject'
+  await setAjaxMockValues(page, ownedBillingProjectName, notOwnedBillingProjectName, erroredBillingProjectName, azureBillingProjectName, true, '1110')
 
   const billingPage = billingProjectsPage(page, testUrl)
 
-  return { ownedBillingProjectName, notOwnedBillingProjectName, erroredBillingProjectName, billingPage }
+  return { ownedBillingProjectName, notOwnedBillingProjectName, erroredBillingProjectName, azureBillingProjectName, billingPage }
 }
 
 const testBillingSpendReportFn = withUserToken(async ({ page, testUrl, token }) => {
-  const { ownedBillingProjectName, notOwnedBillingProjectName, erroredBillingProjectName, billingPage } = await setUpBillingTest(page, testUrl, token)
+  const { ownedBillingProjectName, notOwnedBillingProjectName, erroredBillingProjectName, azureBillingProjectName, billingPage } =
+    await setUpBillingTest(page, testUrl, token)
 
   // Select spend report and verify cost for default date ranges
   await billingPage.visit()
@@ -214,9 +256,12 @@ const testBillingSpendReportFn = withUserToken(async ({ page, testUrl, token }) 
   // Spot-check other 2 workspaces.
   await billingPage.assertChartValue(2, 'Second Most Expensive Workspace', 'Compute', '$90.00')
   await billingPage.assertChartValue(3, 'Third Most Expensive Workspace', 'Storage', '$0.00')
+  // Verify the spend report configuration option is present
+  await billingPage.assertText('View billing account')
 
   // Change the returned mock cost to mimic different date ranges.
-  await setAjaxMockValues(page, ownedBillingProjectName, notOwnedBillingProjectName, erroredBillingProjectName, true, '1110.17', 20)
+  await setAjaxMockValues(page, ownedBillingProjectName, notOwnedBillingProjectName, erroredBillingProjectName,
+    azureBillingProjectName, true, '1110.17', 20)
   await billingPage.setSpendReportDays(90)
   await billingPage.assertText('Total spend$1,110.17')
   // Check that title updated to reflect truncation.
@@ -227,8 +272,15 @@ const testBillingSpendReportFn = withUserToken(async ({ page, testUrl, token }) 
   await billingPage.visit()
   await billingPage.selectProject(notOwnedBillingProjectName)
 
-  //Check that the Spend report tab is not visible on this page
+  // Check that the Spend report tab is not visible on this page
   await billingPage.assertTextNotFound('Spend report')
+
+  // Select an Azure billing project and check that neither the Spend report tab nor the spend report configuration is visible
+  await billingPage.visit()
+  await billingPage.selectProject(azureBillingProjectName)
+  await billingPage.assertTextNotFound('Spend report')
+  // Verify the spend report configuration option is not present
+  await billingPage.assertTextNotFound('View billing account')
 })
 
 registerTest({
@@ -237,7 +289,7 @@ registerTest({
 })
 
 const testBillingWorkspacesFn = withUserToken(async ({ page, testUrl, token }) => {
-  const { ownedBillingProjectName, notOwnedBillingProjectName, billingPage } = await setUpBillingTest(page, testUrl, token)
+  const { ownedBillingProjectName, notOwnedBillingProjectName, azureBillingProjectName, billingPage } = await setUpBillingTest(page, testUrl, token)
 
   // Select a billing project that is owned by the user
   await billingPage.visit()
@@ -248,6 +300,8 @@ const testBillingWorkspacesFn = withUserToken(async ({ page, testUrl, token }) =
   await billingPage.assertText('Name')
   await billingPage.assertText('Created By')
   await billingPage.assertText('Last Modified')
+  await billingPage.showWorkspaceDetails()
+  await billingPage.assertText(`Google Project${ownedBillingProjectName}_project`)
 
   // Select a billing project that is not owned by the user
   await billingPage.visit()
@@ -258,6 +312,12 @@ const testBillingWorkspacesFn = withUserToken(async ({ page, testUrl, token }) =
   await billingPage.assertText('Name')
   await billingPage.assertText('Created By')
   await billingPage.assertText('Last Modified')
+
+  // Select Azure billing project
+  await billingPage.visit()
+  await billingPage.selectProject(azureBillingProjectName)
+  await billingPage.showWorkspaceDetails()
+  await billingPage.assertText(`Resource Group ID${azureBillingProjectName}_mrg`)
 })
 
 registerTest({
@@ -305,7 +365,8 @@ registerTest({
 })
 
 const testDeleteBillingProjectFn = withUserToken(async ({ page, testUrl, token }) => {
-  const { ownedBillingProjectName, notOwnedBillingProjectName, erroredBillingProjectName, billingPage } = await setUpBillingTest(page, testUrl, token)
+  const { ownedBillingProjectName, notOwnedBillingProjectName, erroredBillingProjectName, azureBillingProjectName, billingPage } =
+    await setUpBillingTest(page, testUrl, token)
 
   await billingPage.visit()
 
@@ -323,7 +384,8 @@ const testDeleteBillingProjectFn = withUserToken(async ({ page, testUrl, token }
 
   // Reset the ajax values to NOT include the errored billing project before confirming the deletion
   // This is so we can test that the project list refreshes properly
-  await setAjaxMockValues(page, ownedBillingProjectName, notOwnedBillingProjectName, erroredBillingProjectName, false, '1110.17', 20)
+  await setAjaxMockValues(page, ownedBillingProjectName, notOwnedBillingProjectName, erroredBillingProjectName, azureBillingProjectName,
+    false, '1110.17', 20)
 
   // Confirm delete
   await billingPage.confirmDeleteBillingProject()
@@ -357,23 +419,23 @@ const testBillingProjectOneOwnerWarning = withUserToken(async ({ page, testUrl, 
         fn: window.ajaxOverrideUtils.makeSuccess([
           {
             projectName: ownedAndNoOtherUsersBillingProject,
-            billingAccount: 'billingAccounts/fake-id', invalidBillingAccount: false, roles: ['Owner'], status: 'Ready'
+            billingAccount: 'billingAccounts/fake-id', invalidBillingAccount: false, roles: ['Owner'], status: 'Ready', cloudPlatform: 'GCP'
           },
           {
             projectName: ownedAndSharedBillingProject,
-            billingAccount: 'billingAccounts/fake-id', invalidBillingAccount: false, roles: ['Owner'], status: 'Ready'
+            billingAccount: 'billingAccounts/fake-id', invalidBillingAccount: false, roles: ['Owner'], status: 'Ready', cloudPlatform: 'GCP'
           },
           {
             projectName: ownedWithMultipleOwnersBillingProject,
-            billingAccount: 'billingAccounts/fake-id', invalidBillingAccount: false, roles: ['Owner'], status: 'Ready'
+            billingAccount: 'billingAccounts/fake-id', invalidBillingAccount: false, roles: ['Owner'], status: 'Ready', cloudPlatform: 'GCP'
           },
           {
             projectName: usedWithOneOwnerBillingProject,
-            billingAccount: 'billingAccounts/fake-id', invalidBillingAccount: false, roles: ['User'], status: 'Ready'
+            billingAccount: 'billingAccounts/fake-id', invalidBillingAccount: false, roles: ['User'], status: 'Ready', cloudPlatform: 'GCP'
           },
           {
             projectName: usedWithMultipleOwnersBillingProject,
-            billingAccount: 'billingAccounts/fake-id', invalidBillingAccount: false, roles: ['User'], status: 'Ready'
+            billingAccount: 'billingAccounts/fake-id', invalidBillingAccount: false, roles: ['User'], status: 'Ready', cloudPlatform: 'GCP'
           }
         ])
       },

--- a/integration-tests/tests/billing-projects.js
+++ b/integration-tests/tests/billing-projects.js
@@ -59,8 +59,7 @@ const billingProjectsPage = (testPage, testUrl) => {
       await testPage.waitForXPath(`(//*[@role="img"])[contains(@aria-label,"${number}. Workspace ${workspaceName}, ${category}: ${cost}.")]`)
     },
 
-    showWorkspaceDetails: name =>
-      click(testPage, clickable({ text: `expand workspace ${name}` }))
+    showWorkspaceDetails: name => click(testPage, clickable({ text: `expand workspace ${name}` }))
   }
 }
 

--- a/src/pages/billing/List.js
+++ b/src/pages/billing/List.js
@@ -21,6 +21,7 @@ import Events from 'src/libs/events'
 import { formHint, FormLabel } from 'src/libs/forms'
 import * as Nav from 'src/libs/nav'
 import { useCancellation, useOnMount } from 'src/libs/react-utils'
+import { cloudProviders } from 'src/libs/runtime-utils'
 import * as StateHistory from 'src/libs/state-history'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
@@ -46,11 +47,6 @@ const styles = {
   }
 }
 
-const billingProjectTypes = {
-  azure: 'azure',
-  gcp: 'gcp'
-}
-
 const CreateBillingProjectControl = ({ isAlphaAzureUser, showCreateProjectModal }) => {
   const createButton = (onClickCallback, type) => {
     return h(ButtonOutline, {
@@ -60,7 +56,7 @@ const CreateBillingProjectControl = ({ isAlphaAzureUser, showCreateProjectModal 
   }
 
   if (!isAlphaAzureUser) {
-    return createButton(showCreateProjectModal, billingProjectTypes.gcp)
+    return createButton(showCreateProjectModal, cloudProviders.gcp)
   } else {
     return h(MenuTrigger, {
       side: 'bottom',
@@ -68,11 +64,11 @@ const CreateBillingProjectControl = ({ isAlphaAzureUser, showCreateProjectModal 
       content: h(Fragment, [
         h(MenuButton, {
           'aria-haspopup': 'dialog',
-          onClick: () => showCreateProjectModal(billingProjectTypes.azure)
+          onClick: () => showCreateProjectModal(cloudProviders.azure)
         }, 'Azure Billing Project'),
         h(MenuButton, {
           'aria-haspopup': 'dialog',
-          onClick: () => showCreateProjectModal(billingProjectTypes.gcp)
+          onClick: () => showCreateProjectModal(cloudProviders.gcp)
         }, 'GCP Billing Project')
       ])
     }, [createButton()])
@@ -121,8 +117,8 @@ const ProjectListItem = ({ project, project: { roles, status, cloudPlatform }, l
   const cloudContextIcon =
     div({ style: { display: 'flex', marginRight: '0.5rem' } }, [
       Utils.switchCase(cloudPlatform,
-        ['GCP', () => h(CloudGcpLogo, { title: 'Google Cloud Platform', role: 'img' })],
-        ['AZURE', () => h(CloudAzureLogo, { title: 'Microsoft Azure', role: 'img' })])
+        [cloudProviders.gcp.label, () => h(CloudGcpLogo, { title: 'Google Cloud Platform', role: 'img' })],
+        [cloudProviders.azure.label, () => h(CloudAzureLogo, { title: 'Microsoft Azure', role: 'img' })])
     ])
 
   const selectableProject = ({ projectName }, isActive) => h(Clickable, {
@@ -303,7 +299,7 @@ const NewBillingProjectModal = ({ onSuccess, onDismiss, billingAccounts, loadAcc
 export const BillingList = ({ queryParams: { selectedName } }) => {
   // State
   const [billingProjects, setBillingProjects] = useState(StateHistory.get().billingProjects || [])
-  const [creatingBillingProject, setCreatingBillingProject] = useState(null) // null or billingProjectTypes values
+  const [creatingBillingProject, setCreatingBillingProject] = useState(null) // null or cloudProvider values
   const [billingAccounts, setBillingAccounts] = useState({})
   const [isLoadingProjects, setIsLoadingProjects] = useState(false)
   const [isAuthorizing, setIsAuthorizing] = useState(false)
@@ -362,7 +358,7 @@ export const BillingList = ({ queryParams: { selectedName } }) => {
   const authorizeAndLoadAccounts = () => authorizeAccounts().then(loadAccounts)
 
   const showCreateProjectModal = async type => {
-    if (type === billingProjectTypes.azure) {
+    if (type === cloudProviders.azure) {
       setCreatingBillingProject(type)
     } else if (Auth.hasBillingScope()) {
       setCreatingBillingProject(type)
@@ -447,7 +443,7 @@ export const BillingList = ({ queryParams: { selectedName } }) => {
           ])
         ])
       ]),
-      creatingBillingProject === billingProjectTypes.gcp && h(NewBillingProjectModal, {
+      creatingBillingProject === cloudProviders.gcp && h(NewBillingProjectModal, {
         billingAccounts,
         loadAccounts,
         onDismiss: () => setCreatingBillingProject(null),
@@ -456,7 +452,7 @@ export const BillingList = ({ queryParams: { selectedName } }) => {
           loadProjects()
         }
       }),
-      creatingBillingProject === billingProjectTypes.azure && isAlphaAzureUser && h(CreateAzureBillingProjectModal, {
+      creatingBillingProject === cloudProviders.azure && isAlphaAzureUser && h(CreateAzureBillingProjectModal, {
         onDismiss: () => setCreatingBillingProject(null),
         onSuccess: () => {
           setCreatingBillingProject(null)

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -114,7 +114,7 @@ const WorkspaceCard = memoWithName('WorkspaceCard', ({ workspace, billingProject
         ]),
         div({ style: { flex: `0 0 ${workspaceExpandIconSize}px` } }, [
           h(Link, {
-            'aria-label': 'expand workspace',
+            'aria-label': `expand workspace ${name}`,
             'aria-expanded': isExpanded,
             'aria-controls': isExpanded ? id : undefined,
             'aria-owns': isExpanded ? id : undefined,

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -70,8 +70,7 @@ const ExpandedInfoRow = ({ title, details, errorMessage }) => {
     title: { fontWeight: 600, padding: '0.5rem 1rem 0 2rem', height: '1rem' },
     details: { flexGrow: 1, marginTop: '0.5rem', height: '1rem', ...Style.noWrapEllipsis },
     errorMessage: {
-      flexGrow: 2,
-      padding: '0.5rem', backgroundColor: colors.light(0.3),
+      flexGrow: 2, padding: '0.5rem', backgroundColor: colors.light(0.3),
       border: `solid 2px ${colors.danger(0.3)}`, borderRadius: 5
     }
   }

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -20,6 +20,7 @@ import Events from 'src/libs/events'
 import { FormLabel } from 'src/libs/forms'
 import * as Nav from 'src/libs/nav'
 import { memoWithName, useCancellation, useGetter, useOnMount, usePollingEffect } from 'src/libs/react-utils'
+import { cloudProviders } from 'src/libs/runtime-utils'
 import { contactUsActive } from 'src/libs/state'
 import * as StateHistory from 'src/libs/state-history'
 import * as Style from 'src/libs/style'
@@ -66,10 +67,11 @@ const WorkspaceCardHeaders = memoWithName('WorkspaceCardHeaders', ({ needsStatus
 const ExpandedInfoRow = ({ title, details, errorMessage }) => {
   const expandedInfoStyles = {
     row: { display: 'flex', justifyContent: 'flex-start', alignItems: 'flex-start' },
-    title: { fontWeight: 600, width: '20%', padding: '0.5rem 1rem 0 2rem', height: '1rem' },
-    details: { width: '20%', marginTop: '0.5rem', height: '1rem', ...Style.noWrapEllipsis },
+    title: { fontWeight: 600, padding: '0.5rem 1rem 0 2rem', height: '1rem' },
+    details: { flexGrow: 1, marginTop: '0.5rem', height: '1rem', ...Style.noWrapEllipsis },
     errorMessage: {
-      padding: '0.5rem', width: '55%', backgroundColor: colors.light(0.3),
+      flexGrow: 2,
+      padding: '0.5rem', backgroundColor: colors.light(0.3),
       border: `solid 2px ${colors.danger(0.3)}`, borderRadius: 5
     }
   }
@@ -81,11 +83,11 @@ const ExpandedInfoRow = ({ title, details, errorMessage }) => {
   ])
 }
 
-const WorkspaceCard = memoWithName('WorkspaceCard', ({ workspace, billingAccountStatus, isExpanded, onExpand }) => {
+const WorkspaceCard = memoWithName('WorkspaceCard', ({ workspace, billingProject, billingAccountStatus, isExpanded, onExpand }) => {
   const { namespace, name, createdBy, lastModified, googleProject, billingAccountDisplayName, billingAccountErrorMessage } = workspace
   const workspaceCardStyles = {
     field: {
-      ...Style.noWrapEllipsis, flex: 1, height: '1rem', width: `calc(50% - ${(workspaceLastModifiedWidth + workspaceExpandIconSize) / 2}px)`, paddingRight: '1rem'
+      ...Style.noWrapEllipsis, flex: 1, height: '1.20rem', width: `calc(50% - ${(workspaceLastModifiedWidth + workspaceExpandIconSize) / 2}px)`, paddingRight: '1rem'
     },
     row: { display: 'flex', alignItems: 'center', width: '100%', padding: '1rem' },
     expandedInfoContainer: { display: 'flex', flexDirection: 'column', width: '100%' }
@@ -132,8 +134,9 @@ const WorkspaceCard = memoWithName('WorkspaceCard', ({ workspace, billingAccount
       ]),
       isExpanded && div({ id, style: { ...workspaceCardStyles.row, padding: '0.5rem', border: `1px solid ${colors.light()}` } }, [
         div({ style: workspaceCardStyles.expandedInfoContainer }, [
-          h(ExpandedInfoRow, { title: 'Google Project', details: googleProject }),
-          h(ExpandedInfoRow, { title: 'Billing Account', details: billingAccountDisplayName, errorMessage: billingAccountErrorMessage })
+          billingProject.cloudPlatform === cloudProviders.gcp.label && h(ExpandedInfoRow, { title: 'Google Project', details: googleProject }),
+          billingProject.cloudPlatform === cloudProviders.gcp.label && h(ExpandedInfoRow, { title: 'Billing Account', details: billingAccountDisplayName, errorMessage: billingAccountErrorMessage }),
+          billingProject.cloudPlatform === cloudProviders.azure.label && h(ExpandedInfoRow, { title: 'Resource Group ID', details: billingProject.managedAppCoordinates.managedResourceGroupId })
         ])
       ])
     ])])
@@ -241,6 +244,197 @@ const OtherMessaging = ({ cost }) => {
   ])
 }
 
+const GcpBillingAccountControls = ({
+  authorizeAndLoadAccounts, billingAccounts, billingProject, isOwner, getShowBillingModal, setShowBillingModal,
+  reloadBillingProject, setUpdating
+}) => {
+  const [showBillingRemovalModal, setShowBillingRemovalModal] = useState(false)
+  const [showSpendReportConfigurationModal, setShowSpendReportConfigurationModal] = useState(false)
+  const [selectedBilling, setSelectedBilling] = useState()
+  const [selectedDatasetProjectName, setSelectedDatasetProjectName] = useState(null)
+  const [selectedDatasetName, setSelectedDatasetName] = useState(null)
+
+  const signal = useCancellation()
+
+  // Helpers
+  const setBillingAccount = _.flow(
+    reportErrorAndRethrow('Error updating billing account'),
+    Utils.withBusyState(setUpdating)
+  )(newAccountName => {
+    Ajax().Metrics.captureEvent(Events.changeBillingAccount, {
+      oldName: billingProject.billingAccount,
+      newName: newAccountName,
+      billingProjectName: billingProject.projectName
+    })
+    return Ajax(signal).Billing.changeBillingAccount({
+      billingProjectName: billingProject.projectName,
+      newBillingAccountName: newAccountName
+    })
+  })
+
+  const removeBillingAccount = _.flow(
+    reportErrorAndRethrow('Error removing billing account'),
+    Utils.withBusyState(setUpdating)
+  )(() => {
+    Ajax().Metrics.captureEvent(Events.removeBillingAccount, {
+      billingProject: billingProject.projectName
+    })
+    return Ajax(signal).Billing.removeBillingAccount({
+      billingProjectName: billingProject.projectName
+    })
+  })
+
+  const updateSpendConfiguration = _.flow(
+    reportErrorAndRethrow('Error updating spend report configuration'),
+    Utils.withBusyState(setUpdating)
+  )(() => Ajax(signal).Billing.updateSpendConfiguration({
+    billingProjectName: billingProject.projectName,
+    datasetGoogleProject: selectedDatasetProjectName,
+    datasetName: selectedDatasetName
+  }))
+
+  // (CA-1586) For some reason the api sometimes returns string null, and sometimes returns no field, and sometimes returns null. This is just to be complete.
+  const billingProjectHasBillingAccount = !(billingProject.billingAccount === 'null' || _.isNil(billingProject.billingAccount))
+  const billingAccount = billingProjectHasBillingAccount ? _.find({ accountName: billingProject.billingAccount }, billingAccounts) : undefined
+
+  const billingAccountDisplayText = Utils.cond(
+    [!billingProjectHasBillingAccount, () => 'No linked billing account'],
+    [!billingAccount, () => 'No access to linked billing account'],
+    () => billingAccount.displayName || billingAccount.accountName
+  )
+
+  return h(Fragment, [
+    Auth.hasBillingScope() &&
+    div({ style: { color: colors.dark(), fontSize: 14, display: 'flex', alignItems: 'center', marginTop: '0.5rem', marginLeft: '1rem' } }, [
+      span({ style: { flexShrink: 0, fontWeight: 600, fontSize: 14, margin: '0 0.75rem 0 0' } }, 'Billing Account:'),
+      span({ style: { flexShrink: 0, marginRight: '0.5rem' } }, billingAccountDisplayText),
+      isOwner && h(MenuTrigger, {
+        closeOnClick: true,
+        side: 'bottom',
+        style: { marginLeft: '0.5rem' },
+        content: h(Fragment, [
+          h(MenuButton, {
+            onClick: async () => {
+              if (Auth.hasBillingScope()) {
+                setShowBillingModal(true)
+              } else {
+                await authorizeAndLoadAccounts()
+                setShowBillingModal(Auth.hasBillingScope())
+              }
+            }
+          }, ['Change Billing Account']),
+          h(MenuButton, {
+            onClick: async () => {
+              if (Auth.hasBillingScope()) {
+                setShowBillingRemovalModal(true)
+              } else {
+                await authorizeAndLoadAccounts()
+                setShowBillingRemovalModal(Auth.hasBillingScope())
+              }
+            },
+            disabled: !billingProjectHasBillingAccount
+          }, ['Remove Billing Account'])
+        ])
+      }, [
+        h(Link, { 'aria-label': 'Billing account menu', style: { display: 'flex', alignItems: 'center' } }, [
+          icon('cardMenuIcon', { size: 16, 'aria-haspopup': 'menu' })
+        ])
+      ]),
+      getShowBillingModal() && h(Modal, {
+        title: 'Change Billing Account',
+        onDismiss: () => setShowBillingModal(false),
+        okButton: h(ButtonPrimary, {
+          disabled: !selectedBilling || billingProject.billingAccount === selectedBilling,
+          onClick: () => {
+            setShowBillingModal(false)
+            setBillingAccount(selectedBilling).then(reloadBillingProject)
+          }
+        }, ['Ok'])
+      }, [
+        h(IdContainer, [id => h(Fragment, [
+          h(FormLabel, { htmlFor: id, required: true }, ['Select billing account']),
+          h(Select, {
+            id,
+            value: selectedBilling || billingProject.billingAccount,
+            isClearable: false,
+            options: _.map(({ displayName, accountName }) => ({ label: displayName, value: accountName }), billingAccounts),
+            onChange: ({ value: newAccountName }) => setSelectedBilling(newAccountName)
+          }),
+          div({ style: { marginTop: '1rem' } },
+            ['Note: Changing the billing account for this billing project will clear the spend report configuration.'])
+        ])])
+      ]),
+      showBillingRemovalModal && h(Modal, {
+        title: 'Remove Billing Account',
+        onDismiss: () => setShowBillingRemovalModal(false),
+        okButton: h(ButtonPrimary, {
+          onClick: () => {
+            setShowBillingRemovalModal(false)
+            removeBillingAccount(selectedBilling).then(reloadBillingProject)
+          }
+        }, ['Ok'])
+      }, [
+        div({ style: { marginTop: '1rem' } },
+          ['Are you sure you want to remove this billing project\'s billing account?'])
+      ])
+    ]),
+    Auth.hasBillingScope() && isOwner &&
+    div({ style: { color: colors.dark(), fontSize: 14, display: 'flex', alignItems: 'center', margin: '0.5rem 0 0 1rem' } }, [
+      span({ style: { flexShrink: 0, fontWeight: 600, fontSize: 14, marginRight: '0.75rem' } }, 'Spend Report Configuration:'),
+      span({ style: { flexShrink: 0 } }, 'Edit'),
+      h(Link, {
+        tooltip: 'Configure Spend Reporting',
+        style: { marginLeft: '0.5rem' },
+        onClick: async () => {
+          if (Auth.hasBillingScope()) {
+            setShowSpendReportConfigurationModal(true)
+          } else {
+            await authorizeAndLoadAccounts()
+            setShowSpendReportConfigurationModal(Auth.hasBillingScope())
+          }
+        }
+      }, [icon('edit', { size: 12 })]),
+      showSpendReportConfigurationModal && h(Modal, {
+        title: 'Configure Spend Reporting',
+        onDismiss: () => setShowSpendReportConfigurationModal(false),
+        okButton: h(ButtonPrimary, {
+          disabled: !selectedDatasetProjectName || !selectedDatasetName,
+          onClick: async () => {
+            setShowSpendReportConfigurationModal(false)
+            await updateSpendConfiguration(billingProject.projectName, selectedDatasetProjectName, selectedDatasetName)
+          }
+        }, ['Ok'])
+      }, [
+        h(IdContainer, [id => h(Fragment, [
+          h(FormLabel, { htmlFor: id, required: true }, ['Dataset Project ID']),
+          h(TextInput, {
+            id,
+            onChange: setSelectedDatasetProjectName
+          })
+        ])]),
+        h(IdContainer, [id => h(Fragment, [
+          h(FormLabel, { htmlFor: id, required: true }, ['Dataset Name']),
+          h(TextInput, {
+            id,
+            onChange: setSelectedDatasetName
+          }),
+          div({ style: { marginTop: '1rem' } }, [
+            ['See '],
+            h(Link, { href: 'https://support.terra.bio/hc/en-us/articles/360037862771', ...Utils.newTabLinkProps }, ['our documentation']),
+            [' for details on configuring spend reporting for billing projects.']
+          ])
+        ])])
+      ])
+    ]),
+    !Auth.hasBillingScope() &&
+    div({ style: { color: colors.dark(), fontSize: 14, display: 'flex', alignItems: 'center', marginTop: '0.5rem', marginLeft: '1rem' } }, [
+      h(Link, {
+        onClick: authorizeAndLoadAccounts
+      }, ['View billing account'])
+    ])
+  ])
+}
+
 const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProject, isAlphaSpendReportUser, isOwner, reloadBillingProject }) => {
   // State
   const { query } = Nav.useRoute()
@@ -254,11 +448,6 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
   const [deletingUser, setDeletingUser] = useState(false)
   const [updating, setUpdating] = useState(false)
   const [showBillingModal, setShowBillingModal] = useState(false)
-  const [showBillingRemovalModal, setShowBillingRemovalModal] = useState(false)
-  const [showSpendReportConfigurationModal, setShowSpendReportConfigurationModal] = useState(false)
-  const [selectedBilling, setSelectedBilling] = useState()
-  const [selectedDatasetProjectName, setSelectedDatasetProjectName] = useState(null)
-  const [selectedDatasetName, setSelectedDatasetName] = useState(null)
   const [tab, setTab] = useState(query.tab || 'workspaces')
   const [expandedWorkspaceName, setExpandedWorkspaceName] = useState()
   const [sort, setSort] = useState({ field: 'email', direction: 'asc' })
@@ -329,6 +518,8 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
   const billingAccountsOutOfDate = !(_.isEmpty(groups.error) && _.isEmpty(groups.updating))
   const getBillingAccountStatus = workspace => _.findKey(g => g.has(workspace), groups)
 
+  const isGcpProject = billingProject.cloudPlatform === cloudProviders.gcp.label
+
   const tabToTable = {
     workspaces: h(Fragment, [
       h(WorkspaceCardHeaders, {
@@ -343,6 +534,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
             const isExpanded = expandedWorkspaceName === workspace.name
             return h(WorkspaceCard, {
               workspace: { ...workspace, billingAccountDisplayName: billingAccounts[workspace.billingAccount]?.displayName },
+              billingProject,
               billingAccountStatus: billingAccountsOutOfDate && getBillingAccountStatus(workspace),
               key: workspace.workspaceId,
               isExpanded,
@@ -433,7 +625,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
       _.capitalize(key === 'members' && !isOwner ? 'owners' : key) // Rewrite the 'Members' tab to say 'Owners' if the user has the User role
     ]),
     tableName: _.lowerCase(key)
-  }), _.filter(key => (key !== spendReportKey || (isAlphaSpendReportUser && isOwner)), _.keys(tabToTable)))
+  }), _.filter(key => (key !== spendReportKey || (isAlphaSpendReportUser && isOwner && isGcpProject)), _.keys(tabToTable)))
   useEffect(() => {
     // Note: setting undefined so that falsy values don't show up at all
     const newSearch = qs.stringify({
@@ -444,43 +636,6 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
       Nav.history.replace({ search: newSearch })
     }
   })
-
-  // Helpers
-  const setBillingAccount = _.flow(
-    reportErrorAndRethrow('Error updating billing account'),
-    Utils.withBusyState(setUpdating)
-  )(newAccountName => {
-    Ajax().Metrics.captureEvent(Events.changeBillingAccount, {
-      oldName: billingProject.billingAccount,
-      newName: newAccountName,
-      billingProjectName: billingProject.projectName
-    })
-    return Ajax(signal).Billing.changeBillingAccount({
-      billingProjectName: billingProject.projectName,
-      newBillingAccountName: newAccountName
-    })
-  })
-
-  const removeBillingAccount = _.flow(
-    reportErrorAndRethrow('Error removing billing account'),
-    Utils.withBusyState(setUpdating)
-  )(() => {
-    Ajax().Metrics.captureEvent(Events.removeBillingAccount, {
-      billingProject: billingProject.projectName
-    })
-    return Ajax(signal).Billing.removeBillingAccount({
-      billingProjectName: billingProject.projectName
-    })
-  })
-
-  const updateSpendConfiguration = _.flow(
-    reportErrorAndRethrow('Error updating spend report configuration'),
-    Utils.withBusyState(setUpdating)
-  )(() => Ajax(signal).Billing.updateSpendConfiguration({
-    billingProjectName: billingProject.projectName,
-    datasetGoogleProject: selectedDatasetProjectName,
-    datasetName: selectedDatasetName
-  }))
 
   const collectUserRoles = _.flow(
     _.groupBy('email'),
@@ -575,144 +730,10 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
     { ms: 5000 }
   )
 
-  // (CA-1586) For some reason the api sometimes returns string null, and sometimes returns no field, and sometimes returns null. This is just to be complete.
-  const billingProjectHasBillingAccount = !(billingProject.billingAccount === 'null' || _.isNil(billingProject.billingAccount))
-  const billingAccount = billingProjectHasBillingAccount ? _.find({ accountName: billingProject.billingAccount }, billingAccounts) : undefined
-
-  const billingAccountDisplayText = Utils.cond(
-    [!billingProjectHasBillingAccount, () => 'No linked billing account'],
-    [!billingAccount, () => 'No access to linked billing account'],
-    () => billingAccount.displayName || billingAccount.accountName
-  )
-
   return h(Fragment, [
     div({ style: { padding: '1.5rem 0 0', flexGrow: 1, display: 'flex', flexDirection: 'column' } }, [
       div({ style: { color: colors.dark(), fontSize: 18, fontWeight: 600, display: 'flex', alignItems: 'center', marginLeft: '1rem' } }, [billingProject.projectName]),
-      Auth.hasBillingScope() && div({ style: { color: colors.dark(), fontSize: 14, display: 'flex', alignItems: 'center', marginTop: '0.5rem', marginLeft: '1rem' } }, [
-        span({ style: { flexShrink: 0, fontWeight: 600, fontSize: 14, margin: '0 0.75rem 0 0' } }, 'Billing Account:'),
-        span({ style: { flexShrink: 0, marginRight: '0.5rem' } }, billingAccountDisplayText),
-        isOwner && h(MenuTrigger, {
-          closeOnClick: true,
-          side: 'bottom',
-          style: { marginLeft: '0.5rem' },
-          content: h(Fragment, [
-            h(MenuButton, {
-              onClick: async () => {
-                if (Auth.hasBillingScope()) {
-                  setShowBillingModal(true)
-                } else {
-                  await authorizeAndLoadAccounts()
-                  setShowBillingModal(Auth.hasBillingScope())
-                }
-              }
-            }, ['Change Billing Account']),
-            h(MenuButton, {
-              onClick: async () => {
-                if (Auth.hasBillingScope()) {
-                  setShowBillingRemovalModal(true)
-                } else {
-                  await authorizeAndLoadAccounts()
-                  setShowBillingRemovalModal(Auth.hasBillingScope())
-                }
-              },
-              disabled: !billingProjectHasBillingAccount
-            }, ['Remove Billing Account'])
-          ])
-        }, [
-          h(Link, { 'aria-label': 'Billing account menu', style: { display: 'flex', alignItems: 'center' } }, [
-            icon('cardMenuIcon', { size: 16, 'aria-haspopup': 'menu' })
-          ])
-        ]),
-        showBillingModal && h(Modal, {
-          title: 'Change Billing Account',
-          onDismiss: () => setShowBillingModal(false),
-          okButton: h(ButtonPrimary, {
-            disabled: !selectedBilling || billingProject.billingAccount === selectedBilling,
-            onClick: () => {
-              setShowBillingModal(false)
-              setBillingAccount(selectedBilling).then(reloadBillingProject)
-            }
-          }, ['Ok'])
-        }, [
-          h(IdContainer, [id => h(Fragment, [
-            h(FormLabel, { htmlFor: id, required: true }, ['Select billing account']),
-            h(Select, {
-              id,
-              value: selectedBilling || billingProject.billingAccount,
-              isClearable: false,
-              options: _.map(({ displayName, accountName }) => ({ label: displayName, value: accountName }), billingAccounts),
-              onChange: ({ value: newAccountName }) => setSelectedBilling(newAccountName)
-            }),
-            div({ style: { marginTop: '1rem' } },
-              ['Note: Changing the billing account for this billing project will clear the spend report configuration.'])
-          ])])
-        ]),
-        showBillingRemovalModal && h(Modal, {
-          title: 'Remove Billing Account',
-          onDismiss: () => setShowBillingRemovalModal(false),
-          okButton: h(ButtonPrimary, {
-            onClick: () => {
-              setShowBillingRemovalModal(false)
-              removeBillingAccount(selectedBilling).then(reloadBillingProject)
-            }
-          }, ['Ok'])
-        }, [
-          div({ style: { marginTop: '1rem' } },
-            ['Are you sure you want to remove this billing project\'s billing account?'])
-        ])
-      ]),
-      Auth.hasBillingScope() && isOwner && div({ style: { color: colors.dark(), fontSize: 14, display: 'flex', alignItems: 'center', margin: '0.5rem 0 0 1rem' } }, [
-        span({ style: { flexShrink: 0, fontWeight: 600, fontSize: 14, marginRight: '0.75rem' } }, 'Spend Report Configuration:'),
-        span({ style: { flexShrink: 0 } }, 'Edit'),
-        h(Link, {
-          tooltip: 'Configure Spend Reporting',
-          style: { marginLeft: '0.5rem' },
-          onClick: async () => {
-            if (Auth.hasBillingScope()) {
-              setShowSpendReportConfigurationModal(true)
-            } else {
-              await authorizeAndLoadAccounts()
-              setShowSpendReportConfigurationModal(Auth.hasBillingScope())
-            }
-          }
-        }, [icon('edit', { size: 12 })]),
-        showSpendReportConfigurationModal && h(Modal, {
-          title: 'Configure Spend Reporting',
-          onDismiss: () => setShowSpendReportConfigurationModal(false),
-          okButton: h(ButtonPrimary, {
-            disabled: !selectedDatasetProjectName || !selectedDatasetName,
-            onClick: async () => {
-              setShowSpendReportConfigurationModal(false)
-              await updateSpendConfiguration(billingProject.projectName, selectedDatasetProjectName, selectedDatasetName)
-            }
-          }, ['Ok'])
-        }, [
-          h(IdContainer, [id => h(Fragment, [
-            h(FormLabel, { htmlFor: id, required: true }, ['Dataset Project ID']),
-            h(TextInput, {
-              id,
-              onChange: setSelectedDatasetProjectName
-            })
-          ])]),
-          h(IdContainer, [id => h(Fragment, [
-            h(FormLabel, { htmlFor: id, required: true }, ['Dataset Name']),
-            h(TextInput, {
-              id,
-              onChange: setSelectedDatasetName
-            }),
-            div({ style: { marginTop: '1rem' } }, [
-              ['See '],
-              h(Link, { href: 'https://support.terra.bio/hc/en-us/articles/360037862771', ...Utils.newTabLinkProps }, ['our documentation']),
-              [' for details on configuring spend reporting for billing projects.']
-            ])
-          ])])
-        ])
-      ]),
-      !Auth.hasBillingScope() && div({ style: { color: colors.dark(), fontSize: 14, display: 'flex', alignItems: 'center', marginTop: '0.5rem', marginLeft: '1rem' } }, [
-        h(Link, {
-          onClick: authorizeAndLoadAccounts
-        }, ['View billing account'])
-      ]),
+      isGcpProject && h(GcpBillingAccountControls, { authorizeAndLoadAccounts, billingAccounts, billingProject, isOwner, getShowBillingModal, setShowBillingModal, reloadBillingProject, setUpdating }),
       _.size(projectUsers) > 1 && _.size(projectOwners) === 1 && div({
         style: {
           display: 'flex',


### PR DESCRIPTION
This removes GCP-specific elements when an Azure-backed project is selected. 

For tests, I attempted to write unit tests but the existing components are very large and the amount of mocking I was having to do became prohibitive. Since we already have an integration test (with mocked AJAX calls) for this page, I extended that test to cover these changes.

Changes:
1. Google billing project controls are not present for Azure workspaces.
2. Spend report tab is not present for Azure workspaces.
3. Workspace details show managed resource group instead of Google billing info.
4. Other minor tweaks noted as individual comments on the PR.

Images for 1, 2, and 3:
Azure-backed billing project
![image](https://user-images.githubusercontent.com/484484/189402563-3bf20f9b-166d-4f55-b974-919f073993ee.png)

Google-backed billing project
![image](https://user-images.githubusercontent.com/484484/189402717-b7e69b14-749f-4da5-9fc9-36382497ab52.png)

