### PR TITLE
[WOR-780] Put back in Google permission checking on production, and decrease the odds of failures after initial success

### DIFF
--- a/src/pages/workspaces/workspace/analysis/Analyses.test.ts
+++ b/src/pages/workspaces/workspace/analysis/Analyses.test.ts
@@ -90,7 +90,7 @@ const defaultAnalysesProps: AnalysesProps = {
   workspace: defaultGoogleWorkspace,
   analysesData: defaultAnalysesData,
   onRequesterPaysError: () => {},
-  storageDetails: { googleBucketLocation: '', googleBucketType: '' }
+  storageDetails: { googleBucketLocation: '', googleBucketType: '', fetchedGoogleBucketLocation: undefined }
 }
 
 

--- a/src/pages/workspaces/workspace/analysis/useAnalysisFiles.ts
+++ b/src/pages/workspaces/workspace/analysis/useAnalysisFiles.ts
@@ -100,7 +100,8 @@ export const useAnalysisFiles = (): AnalysisFileStore => {
 
   useEffect(() => {
     refresh()
-  }, [workspace]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [workspace.workspace]) // eslint-disable-line react-hooks/exhaustive-deps
+  // refresh depends only on workspace.workspace, do not want to refresh on workspace.workspaceInitialized
 
   useEffect(() => {
     if (pendingCreate.status === 'Error') {

--- a/src/pages/workspaces/workspace/useWorkspace.test.ts
+++ b/src/pages/workspaces/workspace/useWorkspace.test.ts
@@ -5,9 +5,8 @@ import * as WorkspaceUtils from 'src/components/workspace-utils'
 import { Ajax } from 'src/libs/ajax'
 import { AzureStorage, AzureStorageContract } from 'src/libs/ajax/AzureStorage'
 import * as GoogleStorage from 'src/libs/ajax/GoogleStorage'
-import { getConfig } from 'src/libs/config'
 import * as Notifications from 'src/libs/notifications'
-import { getUser, workspaceStore } from 'src/libs/state'
+import { workspaceStore } from 'src/libs/state'
 import { DeepPartial } from 'src/libs/type-utils/deep-partial'
 import { defaultLocation } from 'src/pages/workspaces/workspace/analysis/utils/runtime-utils'
 import {
@@ -24,10 +23,13 @@ type AjaxContract = ReturnType<AjaxExports['Ajax']>
 
 jest.mock('src/libs/notifications')
 
-jest.mock('src/libs/state', () => ({
-  ...jest.requireActual('src/libs/state'),
-  getUser: jest.fn()
-}))
+type StateExports = typeof import('src/libs/state')
+jest.mock('src/libs/state', (): StateExports => {
+  return {
+    ...jest.requireActual('src/libs/state'),
+    getUser: jest.fn(() => ({ email: 'christina@foo.com' })),
+  }
+})
 
 jest.mock('src/libs/config', () => ({
   ...jest.requireActual('src/libs/config'),
@@ -123,14 +125,6 @@ describe('useActiveWorkspace', () => {
   beforeEach(() => {
     workspaceStore.reset()
     jest.useFakeTimers()
-
-    // @ts-ignore
-    getUser.mockReturnValue({
-      email: 'christina@foo.com'
-    })
-
-    // @ts-ignore
-    getConfig.mockReturnValue({ isProd: false })
 
     jest.spyOn(workspaceStore, 'set')
     jest.spyOn(WorkspaceUtils, 'updateRecentlyViewedWorkspaces')
@@ -469,40 +463,5 @@ describe('useActiveWorkspace', () => {
     expect(WorkspaceUtils.updateRecentlyViewedWorkspaces).toHaveBeenCalledWith(expectedWorkspaceResponse.workspace.workspaceId)
     expect(GoogleStorage.saToken).not.toHaveBeenCalled()
     expect(Notifications.notify).toHaveBeenCalled()
-  })
-
-  it('Does not (temporarily) call checkBucketReadAccess in production', async () => {
-    // Need to add nextflow role to old workspaces (WOR-764)
-
-    // Arrange
-    // @ts-ignore
-    getConfig.mockReturnValue({ isProd: true })
-
-    // remove workspaceInitialized because the server response does not include this information
-    const { workspaceInitialized, ...serverWorkspaceResponse } = initializedGoogleWorkspace
-
-    const mockAjax: DeepPartial<AjaxContract> = {
-      Workspaces: {
-        workspace: () => ({
-          details: jest.fn().mockResolvedValue(serverWorkspaceResponse),
-          checkBucketLocation: jest.fn().mockResolvedValue(bucketLocationResponse)
-        })
-      }
-    }
-    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract)
-
-    const expectedStorageDetails = _.merge({
-      googleBucketLocation: bucketLocationResponse.location,
-      googleBucketType: bucketLocationResponse.locationType
-    }, defaultAzureStorageOptions)
-
-    // Act
-    const { result, waitForNextUpdate } = renderHook(() => useWorkspace('testNamespace', 'testName'))
-    await waitForNextUpdate() // For the call to checkBucketLocation to execute
-
-    // Assert
-    assertResult(result.current, initializedGoogleWorkspace, expectedStorageDetails, false)
-    expect(workspaceStore.set).toHaveBeenCalledWith(initializedGoogleWorkspace)
-    expect(WorkspaceUtils.updateRecentlyViewedWorkspaces).toHaveBeenCalledWith(initializedGoogleWorkspace.workspace.workspaceId)
   })
 })

--- a/src/pages/workspaces/workspace/useWorkspace.ts
+++ b/src/pages/workspaces/workspace/useWorkspace.ts
@@ -19,8 +19,9 @@ import { defaultLocation } from 'src/pages/workspaces/workspace/analysis/utils/r
 
 
 export interface StorageDetails {
-  googleBucketLocation: string // historically returns defaultLocation if cannot be retrieved or Azure
-  googleBucketType: string // historically returns locationTypes.default if cannot be retrieved or Azure
+  googleBucketLocation: string // historically returns defaultLocation if bucket location cannot be retrieved or Azure
+  googleBucketType: string // historically returns locationTypes.default if bucket type cannot be retrieved or Azure
+  fetchedGoogleBucketLocation: 'SUCCESS' | 'ERROR' | undefined // undefined: still fetching
   azureContainerRegion?: string
   azureContainerUrl?: string
   azureContainerSasUrl?: string
@@ -45,9 +46,10 @@ export const useWorkspace = (namespace, name) : WorkspaceDetails => {
   const accessNotificationId = useRef()
   const cachedWorkspace = useStore(workspaceStore)
   const workspace = cachedWorkspace && _.isEqual({ namespace, name }, _.pick(['namespace', 'name'], cachedWorkspace.workspace)) ? cachedWorkspace : undefined
-  const [{ location, locationType }, setGoogleStorage] = useState({
-    location: defaultLocation, locationType: locationTypes.default // These default types are historical
-  })
+  const [{ location, locationType, fetchedLocation }, setGoogleStorage] =
+    useState<{ fetchedLocation: 'SUCCESS' | 'ERROR' | undefined; location: string; locationType: string }>({
+      fetchedLocation: undefined, location: defaultLocation, locationType: locationTypes.default // These default types are historical
+    })
   const [azureStorage, setAzureStorage] = useState<{ location: string; storageContainerUrl: string | undefined; sasUrl: string }>()
   const workspaceInitialized = workspace?.workspaceInitialized // will be stored in cached workspace
 
@@ -64,7 +66,7 @@ export const useWorkspace = (namespace, name) : WorkspaceDetails => {
     console.assert(!!workspace, 'initialization should not be called before workspace details are fetched')
 
     if (isGoogleWorkspace(workspace)) {
-      !workspaceInitialized ? checkGooglePermissions(workspace) : loadGoogleBucketLocation(workspace)
+      !workspaceInitialized ? checkGooglePermissions(workspace) : loadGoogleBucketLocationIgnoringError(workspace)
     } else if (isAzureWorkspace(workspace)) {
       !workspaceInitialized ? checkAzureStorageExists(workspace) : loadAzureStorageDetails(workspace)
     }
@@ -72,12 +74,26 @@ export const useWorkspace = (namespace, name) : WorkspaceDetails => {
 
   const checkGooglePermissions = async workspace => {
     try {
+      // Because checkBucketReadAccess can succeed and subsequent calls to get the bucket location or storage
+      // cost estimate may fail (due to caching of previous failure results), do not consider permissions
+      // to be done syncing until all the methods that we know will be called quickly in succession succeed.
+      // This is not guaranteed to eliminate the issue, but it improves the odds.
       await Ajax(signal).Workspaces.workspace(namespace, name).checkBucketReadAccess()
+      if (Utils.canWrite(workspace.accessLevel)) {
+        // Calls done on the Workspace Dashboard. We could store the results and pass them
+        // through, but then we would have to do it checkWorkspaceInitialization as well,
+        // and nobody else actually needs these values.
+        await Ajax(signal).Workspaces.workspace(namespace, name).storageCostEstimate()
+        await Ajax(signal).Workspaces.workspace(namespace, name).bucketUsage()
+      }
+      await loadGoogleBucketLocation(workspace)
       updateWorkspaceInStore(workspace, true)
-      loadGoogleBucketLocation(workspace)
     } catch (error: any) {
       const errorText = await error.text()
       if (responseContainsRequesterPaysError(errorText)) {
+        // loadGoogleBucketLocation will not get called in this case because checkBucketReadAccess fails first,
+        // but it would also fail with the requester pays error.
+        setGoogleStorage({ fetchedLocation: 'ERROR', location, locationType })
         updateWorkspaceInStore(workspace, true)
       } else {
         updateWorkspaceInStore(workspace, false)
@@ -88,10 +104,20 @@ export const useWorkspace = (namespace, name) : WorkspaceDetails => {
   }
 
   // Note that withErrorIgnoring is used because checkBucketLocation will error for requester pays workspaces.
-  const loadGoogleBucketLocation = withErrorIgnoring(async workspace => {
-    const storageDetails = await Ajax(signal).Workspaces.workspace(namespace, name).checkBucketLocation(workspace.workspace.googleProject, workspace.workspace.bucketName)
-    setGoogleStorage(storageDetails)
+  const loadGoogleBucketLocationIgnoringError = withErrorIgnoring(async workspace => {
+    await loadGoogleBucketLocation(workspace)
   })
+
+  const loadGoogleBucketLocation = async workspace => {
+    try {
+      const storageDetails = await Ajax(signal).Workspaces.workspace(namespace, name).checkBucketLocation(workspace.workspace.googleProject, workspace.workspace.bucketName)
+      storageDetails.fetchedLocation = 'SUCCESS'
+      setGoogleStorage(storageDetails)
+    } catch (error) {
+      setGoogleStorage({ fetchedLocation: 'ERROR', location, locationType })
+      throw error
+    }
+  }
 
   const storeAzureStorageDetails = azureStorageDetails => {
     const { location, sas } = azureStorageDetails
@@ -172,6 +198,7 @@ export const useWorkspace = (namespace, name) : WorkspaceDetails => {
   const storageDetails = {
     googleBucketLocation: location,
     googleBucketType: locationType,
+    fetchedGoogleBucketLocation: fetchedLocation,
     azureContainerRegion: azureStorage?.location,
     azureContainerUrl: azureStorage?.storageContainerUrl,
     azureContainerSasUrl: azureStorage?.sasUrl

--- a/src/pages/workspaces/workspace/useWorkspace.ts
+++ b/src/pages/workspaces/workspace/useWorkspace.ts
@@ -8,7 +8,6 @@ import { Ajax } from 'src/libs/ajax'
 import { responseContainsRequesterPaysError } from 'src/libs/ajax/ajax-common'
 import { AzureStorage } from 'src/libs/ajax/AzureStorage'
 import { saToken } from 'src/libs/ajax/GoogleStorage'
-import { getConfig } from 'src/libs/config'
 import { withErrorIgnoring, withErrorReporting } from 'src/libs/error'
 import { clearNotification, notify } from 'src/libs/notifications'
 import { useCancellation, useOnMount, useStore } from 'src/libs/react-utils'
@@ -73,10 +72,7 @@ export const useWorkspace = (namespace, name) : WorkspaceDetails => {
 
   const checkGooglePermissions = async workspace => {
     try {
-      // Need to add nextflow role to old workspaces (WOR-764) before enabling in production.
-      if (!getConfig().isProd) {
-        await Ajax(signal).Workspaces.workspace(namespace, name).checkBucketReadAccess()
-      }
+      await Ajax(signal).Workspaces.workspace(namespace, name).checkBucketReadAccess()
       updateWorkspaceInStore(workspace, true)
       loadGoogleBucketLocation(workspace)
     } catch (error: any) {


### PR DESCRIPTION
This PR does the following things:

1. Reverts https://github.com/DataBiosphere/terra-ui/pull/3784 to re-enable Google permission checking in production. Note that this is dependent on the next Rawls monolith release, so this PR can't merge until after that.
2. Requires multiple Google permission checks to succeed before deciding that Google permissions are in sync. This is because we have learned that after the initial "global" call succeeds, individual calls often return failure because they have cached failure states. I see this behavior when testing my branch, particularly on newly created workspaces.
3. Does some refactoring in `Dashboard` to use the Google bucket location information passed in from the `WorkspaceContainer`. This was previously ignored by `Dashboard` because `WorkspaceContainer` passes default values if it hits an error (historical behavior that IA code relies on); `Dashboard` wants to show specific messaging and functionality for requester pays workspaces, and the default values with silent failures prevent that. Now `Dashboard` can differentiate default values from whether the Ajax call actually succeeded, which means it can avoid an extra call to get the bucket location except in the case of requester pays workspaces, where the extra call is necessary.
4. Adds unit test coverage for the bit of `Dashboard` that changed.