### PR TITLE
[WOR-905] Do not call useWorkspaces multiple times on billing project page

### DIFF
--- a/src/pages/billing/List/BillingProjectActions.test.ts
+++ b/src/pages/billing/List/BillingProjectActions.test.ts
@@ -1,7 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { h } from 'react-hyperscript-helpers'
-import { useWorkspaces } from 'src/components/workspace-utils'
 import { Ajax } from 'src/libs/ajax'
 import { reportError } from 'src/libs/error'
 import { history } from 'src/libs/nav'
@@ -39,16 +38,15 @@ describe('BillingProjectActions', () => {
   const verifyEnabled = item => expect(item).not.toHaveAttribute('disabled')
   const deleteProjectMock = jest.fn(() => Promise.resolve())
   const projectName = 'testProject'
+  const propsWithNoWorkspacesInProject = {
+    projectName, loadProjects: jest.fn(), workspacesLoading: false,
+    allWorkspaces: [{
+      workspace: { namespace: 'aDifferentProject', name: 'testWorkspaces', workspaceId: '6771d2c8-cd58-47da-a54c-6cdafacc4175' },
+      accessLevel: 'WRITER'
+    }] as WorkspaceWrapper[],
+  }
 
   beforeEach(() => {
-    asMockedFn(useWorkspaces).mockReturnValue({
-      workspaces: [
-        { workspace: { namespace: 'aDifferentProject', name: 'testWorkspaces', workspaceId: '6771d2c8-cd58-47da-a54c-6cdafacc4175' }, accessLevel: 'WRITER' },
-      ] as WorkspaceWrapper[],
-      refresh: () => Promise.resolve(),
-      loading: false,
-    })
-
     asMockedFn(Ajax).mockImplementation(() => ({
       Billing: { deleteProject: deleteProjectMock } as Partial<AjaxContract['Billing']>
     } as Partial<AjaxContract> as AjaxContract))
@@ -58,15 +56,12 @@ describe('BillingProjectActions', () => {
 
   it('renders Delete as disabled while workspaces are loading', () => {
     // Arrange
-    asMockedFn(useWorkspaces).mockReturnValue({
-      workspaces: [] as WorkspaceWrapper[],
-      refresh: () => Promise.resolve(),
-      loading: true,
-    })
-    const projectName = 'testProject'
+    const props = {
+      projectName, loadProjects: jest.fn(), workspacesLoading: true, allWorkspaces: [] as WorkspaceWrapper[]
+    }
 
     // Act
-    render(h(BillingProjectActions, { projectName, loadProjects: jest.fn() }))
+    render(h(BillingProjectActions, props))
 
     // Assert
     const deleteButton = screen.getByLabelText('Cannot delete billing project while workspaces are loading')
@@ -75,16 +70,16 @@ describe('BillingProjectActions', () => {
 
   it('renders Delete as disabled if project has workspaces', () => {
     // Arrange
-    asMockedFn(useWorkspaces).mockReturnValue({
-      workspaces: [
-        { workspace: { namespace: projectName, name: 'testWorkspaces', workspaceId: '6771d2c8-cd58-47da-a54c-6cdafacc4175' }, accessLevel: 'WRITER' },
-      ] as WorkspaceWrapper[],
-      refresh: () => Promise.resolve(),
-      loading: false,
-    })
+    const props = {
+      projectName, loadProjects: jest.fn(), workspacesLoading: false,
+      allWorkspaces: [{
+        workspace: { namespace: projectName, name: 'testWorkspaces', workspaceId: '6771d2c8-cd58-47da-a54c-6cdafacc4175' },
+        accessLevel: 'WRITER'
+      }] as WorkspaceWrapper[]
+    }
 
     // Act
-    render(h(BillingProjectActions, { projectName, loadProjects: jest.fn() }))
+    render(h(BillingProjectActions, props))
 
     // Assert
     const deleteButton = screen.getByLabelText('Cannot delete billing project because it contains workspaces')
@@ -95,7 +90,7 @@ describe('BillingProjectActions', () => {
     // Arrange -- common setup implements mock with no workspaces for project
 
     // Act
-    render(h(BillingProjectActions, { projectName, loadProjects: jest.fn() }))
+    render(h(BillingProjectActions, propsWithNoWorkspacesInProject))
 
     // Assert
     const deleteButton = screen.getByLabelText(`Delete billing project ${projectName}`)
@@ -105,9 +100,10 @@ describe('BillingProjectActions', () => {
   it('calls the server to delete a billing project', async () => {
     // Arrange
     const loadProjects = jest.fn()
+    propsWithNoWorkspacesInProject.loadProjects = loadProjects
 
     // Act
-    render(h(BillingProjectActions, { projectName, loadProjects }))
+    render(h(BillingProjectActions, propsWithNoWorkspacesInProject))
     const deleteButton = screen.getByLabelText(`Delete billing project ${projectName}`)
     await userEvent.click(deleteButton)
     const confirmDeleteButton = screen.getByTestId('confirm-delete')
@@ -122,9 +118,10 @@ describe('BillingProjectActions', () => {
   it('does not call the server to delete a billing project if the user cancels', async () => {
     // Arrange
     const loadProjects = jest.fn()
+    propsWithNoWorkspacesInProject.loadProjects = loadProjects
 
     // Act
-    render(h(BillingProjectActions, { projectName, loadProjects }))
+    render(h(BillingProjectActions, propsWithNoWorkspacesInProject))
     const deleteButton = screen.getByLabelText(`Delete billing project ${projectName}`)
     await userEvent.click(deleteButton)
     const cancelButton = screen.getByText('Cancel')
@@ -142,9 +139,10 @@ describe('BillingProjectActions', () => {
       Billing: { deleteProject: jest.fn().mockRejectedValue({ status: 500 }) } as Partial<AjaxContract['Billing']>
     } as Partial<AjaxContract> as AjaxContract))
     const loadProjects = jest.fn()
+    propsWithNoWorkspacesInProject.loadProjects = loadProjects
 
     // Act
-    render(h(BillingProjectActions, { projectName, loadProjects }))
+    render(h(BillingProjectActions, propsWithNoWorkspacesInProject))
     const deleteButton = screen.getByLabelText(`Delete billing project ${projectName}`)
     await userEvent.click(deleteButton)
     const confirmDeleteButton = screen.getByTestId('confirm-delete')

--- a/src/pages/billing/List/BillingProjectActions.test.ts
+++ b/src/pages/billing/List/BillingProjectActions.test.ts
@@ -57,7 +57,7 @@ describe('BillingProjectActions', () => {
   it('renders Delete as disabled while workspaces are loading', () => {
     // Arrange
     const props = {
-      projectName, loadProjects: jest.fn(), workspacesLoading: true, allWorkspaces: [] as WorkspaceWrapper[]
+      projectName, loadProjects: jest.fn(), workspacesLoading: true, allWorkspaces: undefined
     }
 
     // Act

--- a/src/pages/billing/List/BillingProjectActions.ts
+++ b/src/pages/billing/List/BillingProjectActions.ts
@@ -3,33 +3,34 @@ import { useState } from 'react'
 import { div, h } from 'react-hyperscript-helpers'
 import { Link } from 'src/components/common'
 import { icon } from 'src/components/icons'
-import { useWorkspaces } from 'src/components/workspace-utils'
 import { Ajax } from 'src/libs/ajax'
 import { reportError } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
 import * as Utils from 'src/libs/utils'
+import { WorkspaceWrapper } from 'src/libs/workspace-utils'
 import DeleteBillingProjectModal from 'src/pages/billing/DeleteBillingProjectModal'
 
 
-interface BillingProjectActionsProps {
+export interface BillingProjectActionsProps {
   projectName: string
   loadProjects: () => void
+  workspacesLoading: boolean
+  allWorkspaces: WorkspaceWrapper[] | undefined
 }
 
 export const BillingProjectActions = (props: BillingProjectActionsProps) => {
   const [showDeleteProjectModal, setShowDeleteProjectModal] = useState(false)
   const [deleting, setDeleting] = useState(false)
-  const { workspaces, loading } = useWorkspaces()
 
   const hasWorkspaces = _.find(
     { namespace: props.projectName },
-    _.map('workspace', workspaces)
+    _.map('workspace', props.allWorkspaces)
   ) !== undefined
 
   return div({ style: { marginLeft: 'auto' } }, [h(Link, {
-    disabled: loading || hasWorkspaces,
+    disabled: props.workspacesLoading || hasWorkspaces,
     tooltip: Utils.cond(
-      [loading, () => 'Cannot delete billing project while workspaces are loading'],
+      [props.workspacesLoading, () => 'Cannot delete billing project while workspaces are loading'],
       [hasWorkspaces, () => 'Cannot delete billing project because it contains workspaces'],
       () => `Delete billing project ${props.projectName}`
     ),

--- a/src/pages/billing/List/List.ts
+++ b/src/pages/billing/List/List.ts
@@ -6,6 +6,7 @@ import Collapse from 'src/components/Collapse'
 import { customSpinnerOverlay } from 'src/components/common'
 import FooterWrapper from 'src/components/FooterWrapper'
 import TopBar from 'src/components/TopBar'
+import { useWorkspaces } from 'src/components/workspace-utils'
 import { Ajax } from 'src/libs/ajax'
 import * as Auth from 'src/libs/auth'
 import colors from 'src/libs/colors'
@@ -51,6 +52,7 @@ export const List = (props: ListProps) => {
   const [isAuthorizing, setIsAuthorizing] = useState<boolean>(false)
   const [isLoadingAccounts, setIsLoadingAccounts] = useState<boolean>(false)
   const { isAzurePreviewUser } = useStore(authStore)
+  const { workspaces: allWorkspaces, loading: workspacesLoading } = useWorkspaces()
 
   const signal = useCancellation()
   const interval = useRef<number>()
@@ -146,7 +148,8 @@ export const List = (props: ListProps) => {
 
   const makeProjectListItemProps = (project: BillingProject) : ProjectListItemProps => {
     return {
-      project, loadProjects, isActive: !!selectedName && project.projectName === selectedName
+      project, isActive: !!selectedName && project.projectName === selectedName,
+      billingProjectActionsProps: { allWorkspaces, workspacesLoading, loadProjects, projectName: project.projectName }
     }
   }
 

--- a/src/pages/billing/List/List.ts
+++ b/src/pages/billing/List/List.ts
@@ -52,7 +52,7 @@ export const List = (props: ListProps) => {
   const [isAuthorizing, setIsAuthorizing] = useState<boolean>(false)
   const [isLoadingAccounts, setIsLoadingAccounts] = useState<boolean>(false)
   const { isAzurePreviewUser } = useStore(authStore)
-  const { workspaces: allWorkspaces, loading: workspacesLoading } = useWorkspaces()
+  const { workspaces: allWorkspaces, loading: workspacesLoading, refresh: refreshWorkspaces } = useWorkspaces()
 
   const signal = useCancellation()
   const interval = useRef<number>()
@@ -254,7 +254,9 @@ export const List = (props: ListProps) => {
             billingAccounts,
             authorizeAndLoadAccounts,
             reloadBillingProject: () => reloadBillingProject(billingProject).catch(loadProjects),
-            isOwner: _.find({ projectName: selectedName }, projectsOwned)
+            isOwner: _.find({ projectName: selectedName }, projectsOwned),
+            workspaces: allWorkspaces,
+            refreshWorkspaces
           })
         }],
         [!_.isEmpty(projectsOwned) && !selectedName, () => {

--- a/src/pages/billing/List/ProjectListItem.test.ts
+++ b/src/pages/billing/List/ProjectListItem.test.ts
@@ -7,21 +7,6 @@ import { ProjectListItem, ProjectListItemProps } from 'src/pages/billing/List/Pr
 import { BillingProject } from 'src/pages/billing/models/BillingProject'
 
 
-type WorkspaceUtilsExports = typeof import('src/components/workspace-utils')
-jest.mock('src/components/workspace-utils', (): WorkspaceUtilsExports => {
-  return {
-    ...jest.requireActual('src/components/workspace-utils'),
-    useWorkspaces: jest.fn().mockReturnValue({
-      workspaces: [{
-        workspace: { namespace: 'aDifferentProject', name: 'testWorkspaces', workspaceId: '6771d2c8-cd58-47da-a54c-6cdafacc4175' },
-        accessLevel: 'WRITER'
-      }] as WorkspaceWrapper[],
-      refresh: () => Promise.resolve(),
-      loading: false,
-    })
-  }
-})
-
 // Mocking for using Nav.getLink
 jest.mock('src/libs/nav', () => ({
   ...jest.requireActual('src/libs/nav'),
@@ -48,8 +33,16 @@ describe('ProjectListItem', () => {
     }
     projectListItemProps = {
       project: billingProject,
-      loadProjects: jest.fn(),
-      isActive: true
+      isActive: true,
+      billingProjectActionsProps: {
+        projectName: billingProject.projectName,
+        loadProjects: jest.fn(),
+        allWorkspaces: [{
+          workspace: { namespace: 'aDifferentProject', name: 'testWorkspaces', workspaceId: '6771d2c8-cd58-47da-a54c-6cdafacc4175' },
+          accessLevel: 'WRITER'
+        }] as WorkspaceWrapper[],
+        workspacesLoading: false
+      }
     }
   })
 

--- a/src/pages/billing/List/ProjectListItem.ts
+++ b/src/pages/billing/List/ProjectListItem.ts
@@ -13,7 +13,7 @@ import * as Nav from 'src/libs/nav'
 import * as Style from 'src/libs/style'
 import { isKnownCloudProvider } from 'src/libs/workspace-utils'
 import { billingRoles } from 'src/pages/billing/billing-utils'
-import { BillingProjectActions } from 'src/pages/billing/List/BillingProjectActions'
+import { BillingProjectActions, BillingProjectActionsProps } from 'src/pages/billing/List/BillingProjectActions'
 import { BillingProject, isCreating, isDeleting, isErrored } from 'src/pages/billing/models/BillingProject'
 
 
@@ -36,8 +36,8 @@ const listItemStyle = (selected, hovered) => {
 
 export interface ProjectListItemProps {
   project: BillingProject
-  loadProjects: () => void
   isActive: boolean
+  billingProjectActionsProps: BillingProjectActionsProps
 }
 
 export const ProjectListItem = (props: ProjectListItemProps) => {
@@ -54,7 +54,7 @@ export const ProjectListItem = (props: ProjectListItemProps) => {
 
   const projectNameElement = span({ style: { wordBreak: 'break-all' } }, [projectName])
 
-  const actionElement = isOwner && h(BillingProjectActions, { projectName: props.project.projectName, loadProjects: props.loadProjects })
+  const actionElement = isOwner && h(BillingProjectActions, props.billingProjectActionsProps)
 
   const renderSelectableProject = () => div({
     style: { ...listItemStyle(props.isActive, hovered) },

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -11,7 +11,6 @@ import Modal from 'src/components/Modal'
 import { InfoBox, MenuTrigger } from 'src/components/PopupTrigger'
 import { SimpleTabBar } from 'src/components/tabBars'
 import { ariaSort, HeaderRenderer } from 'src/components/table'
-import { useWorkspaces } from 'src/components/workspace-utils'
 import { Ajax } from 'src/libs/ajax'
 import * as Auth from 'src/libs/auth'
 import colors from 'src/libs/colors'
@@ -390,11 +389,10 @@ const GcpBillingAccountControls = ({
   ])
 }
 
-const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProject, isOwner, reloadBillingProject }) => {
+const ProjectDetail = ({ authorizeAndLoadAccounts, billingAccounts, billingProject, isOwner, reloadBillingProject, workspaces, refreshWorkspaces }) => {
   // State
   const { query } = Nav.useRoute()
   // Rather than using a localized StateHistory store here, we use the existing `workspaceStore` value (via the `useWorkspaces` hook)
-  const { workspaces, refresh: refreshWorkspaces } = useWorkspaces()
 
   const [projectUsers, setProjectUsers] = useState(() => StateHistory.get().projectUsers || [])
   const projectOwners = _.filter(_.flow(_.get('roles'), _.includes(billingRoles.owner)), projectUsers)


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-905

`useWorkspaces` obtains its initial value from a cache, but it will always fetch the most recent workspaces list from the server in `onMount` (and then replace the cached value). This means that we were making a workspaces list server call for every billing project, and that's an expensive/slow call to make for users with lots of workspaces.

Refactored the code to just call `useWorkspaces` once, for all action menus plus the currently selected billing project details (for the lists of workspaces in the billing project).

Before:

![image](https://user-images.githubusercontent.com/484484/231604467-974c8010-2804-4e58-81e5-1ce731e55cce.png)

After: 
![image](https://user-images.githubusercontent.com/484484/231604519-5795a229-ea08-480e-85b6-138d875a1fda.png)
