### PR TITLE
[DC-596] Remove project field from normalized datasets

### DIFF
--- a/src/pages/library/DataBrowser.js
+++ b/src/pages/library/DataBrowser.js
@@ -10,7 +10,7 @@ import Events from 'src/libs/events'
 import * as Nav from 'src/libs/nav'
 import * as Utils from 'src/libs/utils'
 import { commonStyles, SearchAndFilterComponent } from 'src/pages/library/common'
-import { datasetAccessTypes, datasetReleasePolicies, useDataCatalog } from 'src/pages/library/dataBrowser-utils'
+import { datasetAccessTypes, datasetReleasePolicies, renderConsortium, useDataCatalog } from 'src/pages/library/dataBrowser-utils'
 import { RequestDatasetAccessModal } from 'src/pages/library/RequestDatasetAccessModal'
 
 
@@ -52,7 +52,10 @@ const extractCatalogFilters = dataCatalog => {
     }
   }, {
     name: 'Consortium',
-    labels: getUnique('project', dataCatalog)
+    labels: getUnique('dct:title', _.flow(
+      _.flatMap(dataset => dataset['TerraDCAT_ap:hasDataCollection']),
+      _.compact,
+    )(dataCatalog))
   }, {
     name: 'Data use policy',
     labels: getUnique('dataReleasePolicy.policy', dataCatalog),
@@ -84,7 +87,7 @@ const extractCatalogFilters = dataCatalog => {
 // All possible columns for the catalog's table view. The default columns shown are declared below in `Browser`.
 const allColumns = {
   // A column is a key, title and a function that produces the table contents for that column, given a row.
-  project: { title: 'Consortium', contents: row => row.project },
+  consortiums: { title: 'Consortiums', contents: row => renderConsortium(row) },
   subjects: { title: 'No. of Subjects', contents: row => row?.counts?.donors },
   dataModality: { title: 'Data Modality', contents: row => _.join(', ', row.dataModality) },
   lastUpdated: { title: 'Last Updated', contents: row => row.lastUpdated ? Utils.makeStandardDate(row.lastUpdated) : null },
@@ -191,7 +194,7 @@ export const Browser = () => {
   const [sort, setSort] = useState({ field: 'created', direction: 'desc' })
   // This state contains the current set of visible columns, in the order that they appear.
   // Note that the Dataset Name column isn't customizable and is always shown first.
-  const [cols, setCols] = useState(['project', 'subjects', 'dataModality', 'lastUpdated'])
+  const [cols, setCols] = useState(['consortiums', 'subjects', 'dataModality', 'lastUpdated'])
   const [requestDatasetAccessList, setRequestDatasetAccessList] = useState()
   const { dataCatalog, loading } = useDataCatalog()
 

--- a/src/pages/library/DataBrowser.js
+++ b/src/pages/library/DataBrowser.js
@@ -30,8 +30,8 @@ const styles = {
   }
 }
 
-const getUnique = (mapMethod, data) => _.flow(
-  _.flatMap(mapMethod),
+const getUnique = (mapper, data) => _.flow(
+  _.flatMap(mapper),
   _.compact,
   _.uniq,
   _.sortBy(_.toLower)
@@ -55,7 +55,7 @@ const extractCatalogFilters = dataCatalog => {
     labels: getUnique(dataset => getConsortiumsFromDataset(dataset), dataCatalog)
   }, {
     name: 'Data use policy',
-    labels: getUnique(dataset => dataset.dataReleasePolicy.policy, dataCatalog),
+    labels: getUnique('dataReleasePolicy.policy', dataCatalog),
     labelRenderer: rawPolicy => {
       const { label, desc } = datasetReleasePolicies[rawPolicy] || datasetReleasePolicies.releasepolicy_other
       return [div({ key: rawPolicy, style: { display: 'flex', flexDirection: 'column' } }, [
@@ -65,22 +65,19 @@ const extractCatalogFilters = dataCatalog => {
     }
   }, {
     name: 'Data modality',
-    labels: getUnique(dataset => dataset.dataModality, dataCatalog)
+    labels: getUnique('dataModality', dataCatalog)
   }, {
     name: 'Data type',
-    labels: getUnique(dataset => dataset.dataType, dataCatalog)
+    labels: getUnique('dataType', dataCatalog)
   }, {
     name: 'File type',
-    labels: getUnique(dataset => dataset['dcat:mediaType'], _.flow(
-      _.flatMap('files'),
-      _.compact
-    )(dataCatalog))
+    labels: getUnique('dcat:mediaType', _.flatMap('files', dataCatalog))
   }, {
     name: 'Disease',
-    labels: getUnique(dataset => dataset.samples?.disease, dataCatalog)
+    labels: getUnique('samples.disease', dataCatalog)
   }, {
     name: 'Species',
-    labels: getUnique(dataset => dataset.samples?.genus, dataCatalog)
+    labels: getUnique('samples.genus', dataCatalog)
   }]
 }
 
@@ -91,9 +88,9 @@ const allColumns = {
   subjects: { title: 'No. of Subjects', contents: row => row?.counts?.donors },
   dataModality: { title: 'Data Modality', contents: row => _.join(', ', row.dataModality) },
   lastUpdated: { title: 'Last Updated', contents: row => row.lastUpdated ? Utils.makeStandardDate(row.lastUpdated) : null },
-  dataType: { title: 'Data type', contents: row => _.join(', ', getUnique(row => row.dataType, { row })) },
-  fileType: { title: 'File type', contents: row => _.join(', ', getUnique(row => row['dcat:mediaType'], row['files'])) },
-  species: { title: 'Species', contents: row => _.join(', ', getUnique(row => row.samples?.genus, { row })) }
+  dataType: { title: 'Data type', contents: row => _.join(', ', getUnique('dataType', { row })) },
+  fileType: { title: 'File type', contents: row => _.join(', ', getUnique('dcat:mediaType', row['files'])) },
+  species: { title: 'Species', contents: row => _.join(', ', getUnique('samples.genus', { row })) }
 }
 
 // Columns are stored as a list of column key names in `cols` below. The column settings that the ColumnSelector dialog uses contains

--- a/src/pages/library/DataBrowser.js
+++ b/src/pages/library/DataBrowser.js
@@ -54,7 +54,7 @@ const extractCatalogFilters = dataCatalog => {
     name: 'Consortium',
     labels: getUnique('dct:title', _.flow(
       _.flatMap(dataset => dataset['TerraDCAT_ap:hasDataCollection']),
-      _.compact,
+      _.compact
     )(dataCatalog))
   }, {
     name: 'Data use policy',

--- a/src/pages/library/DataBrowser.test.js
+++ b/src/pages/library/DataBrowser.test.js
@@ -4,9 +4,9 @@ import {
 } from 'src/pages/library/DataBrowser'
 
 
-const settings = [{ name: 'Consortium', key: 'project', visible: true },
+const settings = [{ name: 'Consortiums', key: 'consortiums', visible: true },
   { name: 'Species', key: 'species', visible: false }]
-const cols = ['project']
+const cols = ['consortiums']
 
 describe('DataBrowser', () => {
   it('converts selected columns to settings', () => {

--- a/src/pages/library/Showcase.js
+++ b/src/pages/library/Showcase.js
@@ -112,7 +112,7 @@ const Showcase = () => {
   return h(FooterWrapper, { alwaysShow: true }, [
     libraryTopMatter('featured workspaces'),
     h(SearchAndFilterComponent, {
-      fullList, sidebarSections, nameField: 'name',
+      fullList, sidebarSections,
       searchType: 'Featured Workspaces',
       listView: filteredList => {
         return _.map(workspace => {

--- a/src/pages/library/Showcase.js
+++ b/src/pages/library/Showcase.js
@@ -112,7 +112,7 @@ const Showcase = () => {
   return h(FooterWrapper, { alwaysShow: true }, [
     libraryTopMatter('featured workspaces'),
     h(SearchAndFilterComponent, {
-      fullList, sidebarSections,
+      fullList, sidebarSections, nameField: 'name',
       searchType: 'Featured Workspaces',
       listView: filteredList => {
         return _.map(workspace => {

--- a/src/pages/library/common.js
+++ b/src/pages/library/common.js
@@ -44,10 +44,10 @@ const styles = {
   })
 }
 
-const groupByFeaturedTags = (workspaces, sidebarSections) => _.flow(
+const groupByFeaturedTags = (list, sidebarSections) => _.flow(
   _.flatMap(s => _.map(_.toLower, s.labels)),
   _.uniq,
-  _.map(tag => [tag, _.filter(w => _.includes(tag, w.tags?.items), workspaces)]),
+  _.map(tag => [tag, _.filter(listItem => _.includes(tag, listItem.tags?.items), list)]),
   _.fromPairs
 )(sidebarSections)
 

--- a/src/pages/library/dataBrowser-utils.js
+++ b/src/pages/library/dataBrowser-utils.js
@@ -115,7 +115,7 @@ const extractTags = dataset => {
     itemsType: 'AttributeValue',
     items: _.flow(_.flatten, _.toLower)([
       dataset.access,
-      dataset.project,
+      _.map('dct:title', dataset['TerraDCAT_ap:hasDataCollection']),
       dataset.samples?.genus,
       dataset.samples?.disease,
       dataset.dataType,

--- a/src/pages/library/dataBrowser-utils.js
+++ b/src/pages/library/dataBrowser-utils.js
@@ -56,6 +56,12 @@ export const isDatarepoSnapshot = dataset => {
   return _.toLower(dataset['dcat:accessURL']).includes(datarepoSnapshotUrlFragment)
 }
 
+export const renderConsortium = dataset => _.flow(
+  _.map(dataCollection => dataCollection['dct:title']),
+  _.join(', ')
+)(dataset['TerraDCAT_ap:hasDataCollection'])
+
+
 const normalizeDataset = dataset => {
   const contributors = _.map(_.update('contactName', _.flow(
     _.replace(/,+/g, ' '),
@@ -96,7 +102,6 @@ const normalizeDataset = dataset => {
   return {
     ...dataset,
     // TODO: Consortium should show all consortiums, not just the first
-    project: _.get(['TerraDCAT_ap:hasDataCollection', 0, 'dct:title'], dataset),
     lowerName: _.toLower(dataset['dct:title']), lowerDescription: _.toLower(dataset['dct:description']),
     lastUpdated: !!dataset['dct:modified'] && new Date(dataset['dct:modified']),
     dataReleasePolicy,

--- a/src/pages/library/dataBrowser-utils.js
+++ b/src/pages/library/dataBrowser-utils.js
@@ -101,7 +101,6 @@ const normalizeDataset = dataset => {
     () => datasetAccessTypes.CONTROLLED)
   return {
     ...dataset,
-    // TODO: Consortium should show all consortiums, not just the first
     lowerName: _.toLower(dataset['dct:title']), lowerDescription: _.toLower(dataset['dct:description']),
     lastUpdated: !!dataset['dct:modified'] && new Date(dataset['dct:modified']),
     dataReleasePolicy,

--- a/src/pages/library/dataBrowser-utils.js
+++ b/src/pages/library/dataBrowser-utils.js
@@ -56,10 +56,7 @@ export const isDatarepoSnapshot = dataset => {
   return _.toLower(dataset['dcat:accessURL']).includes(datarepoSnapshotUrlFragment)
 }
 
-export const renderConsortium = dataset => _.flow(
-  _.map(dataCollection => dataCollection['dct:title']),
-  _.join(', ')
-)(dataset['TerraDCAT_ap:hasDataCollection'])
+export const getConsortiumsFromDataset = dataset => _.map(dataCollection => dataCollection['dct:title'], dataset['TerraDCAT_ap:hasDataCollection'])
 
 
 const normalizeDataset = dataset => {


### PR DESCRIPTION
This removes the project field from `normalizeDataset` (reducing the number of added fields). It also tangentially fixes a bug where if a dataset has multiple consortiums, we would only render the first.

Filters aren't quite working yet.