### PR TITLE
[IA-4171] Open button incorrectly greyed out for Azure runtimes

### DIFF
--- a/src/pages/workspaces/workspace/analysis/modals/CloudEnvironmentModal.js
+++ b/src/pages/workspaces/workspace/analysis/modals/CloudEnvironmentModal.js
@@ -359,11 +359,14 @@ export const CloudEnvironmentModal = ({
 
     // This defines whether we have successfully set a LeoToken cookie, used for authenticating to apps.
     // - For Azure, apps run in the domain of the Relay namespace in the landing zone; azureCookieReady stores whether a cookie has been set in that domain
+    // - For Azure Runtimes, the cookie is set when opening the runtime.
     // - For GCP, apps are all behind a centralized Leo proxy; leoCookieReady stores whether a cookie has been set in Leo's domain.
+
     const cookieReady = Utils.cond(
-      [cloudProvider === cloudProviderTypes.AZURE, () => azureCookieReady.readyForApp],
+      [cloudProvider === cloudProviderTypes.AZURE && toolLabel in appToolLabels, () => azureCookieReady.readyForApp],
       [Utils.DEFAULT, () => leoCookieReady]
     );
+
     const isDisabled =
       !doesCloudEnvForToolExist ||
       !cookieReady ||


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/IA-4171

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Change the cookieReady / isDisabled logic to account for runtimes properly.

### Why
- Bug introduced prevented users from opening their JupyterLab on Azure instances.

### Testing strategy
- [ ] Verify Open button is clickable immediately after runtime creation.

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 
