### PR TITLE
[SU-251] Support requester pays buckets in new file browser

### DIFF
--- a/src/components/file-browser/DirectoryTree.test.ts
+++ b/src/components/file-browser/DirectoryTree.test.ts
@@ -31,6 +31,7 @@ describe('Directory', () => {
       rootLabel: 'Workspace bucket',
       selectedDirectory: '',
       setActiveDescendant: () => {},
+      onError: () => {},
       onSelectDirectory: jest.fn()
     }))
 
@@ -52,6 +53,7 @@ describe('Directory', () => {
       rootLabel: 'Workspace bucket',
       selectedDirectory: '',
       setActiveDescendant: () => {},
+      onError: () => {},
       onSelectDirectory
     }))
 
@@ -100,6 +102,7 @@ describe('Directory', () => {
           rootLabel: 'Workspace bucket',
           selectedDirectory: '',
           setActiveDescendant: () => {},
+          onError: () => {},
           onSelectDirectory: jest.fn()
         })
       ])
@@ -148,6 +151,7 @@ describe('Directory', () => {
       rootLabel: 'Workspace bucket',
       selectedDirectory: '',
       setActiveDescendant: () => {},
+      onError: () => {},
       onSelectDirectory: jest.fn()
     }))
 
@@ -189,6 +193,7 @@ describe('Directory', () => {
       rootLabel: 'Workspace bucket',
       selectedDirectory: '',
       setActiveDescendant: () => {},
+      onError: () => {},
       onSelectDirectory: jest.fn()
     }))
 
@@ -198,6 +203,49 @@ describe('Directory', () => {
 
     // Assert
     screen.getByText('Error loading subdirectories')
+  })
+
+  it('calls onError callback on errors loading directories', async () => {
+    // Arrange
+    const user = userEvent.setup()
+
+    const errorState = {
+      status: 'Error',
+      error: new Error('Something went wrong'),
+      directories: []
+    } as UseDirectoriesInDirectoryResult['state']
+
+    const useDirectoriesInDirectoryResult: UseDirectoriesInDirectoryResult = {
+      state: errorState,
+      hasNextPage: false,
+      loadNextPage: () => Promise.resolve(),
+      loadAllRemainingItems: () => Promise.resolve(),
+      reload: () => Promise.resolve()
+    }
+
+    asMockedFn(useDirectoriesInDirectory).mockReturnValue(useDirectoriesInDirectoryResult)
+
+    const onError = jest.fn()
+
+    render(h(Directory, {
+      activeDescendant: 'node-0',
+      id: 'node-0',
+      level: 0,
+      path: 'path/to/directory/',
+      provider: mockFileBrowserProvider,
+      rootLabel: 'Workspace bucket',
+      selectedDirectory: '',
+      setActiveDescendant: () => {},
+      onError,
+      onSelectDirectory: jest.fn()
+    }))
+
+    // Act
+    const toggle = screen.getByTestId('toggle-expanded')
+    await user.click(toggle)
+
+    // Assert
+    expect(onError).toHaveBeenCalledWith(new Error('Something went wrong'))
   })
 
   describe('when next page is available', () => {
@@ -236,6 +284,7 @@ describe('Directory', () => {
         rootLabel: 'Workspace bucket',
         selectedDirectory: '',
         setActiveDescendant: () => {},
+        onError: () => {},
         onSelectDirectory: jest.fn()
       }))
 

--- a/src/components/file-browser/DirectoryTree.ts
+++ b/src/components/file-browser/DirectoryTree.ts
@@ -19,6 +19,7 @@ interface SubdirectoriesProps {
   rootLabel: string
   selectedDirectory: string
   setActiveDescendant: Dispatch<SetStateAction<string>>
+  onError: (error: Error) => void
   onFinishedLoading: () => void
   onSelectDirectory: (path: string) => void
 }
@@ -43,6 +44,7 @@ export const Subdirectories = (props: SubdirectoriesProps) => {
     selectedDirectory,
     setActiveDescendant,
     onFinishedLoading,
+    onError,
     onSelectDirectory
   } = props
 
@@ -51,23 +53,33 @@ export const Subdirectories = (props: SubdirectoriesProps) => {
   const loadedAlertElementRef = useRef<HTMLSpanElement | null>(null)
 
   const {
-    state: { status, directories },
+    state,
     hasNextPage,
     loadNextPage
   } = useDirectoriesInDirectory(provider, path)
+
+  const { status, directories } = state
 
   useEffect(() => {
     if (status === 'Ready' || status === 'Error') {
       onFinishedLoading()
     }
+  }, [status, onFinishedLoading])
 
+  useEffect(() => {
+    if (state.status === 'Error') {
+      onError(state.error)
+    }
+  }, [state, onError])
+
+  useEffect(() => {
     if (status === 'Ready') {
       loadedAlertElementRef.current!.innerHTML = `Loaded ${directoryLabel} subdirectories`
     }
     if (status === 'Error') {
       loadedAlertElementRef.current!.innerHTML = `Error loading ${directoryLabel} subdirectories`
     }
-  }, [directoryLabel, onFinishedLoading, status])
+  }, [directoryLabel, status])
 
   return h(Fragment, [
     span({
@@ -102,6 +114,7 @@ export const Subdirectories = (props: SubdirectoriesProps) => {
           rootLabel,
           selectedDirectory,
           setActiveDescendant,
+          onError,
           onSelectDirectory
         })
       }),
@@ -153,6 +166,7 @@ interface DirectoryProps {
   rootLabel: string
   selectedDirectory: string
   setActiveDescendant: Dispatch<SetStateAction<string>>
+  onError: (error: Error) => void
   onSelectDirectory: (path: string) => void
 }
 
@@ -166,6 +180,7 @@ export const Directory = (props: DirectoryProps) => {
     rootLabel,
     selectedDirectory,
     setActiveDescendant,
+    onError,
     onSelectDirectory
   } = props
   const isSelected = path === selectedDirectory
@@ -256,6 +271,7 @@ export const Directory = (props: DirectoryProps) => {
       rootLabel,
       selectedDirectory,
       setActiveDescendant,
+      onError,
       onFinishedLoading: () => setHasLoadedContents(true),
       onSelectDirectory
     })
@@ -266,6 +282,7 @@ interface DirectoryTreeProps {
   provider: FileBrowserProvider
   rootLabel: string
   selectedDirectory: string
+  onError: (error: Error) => void
   onSelectDirectory: (path: string) => void
 }
 
@@ -274,6 +291,7 @@ const DirectoryTree = (props: DirectoryTreeProps) => {
     provider,
     rootLabel,
     selectedDirectory,
+    onError,
     onSelectDirectory
   } = props
 
@@ -375,6 +393,7 @@ const DirectoryTree = (props: DirectoryTreeProps) => {
       rootLabel,
       selectedDirectory,
       setActiveDescendant,
+      onError,
       onSelectDirectory
     })
   ])

--- a/src/components/file-browser/FileBrowser.test.ts
+++ b/src/components/file-browser/FileBrowser.test.ts
@@ -1,0 +1,120 @@
+import '@testing-library/jest-dom'
+
+import { render } from '@testing-library/react'
+import { h } from 'react-hyperscript-helpers'
+import { useFilesInDirectory } from 'src/components/file-browser/file-browser-hooks'
+import FileBrowser from 'src/components/file-browser/FileBrowser'
+import FilesTable from 'src/components/file-browser/FilesTable'
+import RequesterPaysModal from 'src/components/RequesterPaysModal'
+import FileBrowserProvider, { FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
+import { asMockedFn } from 'src/testing/test-utils'
+
+
+jest.mock('src/components/file-browser/file-browser-hooks', () => ({
+  ...jest.requireActual('src/components/file-browser/file-browser-hooks'),
+  useFilesInDirectory: jest.fn()
+}))
+
+jest.mock('src/components/file-browser/FilesTable', () => {
+  const { div } = jest.requireActual('react-hyperscript-helpers')
+  return {
+    ...jest.requireActual('src/components/file-browser/FilesTable'),
+    __esModule: true,
+    default: jest.fn().mockReturnValue(div())
+  }
+})
+
+jest.mock('src/components/RequesterPaysModal', () => {
+  const { div } = jest.requireActual('react-hyperscript-helpers')
+  return {
+    ...jest.requireActual('src/components/RequesterPaysModal'),
+    __esModule: true,
+    default: jest.fn().mockReturnValue(div())
+  }
+})
+
+type UseFilesInDirectoryResult = ReturnType<typeof useFilesInDirectory>
+
+describe('FileBrowser', () => {
+  const mockFileBrowserProvider: FileBrowserProvider = {} as FileBrowserProvider
+
+  it('renders files', () => {
+    // Arrange
+    const files: FileBrowserFile[] = [
+      {
+        path: 'file.txt',
+        url: 'gs://test-bucket/file.txt',
+        size: 1024,
+        createdAt: 1667408400000,
+        updatedAt: 1667408400000
+      }
+    ]
+
+    const useFilesInDirectoryResult: UseFilesInDirectoryResult = {
+      state: { files, status: 'Ready' },
+      hasNextPage: false,
+      loadNextPage: () => Promise.resolve(),
+      loadAllRemainingItems: () => Promise.resolve(),
+      reload: () => Promise.resolve()
+    }
+
+    asMockedFn(useFilesInDirectory).mockReturnValue(useFilesInDirectoryResult)
+
+    // Act
+    render(h(FileBrowser, {
+      provider: mockFileBrowserProvider,
+      rootLabel: 'Test bucket',
+      title: 'Files',
+      workspace: {
+        accessLevel: 'WRITER',
+        workspace: { isLocked: false }
+      }
+    }))
+
+    // Assert
+    expect(FilesTable).toHaveBeenCalledWith(
+      expect.objectContaining({
+        files: [
+          {
+            path: 'file.txt',
+            url: 'gs://test-bucket/file.txt',
+            size: 1024,
+            createdAt: 1667408400000,
+            updatedAt: 1667408400000
+          }
+        ]
+      }),
+      expect.anything(),
+    )
+  })
+
+  it('prompts to select workspace on requester pays errors', () => {
+    // Arrange
+    const requesterPaysError = new Error('Requester pays bucket')
+    ;(requesterPaysError as any).requesterPaysError = true
+
+    const useFilesInDirectoryResult: UseFilesInDirectoryResult = {
+      state: { files: [], status: 'Error', error: requesterPaysError },
+      hasNextPage: false,
+      loadNextPage: () => Promise.resolve(),
+      loadAllRemainingItems: () => Promise.resolve(),
+      reload: () => Promise.resolve(),
+    }
+
+    asMockedFn(useFilesInDirectory).mockReturnValue(useFilesInDirectoryResult)
+
+    // Act
+    render(h(FileBrowser, {
+      provider: mockFileBrowserProvider,
+      rootLabel: 'Test bucket',
+      title: 'Files',
+      workspace: {
+        accessLevel: 'WRITER',
+        workspace: { isLocked: false }
+      }
+    }))
+
+    // Assert
+    expect(RequesterPaysModal).toHaveBeenCalled()
+  })
+})

--- a/src/components/file-browser/FileBrowser.ts
+++ b/src/components/file-browser/FileBrowser.ts
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useState } from 'react'
+import { Fragment, useCallback, useEffect, useState } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
 import DirectoryTree from 'src/components/file-browser/DirectoryTree'
 import { basename } from 'src/components/file-browser/file-browser-utils'
@@ -28,6 +28,8 @@ const FileBrowser = ({ provider, rootLabel, title, workspace }: FileBrowserProps
   useEffect(() => {
     setSelectedFiles({})
   }, [path])
+
+  const onError = useCallback(() => {}, [])
 
   const editWorkspaceError = Utils.editWorkspaceError(workspace)
   const { editDisabled, editDisabledReason } = Utils.cond(
@@ -68,6 +70,7 @@ const FileBrowser = ({ provider, rootLabel, title, workspace }: FileBrowserProps
             provider,
             rootLabel,
             selectedDirectory: path,
+            onError,
             onSelectDirectory: selectedDirectoryPath => {
               setPath(selectedDirectoryPath)
             }
@@ -106,7 +109,8 @@ const FileBrowser = ({ provider, rootLabel, title, workspace }: FileBrowserProps
           rootLabel,
           selectedFiles,
           setSelectedFiles,
-          onClickFile: setFocusedFile
+          onClickFile: setFocusedFile,
+          onError,
         })
       ])
     ]),

--- a/src/components/file-browser/FileBrowser.ts
+++ b/src/components/file-browser/FileBrowser.ts
@@ -6,9 +6,11 @@ import { FileDetails } from 'src/components/file-browser/FileDetails'
 import FilesInDirectory from 'src/components/file-browser/FilesInDirectory'
 import PathBreadcrumbs from 'src/components/file-browser/PathBreadcrumbs'
 import Modal from 'src/components/Modal'
+import RequesterPaysModal from 'src/components/RequesterPaysModal'
 import FileBrowserProvider, { FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
 import colors from 'src/libs/colors'
 import { dataTableVersionsPathRoot } from 'src/libs/data-table-versions'
+import { requesterPaysProjectStore } from 'src/libs/state'
 import * as Utils from 'src/libs/utils'
 
 
@@ -22,6 +24,10 @@ interface FileBrowserProps {
 const FileBrowser = ({ provider, rootLabel, title, workspace }: FileBrowserProps) => {
   const [path, setPath] = useState('')
 
+  // refreshKey is a hack to make hooks in DirectoryTree and FilesInDirectory reload
+  // after selecting a workspace to bill requester pays request to.
+  const [refreshKey, setRefreshKey] = useState(0)
+
   const [focusedFile, setFocusedFile] = useState<FileBrowserFile | null>(null)
 
   const [selectedFiles, setSelectedFiles] = useState<{ [path: string]: FileBrowserFile }>({})
@@ -29,7 +35,12 @@ const FileBrowser = ({ provider, rootLabel, title, workspace }: FileBrowserProps
     setSelectedFiles({})
   }, [path])
 
-  const onError = useCallback(() => {}, [])
+  const [showRequesterPaysModal, setShowRequesterPaysModal] = useState(false)
+  const onError = useCallback((error: Error) => {
+    if ((error as any).requesterPaysError) {
+      setShowRequesterPaysModal(true)
+    }
+  }, [])
 
   const editWorkspaceError = Utils.editWorkspaceError(workspace)
   const { editDisabled, editDisabledReason } = Utils.cond(
@@ -67,6 +78,7 @@ const FileBrowser = ({ provider, rootLabel, title, workspace }: FileBrowserProps
           }
         }, [
           h(DirectoryTree, {
+            key: refreshKey,
             provider,
             rootLabel,
             selectedDirectory: path,
@@ -102,6 +114,7 @@ const FileBrowser = ({ provider, rootLabel, title, workspace }: FileBrowserProps
           })
         ]),
         h(FilesInDirectory, {
+          key: refreshKey,
           editDisabled,
           editDisabledReason,
           provider,
@@ -123,6 +136,15 @@ const FileBrowser = ({ provider, rootLabel, title, workspace }: FileBrowserProps
     }, [
       h(FileDetails, { file: focusedFile, provider })
     ]),
+
+    showRequesterPaysModal && h(RequesterPaysModal, {
+      onDismiss: () => setShowRequesterPaysModal(false),
+      onSuccess: selectedGoogleProject => {
+        requesterPaysProjectStore.set(selectedGoogleProject)
+        setShowRequesterPaysModal(false)
+        setRefreshKey(k => k + 1)
+      }
+    }),
   ])
 }
 

--- a/src/components/file-browser/FilesInDirectory.test.ts
+++ b/src/components/file-browser/FilesInDirectory.test.ts
@@ -59,7 +59,8 @@ describe('FilesInDirectory', () => {
       path: 'path/to/directory/',
       selectedFiles: {},
       setSelectedFiles: () => {},
-      onClickFile: jest.fn()
+      onClickFile: jest.fn(),
+      onError: () => {},
     }))
 
     // Assert
@@ -94,7 +95,8 @@ describe('FilesInDirectory', () => {
       path: 'path/to/directory/',
       selectedFiles: {},
       setSelectedFiles: () => {},
-      onClickFile: jest.fn()
+      onClickFile: jest.fn(),
+      onError: () => {},
     }))
 
     // Assert
@@ -125,13 +127,42 @@ describe('FilesInDirectory', () => {
         path: 'path/to/directory/',
         selectedFiles: {},
         setSelectedFiles: () => {},
-        onClickFile: jest.fn()
+        onClickFile: jest.fn(),
+        onError: () => {},
       }))
 
       // Assert
       screen.getByText(expectedMessage)
     }
   )
+
+  it('calls onError callback on errors loading files', () => {
+    // Arrange
+    const useFilesInDirectoryResult: UseFilesInDirectoryResult = {
+      state: { status: 'Error', error: new Error('Something went wrong'), files: [] },
+      hasNextPage: false,
+      loadNextPage: () => Promise.resolve(),
+      loadAllRemainingItems: () => Promise.resolve(),
+      reload: () => Promise.resolve()
+    }
+
+    asMockedFn(useFilesInDirectory).mockReturnValue(useFilesInDirectoryResult)
+
+    const onError = jest.fn()
+
+    // Act
+    render(h(FilesInDirectory, {
+      provider: mockFileBrowserProvider,
+      path: 'path/to/directory/',
+      selectedFiles: {},
+      setSelectedFiles: () => {},
+      onClickFile: jest.fn(),
+      onError,
+    }))
+
+    // Assert
+    expect(onError).toHaveBeenCalledWith(new Error('Something went wrong'))
+  })
 
   describe('when next page is available', () => {
     // Arrange
@@ -170,7 +201,8 @@ describe('FilesInDirectory', () => {
         path: 'path/to/directory/',
         selectedFiles: {},
         setSelectedFiles: () => {},
-        onClickFile: jest.fn()
+        onClickFile: jest.fn(),
+        onError: () => {},
       }))
 
       // Assert
@@ -189,7 +221,8 @@ describe('FilesInDirectory', () => {
         path: 'path/to/directory/',
         selectedFiles: {},
         setSelectedFiles: () => {},
-        onClickFile: jest.fn()
+        onClickFile: jest.fn(),
+        onError: () => {},
       }))
 
       // Assert
@@ -221,7 +254,8 @@ describe('FilesInDirectory', () => {
       path: 'path/to/directory/',
       selectedFiles: {},
       setSelectedFiles: () => {},
-      onClickFile: jest.fn()
+      onClickFile: jest.fn(),
+      onError: () => {},
     }))
 
     const fileInput = document.querySelector<HTMLInputElement>('input[type="file"]')!

--- a/src/components/file-browser/FilesInDirectory.ts
+++ b/src/components/file-browser/FilesInDirectory.ts
@@ -25,6 +25,7 @@ interface FilesInDirectoryProps {
   selectedFiles: { [path: string]: FileBrowserFile }
   setSelectedFiles: Dispatch<SetStateAction<{ [path: string]: FileBrowserFile }>>
   onClickFile: (file: FileBrowserFile) => void
+  onError: (error: Error) => void
 }
 
 const FilesInDirectory = (props: FilesInDirectoryProps) => {
@@ -36,7 +37,8 @@ const FilesInDirectory = (props: FilesInDirectoryProps) => {
     rootLabel = 'Files',
     selectedFiles,
     setSelectedFiles,
-    onClickFile
+    onClickFile,
+    onError,
   } = props
 
   const directoryLabel = path === '' ? rootLabel : basename(path)
@@ -44,17 +46,24 @@ const FilesInDirectory = (props: FilesInDirectoryProps) => {
   const loadedAlertElementRef = useRef<HTMLSpanElement | null>(null)
 
   const {
-    state: { status, files },
+    state,
     hasNextPage,
     loadAllRemainingItems,
     loadNextPage,
     reload,
   } = useFilesInDirectory(provider, path)
 
+  useEffect(() => {
+    if (state.status === 'Error') {
+      onError(state.error)
+    }
+  }, [state, onError])
+
   const { uploadState, uploadFiles, cancelUpload } = useUploader(file => {
     return provider.uploadFileToDirectory(path, file)
   })
 
+  const { status, files } = state
   const isLoading = status === 'Loading'
 
   useEffect(() => {


### PR DESCRIPTION
Add support for requester pays buckets in the new file browser by prompting to select a workspace to bill to when a requester pays error is encountered.

To see this behavior, use the file browser in a read-only workspace that has a requester pays bucket.

To enable the new file browser, navigate to `http://localhost:3000/#feature-preview` and check the box for "Workspace files".