### PR TITLE
[DC-649] Fix flakiness in import-cohort-data test

### DIFF
--- a/src/pages/ImportData.js
+++ b/src/pages/ImportData.js
@@ -134,7 +134,7 @@ const ImportDataDestination = ({ workspaceId, templateWorkspaces, template, user
     ])
   }
 
-  const SelectExistingWorkspace = () => h(Fragment, [
+  const renderSelectExistingWorkspace = () => h(Fragment, [
     h2({ style: styles.title }, ['Start with an existing workspace']),
     h(IdContainer, [id => h(Fragment, [
       h(FormLabel, { htmlFor: id, style: { marginBottom: '0.25rem' } }, ['Select one of your workspaces']),
@@ -159,7 +159,7 @@ const ImportDataDestination = ({ workspaceId, templateWorkspaces, template, user
     ])
   ])
 
-  const SelectTemplateWorkspace = () => h(Fragment, [
+  const renderSelectTemplateWorkspace = () => h(Fragment, [
     h2({ style: styles.title }, ['Start with a template']),
     importMayTakeTime && div({ style: { marginBottom: '1rem', lineHeight: '1.5' } }, [importMayTakeTimeMessage]),
     div({
@@ -209,8 +209,8 @@ const ImportDataDestination = ({ workspaceId, templateWorkspaces, template, user
 
   return div({ style: { ...styles.card, marginLeft: '2rem' } }, [
     Utils.switchCase(mode,
-      ['existing', () => h(SelectExistingWorkspace)],
-      ['template', () => h(SelectTemplateWorkspace)],
+      ['existing', () => renderSelectExistingWorkspace()],
+      ['template', () => renderSelectTemplateWorkspace()],
       [Utils.DEFAULT, () => {
         return h(Fragment, [
           h2({ style: styles.title }, ['Destination of the prepared data']),


### PR DESCRIPTION
In its render function, ImportDataDestination defines two functions: SelectExistingWorkspace and SelectTemplateWorkspace.

https://github.com/DataBiosphere/terra-ui/blob/b293920f04044f5205ba06ffe44d41923feb21d3/src/pages/ImportData.js#L137-L208

It then renders them _as components_.

https://github.com/DataBiosphere/terra-ui/blob/b293920f04044f5205ba06ffe44d41923feb21d3/src/pages/ImportData.js#L212-L213

This is problematic. Because the functions are created in each render, React sees them as different components each time and will unmount and destroy the old instance and create and mount a new one on each render.

Besides being inefficient, this appears to be creating problems in tests. import-cohort-data frequently fails with a "Node is detached from document" error when trying to select a workspace. I suspect the test is getting a reference to an element which is removed from the document when the SelectExistingWorkspace component is unmounted/recreated on each render.

Instead of rendering these functions as components, this change calls them. It also renames them to fit convention.

Ran this 20 times with `yarn test-flakes` without an error.