### PR TITLE
[DC-597] Exclude TypeScript tests from SonarCloud sources

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,4 +6,4 @@ sonar.javascript.lcov.reportPaths=coverage/lcov.info
 # Only scan code under src.
 sonar.sources=src
 # Skip test files, which can be anywhere in the source tree.
-sonar.exclusions=**/**.test.js
+sonar.exclusions=**/**.test.js,**/**.test.ts


### PR DESCRIPTION
Currently, TypeScript test files show up in coverage metrics on SonarCloud.

https://sonarcloud.io/component_measures?metric=coverage&selected=DataBiosphere_terra-ui%3Asrc&id=DataBiosphere_terra-ui

This is because we currently only exclude `.test.js` files. This also ignores `.test.ts` files.