### PR TITLE
billingAccountErrorMessage has been renamed (WOR-701).

### DIFF
--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -84,7 +84,7 @@ const ExpandedInfoRow = ({ title, details, errorMessage }) => {
 }
 
 const WorkspaceCard = memoWithName('WorkspaceCard', ({ workspace, billingProject, billingAccountStatus, isExpanded, onExpand }) => {
-  const { namespace, name, createdBy, lastModified, googleProject, billingAccountDisplayName, billingAccountErrorMessage } = workspace
+  const { namespace, name, createdBy, lastModified, googleProject, billingAccountDisplayName, errorMessage } = workspace
   const workspaceCardStyles = {
     field: {
       ...Style.noWrapEllipsis, flex: 1, height: '1.20rem', width: `calc(50% - ${(workspaceLastModifiedWidth + workspaceExpandIconSize) / 2}px)`, paddingRight: '1rem'
@@ -135,7 +135,7 @@ const WorkspaceCard = memoWithName('WorkspaceCard', ({ workspace, billingProject
       isExpanded && div({ id, style: { ...workspaceCardStyles.row, padding: '0.5rem', border: `1px solid ${colors.light()}` } }, [
         div({ style: workspaceCardStyles.expandedInfoContainer }, [
           billingProject.cloudPlatform === cloudProviders.gcp.label && h(ExpandedInfoRow, { title: 'Google Project', details: googleProject }),
-          billingProject.cloudPlatform === cloudProviders.gcp.label && h(ExpandedInfoRow, { title: 'Billing Account', details: billingAccountDisplayName, errorMessage: billingAccountErrorMessage }),
+          billingProject.cloudPlatform === cloudProviders.gcp.label && h(ExpandedInfoRow, { title: 'Billing Account', details: billingAccountDisplayName, errorMessage }),
           billingProject.cloudPlatform === cloudProviders.azure.label && h(ExpandedInfoRow, { title: 'Resource Group ID', details: billingProject.managedAppCoordinates.managedResourceGroupId })
         ])
       ])
@@ -182,7 +182,7 @@ const BillingAccountSummaryPanel = ({ counts: { done, error, updating } }) => {
 const groupByBillingAccountStatus = (billingProject, workspaces) => {
   const group = workspace => Utils.cond(
     [billingProject.billingAccount === workspace.billingAccount, () => 'done'],
-    [!!workspace.billingAccountErrorMessage, () => 'error'],
+    [!!workspace.errorMessage, () => 'error'],
     [Utils.DEFAULT, () => 'updating']
   )
 


### PR DESCRIPTION
The Rawls API is returning both `errorMessage` and `billingAccountErrorMessage` during the transition period.

I don't have any workspaces with an errorMessage in a billing project that I have access to, but I hacked the return response from locally running Rawls to contain a bogus error in the response.

<img width="1781" alt="image" src="https://user-images.githubusercontent.com/484484/215230114-99c8042d-8f7e-4056-9cbb-ec3c25743d4c.png">

