### PR TITLE
[SU-259] Show notice when viewing .data-table-versions in file browser

### DIFF
--- a/src/components/file-browser/FilesInDirectory.ts
+++ b/src/components/file-browser/FilesInDirectory.ts
@@ -6,10 +6,12 @@ import { useFilesInDirectory } from 'src/components/file-browser/file-browser-ho
 import { basename } from 'src/components/file-browser/file-browser-utils'
 import { FilesMenu } from 'src/components/file-browser/FilesMenu'
 import FilesTable from 'src/components/file-browser/FilesTable'
+import { NoticeForPath } from 'src/components/file-browser/NoticeForPath'
 import { icon } from 'src/components/icons'
 import { UploadProgressModal } from 'src/components/ProgressBar'
 import FileBrowserProvider, { FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
 import colors from 'src/libs/colors'
+import { dataTableVersionsPathRoot } from 'src/libs/data-table-versions'
 import { useUploader } from 'src/libs/uploads'
 import * as Utils from 'src/libs/utils'
 
@@ -91,6 +93,13 @@ const FilesInDirectory = (props: FilesInDirectoryProps) => {
           setSelectedFiles({})
           reload()
         },
+      }),
+
+      h(NoticeForPath, {
+        notices: {
+          [`${dataTableVersionsPathRoot}/`]: 'Files in this folder are managed via data table versioning.'
+        },
+        path
       }),
 
       span({

--- a/src/components/file-browser/NoticeForPath.test.ts
+++ b/src/components/file-browser/NoticeForPath.test.ts
@@ -1,0 +1,25 @@
+import { render } from '@testing-library/react'
+import { h } from 'react-hyperscript-helpers'
+
+import { NoticeForPath } from './NoticeForPath'
+
+
+describe('NoticeForPath', () => {
+  const notices = {
+    'foo/': 'foo notice',
+    'foo/bar/': 'foo/bar notice',
+  }
+
+  it.each([
+    { path: 'foo/', expectedNotice: 'foo notice' },
+    { path: 'foo/bar/baz/', expectedNotice: 'foo/bar notice' },
+  ])('renders notice with longest matching path', ({ path, expectedNotice }) => {
+    const { container } = render(h(NoticeForPath, { notices, path }))
+    expect(container).toHaveTextContent(expectedNotice)
+  })
+
+  it('renders nothing if no notice matches path', () => {
+    const { container } = render(h(NoticeForPath, { notices, path: '/' }))
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/src/components/file-browser/NoticeForPath.ts
+++ b/src/components/file-browser/NoticeForPath.ts
@@ -1,0 +1,24 @@
+import _ from 'lodash/fp'
+import { div } from 'react-hyperscript-helpers'
+import colors from 'src/libs/colors'
+
+
+type NoticeForPathProps = {
+  notices: { [path: string]: string }
+  path: string
+}
+
+export const NoticeForPath = (props: NoticeForPathProps) => {
+  const { notices, path } = props
+
+  const activeNotice = _.flow(
+    _.keys,
+    _.sortBy(_.size),
+    _.reverse,
+    _.find(_.startsWith(_.placeholder, path)),
+  )(notices)
+
+  return !!activeNotice ?
+    div({ style: { padding: '1rem', background: colors.accent(0.2) } }, [notices[activeNotice]]) :
+    null
+}


### PR DESCRIPTION
When viewing the `.data-table-versions` directory, the current file browser (in the Data tab) shows a notice that the contents of that directory are managed via data table versions instead of the file browser. The new file browser should show the same notice.

<img width="1624" alt="Screen Shot 2023-01-03 at 2 41 43 PM" src="https://user-images.githubusercontent.com/1156625/210430886-261e3388-c440-42fc-8ea7-82fc8729a558.png">

