### PR TITLE
[SU-248] Allow deleting files in new file browser

### DIFF
--- a/src/components/file-browser/DeleteFilesConfirmationModal.test.ts
+++ b/src/components/file-browser/DeleteFilesConfirmationModal.test.ts
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react'
+import { h } from 'react-hyperscript-helpers'
+
+import { DeleteFilesConfirmationModal } from './DeleteFilesConfirmationModal'
+
+
+describe('DeleteFilesConfirmationModal', () => {
+  it('renders list of files to be deleted', () => {
+    render(h(DeleteFilesConfirmationModal, {
+      files: [
+        {
+          path: 'path/to/file1.txt',
+          url: 'gs://test-bucket/path/to/file1.txt',
+          size: 1024,
+          createdAt: 1667408400000,
+          updatedAt: 1667408400000
+        },
+        {
+          path: 'path/to/file2.bam',
+          url: 'gs://test-bucket/path/to/file2.bam',
+          size: 1024 ** 2,
+          createdAt: 1667410200000,
+          updatedAt: 1667410200000
+        },
+        {
+          path: 'path/to/file3.vcf',
+          url: 'gs://test-bucket/path/to/file3.vcf',
+          size: 1024 ** 3,
+          createdAt: 1667412000000,
+          updatedAt: 1667412000000
+        }
+      ],
+      onDismiss: () => {},
+    }))
+
+    screen.getByText('file1.txt')
+    screen.getByText('file2.bam')
+    screen.getByText('file3.vcf')
+  })
+})

--- a/src/components/file-browser/DeleteFilesConfirmationModal.ts
+++ b/src/components/file-browser/DeleteFilesConfirmationModal.ts
@@ -1,0 +1,33 @@
+import pluralize from 'pluralize'
+import { div, h } from 'react-hyperscript-helpers'
+import { DeleteConfirmationModal } from 'src/components/common'
+import { FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
+import colors from 'src/libs/colors'
+
+import { basename } from './file-browser-utils'
+
+
+type DeleteFilesConfirmationModalProps = {
+  files: FileBrowserFile[]
+}
+
+export const DeleteFilesConfirmationModal = ({ files, ...props }: DeleteFilesConfirmationModalProps) => {
+  const numFiles = files.length
+  // @ts-expect-error
+  return h(DeleteConfirmationModal, {
+    ...props,
+    title: `Delete ${pluralize('file', numFiles, true)}`,
+    buttonText: `Delete ${numFiles === 1 ? 'file' : 'files'}`
+  }, [
+    // Size the scroll container to cut off the last row to hint that there's more content to be scrolled into view
+    // Row height calculation is font size * line height + padding + border
+    div({ style: { maxHeight: 'calc((1em * 1.15 + 1rem + 1px) * 10.5)', overflowY: 'auto', margin: '0 -1.25rem' } },
+      files.map((file, i) => div({
+        style: {
+          borderTop: i === 0 ? undefined : `1px solid ${colors.light()}`,
+          padding: '0.5rem 1.25rem'
+        }
+      }, [basename(file.path)]))
+    )
+  ])
+}

--- a/src/components/file-browser/FileBrowser.ts
+++ b/src/components/file-browser/FileBrowser.ts
@@ -6,6 +6,7 @@ import PathBreadcrumbs from 'src/components/file-browser/PathBreadcrumbs'
 import UriViewer from 'src/components/UriViewer'
 import FileBrowserProvider, { FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
 import colors from 'src/libs/colors'
+import * as Utils from 'src/libs/utils'
 
 
 interface FileBrowserProps {
@@ -23,6 +24,9 @@ const FileBrowser = ({ provider, title, workspace }: FileBrowserProps) => {
   useEffect(() => {
     setSelectedFiles({})
   }, [path])
+
+  const editWorkspaceError = Utils.editWorkspaceError(workspace)
+  const canEditWorkspace = !editWorkspaceError
 
   return h(Fragment, [
     div({ style: { display: 'flex', height: '100%' } }, [
@@ -83,6 +87,8 @@ const FileBrowser = ({ provider, title, workspace }: FileBrowserProps) => {
           })
         ]),
         h(FilesInDirectory, {
+          editDisabled: !canEditWorkspace,
+          editDisabledReason: editWorkspaceError,
           provider,
           path,
           rootLabel: 'Workspace bucket',

--- a/src/components/file-browser/FilesInDirectory.ts
+++ b/src/components/file-browser/FilesInDirectory.ts
@@ -3,6 +3,7 @@ import { div, h, p, span } from 'react-hyperscript-helpers'
 import { Link } from 'src/components/common'
 import { useFilesInDirectory } from 'src/components/file-browser/file-browser-hooks'
 import { basename } from 'src/components/file-browser/file-browser-utils'
+import { FilesMenu } from 'src/components/file-browser/FilesMenu'
 import FilesTable from 'src/components/file-browser/FilesTable'
 import { icon } from 'src/components/icons'
 import FileBrowserProvider, { FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
@@ -37,7 +38,8 @@ const FilesInDirectory = (props: FilesInDirectoryProps) => {
     state: { status, files },
     hasNextPage,
     loadAllRemainingItems,
-    loadNextPage
+    loadNextPage,
+    reload,
   } = useFilesInDirectory(provider, path)
 
   const isLoading = status === 'Loading'
@@ -57,6 +59,15 @@ const FilesInDirectory = (props: FilesInDirectoryProps) => {
       flex: '1 0 0'
     }
   }, [
+    h(FilesMenu, {
+      provider,
+      selectedFiles,
+      onDeleteFiles: () => {
+        setSelectedFiles({})
+        reload()
+      },
+    }),
+
     span({
       ref: loadedAlertElementRef,
       'aria-live': 'polite',

--- a/src/components/file-browser/FilesInDirectory.ts
+++ b/src/components/file-browser/FilesInDirectory.ts
@@ -12,6 +12,8 @@ import * as Utils from 'src/libs/utils'
 
 
 interface FilesInDirectoryProps {
+  editDisabled?: boolean
+  editDisabledReason?: string
   provider: FileBrowserProvider
   path: string
   rootLabel?: string
@@ -22,6 +24,8 @@ interface FilesInDirectoryProps {
 
 const FilesInDirectory = (props: FilesInDirectoryProps) => {
   const {
+    editDisabled = false,
+    editDisabledReason,
     path,
     provider,
     rootLabel = 'Files',
@@ -60,6 +64,8 @@ const FilesInDirectory = (props: FilesInDirectoryProps) => {
     }
   }, [
     h(FilesMenu, {
+      disabled: editDisabled,
+      disabledReason: editDisabledReason,
       provider,
       selectedFiles,
       onDeleteFiles: () => {

--- a/src/components/file-browser/FilesMenu.test.ts
+++ b/src/components/file-browser/FilesMenu.test.ts
@@ -1,0 +1,95 @@
+import { act, getByText, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { h } from 'react-hyperscript-helpers'
+import FileBrowserProvider, { FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
+
+import { FilesMenu } from './FilesMenu'
+
+
+jest.mock('src/components/Modal', () => {
+  const { mockModalModule } = jest.requireActual('src/components/Modal.mock')
+  return mockModalModule()
+})
+
+
+describe('FilesMenu', () => {
+  describe('deleting files', () => {
+    const deleteFile = jest.fn((_path: string) => Promise.resolve())
+    const mockProvider = { deleteFile } as Partial<FileBrowserProvider> as FileBrowserProvider
+
+    const selectedFiles: { [path: string]: FileBrowserFile } = {
+      'path/to/file1.txt': {
+        path: 'path/to/file1.txt',
+        url: 'gs://test-bucket/path/to/file1.txt',
+        size: 1024,
+        createdAt: 1667408400000,
+        updatedAt: 1667408400000
+      },
+      'path/to/file2.bam': {
+        path: 'path/to/file2.bam',
+        url: 'gs://test-bucket/path/to/file2.bam',
+        size: 1024 ** 2,
+        createdAt: 1667410200000,
+        updatedAt: 1667410200000
+      },
+      'path/to/file3.vcf': {
+        path: 'path/to/file3.vcf',
+        url: 'gs://test-bucket/path/to/file3.vcf',
+        size: 1024 ** 3,
+        createdAt: 1667412000000,
+        updatedAt: 1667412000000
+      },
+    }
+
+    const onDeleteFiles = jest.fn()
+
+    let user
+
+    beforeEach(async () => {
+      // Arrange
+      user = userEvent.setup()
+
+      render(h(FilesMenu, {
+        provider: mockProvider,
+        selectedFiles,
+        onDeleteFiles,
+      }))
+
+      // Act
+      const deleteButton = screen.getByText('Delete')
+      await user.click(deleteButton)
+    })
+
+    it('prompts for confirmation before deleting files', () => {
+      // Assert
+      getByText(screen.getByRole('dialog'), 'Delete 3 files')
+      expect(deleteFile).not.toHaveBeenCalled()
+    })
+
+    it('deletes selected files', async () => {
+      // Act
+      const confirmDeleteButton = screen.getByText('Delete files')
+      await act(async () => {
+        await user.click(confirmDeleteButton)
+      })
+
+      // Assert
+      expect(deleteFile.mock.calls).toEqual([
+        ['path/to/file1.txt'],
+        ['path/to/file2.bam'],
+        ['path/to/file3.vcf'],
+      ])
+    })
+
+    it('calls onDeleteFiles callback', async () => {
+      // Act
+      const confirmDeleteButton = screen.getByText('Delete files')
+      await act(async () => {
+        await user.click(confirmDeleteButton)
+      })
+
+      // Assert
+      expect(onDeleteFiles).toHaveBeenCalled()
+    })
+  })
+})

--- a/src/components/file-browser/FilesMenu.ts
+++ b/src/components/file-browser/FilesMenu.ts
@@ -1,0 +1,77 @@
+import _ from 'lodash/fp'
+import { useState } from 'react'
+import { div, h } from 'react-hyperscript-helpers'
+import { Link, topSpinnerOverlay } from 'src/components/common'
+import { DeleteFilesConfirmationModal } from 'src/components/file-browser/DeleteFilesConfirmationModal'
+import { icon } from 'src/components/icons'
+import FileBrowserProvider, { FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
+import colors from 'src/libs/colors'
+import { reportError } from 'src/libs/error'
+import * as Utils from 'src/libs/utils'
+
+
+interface FilesMenuProps {
+  disabled?: boolean
+  disabledReason?: string
+  provider: FileBrowserProvider
+  selectedFiles: { [path: string]: FileBrowserFile }
+  onDeleteFiles: () => void
+}
+
+export const FilesMenu = (props: FilesMenuProps) => {
+  const {
+    disabled = false,
+    disabledReason = 'Unable to edit files',
+    provider,
+    selectedFiles,
+    onDeleteFiles,
+  } = props
+
+  const [busy, setBusy] = useState(false)
+  const [confirmingDelete, setConfirmingDelete] = useState(false)
+
+  const hasSelectedFiles = !_.isEmpty(selectedFiles)
+
+  return div({
+    style: {
+      display: 'flex',
+      flexFlow: 'row wrap',
+      alignItems: 'center',
+      width: '100%',
+      padding: '0.5rem',
+      borderBottom: `0.5px solid ${colors.dark(0.2)}`,
+      backgroundColor: colors.light(0.4),
+    },
+  }, [
+    h(Link, {
+      disabled: disabled || !hasSelectedFiles,
+      tooltip: Utils.cond(
+        [disabled, () => disabledReason],
+        [!hasSelectedFiles, () => 'Select files to delete'],
+        () => 'Delete selected files'
+      ),
+      style: { padding: '0.5rem' },
+      onClick: () => setConfirmingDelete(true),
+    }, [icon('trash'), ' Delete']),
+
+    confirmingDelete && h(DeleteFilesConfirmationModal, {
+      files: _.values(selectedFiles),
+      onConfirm: async () => {
+        setConfirmingDelete(false)
+        setBusy(true)
+        try {
+          const deleteRequests = Object.values(selectedFiles).map(file => provider.deleteFile(file.path))
+          await Promise.all(deleteRequests)
+        } catch (error) {
+          reportError('Error deleting objects', error)
+        } finally {
+          setBusy(false)
+          onDeleteFiles()
+        }
+      },
+      onDismiss: () => setConfirmingDelete(false),
+    }),
+
+    busy && topSpinnerOverlay
+  ])
+}

--- a/src/libs/ajax/GoogleStorage.ts
+++ b/src/libs/ajax/GoogleStorage.ts
@@ -206,8 +206,8 @@ export const GoogleStorage = (signal?: AbortSignal) => ({
     return { items, prefixes }
   },
 
-  delete: async (googleProject, bucket, name) => {
-    return fetchBuckets(
+  delete: async (googleProject: string, bucket: string, name: string): Promise<void> => {
+    await fetchBuckets(
       `storage/v1/b/${bucket}/o/${encodeURIComponent(name)}`,
       _.merge(authOpts(await saToken(googleProject)), { signal, method: 'DELETE' })
     )

--- a/src/libs/ajax/file-browser-providers/FileBrowserProvider.ts
+++ b/src/libs/ajax/file-browser-providers/FileBrowserProvider.ts
@@ -16,6 +16,8 @@ export interface FileBrowserDirectory {
 interface FileBrowserProvider {
   getDirectoriesInDirectory(path: string, options?: { signal?: AbortSignal }): Promise<IncrementalResponse<FileBrowserDirectory>>
   getFilesInDirectory(path: string, options?: { signal?: AbortSignal }): Promise<IncrementalResponse<FileBrowserFile>>
+
+  deleteFile(path: string): Promise<void>
 }
 
 export default FileBrowserProvider

--- a/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.test.ts
+++ b/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.test.ts
@@ -1,7 +1,7 @@
 import { Ajax } from 'src/libs/ajax'
 import { FileBrowserDirectory, FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
 import GCSFileBrowserProvider from 'src/libs/ajax/file-browser-providers/GCSFileBrowserProvider'
-import { GCSItem, GCSListObjectsResponse } from 'src/libs/ajax/GoogleStorage'
+import { GCSItem, GCSListObjectsResponse, GoogleStorageContract } from 'src/libs/ajax/GoogleStorage'
 import * as Utils from 'src/libs/utils'
 import { asMockedFn } from 'src/testing/test-utils'
 
@@ -140,5 +140,21 @@ describe('GCSFileBrowserProvider', () => {
     expect(secondResponse.items).toEqual(expectedSecondPageDirectories)
     expect(secondResponse.hasNextPage).toBe(false)
     expect(numGCSRequestsAfterSecondResponse).toBe(3)
+  })
+
+  it('deletes files', async () => {
+    // Arrange
+    const del = jest.fn(() => Promise.resolve())
+    asMockedFn(Ajax).mockImplementation(() => ({
+      Buckets: { delete: del } as Partial<GoogleStorageContract>
+    }) as ReturnType<typeof Ajax>)
+
+    const provider = GCSFileBrowserProvider({ bucket: 'test-bucket', project: 'test-project' })
+
+    // Act
+    await provider.deleteFile('path/to/file.txt')
+
+    // Assert
+    expect(del).toHaveBeenCalledWith('test-project', 'test-bucket', 'path/to/file.txt')
   })
 })

--- a/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.ts
+++ b/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.ts
@@ -99,7 +99,10 @@ const GCSFileBrowserProvider = ({ bucket, project, pageSize = 1000 }: GCSFileBro
       }),
       prefix: path,
       signal
-    })
+    }),
+    deleteFile: async (path: string): Promise<void> => {
+      await Ajax().Buckets.delete(project, bucket, path)
+    },
   }
 }
 


### PR DESCRIPTION
https://user-images.githubusercontent.com/1156625/205395715-d9489511-5cb2-4744-9fb1-e3e768298810.mov

Enable the new file browser from the feature preview page (`/#feature-preview`) and open it from the right sidebar within a workspace.