### PR TITLE
[SU-229] Add types for link component

### DIFF
--- a/src/components/Interactive.d.ts
+++ b/src/components/Interactive.d.ts
@@ -1,0 +1,12 @@
+import { CSSProperties, PropsWithChildren } from 'react'
+
+
+export type InteractiveProps<Tag extends keyof JSX.IntrinsicElements> = PropsWithChildren<{
+  as: Tag
+  disabled?: boolean
+  hover?: Pick<CSSProperties, 'background' | 'backgroundColor' | 'border' | 'color' | 'boxShadow' | 'opacity' | 'textDecoration'>
+} & JSX.IntrinsicElements[Tag]>
+
+const Interactive: <Tag>(props: InteractiveProps<Tag>) => JSX.Element
+
+export default Interactive

--- a/src/components/common.d.ts
+++ b/src/components/common.d.ts
@@ -1,0 +1,22 @@
+import type { InteractiveProps } from 'src/components/Interactive'
+
+
+type TagName = keyof JSX.IntrinsicElements
+
+export type ClickableProps<T extends TagName = 'div'> = {
+  as?: T
+  href?: string
+  tooltip?: string
+  tooltipSide?: 'top' | 'bottom' | 'left' | 'right'
+  tooltipDelay?: number
+  useTooltipAsLabel?: boolean
+} & Omit<InteractiveProps<T>, 'as'>
+
+export const Clickable: <T extends TagName>(props: ClickableProps<T>) => JSX.Element
+
+type LinkProps<T extends TagName> = {
+  variant?: 'light'
+  baseColor?: () => string
+} & ClickableProps<T>
+
+export const Link: <T extends TagName = 'a'>(props: LinkProps<T>) => JSX.Element


### PR DESCRIPTION
In #3469, TypeScript cannot determine the correct type for the Link component's props.

From https://app.circleci.com/pipelines/github/DataBiosphere/terra-ui/12599/workflows/7e1c1ef0-06eb-4574-a2b1-07f27fb57bd4/jobs/52420:
```
TS2345: Argument of type '{ style: { display: string; padding: string; marginLeft: string; }; onClick: () => Promise<void>; }' is not assignable to parameter of type 'WithKey<Omit<{}, "children">>'.
  Object literal may only specify known properties, and 'style' does not exist in type 'WithKey<Omit<{}, "children">>'.
    54 |     status === 'Loading' && renderDirectoryStatus(level, 'Loading...'),
    55 |     hasNextPage && h(Link, {
  > 56 |       style: { display: 'inline-block', padding: '0.25rem 0.5rem', marginLeft: `${level * 1.25}rem` },
       |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    57 |       onClick: () => loadNextPage()
    58 |     }, ['Load next page'])
    59 |   ])
```

For some components that are defined in JS modules, TS can at least figure out the shape of the props object, if not the type of each prop's value. However, since Link is defined using `forwardRefWithName` in a JS module, TS cannot determine the shape of the props object and thinks that the props object should be an empty object.

This adds type [declarations](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html) for the Link component and the other components that it is built from (Clickable and Interactive). Adding type declarations instead of moving LInk to TypeScript lets us keep the import path for Link unchanged while also not converting all of src/components/common.js to TS.