### PR TITLE
[UIE-16] Move WarningTitle out of components/common

### DIFF
--- a/src/components/common.js
+++ b/src/components/common.js
@@ -65,13 +65,6 @@ export const FocusTrapper = ({ children, onBreakout, ...props }) => {
   }, [children])
 }
 
-export const WarningTitle = ({ children, iconSize = 36 }) => {
-  return div({ style: { display: 'flex', alignItems: 'center' } }, [
-    icon('warning-standard', { size: iconSize, style: { color: colors.warning(), marginRight: '0.75rem' } }),
-    children
-  ])
-}
-
 export const ClipboardButton = ({ text, onClick, children, ...props }) => {
   const [copied, setCopied] = useState(false)
   return h(Link, {

--- a/src/pages/workspaces/workspace/analysis/modals/AnalysisModal.js
+++ b/src/pages/workspaces/workspace/analysis/modals/AnalysisModal.js
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp'
 import { Fragment, useState } from 'react'
 import { div, h, h2, hr, img, span } from 'react-hyperscript-helpers'
-import { ButtonPrimary, Clickable, IdContainer, Select, WarningTitle } from 'src/components/common'
+import { ButtonPrimary, Clickable, IdContainer, Select } from 'src/components/common'
 import Dropzone from 'src/components/Dropzone'
 import { icon } from 'src/components/icons'
 import ModalDrawer from 'src/components/ModalDrawer'
@@ -24,6 +24,7 @@ import { AzureComputeModalBase } from 'src/pages/workspaces/workspace/analysis/m
 import { ComputeModalBase } from 'src/pages/workspaces/workspace/analysis/modals/ComputeModal'
 import { CromwellModalBase } from 'src/pages/workspaces/workspace/analysis/modals/CromwellModal'
 import { GalaxyModalBase } from 'src/pages/workspaces/workspace/analysis/modals/GalaxyModal'
+import { WarningTitle } from 'src/pages/workspaces/workspace/analysis/modals/WarningTitle'
 import {
   analysisNameInput, analysisNameValidator, baseRmd, notebookData
 } from 'src/pages/workspaces/workspace/analysis/notebook-utils'

--- a/src/pages/workspaces/workspace/analysis/modals/AzureComputeModal.js
+++ b/src/pages/workspaces/workspace/analysis/modals/AzureComputeModal.js
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp'
 import { Fragment, useState } from 'react'
 import { div, h, label, p, span } from 'react-hyperscript-helpers'
-import { ButtonOutline, ButtonPrimary, IdContainer, Link, Select, spinnerOverlay, WarningTitle } from 'src/components/common'
+import { ButtonOutline, ButtonPrimary, IdContainer, Link, Select, spinnerOverlay } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import { NumberInput } from 'src/components/input'
 import { withModalDrawer } from 'src/components/ModalDrawer'
@@ -16,6 +16,7 @@ import colors from 'src/libs/colors'
 import { withErrorReportingInModal } from 'src/libs/error'
 import { useOnMount } from 'src/libs/react-utils'
 import * as Utils from 'src/libs/utils'
+import { WarningTitle } from 'src/pages/workspaces/workspace/analysis/modals/WarningTitle'
 import {
   computeStyles, getCurrentRuntime, getIsRuntimeBusy
 } from 'src/pages/workspaces/workspace/analysis/runtime-utils'

--- a/src/pages/workspaces/workspace/analysis/modals/ComputeModal.js
+++ b/src/pages/workspaces/workspace/analysis/modals/ComputeModal.js
@@ -2,7 +2,7 @@ import _ from 'lodash/fp'
 import { Fragment, useState } from 'react'
 import { b, br, code, div, fieldset, h, label, legend, li, p, span, strong, ul } from 'react-hyperscript-helpers'
 import {
-  ButtonOutline, ButtonPrimary, ClipboardButton, GroupedSelect, IdContainer, LabeledCheckbox, Link, Select, spinnerOverlay, WarningTitle
+  ButtonOutline, ButtonPrimary, ClipboardButton, GroupedSelect, IdContainer, LabeledCheckbox, Link, Select, spinnerOverlay
 } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import { ImageDepViewer } from 'src/components/ImageDepViewer'
@@ -23,6 +23,7 @@ import * as Nav from 'src/libs/nav'
 import { useOnMount } from 'src/libs/react-utils'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
+import { WarningTitle } from 'src/pages/workspaces/workspace/analysis/modals/WarningTitle'
 import { SaveFilesHelp, SaveFilesHelpRStudio } from 'src/pages/workspaces/workspace/analysis/runtime-common'
 import {
   computeStyles, defaultAutopauseThreshold, defaultComputeRegion, defaultComputeZone, defaultDataprocMachineType, defaultDataprocMasterDiskSize,

--- a/src/pages/workspaces/workspace/analysis/modals/GalaxyModal.js
+++ b/src/pages/workspaces/workspace/analysis/modals/GalaxyModal.js
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp'
 import { Fragment, useState } from 'react'
 import { div, h, label, p, span } from 'react-hyperscript-helpers'
-import { ButtonOutline, ButtonPrimary, ButtonSecondary, IdContainer, Link, Select, spinnerOverlay, WarningTitle } from 'src/components/common'
+import { ButtonOutline, ButtonPrimary, ButtonSecondary, IdContainer, Link, Select, spinnerOverlay } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import { NumberInput } from 'src/components/input'
 import { withModalDrawer } from 'src/components/ModalDrawer'
@@ -15,6 +15,7 @@ import Events, { extractWorkspaceDetails } from 'src/libs/events'
 import { withDisplayName } from 'src/libs/react-utils'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
+import { WarningTitle } from 'src/pages/workspaces/workspace/analysis/modals/WarningTitle'
 import { GalaxyLaunchButton, GalaxyWarning, SaveFilesHelpGalaxy } from 'src/pages/workspaces/workspace/analysis/runtime-common'
 import {
   computeStyles, findMachineType, getCurrentApp, getCurrentAppDataDisk, getCurrentAttachedDataDisk, getGalaxyComputeCost, getGalaxyDiskCost,

--- a/src/pages/workspaces/workspace/analysis/modals/WarningTitle.ts
+++ b/src/pages/workspaces/workspace/analysis/modals/WarningTitle.ts
@@ -1,0 +1,20 @@
+import { PropsWithChildren } from 'react'
+import { div } from 'react-hyperscript-helpers'
+import { icon } from 'src/components/icons'
+import colors from 'src/libs/colors'
+
+
+type WarningTitleProps = PropsWithChildren<{
+  iconSize?: number
+}>
+
+export const WarningTitle = ({ children, iconSize = 36 }: WarningTitleProps) => {
+  return div({ style: { display: 'flex', alignItems: 'center' } }, [
+    icon('warning-standard', {
+      size: iconSize,
+      // @ts-expect-error
+      style: { color: colors.warning(), marginRight: '0.75rem' },
+    }),
+    children,
+  ])
+}


### PR DESCRIPTION
Continuing to split up components/common.js WarningTitle is only used in analysis modals, so moved it to the analysis modals directory. Since it's an IA component, also converted it to TypeScript.