### PR TITLE
[UIE-59] Configure parallelism for tests run against the dev branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -281,13 +281,13 @@ jobs:
           env: staging
   integration-tests-alpha:
     executor: puppeteer
-    parallelism: 1
+    parallelism: 4
     steps:
       - integration-tests:
           env: alpha
   integration-tests-staging:
     executor: puppeteer
-    parallelism: 1
+    parallelism: 4
     steps:
       - integration-tests:
           env: staging


### PR DESCRIPTION
Currently, tests run on PRs run with a parallelism of 4, while tests run on commits to the dev branch and in nightly tests have a parallelism of 1.

https://github.com/DataBiosphere/terra-ui/blob/47673fa6c714ba0b8b90472ca849b59140f96bcd/.circleci/config.yml#L275-L293

Tests on PRs run in ~5-6 minutes while tests on the dev branch run in ~10-12 minutes.
https://app.circleci.com/pipelines/github/DataBiosphere/terra-ui?branch=dev
https://app.circleci.com/pipelines/github/DataBiosphere/terra-ui

Originally, the reason for not having parallelism in tests on the dev branch was to avoid multiple Slack notifications. However, since #3311 changed how Slack notifications are sent, that should no longer be an issue.