### PR TITLE
Show cloud platform icon in billing project dropdown (WOR-295).

### DIFF
--- a/src/components/NewWorkspaceModal.js
+++ b/src/components/NewWorkspaceModal.js
@@ -134,9 +134,7 @@ const NewWorkspaceModal = withDisplayName('NewWorkspaceModal', ({
         setNamespace(_.some({ projectName: namespace }, projects) ? namespace : undefined)
       }),
     Ajax(signal).Groups.list().then(setAllGroups),
-    !!cloneWorkspace && cloneWorkspace.cloudPlatform === cloudProviders.gcp.label &&
-    Ajax(signal).Workspaces.workspace(namespace, cloneWorkspace.workspace.name).checkBucketLocation(cloneWorkspace.workspace.googleProject,
-      cloneWorkspace.workspace.bucketName)
+    !!cloneWorkspace && !cloneWorkspace.azureContext && Ajax(signal).Workspaces.workspace(namespace, cloneWorkspace.workspace.name).checkBucketLocation(cloneWorkspace.workspace.googleProject, cloneWorkspace.workspace.bucketName)
       .then(({ location }) => {
         // For current phased regionality release, we only allow US or NORTHAMERICA-NORTHEAST1 (Montreal) workspace buckets.
         setBucketLocation(isSupportedBucketLocation(location) ? location : defaultLocation)

--- a/src/components/NewWorkspaceModal.js
+++ b/src/components/NewWorkspaceModal.js
@@ -158,8 +158,8 @@ const NewWorkspaceModal = withDisplayName('NewWorkspaceModal', ({
   const isBillingProjectApplicable = project => {
     // Only support cloning a workspace to the same cloud environment.
     return Utils.cond(
-      [!!cloneWorkspace && cloneWorkspace.cloudPlatform === cloudProviders.azure.label, () => isAzureBillingProject(project)],
-      [!!cloneWorkspace && cloneWorkspace.cloudPlatform === cloudProviders.gcp.label, () => !isAzureBillingProject(project)],
+      [!!cloneWorkspace && !!cloneWorkspace.azureContext, () => isAzureBillingProject(project)],
+      [!!cloneWorkspace && !cloneWorkspace.azureContext, () => !isAzureBillingProject(project)],
       [Utils.DEFAULT, () => true]
     )
   }

--- a/src/components/NewWorkspaceModal.js
+++ b/src/components/NewWorkspaceModal.js
@@ -8,6 +8,8 @@ import Modal from 'src/components/Modal'
 import { InfoBox } from 'src/components/PopupTrigger'
 import { allRegions, availableBucketRegions, getLocationType, getRegionInfo, isLocationMultiRegion, isSupportedBucketLocation } from 'src/components/region-common'
 import TooltipTrigger from 'src/components/TooltipTrigger'
+import { ReactComponent as CloudAzureLogo } from 'src/images/cloud_azure_icon.svg'
+import { ReactComponent as CloudGcpLogo } from 'src/images/cloud_google_icon.svg'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { getConfig } from 'src/libs/config'
@@ -17,7 +19,7 @@ import { FormLabel } from 'src/libs/forms'
 import * as Nav from 'src/libs/nav'
 import { useCancellation, useOnMount, withDisplayName } from 'src/libs/react-utils'
 import * as Utils from 'src/libs/utils'
-import { defaultLocation } from 'src/pages/workspaces/workspace/analysis/runtime-utils'
+import { cloudProviders, defaultLocation } from 'src/pages/workspaces/workspace/analysis/runtime-utils'
 import validate from 'validate.js'
 
 
@@ -43,6 +45,14 @@ const constraints = {
   namespace: {
     presence: true
   }
+}
+
+const cloudContextIcon = ({ cloudPlatform }) => {
+  return div({ style: { display: 'flex', marginRight: '0.5rem' } }, [
+    Utils.switchCase(cloudPlatform,
+      [cloudProviders.gcp.label, () => h(CloudGcpLogo, { title: cloudProviders.gcp.iconTitle, role: 'img' })],
+      [cloudProviders.azure.label, () => h(CloudAzureLogo, { title: cloudProviders.azure.iconTitle, role: 'img' })])
+  ])
 }
 
 const NewWorkspaceModal = withDisplayName('NewWorkspaceModal', ({
@@ -124,7 +134,9 @@ const NewWorkspaceModal = withDisplayName('NewWorkspaceModal', ({
         setNamespace(_.some({ projectName: namespace }, projects) ? namespace : undefined)
       }),
     Ajax(signal).Groups.list().then(setAllGroups),
-    !!cloneWorkspace && !cloneWorkspace.azureContext && Ajax(signal).Workspaces.workspace(namespace, cloneWorkspace.workspace.name).checkBucketLocation(cloneWorkspace.workspace.googleProject, cloneWorkspace.workspace.bucketName)
+    !!cloneWorkspace && cloneWorkspace.cloudPlatform === cloudProviders.gcp.label &&
+    Ajax(signal).Workspaces.workspace(namespace, cloneWorkspace.workspace.name).checkBucketLocation(cloneWorkspace.workspace.googleProject,
+      cloneWorkspace.workspace.bucketName)
       .then(({ location }) => {
         // For current phased regionality release, we only allow US or NORTHAMERICA-NORTHEAST1 (Montreal) workspace buckets.
         setBucketLocation(isSupportedBucketLocation(location) ? location : defaultLocation)
@@ -140,15 +152,14 @@ const NewWorkspaceModal = withDisplayName('NewWorkspaceModal', ({
     if (project === undefined) {
       project = _.find({ projectName: namespace }, billingProjects)
     }
-    // Azure billing projects have `managedAppCoordinates` defined.
-    return !!project?.managedAppCoordinates
+    return project?.cloudPlatform === cloudProviders.azure.label
   }
 
   const isBillingProjectApplicable = project => {
     // Only support cloning a workspace to the same cloud environment.
     return Utils.cond(
-      [!!cloneWorkspace && !!cloneWorkspace.azureContext, () => isAzureBillingProject(project)],
-      [!!cloneWorkspace && !cloneWorkspace.azureContext, () => !isAzureBillingProject(project)],
+      [!!cloneWorkspace && cloneWorkspace.cloudPlatform === cloudProviders.azure.label, () => isAzureBillingProject(project)],
+      [!!cloneWorkspace && cloneWorkspace.cloudPlatform === cloudProviders.gcp.label, () => !isAzureBillingProject(project)],
       [Utils.DEFAULT, () => true]
     )
   }
@@ -213,13 +224,16 @@ const NewWorkspaceModal = withDisplayName('NewWorkspaceModal', ({
           placeholder: 'Select a billing project',
           value: namespace,
           onChange: ({ value }) => setNamespace(value),
-          styles: { option: provided => ({ ...provided, padding: 0 }) },
-          options: _.map(({ projectName, invalidBillingAccount }) => ({
+          styles: { option: provided => ({ ...provided, padding: 10 }) },
+          options: _.map(({ projectName, invalidBillingAccount, cloudPlatform }) => ({
             label: h(TooltipTrigger, {
-              content: invalidBillingAccount && 'Workspaces may only be created in billing projects that have a Google billing account accessible in Terra',
+              content: invalidBillingAccount &&
+                'Workspaces may only be created in billing projects that have a Google billing account accessible in Terra',
               side: 'left'
-            }, [div({ style: { padding: 10 } }, [projectName])]
-            ),
+            },
+            [div({ style: { display: 'flex', alignItems: 'center' } },
+              [h(cloudContextIcon, { cloudPlatform }), projectName]
+            )]),
             value: projectName,
             isDisabled: invalidBillingAccount
           }), _.sortBy('projectName', _.uniq(billingProjects)))

--- a/src/components/workspace-utils.js
+++ b/src/components/workspace-utils.js
@@ -24,6 +24,7 @@ import { useCancellation, useInstance, useOnMount, useStore, withDisplayName } f
 import { workspacesStore } from 'src/libs/state'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
+import { cloudProviders } from 'src/pages/workspaces/workspace/analysis/runtime-utils'
 import validate from 'validate.js'
 
 
@@ -477,8 +478,8 @@ export const RecentlyViewedWorkspaceCard = ({ workspace, submissionStatus, loadi
             loadingSubmissionStats
           }),
           !!googleProject ?
-            h(CloudGcpLogo, { title: 'Google Cloud', role: 'img', style: { marginLeft: 5, height: 16 } }) :
-            h(CloudAzureLogo, { title: 'Microsoft Azure', role: 'img', style: { marginLeft: 5, height: 16 } })
+            h(CloudGcpLogo, { title: cloudProviders.gcp.iconTitle, role: 'img', style: { marginLeft: 5, height: 16 } }) :
+            h(CloudAzureLogo, { title: cloudProviders.azure.iconTitle, role: 'img', style: { marginLeft: 5, height: 16 } })
         ])
       ])
     ])

--- a/src/components/workspace-utils.js
+++ b/src/components/workspace-utils.js
@@ -478,8 +478,8 @@ export const RecentlyViewedWorkspaceCard = ({ workspace, submissionStatus, loadi
             loadingSubmissionStats
           }),
           !!googleProject ?
-            h(CloudGcpLogo, { title: cloudProviders.gcp.iconTitle, role: 'img', style: { marginLeft: 5, height: 16 } }) :
-            h(CloudAzureLogo, { title: cloudProviders.azure.iconTitle, role: 'img', style: { marginLeft: 5, height: 16 } })
+            h(CloudGcpLogo, { title: cloudProviders.gcp.iconTitle, role: 'img', style: { marginLeft: 5 } }) :
+            h(CloudAzureLogo, { title: cloudProviders.azure.iconTitle, role: 'img', style: { marginLeft: 5 } })
         ])
       ])
     ])

--- a/src/pages/billing/List.js
+++ b/src/pages/billing/List.js
@@ -117,8 +117,8 @@ const ProjectListItem = ({ project, project: { roles, status, cloudPlatform }, l
   const cloudContextIcon =
     div({ style: { display: 'flex', marginRight: '0.5rem' } }, [
       Utils.switchCase(cloudPlatform,
-        [cloudProviders.gcp.label, () => h(CloudGcpLogo, { title: 'Google Cloud Platform', role: 'img' })],
-        [cloudProviders.azure.label, () => h(CloudAzureLogo, { title: 'Microsoft Azure', role: 'img' })])
+        [cloudProviders.gcp.label, () => h(CloudGcpLogo, { title: cloudProviders.gcp.iconTitle, role: 'img' })],
+        [cloudProviders.azure.label, () => h(CloudAzureLogo, { title: cloudProviders.azure.iconTitle, role: 'img' })])
     ])
 
   const selectableProject = ({ projectName }, isActive) => h(Clickable, {

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -30,6 +30,7 @@ import { useCancellation, useOnMount, useStore } from 'src/libs/react-utils'
 import { authStore } from 'src/libs/state'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
+import { cloudProviders } from 'src/pages/workspaces/workspace/analysis/runtime-utils'
 import DeleteWorkspaceModal from 'src/pages/workspaces/workspace/DeleteWorkspaceModal'
 import LeaveWorkspaceModal from 'src/pages/workspaces/workspace/LeaveWorkspaceModal'
 import LockWorkspaceModal from 'src/pages/workspaces/workspace/LockWorkspaceModal'
@@ -311,9 +312,9 @@ export const WorkspaceList = () => {
             const { workspace: { cloudPlatform } } = sortedWorkspaces[rowIndex]
             return div({ style: { ...styles.tableCellContainer, paddingRight: 0 } }, [
               div({ style: styles.tableCellContent }, [
-                Utils.switchCase(cloudPlatform,
-                  ['Gcp', () => h(CloudGcpLogo, { title: 'Google Cloud Platform', role: 'img' })],
-                  ['Azure', () => h(CloudAzureLogo, { title: 'Microsoft Azure', role: 'img' })])
+                Utils.switchCase(_.toUpper(cloudPlatform),
+                  [cloudProviders.gcp.label, () => h(CloudGcpLogo, { title: cloudProviders.gcp.iconTitle, role: 'img' })],
+                  [cloudProviders.azure.label, () => h(CloudAzureLogo, { title: cloudProviders.azure.iconTitle, role: 'img' })])
               ])
             ])
           },

--- a/src/pages/workspaces/workspace/analysis/runtime-utils.js
+++ b/src/pages/workspaces/workspace/analysis/runtime-utils.js
@@ -496,6 +496,8 @@ export const getIsRuntimeBusy = runtime => {
   return creating || updating || reconfiguring || stopping || starting
 }
 
+// NOTE: the label property is being compared to Ajax response values, so the label cannot be changed without
+// impacting code.
 export const cloudProviders = {
   azure: { label: 'AZURE', iconTitle: 'Microsoft Azure' },
   gcp: { label: 'GCP', iconTitle: 'Google Cloud Platform' }

--- a/src/pages/workspaces/workspace/analysis/runtime-utils.js
+++ b/src/pages/workspaces/workspace/analysis/runtime-utils.js
@@ -496,7 +496,10 @@ export const getIsRuntimeBusy = runtime => {
   return creating || updating || reconfiguring || stopping || starting
 }
 
-export const cloudProviders = { azure: { label: 'AZURE' }, gcp: { label: 'GCP' } }
+export const cloudProviders = {
+  azure: { label: 'AZURE', iconTitle: 'Microsoft Azure' },
+  gcp: { label: 'GCP', iconTitle: 'Google Cloud Platform' }
+}
 
 export const isGcpContext = ({ cloudProvider }) => cloudProvider === cloudProviders.gcp.label
 export const isAzureContext = ({ cloudProvider }) => cloudProvider === cloudProviders.azure.label


### PR DESCRIPTION
Icons are now visible in the create/clone workspace dialog:

![image](https://user-images.githubusercontent.com/484484/191779396-d1c3cc01-b1e0-474d-b07a-a34985e77e26.png)

Note that when you clone, you can only clone to a billing project that is in the same cloud platform. 

![image](https://user-images.githubusercontent.com/484484/191781356-ccbd8c50-7a94-4151-a53e-d7a98ebcb19d.png)

