### PR TITLE
[UIE-97] Resolve warnings in useAnalysisExportState test

### DIFF
--- a/src/analysis/modals/ExportAnalysisModal/useAnalysisExportState.test.ts
+++ b/src/analysis/modals/ExportAnalysisModal/useAnalysisExportState.test.ts
@@ -263,7 +263,9 @@ describe('useAnalysisExportState', () => {
 
     // Act
     const hookResult2 = renderedHook.result.current;
-    hookResult2.copyAnalysis('NewName123');
+    act(() => {
+      hookResult2.copyAnalysis('NewName123');
+    });
     await renderedHook.waitForNextUpdate();
 
     // Assert
@@ -324,7 +326,9 @@ describe('useAnalysisExportState', () => {
 
     // Act
     const hookResult2 = renderedHook.result.current;
-    hookResult2.copyAnalysis('NewName123');
+    act(() => {
+      hookResult2.copyAnalysis('NewName123');
+    });
     await renderedHook.waitForNextUpdate();
 
     // Assert


### PR DESCRIPTION
Currently, the test for useAnalysisExportState logs two warnings about:
```
Warning: An update to TestComponent inside a test was not wrapped in act(...).
```

Wrapping the call to `copyAnalysis` in `act` resolves them.