### PR TITLE
Revert "[WOR-750] Call checkBucketReadAccess (which checks Google permissions) in prod"

### DIFF
--- a/src/pages/workspaces/workspace/useWorkspace.test.ts
+++ b/src/pages/workspaces/workspace/useWorkspace.test.ts
@@ -5,8 +5,9 @@ import * as WorkspaceUtils from 'src/components/workspace-utils'
 import { Ajax } from 'src/libs/ajax'
 import { AzureStorage, AzureStorageContract } from 'src/libs/ajax/AzureStorage'
 import * as GoogleStorage from 'src/libs/ajax/GoogleStorage'
+import { getConfig } from 'src/libs/config'
 import * as Notifications from 'src/libs/notifications'
-import { workspaceStore } from 'src/libs/state'
+import { getUser, workspaceStore } from 'src/libs/state'
 import { DeepPartial } from 'src/libs/type-utils/deep-partial'
 import { defaultLocation } from 'src/pages/workspaces/workspace/analysis/runtime-utils'
 import {
@@ -23,13 +24,10 @@ type AjaxContract = ReturnType<AjaxExports['Ajax']>
 
 jest.mock('src/libs/notifications')
 
-type StateExports = typeof import('src/libs/state')
-jest.mock('src/libs/state', (): StateExports => {
-  return {
-    ...jest.requireActual('src/libs/state'),
-    getUser: jest.fn(() => ({ email: 'christina@foo.com' })),
-  }
-})
+jest.mock('src/libs/state', () => ({
+  ...jest.requireActual('src/libs/state'),
+  getUser: jest.fn()
+}))
 
 jest.mock('src/libs/config', () => ({
   ...jest.requireActual('src/libs/config'),
@@ -125,6 +123,14 @@ describe('useActiveWorkspace', () => {
   beforeEach(() => {
     workspaceStore.reset()
     jest.useFakeTimers()
+
+    // @ts-ignore
+    getUser.mockReturnValue({
+      email: 'christina@foo.com'
+    })
+
+    // @ts-ignore
+    getConfig.mockReturnValue({ isProd: false })
 
     jest.spyOn(workspaceStore, 'set')
     jest.spyOn(WorkspaceUtils, 'updateRecentlyViewedWorkspaces')
@@ -463,5 +469,40 @@ describe('useActiveWorkspace', () => {
     expect(WorkspaceUtils.updateRecentlyViewedWorkspaces).toHaveBeenCalledWith(expectedWorkspaceResponse.workspace.workspaceId)
     expect(GoogleStorage.saToken).not.toHaveBeenCalled()
     expect(Notifications.notify).toHaveBeenCalled()
+  })
+
+  it('Does not (temporarily) call checkBucketReadAccess in production', async () => {
+    // Need to add nextflow role to old workspaces (WOR-764)
+
+    // Arrange
+    // @ts-ignore
+    getConfig.mockReturnValue({ isProd: true })
+
+    // remove workspaceInitialized because the server response does not include this information
+    const { workspaceInitialized, ...serverWorkspaceResponse } = initializedGoogleWorkspace
+
+    const mockAjax: DeepPartial<AjaxContract> = {
+      Workspaces: {
+        workspace: () => ({
+          details: jest.fn().mockResolvedValue(serverWorkspaceResponse),
+          checkBucketLocation: jest.fn().mockResolvedValue(bucketLocationResponse)
+        })
+      }
+    }
+    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract)
+
+    const expectedStorageDetails = _.merge({
+      googleBucketLocation: bucketLocationResponse.location,
+      googleBucketType: bucketLocationResponse.locationType
+    }, defaultAzureStorageOptions)
+
+    // Act
+    const { result, waitForNextUpdate } = renderHook(() => useWorkspace('testNamespace', 'testName'))
+    await waitForNextUpdate() // For the call to checkBucketLocation to execute
+
+    // Assert
+    assertResult(result.current, initializedGoogleWorkspace, expectedStorageDetails, false)
+    expect(workspaceStore.set).toHaveBeenCalledWith(initializedGoogleWorkspace)
+    expect(WorkspaceUtils.updateRecentlyViewedWorkspaces).toHaveBeenCalledWith(initializedGoogleWorkspace.workspace.workspaceId)
   })
 })

--- a/src/pages/workspaces/workspace/useWorkspace.ts
+++ b/src/pages/workspaces/workspace/useWorkspace.ts
@@ -8,6 +8,7 @@ import { Ajax } from 'src/libs/ajax'
 import { responseContainsRequesterPaysError } from 'src/libs/ajax/ajax-common'
 import { AzureStorage } from 'src/libs/ajax/AzureStorage'
 import { saToken } from 'src/libs/ajax/GoogleStorage'
+import { getConfig } from 'src/libs/config'
 import { withErrorIgnoring, withErrorReporting } from 'src/libs/error'
 import { clearNotification, notify } from 'src/libs/notifications'
 import { useCancellation, useOnMount, useStore } from 'src/libs/react-utils'
@@ -72,7 +73,10 @@ export const useWorkspace = (namespace, name) : WorkspaceDetails => {
 
   const checkGooglePermissions = async workspace => {
     try {
-      await Ajax(signal).Workspaces.workspace(namespace, name).checkBucketReadAccess()
+      // Need to add nextflow role to old workspaces (WOR-764) before enabling in production.
+      if (!getConfig().isProd) {
+        await Ajax(signal).Workspaces.workspace(namespace, name).checkBucketReadAccess()
+      }
       updateWorkspaceInStore(workspace, true)
       loadGoogleBucketLocation(workspace)
     } catch (error: any) {


### PR DESCRIPTION
Reverts DataBiosphere/terra-ui#3773

We are seeing 500 errors in production on some of these calls, plus it doesn't behave well for workspaces were the user has only read-only permission.