### PR TITLE
[SU-256] Label workflow outputs as optional

### DIFF
--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -161,7 +161,11 @@ const WorkflowIOTable = ({ which, inputsOutputs: data, config, errors, onChange,
                 h(DelayedAutocompleteTextArea, {
                   autosize: true,
                   spellCheck: false,
-                  placeholder: optional ? 'Optional' : 'Required',
+                  placeholder: Utils.cond(
+                    [which === 'outputs', () => undefined],
+                    [optional, () => 'Optional'],
+                    () => 'Required'
+                  ),
                   value,
                   style: isFile ? { paddingRight: '2rem' } : undefined,
                   onChange: v => onChange(name, v),

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -161,11 +161,7 @@ const WorkflowIOTable = ({ which, inputsOutputs: data, config, errors, onChange,
                 h(DelayedAutocompleteTextArea, {
                   autosize: true,
                   spellCheck: false,
-                  placeholder: Utils.cond(
-                    [which === 'outputs', () => undefined],
-                    [optional, () => 'Optional'],
-                    () => 'Required'
-                  ),
+                  placeholder: which === 'inputs' && !optional ? 'Required' : 'Optional',
                   value,
                   style: isFile ? { paddingRight: '2rem' } : undefined,
                   onChange: v => onChange(name, v),


### PR DESCRIPTION
Terra labels workflow outputs as "Required". But they aren't actually required. Terra will run a workflow without any outputs configured. This changes the placeholder for workflow outputs from "Required" to "Optional".

## Before
<img width="1624" alt="Screen Shot 2022-12-16 at 5 00 35 PM" src="https://user-images.githubusercontent.com/1156625/208197167-269a4b97-d5f9-4d27-a85b-e40ee99b72db.png">

## After
![Screen Shot 2022-12-21 at 12 26 44 PM](https://user-images.githubusercontent.com/1156625/208967029-cb5a1942-fcbe-465d-963f-9daf2b1dfaae.png)


