### PR TITLE
[PE-12] RARE-X library card links to a public workspace instead

### DIFF
--- a/src/pages/library/Datasets.js
+++ b/src/pages/library/Datasets.js
@@ -436,10 +436,10 @@ const rareX = () => h(Participant, {
 }, [
   h(ButtonPrimary, {
     'aria-label': 'Request access to RareX data',
-    tooltip: 'View access request form',
-    href: 'https://docs.google.com/forms/d/e/1FAIpQLScpqfZIXW53IJOiYz2RhASJzm7lZBYAjzkjJ67qFDERUpuDAQ/viewform',
+    tooltip: 'View workspace with details',
+    href: 'https://rare-x.terra.bio/#workspaces/Rare-x-Terra-Billing/RARE-X',
     onClick: () => captureBrowseDataEvent('RARE-X')
-  }, ['Request Access'])
+  }, ['Browse Data'])
 ])
 
 const Datasets = () => {

--- a/src/pages/library/Datasets.js
+++ b/src/pages/library/Datasets.js
@@ -436,7 +436,7 @@ const rareX = () => h(Participant, {
 }, [
   h(ButtonPrimary, {
     'aria-label': 'Request access to RareX data',
-    tooltip: 'View workspace with details',
+    tooltip: 'View details on data and request access',
     href: 'https://rare-x.terra.bio/#workspaces/Rare-x-Terra-Billing/RARE-X',
     onClick: () => captureBrowseDataEvent('RARE-X')
   }, ['Browse Data'])


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/PE-12

Reverts some of #3374 and changes the linked URL as per the changing requirements from the collaborators.

## Before:

![image](https://user-images.githubusercontent.com/5438223/193143978-17f9d33c-a908-4e0d-8e13-857396767015.png)

## After:

![image](https://user-images.githubusercontent.com/5438223/193144299-380fd58b-adc2-4824-9ac6-7f4df7fe3447.png)
