### PR TITLE
[SU-242] Make workspace dashboard breadcrumbs consistent with other tabs

### DIFF
--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -251,8 +251,9 @@ export const WorkspaceNotifications = ({ workspace }) => {
 const WorkspaceDashboard = _.flow(
   forwardRefWithName('WorkspaceDashboard'),
   wrapWorkspace({
-    breadcrumbs: () => breadcrumbs.commonPaths.workspaceList(),
-    activeTab: 'dashboard'
+    breadcrumbs: props => breadcrumbs.commonPaths.workspaceDashboard(props),
+    activeTab: 'dashboard',
+    title: 'Dashboard'
   })
 )(({
   namespace, name,


### PR DESCRIPTION
Currently, the breadcrumbs for the workspace dashboard tab are different from the other workspace tabs. The dashboard tab shows the workspace name in large font while other tabs show the tab name with the workspace name in smaller font.

Dashboard
![before](https://user-images.githubusercontent.com/1156625/196740080-8e1d46c8-3baf-4c72-be73-3708e3349811.png)

Data
![data tab](https://user-images.githubusercontent.com/1156625/196740077-2e2efaca-9970-47a6-b5d6-4685735ef2d5.png)

Analyses
![analyses tab](https://user-images.githubusercontent.com/1156625/196740076-cb2b780a-a5bf-4f1b-b4d8-845be3c59d7d.png)

This changes the dashboard breadcrumbs to be consistent with the other tabs.

## Before
![before](https://user-images.githubusercontent.com/1156625/196740080-8e1d46c8-3baf-4c72-be73-3708e3349811.png)

## After
![after](https://user-images.githubusercontent.com/1156625/196740083-9e69aa32-7342-484c-bccb-48510d7eb729.png)
