### PR TITLE
[SUP-613] Align CSP in meta tag with CSP in header

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -15,9 +15,9 @@ module.exports = {
         }
       ]),
       addWebpackPlugin(new CspHtmlWebpackPlugin({
-        // Per our security policy, 'script-src' cannot contain any of the options containing 'unsafe', e.g. 'unsafe-inline'
         'script-src': [
           '\'self\'',
+          '\'unsafe-eval\'',
           'https://fast.appcues.com', // secondary script loaded by appcues
           'https://us.jsagent.tcell.insight.rapid7.com', // secondary script loaded by tcell
           'https://cdnjs.cloudflare.com' // libraries loaded by notebook preview


### PR DESCRIPTION
IGV.js (by way of `@gmod/cram` and `@gmod/binary-parser`) uses `eval` to parse CRAM files. Terra UI's current [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) blocks the use of `eval`. This causes users to get an "error loading track data" error when trying to view CRAM files in IGV.

This can be seen in this featured workspace: https://app.terra.bio/#workspaces/help-gatk/GATK-Structural-Variants-Single-Sample/data
Select the row in the data table, open in IGV, select the CRAM file, then zoom in on chr1:34,000.

IGV shows an error:
> Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'self' https://fast.appcues.com https://us.jsagent.tcell.insight.rapid7.com https://cdnjs.cloudflare.com 'nonce-WICAggNFFTj1DfjxcaKPrg==' 'nonce-0cJYlDZSKTcV4fWCud4wVQ=='"

#3472 updated the Content Security Policy header, but there is also a meta tag containing a Content Security Policy, which is still causing this error. This adds "unsafe-eval" to the CSP in the meta tag.
