### PR TITLE
[IA-4422] Fix context bar test warnings and convert files to typescript

### DIFF
--- a/src/analysis/ContextBar.test.ts
+++ b/src/analysis/ContextBar.test.ts
@@ -693,17 +693,6 @@ describe('ContextBar - actions', () => {
     };
     asMockedFn(Ajax).mockImplementation(() => newMockAjax as AjaxContract);
 
-    const myWindow = Object.create(window);
-    const url = 'http://dummy.com';
-    Object.defineProperty(myWindow, 'location', {
-      value: {
-        href: url,
-      },
-      writable: true,
-      // @ts-expect-error
-      // TODO: is this needed?
-      hash: '/',
-    });
     const runtime: Runtime = {
       ...jupyter,
       status: 'Stopped',
@@ -750,17 +739,6 @@ describe('ContextBar - actions', () => {
     };
     asMockedFn(Ajax).mockImplementation(() => newMockAjax as AjaxContract);
 
-    const myWindow = Object.create(window);
-    const url = 'http://dummy.com';
-    Object.defineProperty(myWindow, 'location', {
-      value: {
-        href: url,
-      },
-      writable: true,
-      // @ts-expect-error
-      // TODO: is this needed?
-      hash: '/',
-    });
     const jupyterContextBarProps = {
       ...contextBarProps,
       runtimes: [jupyter],

--- a/src/analysis/ContextBar.test.ts
+++ b/src/analysis/ContextBar.test.ts
@@ -1,7 +1,14 @@
 import { act, fireEvent, render } from '@testing-library/react';
 import { div, h } from 'react-hyperscript-helpers';
-import { ContextBar } from 'src/analysis/ContextBar';
+import {
+  defaultAzureWorkspace,
+  defaultGoogleWorkspace,
+  galaxyDisk,
+  galaxyRunning,
+} from 'src/analysis/_testData/testData';
+import { ContextBar, ContextBarProps } from 'src/analysis/ContextBar';
 import { CloudEnvironmentModal } from 'src/analysis/modals/CloudEnvironmentModal';
+import { doesWorkspaceSupportCromwellAppForUser } from 'src/analysis/utils/app-utils';
 import {
   getGalaxyComputeCost,
   getGalaxyDiskCost,
@@ -9,13 +16,19 @@ import {
   getRuntimeCost,
   runtimeConfigCost,
 } from 'src/analysis/utils/cost-utils';
-import { appToolLabels, runtimeToolLabels } from 'src/analysis/utils/tool-utils';
+import { defaultLocation } from 'src/analysis/utils/runtime-utils';
+import { appToolLabels, isToolHidden, runtimeToolLabels } from 'src/analysis/utils/tool-utils';
 import { MenuTrigger } from 'src/components/PopupTrigger';
+import { locationTypes } from 'src/components/region-common';
 import { Ajax } from 'src/libs/ajax';
+import { App } from 'src/libs/ajax/leonardo/models/app-models';
+import { DecoratedPersistentDisk, PersistentDisk } from 'src/libs/ajax/leonardo/models/disk-models';
+import { Runtime, runtimeStatuses } from 'src/libs/ajax/leonardo/models/runtime-models';
 import { defaultAzureMachineType, defaultAzureRegion } from 'src/libs/azure-utils';
-import { getConfig } from 'src/libs/config';
+import { isCromwellAppVisible } from 'src/libs/config';
 import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
 import * as Utils from 'src/libs/utils';
+import { cloudProviderTypes } from 'src/libs/workspace-utils';
 import { asMockedFn } from 'src/testing/test-utils';
 
 const GALAXY_COMPUTE_COST = 10;
@@ -30,6 +43,16 @@ jest.mock('src/analysis/utils/cost-utils', () => ({
   getPersistentDiskCostHourly: jest.fn(),
   getRuntimeCost: jest.fn(),
   runtimeConfigCost: jest.fn(),
+}));
+
+jest.mock('src/analysis/utils/app-utils', () => ({
+  ...jest.requireActual('src/analysis/utils/app-utils'),
+  doesWorkspaceSupportCromwellAppForUser: jest.fn(),
+}));
+
+jest.mock('src/analysis/utils/tool-utils', () => ({
+  ...jest.requireActual('src/analysis/utils/tool-utils'),
+  isToolHidden: jest.fn(),
 }));
 
 // Mocking for terminalLaunchLink using Nav.getLink
@@ -53,104 +76,86 @@ jest.mock('src/analysis/modals/CloudEnvironmentModal', () => ({
 
 jest.mock('src/libs/config', () => ({
   ...jest.requireActual('src/libs/config'),
-  getConfig: jest.fn().mockReturnValue({}),
-  isCromwellAppVisible: () => {
-    return true;
-  },
+  isCromwellAppVisible: jest.fn(),
 }));
 
 jest.mock('src/libs/ajax');
 jest.mock('src/libs/feature-previews');
 
+type AjaxContract = ReturnType<typeof Ajax>;
+type AjaxMetricsContract = AjaxContract['Metrics'];
+
+const mockMetrics: Partial<AjaxMetricsContract> = {
+  captureEvent: () => Promise.resolve(),
+};
+
+const defaultAjaxImpl: Partial<AjaxContract> = {
+  Metrics: mockMetrics as AjaxMetricsContract,
+};
+
 beforeEach(() => {
-  MenuTrigger.mockImplementation(({ content }) => {
+  asMockedFn(MenuTrigger).mockImplementation(({ content }) => {
     return div([content]);
   });
-  CloudEnvironmentModal.mockImplementation(({ isOpen, filterForTool, onSuccess, onDismiss, ...props }) => {
+  asMockedFn(CloudEnvironmentModal).mockImplementation(({ isOpen, filterForTool, onSuccess, onDismiss, ...props }) => {
     return isOpen
       ? div([
           'Cloud Environment Details',
-          div(filterForTool),
-          div({ label: 'Success Button', onClick: () => onSuccess() }, 'SuccessButton'),
-          div({ label: 'Success Button', onClick: () => onDismiss() }, 'DismissButton'),
+          div([filterForTool]),
+          div({ onClick: () => onSuccess('success') }, ['SuccessButton']),
+          div({ onClick: () => onDismiss() }, ['DismissButton']),
         ])
       : div([]);
   });
 
-  Ajax.mockImplementation(() => ({
-    Metrics: {
-      captureEvent: () => {},
-    },
-  }));
+  asMockedFn(Ajax).mockImplementation(() => defaultAjaxImpl as AjaxContract);
 
-  getGalaxyComputeCost.mockImplementation(() => {
-    return GALAXY_COMPUTE_COST;
-  });
-  getGalaxyDiskCost.mockImplementation(() => {
-    return GALAXY_DISK_COST;
-  });
-  getRuntimeCost.mockImplementation(() => {
-    return RUNTIME_COST;
-  });
-  getPersistentDiskCostHourly.mockImplementation(() => {
-    return PERSISTENT_DISK_COST;
-  });
-  runtimeConfigCost.mockImplementation(() => {
-    return RUNTIME_COST + PERSISTENT_DISK_COST;
-  });
+  asMockedFn(getGalaxyComputeCost).mockReturnValue(GALAXY_COMPUTE_COST);
+  asMockedFn(getGalaxyDiskCost).mockReturnValue(GALAXY_DISK_COST);
+  asMockedFn(getRuntimeCost).mockReturnValue(RUNTIME_COST);
+  asMockedFn(getPersistentDiskCostHourly).mockReturnValue(PERSISTENT_DISK_COST);
+  asMockedFn(runtimeConfigCost).mockReturnValue(RUNTIME_COST + PERSISTENT_DISK_COST);
 });
 
 afterEach(() => {
   jest.clearAllMocks();
 });
 
-// Note - These constants are copied from ./runtime-utils.test.ts
-const galaxyRunning = {
-  appName: 'terra-app-69200c2f-89c3-47db-874c-b770d8de737f',
-  appType: 'GALAXY',
-  auditInfo: {
-    creator: 'cahrens@gmail.com',
-    createdDate: '2021-11-29T20:19:13.162484Z',
-    destroyedDate: null,
-    dateAccessed: '2021-11-29T20:19:13.162484Z',
-  },
-  diskName: 'saturn-pd-026594ac-d829-423d-a8df-76fe96f5b4e7',
-  errors: [],
-  googleProject: 'terra-test-e4000484',
-  kubernetesRuntimeConfig: { numNodes: 1, machineType: 'n1-highmem-8', autoscalingEnabled: false },
-  labels: {},
-  proxyUrls: { galaxy: 'https://leonardo-fiab.dsde-dev.broadinstitute.org/a-app-69200c2f-89c3-47db-874c-b770d8de737f/galaxy' },
-  status: 'RUNNING',
-};
-
-const cromwellRunning = {
+const cromwellRunning: App = {
   appName: 'terra-app-83f46705-524c-4fc8-xcyc-97fdvcfby14f',
   appType: 'CROMWELL',
   auditInfo: {
     creator: 'cahrens@gmail.com',
     createdDate: '2021-11-28T20:28:01.998494Z',
-    destroyedDate: null,
     dateAccessed: '2021-11-28T20:28:01.998494Z',
+  },
+  cloudContext: {
+    cloudProvider: cloudProviderTypes.GCP,
+    cloudResource: 'terra-test-e4000484',
   },
   diskName: 'saturn-pd-026594ac-d829-423d-a8df-55fe36f5b4e8',
   errors: [],
-  googleProject: 'terra-test-e4000484',
   kubernetesRuntimeConfig: { numNodes: 1, machineType: 'n1-highmem-8', autoscalingEnabled: false },
   labels: {},
-  proxyUrls: { 'cromwell-service': 'https://leonardo-fiab.dsde-dev.broadinstitute.org/fd0cfbb14f/cromwell-service/swagger/cromwell.yaml' },
+  proxyUrls: {
+    'cromwell-service':
+      'https://leonardo-fiab.dsde-dev.broadinstitute.org/fd0cfbb14f/cromwell-service/swagger/cromwell.yaml',
+  },
   status: 'RUNNING',
 };
 
-const cromwellDisk = {
+const cromwellDisk: PersistentDisk = {
   auditInfo: {
     creator: 'cahrens@gmail.com',
     createdDate: '2021-11-26T20:19:13.162484Z',
-    destroyedDate: null,
     dateAccessed: '2021-11-29T20:19:14.114Z',
   },
   blockSize: 4096,
   diskType: 'pd-standard',
-  googleProject: 'terra-test-e4000484',
+  cloudContext: {
+    cloudProvider: cloudProviderTypes.GCP,
+    cloudResource: 'terra-test-e4000484',
+  },
   id: 16,
   labels: { saturnApplication: 'CROMWELL', saturnWorkspaceName: 'test-workspace' },
   name: 'saturn-pd-026594ac-d829-423d-a8df-55fe36f5b4e8',
@@ -159,7 +164,7 @@ const cromwellDisk = {
   zone: 'us-central1-a',
 };
 
-const cromwellOnAzureRunning = {
+const cromwellOnAzureRunning: App = {
   appName: 'test-cromwell-app',
   cloudContext: {
     cloudProvider: 'AZURE',
@@ -178,12 +183,10 @@ const cromwellOnAzureRunning = {
     cromwell: 'https://lz123.servicebus.windows.net/test-cromwell-app/cromwell',
     wds: 'https://lz123.servicebus.windows.net/test-cromwell-app/wds',
   },
-  diskName: null,
   customEnvironmentVariables: {},
   auditInfo: {
     creator: 'abc.testerson@gmail.com',
     createdDate: '2023-01-18T23:28:47.605176Z',
-    destroyedDate: null,
     dateAccessed: '2023-01-18T23:28:47.605176Z',
   },
   appType: 'CROMWELL',
@@ -195,136 +198,9 @@ const cromwellOnAzureRunning = {
   },
 };
 
-const galaxyDisk = {
-  auditInfo: {
-    creator: 'cahrens@gmail.com',
-    createdDate: '2021-11-29T20:19:13.162484Z',
-    destroyedDate: null,
-    dateAccessed: '2021-11-29T20:19:14.114Z',
-  },
-  blockSize: 4096,
-  diskType: 'pd-standard',
-  googleProject: 'terra-test-e4000484',
-  id: 10,
-  labels: { saturnApplication: 'galaxy', saturnWorkspaceName: 'test-workspace' }, // Note 'galaxy' vs. 'GALAXY', to represent our older naming scheme
-  name: 'saturn-pd-026594ac-d829-423d-a8df-76fe96f5b4e7',
-  size: 500,
-  status: 'Ready',
-  zone: 'us-central1-a',
-};
-
-const jupyter = {
-  id: 75239,
-  workspaceId: null,
-  runtimeName: 'saturn-eae9168f-9b99-4910-945e-dbab66e04d91',
-  googleProject: 'terra-dev-cf677740',
-  cloudContext: {
-    cloudProvider: 'GCP',
-    cloudResource: 'terra-dev-cf677740',
-  },
-  auditInfo: {
-    creator: 'testuser123@broad.com',
-    createdDate: '2022-07-18T18:35:32.012698Z',
-    destroyedDate: null,
-    dateAccessed: '2022-07-18T21:44:17.565Z',
-  },
-  runtimeConfig: {
-    machineType: 'n1-standard-1',
-    persistentDiskId: 15778,
-    cloudService: 'GCE',
-    bootDiskSize: 120,
-    zone: 'us-central1-a',
-    gpuConfig: undefined,
-  },
-  proxyUrl: 'https://leonardo.dsde-dev.broadinstitute.org/proxy/terra-dev-cf677740/saturn-eae9168f-9b99-4910-945e-dbab66e04d91/jupyter',
-  status: 'Running',
-  labels: {
-    saturnWorkspaceNamespace: 'general-dev-billing-account',
-    'saturn-iframe-extension': 'https://bvdp-saturn-dev.appspot.com/jupyter-iframe-extension.js',
-    creator: 'testuser123@broad.com',
-    clusterServiceAccount: 'pet-26534176105071279add1@terra-dev-cf677740.iam.gserviceaccount.com',
-    saturnAutoCreated: 'true',
-    clusterName: 'saturn-eae9168f-9b99-4910-945e-dbab66e04d91',
-    saturnWorkspaceName: 'Broad Test Workspace',
-    saturnVersion: '6',
-    tool: 'Jupyter',
-    runtimeName: 'saturn-eae9168f-9b99-4910-945e-dbab66e04d91',
-    cloudContext: 'Gcp/terra-dev-cf677740',
-    googleProject: 'terra-dev-cf677740',
-  },
-  patchInProgress: false,
-};
-
-const jupyterLabRunning = {
-  auditInfo: {
-    createdDate: '2022-09-09T20:20:06.982538Z',
-    creator: 'ncl.hedwig@gmail.com',
-    dateAccessed: '2022-09-09T20:20:08.185Z',
-    destroyedDate: null,
-  },
-  cloudContext: {
-    cloudProvider: 'AZURE',
-    cloudResource: 'fad90753-2022-4456-9b0a-c7e5b934e408/3efc5bdf-be0e-44e7-b1d7-c08931e3c16c/mrg-terra-workspace-20220412104730',
-  },
-  googleProject: 'fad90753-2022-4456-9b0a-c7e5b934e408/3efc5bdf-be0e-44e7-b1d7-c08931e3c16c/mrg-terra-workspace-20220412104730',
-  id: 76996,
-  labels: {
-    cloudContext: 'Azure/fad90753-2022-4456-9b0a-c7e5b934e408/3efc5bdf-be0e-44e7-b1d7-c08931e3c16c/mrg-terra-workspace-20220412104730',
-    clusterName: 'saturn-b2eecc2d-75d5-44f5-8eb2-5147db41874a',
-    clusterServiceAccount: 'ncl.hedwig@gmail.com',
-    creator: 'ncl.hedwig@gmail.com',
-    runtimeName: 'saturn-b2eecc2d-75d5-44f5-8eb2-5147db41874a',
-    saturnAutoCreated: 'true',
-    saturnVersion: '6',
-    saturnWorkspaceName: 'isAzure',
-    saturnWorkspaceNamespace: 'alpha-azure-billing-project-20220407',
-    tool: 'JupyterLab',
-  },
-  patchInProgress: false,
-  proxyUrl: 'https://relay-ns-2a77dcb5-882c-46b9-a3bc-5d251aff14d0.servicebus.windows.net/saturn-b2eecc2d-75d5-44f5-8eb2-5147db41874a',
-  runtimeConfig: {
-    cloudService: 'AZURE_VM',
-    machineType: defaultAzureMachineType,
-    persistentDiskId: 15778,
-    region: defaultAzureRegion,
-    runtimeName: 'saturn-b2eecc2d-75d5-44f5-8eb2-5147db41874a',
-    status: 'Running',
-    workspaceId: '2a77dcb5-882c-46b9-a3bc-5d251aff14d0',
-  },
-};
-
-const runtimeDisk = {
-  id: 15778,
-  googleProject: 'terra-dev-cf677740',
-  cloudContext: {
-    cloudProvider: 'GCP',
-    cloudResource: 'terra-dev-cf677740',
-  },
-  zone: 'us-central1-a',
-  name: 'saturn-pd-c4aea6ef-5618-47d3-b674-5d456c9dcf4f',
-  status: 'Ready',
-  auditInfo: {
-    creator: 'testuser123@broad.com',
-    createdDate: '2022-07-18T18:35:32.012698Z',
-    destroyedDate: null,
-    dateAccessed: '2022-07-18T20:34:56.092Z',
-  },
-  size: 50,
-  diskType: {
-    label: 'pd-standard',
-    displayName: 'Standard',
-    regionToPricesName: 'monthlyStandardDiskPrice',
-  },
-  blockSize: 4096,
-  labels: {
-    saturnWorkspaceNamespace: 'general-dev-billing-account',
-    saturnWorkspaceName: 'Broad Test Workspace',
-  },
-};
-
-const rstudioRuntime = {
+const rstudioRuntime: Runtime = {
   id: 76979,
-  workspaceId: null,
+  workspaceId: defaultGoogleWorkspace.workspace.workspaceId,
   runtimeName: 'saturn-48afb74a-15b1-4aad-8b23-d039cf8253fb',
   googleProject: 'terra-dev-98897219',
   cloudContext: {
@@ -334,7 +210,6 @@ const rstudioRuntime = {
   auditInfo: {
     creator: 'ncl.hedwig@gmail.com',
     createdDate: '2022-09-08T19:46:37.396597Z',
-    destroyedDate: null,
     dateAccessed: '2022-09-08T19:47:21.206Z',
   },
   runtimeConfig: {
@@ -345,7 +220,8 @@ const rstudioRuntime = {
     zone: 'us-central1-a',
     gpuConfig: undefined,
   },
-  proxyUrl: 'https://leonardo.dsde-dev.broadinstitute.org/proxy/terra-dev-98897219/saturn-48afb74a-15b1-4aad-8b23-d039cf8253fb/rstudio',
+  proxyUrl:
+    'https://leonardo.dsde-dev.broadinstitute.org/proxy/terra-dev-98897219/saturn-48afb74a-15b1-4aad-8b23-d039cf8253fb/rstudio',
   status: 'Running',
   labels: {
     saturnWorkspaceNamespace: 'general-dev-billing-account',
@@ -364,52 +240,150 @@ const rstudioRuntime = {
   patchInProgress: false,
 };
 
-const contextBarProps = {
-  runtimes: [],
-  apps: [],
-  appDataDisks: [],
-  refreshRuntimes: () => '',
-  storageDetails: {
-    googleBucketLocation: 'US-CENTRAL1',
-    googleBucketType: '',
-    azureContainerRegion: 'eastus',
-    azureContainerUrl: 'container-url',
-    azureContainerSasUrl: 'container-url?sas',
+const jupyter: Runtime = {
+  id: 75239,
+  workspaceId: defaultGoogleWorkspace.workspace.workspaceId,
+  runtimeName: 'saturn-eae9168f-9b99-4910-945e-dbab66e04d91',
+  googleProject: 'terra-dev-cf677740',
+  cloudContext: {
+    cloudProvider: 'GCP',
+    cloudResource: 'terra-dev-cf677740',
   },
-  refreshApps: () => '',
-  workspace: {
-    workspace: {
-      namespace: 'namespace',
-      cloudPlatform: 'Gcp',
-    },
-    namespace: 'Broad Test Workspace',
+  auditInfo: {
+    creator: 'testuser123@broad.com',
+    createdDate: '2022-07-18T18:35:32.012698Z',
+    dateAccessed: '2022-07-18T21:44:17.565Z',
+  },
+  runtimeConfig: {
+    machineType: 'n1-standard-1',
+    persistentDiskId: 15778,
+    cloudService: 'GCE',
+    bootDiskSize: 120,
+    zone: 'us-central1-a',
+    gpuConfig: undefined,
+  },
+  proxyUrl:
+    'https://leonardo.dsde-dev.broadinstitute.org/proxy/terra-dev-cf677740/saturn-eae9168f-9b99-4910-945e-dbab66e04d91/jupyter',
+  status: 'Running',
+  labels: {
+    saturnWorkspaceNamespace: 'general-dev-billing-account',
+    'saturn-iframe-extension': 'https://bvdp-saturn-dev.appspot.com/jupyter-iframe-extension.js',
+    creator: 'testuser123@broad.com',
+    clusterServiceAccount: 'pet-26534176105071279add1@terra-dev-cf677740.iam.gserviceaccount.com',
+    saturnAutoCreated: 'true',
+    clusterName: 'saturn-eae9168f-9b99-4910-945e-dbab66e04d91',
+    saturnWorkspaceName: 'Broad Test Workspace',
+    saturnVersion: '6',
+    tool: 'Jupyter',
+    runtimeName: 'saturn-eae9168f-9b99-4910-945e-dbab66e04d91',
+    cloudContext: 'Gcp/terra-dev-cf677740',
+    googleProject: 'terra-dev-cf677740',
+  },
+  patchInProgress: false,
+};
+
+const jupyterLabRunning: Runtime = {
+  auditInfo: {
+    createdDate: '2022-09-09T20:20:06.982538Z',
+    creator: 'ncl.hedwig@gmail.com',
+    dateAccessed: '2022-09-09T20:20:08.185Z',
+  },
+  runtimeName: 'saturn-b2eecc2d-75d5-44f5-8eb2-5147db41874a',
+  cloudContext: {
+    cloudProvider: 'AZURE',
+    cloudResource:
+      'fad90753-2022-4456-9b0a-c7e5b934e408/3efc5bdf-be0e-44e7-b1d7-c08931e3c16c/mrg-terra-workspace-20220412104730',
+  },
+  googleProject:
+    'fad90753-2022-4456-9b0a-c7e5b934e408/3efc5bdf-be0e-44e7-b1d7-c08931e3c16c/mrg-terra-workspace-20220412104730',
+  id: 76996,
+  labels: {
+    cloudContext:
+      'Azure/fad90753-2022-4456-9b0a-c7e5b934e408/3efc5bdf-be0e-44e7-b1d7-c08931e3c16c/mrg-terra-workspace-20220412104730',
+    clusterName: 'saturn-b2eecc2d-75d5-44f5-8eb2-5147db41874a',
+    clusterServiceAccount: 'ncl.hedwig@gmail.com',
+    creator: 'ncl.hedwig@gmail.com',
+    runtimeName: 'saturn-b2eecc2d-75d5-44f5-8eb2-5147db41874a',
+    saturnAutoCreated: 'true',
+    saturnVersion: '6',
+    saturnWorkspaceName: 'isAzure',
+    saturnWorkspaceNamespace: 'alpha-azure-billing-project-20220407',
+    tool: 'JupyterLab',
+  },
+  patchInProgress: false,
+  proxyUrl:
+    'https://relay-ns-2a77dcb5-882c-46b9-a3bc-5d251aff14d0.servicebus.windows.net/saturn-b2eecc2d-75d5-44f5-8eb2-5147db41874a',
+  runtimeConfig: {
+    cloudService: 'AZURE_VM',
+    machineType: defaultAzureMachineType,
+    persistentDiskId: 15778,
+    region: defaultAzureRegion,
+  },
+  workspaceId: '2a77dcb5-882c-46b9-a3bc-5d251aff14d0',
+  status: 'Running',
+};
+
+const runtimeDisk: DecoratedPersistentDisk = {
+  id: 15778,
+  cloudContext: {
+    cloudProvider: 'GCP',
+    cloudResource: 'terra-dev-cf677740',
+  },
+  zone: 'us-central1-a',
+  name: 'saturn-pd-c4aea6ef-5618-47d3-b674-5d456c9dcf4f',
+  status: 'Ready',
+  auditInfo: {
+    creator: 'testuser123@broad.com',
+    createdDate: '2022-07-18T18:35:32.012698Z',
+    dateAccessed: '2022-07-18T20:34:56.092Z',
+  },
+  size: 50,
+  diskType: {
+    value: 'pd-standard',
+    label: 'Standard',
+    regionToPricesName: 'monthlyStandardDiskPrice',
+  },
+  blockSize: 4096,
+  labels: {
+    saturnWorkspaceNamespace: 'general-dev-billing-account',
+    saturnWorkspaceName: 'Broad Test Workspace',
   },
 };
 
-const contextBarPropsForAzure = {
+const defaultGoogleBucketOptions = {
+  googleBucketLocation: defaultLocation,
+  googleBucketType: locationTypes.default,
+  fetchedGoogleBucketLocation: undefined,
+};
+const defaultAzureStorageOptions = {
+  azureContainerRegion: 'eastus',
+  azureContainerUrl: 'container-url',
+  azureContainerSasUrl: 'container-url?sas',
+};
+
+const contextBarProps: ContextBarProps = {
   runtimes: [],
   apps: [],
   appDataDisks: [],
-  refreshRuntimes: () => '',
-  storageDetails: {
-    googleBucketLocation: 'US-CENTRAL1',
-    googleBucketType: 'region',
-    azureContainerRegion: undefined,
-    azureContainerUrl: undefined,
-    azureContainerSasUrl: undefined,
-  },
-  refreshApps: () => '',
-  workspace: {
-    workspace: {
-      namespace: 'namespace',
-      cloudPlatform: 'Azure',
-      createdDate: '2023-02-15T19:17:15.711Z',
-    },
-    namespace: 'Broad Azure Test Workspace',
-  },
+  persistentDisks: [],
+  refreshRuntimes: () => Promise.resolve(),
+  storageDetails: defaultGoogleBucketOptions,
+  refreshApps: () => Promise.resolve(),
+  workspace: defaultGoogleWorkspace,
 };
 
-const hailBatchAppRunning = {
+const contextBarPropsForAzure: ContextBarProps = {
+  runtimes: [],
+  apps: [],
+  appDataDisks: [],
+  persistentDisks: [],
+  refreshRuntimes: () => Promise.resolve(),
+  storageDetails: { ...defaultGoogleBucketOptions, ...defaultAzureStorageOptions },
+  refreshApps: () => Promise.resolve(),
+  workspace: defaultAzureWorkspace,
+};
+
+const hailBatchAppRunning: App = {
   appName: 'test-hail-batch-app',
   cloudContext: {
     cloudProvider: 'AZURE',
@@ -425,12 +399,10 @@ const hailBatchAppRunning = {
   proxyUrls: {
     batch: 'https://lz123.servicebus.windows.net/test-hail-batch-app/batch',
   },
-  diskName: null,
   customEnvironmentVariables: {},
   auditInfo: {
     creator: 'abc.testerson@gmail.com',
     createdDate: '2023-01-18T23:28:47.605176Z',
-    destroyedDate: null,
     dateAccessed: '2023-01-18T23:28:47.605176Z',
   },
   appType: 'HAIL_BATCH',
@@ -455,7 +427,7 @@ describe('ContextBar - buttons', () => {
 
   it('will render Jupyter button with an enabled Terminal Button', () => {
     // Arrange
-    const jupyterContextBarProps = {
+    const jupyterContextBarProps: ContextBarProps = {
       ...contextBarProps,
       runtimes: [jupyter],
       persistentDisks: [runtimeDisk],
@@ -475,7 +447,7 @@ describe('ContextBar - buttons', () => {
 
   it('will render Jupyter in Creating status', () => {
     // Arrange
-    const jupyterContextBarProps = {
+    const jupyterContextBarProps: ContextBarProps = {
       ...contextBarProps,
       runtimes: [{ ...jupyter, status: 'Creating' }],
       persistentDisks: [runtimeDisk],
@@ -495,9 +467,9 @@ describe('ContextBar - buttons', () => {
 
   it('will render Galaxy and RStudio buttons with a disabled Terminal Button', () => {
     // Arrange
-    const rstudioGalaxyContextBarProps = {
+    const rstudioGalaxyContextBarProps: ContextBarProps = {
       ...contextBarProps,
-      runtimes: [{ ...rstudioRuntime, status: 'Creating' }],
+      runtimes: [{ ...rstudioRuntime, status: runtimeStatuses.creating.leoLabel }],
       apps: [galaxyRunning],
       appDataDisks: [galaxyDisk],
       persistentDisks: [runtimeDisk],
@@ -513,18 +485,21 @@ describe('ContextBar - buttons', () => {
     expect(getByLabelText(new RegExp(/RStudio Environment/i)));
     expect(getByLabelText(new RegExp(/Galaxy Environment/i)));
     expect(queryByTestId('terminal-button-id')).not.toBeInTheDocument();
-    expect(getByText(/Running \$.*\/hr/));
-    expect(getByText(/Creating \$.*\/hr/));
-    expect(getByText(/Disk \$.*\/hr/));
+    expect(getByText('Running $0.52/hr'));
+    expect(getByText('Creating $0.20/hr'));
+    expect(getByText('Disk $0.04/hr'));
   });
 
   it('will render a Cromwell button with a disabled Terminal Button', () => {
     // Arrange
-    const rstudioGalaxyContextBarProps = {
+    const rstudioGalaxyContextBarProps: ContextBarProps = {
       ...contextBarProps,
       apps: [cromwellRunning],
       appDataDisks: [cromwellDisk],
     };
+
+    asMockedFn(isCromwellAppVisible).mockReturnValue(true);
+    asMockedFn(doesWorkspaceSupportCromwellAppForUser).mockReturnValue(true);
 
     // Act
     const { getByText, getByLabelText, queryByTestId } = render(h(ContextBar, rstudioGalaxyContextBarProps));
@@ -545,6 +520,8 @@ describe('ContextBar - buttons', () => {
       appDataDisks: [],
     };
 
+    asMockedFn(doesWorkspaceSupportCromwellAppForUser).mockReturnValue(true);
+
     // Act
     const { getByLabelText, queryByTestId } = render(h(ContextBar, cromwellOnAzureContextBarProps));
 
@@ -554,8 +531,44 @@ describe('ContextBar - buttons', () => {
     expect(getByLabelText(new RegExp(/Cromwell Environment/i)));
   });
 
+  it('will not render a Cromwell button if workspace is not supported for cromwell', () => {
+    // Arrange
+    const cromwellOnAzureContextBarProps = {
+      ...contextBarPropsForAzure,
+      apps: [cromwellOnAzureRunning],
+      appDataDisks: [],
+    };
+
+    asMockedFn(doesWorkspaceSupportCromwellAppForUser).mockReturnValue(false);
+
+    // Act
+    const { getByLabelText, queryByLabelText } = render(h(ContextBar, cromwellOnAzureContextBarProps));
+
+    // Assert
+    expect(getByLabelText('Environment Configuration'));
+    expect(queryByLabelText(new RegExp(/Cromwell Environment/i))).not.toBeInTheDocument();
+  });
+
+  it('will not render a cromwell button if it is hidden ', () => {
+    // Arrange
+    const cromwellOnAzureContextBarProps = {
+      ...contextBarPropsForAzure,
+      apps: [cromwellOnAzureRunning],
+      appDataDisks: [],
+    };
+
+    asMockedFn(isToolHidden).mockReturnValue(true);
+
+    // Act
+    const { getByLabelText, queryByLabelText } = render(h(ContextBar, cromwellOnAzureContextBarProps));
+
+    // Assert
+    expect(getByLabelText('Environment Configuration'));
+    expect(queryByLabelText(new RegExp(/Cromwell Environment/i))).not.toBeInTheDocument();
+  });
+
   it('will render JupyterLab Environment button', () => {
-    const jupyterContextBarProps = {
+    const jupyterContextBarProps: ContextBarProps = {
       ...contextBarProps,
       runtimes: [jupyterLabRunning],
       persistentDisks: [],
@@ -573,7 +586,7 @@ describe('ContextBar - buttons', () => {
   });
 
   it('will render button with error status', () => {
-    const jupyterContextBarProps = {
+    const jupyterContextBarProps: ContextBarProps = {
       ...contextBarProps,
       runtimes: [
         {
@@ -593,28 +606,6 @@ describe('ContextBar - buttons', () => {
     expect(getByLabelText('Environment Configuration'));
     expect(getByLabelText(new RegExp(/Jupyter Environment/i)));
     expect(getByText(/Error \$0.00\/hr/));
-  });
-});
-
-describe('ContextBar - buttons (Prod config)', () => {
-  beforeEach(() => {
-    getConfig.mockReturnValue({ isProd: true });
-  });
-
-  it('will not render a Cromwell on Azure button if workspace is created before Workflows Public Preview date', () => {
-    // Arrange
-    const cromwellOnAzureContextBarProps = {
-      ...contextBarPropsForAzure,
-      apps: [cromwellOnAzureRunning],
-      appDataDisks: [],
-    };
-
-    // Act
-    const { getByLabelText, queryByLabelText } = render(h(ContextBar, cromwellOnAzureContextBarProps));
-
-    // Assert
-    expect(getByLabelText('Environment Configuration'));
-    expect(queryByLabelText(new RegExp(/Cromwell Environment/i))).not.toBeInTheDocument();
   });
 });
 
@@ -686,17 +677,21 @@ describe('ContextBar - actions', () => {
   it('clicking Terminal will attempt to start currently stopped runtime', async () => {
     // Arrange
     const mockRuntimesStartFn = jest.fn();
-    const mockRuntimeWrapper = jest.fn(() => ({
+    type RuntimesContract = AjaxContract['Runtimes'];
+
+    const mockRuntimeWrapper: Partial<RuntimesContract['runtimeWrapper']> = jest.fn(() => ({
       start: mockRuntimesStartFn,
     }));
-    Ajax.mockImplementation(() => ({
-      Runtimes: {
-        runtimeWrapper: mockRuntimeWrapper,
-      },
-      Metrics: {
-        captureEvent: jest.fn(),
-      },
-    }));
+
+    const mockRuntimes: Partial<RuntimesContract> = {
+      runtimeWrapper: mockRuntimeWrapper as RuntimesContract['runtimeWrapper'],
+    };
+
+    const newMockAjax: Partial<AjaxContract> = {
+      ...defaultAjaxImpl,
+      Runtimes: mockRuntimes as RuntimesContract,
+    };
+    asMockedFn(Ajax).mockImplementation(() => newMockAjax as AjaxContract);
 
     const myWindow = Object.create(window);
     const url = 'http://dummy.com';
@@ -705,13 +700,15 @@ describe('ContextBar - actions', () => {
         href: url,
       },
       writable: true,
+      // @ts-expect-error
+      // TODO: is this needed?
       hash: '/',
     });
-    const runtime = {
+    const runtime: Runtime = {
       ...jupyter,
       status: 'Stopped',
     };
-    const jupyterContextBarProps = {
+    const jupyterContextBarProps: ContextBarProps = {
       ...contextBarProps,
       runtimes: [runtime],
       persistentDisks: [runtimeDisk],
@@ -737,17 +734,21 @@ describe('ContextBar - actions', () => {
   it('clicking Terminal will not attempt to start an already running Jupyter notebook', () => {
     // Arrange
     const mockRuntimesStartFn = jest.fn();
-    const mockRuntimeWrapper = jest.fn(() => ({
+    type RuntimesContract = AjaxContract['Runtimes'];
+
+    const mockRuntimeWrapper: Partial<RuntimesContract['runtimeWrapper']> = jest.fn(() => ({
       start: mockRuntimesStartFn,
     }));
-    Ajax.mockImplementation(() => ({
-      Runtimes: {
-        runtimeWrapper: mockRuntimeWrapper,
-      },
-      Metrics: {
-        captureEvent: jest.fn(),
-      },
-    }));
+
+    const mockRuntimes: Partial<RuntimesContract> = {
+      runtimeWrapper: mockRuntimeWrapper as RuntimesContract['runtimeWrapper'],
+    };
+
+    const newMockAjax: Partial<AjaxContract> = {
+      ...defaultAjaxImpl,
+      Runtimes: mockRuntimes as RuntimesContract,
+    };
+    asMockedFn(Ajax).mockImplementation(() => newMockAjax as AjaxContract);
 
     const myWindow = Object.create(window);
     const url = 'http://dummy.com';
@@ -756,6 +757,8 @@ describe('ContextBar - actions', () => {
         href: url,
       },
       writable: true,
+      // @ts-expect-error
+      // TODO: is this needed?
       hash: '/',
     });
     const jupyterContextBarProps = {
@@ -797,7 +800,7 @@ describe('ContextBar - actions', () => {
 
   it('will not render Hail Batch if the feature flag is disabled', () => {
     // Arrange
-    const hailBatchContextBarProps = {
+    const hailBatchContextBarProps: ContextBarProps = {
       ...contextBarPropsForAzure,
       apps: [hailBatchAppRunning],
       appDataDisks: [],

--- a/src/analysis/ContextBar.test.ts
+++ b/src/analysis/ContextBar.test.ts
@@ -36,48 +36,76 @@ const GALAXY_DISK_COST = 1;
 const RUNTIME_COST = 0.1;
 const PERSISTENT_DISK_COST = 0.01;
 
-jest.mock('src/analysis/utils/cost-utils', () => ({
-  ...jest.requireActual('src/analysis/utils/cost-utils'),
-  getGalaxyComputeCost: jest.fn(),
-  getGalaxyDiskCost: jest.fn(),
-  getPersistentDiskCostHourly: jest.fn(),
-  getRuntimeCost: jest.fn(),
-  runtimeConfigCost: jest.fn(),
-}));
+type CostUtilsExports = typeof import('src/analysis/utils/cost-utils');
+jest.mock(
+  'src/analysis/utils/cost-utils',
+  (): CostUtilsExports => ({
+    ...jest.requireActual('src/analysis/utils/cost-utils'),
+    getGalaxyComputeCost: jest.fn(),
+    getGalaxyDiskCost: jest.fn(),
+    getPersistentDiskCostHourly: jest.fn(),
+    getRuntimeCost: jest.fn(),
+    runtimeConfigCost: jest.fn(),
+  })
+);
 
-jest.mock('src/analysis/utils/app-utils', () => ({
-  ...jest.requireActual('src/analysis/utils/app-utils'),
-  doesWorkspaceSupportCromwellAppForUser: jest.fn(),
-}));
+type AppUtilsExports = typeof import('src/analysis/utils/app-utils');
+jest.mock(
+  'src/analysis/utils/app-utils',
+  (): AppUtilsExports => ({
+    ...jest.requireActual('src/analysis/utils/app-utils'),
+    doesWorkspaceSupportCromwellAppForUser: jest.fn(),
+  })
+);
 
-jest.mock('src/analysis/utils/tool-utils', () => ({
-  ...jest.requireActual('src/analysis/utils/tool-utils'),
-  isToolHidden: jest.fn(),
-}));
+type ToolUtilsExports = typeof import('src/analysis/utils/tool-utils');
+jest.mock(
+  'src/analysis/utils/tool-utils',
+  (): ToolUtilsExports => ({
+    ...jest.requireActual('src/analysis/utils/tool-utils'),
+    isToolHidden: jest.fn(),
+  })
+);
 
 // Mocking for terminalLaunchLink using Nav.getLink
-jest.mock('src/libs/nav', () => ({
-  ...jest.requireActual('src/libs/nav'),
-  getPath: jest.fn(() => '/test/'),
-  getLink: jest.fn(() => '/'),
-}));
+type NavExports = typeof import('src/libs/nav');
+jest.mock(
+  'src/libs/nav',
+  (): NavExports => ({
+    ...jest.requireActual('src/libs/nav'),
+    getPath: jest.fn(() => '/test/'),
+    getLink: jest.fn(() => '/'),
+  })
+);
 
 // Mocking PopupTrigger to avoid test environment issues with React Portal's requirement to use
 // DOM measure services which are not available in jest environment
-jest.mock('src/components/PopupTrigger', () => ({
-  ...jest.requireActual('src/components/PopupTrigger'),
-  MenuTrigger: jest.fn(),
-}));
+type PopupTriggerExports = typeof import('src/components/PopupTrigger');
+jest.mock(
+  'src/components/PopupTrigger',
+  (): PopupTriggerExports => ({
+    ...jest.requireActual('src/components/PopupTrigger'),
+    MenuTrigger: jest.fn(),
+  })
+);
 
-jest.mock('src/analysis/modals/CloudEnvironmentModal', () => ({
-  ...jest.requireActual('src/analysis/modals/CloudEnvironmentModal'),
-  CloudEnvironmentModal: jest.fn(),
-}));
+type CloudEnvironmentModalExports = typeof import('src/analysis/modals/CloudEnvironmentModal');
+jest.mock(
+  'src/analysis/modals/CloudEnvironmentModal',
+  (): CloudEnvironmentModalExports => ({
+    ...jest.requireActual('src/analysis/modals/CloudEnvironmentModal'),
+    CloudEnvironmentModal: jest.fn(),
+  })
+);
 
-jest.mock('src/libs/config', () => ({
-  ...jest.requireActual('src/libs/config'),
-  isCromwellAppVisible: jest.fn(),
-}));
+type ConfigExports = typeof import('src/libs/config');
+jest.mock(
+  'src/libs/config',
+  (): ConfigExports => ({
+    ...jest.requireActual('src/libs/config'),
+    isCromwellAppVisible: jest.fn(),
+  })
+);
 
 jest.mock('src/libs/ajax');
 jest.mock('src/libs/feature-previews');
@@ -108,7 +136,7 @@ beforeEach(() => {
       : div([]);
   });
 
-  asMockedFn(Ajax).mockImplementation(() => defaultAjaxImpl as AjaxContract);
+  asMockedFn(Ajax).mockReturnValue(defaultAjaxImpl as AjaxContract);
 
   asMockedFn(getGalaxyComputeCost).mockReturnValue(GALAXY_COMPUTE_COST);
   asMockedFn(getGalaxyDiskCost).mockReturnValue(GALAXY_DISK_COST);
@@ -514,7 +542,7 @@ describe('ContextBar - buttons', () => {
 
   it('will render a Cromwell on Azure button with a disabled Terminal Button', () => {
     // Arrange
-    const cromwellOnAzureContextBarProps = {
+    const cromwellOnAzureContextBarProps: ContextBarProps = {
       ...contextBarPropsForAzure,
       apps: [cromwellOnAzureRunning],
       appDataDisks: [],
@@ -533,7 +561,7 @@ describe('ContextBar - buttons', () => {
 
   it('will not render a Cromwell button if workspace is not supported for cromwell', () => {
     // Arrange
-    const cromwellOnAzureContextBarProps = {
+    const cromwellOnAzureContextBarProps: ContextBarProps = {
       ...contextBarPropsForAzure,
       apps: [cromwellOnAzureRunning],
       appDataDisks: [],
@@ -551,7 +579,7 @@ describe('ContextBar - buttons', () => {
 
   it('will not render a cromwell button if it is hidden ', () => {
     // Arrange
-    const cromwellOnAzureContextBarProps = {
+    const cromwellOnAzureContextBarProps: ContextBarProps = {
       ...contextBarPropsForAzure,
       apps: [cromwellOnAzureRunning],
       appDataDisks: [],
@@ -623,7 +651,7 @@ describe('ContextBar - actions', () => {
 
   it('clicking Jupyter opens CloudEnvironmentModal with Jupyter as filter for tool.', () => {
     // Arrange
-    const jupyterContextBarProps = {
+    const jupyterContextBarProps: ContextBarProps = {
       ...contextBarProps,
       runtimes: [jupyter],
       persistentDisks: [runtimeDisk],
@@ -640,7 +668,7 @@ describe('ContextBar - actions', () => {
 
   it('clicking Galaxy opens CloudEnvironmentModal with Galaxy as filter for tool.', () => {
     // Arrange
-    const galaxyContextBarProps = {
+    const galaxyContextBarProps: ContextBarProps = {
       ...contextBarProps,
       apps: [galaxyRunning],
       appDataDisks: [galaxyDisk],
@@ -657,7 +685,7 @@ describe('ContextBar - actions', () => {
 
   it('clicking RStudio opens CloudEnvironmentModal with RStudio as filter for tool.', () => {
     // Act
-    const rstudioContextBarProps = {
+    const rstudioContextBarProps: ContextBarProps = {
       ...contextBarProps,
       runtimes: [rstudioRuntime],
       apps: [galaxyRunning],
@@ -691,7 +719,7 @@ describe('ContextBar - actions', () => {
       ...defaultAjaxImpl,
       Runtimes: mockRuntimes as RuntimesContract,
     };
-    asMockedFn(Ajax).mockImplementation(() => newMockAjax as AjaxContract);
+    asMockedFn(Ajax).mockReturnValue(newMockAjax as AjaxContract);
 
     const runtime: Runtime = {
       ...jupyter,
@@ -737,9 +765,9 @@ describe('ContextBar - actions', () => {
       ...defaultAjaxImpl,
       Runtimes: mockRuntimes as RuntimesContract,
     };
-    asMockedFn(Ajax).mockImplementation(() => newMockAjax as AjaxContract);
+    asMockedFn(Ajax).mockReturnValue(newMockAjax as AjaxContract);
 
-    const jupyterContextBarProps = {
+    const jupyterContextBarProps: ContextBarProps = {
       ...contextBarProps,
       runtimes: [jupyter],
       persistentDisks: [runtimeDisk],
@@ -796,7 +824,7 @@ describe('ContextBar - actions', () => {
 
   it('will render Hail Batch app if the feature flag is enabled', () => {
     // Arrange
-    const hailBatchContextBarProps = {
+    const hailBatchContextBarProps: ContextBarProps = {
       ...contextBarPropsForAzure,
       apps: [hailBatchAppRunning],
       appDataDisks: [],

--- a/src/analysis/ContextBar.ts
+++ b/src/analysis/ContextBar.ts
@@ -9,7 +9,7 @@
  */
 
 import _ from 'lodash/fp';
-import React, { Fragment, useState } from 'react';
+import { CSSProperties, Fragment, useState } from 'react';
 import { br, div, h, img, span } from 'react-hyperscript-helpers';
 import { CloudEnvironmentModal } from 'src/analysis/modals/CloudEnvironmentModal';
 import { appLauncherTabName } from 'src/analysis/runtime-common-components';
@@ -25,7 +25,7 @@ import {
 import {
   getCurrentAppDataDisk,
   getCurrentPersistentDisk,
-  mapToUndecoratedPd,
+  mapToUndecoratedPds,
   updatePdType,
 } from 'src/analysis/utils/disk-utils';
 import { getCurrentRuntime } from 'src/analysis/utils/runtime-utils';
@@ -66,7 +66,7 @@ import {
 } from 'src/libs/workspace-utils';
 import { StorageDetails } from 'src/pages/workspaces/workspace/useWorkspace';
 
-const contextBarStyles: { [label: string]: React.CSSProperties } = {
+const contextBarStyles: { [label: string]: CSSProperties } = {
   contextBarContainer: {
     display: 'flex',
     flexWrap: 'wrap',
@@ -179,7 +179,7 @@ export const ContextBar = ({
               appDataDisks,
               computeRegion,
               currentRuntimeTool,
-              mapToUndecoratedPd(persistentDisks),
+              mapToUndecoratedPds(persistentDisks),
               runtimes,
               toolLabel
             ),
@@ -223,7 +223,7 @@ export const ContextBar = ({
     const galaxyRuntimeCost = galaxyApp ? getGalaxyComputeCost(galaxyApp) : 0;
     const galaxyDiskCost = galaxyDisk ? getGalaxyDiskCost(galaxyDisk) : 0;
     const runtimeCost = currentRuntime ? getRuntimeCost(currentRuntime) : 0;
-    const curPd = getCurrentPersistentDisk(runtimes, mapToUndecoratedPd(persistentDisks));
+    const curPd = getCurrentPersistentDisk(runtimes, mapToUndecoratedPds(persistentDisks));
     const diskCost = curPd ? getPersistentDiskCostHourly(updatePdType(curPd), computeRegion) : 0;
     const display = Utils.formatUSD(galaxyRuntimeCost + galaxyDiskCost + runtimeCost + diskCost);
     return display;
@@ -252,7 +252,7 @@ export const ContextBar = ({
       refreshApps,
       workspace,
       canCompute,
-      persistentDisks: mapToUndecoratedPd(persistentDisks),
+      persistentDisks: mapToUndecoratedPds(persistentDisks),
       location,
       computeRegion,
     }),

--- a/src/analysis/ContextBar.ts
+++ b/src/analysis/ContextBar.ts
@@ -100,7 +100,7 @@ export const ContextBar = ({
   apps,
   appDataDisks,
   refreshRuntimes,
-  storageDetails, // : { azureContainerRegion, googleBucketLocation, googleBucketType },
+  storageDetails,
   refreshApps,
   workspace,
   persistentDisks,
@@ -374,7 +374,6 @@ export const ContextBar = ({
             {
               style: { paddingLeft: '1rem', alignItems: 'center', ...contextBarStyles.contextBarButton },
               hover: contextBarStyles.hover,
-              // 'data-testid': 'workspace-files-link',
               tooltipSide: 'left',
               href: Nav.getLink('workspace-files', { namespace, name }),
               tooltip: 'Browse workspace files',

--- a/src/analysis/ContextBar.ts
+++ b/src/analysis/ContextBar.ts
@@ -38,7 +38,7 @@ import {
 } from 'src/analysis/utils/tool-utils';
 import { Clickable } from 'src/components/common';
 import { icon } from 'src/components/icons';
-import Interactive from 'src/components/Interactive';
+import Interactive, { InteractiveProps } from 'src/components/Interactive';
 import { getRegionInfo } from 'src/components/region-common';
 import TooltipTrigger from 'src/components/TooltipTrigger';
 import cloudIcon from 'src/icons/cloud-compute.svg';
@@ -283,8 +283,6 @@ export const ContextBar = ({
                 Interactive,
                 {
                   as: 'div',
-                  // TODO: debug
-                  // @ts-expect-error
                   style: {
                     flexDirection: 'column',
                     justifyContent: 'center',
@@ -294,7 +292,7 @@ export const ContextBar = ({
                     cursor: 'default',
                   },
                   hover: { ...contextBarStyles.hover },
-                },
+                } as InteractiveProps<'div'>,
                 [
                   div({ style: { textAlign: 'center', color: colors.dark(), fontSize: 12 } }, ['Rate:']),
                   div(

--- a/src/analysis/_testData/testData.ts
+++ b/src/analysis/_testData/testData.ts
@@ -269,6 +269,7 @@ export const getRuntimeConfig = (overrides: Partial<RuntimeConfig> = {}): Runtim
   ...overrides,
 });
 
+// Use this if you only need to override top-level fields, otherwise use `getGoogleRuntime`
 export const generateTestGoogleRuntime = (overrides: Partial<Runtime> = {}): Runtime => {
   const runtime: Runtime = {
     id: getRandomInt(randomMaxInt),
@@ -377,7 +378,7 @@ export const getGoogleDataProcRuntime = ({
   };
 };
 
-// TODO: deprecate this in favor of more robust `generateTestGoogleRuntime`
+// Use this if you want a shortcut to override nested fields. Otherwise use `generateTestGoogleRuntime`
 export const getGoogleRuntime = ({
   workspace = defaultGoogleWorkspace,
   runtimeName = Utils.generateRuntimeName(),

--- a/src/analysis/modals/CloudEnvironmentModal.ts
+++ b/src/analysis/modals/CloudEnvironmentModal.ts
@@ -55,11 +55,10 @@ import { useCancellation, useStore } from 'src/libs/react-utils';
 import { azureCookieReadyStore, cookieReadyStore } from 'src/libs/state';
 import * as Utils from 'src/libs/utils';
 import {
-  AzureWorkspace,
+  BaseWorkspace,
   CloudProvider,
   cloudProviderTypes,
   getCloudProviderFromWorkspace,
-  GoogleWorkspace,
 } from 'src/libs/workspace-utils';
 
 const titleId = 'cloud-env-modal';
@@ -79,9 +78,6 @@ export const CloudEnvironmentModal = ({
   // Note: for Azure environments `location` and `computeRegion` are identical
   location,
   computeRegion,
-  workspace: {
-    workspace: { namespace, name: workspaceName },
-  },
   filterForTool = undefined,
 }: {
   isOpen: boolean;
@@ -93,7 +89,7 @@ export const CloudEnvironmentModal = ({
   appDataDisks: PersistentDisk[];
   refreshRuntimes: () => Promise<void>;
   refreshApps: () => Promise<void>;
-  workspace: GoogleWorkspace | AzureWorkspace;
+  workspace: BaseWorkspace;
   persistentDisks: PersistentDisk[];
   location: string;
   computeRegion: string;
@@ -109,6 +105,7 @@ export const CloudEnvironmentModal = ({
   const currentDisk = getCurrentPersistentDisk(runtimes, persistentDisks);
   const signal = useCancellation();
 
+  const { name, namespace } = workspace.workspace;
   const noCompute = 'You do not have access to run analyses on this workspace.';
 
   const resetView = () => setViewMode(undefined);
@@ -495,7 +492,7 @@ export const CloudEnvironmentModal = ({
           // TODO: Jupyter link isn't currently valid, and button will always be disabled for Jupyter because launching directly into tree view is problematic in terms of welder/nbextensions. We are investigating alternatives in https://broadworkbench.atlassian.net/browse/IA-2873
           const applicationLaunchLink = Nav.getLink(appLauncherTabName, {
             namespace,
-            name: workspaceName,
+            name,
             application: toolLabel,
           });
           return {

--- a/src/analysis/utils/disk-utils.ts
+++ b/src/analysis/utils/disk-utils.ts
@@ -39,7 +39,7 @@ export const undecoratePd = (disk: DecoratedPersistentDisk): PersistentDisk => (
   diskType: disk.diskType.value,
 });
 
-export const mapToUndecoratedPd = (disks: DecoratedPersistentDisk[]): PersistentDisk[] => _.map(undecoratePd, disks);
+export const mapToUndecoratedPds = (disks: DecoratedPersistentDisk[]): PersistentDisk[] => _.map(undecoratePd, disks);
 
 // Dataproc clusters don't have persistent disks.
 export const defaultDataprocMasterDiskSize = 150;

--- a/src/analysis/utils/disk-utils.ts
+++ b/src/analysis/utils/disk-utils.ts
@@ -27,11 +27,20 @@ export const pdTypeFromDiskType = (type: GoogleDiskType): GooglePdType =>
         console.error(`Invalid disk type: Should not be calling googlePdTypes.fromString for ${JSON.stringify(type)}`),
     ]
   );
+
 export const updatePdType = (disk: PersistentDisk): DecoratedPersistentDisk => ({
   ...disk,
   diskType: pdTypeFromDiskType(disk.diskType),
 });
 export const mapToPdTypes = (disks: PersistentDisk[]): DecoratedPersistentDisk[] => _.map(updatePdType, disks);
+
+export const undecoratePd = (disk: DecoratedPersistentDisk): PersistentDisk => ({
+  ...disk,
+  diskType: disk.diskType.value,
+});
+
+export const mapToUndecoratedPd = (disks: DecoratedPersistentDisk[]): PersistentDisk[] => _.map(undecoratePd, disks);
+
 // Dataproc clusters don't have persistent disks.
 export const defaultDataprocMasterDiskSize = 150;
 export const defaultDataprocWorkerDiskSize = 150;
@@ -112,7 +121,7 @@ export const getCurrentAppDataDisk = (
 export const getCurrentPersistentDisk = (
   runtimes: Runtime[],
   persistentDisks: PersistentDisk[]
-): DecoratedPersistentDisk | PersistentDisk | undefined => {
+): PersistentDisk | undefined => {
   const currentRuntime = getCurrentRuntime(runtimes);
   const id: number | undefined = _.get('persistentDiskId', currentRuntime?.runtimeConfig);
   const attachedIds: number[] = _.without(

--- a/src/components/Interactive.d.ts
+++ b/src/components/Interactive.d.ts
@@ -1,6 +1,6 @@
 import { CSSProperties, PropsWithChildren } from 'react';
 
-export type InteractiveProps<Tag extends keyof JSX.IntrinsicElements> = PropsWithChildren<
+export type InteractiveProps<Tag extends keyof JSX.IntrinsicElements = 'div'> = PropsWithChildren<
   {
     as: Tag;
     disabled?: boolean;

--- a/src/components/Interactive.d.ts
+++ b/src/components/Interactive.d.ts
@@ -1,6 +1,6 @@
 import { CSSProperties, PropsWithChildren } from 'react';
 
-export type InteractiveProps<Tag extends keyof JSX.IntrinsicElements = 'div'> = PropsWithChildren<
+export type InteractiveProps<Tag extends keyof JSX.IntrinsicElements> = PropsWithChildren<
   {
     as: Tag;
     disabled?: boolean;

--- a/src/components/common/Clickable.d.ts
+++ b/src/components/common/Clickable.d.ts
@@ -1,9 +1,10 @@
+import React from 'react';
 import type { InteractiveProps } from 'src/components/Interactive';
 
 export type ClickableProps<T extends keyof JSX.IntrinsicElements = 'div'> = {
   as?: T;
   href?: string;
-  tooltip?: string;
+  tooltip?: string | React.ReactElement<any, any>;
   tooltipSide?: 'top' | 'bottom' | 'left' | 'right';
   tooltipDelay?: number;
   useTooltipAsLabel?: boolean;

--- a/src/components/common/Clickable.d.ts
+++ b/src/components/common/Clickable.d.ts
@@ -1,10 +1,10 @@
-import React from 'react';
+import { ReactNode } from 'react';
 import type { InteractiveProps } from 'src/components/Interactive';
 
 export type ClickableProps<T extends keyof JSX.IntrinsicElements = 'div'> = {
   as?: T;
   href?: string;
-  tooltip?: string | React.ReactElement<'div'>;
+  tooltip?: ReactNode;
   tooltipSide?: 'top' | 'bottom' | 'left' | 'right';
   tooltipDelay?: number;
   useTooltipAsLabel?: boolean;

--- a/src/components/common/Clickable.d.ts
+++ b/src/components/common/Clickable.d.ts
@@ -4,7 +4,7 @@ import type { InteractiveProps } from 'src/components/Interactive';
 export type ClickableProps<T extends keyof JSX.IntrinsicElements = 'div'> = {
   as?: T;
   href?: string;
-  tooltip?: string | React.ReactElement<any, any>;
+  tooltip?: string | React.ReactElement<'div'>;
   tooltipSide?: 'top' | 'bottom' | 'left' | 'right';
   tooltipDelay?: number;
   useTooltipAsLabel?: boolean;

--- a/src/libs/ajax/leonardo/models/disk-models.ts
+++ b/src/libs/ajax/leonardo/models/disk-models.ts
@@ -125,6 +125,3 @@ export interface AzurePdSelectOption {
 }
 
 export const azureDiskSizes: number[] = [32, 64, 128, 256, 512, 1024, 2048, 4095];
-
-export const isUndecoratedPersistentDisk = (disk: PersistentDisk | DecoratedPersistentDisk): disk is PersistentDisk =>
-  typeof disk === 'string' && Object.values(googlePdTypes).map((pdt) => pdt.value) === disk;


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/IA-4422

<!-- ### Dependencies --->
There are other warnings caused by IA components, but I will address those in separate PRs

## Summary of changes:
- Some warnings by the tests in `ContextBar.test.js` were brought to our attention. The warnings were really hinting an insidious underlying issue caused by the `.js` test file using improperly typed test data, which was further complicated by the `.js` component also improperly assuming things about the data it received. As a result, I found simply converting the files a much easier exercise, and let the 'compiler' fix the issues for me.
- Note that the `DecoratedPersistentDisk` and `PersistentDisk` types that the issues arose around are pretty code-smelly, and there should definitely be a common/base interface to reconcile this, but the scope of that is a good bit larger than this fix  

### Why
- Our tests should not have warnings and our `.js` should be converted as issues arise due to improper use of typed data/functions

### Testing strategy
- [ ] The file's tests were pretty thorough, I did add a few though

