### PR TITLE
IA-3946 move UI test failures to ia-notification-test

### DIFF
--- a/integration-tests/slack/slack-notify-channels.json
+++ b/integration-tests/slack/slack-notify-channels.json
@@ -11,8 +11,8 @@
       "id": "C53JYBV9A"
     },
     {
-      "name": "dsp-interactive-analysis",
-      "id": "CA3NP1733",
+      "name": "ia-notification-test",
+      "id": "C03ATF4QXEV",
       "tests": [
         {
           "name": "run-analysis"


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3946

`dsp-interactive-analysis` is public channel that have many ppl in it. We get a bit spammed in that channel the last few days which buries more important conversations

#ia-notification-test is what team hero actively monitors for test failures