### PR TITLE
[UIE-25] Add .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+# yarn "unplugged" packages
+.yarn/unplugged
+
+# Build output
+build
+
+# Jest coverage report
+coverage
+
+# Build tool caches
+node_modules


### PR DESCRIPTION
Terra UI’s Docker build copies all of the repository into the image.

https://github.com/DataBiosphere/terra-ui/blob/8faff5649c497e1f148b9290c7021c569e860aec/Dockerfile#L3

When the output from a build run on the host machine is present, `yarn build` in Docker fails with:
```
Failed to compile.
The "path" argument must be of type string. Received an instance of Buffer
```

Deleting the build directory and re-running the Docker build resolves the issue. This hasn't been an issue in CI because CI runs the Docker build in a fresh environment without any existing build output.

Instead of requiring developers to remember to remove that directory before running a Docker build, this adds a [.dockerignore file](https://docs.docker.com/engine/reference/builder/#dockerignore-file) which will prevent copying the build directory into the Docker image.

And while we're at it, this also ignores a few other things:
- .yarn/unplugged - "Unplugged" dependencies have native components that wouldn't work if the version installed/compiled for the host's OS/architecture is copied into a Docker image with a different OS/architecture. This hasn't been an issue yet because the only unplugged dependencies that Terra UI currently has are related to integration tests, which are not run in the Docker build. This folder is a few hundred megabytes, so omitting it also speeds up the Docker build.
- coverage - Jest coverage report isn't used by the Docker build.
- node_modules - Dev tools (Babel, TS, ESLint) store caches in this directory. We want the Docker build to be independent of the host machine.

## Testing

```
yarn build
docker build -t terra-ui .
```