### PR TITLE
[PROD-780] Fix billing page

### DIFF
--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -253,7 +253,8 @@ const initializeTermsOfService = (isSignedIn, state) => {
     currentVersion: isSignedIn ? state.termsOfService.currentVersion : undefined,
     userAcceptedVersion: isSignedIn ? state.termsOfService.userAcceptedVersion : undefined,
     userCanUseTerra: isSignedIn ? state.termsOfService.userCanUseTerra : undefined,
-    showTosPopup: isSignedIn ? state.termsOfService.showTosPopup : undefined
+    showTosPopup: isSignedIn ? state.termsOfService.showTosPopup : undefined,
+    userContinuedUnderGracePeriod: isSignedIn ? state.termsOfService.userContinuedUnderGracePeriod : undefined,
   }
 }
 


### PR DESCRIPTION
Currently, the billing page does not work. It "flickers" and constantly retries requests.

https://user-images.githubusercontent.com/1156625/212547236-4d3180c8-706f-49d2-9991-d75f2fa392b6.mov

Some console log debugging reveals that Terra UI is constantly switching between rendering the ToS page and the billing page. 

I believe this is because of the logic used to render the blocking ToS page in AuthContainer.js

https://github.com/DataBiosphere/terra-ui/blob/d1825e54ba29c45cedf0e9c09d4637181a55c16d/src/components/AuthContainer.js#L16-L34

If `termsOfService.userContinuedUnderGracePeriod` is undefined, Terra shows the ToS page instead of the page for the current route. However, the ToS page sets that value to false on mount. That in turn causes Terra UI to render the page for the route instead of the ToS page.

https://github.com/DataBiosphere/terra-ui/blob/d1825e54ba29c45cedf0e9c09d4637181a55c16d/src/pages/TermsOfService.js#L27-L33

I am guessing there is something in the billing page (probably related to adding the billing scope) that causes `initializeTermsOfService` to get called and `termsOfService.userContinuedUnderGracePeriod` reset to undefined, which results in this endless loop.

https://github.com/DataBiosphere/terra-ui/blob/d1825e54ba29c45cedf0e9c09d4637181a55c16d/src/libs/auth.js#L250-L258

Preserving the current value of `userContinuedUnderGracePeriod` in `initializeTermsOfService` fixes the issue.