### PR TITLE
[UIE-85] Explicitly define TERM envvar

### DIFF
--- a/.github/workflows/appengine-cleanup.yml
+++ b/.github/workflows/appengine-cleanup.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CLOUDSDK_CORE_DISABLE_PROMPTS: 1
+      TERM: xterm
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/scripts/delete-old-app-engine-versions.sh
+++ b/scripts/delete-old-app-engine-versions.sh
@@ -82,7 +82,7 @@ set_dev_deletion_date() {
 
     printf "${INFO} ${GRN}%s${RST} is the oldest PR and was deployed on ${GRN}%s${RST}\n" "${OLDEST_PR_NAME}" "${OLDEST_PR_DATE}"
 
-    OLDEST_PR_DELETION_TIME=$(echo "${OLDEST_PR_TIME}" | jq -r '. - (24 * 60 * 60)') # 1 day
+    OLDEST_PR_DELETION_TIME=$(echo "${OLDEST_PR_TIME}" | jq -r '. - (24 * 60 * 60) | floor') # 1 day
     if [ "${DELETION_TIME}" -gt "${OLDEST_PR_DELETION_TIME}" ]; then
         DELETION_DATE=$(unix_epoch_to_date "${OLDEST_PR_DELETION_TIME}")
     fi
@@ -153,7 +153,7 @@ check_user_permissions
 
 printf "${INFO} Selected project ${GRN}%s${RST}\n" "${NEW_PROJECT}"
 
-DELETION_TIME=$(jq -n 'now - (10 * 24 * 60 * 60)') # 10 days
+DELETION_TIME=$(jq -n 'now - (10 * 24 * 60 * 60) | floor') # 10 days
 DELETION_DATE=$(unix_epoch_to_date "${DELETION_TIME}")
 if [ "$1" == "dev" ]; then
     set_dev_deletion_date


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/UIE-85

### Dependencies

Follow-on to #3924 

## Summary of changes:

The GitHub Action CI doesn't define a `$TERM` variable. Set one explicitly so the script doesn't fail in a CI environment.

### Testing strategy

Manually executed the [GitHub Action](https://github.com/DataBiosphere/terra-ui/actions/workflows/appengine-cleanup.yml) to test.
