### PR TITLE
[SUP-706] Add button to clear all workflow inputs/outputs

### DIFF
--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -66,6 +66,7 @@ const eventsList = {
   removeBillingAccount: 'billing:project:account:remove',
   resourceLeave: 'resource:leave',
   userRegister: 'user:register',
+  workflowClearIO: 'workflow:clearIO',
   workflowImport: 'workflow:import',
   workflowLaunch: 'workflow:launch',
   workflowRerun: 'workflow:rerun',

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -1011,6 +1011,13 @@ const WorkflowView = _.flow(
     }
   }
 
+  clear(key) {
+    this.setState(prevState => {
+      const { modifiedConfig: prevModifiedConfig } = prevState
+      return { modifiedConfig: _.set(key, {}, prevModifiedConfig) }
+    })
+  }
+
   renderWDL() {
     const { wdl } = this.state
     return div({ style: styles.tabContents }, [
@@ -1079,6 +1086,10 @@ const WorkflowView = _.flow(
         isEditable && h(Fragment, [
           div({ style: { whiteSpace: 'pre' } }, ['  |  Drag or click to ']),
           h(Link, { style: linkStyle, onClick: openUploader }, ['upload json'])
+        ]),
+        isEditable && h(Fragment, [
+          div({ style: { whiteSpace: 'pre' } }, ['  |  ']),
+          h(Link, { style: linkStyle, onClick: () => this.clear(key) }, [`Clear ${key}`])
         ]),
         h(DelayedSearchInput, {
           'aria-label': `Search ${key}`,

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -1016,6 +1016,17 @@ const WorkflowView = _.flow(
       const { modifiedConfig: prevModifiedConfig } = prevState
       return { modifiedConfig: _.set(key, {}, prevModifiedConfig) }
     })
+
+    const { workspace } = this.props
+    const { modifiedConfig } = this.state
+    const { methodRepoMethod: { methodVersion, methodNamespace, methodName, methodPath, sourceRepo } } = modifiedConfig
+    Ajax().Metrics.captureEvent(Events.workflowClearIO, {
+      ...extractWorkspaceDetails(workspace.workspace),
+      inputsOrOutputs: key,
+      methodVersion,
+      sourceRepo,
+      methodPath: sourceRepo === 'agora' ? `${methodNamespace}/${methodName}` : methodPath
+    })
   }
 
   renderWDL() {


### PR DESCRIPTION
If a workflow has many inputs/outputs and a user only wants to use a few of them, it can be tedious to clear them one at a time. This adds a button to clear all inputs/outputs.

![Screen Shot 2022-12-16 at 2 04 19 PM](https://user-images.githubusercontent.com/1156625/208170644-fd248993-4181-4f2a-948c-95b91995c308.png)