### PR TITLE
[SU-249] Allow downloading files from new file browser

### DIFF
--- a/src/components/file-browser/DownloadFileLink.test.ts
+++ b/src/components/file-browser/DownloadFileLink.test.ts
@@ -1,0 +1,73 @@
+import { render, screen } from '@testing-library/react'
+import { h } from 'react-hyperscript-helpers'
+import FileBrowserProvider, { FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
+import { asMockedFn } from 'src/testing/test-utils'
+
+import { DownloadFileLink } from './DownloadFileLink'
+import { useFileDownloadUrl } from './useFileDownloadUrl'
+
+
+jest.mock('./useFileDownloadUrl', () => ({
+  ...jest.requireActual('./useFileDownloadUrl'),
+  useFileDownloadUrl: jest.fn(),
+}))
+
+
+describe('DownloadFileLink', () => {
+  // Arrange
+  const file: FileBrowserFile = {
+    path: 'path/to/example.txt',
+    url: 'gs://test-bucket/path/to/example.txt',
+    size: 1024 ** 2,
+    createdAt: 1667408400000,
+    updatedAt: 1667494800000,
+  }
+
+  const mockProvider = {} as FileBrowserProvider
+
+  it('renders link to download URL', () => {
+    // Arrange
+    asMockedFn(useFileDownloadUrl).mockReturnValue({
+      status: 'Ready',
+      state: 'https://terra-ui-test.blob.core.windows.net/test-storage-container?token=sometoken',
+    })
+
+    // Act
+    render(h(DownloadFileLink, { file, provider: mockProvider }))
+
+    // Assert
+    const link = screen.getByRole('link')
+    expect(link.getAttribute('href')).toBe('https://terra-ui-test.blob.core.windows.net/test-storage-container?token=sometoken')
+    expect(link.getAttribute('download')).toBe('example.txt')
+  })
+
+  it('disables link when URL is not available', () => {
+    // Arrange
+    asMockedFn(useFileDownloadUrl).mockReturnValue({
+      status: 'Loading',
+      state: null,
+    })
+
+    // Act
+    render(h(DownloadFileLink, { file, provider: mockProvider }))
+
+    // Assert
+    const link = screen.getByText('Download')
+    expect(link.getAttribute('aria-disabled')).toBe('true')
+  })
+
+  it('renders a spinner while loading URL', () => {
+    // Arrange
+    asMockedFn(useFileDownloadUrl).mockReturnValue({
+      status: 'Loading',
+      state: null,
+    })
+
+    // Act
+    render(h(DownloadFileLink, { file, provider: mockProvider }))
+
+    // Assert
+    const link = screen.getByText('Download')
+    expect(link.querySelector('svg[data-icon="loadingSpinner"]')).toBeTruthy()
+  })
+})

--- a/src/components/file-browser/DownloadFileLink.ts
+++ b/src/components/file-browser/DownloadFileLink.ts
@@ -1,0 +1,30 @@
+import { h } from 'react-hyperscript-helpers'
+import { ButtonPrimary } from 'src/components/common'
+import { basename } from 'src/components/file-browser/file-browser-utils'
+import { useFileDownloadUrl } from 'src/components/file-browser/useFileDownloadUrl'
+import { spinner } from 'src/components/icons'
+import FileBrowserProvider, { FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
+import * as Utils from 'src/libs/utils'
+
+
+interface DownloadFileLinkProps {
+  file: FileBrowserFile
+  provider: FileBrowserProvider
+}
+
+export const DownloadFileLink = (props: DownloadFileLinkProps) => {
+  const { file, provider } = props
+
+  const { status, state: downloadUrl } = useFileDownloadUrl({ file, provider })
+
+  return h(ButtonPrimary, {
+    ...Utils.newTabLinkProps,
+    disabled: !downloadUrl,
+    download: basename(file.path),
+    href: downloadUrl,
+  }, [
+    'Download',
+    // @ts-expect-error
+    status === 'Loading' && spinner({ size: 12, style: { color: '#fff', marginLeft: '1ch' } }),
+  ])
+}

--- a/src/components/file-browser/FileBrowser.ts
+++ b/src/components/file-browser/FileBrowser.ts
@@ -107,7 +107,7 @@ const FileBrowser = ({ provider, title, workspace }: FileBrowserProps) => {
       title: basename(focusedFile.path),
       onDismiss: () => setFocusedFile(null),
     }, [
-      h(FileDetails, { file: focusedFile })
+      h(FileDetails, { file: focusedFile, provider })
     ]),
   ])
 }

--- a/src/components/file-browser/FileDetails.test.ts
+++ b/src/components/file-browser/FileDetails.test.ts
@@ -1,10 +1,21 @@
 import '@testing-library/jest-dom'
 
 import { render, screen } from '@testing-library/react'
-import { h } from 'react-hyperscript-helpers'
+import { div, h } from 'react-hyperscript-helpers'
+import { DownloadFileLink } from 'src/components/file-browser/DownloadFileLink'
 import { FileDetails } from 'src/components/file-browser/FileDetails'
-import { FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
+import FileBrowserProvider, { FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
+import { asMockedFn } from 'src/testing/test-utils'
 
+
+jest.mock('src/components/file-browser/DownloadFileLink', () => ({
+  ...jest.requireActual('src/components/file-browser/DownloadFileLink'),
+  DownloadFileLink: jest.fn(),
+}))
+
+beforeAll(() => {
+  asMockedFn(DownloadFileLink).mockImplementation(() => div(['Download file']))
+})
 
 describe('FileDetails', () => {
   // Arrange
@@ -16,16 +27,26 @@ describe('FileDetails', () => {
     updatedAt: 1667494800000,
   }
 
+  const mockProvider = {} as FileBrowserProvider
+
   it.each([
     { field: 'Last modified', expected: '11/3/2022, 5:00:00 PM' },
     { field: 'Created', expected: '11/2/2022, 5:00:00 PM' },
     { field: 'Size', expected: '1 MB' },
   ])('renders $field', ({ field, expected }) => {
     // Act
-    render(h(FileDetails, { file }))
+    render(h(FileDetails, { file, provider: mockProvider }))
 
     // Assert
     const renderedValue = screen.getByText(field).parentElement!.lastElementChild!.textContent!
     expect(renderedValue).toBe(expected)
+  })
+
+  it('renders download link', () => {
+    // Act
+    render(h(FileDetails, { file, provider: mockProvider }))
+
+    // Assert
+    screen.getByText('Download file')
   })
 })

--- a/src/components/file-browser/FileDetails.ts
+++ b/src/components/file-browser/FileDetails.ts
@@ -1,15 +1,17 @@
 import filesize from 'filesize'
 import { Fragment } from 'react'
 import { dd, div, dl, dt, h } from 'react-hyperscript-helpers'
-import { FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
+import { DownloadFileLink } from 'src/components/file-browser/DownloadFileLink'
+import FileBrowserProvider, { FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
 
 
 interface FileDetailsProps {
   file: FileBrowserFile
+  provider: FileBrowserProvider
 }
 
 export const FileDetails = (props: FileDetailsProps) => {
-  const { file } = props
+  const { file, provider } = props
 
   return h(Fragment, [
     dl([
@@ -25,6 +27,7 @@ export const FileDetails = (props: FileDetailsProps) => {
         dt({ style: { marginBottom: '0.25rem', fontWeight: 500 } }, ['Size']),
         dd({ style: { marginLeft: '0.5rem' } }, [filesize(file.size)]),
       ]),
-    ])
+    ]),
+    h(DownloadFileLink, { file, provider })
   ])
 }

--- a/src/components/file-browser/useFileDownloadUrl.test.ts
+++ b/src/components/file-browser/useFileDownloadUrl.test.ts
@@ -37,7 +37,7 @@ describe('useFileDownloadUrl', () => {
     const result = hookReturnRef.current
 
     // Assert
-    expect(mockProvider.getDownloadUrlForFile).toHaveBeenCalledWith('path/to/example.txt')
+    expect(mockProvider.getDownloadUrlForFile).toHaveBeenCalledWith('path/to/example.txt', { signal: expect.any(AbortSignal) })
     expect(result).toEqual({ status: 'Loading', state: null })
   })
 

--- a/src/components/file-browser/useFileDownloadUrl.test.ts
+++ b/src/components/file-browser/useFileDownloadUrl.test.ts
@@ -1,0 +1,66 @@
+import { renderHook } from '@testing-library/react-hooks'
+import FileBrowserProvider, { FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
+import { reportError } from 'src/libs/error'
+import { controlledPromise } from 'src/testing/test-utils'
+
+import { useFileDownloadUrl } from './useFileDownloadUrl'
+
+
+jest.mock('src/libs/error', () => ({
+  ...jest.requireActual('src/libs/error'),
+  reportError: jest.fn(),
+}))
+
+
+describe('useFileDownloadUrl', () => {
+  let getDownloadUrlForFileController
+
+  const mockProvider = {
+    getDownloadUrlForFile: jest.fn(() => {
+      const [promise, controller] = controlledPromise<string>()
+      getDownloadUrlForFileController = controller
+      return promise
+    })
+  } as Partial<FileBrowserProvider> as FileBrowserProvider
+
+  const file: FileBrowserFile = {
+    path: 'path/to/example.txt',
+    url: 'gs://test-bucket/path/to/example.txt',
+    size: 1024 ** 2,
+    createdAt: 1667408400000,
+    updatedAt: 1667494800000,
+  }
+
+  it('requests URL for file', () => {
+    // Act
+    const { result: hookReturnRef } = renderHook(() => useFileDownloadUrl({ file, provider: mockProvider }))
+    const result = hookReturnRef.current
+
+    // Assert
+    expect(mockProvider.getDownloadUrlForFile).toHaveBeenCalledWith('path/to/example.txt')
+    expect(result).toEqual({ status: 'Loading', state: null })
+  })
+
+  it('returns URL', async () => {
+    // Act
+    const { result: hookReturnRef, waitForNextUpdate } = renderHook(() => useFileDownloadUrl({ file, provider: mockProvider }))
+    getDownloadUrlForFileController.resolve('https://storage.googleapis.com/test-bucket/path/to/example.txt?downloadToken=somevalue')
+    await waitForNextUpdate()
+    const result = hookReturnRef.current
+
+    // Assert
+    expect(result).toEqual({ status: 'Ready', state: 'https://storage.googleapis.com/test-bucket/path/to/example.txt?downloadToken=somevalue' })
+  })
+
+  it('handles errors', async () => {
+    // Act
+    const { result: hookReturnRef, waitForNextUpdate } = renderHook(() => useFileDownloadUrl({ file, provider: mockProvider }))
+    getDownloadUrlForFileController.reject(new Error('Something went wrong'))
+    await waitForNextUpdate()
+    const result = hookReturnRef.current
+
+    // Assert
+    expect(reportError).toHaveBeenCalled()
+    expect(result).toEqual({ status: 'Error', state: null, error: new Error('Something went wrong') })
+  })
+})

--- a/src/components/file-browser/useFileDownloadUrl.ts
+++ b/src/components/file-browser/useFileDownloadUrl.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react'
+import FileBrowserProvider, { FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
+import { reportError } from 'src/libs/error'
+import { useCancellation } from 'src/libs/react-utils'
+import LoadedState, { NoneState } from 'src/libs/type-utils/LoadedState'
+
+
+type UseFileDownloadUrlOptions = {
+  file: FileBrowserFile
+  provider: FileBrowserProvider
+}
+
+type UseFileDownloadUrlResult = Exclude<LoadedState<string, unknown>, NoneState>
+
+export const useFileDownloadUrl = (opts: UseFileDownloadUrlOptions) => {
+  const { file, provider } = opts
+
+  const [result, setResult] = useState<UseFileDownloadUrlResult>({ status: 'Loading', state: null })
+
+  const signal = useCancellation()
+
+  useEffect(() => {
+    (async () => {
+      setResult({ status: 'Loading', state: null })
+      try {
+        const url = await provider.getDownloadUrlForFile(file.path, { signal })
+        setResult({ status: 'Ready', state: url })
+      } catch (error) {
+        reportError('Unable to get download URL', error)
+        setResult({ status: 'Error', state: null, error })
+      }
+    })()
+  }, [file, provider, signal])
+
+  return result
+}

--- a/src/libs/ajax/file-browser-providers/AzureBlobStorageFileBrowserProvider.test.ts
+++ b/src/libs/ajax/file-browser-providers/AzureBlobStorageFileBrowserProvider.test.ts
@@ -184,6 +184,17 @@ describe('AzureBlobStorageFileBrowserProvider', () => {
     })
   })
 
+  it('returns a download URL that includes SAS token', async () => {
+    // Arrange
+    const provider = AzureBlobStorageFileBrowserProvider({ workspaceId: 'test-workspace' })
+
+    // Act
+    const downloadUrl = await provider.getDownloadUrlForFile('path/to/example.txt')
+
+    // Assert
+    expect(downloadUrl).toBe('https://terra-ui-test.blob.core.windows.net/test-storage-container/path/to/example.txt?tokenPlaceholder=value')
+  })
+
   it('uploads a file', async () => {
     // Arrange
     asMockedFn(fetchOk).mockResolvedValue(new Response())

--- a/src/libs/ajax/file-browser-providers/AzureBlobStorageFileBrowserProvider.ts
+++ b/src/libs/ajax/file-browser-providers/AzureBlobStorageFileBrowserProvider.ts
@@ -147,6 +147,12 @@ const AzureBlobStorageFileBrowserProvider = ({ workspaceId, pageSize = 1000 }: A
         signal
       })
     },
+    getDownloadUrlForFile: async path => {
+      const { sas: { url: originalSasUrl } } = await storageDetailsPromise
+      const blobUrl = new URL(originalSasUrl)
+      blobUrl.pathname += `/${path}`
+      return blobUrl.href
+    },
     uploadFileToDirectory: async (directoryPath, file) => {
       const { sas: { url: originalSasUrl } } = await storageDetailsPromise
 

--- a/src/libs/ajax/file-browser-providers/FileBrowserProvider.ts
+++ b/src/libs/ajax/file-browser-providers/FileBrowserProvider.ts
@@ -16,6 +16,7 @@ export interface FileBrowserDirectory {
 interface FileBrowserProvider {
   getDirectoriesInDirectory(path: string, options?: { signal?: AbortSignal }): Promise<IncrementalResponse<FileBrowserDirectory>>
   getFilesInDirectory(path: string, options?: { signal?: AbortSignal }): Promise<IncrementalResponse<FileBrowserFile>>
+  getDownloadUrlForFile(path: string, options?: { signal?: AbortSignal }): Promise<string>
 
   uploadFileToDirectory(directoryPath: string, file: File): Promise<void>
   deleteFile(path: string): Promise<void>

--- a/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.test.ts
+++ b/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.test.ts
@@ -142,6 +142,28 @@ describe('GCSFileBrowserProvider', () => {
     expect(numGCSRequestsAfterSecondResponse).toBe(3)
   })
 
+  it('gets a signed URL for downloads', async () => {
+    // Arrange
+    const getSignedUrl = jest.fn(() => Promise.resolve({ url: 'signedUrl' }))
+    asMockedFn(Ajax).mockImplementation(() => {
+      return {
+        DrsUriResolver: { getSignedUrl } as Partial<ReturnType<typeof Ajax>['DrsUriResolver']>
+      } as ReturnType<typeof Ajax>
+    })
+
+    const provider = GCSFileBrowserProvider({ bucket: 'test-bucket', project: 'test-project' })
+
+    // Act
+    const downloadUrl = await provider.getDownloadUrlForFile('path/to/example.txt')
+
+    // Assert
+    expect(getSignedUrl).toHaveBeenCalledWith(expect.objectContaining({
+      bucket: 'test-bucket',
+      object: 'path/to/example.txt',
+    }))
+    expect(downloadUrl).toBe('signedUrl')
+  })
+
   it('uploads a file', async () => {
     // Arrange
     const upload = jest.fn(() => Promise.resolve())

--- a/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.ts
+++ b/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.ts
@@ -100,6 +100,14 @@ const GCSFileBrowserProvider = ({ bucket, project, pageSize = 1000 }: GCSFileBro
       prefix: path,
       signal
     }),
+    getDownloadUrlForFile: async (path, { signal } = {}) => {
+      const { url } = await Ajax(signal).DrsUriResolver.getSignedUrl({
+        bucket,
+        object: path,
+        dataObjectUri: undefined,
+      })
+      return url
+    },
     uploadFileToDirectory: (directoryPath, file) => {
       return Ajax().Buckets.upload(project, bucket, directoryPath, file)
     },


### PR DESCRIPTION
This adds a download link to the file details modal in the new file browser. For Azure, the download link includes the SAS token. For GCS, a signed URL is retrieved from Martha.

![Screen Shot 2022-12-16 at 10 36 20 AM](https://user-images.githubusercontent.com/1156625/208133975-0f68977e-be6a-4b54-b707-c415f7f7030d.png)
