### PR TITLE
[AJ-789] hide the data tab in azure prod

### DIFF
--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -16,6 +16,7 @@ import { saToken } from 'src/libs/ajax/GoogleStorage'
 import { getUser } from 'src/libs/auth'
 import { isTerra } from 'src/libs/brand-utils'
 import colors from 'src/libs/colors'
+import { getConfig } from 'src/libs/config'
 import { withErrorIgnoring, withErrorReporting } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
 import { clearNotification, notify } from 'src/libs/notifications'
@@ -87,6 +88,7 @@ const WorkspaceTabs = ({
   const isLocked = workspace?.workspace.isLocked
   const workspaceLoaded = !!workspace
   const googleWorkspace = workspaceLoaded && isGoogleWorkspace(workspace)
+  const isDataTabShown = googleWorkspace || !getConfig().isProd
 
   const onClone = () => setCloningWorkspace(true)
   const onDelete = () => setDeletingWorkspace(true)
@@ -96,7 +98,7 @@ const WorkspaceTabs = ({
 
   const tabs = [
     { name: 'dashboard', link: 'workspace-dashboard' },
-    { name: 'data', link: 'workspace-data' },
+    ...(isDataTabShown ? [{ name: 'data', link: 'workspace-data' }] : []),
     { name: 'analyses', link: analysisTabName },
     ...(googleWorkspace ? [{ name: 'workflows', link: 'workspace-workflows' }] : []),
     ...(googleWorkspace ? [{ name: 'job history', link: 'workspace-job-history' }] : [])


### PR DESCRIPTION
Hiding the data tab for azure until release.

Azure dev:
<img width="1366" alt="Screenshot 2023-01-19 at 7 44 13 PM" src="https://user-images.githubusercontent.com/8800717/213596069-d9ff5c2f-bc69-484d-ac4b-fc04f04679b6.png">

GCP dev:
<img width="1434" alt="Screenshot 2023-01-19 at 7 44 37 PM" src="https://user-images.githubusercontent.com/8800717/213596076-de563f00-8fe2-4baa-8a1e-635ef5985757.png">

Azure prod (set isProd to true in dev.json):
<img width="1433" alt="Screenshot 2023-01-19 at 8 02 32 PM" src="https://user-images.githubusercontent.com/8800717/213596084-057064b2-40d5-4c1e-982c-81ebd4878869.png">

GCP prod (set isProd to true in dev.json)
<img width="1363" alt="Screenshot 2023-01-19 at 8 02 54 PM" src="https://user-images.githubusercontent.com/8800717/213596093-a91b5c1b-0e18-41f6-94a5-2e5ea479025c.png">
