### PR TITLE
[WOR-564] delete apps before deleting workspace

### DIFF
--- a/src/pages/workspaces/workspace/DeleteWorkspaceModal.js
+++ b/src/pages/workspaces/workspace/DeleteWorkspaceModal.js
@@ -80,12 +80,12 @@ const DeleteWorkspaceModal = ({ workspace: { workspace: { namespace, name, bucke
   const deleteWorkspace = async () => {
     try {
       setDeleting(true)
-      await Ajax().Workspaces.workspace(namespace, name).delete()
       if (isGoogleWorkspace) {
         await Promise.all(
           _.map(async app => await Ajax().Apps.app(app.cloudContext.cloudResource, app.appName).delete(), deletableApps)
         )
       }
+      await Ajax().Workspaces.workspace(namespace, name).delete()
       onDismiss()
       onSuccess()
     } catch (error) {


### PR DESCRIPTION
Ticket: [WOR-564](https://broadworkbench.atlassian.net/browse/WOR-564)
* Deleting a workspace that still has apps in it will fail in Rawls. We attempt to automatically delete running or errored k8s apps before deleting the workspace, but this needs to happen before we delete the workspace in Rawls, not after. 
<!--
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Also, so if a screen recording [1] and/or screenshots would be a helpful way to communicate context, please consider including some in your PR description.
Thanks!

[1] https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac
--!>
