### PR TITLE
[IA-3906] Add keys to divs in analysisNameValidator message

### DIFF
--- a/src/pages/workspaces/workspace/analysis/notebook-utils.js
+++ b/src/pages/workspaces/workspace/analysis/notebook-utils.js
@@ -17,8 +17,8 @@ export const analysisNameValidator = existing => ({
   format: {
     pattern: /^[^@#$%*+=?,[\]:;/\\]*$/,
     message: h(Fragment, [
-      div('Name can\'t contain these characters:'),
-      div({ style: { margin: '0.5rem 1rem' } }, ['@ # $ % * + = ? , [ ] : ; / \\ '])
+      div({ key: 'message' }, ['Name can\'t contain these characters:']),
+      div({ key: 'characters', style: { margin: '0.5rem 1rem' } }, ['@ # $ % * + = ? , [ ] : ; / \\ '])
     ])
   },
   exclusion: {


### PR DESCRIPTION
I don't see why this is required since the two divs are wrapped in a Fragment, but adding keys here avoids this warning from `yarn test`. Run `yarn test AnalysisDuplicator` with and without keys to see the difference.

```
 console.error
    Warning: Each child in a list should have a unique "key" prop. See https://reactjs.org/link/warning-keys for more information.
        at div
        at div
        at fn (./terra-ui/src/components/TooltipTrigger.js:94:27)
        at fn (./terra-ui/src/components/common/Clickable.js:10:6)
        at fn (./terra-ui/src/components/common/buttons.js:20:33)
        at div
        at div
        at div
        at construct (./terra-ui/.yarn/__virtual__/react-modal-virtual-c7ef39855c/0/cache/react-modal-npm-3.14.3-22dde5a95f-025605ad33.zip/node_modules/react-modal/lib/components/ModalPortal.js:70:5)
        at construct (./terra-ui/.yarn/__virtual__/react-modal-virtual-c7ef39855c/0/cache/react-modal-npm-3.14.3-22dde5a95f-025605ad33.zip/node_modules/react-modal/lib/components/Modal.js:73:5)
        at fn (./terra-ui/.yarn/cache/jest-mock-npm-27.5.1-22d1da854d-f5b5904bb1.zip/node_modules/jest-mock/build/index.js:107:19)
        at fn (./terra-ui/src/pages/workspaces/workspace/analysis/modals/AnalysisDuplicator.ts:40:38)
```