### PR TITLE
[UIE-80] Add SonarCloud coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Terra UI
 Web user interface for the Terra platform.
 
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=DataBiosphere_terra-ui&metric=coverage)](https://sonarcloud.io/component_measures?metric=coverage&id=DataBiosphere_terra-ui&selected=DataBiosphere_terra-ui%3Asrc)
+
 ------------------------
 ### Links:
 - [Terra Support](https://support.terra.bio/hc/en-us)


### PR DESCRIPTION
To make test coverage more visible, this adds a SonarCloud coverage badge to the readme.

[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=DataBiosphere_terra-ui&metric=coverage)](https://sonarcloud.io/component_measures?metric=coverage&id=DataBiosphere_terra-ui&selected=DataBiosphere_terra-ui%3Asrc)

It links to coverage broken down by directory: https://sonarcloud.io/component_measures?metric=coverage&selected=DataBiosphere_terra-ui%3Asrc&id=DataBiosphere_terra-ui