### PR TITLE
[SU-262] Use more generic text for shared component

### DIFF
--- a/src/pages/library/common.js
+++ b/src/pages/library/common.js
@@ -507,7 +507,7 @@ export const SearchAndFilterComponent = ({
           })
         ])])
       ]),
-      div({ style: { fontSize: '1rem', fontWeight: 600 } }, [searchFilter ? `Results For "${searchFilter}"` : 'All datasets'])
+      div({ style: { fontSize: '1rem', fontWeight: 600 } }, [searchFilter ? `Results For "${searchFilter}"` : 'All results'])
     ]),
     div({ style: { display: 'flex', margin: '0 1rem', height: '100%' } }, [
       div({ style: { width: '19rem', flex: 'none' } }, [


### PR DESCRIPTION
`SearchAndFilterComponent` is used on both the [Datasets](https://app.terra.bio/#library/datasets) and [Featured workspaces](https://app.terra.bio/#library/showcase) page. Its "All datasets" text only makes sense on the datasets page. Since the text changes to "Results for <query>" when a search query is entered, this replaces "All datasets" with "All results", which works on both pages.

## Before
![Screen Shot 2023-01-05 at 5 35 59 PM](https://user-images.githubusercontent.com/1156625/210893281-adc11bec-274d-406b-bf07-aac59344c001.png)

## After
![Screen Shot 2023-01-05 at 5 35 50 PM](https://user-images.githubusercontent.com/1156625/210893283-0233d676-6e44-4862-9b2a-e3db1d35029e.png)


