### PR TITLE
[QA-2021] Restore tests against staging to nightly integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -325,3 +325,4 @@ workflows:
           cron: "0 13 * * *"
     jobs:
       - integration-tests-alpha
+      - integration-tests-staging


### PR DESCRIPTION
Tests against staging were removed from nightly jobs in #3191.

However, it’s informative to see if a test is failing in both alpha and staging vs only alpha.