### PR TITLE
[WOR-750] Call checkBucketReadAccess (which checks Google permissions) in prod

### DIFF
--- a/src/pages/workspaces/workspace/useWorkspace.ts
+++ b/src/pages/workspaces/workspace/useWorkspace.ts
@@ -8,7 +8,6 @@ import { Ajax } from 'src/libs/ajax'
 import { responseContainsRequesterPaysError } from 'src/libs/ajax/ajax-common'
 import { AzureStorage } from 'src/libs/ajax/AzureStorage'
 import { saToken } from 'src/libs/ajax/GoogleStorage'
-import { getConfig } from 'src/libs/config'
 import { withErrorIgnoring, withErrorReporting } from 'src/libs/error'
 import { clearNotification, notify } from 'src/libs/notifications'
 import { useCancellation, useOnMount, useStore } from 'src/libs/react-utils'
@@ -73,10 +72,7 @@ export const useWorkspace = (namespace, name) : WorkspaceDetails => {
 
   const checkGooglePermissions = async workspace => {
     try {
-      // Need to add nextflow role to old workspaces (WOR-764) before enabling in production.
-      if (!getConfig().isProd) {
-        await Ajax(signal).Workspaces.workspace(namespace, name).checkBucketReadAccess()
-      }
+      await Ajax(signal).Workspaces.workspace(namespace, name).checkBucketReadAccess()
       updateWorkspaceInStore(workspace, true)
       loadGoogleBucketLocation(workspace)
     } catch (error: any) {


### PR DESCRIPTION
This is a follow-up PR to enable the Google permission checking in prod once the migration to add the Nextflow role to old workspace users is complete.
