### PR TITLE
[SU-274] Split Dockstore ajax methods into a separate module

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -2,7 +2,7 @@ import _ from 'lodash/fp'
 import * as qs from 'qs'
 import { createContext, useContext } from 'react'
 import {
-  appIdentifier, authOpts, fetchAgora, fetchBond, fetchDataRepo, fetchDockstore,
+  appIdentifier, authOpts, fetchAgora, fetchBond, fetchDataRepo,
   fetchDrsHub,
   fetchEcm, fetchGoogleForms,
   fetchMartha, fetchOk, fetchOrchestration, fetchRawls, fetchRex, fetchSam, jsonBody
@@ -12,6 +12,7 @@ import { AzureStorage } from 'src/libs/ajax/AzureStorage'
 import { Billing } from 'src/libs/ajax/Billing'
 import { Catalog } from 'src/libs/ajax/Catalog'
 import { Disks } from 'src/libs/ajax/Disks'
+import { Dockstore } from 'src/libs/ajax/Dockstore'
 import { GoogleStorage } from 'src/libs/ajax/GoogleStorage'
 import { Metrics } from 'src/libs/ajax/Metrics'
 import { Runtimes } from 'src/libs/ajax/Runtimes'
@@ -35,9 +36,6 @@ window.ajaxOverrideUtils = {
   }),
   makeSuccess: body => _wrappedFetch => () => Promise.resolve(new Response(JSON.stringify(body), { status: 200 }))
 }
-
-// %23 = '#', %2F = '/'
-const dockstoreMethodPath = ({ path, isTool }) => `api/ga4gh/v1/tools/${isTool ? '' : '%23workflow%2F'}${encodeURIComponent(path)}/versions`
 
 const getFirstTimeStamp = Utils.memoizeAsync(async token => {
   const res = await fetchRex('firstTimestamps/record', _.mergeAll([authOpts(token), { method: 'POST' }]))
@@ -950,21 +948,6 @@ const Submissions = signal => ({
     const res = await fetchRawls('submissions/queueStatus', _.merge(authOpts(), { signal }))
     return res.json()
   }
-})
-
-const Dockstore = signal => ({
-  getWdl: async ({ path, version, isTool }) => {
-    const res = await fetchDockstore(`${dockstoreMethodPath({ path, isTool })}/${encodeURIComponent(version)}/WDL/descriptor`, { signal })
-    const { url } = await res.json()
-    return fetchOk(url, { signal }).then(res => res.text())
-  },
-
-  getVersions: async ({ path, isTool }) => {
-    const res = await fetchDockstore(dockstoreMethodPath({ path, isTool }), { signal })
-    return res.json()
-  },
-
-  listTools: (params = {}) => fetchDockstore(`api/ga4gh/v1/tools?${qs.stringify(params)}`).then(r => r.json())
 })
 
 const shouldUseDrsHub = !!getConfig().shouldUseDrsHub

--- a/src/libs/ajax/Dockstore.test.ts
+++ b/src/libs/ajax/Dockstore.test.ts
@@ -1,0 +1,97 @@
+import { asMockedFn } from 'src/testing/test-utils'
+
+import { fetchDockstore, fetchOk } from './ajax-common'
+import { Dockstore } from './Dockstore'
+
+
+type AjaxCommonExports = typeof import('./ajax-common')
+jest.mock('./ajax-common', (): Partial<AjaxCommonExports> => {
+  return {
+    fetchDockstore: jest.fn(),
+    fetchOk: jest.fn(),
+  }
+})
+
+describe('Dockstore', () => {
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  const testWorkflowPath = 'github.com/DataBiosphere/test-workflows/test-workflow'
+  const testWorkflowVersion = 'v1.0.0'
+
+  describe('getWdl', () => {
+    beforeEach(() => {
+      // Arrange
+      asMockedFn(fetchDockstore).mockResolvedValue(
+        new Response(JSON.stringify({
+          descriptor: 'Test workflow',
+          type: 'WDL',
+          url: 'https://raw.githubusercontent.com/DataBiosphere/test-workflows/v1.0.0/test-workflow.wdl',
+        }))
+      )
+
+      asMockedFn(fetchOk).mockResolvedValue(new Response('workflow TestWorkflow {}'))
+    })
+
+    it('fetches WDL descriptor from Dockstore', async () => {
+      // Act
+      await Dockstore().getWdl({ path: testWorkflowPath, isTool: false, version: testWorkflowVersion })
+
+      // Assert
+      expect(fetchDockstore).toHaveBeenCalledWith(
+        `api/ga4gh/v1/tools/%23workflow%2F${encodeURIComponent(testWorkflowPath)}/versions/${encodeURIComponent(testWorkflowVersion)}/WDL/descriptor`,
+        { signal: undefined },
+      )
+    })
+
+    it('fetches WDL code', async () => {
+      // Act
+      const wdl = await Dockstore().getWdl({ path: testWorkflowPath, isTool: false, version: testWorkflowVersion })
+
+      // Assert
+      expect(fetchOk).toHaveBeenCalledWith(
+        'https://raw.githubusercontent.com/DataBiosphere/test-workflows/v1.0.0/test-workflow.wdl',
+        { signal: undefined },
+      )
+
+      expect(wdl).toBe('workflow TestWorkflow {}')
+    })
+  })
+
+  describe('listVersions', () => {
+    it('fetches workflow versions', async () => {
+      // Arrange
+      asMockedFn(fetchDockstore).mockResolvedValue(new Response('[]'))
+
+      // Act
+      const versions = await Dockstore().getVersions({ path: testWorkflowPath, isTool: false })
+
+      // Assert
+      expect(fetchDockstore).toHaveBeenCalledWith(
+        `api/ga4gh/v1/tools/%23workflow%2F${encodeURIComponent(testWorkflowPath)}/versions`,
+        { signal: undefined },
+      )
+
+      expect(versions).toEqual([])
+    })
+  })
+
+  describe('listTools', () => {
+    it('fetches workflows', async () => {
+      // Arrange
+      asMockedFn(fetchDockstore).mockResolvedValue(new Response('[]'))
+
+      // Act
+      const tools = await Dockstore().listTools({ organization: 'gatk-workflows' })
+
+      // Assert
+      expect(fetchDockstore).toHaveBeenCalledWith(
+        'api/ga4gh/v1/tools?organization=gatk-workflows',
+        { signal: undefined },
+      )
+
+      expect(tools).toEqual([])
+    })
+  })
+})

--- a/src/libs/ajax/Dockstore.ts
+++ b/src/libs/ajax/Dockstore.ts
@@ -1,0 +1,70 @@
+import * as qs from 'qs'
+
+import { fetchDockstore, fetchOk } from './ajax-common'
+
+
+type DockstoreWorkflowDescriptor = {
+  path: string
+  isTool: boolean
+}
+
+type DockstoreWorkflowVersionDescriptor = DockstoreWorkflowDescriptor & {
+  version: string
+}
+
+type DockstoreWorkflowVersion = {
+  'descriptor-type': unknown[]
+  dockerfile: boolean
+  id: string
+  image: string
+  'meta-version': string
+  name: string
+  url: string
+  verified: boolean
+  'verified-source': string
+}
+
+type DockstoreWorkflow = {
+  author: string
+  contains: unknown[]
+  description: string
+  id: string
+  'meta-version': string
+  organization: string
+  signed: boolean
+  toolclass: {
+    description: string
+    workflow: string
+    name: string
+  }
+  toolname: string
+  url: string
+  verified: boolean
+  'verified-source': string
+  versions: DockstoreWorkflowVersion[]
+}
+
+type ListToolsParams = {
+  organization?: string
+}
+
+// %23 = '#', %2F = '/'
+const workflowVersionsPath = ({ path, isTool }: DockstoreWorkflowDescriptor) => {
+  return `api/ga4gh/v1/tools/${isTool ? '' : '%23workflow%2F'}${encodeURIComponent(path)}/versions`
+}
+
+export const Dockstore = (signal?: AbortSignal) => ({
+  getWdl: async ({ path, version, isTool }: DockstoreWorkflowVersionDescriptor): Promise<string> => {
+    const wdlPath = `${workflowVersionsPath({ path, isTool })}/${encodeURIComponent(version)}/WDL/descriptor`
+    const { url } = await fetchDockstore(wdlPath, { signal }).then(res => res.json())
+    return fetchOk(url, { signal }).then(res => res.text())
+  },
+
+  getVersions: ({ path, isTool }: DockstoreWorkflowDescriptor): Promise<DockstoreWorkflowVersion[]> => {
+    return fetchDockstore(workflowVersionsPath({ path, isTool }), { signal }).then(res => res.json())
+  },
+
+  listTools: (params: ListToolsParams = {}): Promise<DockstoreWorkflow[]> => {
+    return fetchDockstore(`api/ga4gh/v1/tools?${qs.stringify(params)}`, { signal }).then(res => res.json())
+  },
+})


### PR DESCRIPTION
Some preparation for more work on the ImportWorkflow page... this splits the Dockstore methods out of ajax.js and adds type definitions and tests for them.