### PR TITLE
[UIE-85] Switch to warning instead of error

### DIFF
--- a/.github/workflows/appengine-cleanup.yml
+++ b/.github/workflows/appengine-cleanup.yml
@@ -25,8 +25,5 @@ jobs:
         uses: 'google-github-actions/setup-gcloud@v1'
       # Delete old AppEngine versions in each environment
       - run: ./scripts/delete-old-app-engine-versions.sh dev
-        continue-on-error: true
       - run: ./scripts/delete-old-app-engine-versions.sh alpha
-        continue-on-error: true
       - run: ./scripts/delete-old-app-engine-versions.sh staging
-        continue-on-error: true

--- a/.github/workflows/appengine-cleanup.yml
+++ b/.github/workflows/appengine-cleanup.yml
@@ -1,4 +1,4 @@
-name: Automated AppEngine cleanup script
+name: Automated App Engine Cleanup
 on:
   # Run once every week on Sunday
   schedule:

--- a/scripts/delete-old-app-engine-versions.sh
+++ b/scripts/delete-old-app-engine-versions.sh
@@ -17,11 +17,13 @@ check_color_support() {
         BLD="$(tput bold)"
         RED="$(tput setaf 1)"
         GRN="$(tput setaf 2)"
+        YLW="$(tput setaf 3)"
         RST="$(tput sgr0)"
     else
         BLD=""
         RED=""
         GRN=""
+        YLW=""
         RST=""
     fi
     INFO="${BLD}+${RST}"
@@ -43,6 +45,12 @@ error() {
 abort() {
     printf "${RED}ABORT: %s${RST}\n" "$1" >&2
     exit 1
+}
+
+# print out warning to stderr and exit
+warn() {
+    printf "${YLW}WARNING: %s${RST}\n" "$1" >&2
+    exit 0
 }
 
 # ensure that jq is installed
@@ -98,7 +106,7 @@ check_remaining_items() {
     REMAIN_LIST_ITEMS=($(filter_app_engine_versions "version.createTime.date('%Y-%m-%d', Z)>'${DELETION_DATE}'"))
     REMAIN_LIST_COUNT="${#REMAIN_LIST_ITEMS[@]}"
     if [ "$REMAIN_LIST_COUNT" -lt 5 ]; then
-        abort "less than 5 deployments would remain"
+        warn "less than 5 deployments would remain"
     fi
 }
 
@@ -107,9 +115,9 @@ check_deletion_items() {
     DELETE_LIST_ITEMS=($(filter_app_engine_versions "version.createTime.date('%Y-%m-%d', Z)<='${DELETION_DATE}'"))
     DELETE_LIST_COUNT="${#DELETE_LIST_ITEMS[@]}"
     if [ "${DELETE_LIST_COUNT}" -lt 1 ]; then
-        abort "no deployments to delete"
+        warn "no deployments to delete"
     elif [ "${DELETE_LIST_COUNT}" -lt 10 ]; then
-        abort "less than 10 deployments to delete"
+        warn "less than 10 deployments to delete"
     fi
 }
 


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/UIE-85

### Dependencies

Follow-on to #3931 

### Summary of changes:

This is a potential improvement to the cleanup script. It switches some of the errors to warnings so the GitHub Action doesn't need to `continue-on-error`.

### Testing strategy

Manually executed the [GitHub Action](https://github.com/DataBiosphere/terra-ui/actions/workflows/appengine-cleanup.yml) to test:

- https://github.com/DataBiosphere/terra-ui/actions/runs/4996549521/jobs/8949874765
- https://github.com/DataBiosphere/terra-ui/actions/runs/4996654176/jobs/8950114053
