### PR TITLE
[IA-2944] Contrast for buttons in cloud environments page

### DIFF
--- a/src/components/PopupTrigger.js
+++ b/src/components/PopupTrigger.js
@@ -113,7 +113,7 @@ export const InfoBox = ({ size, children, style, side, tooltip, iconOverride }) 
 }
 
 export const makeMenuIcon = (iconName, props) => {
-  return icon(iconName, _.merge({ size: 15, style: { marginRight: '.5rem' } }, props))
+  return icon(iconName, _.merge({ size: 15, style: { marginRight: '.3rem' } }, props))
 }
 
 export const MenuButton = forwardRefWithName('MenuButton', ({ disabled, children, ...props }, ref) => {

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -92,8 +92,8 @@ export const Clickable = forwardRefWithName('Clickable',
 export const Link = forwardRefWithName('Link', ({ disabled, variant, children, baseColor = colors.accent, ...props }, ref) => {
   return h(Clickable, _.merge({
     ref,
-    style: { // Note: 0.72 is the min to meet ANDI's contrast requirement
-      color: disabled ? colors.disabled(0.5) : baseColor(variant === 'light' ? 0.3 : 1),
+    style: {
+      color: disabled ? colors.disabled() : baseColor(variant === 'light' ? 0.3 : 1),
       cursor: disabled ? 'not-allowed' : 'pointer',
       fontWeight: 500, display: 'inline'
     },

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -92,8 +92,8 @@ export const Clickable = forwardRefWithName('Clickable',
 export const Link = forwardRefWithName('Link', ({ disabled, variant, children, baseColor = colors.accent, ...props }, ref) => {
   return h(Clickable, _.merge({
     ref,
-    style: { // 0.72 is the min to meet ANDI's contrast requirement
-      color: disabled ? colors.dark(0.72) : baseColor(variant === 'light' ? 0.3 : 1),
+    style: { // Note: 0.72 is the min to meet ANDI's contrast requirement
+      color: disabled ? colors.dark(0.5) : baseColor(variant === 'light' ? 0.3 : 1),
       cursor: disabled ? 'not-allowed' : 'pointer',
       fontWeight: 500, display: 'inline'
     },

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -93,7 +93,7 @@ export const Link = forwardRefWithName('Link', ({ disabled, variant, children, b
   return h(Clickable, _.merge({
     ref,
     style: { // Note: 0.72 is the min to meet ANDI's contrast requirement
-      color: disabled ? colors.dark(0.5) : baseColor(variant === 'light' ? 0.3 : 1),
+      color: disabled ? colors.disabled(0.5) : baseColor(variant === 'light' ? 0.3 : 1),
       cursor: disabled ? 'not-allowed' : 'pointer',
       fontWeight: 500, display: 'inline'
     },

--- a/src/libs/colors.js
+++ b/src/libs/colors.js
@@ -6,7 +6,7 @@ import {
 import * as Utils from 'src/libs/utils'
 
 
-const ALL_COLORS = ['primary', 'secondary', 'accent', 'success', 'warning', 'danger', 'light', 'dark', 'grey']
+const ALL_COLORS = ['primary', 'secondary', 'accent', 'success', 'warning', 'danger', 'light', 'dark', 'grey', 'disabled']
 
 const baseColors = {
   primary: '#4d72aa', // Used as accent on header, loading spinner, background of beta version tag and some buttons
@@ -17,7 +17,8 @@ const baseColors = {
   danger: '#db3214',
   light: '#e9ecef', // Used as header background color, lightened for background of cells, panels, etc.
   dark: '#333f52', // Used as text color, menu background (lightened), selected background (lightened)
-  grey: '#808080'
+  grey: '#808080',
+  disabled: '#6d6e70'
 }
 
 const colorPalette = Utils.cond(

--- a/src/libs/colors.js
+++ b/src/libs/colors.js
@@ -18,7 +18,7 @@ const baseColors = {
   light: '#e9ecef', // Used as header background color, lightened for background of cells, panels, etc.
   dark: '#333f52', // Used as text color, menu background (lightened), selected background (lightened)
   grey: '#808080',
-  disabled: '#6d6e70'
+  disabled: '#6d6e70' //Used for disabled components at a 0.5 opacity.
 }
 
 const colorPalette = Utils.cond(

--- a/src/libs/colors.js
+++ b/src/libs/colors.js
@@ -18,7 +18,7 @@ const baseColors = {
   light: '#e9ecef', // Used as header background color, lightened for background of cells, panels, etc.
   dark: '#333f52', // Used as text color, menu background (lightened), selected background (lightened)
   grey: '#808080',
-  disabled: '#b6b7b8' //Used for disabled components at a 0.5 opacity.
+  disabled: '#b6b7b8'
 }
 
 const colorPalette = Utils.cond(

--- a/src/libs/colors.js
+++ b/src/libs/colors.js
@@ -18,7 +18,7 @@ const baseColors = {
   light: '#e9ecef', // Used as header background color, lightened for background of cells, panels, etc.
   dark: '#333f52', // Used as text color, menu background (lightened), selected background (lightened)
   grey: '#808080',
-  disabled: '#6d6e70' //Used for disabled components at a 0.5 opacity.
+  disabled: '#b6b7b8' //Used for disabled components at a 0.5 opacity.
 }
 
 const colorPalette = Utils.cond(


### PR DESCRIPTION
Jira Ticket
https://broadworkbench.atlassian.net/browse/IA-2944

## Description

The colors for the buttons in the cloud environments page were too similar. A disabled button vs an enabled button was not easy enough to distinguish.

## Implementation

The UX team explicitly mentions using the color #6D6E70 at 50% opacity to portray a disabled button.
While we use #6D6E70 as color.secondary, that will not be true for other themes. Additionally, colors.dark was used for this disabled state, however, changing colors.dark to #6D6E70 would have widespread color changes across the application.

This is why I decided to add another property in colors.js that is "disabled" since it seems that would be the universal starting color for disabled elements.

Old colors
![Screen Shot 2022-10-03 at 10 10 26 AM](https://user-images.githubusercontent.com/11773357/193598965-053406e1-e6ef-4b95-8a17-4c2867dec549.png)

New colors
![Screen Shot 2022-10-03 at 10 10 54 AM](https://user-images.githubusercontent.com/11773357/193598961-faebb76b-08d1-4504-953f-4a4e2a856a3c.png)


