### PR TITLE
Include cloudPlatform in billing events (WOR-676).

### DIFF
--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -25,6 +25,7 @@ const eventsList = {
   billingProjectGoToWorkspace: 'billing:project:workspace:navigate',
   billingProjectOpenFromList: 'billing:project:open-from-list',
   billingProjectSelectTab: 'billing:project:tab',
+  billingChangeAccount: 'billing:project:account:update',
   billingCreationStep1: 'billing:creation:step1:gcpConsoleClicked',
   billingCreationStep2BillingAccountNoAccess: 'billing:creation:step2:billingAccountNoAccess',
   billingCreationStep2HaveBillingAccount: 'billing:creation:step2:haveBillingAccount',
@@ -37,7 +38,7 @@ const eventsList = {
   billingCreationGCPBillingAccountSelected: 'billing:creation:gcpBillingAccountSelected',
   billingCreationGCPBillingProjectCreated: 'billing:creation:gcpBillingProjectCreated',
   billingCreationAzureBillingProjectCreated: 'billing:creation:azureBillingProjectCreated',
-  changeBillingAccount: 'billing:project:account:update',
+  billingRemoveAccount: 'billing:project:account:remove',
   cloudEnvironmentConfigOpen: 'cloudEnvironment:config:open',
   cloudEnvironmentCreate: 'cloudEnvironment:create',
   cloudEnvironmentDelete: 'cloudEnvironment:delete',
@@ -64,7 +65,6 @@ const eventsList = {
   notebookCopy: 'notebook:copy',
   notificationToggle: 'notification:toggle',
   pageView: 'page:view',
-  removeBillingAccount: 'billing:project:account:remove',
   resourceLeave: 'resource:leave',
   userRegister: 'user:register',
   workflowClearIO: 'workflow:clearIO',
@@ -118,6 +118,13 @@ export const extractCrossWorkspaceDetails = (fromWorkspace, toWorkspace) => {
     fromWorkspaceName: fromWorkspace.workspace.name,
     toWorkspaceNamespace: toWorkspace.workspace.namespace,
     toWorkspaceName: toWorkspace.workspace.name
+  }
+}
+
+export const extractBillingDetails = billingProject => {
+  return {
+    billingProjectName: billingProject.projectName,
+    billingProjectCloudPlatform: _.toUpper(billingProject.cloudPlatform) // Should already be uppercase, but enforce for consistency.
   }
 }
 

--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -36,8 +36,7 @@ const eventsList = {
   billingCreationContactTerraSupport: 'billing:creation:contactTerraSupport',
   billingCreationGCPProjectNameEntered: 'billing:creation:gcpProjectNameEntered',
   billingCreationGCPBillingAccountSelected: 'billing:creation:gcpBillingAccountSelected',
-  billingCreationGCPBillingProjectCreated: 'billing:creation:gcpBillingProjectCreated',
-  billingCreationAzureBillingProjectCreated: 'billing:creation:azureBillingProjectCreated',
+  billingCreationBillingProjectCreated: 'billing:creation:billingProjectCreated',
   billingRemoveAccount: 'billing:project:account:remove',
   cloudEnvironmentConfigOpen: 'cloudEnvironment:config:open',
   cloudEnvironmentCreate: 'cloudEnvironment:create',
@@ -124,7 +123,7 @@ export const extractCrossWorkspaceDetails = (fromWorkspace, toWorkspace) => {
 export const extractBillingDetails = billingProject => {
   return {
     billingProjectName: billingProject.projectName,
-    billingProjectCloudPlatform: _.toUpper(billingProject.cloudPlatform) // Should already be uppercase, but enforce for consistency.
+    cloudPlatform: _.toUpper(billingProject.cloudPlatform) // Should already be uppercase, but enforce for consistency.
   }
 }
 

--- a/src/libs/events.test.js
+++ b/src/libs/events.test.js
@@ -1,0 +1,10 @@
+import { extractBillingDetails } from 'src/libs/events'
+
+
+describe('extractBillingDetails', () => {
+  it('Extracts billing project name and cloudPlatform (as upper case)', () => {
+    expect(extractBillingDetails({ projectName: 'projectName', cloudPlatform: 'billingProjectCloudPlatform' })).toEqual(
+      { billingProjectName: 'projectName', billingProjectCloudPlatform: 'BILLINGPROJECTCLOUDPLATFORM' }
+    )
+  })
+})

--- a/src/libs/events.test.js
+++ b/src/libs/events.test.js
@@ -3,8 +3,8 @@ import { extractBillingDetails } from 'src/libs/events'
 
 describe('extractBillingDetails', () => {
   it('Extracts billing project name and cloudPlatform (as upper case)', () => {
-    expect(extractBillingDetails({ projectName: 'projectName', cloudPlatform: 'billingProjectCloudPlatform' })).toEqual(
-      { billingProjectName: 'projectName', billingProjectCloudPlatform: 'BILLINGPROJECTCLOUDPLATFORM' }
+    expect(extractBillingDetails({ projectName: 'projectName', cloudPlatform: 'cloudPlatform' })).toEqual(
+      { billingProjectName: 'projectName', cloudPlatform: 'CLOUDPLATFORM' }
     )
   })
 })

--- a/src/pages/billing/CreateGCPBillingProject.js
+++ b/src/pages/billing/CreateGCPBillingProject.js
@@ -30,8 +30,10 @@ const CreateGCPBillingProject = ({
           placeholder: 'Enter a name',
           onChange: v => {
             setBillingProjectName(v)
+            if (!billingProjectNameTouched) {
+              Ajax().Metrics.captureEvent(Events.billingCreationGCPProjectNameEntered)
+            }
             setBillingProjectNameTouched(true)
-            Ajax().Metrics.captureEvent(Events.billingCreationGCPProjectNameEntered)
           },
           disabled
         },

--- a/src/pages/billing/List.js
+++ b/src/pages/billing/List.js
@@ -399,8 +399,8 @@ export const BillingList = ({ queryParams: { selectedName } }) => {
         loadAccounts,
         onDismiss: () => setCreatingBillingProject(null),
         onSuccess: billingProjectName => {
-          Ajax().Metrics.captureEvent(Events.billingCreationGCPBillingProjectCreated, {
-            billingProjectName, billingProjectCloudPlatform: cloudProviders.gcp.label
+          Ajax().Metrics.captureEvent(Events.billingCreationBillingProjectCreated, {
+            billingProjectName, cloudPlatform: cloudProviders.gcp.label
           })
           setCreatingBillingProject(null)
           loadProjects()
@@ -409,8 +409,8 @@ export const BillingList = ({ queryParams: { selectedName } }) => {
       creatingBillingProject === cloudProviders.azure && isAlphaAzureUser && h(CreateAzureBillingProjectModal, {
         onDismiss: () => setCreatingBillingProject(null),
         onSuccess: billingProjectName => {
-          Ajax().Metrics.captureEvent(Events.billingCreationAzureBillingProjectCreated, {
-            billingProjectName, billingProjectCloudPlatform: cloudProviders.azure.label
+          Ajax().Metrics.captureEvent(Events.billingCreationBillingProjectCreated, {
+            billingProjectName, cloudPlatform: cloudProviders.azure.label
           })
           setCreatingBillingProject(null)
           loadProjects()
@@ -436,8 +436,8 @@ export const BillingList = ({ queryParams: { selectedName } }) => {
         [!isLoadingProjects && _.isEmpty(billingProjects) && !Auth.isAzureUser(), () => h(CreateNewBillingProjectWizard, {
           billingAccounts,
           onSuccess: billingProjectName => {
-            Ajax().Metrics.captureEvent(Events.billingCreationGCPBillingProjectCreated, {
-              billingProjectName, billingProjectCloudPlatform: cloudProviders.gcp.label
+            Ajax().Metrics.captureEvent(Events.billingCreationBillingProjectCreated, {
+              billingProjectName, cloudPlatform: cloudProviders.gcp.label
             })
             setCreatingBillingProject(null)
             loadProjects()

--- a/src/pages/billing/List.js
+++ b/src/pages/billing/List.js
@@ -16,7 +16,7 @@ import * as Auth from 'src/libs/auth'
 import colors from 'src/libs/colors'
 import { getConfig } from 'src/libs/config'
 import { reportError, reportErrorAndRethrow } from 'src/libs/error'
-import Events from 'src/libs/events'
+import Events, { extractBillingDetails } from 'src/libs/events'
 import * as Nav from 'src/libs/nav'
 import { useCancellation, useOnMount } from 'src/libs/react-utils'
 import * as StateHistory from 'src/libs/state-history'
@@ -115,7 +115,7 @@ const BillingProjectActions = ({ project: { projectName }, loadProjects }) => {
   ])
 }
 
-const ProjectListItem = ({ project, project: { roles, status, cloudPlatform }, loadProjects, isActive }) => {
+const ProjectListItem = ({ project, project: { projectName, roles, status, message, cloudPlatform }, loadProjects, isActive }) => {
   const cloudContextIcon =
     div({ style: { display: 'flex', marginRight: '0.5rem' } }, [
       Utils.switchCase(cloudPlatform,
@@ -123,17 +123,15 @@ const ProjectListItem = ({ project, project: { roles, status, cloudPlatform }, l
         [cloudProviders.azure.label, () => h(CloudAzureLogo, { title: cloudProviders.azure.iconTitle, role: 'img' })])
     ])
 
-  const selectableProject = ({ projectName }, isActive) => h(Clickable, {
+  const selectableProject = () => h(Clickable, {
     style: { ...styles.projectListItem(isActive), color: isActive ? colors.accent(1.1) : colors.accent() },
     href: `${Nav.getLink('billing')}?${qs.stringify({ selectedName: projectName, type: 'project' })}`,
-    onClick: () => Ajax().Metrics.captureEvent(Events.billingProjectOpenFromList, {
-      billingProjectName: projectName
-    }),
+    onClick: () => Ajax().Metrics.captureEvent(Events.billingProjectOpenFromList, extractBillingDetails(project)),
     hover: Style.navList.itemHover(isActive),
     'aria-current': isActive ? 'location' : false
   }, [cloudContextIcon, projectName])
 
-  const unselectableProject = ({ projectName, status, message }, isActive, isOwner) => {
+  const unselectableProject = () => {
     const iconAndTooltip =
       isCreatingStatus(status) ? spinner({ size: 16, style: { color: colors.accent(), margin: '0 1rem 0 0.5rem' } }) :
         status === 'Error' ? h(Fragment, [
@@ -157,8 +155,8 @@ const ProjectListItem = ({ project, project: { roles, status, cloudPlatform }, l
 
   return div({ role: 'listitem' }, [
     !_.isEmpty(viewerRoles) && status === 'Ready' ?
-      selectableProject(project, isActive) :
-      unselectableProject(project, isActive, isOwner)
+      selectableProject() :
+      unselectableProject()
   ])
 }
 
@@ -401,7 +399,9 @@ export const BillingList = ({ queryParams: { selectedName } }) => {
         loadAccounts,
         onDismiss: () => setCreatingBillingProject(null),
         onSuccess: billingProjectName => {
-          Ajax().Metrics.captureEvent(Events.billingCreationGCPBillingProjectCreated, { billingProject: billingProjectName })
+          Ajax().Metrics.captureEvent(Events.billingCreationGCPBillingProjectCreated, {
+            billingProject: billingProjectName, cloudPlatform: cloudProviders.gcp.label
+          })
           setCreatingBillingProject(null)
           loadProjects()
         }
@@ -409,7 +409,9 @@ export const BillingList = ({ queryParams: { selectedName } }) => {
       creatingBillingProject === cloudProviders.azure && isAlphaAzureUser && h(CreateAzureBillingProjectModal, {
         onDismiss: () => setCreatingBillingProject(null),
         onSuccess: billingProjectName => {
-          Ajax().Metrics.captureEvent(Events.billingCreationAzureBillingProjectCreated, { billingProject: billingProjectName })
+          Ajax().Metrics.captureEvent(Events.billingCreationAzureBillingProjectCreated, {
+            billingProject: billingProjectName, cloudPlatform: cloudProviders.azure.label
+          })
           setCreatingBillingProject(null)
           loadProjects()
         },
@@ -434,7 +436,9 @@ export const BillingList = ({ queryParams: { selectedName } }) => {
         [!isLoadingProjects && _.isEmpty(billingProjects) && !Auth.isAzureUser(), () => h(CreateNewBillingProjectWizard, {
           billingAccounts,
           onSuccess: billingProjectName => {
-            Ajax().Metrics.captureEvent(Events.billingCreationGCPBillingProjectCreated, { billingProject: billingProjectName })
+            Ajax().Metrics.captureEvent(Events.billingCreationGCPBillingProjectCreated, {
+              billingProject: billingProjectName, cloudPlatform: cloudProviders.gcp.label
+            })
             setCreatingBillingProject(null)
             loadProjects()
             Nav.history.push({

--- a/src/pages/billing/List.js
+++ b/src/pages/billing/List.js
@@ -400,7 +400,7 @@ export const BillingList = ({ queryParams: { selectedName } }) => {
         onDismiss: () => setCreatingBillingProject(null),
         onSuccess: billingProjectName => {
           Ajax().Metrics.captureEvent(Events.billingCreationGCPBillingProjectCreated, {
-            billingProject: billingProjectName, cloudPlatform: cloudProviders.gcp.label
+            billingProjectName, billingProjectCloudPlatform: cloudProviders.gcp.label
           })
           setCreatingBillingProject(null)
           loadProjects()
@@ -410,7 +410,7 @@ export const BillingList = ({ queryParams: { selectedName } }) => {
         onDismiss: () => setCreatingBillingProject(null),
         onSuccess: billingProjectName => {
           Ajax().Metrics.captureEvent(Events.billingCreationAzureBillingProjectCreated, {
-            billingProject: billingProjectName, cloudPlatform: cloudProviders.azure.label
+            billingProjectName, billingProjectCloudPlatform: cloudProviders.azure.label
           })
           setCreatingBillingProject(null)
           loadProjects()
@@ -437,7 +437,7 @@ export const BillingList = ({ queryParams: { selectedName } }) => {
           billingAccounts,
           onSuccess: billingProjectName => {
             Ajax().Metrics.captureEvent(Events.billingCreationGCPBillingProjectCreated, {
-              billingProject: billingProjectName, cloudPlatform: cloudProviders.gcp.label
+              billingProjectName, billingProjectCloudPlatform: cloudProviders.gcp.label
             })
             setCreatingBillingProject(null)
             loadProjects()

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -17,7 +17,7 @@ import { Ajax } from 'src/libs/ajax'
 import * as Auth from 'src/libs/auth'
 import colors from 'src/libs/colors'
 import { reportErrorAndRethrow } from 'src/libs/error'
-import Events from 'src/libs/events'
+import Events, { extractBillingDetails } from 'src/libs/events'
 import { FormLabel } from 'src/libs/forms'
 import * as Nav from 'src/libs/nav'
 import { memoWithName, useCancellation, useGetter, useOnMount, usePollingEffect } from 'src/libs/react-utils'
@@ -103,8 +103,8 @@ const WorkspaceCard = memoWithName('WorkspaceCard', ({ workspace, billingProject
             href: Nav.getLink('workspace-dashboard', { namespace, name }),
             onClick: () => {
               Ajax().Metrics.captureEvent(Events.billingProjectGoToWorkspace, {
-                billingProjectName: namespace,
-                workspaceName: name
+                workspaceName: name,
+                ...extractBillingDetails(billingProject)
               })
             }
           }, [name])
@@ -122,8 +122,8 @@ const WorkspaceCard = memoWithName('WorkspaceCard', ({ workspace, billingProject
             style: { display: 'flex', alignItems: 'center' },
             onClick: () => {
               Ajax().Metrics.captureEvent(Events.billingProjectExpandWorkspace, {
-                billingProjectName: namespace,
-                workspaceName: name
+                workspaceName: name,
+                ...extractBillingDetails(billingProject)
               })
               onExpand()
             }
@@ -261,10 +261,10 @@ const GcpBillingAccountControls = ({
     reportErrorAndRethrow('Error updating billing account'),
     Utils.withBusyState(setUpdating)
   )(newAccountName => {
-    Ajax().Metrics.captureEvent(Events.changeBillingAccount, {
+    Ajax().Metrics.captureEvent(Events.billingChangeAccount, {
       oldName: billingProject.billingAccount,
       newName: newAccountName,
-      billingProjectName: billingProject.projectName
+      ...extractBillingDetails(billingProject)
     })
     return Ajax(signal).Billing.changeBillingAccount({
       billingProjectName: billingProject.projectName,
@@ -276,9 +276,7 @@ const GcpBillingAccountControls = ({
     reportErrorAndRethrow('Error removing billing account'),
     Utils.withBusyState(setUpdating)
   )(() => {
-    Ajax().Metrics.captureEvent(Events.removeBillingAccount, {
-      billingProject: billingProject.projectName
-    })
+    Ajax().Metrics.captureEvent(Events.billingRemoveAccount, extractBillingDetails(billingProject))
     return Ajax(signal).Billing.removeBillingAccount({
       billingProjectName: billingProject.projectName
     })
@@ -810,7 +808,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
       h(SimpleTabBar, {
         'aria-label': 'project details',
         metricsPrefix: Events.billingProjectSelectTab,
-        metricsData: { billingProjectName: billingProject.projectName },
+        metricsData: extractBillingDetails(billingProject),
         style: { marginTop: '2rem', textTransform: 'none', padding: '0 1rem', height: '1.5rem' },
         tabStyle: { borderBottomWidth: 4 },
         value: tab,


### PR DESCRIPTION
Add `cloudPlatform` info in MixPanel events for billing projects. Prefixing `cloudPlatform` with `billingProject`, similar to prefixing done in https://github.com/DataBiosphere/terra-ui/pull/3619 (will check with Adam).

Not bothering with the billing project wizard events because those are all GCP by definition (and we don't have a billing project name yet).
