### PR TITLE
[AJ-662, AJ-670, AJ-684] Data tab left nav for azure vs google workspaces

### DIFF
--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -501,6 +501,9 @@ const WorkspaceData = _.flow(
 
   const { dataTableVersions, loadDataTableVersions, saveDataTableVersion, deleteDataTableVersion, importDataTableVersion } = useDataTableVersions(workspace)
 
+  const isGoogleWorkspace = !!googleProject
+  const isAzureWorkspace = !isGoogleWorkspace
+
   const signal = useCancellation()
   const asyncImportJobs = useStore(asyncImportJobStore)
 
@@ -643,7 +646,7 @@ const WorkspaceData = _.flow(
   return div({ style: styles.tableContainer }, [
     !entityMetadata ? spinnerOverlay : h(Fragment, [
       div({ style: { ...styles.sidebarContainer, width: sidebarWidth } }, [
-        div({
+        isGoogleWorkspace && div({
           style: {
             display: 'flex', padding: '1rem 1.5rem',
             backgroundColor: colors.light(),
@@ -676,7 +679,7 @@ const WorkspaceData = _.flow(
         ]),
         div({ style: styles.dataTypeSelectionPanel, role: 'navigation', 'aria-label': 'data in this workspace' }, [
           div({ role: 'list' }, [
-            h(DataTypeSection, {
+            isGoogleWorkspace && h(DataTypeSection, {
               title: 'Tables',
               error: entityMetadataError,
               retryFunction: loadEntityMetadata
@@ -758,12 +761,12 @@ const WorkspaceData = _.flow(
                 ])
               }, sortedEntityPairs)
             ]),
-            isFeaturePreviewEnabled('workspace-data-service') && h(DataTypeSection, {
-              title: 'WDS'
+            isFeaturePreviewEnabled('workspace-data-service') && isAzureWorkspace && h(DataTypeSection, {
+              title: 'Tables'
             }, [
               [
                 wdsSchemaError && h(NoDataPlaceholder, {
-                  message: 'WDS is unavailable.'
+                  message: 'Data tables are unavailable.'
                 }),
                 !wdsSchemaError && h(NoDataPlaceholder, {
                   message: _.isEmpty(wdsSchema) ? 'No tables have been uploaded.' : '',
@@ -805,7 +808,7 @@ const WorkspaceData = _.flow(
                 }, wdsSchema)
               ]
             ]),
-            (!_.isEmpty(sortedSnapshotPairs) || snapshotMetadataError) && h(DataTypeSection, {
+            (!_.isEmpty(sortedSnapshotPairs) || snapshotMetadataError) && isGoogleWorkspace && h(DataTypeSection, {
               title: 'Snapshots',
               error: snapshotMetadataError,
               retryFunction: loadSnapshotMetadata
@@ -882,7 +885,7 @@ const WorkspaceData = _.flow(
                 )])
               }, sortedSnapshotPairs)
             ]),
-            h(DataTypeSection, {
+            isGoogleWorkspace && h(DataTypeSection, {
               title: 'Reference Data'
             }, [
               _.isEmpty(referenceData) && h(NoDataPlaceholder, {
@@ -947,7 +950,7 @@ const WorkspaceData = _.flow(
               }, namespace, name,
               workspaceId, entityTypes: wdsSchema.map(item => item['name']), dataProvider: wdsDataTableProvider
             }),
-            h(DataTypeSection, {
+            isGoogleWorkspace && h(DataTypeSection, {
               title: 'Other Data'
             }, [
               h(DataTypeButton, {

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -978,7 +978,7 @@ const WorkspaceData = _.flow(
       div({ style: styles.tableViewPanel }, [
         _.includes(selectedData?.type, [workspaceDataTypes.entities, workspaceDataTypes.entitiesVersion]) && h(DataTableFeaturePreviewFeedbackBanner),
         Utils.switchCase(selectedData?.type,
-          [undefined, () => div({ style: { textAlign: 'center' } }, ['Select a data type'])],
+          [undefined, () => div({ style: { textAlign: 'center' } }, ['Select a data type from the navigation panel on the left'])],
           [workspaceDataTypes.localVariables, () => h(LocalVariablesContent, {
             workspace,
             refreshKey

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -645,8 +645,8 @@ const WorkspaceData = _.flow(
 
   return div({ style: styles.tableContainer }, [
     !entityMetadata ? spinnerOverlay : h(Fragment, [
-      div({ style: { ...styles.sidebarContainer, width: sidebarWidth } }, [
-        isGoogleWorkspace && div({
+      (isGoogleWorkspace || isFeaturePreviewEnabled('workspace-data-service')) && div({ style: { ...styles.sidebarContainer, width: sidebarWidth } }, [
+        div({
           style: {
             display: 'flex', padding: '1rem 1.5rem',
             backgroundColor: colors.light(),
@@ -661,12 +661,12 @@ const WorkspaceData = _.flow(
             content: h(Fragment, [
               h(MenuButton, {
                 'aria-haspopup': 'dialog',
-                onClick: () => setUploadingFile(true)
+                onClick: () => isGoogleWorkspace ? setUploadingFile(true) : setUploadingWDSFile(true)
               }, 'Upload TSV'),
-              h(MenuButton, {
+              isGoogleWorkspace && h(MenuButton, {
                 href: `${Nav.getLink('upload')}?${qs.stringify({ workspace: workspaceId })}`
               }, ['Open data uploader']),
-              h(MenuButton, {
+              isGoogleWorkspace && h(MenuButton, {
                 'aria-haspopup': 'dialog',
                 onClick: () => setImportingReference(true)
               }, 'Add reference data')
@@ -768,8 +768,8 @@ const WorkspaceData = _.flow(
                 wdsSchemaError && h(NoDataPlaceholder, {
                   message: 'Data tables are unavailable.'
                 }),
-                !wdsSchemaError && h(NoDataPlaceholder, {
-                  message: _.isEmpty(wdsSchema) ? 'No tables have been uploaded.' : '',
+                !wdsSchemaError && _.isEmpty(wdsSchema) && h(NoDataPlaceholder, {
+                  message: 'No tables have been uploaded.',
                   buttonText: 'Upload TSV',
                   onAdd: () => setUploadingWDSFile(true)
                 }),


### PR DESCRIPTION
This PR configures the Data tab's left nav for Google vs. Azure workspaces.

| Azure Workspace | Google Workspace | 
| ------------- | ------------- |
| Import Data button, powered by WDS | Import Data button, powered by Rawls Entity Service |
| Tables, powered by WDS  | Tables, powered by Rawls Entity Service  |
| - | Reference Data |
| -  | Snapshots (by-reference), if any |
| -  | Other Data (workspace attributes, files) |

Notes:
* the section previously named "WDS" is now named "Tables".
* the "Import Data" button contains a different submenu for Azure (Upload TSV) than for Google (Upload TSV, Open data uploader, Add reference data)

Google workspace: 
![Screenshot 11-14-2022 at 03 29 PM (1)](https://user-images.githubusercontent.com/6041577/201759903-76deebe6-5007-4913-831e-cf279e9896b4.png)

Azure workspace, with WDS feature flag enabled:
![Screenshot 11-14-2022 at 04 34 PM](https://user-images.githubusercontent.com/6041577/201770246-2b366f42-a273-4091-87d5-8ed174b74b79.png)

empty Google workspace, no tables created yet:
![Screenshot 11-14-2022 at 04 34 PM (1)](https://user-images.githubusercontent.com/6041577/201770339-ac23cd0b-edfb-4ead-9d7b-4f767a443321.png)

empty Azure workspace, no tables created yet, with WDS feature flag enabled:
![Screenshot 11-14-2022 at 04 35 PM](https://user-images.githubusercontent.com/6041577/201770447-f76c560a-22b4-49f2-893b-23681b79aeb1.png)


Azure workspace, WDS feature flag disabled. Note that the "Data" tab is not visible when the feature flag is disabled; the only way to reach this screenshot is by manually changing the URL hash to include "data".
![Screenshot 11-14-2022 at 03 29 PM](https://user-images.githubusercontent.com/6041577/201759918-836f13a1-6416-493e-9d4d-7e144347a81b.png)






