### PR TITLE
AJ-761 add spinning wheel for loading wds tables

### DIFF
--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -985,7 +985,7 @@ const WorkspaceData = _.flow(
       h(SidebarSeparator, { sidebarWidth, setSidebarWidth }),
       div({ style: styles.tableViewPanel }, [
         _.includes(selectedData?.type, [workspaceDataTypes.entities, workspaceDataTypes.entitiesVersion]) && h(DataTableFeaturePreviewFeedbackBanner),
-        Utils.switchCase(selectedData?.type, [undefined, () => Utils.cond([wdsSchemaError && isAzureWorkspace, () => div({ style: { textAlign: 'center' } }, [icon('loadingSpinner'), ' The database that powers your data tables is being created. This may take a few minutes.'])],
+        Utils.switchCase(selectedData?.type, [undefined, () => Utils.cond([wdsSchemaError && isAzureWorkspace, () => div({ style: { textAlign: 'center' } }, [icon('loadingSpinner'), ' The database that powers your data tables is unavailable. It may take a few minutes after initial workspace creation to be ready.'])],
           () => div({ style: { textAlign: 'center' } }, ['Select a data type from the navigation panel on the left']),
         )],
         [workspaceDataTypes.localVariables, () => h(LocalVariablesContent, {

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -985,83 +985,84 @@ const WorkspaceData = _.flow(
       h(SidebarSeparator, { sidebarWidth, setSidebarWidth }),
       div({ style: styles.tableViewPanel }, [
         _.includes(selectedData?.type, [workspaceDataTypes.entities, workspaceDataTypes.entitiesVersion]) && h(DataTableFeaturePreviewFeedbackBanner),
-        Utils.switchCase(selectedData?.type,
-          [undefined, () => div({ style: { textAlign: 'center' } }, ['Select a data type from the navigation panel on the left'])],
-          [workspaceDataTypes.localVariables, () => h(LocalVariablesContent, {
-            workspace,
-            refreshKey
-          })],
-          [workspaceDataTypes.referenceData, () => h(ReferenceDataContent, {
-            key: selectedData.reference,
-            workspace,
-            referenceKey: selectedData.reference
-          })],
-          [workspaceDataTypes.bucketObjects, () => h(FileBrowser, {
-            style: { flex: '1 1 auto' },
-            controlPanelStyle: {
-              padding: '1rem',
-              background: colors.light(0.5)
-            },
-            workspace,
-            extraMenuItems: h(Link, {
-              href: `https://seqr.broadinstitute.org/workspace/${namespace}/${name}`,
-              style: { padding: '0.5rem' }
-            }, [icon('pop-out'), ' Analyze in Seqr']),
-            noticeForPrefix: prefix => prefix.startsWith(`${dataTableVersionsPathRoot}/`) ?
-              'Files in this folder are managed via data table versioning.' :
-              null,
-            shouldDisableEditForPrefix: prefix => prefix.startsWith(`${dataTableVersionsPathRoot}/`)
-          })],
-          [workspaceDataTypes.snapshot, () => h(SnapshotContent, {
-            key: refreshKey,
-            workspace,
-            snapshotDetails,
-            snapshotName: selectedData.snapshotName,
-            tableName: selectedData.tableName,
-            loadMetadata: () => loadSnapshotEntities(selectedData.snapshotName),
-            onUpdate: async newSnapshotName => {
-              await loadSnapshotMetadata()
-              setSelectedData({ type: workspaceDataTypes.snapshot, snapshotName: newSnapshotName })
-              forceRefresh()
-            },
-            onDelete: async () => {
-              await loadSnapshotMetadata()
-              setSelectedData(undefined)
-              forceRefresh()
-            }
-          })],
-          [workspaceDataTypes.entities, () => h(EntitiesContent, {
-            key: refreshKey,
-            workspace,
-            entityMetadata,
-            setEntityMetadata,
-            entityKey: selectedData.entityType,
-            activeCrossTableTextFilter,
-            loadMetadata,
-            deleteColumnUpdateMetadata,
-            forceRefresh
-          })],
-          [workspaceDataTypes.entitiesVersion, () => h(DataTableVersion, {
-            workspace,
-            version: selectedData.version,
-            onDelete: reportErrorAndRethrow('Error deleting version', async () => {
-              await deleteDataTableVersion(selectedData.version)
-              setSelectedData(undefined)
-            }),
-            onImport: reportErrorAndRethrow('Error importing version', async () => {
-              const { tableName } = await importDataTableVersion(selectedData.version)
-              await loadMetadata()
-              setSelectedData({ type: workspaceDataTypes.entities, entityType: tableName })
-            })
-          })],
-          [workspaceDataTypes.wds, () => wdsDataTableProvider && proxyUrlLoaded && !_.isEmpty(wdsSchema) && h(WDSContent, {
-            key: refreshKey,
-            workspaceUUID: workspaceId,
-            workspace,
-            dataProvider: wdsDataTableProvider,
-            recordType: selectedData.entityType,
-            wdsSchema
-          })]
+        Utils.switchCase(selectedData?.type, [undefined, () => Utils.cond([wdsSchemaError && isAzureWorkspace, () => div({ style: { textAlign: 'center' } }, [icon('loadingSpinner'), ' The database that powers your data tables is being created. This may take a few minutes.'])],
+          () => div({ style: { textAlign: 'center' } }, ['Select a data type from the navigation panel on the left']),
+        )],
+        [workspaceDataTypes.localVariables, () => h(LocalVariablesContent, {
+          workspace,
+          refreshKey
+        })],
+        [workspaceDataTypes.referenceData, () => h(ReferenceDataContent, {
+          key: selectedData.reference,
+          workspace,
+          referenceKey: selectedData.reference
+        })],
+        [workspaceDataTypes.bucketObjects, () => h(FileBrowser, {
+          style: { flex: '1 1 auto' },
+          controlPanelStyle: {
+            padding: '1rem',
+            background: colors.light(0.5)
+          },
+          workspace,
+          extraMenuItems: h(Link, {
+            href: `https://seqr.broadinstitute.org/workspace/${namespace}/${name}`,
+            style: { padding: '0.5rem' }
+          }, [icon('pop-out'), ' Analyze in Seqr']),
+          noticeForPrefix: prefix => prefix.startsWith(`${dataTableVersionsPathRoot}/`) ?
+            'Files in this folder are managed via data table versioning.' :
+            null,
+          shouldDisableEditForPrefix: prefix => prefix.startsWith(`${dataTableVersionsPathRoot}/`)
+        })],
+        [workspaceDataTypes.snapshot, () => h(SnapshotContent, {
+          key: refreshKey,
+          workspace,
+          snapshotDetails,
+          snapshotName: selectedData.snapshotName,
+          tableName: selectedData.tableName,
+          loadMetadata: () => loadSnapshotEntities(selectedData.snapshotName),
+          onUpdate: async newSnapshotName => {
+            await loadSnapshotMetadata()
+            setSelectedData({ type: workspaceDataTypes.snapshot, snapshotName: newSnapshotName })
+            forceRefresh()
+          },
+          onDelete: async () => {
+            await loadSnapshotMetadata()
+            setSelectedData(undefined)
+            forceRefresh()
+          }
+        })],
+        [workspaceDataTypes.entities, () => h(EntitiesContent, {
+          key: refreshKey,
+          workspace,
+          entityMetadata,
+          setEntityMetadata,
+          entityKey: selectedData.entityType,
+          activeCrossTableTextFilter,
+          loadMetadata,
+          deleteColumnUpdateMetadata,
+          forceRefresh
+        })],
+        [workspaceDataTypes.entitiesVersion, () => h(DataTableVersion, {
+          workspace,
+          version: selectedData.version,
+          onDelete: reportErrorAndRethrow('Error deleting version', async () => {
+            await deleteDataTableVersion(selectedData.version)
+            setSelectedData(undefined)
+          }),
+          onImport: reportErrorAndRethrow('Error importing version', async () => {
+            const { tableName } = await importDataTableVersion(selectedData.version)
+            await loadMetadata()
+            setSelectedData({ type: workspaceDataTypes.entities, entityType: tableName })
+          })
+        })],
+        [workspaceDataTypes.wds, () => wdsDataTableProvider && proxyUrlLoaded && !_.isEmpty(wdsSchema) && h(WDSContent, {
+          key: refreshKey,
+          workspaceUUID: workspaceId,
+          workspace,
+          dataProvider: wdsDataTableProvider,
+          recordType: selectedData.entityType,
+          wdsSchema
+        })]
         )
       ])
     ])


### PR DESCRIPTION
See [AJ-761](https://broadworkbench.atlassian.net/browse/AJ-761)
For an azure workspace, if WDS is not ready, show a spinning wheel and a message that the database is being created.  Once it exists it will show the same "Select a data type from the navigation panel on the left" message as GCP workspaces.

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/5884792/212963878-b4ac3f8d-7c2f-4558-ae6c-4d98eb300014.png">

[AJ-761]: https://broadworkbench.atlassian.net/browse/AJ-761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ