### PR TITLE
Aj-965 Add identifier for when a file is not present in current workspace

### DIFF
--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -152,7 +152,7 @@ export const renderDataCell = (attributeValue, workspace) => {
     } else if (isAzureWorkspace(workspace)) {
       if (isAzureUri(datum)) {
         const workspaceId = parseAzureUri(datum)
-        return (!!workspaceId && workspaceId !== workspace.workspace.workspaceId)
+        return workspace.workspace.workspaceId !== workspaceId
       }
     }
     return false

--- a/src/components/data/data-utils.test.js
+++ b/src/components/data/data-utils.test.js
@@ -99,8 +99,7 @@ describe('entityAttributeText', () => {
 
 describe('renderDataCell', () => {
   const testGoogleWorkspace = { workspace: { bucketName: 'test-bucket', cloudPlatform: 'Gcp' } }
-  const testAzureWorkspace = { workspace: { bucketName: 'test-bucket', cloudPlatform: 'Azure' } }
-  testAzureWorkspace.workspace.workspaceId = '77397ce7-bb9b-4339-bc12-95e1f52956de'
+  const testAzureWorkspace = { workspace: { bucketName: 'test-bucket', cloudPlatform: 'Azure', workspaceId: '77397ce7-bb9b-4339-bc12-95e1f52956de' } }
   describe('basic data types', () => {
     it.each([
       { testWorkspace: testGoogleWorkspace },

--- a/src/components/data/data-utils.test.js
+++ b/src/components/data/data-utils.test.js
@@ -100,7 +100,7 @@ describe('entityAttributeText', () => {
 describe('renderDataCell', () => {
   const testGoogleWorkspace = { workspace: { bucketName: 'test-bucket', cloudPlatform: 'Gcp' } }
   const testAzureWorkspace = { workspace: { bucketName: 'test-bucket', cloudPlatform: 'Azure' } }
-
+  testAzureWorkspace.workspace.workspaceId = '77397ce7-bb9b-4339-bc12-95e1f52956de'
   describe('basic data types', () => {
     it.each([
       { testWorkspace: testGoogleWorkspace },
@@ -218,6 +218,16 @@ describe('renderDataCell', () => {
 
     it('does not render a warning for GCS URLs in the workspace bucket', () => {
       const { queryByText } = render(renderDataCell('gs://test-bucket/file.txt', testGoogleWorkspace))
+      expect(queryByText('Some files are located outside of the current workspace')).toBeNull()
+    })
+
+    it('renders a warning for Azure URLs outside the workspace storage', () => {
+      const { getByText } = render(renderDataCell('https://lz8a3d793f17ede9b79635cc.blob.core.windows.net/testContainer/test_file.tsv', testAzureWorkspace))
+      expect(getByText('Some files are located outside of the current workspace')).toBeTruthy()
+    })
+
+    it('does not render a warning for Azure URLs in the workspace storage', () => {
+      const { queryByText } = render(renderDataCell('https://lz8a3d793f17ede9b79635cc.blob.core.windows.net/sc-77397ce7-bb9b-4339-bc12-95e1f52956de/test_file.tsv', testAzureWorkspace))
       expect(queryByText('Some files are located outside of the current workspace')).toBeNull()
     })
 


### PR DESCRIPTION
Here is the UI for when a file (called "yay") is in a different workspace
![image](https://user-images.githubusercontent.com/9418602/231307399-ff1eb3e7-eae8-48ee-b253-38107c8b61c8.png)

links to google containers dont register as links, so for now wont have the identifier (host in this context is outside current workspace)
![image](https://user-images.githubusercontent.com/9418602/231307464-c4411d15-33f5-47d7-83bf-b13771c9b146.png)

when hovering over the icon: 
![image](https://user-images.githubusercontent.com/9418602/231307621-ddc10fe1-8608-46f1-befd-e5b2ff2b5e16.png)
