### PR TITLE
[SU-205] Include feature ID in Mixpanel event

### DIFF
--- a/src/libs/feature-previews.js
+++ b/src/libs/feature-previews.js
@@ -15,7 +15,7 @@ export const isFeaturePreviewEnabled = id => !!getLocalPref(featurePreviewPrefer
 
 export const toggleFeaturePreview = (id, enabled) => {
   setLocalPref(featurePreviewPreferenceKey(id), enabled)
-  Ajax().Metrics.captureEvent(Events.featurePreviewToggle, { enabled })
+  Ajax().Metrics.captureEvent(Events.featurePreviewToggle, { featureId: id, enabled })
 }
 
 const getGroups = async ({ signal } = {}) => {

--- a/src/libs/feature-previews.test.js
+++ b/src/libs/feature-previews.test.js
@@ -55,7 +55,7 @@ describe('toggleFeaturePreview', () => {
     Ajax.mockImplementation(() => ({ Metrics: { captureEvent } }))
 
     toggleFeaturePreview('test-feature', true)
-    expect(captureEvent).toHaveBeenCalledWith(Events.featurePreviewToggle, { enabled: true })
+    expect(captureEvent).toHaveBeenCalledWith(Events.featurePreviewToggle, { featureId: 'test-feature', enabled: true })
   })
 })
 


### PR DESCRIPTION
Fixup for #3382. We want to be able to see which feature preview was toggled in Mixpanel.