### PR TITLE
[SU-272] Add cloud platform icons to featured workspaces list

### DIFF
--- a/src/pages/library/Showcase.js
+++ b/src/pages/library/Showcase.js
@@ -1,6 +1,7 @@
 import _ from 'lodash/fp'
 import { useState } from 'react'
 import { a, div, h } from 'react-hyperscript-helpers'
+import { CloudProviderIcon } from 'src/components/CloudProviderIcon'
 import FooterWrapper from 'src/components/FooterWrapper'
 import { libraryTopMatter } from 'src/components/library-common'
 import { FirstParagraphMarkdownViewer } from 'src/components/markdown'
@@ -15,7 +16,7 @@ import { useOnMount } from 'src/libs/react-utils'
 import * as StateHistory from 'src/libs/state-history'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
-import { cloudProviderLabels } from 'src/libs/workspace-utils'
+import { cloudProviderLabels, cloudProviderTypes } from 'src/libs/workspace-utils'
 import { SearchAndFilterComponent } from 'src/pages/library/common'
 
 
@@ -52,7 +53,8 @@ const sidebarSections = [{
 }]
 
 const WorkspaceCard = ({ workspace }) => {
-  const { namespace, name, created, description } = workspace
+  const { namespace, name, cloudPlatform, created, description } = workspace
+
   return a({
     href: Nav.getLink('workspace-dashboard', { namespace, name }),
     style: {
@@ -78,7 +80,14 @@ const WorkspaceCard = ({ workspace }) => {
     div({ style: { flex: 1, minWidth: 0, padding: '15px 20px', overflow: 'hidden' } }, [
       div({ style: { display: 'flex' } }, [
         div({ style: { flex: 1, color: colors.accent(), fontSize: 16, lineHeight: '20px', height: 40, marginBottom: 7 } }, [name]),
-        created && div([Utils.makeStandardDate(created)])
+        created && div([Utils.makeStandardDate(created)]),
+        (cloudPlatform === 'Azure' || cloudPlatform === 'Gcp') && h(CloudProviderIcon, {
+          cloudProvider: {
+            Azure: cloudProviderTypes.Azure,
+            Gcp: cloudProviderTypes.GCP,
+          }[cloudPlatform],
+          style: { marginLeft: '1ch' },
+        }),
       ]),
       h(FirstParagraphMarkdownViewer, {
         style: { margin: 0, fontSize: '14px', lineHeight: '20px', height: 100, overflow: 'hidden' }


### PR DESCRIPTION
Since workspaces cannot be cloned across cloud providers, users will be interested in featured workspaces on their chosen cloud provider. This adds an icon showing each featured workspace's cloud platform.

<img width="983" alt="Screen Shot 2023-01-17 at 8 03 43 PM" src="https://user-images.githubusercontent.com/1156625/213055595-a34a1b51-56d1-4740-ab75-6508db145b38.png">

This currently works on dev and has no effect on production. The `cloudPlatform` field has not yet been added to showcase data in production ([SU-271](https://broadworkbench.atlassian.net/browse/SU-271) tracks that). It can be tested with production data by changing the `firecloudBucketRoot` value in public/config.json.

[SU-271]: https://broadworkbench.atlassian.net/browse/SU-271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ