### PR TITLE
[SU-241] Fix file preview

### DIFF
--- a/src/libs/ajax/GoogleStorage.js
+++ b/src/libs/ajax/GoogleStorage.js
@@ -25,7 +25,7 @@ export const GoogleStorage = signal => ({
         { signal },
         previewFull ? {} : { headers: { Range: 'bytes=0-20000' } }
       ])
-    ).then(res => res.json())
+    )
   },
 
   listNotebooks: async (googleProject, name) => {

--- a/src/pages/workspaces/workspace/analysis/modals/ComputeModal.js
+++ b/src/pages/workspaces/workspace/analysis/modals/ComputeModal.js
@@ -695,7 +695,8 @@ export const ComputeModalBase = ({
         currentRuntime ? Ajax().Runtimes.runtime(currentRuntime.googleProject, currentRuntime.runtimeName).details() : null,
         Ajax()
           .Buckets
-          .getObjectPreview(googleProject, getConfig().terraDockerImageBucket, getConfig().terraDockerVersionsFile, true),
+          .getObjectPreview(googleProject, getConfig().terraDockerImageBucket, getConfig().terraDockerVersionsFile, true)
+          .then(r => r.json()),
         currentDisk ? Ajax().Disks.disk(currentDisk.googleProject, currentDisk.name).details() : null
       ])
 

--- a/src/pages/workspaces/workspace/analysis/modals/ComputeModal.test.js
+++ b/src/pages/workspaces/workspace/analysis/modals/ComputeModal.test.js
@@ -77,7 +77,7 @@ const defaultAjaxImpl = {
       details: jest.fn()
     })
   },
-  Buckets: { getObjectPreview: () => Promise.resolve(imageDocs) },
+  Buckets: { getObjectPreview: () => Promise.resolve({ json: () => Promise.resolve(imageDocs) }) },
   Disks: {
     disk: () => ({
       details: jest.fn()


### PR DESCRIPTION
Currently, when viewing any file in the files browser, the modal says "Unable to load preview".

This is because, since #3403, the `getObjectPreview` function makes an invalid assumption that the object contains JSON.

## Before
![Screen Shot 2022-10-11 at 2 43 39 PM](https://user-images.githubusercontent.com/1156625/195174690-122a985a-753c-4fdc-af61-e2b41b5d8f94.png)

## After
![Screen Shot 2022-10-11 at 2 46 41 PM](https://user-images.githubusercontent.com/1156625/195174712-3e160319-5b0f-418d-a372-0c056e263aa1.png)

