### PR TITLE
[DC-642] Increase test timeout for run-catalog-workflow.js

### DIFF
--- a/integration-tests/tests/run-catalog-workflow.js
+++ b/integration-tests/tests/run-catalog-workflow.js
@@ -22,5 +22,5 @@ const testCatalogFlowFn = _.flow(
 registerTest({
   name: 'run-catalog-workflow',
   fn: testCatalogFlowFn,
-  timeout: 2 * 60 * 1000
+  timeout: 5 * 60 * 1000
 })


### PR DESCRIPTION
Recent changes to retries and permission propagation mean that workspaces can take more time to be ready. We should increase the test timeout as a result.