### PR TITLE
[IA-4316] fix double spinner when cloud env is opened while creating

### DIFF
--- a/src/pages/workspaces/workspace/analysis/AppLauncher.js
+++ b/src/pages/workspaces/workspace/analysis/AppLauncher.js
@@ -351,11 +351,11 @@ const ApplicationLauncher = _.flow(
                 Utils.cond(
                   [
                     runtimeStatus === 'Creating' && azureContext,
-                    () => h(StatusMessage, ['Creating cloud environment. You can navigate away, this may take up to 10 minutes.']),
+                    () => 'Creating cloud environment. You can navigate away, this may take up to 10 minutes.',
                   ],
                   [
                     runtimeStatus === 'Creating' && !!googleProject,
-                    () => h(StatusMessage, ['Creating cloud environment. You can navigate away and return in 3-5 minutes.']),
+                    () => 'Creating cloud environment. You can navigate away and return in 3-5 minutes.',
                   ],
                   [runtimeStatus === 'Starting', () => 'Starting cloud environment, this may take up to 2 minutes.'],
                   [_.includes(runtimeStatus, usableStatuses), () => 'Almost ready...'],


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/IA-4316

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Small bug where 2 loading spinners were present when opening a creating VM from the sidebar

### Why
- 

### Testing strategy
- [ ] create an Azure VM and make sure only 1 loading spinner is present when you try to open it from the sidebar

### Visual Aids
![image](https://github.com/DataBiosphere/terra-ui/assets/85642387/7e68bd98-839e-4cff-89b5-ff00a3cf7c62)

![image](https://github.com/DataBiosphere/terra-ui/assets/85642387/f5bcc474-acf6-4ed0-a171-b9370eef4bab)

