### PR TITLE
[WOR-562] Remove "Community Workbench" from Terra welcome message

### DIFF
--- a/src/libs/brands.js
+++ b/src/libs/brands.js
@@ -220,7 +220,7 @@ export const brands = {
     name: 'Terra',
     signInName: 'Terra',
     queryName: 'terra',
-    welcomeHeader: 'Welcome to Terra Community Workbench',
+    welcomeHeader: 'Welcome to Terra',
     description: 'Terra is a cloud-native platform for biomedical researchers to access data, run analysis tools, and collaborate.',
     hostName: 'app.terra.bio',
     docLinks: [


### PR DESCRIPTION
This is the only place I found "Community Workbench" in the terra-ui codebase.

Before:

![image](https://user-images.githubusercontent.com/484484/195926461-882f7995-91b6-4221-b419-c190d0d0dfa1.png)

After:

![image](https://user-images.githubusercontent.com/484484/195926343-0ca37809-b8f5-49e5-a700-5393d74e7bb5.png)
