### PR TITLE
[SU-243] Add submitter to data table column provenance

### DIFF
--- a/src/components/data/data-table-provenance.js
+++ b/src/components/data/data-table-provenance.js
@@ -24,7 +24,7 @@ export const DataTableColumnProvenance = ({ workspace, column, provenance }) => 
       ' was configured as an output for the following submissions:'
     ]),
     ol({ style: { margin: 0, padding: 0, listStyleType: 'none' } }, [
-      _.map(({ submissionId, submissionDate, configuration, output }) => {
+      _.map(({ submissionId, submissionDate, submitter, configuration, output }) => {
         return li({ key: submissionId, style: { marginBottom: '0.75rem' } }, [
           div({ style: { marginBottom: '0.25rem' } }, [
             h(Link, {
@@ -32,6 +32,7 @@ export const DataTableColumnProvenance = ({ workspace, column, provenance }) => 
             }, [configuration.name])
           ]),
           div({ style: { marginBottom: '0.25rem' } }, [Utils.makeCompleteDate(submissionDate)]),
+          div({ style: { marginBottom: '0.25rem' } }, [`Submitted by ${submitter}`]),
           div({ style: { marginBottom: '0.25rem' } }, [output])
         ])
       }, provenance)

--- a/src/libs/data-table-provenance.js
+++ b/src/libs/data-table-provenance.js
@@ -58,7 +58,7 @@ const getColumnProvenance = async (workspace, entityType, { signal } = {}) => {
     _.map(({ expression, ...output }) => ({ ...output, column: getColumnFromOutputExpression(expression) })),
     _.filter(output => !!output.column),
     _.reduce((acc, { submission, configuration, output, column }) => {
-      const provenanceEntry = { submissionId: submission.submissionId, submissionDate: submission.submissionDate, configuration, output }
+      const provenanceEntry = { submissionId: submission.submissionId, submissionDate: submission.submissionDate, submitter: submission.submitter, configuration, output }
       return _.update(column, _.flow(_.defaultTo([]), Utils.append(provenanceEntry)), acc)
     }, {})
   )(submissions)


### PR DESCRIPTION
In a data table's column provenance, include the user who submitted the workflow that wrote to the column.

Enable data table provenance from the feature preview page (`/#feature-preview`).