### PR TITLE
AJ-655: Ensure that Data Table can be rendered if table selected before page refresh

### DIFF
--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -243,7 +243,7 @@ const DataTable = props => {
 
 
   // Render
-  const columnSettings = applyColumnSettings(columnState || [], entityMetadata[entityType].attributeNames)
+  const columnSettings = applyColumnSettings(columnState || [], entityMetadata[entityType]?.attributeNames)
   const nameWidth = columnWidths['name'] || 150
 
   const showColumnSettingsModal = () => setUpdatingColumnSettings(columnSettings)

--- a/src/components/data/WDSContent.js
+++ b/src/components/data/WDSContent.js
@@ -18,8 +18,6 @@ const WDSContent = ({
   // State
   const [refreshKey] = useState(0)
 
-  // TODO: AJ-655 something in state management is off; reloading the page while a WDS table is displayed causes errors
-
   // Render
   const dataProvider = new WdsDataTableProvider(workspaceId)
   const entityMetadata = wdsToEntityServiceMetadata(wdsSchema)

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -794,7 +794,7 @@ const WorkspaceData = _.flow(
                         onDeleteTable: tableName => {
                           setSelectedData(undefined)
                           setWdsSchema(_.remove(typeDef => typeDef.name === tableName, wdsSchema))
-                          forceRefresh() // TODO: may not be correct, resolve this as part of AJ-655
+                          forceRefresh()
                         },
                         isShowingVersionHistory: false,
                         onSaveVersion: undefined,


### PR DESCRIPTION
Relates to https://broadworkbench.atlassian.net/browse/AJ-655

Fixes bug related to rendering of a Data Table in WDS if a table is selected and then a page refresh occurs.

**Before fix:**

https://user-images.githubusercontent.com/36093535/202013604-b3a2f781-9190-4277-b3c2-44adab6bc293.mov

**After fix:**

https://user-images.githubusercontent.com/36093535/202013963-2d95b22a-f6c5-4f8c-985a-44ee75a7415f.mov

It has been confirmed locally that this does not break the Data Table feature for non-WDS table rendering

<!--
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Also, so if a screen recording [1] and/or screenshots would be a helpful way to communicate context, please consider including some in your PR description.
Thanks!

[1] https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac
--!>
