### PR TITLE
[SU-280 follow up] Small changes to the Azure preview form

### DIFF
--- a/src/pages/AzurePreview.js
+++ b/src/pages/AzurePreview.js
@@ -263,8 +263,9 @@ const AzurePreviewForNonPreviewUser = () => {
   })
 
   const requiredFields = ['firstName', 'lastName', 'title', 'organization', 'contactEmail', 'terraEmail']
+  const useCasesChecked = !!userInfo['otherUseCase'] || userInfo['useCases'].length > 0
 
-  const submitEnabled = requiredFields.every(field => !!userInfo[field]) && !busy
+  const submitEnabled = requiredFields.every(field => !!userInfo[field]) && useCasesChecked && !busy
 
   const submitForm = useCallback(async () => {
     setBusy(true)
@@ -287,7 +288,7 @@ const AzurePreviewForNonPreviewUser = () => {
   if (hasSubmittedForm) {
     return h(Fragment, [
       p({ style: styles.paragraph }, [
-        'Thank you for your interest in using Terra on Microsoft Azure. We will be in touch with your access information soon.'
+        'Thank you for your interest in using Terra on Microsoft Azure. We will be in touch with your access information.'
       ]),
       div({ style: { marginTop: '1.5rem' } }, [
         h(ButtonPrimary, { onClick: signOut, style: styles.button }, ['Sign Out']),

--- a/src/pages/AzurePreview.js
+++ b/src/pages/AzurePreview.js
@@ -129,7 +129,7 @@ const AzurePreviewUserForm = ({ value: formValue, onChange, onSubmit }) => {
 
     fieldset({ style: { padding: 0, border: 'none', margin: '2rem 0 0' } }, [
       h(FormLegend, { style: { marginBottom: '1rem' } }, [
-        'What do you want to do in Terra?',
+        'What do you want to do in Terra? *',
         span({ style: { fontSize: '14px', fontStyle: 'italic', fontWeight: 400 } }, [' Please select all that apply']),
       ]),
 
@@ -310,7 +310,7 @@ const AzurePreviewForNonPreviewUser = () => {
           marginTop: '1.5rem',
         }
       }, [
-        h(ButtonPrimary, { disabled: !submitEnabled, onClick: submitForm, style: styles.button }, [
+        h(ButtonPrimary, { disabled: !submitEnabled, onClick: submitForm, style: styles.button, tooltip: submitEnabled ? '' : 'Please fill out all required fields' }, [
           'Submit',
           busy && icon('loadingSpinner', { size: 12, style: { marginLeft: '1ch' } }),
         ]),

--- a/src/pages/AzurePreview.test.js
+++ b/src/pages/AzurePreview.test.js
@@ -136,7 +136,7 @@ describe('AzurePreview', () => {
           expect(isSubmitEnabled()).toBe(false)
 
           // Act
-          await user.click(screen.getByLabelText('Launch workflows'))
+          await user.click(screen.getByText('Launch workflows'))
 
           // Assert
           expect(isSubmitEnabled()).toBe(true)
@@ -164,7 +164,7 @@ describe('AzurePreview', () => {
           await user.type(screen.getByLabelText('Organization name *'), 'Terra UI')
           await user.clear(screen.getByLabelText('Contact email address *'))
           await user.type(screen.getByLabelText('Contact email address *'), 'user@example.com')
-          await user.click(screen.getByLabelText('Launch workflows'))
+          await user.click(screen.getByText('Launch workflows'))
 
           // Act
           const submitButton = screen.getByText('Submit')

--- a/src/pages/AzurePreview.test.js
+++ b/src/pages/AzurePreview.test.js
@@ -177,7 +177,7 @@ describe('AzurePreview', () => {
 
         it('shows a thank you message', () => {
           // Assert
-          screen.getByText('Thank you for your interest in using Terra on Microsoft Azure. We will be in touch with your access information soon.')
+          screen.getByText('Thank you for your interest in using Terra on Microsoft Azure. We will be in touch with your access information.')
         })
 
         it('saves submission status', () => {
@@ -196,7 +196,7 @@ describe('AzurePreview', () => {
         render(h(AzurePreview))
 
         // Assert
-        screen.getByText('Thank you for your interest in using Terra on Microsoft Azure. We will be in touch with your access information soon.')
+        screen.getByText('Thank you for your interest in using Terra on Microsoft Azure. We will be in touch with your access information.')
       })
 
       it('does not render the form', () => {

--- a/src/pages/AzurePreview.test.js
+++ b/src/pages/AzurePreview.test.js
@@ -133,6 +133,12 @@ describe('AzurePreview', () => {
           await user.type(screen.getByLabelText('Contact email address *'), 'user@example.com')
 
           // Assert
+          expect(isSubmitEnabled()).toBe(false)
+
+          // Act
+          await user.click(screen.getByLabelText('Launch workflows'))
+
+          // Assert
           expect(isSubmitEnabled()).toBe(true)
         })
       })
@@ -158,6 +164,7 @@ describe('AzurePreview', () => {
           await user.type(screen.getByLabelText('Organization name *'), 'Terra UI')
           await user.clear(screen.getByLabelText('Contact email address *'))
           await user.type(screen.getByLabelText('Contact email address *'), 'user@example.com')
+          await user.click(screen.getByLabelText('Launch workflows'))
 
           // Act
           const submitButton = screen.getByText('Submit')
@@ -167,7 +174,7 @@ describe('AzurePreview', () => {
         it('submits user info', () => {
           expect(submitForm).toHaveBeenCalledWith(expect.any(String), expect.any(Object))
           const formInput = submitForm.mock.calls[0][1]
-          expect(Object.values(formInput)).toEqual(expect.arrayContaining(['A', 'User', 'Automated test', 'Terra UI', 'user@example.com', 'user@organization.name']))
+          expect(Object.values(formInput)).toEqual(expect.arrayContaining(['A', 'User', 'Automated test', 'Terra UI', 'user@example.com', 'user@organization.name', 'Launch workflows']))
         })
 
         it('hides the form', () => {


### PR DESCRIPTION
These were both requests from Ilyana by email, as she was testing out the form.

1. Make answering the `What do you want to do in Terra?` question mandatory. The reason is we are gating access on whether they want to perform interactive or batch analysis, so want to make sure we collect that information.

2. Removed `soon` "to be safe". 😂 

Tested the checkbox behavior:

A. Nothing checked, submit disabled:
<img width="837" alt="image" src="https://user-images.githubusercontent.com/5368863/214448253-adddfe4a-ed83-45c5-aeb3-c6978d438750.png">

B. Use case checked, submit enabled:
<img width="890" alt="image" src="https://user-images.githubusercontent.com/5368863/214448278-94a67c92-588e-463c-8e4d-6f5b8f81ffbe.png">

C. Other use case checked, submit enabled:
<img width="869" alt="image" src="https://user-images.githubusercontent.com/5368863/214448344-6ab7daf5-3334-4897-99a2-b63e91bbfc97.png">

