### PR TITLE
[ID-453] add mixpanel events for cloud information clicks

### DIFF
--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -85,6 +85,8 @@ const eventsList = {
   workflowUseDefaultOutputs: 'workflow:useDefaultOutputs',
   workspaceClone: 'workspace:clone',
   workspaceCreate: 'workspace:create',
+  workspaceOpenedBucketInBrowser: 'workspace:openedBucketInBrowser',
+  workspaceOpenedProjectInConsole: 'workspace:openedProjectInCloudConsole',
   workspaceDataAddColumn: 'workspace:data:addColumn',
   workspaceDataAddRow: 'workspace:data:addRow',
   workspaceDataClearColumn: 'workspace:data:clearColumn',

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -487,7 +487,6 @@ const WorkspaceDashboard = _.flow(
             })
           },
           href: bucketBrowserUrl(bucketName),
-
         }, ['Open bucket in browser', icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })]
         )]),
         div({ style: { paddingBottom: '0.5rem' } }, [h(Link, {

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -23,7 +23,7 @@ import { getRegionFlag, getRegionLabel } from 'src/libs/azure-utils'
 import { getEnabledBrand } from 'src/libs/brand-utils'
 import colors from 'src/libs/colors'
 import { reportError, withErrorReporting } from 'src/libs/error'
-import Events from 'src/libs/events'
+import Events, { extractWorkspaceDetails } from 'src/libs/events'
 import * as Nav from 'src/libs/nav'
 import { getLocalPref, setLocalPref } from 'src/libs/prefs'
 import { forwardRefWithName, useCancellation, useOnMount, useStore } from 'src/libs/react-utils'
@@ -481,7 +481,13 @@ const WorkspaceDashboard = _.flow(
         div({ style: { paddingBottom: '0.5rem' } }, [h(Link, {
           style: { margin: '1rem 0.5rem' },
           ...Utils.newTabLinkProps,
-          href: bucketBrowserUrl(bucketName)
+          onClick: () => {
+            Ajax().Metrics.captureEvent(Events.workspaceOpenedBucketInBrowser, {
+              ...extractWorkspaceDetails(workspace)
+            })
+          },
+          href: bucketBrowserUrl(bucketName),
+
         }, ['Open bucket in browser', icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })]
         )]),
         div({ style: { paddingBottom: '0.5rem' } }, [h(Link, {

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -493,6 +493,11 @@ const WorkspaceDashboard = _.flow(
         div({ style: { paddingBottom: '0.5rem' } }, [h(Link, {
           style: { margin: '1rem 0.5rem' },
           ...Utils.newTabLinkProps,
+          onClick: () => {
+            Ajax().Metrics.captureEvent(Events.workspaceOpenedProjectInConsole, {
+              ...extractWorkspaceDetails(workspace)
+            })
+          },
           href: `https://console.cloud.google.com/welcome?project=${googleProject}`
         }, ['Open project in Google Cloud Console', icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })]
         )])


### PR DESCRIPTION
ticket: https://broadworkbench.atlassian.net/browse/ID-453

added two mixpanel events for clickthroughs tracking "open bucket in browser" and "open project in google cloud console." 

I added these events to the dev lexicon, once this is merged I'll add them to the prod mixpanel lexicon as well. 

events should include workspace details and will come through in mixpanel like this: 

<img width="563" alt="Screen Shot 2023-03-16 at 12 14 45 PM" src="https://user-images.githubusercontent.com/19541449/225687687-cee31d8d-11d0-4824-a0f8-002bc50e8186.png">
<img width="563" alt="Screen Shot 2023-03-16 at 12 14 34 PM" src="https://user-images.githubusercontent.com/19541449/225687688-2bb61374-9a21-4578-8d07-4fe641488649.png">
