### PR TITLE
[WOR-511] Storage containers may now be in landing zone storage accounts

### DIFF
--- a/integration-tests/tests/workspace-dashboard.js
+++ b/integration-tests/tests/workspace-dashboard.js
@@ -118,24 +118,17 @@ const setAzureAjaxMockValues = async (testPage, namespace, name, workspaceDescri
     resources: [
       {
         metadata: {
-          resourceId: 'dummy-sa-resource-id',
-          resourceType: 'AZURE_STORAGE_ACCOUNT'
-        },
-        resourceAttributes: { azureStorage: { region: 'eastus' } }
-      },
-      {
-        metadata: {
           resourceType: 'AZURE_STORAGE_CONTAINER',
           controlledResourceMetadata: { accessScope: 'PRIVATE_ACCESS' }
         },
-        resourceAttributes: { azureStorageContainer: { storageAccountId: 'dummy-sa-resource-id', storageContainerName: 'private-sc-name' } }
+        resourceAttributes: { azureStorageContainer: { storageContainerName: 'private-sc-name' } }
       },
       {
         metadata: {
           resourceType: 'AZURE_STORAGE_CONTAINER',
           controlledResourceMetadata: { accessScope: 'SHARED_ACCESS' }
         },
-        resourceAttributes: { azureStorageContainer: { storageAccountId: 'dummy-sa-resource-id', storageContainerName: 'sc-name' } }
+        resourceAttributes: { azureStorageContainer: { storageContainerName: 'sc-name' } }
       }
     ]
   }
@@ -198,7 +191,7 @@ const testAzureWorkspace = withUserToken(async ({ page, token, testUrl }) => {
     'Cloud NameMicrosoft Azure',
     'Resource Group IDdummy-mrg-id',
     'Storage Container URLhttp://storageContainerUrl.com',
-    'Location🇺🇸 East US',
+    // 'Location🇺🇸 East US', depends on TOAZ-265
     'SAS URLhttp://storageContainerUrl.com?sasTokenParams'
   ])
 

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -18,7 +18,6 @@ import { ReactComponent as AzureLogo } from 'src/images/azure.svg'
 import { ReactComponent as GcpLogo } from 'src/images/gcp.svg'
 import { Ajax } from 'src/libs/ajax'
 import { bucketBrowserUrl, refreshTerraProfile } from 'src/libs/auth'
-import { getRegionFlag, getRegionLabel } from 'src/libs/azure-utils'
 import { getEnabledBrand } from 'src/libs/brand-utils'
 import colors from 'src/libs/colors'
 import { reportError, withErrorReporting } from 'src/libs/error'
@@ -273,6 +272,7 @@ const WorkspaceDashboard = _.flow(
   const [submissionsCount, setSubmissionsCount] = useState(undefined)
   const [storageCost, setStorageCost] = useState(undefined)
   const [bucketSize, setBucketSize] = useState(undefined)
+  /* eslint-disable @typescript-eslint/no-unused-vars */
   const [{ storageContainerUrl, storageLocation, sas: { url } }, setAzureStorage] = useState({ storageContainerUrl: undefined, storageLocation: undefined, sas: {} })
   const [editDescription, setEditDescription] = useState(undefined)
   const [saving, setSaving] = useState(false)
@@ -464,9 +464,9 @@ const WorkspaceDashboard = _.flow(
         h(InfoRow, { title: 'Cloud Name' }, [
           h(AzureLogo, { title: 'Microsoft Azure', role: 'img', style: { height: 16 } })
         ]),
-        h(InfoRow, { title: 'Location' }, [
-          h(TooltipCell, !!storageLocation ? [getRegionFlag(storageLocation), ' ', getRegionLabel(storageLocation)] : ['Loading'])
-        ]),
+        // h(InfoRow, { title: 'Location' }, [
+        //   h(TooltipCell, !!storageLocation ? [getRegionFlag(storageLocation), ' ', getRegionLabel(storageLocation)] : ['Loading'])
+        // ]), depends on TOAZ-265
         h(InfoRow, { title: 'Resource Group ID' }, [
           h(TooltipCell, [azureContext.managedResourceGroupId]),
           h(ClipboardButton, { 'aria-label': 'Copy resource group id to clipboard', text: azureContext.managedResourceGroupId, style: { marginLeft: '0.25rem' } })


### PR DESCRIPTION
Works with both existing workspaces that have a storage container in a storage account created by the workspace (note "sa" prefix), and new workspaces with a storage container in a storage account from the landing zone (note "lz" prefix). Screenshots are from pr deployment, but the "new workspace" was created using locally running Rawls running this [branch](https://github.com/broadinstitute/rawls/pull/2115).

Note that we can no longer display the location of the storage container until TOAZ-265 is done because we got the location from the parent storage account (and containers that are created in the LZ storage account do not include that information). https://broadworkbench.atlassian.net/browse/WOR-638 captures adding back the display of the container location.

![image](https://user-images.githubusercontent.com/484484/202278674-d9a8f487-c422-4c9f-b5ea-44962a151e9c.png)

![image](https://user-images.githubusercontent.com/484484/202278897-00a33354-4f44-4ca5-a95b-ab25323bde2a.png)
