### PR TITLE
[SU-290] Convert brands and brand-utils to TypeScript

### DIFF
--- a/src/components/TitleManager.ts
+++ b/src/components/TitleManager.ts
@@ -1,0 +1,19 @@
+import _ from 'lodash/fp'
+import { useEffect } from 'react'
+import { getEnabledBrand } from 'src/libs/brand-utils'
+import { useRoute } from 'src/libs/nav'
+import * as Utils from 'src/libs/utils'
+
+
+export const TitleManager = () => {
+  const { title, params, query } = useRoute()
+  const newTitle = Utils.cond(
+    [_.isFunction(title), () => title({ ...params, queryParams: query })],
+    [title, () => title],
+    () => getEnabledBrand().name
+  )
+  useEffect(() => {
+    document.title = newTitle
+  }, [newTitle])
+  return null
+}

--- a/src/libs/brand-utils.test.ts
+++ b/src/libs/brand-utils.test.ts
@@ -1,26 +1,41 @@
 import { getEnabledBrand, isBrand } from 'src/libs/brand-utils'
-import { brands, defaultBrand } from 'src/libs/brands'
+import { BrandConfiguration, brands, defaultBrand } from 'src/libs/brands'
+import { configOverridesStore } from 'src/libs/state'
 
 
 describe('brand-utils', () => {
-  let location
+  const testBrand: BrandConfiguration = {
+    name: 'Terra Test',
+    queryName: 'terra test',
+    welcomeHeader: 'Welcome to Terra Unit Tests',
+    description: 'This is only a test.',
+    hostName: 'testbrand.terra.bio',
+    docLinks: [],
+    logos: {
+      color: '',
+      white: '',
+    },
+  }
+
+  let originalLocation
 
   beforeAll(() => {
-    location = window.location
+    originalLocation = window.location
+    // @ts-expect-error
     delete window.location
   })
 
   afterAll(() => {
-    window.location = location
+    window.location = originalLocation
   })
 
   describe('isBrand', () => {
     it('returns true if hostname matches brand', () => {
       // Arrange
-      window.location = new URL('https://testbrand.terra.bio/path/to/page')
+      window.location = new URL('https://testbrand.terra.bio/path/to/page') as unknown as Location
 
       // Act
-      const isTestBrand = isBrand({ hostName: 'testbrand.terra.bio' })
+      const isTestBrand = isBrand(testBrand)
 
       // Assert
       expect(isTestBrand).toBe(true)
@@ -28,10 +43,10 @@ describe('brand-utils', () => {
 
     it('returns false if hostname does not match brand', () => {
       // Arrange
-      window.location = new URL('https://app.terra.bio/path/to/page')
+      window.location = new URL('https://app.terra.bio/path/to/page') as unknown as Location
 
       // Act
-      const isTestBrand = isBrand({ hostName: 'testbrand.terra.bio' })
+      const isTestBrand = isBrand(testBrand)
 
       // Assert
       expect(isTestBrand).toBe(false)
@@ -43,10 +58,10 @@ describe('brand-utils', () => {
       ['staging']
     ])('returns true if hostname matches %s subdomain of brand hostname', tier => {
       // Arrange
-      window.location = new URL(`https://${tier}.testbrand.terra.bio/path/to/page`)
+      window.location = new URL(`https://${tier}.testbrand.terra.bio/path/to/page`) as unknown as Location
 
       // Act
-      const isTestBrand = isBrand({ hostName: 'testbrand.terra.bio' })
+      const isTestBrand = isBrand(testBrand)
 
       // Assert
       expect(isTestBrand).toBe(true)
@@ -63,7 +78,7 @@ describe('brand-utils', () => {
 
     it('returns forced brand when a valid one is set', () => {
       // Arrange
-      window.configOverridesStore.set({ brand: 'rareX' })
+      configOverridesStore.set({ brand: 'rareX' })
 
       // Act
       const enabledBrand = getEnabledBrand()
@@ -74,8 +89,8 @@ describe('brand-utils', () => {
 
     it('returns brand based on hostname when an invalid brand is forced', () => {
       // Arrange
-      window.configOverridesStore.set({ brand: 'invalidBrand' })
-      window.location = new URL('https://anvil.terra.bio/path/to/page')
+      configOverridesStore.set({ brand: 'invalidBrand' })
+      window.location = new URL('https://anvil.terra.bio/path/to/page') as unknown as Location
 
       // Act
       const enabledBrand = getEnabledBrand()
@@ -86,7 +101,7 @@ describe('brand-utils', () => {
 
     it('returns default brand when hostname-based brand is invalid', () => {
       // Arrange
-      window.location = new URL('https://invalid-brand.terra.bio/path/to/page')
+      window.location = new URL('https://invalid-brand.terra.bio/path/to/page') as unknown as Location
 
       // Act
       const enabledBrand = getEnabledBrand()

--- a/src/libs/brand-utils.ts
+++ b/src/libs/brand-utils.ts
@@ -1,10 +1,12 @@
 import _ from 'lodash/fp'
 import { BrandConfiguration, brands, defaultBrand } from 'src/libs/brands'
 import { getConfig } from 'src/libs/config'
+import { getCurrentUrl } from 'src/libs/nav'
 
 
 export const isBrand = (brand: BrandConfiguration): boolean => {
-  return new RegExp(`^((dev|alpha|staging)\\.)?${brand.hostName}$`).test(window.location.hostname)
+  const currentHostname = getCurrentUrl().hostname
+  return new RegExp(`^((dev|alpha|staging)\\.)?${brand.hostName}$`).test(currentHostname)
 }
 
 export const getEnabledBrand = (): BrandConfiguration => {

--- a/src/libs/brand-utils.ts
+++ b/src/libs/brand-utils.ts
@@ -1,14 +1,14 @@
 import _ from 'lodash/fp'
-import { brands, defaultBrand } from 'src/libs/brands'
+import { BrandConfiguration, brands, defaultBrand } from 'src/libs/brands'
 import { getConfig } from 'src/libs/config'
 
 
-export const isBrand = brand => {
+export const isBrand = (brand: BrandConfiguration): boolean => {
   return new RegExp(`^((dev|alpha|staging)\\.)?${brand.hostName}$`).test(window.location.hostname)
 }
 
-export const getEnabledBrand = () => {
-  const forcedBrand = getConfig().brand
+export const getEnabledBrand = (): BrandConfiguration => {
+  const forcedBrand: string = getConfig().brand
 
   if (!!forcedBrand && _.has(forcedBrand, brands)) {
     return brands[forcedBrand]
@@ -21,10 +21,10 @@ export const getEnabledBrand = () => {
 
   const brandFromHostName = _.findKey(isBrand, brands)
 
-  return brands[brandFromHostName] ?? defaultBrand
+  return (brandFromHostName && brands[brandFromHostName]) || defaultBrand
 }
 
-export const pickBrandLogo = (color = false) => {
+export const pickBrandLogo = (color: boolean = false): string => {
   const { logos } = getEnabledBrand()
   return color ? logos.color : logos.white
 }

--- a/src/libs/brands.ts
+++ b/src/libs/brands.ts
@@ -23,33 +23,43 @@ import terraLogoShadow from 'src/images/brands/terra/logo-wShadow.svg'
 
 const nonBreakingHyphen = '\u2011'
 
-/**
- * BrandConfiguration
- * @property name - Brand name.
- * @property queryName - Used to construct return URLs for FireCloud.
- * @property welcomeHeader - Landing page header text.
- * @property description - Landing page text.
- * @property hostName - Host name for branded site.
- * @property docLinks - Links shown on landing page.
- * @property docLinks[].link - Link URL.
- * @property docLinks[].text - Link text.
- * @property logos - URLs for logo images.
- * @property logos.color - Brand logo.
- * @property logos.white - Light version of brand logo used against dark backgrounds.
- * @property catalogDataCollectionsToInclude - Customize which datasets show up in the Data Catalog.
- */
-export type BrandConfiguration = {
+
+export interface BrandConfiguration {
+  /** Brand name */
   name: string
+
+  /** Used to construct return URLs for FireCloud */
   queryName: string
+
+  /** Landing page header text */
   welcomeHeader: string
+
+  /** Landing page text */
   description: string
+
+  /** Host name for branded site */
   hostName: string
-  docLinks: { link: string; text: string }[]
+
+  /** Links shown on landing page */
+  docLinks: {
+    /** Link URL */
+    link: string
+
+    /** Link text */
+    text: string
+  }[]
+
+  /** URLs for logo images */
   logos: {
+    /** Brand logo */
     color: string
+
+    /** Light version of brand logo used against dark backgrounds */
     white: string
     [otherLogoType: string]: string
   }
+
+  /** Optionally filter which datasets show up in the Data Catalog */
   catalogDataCollectionsToInclude?: string[]
 }
 

--- a/src/libs/brands.ts
+++ b/src/libs/brands.ts
@@ -23,15 +23,43 @@ import terraLogoShadow from 'src/images/brands/terra/logo-wShadow.svg'
 
 const nonBreakingHyphen = '\u2011'
 
+/**
+ * BrandConfiguration
+ * @property name - Brand name.
+ * @property queryName - Used to construct return URLs for FireCloud.
+ * @property welcomeHeader - Landing page header text.
+ * @property description - Landing page text.
+ * @property hostName - Host name for branded site.
+ * @property docLinks - Links shown on landing page.
+ * @property docLinks[].link - Link URL.
+ * @property docLinks[].text - Link text.
+ * @property logos - URLs for logo images.
+ * @property logos.color - Brand logo.
+ * @property logos.white - Light version of brand logo used against dark backgrounds.
+ * @property catalogDataCollectionsToInclude - Customize which datasets show up in the Data Catalog.
+ */
+export type BrandConfiguration = {
+  name: string
+  queryName: string
+  welcomeHeader: string
+  description: string
+  hostName: string
+  docLinks: { link: string; text: string }[]
+  logos: {
+    color: string
+    white: string
+    [otherLogoType: string]: string
+  }
+  catalogDataCollectionsToInclude?: string[]
+}
 
 /**
  * Configuration for Terra co-brands (a.k.a. white label sites)
  * https://broadworkbench.atlassian.net/wiki/spaces/WOR/pages/2369388553/Cobranding+and+White+Label+Sites
  */
-export const brands = {
+export const brands: { [brandName: string]: BrandConfiguration } = {
   anvil: {
     name: 'AnVIL',
-    signInName: 'AnVIL',
     queryName: 'anvil',
     welcomeHeader: 'Welcome to AnVIL',
     description: 'The NHGRI AnVIL (Genomic Data Science Analysis, Visualization, and Informatics Lab-space) is a project powered by Terra for biomedical researchers to access data, run analysis tools, and collaborate.',
@@ -49,7 +77,6 @@ export const brands = {
   },
   baseline: {
     name: 'Project Baseline',
-    signInName: 'Project Baseline',
     queryName: 'project baseline',
     welcomeHeader: 'Welcome to Project Baseline',
     description: 'The Baseline Health Study Data Portal is a project powered by Terra for biomedical researchers to access data, run analysis tools, and collaborate.',
@@ -67,7 +94,6 @@ export const brands = {
   },
   bioDataCatalyst: {
     name: 'NHLBI BioData Catalyst',
-    signInName: 'NHLBI BioData Catalyst',
     queryName: 'nhlbi biodata catalyst',
     welcomeHeader: 'Welcome to NHLBI BioData Catalyst',
     description: 'NHLBI BioData Catalyst (BDC) is a project powered by Terra for biomedical researchers to access data, run analysis tools, and collaborate.',
@@ -85,7 +111,6 @@ export const brands = {
   },
   datastage: {
     name: 'DataStage',
-    signInName: 'DataStage',
     queryName: 'datastage',
     welcomeHeader: 'Welcome to DataStage',
     description: 'DataStage is a project powered by Terra for biomedical researchers to access data, run analysis tools, and collaborate.',
@@ -103,7 +128,6 @@ export const brands = {
   },
   elwazi: {
     name: 'eLwazi',
-    signInName: 'eLwazi',
     queryName: 'elwazi',
     welcomeHeader: 'Welcome to eLwazi',
     description: 'The eLwazi Open Data Science Platform is a project powered by Terra for biomedical researchers to access data, run analysis tools, and collaborate.',
@@ -121,7 +145,6 @@ export const brands = {
   },
   firecloud: {
     name: 'FireCloud',
-    signInName: 'FireCloud',
     queryName: 'firecloud',
     welcomeHeader: 'Welcome to FireCloud',
     description: 'FireCloud is a NCI Cloud Resource project powered by Terra for biomedical researchers to access data, run analysis tools, and collaborate.',
@@ -147,7 +170,6 @@ export const brands = {
   },
   projectSingular: {
     name: 'Project Singular',
-    signInName: 'Project Singular',
     queryName: 'project singular',
     welcomeHeader: 'Welcome to Project Singular',
     description: 'Project Singular is a project funded by Additional Ventures and powered by Terra for biomedical researchers to access data, run analysis tools, and collaborate.',
@@ -166,7 +188,6 @@ export const brands = {
   radX: {
     name: 'The RADx Data Hub',
     queryName: 'the radx data hub',
-    signInName: 'the RADx Data Hub',
     welcomeHeader: 'Welcome to the RADx Data Hub',
     description: 'The RADx Data Hub is a platform for biomedical researchers to access data, run analysis tools, and collaborate.',
     hostName: 'radxdatahub.nih.gov',
@@ -193,7 +214,6 @@ export const brands = {
   rareX: {
     name: `The RARE${nonBreakingHyphen}X Data Analysis Platform`,
     queryName: `the rare${nonBreakingHyphen}x data analysis platform`,
-    signInName: `the RARE${nonBreakingHyphen}X Data Analysis Platform`,
     welcomeHeader: `Welcome to the RARE${nonBreakingHyphen}X Data Analysis Platform`,
     description: `The RARE${nonBreakingHyphen}X Data Analysis Platform is a federated data repository of rare disease patient health data, including patient reported outcomes, clinical and molecular information. The platform is powered by Terra for biomedical researchers to access data, run analysis tools, and collaborate.`,
     hostName: 'rare-x.terra.bio',
@@ -218,7 +238,6 @@ export const brands = {
   },
   terra: {
     name: 'Terra',
-    signInName: 'Terra',
     queryName: 'terra',
     welcomeHeader: 'Welcome to Terra Community Workbench',
     description: 'Terra is a cloud-native platform for biomedical researchers to access data, run analysis tools, and collaborate.',

--- a/src/libs/brands.ts
+++ b/src/libs/brands.ts
@@ -67,7 +67,7 @@ export interface BrandConfiguration {
  * Configuration for Terra co-brands (a.k.a. white label sites)
  * https://broadworkbench.atlassian.net/wiki/spaces/WOR/pages/2369388553/Cobranding+and+White+Label+Sites
  */
-export const brands: { [brandName: string]: BrandConfiguration } = {
+export const brands: Record<string, BrandConfiguration> = {
   anvil: {
     name: 'AnVIL',
     queryName: 'anvil',

--- a/src/libs/nav.js
+++ b/src/libs/nav.js
@@ -3,7 +3,6 @@ import _ from 'lodash/fp'
 import * as qs from 'qs'
 import { createContext, useContext, useEffect, useState } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
-import { getEnabledBrand } from 'src/libs/brand-utils'
 import { useOnMount, useStore } from 'src/libs/react-utils'
 import { routeHandlersStore } from 'src/libs/state'
 import * as Utils from 'src/libs/utils'
@@ -84,19 +83,6 @@ export const useRoute = () => {
   const location = useContext(locationContext)
   const handlers = useStore(routeHandlersStore)
   return parseRoute(handlers, location)
-}
-
-export const TitleManager = () => {
-  const { title, params, query } = useRoute()
-  const newTitle = Utils.cond(
-    [_.isFunction(title), () => title({ ...params, queryParams: query })],
-    [title, () => title],
-    () => getEnabledBrand().name
-  )
-  useEffect(() => {
-    document.title = newTitle
-  }, [newTitle])
-  return null
 }
 
 export const Router = () => {

--- a/src/libs/nav.js
+++ b/src/libs/nav.js
@@ -72,6 +72,10 @@ export const LocationProvider = ({ children }) => {
   return h(locationContext.Provider, { value: location }, [children])
 }
 
+export const getCurrentUrl = () => {
+  return new URL(window.location.href)
+}
+
 export const getCurrentRoute = () => {
   return parseRoute(routeHandlersStore.get(), history.location)
 }

--- a/src/libs/terms-of-service-alerts.test.js
+++ b/src/libs/terms-of-service-alerts.test.js
@@ -8,7 +8,11 @@ import * as TosAlerts from 'src/libs/terms-of-service-alerts'
 
 
 jest.mock('src/libs/ajax')
-jest.mock('src/libs/nav')
+
+jest.mock('src/libs/nav', () => ({
+  ...jest.requireActual('src/libs/nav'),
+  getLink: jest.fn().mockReturnValue(''),
+}))
 
 jest.mock('react-notifications-component', () => {
   return {

--- a/src/pages/Main.js
+++ b/src/pages/Main.js
@@ -14,9 +14,10 @@ import FirecloudNotification from 'src/components/FirecloudNotification'
 import IdleStatusMonitor from 'src/components/IdleStatusMonitor'
 import ImportStatus from 'src/components/ImportStatus'
 import SupportRequest from 'src/components/SupportRequest'
+import { TitleManager } from 'src/components/TitleManager'
 import { getOidcConfig } from 'src/libs/auth'
 import { PageViewReporter } from 'src/libs/events'
-import { LocationProvider, PathHashInserter, Router, TitleManager } from 'src/libs/nav'
+import { LocationProvider, PathHashInserter, Router } from 'src/libs/nav'
 import { AuthenticatedCookieSetter } from 'src/pages/workspaces/workspace/analysis/runtime-common-components'
 
 

--- a/src/pages/library/data-catalog/CreateDataset/CreateDataset.test.ts
+++ b/src/pages/library/data-catalog/CreateDataset/CreateDataset.test.ts
@@ -4,8 +4,12 @@ import { h } from 'react-hyperscript-helpers'
 import { CreateDataset } from 'src/pages/library/data-catalog/CreateDataset/CreateDataset'
 
 
-jest.mock('src/libs/nav')
-
+type NavExports = typeof import('src/libs/nav')
+jest.mock('src/libs/nav', (): Partial<NavExports> => ({
+  getCurrentUrl: jest.fn().mockReturnValue(new URL('https://app.terra.bio')),
+  getLink: jest.fn(),
+  goToPath: jest.fn(),
+}))
 
 describe('CreateDataset', () => {
   it('Prepopulates storage system', async () => {

--- a/src/pages/library/dataBrowser-utils.ts
+++ b/src/pages/library/dataBrowser-utils.ts
@@ -135,7 +135,7 @@ export const DatasetAccess = ({ dataset }: DatasetAccessProps) => {
 }
 
 
-export const prepareDatasetsForDisplay = (datasets: Dataset[], dataCollectionsToInclude: string[]): Dataset[] => _.filter(
+export const prepareDatasetsForDisplay = (datasets: Dataset[], dataCollectionsToInclude: string[] | undefined): Dataset[] => _.filter(
   dataCollectionsToInclude ?
     dataset => _.intersection(
       dataCollectionsToInclude,
@@ -156,7 +156,7 @@ export const useDataCatalog = (): DataCatalog => {
   ], async (): Promise<void> => {
     const { result: datasets } = await Ajax(signal).Catalog.getDatasets()
     const dataCollectionsToInclude = getEnabledBrand().catalogDataCollectionsToInclude
-    const normList = prepareDatasetsForDisplay(datasets, dataCollectionsToInclude || [])
+    const normList = prepareDatasetsForDisplay(datasets, dataCollectionsToInclude)
 
     dataCatalogStore.set(normList)
   })

--- a/src/pages/library/dataBrowser-utils.ts
+++ b/src/pages/library/dataBrowser-utils.ts
@@ -156,7 +156,7 @@ export const useDataCatalog = (): DataCatalog => {
   ], async (): Promise<void> => {
     const { result: datasets } = await Ajax(signal).Catalog.getDatasets()
     const dataCollectionsToInclude = getEnabledBrand().catalogDataCollectionsToInclude
-    const normList = prepareDatasetsForDisplay(datasets, dataCollectionsToInclude)
+    const normList = prepareDatasetsForDisplay(datasets, dataCollectionsToInclude || [])
 
     dataCatalogStore.set(normList)
   })


### PR DESCRIPTION
Before adding another option for branding, this converts brands and brand-utils to TypeScript and documents the available configuration for brands.