### PR TITLE
[UIE-28] Silence console logs in tests for isAxeEnabled

### DIFF
--- a/src/libs/config.test.js
+++ b/src/libs/config.test.js
@@ -7,6 +7,8 @@ describe('isAxeEnabled', () => {
   beforeAll(() => {
     env = process.env.NODE_ENV
 
+    // isAxeEnabled logs a notice and instructions for developers.
+    // Those should not be shown in test output.
     jest.spyOn(console, 'log').mockImplementation(() => {})
   })
 

--- a/src/libs/config.test.js
+++ b/src/libs/config.test.js
@@ -6,6 +6,8 @@ describe('isAxeEnabled', () => {
 
   beforeAll(() => {
     env = process.env.NODE_ENV
+
+    jest.spyOn(console, 'log').mockImplementation(() => {})
   })
 
   afterAll(() => {


### PR DESCRIPTION
`isAxeEnabled` logs to the console to let devs know if axe is enabled or not and how to enable/disable it.

https://github.com/DataBiosphere/terra-ui/blob/4f39c15aaca7e6d56af8fd3a5834c108d1cd1613/src/libs/config.js#L15-L33

That information is useful when looking at the local development server, but it becomes noise when looking at unit test outputs. This silences those console logs in unit tests.