### PR TITLE
DC-629: Ensure that gcloud is installed when running cleanup script

### DIFF
--- a/scripts/delete-old-app-engine-versions.sh
+++ b/scripts/delete-old-app-engine-versions.sh
@@ -52,6 +52,13 @@ check_jq_installed() {
     fi
 }
 
+# ensure that gcloud is installed
+check_gcloud_installed() {
+    if ! gcloud --version 1>/dev/null 2>&1; then
+        abort "gcloud is required; install using brew install google-cloud-sdk"
+    fi
+}
+
 # ensure that user has appropriate permissions for app engine
 check_user_permissions() {
     FAKE_VERSION="example-invalid-version-for-permission-testing"
@@ -127,6 +134,7 @@ execute_delete() {
 check_color_support
 
 check_jq_installed
+check_gcloud_installed
 
 if [ -z "${1+:}" ]; then
     usage

--- a/scripts/delete-old-app-engine-versions.sh
+++ b/scripts/delete-old-app-engine-versions.sh
@@ -48,14 +48,14 @@ abort() {
 # ensure that jq is installed
 check_jq_installed() {
     if ! jq --version 1>/dev/null 2>&1; then
-        abort "jq v1.6 or above is required; install using brew install jq"
+        abort "jq v1.6 or above is required; install jq to continue"
     fi
 }
 
 # ensure that gcloud is installed
 check_gcloud_installed() {
     if ! gcloud --version 1>/dev/null 2>&1; then
-        abort "gcloud is required; install using brew install google-cloud-sdk"
+        abort "gcloud is required; install google-cloud-sdk to continue"
     fi
 }
 


### PR DESCRIPTION
Currently, the script checks for `jq` installation but not `gcloud`. As a result the script will fail abruptly without a useful error message.