### PR TITLE
[UIE-78] Enable more ESLint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,16 +38,15 @@ module.exports = {
 
     // TS directive comments will be necessary during transition from JS to TS.
     '@typescript-eslint/ban-ts-comment': 'off',
-    '@typescript-eslint/ban-types': 'off',
+    // TODO: Replace these types with alternatives recommended by this rule.
+    '@typescript-eslint/ban-types': ['error', { types: { Function: false, Object: false, '{}': false } }],
+    // No-ops are often used in tests and sometimes as default values for callback props.
     '@typescript-eslint/no-empty-function': 'off',
     // `any` is useful for incremental type improvements during the transition from JS to TS.
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-non-null-assertion': 'off',
     '@typescript-eslint/no-shadow': 'off',
-    '@typescript-eslint/no-throw-literal': 'off',
     '@typescript-eslint/no-use-before-define': 'off',
-    '@typescript-eslint/return-await': 'off',
-    '@typescript-eslint/strict-boolean-expressions': 'off', // TODO: should be 'warn',
 
     'class-methods-use-this': 'off',
     'consistent-return': 'off',
@@ -57,10 +56,11 @@ module.exports = {
     'max-len': 'off',
     'no-await-in-loop': 'off',
     'no-case-declarations': 'off',
-    'no-console': 'off',
+    // Allow some console methods.
+    'no-console': ['error', { allow: ['assert', 'error'] }],
     // Allow `while (true) {...}`
     'no-constant-condition': ['error', {checkLoops: false}],
-    'no-empty': 'off',
+    'no-empty': ['error', { allowEmptyCatch: true }],
     'no-continue': 'off',
     'no-nested-ternary': 'off',
     'no-param-reassign': 'off',
@@ -68,17 +68,14 @@ module.exports = {
     'no-promise-executor-return': 'off',
     'no-restricted-syntax': 'off',
     'no-return-await': 'off',
-    'no-underscore-dangle': 'off',
     'no-unused-expressions': 'off',
     'no-void': 'off',
     'prefer-destructuring': 'off',
     'prefer-promise-reject-errors': 'off',
     'prefer-regex-literals': 'off',
     radix: 'off',
-    'symbol-description': 'off',
     //
 
-    'no-unsafe-optional-chaining': 'warn',
     '@typescript-eslint/no-unused-vars': [
       'warn',
       {
@@ -108,7 +105,9 @@ module.exports = {
         // Integration tests use CommonJS instead of ESM.
         '@typescript-eslint/no-var-requires': 'off',
         // TODO: Add dependencies to package.json.
-        'import/no-extraneous-dependencies': 'off'
+        'import/no-extraneous-dependencies': 'off',
+        // Integration tests frequently log.
+        'no-console': 'off',
       }
     },
     {

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -458,6 +458,7 @@ const gotoPage = async (page, url) => {
     } catch (e) {
       console.error(e);
       // Stop page loading, as if you hit "X" in the browser. ignore exception.
+      // eslint-disable-next-line no-underscore-dangle
       await page._client.send('Page.stopLoading').catch((err) => void err);
       throw new Error(e);
     }

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -534,6 +534,7 @@ export const GridTable = forwardRefWithName(
       if (rowCount > 0) {
         body.current.measureAllCells();
 
+        // eslint-disable-next-line no-underscore-dangle
         scrollSync.current._onScroll({ scrollLeft: initialX }); // BEWARE: utilizing private method from scrollSync that is not intended to be used
 
         body.current.scrollToPosition({ scrollLeft: initialX, scrollTop: initialY }); // waiting to let ScrollSync initialize

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -164,7 +164,7 @@ export const cond = (...args) => {
   }
 };
 
-export const DEFAULT = Symbol();
+export const DEFAULT = Symbol('Default switch case');
 
 export const switchCase = (value, ...pairs) => {
   const match = _.find(([v]) => v === value || v === DEFAULT, pairs);

--- a/src/pages/ImportWorkflow/importDockstoreWorkflow.ts
+++ b/src/pages/ImportWorkflow/importDockstoreWorkflow.ts
@@ -43,8 +43,7 @@ export const importDockstoreWorkflow = async (
           .methodConfig(namespace, workflowName)
           .delete()
           .catch((err) => {
-            if ((err as Response).status === 404) {
-            } else {
+            if ((err as Response).status !== 404) {
               throw err;
             }
           })

--- a/src/pages/workspaces/workspace/analysis/modals/DeleteDiskChoices.ts
+++ b/src/pages/workspaces/workspace/analysis/modals/DeleteDiskChoices.ts
@@ -11,7 +11,7 @@ import {
 import { getMountDir, mountPoints, ToolLabel } from 'src/pages/workspaces/workspace/analysis/utils/tool-utils';
 
 type DeleteDiskChoicesProps = {
-  persistentDiskCostDisplay: String;
+  persistentDiskCostDisplay: string;
   deleteDiskSelected: boolean;
   setDeleteDiskSelected: (p1: boolean) => void;
   toolLabel?: ToolLabel;


### PR DESCRIPTION
Some ESLint rules that are currently disabled can be partially enabled while still allowing existing code.

A few others only produce one or two errors and can be easily resolved or disabled with comments.