### PR TITLE
ID-355 Fix PR template comment

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,8 @@
-<!--
+<!---
 Hello, friend!
 Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
 Also, so if a screen recording [1] and/or screenshots would be a helpful way to communicate context, please consider including some in your PR description.
 Thanks!
 
 [1] https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac
---!>
+-->


### PR DESCRIPTION
<!---
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Also, so if a screen recording [1] and/or screenshots would be a helpful way to communicate context, please consider including some in your PR description.
Thanks!

[1] https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac
-->

https://broadworkbench.atlassian.net/browse/ID-355

what/why:
the comment tag is wrong and breaks markdown formatting

Before:
![Screen Shot 2022-11-30 at 10 42 25 AM](https://user-images.githubusercontent.com/5375000/204843169-f4cabe75-751f-4061-bdd9-284734f85f93.png)
broken markdown

After:
![Screen Shot 2022-11-30 at 10 42 39 AM](https://user-images.githubusercontent.com/5375000/204843184-7de01c3e-81c8-40a0-95e6-e67ba758380a.png)
beautiful markdown


https://stackoverflow.com/questions/4823468/comments-in-markdown