### PR TITLE
[SUP-822] Update Terra UI menu to point to Community Topics page rather than General Discussion

### DIFF
--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -416,7 +416,7 @@ const TopBar = ({ showMenu = true, title, href, children }) => {
                     h(
                       DropDownSubItem,
                       {
-                        href: 'https://support.terra.bio/hc/en-us/community/topics/360000500432',
+                        href: 'https://support.terra.bio/hc/en-us/community/topics',
                         onClick: hideNav,
                         ...Utils.newTabLinkProps,
                       },


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/SUP-822

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Updated the Community Forum link in the Terra main menu to point to the general [Community Topics page](https://support.terra.bio/hc/en-us/community/topics/)

### Why
- The Community Forum link currently points to the [General Discussion](https://support.terra.bio/hc/en-us/community/topics/360000500432) board but there are other boards in the Community Forum that may be of interest to users.

### Testing strategy
- Tested locally
#### Before:
![image](https://user-images.githubusercontent.com/68919432/236305712-169c36b9-05f2-4b8f-8fb1-4feb75ca43bd.png)

#### After: 
![image](https://user-images.githubusercontent.com/68919432/236305731-3e5f95ff-174d-4820-b755-da726ccfd894.png)


<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 
