### PR TITLE
[UIE-16] Split checkbox and radio button components out of components/common.js

### DIFF
--- a/src/components/common.js
+++ b/src/components/common.js
@@ -3,7 +3,7 @@ import _ from 'lodash/fp'
 import * as qs from 'qs'
 import { Fragment, useState } from 'react'
 import FocusLock from 'react-focus-lock'
-import { b, div, h, h1, img, input, label, span } from 'react-hyperscript-helpers'
+import { b, div, h, h1, img, label, span } from 'react-hyperscript-helpers'
 import RSelect, { components as RSelectComponents } from 'react-select'
 import RAsyncCreatableSelect from 'react-select/async-creatable'
 import RSwitch from 'react-switch'
@@ -34,19 +34,9 @@ import * as Utils from 'src/libs/utils'
 export * from 'src/components/common/buttons'
 export * from 'src/components/common/Checkbox'
 export * from 'src/components/common/IdContainer'
+export * from 'src/components/common/RadioButton'
 export { Clickable, Link }
 
-
-export const RadioButton = ({ text, name, labelStyle, ...props }) => {
-  return h(IdContainer, [id => h(Fragment, [
-    input({
-      type: 'radio', id,
-      name,
-      ...props
-    }),
-    text && label({ htmlFor: id, style: labelStyle }, [text])
-  ])])
-}
 
 const makeBaseSpinner = ({ outerStyles = {}, innerStyles = {} }) => div(
   {

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -9,6 +9,7 @@ import RAsyncCreatableSelect from 'react-select/async-creatable'
 import RSwitch from 'react-switch'
 import { ButtonPrimary } from 'src/components/common/buttons'
 import Clickable from 'src/components/common/Clickable'
+import { IdContainer } from 'src/components/common/IdContainer'
 import Link from 'src/components/common/Link'
 import FooterWrapper from 'src/components/FooterWrapper'
 import { centeredSpinner, icon } from 'src/components/icons'
@@ -32,6 +33,7 @@ import * as Utils from 'src/libs/utils'
 
 
 export * from 'src/components/common/buttons'
+export * from 'src/components/common/IdContainer'
 export { Clickable, Link }
 
 
@@ -309,11 +311,6 @@ export const UnlinkFenceAccount = ({ linkText, provider }) => {
       isUnlinking && spinnerOverlay
     ])
   ])
-}
-
-export const IdContainer = ({ children }) => {
-  const [id] = useState(() => _.uniqueId('element-'))
-  return children(id)
 }
 
 export const FocusTrapper = ({ children, onBreakout, ...props }) => {

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -14,7 +14,6 @@ import Link from 'src/components/common/Link'
 import FooterWrapper from 'src/components/FooterWrapper'
 import { centeredSpinner, icon } from 'src/components/icons'
 import { TextInput } from 'src/components/input'
-import Interactive from 'src/components/Interactive'
 import Modal from 'src/components/Modal'
 import { MiniSortable } from 'src/components/table'
 import TopBar from 'src/components/TopBar'
@@ -33,42 +32,10 @@ import * as Utils from 'src/libs/utils'
 
 
 export * from 'src/components/common/buttons'
+export * from 'src/components/common/Checkbox'
 export * from 'src/components/common/IdContainer'
 export { Clickable, Link }
 
-
-export const Checkbox = ({ checked, onChange, disabled, ...props }) => {
-  useLabelAssert('Checkbox', { ...props, allowId: true })
-  return h(Interactive, _.merge({
-    as: 'span',
-    className: 'fa-layers fa-fw',
-    role: 'checkbox',
-    'aria-checked': checked,
-    onClick: () => !disabled && onChange?.(!checked),
-    style: { verticalAlign: 'middle' },
-    disabled
-  }, props), [
-    icon('squareSolid', { style: { color: Utils.cond([disabled, () => colors.light(1.2)], [checked, () => colors.accent()], () => 'white') } }), // bg
-    !disabled && icon('squareLight', { style: { color: checked ? colors.accent(1.2) : colors.dark(0.75) } }), // border
-    checked && icon('check', { size: 8, style: { color: disabled ? colors.dark(0.75) : 'white' } }) // check
-  ])
-}
-
-export const LabeledCheckbox = ({ checked, onChange, disabled, children, ...props }) => {
-  return h(IdContainer, [id => h(Fragment, [
-    h(Checkbox, { checked, onChange, disabled, 'aria-labelledby': id, ...props }),
-    span({
-      id,
-      style: {
-        verticalAlign: 'middle',
-        color: disabled ? colors.dark(0.8) : undefined,
-        cursor: disabled ? 'default' : 'pointer'
-      },
-      onClick: () => !disabled && onChange?.(!checked),
-      disabled
-    }, [children])
-  ])])
-}
 
 export const RadioButton = ({ text, name, labelStyle, ...props }) => {
   return h(IdContainer, [id => h(Fragment, [

--- a/src/components/common/Checkbox.js
+++ b/src/components/common/Checkbox.js
@@ -1,0 +1,44 @@
+import _ from 'lodash/fp'
+import { Fragment } from 'react'
+import { h, span } from 'react-hyperscript-helpers'
+import { icon } from 'src/components/icons'
+import Interactive from 'src/components/Interactive'
+import colors from 'src/libs/colors'
+import { useLabelAssert } from 'src/libs/react-utils'
+import * as Utils from 'src/libs/utils'
+
+import { IdContainer } from './IdContainer'
+
+
+export const Checkbox = ({ checked, onChange, disabled, ...props }) => {
+  useLabelAssert('Checkbox', { ...props, allowId: true })
+  return h(Interactive, _.merge({
+    as: 'span',
+    className: 'fa-layers fa-fw',
+    role: 'checkbox',
+    'aria-checked': checked,
+    onClick: () => !disabled && onChange?.(!checked),
+    style: { verticalAlign: 'middle' },
+    disabled
+  }, props), [
+    icon('squareSolid', { style: { color: Utils.cond([disabled, () => colors.light(1.2)], [checked, () => colors.accent()], () => 'white') } }), // bg
+    !disabled && icon('squareLight', { style: { color: checked ? colors.accent(1.2) : colors.dark(0.75) } }), // border
+    checked && icon('check', { size: 8, style: { color: disabled ? colors.dark(0.75) : 'white' } }) // check
+  ])
+}
+
+export const LabeledCheckbox = ({ checked, onChange, disabled, children, ...props }) => {
+  return h(IdContainer, [id => h(Fragment, [
+    h(Checkbox, { checked, onChange, disabled, 'aria-labelledby': id, ...props }),
+    span({
+      id,
+      style: {
+        verticalAlign: 'middle',
+        color: disabled ? colors.dark(0.8) : undefined,
+        cursor: disabled ? 'default' : 'pointer'
+      },
+      onClick: () => !disabled && onChange?.(!checked),
+      disabled
+    }, [children])
+  ])])
+}

--- a/src/components/common/IdContainer.js
+++ b/src/components/common/IdContainer.js
@@ -1,0 +1,8 @@
+import _ from 'lodash/fp'
+import { useState } from 'react'
+
+
+export const IdContainer = ({ children }) => {
+  const [id] = useState(() => _.uniqueId('element-'))
+  return children(id)
+}

--- a/src/components/common/RadioButton.js
+++ b/src/components/common/RadioButton.js
@@ -1,0 +1,16 @@
+import { Fragment } from 'react'
+import { h, input, label } from 'react-hyperscript-helpers'
+
+import { IdContainer } from './IdContainer'
+
+
+export const RadioButton = ({ text, name, labelStyle, ...props }) => {
+  return h(IdContainer, [id => h(Fragment, [
+    input({
+      type: 'radio', id,
+      name,
+      ...props
+    }),
+    text && label({ htmlFor: id, style: labelStyle }, [text])
+  ])])
+}


### PR DESCRIPTION
Continuing to break up components/common.js. This moves Checkbox and RadioButton components into separate modules. To avoid a circular import, this required splitting IdContainer out first.

All components are re-exported from components/common.js so that import paths in the rest of Terra UI do not change.