### PR TITLE
[UIE-16] Move FocusTrapper and DeleteConfirmationModal out of components/common.js

### DIFF
--- a/src/components/common.js
+++ b/src/components/common.js
@@ -1,7 +1,6 @@
 import * as clipboard from 'clipboard-polyfill/text'
 import _ from 'lodash/fp'
 import { Fragment, useState } from 'react'
-import FocusLock from 'react-focus-lock'
 import { b, div, h, img, label, span } from 'react-hyperscript-helpers'
 import { ButtonPrimary } from 'src/components/common/buttons'
 import Clickable from 'src/components/common/Clickable'
@@ -20,6 +19,7 @@ import * as Utils from 'src/libs/utils'
 
 export * from 'src/components/common/buttons'
 export * from 'src/components/common/Checkbox'
+export * from 'src/components/common/FocusTrapper'
 export * from 'src/components/common/IdContainer'
 export * from 'src/components/common/RadioButton'
 export * from 'src/components/common/Select'
@@ -48,22 +48,6 @@ export const backgroundLogo = img({
   alt: '',
   style: { position: 'fixed', top: 0, left: 0, zIndex: -1 }
 })
-
-export const FocusTrapper = ({ children, onBreakout, ...props }) => {
-  return h(FocusLock, {
-    returnFocus: true,
-    lockProps: _.merge({
-      tabIndex: 0,
-      style: { outline: 'none' },
-      onKeyDown: e => {
-        if (e.key === 'Escape') {
-          onBreakout()
-          e.stopPropagation()
-        }
-      }
-    }, props)
-  }, [children])
-}
 
 export const ClipboardButton = ({ text, onClick, children, ...props }) => {
   const [copied, setCopied] = useState(false)

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -1,14 +1,10 @@
 import * as clipboard from 'clipboard-polyfill/text'
 import _ from 'lodash/fp'
-import { Fragment, useState } from 'react'
-import { b, div, h, img, label, span } from 'react-hyperscript-helpers'
-import { ButtonPrimary } from 'src/components/common/buttons'
+import { useState } from 'react'
+import { div, h, img } from 'react-hyperscript-helpers'
 import Clickable from 'src/components/common/Clickable'
-import { IdContainer } from 'src/components/common/IdContainer'
 import Link from 'src/components/common/Link'
 import { icon } from 'src/components/icons'
-import { TextInput } from 'src/components/input'
-import Modal from 'src/components/Modal'
 import { MiniSortable } from 'src/components/table'
 import scienceBackground from 'src/images/science-background.jpg'
 import { isRadX } from 'src/libs/brand-utils'
@@ -19,6 +15,7 @@ import * as Utils from 'src/libs/utils'
 
 export * from 'src/components/common/buttons'
 export * from 'src/components/common/Checkbox'
+export * from 'src/components/common/DeleteConfirmationModal'
 export * from 'src/components/common/FocusTrapper'
 export * from 'src/components/common/IdContainer'
 export * from 'src/components/common/RadioButton'
@@ -68,53 +65,3 @@ export const ClipboardButton = ({ text, onClick, children, ...props }) => {
 export const HeaderRenderer = ({ name, label, sort, onSort, style, ...props }) => h(MiniSortable, { sort, field: name, onSort }, [
   div({ style: { fontWeight: 600, ...style }, ...props }, [label || Utils.normalizeLabel(name)])
 ])
-
-export const DeleteConfirmationModal = ({
-  objectType,
-  objectName,
-  title: titleProp,
-  children,
-  confirmationPrompt,
-  buttonText: buttonTextProp,
-  onConfirm,
-  onDismiss
-}) => {
-  const title = titleProp || `Delete ${objectType}`
-  const buttonText = buttonTextProp || `Delete ${objectType}`
-
-  const [confirmation, setConfirmation] = useState('')
-
-  const isConfirmed = !confirmationPrompt || _.toLower(confirmation) === _.toLower(confirmationPrompt)
-
-  return h(Modal, {
-    title: span({ style: { display: 'flex', alignItems: 'center' } }, [
-      icon('warning-standard', { size: 24, color: colors.warning() }),
-      span({ style: { marginLeft: '1ch' } }, [title])
-    ]),
-    onDismiss,
-    okButton: h(ButtonPrimary, {
-      'data-testid': 'confirm-delete',
-      onClick: onConfirm,
-      disabled: !isConfirmed,
-      tooltip: isConfirmed ? undefined : 'You must type the confirmation message'
-    }, buttonText),
-    styles: { modal: { backgroundColor: colors.warning(0.1) } }
-  }, [
-    children || h(Fragment, [
-      div([`Are you sure you want to delete the ${objectType} `, b({ style: { wordBreak: 'break-word' } }, [objectName]), '?']),
-      b({ style: { display: 'block', marginTop: '1rem' } }, 'This cannot be undone.')
-    ]),
-    confirmationPrompt && div({ style: { display: 'flex', flexDirection: 'column', marginTop: '1rem' } }, [
-      h(IdContainer, [id => h(Fragment, [
-        label({ htmlFor: id, style: { marginBottom: '0.25rem' } }, [`Type "${confirmationPrompt}" to continue:`]),
-        h(TextInput, {
-          autoFocus: true,
-          id,
-          placeholder: confirmationPrompt,
-          value: confirmation,
-          onChange: setConfirmation
-        })
-      ])])
-    ])
-  ])
-}

--- a/src/components/common/DeleteConfirmationModal.js
+++ b/src/components/common/DeleteConfirmationModal.js
@@ -1,0 +1,60 @@
+import _ from 'lodash/fp'
+import { Fragment, useState } from 'react'
+import { b, div, h, label, span } from 'react-hyperscript-helpers'
+import { ButtonPrimary } from 'src/components/common/buttons'
+import { IdContainer } from 'src/components/common/IdContainer'
+import { icon } from 'src/components/icons'
+import { TextInput } from 'src/components/input'
+import Modal from 'src/components/Modal'
+import colors from 'src/libs/colors'
+
+
+export const DeleteConfirmationModal = ({
+  objectType,
+  objectName,
+  title: titleProp,
+  children,
+  confirmationPrompt,
+  buttonText: buttonTextProp,
+  onConfirm,
+  onDismiss
+}) => {
+  const title = titleProp || `Delete ${objectType}`
+  const buttonText = buttonTextProp || `Delete ${objectType}`
+
+  const [confirmation, setConfirmation] = useState('')
+
+  const isConfirmed = !confirmationPrompt || _.toLower(confirmation) === _.toLower(confirmationPrompt)
+
+  return h(Modal, {
+    title: span({ style: { display: 'flex', alignItems: 'center' } }, [
+      icon('warning-standard', { size: 24, color: colors.warning() }),
+      span({ style: { marginLeft: '1ch' } }, [title])
+    ]),
+    onDismiss,
+    okButton: h(ButtonPrimary, {
+      'data-testid': 'confirm-delete',
+      onClick: onConfirm,
+      disabled: !isConfirmed,
+      tooltip: isConfirmed ? undefined : 'You must type the confirmation message'
+    }, buttonText),
+    styles: { modal: { backgroundColor: colors.warning(0.1) } }
+  }, [
+    children || h(Fragment, [
+      div([`Are you sure you want to delete the ${objectType} `, b({ style: { wordBreak: 'break-word' } }, [objectName]), '?']),
+      b({ style: { display: 'block', marginTop: '1rem' } }, 'This cannot be undone.')
+    ]),
+    confirmationPrompt && div({ style: { display: 'flex', flexDirection: 'column', marginTop: '1rem' } }, [
+      h(IdContainer, [id => h(Fragment, [
+        label({ htmlFor: id, style: { marginBottom: '0.25rem' } }, [`Type "${confirmationPrompt}" to continue:`]),
+        h(TextInput, {
+          autoFocus: true,
+          id,
+          placeholder: confirmationPrompt,
+          value: confirmation,
+          onChange: setConfirmation
+        })
+      ])])
+    ])
+  ])
+}

--- a/src/components/common/FocusTrapper.js
+++ b/src/components/common/FocusTrapper.js
@@ -1,0 +1,20 @@
+import _ from 'lodash/fp'
+import FocusLock from 'react-focus-lock'
+import { h } from 'react-hyperscript-helpers'
+
+
+export const FocusTrapper = ({ children, onBreakout, ...props }) => {
+  return h(FocusLock, {
+    returnFocus: true,
+    lockProps: _.merge({
+      tabIndex: 0,
+      style: { outline: 'none' },
+      onKeyDown: e => {
+        if (e.key === 'Escape') {
+          onBreakout()
+          e.stopPropagation()
+        }
+      }
+    }, props)
+  }, [children])
+}


### PR DESCRIPTION
Continuing to split up components/common.js. This moves FocusTrapper and DeleteConfirmationModal into their own modules under components/common/. They are re-exported from components/common.js to preserve import paths.