### PR TITLE
[UIE-97] Fix warning in PersistentDiskTypeInput test

### DIFF
--- a/src/analysis/modals/ComputeModal/PersistentDiskTypeInput.test.ts
+++ b/src/analysis/modals/ComputeModal/PersistentDiskTypeInput.test.ts
@@ -1,5 +1,3 @@
-import '@testing-library/jest-dom';
-
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { h } from 'react-hyperscript-helpers';
@@ -42,18 +40,19 @@ describe('PersistentDiskTypeInput', () => {
     render(h(PersistentDiskTypeInput, defaultPersistentDiskTypeInputProps));
 
     // Assert
-    expect(screen.findByText('Standard')).toBeTruthy();
+    screen.getByText('Standard');
   });
 
   it('should call onChange when value is updated.', async () => {
     // Arrange
+    const user = userEvent.setup();
     render(h(PersistentDiskTypeInput, defaultPersistentDiskTypeInputProps));
 
     // Act
     const diskTypeSelect = screen.getByLabelText('Disk Type');
-    await userEvent.click(diskTypeSelect);
+    await user.click(diskTypeSelect);
     const balancedDiskType = screen.getByText('Balanced');
-    await userEvent.click(balancedDiskType);
+    await user.click(balancedDiskType);
 
     // Assert
     expect(screen.findByText('Balanced')).toBeTruthy();
@@ -76,6 +75,6 @@ describe('PersistentDiskTypeInput', () => {
 
     // Assert
     expect(diskTypeSelect).toBeDisabled();
-    expect(screen.findByText('Standard')).toBeTruthy();
+    screen.getByText('Standard');
   });
 });


### PR DESCRIPTION
Currently, the unit test for PersistentDiskTypeInput logs a warning:
```
Warning: You seem to have overlapping act() calls, this is not supported. Be sure to await previous act() calls before making a new one.
```

This is because the test uses `findBy...` queries (which return Promises) without awaiting them. That also means the test is invalid... it checks if the return value of `findBy...` is truthy and since a Promise is truthy, that assertion always passes even if the expected text is not found.
https://testing-library.com/docs/queries/about#types-of-queries

While we're at it, this also tidies up the test in a few other places:
- Removes the import `@testing-library/jest-dom` import. That is imported in global test setup (`src/setupTests.js`) and doesn't need to be duplicated in each test.
- Replaces `expect(screen...).toBeTruthy()` with `screen.getByText`. `getBy...` queries throw an error if they don't match, so no `expect` is needed.
- Replaces direct calls to `userEvent.click` with methods called on a user event instance. That is the recommended way to use `@testing-library/user-event` according to https://testing-library.com/docs/user-event/setup#direct-apis.