### PR TITLE
[SU-290] Allow brands to customize landing page background image

### DIFF
--- a/src/components/HeroWrapper.js
+++ b/src/components/HeroWrapper.js
@@ -21,7 +21,7 @@ export const HeroWrapper = ({ showMenu = true, bigSubhead = false, showDocLink =
         color: colors.dark(),
         padding: '3rem 5rem',
         backgroundColor: '#fafbfd', // This not-quite-white fallback color was extracted from the background image
-        backgroundImage: `url(${landingPageHero})`,
+        backgroundImage: `url(${brand.landingPageBackground || landingPageHero})`,
         backgroundRepeat: 'no-repeat', backgroundSize: '750px', backgroundPosition: 'right 0 top 0'
       }
     }, [

--- a/src/images/index.d.ts
+++ b/src/images/index.d.ts
@@ -1,3 +1,8 @@
+declare module '*.jpg' {
+  const value: string
+  export = value;
+}
+
 declare module '*.png' {
   const value: string
   export = value;

--- a/src/libs/brands.ts
+++ b/src/libs/brands.ts
@@ -59,6 +59,9 @@ export interface BrandConfiguration {
     [otherLogoType: string]: string
   }
 
+  /** Optional URL for landing page background image */
+  landingPageBackground?: string
+
   /** Optionally filter which datasets show up in the Data Catalog */
   catalogDataCollectionsToInclude?: string[]
 }


### PR DESCRIPTION
Stacked on #3817.

This adds the option for branded versions of Terra to customize the background image on the landing page. This does not actually change the image for any brands because I don't yet have the desired image.

Expected usage in brands.ts:
```js
import brandImage from 'src/images/brands/brand/background-image.jpg'

...

export const brands = {
  ...
  brand: {
    ...
    landingPageBackground: brandImage
  }
}
```