### PR TITLE
[TUIM-41] Make react-hyperscript-helper's h function accept a key

### DIFF
--- a/types/react-hyperscript-helpers/index.d.ts
+++ b/types/react-hyperscript-helpers/index.d.ts
@@ -8,7 +8,9 @@ declare module 'react-hyperscript-helpers' {
 
   type Children<Props> = Props extends { children?: React.ReactNode } ? React.ReactNode[] : (Props extends { children?: unknown } ? [Props['children']] : never)
 
-  type WithKey<P> = P & { key?: string }
+  type Key = string | number
+
+  type WithKey<P> = P & { key?: Key | null | undefined }
 
   interface HHelper {
     <Props extends {}>(

--- a/types/react-hyperscript-helpers/index.d.ts
+++ b/types/react-hyperscript-helpers/index.d.ts
@@ -8,16 +8,18 @@ declare module 'react-hyperscript-helpers' {
 
   type Children<Props> = Props extends { children?: React.ReactNode } ? React.ReactNode[] : (Props extends { children?: unknown } ? [Props['children']] : never)
 
+  type WithKey<P> = P & { key?: string }
+
   interface HHelper {
     <Props extends {}>(
       component: Component<Props>,
-      props: Omit<Props, 'children'>,
+      props: WithKey<Omit<Props, 'children'>>,
       children: Children<Props>
     ): React.ReactElement<any, any>;
 
     <Props extends {}>(
       component: Component<Props>,
-      propsOrChildren: Props extends { children?: unknown } ? Props | Children<Props> : Props
+      propsOrChildren: Props extends { children?: unknown } ? WithKey<Props> | Children<Props> : WithKey<Props>
     ): React.ReactElement<any, any>;
 
     <Props extends {}>(component: Component<Props>): React.ReactElement<any, any>;

--- a/types/react-hyperscript-helpers/react-hyperscript-helpers.errors.ts
+++ b/types/react-hyperscript-helpers/react-hyperscript-helpers.errors.ts
@@ -22,11 +22,11 @@ const TestComponent = (props: TestComponentProps) => div()
 // Missing required prop
 // TODO: This is currently valid, but preferably would error since it is missing a required prop (stringProp).
 h(TestComponent)
-// THROWS Argument of type '{ optionalNumberProp: number; }' is not assignable to parameter of type 'TestComponentProps'.
+// THROWS Argument of type '{ optionalNumberProp: number; }' is not assignable to parameter of type 'WithKey<TestComponentProps>'.
 h(TestComponent, { optionalNumberProp: 1 })
 
 // Invalid prop
-// THROWS Argument of type '{ invalidProp: string; }' is not assignable to parameter of type 'TestComponentProps'.
+// THROWS Argument of type '{ invalidProp: string; }' is not assignable to parameter of type 'WithKey<TestComponentProps>'.
 h(TestComponent, { invalidProp: 'value' })
 
 // Component does not accept children
@@ -36,7 +36,7 @@ h(TestComponent, { stringProp: 'value' }, [div()])
 // THROWS Argument of type '{ stringProp: string; }' is not assignable to parameter of type 'never'.
 h(TestComponent, { stringProp: 'value' }, { stringProp: 'value' })
 
-// THROWS Argument of type 'string[]' is not assignable to parameter of type 'Omit<TestComponentProps, "children">'.
+// THROWS Argument of type 'string[]' is not assignable to parameter of type 'WithKey<Omit<TestComponentProps, "children">>'.
 h(TestComponent, ['Content'], ['Content'])
 
 // Component that takes a function as a child

--- a/types/react-hyperscript-helpers/react-hyperscript-helpers.types.ts
+++ b/types/react-hyperscript-helpers/react-hyperscript-helpers.types.ts
@@ -25,6 +25,9 @@ interface TestComponentProps {
 
 const TestComponent = (props: PropsWithChildren<TestComponentProps>) => div()
 
+// PropsWithChildren with key
+h(TestComponent, { key: 'key', stringProp: 'value' })
+
 // Props
 h(TestComponent, { stringProp: 'value' })
 h(TestComponent, { stringProp: 'value', optionalNumberProp: 1 })

--- a/types/react-hyperscript-helpers/react-hyperscript-helpers.types.ts
+++ b/types/react-hyperscript-helpers/react-hyperscript-helpers.types.ts
@@ -18,6 +18,10 @@ div([false])
 div({ style: { display: 'flex' } }, ['Content'])
 div({ className: 'a-class' }, [div()])
 
+// Key
+div({ key: 'key' })
+div({ key: 'key', style: { display: 'flex' } }, [div()])
+
 interface TestComponentProps {
   stringProp: string
   optionalNumberProp?: number


### PR DESCRIPTION
Currently, when using a component typed with `PropsWithChildren`, `h` refuses to accept a key with that component.

```ts
import { PropsWithChildren } from 'react'

interface TestComponentProps {
  someProp: string
}

const TestComponent = (props: PropsWithChildren<TestComponentProps>) => div()

// Argument of type '{ key: string; someProp: string; }' is not assignable to parameter of type 'ReactNode[] | PropsWithChildren<TestComponentProps>'.
h(TestComponent, { key: 'key', someProp: 'value' })
```

Not sure why it accepts key when the component props are directly typed as an interface. I'm guessing it has something to do with the intersection applied by `PropsWithChildren`.

After adding this, TS starts complaining about components imported from JS modules. This would require adding ts-expect-error comments or type declarations for JS modules.

```ts
// Argument of type '{ onClick: () => void; }' is not assignable to parameter of type 'WithKey<Omit<{}, "children">>'.
// Object literal may only specify known properties, and 'onClick' does not exist in type 'WithKey<Omit<{}, "children">>'
h(Link, { onClick }, [children])
```