### PR TITLE
[SU-269] Filter workspaces in requester pays modal to GCP workspaces

### DIFF
--- a/src/components/RequesterPaysModal.js
+++ b/src/components/RequesterPaysModal.js
@@ -9,6 +9,7 @@ import { FormLabel } from 'src/libs/forms'
 import * as Nav from 'src/libs/nav'
 import { requesterPaysProjectStore } from 'src/libs/state'
 import * as Utils from 'src/libs/utils'
+import { isGoogleWorkspace } from 'src/libs/workspace-utils'
 
 
 const requesterPaysHelpInfo = div({ style: { paddingTop: '1rem' } }, [
@@ -20,7 +21,7 @@ const requesterPaysHelpInfo = div({ style: { paddingTop: '1rem' } }, [
 
 const RequesterPaysModal = ({ onDismiss, onSuccess }) => {
   const { workspaces, loading } = useWorkspaces()
-  const billableWorkspaces = _.filter(workspace => workspace.accessLevel === 'OWNER' || workspace.accessLevel === 'PROJECT_OWNER', workspaces)
+  const billableWorkspaces = _.filter(workspace => isGoogleWorkspace(workspace) && (workspace.accessLevel === 'OWNER' || workspace.accessLevel === 'PROJECT_OWNER'), workspaces)
 
   const [selectedGoogleProject, setSelectedGoogleProject] = useState(requesterPaysProjectStore.get())
 

--- a/src/components/RequesterPaysModal.test.js
+++ b/src/components/RequesterPaysModal.test.js
@@ -1,0 +1,84 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { h } from 'react-hyperscript-helpers'
+import { mockModalModule } from 'src/components/Modal.mock'
+
+import RequesterPaysModal from './RequesterPaysModal'
+
+
+jest.mock('src/components/Modal', () => {
+  return mockModalModule()
+})
+
+jest.mock('src/components/workspace-utils', () => ({
+  ...jest.requireActual('src/components/workspace-utils'),
+  useWorkspaces: jest.fn().mockReturnValue({
+    loading: false,
+    workspaces: [
+      {
+        workspace: { namespace: 'test-namespace', name: 'workspace-1', cloudPlatform: 'Gcp', googleProject: 'test-project-1' },
+        accessLevel: 'PROJECT_OWNER',
+      },
+      {
+        workspace: { namespace: 'test-namespace', name: 'workspace-2', cloudPlatform: 'Gcp', googleProject: 'test-project-2' },
+        accessLevel: 'OWNER',
+      },
+      {
+        workspace: { namespace: 'test-namespace', name: 'workspace-3', cloudPlatform: 'Gcp', googleProject: 'test-project-3' },
+        accessLevel: 'WRITER',
+      },
+      {
+        workspace: { namespace: 'test-namespace', name: 'workspace-4', cloudPlatform: 'Gcp', googleProject: 'test-project-4' },
+        accessLevel: 'READER',
+      },
+      {
+        workspace: { namespace: 'test-namespace', name: 'workspace-5', cloudPlatform: 'Azure' },
+        accessLevel: 'OWNER',
+      },
+    ]
+  })
+}))
+
+describe('RequesterPaysModal', () => {
+  it('lists GCP workspaces that the user owns', async () => {
+    // Arrange
+    const user = userEvent.setup()
+
+    render(h(RequesterPaysModal, {
+      onDismiss: () => {},
+      onSuccess: () => {},
+    }))
+
+    // Act
+    const workspaceInput = screen.getByLabelText('Workspace *')
+    await user.click(workspaceInput)
+    const options = screen.getAllByRole('option').map(el => el.textContent)
+
+    // Assert
+    expect(options).toEqual(['test-namespace/workspace-1', 'test-namespace/workspace-2'])
+  })
+
+  it('calls onSuccess callback with Google project from selected workspace', async () => {
+    // Arrange
+    const user = userEvent.setup()
+
+    const onSuccess = jest.fn()
+    render(h(RequesterPaysModal, {
+      onDismiss: () => {},
+      onSuccess,
+    }))
+
+    const workspaceInput = screen.getByLabelText('Workspace *')
+    await user.click(workspaceInput)
+
+    // Act
+    const workspaceOption = screen.getByText('test-namespace/workspace-2')
+    await user.click(workspaceOption)
+
+    const okButton = screen.getByText('Ok')
+    await user.click(okButton)
+
+    // Assert
+    expect(onSuccess).toHaveBeenCalledWith('test-project-2')
+  })
+})


### PR DESCRIPTION
When viewing files in a read-only workspace with a requester pays bucket (this occurs most often with public/featured workspaces), Terra prompts the user for a workspace to bill charges for the GCS operations to. Currently, this prompt includes both GCP and Azure workspaces. However, Terra reads the Google project from selected workspace so only GCP workspaces are valid choices. This removes Azure workspaces from the list of choices.

This also refactors RequesterPaysModal to fetch workspaces through the useWorkspaces hook instead of an Ajax call in useOnMount. This is easier to mock in tests.