### PR TITLE
[SU-211] Add option to toggle submission notifications from workspace dashboard

### DIFF
--- a/src/components/ProfilePicture.js
+++ b/src/components/ProfilePicture.js
@@ -1,0 +1,19 @@
+import { img } from 'react-hyperscript-helpers'
+import { getUser } from 'src/libs/auth'
+
+
+const ProfilePicture = ({ size, style, ...props } = {}) => {
+  // Note Azure logins don't currently have an imageUrl, so don't render anything.
+  // See TOAZ-147 to support this in the future.
+  const imageUrl = getUser().imageUrl
+  return imageUrl && img({
+    alt: 'Google profile image',
+    src: imageUrl,
+    height: size, width: size,
+    style: { borderRadius: '100%', ...style },
+    referrerPolicy: 'no-referrer',
+    ...props
+  })
+}
+
+export default ProfilePicture

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -5,9 +5,10 @@ import { a, div, h, h1, img, span } from 'react-hyperscript-helpers'
 import { Transition } from 'react-transition-group'
 import AlertsIndicator from 'src/components/Alerts'
 import { Clickable, CromwellVersionLink, FocusTrapper, IdContainer, LabeledCheckbox, Link, spinnerOverlay } from 'src/components/common'
-import { icon, profilePic } from 'src/components/icons'
+import { icon } from 'src/components/icons'
 import { TextArea } from 'src/components/input'
 import Modal from 'src/components/Modal'
+import ProfilePicture from 'src/components/ProfilePicture'
 import { SkipNavLink, SkipNavTarget } from 'src/components/skipNavLink'
 import fcIconWhite from 'src/images/brands/firecloud/FireCloud-icon-white.svg'
 import headerLeftHexes from 'src/images/header-left-hexes.svg'
@@ -158,7 +159,7 @@ const TopBar = ({ showMenu = true, title, href, children }) => {
           isSignedIn ?
             h(DropDownSection, {
               title: h(Fragment, [
-                profilePic({ size: 32, style: { marginRight: 12, flex: 'none' } }),
+                h(ProfilePicture, { size: 32, style: { marginRight: 12, flex: 'none' } }),
                 div({ style: { ...Style.noWrapEllipsis } }, [`${firstName} ${lastName}`])
               ]),
               onClick: () => setOpenUserMenu(!openUserMenu),

--- a/src/components/icons.js
+++ b/src/components/icons.js
@@ -1,8 +1,7 @@
 import _ from 'lodash/fp'
 import { Children, Fragment } from 'react'
-import { div, h, img, span } from 'react-hyperscript-helpers'
+import { div, h, span } from 'react-hyperscript-helpers'
 import DelayedRender from 'src/components/DelayedRender'
-import { getUser } from 'src/libs/auth'
 import colors from 'src/libs/colors'
 import iconDict from 'src/libs/icon-dict'
 
@@ -63,20 +62,6 @@ export const centeredSpinner = ({ size = 48, ...props } = {}) => spinner(_.merge
     right: `calc(50% - ${size / 2}px)`
   }
 }, props))
-
-export const profilePic = ({ size, style, ...props } = {}) => {
-  // Note Azure logins don't currently have an imageUrl, so don't render anything.
-  // See TOAZ-147 to support this in the future.
-  const imageUrl = getUser().imageUrl
-  return imageUrl && img({
-    alt: 'Google profile image',
-    src: imageUrl,
-    height: size, width: size,
-    style: { borderRadius: '100%', ...style },
-    referrerPolicy: 'no-referrer',
-    ...props
-  })
-}
 
 export const wdlIcon = ({ style = {}, ...props } = {}) => div({
   style: {

--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -9,10 +9,11 @@ import {
   ShibbolethLink, spinnerOverlay, UnlinkFenceAccount
 } from 'src/components/common'
 import FooterWrapper from 'src/components/FooterWrapper'
-import { icon, profilePic, spinner } from 'src/components/icons'
+import { icon, spinner } from 'src/components/icons'
 import { TextInput, ValidatedInput } from 'src/components/input'
 import Modal from 'src/components/Modal'
 import { InfoBox } from 'src/components/PopupTrigger'
+import ProfilePicture from 'src/components/ProfilePicture'
 import { SimpleTabBar } from 'src/components/tabBars'
 import TopBar from 'src/components/TopBar'
 import { useWorkspaces } from 'src/components/workspace-utils'
@@ -531,7 +532,7 @@ const PersonalInfoTab = ({ setSaving }) => {
   return h(PageBox, { role: 'main', style: { flexGrow: 1 }, variant: PageBoxVariants.LIGHT }, [
     div({ style: styles.header.line }, [
       div({ style: { position: 'relative' } }, [
-        profilePic({ size: 48 }),
+        h(ProfilePicture, { size: 48 }),
         h(InfoBox, { style: { alignSelf: 'flex-end' } }, [
           'To change your profile image, visit your ',
           h(Link, {

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -217,7 +217,7 @@ export const WorkspaceNotifications = ({ workspace }) => {
           await refreshTerraProfile()
           Ajax().Metrics.captureEvent(Events.notificationToggle, { notificationKeys: submissionNotificationKeys, enabled: value })
         })
-      }, [span({ style: { marginLeft: '1ch' } }, ['Submission notifications'])]),
+      }, [span({ style: { marginLeft: '1ch' } }, ['Receive submission notifications'])]),
       h(InfoBox, { style: { marginLeft: '1ch' } }, [
         'Receive email notifications when a submission in this workspace has succeeded, failed, or been aborted.'
       ]),

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -4,7 +4,7 @@ import { dd, div, dl, dt, h, h3, i, span } from 'react-hyperscript-helpers'
 import * as breadcrumbs from 'src/components/breadcrumbs'
 import { requesterPaysWrapper } from 'src/components/bucket-utils'
 import Collapse from 'src/components/Collapse'
-import { ButtonPrimary, ButtonSecondary, ClipboardButton, Link, spinnerOverlay } from 'src/components/common'
+import { ButtonPrimary, ButtonSecondary, ClipboardButton, LabeledCheckbox, Link, spinnerOverlay } from 'src/components/common'
 import { centeredSpinner, icon, spinner } from 'src/components/icons'
 import { MarkdownEditor, MarkdownViewer } from 'src/components/markdown'
 import { InfoBox } from 'src/components/PopupTrigger'
@@ -17,11 +17,12 @@ import { displayConsentCodes, displayLibraryAttributes } from 'src/data/workspac
 import { ReactComponent as AzureLogo } from 'src/images/azure.svg'
 import { ReactComponent as GcpLogo } from 'src/images/gcp.svg'
 import { Ajax } from 'src/libs/ajax'
-import { bucketBrowserUrl } from 'src/libs/auth'
+import { bucketBrowserUrl, refreshTerraProfile } from 'src/libs/auth'
 import { getRegionFlag, getRegionLabel } from 'src/libs/azure-utils'
 import { getEnabledBrand } from 'src/libs/brand-utils'
 import colors from 'src/libs/colors'
 import { reportError, withErrorReporting } from 'src/libs/error'
+import Events from 'src/libs/events'
 import * as Nav from 'src/libs/nav'
 import { getLocalPref, setLocalPref } from 'src/libs/prefs'
 import { forwardRefWithName, useCancellation, useOnMount, useStore } from 'src/libs/react-utils'
@@ -185,6 +186,46 @@ const BucketLocation = requesterPaysWrapper({ onDismiss: _.noop })(({ workspace 
   return h(TooltipCell, [flag, ' ', regionDescription])
 })
 
+export const WorkspaceNotifications = ({ workspace }) => {
+  const { workspace: { namespace, name } } = workspace
+
+  const [saving, setSaving] = useState(false)
+
+  const notificationsPreferences = _.pickBy((_v, k) => _.startsWith('notifications/', k), authStore.get().profile)
+
+  const submissionNotificationKeys = [
+    `notifications/SuccessfulSubmissionNotification/${namespace}/${name}`,
+    `notifications/FailedSubmissionNotification/${namespace}/${name}`,
+    `notifications/AbortedSubmissionNotification/${namespace}/${name}`
+  ]
+
+  const submissionNotificationsEnabled = !_.isMatch(
+    _.fromPairs(_.map(k => [k, 'false'], submissionNotificationKeys)),
+    notificationsPreferences
+  )
+
+  return div({ style: { margin: '0.5rem' } }, [
+    div({ style: { display: 'flex', alignItems: 'center' } }, [
+      h(LabeledCheckbox, {
+        checked: submissionNotificationsEnabled,
+        disabled: saving,
+        onChange: _.flow(
+          Utils.withBusyState(setSaving),
+          withErrorReporting('Error saving preferences')
+        )(async value => {
+          await Ajax().User.profile.setPreferences(_.fromPairs(_.map(k => [k, JSON.stringify(value)], submissionNotificationKeys)))
+          await refreshTerraProfile()
+          Ajax().Metrics.captureEvent(Events.notificationToggle, { notificationKeys: submissionNotificationKeys, enabled: value })
+        })
+      }, [span({ style: { marginLeft: '1ch' } }, ['Submission notifications'])]),
+      h(InfoBox, { style: { marginLeft: '1ch' } }, [
+        'Receive email notifications when a submission in this workspace has succeeded, failed, or been aborted.'
+      ]),
+      saving && spinner({ size: 12, style: { marginLeft: '1ch' } })
+    ])
+  ])
+}
+
 const WorkspaceDashboard = _.flow(
   forwardRefWithName('WorkspaceDashboard'),
   wrapWorkspace({
@@ -251,10 +292,11 @@ const WorkspaceDashboard = _.flow(
   const [ownersPanelOpen, setOwnersPanelOpen] = useState(() => getLocalPref(persistenceId)?.ownersPanelOpen || false)
   const [authDomainPanelOpen, setAuthDomainPanelOpen] = useState(() => getLocalPref(persistenceId)?.authDomainPanelOpen || false)
   const [tagsPanelOpen, setTagsPanelOpen] = useState(() => getLocalPref(persistenceId)?.tagsPanelOpen || false)
+  const [notificationsPanelOpen, setNotificationsPanelOpen] = useState(() => getLocalPref(persistenceId)?.notificationsPanelOpen || false)
 
   useEffect(() => {
-    setLocalPref(persistenceId, { workspaceInfoPanelOpen, cloudInfoPanelOpen, ownersPanelOpen, authDomainPanelOpen, tagsPanelOpen })
-  }, [workspaceInfoPanelOpen, cloudInfoPanelOpen, ownersPanelOpen, authDomainPanelOpen, tagsPanelOpen]) // eslint-disable-line react-hooks/exhaustive-deps
+    setLocalPref(persistenceId, { workspaceInfoPanelOpen, cloudInfoPanelOpen, ownersPanelOpen, authDomainPanelOpen, tagsPanelOpen, notificationsPanelOpen })
+  }, [persistenceId, workspaceInfoPanelOpen, cloudInfoPanelOpen, ownersPanelOpen, authDomainPanelOpen, tagsPanelOpen, notificationsPanelOpen])
 
   useEffect(() => {
     return () => {
@@ -582,6 +624,13 @@ const WorkspaceDashboard = _.flow(
             !!tagsList && _.isEmpty(tagsList) && i(['No tags yet'])
           ])
         ])
+      ]),
+      h(RightBoxSection, {
+        title: 'Notifications',
+        initialOpenState: notificationsPanelOpen,
+        onClick: () => setNotificationsPanelOpen(!notificationsPanelOpen)
+      }, [
+        h(WorkspaceNotifications, { workspace })
       ])
     ])
   ])

--- a/src/pages/workspaces/workspace/Dashboard.test.js
+++ b/src/pages/workspaces/workspace/Dashboard.test.js
@@ -43,7 +43,7 @@ describe('WorkspaceNotifications', () => {
     authStore.set({ profile })
 
     const { getByLabelText } = render(h(WorkspaceNotifications, { workspace: testWorkspace }))
-    const submissionNotificationsCheckbox = getByLabelText('Submission notifications')
+    const submissionNotificationsCheckbox = getByLabelText('Receive submission notifications')
     expect(submissionNotificationsCheckbox.getAttribute('aria-checked')).toBe(`${expectedState}`)
   })
 
@@ -72,7 +72,7 @@ describe('WorkspaceNotifications', () => {
     })
 
     const { getByLabelText } = render(h(WorkspaceNotifications, { workspace: testWorkspace }))
-    const submissionNotificationsCheckbox = getByLabelText('Submission notifications')
+    const submissionNotificationsCheckbox = getByLabelText('Receive submission notifications')
 
     await act(() => user.click(submissionNotificationsCheckbox))
     expect(setPreferences).toHaveBeenCalledWith({

--- a/src/pages/workspaces/workspace/Dashboard.test.js
+++ b/src/pages/workspaces/workspace/Dashboard.test.js
@@ -1,0 +1,84 @@
+import '@testing-library/jest-dom'
+
+import { render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { act } from 'react-dom/test-utils'
+import { h } from 'react-hyperscript-helpers'
+import { Ajax } from 'src/libs/ajax'
+import { authStore } from 'src/libs/state'
+import { WorkspaceNotifications } from 'src/pages/workspaces/workspace/Dashboard'
+
+
+jest.mock('src/libs/ajax')
+
+describe('WorkspaceNotifications', () => {
+  const testWorkspace = { workspace: { namespace: 'test', name: 'test' } }
+
+  afterEach(() => {
+    authStore.reset()
+  })
+
+  it.each([
+    {
+      profile: {
+        'notifications/SuccessfulSubmissionNotification/test/test': 'true',
+        'notifications/FailedSubmissionNotification/test/test': 'true',
+        'notifications/AbortedSubmissionNotification/test/test': 'true'
+      },
+      expectedState: true
+    },
+    {
+      profile: {},
+      expectedState: true
+    },
+    {
+      profile: {
+        'notifications/SuccessfulSubmissionNotification/test/test': 'false',
+        'notifications/FailedSubmissionNotification/test/test': 'false',
+        'notifications/AbortedSubmissionNotification/test/test': 'false'
+      },
+      expectedState: false
+    }
+  ])('renders checkbox with submission notifications status', ({ profile, expectedState }) => {
+    authStore.set({ profile })
+
+    const { getByLabelText } = render(h(WorkspaceNotifications, { workspace: testWorkspace }))
+    const submissionNotificationsCheckbox = getByLabelText('Submission notifications')
+    expect(submissionNotificationsCheckbox.getAttribute('aria-checked')).toBe(`${expectedState}`)
+  })
+
+  it('updates preferences when checkbox is clicked', async () => {
+    const user = userEvent.setup()
+
+    const setPreferences = jest.fn().mockReturnValue(Promise.resolve())
+    Ajax.mockImplementation(() => ({
+      Metrics: {
+        captureEvent: jest.fn()
+      },
+      User: {
+        profile: {
+          get: jest.fn().mockReturnValue(Promise.resolve({ keyValuePairs: [] })),
+          setPreferences
+        }
+      }
+    }))
+
+    authStore.set({
+      profile: {
+        'notifications/SuccessfulSubmissionNotification/test/test': 'false',
+        'notifications/FailedSubmissionNotification/test/test': 'false',
+        'notifications/AbortedSubmissionNotification/test/test': 'false'
+      }
+    })
+
+    const { getByLabelText } = render(h(WorkspaceNotifications, { workspace: testWorkspace }))
+    const submissionNotificationsCheckbox = getByLabelText('Submission notifications')
+
+    await act(() => user.click(submissionNotificationsCheckbox))
+    expect(setPreferences).toHaveBeenCalledWith({
+      'notifications/SuccessfulSubmissionNotification/test/test': 'true',
+      'notifications/FailedSubmissionNotification/test/test': 'true',
+      'notifications/AbortedSubmissionNotification/test/test': 'true'
+    })
+  })
+})


### PR DESCRIPTION
Currently, you can toggle workspace submissions notifications for all workspaces from the Notifications tab of the Profile page. This adds an option to toggle them for a specific workspace from the workspace dashboard.

![Screen Shot 2022-09-19 at 5 20 37 PM](https://user-images.githubusercontent.com/1156625/191119409-dcf3a8e2-d3e7-42da-9b00-6cfc81c7e8df.png)

Also had to move `profilePic` to a separate module because a circular import (icons imports auth imports CookieWarning imports common imports icons) prevented the test from running.