### PR TITLE
[IA-4290] Updating creating message with correct wait time for Azure runtimes

### DIFF
--- a/src/pages/workspaces/workspace/analysis/AnalysisLauncher.js
+++ b/src/pages/workspaces/workspace/analysis/AnalysisLauncher.js
@@ -377,6 +377,7 @@ const PreviewHeader = ({
   const { mode } = queryParams;
   const analysisLink = Nav.getLink(analysisLauncherTabName, { namespace, name, analysisName });
   const isAzureWorkspace = !!workspace.azureContext;
+  const isGcpWorkspace = !!workspace.workspace.googleProject;
   const currentRuntimeToolLabel = getToolLabelFromRuntime(runtime);
   const enableJupyterLabPersistenceId = `${namespace}/${name}/${ENABLE_JUPYTERLAB_ID}`;
   const [enableJupyterLabGCP] = useState(() => getLocalPref(enableJupyterLabPersistenceId) || false);
@@ -566,7 +567,7 @@ const PreviewHeader = ({
           () => h(StatusMessage, ['Creating cloud environment. You can navigate away, this may take up to 10 minutes.']),
         ],
         [
-          runtimeStatus === 'Creating' && !isAzureWorkspace,
+          runtimeStatus === 'Creating' && isGcpWorkspace,
           () => h(StatusMessage, ['Creating cloud environment. You can navigate away and return in 3-5 minutes.']),
         ],
         [runtimeStatus === 'Starting', () => h(StatusMessage, ['Starting cloud environment, this may take up to 2 minutes.'])],

--- a/src/pages/workspaces/workspace/analysis/AnalysisLauncher.js
+++ b/src/pages/workspaces/workspace/analysis/AnalysisLauncher.js
@@ -561,7 +561,14 @@ const PreviewHeader = ({
       // Status specific messaging which is not specific to an app
       Utils.cond(
         [_.includes(runtimeStatus, usableStatuses), () => h(StatusMessage, { hideSpinner: true }, ['Cloud environment is ready.'])],
-        [runtimeStatus === 'Creating', () => h(StatusMessage, ['Creating cloud environment. You can navigate away and return in 3-5 minutes.'])],
+        [
+          runtimeStatus === 'Creating' && isAzureWorkspace,
+          () => h(StatusMessage, ['Creating cloud environment. You can navigate away, this may take up to 10 minutes.']),
+        ],
+        [
+          runtimeStatus === 'Creating' && !isAzureWorkspace,
+          () => h(StatusMessage, ['Creating cloud environment. You can navigate away and return in 3-5 minutes.']),
+        ],
         [runtimeStatus === 'Starting', () => h(StatusMessage, ['Starting cloud environment, this may take up to 2 minutes.'])],
         [
           runtimeStatus === 'Stopping',

--- a/src/pages/workspaces/workspace/analysis/AppLauncher.js
+++ b/src/pages/workspaces/workspace/analysis/AppLauncher.js
@@ -354,7 +354,7 @@ const ApplicationLauncher = _.flow(
                     () => h(StatusMessage, ['Creating cloud environment. You can navigate away, this may take up to 10 minutes.']),
                   ],
                   [
-                    runtimeStatus === 'Creating' && !azureContext,
+                    runtimeStatus === 'Creating' && !!googleProject,
                     () => h(StatusMessage, ['Creating cloud environment. You can navigate away and return in 3-5 minutes.']),
                   ],
                   [runtimeStatus === 'Starting', () => 'Starting cloud environment, this may take up to 2 minutes.'],

--- a/src/pages/workspaces/workspace/analysis/AppLauncher.js
+++ b/src/pages/workspaces/workspace/analysis/AppLauncher.js
@@ -349,7 +349,14 @@ const ApplicationLauncher = _.flow(
             !busy &&
               h(StatusMessage, { hideSpinner: ['Error', 'Stopped', null].includes(runtimeStatus) }, [
                 Utils.cond(
-                  [runtimeStatus === 'Creating', () => 'Creating cloud environment. You can navigate away and return in 3-5 minutes.'],
+                  [
+                    runtimeStatus === 'Creating' && azureContext,
+                    () => h(StatusMessage, ['Creating cloud environment. You can navigate away, this may take up to 10 minutes.']),
+                  ],
+                  [
+                    runtimeStatus === 'Creating' && !azureContext,
+                    () => h(StatusMessage, ['Creating cloud environment. You can navigate away and return in 3-5 minutes.']),
+                  ],
                   [runtimeStatus === 'Starting', () => 'Starting cloud environment, this may take up to 2 minutes.'],
                   [_.includes(runtimeStatus, usableStatuses), () => 'Almost ready...'],
                   [


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/IA-4290

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
Updated the messaging when an Azure runtime is being created to reflect an accurate waiting time.


### Why
Azure runtimes currently take closer to 10 minutes to create (vs. 3-5 on GCP).

### Testing strategy
- [ ] Create an azure runtime and try to open the VM from the side panel (look for new messaging)
- [ ] Create an azure runtime and try to open the VM from an analysis file (look for new messaging)
- [ ] Create a GCP runtime and try to open the VM from an analysis file
- [ ] Create a GCP runtime and try to open the VM from the side panel

### Visual Aids
<img width="1012" alt="image" src="https://user-images.githubusercontent.com/85642387/235780120-c2b02653-14a0-4f7b-a23a-6bfb2de60bcb.png">
<img width="656" alt="image" src="https://user-images.githubusercontent.com/85642387/235780176-fad47f04-79f9-46c5-9d51-bf308d235c32.png">