### PR TITLE
[TOAZ-297 cont] Change support email and add subject

### DIFF
--- a/src/pages/AzurePreview.js
+++ b/src/pages/AzurePreview.js
@@ -45,7 +45,8 @@ const AzurePreview = () => {
     }
   }
 
-  const supportEmail = 'support@terra.bio'
+  const supportEmail = 'preview@terra.bio'
+  const supportSubject = 'Terra on Azure Preview Environment'
 
   const dismiss = () => {
     azurePreviewStore.set(true)
@@ -86,7 +87,7 @@ const AzurePreview = () => {
       div({ style: styles.centered }, [
         p({ style: styles.paragraph }, [
           'You are not currently part of the Terra on Azure Preview Program. If you are interested in joining the program, please contact ',
-          h(Link, { href: `mailto:${supportEmail}`, ...Utils.newTabLinkProps, style: { textDecoration: 'underline' } }, supportEmail),
+          h(Link, { href: `mailto:${supportEmail}?subject=${supportSubject}`, ...Utils.newTabLinkProps, style: { textDecoration: 'underline' } }, supportEmail),
           '.'
         ])
       ])

--- a/src/pages/AzurePreview.js
+++ b/src/pages/AzurePreview.js
@@ -87,7 +87,7 @@ const AzurePreview = () => {
       div({ style: styles.centered }, [
         p({ style: styles.paragraph }, [
           'You are not currently part of the Terra on Azure Preview Program. If you are interested in joining the program, please contact ',
-          h(Link, { href: `mailto:${supportEmail}?subject=${supportSubject}`, ...Utils.newTabLinkProps, style: { textDecoration: 'underline' } }, supportEmail),
+          h(Link, { href: `mailto:${supportEmail}?subject=${encodeURIComponent(supportSubject)}`, ...Utils.newTabLinkProps, style: { textDecoration: 'underline' } }, supportEmail),
           '.'
         ])
       ])


### PR DESCRIPTION
Another request from MSFT + Support team. Changed support email (all @terra.bio emails get funneled to support@terra.bio) and added a subject line for easy filtering.

<img width="613" alt="image" src="https://user-images.githubusercontent.com/5368863/208177606-8f4a6202-7cec-4254-a891-dad2621c6796.png">

