### PR TITLE
[SU-220] Improve color contrast in data table menu bars

### DIFF
--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -408,7 +408,7 @@ const EntitiesContent = ({
         ]),
         deleteColumnUpdateMetadata,
         controlPanelStyle: {
-          background: colors.light(isRadX() ? 0.3 : 1),
+          background: colors.light(isRadX() ? 0.3 : 0.5),
           borderBottom: `1px solid ${colors.grey(0.4)}`
         },
         border: false,

--- a/src/components/data/LocalVariablesContent.js
+++ b/src/components/data/LocalVariablesContent.js
@@ -154,7 +154,7 @@ const LocalVariablesContent = ({ workspace, workspace: { workspace: { namespace,
       style: {
         flex: 'none', display: 'flex', alignItems: 'center', justifyContent: 'flex-end',
         padding: '1rem',
-        background: colors.light(),
+        background: colors.light(0.5),
         borderBottom: `1px solid ${colors.grey(0.4)}`
       }
     }, [

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -141,7 +141,7 @@ const ReferenceDataContent = ({ workspace, referenceKey }) => {
       style: {
         display: 'flex', justifyContent: 'flex-end',
         padding: '1rem',
-        background: colors.light(),
+        background: colors.light(0.5),
         borderBottom: `1px solid ${colors.grey(0.4)}`
       }
     }, [
@@ -887,7 +887,7 @@ const WorkspaceData = _.flow(
             style: { flex: '1 1 auto' },
             controlPanelStyle: {
               padding: '1rem',
-              background: colors.light()
+              background: colors.light(0.5)
             },
             workspace,
             extraMenuItems: h(Link, {


### PR DESCRIPTION
Currently, menu bars in the data table do not meet contrast requirements for accessibility.

## Before
![Screen Shot 2022-10-11 at 3 31 16 PM](https://user-images.githubusercontent.com/1156625/195182111-6aac870c-d4ca-4ae2-9e93-46ea3a7d8a2a.png)

## After
![Screen Shot 2022-10-11 at 3 30 37 PM](https://user-images.githubusercontent.com/1156625/195182139-f38d4bee-4098-4001-94f1-2bb038ffae6e.png)

