### PR TITLE
[IA-4033] Added tool and application to cloudEnvironment metrics.

### DIFF
--- a/src/pages/workspaces/workspace/analysis/AnalysisLauncher.js
+++ b/src/pages/workspaces/workspace/analysis/AnalysisLauncher.js
@@ -350,7 +350,7 @@ const PreviewHeader = ({
           onClick: () => {
             if (runtimeStatus === 'Running') {
               Nav.goToPath(appLauncherTabName, { namespace, name, application: 'RStudio', cloudPlatform })
-              Metrics.captureEvent(Events.analysisLaunch,
+              Metrics().captureEvent(Events.analysisLaunch,
                 { origin: 'analysisLauncher', tool: runtimeToolLabels.RStudio, workspaceName: name, namespace, cloudPlatform })
             }
           }
@@ -521,7 +521,7 @@ const AnalysisPreviewFrame = ({ analysisName, toolLabel, workspace, onRequesterP
 // See this ticket for RStudio impl discussion: https://broadworkbench.atlassian.net/browse/IA-2947
 const JupyterFrameManager = ({ onClose, frameRef, details = {} }) => {
   useOnMount(() => {
-    Metrics
+    Metrics()
       .captureEvent(Events.cloudEnvironmentLaunch,
         { tool: runtimeToolLabels.Jupyter, application: runtimeToolLabels.Jupyter, workspaceName: details.name, namespace: details.namespace, cloudPlatform: details.cloudPlatform })
 

--- a/src/pages/workspaces/workspace/analysis/AnalysisLauncher.js
+++ b/src/pages/workspaces/workspace/analysis/AnalysisLauncher.js
@@ -350,7 +350,7 @@ const PreviewHeader = ({
           onClick: () => {
             if (runtimeStatus === 'Running') {
               Nav.goToPath(appLauncherTabName, { namespace, name, application: 'RStudio', cloudPlatform })
-              Ajax().Metrics.captureEvent(Events.analysisLaunch,
+              Metrics.captureEvent(Events.analysisLaunch,
                 { origin: 'analysisLauncher', tool: runtimeToolLabels.RStudio, workspaceName: name, namespace, cloudPlatform })
             }
           }
@@ -521,8 +521,7 @@ const AnalysisPreviewFrame = ({ analysisName, toolLabel, workspace, onRequesterP
 // See this ticket for RStudio impl discussion: https://broadworkbench.atlassian.net/browse/IA-2947
 const JupyterFrameManager = ({ onClose, frameRef, details = {} }) => {
   useOnMount(() => {
-    Ajax()
-      .Metrics
+    Metrics
       .captureEvent(Events.cloudEnvironmentLaunch,
         { tool: runtimeToolLabels.Jupyter, application: runtimeToolLabels.Jupyter, workspaceName: details.name, namespace: details.namespace, cloudPlatform: details.cloudPlatform })
 

--- a/src/pages/workspaces/workspace/analysis/AnalysisLauncher.js
+++ b/src/pages/workspaces/workspace/analysis/AnalysisLauncher.js
@@ -524,7 +524,7 @@ const JupyterFrameManager = ({ onClose, frameRef, details = {} }) => {
     Ajax()
       .Metrics
       .captureEvent(Events.cloudEnvironmentLaunch,
-        { tool: runtimeToolLabels.Jupyter, workspaceName: details.name, namespace: details.namespace, cloudPlatform: details.cloudPlatform })
+        { tool: runtimeToolLabels.Jupyter, application: runtimeToolLabels.Jupyter, workspaceName: details.name, namespace: details.namespace, cloudPlatform: details.cloudPlatform })
 
 
     const isSaved = Utils.atom(true)

--- a/src/pages/workspaces/workspace/analysis/AppLauncher.js
+++ b/src/pages/workspaces/workspace/analysis/AppLauncher.js
@@ -5,6 +5,7 @@ import * as breadcrumbs from 'src/components/breadcrumbs'
 import { ButtonPrimary, ButtonSecondary, spinnerOverlay } from 'src/components/common'
 import Modal from 'src/components/Modal'
 import { Ajax } from 'src/libs/ajax'
+import { Metrics } from 'src/libs/ajax/Metrics'
 import { withErrorReporting, withErrorReportingInModal } from 'src/libs/error'
 import Events from 'src/libs/events'
 import * as Nav from 'src/libs/nav'
@@ -235,7 +236,7 @@ const ApplicationLauncher = _.flow(
 
   useEffect(() => {
     _.includes(runtimeStatus, usableStatuses) && cookieReady &&
-    Ajax().Metrics.captureEvent(Events.cloudEnvironmentLaunch, { application, tool: application, workspaceName: workspace.name, namespace: workspace.namespace, cloudPlatform: workspace.cloudPlatform })
+    Metrics.captureEvent(Events.cloudEnvironmentLaunch, { application, tool: application, workspaceName: workspace.name, namespace: workspace.namespace, cloudPlatform: workspace.cloudPlatform })
   }, [application, cookieReady, runtimeStatus, workspace])
 
   if (!busy && runtime === undefined) Nav.goToPath(analysisTabName, { namespace, name })

--- a/src/pages/workspaces/workspace/analysis/AppLauncher.js
+++ b/src/pages/workspaces/workspace/analysis/AppLauncher.js
@@ -235,7 +235,7 @@ const ApplicationLauncher = _.flow(
 
   useEffect(() => {
     _.includes(runtimeStatus, usableStatuses) && cookieReady &&
-    Ajax().Metrics.captureEvent(Events.cloudEnvironmentLaunch, { application, ...workspace })
+    Ajax().Metrics.captureEvent(Events.cloudEnvironmentLaunch, { application, tool: application, workspaceName: workspace.name, namespace: workspace.namespace, cloudPlatform: workspace.cloudPlatform })
   }, [application, cookieReady, runtimeStatus, workspace])
 
   if (!busy && runtime === undefined) Nav.goToPath(analysisTabName, { namespace, name })

--- a/src/pages/workspaces/workspace/analysis/AppLauncher.js
+++ b/src/pages/workspaces/workspace/analysis/AppLauncher.js
@@ -236,7 +236,7 @@ const ApplicationLauncher = _.flow(
 
   useEffect(() => {
     _.includes(runtimeStatus, usableStatuses) && cookieReady &&
-    Metrics.captureEvent(Events.cloudEnvironmentLaunch, { application, tool: application, workspaceName: workspace.name, namespace: workspace.namespace, cloudPlatform: workspace.cloudPlatform })
+    Metrics().captureEvent(Events.cloudEnvironmentLaunch, { application, tool: application, workspaceName: workspace.name, namespace: workspace.namespace, cloudPlatform: workspace.cloudPlatform })
   }, [application, cookieReady, runtimeStatus, workspace])
 
   if (!busy && runtime === undefined) Nav.goToPath(analysisTabName, { namespace, name })

--- a/src/pages/workspaces/workspace/analysis/modals/AzureComputeModal.js
+++ b/src/pages/workspaces/workspace/analysis/modals/AzureComputeModal.js
@@ -23,6 +23,7 @@ import { getAzureComputeCostEstimate, getAzureDiskCostEstimate } from 'src/pages
 import {
   autopauseDisabledValue, defaultAutopauseThreshold, getAutopauseThreshold, getIsRuntimeBusy, isAutopauseEnabled
 } from 'src/pages/workspaces/workspace/analysis/utils/runtime-utils'
+import { runtimeToolLabels } from 'src/pages/workspaces/workspace/analysis/utils/tool-utils'
 
 import { computeStyles } from './modalStyles'
 import { AboutPersistentDisk, PersistentDiskSection } from './persistent-disk-controls'
@@ -254,7 +255,9 @@ export const AzureComputeModalBase = ({
       desiredRuntime_machineType: computeConfig.machineType,
       desiredPersistentDisk_size: computeConfig.diskSize,
       desiredPersistentDisk_type: 'Standard', // IA-4164 - Azure disks are currently only Standard (HDD), when we add types update this.
-      desiredPersistentDisk_costPerMonth: getAzureDiskCostEstimate(computeConfig)
+      desiredPersistentDisk_costPerMonth: getAzureDiskCostEstimate(computeConfig),
+      tool: runtimeToolLabels.JupyterLab,
+      application: runtimeToolLabels.JupyterLab
     })
   }
 

--- a/src/pages/workspaces/workspace/analysis/modals/ComputeModal.js
+++ b/src/pages/workspaces/workspace/analysis/modals/ComputeModal.js
@@ -583,7 +583,9 @@ export const ComputeModalBase = ({
       existingPersistentDisk_diskType: existingPersistentDisk ? existingPersistentDisk.diskType.displayName : undefined,
       isDefaultConfig: !currentRuntimeDetails,
       selectedLeoImage,
-      isCustomImage
+      isCustomImage,
+      tool,
+      application: tool
     })
   }
 


### PR DESCRIPTION
Current cloud Environment metrics were missing tool / application fields.
This PR will add them in to the appropriate locations.

The reason RStudio and app metrics weren't being captured was due to workspace having a "name" field and that's not allowed in mixpanel.

<!---
Hello, friend!
Remember to mention what sort of testing/verification you performed in the course of building this PR, i.e. checking functionality in the browser locally.
Also, so if a screen recording [1] and/or screenshots would be a helpful way to communicate context, please consider including some in your PR description.
Thanks!

[1] https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac
-->
