### PR TITLE
[IA-3958] Wait for all permissions on GCS bucket in tests

### DIFF
--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -32,24 +32,41 @@ const getTestWorkspaceName = () => `${testWorkspaceNamePrefix}${uuid.v4()}`
  * user access to a workspace. This function polls to check if the logged in user's pet service
  * account has read access to the given workspace's GCS bucket.
  */
-const waitForReadAccessToWorkspaceBucket = async ({ page, billingProject, workspaceName, timeout = defaultTimeout }) => {
+const waitForAccessToWorkspaceBucket = async ({ page, billingProject, workspaceName, timeout = defaultTimeout }) => {
   await page.evaluate(async ({ billingProject, workspaceName, timeout }) => {
+    const { workspace: { googleProject, bucketName } } = await window.Ajax().Workspaces.workspace(billingProject, workspaceName).details(['workspace'])
+
     const startTime = Date.now()
-    while (true) {
-      try {
-        await window.Ajax().Workspaces.workspace(billingProject, workspaceName).checkBucketReadAccess()
-        return
-      } catch (response) {
-        if (response.status === 403) {
-          if (Date.now() - startTime < timeout) {
-            // Wait 15s before retrying
-            await new Promise(resolve => setTimeout(resolve, 15 * 1000))
-            continue
+
+    const checks = [
+      // List objects
+      () => window.Ajax().Buckets.list(googleProject, bucketName, ''),
+      // Create object
+      () => {
+        const file = new File([''], 'permissions-check', { type: 'text/text' })
+        return window.Ajax().Buckets.upload(googleProject, bucketName, '', file)
+      },
+      // Delete object
+      () => window.Ajax().Buckets.delete(googleProject, bucketName, 'permissions-check'),
+    ]
+
+    for (const check of checks) {
+      while (true) {
+        try {
+          await check()
+          break
+        } catch (response) {
+          if (response.status === 403) {
+            if (Date.now() - startTime < timeout) {
+              // Wait 15s before retrying
+              await new Promise(resolve => setTimeout(resolve, 15 * 1000))
+              continue
+            } else {
+              throw new Error('Timed out waiting for access to workspace bucket')
+            }
           } else {
-            throw new Error('Timed out waiting for access to workspace bucket')
+            throw response
           }
-        } else {
-          throw response
         }
       }
     }
@@ -63,7 +80,7 @@ const makeWorkspace = withSignedInPage(async ({ page, billingProject }) => {
       await window.Ajax().Workspaces.create({ namespace: billingProject, name, attributes: {} })
     }, workspaceName, billingProject)
     console.info(`Created workspace: ${workspaceName}`)
-    await waitForReadAccessToWorkspaceBucket({ page, billingProject, workspaceName })
+    await waitForAccessToWorkspaceBucket({ page, billingProject, workspaceName })
   } catch (e) {
     console.error(`Failed to create workspace: ${workspaceName} with billing project: ${billingProject}`)
     console.error(e)


### PR DESCRIPTION
To work around test failures caused by GCP IAM propagation delays, #3682 added a step to wait for read access to a newly created workspace's bucket to available for continuing with the test.

Despite that, we're still seeing occasional run-analysis and run-rstudio failures, now stemming from a 500 response from Leo due to the pet SA not having _create_ permission for the workspace bucket.
- https://app.circleci.com/pipelines/github/DataBiosphere/terra-ui/14034/workflows/a502e039-592d-4746-a6da-cd1d07ad4354/jobs/56450/tests
- https://app.circleci.com/pipelines/github/DataBiosphere/terra-ui/14066/workflows/2c285126-cd0f-4999-9f95-36c55ac79917/jobs/56527/tests

Since different IAM permissions may propagate at different times, this changes the check for read access to the workspace bucket to check for multiple permissions: first read, then create, then delete.