### PR TITLE
[SU-247] Refactor useUploader hook

### DIFF
--- a/src/components/data/FileBrowser.js
+++ b/src/components/data/FileBrowser.js
@@ -305,7 +305,9 @@ const BucketBrowser = (({
 
   const [viewingObject, setViewingObject] = useState(null)
 
-  const { uploadState, uploadFiles, cancelUpload } = useUploader()
+  const { uploadState, uploadFiles, cancelUpload } = useUploader((file, { signal }) => {
+    return Ajax(signal).Buckets.upload(googleProject, bucketName, prefix, file)
+  })
   const [creatingNewFolder, setCreatingNewFolder] = useState(false)
   const [deletingSelectedObjects, setDeletingSelectedObjects] = useState(false)
   const [busy, setBusy] = useState(false)
@@ -331,7 +333,7 @@ const BucketBrowser = (({
       multiple: true,
       maxFiles: 0, // no limit on number of files
       onDropAccepted: async files => {
-        await uploadFiles({ googleProject, bucketName, prefix, files })
+        await uploadFiles(files)
         reload()
         onUploadFiles()
       }

--- a/src/libs/uploads.test.ts
+++ b/src/libs/uploads.test.ts
@@ -1,0 +1,161 @@
+import { act, renderHook } from '@testing-library/react-hooks'
+import { controlledPromise } from 'src/testing/test-utils'
+
+import { useUploader } from './uploads'
+
+
+describe('useUploader', () => {
+  const file1 = new File(['example'], 'file1.txt', { type: 'text/text' })
+  const file2 = new File(['some_content'], 'file2.txt', { type: 'text/text' })
+
+  it('uploads files', async () => {
+    // Arrange
+    const uploadFile = jest.fn(() => Promise.resolve())
+    const { result: hookReturnRef } = renderHook(() => useUploader(uploadFile))
+
+    // Act
+    await act(() => hookReturnRef.current.uploadFiles([file1, file2]))
+
+    // Assert
+    expect(uploadFile.mock.calls).toEqual([
+      [file1, expect.objectContaining({ signal: expect.any(AbortSignal) })],
+      [file2, expect.objectContaining({ signal: expect.any(AbortSignal) })],
+    ])
+  })
+
+  it('tracks progress of upload batch', async () => {
+    // Arrange
+    let finishCurrentUpload: (() => void) | null = null
+    const uploadFile = jest.fn(() => {
+      const [promise, controller] = controlledPromise<void>()
+      finishCurrentUpload = controller.resolve
+      return promise
+    })
+
+    const { result: hookReturnRef, waitForNextUpdate } = renderHook(() => useUploader(uploadFile))
+    const initialState = hookReturnRef.current.uploadState
+
+    // Act
+    act(() => { hookReturnRef.current.uploadFiles([file1, file2]) })
+    const stateAfterStartingUpload = hookReturnRef.current.uploadState
+
+    finishCurrentUpload!()
+    await waitForNextUpdate()
+    const stateAfterFinishingFirstUpload = hookReturnRef.current.uploadState
+
+    finishCurrentUpload!()
+    await waitForNextUpdate()
+    const stateAfterFinishingSecondUpload = hookReturnRef.current.uploadState
+
+    // Assert
+    expect(initialState).toEqual({
+      active: false,
+      totalFiles: 0,
+      totalBytes: 0,
+      uploadedBytes: 0,
+      currentFileNum: 0,
+      currentFile: null,
+      files: [],
+      completedFiles: [],
+      errors: [],
+      aborted: false,
+      done: false,
+    })
+
+    expect(stateAfterStartingUpload).toEqual({
+      active: true,
+      totalFiles: 2,
+      totalBytes: 19,
+      uploadedBytes: 0,
+      currentFileNum: 0,
+      currentFile: file1,
+      files: [file1, file2],
+      completedFiles: [],
+      errors: [],
+      aborted: false,
+      done: false,
+    })
+
+    expect(stateAfterFinishingFirstUpload).toEqual({
+      active: true,
+      totalFiles: 2,
+      totalBytes: 19,
+      uploadedBytes: 7,
+      currentFileNum: 1,
+      currentFile: file2,
+      files: [file1, file2],
+      completedFiles: [file1],
+      errors: [],
+      aborted: false,
+      done: false,
+    })
+
+    expect(stateAfterFinishingSecondUpload).toEqual({
+      active: false,
+      totalFiles: 2,
+      totalBytes: 19,
+      uploadedBytes: 19,
+      currentFileNum: 1,
+      currentFile: file2,
+      files: [file1, file2],
+      completedFiles: [file1, file2],
+      errors: [],
+      aborted: false,
+      done: true,
+    })
+  })
+
+  it('tracks errors during uploads', async () => {
+    // Arrange
+    const uploadFile = jest.fn(() => Promise.reject(new Error('Upload error')))
+    const { result: hookReturnRef } = renderHook(() => useUploader(uploadFile))
+
+    // Act
+    await act(() => hookReturnRef.current.uploadFiles([file1]))
+
+    // Assert
+    expect(hookReturnRef.current.uploadState).toEqual({
+      active: false,
+      totalFiles: 1,
+      totalBytes: 7,
+      uploadedBytes: 0,
+      currentFileNum: 0,
+      currentFile: file1,
+      files: [file1],
+      completedFiles: [],
+      errors: [new Error('Upload error')],
+      aborted: false,
+      done: true,
+    })
+  })
+
+  it('allows canceling upload', async () => {
+    // Arrange
+    const uploadFile = jest.fn(() => Promise.resolve())
+    const { result: hookReturnRef, waitForNextUpdate } = renderHook(() => useUploader(uploadFile))
+
+    // Act
+    act(() => {
+      hookReturnRef.current.uploadFiles([file1, file2])
+      hookReturnRef.current.cancelUpload()
+    })
+    await waitForNextUpdate()
+
+    // Assert
+    expect(uploadFile).toHaveBeenCalledTimes(1)
+
+    expect(hookReturnRef.current.uploadState).toEqual({
+      active: false,
+      totalFiles: 2,
+      totalBytes: 19,
+      uploadedBytes: 7,
+      currentFileNum: 0,
+      currentFile: file1,
+      files: [file1, file2],
+      completedFiles: [file1],
+      errors: [],
+      aborted: true,
+      done: false,
+    })
+  })
+})

--- a/src/libs/uploads.ts
+++ b/src/libs/uploads.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash/fp'
 import { Reducer, useCallback, useReducer } from 'react'
 import { useCancelable } from 'src/libs/react-utils'
 import * as Utils from 'src/libs/utils'
@@ -87,7 +86,7 @@ export const useUploader = (uploadFile: (file: File, opts: { signal: AbortSignal
           active: true,
           files: update.files,
           totalFiles: update.files.length,
-          totalBytes: _.reduce((total, file) => total += file.size, 0, update.files)
+          totalBytes: update.files.reduce((total, file) => total + file.size, 0),
         }
 
       case 'startFile':

--- a/src/testing/test-utils.ts
+++ b/src/testing/test-utils.ts
@@ -7,3 +7,25 @@
 export const asMockedFn = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> => {
   return fn as jest.MockedFunction<T>
 }
+
+export type PromiseController<T> = {
+  resolve: (value: T) => void
+  reject: (reason: unknown) => void
+}
+
+/**
+ * Returns a promise and a controller that allows manually resolving/rejecting the promise.
+ */
+export const controlledPromise = <T>(): [Promise<T>, PromiseController<T>] => {
+  const controller: PromiseController<T> = {
+    resolve: () => {},
+    reject: () => {},
+  }
+
+  const promise = new Promise<T>((resolve, reject) => {
+    controller.resolve = resolve
+    controller.reject = reject
+  })
+
+  return [promise, controller]
+}


### PR DESCRIPTION
Part 1 of adding upload support to the new file browser. Currently, the `useUploader` hook uploads files to GCS. This refactors it to accept an `uploadFile` function (so that it can also be used for Azure in the future), turning it into a more generic hook for tracking the progress of an upload of multiple files. This also converts it to TypeScript and adds tests.

## Testing

This hook is used for uploading files in the Files panel of the workspace Data tab.