### PR TITLE
[DC-643] Rename run-catalog test

### DIFF
--- a/integration-tests/tests/run-catalog-workflow.js
+++ b/integration-tests/tests/run-catalog-workflow.js
@@ -20,7 +20,7 @@ const testCatalogFlowFn = _.flow(
 })
 
 registerTest({
-  name: 'run-catalog',
+  name: 'run-catalog-workflow',
   fn: testCatalogFlowFn,
   timeout: 2 * 60 * 1000
 })


### PR DESCRIPTION
For most (all?) tests, the test name matches the file name. However, the test in `run-catalog-workflow.js` is named `run-catalog`.

On the CircleCI [tests tab](https://app.circleci.com/pipelines/github/DataBiosphere/terra-ui/14052/workflows/c0deaced-fea7-47ec-8627-90eabb6a9ce3/jobs/56495), it shows up as "run-catalog". However, on the [artifacts tab](https://app.circleci.com/pipelines/github/DataBiosphere/terra-ui/14052/workflows/c0deaced-fea7-47ec-8627-90eabb6a9ce3/jobs/56495/artifacts), it shows up as "run-catalog-workflow". This has tripped me up more than once when looking for logs/screenshots for failed tests. Thus, I'm asking to rename the test to match the file name.