### PR TITLE
AJ-1113: reduce payload size of workspace list

### DIFF
--- a/src/components/workspace-utils.js
+++ b/src/components/workspace-utils.js
@@ -44,21 +44,22 @@ export const useWorkspaces = () => {
     withErrorReporting('Error loading workspace list'),
     Utils.withBusyState(setLoading)
   )(async () => {
-    const ws = await ajax(signal).Workspaces.list([
-      'accessLevel',
-      'public',
-      'workspace.attributes.description',
-      'workspace.attributes.tag:tags',
-      'workspace.authorizationDomain',
-      'workspace.cloudPlatform',
-      'workspace.createdBy',
-      // 'workspace.isLocked', // do we actually need this?
-      'workspace.lastModified',
-      'workspace.name',
-      'workspace.namespace',
-      'workspace.workspaceId',
-      // 'workspace.workspaceVersion', // do we actually need this?
-    ]);
+    const ws = await ajax(signal).Workspaces.list(
+      [
+        'accessLevel',
+        'public',
+        'workspace.attributes.description',
+        'workspace.attributes.tag:tags',
+        'workspace.authorizationDomain',
+        'workspace.cloudPlatform',
+        'workspace.createdBy',
+        'workspace.lastModified',
+        'workspace.name',
+        'workspace.namespace',
+        'workspace.workspaceId',
+      ],
+      250
+    );
     workspacesStore.set(ws);
   });
   useOnMount(() => {

--- a/src/components/workspace-utils.js
+++ b/src/components/workspace-utils.js
@@ -35,31 +35,26 @@ import * as Utils from 'src/libs/utils';
 import { getCloudProviderFromWorkspace } from 'src/libs/workspace-utils';
 import validate from 'validate.js';
 
-export const useWorkspaces = () => {
+export const useWorkspaces = (fieldsArg, stringAttributeMaxLength) => {
   const signal = useCancellation();
   const [loading, setLoading] = useState(false);
   const workspaces = useStore(workspacesStore);
   const ajax = useReplaceableAjaxExperimental();
+
+  const fields = fieldsArg || [
+    'accessLevel',
+    'public',
+    'workspace',
+    'workspace.attributes.description',
+    'workspace.attributes.tag:tags',
+    'workspace.workspaceVersion',
+  ];
+
   const refresh = _.flow(
     withErrorReporting('Error loading workspace list'),
     Utils.withBusyState(setLoading)
   )(async () => {
-    const ws = await ajax(signal).Workspaces.list(
-      [
-        'accessLevel',
-        'public',
-        'workspace.attributes.description',
-        'workspace.attributes.tag:tags',
-        'workspace.authorizationDomain',
-        'workspace.cloudPlatform',
-        'workspace.createdBy',
-        'workspace.lastModified',
-        'workspace.name',
-        'workspace.namespace',
-        'workspace.workspaceId',
-      ],
-      250
-    );
+    const ws = await ajax(signal).Workspaces.list(fields, stringAttributeMaxLength);
     workspacesStore.set(ws);
   });
   useOnMount(() => {

--- a/src/components/workspace-utils.js
+++ b/src/components/workspace-utils.js
@@ -47,10 +47,17 @@ export const useWorkspaces = () => {
     const ws = await ajax(signal).Workspaces.list([
       'accessLevel',
       'public',
-      'workspace',
       'workspace.attributes.description',
       'workspace.attributes.tag:tags',
-      'workspace.workspaceVersion',
+      'workspace.authorizationDomain',
+      'workspace.cloudPlatform',
+      'workspace.createdBy',
+      // 'workspace.isLocked', // do we actually need this?
+      'workspace.lastModified',
+      'workspace.name',
+      'workspace.namespace',
+      'workspace.workspaceId',
+      // 'workspace.workspaceVersion', // do we actually need this?
     ]);
     workspacesStore.set(ws);
   });

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -453,7 +453,7 @@ const CromIAM = (signal) => ({
 
 const Workspaces = (signal) => ({
   list: async (fields, stringAttributeMaxLength) => {
-    const lenParam = stringAttributeMaxLength ? `stringAttributeMaxLength=${stringAttributeMaxLength}&` : '';
+    const lenParam = _.isNil(stringAttributeMaxLength) ? '' : `stringAttributeMaxLength=${stringAttributeMaxLength}&`;
     const res = await fetchRawls(`workspaces?${lenParam}${qs.stringify({ fields }, { arrayFormat: 'comma' })}`, _.merge(authOpts(), { signal }));
     return res.json();
   },

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -452,8 +452,9 @@ const CromIAM = (signal) => ({
 });
 
 const Workspaces = (signal) => ({
-  list: async (fields) => {
-    const res = await fetchRawls(`workspaces?${qs.stringify({ fields }, { arrayFormat: 'comma' })}`, _.merge(authOpts(), { signal }));
+  list: async (fields, stringAttributeMaxLength) => {
+    const lenParam = stringAttributeMaxLength ? `stringAttributeMaxLength=${stringAttributeMaxLength}&` : '';
+    const res = await fetchRawls(`workspaces?${lenParam}${qs.stringify({ fields }, { arrayFormat: 'comma' })}`, _.merge(authOpts(), { signal }));
     return res.json();
   },
 

--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -59,7 +59,26 @@ const styles = {
 };
 
 const useWorkspacesWithSubmissionStats = () => {
-  const { workspaces, loading: loadingWorkspaces, refresh } = useWorkspaces();
+  const {
+    workspaces,
+    loading: loadingWorkspaces,
+    refresh,
+  } = useWorkspaces(
+    [
+      'accessLevel',
+      'public',
+      'workspace.attributes.description',
+      'workspace.attributes.tag:tags',
+      'workspace.authorizationDomain',
+      'workspace.cloudPlatform',
+      'workspace.createdBy',
+      'workspace.lastModified',
+      'workspace.name',
+      'workspace.namespace',
+      'workspace.workspaceId',
+    ],
+    250
+  );
 
   const signal = useCancellation();
   const [loadingSubmissionStats, setLoadingSubmissionStats] = useState(true);


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/AJ-1113

### Dependencies
See also https://github.com/broadinstitute/rawls/pull/2386, which is required to take full advantage of this PR.

## Summary of changes:
Significantly decrease size of the list-workspaces payload; this payload powers the de facto Terra UI "homepage"

### What

Changes in this PR:
1. Allow callers of `useWorkspaces()` to override the default values for the `fields` parameter and the hopefully-soon-to-be-released new `stringAttributeMaxLength` parameter.
2. For the workspace list page only, specify only those `fields` we actually need. Previously, we requested the entire `workspace` object, which included fields like `workspace.workflowCollectionName` and `workspace.completedCloneWorkspaceFileTransfer` which we completely ignored.
3. For the workspace list page only, specify the `stringAttributeMaxLength` query parameter to return only the first 250 characters of the workspace description. The list-workspaces UI, in practice, shows approximately 100 characters of each description. I expect this number is variable based on the end-user's screen size and font size and whatnot; 250 seemed like a safe limit.

Note that the second change - `stringAttributeMaxLength` - requires https://github.com/broadinstitute/rawls/pull/2386 to work.  This PR can merge before that other one; adding the extra query parameter is benign - but we won't see the effect until the Rawls PR releases.

My personal workspace list in production is large, as a result of gaining access to lots of workspaces as a project owner and via support. In conjunction with https://github.com/broadinstitute/rawls/pull/2386, here's how this PR affects payload size:

|                        | Current State | `fields` change only | `fields` and `stringAttributeMaxLength` |
| ------------- | ------------- | ------------- | ------------- |
| Uncompressed & Pretty-Printed  | 22.1 MB  | 21.6 MB | 2.4 MB |
| Compressed (ajax)  | 6.1 MB  | 5.8 MB| 387 KB |

_*Out of Scope*_
Not in this PR: changes to `fields` or `stringAttributeMaxLength` for any callers of `useWorkspaces()` other than the workspace list page. I notice, for instance, that some of the dropdown selectors for workspaces request the big `workspace.attributes.description` field when they don't need to. We should tweak that in future PRs!

### Why
… smaller payloads improve performance …

### Testing strategy
- [ ] tested locally

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 
