### PR TITLE
[WOR-1094] Clarify that we only consult the Sam azure preview group in prod.

### DIFF
--- a/config/alpha.json
+++ b/config/alpha.json
@@ -27,7 +27,7 @@
     "appId": "saturnnonprod-O9lUP",
     "apiKey": "AQEBBAEkx4iE2KxNyI7Wx08EwU1ycTM7E4FMSmaibbMUQxNU6uQvuAJt7fyABAtFYSYfgEE"
   },
-  "azurePreviewGroup": "alpha-azure-feature-group",
+  "azurePreviewGroup": true,
   "alphaRegionalityGroup": "Alpha_Regionality_Users",
   "terraDockerVersionsFile": "terra-docker-versions-alpha.json",
   "terraDockerImageBucket": "terra-docker-image-documentation-alpha",

--- a/config/dev.json
+++ b/config/dev.json
@@ -27,7 +27,7 @@
     "appId": "saturnnonprod-O9lUP",
     "apiKey": "AQEBBAEkx4iE2KxNyI7Wx08EwU1ycTM7E4FMSmaibbMUQxNU6uQvuAJt7fyABAtFYSYfgEE"
   },
-  "azurePreviewGroup": "alpha-azure-feature-group",
+  "azurePreviewGroup": true,
   "alphaRegionalityGroup": "Alpha_Regionality_Users",
   "terraDockerVersionsFile": "terra-docker-versions-dev.json",
   "terraDockerImageBucket": "terra-docker-image-documentation-dev",

--- a/config/fiab.json
+++ b/config/fiab.json
@@ -26,7 +26,7 @@
     "appId": "saturnnonprod-O9lUP",
     "apiKey": "AQEBBAEkx4iE2KxNyI7Wx08EwU1ycTM7E4FMSmaibbMUQxNU6uQvuAJt7fyABAtFYSYfgEE"
   },
-  "azurePreviewGroup": "alpha-azure-feature-group",
+  "azurePreviewGroup": true,
   "alphaRegionalityGroup": "Alpha_Regionality_Users",
   "terraDockerVersionsFile": "terra-docker-versions-dev.json",
   "terraDockerImageBucket": "terra-docker-image-documentation-dev",

--- a/config/staging.json
+++ b/config/staging.json
@@ -26,7 +26,7 @@
     "appId": "saturnnonprod-O9lUP",
     "apiKey": "AQEBBAEkx4iE2KxNyI7Wx08EwU1ycTM7E4FMSmaibbMUQxNU6uQvuAJt7fyABAtFYSYfgEE"
   },
-  "azurePreviewGroup": "alpha-azure-feature-group",
+  "azurePreviewGroup": true,
   "alphaRegionalityGroup": "Alpha_Regionality_Users",
   "terraDockerVersionsFile": "terra-docker-versions-staging.json",
   "terraDockerImageBucket": "terra-docker-image-documentation-staging",

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -446,9 +446,9 @@ workspaceStore.subscribe((newState, oldState) => {
 authStore.subscribe(
   withErrorReporting('Error loading azure preview group membership', async (state, oldState) => {
     if (becameRegistered(oldState, state)) {
-      // Note that `azurePreviewGroup` is set to true in all non-prod config files, so only call Sam group for prod.
-      const bypassSam = getConfig().azurePreviewGroup !== true;
-      const isGroupMember = bypassSam || (await Ajax().Groups.group(getConfig().azurePreviewGroup).isMember());
+      // Note that `azurePreviewGroup` is set to true in all non-prod config files, so only call Sam if we have a non-boolean value (prod).
+      const configValue = getConfig().azurePreviewGroup;
+      const isGroupMember = _.isBoolean(configValue) ? configValue : await Ajax().Groups.group(configValue).isMember();
       const isAzurePreviewUser = oldState.isAzurePreviewUser || isGroupMember;
       authStore.update((state) => ({ ...state, isAzurePreviewUser }));
     }


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WOR-1094

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->
There has been confusion about the Sam azure preview group related to when a user needs to be added to it for testing purposes.

This PR attempts to clarify that the Sam group is only consulted in production… in non-prod environments there is no gating at all.

After this merges, I will delete the `alpha-azure-feature-group` group in all non-prod environments.

### Testing strategy
- [x] Make sure you still see the control to create an Azure billing project for your favorite non-Microsoft testing email address on the PR site.
