### PR TITLE
Disable preview-drs-uri test

### DIFF
--- a/integration-tests/tests/preview-drs-uri.js
+++ b/integration-tests/tests/preview-drs-uri.js
@@ -40,5 +40,6 @@ const testPreviewDrsUriFn = _.flow(
 
 registerTest({
   name: 'preview-drs-uri',
-  fn: testPreviewDrsUriFn
+  fn: testPreviewDrsUriFn,
+  targetEnvironments: [],
 })


### PR DESCRIPTION
This test is consistently failing. Disable it to prevent blocking PRs while investigation continues.

See threads in Slack:
- https://broadinstitute.slack.com/archives/C01EHNUM73R/p1670363515390639
- https://broadinstitute.slack.com/archives/CD4HBRFMG/p1670435840581779