### PR TITLE
DC-534: Temporarily disable Data Catalog tests

### DIFF
--- a/integration-tests/tests/link-to-new-workspace.js
+++ b/integration-tests/tests/link-to-new-workspace.js
@@ -46,5 +46,6 @@ const testLinkToNewWorkspaceFn = withUserToken(async ({ billingProject, page, te
 registerTest({
   name: 'link-to-new-workspace',
   fn: testLinkToNewWorkspaceFn,
-  timeout: 2 * 60 * 1000
+  timeout: 2 * 60 * 1000,
+  targetEnvironments: []
 })

--- a/integration-tests/tests/run-catalog-workflow.js
+++ b/integration-tests/tests/run-catalog-workflow.js
@@ -21,5 +21,6 @@ const testCatalogFlowFn = _.flow(
 registerTest({
   name: 'run-catalog',
   fn: testCatalogFlowFn,
-  timeout: 2 * 60 * 1000
+  timeout: 2 * 60 * 1000,
+  targetEnvironments: []
 })


### PR DESCRIPTION
Temporarily disable tests to avoid a notification storm while we investigate the problem.