### PR TITLE
[AJ-799] Fix workspace dashboard test

### DIFF
--- a/integration-tests/tests/workspace-dashboard.js
+++ b/integration-tests/tests/workspace-dashboard.js
@@ -214,9 +214,10 @@ const testAzureWorkspace = withUserToken(async ({ environment, page, token, test
   await dashboard.assertTabs(['notebooks', 'workflows', 'job history'], false)
 
   // Verify Analyses tab is present.
+  await dashboard.assertTabs(['analyses'], true)
+
   // Data tab should only be visible in dev for Azure workspaces
-  const expectedTabs = environment === 'dev' ? ['data', 'analyses'] : ['analyses']
-  await dashboard.assertTabs(expectedTabs, true)
+  await dashboard.assertTabs(['data'], environment === 'dev')
 
   // Check accessibility.
   await verifyAccessibility(page)

--- a/integration-tests/tests/workspace-dashboard.js
+++ b/integration-tests/tests/workspace-dashboard.js
@@ -185,7 +185,7 @@ const setAzureAjaxMockValues = async (testPage, namespace, name, workspaceDescri
   }, azureWorkspacesListResult, azureWorkspaceDetailsResult, azureWorkspaceResourcesResult, namespace, name, workspaceInfo.workspaceId)
 }
 
-const testAzureWorkspace = withUserToken(async ({ page, token, testUrl }) => {
+const testAzureWorkspace = withUserToken(async ({ environment, page, token, testUrl }) => {
   const workspaceDescription = 'azure workspace description'
   const workspaceName = 'azure-workspace'
 
@@ -213,8 +213,11 @@ const testAzureWorkspace = withUserToken(async ({ page, token, testUrl }) => {
   // Verify tabs that currently depend on Google project ID are not present.
   await dashboard.assertTabs(['notebooks', 'workflows', 'job history'], false)
 
-  // Verify Analyses and Data tabs are present.
-  await dashboard.assertTabs(['analyses', 'data'], true)
+  // Verify Analyses tab is present.
+  // Data tab should only be visible in dev for Azure workspaces
+  const expectedTabs = environment === 'dev' ? ['data', 'analyses'] : ['analyses']
+  console.log('expectedTabs', expectedTabs)
+  await dashboard.assertTabs(expectedTabs, true)
 
   // Check accessibility.
   await verifyAccessibility(page)

--- a/integration-tests/tests/workspace-dashboard.js
+++ b/integration-tests/tests/workspace-dashboard.js
@@ -216,7 +216,6 @@ const testAzureWorkspace = withUserToken(async ({ environment, page, token, test
   // Verify Analyses tab is present.
   // Data tab should only be visible in dev for Azure workspaces
   const expectedTabs = environment === 'dev' ? ['data', 'analyses'] : ['analyses']
-  console.log('expectedTabs', expectedTabs)
   await dashboard.assertTabs(expectedTabs, true)
 
   // Check accessibility.

--- a/integration-tests/utils/jest-utils.js
+++ b/integration-tests/utils/jest-utils.js
@@ -23,7 +23,7 @@ const {
   CLUSTER_TIMEOUT_MINUTES: clusterTimeout = 120
 } = process.env
 
-const targetEnvParams = _.merge({ ...envs[environment] }, { billingProject, snapshotColumnName, snapshotId, snapshotTableName, testUrl, workflowName })
+const targetEnvParams = _.merge({ ...envs[environment], environment }, { billingProject, snapshotColumnName, snapshotId, snapshotTableName, testUrl, workflowName })
 
 const registerTest = ({ fn, name, timeout = defaultTimeout, targetEnvironments = _.keys(envs) }) => {
   return _.includes(environment, targetEnvironments) ? test(


### PR DESCRIPTION
Since #3703 hide the Data tab in Azure workspaces, the workspace-dashboard test has been failing. This changes the test to only check for the Data tab in Azure workspaces when running against the dev environment.