### PR TITLE
Add codeowners for Workspaces-owned files (WOR-584).

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,12 @@
 # See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
 /src/libs/brand*.js @DataBiosphere/terra-cobranding
 /src/libs/colors.js @DataBiosphere/terra-cobranding
+/src/pages/billing/ @DataBiosphere/broadworkspaces
+/src/pages/workspaces/* @DataBiosphere/broadworkspaces
+/src/pages/workspaces/workspace/*Dashboard* @DataBiosphere/broadworkspaces
+/src/pages/workspaces/workspace/*Workspace* @DataBiosphere/broadworkspaces
+/src/components/*Workspace* @DataBiosphere/broadworkspaces
+/src/components/workspace-utils* @DataBiosphere/broadworkspaces
+/integration-tests/tests/billing-projects.js @DataBiosphere/broadworkspaces
+/integration-tests/tests/janitor.js @DataBiosphere/broadworkspaces
+/integration-tests/tests/workspace-dashboard.js @DataBiosphere/broadworkspaces


### PR DESCRIPTION
I followed syntax as defined in https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax, but don't know how to actually test that it works before the PR is merged. Iterating if necessary doesn't seem like a big deal though.