### PR TITLE
PROD-769 Use role=creator syntax

### DIFF
--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -134,7 +134,7 @@ const deleteRuntimes = _.flow(withSignedInPage, withUserToken)(async ({ page, bi
   const deletedRuntimes = await page.evaluate(async billingProject => {
     const runtimes = await window.Ajax().Runtimes.list({ googleProject: billingProject, role: 'creator' })
     return Promise.all(_.map(async runtime => {
-      await window.Ajax().Runtimes.runtime(runtime.googleProject, runtime.runtimeName).delete(true) // true = also delete persistent disk
+      await window.Ajax().Runtimes.runtime(runtime.googleProject, runtime.runtimeName).delete(true) // true = also delete persistent disk.
       return runtime.runtimeName
     }, _.remove({ status: 'Deleting' }, runtimes)))
   }, billingProject, email)

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -22,7 +22,6 @@ import {
 import { ReactComponent as CloudAzureLogo } from 'src/images/cloud_azure_icon.svg'
 import { ReactComponent as CloudGcpLogo } from 'src/images/cloud_google_icon.svg'
 import { Ajax } from 'src/libs/ajax'
-import { getUser } from 'src/libs/auth'
 import colors from 'src/libs/colors'
 import { withErrorIgnoring, withErrorReporting } from 'src/libs/error'
 import Events, { extractWorkspaceDetails } from 'src/libs/events'
@@ -157,7 +156,7 @@ export const WorkspaceList = () => {
     const loadPersistentDisks = withErrorIgnoring(async () => {
       setGcpPersistentDisks(_.filter(({ cloudContext }) => isGcpContext(cloudContext),
         await Ajax().Disks.list({
-          creator: getUser().email,
+          role: 'creator',
           includeLabels: ['saturnWorkspaceNamespace', 'saturnWorkspaceName'].join(',')
         })
       ))

--- a/src/pages/workspaces/workspace/DeleteWorkspaceModal.js
+++ b/src/pages/workspaces/workspace/DeleteWorkspaceModal.js
@@ -31,7 +31,7 @@ const DeleteWorkspaceModal = ({ workspace: { workspace: { namespace, name, bucke
     const load = Utils.withBusyState(setLoading, async () => {
       if (isGoogleWorkspace) {
         const [currentWorkspaceAppList, { acl }, { usageInBytes }] = await Promise.all([
-          Ajax(signal).Apps.listWithoutProject({ creator: getUser().email, saturnWorkspaceName: name }),
+          Ajax(signal).Apps.listWithoutProject({ role: 'creator', saturnWorkspaceName: name }),
           Ajax(signal).Workspaces.workspace(namespace, name).getAcl(),
           Ajax(signal).Workspaces.workspace(namespace, name).bucketUsage()
         ])

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -247,7 +247,7 @@ const useCloudEnvironmentPolling = (googleProject, workspace) => {
       // v1 workspaces: cloud environment (runtime + disk) is used across workspaces that share the same googleProject
       // v2 workspaces: 1 cloud environment per workspace - saturnWorkspaceName == workspaceName and saturnWorkspaceNamespace == Terra Billing Project (which is no longer equivalent to googleProject)
       // TODO: after PPW migration - we should only need saturnWorkspaceName and saturnWorkspaceNamespace labels
-      const cloudEnvFilters = _.pickBy(l => !_.isUndefined(l), saturnWorkspaceVersion === 'v1' ? { creator: getUser().email, googleProject } : { creator: getUser().email, saturnWorkspaceName, saturnWorkspaceNamespace })
+      const cloudEnvFilters = _.pickBy(l => !_.isUndefined(l), saturnWorkspaceVersion === 'v1' ? { role: 'creator', googleProject } : { creator: getUser().email, saturnWorkspaceName, saturnWorkspaceNamespace })
 
       // Disks.list API takes includeLabels to specify which labels to return in the response
       // Runtimes.listV2 API always returns all labels for a runtime

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -247,7 +247,7 @@ const useCloudEnvironmentPolling = (googleProject, workspace) => {
       // v1 workspaces: cloud environment (runtime + disk) is used across workspaces that share the same googleProject
       // v2 workspaces: 1 cloud environment per workspace - saturnWorkspaceName == workspaceName and saturnWorkspaceNamespace == Terra Billing Project (which is no longer equivalent to googleProject)
       // TODO: after PPW migration - we should only need saturnWorkspaceName and saturnWorkspaceNamespace labels
-      const cloudEnvFilters = _.pickBy(l => !_.isUndefined(l), saturnWorkspaceVersion === 'v1' ? { role: 'creator', googleProject } : { creator: getUser().email, saturnWorkspaceName, saturnWorkspaceNamespace })
+      const cloudEnvFilters = _.pickBy(l => !_.isUndefined(l), saturnWorkspaceVersion === 'v1' ? { role: 'creator', googleProject } : { role: 'creator', saturnWorkspaceName, saturnWorkspaceNamespace })
 
       // Disks.list API takes includeLabels to specify which labels to return in the response
       // Runtimes.listV2 API always returns all labels for a runtime

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -289,7 +289,7 @@ const useAppPolling = (googleProject, workspaceName) => {
   const loadApps = async () => {
     try {
       const newApps = !!googleProject ?
-        await Ajax(signal).Apps.list(googleProject, { creator: getUser().email, saturnWorkspaceName: workspaceName }) :
+        await Ajax(signal).Apps.list(googleProject, { role: 'creator', saturnWorkspaceName: workspaceName }) :
         []
       setApps(newApps)
       _.forOwn(tool => {


### PR DESCRIPTION
There’s a bug currently where users might see a runtime they don’t own in analysis page, and when they try to start it, they’ll get permission error (becuz it’s a runtime created by someone else)…this is only an issue for workspace owners

This is due to listRuntime call is using the old `creator=<email>` syntax, which should still be supported by Leo api. But we missed the fact that when the request is sent from UI, the `@` is encoded as `%40`. Hence the creator filter isn't being used properly
