### PR TITLE
[SUP-770] Make branding consistent for all tiers of BioData Catalyst

### DIFF
--- a/src/libs/brand-utils.js
+++ b/src/libs/brand-utils.js
@@ -3,17 +3,21 @@ import { getConfig } from 'src/libs/config'
 import * as Utils from 'src/libs/utils'
 
 
-export const isAnvil = () => (window.location.hostname === brands.anvil.hostName) || getConfig().isAnvil
-export const isBaseline = () => (window.location.hostname === brands.baseline.hostName) || getConfig().isBaseline
-export const isBioDataCatalyst = () => (window.location.hostname === brands.bioDataCatalyst.hostName) || getConfig().isBioDataCatalyst
+export const isBrand = brand => {
+  return new RegExp(`^((dev|alpha|perf|staging)\\.)?${brand.hostName}$`).test(window.location.hostname)
+}
+
+export const isAnvil = () => isBrand(brands.anvil) || getConfig().isAnvil
+export const isBaseline = () => isBrand(brands.baseline) || getConfig().isBaseline
+export const isBioDataCatalyst = () => isBrand(brands.bioDataCatalyst) || getConfig().isBioDataCatalyst
 // TODO: Deprecate Datastage (https://broadworkbench.atlassian.net/browse/SATURN-1414)
-export const isDatastage = () => (window.location.hostname === brands.datastage.hostName) || getConfig().isDatastage
-export const isElwazi = () => (window.location.hostname === brands.elwazi.hostName) || getConfig().isElwazi
-export const isFirecloud = () => (window.location.hostname === brands.firecloud.hostName) || getConfig().isFirecloud
-export const isProjectSingular = () => (window.location.hostname === brands.projectSingular.hostName) || getConfig().isProjectSingular
-export const isRadX = () => (window.location.hostname === brands.radX.hostName) || getConfig().isRadX
-export const isRareX = () => (window.location.hostname === brands.rareX.hostName) || getConfig().isRareX
-export const isTerra = () => (window.location.hostname === brands.terra.hostName) || getConfig().isTerra ||
+export const isDatastage = () => isBrand(brands.datastage) || getConfig().isDatastage
+export const isElwazi = () => isBrand(brands.elwazi) || getConfig().isElwazi
+export const isFirecloud = () => isBrand(brands.firecloud) || getConfig().isFirecloud
+export const isProjectSingular = () => isBrand(brands.projectSingular) || getConfig().isProjectSingular
+export const isRadX = () => isBrand(brands.radX) || getConfig().isRadX
+export const isRareX = () => isBrand(brands.rareX) || getConfig().isRareX
+export const isTerra = () => isBrand(brands.terra) || getConfig().isTerra ||
   (!isFirecloud() && !isDatastage() && !isAnvil() && !isBioDataCatalyst() && !isBaseline() && !isElwazi() && !isProjectSingular() && !isRadX() && !isRareX())
 
 export const getEnabledBrand = () => Utils.cond(

--- a/src/libs/brand-utils.test.js
+++ b/src/libs/brand-utils.test.js
@@ -1,0 +1,53 @@
+import { isBrand } from 'src/libs/brand-utils'
+
+
+describe('isBrand', () => {
+  let location
+
+  beforeAll(() => {
+    location = window.location
+    delete window.location
+  })
+
+  afterAll(() => {
+    window.location = location
+  })
+
+  it('returns true if hostname matches brand', () => {
+    // Arrange
+    window.location = new URL('https://testbrand.terra.bio/path/to/page')
+
+    // Act
+    const isTestBrand = isBrand({ hostName: 'testbrand.terra.bio' })
+
+    // Assert
+    expect(isTestBrand).toBe(true)
+  })
+
+  it('returns false if hostname does not match brand', () => {
+    // Arrange
+    window.location = new URL('https://app.terra.bio/path/to/page')
+
+    // Act
+    const isTestBrand = isBrand({ hostName: 'testbrand.terra.bio' })
+
+    // Assert
+    expect(isTestBrand).toBe(false)
+  })
+
+  it.each([
+    ['dev'],
+    ['alpha'],
+    ['perf'],
+    ['staging']
+  ])('returns true if hostname matches %s subdomain of brand hostname', tier => {
+    // Arrange
+    window.location = new URL(`https://${tier}.testbrand.terra.bio/path/to/page`)
+
+    // Act
+    const isTestBrand = isBrand({ hostName: 'testbrand.terra.bio' })
+
+    // Assert
+    expect(isTestBrand).toBe(true)
+  })
+})


### PR DESCRIPTION
Terra UI branding is currently done by comparing `window.location.hostname` to the brand's hostname. If the hostnames are exact matches, the brand's styling is applied.

https://github.com/DataBiosphere/terra-ui/blob/f59fb6bc90ec3123070676b59b047d8f2515e94d/src/libs/brand-utils.js#L6-L17

However, for brands that have their own versions of all tiers (dev, alpha, perf, and staging as well as production) this means that the brand's styling is only applied to the production tier.

This changes the logic for applying a brand to match the hostname against a regular expression `((dev|alpha|perf|staging)\\.)?${brand.hostName}$`.

This can be tested locally using `/etc/hosts`.
```
127.0.0.1 dev.terra.biodatacatalyst.nhlbi.nih.gov
```