### PR TITLE
[SUP-743] Retry failed requests after reloading auth token

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -50,7 +50,7 @@ const getSnapshotEntityMetadata = Utils.memoizeAsync(async (token, workspaceName
 
 const User = signal => ({
   getStatus: async () => {
-    const res = await fetchOk(`${getConfig().samUrlRoot}/register/user/v2/self/info`, _.mergeAll([authOpts(), { signal }, appIdentifier]))
+    const res = await fetchSam('register/user/v2/self/info', _.mergeAll([authOpts(), { signal }]))
     return res.json()
   },
 

--- a/src/libs/ajax/ajax-common.test.ts
+++ b/src/libs/ajax/ajax-common.test.ts
@@ -1,0 +1,103 @@
+import { getUser, reloadAuthToken, signOutAfterSessionTimeout } from 'src/libs/auth'
+import { asMockedFn } from 'src/testing/test-utils'
+
+import { authOpts, withRetryAfterReloadingExpiredAuthToken } from './ajax-common'
+
+
+type AuthExports = typeof import('src/libs/auth')
+jest.mock('src/libs/auth', (): Partial<AuthExports> => {
+  return {
+    getUser: jest.fn(() => ({ token: 'testtoken' })),
+    reloadAuthToken: jest.fn(),
+    signOutAfterSessionTimeout: jest.fn(),
+  }
+})
+
+
+describe('withRetryAfterReloadingExpiredAuthToken', () => {
+  it('passes args through to wrapped fetch', async () => {
+    // Arrange
+    const originalFetch = jest.fn(() => Promise.resolve(new Response(JSON.stringify({ success: true }), { status: 200 })))
+    const wrappedFetch = withRetryAfterReloadingExpiredAuthToken(originalFetch)
+
+    // Act
+    await wrappedFetch('https://example.com', { headers: { 'Content-Type': 'application/json' } })
+
+    // Assert
+    expect(originalFetch).toHaveBeenCalledWith('https://example.com', { headers: { 'Content-Type': 'application/json' } })
+  })
+
+  it('returns result of successful request', async () => {
+    // Arrange
+    const originalFetch = jest.fn(() => Promise.resolve(new Response(JSON.stringify({ success: true }), { status: 200 })))
+    const wrappedFetch = withRetryAfterReloadingExpiredAuthToken(originalFetch)
+
+    // Act
+    const response = await wrappedFetch('https://example.com')
+
+    // Assert
+    expect(response instanceof Response).toBe(true)
+    expect(response.json()).resolves.toEqual({ success: true })
+    expect(response.status).toBe(200)
+  })
+
+  describe('if an authenticated request fails with a 401 status', () => {
+    // Arrange
+    const originalFetch = jest.fn(() => Promise.reject(new Response(JSON.stringify({ success: false }), { status: 401 })))
+    const wrappedFetch = withRetryAfterReloadingExpiredAuthToken(originalFetch)
+    const makeAuthenticatedRequest = () => wrappedFetch('https://example.com', authOpts())
+
+    beforeEach(() => {
+      let mockUser = { token: 'testtoken' }
+      asMockedFn(getUser).mockImplementation(() => mockUser)
+
+      asMockedFn(reloadAuthToken).mockImplementation(() => {
+        mockUser = { token: 'newtesttoken' }
+        return Promise.resolve(true)
+      })
+    })
+
+    it('attempts to reload auth token', async () => {
+      // Act
+      // Ignore errors because the mock originalFetch function always returns a rejected promise.
+      await Promise.allSettled([makeAuthenticatedRequest()])
+
+      // Assert
+      expect(reloadAuthToken).toHaveBeenCalled()
+    })
+
+    it('retries request with new auth token if reloading auth token succeeds', async () => {
+      // Act
+      // Ignore errors because the mock originalFetch function always returns a rejected promise.
+      await Promise.allSettled([makeAuthenticatedRequest()])
+
+      // Assert
+      expect(originalFetch).toHaveBeenCalledTimes(2)
+      expect(originalFetch).toHaveBeenCalledWith('https://example.com', { headers: { Authorization: 'Bearer testtoken' } })
+      expect(originalFetch).toHaveBeenLastCalledWith('https://example.com', { headers: { Authorization: 'Bearer newtesttoken' } })
+    })
+
+    describe('if reloading auth token fails', () => {
+      beforeEach(() => {
+        asMockedFn(reloadAuthToken).mockImplementation(() => Promise.resolve(false))
+      })
+
+      it('signs out user', async () => {
+        // Act
+        // Ignore errors because makeAuthenticatedReuqest is expected to return a rejected promise here.
+        await Promise.allSettled([makeAuthenticatedRequest()])
+
+        // Assert
+        expect(signOutAfterSessionTimeout).toHaveBeenCalled()
+      })
+
+      it('throws an error', () => {
+        // Act
+        const result = makeAuthenticatedRequest()
+
+        // Assert
+        expect(result).rejects.toEqual(new Error('Session timed out'))
+      })
+    })
+  })
+})

--- a/src/libs/ajax/ajax-common.ts
+++ b/src/libs/ajax/ajax-common.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp'
-import { getUser } from 'src/libs/auth'
+import { getUser, reloadAuthToken, signOutAfterSessionTimeout } from 'src/libs/auth'
 import { getConfig } from 'src/libs/config'
 import { ajaxOverridesStore } from 'src/libs/state'
 import * as Utils from 'src/libs/utils'
@@ -17,6 +17,9 @@ export const isCloudProvider = (x: unknown): x is CloudProviderType => {
 export const authOpts = (token = getUser().token) => ({ headers: { Authorization: `Bearer ${token}` } })
 export const jsonBody = body => ({ body: JSON.stringify(body), headers: { 'Content-Type': 'application/json' } })
 export const appIdentifier = { headers: { 'X-App-ID': 'Saturn' } }
+
+type FetchFn = typeof fetch
+
 export const withUrlPrefix = _.curry((prefix, wrappedFetch) => (path, ...args) => {
   return wrappedFetch(prefix + path, ...args)
 })
@@ -41,6 +44,27 @@ export const withRetryOnError = _.curry((shouldNotRetryFn, wrappedFetch) => asyn
   }
   return wrappedFetch(...args)
 })
+
+export const withRetryAfterReloadingExpiredAuthToken = (wrappedFetch: FetchFn): FetchFn => async (resource: RequestInfo | URL, options?: RequestInit) => {
+  const requestHasAuthHeader = _.isMatch(authOpts(), options as object)
+  try {
+    return await wrappedFetch(resource, options)
+  } catch (error) {
+    const isUnauthorizedResponse = error instanceof Response && error.status === 401
+    if (isUnauthorizedResponse && requestHasAuthHeader) {
+      const successfullyReloadedAuthToken = !!(await reloadAuthToken())
+      if (successfullyReloadedAuthToken) {
+        const optionsWithNewAuthToken = _.merge(options, authOpts())
+        return await wrappedFetch(resource, optionsWithNewAuthToken)
+      } else {
+        signOutAfterSessionTimeout()
+        throw new Error('Session timed out')
+      }
+    } else {
+      throw error
+    }
+  }
+}
 
 const withAppIdentifier = wrappedFetch => (url, options) => {
   return wrappedFetch(url, _.merge(options, appIdentifier))
@@ -91,21 +115,93 @@ const withErrorRejection = wrappedFetch => async (...args) => {
 
 
 export const fetchOk = _.flow(withInstrumentation, withCancellation, withErrorRejection)(fetch)
-export const fetchLeo = withUrlPrefix(`${getConfig().leoUrlRoot}/`, fetchOk)
-export const fetchSam = _.flow(withUrlPrefix(`${getConfig().samUrlRoot}/`), withAppIdentifier)(fetchOk)
-export const fetchRawls = _.flow(withUrlPrefix(`${getConfig().rawlsUrlRoot}/api/`), withAppIdentifier)(fetchOk)
-export const fetchBillingProfileManager = _.flow(withUrlPrefix(`${getConfig().billingProfileManagerUrlRoot}/api/`), withAppIdentifier)(fetchOk)
-export const fetchWorkspaceManager = _.flow(withUrlPrefix(`${getConfig().workspaceManagerUrlRoot}/api/`), withAppIdentifier)(fetchOk)
-export const fetchCatalog = withUrlPrefix(`${getConfig().catalogUrlRoot}/api/`, fetchOk)
-export const fetchDataRepo = withUrlPrefix(`${getConfig().dataRepoUrlRoot}/api/`, fetchOk)
-export const fetchDockstore = withUrlPrefix(`${getConfig().dockstoreUrlRoot}/api/`, fetchOk)
-export const fetchAgora = _.flow(withUrlPrefix(`${getConfig().agoraUrlRoot}/api/v1/`), withAppIdentifier)(fetchOk)
-export const fetchOrchestration = _.flow(withUrlPrefix(`${getConfig().orchestrationUrlRoot}/`), withAppIdentifier)(fetchOk)
-export const fetchRex = withUrlPrefix(`${getConfig().rexUrlRoot}/api/`, fetchOk)
-export const fetchBond = withUrlPrefix(`${getConfig().bondUrlRoot}/`, fetchOk)
-export const fetchMartha = withUrlPrefix(`${getConfig().marthaUrlRoot}/`, fetchOk)
-export const fetchDrsHub = withUrlPrefix(`${getConfig().drsHubUrlRoot}/`, fetchOk)
-export const fetchBard = withUrlPrefix(`${getConfig().bardRoot}/`, fetchOk)
-export const fetchEcm = withUrlPrefix(`${getConfig().externalCredsUrlRoot}/`, fetchOk)
+
+export const fetchLeo = _.flow(
+  withUrlPrefix(`${getConfig().leoUrlRoot}/`),
+  withRetryAfterReloadingExpiredAuthToken,
+)(fetchOk)
+
+export const fetchSam = _.flow(
+  withUrlPrefix(`${getConfig().samUrlRoot}/`),
+  withAppIdentifier,
+  withRetryAfterReloadingExpiredAuthToken,
+)(fetchOk)
+
+export const fetchRawls = _.flow(
+  withUrlPrefix(`${getConfig().rawlsUrlRoot}/api/`),
+  withAppIdentifier,
+  withRetryAfterReloadingExpiredAuthToken,
+)(fetchOk)
+
+export const fetchBillingProfileManager = _.flow(
+  withUrlPrefix(`${getConfig().billingProfileManagerUrlRoot}/api/`),
+  withAppIdentifier,
+  withRetryAfterReloadingExpiredAuthToken,
+)(fetchOk)
+
+export const fetchWorkspaceManager = _.flow(
+  withUrlPrefix(`${getConfig().workspaceManagerUrlRoot}/api/`),
+  withAppIdentifier,
+  withRetryAfterReloadingExpiredAuthToken,
+)(fetchOk)
+
+export const fetchCatalog = _.flow(
+  withUrlPrefix(`${getConfig().catalogUrlRoot}/api/`),
+  withRetryAfterReloadingExpiredAuthToken
+)(fetchOk)
+
+export const fetchDataRepo = _.flow(
+  withUrlPrefix(`${getConfig().dataRepoUrlRoot}/api/`),
+  withRetryAfterReloadingExpiredAuthToken
+)(fetchOk)
+
+export const fetchDockstore = _.flow(
+  withUrlPrefix(`${getConfig().dockstoreUrlRoot}/api/`),
+  withRetryAfterReloadingExpiredAuthToken
+)(fetchOk)
+
+export const fetchAgora = _.flow(
+  withUrlPrefix(`${getConfig().agoraUrlRoot}/api/v1/`),
+  withAppIdentifier,
+  withRetryAfterReloadingExpiredAuthToken,
+)(fetchOk)
+
+export const fetchOrchestration = _.flow(
+  withUrlPrefix(`${getConfig().orchestrationUrlRoot}/`),
+  withAppIdentifier,
+  withRetryAfterReloadingExpiredAuthToken,
+)(fetchOk)
+
+export const fetchRex = _.flow(
+  withUrlPrefix(`${getConfig().rexUrlRoot}/api/`),
+  withRetryAfterReloadingExpiredAuthToken,
+)(fetchOk)
+
+export const fetchBond = _.flow(
+  withUrlPrefix(`${getConfig().bondUrlRoot}/`),
+  withRetryAfterReloadingExpiredAuthToken,
+)(fetchOk)
+
+export const fetchMartha = _.flow(
+  withUrlPrefix(`${getConfig().marthaUrlRoot}/`),
+  withRetryAfterReloadingExpiredAuthToken,
+)(fetchOk)
+
+export const fetchDrsHub = _.flow(
+  withUrlPrefix(`${getConfig().drsHubUrlRoot}/`),
+  withRetryAfterReloadingExpiredAuthToken,
+)(fetchOk)
+
+export const fetchBard = _.flow(
+  withUrlPrefix(`${getConfig().bardRoot}/`),
+  withRetryAfterReloadingExpiredAuthToken,
+)(fetchOk)
+
+export const fetchEcm = _.flow(
+  withUrlPrefix(`${getConfig().externalCredsUrlRoot}/`),
+  withRetryAfterReloadingExpiredAuthToken,
+)(fetchOk)
+
 export const fetchGoogleForms = withUrlPrefix('https://docs.google.com/forms/u/0/d/e/', fetchOk)
+
 export const fetchWDS = _.flow(withUrlPrefix(`${getConfig().wdsUrlRoot}/`), withAppIdentifier)(fetchOk)

--- a/src/libs/ajax/ajax-common.ts
+++ b/src/libs/ajax/ajax-common.ts
@@ -155,10 +155,7 @@ export const fetchDataRepo = _.flow(
   withRetryAfterReloadingExpiredAuthToken
 )(fetchOk)
 
-export const fetchDockstore = _.flow(
-  withUrlPrefix(`${getConfig().dockstoreUrlRoot}/api/`),
-  withRetryAfterReloadingExpiredAuthToken
-)(fetchOk)
+export const fetchDockstore = withUrlPrefix(`${getConfig().dockstoreUrlRoot}/api/`, fetchOk)
 
 export const fetchAgora = _.flow(
   withUrlPrefix(`${getConfig().agoraUrlRoot}/api/v1/`),

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -68,6 +68,11 @@ export const signOut = () => {
     .finally(() => auth.clearStaleState())
 }
 
+export const signOutAfterSessionTimeout = () => {
+  signOut()
+  notify('info', 'Session timed out', sessionTimeoutProps)
+}
+
 const revokeTokens = async () => {
   const auth = getAuthInstance()
   if (auth.settings.metadata.revocation_endpoint) {

--- a/src/libs/error.js
+++ b/src/libs/error.js
@@ -1,18 +1,15 @@
 import _ from 'lodash/fp'
-import { reloadAuthToken, signOut } from 'src/libs/auth'
-import { notify, sessionTimeoutProps } from 'src/libs/notifications'
+import { notify } from 'src/libs/notifications'
 
 
 export const reportError = async (title, obj) => {
-  if (obj instanceof Response && obj.status === 401) {
-    if (!await reloadAuthToken()) {
-      notify('info', 'Session timed out', sessionTimeoutProps)
-      signOut()
-    }
-    // Don't report an error if we've successfully reloaded the auth token
-  } else {
-    notify('error', title, { detail: await (obj instanceof Response ? obj.text() : obj) })
+  // Do not show an error notification when a session times out.
+  // Notification for this case is handled elsewhere.
+  if (obj instanceof Error && obj.message === 'Session timed out') {
+    return
   }
+
+  notify('error', title, { detail: await (obj instanceof Response ? obj.text() : obj) })
 }
 
 /**

--- a/src/pages/LandingPage.js
+++ b/src/pages/LandingPage.js
@@ -77,8 +77,8 @@ const LandingPage = () => {
 
   useEffect(() => {
     const loadProjects = withErrorHandling(async error => {
-      const errorJSON = await error.json()
-      console.log(`Unable to load billing projects due to: ${errorJSON?.message}`) // eslint-disable-line no-console
+      const errorObj = await error instanceof Response ? error.json() : error
+      console.log(`Unable to load billing projects due to: ${errorObj?.message}`) // eslint-disable-line no-console
     })(async () => {
       const projects = await Ajax(signal).Billing.listProjects()
       setBillingProjects(projects)

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -14,14 +14,12 @@ import { SimpleTabBar } from 'src/components/tabBars'
 import { ariaSort } from 'src/components/table'
 import { useWorkspaces } from 'src/components/workspace-utils'
 import { Ajax } from 'src/libs/ajax'
-import { reloadAuthToken, signOut } from 'src/libs/auth'
 import * as Auth from 'src/libs/auth'
 import colors from 'src/libs/colors'
 import { reportErrorAndRethrow } from 'src/libs/error'
 import Events from 'src/libs/events'
 import { FormLabel } from 'src/libs/forms'
 import * as Nav from 'src/libs/nav'
-import { notify, sessionTimeoutProps } from 'src/libs/notifications'
 import { memoWithName, useCancellation, useGetter, useOnMount, usePollingEffect } from 'src/libs/react-utils'
 import { contactUsActive } from 'src/libs/state'
 import * as StateHistory from 'src/libs/state-history'
@@ -769,14 +767,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
         }
       })
     maybeLoadProjectCost().catch(async error => {
-      if (error instanceof Response && error.status === 401) {
-        if (!await reloadAuthToken()) {
-          notify('info', 'Session timed out', sessionTimeoutProps)
-          signOut()
-        }
-      } else {
-        setErrorMessage(await (error instanceof Response ? error.text() : error))
-      }
+      setErrorMessage(await (error instanceof Response ? error.text() : error))
       setUpdatingProjectCost(false)
     })
   }, [spendReportLengthInDays, tab]) // eslint-disable-line react-hooks/exhaustive-deps


### PR DESCRIPTION
To authenticate the current user, for most API requests, Terra UI sends a token in the Authorization header.

https://github.com/DataBiosphere/terra-ui/blob/645fa7a3fec9d9ffd9aa8e65d9fc5495fa895d44/src/libs/ajax/ajax-common.ts#L17

These auth tokens expire one hour after they are generated.

Terra UI will automatically renew the auth token 5.5 minutes before it expires.

https://github.com/DataBiosphere/terra-ui/blob/645fa7a3fec9d9ffd9aa8e65d9fc5495fa895d44/src/libs/auth.js#L46

https://github.com/DataBiosphere/terra-ui/blob/645fa7a3fec9d9ffd9aa8e65d9fc5495fa895d44/src/components/AuthStoreSetter.js#L17

However, if Terra UI is not open in any browser window during that time, it may have an expired auth token when it is next opened. API requests made with an expired auth token will fail with a 401 response.

Currently, error handling for that case is located in the `reportError` function. if a request fails with a 401 response, Terra UI will attempt to reload the auth token. If that fails, it will sign out the current user and display a notification.

https://github.com/DataBiosphere/terra-ui/blob/645fa7a3fec9d9ffd9aa8e65d9fc5495fa895d44/src/libs/error.js#L6-L16

However, handling expired auth tokens here is problematic. One, not all requests are wrapped in a function that reports errors. Thus, some components (billing project detail) duplicate the logic for handling errors due to expired auth tokens. And there are likely some requests that don't handle those errors at all.

Also, if reloading the auth token succeeds, the failed request is not retried but Terra UI also doesn't show an error notification. Thus, Terra UI can appear to be "stuck" when it is first loaded and reloading the browser is necessary to resolve the issue.

This moves error handling into the ajax module. Fetch functions for different endpoints (`fetchRawls`, `fetchOrchestration`, etc) are wrapped in a new `withRetryAfterReloadingExpiredAuthToken` that retries the failed request if the auth token is successfully reloaded.

## Testing

- Log into to Terra
- Close all Terra browser windows
- Wait an hour
- Open Terra (open network inspector first to see requests)

## Before

![Screen Shot 2022-11-28 at 5 56 00 PM](https://user-images.githubusercontent.com/1156625/204612807-b0733d84-8da9-4a88-b112-555ed745cc77.png)

## After

![Screen Shot 2022-11-28 at 5 56 48 PM](https://user-images.githubusercontent.com/1156625/204612836-dec8891e-8d3c-42f6-acf3-fdfbb662bea6.png)


