### PR TITLE
[SU-280] Add form for requesting preview access

### DIFF
--- a/src/components/FeaturePreviewFeedbackModal.js
+++ b/src/components/FeaturePreviewFeedbackModal.js
@@ -5,6 +5,7 @@ import { ButtonPrimary, IdContainer, spinnerOverlay } from 'src/components/commo
 import { TextArea, TextInput } from 'src/components/input'
 import Modal from 'src/components/Modal'
 import { Ajax } from 'src/libs/ajax'
+import { withErrorIgnoring } from 'src/libs/error'
 import { FormLabel } from 'src/libs/forms'
 import * as Utils from 'src/libs/utils'
 import validate from 'validate.js'
@@ -16,7 +17,10 @@ export const FeaturePreviewFeedbackModal = ({ onSuccess, onDismiss, formId, feed
   const [submitting, setSubmitting] = useState(false)
   const [thanksShowing, setThanksShowing] = useState(false)
 
-  const submit = Utils.withBusyState(setSubmitting, async () => {
+  const submit = _.flow(
+    withErrorIgnoring,
+    Utils.withBusyState(setSubmitting),
+  )(async () => {
     await Ajax().Surveys.submitForm(formId,
       { [feedbackId]: feedback, [contactEmailId]: contactEmail, [sourcePageId]: sourcePage })
     setThanksShowing(true)

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -18,7 +18,6 @@ import { Resources } from 'src/libs/ajax/Resources'
 import { Runtimes } from 'src/libs/ajax/Runtimes'
 import { WorkspaceData } from 'src/libs/ajax/WorkspaceDataService'
 import { getConfig } from 'src/libs/config'
-import { withErrorIgnoring } from 'src/libs/error'
 import { getUser } from 'src/libs/state'
 import * as Utils from 'src/libs/utils'
 
@@ -1010,9 +1009,7 @@ const OAuth2 = signal => ({
 })
 
 const Surveys = signal => ({
-  submitForm: withErrorIgnoring((formId, data) => {
-    return fetchGoogleForms(`${formId}/formResponse?${qs.stringify(data)}`, { signal })
-  })
+  submitForm: (formId, data) => fetchGoogleForms(`${formId}/formResponse?${qs.stringify(data)}`, { signal })
 })
 
 export const Ajax = signal => {

--- a/src/libs/ajax/ajax-common.ts
+++ b/src/libs/ajax/ajax-common.ts
@@ -189,7 +189,15 @@ export const fetchEcm = _.flow(
   withRetryAfterReloadingExpiredAuthToken,
 )(fetchOk)
 
-export const fetchGoogleForms = withUrlPrefix('https://docs.google.com/forms/u/0/d/e/', fetchOk)
+// Google Forms does not set a CORS header that allows Terra to access the response.
+// Thus, we send the request in no-cors mode and, because the response is "opaque",
+// we do not check response.ok.
+export const fetchGoogleForms = _.flow(
+  withUrlPrefix('https://docs.google.com/forms/u/0/d/e/'),
+  withInstrumentation,
+  withCancellation,
+  wrappedFetch => (url, options) => wrappedFetch(url, _.merge(options, { mode: 'no-cors' })),
+)(fetch)
 
 export const fetchWDS = wdsProxyUrlRoot => _.flow(
   withUrlPrefix(`${wdsProxyUrlRoot}/`),

--- a/src/libs/forms.js
+++ b/src/libs/forms.js
@@ -1,4 +1,4 @@
-import { div, label } from 'react-hyperscript-helpers'
+import { div, label, legend } from 'react-hyperscript-helpers'
 import * as Style from 'src/libs/style'
 
 
@@ -17,6 +17,10 @@ const styles = {
 
 export const FormLabel = ({ style = {}, required = false, children, ...props }) => {
   return label({ ...props, style: { ...styles.formLabel, ...style } }, [children, required && ' *'])
+}
+
+export const FormLegend = ({ style = {}, children, ...props }) => {
+  return legend({ ...props, style: { ...styles.formLabel, ...style } }, [children])
 }
 
 export const formHint = text => {

--- a/src/pages/AzurePreview.js
+++ b/src/pages/AzurePreview.js
@@ -179,7 +179,7 @@ const AzurePreviewForNonPreviewUser = () => {
   if (hasSubmittedForm) {
     return h(Fragment, [
       p({ style: styles.paragraph }, [
-        'Thank you for your interest in using Terra on Azure. We will be in touch with your access information soon.'
+        'Thank you for your interest in using Terra on Microsoft Azure. We will be in touch with your access information soon.'
       ]),
       div({ style: { marginTop: '1.5rem' } }, [
         h(ButtonPrimary, { onClick: signOut, style: styles.button }, ['Sign Out']),
@@ -188,7 +188,7 @@ const AzurePreviewForNonPreviewUser = () => {
   } else {
     return div([
       p({ style: styles.paragraph }, [
-        'Terra on Azure is currently in preview. Please complete the following form if you are interested in accessing the platform and exploring the capabilities of Terra on Azure.'
+        'Terra on Microsoft Azure is currently in preview. Please complete the following form if you are interested in accessing the platform and exploring the capabilities of Terra on Microsoft Azure.'
       ]),
 
       h(AzurePreviewUserForm, { value: userInfo, onChange: setUserInfo, onSubmit: submitEnabled ? submitForm : () => {} }),

--- a/src/pages/AzurePreview.js
+++ b/src/pages/AzurePreview.js
@@ -54,7 +54,7 @@ const AzurePreviewForPreviewUser = () => {
 
     div({ style: { ...styles.centered, marginTop: '1.5rem' } }, [
       h(ButtonPrimary, { onClick: dismiss, style: { ...styles.button, marginBottom: '1rem' } }, ['Proceed to Terra on Microsoft Azure Preview']),
-      h(ButtonOutline, { onClick: signOut, style: styles.button }, ['Log Out']),
+      h(ButtonOutline, { onClick: signOut, style: styles.button }, ['Sign Out']),
     ])
   ])
 }
@@ -70,7 +70,7 @@ const AzurePreviewForNonPreviewUser = () => {
     ]),
 
     div({ style: { ...styles.centered, marginTop: '1.5rem' } }, [
-      h(ButtonPrimary, { onClick: signOut, style: styles.button }, ['Log Out']),
+      h(ButtonPrimary, { onClick: signOut, style: styles.button }, ['Sign Out']),
     ])
   ])
 }

--- a/src/pages/AzurePreview.js
+++ b/src/pages/AzurePreview.js
@@ -139,13 +139,23 @@ const AzurePreviewForNonPreviewUser = () => {
 
   const [busy, setBusy] = useState(false)
 
-  const [userInfo, setUserInfo] = useState({
-    firstName: '',
-    lastName: '',
-    title: '',
-    organization: '',
-    contactEmail: '',
-    terraEmail: getUser().email,
+  const [userInfo, setUserInfo] = useState(() => {
+    const user = getUser()
+
+    // If the user's name contains only one space, guess that it contains
+    // their first and last name and auto populate those inputs.
+    // Otherwise, leave them blank.
+    const nameParts = (user.name || '').trim().split(/\s/)
+    const [firstName, lastName] = nameParts.length === 2 ? nameParts : ['', '']
+
+    return {
+      firstName,
+      lastName,
+      title: '',
+      organization: '',
+      contactEmail: user.email,
+      terraEmail: user.email,
+    }
   })
 
   const submitEnabled = Object.values(userInfo).every(Boolean) && !busy

--- a/src/pages/AzurePreview.js
+++ b/src/pages/AzurePreview.js
@@ -1,10 +1,12 @@
 import { Fragment, useCallback, useEffect, useState } from 'react'
 import { div, form, h, h1, p } from 'react-hyperscript-helpers'
 import { ButtonOutline, ButtonPrimary } from 'src/components/common'
+import { TextInput } from 'src/components/input'
 import planet from 'src/images/register-planet.svg'
 import { ReactComponent as TerraOnAzureLogo } from 'src/images/terra-ms-logo.svg'
 import { signOut } from 'src/libs/auth'
 import colors from 'src/libs/colors'
+import { FormLabel } from 'src/libs/forms'
 import { getLocalPref, setLocalPref } from 'src/libs/prefs'
 import { useStore } from 'src/libs/react-utils'
 import { authStore, azurePreviewStore } from 'src/libs/state'
@@ -58,11 +60,72 @@ const AzurePreviewForPreviewUser = () => {
 
 export const submittedPreviewFormPrefKey = 'submitted-azure-preview-form'
 
+const AzurePreviewUserForm = ({ value: formValue, onChange, onSubmit }) => {
+  const fields = [
+    {
+      key: 'firstName',
+      label: 'First name',
+    },
+    {
+      key: 'lastName',
+      label: 'Last name',
+    },
+    {
+      key: 'title',
+      label: 'Title/Role',
+    },
+    {
+      key: 'organization',
+      label: 'Organization name',
+    },
+    {
+      key: 'contactEmail',
+      label: 'Contact email address',
+    },
+  ]
+
+  return form({
+    name: 'azure-preview-interest',
+    style: {
+      display: 'flex',
+      flexFlow: 'row wrap',
+      justifyContent: 'space-between',
+      width: 570,
+    },
+    onSubmit: e => {
+      e.preventDefault()
+      onSubmit()
+    }
+  }, [
+    fields.map(({ key, label }) => {
+      const inputId = `azure-preview-interest-${key}`
+      return div({ key, style: { width: 250 } }, [
+        h(FormLabel, { htmlFor: inputId, required: true }, [label]),
+        h(TextInput, {
+          id: inputId,
+          value: formValue[key],
+          onChange: value => { onChange({ ...formValue, [key]: value }) },
+        }),
+      ])
+    }),
+  ])
+}
+
 const AzurePreviewForNonPreviewUser = () => {
   const [hasSubmittedForm, setHasSubmittedForm] = useState(() => getLocalPref(submittedPreviewFormPrefKey) || false)
   useEffect(() => {
     setLocalPref(submittedPreviewFormPrefKey, hasSubmittedForm)
   }, [hasSubmittedForm])
+
+  const [userInfo, setUserInfo] = useState({
+    firstName: '',
+    lastName: '',
+    title: '',
+    organization: '',
+    contactEmail: '',
+  })
+
+  const submitEnabled = Object.values(userInfo).every(Boolean)
 
   const submitForm = useCallback(() => {
     setHasSubmittedForm(true)
@@ -89,16 +152,7 @@ const AzurePreviewForNonPreviewUser = () => {
         'You are not currently part of the Terra on Microsoft Azure Preview Program. If you are interested in joining the program, please complete the form below.'
       ]),
 
-      form({
-        name: 'azure-preview-interest',
-        style: {
-          width: '100%',
-        },
-        onSubmit: e => {
-          e.preventDefault()
-          submitForm()
-        }
-      }, []),
+      h(AzurePreviewUserForm, { value: userInfo, onChange: setUserInfo, onSubmit: submitForm }),
 
       div({
         style: {
@@ -108,7 +162,7 @@ const AzurePreviewForNonPreviewUser = () => {
           marginTop: '1.5rem',
         }
       }, [
-        h(ButtonPrimary, { onClick: submitForm, style: styles.button }, ['Submit']),
+        h(ButtonPrimary, { disabled: !submitEnabled, onClick: submitForm, style: styles.button }, ['Submit']),
         h(ButtonOutline, { onClick: signOut, style: styles.button }, ['Sign Out']),
       ])
     ]),

--- a/src/pages/AzurePreview.js
+++ b/src/pages/AzurePreview.js
@@ -117,6 +117,7 @@ const AzurePreviewUserForm = ({ value: formValue, onChange, onSubmit }) => {
       ])
     }),
 
+    // Submit input allows submitting form by pressing the enter key.
     input({ type: 'submit', value: 'submit', style: { display: 'none' } })
   ])
 }

--- a/src/pages/AzurePreview.js
+++ b/src/pages/AzurePreview.js
@@ -1,5 +1,5 @@
 import { Fragment, useCallback, useEffect, useState } from 'react'
-import { div, form, h, h1, p } from 'react-hyperscript-helpers'
+import { div, form, h, h1, input, p } from 'react-hyperscript-helpers'
 import { ButtonOutline, ButtonPrimary } from 'src/components/common'
 import { ValidatedInput } from 'src/components/input'
 import planet from 'src/images/register-planet.svg'
@@ -115,6 +115,8 @@ const AzurePreviewUserForm = ({ value: formValue, onChange, onSubmit }) => {
         }),
       ])
     }),
+
+    input({ type: 'submit', value: 'submit', style: { display: 'none' } })
   ])
 }
 
@@ -188,7 +190,7 @@ const AzurePreviewForNonPreviewUser = () => {
         'Terra on Azure is currently in preview. Please complete the following form if you are interested in accessing the platform and exploring the capabilities of Terra on Azure.'
       ]),
 
-      h(AzurePreviewUserForm, { value: userInfo, onChange: setUserInfo, onSubmit: submitForm }),
+      h(AzurePreviewUserForm, { value: userInfo, onChange: setUserInfo, onSubmit: submitEnabled ? submitForm : () => {} }),
 
       div({
         style: {

--- a/src/pages/AzurePreview.js
+++ b/src/pages/AzurePreview.js
@@ -40,12 +40,43 @@ const styles = {
 const supportEmail = 'preview@terra.bio'
 const supportSubject = 'Terra on Microsoft Azure Preview Environment'
 
-const AzurePreview = () => {
-  const { isAzurePreviewUser } = useStore(authStore)
+const AzurePreviewDescription = () => p({ style: styles.paragraph }, [
+  'This is a preview version of the Terra platform on Microsoft Azure. The public offering of Terra on Microsoft Azure is expected in early 2023.'
+])
 
+const AzurePreviewForPreviewUser = () => {
   const dismiss = () => {
     azurePreviewStore.set(true)
   }
+
+  return h(Fragment, [
+    h(AzurePreviewDescription),
+
+    div({ style: { ...styles.centered, marginTop: '1.5rem' } }, [
+      h(ButtonPrimary, { onClick: dismiss, style: { ...styles.button, marginBottom: '1rem' } }, ['Proceed to Terra on Microsoft Azure Preview']),
+      h(ButtonOutline, { onClick: signOut, style: styles.button }, ['Log Out']),
+    ])
+  ])
+}
+
+const AzurePreviewForNonPreviewUser = () => {
+  return h(Fragment, [
+    h(AzurePreviewDescription),
+
+    p({ style: styles.paragraph }, [
+      'You are not currently part of the Terra on Microsoft Azure Preview Program. If you are interested in joining the program, please contact ',
+      h(Link, { href: `mailto:${supportEmail}?subject=${encodeURIComponent(supportSubject)}`, ...Utils.newTabLinkProps, style: { textDecoration: 'underline' } }, [supportEmail]),
+      '.'
+    ]),
+
+    div({ style: { ...styles.centered, marginTop: '1.5rem' } }, [
+      h(ButtonPrimary, { onClick: signOut, style: styles.button }, ['Log Out']),
+    ])
+  ])
+}
+
+const AzurePreview = () => {
+  const { isAzurePreviewUser } = useStore(authStore)
 
   return div({
     role: 'main',
@@ -60,22 +91,7 @@ const AzurePreview = () => {
     h(TerraOnAzureLogo, { title: 'Terra on Microsoft Azure - Preview', role: 'img' }),
     h1({ style: styles.header }, ['Terra on Microsoft Azure - Preview']),
 
-    p({ style: styles.paragraph }, [
-      'This is a preview version of the Terra platform on Microsoft Azure. The public offering of Terra on Microsoft Azure is expected in early 2023.'
-    ]),
-
-    !isAzurePreviewUser && p({ style: styles.paragraph }, [
-      'You are not currently part of the Terra on Microsoft Azure Preview Program. If you are interested in joining the program, please contact ',
-      h(Link, { href: `mailto:${supportEmail}?subject=${encodeURIComponent(supportSubject)}`, ...Utils.newTabLinkProps, style: { textDecoration: 'underline' } }, [supportEmail]),
-      '.'
-    ]),
-
-    div({ style: { ...styles.centered, marginTop: '1.5rem' } }, [
-      !!isAzurePreviewUser ? h(Fragment, [
-        h(ButtonPrimary, { onClick: dismiss, style: { ...styles.button, marginBottom: '1rem' } }, ['Proceed to Terra on Microsoft Azure Preview']),
-        h(ButtonOutline, { onClick: signOut, style: styles.button }, ['Log Out']),
-      ]) : h(ButtonPrimary, { onClick: signOut, style: styles.button }, ['Log Out']),
-    ])
+    !!isAzurePreviewUser ? h(AzurePreviewForPreviewUser) : h(AzurePreviewForNonPreviewUser),
   ])
 }
 

--- a/src/pages/AzurePreview.js
+++ b/src/pages/AzurePreview.js
@@ -229,6 +229,8 @@ const formInputMap = {
   organization: 'entry.1020670185',
   contactEmail: 'entry.1125156163',
   terraEmail: 'entry.1938956483',
+  useCases: 'entry.768184594',
+  otherUseCase: 'entry.1274069507',
 }
 
 const AzurePreviewForNonPreviewUser = () => {
@@ -260,13 +262,18 @@ const AzurePreviewForNonPreviewUser = () => {
     }
   })
 
-  const submitEnabled = Object.values(userInfo).every(Boolean) && !busy
+  const requiredFields = ['firstName', 'lastName', 'title', 'organization', 'contactEmail', 'terraEmail']
+
+  const submitEnabled = requiredFields.every(field => !!userInfo[field]) && !busy
 
   const submitForm = useCallback(async () => {
     setBusy(true)
     try {
       const formInput = Object.entries(formInputMap)
-        .reduce((acc, [userInfoKey, formFieldId]) => ({ ...acc, [formFieldId]: userInfo[userInfoKey] }), {})
+        .reduce((acc, [userInfoKey, formFieldId]) => ({
+          ...acc,
+          [formFieldId]: userInfoKey === 'useCases' ? userInfo.useCases.join(', ') : userInfo[userInfoKey],
+        }), {})
 
       await Ajax().Surveys.submitForm(formId, formInput)
       setHasSubmittedForm(true)

--- a/src/pages/AzurePreview.js
+++ b/src/pages/AzurePreview.js
@@ -11,7 +11,7 @@ import { reportError } from 'src/libs/error'
 import { FormLabel } from 'src/libs/forms'
 import { getLocalPref, setLocalPref } from 'src/libs/prefs'
 import { useStore } from 'src/libs/react-utils'
-import { authStore, azurePreviewStore } from 'src/libs/state'
+import { authStore, azurePreviewStore, getUser } from 'src/libs/state'
 
 
 const styles = {
@@ -128,6 +128,7 @@ const formInputMap = {
   title: 'titleIdPlaceholder',
   organization: 'organizationIdPlaceholder',
   contactEmail: 'contactEmailIdPlaceholder',
+  terraEmail: 'terraEmailIdPlaceholder',
 }
 
 const AzurePreviewForNonPreviewUser = () => {
@@ -144,6 +145,7 @@ const AzurePreviewForNonPreviewUser = () => {
     title: '',
     organization: '',
     contactEmail: '',
+    terraEmail: getUser().email,
   })
 
   const submitEnabled = Object.values(userInfo).every(Boolean) && !busy

--- a/src/pages/AzurePreview.js
+++ b/src/pages/AzurePreview.js
@@ -121,15 +121,15 @@ const AzurePreviewUserForm = ({ value: formValue, onChange, onSubmit }) => {
   ])
 }
 
-const formId = 'formIdPlaceholder'
+const formId = '1FAIpQLSegf8c7LxlVOS8BLNUrpqkiB7l8L7c135ntdgaBSV2kdrqSAQ'
 
 const formInputMap = {
-  firstName: 'firstNameIdPlaceholder',
-  lastName: 'lastNameIdPlaceholder',
-  title: 'titleIdPlaceholder',
-  organization: 'organizationIdPlaceholder',
-  contactEmail: 'contactEmailIdPlaceholder',
-  terraEmail: 'terraEmailIdPlaceholder',
+  firstName: 'entry.1708226507',
+  lastName: 'entry.677313431',
+  title: 'entry.1500649388',
+  organization: 'entry.1020670185',
+  contactEmail: 'entry.1125156163',
+  terraEmail: 'entry.1938956483',
 }
 
 const AzurePreviewForNonPreviewUser = () => {

--- a/src/pages/AzurePreview.js
+++ b/src/pages/AzurePreview.js
@@ -19,7 +19,6 @@ const styles = {
     alignItems: 'center',
   },
   paragraph: {
-    textAlign: 'center',
     fontSize: 16,
     lineHeight: 1.5,
     maxWidth: 570,
@@ -28,8 +27,6 @@ const styles = {
     display: 'flex',
     marginTop: '3rem',
     marginBotton: '2rem',
-    justifyContent: 'center',
-    alignItems: 'center',
     color: colors.dark(0.8),
     fontSize: '1.8rem',
     fontWeight: 500,
@@ -51,8 +48,10 @@ const AzurePreviewForPreviewUser = () => {
   return h(Fragment, [
     h(AzurePreviewDescription),
 
-    div({ style: { ...styles.centered, marginTop: '1.5rem' } }, [
-      h(ButtonPrimary, { onClick: dismiss, style: { ...styles.button, marginBottom: '1rem' } }, ['Proceed to Terra on Microsoft Azure Preview']),
+    div({ style: { marginTop: '1.5rem' } }, [
+      h(ButtonPrimary, { onClick: dismiss, style: styles.button }, ['Proceed to Terra on Microsoft Azure Preview']),
+    ]),
+    div({ style: { marginTop: '1rem' } }, [
       h(ButtonOutline, { onClick: signOut, style: styles.button }, ['Sign Out']),
     ])
   ])
@@ -146,13 +145,7 @@ const AzurePreviewForNonPreviewUser = () => {
       p({ style: styles.paragraph }, [
         'Thank you for your interest in using Terra on Microsoft Azure. We will be in touch with you shortly with your access information.'
       ]),
-      div({
-        style: {
-          display: 'flex',
-          justifyContent: 'center',
-          marginTop: '1.5rem',
-        }
-      }, [
+      div({ style: { marginTop: '1.5rem' } }, [
         h(ButtonPrimary, { onClick: signOut, style: styles.button }, ['Sign Out']),
       ])
     ]) : div([
@@ -190,10 +183,12 @@ const AzurePreview = () => {
       backgroundRepeat: 'no-repeat', backgroundSize: '750px', backgroundPosition: 'right 0px bottom -600px'
     }
   }, [
-    h(TerraOnAzureLogo, { title: 'Terra on Microsoft Azure - Preview', role: 'img' }),
-    h1({ style: styles.header }, ['Terra on Microsoft Azure - Preview']),
+    div([
+      h(TerraOnAzureLogo, { title: 'Terra on Microsoft Azure - Preview', role: 'img' }),
+      h1({ style: styles.header }, ['Terra on Microsoft Azure - Preview']),
 
-    !!isAzurePreviewUser ? h(AzurePreviewForPreviewUser) : h(AzurePreviewForNonPreviewUser),
+      !!isAzurePreviewUser ? h(AzurePreviewForPreviewUser) : h(AzurePreviewForNonPreviewUser),
+    ]),
   ])
 }
 

--- a/src/pages/AzurePreview.js
+++ b/src/pages/AzurePreview.js
@@ -255,7 +255,7 @@ const AzurePreviewForNonPreviewUser = () => {
       lastName,
       title: '',
       organization: '',
-      contactEmail: user.email,
+      contactEmail: user.email || '',
       terraEmail: user.email,
       useCases: [],
       otherUseCase: '',

--- a/src/pages/AzurePreview.js
+++ b/src/pages/AzurePreview.js
@@ -1,3 +1,4 @@
+import { Fragment } from 'react'
 import { div, h, h1, p } from 'react-hyperscript-helpers'
 import { ButtonOutline, ButtonPrimary, Link } from 'src/components/common'
 import planet from 'src/images/register-planet.svg'
@@ -9,81 +10,72 @@ import { authStore, azurePreviewStore } from 'src/libs/state'
 import * as Utils from 'src/libs/utils'
 
 
+const styles = {
+  centered: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+  },
+  paragraph: {
+    textAlign: 'center',
+    fontSize: 16,
+    lineHeight: 1.5,
+    maxWidth: 570,
+  },
+  header: {
+    display: 'flex',
+    marginTop: '3rem',
+    marginBotton: '2rem',
+    justifyContent: 'center',
+    alignItems: 'center',
+    color: colors.dark(0.8),
+    fontSize: '1.8rem',
+    fontWeight: 500,
+  },
+  button: {
+    textTransform: 'none',
+  },
+}
+
+const supportEmail = 'preview@terra.bio'
+const supportSubject = 'Terra on Microsoft Azure Preview Environment'
+
 const AzurePreview = () => {
-  // State
   const { isAzurePreviewUser } = useStore(authStore)
-
-  // Helpers
-  const styles = {
-    centered: {
-      display: 'flex',
-      justifyContent: 'center',
-      alignItems: 'center'
-    },
-    paragraph: {
-      textAlign: 'center',
-      fontSize: 16,
-      lineHeight: 1.5,
-      maxWidth: 570
-    },
-    header: {
-      display: 'flex',
-      marginTop: '3rem',
-      marginBotton: '2rem',
-      justifyContent: 'center',
-      alignItems: 'center',
-      color: colors.dark(0.8),
-      fontSize: '1.8rem',
-      fontWeight: 500
-    },
-    button: {
-      textTransform: 'none'
-    }
-  }
-
-  const supportEmail = 'preview@terra.bio'
-  const supportSubject = 'Terra on Microsoft Azure Preview Environment'
 
   const dismiss = () => {
     azurePreviewStore.set(true)
   }
 
-  // Render
   return div({
     role: 'main',
     style: {
+      ...styles.centered,
       flexGrow: 1,
       padding: '5rem',
       backgroundImage: `url(${planet})`,
       backgroundRepeat: 'no-repeat', backgroundSize: '750px', backgroundPosition: 'right 0px bottom -600px'
     }
   }, [
-    div({ style: styles.centered }, [
-      h(TerraOnAzureLogo, { title: 'Terra on Microsoft Azure - Preview', role: 'img' })
-    ]),
-    h1({ style: styles.header }, 'Terra on Microsoft Azure - Preview'),
-    div({ style: styles.centered }, [
-      p({ style: styles.paragraph },
-        'This is a preview version of the Terra platform on Microsoft Azure. The public offering of Terra on Microsoft Azure is expected in early 2023.')
+    h(TerraOnAzureLogo, { title: 'Terra on Microsoft Azure - Preview', role: 'img' }),
+    h1({ style: styles.header }, ['Terra on Microsoft Azure - Preview']),
+
+    p({ style: styles.paragraph }, [
+      'This is a preview version of the Terra platform on Microsoft Azure. The public offering of Terra on Microsoft Azure is expected in early 2023.'
     ]),
 
-    isAzurePreviewUser ? undefined : [
-      div({ style: styles.centered }, [
-        p({ style: styles.paragraph }, [
-          'You are not currently part of the Terra on Microsoft Azure Preview Program. If you are interested in joining the program, please contact ',
-          h(Link, { href: `mailto:${supportEmail}?subject=${encodeURIComponent(supportSubject)}`, ...Utils.newTabLinkProps, style: { textDecoration: 'underline' } }, supportEmail),
-          '.'
-        ])
-      ])
-    ],
-    div({ style: { ...styles.centered, marginTop: '1.5rem' } }, [
-      isAzurePreviewUser ?
-        h(ButtonPrimary, { onClick: dismiss, style: styles.button }, 'Proceed to Terra on Microsoft Azure Preview') :
-        h(ButtonPrimary, { onClick: signOut, style: styles.button }, 'Log Out')
+    !isAzurePreviewUser && p({ style: styles.paragraph }, [
+      'You are not currently part of the Terra on Microsoft Azure Preview Program. If you are interested in joining the program, please contact ',
+      h(Link, { href: `mailto:${supportEmail}?subject=${encodeURIComponent(supportSubject)}`, ...Utils.newTabLinkProps, style: { textDecoration: 'underline' } }, [supportEmail]),
+      '.'
     ]),
-    isAzurePreviewUser ? div({ style: { ...styles.centered, marginTop: '1rem' } }, [
-      h(ButtonOutline, { onClick: signOut, style: styles.button }, 'Log Out')
-    ]) : undefined
+
+    div({ style: { ...styles.centered, marginTop: '1.5rem' } }, [
+      !!isAzurePreviewUser ? h(Fragment, [
+        h(ButtonPrimary, { onClick: dismiss, style: { ...styles.button, marginBottom: '1rem' } }, ['Proceed to Terra on Microsoft Azure Preview']),
+        h(ButtonOutline, { onClick: signOut, style: styles.button }, ['Log Out']),
+      ]) : h(ButtonPrimary, { onClick: signOut, style: styles.button }, ['Log Out']),
+    ])
   ])
 }
 

--- a/src/pages/AzurePreview.js
+++ b/src/pages/AzurePreview.js
@@ -179,7 +179,7 @@ const AzurePreviewForNonPreviewUser = () => {
   if (hasSubmittedForm) {
     return h(Fragment, [
       p({ style: styles.paragraph }, [
-        'Thank you for your interest in using Terra on Azure. We will be in touch with you shortly with your access information.'
+        'Thank you for your interest in using Terra on Azure. We will be in touch with your access information soon.'
       ]),
       div({ style: { marginTop: '1.5rem' } }, [
         h(ButtonPrimary, { onClick: signOut, style: styles.button }, ['Sign Out']),

--- a/src/pages/AzurePreview.js
+++ b/src/pages/AzurePreview.js
@@ -1,7 +1,7 @@
 import { Fragment, useCallback, useEffect, useState } from 'react'
 import { div, form, h, h1, p } from 'react-hyperscript-helpers'
 import { ButtonOutline, ButtonPrimary } from 'src/components/common'
-import { TextInput } from 'src/components/input'
+import { ValidatedInput } from 'src/components/input'
 import planet from 'src/images/register-planet.svg'
 import { ReactComponent as TerraOnAzureLogo } from 'src/images/terra-ms-logo.svg'
 import { signOut } from 'src/libs/auth'
@@ -61,6 +61,8 @@ const AzurePreviewForPreviewUser = () => {
 export const submittedPreviewFormPrefKey = 'submitted-azure-preview-form'
 
 const AzurePreviewUserForm = ({ value: formValue, onChange, onSubmit }) => {
+  const [fieldsTouched, setFieldsTouched] = useState({})
+
   const fields = [
     {
       key: 'firstName',
@@ -101,10 +103,16 @@ const AzurePreviewUserForm = ({ value: formValue, onChange, onSubmit }) => {
       const inputId = `azure-preview-interest-${key}`
       return div({ key, style: { width: 250 } }, [
         h(FormLabel, { htmlFor: inputId, required: true }, [label]),
-        h(TextInput, {
-          id: inputId,
-          value: formValue[key],
-          onChange: value => { onChange({ ...formValue, [key]: value }) },
+        h(ValidatedInput, {
+          inputProps: {
+            id: inputId,
+            value: formValue[key],
+            onChange: value => {
+              setFieldsTouched(v => ({ ...v, [key]: true }))
+              onChange({ ...formValue, [key]: value })
+            },
+          },
+          error: fieldsTouched[key] && !formValue[key] ? `${label} is required` : undefined,
         }),
       ])
     }),

--- a/src/pages/AzurePreview.js
+++ b/src/pages/AzurePreview.js
@@ -1,6 +1,7 @@
 import { Fragment, useCallback, useEffect, useState } from 'react'
 import { div, form, h, h1, input, p } from 'react-hyperscript-helpers'
 import { ButtonOutline, ButtonPrimary } from 'src/components/common'
+import { icon } from 'src/components/icons'
 import { ValidatedInput } from 'src/components/input'
 import planet from 'src/images/register-planet.svg'
 import { ReactComponent as TerraOnAzureLogo } from 'src/images/terra-ms-logo.svg'
@@ -200,7 +201,10 @@ const AzurePreviewForNonPreviewUser = () => {
           marginTop: '1.5rem',
         }
       }, [
-        h(ButtonPrimary, { disabled: !submitEnabled, onClick: submitForm, style: styles.button }, ['Submit']),
+        h(ButtonPrimary, { disabled: !submitEnabled, onClick: submitForm, style: styles.button }, [
+          'Submit',
+          busy && icon('loadingSpinner', { size: 12, style: { marginLeft: '1ch' } }),
+        ]),
         h(ButtonOutline, { onClick: signOut, style: styles.button }, ['Sign Out']),
       ])
     ])

--- a/src/pages/AzurePreview.js
+++ b/src/pages/AzurePreview.js
@@ -38,17 +38,15 @@ const styles = {
   },
 }
 
-const AzurePreviewDescription = () => p({ style: styles.paragraph }, [
-  'This is a preview version of the Terra platform on Microsoft Azure. The public offering of Terra on Microsoft Azure is expected in early 2023.'
-])
-
 const AzurePreviewForPreviewUser = () => {
   const dismiss = () => {
     azurePreviewStore.set(true)
   }
 
   return h(Fragment, [
-    h(AzurePreviewDescription),
+    p({ style: styles.paragraph }, [
+      'This is a preview version of the Terra platform on Microsoft Azure.'
+    ]),
 
     div({ style: { marginTop: '1.5rem' } }, [
       h(ButtonPrimary, { onClick: dismiss, style: styles.button }, ['Proceed to Terra on Microsoft Azure Preview']),
@@ -176,18 +174,16 @@ const AzurePreviewForNonPreviewUser = () => {
   }, [userInfo])
 
   return h(Fragment, [
-    h(AzurePreviewDescription),
-
     hasSubmittedForm ? h(Fragment, [
       p({ style: styles.paragraph }, [
-        'Thank you for your interest in using Terra on Microsoft Azure. We will be in touch with you shortly with your access information.'
+        'Thank you for your interest in using Terra on Azure. We will be in touch with you shortly with your access information.'
       ]),
       div({ style: { marginTop: '1.5rem' } }, [
         h(ButtonPrimary, { onClick: signOut, style: styles.button }, ['Sign Out']),
       ])
     ]) : div([
       p({ style: styles.paragraph }, [
-        'You are not currently part of the Terra on Microsoft Azure Preview Program. If you are interested in joining the program, please complete the form below.'
+        'Terra on Azure is currently in preview. Please complete the following form if you are interested in accessing the platform and exploring the capabilities of Terra on Azure.'
       ]),
 
       h(AzurePreviewUserForm, { value: userInfo, onChange: setUserInfo, onSubmit: submitForm }),

--- a/src/pages/AzurePreview.js
+++ b/src/pages/AzurePreview.js
@@ -173,15 +173,17 @@ const AzurePreviewForNonPreviewUser = () => {
     }
   }, [userInfo])
 
-  return h(Fragment, [
-    hasSubmittedForm ? h(Fragment, [
+  if (hasSubmittedForm) {
+    return h(Fragment, [
       p({ style: styles.paragraph }, [
         'Thank you for your interest in using Terra on Azure. We will be in touch with you shortly with your access information.'
       ]),
       div({ style: { marginTop: '1.5rem' } }, [
         h(ButtonPrimary, { onClick: signOut, style: styles.button }, ['Sign Out']),
       ])
-    ]) : div([
+    ])
+  } else {
+    return div([
       p({ style: styles.paragraph }, [
         'Terra on Azure is currently in preview. Please complete the following form if you are interested in accessing the platform and exploring the capabilities of Terra on Azure.'
       ]),
@@ -199,8 +201,8 @@ const AzurePreviewForNonPreviewUser = () => {
         h(ButtonPrimary, { disabled: !submitEnabled, onClick: submitForm, style: styles.button }, ['Submit']),
         h(ButtonOutline, { onClick: signOut, style: styles.button }, ['Sign Out']),
       ])
-    ]),
-  ])
+    ])
+  }
 }
 
 const AzurePreview = () => {

--- a/src/pages/AzurePreview.test.js
+++ b/src/pages/AzurePreview.test.js
@@ -129,6 +129,7 @@ describe('AzurePreview', () => {
           // Act
           await user.type(screen.getByLabelText('Title/Role *'), 'Automated test')
           await user.type(screen.getByLabelText('Organization name *'), 'Terra UI')
+          await user.clear(screen.getByLabelText('Contact email address *'))
           await user.type(screen.getByLabelText('Contact email address *'), 'user@example.com')
 
           // Assert
@@ -155,6 +156,7 @@ describe('AzurePreview', () => {
           await user.type(screen.getByLabelText('Last name *'), 'User')
           await user.type(screen.getByLabelText('Title/Role *'), 'Automated test')
           await user.type(screen.getByLabelText('Organization name *'), 'Terra UI')
+          await user.clear(screen.getByLabelText('Contact email address *'))
           await user.type(screen.getByLabelText('Contact email address *'), 'user@example.com')
 
           // Act

--- a/src/pages/AzurePreview.test.js
+++ b/src/pages/AzurePreview.test.js
@@ -48,15 +48,15 @@ describe('AzurePreview', () => {
       expect(azurePreviewStore.set).toHaveBeenCalledWith(true)
     })
 
-    it('renders a log out button', async () => {
+    it('renders a sign out button', async () => {
       // Arrange
       const user = userEvent.setup()
 
       // Act
       render(h(AzurePreview))
 
-      const logOutButton = screen.getByText('Log Out')
-      await user.click(logOutButton)
+      const signOutButton = screen.getByText('Sign Out')
+      await user.click(signOutButton)
 
       // Assert
       expect(signOut).toHaveBeenCalled()
@@ -79,15 +79,15 @@ describe('AzurePreview', () => {
       expect(supportLink.getAttribute('href')).toEqual(expect.stringContaining('mailto:preview@terra.bio'))
     })
 
-    it('renders a log out button', async () => {
+    it('renders a sign out button', async () => {
       // Arrange
       const user = userEvent.setup()
 
       // Act
       render(h(AzurePreview))
 
-      const logOutButton = screen.getByText('Log Out')
-      await user.click(logOutButton)
+      const signOutButton = screen.getByText('Sign Out')
+      await user.click(signOutButton)
 
       // Assert
       expect(signOut).toHaveBeenCalled()

--- a/src/pages/AzurePreview.test.js
+++ b/src/pages/AzurePreview.test.js
@@ -28,7 +28,10 @@ describe('AzurePreview', () => {
   it('renders different content based on whether the user is a preview user', () => {
     // Act
     const [previewUserContent, nonPreviewUserContent] = [true, false].map(isAzurePreviewUser => {
-      authStore.set({ isAzurePreviewUser })
+      authStore.set({
+        user: { email: 'user@organization.name' },
+        isAzurePreviewUser,
+      })
       const { container, unmount } = render(h(AzurePreview))
       const content = container.innerHTML
       unmount()
@@ -77,7 +80,10 @@ describe('AzurePreview', () => {
 
   describe('for non-preview users', () => {
     beforeAll(() => {
-      authStore.set({ isAzurePreviewUser: false })
+      authStore.set({
+        user: { email: 'user@organization.name' },
+        isAzurePreviewUser: false
+      })
     })
 
     describe('for users who have not submitted the form', () => {
@@ -159,7 +165,7 @@ describe('AzurePreview', () => {
         it('submits user info', () => {
           expect(submitForm).toHaveBeenCalledWith(expect.any(String), expect.any(Object))
           const formInput = submitForm.mock.calls[0][1]
-          expect(Object.values(formInput)).toEqual(expect.arrayContaining(['A', 'User', 'Automated test', 'Terra UI', 'user@example.com']))
+          expect(Object.values(formInput)).toEqual(expect.arrayContaining(['A', 'User', 'Automated test', 'Terra UI', 'user@example.com', 'user@organization.name']))
         })
 
         it('hides the form', () => {

--- a/src/pages/AzurePreview.test.js
+++ b/src/pages/AzurePreview.test.js
@@ -177,7 +177,7 @@ describe('AzurePreview', () => {
 
         it('shows a thank you message', () => {
           // Assert
-          screen.getByText('Thank you for your interest in using Terra on Azure. We will be in touch with you shortly with your access information.')
+          screen.getByText('Thank you for your interest in using Terra on Azure. We will be in touch with your access information soon.')
         })
 
         it('saves submission status', () => {
@@ -196,7 +196,7 @@ describe('AzurePreview', () => {
         render(h(AzurePreview))
 
         // Assert
-        screen.getByText('Thank you for your interest in using Terra on Azure. We will be in touch with you shortly with your access information.')
+        screen.getByText('Thank you for your interest in using Terra on Azure. We will be in touch with your access information soon.')
       })
 
       it('does not render the form', () => {

--- a/src/pages/AzurePreview.test.js
+++ b/src/pages/AzurePreview.test.js
@@ -96,7 +96,7 @@ describe('AzurePreview', () => {
         render(h(AzurePreview))
 
         // Assert
-        screen.getByText('You are not currently part of the Terra on Microsoft Azure Preview Program. If you are interested in joining the program, please complete the form below.')
+        screen.getByText('Terra on Azure is currently in preview. Please complete the following form if you are interested in accessing the platform and exploring the capabilities of Terra on Azure.')
       })
 
       it('renders the form', () => {
@@ -177,7 +177,7 @@ describe('AzurePreview', () => {
 
         it('shows a thank you message', () => {
           // Assert
-          screen.getByText('Thank you for your interest in using Terra on Microsoft Azure. We will be in touch with you shortly with your access information.')
+          screen.getByText('Thank you for your interest in using Terra on Azure. We will be in touch with you shortly with your access information.')
         })
 
         it('saves submission status', () => {
@@ -196,7 +196,7 @@ describe('AzurePreview', () => {
         render(h(AzurePreview))
 
         // Assert
-        screen.getByText('Thank you for your interest in using Terra on Microsoft Azure. We will be in touch with you shortly with your access information.')
+        screen.getByText('Thank you for your interest in using Terra on Azure. We will be in touch with you shortly with your access information.')
       })
 
       it('does not render the form', () => {

--- a/src/pages/AzurePreview.test.js
+++ b/src/pages/AzurePreview.test.js
@@ -96,7 +96,7 @@ describe('AzurePreview', () => {
         render(h(AzurePreview))
 
         // Assert
-        screen.getByText('Terra on Azure is currently in preview. Please complete the following form if you are interested in accessing the platform and exploring the capabilities of Terra on Azure.')
+        screen.getByText('Terra on Microsoft Azure is currently in preview. Please complete the following form if you are interested in accessing the platform and exploring the capabilities of Terra on Microsoft Azure.')
       })
 
       it('renders the form', () => {
@@ -177,7 +177,7 @@ describe('AzurePreview', () => {
 
         it('shows a thank you message', () => {
           // Assert
-          screen.getByText('Thank you for your interest in using Terra on Azure. We will be in touch with your access information soon.')
+          screen.getByText('Thank you for your interest in using Terra on Microsoft Azure. We will be in touch with your access information soon.')
         })
 
         it('saves submission status', () => {
@@ -196,7 +196,7 @@ describe('AzurePreview', () => {
         render(h(AzurePreview))
 
         // Assert
-        screen.getByText('Thank you for your interest in using Terra on Azure. We will be in touch with your access information soon.')
+        screen.getByText('Thank you for your interest in using Terra on Microsoft Azure. We will be in touch with your access information soon.')
       })
 
       it('does not render the form', () => {

--- a/src/pages/AzurePreview.test.js
+++ b/src/pages/AzurePreview.test.js
@@ -1,0 +1,96 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { h } from 'react-hyperscript-helpers'
+import { signOut } from 'src/libs/auth'
+import { authStore, azurePreviewStore } from 'src/libs/state'
+
+import AzurePreview from './AzurePreview'
+
+
+jest.mock('src/libs/auth', () => ({
+  ...jest.requireActual('src/libs/auth'),
+  signOut: jest.fn(),
+}))
+
+describe('AzurePreview', () => {
+  it('renders different content based on whether the user is a preview user', () => {
+    // Act
+    const [previewUserContent, nonPreviewUserContent] = [true, false].map(isAzurePreviewUser => {
+      authStore.set({ isAzurePreviewUser })
+      const { container, unmount } = render(h(AzurePreview))
+      const content = container.innerHTML
+      unmount()
+      return content
+    })
+
+    // Assert
+    expect(previewUserContent).not.toBe(nonPreviewUserContent)
+  })
+
+  describe('for preview users', () => {
+    beforeAll(() => {
+      authStore.set({ isAzurePreviewUser: true })
+    })
+
+    it('renders a button to proceed to Terra', async () => {
+      // Arrange
+      const user = userEvent.setup()
+
+      jest.spyOn(azurePreviewStore, 'set')
+
+      // Act
+      render(h(AzurePreview))
+
+      const proceedToTerraButton = screen.getByText('Proceed to Terra on Microsoft Azure Preview')
+      await user.click(proceedToTerraButton)
+
+      // Assert
+      expect(azurePreviewStore.set).toHaveBeenCalledWith(true)
+    })
+
+    it('renders a log out button', async () => {
+      // Arrange
+      const user = userEvent.setup()
+
+      // Act
+      render(h(AzurePreview))
+
+      const logOutButton = screen.getByText('Log Out')
+      await user.click(logOutButton)
+
+      // Assert
+      expect(signOut).toHaveBeenCalled()
+    })
+  })
+
+  describe('for non-preview users', () => {
+    beforeAll(() => {
+      authStore.set({ isAzurePreviewUser: false })
+    })
+
+    it('renders a message and a link to email support', () => {
+      // Act
+      render(h(AzurePreview))
+
+      // Assert
+      screen.getByText(/You are not currently part of the Terra on Microsoft Azure Preview Program/)
+
+      const supportLink = screen.getByText('preview@terra.bio')
+      expect(supportLink.getAttribute('href')).toEqual(expect.stringContaining('mailto:preview@terra.bio'))
+    })
+
+    it('renders a log out button', async () => {
+      // Arrange
+      const user = userEvent.setup()
+
+      // Act
+      render(h(AzurePreview))
+
+      const logOutButton = screen.getByText('Log Out')
+      await user.click(logOutButton)
+
+      // Assert
+      expect(signOut).toHaveBeenCalled()
+    })
+  })
+})

--- a/src/pages/AzurePreview.test.js
+++ b/src/pages/AzurePreview.test.js
@@ -95,6 +95,35 @@ describe('AzurePreview', () => {
         screen.getByRole('form')
       })
 
+      describe('form validation', () => {
+        it('requires a value for all fields', async () => {
+          // Arrange
+          const user = userEvent.setup()
+
+          render(h(AzurePreview))
+
+          const isSubmitEnabled = () => screen.getByText('Submit').getAttribute('aria-disabled') === 'false'
+
+          // Assert
+          expect(isSubmitEnabled()).toBe(false)
+
+          // Act
+          await user.type(screen.getByLabelText('First name *'), 'A')
+          await user.type(screen.getByLabelText('Last name *'), 'User')
+
+          // Assert
+          expect(isSubmitEnabled()).toBe(false)
+
+          // Act
+          await user.type(screen.getByLabelText('Title/Role *'), 'Automated test')
+          await user.type(screen.getByLabelText('Organization name *'), 'Terra UI')
+          await user.type(screen.getByLabelText('Contact email address *'), 'user@example.com')
+
+          // Assert
+          expect(isSubmitEnabled()).toBe(true)
+        })
+      })
+
       describe('submitting the form', () => {
         let user
 
@@ -103,6 +132,12 @@ describe('AzurePreview', () => {
           user = userEvent.setup()
 
           render(h(AzurePreview))
+
+          await user.type(screen.getByLabelText('First name *'), 'A')
+          await user.type(screen.getByLabelText('Last name *'), 'User')
+          await user.type(screen.getByLabelText('Title/Role *'), 'Automated test')
+          await user.type(screen.getByLabelText('Organization name *'), 'Terra UI')
+          await user.type(screen.getByLabelText('Contact email address *'), 'user@example.com')
 
           // Act
           const submitButton = screen.getByText('Submit')


### PR DESCRIPTION
In order to use Terra with a Microsoft account, users must be added to an allow list of "preview users".

Currently, when a user who's not in the allow list logs into Terra with a Microsoft account, they are prompted to email Support if they want access. To streamline this process, this changes the splash screen to show a form prompting them for some information. Responses are sent to a Google Form/Sheet that Support can use to contact them with their access information.

## Registered preview user

Preview users have to click through this screen once.

<img width="643" alt="splash" src="https://user-images.githubusercontent.com/1156625/214351037-649e9666-2c1e-4a63-a39a-2ea275b0f015.png">

## Other users

Other users are prompted with the form. The name and contact email are pre-populated from their account information. Once they fill out the form, they're shown a confirmation message. We save the fact that they have filled out the form in local storage so that if they visit Terra again, they're not prompted for the same information again.

<img width="813" alt="form" src="https://user-images.githubusercontent.com/1156625/214351079-cc132d64-bf0b-4962-8cf3-3b69cef75b42.png">

<img width="819" alt="confirmation" src="https://user-images.githubusercontent.com/1156625/214351116-d55007e4-fe4a-45d2-b306-f3e7bd564d99.png">

## Notes for reviewers

There's not a great way to mock "not a preview user" if you are a preview user. During development, I did this by changing a line in the AzurePreview component.
```js
// const { isAzurePreviewUser } = useStore(authStore)
isAzurePreviewUser = false
```

There are also some local storage entries that control what's shown that you may want to clear while testing.
- `dynamic-storage/${userId}/submitted-azure-preview-form` is set when a non-preview user submits the form.
- `azurePreview` is set when a preview user clicks through the splash screen.

## ajax changes

This also makes a change to `fetchGoogleForms` and Ajax.Surveys. Currently, Ajax.Surveys ignores all errors from requests to Google Forms. I suspect the reason for that is because Google Forms does not return a CORS header that allows Terra to access the response, so `fetchOk` throws when trying to read `response.ok`. As an alternative, we can send the request in ["no-cors" mode](https://developer.mozilla.org/en-US/docs/Web/API/Request/mode) and treat the response as "opaque" (and not access `response.ok`). This allows us to handle some types of errors (errors sending the request, like failed to connect, etc.) instead of ignoring _all_ errors.