### PR TITLE
[SU-272] Fix cloud platform icon for Azure featured workspaces

### DIFF
--- a/src/pages/library/Showcase.js
+++ b/src/pages/library/Showcase.js
@@ -83,7 +83,7 @@ const WorkspaceCard = ({ workspace }) => {
         created && div([Utils.makeStandardDate(created)]),
         (cloudPlatform === 'Azure' || cloudPlatform === 'Gcp') && h(CloudProviderIcon, {
           cloudProvider: {
-            Azure: cloudProviderTypes.Azure,
+            Azure: cloudProviderTypes.AZURE,
             Gcp: cloudProviderTypes.GCP,
           }[cloudPlatform],
           style: { marginLeft: '1ch' },


### PR DESCRIPTION
Fixup for #3687. The case of the key used to access `cloudProviderTypes` is incorrect, which currently causes a render error if there are any Azure featured workspaces in showcase.json.

https://github.com/DataBiosphere/terra-ui/blob/e3b56c622dcbd2ad698cfb14380339eada185342/src/libs/workspace-utils.ts#L3-L6

Maybe I should have converted this file to TypeScript.

