### PR TITLE
[SU-286] Fix a11y issues in Azure preview form

### DIFF
--- a/src/pages/AzurePreview.js
+++ b/src/pages/AzurePreview.js
@@ -181,14 +181,16 @@ const AzurePreviewUserForm = ({ value: formValue, onChange, onSubmit }) => {
 
         div({ style: { width: '100%' } }, [
           label({
+            htmlFor: 'azure-preview-use-case-other',
             onClick: () => onChange({
               ...formValue,
-              otherUseCase: !!formValue.otherUseCase ? '' : otherUseCase,
+              otherUseCase: !!formValue.otherUseCase ? '' : otherUseCase || ' ',
             }),
-            style: { display: 'flex', alignItems: 'center', marginBottom: '0.5rem' }
+            style: { display: 'inline-flex', alignItems: 'center', marginBottom: '0.5rem' }
           }, [
             h(Checkbox, {
               checked: !!formValue.otherUseCase,
+              id: 'azure-preview-use-case-other',
               style: { flexShrink: 0, marginRight: '1ch' },
               onChange: checked => {
                 onChange({
@@ -201,6 +203,7 @@ const AzurePreviewUserForm = ({ value: formValue, onChange, onSubmit }) => {
           ]),
 
           h(TextArea, {
+            'aria-label': 'Other use case',
             rows: 3,
             value: otherUseCase,
             onChange: value => {


### PR DESCRIPTION
A few form elements in the Azure preview form are missing a label.

Noticed these warnings when running unit tests.

```
For accessibility, Checkbox needs a label. Resolve this by doing any of the following: 
  * add an aria-label property to this component
  * add an aria-labelledby property referencing the id of another component containing the label
  * create a label component and point its htmlFor property to this component's id
```

```
For accessibility, TextArea needs a label. Resolve this by doing any of the following: 
  * add an aria-label property to this component
  * add an aria-labelledby property referencing the id of another component containing the label
  * create a label component and point its htmlFor property to this component's id
```