### PR TITLE
[SU-128] Add divider between sort and edit actions in data table column menu

### DIFF
--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -12,7 +12,7 @@ import { icon } from 'src/components/icons'
 import { AutocompleteTextInput, NumberInput, PasteOnlyInput, TextInput, ValidatedInput } from 'src/components/input'
 import Interactive from 'src/components/Interactive'
 import Modal from 'src/components/Modal'
-import { MenuButton, MenuTrigger } from 'src/components/PopupTrigger'
+import { MenuButton, MenuDivider, MenuTrigger } from 'src/components/PopupTrigger'
 import { SimpleTabBar } from 'src/components/tabBars'
 import { Sortable, TextCell } from 'src/components/table'
 import TooltipTrigger from 'src/components/TooltipTrigger'
@@ -1439,7 +1439,10 @@ export const HeaderOptions = ({ sort, field, onSort, extraActions, children }) =
     content: h(Fragment, [
       h(MenuButton, { onClick: () => onSort({ field, direction: 'asc' }) }, ['Sort Ascending']),
       h(MenuButton, { onClick: () => onSort({ field, direction: 'desc' }) }, ['Sort Descending']),
-      _.map(({ label, disabled, tooltip, onClick }) => h(MenuButton, { key: label, disabled, tooltip, onClick }, [label]), extraActions)
+      !_.isEmpty(extraActions) && h(Fragment, [
+        h(MenuDivider),
+        _.map(({ label, disabled, tooltip, onClick }) => h(MenuButton, { key: label, disabled, tooltip, onClick }, [label]), extraActions)
+      ])
     ])
   }, [
     h(Link, { 'aria-label': 'Column menu' }, [


### PR DESCRIPTION
## Before
![Screen Shot 2022-09-16 at 12 30 01 PM](https://user-images.githubusercontent.com/1156625/190686471-fcf30fa0-942e-438a-bce5-9df73b69df63.png)

## After
![Screen Shot 2022-09-16 at 12 28 56 PM](https://user-images.githubusercontent.com/1156625/190686469-456dac72-2f44-49a7-a187-3836983eed94.png)