### PR TITLE
[SUP-735] Copy analysis missing bugfix

### DIFF
--- a/src/pages/workspaces/workspace/analysis/modals/ExportAnalysisModal.js
+++ b/src/pages/workspaces/workspace/analysis/modals/ExportAnalysisModal.js
@@ -60,15 +60,14 @@ export const ExportAnalysisModal = ({ fromLauncher, onDismiss, printName, toolLa
     }
   })
 
+  // Render
   const errors = validate(
     { selectedWorkspaceId, newName },
     {
       selectedWorkspaceId: { presence: true },
       newName: analysisNameValidator(existingNames)
     },
-    {
-      prettify: v => ({ newName: 'Name' }[v] || validate.prettify(v))
-    }
+    { prettify: v => ({ newName: 'Name' }[v] || validate.prettify(v)) }
   )
 
   return h(Modal, {

--- a/src/pages/workspaces/workspace/analysis/modals/ExportAnalysisModal.js
+++ b/src/pages/workspaces/workspace/analysis/modals/ExportAnalysisModal.js
@@ -13,7 +13,7 @@ import * as Nav from 'src/libs/nav'
 import { useCancellation } from 'src/libs/react-utils'
 import * as Utils from 'src/libs/utils'
 import {
-  analysisNameInput, analysisNameValidator, getAnalysisFileExtension, getDisplayName, stripExtension
+  analysisNameInput, analysisNameValidator, extensionAnalysisNameValidator, getAnalysisFileExtension, getDisplayName, stripExtension
 } from 'src/pages/workspaces/workspace/analysis/notebook-utils'
 import { analysisLauncherTabName, analysisTabName } from 'src/pages/workspaces/workspace/analysis/runtime-common'
 import validate from 'validate.js'
@@ -62,16 +62,23 @@ export const ExportAnalysisModal = ({ fromLauncher, onDismiss, printName, toolLa
     }
   })
 
-
+  const newNameSecondValidation = newName
   // Render
   const errors = validate(
-    { selectedWorkspaceId, newName },
+    { selectedWorkspaceId, newName, newNameSecondValidation },
     {
       selectedWorkspaceId: { presence: true },
-      newName: analysisNameValidator(existingNames)
+      newName: analysisNameValidator(existingNames),
+      newNameSecondValidation: extensionAnalysisNameValidator()
     },
-    { prettify: v => ({ newName: 'Name' }[v] || validate.prettify(v)) }
+    {
+      prettify: v => ({ newName: 'Name' }[v] || validate.prettify(v))
+    }
   )
+
+  if (errors?.newNameSecondValidation) {
+    errors.newName = [].concat(errors.newName, errors.newNameSecondValidation)
+  }
 
   return h(Modal, {
     title: 'Copy to Workspace',

--- a/src/pages/workspaces/workspace/analysis/modals/ExportAnalysisModal.js
+++ b/src/pages/workspaces/workspace/analysis/modals/ExportAnalysisModal.js
@@ -13,7 +13,7 @@ import * as Nav from 'src/libs/nav'
 import { useCancellation } from 'src/libs/react-utils'
 import * as Utils from 'src/libs/utils'
 import {
-  analysisNameInput, analysisNameValidator, extensionAnalysisNameValidator, getAnalysisFileExtension, getDisplayName, stripExtension
+  analysisNameInput, analysisNameValidator, getAnalysisFileExtension, getDisplayName, getExtension, stripExtension
 } from 'src/pages/workspaces/workspace/analysis/notebook-utils'
 import { analysisLauncherTabName, analysisTabName } from 'src/pages/workspaces/workspace/analysis/runtime-common'
 import validate from 'validate.js'
@@ -25,9 +25,8 @@ export const ExportAnalysisModal = ({ fromLauncher, onDismiss, printName, toolLa
   const [error, setError] = useState(undefined)
   const [copying, setCopying] = useState(false)
   const [copied, setCopied] = useState(false)
-  const [newName, setNewName] = useState(printName)
+  const [newName, setNewName] = useState(stripExtension(printName))
   const [existingNames, setExistingNames] = useState(undefined)
-
   const signal = useCancellation()
   const { workspaces } = useWorkspaces()
 
@@ -36,7 +35,6 @@ export const ExportAnalysisModal = ({ fromLauncher, onDismiss, printName, toolLa
 
   const findAnalysis = async v => {
     const tempChosenWorkspace = _.find({ workspace: { workspaceId: v } }, workspaces).workspace
-
     const selectedAnalyses = !!tempChosenWorkspace.googleProject ?
       await Ajax(signal).Buckets.listAnalyses(tempChosenWorkspace.googleProject, tempChosenWorkspace.bucketName) :
       await Ajax(signal).AzureStorage.listNotebooks(tempChosenWorkspace.workspaceId)
@@ -49,7 +47,7 @@ export const ExportAnalysisModal = ({ fromLauncher, onDismiss, printName, toolLa
         await Ajax()
           .Buckets
           .analysis(workspace.workspace.googleProject, workspace.workspace.bucketName, printName, toolLabel)
-          .copy(newName, selectedWorkspace.workspace.bucketName)
+          .copy(`${newName}.${getExtension(printName)}`, selectedWorkspace.workspace.bucketName)
       } else {
         await Ajax(signal).AzureStorage
           .blob(workspace.workspace.workspaceId, printName)
@@ -62,23 +60,16 @@ export const ExportAnalysisModal = ({ fromLauncher, onDismiss, printName, toolLa
     }
   })
 
-  const newNameSecondValidation = newName
-  // Render
   const errors = validate(
-    { selectedWorkspaceId, newName, newNameSecondValidation },
+    { selectedWorkspaceId, newName },
     {
       selectedWorkspaceId: { presence: true },
-      newName: analysisNameValidator(existingNames),
-      newNameSecondValidation: extensionAnalysisNameValidator()
+      newName: analysisNameValidator(existingNames)
     },
     {
       prettify: v => ({ newName: 'Name' }[v] || validate.prettify(v))
     }
   )
-
-  if (errors?.newNameSecondValidation) {
-    errors.newName = [].concat(errors.newName, errors.newNameSecondValidation)
-  }
 
   return h(Modal, {
     title: 'Copy to Workspace',

--- a/src/pages/workspaces/workspace/analysis/notebook-utils.js
+++ b/src/pages/workspaces/workspace/analysis/notebook-utils.js
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp'
 import { Fragment, useState } from 'react'
-import { div, h, span } from 'react-hyperscript-helpers'
+import { div, h } from 'react-hyperscript-helpers'
 import { ButtonPrimary, IdContainer, Select, spinnerOverlay } from 'src/components/common'
 import { centeredSpinner } from 'src/components/icons'
 import { ValidatedInput } from 'src/components/input'
@@ -39,29 +39,17 @@ export const findPotentialNotebookLockers = async ({ canShare, namespace, worksp
 
 export const analysisNameValidator = existing => ({
   presence: { allowEmpty: false },
-  format:
-    {
-      pattern: /^[^@#$%*+=?,[\]:;/\\]*$/,
-      message: h(Fragment, [
-        div('Name can\'t contain these characters:'),
-        div({ style: { margin: '0.5rem 1rem' } }, '@ # $ % * + = ? , [ ] : ; / \\ ')
-      ])
-    },
+  format: {
+    pattern: /^[^@#$%*+=?,[\]:;/\\]*$/,
+    message: h(Fragment, [
+      div('Name can\'t contain these characters:'),
+      div({ style: { margin: '0.5rem 1rem' } }, '@ # $ % * + = ? , [ ] : ; / \\ ')
+    ])
+  },
   exclusion: {
     within: existing,
     message: 'already exists'
   }
-})
-
-export const extensionAnalysisNameValidator = () => ({
-  presence: { allowEmpty: false },
-  format:
-    {
-      pattern: /.*(.ipynb|.Rmd|.R)$/,
-      message: h(Fragment, [
-        div(['Please add file extension: ', span({ style: { textTransform: 'none' } }, '".ipynb" ".Rmd" or ".R"')])
-      ])
-    }
 })
 
 // removes all paths up to and including the last slash
@@ -183,7 +171,6 @@ export const NotebookCreator = ({ reloadList, onSuccess, onDismiss, googleProjec
       notebookName: analysisNameValidator(existingNames),
       notebookKernel: { presence: { allowEmpty: false } }
     },
-    { notebookName: extensionAnalysisNameValidator(existingNames) },
     { prettify: v => ({ notebookName: 'Name', notebookKernel: 'Language' }[v] || validate.prettify(v)) }
   )
 
@@ -255,7 +242,6 @@ export const AnalysisDuplicator = ({ destroyOld = false, fromLauncher = false, p
   const errors = validate(
     { newName },
     { newName: analysisNameValidator(existingNames) },
-    { newName: extensionAnalysisNameValidator(existingNames) },
     { prettify: v => ({ newName: 'Name' }[v] || validate.prettify(v)) }
   )
 

--- a/src/pages/workspaces/workspace/analysis/notebook-utils.js
+++ b/src/pages/workspaces/workspace/analysis/notebook-utils.js
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp'
 import { Fragment, useState } from 'react'
-import { div, h } from 'react-hyperscript-helpers'
+import { div, h, span } from 'react-hyperscript-helpers'
 import { ButtonPrimary, IdContainer, Select, spinnerOverlay } from 'src/components/common'
 import { centeredSpinner } from 'src/components/icons'
 import { ValidatedInput } from 'src/components/input'
@@ -57,9 +57,9 @@ export const extensionAnalysisNameValidator = () => ({
   presence: { allowEmpty: false },
   format:
     {
-      pattern: /.*(.ipynb|.Rmd|.R)$/i,
+      pattern: /.*(.ipynb|.Rmd|.R)$/,
       message: h(Fragment, [
-        div('Please add file extension: ".ipynb" ".Rmd" or ".R"')
+        div(['Please add file extension: ', span({ style: { textTransform: 'none' } }, '".ipynb" ".Rmd" or ".R"')])
       ])
     }
 })

--- a/src/pages/workspaces/workspace/analysis/notebook-utils.js
+++ b/src/pages/workspaces/workspace/analysis/notebook-utils.js
@@ -39,17 +39,29 @@ export const findPotentialNotebookLockers = async ({ canShare, namespace, worksp
 
 export const analysisNameValidator = existing => ({
   presence: { allowEmpty: false },
-  format: {
-    pattern: /^[^@#$%*+=?,[\]:;/\\]*$/,
-    message: h(Fragment, [
-      div('Name can\'t contain these characters:'),
-      div({ style: { margin: '0.5rem 1rem' } }, '@ # $ % * + = ? , [ ] : ; / \\ ')
-    ])
-  },
+  format:
+    {
+      pattern: /^[^@#$%*+=?,[\]:;/\\]*$/,
+      message: h(Fragment, [
+        div('Name can\'t contain these characters:'),
+        div({ style: { margin: '0.5rem 1rem' } }, '@ # $ % * + = ? , [ ] : ; / \\ ')
+      ])
+    },
   exclusion: {
     within: existing,
     message: 'already exists'
   }
+})
+
+export const extensionAnalysisNameValidator = () => ({
+  presence: { allowEmpty: false },
+  format:
+    {
+      pattern: /.*(.ipynb|.Rmd|.R)$/i,
+      message: h(Fragment, [
+        div('Please add file extension: ".ipynb" ".Rmd" or ".R"')
+      ])
+    }
 })
 
 // removes all paths up to and including the last slash
@@ -171,6 +183,7 @@ export const NotebookCreator = ({ reloadList, onSuccess, onDismiss, googleProjec
       notebookName: analysisNameValidator(existingNames),
       notebookKernel: { presence: { allowEmpty: false } }
     },
+    { notebookName: extensionAnalysisNameValidator(existingNames) },
     { prettify: v => ({ notebookName: 'Name', notebookKernel: 'Language' }[v] || validate.prettify(v)) }
   )
 
@@ -242,6 +255,7 @@ export const AnalysisDuplicator = ({ destroyOld = false, fromLauncher = false, p
   const errors = validate(
     { newName },
     { newName: analysisNameValidator(existingNames) },
+    { newName: extensionAnalysisNameValidator(existingNames) },
     { prettify: v => ({ newName: 'Name' }[v] || validate.prettify(v)) }
   )
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/SUP-735

# Description

When a user goes to copy to workspace from the analysis tab, if the file extension is incorrect, the file will not appear to be copied over.

# Implementation

The solution is to remove the file extension and always append the file extension to the name once copy is selected.

# Testing


Tested with names that already exist, error message shows that there's already a file with that name at destination.
Tested with adding an extension anyways.
Tested without renaming.
Tested with a new name.



<!--
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Also, so if a screen recording [1] and/or screenshots would be a helpful way to communicate context, please consider including some in your PR description.
Thanks!

[1] https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac
--!>
