### PR TITLE
Add link to resource group, use pop-out icons (WOR-807, SU-817).

### DIFF
--- a/src/components/NewWorkspaceModal.js
+++ b/src/components/NewWorkspaceModal.js
@@ -367,7 +367,7 @@ const NewWorkspaceModal = withDisplayName('NewWorkspaceModal', ({
             h(Link, {
               href: 'https://support.terra.bio/hc/en-us/articles/12029087819291',
               ...Utils.newTabLinkProps
-            }, ['Learn more and follow changes', icon('pop-out', { size: 10, style: { marginLeft: '0.25rem' } })])])
+            }, ['Learn more and follow changes', icon('pop-out', { size: 14, style: { marginLeft: '0.25rem' } })])])
         ]
       ),
       createError && div({

--- a/src/components/NewWorkspaceModal.js
+++ b/src/components/NewWorkspaceModal.js
@@ -367,7 +367,7 @@ const NewWorkspaceModal = withDisplayName('NewWorkspaceModal', ({
             h(Link, {
               href: 'https://support.terra.bio/hc/en-us/articles/12029087819291',
               ...Utils.newTabLinkProps
-            }, ['Learn more and follow changes.'])])
+            }, ['Learn more and follow changes', icon('pop-out', { size: 10, style: { marginLeft: '0.25rem' } })])])
         ]
       ),
       createError && div({

--- a/src/pages/billing/NewBillingProjectWizard/AzureBillingProjectWizard/AzureSubscriptionStep.ts
+++ b/src/pages/billing/NewBillingProjectWizard/AzureBillingProjectWizard/AzureSubscriptionStep.ts
@@ -96,11 +96,16 @@ export const AzureSubscriptionStep = ({ isActive, subscriptionId, ...props }: Az
     h(StepHeader, { title: 'STEP 1' }),
     h(StepFields, { style: { flexDirection: 'column' } }, [
       h(StepFieldLegend, [
-        'Link Terra to an unassigned managed application in your Azure subscription. A managed application instance can only be assigned to a single Terra billing project.',
-        p({ style: legendDetailsStyle }, [
-          ExternalLink({ text: 'Go to the Azure Portal', url: 'https://portal.azure.com/' }),
-          ' to access your Azure Subscription ID, and to find or create your managed application.'
-        ])
+        'Link Terra to an unassigned managed application in your Azure subscription. A managed application instance can only be assigned to a single Terra billing project. ',
+        h(ExternalLink, {
+          url: 'https://support.terra.bio/hc/en-us/articles/12029032057371',
+          text: 'See documentation with detailed instructions',
+          popoutSize: 16
+        })
+      ]),
+      p({ style: legendDetailsStyle }, [
+        'Need to access your Azure Subscription ID, or to find or create your managed application? ',
+        ExternalLink({ text: 'Go to the Azure Portal', url: 'https://portal.azure.com/' })
       ]),
       div({ style: rowStyle }, [
         h(LabeledField, {

--- a/src/pages/billing/NewBillingProjectWizard/AzureBillingProjectWizard/CreateNamedProjectStep.test.ts
+++ b/src/pages/billing/NewBillingProjectWizard/AzureBillingProjectWizard/CreateNamedProjectStep.test.ts
@@ -57,7 +57,7 @@ describe('CreateNamedProjectStep', () => {
     // @ts-ignore
     expect(getBillingProjectInput().value).toBe(defaultProps.billingProjectName)
     expect(screen.queryByText(uniqueBillingProjectNameMsg)).not.toBeNull()
-    expect(screen.queryByText('Learn more and follow changes.')).not.toBeNull()
+    expect(screen.queryByText('Learn more and follow changes')).not.toBeNull()
     expect(screen.queryByText('It may take up to 15 minutes for the billing project to be fully created and ready for use.')).not.toBeNull()
     verifyCreateBillingProjectDisabled()
     expect(createBillingProject).not.toHaveBeenCalled()

--- a/src/pages/billing/NewBillingProjectWizard/AzureBillingProjectWizard/CreateNamedProjectStep.ts
+++ b/src/pages/billing/NewBillingProjectWizard/AzureBillingProjectWizard/CreateNamedProjectStep.ts
@@ -42,7 +42,7 @@ const AzureCostWarnings = () => {
           h(Link, {
             href: 'https://support.terra.bio/hc/en-us/articles/12029087819291',
             ...newTabLinkProps
-          }, ['Learn more and follow changes.'])
+          }, ['Learn more and follow changes', icon('pop-out', { size: 10, style: { marginLeft: '0.25rem' } })])
         ])
       ]),
       div({ style: rowEntry }, [

--- a/src/pages/billing/NewBillingProjectWizard/AzureBillingProjectWizard/CreateNamedProjectStep.ts
+++ b/src/pages/billing/NewBillingProjectWizard/AzureBillingProjectWizard/CreateNamedProjectStep.ts
@@ -1,15 +1,15 @@
 import { CSSProperties, ReactNode } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
-import { ButtonPrimary, Link, useUniqueId } from 'src/components/common'
+import { ButtonPrimary, useUniqueId } from 'src/components/common'
 import { icon } from 'src/components/icons'
 import { ValidatedInput } from 'src/components/input'
 import colors from 'src/libs/colors'
 import { formHint } from 'src/libs/forms'
-import { newTabLinkProps } from 'src/libs/utils'
 import {
   columnEntryStyle, hintStyle,
   rowStyle
 } from 'src/pages/billing/NewBillingProjectWizard/AzureBillingProjectWizard/styles'
+import { ExternalLink } from 'src/pages/billing/NewBillingProjectWizard/StepWizard/ExternalLink'
 import { Step } from 'src/pages/billing/NewBillingProjectWizard/StepWizard/Step'
 import {
   LabeledField,
@@ -39,10 +39,10 @@ const AzureCostWarnings = () => {
         icon('warning-standard', { size: 16, style: { marginRight: '0.5rem', color: colors.warning() } }),
         div([
           'Creating a Terra billing project currently costs about $5 per day. ',
-          h(Link, {
-            href: 'https://support.terra.bio/hc/en-us/articles/12029087819291',
-            ...newTabLinkProps
-          }, ['Learn more and follow changes', icon('pop-out', { size: 10, style: { marginLeft: '0.25rem' } })])
+          h(ExternalLink, {
+            url: 'https://support.terra.bio/hc/en-us/articles/12029087819291',
+            text: 'Learn more and follow changes'
+          })
         ])
       ]),
       div({ style: rowEntry }, [

--- a/src/pages/billing/NewBillingProjectWizard/StepWizard/ExternalLink.ts
+++ b/src/pages/billing/NewBillingProjectWizard/StepWizard/ExternalLink.ts
@@ -1,6 +1,7 @@
 import React from 'react'
 import { h } from 'react-hyperscript-helpers'
 import { Link } from 'src/components/common'
+import { icon } from 'src/components/icons'
 import colors from 'src/libs/colors'
 import * as Utils from 'src/libs/utils'
 
@@ -8,11 +9,13 @@ import * as Utils from 'src/libs/utils'
 interface ExternalLinkProps {
   text: React.ReactNode
   url: string
+  popoutSize?: number
   style?: React.CSSProperties
 }
 
-export const ExternalLink = ({ text, url, ...props }: ExternalLinkProps) => h(Link, {
+export const ExternalLink = ({ text, url, popoutSize = 14, ...props }: ExternalLinkProps) => h(Link, {
   ...Utils.newTabLinkProps,
-  style: { textDecoration: 'underline', color: colors.accent(), ...props.style },
+  style: { color: colors.accent(), ...props.style },
   href: url,
-}, [text])
+}, [text, icon('pop-out', { style: { marginLeft: '0.25rem' }, size: popoutSize })])
+

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -558,6 +558,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
   const getBillingAccountStatus = workspace => _.findKey(g => g.has(workspace), groups)
 
   const isGcpProject = billingProject.cloudPlatform === cloudProviders.gcp.label
+  const isAzureProject = billingProject.cloudPlatform === cloudProviders.azure.label
 
   const tabToTable = {
     workspaces: h(Fragment, [
@@ -779,11 +780,16 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
     () => !getShowBillingModal() && getBillingAccountsOutOfDate() && refreshWorkspaces(),
     { ms: 5000 }
   )
-
   return h(Fragment, [
     div({ style: { padding: '1.5rem 0 0', flexGrow: 1, display: 'flex', flexDirection: 'column' } }, [
       div({ style: { color: colors.dark(), fontSize: 18, fontWeight: 600, display: 'flex', alignItems: 'center', marginLeft: '1rem' } }, [billingProject.projectName]),
       isGcpProject && h(GcpBillingAccountControls, { authorizeAndLoadAccounts, billingAccounts, billingProject, isOwner, getShowBillingModal, setShowBillingModal, reloadBillingProject, setUpdating }),
+      isAzureProject && div({ style: { color: colors.dark(), fontSize: 14, display: 'flex', alignItems: 'center', marginTop: '0.5rem', marginLeft: '1rem' } }, [
+        h(Link, {
+          href: `https://portal.azure.com/#@${billingProject.managedAppCoordinates.tenantId}/resource/subscriptions/${billingProject.managedAppCoordinates.subscriptionId}/resourceGroups/${billingProject.managedAppCoordinates.managedResourceGroupId}/overview`,
+          ...Utils.newTabLinkProps
+        }, ['Open Resource Group in Azure Portal', icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })])
+      ]),
       _.size(projectUsers) > 1 && _.size(projectOwners) === 1 && div({
         style: {
           display: 'flex',

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -28,6 +28,7 @@ import * as Style from 'src/libs/style'
 import { topBarHeight } from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
 import { billingRoles } from 'src/pages/billing/List'
+import { ExternalLink } from 'src/pages/billing/NewBillingProjectWizard/StepWizard/ExternalLink'
 import { cloudProviders } from 'src/pages/workspaces/workspace/analysis/utils/runtime-utils'
 
 
@@ -785,10 +786,11 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
       div({ style: { color: colors.dark(), fontSize: 18, fontWeight: 600, display: 'flex', alignItems: 'center', marginLeft: '1rem' } }, [billingProject.projectName]),
       isGcpProject && h(GcpBillingAccountControls, { authorizeAndLoadAccounts, billingAccounts, billingProject, isOwner, getShowBillingModal, setShowBillingModal, reloadBillingProject, setUpdating }),
       isAzureProject && div({ style: { color: colors.dark(), fontSize: 14, display: 'flex', alignItems: 'center', marginTop: '0.5rem', marginLeft: '1rem' } }, [
-        h(Link, {
-          href: `https://portal.azure.com/#@${billingProject.managedAppCoordinates.tenantId}/resource/subscriptions/${billingProject.managedAppCoordinates.subscriptionId}/resourceGroups/${billingProject.managedAppCoordinates.managedResourceGroupId}/overview`,
-          ...Utils.newTabLinkProps
-        }, ['Open Resource Group in Azure Portal', icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })])
+        h(ExternalLink, {
+          url: `https://portal.azure.com/#@${billingProject.managedAppCoordinates.tenantId}/resource/subscriptions/${billingProject.managedAppCoordinates.subscriptionId}/resourceGroups/${billingProject.managedAppCoordinates.managedResourceGroupId}/overview`,
+          text: 'Open Resource Group in Azure Portal',
+          popoutSize: 14
+        })
       ]),
       _.size(projectUsers) > 1 && _.size(projectOwners) === 1 && div({
         style: {

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -47,6 +47,8 @@ const getBillingAccountIcon = status => {
   return icon(shape, { size: billingAccountIconSize, color })
 }
 
+const accountLinkStyle = { color: colors.dark(), fontSize: 14, display: 'flex', alignItems: 'center', marginTop: '0.5rem', marginLeft: '1rem' }
+
 const WorkspaceCardHeaders = memoWithName('WorkspaceCardHeaders', ({ needsStatusColumn, sort, onSort }) => {
   return div({ role: 'row', style: { display: 'flex', justifyContent: 'space-between', marginTop: '1.5rem', padding: '0 1rem', marginBottom: '0.5rem' } }, [
     needsStatusColumn && div({ style: { width: billingAccountIconSize } }, [
@@ -305,7 +307,7 @@ const GcpBillingAccountControls = ({
 
   return h(Fragment, [
     Auth.hasBillingScope() &&
-    div({ style: { color: colors.dark(), fontSize: 14, display: 'flex', alignItems: 'center', marginTop: '0.5rem', marginLeft: '1rem' } }, [
+    div({ style: accountLinkStyle }, [
       span({ style: { flexShrink: 0, fontWeight: 600, fontSize: 14, margin: '0 0.75rem 0 0' } }, 'Billing Account:'),
       span({ style: { flexShrink: 0, marginRight: '0.5rem' } }, billingAccountDisplayText),
       isOwner && h(MenuTrigger, {
@@ -379,7 +381,7 @@ const GcpBillingAccountControls = ({
       ])
     ]),
     Auth.hasBillingScope() && isOwner &&
-    div({ style: { color: colors.dark(), fontSize: 14, display: 'flex', alignItems: 'center', margin: '0.5rem 0 0 1rem' } }, [
+    div({ style: accountLinkStyle }, [
       span({ style: { flexShrink: 0, fontWeight: 600, fontSize: 14, marginRight: '0.75rem' } }, 'Spend Report Configuration:'),
       span({ style: { flexShrink: 0 } }, 'Edit'),
       h(Link, {
@@ -427,7 +429,7 @@ const GcpBillingAccountControls = ({
       ])
     ]),
     !Auth.hasBillingScope() &&
-    div({ style: { color: colors.dark(), fontSize: 14, display: 'flex', alignItems: 'center', marginTop: '0.5rem', marginLeft: '1rem' } }, [
+    div({ style: accountLinkStyle }, [
       h(Link, {
         onClick: authorizeAndLoadAccounts
       }, ['View billing account'])
@@ -785,7 +787,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
     div({ style: { padding: '1.5rem 0 0', flexGrow: 1, display: 'flex', flexDirection: 'column' } }, [
       div({ style: { color: colors.dark(), fontSize: 18, fontWeight: 600, display: 'flex', alignItems: 'center', marginLeft: '1rem' } }, [billingProject.projectName]),
       isGcpProject && h(GcpBillingAccountControls, { authorizeAndLoadAccounts, billingAccounts, billingProject, isOwner, getShowBillingModal, setShowBillingModal, reloadBillingProject, setUpdating }),
-      isAzureProject && div({ style: { color: colors.dark(), fontSize: 14, display: 'flex', alignItems: 'center', marginTop: '0.5rem', marginLeft: '1rem' } }, [
+      isAzureProject && div({ style: accountLinkStyle }, [
         h(ExternalLink, {
           url: `https://portal.azure.com/#@${billingProject.managedAppCoordinates.tenantId}/resource/subscriptions/${billingProject.managedAppCoordinates.subscriptionId}/resourceGroups/${billingProject.managedAppCoordinates.managedResourceGroupId}/overview`,
           text: 'Open Resource Group in Azure Portal',

--- a/src/pages/billing/models/BillingProject.ts
+++ b/src/pages/billing/models/BillingProject.ts
@@ -18,7 +18,7 @@ export interface BillingProject {
 
 export interface AzureBillingProject extends BillingProject {
   cloudPlatform: 'AZURE'
-  azureManagedAppCoordinates: AzureManagedAppCoordinates
+  managedAppCoordinates: AzureManagedAppCoordinates
 }
 
 export interface GCPBillingProject extends BillingProject {


### PR DESCRIPTION
Change requested in [WOR-807](https://broadworkbench.atlassian.net/browse/WOR-807):

![image](https://user-images.githubusercontent.com/484484/223738231-7c978caa-91b7-425c-9913-647472efc9df.png)

As part of this, I touched base with Lou about when we should underline a link vs. including a pop-out icon. He prefers pop-out icons whenever a user will be taken out of Terra, and does not think an underline is also needed in that case. Accordingly, I made a few updates for consistency, and we also chose to address https://broadworkbench.atlassian.net/browse/SUP-817:

![image](https://user-images.githubusercontent.com/484484/223738394-8899015b-db02-4b91-908a-3906a8a6083a.png)

Pop-out icon changes:

<img width="768" alt="image" src="https://user-images.githubusercontent.com/484484/223575125-be390946-cb3d-4468-8a48-081cd7f7bb92.png">

![image](https://user-images.githubusercontent.com/484484/223738662-756af3a4-2d82-455c-b658-7614208c08d9.png)

![image](https://user-images.githubusercontent.com/484484/223739080-123ae417-6d79-440e-b67a-3f6188484b93.png)

[WOR-807]: https://broadworkbench.atlassian.net/browse/WOR-807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ