### PR TITLE
AJ-807: troubleshooter tweak for app-not-found

### DIFF
--- a/src/components/data/WdsTroubleshooter.js
+++ b/src/components/data/WdsTroubleshooter.js
@@ -32,8 +32,8 @@ export const WdsTroubleshooter = ({ onDismiss, workspaceId, mrgId }) => {
       setLeoOk(res)
       const foundApp = resolveWdsApp(res)
       setAppFound(foundApp?.appName)
-      setAppRunning(foundApp?.status)
-      setProxyUrl(foundApp?.proxyUrls?.wds)
+      setAppRunning(!!foundApp?.appName ? foundApp?.status : 'unknown')
+      setProxyUrl(!!foundApp?.appName ? foundApp?.proxyUrls?.wds : 'unknown')
       Ajax(signal).WorkspaceData.getVersion(foundApp?.proxyUrls?.wds).then(res => {
         setWdsResponsive(true)
         setVersion(res.git?.commit?.id)


### PR DESCRIPTION
If the WDS Troubleshooter finds 0 apps in RUNNING | PROVISIONING | STOPPED | STOPPING, it will show an infinite spinner for two fields:
![Screenshot 1-30-2023 at 05 52 PM](https://user-images.githubusercontent.com/6041577/215615966-ffd18aa6-a63b-4293-b6a9-b72cd3692f16.png)

This PR fixes that to show "unknown" for those fields.
![Screenshot 1-30-2023 at 05 54 PM](https://user-images.githubusercontent.com/6041577/215616006-6de2fc64-0234-4788-ad15-770af4a46115.png)

In a future PR, we may want to show that the app found by the troubleshooter is in ERROR state, but this PR is an interim fix to stop the infinite spinners.