### PR TITLE
[SU-214][SU-216] Add optional documentation and feedback links for feature previews

### DIFF
--- a/src/pages/FeaturePreviews.js
+++ b/src/pages/FeaturePreviews.js
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp'
 import { Fragment, useCallback, useEffect, useState } from 'react'
 import { div, h, h2, p, span } from 'react-hyperscript-helpers'
-import { Checkbox, PageBox, spinnerOverlay } from 'src/components/common'
+import { Checkbox, Link, PageBox, spinnerOverlay } from 'src/components/common'
 import FooterWrapper from 'src/components/FooterWrapper'
 import { SimpleFlexTable } from 'src/components/table'
 import TopBar from 'src/components/TopBar'
@@ -58,10 +58,15 @@ export const FeaturePreviews = () => {
             field: 'description',
             headerRenderer: () => 'Description',
             cellRenderer: ({ rowIndex }) => {
-              const { title, description } = featurePreviews[rowIndex]
+              const { title, description, documentationUrl, feedbackUrl } = featurePreviews[rowIndex]
               return div([
                 p({ style: { fontWeight: 600, margin: '0.5rem 0 0.5rem' } }, [title]),
-                p({ style: { margin: '0.5rem 0' } }, [description])
+                p({ style: { margin: '0.5rem 0' } }, [description]),
+                !!(documentationUrl || feedbackUrl) && p({ style: { margin: '0.5rem 0' } }, [
+                  documentationUrl && h(Link, { ...Utils.newTabLinkProps, href: documentationUrl }, ['Documentation']),
+                  !!(documentationUrl && feedbackUrl) && ' | ',
+                  feedbackUrl && h(Link, { ...Utils.newTabLinkProps, href: feedbackUrl }, ['Submit feedback'])
+                ])
               ])
             }
           }

--- a/src/pages/FeaturePreviews.test.js
+++ b/src/pages/FeaturePreviews.test.js
@@ -17,12 +17,14 @@ describe('FeaturePreviews', () => {
         {
           id: 'feature1',
           title: 'Feature #1',
-          description: 'A new feature'
+          description: 'A new feature',
+          documentationUrl: 'https://example.com/feature-1-docs'
         },
         {
           id: 'feature2',
           title: 'Feature #2',
-          description: 'Another new feature'
+          description: 'Another new feature',
+          feedbackUrl: 'mailto:feature2-feedback@example.com'
         }
       ]
     })
@@ -60,5 +62,19 @@ describe('FeaturePreviews', () => {
 
     fireEvent.click(checkboxes[0])
     expect(toggleFeaturePreview).toHaveBeenCalledWith('feature1', false)
+  })
+
+  it('should render documentation link if provided', () => {
+    const { getAllByText } = render(h(FeaturePreviews))
+    const docLinks = getAllByText('Documentation')
+    expect(docLinks.length).toBe(1)
+    expect(docLinks[0].getAttribute('href')).toBe('https://example.com/feature-1-docs')
+  })
+
+  it('should render feedback link if provided', () => {
+    const { getAllByText } = render(h(FeaturePreviews))
+    const feedbackLinks = getAllByText('Submit feedback')
+    expect(feedbackLinks.length).toBe(1)
+    expect(feedbackLinks[0].getAttribute('href')).toBe('mailto:feature2-feedback@example.com')
   })
 })


### PR DESCRIPTION
Add the option to configure feature previews with documentation and feedback URLs which will be shown on the feature preview page.

![Screen Shot 2022-09-20 at 1 44 45 PM](https://user-images.githubusercontent.com/1156625/191328017-321095ac-9da6-4e13-a8f0-b22c820e69b4.png)
