### PR TITLE
[SU-294] Add note about emails for preview access

### DIFF
--- a/src/pages/AzurePreview.js
+++ b/src/pages/AzurePreview.js
@@ -291,7 +291,10 @@ const AzurePreviewForNonPreviewUser = () => {
   if (hasSubmittedForm) {
     return h(Fragment, [
       p({ style: styles.paragraph }, [
-        'Thank you for your interest in using Terra on Microsoft Azure. We will be in touch with your access information.'
+        'Thank you for your interest in using Terra on Microsoft Azure. We will be in touch with your access information. ',
+      ]),
+      p({ style: styles.paragraph }, [
+        'Please add preview@terra.bio to your contact list to not miss emails about access to the preview.',
       ]),
       div({ style: { marginTop: '1.5rem' } }, [
         h(ButtonPrimary, { onClick: signOut, style: styles.button }, ['Sign Out']),


### PR DESCRIPTION
This adds a sentence to the screen that's shown after submitting the Azure preview form, suggesting the user add `preview@terra.bio` to their contacts list to prevent the email about preview access from going to spam.

![Screenshot 2023-03-06 at 9 51 52 AM](https://user-images.githubusercontent.com/1156625/223150672-6e896ec4-062a-4b6a-9bdc-92ef2da82267.png)
