### PR TITLE
[PROD-835] Interactive Analysis hotfix release 20230906 Keep disk size input enabled on GCP 

### DIFF
--- a/src/pages/workspaces/workspace/analysis/modals/ComputeModal/GcpComputeModal/GcpPersistentDiskSection.test.ts
+++ b/src/pages/workspaces/workspace/analysis/modals/ComputeModal/GcpComputeModal/GcpPersistentDiskSection.test.ts
@@ -63,7 +63,7 @@ describe('GcpPersistentDiskSection', () => {
     });
   });
 
-  it('should be disabled when persistentDiskExists is true', () => {
+  it('should not be disabled when persistentDiskExists is true', () => {
     // Arrange
     render(
       h(GcpPersistentDiskSection, {
@@ -75,6 +75,6 @@ describe('GcpPersistentDiskSection', () => {
     // Assert
     expect(screen.getByLabelText('Disk Type')).toBeDisabled();
     expect(screen.getByText('Standard')).toBeTruthy();
-    expect(screen.getByLabelText('Disk Size (GB)')).toBeDisabled();
+    expect(screen.getByLabelText('Disk Size (GB)')).toBeEnabled();
   });
 });

--- a/src/pages/workspaces/workspace/analysis/modals/ComputeModal/GcpComputeModal/GcpPersistentDiskSection.ts
+++ b/src/pages/workspaces/workspace/analysis/modals/ComputeModal/GcpComputeModal/GcpPersistentDiskSection.ts
@@ -40,7 +40,8 @@ export const GcpPersistentDiskSection: React.FC<GcpPersistentDiskSectionProps> =
       }),
       GcpPersistentDiskSizeNumberInput({
         persistentDiskSize,
-        isDisabled: persistentDiskExists,
+        // GCP disk size may be updated after creation
+        isDisabled: false,
         onChangePersistentDiskSize,
       }),
     ]),


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/IA-4383

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Keep GCP disk size (and type??) inputs enabled even when disk exists.

### Why
- GCP disks should be editable after creation; the inputs are disabled currently.

### Testing strategy
- Given a GCP runtime
- Open the Compute Modal and change disk size (and type??)
- Save changes to environment
- Verify changes to disk size (and type??) persist

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 
