### PR TITLE
sup-753 remove name from radiobutton

### DIFF
--- a/src/components/data/AttributeInput.js
+++ b/src/components/data/AttributeInput.js
@@ -38,7 +38,6 @@ export const AttributeTypeInput = ({ label: labelText = 'Type', value, onChange,
         span({ style: { display: 'inline-block', whiteSpace: 'nowrap' } }, [
           h(RadioButton, {
             text: label || _.startCase(typeOption),
-            name: 'edit-type',
             checked: type === typeOption,
             onChange: () => {
               const newType = { type: typeOption }


### PR DESCRIPTION
See [SUP-753](https://broadworkbench.atlassian.net/browse/SUP-753) for description of the problem - in the 'add row' modal for a data table, all lists of radio buttons were considered the same and so only one at a time could be highlighted.  Turns out they all had the same `name` and removing it solved the problem.  I did not find the name `edit-name` used anywhere else in the code.  I wanted to change the name to reflect which attribute it was referring to, but as far as I could tell, this is not accessible at the level of radio button, so I've simply left it off.