### PR TITLE
[IA-3586] Test compute modal component

### DIFF
--- a/src/libs/ajax/GoogleStorage.js
+++ b/src/libs/ajax/GoogleStorage.js
@@ -25,7 +25,7 @@ export const GoogleStorage = signal => ({
         { signal },
         previewFull ? {} : { headers: { Range: 'bytes=0-20000' } }
       ])
-    )
+    ).then(res => res.json())
   },
 
   listNotebooks: async (googleProject, name) => {

--- a/src/pages/workspaces/workspace/analysis/_testData/testData.js
+++ b/src/pages/workspaces/workspace/analysis/_testData/testData.js
@@ -1,0 +1,243 @@
+import _ from 'lodash/fp'
+import * as Utils from 'src/libs/utils'
+import { tools } from 'src/pages/workspaces/workspace/analysis/notebook-utils'
+import {
+  defaultGceBootDiskSize, defaultGceMachineType, defaultGcePersistentDiskSize, defaultLocation, defaultPersistentDiskType, runtimeStatuses
+} from 'src/pages/workspaces/workspace/analysis/runtime-utils'
+import { v4 as uuid } from 'uuid'
+
+
+const defaultGoogleWorkspaceNamespace = 'test-ws'
+
+//this is important, so the test impl can diverge
+export const testDefaultLocation = defaultLocation
+
+
+export const defaultImage = {
+  id: 'terra-jupyter-gatk',
+  image: 'us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.2.8',
+  label: 'Default: (GATK 4.2.4.0, Python 3.7.12, R 4.2.1)',
+  packages: 'https://storage.googleapis.com/terra-docker-image-documentation/terra-jupyter-gatk-2.2.8-versions.json',
+  requiresSpark: false,
+  updated: '2022-08-09',
+  version: '2.2.8'
+}
+export const defaultRImage = {
+  id: 'RStudio',
+  image: 'us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.15.2',
+  isRStudio: true,
+  label: 'RStudio (R 4.2.0, Bioconductor 3.15, Python 3.8.10)',
+  packages: 'https://storage.googleapis.com/terra-docker-image-documentation/placeholder.json',
+  requiresSpark: false,
+  updated: '2022-05-09',
+  version: '3.15.2'
+}
+
+export const hailImage = {
+  id: 'terra-jupyter-hail',
+  image: 'us.gcr.io/broad-dsp-gcr-public/terra-jupyter-hail:1.0.20',
+  label: 'Hail: (Python 3.7.12, Spark 2.4.5, hail 0.2.98)',
+  packages: 'https://storage.googleapis.com/terra-docker-image-documentation/terra-jupyter-hail-1.0.20-versions.json',
+  requiresSpark: true,
+  updated: '2022-08-25',
+  version: '1.0.20'
+}
+export const imageDocs = [
+  defaultImage,
+  {
+    id: 'terra-jupyter-bioconductor',
+    image: 'us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:2.1.7',
+    label: 'R / Bioconductor: (Python 3.7.12, R 4.2.1, Bioconductor 3.15, tidyverse 1.3.2)',
+    packages: 'https://storage.googleapis.com/terra-docker-image-documentation/terra-jupyter-bioconductor-2.1.7-versions.json',
+    requiresSpark: false,
+    updated: '2022-08-08',
+    version: '2.1.7'
+  },
+  hailImage,
+  {
+    id: 'terra-jupyter-python',
+    image: 'us.gcr.io/broad-dsp-gcr-public/terra-jupyter-python:1.0.13',
+    label: 'Python: (Python 3.7.12, pandas 1.3.5, scikit-learn 1.0.2)',
+    packages: 'https://storage.googleapis.com/terra-docker-image-documentation/terra-jupyter-python-1.0.13-versions.json',
+    requiresSpark: false,
+    updated: '2022-08-18',
+    version: '1.0.13'
+  },
+  {
+    id: 'Pegasus',
+    image: 'cumulusprod/pegasus-terra:1.6.0',
+    isCommunity: true,
+    label: 'Pegasus (Pegasuspy 1.6.0, Python 3.7.12, harmony-pytorch 0.1.7, nmf-torch 0.1.1, scVI-tools 0.16.0)',
+    packages: 'https://raw.githubusercontent.com/lilab-bcb/cumulus/master/docker/pegasus-terra/1.6.0/pegasus-terra-1_6_0-versions.json',
+    requiresSpark: false,
+    updated: '2022-04-16',
+    version: '1.6.0'
+  },
+  defaultRImage,
+  {
+    id: 'OpenVINO integration with Tensorflow',
+    image: 'us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk-ovtf:0.1.7',
+    isCommunity: true,
+    label: 'OpenVINO integration with Tensorflow (openvino-tensorflow 1.1.0, Python 3.7.12, GATK 4.2.4.1)',
+    packages: 'https://storage.googleapis.com/terra-docker-image-documentation/terra-jupyter-gatk-ovtf-0.1.7-versions.json',
+    requiresSpark: false,
+    updated: '2022-01-31',
+    version: '0.2.0'
+  },
+  {
+    id: 'terra-jupyter-gatk_legacy',
+    image: 'us.gcr.io/broad-dsp-gcr-public/terra-jupyter-gatk:2.0.9',
+    label: 'Legacy GATK: (GATK 4.2.4.0, Python 3.7.12, R 4.1.3)',
+    packages: 'https://storage.googleapis.com/terra-docker-image-documentation/terra-jupyter-gatk-2.0.9-versions.json',
+    requiresSpark: false,
+    updated: '2022-04-25',
+    version: '2.0.9'
+  },
+  {
+    id: 'terra-jupyter-bioconductor_legacy',
+    image: 'us.gcr.io/broad-dsp-gcr-public/terra-jupyter-bioconductor:2.1.3',
+    label: 'Legacy R / Bioconductor: (Python 3.7.12, R 4.1.3, Bioconductor 3.14, tidyverse 1.3.1)',
+    packages: 'https://storage.googleapis.com/terra-docker-image-documentation/terra-jupyter-bioconductor-2.1.3-versions.json',
+    requiresSpark: false,
+    updated: '2022-05-31',
+    version: '2.1.3'
+  }
+]
+
+export const defaultGoogleWorkspace = {
+  cloudPlatform: 'Gcp',
+  workspace: {
+    bucketName: 'test-bucket', googleProject: `${defaultGoogleWorkspaceNamespace}-project`,
+    name: `${defaultGoogleWorkspaceNamespace}_ws`, namespace: defaultGoogleWorkspaceNamespace
+  }
+}
+
+export const defaultTestDisk = {
+  id: 15778,
+  googleProject: defaultGoogleWorkspace.workspace.googleProject,
+  cloudContext: {
+    cloudProvider: 'GCP',
+    cloudResource: defaultGoogleWorkspace.workspace.googleProject
+  },
+  zone: 'us-central1-a',
+  name: 'saturn-pd-c4aea6ef-5618-47d3-b674-5d456c9dcf4f',
+  status: 'Ready',
+  auditInfo: {
+    creator: 'testuser123@broad.com',
+    createdDate: '2022-07-18T18:35:32.012698Z',
+    destroyedDate: null,
+    dateAccessed: '2022-07-18T20:34:56.092Z'
+  },
+  size: defaultGcePersistentDiskSize,
+  diskType: defaultPersistentDiskType,
+  blockSize: 4096
+}
+
+export const getDisk = ({ size = defaultGcePersistentDiskSize } = {}) => ({
+  ...defaultTestDisk,
+  id: getRandomInt(10000),
+  size
+})
+
+
+export const defaultWorkspaceLabels = {
+  saturnWorkspaceNamespace: defaultGoogleWorkspace.workspace.namespace,
+  saturnWorkspaceName: defaultGoogleWorkspace.workspace.name
+}
+
+const randomMaxInt = 10000
+export const getJupyterRuntimeConfig = ({ diskId = getRandomInt(randomMaxInt), machineType = defaultGceMachineType } = {}) => ({
+  machineType,
+  persistentDiskId: diskId,
+  cloudService: 'GCE',
+  bootDiskSize: defaultGceBootDiskSize,
+  zone: 'us-central1-a',
+  gpuConfig: null
+})
+
+export const getRandomInt = max => Math.floor(Math.random() * max)
+
+export const defaultAuditInfo = {
+  creator: 'testuser123@broad.com',
+  createdDate: '2022-07-18T18:35:32.012698Z',
+  destroyedDate: null,
+  dateAccessed: '2022-07-18T21:44:17.565Z'
+}
+
+export const generateGoogleProject = () => `terra-test-${uuid().substring(0, 8)}`
+
+export const getGoogleRuntime = ({
+  workspace = defaultGoogleWorkspace,
+  runtimeName = Utils.generateRuntimeName(),
+  status = runtimeStatuses.running.label,
+  tool = tools.Jupyter,
+  runtimeConfig = getJupyterRuntimeConfig(),
+  image = undefined
+} = {}) => {
+  const googleProject = workspace.workspace.googleProject
+  const imageUri = image ? image : Utils.switchCase(tool.label,
+    [tools.RStudio.label, () => defaultRImage.image],
+    [Utils.DEFAULT, () => defaultImage.image])
+
+  return {
+    id: getRandomInt(randomMaxInt),
+    workspaceId: null,
+    runtimeName,
+    googleProject,
+    cloudContext: {
+      cloudProvider: 'GCP',
+      cloudResource: googleProject
+    },
+    auditInfo: defaultAuditInfo,
+    runtimeConfig,
+    proxyUrl: `https://leonardo.dsde-dev.broadinstitute.org/proxy/${googleProject}/${runtimeName}/${_.toLower(tool.label)}`,
+    status,
+    autopauseThreshold: 30,
+    labels: {
+      ...defaultWorkspaceLabels,
+      'saturn-iframe-extension': 'https://bvdp-saturn-dev.appspot.com/jupyter-iframe-extension.js',
+      creator: 'testuser123@broad.com',
+      clusterServiceAccount: 'pet-26534176105071279add1@terra-dev-cf677740.iam.gserviceaccount.com',
+      saturnAutoCreated: 'true',
+      clusterName: runtimeName,
+      saturnVersion: '6',
+      tool: tool.label,
+      runtimeName,
+      cloudContext: `Gcp/${googleProject}`,
+      googleProject
+    },
+    runtimeImages: [
+      {
+        imageType: 'Proxy',
+        imageUrl: 'broadinstitute/openidc-proxy:2.3.1_2',
+        homeDirectory: null,
+        timestamp: '2022-09-19T15:37:11.035465Z'
+      },
+      {
+        imageType: tool.label,
+        imageUrl: imageUri,
+        // "homeDirectory": "/home/jupyter", //TODO: is this needed anywhere in UI?
+        timestamp: '2022-09-19T15:37:11.035465Z'
+      },
+      {
+        imageType: 'Welder',
+        imageUrl: 'us.gcr.io/broad-dsp-gcr-public/welder-server:ef956b2',
+        homeDirectory: null,
+        timestamp: '2022-09-19T15:37:11.035465Z'
+      },
+      {
+        imageType: 'BootSource',
+        imageUrl: 'projects/broad-dsp-gcr-public/global/images/nl-825-2-gce-cos-image-e06f7d9',
+        homeDirectory: null,
+        timestamp: '2022-09-19T15:37:12.119Z'
+      },
+      {
+        imageType: 'CryptoDetector',
+        imageUrl: 'us.gcr.io/broad-dsp-gcr-public/cryptomining-detector:0.0.2',
+        homeDirectory: null,
+        timestamp: '2022-09-19T15:37:11.035465Z'
+      }
+    ],
+    patchInProgress: false
+  }
+}

--- a/src/pages/workspaces/workspace/analysis/modals/AnalysisModal.js
+++ b/src/pages/workspaces/workspace/analysis/modals/AnalysisModal.js
@@ -26,7 +26,9 @@ import {
   analysisNameInput, analysisNameValidator, getAppType, getFileName, getToolFromFileExtension, getToolFromRuntime, isToolAnApp, notebookData,
   toolExtensionDisplay, tools
 } from 'src/pages/workspaces/workspace/analysis/notebook-utils'
-import { getCurrentApp, getCurrentRuntime, isResourceDeletable } from 'src/pages/workspaces/workspace/analysis/runtime-utils'
+import {
+  getCurrentApp, getCurrentPersistentDisk, getCurrentRuntime, isResourceDeletable
+} from 'src/pages/workspaces/workspace/analysis/runtime-utils'
 import validate from 'validate.js'
 
 
@@ -48,6 +50,7 @@ export const AnalysisModal = withDisplayName('AnalysisModal')(
     const currentTool = currentToolObj?.label
 
     const currentRuntime = getCurrentRuntime(runtimes)
+    const currentDisk = getCurrentPersistentDisk(runtimes, persistentDisks)
     const currentRuntimeTool = getToolFromRuntime(currentRuntime)
     const currentApp = toolLabel => getCurrentApp(getAppType(toolLabel))(apps)
 
@@ -105,8 +108,8 @@ export const AnalysisModal = withDisplayName('AnalysisModal')(
       location,
       workspace,
       tool: currentTool,
-      runtimes,
-      persistentDisks,
+      currentRuntime,
+      currentDisk,
       onDismiss,
       onError,
       onSuccess

--- a/src/pages/workspaces/workspace/analysis/modals/CloudEnvironmentModal.js
+++ b/src/pages/workspaces/workspace/analysis/modals/CloudEnvironmentModal.js
@@ -25,7 +25,7 @@ import { getAppType, getToolsToDisplay, isPauseSupported, isToolAnApp, tools } f
 import { appLauncherTabName } from 'src/pages/workspaces/workspace/analysis/runtime-common'
 import {
   getComputeStatusForDisplay, getConvertedRuntimeStatus, getCostDisplayForDisk, getCostDisplayForTool,
-  getCurrentApp, getCurrentRuntime, getIsAppBusy, getIsRuntimeBusy, getRuntimeForTool,
+  getCurrentApp, getCurrentPersistentDisk, getCurrentRuntime, getIsAppBusy, getIsRuntimeBusy, getRuntimeForTool,
   isCurrentGalaxyDiskDetaching
 } from 'src/pages/workspaces/workspace/analysis/runtime-utils'
 import { AppErrorModal, RuntimeErrorModal } from 'src/pages/workspaces/workspace/analysis/RuntimeManager'
@@ -43,6 +43,7 @@ export const CloudEnvironmentModal = ({
   const [errorRuntimeId, setErrorRuntimeId] = useState(undefined)
   const [errorAppId, setErrorAppId] = useState(undefined)
   const cookieReady = useStore(cookieReadyStore)
+  const currentDisk = getCurrentPersistentDisk(runtimes, persistentDisks)
 
   const noCompute = 'You do not have access to run analyses on this workspace.'
 
@@ -52,8 +53,8 @@ export const CloudEnvironmentModal = ({
     isOpen: viewMode === NEW_JUPYTER_MODE || viewMode === NEW_RSTUDIO_MODE,
     workspace,
     tool,
-    runtimes,
-    persistentDisks,
+    currentRuntime,
+    currentDisk,
     location,
     onDismiss,
     onSuccess,

--- a/src/pages/workspaces/workspace/analysis/modals/ComputeModal.test.js
+++ b/src/pages/workspaces/workspace/analysis/modals/ComputeModal.test.js
@@ -803,7 +803,7 @@ describe('ComputeModal', () => {
 
     // Assert
     expect(screen.getByText('About persistent disk')).toBeInTheDocument()
-    expect(screen.getByText('Your persistent disk is mounted in the directory', { exact: false })).toBeInTheDocument()
+    expect(screen.getByText(/Your persistent disk is mounted in the directory/)).toBeInTheDocument()
   })
 
   it('should render whats installed on this environment', async () => {

--- a/src/pages/workspaces/workspace/analysis/modals/ComputeModal.test.js
+++ b/src/pages/workspaces/workspace/analysis/modals/ComputeModal.test.js
@@ -1,0 +1,863 @@
+import '@testing-library/jest-dom'
+
+import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import _ from 'lodash/fp'
+import { act } from 'react-dom/test-utils'
+import { h } from 'react-hyperscript-helpers'
+import { cloudServices } from 'src/data/machines'
+import { Ajax } from 'src/libs/ajax'
+import {
+  defaultGoogleWorkspace, defaultImage, defaultTestDisk, getDisk,
+  getGoogleRuntime, getJupyterRuntimeConfig, hailImage,
+  imageDocs, testDefaultLocation
+} from 'src/pages/workspaces/workspace/analysis/_testData/testData'
+import { ComputeModalBase } from 'src/pages/workspaces/workspace/analysis/modals/ComputeModal'
+import { tools } from 'src/pages/workspaces/workspace/analysis/notebook-utils'
+import {
+  defaultDataprocMachineType, defaultDataprocMasterDiskSize, defaultDataprocWorkerDiskSize,
+  defaultGceMachineType, defaultGpuType, defaultNumDataprocPreemptibleWorkers, defaultNumDataprocWorkers, defaultNumGpus, defaultPersistentDiskType,
+  runtimeStatuses
+} from 'src/pages/workspaces/workspace/analysis/runtime-utils'
+
+
+jest.mock('src/components/Modal', () => {
+  const { div, h } = jest.requireActual('react-hyperscript-helpers')
+  const originalModule = jest.requireActual('src/components/Modal')
+  return {
+    ...originalModule,
+    __esModule: true,
+    default: props => div({ id: 'modal-root' }, [
+      h(originalModule.default, { onAfterOpen: jest.fn(), ...props })
+    ])
+  }
+})
+
+// Mocking PopupTrigger to avoid test environment issues with React Portal's requirement to use
+// DOM measure services which are not available in jest environment
+jest.mock('src/components/PopupTrigger', () => {
+  const originalModule = jest.requireActual('src/components/PopupTrigger')
+  return {
+    ...originalModule,
+    MenuTrigger: jest.fn()
+  }
+})
+
+jest.mock('src/libs/notifications', () => ({
+  notify: (...args) => {
+    console.debug('######################### notify')/* eslint-disable-line */
+    console.debug({ method: 'notify', args: [...args] })/* eslint-disable-line */
+  }
+}))
+
+jest.mock('src/libs/ajax')
+
+const onSuccess = jest.fn()
+const defaultModalProps = {
+  onSuccess, onDismiss: jest.fn(), onError: jest.fn(),
+  currentRuntime: undefined, currentDisk: undefined, tool: tools.Jupyter.label, workspace: defaultGoogleWorkspace,
+  location: testDefaultLocation
+}
+
+jest.mock('react-dom', () => {
+  const originalModule = jest.requireActual('react-dom')
+  return {
+    ...originalModule,
+    createPortal: () => <div></div>
+  }
+})
+
+//TODO: test utils??
+const verifyDisabled = item => expect(item).toHaveAttribute('disabled')
+const verifyEnabled = item => expect(item).not.toHaveAttribute('disabled')
+
+const defaultAjaxImpl = {
+  Runtimes: {
+    runtime: () => ({
+      details: jest.fn()
+    })
+  },
+  Buckets: { getObjectPreview: () => Promise.resolve(imageDocs) },
+  Disks: {
+    disk: () => ({
+      details: jest.fn()
+    })
+  },
+  Metrics: {
+    captureEvent: () => jest.fn()
+  }
+}
+
+describe('ComputeModal', () => {
+  beforeAll(() => {
+  })
+
+  beforeEach(() => {
+    // Arrange
+    Ajax.mockImplementation(() => ({
+      ...defaultAjaxImpl
+    }))
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  const getCreateButton = () => screen.getByText('Create')
+
+  it('renders correctly with minimal state', async () => {
+    // Arrange
+
+    // Act
+    await act(async () => await render(h(ComputeModalBase, defaultModalProps)))
+
+    // Assert
+    verifyEnabled(getCreateButton())
+    const title = screen.getByText('Jupyter Cloud Environment')
+    expect(title).toBeInTheDocument()
+    expect(screen.getByText('Create custom environment')).toBeInTheDocument()
+  })
+
+  it('sends the proper leo API call in default create case (no runtimes or disks)', async () => {
+    // Arrange
+    const createFunc = jest.fn()
+    const runtimeFunc = jest.fn(() => ({
+      create: createFunc,
+      details: jest.fn()
+    }))
+    Ajax.mockImplementation(() => ({
+      ...defaultAjaxImpl,
+      Runtimes: {
+        runtime: runtimeFunc
+      }
+    }))
+
+    // Act
+    await act(async () => {
+      await render(h(ComputeModalBase, defaultModalProps))
+      await userEvent.click(getCreateButton())
+    })
+
+    // Assert
+    const labels = {
+      saturnWorkspaceNamespace: defaultModalProps.workspace.workspace.namespace,
+      saturnWorkspaceName: defaultModalProps.workspace.workspace.name
+    }
+    expect(runtimeFunc).toHaveBeenCalledWith(defaultModalProps.workspace.workspace.googleProject, expect.anything())
+    expect(createFunc).toHaveBeenCalledWith(expect.objectContaining({
+      labels,
+      runtimeConfig: expect.objectContaining({
+        cloudService: cloudServices.GCE,
+        machineType: defaultGceMachineType,
+        persistentDisk: expect.objectContaining({
+          diskType: defaultPersistentDiskType.label,
+          labels,
+          name: expect.anything()
+        })
+      }),
+      toolDockerImage: defaultImage.image
+    }))
+    expect(onSuccess).toHaveBeenCalled()
+  })
+
+  //create button with disk but no runtime
+  it('sends the proper API call in create case with an existing disk but no runtime', async () => {
+    // Arrange
+    // put value into local var so its easier to refactor
+    const disk = defaultTestDisk
+    const createFunc = jest.fn()
+    const runtimeFunc = jest.fn(() => ({
+      create: createFunc,
+      details: jest.fn()
+    }))
+    Ajax.mockImplementation(() => ({
+      ...defaultAjaxImpl,
+      Runtimes: {
+        runtime: runtimeFunc
+      },
+      Disks: {
+        disk: () => ({
+          details: () => disk
+        })
+      }
+    }))
+
+    // Act
+    await act(async () => {
+      await render(h(ComputeModalBase, {
+        ...defaultModalProps,
+        currentDisk: disk
+      }))
+      await userEvent.click(getCreateButton())
+    })
+
+    // Assert
+    expect(runtimeFunc).toHaveBeenCalledWith(defaultGoogleWorkspace.workspace.googleProject, expect.anything())
+    expect(createFunc).toHaveBeenCalledWith(expect.objectContaining({
+      runtimeConfig: expect.objectContaining({
+        persistentDisk: { name: disk.name }
+      })
+    }))
+    expect(onSuccess).toHaveBeenCalled()
+  })
+
+  // with a [jupyter, rstudio] runtime existing and, details pane is open
+  it.each([
+    { runtimeTool: tools.Jupyter },
+    { runtimeTool: tools.RStudio }
+  ])('opens runtime details pane with a $runtimeTool.label runtime and a disk existing', async ({ runtimeTool }) => {
+    // Arrange
+    const disk = getDisk()
+    const machine = { name: 'n1-standard-4', cpu: 4, memory: 15 }
+    const runtimeProps = { tool: runtimeTool, runtimeConfig: getJupyterRuntimeConfig({ diskId: disk.id, machineType: machine.name }) }
+    const runtime = getGoogleRuntime(runtimeProps)
+
+    const runtimeFunc = jest.fn(() => ({
+      create: jest.fn(),
+      details: () => runtime
+    }))
+    Ajax.mockImplementation(() => ({
+      ...defaultAjaxImpl,
+      Runtimes: {
+        runtime: runtimeFunc
+      },
+      Disks: {
+        disk: () => ({
+          details: () => disk
+        })
+      }
+    }))
+
+    // Act
+    await act(async () => {
+      await render(h(ComputeModalBase, {
+        ...defaultModalProps,
+        currentDisk: disk,
+        currentRuntime: runtime,
+        tool: runtimeTool.label
+      }))
+    })
+
+    // Assert
+    expect(screen.getByText(`${runtimeTool.label} Cloud Environment`)).toBeInTheDocument()
+
+    const toolImage = _.find({ imageType: runtimeTool.label }, runtime.runtimeImages)
+    const selectText = _.find({ image: toolImage.imageUrl }, imageDocs).label
+    expect(screen.getByText(selectText)).toBeInTheDocument()
+
+    expect(screen.getByText(machine.cpu)).toBeInTheDocument()
+    expect(screen.getByText(machine.memory)).toBeInTheDocument()
+
+    verifyDisabled(screen.getByLabelText('Disk Type'))
+    verifyDisabled(screen.getByLabelText('Location'))
+    expect(screen.getByDisplayValue(disk.size)).toBeInTheDocument()
+
+    verifyEnabled(screen.getByText('Delete Environment'))
+    verifyEnabled(screen.getByText('Update'))
+  })
+
+  it.each([
+    { status: runtimeStatuses.running },
+    { status: runtimeStatuses.starting }
+  ])('lets the user update a runtime only in an appropriate status ($status.label, $status.canChangeCompute)', async ({ status }) => {
+    // Arrange
+    const disk = getDisk()
+    const runtimeProps = { status: status.leoLabel, runtimeConfig: getJupyterRuntimeConfig({ diskId: disk.id }) }
+    const runtime = getGoogleRuntime(runtimeProps)
+
+    const runtimeFunc = jest.fn(() => ({
+      details: () => runtime
+    }))
+    Ajax.mockImplementation(() => ({
+      ...defaultAjaxImpl,
+      Runtimes: {
+        runtime: runtimeFunc
+      },
+      Disks: {
+        disk: () => ({
+          details: () => disk
+        })
+      }
+    }))
+
+    // Act
+    await act(async () => {
+      await render(h(ComputeModalBase, {
+        ...defaultModalProps,
+        currentDisk: disk,
+        currentRuntime: runtime
+      }))
+    })
+
+    // Assert
+    if (!!status.canChangeCompute) {
+      verifyEnabled(screen.getByText('Update'))
+    } else {
+      verifyDisabled(screen.getByText('Update'))
+    }
+  })
+
+  // click delete environment on an existing [jupyter, rstudio] runtime with disk should bring up confirmation
+  it.each([
+    { tool: tools.Jupyter },
+    { tool: tools.RStudio }
+  ])('deletes environment with a confirmation for disk deletion for tool $tool.label', async ({ tool }) => {
+    // Arrange
+    const disk = getDisk()
+    const runtimeProps = { runtimeConfig: getJupyterRuntimeConfig({ diskId: disk.id, tool }) }
+    const runtime = getGoogleRuntime(runtimeProps)
+
+    const runtimeFunc = jest.fn(() => ({
+      details: () => runtime
+    }))
+    Ajax.mockImplementation(() => ({
+      ...defaultAjaxImpl,
+      Runtimes: {
+        runtime: runtimeFunc
+      },
+      Disks: {
+        disk: () => ({
+          details: () => disk
+        })
+      }
+    }))
+
+    // Act
+    await act(async () => {
+      render(h(ComputeModalBase, {
+        ...defaultModalProps,
+        currentDisk: disk,
+        currentRuntime: runtime
+      }))
+      await userEvent.click(screen.getByText('Delete Environment'))
+    })
+
+    // Assert
+    verifyEnabled(screen.getByText('Delete'))
+    const radio1 = screen.getByLabelText('Keep persistent disk, delete application configuration and compute profile')
+    expect(radio1).toBeChecked()
+    const radio2 = screen.getByLabelText('Delete everything, including persistent disk')
+    expect(radio2).not.toBeChecked()
+  })
+
+  // click delete environment on an existing [jupyter, rstudio] runtime with disk should delete
+  it.each([
+    { tool: tools.Jupyter },
+    { tool: tools.RStudio }
+  ])('clicking through delete confirmation and then delete should call delete for tool $tool.label', async ({ tool }) => {
+    // Arrange
+    const disk = getDisk()
+    const runtimeProps = { runtimeConfig: getJupyterRuntimeConfig({ diskId: disk.id, tool }) }
+    const runtime = getGoogleRuntime(runtimeProps)
+
+    const deleteFunc = jest.fn()
+
+    const runtimeFunc = jest.fn(() => ({
+      details: () => runtime,
+      delete: deleteFunc
+    }))
+    Ajax.mockImplementation(() => ({
+      ...defaultAjaxImpl,
+      Runtimes: {
+        runtime: runtimeFunc
+      },
+      Disks: {
+        disk: () => ({
+          details: () => disk
+        })
+      }
+    }))
+
+    // Act
+    await act(async () => {
+      render(h(ComputeModalBase, {
+        ...defaultModalProps,
+        currentDisk: disk,
+        currentRuntime: runtime
+      }))
+      await userEvent.click(screen.getByText('Delete Environment'))
+      await userEvent.click(screen.getByText('Delete'))
+    })
+
+    // Assert
+    expect(runtimeFunc).toHaveBeenCalledWith(defaultModalProps.workspace.workspace.googleProject, expect.anything())
+    expect(deleteFunc).toHaveBeenCalled()
+  })
+
+  // click update with downtime (and keep pd)
+  it.each([
+    { tool: tools.Jupyter },
+    { tool: tools.RStudio }
+  ])('updating a runtime after changing a field that requires downtime should call update for tool $tool.label', async ({ tool }) => {
+    // Arrange
+    const disk = getDisk()
+    const runtimeProps = { runtimeConfig: getJupyterRuntimeConfig({ diskId: disk.id, tool }) }
+    const runtime = getGoogleRuntime(runtimeProps)
+
+    const updateFunc = jest.fn()
+
+    const runtimeFunc = jest.fn(() => ({
+      details: () => runtime,
+      update: updateFunc
+    }))
+    Ajax.mockImplementation(() => ({
+      ...defaultAjaxImpl,
+      Runtimes: {
+        runtime: runtimeFunc
+      },
+      Disks: {
+        disk: () => ({
+          details: () => disk
+        })
+      }
+    }))
+
+    // Act
+    await act(async () => {
+      await render(h(ComputeModalBase, {
+        ...defaultModalProps,
+        currentDisk: disk,
+        currentRuntime: runtime
+      }))
+
+      await userEvent.click(screen.getByLabelText('CPUs'))
+      const selectOption = await screen.findByText('2')
+      await userEvent.click(selectOption)
+      const nextButton = await screen.findByText('Next')
+      await userEvent.click(nextButton)
+    })
+
+    // Assert
+    const headerForNextPane = await screen.findByText('Downtime required')
+    expect(headerForNextPane).toBeInTheDocument()
+
+    // Act
+    await act(async () => {
+      const updateButton = await screen.findByText('Update')
+      await userEvent.click(updateButton)
+    })
+
+    // Assert
+    expect(runtimeFunc).toHaveBeenCalledWith(defaultModalProps.workspace.workspace.googleProject, expect.anything())
+    expect(updateFunc).toHaveBeenCalledWith(expect.objectContaining({
+      runtimeConfig: {
+        cloudService: 'GCE',
+        machineType: 'n1-standard-2',
+        zone: 'us-central1-a'
+      }
+    }))
+  })
+
+  // TODO: this is a bug that this doesn't work... needs moore investigation
+  // click update with no downtime (and keep pd)
+  // it.each([
+  //   { tool: tools.Jupyter },
+  //   { tool: tools.RStudio }
+  // ])
+  // ('Updating a runtime and changing a field that requires no downtime should call update for tool $tool.label', async ({ tool }) => {
+  //   const disk = getDisk()
+  //   const runtimeProps = { runtimeConfig: getJupyterRuntimeConfig({ diskId: disk.id, tool }) }
+  //   const runtime = getGoogleRuntime(runtimeProps)
+  //
+  //   const updateFunc = jest.fn()
+  //
+  //   const runtimeFunc = jest.fn(() => ({
+  //     details: () => runtime,
+  //     update: updateFunc
+  //   }))
+  //   Ajax.mockImplementation(() => ({
+  //     ...defaultAjaxImpl,
+  //     Runtimes: {
+  //       runtime: runtimeFunc,
+  //     },
+  //     Disks: {
+  //       disk: () => ({
+  //         details: () => disk
+  //       })
+  //     }
+  //   }))
+  //
+  //   // Act
+  //   await act(async () => {
+  //     await render(h(ComputeModalBase, {
+  //       ...defaultModalProps,
+  //       currentDisk: disk,
+  //       currentRuntime: runtime
+  //     }))
+  //
+  //     const numberInput = await screen.getByDisplayValue(disk.size)
+  //     expect(numberInput).toBeInTheDocument()
+  //     fireEvent.change(numberInput, { target: { value: 51 } })
+  //
+  //     const changedNumberInput = await screen.getByDisplayValue(51)
+  //     expect(changedNumberInput).toBeInTheDocument()
+  //
+  //     const updateButton = await screen.findByText('Update')
+  //     await userEvent.click(updateButton)
+  //   })
+  //
+  //   expect(runtimeFunc).toHaveBeenCalledWith(defaultModalProps.workspace.workspace.googleProject, expect.anything())
+  //   // expect(screen.getByText('51')).toBeInTheDocument()
+  //   expect(updateFunc).toHaveBeenCalledWith(expect.objectContaining({
+  //     runtimeConfig: expect.objectContaining({
+  //       diskSize: 51
+  //     })
+  //   }))
+  // })
+
+  // TODO: this is a bug that this doesn't work... needs more investigation
+  // decrease disk size
+  // it.each([
+  //   { tool: tools.Jupyter },
+  //   { tool: tools.RStudio }
+  // ])
+  // ('Decreasing disk size should prompt user their disk will be deleted for $tool.label', async ({ tool }) => {
+  //   const disk = getDisk()
+  //   const runtimeProps = { runtimeConfig: getJupyterRuntimeConfig({ diskId: disk.id, tool }) }
+  //   const runtime = getGoogleRuntime(runtimeProps)
+  //
+  //   const createFunc = jest.fn()
+  //   const deleteFunc = jest.fn()
+  //
+  //   const runtimeFunc = jest.fn(() => ({
+  //     details: () => runtime,
+  //     create: createFunc,
+  //     delete: deleteFunc
+  //   }))
+  //   Ajax.mockImplementation(() => ({
+  //     ...defaultAjaxImpl,
+  //     Runtimes: {
+  //       runtime: runtimeFunc,
+  //     },
+  //     Disks: {
+  //       disk: () => ({
+  //         details: () => disk
+  //       })
+  //     }
+  //   }))
+  //
+  //   // Act
+  //   await act(async () => {
+  //     await render(h(ComputeModalBase, {
+  //       ...defaultModalProps,
+  //       currentDisk: disk,
+  //       currentRuntime: runtime
+  //     }))
+  //
+  //     const numberInput = await screen.getByDisplayValue(disk.size)
+  //     expect(numberInput).toBeInTheDocument()
+  //     fireEvent.change(numberInput, { target: { value: disk.size - 1 } })
+  //
+  //     const changedNumberInput = await screen.getByDisplayValue(disk.size - 1)
+  //     expect(changedNumberInput).toBeInTheDocument()
+  //
+  //     const nextButton = await screen.findByText('Update')
+  //     await userEvent.click(nextButton)
+  //
+  //     const deleteConfirmationPaneHeader = await screen.findByText('Data will be deleted')
+  //     expect(deleteConfirmationPaneHeader).toBeInTheDocument()
+  //
+  //     const updateButton = await screen.findByText('Update')
+  //     await userEvent.click(updateButton)
+  //   })
+  //
+  //   expect(runtimeFunc).toHaveBeenCalledWith(defaultModalProps.workspace.workspace.googleProject, runtime.runtimeName)
+  //   expect(deleteFunc).toHaveBeenCalled()
+  //   expect(createFunc).toHaveBeenCalledWith(expect.objectContaining({
+  //     runtimeConfig: expect.objectContaining({
+  //       persistentDisk: expect.objectContaining({
+  //         size: disk.size - 1
+  //       })
+  //     })
+  //   }))
+  // })
+
+  // with a [jupyter, rstudio] runtime existing and [a disk, no disk], details pane is open
+  it('dataproc runtime should display properly in modal', async () => {
+    // Arrange
+    const machine1 = { name: 'n1-standard-2', cpu: 2, memory: 7.50 }
+    const machine2 = { name: 'n1-standard-4', cpu: 4, memory: 15 }
+    const runtimeProps = {
+      image: hailImage.image, status: runtimeStatuses.stopped.leoLabel, runtimeConfig: {
+        numberOfWorkers: 2,
+        masterMachineType: machine1.name,
+        masterDiskSize: 151,
+        workerMachineType: machine2.name,
+        workerDiskSize: 150,
+        numberOfWorkerLocalSSDs: 0,
+        numberOfPreemptibleWorkers: 0,
+        cloudService: 'DATAPROC',
+        region: 'us-central1',
+        componentGatewayEnabled: true,
+        workerPrivateAccess: false
+      }
+    }
+    const runtime = getGoogleRuntime(runtimeProps)
+
+    const runtimeFunc = jest.fn(() => ({
+      create: jest.fn(),
+      details: () => runtime
+    }))
+    Ajax.mockImplementation(() => ({
+      ...defaultAjaxImpl,
+      Runtimes: {
+        runtime: runtimeFunc
+      },
+      Disks: {
+        disk: () => ({
+          details: jest.fn()
+        })
+      }
+    }))
+
+    // Act
+    await act(async () => {
+      await render(h(ComputeModalBase, {
+        ...defaultModalProps,
+        currentRuntime: runtime
+      }))
+    })
+
+    // Assert
+    expect(screen.getByText(`${tools.Jupyter.label} Cloud Environment`)).toBeInTheDocument()
+
+    const selectText = hailImage.label
+    expect(screen.getByText(selectText)).toBeInTheDocument()
+
+    expect(screen.getByText(machine1.cpu)).toBeInTheDocument()
+    expect(screen.getByText(machine1.memory)).toBeInTheDocument()
+    expect(screen.getByText('Spark cluster')).toBeInTheDocument()
+
+    verifyDisabled(screen.getByLabelText('Workers'))
+    verifyDisabled(screen.getByLabelText('Location'))
+
+    //TODO: fix bug affecting this, IA-3739
+    //master and worker disk sizes, there is a bug currently
+    // expect(screen.getByDisplayValue(150)).toBeInTheDocument()
+    // expect(screen.getByDisplayValue(151)).toBeInTheDocument()
+
+    expect(screen.getByText(machine2.cpu)).toBeInTheDocument()
+    expect(screen.getByText(machine2.memory)).toBeInTheDocument()
+
+    verifyEnabled(screen.getByText('Delete Runtime'))
+    //TODO: verify this is disabled once bug is fixed
+    expect(screen.getByText('Next')).toBeInTheDocument()
+  })
+
+  // spark cluster (pass a dataproc runtime and ensure it loads correctly) (
+  it('creates a datapoc runtime', async () => {
+    // Arrange
+    const createFunc = jest.fn()
+    const runtimeFunc = jest.fn(() => ({
+      create: createFunc,
+      details: jest.fn()
+    }))
+    Ajax.mockImplementation(() => ({
+      ...defaultAjaxImpl,
+      Runtimes: {
+        runtime: runtimeFunc
+      },
+      Disks: {
+        disk: () => ({
+          details: jest.fn()
+        })
+      }
+    }))
+
+    // Act
+    await act(async () => {
+      await render(h(ComputeModalBase, defaultModalProps))
+
+      await userEvent.click(screen.getByText('Customize'))
+      const selectMenu = await screen.getByLabelText('Application configuration')
+      await userEvent.click(selectMenu)
+      const selectOption = await screen.findByText(hailImage.label)
+      await userEvent.click(selectOption)
+      const computeTypeSelect = await screen.getByLabelText('Compute type')
+      await userEvent.click(computeTypeSelect)
+      const sparkClusterOption = await screen.findByText('Spark cluster')
+      await userEvent.click(sparkClusterOption)
+
+      const create = await screen.getByText('Create')
+      await userEvent.click(create)
+    })
+
+    expect(runtimeFunc).toHaveBeenCalledWith(defaultModalProps.workspace.workspace.googleProject, expect.anything())
+    expect(createFunc).toHaveBeenCalledWith(expect.objectContaining({
+      toolDockerImage: hailImage.image,
+      runtimeConfig: expect.objectContaining({
+        numberOfWorkers: defaultNumDataprocWorkers,
+        masterMachineType: defaultDataprocMachineType,
+        masterDiskSize: defaultDataprocMasterDiskSize,
+        workerMachineType: defaultDataprocMachineType,
+        workerDiskSize: defaultDataprocWorkerDiskSize,
+        numberOfPreemptibleWorkers: defaultNumDataprocPreemptibleWorkers,
+        cloudService: 'DATAPROC',
+        region: 'us-central1',
+        componentGatewayEnabled: true
+      })
+    }))
+  })
+
+  //custom on image select with a [valid, invalid] custom image should function
+  it('custom Environment pane should behave correctly with an invalid image URI', async () => {
+    // Arrange
+    const createFunc = jest.fn()
+
+    const runtimeFunc = jest.fn(() => ({
+      details: jest.fn(),
+      create: createFunc
+    }))
+    Ajax.mockImplementation(() => ({
+      ...defaultAjaxImpl,
+      Runtimes: {
+        runtime: runtimeFunc
+      },
+      Disks: {
+        disk: () => ({
+          details: jest.fn()
+        })
+      }
+    }))
+
+    // Act and assert
+    await act(async () => {
+      await render(h(ComputeModalBase, defaultModalProps))
+
+      await userEvent.click(screen.getByText('Customize'))
+      const selectMenu = await screen.getByLabelText('Application configuration')
+      await userEvent.click(selectMenu)
+      const selectOption = await screen.findByText('Custom Environment')
+      await userEvent.click(selectOption)
+
+      const imageInput = await screen.getByLabelText('Container image')
+      expect(imageInput).toBeInTheDocument()
+      const invalidImageUri = 'b'
+      await userEvent.type(imageInput, invalidImageUri)
+
+      const nextButton = await screen.findByText('Next')
+
+      verifyDisabled(nextButton)
+    })
+  })
+
+  //custom on image select with a [valid, invalid] custom image should function
+  it('custom Environment pane should work with a valid image URI ', async () => {
+    // Arrange
+    const createFunc = jest.fn()
+
+    const runtimeFunc = jest.fn(() => ({
+      details: jest.fn(),
+      create: createFunc
+    }))
+    Ajax.mockImplementation(() => ({
+      ...defaultAjaxImpl,
+      Runtimes: {
+        runtime: runtimeFunc
+      },
+      Disks: {
+        disk: () => ({
+          details: jest.fn()
+        })
+      }
+    }))
+
+    // Act and assert
+    await act(async () => {
+      await render(h(ComputeModalBase, defaultModalProps))
+
+      await userEvent.click(screen.getByText('Customize'))
+      const selectMenu = await screen.getByLabelText('Application configuration')
+      await userEvent.click(selectMenu)
+      const selectOption = await screen.findByText('Custom Environment')
+      await userEvent.click(selectOption)
+
+      const imageInput = await screen.getByLabelText('Container image')
+      expect(imageInput).toBeInTheDocument()
+      const customImageUri = 'us'
+      await fireEvent.change(imageInput, { target: { value: customImageUri } })
+
+      const nextButton = await screen.findByText('Next')
+      verifyEnabled(nextButton)
+      await userEvent.click(nextButton)
+      const unverifiedDockerWarningHeader = await screen.findByText('Unverified Docker image')
+
+      expect(unverifiedDockerWarningHeader).toBeInTheDocument()
+      const createButton = await screen.findByText('Create')
+      await userEvent.click(createButton)
+      expect(runtimeFunc).toHaveBeenCalledWith(defaultModalProps.workspace.workspace.googleProject, expect.anything())
+      expect(createFunc).toHaveBeenCalledWith(expect.objectContaining({
+        toolDockerImage: customImageUri
+      }))
+    })
+  })
+
+  // click learn more about persistent disk
+  it('should render learn more about persistent disks', async () => {
+    // Act
+    await act(async () => {
+      await render(h(ComputeModalBase, defaultModalProps))
+      const link = screen.getByText('Learn more about Persistent Disks.')
+      await userEvent.click(link)
+    })
+
+    // Assert
+    expect(screen.getByText('About persistent disk')).toBeInTheDocument()
+  })
+
+  it('should render whats installed on this environment', async () => {
+    // Act
+    await act(async () => {
+      await render(h(ComputeModalBase, defaultModalProps))
+      const link = await screen.getByText('What’s installed on this environment?')
+      await userEvent.click(link)
+    })
+
+    // Assert
+    expect(screen.getByText('Installed packages')).toBeInTheDocument()
+    expect(screen.getByText(defaultImage.label)).toBeInTheDocument()
+    expect(screen.getByText('Language:')).toBeInTheDocument()
+  })
+
+  // GPUs should function properly
+  it('creates a runtime with GPUs', async () => {
+    // Arrange
+    const createFunc = jest.fn()
+    const runtimeFunc = jest.fn(() => ({
+      create: createFunc,
+      details: jest.fn()
+    }))
+    Ajax.mockImplementation(() => ({
+      ...defaultAjaxImpl,
+      Runtimes: {
+        runtime: runtimeFunc
+      }
+    }))
+
+    // Act
+    await act(async () => {
+      await render(h(ComputeModalBase, defaultModalProps))
+      const link = screen.getByText('Customize')
+      await userEvent.click(link)
+      const enableGPU = await screen.getByText('Enable GPUs')
+      await userEvent.click(enableGPU)
+    })
+
+    // Assert
+    expect(screen.getByText('GPU type')).toBeInTheDocument()
+    expect(screen.getByText('GPUs')).toBeInTheDocument()
+
+    // Act
+    await act(async () => {
+      const create = screen.getByText('Create')
+      await userEvent.click(create)
+    })
+
+    // Assert
+    expect(createFunc).toHaveBeenCalledWith(expect.objectContaining({
+      runtimeConfig: expect.objectContaining({
+        gpuConfig: { gpuType: defaultGpuType, numOfGpus: defaultNumGpus }
+      })
+    }))
+  })
+})

--- a/src/pages/workspaces/workspace/analysis/modals/ComputeModal.test.js
+++ b/src/pages/workspaces/workspace/analysis/modals/ComputeModal.test.js
@@ -803,6 +803,7 @@ describe('ComputeModal', () => {
 
     // Assert
     expect(screen.getByText('About persistent disk')).toBeInTheDocument()
+    expect(screen.getByText('Your persistent disk is mounted in the directory', { exact: false })).toBeInTheDocument()
   })
 
   it('should render whats installed on this environment', async () => {

--- a/src/pages/workspaces/workspace/analysis/runtime-utils.js
+++ b/src/pages/workspaces/workspace/analysis/runtime-utils.js
@@ -283,7 +283,7 @@ export const trimRuntimesOldestFirst = _.flow(
   _.sortBy('auditInfo.createdDate')
 )
 
-// Status note: undefined means still loading, null means no runtime
+// Status note: undefined means still loading and no runtime
 export const getCurrentRuntime = runtimes => !runtimes ? undefined : (_.flow(trimRuntimesOldestFirst, _.last)(runtimes) || undefined)
 
 const getCurrentAppExcludingStatuses = (appType, statuses) => _.flow(

--- a/src/pages/workspaces/workspace/analysis/runtime-utils.js
+++ b/src/pages/workspaces/workspace/analysis/runtime-utils.js
@@ -284,7 +284,7 @@ export const trimRuntimesOldestFirst = _.flow(
 )
 
 // Status note: undefined means still loading, null means no runtime
-export const getCurrentRuntime = runtimes => !runtimes ? undefined : (_.flow(trimRuntimesOldestFirst, _.last)(runtimes) || null)
+export const getCurrentRuntime = runtimes => !runtimes ? undefined : (_.flow(trimRuntimesOldestFirst, _.last)(runtimes) || undefined)
 
 const getCurrentAppExcludingStatuses = (appType, statuses) => _.flow(
   _.filter({ appType }),
@@ -359,6 +359,8 @@ export const getCurrentAppDataDisk = (appType, apps, appDataDisks, workspaceName
  * @param {persistentDisk[]} persistentDisks List of persistent disks.
  * @returns persistentDisk attached to the currentRuntime.
  */
+//TODO: can this just take current runtime>runtimes?
+// what is the significance of of the filter on ` !_.includes(id, attachedIds)`?
 export const getCurrentPersistentDisk = (runtimes, persistentDisks) => {
   const currentRuntime = getCurrentRuntime(runtimes)
   const id = currentRuntime?.runtimeConfig.persistentDiskId
@@ -505,4 +507,18 @@ export const cloudProviders = {
 
 export const isGcpContext = ({ cloudProvider }) => cloudProvider === cloudProviders.gcp.label
 export const isAzureContext = ({ cloudProvider }) => cloudProvider === cloudProviders.azure.label
+
+//TODO: fields isAppStatus? LeoLabel? isRuntimeStatus?
+export const runtimeStatuses = {
+  running: { label: 'Running', leoLabel: 'Running', canChangeCompute: true },
+  deleted: { label: 'Deleted', leoLabel: 'Deleted' },
+  deleting: { label: 'Deleting', leoLabel: 'Deleting' },
+  creating: { label: 'Creating', leoLabel: 'Creating' },
+  updating: { label: 'Updating', leoLabel: 'Updating' },
+  starting: { label: 'Starting', leoLabel: 'Starting' },
+  stopping: { label: 'Stopping', leoLabel: 'Stopping' },
+  stopped: { label: 'Stopped', leoLabel: 'Stopped', canChangeCompute: true },
+  error: { label: 'Error', leoLabel: 'Error', canChangeCompute: true }
+}
+
 


### PR DESCRIPTION
Achieved 80% test coverage for the massive compute modal component, as well as increased coverage in the associated runtime-utils.

<img width="814" alt="image" src="https://user-images.githubusercontent.com/6465084/191573150-6f291ad0-b055-4500-8526-50ec25bc7bdb.png">

I also added a testData file with useful runtime/disk data generation functions. 

There are 3 tests I really wanted to get in, but I believe all of them uncover bugs in the base component that need more careful investigation that I don't wish to undertake before going on vacation. Additionally, this ticket has taken a bit more time than we wanted to invest originally. 