### PR TITLE
[IA-4008] Updated zIndex to allow side menu to go over the jupyterlab iframe.

### DIFF
--- a/src/pages/workspaces/workspace/analysis/AppLauncher.js
+++ b/src/pages/workspaces/workspace/analysis/AppLauncher.js
@@ -240,13 +240,13 @@ const ApplicationLauncher = _.flow(
     fileOutdatedOpen && h(FileOutdatedModal, { onDismiss: () => setFileOutdatedOpen(false), bucketName }),
     _.includes(runtimeStatus, usableStatuses) && cookieReady ?
       h(Fragment, [
-        application === toolLabels.JupyterLab && div({ style: { padding: '2rem', position: 'absolute', top: 0, left: 0, zIndex: 1 } }, [
+        application === toolLabels.JupyterLab && div({ style: { padding: '2rem', position: 'absolute', top: 0, left: 0, zIndex: 0 } }, [
           h(StatusMessage, {}, ['Your Virtual Machine (VM) is ready. JupyterLab will launch momentarily...'])
         ]),
         iframe({
           src: iframeSrc,
           style: {
-            border: 'none', flex: 1, zIndex: 2,
+            border: 'none', flex: 1, zIndex: 1,
             ...(application === toolLabels.terminal ? { marginTop: -45, clipPath: 'inset(45px 0 0)' } : {}) // cuts off the useless Jupyter top bar
           },
           title: `Interactive ${application} iframe`


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/IA-4008

Problem:
The left menu for primary navigation of Terra is being covered up by JupyterLab.

Fix:
Update the zIndex to be below 2 (which is the zIndex of the menu.)

<!---
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Also, so if a screen recording [1] and/or screenshots would be a helpful way to communicate context, please consider including some in your PR description.
Thanks!

[1] https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac
-->
