### PR TITLE
[UIE-61] Handle error loading bucket location

### DIFF
--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -346,12 +346,12 @@ export const wrapWorkspace = ({ breadcrumbs, activeTab, title, topBarContent, sh
       }
     }
 
-    const loadBucketLocation = async (googleProject, bucketName) => {
+    const loadBucketLocation = withErrorReporting('Error loading bucket location', async (googleProject, bucketName) => {
       if (!!googleProject) {
         const bucketLocation = await Ajax(signal).Workspaces.workspace(namespace, name).checkBucketLocation(googleProject, bucketName)
         setBucketLocation(bucketLocation)
       }
-    }
+    })
 
     const refreshWorkspace = _.flow(
       withErrorReporting('Error loading workspace'),

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -346,7 +346,7 @@ export const wrapWorkspace = ({ breadcrumbs, activeTab, title, topBarContent, sh
       }
     }
 
-    const loadBucketLocation = withErrorReporting('Error loading bucket location', async (googleProject, bucketName) => {
+    const loadBucketLocation = withErrorIgnoring(async (googleProject, bucketName) => {
       if (!!googleProject) {
         const bucketLocation = await Ajax(signal).Workspaces.workspace(namespace, name).checkBucketLocation(googleProject, bucketName)
         setBucketLocation(bucketLocation)


### PR DESCRIPTION
In https://app.circleci.com/pipelines/github/DataBiosphere/terra-ui/14088/workflows/736a1950-120e-4581-8677-d6ad4d0e2ab6/jobs/56587, export-workspace-dataset-to-new-workspace failed because the request for the new workspace's bucket location failed.

```
page.http GET 403 https://storage.googleapis.com/storage/v1/b/fc-f6093620-4a02-4d8a-943a-c1a792c4ae27?fields=location%2ClocationType
page.console Failed to load resource: the server responded with a status of 403 ()
page.pageerror {}
```

The request likely failed because of IAM propagation delays. However, even if the request fails, it should not throw an error. It does because, unlike most requests, `loadBucketLocation` is not currently wrapped in any error handling.

This wraps it in `withErrorReporting` so that request failures will not throw an error. Instead, they will show an error notification, which should not cause the test to fail.

I waffled between using `withErrorReporting` or `withErrorIgnoring`. Since `loadBucketLocation` is not awaited, it appears that downstream must already tolerate the location being potentially missing.