### PR TITLE
[IA-3856] Remove the Standard_DS1_v2 VM option from UI

### DIFF
--- a/src/libs/azure-utils.js
+++ b/src/libs/azure-utils.js
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp'
 
 
-export const defaultAzureMachineType = 'Standard_DS1_v2'
+export const defaultAzureMachineType = 'Standard_DS2_v2'
 export const defaultAzureDiskSize = 50
 export const defaultAzureRegion = 'eastus'
 
@@ -16,6 +16,6 @@ export const azureRegions = { eastus: { flag: '🇺🇸', label: 'East US' } }
 export const getRegionLabel = key => _.has(key, azureRegions) ? azureRegions[key].label : 'Unknown azure region'
 export const getRegionFlag = key => _.has(key, azureRegions) ? azureRegions[key].flag : '❓'
 
-export const azureMachineTypes = { Standard_DS1_v2: { cpu: 1, ramInGb: 3.5 }, Standard_DS2_v2: { cpu: 2, ramInGb: 7 }, Standard_DS3_v2: { cpu: 4, ramInGb: 14 }, Standard_DS4_v2: { cpu: 8, ramInGb: 28 }, Standard_DS5_v2: { cpu: 16, ramInGb: 56 } }
+export const azureMachineTypes = { Standard_DS2_v2: { cpu: 2, ramInGb: 7 }, Standard_DS3_v2: { cpu: 4, ramInGb: 14 }, Standard_DS4_v2: { cpu: 8, ramInGb: 28 }, Standard_DS5_v2: { cpu: 16, ramInGb: 56 } }
 export const getMachineTypeLabel = key => _.has(key, azureMachineTypes) ? `${key}, ${azureMachineTypes[key].cpu} CPU(s), ${azureMachineTypes[key].ramInGb} GBs` : 'Unknown machine type'
 

--- a/src/pages/workspaces/workspace/analysis/ContextBar.test.js
+++ b/src/pages/workspaces/workspace/analysis/ContextBar.test.js
@@ -3,6 +3,7 @@ import { act } from 'react-dom/test-utils'
 import { div, h } from 'react-hyperscript-helpers'
 import { MenuTrigger } from 'src/components/PopupTrigger'
 import { Ajax } from 'src/libs/ajax'
+import { defaultAzureMachineType, defaultAzureRegion } from 'src/libs/azure-utils'
 import * as Utils from 'src/libs/utils'
 import { ContextBar } from 'src/pages/workspaces/workspace/analysis/ContextBar'
 import { CloudEnvironmentModal } from 'src/pages/workspaces/workspace/analysis/modals/CloudEnvironmentModal'
@@ -224,9 +225,9 @@ const azureRunning = {
   proxyUrl: 'https://relay-ns-2a77dcb5-882c-46b9-a3bc-5d251aff14d0.servicebus.windows.net/saturn-b2eecc2d-75d5-44f5-8eb2-5147db41874a',
   runtimeConfig: {
     cloudService: 'AZURE_VM',
-    machineType: 'Standard_DS2_v2',
+    machineType: defaultAzureMachineType,
     persistentDiskId: 15778,
-    region: 'eastus',
+    region: defaultAzureRegion,
     runtimeName: 'saturn-b2eecc2d-75d5-44f5-8eb2-5147db41874a',
     status: 'Running',
     workspaceId: '2a77dcb5-882c-46b9-a3bc-5d251aff14d0'

--- a/src/pages/workspaces/workspace/analysis/ContextBar.test.js
+++ b/src/pages/workspaces/workspace/analysis/ContextBar.test.js
@@ -224,7 +224,7 @@ const azureRunning = {
   proxyUrl: 'https://relay-ns-2a77dcb5-882c-46b9-a3bc-5d251aff14d0.servicebus.windows.net/saturn-b2eecc2d-75d5-44f5-8eb2-5147db41874a',
   runtimeConfig: {
     cloudService: 'AZURE_VM',
-    machineType: 'Standard_DS1_v2',
+    machineType: 'Standard_DS2_v2',
     persistentDiskId: 15778,
     region: 'eastus',
     runtimeName: 'saturn-b2eecc2d-75d5-44f5-8eb2-5147db41874a',


### PR DESCRIPTION
removed the smallest VM option:  Standard_DS1_v2 and made the default  Standard_DS2_v2
