### PR TITLE
[TUIM-45] Allow trailing commas

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,7 +23,7 @@ module.exports = {
     'block-spacing': 'warn',
     'brace-style': ['warn', '1tbs', { 'allowSingleLine': true }],
     'camelcase': ['warn', { 'properties': 'never' }],
-    'comma-dangle': 'warn',
+    'comma-dangle': ['warn', 'only-multiline'],
     'comma-spacing': 'warn',
     'comma-style': 'warn',
     'computed-property-spacing': 'warn',


### PR DESCRIPTION
Update ESLint configuration to allow trailing commas in some cases.

> "only-multiline" allows (but does not require) trailing commas when the last element or property is in a different line than the closing ] or } and disallows trailing commas when the last element or property is on the same line as the closing ] or }

For example, currently in a case like this, ESLint requires no comma after the last element.

```js
const list = [
  'foo',
  'bar',
  'baz'
]
```

This change would allow (but not require) it.
```js
const list = [
  'foo',
  'bar',
  'baz',
]
```

Trailing commas make for cleaner diffs when adding or removing items. See example in the [docs for the comma-dangle rule](https://eslint.org/docs/latest/rules/comma-dangle).