### PR TITLE
[WOR-195] Make billing project select usable with a screen reader.

### DIFF
--- a/src/components/NewWorkspaceModal.js
+++ b/src/components/NewWorkspaceModal.js
@@ -195,7 +195,7 @@ const NewWorkspaceModal = withDisplayName('NewWorkspaceModal', ({
   const destLocationType = getLocationType(bucketLocation)
 
   const onFocusAria = ({ focused, isDisabled }) => {
-    return `You are currently focused on ${isDisabled ? 'disabled ' : ''}option ${focused['aria-label']}.`
+    return `${isDisabled ? 'Disabled option ' : 'Option '}${focused['aria-label']}, focused.`
   }
 
   const onChangeAria = ({ value }) => {

--- a/src/components/NewWorkspaceModal.js
+++ b/src/components/NewWorkspaceModal.js
@@ -47,15 +47,15 @@ const constraints = {
   }
 }
 
-const getCloudContextTitle = cloudPlatform => {
+const getCloudPlatformTitle = cloudPlatform => {
   return Utils.switchCase(cloudPlatform,
     [cloudProviders.gcp.label, () => cloudProviders.gcp.iconTitle],
     [cloudProviders.azure.label, () => cloudProviders.azure.iconTitle]
   )
 }
 
-const cloudContextIcon = ({ cloudPlatform }) => {
-  const props = { title: getCloudContextTitle(cloudPlatform), role: 'img' }
+const cloudPlatformIcon = ({ cloudPlatform }) => {
+  const props = { title: getCloudPlatformTitle(cloudPlatform), role: 'img' }
 
   return div({ style: { display: 'flex', marginRight: '0.5rem' } }, [
     Utils.switchCase(cloudPlatform,
@@ -248,12 +248,12 @@ const NewWorkspaceModal = withDisplayName('NewWorkspaceModal', ({
           onChange: ({ value }) => setNamespace(value),
           styles: { option: provided => ({ ...provided, padding: 10 }) },
           options: _.map(({ projectName, invalidBillingAccount, cloudPlatform }) => ({
-            'aria-label': `${getCloudContextTitle(cloudPlatform)} ${projectName}${ariaInvalidBillingAccountMsg(invalidBillingAccount)}`,
+            'aria-label': `${getCloudPlatformTitle(cloudPlatform)} ${projectName}${ariaInvalidBillingAccountMsg(invalidBillingAccount)}`,
             label: h(TooltipTrigger, {
               content: invalidBillingAccount && invalidBillingAccountMsg, side: 'left'
             },
             [div({ style: { display: 'flex', alignItems: 'center' } },
-              [h(cloudContextIcon, { cloudPlatform, key: projectName }), projectName]
+              [h(cloudPlatformIcon, { cloudPlatform, key: projectName }), projectName]
             )]),
             value: projectName,
             isDisabled: invalidBillingAccount

--- a/src/components/NewWorkspaceModal.js
+++ b/src/components/NewWorkspaceModal.js
@@ -199,10 +199,7 @@ const NewWorkspaceModal = withDisplayName('NewWorkspaceModal', ({
   }
 
   const onChangeAria = ({ value }) => {
-    if (!value) {
-      return ''
-    }
-    return `Option ${value['aria-label']} selected.`
+    return !value ? '' : `Option ${value['aria-label']} selected.`
   }
 
   return Utils.cond(


### PR DESCRIPTION
The React Select component we use is really trying to be [accessible](https://react-select.com/advanced#accessibility). However, sometimes the very verbose aria live messaging actually makes things worse.

The default aria live messaging uses an option's label in the messages. The label for this particular Select usage is quite complicated-- an object containing an object. This leads to messages that actually render the Select unusable- you can't tell what item you are focused on, nor what is actually selected.

![image](https://user-images.githubusercontent.com/484484/191850083-ce3c50a5-8a67-493d-90fd-e16c0462f89c.png)

I have implemented custom aria live messaging for the select, simplified for the fact that this select only supports single value selection and cannot be empty (you can't deselect an item once selected).

Example:
<img width="703" alt="image" src="https://user-images.githubusercontent.com/484484/191849968-c4db13e4-c2e1-431e-9a69-6d909b2505f1.png">

I don't think we have other Selects in the codebase that are rendering complicated objects like this. If it turns out that we do, we probably want to consider generalizing this type of solution.