### PR TITLE
[SUP-613] Update Content Security policy - add unsafe-eval to script-src

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -24,7 +24,7 @@ handlers:
   expiration: 0s
   secure: always
   http_headers:
-    Content-Security-Policy: "base-uri 'self'; object-src 'none'; script-src 'self' https://fast.appcues.com https://us.jsagent.tcell.insight.rapid7.com https://cdnjs.cloudflare.com; style-src * 'unsafe-inline'"
+    Content-Security-Policy: "base-uri 'self'; object-src 'none'; script-src 'self' 'unsafe-eval' https://fast.appcues.com https://us.jsagent.tcell.insight.rapid7.com https://cdnjs.cloudflare.com; style-src * 'unsafe-inline'"
     X-Frame-Options: "SAMEORIGIN"
     Strict-Transport-Security: "max-age=31536000; includeSubdomains; preload"
     X-Content-Type-Options: "nosniff"


### PR DESCRIPTION
IGV.js (by way of `@gmod/cram` and `@gmod/binary-parser`) uses `eval` to parse CRAM files. Terra UI's current [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) blocks the use of `eval`. This causes users to get an "error loading track data" error when trying to view CRAM files in IGV.

To allow `eval`, this adds `'unsafe-eval'` to the [script-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src) directive in the CSP header.

According to https://csp.withgoogle.com/docs/strict-csp.html,
> 'unsafe-eval' allows the application to use the eval() JavaScript function. This reduces the protection against certain types of DOM-based XSS bugs, but makes it easier to adopt CSP. If your application doesn't use eval(), you can remove this keyword and have a safer policy.