### PR TITLE
[SU-257] Avoid "this.undefined_id" in workflow input suggestions

### DIFF
--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -1063,7 +1063,7 @@ const WorkflowView = _.flow(
     const attributeNames = _.get([modifiedConfig.rootEntityType, 'attributeNames'], selectionMetadata) || []
 
     const suggestions = [
-      ...(!selectedTableName && !modifiedConfig.dataReferenceName) ? [`this.${modifiedConfig.rootEntityType}_id`] : [],
+      ...(!selectedTableName && !modifiedConfig.dataReferenceName && modifiedConfig.rootEntityType) ? [`this.${modifiedConfig.rootEntityType}_id`] : [],
       ...(modifiedConfig.rootEntityType ? _.map(name => `this.${name}`, attributeNames) : []),
       ...getWorkflowInputSuggestionsForAttributesOfSetMembers(selectedEntities, selectionMetadata),
       ..._.map(name => `workspace.${name}`, workspaceAttributes)


### PR DESCRIPTION
Currently, when "Run workflow with inputs defined by file paths" is selected, the workflow inputs autocomplete includes an entry "this.undefined_id". This is because it is including `this.${modifiedConfig.rootEntityType}_id` when `modifiedConfig.rootEntityType` is undefined. With this change, that suggestion is only included if the root entity type is defined.

## Before
<img width="1624" alt="Screen Shot 2022-12-21 at 3 50 40 PM" src="https://user-images.githubusercontent.com/1156625/209000534-6a3aee4d-ef54-4686-8edb-592e408a7b82.png">

## After
<img width="1624" alt="Screen Shot 2022-12-21 at 3 50 13 PM" src="https://user-images.githubusercontent.com/1156625/209000553-e989807c-79e0-4cdb-8360-289faba94b93.png">
