### PR TITLE
AJ-586: feature flag for WDS

### DIFF
--- a/src/libs/feature-previews-config.js
+++ b/src/libs/feature-previews-config.js
@@ -12,6 +12,13 @@ const featurePreviewsConfig = [
     description: 'Enabling this feature will allow you to view information about the workflow that generated data table columns and files.',
     groups: ['preview-data-versioning-and-provenance'],
     feedbackUrl: `mailto:dsp-sue@broadinstitute.org?subject=${encodeURIComponent(`Feedback on data table provenance`)}`
+  },
+  {
+    id: 'workspace-data-service',
+    title: 'Workspace Data Service (WDS) on Azure',
+    description: 'Enabling this feature will enable WDS-powered data tables.',
+    groups: ['preview-wds-on-azure'],
+    feedbackUrl: `mailto:dsp-analysis-journeys@broadinstitute.org?subject=${encodeURIComponent(`Feedback on WDS UI`)}`
   }
 ]
 

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -700,6 +700,18 @@ const WorkspaceData = _.flow(
                 ])
               }, sortedEntityPairs)
             ]),
+            isFeaturePreviewEnabled('workspace-data-service') && h(DataTypeSection, {
+              title: 'WDS'
+            }, [
+              div({
+                style: {
+                  display: 'flex', flexDirection: 'column', alignItems: 'flex-start',
+                  padding: '0.5rem 1.5rem', borderBottom: `1px solid ${colors.dark(0.2)}`,
+                  backgroundColor: 'white'
+                }
+              }, ['Coming soon.']),
+              div({}, '')
+            ]),
             (!_.isEmpty(sortedSnapshotPairs) || snapshotMetadataError) && h(DataTypeSection, {
               title: 'Snapshots',
               error: snapshotMetadataError,


### PR DESCRIPTION
Scope of this PR is to:
1. Create a feature flag, available at #feature-preview, to control WDS data tables
2. Show a visual indication if the feature flag is enabled

Out of scope for this PR is any actual connection to WDS. We're not displaying any real WDS data; this PR is simply about the feature flag.

Feature flag:
![Screenshot 9-27-2022 at 03 44 PM (1)](https://user-images.githubusercontent.com/6041577/192621458-172d797c-ea75-4c36-a2e2-1064fc417180.png)

with flag disabled (no changes compared to current UI):
![Screenshot 9-27-2022 at 03 44 PM (2)](https://user-images.githubusercontent.com/6041577/192621513-17fcfcf2-c99e-4c1f-b4c0-f4d35923e5ee.png)

with flag enabled:
![Screenshot 9-27-2022 at 03 44 PM](https://user-images.githubusercontent.com/6041577/192621539-b4b9c684-5a31-4e46-9c41-397e4cb68e04.png)

