### PR TITLE
[WOR-643] Add some a11y checks to register-user integration test

### DIFF
--- a/integration-tests/tests/register-user.js
+++ b/integration-tests/tests/register-user.js
@@ -6,8 +6,8 @@ const { registerTest } = require('../utils/jest-utils')
 
 const testRegisterUserFn = withUser(async ({ page, testUrl, token }) => {
   await gotoPage(page, testUrl)
-  await click(page, clickable({ textContains: 'View Workspaces' }))
   await verifyAccessibility(page)
+  await click(page, clickable({ textContains: 'View Workspaces' }))
   await signIntoTerra(page, { token })
   await fillInReplace(page, input({ labelContains: 'First Name' }), 'Integration')
   await fillIn(page, input({ labelContains: 'Last Name' }), 'Test')

--- a/integration-tests/tests/register-user.js
+++ b/integration-tests/tests/register-user.js
@@ -1,5 +1,5 @@
 const { withUser } = require('../utils/integration-helpers')
-const { fillIn, findText, click, clickable, input, signIntoTerra } = require('../utils/integration-utils')
+const { fillIn, findText, click, clickable, input, signIntoTerra, verifyAccessibility } = require('../utils/integration-utils')
 const { fillInReplace, gotoPage } = require('../utils/integration-utils')
 const { registerTest } = require('../utils/jest-utils')
 
@@ -7,12 +7,15 @@ const { registerTest } = require('../utils/jest-utils')
 const testRegisterUserFn = withUser(async ({ page, testUrl, token }) => {
   await gotoPage(page, testUrl)
   await click(page, clickable({ textContains: 'View Workspaces' }))
+  await verifyAccessibility(page)
   await signIntoTerra(page, { token })
   await fillInReplace(page, input({ labelContains: 'First Name' }), 'Integration')
   await fillIn(page, input({ labelContains: 'Last Name' }), 'Test')
+  await verifyAccessibility(page)
   await click(page, clickable({ textContains: 'Register' }))
   await click(page, clickable({ textContains: 'Accept' }), { timeout: 90000 })
   await findText(page, 'To get started, Create a New Workspace')
+  await verifyAccessibility(page)
 })
 
 registerTest({


### PR DESCRIPTION
Adding 3 calls in existing `register-user` integration test verify that there are no accessibility errors on these pages:

1) Terra landing page (before logged in)
2) Register user page
3) Workspaces list page (no workspaces exist as user just registered)

As a sanity check, I temporarily introduced an issue on the register user page (removed a label) and verified that the test failed.

Ticket: https://broadworkbench.atlassian.net/browse/WOR-643
