### PR TITLE
[DDO-2892] Remove default nginx config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,11 @@ COPY . /terra-ui/
 RUN cd /terra-ui && yarn build
 
 FROM us.gcr.io/broad-dsp-gcr-public/base/nginx:stable-alpine
-COPY --from=0 /terra-ui/build /usr/share/nginx/html
+
+RUN rm /etc/nginx/conf.d/default.conf
 COPY nginx-bees.conf /etc/nginx/conf.d
+
+COPY --from=0 /terra-ui/build /usr/share/nginx/html
 
 # App port forwarding.
 EXPOSE 8080


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/DDO-2892

## Summary of changes:

### What
- Remove the nginx container's default config during the docker build

### Why
- It now conflicts with Terra UI running on port 8080, after #3958 

### Testing strategy
- I was able to sign in with my account on Chelsea's BEE https://terra.choover.bee.envs-terra.bio/

