### PR TITLE
[IA-3816] Display startup messaage for JupyterLab

### DIFF
--- a/src/pages/workspaces/workspace/analysis/AppLauncher.js
+++ b/src/pages/workspaces/workspace/analysis/AppLauncher.js
@@ -212,7 +212,9 @@ const ApplicationLauncher = _.flow(
       // periodically check for outdated R analyses
       interval.current = !!googleProject && setInterval(findOutdatedAnalyses, 10000)
     }
-
+    // if (runtime) {
+    //   setBusy(false)
+    // }
     return () => {
       clearInterval(interval.current)
       interval.current = undefined

--- a/src/pages/workspaces/workspace/analysis/AppLauncher.js
+++ b/src/pages/workspaces/workspace/analysis/AppLauncher.js
@@ -230,16 +230,20 @@ const ApplicationLauncher = _.flow(
     fileOutdatedOpen && h(FileOutdatedModal, { onDismiss: () => setFileOutdatedOpen(false), bucketName }),
     _.includes(runtimeStatus, usableStatuses) && cookieReady ?
       h(Fragment, [
+        application === toolLabels.JupyterLab && div({ style: { padding: '2rem', position: 'absolute', top: 0, left: 0, zIndex: 1 } }, [
+          h(StatusMessage, {}, ['Your Virtual Machine (VM) is ready. JupyterLab will launch momentarily...'])
+        ]),
         iframe({
           src: iframeSrc,
           style: {
             border: 'none', flex: 1,
+            zIndex: 2,
             ...(application === toolLabels.terminal ? { marginTop: -45, clipPath: 'inset(45px 0 0)' } : {}) // cuts off the useless Jupyter top bar
           },
           title: `Interactive ${application} iframe`
         })
       ]) :
-      div({ style: { padding: '2rem' } }, [
+      div({ style: { padding: '2rem', zIndex: 0 } }, [
         !busy && h(StatusMessage, { hideSpinner: ['Error', 'Stopped', null].includes(runtimeStatus) }, [
           Utils.cond(
             [runtimeStatus === 'Creating', () => 'Creating cloud environment. You can navigate away and return in 3-5 minutes.'],

--- a/src/pages/workspaces/workspace/analysis/AppLauncher.js
+++ b/src/pages/workspaces/workspace/analysis/AppLauncher.js
@@ -212,9 +212,7 @@ const ApplicationLauncher = _.flow(
       // periodically check for outdated R analyses
       interval.current = !!googleProject && setInterval(findOutdatedAnalyses, 10000)
     }
-    // if (runtime) {
-    //   setBusy(false)
-    // }
+
     return () => {
       clearInterval(interval.current)
       interval.current = undefined

--- a/src/pages/workspaces/workspace/analysis/AppLauncher.js
+++ b/src/pages/workspaces/workspace/analysis/AppLauncher.js
@@ -237,7 +237,7 @@ const ApplicationLauncher = _.flow(
         iframe({
           src: iframeSrc,
           style: {
-            border: 'none', flex: 1,
+            border: 'none', flex: 1, zIndex: 2,
             ...(application === toolLabels.terminal ? { marginTop: -45, clipPath: 'inset(45px 0 0)' } : {}) // cuts off the useless Jupyter top bar
           },
           title: `Interactive ${application} iframe`

--- a/src/pages/workspaces/workspace/analysis/AppLauncher.js
+++ b/src/pages/workspaces/workspace/analysis/AppLauncher.js
@@ -12,7 +12,7 @@ import { forwardRefWithName, useCancellation, useOnMount, useStore } from 'src/l
 import { authStore, azureCookieReadyStore, cookieReadyStore } from 'src/libs/state'
 import * as Utils from 'src/libs/utils'
 import { getExtension, notebookLockHash, stripExtension } from 'src/pages/workspaces/workspace/analysis/file-utils'
-import { analysisTabName, appLauncherTabName, PeriodicAzureCookieSetter, RuntimeKicker, RuntimeStatusMonitor, StatusMessage } from 'src/pages/workspaces/workspace/analysis/runtime-common'
+import { appLauncherTabName, PeriodicAzureCookieSetter, RuntimeKicker, RuntimeStatusMonitor, StatusMessage } from 'src/pages/workspaces/workspace/analysis/runtime-common'
 import { getAnalysesDisplayList, getConvertedRuntimeStatus, getCurrentRuntime, usableStatuses } from 'src/pages/workspaces/workspace/analysis/runtime-utils'
 import { getPatternFromRuntimeTool, getToolLabelFromRuntime, runtimeTools, toolLabels } from 'src/pages/workspaces/workspace/analysis/tool-utils'
 import { wrapWorkspace } from 'src/pages/workspaces/workspace/WorkspaceContainer'
@@ -27,13 +27,14 @@ const ApplicationLauncher = _.flow(
   })
 )(({
   name: workspaceName, sparkInterface, analysesData: { runtimes, refreshRuntimes },
-  application, workspace: { azureContext, workspace: { namespace, name, workspaceId, googleProject, bucketName } }
+  application, workspace: { azureContext, workspace: { workspaceId, googleProject, bucketName } }
 }, _ref) => {
-  const [busy, setBusy] = useState(true)
+  const [busy, setBusy] = useState(false)
   const [outdatedAnalyses, setOutdatedAnalyses] = useState()
   const [fileOutdatedOpen, setFileOutdatedOpen] = useState(false)
   const [hashedOwnerEmail, setHashedOwnerEmail] = useState()
   const [iframeSrc, setIframeSrc] = useState()
+
   const leoCookieReady = useStore(cookieReadyStore)
   const azureCookieReady = useStore(azureCookieReadyStore)
   const cookieReady = !!googleProject ? leoCookieReady : azureCookieReady.readyForRuntime
@@ -49,6 +50,7 @@ const ApplicationLauncher = _.flow(
 
   const runtime = getCurrentRuntime(runtimes)
   const runtimeStatus = getConvertedRuntimeStatus(runtime) // preserve null vs undefined
+
   const FileOutdatedModal = ({ onDismiss, bucketName }) => {
     const handleChoice = _.flow(
       withErrorReportingInModal('Error setting up analysis file syncing')(onDismiss),
@@ -127,14 +129,13 @@ const ApplicationLauncher = _.flow(
       analysis?.metadata[hashedOwnerEmail] === 'outdated', analyses)
   }
 
-  useOnMount(async () => {
+  useOnMount(() => {
     const findHashedEmail = withErrorReporting('Error loading user email information', async () => {
       const hashedEmail = await notebookLockHash(bucketName, email)
       setHashedOwnerEmail(hashedEmail)
     })
 
-    await refreshRuntimes()
-    setBusy(false)
+    refreshRuntimes()
     findHashedEmail()
   })
 
@@ -237,13 +238,12 @@ const ApplicationLauncher = _.flow(
           src: iframeSrc,
           style: {
             border: 'none', flex: 1,
-            zIndex: 2,
             ...(application === toolLabels.terminal ? { marginTop: -45, clipPath: 'inset(45px 0 0)' } : {}) // cuts off the useless Jupyter top bar
           },
           title: `Interactive ${application} iframe`
         })
       ]) :
-      div({ style: { padding: '2rem', zIndex: 0 } }, [
+      div({ style: { padding: '2rem' } }, [
         !busy && h(StatusMessage, { hideSpinner: ['Error', 'Stopped', null].includes(runtimeStatus) }, [
           Utils.cond(
             [runtimeStatus === 'Creating', () => 'Creating cloud environment. You can navigate away and return in 3-5 minutes.'],
@@ -254,7 +254,6 @@ const ApplicationLauncher = _.flow(
             [runtimeStatus === 'LeoReconfiguring', () => 'Cloud environment is updating, please wait.'],
             [runtimeStatus === 'Error', () => 'Error with the cloud environment, please try again.'],
             [runtimeStatus === null, () => 'Create a cloud environment to continue.'],
-            [runtimeStatus === undefined && runtime === undefined, () => Nav.goToPath(analysisTabName, { namespace, name })],
             [runtimeStatus === undefined, () => 'Loading...'],
             () => 'Unknown cloud environment status. Please create a new cloud environment or contact support.'
           )


### PR DESCRIPTION
Currently, users are met with a blank screen with no indicators when JupyterLab first loads when landing on the app page.
This PR will add a new message that will disappear once JupyterLab has it's first render.


Summary: 

When creating a DSVM on Azure, it can take over 15 seconds for JupyterLab to deploy the very first time you create it. During that interval, the "loading" Jupyter logo will frequently not appear until the last ~3-5 seconds. This results in a blank screen with no indication that there is an action in progress.

To replicate:

    Create Azure workspace

    Create JupyterLab instance (does not matter how)

    Click “Open” either from the side panel or from the preview screen of an ipynb file

    After clicking Open there will be a 10-15s delay before the JupyterLab loading logo shows up, with a blank screen


<!---
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Also, so if a screen recording [1] and/or screenshots would be a helpful way to communicate context, please consider including some in your PR description.
Thanks!

[1] https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac
-->
