### PR TITLE
[UIE-97] Avoid output from ImportWorkflow test

### DIFF
--- a/src/libs/error.mock.ts
+++ b/src/libs/error.mock.ts
@@ -23,9 +23,9 @@ export const mockWithErrorReporting = _.curry((title, fn) => {
  * Provides a mocked version of error module's withErrorReportingInModal
  */
 export const mockWithErrorReportingInModal = _.curry((title, onDismiss, fn) => {
-  const errorHandler = async () => {
+  const errorHandler = async (...args) => {
     try {
-      return await fn();
+      return await fn(...args);
     } catch (error) {
       errorWatcher(title, error);
       onDismiss();

--- a/src/libs/error.mock.ts
+++ b/src/libs/error.mock.ts
@@ -9,6 +9,16 @@ import _ from 'lodash/fp';
  */
 export const errorWatcher = jest.fn();
 
+export const mockWithErrorReporting = _.curry((title, fn) => {
+  return async (...args) => {
+    try {
+      return await fn(...args);
+    } catch (error) {
+      errorWatcher(title, error);
+    }
+  };
+});
+
 /**
  * Provides a mocked version of error module's withErrorReportingInModal
  */

--- a/src/pages/ImportWorkflow/ImportWorkflow.test.ts
+++ b/src/pages/ImportWorkflow/ImportWorkflow.test.ts
@@ -5,6 +5,7 @@ import { setAzureCookieOnUrl } from 'src/analysis/runtime-common-components';
 import { useWorkspaces } from 'src/components/workspace-utils';
 import { Ajax } from 'src/libs/ajax';
 import { Apps } from 'src/libs/ajax/leonardo/Apps';
+import { errorWatcher } from 'src/libs/error.mock';
 import { getUser } from 'src/libs/state';
 import { DeepPartial } from 'src/libs/type-utils/deep-partial';
 import { WorkspaceWrapper } from 'src/libs/workspace-utils';
@@ -77,6 +78,15 @@ jest.mock('react-virtualized', () => ({
   ...jest.requireActual('react-virtualized'),
   AutoSizer: ({ children }) => children({ width: 300 }),
 }));
+
+jest.mock('src/libs/error', () => {
+  const errorModule = jest.requireActual('src/libs/error');
+  const mockErrorModule = jest.requireActual('src/libs/error.mock');
+  return {
+    ...errorModule,
+    withErrorReporting: mockErrorModule.mockWithErrorReporting,
+  };
+});
 
 jest.mock('src/libs/state', () => ({
   ...jest.requireActual('src/libs/state'),
@@ -415,6 +425,7 @@ describe('ImportWorkflow', () => {
 
     // Assert
     expect(mockListAppsFn).toBeCalledTimes(0);
+    expect(errorWatcher).toHaveBeenCalledWith('Error importing workflow', expect.any(Error));
   });
 
   it('opens new workspace modal with azure disabled', async () => {

--- a/src/pages/ImportWorkflow/ImportWorkflow.test.ts
+++ b/src/pages/ImportWorkflow/ImportWorkflow.test.ts
@@ -17,11 +17,11 @@ import { useDockstoreWdl } from './useDockstoreWdl';
 
 type AjaxContract = ReturnType<typeof Ajax>;
 type AppsContract = ReturnType<typeof Apps>;
-type WorkspaceUtilsExports = typeof import('src/components/workspace-utils');
 
 jest.mock('src/libs/ajax');
 jest.mock('src/libs/ajax/leonardo/Apps');
 
+type WorkspaceUtilsExports = typeof import('src/components/workspace-utils');
 jest.mock('src/components/workspace-utils', (): WorkspaceUtilsExports => {
   const { h } = jest.requireActual('react-hyperscript-helpers');
 
@@ -51,35 +51,56 @@ jest.mock('src/components/workspace-utils', (): WorkspaceUtilsExports => {
   };
 });
 
-jest.mock('./importDockstoreWorkflow', () => ({
-  importDockstoreWorkflow: jest.fn().mockResolvedValue(undefined),
-}));
+type ImportDockstoreWorkflowExports = typeof import('./importDockstoreWorkflow');
+jest.mock(
+  './importDockstoreWorkflow',
+  (): ImportDockstoreWorkflowExports => ({
+    importDockstoreWorkflow: jest.fn().mockResolvedValue(undefined),
+  })
+);
 
-jest.mock('./useDockstoreWdl', () => ({
-  useDockstoreWdl: jest.fn().mockReturnValue({
-    status: 'Ready',
-    wdl: 'workflow TestWorkflow {}',
-  }),
-}));
+type UseDockstoreWdlExports = typeof import('./useDockstoreWdl');
+jest.mock(
+  './useDockstoreWdl',
+  (): UseDockstoreWdlExports => ({
+    useDockstoreWdl: jest.fn().mockReturnValue({
+      status: 'Ready',
+      wdl: 'workflow TestWorkflow {}',
+    }),
+  })
+);
 
-jest.mock('src/analysis/runtime-common-components.js', () => ({
-  setAzureCookieOnUrl: jest.fn().mockResolvedValue(undefined),
-}));
+type RuntimeCommonComponentsExports = typeof import('src/analysis/runtime-common-components.js');
+jest.mock(
+  'src/analysis/runtime-common-components.js',
+  (): Partial<RuntimeCommonComponentsExports> => ({
+    setAzureCookieOnUrl: jest.fn().mockResolvedValue(undefined),
+  })
+);
 
-jest.mock('src/libs/nav', () => ({
-  ...jest.requireActual('src/libs/nav'),
-  goToPath: jest.fn(),
-  getLink: jest.fn().mockReturnValue(''),
-}));
+type NavExports = typeof import('src/libs/nav');
+jest.mock(
+  'src/libs/nav',
+  (): NavExports => ({
+    ...jest.requireActual('src/libs/nav'),
+    goToPath: jest.fn(),
+    getLink: jest.fn().mockReturnValue(''),
+  })
+);
 
 // The workspace menu uses react-virtualized's AutoSizer to size the options menu.
 // This makes the virtualized window large enough for options to be rendered.
-jest.mock('react-virtualized', () => ({
-  ...jest.requireActual('react-virtualized'),
-  AutoSizer: ({ children }) => children({ width: 300 }),
-}));
+type ReactVirtualizedExports = typeof import('react-virtualized');
+jest.mock(
+  'react-virtualized',
+  (): ReactVirtualizedExports => ({
+    ...jest.requireActual('react-virtualized'),
+    AutoSizer: ({ children }) => children({ width: 300 }),
+  })
+);
 
-jest.mock('src/libs/error', () => {
+type ErrorExports = typeof import('src/libs/error');
+jest.mock('src/libs/error', (): ErrorExports => {
   const errorModule = jest.requireActual('src/libs/error');
   const mockErrorModule = jest.requireActual('src/libs/error.mock');
   return {
@@ -88,12 +109,17 @@ jest.mock('src/libs/error', () => {
   };
 });
 
-jest.mock('src/libs/state', () => ({
-  ...jest.requireActual('src/libs/state'),
-  getUser: jest.fn(),
-}));
+type StateExports = typeof import('src/libs/state');
+jest.mock(
+  'src/libs/state',
+  (): StateExports => ({
+    ...jest.requireActual('src/libs/state'),
+    getUser: jest.fn(),
+  })
+);
 
-jest.mock('react-notifications-component', () => {
+type ReactNotificationsComponentExports = typeof import('react-notifications-component');
+jest.mock('react-notifications-component', (): ReactNotificationsComponentExports => {
   return {
     store: {
       addNotification: jest.fn(),

--- a/src/pages/ImportWorkflow/ImportWorkflow.test.ts
+++ b/src/pages/ImportWorkflow/ImportWorkflow.test.ts
@@ -1,4 +1,4 @@
-import { act, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { h } from 'react-hyperscript-helpers';
 import { setAzureCookieOnUrl } from 'src/analysis/runtime-common-components';
@@ -313,7 +313,7 @@ describe('ImportWorkflow', () => {
     await user.click(option);
 
     const importButton = screen.getByText('Import');
-    await act(() => user.click(importButton));
+    await user.click(importButton);
 
     // Assert
     expect(importDockstoreWorkflow).toHaveBeenCalledWith(
@@ -369,7 +369,7 @@ describe('ImportWorkflow', () => {
     await user.click(option);
 
     const importButton = screen.getByText('Import');
-    await act(() => user.click(importButton));
+    await user.click(importButton);
 
     // Assert
     expect(mockListAppsFn).toHaveBeenCalledWith('79201ea6-519a-4077-a9a4-75b2a7c4cdeb');
@@ -421,7 +421,7 @@ describe('ImportWorkflow', () => {
     await user.click(option);
 
     const importButton = screen.getByText('Import');
-    await act(() => user.click(importButton));
+    await user.click(importButton);
 
     // Assert
     expect(mockListAppsFn).toBeCalledTimes(0);
@@ -442,7 +442,7 @@ describe('ImportWorkflow', () => {
 
     // Act
     const createWorkspaceButton = screen.getByText('create a new workspace');
-    await act(() => user.click(createWorkspaceButton));
+    await user.click(createWorkspaceButton);
 
     screen.getByText(
       'Importing directly into new Azure workspaces is not currently supported. To create a new workspace with an Azure billing project, visit the main',
@@ -471,14 +471,14 @@ describe('ImportWorkflow', () => {
     await user.click(option);
 
     const importButton = screen.getByText('Import');
-    await act(() => user.click(importButton));
+    await user.click(importButton);
     const firstImportDockstoreWorkflowCallArgs = asMockedFn(importDockstoreWorkflow).mock.calls[0];
 
     const confirmationMessageShown = !!screen.queryByText(
       'The selected workspace already contains a workflow named "test-workflow". Are you sure you want to overwrite it?'
     );
     const confirmButton = screen.getByText('Overwrite');
-    await act(() => user.click(confirmButton));
+    await user.click(confirmButton);
     const secondImportDockstoreWorkflowCallArgs = asMockedFn(importDockstoreWorkflow).mock.calls[1];
 
     // Assert


### PR DESCRIPTION
Currently, one ImportWorkflow unit test logs a lot of output:
```
Error importing workflow Error: Currently only a workspace creator can import workflow to their Azure workspace.
          at fn (/terra-ui/src/pages/ImportWorkflow/ImportWorkflow.js:120:17)
          at fn (/terra-ui/src/libs/utils.ts:350:20)
          at fn (/terra-ui/src/libs/error.ts:25:20)
          at doImport (/terra-ui/src/libs/error.ts:25:20)
          at onImport (/terra-ui/src/pages/ImportWorkflow/ImportWorkflow.js:181:40)
          at onClick (/terra-ui/src/pages/ImportWorkflow/WorkspaceImporter.ts:71:15)
          at apply (/terra-ui/src/components/common/Clickable.js:18:55)
          at HTMLUnknownElement.callCallback (/terra-ui/.yarn/__virtual__/react-dom-virtual-148c633abb/0/cache/react-dom-npm-17.0.2-f551215af1-1c1eaa3bca.zip/node_modules/react-dom/cjs/react-dom.development.js:3945:14)
          at HTMLUnknownElement.callTheUserObjectsOperation (/terra-ui/.yarn/__virtual__/jsdom-virtual-f91bf4c0c4/0/cache/jsdom-npm-16.7.0-216c5c4bf9-454b833718.zip/node_modules/jsdom/lib/jsdom/living/generated/EventListener.js:26:30)
          at innerInvokeEventListeners (/terra-ui/.yarn/__virtual__/jsdom-virtual-f91bf4c0c4/0/cache/jsdom-npm-16.7.0-216c5c4bf9-454b833718.zip/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:338:25)
          at invokeEventListeners (/terra-ui/.yarn/__virtual__/jsdom-virtual-f91bf4c0c4/0/cache/jsdom-npm-16.7.0-216c5c4bf9-454b833718.zip/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:274:3)
          at HTMLUnknownElementImpl._dispatch (/terra-ui/.yarn/__virtual__/jsdom-virtual-f91bf4c0c4/0/cache/jsdom-npm-16.7.0-216c5c4bf9-454b833718.zip/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:221:9)
          at HTMLUnknownElementImpl.dispatchEvent (/terra-ui/.yarn/__virtual__/jsdom-virtual-f91bf4c0c4/0/cache/jsdom-npm-16.7.0-216c5c4bf9-454b833718.zip/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:94:17)
          at HTMLUnknownElement.dispatchEvent (/terra-ui/.yarn/__virtual__/jsdom-virtual-f91bf4c0c4/0/cache/jsdom-npm-16.7.0-216c5c4bf9-454b833718.zip/node_modules/jsdom/lib/jsdom/living/generated/EventTarget.js:231:34)
          at Object.apply (/terra-ui/.yarn/__virtual__/react-dom-virtual-148c633abb/0/cache/react-dom-npm-17.0.2-f551215af1-1c1eaa3bca.zip/node_modules/react-dom/cjs/react-dom.development.js:3994:16)
          at apply (/terra-ui/.yarn/__virtual__/react-dom-virtual-148c633abb/0/cache/react-dom-npm-17.0.2-f551215af1-1c1eaa3bca.zip/node_modules/react-dom/cjs/react-dom.development.js:4056:31)
          at invokeGuardedCallbackAndCatchFirstError (/terra-ui/.yarn/__virtual__/react-dom-virtual-148c633abb/0/cache/react-dom-npm-17.0.2-f551215af1-1c1eaa3bca.zip/node_modules/react-dom/cjs/react-dom.development.js:4070:25)
          at executeDispatch (/terra-ui/.yarn/__virtual__/react-dom-virtual-148c633abb/0/cache/react-dom-npm-17.0.2-f551215af1-1c1eaa3bca.zip/node_modules/react-dom/cjs/react-dom.development.js:8243:3)
          at processDispatchQueueItemsInOrder (/terra-ui/.yarn/__virtual__/react-dom-virtual-148c633abb/0/cache/react-dom-npm-17.0.2-f551215af1-1c1eaa3bca.zip/node_modules/react-dom/cjs/react-dom.development.js:8275:7)
          at processDispatchQueue (/terra-ui/.yarn/__virtual__/react-dom-virtual-148c633abb/0/cache/react-dom-npm-17.0.2-f551215af1-1c1eaa3bca.zip/node_modules/react-dom/cjs/react-dom.development.js:8288:5)
          at dispatchEventsForPlugins (/terra-ui/.yarn/__virtual__/react-dom-virtual-148c633abb/0/cache/react-dom-npm-17.0.2-f551215af1-1c1eaa3bca.zip/node_modules/react-dom/cjs/react-dom.development.js:8299:3)
          at fn (/terra-ui/.yarn/__virtual__/react-dom-virtual-148c633abb/0/cache/react-dom-npm-17.0.2-f551215af1-1c1eaa3bca.zip/node_modules/react-dom/cjs/react-dom.development.js:8508:12)
          at batchedEventUpdatesImpl (/terra-ui/.yarn/__virtual__/react-dom-virtual-148c633abb/0/cache/react-dom-npm-17.0.2-f551215af1-1c1eaa3bca.zip/node_modules/react-dom/cjs/react-dom.development.js:22396:12)
          at batchedEventUpdates (/terra-ui/.yarn/__virtual__/react-dom-virtual-148c633abb/0/cache/react-dom-npm-17.0.2-f551215af1-1c1eaa3bca.zip/node_modules/react-dom/cjs/react-dom.development.js:3745:12)
          at dispatchEventForPluginEventSystem (/terra-ui/.yarn/__virtual__/react-dom-virtual-148c633abb/0/cache/react-dom-npm-17.0.2-f551215af1-1c1eaa3bca.zip/node_modules/react-dom/cjs/react-dom.development.js:8507:3)
          at attemptToDispatchEvent (/terra-ui/.yarn/__virtual__/react-dom-virtual-148c633abb/0/cache/react-dom-npm-17.0.2-f551215af1-1c1eaa3bca.zip/node_modules/react-dom/cjs/react-dom.development.js:6005:3)
          at eventHandler (/terra-ui/.yarn/__virtual__/react-dom-virtual-148c633abb/0/cache/react-dom-npm-17.0.2-f551215af1-1c1eaa3bca.zip/node_modules/react-dom/cjs/react-dom.development.js:5924:19)
          at Scheduler_runWithPriority (/terra-ui/.yarn/cache/scheduler-npm-0.20.2-90beaecfba-c4b35cf967.zip/node_modules/scheduler/cjs/scheduler.development.js:468:12)
          at runWithPriority$1 (/terra-ui/.yarn/__virtual__/react-dom-virtual-148c633abb/0/cache/react-dom-npm-17.0.2-f551215af1-1c1eaa3bca.zip/node_modules/react-dom/cjs/react-dom.development.js:11276:10)
          at discreteUpdatesImpl (/terra-ui/.yarn/__virtual__/react-dom-virtual-148c633abb/0/cache/react-dom-npm-17.0.2-f551215af1-1c1eaa3bca.zip/node_modules/react-dom/cjs/react-dom.development.js:22413:14)
          at discreteUpdates (/terra-ui/.yarn/__virtual__/react-dom-virtual-148c633abb/0/cache/react-dom-npm-17.0.2-f551215af1-1c1eaa3bca.zip/node_modules/react-dom/cjs/react-dom.development.js:3756:12)
          at dispatchDiscreteEvent (/terra-ui/.yarn/__virtual__/react-dom-virtual-148c633abb/0/cache/react-dom-npm-17.0.2-f551215af1-1c1eaa3bca.zip/node_modules/react-dom/cjs/react-dom.development.js:5889:3)
          at HTMLDivElement.callTheUserObjectsOperation (/terra-ui/.yarn/__virtual__/jsdom-virtual-f91bf4c0c4/0/cache/jsdom-npm-16.7.0-216c5c4bf9-454b833718.zip/node_modules/jsdom/lib/jsdom/living/generated/EventListener.js:26:30)
          at innerInvokeEventListeners (/terra-ui/.yarn/__virtual__/jsdom-virtual-f91bf4c0c4/0/cache/jsdom-npm-16.7.0-216c5c4bf9-454b833718.zip/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:338:25)
          at invokeEventListeners (/terra-ui/.yarn/__virtual__/jsdom-virtual-f91bf4c0c4/0/cache/jsdom-npm-16.7.0-216c5c4bf9-454b833718.zip/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:274:3)
          at HTMLDivElementImpl._dispatch (/terra-ui/.yarn/__virtual__/jsdom-virtual-f91bf4c0c4/0/cache/jsdom-npm-16.7.0-216c5c4bf9-454b833718.zip/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:221:9)
          at HTMLDivElementImpl.dispatchEvent (/terra-ui/.yarn/__virtual__/jsdom-virtual-f91bf4c0c4/0/cache/jsdom-npm-16.7.0-216c5c4bf9-454b833718.zip/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:94:17)
          at HTMLDivElement.dispatchEvent (/terra-ui/.yarn/__virtual__/jsdom-virtual-f91bf4c0c4/0/cache/jsdom-npm-16.7.0-216c5c4bf9-454b833718.zip/node_modules/jsdom/lib/jsdom/living/generated/EventTarget.js:231:34)
          at cb (/terra-ui/.yarn/__virtual__/@testing-library-user-event-virtual-3c4cd93763/0/cache/@testing-library-user-event-npm-14.4.3-2d1a75355f-852c48ea6d.zip/node_modules/@testing-library/user-event/dist/cjs/event/dispatchEvent.js:47:43)
          at fn (/terra-ui/.yarn/__virtual__/@testing-library-react-virtual-cdcbe96425/0/cache/@testing-library-react-npm-12.1.5-745f86e555-4abd049040.zip/node_modules/@testing-library/react/dist/pure.js:66:16)
          at batchedUpdates (/terra-ui/.yarn/__virtual__/react-dom-virtual-148c633abb/0/cache/react-dom-npm-17.0.2-f551215af1-1c1eaa3bca.zip/node_modules/react-dom/cjs/react-dom.development.js:22380:12)
          at act (/terra-ui/.yarn/__virtual__/react-dom-virtual-148c633abb/0/cache/react-dom-npm-17.0.2-f551215af1-1c1eaa3bca.zip/node_modules/react-dom/cjs/react-dom-test-utils.development.js:1042:14)
          at Object.eventWrapper (/terra-ui/.yarn/__virtual__/@testing-library-react-virtual-cdcbe96425/0/cache/@testing-library-react-npm-12.1.5-745f86e555-4abd049040.zip/node_modules/@testing-library/react/dist/pure.js:65:27)
          at Object.wrapEvent (/terra-ui/.yarn/__virtual__/@testing-library-user-event-virtual-3c4cd93763/0/cache/@testing-library-user-event-npm-14.4.3-2d1a75355f-852c48ea6d.zip/node_modules/@testing-library/user-event/dist/cjs/event/wrapEvent.js:8:28)
          at Object.call (/terra-ui/.yarn/__virtual__/@testing-library-user-event-virtual-3c4cd93763/0/cache/@testing-library-user-event-npm-14.4.3-2d1a75355f-852c48ea6d.zip/node_modules/@testing-library/user-event/dist/cjs/event/dispatchEvent.js:47:22)
          at Object.dispatchUIEvent (/terra-ui/.yarn/__virtual__/@testing-library-user-event-virtual-3c4cd93763/0/cache/@testing-library-user-event-npm-14.4.3-2d1a75355f-852c48ea6d.zip/node_modules/@testing-library/user-event/dist/cjs/event/dispatchEvent.js:24:26)
          at Mouse.up (/terra-ui/.yarn/__virtual__/@testing-library-user-event-virtual-3c4cd93763/0/cache/@testing-library-user-event-npm-14.4.3-2d1a75355f-852c48ea6d.zip/node_modules/@testing-library/user-event/dist/cjs/system/pointer/mouse.js:91:30)
          at PointerHost.release (/terra-ui/.yarn/__virtual__/@testing-library-user-event-virtual-3c4cd93763/0/cache/@testing-library-user-event-npm-14.4.3-2d1a75355f-852c48ea6d.zip/node_modules/@testing-library/user-event/dist/cjs/system/pointer/index.js:74:28)
          at pointerAction (/terra-ui/.yarn/__virtual__/@testing-library-user-event-virtual-3c4cd93763/0/cache/@testing-library-user-event-npm-14.4.3-2d1a75355f-852c48ea6d.zip/node_modules/@testing-library/user-event/dist/cjs/pointer/index.js:62:47)
          at Object.pointer (/terra-ui/.yarn/__virtual__/@testing-library-user-event-virtual-3c4cd93763/0/cache/@testing-library-user-event-npm-14.4.3-2d1a75355f-852c48ea6d.zip/node_modules/@testing-library/user-event/dist/cjs/pointer/index.js:35:9)
          at /terra-ui/.yarn/__virtual__/@testing-library-react-virtual-cdcbe96425/0/cache/@testing-library-react-npm-12.1.5-745f86e555-4abd049040.zip/node_modules/@testing-library/react/dist/pure.js:59:16

       5 |
       6 | export const reportError = async (title, obj) => {
    >  7 |   console.error(title, obj); // helpful when the notify component fails to render
         |           ^
       8 |   // Do not show an error notification when a session times out.
       9 |   // Notification for this case is handled elsewhere.
      10 |   if (obj instanceof Error && obj.message === 'Session timed out') {

      at reportError (src/libs/error.ts:7:11)
      at callback (src/libs/error.ts:49:5)
      at src/libs/error.ts:27:13
      at src/libs/error.ts:25:14
```

To reduce noise in test output, this silences that output by mocking `reportError`.