### PR TITLE
reassign a few integration tests to different teams

### DIFF
--- a/integration-tests/slack/slack-notify-channels.json
+++ b/integration-tests/slack/slack-notify-channels.json
@@ -79,6 +79,12 @@
         },
         {
           "name": "link-to-new-workspace"
+        },
+        {
+          "name": "import-cohort-data"
+        },
+        {
+          "name": "request-access"
         }
       ]
     },
@@ -102,7 +108,7 @@
           "name": "import-cohort-data"
         },
         {
-          "name": "request-access"
+          "name": "run-workflow-on-snapshot"
         }
       ]
     }


### PR DESCRIPTION
1. `request-access` moves from AJ to Explorer (it remains with Identiteam as shared ownership)
2. `run-workflow-on-snapshot` was previously Batch only; it is now shared Batch and AJ
3. `import-cohort-data` was previously AJ only; it is now shared Explorer and AJ

This PR addresses a few ownership issues that I noticed. It does not attempt to resolve any/all ownership issues. We can make future PRs for any other changes.
