### PR TITLE
[IA-3855] Azure compute modal shows current values

### DIFF
--- a/src/pages/workspaces/workspace/analysis/modals/AzureComputeModal.js
+++ b/src/pages/workspaces/workspace/analysis/modals/AzureComputeModal.js
@@ -38,12 +38,12 @@ export const AzureComputeModalBase = ({
     Utils.withBusyState(setLoading)
   )(async () => {
     const currentRuntime = getCurrentRuntime(runtimes)
-    setCurrentRuntimeDetails(currentRuntime ? await Ajax().Runtimes.runtimeV2(workspaceId, currentRuntime.runtimeName).details() : null)
-
+    const runtimeDetails = currentRuntime ? await Ajax().Runtimes.runtimeV2(workspaceId, currentRuntime.runtimeName).details() : null
+    setCurrentRuntimeDetails(runtimeDetails)
     setComputeConfig({
-      machineType: currentRuntimeDetails?.runtimeConfig?.machineType || defaultAzureMachineType,
-      diskSize: currentRuntimeDetails?.diskConfig?.size || defaultAzureDiskSize,
-      region: currentRuntime?.runtimeConfig?.region || defaultAzureRegion
+      machineType: runtimeDetails?.runtimeConfig?.machineType || defaultAzureMachineType,
+      diskSize: runtimeDetails?.diskConfig?.size || defaultAzureDiskSize,
+      region: runtimeDetails?.runtimeConfig?.region || defaultAzureRegion
     })
   }))
 


### PR DESCRIPTION
Show correct disk size, machine type, and region in Azure compute modal when viewing an existing runtime.
Verified locally with an Azure workspace.

Issue appears to be a call to a useState() setter, then to its getter, expecting the getter to have the updated value (it won't because state refreshes outside of the context of a single function - my React chops are very fresh so this is the best I can do to diagnose :) )

<img width="525" alt="Screen Shot 2022-11-29 at 1 50 53 PM" src="https://user-images.githubusercontent.com/117680805/204619811-ede03095-9b7c-4b75-8c2f-43313c8e2be8.png">