### PR TITLE
[SU-252] Allow creating and deleting empty folders in new file browser

### DIFF
--- a/src/components/file-browser/DirectoryTree.test.ts
+++ b/src/components/file-browser/DirectoryTree.test.ts
@@ -7,6 +7,7 @@ import { h, ul } from 'react-hyperscript-helpers'
 import { Directory } from 'src/components/file-browser/DirectoryTree'
 import { useDirectoriesInDirectory } from 'src/components/file-browser/file-browser-hooks'
 import FileBrowserProvider from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
+import * as Utils from 'src/libs/utils'
 import { asMockedFn } from 'src/testing/test-utils'
 
 
@@ -28,6 +29,7 @@ describe('Directory', () => {
       id: 'node-0',
       path: 'path/to/directory/',
       provider: mockFileBrowserProvider,
+      reloadRequests: Utils.subscribable(),
       rootLabel: 'Workspace bucket',
       selectedDirectory: '',
       setActiveDescendant: () => {},
@@ -50,6 +52,7 @@ describe('Directory', () => {
       level: 0,
       path: 'path/to/directory/',
       provider: mockFileBrowserProvider,
+      reloadRequests: Utils.subscribable(),
       rootLabel: 'Workspace bucket',
       selectedDirectory: '',
       setActiveDescendant: () => {},
@@ -99,6 +102,7 @@ describe('Directory', () => {
           level: 0,
           path: 'path/to/directory/',
           provider: mockFileBrowserProvider,
+          reloadRequests: Utils.subscribable(),
           rootLabel: 'Workspace bucket',
           selectedDirectory: '',
           setActiveDescendant: () => {},
@@ -148,6 +152,7 @@ describe('Directory', () => {
       level: 0,
       path: 'path/to/directory/',
       provider: mockFileBrowserProvider,
+      reloadRequests: Utils.subscribable(),
       rootLabel: 'Workspace bucket',
       selectedDirectory: '',
       setActiveDescendant: () => {},
@@ -190,6 +195,7 @@ describe('Directory', () => {
       level: 0,
       path: 'path/to/directory/',
       provider: mockFileBrowserProvider,
+      reloadRequests: Utils.subscribable(),
       rootLabel: 'Workspace bucket',
       selectedDirectory: '',
       setActiveDescendant: () => {},
@@ -233,6 +239,7 @@ describe('Directory', () => {
       level: 0,
       path: 'path/to/directory/',
       provider: mockFileBrowserProvider,
+      reloadRequests: Utils.subscribable(),
       rootLabel: 'Workspace bucket',
       selectedDirectory: '',
       setActiveDescendant: () => {},
@@ -281,6 +288,7 @@ describe('Directory', () => {
         level: 0,
         path: 'path/to/directory/',
         provider: mockFileBrowserProvider,
+        reloadRequests: Utils.subscribable(),
         rootLabel: 'Workspace bucket',
         selectedDirectory: '',
         setActiveDescendant: () => {},

--- a/src/components/file-browser/DirectoryTree.ts
+++ b/src/components/file-browser/DirectoryTree.ts
@@ -10,12 +10,17 @@ import colors from 'src/libs/colors'
 import * as Utils from 'src/libs/utils'
 
 
+interface ReloadRequestSubscribable {
+  subscribe: (fn: (path: string) => void) => { unsubscribe: () => void }
+}
+
 interface SubdirectoriesProps {
   activeDescendant: string
   level: number
   parentId: string
   path: string
   provider: FileBrowserProvider
+  reloadRequests: ReloadRequestSubscribable
   rootLabel: string
   selectedDirectory: string
   setActiveDescendant: Dispatch<SetStateAction<string>>
@@ -40,6 +45,7 @@ export const Subdirectories = (props: SubdirectoriesProps) => {
     parentId,
     path,
     provider,
+    reloadRequests,
     rootLabel,
     selectedDirectory,
     setActiveDescendant,
@@ -55,7 +61,8 @@ export const Subdirectories = (props: SubdirectoriesProps) => {
   const {
     state,
     hasNextPage,
-    loadNextPage
+    loadNextPage,
+    reload,
   } = useDirectoriesInDirectory(provider, path)
 
   const { status, directories } = state
@@ -80,6 +87,14 @@ export const Subdirectories = (props: SubdirectoriesProps) => {
       loadedAlertElementRef.current!.innerHTML = `Error loading ${directoryLabel} subdirectories`
     }
   }, [directoryLabel, status])
+
+  useEffect(() => {
+    return reloadRequests.subscribe((pathToReload: string) => {
+      if (pathToReload === path) {
+        reload()
+      }
+    }).unsubscribe
+  }, [path, reload, reloadRequests])
 
   return h(Fragment, [
     span({
@@ -111,6 +126,7 @@ export const Subdirectories = (props: SubdirectoriesProps) => {
           level: level + 1,
           path: directory.path,
           provider,
+          reloadRequests,
           rootLabel,
           selectedDirectory,
           setActiveDescendant,
@@ -163,6 +179,7 @@ interface DirectoryProps {
   provider: FileBrowserProvider
   level: number
   path: string
+  reloadRequests: ReloadRequestSubscribable
   rootLabel: string
   selectedDirectory: string
   setActiveDescendant: Dispatch<SetStateAction<string>>
@@ -177,6 +194,7 @@ export const Directory = (props: DirectoryProps) => {
     level,
     path,
     provider,
+    reloadRequests,
     rootLabel,
     selectedDirectory,
     setActiveDescendant,
@@ -268,6 +286,7 @@ export const Directory = (props: DirectoryProps) => {
       parentId: id,
       path,
       provider,
+      reloadRequests,
       rootLabel,
       selectedDirectory,
       setActiveDescendant,
@@ -280,6 +299,7 @@ export const Directory = (props: DirectoryProps) => {
 
 interface DirectoryTreeProps {
   provider: FileBrowserProvider
+  reloadRequests: ReloadRequestSubscribable
   rootLabel: string
   selectedDirectory: string
   onError: (error: Error) => void
@@ -289,6 +309,7 @@ interface DirectoryTreeProps {
 const DirectoryTree = (props: DirectoryTreeProps) => {
   const {
     provider,
+    reloadRequests,
     rootLabel,
     selectedDirectory,
     onError,
@@ -390,6 +411,7 @@ const DirectoryTree = (props: DirectoryTreeProps) => {
       id: 'node-0',
       level: 0,
       path: '',
+      reloadRequests,
       rootLabel,
       selectedDirectory,
       setActiveDescendant,

--- a/src/components/file-browser/FileBrowser.ts
+++ b/src/components/file-browser/FileBrowser.ts
@@ -1,13 +1,13 @@
 import { Fragment, useCallback, useEffect, useState } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
 import DirectoryTree from 'src/components/file-browser/DirectoryTree'
-import { basename } from 'src/components/file-browser/file-browser-utils'
+import { basename, dirname } from 'src/components/file-browser/file-browser-utils'
 import { FileDetails } from 'src/components/file-browser/FileDetails'
 import FilesInDirectory from 'src/components/file-browser/FilesInDirectory'
 import PathBreadcrumbs from 'src/components/file-browser/PathBreadcrumbs'
 import Modal from 'src/components/Modal'
 import RequesterPaysModal from 'src/components/RequesterPaysModal'
-import FileBrowserProvider, { FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
+import FileBrowserProvider, { FileBrowserDirectory, FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
 import colors from 'src/libs/colors'
 import { dataTableVersionsPathRoot } from 'src/libs/data-table-versions'
 import { requesterPaysProjectStore } from 'src/libs/state'
@@ -123,6 +123,13 @@ const FileBrowser = ({ provider, rootLabel, title, workspace }: FileBrowserProps
           selectedFiles,
           setSelectedFiles,
           onClickFile: setFocusedFile,
+          onCreateDirectory: (directory: FileBrowserDirectory) => {
+            setPath(directory.path)
+          },
+          onDeleteDirectory: () => {
+            const parentPath = dirname(path)
+            setPath(parentPath)
+          },
           onError,
         })
       ])

--- a/src/components/file-browser/FileBrowser.ts
+++ b/src/components/file-browser/FileBrowser.ts
@@ -52,6 +52,8 @@ const FileBrowser = ({ provider, rootLabel, title, workspace }: FileBrowserProps
     () => ({ editDisabled: false, editDisabledReason: undefined })
   )
 
+  const reloadRequests = Utils.subscribable()
+
   return h(Fragment, [
     div({ style: { display: 'flex', height: '100%' } }, [
       div({
@@ -80,6 +82,7 @@ const FileBrowser = ({ provider, rootLabel, title, workspace }: FileBrowserProps
           h(DirectoryTree, {
             key: refreshKey,
             provider,
+            reloadRequests,
             rootLabel,
             selectedDirectory: path,
             onError,
@@ -125,10 +128,13 @@ const FileBrowser = ({ provider, rootLabel, title, workspace }: FileBrowserProps
           onClickFile: setFocusedFile,
           onCreateDirectory: (directory: FileBrowserDirectory) => {
             setPath(directory.path)
+            const parentPath = dirname(directory.path)
+            reloadRequests.next(parentPath)
           },
           onDeleteDirectory: () => {
             const parentPath = dirname(path)
             setPath(parentPath)
+            reloadRequests.next(parentPath)
           },
           onError,
         })

--- a/src/components/file-browser/FilesInDirectory.test.ts
+++ b/src/components/file-browser/FilesInDirectory.test.ts
@@ -60,6 +60,8 @@ describe('FilesInDirectory', () => {
       selectedFiles: {},
       setSelectedFiles: () => {},
       onClickFile: jest.fn(),
+      onCreateDirectory: () => {},
+      onDeleteDirectory: () => {},
       onError: () => {},
     }))
 
@@ -96,6 +98,8 @@ describe('FilesInDirectory', () => {
       selectedFiles: {},
       setSelectedFiles: () => {},
       onClickFile: jest.fn(),
+      onCreateDirectory: () => {},
+      onDeleteDirectory: () => {},
       onError: () => {},
     }))
 
@@ -128,6 +132,8 @@ describe('FilesInDirectory', () => {
         selectedFiles: {},
         setSelectedFiles: () => {},
         onClickFile: jest.fn(),
+        onCreateDirectory: () => {},
+        onDeleteDirectory: () => {},
         onError: () => {},
       }))
 
@@ -157,6 +163,8 @@ describe('FilesInDirectory', () => {
       selectedFiles: {},
       setSelectedFiles: () => {},
       onClickFile: jest.fn(),
+      onCreateDirectory: () => {},
+      onDeleteDirectory: () => {},
       onError,
     }))
 
@@ -202,6 +210,8 @@ describe('FilesInDirectory', () => {
         selectedFiles: {},
         setSelectedFiles: () => {},
         onClickFile: jest.fn(),
+        onCreateDirectory: () => {},
+        onDeleteDirectory: () => {},
         onError: () => {},
       }))
 
@@ -222,6 +232,8 @@ describe('FilesInDirectory', () => {
         selectedFiles: {},
         setSelectedFiles: () => {},
         onClickFile: jest.fn(),
+        onCreateDirectory: () => {},
+        onDeleteDirectory: () => {},
         onError: () => {},
       }))
 
@@ -255,6 +267,8 @@ describe('FilesInDirectory', () => {
       selectedFiles: {},
       setSelectedFiles: () => {},
       onClickFile: jest.fn(),
+      onCreateDirectory: () => {},
+      onDeleteDirectory: () => {},
       onError: () => {},
     }))
 
@@ -267,5 +281,47 @@ describe('FilesInDirectory', () => {
 
     // Assert
     expect(uploadFileToDirectory).toHaveBeenCalledWith('path/to/directory/', file)
+  })
+
+  it('allows deleting empty folders', async () => {
+    // Arrange
+    const user = userEvent.setup()
+
+    const deleteEmptyDirectory = jest.fn(() => Promise.resolve())
+    const mockProvider = {
+      supportsEmptyDirectories: true,
+      deleteEmptyDirectory,
+    } as Partial<FileBrowserProvider> as FileBrowserProvider
+
+    const onDeleteDirectory = jest.fn()
+
+    const useFilesInDirectoryResult: UseFilesInDirectoryResult = {
+      state: { status: 'Ready', files: [] },
+      hasNextPage: false,
+      loadNextPage: () => Promise.resolve(),
+      loadAllRemainingItems: () => Promise.resolve(),
+      reload: () => Promise.resolve()
+    }
+
+    asMockedFn(useFilesInDirectory).mockReturnValue(useFilesInDirectoryResult)
+
+    render(h(FilesInDirectory, {
+      provider: mockProvider,
+      path: 'path/to/directory/',
+      selectedFiles: {},
+      setSelectedFiles: () => {},
+      onClickFile: jest.fn(),
+      onCreateDirectory: () => {},
+      onDeleteDirectory,
+      onError: () => {},
+    }))
+
+    // Act
+    const deleteButton = screen.getByText('Delete this folder')
+    await act(() => user.click(deleteButton))
+
+    // Assert
+    expect(deleteEmptyDirectory).toHaveBeenCalledWith('path/to/directory/')
+    expect(onDeleteDirectory).toHaveBeenCalled()
   })
 })

--- a/src/components/file-browser/FilesMenu.test.ts
+++ b/src/components/file-browser/FilesMenu.test.ts
@@ -50,9 +50,11 @@ describe('FilesMenu', () => {
       user = userEvent.setup()
 
       render(h(FilesMenu, {
+        path: 'path/to/',
         provider: mockProvider,
         selectedFiles,
         onClickUpload: () => {},
+        onCreateDirectory: () => {},
         onDeleteFiles,
       }))
 
@@ -92,5 +94,41 @@ describe('FilesMenu', () => {
       // Assert
       expect(onDeleteFiles).toHaveBeenCalled()
     })
+  })
+
+  it('creates new folder', async () => {
+    // Arrange
+    const user = userEvent.setup()
+
+    const createEmptyDirectory = jest.fn((path: string) => Promise.resolve({ path }))
+    const mockProvider = {
+      supportsEmptyDirectories: true,
+      createEmptyDirectory
+    } as Partial<FileBrowserProvider> as FileBrowserProvider
+
+    const onCreateDirectory = jest.fn()
+
+    render(h(FilesMenu, {
+      path: 'path/to/directory/',
+      provider: mockProvider,
+      selectedFiles: {},
+      onClickUpload: () => {},
+      onCreateDirectory,
+      onDeleteFiles: () => {},
+    }))
+
+    // Act
+    const newFolderButton = screen.getByText('New folder')
+    await user.click(newFolderButton)
+
+    const nameInput = screen.getByLabelText('Folder name *')
+    await user.type(nameInput, 'test-folder')
+
+    const createButton = screen.getByText('Create Folder')
+    await act(() => user.click(createButton))
+
+    // Assert
+    expect(createEmptyDirectory).toHaveBeenCalledWith('path/to/directory/test-folder/')
+    expect(onCreateDirectory).toHaveBeenCalledWith({ path: 'path/to/directory/test-folder/' })
   })
 })

--- a/src/components/file-browser/FilesMenu.ts
+++ b/src/components/file-browser/FilesMenu.ts
@@ -4,7 +4,8 @@ import { div, h } from 'react-hyperscript-helpers'
 import { ButtonPrimary, Link, topSpinnerOverlay } from 'src/components/common'
 import { DeleteFilesConfirmationModal } from 'src/components/file-browser/DeleteFilesConfirmationModal'
 import { icon } from 'src/components/icons'
-import FileBrowserProvider, { FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
+import { NameModal } from 'src/components/NameModal'
+import FileBrowserProvider, { FileBrowserDirectory, FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider'
 import colors from 'src/libs/colors'
 import { reportError } from 'src/libs/error'
 import * as Utils from 'src/libs/utils'
@@ -13,9 +14,11 @@ import * as Utils from 'src/libs/utils'
 interface FilesMenuProps {
   disabled?: boolean
   disabledReason?: string
+  path: string
   provider: FileBrowserProvider
   selectedFiles: { [path: string]: FileBrowserFile }
   onClickUpload: () => void
+  onCreateDirectory: (directory: FileBrowserDirectory) => void
   onDeleteFiles: () => void
 }
 
@@ -23,13 +26,16 @@ export const FilesMenu = (props: FilesMenuProps) => {
   const {
     disabled = false,
     disabledReason = 'Unable to edit files',
+    path,
     provider,
     selectedFiles,
     onClickUpload,
+    onCreateDirectory,
     onDeleteFiles,
   } = props
 
   const [busy, setBusy] = useState(false)
+  const [creatingNewDirectory, setCreatingNewDirectory] = useState(false)
   const [confirmingDelete, setConfirmingDelete] = useState(false)
 
   const hasSelectedFiles = !_.isEmpty(selectedFiles)
@@ -56,6 +62,13 @@ export const FilesMenu = (props: FilesMenuProps) => {
       },
     }), ' Upload']),
 
+    provider.supportsEmptyDirectories && h(Link, {
+      disabled,
+      tooltip: disabled ? disabledReason : undefined,
+      style: { padding: '0.5rem' },
+      onClick: () => setCreatingNewDirectory(true),
+    }, [icon('folder'), ' New folder']),
+
     h(Link, {
       disabled: disabled || !hasSelectedFiles,
       tooltip: Utils.cond(
@@ -66,6 +79,24 @@ export const FilesMenu = (props: FilesMenuProps) => {
       style: { padding: '0.5rem' },
       onClick: () => setConfirmingDelete(true),
     }, [icon('trash'), ' Delete']),
+
+    // @ts-expect-error
+    creatingNewDirectory && h(NameModal, {
+      thing: 'Folder',
+      onDismiss: () => setCreatingNewDirectory(false),
+      onSuccess: async ({ name }) => {
+        setCreatingNewDirectory(false)
+        setBusy(true)
+        try {
+          const newDirectory = await provider.createEmptyDirectory(`${path}${name}/`)
+          onCreateDirectory(newDirectory)
+        } catch (error) {
+          reportError('Error creating folder', error)
+        } finally {
+          setBusy(false)
+        }
+      }
+    }),
 
     confirmingDelete && h(DeleteFilesConfirmationModal, {
       files: _.values(selectedFiles),

--- a/src/components/file-browser/FilesMenu.ts
+++ b/src/components/file-browser/FilesMenu.ts
@@ -80,9 +80,11 @@ export const FilesMenu = (props: FilesMenuProps) => {
       onClick: () => setConfirmingDelete(true),
     }, [icon('trash'), ' Delete']),
 
-    // @ts-expect-error
     creatingNewDirectory && h(NameModal, {
       thing: 'Folder',
+      // @ts-expect-error
+      validator: /^[^\s/#*?\[\]]+$/, // eslint-disable-line no-useless-escape
+      validationMessage: 'Folder name may not contain spaces, forward slashes, or any of the following characters: # * ? [ ]',
       onDismiss: () => setCreatingNewDirectory(false),
       onSuccess: async ({ name }) => {
         setCreatingNewDirectory(false)

--- a/src/components/file-browser/file-browser-utils.test.ts
+++ b/src/components/file-browser/file-browser-utils.test.ts
@@ -1,4 +1,4 @@
-import { basename } from 'src/components/file-browser/file-browser-utils'
+import { basename, dirname } from 'src/components/file-browser/file-browser-utils'
 
 
 describe('basename', () => {
@@ -13,5 +13,20 @@ describe('basename', () => {
 
     expect(basename('')).toBe('')
     expect(basename('/')).toBe('')
+  })
+})
+
+describe('dirname', () => {
+  it('returns file dirname from path', () => {
+    expect(dirname('path/to/file.txt')).toBe('path/to/')
+    expect(dirname('file.txt')).toBe('')
+  })
+
+  it('returns directory dirname from path', () => {
+    expect(dirname('path/to/directory/')).toBe('path/to/')
+    expect(dirname('directory/')).toBe('')
+
+    expect(dirname('')).toBe('')
+    expect(dirname('/')).toBe('')
   })
 })

--- a/src/components/file-browser/file-browser-utils.ts
+++ b/src/components/file-browser/file-browser-utils.ts
@@ -1,1 +1,6 @@
 export const basename = (path: string) => path.replace(/\/$/, '').split('/').at(-1)
+
+export const dirname = (path: string) => {
+  const parentPath = path.replace(/\/$/, '').split('/').slice(0, -1).join('/')
+  return parentPath === '' ? '' : `${parentPath}/`
+}

--- a/src/libs/ajax/file-browser-providers/AzureBlobStorageFileBrowserProvider.ts
+++ b/src/libs/ajax/file-browser-providers/AzureBlobStorageFileBrowserProvider.ts
@@ -100,6 +100,7 @@ const AzureBlobStorageFileBrowserProvider = ({ workspaceId, pageSize = 1000 }: A
   }
 
   return {
+    supportsEmptyDirectories: false,
     getFilesInDirectory: async (path, { signal } = {}) => {
       const { sas: { url: sasUrl } } = await storageDetailsPromise
       return getNextPage({
@@ -190,6 +191,12 @@ const AzureBlobStorageFileBrowserProvider = ({ workspaceId, pageSize = 1000 }: A
           method: 'DELETE',
         }
       )
+    },
+    createEmptyDirectory: (_directoryPath: string) => {
+      return Promise.reject(new Error('Empty directories not supported in Azure workspaces'))
+    },
+    deleteEmptyDirectory: (_directoryPath: string) => {
+      return Promise.reject(new Error('Empty directories not supported in Azure workspaces'))
     },
   }
 }

--- a/src/libs/ajax/file-browser-providers/FileBrowserProvider.ts
+++ b/src/libs/ajax/file-browser-providers/FileBrowserProvider.ts
@@ -14,6 +14,8 @@ export interface FileBrowserDirectory {
 }
 
 interface FileBrowserProvider {
+  supportsEmptyDirectories: boolean
+
   getDirectoriesInDirectory(path: string, options?: { signal?: AbortSignal }): Promise<IncrementalResponse<FileBrowserDirectory>>
   getFilesInDirectory(path: string, options?: { signal?: AbortSignal }): Promise<IncrementalResponse<FileBrowserFile>>
   getDownloadUrlForFile(path: string, options?: { signal?: AbortSignal }): Promise<string>
@@ -21,6 +23,9 @@ interface FileBrowserProvider {
 
   uploadFileToDirectory(directoryPath: string, file: File): Promise<void>
   deleteFile(path: string): Promise<void>
+
+  createEmptyDirectory(directoryPath: string): Promise<FileBrowserDirectory>
+  deleteEmptyDirectory(directoryPath: string): Promise<void>
 }
 
 export default FileBrowserProvider

--- a/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.test.ts
+++ b/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.test.ts
@@ -208,4 +208,47 @@ describe('GCSFileBrowserProvider', () => {
     // Assert
     expect(del).toHaveBeenCalledWith('test-project', 'test-bucket', 'path/to/file.txt')
   })
+
+  it('creates empty directories', async () => {
+    // Arrange
+    const upload = jest.fn(() => Promise.resolve())
+    asMockedFn(Ajax).mockImplementation(() => ({
+      Buckets: { upload } as Partial<GoogleStorageContract>
+    }) as ReturnType<typeof Ajax>)
+
+    const provider = GCSFileBrowserProvider({ bucket: 'test-bucket', project: 'test-project' })
+
+    // Act
+    const directory = await provider.createEmptyDirectory('foo/bar/baz/')
+
+    // Assert
+    expect(upload).toHaveBeenCalledWith(
+      'test-project',
+      'test-bucket',
+      'foo/bar/',
+      new File([], 'baz/', { type: 'text/plain' })
+    )
+
+    expect(directory).toEqual({ path: 'foo/bar/baz/' })
+  })
+
+  it('deletes empty directories', async () => {
+    // Arrange
+    const del = jest.fn(() => Promise.resolve())
+    asMockedFn(Ajax).mockImplementation(() => ({
+      Buckets: { delete: del } as Partial<GoogleStorageContract>
+    }) as ReturnType<typeof Ajax>)
+
+    const provider = GCSFileBrowserProvider({ bucket: 'test-bucket', project: 'test-project' })
+
+    // Act
+    await provider.deleteEmptyDirectory('foo/bar/baz/')
+
+    // Assert
+    expect(del).toHaveBeenCalledWith(
+      'test-project',
+      'test-bucket',
+      'foo/bar/baz/',
+    )
+  })
 })

--- a/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.ts
+++ b/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.ts
@@ -47,8 +47,13 @@ const GCSFileBrowserProvider = ({ bucket, project, pageSize = 1000 }: GCSFileBro
         }
 
         const response = await Ajax(signal).Buckets.list(project, bucket, prefix, requestOptions)
+        const responseItems = (response[itemsOrPrefixes] || []).map(itemOrPrefix => mapItemOrPrefix(itemOrPrefix))
 
-        buffer = buffer.concat((response[itemsOrPrefixes] || []).map(itemOrPrefix => mapItemOrPrefix(itemOrPrefix)))
+        // Exclude folder placeholder objects.
+        // See https://cloud.google.com/storage/docs/folders for more information.
+        const responseItemsWithoutPlaceholders = responseItems.filter(fileOrDirectory => (fileOrDirectory as any).path !== prefix)
+
+        buffer = buffer.concat(responseItemsWithoutPlaceholders)
         nextPageToken = response.nextPageToken
       } while (buffer.length < pageSize && nextPageToken)
     }

--- a/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.ts
+++ b/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.ts
@@ -78,6 +78,7 @@ const GCSFileBrowserProvider = ({ bucket, project, pageSize = 1000 }: GCSFileBro
   }
 
   return {
+    supportsEmptyDirectories: true,
     getFilesInDirectory: (path, { signal } = {}) => getNextPage({
       isFirstPage: true,
       itemsOrPrefixes: 'items',
@@ -116,6 +117,32 @@ const GCSFileBrowserProvider = ({ bucket, project, pageSize = 1000 }: GCSFileBro
     },
     deleteFile: async (path: string): Promise<void> => {
       await Ajax().Buckets.delete(project, bucket, path)
+    },
+    createEmptyDirectory: async (directoryPath: string) => {
+      // Create a placeholder object for the new folder.
+      // See https://cloud.google.com/storage/docs/folders for more information.
+      console.assert(directoryPath.endsWith('/'), 'Directory paths must include a trailing slash')
+      const prefixSegments = directoryPath.split('/').slice(0, -2)
+      const prefix = prefixSegments.length === 0 ? '' : `${prefixSegments.join('/')}/`
+      const directoryName = directoryPath.split('/').slice(-2, -1)[0]
+      const placeholderObject = new File([''], `${directoryName}/`, { type: 'text/plain' })
+      await Ajax().Buckets.upload(project, bucket, prefix, placeholderObject)
+      return {
+        path: directoryPath
+      }
+    },
+    deleteEmptyDirectory: async (directoryPath: string) => {
+      console.assert(directoryPath.endsWith('/'), 'Directory paths must include a trailing slash')
+      // Attempt to delete folder placeholder object.
+      // A placeholder object may not exist for the prefix being viewed, so do not an report error for 404 responses.
+      // See https://cloud.google.com/storage/docs/folders for more information on placeholder objects.
+      try {
+        await Ajax().Buckets.delete(project, bucket, directoryPath)
+      } catch (error) {
+        if (!(error instanceof Response && error.status === 404)) {
+          throw error
+        }
+      }
     },
   }
 }


### PR DESCRIPTION
Adding this feature to the new file browser. Creating empty folders is currently only supported in GCP workspaces.

https://user-images.githubusercontent.com/1156625/211425081-6e545a1d-c8ed-4aae-a374-65f8151ba233.mov

