### PR TITLE
[IA-4378] Updated the azureDiskSizes

### DIFF
--- a/src/libs/ajax/leonardo/models/disk-models.ts
+++ b/src/libs/ajax/leonardo/models/disk-models.ts
@@ -124,7 +124,7 @@ export interface AzurePdSelectOption {
   label: string;
 }
 
-export const azureDiskSizes: number[] = [32, 64, 128, 256, 512, 1024, 2048, 4096, 8192];
+export const azureDiskSizes: number[] = [32, 64, 128, 256, 512, 1024, 2048, 4095];
 
 export const isUndecoratedPersistentDisk = (disk: PersistentDisk | DecoratedPersistentDisk): disk is PersistentDisk =>
   typeof disk === 'string' && Object.values(googlePdTypes).map((pdt) => pdt.value) === disk;


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/IA-4378

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Remove the problematic disk sizes for Azure with our current implementation of the API request to Azure.

### Why
- Disk sizes above a certain size are unable to cache. 4095 is the largest size that is compatible.

### Testing strategy
- [ ] Create a VM with 4095 as the disk size and verify the runtime starts. <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 
