### PR TITLE
[SUP-537] Prevent crash when cookies are blocked

### DIFF
--- a/src/components/CookieWarning.js
+++ b/src/components/CookieWarning.js
@@ -5,6 +5,7 @@ import { Transition } from 'react-transition-group'
 import { ButtonPrimary, ButtonSecondary, Link } from 'src/components/common'
 import { Ajax } from 'src/libs/ajax'
 import { getEnabledBrand } from 'src/libs/brand-utils'
+import { getStorage } from 'src/libs/browser-storage'
 import colors from 'src/libs/colors'
 import * as Nav from 'src/libs/nav'
 import { useCancellation, useStore } from 'src/libs/react-utils'
@@ -59,7 +60,7 @@ const CookieWarning = () => {
 
     cookieReadyStore.reset()
     azureCookieReadyStore.reset()
-    sessionStorage.clear()
+    getStorage('session').clear()
   }
 
   return h(Transition, {

--- a/src/components/CookieWarning.js
+++ b/src/components/CookieWarning.js
@@ -5,7 +5,7 @@ import { Transition } from 'react-transition-group'
 import { ButtonPrimary, ButtonSecondary, Link } from 'src/components/common'
 import { Ajax } from 'src/libs/ajax'
 import { getEnabledBrand } from 'src/libs/brand-utils'
-import { getStorage } from 'src/libs/browser-storage'
+import { getSessionStorage } from 'src/libs/browser-storage'
 import colors from 'src/libs/colors'
 import * as Nav from 'src/libs/nav'
 import { useCancellation, useStore } from 'src/libs/react-utils'
@@ -60,7 +60,7 @@ const CookieWarning = () => {
 
     cookieReadyStore.reset()
     azureCookieReadyStore.reset()
-    getStorage('session').clear()
+    getSessionStorage().clear()
   }
 
   return h(Transition, {

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -8,7 +8,7 @@ import { cookiesAcceptedKey } from 'src/components/CookieWarning'
 import { Ajax } from 'src/libs/ajax'
 import { fetchOk } from 'src/libs/ajax/ajax-common'
 import { getEnabledBrand } from 'src/libs/brand-utils'
-import { getStorage } from 'src/libs/browser-storage'
+import { getLocalStorage, getSessionStorage } from 'src/libs/browser-storage'
 import { getConfig } from 'src/libs/config'
 import { withErrorIgnoring, withErrorReporting } from 'src/libs/error'
 import { captureAppcuesEvent } from 'src/libs/events'
@@ -40,8 +40,8 @@ export const getOidcConfig = () => {
     prompt: 'consent login',
     scope: 'openid email profile',
     loadUserInfo: isGoogleAuthority(),
-    stateStore: new WebStorageStateStore({ store: getStorage('local') }),
-    userStore: new WebStorageStateStore({ store: getStorage('local') }),
+    stateStore: new WebStorageStateStore({ store: getLocalStorage() }),
+    userStore: new WebStorageStateStore({ store: getLocalStorage() }),
     automaticSilentRenew: true,
     includeIdTokenInSilentRenew: true,
     extraQueryParams: { access_type: 'offline' }
@@ -60,7 +60,7 @@ export const signOut = () => {
   // TODO: invalidate runtime cookies https://broadworkbench.atlassian.net/browse/IA-3498
   cookieReadyStore.reset()
   azureCookieReadyStore.reset()
-  getStorage('session').clear()
+  getSessionStorage().clear()
   const auth = getAuthInstance()
   revokeTokens()
     .finally(() => auth.removeUser())

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -8,6 +8,7 @@ import { cookiesAcceptedKey } from 'src/components/CookieWarning'
 import { Ajax } from 'src/libs/ajax'
 import { fetchOk } from 'src/libs/ajax/ajax-common'
 import { getEnabledBrand } from 'src/libs/brand-utils'
+import { getStorage } from 'src/libs/browser-storage'
 import { getConfig } from 'src/libs/config'
 import { withErrorIgnoring, withErrorReporting } from 'src/libs/error'
 import { captureAppcuesEvent } from 'src/libs/events'
@@ -39,7 +40,8 @@ export const getOidcConfig = () => {
     prompt: 'consent login',
     scope: 'openid email profile',
     loadUserInfo: isGoogleAuthority(),
-    userStore: new WebStorageStateStore({ store: window.localStorage }),
+    stateStore: new WebStorageStateStore({ store: getStorage('local') }),
+    userStore: new WebStorageStateStore({ store: getStorage('local') }),
     automaticSilentRenew: true,
     includeIdTokenInSilentRenew: true,
     extraQueryParams: { access_type: 'offline' }
@@ -58,7 +60,7 @@ export const signOut = () => {
   // TODO: invalidate runtime cookies https://broadworkbench.atlassian.net/browse/IA-3498
   cookieReadyStore.reset()
   azureCookieReadyStore.reset()
-  sessionStorage.clear()
+  getStorage('session').clear()
   const auth = getAuthInstance()
   revokeTokens()
     .finally(() => auth.removeUser())

--- a/src/libs/browser-storage.js
+++ b/src/libs/browser-storage.js
@@ -36,21 +36,21 @@ class InMemoryStorage {
   }
 }
 
-export const getLocalStorage = () => {
+export const getLocalStorage = _.once(() => {
   try {
     return window.localStorage
   } catch (error) {
     return new InMemoryStorage()
   }
-}
+})
 
-export const getSessionStorage = () => {
+export const getSessionStorage = _.once(() => {
   try {
     return window.sessionStorage
   } catch (error) {
     return new InMemoryStorage()
   }
-}
+})
 
 const forceSetItem = (storage, key, value) => {
   while (true) {

--- a/src/libs/prefs.js
+++ b/src/libs/prefs.js
@@ -1,11 +1,11 @@
 import { getUser } from 'src/libs/auth'
-import { getDynamic, setDynamic } from 'src/libs/browser-storage'
+import { getDynamic, getLocalStorage, setDynamic } from 'src/libs/browser-storage'
 
 
 const withUserPrefix = key => `${getUser().id}/${key}`
 const withUserPrefixForSpecifiedUserId = (userId, key) => `${userId}/${key}`
 
-export const getLocalPref = key => getDynamic('local', withUserPrefix(key))
+export const getLocalPref = key => getDynamic(getLocalStorage(), withUserPrefix(key))
 // Needed for loading from localStorage on signin or signout event
-export const getLocalPrefForUserId = (userId, key) => getDynamic('local', withUserPrefixForSpecifiedUserId(userId, key))
-export const setLocalPref = (key, value) => setDynamic('local', withUserPrefix(key), value)
+export const getLocalPrefForUserId = (userId, key) => getDynamic(getLocalStorage(), withUserPrefixForSpecifiedUserId(userId, key))
+export const setLocalPref = (key, value) => setDynamic(getLocalStorage(), withUserPrefix(key), value)

--- a/src/libs/prefs.js
+++ b/src/libs/prefs.js
@@ -5,7 +5,7 @@ import { getDynamic, setDynamic } from 'src/libs/browser-storage'
 const withUserPrefix = key => `${getUser().id}/${key}`
 const withUserPrefixForSpecifiedUserId = (userId, key) => `${userId}/${key}`
 
-export const getLocalPref = key => getDynamic(localStorage, withUserPrefix(key))
+export const getLocalPref = key => getDynamic('local', withUserPrefix(key))
 // Needed for loading from localStorage on signin or signout event
-export const getLocalPrefForUserId = (userId, key) => getDynamic(localStorage, withUserPrefixForSpecifiedUserId(userId, key))
-export const setLocalPref = (key, value) => setDynamic(localStorage, withUserPrefix(key), value)
+export const getLocalPrefForUserId = (userId, key) => getDynamic('local', withUserPrefixForSpecifiedUserId(userId, key))
+export const setLocalPref = (key, value) => setDynamic('local', withUserPrefix(key), value)

--- a/src/libs/state-history.js
+++ b/src/libs/state-history.js
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp'
-import { getDynamic, setDynamic } from 'src/libs/browser-storage'
+import { getDynamic, getSessionStorage, setDynamic } from 'src/libs/browser-storage'
 import { v4 as uuid } from 'uuid'
 
 
@@ -16,14 +16,14 @@ const getKey = () => {
 
 
 export const get = () => {
-  const data = getDynamic('session', getKey())
+  const data = getDynamic(getSessionStorage(), getKey())
   return _.isPlainObject(data) ? data : {}
 }
 
 export const set = newState => {
-  return setDynamic('session', getKey(), newState)
+  return setDynamic(getSessionStorage(), getKey(), newState)
 }
 
 export const update = newState => { set({ ...get(), ...newState }) }
 
-export const clearCurrent = () => setDynamic('session', getKey(), undefined)
+export const clearCurrent = () => setDynamic(getSessionStorage(), getKey(), undefined)

--- a/src/libs/state-history.js
+++ b/src/libs/state-history.js
@@ -16,14 +16,14 @@ const getKey = () => {
 
 
 export const get = () => {
-  const data = getDynamic(sessionStorage, getKey())
+  const data = getDynamic('session', getKey())
   return _.isPlainObject(data) ? data : {}
 }
 
 export const set = newState => {
-  return setDynamic(sessionStorage, getKey(), newState)
+  return setDynamic('session', getKey(), newState)
 }
 
 export const update = newState => { set({ ...get(), ...newState }) }
 
-export const clearCurrent = () => setDynamic(sessionStorage, getKey(), undefined)
+export const clearCurrent = () => setDynamic('session', getKey(), undefined)

--- a/src/libs/state.js
+++ b/src/libs/state.js
@@ -27,10 +27,10 @@ export const userStatus = {
 export const cookieReadyStore = Utils.atom(false)
 export const azureCookieReadyStore = Utils.atom(false)
 
-export const lastActiveTimeStore = staticStorageSlot(localStorage, 'idleTimeout')
+export const lastActiveTimeStore = staticStorageSlot('local', 'idleTimeout')
 lastActiveTimeStore.update(v => v || {})
 
-export const toggleStateAtom = staticStorageSlot(sessionStorage, 'toggleState')
+export const toggleStateAtom = staticStorageSlot('session', 'toggleState')
 toggleStateAtom.update(v => v || { notebooksTab: true })
 
 export const notificationStore = Utils.atom([])
@@ -78,5 +78,5 @@ window.ajaxOverridesStore = ajaxOverridesStore
  * Modifies config settings for testing purposes.
  * Can be set to an object which will be merged with the loaded config object.
  */
-export const configOverridesStore = staticStorageSlot(sessionStorage, 'config-overrides')
+export const configOverridesStore = staticStorageSlot('session', 'config-overrides')
 window.configOverridesStore = configOverridesStore

--- a/src/libs/state.js
+++ b/src/libs/state.js
@@ -1,4 +1,4 @@
-import { staticStorageSlot } from 'src/libs/browser-storage'
+import { getLocalStorage, getSessionStorage, staticStorageSlot } from 'src/libs/browser-storage'
 import * as Utils from 'src/libs/utils'
 
 
@@ -27,10 +27,10 @@ export const userStatus = {
 export const cookieReadyStore = Utils.atom(false)
 export const azureCookieReadyStore = Utils.atom(false)
 
-export const lastActiveTimeStore = staticStorageSlot('local', 'idleTimeout')
+export const lastActiveTimeStore = staticStorageSlot(getLocalStorage(), 'idleTimeout')
 lastActiveTimeStore.update(v => v || {})
 
-export const toggleStateAtom = staticStorageSlot('session', 'toggleState')
+export const toggleStateAtom = staticStorageSlot(getSessionStorage(), 'toggleState')
 toggleStateAtom.update(v => v || { notebooksTab: true })
 
 export const notificationStore = Utils.atom([])
@@ -78,5 +78,5 @@ window.ajaxOverridesStore = ajaxOverridesStore
  * Modifies config settings for testing purposes.
  * Can be set to an object which will be merged with the loaded config object.
  */
-export const configOverridesStore = staticStorageSlot('session', 'config-overrides')
+export const configOverridesStore = staticStorageSlot(getSessionStorage(), 'config-overrides')
 window.configOverridesStore = configOverridesStore

--- a/src/pages/workspaces/workspace/analysis/RuntimeManager.js
+++ b/src/pages/workspaces/workspace/analysis/RuntimeManager.js
@@ -8,7 +8,7 @@ import { ButtonPrimary, Clickable, Link, spinnerOverlay } from 'src/components/c
 import Modal from 'src/components/Modal'
 import { dataSyncingDocUrl } from 'src/data/machines'
 import { Ajax } from 'src/libs/ajax'
-import { getDynamic, setDynamic } from 'src/libs/browser-storage'
+import { getDynamic, getSessionStorage, setDynamic } from 'src/libs/browser-storage'
 import colors from 'src/libs/colors'
 import { withErrorReporting } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
@@ -132,7 +132,7 @@ const RuntimeManager = ({ namespace, name, runtimes, apps }) => {
     const twoMonthsAgo = _.tap(d => d.setMonth(d.getMonth() - 2), new Date())
     const welderCutOff = new Date('2019-08-01')
     const createdDate = new Date(runtime?.createdDate)
-    const dateNotified = getDynamic('session', `notifiedOutdatedRuntime${runtime?.id}`) || {}
+    const dateNotified = getDynamic(getSessionStorage(), `notifiedOutdatedRuntime${runtime?.id}`) || {}
     const rStudioLaunchLink = Nav.getLink(appLauncherTabName, { namespace, name, application: 'RStudio' })
     const galaxyApp = getCurrentApp(tools.Galaxy.appType)(apps)
     const prevGalaxyApp = getCurrentApp(tools.Galaxy.appType)(prevApps)
@@ -153,7 +153,7 @@ const RuntimeManager = ({ namespace, name, runtimes, apps }) => {
         }, 'Open RStudio')
       })
     } else if (isAfter(createdDate, welderCutOff) && !isToday(dateNotified)) { // TODO: remove this notification some time after the data syncing release
-      setDynamic('session', `notifiedOutdatedRuntime${runtime.id}`, Date.now())
+      setDynamic(getSessionStorage(), `notifiedOutdatedRuntime${runtime.id}`, Date.now())
       notify('warn', 'Please Update Your Cloud Environment', {
         message: h(Fragment, [
           p(['Last year, we introduced important updates to Terra that are not compatible with the older cloud environment associated with this workspace. You are no longer able to save new changes to notebooks using this older cloud environment.']),
@@ -161,7 +161,7 @@ const RuntimeManager = ({ namespace, name, runtimes, apps }) => {
         ])
       })
     } else if (isAfter(createdDate, twoMonthsAgo) && !isToday(dateNotified)) {
-      setDynamic('session', `notifiedOutdatedRuntime${runtime.id}`, Date.now())
+      setDynamic(getSessionStorage(), `notifiedOutdatedRuntime${runtime.id}`, Date.now())
       notify('warn', 'Outdated Cloud Environment', {
         message: 'Your cloud environment is over two months old. Please consider deleting and recreating your cloud environment in order to access the latest features and security updates.'
       })

--- a/src/pages/workspaces/workspace/analysis/RuntimeManager.js
+++ b/src/pages/workspaces/workspace/analysis/RuntimeManager.js
@@ -132,7 +132,7 @@ const RuntimeManager = ({ namespace, name, runtimes, apps }) => {
     const twoMonthsAgo = _.tap(d => d.setMonth(d.getMonth() - 2), new Date())
     const welderCutOff = new Date('2019-08-01')
     const createdDate = new Date(runtime?.createdDate)
-    const dateNotified = getDynamic(sessionStorage, `notifiedOutdatedRuntime${runtime?.id}`) || {}
+    const dateNotified = getDynamic('session', `notifiedOutdatedRuntime${runtime?.id}`) || {}
     const rStudioLaunchLink = Nav.getLink(appLauncherTabName, { namespace, name, application: 'RStudio' })
     const galaxyApp = getCurrentApp(tools.Galaxy.appType)(apps)
     const prevGalaxyApp = getCurrentApp(tools.Galaxy.appType)(prevApps)
@@ -153,7 +153,7 @@ const RuntimeManager = ({ namespace, name, runtimes, apps }) => {
         }, 'Open RStudio')
       })
     } else if (isAfter(createdDate, welderCutOff) && !isToday(dateNotified)) { // TODO: remove this notification some time after the data syncing release
-      setDynamic(sessionStorage, `notifiedOutdatedRuntime${runtime.id}`, Date.now())
+      setDynamic('session', `notifiedOutdatedRuntime${runtime.id}`, Date.now())
       notify('warn', 'Please Update Your Cloud Environment', {
         message: h(Fragment, [
           p(['Last year, we introduced important updates to Terra that are not compatible with the older cloud environment associated with this workspace. You are no longer able to save new changes to notebooks using this older cloud environment.']),
@@ -161,7 +161,7 @@ const RuntimeManager = ({ namespace, name, runtimes, apps }) => {
         ])
       })
     } else if (isAfter(createdDate, twoMonthsAgo) && !isToday(dateNotified)) {
-      setDynamic(sessionStorage, `notifiedOutdatedRuntime${runtime.id}`, Date.now())
+      setDynamic('session', `notifiedOutdatedRuntime${runtime.id}`, Date.now())
       notify('warn', 'Outdated Cloud Environment', {
         message: 'Your cloud environment is over two months old. Please consider deleting and recreating your cloud environment in order to access the latest features and security updates.'
       })


### PR DESCRIPTION
Currently, if cookies are blocked, Terra UI does not load (infinite loading spinner). This is because of errors when attempting to access window.localStorage or window.sessionStorage. This catches those errors and provides a fallback in memory storage.

With cookies blocked, you can't log in (at least not with B2C) but you can still browse public pages and see the cookie banner.

## Before
![Screen Shot 2022-09-16 at 1 48 36 PM](https://user-images.githubusercontent.com/1156625/190701457-cde5a795-8664-454c-bd2c-44c3b58a8725.png)

## After
![Screen Shot 2022-09-16 at 1 48 49 PM](https://user-images.githubusercontent.com/1156625/190701472-1236a0ea-27aa-440f-9117-1ea406328a65.png)

