### PR TITLE
[SUP-807] Update link to Service Notifications page in Terra main menu

### DIFF
--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -285,7 +285,7 @@ const TopBar = ({ showMenu = true, title, href, children }) => {
               ...Utils.newTabLinkProps
             }, ['Release Notes']),
             h(DropDownSubItem, {
-              href: 'https://support.terra.bio/hc/en-us/categories/4408258992795',
+              href: 'https://support.terra.bio/hc/en-us/sections/4415104213787',
               onClick: hideNav,
               ...Utils.newTabLinkProps
             }, ['Service Notifications'])


### PR DESCRIPTION
The Service Notifications page on the Terra Support site has been moved so the current link in Terra is pointing to a blank page.

![image](https://user-images.githubusercontent.com/68919432/217599340-6f9bc320-f6a6-496a-937d-b65e5d468764.png)

### Old URL: https://support.terra.bio/hc/en-us/categories/4408258992795
![image](https://user-images.githubusercontent.com/68919432/217599742-c002653d-f894-4d83-b5d7-576eb3a7a573.png)

### New URL: https://support.terra.bio/hc/en-us/sections/4415104213787
![image](https://user-images.githubusercontent.com/68919432/217599881-7aad3042-c4e2-4dd4-a593-ceaaed2dea15.png)
