### PR TITLE
WOR-518: remove cloud platform workaround

### DIFF
--- a/src/pages/billing/List.js
+++ b/src/pages/billing/List.js
@@ -330,15 +330,8 @@ export const BillingList = ({ queryParams: { selectedName } }) => {
     Utils.withBusyState(setIsLoadingProjects)
   )(async ({ projectName }) => {
     const index = _.findIndex({ projectName }, billingProjects)
-    // Workaround until getProject has the correct cloudPlatform and managed app coordinates populated, WOR-518
-    const cloudPlatform = billingProjects[index].cloudPlatform
-    const managedAppCoordinates = billingProjects[index].managedAppCoordinates
     // fetch the project to error if it doesn't exist/user can't access
     const project = await Ajax(signal).Billing.getProject(selectedName)
-    project.cloudPlatform = cloudPlatform
-    if (!!managedAppCoordinates) {
-      project.managedAppCoordinates = managedAppCoordinates
-    }
     setBillingProjects(_.set([index], project))
   })
 


### PR DESCRIPTION
[WOR-518](https://broadworkbench.atlassian.net/browse/WOR-518)

Tested locally in browser by looking at billing account details, causing the billing project to be refreshed.

