### PR TITLE
[SU-217] Prevent crash when signing out

### DIFF
--- a/src/components/ProfilePicture.js
+++ b/src/components/ProfilePicture.js
@@ -1,24 +1,19 @@
 import { img } from 'react-hyperscript-helpers'
 import { getUser } from 'src/libs/auth'
-import * as Utils from 'src/libs/utils'
 
 
 const ProfilePicture = ({ size, style, ...props } = {}) => {
   // Note Azure logins don't currently have an imageUrl, so don't render anything.
   // See TOAZ-147 to support this in the future.
   const imageUrl = getUser().imageUrl
-
-  return Utils.cond(
-    [!imageUrl, () => null],
-    () => img({
-      alt: 'Google profile image',
-      src: imageUrl,
-      height: size, width: size,
-      style: { borderRadius: '100%', ...style },
-      referrerPolicy: 'no-referrer',
-      ...props
-    })
-  )
+  return !!imageUrl && img({
+    alt: 'Google profile image',
+    src: imageUrl,
+    height: size, width: size,
+    style: { borderRadius: '100%', ...style },
+    referrerPolicy: 'no-referrer',
+    ...props
+  })
 }
 
 export default ProfilePicture

--- a/src/components/ProfilePicture.js
+++ b/src/components/ProfilePicture.js
@@ -1,19 +1,24 @@
 import { img } from 'react-hyperscript-helpers'
 import { getUser } from 'src/libs/auth'
+import * as Utils from 'src/libs/utils'
 
 
 const ProfilePicture = ({ size, style, ...props } = {}) => {
   // Note Azure logins don't currently have an imageUrl, so don't render anything.
   // See TOAZ-147 to support this in the future.
   const imageUrl = getUser().imageUrl
-  return imageUrl && img({
-    alt: 'Google profile image',
-    src: imageUrl,
-    height: size, width: size,
-    style: { borderRadius: '100%', ...style },
-    referrerPolicy: 'no-referrer',
-    ...props
-  })
+
+  return Utils.cond(
+    [!imageUrl, () => null],
+    () => img({
+      alt: 'Google profile image',
+      src: imageUrl,
+      height: size, width: size,
+      style: { borderRadius: '100%', ...style },
+      referrerPolicy: 'no-referrer',
+      ...props
+    })
+  )
 }
 
 export default ProfilePicture


### PR DESCRIPTION
Currently, Terra UI crashes when signing out from the sidebar (at least while viewing the workspaces page or a workspace page).

This is because the render function for the ProfilePicture component returns undefined when there is no user signed in.

https://github.com/DataBiosphere/terra-ui/blob/2f5887b33efc6dff3f8614cd15574bd775ad9a91/src/components/ProfilePicture.js#L5-L17

This previously worked because this code was in a render function instead of a component. That changed in #3398.