### PR TITLE
[no ticket] Adjust target to es2022

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,7 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
-    "target": "es5",
+    "target": "es2022",
   },
   "include": ["src", "types", "integration-tests", "config-overrides.js"]
 }


### PR DESCRIPTION
### Jira Ticket: N/A

## Summary of changes:

es5 is a very old target. Terra officially supports only Google Chrome, but es2022 is widely supported by browsers and Node LTS.

Adjusting this target makes it easier to build this code using esbuild, which is how we use it in AoU.

### Testing strategy

- Deploy and manually test some major UI components. Should see no change in behavior.