### PR TITLE
IA-3762 useMetrics and Metrics TS improvements

### DIFF
--- a/src/components/common/IdContainer.ts
+++ b/src/components/common/IdContainer.ts
@@ -7,7 +7,7 @@ type IdContainerProps = {
 }
 
 /**
- * DEPRECATED - should switch to useUniqueIdFn pattern
+ * DEPRECATED - should switch to useUniqueId pattern (below)
  */
 export const IdContainer = ({ children }: IdContainerProps) => {
   const [id] = useState(() => _.uniqueId('element-'))

--- a/src/components/file-browser/FileDetails.test.ts
+++ b/src/components/file-browser/FileDetails.test.ts
@@ -45,7 +45,9 @@ describe('FileDetails', () => {
     render(h(FileDetails, { file, provider: mockProvider }))
 
     // Assert
-    const renderedValue = screen.getByText(field).parentElement!.lastElementChild!.textContent!
+    const rawRenderedValue = screen.getByText(field).parentElement!.lastElementChild!.textContent!
+    // normalize non-breaking spaces to just be normal space character for simpler assertion
+    const renderedValue = rawRenderedValue.replace(/\xa0/g, ' ').replace(/\u202f/g, ' ')
     expect(renderedValue).toBe(expected)
   })
 

--- a/src/libs/ajax/metrics/useMetrics.test.ts
+++ b/src/libs/ajax/metrics/useMetrics.test.ts
@@ -29,8 +29,8 @@ describe('useMetricsEvent', () => {
 
     // Act
     const renderedHook = renderHook(() => useMetricsEvent())
-    const logEvent = renderedHook.result.current
-    logEvent('hi there', { something: 'interesting' })
+    const { captureEvent } = renderedHook.result.current
+    captureEvent('hi there', { something: 'interesting' })
 
     // Assert
     expect(watchCaptureEvent).toBeCalledTimes(1)

--- a/src/libs/ajax/metrics/useMetrics.test.ts
+++ b/src/libs/ajax/metrics/useMetrics.test.ts
@@ -1,0 +1,39 @@
+import { renderHook } from '@testing-library/react-hooks'
+import { Ajax } from 'src/libs/ajax'
+import { asMockedFn } from 'src/testing/test-utils'
+
+import { useMetricsEvent } from './useMetrics'
+
+
+type AjaxExports = typeof import('src/libs/ajax')
+jest.mock('src/libs/ajax', (): AjaxExports => {
+  return {
+    Ajax: jest.fn()
+  }
+})
+
+type AjaxContract = ReturnType<typeof Ajax>;
+type AjaxMetricsContract = AjaxContract['Metrics']
+
+describe('useMetricsEvent', () => {
+  it('calls event logger', () => {
+    // Arrange
+    const watchCaptureEvent = jest.fn()
+    const mockMetrics: Partial<AjaxMetricsContract> = {
+      captureEvent: (event, details) => watchCaptureEvent(event, details)
+    }
+    const mockAjax: Partial<AjaxContract> = {
+      Metrics: mockMetrics as AjaxMetricsContract
+    }
+    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract)
+
+    // Act
+    const renderedHook = renderHook(() => useMetricsEvent())
+    const logEvent = renderedHook.result.current
+    logEvent('hi there', { something: 'interesting' })
+
+    // Assert
+    expect(watchCaptureEvent).toBeCalledTimes(1)
+    expect(watchCaptureEvent).toBeCalledWith('hi there', { something: 'interesting' })
+  })
+})

--- a/src/libs/ajax/metrics/useMetrics.ts
+++ b/src/libs/ajax/metrics/useMetrics.ts
@@ -1,0 +1,13 @@
+import { useMemo } from 'react'
+import { Ajax } from 'src/libs/ajax'
+
+
+export type CaptureEventFn = (event: string, details?: {}) => void
+
+export const useMetricsEvent = (): CaptureEventFn => {
+  const sendEvent = useMemo(() => Ajax().Metrics.captureEvent, [])
+  const captureEvent: CaptureEventFn = (event: string, details?: {}): void => {
+    void sendEvent(event, details)
+  }
+  return captureEvent
+}

--- a/src/libs/ajax/metrics/useMetrics.ts
+++ b/src/libs/ajax/metrics/useMetrics.ts
@@ -4,10 +4,18 @@ import { Ajax } from 'src/libs/ajax'
 
 export type CaptureEventFn = (event: string, details?: {}) => void
 
-export const useMetricsEvent = (): CaptureEventFn => {
+export interface UseMetricsContract {
+  captureEvent: CaptureEventFn
+}
+
+export const useMetricsEvent = (): UseMetricsContract => {
   const sendEvent = useMemo(() => Ajax().Metrics.captureEvent, [])
+  // By returning a wrapper function, we can handle the fire-and-forget promise mechanics properly here
+  // instead of burdening the consumer side with silencing the Typescript/lint complaints, which can be
+  // quite awkward in some nested functional uses.
   const captureEvent: CaptureEventFn = (event: string, details?: {}): void => {
+    // fire and forget
     void sendEvent(event, details)
   }
-  return captureEvent
+  return { captureEvent }
 }

--- a/src/pages/library/dataBrowser-utils.ts
+++ b/src/pages/library/dataBrowser-utils.ts
@@ -133,7 +133,6 @@ export const DatasetAccess = ({ dataset }: DatasetAccessProps) => {
         style: buttonStyle,
         onClick: () => {
           setRequestingAccess(true)
-          // @ts-expect-error
           Ajax().Metrics.captureEvent(`${Events.catalogRequestAccess}:popUp`, {
             id: dataset.id,
             title: dataset['dct:title']

--- a/src/pages/workspaces/workspace/analysis/modals/AnalysisDuplicator.ts
+++ b/src/pages/workspaces/workspace/analysis/modals/AnalysisDuplicator.ts
@@ -70,7 +70,6 @@ export const AnalysisDuplicator = ({ destroyOld = false, fromLauncher = false, p
 
         if (destroyOld) {
           await rename()
-          // @ts-expect-error
           Ajax().Metrics.captureEvent(Events.notebookRename, {
             oldName: printName,
             newName,
@@ -78,7 +77,6 @@ export const AnalysisDuplicator = ({ destroyOld = false, fromLauncher = false, p
           })
         } else {
           await duplicate()
-          // @ts-expect-error
           Ajax().Metrics.captureEvent(Events.notebookCopy, {
             oldName: printName,
             newName,


### PR DESCRIPTION
- part of work for Export Analysis Modal Typescript and Unit Tests
- implemented useMetrics helper hook to remove boiler-plate code from event logging and improve Typescript ergonomics.
- removed now unnecessary @ts-expect-error escapes for Metrics.captureEvent calls in ts files.
- minor cleanup
