### PR TITLE
[Needs ticket] Update Jest configuration for mocks in unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,6 +118,10 @@
   "workspaces": [
     "integration-tests"
   ],
+  "jest": {
+    "clearMocks": true,
+    "resetMocks": false
+  },
   "lint-staged": {
     "**/*.js": [
       "yarn eslint --max-warnings=0"


### PR DESCRIPTION
See Jest documentation for a description of these settings:
- [clearMocks](https://jestjs.io/docs/configuration#clearmocks-boolean) / [clearAllMocks](https://jestjs.io/docs/jest-object#jestclearallmocks)
- [resetMocks](https://jestjs.io/docs/configuration#resetmocks-boolean) / [resetAllMocks](https://jestjs.io/docs/jest-object#jestresetallmocks)

[Create React App's default configuration](https://create-react-app.dev/docs/running-tests#configuration) sets `resetMocks` to true.

However, it can be convenient to define a mock implementation for a module once per test.

```js
import { fn } from 'module'

jest.mock('module', () => ({
  ...jest.requireActual('module'),
  fn: jest.fn().mockImplementation(...)
}))

it(...
```

Currently, with `resetMocks` true, the mock implementation is reset after each test and thus has to be added in a `beforeEach`.

```js
import { fn } from 'module'

jest.mock('module', () => ({
  ...jest.requireActual('module'),
  fn: jest.fn()
}))

beforeEach(() => {
  fn.mockImplementation(...)
})

it(...
```

This also prevents using shared mocks defined in a `__mocks__` directory (https://jestjs.io/docs/manual-mocks) or similar shared mocking helpers based on `jest.mock`.

Without `resetMocks`, `clearMocks` maintains some test isolation and avoids surprises by resetting things like mock call counts between tests.