### PR TITLE
[SU-342] Set height of workspace description in workspaces list

### DIFF
--- a/src/pages/workspaces/List.js
+++ b/src/pages/workspaces/List.js
@@ -317,7 +317,13 @@ export const WorkspaceList = () => {
                     h(
                       FirstParagraphMarkdownViewer,
                       {
-                        style: { ...Style.noWrapEllipsis, margin: 0, color: description ? undefined : colors.dark(0.75), fontSize: 14 },
+                        style: {
+                          height: '1.5rem',
+                          margin: 0,
+                          ...Style.noWrapEllipsis,
+                          color: description ? undefined : colors.dark(0.75),
+                          fontSize: 14,
+                        },
                       },
                       [description?.toString() || 'No description added']
                     ),


### PR DESCRIPTION
The workspaces list displays the first paragraph of the workspace description. The intent is that long paragraphs are handled by the text overflow ellipsis styles on the paragraph. However, in some cases, if the workspace description contains poorly formatted Markdown, that first paragraph may include line breaks. Currently, this causes the workspace description to expand and fill the row, overlapping and blocking the workspace link.

This adds a height style to prevent that.

## Before
![Screenshot 2023-06-13 at 10 29 12 AM](https://github.com/DataBiosphere/terra-ui/assets/1156625/8a6556a0-ef99-4c00-959f-2890e6b5ee25)

## After
![Screenshot 2023-06-13 at 10 28 53 AM](https://github.com/DataBiosphere/terra-ui/assets/1156625/6c459980-998c-4a9c-b486-a01173b0e272)
