### PR TITLE
[UIE-86] Fix VS Code formatting settings

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,3 @@
 {
-  "recommendations": [
-    "arcanis.vscode-zipfs",
-    "dbaeumer.vscode-eslint",
-    "dbaeumer.vscode-eslint"
-  ]
+  "recommendations": ["arcanis.vscode-zipfs", "dbaeumer.vscode-eslint"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
     "**/.yarn": true,
     "**/.pnp.*": true
   },
+  "eslint.format.enable": true,
   "eslint.nodePath": ".yarn/sdks",
   "typescript.tsdk": ".yarn/sdks/typescript/lib",
   "typescript.enablePromptUseWorkspaceTsdk": true,

--- a/.yarn/sdks/prettier/index.js
+++ b/.yarn/sdks/prettier/index.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+const {existsSync} = require(`fs`);
+const {createRequire} = require(`module`);
+const {resolve} = require(`path`);
+
+const relPnpApiPath = "../../../.pnp.cjs";
+
+const absPnpApiPath = resolve(__dirname, relPnpApiPath);
+const absRequire = createRequire(absPnpApiPath);
+
+if (existsSync(absPnpApiPath)) {
+  if (!process.versions.pnp) {
+    // Setup the environment to be able to require prettier/index.js
+    require(absPnpApiPath).setup();
+  }
+}
+
+// Defer to the real prettier/index.js your application uses
+module.exports = absRequire(`prettier/index.js`);

--- a/.yarn/sdks/prettier/package.json
+++ b/.yarn/sdks/prettier/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "prettier",
+  "version": "2.8.8-sdk",
+  "main": "./index.js",
+  "type": "commonjs"
+}


### PR DESCRIPTION
Currently, when I save a file in VS Code, it's automatically formatted in a way that introduces ESLint errors.

To get it to format as desired, I had to enable the [`eslint.format.enable` option](https://github.com/Microsoft/vscode-eslint#settings-options) for the ESLint extension and add the Prettier yarn SDK that is referenced by the `prettier.prettierPath` setting.