### PR TITLE
[TUIM-40] Run ESLint in pre-commit hook when TS files are changed

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -121,7 +121,7 @@ module.exports = {
   },
   'overrides': [
     {
-      'files': 'src/**/*.js',
+      'files': 'src/**/*.{js,ts}',
       'rules': {
         'no-console': ['warn', { 'allow': ['assert', 'error'] }]
       }

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "integration-tests"
   ],
   "lint-staged": {
-    "**/*.js": [
+    "**/*.{js,ts}": [
       "yarn eslint --max-warnings=0"
     ]
   }


### PR DESCRIPTION
This changes a few places where ESLint was configured to only look at JavaScript files instead of both JS and TypeScript.

The change to lint-staged's configuration in package.json causes the pre-commit hook to run ESLint on TS files as well as JS files that were modified in the commit.

The change in .eslintrc.js makes ESLint complain about console logs in TS files in the src directory (as it currently does for JS files).