### PR TITLE
[DC-645] Error logging follow-up

### DIFF
--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -362,10 +362,10 @@ const withScreenshot = _.curry((testName, fn) => async options => {
 
 // Emitted when the page crashes
 const logError = page => {
-  // this error will log an object of type [Error: Response] which is not very
+  // this error will log an object of type [Error: ...] which is not very
   // informative and looks incorrect at first glance since the contents would be
   // more useful but in fact this is the best we can do here since the object
-  // contents are empty and so stringifying it you get {}
+  // contents cannot be easily stringified otherwise you get {}
   const handle = msg => console.error('page.error', msg)
   page.on('error', handle)
   return () => page.off('error', handle)
@@ -373,10 +373,10 @@ const logError = page => {
 
 // Emitted when an uncaught exception happens within the page
 const logPageError = page => {
-  // this error will log an object of type [Error: Response] which is not very
+  // this error will log an object of type [Error: ...] which is not very
   // informative and looks incorrect at first glance since the contents would be
   // more useful but in fact this is the best we can do here since the object
-  // contents are empty and so stringifying it you get {}
+  // contents cannot be easily stringified otherwise you get {}
   const handle = msg => console.error('page.pageerror', msg)
   page.on('pageerror', handle)
   return () => page.off('pageerror', handle)

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -362,6 +362,10 @@ const withScreenshot = _.curry((testName, fn) => async options => {
 
 // Emitted when the page crashes
 const logError = page => {
+  // this error will log an object of type [Error: Response] which is not very
+  // informative and looks incorrect at first glance since the contents would be
+  // more useful but in fact this is the best we can do here since the object
+  // contents are empty and so stringifying it you get {}
   const handle = msg => console.error('page.error', msg)
   page.on('error', handle)
   return () => page.off('error', handle)
@@ -369,6 +373,10 @@ const logError = page => {
 
 // Emitted when an uncaught exception happens within the page
 const logPageError = page => {
+  // this error will log an object of type [Error: Response] which is not very
+  // informative and looks incorrect at first glance since the contents would be
+  // more useful but in fact this is the best we can do here since the object
+  // contents are empty and so stringifying it you get {}
   const handle = msg => console.error('page.pageerror', msg)
   page.on('pageerror', handle)
   return () => page.off('pageerror', handle)

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -362,18 +362,14 @@ const withScreenshot = _.curry((testName, fn) => async options => {
 
 // Emitted when the page crashes
 const logError = page => {
-  const handle = msg => {
-    console.error('page.error', typeof msg === 'object' ? JSON.stringify(msg) : msg)
-  }
+  const handle = msg => console.error('page.error', msg)
   page.on('error', handle)
   return () => page.off('error', handle)
 }
 
 // Emitted when an uncaught exception happens within the page
 const logPageError = page => {
-  const handle = msg => {
-    console.error('page.pageerror', typeof msg === 'object' ? JSON.stringify(msg) : msg)
-  }
+  const handle = msg => console.error('page.pageerror', msg)
   page.on('pageerror', handle)
   return () => page.off('pageerror', handle)
 }


### PR DESCRIPTION
Following up on conversations in https://github.com/DataBiosphere/terra-ui/pull/3652 , there are situations where just logging the response contents are not useful. Log both the object name and response contents instead.