### PR TITLE
ID-261 Add state to oauthcode Bond calls

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -297,10 +297,11 @@ const User = signal => ({
     return res.json()
   },
 
-  linkFenceAccount: async (provider, authCode, redirectUri) => {
+  linkFenceAccount: async (provider, authCode, redirectUri, state) => {
     const queryParams = {
       oauthcode: authCode,
-      redirect_uri: redirectUri
+      redirect_uri: redirectUri,
+      state
     }
     const res = await fetchBond(`api/link/v1/${provider}/oauthcode?${qs.stringify(queryParams)}`, _.merge(authOpts(), { signal, method: 'POST' }))
     return res.json()

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -293,7 +293,7 @@ const User = signal => ({
       redirect_uri: redirectUri,
       state: btoa(JSON.stringify({ provider }))
     }
-    const res = await fetchBond(`api/link/v1/${provider}/authorization-url?${qs.stringify(queryParams, { indices: false })}`, { signal })
+    const res = await fetchBond(`api/link/v1/${provider}/authorization-url?${qs.stringify(queryParams, { indices: false })}`, _.merge(authOpts(), { signal }))
     return res.json()
   },
 

--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -244,7 +244,7 @@ const FenceLink = ({ provider: { key, name, expiresAfter, short } }) => {
       withErrorReporting('Error linking NIH account'),
       Utils.withBusyState(setIsLinking)
     )(async () => {
-      const status = await Ajax().User.linkFenceAccount(key, token, redirectUrl)
+      const status = await Ajax().User.linkFenceAccount(key, token, redirectUrl, state)
       authStore.update(_.set(['fenceStatus', key], status))
     })
 


### PR DESCRIPTION
As a part of https://broadworkbench.atlassian.net/browse/ID-261, Terra UI needs to send the `state` returned in the OAuth handshake back to Bond. This is a part of CSRF mitigation. There are no changes the user should see.

<!--
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Also, so if a screen recording [1] and/or screenshots would be a helpful way to communicate context, please consider including some in your PR description.
Thanks!

[1] https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac
--!>
