### PR TITLE
[DC-597] Stop uploading coverage report to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,8 +239,6 @@ jobs:
       - run: tar -czf build.tgz .gcloudignore app.yaml build config
       - store_artifacts:
           path: build.tgz
-      - store_artifacts:
-          path: coverage
       - persist_to_workspace:
           root: .
           paths:


### PR DESCRIPTION
Now that [coverage is available in SonarCloud](https://sonarcloud.io/component_measures?metric=coverage&selected=DataBiosphere_terra-ui%3Asrc&id=DataBiosphere_terra-ui), there's no need to upload it to CircleCI artifacts.

Since we're currently uploading all the HTML files for the coverage report, removing this shaves ~30s off the build job's run time.