### PR TITLE
[WOR-759] Fix accessibility issue with children being in navigation bar

### DIFF
--- a/integration-tests/tests/workspace-dashboard.js
+++ b/integration-tests/tests/workspace-dashboard.js
@@ -78,7 +78,7 @@ const testGoogleWorkspace = _.flow(
   await dashboard.assertTabs(['data', 'analyses', 'workflows', 'job history'], true)
 
   // Check accessibility.
-  await verifyAccessibility(page, 1) // Need to fix: "Certain ARIA roles must contain particular children", WOR-759
+  await verifyAccessibility(page)
 
   // Verify that there is no Azure warning
   await assertTextNotFound(azureWarning)
@@ -217,7 +217,7 @@ const testAzureWorkspace = withUserToken(async ({ page, token, testUrl }) => {
   await dashboard.assertTabs(['analyses', 'data'], true)
 
   // Check accessibility.
-  await verifyAccessibility(page, 1) // Need to fix: "Certain ARIA roles must contain particular children", WOR-759
+  await verifyAccessibility(page)
 
   // Verify Azure warning is visible
   await dashboard.assertAzureWarning()

--- a/src/components/tabBars.js
+++ b/src/components/tabBars.js
@@ -71,7 +71,7 @@ export const TabBar = ({
         href
       }, [
         div({
-          style: { flex: '1 1 100%', marginBottom: selected ? -(Style.tabBar.active.borderBottomWidth) : undefined }
+          style: { flex: '1 1 100%', height: 'inherit', marginBottom: selected ? -(Style.tabBar.active.borderBottomWidth) : undefined }
         }, displayNames[currentTab] || currentTab)
       ])
     ])
@@ -80,18 +80,18 @@ export const TabBar = ({
   return div({
     role: 'navigation',
     'aria-label': props['aria-label'], // duplicate the menu's label on the navigation element
-    'aria-labelledby': props['aria-labelledby']
+    'aria-labelledby': props['aria-labelledby'],
+    style: Style.tabBar.container
   }, [
     h(HorizontalNavigation, {
       role: 'menu',
       'aria-orientation': 'horizontal',
-      style: Style.tabBar.container,
+      style: { display: 'flex', flexGrow: 1, height: 'inherit' },
       ...props
     }, [
-      ..._.map(([i, name]) => navTab(i, name), Utils.toIndexPairs(tabNames)),
-      div({ style: { flexGrow: 1 } }),
-      children
-    ])
+      ..._.map(([i, name]) => navTab(i, name), Utils.toIndexPairs(tabNames))
+    ]),
+    div({ style: { display: 'flex', flexGrow: 0, alignItems: 'center' } }, children)
   ])
 }
 TabBar.propTypes = {

--- a/src/components/tabBars.js
+++ b/src/components/tabBars.js
@@ -71,7 +71,7 @@ export const TabBar = ({
         href
       }, [
         div({
-          style: { flex: '1 1 100%', height: 'inherit', marginBottom: selected ? -(Style.tabBar.active.borderBottomWidth) : undefined }
+          style: { flex: '1 1 100%', marginBottom: selected ? -(Style.tabBar.active.borderBottomWidth) : undefined }
         }, displayNames[currentTab] || currentTab)
       ])
     ])
@@ -86,7 +86,7 @@ export const TabBar = ({
     h(HorizontalNavigation, {
       role: 'menu',
       'aria-orientation': 'horizontal',
-      style: { display: 'flex', flexGrow: 1, height: 'inherit' },
+      style: { display: 'flex', flexGrow: 1, height: '100%' },
       ...props
     }, [
       ..._.map(([i, name]) => navTab(i, name), Utils.toIndexPairs(tabNames))

--- a/src/components/tabBars.js
+++ b/src/components/tabBars.js
@@ -37,7 +37,7 @@ const styles = {
  *
  * @param activeTab The key of the active tab
  * @param tabNames An array of keys for each tab
- * @param displayNames An optional array of display names for each tab (otherwise the keys will be displayed)
+ * @param displayNames An optional mapping of display names for each tab (otherwise the keys will be displayed)
  * @param refresh If provided, a function to refresh the current tab
  * @param getHref A function to get the href for a given tab
  * @param getOnClick An optional click handler function, given the current tab
@@ -97,7 +97,7 @@ export const TabBar = ({
 TabBar.propTypes = {
   activeTab: PropTypes.string,
   tabNames: PropTypes.arrayOf(PropTypes.string).isRequired,
-  displayNames: PropTypes.arrayOf(PropTypes.string),
+  displayNames: PropTypes.object,
   refresh: PropTypes.func,
   getHref: PropTypes.func,
   getOnClick: PropTypes.func,

--- a/src/components/tabBars.js
+++ b/src/components/tabBars.js
@@ -78,18 +78,22 @@ export const TabBar = ({
   }
 
   return div({
-    role: 'navigation',
-    'aria-label': props['aria-label'], // duplicate the menu's label on the navigation element
-    'aria-labelledby': props['aria-labelledby'],
     style: Style.tabBar.container
   }, [
-    h(HorizontalNavigation, {
-      role: 'menu',
-      'aria-orientation': 'horizontal',
+    div({
+      role: 'navigation',
+      'aria-label': props['aria-label'], // duplicate the menu's label on the navigation element
+      'aria-labelledby': props['aria-labelledby'],
       style: { display: 'flex', flexGrow: 1, height: '100%' },
-      ...props
     }, [
-      ..._.map(([i, name]) => navTab(i, name), Utils.toIndexPairs(tabNames))
+      h(HorizontalNavigation, {
+        role: 'menu',
+        'aria-orientation': 'horizontal',
+        style: { display: 'flex' },
+        ...props
+      }, [
+        ..._.map(([i, name]) => navTab(i, name), Utils.toIndexPairs(tabNames))
+      ])
     ]),
     div({ style: { display: 'flex', flexGrow: 0, alignItems: 'center' } }, children)
   ])

--- a/src/components/tabBars.js
+++ b/src/components/tabBars.js
@@ -43,7 +43,7 @@ const styles = {
  * @param getOnClick An optional click handler function, given the current tab
  * @param aria-label The ARIA label for the menu, which is required for accessibility
  * @param tabProps Optionally, properties to add to each tab
- * @param children Children, which will be appended to teh end of the tab bar
+ * @param children Children, which will be appended to the end of the tab bar
  * @param props Any additional properties to add to the container menu element
  */
 export const TabBar = ({

--- a/src/pages/workflows/workflow/WorkflowDetails.js
+++ b/src/pages/workflows/workflow/WorkflowDetails.js
@@ -5,7 +5,7 @@ import { Fragment, useState } from 'react'
 import { div, h, h2, label } from 'react-hyperscript-helpers'
 import { AutoSizer } from 'react-virtualized'
 import * as breadcrumbs from 'src/components/breadcrumbs'
-import { ButtonSecondary, IdContainer, Link, Select } from 'src/components/common'
+import { ButtonSecondary, Link, Select } from 'src/components/common'
 import FooterWrapper from 'src/components/FooterWrapper'
 import { centeredSpinner, icon } from 'src/components/icons'
 import { MarkdownViewer, newWindowLinkRenderer } from 'src/components/markdown'
@@ -19,7 +19,7 @@ import colors from 'src/libs/colors'
 import { getConfig } from 'src/libs/config'
 import { withErrorReporting } from 'src/libs/error'
 import * as Nav from 'src/libs/nav'
-import { useCancellation, useOnMount, useStore } from 'src/libs/react-utils'
+import { useCancellation, useOnMount, useStore, useUniqueId } from 'src/libs/react-utils'
 import { snapshotsListStore, snapshotStore } from 'src/libs/state'
 import * as Style from 'src/libs/style'
 import * as Utils from 'src/libs/utils'
@@ -73,6 +73,7 @@ const SnapshotWrapper = ({ namespace, name, snapshotId, tabName, children }) => 
   const cachedSnapshotsList = useStore(snapshotsListStore)
   const cachedSnapshot = useStore(snapshotStore)
   const selectedSnapshot = (snapshotId * 1) || _.last(cachedSnapshotsList).snapshotId
+  const snapshotLabelId = useUniqueId()
 
   const snapshot = cachedSnapshot &&
   _.isEqual({ namespace, name, snapshotId: selectedSnapshot }, _.pick(['namespace', 'name', 'snapshotId'], cachedSnapshot)) ?
@@ -101,18 +102,16 @@ const SnapshotWrapper = ({ namespace, name, snapshotId, tabName, children }) => 
       displayNames: { configs: 'configurations' },
       getHref: currentTab => Nav.getLink(`workflow-${currentTab}`, { namespace, name, snapshotId: selectedSnapshot })
     }, [
-      h(IdContainer, [id => h(Fragment, [
-        label({ htmlFor: id, style: { marginRight: '1rem' } }, ['Snapshot:']),
-        div({ style: { width: 100 } }, [
-          h(Select, {
-            id,
-            value: selectedSnapshot,
-            isSearchable: false,
-            options: _.map('snapshotId', cachedSnapshotsList),
-            onChange: ({ value }) => Nav.goToPath(`workflow-${tabName}`, { namespace, name, snapshotId: value })
-          })
-        ])
-      ])])
+      label({ htmlFor: snapshotLabelId, style: { marginRight: '1rem' } }, ['Snapshot:']),
+      div({ style: { width: 100 } }, [
+        h(Select, {
+          id: snapshotLabelId,
+          value: selectedSnapshot,
+          isSearchable: false,
+          options: _.map('snapshotId', cachedSnapshotsList),
+          onChange: ({ value }) => Nav.goToPath(`workflow-${tabName}`, { namespace, name, snapshotId: value })
+        })
+      ])
     ]),
     snapshot ?
       children :


### PR DESCRIPTION
The workspace action menu and "pill" indicating workspace state are currently rendered within the navigation "menu". This is causing accessibility failures (see image below) because they are not "menu" items. This PR moves them outside of the navigation/menu component.

![image](https://user-images.githubusercontent.com/484484/232123965-bac7dd59-5239-493a-8bc7-708528e5c2fb.png)

Here are after images of all the parts of the UI that use this common component:

1) WorkspaceContainer:
![image](https://user-images.githubusercontent.com/484484/232129520-cb2c73d6-1ca6-4a4f-a4b7-329a1ce20318.png)

2) Various Library items:
![image](https://user-images.githubusercontent.com/484484/232129797-aeea0a57-2379-450b-88f2-fc6bb3c81509.png)

3) Workflows list:
![image](https://user-images.githubusercontent.com/484484/232130627-abb3ba61-f024-4ff9-b0bc-59d2bc96140f.png)

4) Workflow details (note snapshot selector):
![image](https://user-images.githubusercontent.com/484484/232135688-da81ad2f-b6d5-4aa6-aff1-71ac48b3fa93.png)


