### PR TITLE
[WOR-809] extract spend report code and TS-ify

### DIFF
--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -481,7 +481,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
         )
       ])
     ]),
-    [spendReportKey]: h(SpendReport, { tab, billingProject })
+    [spendReportKey]: h(SpendReport, { billingProjectName: billingProject.projectName, viewSelected: tab === spendReportKey })
   }
 
   const tabs = _.map(key => ({

--- a/src/pages/billing/SpendReport/CostCard.ts
+++ b/src/pages/billing/SpendReport/CostCard.ts
@@ -8,12 +8,12 @@ interface CostCardProps {
   amount: string
   isProjectCostReady: boolean
   showAsterisk: boolean
-  key: string
+  type: string
 }
 
 export const CostCard = (props: CostCardProps) => {
   return div({
-    key: props.key,
+    key: props.type,
     style: {
       ...Style.elements.card.container,
       backgroundColor: 'white',
@@ -30,7 +30,7 @@ export const CostCard = (props: CostCardProps) => {
       },
       [
         div({ style: { fontSize: 16, color: colors.accent(), margin: '0.25rem 0.0rem', fontWeight: 'normal' } }, [props.title]),
-        div({ style: { fontSize: 32, height: 40, fontWeight: 'bold', gridRowStart: '2' } }, [
+        div({ style: { fontSize: 32, height: 40, fontWeight: 'bold', gridRowStart: '2' }, 'data-testid': props.type }, [
           props.amount,
           (!!props.showAsterisk && props.isProjectCostReady) ? span(
             {

--- a/src/pages/billing/SpendReport/CostCard.ts
+++ b/src/pages/billing/SpendReport/CostCard.ts
@@ -1,0 +1,46 @@
+import { div, span } from 'react-hyperscript-helpers'
+import colors from 'src/libs/colors'
+import * as Style from 'src/libs/style'
+
+
+interface CostCardProps {
+  title: string
+  amount: string
+  isProjectCostReady: boolean
+  showAsterisk: boolean
+  key: string
+}
+
+export const CostCard = (props: CostCardProps) => {
+  return div({
+    key: props.key,
+    style: {
+      ...Style.elements.card.container,
+      backgroundColor: 'white',
+      padding: undefined,
+      boxShadow: undefined,
+      gridRowStart: '2'
+    }
+  }, [
+    div(
+      {
+        style: { flex: 'none', padding: '0.625rem 1.25rem' },
+        'aria-live': props.isProjectCostReady ? 'polite' : 'off',
+        'aria-atomic': true
+      },
+      [
+        div({ style: { fontSize: 16, color: colors.accent(), margin: '0.25rem 0.0rem', fontWeight: 'normal' } }, [props.title]),
+        div({ style: { fontSize: 32, height: 40, fontWeight: 'bold', gridRowStart: '2' } }, [
+          props.amount,
+          (!!props.showAsterisk && props.isProjectCostReady) ? span(
+            {
+              style: { fontSize: 16, fontWeight: 'normal', verticalAlign: 'super' },
+              'aria-hidden': true
+            },
+            ['*']
+          ) : null
+        ])
+      ]
+    )
+  ])
+}

--- a/src/pages/billing/SpendReport/ErrorAlert.ts
+++ b/src/pages/billing/SpendReport/ErrorAlert.ts
@@ -1,0 +1,48 @@
+import _ from 'lodash/fp'
+import { div, h } from 'react-hyperscript-helpers'
+import Collapse from 'src/components/Collapse'
+import { icon } from 'src/components/icons'
+import colors from 'src/libs/colors'
+import * as Utils from 'src/libs/utils'
+
+
+export const ErrorAlert = ({ errorMessage }) => {
+  const error: any | undefined = Utils.maybeParseJSON(errorMessage)
+  return div({
+    style: {
+      backgroundColor: colors.danger(0.15), borderRadius: '4px',
+      boxShadow: '0 0 4px 0 rgba(0,0,0,0.5)', display: 'flex',
+      padding: '1rem', margin: '1rem 0 0'
+    }
+  }, [
+    div({ style: { display: 'flex' } },
+      [
+        div({ style: { margin: '0.3rem' } }, [
+          icon('error-standard', {
+            // @ts-ignore
+            'aria-hidden': false, 'aria-label': 'error notification', size: 30,
+            style: { color: colors.danger(), flexShrink: 0, marginRight: '0.3rem' }
+          })
+        ]),
+        Utils.cond(
+          [_.isString(errorMessage), () => div({ style: { display: 'flex', flexDirection: 'column', justifyContent: 'center' } },
+            [
+              div({ style: { fontWeight: 'bold', marginLeft: '0.2rem' }, role: 'alert' },
+                // @ts-ignore
+                _.upperFirst(error.message)),
+              h(Collapse, { title: 'Full Error Detail', style: { marginTop: '0.5rem' } },
+                [
+                  div({
+                    style: {
+                      padding: '0.5rem', marginTop: '0.5rem', backgroundColor: colors.light(),
+                      whiteSpace: 'pre-wrap', overflow: 'auto', overflowWrap: 'break-word',
+                      fontFamily: 'Menlo, monospace',
+                      maxHeight: 400
+                    }
+                  }, [JSON.stringify(error, null, 2)])
+                ])
+            ])],
+          () => div({ style: { display: 'flex', alignItems: 'center' }, role: 'alert' }, errorMessage.toString()))
+      ])
+  ])
+}

--- a/src/pages/billing/SpendReport/SpendReport.test.ts
+++ b/src/pages/billing/SpendReport/SpendReport.test.ts
@@ -45,55 +45,58 @@ describe('SpendReport', () => {
   const otherCostMessaging = /other infrastructure or query costs related to the general operations of Terra/i
 
   const createSpendReportResult = totalCost => {
-    const categorySpendData = {
+    const categorySpendData: AggregatedCategorySpendData = {
       aggregationKey: 'Category',
       spendData: [
-        { cost: '999', category: 'Compute' },
-        { cost: '22', category: 'Storage' },
-        { cost: '89', category: 'Other' }
+        { cost: '999', category: 'Compute', credits: '0.00', currency: 'USD' },
+        { cost: '22', category: 'Storage', credits: '0.00', currency: 'USD' },
+        { cost: '89', category: 'Other', credits: '0.00', currency: 'USD' }
       ]
-    } as AggregatedCategorySpendData
+    }
 
-    const workspaceSpendData = {
+    const workspaceSpendData: AggregatedWorkspaceSpendData = {
       aggregationKey: 'Workspace',
       spendData: [
         {
-          cost: '100', workspace: { name: 'Second Most Expensive Workspace' },
+          cost: '100', credits: '0.00', currency: 'USD', googleProjectId: 'googleProjectId',
+          workspace: { name: 'Second Most Expensive Workspace', namespace: 'namespace' },
           subAggregation: {
             aggregationKey: 'Category',
             spendData: [
-              { cost: '90', category: 'Compute' },
-              { cost: '2', category: 'Storage' },
-              { cost: '8', category: 'Other' }
+              { cost: '90', category: 'Compute', credits: '0.00', currency: 'USD' },
+              { cost: '2', category: 'Storage', credits: '0.00', currency: 'USD' },
+              { cost: '8', category: 'Other', credits: '0.00', currency: 'USD' }
             ]
           }
         },
         {
-          cost: '1000', workspace: { name: 'Most Expensive Workspace' },
+          cost: '1000', credits: '0.00', currency: 'USD', googleProjectId: 'googleProjectId',
+          workspace: { name: 'Most Expensive Workspace', namespace: 'namespace' },
           subAggregation: {
             aggregationKey: 'Category',
             spendData: [
-              { cost: '900', category: 'Compute' },
-              { cost: '20', category: 'Storage' },
-              { cost: '80', category: 'Other' }
+              { cost: '900', category: 'Compute', credits: '0.00', currency: 'USD' },
+              { cost: '20', category: 'Storage', credits: '0.00', currency: 'USD' },
+              { cost: '80', category: 'Other', credits: '0.00', currency: 'USD' }
             ]
           }
         },
         {
-          cost: '10', workspace: { name: 'Third Most Expensive Workspace' },
+          cost: '10', credits: '0.00', currency: 'USD', googleProjectId: 'googleProjectId',
+          workspace: { name: 'Third Most Expensive Workspace', namespace: 'namespace' },
           subAggregation: {
             aggregationKey: 'Category',
             spendData: [
-              { cost: '9', category: 'Compute' },
-              { cost: '0', category: 'Storage' },
-              { cost: '1', category: 'Other' }
+              { cost: '9', category: 'Compute', credits: '0.00', currency: 'USD' },
+              { cost: '0', category: 'Storage', credits: '0.00', currency: 'USD' },
+              { cost: '1', category: 'Other', credits: '0.00', currency: 'USD' }
             ]
           }
         }
       ]
-    } as AggregatedWorkspaceSpendData
+    }
 
-    const mockServerResponse = {
+    const mockServerResponse: SpendReportServerResponse = {
       spendSummary: {
         cost: totalCost, credits: '2.50', currency: 'USD', endTime: 'dummyTime', startTime: 'dummyTime'
       },
@@ -101,7 +104,7 @@ describe('SpendReport', () => {
         workspaceSpendData,
         categorySpendData
       ]
-    } as SpendReportServerResponse
+    }
 
     return mockServerResponse
   }

--- a/src/pages/billing/SpendReport/SpendReport.test.ts
+++ b/src/pages/billing/SpendReport/SpendReport.test.ts
@@ -2,7 +2,11 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import { act } from 'react-dom/test-utils'
 import { h } from 'react-hyperscript-helpers'
 import { Ajax } from 'src/libs/ajax'
-import { SpendReport } from 'src/pages/billing/SpendReport/SpendReport'
+import {
+  AggregatedCategorySpendData, AggregatedWorkspaceSpendData,
+  SpendReport,
+  SpendReportServerResponse
+} from 'src/pages/billing/SpendReport/SpendReport'
 import { asMockedFn } from 'src/testing/test-utils'
 
 
@@ -41,55 +45,65 @@ describe('SpendReport', () => {
   const otherCostMessaging = /other infrastructure or query costs related to the general operations of Terra/i
 
   const createSpendReportResult = totalCost => {
-    return {
+    const categorySpendData = {
+      aggregationKey: 'Category',
+      spendData: [
+        { cost: '999', category: 'Compute' },
+        { cost: '22', category: 'Storage' },
+        { cost: '89', category: 'Other' }
+      ]
+    } as AggregatedCategorySpendData
+
+    const workspaceSpendData = {
+      aggregationKey: 'Workspace',
+      spendData: [
+        {
+          cost: '100', workspace: { name: 'Second Most Expensive Workspace' },
+          subAggregation: {
+            aggregationKey: 'Category',
+            spendData: [
+              { cost: '90', category: 'Compute' },
+              { cost: '2', category: 'Storage' },
+              { cost: '8', category: 'Other' }
+            ]
+          }
+        },
+        {
+          cost: '1000', workspace: { name: 'Most Expensive Workspace' },
+          subAggregation: {
+            aggregationKey: 'Category',
+            spendData: [
+              { cost: '900', category: 'Compute' },
+              { cost: '20', category: 'Storage' },
+              { cost: '80', category: 'Other' }
+            ]
+          }
+        },
+        {
+          cost: '10', workspace: { name: 'Third Most Expensive Workspace' },
+          subAggregation: {
+            aggregationKey: 'Category',
+            spendData: [
+              { cost: '9', category: 'Compute' },
+              { cost: '0', category: 'Storage' },
+              { cost: '1', category: 'Other' }
+            ]
+          }
+        }
+      ]
+    } as AggregatedWorkspaceSpendData
+
+    const mockServerResponse = {
       spendSummary: {
         cost: totalCost, credits: '2.50', currency: 'USD', endTime: 'dummyTime', startTime: 'dummyTime'
       },
       spendDetails: [
-        {
-          aggregationKey: 'Workspace',
-          spendData: [
-            {
-              cost: '100', workspace: { name: 'Second Most Expensive Workspace' },
-              subAggregation: {
-                aggregationKey: 'Category',
-                spendData: [{ cost: '90', category: 'Compute' }, { cost: '2', category: 'Storage' }, {
-                  cost: '8',
-                  category: 'Other'
-                }]
-              }
-            },
-            {
-              cost: '1000', workspace: { name: 'Most Expensive Workspace' },
-              subAggregation: {
-                aggregationKey: 'Category',
-                spendData: [{ cost: '900', category: 'Compute' }, { cost: '20', category: 'Storage' }, {
-                  cost: '80',
-                  category: 'Other'
-                }]
-              }
-            },
-            {
-              cost: '10', workspace: { name: 'Third Most Expensive Workspace' },
-              subAggregation: {
-                aggregationKey: 'Category',
-                spendData: [{ cost: '9', category: 'Compute' }, { cost: '0', category: 'Storage' }, {
-                  cost: '1',
-                  category: 'Other'
-                }]
-              }
-            }
-          ]
-        },
-        {
-          aggregationKey: 'Category',
-          spendData: [{ cost: '999', category: 'Compute' }, { cost: '22', category: 'Storage' }, {
-            cost: '89',
-            category: 'Other'
-          }]
-        }
+        workspaceSpendData,
+        categorySpendData
       ]
-    }
+    } as SpendReportServerResponse
+
+    return mockServerResponse
   }
 
   it('does not call the server if view is not active', async () => {

--- a/src/pages/billing/SpendReport/SpendReport.test.ts
+++ b/src/pages/billing/SpendReport/SpendReport.test.ts
@@ -1,0 +1,190 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { act } from 'react-dom/test-utils'
+import { h } from 'react-hyperscript-helpers'
+import { Ajax } from 'src/libs/ajax'
+import { SpendReport } from 'src/pages/billing/SpendReport/SpendReport'
+import { asMockedFn } from 'src/testing/test-utils'
+
+
+type AjaxContract = ReturnType<typeof Ajax>
+jest.mock('src/libs/ajax')
+
+describe('SpendReport', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+    jest.useFakeTimers()
+    // Note that month is 0-based. This is April 1st, 2022.
+    jest.setSystemTime(new Date(Date.UTC(2022, 3, 1, 20, 17, 5, 0)))
+  })
+
+  afterAll(() => {
+    jest.useRealTimers()
+  })
+
+  const select90Days = async () => {
+    // Selecting the option by all the "usual" methods of supplying label text, selecting an option, etc. failed.
+    // Perhaps this is because these options have both display text and a value?
+    // Unfortunately this awkward approach was the only thing that appeared to work.
+    const getDateRangeSelect = () => screen.getByLabelText('Date range')
+    // 7 days
+    fireEvent.keyDown(getDateRangeSelect(), { key: 'ArrowDown', code: 'ArrowDown' })
+    // 30 days
+    fireEvent.keyDown(getDateRangeSelect(), { key: 'ArrowDown', code: 'ArrowDown' })
+    // 90 days
+    fireEvent.keyDown(getDateRangeSelect(), { key: 'ArrowDown', code: 'ArrowDown' })
+    await act(async () => { // eslint-disable-line require-await
+      // Trigger the option to be selected
+      fireEvent.keyDown(getDateRangeSelect(), { key: 'Enter', code: 'Enter' })
+    })
+  }
+
+  const otherCostMessaging = /other infrastructure or query costs related to the general operations of Terra/i
+
+  const createSpendReportResult = totalCost => {
+    return {
+      spendSummary: {
+        cost: totalCost, credits: '2.50', currency: 'USD', endTime: 'dummyTime', startTime: 'dummyTime'
+      },
+      spendDetails: [
+        {
+          aggregationKey: 'Workspace',
+          spendData: [
+            {
+              cost: '100', workspace: { name: 'Second Most Expensive Workspace' },
+              subAggregation: {
+                aggregationKey: 'Category',
+                spendData: [{ cost: '90', category: 'Compute' }, { cost: '2', category: 'Storage' }, {
+                  cost: '8',
+                  category: 'Other'
+                }]
+              }
+            },
+            {
+              cost: '1000', workspace: { name: 'Most Expensive Workspace' },
+              subAggregation: {
+                aggregationKey: 'Category',
+                spendData: [{ cost: '900', category: 'Compute' }, { cost: '20', category: 'Storage' }, {
+                  cost: '80',
+                  category: 'Other'
+                }]
+              }
+            },
+            {
+              cost: '10', workspace: { name: 'Third Most Expensive Workspace' },
+              subAggregation: {
+                aggregationKey: 'Category',
+                spendData: [{ cost: '9', category: 'Compute' }, { cost: '0', category: 'Storage' }, {
+                  cost: '1',
+                  category: 'Other'
+                }]
+              }
+            }
+          ]
+        },
+        {
+          aggregationKey: 'Category',
+          spendData: [{ cost: '999', category: 'Compute' }, { cost: '22', category: 'Storage' }, {
+            cost: '89',
+            category: 'Other'
+          }]
+        }
+      ]
+    }
+  }
+
+  it('does not call the server if view is not active', async () => {
+    //Arrange
+    const getSpendReport = jest.fn(() => Promise.resolve())
+    asMockedFn(Ajax).mockImplementation(() => ({
+      Billing: { getSpendReport } as Partial<AjaxContract['Billing']>
+    } as Partial<AjaxContract> as AjaxContract))
+
+    // Act
+    await act(async () => {
+      await render(h(SpendReport, { viewSelected: false, billingProjectName: 'thrifty' }))
+    })
+
+    // Assert
+    expect(getSpendReport).not.toHaveBeenCalled()
+    expect(screen.queryByText(otherCostMessaging)).toBeNull()
+  })
+
+  it('fetches reports based on selected date range, if active', async () => {
+    //Arrange
+    const getSpendReport = jest.fn()
+    asMockedFn(Ajax).mockImplementation(() => ({
+      Billing: { getSpendReport } as Partial<AjaxContract['Billing']>
+    } as Partial<AjaxContract> as AjaxContract))
+    getSpendReport.mockResolvedValueOnce(
+      createSpendReportResult('1110')
+    ).mockResolvedValue(
+      createSpendReportResult('1110.17')
+    )
+
+    // Act
+    await act(async () => {
+      await render(h(SpendReport, { viewSelected: true, billingProjectName: 'thrifty' }))
+    })
+    await select90Days()
+
+    // Assert
+    expect(screen.getByTestId('spend').textContent).toBe('$1,110.17*')
+    screen.getByText(otherCostMessaging)
+    expect(getSpendReport).toHaveBeenCalledTimes(2)
+    expect(getSpendReport).toHaveBeenNthCalledWith(1, { billingProjectName: 'thrifty', endDate: '2022-04-01', startDate: '2022-03-02' })
+    expect(getSpendReport).toHaveBeenNthCalledWith(2, { billingProjectName: 'thrifty', endDate: '2022-04-01', startDate: '2022-01-01' })
+  })
+
+  it('displays cost information', async () => {
+    //Arrange
+    const getSpendReport = jest.fn()
+    asMockedFn(Ajax).mockImplementation(() => ({
+      Billing: { getSpendReport } as Partial<AjaxContract['Billing']>
+    } as Partial<AjaxContract> as AjaxContract))
+    getSpendReport.mockResolvedValue(createSpendReportResult('1110'))
+
+    // Act
+    await act(async () => {
+      await render(h(SpendReport, { viewSelected: true, billingProjectName: 'thrifty' }))
+    })
+
+    // Assert
+    expect(getSpendReport).toHaveBeenCalledTimes(1)
+    expect(screen.getByTestId('spend').textContent).toBe('$1,110.00*')
+    expect(screen.getByTestId('compute').textContent).toBe('$999.00')
+    expect(screen.getByTestId('storage').textContent).toBe('$22.00')
+    screen.getByText(/\$89.00 in other infrastructure/i)
+
+    // Highcharts content is very minimal when rendered in the unit test. Testing of "most expensive workspaces"
+    // is in the integration test. Accessibility is also tested in the integration test.
+  })
+
+  it('shows an error if no cost information exists', async () => {
+    //Arrange
+    let getSpendReport = jest.fn(() => Promise.reject(new Response(JSON.stringify({ message: 'No spend data for 30 days' }), { status: 404 })))
+    asMockedFn(Ajax).mockImplementation(() => ({
+      Billing: { getSpendReport } as Partial<AjaxContract['Billing']>
+    } as Partial<AjaxContract> as AjaxContract))
+
+    // Act
+    await act(async () => {
+      await render(h(SpendReport, { viewSelected: true, billingProjectName: 'thrifty' }))
+    })
+
+    // Assert
+    expect(screen.getByRole('alert').textContent).toEqual('No spend data for 30 days')
+
+    // Arrange, switch error message to verify that the UI updates with the new message.
+    getSpendReport = jest.fn(() => Promise.reject(new Response(JSON.stringify({ message: 'No spend data for 90 days' }), { status: 404 })))
+    asMockedFn(Ajax).mockImplementation(() => ({
+      Billing: { getSpendReport } as Partial<AjaxContract['Billing']>
+    } as Partial<AjaxContract> as AjaxContract))
+
+    // Act -- switch to 90 days and verify that the alert is updated
+    await select90Days()
+
+    // Assert
+    expect(screen.getByRole('alert').textContent).toEqual('No spend data for 90 days')
+  })
+})
+

--- a/src/pages/billing/SpendReport/SpendReport.ts
+++ b/src/pages/billing/SpendReport/SpendReport.ts
@@ -213,8 +213,6 @@ export const SpendReport = (props: SpendReportProps) => {
     })
   }, [spendReportLengthInDays, props, signal, projectCost, updatingProjectCost, errorMessage])
 
-  const NumberSelect = Select as typeof Select<number>
-
   return h(Fragment, [
     div({ style: { display: 'grid', rowGap: '0.5rem' } }, [
       !!errorMessage && h(ErrorAlert, { errorMessage }),
@@ -230,7 +228,7 @@ export const SpendReport = (props: SpendReportProps) => {
           div({ style: { gridRowStart: 1, gridColumnStart: 1 } }, [
             h(IdContainer, [id => h(Fragment, [
               h(FormLabel, { htmlFor: id }, ['Date range']),
-              h(NumberSelect, {
+              h((Select<number>), {
                 id,
                 value: spendReportLengthInDays,
                 options: _.map(days => ({

--- a/src/pages/billing/SpendReport/SpendReport.ts
+++ b/src/pages/billing/SpendReport/SpendReport.ts
@@ -162,7 +162,7 @@ export const SpendReport = (props: SpendReportProps) => {
         setUpdatingProjectCost(true)
         const endDate = new Date().toISOString().slice(0, 10)
         const startDate = subDays(spendReportLengthInDays, new Date()).toISOString().slice(0, 10)
-        const spend = await Ajax(signal).Billing.getSpendReport({ billingProjectName: props.billingProjectName, startDate, endDate }) as SpendReportServerResponse
+        const spend: SpendReportServerResponse = await Ajax(signal).Billing.getSpendReport({ billingProjectName: props.billingProjectName, startDate, endDate })
         const costFormatter = new Intl.NumberFormat(navigator.language, { style: 'currency', currency: spend.spendSummary.currency })
         const categoryDetails = _.find(details => details.aggregationKey === 'Category', spend.spendDetails) as AggregatedCategorySpendData
         console.assert(categoryDetails !== undefined, 'Spend report details do not include aggregation by Category')

--- a/src/pages/billing/SpendReport/SpendReport.ts
+++ b/src/pages/billing/SpendReport/SpendReport.ts
@@ -48,7 +48,7 @@ interface ProjectCost {
 
 // Interfaces for dealing with the server SpendReport JSON response
 interface CategorySpendData {
-  category: string
+  category: 'Compute' | 'Storage' | 'Other'
   cost: string
   credits: string
   currency: string
@@ -67,24 +67,24 @@ interface AggregatedSpendData {
   aggregationKey: 'Workspace' | 'Category'
 }
 
-interface AggregatedWorkspaceSpendData extends AggregatedSpendData{
+export interface AggregatedWorkspaceSpendData extends AggregatedSpendData{
   aggregationKey: 'Workspace'
   spendData: WorkspaceSpendData[]
 }
 
-interface AggregatedCategorySpendData extends AggregatedSpendData {
+export interface AggregatedCategorySpendData extends AggregatedSpendData {
   aggregationKey: 'Category'
   spendData: CategorySpendData[]
 }
 
-interface SpendReportServerResponse {
+export interface SpendReportServerResponse {
   spendDetails: AggregatedSpendData[]
   spendSummary: {
     cost: string
     credits: string
     currency: string
-    startDate: string
-    endDate: string
+    endTime: string
+    startTime: string
   }
 }
 // End of interfaces for dealing with the server SpendReport JSON response

--- a/src/pages/billing/SpendReport/SpendReport.ts
+++ b/src/pages/billing/SpendReport/SpendReport.ts
@@ -1,0 +1,297 @@
+import { subDays } from 'date-fns/fp'
+import _ from 'lodash/fp'
+import { Fragment, lazy, Suspense, useEffect, useState } from 'react'
+import { div, h, span } from 'react-hyperscript-helpers'
+import Collapse from 'src/components/Collapse'
+import {
+  customSpinnerOverlay,
+  IdContainer,
+  Select
+} from 'src/components/common'
+import { icon } from 'src/components/icons'
+import { Ajax } from 'src/libs/ajax'
+import colors from 'src/libs/colors'
+import { FormLabel } from 'src/libs/forms'
+import { useCancellation } from 'src/libs/react-utils'
+import * as Style from 'src/libs/style'
+import * as Utils from 'src/libs/utils'
+
+
+const LazyChart = lazy(() => import('src/components/Chart'))
+const maxWorkspacesInChart = 10
+const spendReportKey = 'spend report'
+
+const CostCard = ({ title, amount, isProjectCostReady, showAsterisk, ...props }) => {
+  return div({
+    ...props,
+    style: {
+      ...Style.elements.card.container,
+      backgroundColor: 'white',
+      padding: undefined,
+      boxShadow: undefined,
+      gridRowStart: '2'
+    }
+  }, [
+    div(
+      {
+        style: { flex: 'none', padding: '0.625rem 1.25rem' },
+        'aria-live': isProjectCostReady ? 'polite' : 'off',
+        'aria-atomic': true
+      },
+      [
+        div({ style: { fontSize: 16, color: colors.accent(), margin: '0.25rem 0.0rem', fontWeight: 'normal' } }, [title]),
+        div({ style: { fontSize: 32, height: 40, fontWeight: 'bold', gridRowStart: '2' } }, [
+          amount,
+          (!!showAsterisk && isProjectCostReady) ? span(
+            {
+              style: { fontSize: 16, fontWeight: 'normal', verticalAlign: 'super' },
+              'aria-hidden': true
+            },
+            ['*']
+          ) : null
+        ])
+      ]
+    )
+  ])
+}
+
+const ErrorAlert = ({ errorMessage }) => {
+  const error = Utils.maybeParseJSON(errorMessage)
+  // @ts-ignore
+  return div({
+    style: {
+      backgroundColor: colors.danger(0.15), borderRadius: '4px',
+      boxShadow: '0 0 4px 0 rgba(0,0,0,0.5)', display: 'flex',
+      padding: '1rem', margin: '1rem 0 0'
+    }
+  }, [
+    div({ style: { display: 'flex' } },
+      [
+        div({ style: { margin: '0.3rem' } }, [
+          icon('error-standard', {
+            // @ts-ignore
+            'aria-hidden': false, 'aria-label': 'error notification', size: 30,
+            style: { color: colors.danger(), flexShrink: 0, marginRight: '0.3rem' }
+          })
+        ]),
+        Utils.cond(
+          [_.isString(errorMessage), () => div({ style: { display: 'flex', flexDirection: 'column', justifyContent: 'center' } },
+            [
+              div({ style: { fontWeight: 'bold', marginLeft: '0.2rem' }, role: 'alert' }, // @ts-ignore
+                _.upperFirst(error.message)),
+              h(Collapse, { title: 'Full Error Detail', style: { marginTop: '0.5rem' } },
+                [
+                  div({
+                    style: {
+                      padding: '0.5rem', marginTop: '0.5rem', backgroundColor: colors.light(),
+                      whiteSpace: 'pre-wrap', overflow: 'auto', overflowWrap: 'break-word',
+                      fontFamily: 'Menlo, monospace',
+                      maxHeight: 400
+                    }
+                  }, [JSON.stringify(error, null, 2)])
+                ])
+            ])],
+          () => div({ style: { display: 'flex', alignItems: 'center' }, role: 'alert' }, errorMessage.toString()))
+      ])
+  ])
+}
+
+const OtherMessaging = ({ cost }) => {
+  const msg = cost !== null ?
+    `Total spend includes ${cost} in other infrastructure or query costs related to the general operations of Terra.` :
+    'Total spend includes infrastructure or query costs related to the general operations of Terra'
+  return div({ 'aria-live': cost !== null ? 'polite' : 'off', 'aria-atomic': true }, [
+    span({ 'aria-hidden': true }, ['*']),
+    '',
+    msg
+  ])
+}
+
+export const SpendReport = ({ tab, billingProject }) => {
+  const [updating, setUpdating] = useState(false)
+  const [projectCost, setProjectCost] = useState(null)
+  const [costPerWorkspace, setCostPerWorkspace] = useState(
+    { workspaceNames: [], computeCosts: [], otherCosts: [], storageCosts: [], numWorkspaces: 0, costFormatter: null }
+  )
+  const [updatingProjectCost, setUpdatingProjectCost] = useState(false)
+  const [spendReportLengthInDays, setSpendReportLengthInDays] = useState(30)
+  const [errorMessage, setErrorMessage] = useState()
+
+  const signal = useCancellation()
+
+  const spendChartOptions = {
+    chart: { marginTop: 50, spacingLeft: 20, style: { fontFamily: 'inherit' }, type: 'bar' },
+    credits: { enabled: false },
+    legend: { reversed: true },
+    plotOptions: { series: { stacking: 'normal' } },
+    series: [
+      { name: 'Compute', data: costPerWorkspace.computeCosts },
+      { name: 'Storage', data: costPerWorkspace.storageCosts }
+    ],
+    title: {
+      align: 'left', style: { fontSize: '16px' }, y: 25,
+      text: costPerWorkspace.numWorkspaces > maxWorkspacesInChart ? `Top ${maxWorkspacesInChart} Spending Workspaces` : 'Spend By Workspace'
+    },
+    tooltip: {
+      followPointer: true,
+      shared: true,
+      headerFormat: '{point.key}',
+      pointFormatter: function() { // eslint-disable-line object-shorthand
+        // @ts-ignore
+        return `<br/><span style="color:${this.color}">\u25CF</span> ${this.series.name}: ${costPerWorkspace.costFormatter.format(this.y)}`
+      }
+    },
+    xAxis: {
+      categories: costPerWorkspace.workspaceNames, crosshair: true,
+      labels: { style: { fontSize: '12px' } }
+    },
+    yAxis: {
+      crosshair: true, min: 0,
+      labels: {
+        formatter() { // @ts-ignore
+          return costPerWorkspace.costFormatter.format(this.value)
+        }, // eslint-disable-line object-shorthand
+        style: { fontSize: '12px' }
+      },
+      title: { enabled: false },
+      width: '96%'
+    },
+    accessibility: {
+      point: {
+        descriptionFormatter: point => {
+          // @ts-ignore
+          return `${point.index + 1}. Workspace ${point.category}, ${point.series.name}: ${costPerWorkspace.costFormatter.format(point.y)}.`
+        }
+      }
+    },
+    exporting: { buttons: { contextButton: { x: -15 } } }
+  }
+
+  const isProjectCostReady = projectCost !== null
+
+  // Update cost data only if report date range changes, or if spend report tab was selected.
+  useEffect(() => {
+    const maybeLoadProjectCost =
+        Utils.withBusyState(setUpdating, async () => {
+          if (!updatingProjectCost && projectCost === null && tab === spendReportKey) {
+            setUpdatingProjectCost(true)
+            const endDate = new Date().toISOString().slice(0, 10)
+            const startDate = subDays(spendReportLengthInDays, new Date()).toISOString().slice(0, 10)
+            const spend = await Ajax(signal).Billing.getSpendReport({ billingProjectName: billingProject.projectName, startDate, endDate })
+            const costFormatter = new Intl.NumberFormat(navigator.language, { style: 'currency', currency: spend.spendSummary.currency })
+            // @ts-ignore
+            const categoryDetails = _.find(details => details.aggregationKey === 'Category')(spend.spendDetails)
+            console.assert(categoryDetails !== undefined, 'Spend report details do not include aggregation by Category')
+            const getCategoryCosts = (categorySpendData, asFloat) => {
+              const costDict = {}
+              _.forEach(type => {
+                // @ts-ignore
+                const costAsString = _.find(['category', type])(categorySpendData)?.cost ?? 0
+                costDict[type] = asFloat ? parseFloat(costAsString) : costFormatter.format(costAsString)
+              }, ['Compute', 'Storage', 'Other'])
+              return costDict
+            }
+            // @ts-ignore
+            const costDict = getCategoryCosts(categoryDetails.spendData, false)
+
+            const totalCosts = {
+              spend: costFormatter.format(spend.spendSummary.cost), // @ts-ignore
+              compute: costDict.Compute, // @ts-ignore
+              storage: costDict.Storage, // @ts-ignore
+              other: costDict.Other
+            }
+
+            // @ts-ignore
+            setProjectCost(totalCosts)
+
+            // @ts-ignore
+            const workspaceDetails = _.find(details => details.aggregationKey === 'Workspace')(spend.spendDetails)
+            console.assert(workspaceDetails !== undefined, 'Spend report details do not include aggregation by Workspace')
+            // Get the most expensive workspaces, sorted from most to least expensive.
+            // @ts-ignore
+            const mostExpensiveWorkspaces = _.flow(
+              _.sortBy(({ cost }) => { return parseFloat(cost) }),
+              _.reverse,
+              _.slice(0, maxWorkspacesInChart) // @ts-ignore
+            )(workspaceDetails?.spendData)
+            // Pull out names and costs.
+            const costPerWorkspace = {
+              // @ts-ignore
+              workspaceNames: [], computeCosts: [], storageCosts: [], otherCosts: [], costFormatter, numWorkspaces: workspaceDetails?.spendData.length
+            }
+            _.forEach(workspaceCostData => {
+              // @ts-ignore
+              costPerWorkspace.workspaceNames.push(workspaceCostData.workspace.name)
+              // @ts-ignore
+              const categoryDetails = workspaceCostData.subAggregation
+              console.assert(categoryDetails.key !== 'Category', 'Workspace spend report details do not include sub-aggregation by Category')
+              const costDict = getCategoryCosts(categoryDetails.spendData, true) // @ts-ignore
+              costPerWorkspace.computeCosts.push(costDict.Compute) // @ts-ignore
+              costPerWorkspace.storageCosts.push(costDict.Storage) // @ts-ignore
+              costPerWorkspace.otherCosts.push(costDict.Other) // @ts-ignore
+            })(mostExpensiveWorkspaces) // @ts-ignore
+            setCostPerWorkspace(costPerWorkspace)
+            setUpdatingProjectCost(false)
+          }
+        })
+    maybeLoadProjectCost().catch(async error => {
+      setErrorMessage(await (error instanceof Response ? error.text() : error))
+      setUpdatingProjectCost(false)
+    })
+  }, [spendReportLengthInDays, tab]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  return h(Fragment, [
+    div({ style: { display: 'grid', rowGap: '0.5rem' } }, [
+      !!errorMessage && h(ErrorAlert, { errorMessage }),
+      div(
+        {
+          style: {
+            display: 'grid',
+            gridTemplateColumns: 'repeat(3, minmax(max-content, 1fr))',
+            rowGap: '1.66rem',
+            columnGap: '1.25rem'
+          }
+        }, [
+          div({ style: { gridRowStart: 1, gridColumnStart: 1 } }, [
+            h(IdContainer, [id => h(Fragment, [
+              h(FormLabel, { htmlFor: id }, ['Date range']),
+              h(Select, {
+                id,
+                value: spendReportLengthInDays,
+                options: _.map(days => ({
+                  label: `Last ${days} days`,
+                  value: days
+                }), [7, 30, 90]),
+                // @ts-ignore
+                onChange: ({ value: selectedDays }) => {
+                  if (selectedDays !== spendReportLengthInDays) {
+                    setSpendReportLengthInDays(selectedDays)
+                    setProjectCost(null)
+                  }
+                }
+              })
+            ])])
+          ]),
+          ...(_.map(name => h(CostCard, {
+            title: `Total ${name}`,
+            amount: (!isProjectCostReady ? '...' : projectCost[name]),
+            isProjectCostReady,
+            showAsterisk: name === 'spend',
+            key: name
+          }),
+          ['spend', 'compute', 'storage'])
+          )
+        ]
+      ),
+      h(OtherMessaging, { cost: isProjectCostReady ? projectCost['other'] : null }),
+      costPerWorkspace.numWorkspaces > 0 && div(
+        {
+          style: { minWidth: 500, marginTop: '1rem' }
+        }, [ // Set minWidth so chart will shrink on resize
+          h(Suspense, { fallback: null }, [h(LazyChart, { options: spendChartOptions })])
+        ]
+      )
+    ]),
+    updating && customSpinnerOverlay({ height: '100vh', width: '100vw', position: 'fixed' })
+  ])
+}

--- a/src/pages/billing/SpendReport/SpendReport.ts
+++ b/src/pages/billing/SpendReport/SpendReport.ts
@@ -2,99 +2,23 @@ import { subDays } from 'date-fns/fp'
 import _ from 'lodash/fp'
 import { Fragment, lazy, Suspense, useEffect, useState } from 'react'
 import { div, h, span } from 'react-hyperscript-helpers'
-import Collapse from 'src/components/Collapse'
 import {
   customSpinnerOverlay,
   IdContainer,
   Select
 } from 'src/components/common'
-import { icon } from 'src/components/icons'
 import { Ajax } from 'src/libs/ajax'
-import colors from 'src/libs/colors'
 import { FormLabel } from 'src/libs/forms'
 import { useCancellation } from 'src/libs/react-utils'
-import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
+import { CostCard } from 'src/pages/billing/SpendReport/CostCard'
+import { ErrorAlert } from 'src/pages/billing/SpendReport/ErrorAlert'
 
 
 const LazyChart = lazy(() => import('src/components/Chart'))
 const maxWorkspacesInChart = 10
 const spendReportKey = 'spend report'
 
-const CostCard = ({ title, amount, isProjectCostReady, showAsterisk, ...props }) => {
-  return div({
-    ...props,
-    style: {
-      ...Style.elements.card.container,
-      backgroundColor: 'white',
-      padding: undefined,
-      boxShadow: undefined,
-      gridRowStart: '2'
-    }
-  }, [
-    div(
-      {
-        style: { flex: 'none', padding: '0.625rem 1.25rem' },
-        'aria-live': isProjectCostReady ? 'polite' : 'off',
-        'aria-atomic': true
-      },
-      [
-        div({ style: { fontSize: 16, color: colors.accent(), margin: '0.25rem 0.0rem', fontWeight: 'normal' } }, [title]),
-        div({ style: { fontSize: 32, height: 40, fontWeight: 'bold', gridRowStart: '2' } }, [
-          amount,
-          (!!showAsterisk && isProjectCostReady) ? span(
-            {
-              style: { fontSize: 16, fontWeight: 'normal', verticalAlign: 'super' },
-              'aria-hidden': true
-            },
-            ['*']
-          ) : null
-        ])
-      ]
-    )
-  ])
-}
-
-const ErrorAlert = ({ errorMessage }) => {
-  const error = Utils.maybeParseJSON(errorMessage)
-  // @ts-ignore
-  return div({
-    style: {
-      backgroundColor: colors.danger(0.15), borderRadius: '4px',
-      boxShadow: '0 0 4px 0 rgba(0,0,0,0.5)', display: 'flex',
-      padding: '1rem', margin: '1rem 0 0'
-    }
-  }, [
-    div({ style: { display: 'flex' } },
-      [
-        div({ style: { margin: '0.3rem' } }, [
-          icon('error-standard', {
-            // @ts-ignore
-            'aria-hidden': false, 'aria-label': 'error notification', size: 30,
-            style: { color: colors.danger(), flexShrink: 0, marginRight: '0.3rem' }
-          })
-        ]),
-        Utils.cond(
-          [_.isString(errorMessage), () => div({ style: { display: 'flex', flexDirection: 'column', justifyContent: 'center' } },
-            [
-              div({ style: { fontWeight: 'bold', marginLeft: '0.2rem' }, role: 'alert' }, // @ts-ignore
-                _.upperFirst(error.message)),
-              h(Collapse, { title: 'Full Error Detail', style: { marginTop: '0.5rem' } },
-                [
-                  div({
-                    style: {
-                      padding: '0.5rem', marginTop: '0.5rem', backgroundColor: colors.light(),
-                      whiteSpace: 'pre-wrap', overflow: 'auto', overflowWrap: 'break-word',
-                      fontFamily: 'Menlo, monospace',
-                      maxHeight: 400
-                    }
-                  }, [JSON.stringify(error, null, 2)])
-                ])
-            ])],
-          () => div({ style: { display: 'flex', alignItems: 'center' }, role: 'alert' }, errorMessage.toString()))
-      ])
-  ])
-}
 
 const OtherMessaging = ({ cost }) => {
   const msg = cost !== null ?


### PR DESCRIPTION
This PR pull out out the spend report components into TS files and adds interfaces to help clarify the expected structure of the server response. It does not convert `ajax/Billing.js` to TS, though perhaps it should?

Unit test coverage was added and provides some minimal coverage of the error display (not covered in the integration test). There are some things that cannot be tested in the unit test, and therefore I suggest we leave the integration test as-is.

The first 2 commits are meant to be straight code extraction, with ts-ignores added wherever necessary. The [third commit](5245f7d16c08c31c7124bbc89f18732fdfa61b95) is the one that should be most closely reviewed, as it adds the interfaces and removes ts-ignores where possible (a few remain related to HighCharts).

Billing project with some data: https://pr-3-dot-bvdp-saturn-dev.appspot.com/#billing?selectedName=galaxy-anvil-dev&type=project&tab=spend%20report

![image](https://user-images.githubusercontent.com/484484/224165599-5ffaf7be-bb8d-481f-bac3-05e7941c1e57.png)

