### PR TITLE
[PPWM-77] Add Persistent Disk Notification to Workspace List Page

### DIFF
--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -382,6 +382,12 @@ export const WorkspaceList = () => {
   return h(FooterWrapper, [
     h(TopBar, { title: 'Workspaces' }),
     div({ role: 'main', style: { padding: '1.5rem', flex: 1, display: 'flex', flexDirection: 'column' } }, [
+      somePersistentDiskRequiresMigration(workspaces, gcpPersistentDisks) && h(UnboundDiskNotification, {
+        style: {
+          position: 'absolute', top: topBarHeight, left: '50%', transform: 'translate(-50%, -50%)',
+          zIndex: 2 // Draw over top bar but behind contact support dialog
+        }
+      }),
       div({ style: { display: 'flex', alignItems: 'center', marginBottom: '0.5rem' } }, [
         div({ style: { ...Style.elements.sectionHeader, fontSize: '1.5rem' } }, ['Workspaces']),
         h(Link, {
@@ -528,13 +534,7 @@ export const WorkspaceList = () => {
         workspace: getWorkspace(requestingAccessWorkspaceId),
         onDismiss: () => setRequestingAccessWorkspaceId(undefined)
       }),
-      loadingWorkspaces && (!workspaces ? transparentSpinnerOverlay : topSpinnerOverlay),
-      somePersistentDiskRequiresMigration(workspaces, gcpPersistentDisks) && h(UnboundDiskNotification, {
-        style: {
-          position: 'absolute', top: topBarHeight, left: '50%', transform: 'translate(-50%, -50%)',
-          zIndex: 2 // Draw over top bar but behind contact support dialog
-        }
-      })
+      loadingWorkspaces && (!workspaces ? transparentSpinnerOverlay : topSpinnerOverlay)
     ])
   ])
 }

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -95,7 +95,7 @@ const workspaceSubmissionStatus = workspace => {
 }
 
 // [PPWM-104] Temporary logic supporting project-per-workspace persistent disk migration
-const anyPersistentDiskRequiresMigration = (workspaces, disks) => {
+const somePersistentDiskRequiresMigration = (workspaces, disks) => {
   // construct map of namespace -> (map of name -> workspace) from list of workspace
   const workspacesByNsAndName = _.flow(
     _.map('workspace'),
@@ -103,7 +103,7 @@ const anyPersistentDiskRequiresMigration = (workspaces, disks) => {
     _.mapValues(_.flow(_.groupBy('name'), _.mapValues(_.head)))
   )(workspaces)
 
-  return _.flip(_.some)(disks, ({ googleProject, labels }) => {
+  return workspaces && _.flip(_.some)(disks, ({ googleProject, labels }) => {
     return workspacesByNsAndName[labels.saturnWorkspaceNamespace]?.[labels.saturnWorkspaceName]?.googleProject !== googleProject
   })
 }
@@ -529,7 +529,7 @@ export const WorkspaceList = () => {
         onDismiss: () => setRequestingAccessWorkspaceId(undefined)
       }),
       loadingWorkspaces && (!workspaces ? transparentSpinnerOverlay : topSpinnerOverlay),
-      !loadingWorkspaces && anyPersistentDiskRequiresMigration(workspaces, gcpPersistentDisks) && h(UnboundDiskNotification, {
+      somePersistentDiskRequiresMigration(workspaces, gcpPersistentDisks) && h(UnboundDiskNotification, {
         style: {
           position: 'absolute', top: topBarHeight, left: '50%', transform: 'translate(-50%, -50%)',
           zIndex: 2 // Draw over top bar but behind contact support dialog

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -95,14 +95,15 @@ const workspaceSubmissionStatus = workspace => {
 }
 
 const anyPersistentDiskRequiresMigration = (workspaces, disks) => {
-  const workspacesByNamespace = _.flow(
+  // construct map of namespace -> (map of name -> workspace) from list of workspace
+  const workspacesByNsAndName = _.flow(
     _.map('workspace'),
     _.groupBy('namespace'),
-    _.mapValues(_.flowRight(_.mapValues(_.head), _.groupBy('name')))
+    _.mapValues(_.flow(_.groupBy('name'), _.mapValues(_.head)))
   )(workspaces)
 
   return _.flip(_.some)(disks, ({ googleProject, labels }) => {
-    return workspacesByNamespace[labels.saturnWorkspaceNamespace]?.[labels.saturnWorkspaceName]?.googleProject !== googleProject
+    return workspacesByNsAndName[labels.saturnWorkspaceNamespace]?.[labels.saturnWorkspaceName]?.googleProject !== googleProject
   })
 }
 

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -127,13 +127,15 @@ const RightBoxSection = ({ title, info, initialOpenState, afterTitle, onClick, c
   ])
 }
 
-const UnboundDiskNotification = () => {
+export const UnboundDiskNotification = props => {
   return div({
+    ...props,
     style: {
       ...Style.dashboard.rightBoxContainer,
       padding: '1rem',
       border: '1px solid',
-      borderColor: colors.accent()
+      borderColor: colors.accent(),
+      ...props?.style
     }
   }, [
     strong(['Persistent disks can no longer be shared between workspaces. ']),


### PR DESCRIPTION
RR: https://broadworkbench.atlassian.net/browse/PPWM-77 
Add a notification to the workspace list page if the user has any persistent disks that need migrating (ie created in the workspaces old google project).

Notes
- this notification appears in the workspace list page rather than the main landing page to avoid loading all workspaces and disks before the user does anything.
- notification text from https://github.com/DataBiosphere/terra-ui/pull/3425 


![image](https://user-images.githubusercontent.com/8223952/196238651-fbacfd0a-2385-4d8e-aad4-ff6d82536a0d.png)

<!--
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Also, so if a screen recording [1] and/or screenshots would be a helpful way to communicate context, please consider including some in your PR description.
Thanks!

[1] https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac
--!>
