### PR TITLE
[UIE-97] Resolve React warning in TermsOfService test

### DIFF
--- a/src/pages/TermsOfService.test.js
+++ b/src/pages/TermsOfService.test.js
@@ -1,5 +1,4 @@
-import { render, screen } from '@testing-library/react';
-import { act } from 'react-dom/test-utils';
+import { act, render, screen } from '@testing-library/react';
 import { h } from 'react-hyperscript-helpers';
 import { Ajax } from 'src/libs/ajax';
 import { authStore } from 'src/libs/state';
@@ -61,8 +60,7 @@ describe('TermsOfService', () => {
     // Assert
     expect(getTosFn).toHaveBeenCalled();
 
-    const termsOfServiceText = screen.findByText('some text');
-    expect(termsOfServiceText).not.toBeFalsy();
+    screen.getByText('some text');
   });
 
   it('shows "Continue under grace period" when the user has not accepted the latest ToS but is still allowed to use Terra', async () => {
@@ -78,8 +76,7 @@ describe('TermsOfService', () => {
     await act(async () => { render(h(TermsOfServicePage)) }) //eslint-disable-line
 
     // Assert
-    const continueUnderGracePeriodButton = screen.findByText('Continue under grace period');
-    expect(continueUnderGracePeriodButton).not.toBeFalsy();
+    screen.getByText('Continue under grace period');
   });
 
   it('does not show "Continue under grace period" when the user has not accepted the latest ToS and is not allowed to use Terra', async () => {


### PR DESCRIPTION
Currently, the TermsOfService unit test logs a warning:
```
Warning: You seem to have overlapping act() calls, this is not supported. Be sure to await previous act() calls before making a new one
```

This is because it uses `findBy...` queries, which return a Promise, without awaiting them. That also means the test isn't actually testing anything. It asserts that the result of `findByText` is not falsy. Since the result of `findByText` is a Promise object, that assertion will always be true.
https://testing-library.com/docs/queries/about#types-of-queries

This switches from `findBy...` queries to `getBy...` queries, which are synchronous and throw an error if no matching element is found.