### PR TITLE
[UIE-74] Add types for FocusTrapper component

### DIFF
--- a/src/components/common/FocusTrapper.ts
+++ b/src/components/common/FocusTrapper.ts
@@ -11,7 +11,9 @@ export type FocusTrapperProps = FocusLockProps & {
   onBreakout: () => void
 }
 
-export const FocusTrapper = ({ children, onBreakout, ...props }: FocusTrapperProps) => {
+export const FocusTrapper = (props: FocusTrapperProps) => {
+  const { children, onBreakout, ...otherProps } = props
+
   return h(FocusLock, {
     returnFocus: true,
     lockProps: _.merge({
@@ -23,6 +25,6 @@ export const FocusTrapper = ({ children, onBreakout, ...props }: FocusTrapperPro
           e.stopPropagation()
         }
       }
-    }, props)
+    }, otherProps)
   }, [children])
 }

--- a/src/components/common/FocusTrapper.ts
+++ b/src/components/common/FocusTrapper.ts
@@ -3,7 +3,13 @@ import FocusLock from 'react-focus-lock'
 import { h } from 'react-hyperscript-helpers'
 
 
-export const FocusTrapper = ({ children, onBreakout, ...props }) => {
+type FocusLockProps = Parameters<typeof FocusLock>[0]
+
+export type FocusTrapperProps = FocusLockProps & {
+  onBreakout: () => void
+}
+
+export const FocusTrapper = ({ children, onBreakout, ...props }: FocusTrapperProps) => {
   return h(FocusLock, {
     returnFocus: true,
     lockProps: _.merge({

--- a/src/components/common/FocusTrapper.ts
+++ b/src/components/common/FocusTrapper.ts
@@ -3,6 +3,8 @@ import FocusLock from 'react-focus-lock'
 import { h } from 'react-hyperscript-helpers'
 
 
+// react-focus-lock does not export a type for FocusLock's props, but since FocusLock
+// is a function component, we can get the type from its parameters.
 type FocusLockProps = Parameters<typeof FocusLock>[0]
 
 export type FocusTrapperProps = FocusLockProps & {

--- a/src/components/common/FocusTrapper.ts
+++ b/src/components/common/FocusTrapper.ts
@@ -7,7 +7,7 @@ import { h } from 'react-hyperscript-helpers'
 // is a function component, we can get the type from its parameters.
 type FocusLockProps = Parameters<typeof FocusLock>[0]
 
-export type FocusTrapperProps = FocusLockProps & {
+export interface FocusTrapperProps extends FocusLockProps {
   onBreakout: () => void
 }
 


### PR DESCRIPTION
This component is mostly a pass through to [react-focus-lock](https://www.npmjs.com/package/react-focus-lock).