### PR TITLE
WDS vs Entity Service discriminator for (some) Mixpanel events

### DIFF
--- a/src/libs/ajax/data-table-providers/DataTableProvider.ts
+++ b/src/libs/ajax/data-table-providers/DataTableProvider.ts
@@ -75,6 +75,7 @@ export interface DataTableFeatures {
 }
 
 export interface DataTableProvider {
+  providerName: string
   features: DataTableFeatures
   getPage: GetPageFn
   deleteTable: DeleteTableFn

--- a/src/libs/ajax/data-table-providers/EntityServiceDataTableProvider.ts
+++ b/src/libs/ajax/data-table-providers/EntityServiceDataTableProvider.ts
@@ -9,6 +9,8 @@ export class EntityServiceDataTableProvider implements DataTableProvider {
     this.name = name
   }
 
+  providerName: string = 'Entity Service'
+
   namespace: string
 
   name: string

--- a/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
+++ b/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
@@ -68,6 +68,8 @@ export class WdsDataTableProvider implements DataTableProvider {
     this.workspaceId = workspaceId
   }
 
+  providerName: string = 'WDS'
+
   workspaceId: string
 
   features: DataTableFeatures = {

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -336,9 +336,9 @@ const DataTableActions = ({ workspace, tableName, rowCount, entityMetadata, onRe
               // TODO: this overrides the filename specified by the WDS API. Is that ok?
               dataProvider.downloadTsv(signal, tableName).then(blob => FileSaver.saveAs(blob, `${tableName}.tsv`))
             }
-            // TODO: AJ-656 add Entity Service vs. WDS indicator to mixpanel event
             Ajax().Metrics.captureEvent(Events.workspaceDataDownload, {
               ...extractWorkspaceDetails(workspace.workspace),
+              providerName: dataProvider.providerName,
               downloadFrom: 'all rows',
               fileType: '.tsv'
             })
@@ -427,9 +427,9 @@ const DataTableActions = ({ workspace, tableName, rowCount, entityMetadata, onRe
       onConfirm: Utils.withBusyState(setLoading)(async () => {
         try {
           await dataProvider.deleteTable(tableName)
-          // TODO: AJ-656 add WDS vs. Entity Service property to the mixpanel event
           Ajax().Metrics.captureEvent(Events.workspaceDataDeleteTable, {
-            ...extractWorkspaceDetails(workspace.workspace)
+            ...extractWorkspaceDetails(workspace.workspace),
+            providerName: dataProvider.providerName
           })
           setDeleting(false)
           onDeleteTable(tableName)


### PR DESCRIPTION
Adds `providerName: WDS` or `providerName: Entity Service` as properties of a couple Mixpanel events.

I reviewed the `dataTable*` and `workspaceData*` events listed in https://github.com/DataBiosphere/terra-ui/blob/dev/src/libs/events.js, and only found these two that are possible to change in this PR. #3495 has another two events that will need updating.

Tested by inspecting the outbound Ajax requests when running locally, and by inspecting the events that landed in Mixpanel dev:
![Screenshot 11-10-2022 at 09 50 AM](https://user-images.githubusercontent.com/6041577/201123501-a2e3d173-bcb4-4368-9a82-beeb5ab9cdea.png)

I have also updated the Mixpanel lexicon to describe this event property:
![Screenshot 11-10-2022 at 10 17 AM](https://user-images.githubusercontent.com/6041577/201133820-8cdd564d-9671-4802-b6e4-4b867bc01ec0.png)

