### PR TITLE
[UIE-85] Automate AppEngine cleanup script for CI

### DIFF
--- a/.github/workflows/appengine-cleanup.yml
+++ b/.github/workflows/appengine-cleanup.yml
@@ -1,0 +1,31 @@
+name: Automated AppEngine cleanup script
+on:
+  # Run once every week on Sunday
+  schedule:
+    - cron: "0 0 * * 0"
+  # To manually trigger workflow
+  workflow_dispatch: {}
+jobs:
+  appengine_cleanup:
+    runs-on: ubuntu-latest
+    env:
+      CLOUDSDK_CORE_DISABLE_PROMPTS: 1
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - uses: actions/checkout@v3
+      - name: 'Authenticate with Google Cloud'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          workload_identity_provider: 'projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider'
+          service_account: 'appengine-cleanup-non-prod@bvdp-saturn-dev.iam.gserviceaccount.com'
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v1'
+      # Delete old AppEngine versions in each environment
+      - run: ./scripts/delete-old-app-engine-versions.sh dev
+        continue-on-error: true
+      - run: ./scripts/delete-old-app-engine-versions.sh alpha
+        continue-on-error: true
+      - run: ./scripts/delete-old-app-engine-versions.sh staging
+        continue-on-error: true


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/UIE-85

## Summary of changes:

Creates a new GitHub Action that runs on a Cron job, and sets `CLOUDSDK_CORE_DISABLE_PROMPTS=1` to bypass the required `yes/no` confirmation dialog in the AppEngine cleanup script.

### Why

In #3051 , a script was introduced to delete old Google App Engine deployments of Terra UI in non-prod environments. This script replaced a dangerous and tedious manual process.

Every week, a reminder is sent to the Terra UI group that someone should run this script to cleanup old AppEngine deployments.

After cleaning up more than [5000 AppEngine deployments](https://cloudlogging.app.goo.gl/bThgdq9atr8ZQ4JL9) without issues across development, alpha, perf and staging environments, I think it is safe to fully automate this script and run it on a cron job every n-weeks (1/2?).

### Testing strategy

- Ran `shellcheck` to ensure script was linted appropriately.
- Manually tested script with various inputs.