### PR TITLE
Aj-757 remove getConfig.isProd

### DIFF
--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -566,7 +566,7 @@ const WorkspaceData = _.flow(
   }
 
   const loadWdsSchema = async () => {
-    if (!getConfig().isProd && isAzureWorkspace) {
+    if (isAzureWorkspace) {
       try {
         setWdsSchema([])
         setWdsSchemaError(undefined)


### PR DESCRIPTION
See [AJ-757](https://broadworkbench.atlassian.net/browse/AJ-757). All this PR does is remove the `isProd` check before loading the WDS schema since WDS is now on prod.  I changed the "isProd" value in `dev.json` to `true` and ran it locally to verify that the schema does load.

[AJ-757]: https://broadworkbench.atlassian.net/browse/AJ-757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ