### PR TITLE
[UIE-58] Configure ESLint to prevent use of JSX

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -69,7 +69,11 @@ module.exports = {
     'arrow-parens': ['warn', 'as-needed'],
     'arrow-spacing': 'warn',
     'no-duplicate-imports': 'warn',
-    'no-restricted-syntax': ['warn', { 'selector': 'TSEnumDeclaration', 'message': 'Use a union of literals instead of an enum' }],
+    'no-restricted-syntax': [
+      'warn',
+      { 'selector': 'TSEnumDeclaration', 'message': 'Use a union of literals instead of an enum' },
+      { 'selector': 'JSXElement', 'message': 'Use react-hyperscript-helpers instead of JSX' }
+    ],
     // TODO: Set 'variables' to 'true' after fixing the existing issues
     'no-use-before-define': ['warn', { 'functions': true, 'classes': true, 'variables': false }],
     'no-useless-rename': 'warn',

--- a/src/libs/terms-of-service-alerts.js
+++ b/src/libs/terms-of-service-alerts.js
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp'
 import { Fragment, useEffect } from 'react'
-import { h } from 'react-hyperscript-helpers'
+import { br, h } from 'react-hyperscript-helpers'
 import { Link } from 'src/components/common'
 import { Ajax } from 'src/libs/ajax'
 import * as Nav from 'src/libs/nav'
@@ -31,7 +31,7 @@ const getNewTermsOfServiceNeedsAcceptingAlert = async termsOfServiceState => {
     title: 'There is a new Terra Terms of Service.',
     message: h(Fragment, [
       h(Fragment, { key: 'customText' }, [gracePeriodText]),
-      h(Fragment, { key: 'lineBreak' }, [<br/>]),
+      h(Fragment, { key: 'lineBreak' }, [br()]),
       h(Link, { href: Nav.getLink('terms-of-service'), key: 'tosLink' }, 'Accept the new Terms of Service here.')
     ]),
     severity: 'error'


### PR DESCRIPTION
Terra UI's [coding guidelines](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide#coding-guidelines) say:

> - Use [react-hyperscript-helpers](https://github.com/Jador/react-hyperscript-helpers) rather than JSX or TSX.
>   - Hyperscript helpers allow developers to remain in a Javascript context rather than having to make a mental context switch to an XML templating language while developing.

This configures ESLint to enforce that guideline using the [no-restricted-syntax](https://eslint.org/docs/latest/rules/no-restricted-syntax) rule.