### PR TITLE
AJ-837: disable auto-deploy of WDS from Data tab

### DIFF
--- a/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
+++ b/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
@@ -12,7 +12,6 @@ import {
 } from 'src/libs/ajax/data-table-providers/DataTableProvider'
 import { withErrorReporting } from 'src/libs/error'
 import * as Utils from 'src/libs/utils'
-import { v4 as uuid } from 'uuid'
 
 // interface definitions for WDS payload responses
 interface AttributeSchema {
@@ -127,7 +126,12 @@ export const resolveWdsApp = (apps, shouldAutoDeployWds) => {
   // Due to Leo naming requirements, ensure this app has a unique name; this prevents
   // name collisions with previously-deployed apps which may be in ERROR or DELETED states.
   if (shouldAutoDeployWds) {
-    createLeoAppWithErrorHandling(uuid())
+    // David An: disabled for now. This needs to pass both the workspaceId and a random app name to
+    // createLeoAppWithErrorHandling.
+    // Additionally, it needs to be failsafe to race conditions in which the user enters the Data
+    // tab before Leo has had a chance to respond with knowledge about the app that was created
+    // during workspace creation.
+    // createLeoAppWithErrorHandling(uuid())
   }
 
   return ''


### PR DESCRIPTION
Because Leo requires unique names for apps we generated a new random uuid to pass to `createLeoAppWithErrorHandling`, but unfortunately we're now using the random uuid as the workspaceId, resulting in 403s from Leo because Leo doesn't find the workspace.

Additionally, from empirical testing, this code is not resilient to a race condition in which an end user creates a workspace and then clicks into the Data tab immediately. In this case, Leo does not yet reply with the app which was created via the new-workspace modal, so the Data tab tries to deploy another app.

This code exists to "backfill" all the workspaces created between the initial Azure launch and the launch of WDS … which are zero. It's also a failsafe in case app creation failed when making a workspace, but it's causing more problems than it's fixing, so I'm disabling it quickly for launch and we will revisit to see how we want to handle this.