### PR TITLE
[AJ-755] disable run-workflow-on-snapshot test

### DIFF
--- a/integration-tests/tests/run-workflow-on-snapshot.js
+++ b/integration-tests/tests/run-workflow-on-snapshot.js
@@ -78,5 +78,6 @@ const testRunWorkflowOnSnapshotFn = _.flow(
 registerTest({
   name: 'run-workflow-on-snapshot',
   fn: testRunWorkflowOnSnapshotFn,
-  timeout: 20 * 60 * 1000
+  timeout: 20 * 60 * 1000,
+  targetEnvironments: [],
 })


### PR DESCRIPTION
Current hypothesis is this test is failing due to a race condition in which GCP does not propagate the `bigquery.jobs.create` permission by the time this test tries to use it.

If that hypothesis is true, the fix is to refactor this test to validate the permission exists before trying to use it. That refactor will take some time; meanwhile, this test is consistently blocking PRs.

The feature under test - running workflows on snapshot-by-reference - is only used by a handful of internal users. The ability to add a snapshot-by-reference to your workspace is not exposed in the UI; users must know of its existence and make manual API calls to enable it. Disabling this test does not lower our coverage by a significant amount.