### PR TITLE
TOAZ-301: Represent Azure user allowed-ness in B2C

### DIFF
--- a/config/alpha.json
+++ b/config/alpha.json
@@ -27,7 +27,7 @@
     "appId": "saturnnonprod-O9lUP",
     "apiKey": "AQEBBAEkx4iE2KxNyI7Wx08EwU1ycTM7E4FMSmaibbMUQxNU6uQvuAJt7fyABAtFYSYfgEE"
   },
-  "alphaAzureGroup": "alpha-azure-feature-group",
+  "azurePreviewGroup": "alpha-azure-feature-group",
   "alphaRegionalityGroup": "Alpha_Regionality_Users",
   "terraDockerVersionsFile": "terra-docker-versions-alpha.json",
   "terraDockerImageBucket": "terra-docker-image-documentation-alpha",

--- a/config/dev.json
+++ b/config/dev.json
@@ -27,7 +27,7 @@
     "appId": "saturnnonprod-O9lUP",
     "apiKey": "AQEBBAEkx4iE2KxNyI7Wx08EwU1ycTM7E4FMSmaibbMUQxNU6uQvuAJt7fyABAtFYSYfgEE"
   },
-  "alphaAzureGroup": "alpha-azure-feature-group",
+  "azurePreviewGroup": "alpha-azure-feature-group",
   "alphaRegionalityGroup": "Alpha_Regionality_Users",
   "terraDockerVersionsFile": "terra-docker-versions-dev.json",
   "terraDockerImageBucket": "terra-docker-image-documentation-dev",

--- a/config/fiab.json
+++ b/config/fiab.json
@@ -26,7 +26,7 @@
     "appId": "saturnnonprod-O9lUP",
     "apiKey": "AQEBBAEkx4iE2KxNyI7Wx08EwU1ycTM7E4FMSmaibbMUQxNU6uQvuAJt7fyABAtFYSYfgEE"
   },
-  "alphaAzureGroup": "alpha-azure-feature-group",
+  "azurePreviewGroup": "alpha-azure-feature-group",
   "alphaRegionalityGroup": "Alpha_Regionality_Users",
   "terraDockerVersionsFile": "terra-docker-versions-dev.json",
   "terraDockerImageBucket": "terra-docker-image-documentation-dev",

--- a/config/prod.json
+++ b/config/prod.json
@@ -25,7 +25,7 @@
     "appId": "saturnprod-VuHKy",
     "apiKey": "AQEBBAEGP2gTM2pIdJAQOIeNrm8dcTM7E4FMSmaibbMUQxNU6qy6nLPOBK8QfSvPFSsX8PQ"
   },
-  "alphaAzureGroup": "alpha-azure-feature-group",
+  "azurePreviewGroup": "alpha-azure-feature-group",
   "alphaRegionalityGroup": "Alpha_Regionality_Users",
   "terraDockerVersionsFile": "terra-docker-versions-prod.json",
   "terraDockerImageBucket": "terra-docker-image-documentation-prod",

--- a/config/staging.json
+++ b/config/staging.json
@@ -26,7 +26,7 @@
     "appId": "saturnnonprod-O9lUP",
     "apiKey": "AQEBBAEkx4iE2KxNyI7Wx08EwU1ycTM7E4FMSmaibbMUQxNU6uQvuAJt7fyABAtFYSYfgEE"
   },
-  "alphaAzureGroup": "alpha-azure-feature-group",
+  "azurePreviewGroup": "alpha-azure-feature-group",
   "alphaRegionalityGroup": "Alpha_Regionality_Users",
   "terraDockerVersionsFile": "terra-docker-versions-staging.json",
   "terraDockerImageBucket": "terra-docker-image-documentation-staging",

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -227,7 +227,8 @@ export const processUser = (user, isSignInEvent) => {
           givenName: profile.givenName,
           familyName: profile.familyName,
           imageUrl: profile.picture,
-          idp: profile.idp
+          idp: profile.idp,
+          allowAppAccess: profile.allowAppAccess
         } : {})
       }
     }

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -183,6 +183,9 @@ export const bucketBrowserUrl = id => {
   return `https://console.cloud.google.com/storage/browser/${id}?authuser=${getUser().email}`
 }
 
+/*
+ * Specifies whether the user has logged in via the Azure identity provider.
+ */
 export const isAzureUser = () => {
   return _.startsWith('https://login.microsoftonline.com', getUser().idp)
 }
@@ -217,6 +220,9 @@ export const processUser = (user, isSignInEvent) => {
       cookiesAccepted: isSignedIn ? state.cookiesAccepted || getLocalPrefForUserId(userId, cookiesAcceptedKey) : undefined,
       isTimeoutEnabled: isSignedIn ? state.isTimeoutEnabled : undefined,
       hasGcpBillingScopeThroughB2C: isSignedIn ? state.hasGcpBillingScopeThroughB2C : undefined,
+      // A user is an Azure preview user if they are a member of the Sam group _or_ they have the `azurePreviewUser` claim set from B2C.
+      // Only enforce the Azure preview allow-list on prod.
+      isAzurePreviewUser: isSignedIn ? !getConfig().isProd || state.isAzurePreviewUser || profile.azurePreviewUser : undefined,
       user: {
         token: user?.access_token,
         scope: user?.scope,
@@ -227,8 +233,7 @@ export const processUser = (user, isSignInEvent) => {
           givenName: profile.givenName,
           familyName: profile.familyName,
           imageUrl: profile.picture,
-          idp: profile.idp,
-          allowAppAccess: profile.allowAppAccess
+          idp: profile.idp
         } : {})
       }
     }
@@ -393,3 +398,10 @@ workspaceStore.subscribe((newState, oldState) => {
     requesterPaysProjectStore.reset()
   }
 })
+
+authStore.subscribe(withErrorReporting('Error loading azure preview group membership', async (state, oldState) => {
+  if (becameRegistered(oldState, state)) {
+    const isAzurePreviewUser = await Ajax().Groups.group(getConfig().azurePreviewGroup).isMember()
+    authStore.update(state => ({ ...state, isAzurePreviewUser }))
+  }
+}))

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -222,7 +222,7 @@ export const processUser = (user, isSignInEvent) => {
       hasGcpBillingScopeThroughB2C: isSignedIn ? state.hasGcpBillingScopeThroughB2C : undefined,
       // A user is an Azure preview user if they are a member of the Sam group _or_ they have the `azurePreviewUser` claim set from B2C.
       // Only enforce the Azure preview allow-list on prod.
-      isAzurePreviewUser: isSignedIn ? !getConfig().isProd || state.isAzurePreviewUser || profile.azurePreviewUser : undefined,
+      isAzurePreviewUser: isSignedIn ? !getConfig().isProd || state.isAzurePreviewUser || profile.isAzurePreviewUser : undefined,
       user: {
         token: user?.access_token,
         scope: user?.scope,

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -401,7 +401,8 @@ workspaceStore.subscribe((newState, oldState) => {
 
 authStore.subscribe(withErrorReporting('Error loading azure preview group membership', async (state, oldState) => {
   if (becameRegistered(oldState, state)) {
-    const isAzurePreviewUser = await Ajax().Groups.group(getConfig().azurePreviewGroup).isMember()
+    const isGroupMember = await Ajax().Groups.group(getConfig().azurePreviewGroup).isMember()
+    const isAzurePreviewUser = oldState.isAzurePreviewUser || isGroupMember
     authStore.update(state => ({ ...state, isAzurePreviewUser }))
   }
 }))

--- a/src/pages/AzurePreview.js
+++ b/src/pages/AzurePreview.js
@@ -4,12 +4,15 @@ import planet from 'src/images/register-planet.svg'
 import { ReactComponent as TerraOnAzureLogo } from 'src/images/terra-ms-logo.svg'
 import { signOut } from 'src/libs/auth'
 import colors from 'src/libs/colors'
-import { getConfig } from 'src/libs/config'
-import { azurePreviewStore, getUser } from 'src/libs/state'
+import { useStore } from 'src/libs/react-utils'
+import { authStore, azurePreviewStore } from 'src/libs/state'
 import * as Utils from 'src/libs/utils'
 
 
 const AzurePreview = () => {
+  // State
+  const { isAzurePreviewUser } = useStore(authStore)
+
   // Helpers
   const styles = {
     centered: {
@@ -45,8 +48,6 @@ const AzurePreview = () => {
     azurePreviewStore.set(true)
   }
 
-  const isAlphaAzureUser = !getConfig().isProd || getUser().allowAppAccess === 'true'
-
   // Render
   return div({
     role: 'main',
@@ -66,7 +67,7 @@ const AzurePreview = () => {
         'This is a preview version of the Terra platform on Microsoft Azure. The public offering of Terra on Microsoft Azure is expected in early 2023.')
     ]),
 
-    isAlphaAzureUser ? undefined : [
+    isAzurePreviewUser ? undefined : [
       div({ style: styles.centered }, [
         p({ style: styles.paragraph }, [
           'You are not currently part of the Terra on Microsoft Azure Preview Program. If you are interested in joining the program, please contact ',
@@ -76,11 +77,11 @@ const AzurePreview = () => {
       ])
     ],
     div({ style: { ...styles.centered, marginTop: '1.5rem' } }, [
-      isAlphaAzureUser ?
+      isAzurePreviewUser ?
         h(ButtonPrimary, { onClick: dismiss, style: styles.button }, 'Proceed to Terra on Microsoft Azure Preview') :
         h(ButtonPrimary, { onClick: signOut, style: styles.button }, 'Log Out')
     ]),
-    isAlphaAzureUser ? div({ style: { ...styles.centered, marginTop: '1rem' } }, [
+    isAzurePreviewUser ? div({ style: { ...styles.centered, marginTop: '1rem' } }, [
       h(ButtonOutline, { onClick: signOut, style: styles.button }, 'Log Out')
     ]) : undefined
   ])

--- a/src/pages/AzurePreview.js
+++ b/src/pages/AzurePreview.js
@@ -1,23 +1,15 @@
-import { useState } from 'react'
 import { div, h, h1, p } from 'react-hyperscript-helpers'
 import { ButtonOutline, ButtonPrimary, Link } from 'src/components/common'
 import planet from 'src/images/register-planet.svg'
 import { ReactComponent as TerraOnAzureLogo } from 'src/images/terra-ms-logo.svg'
-import { Ajax } from 'src/libs/ajax'
 import { signOut } from 'src/libs/auth'
 import colors from 'src/libs/colors'
 import { getConfig } from 'src/libs/config'
-import { withErrorIgnoring } from 'src/libs/error'
-import { useCancellation, useOnMount } from 'src/libs/react-utils'
-import { azurePreviewStore } from 'src/libs/state'
+import { azurePreviewStore, getUser } from 'src/libs/state'
 import * as Utils from 'src/libs/utils'
 
 
 const AzurePreview = () => {
-  // State
-  const [isAlphaAzureUser, setIsAlphaAzureUser] = useState(false)
-  const signal = useCancellation()
-
   // Helpers
   const styles = {
     centered: {
@@ -53,17 +45,7 @@ const AzurePreview = () => {
     azurePreviewStore.set(true)
   }
 
-  // Use a Sam group to determine if a user is an Azure Preview user.
-  // This is problematic when the user needs to register/accept ToS, since that's a prerequisite
-  // for checking Sam group membership. TOAZ-301 is open to change this to a B2C check instead of Sam.
-  const loadAlphaAzureMember = withErrorIgnoring(async () => {
-    setIsAlphaAzureUser(await Ajax(signal).Groups.group(getConfig().alphaAzureGroup).isMember())
-  })
-
-  // Lifecycle
-  useOnMount(() => {
-    loadAlphaAzureMember()
-  })
+  const isAlphaAzureUser = !getConfig().isProd || getUser().allowAppAccess === 'true'
 
   // Render
   return div({


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/TOAZ-301

Related B2C/terraform PR: https://github.com/broadinstitute/terraform-ap-deployments/pull/860

Follow-up change for the Azure preview screen ([PR](https://github.com/DataBiosphere/terra-ui/pull/3606)) which I punted on last year. Instead of using a Sam group to represent the allow-list in `AzurePreview.js`, use a claim from B2C. This avoids a chicken-and-egg problem where an allowed user can't register/accept ToS (since a user must be registered/ToS-accepted in order to check Sam group membership). See also description in above terraform PR.

I tested in dev:
- Google logins work as normal
- Disallowed Azure users get the block screen
- Allowed Azure users get the "proceed to Terra" screen
- Allowed Azure users who are not registered get the "proceed to Terra" screen followed by the registration and ToS pages



[TOAZ-301]: https://broadworkbench.atlassian.net/browse/TOAZ-301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ