### PR TITLE
[AJ-727] data table support for user-defined primary key column

### DIFF
--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -141,7 +141,7 @@ const DataTable = props => {
       pageNumber, itemsPerPage, sortField: sort.field, sortDirection: sort.direction, snapshotName,
       googleProject, activeTextFilter, filterOperator
     }
-    const { results, resultMetadata: { filteredCount, unfilteredCount } } = await dataProvider.getPage(signal, entityType, queryOptions)
+    const { results, resultMetadata: { filteredCount, unfilteredCount } } = await dataProvider.getPage(signal, entityType, queryOptions, entityMetadata)
 
     // Find all the unique attribute names contained in the current page of results.
     const attrNamesFromResults = _.uniq(_.flatMap(_.keys, _.map('attributes', results)))

--- a/src/libs/ajax/data-table-providers/DataTableProvider.ts
+++ b/src/libs/ajax/data-table-providers/DataTableProvider.ts
@@ -86,7 +86,7 @@ export interface AttributeArray {
 }
 
 // queryOptions can contain:
-export type GetPageFn = (signal: AbortSignal, entityType: string, queryOptions: EntityQueryOptions) => Promise<EntityQueryResponse>
+export type GetPageFn = (signal: AbortSignal, entityType: string, queryOptions: EntityQueryOptions, metadata: EntityMetadata) => Promise<EntityQueryResponse>
 
 export type GetMetadataFn = (signal: AbortSignal) => Promise<EntityMetadata>
 

--- a/src/libs/ajax/data-table-providers/EntityServiceDataTableProvider.ts
+++ b/src/libs/ajax/data-table-providers/EntityServiceDataTableProvider.ts
@@ -4,6 +4,7 @@ import { Ajax } from 'src/libs/ajax'
 import {
   DataTableFeatures,
   DataTableProvider,
+  EntityMetadata,
   EntityQueryOptions,
   EntityQueryResponse, InvalidTsvOptions, TSVFeatures, TsvUploadButtonDisabledOptions,
   TsvUploadButtonTooltipOptions,
@@ -51,7 +52,7 @@ export class EntityServiceDataTableProvider implements DataTableProvider {
     }
   }
 
-  getPage = (signal: AbortSignal, entityType: string, queryOptions: EntityQueryOptions): Promise<EntityQueryResponse> => {
+  getPage = (signal: AbortSignal, entityType: string, queryOptions: EntityQueryOptions, _metadata: EntityMetadata): Promise<EntityQueryResponse> => {
     return Ajax(signal).Workspaces.workspace(this.namespace, this.name)
       .paginatedEntitiesOfType(entityType, _.pickBy(v => _.trim(v?.toString()), {
         page: queryOptions.pageNumber, pageSize: queryOptions.itemsPerPage,

--- a/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
+++ b/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
@@ -153,7 +153,7 @@ export class WdsDataTableProvider implements DataTableProvider {
     // translate WDS to Entity Service
     const filteredCount = wdsPage.totalRecords
     const unfilteredCount = wdsPage.totalRecords
-    const primaryKey = !!metadata[recordType] ? metadata[recordType].idName : 'sys_name' // for safety; recordType should always be present
+    const primaryKey = !!metadata[recordType] ? metadata[recordType].idName : '(unknown column)' // for safety; recordType should always be present
     const results = _.map(rec => {
       return {
         entityType: recordType,

--- a/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
+++ b/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
@@ -23,6 +23,7 @@ export interface RecordTypeSchema {
   name: string
   count: number
   attributes: AttributeSchema[]
+  primaryKey: string
 }
 
 export interface SearchRequest {
@@ -32,7 +33,7 @@ export interface SearchRequest {
   sortAttribute?: string
 }
 
-type RecordAttributes = Record<string, unknown> // truly "unknown" here; the backend Java representation is Map<String, Object>
+export type RecordAttributes = Record<string, unknown> // truly "unknown" here; the backend Java representation is Map<String, Object>
 
 interface RecordResponse {
   id: string
@@ -55,7 +56,10 @@ export interface TsvUploadResponse {
 export const wdsToEntityServiceMetadata = (wdsSchema: RecordTypeSchema[]): EntityMetadata => {
   const keyedSchema: Record<string, RecordTypeSchema> = _.keyBy(x => x.name, wdsSchema)
   return _.mapValues(typeDef => {
-    return { count: typeDef.count, attributeNames: _.map(attr => attr.name, typeDef.attributes), idName: 'sys_name' }
+    // exclude the primary-key attribute from the list of attributes. The data table reads
+    // the primary-key attribute from the "idName" property.
+    const attrs = _.filter(attr => attr.name !== typeDef.primaryKey, typeDef.attributes)
+    return { count: typeDef.count, attributeNames: _.map(attr => attr.name, attrs), idName: typeDef.primaryKey }
   }, keyedSchema)
 }
 
@@ -136,20 +140,24 @@ export class WdsDataTableProvider implements DataTableProvider {
   }
 
   // transforms a WDS array to Entity Service array format
-  private transformAttributes = (attributes: RecordAttributes): RecordAttributes => {
-    return _.mapValues(val => {
+  protected transformAttributes = (attributes: RecordAttributes, primaryKey: string): RecordAttributes => {
+    // the pickBy here excludes the primary-key attribute from the attribute map. The data table reads
+    // the primary-key attribute name from the idName of entity metadata, and its value from the entity name.
+    // if we included the primary-key attribute in the attribute map, the data table would show a duplicate column.
+    return _.pickBy((_v, k) => k !== primaryKey, _.mapValues(val => {
       return _.isArray(val) ? this.toEntityServiceArray(val) : this.maybeTransformRelation(val)
-    }, attributes)
+    }, attributes))
   }
 
-  protected transformPage = (wdsPage: RecordQueryResponse, recordType: string, queryOptions: EntityQueryOptions): EntityQueryResponse => {
+  protected transformPage = (wdsPage: RecordQueryResponse, recordType: string, queryOptions: EntityQueryOptions, metadata: EntityMetadata): EntityQueryResponse => {
     // translate WDS to Entity Service
     const filteredCount = wdsPage.totalRecords
     const unfilteredCount = wdsPage.totalRecords
+    const primaryKey = !!metadata[recordType] ? metadata[recordType].idName : 'sys_name' // for safety; recordType should always be present
     const results = _.map(rec => {
       return {
         entityType: recordType,
-        attributes: this.transformAttributes(rec.attributes),
+        attributes: this.transformAttributes(rec.attributes, primaryKey),
         name: rec.id
       }
     }, wdsPage.records)
@@ -172,7 +180,7 @@ export class WdsDataTableProvider implements DataTableProvider {
     }
   }
 
-  getPage = async (signal: AbortSignal, entityType: string, queryOptions: EntityQueryOptions): Promise<EntityQueryResponse> => {
+  getPage = async (signal: AbortSignal, entityType: string, queryOptions: EntityQueryOptions, metadata: EntityMetadata): Promise<EntityQueryResponse> => {
     const wdsPage: RecordQueryResponse = await Ajax(signal).WorkspaceData
       .getRecords(this.workspaceId, entityType,
         _.merge({
@@ -182,7 +190,7 @@ export class WdsDataTableProvider implements DataTableProvider {
         },
         queryOptions.sortField === 'name' ? {} : { sortAttribute: queryOptions.sortField }
         ))
-    return this.transformPage(wdsPage, entityType, queryOptions)
+    return this.transformPage(wdsPage, entityType, queryOptions, metadata)
   }
 
   deleteTable = (entityType: string): Promise<Response> => {


### PR DESCRIPTION
WDS now allows the user to specify an arbitrary column as the primary key for a table. The API responses from WDS have changed to support this.

This PR adds compatibility for displaying such tables. Without these changes, we'd display the primary key column twice - once with an incorrect header of "sys_name" and a second time containing blank values.

Tested by running locally, as well as the added/updated unit tests. This screenshot shows that we display the `participant_id` column - the primary key column - as the leftmost column; it is not duplicated again:
![Screenshot 12-1-2022 at 05 22 PM](https://user-images.githubusercontent.com/6041577/205172061-9662d5a6-f3fb-4092-896a-2cd1066b3cf1.png)
