### PR TITLE
[IA-3676] [IA-3884] Add user input timeout for legacy and custom images.

### DIFF
--- a/src/pages/workspaces/workspace/analysis/modals/ComputeModal.js
+++ b/src/pages/workspaces/workspace/analysis/modals/ComputeModal.js
@@ -874,6 +874,7 @@ export const ComputeModalBase = ({
         ]),
         div({ style: { display: 'grid', alignItems: 'center', gridGap: '0.7rem', gridTemplateColumns: '4.5rem 9.5rem', marginTop: '0.75rem' } }, [
           h(NumberInput, {
+              id,
               min: 10,
               max: 45,
               isClearable: false,

--- a/src/pages/workspaces/workspace/analysis/modals/ComputeModal.js
+++ b/src/pages/workspaces/workspace/analysis/modals/ComputeModal.js
@@ -192,7 +192,7 @@ export const ComputeModalBase = ({
   const [simplifiedForm, setSimplifiedForm] = useState(!currentRuntimeDetails)
   const [leoImages, setLeoImages] = useState([])
   const [selectedLeoImage, setSelectedLeoImage] = useState(undefined)
-  const [timeoutInMinutes, setTimeoutInMinutes] = useState(undefined)
+  const [timeoutInMinutes, setTimeoutInMinutes] = useState(null)
   const [customEnvImage, setCustomEnvImage] = useState('')
   const [jupyterUserScriptUri, setJupyterUserScriptUri] = useState('')
   const [runtimeType, setRuntimeType] = useState(runtimeTypes.gceVm)
@@ -1576,8 +1576,7 @@ export const ComputeModalBase = ({
           [Utils.DEFAULT, () => runtimeTypes.gceVm]
         )
         setSelectedLeoImage(value)
-        //TODO: Is this the best way to "un-set"?
-        setTimeoutInMinutes(supportedImages.includes(value) ? undefined : timeoutInMinutes)
+        setTimeoutInMinutes(supportedImages.includes(value) ? null : timeoutInMinutes)
         setCustomEnvImage('')
         setRuntimeType(newRuntimeType)
         updateComputeConfig('componentGatewayEnabled', isDataproc(newRuntimeType))

--- a/src/pages/workspaces/workspace/analysis/modals/ComputeModal.js
+++ b/src/pages/workspaces/workspace/analysis/modals/ComputeModal.js
@@ -329,11 +329,11 @@ export const ComputeModalBase = ({
         }
 
         const createRuntimeConfig = { ...runtimeConfig, ...diskConfig }
-
         await Ajax().Runtimes.runtime(googleProject, Utils.generateRuntimeName()).create({
           runtimeConfig: createRuntimeConfig,
           autopauseThreshold: computeConfig.autopauseThreshold,
           toolDockerImage: desiredRuntime.toolDockerImage,
+          timeoutInMinutes,
           labels: {
             saturnWorkspaceNamespace: namespace,
             saturnWorkspaceName: name

--- a/src/pages/workspaces/workspace/analysis/modals/ComputeModal.js
+++ b/src/pages/workspaces/workspace/analysis/modals/ComputeModal.js
@@ -867,22 +867,24 @@ export const ComputeModalBase = ({
       id => h(div, {}, [
         div({ style: { margin: '0.5rem 0' } }, [
           label({ htmlFor: id, style: { ...computeStyles.label } }, ['Creation Timeout Limit']),
-          h(InfoBox, { style: { marginLeft: '0.5rem' } }, ['Custom and legacy images may need extra time on create. Enter a value between 10 and 45 minutes.'])
+          h(InfoBox, { style: { marginLeft: '0.5rem' } }, [
+            'Custom and Legacy image creation may take longer than the default 10 minute timeout window. ' +
+            'To avoid an error, you may enter a value between 10 and 45 minutes.'
+          ])
         ]),
         div({ style: { display: 'grid', alignItems: 'center', gridGap: '0.7rem', gridTemplateColumns: '4.5rem 9.5rem', marginTop: '0.75rem' } }, [
           h(NumberInput, {
-                  min: 10,
-                  max: 45,
-                  isClearable: false,
-                  onlyInteger: true,
-                  value: timeoutInMinutes,
-                  placeholder: '10',
-                  onChange: value => setTimeoutInMinutes(value),
-                  'aria-label': 'Minutes of processing before failure'
-                }),
-                span('Minutes')
-              ]
-          )
+              min: 10,
+              max: 45,
+              isClearable: false,
+              onlyInteger: true,
+              value: timeoutInMinutes,
+              placeholder: '10',
+              onChange: value => setTimeoutInMinutes(value),
+              'aria-label': 'Minutes of processing before failure'
+            }),
+            span('Minutes')
+        ])
       ])
     ])
   }

--- a/src/pages/workspaces/workspace/analysis/modals/ComputeModal.js
+++ b/src/pages/workspaces/workspace/analysis/modals/ComputeModal.js
@@ -869,14 +869,14 @@ export const ComputeModalBase = ({
           label({ htmlFor: id, style: { ...computeStyles.label } }, ['Creation Timeout Limit']),
           h(InfoBox, { style: { marginLeft: '0.5rem' } }, [
             'Custom and Legacy image creation may take longer than the default 10 minute timeout window. ' +
-            'To avoid an error, you may enter a value between 10 and 45 minutes.'
+            'To avoid an error, you may enter a value between 10 and 30 minutes.'
           ])
         ]),
         div({ style: { display: 'grid', alignItems: 'center', gridGap: '0.7rem', gridTemplateColumns: '4.5rem 9.5rem', marginTop: '0.75rem' } }, [
           h(NumberInput, {
               id,
               min: 10,
-              max: 45,
+              max: 30,
               isClearable: false,
               onlyInteger: true,
               value: timeoutInMinutes,

--- a/src/pages/workspaces/workspace/analysis/modals/ComputeModal.js
+++ b/src/pages/workspaces/workspace/analysis/modals/ComputeModal.js
@@ -877,7 +877,7 @@ export const ComputeModalBase = ({
                   onlyInteger: true,
                   value: timeoutInMinutes,
                   placeholder: '10',
-                  onChange: value => setTimeoutInMinutes(value), //updateComputeConfig('autopauseThreshold'),
+                  onChange: value => setTimeoutInMinutes(value),
                   'aria-label': 'Minutes of processing before failure'
                 }),
                 span('Minutes')

--- a/src/pages/workspaces/workspace/analysis/modals/ComputeModal.test.js
+++ b/src/pages/workspaces/workspace/analysis/modals/ComputeModal.test.js
@@ -756,6 +756,9 @@ describe('ComputeModal', () => {
       const customImageUri = 'us'
       await fireEvent.change(imageInput, { target: { value: customImageUri } })
 
+      const customImageTimeoutLimit = await screen.findByText('Creation Timeout Limit')
+      expect(customImageTimeoutLimit).toBeInTheDocument()
+
       const nextButton = await screen.findByText('Next')
       verifyEnabled(nextButton)
       await userEvent.click(nextButton)

--- a/src/pages/workspaces/workspace/analysis/modals/ComputeModal.test.js
+++ b/src/pages/workspaces/workspace/analysis/modals/ComputeModal.test.js
@@ -756,8 +756,7 @@ describe('ComputeModal', () => {
       const customImageUri = 'us'
       await fireEvent.change(imageInput, { target: { value: customImageUri } })
 
-      const customImageTimeoutLimit = await screen.findByText('Creation Timeout Limit')
-      expect(customImageTimeoutLimit).toBeInTheDocument()
+      await screen.findByText('Creation Timeout Limit')
 
       const nextButton = await screen.findByText('Next')
       verifyEnabled(nextButton)
@@ -844,3 +843,13 @@ describe('ComputeModal', () => {
     }))
   })
 })
+
+// TODO: Write a test that does the following:
+// Render default compute modal
+// Verify timeoutInMinutes not in document
+// Select Legacy Image
+// Verify timeoutInMinutes is in document
+// Change value of timeoutInMinutes
+// Select default Image
+// Verify timeoutInMinutes is now null
+// Verify timeoutInMinutes no longer in document

--- a/src/pages/workspaces/workspace/analysis/modals/ComputeModal.test.js
+++ b/src/pages/workspaces/workspace/analysis/modals/ComputeModal.test.js
@@ -907,8 +907,8 @@ describe('ComputeModal', () => {
         await userEvent.click(screen.getByText('Customize'))
         const selectMenu = await screen.getByLabelText('Application configuration')
         await userEvent.click(selectMenu)
-        const selectOption = await screen.findByText('Custom Environment')
-        await userEvent.click(selectOption)
+        const customImageSelect = await screen.findByText('Custom Environment')
+        await userEvent.click(customImageSelect)
 
         await screen.findByText('Creation Timeout Limit')
         const timeoutInput = await screen.getByLabelText('Creation Timeout Limit')
@@ -944,7 +944,7 @@ describe('ComputeModal', () => {
   it.each([
     { runtimeTool: runtimeTools.Jupyter, imageLabel: defaultImage.label },
     { runtimeTool: runtimeTools.RStudio, imageLabel: defaultRImage.label }
-  ])('sends null timeout in minutes for tool $runtimeTool.label', async ({ runtimeTool, imageLabel }) => {
+  ])('sends null timeout in minutes  for tool $runtimeTool.label after setting and clearing the field', async ({ runtimeTool, imageLabel }) => {
     await act(async () => {
       // Arrange
       const createFunc = jest.fn()
@@ -966,15 +966,17 @@ describe('ComputeModal', () => {
         await userEvent.click(screen.getByText('Customize'))
         const selectMenu = await screen.getByLabelText('Application configuration')
         await userEvent.click(selectMenu)
-        const selectOption = await screen.findByText('Custom Environment')
-        await userEvent.click(selectOption)
+        const customImageSelect = await screen.findByText('Custom Environment')
+        await userEvent.click(customImageSelect)
 
         await screen.findByText('Creation Timeout Limit')
         const timeoutInput = await screen.getByLabelText('Creation Timeout Limit')
+        // Set the field to an arbitrary value
         await fireEvent.change(timeoutInput, { target: { value: 20 } })
         await userEvent.click(selectMenu)
-        const selectOption2 = await screen.findByText(imageLabel)
-        await userEvent.click(selectOption2)
+        const supportedImageSelect = await screen.findByText(imageLabel)
+        // Clear timeoutInput by selecting
+        await userEvent.click(supportedImageSelect)
       })
 
       // Act
@@ -985,6 +987,8 @@ describe('ComputeModal', () => {
 
       // Assert
       expect(createFunc).toHaveBeenCalledWith(expect.objectContaining({
+        // Verify that timeoutInMinutes is actually cleared by selecting
+        // a supported image.
         timeoutInMinutes: null
       }))
     })

--- a/src/pages/workspaces/workspace/analysis/modals/ComputeModal.test.js
+++ b/src/pages/workspaces/workspace/analysis/modals/ComputeModal.test.js
@@ -842,6 +842,131 @@ describe('ComputeModal', () => {
       })
     }))
   })
+
+  it('correctly renders and updates timeoutInMinutes', async () => {
+    await act(async () => {
+      // Arrange
+      const createFunc = jest.fn()
+      const runtimeFunc = jest.fn(() => ({
+        create: createFunc,
+        details: jest.fn()
+      }))
+      Ajax.mockImplementation(() => ({
+        ...defaultAjaxImpl,
+        Runtimes: {
+          runtime: runtimeFunc
+        }
+      }))
+      await render(h(ComputeModalBase, defaultModalProps))
+
+      // Act
+      await userEvent.click(screen.getByText('Customize'))
+      const selectMenu = await screen.getByLabelText('Application configuration')
+      await userEvent.click(selectMenu)
+      const selectOption = await screen.findByText(/Legacy GATK:/)
+      await userEvent.click(selectOption)
+
+      await screen.findByText('Creation Timeout Limit')
+      const timeoutInput = await screen.getByLabelText('Creation Timeout Limit')
+      await fireEvent.change(timeoutInput, { target: { value: 20 } })
+
+      //Assert
+      expect(timeoutInput.value).toBe('20')
+
+      //Act
+      await userEvent.click(selectMenu)
+      const selectOption2 = await screen.findByText(defaultImage.label)
+      await userEvent.click(selectOption2)
+      // Assert
+      expect(timeoutInput).not.toBeVisible()
+    })
+  })
+
+  it('correctly sends timeoutInMinutes to create', async () => {
+    await act(async () => {
+      // Arrange
+      const createFunc = jest.fn()
+      const runtimeFunc = jest.fn(() => ({
+        create: createFunc,
+        details: jest.fn()
+      }))
+      Ajax.mockImplementation(() => ({
+        ...defaultAjaxImpl,
+        Runtimes: {
+          runtime: runtimeFunc
+        }
+      }))
+      await render(h(ComputeModalBase, defaultModalProps))
+
+      // Act
+      await act(async () => {
+        await userEvent.click(screen.getByText('Customize'))
+        const selectMenu = await screen.getByLabelText('Application configuration')
+        await userEvent.click(selectMenu)
+        const selectOption = await screen.findByText(/Legacy GATK:/)
+        await userEvent.click(selectOption)
+
+        await screen.findByText('Creation Timeout Limit')
+        const timeoutInput = await screen.getByLabelText('Creation Timeout Limit')
+        await fireEvent.change(timeoutInput, { target: { value: 20 } })
+      })
+
+      // Act
+      await act(async () => {
+        const create = screen.getByText('Create')
+        await userEvent.click(create)
+      })
+
+      // Assert
+      expect(createFunc).toHaveBeenCalledWith(expect.objectContaining({
+        timeoutInMinutes: 20
+      }))
+    })
+  })
+
+  it('correctly sends null timeoutInMinutes to runtime create', async () => {
+    await act(async () => {
+      // Arrange
+      const createFunc = jest.fn()
+      const runtimeFunc = jest.fn(() => ({
+        create: createFunc,
+        details: jest.fn()
+      }))
+      Ajax.mockImplementation(() => ({
+        ...defaultAjaxImpl,
+        Runtimes: {
+          runtime: runtimeFunc
+        }
+      }))
+      await act(async () => {
+        await render(h(ComputeModalBase, defaultModalProps))
+
+        await userEvent.click(screen.getByText('Customize'))
+        const selectMenu = await screen.getByLabelText('Application configuration')
+        await userEvent.click(selectMenu)
+        const selectOption = await screen.findByText(/Legacy GATK:/)
+        await userEvent.click(selectOption)
+
+        await screen.findByText('Creation Timeout Limit')
+        const timeoutInput = await screen.getByLabelText('Creation Timeout Limit')
+        await fireEvent.change(timeoutInput, { target: { value: 20 } })
+        await userEvent.click(selectMenu)
+        const selectOption2 = await screen.findByText(defaultImage.label)
+        await userEvent.click(selectOption2)
+      })
+
+      // Act
+      await act(async () => {
+        const create = screen.getByText('Create')
+        await userEvent.click(create)
+      })
+
+      // Assert
+      expect(createFunc).toHaveBeenCalledWith(expect.objectContaining({
+        timeoutInMinutes: null
+      }))
+    })
+  })
 })
 
 // TODO: Write a test that does the following:

--- a/src/pages/workspaces/workspace/analysis/tool-utils.ts
+++ b/src/pages/workspaces/workspace/analysis/tool-utils.ts
@@ -45,6 +45,10 @@ export interface AppTool extends Tool {
   appType: string
 }
 
+export const terraSupportedRuntimeImageIds: string[] = [
+  'terra-jupyter-bioconductor', 'terra-jupyter-hail', 'terra-jupyter-python', 'terra-jupyter-gatk', 'RStudio'
+]
+
 const RStudio: RuntimeTool = { label: toolLabels.RStudio, ext: ['Rmd', 'R'] as Extension[], imageIds: ['RStudio'], defaultImageId: 'RStudio', defaultExt: 'Rmd' as Extension }
 
 const Jupyter: RuntimeTool = {


### PR DESCRIPTION
Ticket:
https://broadworkbench.atlassian.net/browse/IA-3676

Sub Task:
https://broadworkbench.atlassian.net/browse/IA-3884

Dependency is merged:
Depends on: https://broadworkbench.atlassian.net/browse/IA-3885 is complete.

This ticket adds a new const in tool-utils that defines our cached + supported imageIds. Using this list, we can show and hide the new NumberInput for users to input a custom timeout.
![Screen Shot 2022-12-06 at 11 13 45 AM](https://user-images.githubusercontent.com/11773357/206005335-13a73d4e-afdb-4473-a0b2-c5752cdf149f.png)
![Screen Shot 2022-12-06 at 11 19 05 AM](https://user-images.githubusercontent.com/11773357/206005339-14f64f88-30fb-46c9-8aed-4f20e47f805e.png)


<!---
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Also, so if a screen recording [1] and/or screenshots would be a helpful way to communicate context, please consider including some in your PR description.
Thanks!

[1] https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac
-->
