### PR TITLE
PROD-739 fix bug for RStudio file syncing

### DIFF
--- a/src/pages/workspaces/workspace/analysis/AppLauncher.js
+++ b/src/pages/workspaces/workspace/analysis/AppLauncher.js
@@ -174,7 +174,7 @@ const ApplicationLauncher = _.flow(
         await Ajax()
           .Runtimes
           .fileSyncing(googleProject, runtime.runtimeName)
-          .setStorageLinks(localBaseDirectory, cloudStorageDirectory, getPatternFromTool(getToolFromRuntime(runtime))) :
+          .setStorageLinks(localBaseDirectory, ``, cloudStorageDirectory, getPatternFromTool(getToolFromRuntime(runtime))) :
         await Ajax()
           .Runtimes
           .azureProxy(runtime.proxyUrl)


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/PROD-740

This bug was introduced in https://github.com/DataBiosphere/terra-ui/pull/3411.
For RStudio, in theory we don't have to pass `localSafeModeBaseDirectory` either, but the `Ajax().Runtimes        .fileSyncing(googleProject, runtime.runtimeName).setStorageLinks` is expecting the field, so we still need to pass it.

