### PR TITLE
[WOR-831] SpendReport unit test improvements for stability

### DIFF
--- a/src/pages/billing/SpendReport/SpendReport.test.ts
+++ b/src/pages/billing/SpendReport/SpendReport.test.ts
@@ -150,9 +150,9 @@ describe('SpendReport', () => {
       expect(screen.getByText(/\$89.00 in other infrastructure/i)).toBeInTheDocument()
     })
     expect(getSpendReport).toHaveBeenCalledTimes(1)
-    expect(screen.getByTestId('spend').textContent).toBe('$1,110.00*')
-    expect(screen.getByTestId('compute').textContent).toBe('$999.00')
-    expect(screen.getByTestId('storage').textContent).toBe('$22.00')
+    expect(screen.getByTestId('spend')).toHaveTextContent('$1,110.00*')
+    expect(screen.getByTestId('compute')).toHaveTextContent('$999.00')
+    expect(screen.getByTestId('storage')).toHaveTextContent('$22.00')
 
     // Highcharts content is very minimal when rendered in the unit test. Testing of "most expensive workspaces"
     // is in the integration test. Accessibility is also tested in the integration test.
@@ -180,7 +180,7 @@ describe('SpendReport', () => {
     await waitFor(() => {
       expect(screen.getByText(otherCostMessaging)).toBeInTheDocument()
     })
-    expect(screen.getByTestId('spend').textContent).toBe('$1,110.17*')
+    expect(screen.getByTestId('spend')).toHaveTextContent('$1,110.17*')
     expect(getSpendReport).toHaveBeenCalledTimes(2)
     expect(getSpendReport).toHaveBeenNthCalledWith(1, { billingProjectName: 'thrifty', endDate: '2022-04-01', startDate: '2022-03-02' })
     expect(getSpendReport).toHaveBeenNthCalledWith(2, { billingProjectName: 'thrifty', endDate: '2022-04-01', startDate: '2022-01-01' })
@@ -200,7 +200,7 @@ describe('SpendReport', () => {
 
     // Assert
     await waitFor(() => {
-      expect(screen.getByRole('alert').textContent).toEqual('No spend data for 30 days')
+      expect(screen.getByRole('alert')).toHaveTextContent('No spend data for 30 days')
     })
 
     // Arrange, switch error message to verify that the UI updates with the new message.
@@ -214,7 +214,7 @@ describe('SpendReport', () => {
 
     // Assert
     await waitFor(() => {
-      expect(screen.getByRole('alert').textContent).toEqual('No spend data for 90 days')
+      expect(screen.getByRole('alert')).toHaveTextContent('No spend data for 90 days')
     })
   })
 })

--- a/src/pages/billing/SpendReport/SpendReport.test.ts
+++ b/src/pages/billing/SpendReport/SpendReport.test.ts
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { act } from 'react-dom/test-utils'
 import { h } from 'react-hyperscript-helpers'
 import { Ajax } from 'src/libs/ajax'
@@ -29,16 +29,22 @@ describe('SpendReport', () => {
     // Selecting the option by all the "usual" methods of supplying label text, selecting an option, etc. failed.
     // Perhaps this is because these options have both display text and a value?
     // Unfortunately this awkward approach was the only thing that appeared to work.
-    const getDateRangeSelect = () => screen.getByLabelText('Date range')
+    const getDateRangeSelect = screen.getByLabelText('Date range')
     // 7 days
-    fireEvent.keyDown(getDateRangeSelect(), { key: 'ArrowDown', code: 'ArrowDown' })
+    fireEvent.keyDown(getDateRangeSelect, { key: 'ArrowDown', code: 'ArrowDown' })
     // 30 days
-    fireEvent.keyDown(getDateRangeSelect(), { key: 'ArrowDown', code: 'ArrowDown' })
+    fireEvent.keyDown(getDateRangeSelect, { key: 'ArrowDown', code: 'ArrowDown' })
     // 90 days
-    fireEvent.keyDown(getDateRangeSelect(), { key: 'ArrowDown', code: 'ArrowDown' })
-    await act(async () => { // eslint-disable-line require-await
-      // Trigger the option to be selected
-      fireEvent.keyDown(getDateRangeSelect(), { key: 'Enter', code: 'Enter' })
+    fireEvent.keyDown(getDateRangeSelect, { key: 'ArrowDown', code: 'ArrowDown' })
+    // Choose the current focused option.
+    fireEvent.keyDown(getDateRangeSelect, { key: 'Enter', code: 'Enter' })
+
+    await waitFor(() => {
+      // Check that 90 days was actually selected. There will always be a DOM element present with
+      // text "Last 90 days", but if it is the selected element (which means the option dropdown has closed),
+      // it will have a class name ending in "singleValue". This is ugly, but the Select component we are
+      // using does not set the value on the input element itself.
+      expect(screen.getByText('Last 90 days').className).toContain('singleValue')
     })
   }
 
@@ -145,8 +151,10 @@ describe('SpendReport', () => {
     await select90Days()
 
     // Assert
+    await waitFor(() => {
+      expect(screen.getByText(otherCostMessaging)).toBeInTheDocument()
+    })
     expect(screen.getByTestId('spend').textContent).toBe('$1,110.17*')
-    screen.getByText(otherCostMessaging)
     expect(getSpendReport).toHaveBeenCalledTimes(2)
     expect(getSpendReport).toHaveBeenNthCalledWith(1, { billingProjectName: 'thrifty', endDate: '2022-04-01', startDate: '2022-03-02' })
     expect(getSpendReport).toHaveBeenNthCalledWith(2, { billingProjectName: 'thrifty', endDate: '2022-04-01', startDate: '2022-01-01' })
@@ -166,11 +174,13 @@ describe('SpendReport', () => {
     })
 
     // Assert
+    await waitFor(() => {
+      expect(screen.getByText(/\$89.00 in other infrastructure/i)).toBeInTheDocument()
+    })
     expect(getSpendReport).toHaveBeenCalledTimes(1)
     expect(screen.getByTestId('spend').textContent).toBe('$1,110.00*')
     expect(screen.getByTestId('compute').textContent).toBe('$999.00')
     expect(screen.getByTestId('storage').textContent).toBe('$22.00')
-    screen.getByText(/\$89.00 in other infrastructure/i)
 
     // Highcharts content is very minimal when rendered in the unit test. Testing of "most expensive workspaces"
     // is in the integration test. Accessibility is also tested in the integration test.
@@ -189,7 +199,9 @@ describe('SpendReport', () => {
     })
 
     // Assert
-    expect(screen.getByRole('alert').textContent).toEqual('No spend data for 30 days')
+    await waitFor(() => {
+      expect(screen.getByRole('alert').textContent).toEqual('No spend data for 30 days')
+    })
 
     // Arrange, switch error message to verify that the UI updates with the new message.
     getSpendReport = jest.fn(() => Promise.reject(new Response(JSON.stringify({ message: 'No spend data for 90 days' }), { status: 404 })))
@@ -201,7 +213,9 @@ describe('SpendReport', () => {
     await select90Days()
 
     // Assert
-    expect(screen.getByRole('alert').textContent).toEqual('No spend data for 90 days')
+    await waitFor(() => {
+      expect(screen.getByRole('alert').textContent).toEqual('No spend data for 90 days')
+    })
   })
 })
 


### PR DESCRIPTION
This test flaked on a [build](https://app.circleci.com/pipelines/github/DataBiosphere/terra-ui/15349/workflows/9fe2a974-deca-4465-a9e6-c8f7bd874f1d/jobs/59950)-- I was not able to reproduce the failure.

There are 2 things that I think could lead to instability in the test-- the interactions with the select component, which is complicated due to the way the component is storing the values, and the fact that the Ajax callback occurs in an `useEffect` callback. I have added `waitFor`s to the test in an attempt to improve the stability or at least produce an error that might be clearer (the first test case that failed timed out with no cause).

**Note** that the second commit is simply swapping the order of 2 of the test cases so that all interactions with the select happen _after_ the tests that do not rely on it. I have seen cases where a timeout causes all subsequent tests to fail, so I'm trying to get more information about if failures only happen in the test cases that use the select (should the failures occur again). The first commit is the one with actual changes.


