### PR TITLE
Configure test scope for SonarCloud

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,3 +5,6 @@ sonar.organization=broad-databiosphere
 sonar.sources=src
 # Skip test files, which can be anywhere in the source tree.
 sonar.exclusions=**/**.test.js
+
+sonar.tests=src
+sonar.test.inclusions=**/**.test.js


### PR DESCRIPTION
This configures the test scope based on the example at https://docs.sonarqube.org/latest/project-administration/narrowing-the-focus/#file-exclusion-and-inclusion.