### PR TITLE
IA-3829 Cloud environment modal layout

### DIFF
--- a/src/pages/workspaces/workspace/analysis/modals/ComputeModal.js
+++ b/src/pages/workspaces/workspace/analysis/modals/ComputeModal.js
@@ -1490,7 +1490,7 @@ export const ComputeModalBase = ({
             existingRuntime?.tool === 'RStudio' ? h(SaveFilesHelpRStudio) : h(SaveFilesHelp)
           ])],
           [willRequireDowntime(), () => h(Fragment, [
-            existingRuntime?.tool !== desiredTool ? p(['By continuing, you will be changing the application of your cloud environment from ', strong([existingRuntime.tool]), ' to ',
+            existingRuntime && existingRuntime.tool !== desiredTool ? p(['By continuing, you will be changing the application of your cloud environment from ', strong([existingRuntime.tool]), ' to ',
         desiredToolPhrase, '.']) : undefined,
             p(['This change will require temporarily shutting down your cloud environment. You will be unable to perform analysis for a few minutes.']),
             p(['Your existing data will be preserved during this update.'])

--- a/src/pages/workspaces/workspace/analysis/modals/ComputeModal.js
+++ b/src/pages/workspaces/workspace/analysis/modals/ComputeModal.js
@@ -126,6 +126,7 @@ const DataprocDiskSelector = ({ value, onChange }) => {
       label({ htmlFor: id, style: computeStyles.label }, ['Disk size (GB)']),
       h(NumberInput, {
         id,
+        style: { minWidth: '6rem' },
         min: 150, // less than this size causes failures in cluster creation
         max: 64000,
         isClearable: false,
@@ -912,12 +913,13 @@ export const ComputeModalBase = ({
     const enableGpusSpan = span(['Enable GPUs ', betaVersionTag])
     const autoPauseCheckboxEnabled = true
     const enableAutopauseSpan = span(['Enable autopause'])
-    const gridStyle = { display: 'grid', gridGap: '1.3rem', alignItems: 'center', marginTop: '1rem' }
+    const gridStyle = { display: 'grid', gridGap: '1rem', alignItems: 'center', marginTop: '1rem' }
+    const gridItemInputStyle = { minWidth: '6rem' }
 
     return div({ style: { ...computeStyles.whiteBoxContainer, marginTop: '1rem' } }, [
       div({ style: { fontSize: '0.875rem', fontWeight: 600 } }, ['Cloud compute profile']),
       div([
-        div({ style: { ...gridStyle, gridGap: '.75rem', gridTemplateColumns: '0.25fr 5rem 1fr 5.5rem 1fr 5.5rem' } }, [
+        div({ style: { ...gridStyle, gridGap: '.75rem', gridTemplateColumns: 'repeat(6, auto)', justifyContent: 'flex-start' } }, [
           // CPU & Memory Selection
           h(IdContainer, [
             id => h(Fragment, [
@@ -925,6 +927,7 @@ export const ComputeModalBase = ({
               div([
                 h(Select, {
                   id,
+                  style: gridItemInputStyle,
                   isSearchable: false,
                   value: currentNumCpus,
                   onChange: ({ value }) => {
@@ -945,6 +948,7 @@ export const ComputeModalBase = ({
               div([
                 h(Select, {
                   id,
+                  style: gridItemInputStyle,
                   isSearchable: false,
                   value: currentMemory,
                   onChange: ({ value }) => {
@@ -1699,7 +1703,7 @@ export const ComputeModalBase = ({
   }
 
   const renderPersistentDiskSection = diskExists => {
-    const gridStyle = { display: 'grid', gridGap: '1.3rem', alignItems: 'center', marginTop: '1rem' }
+    const gridStyle = { display: 'grid', gridGap: '1rem', alignItems: 'center', marginTop: '1rem' }
 
     const renderPersistentDiskType = id => h(div, [
       label({ htmlFor: id, style: computeStyles.label }, ['Disk Type']),

--- a/src/pages/workspaces/workspace/analysis/modals/ComputeModal.js
+++ b/src/pages/workspaces/workspace/analysis/modals/ComputeModal.js
@@ -1440,8 +1440,8 @@ export const ComputeModalBase = ({
 
   const renderEnvironmentWarning = () => {
     const { runtime: existingRuntime } = getExistingEnvironmentConfig()
-
     const desiredTool = getToolForImage(_.find({ image: selectedLeoImage }, leoImages)?.id)
+    const desiredToolPhrase = isCustomImage ? 'a custom image' : strong([desiredTool])
 
     return div({ style: { ...computeStyles.drawerContent, ...computeStyles.warningView } }, [
       h(TitleBar, {
@@ -1486,10 +1486,8 @@ export const ComputeModalBase = ({
             existingRuntime?.tool === 'RStudio' ? h(SaveFilesHelpRStudio) : h(SaveFilesHelp)
           ])],
           [willRequireDowntime(), () => h(Fragment, [
-            existingRuntime && existingRuntime.tool !== desiredTool ?
-              p(['By continuing, you will be changing the application of your cloud environment from ', strong([existingRuntime?.tool]), ' to ',
-                strong([desiredTool]), '.']) :
-              undefined,
+            existingRuntime?.tool !== desiredTool ? p(['By continuing, you will be changing the application of your cloud environment from ', strong([existingRuntime.tool]), ' to ',
+        desiredToolPhrase, '.']) : undefined,
             p(['This change will require temporarily shutting down your cloud environment. You will be unable to perform analysis for a few minutes.']),
             p(['Your existing data will be preserved during this update.'])
           ])]

--- a/src/pages/workspaces/workspace/analysis/modals/GalaxyModal.js
+++ b/src/pages/workspaces/workspace/analysis/modals/GalaxyModal.js
@@ -269,7 +269,7 @@ export const GalaxyModalBase = withDisplayName('GalaxyModal')(
     }
 
     const renderComputeProfileSection = () => {
-      const gridStyle = { display: 'grid', gridTemplateColumns: '0.75fr 4.5rem 1fr 5.5rem 1fr 5.5rem', gridGap: '2rem', alignItems: 'center' }
+      const gridStyle = { display: 'grid', gridTemplateColumns: 'repeat(6, auto)', gridGap: '0.75rem', alignItems: 'center', justifyContent: 'flex-start' }
       return div({ style: { ...computeStyles.whiteBoxContainer, marginTop: '1rem' } }, [
         div({ style: computeStyles.headerText }, ['Cloud compute profile']),
         div({ style: { ...gridStyle, marginTop: '0.75rem' } }, [
@@ -454,11 +454,14 @@ export const GalaxyModalBase = withDisplayName('GalaxyModal')(
 
 const MachineSelector = ({ value, onChange }) => {
   const { cpu: currentCpu, memory: currentMemory } = findMachineType(value.machineType)
+
+  const gridItemInputStyle = { minWidth: '6rem' }
+
   return h(Fragment, [
     h(IdContainer, [
       id => h(Fragment, [
         label({ htmlFor: id, style: computeStyles.label }, ['Nodes']),
-        div([
+        div({ style: gridItemInputStyle }, [
           h(NumberInput, {
             id,
             min: 1,
@@ -474,7 +477,7 @@ const MachineSelector = ({ value, onChange }) => {
     h(IdContainer, [
       id => h(Fragment, [
         label({ htmlFor: id, style: computeStyles.label }, ['CPUs']),
-        div([
+        div({ style: gridItemInputStyle }, [
           h(Select, {
             id,
             isSearchable: false,
@@ -491,7 +494,7 @@ const MachineSelector = ({ value, onChange }) => {
     h(IdContainer, [
       id => h(Fragment, [
         label({ htmlFor: id, style: computeStyles.label }, ['Memory (GB)']),
-        div([
+        div({ style: gridItemInputStyle }, [
           h(Select, {
             id,
             isSearchable: false,


### PR DESCRIPTION
Compute Modal (with and without dataproc Disk Size field) and Galaxy Compute Modal show "Cloud compute profile" fields in one line with min-width to avoid overflow, and retain these sizes when their values change.

When updating an environment to a custom image, the downtime warning shows "a custom image" rather than a sentence fragment.
![Screen Shot 2022-11-21 at 9 06 26 PM
![Screen Shot 2022-11-21 at 9 11 49 PM](https://user-images.githubusercontent.com/117680805/203209460-3ab36b30-1e6c-4b9e-ab47-c9c31939ef60.png)
](https://user-images.githubusercontent.com/117680805/203209415-e930ea04-8034-4d58-b8dc-30df0a08aec5.png)

Unit tests pass with no changes.