### PR TITLE
[UIE-84] Increase resources for build job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,7 +220,7 @@ commands:
 jobs:
   build:
     executor: node
-    resource_class: medium+
+    resource_class: large
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
We're frequently seeing builds fail in CircleCI with this message:
> The build failed because the process exited too early. This probably means the system ran out of memory or someone called `kill -9` on the process.

This updates the build job to use a higher [resource class](https://circleci.com/docs/configuration-reference/#docker-execution-environment) with more memory.