### PR TITLE
Link labels to autocomplete inputs (TUIM-43).

### DIFF
--- a/src/components/data/SavedColumnSettings.js
+++ b/src/components/data/SavedColumnSettings.js
@@ -209,10 +209,10 @@ const SavedColumnSettings = ({ workspace, snapshotName, entityType, entityMetada
     div(showSaveForm ? [
       p({ style: { marginTop: 0 } }, 'Save this column selection'),
       h(IdContainer, [id => h(Fragment, [
-        h(FormLabel, { htmlFor: id }, 'Column selection name'),
+        h(FormLabel, { id }, 'Column selection name'),
         h(AutocompleteTextInput, {
           ref: settingsNameInput,
-          id,
+          labelId: id,
           openOnFocus: true,
           placeholderText: 'Enter a name for selection',
           onPick: setSelectedSettingsName,

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -742,10 +742,10 @@ export const MultipleEntityEditor = ({ entityType, entities, attributeNames, ent
         div({ style: { display: 'flex', flexDirection: 'column', marginBottom: '1rem' } }, [
           h(IdContainer, [
             id => h(Fragment, [
-              label({ htmlFor: id, style: { marginBottom: '0.5rem', fontWeight: 'bold' } }, 'Select a column to edit'),
+              label({ id, style: { marginBottom: '0.5rem', fontWeight: 'bold' } }, 'Select a column to edit'),
               div({ style: { position: 'relative', display: 'flex', alignItems: 'center' } }, [
                 h(AutocompleteTextInput, {
-                  id,
+                  labelId: id,
                   value: attributeToEdit,
                   suggestions: attributeNames,
                   placeholder: 'Column name',

--- a/src/components/group-common.js
+++ b/src/components/group-common.js
@@ -182,9 +182,9 @@ export const NewUserModal = ({
       }, ['Add User'])
     }, [
       h(IdContainer, [id => h(Fragment, [
-        h(FormLabel, { htmlFor: id, required: true }, ['User email']),
+        h(FormLabel, { id, required: true }, ['User email']),
         h(AutocompleteTextInput, {
-          id,
+          labelId: id,
           autoFocus: true,
           openOnFocus: false,
           value: userEmail,

--- a/src/components/input.js
+++ b/src/components/input.js
@@ -324,6 +324,14 @@ const withAutocomplete = WrappedComponent => forwardRefWithName(`withAutocomplet
   ])
 })
 
+/**
+ * Note that `labelId` (the id of the label associated with the text input) must be passed in the props to avoid
+ * an accessibility bug-- our typical pattern of associating a label with the id does not work because this is
+ * a wrapped component with a child component (`Downshift`) that uses `labelId` as the id for `aria-labelledby`.
+ *
+ * If no visible label is desired, use `className: 'sr-only'` to visually hide the label while still properly
+ * associating a label for accessibility support.
+ */
 export const AutocompleteTextInput = withAutocomplete(TextInput)
 
 export const DelayedAutoCompleteInput = withDebouncedChange(AutocompleteTextInput)

--- a/src/pages/library/common.js
+++ b/src/pages/library/common.js
@@ -101,7 +101,9 @@ const FilterBar = ({ name, onClear, onFilterByLetter, onFilterBySearchText, onSo
           fontWeight: 'bold', display: 'flex', justifyContent: 'center', alignItems: 'center', padding: 5, borderRadius: '50%', minWidth: 20,
           background: filteredBy === String.fromCharCode(index) ? colors.accent(0.3) : 'transparent'
         },
-        'aria-label': filteredBy === String.fromCharCode(index) ? `Filtering by ${String.fromCharCode(index)}` : `Filter option: ${String.fromCharCode(index)}`,
+        'aria-label': filteredBy === String.fromCharCode(index) ?
+          `Filtering by ${String.fromCharCode(index)}` :
+          `Filter option: ${String.fromCharCode(index)}`,
         onClick: () => {
           const charFromCode = String.fromCharCode(index)
           setFilteredBy(charFromCode)
@@ -121,7 +123,8 @@ const FilterBar = ({ name, onClear, onFilterByLetter, onFilterBySearchText, onSo
         ])
       ])
     ]),
-    filterType === filterOptions.alpha && filteredBy && div({ style: { display: 'flex', flexDirection: 'row', justifyContent: 'flex-end', marginTop: 5 } }, [
+    filterType === filterOptions.alpha && filteredBy &&
+    div({ style: { display: 'flex', flexDirection: 'row', justifyContent: 'flex-end', marginTop: 5 } }, [
       h(Link, {
         style: { fontSize: '1rem' },
         onClick: () => {
@@ -206,7 +209,9 @@ const FilterModal = ({ name, labels, setShowAll, onTagFilter, listDataByTag, low
           h(LabeledCheckbox, {
             checked: !!filterChanges[escapedTag] ^ _.includes(lowerTag, lowerSelectedTags),
             onChange: () => {
-              setFilterChanges(prevFilter => prevFilter[escapedTag] ? _.omit(escapedTag, prevFilter) : _.set(escapedTag, { lowerTag, label, section: name }, prevFilter))
+              setFilterChanges(prevFilter => prevFilter[escapedTag] ?
+                _.omit(escapedTag, prevFilter) :
+                _.set(escapedTag, { lowerTag, label, section: name }, prevFilter))
             },
             style: { position: 'absolute', left: -25, top: 2 }
           }, [
@@ -440,7 +445,10 @@ export const SearchAndFilterComponent = ({
     }, [
       h2({ style: { ...styles.sidebarRow } }, [
         div({ style: styles.header }, [searchType]),
-        div({ style: styles.pill(_.isEmpty(selectedSections) && _.isEmpty(selectedTags)), role: 'status', 'aria-label': `${_.size(filteredData.data)} Results found` }, [_.size(filteredData.data)])
+        div({
+          style: styles.pill(_.isEmpty(selectedSections) && _.isEmpty(selectedTags)), role: 'status',
+          'aria-label': `${_.size(filteredData.data)} Results found`
+        }, [_.size(filteredData.data)])
       ]),
       div({ style: { ...styles.nav.title, display: 'flex', alignItems: 'baseline' } }, [
         div({ style: { flex: 1, fontSize: '1.125rem', fontWeight: 600 } }, ['Filters']),
@@ -452,32 +460,35 @@ export const SearchAndFilterComponent = ({
         }, ['clear'])
       ]),
       div({ style: { display: 'flex', alignItems: 'center' } }, [
-        h(DelayedAutoCompleteInput, {
-          style: { borderRadius: 25, flex: '1 1 0' },
-          inputIcon: 'search',
-          openOnFocus: true,
-          value: searchFilter,
-          'aria-label': `Search ${searchType}`,
-          placeholder: 'Search Name or Description',
-          itemToString: v => v[titleField],
-          onChange: onSearchChange,
-          suggestionFilter: _.curry((needle, { lowerName, lowerDescription }) => _.includes(_.toLower(needle), `${lowerName} ${lowerDescription}`)),
-          renderSuggestion: suggestion => {
-            return div({ style: { lineHeight: '1.75rem', padding: '0.375rem 0', borderBottom: `1px dotted ${colors.dark(0.7)}` } },
-              _.flow(
-                _.split(filterRegex),
-                _.map(item => _.toLower(item) === _.toLower(searchFilter) ? strong([item]) : item),
-                maybeMatch => {
-                  return _.size(maybeMatch) < 2 ? [
-                    _.truncate({ length: 90 }, _.head(maybeMatch)),
-                    div({ style: { lineHeight: '1.5rem', marginLeft: '2rem' } }, [...getContext(suggestion[descField])])
-                  ] : maybeMatch
-                }
-              )(suggestion[titleField])
-            )
-          },
-          suggestions: filteredData.data
-        }),
+        h(IdContainer, [id => h(Fragment, [
+          h(div, { id, className: 'sr-only' }, `Search ${searchType}`),
+          h(DelayedAutoCompleteInput, {
+            style: { borderRadius: 25, flex: '1 1 0' },
+            inputIcon: 'search',
+            openOnFocus: true,
+            value: searchFilter,
+            labelId: id,
+            placeholder: 'Search Name or Description',
+            itemToString: v => v[titleField],
+            onChange: onSearchChange,
+            suggestionFilter: _.curry((needle, { lowerName, lowerDescription }) => _.includes(_.toLower(needle), `${lowerName} ${lowerDescription}`)),
+            renderSuggestion: suggestion => {
+              return div({ style: { lineHeight: '1.75rem', padding: '0.375rem 0', borderBottom: `1px dotted ${colors.dark(0.7)}` } },
+                _.flow(
+                  _.split(filterRegex),
+                  _.map(item => _.toLower(item) === _.toLower(searchFilter) ? strong([item]) : item),
+                  maybeMatch => {
+                    return _.size(maybeMatch) < 2 ? [
+                      _.truncate({ length: 90 }, _.head(maybeMatch)),
+                      div({ style: { lineHeight: '1.5rem', marginLeft: '2rem' } }, [...getContext(suggestion[descField])])
+                    ] : maybeMatch
+                  }
+                )(suggestion[titleField])
+              )
+            },
+            suggestions: filteredData.data
+          })
+        ])]),
         !customSort && h(IdContainer, [id => h(Fragment, [
           label({
             htmlFor: id,

--- a/src/pages/workspaces/workspace/ShareWorkspaceModal.js
+++ b/src/pages/workspaces/workspace/ShareWorkspaceModal.js
@@ -237,9 +237,9 @@ const ShareWorkspaceModal = ({ onDismiss, workspace, workspace: { workspace: { n
   }, [
     div({ style: { display: 'flex', alignItems: 'flex-end' } }, [
       h(IdContainer, [id => div({ style: { flexGrow: 1, marginRight: '1rem' } }, [
-        h(FormLabel, { htmlFor: id }, ['User email']),
+        h(FormLabel, { id }, ['User email']),
         h(AutocompleteTextInput, {
-          id,
+          labelId: id,
           openOnFocus: true,
           placeholderText: _.includes(searchValue, aclEmails) ?
             'This email has already been added to the list' :


### PR DESCRIPTION
Fixes this bug (https://broadworkbench.atlassian.net/browse/TUIM-43):

Because `AutoCompleteTextInput` is a component that wraps other components, during our typical pattern of associating a label with it does not work (the id passed does not propagate down into the child components). Instead, the label of the id must be passed in as `labelId`, and this will ultimately make its way into `Downshift`, which will properly add the `aria-labelledby` attribute with the passed id. If it is not done that way, `Downshift` will generate an id, but nothing on the page actually exists with that id.

![image](https://user-images.githubusercontent.com/484484/201672104-1ac47f9f-1c55-4a43-afbc-01b9cc59ff88.png)
