### PR TITLE
WX-776: Delete Cromwell version labels from Terra UI

### DIFF
--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -4,7 +4,7 @@ import { UnmountClosed as RCollapse } from 'react-collapse'
 import { a, div, h, h1, img, span } from 'react-hyperscript-helpers'
 import { Transition } from 'react-transition-group'
 import AlertsIndicator from 'src/components/Alerts'
-import { Clickable, CromwellVersionLink, FocusTrapper, IdContainer, LabeledCheckbox, Link, spinnerOverlay } from 'src/components/common'
+import { Clickable, FocusTrapper, IdContainer, LabeledCheckbox, Link, spinnerOverlay } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import { TextArea } from 'src/components/input'
 import Modal from 'src/components/Modal'
@@ -314,7 +314,6 @@ const TopBar = ({ showMenu = true, title, href, children }) => {
           div({
             style: { flex: 'none', padding: 28, marginTop: 'auto' }
           }, [
-            h(CromwellVersionLink, { variant: 'light', style: { textDecoration: 'underline', color: 'white' } }),
             isBioDataCatalyst() && h(Fragment, [
               h(Link,
                 {

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -26,7 +26,7 @@ import { getConfig } from 'src/libs/config'
 import { withErrorReporting } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
 import { notify } from 'src/libs/notifications'
-import { forwardRefWithName, useCancellation, useLabelAssert, useOnMount, useUniqueId } from 'src/libs/react-utils'
+import { forwardRefWithName, useLabelAssert, useOnMount, useUniqueId } from 'src/libs/react-utils'
 import { authStore } from 'src/libs/state'
 import * as Utils from 'src/libs/utils'
 
@@ -330,29 +330,6 @@ export const FocusTrapper = ({ children, onBreakout, ...props }) => {
       }
     }, props)
   }, [children])
-}
-
-export const CromwellVersionLink = props => {
-  const [version, setVersion] = useState()
-  const signal = useCancellation()
-
-  useOnMount(() => {
-    const setCromwellVersion = async () => {
-      const { cromwell } = await Ajax(signal).Submissions.cromwellVersion()
-
-      setVersion(cromwell.split('-')[0])
-    }
-
-    setCromwellVersion()
-  })
-
-  return version ?
-    h(Link, {
-      href: `https://github.com/broadinstitute/cromwell/releases/tag/${version}`,
-      ...Utils.newTabLinkProps,
-      ...props
-    }, ['Cromwell ', version, icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })]) :
-    'Cromwell version loading...'
 }
 
 const SwitchLabel = ({ isOn, onLabel, offLabel }) => div({

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -956,11 +956,6 @@ const Submissions = signal => ({
   queueStatus: async () => {
     const res = await fetchRawls('submissions/queueStatus', _.merge(authOpts(), { signal }))
     return res.json()
-  },
-
-  cromwellVersion: async () => {
-    const res = await fetchOk(`${getConfig().rawlsUrlRoot}/version/executionEngine`, { signal })
-    return res.json()
   }
 })
 

--- a/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
+++ b/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp'
 import { Fragment, useState } from 'react'
 import { b, div, h, label, p, span } from 'react-hyperscript-helpers'
-import { ButtonPrimary, CromwellVersionLink, IdContainer, Link } from 'src/components/common'
+import { ButtonPrimary, IdContainer, Link } from 'src/components/common'
 import { warningBoxStyle } from 'src/components/data/data-utils'
 import { icon, spinner } from 'src/components/icons'
 import { ValidatedTextArea } from 'src/components/input'
@@ -102,7 +102,6 @@ const LaunchAnalysisModal = ({
       }, ['Launch']) :
       h(ButtonPrimary, { onClick: onDismiss }, ['OK'])
   }, [
-    div({ style: { margin: '1rem 0 1.5rem' } }, ['This analysis will be run by ', h(CromwellVersionLink), '.']),
     div(['Output files will be saved as workspace data in:']),
     div({ style: { margin: '0.5rem 0 1.5rem' } }, [
       location ? h(Fragment, [span({ style: { marginRight: '0.5rem' } }, [flag]),


### PR DESCRIPTION
Addresses [WX-776](https://broadworkbench.atlassian.net/browse/WX-776)

PR removes Cromwell version labelling (rendered by `CromwellVersionLink.js`), from the `TopBar` and `LaunchAnalysisModal` components.
