### PR TITLE
[SU-250] Support Azure workspaces in new file browser

### DIFF
--- a/src/libs/ajax/file-browser-providers/AzureBlobStorageFileBrowserProvider.test.ts
+++ b/src/libs/ajax/file-browser-providers/AzureBlobStorageFileBrowserProvider.test.ts
@@ -1,0 +1,230 @@
+import * as qs from 'qs'
+import { fetchOk } from 'src/libs/ajax/ajax-common'
+import { AzureStorageContract } from 'src/libs/ajax/AzureStorage'
+import AzureBlobStorageFileBrowserProvider from 'src/libs/ajax/file-browser-providers/AzureBlobStorageFileBrowserProvider'
+import { FileBrowserDirectory, FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
+import * as Utils from 'src/libs/utils'
+import { asMockedFn } from 'src/testing/test-utils'
+
+
+jest.mock('src/libs/ajax/ajax-common', () => ({
+  fetchOk: jest.fn(),
+}))
+
+jest.mock('src/libs/ajax/AzureStorage', () => ({
+  AzureStorage: () => ({
+    details: jest.fn(() => Promise.resolve({
+      location: 'Unknown',
+      storageContainerName: 'test-storage-container',
+      sas: {
+        token: 'tokenPlaceholder=value',
+        url: 'https://terra-ui-test.blob.core.windows.net/test-storage-container?tokenPlaceholder=value',
+      },
+    })),
+  }) as Partial<AzureStorageContract>,
+}))
+
+const blobXml = (name: string): string => {
+  return `
+    <Blob>
+      <Name>${name}</Name>
+      <Properties>
+        <Creation-Time>Wed, 07 Dec 2022 23:25:00 GMT</Creation-Time>
+        <Last-Modified>Wed, 07 Dec 2022 23:30:00 GMT</Last-Modified>
+        <Etag>0x8DAD8AA481719B0</Etag>
+        <Content-Length>1</Content-Length>
+        <Content-Type>text/plain</Content-Type>
+        <Content-Encoding />
+        <Content-Language />
+        <Content-CRC64 />
+        <Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5>
+        <Cache-Control />
+        <Content-Disposition />
+        <BlobType>BlockBlob</BlobType>
+        <AccessTier>Hot</AccessTier>
+        <AccessTierInferred>true</AccessTierInferred>
+        <LeaseStatus>unlocked</LeaseStatus>
+        <LeaseState>available</LeaseState>
+        <ServerEncrypted>true</ServerEncrypted>
+      </Properties>
+      <OrMetadata />
+    </Blob>`
+}
+
+const blobPrefixXml = (name: string): string => {
+  return `
+    <BlobPrefix>
+      <Name>${name}</Name>
+    </BlobPrefix>`
+}
+
+const expectedFile = (path: string): FileBrowserFile => ({
+  path,
+  url: `https://terra-ui-test.blob.core.windows.net/test-storage-container/${path}?tokenPlaceholder=value`,
+  size: 1,
+  createdAt: 1670455500000,
+  updatedAt: 1670455800000,
+})
+
+describe('AzureBlobStorageFileBrowserProvider', () => {
+  describe('listing files/directories', () => {
+    beforeAll(() => {
+      asMockedFn(fetchOk).mockImplementation(url => {
+        const { marker } = qs.parse(new URL(url).search)
+
+        const responseXml = Utils.switchCase(marker,
+          [undefined, () => {
+            return `
+              <EnumerationResults ServiceEndpoint="https://terra-ui-test.blob.core.windows.net/" ContainerName="test-storage-container">
+                <MaxResults>1000</MaxResults>
+                <Delimiter>/</Delimiter>
+                <Blobs>
+                  ${blobXml('a-file.txt')}
+                  ${blobPrefixXml('a-prefix/')}
+                  ${blobXml('b-file.txt')}
+                </Blobs>
+                <NextMarker>2</NextMarker>
+              </EnumerationResults>
+            `
+          }],
+          ['2', () => {
+            return `
+              <EnumerationResults ServiceEndpoint="https://terra-ui-test.blob.core.windows.net/" ContainerName="test-storage-container">
+                <MaxResults>1000</MaxResults>
+                <Delimiter>/</Delimiter>
+                <Blobs>
+                  ${blobPrefixXml('b-prefix/')}
+                  ${blobXml('c-file.txt')}
+                  ${blobXml('d-file.txt')}
+                </Blobs>
+                <NextMarker>3</NextMarker>
+              </EnumerationResults>`
+          }],
+          ['3', () => {
+            return `
+              <EnumerationResults ServiceEndpoint="https://terra-ui-test.blob.core.windows.net/" ContainerName="test-storage-container">
+                <MaxResults>1000</MaxResults>
+                <Delimiter>/</Delimiter>
+                <Blobs>
+                  ${blobPrefixXml('c-prefix/')}
+                  ${blobPrefixXml('d-prefix/')}
+                </Blobs>
+                <NextMarker />
+              </EnumerationResults>`
+          }],
+          [Utils.DEFAULT, () => {
+            throw new Error('Unrecognized page token')
+          }]
+        )
+
+        return Promise.resolve(new Response(responseXml))
+      })
+    })
+
+    it('pages through files (objects)', async () => {
+      // Arrange
+      const provider = AzureBlobStorageFileBrowserProvider({ workspaceId: 'test-workspace', pageSize: 3 })
+
+      // Act
+      const firstResponse = await provider.getFilesInDirectory('')
+      const numAzureStorageRequestsAfterFirstResponse = asMockedFn(fetchOk).mock.calls.length
+      const secondResponse = await firstResponse.getNextPage()
+      const numAzureStorageRequestsAfterSecondResponse = asMockedFn(fetchOk).mock.calls.length
+
+      // Assert
+      const expectedFirstPageFiles: FileBrowserFile[] = [
+        expectedFile('a-file.txt'),
+        expectedFile('b-file.txt'),
+        expectedFile('c-file.txt')
+      ]
+      expect(firstResponse.items).toEqual(expectedFirstPageFiles)
+      expect(firstResponse.hasNextPage).toBe(true)
+      expect(numAzureStorageRequestsAfterFirstResponse).toBe(2)
+
+      const expectedSecondPageFiles: FileBrowserFile[] = [
+        expectedFile('a-file.txt'),
+        expectedFile('b-file.txt'),
+        expectedFile('c-file.txt'),
+        expectedFile('d-file.txt')
+      ]
+      expect(secondResponse.items).toEqual(expectedSecondPageFiles)
+      expect(secondResponse.hasNextPage).toBe(false)
+      expect(numAzureStorageRequestsAfterSecondResponse).toBe(3)
+    })
+
+    it('pages through directories (prefixes)', async () => {
+      // Arrange
+      const provider = AzureBlobStorageFileBrowserProvider({ workspaceId: 'test-workspace', pageSize: 3 })
+
+      // Act
+      const firstResponse = await provider.getDirectoriesInDirectory('')
+      const numAzureStorageRequestsAfterFirstResponse = asMockedFn(fetchOk).mock.calls.length
+      const secondResponse = await firstResponse.getNextPage()
+      const numAzureStorageRequestsAfterSecondResponse = asMockedFn(fetchOk).mock.calls.length
+
+      // Assert
+      const expectedFirstPageDirectories: FileBrowserDirectory[] = [
+        { path: 'a-prefix/' },
+        { path: 'b-prefix/' },
+        { path: 'c-prefix/' }
+      ]
+      expect(firstResponse.items).toEqual(expectedFirstPageDirectories)
+      expect(firstResponse.hasNextPage).toBe(true)
+      expect(numAzureStorageRequestsAfterFirstResponse).toBe(3)
+
+      const expectedSecondPageDirectories: FileBrowserDirectory[] = [
+        { path: 'a-prefix/' },
+        { path: 'b-prefix/' },
+        { path: 'c-prefix/' },
+        { path: 'd-prefix/' }
+      ]
+      expect(secondResponse.items).toEqual(expectedSecondPageDirectories)
+      expect(secondResponse.hasNextPage).toBe(false)
+      expect(numAzureStorageRequestsAfterSecondResponse).toBe(3)
+    })
+  })
+
+  it('uploads a file', async () => {
+    // Arrange
+    asMockedFn(fetchOk).mockResolvedValue(new Response())
+
+    const testFile = new File(['somecontent'], 'example.txt', { type: 'text/text' })
+
+    const provider = AzureBlobStorageFileBrowserProvider({ workspaceId: 'test-workspace' })
+
+    // Act
+    await provider.uploadFileToDirectory('path/to/directory/', testFile)
+
+    // Assert
+    expect(fetchOk).toHaveBeenCalledWith(
+      'https://terra-ui-test.blob.core.windows.net/test-storage-container/path/to/directory/example.txt?tokenPlaceholder=value',
+      {
+        body: testFile,
+        headers: {
+          'Content-Length': 11,
+          'Content-Type': 'text/text',
+          'x-ms-blob-type': 'BlockBlob',
+        },
+        method: 'PUT',
+      }
+    )
+  })
+
+  it('deletes files', async () => {
+    // Arrange
+    asMockedFn(fetchOk).mockResolvedValue(new Response())
+
+    const provider = AzureBlobStorageFileBrowserProvider({ workspaceId: 'test-workspace' })
+
+    // Act
+    await provider.deleteFile('path/to/file.txt')
+
+    // Assert
+    expect(fetchOk).toHaveBeenCalledWith(
+      'https://terra-ui-test.blob.core.windows.net/test-storage-container/path/to/file.txt?tokenPlaceholder=value',
+      {
+        method: 'DELETE',
+      }
+    )
+  })
+})

--- a/src/libs/ajax/file-browser-providers/AzureBlobStorageFileBrowserProvider.test.ts
+++ b/src/libs/ajax/file-browser-providers/AzureBlobStorageFileBrowserProvider.test.ts
@@ -60,7 +60,7 @@ const blobPrefixXml = (name: string): string => {
 
 const expectedFile = (path: string): FileBrowserFile => ({
   path,
-  url: `https://terra-ui-test.blob.core.windows.net/test-storage-container/${path}?tokenPlaceholder=value`,
+  url: `https://terra-ui-test.blob.core.windows.net/test-storage-container/${path}`,
   size: 1,
   createdAt: 1670455500000,
   updatedAt: 1670455800000,

--- a/src/libs/ajax/file-browser-providers/AzureBlobStorageFileBrowserProvider.ts
+++ b/src/libs/ajax/file-browser-providers/AzureBlobStorageFileBrowserProvider.ts
@@ -108,10 +108,10 @@ const AzureBlobStorageFileBrowserProvider = ({ workspaceId, pageSize = 1000 }: A
         mapBlobOrBlobPrefix: blob => {
           const name = blob.getElementsByTagName('Name').item(0)!.textContent!
 
-          const blobProperties = blob.getElementsByTagName('Properties').item(0)
-          const creationTime = blobProperties?.getElementsByTagName('Creation-Time').item(0)!.textContent!
-          const lastModified = blobProperties?.getElementsByTagName('Last-Modified').item(0)!.textContent!
-          const contentLength = blobProperties?.getElementsByTagName('Content-Length').item(0)!.textContent!
+          const blobProperties = blob.getElementsByTagName('Properties').item(0)!
+          const creationTime = blobProperties.getElementsByTagName('Creation-Time').item(0)!.textContent!
+          const lastModified = blobProperties.getElementsByTagName('Last-Modified').item(0)!.textContent!
+          const contentLength = blobProperties.getElementsByTagName('Content-Length').item(0)!.textContent!
 
           const blobUrl = new URL(sasUrl)
           blobUrl.pathname += `/${name}`

--- a/src/libs/ajax/file-browser-providers/AzureBlobStorageFileBrowserProvider.ts
+++ b/src/libs/ajax/file-browser-providers/AzureBlobStorageFileBrowserProvider.ts
@@ -115,6 +115,7 @@ const AzureBlobStorageFileBrowserProvider = ({ workspaceId, pageSize = 1000 }: A
 
           const blobUrl = new URL(sasUrl)
           blobUrl.pathname += `/${name}`
+          blobUrl.search = ''
 
           return {
             path: name,

--- a/src/libs/ajax/file-browser-providers/AzureBlobStorageFileBrowserProvider.ts
+++ b/src/libs/ajax/file-browser-providers/AzureBlobStorageFileBrowserProvider.ts
@@ -1,0 +1,184 @@
+import { fetchOk } from 'src/libs/ajax/ajax-common'
+import { AzureStorage } from 'src/libs/ajax/AzureStorage'
+import FileBrowserProvider from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
+import IncrementalResponse from 'src/libs/ajax/incremental-response/IncrementalResponse'
+import * as Utils from 'src/libs/utils'
+
+
+export interface AzureBlobStorageFileBrowserProviderParams {
+  workspaceId: string
+  pageSize?: number
+}
+
+type AzureBlobStorageFileBrowserProviderGetPageParams<T> = {
+  isFirstPage: boolean
+  pageToken?: string
+  pendingItems?: T[]
+  prefix: string
+  previousItems?: T[]
+  sasUrl: string
+  signal: any
+  tagName: 'Blob' | 'BlobPrefix'
+  mapBlobOrBlobPrefix: (blobOrBlobPrefix: Element) => T
+}
+
+interface BlobListRequestOptions {
+  maxResults: number
+  marker?: string
+}
+
+const AzureBlobStorageFileBrowserProvider = ({ workspaceId, pageSize = 1000 }: AzureBlobStorageFileBrowserProviderParams): FileBrowserProvider => {
+  const storageDetailsPromise = AzureStorage().details(workspaceId)
+
+  const getNextPage = async <T>(params: AzureBlobStorageFileBrowserProviderGetPageParams<T>): Promise<IncrementalResponse<T>> => {
+    const {
+      isFirstPage,
+      tagName,
+      mapBlobOrBlobPrefix,
+      pageToken,
+      pendingItems = [],
+      prefix,
+      previousItems = [],
+      sasUrl,
+      signal,
+    } = params
+
+    let buffer = pendingItems
+    let nextPageToken = pageToken
+
+    if (nextPageToken || isFirstPage) {
+      do {
+        const requestOptions: BlobListRequestOptions = {
+          maxResults: pageSize
+        }
+        if (nextPageToken) {
+          requestOptions.marker = nextPageToken
+        }
+
+        const url = Utils.mergeQueryParams({
+          restype: 'container',
+          comp: 'list',
+          delimiter: '/',
+          prefix,
+          ...requestOptions,
+        }, sasUrl)
+
+        const response = await fetchOk(url, { signal })
+        const responseText = await response.text()
+        const responseXML = new window.DOMParser().parseFromString(responseText, 'text/xml')
+
+        const blobOrBlobPrefixElements = Array.from(responseXML.getElementsByTagName(tagName))
+        buffer = buffer.concat(blobOrBlobPrefixElements.map(mapBlobOrBlobPrefix))
+
+        nextPageToken = responseXML.getElementsByTagName('NextMarker').item(0)?.textContent || undefined
+      } while (buffer.length < pageSize && nextPageToken)
+    }
+
+    const items = previousItems.concat(buffer.slice(0, pageSize))
+    const nextPendingItems = buffer.slice(pageSize)
+    const hasNextPage = nextPendingItems.length > 0 || !!nextPageToken
+
+    return {
+      items,
+      getNextPage: hasNextPage ?
+        ({ signal } = {}) => getNextPage({
+          isFirstPage: false,
+          tagName,
+          mapBlobOrBlobPrefix,
+          pageToken: nextPageToken,
+          pendingItems: nextPendingItems,
+          prefix,
+          previousItems: items,
+          sasUrl,
+          signal
+        } as AzureBlobStorageFileBrowserProviderGetPageParams<T>) :
+        () => {
+          throw new Error('No next page')
+        },
+      hasNextPage
+    }
+  }
+
+  return {
+    getFilesInDirectory: async (path, { signal } = {}) => {
+      const { sas: { url: sasUrl } } = await storageDetailsPromise
+      return getNextPage({
+        isFirstPage: true,
+        tagName: 'Blob',
+        mapBlobOrBlobPrefix: blob => {
+          const name = blob.getElementsByTagName('Name').item(0)!.textContent!
+
+          const blobProperties = blob.getElementsByTagName('Properties').item(0)
+          const creationTime = blobProperties?.getElementsByTagName('Creation-Time').item(0)!.textContent!
+          const lastModified = blobProperties?.getElementsByTagName('Last-Modified').item(0)!.textContent!
+          const contentLength = blobProperties?.getElementsByTagName('Content-Length').item(0)!.textContent!
+
+          const blobUrl = new URL(sasUrl)
+          blobUrl.pathname += `/${name}`
+
+          return {
+            path: name,
+            url: blobUrl.href,
+            size: parseInt(contentLength),
+            createdAt: new Date(creationTime).getTime(),
+            updatedAt: new Date(lastModified).getTime()
+          }
+        },
+        prefix: path,
+        sasUrl,
+        signal
+      })
+    },
+    getDirectoriesInDirectory: async (path, { signal } = {}) => {
+      const { sas: { url: sasUrl } } = await storageDetailsPromise
+      return getNextPage({
+        isFirstPage: true,
+        tagName: 'BlobPrefix',
+        mapBlobOrBlobPrefix: blobPrefix => {
+          const name = blobPrefix.getElementsByTagName('Name').item(0)!.textContent!
+
+          return {
+            path: name,
+          }
+        },
+        prefix: path,
+        sasUrl,
+        signal
+      })
+    },
+    uploadFileToDirectory: async (directoryPath, file) => {
+      const { sas: { url: originalSasUrl } } = await storageDetailsPromise
+
+      const blobUrl = new URL(originalSasUrl)
+      blobUrl.pathname += `/${directoryPath}${encodeURIComponent(file.name)}`
+
+      await fetchOk(
+        blobUrl.href,
+        {
+          body: file,
+          headers: {
+            'Content-Length': file.size,
+            'Content-Type': file.type,
+            'x-ms-blob-type': 'BlockBlob',
+          },
+          method: 'PUT',
+        }
+      )
+    },
+    deleteFile: async (path: string) => {
+      const { sas: { url: originalSasUrl } } = await storageDetailsPromise
+
+      const blobUrl = new URL(originalSasUrl)
+      blobUrl.pathname += `/${path}`
+
+      await fetchOk(
+        blobUrl.href,
+        {
+          method: 'DELETE',
+        }
+      )
+    },
+  }
+}
+
+export default AzureBlobStorageFileBrowserProvider

--- a/src/pages/workspaces/workspace/Files.ts
+++ b/src/pages/workspaces/workspace/Files.ts
@@ -2,6 +2,7 @@ import _ from 'lodash/fp'
 import { div, h } from 'react-hyperscript-helpers'
 import * as breadcrumbs from 'src/components/breadcrumbs'
 import FileBrowser from 'src/components/file-browser/FileBrowser'
+import AzureBlobStorageFileBrowserProvider from 'src/libs/ajax/file-browser-providers/AzureBlobStorageFileBrowserProvider'
 import GCSFileBrowserProvider from 'src/libs/ajax/file-browser-providers/GCSFileBrowserProvider'
 import { forwardRefWithName } from 'src/libs/react-utils'
 import { wrapWorkspace } from 'src/pages/workspaces/workspace/WorkspaceContainer'
@@ -17,11 +18,17 @@ export const Files = _.flow(
     topBarContent: null
   })
 )(({ workspace }, _ref) => {
-  const { bucketName, googleProject } = workspace.workspace
-
   const fileBrowserProvider = useMemo(
-    () => GCSFileBrowserProvider({ bucket: bucketName, project: googleProject }),
-    [bucketName, googleProject]
+    () => {
+      if (workspace.azureContext) {
+        const { workspaceId } = workspace.workspace
+        return AzureBlobStorageFileBrowserProvider({ workspaceId })
+      } else {
+        const { bucketName, googleProject } = workspace.workspace
+        return GCSFileBrowserProvider({ bucket: bucketName, project: googleProject })
+      }
+    },
+    [workspace]
   )
 
   return div({

--- a/src/pages/workspaces/workspace/Files.ts
+++ b/src/pages/workspaces/workspace/Files.ts
@@ -5,6 +5,7 @@ import FileBrowser from 'src/components/file-browser/FileBrowser'
 import AzureBlobStorageFileBrowserProvider from 'src/libs/ajax/file-browser-providers/AzureBlobStorageFileBrowserProvider'
 import GCSFileBrowserProvider from 'src/libs/ajax/file-browser-providers/GCSFileBrowserProvider'
 import { forwardRefWithName } from 'src/libs/react-utils'
+import { isAzureWorkspace } from 'src/libs/workspace-utils'
 import { wrapWorkspace } from 'src/pages/workspaces/workspace/WorkspaceContainer'
 import { useMemo } from 'use-memo-one'
 
@@ -20,7 +21,7 @@ export const Files = _.flow(
 )(({ workspace }, _ref) => {
   const fileBrowserProvider = useMemo(
     () => {
-      if (workspace.azureContext) {
+      if (isAzureWorkspace(workspace)) {
         const { workspaceId } = workspace.workspace
         return AzureBlobStorageFileBrowserProvider({ workspaceId })
       } else {

--- a/src/pages/workspaces/workspace/analysis/ContextBar.js
+++ b/src/pages/workspaces/workspace/analysis/ContextBar.js
@@ -65,7 +65,6 @@ export const ContextBar = ({
   const isTerminalEnabled = currentRuntimeTool === toolLabels.Jupyter && currentRuntime && currentRuntime.status !== 'Error'
   const terminalLaunchLink = Nav.getLink(appLauncherTabName, { namespace, name: workspaceName, application: 'terminal' })
   const canCompute = !!(workspace?.canCompute || runtimes?.length)
-  const isAzureWorkspace = !!workspace.azureContext
 
   const getImgForTool = toolLabel => Utils.switchCase(toolLabel,
     [toolLabels.Jupyter, () => img({ src: jupyterLogo, style: { height: 45, width: 45 }, alt: '' })],
@@ -221,7 +220,7 @@ export const ContextBar = ({
           useTooltipAsLabel: false,
           ...Utils.newTabLinkProps
         }, [icon('terminal', { size: 40 }), span({ className: 'sr-only' }, ['Terminal button'])]),
-        isFeaturePreviewEnabled('workspace-files') && !isAzureWorkspace && h(Clickable, {
+        isFeaturePreviewEnabled('workspace-files') && h(Clickable, {
           style: { paddingLeft: '1rem', alignItems: 'center', ...contextBarStyles.contextBarButton },
           hover: contextBarStyles.hover,
           'data-testid': 'workspace-files-link',


### PR DESCRIPTION
This enables the new file browser for Azure workspaces by implementing a version of the FileBrowserProvider interface for Azure Blob Storage. Files are stored in the workspace's storage container. The storage container URL can be found in the Cloud Information panel on the workspace dashboard.

Enable the new file browser from the feature preview page (/#feature-preview) and open it from the right sidebar within a workspace.