### PR TITLE
[UIE-97] Silence logs in useDeleteWorkspaceState tests

### DIFF
--- a/src/pages/workspaces/workspace/useDeleteWorkspaceState.test.ts
+++ b/src/pages/workspaces/workspace/useDeleteWorkspaceState.test.ts
@@ -32,7 +32,7 @@ type AjaxAppsContract = AjaxContract['Apps'];
 type AjaxRuntimesContract = AjaxContract['Runtimes'];
 type AjaxWorkspacesContract = AjaxContract['Workspaces'];
 
-describe('useDeleteWorkspace', () => {
+describe('useDeleteWorkspaceState', () => {
   const googleWorkspace = {
     accessLevel: 'WRITER',
     canShare: true,
@@ -57,6 +57,10 @@ describe('useDeleteWorkspace', () => {
   } as BaseWorkspace;
   const mockOnDismiss = jest.fn(() => {});
   const mockOnSuccess = jest.fn(() => {});
+
+  beforeAll(() => {
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
 
   beforeEach(() => {
     jest.useFakeTimers();


### PR DESCRIPTION
Currently, useDeleteWorkspaceState tests produce a lot of log output:
```
  console.log
    Requesting app and runtime deletion for workspace azureWorkspaceId

      at Object.deleteWorkspaceResources (src/pages/workspaces/workspace/useDeleteWorkspaceState.ts:181:15)

  console.log
    Resource deletions requested, starting poll.

      at Object.deleteWorkspaceResources (src/pages/workspaces/workspace/useDeleteWorkspaceState.ts:184:15)

  console.log
    Checking azure resources...

      at checkAzureResources (src/pages/workspaces/workspace/useDeleteWorkspaceState.ts:146:15)

  console.log
    Resources gone.

      at checkAzureResources (src/pages/workspaces/workspace/useDeleteWorkspaceState.ts:157:17)

  console.log
    Requesting app and runtime deletion for workspace azureWorkspaceId

      at Object.deleteWorkspaceResources (src/pages/workspaces/workspace/useDeleteWorkspaceState.ts:181:15)

  console.log
    Requesting app and runtime deletion for workspace azureWorkspaceId

      at Object.deleteWorkspaceResources (src/pages/workspaces/workspace/useDeleteWorkspaceState.ts:181:15)

  console.log
    Resource deletions requested, starting poll.

      at Object.deleteWorkspaceResources (src/pages/workspaces/workspace/useDeleteWorkspaceState.ts:184:15)

  console.log
    Checking azure resources...

      at checkAzureResources (src/pages/workspaces/workspace/useDeleteWorkspaceState.ts:146:15)
```

To reduce noise in test output, this mocks console.log to silence that output.