### PR TITLE
[PE-26] Silence console logs in tests for getEnabledBrand

### DIFF
--- a/src/libs/brand-utils.test.js
+++ b/src/libs/brand-utils.test.js
@@ -54,6 +54,13 @@ describe('brand-utils', () => {
   })
 
   describe('getEnabledBrand', () => {
+    beforeAll(() => {
+      // For invalid brands, getEnabledBrand logs a notice and instructions for developers.
+      // Those should not be shown in test output.
+      jest.spyOn(console, 'log').mockImplementation(() => {})
+      jest.spyOn(console, 'warn').mockImplementation(() => {})
+    })
+
     it('returns forced brand when a valid one is set', () => {
       // Arrange
       window.configOverridesStore.set({ brand: 'rareX' })


### PR DESCRIPTION
Follow up to #3625.

If a developer configures an invalid brand, `getEnabledBrand` logs a warning and instructions. This is useful for developers, but noise in tests. This silences the console logs/warnings in tests.