### PR TITLE
[IA-3769] Convert Analyses.js to typescript

### DIFF
--- a/integration-tests/tests/run-analysis.js
+++ b/integration-tests/tests/run-analysis.js
@@ -35,8 +35,7 @@ const testRunAnalysisFn = _.flowRight(
   await delay(200)
 
   // Navigate to analysis launcher
-  await findElement(page, clickable({ textContains: notebookName }), { timeout: 60000 })
-  await click(page, clickable({ text: `${notebookName}.ipynb` }))
+  await click(page, `//*[@title="${notebookName}.ipynb"]`, { timeout: 30000 })
   await dismissNotifications(page)
 
   await noSpinnersAfter(page, {

--- a/integration-tests/tests/run-analysis.js
+++ b/integration-tests/tests/run-analysis.js
@@ -36,7 +36,7 @@ const testRunAnalysisFn = _.flowRight(
 
   // Navigate to analysis launcher
   await findElement(page, clickable({ textContains: notebookName }), { timeout: 60000 })
-  await click(page, clickable({ textContains: notebookName }))
+  await click(page, clickable({ text: `${notebookName}.ipynb` }))
   await dismissNotifications(page)
 
   await noSpinnersAfter(page, {

--- a/integration-tests/tests/run-rstudio.js
+++ b/integration-tests/tests/run-rstudio.js
@@ -34,9 +34,7 @@ const testRunRStudioFn = _.flowRight(
   await delay(200)
 
   // Navigate to analysis launcher
-  // await click(page, `//*[@title="${rFileName}.Rmd"]`, { timeout: 60000 })
-  await findElement(page, clickable({ text: `${rFileName}.Rmd` }), { timeout: 30000 })
-  // await clickTableCell(page, { tableName: 'analyses', columnHeader: 'Name', text: `${rFileName}.Rmd`, isDescendant: true })
+  await click(page, `//*[@title="${rFileName}.Rmd"]`, { timeout: 30000 })
   await dismissNotifications(page)
 
   await noSpinnersAfter(page, {

--- a/integration-tests/tests/run-rstudio.js
+++ b/integration-tests/tests/run-rstudio.js
@@ -36,6 +36,7 @@ const testRunRStudioFn = _.flowRight(
   // Navigate to analysis launcher
   await findElement(page, clickable({ textContains: rFileName }), { timeout: 60000 })
   await click(page, clickable({ textContains: rFileName }))
+
   await dismissNotifications(page)
 
   await noSpinnersAfter(page, {

--- a/integration-tests/tests/run-rstudio.js
+++ b/integration-tests/tests/run-rstudio.js
@@ -34,9 +34,9 @@ const testRunRStudioFn = _.flowRight(
   await delay(200)
 
   // Navigate to analysis launcher
-  await findElement(page, clickable({ textContains: rFileName }), { timeout: 60000 })
-  await click(page, clickable({ textContains: rFileName }))
-
+  // await click(page, `//*[@title="${rFileName}.Rmd"]`, { timeout: 60000 })
+  await findElement(page, clickable({ text: `${rFileName}.Rmd` }), { timeout: 30000 })
+  // await clickTableCell(page, { tableName: 'analyses', columnHeader: 'Name', text: `${rFileName}.Rmd`, isDescendant: true })
   await dismissNotifications(page)
 
   await noSpinnersAfter(page, {

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -52,7 +52,7 @@ const getAnimatedDrawer = textContains => {
 // Note: isEnabled is not fully supported for native anchor and button elements (only aria-disabled is examined).
 const clickable = ({ text, textContains, isDescendant = false, isEnabled = true }) => {
   const checkEnabled = isEnabled === false ? '[@aria-disabled="true"]' : '[not(@aria-disabled="true")]'
-  const base = `(//a | //button | //*[@role="button"] | //*[@role="link"] | //*[@role="combobox"] | //*[@role="option"] | //*[@role="switch"] | //*[@role="tab"])${checkEnabled}`
+  const base = `(//a | //button | //*[@role="button"] | //*[@role="link"] | //*[@role="combobox"] | //*[@role="option"] | //*[@role="switch"] | //*[@role="tab"] | //*[@role="cell"])${checkEnabled}`
   return getClickablePath(base, text, textContains, isDescendant)
 }
 

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -52,7 +52,7 @@ const getAnimatedDrawer = textContains => {
 // Note: isEnabled is not fully supported for native anchor and button elements (only aria-disabled is examined).
 const clickable = ({ text, textContains, isDescendant = false, isEnabled = true }) => {
   const checkEnabled = isEnabled === false ? '[@aria-disabled="true"]' : '[not(@aria-disabled="true")]'
-  const base = `(//a | //button | //*[@role="button"] | //*[@role="link"] | //*[@role="combobox"] | //*[@role="option"] | //*[@role="switch"] | //*[@role="tab"])${checkEnabled}`
+  const base = `(//a | //button | //div | //*[@role="button"] | //*[@role="link"] | //*[@role="combobox"] | //*[@role="option"] | //*[@role="switch"] | //*[@role="tab"] | //*[@role="row"])${checkEnabled}`
   return getClickablePath(base, text, textContains, isDescendant)
 }
 

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -52,7 +52,7 @@ const getAnimatedDrawer = textContains => {
 // Note: isEnabled is not fully supported for native anchor and button elements (only aria-disabled is examined).
 const clickable = ({ text, textContains, isDescendant = false, isEnabled = true }) => {
   const checkEnabled = isEnabled === false ? '[@aria-disabled="true"]' : '[not(@aria-disabled="true")]'
-  const base = `(//a | //button | //div | //*[@role="button"] | //*[@role="link"] | //*[@role="combobox"] | //*[@role="option"] | //*[@role="switch"] | //*[@role="tab"])${checkEnabled}`
+  const base = `(//a | //button | //*[@role="button"] | //*[@role="link"] | //*[@role="combobox"] | //*[@role="option"] | //*[@role="switch"] | //*[@role="tab"])${checkEnabled}`
   return getClickablePath(base, text, textContains, isDescendant)
 }
 

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -52,7 +52,7 @@ const getAnimatedDrawer = textContains => {
 // Note: isEnabled is not fully supported for native anchor and button elements (only aria-disabled is examined).
 const clickable = ({ text, textContains, isDescendant = false, isEnabled = true }) => {
   const checkEnabled = isEnabled === false ? '[@aria-disabled="true"]' : '[not(@aria-disabled="true")]'
-  const base = `(//a | //button | //*[@role="button"] | //*[@role="link"] | //*[@role="combobox"] | //*[@role="option"] | //*[@role="switch"] | //*[@role="tab"] | //*[@role="cell"])${checkEnabled}`
+  const base = `(//a | //button | //div | //*[@role="button"] | //*[@role="link"] | //*[@role="combobox"] | //*[@role="option"] | //*[@role="switch"] | //*[@role="tab"])${checkEnabled}`
   return getClickablePath(base, text, textContains, isDescendant)
 }
 

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -52,7 +52,7 @@ const getAnimatedDrawer = textContains => {
 // Note: isEnabled is not fully supported for native anchor and button elements (only aria-disabled is examined).
 const clickable = ({ text, textContains, isDescendant = false, isEnabled = true }) => {
   const checkEnabled = isEnabled === false ? '[@aria-disabled="true"]' : '[not(@aria-disabled="true")]'
-  const base = `(//a | //button | //div | //*[@role="button"] | //*[@role="link"] | //*[@role="combobox"] | //*[@role="option"] | //*[@role="switch"] | //*[@role="tab"] | //*[@role="row"])${checkEnabled}`
+  const base = `(//a | //button | //*[@role="button"] | //*[@role="link"] | //*[@role="combobox"] | //*[@role="option"] | //*[@role="switch"] | //*[@role="tab"])${checkEnabled}`
   return getClickablePath(base, text, textContains, isDescendant)
 }
 

--- a/src/components/common/DeleteConfirmationModal.js
+++ b/src/components/common/DeleteConfirmationModal.js
@@ -13,18 +13,14 @@ import { IdContainer } from './IdContainer'
 export const DeleteConfirmationModal = ({
   objectType,
   objectName,
-  title: titleProp,
-  children,
-  confirmationPrompt,
-  buttonText: buttonTextProp,
   onConfirm,
-  onDismiss
+  onDismiss,
+  children = undefined,
+  confirmationPrompt = undefined,
+  title = `Delete ${objectType}`,
+  buttonText = `Delete ${objectType}`,
 }) => {
-  const title = titleProp || `Delete ${objectType}`
-  const buttonText = buttonTextProp || `Delete ${objectType}`
-
   const [confirmation, setConfirmation] = useState('')
-
   const isConfirmed = !confirmationPrompt || _.toLower(confirmation) === _.toLower(confirmationPrompt)
 
   return h(Modal, {

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -181,7 +181,7 @@ export const ariaSort = (sort, field) => {
     return 'none'
   }
   // Otherwise this column is not sortable
-  return null
+  return undefined
 }
 
 const NoContentRow = ({ noContentMessage, noContentRenderer = _.noop, numColumns }) => div({
@@ -796,8 +796,8 @@ export const MiniSortable = ({ sort, field, onSort, children }) => {
   ])])
 }
 
-export const HeaderRenderer = ({ name, label, sort, onSort, style, ...props }) => h(MiniSortable, { sort, field: name, onSort }, [
-  div({ style: { fontWeight: 600, ...style }, ...props }, [label || Utils.normalizeLabel(name)])
+export const HeaderRenderer = ({ name, label = Utils.normalizeLabel(name), sort, onSort, style = {}, ...props }) => h(MiniSortable, { sort, field: name, onSort }, [
+  div({ style: { fontWeight: 600, ...style }, ...props }, [label])
 ])
 
 export const Resizable = ({ onWidthChange, width, minWidth = 100, children }) => {

--- a/src/libs/ajax/AzureStorage.ts
+++ b/src/libs/ajax/AzureStorage.ts
@@ -6,12 +6,11 @@ import * as Utils from 'src/libs/utils'
 import { cloudProviderTypes } from 'src/libs/workspace-utils'
 import {
   AbsolutePath,
-  AnalysisFile,
-  AnalysisFileMetadata,
   getDisplayName,
   getExtension, getFileName
 } from 'src/pages/workspaces/workspace/analysis/file-utils'
 import { toolLabels } from 'src/pages/workspaces/workspace/analysis/tool-utils'
+import { AnalysisFile, AnalysisFileMetadata } from 'src/pages/workspaces/workspace/analysis/useAnalysisFiles'
 
 
 type SasInfo = {

--- a/src/libs/ajax/GoogleStorage.ts
+++ b/src/libs/ajax/GoogleStorage.ts
@@ -8,8 +8,6 @@ import * as Utils from 'src/libs/utils'
 import { cloudProviderTypes } from 'src/libs/workspace-utils'
 import {
   AbsolutePath,
-  AnalysisFile,
-  AnalysisFileMetadata,
   getDisplayName,
   getExtension,
   getFileName
@@ -20,6 +18,7 @@ import {
   ToolLabel,
   toolLabels
 } from 'src/pages/workspaces/workspace/analysis/tool-utils'
+import { AnalysisFile, AnalysisFileMetadata } from 'src/pages/workspaces/workspace/analysis/useAnalysisFiles'
 
 /*
  * Detects errors due to requester pays buckets, and adds the current workspace's billing

--- a/src/libs/feature-previews-config.js
+++ b/src/libs/feature-previews-config.js
@@ -1,3 +1,6 @@
+export const JUPYTERLAB_GCP_FEATURE_ID = 'jupyterlab-gcp'
+export const ENABLE_JUPYTERLAB_ID = 'enableJupyterLabGCP'
+
 const featurePreviewsConfig = [
   {
     id: 'data-table-versioning',
@@ -14,7 +17,7 @@ const featurePreviewsConfig = [
     feedbackUrl: `mailto:dsp-sue@broadinstitute.org?subject=${encodeURIComponent('Feedback on data table provenance')}`
   },
   {
-    id: 'jupyterlab-gcp',
+    id: JUPYTERLAB_GCP_FEATURE_ID,
     title: 'JupyterLab on GCP',
     description: 'Enabling this feature will allow you to launch notebooks using JupyterLab in GCP workspaces.',
     groups: ['preview-jupyterlab-gcp'],

--- a/src/libs/style.ts
+++ b/src/libs/style.ts
@@ -1,3 +1,4 @@
+import { CSSProperties } from 'react'
 import { isTerra } from 'src/libs/brand-utils'
 import colors, { terraSpecial } from 'src/libs/colors'
 
@@ -15,16 +16,18 @@ export const noWrapEllipsis = { whiteSpace: 'nowrap', overflow: 'hidden', textOv
 
 export const codeFont = { fontFamily: 'Courier New' }
 
+const cardStyles: Record<string, CSSProperties> = {
+  title: { color: colors.accent(), fontSize: 16, overflow: 'hidden' },
+  container: {
+    display: 'flex', flexDirection: 'column', justifyContent: 'space-between',
+    borderRadius: 5, padding: '1rem', wordWrap: 'break-word',
+    backgroundColor: 'white',
+    boxShadow: '0 2px 5px 0 rgba(0,0,0,0.35), 0 3px 2px 0 rgba(0,0,0,0.12)'
+  }
+}
+
 export const elements = {
-  card: {
-    title: { color: colors.accent(), fontSize: 16, overflow: 'hidden' },
-    container: {
-      display: 'flex', flexDirection: 'column', justifyContent: 'space-between',
-      borderRadius: 5, padding: '1rem', wordWrap: 'break-word',
-      backgroundColor: 'white',
-      boxShadow: '0 2px 5px 0 rgba(0,0,0,0.35), 0 3px 2px 0 rgba(0,0,0,0.12)'
-    }
-  },
+  card: cardStyles,
   sectionHeader: { color: colors.dark(), fontSize: 16, fontWeight: 600, margin: '0.25em 0' },
   pageContentContainer: { position: 'relative', flexGrow: 1, display: 'flex', flexDirection: 'column' },
   contextBarContainer: { flex: 'none', width: 55, backgroundColor: colors.light(), borderLeft: `1px solid ${colors.accent()}` }

--- a/src/libs/utils.test.ts
+++ b/src/libs/utils.test.ts
@@ -1,4 +1,4 @@
-import { differenceFromNowInSeconds, formatBytes, isValidWsExportTarget } from 'src/libs/utils'
+import { differenceFromNowInSeconds, formatBytes, isValidWsExportTarget, textMatch } from 'src/libs/utils'
 import { defaultAzureWorkspace, defaultGoogleWorkspace } from 'src/pages/workspaces/workspace/analysis/_testData/testData'
 
 
@@ -158,5 +158,17 @@ describe('formatBytes', () => {
 
     // Assert
     expect(result).toBe('40 B')
+  })
+})
+
+describe('textMatch', () => {
+  it.each([
+    { needle: 'success', haystack: 'success', result: true },
+    { needle: 'Succes', haystack: 'successss', result: true },
+    { needle: 'nomatch', haystack: '404', result: false }
+  ])('properly determines if the needle is in the haystack', ({ needle, haystack, result }) => {
+    // Act
+    const doesMatch = textMatch(needle, haystack)
+    expect(doesMatch).toBe(result)
   })
 })

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -230,9 +230,9 @@ export const computeWorkspaceError = ({ canCompute, workspace: { isLocked } }) =
   )
 }
 
-export const textMatch = (needle: string, haystack: string): boolean => {
+export const textMatch = safeCurry((needle: string, haystack: string): boolean => {
   return haystack.toLowerCase().includes(needle.toLowerCase())
-}
+})
 
 export const nextSort = ({ field, direction }, newField) => {
   return newField === field ?

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -232,7 +232,7 @@ export const computeWorkspaceError = ({ canCompute, workspace: { isLocked } }) =
 
 export const textMatch = safeCurry((needle: string, haystack: string): boolean => {
   return haystack.toLowerCase().includes(needle.toLowerCase())
-})
+}) as ((needle: string, haystack: string) => boolean)
 
 export const nextSort = ({ field, direction }, newField) => {
   return newField === field ?

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -105,9 +105,9 @@ export const formatNumber = new Intl.NumberFormat('en-US').format
 
 export const workspaceAccessLevels = ['NO ACCESS', 'READER', 'WRITER', 'OWNER', 'PROJECT_OWNER']
 
-export const hasAccessLevel = _.curry((required, current) => {
+export const hasAccessLevel = (required: string, current: string): boolean => {
   return workspaceAccessLevels.indexOf(current) >= workspaceAccessLevels.indexOf(required)
-})
+}
 
 export const canWrite = accessLevel => hasAccessLevel('WRITER', accessLevel)
 export const canRead = accessLevel => hasAccessLevel('READER', accessLevel)
@@ -230,9 +230,9 @@ export const computeWorkspaceError = ({ canCompute, workspace: { isLocked } }) =
   )
 }
 
-export const textMatch = _.curry((needle, haystack) => {
+export const textMatch = (needle: string, haystack: string): boolean => {
   return haystack.toLowerCase().includes(needle.toLowerCase())
-})
+}
 
 export const nextSort = ({ field, direction }, newField) => {
   return newField === field ?

--- a/src/libs/workspace-utils.ts
+++ b/src/libs/workspace-utils.ts
@@ -48,6 +48,7 @@ export interface AzureWorkspace extends BaseWorkspace {
 }
 
 export interface GoogleWorkspace extends BaseWorkspace {
+  workspace: GoogleWorkspaceInfo
 }
 
 export type WorkspaceWrapper = GoogleWorkspace | AzureWorkspace

--- a/src/pages/workspaces/workspace/analysis/Analyses.test.ts
+++ b/src/pages/workspaces/workspace/analysis/Analyses.test.ts
@@ -1,0 +1,371 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { act } from 'react-dom/test-utils'
+import { h } from 'react-hyperscript-helpers'
+import { Ajax } from 'src/libs/ajax'
+import { isFeaturePreviewEnabled } from 'src/libs/feature-previews'
+import { ENABLE_JUPYTERLAB_ID, JUPYTERLAB_GCP_FEATURE_ID } from 'src/libs/feature-previews-config'
+import { goToPath } from 'src/libs/nav'
+import { getLocalPref, setLocalPref } from 'src/libs/prefs'
+import LoadedState from 'src/libs/type-utils/LoadedState'
+import {
+  defaultAzureWorkspace,
+  defaultGoogleWorkspace
+} from 'src/pages/workspaces/workspace/analysis/_testData/testData'
+import {
+  AnalysesData,
+  AnalysesProps,
+  BaseAnalyses, getUniqueFileName
+} from 'src/pages/workspaces/workspace/analysis/Analyses'
+import {
+  AbsolutePath, FileName, findPotentialNotebookLockers, notebookLockHash
+} from 'src/pages/workspaces/workspace/analysis/file-utils'
+import { analysisLauncherTabName } from 'src/pages/workspaces/workspace/analysis/runtime-common-components'
+import { toolLabels } from 'src/pages/workspaces/workspace/analysis/tool-utils'
+import { AnalysisFile, getFileFromPath, useAnalysisFiles } from 'src/pages/workspaces/workspace/analysis/useAnalysisFiles'
+import { asMockedFn } from 'src/testing/test-utils'
+
+
+type NavExports = typeof import('src/libs/nav')
+jest.mock('src/libs/nav', (): NavExports => ({
+  ...jest.requireActual('src/libs/nav'),
+  getLink: jest.fn(),
+  goToPath: jest.fn(),
+}))
+
+type FileUtilsExports = typeof import('src/pages/workspaces/workspace/analysis/file-utils')
+jest.mock('src/pages/workspaces/workspace/analysis/file-utils', (): FileUtilsExports => ({
+  ...jest.requireActual('src/pages/workspaces/workspace/analysis/file-utils'),
+  notebookLockHash: jest.fn(),
+  findPotentialNotebookLockers: jest.fn()
+}))
+
+type UseAnalysisFilesExport = typeof import('src/pages/workspaces/workspace/analysis/useAnalysisFiles')
+jest.mock('src/pages/workspaces/workspace/analysis/useAnalysisFiles', (): UseAnalysisFilesExport => ({
+  ...jest.requireActual('src/pages/workspaces/workspace/analysis/useAnalysisFiles'),
+  useAnalysisFiles: jest.fn()
+}))
+
+jest.mock('src/libs/ajax')
+
+type NotificationExports = typeof import('src/libs/notifications')
+jest.mock('src/libs/notifications', (): NotificationExports => ({
+  ...jest.requireActual('src/libs/notifications'),
+  notify: jest.fn()
+}))
+
+
+type PrefsExports = typeof import('src/libs/prefs')
+jest.mock('src/libs/prefs', (): PrefsExports => ({
+  ...jest.requireActual('src/libs/prefs'),
+  getLocalPref: jest.fn(),
+  setLocalPref: jest.fn()
+}))
+
+type FeaturePrev = typeof import('src/libs/feature-previews')
+jest.mock('src/libs/feature-previews', (): FeaturePrev => ({
+  ...jest.requireActual('src/libs/feature-previews'),
+  isFeaturePreviewEnabled: jest.fn()
+}))
+
+const defaultAnalysesData: AnalysesData = {
+  apps: [],
+  refreshApps: () => Promise.resolve(),
+  runtimes: [],
+  refreshRuntimes: () => Promise.resolve(),
+  appDataDisks: [],
+  persistentDisks: []
+}
+
+const defaultUseAnalysisStore = {
+  refreshFileStore: () => Promise.resolve(),
+  loadedState: { status: 'Ready', state: [] as AnalysisFile[] } as LoadedState<AnalysisFile[], unknown>,
+  create: () => Promise.resolve(),
+  pendingCreate: { status: 'None', state: true } as LoadedState<true, unknown>,
+  pendingDelete: { status: 'None', state: true } as LoadedState<true, unknown>,
+  deleteFile: () => Promise.resolve()
+}
+
+const defaultAnalysesProps: AnalysesProps = {
+  workspace: defaultGoogleWorkspace,
+  analysesData: defaultAnalysesData,
+  onRequesterPaysError: () => {},
+  storageDetails: { googleBucketLocation: '', googleBucketType: '' }
+}
+
+
+const watchCaptureEvent = jest.fn()
+type AjaxContract = ReturnType<typeof Ajax>;
+type AjaxMetricsContract = AjaxContract['Metrics']
+type OuterWorkspacesContract = AjaxContract['Workspaces']
+type InnerWorkspacesContract = AjaxContract['Workspaces']['workspace']
+const mockInnerWorkspaces = jest.fn().mockReturnValue({
+  listActiveFileTransfers: jest.fn()
+}) as InnerWorkspacesContract
+const mockOuterWorkspaces: Partial<OuterWorkspacesContract> = {
+  workspace: mockInnerWorkspaces
+}
+
+const mockMetrics: Partial<AjaxMetricsContract> = {
+  captureEvent: (event, details) => watchCaptureEvent(event, details)
+}
+
+const defaultAjaxImpl: Partial<AjaxContract> = {
+  Workspaces: mockOuterWorkspaces as OuterWorkspacesContract,
+  Metrics: mockMetrics as AjaxMetricsContract
+}
+
+describe('Analyses', () => {
+  beforeEach(() => {
+    // Arrange
+    asMockedFn(useAnalysisFiles).mockReturnValue(defaultUseAnalysisStore)
+    asMockedFn(notebookLockHash).mockReturnValue(Promise.resolve('testhash'))
+    asMockedFn(findPotentialNotebookLockers).mockReturnValue(Promise.resolve({}))
+    asMockedFn(Ajax).mockReturnValue(defaultAjaxImpl as AjaxContract)
+    asMockedFn(getLocalPref).mockReturnValue(undefined)
+  })
+
+  it('loads properly with no files', async () => {
+    // Act
+    await act(async () => { // eslint-disable-line require-await
+      render(h(BaseAnalyses, defaultAnalysesProps))
+    })
+
+    // Assert
+    screen.getByText('Start')
+    // Banner text and images
+    screen.getByText('A place for all your analyses')
+    screen.getByAltText('Jupyter')
+    screen.getByAltText('RStudio Bioconductor')
+    screen.getByAltText('Galaxy')
+  })
+
+  it('loads properly with files for a google workspace', async () => {
+    // Arrange
+    const fileName1 = 'file1.ipynb'
+    const fileName2 = 'file2.ipynb'
+    const files = [getFileFromPath(`test/${fileName1}` as AbsolutePath), getFileFromPath(`test/${fileName2}` as AbsolutePath)]
+
+    asMockedFn(useAnalysisFiles).mockReturnValue({
+      ...defaultUseAnalysisStore,
+      loadedState: { status: 'Ready', state: files }
+    })
+
+    // Act
+    await act(async () => { // eslint-disable-line require-await
+      render(h(BaseAnalyses, defaultAnalysesProps))
+    })
+
+    // Assert
+    screen.getByText('Start')
+    // Table headings
+    screen.getByText('Application')
+    screen.getByText('Name')
+    screen.getByText('Last Modified')
+    screen.getByPlaceholderText('Search analyses')
+    screen.getByText(fileName1)
+    screen.getByText(fileName2)
+  })
+
+  it('loads properly with files for an azure workspace', async () => {
+    // Arrange
+    const fileName1 = 'file1.ipynb'
+    const fileName2 = 'file2.ipynb'
+    const files = [getFileFromPath(`test/${fileName1}` as AbsolutePath), getFileFromPath(`test/${fileName2}` as AbsolutePath)]
+
+    asMockedFn(useAnalysisFiles).mockReturnValue({
+      ...defaultUseAnalysisStore,
+      loadedState: { status: 'Ready', state: files }
+    })
+
+    // Act
+    await act(async () => { // eslint-disable-line require-await
+      render(h(BaseAnalyses, { ...defaultAnalysesProps, workspace: defaultAzureWorkspace }))
+    })
+
+    // Assert
+    screen.getByText('Start')
+    // Table headings
+    screen.getByText('Application')
+    screen.getByText('Name')
+    screen.getByText('Last Modified')
+    screen.getByPlaceholderText('Search analyses')
+    screen.getByText(fileName1)
+    screen.getByText(fileName2)
+  })
+
+  it('Sorts analysis table properly', async () => {
+    // Arrange
+    const fileName1 = 'file1.ipynb'
+    const fileName2 = 'file2.ipynb'
+    const file1Date = new Date().getTime()
+    const file2Date = file1Date + 10000
+    const files = [{ ...getFileFromPath(`test/${fileName1}` as AbsolutePath), lastModified: file1Date }, { ...getFileFromPath(`test/${fileName2}` as AbsolutePath), lastModified: file2Date }]
+
+    asMockedFn(useAnalysisFiles).mockReturnValue({
+      ...defaultUseAnalysisStore,
+      loadedState: { status: 'Ready', state: files }
+    })
+
+    // Act
+    await act(async () => { // eslint-disable-line require-await
+      render(h(BaseAnalyses, defaultAnalysesProps))
+    })
+
+    const analysisRowsBeforeSort: HTMLElement[] = screen.queryAllByRole('row')
+    const nameTableHeader = screen.getByText('Name')
+
+    await act(async () => {
+      await userEvent.click(nameTableHeader)
+    })
+
+    // Assert visual state before sorting
+    expect(analysisRowsBeforeSort.length).toBe(3)
+    expect(analysisRowsBeforeSort[1].textContent).toContain(fileName2)
+    expect(analysisRowsBeforeSort[2].textContent).toContain(fileName1)
+
+    // Assert files have inverted in table after sort
+    const analysisRowsAfterSort: HTMLElement[] = screen.queryAllByRole('row')
+    expect(analysisRowsAfterSort.length).toBe(3) // 2 files plus 1 header row = 3
+    expect(analysisRowsAfterSort[1].textContent).toContain(fileName1)
+    expect(analysisRowsAfterSort[2].textContent).toContain(fileName2)
+  })
+
+  it('Properly navigates to launcher on clicking an analysis', async () => {
+    // Arrange
+    const navGoToPathObservable = jest.fn()
+    asMockedFn(goToPath).mockImplementation(navGoToPathObservable)
+
+    const fileName1 = 'file1.ipynb'
+    const fileName2 = 'file2.ipynb'
+    const files = [getFileFromPath(`test/${fileName1}` as AbsolutePath), getFileFromPath(`test/${fileName2}` as AbsolutePath)]
+
+    asMockedFn(useAnalysisFiles).mockReturnValue({
+      ...defaultUseAnalysisStore,
+      loadedState: { status: 'Ready', state: files }
+    })
+
+    // Act
+    await act(async () => { // eslint-disable-line require-await
+      render(h(BaseAnalyses, defaultAnalysesProps))
+    })
+
+    // Assert
+    const analysisCard = screen.getByText(fileName1)
+    await userEvent.click(analysisCard)
+    expect(goToPath).toHaveBeenCalledWith(analysisLauncherTabName, { namespace: defaultAnalysesProps.workspace.workspace.namespace, name: defaultAnalysesProps.workspace.workspace.name, analysisName: fileName1 })
+  })
+
+  it('Displays JupyterLab enablement feature properly', async () => {
+    // Arrange
+    const fileName1 = 'file1.ipynb'
+    const fileName2 = 'file2.ipynb'
+    const files = [getFileFromPath(`test/${fileName1}` as AbsolutePath), getFileFromPath(`test/${fileName2}` as AbsolutePath)]
+
+    asMockedFn(useAnalysisFiles).mockReturnValue({
+      ...defaultUseAnalysisStore,
+      loadedState: { status: 'Ready', state: files }
+    })
+
+    asMockedFn(isFeaturePreviewEnabled).mockImplementation(key => {
+      return key === JUPYTERLAB_GCP_FEATURE_ID
+    })
+    const setLocalPrefObservable = jest.fn()
+    asMockedFn(setLocalPref).mockImplementation(setLocalPrefObservable)
+
+    // Act
+    await act(async () => { // eslint-disable-line require-await
+      render(h(BaseAnalyses, defaultAnalysesProps))
+    })
+
+    // Assert
+    const enableJupyterLabButton = screen.getByLabelText('Enable JupyterLab')
+
+    expect(enableJupyterLabButton).not.toBeChecked()
+    await userEvent.click(enableJupyterLabButton)
+    expect(setLocalPrefObservable).toHaveBeenCalledWith(`${defaultAnalysesProps.workspace.workspace.namespace}/${defaultAnalysesProps.workspace.workspace.name}/${ENABLE_JUPYTERLAB_ID}`, true)
+    expect(enableJupyterLabButton).toBeChecked()
+  })
+
+  it('Displays active file transfer message', async () => {
+    const fileName1 = 'file1.ipynb'
+    const fileName2 = 'file2.ipynb'
+    const files = [getFileFromPath(`test/${fileName1}` as AbsolutePath), getFileFromPath(`test/${fileName2}` as AbsolutePath)]
+
+    asMockedFn(useAnalysisFiles).mockReturnValue({
+      ...defaultUseAnalysisStore,
+      loadedState: { status: 'Ready', state: files }
+    })
+
+    const mockInnerWorkspaces = jest.fn().mockReturnValue({
+      //TODO: once this function is typed this will need to return something valid, not a number[]
+      listActiveFileTransfers: () => Promise.resolve([1])
+    }) as InnerWorkspacesContract
+    const mockOuterWorkspaces: Partial<OuterWorkspacesContract> = {
+      workspace: mockInnerWorkspaces
+    }
+
+    asMockedFn(Ajax).mockReturnValue({ ...defaultAjaxImpl, Workspaces: mockOuterWorkspaces } as AjaxContract)
+
+    // Act
+    await act(async () => { // eslint-disable-line require-await
+      render(h(BaseAnalyses, defaultAnalysesProps))
+    })
+
+    screen.getByText('Copying 1 or more interactive analysis files from another workspace.')
+  })
+
+  it('Should compute a new unique file name', () => {
+    // Arrange
+    const file1 = 'file1.ipynb' as FileName
+    const file2 = 'file2.ipynb' as FileName
+    const file3 = 'file3.ipynb' as FileName
+
+    // Act
+    const result1 = getUniqueFileName(file1, [file2, file3])
+    const result2 = getUniqueFileName(file2, [file2, file3])
+
+    // Assert
+    expect(result1).toBe(file1)
+    expect(result2).toBe('file2_1.ipynb' as FileName)
+  })
+
+  it('Should upload files properly', async () => {
+    // Arrange
+    const fileName1 = 'file1.ipynb'
+    const fileName2 = 'file2.ipynb'
+    const files = [getFileFromPath(`test/${fileName1}` as AbsolutePath), getFileFromPath(`test/${fileName2}` as AbsolutePath)]
+    const droppedFileName = 'file3.ipynb'
+    const droppedFileContents = 'testContent'
+    const fileToDrop = new File([droppedFileContents], droppedFileName)
+    const createObservable = jest.fn()
+    const user = userEvent.setup()
+
+    asMockedFn(useAnalysisFiles).mockReturnValue({
+      ...defaultUseAnalysisStore,
+      loadedState: { status: 'Ready', state: files },
+      create: createObservable
+    })
+
+    // Act
+    await act(async () => { // eslint-disable-line require-await
+      render(h(BaseAnalyses, defaultAnalysesProps))
+      const fileInput = document.querySelector<HTMLInputElement>('input[type="file"]')!
+      await user.upload(fileInput, [fileToDrop])
+    })
+
+    expect(createObservable).toHaveBeenCalledWith(droppedFileName, toolLabels.Jupyter, fileToDrop)
+  })
+
+  it('Should open a modal when I click start', async () => {
+    await act(async () => { // eslint-disable-line require-await
+      render(h(BaseAnalyses, defaultAnalysesProps))
+    })
+
+    const startButton = screen.getByText('Start')
+    await userEvent.click(startButton)
+
+    const modalTitle = document.getElementById('analysis-modal-title')
+    expect(modalTitle).toBeInTheDocument()
+  })
+})

--- a/src/pages/workspaces/workspace/analysis/Analyses.ts
+++ b/src/pages/workspaces/workspace/analysis/Analyses.ts
@@ -332,7 +332,8 @@ export const BaseAnalyses: FC<AnalysesProps> = ({
 
   const authState = useStore(authStore)
   const signal = useCancellation()
-  const { loadedState, refreshFileStore, create, deleteFile } = useAnalysisFiles()
+  const analysisFileStore = useAnalysisFiles()
+  const { loadedState, refreshFileStore, create, deleteFile } = analysisFileStore
   const currentRuntime = getCurrentRuntime(runtimes)
   const location = Utils.cond(
     [isGoogleWorkspace(workspace), () => googleBucketLocation],
@@ -547,16 +548,15 @@ export const BaseAnalyses: FC<AnalysesProps> = ({
           },
           onError: () => {
             setCreating(false)
-            refreshAnalyses()
             refreshRuntimes()
             refreshApps()
           },
           onSuccess: () => {
             setCreating(false)
-            refreshAnalyses()
             refreshRuntimes()
             refreshApps()
-          }
+          },
+          analysisFileStore
         }),
         renamingAnalysisName && h(AnalysisDuplicator, {
           printName: getFileName(renamingAnalysisName),

--- a/src/pages/workspaces/workspace/analysis/Analyses.ts
+++ b/src/pages/workspaces/workspace/analysis/Analyses.ts
@@ -314,18 +314,18 @@ export const BaseAnalyses: FC<AnalysesProps> = ({
   storageDetails: { googleBucketLocation, azureContainerRegion },
   onRequesterPaysError
 }: AnalysesProps, _ref) => {
-  const [renamingAnalysisName, setRenamingAnalysisName] = useState<AbsolutePath | undefined>(undefined)
-  const [copyingAnalysisName, setCopyingAnalysisName] = useState<AbsolutePath | undefined>(undefined)
-  const [deletingAnalysisName, setDeletingAnalysisName] = useState<AbsolutePath | undefined>(undefined)
-  const [exportingAnalysisName, setExportingAnalysisName] = useState<AbsolutePath | undefined>(undefined)
+  const [renamingAnalysisName, setRenamingAnalysisName] = useState<AbsolutePath>()
+  const [copyingAnalysisName, setCopyingAnalysisName] = useState<AbsolutePath>()
+  const [deletingAnalysisName, setDeletingAnalysisName] = useState<AbsolutePath>()
+  const [exportingAnalysisName, setExportingAnalysisName] = useState<AbsolutePath>()
   const [sortOrder, setSortOrder] = useState<SortOrderInfo>(() => getLocalPref(KEY_ANALYSES_SORT_ORDER) || defaultSort.value)
   const [feedbackShowing, setFeedbackShowing] = useState(false)
   const [filter, setFilter] = useState(() => StateHistory.get().filter || '')
   const [busy, setBusy] = useState(false)
   const [creating, setCreating] = useState(false)
-  const [analyses, setAnalyses] = useState<DisplayAnalysisFile[] | undefined>(() => StateHistory.get().analyses || undefined)
-  const [currentUserHash, setCurrentUserHash] = useState<string | undefined>(undefined)
-  const [potentialLockers, setPotentialLockers] = useState(undefined)
+  const [analyses, setAnalyses] = useState<DisplayAnalysisFile[]>(() => StateHistory.get().analyses || undefined)
+  const [currentUserHash, setCurrentUserHash] = useState<string>()
+  const [potentialLockers, setPotentialLockers] = useState()
   const [activeFileTransfers, setActiveFileTransfers] = useState(false)
   const enableJupyterLabPersistenceId: string = `${workspace.workspace.namespace}/${workspace.workspace.name}/${ENABLE_JUPYTERLAB_ID}`
   const [enableJupyterLabGCP, setEnableJupyterLabGCP] = useState<boolean>(() => getLocalPref(enableJupyterLabPersistenceId) || false)

--- a/src/pages/workspaces/workspace/analysis/Analyses.ts
+++ b/src/pages/workspaces/workspace/analysis/Analyses.ts
@@ -486,7 +486,7 @@ export const BaseAnalyses: FC<AnalysesProps> = ({
         [!_.isEmpty(analyses) && _.isEmpty(analysisCards), () => {
           return div({ style: { fontStyle: 'italic' } }, ['No matching analyses'])
         }],
-        [Utils.DEFAULT, () => div({ role: 'table' }, [
+        [Utils.DEFAULT, () => div({ role: 'table', 'aria-label': 'analyses' }, [
           h(AnalysisCardHeaders, {
             sort: sortOrder, onSort: newSortOrder => {
               setLocalPref(KEY_ANALYSES_SORT_ORDER, newSortOrder)

--- a/src/pages/workspaces/workspace/analysis/Analyses.ts
+++ b/src/pages/workspaces/workspace/analysis/Analyses.ts
@@ -442,7 +442,7 @@ export const BaseAnalyses: FC<AnalysesProps> = ({
     const { field, direction } = sortOrder
     const canWrite = Utils.canWrite(accessLevel)
 
-    const filteredAnalyses: DisplayAnalysisFile[] = _.filter((analysisFile: DisplayAnalysisFile) => Utils.textMatch(filter, getFileName(analysisFile.name)) as unknown as boolean, analyses)
+    const filteredAnalyses: DisplayAnalysisFile[] = _.filter((analysisFile: DisplayAnalysisFile) => Utils.textMatch(filter, getFileName(analysisFile.name)), analyses)
     // Lodash does not have a well-typed return on this function and there are not any nice alternatives, so expect error for now
     // @ts-expect-error
     const sortedAnalyses: DisplayAnalysisFile[] = _.orderBy(sortTokens[field] || field, direction, filteredAnalyses)

--- a/src/pages/workspaces/workspace/analysis/Analyses.ts
+++ b/src/pages/workspaces/workspace/analysis/Analyses.ts
@@ -442,7 +442,7 @@ export const BaseAnalyses: FC<AnalysesProps> = ({
     const { field, direction } = sortOrder
     const canWrite = Utils.canWrite(accessLevel)
 
-    const filteredAnalyses: DisplayAnalysisFile[] = _.filter((analysisFile: DisplayAnalysisFile) => Utils.textMatch(filter, getFileName(analysisFile.name)), analyses)
+    const filteredAnalyses: DisplayAnalysisFile[] = _.filter((analysisFile: DisplayAnalysisFile) => Utils.textMatch(filter, getFileName(analysisFile.name)) as unknown as boolean, analyses)
     // Lodash does not have a well-typed return on this function and there are not any nice alternatives, so expect error for now
     // @ts-expect-error
     const sortedAnalyses: DisplayAnalysisFile[] = _.orderBy(sortTokens[field] || field, direction, filteredAnalyses)

--- a/src/pages/workspaces/workspace/analysis/Analyses.ts
+++ b/src/pages/workspaces/workspace/analysis/Analyses.ts
@@ -1,8 +1,8 @@
 import * as clipboard from 'clipboard-polyfill/text'
 import _ from 'lodash/fp'
 import * as qs from 'qs'
-import { Fragment, useEffect, useState } from 'react'
-import { a, div, h, img, label, span } from 'react-hyperscript-helpers'
+import { CSSProperties, FC, Fragment, useEffect, useState } from 'react'
+import { div, h, img, label, span } from 'react-hyperscript-helpers'
 import * as breadcrumbs from 'src/components/breadcrumbs'
 import { requesterPaysWrapper, withRequesterPaysHandler } from 'src/components/bucket-utils'
 import { withViewToggle } from 'src/components/CardsListToggle'
@@ -25,6 +25,7 @@ import colors from 'src/libs/colors'
 import { reportError, withErrorReporting } from 'src/libs/error'
 import Events, { extractWorkspaceDetails } from 'src/libs/events'
 import { isFeaturePreviewEnabled } from 'src/libs/feature-previews'
+import { ENABLE_JUPYTERLAB_ID, JUPYTERLAB_GCP_FEATURE_ID } from 'src/libs/feature-previews-config'
 import * as Nav from 'src/libs/nav'
 import { notify } from 'src/libs/notifications'
 import { getLocalPref, setLocalPref } from 'src/libs/prefs'
@@ -32,15 +33,33 @@ import { forwardRefWithName, useCancellation, useOnMount, useStore } from 'src/l
 import { authStore } from 'src/libs/state'
 import * as StateHistory from 'src/libs/state-history'
 import * as Style from 'src/libs/style'
+import { withHandlers } from 'src/libs/type-utils/lodash-fp-helpers'
 import * as Utils from 'src/libs/utils'
-import { isAzureWorkspace, isGoogleWorkspace } from 'src/libs/workspace-utils'
-import { findPotentialNotebookLockers, getExtension, getFileName, notebookLockHash } from 'src/pages/workspaces/workspace/analysis/file-utils'
+import { isAzureWorkspace, isGoogleWorkspace, isGoogleWorkspaceInfo, WorkspaceWrapper } from 'src/libs/workspace-utils'
+import {
+  AbsolutePath,
+  FileName,
+  findPotentialNotebookLockers, getDisplayName,
+  getExtension,
+  getFileName,
+  notebookLockHash
+} from 'src/pages/workspaces/workspace/analysis/file-utils'
 import { AnalysisDuplicator } from 'src/pages/workspaces/workspace/analysis/modals/AnalysisDuplicator'
 import { AnalysisModal } from 'src/pages/workspaces/workspace/analysis/modals/AnalysisModal'
 import ExportAnalysisModal from 'src/pages/workspaces/workspace/analysis/modals/ExportAnalysisModal'
 import { analysisLauncherTabName, analysisTabName, appLauncherTabName } from 'src/pages/workspaces/workspace/analysis/runtime-common-components'
 import { getCurrentRuntime } from 'src/pages/workspaces/workspace/analysis/runtime-utils'
-import { getToolLabelFromFileExtension, getToolLabelFromRuntime, runtimeTools, toolLabels, tools } from 'src/pages/workspaces/workspace/analysis/tool-utils'
+import {
+  App,
+  getToolLabelFromFileExtension,
+  getToolLabelFromRuntime, PersistentDisk, Runtime,
+  runtimeTools,
+  ToolLabel,
+  toolLabels,
+  tools
+} from 'src/pages/workspaces/workspace/analysis/tool-utils'
+import { AnalysisFile, useAnalysisFiles } from 'src/pages/workspaces/workspace/analysis/useAnalysisFiles'
+import { StorageDetails } from 'src/pages/workspaces/workspace/useWorkspace'
 import { wrapWorkspace } from 'src/pages/workspaces/workspace/WorkspaceContainer'
 
 
@@ -50,18 +69,19 @@ const tableFields = {
   lastModified: 'lastModified'
 }
 
-const KEY_ANALYSES_SORT_ORDER = 'AnalysesSortOrder'
+export const KEY_ANALYSES_SORT_ORDER = 'AnalysesSortOrder'
 
 const noWrite = 'You do not have access to modify this workspace.'
 
 const sortTokens = {
-  name: notebook => notebook.name.toLowerCase()
+  name: (notebook: AnalysisFile) => notebook.name.toLowerCase()
 }
+
 const defaultSort = { value: { field: tableFields.lastModified, direction: 'desc' } }
 
 const analysisContextMenuSize = 16
-const centerColumnFlex = { flex: 5 }
-const endColumnFlex = { flex: '0 0 150px', display: 'flex', justifyContent: 'flex-left', whiteSpace: 'nowrap' }
+const centerColumnFlex: CSSProperties = { flex: 5 }
+const endColumnFlex: CSSProperties = { flex: '0 0 150px', display: 'flex', justifyContent: 'flex-left', whiteSpace: 'nowrap' }
 
 const AnalysisCardHeaders = ({ sort, onSort }) => {
   return div({ role: 'row', style: { display: 'flex', justifyContent: 'space-between', marginTop: '1.5rem', paddingLeft: '1.5rem', marginBottom: '0.5rem' } }, [
@@ -80,18 +100,19 @@ const AnalysisCardHeaders = ({ sort, onSort }) => {
   ])
 }
 
+//TODO: move to separate file
 const AnalysisCard = ({
   currentRuntime, namespace, name, lastModified, metadata, application, workspaceName, onRename, onCopy, onDelete, onExport, canWrite,
   currentUserHash, potentialLockers
 }) => {
   const { lockExpiresAt, lastLockedBy } = metadata || {}
-  const lockExpirationDate = new Date(parseInt(lockExpiresAt))
-  const locked = currentUserHash && lastLockedBy && lastLockedBy !== currentUserHash && lockExpirationDate > Date.now()
+  const isLockExpired: boolean = new Date(parseInt(lockExpiresAt)).getTime() > Date.now()
+  const isLocked: boolean = currentUserHash && lastLockedBy && lastLockedBy !== currentUserHash && !isLockExpired
   const lockedBy = potentialLockers ? potentialLockers[lastLockedBy] : null
 
-  const analysisName = getFileName(name)
+  const analysisName: FileName = getFileName(name)
   const analysisLink = Nav.getLink(analysisLauncherTabName, { namespace, name: workspaceName, analysisName })
-  const toolLabel = getToolLabelFromFileExtension(name)
+  const toolLabel: ToolLabel = getToolLabelFromFileExtension(name)
 
   const currentRuntimeToolLabel = getToolLabelFromRuntime(currentRuntime)
 
@@ -114,11 +135,11 @@ const AnalysisCard = ({
         h(MenuButton, {
           'aria-label': 'Edit',
           href: analysisEditLink,
-          disabled: locked || !canWrite || currentRuntimeToolLabel === toolLabels.RStudio,
+          disabled: isLocked || !canWrite || currentRuntimeToolLabel === toolLabels.RStudio,
           tooltip: Utils.cond([!canWrite, () => noWrite],
             [currentRuntimeToolLabel === toolLabels.RStudio, () => 'You must have a runtime with Jupyter to edit.']),
           tooltipSide: 'left'
-        }, locked ? [makeMenuIcon('lock'), 'Open (In Use)'] : [makeMenuIcon('edit'), 'Edit']),
+        }, isLocked ? [makeMenuIcon('lock'), 'Open (In Use)'] : [makeMenuIcon('edit'), 'Edit']),
         h(MenuButton, {
           'aria-label': 'Playground',
           href: analysisPlaygroundLink,
@@ -138,7 +159,7 @@ const AnalysisCard = ({
       h(MenuButton, {
         'aria-label': 'Copy',
         disabled: !canWrite,
-        tooltip: !canWrite && noWrite,
+        tooltip: !canWrite ? noWrite : undefined,
         tooltipSide: 'left',
         onClick: () => onCopy()
       }, [makeMenuIcon('copy'), 'Make a copy']),
@@ -160,14 +181,14 @@ const AnalysisCard = ({
       h(MenuButton, {
         'aria-label': 'Rename',
         disabled: !canWrite,
-        tooltip: !canWrite && noWrite,
+        tooltip: !canWrite ? noWrite : undefined,
         tooltipSide: 'left',
         onClick: () => onRename()
       }, [makeMenuIcon('renameIcon'), 'Rename']),
       h(MenuButton, {
         'aria-label': 'Delete',
         disabled: !canWrite,
-        tooltip: !canWrite && noWrite,
+        tooltip: !canWrite ? noWrite : undefined,
         tooltipSide: 'left',
         onClick: () => onDelete()
       }, [makeMenuIcon('trash'), 'Delete'])
@@ -182,17 +203,17 @@ const AnalysisCard = ({
 
   //the flex values for columns here correspond to the flex values in the header
   const artifactName = div({
+    onClick: () => Nav.goToPath(analysisLauncherTabName, { namespace, name: workspaceName, analysisName }),
     title: getFileName(name),
-
     role: 'cell',
     style: {
-      ...Style.elements.card.title, whiteSpace: 'normal', overflowY: 'auto', textAlign: 'left', ...centerColumnFlex
+      ...Style.elements.card.title, whiteSpace: 'normal', textAlign: 'left', cursor: 'pointer', ...centerColumnFlex
     }
   }, [
-    a({ href: analysisLink }, [getFileName(name)])
+    getFileName(name)
   ])
 
-  const toolIconSrc = Utils.switchCase(application,
+  const toolIconSrc: string = Utils.switchCase(application,
     [toolLabels.Jupyter, () => jupyterLogo],
     [toolLabels.RStudio, () => rstudioSquareLogo],
     [toolLabels.JupyterLab, () => jupyterLogo]
@@ -214,7 +235,7 @@ const AnalysisCard = ({
     artifactName,
     div({ role: 'cell', style: { ...endColumnFlex, flexDirection: 'row' } }, [
       div({ style: { flex: 1, display: 'flex' } }, [
-        locked && h(Clickable, {
+        isLocked && h(Clickable, {
           'aria-label': `${artifactName} artifact label`,
           style: { display: 'flex', paddingRight: '1rem', color: colors.dark(0.75) },
           tooltip: `This analysis is currently being edited by ${lockedBy || 'another user'}`
@@ -230,41 +251,88 @@ const AnalysisCard = ({
   ])
 }
 
-const Analyses = _.flow(
-  forwardRefWithName('Analyses'),
-  requesterPaysWrapper({
-    onDismiss: () => Nav.history.goBack()
-  }),
-  wrapWorkspace({
-    breadcrumbs: props => breadcrumbs.commonPaths.workspaceDashboard(props),
-    title: 'Analyses',
-    activeTab: 'analyses'
-  }),
-  withViewToggle('analysesTab')
-)(({
-  name: workspaceName, namespace, workspace, workspace: { accessLevel, canShare, workspace: { cloudPlatform, workspaceId, googleProject, bucketName } },
+const activeFileTransferMessage = div({
+  style: _.merge(
+    Style.elements.card.container,
+    { backgroundColor: colors.warning(0.15), flexDirection: 'none', justifyContent: 'start', alignItems: 'center' })
+}, [
+  icon('warning-standard', { size: 19, style: { color: colors.warning(), flex: 'none', marginRight: '1rem' } }),
+  'Copying 1 or more interactive analysis files from another workspace.',
+  span({ style: { fontWeight: 'bold', marginLeft: '0.5ch' } }, ['This may take a few minutes.'])
+])
+
+export type DisplayAnalysisFile = AnalysisFile & {
+  application: ToolLabel
+}
+
+export const decorateAnalysisFiles = (rawAnalyses: AnalysisFile[]): DisplayAnalysisFile[] => {
+  const notebooks: AnalysisFile[] = _.filter(({ name }) => _.includes(getExtension(name), runtimeTools.Jupyter.ext), rawAnalyses)
+  const rAnalyses: AnalysisFile[] = _.filter(({ name }) => _.includes(getExtension(name), runtimeTools.RStudio.ext), rawAnalyses)
+
+  //we map the `toolLabel` corresponding header label, which simplifies the table sorting code
+  const enhancedNotebooks: DisplayAnalysisFile[] = _.map(file => ({ application: tools.Jupyter.label, ...file }), notebooks)
+  const enhancedRmd: DisplayAnalysisFile[] = _.map(file => ({ application: tools.RStudio.label, ...file }), rAnalyses)
+
+  const tempAnalyses: DisplayAnalysisFile[] = _.concat(enhancedNotebooks, enhancedRmd)
+  return _.reverse(_.sortBy(tableFields.lastModified, tempAnalyses))
+}
+
+export const getUniqueFileName = (originalName: string, existingFileNames: FileName[]): FileName => {
+  const name: FileName = originalName as FileName
+  let resolvedName: FileName = name
+  let c = 0
+  while (_.includes(resolvedName, existingFileNames)) {
+    resolvedName = `${getDisplayName(name)}_${++c}.${getExtension(name)}` as FileName
+  }
+  return resolvedName
+}
+
+export interface AnalysesData {
+  apps: App[]
+  refreshApps: () => Promise<void>
+  runtimes: Runtime[]
+  refreshRuntimes: () => Promise<void>
+  appDataDisks: PersistentDisk[]
+  persistentDisks: PersistentDisk[]
+}
+
+export interface AnalysesProps {
+  workspace: WorkspaceWrapper
+  analysesData: AnalysesData
+  onRequesterPaysError: () => void
+  storageDetails: StorageDetails
+}
+
+export interface SortOrderInfo {
+  field: string
+  direction: 'asc' | 'desc'
+}
+
+export const BaseAnalyses: FC<AnalysesProps> = ({
+  workspace,
   analysesData: { apps, refreshApps, runtimes, refreshRuntimes, appDataDisks, persistentDisks },
   storageDetails: { googleBucketLocation, azureContainerRegion },
   onRequesterPaysError
-}, _ref) => {
-  const [renamingAnalysisName, setRenamingAnalysisName] = useState(undefined)
-  const [copyingAnalysisName, setCopyingAnalysisName] = useState(undefined)
-  const [deletingAnalysisName, setDeletingAnalysisName] = useState(undefined)
-  const [exportingAnalysisName, setExportingAnalysisName] = useState(undefined)
-  const [sortOrder, setSortOrder] = useState(() => getLocalPref(KEY_ANALYSES_SORT_ORDER) || defaultSort.value)
-  const enableJupyterLabPersistenceId = `${namespace}/${workspaceName}/enableJupyterLabGCP`
-  const [enableJupyterLabGCP, setEnableJupyterLabGCP] = useState(() => getLocalPref(enableJupyterLabPersistenceId) || false)
+}: AnalysesProps, _ref) => {
+  const [renamingAnalysisName, setRenamingAnalysisName] = useState<AbsolutePath | undefined>(undefined)
+  const [copyingAnalysisName, setCopyingAnalysisName] = useState<AbsolutePath | undefined>(undefined)
+  const [deletingAnalysisName, setDeletingAnalysisName] = useState<AbsolutePath | undefined>(undefined)
+  const [exportingAnalysisName, setExportingAnalysisName] = useState<AbsolutePath | undefined>(undefined)
+  const [sortOrder, setSortOrder] = useState<SortOrderInfo>(() => getLocalPref(KEY_ANALYSES_SORT_ORDER) || defaultSort.value)
   const [feedbackShowing, setFeedbackShowing] = useState(false)
   const [filter, setFilter] = useState(() => StateHistory.get().filter || '')
   const [busy, setBusy] = useState(false)
   const [creating, setCreating] = useState(false)
-  const [analyses, setAnalyses] = useState(() => StateHistory.get().analyses || undefined)
-  const [currentUserHash, setCurrentUserHash] = useState(undefined)
+  const [analyses, setAnalyses] = useState<DisplayAnalysisFile[] | undefined>(() => StateHistory.get().analyses || undefined)
+  const [currentUserHash, setCurrentUserHash] = useState<string | undefined>(undefined)
   const [potentialLockers, setPotentialLockers] = useState(undefined)
   const [activeFileTransfers, setActiveFileTransfers] = useState(false)
+  const enableJupyterLabPersistenceId: string = `${workspace.workspace.namespace}/${workspace.workspace.name}/${ENABLE_JUPYTERLAB_ID}`
+  const [enableJupyterLabGCP, setEnableJupyterLabGCP] = useState<boolean>(() => getLocalPref(enableJupyterLabPersistenceId) || false)
 
   const authState = useStore(authStore)
   const signal = useCancellation()
+  const { loadedState, refreshFileStore, create, deleteFile } = useAnalysisFiles()
   const currentRuntime = getCurrentRuntime(runtimes)
   const location = Utils.cond(
     [isGoogleWorkspace(workspace), () => googleBucketLocation],
@@ -272,119 +340,51 @@ const Analyses = _.flow(
     () => null
   )
 
-  // Helpers
-  //TODO: does this prevent users from making an .Rmd with the same name as an .ipynb?
-  const existingNames = _.map(({ name }) => {
-    return getFileName(name)
-  }, analyses)
+  const { accessLevel, workspace: workspaceInfo } = workspace
 
-  const loadGoogleAnalyses = async () => {
-    const rawAnalyses = await Ajax(signal).Buckets.listAnalyses(googleProject, bucketName)
-    const notebooks = _.filter(({ name }) => _.endsWith(`.${tools.Jupyter.ext}`, name), rawAnalyses)
-    const rAnalyses = _.filter(({ name }) => _.includes(getExtension(name), tools.RStudio.ext), rawAnalyses)
+  const refreshAnalyses: () => Promise<void> = withHandlers([withRequesterPaysHandler(onRequesterPaysError) as any], refreshFileStore)
 
-    //we map the `toolLabel` corresponding header label, which simplifies the table sorting code
-    const enhancedNotebooks = _.map(_.set('application', tools.Jupyter.label), notebooks)
-    const enhancedRmd = _.map(_.set('application', tools.RStudio.label), rAnalyses)
-
-    const analyses = _.concat(enhancedNotebooks, enhancedRmd)
-    setAnalyses(_.reverse(_.sortBy(tableFields.lastModified, analyses)))
-  }
-
-  const loadAzureAnalyses = async () => {
-    const analyses = await Ajax(signal).AzureStorage.listNotebooks(workspaceId)
-    const enhancedAnalyses = _.map(_.set('application', tools.JupyterLab.label), analyses)
-    setAnalyses(_.reverse(_.sortBy(tableFields.lastModified, enhancedAnalyses)))
-  }
-
-  const refreshAnalyses = _.flow(
-    withRequesterPaysHandler(onRequesterPaysError),
-    withErrorReporting('Error loading analyses'),
+  const existingFileNames: FileName[] = _.map((analysis: DisplayAnalysisFile) => analysis.fileName, analyses)
+  const uploadFiles: (files: File[]) => Promise<unknown> = _.flow(
+    withErrorReporting('Error uploading files. Ensure the file has the proper extension'),
     Utils.withBusyState(setBusy)
-  )(!!googleProject ? loadGoogleAnalyses : loadAzureAnalyses)
-
-  const getActiveFileTransfers = _.flow(
-    withErrorReporting('Error loading file transfer status for notebooks in the workspace.'),
-    Utils.withBusyState(setBusy)
-  )(async () => {
-    const fileTransfers = await Ajax(signal).Workspaces.workspace(namespace, workspaceName).listActiveFileTransfers()
-    setActiveFileTransfers(!_.isEmpty(fileTransfers))
-  })
-
-  const uploadFiles = _.flow(
-    withErrorReporting('Error uploading files'),
-    Utils.withBusyState(setBusy)
-  )(async files => {
-    try {
-      await Promise.all(_.map(file => {
-        const name = file.name
-        const toolLabel = getToolLabelFromFileExtension(file.name)
-        let resolvedName = name
-        let c = 0
-        while (_.includes(resolvedName, existingNames)) {
-          resolvedName = `${name} ${++c}`
-        }
-        return !!googleProject ?
-          Ajax().Buckets.analysis(googleProject, bucketName, resolvedName, toolLabel).create(file) :
-          Ajax(signal).AzureStorage.blob(workspaceId, resolvedName).create(file)
-      }, files))
-      refreshAnalyses()
-    } catch (error) {
-      if (error instanceof SyntaxError) {
-        reportError('Error uploading analysis', 'This file is not formatted correctly, ensure it has the correct extension')
-      } else {
-        reportError('Error creating analysis', error)
-      }
-    }
+  )(async (files: File[]) => {
+    await Promise.all(_.map(file => {
+      const uniqueFileName = getUniqueFileName(file.name, existingFileNames)
+      const toolLabel: ToolLabel = getToolLabelFromFileExtension(getExtension(file.name))
+      return create(uniqueFileName, toolLabel, file)
+    }, files))
   })
 
   // Lifecycle
-  useOnMount(_.flow(
-    withErrorReporting('Error loading analyses'),
-    Utils.withBusyState(setBusy)
-  )(async () => {
-    const [currentUserHash, potentialLockers] = !!googleProject ?
-      await Promise.all([notebookLockHash(bucketName, authState.user.email), findPotentialNotebookLockers({ canShare, namespace, workspaceName, bucketName })]) :
-      await Promise.all([Promise.resolve(undefined), Promise.resolve([])])
+  useOnMount(() => {
+    const load = _.flow(
+      withErrorReporting('Error loading analyses'),
+      Utils.withBusyState(setBusy)
+    )(async () => {
+      const [currentUserHash, potentialLockers]: [string | undefined, any] = isGoogleWorkspace(workspace) ?
+        await Promise.all([notebookLockHash(workspace.workspace.bucketName, authState.user.email), findPotentialNotebookLockers(workspace)]) :
+        await Promise.all([Promise.resolve(undefined), Promise.resolve([])])
 
-    setCurrentUserHash(currentUserHash)
-    setPotentialLockers(potentialLockers)
-    getActiveFileTransfers()
-    await refreshAnalyses()
-    await refreshRuntimes()
+      setCurrentUserHash(currentUserHash)
+      setPotentialLockers(potentialLockers)
+
+      const fileTransfers: any[] = await Ajax(signal).Workspaces.workspace(workspaceInfo.namespace, workspaceInfo.name).listActiveFileTransfers()
+      setActiveFileTransfers(!_.isEmpty(fileTransfers))
+
+      await refreshRuntimes()
+    })
+
+    load()
   })
-  )
 
+  //We reference the analyses from `useAnalysisStore`, and on change, we decorate them from `AnalysisFile[]` to `DisplayAnalysisFile[]` and update state history
   useEffect(() => {
-    StateHistory.update({ analyses, sortOrder, filter })
-  }, [analyses, sortOrder, filter])
-
-  useEffect(() => {
-    setLocalPref(enableJupyterLabPersistenceId, enableJupyterLabGCP)
-  }, [enableJupyterLabGCP, enableJupyterLabPersistenceId])
-
-  const noAnalysisBanner = div([
-    div({ style: { fontSize: 48 } }, ['A place for all your analyses ']),
-    div({ style: { display: 'flex', flexDirection: 'row', justifyContent: 'space-evenly', alignItems: 'center', columnGap: '5rem' } }, _.dropRight(!!googleProject ? 0 : 2, [
-      img({ src: jupyterLogo, style: { height: 120, width: 80 }, alt: 'Jupyter' }),
-      img({ src: rstudioBioLogo, style: { width: 400 }, alt: 'RStudio Bioconductor' }),
-      img({ src: galaxyLogo, style: { height: 60, width: 208 }, alt: 'Galaxy' })
-    ])
-    ),
-    div({ style: { marginTop: '1rem', fontSize: 20 } }, [
-      'Click the button above to create an analysis.'
-    ])
-  ])
-
-  const activeFileTransferMessage = div({
-    style: _.merge(
-      Style.elements.card.container,
-      { backgroundColor: colors.warning(0.15), flexDirection: 'none', justifyContent: 'start', alignItems: 'center' })
-  }, [
-    icon('warning-standard', { size: 19, style: { color: colors.warning(), flex: 'none', marginRight: '1rem' } }),
-    'Copying 1 or more interactive analysis files from another workspace.',
-    span({ style: { fontWeight: 'bold', marginLeft: '0.5ch' } }, ['This may take a few minutes.'])
-  ])
+    const rawAnalyses: AnalysisFile[] = loadedState.status !== 'None' && loadedState.state !== null ? loadedState.state : []
+    const decoratedAnalyses = decorateAnalysisFiles(rawAnalyses)
+    setAnalyses(decoratedAnalyses)
+    StateHistory.update({ analyses: decoratedAnalyses, sortOrder, filter })
+  }, [loadedState.status, sortOrder, filter]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const previewJupyterLabMessage = div({
     style: _.merge(
@@ -405,19 +405,34 @@ const Analyses = _.flow(
         div({
           style: { display: 'flex', alignItems: 'center' }
         }, [
-          label({ htmlFor: id, style: { fontWeight: 'bold', margin: '0 0.5rem', whiteSpace: 'nowrap' } }, 'Enable JupyterLab'),
+          label({ htmlFor: id, style: { fontWeight: 'bold', margin: '0 0.5rem', whiteSpace: 'nowrap' } }, ['Enable JupyterLab']),
           h(Switch, {
-            id,
-            checked: enableJupyterLabGCP,
+            // @ts-expect-error
             onLabel: '', offLabel: '',
-            width: 40, height: 20,
             onChange: value => {
               setEnableJupyterLabGCP(value)
-              Ajax().Metrics.captureEvent(Events.analysisToggleJupyterLabGCP, { ...extractWorkspaceDetails(workspace.workspace), enabled: value })
-            }
-          })
+              setLocalPref(enableJupyterLabPersistenceId, value)
+              Ajax().Metrics.captureEvent(Events.analysisToggleJupyterLabGCP, { ...extractWorkspaceDetails(workspaceInfo), enabled: value })
+            },
+            id,
+            checked: enableJupyterLabGCP,
+            width: 40, height: 20,
+          }, [])
         ])
       ])])
+    ])
+  ])
+
+  const noAnalysisBanner = div([
+    div({ style: { fontSize: 48 } }, ['A place for all your analyses ']),
+    div({ style: { display: 'flex', flexDirection: 'row', justifyContent: 'space-evenly', alignItems: 'center', columnGap: '5rem' } }, _.dropRight(isGoogleWorkspaceInfo(workspaceInfo) ? 0 : 2, [
+      img({ src: jupyterLogo, style: { height: 120, width: 80 }, alt: 'Jupyter' }),
+      img({ src: rstudioBioLogo, style: { width: 400 }, alt: 'RStudio Bioconductor' }),
+      img({ src: galaxyLogo, style: { height: 60, width: 208 }, alt: 'Galaxy' })
+    ])
+    ),
+    div({ style: { marginTop: '1rem', fontSize: 20 } }, [
+      'Click the button above to create an analysis.'
     ])
   ])
 
@@ -425,24 +440,27 @@ const Analyses = _.flow(
   const renderAnalyses = () => {
     const { field, direction } = sortOrder
     const canWrite = Utils.canWrite(accessLevel)
-    const renderedAnalyses = _.flow(
-      _.filter(({ name }) => Utils.textMatch(filter, getFileName(name))),
-      _.orderBy(sortTokens[field] || field, direction),
-      _.map(({ name, lastModified, metadata, application }) => h(AnalysisCard, {
-        key: name,
-        role: 'rowgroup',
-        currentRuntime, name, lastModified, metadata, application, namespace, workspaceName, canWrite, currentUserHash, potentialLockers,
-        onRename: () => setRenamingAnalysisName(name),
-        onCopy: () => setCopyingAnalysisName(name),
-        onExport: () => setExportingAnalysisName(name),
-        onDelete: () => setDeletingAnalysisName(name)
-      }))
-    )(analyses)
 
+    const filteredAnalyses: DisplayAnalysisFile[] = _.filter((analysisFile: DisplayAnalysisFile) => Utils.textMatch(filter, getFileName(analysisFile.name)), analyses)
+    // Lodash does not have a well-typed return on this function and there are not any nice alternatives, so expect error for now
+    // @ts-expect-error
+    const sortedAnalyses: DisplayAnalysisFile[] = _.orderBy(sortTokens[field] || field, direction, filteredAnalyses)
+    const analysisCards = _.map(({ name, lastModified, metadata, application }) => h(AnalysisCard, {
+      key: name,
+      role: 'rowgroup',
+      currentRuntime, name, lastModified, metadata, application, namespace: workspaceInfo.namespace, workspaceName: workspaceInfo.name, canWrite, currentUserHash, potentialLockers,
+      onRename: () => setRenamingAnalysisName(name),
+      onCopy: () => setCopyingAnalysisName(name),
+      onExport: () => setExportingAnalysisName(name),
+      onDelete: () => setDeletingAnalysisName(name)
+    }), sortedAnalyses)
+
+
+    const basePageStyles: CSSProperties = _.isEmpty(analyses) ? { alignItems: 'center', height: '80%' } : { flexDirection: 'column' }
     return div({
       style: {
         ..._.merge({ textAlign: 'center', display: 'flex', justifyContent: 'center', padding: '0 1rem 0 1rem' },
-          _.isEmpty(analyses) ? { alignItems: 'center', height: '80%' } : { flexDirection: 'column' })
+          basePageStyles)
       }
     }, [
       activeFileTransfers && activeFileTransferMessage,
@@ -461,10 +479,10 @@ const Analyses = _.flow(
       }),
       //Show the JupyterLab preview message only for GCP workspaces, because it's already the default for Azure workspaces
       //It's currently hidden behind a feature preview flag until the supporting documentation/blog post are ready
-      isFeaturePreviewEnabled('jupyterlab-gcp') && !_.isEmpty(analyses) && !!googleProject && previewJupyterLabMessage,
+      isFeaturePreviewEnabled(JUPYTERLAB_GCP_FEATURE_ID) && !_.isEmpty(analyses) && isGoogleWorkspace(workspace) && previewJupyterLabMessage,
       Utils.cond(
         [_.isEmpty(analyses), () => noAnalysisBanner],
-        [!_.isEmpty(analyses) && _.isEmpty(renderedAnalyses), () => {
+        [!_.isEmpty(analyses) && _.isEmpty(analysisCards), () => {
           return div({ style: { fontStyle: 'italic' } }, ['No matching analyses'])
         }],
         [Utils.DEFAULT, () => div({ role: 'table' }, [
@@ -474,7 +492,7 @@ const Analyses = _.flow(
               setSortOrder(newSortOrder)
             }
           }),
-          renderedAnalyses
+          analysisCards
         ])]
       )
     ])
@@ -512,7 +530,6 @@ const Analyses = _.flow(
         }),
         h(AnalysisModal, {
           isOpen: creating,
-          namespace,
           workspace,
           runtimes,
           persistentDisks,
@@ -528,35 +545,35 @@ const Analyses = _.flow(
           onDismiss: () => {
             setCreating(false)
           },
-          onError: async () => {
+          onError: () => {
             setCreating(false)
-            await refreshAnalyses()
-            await refreshRuntimes()
-            await refreshApps()
+            refreshAnalyses()
+            refreshRuntimes()
+            refreshApps()
           },
-          onSuccess: async () => {
+          onSuccess: () => {
             setCreating(false)
-            await refreshAnalyses()
-            await refreshRuntimes()
-            await refreshApps()
+            refreshAnalyses()
+            refreshRuntimes()
+            refreshApps()
           }
         }),
         renamingAnalysisName && h(AnalysisDuplicator, {
           printName: getFileName(renamingAnalysisName),
-          toolLabel: getToolLabelFromFileExtension(renamingAnalysisName),
-          workspaceInfo: { cloudPlatform, googleProject, workspaceId, namespace, name: workspaceName, bucketName },
+          toolLabel: getToolLabelFromFileExtension(getExtension(renamingAnalysisName)),
+          workspaceInfo,
           destroyOld: true,
           fromLauncher: false,
-          onDismiss: () => setRenamingAnalysisName(undefined),
-          onSuccess: () => {
+          onDismiss: () => {
             setRenamingAnalysisName(undefined)
             refreshAnalyses()
-          }
+          },
+          onSuccess: () => setRenamingAnalysisName(undefined)
         }),
         copyingAnalysisName && h(AnalysisDuplicator, {
           printName: getFileName(copyingAnalysisName),
-          toolLabel: getToolLabelFromFileExtension(copyingAnalysisName),
-          workspaceInfo: { cloudPlatform, googleProject, workspaceId, namespace, name: workspaceName, bucketName },
+          toolLabel: getToolLabelFromFileExtension(getExtension(copyingAnalysisName)),
+          workspaceInfo,
           destroyOld: false,
           fromLauncher: false,
           onDismiss: () => setCopyingAnalysisName(undefined),
@@ -566,13 +583,14 @@ const Analyses = _.flow(
           }
         }),
         exportingAnalysisName && h(ExportAnalysisModal, {
+          fromLauncher: false,
           printName: getFileName(exportingAnalysisName),
-          toolLabel: getToolLabelFromFileExtension(exportingAnalysisName),
+          toolLabel: getToolLabelFromFileExtension(getExtension(exportingAnalysisName)),
           workspace,
           onDismiss: () => setExportingAnalysisName(undefined)
         }),
         deletingAnalysisName && h(DeleteConfirmationModal, {
-          objectType: getToolLabelFromFileExtension(deletingAnalysisName) ? `${getToolLabelFromFileExtension(deletingAnalysisName)} analysis` : 'analysis',
+          objectType: getToolLabelFromFileExtension(getExtension(deletingAnalysisName)) ? `${getToolLabelFromFileExtension(getExtension(deletingAnalysisName))} analysis` : 'analysis',
           objectName: getFileName(deletingAnalysisName),
           buttonText: 'Delete analysis',
           onConfirm: _.flow(
@@ -580,26 +598,30 @@ const Analyses = _.flow(
             withErrorReporting('Error deleting analysis.')
           )(async () => {
             setDeletingAnalysisName(undefined)
-            if (!!googleProject) {
-              await Ajax().Buckets.analysis(
-                googleProject,
-                bucketName,
-                getFileName(deletingAnalysisName),
-                getToolLabelFromFileExtension(deletingAnalysisName)
-              ).delete()
-            } else {
-              await Ajax(signal).AzureStorage.blob(workspaceId, getFileName(deletingAnalysisName)).delete()
-            }
-            refreshAnalyses()
+            await deleteFile(deletingAnalysisName)
           }),
           onDismiss: () => setDeletingAnalysisName(undefined)
         })
       ]),
       renderAnalyses()
     ]),
-    busy && spinnerOverlay
+    (loadedState.status === 'Loading' || busy) && spinnerOverlay
   ])])
-})
+}
+
+const Analyses = _.flow(
+  forwardRefWithName('Analyses'),
+  requesterPaysWrapper({
+    onDismiss: () => Nav.history.goBack()
+  }),
+  wrapWorkspace({
+    breadcrumbs: props => breadcrumbs.commonPaths.workspaceDashboard(props),
+    title: 'Analyses',
+    activeTab: 'analyses',
+    topBarContent: null
+  }),
+  withViewToggle('analysesTab')
+)(BaseAnalyses)
 
 export const navPaths = [
   {

--- a/src/pages/workspaces/workspace/analysis/AnalysisLauncher.js
+++ b/src/pages/workspaces/workspace/analysis/AnalysisLauncher.js
@@ -16,6 +16,7 @@ import { Metrics } from 'src/libs/ajax/Metrics'
 import colors from 'src/libs/colors'
 import { withErrorReporting } from 'src/libs/error'
 import Events from 'src/libs/events'
+import { ENABLE_JUPYTERLAB_ID } from 'src/libs/feature-previews-config'
 import * as Nav from 'src/libs/nav'
 import { notify } from 'src/libs/notifications'
 import { getLocalPref, setLocalPref } from 'src/libs/prefs'
@@ -264,7 +265,7 @@ const PreviewHeader = ({
   const analysisLink = Nav.getLink(analysisLauncherTabName, { namespace, name, analysisName })
   const isAzureWorkspace = !!workspace.azureContext
   const currentRuntimeToolLabel = getToolLabelFromRuntime(runtime)
-  const enableJupyterLabPersistenceId = `${namespace}/${name}/enableJupyterLabGCP`
+  const enableJupyterLabPersistenceId = `${namespace}/${name}/${ENABLE_JUPYTERLAB_ID}`
   const [enableJupyterLabGCP] = useState(() => getLocalPref(enableJupyterLabPersistenceId) || false)
 
   const checkIfLocked = withErrorReporting('Error checking analysis lock status', async () => {

--- a/src/pages/workspaces/workspace/analysis/_testData/testData.ts
+++ b/src/pages/workspaces/workspace/analysis/_testData/testData.ts
@@ -185,7 +185,6 @@ export const getJupyterRuntimeConfig = ({ diskId = getRandomInt(randomMaxInt), m
   gpuConfig: null
 })
 
-// NOSONAR
 export const getRandomInt = max => Math.floor(Math.random() * max)
 
 export const defaultAuditInfo = {

--- a/src/pages/workspaces/workspace/analysis/_testData/testData.ts
+++ b/src/pages/workspaces/workspace/analysis/_testData/testData.ts
@@ -185,6 +185,7 @@ export const getJupyterRuntimeConfig = ({ diskId = getRandomInt(randomMaxInt), m
   gpuConfig: null
 })
 
+// NOSONAR
 export const getRandomInt = max => Math.floor(Math.random() * max)
 
 export const defaultAuditInfo = {

--- a/src/pages/workspaces/workspace/analysis/_testData/testData.ts
+++ b/src/pages/workspaces/workspace/analysis/_testData/testData.ts
@@ -2,7 +2,12 @@ import _ from 'lodash/fp'
 import { defaultAzureRegion } from 'src/libs/azure-utils'
 import * as Utils from 'src/libs/utils'
 import {
-  defaultGceBootDiskSize, defaultGceMachineType, defaultGcePersistentDiskSize, defaultLocation, defaultPersistentDiskType, runtimeStatuses
+  defaultGceBootDiskSize,
+  defaultGceMachineType,
+  defaultGcePersistentDiskSize,
+  defaultLocation,
+  defaultPersistentDiskType,
+  runtimeStatuses
 } from 'src/pages/workspaces/workspace/analysis/runtime-utils'
 import { toolLabels, tools } from 'src/pages/workspaces/workspace/analysis/tool-utils'
 import { v4 as uuid } from 'uuid'

--- a/src/pages/workspaces/workspace/analysis/file-utils.test.ts
+++ b/src/pages/workspaces/workspace/analysis/file-utils.test.ts
@@ -6,20 +6,13 @@ import { GoogleStorage, GoogleStorageContract } from 'src/libs/ajax/GoogleStorag
 import { reportError } from 'src/libs/error'
 import { workspaceStore } from 'src/libs/state'
 import { ReadyState } from 'src/libs/type-utils/LoadedState'
-import {
-  CloudProviderType,
-  cloudProviderTypes
-} from 'src/libs/workspace-utils'
 import { defaultAzureWorkspace, defaultGoogleWorkspace } from 'src/pages/workspaces/workspace/analysis/_testData/testData'
 import {
   AbsolutePath,
-  AnalysisFile,
-  getDisplayName,
-  getExtension,
-  getFileName,
-  useAnalysisFiles
+  getExtension, getFileName
 } from 'src/pages/workspaces/workspace/analysis/file-utils'
-import { getToolLabelFromFileExtension, ToolLabel, toolLabels } from 'src/pages/workspaces/workspace/analysis/tool-utils'
+import { getToolLabelFromFileExtension, toolLabels } from 'src/pages/workspaces/workspace/analysis/tool-utils'
+import { AnalysisFile, getFileFromPath, useAnalysisFiles } from 'src/pages/workspaces/workspace/analysis/useAnalysisFiles'
 import { asMockedFn } from 'src/testing/test-utils'
 
 
@@ -36,17 +29,6 @@ jest.mock('src/libs/notifications', () => ({
     console.debug({ method: 'notify', args: [...args] })/* eslint-disable-line */
   })
 }))
-
-//TODO: test commons
-const getTestFile = (abs: AbsolutePath, cloudProvider: CloudProviderType = cloudProviderTypes.GCP): AnalysisFile => ({
-  name: abs,
-  ext: getExtension(abs),
-  displayName: getDisplayName(abs),
-  fileName: getFileName(abs),
-  tool: getToolLabelFromFileExtension(getExtension(abs)) as ToolLabel,
-  lastModified: new Date().getTime(),
-  cloudProvider
-})
 
 describe('file-utils', () => {
   describe('useAnalysisFiles', () => {
@@ -65,7 +47,7 @@ describe('file-utils', () => {
 
     it('returns the correct files', async () => {
       // Arrange
-      const fileList: AnalysisFile[] = [getTestFile('test/file1.ipynb' as AbsolutePath), getTestFile('test/file2.ipynb' as AbsolutePath)]
+      const fileList: AnalysisFile[] = [getFileFromPath('test/file1.ipynb' as AbsolutePath), getFileFromPath('test/file2.ipynb' as AbsolutePath)]
 
       const listAnalyses = jest.fn(() => Promise.resolve(fileList))
       const googleStorageMock: Partial<GoogleStorageContract> = ({
@@ -86,7 +68,7 @@ describe('file-utils', () => {
 
     it('loads files from the correct cloud provider storage with a google workspace', async () => {
       // Arrange
-      const fileList: AnalysisFile[] = [getTestFile('test/file1.ipynb' as AbsolutePath), getTestFile('test/file2.ipynb' as AbsolutePath)]
+      const fileList: AnalysisFile[] = [getFileFromPath('test/file1.ipynb' as AbsolutePath), getFileFromPath('test/file2.ipynb' as AbsolutePath)]
 
       const listAnalyses = jest.fn(() => Promise.resolve(fileList))
       const googleStorageMock: Partial<GoogleStorageContract> = ({
@@ -105,7 +87,7 @@ describe('file-utils', () => {
 
     it('loads files from the correct cloud provider storage with an azure workspace', async () => {
       // Arrange
-      const fileList = [getTestFile('test/file1.ipynb' as AbsolutePath), getTestFile('test/file2.ipynb' as AbsolutePath)]
+      const fileList = [getFileFromPath('test/file1.ipynb' as AbsolutePath), getFileFromPath('test/file2.ipynb' as AbsolutePath)]
 
       const calledMock = jest.fn(() => Promise.resolve(fileList))
       const azureStorageMock: Partial<AzureStorageContract> = ({
@@ -124,7 +106,7 @@ describe('file-utils', () => {
 
     it('creates a file with a GCP workspace', async () => {
       // Arrange
-      const fileList: AnalysisFile[] = [getTestFile('test/file1.ipynb' as AbsolutePath), getTestFile('test/file2.ipynb' as AbsolutePath)]
+      const fileList: AnalysisFile[] = [getFileFromPath('test/file1.ipynb' as AbsolutePath), getFileFromPath('test/file2.ipynb' as AbsolutePath)]
 
       const listAnalyses = jest.fn(() => Promise.resolve(fileList))
       const create = jest.fn(() => Promise.resolve())
@@ -141,9 +123,7 @@ describe('file-utils', () => {
       workspaceStore.set(defaultGoogleWorkspace)
       const { result: hookReturnRef, waitForNextUpdate } = renderHook(() => useAnalysisFiles())
       await waitForNextUpdate()
-      await act(async () => {
-        await hookReturnRef.current.create('AnalysisFile', toolLabels.Jupyter, 'myContents')
-      })
+      await act(() => hookReturnRef.current.create('AnalysisFile', toolLabels.Jupyter, 'myContents'))
 
       // Assert
       expect(create).toHaveBeenCalledWith('myContents')
@@ -168,9 +148,7 @@ describe('file-utils', () => {
       const hookRender1 = renderHook(() => useAnalysisFiles())
       await hookRender1.waitForNextUpdate()
       const hookResult2 = hookRender1.result.current
-      await act(async () => {
-        await hookResult2.create('AnalysisFile', toolLabels.Jupyter, 'myContents')
-      })
+      await act(() => hookResult2.create('AnalysisFile', toolLabels.Jupyter, 'myContents'))
 
       // Assert
       expect(create).toHaveBeenCalledWith('myContents')
@@ -179,7 +157,7 @@ describe('file-utils', () => {
 
     it('creates a file with an Azure workspace', async () => {
       // Arrange
-      const fileList: AnalysisFile[] = [getTestFile('test/file1.ipynb' as AbsolutePath), getTestFile('test/file2.ipynb' as AbsolutePath)]
+      const fileList: AnalysisFile[] = [getFileFromPath('test/file1.ipynb' as AbsolutePath), getFileFromPath('test/file2.ipynb' as AbsolutePath)]
 
       const listNotebooks = jest.fn(() => Promise.resolve(fileList))
       const create = jest.fn(() => Promise.resolve())
@@ -195,9 +173,7 @@ describe('file-utils', () => {
       const { result: hookReturnRef, waitForNextUpdate } = renderHook(() => useAnalysisFiles())
       await waitForNextUpdate()
       // Act
-      await act(async () => {
-        await hookReturnRef.current.create('AnalysisFile', toolLabels.Jupyter, 'myContents')
-      })
+      await act(() => hookReturnRef.current.create('AnalysisFile', toolLabels.Jupyter, 'myContents'))
 
       // Assert
       expect(create).toHaveBeenCalledWith('myContents')
@@ -222,12 +198,121 @@ describe('file-utils', () => {
     const hookRender1 = renderHook(() => useAnalysisFiles())
     await hookRender1.waitForNextUpdate()
     const hookResult2 = hookRender1.result.current
-    await act(async () => {
-      await hookResult2.create('AnalysisFile', toolLabels.Jupyter, 'myContents')
-    })
+    await act(() => hookResult2.create('AnalysisFile', toolLabels.Jupyter, 'myContents'))
 
     // Assert
     expect(create).toHaveBeenCalledWith('myContents')
+    expect(reportError).toHaveBeenCalled()
+  })
+
+
+  // file deletion tests
+
+  it('deletes a file with a GCP workspace', async () => {
+    // Arrange
+    const file1Path = 'test/file1.ipynb' as AbsolutePath
+    const fileList: AnalysisFile[] = [getFileFromPath(file1Path), getFileFromPath('test/file2.ipynb' as AbsolutePath)]
+
+    const listAnalyses = jest.fn(() => Promise.resolve(fileList))
+    const doDelete = jest.fn(() => Promise.resolve())
+    const analysisMock: Partial<GoogleStorageContract['analysis']> = jest.fn(() => ({
+      delete: doDelete
+    }))
+    const googleStorageMock: Partial<GoogleStorageContract> = ({
+      listAnalyses,
+      analysis: analysisMock as GoogleStorageContract['analysis']
+    })
+    asMockedFn(GoogleStorage).mockImplementation(() => googleStorageMock as GoogleStorageContract)
+
+    // Act
+    workspaceStore.set(defaultGoogleWorkspace)
+    const { result: hookReturnRef, waitForNextUpdate } = renderHook(() => useAnalysisFiles())
+    await waitForNextUpdate()
+    await act(() => hookReturnRef.current.deleteFile(file1Path))
+
+    // Assert
+    expect(analysisMock).toHaveBeenCalledWith(defaultGoogleWorkspace.workspace.googleProject, defaultGoogleWorkspace.workspace.bucketName, getFileName(file1Path), getToolLabelFromFileExtension(getExtension(file1Path)))
+    expect(doDelete).toHaveBeenCalled()
+  })
+
+  it('Fails to create a file with a GCP workspace', async () => {
+    // Arrange
+    const file1Path = 'test/file1.ipynb' as AbsolutePath
+    const listAnalyses = jest.fn(() => Promise.resolve([]))
+    const doDelete = jest.fn(() => Promise.reject(new Error('myError')))
+    const analysisMock: Partial<GoogleStorageContract['analysis']> = jest.fn(() => ({
+      delete: doDelete,
+      refresh: jest.fn(() => Promise.reject(new Error('ee')))
+    }))
+    const googleStorageMock: Partial<GoogleStorageContract> = ({
+      listAnalyses,
+      analysis: analysisMock as GoogleStorageContract['analysis']
+    })
+    asMockedFn(GoogleStorage).mockImplementation(() => googleStorageMock as GoogleStorageContract)
+
+    // Act
+    workspaceStore.set(defaultGoogleWorkspace)
+    const hookRender1 = renderHook(() => useAnalysisFiles())
+    await hookRender1.waitForNextUpdate()
+    const hookResult2 = hookRender1.result.current
+    await act(() => hookResult2.deleteFile(file1Path))
+
+    // Assert
+    expect(analysisMock).toHaveBeenCalledWith(defaultGoogleWorkspace.workspace.googleProject, defaultGoogleWorkspace.workspace.bucketName, getFileName(file1Path), getToolLabelFromFileExtension(getExtension(file1Path)))
+    expect(doDelete).toHaveBeenCalled()
+    expect(reportError).toHaveBeenCalled()
+  })
+
+  it('creates a file with an Azure workspace', async () => {
+    // Arrange
+    const file1Path = 'test/file1.ipynb' as AbsolutePath
+    const fileList: AnalysisFile[] = [getFileFromPath(file1Path), getFileFromPath('test/file2.ipynb' as AbsolutePath)]
+
+    const listNotebooks = jest.fn(() => Promise.resolve(fileList))
+    const doDelete = jest.fn(() => Promise.resolve())
+    const blobMock: Partial<AzureStorageContract['blob']> = jest.fn(() => ({
+      delete: doDelete
+    }))
+    const azureStorageMock: Partial<AzureStorageContract> = ({
+      listNotebooks,
+      blob: blobMock as AzureStorageContract['blob']
+    })
+    asMockedFn(AzureStorage).mockImplementation(() => azureStorageMock as AzureStorageContract)
+    workspaceStore.set(defaultAzureWorkspace)
+    const { result: hookReturnRef, waitForNextUpdate } = renderHook(() => useAnalysisFiles())
+    await waitForNextUpdate()
+    // Act
+    await act(() => hookReturnRef.current.deleteFile(file1Path))
+
+    // Assert
+    expect(blobMock).toHaveBeenCalledWith(defaultAzureWorkspace.workspace.workspaceId, getFileName(file1Path))
+    expect(doDelete).toHaveBeenCalled()
+  })
+
+  it('Fails to create a file with an Azure workspace', async () => {
+    // Arrange
+    const file1Path = 'test/file1.ipynb' as AbsolutePath
+    const listNotebooks = jest.fn(() => Promise.resolve([]))
+    const doDelete = jest.fn(() => Promise.reject(new Error('myError')))
+    const blobMock: Partial<AzureStorageContract['blob']> = jest.fn(() => ({
+      delete: doDelete
+    }))
+    const azureStorageMock: Partial<AzureStorageContract> = ({
+      listNotebooks,
+      blob: blobMock as AzureStorageContract['blob']
+    })
+    asMockedFn(AzureStorage).mockImplementation(() => azureStorageMock as AzureStorageContract)
+
+    // Act
+    workspaceStore.set(defaultAzureWorkspace)
+    const hookRender1 = renderHook(() => useAnalysisFiles())
+    await hookRender1.waitForNextUpdate()
+    const hookResult2 = hookRender1.result.current
+    await act(() => hookResult2.deleteFile(file1Path))
+
+    // Assert
+    expect(blobMock).toHaveBeenCalledWith(defaultAzureWorkspace.workspace.workspaceId, getFileName(file1Path))
+    expect(doDelete).toHaveBeenCalled()
     expect(reportError).toHaveBeenCalled()
   })
 })

--- a/src/pages/workspaces/workspace/analysis/file-utils.ts
+++ b/src/pages/workspaces/workspace/analysis/file-utils.ts
@@ -1,31 +1,20 @@
 import _ from 'lodash/fp'
-import { useEffect, useState } from 'react'
 import { Ajax } from 'src/libs/ajax'
-import { useLoadedData } from 'src/libs/ajax/loaded-data/useLoadedData'
-import { reportError, withErrorReporting } from 'src/libs/error'
-import { useCancellation, useStore } from 'src/libs/react-utils'
-import { workspaceStore } from 'src/libs/state'
-import LoadedState from 'src/libs/type-utils/LoadedState'
-import { withHandlers } from 'src/libs/type-utils/lodash-fp-helpers'
 import { NominalType } from 'src/libs/type-utils/type-helpers'
 import * as Utils from 'src/libs/utils'
-import {
-  CloudProviderType,
-  isGoogleWorkspaceInfo,
-  WorkspaceWrapper
-} from 'src/libs/workspace-utils'
+import { GoogleWorkspace } from 'src/libs/workspace-utils'
 import { runtimeTools, ToolLabel, toolToExtensionMap } from 'src/pages/workspaces/workspace/analysis/tool-utils'
 
 
 export type FileName = NominalType<string, 'FileName'> // represents a file with an extension and no path, eg `dir/file.ipynb` =>  `file.ipynb`
 export type AbsolutePath = NominalType<string, 'AbsolutePath'> // represents an absolute path in the context of a cloud storage directory structure, i.e. `dir/file.ipynb`
-export type Extension = NominalType<string, 'Extension'> // represents the substring found after the last dot in a file, eg `dir/file.txt.ipynb` => `ipynb`
+export type FileExtension = NominalType<string, 'Extension'> // represents the substring found after the last dot in a file, eg `dir/file.txt.ipynb` => `ipynb`
 export type DisplayName = NominalType<string, 'DisplayName'> // represents the name of a file without an extension or pathing eg `dir/file.ipynb`=> `file`
 
 // removes all paths up to and including the last slash, eg dir/file.ipynb` => `file.ipynb`
 export const getFileName = (path: string): FileName => _.flow(_.split('/'), _.last)(path) as FileName
 
-export const getExtension = (path: string): Extension => _.flow(_.split('.'), _.last)(path) as Extension
+export const getExtension = (path: string): FileExtension => _.flow(_.split('.'), _.last)(path) as FileExtension
 
 // ex abs/file.ipynb -> abs/file
 export const stripExtension = (path: string): string => _.replace(/\.[^/.]+$/, '', path)
@@ -33,81 +22,15 @@ export const stripExtension = (path: string): string => _.replace(/\.[^/.]+$/, '
 // removes leading dirs and a file ext suffix on paths eg `dir/file.ipynb`=> `file`
 export const getDisplayName = (path: string): DisplayName => _.flow(getFileName, stripExtension)(path) as DisplayName
 
-export interface AnalysisFileMetadata {
-  lockExpiresAt: string
-  lastLockedBy: string
-  hashedOwnerEmail?: string
-}
-
-export interface AnalysisFile {
-  name: AbsolutePath
-  ext: Extension
-  displayName: DisplayName
-  fileName: FileName
-  lastModified: number
-  tool: ToolLabel
-  cloudProvider: CloudProviderType
-  // We only populate this for google files to handle file syncing
-  // If there is a differentiation for Azure, we should add sub-types
-  metadata?: AnalysisFileMetadata
-}
-
-export interface AnalysisFileStore {
-  refresh: () => Promise<void>
-  loadedState: LoadedState<AnalysisFile[], unknown>
-  create: (fullAnalysisName: string, toolLabel: ToolLabel, contents: string) => Promise<void>
-  pendingCreate: LoadedState<true, unknown>
-}
-
-export const useAnalysisFiles = (): AnalysisFileStore => {
-  const signal = useCancellation()
-  const [loading, setLoading] = useState(false)
-  const workspace: WorkspaceWrapper = useStore(workspaceStore)
-  const [analyses, setAnalyses] = useState<AnalysisFile[]>([])
-  const [pendingCreate, setPendingCreate] = useLoadedData<true>()
-
-  const refresh = withHandlers([
-    withErrorReporting('Error loading analysis files'),
-    Utils.withBusyState(setLoading)
-  ], async (): Promise<void> => {
-    const workspaceInfo = workspace.workspace
-    const existingAnalyses: AnalysisFile[] = isGoogleWorkspaceInfo(workspaceInfo) ?
-      await Ajax(signal).Buckets.listAnalyses(workspaceInfo.googleProject, workspaceInfo.bucketName) :
-      await Ajax(signal).AzureStorage.listNotebooks(workspaceInfo.workspaceId)
-    setAnalyses(existingAnalyses)
-  })
-
-  const create = async (fullAnalysisName: any, toolLabel: ToolLabel, contents: any): Promise<void> => {
-    await setPendingCreate(async () => {
-      const workspaceInfo = workspace.workspace
-      isGoogleWorkspaceInfo(workspaceInfo) ?
-        await Ajax().Buckets.analysis(workspaceInfo.googleProject, workspaceInfo.bucketName, fullAnalysisName, toolLabel).create(contents) :
-        await Ajax().AzureStorage.blob(workspaceInfo.workspaceId, fullAnalysisName).create(contents)
-      await refresh()
-      return true
-    })
-  }
-
-  useEffect(() => {
-    refresh()
-  }, [workspace]) // eslint-disable-line react-hooks/exhaustive-deps
-
-  useEffect(() => {
-    if (pendingCreate.status === 'Error') {
-      reportError('Error creating Analysis file.', pendingCreate.error)
-    }
-  }, [pendingCreate])
-  return { refresh, create, loadedState: { status: loading ? 'Loading' : 'Ready', state: analyses }, pendingCreate }
-}
-
 export const notebookLockHash = (bucketName: string, email: string): Promise<string> => Utils.sha256(`${bucketName}:${email}`)
 
-//TODO: this should take the workspace wrapper not destructure, redo when we convert analysis.js
-export const findPotentialNotebookLockers = async ({ canShare, namespace, workspaceName, bucketName }) => {
+export const findPotentialNotebookLockers = async (workspace: GoogleWorkspace): Promise<{[key: string]: string}> => {
+  const { canShare, workspace: { namespace, name, bucketName } } = workspace
   if (!canShare) {
     return {}
   }
-  const { acl } = await Ajax().Workspaces.workspace(namespace, workspaceName).getAcl()
+  //TODO: type
+  const { acl } = await Ajax().Workspaces.workspace(namespace, name).getAcl()
   const potentialLockers = _.flow(
     _.toPairs,
     _.map(([email, data]) => ({ email, ...data })),
@@ -117,9 +40,12 @@ export const findPotentialNotebookLockers = async ({ canShare, namespace, worksp
     const lockHash = await notebookLockHash(bucketName, email)
     return { [lockHash]: email }
   }, potentialLockers)
-  return _.mergeAll(await Promise.all(lockHolderPromises))
+  const lockHolders = _.mergeAll(await Promise.all(lockHolderPromises))
+
+  return lockHolders
 }
 
 export const addExtensionToNotebook = (name: string): string => `${name}.${runtimeTools.Jupyter.defaultExt}`
 
-export const getAnalysisFileExtension = (toolLabel: ToolLabel): Extension => toolToExtensionMap[toolLabel]
+export const getAnalysisFileExtension = (toolLabel: ToolLabel): FileExtension => toolToExtensionMap[toolLabel]
+

--- a/src/pages/workspaces/workspace/analysis/modals/AnalysisDuplicator.ts
+++ b/src/pages/workspaces/workspace/analysis/modals/AnalysisDuplicator.ts
@@ -15,7 +15,7 @@ import {
   DisplayName,
   FileName, getDisplayName,
   getExtension,
-  getFileName, useAnalysisFiles
+  getFileName
 } from 'src/pages/workspaces/workspace/analysis/file-utils'
 import {
   analysisNameInput,
@@ -23,6 +23,7 @@ import {
 } from 'src/pages/workspaces/workspace/analysis/notebook-utils'
 import { analysisLauncherTabName } from 'src/pages/workspaces/workspace/analysis/runtime-common-components'
 import { ToolLabel } from 'src/pages/workspaces/workspace/analysis/tool-utils'
+import { useAnalysisFiles } from 'src/pages/workspaces/workspace/analysis/useAnalysisFiles'
 import validate from 'validate.js'
 
 

--- a/src/pages/workspaces/workspace/analysis/modals/AnalysisModal.ts
+++ b/src/pages/workspaces/workspace/analysis/modals/AnalysisModal.ts
@@ -19,7 +19,7 @@ import { usePrevious, withDisplayName } from 'src/libs/react-utils'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 import { BaseWorkspace, cloudProviderTypes, isGoogleWorkspaceInfo } from 'src/libs/workspace-utils'
-import { getFileName, useAnalysisFiles } from 'src/pages/workspaces/workspace/analysis/file-utils'
+import { getFileName } from 'src/pages/workspaces/workspace/analysis/file-utils'
 import { AzureComputeModalBase } from 'src/pages/workspaces/workspace/analysis/modals/AzureComputeModal'
 import { ComputeModalBase } from 'src/pages/workspaces/workspace/analysis/modals/ComputeModal'
 import { CromwellModalBase } from 'src/pages/workspaces/workspace/analysis/modals/CromwellModal'
@@ -30,6 +30,7 @@ import {
   getCurrentApp, getCurrentPersistentDisk, getCurrentRuntime, isResourceDeletable
 } from 'src/pages/workspaces/workspace/analysis/runtime-utils'
 import { AppDataDisk, AppTool, cloudAppTools, cloudRuntimeTools, getAppType, getToolLabelFromFileExtension, getToolLabelFromRuntime, isAppToolLabel, PersistentDisk, Runtime, runtimeTools, Tool, toolExtensionDisplay, toolLabels, tools } from 'src/pages/workspaces/workspace/analysis/tool-utils'
+import { useAnalysisFiles } from 'src/pages/workspaces/workspace/analysis/useAnalysisFiles'
 import validate from 'validate.js'
 
 
@@ -50,8 +51,6 @@ export interface AnalysisModalProps {
   onSuccess: () => void
   openUploader: () => void
   uploadFiles: () => void
-  //TODO: Temporary until Analyses.js implements useAnalysisFiles
-  refreshAnalyses: () => void
 }
 
 export const AnalysisModal = withDisplayName('AnalysisModal')(
@@ -63,8 +62,7 @@ export const AnalysisModal = withDisplayName('AnalysisModal')(
     uploadFiles,
     openUploader,
     workspace,
-    location,
-    refreshAnalyses
+    location
   }: AnalysisModalProps) => {
     const [viewMode, setViewMode] = useState<any>()
     const cloudPlatform = workspace.workspace.cloudPlatform.toUpperCase()
@@ -361,8 +359,6 @@ export const AnalysisModal = withDisplayName('AnalysisModal')(
                   [isRStudio, () => baseRmd])
                 const fullAnalysisName = `${analysisName}.${fileExt}`
                 await create(fullAnalysisName, toolLabel, contents)
-                //TODO: Temporary, once Analyses.js uses store, refreshAnalyses will be deprecated in favor of refresh() within the create function
-                await refreshAnalyses()
                 await Ajax().Metrics.captureEvent(Events.analysisCreate, { source: toolLabel, application: toolLabel, filename: fullAnalysisName, cloudPlatform })
                 setAnalysisName('')
                 enterNextViewMode(toolLabel)

--- a/src/pages/workspaces/workspace/analysis/modals/AnalysisModal.ts
+++ b/src/pages/workspaces/workspace/analysis/modals/AnalysisModal.ts
@@ -30,7 +30,7 @@ import {
   getCurrentApp, getCurrentPersistentDisk, getCurrentRuntime, isResourceDeletable
 } from 'src/pages/workspaces/workspace/analysis/runtime-utils'
 import { AppDataDisk, AppTool, cloudAppTools, cloudRuntimeTools, getAppType, getToolLabelFromFileExtension, getToolLabelFromRuntime, isAppToolLabel, PersistentDisk, Runtime, runtimeTools, Tool, toolExtensionDisplay, toolLabels, tools } from 'src/pages/workspaces/workspace/analysis/tool-utils'
-import { useAnalysisFiles } from 'src/pages/workspaces/workspace/analysis/useAnalysisFiles'
+import { AnalysisFileStore } from 'src/pages/workspaces/workspace/analysis/useAnalysisFiles'
 import validate from 'validate.js'
 
 
@@ -51,6 +51,7 @@ export interface AnalysisModalProps {
   onSuccess: () => void
   openUploader: () => void
   uploadFiles: () => void
+  analysisFileStore: AnalysisFileStore
 }
 
 export const AnalysisModal = withDisplayName('AnalysisModal')(
@@ -62,7 +63,8 @@ export const AnalysisModal = withDisplayName('AnalysisModal')(
     uploadFiles,
     openUploader,
     workspace,
-    location
+    location,
+    analysisFileStore
   }: AnalysisModalProps) => {
     const [viewMode, setViewMode] = useState<any>()
     const cloudPlatform = workspace.workspace.cloudPlatform.toUpperCase()
@@ -79,7 +81,7 @@ export const AnalysisModal = withDisplayName('AnalysisModal')(
     const currentApp: any = toolLabel => getCurrentApp(getAppType(toolLabel))(apps)
 
     //TODO: Bring in as props from Analyses OR bring entire AnalysisFileStore from props.
-    const { loadedState, create, pendingCreate } = useAnalysisFiles()
+    const { loadedState, create, pendingCreate } = analysisFileStore
     //TODO: When the above is done, this check below may not be necessary.
     const analyses = loadedState.status !== 'None' ? loadedState.state : null
     const status = loadedState.status

--- a/src/pages/workspaces/workspace/analysis/useAnalysisFiles.ts
+++ b/src/pages/workspaces/workspace/analysis/useAnalysisFiles.ts
@@ -1,0 +1,136 @@
+import { useEffect, useState } from 'react'
+import { Ajax } from 'src/libs/ajax'
+import { useLoadedData } from 'src/libs/ajax/loaded-data/useLoadedData'
+import { reportError, withErrorReporting } from 'src/libs/error'
+import { useCancellation, useStore } from 'src/libs/react-utils'
+import { workspaceStore } from 'src/libs/state'
+import LoadedState from 'src/libs/type-utils/LoadedState'
+import { withHandlers } from 'src/libs/type-utils/lodash-fp-helpers'
+import * as Utils from 'src/libs/utils'
+import { CloudProviderType, cloudProviderTypes, isGoogleWorkspaceInfo, WorkspaceWrapper } from 'src/libs/workspace-utils'
+import {
+  AbsolutePath,
+  DisplayName,
+  FileExtension,
+  FileName,
+  getDisplayName,
+  getExtension,
+  getFileName
+} from 'src/pages/workspaces/workspace/analysis/file-utils'
+import { getToolLabelFromFileExtension, ToolLabel } from 'src/pages/workspaces/workspace/analysis/tool-utils'
+
+
+export interface AnalysisFileMetadata {
+  lockExpiresAt: string
+  lastLockedBy: string
+  hashedOwnerEmail?: string
+}
+
+export interface AnalysisFile {
+  name: AbsolutePath
+  ext: FileExtension
+  displayName: DisplayName
+  fileName: FileName
+  lastModified: number
+  tool: ToolLabel
+  cloudProvider: CloudProviderType
+  // We only populate this for google files to handle file syncing
+  // If there is a differentiation for Azure, we should add sub-types
+  metadata?: AnalysisFileMetadata
+}
+
+export type CreateAnalysisFn = (fullAnalysisName: string, toolLabel: ToolLabel, contents: any) => Promise<void>
+
+export interface AnalysisFileStore {
+  refreshFileStore: () => Promise<void>
+  loadedState: LoadedState<AnalysisFile[], unknown>
+  create: CreateAnalysisFn
+  deleteFile: (path: AbsolutePath) => Promise<void>
+  pendingCreate: LoadedState<true, unknown>
+  pendingDelete: LoadedState<true, unknown>
+}
+
+export const useAnalysisFiles = (): AnalysisFileStore => {
+  const signal = useCancellation()
+  const [loading, setLoading] = useState(false)
+  const workspace: WorkspaceWrapper = useStore(workspaceStore)
+  const [analyses, setAnalyses] = useState<AnalysisFile[]>([])
+  const [pendingCreate, setPendingCreate] = useLoadedData<true>()
+  const [pendingDelete, setPendingDelete] = useLoadedData<true>()
+
+  const refresh = withHandlers([
+    withErrorReporting('Error loading analysis files'),
+    Utils.withBusyState(setLoading)
+  ], async (): Promise<void> => {
+    const workspaceInfo = workspace.workspace
+    const existingAnalyses: AnalysisFile[] = isGoogleWorkspaceInfo(workspaceInfo) ?
+      await Ajax(signal).Buckets.listAnalyses(workspaceInfo.googleProject, workspaceInfo.bucketName) :
+      await Ajax(signal).AzureStorage.listNotebooks(workspaceInfo.workspaceId)
+    setAnalyses(existingAnalyses)
+  })
+
+  const create = async (fullAnalysisName: string, toolLabel: ToolLabel, contents: any): Promise<void> => {
+    await setPendingCreate(async () => {
+      const workspaceInfo = workspace.workspace
+      isGoogleWorkspaceInfo(workspaceInfo) ?
+        await Ajax().Buckets.analysis(workspaceInfo.googleProject, workspaceInfo.bucketName, fullAnalysisName, toolLabel).create(contents) :
+        await Ajax().AzureStorage.blob(workspaceInfo.workspaceId, fullAnalysisName).create(contents)
+      await refresh()
+      return true
+    })
+  }
+
+  const deleteFile = async (path: AbsolutePath): Promise<void> => {
+    await setPendingDelete(async () => {
+      const workspaceInfo = workspace.workspace
+      if (isGoogleWorkspaceInfo(workspaceInfo)) {
+        await Ajax().Buckets.analysis(
+          workspaceInfo.googleProject,
+          workspaceInfo.bucketName,
+          getFileName(path),
+          getToolLabelFromFileExtension(getExtension(path))
+        ).delete()
+      } else {
+        await Ajax(signal).AzureStorage.blob(workspaceInfo.workspaceId, getFileName(path)).delete()
+      }
+      await refresh()
+      return true
+    })
+  }
+
+  useEffect(() => {
+    refresh()
+  }, [workspace]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (pendingCreate.status === 'Error') {
+      reportError('Error creating Analysis file.', pendingCreate.error)
+    }
+  }, [pendingCreate])
+
+  useEffect(() => {
+    if (pendingDelete.status === 'Error') {
+      reportError('Error deleting Analysis file.', pendingDelete.error)
+    }
+  }, [pendingDelete])
+  return {
+    refreshFileStore: refresh,
+    create,
+    deleteFile,
+    loadedState: { status: loading ? 'Loading' : 'Ready', state: analyses },
+    pendingCreate,
+    pendingDelete
+  }
+}
+
+// This is mainly a test utility in its current form
+// AnalysisFile objects should not usually be constructed with this in app code, as the lastModified date is set to the current time
+export const getFileFromPath = (abs: AbsolutePath, cloudProvider: CloudProviderType = cloudProviderTypes.GCP): AnalysisFile => ({
+  name: abs,
+  ext: getExtension(abs),
+  displayName: getDisplayName(abs),
+  fileName: getFileName(abs),
+  tool: getToolLabelFromFileExtension(getExtension(abs)) as ToolLabel,
+  lastModified: new Date().getTime(),
+  cloudProvider
+})

--- a/src/pages/workspaces/workspace/useWorkspace.ts
+++ b/src/pages/workspaces/workspace/useWorkspace.ts
@@ -19,7 +19,7 @@ import { isAzureWorkspace, isGoogleWorkspace, WorkspaceWrapper } from 'src/libs/
 import { defaultLocation } from 'src/pages/workspaces/workspace/analysis/runtime-utils'
 
 
-interface StorageDetails {
+export interface StorageDetails {
   googleBucketLocation: string // historically returns defaultLocation if cannot be retrieved or Azure
   googleBucketType: string // historically returns locationTypes.default if cannot be retrieved or Azure
   azureContainerRegion?: string


### PR DESCRIPTION
Converts the base analysis page to typescript and adds tests.

Theres a moderate amount of files touched, but most are simple changes, as a lot of places the converted component depends on did not declare defaults in their props (aka in a way that made typescript happy)

Theres a few TODOs that mark discussions to be had where I used ts-expect-error due to typescript having some inference trouble. Other than that, the component has been converted, with the vast majority of it tested! Its at 69%, but a little less than 23% of that is a component I believe should live in its own file with tests, and I did not bother to split it out and test it in this large PR
