### PR TITLE
[WOR-566] Add function to differentiate between Azure and Google users based on idp claim in token

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -86,6 +86,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["igv", "npm:2.11.2"],\
             ["jest-axe", "npm:6.0.0"],\
             ["jszip", "npm:3.7.1"],\
+            ["jwt-decode", "npm:3.1.2"],\
             ["lint-staged", "npm:13.0.3"],\
             ["lodash", "npm:4.17.21"],\
             ["marked", "npm:4.0.10"],\
@@ -19299,6 +19300,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["igv", "npm:2.11.2"],\
             ["jest-axe", "npm:6.0.0"],\
             ["jszip", "npm:3.7.1"],\
+            ["jwt-decode", "npm:3.1.2"],\
             ["lint-staged", "npm:13.0.3"],\
             ["lodash", "npm:4.17.21"],\
             ["marked", "npm:4.0.10"],\

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "iframe-resizer": "^4.3.2",
     "igv": "2.11.2",
     "jszip": "^3.7.1",
+    "jwt-decode": "^3.1.2",
     "lodash": "^4.17.21",
     "marked": "^4.0.10",
     "oidc-client-ts": "^2.0.4",

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -178,7 +178,7 @@ export const bucketBrowserUrl = id => {
 }
 
 export const isAzureUser = () => {
-  return authStore.get().isAzureUser
+  return jwtDecode(authStore.get().user.token)['idp'].startsWith('https://login.microsoftonline.com/')
 }
 
 export const processUser = (user, isSignInEvent) => {
@@ -211,7 +211,6 @@ export const processUser = (user, isSignInEvent) => {
       cookiesAccepted: isSignedIn ? state.cookiesAccepted || getLocalPrefForUserId(userId, cookiesAcceptedKey) : undefined,
       isTimeoutEnabled: isSignedIn ? state.isTimeoutEnabled : undefined,
       hasGcpBillingScopeThroughB2C: isSignedIn ? state.hasGcpBillingScopeThroughB2C : undefined,
-      isAzureUser: jwtDecode(user?.access_token)['idp'].startsWith('https://login.microsoftonline.com/'),
       user: {
         token: user?.access_token,
         scope: user?.scope,

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -178,7 +178,11 @@ export const bucketBrowserUrl = id => {
 }
 
 export const isAzureUser = () => {
-  return jwtDecode(authStore.get().user.token)['idp'].startsWith('https://login.microsoftonline.com/')
+  try {
+    return jwtDecode(authStore.get().user.token)['idp'].startsWith('https://login.microsoftonline.com/')
+  } catch {
+    return false
+  }
 }
 
 export const processUser = (user, isSignInEvent) => {

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -1,4 +1,5 @@
 import { parseJSON } from 'date-fns/fp'
+import jwtDecode from 'jwt-decode'
 import _ from 'lodash/fp'
 import { UserManager, WebStorageStateStore } from 'oidc-client-ts'
 import { cookiesAcceptedKey } from 'src/components/CookieWarning'
@@ -176,6 +177,10 @@ export const bucketBrowserUrl = id => {
   return `https://console.cloud.google.com/storage/browser/${id}?authuser=${getUser().email}`
 }
 
+export const isAzureUser = () => {
+  return authStore.get().isAzureUser
+}
+
 export const processUser = (user, isSignInEvent) => {
   return authStore.update(state => {
     const isSignedIn = !_.isNil(user)
@@ -206,6 +211,7 @@ export const processUser = (user, isSignInEvent) => {
       cookiesAccepted: isSignedIn ? state.cookiesAccepted || getLocalPrefForUserId(userId, cookiesAcceptedKey) : undefined,
       isTimeoutEnabled: isSignedIn ? state.isTimeoutEnabled : undefined,
       hasGcpBillingScopeThroughB2C: isSignedIn ? state.hasGcpBillingScopeThroughB2C : undefined,
+      isAzureUser: jwtDecode(user?.access_token)['idp'].startsWith('https://login.microsoftonline.com/'),
       user: {
         token: user?.access_token,
         scope: user?.scope,

--- a/src/pages/billing/List.js
+++ b/src/pages/billing/List.js
@@ -435,7 +435,7 @@ export const BillingList = ({ queryParams: { selectedName } }) => {
               p(['It may not exist, or you may not have access to it.'])
             ])
           ])],
-        [!isLoadingProjects && _.isEmpty(billingProjects), () => h(CreateNewBillingProjectWizard, {
+        [!isLoadingProjects && _.isEmpty(billingProjects) && !Auth.isAzureUser(), () => h(CreateNewBillingProjectWizard, {
           billingAccounts,
           onSuccess: billingProjectName => {
             Ajax().Metrics.captureEvent(Events.billingCreationGCPBillingProjectCreated, { billingProject: billingProjectName })

--- a/yarn.lock
+++ b/yarn.lock
@@ -14372,6 +14372,7 @@ resolve@^2.0.0-next.3:
     igv: 2.11.2
     jest-axe: ^6.0.0
     jszip: ^3.7.1
+    jwt-decode: ^3.1.2
     lint-staged: ^13.0.3
     lodash: ^4.17.21
     marked: ^4.0.10


### PR DESCRIPTION
Ticket: [WOR-566](https://broadworkbench.atlassian.net/browse/WOR-566)
* use `jwtDecode` to check the idp claim in the user's JWT to determine if they have auth'd with Microsoft and should be considered an Azure user
* hide billing project creation wizard from Azure users since it is GCP specific

<!--
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Also, so if a screen recording [1] and/or screenshots would be a helpful way to communicate context, please consider including some in your PR description.
Thanks!

[1] https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac
--!>
