### PR TITLE
[WOR-387] Don't provide delete project option for non-owners, and temporary workaround for Azure project.

### DIFF
--- a/src/pages/billing/List.js
+++ b/src/pages/billing/List.js
@@ -330,11 +330,15 @@ export const BillingList = ({ queryParams: { selectedName } }) => {
     Utils.withBusyState(setIsLoadingProjects)
   )(async ({ projectName }) => {
     const index = _.findIndex({ projectName }, billingProjects)
-    // Workaround until getProject has the correct cloudPlatform, WOR-518
+    // Workaround until getProject has the correct cloudPlatform and managed app coordinates populated, WOR-518
     const cloudPlatform = billingProjects[index].cloudPlatform
+    const managedAppCoordinates = billingProjects[index].managedAppCoordinates
     // fetch the project to error if it doesn't exist/user can't access
     const project = await Ajax(signal).Billing.getProject(selectedName)
     project.cloudPlatform = cloudPlatform
+    if (!!managedAppCoordinates) {
+      project.managedAppCoordinates = managedAppCoordinates
+    }
     setBillingProjects(_.set([index], project))
   })
 


### PR DESCRIPTION
While working on https://github.com/broadinstitute/rawls/pull/2046 I noticed that we were showing the delete billing project menu for non-owners (when the billing project does not have a linked billing profile); this state is visible on dev for Azure workspaces since sharing an Azure-backed billing project on dev isn't yet calling the BPM API to share the underlying billing profile.

Before:
![image](https://user-images.githubusercontent.com/484484/191122723-5ec84f11-f33a-4103-9669-6f7b3e9c6c63.png)

After:
![image](https://user-images.githubusercontent.com/484484/191122852-24c019f6-1009-4d39-a4ed-dab6a25568a1.png)

Also, because the Rawls `getBillingProject` endpoint doesn't populate information from BPM profiles, there is a bug that if you remove a user/owner from an Azure-backed billing project (or change the role on such a user), the React rendering breaks due to extra hooks. This is because the front-end code thinks the project has gone from Azure -> GCP, and we try to render a section that we didn't previously (the Ajax response from `getBillingProject` has the cloudPlatform incorrectly specified as GCP). I have created https://broadworkbench.atlassian.net/browse/WOR-518 to fix the backend bug, but am working around it temporarily in this PR (the workaround will be removed as part of WOR-518).

For testing, you really need the Rawls changes in https://github.com/broadinstitute/rawls/pull/2046 and access to Azure billing projects.

<!--
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Also, so if a screen recording [1] and/or screenshots would be a helpful way to communicate context, please consider including some in your PR description.
Thanks!

[1] https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac
--!>
