### PR TITLE
[SU-266] Automatically configure imported workflows with default outputs

### DIFF
--- a/src/pages/ImportWorkflow.js
+++ b/src/pages/ImportWorkflow.js
@@ -74,9 +74,13 @@ const DockstoreImporter = ({ path, version, source }) => {
         }),
       ])
 
-      const defaultOutputConfiguration = _.fromPairs(
-        _.map(({ name }) => [name, `this.${_.last(name.split('.'))}`], workflowOutputs)
-      )
+      const defaultOutputConfiguration = _.flow(
+        _.map(output => {
+          const outputExpression = `this.${_.last(_.split('.', output.name))}`
+          return [output.name, outputExpression]
+        }),
+        _.fromPairs
+      )(workflowOutputs)
 
       await rawlsWorkspace.importMethodConfigFromDocker({
         namespace, name: workflowName, rootEntityType: _.head(_.keys(entityMetadata)),


### PR DESCRIPTION
Currently, when a workflow is imported from Dockstore, its outputs are not configured. This is rarely what users want and can lead to wasted time and money if the user forgets to configure outputs and runs the workflow without saving its outputs to a data table.

With this change, workflow outputs will be automatically configured as if the user had clicked the "Use defaults" button in the workflow outputs tab.

## Before
https://user-images.githubusercontent.com/1156625/211585533-8597f84b-6daa-4617-b3cb-a9abcbe4e4e2.mov

## After 
https://user-images.githubusercontent.com/1156625/211585578-4fd0d8df-e447-476c-ae22-67c218f4e402.mov


