### PR TITLE
[IA-3825] aks vs gke apps fixes

### DIFF
--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -104,7 +104,7 @@ const DeleteAppModal = ({ app: { appName, diskName, appType, cloudContext: { clo
       await Ajax().Apps.app(cloudResource, appName).delete(deleteDisk)
       onSuccess()
     } else {
-      throw new Error('unable to delete non-GCP apps currently - unimplemented')
+      throw new Error('Deleting apps is currently only supported on GCP')
     }
   })
   return h(Modal, {

--- a/src/pages/Environments.js
+++ b/src/pages/Environments.js
@@ -15,7 +15,7 @@ import { useWorkspaces } from 'src/components/workspace-utils'
 import { Ajax } from 'src/libs/ajax'
 import { getUser } from 'src/libs/auth'
 import colors from 'src/libs/colors'
-import { reportErrorAndRethrow, withErrorHandling, withErrorIgnoring, withErrorReporting } from 'src/libs/error'
+import { reportErrorAndRethrow, withErrorHandling, withErrorIgnoring, withErrorReporting, withErrorReportingInModal } from 'src/libs/error'
 import Events from 'src/libs/events'
 import * as Nav from 'src/libs/nav'
 import { useCancellation, useGetter, useOnMount, usePollingEffect } from 'src/libs/react-utils'
@@ -92,15 +92,20 @@ const DeleteDiskModal = ({ disk: { googleProject, name }, isGalaxyDisk, onDismis
   ])
 }
 
-const DeleteAppModal = ({ app: { googleProject, appName, diskName, appType }, onDismiss, onSuccess }) => {
+const DeleteAppModal = ({ app: { appName, diskName, appType, cloudContext: { cloudProvider, cloudResource } }, onDismiss, onSuccess }) => {
   const [deleteDisk, setDeleteDisk] = useState(false)
   const [deleting, setDeleting] = useState()
   const deleteApp = _.flow(
     Utils.withBusyState(setDeleting),
-    withErrorReporting('Error deleting cloud environment')
+    withErrorReportingInModal('Error deleting cloud environment', onDismiss)
   )(async () => {
-    await Ajax().Apps.app(googleProject, appName).delete(deleteDisk)
-    onSuccess()
+    //TODO: this should use types in IA-3824
+    if (cloudProvider === 'GCP') {
+      await Ajax().Apps.app(cloudResource, appName).delete(deleteDisk)
+      onSuccess()
+    } else {
+      throw new Error('unable to delete non-GCP apps currently - unimplemented')
+    }
   })
   return h(Modal, {
     title: 'Delete cloud environment?',
@@ -365,7 +370,8 @@ const Environments = () => {
   const pauseComputeAndRefresh = Utils.withBusyState(setLoading, async (computeType, compute) => {
     const wrappedPauseCompute = withErrorReporting('Error pausing compute', () => computeType === 'runtime' ?
       Ajax().Runtimes.runtimeWrapper(compute).stop() :
-      Ajax().Apps.app(compute.googleProject, compute.appName).pause())
+      //TODO: AKS vs GKE apps
+      Ajax().Apps.app(compute.workspace.googleProject, compute.appName).pause())
     await wrappedPauseCompute()
     await loadData()
   })
@@ -374,6 +380,7 @@ const Environments = () => {
   usePollingEffect(withErrorIgnoring(refreshData), { ms: 30000 })
 
   const getCloudProvider = cloudEnvironment => Utils.cond(
+    //TODO: AKS vs GKE apps
     [isApp(cloudEnvironment), () => 'Kubernetes'],
     [cloudEnvironment?.runtimeConfig?.cloudService === 'DATAPROC', () => 'Dataproc'],
     [Utils.DEFAULT, () => cloudEnvironment?.runtimeConfig?.cloudService])
@@ -469,7 +476,7 @@ const Environments = () => {
   }
 
   const renderDetailsApp = (app, disks) => {
-    const { appName, diskName, googleProject, auditInfo: { creator }, workspaceId } = app
+    const { appName, diskName, auditInfo: { creator }, workspace: { workspaceId, googleProject } } = app
     const disk = _.find({ name: diskName }, disks)
     return getDetailsPopup(appName, googleProject, disk, creator, workspaceId)
   }


### PR DESCRIPTION
We modified the backend implementation of app endpoints to allow for AKS apps as well as GKE apps, and it seems we removed googleProject as a top-level field and never made the necessary UI modifications. This caused the details pop-up and delete/pause for GKE apps to break in the Environments page. Fixed this, and added some TODOs/tickets for testing/adding types since this file is a warren of magic strings/delayed deconstructions/decorating api call data on the fly. Worth mentioning contract testing and not unit tests would be needed to catch this sort of thing though... Perhaps worth investing in an integration test in this case, though they seem inherently unreliable. 