### PR TITLE
[TUIM-46] Change script to require only 5 deployments to remain from previous 10 days.

### DIFF
--- a/scripts/delete-old-app-engine-versions.sh
+++ b/scripts/delete-old-app-engine-versions.sh
@@ -90,10 +90,8 @@ filter_app_engine_versions() {
 check_remaining_items() {
     REMAIN_LIST_ITEMS=($(filter_app_engine_versions "version.createTime.date('%Y-%m-%d', Z)>'${DELETION_DATE}'"))
     REMAIN_LIST_COUNT="${#REMAIN_LIST_ITEMS[@]}"
-    if [ "${REMAIN_LIST_COUNT}" -lt 1 ]; then
-        abort "all deployments would be deleted"
-    elif [ "$REMAIN_LIST_COUNT" -lt 15 ]; then
-        abort "less than 15 deployments would remain"
+    if [ "$REMAIN_LIST_COUNT" -lt 5 ]; then
+        abort "less than 5 deployments would remain"
     fi
 }
 
@@ -147,7 +145,7 @@ check_user_permissions
 
 printf "${INFO} Selected project ${GRN}%s${RST}\n" "${NEW_PROJECT}"
 
-DELETION_TIME=$(jq -n 'now - (7 * 24 * 60 * 60)') # 7 days
+DELETION_TIME=$(jq -n 'now - (10 * 24 * 60 * 60)') # 10 days
 DELETION_DATE=$(unix_epoch_to_date "${DELETION_TIME}")
 if [ "$1" == "dev" ]; then
     set_dev_deletion_date


### PR DESCRIPTION
The delete-old-app-engine-versions script would not delete any deployments if less than 15 exist from the 7 days preceding when the script is executed. This causes an issue for staging, where often <= 1 deployment exists per day, causing them to build up to the point where there are no available deplouments. [Slack thread](https://broadinstitute.slack.com/archives/C01EHNUM73R/p1669211940692009)

I changed the numbers to 5 deployments in the preceding 10 days. For context, when I ran the script today there were only 3 deployments in the last 7 days because of Thanksgiving, and 8 deployments from the last 10 days.