### PR TITLE
[DC-608] remove policy field from normalize dataset

### DIFF
--- a/src/pages/library/DataBrowser.js
+++ b/src/pages/library/DataBrowser.js
@@ -11,7 +11,9 @@ import * as Nav from 'src/libs/nav'
 import * as Utils from 'src/libs/utils'
 import { commonStyles, SearchAndFilterComponent } from 'src/pages/library/common'
 import {
-  datasetAccessTypes, datasetReleasePolicies, getConsortiumsFromDataset, getDataReleasePolicyFromDataset, useDataCatalog
+  datasetAccessTypes, DatasetReleasePolicyDisplayInformation, getConsortiumsFromDataset,
+  getDatasetReleasePoliciesDisplayInformation,
+  useDataCatalog
 } from 'src/pages/library/dataBrowser-utils'
 import { RequestDatasetAccessModal } from 'src/pages/library/RequestDatasetAccessModal'
 
@@ -57,12 +59,10 @@ const extractCatalogFilters = dataCatalog => {
     labels: getUnique(dataset => getConsortiumsFromDataset(dataset), dataCatalog)
   }, {
     name: 'Data use policy',
-    labels: getUnique(dataset => getDataReleasePolicyFromDataset(dataset).policy, dataCatalog),
+    labels: getUnique(dataset => getDatasetReleasePoliciesDisplayInformation(dataset['TerraDCAT_ap:hasDataUsePermission']).label, dataCatalog),
     labelRenderer: rawPolicy => {
-      const { label, desc } = datasetReleasePolicies[rawPolicy] || datasetReleasePolicies.unknownReleasePolicy
       return [div({ key: rawPolicy, style: { display: 'flex', flexDirection: 'column' } }, [
-        label,
-        rawPolicy !== datasetReleasePolicies.unknownReleasePolicy.policy && div({ style: { fontSize: '0.625rem', lineHeight: '0.625rem' } }, [desc])
+        h(DatasetReleasePolicyDisplayInformation, { dataUsePermission: rawPolicy })
       ])]
     }
   }, {

--- a/src/pages/library/DataBrowser.js
+++ b/src/pages/library/DataBrowser.js
@@ -10,7 +10,9 @@ import Events from 'src/libs/events'
 import * as Nav from 'src/libs/nav'
 import * as Utils from 'src/libs/utils'
 import { commonStyles, SearchAndFilterComponent } from 'src/pages/library/common'
-import { datasetAccessTypes, datasetReleasePolicies, getConsortiumsFromDataset, useDataCatalog } from 'src/pages/library/dataBrowser-utils'
+import {
+  datasetAccessTypes, datasetReleasePolicies, getConsortiumsFromDataset, getDataReleasePolicyFromDataset, useDataCatalog
+} from 'src/pages/library/dataBrowser-utils'
 import { RequestDatasetAccessModal } from 'src/pages/library/RequestDatasetAccessModal'
 
 
@@ -55,12 +57,12 @@ const extractCatalogFilters = dataCatalog => {
     labels: getUnique(dataset => getConsortiumsFromDataset(dataset), dataCatalog)
   }, {
     name: 'Data use policy',
-    labels: getUnique('dataReleasePolicy.policy', dataCatalog),
+    labels: getUnique(dataset => getDataReleasePolicyFromDataset(dataset).policy, dataCatalog),
     labelRenderer: rawPolicy => {
-      const { label, desc } = datasetReleasePolicies[rawPolicy] || datasetReleasePolicies.releasepolicy_other
+      const { label, desc } = datasetReleasePolicies[rawPolicy] || datasetReleasePolicies.unknownReleasePolicy
       return [div({ key: rawPolicy, style: { display: 'flex', flexDirection: 'column' } }, [
-        label ? label : rawPolicy,
-        desc && div({ style: { fontSize: '0.625rem', lineHeight: '0.625rem' } }, [desc])
+        label,
+        rawPolicy !== datasetReleasePolicies.unknownReleasePolicy.policy && div({ style: { fontSize: '0.625rem', lineHeight: '0.625rem' } }, [desc])
       ])]
     }
   }, {

--- a/src/pages/library/DataBrowser.js
+++ b/src/pages/library/DataBrowser.js
@@ -12,7 +12,6 @@ import * as Utils from 'src/libs/utils'
 import { commonStyles, SearchAndFilterComponent } from 'src/pages/library/common'
 import {
   datasetAccessTypes, DatasetReleasePolicyDisplayInformation, getConsortiumsFromDataset,
-  getDatasetReleasePoliciesDisplayInformation,
   useDataCatalog
 } from 'src/pages/library/dataBrowser-utils'
 import { RequestDatasetAccessModal } from 'src/pages/library/RequestDatasetAccessModal'
@@ -59,7 +58,7 @@ const extractCatalogFilters = dataCatalog => {
     labels: getUnique(dataset => getConsortiumsFromDataset(dataset), dataCatalog)
   }, {
     name: 'Data use policy',
-    labels: getUnique(dataset => getDatasetReleasePoliciesDisplayInformation(dataset['TerraDCAT_ap:hasDataUsePermission']).label, dataCatalog),
+    labels: getUnique(dataset => dataset['TerraDCAT_ap:hasDataUsePermission'], dataCatalog),
     labelRenderer: rawPolicy => {
       return [div({ key: rawPolicy, style: { display: 'flex', flexDirection: 'column' } }, [
         h(DatasetReleasePolicyDisplayInformation, { dataUsePermission: rawPolicy })

--- a/src/pages/library/DataBrowserDetails.js
+++ b/src/pages/library/DataBrowserDetails.js
@@ -19,7 +19,7 @@ import { useCancellation, usePollingEffect } from 'src/libs/react-utils'
 import * as Utils from 'src/libs/utils'
 import { commonStyles } from 'src/pages/library/common'
 import {
-  datasetAccessTypes, isDatarepoSnapshot, isWorkspace, uiMessaging, useDataCatalog
+  datasetAccessTypes, datasetReleasePolicies, getDataReleasePolicyFromDataset, isDatarepoSnapshot, isWorkspace, uiMessaging, useDataCatalog
 } from 'src/pages/library/dataBrowser-utils'
 import { DataBrowserFeedbackModal } from 'src/pages/library/DataBrowserFeedbackModal'
 import { RequestDatasetAccessModal } from 'src/pages/library/RequestDatasetAccessModal'
@@ -48,8 +48,8 @@ const MetadataDetailsComponent = ({ dataObj, name }) => {
     div({ style: { display: 'flex', width: '100%', flexWrap: 'wrap' } }, [
       div({ style: styles.attributesColumn }, [
         h3({ style: styles.headers }, ['Data release policy']),
-        dataObj.dataReleasePolicy.label,
-        dataObj.dataReleasePolicy.desc && div({ style: { fontSize: '0.625rem', lineHeight: '0.625rem' } }, [dataObj.dataReleasePolicy.desc])
+        getDataReleasePolicyFromDataset(dataObj).label,
+        getDataReleasePolicyFromDataset(dataObj) !== datasetReleasePolicies.unknownReleasePolicy && getDataReleasePolicyFromDataset(dataObj).desc && div({ style: { fontSize: '0.625rem', lineHeight: '0.625rem' } }, [getDataReleasePolicyFromDataset(dataObj).desc])
       ]),
       div({ style: styles.attributesColumn }, [
         h3({ style: styles.headers }, ['Last Updated']),

--- a/src/pages/library/DataBrowserDetails.js
+++ b/src/pages/library/DataBrowserDetails.js
@@ -19,7 +19,8 @@ import { useCancellation, usePollingEffect } from 'src/libs/react-utils'
 import * as Utils from 'src/libs/utils'
 import { commonStyles } from 'src/pages/library/common'
 import {
-  datasetAccessTypes, datasetReleasePolicies, getDataReleasePolicyFromDataset, isDatarepoSnapshot, isWorkspace, uiMessaging, useDataCatalog
+  datasetAccessTypes, DatasetReleasePolicyDisplayInformation, isDatarepoSnapshot,
+  isWorkspace, uiMessaging, useDataCatalog
 } from 'src/pages/library/dataBrowser-utils'
 import { DataBrowserFeedbackModal } from 'src/pages/library/DataBrowserFeedbackModal'
 import { RequestDatasetAccessModal } from 'src/pages/library/RequestDatasetAccessModal'
@@ -48,8 +49,7 @@ const MetadataDetailsComponent = ({ dataObj, name }) => {
     div({ style: { display: 'flex', width: '100%', flexWrap: 'wrap' } }, [
       div({ style: styles.attributesColumn }, [
         h3({ style: styles.headers }, ['Data release policy']),
-        getDataReleasePolicyFromDataset(dataObj).label,
-        getDataReleasePolicyFromDataset(dataObj) !== datasetReleasePolicies.unknownReleasePolicy && getDataReleasePolicyFromDataset(dataObj).desc && div({ style: { fontSize: '0.625rem', lineHeight: '0.625rem' } }, [getDataReleasePolicyFromDataset(dataObj).desc])
+        h(DatasetReleasePolicyDisplayInformation, { dataUsePermission: dataObj['TerraDCAT_ap:hasDataUsePermission'] })
       ]),
       div({ style: styles.attributesColumn }, [
         h3({ style: styles.headers }, ['Last Updated']),

--- a/src/pages/library/dataBrowser-utils.js
+++ b/src/pages/library/dataBrowser-utils.js
@@ -111,7 +111,7 @@ const extractTags = dataset => {
       dataset.dataType,
       dataset.dataModality,
       _.map('dcat:mediaType', dataset.files),
-      getDatasetReleasePoliciesDisplayInformation(dataset['TerraDCAT_ap:hasDataUsePermission']).label
+      dataset['TerraDCAT_ap:hasDataUsePermission']
     ])
   }
 }

--- a/src/pages/library/dataBrowser-utils.js
+++ b/src/pages/library/dataBrowser-utils.js
@@ -21,6 +21,7 @@ export const uiMessaging = {
   unsupportedDatasetTypeTooltip: action => `The Data Catalog currently does not support ${action} for this dataset.`
 }
 
+// This list is generated from the schema enum
 export const getDatasetReleasePoliciesDisplayInformation = dataUsePermission => {
   return Utils.switchCase(
     dataUsePermission,

--- a/src/pages/library/dataBrowser-utils.js
+++ b/src/pages/library/dataBrowser-utils.js
@@ -56,7 +56,7 @@ export const isDatarepoSnapshot = dataset => {
   return _.toLower(dataset['dcat:accessURL']).includes(datarepoSnapshotUrlFragment)
 }
 
-export const getConsortiumsFromDataset = dataset => _.map(dataCollection => dataCollection['dct:title'], dataset['TerraDCAT_ap:hasDataCollection'])
+export const getConsortiumsFromDataset = dataset => _.map('dct:title', dataset['TerraDCAT_ap:hasDataCollection'])
 
 
 const normalizeDataset = dataset => {
@@ -112,7 +112,7 @@ const extractTags = dataset => {
     itemsType: 'AttributeValue',
     items: _.flow(_.flatten, _.toLower)([
       dataset.access,
-      _.map('dct:title', dataset['TerraDCAT_ap:hasDataCollection']),
+      getConsortiumsFromDataset(dataset),
       dataset.samples?.genus,
       dataset.samples?.disease,
       dataset.dataType,

--- a/src/pages/library/dataBrowser-utils.test.js
+++ b/src/pages/library/dataBrowser-utils.test.js
@@ -1,7 +1,8 @@
 import { brands } from 'src/libs/brands'
 import { dataCatalogStore } from 'src/libs/state'
 import {
-  datarepoSnapshotUrlFragment, datasetAccessTypes, filterAndNormalizeDatasets, workspaceUrlFragment
+  datarepoSnapshotUrlFragment, datasetAccessTypes, datasetReleasePolicies, filterAndNormalizeDatasets, getDataReleasePolicyFromDataset,
+  workspaceUrlFragment
 } from 'src/pages/library/dataBrowser-utils'
 
 
@@ -25,5 +26,19 @@ describe('dataBrowser-utils', () => {
     )
     expect(normalizedDatasets[0].access).not.toBe(datasetAccessTypes.EXTERNAL)
     expect(normalizedDatasets[1].access).not.toBe(datasetAccessTypes.EXTERNAL)
+  })
+
+  it('finds the correct data use policy if it exists', () => {
+    const normalizedDatasets = filterAndNormalizeDatasets([{ 'TerraDCAT_ap:hasDataUsePermission': 'DUO:0000007' }])
+    expect(getDataReleasePolicyFromDataset(normalizedDatasets[0]).desc).toBe(datasetReleasePolicies['DUO:0000007'].desc)
+    expect(getDataReleasePolicyFromDataset(normalizedDatasets[0]).label).toBe(datasetReleasePolicies['DUO:0000007'].label)
+    expect(getDataReleasePolicyFromDataset(normalizedDatasets[0]).policy).toBe('DUO:0000007')
+  })
+
+  it('uses other as the data use policy if our map doesn\'t contain it or is undefined', () => {
+    const normalizedDatasets = filterAndNormalizeDatasets([{ 'TerraDCAT_ap:hasDataUsePermission': undefined }, { 'TerraDCAT_ap:hasDataUsePermission': 'DUO:1234567' }])
+    expect(getDataReleasePolicyFromDataset(normalizedDatasets[0]).desc).toBe(datasetReleasePolicies.unknownReleasePolicy.desc)
+    expect(getDataReleasePolicyFromDataset(normalizedDatasets[0]).label).toBe(datasetReleasePolicies.unknownReleasePolicy.label)
+    expect(getDataReleasePolicyFromDataset(normalizedDatasets[0]).policy).toBe(datasetReleasePolicies.unknownReleasePolicy.policy)
   })
 })

--- a/src/pages/library/dataBrowser-utils.test.js
+++ b/src/pages/library/dataBrowser-utils.test.js
@@ -1,7 +1,9 @@
+import { render } from '@testing-library/react'
+import { h } from 'react-hyperscript-helpers'
 import { brands } from 'src/libs/brands'
 import { dataCatalogStore } from 'src/libs/state'
 import {
-  datarepoSnapshotUrlFragment, datasetAccessTypes, datasetReleasePolicies, filterAndNormalizeDatasets, getDataReleasePolicyFromDataset,
+  datarepoSnapshotUrlFragment, datasetAccessTypes, DatasetReleasePolicyDisplayInformation, filterAndNormalizeDatasets,
   workspaceUrlFragment
 } from 'src/pages/library/dataBrowser-utils'
 
@@ -28,17 +30,18 @@ describe('dataBrowser-utils', () => {
     expect(normalizedDatasets[1].access).not.toBe(datasetAccessTypes.EXTERNAL)
   })
 
-  it('finds the correct data use policy if it exists', () => {
-    const normalizedDatasets = filterAndNormalizeDatasets([{ 'TerraDCAT_ap:hasDataUsePermission': 'DUO:0000007' }])
-    expect(getDataReleasePolicyFromDataset(normalizedDatasets[0]).desc).toBe(datasetReleasePolicies['DUO:0000007'].desc)
-    expect(getDataReleasePolicyFromDataset(normalizedDatasets[0]).label).toBe(datasetReleasePolicies['DUO:0000007'].label)
-    expect(getDataReleasePolicyFromDataset(normalizedDatasets[0]).policy).toBe('DUO:0000007')
+  it('finds the correct data use policy to display if it exists', () => {
+    const { getByText } = render(h(DatasetReleasePolicyDisplayInformation, { dataUsePermission: 'DUO:0000007' }))
+    expect(getByText('Disease specific research')).toBeTruthy()
   })
 
-  it('uses other as the data use policy if our map doesn\'t contain it or is undefined', () => {
-    const normalizedDatasets = filterAndNormalizeDatasets([{ 'TerraDCAT_ap:hasDataUsePermission': undefined }, { 'TerraDCAT_ap:hasDataUsePermission': 'DUO:1234567' }])
-    expect(getDataReleasePolicyFromDataset(normalizedDatasets[0]).desc).toBe(datasetReleasePolicies.unknownReleasePolicy.desc)
-    expect(getDataReleasePolicyFromDataset(normalizedDatasets[0]).label).toBe(datasetReleasePolicies.unknownReleasePolicy.label)
-    expect(getDataReleasePolicyFromDataset(normalizedDatasets[0]).policy).toBe(datasetReleasePolicies.unknownReleasePolicy.policy)
+  it('uses unspecified as the data use policy if undefined', () => {
+    const { getByText } = render(h(DatasetReleasePolicyDisplayInformation, { dataUsePermission: undefined }))
+    expect(getByText('Unspecified')).toBeTruthy()
+  })
+
+  it('uses given data use policy as the data use policy if unknown', () => {
+    const { getByText } = render(h(DatasetReleasePolicyDisplayInformation, { dataUsePermission: 'Something else' }))
+    expect(getByText('Something else')).toBeTruthy()
   })
 })


### PR DESCRIPTION
Screenshots below. Removes the policy field from the normalize dataset with the goal of eventually making that function return its input, and be removed. 

![Screen Shot 2022-12-12 at 10 46 51 AM](https://user-images.githubusercontent.com/15351021/207091079-db1c85a8-4d86-4264-8cd4-a2373ec53ea4.png)
![Screen Shot 2022-12-12 at 10 48 49 AM](https://user-images.githubusercontent.com/15351021/207091098-e025be03-3350-4936-8400-c0d3547b1400.png)
![Screen Shot 2022-12-12 at 10 48 52 AM](https://user-images.githubusercontent.com/15351021/207091104-a75a6284-5476-4e23-ae73-87403f055d5a.png)

