### PR TITLE
[UIE-63] Log content of error responses in integration tests

### DIFF
--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -409,6 +409,8 @@ const logPageResponses = page => {
         const responseIsJSON = response.headers()['content-type'] === 'application/json'
         response.text().then(content => {
           console.log('page.http.error', `${method} ${status} ${url}`, responseIsJSON ? JSON.parse(content) : content)
+        }).catch(err => {
+          console.error('page.http.error', 'Unable to get response content', err)
         })
       }
     }

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -395,10 +395,22 @@ const logPageResponses = page => {
     'googleapis',
     'bvdp'
   ]
-  const handle = res => {
-    const request = res.request()
-    if (terraRequests.some(urlPart => request.url().includes(urlPart))) {
-      console.log('page.http', `${request.method()} ${res.status()} ${res.url()}`)
+  const handle = response => {
+    const request = response.request()
+    const url = request.url()
+    const shouldLogRequest = terraRequests.some(urlPart => url.includes(urlPart))
+    if (shouldLogRequest) {
+      const method = request.method()
+      const status = response.status()
+      console.log('page.http', `${method} ${status} ${url}`)
+
+      const isErrorResponse = status >= 400
+      if (isErrorResponse) {
+        const responseIsJSON = response.headers()['content-type'] === 'application/json'
+        response.text().then(content => {
+          console.log('page.http.error', `${method} ${status} ${url}`, responseIsJSON ? JSON.parse(content) : content)
+        })
+      }
     }
   }
   page.on('response', handle)


### PR DESCRIPTION
Currently, when a request returns an error response in an integration test, we get some information from various event handlers.

For example, making an un-authenticated request for workspace details:

From the "response" event handler:
```
console.log
  page.http GET 401 https://rawls.dsde-dev.broadinstitute.org/api/workspaces/general-dev-billing-account/my-first-workspace

  at handle (utils/integration-utils.js:401:15)
      at Array.map (<anonymous>)
      at Array.map (<anonymous>)
```

From the "console" event handler:
```
console.log
  page.console Failed to load resource: the server responded with a status of 401 ()

  at handle (utils/integration-utils.js:382:33)
      at Array.map (<anonymous>)
```

And from the "pageerror" event handler (see #3700 for more discussion about this)
```
console.error
  page.pageerror {}

    373 | const logPageError = page => {
    374 |   const handle = msg => {
  > 375 |     console.error('page.pageerror', typeof msg === 'object' ? JSON.stringify(msg) : msg)
        |             ^
    376 |   }
    377 |   page.on('pageerror', handle)
    378 |   return () => page.off('pageerror', handle)

    at handle (utils/integration-utils.js:375:13)
    at ../.yarn/unplugged/puppeteer-npm-13.5.1-231e586c7a/node_modules/puppeteer/vendor/mitt/src/index.ts:88:75
        at Array.map (<anonymous>)
    at Object.emit (../.yarn/unplugged/puppeteer-npm-13.5.1-231e586c7a/node_modules/puppeteer/vendor/mitt/src/index.ts:88:56)
    at Page.emit (../.yarn/unplugged/puppeteer-npm-13.5.1-231e586c7a/node_modules/puppeteer/src/common/EventEmitter.ts:102:18)
    at Page._handleException (../.yarn/unplugged/puppeteer-npm-13.5.1-231e586c7a/node_modules/puppeteer/src/common/Page.ts:1519:10)
    at ../.yarn/unplugged/puppeteer-npm-13.5.1-231e586c7a/node_modules/puppeteer/src/common/Page.ts:571:12
    at ../.yarn/unplugged/puppeteer-npm-13.5.1-231e586c7a/node_modules/puppeteer/vendor/mitt/src/index.ts:88:75
```

For debugging, it would be helpful to see the actual content of error responses. This change adds that to the "response" event handler.

With this change, for the example request above, we would also see this:
```
console.log
  page.http.error GET 401 https://rawls.dsde-dev.broadinstitute.org/api/workspaces/general-dev-billing-account/my-first-workspace <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
  <html><head><script src="https://us.jsagent.tcell.insight.rapid7.com/tcellagent.min.js" tcellappid="FCNonprod-NaVu9" tcellapikey="AQQBBAFLGLOxL7VE9IF9ESlLvCxD5Ykr_7xkQKq_rgn_P58IWjOhOzIh6p3aI4pTWaprlUw" tcellbaseurl="https://us.agent.tcell.insight.rapid7.com/api/v1"></script>
  <title>401 Unauthorized</title>
  </head><body>
  <h1>Unauthorized</h1>
  <p>This server could not verify that you
  are authorized to access the document
  requested.  Either you supplied the wrong
  credentials (e.g., bad password), or your
  browser doesn't understand how to supply
  the credentials required.</p>
  </body></html>
```

A 401 response isn't a great example of the utility of this. This would likely be most useful for 400 and 500 responses.

Note, this will add some noise to the logs, since 404 responses are expected from endpoints related to external account links. Most of those endpoints appear to return empty responses, so I don't think the noise will too much.