### PR TITLE
[SU-229] New file browser part 3: files table

### DIFF
--- a/src/components/file-browser/FileBrowser.ts
+++ b/src/components/file-browser/FileBrowser.ts
@@ -81,7 +81,12 @@ const FileBrowser = ({ provider, title, workspace }: FileBrowserProps) => {
             onClickPath: setPath
           })
         ]),
-        h(FilesInDirectory, { provider, path, onClickFile: setFocusedFile })
+        h(FilesInDirectory, {
+          provider,
+          path,
+          rootLabel: 'Workspace bucket',
+          onClickFile: setFocusedFile
+        })
       ])
     ]),
 

--- a/src/components/file-browser/FileBrowser.ts
+++ b/src/components/file-browser/FileBrowser.ts
@@ -1,77 +1,89 @@
-import { useState } from 'react'
+import { Fragment, useState } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
 import DirectoryTree from 'src/components/file-browser/DirectoryTree'
 import FilesInDirectory from 'src/components/file-browser/FilesInDirectory'
 import PathBreadcrumbs from 'src/components/file-browser/PathBreadcrumbs'
-import FileBrowserProvider from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
+import UriViewer from 'src/components/UriViewer'
+import FileBrowserProvider, { FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
 import colors from 'src/libs/colors'
 
 
 interface FileBrowserProps {
   provider: FileBrowserProvider
   title: string
+  workspace: any // TODO: Type for workspace
 }
 
-const FileBrowser = ({ provider, title }: FileBrowserProps) => {
+const FileBrowser = ({ provider, title, workspace }: FileBrowserProps) => {
   const [path, setPath] = useState('')
 
-  return div({ style: { display: 'flex', height: '100%' } }, [
-    div({
-      style: {
-        display: 'flex',
-        flexDirection: 'column',
-        width: 300,
-        height: '100%',
-        borderRight: `0.5px solid ${colors.dark(0.2)}`
-      }
-    }, [
-      div({
-        style: {
-          padding: '1rem 0.5rem',
-          borderBottom: `0.5px solid ${colors.dark(0.2)}`,
-          backgroundColor: colors.light(0.4)
-        }
-      }, [title]),
-      div({
-        style: {
-          flex: '1 0 0',
-          overflow: 'hidden auto',
-          background: '#fff'
-        }
-      }, [
-        h(DirectoryTree, {
-          provider,
-          selectedDirectory: path,
-          onSelectDirectory: setPath
-        })
-      ])
-    ]),
-    div({
-      style: {
-        display: 'flex',
-        flexDirection: 'column',
-        flex: '1 0 0'
-      }
-    }, [
+  const [focusedFile, setFocusedFile] = useState<FileBrowserFile | null>(null)
+
+  return h(Fragment, [
+    div({ style: { display: 'flex', height: '100%' } }, [
       div({
         style: {
           display: 'flex',
-          flexFlow: 'row wrap',
-          alignItems: 'center',
-          width: '100%',
-          padding: '0.5rem',
-          borderBottom: `0.5px solid ${colors.dark(0.2)}`,
-          backgroundColor: colors.light(0.4)
+          flexDirection: 'column',
+          width: 300,
+          height: '100%',
+          borderRight: `0.5px solid ${colors.dark(0.2)}`
         }
       }, [
-        h(PathBreadcrumbs, {
-          path,
-          rootLabel: 'Workspace bucket',
-          onClickPath: setPath
-        })
+        div({
+          style: {
+            padding: '1rem 0.5rem',
+            borderBottom: `0.5px solid ${colors.dark(0.2)}`,
+            backgroundColor: colors.light(0.4)
+          }
+        }, [title]),
+        div({
+          style: {
+            flex: '1 0 0',
+            overflow: 'hidden auto',
+            background: '#fff'
+          }
+        }, [
+          h(DirectoryTree, {
+            provider,
+            selectedDirectory: path,
+            onSelectDirectory: setPath
+          })
+        ])
       ]),
-      h(FilesInDirectory, { provider, path })
-    ])
+      div({
+        style: {
+          display: 'flex',
+          flexDirection: 'column',
+          flex: '1 0 0'
+        }
+      }, [
+        div({
+          style: {
+            display: 'flex',
+            flexFlow: 'row wrap',
+            alignItems: 'center',
+            width: '100%',
+            padding: '0.5rem',
+            borderBottom: `0.5px solid ${colors.dark(0.2)}`,
+            backgroundColor: colors.light(0.4)
+          }
+        }, [
+          h(PathBreadcrumbs, {
+            path,
+            rootLabel: 'Workspace bucket',
+            onClickPath: setPath
+          })
+        ]),
+        h(FilesInDirectory, { provider, path, onClickFile: setFocusedFile })
+      ])
+    ]),
+
+    focusedFile && h(UriViewer, {
+      workspace,
+      uri: focusedFile.url,
+      onDismiss: () => setFocusedFile(null)
+    })
   ])
 }
 

--- a/src/components/file-browser/FileBrowser.ts
+++ b/src/components/file-browser/FileBrowser.ts
@@ -1,4 +1,4 @@
-import { Fragment, useState } from 'react'
+import { Fragment, useRef, useState } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
 import DirectoryTree from 'src/components/file-browser/DirectoryTree'
 import FilesInDirectory from 'src/components/file-browser/FilesInDirectory'
@@ -18,6 +18,8 @@ const FileBrowser = ({ provider, title, workspace }: FileBrowserProps) => {
   const [path, setPath] = useState('')
 
   const [focusedFile, setFocusedFile] = useState<FileBrowserFile | null>(null)
+
+  const rightPaneRef = useRef<HTMLDivElement | null>(null)
 
   return h(Fragment, [
     div({ style: { display: 'flex', height: '100%' } }, [
@@ -47,11 +49,15 @@ const FileBrowser = ({ provider, title, workspace }: FileBrowserProps) => {
           h(DirectoryTree, {
             provider,
             selectedDirectory: path,
-            onSelectDirectory: setPath
+            onSelectDirectory: selectedDirectoryPath => {
+              setPath(selectedDirectoryPath)
+              ;(rightPaneRef.current!.querySelector('[role="table"]') as HTMLElement).focus()
+            }
           })
         ])
       ]),
       div({
+        ref: rightPaneRef,
         style: {
           display: 'flex',
           flexDirection: 'column',

--- a/src/components/file-browser/FileBrowser.ts
+++ b/src/components/file-browser/FileBrowser.ts
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
 import DirectoryTree from 'src/components/file-browser/DirectoryTree'
 import FilesInDirectory from 'src/components/file-browser/FilesInDirectory'
+import PathBreadcrumbs from 'src/components/file-browser/PathBreadcrumbs'
 import FileBrowserProvider from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
 import colors from 'src/libs/colors'
 
@@ -45,7 +46,30 @@ const FileBrowser = ({ provider, title }: FileBrowserProps) => {
         })
       ])
     ]),
-    div({ style: { flex: '1 0 0' } }, [
+    div({
+      style: {
+        display: 'flex',
+        flexDirection: 'column',
+        flex: '1 0 0'
+      }
+    }, [
+      div({
+        style: {
+          display: 'flex',
+          flexFlow: 'row wrap',
+          alignItems: 'center',
+          width: '100%',
+          padding: '0.5rem',
+          borderBottom: `0.5px solid ${colors.dark(0.2)}`,
+          backgroundColor: colors.light(0.4)
+        }
+      }, [
+        h(PathBreadcrumbs, {
+          path,
+          rootLabel: 'Workspace bucket',
+          onClickPath: setPath
+        })
+      ]),
       h(FilesInDirectory, { provider, path })
     ])
   ])

--- a/src/components/file-browser/FileBrowser.ts
+++ b/src/components/file-browser/FileBrowser.ts
@@ -1,4 +1,4 @@
-import { Fragment, useRef, useState } from 'react'
+import { Fragment, useState } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
 import DirectoryTree from 'src/components/file-browser/DirectoryTree'
 import FilesInDirectory from 'src/components/file-browser/FilesInDirectory'
@@ -18,8 +18,6 @@ const FileBrowser = ({ provider, title, workspace }: FileBrowserProps) => {
   const [path, setPath] = useState('')
 
   const [focusedFile, setFocusedFile] = useState<FileBrowserFile | null>(null)
-
-  const rightPaneRef = useRef<HTMLDivElement | null>(null)
 
   return h(Fragment, [
     div({ style: { display: 'flex', height: '100%' } }, [
@@ -51,13 +49,11 @@ const FileBrowser = ({ provider, title, workspace }: FileBrowserProps) => {
             selectedDirectory: path,
             onSelectDirectory: selectedDirectoryPath => {
               setPath(selectedDirectoryPath)
-              ;(rightPaneRef.current!.querySelector('[role="table"]') as HTMLElement).focus()
             }
           })
         ])
       ]),
       div({
-        ref: rightPaneRef,
         style: {
           display: 'flex',
           flexDirection: 'column',

--- a/src/components/file-browser/FilesInDirectory.test.ts
+++ b/src/components/file-browser/FilesInDirectory.test.ts
@@ -56,7 +56,8 @@ describe('FilesInDirectory', () => {
     // Act
     render(h(FilesInDirectory, {
       provider: mockFileBrowserProvider,
-      path: 'path/to/directory/'
+      path: 'path/to/directory/',
+      onClickFile: jest.fn()
     }))
 
     // Assert
@@ -88,7 +89,8 @@ describe('FilesInDirectory', () => {
     // Act
     render(h(FilesInDirectory, {
       provider: mockFileBrowserProvider,
-      path: 'path/to/directory/'
+      path: 'path/to/directory/',
+      onClickFile: jest.fn()
     }))
 
     // Assert
@@ -116,7 +118,8 @@ describe('FilesInDirectory', () => {
       // Act
       render(h(FilesInDirectory, {
         provider: mockFileBrowserProvider,
-        path: 'path/to/directory/'
+        path: 'path/to/directory/',
+        onClickFile: jest.fn()
       }))
 
       // Assert
@@ -158,7 +161,8 @@ describe('FilesInDirectory', () => {
       // Act
       render(h(FilesInDirectory, {
         provider: mockFileBrowserProvider,
-        path: 'path/to/directory/'
+        path: 'path/to/directory/',
+        onClickFile: jest.fn()
       }))
 
       // Assert
@@ -174,7 +178,8 @@ describe('FilesInDirectory', () => {
       // Act
       render(h(FilesInDirectory, {
         provider: mockFileBrowserProvider,
-        path: 'path/to/directory/'
+        path: 'path/to/directory/',
+        onClickFile: jest.fn()
       }))
 
       // Assert

--- a/src/components/file-browser/FilesInDirectory.test.ts
+++ b/src/components/file-browser/FilesInDirectory.test.ts
@@ -1,0 +1,186 @@
+import '@testing-library/jest-dom'
+
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { div, h } from 'react-hyperscript-helpers'
+import { useFilesInDirectory } from 'src/components/file-browser/file-browser-hooks'
+import FilesInDirectory from 'src/components/file-browser/FilesInDirectory'
+import FilesTable from 'src/components/file-browser/FilesTable'
+import FileBrowserProvider, { FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
+import { asMockedFn } from 'src/testing/test-utils'
+
+
+jest.mock('src/components/file-browser/file-browser-hooks', () => ({
+  ...jest.requireActual('src/components/file-browser/file-browser-hooks'),
+  useFilesInDirectory: jest.fn()
+}))
+
+jest.mock('src/components/file-browser/FilesTable', () => ({
+  ...jest.requireActual('src/components/file-browser/FilesTable'),
+  __esModule: true,
+  default: jest.fn()
+}))
+
+beforeEach(() => {
+  asMockedFn(FilesTable).mockReturnValue(div())
+})
+
+type UseFilesInDirectoryResult = ReturnType<typeof useFilesInDirectory>
+
+// modals, popups, tooltips, etc. render into this element.
+beforeAll(() => {
+  const modalRoot = document.createElement('div')
+  modalRoot.id = 'modal-root'
+  document.body.append(modalRoot)
+})
+
+afterAll(() => {
+  document.getElementById('modal-root')!.remove()
+})
+
+describe('FilesInDirectory', () => {
+  const mockFileBrowserProvider: FileBrowserProvider = {} as FileBrowserProvider
+
+  it('loads files in the given path', () => {
+    // Arrange
+    const useFilesInDirectoryResult: UseFilesInDirectoryResult = {
+      state: { files: [], status: 'Loading' },
+      hasNextPage: undefined,
+      loadNextPage: () => Promise.resolve(),
+      loadAllRemainingItems: () => Promise.resolve(),
+      reload: () => Promise.resolve()
+    }
+
+    asMockedFn(useFilesInDirectory).mockReturnValue(useFilesInDirectoryResult)
+
+    // Act
+    render(h(FilesInDirectory, {
+      provider: mockFileBrowserProvider,
+      path: 'path/to/directory/'
+    }))
+
+    // Assert
+    expect(asMockedFn(useFilesInDirectory)).toHaveBeenCalledWith(mockFileBrowserProvider, 'path/to/directory/')
+  })
+
+  it('renders FilesTable with loaded files', () => {
+    // Arrange
+    const files: FileBrowserFile[] = [
+      {
+        path: 'path/to/file.txt',
+        url: 'gs://test-bucket/path/to/file.txt',
+        size: 1024,
+        createdAt: 1667408400000,
+        updatedAt: 1667408400000
+      }
+    ]
+
+    const useFilesInDirectoryResult: UseFilesInDirectoryResult = {
+      state: { files, status: 'Ready' },
+      hasNextPage: undefined,
+      loadNextPage: () => Promise.resolve(),
+      loadAllRemainingItems: () => Promise.resolve(),
+      reload: () => Promise.resolve()
+    }
+
+    asMockedFn(useFilesInDirectory).mockReturnValue(useFilesInDirectoryResult)
+
+    // Act
+    render(h(FilesInDirectory, {
+      provider: mockFileBrowserProvider,
+      path: 'path/to/directory/'
+    }))
+
+    // Assert
+    expect(FilesTable).toHaveBeenCalledWith(expect.objectContaining({ files }), expect.anything())
+  })
+
+  it.each([
+    { state: { status: 'Loading', files: [] }, expectedMessage: 'Loading files...' },
+    { state: { status: 'Ready', files: [] }, expectedMessage: 'No files have been uploaded yet' },
+    { state: { status: 'Error', error: new Error('Something went wrong'), files: [] }, expectedMessage: 'Unable to load files' }
+  ] as { state: UseFilesInDirectoryResult['state']; expectedMessage: string }[])(
+    'sets noFilesMessage prop for FilesTable based on loading state ($state.status)',
+    ({ state, expectedMessage }) => {
+      // Arrange
+      const useFilesInDirectoryResult: UseFilesInDirectoryResult = {
+        state,
+        hasNextPage: false,
+        loadNextPage: () => Promise.resolve(),
+        loadAllRemainingItems: () => Promise.resolve(),
+        reload: () => Promise.resolve()
+      }
+
+      asMockedFn(useFilesInDirectory).mockReturnValue(useFilesInDirectoryResult)
+
+      // Act
+      render(h(FilesInDirectory, {
+        provider: mockFileBrowserProvider,
+        path: 'path/to/directory/'
+      }))
+
+      // Assert
+      expect(FilesTable).toHaveBeenCalledWith(expect.objectContaining({ noFilesMessage: expectedMessage }), expect.anything())
+    }
+  )
+
+  describe('when next page is available', () => {
+    // Arrange
+    const loadNextPage = jest.fn()
+    const loadAllRemainingItems = jest.fn()
+
+    const files: FileBrowserFile[] = [
+      {
+        path: 'path/to/file.txt',
+        url: 'gs://test-bucket/path/to/file.txt',
+        size: 1024,
+        createdAt: 1667408400000,
+        updatedAt: 1667408400000
+      }
+    ]
+
+    const useFilesInDirectoryResult: UseFilesInDirectoryResult = {
+      state: { files, status: 'Ready' },
+      hasNextPage: true,
+      loadNextPage,
+      loadAllRemainingItems,
+      reload: () => Promise.resolve()
+    }
+
+    beforeEach(() => {
+      asMockedFn(useFilesInDirectory).mockReturnValue(useFilesInDirectoryResult)
+    })
+
+    it('renders a button to load next page', async () => {
+      // Arrange
+      const user = userEvent.setup()
+
+      // Act
+      render(h(FilesInDirectory, {
+        provider: mockFileBrowserProvider,
+        path: 'path/to/directory/'
+      }))
+
+      // Assert
+      const loadNextPageButton = screen.getByText('Load next page')
+      await user.click(loadNextPageButton)
+      expect(loadNextPage).toHaveBeenCalled()
+    })
+
+    it('renders a button to load all remaining pages', async () => {
+      // Arrange
+      const user = userEvent.setup()
+
+      // Act
+      render(h(FilesInDirectory, {
+        provider: mockFileBrowserProvider,
+        path: 'path/to/directory/'
+      }))
+
+      // Assert
+      const loadAllPagesButton = screen.getByText('Load all')
+      await user.click(loadAllPagesButton)
+      expect(loadAllRemainingItems).toHaveBeenCalled()
+    })
+  })
+})

--- a/src/components/file-browser/FilesInDirectory.test.ts
+++ b/src/components/file-browser/FilesInDirectory.test.ts
@@ -102,7 +102,7 @@ describe('FilesInDirectory', () => {
     { state: { status: 'Ready', files: [] }, expectedMessage: 'No files have been uploaded yet' },
     { state: { status: 'Error', error: new Error('Something went wrong'), files: [] }, expectedMessage: 'Unable to load files' }
   ] as { state: UseFilesInDirectoryResult['state']; expectedMessage: string }[])(
-    'sets noFilesMessage prop for FilesTable based on loading state ($state.status)',
+    'renders a message based on loading state ($state.status) when no files are present',
     ({ state, expectedMessage }) => {
       // Arrange
       const useFilesInDirectoryResult: UseFilesInDirectoryResult = {
@@ -123,7 +123,7 @@ describe('FilesInDirectory', () => {
       }))
 
       // Assert
-      expect(FilesTable).toHaveBeenCalledWith(expect.objectContaining({ noFilesMessage: expectedMessage }), expect.anything())
+      screen.getByText(expectedMessage)
     }
   )
 

--- a/src/components/file-browser/FilesInDirectory.ts
+++ b/src/components/file-browser/FilesInDirectory.ts
@@ -12,10 +12,11 @@ import * as Utils from 'src/libs/utils'
 interface FilesInDirectoryProps {
   provider: FileBrowserProvider
   path: string
+  onClickFile: (file: FileBrowserFile) => void
 }
 
 const FilesInDirectory = (props: FilesInDirectoryProps) => {
-  const { provider, path } = props
+  const { provider, path, onClickFile } = props
 
   const {
     state: { status, files },
@@ -40,9 +41,7 @@ const FilesInDirectory = (props: FilesInDirectoryProps) => {
         [status === 'Error', () => 'Unable to load files'],
         () => 'No files have been uploaded yet'
       ),
-      onClickFile: (file: FileBrowserFile) => {
-        console.log(file)
-      }
+      onClickFile
     }),
     div({
       style: {

--- a/src/components/file-browser/FilesInDirectory.ts
+++ b/src/components/file-browser/FilesInDirectory.ts
@@ -2,6 +2,7 @@ import { Fragment } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
 import { Link } from 'src/components/common'
 import { useFilesInDirectory } from 'src/components/file-browser/file-browser-hooks'
+import { basename } from 'src/components/file-browser/file-browser-utils'
 import FilesTable from 'src/components/file-browser/FilesTable'
 import { icon } from 'src/components/icons'
 import FileBrowserProvider, { FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
@@ -12,11 +13,12 @@ import * as Utils from 'src/libs/utils'
 interface FilesInDirectoryProps {
   provider: FileBrowserProvider
   path: string
+  rootLabel?: string
   onClickFile: (file: FileBrowserFile) => void
 }
 
 const FilesInDirectory = (props: FilesInDirectoryProps) => {
-  const { provider, path, onClickFile } = props
+  const { provider, path, rootLabel = 'Files', onClickFile } = props
 
   const {
     state: { status, files },
@@ -35,6 +37,7 @@ const FilesInDirectory = (props: FilesInDirectoryProps) => {
     }
   }, [
     h(FilesTable, {
+      'aria-label': `Files in ${path === '' ? rootLabel : basename(path)}`,
       files,
       noFilesMessage: Utils.cond(
         [status === 'Loading', () => 'Loading files...'],

--- a/src/components/file-browser/FilesInDirectory.ts
+++ b/src/components/file-browser/FilesInDirectory.ts
@@ -1,5 +1,5 @@
 import { Fragment } from 'react'
-import { div, h } from 'react-hyperscript-helpers'
+import { div, h, p } from 'react-hyperscript-helpers'
 import { Link } from 'src/components/common'
 import { useFilesInDirectory } from 'src/components/file-browser/file-browser-hooks'
 import { basename } from 'src/components/file-browser/file-browser-utils'
@@ -36,45 +36,55 @@ const FilesInDirectory = (props: FilesInDirectoryProps) => {
       flex: '1 0 0'
     }
   }, [
-    h(FilesTable, {
-      'aria-label': `Files in ${path === '' ? rootLabel : basename(path)}`,
-      files,
-      noFilesMessage: Utils.cond(
+    files.length > 0 && h(Fragment, [
+      h(FilesTable, {
+        'aria-label': `Files in ${path === '' ? rootLabel : basename(path)}`,
+        files,
+        onClickFile
+      }),
+      div({
+        style: {
+          display: 'flex',
+          justifyContent: 'space-between',
+          padding: '1rem',
+          borderTop: `1px solid ${colors.dark(0.2)}`,
+          background: '#fff'
+        }
+      }, [
+        div([
+          `${files.length} files `,
+          isLoading && h(Fragment, [
+            'Loading more... ',
+            icon('loadingSpinner', { size: 12 })
+          ])
+        ]),
+        hasNextPage !== false && div([
+          h(Link, {
+            disabled: isLoading,
+            style: { marginLeft: '1ch' },
+            onClick: () => loadNextPage()
+          }, ['Load next page']),
+          h(Link, {
+            disabled: isLoading,
+            style: { marginLeft: '1ch' },
+            tooltip: 'This may take a long time for folders containing several thousand objects.',
+            onClick: () => loadAllRemainingItems()
+          }, ['Load all'])
+        ])
+      ])
+    ]),
+    files.length === 0 && p({
+      style: {
+        marginTop: '1rem',
+        fontStyle: 'italic',
+        textAlign: 'center',
+      }
+    }, [
+      Utils.cond(
         [status === 'Loading', () => 'Loading files...'],
         [status === 'Error', () => 'Unable to load files'],
         () => 'No files have been uploaded yet'
-      ),
-      onClickFile
-    }),
-    div({
-      style: {
-        display: 'flex',
-        justifyContent: 'space-between',
-        padding: '1rem',
-        borderTop: `1px solid ${colors.dark(0.2)}`,
-        background: '#fff'
-      }
-    }, [
-      div([
-        `${files.length} files `,
-        isLoading && h(Fragment, [
-          'Loading more... ',
-          icon('loadingSpinner', { size: 12 })
-        ])
-      ]),
-      hasNextPage !== false && div([
-        h(Link, {
-          disabled: isLoading,
-          style: { marginLeft: '1ch' },
-          onClick: () => loadNextPage()
-        }, ['Load next page']),
-        h(Link, {
-          disabled: isLoading,
-          style: { marginLeft: '1ch' },
-          tooltip: 'This may take a long time for folders containing several thousand objects.',
-          onClick: () => loadAllRemainingItems()
-        }, ['Load all'])
-      ])
+      )
     ])
   ])
 }

--- a/src/components/file-browser/FilesInDirectory.ts
+++ b/src/components/file-browser/FilesInDirectory.ts
@@ -56,7 +56,7 @@ const FilesInDirectory = (props: FilesInDirectoryProps) => {
       }
     }, [
       div([
-        `${files.length} files. `,
+        `${files.length} files `,
         isLoading && h(Fragment, [
           'Loading more... ',
           icon('loadingSpinner', { size: 12 })

--- a/src/components/file-browser/FilesInDirectory.ts
+++ b/src/components/file-browser/FilesInDirectory.ts
@@ -1,6 +1,12 @@
-import { div, li, ul } from 'react-hyperscript-helpers'
+import { Fragment } from 'react'
+import { div, h } from 'react-hyperscript-helpers'
+import { Link } from 'src/components/common'
 import { useFilesInDirectory } from 'src/components/file-browser/file-browser-hooks'
-import FileBrowserProvider from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
+import FilesTable from 'src/components/file-browser/FilesTable'
+import { icon } from 'src/components/icons'
+import FileBrowserProvider, { FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
+import colors from 'src/libs/colors'
+import * as Utils from 'src/libs/utils'
 
 
 interface FilesInDirectoryProps {
@@ -11,13 +17,62 @@ interface FilesInDirectoryProps {
 const FilesInDirectory = (props: FilesInDirectoryProps) => {
   const { provider, path } = props
 
-  const { state: { files } } = useFilesInDirectory(provider, path)
+  const {
+    state: { status, files },
+    hasNextPage,
+    loadAllRemainingItems,
+    loadNextPage
+  } = useFilesInDirectory(provider, path)
 
-  return div([
-    ul([
-      files.map(file => li({
-        key: file.path
-      }, [file.path]))
+  const isLoading = status === 'Loading'
+
+  return div({
+    style: {
+      display: 'flex',
+      flexDirection: 'column',
+      flex: '1 0 0'
+    }
+  }, [
+    h(FilesTable, {
+      files,
+      noFilesMessage: Utils.cond(
+        [status === 'Loading', () => 'Loading files...'],
+        [status === 'Error', () => 'Unable to load files'],
+        () => 'No files have been uploaded yet'
+      ),
+      onClickFile: (file: FileBrowserFile) => {
+        console.log(file)
+      }
+    }),
+    div({
+      style: {
+        display: 'flex',
+        justifyContent: 'space-between',
+        padding: '1rem',
+        borderTop: `1px solid ${colors.dark(0.2)}`,
+        background: '#fff'
+      }
+    }, [
+      div([
+        `${files.length} files. `,
+        isLoading && h(Fragment, [
+          'Loading more... ',
+          icon('loadingSpinner', { size: 12 })
+        ])
+      ]),
+      hasNextPage !== false && div([
+        h(Link, {
+          disabled: isLoading,
+          style: { marginLeft: '1ch' },
+          onClick: () => loadNextPage()
+        }, ['Load next page']),
+        h(Link, {
+          disabled: isLoading,
+          style: { marginLeft: '1ch' },
+          tooltip: 'This may take a long time for folders containing several thousand objects.',
+          onClick: () => loadAllRemainingItems()
+        }, ['Load all'])
+      ])
     ])
   ])
 }

--- a/src/components/file-browser/FilesTable.test.ts
+++ b/src/components/file-browser/FilesTable.test.ts
@@ -1,0 +1,116 @@
+import '@testing-library/jest-dom'
+
+import { getAllByRole, getByRole, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { h } from 'react-hyperscript-helpers'
+import FilesTable from 'src/components/file-browser/FilesTable'
+import { FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
+
+
+// FileBrowserTable uses react-virtualized's AutoSizer to size the table.
+// This makes the virtualized window large enough for all rows/columns to be rendered in tests.
+jest.mock('react-virtualized', () => ({
+  ...jest.requireActual('react-virtualized'),
+  AutoSizer: ({ children }) => children({ width: 1000, height: 1000 })
+}))
+
+describe('FilesTable', () => {
+  const files: FileBrowserFile[] = [
+    {
+      path: 'path/to/file1.txt',
+      url: 'gs://test-bucket/path/to/file1.txt',
+      size: 1024,
+      createdAt: 1667408400000,
+      updatedAt: 1667408400000
+    },
+    {
+      path: 'path/to/file2.bam',
+      url: 'gs://test-bucket/path/to/file2.bam',
+      size: 1024 ** 2,
+      createdAt: 1667410200000,
+      updatedAt: 1667410200000
+    },
+    {
+      path: 'path/to/file3.vcf',
+      url: 'gs://test-bucket/path/to/file3.vcf',
+      size: 1024 ** 3,
+      createdAt: 1667412000000,
+      updatedAt: 1667412000000
+    }
+  ]
+
+  it.each([
+    { field: 'name', columnIndex: 0, expected: ['file1.txt', 'file2.bam', 'file3.vcf'] },
+    { field: 'size', columnIndex: 1, expected: ['1 KB', '1 MB', '1 GB'] }
+    // { field: 'last modified', columnIndex: 2, expected: [] }
+  ])('renders a column with file $field', ({ columnIndex, expected }) => {
+    // Act
+    render(h(FilesTable, { files, noFilesMessage: 'No files available', onClickFile: jest.fn() }))
+
+    const tableRows = screen.getAllByRole('row').slice(1) // skip header row
+    const cellsInColumn = tableRows.map(row => getAllByRole(row, 'cell')[columnIndex])
+    const valuesInColumn = cellsInColumn.map(cell => cell.textContent)
+
+    // Assert
+    expect(valuesInColumn).toEqual(expected)
+  })
+
+  it('renders file names as links', () => {
+    // Act
+    render(h(FilesTable, { files, noFilesMessage: 'No files available', onClickFile: jest.fn() }))
+
+    const tableRows = screen.getAllByRole('row').slice(1) // skip header row
+    const fileNameCells = tableRows.map(row => getAllByRole(row, 'cell')[0])
+    const fileLinks = fileNameCells.map(cell => getByRole(cell, 'link'))
+
+    // Assert
+    expect(fileLinks.map(link => link.getAttribute('href'))).toEqual([
+      'gs://test-bucket/path/to/file1.txt',
+      'gs://test-bucket/path/to/file2.bam',
+      'gs://test-bucket/path/to/file3.vcf'
+    ])
+  })
+
+  it('renders a message if no files are present', () => {
+    // Act
+    render(h(FilesTable, { files: [], noFilesMessage: 'No files available', onClickFile: jest.fn() }))
+
+    // Assert
+    screen.getByText('No files available')
+  })
+
+  it('calls onClickFile callback when a file link is clicked', async () => {
+    // Arrange
+    const user = userEvent.setup()
+
+    const onClickFile = jest.fn()
+    render(h(FilesTable, { files, noFilesMessage: 'No files available', onClickFile }))
+
+    const tableRows = screen.getAllByRole('row').slice(1) // skip header row
+    const fileNameCells = tableRows.map(row => getAllByRole(row, 'cell')[0])
+    const fileLinks = fileNameCells.map(cell => getByRole(cell, 'link'))
+
+    // Act
+    await user.click(fileLinks[0])
+    await user.click(fileLinks[1])
+
+    // Assert
+    expect(onClickFile).toHaveBeenCalledTimes(2)
+    expect(onClickFile.mock.calls.map(call => call[0])).toEqual([
+      {
+        path: 'path/to/file1.txt',
+        url: 'gs://test-bucket/path/to/file1.txt',
+        size: 1024,
+        createdAt: 1667408400000,
+        updatedAt: 1667408400000
+      },
+      {
+        path: 'path/to/file2.bam',
+        url: 'gs://test-bucket/path/to/file2.bam',
+        size: 1024 ** 2,
+        createdAt: 1667410200000,
+        updatedAt: 1667410200000
+      }
+    ])
+  })
+})

--- a/src/components/file-browser/FilesTable.test.ts
+++ b/src/components/file-browser/FilesTable.test.ts
@@ -45,7 +45,7 @@ describe('FilesTable', () => {
     // { field: 'last modified', columnIndex: 2, expected: [] }
   ])('renders a column with file $field', ({ columnIndex, expected }) => {
     // Act
-    render(h(FilesTable, { files, noFilesMessage: 'No files available', onClickFile: jest.fn() }))
+    render(h(FilesTable, { files, onClickFile: jest.fn() }))
 
     const tableRows = screen.getAllByRole('row').slice(1) // skip header row
     const cellsInColumn = tableRows.map(row => getAllByRole(row, 'cell')[columnIndex])
@@ -57,7 +57,7 @@ describe('FilesTable', () => {
 
   it('renders file names as links', () => {
     // Act
-    render(h(FilesTable, { files, noFilesMessage: 'No files available', onClickFile: jest.fn() }))
+    render(h(FilesTable, { files, onClickFile: jest.fn() }))
 
     const tableRows = screen.getAllByRole('row').slice(1) // skip header row
     const fileNameCells = tableRows.map(row => getAllByRole(row, 'cell')[0])
@@ -71,20 +71,12 @@ describe('FilesTable', () => {
     ])
   })
 
-  it('renders a message if no files are present', () => {
-    // Act
-    render(h(FilesTable, { files: [], noFilesMessage: 'No files available', onClickFile: jest.fn() }))
-
-    // Assert
-    screen.getByText('No files available')
-  })
-
   it('calls onClickFile callback when a file link is clicked', async () => {
     // Arrange
     const user = userEvent.setup()
 
     const onClickFile = jest.fn()
-    render(h(FilesTable, { files, noFilesMessage: 'No files available', onClickFile }))
+    render(h(FilesTable, { files, onClickFile }))
 
     const tableRows = screen.getAllByRole('row').slice(1) // skip header row
     const fileNameCells = tableRows.map(row => getAllByRole(row, 'cell')[0])

--- a/src/components/file-browser/FilesTable.ts
+++ b/src/components/file-browser/FilesTable.ts
@@ -9,19 +9,25 @@ import * as Utils from 'src/libs/utils'
 
 
 interface FilesTableProps {
+  'aria-label'?: string
   files: FileBrowserFile[]
   noFilesMessage: string
   onClickFile: (file: FileBrowserFile) => void
 }
 
 const FilesTable = (props: FilesTableProps) => {
-  const { files, noFilesMessage, onClickFile } = props
+  const {
+    'aria-label': ariaLabel = 'Files',
+    files,
+    noFilesMessage,
+    onClickFile
+  } = props
 
   return div({ style: { display: 'flex', flex: '1 1 auto' } }, [
     h(AutoSizer, {}, [
       /* @ts-expect-error */
       ({ width, height }) => h(FlexTable, {
-        'aria-label': 'File browser',
+        'aria-label': ariaLabel,
         width,
         height,
         rowCount: files.length,

--- a/src/components/file-browser/FilesTable.ts
+++ b/src/components/file-browser/FilesTable.ts
@@ -5,6 +5,7 @@ import { Link } from 'src/components/common'
 import { basename } from 'src/components/file-browser/file-browser-utils'
 import { FlexTable, HeaderCell, TextCell } from 'src/components/table'
 import { FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
+import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 
 
@@ -43,16 +44,18 @@ const FilesTable = (props: FilesTableProps) => {
             headerRenderer: () => h(HeaderCell, ['Name']),
             cellRenderer: ({ rowIndex }) => {
               const file = files[rowIndex]
-              return h(TextCell, [
-                h(Link, {
-                  href: file.url,
-                  style: { textDecoration: 'underline' },
-                  onClick: e => {
-                    e.preventDefault()
-                    onClickFile(file)
-                  }
-                }, [basename(file.path)])
-              ])
+              return h(Link, {
+                href: file.url,
+                // @ts-expect-error
+                style: {
+                  ...Style.noWrapEllipsis,
+                  textDecoration: 'underline'
+                },
+                onClick: e => {
+                  e.preventDefault()
+                  onClickFile(file)
+                }
+              }, [basename(file.path)])
             }
           },
           {

--- a/src/components/file-browser/FilesTable.ts
+++ b/src/components/file-browser/FilesTable.ts
@@ -12,7 +12,6 @@ import * as Utils from 'src/libs/utils'
 interface FilesTableProps {
   'aria-label'?: string
   files: FileBrowserFile[]
-  noFilesMessage: string
   onClickFile: (file: FileBrowserFile) => void
 }
 
@@ -20,7 +19,6 @@ const FilesTable = (props: FilesTableProps) => {
   const {
     'aria-label': ariaLabel = 'Files',
     files,
-    noFilesMessage,
     onClickFile
   } = props
 
@@ -32,7 +30,7 @@ const FilesTable = (props: FilesTableProps) => {
         width,
         height,
         rowCount: files.length,
-        noContentMessage: noFilesMessage,
+        noContentMessage: ' ',
         styleCell: () => ({ padding: '0.5em', borderRight: 'none', borderLeft: 'none' }),
         styleHeader: () => ({ padding: '0.5em', borderRight: 'none', borderLeft: 'none' }),
         hoverHighlight: true,

--- a/src/components/file-browser/FilesTable.ts
+++ b/src/components/file-browser/FilesTable.ts
@@ -1,0 +1,73 @@
+import filesize from 'filesize'
+import { div, h } from 'react-hyperscript-helpers'
+import { AutoSizer } from 'react-virtualized'
+import { Link } from 'src/components/common'
+import { basename } from 'src/components/file-browser/file-browser-utils'
+import { FlexTable, HeaderCell, TextCell } from 'src/components/table'
+import { FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
+import * as Utils from 'src/libs/utils'
+
+
+interface FilesTableProps {
+  files: FileBrowserFile[]
+  noFilesMessage: string
+  onClickFile: (file: FileBrowserFile) => void
+}
+
+const FilesTable = (props: FilesTableProps) => {
+  const { files, noFilesMessage, onClickFile } = props
+
+  return div({ style: { display: 'flex', flex: '1 1 auto' } }, [
+    h(AutoSizer, {}, [
+      /* @ts-expect-error */
+      ({ width, height }) => h(FlexTable, {
+        'aria-label': 'File browser',
+        width,
+        height,
+        rowCount: files.length,
+        noContentMessage: noFilesMessage,
+        styleCell: () => ({ padding: '0.5em', borderRight: 'none', borderLeft: 'none' }),
+        styleHeader: () => ({ padding: '0.5em', borderRight: 'none', borderLeft: 'none' }),
+        hoverHighlight: true,
+        border: false,
+        columns: [
+          {
+            size: { min: 100, grow: 1 },
+            headerRenderer: () => h(HeaderCell, ['Name']),
+            cellRenderer: ({ rowIndex }) => {
+              const file = files[rowIndex]
+              return h(TextCell, [
+                h(Link, {
+                  href: file.url,
+                  style: { textDecoration: 'underline' },
+                  onClick: e => {
+                    e.preventDefault()
+                    onClickFile(file)
+                  }
+                }, [basename(file.path)])
+              ])
+            }
+          },
+          {
+            size: { min: 150, grow: 0 },
+            headerRenderer: () => h(HeaderCell, ['Size']),
+            cellRenderer: ({ rowIndex }) => {
+              const file = files[rowIndex]
+              return h(TextCell, [filesize(file.size, { round: 0 })])
+            }
+          },
+          {
+            size: { min: 200, grow: 0 },
+            headerRenderer: () => h(HeaderCell, ['Last modified']),
+            cellRenderer: ({ rowIndex }) => {
+              const file = files[rowIndex]
+              return h(TextCell, [Utils.makePrettyDate(file.updatedAt)])
+            }
+          }
+        ]
+      })
+    ])
+  ])
+}
+
+export default FilesTable

--- a/src/components/file-browser/FilesTable.ts
+++ b/src/components/file-browser/FilesTable.ts
@@ -30,6 +30,7 @@ const FilesTable = (props: FilesTableProps) => {
         styleHeader: () => ({ padding: '0.5em', borderRight: 'none', borderLeft: 'none' }),
         hoverHighlight: true,
         border: false,
+        tabIndex: -1,
         columns: [
           {
             size: { min: 100, grow: 1 },

--- a/src/components/file-browser/PathBreadcrumbs.test.ts
+++ b/src/components/file-browser/PathBreadcrumbs.test.ts
@@ -1,0 +1,52 @@
+import '@testing-library/jest-dom'
+
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { h } from 'react-hyperscript-helpers'
+import PathBreadcrumbs from 'src/components/file-browser/PathBreadcrumbs'
+
+
+describe('PathBreadcrumbs', () => {
+  it('renders path segments (including root path) as buttons', () => {
+    // Act
+    render(h(PathBreadcrumbs, {
+      path: 'path/to/directory/',
+      rootLabel: 'Files',
+      onClickPath: jest.fn()
+    }))
+    const buttons = screen.getAllByRole('button')
+    const buttonLabels = buttons.map(button => button.textContent)
+
+    // Assert
+    expect(buttonLabels).toEqual(['Files', 'path', 'to', 'directory'])
+  })
+
+  it('clicking a path segments calls onClickPath with the path up to that segment', async () => {
+    // Arrange
+    userEvent.setup()
+
+    const onClickPath = jest.fn()
+    render(h(PathBreadcrumbs, {
+      path: 'path/to/directory/',
+      rootLabel: 'Files',
+      onClickPath
+    }))
+    const buttons = screen.getAllByRole('button')
+
+    // Act
+    await userEvent.click(buttons[0])
+    await userEvent.click(buttons[1])
+    await userEvent.click(buttons[2])
+    await userEvent.click(buttons[3])
+
+    // Assert
+    expect(onClickPath.mock.calls.length).toBe(4)
+    const onClickPathCallArgs = onClickPath.mock.calls.map(call => call[0])
+    expect(onClickPathCallArgs).toEqual([
+      '',
+      'path/',
+      'path/to/',
+      'path/to/directory/'
+    ])
+  })
+})

--- a/src/components/file-browser/PathBreadcrumbs.ts
+++ b/src/components/file-browser/PathBreadcrumbs.ts
@@ -1,0 +1,42 @@
+import { Fragment } from 'react'
+import { h, span } from 'react-hyperscript-helpers'
+import { Link } from 'src/components/common'
+import * as Utils from 'src/libs/utils'
+
+
+interface PathBreadcrumbsProps {
+  path: string
+  rootLabel: string
+  onClickPath: (path: string) => void
+}
+
+const PathBreadcrumbs = (props: PathBreadcrumbsProps) => {
+  const { path, rootLabel, onClickPath } = props
+
+  const segments = path.replace(/(^\/)|(\/$)/, '').split('/').filter(Boolean)
+
+  return h(Fragment, [
+    h(Link, {
+      style: { padding: '0.5rem', textDecoration: 'underline' },
+      onClick: e => {
+        e.preventDefault()
+        onClickPath('')
+      }
+    }, [rootLabel]),
+    Utils.toIndexPairs(segments).map(([index, segment]) => {
+      const pathUpToSegment = [...segments.slice(0, index + 1), ''].join('/')
+      return h(Fragment, { key: pathUpToSegment }, [
+        span({ style: { padding: '0.5rem 0' } }, [' / ']),
+        h(Link, {
+          style: { padding: '0.5rem', textDecoration: 'underline' },
+          onClick: e => {
+            e.preventDefault()
+            onClickPath(pathUpToSegment)
+          }
+        }, [segment])
+      ])
+    })
+  ])
+}
+
+export default PathBreadcrumbs

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -208,7 +208,7 @@ export const FlexTable = ({
   initialY = 0, width, height, rowCount, variant, columns = [], hoverHighlight = false,
   onScroll = _.noop, noContentMessage, noContentRenderer = _.noop, headerHeight = flexTableDefaultRowHeight, rowHeight = flexTableDefaultRowHeight,
   styleCell = () => ({}), styleHeader = () => ({}), 'aria-label': ariaLabel, sort = null, readOnly = false,
-  border = true,
+  border = true, tabIndex,
   ...props
 }) => {
   useLabelAssert('FlexTable', { 'aria-label': ariaLabel, allowLabelledBy: false })
@@ -226,7 +226,8 @@ export const FlexTable = ({
     'aria-colcount': columns.length,
     'aria-label': ariaLabel,
     'aria-readonly': readOnly || undefined,
-    className: 'flex-table'
+    className: 'flex-table',
+    tabIndex,
   }, [
     div({
       style: {

--- a/src/pages/workspaces/workspace/Files.ts
+++ b/src/pages/workspaces/workspace/Files.ts
@@ -30,7 +30,7 @@ export const Files = _.flow(
       overflow: 'hidden'
     }
   }, [
-    h(FileBrowser, { provider: fileBrowserProvider, title: 'Files' })
+    h(FileBrowser, { workspace, provider: fileBrowserProvider, title: 'Files' })
   ])
 })
 


### PR DESCRIPTION
This is part 3 ([part 2](https://github.com/DataBiosphere/terra-ui/pull/3469), [part 1](https://github.com/DataBiosphere/terra-ui/pull/3468)) of adding a new file browser to replace the files section in the workspace Data tab.

This adds a table showing information about files and adds support for viewing multiple "pages" of files (files are loaded in increments of 1000 at a time). Following PRs will add features like uploading and deleting files, etc.

To access the new file browser, use the files button in the right sidebar.

![Screen Shot 2022-11-03 at 11 14 02 AM](https://user-images.githubusercontent.com/1156625/199760376-12c48ae8-8456-46b6-9d03-682b11839673.png)

To try pagination, add a small `pageSize` parameter to the GCSFileBrowserBackend in WorkspaceFiles.ts. For example,
```ts
GCSFileBrowserBackend({ bucket: bucketName, project: googleProject, pageSize: 5 })
```
