### PR TITLE
[SU-274] Add unit test for importing Dockstore workflow

### DIFF
--- a/src/components/workspace-utils.js
+++ b/src/components/workspace-utils.js
@@ -9,7 +9,6 @@ import { icon, spinner } from 'src/components/icons'
 import { ValidatedInput } from 'src/components/input'
 import { MarkdownEditor, MarkdownViewer } from 'src/components/markdown'
 import Modal from 'src/components/Modal'
-import NewWorkspaceModal from 'src/components/NewWorkspaceModal'
 import TooltipTrigger from 'src/components/TooltipTrigger'
 import { Ajax, useReplaceableAjaxExperimental } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
@@ -305,53 +304,6 @@ export const SnapshotInfo = ({
     ])
   ])
 }
-
-export const WorkspaceImporter = _.flow(
-  withDisplayName('WorkspaceImporter'),
-  withWorkspaces
-)(({ workspaces, refreshWorkspaces, onImport, authorizationDomain: ad, selectedWorkspaceId: initialWs, additionalErrors, ...props }) => {
-  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState(initialWs)
-  const [creatingWorkspace, setCreatingWorkspace] = useState(false)
-
-  const selectedWorkspace = _.find({ workspace: { workspaceId: selectedWorkspaceId } }, workspaces)
-
-  return h(Fragment, [
-    h(WorkspaceSelector, {
-      workspaces: _.filter(ws => {
-        return Utils.canWrite(ws.accessLevel) &&
-          (!ad || _.some({ membersGroupName: ad }, ws.workspace.authorizationDomain))
-      }, workspaces),
-      value: selectedWorkspaceId,
-      onChange: setSelectedWorkspaceId,
-      ...props
-    }),
-    div({ style: { display: 'flex', alignItems: 'center', marginTop: '1rem' } }, [
-      h(ButtonPrimary, {
-        disabled: !selectedWorkspace || additionalErrors,
-        tooltip: Utils.cond([!selectedWorkspace, () => 'Select valid a workspace to import'],
-          [additionalErrors, () => Utils.summarizeErrors(additionalErrors)],
-          () => 'Import workflow to workspace'
-        ),
-        onClick: () => onImport(selectedWorkspace.workspace)
-      }, ['Import']),
-      div({ style: { marginLeft: '1rem', whiteSpace: 'pre' } }, ['Or ']),
-      h(Link, {
-        disabled: additionalErrors,
-        onClick: () => setCreatingWorkspace(true)
-      }, ['create a new workspace'])
-    ]),
-    creatingWorkspace && h(NewWorkspaceModal, {
-      requiredAuthDomain: ad,
-      onDismiss: () => setCreatingWorkspace(false),
-      onSuccess: w => {
-        setCreatingWorkspace(false)
-        setSelectedWorkspaceId(w.workspaceId)
-        refreshWorkspaces()
-        onImport(w)
-      }
-    })
-  ])
-})
 
 export const WorkspaceTagSelect = props => {
   const signal = useCancellation()

--- a/src/libs/workspace-utils.ts
+++ b/src/libs/workspace-utils.ts
@@ -19,6 +19,7 @@ export interface BaseWorkspaceInfo {
   name: string
   workspaceId: string
   cloudPlatform: string
+  authorizationDomain: string[]
 }
 
 export interface AzureWorkspaceInfo extends BaseWorkspaceInfo {

--- a/src/pages/ImportWorkflow/ImportWorkflow.js
+++ b/src/pages/ImportWorkflow/ImportWorkflow.js
@@ -11,15 +11,15 @@ import { WorkspaceImporter } from 'src/components/workspace-utils'
 import importBackground from 'src/images/hex-import-background.svg'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
-import { reportError } from 'src/libs/error'
+import { withErrorReporting } from 'src/libs/error'
 import Events, { extractWorkspaceDetails } from 'src/libs/events'
 import * as Nav from 'src/libs/nav'
-import { useCancellation } from 'src/libs/react-utils'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 import { workflowNameValidation } from 'src/libs/workflow-utils'
 import validate from 'validate.js'
 
+import { importDockstoreWorkflow } from './importDockstoreWorkflow'
 import { useDockstoreWdl } from './useDockstoreWdl'
 
 
@@ -45,47 +45,24 @@ export const ImportWorkflow = ({ path, version, source }) => {
 
   const { wdl, status: wdlStatus } = useDockstoreWdl({ path, version, isTool: source === 'dockstoretools' })
 
-  const signal = useCancellation()
-
-  const doImport = Utils.withBusyState(setIsBusy, async workspace => {
+  const doImport = _.flow(
+    Utils.withBusyState(setIsBusy),
+    withErrorReporting('Error importing workflow'),
+  )(async workspace => {
     const { name, namespace } = workspace
     const eventData = { source, ...extractWorkspaceDetails(workspace) }
 
     try {
-      const rawlsWorkspace = Ajax().Workspaces.workspace(namespace, name)
-      const [entityMetadata, { outputs: workflowOutputs }] = await Promise.all([
-        rawlsWorkspace.entityMetadata(),
-        Ajax(signal).Methods.configInputsOutputs({
-          methodRepoMethod: {
-            methodPath: path,
-            methodVersion: version,
-            sourceRepo: source,
-          }
-        }),
-      ])
-
-      const defaultOutputConfiguration = _.flow(
-        _.map(output => {
-          const outputExpression = `this.${_.last(_.split('.', output.name))}`
-          return [output.name, outputExpression]
-        }),
-        _.fromPairs
-      )(workflowOutputs)
-
-      await rawlsWorkspace.importMethodConfigFromDocker({
-        namespace, name: workflowName, rootEntityType: _.head(_.keys(entityMetadata)),
-        inputs: {}, outputs: defaultOutputConfiguration, prerequisites: {}, methodConfigVersion: 1, deleted: false,
-        methodRepoMethod: {
-          sourceRepo: source,
-          methodPath: path,
-          methodVersion: version
-        }
+      await importDockstoreWorkflow({
+        workspace,
+        workflow: { path, version, source },
+        workflowName
       })
       Ajax().Metrics.captureEvent(Events.workflowImport, { ...eventData, success: true })
       Nav.goToPath('workflow', { namespace, name, workflowNamespace: namespace, workflowName })
     } catch (error) {
-      reportError('Error importing workflow', error)
       Ajax().Metrics.captureEvent(Events.workflowImport, { ...eventData, success: false })
+      throw error
     }
   })
 

--- a/src/pages/ImportWorkflow/ImportWorkflow.js
+++ b/src/pages/ImportWorkflow/ImportWorkflow.js
@@ -7,7 +7,6 @@ import { icon } from 'src/components/icons'
 import { ValidatedInput } from 'src/components/input'
 import TopBar from 'src/components/TopBar'
 import WDLViewer from 'src/components/WDLViewer'
-import { WorkspaceImporter } from 'src/components/workspace-utils'
 import importBackground from 'src/images/hex-import-background.svg'
 import { Ajax } from 'src/libs/ajax'
 import colors from 'src/libs/colors'
@@ -21,6 +20,7 @@ import validate from 'validate.js'
 
 import { importDockstoreWorkflow } from './importDockstoreWorkflow'
 import { useDockstoreWdl } from './useDockstoreWdl'
+import { WorkspaceImporter } from './WorkspaceImporter'
 
 
 const styles = {
@@ -66,7 +66,7 @@ export const ImportWorkflow = ({ path, version, source }) => {
     }
   })
 
-  const errors = (validate({ workflowName }, { workflowName: workflowNameValidation() }))
+  const errors = validate({ workflowName }, { workflowName: workflowNameValidation() })
 
   return div({ style: styles.container }, [
     div({ style: { ...styles.card, maxWidth: 740 } }, [

--- a/src/pages/ImportWorkflow/ImportWorkflow.test.ts
+++ b/src/pages/ImportWorkflow/ImportWorkflow.test.ts
@@ -1,16 +1,47 @@
-import { render, screen } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { h } from 'react-hyperscript-helpers'
+import { useWorkspaces } from 'src/components/workspace-utils'
+import { WorkspaceWrapper } from 'src/libs/workspace-utils'
+import { asMockedFn } from 'src/testing/test-utils'
 
+import { importDockstoreWorkflow } from './importDockstoreWorkflow'
 import { ImportWorkflow } from './ImportWorkflow'
 import { useDockstoreWdl } from './useDockstoreWdl'
 
 
-// Avoid WorkspaceImporter attempting to load workspaces.
-// Preferably, we could mock useWorkspaces here, but that doesn't work because it's in the same module as WorkspaceImpoter.
-jest.mock('src/components/workspace-utils', () => ({
-  ...jest.requireActual('src/components/workspace-utils'),
-  WorkspaceImporter: () => null,
+type WorkspaceUtilsExports = typeof import('src/components/workspace-utils')
+jest.mock('src/components/workspace-utils', (): WorkspaceUtilsExports => {
+  const { h } = jest.requireActual('react-hyperscript-helpers')
+
+  const useWorkspaces = jest.fn()
+  return {
+    ...jest.requireActual('src/components/workspace-utils'),
+    useWorkspaces,
+    // WorkspaceImporter is wrapped in withWorkspaces to fetch the list of workspaces.
+    // withWorkspaces calls useWorkspaces.
+    // However, since withWorkspaces and useWorkspaces are in the same module, simply
+    // mocking useWorkspaces won't work: withWorkspaces will use the unmocked version.
+    // So we have to mock withWorkspaces.
+    // And since WorkspaceImporter calls withWorkspaces at the module level, it must
+    // be mocked here, not in a before... block.
+    // Thus, we also mock useWorkspaces to allow tests to control the returned workspaces.
+    withWorkspaces: Component => {
+      return props => {
+        const { workspaces, refresh, loading } = useWorkspaces()
+        return h(Component, {
+          ...props,
+          workspaces,
+          refreshWorkspaces: refresh,
+          loadingWorkspaces: loading,
+        })
+      }
+    },
+  }
+})
+
+jest.mock('./importDockstoreWorkflow', () => ({
+  importDockstoreWorkflow: jest.fn().mockResolvedValue(undefined),
 }))
 
 jest.mock('./useDockstoreWdl', () => ({
@@ -20,7 +51,24 @@ jest.mock('./useDockstoreWdl', () => ({
   })
 }))
 
+jest.mock('src/libs/nav', () => ({
+  ...jest.requireActual('src/libs/nav'),
+  goToPath: jest.fn(),
+}))
+
 describe('ImportWorkflow', () => {
+  beforeAll(() => {
+    // Arrange
+    asMockedFn(useWorkspaces).mockReturnValue({
+      workspaces: [
+        { workspace: { namespace: 'test', name: 'workspace1', workspaceId: '6771d2c8-cd58-47da-a54c-6cdafacc4175' }, accessLevel: 'WRITER' },
+        { workspace: { namespace: 'test', name: 'workspace2', workspaceId: '5cfa16d8-d604-4de8-8e8a-acde05d71b99' }, accessLevel: 'WRITER' },
+      ] as WorkspaceWrapper[],
+      refresh: () => Promise.resolve(),
+      loading: false,
+    })
+  })
+
   it('fetches and renders WDL', () => {
     // Act
     render(h(ImportWorkflow, {
@@ -73,5 +121,35 @@ describe('ImportWorkflow', () => {
       // Assert
       screen.getByText('Workflow name can only contain letters, numbers, underscores, dashes, and periods')
     })
+  })
+
+  it('it imports the workflow into the selected workspace', async () => {
+    // Arrange
+    const user = userEvent.setup()
+
+    const testWorkflow = {
+      path: 'github.com/DataBiosphere/test-workflows/test-workflow',
+      version: 'v1.0.0',
+      source: 'dockstore',
+    }
+
+    render(h(ImportWorkflow, { ...testWorkflow }))
+
+    // Act
+    const workspaceMenu = screen.getByLabelText('Destination Workspace')
+    await user.click(workspaceMenu)
+    const option = screen.getAllByRole('option').find(el => el.textContent === 'workspace1')!
+    await user.click(option)
+
+    const importButton = screen.getByText('Import')
+    await act(() => user.click(importButton))
+
+    // Assert
+    expect(importDockstoreWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspace: expect.objectContaining({ namespace: 'test', name: 'workspace1' }),
+        workflow: testWorkflow,
+      })
+    )
   })
 })

--- a/src/pages/ImportWorkflow/WorkspaceImporter.ts
+++ b/src/pages/ImportWorkflow/WorkspaceImporter.ts
@@ -1,0 +1,75 @@
+import _ from 'lodash/fp'
+import { Fragment, useState } from 'react'
+import { div, h } from 'react-hyperscript-helpers'
+import { ButtonPrimary, Link } from 'src/components/common'
+import NewWorkspaceModal from 'src/components/NewWorkspaceModal'
+import { withWorkspaces, WorkspaceSelector } from 'src/components/workspace-utils'
+import { withDisplayName } from 'src/libs/react-utils'
+import * as Utils from 'src/libs/utils'
+import { WorkspaceInfo, WorkspaceWrapper } from 'src/libs/workspace-utils'
+
+
+type WorkspaceImporterProps = {
+  additionalErrors: any
+  authorizationDomain?: string
+  selectedWorkspaceId?: string
+  onImport: (workspace: WorkspaceInfo) => void
+}
+
+type WorkspaceImporterInnerProps = WorkspaceImporterProps & {
+  workspaces: WorkspaceWrapper[]
+  refreshWorkspaces: () => void
+}
+
+export const WorkspaceImporter = _.flow(
+  withDisplayName('WorkspaceImporter'),
+  withWorkspaces
+)(({ workspaces, refreshWorkspaces, onImport, authorizationDomain: ad, selectedWorkspaceId: initialWs, additionalErrors, ...props }: WorkspaceImporterInnerProps) => {
+  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState(initialWs)
+  const [creatingWorkspace, setCreatingWorkspace] = useState(false)
+
+  const selectedWorkspace = _.find({ workspace: { workspaceId: selectedWorkspaceId } }, workspaces)
+
+  return h(Fragment, [
+    // @ts-expect-error
+    h(WorkspaceSelector, {
+      workspaces: _.filter(ws => {
+        return Utils.canWrite(ws.accessLevel) &&
+          (!ad || _.some({ membersGroupName: ad }, ws.workspace.authorizationDomain))
+      }, workspaces),
+      value: selectedWorkspaceId,
+      onChange: setSelectedWorkspaceId,
+      ...props
+    }),
+    div({ style: { display: 'flex', alignItems: 'center', marginTop: '1rem' } }, [
+      h(ButtonPrimary, {
+        disabled: !selectedWorkspace || additionalErrors,
+        tooltip: Utils.cond([!selectedWorkspace, () => 'Select valid a workspace to import'],
+          [additionalErrors, () => Utils.summarizeErrors(additionalErrors)],
+          () => 'Import workflow to workspace'
+        ),
+        onClick: () => {
+          // Since this button is disabled when selectedWorkspace is falsy,
+          // we can safely assert that it's non-null when the button is clicked.
+          onImport(selectedWorkspace!.workspace)
+        }
+      }, ['Import']),
+      div({ style: { marginLeft: '1rem', whiteSpace: 'pre' } }, ['Or ']),
+      h(Link, {
+        disabled: additionalErrors,
+        onClick: () => setCreatingWorkspace(true)
+      }, ['create a new workspace'])
+    ]),
+    creatingWorkspace && h(NewWorkspaceModal, {
+      // @ts-expect-error
+      requiredAuthDomain: ad,
+      onDismiss: () => setCreatingWorkspace(false),
+      onSuccess: w => {
+        setCreatingWorkspace(false)
+        setSelectedWorkspaceId(w.workspaceId)
+        refreshWorkspaces()
+        onImport(w)
+      }
+    })
+  ])
+})

--- a/src/pages/ImportWorkflow/WorkspaceImporter.ts
+++ b/src/pages/ImportWorkflow/WorkspaceImporter.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp'
-import { Fragment, useState } from 'react'
+import { Fragment, ReactElement, useState } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
 import { ButtonPrimary, Link } from 'src/components/common'
 import NewWorkspaceModal from 'src/components/NewWorkspaceModal'
@@ -21,7 +21,8 @@ type WorkspaceImporterInnerProps = WorkspaceImporterProps & {
   refreshWorkspaces: () => void
 }
 
-export const WorkspaceImporter = _.flow(
+// Type WorkspaceImporter because types don't carry through flow.
+export const WorkspaceImporter: (props: WorkspaceImporterInnerProps) => ReactElement<any, any> = _.flow(
   withDisplayName('WorkspaceImporter'),
   withWorkspaces
 )(({ workspaces, refreshWorkspaces, onImport, authorizationDomain: ad, selectedWorkspaceId: initialWs, additionalErrors, ...props }: WorkspaceImporterInnerProps) => {

--- a/src/pages/ImportWorkflow/importDockstoreWorkflow.test.ts
+++ b/src/pages/ImportWorkflow/importDockstoreWorkflow.test.ts
@@ -1,0 +1,102 @@
+import { Ajax } from 'src/libs/ajax'
+import { DeepPartial } from 'src/libs/type-utils/deep-partial'
+import { asMockedFn } from 'src/testing/test-utils'
+
+import { importDockstoreWorkflow } from './importDockstoreWorkflow'
+
+
+jest.mock('src/libs/ajax')
+
+type AjaxExports = typeof import('src/libs/ajax')
+type AjaxContract = ReturnType<AjaxExports['Ajax']>
+
+describe('importDockstoreWorkflow', () => {
+  const testWorkspace = {
+    namespace: 'test',
+    name: 'import-workflow',
+  }
+
+  const testWorkflow = {
+    path: 'github.com/DataBiosphere/test-workflows/test-workflow',
+    version: 'v1.0.0',
+    source: 'dockstore',
+  }
+
+  let workspaceAjax
+  let methodConfigInputsOutputs
+  let importMethodConfigFromDocker
+
+  beforeEach(() => {
+    // Arrange
+    importMethodConfigFromDocker = jest.fn().mockResolvedValue(undefined)
+
+    const mockWorkspaceAjax: DeepPartial<ReturnType<AjaxContract['Workspaces']['workspace']>> = {
+      entityMetadata: () => Promise.resolve({
+        participant: { count: 1, idName: 'participant_id', attributeNames: [] },
+        sample: { count: 1, idName: 'sample_id', attributeNames: [] },
+      }),
+      importMethodConfigFromDocker,
+    }
+
+    workspaceAjax = jest.fn().mockReturnValue(mockWorkspaceAjax)
+
+    methodConfigInputsOutputs = jest.fn().mockResolvedValue({
+      inputs: [],
+      outputs: [
+        { name: 'taskA.output1', outputType: 'String' },
+        { name: 'taskA.output2', outputType: 'String' },
+      ],
+    })
+
+    const mockAjax: DeepPartial<AjaxContract> = {
+      Workspaces: { workspace: workspaceAjax },
+      Methods: { configInputsOutputs: methodConfigInputsOutputs },
+    }
+    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract)
+  })
+
+  it('imports workflow into workspace', async () => {
+    // Act
+    await importDockstoreWorkflow({ workspace: testWorkspace, workflow: testWorkflow, workflowName: 'test-workflow' })
+
+    // Assert
+    expect(importMethodConfigFromDocker).toHaveBeenCalledWith(
+      expect.objectContaining({
+        namespace: testWorkspace.namespace,
+        name: 'test-workflow',
+        methodConfigVersion: 1,
+        deleted: false,
+        methodRepoMethod: {
+          sourceRepo: testWorkflow.source,
+          methodPath: testWorkflow.path,
+          methodVersion: testWorkflow.version,
+        },
+      })
+    )
+  })
+
+  it('sets a default root entity type', async () => {
+    // Act
+    await importDockstoreWorkflow({ workspace: testWorkspace, workflow: testWorkflow, workflowName: 'test-workflow' })
+
+    // Assert
+    expect(importMethodConfigFromDocker).toHaveBeenCalledWith(
+      expect.objectContaining({ rootEntityType: 'participant' })
+    )
+  })
+
+  it('configures default outputs', async () => {
+    // Act
+    await importDockstoreWorkflow({ workspace: testWorkspace, workflow: testWorkflow, workflowName: 'test-workflow' })
+
+    // Assert
+    expect(importMethodConfigFromDocker).toHaveBeenCalledWith(
+      expect.objectContaining({
+        outputs: {
+          'taskA.output1': 'this.output1',
+          'taskA.output2': 'this.output2',
+        },
+      })
+    )
+  })
+})

--- a/src/pages/ImportWorkflow/importDockstoreWorkflow.ts
+++ b/src/pages/ImportWorkflow/importDockstoreWorkflow.ts
@@ -1,0 +1,57 @@
+import _ from 'lodash/fp'
+import { Ajax } from 'src/libs/ajax'
+
+
+type ImportDockstoreWorkflowArgs = {
+  workspace: {
+    namespace: string
+    name: string
+  }
+  workflow: {
+    path: string
+    version: string
+    source: string
+  }
+  workflowName: string
+}
+
+export const importDockstoreWorkflow = async ({ workspace, workflow, workflowName }: ImportDockstoreWorkflowArgs) => {
+  const { name, namespace } = workspace
+  const { path, version, source } = workflow
+
+  const workspaceApi = Ajax().Workspaces.workspace(namespace, name)
+
+  const [entityMetadata, { outputs: workflowOutputs }] = await Promise.all([
+    workspaceApi.entityMetadata(),
+    Ajax().Methods.configInputsOutputs({
+      methodRepoMethod: {
+        methodPath: path,
+        methodVersion: version,
+        sourceRepo: source,
+      }
+    }),
+  ])
+
+  const defaultOutputConfiguration = _.flow(
+    _.map((output: { name: string }) => {
+      const outputExpression = `this.${_.last(_.split('.', output.name))}`
+      return [output.name, outputExpression]
+    }),
+    _.fromPairs
+  )(workflowOutputs)
+
+  await workspaceApi.importMethodConfigFromDocker({
+    namespace, name: workflowName,
+    rootEntityType: _.head(_.keys(entityMetadata)),
+    inputs: {},
+    outputs: defaultOutputConfiguration,
+    prerequisites: {},
+    methodConfigVersion: 1,
+    deleted: false,
+    methodRepoMethod: {
+      sourceRepo: source,
+      methodPath: path,
+      methodVersion: version
+    }
+  })
+}

--- a/src/pages/workspaces/workspace/analysis/_testData/testData.js
+++ b/src/pages/workspaces/workspace/analysis/_testData/testData.js
@@ -109,6 +109,7 @@ export const imageDocs = [
 
 export const defaultGoogleWorkspace = {
   workspace: {
+    authorizationDomain: [],
     cloudPlatform: 'Gcp',
     bucketName: 'test-bucket',
     googleProject: `${defaultGoogleWorkspaceNamespace}-project`,
@@ -123,6 +124,7 @@ export const defaultGoogleWorkspace = {
 
 export const defaultAzureWorkspace = {
   workspace: {
+    authorizationDomain: [],
     cloudPlatform: 'Azure',
     googleProject: '',
     bucketName: '',


### PR DESCRIPTION
Continuing from #3794, this adds a unit test that clicks the import workflow button.

To facilitate that, it splits the import ajax requests into a separate module (for easier mocking) and moves WorkspaceImporter to a separate module (to allow mocking the workspaces list).