### PR TITLE
Fix polling/display of creating billing projects to work with Azure asynchronous creation (WOR-506).

### DIFF
--- a/src/pages/billing/List.js
+++ b/src/pages/billing/List.js
@@ -47,6 +47,8 @@ const styles = {
   }
 }
 
+const isCreatingStatus = status => _.includes(status, ['Creating', 'CreatingLandingZone'])
+
 const CreateBillingProjectControl = ({ isAlphaAzureUser, showCreateProjectModal }) => {
   const createButton = (onClickCallback, type) => {
     return h(ButtonOutline, {
@@ -133,7 +135,7 @@ const ProjectListItem = ({ project, project: { roles, status, cloudPlatform }, l
 
   const unselectableProject = ({ projectName, status, message }, isActive, isOwner) => {
     const iconAndTooltip =
-      status === 'Creating' ? spinner({ size: 16, style: { color: colors.accent(), margin: '0 1rem 0 0.5rem' } }) :
+      isCreatingStatus(status) ? spinner({ size: 16, style: { color: colors.accent(), margin: '0 1rem 0 0.5rem' } }) :
         status === 'Error' ? h(Fragment, [
           h(InfoBox, { style: { color: colors.danger(), margin: '0 0.5rem 0 0.5rem' }, side: 'right' }, [
             div({ style: { wordWrap: 'break-word', whiteSpace: 'pre-wrap' } }, [
@@ -378,7 +380,7 @@ export const BillingList = ({ queryParams: { selectedName } }) => {
   })
 
   useEffect(() => {
-    const anyProjectsCreating = _.some({ creationStatus: 'Creating' }, billingProjects)
+    const anyProjectsCreating = _.some(({ status }) => isCreatingStatus(status), billingProjects)
 
     if (anyProjectsCreating && !interval.current) {
       interval.current = setInterval(loadProjects, 10000)


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-506

The v1 Rawls billing API included `creationStatus` for each project in the billing project list response. The `v2` API uses `status` instead, so the code in terra-ui that was looking for `creationStatus` was dead code.

This wasn't a big deal because Google project creation is now synchronous (`creationStatus` and related code was left over from when Google project creation was asynchronous). But now Azure project creation is going to be asynchronous (once https://github.com/broadinstitute/rawls/pull/2070 merges), and we would like to reuse the existing machinery to properly show when Azure-backed projects are still in Creating state.

This is how it looks when running against my Rawls branch. Note the repeated polls to check status. 

![image](https://user-images.githubusercontent.com/484484/196765614-9b9ede93-f6a2-4e12-ace6-6eb7d95f5c00.png)

I wanted to extend our existing (mocked) integration test to cover this, but ran into a problem about the fact that our SVGs have non-unique IDs (IDs are required when using `linearGradient`). This impacts the test in a couple of ways:

1. The a11y check would fail because we would have multiple billing projects with the Azure cloud SVG (multiple IDs). I guess I could mock the data to not include the Azure cloud platform to avoid this, but it would make the mock data unrealistic.
2. The `waitForNoSpinners` calls (which exist in a number of helper methods) would fail because the project in the "Creating" state will show a small spinner beside it. The `waitForNoSpinners` method currently looks for an element with id `loadingSpinner`, and that same ID is present in all loading spinners (which again is an accessibility issue). I could do something like also require the spinner to also have position `absolute`, but that would impact tests that actually want to use `waitForNoSpinners` to wait for _all_ spinners to be gone. Again, the fact that we have non-unique IDs in our SVGs is an actual problem, and we should think of a more holistic solution.

I spent some time Googling for solutions for dealing with SVGs that use `linearGradient` and so far haven't come up with anything. Created https://broadworkbench.atlassian.net/browse/TUIM-37 to investigate this further.


