### PR TITLE
[SU-253] Disable upload/delete in .data-table-versions folder

### DIFF
--- a/src/components/file-browser/FileBrowser.ts
+++ b/src/components/file-browser/FileBrowser.ts
@@ -8,6 +8,7 @@ import PathBreadcrumbs from 'src/components/file-browser/PathBreadcrumbs'
 import Modal from 'src/components/Modal'
 import FileBrowserProvider, { FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
 import colors from 'src/libs/colors'
+import { dataTableVersionsPathRoot } from 'src/libs/data-table-versions'
 import * as Utils from 'src/libs/utils'
 
 
@@ -28,7 +29,11 @@ const FileBrowser = ({ provider, title, workspace }: FileBrowserProps) => {
   }, [path])
 
   const editWorkspaceError = Utils.editWorkspaceError(workspace)
-  const canEditWorkspace = !editWorkspaceError
+  const { editDisabled, editDisabledReason } = Utils.cond(
+    [!!editWorkspaceError, () => ({ editDisabled: true, editDisabledReason: editWorkspaceError })],
+    [path.startsWith(`${dataTableVersionsPathRoot}/`), () => ({ editDisabled: true, editDisabledReason: 'This folder cannot be edited' })],
+    () => ({ editDisabled: false, editDisabledReason: undefined })
+  )
 
   return h(Fragment, [
     div({ style: { display: 'flex', height: '100%' } }, [
@@ -89,8 +94,8 @@ const FileBrowser = ({ provider, title, workspace }: FileBrowserProps) => {
           })
         ]),
         h(FilesInDirectory, {
-          editDisabled: !canEditWorkspace,
-          editDisabledReason: editWorkspaceError,
+          editDisabled,
+          editDisabledReason,
           provider,
           path,
           rootLabel: 'Workspace bucket',

--- a/src/components/file-browser/FileBrowser.ts
+++ b/src/components/file-browser/FileBrowser.ts
@@ -31,7 +31,10 @@ const FileBrowser = ({ provider, title, workspace }: FileBrowserProps) => {
   const editWorkspaceError = Utils.editWorkspaceError(workspace)
   const { editDisabled, editDisabledReason } = Utils.cond(
     [!!editWorkspaceError, () => ({ editDisabled: true, editDisabledReason: editWorkspaceError })],
-    [path.startsWith(`${dataTableVersionsPathRoot}/`), () => ({ editDisabled: true, editDisabledReason: 'This folder cannot be edited' })],
+    [path.startsWith(`${dataTableVersionsPathRoot}/`), () => ({
+      editDisabled: true,
+      editDisabledReason: 'This folder is managed by data table versioning and cannot be edited here.',
+    })],
     () => ({ editDisabled: false, editDisabledReason: undefined })
   )
 


### PR DESCRIPTION
Files in the `.data-table-versions` folder of the workspace bucket are managed by data table versioning. To avoid interfering with that feature, disable upload/edit when viewing that folder in the file browser.