### PR TITLE
[IA-4267] Can create new Azure VM while disk is deleting

### DIFF
--- a/src/pages/workspaces/workspace/analysis/modals/CloudEnvironmentModal.js
+++ b/src/pages/workspaces/workspace/analysis/modals/CloudEnvironmentModal.js
@@ -30,7 +30,7 @@ import {
   getIsAppBusy
 } from 'src/pages/workspaces/workspace/analysis/utils/app-utils'
 import { getCostDisplayForDisk, getCostDisplayForTool } from 'src/pages/workspaces/workspace/analysis/utils/cost-utils'
-import { getCurrentPersistentDisk, isCurrentGalaxyDiskDetaching } from 'src/pages/workspaces/workspace/analysis/utils/disk-utils'
+import { getCurrentPersistentDisk, getReadyPersistentDisk, isCurrentGalaxyDiskDetaching } from 'src/pages/workspaces/workspace/analysis/utils/disk-utils'
 import {
   getComputeStatusForDisplay, getConvertedRuntimeStatus,
   getCurrentRuntime, getIsRuntimeBusy, getRuntimeForTool
@@ -82,7 +82,7 @@ export const CloudEnvironmentModal = ({
     hideCloseButton: true,
     workspace,
     currentRuntime,
-    currentDisk: persistentDisks ? persistentDisks[0] : undefined,
+    currentDisk: getReadyPersistentDisk(persistentDisks),
     location,
     tool,
     onDismiss,

--- a/src/pages/workspaces/workspace/analysis/utils/disk-utils.test.ts
+++ b/src/pages/workspaces/workspace/analysis/utils/disk-utils.test.ts
@@ -4,7 +4,7 @@ import {
   generateTestDisk,
   getRuntime, getRuntimeConfig
 } from 'src/pages/workspaces/workspace/analysis/_testData/testData'
-import { getCurrentPersistentDisk } from 'src/pages/workspaces/workspace/analysis/utils/disk-utils'
+import { getCurrentPersistentDisk, getReadyPersistentDisk } from 'src/pages/workspaces/workspace/analysis/utils/disk-utils'
 
 
 describe('getCurrentPersistentDisk', () => {
@@ -93,5 +93,34 @@ describe('getCurrentPersistentDisk', () => {
 
     // Assert
     expect(getCurrentPersistentDisk([runtime1, runtime2], [disk1, disk2, disk3])).toStrictEqual(undefined)
+  })
+})
+
+
+describe('getReadyPersistentDisk', () => {
+  it('returns a disk if 1 exists and is ready', () => {
+    // Arrange
+    const disk1 = generateTestDisk()
+
+    // Assert
+    expect(getReadyPersistentDisk([disk1])).toStrictEqual(disk1)
+  })
+  it('returns undefined if no disks/runtimes exist', () => {
+    // Assert
+    expect(getReadyPersistentDisk([])).toBeUndefined()
+  })
+  it('returns undefined if only deleting disks exists', () => {
+    // Arrange
+    const disk1 = generateTestDisk({ status: diskStatuses.deleting.leoLabel })
+
+    // Assert
+    expect(getReadyPersistentDisk([disk1])).toBeUndefined()
+  })
+  it('returns undefined if only errored disks exists', () => {
+    // Arrange
+    const disk1 = generateTestDisk({ status: diskStatuses.error.leoLabel })
+
+    // Assert
+    expect(getReadyPersistentDisk([disk1])).toBeUndefined()
   })
 })

--- a/src/pages/workspaces/workspace/analysis/utils/disk-utils.ts
+++ b/src/pages/workspaces/workspace/analysis/utils/disk-utils.ts
@@ -93,9 +93,8 @@ export const getCurrentPersistentDisk = (runtimes: Runtime[], persistentDisks: P
 }
 
 export const getReadyPersistentDisk = (persistentDisks: PersistentDisk[]): PersistentDisk | undefined => {
-  // returns persistent disk if one exists and is in ready status
-  const disk = persistentDisks ? persistentDisks[0] : undefined
-  return disk ? (disk.status === diskStatuses.ready.leoLabel ? disk : undefined) : undefined
+  // returns PD if one exists and is in ready status
+  return persistentDisks.find(disk => disk.status === diskStatuses.ready.leoLabel)
 }
 
 export const isCurrentGalaxyDiskDetaching = (apps: App[]): boolean => {

--- a/src/pages/workspaces/workspace/analysis/utils/disk-utils.ts
+++ b/src/pages/workspaces/workspace/analysis/utils/disk-utils.ts
@@ -3,6 +3,7 @@ import _ from 'lodash/fp'
 import { App } from 'src/libs/ajax/leonardo/models/app-models'
 import {
   DecoratedPersistentDisk,
+  diskStatuses,
   GoogleDiskType,
   PdType,
   pdTypes,
@@ -89,6 +90,12 @@ export const getCurrentPersistentDisk = (runtimes: Runtime[], persistentDisks: P
   return id ?
     _.find({ id }, persistentDisks) :
     _.last(_.sortBy('auditInfo.createdDate', _.filter(({ id, status }) => status !== 'Deleting' && !_.includes(id, attachedIds), persistentDisks)))
+}
+
+export const getReadyPersistentDisk = (persistentDisks: PersistentDisk[]): PersistentDisk | undefined => {
+  // returns persistent disk if one exists and is in ready status
+  const disk = persistentDisks ? persistentDisks[0] : undefined
+  return disk ? (disk.status === diskStatuses.ready.leoLabel ? disk : undefined) : undefined
 }
 
 export const isCurrentGalaxyDiskDetaching = (apps: App[]): boolean => {


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/[IA-4267]

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
When creating a new azure Vm after deleting the disk and VM, the previous disk being in 'deleting' status was causing conflicts. 

### What
This filters out disks in non 'Ready' status from being set as the current PD.

### Why
This allows users to create a new Azure VM immediately after deleting the previous one when they delete the PD.

### Testing strategy
- [ ] Create and delete a VM and PD, then create another immediately and check that the useExistingDisk flag is true and it succeeds
- [ ] Create and delete a VM (without deleting the PD), then create another immediately and check that the useExistingDisk flag is false and it succeeds

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 


[IA-4267]: https://broadworkbench.atlassian.net/browse/IA-4267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ