### PR TITLE
[SU-245] Group error notifications from checking for outdated analyses

### DIFF
--- a/src/pages/workspaces/workspace/analysis/AppLauncher.js
+++ b/src/pages/workspaces/workspace/analysis/AppLauncher.js
@@ -7,6 +7,7 @@ import Modal from 'src/components/Modal'
 import { Ajax } from 'src/libs/ajax'
 import { withErrorReporting, withErrorReportingInModal } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
+import { notify } from 'src/libs/notifications'
 import { forwardRefWithName, useCancellation, useOnMount, useStore } from 'src/libs/react-utils'
 import { authStore, azureCookieReadyStore, cookieReadyStore } from 'src/libs/state'
 import * as Utils from 'src/libs/utils'
@@ -188,11 +189,18 @@ const ApplicationLauncher = _.flow(
       setShouldSetupWelder(false)
     }
 
-    const findOutdatedAnalyses = withErrorReporting('Error loading outdated analyses', async () => {
-      const outdatedRAnalyses = await checkForOutdatedAnalyses({ googleProject, bucketName })
-      setOutdatedAnalyses(outdatedRAnalyses)
-      !_.isEmpty(outdatedRAnalyses) && setFileOutdatedOpen(true)
-    })
+    const findOutdatedAnalyses = async () => {
+      try {
+        const outdatedRAnalyses = await checkForOutdatedAnalyses({ googleProject, bucketName })
+        setOutdatedAnalyses(outdatedRAnalyses)
+        !_.isEmpty(outdatedRAnalyses) && setFileOutdatedOpen(true)
+      } catch (error) {
+        notify('error', 'Error loading outdated analyses', {
+          id: 'error-loading-outdated-analyses',
+          detail: error instanceof Response ? await error.text() : error
+        })
+      }
+    }
 
     computeIframeSrc()
     if (runtimeStatus === 'Running') {


### PR DESCRIPTION
While running an RStudio application, Terra UI checks for outdated analyses every 10 seconds. If that request fails for some reason, error notifications can clog up the screen (there's no easy way to dismiss all notifications).

This changes the error notifications to use an ID, which causes them to be grouped into one notification, which can be easily dismissed.

To reproduce, start an RStudio application and run the following in the browser console:
```js
window.ajaxOverridesStore.set([
  {
    filter: { url: /o\?prefix=notebooks/ },
    fn: window.ajaxOverrideUtils.makeError(400)
  }
])
```

Unfortunately, `reportError` from libs/error doesn't allow passing an ID so this uses `notify` directly. Alternatively, I'm debating changing `reportError` to use the error message as the notification ID so that get this sort of grouping for all error notifications. It's not as important in most other cases, since most requests that may trigger an error notification are done on some user interaction instead of on a short interval.

## Before
https://user-images.githubusercontent.com/1156625/202205756-e2ecdb13-bf95-4590-b3c7-6d9addc0eb56.mov

## After
https://user-images.githubusercontent.com/1156625/202205820-12059c9b-f1db-49b4-8f9d-9d77b2bc2a3e.mov
