### PR TITLE
[IA-4262] Use application not tool for icons

### DIFF
--- a/src/pages/workspaces/workspace/analysis/Analyses.ts
+++ b/src/pages/workspaces/workspace/analysis/Analyses.ts
@@ -118,18 +118,11 @@ export interface AnalysisCardProps {
   potentialLockers: any
 }
 
-//currentUserHash && lastLockedBy && lastLockedBy !== currentUserHash && !isLockExpired
-export const getLocked = (isLockExpired: boolean, currentUserHash?: string, lastLockedBy?: string): boolean => {
-  const present = (currentUserHash && lastLockedBy) ? lastLockedBy !== currentUserHash : false
-  return present && !isLockExpired
-}
-
 //TODO: move to separate file
 const AnalysisCard = ({
   currentRuntime, namespace, name, lastModified, metadata, tool, workspaceName, onRename, onCopy, onDelete, onExport, canWrite,
   currentUserHash, potentialLockers
 }: AnalysisCardProps) => {
-//}) => {
   const { lockExpiresAt, lastLockedBy } = metadata || {}
   const isLockExpired: boolean = lockExpiresAt ? new Date(parseInt(lockExpiresAt)).getTime() > Date.now() : false
   // if there is a currentUserHash & lastLockedBy, they are not equal, and the lock isn't expired

--- a/src/pages/workspaces/workspace/analysis/Analyses.ts
+++ b/src/pages/workspaces/workspace/analysis/Analyses.ts
@@ -215,7 +215,7 @@ const AnalysisCard = ({
     getFileName(name)
   ])
 
-  const toolIconSrc: string = Utils.switchCase(currentRuntimeToolLabel,
+  const toolIconSrc: string = Utils.switchCase(application,
     [runtimeToolLabels.Jupyter, () => jupyterLogo],
     [runtimeToolLabels.RStudio, () => rstudioSquareLogo],
     [runtimeToolLabels.JupyterLab, () => jupyterLogo]


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/IA-4262

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
The application icons (RStudio and Jupyter) are not loading next to the ipynb and Rmd/R files displayed in the Analyses tab

### What
- The icons were using the runtimeToolLabel rather than the application

### Why
- I noticed that the icons appear once a VM is created and are only the type of the tool created

### Testing strategy
- [ ] Create multiple analyses files of different types and make sure icons are correct with and without a VM
<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 


[IA-4262]: https://broadworkbench.atlassian.net/browse/IA-4262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ