### PR TITLE
[PROD-780] Fix billing page

### DIFF
--- a/integration-tests/tests/register-user.js
+++ b/integration-tests/tests/register-user.js
@@ -14,7 +14,7 @@ const testRegisterUserFn = withUser(async ({ page, testUrl, token }) => {
   await verifyAccessibility(page)
   await click(page, clickable({ textContains: 'Register' }))
   await click(page, clickable({ textContains: 'Accept' }), { timeout: 90000 })
-  await findText(page, 'To get started, Create a New Workspace')
+  await findText(page, 'Welcome to Terra Community Workbench')
 })
 
 registerTest({

--- a/src/components/AuthContainer.js
+++ b/src/components/AuthContainer.js
@@ -16,7 +16,7 @@ import TermsOfService from 'src/pages/TermsOfService'
 const AuthContainer = ({ children }) => {
   const { name, public: isPublic } = useRoute()
   const { isSignedIn, registrationStatus, termsOfService, profile } = useStore(authStore)
-  const displayTosPage = isSignedIn && (!termsOfService.userContinuedUnderGracePeriod || !termsOfService.userCanUseTerra)
+  const displayTosPage = isSignedIn && !termsOfService.userCanUseTerra
   const seenAzurePreview = useStore(azurePreviewStore) || false
   const authspinner = () => h(centeredSpinner, { style: { position: 'fixed' } })
 
@@ -26,7 +26,7 @@ const AuthContainer = ({ children }) => {
     [seenAzurePreview === false && isAzureUser(), () => h(AzurePreview)],
     [registrationStatus === undefined && !isPublic, authspinner],
     [registrationStatus === userStatus.unregistered, () => h(Register)],
-    [displayTosPage && _.isUndefined(termsOfService.userContinuedUnderGracePeriod) && name !== 'privacy', () => h(TermsOfService)],
+    [displayTosPage && name !== 'privacy', () => h(TermsOfService)],
     [registrationStatus === userStatus.disabled, () => h(Disabled)],
     [_.isEmpty(profile) && !isPublic, authspinner],
     () => children


### PR DESCRIPTION
Currently, the billing page does not work. It "flickers" and constantly retries requests.

https://user-images.githubusercontent.com/1156625/212547236-4d3180c8-706f-49d2-9991-d75f2fa392b6.mov

Some console log debugging reveals that Terra UI is constantly switching between rendering the ToS page and the billing page. 

I believe this is because of the logic used to render the blocking ToS page in AuthContainer.js

https://github.com/DataBiosphere/terra-ui/blob/d1825e54ba29c45cedf0e9c09d4637181a55c16d/src/components/AuthContainer.js#L16-L34

If `termsOfService.userContinuedUnderGracePeriod` is undefined, Terra shows the ToS page instead of the page for the current route. However, the ToS page sets that value to false on mount. That in turn causes Terra UI to render the page for the route instead of the ToS page.

https://github.com/DataBiosphere/terra-ui/blob/d1825e54ba29c45cedf0e9c09d4637181a55c16d/src/pages/TermsOfService.js#L27-L33

I am guessing there is something in the billing page (probably related to adding the billing scope) that causes `initializeTermsOfService` to get called and `termsOfService.userContinuedUnderGracePeriod` reset to undefined, which results in this endless loop.

https://github.com/DataBiosphere/terra-ui/blob/d1825e54ba29c45cedf0e9c09d4637181a55c16d/src/libs/auth.js#L250-L258

Update: I'm almost certain that's the issue, as #3676 also fixes the issue.