### PR TITLE
[IA-3921] Fix key warnings in ComputeModal

### DIFF
--- a/src/pages/workspaces/workspace/analysis/modals/ComputeModal.js
+++ b/src/pages/workspaces/workspace/analysis/modals/ComputeModal.js
@@ -891,7 +891,7 @@ export const ComputeModalBase = ({
             ]),
             div([
               'Custom environments ', b(['must ']), 'be based off ',
-              Utils.switchCase(tool, [
+              ...Utils.switchCase(tool, [
                 toolLabels.RStudio, () => ['the ', h(Link,
                   { href: anVILRStudioImage, ...Utils.newTabLinkProps }, ['AnVIL RStudio image'])]
                 ], [
@@ -1237,7 +1237,7 @@ export const ComputeModalBase = ({
         p([
           'You are about to create a virtual machine using an unverified Docker image. ',
           'Please make sure that it was created by you or someone you trust using ',
-          Utils.switchCase(tool, [
+          ...Utils.switchCase(tool, [
             toolLabels.RStudio, () => ['our base ', h(Link, { href: anVILRStudioImage, ...Utils.newTabLinkProps }, ['AnVIL RStudio image.'])]
           ], [
             toolLabels.Jupyter, () => ['one of our ', h(Link, { href: terraBaseImages, ...Utils.newTabLinkProps }, ['Terra base images.'])]


### PR DESCRIPTION
Fix React key warnings in a few places in ComputeModal. This reduces noise in unit test output. Run `yarn test ComputeModal` to see the difference.

These warnings appear when selecting a custom image:

<img width="655" alt="Screen Shot 2022-12-20 at 1 06 43 PM" src="https://user-images.githubusercontent.com/1156625/208736578-c1ac7e72-567d-468d-a6f1-840523d74407.png">

<img width="652" alt="Screen Shot 2022-12-20 at 1 09 29 PM" src="https://user-images.githubusercontent.com/1156625/208736588-875d88c5-a334-453d-b8c9-0f23a00696e6.png">

Alternatively, these could be fixed by having the functions in `Utils.switchCase` return Fragments instead of arrays.