### PR TITLE
[SU-254] Add terminal download command to file details modal

### DIFF
--- a/src/components/file-browser/DownloadFileCommand.test.ts
+++ b/src/components/file-browser/DownloadFileCommand.test.ts
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react'
+import { h } from 'react-hyperscript-helpers'
+import FileBrowserProvider, { FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
+import { asMockedFn } from 'src/testing/test-utils'
+
+import { DownloadFileCommand } from './DownloadFileCommand'
+import { useFileDownloadCommand } from './useFileDownloadCommand'
+
+
+jest.mock('./useFileDownloadCommand', () => ({
+  ...jest.requireActual('./useFileDownloadCommand'),
+  useFileDownloadCommand: jest.fn(),
+}))
+
+
+describe('DownloadFileComamnd', () => {
+  // Arrange
+  const file: FileBrowserFile = {
+    path: 'path/to/example.txt',
+    url: 'gs://test-bucket/path/to/example.txt',
+    size: 1024 ** 2,
+    createdAt: 1667408400000,
+    updatedAt: 1667494800000,
+  }
+
+  const mockProvider = {} as FileBrowserProvider
+
+  it('renders download command', () => {
+    // Arrange
+    asMockedFn(useFileDownloadCommand).mockReturnValue({
+      status: 'Ready',
+      state: 'gsutil cp gs://test-bucket/path/to/example.txt example.txt',
+    })
+
+    // Act
+    render(h(DownloadFileCommand, { file, provider: mockProvider }))
+
+    // Assert
+    screen.getByText('gsutil cp gs://test-bucket/path/to/example.txt example.txt')
+  })
+
+  it('renders a spinner while loading command', () => {
+    // Arrange
+    asMockedFn(useFileDownloadCommand).mockReturnValue({
+      status: 'Loading',
+      state: null,
+    })
+
+    // Act
+    const { container } = render(h(DownloadFileCommand, { file, provider: mockProvider }))
+
+    // Assert
+    expect(container.querySelector('svg[data-icon="loadingSpinner"]')).toBeTruthy()
+  })
+})

--- a/src/components/file-browser/DownloadFileCommand.ts
+++ b/src/components/file-browser/DownloadFileCommand.ts
@@ -1,0 +1,51 @@
+import { Fragment } from 'react'
+import { h, p, pre, span } from 'react-hyperscript-helpers'
+import { ClipboardButton } from 'src/components/ClipboardButton'
+import { useFileDownloadCommand } from 'src/components/file-browser/useFileDownloadCommand'
+import { spinner } from 'src/components/icons'
+import FileBrowserProvider, { FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
+import colors from 'src/libs/colors'
+
+
+interface DownloadFileCommandProps {
+  file: FileBrowserFile
+  provider: FileBrowserProvider
+}
+
+export const DownloadFileCommand = (props: DownloadFileCommandProps) => {
+  const { file, provider } = props
+
+  const { status, state: downloadCommand } = useFileDownloadCommand({ file, provider })
+
+  return h(Fragment, [
+    p({ style: { marginBottom: '0.5rem', fontWeight: 500 } }, [
+      'Terminal download command:',
+      // @ts-expect-error
+      status === 'Loading' && spinner({ size: 12, style: { color: '#000', marginLeft: '1ch' } }),
+    ]),
+    pre({
+      style: {
+        display: 'flex',
+        alignItems: 'center',
+        margin: 0,
+        padding: '0 0.5rem',
+        background: colors.light(0.4),
+      }
+    }, [
+      span({
+        style: {
+          overflowX: 'auto',
+          flex: '1 1 0',
+          padding: '1rem 0',
+        }
+      }, [downloadCommand || ' ']),
+      h(ClipboardButton, {
+        children: undefined,
+        disabled: !downloadCommand,
+        style: { marginLeft: '1ch' },
+        text: downloadCommand,
+        onClick: undefined,
+      })
+    ])
+  ])
+}

--- a/src/components/file-browser/DownloadFileCommand.ts
+++ b/src/components/file-browser/DownloadFileCommand.ts
@@ -19,7 +19,7 @@ export const DownloadFileCommand = (props: DownloadFileCommandProps) => {
 
   return h(Fragment, [
     p({ style: { marginBottom: '0.5rem', fontWeight: 500 } }, [
-      'Terminal download command:',
+      'Terminal download command',
       // @ts-expect-error
       status === 'Loading' && spinner({ size: 12, style: { color: '#000', marginLeft: '1ch' } }),
     ]),

--- a/src/components/file-browser/FileDetails.test.ts
+++ b/src/components/file-browser/FileDetails.test.ts
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom'
 
 import { render, screen } from '@testing-library/react'
 import { div, h } from 'react-hyperscript-helpers'
+import { DownloadFileCommand } from 'src/components/file-browser/DownloadFileCommand'
 import { DownloadFileLink } from 'src/components/file-browser/DownloadFileLink'
 import { FileDetails } from 'src/components/file-browser/FileDetails'
 import FileBrowserProvider, { FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
@@ -13,8 +14,14 @@ jest.mock('src/components/file-browser/DownloadFileLink', () => ({
   DownloadFileLink: jest.fn(),
 }))
 
+jest.mock('src/components/file-browser/DownloadFileCommand', () => ({
+  ...jest.requireActual('src/components/file-browser/DownloadFileCommand'),
+  DownloadFileCommand: jest.fn(),
+}))
+
 beforeAll(() => {
   asMockedFn(DownloadFileLink).mockImplementation(() => div(['Download file']))
+  asMockedFn(DownloadFileCommand).mockImplementation(() => div(['Download command']))
 })
 
 describe('FileDetails', () => {
@@ -48,5 +55,13 @@ describe('FileDetails', () => {
 
     // Assert
     screen.getByText('Download file')
+  })
+
+  it('renders download command', () => {
+    // Act
+    render(h(FileDetails, { file, provider: mockProvider }))
+
+    // Assert
+    screen.getByText('Download command')
   })
 })

--- a/src/components/file-browser/FileDetails.ts
+++ b/src/components/file-browser/FileDetails.ts
@@ -1,6 +1,7 @@
 import filesize from 'filesize'
 import { Fragment } from 'react'
 import { dd, div, dl, dt, h } from 'react-hyperscript-helpers'
+import { DownloadFileCommand } from 'src/components/file-browser/DownloadFileCommand'
 import { DownloadFileLink } from 'src/components/file-browser/DownloadFileLink'
 import FileBrowserProvider, { FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
 
@@ -28,6 +29,7 @@ export const FileDetails = (props: FileDetailsProps) => {
         dd({ style: { marginLeft: '0.5rem' } }, [filesize(file.size)]),
       ]),
     ]),
-    h(DownloadFileLink, { file, provider })
+    h(DownloadFileLink, { file, provider }),
+    h(DownloadFileCommand, { file, provider }),
   ])
 }

--- a/src/components/file-browser/useFileDownloadCommand.test.ts
+++ b/src/components/file-browser/useFileDownloadCommand.test.ts
@@ -1,0 +1,67 @@
+import { renderHook } from '@testing-library/react-hooks'
+import FileBrowserProvider, { FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
+import { reportError } from 'src/libs/error'
+import { controlledPromise } from 'src/testing/test-utils'
+
+import { useFileDownloadCommand } from './useFileDownloadCommand'
+
+
+jest.mock('src/libs/error', () => ({
+  ...jest.requireActual('src/libs/error'),
+  reportError: jest.fn(),
+}))
+
+
+describe('useFileDownloadCommand', () => {
+  let getDownloadCommandForFileController
+
+  // Arrange
+  const mockProvider = {
+    getDownloadCommandForFile: jest.fn(() => {
+      const [promise, controller] = controlledPromise<string>()
+      getDownloadCommandForFileController = controller
+      return promise
+    })
+  } as Partial<FileBrowserProvider> as FileBrowserProvider
+
+  it('returns download command for file', async () => {
+    // Arrange
+    const file: FileBrowserFile = {
+      path: 'path/to/example.txt',
+      url: 'gs://test-bucket/path/to/example.txt',
+      size: 1024 ** 2,
+      createdAt: 1667408400000,
+      updatedAt: 1667494800000,
+    }
+
+    // Act
+    const { result: hookReturnRef, waitForNextUpdate } = renderHook(() => useFileDownloadCommand({ file, provider: mockProvider }))
+    getDownloadCommandForFileController.resolve('gsutil cp gs://test-bucket/path/to/example.txt .')
+    await waitForNextUpdate()
+    const result = hookReturnRef.current
+
+    // Assert
+    expect(result).toEqual({ status: 'Ready', state: 'gsutil cp gs://test-bucket/path/to/example.txt .' })
+  })
+
+  it('handles errors', async () => {
+    // Arrange
+    const file: FileBrowserFile = {
+      path: 'path/to/example.txt',
+      url: 'gs://test-bucket/path/to/example.txt',
+      size: 1024 ** 2,
+      createdAt: 1667408400000,
+      updatedAt: 1667494800000,
+    }
+
+    // Act
+    const { result: hookReturnRef, waitForNextUpdate } = renderHook(() => useFileDownloadCommand({ file, provider: mockProvider }))
+    getDownloadCommandForFileController.reject(new Error('Something went wrong'))
+    await waitForNextUpdate()
+    const result = hookReturnRef.current
+
+    // Assert
+    expect(reportError).toHaveBeenCalled()
+    expect(result).toEqual({ status: 'Error', state: null, error: new Error('Something went wrong') })
+  })
+})

--- a/src/components/file-browser/useFileDownloadCommand.ts
+++ b/src/components/file-browser/useFileDownloadCommand.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react'
+import FileBrowserProvider, { FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
+import { reportError } from 'src/libs/error'
+import { useCancellation } from 'src/libs/react-utils'
+import LoadedState, { NoneState } from 'src/libs/type-utils/LoadedState'
+
+
+type UseFileDownloadCommandOptions = {
+  file: FileBrowserFile
+  provider: FileBrowserProvider
+}
+
+type UseFileDownloadCommandResult = Exclude<LoadedState<string, unknown>, NoneState>
+
+export const useFileDownloadCommand = (opts: UseFileDownloadCommandOptions) => {
+  const { file, provider } = opts
+
+  const [result, setResult] = useState<UseFileDownloadCommandResult>({ status: 'Loading', state: null })
+
+  const signal = useCancellation()
+
+  useEffect(() => {
+    (async () => {
+      setResult({ status: 'Loading', state: null })
+      try {
+        const url = await provider.getDownloadCommandForFile(file.path, { signal })
+        setResult({ status: 'Ready', state: url })
+      } catch (error) {
+        reportError('Unable to get download command', error)
+        setResult({ status: 'Error', state: null, error })
+      }
+    })()
+  }, [file, provider, signal])
+
+  return result
+}

--- a/src/libs/ajax/file-browser-providers/AzureBlobStorageFileBrowserProvider.test.ts
+++ b/src/libs/ajax/file-browser-providers/AzureBlobStorageFileBrowserProvider.test.ts
@@ -195,6 +195,17 @@ describe('AzureBlobStorageFileBrowserProvider', () => {
     expect(downloadUrl).toBe('https://terra-ui-test.blob.core.windows.net/test-storage-container/path/to/example.txt?tokenPlaceholder=value')
   })
 
+  it('returns an azcopy download command', async () => {
+    // Arrange
+    const provider = AzureBlobStorageFileBrowserProvider({ workspaceId: 'test-workspace' })
+
+    // Act
+    const downloadCommand = await provider.getDownloadCommandForFile('path/to/example.txt')
+
+    // Assert
+    expect(downloadCommand).toBe('azcopy copy \'https://terra-ui-test.blob.core.windows.net/test-storage-container/path/to/example.txt?tokenPlaceholder=value\' .')
+  })
+
   it('uploads a file', async () => {
     // Arrange
     asMockedFn(fetchOk).mockResolvedValue(new Response())

--- a/src/libs/ajax/file-browser-providers/AzureBlobStorageFileBrowserProvider.ts
+++ b/src/libs/ajax/file-browser-providers/AzureBlobStorageFileBrowserProvider.ts
@@ -153,6 +153,12 @@ const AzureBlobStorageFileBrowserProvider = ({ workspaceId, pageSize = 1000 }: A
       blobUrl.pathname += `/${path}`
       return blobUrl.href
     },
+    getDownloadCommandForFile: async path => {
+      const { sas: { url: originalSasUrl } } = await storageDetailsPromise
+      const blobUrl = new URL(originalSasUrl)
+      blobUrl.pathname += `/${path}`
+      return `azcopy copy '${blobUrl.href}' .`
+    },
     uploadFileToDirectory: async (directoryPath, file) => {
       const { sas: { url: originalSasUrl } } = await storageDetailsPromise
 

--- a/src/libs/ajax/file-browser-providers/FileBrowserProvider.ts
+++ b/src/libs/ajax/file-browser-providers/FileBrowserProvider.ts
@@ -17,6 +17,7 @@ interface FileBrowserProvider {
   getDirectoriesInDirectory(path: string, options?: { signal?: AbortSignal }): Promise<IncrementalResponse<FileBrowserDirectory>>
   getFilesInDirectory(path: string, options?: { signal?: AbortSignal }): Promise<IncrementalResponse<FileBrowserFile>>
   getDownloadUrlForFile(path: string, options?: { signal?: AbortSignal }): Promise<string>
+  getDownloadCommandForFile(path: string, options?: { signal?: AbortSignal }): Promise<string>
 
   uploadFileToDirectory(directoryPath: string, file: File): Promise<void>
   deleteFile(path: string): Promise<void>

--- a/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.test.ts
+++ b/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.test.ts
@@ -164,6 +164,17 @@ describe('GCSFileBrowserProvider', () => {
     expect(downloadUrl).toBe('signedUrl')
   })
 
+  it('returns a gsutil download command', async () => {
+    // Arrange
+    const provider = GCSFileBrowserProvider({ bucket: 'test-bucket', project: 'test-project' })
+
+    // Act
+    const downloadCommand = await provider.getDownloadCommandForFile('path/to/example.txt')
+
+    // Assert
+    expect(downloadCommand).toBe('gsutil cp gs://test-bucket/path/to/example.txt .')
+  })
+
   it('uploads a file', async () => {
     // Arrange
     const upload = jest.fn(() => Promise.resolve())

--- a/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.ts
+++ b/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.ts
@@ -108,6 +108,9 @@ const GCSFileBrowserProvider = ({ bucket, project, pageSize = 1000 }: GCSFileBro
       })
       return url
     },
+    getDownloadCommandForFile: path => {
+      return Promise.resolve(`gsutil cp gs://${bucket}/${path} .`)
+    },
     uploadFileToDirectory: (directoryPath, file) => {
       return Ajax().Buckets.upload(project, bucket, directoryPath, file)
     },


### PR DESCRIPTION
Add a command to download the file from the terminal to the file details modal in the new file browser. For GCS files, it shows a gsutil command. For Azure files, an azcopy command.

<img width="456" alt="Screen Shot 2022-12-20 at 12 58 54 PM" src="https://user-images.githubusercontent.com/1156625/208734786-449cbd78-a73f-4fd1-a6a5-78a1cb6cda19.png">

<img width="460" alt="Screen Shot 2022-12-20 at 12 58 40 PM" src="https://user-images.githubusercontent.com/1156625/208734788-fc78ae76-265f-4be1-ac97-68c28389aff8.png">


