### PR TITLE
[IA-3976] Simplify IA tests

### DIFF
--- a/integration-tests/tests/analysis-context-bar.js
+++ b/integration-tests/tests/analysis-context-bar.js
@@ -1,17 +1,17 @@
 // This test is owned by the Interactive Analysis (IA) Team.
 const _ = require('lodash/fp')
-const { withRegisteredUser, withBilling, withWorkspace, performAnalysisTabSetup } = require('../utils/integration-helpers')
+const { deleteRuntimes, withWorkspace, performAnalysisTabSetup } = require('../utils/integration-helpers')
 const {
   click, clickable, getAnimatedDrawer, findElement, noSpinnersAfter, findButtonInDialogByAriaLabel
 } = require('../utils/integration-utils')
 const { registerTest } = require('../utils/jest-utils')
+const { withUserToken } = require('../utils/terra-sa-utils')
 
 
-const testAnalysisContextBarFn = _.flow(
+const testAnalysisContextBarFn = _.flowRight(
+  withUserToken,
   withWorkspace,
-  withBilling,
-  withRegisteredUser
-)(async ({ page, token, testUrl, workspaceName }) => {
+)(async ({ billingProject, page, token, testUrl, workspaceName }) => {
   // Navigate to appropriate part of UI (the analysis tab)
   await performAnalysisTabSetup(page, token, testUrl, workspaceName)
 
@@ -58,6 +58,8 @@ const testAnalysisContextBarFn = _.flow(
   await findElement(page, clickable({ textContains: 'Pausing' }), { timeout: 40000 })
 
   // We don't wait for the env to pause for the sake of time, since its redundant and more-so tests the backend
+
+  await deleteRuntimes({ page, billingProject, workspaceName })
 })
 
 registerTest({

--- a/integration-tests/tests/run-analysis.js
+++ b/integration-tests/tests/run-analysis.js
@@ -1,19 +1,19 @@
 // This test is owned by the Interactive Analysis (IA) Team.
 const _ = require('lodash/fp')
-const { withRegisteredUser, withBilling, withWorkspace, performAnalysisTabSetup } = require('../utils/integration-helpers')
+const { deleteRuntimes, withWorkspace, performAnalysisTabSetup } = require('../utils/integration-helpers')
 const {
   click, clickable, delay, findElement, noSpinnersAfter, fillIn, findIframe, findText, dismissNotifications, getAnimatedDrawer, image, input
 } = require('../utils/integration-utils')
 const { registerTest } = require('../utils/jest-utils')
+const { withUserToken } = require('../utils/terra-sa-utils')
 
 
 const notebookName = 'test-notebook'
 
-const testRunAnalysisFn = _.flow(
+const testRunAnalysisFn = _.flowRight(
+  withUserToken,
   withWorkspace,
-  withBilling,
-  withRegisteredUser
-)(async ({ workspaceName, page, testUrl, token }) => {
+)(async ({ billingProject, workspaceName, page, testUrl, token }) => {
   await performAnalysisTabSetup(page, token, testUrl, workspaceName)
 
   // Create analysis file
@@ -68,6 +68,8 @@ const testRunAnalysisFn = _.flow(
 
   // Save notebook to avoid "unsaved changes" modal when test tear-down tries to close the window
   await click(frame, clickable({ text: 'Save and Checkpoint' }))
+
+  await deleteRuntimes({ page, billingProject, workspaceName })
 })
 
 registerTest({

--- a/integration-tests/tests/run-rstudio.js
+++ b/integration-tests/tests/run-rstudio.js
@@ -1,19 +1,19 @@
 // This test is owned by the Interactive Analysis (IA) Team.
 const _ = require('lodash/fp')
-const { withRegisteredUser, withBilling, withWorkspace, performAnalysisTabSetup } = require('../utils/integration-helpers')
+const { deleteRuntimes, withWorkspace, performAnalysisTabSetup } = require('../utils/integration-helpers')
 const {
   click, clickable, delay, findElement, noSpinnersAfter, fillIn, findIframe, findText, dismissNotifications, getAnimatedDrawer, image, input
 } = require('../utils/integration-utils')
 const { registerTest } = require('../utils/jest-utils')
+const { withUserToken } = require('../utils/terra-sa-utils')
 
 
 const rFileName = 'test-rmd'
 
-const testRunRStudioFn = _.flow(
+const testRunRStudioFn = _.flowRight(
+  withUserToken,
   withWorkspace,
-  withBilling,
-  withRegisteredUser
-)(async ({ workspaceName, page, testUrl, token }) => {
+)(async ({ billingProject, workspaceName, page, testUrl, token }) => {
   await performAnalysisTabSetup(page, token, testUrl, workspaceName)
 
   // Create analysis file
@@ -66,6 +66,8 @@ const testRunRStudioFn = _.flow(
   await findText(frame, '[1] 1')
 
   await dismissNotifications(page)
+
+  await deleteRuntimes({ page, billingProject, workspaceName })
 })
 
 registerTest({


### PR DESCRIPTION
Despite the wait for permission steps added in #3695 and #3697, we occasionally still see errors due to missing permissions in run-analysis/run-studio. For example, run-rstudio in https://app.circleci.com/pipelines/github/DataBiosphere/terra-ui/14088/workflows/736a1950-120e-4581-8677-d6ad4d0e2ab6/jobs/56587.

One difference between the IA tests and most other tests is that the IA tests create a new user (using Lyle), register it in Terra, and run the test as that user. Most other tests run the test as `Scarlett.Flowerpicker@test.firecloud.org`.

I don't know for sure why the IA tests register a new user. #2865, which added the original create-interactive-analysis test that run-analysis was copied from in #3037, doesn't mention a reason for using a new user.

Thus, I'm _guessing_ that it's a holdover from the pre project-per-workspace days and was used as a way to have multiple cloud environments running at once. Now, since each IA test creates its own workspaces, the same user can have a cloud environment in each workspace running at the same time.

This removes the create/register user steps from the IA tests, so that they run as `Scarlett.Flowerpicker@test.firecloud.org`. That allows removing several helper functions.