### PR TITLE
[WOR-628] Fix canUseWorkspaceProject function

### DIFF
--- a/src/libs/ajax/Billing.js
+++ b/src/libs/ajax/Billing.js
@@ -124,6 +124,6 @@ export const Billing = signal => ({
 export const canUseWorkspaceProject = async ({ canCompute, workspace: { namespace } }) => {
   return canCompute || _.some(
     ({ projectName, roles }) => projectName === namespace && _.includes('Owner', roles),
-    await Billing.listProjects()
+    await Billing().listProjects()
   )
 }


### PR DESCRIPTION
Currently, trying to view files in a read only workspace with a requester pays bucket fails with an error "Billing.listProjects" is not a function. This bug was introduced in #3483.

## Before

https://user-images.githubusercontent.com/1156625/202008246-0d479918-5701-4662-9e00-fcfe6b55cedb.mov

## After

https://user-images.githubusercontent.com/1156625/202008268-96605e3f-585d-4a24-bc87-e634b7aeed28.mov


