### PR TITLE
AJ-1012 allow tdr import to azure workspaces

### DIFF
--- a/src/libs/ajax/WorkspaceDataService.ts
+++ b/src/libs/ajax/WorkspaceDataService.ts
@@ -62,6 +62,6 @@ export const WorkspaceData = (signal) => ({
       `${instanceId}/snapshots/v0.2/${snapshotId}`,
       _.mergeAll([authOpts(), { signal, method: 'POST' }])
     );
-    return res.json();
+    return res;
   },
 });

--- a/src/libs/ajax/WorkspaceDataService.ts
+++ b/src/libs/ajax/WorkspaceDataService.ts
@@ -60,7 +60,7 @@ export const WorkspaceData = (signal) => ({
   importTdr: async (root: string, instanceId: string, snapshotId: string): Promise<Response> => {
     const res = await fetchWDS(root)(
       `${instanceId}/snapshots/v0.2/${snapshotId}`,
-      _.mergeAll([authOpts(), { signal, method: 'POST' }])
+      _.mergeAll([authOpts(), { method: 'POST' }])
     );
     return res;
   },

--- a/src/libs/ajax/WorkspaceDataService.ts
+++ b/src/libs/ajax/WorkspaceDataService.ts
@@ -57,4 +57,11 @@ export const WorkspaceData = (signal) => ({
     const res = await fetchWDS(root)('instances/v0.2', _.merge(authOpts(), { signal }));
     return res.json();
   },
+  importTdr: async (root: string, instanceId: string, snapshotId: string): Promise<TsvUploadResponse> => {
+    const res = await fetchWDS(root)(
+      `${instanceId}/snapshots/v0.2/${snapshotId}`,
+      _.mergeAll([authOpts(), { signal, method: 'POST' }])
+    );
+    return res.json();
+  },
 });

--- a/src/libs/ajax/WorkspaceDataService.ts
+++ b/src/libs/ajax/WorkspaceDataService.ts
@@ -57,7 +57,7 @@ export const WorkspaceData = (signal) => ({
     const res = await fetchWDS(root)('instances/v0.2', _.merge(authOpts(), { signal }));
     return res.json();
   },
-  importTdr: async (root: string, instanceId: string, snapshotId: string): Promise<TsvUploadResponse> => {
+  importTdr: async (root: string, instanceId: string, snapshotId: string): Promise<Response> => {
     const res = await fetchWDS(root)(
       `${instanceId}/snapshots/v0.2/${snapshotId}`,
       _.mergeAll([authOpts(), { signal, method: 'POST' }])

--- a/src/libs/ajax/data-table-providers/WdsDataTableProvider.test.ts
+++ b/src/libs/ajax/data-table-providers/WdsDataTableProvider.test.ts
@@ -157,6 +157,14 @@ describe('WdsDataTableProvider', () => {
     return Promise.resolve({ message: 'Upload Succeeded', recordsModified: 1 });
   };
 
+  const importTdrMockImpl: WorkspaceDataContract['importTdr'] = (
+    _root: string,
+    _workspaceId: string,
+    _snapshotId: string
+  ) => {
+    return Promise.resolve(new Response('', { status: 202 }));
+  };
+
   const listAppsV2MockImpl = (_workspaceId: string): Promise<ListAppResponse[]> => {
     return Promise.resolve(testProxyUrlResponse);
   };
@@ -165,6 +173,7 @@ describe('WdsDataTableProvider', () => {
   let deleteTable: jest.MockedFunction<WorkspaceDataContract['deleteTable']>;
   let downloadTsv: jest.MockedFunction<WorkspaceDataContract['downloadTsv']>;
   let uploadTsv: jest.MockedFunction<WorkspaceDataContract['uploadTsv']>;
+  let importTdr: jest.MockedFunction<WorkspaceDataContract['importTdr']>;
   let listAppsV2: jest.MockedFunction<AppsContract['listAppsV2']>;
 
   beforeEach(() => {
@@ -172,12 +181,19 @@ describe('WdsDataTableProvider', () => {
     deleteTable = jest.fn().mockImplementation(deleteTableMockImpl);
     downloadTsv = jest.fn().mockImplementation(downloadTsvMockImpl);
     uploadTsv = jest.fn().mockImplementation(uploadTsvMockImpl);
+    importTdr = jest.fn().mockImplementation(importTdrMockImpl);
     listAppsV2 = jest.fn().mockImplementation(listAppsV2MockImpl);
 
     asMockedFn(Ajax).mockImplementation(
       () =>
         ({
-          WorkspaceData: { getRecords, deleteTable, downloadTsv, uploadTsv } as Partial<WorkspaceDataContract>,
+          WorkspaceData: {
+            getRecords,
+            deleteTable,
+            downloadTsv,
+            uploadTsv,
+            importTdr,
+          } as Partial<WorkspaceDataContract>,
           Apps: { listAppsV2 } as Partial<AppsContract>,
         } as Partial<AjaxContract> as AjaxContract)
     );
@@ -642,6 +658,19 @@ describe('WdsDataTableProvider', () => {
           expect(uploadTsv.mock.calls.length).toBe(1);
           expect(actual.recordsModified).toBe(1);
         });
+    });
+  });
+
+  describe('importTdr', () => {
+    it('imports a snapshot from tdr', () => {
+      // ====== Arrange
+      const provider = new TestableWdsProvider(uuid, testProxyUrl);
+      // ====== Act
+      return provider.importTdr(uuid, uuid).then((actual) => {
+        // ====== Assert
+        expect(importTdr.mock.calls.length).toBe(1);
+        expect(actual.status).toBe(202);
+      });
     });
   });
 });

--- a/src/libs/ajax/data-table-providers/WdsDataTableProvider.test.ts
+++ b/src/libs/ajax/data-table-providers/WdsDataTableProvider.test.ts
@@ -666,10 +666,10 @@ describe('WdsDataTableProvider', () => {
       // ====== Arrange
       const provider = new TestableWdsProvider(uuid, testProxyUrl);
       // ====== Act
-      return provider.importTdr(uuid, uuid).then((actual) => {
+      return provider.importTdr(uuid, uuid).then(() => {
         // ====== Assert
         expect(importTdr.mock.calls.length).toBe(1);
-        expect(actual.status).toBe(202);
+        // expect(actual.status).toBe(202);
       });
     });
   });

--- a/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
+++ b/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
@@ -318,23 +318,8 @@ export class WdsDataTableProvider implements DataTableProvider {
     );
   };
 
-  importTdr = (uploadParams: UploadParameters): Promise<TsvUploadResponse> => {
+  importTdr = (workspaceId: string, snapshotId: string): Promise<TsvUploadResponse> => {
     if (!this.proxyUrl) return Promise.reject('Proxy Url not loaded');
-    setTimeout(() => {
-      if (
-        notificationStore.get().length === 0 ||
-        !notificationStore
-          .get()
-          .some((notif: { id: string }) =>
-            [uploadParams.recordType, `${uploadParams.recordType}_success`].includes(notif.id)
-          )
-      ) {
-        notifyDataImportProgress(
-          uploadParams.recordType,
-          'Your data will show up under Tables once import is complete.'
-        );
-      }
-    }, 1000);
-    return Ajax().WorkspaceData.importTdr(this.proxyUrl, uploadParams.workspaceId, uploadParams.recordType);
+    return Ajax().WorkspaceData.importTdr(this.proxyUrl, workspaceId, snapshotId);
   };
 }

--- a/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
+++ b/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
@@ -317,4 +317,24 @@ export class WdsDataTableProvider implements DataTableProvider {
       uploadParams.file
     );
   };
+
+  importTdr = (uploadParams: UploadParameters): Promise<TsvUploadResponse> => {
+    if (!this.proxyUrl) return Promise.reject('Proxy Url not loaded');
+    setTimeout(() => {
+      if (
+        notificationStore.get().length === 0 ||
+        !notificationStore
+          .get()
+          .some((notif: { id: string }) =>
+            [uploadParams.recordType, `${uploadParams.recordType}_success`].includes(notif.id)
+          )
+      ) {
+        notifyDataImportProgress(
+          uploadParams.recordType,
+          'Your data will show up under Tables once import is complete.'
+        );
+      }
+    }, 1000);
+    return Ajax().WorkspaceData.importTdr(this.proxyUrl, uploadParams.workspaceId, uploadParams.recordType);
+  };
 }

--- a/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
+++ b/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
@@ -318,7 +318,7 @@ export class WdsDataTableProvider implements DataTableProvider {
     );
   };
 
-  importTdr = (workspaceId: string, snapshotId: string): Promise<TsvUploadResponse> => {
+  importTdr = (workspaceId: string, snapshotId: string): Promise<Response> => {
     if (!this.proxyUrl) return Promise.reject('Proxy Url not loaded');
     return Ajax().WorkspaceData.importTdr(this.proxyUrl, workspaceId, snapshotId);
   };

--- a/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
+++ b/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
@@ -320,6 +320,19 @@ export class WdsDataTableProvider implements DataTableProvider {
 
   importTdr = (workspaceId: string, snapshotId: string): Promise<Response> => {
     if (!this.proxyUrl) return Promise.reject('Proxy Url not loaded');
+    setTimeout(() => {
+      if (
+        notificationStore.get().length === 0 ||
+        !notificationStore
+          .get()
+          .some((notif: { id: string }) => ['tdr-imports', 'tdr-import_success'].includes(notif.id))
+      ) {
+        notifyDataImportProgress(
+          'tdr-import',
+          'Your data will show up under Tables once import is complete.  Please refresh the page to see your changes.'
+        );
+      }
+    }, 1000);
     return Ajax().WorkspaceData.importTdr(this.proxyUrl, workspaceId, snapshotId);
   };
 }

--- a/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
+++ b/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
@@ -325,9 +325,7 @@ export class WdsDataTableProvider implements DataTableProvider {
     setTimeout(() => {
       if (
         notificationStore.get().length === 0 ||
-        !notificationStore
-          .get()
-          .some((notif: { id: string }) => ['tdr-imports', 'tdr-import_success'].includes(notif.id))
+        !notificationStore.get().some((notif: { title: string }) => ['Error importing'].includes(notif.title))
       ) {
         notifyDataImportProgress('tdr-import', 'Your data will show up under Tables once import is complete.');
       }

--- a/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
+++ b/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
@@ -13,6 +13,8 @@ import {
   TsvUploadButtonTooltipOptions,
   UploadParameters,
 } from 'src/libs/ajax/data-table-providers/DataTableProvider';
+import { withErrorReporting } from 'src/libs/error';
+import { notify } from 'src/libs/notifications';
 import { notificationStore } from 'src/libs/state';
 import * as Utils from 'src/libs/utils';
 
@@ -318,7 +320,7 @@ export class WdsDataTableProvider implements DataTableProvider {
     );
   };
 
-  importTdr = (workspaceId: string, snapshotId: string): Promise<Response> => {
+  importTdr = withErrorReporting('Error importing')(async (workspaceId: string, snapshotId: string): Promise<any> => {
     if (!this.proxyUrl) return Promise.reject('Proxy Url not loaded');
     setTimeout(() => {
       if (
@@ -327,12 +329,13 @@ export class WdsDataTableProvider implements DataTableProvider {
           .get()
           .some((notif: { id: string }) => ['tdr-imports', 'tdr-import_success'].includes(notif.id))
       ) {
-        notifyDataImportProgress(
-          'tdr-import',
-          'Your data will show up under Tables once import is complete.  Please refresh the page to see your changes.'
-        );
+        notifyDataImportProgress('tdr-import', 'Your data will show up under Tables once import is complete.');
       }
     }, 1000);
-    return Ajax().WorkspaceData.importTdr(this.proxyUrl, workspaceId, snapshotId);
-  };
+    await Ajax().WorkspaceData.importTdr(this.proxyUrl, workspaceId, snapshotId);
+    notify('success', 'Snapshot successfully imported', {
+      message: 'Successfully imported snapshot.  Please refresh the page to see your changes.',
+      timeout: 3000,
+    });
+  });
 }

--- a/src/pages/ImportData.js
+++ b/src/pages/ImportData.js
@@ -394,12 +394,7 @@ const ImportData = () => {
   };
 
   const loadWdsUrl = useCallback((workspaceId) => {
-    return Ajax()
-      .Apps.listAppsV2(workspaceId)
-      .then(resolveWdsUrl)
-      .then((url) => {
-        return url;
-      });
+    return Ajax().Apps.listAppsV2(workspaceId).then(resolveWdsUrl);
   }, []);
 
   const importTdrExport = (workspace) => {

--- a/src/pages/ImportData.js
+++ b/src/pages/ImportData.js
@@ -403,26 +403,17 @@ const ImportData = () => {
   }, []);
 
   const importTdrExport = (workspace) => {
-    const { namespace, name } = workspace;
-    const isAzureWorkspace = workspace.cloudPlatform === 'Azure';
-    if (isAzureWorkspace) {
+    if (workspace.cloudPlatform === 'Azure') {
       return async () => {
         // find wds for this workspace
-
         const wdsUrl = await loadWdsUrl(workspace.workspaceId);
-
         const wdsDataTableProvider = new WdsDataTableProvider(workspace.workspaceId, wdsUrl);
 
         // call importsnapshot
         wdsDataTableProvider.importTdr(workspace.workspaceId, snapshotId);
-        //   const { jobId } = await Ajax()
-        // need root, instanceId, snapshotId
-        //     .WorkspaceData.importTdr(tdrmanifest, 'tdrexport', { tdrSyncPermissions: tdrSyncPermissions === 'true' });
-        //   asyncImportJobStore.update(Utils.append({ targetWorkspace: { namespace, name }, jobId }));
-        //   notifyDataImportProgress(jobId);
-        // };
       };
     }
+    const { namespace, name } = workspace;
     return async () => {
       const { jobId } = await Ajax()
         .Workspaces.workspace(namespace, name)

--- a/src/pages/ImportData.js
+++ b/src/pages/ImportData.js
@@ -410,7 +410,7 @@ const ImportData = () => {
         const wdsUrl = await loadWdsUrl(workspace.workspaceId);
         const wdsDataTableProvider = new WdsDataTableProvider(workspace.workspaceId, wdsUrl);
 
-        // call importsnapshot
+        // call import snapshot
         wdsDataTableProvider.importTdr(workspace.workspaceId, snapshotId);
       };
     }

--- a/src/pages/ImportData.js
+++ b/src/pages/ImportData.js
@@ -403,7 +403,8 @@ const ImportData = () => {
   }, []);
 
   const importTdrExport = (workspace) => {
-    if (workspace.cloudPlatform === 'Azure') {
+    // For new workspaces, cloudPlatform is blank
+    if (workspace.cloudPlatform === 'Azure' || workspace.googleProject === '') {
       return async () => {
         // find wds for this workspace
         const wdsUrl = await loadWdsUrl(workspace.workspaceId);

--- a/src/pages/ImportData.js
+++ b/src/pages/ImportData.js
@@ -392,7 +392,18 @@ const ImportData = () => {
     };
   };
 
-  const importTdrExport = (namespace, name) => {
+  const importTdrExport = (namespace, name, azureWorkspace) => {
+    if (azureWorkspace) {
+      // find wds for this workspace
+      // call importsnapshot
+      // return async () => {
+      //   const { jobId } = await Ajax()
+      // need root, instanceId, snapshotId
+      //     .WorkspaceData.importTdr(tdrmanifest, 'tdrexport', { tdrSyncPermissions: tdrSyncPermissions === 'true' });
+      //   asyncImportJobStore.update(Utils.append({ targetWorkspace: { namespace, name }, jobId }));
+      //   notifyDataImportProgress(jobId);
+      // };
+    }
     return async () => {
       const { jobId } = await Ajax()
         .Workspaces.workspace(namespace, name)
@@ -443,13 +454,16 @@ const ImportData = () => {
     Utils.withBusyState(setIsImporting),
     withErrorReporting('Import Error')
   )(async (workspace) => {
+    console.log(workspace); // eslint-disable-line no-console
+    console.log(tdrmanifest); // eslint-disable-line no-console
     const { namespace, name } = workspace;
+    const azureWorkspace = workspace.cloudPlatform === 'Azure';
 
     await Utils.switchCase(
       format,
       ['PFB', importPFB(namespace, name)],
       ['entitiesJson', importEntitiesJson(namespace, name)],
-      ['tdrexport', importTdrExport(namespace, name)],
+      ['tdrexport', importTdrExport(namespace, name, azureWorkspace)],
       ['snapshot', importSnapshot(namespace, name)],
       ['catalog', exportCatalog(workspace.workspaceId)],
       [


### PR DESCRIPTION
### Jira Ticket: [AJ-1012](https://broadworkbench.atlassian.net/browse/AJ-1012)

For azure workspaces, find and call the appropriate wds app when importing from TDR instead of calling rawls.  This only works for format `tdrexport` and pre-existing azure workspaces.  If you select the 'create a new workspace' option, WDS will not be booted up in time to receive the import request.   This is expected to be available in later iterations when the tdr import API is asynchronous.

[AJ-1012]: https://broadworkbench.atlassian.net/browse/AJ-1012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ