### PR TITLE
[AJ-770] add cloudPlatform property to WDS Mixpanel events

### DIFF
--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -21,6 +21,7 @@ import { UriViewerLink } from 'src/components/UriViewer'
 import ReferenceData from 'src/data/reference-data'
 import { Ajax } from 'src/libs/ajax'
 import { canUseWorkspaceProject } from 'src/libs/ajax/Billing'
+import { wdsProviderName } from 'src/libs/ajax/data-table-providers/WdsDataTableProvider'
 import { defaultAzureRegion, getRegionLabel } from 'src/libs/azure-utils'
 import colors from 'src/libs/colors'
 import { reportError } from 'src/libs/error'
@@ -30,6 +31,7 @@ import { notify } from 'src/libs/notifications'
 import { requesterPaysProjectStore } from 'src/libs/state'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
+import { cloudProviders } from 'src/pages/workspaces/workspace/analysis/runtime-utils'
 import validate from 'validate.js'
 
 
@@ -326,7 +328,8 @@ export const EntityUploader = ({ onSuccess, onDismiss, namespace, name, entityTy
       await dataProvider.uploadTsv({ workspaceId, recordType, file, useFireCloudDataModel, deleteEmptyValues, namespace, name })
       onSuccess()
       Ajax().Metrics.captureEvent(Events.workspaceDataUpload, {
-        workspaceNamespace: namespace, workspaceName: name, providerName: dataProvider.providerName
+        workspaceNamespace: namespace, workspaceName: name, providerName: dataProvider.providerName,
+        cloudPlatform: dataProvider.providerName === wdsProviderName ? cloudProviders.azure.label : cloudProviders.gcp.label
       })
     } catch (error) {
       await reportError('Error uploading entities', error)
@@ -523,7 +526,8 @@ export const EntityUploader = ({ onSuccess, onDismiss, namespace, name, entityTy
               href: dataProvider.tsvFeatures.sampleTSVLink,
               ...Utils.newTabLinkProps,
               onClick: () => Ajax().Metrics.captureEvent(Events.workspaceSampleTsvDownload, {
-                workspaceNamespace: namespace, workspaceName: name, providerName: dataProvider.providerName
+                workspaceNamespace: namespace, workspaceName: name, providerName: dataProvider.providerName,
+                cloudPlatform: dataProvider.providerName === wdsProviderName ? cloudProviders.azure.label : cloudProviders.gcp.label
               })
             }, ['sample_template.tsv '])
           ]),

--- a/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
+++ b/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
@@ -103,13 +103,15 @@ export const getWdsUrl = apps => {
   return candidates[0].proxyUrls.wds
 }
 
+export const wdsProviderName: string = 'WDS'
+
 export class WdsDataTableProvider implements DataTableProvider {
   constructor(workspaceId: string) {
     this.workspaceId = workspaceId
     this.proxyUrlPromise = Ajax().Apps.getV2AppInfo(workspaceId).then(getWdsUrl)
   }
 
-  providerName: string = 'WDS'
+  providerName: string = wdsProviderName
 
   proxyUrlPromise: Promise<string>
 

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -27,7 +27,7 @@ import { FlexTable, HeaderCell } from 'src/components/table'
 import { SnapshotInfo } from 'src/components/workspace-utils'
 import { Ajax } from 'src/libs/ajax'
 import { EntityServiceDataTableProvider } from 'src/libs/ajax/data-table-providers/EntityServiceDataTableProvider'
-import { WdsDataTableProvider } from 'src/libs/ajax/data-table-providers/WdsDataTableProvider'
+import { WdsDataTableProvider, wdsProviderName } from 'src/libs/ajax/data-table-providers/WdsDataTableProvider'
 import colors from 'src/libs/colors'
 import { getConfig } from 'src/libs/config'
 import { dataTableVersionsPathRoot, useDataTableVersions } from 'src/libs/data-table-versions'
@@ -41,6 +41,7 @@ import { asyncImportJobStore, getUser } from 'src/libs/state'
 import * as StateHistory from 'src/libs/state-history'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
+import { cloudProviders } from 'src/pages/workspaces/workspace/analysis/runtime-utils'
 import { wrapWorkspace } from 'src/pages/workspaces/workspace/WorkspaceContainer'
 
 
@@ -340,6 +341,7 @@ const DataTableActions = ({ workspace, tableName, rowCount, entityMetadata, onRe
             Ajax().Metrics.captureEvent(Events.workspaceDataDownload, {
               ...extractWorkspaceDetails(workspace.workspace),
               providerName: dataProvider.providerName,
+              cloudPlatform: dataProvider.providerName === wdsProviderName ? cloudProviders.azure.label : cloudProviders.gcp.label,
               downloadFrom: 'all rows',
               fileType: '.tsv'
             })
@@ -430,7 +432,8 @@ const DataTableActions = ({ workspace, tableName, rowCount, entityMetadata, onRe
           await dataProvider.deleteTable(tableName)
           Ajax().Metrics.captureEvent(Events.workspaceDataDeleteTable, {
             ...extractWorkspaceDetails(workspace.workspace),
-            providerName: dataProvider.providerName
+            providerName: dataProvider.providerName,
+            cloudPlatform: dataProvider.providerName === wdsProviderName ? cloudProviders.azure.label : cloudProviders.gcp.label
           })
           setDeleting(false)
           onDeleteTable(tableName)


### PR DESCRIPTION
Adds the `cloudPlatform` property to the Mixpanel events logged in WDS code. I kept the `providerName` property in place. Currently, `cloudPlatform` and `providerName` are totally in sync with each other, but in the future when we port WDS back to GCP, these will be independent.

Tested all four events locally for both GCP and Azure.