### PR TITLE
[IA-3801] Added logic to open the correct compute modal from the preview page.

### DIFF
--- a/src/pages/workspaces/workspace/analysis/AnalysisLauncher.js
+++ b/src/pages/workspaces/workspace/analysis/AnalysisLauncher.js
@@ -68,6 +68,7 @@ const AnalysisLauncher = _.flow(
     const currentFileToolLabel = getToolFromFileExtension(analysisName)
     const currentRuntimeTool = getToolFromRuntime(currentRuntime)
     const iframeStyles = { height: '100%', width: '100%' }
+    const isAzureWorkspace = !!workspace.azureContext
 
     useOnMount(() => {
       refreshRuntimes()
@@ -90,7 +91,7 @@ const AnalysisLauncher = _.flow(
         mode && h(RuntimeKicker, { runtime: currentRuntime, refreshRuntimes }),
         mode && h(RuntimeStatusMonitor, { runtime: currentRuntime }),
         h(ComputeModal, {
-          isOpen: createOpen && !workspace?.azureContext,
+          isOpen: createOpen && !isAzureWorkspace,
           tool: currentFileToolLabel,
           shouldHideCloseButton: false,
           workspace,
@@ -110,7 +111,7 @@ const AnalysisLauncher = _.flow(
           })
         }),
         h(AzureComputeModal, {
-          isOpen: createOpen && workspace?.azureContext,
+          isOpen: createOpen && isAzureWorkspace,
           hideCloseButton: true,
           workspace,
           runtimes,

--- a/src/pages/workspaces/workspace/analysis/AnalysisLauncher.js
+++ b/src/pages/workspaces/workspace/analysis/AnalysisLauncher.js
@@ -256,7 +256,6 @@ const PreviewHeader = ({
   const { mode } = queryParams
   const analysisLink = Nav.getLink(analysisLauncherTabName, { namespace, name, analysisName })
   const isAzureWorkspace = !!workspace.azureContext
-
   const currentRuntimeTool = getToolFromRuntime(runtime)
 
   const checkIfLocked = withErrorReporting('Error checking analysis lock status', async () => {

--- a/src/pages/workspaces/workspace/analysis/AnalysisLauncher.js
+++ b/src/pages/workspaces/workspace/analysis/AnalysisLauncher.js
@@ -291,7 +291,6 @@ const PreviewHeader = ({
 
   const editModeButton = h(HeaderButton, { onClick: () => chooseMode('edit') }, openMenuIcon)
 
-
   return h(ApplicationHeader, {
     label: 'PREVIEW (READ-ONLY)',
     labelBgColor: colors.dark(0.2)
@@ -313,7 +312,9 @@ const PreviewHeader = ({
             Nav.goToPath(appLauncherTabName, { namespace, name, application: currentRuntimeTool })
           }
         }, openMenuIcon)],
+      [currentRuntimeTool === tools.Azure.label && runtimeStatus !== 'Running', () => {}],
       // Azure logic must come before this branch, as currentRuntimeTool !== currentFileToolLabel for azure.
+
       [currentRuntimeTool !== currentFileToolLabel, () => createNewRuntimeOpenButton],
       // If the tool is RStudio and we are in this branch, we need to either start an existing runtime or launch the app
       // Worth mentioning that the Stopped branch will launch RStudio, and then we depend on the RuntimeManager to prompt user the app is ready to launch

--- a/src/pages/workspaces/workspace/analysis/AnalysisLauncher.js
+++ b/src/pages/workspaces/workspace/analysis/AnalysisLauncher.js
@@ -255,6 +255,7 @@ const PreviewHeader = ({
   const welderEnabled = runtime && !runtime.labels?.welderInstallFailed
   const { mode } = queryParams
   const analysisLink = Nav.getLink(analysisLauncherTabName, { namespace, name, analysisName })
+  const isAzureWorkspace = !!workspace.azureContext
 
   const currentRuntimeTool = getToolFromRuntime(runtime)
 
@@ -305,7 +306,7 @@ const PreviewHeader = ({
       [runtimeStatus === 'Stopped', () => h(HeaderButton, {
         onClick: () => startAndRefresh(refreshRuntimes, runtime)
       }, openMenuIcon)],
-      [currentRuntimeTool === tools.Azure.label && _.includes(runtimeStatus, usableStatuses) && currentFileToolLabel === tools.Jupyter.label,
+      [isAzureWorkspace && _.includes(runtimeStatus, usableStatuses) && currentFileToolLabel === tools.Jupyter.label,
         () => h(HeaderButton, {
           onClick: () => {
             Ajax().Metrics.captureEvent(Events.analysisLaunch,
@@ -313,7 +314,7 @@ const PreviewHeader = ({
             Nav.goToPath(appLauncherTabName, { namespace, name, application: currentRuntimeTool })
           }
         }, openMenuIcon)],
-      [currentRuntimeTool === tools.Azure.label && runtimeStatus !== 'Running', () => {}],
+      [isAzureWorkspace && runtimeStatus !== 'Running', () => {}],
       // Azure logic must come before this branch, as currentRuntimeTool !== currentFileToolLabel for azure.
 
       [currentRuntimeTool !== currentFileToolLabel, () => createNewRuntimeOpenButton],


### PR DESCRIPTION

## Testing:

Ensured in a GCP workspace the old and correct compute modal still pops up.


Ensured clicking "Open" when VM is running will open JupyterLab for Azure.


Ensured when not in "running" state, open button doesn't render.


Ensured Open button can start the environment after it's paused.