### PR TITLE
UIE-5 Shared Jest Mocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,6 +134,10 @@
   "workspaces": [
     "integration-tests"
   ],
+  "jest": {
+    "clearMocks": true,
+    "resetMocks": false
+  },
   "lint-staged": {
     "**/*.{js,ts}": [
       "yarn eslint --max-warnings=0"

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -86,7 +86,7 @@ const Modal = ({ onDismiss, title, titleExtras, children, width = 450, showCance
   ])
 }
 
-Modal.propTypes = {
+export const modalPropTypes = {
   onDismiss: PropTypes.func.isRequired,
   title: PropTypes.node,
   titleExtras: PropTypes.node,
@@ -98,5 +98,7 @@ Modal.propTypes = {
   okButton: PropTypes.oneOfType([PropTypes.string, PropTypes.func, PropTypes.node]),
   children: PropTypes.node
 }
+
+Modal.propTypes = modalPropTypes
 
 export default Modal

--- a/src/components/Modal.mock.ts
+++ b/src/components/Modal.mock.ts
@@ -1,0 +1,29 @@
+import { FunctionComponent } from 'react'
+
+
+export type ModalExports = typeof import('src/components/Modal') & { __esModule: true }
+
+/**
+ * provides a mocked version of Modal module's Modal component that avoids
+ * pitfalls specific to missing services in jest simulated browser environment
+ * including dom measurement calls.
+ */
+export const mockModalModule = (): ModalExports => {
+  const originalModule = jest.requireActual<ModalExports>('src/components/Modal')
+
+  type ModalFn = FunctionComponent & {propTypes: typeof originalModule.modalPropTypes};
+
+  // Stub out onAfterOpen for noOp because real implementation needs
+  // unavailable dom measuring services
+  const modalFn = props => originalModule.default({ onAfterOpen: jest.fn(), ...props })
+  modalFn.propTypes = originalModule.modalPropTypes
+
+  type MockedModalFn = ModalFn & jest.Mock
+  const mockModalFn: MockedModalFn = jest.fn(modalFn) as MockedModalFn
+
+  return {
+    ...originalModule,
+    __esModule: true,
+    default: mockModalFn
+  }
+}

--- a/src/components/Modal.mock.ts
+++ b/src/components/Modal.mock.ts
@@ -13,8 +13,11 @@ export const mockModalModule = (): ModalExports => {
 
   type ModalFn = FunctionComponent & {propTypes: typeof originalModule.modalPropTypes};
 
-  // Stub out onAfterOpen for noOp because real implementation needs
-  // unavailable dom measuring services
+  // Stub out onAfterOpen for noOp because the real implementation needs
+  // unavailable dom measuring services.
+  // Note that this issue may not show up in non-async tests, since the
+  // internal implementation of react-modal only hits onAfterOpen as part of
+  // a requestAnimationFrame async flow.
   const modalFn = props => originalModule.default({ onAfterOpen: jest.fn(), ...props })
   modalFn.propTypes = originalModule.modalPropTypes
 

--- a/src/pages/billing/CreateAzureBillingProjectModal.test.js
+++ b/src/pages/billing/CreateAzureBillingProjectModal.test.js
@@ -4,6 +4,7 @@ import { axe } from 'jest-axe'
 import _ from 'lodash/fp'
 import { act } from 'react-dom/test-utils'
 import { h } from 'react-hyperscript-helpers'
+import { mockModalModule } from 'src/components/Modal.mock'
 import { Ajax } from 'src/libs/ajax'
 import CreateAzureBillingProjectModal from 'src/pages/billing/CreateAzureBillingProjectModal'
 import { billingProjectNameValidator } from 'src/pages/billing/List'
@@ -11,13 +12,9 @@ import { v4 as uuid } from 'uuid'
 
 
 jest.mock('src/components/Modal', () => {
-  const originalModule = jest.requireActual('src/components/Modal')
-  return {
-    ...originalModule,
-    __esModule: true,
-    default: props => originalModule.default({ onAfterOpen: jest.fn(), ...props })
-  }
+  return mockModalModule()
 })
+
 jest.mock('src/libs/ajax')
 
 describe('CreateAzureBillingProjectModal', () => {

--- a/src/pages/billing/CreateNewBillingProjectWizard.test.js
+++ b/src/pages/billing/CreateNewBillingProjectWizard.test.js
@@ -128,6 +128,8 @@ describe('CreateNewBillingProjectWizard Steps', () => {
   let wizardComponent
 
   beforeEach(() => {
+    jest.resetAllMocks()
+
     // Arrange
     Ajax.mockImplementation(() => ({
       Billing: { createGCPProject },


### PR DESCRIPTION
- implemented recommended pattern for shared reusable jest mocks with good type safety in Typescript.
- changed project config to have jest auto-clear mocks but not auto-reset them.  This lets test files provide a file-level-default for a given module mock, and enables convenience when using the implemented shared mock pattern.
- existing test files that expect autoReset to be true can manually restore that setup with a call to jest.resetAllMocks() in beforeEach()
- xxxx.mock.ts files are co-located next to the module file it provides mocks for.  The same pattern should work fine for xxxx.mock.js for teams not ready to jump onto Typescript.

See my PR comments for more info

The hope is that this pattern can be replicated for all common mocks to avoid cut-and-paste and avoid DRY on what can be non-trivial mocks.

Jest provides a built-in mechanic to do 'default mocks', but I feel it has a few shortcomings:
- poor discoverability: mocks magically cascade into your test files and no direct 'goto definition' and 'find uses' tracing like this pattern provides.
- `__mocks__` directory requirement can be cludgy
- harder to provide good type safety.
- appears to be less composable for partial overrides of exports