### PR TITLE
[SU-285] Improve visibility of folders in new file browser

### DIFF
--- a/src/components/file-browser/DirectoryTree.test.ts
+++ b/src/components/file-browser/DirectoryTree.test.ts
@@ -41,6 +41,57 @@ describe('Directory', () => {
     screen.getByText('directory')
   })
 
+  it('immediately fetches and renders directory contents for root directory', () => {
+    // Arrange
+    const directories = [
+      {
+        path: 'directory1'
+      },
+      {
+        path: 'directory2'
+      },
+      {
+        path: 'directory3'
+      }
+    ]
+
+    const useDirectoriesInDirectoryResult: UseDirectoriesInDirectoryResult = {
+      state: { directories, status: 'Ready' },
+      hasNextPage: undefined,
+      loadNextPage: () => Promise.resolve(),
+      loadAllRemainingItems: () => Promise.resolve(),
+      reload: () => Promise.resolve()
+    }
+
+    asMockedFn(useDirectoriesInDirectory).mockReturnValue(useDirectoriesInDirectoryResult)
+
+    // Act
+    render(
+      ul({ role: 'tree' }, [
+        h(Directory, {
+          activeDescendant: 'node-0',
+          id: 'node-0',
+          level: 0,
+          path: '',
+          provider: mockFileBrowserProvider,
+          reloadRequests: Utils.subscribable(),
+          rootLabel: 'Workspace bucket',
+          selectedDirectory: '',
+          setActiveDescendant: () => {},
+          onError: () => {},
+          onSelectDirectory: jest.fn()
+        })
+      ])
+    )
+
+    // Assert
+    expect(useDirectoriesInDirectory).toHaveBeenCalled()
+
+    const subdirectoryList = screen.getByRole('group')
+    const renderedSubdirectories = Array.from(subdirectoryList.children).map(el => el.children[1].textContent)
+    expect(renderedSubdirectories).toEqual(['directory1', 'directory2', 'directory3'])
+  })
+
   describe('when directory name is clicked', () => {
     let onSelectDirectory
 

--- a/src/components/file-browser/DirectoryTree.ts
+++ b/src/components/file-browser/DirectoryTree.ts
@@ -203,7 +203,8 @@ export const Directory = (props: DirectoryProps) => {
   } = props
   const isSelected = path === selectedDirectory
 
-  const [isExpanded, setIsExpanded] = useState(false)
+  // Automatically expand root directory.
+  const [isExpanded, setIsExpanded] = useState(path === '')
   const [hasLoadedContents, setHasLoadedContents] = useState(false)
 
   return li({

--- a/src/components/file-browser/DirectoryTree.ts
+++ b/src/components/file-browser/DirectoryTree.ts
@@ -278,6 +278,7 @@ export const Directory = (props: DirectoryProps) => {
       }),
       onClick: () => {
         onSelectDirectory(path)
+        setIsExpanded(true)
       }
     }, [path === '' ? rootLabel : basename(path)]),
     isExpanded && h(Subdirectories, {


### PR DESCRIPTION
We've gotten quite a bit of feedback that it's not obvious how to finder subfolders in the new file browser (folders are shown in the left sidebar while the main panel shows only files).

To improve this, this change:
1. Expands the root directory in the directory tree by default.
2. When a directory is selected, it's expanded in the directory tree. Previously, expanding the directory in the tree and selecting it to view files were two separate interactions.

## Before
https://user-images.githubusercontent.com/1156625/219022705-a691cd90-6f31-4c37-a029-daf9b89d694f.mov

## After
https://user-images.githubusercontent.com/1156625/219022740-2e166e75-b735-4c41-99b2-7bf7955a13a6.mov
