### PR TITLE
[UIE-16] Move select, switch, and spinner components out of components/common.js

### DIFF
--- a/src/components/common/Select.js
+++ b/src/components/common/Select.js
@@ -1,0 +1,123 @@
+import _ from 'lodash/fp'
+import { div, h } from 'react-hyperscript-helpers'
+import RSelect, { components as RSelectComponents } from 'react-select'
+import RAsyncCreatableSelect from 'react-select/async-creatable'
+import { icon } from 'src/components/icons'
+import colors from 'src/libs/colors'
+import { useLabelAssert, useUniqueId } from 'src/libs/react-utils'
+
+
+const commonSelectProps = {
+  theme: base => _.merge(base, {
+    colors: {
+      primary: colors.accent(),
+      neutral20: colors.dark(0.55),
+      neutral30: colors.dark(0.55)
+    },
+    spacing: { controlHeight: 36 }
+  }),
+  styles: {
+    control: (base, { isDisabled }) => _.merge(base, {
+      backgroundColor: isDisabled ? colors.dark(0.25) : 'white',
+      boxShadow: 'none'
+    }),
+    singleValue: base => ({ ...base, color: colors.dark() }),
+    option: (base, { isSelected, isFocused, isDisabled }) => _.merge(base, {
+      fontWeight: isSelected ? 600 : undefined,
+      backgroundColor: isFocused ? colors.dark(0.15) : 'white',
+      color: isDisabled ? undefined : colors.dark(),
+      ':active': { backgroundColor: colors.accent(isSelected ? 0.55 : 0.4) }
+    }),
+    clearIndicator: base => ({ ...base, paddingRight: 0 }),
+    indicatorSeparator: () => ({ display: 'none' }),
+    dropdownIndicator: (base, { selectProps: { isClearable } }) => _.merge(base, { paddingLeft: isClearable ? 0 : undefined }),
+    multiValueLabel: base => ({ ...base, maxWidth: '100%' }),
+    multiValueRemove: base => _.merge(base, { ':hover': { backgroundColor: 'unset' } }),
+    placeholder: base => ({ ...base, color: colors.dark(0.8) })
+  },
+  components: {
+    Option: ({ children, selectProps, ...props }) => h(RSelectComponents.Option, _.merge(props, {
+      selectProps,
+      innerProps: {
+        role: 'option',
+        'aria-selected': props.isSelected
+      }
+    }), [
+      div({ style: { display: 'flex', alignItems: 'center', minHeight: 25 } }, [
+        div({ style: { flex: 1, minWidth: 0, overflowWrap: 'break-word' } }, [children]),
+        props.isSelected && icon('check', { size: 14, style: { flex: 'none', marginLeft: '0.5rem', color: colors.dark(0.5) } })
+      ])
+    ]),
+    Menu: ({ children, selectProps, ...props }) => h(RSelectComponents.Menu, _.merge(props, {
+      selectProps,
+      innerProps: {
+        role: 'listbox',
+        'aria-label': 'Options',
+        'aria-multiselectable': selectProps.isMulti
+      }
+    }), [children])
+  }
+}
+
+const formatGroupLabel = group => (
+  div({
+    style: {
+      color: colors.dark(),
+      fontSize: 14,
+      height: 30,
+      fontWeight: 600,
+      borderBottom: `1px solid ${colors.dark(0.25)}`
+    }
+  }, [group.label]))
+
+const BaseSelect = ({ value, newOptions, id, findValue, ...props }) => {
+  const newValue = props.isMulti ? _.map(findValue, value) : findValue(value)
+  const myId = useUniqueId()
+  const inputId = id || myId
+
+  return h(RSelect, _.merge({
+    inputId,
+    ...commonSelectProps,
+    getOptionLabel: ({ value, label }) => label || value.toString(),
+    value: newValue || null, // need null instead of undefined to clear the select
+    options: newOptions,
+    formatGroupLabel
+  }, props))
+}
+
+/**
+ * @param {Object} props - see {@link https://react-select.com/props#select-props}
+ * @param props.value - a member of options
+ * @param {Array} props.options - can be of any type; if objects, they should each contain a value and label, unless defining getOptionLabel
+ * @param props.id - The HTML ID to give the form element
+ */
+export const Select = ({ value, options, ...props }) => {
+  useLabelAssert('Select', { ...props, allowId: true })
+
+  const newOptions = options && !_.isObject(options[0]) ? _.map(value => ({ value }), options) : options
+  const findValue = target => _.find({ value: target }, newOptions)
+
+  return h(BaseSelect, { value, newOptions, findValue, ...props })
+}
+
+/**
+ * @param {Object} props - see {@link https://react-select.com/props#select-props}
+ * @param props.value - a member of an inner options object
+ * @param {Array} props.options - an object with toplevel pairs of label:options where label is a group label and options is an array of objects containing value:label pairs
+ * @param props.id - The HTML ID to give the form element
+ */
+export const GroupedSelect = ({ value, options, ...props }) => {
+  useLabelAssert('GroupedSelect', { ...props, allowId: true })
+
+  const flattenedOptions = _.flatMap('options', options)
+  const findValue = target => _.find({ value: target }, flattenedOptions)
+
+  return h(BaseSelect, { value, newOptions: options, findValue, ...props })
+}
+
+export const AsyncCreatableSelect = props => {
+  return h(RAsyncCreatableSelect, {
+    ...commonSelectProps,
+    ...props
+  })
+}

--- a/src/components/common/Switch.js
+++ b/src/components/common/Switch.js
@@ -1,0 +1,35 @@
+import _ from 'lodash/fp'
+import { div, h } from 'react-hyperscript-helpers'
+import RSwitch from 'react-switch'
+import colors from 'src/libs/colors'
+import { forwardRefWithName } from 'src/libs/react-utils'
+
+
+const SwitchLabel = ({ isOn, onLabel, offLabel }) => div({
+  style: {
+    display: 'flex', justifyContent: isOn ? 'flex-start' : 'flex-end',
+    fontSize: 15, fontWeight: 'bold', color: 'white',
+    height: '100%', lineHeight: '28px',
+    ...(isOn ? { marginLeft: '0.75rem' } : { marginRight: '0.5rem' })
+  }
+}, [isOn ? onLabel : offLabel])
+
+export const Switch = forwardRefWithName('Switch', ({ onChange, onLabel = 'True', offLabel = 'False', ...props }, ref) => {
+  return h(RSwitch, {
+    onChange: value => onChange(value),
+    offColor: colors.dark(0.5),
+    onColor: colors.success(1.2),
+    checkedIcon: h(SwitchLabel, { isOn: true, onLabel, offLabel }),
+    uncheckedIcon: h(SwitchLabel, { isOn: false, onLabel, offLabel }),
+    width: 80,
+    ...props,
+    ref: rSwitch => {
+      const inputEl = rSwitch ? rSwitch.$inputRef : null
+      if (_.has('current', ref)) {
+        ref.current = inputEl
+      } else if (_.isFunction(ref)) {
+        ref(inputEl)
+      }
+    }
+  })
+})

--- a/src/components/common/spinners.js
+++ b/src/components/common/spinners.js
@@ -1,0 +1,31 @@
+import { div } from 'react-hyperscript-helpers'
+import { centeredSpinner } from 'src/components/icons'
+
+
+const makeBaseSpinner = ({ outerStyles = {}, innerStyles = {} }) => div(
+  {
+    style: {
+      position: 'absolute',
+      display: 'flex', alignItems: 'center',
+      top: 0, right: 0, bottom: 0, left: 0,
+      backgroundColor: 'rgba(0, 0, 0, 0.1)',
+      zIndex: 9999, // make sure it's on top of any third party components with z-indicies
+      ...outerStyles
+    }
+  }, [
+    centeredSpinner({
+      size: 64,
+      style: { backgroundColor: 'rgba(255, 255, 255, 0.85)', padding: '1rem', borderRadius: '0.5rem', ...innerStyles }
+    })
+  ]
+)
+
+export const spinnerOverlay = makeBaseSpinner({})
+
+export const absoluteSpinnerOverlay = makeBaseSpinner({ innerStyles: { position: 'absolute' } })
+
+export const fixedSpinnerOverlay = makeBaseSpinner({ innerStyles: { position: 'fixed' } })
+
+export const transparentSpinnerOverlay = makeBaseSpinner({ innerStyles: { backgroundColor: 'rgba(255, 255, 255, 0.0)' } })
+
+export const topSpinnerOverlay = makeBaseSpinner({ innerStyles: { marginTop: 150 } })


### PR DESCRIPTION
Continuing to split up components/common.js. This moves Select, Switch, and spinner components into their own modules. All components are re-exported from common.js so that import paths in the rest of Terra UI continue to work.