### PR TITLE
[UIE-32] Add types for Dropzone

### DIFF
--- a/src/components/Dropzone.ts
+++ b/src/components/Dropzone.ts
@@ -1,9 +1,24 @@
-import { useState } from 'react'
-import { useDropzone } from 'react-dropzone'
+import { CSSProperties, useState } from 'react'
+import {
+  DropzoneOptions as ReactDropzoneOptions,
+  DropzoneState as ReactDropzoneState,
+  useDropzone,
+} from 'react-dropzone'
 import { div, input } from 'react-hyperscript-helpers'
 
 
-const Dropzone = ({ disabled = false, onDragOver, onDrop, onDragLeave, style = {}, activeStyle = {}, children, ...props }) => {
+type DropzoneState = Omit<ReactDropzoneState, 'getInputProps' | 'getRootProps' | 'open'> & {
+  dragging: boolean
+  openUploader: () => void
+}
+
+type DropzoneProps = ReactDropzoneOptions & {
+  activeStyle?: CSSProperties
+  children: (state: DropzoneState) => JSX.Element
+  style?: CSSProperties
+}
+
+const Dropzone = ({ disabled = false, onDragOver, onDrop, onDragLeave, style = {}, activeStyle = {}, children, ...props }: DropzoneProps) => {
   // dropzone's built-in dragging status doesn't seem to work if there's anything rendered over the root div
   const [dragging, setDragging] = useState(false)
 

--- a/src/components/Dropzone.ts
+++ b/src/components/Dropzone.ts
@@ -9,7 +9,7 @@ import { div, input } from 'react-hyperscript-helpers'
 
 type DropzoneState = Omit<ReactDropzoneState, 'getInputProps' | 'getRootProps' | 'open'> & {
   dragging: boolean
-  openUploader: () => void
+  openUploader: ReactDropzoneState['open']
 }
 
 type DropzoneProps = ReactDropzoneOptions & {

--- a/src/components/file-browser/FilesInDirectory.ts
+++ b/src/components/file-browser/FilesInDirectory.ts
@@ -80,7 +80,6 @@ const FilesInDirectory = (props: FilesInDirectoryProps) => {
         await uploadFiles(files)
         reload()
       }
-      // @ts-expect-error
     }, [({ openUploader }) => h(Fragment, [
       h(FilesMenu, {
         disabled: editDisabled,


### PR DESCRIPTION
Currently, any use of the Dropzone component in TypeScript requires a `ts-ignore` or `ts-expect-error` because, without any other type information, our types for react-hyperscript-helpers assume that components' children should be an array of React nodes. Dropzone, however, accepts a function as a child. This converts Dropzone.js to TypeScript and adds types for Dropzone's props.