### PR TITLE
[WOR-636] Reset updating flag in case of error so that we will retry when date range changes.

### DIFF
--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -777,6 +777,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
       } else {
         setErrorMessage(await (error instanceof Response ? error.text() : error))
       }
+      setUpdatingProjectCost(false)
     })
   }, [spendReportLengthInDays, tab]) // eslint-disable-line react-hooks/exhaustive-deps
 


### PR DESCRIPTION
Changing the date range select after an error wasn't resulting in a new server call because we hadn't reset the updating flag.

This is reproducible with any project that doesn't have spend report data, as you can see that the date range isn't changing.

<!--
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Also, so if a screen recording [1] and/or screenshots would be a helpful way to communicate context, please consider including some in your PR description.
Thanks!

[1] https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac
--!>
