### PR TITLE
[UIE-60] Wait for get bucket permission on GCS buckets in tests

### DIFF
--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -39,6 +39,8 @@ const waitForAccessToWorkspaceBucket = async ({ page, billingProject, workspaceN
     const startTime = Date.now()
 
     const checks = [
+      // Get bucket metadata
+      () => window.Ajax().Buckets.checkBucketLocation(googleProject, bucketName),
       // List objects
       () => window.Ajax().Buckets.list(googleProject, bucketName, ''),
       // Create object


### PR DESCRIPTION
Continuing from #3682 and #3695, there's at least one more permission that Terra UI uses: get bucket for loading the bucket location on the workspace dashboard.

Saw some 403s related to this in the withWorkspace cleanup of import-cohort-data in this test:
https://app.circleci.com/pipelines/github/DataBiosphere/terra-ui/14081/workflows/67850dcb-8c6a-460a-b969-f19bce1ac6c8/jobs/56566/tests. I'm not sure if that's what caused this test to fail, but I think it's still worth adding to the "wait for IAM propagation" section of the withWorkspace helper.