### PR TITLE
AJ-843: remove extraneous array to avoid console warnings on Azure Data tab

### DIFF
--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -846,9 +846,11 @@ const WorkspaceData = _.flow(
             }, [
               [
                 (wdsLoading || wdsError) && h(NoDataPlaceholder, {
+                  key: 'wds-loading-unavailable-NoDataPlaceholder',
                   message: wdsLoading ? icon('loadingSpinner') : 'Data tables are unavailable'
                 }),
                 wdsReady && _.isEmpty(wdsTypes.state) && h(NoDataPlaceholder, {
+                  key: 'wds-no-data-NoDataPlaceholder',
                   message: 'No tables have been uploaded.'
                 }),
                 wdsReady && !_.isEmpty(wdsTypes.state) && _.map(typeDef => {
@@ -885,6 +887,7 @@ const WorkspaceData = _.flow(
                   ])
                 }, wdsTypes.state),
                 h(NoDataPlaceholder, {
+                  key: 'wds-troubleshooter-status-NoDataPlaceholder',
                   buttonText: 'Data Table Status',
                   onAdd: () => setTroubleshootingWds(true)
                 }),

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -844,54 +844,49 @@ const WorkspaceData = _.flow(
             isAzureWorkspace && h(DataTypeSection, {
               title: 'Tables'
             }, [
-              [
-                (wdsLoading || wdsError) && h(NoDataPlaceholder, {
-                  key: 'wds-loading-unavailable-NoDataPlaceholder',
-                  message: wdsLoading ? icon('loadingSpinner') : 'Data tables are unavailable'
-                }),
-                wdsReady && _.isEmpty(wdsTypes.state) && h(NoDataPlaceholder, {
-                  key: 'wds-no-data-NoDataPlaceholder',
-                  message: 'No tables have been uploaded.'
-                }),
-                wdsReady && !_.isEmpty(wdsTypes.state) && _.map(typeDef => {
-                  return div({ key: typeDef.name, role: 'listitem' }, [
-                    h(DataTypeButton, {
-                      key: typeDef.name,
-                      selected: selectedData?.type === workspaceDataTypes.wds && selectedData.entityType === typeDef.name,
-                      entityName: typeDef.name,
-                      entityCount: typeDef.count,
-                      filteredCount: typeDef.count,
-                      activeCrossTableTextFilter: false,
-                      crossTableSearchInProgress: false,
-                      onClick: () => {
-                        setSelectedData({ type: workspaceDataTypes.wds, entityType: typeDef.name })
+              (wdsLoading || wdsError) && h(NoDataPlaceholder, {
+                message: wdsLoading ? icon('loadingSpinner') : 'Data tables are unavailable'
+              }),
+              wdsReady && _.isEmpty(wdsTypes.state) && h(NoDataPlaceholder, {
+                message: 'No tables have been uploaded.'
+              }),
+              wdsReady && !_.isEmpty(wdsTypes.state) && _.map(typeDef => {
+                return div({ key: typeDef.name, role: 'listitem' }, [
+                  h(DataTypeButton, {
+                    key: typeDef.name,
+                    selected: selectedData?.type === workspaceDataTypes.wds && selectedData.entityType === typeDef.name,
+                    entityName: typeDef.name,
+                    entityCount: typeDef.count,
+                    filteredCount: typeDef.count,
+                    activeCrossTableTextFilter: false,
+                    crossTableSearchInProgress: false,
+                    onClick: () => {
+                      setSelectedData({ type: workspaceDataTypes.wds, entityType: typeDef.name })
+                      forceRefresh()
+                    },
+                    after: h(DataTableActions, {
+                      dataProvider: wdsDataTableProvider,
+                      tableName: typeDef.name,
+                      rowCount: typeDef.count,
+                      entityMetadata,
+                      workspace,
+                      onRenameTable: undefined,
+                      onDeleteTable: tableName => {
+                        setSelectedData(undefined)
+                        setWdsTypes({ status: 'Ready', state: _.remove(typeDef => typeDef.name === tableName, wdsTypes.state) })
                         forceRefresh()
                       },
-                      after: h(DataTableActions, {
-                        dataProvider: wdsDataTableProvider,
-                        tableName: typeDef.name,
-                        rowCount: typeDef.count,
-                        entityMetadata,
-                        workspace,
-                        onRenameTable: undefined,
-                        onDeleteTable: tableName => {
-                          setSelectedData(undefined)
-                          setWdsTypes({ status: 'Ready', state: _.remove(typeDef => typeDef.name === tableName, wdsTypes.state) })
-                          forceRefresh()
-                        },
-                        isShowingVersionHistory: false,
-                        onSaveVersion: undefined,
-                        onToggleVersionHistory: undefined
-                      })
+                      isShowingVersionHistory: false,
+                      onSaveVersion: undefined,
+                      onToggleVersionHistory: undefined
                     })
-                  ])
-                }, wdsTypes.state),
-                h(NoDataPlaceholder, {
-                  key: 'wds-troubleshooter-status-NoDataPlaceholder',
-                  buttonText: 'Data Table Status',
-                  onAdd: () => setTroubleshootingWds(true)
-                }),
-              ]
+                  })
+                ])
+              }, wdsTypes.state),
+              h(NoDataPlaceholder, {
+                buttonText: 'Data Table Status',
+                onAdd: () => setTroubleshootingWds(true)
+              }),
             ]),
             (!_.isEmpty(sortedSnapshotPairs) || snapshotMetadataError) && isGoogleWorkspace && h(DataTypeSection, {
               title: 'Snapshots',


### PR DESCRIPTION
Reviewer: the diff is *much* cleaner if you ignore whitespace.

Eliminates `Warning: Each child in a list should have a unique "key" prop.` warnings in the browser console when loading the Data tab of an Azure workspace.

Tested locally.