### PR TITLE
AJ-1022 remove wds autodeploy code

### DIFF
--- a/src/libs/ajax/ajax-common.ts
+++ b/src/libs/ajax/ajax-common.ts
@@ -162,11 +162,6 @@ export const fetchRawls = _.flow(
   withRetryAfterReloadingExpiredAuthToken
 )(fetchOk);
 
-export const fetchRawlsUnauthenticated = _.flow(
-  withUrlPrefix(`${getConfig().rawlsUrlRoot}/`),
-  withAppIdentifier
-)(fetchOk);
-
 export const fetchBillingProfileManager = _.flow(
   withUrlPrefix(`${getConfig().billingProfileManagerUrlRoot}/api/`),
   withAppIdentifier,

--- a/src/libs/ajax/data-table-providers/WdsDataTableProvider.test.ts
+++ b/src/libs/ajax/data-table-providers/WdsDataTableProvider.test.ts
@@ -161,16 +161,11 @@ describe('WdsDataTableProvider', () => {
     return Promise.resolve(testProxyUrlResponse);
   };
 
-  const createAppV2MockImpl: AppsContract['createAppV2'] = (_workspaceId: string) => {
-    return Promise.resolve();
-  };
-
   let getRecords: jest.MockedFunction<WorkspaceDataContract['getRecords']>;
   let deleteTable: jest.MockedFunction<WorkspaceDataContract['deleteTable']>;
   let downloadTsv: jest.MockedFunction<WorkspaceDataContract['downloadTsv']>;
   let uploadTsv: jest.MockedFunction<WorkspaceDataContract['uploadTsv']>;
   let listAppsV2: jest.MockedFunction<AppsContract['listAppsV2']>;
-  let createAppV2: jest.MockedFunction<AppsContract['createAppV2']>;
 
   beforeEach(() => {
     getRecords = jest.fn().mockImplementation(getRecordsMockImpl);
@@ -178,13 +173,12 @@ describe('WdsDataTableProvider', () => {
     downloadTsv = jest.fn().mockImplementation(downloadTsvMockImpl);
     uploadTsv = jest.fn().mockImplementation(uploadTsvMockImpl);
     listAppsV2 = jest.fn().mockImplementation(listAppsV2MockImpl);
-    createAppV2 = jest.fn().mockImplementation(createAppV2MockImpl);
 
     asMockedFn(Ajax).mockImplementation(
       () =>
         ({
           WorkspaceData: { getRecords, deleteTable, downloadTsv, uploadTsv } as Partial<WorkspaceDataContract>,
-          Apps: { listAppsV2, createAppV2 } as Partial<AppsContract>,
+          Apps: { listAppsV2 } as Partial<AppsContract>,
         } as Partial<AjaxContract> as AjaxContract)
     );
   });

--- a/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
+++ b/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
@@ -13,7 +13,6 @@ import {
   TsvUploadButtonTooltipOptions,
   UploadParameters,
 } from 'src/libs/ajax/data-table-providers/DataTableProvider';
-import { withErrorReporting } from 'src/libs/error';
 import { notificationStore } from 'src/libs/state';
 import * as Utils from 'src/libs/utils';
 
@@ -86,17 +85,6 @@ const getRelationParts = (val: unknown): string[] => {
   return [];
 };
 
-export const createLeoAppWithErrorHandling = (workspaceId) => {
-  const typedWithErrorReporting: any = withErrorReporting;
-  const createLeoAppCall = typedWithErrorReporting(
-    'An error occurred when creating your data tables. Please reach out to support@terra.bio',
-    async () => {
-      await Ajax().Apps.createAppV2(`wds-${workspaceId}`, `${workspaceId}`);
-    }
-  );
-  createLeoAppCall();
-};
-
 // Invokes logic to determine the appropriate app for WDS
 // If WDS is not running, a URL will not be present -- in some cases, this function may invoke
 // a new call to Leo to instantiate a WDS being available, thus having a valid URL
@@ -140,19 +128,6 @@ export const resolveWdsApp = (apps) => {
       return allWdsApps[0];
     }
   }
-
-  // we could not find an app of type CROMWELL in any healthy state, regardless of its name.
-  // Self-heal and try to deploy an app, assuming shouldAutoDeployWds is true.
-  // Due to Leo naming requirements, ensure this app has a unique name; this prevents
-  // name collisions with previously-deployed apps which may be in ERROR or DELETED states.
-  // if (shouldAutoDeployWds) {
-  // David An: disabled for now. This needs to pass both the workspaceId and a random app name to
-  // createLeoAppWithErrorHandling.
-  // Additionally, it needs to be failsafe to race conditions in which the user enters the Data
-  // tab before Leo has had a chance to respond with knowledge about the app that was created
-  // during workspace creation.
-  // createLeoAppWithErrorHandling(uuid())
-  // }
 
   return '';
 };

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -656,9 +656,6 @@ const WorkspaceData = _.flow(
 
     const entityServiceDataTableProvider = new EntityServiceDataTableProvider(namespace, name);
 
-    // auto-deploy WDS for a user who is: 1) the workspace creator, and 2) still an OWNER of the workspace
-    // disablied: const shouldAutoDeployWds = workspace?.accessLevel === 'OWNER' && createdBy === getUser()?.email
-
     const wdsDataTableProvider = useMemo(() => {
       const proxyUrl = !!wdsProxyUrl && wdsProxyUrl.state;
       return new WdsDataTableProvider(workspaceId, proxyUrl);


### PR DESCRIPTION
See [AJ-1022](https://broadworkbench.atlassian.net/browse/AJ-1022)
Now that standalone WDS is fully deployed from the back end, there is no need for front-end logic to ask leo to create the app.  This PR removes all WDS-creation-related code.

[AJ-1022]: https://broadworkbench.atlassian.net/browse/AJ-1022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ