### PR TITLE
IA-3866 add saturnAutoCreated: 'true' label

### DIFF
--- a/src/libs/ajax/Apps.js
+++ b/src/libs/ajax/Apps.js
@@ -25,7 +25,8 @@ export const Apps = signal => ({
         const body = {
           labels: {
             saturnWorkspaceNamespace: namespace,
-            saturnWorkspaceName: workspaceName
+            saturnWorkspaceName: workspaceName,
+            saturnAutoCreated: 'true'
           },
           kubernetesRuntimeConfig,
           diskConfig: {


### PR DESCRIPTION
See details in https://broadworkbench.atlassian.net/browse/IA-3864

This PR will just start setting the label when creating apps. Together with https://github.com/DataBiosphere/leonardo/pull/3034, we'll make sure the label exists for all new and non-deleted existing apps