### PR TITLE
[UIE-22] Configure security and caching headers in Nginx

### DIFF
--- a/nginx-bees.conf
+++ b/nginx-bees.conf
@@ -6,7 +6,33 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    location ~* \.(css|eot|gz|ico|jpg|jpeg|js|json|map|png|svg|otf|ttf|woff|woff2)$ {
+        add_header X-Content-Type-Options "nosniff";
+
+        # Cache static files.
+        expires 1h;
+        add_header Cache-Control "public, max-age=3600, immutable";
+    }
+
+    location ~* google[a-z0-9]*\.html$ {
+        add_header X-Content-Type-Options "nosniff";
+
+        # HTML responses must not be cached.
+        expires -1y;
+        add_header Pragma "no-cache";
+    }
+
     location / {
+        add_header Content-Security-Policy "base-uri 'self'; object-src 'none'; script-src 'self' 'unsafe-eval' https://fast.appcues.com https://us.jsagent.tcell.insight.rapid7.com https://cdnjs.cloudflare.com; style-src * 'unsafe-inline'";
+        add_header Strict-Transport-Security "max-age=31536000; includeSubdomains; preload";
+        add_header X-Content-Type-Options "nosniff";
+        add_header X-Frame-Options "SAMEORIGIN";
+        add_header X-XSS-Protection "1; mode=block";
+
+        # HTML responses must not be cached.
+        expires -1y;
+        add_header Pragma "no-cache";
+
         # First attempt to serve request as file, then as directory, then fall back to redirecting to index.html
         try_files $uri $uri/ /index.html;
     }


### PR DESCRIPTION
Currently, Terra UI is deployed onto App Engine for dev, staging, and production environments. Security and caching headers returned for different URLs are configured in app.yaml.

https://github.com/DataBiosphere/terra-ui/blob/8faff5649c497e1f148b9290c7021c569e860aec/app.yaml

In BEEs, Terra UI is served by Nginx. Currently, Nginx does not set the same headers as App Engine. This adds the security and caching headers to Nginx.

## Testing

Build and run the Terra UI Docker image:
```
rm -rf build
docker build -t terra-ui .
docker run --rm -ti -p 3000:80 -v $(pwd)/config/dev.json:/usr/share/nginx/html/config.json terra-ui
```

Compare headers:
```
curl -I http://localhost:3000/
curl -I https://app.terra.bio/
```

There are 3 categories of URLs to compare headers for:
- Static files, such as JavaScript files. Most static files are named differently for each revision of Terra UI. Find the main JS bundle's filename with `curl https://app.terra.bio/ | grep 'main.*.js'` / `curl http://localhost:3000/ | grep 'main.*.js'`.
- Google verification files (ex: https://app.terra.bio/google04dfa0c4e6a35632.html and http://localhost:3000/google04dfa0c4e6a35632.html)
- index.html (https://app.terra.bio/ and http://localhost:3000/)

## Caching

This does configure slightly more aggressive caching than the current App Engine configuration. The App Engine configuration caches static files for 2 minutes, while this caches them for 1 hour. Since webpack names files with a hash based on their content, if a file changes, then its URL will change. Thus, we could cache static files much more aggressively / indefinitely.