### PR TITLE
[IA-4126] Autopause UI for Azure runtimes

### DIFF
--- a/src/libs/azure-utils.js
+++ b/src/libs/azure-utils.js
@@ -1,4 +1,5 @@
 import _ from 'lodash/fp'
+import { defaultAutopauseThreshold } from 'src/pages/workspaces/workspace/analysis/utils/runtime-utils'
 
 // AZURE REGIONS, COMPUTE TYPES, STORAGE TYPES AND PRICING
 
@@ -7,6 +8,7 @@ export const defaultAzureDiskSize = 50
 export const defaultAzureRegion = 'eastus'
 
 export const defaultAzureComputeConfig = {
+  autopauseThreshold: defaultAutopauseThreshold,
   machineType: defaultAzureMachineType,
   diskSize: defaultAzureDiskSize,
   region: defaultAzureRegion,

--- a/src/pages/workspaces/workspace/analysis/modals/AnalysisModal.ts
+++ b/src/pages/workspaces/workspace/analysis/modals/AnalysisModal.ts
@@ -177,7 +177,7 @@ export const AnalysisModal = withDisplayName('AnalysisModal')(
       onSuccess
     })
 
-    const renderAzureModal = () => h(AzureComputeModalBase, {
+    const renderAzureModal: any = () => h(AzureComputeModalBase, {
       workspace,
       runtimes,
       location,

--- a/src/pages/workspaces/workspace/analysis/modals/AnalysisModal.ts
+++ b/src/pages/workspaces/workspace/analysis/modals/AnalysisModal.ts
@@ -177,7 +177,7 @@ export const AnalysisModal = withDisplayName('AnalysisModal')(
       onSuccess
     })
 
-    const renderAzureModal: any = () => h(AzureComputeModalBase, {
+    const renderAzureModal = () => h(AzureComputeModalBase, {
       workspace,
       runtimes,
       location,

--- a/src/pages/workspaces/workspace/analysis/modals/AzureComputeModal.js
+++ b/src/pages/workspaces/workspace/analysis/modals/AzureComputeModal.js
@@ -157,16 +157,13 @@ export const AzureComputeModalBase = ({
       ]),
       div({ style: { gridColumnEnd: 'span 6', marginTop: '1.5rem' } }, [
         h(IdContainer, [
-          id => h(Fragment, [
+          id1 => h(Fragment, [
             h(LabeledCheckbox, {
-              id,
+              id1,
               checked: isAutopauseEnabled(computeConfig.autopauseThreshold),
               disabled: !autoPauseCheckboxEnabled,
               onChange: v => updateComputeConfig('autopauseThreshold', getAutopauseThreshold(v))
-            }),
-            label({ htmlFor: id, style: { ...computeStyles.label, marginLeft: '0.25rem' } }, [
-              'Enable autopause'
-            ]),
+            }, ['Enable autopause']),
           ])
         ]),
         h(Link, {
@@ -189,7 +186,7 @@ export const AzureComputeModalBase = ({
                 value: computeConfig.autopauseThreshold,
                 hidden: !isAutopauseEnabled(computeConfig.autopauseThreshold),
                 tooltip: !isAutopauseEnabled(computeConfig.autopauseThreshold) ? 'Autopause must be enabled to configure pause time.' : undefined,
-                onChange: v => updateComputeConfig('autopauseThreshold', v),
+                onChange: v => updateComputeConfig('autopauseThreshold', Number(v)),
                 'aria-label': 'Minutes of inactivity before autopausing'
               }),
               label({

--- a/src/pages/workspaces/workspace/analysis/modals/AzureComputeModal.js
+++ b/src/pages/workspaces/workspace/analysis/modals/AzureComputeModal.js
@@ -178,7 +178,7 @@ export const AzureComputeModalBase = ({
             id => h(Fragment, [
               h(NumberInput, {
                 id,
-                min: 1,
+                min: 10,
                 max: 999,
                 isClearable: false,
                 onlyInteger: true,

--- a/src/pages/workspaces/workspace/analysis/modals/AzureComputeModal.js
+++ b/src/pages/workspaces/workspace/analysis/modals/AzureComputeModal.js
@@ -20,7 +20,7 @@ import * as Utils from 'src/libs/utils'
 import { WarningTitle } from 'src/pages/workspaces/workspace/analysis/modals/WarningTitle'
 import { getAzureComputeCostEstimate, getAzureDiskCostEstimate } from 'src/pages/workspaces/workspace/analysis/utils/cost-utils'
 import {
-  autopauseDisabledValue, getAutopauseThreshold, getCurrentRuntime, getIsRuntimeBusy, isAutopauseEnabled
+  autopauseDisabledValue, defaultAutopauseThreshold, getAutopauseThreshold, getCurrentRuntime, getIsRuntimeBusy, isAutopauseEnabled
 } from 'src/pages/workspaces/workspace/analysis/utils/runtime-utils'
 
 import { computeStyles } from './modalStyles'
@@ -54,7 +54,7 @@ export const AzureComputeModalBase = ({
       diskSize: runtimeDetails?.diskConfig?.size || defaultAzureDiskSize,
       // Azure workspace containers will pass the 'location' param as an Azure armRegionName, which can be used directly as the computeRegion
       region: runtimeDetails?.runtimeConfig?.region || location || defaultAzureRegion,
-      autopauseThreshold: runtimeDetails?.autopauseThreshold || autopauseDisabledValue,
+      autopauseThreshold: runtimeDetails ? (runtimeDetails.autopauseThreshold || autopauseDisabledValue) : defaultAutopauseThreshold,
     })
   }))
 
@@ -156,14 +156,18 @@ export const AzureComputeModalBase = ({
         ])
       ]),
       div({ style: { gridColumnEnd: 'span 6', marginTop: '1.5rem' } }, [
-        h(LabeledCheckbox, {
-          checked: isAutopauseEnabled(computeConfig.autopauseThreshold),
-          disabled: !autoPauseCheckboxEnabled,
-          onChange: v => updateComputeConfig('autopauseThreshold', getAutopauseThreshold(v))
-        }, [
-          span({ style: { marginLeft: '0.5rem', ...computeStyles.label, verticalAlign: 'top' } }, [
-            span([autoPauseCheckboxEnabled || isAutopauseEnabled(computeConfig.autopauseThreshold) ? 'Enable autopause' : 'Autopause disabled'])
-          ]),
+        h(IdContainer, [
+          id => h(Fragment, [
+            h(LabeledCheckbox, {
+              id,
+              checked: isAutopauseEnabled(computeConfig.autopauseThreshold),
+              disabled: !autoPauseCheckboxEnabled,
+              onChange: v => updateComputeConfig('autopauseThreshold', getAutopauseThreshold(v))
+            }),
+            label({ htmlFor: id, style: { ...computeStyles.label, marginLeft: '0.25rem' } }, [
+              'Enable autopause'
+            ]),
+          ])
         ]),
         h(Link, {
           style: { marginLeft: '1rem', verticalAlign: 'top' },
@@ -173,19 +177,27 @@ export const AzureComputeModalBase = ({
           icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })
         ]),
         div({ style: { ...gridStyle, gridGap: '0.7rem', gridTemplateColumns: '4.5rem 9.5rem', marginTop: '0.75rem' } }, [
-          h(NumberInput, {
-            min: 1,
-            max: 999,
-            isClearable: false,
-            onlyInteger: true,
-            disabled: !autoPauseCheckboxEnabled,
-            value: computeConfig.autopauseThreshold,
-            hidden: !isAutopauseEnabled(computeConfig.autopauseThreshold),
-            tooltip: !isAutopauseEnabled(computeConfig.autopauseThreshold) ? 'Autopause must be enabled to configure pause time.' : undefined,
-            onChange: v => updateComputeConfig('autopauseThreshold', v),
-            'aria-label': 'Minutes of inactivity before autopausing'
-          }),
-          span({ hidden: !isAutopauseEnabled(computeConfig.autopauseThreshold) }, ['minutes of inactivity'])
+          h(IdContainer, [
+            id => h(Fragment, [
+              h(NumberInput, {
+                id,
+                min: 1,
+                max: 999,
+                isClearable: false,
+                onlyInteger: true,
+                disabled: !autoPauseCheckboxEnabled,
+                value: computeConfig.autopauseThreshold,
+                hidden: !isAutopauseEnabled(computeConfig.autopauseThreshold),
+                tooltip: !isAutopauseEnabled(computeConfig.autopauseThreshold) ? 'Autopause must be enabled to configure pause time.' : undefined,
+                onChange: v => updateComputeConfig('autopauseThreshold', v),
+                'aria-label': 'Minutes of inactivity before autopausing'
+              }),
+              label({
+                htmlFor: id,
+                hidden: !isAutopauseEnabled(computeConfig.autopauseThreshold)
+              }, ['minutes of inactivity'])
+            ])
+          ])
         ])
       ])
     ])

--- a/src/pages/workspaces/workspace/analysis/modals/AzureComputeModal.test.js
+++ b/src/pages/workspaces/workspace/analysis/modals/AzureComputeModal.test.js
@@ -125,6 +125,7 @@ describe('AzureComputeModal', () => {
 
   it('sends the proper leo API call in create case (custom autopause)', async () => {
     // Arrange
+    const user = userEvent.setup()
     const createFunc = jest.fn()
     const runtimeFunc = jest.fn(() => ({
       create: createFunc,
@@ -144,10 +145,10 @@ describe('AzureComputeModal', () => {
 
       const numberInput = await screen.getByLabelText('minutes of inactivity')
       expect(numberInput).toBeInTheDocument()
-      await fireEvent.change(numberInput, { target: { value: 5 } })
-      expect(numberInput.value).toBe('5')
+      await user.type(numberInput, '0')
+      expect(numberInput.value).toBe('300')
 
-      await userEvent.click(getCreateButton())
+      await user.click(getCreateButton())
     })
 
     // Assert
@@ -163,7 +164,7 @@ describe('AzureComputeModal', () => {
         name: expect.anything()
       }),
       machineSize: defaultAzureMachineType,
-      autopauseThreshold: 5,
+      autopauseThreshold: 300,
     }))
 
     expect(onSuccess).toHaveBeenCalled()
@@ -190,8 +191,12 @@ describe('AzureComputeModal', () => {
 
       const autopauseCheckbox = await screen.getByLabelText('Enable autopause')
       expect(autopauseCheckbox).toBeInTheDocument()
+      await expect(autopauseCheckbox).toBeChecked()
+      await fireEvent.click(autopauseCheckbox) // click to focus?
       await fireEvent.click(autopauseCheckbox)
-      expect(autopauseCheckbox).not.toBeInTheDocument()
+      await expect(autopauseCheckbox).not.toBeChecked()
+      const numberInput = await screen.getByLabelText('minutes of inactivity')
+      await expect(numberInput).not.toBeVisible()
 
       await userEvent.click(getCreateButton())
     })

--- a/src/pages/workspaces/workspace/analysis/modals/ComputeModal.js
+++ b/src/pages/workspaces/workspace/analysis/modals/ComputeModal.js
@@ -1136,7 +1136,6 @@ export const ComputeModalBase = ({
         ])
       ]),
       div({ style: { gridColumnEnd: 'span 6', marginTop: '1.5rem' } }, [
-        // Autopause component
         h(LabeledCheckbox, {
           checked: isAutopauseEnabled(computeConfig.autopauseThreshold),
           disabled: !autoPauseCheckboxEnabled,
@@ -1153,7 +1152,6 @@ export const ComputeModalBase = ({
           'Learn more about autopause.',
           icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })
         ]),
-        // end Autopause component
         div({ style: { ...gridStyle, gridGap: '0.7rem', gridTemplateColumns: '4.5rem 9.5rem', marginTop: '0.75rem' } }, [
           h(NumberInput, {
             min: 1,

--- a/src/pages/workspaces/workspace/analysis/modals/ComputeModal.js
+++ b/src/pages/workspaces/workspace/analysis/modals/ComputeModal.js
@@ -977,7 +977,6 @@ export const ComputeModalBase = ({
     const gpuCheckboxDisabled = computeExists ? !computeConfig.gpuEnabled : isDataproc(runtimeType) || isRStudioImage
     const enableGpusSpan = span(['Enable GPUs ', betaVersionTag])
     const autoPauseCheckboxEnabled = true
-    const enableAutopauseSpan = span(['Enable autopause'])
     const gridStyle = { display: 'grid', gridGap: '1rem', alignItems: 'center', marginTop: '1rem' }
     const gridItemInputStyle = { minWidth: '6rem' }
 
@@ -1137,13 +1136,14 @@ export const ComputeModalBase = ({
         ])
       ]),
       div({ style: { gridColumnEnd: 'span 6', marginTop: '1.5rem' } }, [
+        // Autopause component
         h(LabeledCheckbox, {
           checked: isAutopauseEnabled(computeConfig.autopauseThreshold),
           disabled: !autoPauseCheckboxEnabled,
           onChange: v => updateComputeConfig('autopauseThreshold', getAutopauseThreshold(v))
         }, [
           span({ style: { marginLeft: '0.5rem', ...computeStyles.label, verticalAlign: 'top' } }, [
-            enableAutopauseSpan
+            span(['Enable autopause'])
           ]),
         ]),
         h(Link, {
@@ -1153,6 +1153,7 @@ export const ComputeModalBase = ({
           'Learn more about autopause.',
           icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })
         ]),
+        // end Autopause component
         div({ style: { ...gridStyle, gridGap: '0.7rem', gridTemplateColumns: '4.5rem 9.5rem', marginTop: '0.75rem' } }, [
           h(NumberInput, {
             min: 1,

--- a/src/pages/workspaces/workspace/analysis/utils/runtime-utils.ts
+++ b/src/pages/workspaces/workspace/analysis/utils/runtime-utils.ts
@@ -34,7 +34,7 @@ export const defaultAutopauseThreshold = 30
 export const autopauseDisabledValue = 0
 
 export const isAutopauseEnabled = threshold => threshold > autopauseDisabledValue
-// TODO contained within new component
+
 export const getAutopauseThreshold = isEnabled => isEnabled ? defaultAutopauseThreshold : autopauseDisabledValue
 
 export const usableStatuses: LeoRuntimeStatus[] = ['Updating', 'Running']

--- a/src/pages/workspaces/workspace/analysis/utils/runtime-utils.ts
+++ b/src/pages/workspaces/workspace/analysis/utils/runtime-utils.ts
@@ -34,6 +34,7 @@ export const defaultAutopauseThreshold = 30
 export const autopauseDisabledValue = 0
 
 export const isAutopauseEnabled = threshold => threshold > autopauseDisabledValue
+// TODO contained within new component
 export const getAutopauseThreshold = isEnabled => isEnabled ? defaultAutopauseThreshold : autopauseDisabledValue
 
 export const usableStatuses: LeoRuntimeStatus[] = ['Updating', 'Running']


### PR DESCRIPTION
Setup Azure runtimes with autopause! Can enable/disable autopause on prospective runtimes, submit to create with the selected autopause value, and watch as after X minutes your runtime pauses. Opening an existing runtime shows a disabled autopause section with the existing value, if any, or a grayed checkbox with the input hidden otherwise.

Behavior validated locally & via unit tests.

merge BLOCKED until https://broadworkbench.atlassian.net/browse/IA-4168 merged.