### PR TITLE
[SU-249] Add file details modal

### DIFF
--- a/src/components/file-browser/FileBrowser.ts
+++ b/src/components/file-browser/FileBrowser.ts
@@ -1,9 +1,11 @@
 import { Fragment, useEffect, useState } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
 import DirectoryTree from 'src/components/file-browser/DirectoryTree'
+import { basename } from 'src/components/file-browser/file-browser-utils'
+import { FileDetails } from 'src/components/file-browser/FileDetails'
 import FilesInDirectory from 'src/components/file-browser/FilesInDirectory'
 import PathBreadcrumbs from 'src/components/file-browser/PathBreadcrumbs'
-import UriViewer from 'src/components/UriViewer'
+import Modal from 'src/components/Modal'
 import FileBrowserProvider, { FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
 import colors from 'src/libs/colors'
 import * as Utils from 'src/libs/utils'
@@ -99,11 +101,14 @@ const FileBrowser = ({ provider, title, workspace }: FileBrowserProps) => {
       ])
     ]),
 
-    focusedFile && h(UriViewer, {
-      workspace,
-      uri: focusedFile.url,
-      onDismiss: () => setFocusedFile(null)
-    })
+    focusedFile && h(Modal, {
+      'aria-label': 'File details',
+      showCancel: false,
+      title: basename(focusedFile.path),
+      onDismiss: () => setFocusedFile(null),
+    }, [
+      h(FileDetails, { file: focusedFile })
+    ]),
   ])
 }
 

--- a/src/components/file-browser/FileDetails.test.ts
+++ b/src/components/file-browser/FileDetails.test.ts
@@ -1,0 +1,31 @@
+import '@testing-library/jest-dom'
+
+import { render, screen } from '@testing-library/react'
+import { h } from 'react-hyperscript-helpers'
+import { FileDetails } from 'src/components/file-browser/FileDetails'
+import { FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
+
+
+describe('FileDetails', () => {
+  // Arrange
+  const file: FileBrowserFile = {
+    path: 'path/to/example.txt',
+    url: 'gs://test-bucket/path/to/example.txt',
+    size: 1024 ** 2,
+    createdAt: 1667408400000,
+    updatedAt: 1667494800000,
+  }
+
+  it.each([
+    { field: 'Last modified', expected: '11/3/2022, 5:00:00 PM' },
+    { field: 'Created', expected: '11/2/2022, 5:00:00 PM' },
+    { field: 'Size', expected: '1 MB' },
+  ])('renders $field', ({ field, expected }) => {
+    // Act
+    render(h(FileDetails, { file }))
+
+    // Assert
+    const renderedValue = screen.getByText(field).parentElement!.lastElementChild!.textContent!
+    expect(renderedValue).toBe(expected)
+  })
+})

--- a/src/components/file-browser/FileDetails.ts
+++ b/src/components/file-browser/FileDetails.ts
@@ -1,5 +1,6 @@
 import filesize from 'filesize'
-import { dd, div, dl, dt } from 'react-hyperscript-helpers'
+import { Fragment } from 'react'
+import { dd, div, dl, dt, h } from 'react-hyperscript-helpers'
 import { FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
 
 
@@ -10,10 +11,7 @@ interface FileDetailsProps {
 export const FileDetails = (props: FileDetailsProps) => {
   const { file } = props
 
-  return div({
-    style: {
-    }
-  }, [
+  return h(Fragment, [
     dl([
       div({ style: { marginBottom: '0.5rem' } }, [
         dt({ style: { marginBottom: '0.25rem', fontWeight: 500 } }, ['Last modified']),

--- a/src/components/file-browser/FileDetails.ts
+++ b/src/components/file-browser/FileDetails.ts
@@ -1,0 +1,32 @@
+import filesize from 'filesize'
+import { dd, div, dl, dt } from 'react-hyperscript-helpers'
+import { FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
+
+
+interface FileDetailsProps {
+  file: FileBrowserFile
+}
+
+export const FileDetails = (props: FileDetailsProps) => {
+  const { file } = props
+
+  return div({
+    style: {
+    }
+  }, [
+    dl([
+      div({ style: { marginBottom: '0.5rem' } }, [
+        dt({ style: { marginBottom: '0.25rem', fontWeight: 500 } }, ['Last modified']),
+        dd({ style: { marginLeft: '0.5rem' } }, [new Date(file.updatedAt).toLocaleString()]),
+      ]),
+      div({ style: { marginBottom: '0.5rem' } }, [
+        dt({ style: { marginBottom: '0.25rem', fontWeight: 500 } }, ['Created']),
+        dd({ style: { marginLeft: '0.5rem' } }, [new Date(file.createdAt).toLocaleString()]),
+      ]),
+      div({ style: { marginBottom: '0.5rem' } }, [
+        dt({ style: { marginBottom: '0.25rem', fontWeight: 500 } }, ['Size']),
+        dd({ style: { marginLeft: '0.5rem' } }, [filesize(file.size)]),
+      ]),
+    ])
+  ])
+}


### PR DESCRIPTION
Currently, when a file is clicked in the new file browser, it shows the same UriViewer modal that is used in the current file browser and data tables. However, UriViewer supports GCS and DRS URLs. For the new file browser, we want something that supports files in GCS and Azure Storage. This adds a new FileDetails modal that displays a few pieces of metadata (file size, create/modified date) about the selected file. Other features, such as downloading and previewing the file, will be added in following PRs.