### PR TITLE
[IA-4281] Updated Azure setStorageLinks to retry

### DIFF
--- a/src/libs/ajax/ajax-common.test.ts
+++ b/src/libs/ajax/ajax-common.test.ts
@@ -2,7 +2,7 @@ import { reloadAuthToken, signOutAfterSessionTimeout } from 'src/libs/auth';
 import { getUser } from 'src/libs/state';
 import { asMockedFn } from 'src/testing/test-utils';
 
-import { authOpts, withRetryAfterReloadingExpiredAuthToken } from './ajax-common';
+import { authOpts, makeRequestRetry, withRetryAfterReloadingExpiredAuthToken } from './ajax-common';
 
 type AuthExports = typeof import('src/libs/auth');
 jest.mock('src/libs/auth', (): Partial<AuthExports> => {
@@ -117,5 +117,50 @@ describe('withRetryAfterReloadingExpiredAuthToken', () => {
         expect(result).rejects.toEqual(new Error('Session timed out'));
       });
     });
+  });
+});
+
+describe('makeRequestRetry', () => {
+  it('fails after max retries', async () => {
+    // Arrange
+    const fetchFunction = jest.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          setTimeout(() => resolve(), 51);
+        })
+    );
+
+    let thrownError;
+    // Act
+    try {
+      await makeRequestRetry(fetchFunction, 5, 10);
+    } catch (error) {
+      thrownError = error;
+    }
+
+    // Assert
+    expect(thrownError).toEqual(new Error('Request timed out'));
+  });
+
+  it('succeeds after one fail', async () => {
+    // Arrange
+    let callCount = 0;
+    const fetchFunction = jest.fn(
+      () =>
+        new Promise((resolve) => {
+          if (callCount === 0) {
+            callCount++;
+            setTimeout(() => resolve(new Response()), 51);
+          } else {
+            resolve(new Response(JSON.stringify({ success: true }), { status: 200 }));
+          }
+        })
+    );
+
+    // Act
+    const result = await makeRequestRetry(fetchFunction, 5, 10);
+
+    // Assert
+    expect(result.success).toBe(true);
   });
 });

--- a/src/libs/ajax/ajax-common.ts
+++ b/src/libs/ajax/ajax-common.ts
@@ -35,6 +35,29 @@ export const withRetryOnError = _.curry((shouldNotRetryFn, wrappedFetch) => asyn
   return wrappedFetch(...args);
 });
 
+const TIMEOUT_DURATION = 10000;
+
+export function makeRequestRetry(request: Function, retriesLeft: number) {
+  return Promise.race([
+    request(),
+    new Promise((_, reject) => setTimeout(() => reject(new Error('Request timed out')), TIMEOUT_DURATION)),
+  ])
+    .then((response) => {
+      if (response.ok) {
+        return response.json();
+      }
+      throw new Error('Network response was not ok.');
+    })
+    .catch((error) => {
+      if (retriesLeft === 0) {
+        throw error;
+      }
+      return new Promise((resolve) => {
+        setTimeout(resolve, TIMEOUT_DURATION);
+      }).then(() => makeRequestRetry(request, retriesLeft - 1));
+    });
+}
+
 export const withRetryAfterReloadingExpiredAuthToken =
   (wrappedFetch: FetchFn): FetchFn =>
   async (resource: RequestInfo | URL, options?: RequestInit) => {

--- a/src/libs/ajax/leonardo/Runtimes.ts
+++ b/src/libs/ajax/leonardo/Runtimes.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp';
 import * as qs from 'qs';
 import { version } from 'src/data/gce-machines';
-import { appIdentifier, authOpts, fetchLeo, fetchOk, jsonBody } from 'src/libs/ajax/ajax-common';
+import { appIdentifier, authOpts, fetchLeo, fetchOk, jsonBody, makeRequestRetry } from 'src/libs/ajax/ajax-common';
 import { GetRuntimeItem, ListRuntimeItem } from 'src/libs/ajax/leonardo/models/runtime-models';
 import { getConfig } from 'src/libs/config';
 import { CloudPlatform } from 'src/pages/billing/models/BillingProject';
@@ -131,17 +131,21 @@ export const Runtimes = (signal) => {
         },
 
         setStorageLinks: (localBaseDirectory, cloudStorageDirectory, pattern) => {
-          return fetchOk(
-            `${proxyUrl}/welder/storageLinks`,
-            _.mergeAll([
-              authOpts(),
-              jsonBody({
-                localBaseDirectory,
-                cloudStorageDirectory,
-                pattern,
-              }),
-              { signal, method: 'POST' },
-            ])
+          return makeRequestRetry(
+            () =>
+              fetchOk(
+                `${proxyUrl}/welder/storageLinks`,
+                _.mergeAll([
+                  authOpts(),
+                  jsonBody({
+                    localBaseDirectory,
+                    cloudStorageDirectory,
+                    pattern,
+                  }),
+                  { signal, method: 'POST' },
+                ])
+              ),
+            5
           );
         },
       };
@@ -256,3 +260,27 @@ export const Runtimes = (signal) => {
     },
   };
 };
+
+// const MAX_RETRIES = 5;
+// const TIMEOUT_DURATION = 10000;
+
+// function makeRequestRetry(request, retriesLeft) {
+//   return Promise.race([
+//     request(),
+//     new Promise((_, reject) => setTimeout(() => reject(new Error('Request timed out')), TIMEOUT_DURATION)),
+//   ])
+//     .then((response) => {
+//       if (response.ok) {
+//         return response.json();
+//       }
+//       throw new Error('Network response was not ok.');
+//     })
+//     .catch((error) => {
+//       if (retriesLeft === 0) {
+//         throw error;
+//       }
+//       return new Promise((resolve) => {
+//         setTimeout(resolve, TIMEOUT_DURATION);
+//       }).then(() => makeRequestRetry(request, retriesLeft - 1));
+//     });
+// }

--- a/src/libs/ajax/leonardo/Runtimes.ts
+++ b/src/libs/ajax/leonardo/Runtimes.ts
@@ -260,27 +260,3 @@ export const Runtimes = (signal) => {
     },
   };
 };
-
-// const MAX_RETRIES = 5;
-// const TIMEOUT_DURATION = 10000;
-
-// function makeRequestRetry(request, retriesLeft) {
-//   return Promise.race([
-//     request(),
-//     new Promise((_, reject) => setTimeout(() => reject(new Error('Request timed out')), TIMEOUT_DURATION)),
-//   ])
-//     .then((response) => {
-//       if (response.ok) {
-//         return response.json();
-//       }
-//       throw new Error('Network response was not ok.');
-//     })
-//     .catch((error) => {
-//       if (retriesLeft === 0) {
-//         throw error;
-//       }
-//       return new Promise((resolve) => {
-//         setTimeout(resolve, TIMEOUT_DURATION);
-//       }).then(() => makeRequestRetry(request, retriesLeft - 1));
-//     });
-// }

--- a/src/libs/ajax/leonardo/Runtimes.ts
+++ b/src/libs/ajax/leonardo/Runtimes.ts
@@ -1,7 +1,16 @@
 import _ from 'lodash/fp';
 import * as qs from 'qs';
 import { version } from 'src/data/gce-machines';
-import { appIdentifier, authOpts, fetchLeo, fetchOk, jsonBody, makeRequestRetry } from 'src/libs/ajax/ajax-common';
+import {
+  appIdentifier,
+  authOpts,
+  DEFAULT_RETRY_COUNT,
+  DEFAULT_TIMEOUT_DURATION,
+  fetchLeo,
+  fetchOk,
+  jsonBody,
+  makeRequestRetry,
+} from 'src/libs/ajax/ajax-common';
 import { GetRuntimeItem, ListRuntimeItem } from 'src/libs/ajax/leonardo/models/runtime-models';
 import { getConfig } from 'src/libs/config';
 import { CloudPlatform } from 'src/pages/billing/models/BillingProject';
@@ -145,7 +154,8 @@ export const Runtimes = (signal) => {
                   { signal, method: 'POST' },
                 ])
               ),
-            5
+            DEFAULT_RETRY_COUNT,
+            DEFAULT_TIMEOUT_DURATION
           );
         },
       };


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/IA-4281

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Users would often see an error with setStorageLinks not succeeding, and the error wouldn't retry. However, if users refreshed the page, the call would succeed.

### Testing strategy
- [ ] Create an Azure JupyterLab VM. "Open" the app before it's set to "running". Confirm there's no error popup. Additionally on the network tab, confirm that the initial storageLinks request fails, and the subsequent request succeeds.

### Additional Comments
This solution could be permanent, however, we may also want to consider adding a status endpoint into the relay listener and have Leo poll for it to be up, much like it polls JupyterLab and Welder.

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 
