### PR TITLE
[AJ-781] don't show upload tsv when WDS isn't running

### DIFF
--- a/src/libs/ajax/data-table-providers/WdsDataTableProvider.test.ts
+++ b/src/libs/ajax/data-table-providers/WdsDataTableProvider.test.ts
@@ -31,7 +31,7 @@ const recordType: string = 'item'
 
 const testProxyUrl: string = 'https://lzsomeTestUrl.servicebus.windows.net/super-cool-proxy-url/wds'
 const testProxyUrlResponse: Array<Object> = [
-  { appType: 'CROMWELL', appName: 'cbas-wds-default', proxyUrls: { wds: testProxyUrl } }
+  { appType: 'CROMWELL', appName: 'cbas-wds-default', status: 'RUNNING', proxyUrls: { wds: testProxyUrl } }
 ]
 
 const queryOptions: EntityQueryOptions = {

--- a/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
+++ b/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
@@ -86,7 +86,7 @@ const getRelationParts = (val: unknown): string[] => {
 export const getWdsUrl = apps => {
   // look explicitly for an app named 'cbas-wds-default'. If found, use it, even if it isn't running
   // this handles the case where the user has explicitly shut down the app
-  const namedApp = apps.filter(app => app.appType === 'CROMWELL' && app.appName === 'cbas-wds-default')
+  const namedApp = apps.filter(app => app.appType === 'CROMWELL' && app.appName === 'cbas-wds-default' && app.status === 'RUNNING')
   if (namedApp.length === 1) {
     return namedApp[0].proxyUrls.wds
   }

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -647,10 +647,11 @@ const WorkspaceData = _.flow(
   const editWorkspaceErrorMessage = Utils.editWorkspaceError(workspace)
   const canEditWorkspace = !editWorkspaceErrorMessage
 
+  const canUploadTsv = isGoogleWorkspace || (isAzureWorkspace && proxyUrlLoaded)
   return div({ style: styles.tableContainer }, [
     !entityMetadata ? spinnerOverlay : h(Fragment, [
       div({ style: { ...styles.sidebarContainer, width: sidebarWidth } }, [
-        div({
+        canUploadTsv && div({
           style: {
             display: 'flex', padding: '1rem 1.5rem',
             backgroundColor: colors.light(),
@@ -765,7 +766,7 @@ const WorkspaceData = _.flow(
                 ])
               }, sortedEntityPairs)
             ]),
-            isAzureWorkspace && h(DataTypeSection, {
+            isAzureWorkspace && proxyUrlLoaded && h(DataTypeSection, {
               title: 'Tables'
             }, [
               [


### PR DESCRIPTION
PR to hide the Upload TSV button when WDS isn't yet running in the app, to avoid confusion. Once the WDS app is in a "RUNNING" state, the upload button will appear. Checking whether the instance exists is out of scope for this change.

Future thoughts:
- We can continue to improve messaging around WDS state
- ~~When WDS is provisioning, the proxyUrl is found. I think we should ignore WDS until provisioning is completed, since the user can't interact with WDS in a provisioning state. This also is creating confusing messaging. This is somewhat because we are using the proxy URL as a proxy (sorry!) for whether WDS is running or not. If we want to stick with this, we shouldn't populate the field until WDS is running.~~
- I noticed that proxyUrl doesn't get unset if WDS is shutdown. I don't think this is a major issue, since the values will be unset if the user refreshes the page.

https://broadworkbench.atlassian.net/browse/AJ-781

Testing:
- Created a new workspace and verified that the sidebar was no longer shown
- Called leo swagger to create a WDS and verified that sidebar was added

Before:
<img width="786" alt="Screenshot 2023-01-18 at 1 24 37 PM" src="https://user-images.githubusercontent.com/8800717/213283691-2cb05e45-bebc-49a6-9ac1-689e95340c1a.png">

After:
<img width="801" alt="Screenshot 2023-01-18 at 1 41 35 PM" src="https://user-images.githubusercontent.com/8800717/213283699-b5e15881-64a6-40b7-8222-bb0a70c1425f.png">
