### PR TITLE
[SU-247] Allow uploading files in new file browser

### DIFF
--- a/src/components/file-browser/FilesInDirectory.test.ts
+++ b/src/components/file-browser/FilesInDirectory.test.ts
@@ -224,7 +224,7 @@ describe('FilesInDirectory', () => {
       onClickFile: jest.fn()
     }))
 
-    const fileInput = document.querySelector('input[type="file"]')! as HTMLElement
+    const fileInput = document.querySelector<HTMLInputElement>('input[type="file"]')!
 
     const file = new File(['somecontent'], 'example.txt')
 

--- a/src/components/file-browser/FilesInDirectory.test.ts
+++ b/src/components/file-browser/FilesInDirectory.test.ts
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 
-import { render, screen } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { div, h } from 'react-hyperscript-helpers'
 import { useFilesInDirectory } from 'src/components/file-browser/file-browser-hooks'
@@ -197,5 +197,41 @@ describe('FilesInDirectory', () => {
       await user.click(loadAllPagesButton)
       expect(loadAllRemainingItems).toHaveBeenCalled()
     })
+  })
+
+  it('uploads files', async () => {
+    // Arrange
+    const user = userEvent.setup()
+
+    const uploadFileToDirectory = jest.fn(() => Promise.resolve())
+    const mockProvider = { uploadFileToDirectory } as Partial<FileBrowserProvider> as FileBrowserProvider
+
+    const useFilesInDirectoryResult: UseFilesInDirectoryResult = {
+      state: { status: 'Ready', files: [] },
+      hasNextPage: false,
+      loadNextPage: () => Promise.resolve(),
+      loadAllRemainingItems: () => Promise.resolve(),
+      reload: () => Promise.resolve()
+    }
+
+    asMockedFn(useFilesInDirectory).mockReturnValue(useFilesInDirectoryResult)
+
+    render(h(FilesInDirectory, {
+      provider: mockProvider,
+      path: 'path/to/directory/',
+      selectedFiles: {},
+      setSelectedFiles: () => {},
+      onClickFile: jest.fn()
+    }))
+
+    const fileInput = document.querySelector('input[type="file"]')! as HTMLElement
+
+    const file = new File(['somecontent'], 'example.txt')
+
+    // Act
+    await act(() => user.upload(fileInput, [file]))
+
+    // Assert
+    expect(uploadFileToDirectory).toHaveBeenCalledWith('path/to/directory/', file)
   })
 })

--- a/src/components/file-browser/FilesInDirectory.ts
+++ b/src/components/file-browser/FilesInDirectory.ts
@@ -1,13 +1,16 @@
 import { Dispatch, Fragment, SetStateAction, useEffect, useRef } from 'react'
 import { div, h, p, span } from 'react-hyperscript-helpers'
 import { Link } from 'src/components/common'
+import Dropzone from 'src/components/Dropzone'
 import { useFilesInDirectory } from 'src/components/file-browser/file-browser-hooks'
 import { basename } from 'src/components/file-browser/file-browser-utils'
 import { FilesMenu } from 'src/components/file-browser/FilesMenu'
 import FilesTable from 'src/components/file-browser/FilesTable'
 import { icon } from 'src/components/icons'
+import { UploadProgressModal } from 'src/components/ProgressBar'
 import FileBrowserProvider, { FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
 import colors from 'src/libs/colors'
+import { useUploader } from 'src/libs/uploads'
 import * as Utils from 'src/libs/utils'
 
 
@@ -46,6 +49,10 @@ const FilesInDirectory = (props: FilesInDirectoryProps) => {
     reload,
   } = useFilesInDirectory(provider, path)
 
+  const { uploadState, uploadFiles, cancelUpload } = useUploader(file => {
+    return provider.uploadFileToDirectory(path, file)
+  })
+
   const isLoading = status === 'Loading'
 
   useEffect(() => {
@@ -63,80 +70,99 @@ const FilesInDirectory = (props: FilesInDirectoryProps) => {
       flex: '1 0 0'
     }
   }, [
-    h(FilesMenu, {
-      disabled: editDisabled,
-      disabledReason: editDisabledReason,
-      provider,
-      selectedFiles,
-      onDeleteFiles: () => {
-        setSelectedFiles({})
+    h(Dropzone, {
+      disabled: editDisabled || uploadState.active,
+      style: { display: 'flex', flexFlow: 'column nowrap', height: '100%' },
+      activeStyle: { backgroundColor: colors.accent(0.2), cursor: 'copy' },
+      multiple: true,
+      maxFiles: 0, // no limit on number of files
+      onDropAccepted: async files => {
+        await uploadFiles(files)
         reload()
-      },
-    }),
-
-    span({
-      ref: loadedAlertElementRef,
-      'aria-live': 'polite',
-      className: 'sr-only',
-      role: 'alert',
-    }),
-    status === 'Loading' && span({
-      'aria-live': 'assertive',
-      className: 'sr-only',
-      role: 'alert',
-    }, [`Loading files in ${directoryLabel}`]),
-    files.length > 0 && h(Fragment, [
-      h(FilesTable, {
-        'aria-label': `Files in ${directoryLabel}`,
-        files,
+      }
+      // @ts-expect-error
+    }, [({ openUploader }) => h(Fragment, [
+      h(FilesMenu, {
+        disabled: editDisabled,
+        disabledReason: editDisabledReason,
+        provider,
         selectedFiles,
-        setSelectedFiles,
-        onClickFile
+        onClickUpload: openUploader,
+        onDeleteFiles: () => {
+          setSelectedFiles({})
+          reload()
+        },
       }),
-      div({
+
+      span({
+        ref: loadedAlertElementRef,
+        'aria-live': 'polite',
+        className: 'sr-only',
+        role: 'alert',
+      }),
+      status === 'Loading' && span({
+        'aria-live': 'assertive',
+        className: 'sr-only',
+        role: 'alert',
+      }, [`Loading files in ${directoryLabel}`]),
+
+      files.length > 0 && h(Fragment, [
+        h(FilesTable, {
+          'aria-label': `Files in ${directoryLabel}`,
+          files,
+          selectedFiles,
+          setSelectedFiles,
+          onClickFile
+        }),
+        div({
+          style: {
+            display: 'flex',
+            justifyContent: 'space-between',
+            padding: '1rem',
+            borderTop: `1px solid ${colors.dark(0.2)}`,
+            background: '#fff'
+          }
+        }, [
+          div([
+            `${files.length} files `,
+            isLoading && h(Fragment, [
+              'Loading more... ',
+              icon('loadingSpinner', { size: 12 })
+            ])
+          ]),
+          hasNextPage !== false && div([
+            h(Link, {
+              disabled: isLoading,
+              style: { marginLeft: '1ch' },
+              onClick: () => loadNextPage()
+            }, ['Load next page']),
+            h(Link, {
+              disabled: isLoading,
+              style: { marginLeft: '1ch' },
+              tooltip: 'This may take a long time for folders containing several thousand objects.',
+              onClick: () => loadAllRemainingItems()
+            }, ['Load all'])
+          ])
+        ])
+      ]),
+      files.length === 0 && p({
         style: {
-          display: 'flex',
-          justifyContent: 'space-between',
-          padding: '1rem',
-          borderTop: `1px solid ${colors.dark(0.2)}`,
-          background: '#fff'
+          marginTop: '1rem',
+          fontStyle: 'italic',
+          textAlign: 'center',
         }
       }, [
-        div([
-          `${files.length} files `,
-          isLoading && h(Fragment, [
-            'Loading more... ',
-            icon('loadingSpinner', { size: 12 })
-          ])
-        ]),
-        hasNextPage !== false && div([
-          h(Link, {
-            disabled: isLoading,
-            style: { marginLeft: '1ch' },
-            onClick: () => loadNextPage()
-          }, ['Load next page']),
-          h(Link, {
-            disabled: isLoading,
-            style: { marginLeft: '1ch' },
-            tooltip: 'This may take a long time for folders containing several thousand objects.',
-            onClick: () => loadAllRemainingItems()
-          }, ['Load all'])
-        ])
+        Utils.cond(
+          [status === 'Loading', () => 'Loading files...'],
+          [status === 'Error', () => 'Unable to load files'],
+          () => 'No files have been uploaded yet'
+        )
       ])
-    ]),
-    files.length === 0 && p({
-      style: {
-        marginTop: '1rem',
-        fontStyle: 'italic',
-        textAlign: 'center',
-      }
-    }, [
-      Utils.cond(
-        [status === 'Loading', () => 'Loading files...'],
-        [status === 'Error', () => 'Unable to load files'],
-        () => 'No files have been uploaded yet'
-      )
-    ])
+    ])]),
+    uploadState.active && h(UploadProgressModal, {
+      status: uploadState,
+      abort: cancelUpload
+    }),
   ])
 }
 

--- a/src/components/file-browser/FilesMenu.test.ts
+++ b/src/components/file-browser/FilesMenu.test.ts
@@ -52,6 +52,7 @@ describe('FilesMenu', () => {
       render(h(FilesMenu, {
         provider: mockProvider,
         selectedFiles,
+        onClickUpload: () => {},
         onDeleteFiles,
       }))
 

--- a/src/components/file-browser/FilesMenu.ts
+++ b/src/components/file-browser/FilesMenu.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp'
 import { useState } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
-import { Link, topSpinnerOverlay } from 'src/components/common'
+import { ButtonPrimary, Link, topSpinnerOverlay } from 'src/components/common'
 import { DeleteFilesConfirmationModal } from 'src/components/file-browser/DeleteFilesConfirmationModal'
 import { icon } from 'src/components/icons'
 import FileBrowserProvider, { FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
@@ -15,6 +15,7 @@ interface FilesMenuProps {
   disabledReason?: string
   provider: FileBrowserProvider
   selectedFiles: { [path: string]: FileBrowserFile }
+  onClickUpload: () => void
   onDeleteFiles: () => void
 }
 
@@ -24,6 +25,7 @@ export const FilesMenu = (props: FilesMenuProps) => {
     disabledReason = 'Unable to edit files',
     provider,
     selectedFiles,
+    onClickUpload,
     onDeleteFiles,
   } = props
 
@@ -43,6 +45,18 @@ export const FilesMenu = (props: FilesMenuProps) => {
       backgroundColor: colors.light(0.4),
     },
   }, [
+    h(ButtonPrimary, {
+      disabled,
+      tooltip: disabled ? disabledReason : undefined,
+      style: { padding: '0.5rem', marginRight: '0.5rem' },
+      onClick: onClickUpload
+    }, [icon('upload-cloud', {
+      // @ts-expect-error
+      style: {
+        marginRight: '1ch',
+      },
+    }), ' Upload']),
+
     h(Link, {
       disabled: disabled || !hasSelectedFiles,
       tooltip: Utils.cond(

--- a/src/libs/ajax/GoogleStorage.ts
+++ b/src/libs/ajax/GoogleStorage.ts
@@ -213,8 +213,8 @@ export const GoogleStorage = (signal?: AbortSignal) => ({
     )
   },
 
-  upload: async (googleProject, bucket, prefix, file) => {
-    return fetchBuckets(
+  upload: async (googleProject: string, bucket: string, prefix: string, file: File): Promise<void> => {
+    await fetchBuckets(
       `upload/storage/v1/b/${bucket}/o?uploadType=media&name=${encodeURIComponent(prefix + file.name)}`,
       _.merge(authOpts(await saToken(googleProject)), {
         signal, method: 'POST', body: file,

--- a/src/libs/ajax/file-browser-providers/FileBrowserProvider.ts
+++ b/src/libs/ajax/file-browser-providers/FileBrowserProvider.ts
@@ -17,6 +17,7 @@ interface FileBrowserProvider {
   getDirectoriesInDirectory(path: string, options?: { signal?: AbortSignal }): Promise<IncrementalResponse<FileBrowserDirectory>>
   getFilesInDirectory(path: string, options?: { signal?: AbortSignal }): Promise<IncrementalResponse<FileBrowserFile>>
 
+  uploadFileToDirectory(directoryPath: string, file: File): Promise<void>
   deleteFile(path: string): Promise<void>
 }
 

--- a/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.test.ts
+++ b/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.test.ts
@@ -142,6 +142,24 @@ describe('GCSFileBrowserProvider', () => {
     expect(numGCSRequestsAfterSecondResponse).toBe(3)
   })
 
+  it('uploads a file', async () => {
+    // Arrange
+    const upload = jest.fn(() => Promise.resolve())
+    asMockedFn(Ajax).mockImplementation(() => ({
+      Buckets: { upload } as Partial<GoogleStorageContract>
+    }) as ReturnType<typeof Ajax>)
+
+    const testFile = new File(['somecontent'], 'example.txt', { type: 'text/text' })
+
+    const provider = GCSFileBrowserProvider({ bucket: 'test-bucket', project: 'test-project' })
+
+    // Act
+    await provider.uploadFileToDirectory('path/to/directory/', testFile)
+
+    // Assert
+    expect(upload).toHaveBeenCalledWith('test-project', 'test-bucket', 'path/to/directory/', testFile)
+  })
+
   it('deletes files', async () => {
     // Arrange
     const del = jest.fn(() => Promise.resolve())

--- a/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.ts
+++ b/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.ts
@@ -100,6 +100,9 @@ const GCSFileBrowserProvider = ({ bucket, project, pageSize = 1000 }: GCSFileBro
       prefix: path,
       signal
     }),
+    uploadFileToDirectory: (directoryPath, file) => {
+      return Ajax().Buckets.upload(project, bucket, directoryPath, file)
+    },
     deleteFile: async (path: string): Promise<void> => {
       await Ajax().Buckets.delete(project, bucket, path)
     },


### PR DESCRIPTION
Allow uploading files in the new file browser either via the upload button or by dragging a file into the list.

![Screen Shot 2022-12-06 at 9 31 30 AM](https://user-images.githubusercontent.com/1156625/205939619-d3adf54b-492e-4e70-8858-72a2363346be.png)

Enable the new file browser from the feature preview page (`/#feature-preview`) and open it from the right sidebar within a workspace.