### PR TITLE
on Data tab, only auto-deploy WDS for owner/creator

### DIFF
--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -480,7 +480,7 @@ const WorkspaceData = _.flow(
     breadcrumbs: props => breadcrumbs.commonPaths.workspaceDashboard(props),
     title: 'Data', activeTab: 'data'
   })
-)(({ namespace, name, workspace, workspace: { workspace: { googleProject, attributes, workspaceId } }, refreshWorkspace }, ref) => {
+)(({ namespace, name, workspace, workspace: { workspace: { createdBy, googleProject, attributes, workspaceId } }, refreshWorkspace }, ref) => {
   // State
   const [refreshKey, setRefreshKey] = useState(0)
   const forceRefresh = () => setRefreshKey(_.add(1))
@@ -512,7 +512,11 @@ const WorkspaceData = _.flow(
 
   const entityServiceDataTableProvider = new EntityServiceDataTableProvider(namespace, name)
 
-  const wdsDataTableProvider = useMemo(() => new WdsDataTableProvider(workspaceId), [workspaceId])
+  // auto-deploy WDS for a user who is: 1) the workspace creator, and 2) still an OWNER of the workspace
+  // TODO: pass this `autoDeployWds` variable into WdsDataTableProvider and respect it in resolveWdsUrl
+  const autoDeployWds = workspace?.accessLevel === 'OWNER' && createdBy === getUser()?.email
+
+  const wdsDataTableProvider = useMemo(() => new WdsDataTableProvider(workspaceId, autoDeployWds), [workspaceId, autoDeployWds])
 
   const loadEntityMetadata = async () => {
     try {


### PR DESCRIPTION
note: this is a code suggestion for #3709, it is not a PR that will be merged to dev!

---

@aaronkanzer I think this will isolate the logic you're working on in #3709 to the right user. The `autoDeployWds` boolean in this PR is only true if the current user is the same user who created the workspace - and that user still has OWNER permissions.

I have NOT done anything inside of `WdsDataTableProvider` to look at the `autoDeployWds` argument and conditionally deploy/not deploy … leaving that up to you!