### PR TITLE
[WOR-703] Fixups for StepWizard components

### DIFF
--- a/src/pages/billing/NewBillingProjectWizard/GCPBillingProjectWizard/BillingAccountAccessStep.ts
+++ b/src/pages/billing/NewBillingProjectWizard/GCPBillingProjectWizard/BillingAccountAccessStep.ts
@@ -14,7 +14,7 @@ export interface BillingAccountAccessStepProps {
 }
 
 export const BillingAccountAccessStep = ({ isActive, ...props }: BillingAccountAccessStepProps) => h(Step, { isActive }, [
-  h(StepHeader, { title: 'STEP 2', children: [] }),
+  h(StepHeader, { title: 'STEP 2' }),
   h(StepFields, [
     h(StepFieldLegend, { style: { width: '70%' } }, [
       'Select an existing billing account or create a new one.',

--- a/src/pages/billing/NewBillingProjectWizard/GCPBillingProjectWizard/GoToGCPConsoleStep.ts
+++ b/src/pages/billing/NewBillingProjectWizard/GCPBillingProjectWizard/GoToGCPConsoleStep.ts
@@ -15,7 +15,7 @@ interface GoToGCPConsoleStepProps {
 
 export const GoToGCPConsoleStep = ({ isActive, ...props }: GoToGCPConsoleStepProps) => {
   return h(Step, { isActive }, [
-    StepHeader({ title: 'STEP 1' }),
+    h(StepHeader, { title: 'STEP 1' }),
     div({ style: { display: 'flex', flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' } }, [
       h(StepInfo, { style: { maxWidth: '60%' } },
         ['Go to the Google Cloud Platform Billing Console and sign-in with the same user you use to login to Terra.']),

--- a/src/pages/billing/NewBillingProjectWizard/GCPBillingProjectWizard/LabeledRadioButton.ts
+++ b/src/pages/billing/NewBillingProjectWizard/GCPBillingProjectWizard/LabeledRadioButton.ts
@@ -1,3 +1,4 @@
+import { PropsWithChildren } from 'react'
 import { div, HTMLElementProps } from 'react-hyperscript-helpers'
 import { RadioButton } from 'src/components/common'
 import { styles } from 'src/pages/billing/NewBillingProjectWizard/GCPBillingProjectWizard/GCPBillingProjectWizard'
@@ -21,7 +22,11 @@ export const LabeledRadioButton = ({ text, name, labelStyle, style, ...props }: 
   ]
 )
 
-export const LabeledRadioGroup = ({ style, children }: {style?: React.CSSProperties; children: React.ReactNode[]}) => div({
+type LabeledRadioGroupProps = PropsWithChildren<{
+  style?: React.CSSProperties
+}>
+
+export const LabeledRadioGroup = ({ style, children }: LabeledRadioGroupProps) => div({
   style: {
     display: 'flex',
     margin: '1rem',

--- a/src/pages/billing/NewBillingProjectWizard/StepWizard/Step.test.ts
+++ b/src/pages/billing/NewBillingProjectWizard/StepWizard/Step.test.ts
@@ -8,7 +8,7 @@ import { Step } from 'src/pages/billing/NewBillingProjectWizard/StepWizard/Step'
 
 describe('Step', () => {
   it('renders all child props in order', () => {
-    const d1 = div({ id: 'd1', children: ['d1Text'] })
+    const d1 = div({ id: 'd1' }, ['d1Text'])
     const d2 = div({ id: 'd2' })
     const d3 = div({ id: 'd3' })
 
@@ -22,9 +22,9 @@ describe('Step', () => {
   })
 
   it('sets aria-current to step when active', () => {
-    const renderResult = render(h(div, {}, [
-      Step({ isActive: true, children: [div({ children: ['activeStepChild'] })] }),
-      Step({ isActive: false, children: [div({ children: ['inactiveStepChild'] })] })
+    const renderResult = render(div([
+      h(Step, { isActive: true }, [div(['activeStepChild'])]),
+      h(Step, { isActive: false }, [div(['inactiveStepChild'])])
     ]))
 
     const activeStep = renderResult.getByText('activeStepChild')!.parentElement!
@@ -35,9 +35,9 @@ describe('Step', () => {
   })
 
   it('has a more intense border and lighter background when active', () => {
-    const renderResult = render(h(div, {}, [
-      Step({ isActive: true, children: [div({ children: ['activeStepChild'] })] }),
-      Step({ isActive: false, children: [div({ children: ['inactiveStepChild'] })] })
+    const renderResult = render(div([
+      h(Step, { isActive: true }, [div(['activeStepChild'])]),
+      h(Step, { isActive: false }, [div(['inactiveStepChild'])])
     ]))
     const activeStyle = getComputedStyle(renderResult.getByText('activeStepChild').parentElement!)
     const inactiveStyle = getComputedStyle(renderResult.getByText('inactiveStepChild').parentElement!)
@@ -51,4 +51,3 @@ describe('Step', () => {
       .toBeLessThan(parseInt(inactiveStyle.borderColor.substring(1), 16))
   })
 })
-

--- a/src/pages/billing/NewBillingProjectWizard/StepWizard/Step.ts
+++ b/src/pages/billing/NewBillingProjectWizard/StepWizard/Step.ts
@@ -1,4 +1,4 @@
-import { CSSProperties } from 'react'
+import { CSSProperties, PropsWithChildren } from 'react'
 import { li } from 'react-hyperscript-helpers'
 import colors from 'src/libs/colors'
 
@@ -18,16 +18,15 @@ function stepBanner(active: boolean): CSSProperties {
   }
 }
 
-export interface StepProps {
+export type StepProps = PropsWithChildren<{
   isActive: boolean
   style?: React.CSSProperties
-  children?: React.ReactNode[]
-}
+}>
 
-export const Step = ({ isActive, children = [], ...props }: StepProps) => li({
+export const Step = ({ isActive, children, style }: StepProps) => li({
   'data-test-id': 'Step',
   'aria-current': isActive ? 'step' : false,
-  style: { ...stepBanner(isActive), ...props.style },
+  style: { ...stepBanner(isActive), ...style },
 }, [
   children
 ])

--- a/src/pages/billing/NewBillingProjectWizard/StepWizard/StepFields.ts
+++ b/src/pages/billing/NewBillingProjectWizard/StepWizard/StepFields.ts
@@ -1,14 +1,13 @@
-import { CSSProperties, ReactNode } from 'react'
+import { CSSProperties, PropsWithChildren, ReactNode } from 'react'
 import { div, fieldset, form, h, legend } from 'react-hyperscript-helpers'
 import { FormLabel } from 'src/libs/forms'
 
 
-interface StepFieldsProps {
-  children?: ReactNode[]
+type StepFieldsProps = PropsWithChildren<{
   style?: CSSProperties
-}
+}>
 
-export const StepFields = ({ children = [], style, disabled = false }: StepFieldsProps & { disabled?: boolean }) => fieldset({
+export const StepFields = ({ children, style, disabled = false }: StepFieldsProps & { disabled?: boolean }) => fieldset({
   disabled,
   style: {
     border: 'none',
@@ -32,17 +31,17 @@ const primaryStepTextStyle = {
   float: 'left'
 }
 
-export const StepFieldLegend = ({ children = [], style }: StepFieldsProps) => legend({
+export const StepFieldLegend = ({ children, style }: StepFieldsProps) => legend({
   style: { ...primaryStepTextStyle as CSSProperties, ...style }
-}, children)
+}, [children])
 
 // An alternative to StepFieldLegend that will render in the same way, but is not expected to be inside
 // a fieldset.
-export const StepInfo = ({ children = [], style }: StepFieldsProps) => div({
+export const StepInfo = ({ children, style }: StepFieldsProps) => div({
   style: { ...primaryStepTextStyle as CSSProperties, ...style }
-}, children)
+}, [children])
 
-export const StepFieldForm = ({ children = [], style }: StepFieldsProps) => form({
+export const StepFieldForm = ({ children, style }: StepFieldsProps) => form({
   style: {
     display: 'flex',
     flexDirection: 'row',
@@ -51,7 +50,7 @@ export const StepFieldForm = ({ children = [], style }: StepFieldsProps) => form
     width: '100%',
     ...style
   }
-}, children)
+}, [children])
 
 interface LabeledFieldProps extends StepFieldsProps {
   formId: string
@@ -59,7 +58,7 @@ interface LabeledFieldProps extends StepFieldsProps {
   required?: boolean
 }
 
-export const LabeledField = ({ label, formId, required = false, children = [], style }: LabeledFieldProps) => div({ style: { display: 'flex', flexDirection: 'column', ...style } }, [
+export const LabeledField = ({ label, formId, required = false, children, style }: LabeledFieldProps) => div({ style: { display: 'flex', flexDirection: 'column', ...style } }, [
   h(FormLabel, { htmlFor: formId, required }, [label]),
   children
 ])

--- a/src/pages/billing/NewBillingProjectWizard/StepWizard/StepHeader.ts
+++ b/src/pages/billing/NewBillingProjectWizard/StepWizard/StepHeader.ts
@@ -1,14 +1,13 @@
+import { PropsWithChildren } from 'react'
 import { h3, header, span } from 'react-hyperscript-helpers'
 
 
-interface StepHeaderProps {
+type StepHeaderProps = PropsWithChildren<{
   title: React.ReactNode
-  children?: React.ReactNode[]
-  styles?: React.CSSProperties
-}
+  style?: React.CSSProperties
+}>
 
-export const StepHeader = ({ title, children = [], ...props }: StepHeaderProps) => header({ style: { width: '100%', display: 'flex', flexDirection: 'row', ...props.styles } }, [
+export const StepHeader = ({ title, children, style }: StepHeaderProps) => header({ style: { width: '100%', display: 'flex', flexDirection: 'row', ...style } }, [
   h3({ style: { fontSize: 18, marginTop: 0, marginRight: '1rem' } }, [title]),
   span({ style: { fontSize: '1rem', lineHeight: '22px', width: '75%' } }, [children]),
-]
-)
+])

--- a/src/pages/billing/NewBillingProjectWizard/StepWizard/StepWizard.ts
+++ b/src/pages/billing/NewBillingProjectWizard/StepWizard/StepWizard.ts
@@ -1,17 +1,16 @@
+import { PropsWithChildren } from 'react'
 import { div, h2, section, ul } from 'react-hyperscript-helpers'
 
 
-export interface StepWizardProps {
+export type StepWizardProps = PropsWithChildren<{
   title: string
   intro: string
-  children?: React.ReactNode
-}
+}>
 
-export const StepWizard = ({ title, intro, ...props }: StepWizardProps) => {
+export const StepWizard = ({ children, title, intro }: StepWizardProps) => {
   return section({ style: { padding: '1.5rem 3rem', width: '100%' } }, [
     h2({ style: { fontWeight: 'bold', fontSize: 18 } }, [title]),
     div({ style: { marginTop: '0.5rem', fontSize: 14, padding: 0, listStyleType: 'none', width: '100%' } }, [intro]),
-    ul({ style: { padding: 0 } }, [props.children])
+    ul({ style: { padding: 0 } }, [children])
   ])
 }
-


### PR DESCRIPTION
When running unit tests, I noticed this warning from Step.test.ts:

```
Warning: Each child in a list should have a unique "key" prop.
      
      Check the top-level render call using <li>. See https://reactjs.org/link/warning-keys for more information.
          at div

      25 | }
      26 |
    > 27 | export const Step = ({ isActive, children = [], ...props }: StepProps) => li({
         |                                                                           ^
      28 |   'data-test-id': 'Step',
      29 |   'aria-current': isActive ? 'step' : false,
      30 |   style: { ...stepBanner(isActive), ...props.style },
```

I found this was related to how children were being passed in the test and it led me to change several prop types in StepWizard components and make a few other fixups related to React/react-hyperscript-helpers usage and general conventions.

Most of these were around the type for `children`. The correct type for the children prop is `ReactNode` (or `ReactNode | undefined`)

React provides a utility type for this: `PropsWithChildren`.
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/294c9948de66ce69981bcb260637f386bfffdd4d/types/react/index.d.ts#L800

Note: `ReactNode` includes `ReactNode[]` (via `ReactFragment`), so typing children as `ReactNode` works even when there are multiple children.
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/294c9948de66ce69981bcb260637f386bfffdd4d/types/react/index.d.ts#L231

The last argument to react-hyperscript-helpers' `h` function and other helper functions is "the innerHTML text (string|boolean|number), or an array of elements" (https://www.npmjs.com/package/react-hyperscript-helpers#api).

By convention, we always use the array form of that last argument and our type definitions for react-hyperscript-helpers enforce that.

Also by convention, we pass children as the last argument to `h` (or other RHH functions), not through the props object (`div(['Hello world'])` vs `div({ children: 'Hello world' })`).