### PR TITLE
[WOR-586, WOR-582] Remove menu integration test coverage, add Azure storage URL details.

### DIFF
--- a/integration-tests/tests/workspace-dashboard.js
+++ b/integration-tests/tests/workspace-dashboard.js
@@ -166,7 +166,7 @@ const setAzureAjaxMockValues = async (testPage, namespace, name, workspaceDescri
       },
       {
         filter: { url: workspaceSasTokenUrl },
-        fn: () => () => Promise.resolve(new Response(JSON.stringify({ sasToken: 'fake_token', url: 'http://example.com' }), { status: 200 }))
+        fn: () => () => Promise.resolve(new Response(JSON.stringify({ sasToken: 'fake_token', url: 'http://storageContainerUrl.com?sasTokenParams' }), { status: 200 }))
       },
       {
         filter: { url: /api\/workspaces[^/](.*)/ },
@@ -197,9 +197,9 @@ const testAzureWorkspace = withUserToken(async ({ page, token, testUrl }) => {
   await dashboard.assertCloudInformation([
     'Cloud NameMicrosoft Azure',
     'Resource Group IDdummy-mrg-id',
-    'Storage Container Namesc-name',
+    'Storage Container URLhttp://storageContainerUrl.com',
     'Location🇺🇸 East US',
-    'SAS URLhttp://example.com'
+    'SAS URLhttp://storageContainerUrl.com?sasTokenParams'
   ])
 
   // READER permissions only

--- a/integration-tests/tests/workspace-dashboard.js
+++ b/integration-tests/tests/workspace-dashboard.js
@@ -2,7 +2,7 @@
 const _ = require('lodash/fp')
 const { viewWorkspaceDashboard, withWorkspace } = require('../utils/integration-helpers')
 const {
-  assertNavChildNotFound, assertTextNotFound, click, clickable, findElement, findText, gotoPage, navChild, noSpinnersAfter, verifyAccessibility
+  assertNavChildNotFound, click, clickable, findText, gotoPage, navChild, verifyAccessibility
 } = require('../utils/integration-utils')
 const { registerTest } = require('../utils/jest-utils')
 const { withUserToken } = require('../utils/terra-sa-utils')
@@ -25,34 +25,6 @@ const workspaceDashboardPage = (testPage, token, workspaceName) => {
 
     assertReadOnly: async () => {
       await findText(testPage, 'Workspace is read only')
-    },
-
-    assertWorkspaceMenuItems: async expectedMenuItems => {
-      await click(testPage, clickable({ text: 'Workspace Action Menu' }))
-      await Promise.all(_.map(async ({ label, tooltip }) => {
-        if (!!tooltip) {
-          await findElement(testPage, clickable({ textContains: label, isEnabled: false }))
-          await findText(testPage, tooltip)
-        } else {
-          await findElement(testPage, clickable({ textContains: label }))
-        }
-      }, expectedMenuItems))
-    },
-
-    assertLockWorkspace: async () => {
-      await assertTextNotFound(testPage, 'Workspace is locked')
-      await click(testPage, clickable({ text: 'Workspace Action Menu' }))
-      await click(testPage, clickable({ textContains: 'Lock' }))
-      await noSpinnersAfter(testPage, { action: () => click(testPage, clickable({ text: 'Lock Workspace' })) })
-      await findText(testPage, 'Workspace is locked')
-    },
-
-    assertUnlockWorkspace: async () => {
-      await findText(testPage, 'Workspace is locked')
-      await click(testPage, clickable({ text: 'Workspace Action Menu' }))
-      await click(testPage, clickable({ textContains: 'Unlock' }))
-      await noSpinnersAfter(testPage, { action: () => click(testPage, clickable({ text: 'Unlock Workspace' })) })
-      await assertTextNotFound(testPage, 'Workspace is locked')
     },
 
     assertTabs: async (expectedTabs, enabled) => {
@@ -93,13 +65,6 @@ const testGoogleWorkspace = _.flow(
   // Check selected items in cloud information
   const currentDate = new Date().toLocaleDateString()
   await dashboard.assertCloudInformation(['Cloud NameGoogle Cloud Platform', `Bucket SizeUpdated on ${currentDate}0 B`])
-
-  // Test locking and unlocking the workspace
-  await dashboard.assertLockWorkspace()
-  await dashboard.assertUnlockWorkspace()
-
-  // Verify other Workspace menu items are in correct state (all will be enabled).
-  await dashboard.assertWorkspaceMenuItems([{ label: 'Clone' }, { label: 'Share' }, { label: 'Delete' }, { label: 'Lock' }])
 
   // Verify expected tabs are present.
   await dashboard.assertTabs(['data', 'analyses', 'workflows', 'job history'], true)
@@ -239,14 +204,6 @@ const testAzureWorkspace = withUserToken(async ({ page, token, testUrl }) => {
 
   // READER permissions only
   await dashboard.assertReadOnly()
-
-  // Verify workspace tooltips on Workspace menu items (all will be disabled due to Azure workspace + READER permissions).
-  await dashboard.assertWorkspaceMenuItems([
-    { label: 'Clone', tooltip: 'Cloning is not currently supported on Azure Workspaces' },
-    { label: 'Share', tooltip: 'You have not been granted permission to share this workspace' },
-    { label: 'Lock', tooltip: 'You have not been granted permission to lock this workspace' },
-    { label: 'Delete', tooltip: 'You must be an owner of this workspace or the underlying billing project' }
-  ])
 
   // Verify tabs that currently depend on Google project ID are not present.
   await dashboard.assertTabs(['data', 'notebooks', 'workflows', 'job history'], false)

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -273,7 +273,7 @@ const WorkspaceDashboard = _.flow(
   const [submissionsCount, setSubmissionsCount] = useState(undefined)
   const [storageCost, setStorageCost] = useState(undefined)
   const [bucketSize, setBucketSize] = useState(undefined)
-  const [{ storageContainerName, storageLocation, sas: { url } }, setAzureStorage] = useState({ storageContainerName: undefined, storageLocation: undefined, sas: {} })
+  const [{ storageContainerUrl, storageLocation, sas: { url } }, setAzureStorage] = useState({ storageContainerUrl: undefined, storageLocation: undefined, sas: {} })
   const [editDescription, setEditDescription] = useState(undefined)
   const [saving, setSaving] = useState(false)
   const [busy, setBusy] = useState(false)
@@ -365,8 +365,8 @@ const WorkspaceDashboard = _.flow(
   })
 
   const loadAzureStorage = withErrorReporting('Error loading Azure storage information.', async () => {
-    const { storageContainerName, location, sas } = await Ajax(signal).AzureStorage.details(workspaceId)
-    setAzureStorage({ storageContainerName, storageLocation: location, sas })
+    const { location, sas } = await Ajax(signal).AzureStorage.details(workspaceId)
+    setAzureStorage({ storageContainerUrl: _.head(_.split('?', sas.url)), storageLocation: location, sas })
   })
 
   const loadConsent = withErrorReporting('Error loading data', async () => {
@@ -483,11 +483,11 @@ const WorkspaceDashboard = _.flow(
           h(TooltipCell, [azureContext.managedResourceGroupId]),
           h(ClipboardButton, { 'aria-label': 'Copy resource group id to clipboard', text: azureContext.managedResourceGroupId, style: { marginLeft: '0.25rem' } })
         ]),
-        h(InfoRow, { title: 'Storage Container Name' }, [
-          h(TooltipCell, [!!storageContainerName ? storageContainerName : 'Loading']),
+        h(InfoRow, { title: 'Storage Container URL' }, [
+          h(TooltipCell, [!!storageContainerUrl ? storageContainerUrl : 'Loading']),
           h(ClipboardButton, {
-            'aria-label': 'Copy storage container name to clipboard',
-            text: storageContainerName, style: { marginLeft: '0.25rem' }
+            'aria-label': 'Copy storage container URL to clipboard',
+            text: storageContainerUrl, style: { marginLeft: '0.25rem' }
           })
         ]),
         h(InfoRow, { title: 'Storage SAS URL' }, [
@@ -496,6 +496,21 @@ const WorkspaceDashboard = _.flow(
             'aria-label': 'Copy SAS URL to clipboard',
             text: url, style: { marginLeft: '0.25rem' }
           })
+        ]),
+        div({ style: { margin: '0.5rem', fontSize: 12 } }, [
+          div(['Use SAS URL in conjunction with ',
+            h(Link, {
+              ...Utils.newTabLinkProps, href: 'https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-v10',
+              style: { textDecoration: 'underline' }
+            }, 'AzCopy'),
+            ' or ',
+            h(Link, {
+              ...Utils.newTabLinkProps, href: 'https://azure.microsoft.com/en-us/products/storage/storage-explorer',
+              style: { textDecoration: 'underline' }
+            }, 'Azure Storage Explorer'),
+            ' to access storage associated with this workspace.']),
+          div({ style: { paddingTop: '0.5rem', fontWeight: 'bold' } },
+            ['The SAS URL expires after 1 hour. To generate a new SAS URL, refresh this page.'])
         ])
       ]),
       !!googleProject && div({ style: { paddingBottom: '0.5rem' } }, [h(Link, {

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -496,21 +496,6 @@ const WorkspaceDashboard = _.flow(
             'aria-label': 'Copy SAS URL to clipboard',
             text: url, style: { marginLeft: '0.25rem' }
           })
-        ]),
-        div({ style: { margin: '0.5rem', fontSize: 12 } }, [
-          div(['Use SAS URL in conjunction with ',
-            h(Link, {
-              ...Utils.newTabLinkProps, href: 'https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-v10',
-              style: { textDecoration: 'underline' }
-            }, 'AzCopy'),
-            ' or ',
-            h(Link, {
-              ...Utils.newTabLinkProps, href: 'https://azure.microsoft.com/en-us/products/storage/storage-explorer',
-              style: { textDecoration: 'underline' }
-            }, 'Azure Storage Explorer'),
-            ' to access storage associated with this workspace.']),
-          div({ style: { paddingTop: '0.5rem', fontWeight: 'bold' } },
-            ['The SAS URL expires after 1 hour. To generate a new SAS URL, refresh this page.'])
         ])
       ]),
       !!googleProject && div({ style: { paddingBottom: '0.5rem' } }, [h(Link, {
@@ -518,7 +503,22 @@ const WorkspaceDashboard = _.flow(
         ...Utils.newTabLinkProps,
         href: bucketBrowserUrl(bucketName)
       }, ['Open bucket in browser', icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })]
-      )])
+      )]),
+      !googleProject && div({ style: { margin: '0.5rem', fontSize: 12 } }, [
+        div(['Use SAS URL in conjunction with ',
+          h(Link, {
+            ...Utils.newTabLinkProps, href: 'https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-v10',
+            style: { textDecoration: 'underline' }
+          }, 'AzCopy'),
+          ' or ',
+          h(Link, {
+            ...Utils.newTabLinkProps, href: 'https://azure.microsoft.com/en-us/products/storage/storage-explorer',
+            style: { textDecoration: 'underline' }
+          }, 'Azure Storage Explorer'),
+          ' to access storage associated with this workspace.']),
+        div({ style: { paddingTop: '0.5rem', fontWeight: 'bold' } },
+          ['The SAS URL expires after 1 hour. To generate a new SAS URL, refresh this page.'])
+      ])
     ]
   }
 


### PR DESCRIPTION
This PR has 2 things: updates to the Azure workspace dashboard for WOR-582, and removal of some integration test coverage (details below).

**UI changes:**

![image](https://user-images.githubusercontent.com/484484/199052289-91a0f0f0-38b7-4ee9-b391-6600a344924e.png)

**Test removal details:**

We have sporadically seen failures in this test due to notifications appearing in the upper right corner, which prevents the workspace menu from being clickable. I have experimented in the past with dismissing notifications before attempting to click on the menu, but the solution was never robust (and I removed it). [Example failure.](https://circleci-tasks-prod.s3.us-east-1.amazonaws.com/storage/artifacts/1c1bde7e-0f01-4eef-b2bc-01f4b12ed651/ca8cf5fc-fdb5-472d-8008-0e062f8d6c17/0/results/failure-screenshots/failure-1667135075354-google-workspace.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAQVFQINEOBJCOLRXM%2F20221031%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20221031T131904Z&X-Amz-Expires=60&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEI7%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCXVzLWVhc3QtMSJGMEQCID9HnU8hkL6YDb%2FInOtNOecbeh%2FBc0hV%2FcUUUnFPrYooAiA%2BkiewyNZq%2FfFHC%2Bkmc8VR6gRxNRCyBR6aHYhCM86EaCqrAgh2EAMaDDA0NTQ2NjgwNjU1NiIMUgHwM8oTCNeM6R6fKogCosxTaXqjxjTgFDGgAzLkCVoR3KLghJQSsgBUpWIhPTvC3pzpZMDiQosI%2BIC6zgGwphKyI%2BjvZxEP3icM73evECSFYAGqximmI89O7asejFn%2FX%2BZx9WveN0sEvnnAelRZQWCNTc%2FvTO0WPP9BEAqnAdAB%2BrYqVi7jThG6XDWGFrBy0UYDOyXXtocwEvWWof1OpaNk6DIRgB3mMEYhac7qzORK%2FeKSltk%2BySS28R1iWwSsbAPMhJDJtWacX3hgtPwLVOur4ePyeZ0Z6oEz4cDYRTntQSRFjuuOcI6TvKZXrifT%2FyUgKTsjUE6Tc%2B3vn2nxLACOnno%2FvipmfGPwnNF%2FpXWbe4VxhDNDMJKU%2F5oGOp4Bskc354ctqfhRKqPzmdeULq0etF5E0f9yqreEYgP6fvVH%2FFyM%2BORrNL0ZkmV32Nl4nH0wFJlTSA7Ml%2BuZQwXDq03R6pSxcJELeSqgkwP5A8adBXTYdnpvzxBdnsfqzNQMy4v13KjNsRg29PHmHEbF7G3JJ7ZtsQoM0O7pLSN0f6uNxXaQTGx1Qvg66ddAFjlTSDHHg5021%2FhUBUQrY3E%3D&X-Amz-SignedHeaders=host&x-id=GetObject&X-Amz-Signature=583163e08b753c5101d68c9e26f04d508006a2131fbef8718d4ea2e77880a2f1)

We now have unit test coverage of the enable/disable state and tooltips of the menu itself. Removing the integration test coverage does mean that we lose the ability to test that the server responses are as we expect (Google workspace only-- Azure server responses are mocked) and that locking/unlocking a Google workspace works, but I still think removing the coverage to reduce flakiness is the best decision.
