### PR TITLE
[IA-4053] create azure vm with existing disk

### DIFF
--- a/src/libs/ajax/leonardo/Runtimes.test.js
+++ b/src/libs/ajax/leonardo/Runtimes.test.js
@@ -45,4 +45,21 @@ describe('Runtimes ajax', () => {
       expect(mockFetchLeo).toHaveBeenCalledWith(`api/google/v1/runtimes/${runtime.googleProject}/${runtime.runtimeName}/start`, expect.anything())
     }
   })
+
+  // TODO (LM) failing on TypeError: (0 , _ajaxCommon.jsonBody) is not a function
+  it.each([
+    { runtimeName: 'runtime1', workspaceId: 'test1', persistentDiskExists: true },
+    { runtimeName: 'runtime2', workspaceId: 'test2', persistentDiskExists: false }
+  ])('should call use the approprate query param based on the persistent disk status', async runtime => {
+    // Arrange
+    // Act
+    await Runtimes().runtimeV2(runtime.workspaceId, runtime.runtimeName).create({ test: 'test' }, runtime.persistentDiskExists)
+
+    // Assert
+    if (runtime.persistentDiskExists) {
+      expect(mockFetchLeo).toHaveBeenCalledWith(`api/v2/runtimes/${runtime.workspaceId}/${runtime.runtimeName}?useExistingDisk=true`, expect.anything())
+    } else {
+      expect(mockFetchLeo).toHaveBeenCalledWith(`api/v2/runtimes/${runtime.workspaceId}/${runtime.runtimeName}?useExistingDisk=false`, expect.anything())
+    }
+  })
 })

--- a/src/libs/ajax/leonardo/Runtimes.test.js
+++ b/src/libs/ajax/leonardo/Runtimes.test.js
@@ -47,7 +47,6 @@ describe('Runtimes ajax', () => {
     }
   })
 
-  // TODO (LM) failing on TypeError: (0 , _ajaxCommon.jsonBody) is not a function
   it.each([
     { runtimeName: 'runtime1', workspaceId: 'test1', persistentDiskExists: true },
     { runtimeName: 'runtime2', workspaceId: 'test2', persistentDiskExists: false }

--- a/src/libs/ajax/leonardo/Runtimes.test.js
+++ b/src/libs/ajax/leonardo/Runtimes.test.js
@@ -4,7 +4,8 @@ import { Runtimes } from 'src/libs/ajax/leonardo/Runtimes'
 
 jest.mock('src/libs/ajax/ajax-common', () => ({
   fetchLeo: jest.fn(),
-  authOpts: jest.fn()
+  authOpts: jest.fn(),
+  jsonBody: jest.fn()
 }))
 
 describe('Runtimes ajax', () => {
@@ -53,13 +54,13 @@ describe('Runtimes ajax', () => {
   ])('should call use the approprate query param based on the persistent disk status', async runtime => {
     // Arrange
     // Act
-    await Runtimes().runtimeV2(runtime.workspaceId, runtime.runtimeName).create({ test: 'test' }, runtime.persistentDiskExists)
+    await Runtimes().runtimeV2(runtime.workspaceId, runtime.runtimeName).create({}, runtime.persistentDiskExists)
 
     // Assert
     if (runtime.persistentDiskExists) {
-      expect(mockFetchLeo).toHaveBeenCalledWith(`api/v2/runtimes/${runtime.workspaceId}/${runtime.runtimeName}?useExistingDisk=true`, expect.anything())
+      expect(mockFetchLeo).toHaveBeenCalledWith(`api/v2/runtimes/${runtime.workspaceId}/azure/${runtime.runtimeName}?useExistingDisk=true`, expect.anything())
     } else {
-      expect(mockFetchLeo).toHaveBeenCalledWith(`api/v2/runtimes/${runtime.workspaceId}/${runtime.runtimeName}?useExistingDisk=false`, expect.anything())
+      expect(mockFetchLeo).toHaveBeenCalledWith(`api/v2/runtimes/${runtime.workspaceId}/azure/${runtime.runtimeName}?useExistingDisk=false`, expect.anything())
     }
   })
 })

--- a/src/libs/ajax/leonardo/Runtimes.ts
+++ b/src/libs/ajax/leonardo/Runtimes.ts
@@ -67,11 +67,12 @@ export const Runtimes = signal => {
         return res.json()
       },
 
-      create: (options): Promise<void> => {
+      create: (options, useExistingDisk): Promise<void> => {
         const body = _.merge(options, {
           labels: { saturnAutoCreated: 'true', saturnVersion: version }
         })
-        return fetchLeo(root, _.mergeAll([authOpts(), jsonBody(body), { signal, method: 'POST' }, appIdentifier]))
+        return fetchLeo(`${root}${qs.stringify({ useExistingDisk }, { addQueryPrefix: true })}`,
+          _.mergeAll([authOpts(), jsonBody(body), { signal, method: 'POST' }, appIdentifier]))
       },
 
       delete: (deleteDisk: boolean = true): Promise<void> => {

--- a/src/libs/ajax/leonardo/Runtimes.ts
+++ b/src/libs/ajax/leonardo/Runtimes.ts
@@ -67,7 +67,7 @@ export const Runtimes = signal => {
         return res.json()
       },
 
-      create: (options, useExistingDisk): Promise<void> => {
+      create: (options, useExistingDisk: boolean = false): Promise<void> => {
         const body = _.merge(options, {
           labels: { saturnAutoCreated: 'true', saturnVersion: version }
         })

--- a/src/pages/workspaces/workspace/analysis/modals/AzureComputeModal.js
+++ b/src/pages/workspaces/workspace/analysis/modals/AzureComputeModal.js
@@ -16,6 +16,7 @@ import { withErrorReportingInModal } from 'src/libs/error'
 import Events, { extractWorkspaceDetails } from 'src/libs/events'
 import { useOnMount } from 'src/libs/react-utils'
 import * as Utils from 'src/libs/utils'
+import { cloudProviderTypes } from 'src/libs/workspace-utils'
 import { DeleteEnvironment } from 'src/pages/workspaces/workspace/analysis/modals/DeleteEnvironment'
 import { getAzureComputeCostEstimate, getAzureDiskCostEstimate } from 'src/pages/workspaces/workspace/analysis/utils/cost-utils'
 import { getIsRuntimeBusy } from 'src/pages/workspaces/workspace/analysis/utils/runtime-utils'
@@ -172,6 +173,7 @@ export const AzureComputeModalBase = ({
 
     return h(ButtonPrimary, {
       ...commonButtonProps,
+      tooltip: persistentDiskExists ? 'Mount existing Persistent disk to a new Virtual Machine.' : undefined,
       onClick: () => applyChanges()
     }, [Utils.cond(
       [viewMode === 'deleteEnvironment', () => 'Delete'],
@@ -228,7 +230,8 @@ export const AzureComputeModalBase = ({
             saturnWorkspaceName: workspaceName
           },
           disk
-        })
+        }, persistentDiskExists,
+        )
       }]
     )
 
@@ -244,7 +247,7 @@ export const AzureComputeModalBase = ({
       div({ style: { padding: '1.5rem', overflowY: 'auto', flex: 'auto' } }, [
         renderApplicationConfigurationSection(),
         renderComputeProfileSection(),
-        h(PersistentDiskSection, { persistentDiskExists, computeConfig, updateComputeConfig, setViewMode, tool }),
+        h(PersistentDiskSection, { persistentDiskExists, computeConfig, updateComputeConfig, setViewMode, cloudPlatform: cloudProviderTypes.AZURE }),
         renderBottomButtons()
       ])
     ])

--- a/src/pages/workspaces/workspace/analysis/modals/AzureComputeModal.test.js
+++ b/src/pages/workspaces/workspace/analysis/modals/AzureComputeModal.test.js
@@ -31,7 +31,7 @@ const defaultModalProps = {
   location: testAzureDefaultRegion
 }
 
-const pesistentDiskModalProps = {
+const persistentDiskModalProps = {
   onSuccess, onDismiss: jest.fn(), onError: jest.fn(),
   currentRuntime: undefined, currentDisk: defaultTestDisk, tool: runtimeToolLabels.JupyterLab, workspace: defaultAzureWorkspace,
   location: testAzureDefaultRegion
@@ -142,7 +142,7 @@ describe('AzureComputeModal', () => {
     // Act
     // wrapping component init-time stateful side-effects with act()
     await act(async () => {
-      await render(h(AzureComputeModalBase, pesistentDiskModalProps))
+      await render(h(AzureComputeModalBase, persistentDiskModalProps))
       await userEvent.click(getCreateButton())
     })
 

--- a/src/pages/workspaces/workspace/analysis/modals/persistent-disk-controls.test.ts
+++ b/src/pages/workspaces/workspace/analysis/modals/persistent-disk-controls.test.ts
@@ -58,6 +58,15 @@ const defaultPersistentDiskProps: PersistentDiskControlProps = {
   handleLearnMoreAboutPersistentDisk: jest.fn()
 }
 
+const defaultAzurePersistentDiskProps: PersistentDiskControlProps = {
+  persistentDiskExists: true,
+  computeConfig: defaultIComputeConfig,
+  updateComputeConfig: () => updateComputeConfig,
+  setViewMode: jest.fn(),
+  cloudPlatform: 'AZURE',
+  handleLearnMoreAboutPersistentDisk: jest.fn()
+}
+
 const defaultPersistentDiskTypeProps: PersistentDiskTypeProps = {
   persistentDiskExists: true,
   computeConfig: defaultIComputeConfig,
@@ -131,7 +140,7 @@ describe('compute-modal-component', () => {
       expect(tipText).toBeNull()
     })
 
-    it('should show tooltip when existing PD', async () => {
+    it('should show disk type tooltip when existing PD for GCP', async () => {
       // Arrange
       render(h(PersistentDiskSection, defaultPersistentDiskProps))
 
@@ -141,6 +150,15 @@ describe('compute-modal-component', () => {
 
       // Assert
       screen.getByText(/You already have a persistent disk in this workspace. /)
+    })
+
+    it('should show disk size tooltip when existing PD for Azure', () => {
+      // Arrange
+      render(h(PersistentDiskSection, defaultAzurePersistentDiskProps))
+
+      // Act
+      // Assert
+      screen.queryByText(/You already have a persistent disk in this workspace. /)
     })
 
     // Ensuring updateComputeConfig gets called with proper value on change

--- a/src/pages/workspaces/workspace/analysis/modals/persistent-disk-controls.test.ts
+++ b/src/pages/workspaces/workspace/analysis/modals/persistent-disk-controls.test.ts
@@ -61,7 +61,7 @@ const defaultPersistentDiskProps: PersistentDiskControlProps = {
 const defaultAzurePersistentDiskProps: PersistentDiskControlProps = {
   persistentDiskExists: true,
   computeConfig: defaultIComputeConfig,
-  updateComputeConfig: () => updateComputeConfig,
+  updateComputeConfig: () => updateComputeConfigMock,
   setViewMode: jest.fn(),
   cloudPlatform: 'AZURE',
   handleLearnMoreAboutPersistentDisk: jest.fn()

--- a/src/pages/workspaces/workspace/analysis/modals/persistent-disk-controls.ts
+++ b/src/pages/workspaces/workspace/analysis/modals/persistent-disk-controls.ts
@@ -97,6 +97,11 @@ export const PersistentDiskType = (props: PersistentDiskTypeProps) => {
           isDisabled: persistentDiskExists,
           onChange: e => updateComputeConfig('persistentDiskType', e?.value),
           menuPlacement: 'auto',
+          // tooltip: persistentDiskExists ? [
+          //   'You already have a persistent disk in this workspace. ',
+          //   'Disk size can only be configured at creation time. ',
+          //   'Please delete the existing disk before selecting a new size.'
+          // ] : undefined,
           options: [
             { label: pdTypes.standard.displayName, value: pdTypes.standard },
             { label: pdTypes.balanced.displayName, value: pdTypes.balanced },
@@ -133,7 +138,13 @@ export const PersistentDiskSection = (props: PersistentDiskControlProps) => {
               max: 64000,
               isClearable: false,
               onlyInteger: true,
+              tooltip: persistentDiskExists && cloudPlatform === cloudProviderTypes.AZURE ? [
+                'You already have a persistent disk in this workspace. ',
+                'Disk size can only be configured at creation time. ',
+                'Please delete the existing disk before selecting a new size.'
+              ] : undefined,
               value: computeConfig.persistentDiskSize,
+              disabled: persistentDiskExists && cloudPlatform === cloudProviderTypes.AZURE,
               onChange: value => {
                 updateComputeConfig('persistentDiskSize', value)
               },

--- a/src/pages/workspaces/workspace/analysis/modals/persistent-disk-controls.ts
+++ b/src/pages/workspaces/workspace/analysis/modals/persistent-disk-controls.ts
@@ -97,11 +97,6 @@ export const PersistentDiskType = (props: PersistentDiskTypeProps) => {
           isDisabled: persistentDiskExists,
           onChange: e => updateComputeConfig('persistentDiskType', e?.value),
           menuPlacement: 'auto',
-          // tooltip: persistentDiskExists ? [
-          //   'You already have a persistent disk in this workspace. ',
-          //   'Disk size can only be configured at creation time. ',
-          //   'Please delete the existing disk before selecting a new size.'
-          // ] : undefined,
           options: [
             { label: pdTypes.standard.displayName, value: pdTypes.standard },
             { label: pdTypes.balanced.displayName, value: pdTypes.balanced },


### PR DESCRIPTION
When a persistent disk is present in a workspace, the user must either delete the disk or create a new VM with the existing disk

This PR adds:
 - tooltips:
    - explaining the user can't alter the size of their PD without deleting the current one
    - explaining that a PD is present and will be mounted to the new VM
 - alters the call to Leo to add the `useExistingDisk` flag
