### PR TITLE
[IA-3978] Remove noise from AnalysisModal test

### DIFF
--- a/src/pages/workspaces/workspace/analysis/modals/AnalysisModal.test.ts
+++ b/src/pages/workspaces/workspace/analysis/modals/AnalysisModal.test.ts
@@ -78,6 +78,7 @@ const getTestFile = (abs: AbsolutePath, cloudProvider: CloudProviderType = cloud
   cloudProvider
 })
 
+type AjaxContract = ReturnType<typeof Ajax>
 
 describe('AnalysisModal', () => {
   beforeEach(() => {
@@ -89,11 +90,12 @@ describe('AnalysisModal', () => {
       pendingCreate: { status: 'Ready', state: true }
     }))
 
-    //@ts-expect-error
-    Ajax.mockImplementation(() => ({
-      Buckets: { getObjectPreview: () => Promise.resolve({ json: () => Promise.resolve(imageDocs) }) },
-      Metrics: { captureEvent: jest.fn() },
-    }))
+    asMockedFn(Ajax).mockImplementation(() => ({
+      Buckets: {
+        getObjectPreview: () => Promise.resolve({ json: () => Promise.resolve(imageDocs) }),
+      } as Partial<AjaxContract['Buckets']>,
+      Metrics: { captureEvent: jest.fn() } as Partial<AjaxContract['Metrics']>,
+    }) as Partial<AjaxContract> as AjaxContract)
   })
 
   it('GCP - Renders correctly by default', () => {

--- a/src/pages/workspaces/workspace/analysis/modals/AnalysisModal.test.ts
+++ b/src/pages/workspaces/workspace/analysis/modals/AnalysisModal.test.ts
@@ -19,7 +19,7 @@ import {
 import { AppTool, getToolLabelFromFileExtension, ToolLabel, tools } from 'src/pages/workspaces/workspace/analysis/tool-utils'
 import { asMockedFn } from 'src/testing/test-utils'
 
-import { defaultAzureWorkspace, defaultGoogleWorkspace, galaxyDisk, galaxyRunning, getGoogleRuntime } from '../_testData/testData'
+import { defaultAzureWorkspace, defaultGoogleWorkspace, galaxyDisk, galaxyRunning, getGoogleRuntime, imageDocs } from '../_testData/testData'
 import { AnalysisModal, AnalysisModalProps } from './AnalysisModal'
 
 
@@ -90,7 +90,10 @@ describe('AnalysisModal', () => {
     }))
 
     //@ts-expect-error
-    Ajax.mockImplementation(() => ({ Metrics: { captureEvent: jest.fn() } }))
+    Ajax.mockImplementation(() => ({
+      Buckets: { getObjectPreview: () => Promise.resolve({ json: () => Promise.resolve(imageDocs) }) },
+      Metrics: { captureEvent: jest.fn() },
+    }))
   })
 
   it('GCP - Renders correctly by default', () => {


### PR DESCRIPTION
https://github.com/DataBiosphere/terra-ui/pull/3669 added a console log to the reportError function.

This has revealed several errors that are occurring in AnalysisModal unit tests.

When running unit tests, an error `Error loading cloud environment TypeError: Cannot read properties of undefined (reading ‘getObjectPreview')` is thrown multiple times in AnalysisModal tests. This fills the logs with noise, making them more difficult to read.

This copies the mock for `getObjectPreview` from ComputeModal tests to AnalysisModal tests. It also replaces a `ts-expect-error` with casts.