### PR TITLE
Change link to Azure resources (WOR-833).

### DIFF
--- a/integration-tests/tests/billing-projects.js
+++ b/integration-tests/tests/billing-projects.js
@@ -125,7 +125,7 @@ const setAjaxMockValues = async (testPage, ownedBillingProjectName, notOwnedBill
   {
     projectName: azureBillingProjectName,
     managedAppCoordinates: { managedResourceGroupId: `${azureBillingProjectName}_mrg`, subscriptionId: 'subId', tenantId: 'tenantId' },
-    invalidBillingAccount: false, roles: ['Owner'], status: 'Ready', cloudPlatform: 'AZURE'
+    invalidBillingAccount: false, roles: ['Owner'], status: 'Ready', cloudPlatform: 'AZURE', landingZoneId: 'fakeLandingZoneId'
   }])
 
   const ownedProjectMembersListResult = [{
@@ -249,6 +249,8 @@ const testBillingSpendReportFn = withUserToken(async ({ page, testUrl, token }) 
   await billingPage.assertChartValue(3, 'Third Most Expensive Workspace', 'Storage', '$0.00')
   // Verify the spend report configuration option is present
   await billingPage.assertText('View billing account')
+  // Verify link to Azure portal is not present
+  await billingPage.assertTextNotFound('Open resources in Azure Portal')
 
   // Change the returned mock cost to mimic different date ranges.
   await setAjaxMockValues(page, ownedBillingProjectName, notOwnedBillingProjectName, erroredBillingProjectName,
@@ -274,6 +276,8 @@ const testBillingSpendReportFn = withUserToken(async ({ page, testUrl, token }) 
   await billingPage.selectProject(azureBillingProjectName, AZURE)
   await billingPage.assertTextNotFound('Spend report')
   await billingPage.assertTextNotFound('View billing account')
+  // Verify link to Azure portal is present
+  await billingPage.assertText('Open resources in Azure Portal')
 
   // Check accessibility of initial view.
   await verifyAccessibility(page)

--- a/integration-tests/tests/billing-projects.js
+++ b/integration-tests/tests/billing-projects.js
@@ -250,7 +250,7 @@ const testBillingSpendReportFn = withUserToken(async ({ page, testUrl, token }) 
   // Verify the spend report configuration option is present
   await billingPage.assertText('View billing account')
   // Verify link to Azure portal is not present
-  await billingPage.assertTextNotFound('Open resources in Azure Portal')
+  await billingPage.assertTextNotFound('Open project resources in Azure Portal')
 
   // Change the returned mock cost to mimic different date ranges.
   await setAjaxMockValues(page, ownedBillingProjectName, notOwnedBillingProjectName, erroredBillingProjectName,
@@ -277,7 +277,7 @@ const testBillingSpendReportFn = withUserToken(async ({ page, testUrl, token }) 
   await billingPage.assertTextNotFound('Spend report')
   await billingPage.assertTextNotFound('View billing account')
   // Verify link to Azure portal is present
-  await billingPage.assertText('Open resources in Azure Portal')
+  await billingPage.assertText('Open project resources in Azure Portal')
 
   // Check accessibility of initial view.
   await verifyAccessibility(page)

--- a/integration-tests/tests/billing-projects.js
+++ b/integration-tests/tests/billing-projects.js
@@ -250,7 +250,7 @@ const testBillingSpendReportFn = withUserToken(async ({ page, testUrl, token }) 
   // Verify the spend report configuration option is present
   await billingPage.assertText('View billing account')
   // Verify link to Azure portal is not present
-  await billingPage.assertTextNotFound('Open project resources in Azure Portal')
+  await billingPage.assertTextNotFound('View project resources in Azure Portal')
 
   // Change the returned mock cost to mimic different date ranges.
   await setAjaxMockValues(page, ownedBillingProjectName, notOwnedBillingProjectName, erroredBillingProjectName,
@@ -277,7 +277,7 @@ const testBillingSpendReportFn = withUserToken(async ({ page, testUrl, token }) 
   await billingPage.assertTextNotFound('Spend report')
   await billingPage.assertTextNotFound('View billing account')
   // Verify link to Azure portal is present
-  await billingPage.assertText('Open project resources in Azure Portal')
+  await billingPage.assertText('View project resources in Azure Portal')
 
   // Check accessibility of initial view.
   await verifyAccessibility(page)

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -542,8 +542,8 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
       isGcpProject && h(GcpBillingAccountControls, { authorizeAndLoadAccounts, billingAccounts, billingProject, isOwner, getShowBillingModal, setShowBillingModal, reloadBillingProject, setUpdating }),
       isAzureProject && div({ style: accountLinkStyle }, [
         h(ExternalLink, {
-          url: `https://portal.azure.com/#@${billingProject.managedAppCoordinates.tenantId}/resource/subscriptions/${billingProject.managedAppCoordinates.subscriptionId}/resourceGroups/${billingProject.managedAppCoordinates.managedResourceGroupId}/overview`,
-          text: 'Open Resource Group in Azure Portal',
+          url: `https://portal.azure.com/#view/HubsExtension/BrowseResourcesWithTag/tagName/WLZ-ID/tagValue/${billingProject.landingZoneId}`,
+          text: 'Open resources in Azure Portal',
           popoutSize: 14
         })
       ]),

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -543,7 +543,7 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
       isAzureProject && div({ style: accountLinkStyle }, [
         h(ExternalLink, {
           url: `https://portal.azure.com/#view/HubsExtension/BrowseResourcesWithTag/tagName/WLZ-ID/tagValue/${billingProject.landingZoneId}`,
-          text: 'Open project resources in Azure Portal',
+          text: 'View project resources in Azure Portal',
           popoutSize: 14
         }),
         h(InfoBox, { style: { marginLeft: '0.25rem' } }, [

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -1,14 +1,14 @@
 import _ from 'lodash/fp'
 import * as qs from 'qs'
 import { Fragment, useEffect, useMemo, useState } from 'react'
-import { div, h, span } from 'react-hyperscript-helpers'
+import { div, h, p, span } from 'react-hyperscript-helpers'
 import { ButtonPrimary, customSpinnerOverlay, IdContainer, Link, Select } from 'src/components/common'
 import { DeleteUserModal, EditUserModal, MemberCard, MemberCardHeaders, NewUserCard, NewUserModal } from 'src/components/group-common'
 import { icon } from 'src/components/icons'
 import { TextInput } from 'src/components/input'
 import { MenuButton } from 'src/components/MenuButton'
 import Modal from 'src/components/Modal'
-import { MenuTrigger } from 'src/components/PopupTrigger'
+import { InfoBox, MenuTrigger } from 'src/components/PopupTrigger'
 import { SimpleTabBar } from 'src/components/tabBars'
 import { ariaSort, HeaderRenderer } from 'src/components/table'
 import { useWorkspaces } from 'src/components/workspace-utils'
@@ -543,9 +543,16 @@ const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProje
       isAzureProject && div({ style: accountLinkStyle }, [
         h(ExternalLink, {
           url: `https://portal.azure.com/#view/HubsExtension/BrowseResourcesWithTag/tagName/WLZ-ID/tagValue/${billingProject.landingZoneId}`,
-          text: 'Open resources in Azure Portal',
+          text: 'Open project resources in Azure Portal',
           popoutSize: 14
-        })
+        }),
+        h(InfoBox, { style: { marginLeft: '0.25rem' } }, [
+          "Project resources can only be viewed when you are logged into the same tenant as the project's Azure subscription.",
+          p({ style: { marginBlockEnd: 0 } }, [h(ExternalLink, {
+            url: `https://portal.azure.com/#@${billingProject.managedAppCoordinates.tenantId}/resource/subscriptions/${billingProject.managedAppCoordinates.subscriptionId}/overview`,
+            text: 'View subscription in Azure Portal',
+          })])
+        ])
       ]),
       _.size(projectUsers) > 1 && _.size(projectOwners) === 1 && div({
         style: {

--- a/src/pages/billing/models/BillingProject.ts
+++ b/src/pages/billing/models/BillingProject.ts
@@ -19,7 +19,7 @@ export interface BillingProject {
 export interface AzureBillingProject extends BillingProject {
   cloudPlatform: 'AZURE'
   managedAppCoordinates: AzureManagedAppCoordinates
-  landingZoneId?: string
+  landingZoneId: string
 }
 
 export interface GCPBillingProject extends BillingProject {

--- a/src/pages/billing/models/BillingProject.ts
+++ b/src/pages/billing/models/BillingProject.ts
@@ -19,6 +19,7 @@ export interface BillingProject {
 export interface AzureBillingProject extends BillingProject {
   cloudPlatform: 'AZURE'
   managedAppCoordinates: AzureManagedAppCoordinates
+  landingZoneId?: string
 }
 
 export interface GCPBillingProject extends BillingProject {


### PR DESCRIPTION
Depends on https://github.com/broadinstitute/rawls/pull/2280, so will not be merged until after Monolith release.

Changes the Azure Portal link as requested by product.

<img width="1318" alt="image" src="https://user-images.githubusercontent.com/484484/227543070-496881d5-ecb3-43a8-9fa3-9b36093bc69e.png">
