### PR TITLE
[UIE-74] Add types for withDisplayName and forwardRefWithName

### DIFF
--- a/src/libs/react-utils.ts
+++ b/src/libs/react-utils.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp'
-import { EffectCallback, forwardRef, memo, useEffect, useRef, useState } from 'react'
+import { EffectCallback, forwardRef, ForwardRefRenderFunction, memo, ReactElement, useEffect, useRef, useState } from 'react'
 import { h } from 'react-hyperscript-helpers'
 import { safeCurry } from 'src/libs/type-utils/lodash-fp-helpers'
 import { delay, pollWithCancellation } from 'src/libs/utils'
@@ -84,7 +84,17 @@ export const useCancellation = (): AbortSignal => {
   return controller.current.signal
 }
 
-export const withDisplayName = _.curry((name, WrappedComponent) => {
+type ComponentWithDisplayName = {
+  (props: any, context?: any): ReactElement<any, any> | null
+  displayName?: string | undefined
+}
+
+type WithDisplayNameFn = {
+  (name: string): <T extends ComponentWithDisplayName>(WrappedComponent: T) => T
+  <T extends ComponentWithDisplayName>(name: string, WrappedComponent: T): T
+}
+
+export const withDisplayName: WithDisplayNameFn = safeCurry(<T extends ComponentWithDisplayName>(name: string, WrappedComponent: T): T => {
   WrappedComponent.displayName = name
   return WrappedComponent
 })
@@ -101,8 +111,12 @@ export const combineRefs = refs => {
   }
 }
 
-// TODO: improve these types further
-export const forwardRefWithName = safeCurry((name: string, WrappedComponent) => {
+type ForwardRefWithNameFn = {
+  (name: string): <T, P = any>(WrappedComponent: ForwardRefRenderFunction<T, P>) => ReturnType<typeof forwardRef<T, P>>
+  <T, P>(name: string, WrappedComponent: ForwardRefRenderFunction<T, P>): ReturnType<typeof forwardRef<T, P>>
+}
+
+export const forwardRefWithName: ForwardRefWithNameFn = safeCurry(<T, P>(name: string, WrappedComponent: ForwardRefRenderFunction<T, P>) => {
   return withDisplayName(name, forwardRef(WrappedComponent))
 })
 

--- a/src/pages/ImportWorkflow/WorkspaceImporter.ts
+++ b/src/pages/ImportWorkflow/WorkspaceImporter.ts
@@ -64,7 +64,6 @@ export const WorkspaceImporter: (props: WorkspaceImporterInnerProps) => ReactEle
       }, ['create a new workspace'])
     ]),
     creatingWorkspace && h(NewWorkspaceModal, {
-      // @ts-expect-error
       requiredAuthDomain: ad,
       onDismiss: () => setCreatingWorkspace(false),
       onSuccess: w => {

--- a/src/pages/workspaces/workspace/Files.ts
+++ b/src/pages/workspaces/workspace/Files.ts
@@ -18,7 +18,7 @@ export const Files = _.flow(
     title: 'Files',
     topBarContent: null
   })
-)(({ workspace }, _ref) => {
+)(({ workspace }: { workspace: any }, _ref) => {
   const fileBrowserProvider = useMemo(
     () => {
       if (isAzureWorkspace(workspace)) {

--- a/src/pages/workspaces/workspace/analysis/Analyses.ts
+++ b/src/pages/workspaces/workspace/analysis/Analyses.ts
@@ -1,7 +1,7 @@
 import * as clipboard from 'clipboard-polyfill/text'
 import _ from 'lodash/fp'
 import * as qs from 'qs'
-import { CSSProperties, FC, Fragment, useEffect, useState } from 'react'
+import { CSSProperties, ForwardedRef, Fragment, useEffect, useState } from 'react'
 import { div, h, img, label, span } from 'react-hyperscript-helpers'
 import * as breadcrumbs from 'src/components/breadcrumbs'
 import { requesterPaysWrapper, withRequesterPaysHandler } from 'src/components/bucket-utils'
@@ -310,12 +310,12 @@ export interface SortOrderInfo {
   direction: 'asc' | 'desc'
 }
 
-export const BaseAnalyses: FC<AnalysesProps> = ({
+export const BaseAnalyses = ({
   workspace,
   analysesData: { apps, refreshApps, runtimes, refreshRuntimes, appDataDisks, persistentDisks },
   storageDetails: { googleBucketLocation, azureContainerRegion },
   onRequesterPaysError
-}: AnalysesProps, _ref) => {
+}: AnalysesProps, _ref: ForwardedRef<unknown>) => {
   const [renamingAnalysisName, setRenamingAnalysisName] = useState<AbsolutePath>()
   const [copyingAnalysisName, setCopyingAnalysisName] = useState<AbsolutePath>()
   const [deletingAnalysisName, setDeletingAnalysisName] = useState<AbsolutePath>()
@@ -410,7 +410,6 @@ export const BaseAnalyses: FC<AnalysesProps> = ({
         }, [
           label({ htmlFor: id, style: { fontWeight: 'bold', margin: '0 0.5rem', whiteSpace: 'nowrap' } }, ['Enable JupyterLab']),
           h(Switch, {
-            // @ts-expect-error
             onLabel: '', offLabel: '',
             onChange: value => {
               setEnableJupyterLabGCP(value)
@@ -420,7 +419,7 @@ export const BaseAnalyses: FC<AnalysesProps> = ({
             id,
             checked: enableJupyterLabGCP,
             width: 40, height: 20,
-          }, [])
+          })
         ])
       ])])
     ])
@@ -540,8 +539,10 @@ export const BaseAnalyses: FC<AnalysesProps> = ({
           appDataDisks,
           refreshAnalyses,
           analyses,
+          // @ts-expect-error
           apps,
           refreshApps,
+          // @ts-expect-error
           uploadFiles,
           openUploader,
           location,

--- a/src/pages/workspaces/workspace/analysis/_testData/testData.ts
+++ b/src/pages/workspaces/workspace/analysis/_testData/testData.ts
@@ -282,6 +282,7 @@ export const getGoogleRuntime = ({
 
 export const galaxyRunning = {
   appName: 'terra-app-69200c2f-89c3-47db-874c-b770d8de737f',
+  label: toolLabels.Galaxy,
   appType: 'GALAXY',
   auditInfo: {
     creator: 'cahrens@gmail.com', createdDate: '2021-11-29T20:19:13.162484Z', destroyedDate: null, dateAccessed: '2021-11-29T20:19:13.162484Z'

--- a/src/pages/workspaces/workspace/analysis/modals/AnalysisModal.test.ts
+++ b/src/pages/workspaces/workspace/analysis/modals/AnalysisModal.test.ts
@@ -6,8 +6,9 @@ import { h } from 'react-hyperscript-helpers'
 import { Ajax } from 'src/libs/ajax'
 import { GoogleStorage, GoogleStorageContract } from 'src/libs/ajax/GoogleStorage'
 import { reportError } from 'src/libs/error'
+import LoadedState from 'src/libs/type-utils/LoadedState'
 import { defaultAzureWorkspace, defaultGoogleWorkspace, galaxyDisk, galaxyRunning, getGoogleRuntime, imageDocs } from 'src/pages/workspaces/workspace/analysis/_testData/testData'
-import { getFileFromPath } from 'src/pages/workspaces/workspace/analysis/useAnalysisFiles'
+import { AnalysisFile, getFileFromPath } from 'src/pages/workspaces/workspace/analysis/useAnalysisFiles'
 import {
   AbsolutePath
 } from 'src/pages/workspaces/workspace/analysis/utils/file-utils'
@@ -340,11 +341,11 @@ describe('AnalysisModal', () => {
     // Arrange
     const fileList = [getFileFromPath('test/file1.ipynb' as AbsolutePath), getFileFromPath('test/file2.ipynb' as AbsolutePath)]
     const mockFileStore = {
-      loadedState: { state: fileList, status: 'Ready' },
+      loadedState: { state: fileList, status: 'Ready' } as LoadedState<AnalysisFile[]>,
       refreshFileStore: () => Promise.resolve(),
       create: () => Promise.resolve(),
-      pendingCreate: { status: 'Ready', state: true },
-      pendingDelete: { status: 'Ready', state: true },
+      pendingCreate: { status: 'Ready', state: true } as LoadedState<true, unknown>,
+      pendingDelete: { status: 'Ready', state: true } as LoadedState<true, unknown>,
       deleteFile: () => Promise.resolve()
     }
 
@@ -372,11 +373,11 @@ describe('AnalysisModal', () => {
     const fileList = [getFileFromPath('test/file1.ipynb' as AbsolutePath)]
     const createMock = jest.fn().mockRejectedValue(new Error('MyTestError'))
     const mockFileStore = {
-      loadedState: { state: fileList, status: 'Ready' },
+      loadedState: { state: fileList, status: 'Ready' } as LoadedState<AnalysisFile[]>,
       refreshFileStore: () => Promise.resolve(),
       create: createMock,
-      pendingCreate: { status: 'Ready', state: true },
-      pendingDelete: { status: 'Ready', state: true },
+      pendingCreate: { status: 'Ready', state: true } as LoadedState<true, unknown>,
+      pendingDelete: { status: 'Ready', state: true } as LoadedState<true, unknown>,
       deleteFile: () => Promise.resolve()
     }
     const user = userEvent.setup()


### PR DESCRIPTION
Adding types for few frequently used functions in react-utils.

This seems to work. When I do something like:

```ts
type TestProps = {
  foo: string
}

const TestComponent = forwardRefWithName('TestComponent', (props: TestProps, ref) => {
  return div()
})
```

or

```ts
const TestComponent = forwardRefWithName('TestComponent')((props: TestProps, ref) => {
  return null
})
```

The resulting component has the correct props type.

However, the props type does get lost in flows like in Files and Analyses. For now at least, this seems an acceptable limitation.