### PR TITLE
[IA-3749] add lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,7 +17,6 @@ module.exports = {
     // Best Practices
     'no-multi-spaces': 'warn',
     'require-await': 'warn',
-
     // Stylistic Issues
     'array-bracket-newline': ['warn', 'consistent'],
     'array-bracket-spacing': 'warn',
@@ -35,6 +34,7 @@ module.exports = {
     'key-spacing': 'warn',
     'keyword-spacing': 'warn',
     'lines-between-class-members': 'warn',
+    '@typescript-eslint/member-delimiter-style': ['warn', { 'multiline': { 'delimiter': 'none' } }],
     'no-floating-decimal': 'warn',
     'no-lonely-if': 'warn',
     'no-multi-assign': 'warn',

--- a/src/libs/ajax/data-table-providers/DataTableProvider.ts
+++ b/src/libs/ajax/data-table-providers/DataTableProvider.ts
@@ -1,7 +1,7 @@
 // define metadata structures
 interface EntityTypeMetadata {
-  attributeNames: string[],
-  count: number,
+  attributeNames: string[]
+  count: number
   idName: string
 }
 
@@ -15,38 +15,38 @@ export type EntityQueryFilterOperator = 'and' | 'or'
 
 // define paginated query result structures
 interface EntityQuery {
-  page: number,
-  pageSize: number,
-  sortField: string,
-  sortDirection: EntityQuerySortDirection,
-  filterTerms: string,
+  page: number
+  pageSize: number
+  sortField: string
+  sortDirection: EntityQuerySortDirection
+  filterTerms: string
   filterOperator: EntityQueryFilterOperator
 }
 interface EntityQueryResultMetadata {
-  unfilteredCount: number,
-  filteredCount: number,
+  unfilteredCount: number
+  filteredCount: number
   filteredPageCount: number
 }
 interface Entity {
-  name: string,
-  entityType: string,
+  name: string
+  entityType: string
   attributes: Record<string, any>
 }
 
 export interface EntityQueryResponse {
-  parameters: EntityQuery,
-  resultMetadata: EntityQueryResultMetadata,
+  parameters: EntityQuery
+  resultMetadata: EntityQueryResultMetadata
   results: Entity[]
 }
 
 export interface EntityQueryOptions {
-  pageNumber: number,
-  itemsPerPage: number,
-  sortField: string,
-  sortDirection: EntityQuerySortDirection,
-  snapshotName: string,
-  googleProject: string,
-  activeTextFilter: string,
+  pageNumber: number
+  itemsPerPage: number
+  sortField: string
+  sortDirection: EntityQuerySortDirection
+  snapshotName: string
+  googleProject: string
+  activeTextFilter: string
   filterOperator: string
 }
 
@@ -58,17 +58,17 @@ export type GetMetadataFn = (signal: AbortSignal) => Promise<EntityMetadata>
 export type DeleteTableFn = (entityType: string) => Promise<void>
 
 export interface DataTableFeatures {
-  supportsTsvDownload: boolean,
-  supportsTypeDeletion: boolean,
-  supportsTypeRenaming: boolean,
-  supportsExport: boolean,
-  supportsPointCorrection: boolean,
+  supportsTsvDownload: boolean
+  supportsTypeDeletion: boolean
+  supportsTypeRenaming: boolean
+  supportsExport: boolean
+  supportsPointCorrection: boolean
   supportsFiltering: boolean
 }
 
 export interface DataTableProvider {
-  features: DataTableFeatures,
-  getPage: GetPageFn,
+  features: DataTableFeatures
+  getPage: GetPageFn
   deleteTable: DeleteTableFn
   // todos that we will need soon:
   // getMetadata: GetMetadataFn

--- a/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.ts
+++ b/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.ts
@@ -34,7 +34,7 @@ const GCSFileBrowserProvider = ({ bucket, project, pageSize = 1000 }: GCSFileBro
 
     if (nextPageToken || isFirstPage) {
       do {
-        const requestOptions: { maxResults: number, pageToken?: string } = {
+        const requestOptions: { maxResults: number; pageToken?: string } = {
           maxResults: pageSize
         }
         if (nextPageToken) {

--- a/src/libs/type-utils/lodash-fp-helpers.ts
+++ b/src/libs/type-utils/lodash-fp-helpers.ts
@@ -11,7 +11,7 @@ export interface WithHandlersFn {
   <P, A extends any[], F extends (...args: A) => Promise<P>>(
       handlers: WrapFn<(...args: A) => Promise<P | unknown>>[],
       mainFn: F
-  ): F;
+  ): F
   <F extends AnyFn, F2 extends F>(
       handlers: WrapFn<GenericFn<F2>>[],
       mainFn: F
@@ -35,16 +35,16 @@ export const withHandlers : WithHandlersFn = <F extends AnyFn>(handlers: WrapFn<
 export interface CurryLastArgFn {
   <A, LAST, R>(
       fn: (a: A, last: LAST) => R
-  ) : (a: A) => (last: LAST) => R;
+  ) : (a: A) => (last: LAST) => R
   <A, B, LAST, R>(
       fn: (a: A, b: B, last: LAST) => R
-  ) : (a: A, b: B) => (last: LAST) => R;
+  ) : (a: A, b: B) => (last: LAST) => R
   <A, B, C, LAST, R>(
       fn: (a: A, b: B, c: C, last: LAST) => R
-  ) : (a: A, b: B, c: C) => (last: LAST) => R;
+  ) : (a: A, b: B, c: C) => (last: LAST) => R
   <A, B, C, D, LAST, R>(
       fn: (a: A, b: B, c: C, d: D, last: LAST) => R
-  ) : (a: A, b: B, c: C, d: D) => (last: LAST) => R;
+  ) : (a: A, b: B, c: C, d: D) => (last: LAST) => R
 }
 
 /**

--- a/types/react-hyperscript-helpers/index.d.ts
+++ b/types/react-hyperscript-helpers/index.d.ts
@@ -17,14 +17,14 @@ declare module 'react-hyperscript-helpers' {
       component: Component<Props>,
       props: WithKey<Omit<Props, 'children'>>,
       children: Children<Props>
-    ): React.ReactElement<any, any>;
+    ): React.ReactElement<any, any>
 
     <Props extends {}>(
       component: Component<Props>,
       propsOrChildren: Props extends { children?: unknown } ? WithKey<Props> | Children<Props> : WithKey<Props>
-    ): React.ReactElement<any, any>;
+    ): React.ReactElement<any, any>
 
-    <Props extends {}>(component: Component<Props>): React.ReactElement<any, any>;
+    <Props extends {}>(component: Component<Props>): React.ReactElement<any, any>
   }
 
   export const h: HHelper
@@ -36,7 +36,7 @@ declare module 'react-hyperscript-helpers' {
   type DataAttributeKey = `data-${string}`
 
   type WithDataAttributes<T> = T & {
-    [dataAttribute: DataAttributeKey]: string;
+    [dataAttribute: DataAttributeKey]: string
   }
 
   type HtmlHelper<T extends TagName> = {


### PR DESCRIPTION
This PR adds a lint rule to enforce interface styling consistency. 

In most cases (i.e. object definition) we enforce commas separating entries with no trailing comma. I like the idea of enforcing interfaces to have no commas since then they are easily distinguishable from other constructs at a first glance. 