### PR TITLE
DC-627: Fix error message when error is an object

### DIFF
--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -362,14 +362,18 @@ const withScreenshot = _.curry((testName, fn) => async options => {
 
 // Emitted when the page crashes
 const logError = page => {
-  const handle = msg => console.error('page.error', msg)
+  const handle = msg => {
+    console.error('page.error', typeof msg === 'object' ? JSON.stringify(msg) : msg)
+  }
   page.on('error', handle)
   return () => page.off('error', handle)
 }
 
 // Emitted when an uncaught exception happens within the page
 const logPageError = page => {
-  const handle = msg => console.error('page.pageerror', msg)
+  const handle = msg => {
+    console.error('page.pageerror', typeof msg === 'object' ? JSON.stringify(msg) : msg)
+  }
   page.on('pageerror', handle)
   return () => page.off('pageerror', handle)
 }


### PR DESCRIPTION
Response objects are logged as `[Error: Response]` instead of the contents of the error response when the response is an object.

Example: https://circleci.com/gh/DataBiosphere/terra-ui/55527