### PR TITLE
[AJ-522] added ignore empty outputs field to UI

### DIFF
--- a/src/libs/analysis.js
+++ b/src/libs/analysis.js
@@ -8,7 +8,7 @@ export const launch = async ({
   workspace: { workspace: { namespace, name, googleProject, bucketName }, accessLevel },
   config: { namespace: configNamespace, name: configName, rootEntityType },
   selectedEntityType, selectedEntityNames, newSetName, useCallCache = true, deleteIntermediateOutputFiles, useReferenceDisks,
-  memoryRetryMultiplier, userComment, onProgress
+  memoryRetryMultiplier, userComment, ignoreEmptyOutputs, onProgress
 }) => {
   const createSet = () => {
     onProgress('createSet')
@@ -59,6 +59,6 @@ export const launch = async ({
     ),
     entityName,
     expression: processSet ? `this.${rootEntityType}s` : undefined,
-    useCallCache, deleteIntermediateOutputFiles, useReferenceDisks, memoryRetryMultiplier, userComment
+    useCallCache, deleteIntermediateOutputFiles, useReferenceDisks, memoryRetryMultiplier, userComment, ignoreEmptyOutputs
   })
 }

--- a/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
+++ b/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
@@ -23,7 +23,7 @@ const LaunchAnalysisModal = ({
   workspace, workspace: { workspace: { namespace, name: workspaceName, bucketName, googleProject } }, processSingle,
   entitySelectionModel: { type, selectedEntities, newSetName },
   config, config: { rootEntityType }, useCallCache, deleteIntermediateOutputFiles, useReferenceDisks,
-  retryWithMoreMemory, retryMemoryFactor, onSuccess
+  retryWithMoreMemory, retryMemoryFactor, ignoreEmptyOutputs, onSuccess
 }) => {
   const [launching, setLaunching] = useState(undefined)
   const [message, setMessage] = useState(undefined)
@@ -59,7 +59,7 @@ const LaunchAnalysisModal = ({
       const { submissionId } = await launch({
         isSnapshot: type === processSnapshotTable,
         workspace, config, selectedEntityType, selectedEntityNames, newSetName, useCallCache, deleteIntermediateOutputFiles, useReferenceDisks,
-        memoryRetryMultiplier: retryWithMoreMemory ? retryMemoryFactor : undefined, userComment: _.trim(userComment),
+        memoryRetryMultiplier: retryWithMoreMemory ? retryMemoryFactor : undefined, userComment: _.trim(userComment), ignoreEmptyOutputs,
         onProgress: stage => {
           setMessage({ createSet: 'Creating set...', launch: 'Launching analysis...', checkBucketAccess: 'Checking bucket access...' }[stage])
         }

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -326,6 +326,7 @@ const WorkflowView = _.flow(
       useReferenceDisks: false,
       retryWithMoreMemory: false,
       retryMemoryFactor: 1.2,
+      ignoreEmptyOutputs: false,
       includeOptionalInputs: true,
       filter: '',
       errors: { inputs: {}, outputs: {} },
@@ -370,7 +371,7 @@ const WorkflowView = _.flow(
     // modifiedConfig: active data, potentially unsaved
     const {
       isFreshData, savedConfig, launching, activeTab, useCallCache, deleteIntermediateOutputFiles, useReferenceDisks,
-      retryWithMoreMemory, retryMemoryFactor, entitySelectionModel, variableSelected, modifiedConfig, updatingConfig,
+      retryWithMoreMemory, retryMemoryFactor, ignoreEmptyOutputs, entitySelectionModel, variableSelected, modifiedConfig, updatingConfig,
       selectedSnapshotEntityMetadata, availableSnapshots
     } = this.state
     const { namespace, name, workspace } = this.props
@@ -388,7 +389,7 @@ const WorkflowView = _.flow(
           workspace, config: savedConfig, entityMetadata: selectedSnapshotEntityMetadata,
           accessLevel: workspace.accessLevel, bucketName: workspace.workspace.bucketName,
           processSingle: this.isSingle(), entitySelectionModel, useCallCache, deleteIntermediateOutputFiles,
-          useReferenceDisks, retryWithMoreMemory, retryMemoryFactor,
+          useReferenceDisks, retryWithMoreMemory, retryMemoryFactor, ignoreEmptyOutputs,
           onDismiss: () => this.setState({ launching: false }),
           onSuccess: submissionId => {
             const { methodRepoMethod: { methodVersion, methodNamespace, methodName, methodPath, sourceRepo } } = modifiedConfig
@@ -604,7 +605,7 @@ const WorkflowView = _.flow(
     const {
       modifiedConfig, savedConfig, saving, saved, exporting, copying, deleting, selectingData, activeTab, errors, synopsis, documentation,
       availableSnapshots, selectedSnapshotEntityMetadata, selectedEntityType, entityMetadata, entitySelectionModel, versionIds = [], useCallCache,
-      deleteIntermediateOutputFiles, useReferenceDisks, retryWithMoreMemory, retryMemoryFactor, currentSnapRedacted, savedSnapRedacted, wdl,
+      deleteIntermediateOutputFiles, useReferenceDisks, retryWithMoreMemory, retryMemoryFactor, ignoreEmptyOutputs, currentSnapRedacted, savedSnapRedacted, wdl,
       snapshotReferenceError
     } = this.state
     const { name, methodRepoMethod: { methodPath, methodVersion, methodNamespace, methodName, sourceRepo }, rootEntityType } = modifiedConfig
@@ -884,7 +885,17 @@ const WorkflowView = _.flow(
                 h(Link, { href: this.getSupportLink('4403215299355'), ...Utils.newTabLinkProps },
                   [clickToLearnMore])
               ])
-            )
+            ),
+            span({ style: styles.checkBoxSpanMargins }, [
+              h(LabeledCheckbox, {
+                checked: ignoreEmptyOutputs,
+                onChange: v => this.setState({ ignoreEmptyOutputs: v }),
+                style: styles.checkBoxLeftMargin
+              }, [' Ignore empty outputs'])
+            ]),
+            h(InfoBox, [
+              'Do not create output columns if the data is null/empty. '
+            ])
           ]),
           h(StepButtons, {
             tabs: [


### PR DESCRIPTION
Added the new "Ignore empty columns" option to the workflow submission page. This is wired through as an additional param to the rawls API, which defaults to false.
Testing: verified that the param is correctly passed when the box is checked/unchecked.

<img width="1394" alt="Screen Shot 2022-10-26 at 10 57 46 AM" src="https://user-images.githubusercontent.com/8800717/198065545-076c8f8e-c418-4562-a89d-56abf7e05636.png">

<img width="481" alt="Screen Shot 2022-10-26 at 10 59 17 AM" src="https://user-images.githubusercontent.com/8800717/198065565-a9a261e5-d518-4e7a-8d4e-7dec62cd7cf4.png">
