### PR TITLE
[SU-205] Add framework for feature previews

### DIFF
--- a/src/components/UriViewer.js
+++ b/src/components/UriViewer.js
@@ -13,8 +13,8 @@ import DownloadPrices from 'src/data/download-prices'
 import { Ajax } from 'src/libs/ajax'
 import { bucketBrowserUrl } from 'src/libs/auth'
 import colors from 'src/libs/colors'
-import { isDataTableProvenanceEnabled } from 'src/libs/config'
 import Events, { extractWorkspaceDetails } from 'src/libs/events'
+import { isFeaturePreviewEnabled } from 'src/libs/feature-previews'
 import { useCancellation, useOnMount, withDisplayName } from 'src/libs/react-utils'
 import { knownBucketRequesterPaysStatuses, workspaceStore } from 'src/libs/state'
 import * as Utils from 'src/libs/utils'
@@ -268,7 +268,7 @@ const UriViewer = _.flow(
             els.label('Updated'),
             els.data(new Date(updated).toLocaleString())
           ]),
-          isDataTableProvenanceEnabled() && els.cell([
+          isFeaturePreviewEnabled('data-table-provenance') && els.cell([
             els.label('Where did this file come from?'),
             els.data([h(FileProvenance, { workspace, fileUrl: uri })])
           ])

--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -27,10 +27,10 @@ import wdlLogo from 'src/images/wdl-logo.png'
 import { Ajax } from 'src/libs/ajax'
 import { isRadX } from 'src/libs/brand-utils'
 import colors from 'src/libs/colors'
-import { isDataTableProvenanceEnabled } from 'src/libs/config'
 import { useColumnProvenance } from 'src/libs/data-table-provenance'
 import { withErrorReporting } from 'src/libs/error'
 import Events, { extractWorkspaceDetails } from 'src/libs/events'
+import { isFeaturePreviewEnabled } from 'src/libs/feature-previews'
 import * as Nav from 'src/libs/nav'
 import { notify } from 'src/libs/notifications'
 import { useCancellation, useOnMount, withDisplayName } from 'src/libs/react-utils'
@@ -412,7 +412,7 @@ const EntitiesContent = ({
           borderBottom: `1px solid ${colors.grey(0.4)}`
         },
         border: false,
-        extraColumnActions: isDataTableProvenanceEnabled() ?
+        extraColumnActions: isFeaturePreviewEnabled('data-table-provenance') ?
           columnName => [{
             label: 'Show Provenance',
             onClick: () => {

--- a/src/libs/config.js
+++ b/src/libs/config.js
@@ -13,5 +13,3 @@ export const getConfig = () => {
  */
 export const isCromwellAppVisible = () => getConfig().isCromwellAppVisible
 export const isDataBrowserFrontPage = () => false
-export const isDataTableProvenanceEnabled = () => getConfig().isDataTableProvenanceEnabled
-export const isDataTableVersioningEnabled = () => getConfig().isDataTableVersioningEnabled

--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -43,6 +43,7 @@ const eventsList = {
   dataTableVersioningSaveVersion: 'dataTable:versioning:saveVersion',
   dataTableVersioningRestoreVersion: 'dataTable:versioning:restoreVersion',
   dataTableVersioningDeleteVersion: 'dataTable:versioning:deleteVersion',
+  featurePreviewToggle: 'featurePreview:toggle',
   // Note: "external" refers to the common Job Manager deployment, not a Job Manager bundled in CromwellApp
   jobManagerOpenExternal: 'job-manager:open-external',
   notebookLaunch: 'notebook:launch',

--- a/src/libs/feature-previews-config.js
+++ b/src/libs/feature-previews-config.js
@@ -1,0 +1,3 @@
+const featurePreviewsConfig = []
+
+export default featurePreviewsConfig

--- a/src/libs/feature-previews-config.js
+++ b/src/libs/feature-previews-config.js
@@ -2,12 +2,14 @@ const featurePreviewsConfig = [
   {
     id: 'data-table-versioning',
     title: 'Data Table Versioning',
-    description: 'Enabling this feature will allow you to save uniquely named versions of data tables. These saved versions will appear in the Data tab and can be restored at any time.'
+    description: 'Enabling this feature will allow you to save uniquely named versions of data tables. These saved versions will appear in the Data tab and can be restored at any time.',
+    groups: ['preview-data-versioning-and-provenance']
   },
   {
     id: 'data-table-provenance',
     title: 'Data Table Provenance',
-    description: 'Enabling this feature will allow you to view information about the workflow that generated data table columns and files.'
+    description: 'Enabling this feature will allow you to view information about the workflow that generated data table columns and files.',
+    groups: ['preview-data-versioning-and-provenance']
   }
 ]
 

--- a/src/libs/feature-previews-config.js
+++ b/src/libs/feature-previews-config.js
@@ -2,12 +2,12 @@ const featurePreviewsConfig = [
   {
     id: 'data-table-versioning',
     title: 'Data Table Versioning',
-    description: 'Save versions of data tables.'
+    description: 'Enabling this feature will allow you to save uniquely named versions of data tables. These saved versions will appear in the Data tab and can be restored at any time.'
   },
   {
     id: 'data-table-provenance',
     title: 'Data Table Provenance',
-    description: 'View provenance of data table columns.'
+    description: 'Enabling this feature will allow you to view information about the workflow that generated data table columns and files.'
   }
 ]
 

--- a/src/libs/feature-previews-config.js
+++ b/src/libs/feature-previews-config.js
@@ -1,3 +1,14 @@
-const featurePreviewsConfig = []
+const featurePreviewsConfig = [
+  {
+    id: 'data-table-versioning',
+    title: 'Data Table Versioning',
+    description: 'Save versions of data tables.'
+  },
+  {
+    id: 'data-table-provenance',
+    title: 'Data Table Provenance',
+    description: 'View provenance of data table columns.'
+  }
+]
 
 export default featurePreviewsConfig

--- a/src/libs/feature-previews.js
+++ b/src/libs/feature-previews.js
@@ -1,0 +1,60 @@
+import _ from 'lodash/fp'
+import { useState } from 'react'
+import { Ajax } from 'src/libs/ajax'
+import { getConfig } from 'src/libs/config'
+import featurePreviewsConfig from 'src/libs/feature-previews-config'
+import { getLocalPref, setLocalPref } from 'src/libs/prefs'
+import { useCancellation, useOnMount } from 'src/libs/react-utils'
+import * as Utils from 'src/libs/utils'
+
+
+const featurePreviewPreferenceKey = id => `feature-preview/${id}`
+
+export const isFeaturePreviewEnabled = id => !!getLocalPref(featurePreviewPreferenceKey(id))
+
+export const toggleFeaturePreview = (id, enabled) => {
+  setLocalPref(featurePreviewPreferenceKey(id), enabled)
+}
+
+const getGroups = async ({ signal } = {}) => {
+  const rawGroups = await Ajax(signal).Groups.list()
+  return _.flow(_.map('groupName'), _.uniq)(rawGroups)
+}
+
+export const getAvailableFeaturePreviews = async ({ signal } = {}) => {
+  const userGroups = await getGroups({ signal })
+
+  return _.flow(
+    _.filter(({ id, groups: previewGroups }) => Utils.cond(
+      // Allow access to all feature previews in development.
+      [!getConfig().isProd, () => true],
+      // Feature previews may be configured to only be available for members of certain groups.
+      // Any enabled feature previews should always be shown to allow users to turn them off
+      // even if they've been removed from the preview group.
+      [!_.isNil(previewGroups), () => _.size(_.intersection(userGroups, previewGroups)) > 0 || isFeaturePreviewEnabled(id)],
+      () => true
+    )),
+    _.sortBy('title')
+  )(featurePreviewsConfig)
+}
+
+export const useAvailableFeaturePreviews = () => {
+  const [featurePreviews, setFeaturePreviews] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const signal = useCancellation()
+
+  useOnMount(() => {
+    const loadAvailableFeaturePreviews = Utils.withBusyState(setLoading, async () => {
+      try {
+        setFeaturePreviews(await getAvailableFeaturePreviews({ signal }))
+      } catch (error) {
+        setError(error)
+      }
+    })
+
+    loadAvailableFeaturePreviews()
+  })
+
+  return { featurePreviews, loading, error }
+}

--- a/src/libs/feature-previews.js
+++ b/src/libs/feature-previews.js
@@ -2,6 +2,7 @@ import _ from 'lodash/fp'
 import { useState } from 'react'
 import { Ajax } from 'src/libs/ajax'
 import { getConfig } from 'src/libs/config'
+import Events from 'src/libs/events'
 import featurePreviewsConfig from 'src/libs/feature-previews-config'
 import { getLocalPref, setLocalPref } from 'src/libs/prefs'
 import { useCancellation, useOnMount } from 'src/libs/react-utils'
@@ -14,6 +15,7 @@ export const isFeaturePreviewEnabled = id => !!getLocalPref(featurePreviewPrefer
 
 export const toggleFeaturePreview = (id, enabled) => {
   setLocalPref(featurePreviewPreferenceKey(id), enabled)
+  Ajax().Metrics.captureEvent(Events.featurePreviewToggle, { enabled })
 }
 
 const getGroups = async ({ signal } = {}) => {

--- a/src/libs/feature-previews.test.js
+++ b/src/libs/feature-previews.test.js
@@ -1,0 +1,144 @@
+import { Ajax } from 'src/libs/ajax'
+import { getConfig } from 'src/libs/config'
+import { getAvailableFeaturePreviews, isFeaturePreviewEnabled, toggleFeaturePreview } from 'src/libs/feature-previews'
+import { getLocalPref, setLocalPref } from 'src/libs/prefs'
+
+
+jest.mock('src/libs/ajax')
+jest.mock('src/libs/config', () => ({
+  ...jest.requireActual('src/libs/config'),
+  getConfig: jest.fn().mockReturnValue({})
+}))
+jest.mock('src/libs/feature-previews-config', () => ({
+  __esModule: true,
+  default: [
+    {
+      id: 'feature1',
+      title: 'Feature #1',
+      description: 'A new feature'
+    },
+    {
+      id: 'feature2',
+      title: 'Feature #2',
+      description: 'Another new feature',
+      groups: ['preview-group']
+    }
+  ]
+}))
+jest.mock('src/libs/prefs')
+
+
+beforeEach(() => {
+  getConfig.mockReturnValue(({ isProd: true }))
+})
+
+
+describe('isFeaturePreviewEnabled', () => {
+  it('reads from local preference', () => {
+    getLocalPref.mockReturnValue(true)
+    expect(isFeaturePreviewEnabled('test-feature')).toBe(true)
+    expect(getLocalPref).toHaveBeenCalledWith('feature-preview/test-feature')
+  })
+})
+
+describe('toggleFeaturePreview', () => {
+  it('sets local preference', () => {
+    toggleFeaturePreview('test-feature', false)
+    expect(setLocalPref).toHaveBeenCalledWith('feature-preview/test-feature', false)
+  })
+})
+
+describe('getAvailableFeaturePreviews', () => {
+  it('should return available feature previews based on user\'s groups', async () => {
+    getLocalPref.mockReturnValue(false)
+
+    Ajax.mockImplementation(() => ({
+      Groups: {
+        list: jest.fn().mockReturnValue(Promise.resolve([]))
+      }
+    }))
+
+    expect(await getAvailableFeaturePreviews()).toEqual([
+      {
+        id: 'feature1',
+        title: 'Feature #1',
+        description: 'A new feature'
+      }
+    ])
+
+    Ajax.mockImplementation(() => ({
+      Groups: {
+        list: jest.fn().mockReturnValue(Promise.resolve([
+          {
+            groupName: 'preview-group',
+            groupEmail: 'preview-group@test.firecloud.org',
+            role: 'member'
+          }
+        ]))
+      }
+    }))
+
+    expect(await getAvailableFeaturePreviews()).toEqual([
+      {
+        id: 'feature1',
+        title: 'Feature #1',
+        description: 'A new feature'
+      },
+      {
+        id: 'feature2',
+        title: 'Feature #2',
+        description: 'Another new feature',
+        groups: ['preview-group']
+      }
+    ])
+  })
+
+  it('should include enabled feature previews regardless of group', async () => {
+    getLocalPref.mockImplementation(key => key === 'feature-preview/feature2')
+
+    Ajax.mockImplementation(() => ({
+      Groups: {
+        list: jest.fn().mockReturnValue(Promise.resolve([]))
+      }
+    }))
+
+    expect(await getAvailableFeaturePreviews()).toEqual([
+      {
+        id: 'feature1',
+        title: 'Feature #1',
+        description: 'A new feature'
+      },
+      {
+        id: 'feature2',
+        title: 'Feature #2',
+        description: 'Another new feature',
+        groups: ['preview-group']
+      }
+    ])
+  })
+
+  it('should include all feature previews in non-production environments', async () => {
+    getConfig.mockReturnValue({ isProd: false })
+    getLocalPref.mockReturnValue(false)
+
+    Ajax.mockImplementation(() => ({
+      Groups: {
+        list: jest.fn().mockReturnValue(Promise.resolve([]))
+      }
+    }))
+
+    expect(await getAvailableFeaturePreviews()).toEqual([
+      {
+        id: 'feature1',
+        title: 'Feature #1',
+        description: 'A new feature'
+      },
+      {
+        id: 'feature2',
+        title: 'Feature #2',
+        description: 'Another new feature',
+        groups: ['preview-group']
+      }
+    ])
+  })
+})

--- a/src/libs/feature-previews.test.js
+++ b/src/libs/feature-previews.test.js
@@ -1,5 +1,6 @@
 import { Ajax } from 'src/libs/ajax'
 import { getConfig } from 'src/libs/config'
+import Events from 'src/libs/events'
 import { getAvailableFeaturePreviews, isFeaturePreviewEnabled, toggleFeaturePreview } from 'src/libs/feature-previews'
 import { getLocalPref, setLocalPref } from 'src/libs/prefs'
 
@@ -43,8 +44,18 @@ describe('isFeaturePreviewEnabled', () => {
 
 describe('toggleFeaturePreview', () => {
   it('sets local preference', () => {
+    Ajax.mockImplementation(() => ({ Metrics: { captureEvent: jest.fn() } }))
+
     toggleFeaturePreview('test-feature', false)
     expect(setLocalPref).toHaveBeenCalledWith('feature-preview/test-feature', false)
+  })
+
+  it('captures metrics', () => {
+    const captureEvent = jest.fn()
+    Ajax.mockImplementation(() => ({ Metrics: { captureEvent } }))
+
+    toggleFeaturePreview('test-feature', true)
+    expect(captureEvent).toHaveBeenCalledWith(Events.featurePreviewToggle, { enabled: true })
   })
 })
 

--- a/src/libs/routes.js
+++ b/src/libs/routes.js
@@ -3,6 +3,7 @@ import { compile, pathToRegexp } from 'path-to-regexp'
 import { routeHandlersStore } from 'src/libs/state'
 import * as Projects from 'src/pages/billing/List'
 import * as Environments from 'src/pages/Environments'
+import * as FeaturePreviews from 'src/pages/FeaturePreviews'
 import * as Group from 'src/pages/groups/Group'
 import * as Groups from 'src/pages/groups/List'
 import * as HoF from 'src/pages/HoF'
@@ -76,6 +77,7 @@ const routes = _.flatten([
   WorkflowsList.navPaths,
   WorkflowDetails.navPaths,
   Upload.navPaths,
+  FeaturePreviews.navPaths,
   NotFound.navPaths // must be last
 ])
 

--- a/src/pages/FeaturePreviews.js
+++ b/src/pages/FeaturePreviews.js
@@ -68,17 +68,15 @@ export const FeaturePreviews = () => {
   )
 }
 
-const FeaturePreviewsPage = () => {
-  return h(FooterWrapper, [
-    h(TopBar, { title: 'Feature Preview' }),
-    h(PageBox, { role: 'main' }, [
-      h2({ style: { ...Style.elements.sectionHeader, textTransform: 'uppercase' } }, [
-        'Feature Preview'
-      ]),
-      h(FeaturePreviews)
-    ])
+const FeaturePreviewsPage = () => h(FooterWrapper, [
+  h(TopBar, { title: 'Feature Preview' }),
+  h(PageBox, { role: 'main' }, [
+    h2({ style: { ...Style.elements.sectionHeader, textTransform: 'uppercase' } }, [
+      'Feature Preview'
+    ]),
+    h(FeaturePreviews)
   ])
-}
+])
 
 export const navPaths = [
   {

--- a/src/pages/FeaturePreviews.js
+++ b/src/pages/FeaturePreviews.js
@@ -1,0 +1,90 @@
+import _ from 'lodash/fp'
+import { Fragment, useCallback, useEffect, useState } from 'react'
+import { div, h, h2, p, span } from 'react-hyperscript-helpers'
+import { Checkbox, PageBox, spinnerOverlay } from 'src/components/common'
+import FooterWrapper from 'src/components/FooterWrapper'
+import { SimpleFlexTable } from 'src/components/table'
+import TopBar from 'src/components/TopBar'
+import { isFeaturePreviewEnabled, toggleFeaturePreview, useAvailableFeaturePreviews } from 'src/libs/feature-previews'
+import * as Style from 'src/libs/style'
+import * as Utils from 'src/libs/utils'
+
+
+export const FeaturePreviews = () => {
+  const { featurePreviews, loading, error } = useAvailableFeaturePreviews()
+
+  // The source of truth for whether or not a feature preview is enabled is `isFeaturePreviewEnabled`, which reads
+  // from local preferences. However, changing a local preference won't re-render this component and its checkboxes.
+  // Thus, we also need to store this in component state and keep in sync with local preferences.
+  const getFeaturePreviewState = useCallback(() => {
+    return _.flow(_.map(({ id }) => [id, isFeaturePreviewEnabled(id)]), _.fromPairs)(featurePreviews)
+  }, [featurePreviews])
+
+  // Map of feature preview ID => enabled boolean
+  const [featurePreviewState, setFeaturePreviewState] = useState(getFeaturePreviewState)
+  useEffect(() => { setFeaturePreviewState(getFeaturePreviewState()) }, [getFeaturePreviewState])
+
+  return Utils.cond(
+    [loading, () => spinnerOverlay],
+    [error, () => p({ style: { margin: 0 } }, ['Unable to load feature previews.'])],
+    [_.size(featurePreviews) === 0, () => p({ style: { margin: 0 } }, ['No feature previews available at this time.'])],
+    () => h(Fragment, [
+      p(['These features are experimental and may change without notice.']),
+      h(SimpleFlexTable, {
+        'aria-label': 'Features',
+        rowCount: featurePreviews.length,
+        columns: [
+          {
+            size: { basis: 55, grow: 0 },
+            field: 'enabled',
+            headerRenderer: () => span({ className: 'sr-only' }, ['Enabled']),
+            cellRenderer: ({ rowIndex }) => {
+              const { id, title } = featurePreviews[rowIndex]
+              return h(Checkbox, {
+                'aria-label': `Enable ${title}`,
+                checked: featurePreviewState[id],
+                onChange: checked => {
+                  toggleFeaturePreview(id, checked)
+                  setFeaturePreviewState(_.set(id, checked))
+                }
+              })
+            }
+          },
+          {
+            size: { basis: 250 },
+            field: 'description',
+            headerRenderer: () => 'Description',
+            cellRenderer: ({ rowIndex }) => {
+              const { title, description } = featurePreviews[rowIndex]
+              return div([
+                p({ style: { fontWeight: 600, margin: '0.5rem 0 0.5rem' } }, [title]),
+                p({ style: { margin: '0.5rem 0' } }, [description])
+              ])
+            }
+          }
+        ]
+      })
+    ])
+  )
+}
+
+const FeaturePreviewsPage = () => {
+  return h(FooterWrapper, [
+    h(TopBar, { title: 'Feature Preview' }),
+    h(PageBox, { role: 'main' }, [
+      h2({ style: { ...Style.elements.sectionHeader, textTransform: 'uppercase' } }, [
+        'Feature Preview'
+      ]),
+      h(FeaturePreviews)
+    ])
+  ])
+}
+
+export const navPaths = [
+  {
+    name: 'feature-previews',
+    path: '/feature-preview',
+    component: FeaturePreviewsPage,
+    title: 'Feature Previews'
+  }
+]

--- a/src/pages/FeaturePreviews.js
+++ b/src/pages/FeaturePreviews.js
@@ -17,7 +17,10 @@ export const FeaturePreviews = () => {
   // from local preferences. However, changing a local preference won't re-render this component and its checkboxes.
   // Thus, we also need to store this in component state and keep in sync with local preferences.
   const getFeaturePreviewState = useCallback(() => {
-    return _.flow(_.map(({ id }) => [id, isFeaturePreviewEnabled(id)]), _.fromPairs)(featurePreviews)
+    return _.flow(
+      _.map(({ id }) => [id, isFeaturePreviewEnabled(id)]),
+      _.fromPairs
+    )(featurePreviews)
   }, [featurePreviews])
 
   // Map of feature preview ID => enabled boolean

--- a/src/pages/FeaturePreviews.js
+++ b/src/pages/FeaturePreviews.js
@@ -29,7 +29,7 @@ export const FeaturePreviews = () => {
     [error, () => p({ style: { margin: 0 } }, ['Unable to load feature previews.'])],
     [_.size(featurePreviews) === 0, () => p({ style: { margin: 0 } }, ['No feature previews available at this time.'])],
     () => h(Fragment, [
-      p(['These features are experimental and may change without notice.']),
+      p(['These features are proof-of-concept and may change without notice.']),
       h(SimpleFlexTable, {
         'aria-label': 'Features',
         rowCount: featurePreviews.length,

--- a/src/pages/FeaturePreviews.js
+++ b/src/pages/FeaturePreviews.js
@@ -27,7 +27,7 @@ export const FeaturePreviews = () => {
   return Utils.cond(
     [loading, () => spinnerOverlay],
     [error, () => p({ style: { margin: 0 } }, ['Unable to load feature previews.'])],
-    [_.size(featurePreviews) === 0, () => p({ style: { margin: 0 } }, ['No feature previews available at this time.'])],
+    [_.isEmpty(featurePreviews), () => p({ style: { margin: 0 } }, ['No feature previews available at this time.'])],
     () => h(Fragment, [
       p(['These features are proof-of-concept and may change without notice.']),
       h(SimpleFlexTable, {

--- a/src/pages/FeaturePreviews.test.js
+++ b/src/pages/FeaturePreviews.test.js
@@ -1,0 +1,63 @@
+import '@testing-library/jest-dom'
+
+import { fireEvent, getByText, render } from '@testing-library/react'
+import { h } from 'react-hyperscript-helpers'
+import { isFeaturePreviewEnabled, toggleFeaturePreview, useAvailableFeaturePreviews } from 'src/libs/feature-previews'
+import { FeaturePreviews } from 'src/pages/FeaturePreviews'
+
+
+jest.mock('src/libs/feature-previews')
+
+
+describe('FeaturePreviews', () => {
+  beforeEach(() => {
+    useAvailableFeaturePreviews.mockReturnValue({
+      featurePreviews: [
+        {
+          id: 'feature1',
+          title: 'Feature #1',
+          description: 'A new feature'
+        },
+        {
+          id: 'feature2',
+          title: 'Feature #2',
+          description: 'Another new feature'
+        }
+      ]
+    })
+
+    isFeaturePreviewEnabled.mockReturnValue(false)
+  })
+
+  it('should render available feature previews', () => {
+    const { getAllByRole } = render(h(FeaturePreviews))
+    const cells = getAllByRole('cell')
+
+    expect(getByText(cells[1], 'Feature #1')).toBeTruthy()
+    expect(getByText(cells[1], 'A new feature')).toBeTruthy()
+
+    expect(getByText(cells[3], 'Feature #2')).toBeTruthy()
+    expect(getByText(cells[3], 'Another new feature')).toBeTruthy()
+  })
+
+  it('should render whether features are enabled', () => {
+    isFeaturePreviewEnabled.mockImplementation(id => id === 'feature1')
+
+    const { getAllByRole } = render(h(FeaturePreviews))
+    const checkboxes = getAllByRole('checkbox')
+
+    expect(checkboxes[0].getAttribute('aria-checked')).toBe('true')
+    expect(checkboxes[1].getAttribute('aria-checked')).toBe('false')
+  })
+
+  it('checking a checkbox should toggle feature previews', () => {
+    const { getAllByRole } = render(h(FeaturePreviews))
+    const checkboxes = getAllByRole('checkbox')
+
+    fireEvent.click(checkboxes[0])
+    expect(toggleFeaturePreview).toHaveBeenCalledWith('feature1', true)
+
+    fireEvent.click(checkboxes[0])
+    expect(toggleFeaturePreview).toHaveBeenCalledWith('feature1', false)
+  })
+})

--- a/src/pages/FeaturePreviews.test.js
+++ b/src/pages/FeaturePreviews.test.js
@@ -6,6 +6,7 @@ import { isFeaturePreviewEnabled, toggleFeaturePreview, useAvailableFeaturePrevi
 import { FeaturePreviews } from 'src/pages/FeaturePreviews'
 
 
+jest.mock('src/libs/ajax')
 jest.mock('src/libs/feature-previews')
 
 

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -23,10 +23,11 @@ import { SnapshotInfo } from 'src/components/workspace-utils'
 import { Ajax } from 'src/libs/ajax'
 import { getUser } from 'src/libs/auth'
 import colors from 'src/libs/colors'
-import { getConfig, isDataTableVersioningEnabled } from 'src/libs/config'
+import { getConfig } from 'src/libs/config'
 import { dataTableVersionsPathRoot, useDataTableVersions } from 'src/libs/data-table-versions'
 import { reportError, reportErrorAndRethrow, withErrorReporting } from 'src/libs/error'
 import Events, { extractWorkspaceDetails } from 'src/libs/events'
+import { isFeaturePreviewEnabled } from 'src/libs/feature-previews'
 import * as Nav from 'src/libs/nav'
 import { notify } from 'src/libs/notifications'
 import { forwardRefWithName, useCancellation, useOnMount, useStore } from 'src/libs/react-utils'
@@ -335,7 +336,7 @@ const DataTableActions = ({ workspace, tableName, rowCount, entityMetadata, onRe
           disabled: !!editWorkspaceErrorMessage,
           tooltip: editWorkspaceErrorMessage || ''
         }, 'Delete table'),
-        isDataTableVersioningEnabled() && h(Fragment, [
+        isFeaturePreviewEnabled('data-table-versioning') && h(Fragment, [
           h(MenuDivider),
           h(MenuButton, { onClick: () => setSavingVersion(true) }, ['Save version']),
           h(MenuButton, {


### PR DESCRIPTION
Terra UI has a global configuration object that is mainly used for environment-specific configuration (dev vs staging vs production, etc). For example, the [production configuration file](https://github.com/DataBiosphere/terra-ui/blob/dev/config/prod.json).

It also allows overriding this configuration at runtime by adding values to a global variable, [configOverridesStore](https://github.com/DataBiosphere/terra-ui/blob/f482c08ea4057065cb76f846f08ddafc7af47b7a/src/libs/state.js#L77-L82). When configuration is modified like this, Terra UI shows a notice in the lower right corner of the window: “Config overrides are in effect”.

Our [current process for implementing feature flags](https://github.com/DataBiosphere/terra-ui/wiki/Feature-Flags) makes use of this ability to override configuration. The current process for enabling a feature flag is to [open the browser console](https://developer.chrome.com/docs/devtools/open/#console) and run some JavaScript code:
```
window.configOverridesStore.set({ isMyFeatureEnabled: true })
```

This process is ok if we are using feature flags to allow incrementally merging a large feature and letting developers test it out (or sharing the feature flag with select users, which can sometimes be a confusing experience) before we finally make it available to users by removing the feature flag. 

However, we often want to test a new feature with a group of users and collect feedback and iterate before making the feature generally available. For example, the Analyses tab and the Data Catalog. Asking users to open the browser console and run JS code is less than ideal for demonstrating a new feature to a small group of friendly users and entirely unacceptable for making a preview option generally available as in the case of the Analyses tab or Data Catalog.

Thus, each team that wants to have such a feature preview has to decide how to implement it themselves. This leads to inconsistent implementations and UX. For example, the [Data Catalog preview is implemented using a user preference stored in local storage](https://github.com/DataBiosphere/terra-ui/blob/f482c08ea4057065cb76f846f08ddafc7af47b7a/src/pages/library/Datasets.js#L451-L461) while the [Analyses tab preview used the configuration overrides store](https://github.com/DataBiosphere/terra-ui/blob/816840a096d303971fb75d0c8bb64743833dc730/src/pages/workspaces/workspace/Notebooks.js#L454-L465) and [modified the warning to not show](https://github.com/DataBiosphere/terra-ui/blob/816840a096d303971fb75d0c8bb64743833dc730/src/components/ConfigOverridesWarning.js#L12). The Data Catalog preview uses a switch control, while the Analyses tab preview used buttons (“Try new layout” and “Revert layout”).

This creates a framework for feature previews. Adding information about the feature to `feature-previews-config.js` causes it to show up in a new page (`/#feature-preview`) that list all feature previews available to the user and lets them toggle them on and off. Visibility of feature previews on this page can also be controlled by group membership. If desired, teams can use the `toggleFeaturePreview` function with their own custom UI elements to present new features.

![Screen Shot 2022-09-15 at 10 25 05 AM](https://user-images.githubusercontent.com/1156625/190429642-96f4a811-f9de-4995-88eb-e4cd6fdb61fd.png)

The feature preview page is currently not linked from anywhere in Terra UI, pending discussion on where to put it. Even so, the preview experience for users is much improved since now we can send them a link instead of instructions to open the console and run some code.