### PR TITLE
AJ-839 workspace collaborators see message that data tables are for creators only 

### DIFF
--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -1014,7 +1014,8 @@ const WorkspaceData = _.flow(
       h(SidebarSeparator, { sidebarWidth, setSidebarWidth }),
       div({ style: styles.tableViewPanel }, [
         _.includes(selectedData?.type, [workspaceDataTypes.entities, workspaceDataTypes.entitiesVersion]) && h(DataTableFeaturePreviewFeedbackBanner),
-        Utils.switchCase(selectedData?.type, [undefined, () => Utils.cond([!wdsReady && isAzureWorkspace, () => div({ style: { textAlign: 'center', lineHeight: '1.4rem', marginTop: '1rem', marginLeft: '5rem', marginRight: '5rem' } },
+        Utils.cond([createdBy === getUser()?.email || isGoogleWorkspace, () => Utils.switchCase(selectedData?.type, [undefined, () => Utils.cond([!wdsReady && isAzureWorkspace, () => div({ style: { textAlign: 'center', lineHeight: '1.4rem', marginTop: '1rem', marginLeft: '5rem', marginRight: '5rem' } },
+
           [icon('loadingSpinner'),
             ' The database that powers your data tables is unavailable. It may take a few minutes after initial workspace creation to be ready. If you think something has gone wrong, please reach out to support@terra.bio and include information from our ',
             h(Link, { style: { marginTop: '0.5rem' }, onClick: () => setTroubleshootingWds(true) }, ['Troubleshoot']), ' page.'])],
@@ -1095,7 +1096,8 @@ const WorkspaceData = _.flow(
           recordType: selectedData.entityType,
           wdsSchema: wdsTypes.state
         })]
-        )
+        )], () => div({ style: { textAlign: 'center', lineHeight: '1.4rem', marginTop: '1rem', marginLeft: '5rem', marginRight: '5rem' } }, ['Currently, only a workspace creator can use data tables. If you were invited to this workspace, you can use the clone feature to create your own workspace to use data tables.']))
+      // ]
       ])
     ])
   ])


### PR DESCRIPTION
See [AJ-839](https://broadworkbench.atlassian.net/browse/AJ-839)
Currently only the creator of a workspace can see and use its WDS app.  This causes anyone else with whom the workspace has been shared to perpetually see the spinning "data tables are not available" message.  
This PR changes that to show a message explaining that they must clone the workspace if they want to use data tables.
Before:
<img width="1494" alt="image" src="https://user-images.githubusercontent.com/5884792/216368030-93e588c4-2f2e-4189-b39f-b752ee13a805.png">
After:
<img width="1505" alt="image" src="https://user-images.githubusercontent.com/5884792/216368178-a5a3f44a-cc83-49aa-8bbf-b73cc22b1fc0.png">

[AJ-839]: https://broadworkbench.atlassian.net/browse/AJ-839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ