### PR TITLE
[SU-209] Add message when workspace has no tables/reference data

### DIFF
--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -225,6 +225,14 @@ const DataTypeSection = ({ title, error, retryFunction, children }) => {
   ])
 }
 
+const NoDataPlaceholder = ({ children }) => div({
+  style: {
+    display: 'flex', flexDirection: 'column', alignItems: 'flex-start',
+    padding: '0.5rem 1.5rem', borderBottom: `1px solid ${colors.dark(0.2)}`,
+    backgroundColor: 'white'
+  }
+}, children)
+
 const SidebarSeparator = ({ sidebarWidth, setSidebarWidth }) => {
   const minWidth = 280
   const getMaxWidth = useCallback(() => _.clamp(minWidth, 1200, window.innerWidth - 200), [])
@@ -593,13 +601,7 @@ const WorkspaceData = _.flow(
               retryFunction: loadEntityMetadata
             }, [
               _.some({ targetWorkspace: { namespace, name } }, asyncImportJobs) && h(DataImportPlaceholder),
-              !_.some({ targetWorkspace: { namespace, name } }, asyncImportJobs) && _.isEmpty(sortedEntityPairs) && div({
-                style: {
-                  display: 'flex', flexDirection: 'column', alignItems: 'flex-start',
-                  padding: '0.5rem 1.5rem', borderBottom: `1px solid ${colors.dark(0.2)}`,
-                  backgroundColor: 'white'
-                }
-              }, [
+              !_.some({ targetWorkspace: { namespace, name } }, asyncImportJobs) && _.isEmpty(sortedEntityPairs) && h(NoDataPlaceholder, [
                 'No tables have been uploaded.',
                 h(Link, { style: { marginTop: '0.5rem' }, onClick: () => setUploadingFile(true) }, ['Upload TSV'])
               ]),
@@ -743,13 +745,7 @@ const WorkspaceData = _.flow(
             h(DataTypeSection, {
               title: 'Reference Data'
             }, [
-              _.isEmpty(referenceData) && div({
-                style: {
-                  display: 'flex', flexDirection: 'column', alignItems: 'flex-start',
-                  padding: '0.5rem 1.5rem', borderBottom: `1px solid ${colors.dark(0.2)}`,
-                  backgroundColor: 'white'
-                }
-              }, [
+              _.isEmpty(referenceData) && h(NoDataPlaceholder, [
                 'No references have been added.',
                 h(Link, { style: { marginTop: '0.5rem' }, onClick: () => setImportingReference(true) }, ['Add reference data'])
               ]),

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -593,6 +593,16 @@ const WorkspaceData = _.flow(
               retryFunction: loadEntityMetadata
             }, [
               _.some({ targetWorkspace: { namespace, name } }, asyncImportJobs) && h(DataImportPlaceholder),
+              !_.some({ targetWorkspace: { namespace, name } }, asyncImportJobs) && _.isEmpty(sortedEntityPairs) && div({
+                style: {
+                  display: 'flex', flexDirection: 'column', alignItems: 'flex-start',
+                  padding: '0.5rem 1.5rem', borderBottom: `1px solid ${colors.dark(0.2)}`,
+                  backgroundColor: 'white'
+                }
+              }, [
+                'No tables have been uploaded.',
+                h(Link, { style: { marginTop: '0.5rem' }, onClick: () => setUploadingFile(true) }, ['Upload TSV'])
+              ]),
               !_.isEmpty(sortedEntityPairs) && div({ style: { margin: '1rem' } }, [
                 h(ConfirmedSearchInput, {
                   'aria-label': 'Search all tables',
@@ -732,25 +742,36 @@ const WorkspaceData = _.flow(
             ]),
             h(DataTypeSection, {
               title: 'Reference Data'
-            }, [_.map(type => h(DataTypeButton, {
-              key: type,
-              wrapperProps: { role: 'listitem' },
-              selected: selectedData?.type === workspaceDataTypes.referenceData && selectedData.reference === type,
-              onClick: () => {
-                setSelectedData({ type: workspaceDataTypes.referenceData, reference: type })
-                refreshWorkspace()
-              },
-              after: h(Link, {
-                style: { flex: 0 },
-                disabled: !!Utils.editWorkspaceError(workspace),
-                tooltip: Utils.editWorkspaceError(workspace) || `Delete ${type}`,
-                onClick: e => {
-                  e.stopPropagation()
-                  setDeletingReference(type)
+            }, [
+              _.isEmpty(referenceData) && div({
+                style: {
+                  display: 'flex', flexDirection: 'column', alignItems: 'flex-start',
+                  padding: '0.5rem 1.5rem', borderBottom: `1px solid ${colors.dark(0.2)}`,
+                  backgroundColor: 'white'
                 }
-              }, [icon('minus-circle', { size: 16 })])
-            }, [type]), _.keys(referenceData)
-            )]),
+              }, [
+                'No references have been added.',
+                h(Link, { style: { marginTop: '0.5rem' }, onClick: () => setImportingReference(true) }, ['Add reference data'])
+              ]),
+              _.map(type => h(DataTypeButton, {
+                key: type,
+                wrapperProps: { role: 'listitem' },
+                selected: selectedData?.type === workspaceDataTypes.referenceData && selectedData.reference === type,
+                onClick: () => {
+                  setSelectedData({ type: workspaceDataTypes.referenceData, reference: type })
+                  refreshWorkspace()
+                },
+                after: h(Link, {
+                  style: { flex: 0 },
+                  disabled: !!Utils.editWorkspaceError(workspace),
+                  tooltip: Utils.editWorkspaceError(workspace) || `Delete ${type}`,
+                  onClick: e => {
+                    e.stopPropagation()
+                    setDeletingReference(type)
+                  }
+                }, [icon('minus-circle', { size: 16 })])
+              }, [type]), _.keys(referenceData))
+            ]),
             importingReference && h(ReferenceDataImporter, {
               onDismiss: () => setImportingReference(false),
               onSuccess: () => {

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -225,13 +225,16 @@ const DataTypeSection = ({ title, error, retryFunction, children }) => {
   ])
 }
 
-const NoDataPlaceholder = ({ children }) => div({
+const NoDataPlaceholder = ({ message, buttonText, onAdd }) => div({
   style: {
     display: 'flex', flexDirection: 'column', alignItems: 'flex-start',
     padding: '0.5rem 1.5rem', borderBottom: `1px solid ${colors.dark(0.2)}`,
     backgroundColor: 'white'
   }
-}, children)
+}, [
+  message,
+  h(Link, { style: { marginTop: '0.5rem' }, onClick: onAdd }, [buttonText])
+])
 
 const SidebarSeparator = ({ sidebarWidth, setSidebarWidth }) => {
   const minWidth = 280
@@ -601,10 +604,11 @@ const WorkspaceData = _.flow(
               retryFunction: loadEntityMetadata
             }, [
               _.some({ targetWorkspace: { namespace, name } }, asyncImportJobs) && h(DataImportPlaceholder),
-              !_.some({ targetWorkspace: { namespace, name } }, asyncImportJobs) && _.isEmpty(sortedEntityPairs) && h(NoDataPlaceholder, [
-                'No tables have been uploaded.',
-                h(Link, { style: { marginTop: '0.5rem' }, onClick: () => setUploadingFile(true) }, ['Upload TSV'])
-              ]),
+              !_.some({ targetWorkspace: { namespace, name } }, asyncImportJobs) && _.isEmpty(sortedEntityPairs) && h(NoDataPlaceholder, {
+                message: 'No tables have been uploaded.',
+                buttonText: 'Upload TSV',
+                onAdd: () => setUploadingFile(true)
+              }),
               !_.isEmpty(sortedEntityPairs) && div({ style: { margin: '1rem' } }, [
                 h(ConfirmedSearchInput, {
                   'aria-label': 'Search all tables',
@@ -745,10 +749,11 @@ const WorkspaceData = _.flow(
             h(DataTypeSection, {
               title: 'Reference Data'
             }, [
-              _.isEmpty(referenceData) && h(NoDataPlaceholder, [
-                'No references have been added.',
-                h(Link, { style: { marginTop: '0.5rem' }, onClick: () => setImportingReference(true) }, ['Add reference data'])
-              ]),
+              _.isEmpty(referenceData) && h(NoDataPlaceholder, {
+                message: 'No references have been added.',
+                buttonText: 'Add reference data',
+                onAdd: () => setImportingReference(true)
+              }),
               _.map(type => h(DataTypeButton, {
                 key: type,
                 wrapperProps: { role: 'listitem' },


### PR DESCRIPTION
Currently, nothing is displayed in the Tables and Reference Data sections of the Data tab sidebar if the workspace has no tables or reference data. This adds a message and a prompt to add data.

## Before
![Screen Shot 2022-09-16 at 2 29 47 PM](https://user-images.githubusercontent.com/1156625/190707673-eb5aa30a-7fc2-4363-864d-b5af95607cef.png)


## After
![Screen Shot 2022-09-16 at 2 28 54 PM](https://user-images.githubusercontent.com/1156625/190707752-52384d87-5b8c-44cf-b477-544bd400d464.png)

