### PR TITLE
IA-3864  Only read apps that has `saturnAutoCreated` label apps similar to runtimes

### DIFF
--- a/src/libs/ajax/Apps.js
+++ b/src/libs/ajax/Apps.js
@@ -5,12 +5,12 @@ import { appIdentifier, authOpts, fetchLeo, jsonBody } from 'src/libs/ajax/ajax-
 
 export const Apps = signal => ({
   list: async (project, labels = {}) => {
-    const res = await fetchLeo(`api/google/v1/apps/${project}?${qs.stringify({ ...labels })}`,
+    const res = await fetchLeo(`api/google/v1/apps/${project}?${qs.stringify({ saturnAutoCreated: true, ...labels })}`,
       _.mergeAll([authOpts(), appIdentifier, { signal }]))
     return res.json()
   },
-  listWithoutProject: async labels => {
-    const res = await fetchLeo(`api/google/v1/apps?${qs.stringify(labels)}`,
+  listWithoutProject: async (labels = {}) => {
+    const res = await fetchLeo(`api/google/v1/apps?${qs.stringify({ saturnAutoCreated: true, ...labels })}`,
       _.mergeAll([authOpts(), appIdentifier, { signal }]))
     return res.json()
   },


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3864

Tested out the change locally, and I'm able to load cloud env page properly now. VS, on dev, cloud env fail to load because it tries to load apps created outside terra UI as well

<!--
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Also, so if a screen recording [1] and/or screenshots would be a helpful way to communicate context, please consider including some in your PR description.
Thanks!

[1] https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac
--!>
