### PR TITLE
Replace mocked Azure integration test with unittests (WOR-1055).

### DIFF
--- a/integration-tests/tests/workspace-dashboard.js
+++ b/integration-tests/tests/workspace-dashboard.js
@@ -1,21 +1,9 @@
 // This test is owned by the Workspaces Team.
 const _ = require('lodash/fp');
 const { viewWorkspaceDashboard, withWorkspace } = require('../utils/integration-helpers');
-const {
-  assertNavChildNotFound,
-  assertTextNotFound,
-  click,
-  clickable,
-  findText,
-  gotoPage,
-  navChild,
-  verifyAccessibility,
-} = require('../utils/integration-utils');
+const { assertNavChildNotFound, click, clickable, findText, gotoPage, navChild, verifyAccessibility } = require('../utils/integration-utils');
 const { registerTest } = require('../utils/jest-utils');
 const { withUserToken } = require('../utils/terra-sa-utils');
-
-const azureWarning =
-  'Do not store Unclassified Confidential Information in this platform, as it violates US Federal Policy (ie FISMA, FIPS-199, etc) unless explicitly authorized by the dataset manager or governed by your own agreements.';
 
 const workspaceDashboardPage = (testPage, token, workspaceName) => {
   return {
@@ -32,20 +20,12 @@ const workspaceDashboardPage = (testPage, token, workspaceName) => {
       await Promise.all(_.map(async (item) => await findText(testPage, item), expectedTextItems));
     },
 
-    assertReadOnly: async () => {
-      await findText(testPage, 'Workspace is read only');
-    },
-
     assertTabs: async (expectedTabs, enabled) => {
       await Promise.all(
         _.map(async (tab) => {
           await (enabled ? testPage.waitForXPath(navChild(tab)) : assertNavChildNotFound(testPage, tab));
         }, expectedTabs)
       );
-    },
-
-    assertAzureWarning: async () => {
-      await testPage.waitForXPath(`//*[@role='alert']/*[contains(text(), "${azureWarning}")]`, { visible: true });
     },
   };
 };
@@ -90,164 +70,9 @@ const testGoogleWorkspace = _.flow(
 
   // Check accessibility.
   await verifyAccessibility(page);
-
-  // Verify that there is no Azure warning
-  await assertTextNotFound(azureWarning);
 });
 
 registerTest({
   name: 'google-workspace',
   fn: testGoogleWorkspace,
-});
-
-const setAzureAjaxMockValues = async (testPage, namespace, name, workspaceDescription) => {
-  const workspaceInfo = {
-    attributes: { description: workspaceDescription },
-    authorizationDomain: [],
-    bucketName: '',
-    cloudPlatform: 'Azure',
-    createdBy: 'dummy@email.com',
-    createdDate: '2022-04-12T18:12:25.912Z',
-    googleProject: '',
-    isLocked: false,
-    lastModified: '2022-04-12T18:12:26.199Z',
-    name,
-    namespace,
-    workspaceId: '95accxxx-4c68-4e60-9c2e-c0863af11xxx',
-    workspaceVersion: 'v2',
-  };
-  const azureWorkspacesListResult = [
-    {
-      accessLevel: 'READER',
-      public: false,
-      workspace: workspaceInfo,
-      workspaceSubmissionStats: { runningSubmissionsCount: 0 },
-    },
-  ];
-
-  const azureWorkspaceDetailsResult = {
-    azureContext: {
-      managedResourceGroupId: 'dummy-mrg-id',
-      subscriptionId: 'dummy-subscription-id',
-      tenantId: 'dummy-tenant-id',
-    },
-    workspaceSubmissionStats: { runningSubmissionsCount: 0 },
-    accessLevel: 'READER',
-    owners: ['dummy@email.comm'],
-    workspace: workspaceInfo,
-    canShare: false,
-    canCompute: false,
-  };
-
-  const azureWorkspaceResourcesResult = {
-    resources: [
-      {
-        metadata: {
-          resourceType: 'AZURE_STORAGE_CONTAINER',
-          controlledResourceMetadata: { accessScope: 'PRIVATE_ACCESS' },
-        },
-        resourceAttributes: { azureStorageContainer: { storageContainerName: 'private-sc-name' } },
-      },
-      {
-        metadata: {
-          resourceType: 'AZURE_STORAGE_CONTAINER',
-          controlledResourceMetadata: { accessScope: 'SHARED_ACCESS', region: 'eastus' },
-        },
-        resourceAttributes: { azureStorageContainer: { storageContainerName: 'sc-name' } },
-      },
-    ],
-  };
-
-  return await testPage.evaluate(
-    (azureWorkspacesListResult, azureWorkspaceDetailsResult, azureWorkspaceResourcesResult, namespace, name, workspaceId) => {
-      const detailsUrl = new RegExp(`api/workspaces/${namespace}/${name}[^/](.*)`, 'g');
-      const submissionsUrl = new RegExp(`api/workspaces/${namespace}/${name}/submissions(.*)`, 'g');
-      const tagsUrl = new RegExp(`api/workspaces/${namespace}/${name}/tags(.*)`, 'g');
-      const workspaceResourcesUrl = new RegExp(`api/workspaces/v1/${workspaceId}/resources(.*)`, 'g');
-      const workspaceSasTokenUrl = new RegExp(`api/workspaces/v1/${workspaceId}/resources/controlled/azure/storageContainer/(.*)/getSasToken`);
-
-      window.ajaxOverridesStore.set([
-        {
-          filter: { url: tagsUrl },
-          fn: () => () => Promise.resolve(new Response(JSON.stringify([]), { status: 200 })),
-        },
-        {
-          filter: { url: submissionsUrl },
-          fn: () => () => Promise.resolve(new Response(JSON.stringify([]), { status: 200 })),
-        },
-        {
-          filter: { url: detailsUrl },
-          fn: () => () => Promise.resolve(new Response(JSON.stringify(azureWorkspaceDetailsResult), { status: 200 })),
-        },
-        {
-          filter: { url: workspaceResourcesUrl },
-          fn: () => () => Promise.resolve(new Response(JSON.stringify(azureWorkspaceResourcesResult), { status: 200 })),
-        },
-        {
-          filter: { url: workspaceSasTokenUrl },
-          fn: () => () =>
-            Promise.resolve(
-              new Response(JSON.stringify({ sasToken: 'fake_token', url: 'http://storageContainerUrl.com?sasTokenParams' }), { status: 200 })
-            ),
-        },
-        {
-          filter: { url: /api\/workspaces[^/](.*)/ },
-          fn: () => () => Promise.resolve(new Response(JSON.stringify(azureWorkspacesListResult), { status: 200 })),
-        },
-        {
-          filter: { url: /api\/v2\/runtimes(.*)/ }, // Needed to prevent errors from the Runtime (IA) component that will be going away.
-          fn: () => () => Promise.resolve(new Response(JSON.stringify([]), { status: 200 })),
-        },
-      ]);
-    },
-    azureWorkspacesListResult,
-    azureWorkspaceDetailsResult,
-    azureWorkspaceResourcesResult,
-    namespace,
-    name,
-    workspaceInfo.workspaceId
-  );
-};
-
-const testAzureWorkspace = withUserToken(async ({ page, token, testUrl }) => {
-  const workspaceDescription = 'azure workspace description';
-  const workspaceName = 'azure-workspace';
-
-  // Must load page before setting mock responses.
-  await gotoPage(page, testUrl);
-  await findText(page, 'View Workspaces');
-  await setAzureAjaxMockValues(page, 'azure-workspace-ns', workspaceName, workspaceDescription);
-
-  const dashboard = workspaceDashboardPage(page, token, workspaceName);
-  await dashboard.visit();
-  await dashboard.assertDescription(workspaceDescription);
-
-  // Check cloud information
-  await dashboard.assertCloudInformation([
-    'Cloud NameMicrosoft Azure',
-    'Resource Group IDdummy-mrg-id',
-    'Storage Container URLhttp://storageContainerUrl.com',
-    'Location🇺🇸 East US',
-    'SAS URLhttp://storageContainerUrl.com?sasTokenParams',
-  ]);
-
-  // READER permissions only
-  await dashboard.assertReadOnly();
-
-  // Verify tabs that currently depend on Google project ID are not present.
-  await dashboard.assertTabs(['notebooks', 'workflows', 'job history'], false);
-
-  // Verify Analyses and Data tabs are present.
-  await dashboard.assertTabs(['analyses', 'data'], true);
-
-  // Check accessibility.
-  await verifyAccessibility(page);
-
-  // Verify Azure warning is visible
-  await dashboard.assertAzureWarning();
-});
-
-registerTest({
-  name: 'azure-workspace',
-  fn: testAzureWorkspace,
 });

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -222,6 +222,44 @@ export const BucketLocation = requesterPaysWrapper({ onDismiss: _.noop })(({ wor
   return h(TooltipCell, [flag, ' ', regionDescription]);
 });
 
+export const AzureStorageDetails = ({ azureContext, storageDetails }) => {
+  return h(Fragment, [
+    h(InfoRow, { title: 'Cloud Name' }, [h(AzureLogo, { title: 'Microsoft Azure', role: 'img', style: { height: 16 } })]),
+    h(InfoRow, { title: 'Location' }, [
+      h(
+        TooltipCell,
+        storageDetails.azureContainerRegion
+          ? [getRegionFlag(storageDetails.azureContainerRegion), ' ', getRegionLabel(storageDetails.azureContainerRegion)]
+          : ['Loading']
+      ),
+    ]),
+    h(InfoRow, { title: 'Resource Group ID' }, [
+      h(TooltipCell, [azureContext.managedResourceGroupId]),
+      h(ClipboardButton, {
+        'aria-label': 'Copy resource group id to clipboard',
+        text: azureContext.managedResourceGroupId,
+        style: { marginLeft: '0.25rem' },
+      }),
+    ]),
+    h(InfoRow, { title: 'Storage Container URL' }, [
+      h(TooltipCell, [storageDetails.azureContainerUrl ? storageDetails.azureContainerUrl : 'Loading']),
+      h(ClipboardButton, {
+        'aria-label': 'Copy storage container URL to clipboard',
+        text: storageDetails.azureContainerUrl,
+        style: { marginLeft: '0.25rem' },
+      }),
+    ]),
+    h(InfoRow, { title: 'Storage SAS URL' }, [
+      h(TooltipCell, [storageDetails.azureContainerSasUrl ? storageDetails.azureContainerSasUrl : 'Loading']),
+      h(ClipboardButton, {
+        'aria-label': 'Copy SAS URL to clipboard',
+        text: storageDetails.azureContainerSasUrl,
+        style: { marginLeft: '0.25rem' },
+      }),
+    ]),
+  ]);
+};
+
 export const WorkspaceNotifications = ({ workspace }) => {
   const {
     workspace: { namespace, name },
@@ -519,41 +557,7 @@ const WorkspaceDashboard = _.flow(
                         [bucketSize?.usage]
                       ),
                   ]
-                : [
-                    h(InfoRow, { title: 'Cloud Name' }, [h(AzureLogo, { title: 'Microsoft Azure', role: 'img', style: { height: 16 } })]),
-                    h(InfoRow, { title: 'Location' }, [
-                      h(
-                        TooltipCell,
-                        storageDetails.azureContainerRegion
-                          ? [getRegionFlag(storageDetails.azureContainerRegion), ' ', getRegionLabel(storageDetails.azureContainerRegion)]
-                          : ['Loading']
-                      ),
-                    ]),
-                    h(InfoRow, { title: 'Resource Group ID' }, [
-                      h(TooltipCell, [azureContext.managedResourceGroupId]),
-                      h(ClipboardButton, {
-                        'aria-label': 'Copy resource group id to clipboard',
-                        text: azureContext.managedResourceGroupId,
-                        style: { marginLeft: '0.25rem' },
-                      }),
-                    ]),
-                    h(InfoRow, { title: 'Storage Container URL' }, [
-                      h(TooltipCell, [storageDetails.azureContainerUrl ? storageDetails.azureContainerUrl : 'Loading']),
-                      h(ClipboardButton, {
-                        'aria-label': 'Copy storage container URL to clipboard',
-                        text: storageDetails.azureContainerUrl,
-                        style: { marginLeft: '0.25rem' },
-                      }),
-                    ]),
-                    h(InfoRow, { title: 'Storage SAS URL' }, [
-                      h(TooltipCell, [storageDetails.azureContainerSasUrl ? storageDetails.azureContainerSasUrl : 'Loading']),
-                      h(ClipboardButton, {
-                        'aria-label': 'Copy SAS URL to clipboard',
-                        text: storageDetails.azureContainerSasUrl,
-                        style: { marginLeft: '0.25rem' },
-                      }),
-                    ]),
-                  ]
+                : [h(AzureStorageDetails, { azureContext, storageDetails })]
             ),
             isGoogleWorkspace(workspace) &&
               h(Fragment, [

--- a/src/pages/workspaces/workspace/Dashboard.test.js
+++ b/src/pages/workspaces/workspace/Dashboard.test.js
@@ -8,7 +8,7 @@ import { locationTypes } from 'src/components/region-common';
 import { Ajax } from 'src/libs/ajax';
 import { authStore } from 'src/libs/state';
 import { defaultLocation } from 'src/pages/workspaces/workspace/analysis/utils/runtime-utils';
-import { BucketLocation, WorkspaceNotifications } from 'src/pages/workspaces/workspace/Dashboard';
+import { AzureStorageDetails, BucketLocation, WorkspaceNotifications } from 'src/pages/workspaces/workspace/Dashboard';
 import { asMockedFn } from 'src/testing/test-utils';
 
 jest.mock('src/libs/ajax');
@@ -101,18 +101,19 @@ describe('WorkspaceNotifications', () => {
   });
 });
 
+const defaultGoogleBucketOptions = {
+  googleBucketLocation: defaultLocation,
+  googleBucketType: locationTypes.default,
+  fetchedGoogleBucketLocation: undefined,
+};
+const defaultAzureStorageOptions = {
+  azureContainerRegion: undefined,
+  azureContainerUrl: undefined,
+  azureContainerSasUrl: undefined,
+};
+
 describe('BucketLocation', () => {
   const workspace = { workspace: { namespace: 'test', name: 'test', cloudPlatform: 'Gcp' }, workspaceInitialized: true };
-  const defaultGoogleBucketOptions = {
-    googleBucketLocation: defaultLocation,
-    googleBucketType: locationTypes.default,
-    fetchedGoogleBucketLocation: undefined,
-  };
-  const defaultAzureStorageOptions = {
-    azureContainerRegion: undefined,
-    azureContainerUrl: undefined,
-    azureContainerSasUrl: undefined,
-  };
 
   afterEach(() => {
     jest.resetAllMocks();
@@ -212,5 +213,58 @@ describe('BucketLocation', () => {
     // Assert
     expect(screen.queryByText('Loading')).toBeNull();
     expect(screen.getAllByText(/bucket is requester pays/)).not.toBeNull();
+  });
+});
+
+describe('AzureDetails', () => {
+  const azureContext = {
+    managedResourceGroupId: 'dummy-mrg-id',
+    subscriptionId: 'dummy-subscription-id',
+    tenantId: 'dummy-tenant-id',
+  };
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('shows Loading initially when uninitialized and should not fail any accessibility tests', async () => {
+    // Arrange
+    const props = {
+      azureContext,
+      storageDetails: _.merge(defaultGoogleBucketOptions, defaultAzureStorageOptions),
+    };
+
+    // Act
+    const { container } = render(h(AzureStorageDetails, props), { container: document.body.appendChild(document.createElement('dl')) });
+
+    // Assert
+    expect(screen.queryByTitle('Microsoft Azure')).not.toBeNull();
+    expect(screen.getAllByText('dummy-mrg-id')).not.toBeNull();
+    // (Location, Storage Container URL, Storage Container SAS) x 2 because of tooltips
+    expect(screen.getAllByText('Loading').length).toEqual(6);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('shows storage information when present', async () => {
+    // Arrange
+    const props = {
+      azureContext,
+      storageDetails: _.merge(defaultGoogleBucketOptions, {
+        azureContainerRegion: 'westus',
+        azureContainerUrl: 'only-container-url',
+        azureContainerSasUrl: 'url-with-sas-token',
+      }),
+    };
+
+    // Act
+    const { container } = render(h(AzureStorageDetails, props), { container: document.body.appendChild(document.createElement('dl')) });
+
+    // Assert
+    expect(screen.queryByText('Loading')).toBeNull();
+    expect(screen.getAllByText(/West US/)).not.toBeNull();
+    expect(screen.getAllByText(/🇺🇸/)).not.toBeNull();
+    expect(screen.getAllByText(/only-container-url/)).not.toBeNull();
+    expect(screen.getAllByText(/url-with-sas-token/)).not.toBeNull();
+    expect(await axe(container)).toHaveNoViolations();
   });
 });

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -32,9 +32,8 @@ import ShareWorkspaceModal from 'src/pages/workspaces/workspace/ShareWorkspaceMo
 import { useWorkspace } from 'src/pages/workspaces/workspace/useWorkspace';
 import WorkspaceMenu from 'src/pages/workspaces/workspace/WorkspaceMenu';
 
-const WorkspacePermissionNotice = ({ workspace }) => {
-  const isReadOnly = !Utils.canWrite(workspace.accessLevel);
-  const isLocked = workspace.workspace.isLocked;
+export const WorkspacePermissionNotice = ({ accessLevel, isLocked }) => {
+  const isReadOnly = !Utils.canWrite(accessLevel);
 
   return (
     (isReadOnly || isLocked) &&
@@ -98,7 +97,7 @@ const GooglePermissionsWarning = () => {
   return TitleBarWarning(warningMessage);
 };
 
-const WorkspaceTabs = ({
+export const WorkspaceTabs = ({
   namespace,
   name,
   workspace,
@@ -140,7 +139,7 @@ const WorkspaceTabs = ({
         getHref: (currentTab) => Nav.getLink(_.find({ name: currentTab }, tabs).link, { namespace, name }),
       },
       [
-        workspace && h(WorkspacePermissionNotice, { workspace }),
+        workspace && h(WorkspacePermissionNotice, { accessLevel: workspace.accessLevel, isLocked }),
         h(WorkspaceMenu, {
           iconSize: 27,
           popupLocation: 'bottom',

--- a/src/pages/workspaces/workspace/WorkspaceContainer.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.js
@@ -151,7 +151,7 @@ export const WorkspaceTabs = ({
   ]);
 };
 
-const WorkspaceContainer = ({
+export const WorkspaceContainer = ({
   namespace,
   name,
   breadcrumbs,

--- a/src/pages/workspaces/workspace/WorkspaceContainer.test.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.test.js
@@ -1,0 +1,138 @@
+import { render, screen, within } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { h } from 'react-hyperscript-helpers';
+import { WorkspacePermissionNotice, WorkspaceTabs } from 'src/pages/workspaces/workspace/WorkspaceContainer';
+
+// Mocking for Nav.getLink
+jest.mock('src/libs/nav', () => ({
+  ...jest.requireActual('src/libs/nav'),
+  getLink: jest.fn(() => '/'),
+}));
+
+const mockWorkspaceMenu = jest.fn();
+jest.mock(
+  'src/pages/workspaces/workspace/WorkspaceMenu',
+  () =>
+    function (props) {
+      mockWorkspaceMenu(props);
+      return <mock-workspaceMenu />; // eslint-disable-line
+    }
+);
+
+describe('WorkspacePermissionNotice', () => {
+  it('renders read-only and locked workspace, with no accessibility issues', async () => {
+    // Arrange
+    const props = { accessLevel: 'READER', isLocked: true };
+    // Act
+    const { container } = render(h(WorkspacePermissionNotice, props));
+    // Assert
+    expect(screen.queryByText('Workspace is locked and read only')).not.toBeNull();
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('renders read-only workspace', () => {
+    // Arrange
+    const props = { accessLevel: 'READER', isLocked: false };
+    // Act
+    render(h(WorkspacePermissionNotice, props));
+    // Assert
+    expect(screen.queryByText('Workspace is read only')).not.toBeNull();
+  });
+
+  it('renders locked workspace', () => {
+    // Arrange
+    const props = { accessLevel: 'WRITER', isLocked: true };
+    // Act
+    render(h(WorkspacePermissionNotice, props));
+    // Assert
+    expect(screen.queryByText('Workspace is locked')).not.toBeNull();
+  });
+
+  it('renders no messages for unlocked with writer access, with no with no accessibility issues', async () => {
+    // Arrange
+    const props = { accessLevel: 'WRITER', isLocked: false };
+    // Act
+    const { container } = render(h(WorkspacePermissionNotice, props));
+
+    // Assert
+    expect(screen.queryByText(/locked/)).toBeNull();
+    expect(screen.queryByText(/read only/)).toBeNull();
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});
+
+describe('WorkspaceTabs', () => {
+  it('renders subset of tabs if workspace is unknown, with no accessibility issues', async () => {
+    // Arrange
+    const props = { workspace: undefined };
+    // Act
+    const { container } = render(h(WorkspaceTabs, props));
+    // Assert
+    const tabs = screen.getAllByRole('menuitem');
+    expect(tabs.length).toBe(3);
+    expect(within(tabs[0]).getByText('dashboard')).not.toBeNull();
+    expect(within(tabs[1]).getByText('data')).not.toBeNull();
+    expect(within(tabs[2]).getByText('analyses')).not.toBeNull();
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('renders subset of tabs for Azure workspace, with no accessibility issues', async () => {
+    // Arrange
+    const props = { workspace: { workspace: { cloudPlatform: 'Azure' } } };
+    // Act
+    const { container } = render(h(WorkspaceTabs, props));
+    // Assert
+    const tabs = screen.getAllByRole('menuitem');
+    expect(tabs.length).toBe(3);
+    expect(within(tabs[0]).getByText('dashboard')).not.toBeNull();
+    expect(within(tabs[1]).getByText('data')).not.toBeNull();
+    expect(within(tabs[2]).getByText('analyses')).not.toBeNull();
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('renders subset of tabs for Gcp workspace, with no accessibility issues', async () => {
+    // Arrange
+    const props = { workspace: { workspace: { cloudPlatform: 'Gcp' } } };
+    // Act
+    const { container } = render(h(WorkspaceTabs, props));
+    // Assert
+    const tabs = screen.getAllByRole('menuitem');
+    expect(tabs.length).toBe(5);
+    expect(within(tabs[0]).getByText('dashboard')).not.toBeNull();
+    expect(within(tabs[1]).getByText('data')).not.toBeNull();
+    expect(within(tabs[2]).getByText('analyses')).not.toBeNull();
+    expect(within(tabs[3]).getByText('workflows')).not.toBeNull();
+    expect(within(tabs[4]).getByText('job history')).not.toBeNull();
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('passes workspaceInfo to the workspaceMenu (OWNER, canShare) and workspacePermissionNotice', () => {
+    // Arrange
+    const props = {
+      workspace: { canShare: true, accessLevel: 'OWNER', workspace: { cloudPlatform: 'Gcp', isLocked: false } },
+    };
+    // Act
+    render(h(WorkspaceTabs, props));
+    // Assert
+    expect(mockWorkspaceMenu).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceInfo: { canShare: true, isLocked: false, isOwner: true, workspaceLoaded: true },
+      })
+    );
+  });
+
+  it('passes default workspaceInfo to the workspaceMenu if workspace is not loaded', () => {
+    // Arrange
+    const props = {
+      workspace: undefined,
+    };
+    // Act
+    render(h(WorkspaceTabs, props));
+    // Assert
+    expect(mockWorkspaceMenu).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceInfo: { canShare: undefined, isLocked: undefined, isOwner: undefined, workspaceLoaded: false },
+      })
+    );
+  });
+});

--- a/src/pages/workspaces/workspace/WorkspaceContainer.test.js
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.test.js
@@ -1,7 +1,7 @@
 import { render, screen, within } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import { h } from 'react-hyperscript-helpers';
-import { WorkspacePermissionNotice, WorkspaceTabs } from 'src/pages/workspaces/workspace/WorkspaceContainer';
+import { WorkspaceContainer, WorkspacePermissionNotice, WorkspaceTabs } from 'src/pages/workspaces/workspace/WorkspaceContainer';
 
 // Mocking for Nav.getLink
 jest.mock('src/libs/nav', () => ({
@@ -134,5 +134,54 @@ describe('WorkspaceTabs', () => {
         workspaceInfo: { canShare: undefined, isLocked: undefined, isOwner: undefined, workspaceLoaded: false },
       })
     );
+  });
+});
+
+describe('WorkspaceContainer', () => {
+  it('shows a warning for Azure workspaces', async () => {
+    // Arrange
+    const props = {
+      namespace: 'mock-namespace',
+      name: 'mock-name',
+      workspace: { workspace: { cloudPlatform: 'Azure' } },
+      analysesData: {},
+      storageDetails: {},
+    };
+    // Act
+    render(h(WorkspaceContainer, props));
+    // Assert
+    const alert = screen.getByRole('alert');
+    expect(within(alert).getByText(/Do not store Unclassified Confidential Information in this platform/)).not.toBeNull();
+  });
+
+  it('shows a propagation warning for uninitialized Gcp workspaces', async () => {
+    // Arrange
+    const props = {
+      namespace: 'mock-namespace',
+      name: 'mock-name',
+      workspace: { workspaceInitialized: false, workspace: { cloudPlatform: 'Gcp' } },
+      analysesData: {},
+      storageDetails: {},
+    };
+    // Act
+    render(h(WorkspaceContainer, props));
+    // Assert
+    const alert = screen.getByRole('alert');
+    expect(within(alert).getByText(/Google is syncing permissions for this workspace/)).not.toBeNull();
+  });
+
+  it('shows no alerts for initialized Gcp workspaces', async () => {
+    // Arrange
+    const props = {
+      namespace: 'mock-namespace',
+      name: 'mock-name',
+      workspace: { workspaceInitialized: true, workspace: { cloudPlatform: 'Gcp' } },
+      analysesData: {},
+      storageDetails: {},
+    };
+    // Act
+    render(h(WorkspaceContainer, props));
+    // Assert
+    expect(screen.queryByRole('alert')).toBeNull();
   });
 });


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WOR-1055

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:

### What
Remove Workspace dashboard "integration" test that depended on mocked data, replace coverage with unit tests.

### Why
New Ajax calls with no mock coverage have been creeping in, causing confusing test failures. Also, unit tests are a faster and more reliable way to test with mocked data.

<img width="1363" alt="image" src="https://github.com/DataBiosphere/terra-ui/assets/484484/08325f1f-5e4a-4fc1-9296-c1f0021ebf59">

### Testing strategy
Wrote unit tests with very minimal code changes, ran existing integration tests to verify they still passed (see test results on first commit), then deleted the mocked integration test.
