### PR TITLE
[IA-4370] Fixed key for compute config

### DIFF
--- a/src/pages/workspaces/workspace/analysis/modals/persistent-disk-controls.test.ts
+++ b/src/pages/workspaces/workspace/analysis/modals/persistent-disk-controls.test.ts
@@ -109,7 +109,7 @@ describe('compute-modal-component', () => {
       await userEvent.click(dTypeNew);
 
       // Assert
-      expect(updateComputeConfigMock).toBeCalledWith('persistentDiskType', {
+      expect(updateComputeConfigMock).toBeCalledWith('diskType', {
         displayName: 'Balanced',
         label: 'pd-balanced',
         regionToPricesName: 'monthlyBalancedDiskPrice',
@@ -178,7 +178,7 @@ describe('compute-modal-component', () => {
       await userEvent.click(dTypeNew);
 
       // Assert
-      expect(updateComputeConfigMock).toBeCalledWith('persistentDiskType', {
+      expect(updateComputeConfigMock).toBeCalledWith('diskType', {
         displayName: 'Balanced',
         label: 'pd-balanced',
         regionToPricesName: 'monthlyBalancedDiskPrice',

--- a/src/pages/workspaces/workspace/analysis/modals/persistent-disk-controls.ts
+++ b/src/pages/workspaces/workspace/analysis/modals/persistent-disk-controls.ts
@@ -90,7 +90,7 @@ export const PersistentDiskType = (props: PersistentDiskTypeProps) => {
         id: persistentDiskId,
         value: computeConfig.diskType,
         isDisabled: persistentDiskExists,
-        onChange: (e) => updateComputeConfig('persistentDiskType', e?.value),
+        onChange: (e) => updateComputeConfig('diskType', e?.value),
         menuPlacement: 'auto',
         options: [
           { label: pdTypes.standard.displayName, value: pdTypes.standard },


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/IA-4370

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- The key for compute config was incorrect in the persistent-disk-controls file. Design wise, this is incorrect, and will be fixed in https://github.com/DataBiosphere/terra-ui/pull/3921 where we better separate concerns.

### Why
- So users can select a disk type.

### Testing strategy
- [ ] go to a GCP workspace, try to make a jupyterlab instance, select a different disk type. <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 
