### PR TITLE
[UIE-16] Inline backgroundLogo image

### DIFF
--- a/src/components/common.js
+++ b/src/components/common.js
@@ -1,12 +1,11 @@
 import * as clipboard from 'clipboard-polyfill/text'
 import _ from 'lodash/fp'
 import { useState } from 'react'
-import { div, h, img } from 'react-hyperscript-helpers'
+import { div, h } from 'react-hyperscript-helpers'
 import Clickable from 'src/components/common/Clickable'
 import Link from 'src/components/common/Link'
 import { icon } from 'src/components/icons'
 import { MiniSortable } from 'src/components/table'
-import scienceBackground from 'src/images/science-background.jpg'
 import { withErrorReporting } from 'src/libs/error'
 import * as Utils from 'src/libs/utils'
 
@@ -22,12 +21,6 @@ export * from 'src/components/common/spinners'
 export * from 'src/components/common/Switch'
 export { Clickable, Link }
 
-
-export const backgroundLogo = img({
-  src: scienceBackground,
-  alt: '',
-  style: { position: 'fixed', top: 0, left: 0, zIndex: -1 }
-})
 
 export const ClipboardButton = ({ text, onClick, children, ...props }) => {
   const [copied, setCopied] = useState(false)

--- a/src/pages/ImportData.js
+++ b/src/pages/ImportData.js
@@ -2,7 +2,7 @@ import _ from 'lodash/fp'
 import { Fragment, useState } from 'react'
 import { div, h, h2, img, li, p, span, strong, ul } from 'react-hyperscript-helpers'
 import Collapse from 'src/components/Collapse'
-import { backgroundLogo, ButtonPrimary, ButtonSecondary, Clickable, IdContainer, RadioButton, spinnerOverlay } from 'src/components/common'
+import { ButtonPrimary, ButtonSecondary, Clickable, IdContainer, RadioButton, spinnerOverlay } from 'src/components/common'
 import { notifyDataImportProgress } from 'src/components/data/data-utils'
 import FooterWrapper from 'src/components/FooterWrapper'
 import { icon, wdlIcon } from 'src/components/icons'
@@ -10,6 +10,7 @@ import NewWorkspaceModal from 'src/components/NewWorkspaceModal'
 import TopBar from 'src/components/TopBar'
 import { useWorkspaces, WorkspaceSelector } from 'src/components/workspace-utils'
 import jupyterLogo from 'src/images/jupyter-logo.svg'
+import scienceBackground from 'src/images/science-background.jpg'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
 import { withErrorReporting } from 'src/libs/error'
@@ -205,7 +206,11 @@ const ImportData = () => {
   return h(FooterWrapper, [
     h(TopBar, { title }),
     div({ role: 'main', style: styles.container }, [
-      backgroundLogo,
+      img({
+        src: scienceBackground,
+        alt: '',
+        style: { position: 'fixed', top: 0, left: 0, zIndex: -1 }
+      }),
       div({ style: styles.card }, [
         h2({ style: styles.title }, [header]),
         !_.isEmpty(snapshots) ?

--- a/src/pages/TermsOfService.js
+++ b/src/pages/TermsOfService.js
@@ -1,9 +1,10 @@
 import _ from 'lodash/fp'
 import { useState } from 'react'
-import { div, h, h1 } from 'react-hyperscript-helpers'
-import { backgroundLogo, ButtonPrimary, ButtonSecondary } from 'src/components/common'
+import { div, h, h1, img } from 'react-hyperscript-helpers'
+import { ButtonPrimary, ButtonSecondary } from 'src/components/common'
 import { centeredSpinner } from 'src/components/icons'
 import { MarkdownViewer, newWindowLinkRenderer } from 'src/components/markdown'
+import scienceBackground from 'src/images/science-background.jpg'
 import { Ajax } from 'src/libs/ajax'
 import { signOut } from 'src/libs/auth'
 import colors from 'src/libs/colors'
@@ -42,7 +43,11 @@ const TermsOfServicePage = () => {
   }
 
   return div({ role: 'main', style: { padding: '1rem', minHeight: '100%', display: 'flex', justifyContent: 'center', alignItems: 'center' } }, [
-    backgroundLogo,
+    img({
+      src: scienceBackground,
+      alt: '',
+      style: { position: 'fixed', top: 0, left: 0, zIndex: -1 }
+    }),
     div({ style: { backgroundColor: 'white', borderRadius: 5, width: 800, maxHeight: '100%', padding: '2rem', boxShadow: Style.standardShadow } }, [
       h1({ style: { color: colors.dark(), fontSize: 38, fontWeight: 400 } }, ['Terra Terms of Service']),
       needToAccept && div({ style: { fontSize: 18, fontWeight: 600 } }, ['Please accept the Terms of Service to continue.']),


### PR DESCRIPTION
Continuing to split up components/common.js. `backgroundLogo` is used in only two places (the terms of service and import data pages) and is so small that I inlined it in both pages instead of having a shared element.