### PR TITLE
[WOR-528] Fix bug caused by currying swapping order of args.

### DIFF
--- a/src/libs/_tests/utils.test.js
+++ b/src/libs/_tests/utils.test.js
@@ -1,0 +1,26 @@
+import { differenceFromNowInSeconds } from 'src/libs/utils'
+
+
+beforeAll(() => {
+  jest.useFakeTimers().setSystemTime(new Date(2022, 4, 1, 12, 30, 7, 999))
+})
+
+afterAll(() => {
+  jest.useRealTimers()
+})
+
+describe('differenceFromNowInSeconds', () => {
+  it('returns the number of seconds between current time and server-formatted date', () => {
+    const workspaceDate = '2022-04-01T20:17:04.324Z'
+
+    // Month is 0-based, ms will create rounding.
+    jest.setSystemTime(new Date(Date.UTC(2022, 3, 1, 20, 17, 5, 0)))
+    expect(differenceFromNowInSeconds(workspaceDate)).toBe(0)
+
+    jest.advanceTimersByTime(3000)
+    expect(differenceFromNowInSeconds(workspaceDate)).toBe(3)
+
+    jest.advanceTimersByTime(60000)
+    expect(differenceFromNowInSeconds(workspaceDate)).toBe(63)
+  })
+})

--- a/src/libs/_tests/utils.test.js
+++ b/src/libs/_tests/utils.test.js
@@ -2,7 +2,7 @@ import { differenceFromNowInSeconds } from 'src/libs/utils'
 
 
 beforeAll(() => {
-  jest.useFakeTimers().setSystemTime(new Date(2022, 4, 1, 12, 30, 7, 999))
+  jest.useFakeTimers()
 })
 
 afterAll(() => {

--- a/src/libs/test-utils.js
+++ b/src/libs/test-utils.js
@@ -1,6 +1,0 @@
-import * as Utils from 'src/libs/utils'
-
-
-export const waitOneTickAndUpdate = wrapper => {
-  return Utils.waitOneTick().then(() => wrapper.update())
-}

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -1,5 +1,5 @@
 import { isToday, isYesterday } from 'date-fns'
-import { differenceInCalendarMonths } from 'date-fns/fp'
+import { differenceInCalendarMonths, differenceInSeconds, parseJSON } from 'date-fns/fp'
 import _ from 'lodash/fp'
 import * as qs from 'qs'
 import { div, span } from 'react-hyperscript-helpers'
@@ -65,6 +65,13 @@ export const makeCompleteDate = dateString => completeDateFormat.format(new Date
 
 export const makeCompleteDateParts = dateString => {
   return _.map(part => part.format(new Date(dateString)), completeDateFormatParts)
+}
+
+/**
+ * Returns difference in seconds between current time and supplied JSON formatted date (which is assumed to be older).
+ */
+export const differenceFromNowInSeconds = jsonDateString => {
+  return differenceInSeconds(parseJSON(jsonDateString), Date.now())
 }
 
 const usdFormatter = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' })

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -1,4 +1,3 @@
-import { differenceInSeconds, parseJSON } from 'date-fns/fp'
 import _ from 'lodash/fp'
 import { Fragment, useRef, useState } from 'react'
 import { br, div, h, h2, p, span } from 'react-hyperscript-helpers'
@@ -20,6 +19,7 @@ import { clearNotification, notify } from 'src/libs/notifications'
 import { useCancellation, useOnMount, usePrevious, useStore, withDisplayName } from 'src/libs/react-utils'
 import { workspaceStore } from 'src/libs/state'
 import * as Style from 'src/libs/style'
+import { differenceFromNowInSeconds } from 'src/libs/utils'
 import * as Utils from 'src/libs/utils'
 import { ContextBar } from 'src/pages/workspaces/workspace/analysis/ContextBar'
 import { tools } from 'src/pages/workspaces/workspace/analysis/notebook-utils'
@@ -362,7 +362,7 @@ export const wrapWorkspace = ({ breadcrumbs, activeTab, title, topBarContent, sh
           saToken(googleProject)
         }
 
-        if (!Utils.isOwner(accessLevel) && (createdBy === getUser().email) && (differenceInSeconds(Date.now(), parseJSON(createdDate)) < 60)) {
+        if (!Utils.isOwner(accessLevel) && (createdBy === getUser().email) && (differenceFromNowInSeconds(createdDate) < 60)) {
           accessNotificationId.current = notify('info', 'Workspace access synchronizing', {
             message: h(Fragment, [
               'It looks like you just created this workspace. It may take up to a minute before you have access to modify it. Refresh at any time to re-check.',


### PR DESCRIPTION
This is one of those really confusing cases where one reads the documentation but has to realize that the order of arguments will actually be swapped. Having a unit test is really critical to understanding/documenting what is going on.

For reproduction steps of bug, see https://broadworkbench.atlassian.net/browse/WOR-528. Basically,

1. Create a workspace.
2. Assign a second owner to it.
3. Log in as second owner and demote original owner to reader.
4. Log in as the original owner/reader and view the workspace.

On dev you will end up with this dialog which never goes away because the difference in seconds is always negative:

![image](https://user-images.githubusercontent.com/484484/192351167-1b9ed3b7-062e-4e8b-af25-38cc3f682d18.png)

I'm not sure how to reproduce the [situation that the dialog is trying to cover](https://github.com/DataBiosphere/terra-ui/pull/1754)… I tried creating a workspace in one tab and quickly trying to view it in a second tab so that the dialog would briefly display, but I couldn't get the timing right.


