### PR TITLE
[SUP-384] Avoid cutting off autocomplete suggestions if they overflow the window

### DIFF
--- a/src/components/input.js
+++ b/src/components/input.js
@@ -5,7 +5,7 @@ import { div, h, input, textarea } from 'react-hyperscript-helpers'
 import TextAreaAutosize from 'react-textarea-autosize'
 import { ButtonPrimary } from 'src/components/common'
 import { icon } from 'src/components/icons'
-import { PopupPortal, useDynamicPosition } from 'src/components/popup-utils'
+import { PopupPortal, useDynamicPosition, useWindowDimensions } from 'src/components/popup-utils'
 import TooltipTrigger from 'src/components/TooltipTrigger'
 import colors from 'src/libs/colors'
 import { combineRefs, forwardRefWithName, useGetter, useInstance, useLabelAssert, useOnMount } from 'src/libs/react-utils'
@@ -18,7 +18,7 @@ const styles = {
     border: `1px solid ${colors.dark(0.55)}`, borderRadius: 4
   },
   suggestionsContainer: {
-    position: 'fixed', top: 0, left: 0,
+    position: 'fixed', left: 0,
     maxHeight: 36 * 8 + 2, overflowY: 'auto',
     backgroundColor: 'white',
     border: `1px solid ${colors.light()}`,
@@ -222,13 +222,25 @@ export const ValidatedInput = ({ inputProps, width, error }) => {
 
 const AutocompleteSuggestions = ({ target: targetId, containerProps, children }) => {
   const [target] = useDynamicPosition([{ id: targetId }])
+  const windowDimensions = useWindowDimensions()
+
+  const anchorToBottom = (windowDimensions.height - target.bottom) >= styles.suggestionsContainer.maxHeight
+  const style = anchorToBottom ? {
+    top: 0,
+    transform: `translate(${target.left}px, ${target.bottom}px)`,
+  } : {
+    bottom: 0,
+    transform: `translate(${target.left}px, -${windowDimensions.height - target.top}px)`,
+  }
+
   return h(PopupPortal, [
     div({
       ...containerProps,
       style: {
-        transform: `translate(${target.left}px, ${target.bottom}px)`, width: target.width,
+        ...styles.suggestionsContainer,
+        ...style,
         visibility: !target.width ? 'hidden' : undefined,
-        ...styles.suggestionsContainer
+        width: target.width,
       }
     }, [children])
   ])

--- a/src/components/popup-utils.js
+++ b/src/components/popup-utils.js
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp'
-import { Children, useRef, useState } from 'react'
+import { Children, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useGetter, useOnMount } from 'src/libs/react-utils'
 import * as Utils from 'src/libs/utils'
@@ -29,6 +29,20 @@ export const useDynamicPosition = selectors => {
     computePosition()
     return () => cancelAnimationFrame(animation.current)
   })
+  return dimensions
+}
+
+export const useWindowDimensions = () => {
+  const [dimensions, setDimensions] = useState(() => ({ width: window.innerWidth, height: window.innerHeight }))
+
+  useEffect(() => {
+    const onResize = () => {
+      setDimensions({ width: window.innerWidth, height: window.innerHeight })
+    }
+    window.addEventListener('resize', onResize)
+    return () => window.removeEventListener('resize', onResize)
+  }, [])
+
   return dimensions
 }
 


### PR DESCRIPTION
Currently, autocomplete suggestions are always placed below the input. When the input is near the bottom of the window, this can cause the suggestions to overflow the window and become unreachable. This is especially a problem for the last few workflow inputs/outputs.

This change places suggestions above the input if there is not enough room for them below.

## Before
![Screen Shot 2023-01-10 at 11 37 54 AM](https://user-images.githubusercontent.com/1156625/211610006-a6ba7f7c-e035-4f60-a44d-80497277670f.png)

## After
![Screen Shot 2023-01-10 at 11 38 14 AM](https://user-images.githubusercontent.com/1156625/211610045-5df319d2-faa2-4249-a310-b3360f2f2553.png)
