### PR TITLE
IA-3755 remove localSafeModeBaseDirectory

### DIFF
--- a/src/libs/ajax/Runtimes.js
+++ b/src/libs/ajax/Runtimes.js
@@ -74,11 +74,10 @@ export const Runtimes = signal => ({
         return fetchOk(`${proxyUrl}/setCookie`, _.merge(authOpts(), { signal, credentials: 'include' }))
       },
 
-      setStorageLinks: (localBaseDirectory, localSafeModeBaseDirectory, cloudStorageDirectory, pattern) => {
+      setStorageLinks: (localBaseDirectory, cloudStorageDirectory, pattern) => {
         return fetchOk(`${proxyUrl}/welder/storageLinks`,
           _.mergeAll([authOpts(), jsonBody({
             localBaseDirectory,
-            localSafeModeBaseDirectory,
             cloudStorageDirectory,
             pattern
           }), { signal, method: 'POST' }]))

--- a/src/pages/workspaces/workspace/analysis/AppLauncher.js
+++ b/src/pages/workspaces/workspace/analysis/AppLauncher.js
@@ -165,8 +165,6 @@ const ApplicationLauncher = _.flow(
       withErrorReporting('Error setting up analysis file syncing')
     )(async () => {
       const localBaseDirectory = ``
-      const localSafeModeBaseDirectory = ``
-
 
       const { storageContainerName: azureStorageContainer } = !!azureContext ? await Ajax(signal).AzureStorage.details(workspaceId) : {}
       const cloudStorageDirectory = !!azureContext ? `${azureStorageContainer}/analyses` : `gs://${bucketName}/notebooks`
@@ -176,11 +174,11 @@ const ApplicationLauncher = _.flow(
         await Ajax()
           .Runtimes
           .fileSyncing(googleProject, runtime.runtimeName)
-          .setStorageLinks(localBaseDirectory, localSafeModeBaseDirectory, cloudStorageDirectory, getPatternFromTool(getToolFromRuntime(runtime))) :
+          .setStorageLinks(localBaseDirectory, cloudStorageDirectory, getPatternFromTool(getToolFromRuntime(runtime))) :
         await Ajax()
           .Runtimes
           .azureProxy(runtime.proxyUrl)
-          .setStorageLinks(localBaseDirectory, localSafeModeBaseDirectory, cloudStorageDirectory, getPatternFromTool(getToolFromRuntime(runtime)))
+          .setStorageLinks(localBaseDirectory, cloudStorageDirectory, getPatternFromTool(getToolFromRuntime(runtime)))
     })
 
 


### PR DESCRIPTION
The welder call for Azure file syncing doesn't require `localSafeModeBaseDirectory` since we don't really have the difference between safe mode vs edit mode on Azure...

Currently file syncing is broken, because the storagelink in welder is wrong. This should fix the bug

Tested locally
1. on Azure JupyterLab, create a notebook file and make some updates
2. Make sure the new updates are delocalized to workspace storage container

<!--
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Also, so if a screen recording [1] and/or screenshots would be a helpful way to communicate context, please consider including some in your PR description.
Thanks!

[1] https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac
--!>
