### PR TITLE
[ID-398] Avoid always showing ToS page when loading Terra

### DIFF
--- a/integration-tests/tests/register-user.js
+++ b/integration-tests/tests/register-user.js
@@ -14,7 +14,7 @@ const testRegisterUserFn = withUser(async ({ page, testUrl, token }) => {
   await verifyAccessibility(page)
   await click(page, clickable({ textContains: 'Register' }))
   await click(page, clickable({ textContains: 'Accept' }), { timeout: 90000 })
-  await findText(page, 'To get started, Create a New Workspace')
+  await findText(page, 'Welcome to Terra Community Workbench')
 })
 
 registerTest({

--- a/src/components/AuthContainer.js
+++ b/src/components/AuthContainer.js
@@ -16,7 +16,7 @@ import TermsOfService from 'src/pages/TermsOfService'
 const AuthContainer = ({ children }) => {
   const { name, public: isPublic } = useRoute()
   const { isSignedIn, registrationStatus, termsOfService, profile } = useStore(authStore)
-  const displayTosPage = isSignedIn && (!termsOfService.userContinuedUnderGracePeriod || !termsOfService.userCanUseTerra)
+  const displayTosPage = isSignedIn && !termsOfService.userCanUseTerra
   const seenAzurePreview = useStore(azurePreviewStore) || false
   const authspinner = () => h(centeredSpinner, { style: { position: 'fixed' } })
 
@@ -26,7 +26,7 @@ const AuthContainer = ({ children }) => {
     [seenAzurePreview === false && isAzureUser(), () => h(AzurePreview)],
     [registrationStatus === undefined && !isPublic, authspinner],
     [registrationStatus === userStatus.unregistered, () => h(Register)],
-    [displayTosPage && _.isUndefined(termsOfService.userContinuedUnderGracePeriod) && name !== 'privacy', () => h(TermsOfService)],
+    [displayTosPage && name !== 'privacy', () => h(TermsOfService)],
     [registrationStatus === userStatus.disabled, () => h(Disabled)],
     [_.isEmpty(profile) && !isPublic, authspinner],
     () => children

--- a/src/components/AuthContainer.js
+++ b/src/components/AuthContainer.js
@@ -16,7 +16,7 @@ import TermsOfService from 'src/pages/TermsOfService'
 const AuthContainer = ({ children }) => {
   const { name, public: isPublic } = useRoute()
   const { isSignedIn, registrationStatus, termsOfService, profile } = useStore(authStore)
-  const displayTosPage = isSignedIn && !termsOfService.userCanUseTerra
+  const displayTosPage = isSignedIn && termsOfService.userCanUseTerra === false
   const seenAzurePreview = useStore(azurePreviewStore) || false
   const authspinner = () => h(centeredSpinner, { style: { position: 'fixed' } })
 

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -254,7 +254,6 @@ const initializeTermsOfService = (isSignedIn, state) => {
     userAcceptedVersion: isSignedIn ? state.termsOfService.userAcceptedVersion : undefined,
     userCanUseTerra: isSignedIn ? state.termsOfService.userCanUseTerra : undefined,
     showTosPopup: isSignedIn ? state.termsOfService.showTosPopup : undefined,
-    userContinuedUnderGracePeriod: isSignedIn ? state.termsOfService.userContinuedUnderGracePeriod : undefined,
   }
 }
 

--- a/src/pages/TermsOfService.js
+++ b/src/pages/TermsOfService.js
@@ -25,12 +25,6 @@ const TermsOfServicePage = () => {
   const [tosText, setTosText] = useState()
 
   useOnMount(() => {
-    authStore.update(state => ({
-      ...state, termsOfService: {
-        ...termsOfService,
-        userContinuedUnderGracePeriod: false
-      }
-    }))
     const loadTosAndUpdateState = _.flow(
       Utils.withBusyState(setBusy),
       withErrorReporting('There was an error retrieving our terms of service.')
@@ -58,6 +52,7 @@ const TermsOfServicePage = () => {
         Nav.goToPath('root')
       } else {
         reportError('Error accepting TOS, unexpected backend error occurred.')
+        setBusy(false)
       }
     } catch (error) {
       reportError('Error accepting TOS', error)
@@ -66,18 +61,7 @@ const TermsOfServicePage = () => {
   }
 
   const continueButton = () => {
-    try {
-      setBusy(true)
-      const newTermsOfService = {
-        ...termsOfService,
-        userContinuedUnderGracePeriod: true
-      }
-      authStore.update(state => ({ ...state, termsOfService: newTermsOfService }))
-      Nav.goToPath('root')
-    } catch (error) {
-      reportError('Error continuing under TOS grace period', error)
-      setBusy(false)
-    }
+    Nav.goToPath('root')
   }
 
   return div({ role: 'main', style: { padding: '1rem', minHeight: '100%', display: 'flex', justifyContent: 'center', alignItems: 'center' } }, [


### PR DESCRIPTION
Currently, when loading Terra, the ToS page is always briefly shown. It The effects of this are visible as...
- a flicker in the loading spinner
- a React state warning in the console (because the ToS page doesn't cancel its request for ToS text when unmounted)
- the request for the ToS text in the network inspector.

https://user-images.githubusercontent.com/1156625/212907326-069324bf-a1f2-4bdc-b99f-5a7c9645e22d.mov

---

AuthContainer displays the ToS page if the user can't use Terra or if they have not continued under a ToS grace period.

https://github.com/DataBiosphere/terra-ui/blob/c0d416875ed08db77082d3f64393f0e783089d49/src/components/AuthContainer.js#L19

However, when it comes to the grace period, it actually only shows the ToS page if `termsOfService.userContinuedUnderGracePeriod` is undefined.

https://github.com/DataBiosphere/terra-ui/blob/c0d416875ed08db77082d3f64393f0e783089d49/src/components/AuthContainer.js#L29

When a user first loads Terra or first signs in, `termsOfService.userContinuedUnderGracePeriod` will be undefined.

https://github.com/DataBiosphere/terra-ui/blob/c0d416875ed08db77082d3f64393f0e783089d49/src/libs/auth.js#L250-L259

Thus, AuthContainer will always show the ToS page.

However, when mounted, the ToS page sets `termsOfService.userContinuedUnderGracePeriod` to false.

https://github.com/DataBiosphere/terra-ui/blob/c0d416875ed08db77082d3f64393f0e783089d49/src/pages/TermsOfService.js#L27-L33

That makes AuthContainer's condition for showing the ToS page false, and AuthContainer renders the page for the current route. Since `termsOfService.userContinuedUnderGracePeriod` is not persisted anywhere, this occurs every time Terra is loaded.

Because of this, `termsOfService.userContinuedUnderGracePeriod` is effectively useless. It's never used in a way that will make the ToS page visible for long enough for the user to actually see it. And so, this PR removes it.

---

However, that alone doesn't fix the issue. AuthContainer displays the ToS page when `termsOfService.userCanUseTerra` is falsy.

https://github.com/DataBiosphere/terra-ui/blob/c0d416875ed08db77082d3f64393f0e783089d49/src/components/AuthContainer.js#L19

When a user loads Terra or signs in, `termsOfService.userCanUseTerra` is initialized to undefined.

https://github.com/DataBiosphere/terra-ui/blob/c0d416875ed08db77082d3f64393f0e783089d49/src/libs/auth.js#L250-L259

Terra UI then fetches the user's ToS status from Sam and sets `termsOfService.userCanUseTerra` based on that.

https://github.com/DataBiosphere/terra-ui/blob/c0d416875ed08db77082d3f64393f0e783089d49/src/libs/auth.js#L331-L337

But while that request is in progress, `termsOfService.userCanUseTerra` will be falsy and the ToS page will be shown. Once the request completes, if the user has accepted the ToS, the ToS page will be removed.

Most of the time, when a signed in user is loading Terra, it's going to be a user that has already accepted the ToS as opposed to a new user that needs to. By changing `!termsOfService.userCanUseTerra` to `termsOfService.userCanUseTerra === false` in AuthContainer's logic for displaying the ToS page, this waits until the user's ToS status has been loaded from Sam to show the ToS page.