### PR TITLE
[QA-2013] Allow manually running integration tests from latest dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,14 @@
 version: 2.1
 
+parameters:
+  workflow_to_run:
+    type: enum
+    enum:
+      - build-deploy
+      - integration-tests-staging
+      - integration-tests-alpha
+    default: build-deploy
+
 orbs:
   slack: circleci/slack@3.4.2
 
@@ -288,6 +297,8 @@ jobs:
 workflows:
   version: 2
   build-deploy:
+    when:
+      equal: [build-deploy, << pipeline.parameters.workflow_to_run >>]
     jobs:
       - build
       - integration-tests-pr-staging:
@@ -318,6 +329,16 @@ workflows:
           <<: *filter-dev-branch
           requires:
             - deploy-staging
+  integration-tests-staging:
+    when:
+      equal: [integration-tests-staging, << pipeline.parameters.workflow_to_run >>]
+    jobs:
+      - integration-tests-staging
+  integration-tests-alpha:
+    when:
+      equal: [integration-tests-alpha, << pipeline.parameters.workflow_to_run >>]
+    jobs:
+      - integration-tests-alpha
   nightly-integration-tests:
     triggers:
       - schedule:


### PR DESCRIPTION
Currently, the only way we have to manually run Terra UI end to end tests is to re-run a workflow in CircleCI.

Re-running the build-deploy workflow (which is run on each commit to the dev branch) from the latest commit to dev will re-deploy the UI to dev, alpha, and staging and run e2e tests against staging.

Tests against alpha are run daily as part of the nightly-integration-tests workflow. Re-running this workflow has an additional complication. If the dev branch has been updated since the workflow originally ran, re-running it may use out of date tests (because the re-run workflow will use the same revision of tests as the original workflow).

We want a way to manually run e2e tests against alpha or staging using the current tests from the tip of the dev branch.


This selects a workflow to run based on a pipeline parameter. The parameter defaults to build-deploy so that the build-deploy workflow by default when a commit is pushed to dev. When manually triggering a pipeline from the CircleCI app, a parameter can be provided to run integration tests against alpha or staging.


See workflows at https://app.circleci.com/pipelines/github/DataBiosphere/terra-ui?branch=manually-run-integration-tests


Relevant CircleCI docs:
- [Selecting a workflow to run using pipeline parameters](https://circleci.com/docs/selecting-a-workflow-to-run-using-pipeline-parameters)
- [Pipeline parameters](https://circleci.com/docs/pipeline-variables#pipeline-parameters-in-configuration)
- [Logic statements](https://circleci.com/docs/configuration-reference#logic-statements)