### PR TITLE
[SU-107] Ignore errors fetching service alerts

### DIFF
--- a/src/libs/service-alerts-polling.js
+++ b/src/libs/service-alerts-polling.js
@@ -1,14 +1,12 @@
+import _ from 'lodash/fp'
 import { getServiceAlerts, serviceAlertsStore } from 'src/libs/service-alerts'
 
 
 export const startPollingServiceAlerts = () => {
-  getServiceAlerts().then(serviceAlerts => serviceAlertsStore.set(serviceAlerts))
+  getServiceAlerts().then(serviceAlerts => serviceAlertsStore.set(serviceAlerts), _.noop)
 
   const interval = setInterval(() => {
-    try {
-      getServiceAlerts().then(serviceAlerts => serviceAlertsStore.set(serviceAlerts))
-    } catch (error) {
-    }
+    getServiceAlerts().then(serviceAlerts => serviceAlertsStore.set(serviceAlerts), _.noop)
   }, 60000)
 
   return () => clearInterval(interval)

--- a/src/libs/service-alerts-polling.js
+++ b/src/libs/service-alerts-polling.js
@@ -3,11 +3,9 @@ import { getServiceAlerts, serviceAlertsStore } from 'src/libs/service-alerts'
 
 
 export const startPollingServiceAlerts = () => {
-  getServiceAlerts().then(serviceAlerts => serviceAlertsStore.set(serviceAlerts), _.noop)
+  const loadServiceAlerts = () => getServiceAlerts().then(serviceAlerts => serviceAlertsStore.set(serviceAlerts), _.noop)
 
-  const interval = setInterval(() => {
-    getServiceAlerts().then(serviceAlerts => serviceAlertsStore.set(serviceAlerts), _.noop)
-  }, 60000)
-
+  loadServiceAlerts()
+  const interval = setInterval(loadServiceAlerts, 60000)
   return () => clearInterval(interval)
 }


### PR DESCRIPTION
Follow on to #3361.

The previous ServiceAlerts component ignored errors from fetching alerts.
https://github.com/DataBiosphere/terra-ui/blob/321fa96c72666f094050b07e626f78fd1ac5e7be/src/components/ServiceAlerts.js#L22-L24

The new code was intended to do the same thing, but doesn't. Since the request is not awaited, the try/catch doesn't handle failed requests.
https://github.com/DataBiosphere/terra-ui/blob/ff9c7a2b69eb4cc5f0be9d4b3d2956c4ab8ff076/src/libs/service-alerts-polling.js#L8-L11

The uncaught rejection caused alpha integration tests to fail, since it seems the alpha alerts bucket is not public.
https://broadinstitute.slack.com/archives/C53JYBV9A/p1663086922835709

This ignores errors by adding an error callback to `then`.