### PR TITLE
Include workspace name in delete messages (WOR-967).

### DIFF
--- a/src/pages/workspaces/workspace/DeleteWorkspaceModal.js
+++ b/src/pages/workspaces/workspace/DeleteWorkspaceModal.js
@@ -68,6 +68,7 @@ const DeleteWorkspaceModal = ({ workspace, workspace: { workspace: { name, bucke
           workspaceResources.deleteableApps.length, false)}.`])
   }
 
+  const getWorkspaceName = () => { return span({ style: { fontWeight: 600, wordBreak: 'break-word' } }, name) }
 
   const renderAzureCleanupModal = () => {
     return h(Modal, {
@@ -87,7 +88,9 @@ const DeleteWorkspaceModal = ({ workspace, workspace: { workspace: { name, bucke
     },
     [
       isDeleteDisabledFromResources && !deletingResources && div([
-        p(['This workspace has resources that are not deletable.']),
+        p([span('Workspace '),
+          getWorkspaceName(),
+          span(' has resources that are not deletable.')]),
         p(['If the resource is provisioning or deleting, try again in a few minutes. Please reach out to support@terra.bio for assistance.']),
         ul([
           workspaceResources.nonDeleteableApps.map(app => li({ key: app.appName }, [app.appName, ` (${app.status.toLowerCase()})`])),
@@ -96,7 +99,9 @@ const DeleteWorkspaceModal = ({ workspace, workspace: { workspace: { name, bucke
         ])
       ]),
       (!isDeleteDisabledFromResources || deletingResources) && div([
-        p(['This workspace cannot be deleted because of the following running cloud resources:']),
+        p([span('Workspace '),
+          getWorkspaceName(),
+          span(' cannot be deleted because of the following running cloud resources:')]),
         ul([
           workspaceResources.apps.map(app => li({ key: app.appName }, [app.appName])),
           workspaceResources.runtimes.map(runtime => li({ key: runtime.runtimeName }, [runtime.runtimeName]))
@@ -128,9 +133,7 @@ const DeleteWorkspaceModal = ({ workspace, workspace: { workspace: { name, bucke
       }, 'Delete workspace'),
       styles: { modal: { background: colors.warning(0.1) } }
     }, [
-      div(['Are you sure you want to permanently delete the workspace ',
-        span({ style: { fontWeight: 600, wordBreak: 'break-word' } }, name),
-        '?']),
+      div(['Are you sure you want to permanently delete the workspace ', getWorkspaceName(), '?']),
       getStorageDeletionMessage(),
       isDeleteDisabledFromResources && div({ style: { marginTop: '1rem' } }, [
         getResourceDeletionMessage()


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WOR-967

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

Consistency among these dialogs:

<img width="489" alt="image" src="https://user-images.githubusercontent.com/484484/234386620-b85658ad-eaae-4e2c-b85b-31d42f215986.png">

<img width="490" alt="image" src="https://user-images.githubusercontent.com/484484/234386785-b13a6546-8923-46cd-8065-3ec280e5641d.png">

<img width="478" alt="image" src="https://user-images.githubusercontent.com/484484/234386957-4f641d06-108f-438b-9844-69c58c7cf015.png">

### What
- Include the workspace name in all dialogs about workspace deletion.

### Why
- If you launch delete from the workspace list (instead of the workspace dashboard), you want to make sure you are deleting the correct workspace because it is not reversible operation. 

### Testing strategy
- [x] Create an Azure workspace
- [x] Verify delete dialog while WDS is still creating (dialog 1 above)
- [x] Verify delete dialog after WDS has created (dialog 2 above)
- [x] Verify delete dialog after deleting WDS resources (dialog 3 above)

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 
