### PR TITLE
[UIE-14] Remove requirement for modal-root element in unit tests

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -29,7 +29,6 @@
       </div>
     </div>
     <div id="main-menu-container"></div>
-    <div id="modal-root" role="complementary"></div>
     <div id="outdated"></div> <!-- for outdated-browser-rework -->
   </body>
 </html>

--- a/src/components/Alerts.test.js
+++ b/src/components/Alerts.test.js
@@ -16,16 +16,6 @@ jest.mock('src/libs/service-alerts', () => {
   }
 })
 
-beforeAll(() => {
-  const modalRoot = document.createElement('div')
-  modalRoot.id = 'modal-root'
-  document.body.append(modalRoot)
-})
-
-afterAll(() => {
-  document.getElementById('modal-root').remove()
-})
-
 const testAlerts = [
   {
     id: 'abc',

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -5,6 +5,7 @@ import { div, h } from 'react-hyperscript-helpers'
 import RModal from 'react-modal'
 import { ButtonPrimary, ButtonSecondary, Clickable } from 'src/components/common'
 import { icon } from 'src/components/icons'
+import { getPopupRoot } from 'src/components/popup-utils'
 import { useOnMount, useUniqueId } from 'src/libs/react-utils'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
@@ -42,7 +43,7 @@ const Modal = ({ onDismiss, title, titleExtras, children, width = 450, showCance
     contentRef: node => { modalNode.current = node },
     aria: { labelledby: titleId, modal: true },
     ariaHideApp: false,
-    parentSelector: () => document.getElementById('modal-root'),
+    parentSelector: getPopupRoot,
     isOpen: true,
     shouldFocusAfterRender: false,
     shouldReturnFocusAfterClose: false,

--- a/src/components/ModalDrawer.js
+++ b/src/components/ModalDrawer.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types'
 import { h } from 'react-hyperscript-helpers'
 import RModal from 'react-modal'
 import { Transition } from 'react-transition-group'
+import { getPopupRoot } from 'src/components/popup-utils'
 import colors from 'src/libs/colors'
 import { useLabelAssert } from 'src/libs/react-utils'
 
@@ -37,7 +38,7 @@ const ModalDrawer = ({ isOpen, onDismiss, width = 450, children, onExited, ...pr
   }, [transitionState => h(RModal, {
     aria: { label: props['aria-label'], labelledby: props['aria-labelledby'], modal: true, hidden: transitionState !== 'entered' },
     ariaHideApp: false,
-    parentSelector: () => document.getElementById('modal-root'),
+    parentSelector: getPopupRoot,
     isOpen: true,
     onRequestClose: onDismiss,
     style: { overlay: drawer.overlay(transitionState), content: { ...drawer.container(transitionState), width } },

--- a/src/components/data/data-table-versions.test.js
+++ b/src/components/data/data-table-versions.test.js
@@ -6,16 +6,6 @@ import { h } from 'react-hyperscript-helpers'
 import { DataTableSaveVersionModal, DataTableVersion } from 'src/components/data/data-table-versions'
 
 
-beforeAll(() => {
-  const modalRoot = document.createElement('div')
-  modalRoot.id = 'modal-root'
-  document.body.append(modalRoot)
-})
-
-afterAll(() => {
-  document.getElementById('modal-root').remove()
-})
-
 describe('DataTableSaveVersionModal', () => {
   it('renders input for description', () => {
     const { getByLabelText } = render(h(DataTableSaveVersionModal, {

--- a/src/components/popup-utils.js
+++ b/src/components/popup-utils.js
@@ -64,8 +64,17 @@ export const computePopupPosition = ({ side, viewport, target, element, gap }) =
 }
 
 // Render popups, modals, etc. into the #modal-root element.
-// Fall back to document.body in tests.
-export const getPopupRoot = () => document.getElementById('modal-root') || document.body
+// Create the element if it does not exist.
+export const getPopupRoot = () => {
+  let popupRoot = document.getElementById('modal-root')
+  if (!popupRoot) {
+    popupRoot = document.createElement('div')
+    popupRoot.id = 'modal-root'
+    popupRoot.role = 'complementary'
+    document.body.append(popupRoot)
+  }
+  return popupRoot
+}
 
 export const PopupPortal = ({ children }) => {
   return createPortal(Children.only(children), getPopupRoot())

--- a/src/components/popup-utils.js
+++ b/src/components/popup-utils.js
@@ -63,6 +63,10 @@ export const computePopupPosition = ({ side, viewport, target, element, gap }) =
   return { side: finalSide, position: finalPosition }
 }
 
+// Render popups, modals, etc. into the #modal-root element.
+// Fall back to document.body in tests.
+export const getPopupRoot = () => document.getElementById('modal-root') || document.body
+
 export const PopupPortal = ({ children }) => {
-  return createPortal(Children.only(children), document.getElementById('modal-root'))
+  return createPortal(Children.only(children), getPopupRoot())
 }

--- a/src/components/popup-utils.test.js
+++ b/src/components/popup-utils.test.js
@@ -1,0 +1,42 @@
+import '@testing-library/jest-dom'
+
+import { getPopupRoot } from 'src/components/popup-utils'
+
+
+describe('getPopupRoot', () => {
+  afterEach(() => {
+    document.getElementById('modal-root').remove()
+  })
+
+  it('creates root element if it does not exist', () => {
+    // Arrange
+    expect(document.getElementById('modal-root')).toBeNull()
+
+    // Act
+    const popupRoot = getPopupRoot()
+
+    // Assert
+    expect(popupRoot).toBeInTheDocument()
+  })
+
+  it('adds "complementary" role to root element', () => {
+    // Arrange
+    const popupRoot = getPopupRoot()
+
+    // Assert
+    expect(popupRoot.role).toBe('complementary')
+  })
+
+  it('returns root element if it exists', () => {
+    // Arrange
+    const existingPopupRoot = document.createElement('div')
+    existingPopupRoot.id = 'modal-root'
+    document.body.append(existingPopupRoot)
+
+    // Act
+    const popupRoot = getPopupRoot()
+
+    // Assert
+    expect(popupRoot).toBe(existingPopupRoot)
+  })
+})

--- a/src/pages/billing/CreateAzureBillingProjectModal.test.js
+++ b/src/pages/billing/CreateAzureBillingProjectModal.test.js
@@ -12,17 +12,6 @@ import { billingProjectNameValidator } from 'src/pages/billing/List'
 import { v4 as uuid } from 'uuid'
 
 
-jest.mock('src/components/Modal', () => {
-  const { div, h } = jest.requireActual('react-hyperscript-helpers')
-  const originalModule = jest.requireActual('src/components/Modal')
-  return {
-    ...originalModule,
-    __esModule: true,
-    default: props => div({ id: 'modal-root' }, [
-      h(originalModule.default, { onAfterOpen: jest.fn(), ...props })
-    ])
-  }
-})
 jest.mock('src/libs/ajax')
 
 describe('CreateAzureBillingProjectModal', () => {

--- a/src/pages/billing/CreateAzureBillingProjectModal.test.js
+++ b/src/pages/billing/CreateAzureBillingProjectModal.test.js
@@ -12,6 +12,14 @@ import { billingProjectNameValidator } from 'src/pages/billing/List'
 import { v4 as uuid } from 'uuid'
 
 
+jest.mock('src/components/Modal', () => {
+  const originalModule = jest.requireActual('src/components/Modal')
+  return {
+    ...originalModule,
+    __esModule: true,
+    default: props => originalModule.default({ onAfterOpen: jest.fn(), ...props })
+  }
+})
 jest.mock('src/libs/ajax')
 
 describe('CreateAzureBillingProjectModal', () => {

--- a/src/pages/billing/CreateAzureBillingProjectModal.test.js
+++ b/src/pages/billing/CreateAzureBillingProjectModal.test.js
@@ -12,6 +12,15 @@ import { billingProjectNameValidator } from 'src/pages/billing/List'
 import { v4 as uuid } from 'uuid'
 
 
+jest.mock('src/components/Modal', () => {
+  const { h } = jest.requireActual('react-hyperscript-helpers')
+  const originalModule = jest.requireActual('src/components/Modal')
+  return {
+    ...originalModule,
+    __esModule: true,
+    default: props => h(originalModule.default, { onAfterOpen: jest.fn(), ...props })
+  }
+})
 jest.mock('src/libs/ajax')
 
 describe('CreateAzureBillingProjectModal', () => {

--- a/src/pages/billing/CreateAzureBillingProjectModal.test.js
+++ b/src/pages/billing/CreateAzureBillingProjectModal.test.js
@@ -12,15 +12,6 @@ import { billingProjectNameValidator } from 'src/pages/billing/List'
 import { v4 as uuid } from 'uuid'
 
 
-jest.mock('src/components/Modal', () => {
-  const { h } = jest.requireActual('react-hyperscript-helpers')
-  const originalModule = jest.requireActual('src/components/Modal')
-  return {
-    ...originalModule,
-    __esModule: true,
-    default: props => h(originalModule.default, { onAfterOpen: jest.fn(), ...props })
-  }
-})
 jest.mock('src/libs/ajax')
 
 describe('CreateAzureBillingProjectModal', () => {

--- a/src/pages/workspaces/workspace/ShareWorkspaceModal.js
+++ b/src/pages/workspaces/workspace/ShareWorkspaceModal.js
@@ -5,6 +5,7 @@ import { ButtonPrimary, ButtonSecondary, IdContainer, LabeledCheckbox, Link, Sel
 import { centeredSpinner, icon } from 'src/components/icons'
 import { AutocompleteTextInput } from 'src/components/input'
 import Modal, { styles as modalStyles } from 'src/components/Modal'
+import { getPopupRoot } from 'src/components/popup-utils'
 import TooltipTrigger from 'src/components/TooltipTrigger'
 import { Ajax } from 'src/libs/ajax'
 import { getUser } from 'src/libs/auth'
@@ -56,7 +57,7 @@ const AclInput = ({ value, onChange, disabled, maxAccessLevel, isAzureWorkspace,
           )
         }),
         options: accessLevel === 'PROJECT_OWNER' ? ['PROJECT_OWNER'] : ['READER', 'WRITER', 'OWNER'],
-        menuPortalTarget: document.getElementById('modal-root'),
+        menuPortalTarget: getPopupRoot(),
         ...props
       })
     ]),

--- a/src/pages/workspaces/workspace/analysis/modals/ComputeModal.test.js
+++ b/src/pages/workspaces/workspace/analysis/modals/ComputeModal.test.js
@@ -21,28 +21,6 @@ import {
 } from 'src/pages/workspaces/workspace/analysis/runtime-utils'
 
 
-jest.mock('src/components/Modal', () => {
-  const { div, h } = jest.requireActual('react-hyperscript-helpers')
-  const originalModule = jest.requireActual('src/components/Modal')
-  return {
-    ...originalModule,
-    __esModule: true,
-    default: props => div({ id: 'modal-root' }, [
-      h(originalModule.default, { onAfterOpen: jest.fn(), ...props })
-    ])
-  }
-})
-
-// Mocking PopupTrigger to avoid test environment issues with React Portal's requirement to use
-// DOM measure services which are not available in jest environment
-jest.mock('src/components/PopupTrigger', () => {
-  const originalModule = jest.requireActual('src/components/PopupTrigger')
-  return {
-    ...originalModule,
-    MenuTrigger: jest.fn()
-  }
-})
-
 jest.mock('src/libs/notifications', () => ({
   notify: (...args) => {
     console.debug('######################### notify')/* eslint-disable-line */

--- a/src/pages/workspaces/workspace/analysis/modals/ComputeModal.test.js
+++ b/src/pages/workspaces/workspace/analysis/modals/ComputeModal.test.js
@@ -37,14 +37,6 @@ const defaultModalProps = {
   location: testDefaultLocation
 }
 
-jest.mock('react-dom', () => {
-  const originalModule = jest.requireActual('react-dom')
-  return {
-    ...originalModule,
-    createPortal: () => <div></div>
-  }
-})
-
 //TODO: test utils??
 const verifyDisabled = item => expect(item).toHaveAttribute('disabled')
 const verifyEnabled = item => expect(item).not.toHaveAttribute('disabled')

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -8,3 +8,13 @@ jest.mock('src/configStore', () => ({
 }))
 
 expect.extend(toHaveNoViolations)
+
+beforeAll(() => {
+  const modalRoot = document.createElement('div')
+  modalRoot.id = 'modal-root'
+  document.body.append(modalRoot)
+})
+
+afterAll(() => {
+  document.getElementById('modal-root').remove()
+})

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -8,13 +8,3 @@ jest.mock('src/configStore', () => ({
 }))
 
 expect.extend(toHaveNoViolations)
-
-beforeAll(() => {
-  const modalRoot = document.createElement('div')
-  modalRoot.id = 'modal-root'
-  document.body.append(modalRoot)
-})
-
-afterAll(() => {
-  document.getElementById('modal-root').remove()
-})


### PR DESCRIPTION
index.html includes a div with ID "modal-root".

https://github.com/DataBiosphere/terra-ui/blob/8f83ade4e2787de056a7db8ecb62af8916ef0db8/public/index.html#L32

Modal and PopupPortal (which is used by Autocomplete, PopupTrigger, and TooltipTrigger) render into this element via a React Portal.

However, in unit tests, the "modal-root" element does not exist, so these components all fail to render. Currently, tests use a mix of mocking the components or adding a modal-root element to work around this.

This replaces references to the "modal-root" element with a `getPopupRoot` function that returns the modal-root element or falls back to document.body.

I recently encountered this issue while using `@testing-library/user-event` to click on a button that has a tooltip. I don't think tests should have to mock TooltipTrigger or PopupPortal, etc. to test clicking on a button.