### PR TITLE
[SU-215] Version related set tables with tables

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "preinstall": "node .hooks/check-engine-light.js",
     "setenv": "echo REACT_APP_VERSION=$(git rev-parse HEAD) REACT_APP_BUILD_TIMESTAMP=$(date -u \"+%s000\")",
     "start": "env $(yarn setenv) react-app-rewired start",
-    "test": "react-app-rewired test",
+    "test": "TZ=UTC react-app-rewired test",
     "check-types": "check-dts types/**/*.ts",
     "postinstall": "husky install"
   },

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -581,6 +581,7 @@ export const DeleteConfirmationModal = ({
     ]),
     onDismiss,
     okButton: h(ButtonPrimary, {
+      'data-testid': 'confirm-delete',
       onClick: onConfirm,
       disabled: !isConfirmed,
       tooltip: isConfirmed ? undefined : 'You must type the confirmation message'

--- a/src/components/data/data-table-versions.js
+++ b/src/components/data/data-table-versions.js
@@ -1,50 +1,16 @@
 import _ from 'lodash/fp'
-import { Fragment, useEffect, useState } from 'react'
+import { Fragment, useState } from 'react'
 import { div, fieldset, h, h1, legend, li, ol, p, span, ul } from 'react-hyperscript-helpers'
 import { ButtonPrimary, ButtonSecondary, DeleteConfirmationModal, IdContainer, LabeledCheckbox, spinnerOverlay } from 'src/components/common'
-import { parseGsUri } from 'src/components/data/data-utils'
-import { icon, spinner } from 'src/components/icons'
+import { spinner } from 'src/components/icons'
 import { TextInput } from 'src/components/input'
 import Modal from 'src/components/Modal'
-import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { tableNameForRestore } from 'src/libs/data-table-versions'
 import { FormLabel } from 'src/libs/forms'
-import { useCancellation } from 'src/libs/react-utils'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 
-
-const DownloadVersionButton = ({ url }) => {
-  const signal = useCancellation()
-  const [downloadUrl, setDownloadUrl] = useState()
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState(false)
-
-  useEffect(() => {
-    const loadUrl = Utils.withBusyState(setLoading, async () => {
-      try {
-        setDownloadUrl(null)
-        setError(false)
-        const [bucket, object] = parseGsUri(url)
-        const { url: signedUrl } = await Ajax(signal).DrsUriResolver.getSignedUrl({ bucket, object })
-        setDownloadUrl(signedUrl)
-      } catch (error) {
-        setError(true)
-      }
-    })
-    loadUrl()
-  }, [signal, url])
-
-  return h(ButtonPrimary, {
-    disabled: !downloadUrl,
-    href: downloadUrl,
-    tooltip: !!error && 'Error generating download URL'
-  }, [
-    loading && icon('loadingSpinner', { size: 12, style: { marginRight: '1ch' } }),
-    'Download'
-  ])
-}
 
 export const DataTableVersion = ({ version, onDelete, onRestore }) => {
   const { entityType, includedSetEntityTypes, timestamp, description } = version
@@ -70,9 +36,6 @@ export const DataTableVersion = ({ version, onDelete, onRestore }) => {
     ])]),
     version.createdBy && p([`Created by: ${version.createdBy}`]),
     p([description || 'No description']),
-    div({ style: { marginBottom: '1rem' } }, [
-      h(DownloadVersionButton, { url: version.url })
-    ]),
     div({ style: { marginBottom: '1rem' } }, [
       h(ButtonPrimary, {
         disabled: busy,

--- a/src/components/data/data-table-versions.js
+++ b/src/components/data/data-table-versions.js
@@ -6,16 +6,16 @@ import { spinner } from 'src/components/icons'
 import { TextInput } from 'src/components/input'
 import Modal from 'src/components/Modal'
 import colors from 'src/libs/colors'
-import { tableNameForRestore } from 'src/libs/data-table-versions'
+import { tableNameForImport } from 'src/libs/data-table-versions'
 import { FormLabel } from 'src/libs/forms'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 
 
-export const DataTableVersion = ({ version, onDelete, onRestore }) => {
+export const DataTableVersion = ({ version, onDelete, onImport }) => {
   const { entityType, includedSetEntityTypes, timestamp, description } = version
 
-  const [showRestoreConfirmation, setShowRestoreConfirmation] = useState(false)
+  const [showImportConfirmation, setShowImportConfirmation] = useState(false)
   const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false)
   const [busy, setBusy] = useState(false)
 
@@ -39,7 +39,7 @@ export const DataTableVersion = ({ version, onDelete, onRestore }) => {
     div({ style: { display: 'flex', marginBottom: '1rem' } }, [
       h(ButtonPrimary, {
         disabled: busy,
-        onClick: () => setShowRestoreConfirmation(true)
+        onClick: () => setShowImportConfirmation(true)
       }, ['Import']),
       h(ButtonPrimary, {
         danger: true,
@@ -48,19 +48,19 @@ export const DataTableVersion = ({ version, onDelete, onRestore }) => {
         onClick: () => setShowDeleteConfirmation(true)
       }, ['Delete'])
     ]),
-    showRestoreConfirmation && h(DataTableRestoreVersionModal, {
+    showImportConfirmation && h(DataTableImportVersionModal, {
       version,
       onConfirm: async () => {
-        setShowRestoreConfirmation(false)
+        setShowImportConfirmation(false)
         setBusy(true)
         try {
-          await onRestore()
+          await onImport()
         } catch (err) {
           setBusy(false)
         }
       },
       onDismiss: () => {
-        setShowRestoreConfirmation(false)
+        setShowImportConfirmation(false)
       }
     }),
     showDeleteConfirmation && h(DeleteConfirmationModal, {
@@ -159,13 +159,13 @@ export const DataTableSaveVersionModal = ({ entityType, allEntityTypes, includeS
   ])
 }
 
-export const DataTableRestoreVersionModal = ({ version, onDismiss, onConfirm }) => {
+export const DataTableImportVersionModal = ({ version, onDismiss, onConfirm }) => {
   return h(Modal, {
     onDismiss,
     title: 'Import version',
-    okButton: h(ButtonPrimary, { 'data-testid': 'confirm-restore', onClick: () => onConfirm() }, ['Import'])
+    okButton: h(ButtonPrimary, { 'data-testid': 'confirm-import', onClick: () => onConfirm() }, ['Import'])
   }, [
     'This version will be imported to a new data table: ',
-    span({ style: { fontWeight: 600 } }, [tableNameForRestore(version)])
+    span({ style: { fontWeight: 600 } }, [tableNameForImport(version)])
   ])
 }

--- a/src/components/data/data-table-versions.js
+++ b/src/components/data/data-table-versions.js
@@ -40,7 +40,7 @@ export const DataTableVersion = ({ version, onDelete, onRestore }) => {
       h(ButtonPrimary, {
         disabled: busy,
         onClick: () => setShowRestoreConfirmation(true)
-      }, ['Restore'])
+      }, ['Import'])
     ]),
     div({ style: { marginBottom: '1rem' } }, [
       h(ButtonPrimary, {
@@ -163,10 +163,10 @@ export const DataTableSaveVersionModal = ({ entityType, allEntityTypes, onDismis
 export const DataTableRestoreVersionModal = ({ version, onDismiss, onConfirm }) => {
   return h(Modal, {
     onDismiss,
-    title: `Restore version`,
-    okButton: h(ButtonPrimary, { 'data-testid': 'confirm-restore', onClick: () => onConfirm() }, ['Restore'])
+    title: 'Import version',
+    okButton: h(ButtonPrimary, { 'data-testid': 'confirm-restore', onClick: () => onConfirm() }, ['Import'])
   }, [
-    'This version will be restored to a new data table: ',
+    'This version will be imported to a new data table: ',
     span({ style: { fontWeight: 600 } }, [tableNameForRestore(version)])
   ])
 }

--- a/src/components/data/data-table-versions.js
+++ b/src/components/data/data-table-versions.js
@@ -36,16 +36,15 @@ export const DataTableVersion = ({ version, onDelete, onRestore }) => {
     ])]),
     version.createdBy && p([`Created by: ${version.createdBy}`]),
     p([description || 'No description']),
-    div({ style: { marginBottom: '1rem' } }, [
+    div({ style: { display: 'flex', marginBottom: '1rem' } }, [
       h(ButtonPrimary, {
         disabled: busy,
         onClick: () => setShowRestoreConfirmation(true)
-      }, ['Import'])
-    ]),
-    div({ style: { marginBottom: '1rem' } }, [
+      }, ['Import']),
       h(ButtonPrimary, {
         danger: true,
         disabled: busy,
+        style: { marginLeft: '1rem' },
         onClick: () => setShowDeleteConfirmation(true)
       }, ['Delete'])
     ]),

--- a/src/components/data/data-table-versions.js
+++ b/src/components/data/data-table-versions.js
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp'
 import { Fragment, useEffect, useState } from 'react'
-import { div, fieldset, h, h1, legend, li, ol, p, span } from 'react-hyperscript-helpers'
+import { div, fieldset, h, h1, legend, li, ol, p, span, ul } from 'react-hyperscript-helpers'
 import { ButtonPrimary, ButtonSecondary, DeleteConfirmationModal, IdContainer, LabeledCheckbox, spinnerOverlay } from 'src/components/common'
 import { parseGsUri } from 'src/components/data/data-utils'
 import { icon, spinner } from 'src/components/icons'
@@ -42,12 +42,12 @@ const DownloadVersionButton = ({ url }) => {
     tooltip: !!error && 'Error generating download URL'
   }, [
     loading && icon('loadingSpinner', { size: 12, style: { marginRight: '1ch' } }),
-    'Download TSV'
+    'Download'
   ])
 }
 
 export const DataTableVersion = ({ version, onDelete, onRestore }) => {
-  const { entityType, timestamp, description } = version
+  const { entityType, includedSetEntityTypes, timestamp, description } = version
 
   const [showRestoreConfirmation, setShowRestoreConfirmation] = useState(false)
   const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false)
@@ -62,6 +62,12 @@ export const DataTableVersion = ({ version, onDelete, onRestore }) => {
     }, [
       `${entityType} (${Utils.makeCompleteDate(timestamp)})`
     ]),
+    _.size(includedSetEntityTypes) > 0 && h(IdContainer, [id => h(Fragment, [
+      p({ id }, ['Included set tables:']),
+      ul({ 'aria-labelledby': id, style: { margin: 0 } }, [
+        _.map(type => li({ key: type }, [type]), includedSetEntityTypes)
+      ])
+    ])]),
     version.createdBy && p([`Created by: ${version.createdBy}`]),
     p([description || 'No description']),
     div({ style: { marginBottom: '1rem' } }, [
@@ -195,7 +201,7 @@ export const DataTableRestoreVersionModal = ({ version, onDismiss, onConfirm }) 
   return h(Modal, {
     onDismiss,
     title: `Restore version`,
-    okButton: h(ButtonPrimary, { onClick: () => onConfirm() }, ['Restore'])
+    okButton: h(ButtonPrimary, { 'data-testid': 'confirm-restore', onClick: () => onConfirm() }, ['Restore'])
   }, [
     'This version will be restored to a new data table: ',
     span({ style: { fontWeight: 600 } }, [tableNameForRestore(version)])

--- a/src/components/data/data-table-versions.js
+++ b/src/components/data/data-table-versions.js
@@ -113,14 +113,14 @@ export const DataTableVersions = ({ loading, error, versions, savingNewVersion, 
   ])
 }
 
-export const DataTableSaveVersionModal = ({ entityType, allEntityTypes, onDismiss, onSubmit }) => {
+export const DataTableSaveVersionModal = ({ entityType, allEntityTypes, includeSetsByDefault = false, onDismiss, onSubmit }) => {
   const relatedSetTables = _.flow(
     _.filter(t => (new RegExp(`^${entityType}(_set)+$`)).test(t)),
     _.sortBy(_.identity)
   )(allEntityTypes)
 
   const [description, setDescription] = useState('')
-  const [selectedSetTables, setSelectedSetTables] = useState(_.fromPairs(_.map(table => [table, false], relatedSetTables)))
+  const [selectedSetTables, setSelectedSetTables] = useState(_.fromPairs(_.map(table => [table, includeSetsByDefault], relatedSetTables)))
 
   return h(Modal, {
     onDismiss,

--- a/src/components/data/data-table-versions.js
+++ b/src/components/data/data-table-versions.js
@@ -138,7 +138,7 @@ export const DataTableVersions = ({ loading, error, versions, savingNewVersion, 
           spinner({ size: 16, style: { marginRight: '1ch' } }),
           'Saving new version'
         ]),
-        ol({ 'aria-labelledby': id, style: { margin: 0, padding: 0, listStyleType: 'none' } }, [
+        ol({ 'aria-labelledby': id, style: { margin: savingNewVersion ? '0.5rem 0 0 ' : 0, padding: 0, listStyleType: 'none' } }, [
           _.map(([index, version]) => {
             return li({ key: version.url, style: { marginBottom: index < versions.length - 1 ? '0.5rem' : 0 } }, [
               h(ButtonSecondary, { style: { height: 'auto' }, onClick: () => onClickVersion(version) }, [Utils.makeCompleteDate(version.timestamp)]),

--- a/src/components/data/data-table-versions.test.js
+++ b/src/components/data/data-table-versions.test.js
@@ -113,11 +113,6 @@ describe('DataTableVersion', () => {
     })
   })
 
-  it('renders download link', () => {
-    const { getByText } = render(h(DataTableVersion, { version: testVersion, onDelete: jest.fn(), onRestore: jest.fn() }))
-    expect(getByText('Download')).toBeTruthy()
-  })
-
   it('renders restore button and confirms restore', () => {
     const onRestore = jest.fn()
     const { getByTestId, getByText } = render(h(DataTableVersion, { version: testVersion, onDelete: jest.fn(), onRestore }))

--- a/src/components/data/data-table-versions.test.js
+++ b/src/components/data/data-table-versions.test.js
@@ -87,7 +87,7 @@ describe('DataTableVersion', () => {
     let renderResult
 
     beforeEach(() => {
-      renderResult = render(h(DataTableVersion, { version: testVersion, onDelete: jest.fn(), onRestore: jest.fn() }))
+      renderResult = render(h(DataTableVersion, { version: testVersion, onDelete: jest.fn(), onImport: jest.fn() }))
     })
 
     it('renders entity type and timestamp', () => {
@@ -113,24 +113,24 @@ describe('DataTableVersion', () => {
     })
   })
 
-  it('renders restore button and confirms restore', () => {
-    const onRestore = jest.fn()
-    const { getByTestId, getByText } = render(h(DataTableVersion, { version: testVersion, onDelete: jest.fn(), onRestore }))
+  it('renders import button and confirms import', () => {
+    const onImport = jest.fn()
+    const { getByTestId, getByText } = render(h(DataTableVersion, { version: testVersion, onDelete: jest.fn(), onImport }))
 
-    const restoreButton = getByText('Import')
-    fireEvent.click(restoreButton)
+    const importButton = getByText('Import')
+    fireEvent.click(importButton)
 
     expect(getByText(/This version will be imported to a new data table/)).toBeTruthy()
 
-    const confirmRestoreButton = getByTestId('confirm-restore')
-    fireEvent.click(confirmRestoreButton)
+    const confirmImportButton = getByTestId('confirm-import')
+    fireEvent.click(confirmImportButton)
 
-    expect(onRestore).toHaveBeenCalled()
+    expect(onImport).toHaveBeenCalled()
   })
 
   it('renders delete button and confirms delete', () => {
     const onDelete = jest.fn()
-    const { getByTestId, getByText } = render(h(DataTableVersion, { version: testVersion, onDelete, onRestore: jest.fn() }))
+    const { getByTestId, getByText } = render(h(DataTableVersion, { version: testVersion, onDelete, onImport: jest.fn() }))
 
     const deleteButton = getByText('Delete')
     fireEvent.click(deleteButton)

--- a/src/components/data/data-table-versions.test.js
+++ b/src/components/data/data-table-versions.test.js
@@ -117,10 +117,10 @@ describe('DataTableVersion', () => {
     const onRestore = jest.fn()
     const { getByTestId, getByText } = render(h(DataTableVersion, { version: testVersion, onDelete: jest.fn(), onRestore }))
 
-    const restoreButton = getByText('Restore')
+    const restoreButton = getByText('Import')
     fireEvent.click(restoreButton)
 
-    expect(getByText(/This version will be restored to a new data table/)).toBeTruthy()
+    expect(getByText(/This version will be imported to a new data table/)).toBeTruthy()
 
     const confirmRestoreButton = getByTestId('confirm-restore')
     fireEvent.click(confirmRestoreButton)

--- a/src/components/data/data-table-versions.test.js
+++ b/src/components/data/data-table-versions.test.js
@@ -1,7 +1,6 @@
 import '@testing-library/jest-dom'
 
 import { fireEvent, render } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
 import _ from 'lodash/fp'
 import { h } from 'react-hyperscript-helpers'
 import { DataTableSaveVersionModal, DataTableVersion } from 'src/components/data/data-table-versions'
@@ -48,9 +47,7 @@ describe('DataTableSaveVersionModal', () => {
     expect(setTableCheckboxes[1].getAttribute('aria-checked')).toBe('false')
   })
 
-  it('calls onSubmit with entered description and selected set tables', async () => {
-    const user = userEvent.setup()
-
+  it('calls onSubmit with entered description and selected set tables', () => {
     const onSubmit = jest.fn()
 
     const { getAllByRole, getByLabelText, getByText } = render(h(DataTableSaveVersionModal, {
@@ -61,13 +58,13 @@ describe('DataTableSaveVersionModal', () => {
     }))
 
     const descriptionInput = getByLabelText('Description')
-    await user.type(descriptionInput, 'this is a version')
+    fireEvent.change(descriptionInput, { target: { value: 'this is a version' } })
 
     const setTableCheckboxes = getAllByRole('checkbox')
-    await user.click(setTableCheckboxes[0])
+    fireEvent.click(setTableCheckboxes[0])
 
     const saveButton = getByText('Save')
-    await user.click(saveButton)
+    fireEvent.click(saveButton)
 
     expect(onSubmit).toHaveBeenCalledWith({
       description: 'this is a version',

--- a/src/components/data/data-table-versions.test.js
+++ b/src/components/data/data-table-versions.test.js
@@ -1,0 +1,77 @@
+import '@testing-library/jest-dom'
+
+import { render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import _ from 'lodash/fp'
+import { h } from 'react-hyperscript-helpers'
+import { DataTableSaveVersionModal } from 'src/components/data/data-table-versions'
+
+
+describe('DataTableSaveVersionModal', () => {
+  beforeAll(() => {
+    const modalRoot = document.createElement('div')
+    modalRoot.id = 'modal-root'
+    document.body.append(modalRoot)
+  })
+
+  afterAll(() => {
+    document.getElementById('modal-root').remove()
+  })
+
+  it('renders input for description', () => {
+    const { getByLabelText } = render(h(DataTableSaveVersionModal, {
+      entityType: 'sample',
+      allEntityTypes: ['sample'],
+      onDismiss: _.noop,
+      onSubmit: _.noop
+    }))
+
+    const descriptionInput = getByLabelText('Description')
+    expect(descriptionInput).toBeTruthy()
+  })
+
+  it('renders checkboxes to include related set tables', () => {
+    const { getAllByRole } = render(h(DataTableSaveVersionModal, {
+      entityType: 'sample',
+      allEntityTypes: ['sample', 'sample_set', 'sample_set_set', 'participant'],
+      onDismiss: _.noop,
+      onSubmit: _.noop
+    }))
+
+    const setTableCheckboxes = getAllByRole('checkbox')
+    expect(setTableCheckboxes.length).toBe(2)
+
+    expect(setTableCheckboxes[0].parentElement).toHaveTextContent('sample_set')
+    expect(setTableCheckboxes[0].getAttribute('aria-checked')).toBe('false')
+
+    expect(setTableCheckboxes[1].parentElement).toHaveTextContent('sample_set_set')
+    expect(setTableCheckboxes[1].getAttribute('aria-checked')).toBe('false')
+  })
+
+  it('calls onSubmit with entered description and selected set tables', async () => {
+    const user = userEvent.setup()
+
+    const onSubmit = jest.fn()
+
+    const { getAllByRole, getByLabelText, getByText } = render(h(DataTableSaveVersionModal, {
+      entityType: 'sample',
+      allEntityTypes: ['sample', 'sample_set', 'sample_set_set', 'participant'],
+      onDismiss: _.noop,
+      onSubmit
+    }))
+
+    const descriptionInput = getByLabelText('Description')
+    await user.type(descriptionInput, 'this is a version')
+
+    const setTableCheckboxes = getAllByRole('checkbox')
+    await user.click(setTableCheckboxes[0])
+
+    const saveButton = getByText('Save')
+    await user.click(saveButton)
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      description: 'this is a version',
+      includedSetEntityTypes: ['sample_set']
+    })
+  })
+})

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -64,6 +64,8 @@ export const getUserProjectForWorkspace = async workspace => (workspace && await
 
 const isUri = datum => _.startsWith('gs://', datum) || _.startsWith('dos://', datum) || _.startsWith('drs://', datum)
 
+export const getRootTypeForSetTable = tableName => _.replace(/(_set)+$/, '', tableName)
+
 export const entityAttributeText = (attributeValue, machineReadable) => {
   const { type, isList } = getAttributeType(attributeValue)
 

--- a/src/components/data/data-utils.test.js
+++ b/src/components/data/data-utils.test.js
@@ -2,9 +2,19 @@ import '@testing-library/jest-dom'
 
 import { render } from '@testing-library/react'
 import _ from 'lodash/fp'
-import { entityAttributeText, prepareAttributeForUpload, renderDataCell } from 'src/components/data/data-utils'
+import { entityAttributeText, getRootTypeForSetTable, prepareAttributeForUpload, renderDataCell } from 'src/components/data/data-utils'
 import * as Utils from 'src/libs/utils'
 
+
+describe('getRootTypeForSetTable', () => {
+  it('gets member type for set tables', () => {
+    expect(getRootTypeForSetTable('sample_set')).toBe('sample')
+  })
+
+  it('gets member type for nested set tables', () => {
+    expect(getRootTypeForSetTable('sample_set_set')).toBe('sample')
+  })
+})
 
 describe('entityAttributeText', () => {
   describe('basic data types', () => {

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -889,6 +889,8 @@ const Workspaces = signal => ({
         return fetchRawls(`${root}/entities/delete`, _.mergeAll([authOpts(), jsonBody(entities), { signal, method: 'POST' }]))
       },
 
+      getEntities: entityType => fetchRawls(`${root}/entities/${entityType}`, _.merge(authOpts(), { signal })).then(r => r.json()),
+
       getEntitiesTsv: entityType => fetchOrchestration(`api/workspaces/${namespace}/${name}/entities/${entityType}/tsv?model=flexible`, _.mergeAll([authOpts(), { signal }])).then(r => r.text()),
 
       copyEntities: async (destNamespace, destName, entityType, entities, link) => {

--- a/src/libs/data-table-versions.js
+++ b/src/libs/data-table-versions.js
@@ -13,7 +13,7 @@ import * as Utils from 'src/libs/utils'
 
 export const dataTableVersionsPathRoot = '.data-table-versions'
 
-export const saveDataTableVersion = async (workspace, entityType, { description = null } = {}) => {
+export const saveDataTableVersion = async (workspace, entityType, { description = null, includedSetEntityTypes = [] } = {}) => {
   Ajax().Metrics.captureEvent(Events.dataTableVersioningSaveVersion, {
     ...extractWorkspaceDetails(workspace.workspace),
     tableName: entityType
@@ -131,10 +131,10 @@ export const useDataTableVersions = workspace => {
       }
     },
 
-    saveDataTableVersion: async (entityType, { description = null } = {}) => {
+    saveDataTableVersion: async (entityType, options = {}) => {
       setDataTableVersions(_.update(entityType, _.set('savingNewVersion', true)))
       try {
-        const newVersion = await saveDataTableVersion(workspace, entityType, { description })
+        const newVersion = await saveDataTableVersion(workspace, entityType, options)
         notify('success', `Saved version of ${entityType}`, { timeout: 3000 })
         setDataTableVersions(_.update([entityType, 'versions'],
           _.flow(_.defaultTo([]), Utils.append(newVersion), _.sortBy(version => -version.timestamp))

--- a/src/libs/data-table-versions.js
+++ b/src/libs/data-table-versions.js
@@ -64,7 +64,7 @@ export const saveDataTableVersion = async (workspace, entityType, { description 
 
   const { workspace: { namespace, name, googleProject, bucketName } } = workspace
 
-  const timestamp = (new Date()).getTime()
+  const timestamp = Date.now()
   const versionName = `${entityType}.v${timestamp}`
 
   const entityMetadata = await Ajax().Workspaces.workspace(namespace, name).entityMetadata()

--- a/src/libs/data-table-versions.test.js
+++ b/src/libs/data-table-versions.test.js
@@ -1,7 +1,7 @@
 import JSZip from 'jszip'
 import { Ajax } from 'src/libs/ajax'
 import { getUser } from 'src/libs/auth'
-import { restoreDataTableVersion, saveDataTableVersion, tableNameForRestore } from 'src/libs/data-table-versions'
+import { importDataTableVersion, saveDataTableVersion, tableNameForImport } from 'src/libs/data-table-versions'
 
 
 jest.mock('src/libs/ajax')
@@ -11,9 +11,9 @@ jest.mock('src/libs/auth', () => ({
   getUser: jest.fn()
 }))
 
-describe('tableNameForRestore', () => {
-  it('names restored table with version timestamp', () => {
-    expect(tableNameForRestore({
+describe('tableNameForImport', () => {
+  it('names imported table with version timestamp', () => {
+    expect(tableNameForImport({
       url: 'gs://workspace-bucket/.data-table-versions/thing/thing.v1663096364243',
       createdBy: 'user@example.com',
       entityType: 'thing',
@@ -228,7 +228,7 @@ describe('saveDataTableVersion', () => {
   })
 })
 
-describe('restoreDataTableVersion', () => {
+describe('importDataTableVersion', () => {
   const workspace = { workspace: { namespace: 'test', name: 'test', googleProject: 'test-project', bucketName: 'test-bucket' } }
   const version = {
     url: 'gs://workspace-bucket/.data-table-versions/thing/thing.v1663096364243.zip',
@@ -304,17 +304,17 @@ describe('restoreDataTableVersion', () => {
   })
 
   it('downloads version from GCS', async () => {
-    await restoreDataTableVersion(workspace, version)
+    await importDataTableVersion(workspace, version)
     expect(getObjectPreview).toHaveBeenCalledWith('test-project', 'test-bucket', '.data-table-versions/thing/thing.v1663096364243.zip', true)
   })
 
   it('imports table and set tables', async () => {
-    await restoreDataTableVersion(workspace, version)
+    await importDataTableVersion(workspace, version)
     expect(upsertEntities).toHaveBeenCalledTimes(2)
   })
 
   it('rewrites entity type', async () => {
-    await restoreDataTableVersion(workspace, version)
+    await importDataTableVersion(workspace, version)
 
     const entities = upsertEntities.mock.calls[0][0]
     expect(entities[0].entityType).toBe('thing_2022-09-13_19-12-44')
@@ -344,8 +344,8 @@ describe('restoreDataTableVersion', () => {
     ]))
   })
 
-  it('returns restored table name', async () => {
-    const { tableName } = await restoreDataTableVersion(workspace, version)
+  it('returns imported table name', async () => {
+    const { tableName } = await importDataTableVersion(workspace, version)
     expect(tableName).toBe('thing_2022-09-13_19-12-44')
   })
 })

--- a/src/libs/data-table-versions.test.js
+++ b/src/libs/data-table-versions.test.js
@@ -91,11 +91,11 @@ describe('saveDataTableVersion', () => {
 
   beforeEach(() => {
     getEntityMetadata = jest.fn().mockReturnValue(Promise.resolve(entityMetadata))
-    paginatedEntitiesOfType = jest.fn().mockImplementation(entityType => Promise.resolve({
+    paginatedEntitiesOfType = jest.fn().mockImplementation((entityType, { page }) => Promise.resolve({
       resultMetadata: {
-        filterePageCount: 1
+        filteredPageCount: Math.ceil((entities[entityType] || []).length / 2)
       },
-      results: entities[entityType] || []
+      results: (entities[entityType] || []).slice(2 * (page - 1), 2 * page)
     }))
     uploadObject = jest.fn()
     patchObject = jest.fn()

--- a/src/libs/data-table-versions.test.js
+++ b/src/libs/data-table-versions.test.js
@@ -86,13 +86,18 @@ describe('saveDataTableVersion', () => {
   }
 
   let getEntityMetadata
-  let getEntities
+  let paginatedEntitiesOfType
   let uploadObject
   let patchObject
 
   beforeEach(() => {
     getEntityMetadata = jest.fn().mockReturnValue(Promise.resolve(entityMetadata))
-    getEntities = jest.fn().mockImplementation(entityType => Promise.resolve(entities[entityType] || null))
+    paginatedEntitiesOfType = jest.fn().mockImplementation(entityType => Promise.resolve({
+      resultMetadata: {
+        filterePageCount: 1
+      },
+      results: entities[entityType] || []
+    }))
     uploadObject = jest.fn()
     patchObject = jest.fn()
 
@@ -107,7 +112,7 @@ describe('saveDataTableVersion', () => {
       Workspaces: {
         workspace: () => ({
           entityMetadata: getEntityMetadata,
-          getEntities
+          paginatedEntitiesOfType
         })
       }
     }))
@@ -119,13 +124,13 @@ describe('saveDataTableVersion', () => {
 
   it('downloads entities', async () => {
     await saveDataTableVersion(workspace, 'thing', {})
-    expect(getEntities).toHaveBeenCalledWith('thing')
+    expect(paginatedEntitiesOfType).toHaveBeenCalledWith('thing', expect.objectContaining({ page: 1 }))
   })
 
   it('downloads related sets', async () => {
     await saveDataTableVersion(workspace, 'thing', { includedSetEntityTypes: ['thing_set'] })
-    expect(getEntities).toHaveBeenCalledWith('thing')
-    expect(getEntities).toHaveBeenCalledWith('thing_set')
+    expect(paginatedEntitiesOfType).toHaveBeenCalledWith('thing', expect.objectContaining({ page: 1 }))
+    expect(paginatedEntitiesOfType).toHaveBeenCalledWith('thing_set', expect.objectContaining({ page: 1 }))
   })
 
   it('uploads zip file of data', async () => {

--- a/src/libs/data-table-versions.test.js
+++ b/src/libs/data-table-versions.test.js
@@ -1,9 +1,16 @@
+import JSZip from 'jszip'
 import _ from 'lodash/fp'
 import { Ajax } from 'src/libs/ajax'
-import { restoreDataTableVersion, tableNameForRestore } from 'src/libs/data-table-versions'
+import { getUser } from 'src/libs/auth'
+import { restoreDataTableVersion, saveDataTableVersion, tableNameForRestore } from 'src/libs/data-table-versions'
 
 
 jest.mock('src/libs/ajax')
+
+jest.mock('src/libs/auth', () => ({
+  ...jest.requireActual('src/libs/auth'),
+  getUser: jest.fn()
+}))
 
 describe('tableNameForRestore', () => {
   it('names restored table with version timestamp', () => {
@@ -17,21 +24,211 @@ describe('tableNameForRestore', () => {
   })
 })
 
+describe('saveDataTableVersion', () => {
+  const workspace = { workspace: { namespace: 'test', name: 'test', googleProject: 'test-project', bucketName: 'test-bucket' } }
+
+  const entityMetadata = {
+    thing: {
+      attributeNames: ['attribute_one', 'attribute_two'],
+      count: 3,
+      id_name: 'thing_id'
+    },
+    thing_set: {
+      attributeNames: ['things', 'attribute_one'],
+      count: 1,
+      id_name: 'thing_set_id'
+    }
+  }
+
+  const entities = {
+    thing: [
+      {
+        name: 'thing_one',
+        entityType: 'thing',
+        attributes: {
+          attribute_one: 'a',
+          attribute_two: 1
+        }
+      },
+      {
+        name: 'thing_two',
+        entityType: 'thing',
+        attributes: {
+          attribute_one: 'b',
+          attribute_two: 2
+        }
+      },
+      {
+        name: 'thing_three',
+        entityType: 'thing',
+        attributes: {
+          attribute_one: 'c',
+          attribute_two: 3
+        }
+      }
+    ],
+    thing_set: [
+      {
+        name: 'some_things',
+        entityType: 'thing_set',
+        attributes: {
+          attribute_one: 'a',
+          things: {
+            itemsType: 'EntityReference',
+            items: [
+              { entityType: 'thing', entityName: 'thing_one' },
+              { entityType: 'thing', entityName: 'thing_two' }
+            ]
+          }
+        }
+      }
+    ]
+  }
+
+  let getEntityMetadata
+  let getEntities
+  let uploadObject
+  let patchObject
+
+  beforeEach(() => {
+    getEntityMetadata = jest.fn().mockReturnValue(Promise.resolve(entityMetadata))
+    getEntities = jest.fn().mockImplementation(entityType => Promise.resolve(entities[entityType] || null))
+    uploadObject = jest.fn()
+    patchObject = jest.fn()
+
+    Ajax.mockImplementation(() => ({
+      Buckets: {
+        upload: uploadObject,
+        patch: patchObject
+      },
+      Metrics: {
+        captureEvent: jest.fn()
+      },
+      Workspaces: {
+        workspace: () => ({
+          entityMetadata: getEntityMetadata,
+          getEntities
+        })
+      }
+    }))
+
+    getUser.mockReturnValue({
+      email: 'user@example.com'
+    })
+  })
+
+  it('downloads entities', async () => {
+    await saveDataTableVersion(workspace, 'thing', {})
+    expect(getEntities).toHaveBeenCalledWith('thing')
+  })
+
+  it('downloads related sets', async () => {
+    await saveDataTableVersion(workspace, 'thing', { includedSetEntityTypes: ['thing_set'] })
+    expect(getEntities).toHaveBeenCalledWith('thing')
+    expect(getEntities).toHaveBeenCalledWith('thing_set')
+  })
+
+  it('uploads zip file of data', async () => {
+    await saveDataTableVersion(workspace, 'thing', { includedSetEntityTypes: ['thing_set'] })
+    expect(uploadObject).toHaveBeenCalledWith('test-project', 'test-bucket', '.data-table-versions/thing/', expect.any(File))
+  })
+
+  describe('uploaded zip file', () => {
+    let file
+
+    beforeEach(async () => {
+      jest.spyOn(Date, 'now').mockReturnValue(1664838597117)
+      await saveDataTableVersion(workspace, 'thing', { includedSetEntityTypes: ['thing_set'] })
+      file = uploadObject.mock.calls[0][3]
+    })
+
+    it('is named with version timestamp', () => {
+      expect(file.name).toBe('thing.v1664838597117.zip')
+    })
+
+    it('contains TSV export of table', async () => {
+      const zip = await JSZip.loadAsync(file)
+      expect(await zip.file('thing.tsv').async('text')).toBe(
+        'entity:thing_id\tattribute_one\tattribute_two\n' +
+    	  'thing_one\ta\t1\n' +
+    	  'thing_two\tb\t2\n' +
+    	  'thing_three\tc\t3\n'
+      )
+    })
+
+    it('contains TSV export of set tables', async () => {
+      const zip = await JSZip.loadAsync(file)
+      expect(await zip.file('thing_set.tsv').async('text')).toBe(
+        'entity:thing_set_id\tattribute_one\n' +
+    	  'some_things\ta\n'
+      )
+      expect(await zip.file('thing_set.membership.tsv').async('text')).toBe(
+        'membership:thing_set_id\tthing\n' +
+    	  'some_things\tthing_one\n' +
+        'some_things\tthing_two\n'
+      )
+    })
+  })
+
+  it('attaches metadata to uploaded zip file', async () => {
+    jest.spyOn(Date, 'now').mockReturnValue(1664838597117)
+    await saveDataTableVersion(workspace, 'thing', {
+      description: 'This is a test',
+      includedSetEntityTypes: ['thing_set']
+    })
+    expect(patchObject).toHaveBeenCalledWith(
+      'test-project',
+      'test-bucket',
+      '.data-table-versions/thing/thing.v1664838597117.zip',
+      {
+        metadata: {
+          createdBy: 'user@example.com',
+          entityType: 'thing',
+          includedSetEntityTypes: 'thing_set',
+          timestamp: 1664838597117,
+          description: 'This is a test'
+        }
+      }
+    )
+  })
+})
+
 describe('restoreDataTableVersion', () => {
   const workspace = { workspace: { namespace: 'test', name: 'test', googleProject: 'test-project', bucketName: 'test-bucket' } }
   const version = {
-    url: 'gs://workspace-bucket/.data-table-versions/thing/thing.v1663096364243',
+    url: 'gs://workspace-bucket/.data-table-versions/thing/thing.v1663096364243.zip',
     createdBy: 'user@example.com',
     entityType: 'thing',
+    includedSetEntityTypes: ['thing_set'],
     timestamp: 1663096364243,
     description: 'A version'
   }
+
+  const versionFile = new JSZip()
+  versionFile.file(
+    'thing.tsv',
+    'entity:thing_id\tattribute_one\tattribute_two\n' +
+    'thing_one\ta\t1\n' +
+    'thing_two\tb\t2\n' +
+    'thing_three\tc\t3\n'
+  )
+  versionFile.file(
+    'thing_set.tsv',
+    'entity:thing_set_id\tattribute_one\n' +
+    'some_things\ta\n'
+  )
+  versionFile.file(
+    'thing_set.membership.tsv',
+    'membership:thing_set_id\tthing\n' +
+    'some_things\tthing_one\n' +
+    'some_things\tthing_two\n'
+  )
 
   let getObjectPreview
   let importFlexibleEntitiesFileSynchronous
 
   beforeEach(() => {
-    getObjectPreview = jest.fn().mockReturnValue(Promise.resolve({ text: () => Promise.resolve('entity:thing_id\tvalue\nthing_1\tabc') }))
+    getObjectPreview = jest.fn().mockReturnValue(Promise.resolve({ blob: () => versionFile.generateAsync({ type: 'blob' }) }))
     importFlexibleEntitiesFileSynchronous = jest.fn().mockReturnValue(Promise.resolve({}))
 
     Ajax.mockImplementation(() => ({
@@ -43,22 +240,32 @@ describe('restoreDataTableVersion', () => {
 
   it('downloads version from GCS', async () => {
     await restoreDataTableVersion(workspace, version)
-    expect(getObjectPreview).toHaveBeenCalledWith('test-project', 'test-bucket', '.data-table-versions/thing/thing.v1663096364243', true)
+    expect(getObjectPreview).toHaveBeenCalledWith('test-project', 'test-bucket', '.data-table-versions/thing/thing.v1663096364243.zip', true)
   })
 
-  it('imports table', async () => {
+  it('imports table and set tables', async () => {
     await restoreDataTableVersion(workspace, version)
-    expect(importFlexibleEntitiesFileSynchronous).toHaveBeenCalled()
+    expect(importFlexibleEntitiesFileSynchronous).toHaveBeenCalledTimes(3)
   })
 
   it('rewrites entity type', async () => {
     await restoreDataTableVersion(workspace, version)
 
-    const importedFile = importFlexibleEntitiesFileSynchronous.mock.calls[0][0]
-    const importedTsv = await importedFile.text()
+    const getHeaders = async callIndex => {
+      const file = importFlexibleEntitiesFileSynchronous.mock.calls[callIndex][0]
+      const tsv = await file.text()
+      const headers = _.flow(_.split('\n'), _.first, _.split('\t'))(tsv)
+      return headers
+    }
 
-    const entityTypeHeader = _.flow(_.split('\n'), _.first, _.split('\t'), _.first)(importedTsv)
-    expect(entityTypeHeader).toBe('entity:thing_2022-09-13_19-12-44_id')
+    const tableHeaders = await getHeaders(0)
+    expect(tableHeaders[0]).toBe('entity:thing_2022-09-13_19-12-44_id')
+
+    const setTableHeaders = await getHeaders(1)
+    expect(setTableHeaders[0]).toBe('entity:thing_2022-09-13_19-12-44_set_id')
+
+    const setMembershipTableHeaders = await getHeaders(2)
+    expect(setMembershipTableHeaders).toEqual(['membership:thing_2022-09-13_19-12-44_set_id', 'thing_2022-09-13_19-12-44'])
   })
 
   it('returns restored table name', async () => {

--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -42,7 +42,7 @@ const eventsList = {
   dataTableLoadColumnSettings: 'dataTable:loadColumnSettings',
   dataTableVersioningViewVersionHistory: 'dataTable:versioning:viewVersionHistory',
   dataTableVersioningSaveVersion: 'dataTable:versioning:saveVersion',
-  dataTableVersioningRestoreVersion: 'dataTable:versioning:restoreVersion',
+  dataTableVersioningImportVersion: 'dataTable:versioning:importVersion',
   dataTableVersioningDeleteVersion: 'dataTable:versioning:deleteVersion',
   featurePreviewToggle: 'featurePreview:toggle',
   // Note: "external" refers to the common Job Manager deployment, not a Job Manager bundled in CromwellApp

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -945,11 +945,9 @@ const WorkspaceData = _.flow(
               setSelectedData(undefined)
             }),
             onRestore: reportErrorAndRethrow('Error restoring version', async () => {
-              const { tableName, ready } = await restoreDataTableVersion(selectedData.version)
+              const { tableName } = await restoreDataTableVersion(selectedData.version)
               await loadMetadata()
-              if (ready) {
-                setSelectedData({ type: workspaceDataTypes.entities, entityType: tableName })
-              }
+              setSelectedData({ type: workspaceDataTypes.entities, entityType: tableName })
             })
           })]
         )

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -8,7 +8,7 @@ import * as breadcrumbs from 'src/components/breadcrumbs'
 import Collapse from 'src/components/Collapse'
 import { ButtonOutline, Clickable, DeleteConfirmationModal, Link, spinnerOverlay } from 'src/components/common'
 import { DataTableSaveVersionModal, DataTableVersion, DataTableVersions } from 'src/components/data/data-table-versions'
-import { EntityUploader, ReferenceDataDeleter, ReferenceDataImporter, renderDataCell } from 'src/components/data/data-utils'
+import { EntityUploader, getRootTypeForSetTable, ReferenceDataDeleter, ReferenceDataImporter, renderDataCell } from 'src/components/data/data-utils'
 import EntitiesContent from 'src/components/data/EntitiesContent'
 import ExportDataModal from 'src/components/data/ExportDataModal'
 import FileBrowser from 'src/components/data/FileBrowser'
@@ -384,7 +384,7 @@ const DataTableActions = ({ workspace, tableName, rowCount, entityMetadata, onRe
     }),
     savingVersion && h(DataTableSaveVersionModal, {
       workspace,
-      entityType: isSet ? _.replace(/(_set)+$/, '', tableName) : tableName,
+      entityType: isSet ? getRootTypeForSetTable(tableName) : tableName,
       allEntityTypes: _.keys(entityMetadata),
       includeSetsByDefault: isSet,
       onDismiss: () => setSavingVersion(false),
@@ -692,7 +692,7 @@ const WorkspaceData = _.flow(
                       onToggleVersionHistory: withErrorReporting('Error loading version history', showVersionHistory => {
                         setShowDataTableVersionHistory(_.set(type, showVersionHistory))
                         if (showVersionHistory) {
-                          loadDataTableVersions(type.endsWith('_set') ? _.replace(/(_set)+$/, '', type) : type)
+                          loadDataTableVersions(type.endsWith('_set') ? getRootTypeForSetTable(type) : type)
                         }
                       })
                     })
@@ -700,7 +700,7 @@ const WorkspaceData = _.flow(
                   isShowingVersionHistory && h(DataTableVersions, {
                     ...Utils.cond(
                       [type.endsWith('_set'), () => {
-                        const referencedType = _.replace(/(_set)+$/, '', type)
+                        const referencedType = getRootTypeForSetTable(type)
                         return _.update(
                           'versions',
                           _.filter(version => _.includes(type, version.includedSetEntityTypes)),

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -351,11 +351,7 @@ const DataTableActions = ({ workspace, tableName, rowCount, entityMetadata, onRe
         }, 'Delete table'),
         isFeaturePreviewEnabled('data-table-versioning') && h(Fragment, [
           h(MenuDivider),
-          h(MenuButton, {
-            disabled: isSet,
-            tooltip: isSet && `Set tables are versioned with the table they reference. To version this table, save a version of the ${tableName.replace(/(_set)+/, '')} table.`,
-            onClick: () => setSavingVersion(true)
-          }, ['Save version']),
+          h(MenuButton, { onClick: () => setSavingVersion(true) }, ['Save version']),
           h(MenuButton, {
             disabled: isSet,
             tooltip: isSet && `Set tables are versioned with the table they reference. See the version history of the ${tableName.replace(/(_set)+/, '')} table.`,
@@ -390,8 +386,9 @@ const DataTableActions = ({ workspace, tableName, rowCount, entityMetadata, onRe
     }),
     savingVersion && h(DataTableSaveVersionModal, {
       workspace,
-      entityType: tableName,
+      entityType: isSet ? _.replace(/(_set)+$/, '', tableName) : tableName,
       allEntityTypes: _.keys(entityMetadata),
+      includeSetsByDefault: isSet,
       onDismiss: () => setSavingVersion(false),
       onSubmit: versionOpts => {
         setSavingVersion(false)

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -284,6 +284,8 @@ const SidebarSeparator = ({ sidebarWidth, setSidebarWidth }) => {
 
 const DataTableActions = ({ workspace, tableName, rowCount, entityMetadata, onRenameTable, onDeleteTable, isShowingVersionHistory, onSaveVersion, onToggleVersionHistory }) => {
   const { workspace: { namespace, name }, workspaceSubmissionStats: { runningSubmissionsCount } } = workspace
+
+  const isSet = tableName.endsWith('_set')
   const isSetOfSets = tableName.endsWith('_set_set')
 
   const editWorkspaceErrorMessage = Utils.editWorkspaceError(workspace)
@@ -349,8 +351,14 @@ const DataTableActions = ({ workspace, tableName, rowCount, entityMetadata, onRe
         }, 'Delete table'),
         isFeaturePreviewEnabled('data-table-versioning') && h(Fragment, [
           h(MenuDivider),
-          h(MenuButton, { onClick: () => setSavingVersion(true) }, ['Save version']),
           h(MenuButton, {
+            disabled: isSet,
+            tooltip: isSet && `Set tables are versioned with the table they reference. To version this table, save a version of the ${tableName.replace(/(_set)+/, '')} table.`,
+            onClick: () => setSavingVersion(true)
+          }, ['Save version']),
+          h(MenuButton, {
+            disabled: isSet,
+            tooltip: isSet && `Set tables are versioned with the table they reference. See the version history of the ${tableName.replace(/(_set)+/, '')} table.`,
             onClick: () => {
               onToggleVersionHistory(!isShowingVersionHistory)
               if (!isShowingVersionHistory) {

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -391,6 +391,7 @@ const DataTableActions = ({ workspace, tableName, rowCount, entityMetadata, onRe
     savingVersion && h(DataTableSaveVersionModal, {
       workspace,
       entityType: tableName,
+      allEntityTypes: _.keys(entityMetadata),
       onDismiss: () => setSavingVersion(false),
       onSubmit: versionOpts => {
         setSavingVersion(false)

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -472,7 +472,7 @@ const WorkspaceData = _.flow(
   const [crossTableSearchInProgress, setCrossTableSearchInProgress] = useState(false)
   const [showDataTableVersionHistory, setShowDataTableVersionHistory] = useState({}) // { [entityType: string]: boolean }
 
-  const { dataTableVersions, loadDataTableVersions, saveDataTableVersion, deleteDataTableVersion, restoreDataTableVersion } = useDataTableVersions(workspace)
+  const { dataTableVersions, loadDataTableVersions, saveDataTableVersion, deleteDataTableVersion, importDataTableVersion } = useDataTableVersions(workspace)
 
   const signal = useCancellation()
   const asyncImportJobs = useStore(asyncImportJobStore)
@@ -949,8 +949,8 @@ const WorkspaceData = _.flow(
               await deleteDataTableVersion(selectedData.version)
               setSelectedData(undefined)
             }),
-            onRestore: reportErrorAndRethrow('Error restoring version', async () => {
-              const { tableName } = await restoreDataTableVersion(selectedData.version)
+            onImport: reportErrorAndRethrow('Error importing version', async () => {
+              const { tableName } = await importDataTableVersion(selectedData.version)
               await loadMetadata()
               setSelectedData({ type: workspaceDataTypes.entities, entityType: tableName })
             })


### PR DESCRIPTION
Currently, versions of individual data tables can be saved and restored. This changes set tables so that they may be versioned with the table that they reference. This makes it easy to have the restored set table reference the restored referenced table.

To enable data table versioning, go to the feature preview page (`/#feature-preview`) and check the box for data table versioning.

https://user-images.githubusercontent.com/1156625/193836501-da9305a9-23a3-4508-97d7-6d75e8b4481b.mov

