### PR TITLE
[PROD-814] Added undefined safety for currentPersistentDiskDetails.

### DIFF
--- a/src/pages/workspaces/workspace/analysis/modals/ComputeModal.js
+++ b/src/pages/workspaces/workspace/analysis/modals/ComputeModal.js
@@ -1531,8 +1531,8 @@ export const ComputeModalBase = ({
       ['deleteEnvironment', () => DeleteEnvironment({
         id: titleId,
         runtimeConfig: currentRuntime && currentRuntime.runtimeConfig,
-        persistentDiskId: currentPersistentDiskDetails.id,
-        persistentDiskCostDisplay: Utils.formatUSD(getPersistentDiskCostMonthly(currentPersistentDiskDetails, computeConfig.computeRegion)),
+        persistentDiskId: currentPersistentDiskDetails?.id,
+        persistentDiskCostDisplay: currentPersistentDiskDetails ? Utils.formatUSD(getPersistentDiskCostMonthly(currentPersistentDiskDetails, computeConfig.computeRegion)) : 'N/A',
         deleteDiskSelected,
         setDeleteDiskSelected,
         setViewMode,


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/PROD-814

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- There's an issue deleting a dataproc cluster due to the persistent disk being undefined.

### Why
- Ensures UI doesn't breka

### Testing strategy
- [ ] Create a dataproc cluster
- [ ] Click Delete Runtime after the dataproc cluster is created

<!-- ### Visual Aids -->
![image](https://user-images.githubusercontent.com/11773357/233191135-a3a9896b-624c-4f31-8f85-7d1dc1cdb3be.png)

<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 
