### PR TITLE
[SU-277] Require input in NameModal

### DIFF
--- a/src/components/NameModal.js
+++ b/src/components/NameModal.js
@@ -9,26 +9,29 @@ import { FormLabel } from 'src/libs/forms'
 
 export const NameModal = ({ onSuccess, onDismiss, thing, value, validator = null, validationMessage = 'Invalid input' }) => {
   const [name, setName] = useState(value || '')
+  const [inputTouched, setInputTouched] = useState(false)
   const [error, setError] = useState(null)
   const isUpdate = value !== undefined
 
   useEffect(() => {
-    if (name !== '' && _.isRegExp(validator) && !validator.test(name)) {
+    if (!name && inputTouched) {
+      setError('Name is required')
+    } else if (_.isRegExp(validator) && !validator.test(name)) {
       setError(validationMessage)
-    } else if (name !== '' && _.isFunction(validator)) {
+    } else if (_.isFunction(validator)) {
       const msg = validator(name)
       setError(msg === false ? null : _.isString(msg) ? msg : validationMessage)
     } else {
       setError(null)
     }
-  }, [name]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [name, inputTouched]) // eslint-disable-line react-hooks/exhaustive-deps
 
   return h(Modal, {
     title: (isUpdate ? 'Update ' : 'Create a New ') + thing,
     onDismiss,
     okButton: h(ButtonPrimary, {
       onClick: () => onSuccess({ name }),
-      disabled: error !== null
+      disabled: !name || error !== null
     }, [
       isUpdate ? 'Update ' : 'Create ',
       thing
@@ -43,7 +46,10 @@ export const NameModal = ({ onSuccess, onDismiss, thing, value, validator = null
             autoFocus: true,
             placeholder: 'Enter a name',
             value: name,
-            onChange: v => setName(v)
+            onChange: v => {
+              setInputTouched(true)
+              setName(v)
+            }
           },
           error
         })

--- a/src/components/NameModal.test.js
+++ b/src/components/NameModal.test.js
@@ -1,0 +1,232 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { h } from 'react-hyperscript-helpers'
+
+import { NameModal } from './NameModal'
+
+
+jest.mock('src/components/Modal', () => {
+  const { mockModalModule } = jest.requireActual('src/components/Modal.mock')
+  return mockModalModule()
+})
+
+describe('NameModal', () => {
+  it('renders a prompt for a new thing name', () => {
+    // Act
+    render(h(NameModal, {
+      thing: 'Thing',
+      onSuccess: () => {},
+      onDismiss: () => {},
+    }))
+
+    // Assert
+    screen.getByLabelText('Create a New Thing')
+
+    const nameInput = screen.getByLabelText('Thing name *')
+    expect(nameInput.value).toBe('')
+  })
+
+  it('renders a prompt to update an existing thing\'s name', () => {
+    // Act
+    render(h(NameModal, {
+      thing: 'Thing',
+      value: 'foo',
+      onSuccess: () => {},
+      onDismiss: () => {},
+    }))
+
+    // Assert
+    screen.getByLabelText('Update Thing')
+
+    const nameInput = screen.getByLabelText('Thing name *')
+    expect(nameInput.value).toBe('foo')
+  })
+
+  it('when submit button is clicked, it calls onSuccess with entered name', async () => {
+    // Arrange
+    const user = userEvent.setup()
+
+    const onSuccess = jest.fn()
+    render(h(NameModal, {
+      thing: 'Thing',
+      onSuccess,
+      onDismiss: () => {},
+    }))
+
+    // Act
+    const nameInput = screen.getByLabelText('Thing name *')
+    await user.type(nameInput, 'foo')
+
+    const submitButton = screen.getByText('Create Thing')
+    await user.click(submitButton)
+
+    // Assert
+    expect(onSuccess).toHaveBeenCalledWith({ name: 'foo' })
+  })
+
+  it('when cancel button is clicked, it calls onDismiss', async () => {
+    // Arrange
+    const user = userEvent.setup()
+
+    const onDismiss = jest.fn()
+    render(h(NameModal, {
+      thing: 'Thing',
+      onSuccess: () => {},
+      onDismiss,
+    }))
+
+    // Act
+    const cancelButton = screen.getByText('Cancel')
+    await user.click(cancelButton)
+
+    // Assert
+    expect(onDismiss).toHaveBeenCalled()
+  })
+
+  describe('validation', () => {
+    it('requires input', async () => {
+      // Arrange
+      const user = userEvent.setup()
+
+      render(h(NameModal, {
+        thing: 'Thing',
+        onSuccess: () => {},
+        onDismiss: () => {},
+      }))
+
+      const nameInput = screen.getByLabelText('Thing name *')
+      const submitButton = screen.getByText('Create Thing')
+
+      // Assert
+      expect(nameInput.value).toBe('')
+      expect(submitButton.getAttribute('aria-disabled')).toBe('true')
+
+      // Act
+      await user.type(nameInput, 'foo')
+
+      // Assert
+      expect(nameInput.value).toBe('foo')
+      expect(submitButton.getAttribute('aria-disabled')).toBe('false')
+    })
+
+    it('shows required input message only after input is touched', async () => {
+      // Arrange
+      const user = userEvent.setup()
+
+      render(h(NameModal, {
+        thing: 'Thing',
+        onSuccess: () => {},
+        onDismiss: () => {},
+      }))
+
+      const nameInput = screen.getByLabelText('Thing name *')
+
+      // Assert
+      expect(screen.queryByText('Name is required')).toBeNull()
+
+      // Act
+      await user.type(nameInput, 'foo')
+      await user.clear(nameInput)
+
+      // Assert
+      expect(nameInput.value).toBe('')
+      screen.getByText('Name is required')
+    })
+
+    describe('regex', () => {
+      it('validates name matches regex', async () => {
+        // Arrange
+        const user = userEvent.setup()
+
+        render(h(NameModal, {
+          thing: 'Thing',
+          validator: /b.*/,
+          validationMessage: 'Name must start with the letter b',
+          onSuccess: () => {},
+          onDismiss: () => {},
+        }))
+
+        const nameInput = screen.getByLabelText('Thing name *')
+        const submitButton = screen.getByText('Create Thing')
+
+        // Act
+        await user.type(nameInput, 'foo')
+
+        // Assert
+        screen.getByText('Name must start with the letter b')
+        expect(submitButton.getAttribute('aria-disabled')).toBe('true')
+
+        // Act
+        await user.clear(nameInput)
+        await user.type(nameInput, 'bar')
+
+        // Assert
+        expect(screen.queryByText('Name must start with the letter b')).toBeNull()
+        expect(submitButton.getAttribute('aria-disabled')).toBe('false')
+      })
+    })
+
+    describe('function', () => {
+      it('validates with function returning boolean (true if invalid)', async () => {
+        // Arrange
+        const user = userEvent.setup()
+
+        render(h(NameModal, {
+          thing: 'Thing',
+          validator: name => !name.startsWith('b'),
+          validationMessage: 'Name must start with the letter b',
+          onSuccess: () => {},
+          onDismiss: () => {},
+        }))
+
+        const nameInput = screen.getByLabelText('Thing name *')
+        const submitButton = screen.getByText('Create Thing')
+
+        // Act
+        await user.type(nameInput, 'foo')
+
+        // Assert
+        screen.getByText('Name must start with the letter b')
+        expect(submitButton.getAttribute('aria-disabled')).toBe('true')
+
+        // Act
+        await user.clear(nameInput)
+        await user.type(nameInput, 'bar')
+
+        // Assert
+        expect(screen.queryByText('Name must start with the letter b')).toBeNull()
+        expect(submitButton.getAttribute('aria-disabled')).toBe('false')
+      })
+
+      it('validates with function returning string (validation message)', async () => {
+        // Arrange
+        const user = userEvent.setup()
+
+        render(h(NameModal, {
+          thing: 'Thing',
+          validator: name => !name.startsWith('b') ? 'Name must start with the letter b' : false,
+          onSuccess: () => {},
+          onDismiss: () => {},
+        }))
+
+        const nameInput = screen.getByLabelText('Thing name *')
+        const submitButton = screen.getByText('Create Thing')
+
+        // Act
+        await user.type(nameInput, 'foo')
+
+        // Assert
+        screen.getByText('Name must start with the letter b')
+        expect(submitButton.getAttribute('aria-disabled')).toBe('true')
+
+        // Act
+        await user.clear(nameInput)
+        await user.type(nameInput, 'bar')
+
+        // Assert
+        expect(screen.queryByText('Name must start with the letter b')).toBeNull()
+        expect(submitButton.getAttribute('aria-disabled')).toBe('false')
+      })
+    })
+  })
+})

--- a/src/components/data/FileBrowser.js
+++ b/src/components/data/FileBrowser.js
@@ -472,7 +472,7 @@ const BucketBrowser = (({
       }),
 
       creatingNewFolder && h(NameModal, {
-        thing: 'New folder',
+        thing: 'Folder',
         onDismiss: () => setCreatingNewFolder(false),
         onSuccess: _.flow(
           Utils.withBusyState(setBusy),


### PR DESCRIPTION
NameModal is used in a few places for table and file names.

Currently, it will happily accept an empty string as name. Its current mechanisms for validating the input are useless to stop this, as it does not attempt any validation if the input is blank.

https://github.com/DataBiosphere/terra-ui/blob/2244d930ec64ed3b895dcb470d2bec144dec8b6a/src/components/NameModal.js#L16-L23

Since an empty string is never desired when naming something, this makes an input required.