### PR TITLE
AJ-720 remove hardcoding of Azure region

### DIFF
--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -35,7 +35,7 @@ import ReferenceData from 'src/data/reference-data';
 import { Ajax } from 'src/libs/ajax';
 import { canUseWorkspaceProject } from 'src/libs/ajax/Billing';
 import { wdsProviderName } from 'src/libs/ajax/data-table-providers/WdsDataTableProvider';
-import { defaultAzureRegion, getRegionLabel } from 'src/libs/azure-utils';
+import { getRegionLabel } from 'src/libs/azure-utils';
 import colors from 'src/libs/colors';
 import { reportError } from 'src/libs/error';
 import Events from 'src/libs/events';
@@ -364,7 +364,7 @@ export const notifyDataImportProgress = (jobId, message) => {
   });
 };
 
-export const EntityUploader = ({ onSuccess, onDismiss, namespace, name, entityTypes, workspaceId, dataProvider, isGoogleWorkspace }) => {
+export const EntityUploader = ({ onSuccess, onDismiss, namespace, name, entityTypes, workspaceId, dataProvider, isGoogleWorkspace, region }) => {
   const [useFireCloudDataModel, setUseFireCloudDataModel] = useState(false);
   const [isFileImportCurrMode, setIsFileImportCurrMode] = useState(true);
   const [isFileImportLastUsedMode, setIsFileImportLastUsedMode] = useState(undefined);
@@ -378,7 +378,8 @@ export const EntityUploader = ({ onSuccess, onDismiss, namespace, name, entityTy
 
   // TODO: https://broadworkbench.atlassian.net/browse/WOR-614
   // This value is mostly hard-coded for now for Azure public preview. Once WOR-614 is complete, this value can be dynamically updated
-  const regionLabelToDisplay = isGoogleWorkspace ? 'US' : getRegionLabel(defaultAzureRegion);
+  // const regionLabelToDisplay = isGoogleWorkspace ? 'US' : getRegionLabel(defaultAzureRegion);
+  const regionLabelToDisplay = isGoogleWorkspace ? 'US' : getRegionLabel(region);
 
   const doUpload = async () => {
     setUploading(true);

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -35,7 +35,7 @@ import ReferenceData from 'src/data/reference-data';
 import { Ajax } from 'src/libs/ajax';
 import { canUseWorkspaceProject } from 'src/libs/ajax/Billing';
 import { wdsProviderName } from 'src/libs/ajax/data-table-providers/WdsDataTableProvider';
-import { getRegionLabel } from 'src/libs/azure-utils';
+import { getRegionFlag, getRegionLabel } from 'src/libs/azure-utils';
 import colors from 'src/libs/colors';
 import { reportError } from 'src/libs/error';
 import Events from 'src/libs/events';
@@ -376,10 +376,8 @@ export const EntityUploader = ({ onSuccess, onDismiss, namespace, name, entityTy
   const [recordType, setRecordType] = useState(undefined);
   const [recordTypeInputTouched, setRecordTypeInputTouched] = useState(false);
 
-  // TODO: https://broadworkbench.atlassian.net/browse/WOR-614
-  // This value is mostly hard-coded for now for Azure public preview. Once WOR-614 is complete, this value can be dynamically updated
-  // const regionLabelToDisplay = isGoogleWorkspace ? 'US' : getRegionLabel(defaultAzureRegion);
   const regionLabelToDisplay = isGoogleWorkspace ? 'US' : getRegionLabel(region);
+  const regionFlagToDisplay = isGoogleWorkspace ? '🇺🇸' : getRegionFlag(region);
 
   const doUpload = async () => {
     setUploading(true);
@@ -466,7 +464,12 @@ export const EntityUploader = ({ onSuccess, onDismiss, namespace, name, entityTy
                       },
                       ['Click here for more info on the table.']
                     ),
-                  p(['Data will be saved in location: 🇺🇸  ', span({ style: { fontWeight: 'bold' } }, regionLabelToDisplay), ' (Terra-managed).']),
+                  p([
+                    'Data will be saved in location:  ',
+                    regionFlagToDisplay,
+                    span({ style: { fontWeight: 'bold' } }, regionLabelToDisplay),
+                    ' (Terra-managed).',
+                  ]),
                 ]),
                 dataProvider.tsvFeatures.needsTypeInput &&
                   div({ style: { paddingTop: '0.1rem', paddingBottom: '2rem' } }, [

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -376,6 +376,7 @@ export const EntityUploader = ({ onSuccess, onDismiss, namespace, name, entityTy
   const [recordType, setRecordType] = useState(undefined);
   const [recordTypeInputTouched, setRecordTypeInputTouched] = useState(false);
 
+  // Google workspace regions are hardcoded for now, as GCP uploads to the Rawls service which is only on uscentral-1
   const regionLabelToDisplay = isGoogleWorkspace ? 'US' : getRegionLabel(region);
   const regionFlagToDisplay = isGoogleWorkspace ? '🇺🇸' : getRegionFlag(region);
 

--- a/src/libs/azure-utils.js
+++ b/src/libs/azure-utils.js
@@ -1,4 +1,5 @@
 import _ from 'lodash/fp';
+import * as Utils from 'src/libs/utils';
 import { defaultAutopauseThreshold } from 'src/pages/workspaces/workspace/analysis/utils/runtime-utils';
 
 // AZURE REGIONS, COMPUTE TYPES, STORAGE TYPES AND PRICING
@@ -95,8 +96,10 @@ const azureRegions = {
   uaecentral: { flag: '', label: 'UAE Central' },
   brazilsoutheast: { flag: '', label: 'Brazil Southeast' },
 };
-export const getRegionLabel = (key) => (_.has(key, azureRegions) ? azureRegions[key].label : 'Unknown azure region');
-export const getRegionFlag = (key) => (_.has(key, azureRegions) ? azureRegions[key].flag : '❓');
+
+export const getRegionLabel = (key) =>
+  Utils.cond([!key, () => 'Loading'], [_.has(key, azureRegions), () => azureRegions[key].label], () => 'Unknown azure region');
+export const getRegionFlag = (key) => Utils.cond([!key, () => ''], [_.has(key, azureRegions), () => azureRegions[key].flag], () => '❓');
 
 export const azureMachineTypes = {
   Standard_DS2_v2: { cpu: 2, ramInGb: 7 },

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -656,7 +656,7 @@ const WorkspaceData = _.flow(
     const asyncImportJobs = useStore(asyncImportJobStore);
 
     const entityServiceDataTableProvider = new EntityServiceDataTableProvider(namespace, name);
-    const region = isAzureWorkspace ? storageDetails.azureContainerRegion : storageDetails.googleBucketLocation;
+    const region = isAzureWorkspace ? storageDetails?.azureContainerRegion : storageDetails?.googleBucketLocation;
 
     const wdsDataTableProvider = useMemo(() => {
       const proxyUrl = !!wdsProxyUrl && wdsProxyUrl.state;

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -656,7 +656,7 @@ const WorkspaceData = _.flow(
     const asyncImportJobs = useStore(asyncImportJobStore);
 
     const entityServiceDataTableProvider = new EntityServiceDataTableProvider(namespace, name);
-    const region = isAzureWorkspace ? storageDetails?.azureContainerRegion : storageDetails?.googleBucketLocation;
+    const region = isAzureWorkspace ? storageDetails.azureContainerRegion : storageDetails.googleBucketLocation;
 
     const wdsDataTableProvider = useMemo(() => {
       const proxyUrl = !!wdsProxyUrl && wdsProxyUrl.state;

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -619,6 +619,7 @@ const WorkspaceData = _.flow(
         workspace: { googleProject, attributes, workspaceId },
       },
       refreshWorkspace,
+      storageDetails,
     },
     ref
   ) => {
@@ -655,6 +656,7 @@ const WorkspaceData = _.flow(
     const asyncImportJobs = useStore(asyncImportJobStore);
 
     const entityServiceDataTableProvider = new EntityServiceDataTableProvider(namespace, name);
+    const region = isAzureWorkspace ? storageDetails.azureContainerRegion : storageDetails.googleBucketLocation;
 
     const wdsDataTableProvider = useMemo(() => {
       const proxyUrl = !!wdsProxyUrl && wdsProxyUrl.state;
@@ -1320,6 +1322,7 @@ const WorkspaceData = _.flow(
                       entityTypes: _.keys(entityMetadata),
                       dataProvider: entityServiceDataTableProvider,
                       isGoogleWorkspace,
+                      region,
                     }),
                   uploadingWDSFile &&
                     h(EntityUploader, {
@@ -1338,6 +1341,7 @@ const WorkspaceData = _.flow(
                       entityTypes: wdsTypes.state.map((item) => item.name),
                       dataProvider: wdsDataTableProvider,
                       isGoogleWorkspace,
+                      region,
                     }),
                   isGoogleWorkspace &&
                     h(


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/AJ-720

The region displayed when uploading a TSV was previously hardcoded for Azure.  No matter what region the MRG was in, '🇺🇸 East US' would be displayed in the upload modal, although the 'Cloud Information' on the dashboard displayed the correct region.
This PR checks for the actual region and uses that to determine what to display.  Google workspaces are left hardcoded as before.

(Images taken from same workspace)
Before this PR:
![image](https://github.com/DataBiosphere/terra-ui/assets/5884792/c7865df2-3184-4db5-8a2a-b79fff2c9c06)


After this PR:
![image](https://github.com/DataBiosphere/terra-ui/assets/5884792/2213d2b8-8349-475a-a049-1eb57dc73887)
