### PR TITLE
[SU-214] Add feedback links for data table feature previews

### DIFF
--- a/src/libs/feature-previews-config.js
+++ b/src/libs/feature-previews-config.js
@@ -3,13 +3,15 @@ const featurePreviewsConfig = [
     id: 'data-table-versioning',
     title: 'Data Table Versioning',
     description: 'Enabling this feature will allow you to save uniquely named versions of data tables. These saved versions will appear in the Data tab and can be restored at any time.',
-    groups: ['preview-data-versioning-and-provenance']
+    groups: ['preview-data-versioning-and-provenance'],
+    feedbackUrl: `mailto:dsp-sue@broadinstitute.org?subject=${encodeURIComponent(`Feedback on data table versioning`)}`
   },
   {
     id: 'data-table-provenance',
     title: 'Data Table Provenance',
     description: 'Enabling this feature will allow you to view information about the workflow that generated data table columns and files.',
-    groups: ['preview-data-versioning-and-provenance']
+    groups: ['preview-data-versioning-and-provenance'],
+    feedbackUrl: `mailto:dsp-sue@broadinstitute.org?subject=${encodeURIComponent(`Feedback on data table provenance`)}`
   }
 ]
 

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -436,7 +436,7 @@ const DataTableFeaturePreviewFeedbackBanner = () => {
     style: {
       padding: '1rem',
       borderBottom: `1px solid ${colors.accent()}`,
-      background: colors.accent(0.2),
+      background: '#fff',
       textAlign: 'center'
     }
   }, [h(Link, { ...Utils.newTabLinkProps, href: feedbackUrl }, [`Provide feedback on data table ${label}`])])

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -422,6 +422,26 @@ const DataTableActions = ({ workspace, tableName, rowCount, entityMetadata, onRe
   ])
 }
 
+const DataTableFeaturePreviewFeedbackBanner = () => {
+  const isDataTableProvenanceEnabled = isFeaturePreviewEnabled('data-table-provenance')
+  const isDataTableVersioningEnabled = isFeaturePreviewEnabled('data-table-versioning')
+
+  const label = _.join(' and ', _.compact([
+    isDataTableVersioningEnabled && 'versioning',
+    isDataTableProvenanceEnabled && 'provenance'
+  ]))
+  const feedbackUrl = `mailto:dsp-sue@broadinstitute.org?subject=${encodeURIComponent(`Feedback on data table ${label}`)}`
+
+  return (isDataTableProvenanceEnabled || isDataTableVersioningEnabled) && div({
+    style: {
+      padding: '1rem',
+      borderBottom: `1px solid ${colors.accent()}`,
+      background: colors.accent(0.2),
+      textAlign: 'center'
+    }
+  }, [h(Link, { ...Utils.newTabLinkProps, href: feedbackUrl }, [`Provide feedback on data table ${label}`])])
+}
+
 const workspaceDataTypes = Utils.enumify(['entities', 'entitiesVersion', 'snapshot', 'referenceData', 'localVariables', 'bucketObjects'])
 
 const WorkspaceData = _.flow(
@@ -839,6 +859,7 @@ const WorkspaceData = _.flow(
       ]),
       h(SidebarSeparator, { sidebarWidth, setSidebarWidth }),
       div({ style: styles.tableViewPanel }, [
+        _.includes(selectedData?.type, [workspaceDataTypes.entities, workspaceDataTypes.entitiesVersion]) && h(DataTableFeaturePreviewFeedbackBanner),
         Utils.switchCase(selectedData?.type,
           [undefined, () => div({ style: { textAlign: 'center' } }, ['Select a data type'])],
           [workspaceDataTypes.localVariables, () => h(LocalVariablesContent, {


### PR DESCRIPTION
Add feedback links to the feature previews page (https://app.terra.bio/#feature-preview).

![Screen Shot 2022-09-22 at 3 10 54 PM](https://user-images.githubusercontent.com/1156625/191831845-d277db1d-b15b-418c-b4cd-6cac7255944f.png)

And add a banner requesting feedback to the data table. This is only shown when one or both of the relevant feature previews is enabled.

![Screen Shot 2022-09-22 at 3 10 48 PM](https://user-images.githubusercontent.com/1156625/191831978-6fd85113-6417-4980-85b0-4b69375d5503.png)
