### PR TITLE
[IA-3754] Azure stop/start

### DIFF
--- a/src/libs/ajax/Runtimes.js
+++ b/src/libs/ajax/Runtimes.js
@@ -5,22 +5,8 @@ import { appIdentifier, authOpts, fetchLeo, fetchOk, jsonBody } from 'src/libs/a
 import { getConfig } from 'src/libs/config'
 
 
-export const Runtimes = signal => ({
-  list: async (labels = {}) => {
-    const res = await fetchLeo(`api/google/v1/runtimes?${qs.stringify({ saturnAutoCreated: true, ...labels })}`,
-      _.mergeAll([authOpts(), appIdentifier, { signal }]))
-    return res.json()
-  },
-
-  invalidateCookie: () => {
-    return fetchLeo('proxy/invalidateToken', _.merge(authOpts(), { signal }))
-  },
-
-  setCookie: () => {
-    return fetchLeo('proxy/setCookie', _.merge(authOpts(), { signal, credentials: 'include' }))
-  },
-
-  runtime: (project, name) => {
+export const Runtimes = signal => {
+  const v1Func = (project, name) => {
     const root = `api/google/v1/runtimes/${project}/${name}`
 
     return {
@@ -66,42 +52,13 @@ export const Runtimes = signal => ({
           _.mergeAll([authOpts(), { signal, method: 'DELETE' }, appIdentifier]))
       }
     }
-  },
+  }
 
-  azureProxy: proxyUrl => {
-    return {
-      setAzureCookie: () => {
-        return fetchOk(`${proxyUrl}/setCookie`, _.merge(authOpts(), { signal, credentials: 'include' }))
-      },
-
-      setStorageLinks: (localBaseDirectory, cloudStorageDirectory, pattern) => {
-        return fetchOk(`${proxyUrl}/welder/storageLinks`,
-          _.mergeAll([authOpts(), jsonBody({
-            localBaseDirectory,
-            cloudStorageDirectory,
-            pattern
-          }), { signal, method: 'POST' }]))
-      }
-    }
-  },
-
-  listV2: async (labels = {}) => {
-    const res = await fetchLeo(`api/v2/runtimes?${qs.stringify({ saturnAutoCreated: true, ...labels })}`,
-      _.mergeAll([authOpts(), appIdentifier, { signal }]))
-    return res.json()
-  },
-
-  listV2WithWorkspace: async (workspaceId, labels = {}) => {
-    const res = await fetchLeo(`api/v2/runtimes/${workspaceId}?${qs.stringify({ saturnAutoCreated: true, ...labels })}`,
-      _.mergeAll([authOpts(), appIdentifier, { signal }]))
-    return res.json()
-  },
-
-  runtimeV2: (workspaceId, name, cloudProvider = 'azure') => {
+  const v2Func = (workspaceId, name, cloudProvider = 'azure') => {
     const root = `api/v2/runtimes/${workspaceId}/${cloudProvider}/${name}`
+    const noCloudProviderRoot = `api/v2/runtimes/${workspaceId}/${name}`
 
     return {
-
       details: async () => {
         const res = await fetchLeo(root, _.mergeAll([authOpts(), { signal }, appIdentifier]))
         return res.json()
@@ -117,47 +74,122 @@ export const Runtimes = signal => ({
       delete: (deleteDisk = true) => {
         return fetchLeo(`${root}${qs.stringify({ deleteDisk }, { addQueryPrefix: true })}`,
           _.mergeAll([authOpts(), { signal, method: 'DELETE' }, appIdentifier]))
+      },
+
+      start: () => {
+        return fetchLeo(`${noCloudProviderRoot}/start`, _.mergeAll([authOpts(), { signal, method: 'POST' }, appIdentifier]))
+      },
+
+      stop: () => {
+        return fetchLeo(`${noCloudProviderRoot}/stop`, _.mergeAll([authOpts(), { signal, method: 'POST' }, appIdentifier]))
       }
     }
-  },
+  }
 
-  fileSyncing: (project, name) => {
-    const root = `proxy/${project}/${name}`
+  return ({
+    list: async (labels = {}) => {
+      const res = await fetchLeo(`api/google/v1/runtimes?${qs.stringify({ saturnAutoCreated: true, ...labels })}`,
+        _.mergeAll([authOpts(), appIdentifier, { signal }]))
+      return res.json()
+    },
 
-    return {
-      oldLocalize: files => {
-        return fetchLeo(`notebooks/${project}/${name}/api/localize`, // this is the old root url
-          _.mergeAll([authOpts(), jsonBody(files), { signal, method: 'POST' }]))
-      },
+    invalidateCookie: () => {
+      return fetchLeo('proxy/invalidateToken', _.merge(authOpts(), { signal }))
+    },
 
-      localize: entries => {
-        const body = { action: 'localize', entries }
-        return fetchLeo(`${root}/welder/objects`,
-          _.mergeAll([authOpts(), jsonBody(body), { signal, method: 'POST' }]))
-      },
+    setCookie: () => {
+      return fetchLeo('proxy/setCookie', _.merge(authOpts(), { signal, credentials: 'include' }))
+    },
 
-      setStorageLinks: (localBaseDirectory, localSafeModeBaseDirectory, cloudStorageDirectory, pattern) => {
-        return fetchLeo(`${root}/welder/storageLinks`,
-          _.mergeAll([authOpts(), jsonBody({
-            localBaseDirectory,
-            localSafeModeBaseDirectory,
-            cloudStorageDirectory,
-            pattern
-          }), { signal, method: 'POST' }]))
-      },
+    runtime: v1Func,
 
-      lock: async localPath => {
-        try {
-          await fetchLeo(`${root}/welder/objects/lock`, _.mergeAll([authOpts(), jsonBody({ localPath }), { signal, method: 'POST' }]))
-          return true
-        } catch (error) {
-          if (error.status === 409) {
-            return false
-          } else {
-            throw error
+    azureProxy: proxyUrl => {
+      return {
+        setAzureCookie: () => {
+          return fetchOk(`${proxyUrl}/setCookie`, _.merge(authOpts(), { signal, credentials: 'include' }))
+        },
+
+        setStorageLinks: (localBaseDirectory, cloudStorageDirectory, pattern) => {
+          return fetchOk(`${proxyUrl}/welder/storageLinks`,
+            _.mergeAll([authOpts(), jsonBody({
+              localBaseDirectory,
+              cloudStorageDirectory,
+              pattern
+            }), { signal, method: 'POST' }]))
+        }
+      }
+    },
+
+    listV2: async (labels = {}) => {
+      const res = await fetchLeo(`api/v2/runtimes?${qs.stringify({ saturnAutoCreated: true, ...labels })}`,
+        _.mergeAll([authOpts(), appIdentifier, { signal }]))
+      return res.json()
+    },
+
+    listV2WithWorkspace: async (workspaceId, labels = {}) => {
+      const res = await fetchLeo(`api/v2/runtimes/${workspaceId}?${qs.stringify({ saturnAutoCreated: true, ...labels })}`,
+        _.mergeAll([authOpts(), appIdentifier, { signal }]))
+      return res.json()
+    },
+
+    runtimeV2: v2Func,
+
+    runtimeWrapper: ({ googleProject, runtimeName, workspaceId }) => {
+      return {
+        stop: () => {
+          const stopFunc = !!workspaceId ?
+            () => v2Func(workspaceId, runtimeName).stop() :
+            () => v1Func(googleProject, runtimeName).stop()
+          return stopFunc()
+        },
+
+        start: () => {
+          const startFunc = !!workspaceId ?
+            () => v2Func(workspaceId, runtimeName).start() :
+            () => v1Func(googleProject, runtimeName).start()
+          return startFunc()
+        }
+      }
+    },
+
+    fileSyncing: (project, name) => {
+      const root = `proxy/${project}/${name}`
+
+      return {
+        oldLocalize: files => {
+          return fetchLeo(`notebooks/${project}/${name}/api/localize`, // this is the old root url
+            _.mergeAll([authOpts(), jsonBody(files), { signal, method: 'POST' }]))
+        },
+
+        localize: entries => {
+          const body = { action: 'localize', entries }
+          return fetchLeo(`${root}/welder/objects`,
+            _.mergeAll([authOpts(), jsonBody(body), { signal, method: 'POST' }]))
+        },
+
+        setStorageLinks: (localBaseDirectory, localSafeModeBaseDirectory, cloudStorageDirectory, pattern) => {
+          return fetchLeo(`${root}/welder/storageLinks`,
+            _.mergeAll([authOpts(), jsonBody({
+              localBaseDirectory,
+              localSafeModeBaseDirectory,
+              cloudStorageDirectory,
+              pattern
+            }), { signal, method: 'POST' }]))
+        },
+
+        lock: async localPath => {
+          try {
+            await fetchLeo(`${root}/welder/objects/lock`, _.mergeAll([authOpts(), jsonBody({ localPath }), { signal, method: 'POST' }]))
+            return true
+          } catch (error) {
+            if (error.status === 409) {
+              return false
+            } else {
+              throw error
+            }
           }
         }
       }
     }
-  }
-})
+  })
+}

--- a/src/libs/ajax/Runtimes.test.js
+++ b/src/libs/ajax/Runtimes.test.js
@@ -1,0 +1,50 @@
+import '@testing-library/jest-dom'
+
+import { authOpts, fetchLeo } from 'src/libs/ajax/ajax-common'
+import { Runtimes } from 'src/libs/ajax/Runtimes'
+
+
+jest.mock('src/libs/ajax/ajax-common', () => ({
+  fetchLeo: jest.fn(),
+  authOpts: jest.fn()
+}))
+
+describe('Runtimes ajax', () => {
+  const mockFetchLeo = jest.fn()
+  beforeEach(() => {
+    fetchLeo.mockImplementation(mockFetchLeo)
+    authOpts.mockImplementation(jest.fn())
+  })
+
+  it.each([
+    { googleProject: 'test', runtimeName: 'runtime1', workspaceId: undefined },
+    { googleProject: undefined, runtimeName: 'runtime2', workspaceId: 'test' }
+  ])('should call the appropriate leo version API for stop function based on the runtime workspaceId: ($workspaceId)', async runtime => {
+    // Arrange
+    // Act
+    await Runtimes().runtimeWrapper(runtime).stop()
+
+    // Assert
+    if (runtime.workspaceId) {
+      expect(mockFetchLeo).toHaveBeenCalledWith(`api/v2/runtimes/${runtime.workspaceId}/${runtime.runtimeName}/stop`, expect.anything())
+    } else {
+      expect(mockFetchLeo).toHaveBeenCalledWith(`api/google/v1/runtimes/${runtime.googleProject}/${runtime.runtimeName}/stop`, expect.anything())
+    }
+  })
+
+  it.each([
+    { googleProject: 'test', runtimeName: 'runtime1', workspaceId: undefined },
+    { googleProject: undefined, runtimeName: 'runtime2', workspaceId: 'test' }
+  ])('should call the appropriate leo version API for start function based on the runtime workspaceId: ($workspaceId)', async runtime => {
+    // Arrange
+    // Act
+    await Runtimes().runtimeWrapper(runtime).start()
+
+    // Assert
+    if (runtime.workspaceId) {
+      expect(mockFetchLeo).toHaveBeenCalledWith(`api/v2/runtimes/${runtime.workspaceId}/${runtime.runtimeName}/start`, expect.anything())
+    } else {
+      expect(mockFetchLeo).toHaveBeenCalledWith(`api/google/v1/runtimes/${runtime.googleProject}/${runtime.runtimeName}/start`, expect.anything())
+    }
+  })
+})

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -364,7 +364,7 @@ const Environments = () => {
 
   const pauseComputeAndRefresh = Utils.withBusyState(setLoading, async (computeType, compute) => {
     const wrappedPauseCompute = withErrorReporting('Error pausing compute', () => computeType === 'runtime' ?
-      Ajax().Runtimes.runtime(compute.googleProject, compute.runtimeName).stop() :
+      Ajax().Runtimes.runtimeWrapper(compute).stop() :
       Ajax().Apps.app(compute.googleProject, compute.appName).pause())
     await wrappedPauseCompute()
     await loadData()

--- a/src/pages/workspaces/workspace/analysis/AnalysisLauncher.js
+++ b/src/pages/workspaces/workspace/analysis/AnalysisLauncher.js
@@ -12,7 +12,7 @@ import { makeMenuIcon, MenuButton, MenuTrigger } from 'src/components/PopupTrigg
 import { dataSyncingDocUrl } from 'src/data/machines'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
-import { reportError, withErrorReporting } from 'src/libs/error'
+import { withErrorReporting } from 'src/libs/error'
 import Events from 'src/libs/events'
 import * as Nav from 'src/libs/nav'
 import { notify } from 'src/libs/notifications'
@@ -248,18 +248,10 @@ const PreviewHeader = ({
     }
   })
 
-  const startAndRefresh = async (refreshRuntimes, runtime) => {
-    try {
-      if (!!googleProject) {
-        await Ajax().Runtimes.runtime(googleProject, runtime.runtimeName).start()
-      } else {
-        //TODO start for azure
-      }
-      await refreshRuntimes(true)
-    } catch (error) {
-      reportError('Cloud Environment Error', error)
-    }
-  }
+  const startAndRefresh = withErrorReporting('Error starting compute', async (refreshRuntimes, runtime) => {
+    await Ajax().Runtimes.runtimeWrapper(runtime).start()
+    await refreshRuntimes(true)
+  })
 
   useOnMount(() => {
     if (!!googleProject) {

--- a/src/pages/workspaces/workspace/analysis/ContextBar.test.js
+++ b/src/pages/workspaces/workspace/analysis/ContextBar.test.js
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom'
 
 import { fireEvent, render } from '@testing-library/react'
+import { act } from 'react-dom/test-utils'
 import { div, h } from 'react-hyperscript-helpers'
 import { MenuTrigger } from 'src/components/PopupTrigger'
 import { Ajax } from 'src/libs/ajax'
@@ -523,7 +524,7 @@ describe('ContextBar - actions', () => {
     getByText(tools.RStudio.label)
   })
 
-  it('clicking Terminal will attempt to start currently stopped runtime', () => {
+  it('clicking Terminal will attempt to start currently stopped runtime', async () => {
     // Arrange
     const mockRuntimesStartFn = jest.fn()
     const mockRuntimeWrapper = jest.fn(() => ({
@@ -559,8 +560,11 @@ describe('ContextBar - actions', () => {
     }
 
     // Act
-    const { getByTestId } = render(h(ContextBar, jupyterContextBarProps))
-    fireEvent.click(getByTestId('terminal-button-id'))
+    await act(async () => {
+      const { getByTestId } = render(h(ContextBar, jupyterContextBarProps))
+      await fireEvent.click(getByTestId('terminal-button-id'))
+    })
+
 
     // Assert
     expect(mockRuntimeWrapper).toHaveBeenCalledWith(expect.objectContaining({

--- a/src/pages/workspaces/workspace/analysis/ContextBar.test.js
+++ b/src/pages/workspaces/workspace/analysis/ContextBar.test.js
@@ -523,7 +523,7 @@ describe('ContextBar - actions', () => {
     getByText(tools.RStudio.label)
   })
 
-  it('clicking Terminal will attempt to start currently stopped runtime', async () => {
+  it('clicking Terminal will attempt to start currently stopped runtime', () => {
     // Arrange
     const mockRuntimesStartFn = jest.fn()
     const mockRuntimeWrapper = jest.fn(() => ({
@@ -571,7 +571,7 @@ describe('ContextBar - actions', () => {
     expect(mockRuntimesStartFn).toHaveBeenCalled()
   })
 
-  it('clicking Terminal will not attempt to start an already running Jupyter notebook', async () => {
+  it('clicking Terminal will not attempt to start an already running Jupyter notebook', () => {
     // Arrange
     const mockRuntimesStartFn = jest.fn()
     const mockRuntimeWrapper = jest.fn(() => ({

--- a/src/pages/workspaces/workspace/analysis/modals/CloudEnvironmentModal.js
+++ b/src/pages/workspaces/workspace/analysis/modals/CloudEnvironmentModal.js
@@ -155,17 +155,15 @@ export const CloudEnvironmentModal = ({
     executeAndRefresh(toolLabel,
       Ajax().Apps.app(cloudContext.cloudResource, appName).resume())
   }], [Utils.DEFAULT, () => {
-    const { googleProject, runtimeName } = currentRuntime
     executeAndRefresh(toolLabel,
-      Ajax().Runtimes.runtime(googleProject, runtimeName).start())
+      Ajax().Runtimes.runtimeWrapper(currentRuntime).start())
   }])
 
   const stopApp = toolLabel => Utils.cond([isToolAnApp(toolLabel), () => {
     const { appName, cloudContext } = currentApp(toolLabel)
     executeAndRefresh(toolLabel, Ajax().Apps.app(cloudContext.cloudResource, appName).pause())
   }], [Utils.DEFAULT, () => {
-    const { googleProject, runtimeName } = currentRuntime
-    executeAndRefresh(toolLabel, Ajax().Runtimes.runtime(googleProject, runtimeName).stop())
+    executeAndRefresh(toolLabel, Ajax().Runtimes.runtimeWrapper(currentRuntime).stop())
   }])
 
   const defaultIcon = toolLabel => isPauseSupported(toolLabel) && h(RuntimeIcon, {

--- a/src/pages/workspaces/workspace/analysis/notebook-utils.js
+++ b/src/pages/workspaces/workspace/analysis/notebook-utils.js
@@ -79,7 +79,7 @@ export const tools = {
   spark: { label: 'spark' },
   Galaxy: { label: 'Galaxy', appType: 'GALAXY' },
   Cromwell: { label: 'Cromwell', appType: 'CROMWELL', isAppHidden: !isCromwellAppVisible(), isPauseUnsupported: true },
-  Azure: { label: 'Azure', isNotebook: true, ext: ['ipynb'], isAzureCompatible: true, isPauseUnsupported: true, isLaunchUnsupported: false, defaultExt: 'ipynb' }
+  Azure: { label: 'Azure', isNotebook: true, ext: ['ipynb'], isAzureCompatible: true, isLaunchUnsupported: false, defaultExt: 'ipynb' }
 }
 
 export const toolExtensionDisplay = {


### PR DESCRIPTION
This PR looks a lot more complex than it is. All it does is add azure stop/start and add a wrapper that takes the runtime and determines whether the v1/v2 stop endpoint should be called.

This proves quite problematic to test with jest, as the v1/v2 functions are not exposed directly (and exposing them directly raises its own problems). This will be tested fully when we get to testing `CloudEnvironmentModal`, but I'm choosing to prioritize other testing tickets I have around adding typescript tests instead of adding more non-typescript tests at the moment.  