### PR TITLE
[TOAZ-297] Add messaging for Azure beta users

### DIFF
--- a/config/prod.json
+++ b/config/prod.json
@@ -28,5 +28,6 @@
   "alphaAzureGroup": "alpha-azure-feature-group",
   "alphaRegionalityGroup": "Alpha_Regionality_Users",
   "terraDockerVersionsFile": "terra-docker-versions-prod.json",
-  "terraDockerImageBucket": "terra-docker-image-documentation-prod"
+  "terraDockerImageBucket": "terra-docker-image-documentation-prod",
+  "b2cBillingPolicy": "b2c_1a_signup_signin_billing_prod"
 }

--- a/src/components/AuthContainer.js
+++ b/src/components/AuthContainer.js
@@ -1,6 +1,7 @@
 import _ from 'lodash/fp'
 import { h } from 'react-hyperscript-helpers'
 import { centeredSpinner } from 'src/components/icons'
+import { isAzureIdp } from 'src/libs/auth'
 import { useRoute } from 'src/libs/nav'
 import { useStore } from 'src/libs/react-utils'
 import { authStore, userStatus } from 'src/libs/state'
@@ -14,12 +15,8 @@ import TermsOfService from 'src/pages/TermsOfService'
 
 const AuthContainer = ({ children }) => {
   const { name, public: isPublic } = useRoute()
-  const { isSignedIn, registrationStatus, acceptedTos, profile, user, seenAzurePreviewScreen } = useStore(authStore)
+  const { isSignedIn, registrationStatus, acceptedTos, profile, seenAzurePreviewScreen } = useStore(authStore)
   const authspinner = () => h(centeredSpinner, { style: { position: 'fixed' } })
-
-  const isAzureIdp = () => {
-    return user.idp && user.idp.startsWith('https://login.microsoftonline.com')
-  }
 
   return Utils.cond(
     [isSignedIn === undefined && !isPublic, authspinner],

--- a/src/components/AuthContainer.js
+++ b/src/components/AuthContainer.js
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp'
 import { h } from 'react-hyperscript-helpers'
 import { centeredSpinner } from 'src/components/icons'
-import { isAzureIdp } from 'src/libs/auth'
+import { isAzureUser } from 'src/libs/auth'
 import { useRoute } from 'src/libs/nav'
 import { useStore } from 'src/libs/react-utils'
 import { authStore, azurePreviewStore, userStatus } from 'src/libs/state'
@@ -22,7 +22,7 @@ const AuthContainer = ({ children }) => {
   return Utils.cond(
     [isSignedIn === undefined && !isPublic, authspinner],
     [isSignedIn === false && !isPublic, () => h(SignIn)],
-    [seenAzurePreview === false && isAzureIdp(), () => h(AzurePreview)],
+    [seenAzurePreview === false && isAzureUser(), () => h(AzurePreview)],
     [registrationStatus === undefined && !isPublic, authspinner],
     [registrationStatus === userStatus.unregistered, () => h(Register)],
     [acceptedTos === undefined && !isPublic, authspinner],

--- a/src/components/AuthContainer.js
+++ b/src/components/AuthContainer.js
@@ -5,6 +5,7 @@ import { useRoute } from 'src/libs/nav'
 import { useStore } from 'src/libs/react-utils'
 import { authStore, userStatus } from 'src/libs/state'
 import * as Utils from 'src/libs/utils'
+import AzurePreview from 'src/pages/AzurePreview'
 import { Disabled } from 'src/pages/Disabled'
 import Register from 'src/pages/Register'
 import SignIn from 'src/pages/SignIn'
@@ -13,12 +14,17 @@ import TermsOfService from 'src/pages/TermsOfService'
 
 const AuthContainer = ({ children }) => {
   const { name, public: isPublic } = useRoute()
-  const { isSignedIn, registrationStatus, acceptedTos, profile } = useStore(authStore)
+  const { isSignedIn, registrationStatus, acceptedTos, profile, user, seenAzurePreviewScreen } = useStore(authStore)
   const authspinner = () => h(centeredSpinner, { style: { position: 'fixed' } })
+
+  const isAzureIdp = () => {
+    return user.idp && user.idp.startsWith('https://login.microsoftonline.com')
+  }
 
   return Utils.cond(
     [isSignedIn === undefined && !isPublic, authspinner],
     [isSignedIn === false && !isPublic, () => h(SignIn)],
+    [seenAzurePreviewScreen === undefined && isAzureIdp(), () => h(AzurePreview)],
     [registrationStatus === undefined && !isPublic, authspinner],
     [registrationStatus === userStatus.unregistered, () => h(Register)],
     [acceptedTos === undefined && !isPublic, authspinner],

--- a/src/components/AuthContainer.js
+++ b/src/components/AuthContainer.js
@@ -4,7 +4,7 @@ import { centeredSpinner } from 'src/components/icons'
 import { isAzureIdp } from 'src/libs/auth'
 import { useRoute } from 'src/libs/nav'
 import { useStore } from 'src/libs/react-utils'
-import { authStore, userStatus } from 'src/libs/state'
+import { authStore, azurePreviewStore, userStatus } from 'src/libs/state'
 import * as Utils from 'src/libs/utils'
 import AzurePreview from 'src/pages/AzurePreview'
 import { Disabled } from 'src/pages/Disabled'
@@ -15,13 +15,14 @@ import TermsOfService from 'src/pages/TermsOfService'
 
 const AuthContainer = ({ children }) => {
   const { name, public: isPublic } = useRoute()
-  const { isSignedIn, registrationStatus, acceptedTos, profile, seenAzurePreviewScreen } = useStore(authStore)
+  const { isSignedIn, registrationStatus, acceptedTos, profile } = useStore(authStore)
+  const seenAzurePreview = useStore(azurePreviewStore) || false
   const authspinner = () => h(centeredSpinner, { style: { position: 'fixed' } })
 
   return Utils.cond(
     [isSignedIn === undefined && !isPublic, authspinner],
     [isSignedIn === false && !isPublic, () => h(SignIn)],
-    [seenAzurePreviewScreen === undefined && isAzureIdp(), () => h(AzurePreview)],
+    [seenAzurePreview === false && isAzureIdp(), () => h(AzurePreview)],
     [registrationStatus === undefined && !isPublic, authspinner],
     [registrationStatus === userStatus.unregistered, () => h(Register)],
     [acceptedTos === undefined && !isPublic, authspinner],

--- a/src/images/azure-new.svg
+++ b/src/images/azure-new.svg
@@ -1,0 +1,23 @@
+<svg width="150" height="150" viewBox="0 0 96 96" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <linearGradient id="e399c19f-b68f-429d-b176-18c2117ff73c" x1="-1032.172" x2="-1059.213" y1="145.312" y2="65.426" gradientTransform="matrix(1 0 0 -1 1075 158)" gradientUnits="userSpaceOnUse">
+            <stop offset="0" stop-color="#114a8b"></stop>
+            <stop offset="1" stop-color="#0669bc"></stop>
+        </linearGradient>
+        <linearGradient id="ac2a6fc2-ca48-4327-9a3c-d4dcc3256e15" x1="-1023.725" x2="-1029.98" y1="108.083" y2="105.968" gradientTransform="matrix(1 0 0 -1 1075 158)" gradientUnits="userSpaceOnUse">
+            <stop offset="0" stop-opacity=".3"></stop>
+            <stop offset=".071" stop-opacity=".2"></stop>
+            <stop offset=".321" stop-opacity=".1"></stop>
+            <stop offset=".623" stop-opacity=".05"></stop>
+            <stop offset="1" stop-opacity="0"></stop>
+        </linearGradient>
+        <linearGradient id="a7fee970-a784-4bb1-af8d-63d18e5f7db9" x1="-1027.165" x2="-997.482" y1="147.642" y2="68.561" gradientTransform="matrix(1 0 0 -1 1075 158)" gradientUnits="userSpaceOnUse">
+            <stop offset="0" stop-color="#3ccbf4"></stop>
+            <stop offset="1" stop-color="#2892df"></stop>
+        </linearGradient>
+    </defs>
+    <path fill="url(#e399c19f-b68f-429d-b176-18c2117ff73c)" d="M33.338 6.544h26.038l-27.03 80.087a4.152 4.152 0 0 1-3.933 2.824H8.149a4.145 4.145 0 0 1-3.928-5.47L29.404 9.368a4.152 4.152 0 0 1 3.934-2.825z"></path>
+    <path fill="#0078d4" d="M71.175 60.261h-41.29a1.911 1.911 0 0 0-1.305 3.309l26.532 24.764a4.171 4.171 0 0 0 2.846 1.121h23.38z"></path>
+    <path fill="url(#ac2a6fc2-ca48-4327-9a3c-d4dcc3256e15)" d="M33.338 6.544a4.118 4.118 0 0 0-3.943 2.879L4.252 83.917a4.14 4.14 0 0 0 3.908 5.538h20.787a4.443 4.443 0 0 0 3.41-2.9l5.014-14.777 17.91 16.705a4.237 4.237 0 0 0 2.666.972H81.24L71.024 60.261l-29.781.007L59.47 6.544z"></path>
+    <path fill="url(#a7fee970-a784-4bb1-af8d-63d18e5f7db9)" d="M66.595 9.364a4.145 4.145 0 0 0-3.928-2.82H33.648a4.146 4.146 0 0 1 3.928 2.82l25.184 74.62a4.146 4.146 0 0 1-3.928 5.472h29.02a4.146 4.146 0 0 0 3.927-5.472z"></path>
+</svg>

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -13,7 +13,7 @@ import { clearNotification, notify, sessionTimeoutProps } from 'src/libs/notific
 import { getLocalPref, getLocalPrefForUserId, setLocalPref } from 'src/libs/prefs'
 import allProviders from 'src/libs/providers'
 import {
-  asyncImportJobStore, authStore, azureCookieReadyStore, cookieReadyStore, getUser, requesterPaysProjectStore, userStatus, workspacesStore, workspaceStore
+  asyncImportJobStore, authStore, azureCookieReadyStore, azurePreviewStore, cookieReadyStore, getUser, requesterPaysProjectStore, userStatus, workspacesStore, workspaceStore
 } from 'src/libs/state'
 import * as Utils from 'src/libs/utils'
 
@@ -66,6 +66,7 @@ export const signOut = () => {
   cookieReadyStore.reset()
   azureCookieReadyStore.reset()
   getSessionStorage().clear()
+  azurePreviewStore.set(false)
   const auth = getAuthInstance()
   revokeTokens()
     .finally(() => auth.removeUser())
@@ -225,7 +226,6 @@ export const processUser = (user, isSignInEvent) => {
       cookiesAccepted: isSignedIn ? state.cookiesAccepted || getLocalPrefForUserId(userId, cookiesAcceptedKey) : undefined,
       isTimeoutEnabled: isSignedIn ? state.isTimeoutEnabled : undefined,
       hasGcpBillingScopeThroughB2C: isSignedIn ? state.hasGcpBillingScopeThroughB2C : undefined,
-      seenAzurePreviewScreen: isSignedIn ? state.seenAzurePreviewScreen : undefined,
       user: {
         token: user?.access_token,
         scope: user?.scope,

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -221,6 +221,7 @@ export const processUser = (user, isSignInEvent) => {
       cookiesAccepted: isSignedIn ? state.cookiesAccepted || getLocalPrefForUserId(userId, cookiesAcceptedKey) : undefined,
       isTimeoutEnabled: isSignedIn ? state.isTimeoutEnabled : undefined,
       hasGcpBillingScopeThroughB2C: isSignedIn ? state.hasGcpBillingScopeThroughB2C : undefined,
+      seenAzurePreviewScreen: isSignedIn ? state.seenAzurePreviewScreen : undefined,
       user: {
         token: user?.access_token,
         scope: user?.scope,
@@ -230,7 +231,8 @@ export const processUser = (user, isSignInEvent) => {
           name: profile.name,
           givenName: profile.givenName,
           familyName: profile.familyName,
-          imageUrl: profile.picture
+          imageUrl: profile.picture,
+          idp: profile.idp
         } : {})
       }
     }

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -53,6 +53,10 @@ const isGoogleAuthority = () => {
   return _.startsWith('https://accounts.google.com', authStore.get().oidcConfig.authorityEndpoint)
 }
 
+export const isAzureIdp = () => {
+  return _.startsWith('https://login.microsoftonline.com', getUser().idp)
+}
+
 const getAuthInstance = () => {
   return authStore.get().authContext
 }

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -1,5 +1,4 @@
 import { parseJSON } from 'date-fns/fp'
-import jwtDecode from 'jwt-decode'
 import _ from 'lodash/fp'
 import { UserManager, WebStorageStateStore } from 'oidc-client-ts'
 import { cookiesAcceptedKey } from 'src/components/CookieWarning'
@@ -51,10 +50,6 @@ export const getOidcConfig = () => {
 
 const isGoogleAuthority = () => {
   return _.startsWith('https://accounts.google.com', authStore.get().oidcConfig.authorityEndpoint)
-}
-
-export const isAzureIdp = () => {
-  return _.startsWith('https://login.microsoftonline.com', getUser().idp)
 }
 
 const getAuthInstance = () => {
@@ -189,11 +184,7 @@ export const bucketBrowserUrl = id => {
 }
 
 export const isAzureUser = () => {
-  try {
-    return jwtDecode(authStore.get().user.token)['idp'].startsWith('https://login.microsoftonline.com/')
-  } catch {
-    return false
-  }
+  return _.startsWith('https://login.microsoftonline.com', getUser().idp)
 }
 
 export const processUser = (user, isSignInEvent) => {

--- a/src/libs/routes.js
+++ b/src/libs/routes.js
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp'
 import { compile, pathToRegexp } from 'path-to-regexp'
 import { routeHandlersStore } from 'src/libs/state'
-import * as AzureBeta from 'src/pages/AzureBeta'
+import * as AzurePreview from 'src/pages/AzurePreview'
 import * as Projects from 'src/pages/billing/List'
 import * as Environments from 'src/pages/Environments'
 import * as FeaturePreviews from 'src/pages/FeaturePreviews'
@@ -79,7 +79,7 @@ const routes = _.flatten([
   Upload.navPaths,
   FeaturePreviews.navPaths,
   WorkspaceFiles.navPaths,
-  AzureBeta.navPaths,
+  AzurePreview.navPaths,
   NotFound.navPaths // must be last
 ])
 

--- a/src/libs/routes.js
+++ b/src/libs/routes.js
@@ -1,6 +1,7 @@
 import _ from 'lodash/fp'
 import { compile, pathToRegexp } from 'path-to-regexp'
 import { routeHandlersStore } from 'src/libs/state'
+import * as AzureBeta from 'src/pages/AzureBeta'
 import * as Projects from 'src/pages/billing/List'
 import * as Environments from 'src/pages/Environments'
 import * as FeaturePreviews from 'src/pages/FeaturePreviews'
@@ -78,6 +79,7 @@ const routes = _.flatten([
   Upload.navPaths,
   FeaturePreviews.navPaths,
   WorkspaceFiles.navPaths,
+  AzureBeta.navPaths,
   NotFound.navPaths // must be last
 ])
 

--- a/src/libs/state.js
+++ b/src/libs/state.js
@@ -35,6 +35,9 @@ lastActiveTimeStore.update(v => v || {})
 export const toggleStateAtom = staticStorageSlot(getSessionStorage(), 'toggleState')
 toggleStateAtom.update(v => v || { notebooksTab: true })
 
+export const azurePreviewStore = staticStorageSlot(getLocalStorage(), 'azurePreview')
+azurePreviewStore.update(v => v || false)
+
 export const notificationStore = Utils.atom([])
 
 export const contactUsActive = Utils.atom(false)

--- a/src/pages/AzureBeta.js
+++ b/src/pages/AzureBeta.js
@@ -1,0 +1,63 @@
+import { div, h } from 'react-hyperscript-helpers'
+import { ButtonPrimary, ButtonSecondary } from 'src/components/common'
+import { icon } from 'src/components/icons'
+import { ReactComponent as AzureLogo } from 'src/images/azure.svg'
+import planet from 'src/images/register-planet.svg'
+import { brands } from 'src/libs/brands'
+import colors from 'src/libs/colors'
+import { terraLogoMaker } from 'src/libs/logos'
+
+
+const AzureBeta = () => {
+  return div({
+    role: 'main',
+    style: {
+      flexGrow: 1,
+      padding: '5rem',
+      backgroundImage: `url(${planet})`,
+      backgroundRepeat: 'no-repeat', backgroundSize: '750px', backgroundPosition: 'right 0px bottom -600px'
+    }
+  }, [
+    div({ style: { display: 'flex', alignItems: 'center' } }, [
+      terraLogoMaker(brands.terra.logos.color, { height: 100, marginRight: 20 }),
+      div({ style: { borderLeft: `1px solid ${colors.dark()}` } }, [
+        h(AzureLogo, { title: 'Microsoft Azure', role: 'img', style: { height: 80, marginLeft: '1rem' } })
+      ]),
+    ]),
+    div({
+      style: {
+        marginTop: '4rem', color: colors.dark(0.6),
+        fontSize: '1.5rem', fontWeight: 500
+      }
+    }, [
+      icon('warning-standard', { style: { color: colors.warning(), height: '1.5rem', width: '1.5rem', marginRight: '0.5rem', marginTop: '0.25rem' } }),
+      'Beta Test Environment'
+    ]),
+    div({ style: { marginTop: '3rem', display: 'flex' } },
+      'This is a beta version of the Terra on Azure platform.',
+    ),
+    div({ style: { marginTop: '3rem', display: 'flex' } },
+      'The official release is expected to come soon in 2023.',
+    ),
+    div({ style: { marginTop: '3rem', display: 'flex' } },
+      'If you are not in the beta test program, please log in using Google.',
+    ),
+    div({ style: { marginTop: '3rem' } }, [
+      h(ButtonPrimary,
+        'Proceed to beta environment'
+      ),
+      h(ButtonSecondary, { style: { marginLeft: '1rem' } }, 'Cancel')
+    ])
+  ])
+}
+export default AzureBeta
+
+export const navPaths = [
+  {
+    name: 'azure-beta',
+    path: '/azure-beta',
+    component: AzureBeta,
+    public: true,
+    title: 'Terra on Azure Beta'
+  }
+]

--- a/src/pages/AzurePreview.js
+++ b/src/pages/AzurePreview.js
@@ -8,10 +8,10 @@ import { signOut } from 'src/libs/auth'
 import { brands } from 'src/libs/brands'
 import colors from 'src/libs/colors'
 import { getConfig } from 'src/libs/config'
-import { reportErrorAndRethrow } from 'src/libs/error'
+import { withErrorIgnoring } from 'src/libs/error'
 import { terraLogoMaker } from 'src/libs/logos'
 import { useCancellation, useOnMount } from 'src/libs/react-utils'
-import { authStore } from 'src/libs/state'
+import { azurePreviewStore } from 'src/libs/state'
 import * as Utils from 'src/libs/utils'
 
 
@@ -21,12 +21,12 @@ const AzurePreview = () => {
   const signal = useCancellation()
 
   // Helpers
-  const loadAlphaAzureMember = reportErrorAndRethrow('Error loading azure alpha group membership')(async () => {
+  const loadAlphaAzureMember = withErrorIgnoring(async () => {
     setIsAlphaAzureUser(await Ajax(signal).Groups.group(getConfig().alphaAzureGroup).isMember())
   })
 
   const dismiss = () => {
-    authStore.update(state => ({ ...state, seenAzurePreviewScreen: true }))
+    azurePreviewStore.set(true)
   }
 
   const styles = {

--- a/src/pages/AzurePreview.js
+++ b/src/pages/AzurePreview.js
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
-import { ButtonPrimary, ButtonSecondary } from 'src/components/common'
+import { ButtonOutline, ButtonPrimary, Link } from 'src/components/common'
 import { ReactComponent as AzureLogo } from 'src/images/azure.svg'
 import planet from 'src/images/register-planet.svg'
 import { Ajax } from 'src/libs/ajax'
@@ -12,6 +12,7 @@ import { reportErrorAndRethrow } from 'src/libs/error'
 import { terraLogoMaker } from 'src/libs/logos'
 import { useCancellation, useOnMount } from 'src/libs/react-utils'
 import { authStore } from 'src/libs/state'
+import * as Utils from 'src/libs/utils'
 
 
 const AzurePreview = () => {
@@ -28,6 +29,31 @@ const AzurePreview = () => {
     authStore.update(state => ({ ...state, seenAzurePreviewScreen: true }))
   }
 
+  const styles = {
+    centered: {
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center'
+    },
+    paragraph: {
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+      fontSize: 16,
+      lineHeight: 1.5
+    },
+    header: {
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+      color: colors.dark(0.8),
+      fontSize: '1.8rem',
+      fontWeight: 500
+    }
+  }
+
+  const supportEmail = 'support@terra.bio'
+
   // Lifecycle
   useOnMount(() => {
     loadAlphaAzureMember()
@@ -43,34 +69,39 @@ const AzurePreview = () => {
       backgroundRepeat: 'no-repeat', backgroundSize: '750px', backgroundPosition: 'right 0px bottom -600px'
     }
   }, [
-    div({ style: { display: 'flex', alignItems: 'center' } }, [
+    div({ style: styles.centered }, [
       terraLogoMaker(brands.terra.logos.color, { height: 100, marginRight: 20 }),
       div({ style: { borderLeft: `1px solid ${colors.dark()}` } }, [
         h(AzureLogo, { title: 'Microsoft Azure', role: 'img', style: { height: 80, marginLeft: '1rem' } })
       ]),
     ]),
-    div({
-      style: {
-        marginTop: '4rem', color: colors.dark(0.9),
-        fontSize: '1.5rem', fontWeight: 500
-      }
-    }, 'Preview Environment'),
-    div({ style: { marginTop: '3rem', display: 'flex' } },
-      'This is an invite-only limited version of the Terra on Azure platform. The public offering of Terra on Azure is expected in early 2023.'
-    ),
-    isAlphaAzureUser ? [] : div({ style: { marginTop: '3rem', display: 'flex' } },
-      'If you are not in the Terra on Azure Preview Program and would like to join, contact support@terra.bio.',
-    ),
-    div({ style: { marginTop: '3rem' } },
-      isAlphaAzureUser ? [
-        h(ButtonPrimary, { onClick: dismiss }, 'Proceed to Terra on Azure Preview'),
-        h(ButtonSecondary, { style: { marginLeft: '1rem' }, onClick: signOut }, 'Cancel')
-      ] : [
-        h(ButtonPrimary, { style: { marginLeft: '1rem' }, onClick: signOut }, 'Close')
-      ]
-    )
+    div({ style: { ...styles.header, marginTop: '3rem' } },
+      'Preview Environment'),
+    div({ style: { ...styles.paragraph, marginTop: '1rem' } },
+      'This is an invite-only limited version of the Terra on Azure platform.'),
+    div({ style: { ...styles.paragraph } },
+      'The public offering of Terra on Azure is expected in early 2023.'),
+
+    isAlphaAzureUser ? undefined : [
+      div({ style: { ...styles.paragraph, marginTop: '1rem' } },
+        'If you are not in the Terra on Azure Preview Program'),
+      div({ style: { ...styles.paragraph } }, [
+        'and would like to join, contact ',
+        h(Link, { style: { marginLeft: '0.3rem' }, href: `mailto:${supportEmail}`, ...Utils.newTabLinkProps }, supportEmail),
+        '.'
+      ])
+    ],
+    div({ style: { ...styles.centered, marginTop: '2rem' } }, [
+      isAlphaAzureUser ?
+        h(ButtonPrimary, { onClick: dismiss }, 'Proceed to Terra on Azure Preview') :
+        h(ButtonPrimary, { onClick: signOut }, 'Close')
+    ]),
+    isAlphaAzureUser ? div({ style: { ...styles.centered, marginTop: '1rem' } }, [
+      h(ButtonOutline, { onClick: signOut }, 'Cancel')
+    ]) : undefined
   ])
 }
+
 export default AzurePreview
 
 export const navPaths = [

--- a/src/pages/AzurePreview.js
+++ b/src/pages/AzurePreview.js
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
 import { ButtonOutline, ButtonPrimary, Link } from 'src/components/common'
-import { ReactComponent as AzureLogo } from 'src/images/azure.svg'
+import { ReactComponent as AzureLogo } from 'src/images/azure-new.svg'
 import planet from 'src/images/register-planet.svg'
 import { Ajax } from 'src/libs/ajax'
 import { signOut } from 'src/libs/auth'
@@ -49,6 +49,9 @@ const AzurePreview = () => {
       color: colors.dark(0.8),
       fontSize: '1.8rem',
       fontWeight: 500
+    },
+    button: {
+      textTransform: 'none'
     }
   }
 
@@ -69,11 +72,10 @@ const AzurePreview = () => {
       backgroundRepeat: 'no-repeat', backgroundSize: '750px', backgroundPosition: 'right 0px bottom -600px'
     }
   }, [
-    div({ style: styles.centered }, [
-      terraLogoMaker(brands.terra.logos.color, { height: 100, marginRight: 20 }),
-      div({ style: { borderLeft: `1px solid ${colors.dark()}` } }, [
-        h(AzureLogo, { title: 'Microsoft Azure', role: 'img', style: { height: 80, marginLeft: '1rem' } })
-      ]),
+    div({ style: styles.header }, [
+      terraLogoMaker(brands.terra.logos.color, { height: 100, marginRight: 25 }),
+      h(AzureLogo, { title: 'Microsoft Azure', role: 'img', style: { height: 100, borderLeft: `1px solid ${colors.dark()}` } }),
+      'Azure'
     ]),
     div({ style: { ...styles.header, marginTop: '3rem' } },
       'Preview Environment'),
@@ -93,11 +95,11 @@ const AzurePreview = () => {
     ],
     div({ style: { ...styles.centered, marginTop: '2rem' } }, [
       isAlphaAzureUser ?
-        h(ButtonPrimary, { onClick: dismiss }, 'Proceed to Terra on Azure Preview') :
-        h(ButtonPrimary, { onClick: signOut }, 'Close')
+        h(ButtonPrimary, { onClick: dismiss, style: styles.button }, 'Proceed to Terra on Azure Preview') :
+        h(ButtonPrimary, { onClick: signOut, style: styles.button }, 'Close')
     ]),
     isAlphaAzureUser ? div({ style: { ...styles.centered, marginTop: '1rem' } }, [
-      h(ButtonOutline, { onClick: signOut }, 'Cancel')
+      h(ButtonOutline, { onClick: signOut, style: styles.button }, 'Cancel')
     ]) : undefined
   ])
 }

--- a/src/pages/AzurePreview.js
+++ b/src/pages/AzurePreview.js
@@ -1,14 +1,21 @@
 import { div, h } from 'react-hyperscript-helpers'
 import { ButtonPrimary, ButtonSecondary } from 'src/components/common'
-import { icon } from 'src/components/icons'
 import { ReactComponent as AzureLogo } from 'src/images/azure.svg'
 import planet from 'src/images/register-planet.svg'
+import { signOut } from 'src/libs/auth'
 import { brands } from 'src/libs/brands'
 import colors from 'src/libs/colors'
 import { terraLogoMaker } from 'src/libs/logos'
+import { authStore } from 'src/libs/state'
 
 
-const AzureBeta = () => {
+const AzurePreview = () => {
+  const isOnAllowList = true
+
+  const dismiss = () => {
+    authStore.update(state => ({ ...state, seenAzurePreviewScreen: true }))
+  }
+
   return div({
     role: 'main',
     style: {
@@ -26,38 +33,34 @@ const AzureBeta = () => {
     ]),
     div({
       style: {
-        marginTop: '4rem', color: colors.dark(0.6),
+        marginTop: '4rem', color: colors.dark(0.9),
         fontSize: '1.5rem', fontWeight: 500
       }
-    }, [
-      icon('warning-standard', { style: { color: colors.warning(), height: '1.5rem', width: '1.5rem', marginRight: '0.5rem', marginTop: '0.25rem' } }),
-      'Beta Test Environment'
-    ]),
+    }, 'Preview Environment'),
     div({ style: { marginTop: '3rem', display: 'flex' } },
-      'This is a beta version of the Terra on Azure platform.',
+      'This is an invite-only limited version of the Terra on Azure platform. The public offering of Terra on Azure is expected in early 2023.'
     ),
-    div({ style: { marginTop: '3rem', display: 'flex' } },
-      'The official release is expected to come soon in 2023.',
+    isOnAllowList ? [] : div({ style: { marginTop: '3rem', display: 'flex' } },
+      'If you are not in the Terra on Azure Preview Program and would like to join, contact support@terra.bio.',
     ),
-    div({ style: { marginTop: '3rem', display: 'flex' } },
-      'If you are not in the beta test program, please log in using Google.',
-    ),
-    div({ style: { marginTop: '3rem' } }, [
-      h(ButtonPrimary,
-        'Proceed to beta environment'
-      ),
-      h(ButtonSecondary, { style: { marginLeft: '1rem' } }, 'Cancel')
-    ])
+    div({ style: { marginTop: '3rem' } },
+      isOnAllowList ? [
+        h(ButtonPrimary, { onClick: dismiss }, 'Proceed to Terra on Azure Preview'),
+        h(ButtonSecondary, { style: { marginLeft: '1rem' }, onClick: signOut }, 'Cancel')
+      ] : [
+        h(ButtonPrimary, { style: { marginLeft: '1rem' }, onClick: signOut }, 'Close')
+      ]
+    )
   ])
 }
-export default AzureBeta
+export default AzurePreview
 
 export const navPaths = [
   {
-    name: 'azure-beta',
-    path: '/azure-beta',
-    component: AzureBeta,
+    name: 'azure-preview',
+    path: '/azure-preview',
+    component: AzurePreview,
     public: true,
-    title: 'Terra on Azure Beta'
+    title: 'Terra on Azure Preview'
   }
 ]

--- a/src/pages/AzurePreview.js
+++ b/src/pages/AzurePreview.js
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { div, h } from 'react-hyperscript-helpers'
+import { div, h, h1, p } from 'react-hyperscript-helpers'
 import { ButtonOutline, ButtonPrimary, Link } from 'src/components/common'
 import { ReactComponent as AzureLogo } from 'src/images/azure-new.svg'
 import planet from 'src/images/register-planet.svg'
@@ -32,18 +32,19 @@ const AzurePreview = () => {
   const styles = {
     centered: {
       display: 'flex',
+      marginTop: '1rem',
       justifyContent: 'center',
       alignItems: 'center'
     },
     paragraph: {
-      display: 'flex',
-      justifyContent: 'center',
-      alignItems: 'center',
+      textAlign: 'center',
       fontSize: 16,
-      lineHeight: 1.5
+      lineHeight: 1.5,
+      maxWidth: 535
     },
     header: {
       display: 'flex',
+      marginTop: '3rem',
       justifyContent: 'center',
       alignItems: 'center',
       color: colors.dark(0.8),
@@ -72,34 +73,32 @@ const AzurePreview = () => {
       backgroundRepeat: 'no-repeat', backgroundSize: '750px', backgroundPosition: 'right 0px bottom -600px'
     }
   }, [
-    div({ style: styles.header }, [
+    div({ style: styles.centered }, [
       terraLogoMaker(brands.terra.logos.color, { height: 100, marginRight: 25 }),
-      h(AzureLogo, { title: 'Microsoft Azure', role: 'img', style: { height: 100, borderLeft: `1px solid ${colors.dark()}` } }),
-      'Azure'
+      h(AzureLogo, { title: 'Microsoft Azure', role: 'img', style: { height: 100, borderLeft: `1px solid ${colors.dark()}` } })
     ]),
-    div({ style: { ...styles.header, marginTop: '3rem' } },
-      'Preview Environment'),
-    div({ style: { ...styles.paragraph, marginTop: '1rem' } },
-      'This is an invite-only limited version of the Terra on Azure platform.'),
-    div({ style: { ...styles.paragraph } },
-      'The public offering of Terra on Azure is expected in early 2023.'),
+    h1({ style: styles.header }, 'Azure Preview Environment'),
+    div({ style: styles.centered }, [
+      p({ style: styles.paragraph },
+        'This is an invite-only limited version of the Terra on Azure platform. The public offering of Terra on Azure is expected in early 2023.')
+    ]),
 
     isAlphaAzureUser ? undefined : [
-      div({ style: { ...styles.paragraph, marginTop: '1rem' } },
-        'If you are not in the Terra on Azure Preview Program'),
-      div({ style: { ...styles.paragraph } }, [
-        'and would like to join, contact ',
-        h(Link, { style: { marginLeft: '0.3rem' }, href: `mailto:${supportEmail}`, ...Utils.newTabLinkProps }, supportEmail),
-        '.'
+      div({ style: styles.centered }, [
+        div({ style: { ...styles.paragraph } }, [
+          'You are not currently part of the Terra on Azure Preview Program. If you are interested in joining the program, or think there may be an error, please contact ',
+          h(Link, { href: `mailto:${supportEmail}`, ...Utils.newTabLinkProps }, supportEmail),
+          '.'
+        ])
       ])
     ],
     div({ style: { ...styles.centered, marginTop: '2rem' } }, [
       isAlphaAzureUser ?
         h(ButtonPrimary, { onClick: dismiss, style: styles.button }, 'Proceed to Terra on Azure Preview') :
-        h(ButtonPrimary, { onClick: signOut, style: styles.button }, 'Close')
+        h(ButtonPrimary, { onClick: signOut, style: styles.button }, 'Log Out')
     ]),
     isAlphaAzureUser ? div({ style: { ...styles.centered, marginTop: '1rem' } }, [
-      h(ButtonOutline, { onClick: signOut, style: styles.button }, 'Cancel')
+      h(ButtonOutline, { onClick: signOut, style: styles.button }, 'Log Out')
     ]) : undefined
   ])
 }

--- a/src/pages/AzurePreview.js
+++ b/src/pages/AzurePreview.js
@@ -32,7 +32,6 @@ const AzurePreview = () => {
   const styles = {
     centered: {
       display: 'flex',
-      marginTop: '1rem',
       justifyContent: 'center',
       alignItems: 'center'
     },
@@ -85,14 +84,14 @@ const AzurePreview = () => {
 
     isAlphaAzureUser ? undefined : [
       div({ style: styles.centered }, [
-        div({ style: { ...styles.paragraph } }, [
+        p({ style: styles.paragraph }, [
           'You are not currently part of the Terra on Azure Preview Program. If you are interested in joining the program, or think there may be an error, please contact ',
           h(Link, { href: `mailto:${supportEmail}`, ...Utils.newTabLinkProps }, supportEmail),
           '.'
         ])
       ])
     ],
-    div({ style: { ...styles.centered, marginTop: '2rem' } }, [
+    div({ style: { ...styles.centered, marginTop: '1.5rem' } }, [
       isAlphaAzureUser ?
         h(ButtonPrimary, { onClick: dismiss, style: styles.button }, 'Proceed to Terra on Azure Preview') :
         h(ButtonPrimary, { onClick: signOut, style: styles.button }, 'Log Out')

--- a/src/pages/AzurePreview.js
+++ b/src/pages/AzurePreview.js
@@ -31,7 +31,7 @@ const AzurePreview = () => {
       textAlign: 'center',
       fontSize: 16,
       lineHeight: 1.5,
-      maxWidth: 535
+      maxWidth: 500
     },
     header: {
       display: 'flex',
@@ -79,16 +79,16 @@ const AzurePreview = () => {
       terraLogoMaker(brands.terra.logos.color, { height: 100, marginRight: 25 }),
       h(AzureLogo, { title: 'Microsoft Azure', role: 'img', style: { height: 100, borderLeft: `1px solid ${colors.dark()}` } })
     ]),
-    h1({ style: styles.header }, 'Azure Preview Environment'),
+    h1({ style: styles.header }, 'Terra on Azure Preview Environment'),
     div({ style: styles.centered }, [
       p({ style: styles.paragraph },
-        'This is an invite-only limited version of the Terra on Azure platform. The public offering of Terra on Azure is expected in early 2023.')
+        'This is an invite-only version of the Terra on Azure platform. The public offering of Terra on Azure is expected in early 2023.')
     ]),
 
     isAlphaAzureUser ? undefined : [
       div({ style: styles.centered }, [
         p({ style: styles.paragraph }, [
-          'You are not currently part of the Terra on Azure Preview Program. If you are interested in joining the program, or think there may be an error, please contact ',
+          'You are not currently part of the Terra on Azure Preview Program. If you are interested in joining the program, please contact ',
           h(Link, { href: `mailto:${supportEmail}`, ...Utils.newTabLinkProps }, supportEmail),
           '.'
         ])

--- a/src/pages/AzurePreview.js
+++ b/src/pages/AzurePreview.js
@@ -21,14 +21,6 @@ const AzurePreview = () => {
   const signal = useCancellation()
 
   // Helpers
-  const loadAlphaAzureMember = withErrorIgnoring(async () => {
-    setIsAlphaAzureUser(await Ajax(signal).Groups.group(getConfig().alphaAzureGroup).isMember())
-  })
-
-  const dismiss = () => {
-    azurePreviewStore.set(true)
-  }
-
   const styles = {
     centered: {
       display: 'flex',
@@ -56,6 +48,17 @@ const AzurePreview = () => {
   }
 
   const supportEmail = 'support@terra.bio'
+
+  const dismiss = () => {
+    azurePreviewStore.set(true)
+  }
+
+  // Use a Sam group to determine if a user is an Azure Preview user.
+  // This is problematic when the user needs to register/accept ToS, since that's a prerequisite
+  // for checking Sam group membership. TOAZ-301 is open to change this to a B2C check instead of Sam.
+  const loadAlphaAzureMember = withErrorIgnoring(async () => {
+    setIsAlphaAzureUser(await Ajax(signal).Groups.group(getConfig().alphaAzureGroup).isMember())
+  })
 
   // Lifecycle
   useOnMount(() => {


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/TOAZ-297
Wireframes: https://dspuxteam.invisionapp.com/console/share/B7U9CE6T5K3

Basically this change interposes a screen right after login for Azure users. If a user is on the allow-list they are allowed to proceed using Terra; otherwise they are directed to support and prompted to sign out.

Cases to test:
1. Google login -- no change
2. Azure login, on allow list
   * Test user: testuser1@azure.dev.envs-terra.bio
      * password: `vault read -field="users_passwd" secret/dsde/firecloud/dev/common/users`
      * skip setting up 2FA
   * <img width="300" alt="image" src="https://user-images.githubusercontent.com/5368863/207383216-01dc6362-d4c0-4c82-b44f-47ec5d7fd86d.png">
3. Azure login, not on allow list
   * Test user: testuser2@azure.dev.envs-terra.bio
      * password: `vault read -field="users_passwd" secret/dsde/firecloud/dev/common/users`
      * skip setting up 2FA
    * <img width="300" alt="image" src="https://user-images.githubusercontent.com/5368863/207383020-84970b9b-c0a4-4b68-87e6-9963fc72252b.png">
