### PR TITLE
[DDO-2892] Run the BEE NGINX on port 8080, not 80

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ COPY --from=0 /terra-ui/build /usr/share/nginx/html
 COPY nginx-bees.conf /etc/nginx/conf.d
 
 # App port forwarding.
-EXPOSE 80
+EXPOSE 8080

--- a/nginx-bees.conf
+++ b/nginx-bees.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80;
+    listen 8080;
 
     access_log /var/log/nginx/access.log;
 


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/DDO-2892

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

Needed for https://github.com/broadinstitute/terra-helmfile/pull/4273

## Summary of changes:

### What
- Run on port 8080 instead of port 80 in BEEs only, check the changed files

### Why
- GCP requiring us to move our Kubernetes clusters from `docker` runtime to `containerd`. `containerd` runtime doesn't allow [nonroot users](https://github.com/broadinstitute/dsp-appsec-blessed-images/blob/main/nginx/Dockerfile.mainline-alpine#L5) to bind to port 80 or 443 etc (as in, `containerd` correctly enforces the "root can't bind to those ports" rule). https://github.com/containerd/containerd/issues/2516

### Testing strategy
- [x] It ran in Chelsea's BEE https://ap-argocd.dsp-devops.broadinstitute.org/applications/ap-argocd/terraui-choover?view=tree&resource=

