### PR TITLE
[SU-263] Update Vault path for Terra SA key

### DIFF
--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "test": "jest",
-    "test-local": "TERRA_SA_KEY=$(vault read --format=json secret/dsde/alpha/common/firecloud-account.pem | jq .data) LYLE_SA_KEY=$(vault read --format=json secret/dsde/terra/envs/common/lyle-user-service-account-key | jq .data) TEST_URL=http://localhost:3000 yarn test",
+    "test-local": "TERRA_SA_KEY=$(vault read --format=json secret/dsde/firecloud/alpha/common/firecloud-account.json | jq .data) LYLE_SA_KEY=$(vault read --format=json secret/dsde/terra/envs/common/lyle-user-service-account-key | jq .data) TEST_URL=http://localhost:3000 yarn test",
     "test-flakes": "FLAKES=true yarn test-local --runInBand"
   },
   "devDependencies": {


### PR DESCRIPTION
See https://broadinstitute.slack.com/archives/C04HMP3UYSF/p1673017294068659

This SA key was stored in multiple places in Vault. As a result, when it was rotated, not all Vault paths were updated. This updates the Vault path used by the `test-local` script to be consistent with other uses of the SA key. And the current `.pem` path doesn't make sense anyway, since the data is a JSON file.