### PR TITLE
[IA-3843] When deleting RStudio or JupyterLab, redirect to Analyses tab.

### DIFF
--- a/src/pages/workspaces/workspace/analysis/AppLauncher.js
+++ b/src/pages/workspaces/workspace/analysis/AppLauncher.js
@@ -212,9 +212,7 @@ const ApplicationLauncher = _.flow(
       // periodically check for outdated R analyses
       interval.current = !!googleProject && setInterval(findOutdatedAnalyses, 10000)
     }
-    // if (runtime) {
-    //   setBusy(false)
-    // }
+
     return () => {
       clearInterval(interval.current)
       interval.current = undefined

--- a/src/pages/workspaces/workspace/analysis/AppLauncher.js
+++ b/src/pages/workspaces/workspace/analysis/AppLauncher.js
@@ -24,7 +24,7 @@ const ApplicationLauncher = _.flow(
     breadcrumbs: props => breadcrumbs.commonPaths.workspaceDashboard(props),
     title: _.get('application'),
     activeTab: appLauncherTabName
-  }) // TODO: Check if name: workspaceName could be moved into the other workspace deconstruction
+  })
 )(({
   name: workspaceName, sparkInterface, analysesData: { runtimes, refreshRuntimes },
   application, workspace: { azureContext, workspace: { namespace, name, workspaceId, googleProject, bucketName } }

--- a/src/pages/workspaces/workspace/analysis/AppLauncher.js
+++ b/src/pages/workspaces/workspace/analysis/AppLauncher.js
@@ -12,7 +12,7 @@ import { forwardRefWithName, useCancellation, useOnMount, useStore } from 'src/l
 import { authStore, azureCookieReadyStore, cookieReadyStore } from 'src/libs/state'
 import * as Utils from 'src/libs/utils'
 import { getExtension, notebookLockHash, stripExtension } from 'src/pages/workspaces/workspace/analysis/file-utils'
-import { appLauncherTabName, PeriodicAzureCookieSetter, RuntimeKicker, RuntimeStatusMonitor, StatusMessage } from 'src/pages/workspaces/workspace/analysis/runtime-common'
+import { analysisTabName, appLauncherTabName, PeriodicAzureCookieSetter, RuntimeKicker, RuntimeStatusMonitor, StatusMessage } from 'src/pages/workspaces/workspace/analysis/runtime-common'
 import { getAnalysesDisplayList, getConvertedRuntimeStatus, getCurrentRuntime, usableStatuses } from 'src/pages/workspaces/workspace/analysis/runtime-utils'
 import { getPatternFromRuntimeTool, getToolFromRuntime, runtimeTools, toolLabels } from 'src/pages/workspaces/workspace/analysis/tool-utils'
 import { wrapWorkspace } from 'src/pages/workspaces/workspace/WorkspaceContainer'
@@ -27,14 +27,13 @@ const ApplicationLauncher = _.flow(
   }) // TODO: Check if name: workspaceName could be moved into the other workspace deconstruction
 )(({
   name: workspaceName, sparkInterface, analysesData: { runtimes, refreshRuntimes },
-  application, workspace: { azureContext, workspace: { workspaceId, googleProject, bucketName } }
+  application, workspace: { azureContext, workspace: { namespace, name, workspaceId, googleProject, bucketName } }
 }, _ref) => {
-  const [busy, setBusy] = useState(false)
+  const [busy, setBusy] = useState(true)
   const [outdatedAnalyses, setOutdatedAnalyses] = useState()
   const [fileOutdatedOpen, setFileOutdatedOpen] = useState(false)
   const [hashedOwnerEmail, setHashedOwnerEmail] = useState()
   const [iframeSrc, setIframeSrc] = useState()
-
   const leoCookieReady = useStore(cookieReadyStore)
   const azureCookieReady = useStore(azureCookieReadyStore)
   const cookieReady = !!googleProject ? leoCookieReady : azureCookieReady
@@ -50,7 +49,6 @@ const ApplicationLauncher = _.flow(
 
   const runtime = getCurrentRuntime(runtimes)
   const runtimeStatus = getConvertedRuntimeStatus(runtime) // preserve null vs undefined
-
   const FileOutdatedModal = ({ onDismiss, bucketName }) => {
     const handleChoice = _.flow(
       withErrorReportingInModal('Error setting up analysis file syncing')(onDismiss),
@@ -129,13 +127,14 @@ const ApplicationLauncher = _.flow(
       analysis?.metadata[hashedOwnerEmail] === 'outdated', analyses)
   }
 
-  useOnMount(() => {
+  useOnMount(async () => {
     const findHashedEmail = withErrorReporting('Error loading user email information', async () => {
       const hashedEmail = await notebookLockHash(bucketName, email)
       setHashedOwnerEmail(hashedEmail)
     })
 
-    refreshRuntimes()
+    await refreshRuntimes()
+    setBusy(false)
     findHashedEmail()
   })
 
@@ -213,7 +212,9 @@ const ApplicationLauncher = _.flow(
       // periodically check for outdated R analyses
       interval.current = !!googleProject && setInterval(findOutdatedAnalyses, 10000)
     }
-
+    // if (runtime) {
+    //   setBusy(false)
+    // }
     return () => {
       clearInterval(interval.current)
       interval.current = undefined
@@ -251,6 +252,7 @@ const ApplicationLauncher = _.flow(
             [runtimeStatus === 'LeoReconfiguring', () => 'Cloud environment is updating, please wait.'],
             [runtimeStatus === 'Error', () => 'Error with the cloud environment, please try again.'],
             [runtimeStatus === null, () => 'Create a cloud environment to continue.'],
+            [runtimeStatus === undefined && runtime === undefined, () => Nav.goToPath(analysisTabName, { namespace, name })],
             [runtimeStatus === undefined, () => 'Loading...'],
             () => 'Unknown cloud environment status. Please create a new cloud environment or contact support.'
           )


### PR DESCRIPTION
When deleting RStudio or JupyterLab, the user will get stuck with a loading spinner indefinitely in the AppLauncher component. Instead, we should redirect to the Analyses tab.


<!---
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Also, so if a screen recording [1] and/or screenshots would be a helpful way to communicate context, please consider including some in your PR description.
Thanks!

[1] https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac
-->
