### PR TITLE
[AJ-1136] Infer table name from uploaded TSV's header

### DIFF
--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -366,8 +366,12 @@ export const notifyDataImportProgress = (jobId, message) => {
 
 /** Use the first column heading in the TSV as a suggested name for the table. */
 export const getSuggestedTableName = (tsv) => {
-  const match = /([^\s]+)\s/.exec(tsv);
-  return match ? match[1].replace(/_id$/, '').replace(/^(membership|entity):/, '') : undefined;
+  const indexOfFirstSpace = tsv.search(/\s/);
+  if (indexOfFirstSpace === -1) {
+    return undefined;
+  }
+  const firstColumnHeading = tsv.slice(0, indexOfFirstSpace);
+  return firstColumnHeading.replace(/_id$/, '').replace(/^(membership|entity):/, '');
 };
 
 export const EntityUploader = ({ onSuccess, onDismiss, namespace, name, entityTypes, workspaceId, dataProvider, isGoogleWorkspace, region }) => {

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -364,6 +364,16 @@ export const notifyDataImportProgress = (jobId, message) => {
   });
 };
 
+/** Use the first column heading in the TSV as a suggested name for the table. */
+export const getSuggestedTableName = (tsv) => {
+  const indexOfFirstTab = tsv.indexOf('\t');
+  if (indexOfFirstTab === -1) {
+    return undefined;
+  }
+  const firstColumnHeading = tsv.slice(0, indexOfFirstTab);
+  return firstColumnHeading.replace(/_id$/, '').replace(/^entity:/, '');
+};
+
 export const EntityUploader = ({ onSuccess, onDismiss, namespace, name, entityTypes, workspaceId, dataProvider, isGoogleWorkspace, region }) => {
   const [useFireCloudDataModel, setUseFireCloudDataModel] = useState(false);
   const [isFileImportCurrMode, setIsFileImportCurrMode] = useState(true);
@@ -373,7 +383,7 @@ export const EntityUploader = ({ onSuccess, onDismiss, namespace, name, entityTy
   const [showInvalidEntryMethodWarning, setShowInvalidEntryMethodWarning] = useState(false);
   const [uploading, setUploading] = useState(false);
   const [deleteEmptyValues, setDeleteEmptyValues] = useState(false);
-  const [recordType, setRecordType] = useState(undefined);
+  const [recordType, setRecordType] = useState('');
   const [recordTypeInputTouched, setRecordTypeInputTouched] = useState(false);
 
   // Google workspace regions are hardcoded for now, as GCP uploads to the Rawls service which is only on uscentral-1
@@ -429,7 +439,11 @@ export const EntityUploader = ({ onSuccess, onDismiss, namespace, name, entityTy
       activeStyle: { cursor: 'copy' },
       onDropAccepted: async ([file]) => {
         setFile(file);
-        setFileContents(await Utils.readFileAsText(file.slice(0, 1000)));
+        const fileContentPreview = await Utils.readFileAsText(file.slice(0, 1000));
+        setFileContents(fileContentPreview);
+        if (!recordType) {
+          setRecordType(getSuggestedTableName(fileContentPreview) || '');
+        }
         setIsFileImportLastUsedMode(true);
       },
     },

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -366,12 +366,8 @@ export const notifyDataImportProgress = (jobId, message) => {
 
 /** Use the first column heading in the TSV as a suggested name for the table. */
 export const getSuggestedTableName = (tsv) => {
-  const indexOfFirstTab = tsv.indexOf('\t');
-  if (indexOfFirstTab === -1) {
-    return undefined;
-  }
-  const firstColumnHeading = tsv.slice(0, indexOfFirstTab);
-  return firstColumnHeading.replace(/_id$/, '').replace(/^entity:/, '');
+  const match = /(?:(?:membership|entity):)?([^\s]+)\s/.exec(tsv);
+  return match ? match[1].replace(/_id$/, '') : undefined;
 };
 
 export const EntityUploader = ({ onSuccess, onDismiss, namespace, name, entityTypes, workspaceId, dataProvider, isGoogleWorkspace, region }) => {

--- a/src/components/data/data-utils.js
+++ b/src/components/data/data-utils.js
@@ -366,8 +366,8 @@ export const notifyDataImportProgress = (jobId, message) => {
 
 /** Use the first column heading in the TSV as a suggested name for the table. */
 export const getSuggestedTableName = (tsv) => {
-  const match = /(?:(?:membership|entity):)?([^\s]+)\s/.exec(tsv);
-  return match ? match[1].replace(/_id$/, '') : undefined;
+  const match = /([^\s]+)\s/.exec(tsv);
+  return match ? match[1].replace(/_id$/, '').replace(/^(membership|entity):/, '') : undefined;
 };
 
 export const EntityUploader = ({ onSuccess, onDismiss, namespace, name, entityTypes, workspaceId, dataProvider, isGoogleWorkspace, region }) => {

--- a/src/components/data/data-utils.test.js
+++ b/src/components/data/data-utils.test.js
@@ -368,6 +368,17 @@ describe('getSuggestedTableName', () => {
     expect(suggestedTableName).toBe('sample');
   });
 
+  it('handles one column heading', () => {
+    // Arrange
+    const tsv = 'sample_id\nfoo\nbar\nbaz\n';
+
+    // Act
+    const suggestedTableName = getSuggestedTableName(tsv);
+
+    // Assert
+    expect(suggestedTableName).toBe('sample');
+  });
+
   it('returns undefined if no name can be determined', () => {
     // Arrange
     const notATsv = 'abcdefghijklmnopqrstuvwxyz';

--- a/src/components/data/data-utils.test.js
+++ b/src/components/data/data-utils.test.js
@@ -4,6 +4,7 @@ import {
   entityAttributeText,
   getDownloadCommand,
   getRootTypeForSetTable,
+  getSuggestedTableName,
   prepareAttributeForUpload,
   renderDataCell,
 } from 'src/components/data/data-utils';
@@ -330,5 +331,51 @@ describe('prepareAttributeForUpload', () => {
       items: [1, 2, 3],
       itemsType: 'AttributeValue',
     });
+  });
+});
+
+describe('getSuggestedTableName', () => {
+  it('returns first column heading', () => {
+    // Arrange
+    const tsv = 'foo\tbar\tbaz\n1\t2\t3\n';
+
+    // Act
+    const suggestedTableName = getSuggestedTableName(tsv);
+
+    // Assert
+    expect(suggestedTableName).toBe('foo');
+  });
+
+  it('removes _id suffix', () => {
+    // Arrange
+    const tsv = 'sample_id\tnumber\nfoo\t1\nbar\t2\nbaz\t3\n';
+
+    // Act
+    const suggestedTableName = getSuggestedTableName(tsv);
+
+    // Assert
+    expect(suggestedTableName).toBe('sample');
+  });
+
+  it('removes entity: prefix', () => {
+    // Arrange
+    const tsv = 'entity:sample_id\tnumber\nfoo\t1\nbar\t2\nbaz\t3\n';
+
+    // Act
+    const suggestedTableName = getSuggestedTableName(tsv);
+
+    // Assert
+    expect(suggestedTableName).toBe('sample');
+  });
+
+  it('returns undefined if no name can be determined', () => {
+    // Arrange
+    const notATsv = 'abcdefghijklmnopqrstuvwxyz';
+
+    // Act
+    const suggestedTableName = getSuggestedTableName(notATsv);
+
+    // Assert
+    expect(suggestedTableName).toBe(undefined);
   });
 });


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1136

In GCP workspaces, data tables imported from TSVs are named based on the first column heading in the TSV, which must match the pattern `entity:<table_name>_id`.

In Azure workspaces, the user is prompted to name the table when importing a TSV. With this change, if a user uploads a TSV before entering a name for the table, the table name is auto populated based on the first column heading in the TSV.

https://github.com/DataBiosphere/terra-ui/assets/1156625/22e70088-c6b0-426d-b6f5-ec1fbec714f9

This implementation has some limitations... it only looks at the first 1000 bytes of the TSV and it doesn't support TSVs with quotes around column names. This seems no worse that other TSV handling code in Terra UI.