### PR TITLE
[UIE-30] Fix types for IdContainer

### DIFF
--- a/src/components/common/IdContainer.ts
+++ b/src/components/common/IdContainer.ts
@@ -1,10 +1,15 @@
 import _ from 'lodash/fp'
-import { useMemo, useState } from 'react'
+import { ReactElement, useMemo, useState } from 'react'
+
+
+type IdContainerProps = {
+  children: (id: string) => ReactElement<any, any> | null
+}
 
 /**
  * DEPRECATED - should switch to useUniqueIdFn pattern
  */
-export const IdContainer = ({ children }) => {
+export const IdContainer = ({ children }: IdContainerProps) => {
   const [id] = useState(() => _.uniqueId('element-'))
   return children(id)
 }


### PR DESCRIPTION
Follow up to this comment on #3603: https://github.com/DataBiosphere/terra-ui/pull/3603#pullrequestreview-1223226164

> I think the TypeScript headaches would be solved by typing IdContainer's children prop so that it's not assumed to be a React node.

Currently, TypeScript complains about something like
```js
h(IdContainer, [id => div([id])]),
```
saying that 
> Type '(id: any) => ReactElement<any, any>' is not assignable to type 'ReactNode'.

Without any other information, our types for react-hyperscript-helpers assume that children should be an array of React nodes. This adds the proper type for IdContainer's children: a function that accepts an ID parameter and returns a React element.