### PR TITLE
[TUIM-33] Configure supported architectures for yarn

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -45,4 +45,12 @@ plugins:
     spec: "@yarnpkg/plugin-interactive-tools"
   - ./.hooks/plugin-warning-logger.js
 
+supportedArchitectures:
+  os:
+    - darwin
+    - linux
+  cpu:
+    - arm64
+    - x64
+
 yarnPath: .yarn/releases/yarn-3.2.3.cjs


### PR DESCRIPTION
Splitting out a finding from #3370.

Developers are running `yarn add` on MacOS, but we want to make sure that Linux versions of any dependencies are also cached since CircleCI runs on Linux and requires an immutable cache.
https://github.com/DataBiosphere/terra-ui/blob/f1c195a9e58f40d5f756df794147210d6be86cb6/.circleci/config.yml#L166

https://yarnpkg.com/configuration/yarnrc#supportedArchitectures

This is not required for any of our current dependencies, but it avoids surprises later if we do add something like ESBuild that has platform specific pieces.