### PR TITLE
[QA-2039] Disable run-workflow test

### DIFF
--- a/integration-tests/tests/run-workflow.js
+++ b/integration-tests/tests/run-workflow.js
@@ -46,5 +46,6 @@ const testRunWorkflowFn = _.flow(
 registerTest({
   name: 'run-workflow',
   fn: testRunWorkflowFn,
-  timeout: 20 * 60 * 1000
+  timeout: 20 * 60 * 1000,
+  targetEnvironments: [], // See QA-2039
 })


### PR DESCRIPTION
run-workflow is consistently failing because the workflow fails.
https://app.circleci.com/pipelines/github/DataBiosphere/terra-ui

This disables (at least temporarily) to unblock release automation.