### PR TITLE
[SU-343] Add questions to Azure Preview sign up form

### DIFF
--- a/src/pages/AzurePreview.js
+++ b/src/pages/AzurePreview.js
@@ -259,6 +259,7 @@ const AzurePreviewUserForm = ({ value: formValue, onChange, onSubmit }) => {
           value: formValue.organizationDescription,
           onChange: (opt) => onChange({ ...formValue, organizationDescription: opt.value }),
           options: organizationDescriptions,
+          menuPlacement: 'auto',
         }),
 
         formValue.organizationDescription.includes('Other') &&
@@ -287,6 +288,7 @@ const AzurePreviewUserForm = ({ value: formValue, onChange, onSubmit }) => {
           value: formValue.organizationRegion,
           onChange: (opt) => onChange({ ...formValue, organizationRegion: opt.value }),
           options: organizationRegions,
+          menuPlacement: 'auto',
         }),
       ]),
 

--- a/src/pages/AzurePreview.js
+++ b/src/pages/AzurePreview.js
@@ -1,6 +1,6 @@
 import { Fragment, useCallback, useEffect, useState } from 'react';
 import { div, fieldset, form, h, h1, input, label, p, span } from 'react-hyperscript-helpers';
-import { ButtonOutline, ButtonPrimary, Checkbox } from 'src/components/common';
+import { ButtonOutline, ButtonPrimary, Checkbox, Select } from 'src/components/common';
 import { icon } from 'src/components/icons';
 import { TextArea, ValidatedInput } from 'src/components/input';
 import planet from 'src/images/register-planet.svg';
@@ -89,6 +89,30 @@ const AzurePreviewUserForm = ({ value: formValue, onChange, onSubmit }) => {
     'Access data',
     'Complete interactive analyses',
     'Collaborate with others outside of your organization',
+  ];
+
+  const organizationDescriptions = [
+    'Healthcare (Academic Research Institute)',
+    'Healthcare (Hospital/Medical Center)',
+    'Healthcare (Other)',
+    'Healthcare/Genomic Data Generator',
+    'Public Health/Infectious Disease',
+    'Pharmaceutical',
+    'BioPharma',
+    'Biotech',
+    'Biobank',
+    'Prefer not to answer',
+  ];
+
+  const organizationRegions = [
+    'Asia',
+    'Australia and Oceania',
+    'Central America and the Caribbean',
+    'Europe',
+    'Middle East, North Africa, and Greater Arabia',
+    'North America',
+    'South America',
+    'Sub-Saharan Africa',
   ];
 
   return form(
@@ -225,6 +249,47 @@ const AzurePreviewUserForm = ({ value: formValue, onChange, onSubmit }) => {
         ),
       ]),
 
+      fieldset({ style: { padding: 0, border: 'none', margin: '1rem 0', width: '100%' } }, [
+        h(FormLabel, { htmlFor: 'azure-preview-interest-org-description', required: true }, [
+          'Which of the following best describes your organization?',
+        ]),
+        h(Select, {
+          id: 'azure-preview-interest-org-description',
+          getOptionLabel: ({ value }) => value,
+          value: formValue.organizationDescription,
+          onChange: (opt) => onChange({ ...formValue, organizationDescription: opt.value }),
+          options: organizationDescriptions,
+        }),
+
+        formValue.organizationDescription.includes('Other') &&
+          h(Fragment, [
+            h(FormLabel, { htmlFor: 'azure-preview-interest-org-description-other', required: true }, ['Please specify']),
+            h(ValidatedInput, {
+              inputProps: {
+                id: 'azure-preview-interest-org-description-other',
+                placeholder: 'Description',
+                value: formValue.organizationDescriptionOther,
+                onChange: (value) => {
+                  setFieldsTouched((v) => ({ ...v, organizationDescriptionOther: true }));
+                  onChange({ ...formValue, organizationDescriptionOther: value });
+                },
+              },
+              error: fieldsTouched.organizationDescriptionOther && !formValue.organizationDescriptionOther ? 'A description is required' : undefined,
+            }),
+          ]),
+      ]),
+
+      div({ style: { width: '100%' } }, [
+        h(FormLabel, { htmlFor: 'azure-preview-interest-org-region', required: true }, ['In which region is your organization located?']),
+        h(Select, {
+          id: 'azure-preview-interest-org-region',
+          getOptionLabel: ({ value }) => value,
+          value: formValue.organizationRegion,
+          onChange: (opt) => onChange({ ...formValue, organizationRegion: opt.value }),
+          options: organizationRegions,
+        }),
+      ]),
+
       // Submit input allows submitting form by pressing the enter key.
       input({ type: 'submit', value: 'submit', style: { display: 'none' } }),
     ]
@@ -233,6 +298,9 @@ const AzurePreviewUserForm = ({ value: formValue, onChange, onSubmit }) => {
 
 const formId = '1FAIpQLSegf8c7LxlVOS8BLNUrpqkiB7l8L7c135ntdgaBSV2kdrqSAQ';
 
+// To find the entry IDs for each question, select "Get pre-filled link" from the Google Form,
+// answer each question with the question title / ID, and get the link. The query parameters
+// in the URL will contain the entry IDs.
 const formInputMap = {
   firstName: 'entry.1708226507',
   lastName: 'entry.677313431',
@@ -242,6 +310,9 @@ const formInputMap = {
   terraEmail: 'entry.1938956483',
   useCases: 'entry.768184594',
   otherUseCase: 'entry.1274069507',
+  organizationDescription: 'entry.1230284397',
+  organizationDescriptionOther: 'entry.548834294',
+  organizationRegion: 'entry.2049653730',
 };
 
 const AzurePreviewForNonPreviewUser = () => {
@@ -270,10 +341,26 @@ const AzurePreviewForNonPreviewUser = () => {
       terraEmail: user.email,
       useCases: [],
       otherUseCase: '',
+      organizationDescription: '',
+      organizationDescriptionOther: '',
+      organizationRegion: '',
     };
   });
 
-  const requiredFields = ['firstName', 'lastName', 'title', 'organization', 'contactEmail', 'terraEmail'];
+  const requiredFields = [
+    'firstName',
+    'lastName',
+    'title',
+    'organization',
+    'contactEmail',
+    'terraEmail',
+    'organizationDescription',
+    'organizationRegion',
+  ];
+  if (userInfo.organizationDescription.includes('Other')) {
+    requiredFields.push('organizationDescriptionOther');
+  }
+
   const useCasesChecked = !!userInfo.otherUseCase || userInfo.useCases.length > 0;
 
   const submitEnabled = requiredFields.every((field) => !!userInfo[field]) && useCasesChecked && !busy;

--- a/src/pages/AzurePreview.test.js
+++ b/src/pages/AzurePreview.test.js
@@ -140,6 +140,16 @@ describe('AzurePreview', () => {
           await user.click(screen.getByText('Launch workflows'));
 
           // Assert
+          expect(isSubmitEnabled()).toBe(false);
+
+          // Act
+          await user.click(screen.getByLabelText('Which of the following best describes your organization? *'));
+          await user.click(screen.getByText('Healthcare (Academic Research Institute)'));
+
+          await user.click(screen.getByLabelText('In which region is your organization located? *'));
+          await user.click(screen.getByText('North America'));
+
+          // Assert
           expect(isSubmitEnabled()).toBe(true);
         });
       });
@@ -166,6 +176,10 @@ describe('AzurePreview', () => {
           await user.clear(screen.getByLabelText('Contact email address *'));
           await user.type(screen.getByLabelText('Contact email address *'), 'user@example.com');
           await user.click(screen.getByText('Launch workflows'));
+          await user.click(screen.getByLabelText('Which of the following best describes your organization? *'));
+          await user.click(screen.getByText('Healthcare (Academic Research Institute)'));
+          await user.click(screen.getByLabelText('In which region is your organization located? *'));
+          await user.click(screen.getByText('North America'));
 
           // Act
           const submitButton = screen.getByText('Submit');
@@ -176,7 +190,18 @@ describe('AzurePreview', () => {
           expect(submitForm).toHaveBeenCalledWith(expect.any(String), expect.any(Object));
           const formInput = submitForm.mock.calls[0][1];
           expect(Object.values(formInput)).toEqual(
-            expect.arrayContaining(['A', 'User', 'Automated test', 'Terra UI', 'user@example.com', 'user@organization.name', 'Launch workflows'])
+            expect.arrayContaining([
+              'A', // First name
+              'User', // Last name
+              'Automated test', // Title/Role
+              'Terra UI', // Organization name
+              'user@example.com', // Contact email
+              'user@organization.name', // Terra email
+              'Launch workflows', // Use case
+              'Healthcare (Academic Research Institute)', // Organization description
+              '', // Organization description (other)
+              'North America', // Organization region
+            ])
           );
         });
 


### PR DESCRIPTION
This adds two new questions to the Azure Preview sign up form.

<img width="800" alt="Screenshot 2023-06-26 at 1 53 45 PM" src="https://github.com/DataBiosphere/terra-ui/assets/1156625/46bcde74-1b6c-400a-a6ca-2e7666a7c6b7">

If a user selects "Healthcare (Other)" for "Which of the following best describes your organization?", then they are also prompted to enter a description.

https://broadworkbench.atlassian.net/browse/SU-343

## Testing

Sign into Terra with a Microsoft account. If your account is already in the Azure Preview, change this line
https://github.com/DataBiosphere/terra-ui/blob/8fb849e77f3231914fadb2234b566ad1a77e29a4/src/pages/AzurePreview.js#L344
to
```js
const isAzurePreviewUser = false
```

Terra UI also stores whether you've completed the Azure Preview sign up form in local storage, so to fill out the form again, you'll need to remove the local storage item `dynamic-storage/<user-id>/submitted-azure-preview-form`.

 