### PR TITLE
[SU-246] Allow selecting files in new file browser

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -46,7 +46,8 @@ module.exports = {
       'warn', {
         'vars': 'all',
         'args': 'all',
-        'argsIgnorePattern': '^_|^props'
+        'argsIgnorePattern': '^_|^props',
+        'ignoreRestSiblings': true,
       }
     ],
     'no-whitespace-before-property': 'warn',

--- a/src/components/common/Checkbox.js
+++ b/src/components/common/Checkbox.js
@@ -10,7 +10,7 @@ import * as Utils from 'src/libs/utils'
 import { IdContainer } from './IdContainer'
 
 
-export const Checkbox = ({ checked, onChange, disabled, ...props }) => {
+export const Checkbox = ({ checked, onChange, disabled = false, ...props }) => {
   useLabelAssert('Checkbox', { ...props, allowId: true })
   return h(Interactive, _.merge({
     as: 'span',

--- a/src/components/file-browser/FileBrowser.ts
+++ b/src/components/file-browser/FileBrowser.ts
@@ -1,4 +1,4 @@
-import { Fragment, useState } from 'react'
+import { Fragment, useEffect, useState } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
 import DirectoryTree from 'src/components/file-browser/DirectoryTree'
 import FilesInDirectory from 'src/components/file-browser/FilesInDirectory'
@@ -18,6 +18,11 @@ const FileBrowser = ({ provider, title, workspace }: FileBrowserProps) => {
   const [path, setPath] = useState('')
 
   const [focusedFile, setFocusedFile] = useState<FileBrowserFile | null>(null)
+
+  const [selectedFiles, setSelectedFiles] = useState<{ [path: string]: FileBrowserFile }>({})
+  useEffect(() => {
+    setSelectedFiles({})
+  }, [path])
 
   return h(Fragment, [
     div({ style: { display: 'flex', height: '100%' } }, [
@@ -81,6 +86,8 @@ const FileBrowser = ({ provider, title, workspace }: FileBrowserProps) => {
           provider,
           path,
           rootLabel: 'Workspace bucket',
+          selectedFiles,
+          setSelectedFiles,
           onClickFile: setFocusedFile
         })
       ])

--- a/src/components/file-browser/FilesInDirectory.test.ts
+++ b/src/components/file-browser/FilesInDirectory.test.ts
@@ -57,6 +57,8 @@ describe('FilesInDirectory', () => {
     render(h(FilesInDirectory, {
       provider: mockFileBrowserProvider,
       path: 'path/to/directory/',
+      selectedFiles: {},
+      setSelectedFiles: () => {},
       onClickFile: jest.fn()
     }))
 
@@ -90,6 +92,8 @@ describe('FilesInDirectory', () => {
     render(h(FilesInDirectory, {
       provider: mockFileBrowserProvider,
       path: 'path/to/directory/',
+      selectedFiles: {},
+      setSelectedFiles: () => {},
       onClickFile: jest.fn()
     }))
 
@@ -119,6 +123,8 @@ describe('FilesInDirectory', () => {
       render(h(FilesInDirectory, {
         provider: mockFileBrowserProvider,
         path: 'path/to/directory/',
+        selectedFiles: {},
+        setSelectedFiles: () => {},
         onClickFile: jest.fn()
       }))
 
@@ -162,6 +168,8 @@ describe('FilesInDirectory', () => {
       render(h(FilesInDirectory, {
         provider: mockFileBrowserProvider,
         path: 'path/to/directory/',
+        selectedFiles: {},
+        setSelectedFiles: () => {},
         onClickFile: jest.fn()
       }))
 
@@ -179,6 +187,8 @@ describe('FilesInDirectory', () => {
       render(h(FilesInDirectory, {
         provider: mockFileBrowserProvider,
         path: 'path/to/directory/',
+        selectedFiles: {},
+        setSelectedFiles: () => {},
         onClickFile: jest.fn()
       }))
 

--- a/src/components/file-browser/FilesInDirectory.ts
+++ b/src/components/file-browser/FilesInDirectory.ts
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useRef } from 'react'
+import { Dispatch, Fragment, SetStateAction, useEffect, useRef } from 'react'
 import { div, h, p, span } from 'react-hyperscript-helpers'
 import { Link } from 'src/components/common'
 import { useFilesInDirectory } from 'src/components/file-browser/file-browser-hooks'
@@ -14,11 +14,20 @@ interface FilesInDirectoryProps {
   provider: FileBrowserProvider
   path: string
   rootLabel?: string
+  selectedFiles: { [path: string]: FileBrowserFile }
+  setSelectedFiles: Dispatch<SetStateAction<{ [path: string]: FileBrowserFile }>>
   onClickFile: (file: FileBrowserFile) => void
 }
 
 const FilesInDirectory = (props: FilesInDirectoryProps) => {
-  const { provider, path, rootLabel = 'Files', onClickFile } = props
+  const {
+    path,
+    provider,
+    rootLabel = 'Files',
+    selectedFiles,
+    setSelectedFiles,
+    onClickFile
+  } = props
 
   const directoryLabel = path === '' ? rootLabel : basename(path)
 
@@ -63,6 +72,8 @@ const FilesInDirectory = (props: FilesInDirectoryProps) => {
       h(FilesTable, {
         'aria-label': `Files in ${directoryLabel}`,
         files,
+        selectedFiles,
+        setSelectedFiles,
         onClickFile
       }),
       div({

--- a/src/components/file-browser/FilesTable.test.ts
+++ b/src/components/file-browser/FilesTable.test.ts
@@ -2,8 +2,10 @@ import '@testing-library/jest-dom'
 
 import { getAllByRole, getByRole, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { useState } from 'react'
 import { h } from 'react-hyperscript-helpers'
-import FilesTable from 'src/components/file-browser/FilesTable'
+import { basename } from 'src/components/file-browser/file-browser-utils'
+import FilesTable, { FilesTableProps } from 'src/components/file-browser/FilesTable'
 import { FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
 
 
@@ -40,12 +42,17 @@ describe('FilesTable', () => {
   ]
 
   it.each([
-    { field: 'name', columnIndex: 0, expected: ['file1.txt', 'file2.bam', 'file3.vcf'] },
-    { field: 'size', columnIndex: 1, expected: ['1 KB', '1 MB', '1 GB'] }
+    { field: 'name', columnIndex: 1, expected: ['file1.txt', 'file2.bam', 'file3.vcf'] },
+    { field: 'size', columnIndex: 2, expected: ['1 KB', '1 MB', '1 GB'] }
     // { field: 'last modified', columnIndex: 2, expected: [] }
   ])('renders a column with file $field', ({ columnIndex, expected }) => {
     // Act
-    render(h(FilesTable, { files, onClickFile: jest.fn() }))
+    render(h(FilesTable, {
+      files,
+      selectedFiles: {},
+      setSelectedFiles: () => {},
+      onClickFile: jest.fn(),
+    }))
 
     const tableRows = screen.getAllByRole('row').slice(1) // skip header row
     const cellsInColumn = tableRows.map(row => getAllByRole(row, 'cell')[columnIndex])
@@ -57,10 +64,15 @@ describe('FilesTable', () => {
 
   it('renders file names as links', () => {
     // Act
-    render(h(FilesTable, { files, onClickFile: jest.fn() }))
+    render(h(FilesTable, {
+      files,
+      selectedFiles: {},
+      setSelectedFiles: () => {},
+      onClickFile: jest.fn(),
+    }))
 
     const tableRows = screen.getAllByRole('row').slice(1) // skip header row
-    const fileNameCells = tableRows.map(row => getAllByRole(row, 'cell')[0])
+    const fileNameCells = tableRows.map(row => getAllByRole(row, 'cell')[1])
     const fileLinks = fileNameCells.map(cell => getByRole(cell, 'link'))
 
     // Assert
@@ -76,10 +88,15 @@ describe('FilesTable', () => {
     const user = userEvent.setup()
 
     const onClickFile = jest.fn()
-    render(h(FilesTable, { files, onClickFile }))
+    render(h(FilesTable, {
+      files,
+      selectedFiles: {},
+      setSelectedFiles: () => {},
+      onClickFile,
+    }))
 
     const tableRows = screen.getAllByRole('row').slice(1) // skip header row
-    const fileNameCells = tableRows.map(row => getAllByRole(row, 'cell')[0])
+    const fileNameCells = tableRows.map(row => getAllByRole(row, 'cell')[1])
     const fileLinks = fileNameCells.map(cell => getByRole(cell, 'link'))
 
     // Act
@@ -104,5 +121,61 @@ describe('FilesTable', () => {
         updatedAt: 1667410200000
       }
     ])
+  })
+
+  describe('selected files', () => {
+    // Arrange
+    const user = userEvent.setup()
+
+    type TestComponentProps = Omit<FilesTableProps, 'selectedFiles' | 'setSelectedFiles'> & {
+      initialSelectedFiles: FilesTableProps['selectedFiles']
+    }
+
+    const TestComponent = ({ initialSelectedFiles, ...otherProps }: TestComponentProps) => {
+      const [selectedFiles, setSelectedFiles] = useState<{ [path: string]: FileBrowserFile }>(initialSelectedFiles)
+
+      return h(FilesTable, {
+        ...otherProps,
+        selectedFiles,
+        setSelectedFiles,
+      })
+    }
+
+    beforeEach(() => {
+      render(h(TestComponent, {
+        initialSelectedFiles: { [files[0].path]: files[0] },
+        files,
+        onClickFile: () => {},
+      }))
+    })
+
+    it('renders a checkbox for selected files', () => {
+      // Assert
+      const fileCheckboxes = files.map(file => screen.getByLabelText(`Select ${basename(file.path)}`))
+      expect(fileCheckboxes.map(checkbox => checkbox.getAttribute('aria-checked'))).toEqual(['true', 'false', 'false'])
+    })
+
+    it('selects/unselects file when checkbox is checked/unchecked', async () => {
+      // Act
+      const file1Checkbox = screen.getByLabelText(`Select ${basename(files[0].path)}`)
+      const file2Checkbox = screen.getByLabelText(`Select ${basename(files[1].path)}`)
+
+      await user.click(file1Checkbox)
+      await user.click(file2Checkbox)
+
+      // Assert
+      expect(file1Checkbox.getAttribute('aria-checked')).toBe('false')
+      expect(file2Checkbox.getAttribute('aria-checked')).toBe('true')
+    })
+
+    it('renders a checkbox for selecting all files', async () => {
+      // Act
+      const selectAllCheckbox = screen.getByLabelText('Select all files')
+      await user.click(selectAllCheckbox)
+
+      // Assert
+      const fileCheckboxes = files.map(file => screen.getByLabelText(`Select ${basename(file.path)}`))
+      expect(fileCheckboxes.map(checkbox => checkbox.getAttribute('aria-checked'))).toEqual(['true', 'true', 'true'])
+    })
   })
 })


### PR DESCRIPTION
Add checkboxes to the files table in the new file browser. This will be used to allow deleting selected files.

![Screen Shot 2022-11-30 at 9 07 48 AM](https://user-images.githubusercontent.com/1156625/204817474-c08e1382-9451-43b3-82ed-abd2d21eb4e5.png)

Selected files state and setter are stored in the root FileBrowser component and plumbed through FilesInDirectory to FilesTable, which wires them up to checkboxes.

To enable the new file browser, enable the "Workspace Files Browser" from the feature preview page (`/#feature-preview`) and then click the files link in the right sidebar from within a workspace.