### PR TITLE
[UIE-15] Import @testing-library/jest-dom in setupTests.js

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -54,6 +54,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/node", "npm:18.7.16"],\
             ["@types/react", "npm:18.0.18"],\
             ["@types/react-dom", "npm:18.0.6"],\
+            ["@types/testing-library__jest-dom", "npm:5.14.5"],\
             ["animate.css", "npm:4.1.1"],\
             ["array-move", "npm:4.0.0"],\
             ["babel-plugin-prismjs", "virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#npm:2.1.0"],\
@@ -19266,6 +19267,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/node", "npm:18.7.16"],\
             ["@types/react", "npm:18.0.18"],\
             ["@types/react-dom", "npm:18.0.6"],\
+            ["@types/testing-library__jest-dom", "npm:5.14.5"],\
             ["animate.css", "npm:4.1.1"],\
             ["array-move", "npm:4.0.0"],\
             ["babel-plugin-prismjs", "virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#npm:2.1.0"],\

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "@types/node": "^18.7.16",
     "@types/react": "^18.0.18",
     "@types/react-dom": "^18.0.6",
+    "@types/testing-library__jest-dom": "^5.9.1",
     "babel-plugin-prismjs": "^2.1.0",
     "blob-polyfill": "^7.0.20220408",
     "check-dts": "^0.6.7",

--- a/src/components/Alerts.test.js
+++ b/src/components/Alerts.test.js
@@ -1,5 +1,3 @@
-import '@testing-library/jest-dom'
-
 import { fireEvent, getByText, render } from '@testing-library/react'
 import _ from 'lodash/fp'
 import { h } from 'react-hyperscript-helpers'

--- a/src/components/data/AttributeInput.test.js
+++ b/src/components/data/AttributeInput.test.js
@@ -1,5 +1,3 @@
-import '@testing-library/jest-dom'
-
 import { fireEvent, render } from '@testing-library/react'
 import { h } from 'react-hyperscript-helpers'
 import AttributeInput, { AttributeTypeInput } from 'src/components/data/AttributeInput'

--- a/src/components/data/attribute-utils.test.js
+++ b/src/components/data/attribute-utils.test.js
@@ -1,5 +1,3 @@
-import '@testing-library/jest-dom'
-
 import { concatenateAttributeNames, convertAttributeValue, getAttributeType } from 'src/components/data/attribute-utils'
 
 

--- a/src/components/data/data-table-provenance.test.js
+++ b/src/components/data/data-table-provenance.test.js
@@ -1,5 +1,3 @@
-import '@testing-library/jest-dom'
-
 import { render } from '@testing-library/react'
 import _ from 'lodash/fp'
 import { h } from 'react-hyperscript-helpers'

--- a/src/components/data/data-table-versions.test.js
+++ b/src/components/data/data-table-versions.test.js
@@ -1,5 +1,3 @@
-import '@testing-library/jest-dom'
-
 import { fireEvent, render } from '@testing-library/react'
 import _ from 'lodash/fp'
 import { h } from 'react-hyperscript-helpers'

--- a/src/components/data/data-utils.test.js
+++ b/src/components/data/data-utils.test.js
@@ -1,5 +1,3 @@
-import '@testing-library/jest-dom'
-
 import { render } from '@testing-library/react'
 import _ from 'lodash/fp'
 import { entityAttributeText, getRootTypeForSetTable, prepareAttributeForUpload, renderDataCell } from 'src/components/data/data-utils'

--- a/src/components/popup-utils.test.js
+++ b/src/components/popup-utils.test.js
@@ -1,5 +1,3 @@
-import '@testing-library/jest-dom'
-
 import { getPopupRoot } from 'src/components/popup-utils'
 
 

--- a/src/libs/ajax/Runtimes.test.js
+++ b/src/libs/ajax/Runtimes.test.js
@@ -1,5 +1,3 @@
-import '@testing-library/jest-dom'
-
 import { authOpts, fetchLeo } from 'src/libs/ajax/ajax-common'
 import { Runtimes } from 'src/libs/ajax/Runtimes'
 

--- a/src/libs/link-expiration-alerts.test.js
+++ b/src/libs/link-expiration-alerts.test.js
@@ -1,5 +1,3 @@
-import '@testing-library/jest-dom'
-
 import { render } from '@testing-library/react'
 import { addDays, addHours, setMilliseconds } from 'date-fns/fp'
 import _ from 'lodash/fp'

--- a/src/pages/FeaturePreviews.test.js
+++ b/src/pages/FeaturePreviews.test.js
@@ -1,5 +1,3 @@
-import '@testing-library/jest-dom'
-
 import { fireEvent, getByText, render } from '@testing-library/react'
 import { h } from 'react-hyperscript-helpers'
 import { isFeaturePreviewEnabled, toggleFeaturePreview, useAvailableFeaturePreviews } from 'src/libs/feature-previews'

--- a/src/pages/billing/CreateAzureBillingProjectModal.test.js
+++ b/src/pages/billing/CreateAzureBillingProjectModal.test.js
@@ -1,5 +1,3 @@
-import '@testing-library/jest-dom'
-
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { axe } from 'jest-axe'

--- a/src/pages/billing/CreateNewBillingProjectWizard.test.js
+++ b/src/pages/billing/CreateNewBillingProjectWizard.test.js
@@ -1,5 +1,3 @@
-import '@testing-library/jest-dom'
-
 import { fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { axe } from 'jest-axe'

--- a/src/pages/library/Datasets.test.js
+++ b/src/pages/library/Datasets.test.js
@@ -1,5 +1,3 @@
-import '@testing-library/jest-dom'
-
 import { render } from '@testing-library/react'
 import { h } from 'react-hyperscript-helpers'
 import { getEnabledBrand, isRadX } from 'src/libs/brand-utils'

--- a/src/pages/library/dataBrowser-utils.test.js
+++ b/src/pages/library/dataBrowser-utils.test.js
@@ -1,5 +1,3 @@
-import '@testing-library/jest-dom'
-
 import { brands } from 'src/libs/brands'
 import { dataCatalogStore } from 'src/libs/state'
 import {

--- a/src/pages/workspaces/workspace/Dashboard.test.js
+++ b/src/pages/workspaces/workspace/Dashboard.test.js
@@ -1,5 +1,3 @@
-import '@testing-library/jest-dom'
-
 import { render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { axe } from 'jest-axe'

--- a/src/pages/workspaces/workspace/WorkspaceMenu.test.js
+++ b/src/pages/workspaces/workspace/WorkspaceMenu.test.js
@@ -1,5 +1,3 @@
-import '@testing-library/jest-dom'
-
 import { fireEvent, render, screen } from '@testing-library/react'
 import { axe } from 'jest-axe'
 import { useState } from 'react'

--- a/src/pages/workspaces/workspace/analysis/ContextBar.test.js
+++ b/src/pages/workspaces/workspace/analysis/ContextBar.test.js
@@ -1,5 +1,3 @@
-import '@testing-library/jest-dom'
-
 import { fireEvent, render } from '@testing-library/react'
 import { act } from 'react-dom/test-utils'
 import { div, h } from 'react-hyperscript-helpers'

--- a/src/pages/workspaces/workspace/analysis/modals/ComputeModal.test.js
+++ b/src/pages/workspaces/workspace/analysis/modals/ComputeModal.test.js
@@ -1,5 +1,3 @@
-import '@testing-library/jest-dom'
-
 import { fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import _ from 'lodash/fp'

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,3 +1,4 @@
+import '@testing-library/jest-dom'
 import 'blob-polyfill'
 
 import { toHaveNoViolations } from 'jest-axe'

--- a/yarn.lock
+++ b/yarn.lock
@@ -14343,6 +14343,7 @@ resolve@^2.0.0-next.3:
     "@types/node": ^18.7.16
     "@types/react": ^18.0.18
     "@types/react-dom": ^18.0.6
+    "@types/testing-library__jest-dom": ^5.9.1
     animate.css: ^4.1.1
     array-move: ^4.0.0
     babel-plugin-prismjs: ^2.1.0


### PR DESCRIPTION
[`@testing-library/jest-dom`](https://testing-library.com/docs/ecosystem-jest-dom/) extends `expect` with [several custom matchers](https://github.com/testing-library/jest-dom#custom-matchers) such as `toHaveTextContent`.

We use these matchers in probably most tests that render a component. Currently, each test imports `@testing-library/jest-dom`. This moves that import to `setupTests.js` so that the custom matchers are always available without each test having to import `@testing-library/jest-dom`.

This also adds `@types/testing-library__jest-dom` to package.json. This was already included in the project (it's a dependency of `@testing-library/jest-dom`), but adding it directly to Terra UI's package.json was necessary to get VSCode's TypeScript integration to recognize that these custom matchers are valid.