### PR TITLE
[SU-206] Add Mixpanel events for data table versioning

### DIFF
--- a/src/libs/data-table-versions.js
+++ b/src/libs/data-table-versions.js
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { notifyDataImportProgress, parseGsUri } from 'src/components/data/data-utils'
 import { Ajax } from 'src/libs/ajax'
 import { getUser } from 'src/libs/auth'
+import Events, { extractWorkspaceDetails } from 'src/libs/events'
 import { notify } from 'src/libs/notifications'
 import { useCancellation } from 'src/libs/react-utils'
 import { asyncImportJobStore } from 'src/libs/state'
@@ -13,6 +14,11 @@ import * as Utils from 'src/libs/utils'
 export const dataTableVersionsPathRoot = '.data-table-versions'
 
 export const saveDataTableVersion = async (workspace, entityType, { description = null } = {}) => {
+  Ajax().Metrics.captureEvent(Events.dataTableVersioningSaveVersion, {
+    ...extractWorkspaceDetails(workspace.workspace),
+    tableName: entityType
+  })
+
   const { workspace: { namespace, name, googleProject, bucketName } } = workspace
 
   const timestamp = (new Date()).getTime()
@@ -58,6 +64,11 @@ export const listDataTableVersions = async (workspace, entityType, { signal } = 
 }
 
 export const deleteDataTableVersion = async (workspace, version) => {
+  Ajax().Metrics.captureEvent(Events.dataTableVersioningDeleteVersion, {
+    ...extractWorkspaceDetails(workspace.workspace),
+    tableName: version.entityType
+  })
+
   const { workspace: { googleProject, bucketName } } = workspace
 
   const [, objectName] = parseGsUri(version.url)
@@ -70,6 +81,11 @@ export const tableNameForRestore = version => {
 }
 
 export const restoreDataTableVersion = async (workspace, version) => {
+  Ajax().Metrics.captureEvent(Events.dataTableVersioningRestoreVersion, {
+    ...extractWorkspaceDetails(workspace.workspace),
+    tableName: version.entityType
+  })
+
   const { workspace: { namespace, name, googleProject, bucketName } } = workspace
 
   const [, objectName] = parseGsUri(version.url)

--- a/src/libs/data-table-versions.test.js
+++ b/src/libs/data-table-versions.test.js
@@ -36,6 +36,7 @@ describe('restoreDataTableVersion', () => {
 
     Ajax.mockImplementation(() => ({
       Buckets: { getObjectPreview },
+      Metrics: { captureEvent: jest.fn() },
       Workspaces: { workspace: () => ({ importFlexibleEntitiesFileSynchronous }) }
     }))
   })

--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -39,6 +39,10 @@ const eventsList = {
   datasetLibraryBrowseData: 'library:browseData',
   dataTableSaveColumnSettings: 'dataTable:saveColumnSettings',
   dataTableLoadColumnSettings: 'dataTable:loadColumnSettings',
+  dataTableVersioningViewVersionHistory: 'dataTable:versioning:viewVersionHistory',
+  dataTableVersioningSaveVersion: 'dataTable:versioning:saveVersion',
+  dataTableVersioningRestoreVersion: 'dataTable:versioning:restoreVersion',
+  dataTableVersioningDeleteVersion: 'dataTable:versioning:deleteVersion',
   // Note: "external" refers to the common Job Manager deployment, not a Job Manager bundled in CromwellApp
   jobManagerOpenExternal: 'job-manager:open-external',
   notebookLaunch: 'notebook:launch',

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -338,7 +338,17 @@ const DataTableActions = ({ workspace, tableName, rowCount, entityMetadata, onRe
         isDataTableVersioningEnabled() && h(Fragment, [
           h(MenuDivider),
           h(MenuButton, { onClick: () => setSavingVersion(true) }, ['Save version']),
-          h(MenuButton, { onClick: () => onToggleVersionHistory(!isShowingVersionHistory) }, [`${isShowingVersionHistory ? 'Hide' : 'Show'} version history`])
+          h(MenuButton, {
+            onClick: () => {
+              onToggleVersionHistory(!isShowingVersionHistory)
+              if (!isShowingVersionHistory) {
+                Ajax().Metrics.captureEvent(Events.dataTableVersioningViewVersionHistory, {
+                  ...extractWorkspaceDetails(workspace.workspace),
+                  tableName
+                })
+              }
+            }
+          }, [`${isShowingVersionHistory ? 'Hide' : 'Show'} version history`])
         ])
       ])
     }, [


### PR DESCRIPTION
Add Mixpanel events for viewing version history and saving/restoring/deleting versions.

To enable data table versioning, run `window.configOverridesStore.set({ isDataTableVersioningEnabled: true })` and refresh.