### PR TITLE
Restrict workspace cloning on Azure to analysis directory (WOR-544).

### DIFF
--- a/src/components/NewWorkspaceModal.js
+++ b/src/components/NewWorkspaceModal.js
@@ -101,7 +101,7 @@ const NewWorkspaceModal = withDisplayName('NewWorkspaceModal', ({
         name,
         authorizationDomain: _.map(v => ({ membersGroupName: v }), [...getRequiredGroups(), ...groups]),
         attributes: { description },
-        copyFilesWithPrefix: 'notebooks/',
+        copyFilesWithPrefix: isGoogleBillingProject() ? 'notebooks/' : 'analyses/',
         ...(!!bucketLocation && isGoogleBillingProject() && { bucketLocation })
       }
       const createdWorkspace = await Utils.cond(


### PR DESCRIPTION
To test (with https://github.com/broadinstitute/rawls/pull/2314):

1. Create an Azure workspace
2. Upload a file to the storage container (can use file explorer within the workspace, from right context bar)
3. Create a Jupyter notebook
4. Clone the workspace
5. Check that the cloned workspace includes the notebook file (under `analyses/`), but not the uploaded file.

![image](https://user-images.githubusercontent.com/484484/230922802-03071592-6d49-4fc6-a793-4ca4703a12eb.png)

