### PR TITLE
WM-1988: No new azure workspaces on import page

### DIFF
--- a/src/components/NewWorkspaceModal.js
+++ b/src/components/NewWorkspaceModal.js
@@ -63,9 +63,10 @@ const ariaInvalidBillingAccountMsg = (invalidBillingAccount) => {
 
 const NewWorkspaceModal = withDisplayName(
   'NewWorkspaceModal',
-  ({ cloneWorkspace, onSuccess, onDismiss, customMessage, requiredAuthDomain, title, buttonText }) => {
+  ({ cloneWorkspace, onSuccess, onDismiss, customMessage, requiredAuthDomain, title, buttonText, workflowImport }) => {
     // State
     const [billingProjects, setBillingProjects] = useState();
+    const [azureBillingProjectsExist, setAzureBillingProjectsExist] = useState(false);
     const [allGroups, setAllGroups] = useState();
     const [name, setName] = useState(cloneWorkspace ? `${cloneWorkspace.workspace.name} copy` : '');
     const [namespace, setNamespace] = useState(cloneWorkspace ? cloneWorkspace.workspace.namespace : undefined);
@@ -149,6 +150,13 @@ const NewWorkspaceModal = withDisplayName(
         Ajax(signal)
           .Billing.listProjects()
           .then(_.filter({ status: 'Ready' }))
+          .then(
+            _.forEach((project) => {
+              if (isAzureBillingProject(project)) {
+                setAzureBillingProjectsExist(true);
+              }
+            })
+          )
           .then(_.filter((project) => isBillingProjectApplicable(project)))
           .then((projects) => {
             setBillingProjects(projects);
@@ -189,6 +197,7 @@ const NewWorkspaceModal = withDisplayName(
       // Only support cloning a workspace to the same cloud environment. If this changes, also update
       // the Events.workspaceClone event data.
       return Utils.cond(
+        [!!workflowImport, () => !isAzureBillingProject(project)],
         [!!cloneWorkspace && isAzureWorkspace(cloneWorkspace), () => isAzureBillingProject(project)],
         [!!cloneWorkspace && isGoogleWorkspace(cloneWorkspace), () => isGoogleBillingProject(project)],
         [Utils.DEFAULT, () => true]
@@ -409,6 +418,22 @@ const NewWorkspaceModal = withDisplayName(
                     ]),
                 ]),
               customMessage && div({ style: { marginTop: '1rem', lineHeight: '1.5rem' } }, [customMessage]),
+              workflowImport &&
+                azureBillingProjectsExist &&
+                div({ style: { paddingTop: '1.0rem', display: 'flex' } }, [
+                  icon('info-circle', { size: 16, style: { marginRight: '0.5rem', color: colors.accent() } }),
+                  div([
+                    'Importing directly into new Azure workspaces is not currently supported. To create a new workspace with an Azure billing project, visit the main ',
+                    h(
+                      Link,
+                      {
+                        href: Nav.getLink('workspaces'),
+                      },
+                      ['Workspaces']
+                    ),
+                    ' page.',
+                  ]),
+                ]),
               isAzureBillingProject() &&
                 div({ style: { paddingTop: '1.0rem', display: 'flex' } }, [
                   icon('warning-standard', { size: 16, style: { marginRight: '0.5rem', color: colors.warning() } }),

--- a/src/components/NewWorkspaceModal.test.js
+++ b/src/components/NewWorkspaceModal.test.js
@@ -1,0 +1,176 @@
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { h } from 'react-hyperscript-helpers';
+import { mockModalModule } from 'src/components/Modal.mock';
+import { Ajax } from 'src/libs/ajax';
+
+import NewWorkspaceModal from './NewWorkspaceModal';
+
+jest.mock('src/components/Modal', () => {
+  return mockModalModule();
+});
+
+jest.mock('src/libs/ajax');
+
+jest.mock('src/libs/nav', () => ({
+  ...jest.requireActual('src/libs/nav'),
+  getLink: jest.fn().mockReturnValue(''),
+}));
+
+const gcpBillingProject = {
+  billingAccount: 'billingAccounts/FOO-BAR-BAZ',
+  cloudPlatform: 'GCP',
+  invalidBillingAccount: false,
+  projectName: 'Google Billing Project',
+  roles: ['Owner'],
+  status: 'Ready',
+};
+
+const azureBillingProject = {
+  billingAccount: 'billingAccounts/BAA-RAM-EWE',
+  cloudPlatform: 'AZURE',
+  invalidBillingAccount: false,
+  projectName: 'Azure Billing Project',
+  roles: ['Owner'],
+  status: 'Ready',
+};
+
+const nonBillingAjax = {
+  Groups: {
+    list: async () => {
+      return [];
+    },
+    group: (_groupName) => {
+      return {
+        isMember: async () => {
+          return true;
+        },
+      };
+    },
+  },
+  Metrics: {
+    captureEvent: async (_name, _details) => {
+      // Do nothing
+    },
+  },
+};
+
+describe('NewWorkspaceModal', () => {
+  it('Shows all available billing projects by default', async () => {
+    // Arrange
+    const user = userEvent.setup();
+
+    Ajax.mockImplementation(() => ({
+      Billing: {
+        listProjects: async () => [gcpBillingProject, azureBillingProject],
+      },
+      ...nonBillingAjax,
+    }));
+
+    await act(async () => {
+      // eslint-disable-line require-await
+      render(
+        h(NewWorkspaceModal, {
+          cloneWorkspace: false,
+          onSuccess: () => null,
+          onDismiss: () => null,
+          customMessage: null,
+          requiredAuthDomain: false,
+          title: null,
+          buttonText: null,
+          // workflowImport: false <== Not specified. False should be the default
+        })
+      );
+    });
+
+    const projectSelector = screen.getByText('Select a billing project');
+    await user.click(projectSelector);
+
+    // Assert
+    // getByText throws an error if the element is not found:
+    screen.getByText('Google Billing Project');
+    screen.getByText('Azure Billing Project');
+    // queryByText returns null if the element is not found:
+    expect(screen.queryByText('Importing directly into new Azure workspaces is not currently supported.')).toBeNull();
+  });
+
+  it('Hides azure billing projects if part of workflow import', async () => {
+    // Arrange
+    const user = userEvent.setup();
+
+    Ajax.mockImplementation(() => ({
+      Billing: {
+        listProjects: async () => [gcpBillingProject, azureBillingProject],
+      },
+      ...nonBillingAjax,
+    }));
+
+    await act(async () => {
+      // eslint-disable-line require-await
+      render(
+        h(NewWorkspaceModal, {
+          cloneWorkspace: false,
+          onSuccess: () => null,
+          onDismiss: () => null,
+          customMessage: null,
+          requiredAuthDomain: false,
+          title: null,
+          buttonText: null,
+          workflowImport: true,
+        })
+      );
+    });
+
+    const projectSelector = screen.getByText('Select a billing project');
+    await user.click(projectSelector);
+
+    // Assert
+    screen.getByText('Google Billing Project');
+    expect(screen.queryByText('Azure Billing Project')).toBeNull();
+    screen.getByText(
+      'Importing directly into new Azure workspaces is not currently supported. To create a new workspace with an Azure billing project, visit the main',
+      { exact: false }
+    );
+  });
+
+  it('Does not warn about no Azure support if no billing projects were hidden', async () => {
+    // Arrange
+    const user = userEvent.setup();
+
+    Ajax.mockImplementation(() => ({
+      Billing: {
+        listProjects: async () => [gcpBillingProject],
+      },
+      ...nonBillingAjax,
+    }));
+
+    await act(async () => {
+      // eslint-disable-line require-await
+      render(
+        h(NewWorkspaceModal, {
+          cloneWorkspace: false,
+          onSuccess: () => null,
+          onDismiss: () => null,
+          customMessage: null,
+          requiredAuthDomain: false,
+          title: null,
+          buttonText: null,
+          workflowImport: true,
+        })
+      );
+    });
+
+    const projectSelector = screen.getByText('Select a billing project');
+    await user.click(projectSelector);
+
+    // Assert
+    screen.getByText('Google Billing Project');
+    expect(screen.queryByText('Azure Billing Project')).toBeNull();
+    expect(
+      screen.queryByText(
+        'Importing directly into new Azure workspaces is not currently supported. To create a new workspace with an Azure billing project, visit the main',
+        { exact: false }
+      )
+    ).toBeNull();
+  });
+});

--- a/src/pages/ImportWorkflow/WorkspaceImporter.ts
+++ b/src/pages/ImportWorkflow/WorkspaceImporter.ts
@@ -86,6 +86,7 @@ export const WorkspaceImporter: (props: WorkspaceImporterInnerProps) => ReactEle
       creatingWorkspace &&
         h(NewWorkspaceModal, {
           requiredAuthDomain: ad,
+          workflowImport: true,
           onDismiss: () => setCreatingWorkspace(false),
           onSuccess: (w) => {
             setCreatingWorkspace(false);


### PR DESCRIPTION
When importing a workflow, (and ONLY when importing a workflow), do not show Azure billing projects as options to create a new workspace.

![image](https://github.com/DataBiosphere/terra-ui/assets/13006282/35ce9172-8d77-44ee-8341-a563f4dd0626)

To reach this modal in a testing environment you'll want to manually open an appropriate path in Terra UI. In deployed Terra, dockstore will generate these link to the appropriate paths in the appropriate environment. For example, navigating to `#import-workflow/dockstore/github.com/broadinstitute/warp/WholeGenomeGermlineSingleSample:WholeGenomeGermlineSingleSample_v3.1.10` will load a page to import the whole genome germline single sample workflow from the WARP project.