### PR TITLE
[DC-733] Import act from React Testing Library

### DIFF
--- a/src/analysis/Analyses.test.ts
+++ b/src/analysis/Analyses.test.ts
@@ -1,6 +1,5 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { act } from 'react-dom/test-utils';
 import { h } from 'react-hyperscript-helpers';
 import { defaultAzureWorkspace, defaultGoogleWorkspace } from 'src/analysis/_testData/testData';
 import { AnalysesData, AnalysesProps, BaseAnalyses, getUniqueFileName } from 'src/analysis/Analyses';

--- a/src/analysis/ContextBar.test.js
+++ b/src/analysis/ContextBar.test.js
@@ -1,5 +1,4 @@
-import { fireEvent, render } from '@testing-library/react';
-import { act } from 'react-dom/test-utils';
+import { act, fireEvent, render } from '@testing-library/react';
 import { div, h } from 'react-hyperscript-helpers';
 import { ContextBar } from 'src/analysis/ContextBar';
 import { CloudEnvironmentModal } from 'src/analysis/modals/CloudEnvironmentModal';

--- a/src/analysis/Environments.test.ts
+++ b/src/analysis/Environments.test.ts
@@ -1,7 +1,6 @@
-import { fireEvent, getAllByRole, render, screen } from '@testing-library/react';
+import { act, fireEvent, getAllByRole, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import _ from 'lodash/fp';
-import { act } from 'react-dom/test-utils';
 import { h } from 'react-hyperscript-helpers';
 import {
   azureRuntime,

--- a/src/analysis/PeriodicAzureCookieSetter.test.ts
+++ b/src/analysis/PeriodicAzureCookieSetter.test.ts
@@ -1,5 +1,3 @@
-import '@testing-library/jest-dom';
-
 import { render } from '@testing-library/react';
 import { h } from 'react-hyperscript-helpers';
 import { PeriodicAzureCookieSetter } from 'src/analysis/runtime-common-components';

--- a/src/analysis/modals/AnalysisDuplicator.test.ts
+++ b/src/analysis/modals/AnalysisDuplicator.test.ts
@@ -1,5 +1,3 @@
-import '@testing-library/jest-dom';
-
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { h } from 'react-hyperscript-helpers';

--- a/src/analysis/modals/AnalysisModal.test.ts
+++ b/src/analysis/modals/AnalysisModal.test.ts
@@ -1,5 +1,3 @@
-import '@testing-library/jest-dom';
-
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { h } from 'react-hyperscript-helpers';

--- a/src/analysis/modals/CloudEnvironmentModal.test.ts
+++ b/src/analysis/modals/CloudEnvironmentModal.test.ts
@@ -1,5 +1,3 @@
-import '@testing-library/jest-dom';
-
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { h, p } from 'react-hyperscript-helpers';

--- a/src/analysis/modals/CloudEnvironmentModal.test.ts
+++ b/src/analysis/modals/CloudEnvironmentModal.test.ts
@@ -1,8 +1,7 @@
 import '@testing-library/jest-dom';
 
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { act } from 'react-dom/test-utils';
 import { h, p } from 'react-hyperscript-helpers';
 import {
   azureDisk,

--- a/src/analysis/modals/ComputeModal/AboutPersistentDiskSection.test.ts
+++ b/src/analysis/modals/ComputeModal/AboutPersistentDiskSection.test.ts
@@ -1,5 +1,3 @@
-import '@testing-library/dom';
-
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { h } from 'react-hyperscript-helpers';

--- a/src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeModal.test.js
+++ b/src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeModal.test.js
@@ -1,7 +1,6 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import _ from 'lodash/fp';
-import { act } from 'react-dom/test-utils';
 import { h } from 'react-hyperscript-helpers';
 import { azureRuntime, defaultAzureWorkspace, defaultTestDisk, getDisk, imageDocs, testAzureDefaultRegion } from 'src/analysis/_testData/testData';
 import { getAzureComputeCostEstimate, getAzureDiskCostEstimate } from 'src/analysis/utils/cost-utils';

--- a/src/analysis/modals/ComputeModal/AzureComputeModal/AzurePersistentDiskSection.test.ts
+++ b/src/analysis/modals/ComputeModal/AzureComputeModal/AzurePersistentDiskSection.test.ts
@@ -1,5 +1,3 @@
-import '@testing-library/jest-dom';
-
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { h } from 'react-hyperscript-helpers';

--- a/src/analysis/modals/ComputeModal/AzureComputeModal/AzurePersistentDiskSizeSelectInput.test.ts
+++ b/src/analysis/modals/ComputeModal/AzureComputeModal/AzurePersistentDiskSizeSelectInput.test.ts
@@ -1,5 +1,3 @@
-import '@testing-library/dom';
-
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { h } from 'react-hyperscript-helpers';

--- a/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal.test.js
+++ b/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal.test.js
@@ -1,7 +1,6 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import _ from 'lodash/fp';
-import { act } from 'react-dom/test-utils';
 import { h } from 'react-hyperscript-helpers';
 import {
   defaultGoogleWorkspace,

--- a/src/analysis/modals/ComputeModal/GcpComputeModal/GcpPersistentDiskSection.test.ts
+++ b/src/analysis/modals/ComputeModal/GcpComputeModal/GcpPersistentDiskSection.test.ts
@@ -1,5 +1,3 @@
-import '@testing-library/jest-dom';
-
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { h } from 'react-hyperscript-helpers';

--- a/src/analysis/modals/ComputeModal/GcpComputeModal/GcpPersistentDiskSizeNumberInput.test.ts
+++ b/src/analysis/modals/ComputeModal/GcpComputeModal/GcpPersistentDiskSizeNumberInput.test.ts
@@ -1,5 +1,3 @@
-import '@testing-library/dom';
-
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { h } from 'react-hyperscript-helpers';

--- a/src/analysis/modals/ComputeModal/PersistentDiskTypeInput.test.ts
+++ b/src/analysis/modals/ComputeModal/PersistentDiskTypeInput.test.ts
@@ -1,5 +1,3 @@
-import '@testing-library/jest-dom';
-
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { h } from 'react-hyperscript-helpers';

--- a/src/analysis/modals/DeleteDiskChoices.test.ts
+++ b/src/analysis/modals/DeleteDiskChoices.test.ts
@@ -1,5 +1,3 @@
-import '@testing-library/jest-dom';
-
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { h } from 'react-hyperscript-helpers';

--- a/src/analysis/modals/HailBatchModal.test.ts
+++ b/src/analysis/modals/HailBatchModal.test.ts
@@ -1,5 +1,3 @@
-import '@testing-library/jest-dom';
-
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { h } from 'react-hyperscript-helpers';

--- a/src/analysis/setAzureCookieOnUrl.test.ts
+++ b/src/analysis/setAzureCookieOnUrl.test.ts
@@ -1,5 +1,3 @@
-import '@testing-library/jest-dom';
-
 import { render } from '@testing-library/react';
 import { h } from 'react-hyperscript-helpers';
 import { PeriodicAzureCookieSetter, setAzureCookieOnUrl } from 'src/analysis/runtime-common-components';

--- a/src/analysis/utils/file-utils.test.ts
+++ b/src/analysis/utils/file-utils.test.ts
@@ -1,5 +1,3 @@
-import '@testing-library/jest-dom';
-
 import { act, renderHook } from '@testing-library/react-hooks';
 import { defaultAzureWorkspace, defaultGoogleWorkspace } from 'src/analysis/_testData/testData';
 import { AnalysisFile, getFileFromPath, useAnalysisFiles } from 'src/analysis/useAnalysisFiles';

--- a/src/components/file-browser/DirectoryTree.test.ts
+++ b/src/components/file-browser/DirectoryTree.test.ts
@@ -1,5 +1,3 @@
-import '@testing-library/jest-dom';
-
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';

--- a/src/components/file-browser/FileBrowser.test.ts
+++ b/src/components/file-browser/FileBrowser.test.ts
@@ -1,5 +1,3 @@
-import '@testing-library/jest-dom';
-
 import { render } from '@testing-library/react';
 import { h } from 'react-hyperscript-helpers';
 import { useFilesInDirectory } from 'src/components/file-browser/file-browser-hooks';

--- a/src/components/file-browser/FileDetails.test.ts
+++ b/src/components/file-browser/FileDetails.test.ts
@@ -1,5 +1,3 @@
-import '@testing-library/jest-dom';
-
 import { render, screen } from '@testing-library/react';
 import { div, h } from 'react-hyperscript-helpers';
 import { DownloadFileCommand } from 'src/components/file-browser/DownloadFileCommand';

--- a/src/components/file-browser/FilesInDirectory.test.ts
+++ b/src/components/file-browser/FilesInDirectory.test.ts
@@ -1,5 +1,3 @@
-import '@testing-library/jest-dom';
-
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { div, h } from 'react-hyperscript-helpers';

--- a/src/components/file-browser/FilesTable.test.ts
+++ b/src/components/file-browser/FilesTable.test.ts
@@ -1,5 +1,3 @@
-import '@testing-library/jest-dom';
-
 import { getAllByRole, getByRole, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useState } from 'react';

--- a/src/components/file-browser/PathBreadcrumbs.test.ts
+++ b/src/components/file-browser/PathBreadcrumbs.test.ts
@@ -1,5 +1,3 @@
-import '@testing-library/jest-dom';
-
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { h } from 'react-hyperscript-helpers';

--- a/src/libs/terms-of-service-alerts.test.js
+++ b/src/libs/terms-of-service-alerts.test.js
@@ -1,5 +1,4 @@
-import { render } from '@testing-library/react';
-import { act } from 'react-dom/test-utils';
+import { act, render } from '@testing-library/react';
 import { h } from 'react-hyperscript-helpers';
 import Alerts from 'src/components/Alerts';
 import { Ajax } from 'src/libs/ajax';

--- a/src/pages/TermsOfService.test.js
+++ b/src/pages/TermsOfService.test.js
@@ -1,5 +1,4 @@
-import { render, screen } from '@testing-library/react';
-import { act } from 'react-dom/test-utils';
+import { act, render, screen } from '@testing-library/react';
 import { h } from 'react-hyperscript-helpers';
 import { Ajax } from 'src/libs/ajax';
 import { authStore } from 'src/libs/state';

--- a/src/pages/billing/NewBillingProjectWizard/AzureBillingProjectWizard/AddUsersStep.test.ts
+++ b/src/pages/billing/NewBillingProjectWizard/AzureBillingProjectWizard/AddUsersStep.test.ts
@@ -1,6 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { act } from 'react-dom/test-utils';
 import { h } from 'react-hyperscript-helpers';
 import { AddUsersStep } from 'src/pages/billing/NewBillingProjectWizard/AzureBillingProjectWizard/AddUsersStep';
 

--- a/src/pages/billing/NewBillingProjectWizard/AzureBillingProjectWizard/CreateNamedProjectStep.test.ts
+++ b/src/pages/billing/NewBillingProjectWizard/AzureBillingProjectWizard/CreateNamedProjectStep.test.ts
@@ -1,6 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { act } from 'react-dom/test-utils';
 import { h } from 'react-hyperscript-helpers';
 import { CreateNamedProjectStep } from 'src/pages/billing/NewBillingProjectWizard/AzureBillingProjectWizard/CreateNamedProjectStep';
 

--- a/src/pages/billing/NewBillingProjectWizard/GCPBillingProjectWizard/GCPBillingProjectWizard.test.ts
+++ b/src/pages/billing/NewBillingProjectWizard/GCPBillingProjectWizard/GCPBillingProjectWizard.test.ts
@@ -1,7 +1,6 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
-import { act } from 'react-dom/test-utils';
 import { h } from 'react-hyperscript-helpers';
 import { Ajax } from 'src/libs/ajax';
 import Events from 'src/libs/events';

--- a/src/pages/billing/NewBillingProjectWizard/StepWizard/Step.test.ts
+++ b/src/pages/billing/NewBillingProjectWizard/StepWizard/Step.test.ts
@@ -1,5 +1,3 @@
-import '@testing-library/jest-dom';
-
 import { render } from '@testing-library/react';
 import { sum } from 'lodash/fp';
 import { div, h } from 'react-hyperscript-helpers';

--- a/src/pages/billing/SpendReport/SpendReport.test.ts
+++ b/src/pages/billing/SpendReport/SpendReport.test.ts
@@ -1,5 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { act } from 'react-dom/test-utils';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { h } from 'react-hyperscript-helpers';
 import { Ajax } from 'src/libs/ajax';
 import {

--- a/src/pages/workspaces/workspace/Dashboard.test.js
+++ b/src/pages/workspaces/workspace/Dashboard.test.js
@@ -1,8 +1,7 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 import _ from 'lodash/fp';
-import { act } from 'react-dom/test-utils';
 import { h } from 'react-hyperscript-helpers';
 import { defaultLocation } from 'src/analysis/utils/runtime-utils';
 import { locationTypes } from 'src/components/region-common';

--- a/src/pages/workspaces/workspace/ShareWorkspaceModal/Collaborator.test.ts
+++ b/src/pages/workspaces/workspace/ShareWorkspaceModal/Collaborator.test.ts
@@ -1,5 +1,3 @@
-import '@testing-library/jest-dom';
-
 import { fireEvent, render, screen } from '@testing-library/react';
 import { Dispatch, SetStateAction } from 'react';
 import { h } from 'react-hyperscript-helpers';

--- a/src/pages/workspaces/workspace/ShareWorkspaceModal/ShareWorkspaceModal.test.ts
+++ b/src/pages/workspaces/workspace/ShareWorkspaceModal/ShareWorkspaceModal.test.ts
@@ -1,5 +1,3 @@
-import '@testing-library/jest-dom';
-
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import _ from 'lodash/fp';
 import { h } from 'react-hyperscript-helpers';


### PR DESCRIPTION
>  It is recommended to use the import from `@testing-library/react` over `react-dom/test-utils` for consistency reasons.
https://testing-library.com/docs/react-testing-library/api#act

With React 18 and React Testing Library v14, importing act from `react-dom/test-utils` results in warnings about "The current testing environment is not configured to support act".

While we're at it, this removes unnecessary imports from `@testing-library/dom` and `@testing-library/jest-dom`. These are imported within Testing Library and in setupTests, respectively.