### PR TITLE
ID-646 Inject TERRA_DEPLOYMENT_ENV into jupyter notebooks

### DIFF
--- a/config/alpha.json
+++ b/config/alpha.json
@@ -31,5 +31,6 @@
   "alphaRegionalityGroup": "Alpha_Regionality_Users",
   "terraDockerVersionsFile": "terra-docker-versions-alpha.json",
   "terraDockerImageBucket": "terra-docker-image-documentation-alpha",
-  "b2cBillingPolicy": "b2c_1a_signup_signin_billing_alpha"
+  "b2cBillingPolicy": "b2c_1a_signup_signin_billing_alpha",
+  "terraDeploymentEnv": "alpha"
 }

--- a/config/dev.json
+++ b/config/dev.json
@@ -31,5 +31,6 @@
   "alphaRegionalityGroup": "Alpha_Regionality_Users",
   "terraDockerVersionsFile": "terra-docker-versions-dev.json",
   "terraDockerImageBucket": "terra-docker-image-documentation-dev",
-  "b2cBillingPolicy": "b2c_1a_signup_signin_billing_dev"
+  "b2cBillingPolicy": "b2c_1a_signup_signin_billing_dev",
+  "terraDeploymentEnv": "dev"
 }

--- a/config/prod.json
+++ b/config/prod.json
@@ -29,5 +29,6 @@
   "alphaRegionalityGroup": "Alpha_Regionality_Users",
   "terraDockerVersionsFile": "terra-docker-versions-prod.json",
   "terraDockerImageBucket": "terra-docker-image-documentation-prod",
-  "b2cBillingPolicy": "b2c_1a_signup_signin_billing_prod"
+  "b2cBillingPolicy": "b2c_1a_signup_signin_billing_prod",
+  "terraDeploymentEnv": "prod"
 }

--- a/config/staging.json
+++ b/config/staging.json
@@ -30,5 +30,6 @@
   "alphaRegionalityGroup": "Alpha_Regionality_Users",
   "terraDockerVersionsFile": "terra-docker-versions-staging.json",
   "terraDockerImageBucket": "terra-docker-image-documentation-staging",
-  "b2cBillingPolicy": "b2c_1a_signup_signin_billing_staging"
+  "b2cBillingPolicy": "b2c_1a_signup_signin_billing_staging",
+  "terraDeploymentEnv": "staging"
 }

--- a/src/pages/workspaces/workspace/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal.js
+++ b/src/pages/workspaces/workspace/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal.js
@@ -309,6 +309,7 @@ export const GcpComputeModalBase = ({
     const shouldCreateRuntime = !canUpdateRuntime() && !!desiredRuntime;
     const { namespace, name, bucketName, googleProject } = getWorkspaceObject();
     const desiredToolLabel = getToolLabelFromCloudEnv(desiredRuntime);
+    const terraDeploymentEnv = getConfig().terraDeploymentEnv;
 
     const customEnvVars = {
       WORKSPACE_NAME: name,
@@ -316,6 +317,7 @@ export const GcpComputeModalBase = ({
       WORKSPACE_BUCKET: `gs://${bucketName}`,
       GOOGLE_PROJECT: googleProject,
       CUSTOM_IMAGE: isCustomImage.toString(),
+      ...(!!terraDeploymentEnv && { TERRA_DEPLOYMENT_ENV: terraDeploymentEnv }),
     };
 
     sendCloudEnvironmentMetrics();

--- a/src/pages/workspaces/workspace/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal.test.js
+++ b/src/pages/workspaces/workspace/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal.test.js
@@ -47,6 +47,11 @@ jest.mock('src/libs/notifications', () => ({
 
 jest.mock('src/libs/ajax');
 jest.mock('src/pages/workspaces/workspace/analysis/utils/cost-utils');
+jest.mock('src/libs/config', () => ({
+  getConfig: () => ({
+    terraDeploymentEnv: 'unitTest',
+  }),
+}));
 
 const onSuccess = jest.fn();
 const defaultModalProps = {
@@ -106,6 +111,38 @@ describe('GcpComputeModal', () => {
     // Assert
     verifyEnabled(getCreateButton());
     screen.getByText('Jupyter Cloud Environment');
+  });
+
+  it('passes the TERRA_DEPLOYMENT_ENV env var through to the notebook through custom env vars', async () => {
+    // Arrange
+    const createFunc = jest.fn();
+    const runtimeFunc = jest.fn(() => ({
+      create: createFunc,
+      details: jest.fn(),
+    }));
+    Ajax.mockImplementation(() => ({
+      ...defaultAjaxImpl,
+      Runtimes: {
+        runtime: runtimeFunc,
+      },
+    }));
+
+    // Act
+    await act(async () => {
+      await render(h(GcpComputeModalBase, defaultModalProps));
+      await userEvent.click(getCreateButton());
+    });
+
+    // Assert
+    expect(runtimeFunc).toHaveBeenCalledWith(defaultModalProps.workspace.workspace.googleProject, expect.anything());
+    expect(createFunc).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customEnvironmentVariables: expect.objectContaining({
+          TERRA_DEPLOYMENT_ENV: 'unitTest',
+        }),
+      })
+    );
+    expect(onSuccess).toHaveBeenCalled();
   });
 
   it('sends the proper leo API call in default create case (no runtimes or disks)', async () => {


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/ID-646

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Inject a TERRA_DEPLOYMENT_ENV env var into Jupyter notebooks

### Why
- So that TNU can talk to the correct instance of Bond, DRSHub/Martha, and Rawls

### Testing strategy
- a unit test has been written
- one deployed to dev, make sure `TERRA_DEPLOYMENT_ENV=dev` is passed into a jupyter notebook

<!-- ### Visual Aids -->
![image](https://github.com/DataBiosphere/terra-ui/assets/3210510/90f265b5-f4ca-4c40-8959-c99a53c3f42f)

<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 
