### PR TITLE
Don't emit public because it isn't consistently populated (WOR-114).

### DIFF
--- a/src/components/NewWorkspaceModal.js
+++ b/src/components/NewWorkspaceModal.js
@@ -118,7 +118,6 @@ const NewWorkspaceModal = withDisplayName('NewWorkspaceModal', ({
           const workspace = await Ajax().Workspaces.workspace(cloneWorkspace.workspace.namespace, cloneWorkspace.workspace.name).clone(body)
           const featuredList = await Ajax().FirecloudBucket.getFeaturedWorkspaces()
           Ajax().Metrics.captureEvent(Events.workspaceClone, {
-            public: cloneWorkspace.public,
             featured: _.some({ namespace: cloneWorkspace.workspace.namespace, name: cloneWorkspace.workspace.name }, featuredList),
             fromWorkspaceName: cloneWorkspace.workspace.name, fromWorkspaceNamespace: cloneWorkspace.workspace.namespace,
             toWorkspaceName: workspace.name, toWorkspaceNamespace: workspace.namespace


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-114

The issue here is that whether or not we know if a workspace is “public” depends on where it was cloned from. If you clone a workspace from the list of workspaces, the public attribute will be present. However, if you open a workspace and clone it from the details page, the public attribute is not present, and the MixPanel event will be fired with “public” absent (in the JavaScript object it is undefined, but this gets filtered out in the conversion to JSON). Apparently MixPanel lumps “public” being missing into the same bucket as it being false.

In the future, we could choose to add "public" to the Workspace details response so that it is always available. But until that is requested and prioritized, let's stop emitting a metric that is incorrect.
