### PR TITLE
[SU-204] Add MixPanel event for starred workspaces

### DIFF
--- a/src/components/workspace-utils.js
+++ b/src/components/workspace-utils.js
@@ -390,6 +390,7 @@ export const WorkspaceStarControl = ({ workspace, stars, setStars, style, updati
       _.concat(refreshedStarredWorkspaceList, [workspaceId]) :
       _.without([workspaceId], refreshedStarredWorkspaceList)
     await Ajax().User.profile.setPreferences({ starredWorkspaces: _.join(',', updatedWorkspaceIds) })
+    Ajax().Metrics.captureEvent(Events.workspaceStar, { workspaceId, starred: star })
     setStars(updatedWorkspaceIds)
   })
 

--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -81,9 +81,9 @@ const eventsList = {
   workspaceSampleTsvDownload: 'workspace:sample-tsv:download',
   workspaceShare: 'workspace:share',
   workspaceShareWithSupport: 'workspace:shareWithSupport',
-  workspaceStar: 'workspace:star',
   workspaceSnapshotDelete: 'workspace:snapshot:delete',
-  workspaceSnapshotContentsView: 'workspace:snapshot:contents:view'
+  workspaceSnapshotContentsView: 'workspace:snapshot:contents:view',
+  workspaceStar: 'workspace:star'
 }
 
 export const extractWorkspaceDetails = workspaceObject => {

--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -81,6 +81,7 @@ const eventsList = {
   workspaceSampleTsvDownload: 'workspace:sample-tsv:download',
   workspaceShare: 'workspace:share',
   workspaceShareWithSupport: 'workspace:shareWithSupport',
+  workspaceStar: 'workspace:star',
   workspaceSnapshotDelete: 'workspace:snapshot:delete',
   workspaceSnapshotContentsView: 'workspace:snapshot:contents:view'
 }


### PR DESCRIPTION
This is something we'd like to keep track of, so we're adding an event

Lexicon has been updated in dev, will update in prod once it starts receiving events.

<!--
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Also, so if a screen recording [1] and/or screenshots would be a helpful way to communicate context, please consider including some in your PR description.
Thanks!

[1] https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac
--!>
