### PR TITLE
IA-3817 add accessTokenExpiringNotificationTimeInSeconds

### DIFF
--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -42,7 +42,8 @@ export const getOidcConfig = () => {
     stateStore: new WebStorageStateStore({ store: getLocalStorage() }),
     userStore: new WebStorageStateStore({ store: getLocalStorage() }),
     automaticSilentRenew: true,
-    accessTokenExpiringNotificationTimeInSeconds: 300,
+    // Leo's setCookie interval is currently 5 min, set refresh auth then 5 min 30 seconds to gurantee that setCookie's token won't expire between 2 setCookie api calls
+    accessTokenExpiringNotificationTimeInSeconds: 330,
     includeIdTokenInSilentRenew: true,
     extraQueryParams: { access_type: 'offline' }
   }

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -42,6 +42,7 @@ export const getOidcConfig = () => {
     stateStore: new WebStorageStateStore({ store: getLocalStorage() }),
     userStore: new WebStorageStateStore({ store: getLocalStorage() }),
     automaticSilentRenew: true,
+    accessTokenExpiringNotificationTimeInSeconds: 300,
     includeIdTokenInSilentRenew: true,
     extraQueryParams: { access_type: 'offline' }
   }


### PR DESCRIPTION
A soon-to-expire token is causing some issues with notebooks functionality, and I’m suspecting it’s causing issue elsewhere as well

The specific issue with setCookie in leo is something like this:
* UI calls setCookie with a token that’s about to expire in 161 seconds
* Leo responds the api call and sets the leoToken cookie to the soon-to-expire token, and sets max-age to 161 seconds
* 3 min passed. And max-age reached, the leoToken cookie expires and gets cleaned up by browser
* shit starts happening until next setCookie call happens

For reference https://authts.github.io/oidc-client-ts/interfaces/UserManagerSettings.html#accessTokenExpiringNotificationTimeInSeconds

Test that I did:
1. Create a GCP notebook instance
2. Open network tab and observe setCookie calls. At one point, setCookie response will return `Max-Age=387; Path=/; Secure; SameSite=None`; But the one after that will return `Max-Age=3446; Path=/; Secure; SameSite=None`...This proves that the auth token's expiration never went below 5 min. So I think things are working as expected