### PR TITLE
[SU-221] Fix converting attribute values between reference types

### DIFF
--- a/src/components/data/attribute-utils.js
+++ b/src/components/data/attribute-utils.js
@@ -25,7 +25,11 @@ export const convertAttributeValue = (attributeValue, newType, referenceEntityTy
   }
 
   const { type, isList } = getAttributeType(attributeValue)
-  if (type === newType) {
+
+  const isNoop = type === 'reference' ?
+    newType === 'reference' && referenceEntityType === attributeValue.entityType :
+    newType === type
+  if (isNoop) {
     return attributeValue
   }
 

--- a/src/components/data/attribute-utils.test.js
+++ b/src/components/data/attribute-utils.test.js
@@ -71,6 +71,10 @@ describe('convertAttributeValue', () => {
     expect(() => convertAttributeValue('thing_one', 'reference')).toThrowError()
   })
 
+  it('changes referenced entity type', () => {
+    expect(convertAttributeValue({ entityType: 'thing', entityName: 'thing_one' }, 'reference', 'other_thing')).toEqual({ entityType: 'other_thing', entityName: 'thing_one' })
+  })
+
   it('converts each value of lists', () => {
     expect(convertAttributeValue({ items: ['42', 'value'], itemsType: 'AttributeValue' }, 'number')).toEqual({ items: [42, 0], itemsType: 'AttributeValue' })
 


### PR DESCRIPTION
Currently, the referenced entity type can't be changed for references in data tables.

This is because `convertAttributeValue` returns early if the attribute value is already of the target type, which doesn't take into account references to different entity types.

## Before
https://user-images.githubusercontent.com/1156625/193589413-a4210f20-7b70-4f2d-9df9-5ce9b7bcbbd3.mov

## After
https://user-images.githubusercontent.com/1156625/193589429-d7aad66d-28a8-4533-9235-9ffcf2cfe348.mov

