### PR TITLE
[SU-295] Quote URL is gsutil cp commands

### DIFF
--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -63,7 +63,7 @@ export const getDownloadCommand = (fileName, gsUri, accessUrl) => {
   }
 
   if (gsUri) {
-    return `gsutil cp ${gsUri} ${fileName || '.'}`
+    return `gsutil cp '${gsUri}' ${fileName || '.'}`
   }
 }
 

--- a/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.test.ts
+++ b/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.test.ts
@@ -172,7 +172,7 @@ describe('GCSFileBrowserProvider', () => {
     const downloadCommand = await provider.getDownloadCommandForFile('path/to/example.txt')
 
     // Assert
-    expect(downloadCommand).toBe('gsutil cp gs://test-bucket/path/to/example.txt .')
+    expect(downloadCommand).toBe('gsutil cp \'gs://test-bucket/path/to/example.txt\' .')
   })
 
   it('uploads a file', async () => {

--- a/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.ts
+++ b/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.ts
@@ -115,7 +115,7 @@ const GCSFileBrowserProvider = ({ bucket, project, pageSize = 1000 }: GCSFileBro
       return url
     },
     getDownloadCommandForFile: path => {
-      return Promise.resolve(`gsutil cp gs://${bucket}/${path} .`)
+      return Promise.resolve(`gsutil cp 'gs://${bucket}/${path}' .`)
     },
     uploadFileToDirectory: (directoryPath, file) => {
       return Ajax().Buckets.upload(project, bucket, directoryPath, file)


### PR DESCRIPTION
Viewing a GCS URL in a data table or a file in the file browser in a GCP workspace shows a `gsutil cp` command to download the file.

This quotes the file URL in those commands to support files with spaces or other characters that the shell would otherwise interpret.

## Before (data table)
<img width="457" alt="Screenshot 2023-03-30 at 1 00 06 PM" src="https://user-images.githubusercontent.com/1156625/228912168-b57d172f-1f23-4e71-8b88-8031133dbbf6.png">

## After
<img width="463" alt="Screenshot 2023-03-30 at 1 06 34 PM" src="https://user-images.githubusercontent.com/1156625/228912190-c65f7cd8-0e8a-4036-919e-6389070c14c3.png">
