### PR TITLE
DC-537: fix flaky tests by adding more wait for spinners

### DIFF
--- a/integration-tests/tests/link-to-new-workspace.js
+++ b/integration-tests/tests/link-to-new-workspace.js
@@ -1,5 +1,5 @@
 const { linkDataToWorkspace, eitherThrow } = require('../utils/catalog-utils')
-const { click, clickable, fillIn, findText, noSpinnersAfter, select } = require('../utils/integration-utils')
+const { click, clickable, fillIn, findText, noSpinnersAfter, select, waitForNoSpinners } = require('../utils/integration-utils')
 const { testWorkspaceName } = require('../utils/integration-helpers')
 const { registerTest } = require('../utils/jest-utils')
 const { withUserToken } = require('../utils/terra-sa-utils')
@@ -8,6 +8,7 @@ const { withUserToken } = require('../utils/terra-sa-utils')
 const testLinkToNewWorkspaceFn = withUserToken(async ({ billingProject, page, testUrl, token }) => {
   await linkDataToWorkspace(page, testUrl, token)
   const newWorkspaceName = testWorkspaceName()
+  await waitForNoSpinners(page)
   await click(page, clickable({ textContains: 'Start with a new workspace' }))
   await fillIn(page, '//*[@placeholder="Enter a name"]', `${newWorkspaceName}`)
   await select(page, 'Billing project', `${billingProject}`)
@@ -46,6 +47,5 @@ const testLinkToNewWorkspaceFn = withUserToken(async ({ billingProject, page, te
 registerTest({
   name: 'link-to-new-workspace',
   fn: testLinkToNewWorkspaceFn,
-  timeout: 2 * 60 * 1000,
-  targetEnvironments: []
+  timeout: 2 * 60 * 1000
 })

--- a/integration-tests/tests/run-catalog-workflow.js
+++ b/integration-tests/tests/run-catalog-workflow.js
@@ -1,6 +1,6 @@
 const _ = require('lodash/fp')
 const { linkDataToWorkspace } = require('../utils/catalog-utils')
-const { click, clickable, findText, noSpinnersAfter, select } = require('../utils/integration-utils')
+const { click, clickable, findText, noSpinnersAfter, select, waitForNoSpinners } = require('../utils/integration-utils')
 const { withWorkspace } = require('../utils/integration-helpers')
 const { registerTest } = require('../utils/jest-utils')
 const { withUserToken } = require('../utils/terra-sa-utils')
@@ -11,6 +11,7 @@ const testCatalogFlowFn = _.flow(
   withUserToken
 )(async ({ billingProject, page, testUrl, token, workspaceName }) => {
   await linkDataToWorkspace(page, testUrl, token)
+  await waitForNoSpinners(page)
   await click(page, clickable({ textContains: 'Start with an existing workspace' }))
   await select(page, 'Select a workspace', `${workspaceName}`)
   await noSpinnersAfter(page, { action: () => click(page, clickable({ text: 'Import' })) })
@@ -21,6 +22,5 @@ const testCatalogFlowFn = _.flow(
 registerTest({
   name: 'run-catalog',
   fn: testCatalogFlowFn,
-  timeout: 2 * 60 * 1000,
-  targetEnvironments: []
+  timeout: 2 * 60 * 1000
 })


### PR DESCRIPTION
Two catalog tests have been failing flakily and blocking working on terra-ui.

Using the flake shaker, I was able to see a failure rate of ~10-20% when running 100 tests, using dev and staging environments. Looking at where the failure occurs, I added another `waitForNoSpinners()`. With this change, I saw 1 failure out of 100, which went away after running again. I tested using 100 runs in both dev and staging.

When one of the services in terra is under heavy load, it's possible that we'll need to add more delays, or add a larger timeout to the existing operations.