### PR TITLE
[TUIM-38] Remove code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,2 @@
-# This is a comment.
 # Each line is a file pattern followed by one or more owners.
 # See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,3 @@
 # This is a comment.
 # Each line is a file pattern followed by one or more owners.
-
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# @DataBiosphere/terra-ui-code-owners will be requested for
-# review when someone opens a pull request.
-* @DataBiosphere/terra-ui-code-owners
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax


### PR DESCRIPTION
This removes the `@DataBiosphere/terra-ui-code-owners` group as a code owner for all of terra-ui.

Left the CODEOWNERS file in place since Individual teams may add themselves as code owners for specific components. Once this is merged, we can re-enable "Require review from code owners" in the dev branch's branch protection rules.