### PR TITLE
[ID-373] update preview-drs-uri test

### DIFF
--- a/integration-tests/tests/preview-drs-uri.js
+++ b/integration-tests/tests/preview-drs-uri.js
@@ -35,7 +35,8 @@ const testPreviewDrsUriFn = _.flow(
   await click(page, clickable({ textContains: testEntity.entityType }))
   await click(page, elementInDataTableRow(testEntity.name, testEntity.attributes.file_uri))
   await waitForNoSpinners(page)
-  await findText(page, 'View this file in the Google Cloud Storage Browser')
+  await findText(page, 'Filename')
+  await findText(page, 'File size')
 })
 
 registerTest({


### PR DESCRIPTION
This updates the preview-drs-uri integration tests to look for different information on the page. This test uses a TDR DRS URI, and we are about to enable signed URLs for TDR. This changes the modal display when previewing files such that the string the test was looking for does not appear. The checks I added should be present for any DRS URI regardless of signed URL status. 
