### PR TITLE
[SUP-808] Improve performance of WorkspaceSelector with many workspaces

### DIFF
--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -169,7 +169,12 @@ const fillInReplace = async (page, xpath, text) => {
 }
 
 const select = async (page, labelContains, text) => {
-  await click(page, input({ labelContains }))
+  const inputXpath = input({ labelContains })
+  await click(page, inputXpath)
+  // Some select menus have virtualized lists of options, so the desired option may not be present in
+  // the DOM if the full options list is shown. Search for the desired option to narrow down the list
+  // of options.
+  await fillInReplace(page, inputXpath, text)
   return click(page, `//div[starts-with(@id, "react-select-") and @role="option" and contains(normalize-space(.),"${text}")]`)
 }
 

--- a/src/components/common/Select.js
+++ b/src/components/common/Select.js
@@ -1,10 +1,12 @@
 import _ from 'lodash/fp'
+import { Children, useEffect, useRef } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
 import RSelect, { components as RSelectComponents } from 'react-select'
 import RAsyncCreatableSelect from 'react-select/async-creatable'
+import { AutoSizer, List } from 'react-virtualized'
 import { icon } from 'src/components/icons'
 import colors from 'src/libs/colors'
-import { useLabelAssert, useUniqueId } from 'src/libs/react-utils'
+import { useLabelAssert, useOnMount, useUniqueId } from 'src/libs/react-utils'
 
 
 const commonSelectProps = {
@@ -129,4 +131,66 @@ export const AsyncCreatableSelect = props => {
     ...commonSelectProps,
     ...props
   })
+}
+
+const VirtualizedMenuList = props => {
+  const { children, focusedOption, getStyles, getValue, maxHeight } = props
+
+  const list = useRef()
+
+  // Scroll to the currently selected value (if there is one) when the menu is opened.
+  useOnMount(() => {
+    const [value] = getValue()
+    if (value) {
+      const renderedOptions = Children.map(children, child => child.props.data)
+      const valueIndex = renderedOptions.findIndex(opt => opt.value === value.value)
+      if (valueIndex !== -1) {
+        list.current.scrollToRow(valueIndex)
+      }
+    }
+  })
+
+  // When navigating option with arrow keys, scroll the virtualized list so that the focused option is visible.
+  useEffect(() => {
+    const renderedOptions = Children.map(children, child => child.props.data)
+    const focusedOptionIndex = renderedOptions.indexOf(focusedOption)
+    if (focusedOptionIndex !== -1) {
+      list.current.scrollToRow(focusedOptionIndex)
+    }
+  }, [children, focusedOption])
+
+  const hasRenderedOptions = Array.isArray(children)
+
+  // If no options are rendered, then render the "no options" message.
+  if (!hasRenderedOptions) {
+    return children
+  }
+
+  const rowCount = children.length
+  const rowHeight = 40
+  const height = _.clamp(rowHeight, maxHeight, rowHeight * rowCount)
+
+  return h(AutoSizer, { disableHeight: true }, [
+    ({ width }) => {
+      return h(List, {
+        ref: list,
+        height,
+        width,
+        rowCount,
+        rowHeight,
+        rowRenderer: ({ index, style, key }) => div({ key, style }, [children[index]]),
+        style: { ...getStyles('menuList', props), boxSizing: 'content-box' },
+      })
+    }
+  ])
+}
+
+export const VirtualizedSelect = props => {
+  return h(Select, _.merge({
+    // react-select performs poorly when it has to render hundreds or thousands of options.
+    // This can happen for example in a workspace menu if the user has many workspaces.
+    // To address that, this component virtualizes the list of options.
+    // See https://broadworkbench.atlassian.net/browse/SUP-808 for more information.
+    components: { MenuList: VirtualizedMenuList },
+  }, props))
 }

--- a/src/components/common/Select.js
+++ b/src/components/common/Select.js
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp'
-import { Children, useEffect, useRef } from 'react'
+import { Children, useCallback, useEffect, useRef } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
 import RSelect, { components as RSelectComponents } from 'react-select'
 import RAsyncCreatableSelect from 'react-select/async-creatable'
@@ -138,26 +138,28 @@ const VirtualizedMenuList = props => {
 
   const list = useRef()
 
+  const scrollToOptionForValue = useCallback(value => {
+    const renderedOptions = Children.map(children, child => child.props.data)
+    const valueIndex = renderedOptions.findIndex(opt => opt.value === value)
+    if (valueIndex !== -1) {
+      list.current.scrollToRow(valueIndex)
+    }
+  }, [children])
+
   // Scroll to the currently selected value (if there is one) when the menu is opened.
   useOnMount(() => {
-    const [value] = getValue()
-    if (value) {
-      const renderedOptions = Children.map(children, child => child.props.data)
-      const valueIndex = renderedOptions.findIndex(opt => opt.value === value.value)
-      if (valueIndex !== -1) {
-        list.current.scrollToRow(valueIndex)
-      }
+    const [selectedOption] = getValue()
+    if (selectedOption) {
+      scrollToOptionForValue(selectedOption.value)
     }
   })
 
   // When navigating option with arrow keys, scroll the virtualized list so that the focused option is visible.
   useEffect(() => {
-    const renderedOptions = Children.map(children, child => child.props.data)
-    const focusedOptionIndex = renderedOptions.indexOf(focusedOption)
-    if (focusedOptionIndex !== -1) {
-      list.current.scrollToRow(focusedOptionIndex)
+    if (focusedOption) {
+      scrollToOptionForValue(focusedOption.value)
     }
-  }, [children, focusedOption])
+  }, [children, focusedOption]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const hasRenderedOptions = Array.isArray(children)
 

--- a/src/components/workspace-utils.js
+++ b/src/components/workspace-utils.js
@@ -1,11 +1,10 @@
 import debouncePromise from 'debounce-promise'
 import _ from 'lodash/fp'
-import { Children, Fragment, useEffect, useRef, useState } from 'react'
+import { Fragment, useState } from 'react'
 import { b, div, h, p, span } from 'react-hyperscript-helpers'
-import { AutoSizer, List } from 'react-virtualized'
 import { ClipboardButton } from 'src/components/ClipboardButton'
 import { CloudProviderIcon } from 'src/components/CloudProviderIcon'
-import { AsyncCreatableSelect, ButtonPrimary, ButtonSecondary, Clickable, DelayedRender, IdContainer, Link, Select, spinnerOverlay } from 'src/components/common'
+import { AsyncCreatableSelect, ButtonPrimary, ButtonSecondary, Clickable, DelayedRender, IdContainer, Link, spinnerOverlay, VirtualizedSelect } from 'src/components/common'
 import { icon, spinner } from 'src/components/icons'
 import { ValidatedInput } from 'src/components/input'
 import { MarkdownEditor, MarkdownViewer } from 'src/components/markdown'
@@ -78,64 +77,8 @@ export const withWorkspaces = WrappedComponent => {
   })
 }
 
-const WorkspaceSelectorMenuList = props => {
-  const { children, focusedOption, getStyles, getValue, maxHeight } = props
-
-  const list = useRef()
-
-  // Scroll to the currently selected value (if there is one) when the menu is opened.
-  useOnMount(() => {
-    const [value] = getValue()
-    if (value) {
-      const renderedOptions = Children.map(children, child => child.props.data)
-      const valueIndex = renderedOptions.findIndex(opt => opt.value === value.value)
-      if (valueIndex !== -1) {
-        list.current.scrollToRow(valueIndex)
-      }
-    }
-  })
-
-  // When navigating option with arrow keys, scroll the virtualized list so that the focused option is visible.
-  useEffect(() => {
-    const renderedOptions = Children.map(children, child => child.props.data)
-    const focusedOptionIndex = renderedOptions.indexOf(focusedOption)
-    if (focusedOptionIndex !== -1) {
-      list.current.scrollToRow(focusedOptionIndex)
-    }
-  }, [children, focusedOption])
-
-  const hasRenderedOptions = Array.isArray(children)
-
-  // If no options are rendered, then render the "no options" message.
-  if (!hasRenderedOptions) {
-    return children
-  }
-
-  const rowCount = children.length
-  const rowHeight = 40
-  const height = _.clamp(rowHeight, maxHeight, rowHeight * rowCount)
-
-  return h(AutoSizer, { disableHeight: true }, [
-    ({ width }) => {
-      return h(List, {
-        ref: list,
-        height,
-        width,
-        rowCount,
-        rowHeight,
-        rowRenderer: ({ index, style, key }) => div({ key, style }, [children[index]]),
-        style: { ...getStyles('menuList', props), boxSizing: 'content-box' },
-      })
-    }
-  ])
-}
-
 export const WorkspaceSelector = ({ workspaces, value, onChange, id, 'aria-label': ariaLabel, ...props }) => {
-  return h(Select, {
-    // Some users may have hundreds or thousands of workspaces. react-select performs poorly when it
-    // renders that many options. To address that, this component virtualizes the list of options.
-    // See https://broadworkbench.atlassian.net/browse/SUP-808 for more information.
-    components: { MenuList: WorkspaceSelectorMenuList },
+  return h(VirtualizedSelect, {
     id,
     'aria-label': ariaLabel || 'Select a workspace',
     placeholder: 'Select a workspace',

--- a/src/pages/ImportWorkflow/ImportWorkflow.test.ts
+++ b/src/pages/ImportWorkflow/ImportWorkflow.test.ts
@@ -56,6 +56,13 @@ jest.mock('src/libs/nav', () => ({
   goToPath: jest.fn(),
 }))
 
+// The workspace menu uses react-virtualized's AutoSizer to size the options menu.
+// This makes the virtualized window large enough for options to be rendered.
+jest.mock('react-virtualized', () => ({
+  ...jest.requireActual('react-virtualized'),
+  AutoSizer: ({ children }) => children({ width: 300 })
+}))
+
 describe('ImportWorkflow', () => {
   beforeAll(() => {
     // Arrange

--- a/src/pages/ImportWorkflow/WorkspaceImporter.ts
+++ b/src/pages/ImportWorkflow/WorkspaceImporter.ts
@@ -18,6 +18,7 @@ type WorkspaceImporterProps = {
 
 type WorkspaceImporterInnerProps = WorkspaceImporterProps & {
   workspaces: WorkspaceWrapper[]
+  loadingWorkspaces: boolean
   refreshWorkspaces: () => void
 }
 
@@ -25,7 +26,7 @@ type WorkspaceImporterInnerProps = WorkspaceImporterProps & {
 export const WorkspaceImporter: (props: WorkspaceImporterInnerProps) => ReactElement<any, any> = _.flow(
   withDisplayName('WorkspaceImporter'),
   withWorkspaces
-)(({ workspaces, refreshWorkspaces, onImport, authorizationDomain: ad, selectedWorkspaceId: initialWs, additionalErrors, ...props }: WorkspaceImporterInnerProps) => {
+)(({ workspaces, loadingWorkspaces, refreshWorkspaces, onImport, authorizationDomain: ad, selectedWorkspaceId: initialWs, additionalErrors, ...props }: WorkspaceImporterInnerProps) => {
   const [selectedWorkspaceId, setSelectedWorkspaceId] = useState(initialWs)
   const [creatingWorkspace, setCreatingWorkspace] = useState(false)
 
@@ -38,6 +39,7 @@ export const WorkspaceImporter: (props: WorkspaceImporterInnerProps) => ReactEle
         return Utils.canWrite(ws.accessLevel) &&
           (!ad || _.some({ membersGroupName: ad }, ws.workspace.authorizationDomain))
       }, workspaces),
+      noOptionsMessage: loadingWorkspaces ? _.constant('Loading workspaces') : undefined,
       value: selectedWorkspaceId,
       onChange: setSelectedWorkspaceId,
       ...props


### PR DESCRIPTION
The WorkspaceSelector component uses [react-select](https://www.npmjs.com/package/react-select) under the hood. By default, that library renders every option. For users that have hundreds or thousands of workspaces, this results in very poor performance when trying to select anything from that list. To improve performance, this virtualizes the list of options (using [react-virtualized](https://www.npmjs.com/package/react-virtualized)) This way, only the visible options are rendered.

Tested this by modifying `useWorkspaces` to create a list of 1000 workspaces and store it in `workspacesStore`.

## Before

Despite what it looks like, I started typing immediately after the menu opens. The menu takes that long to update.

https://user-images.githubusercontent.com/1156625/220777966-460902c4-e1b8-474c-b27f-57ef47b91de9.mov

## After

https://user-images.githubusercontent.com/1156625/220777954-098e63a2-b202-41ca-96b6-6c1956c36355.mov
