### PR TITLE
[DC-733] Update tests that use renderHook for compatibility with React 18

### DIFF
--- a/src/analysis/modals/ExportAnalysisModal/useAnalysisExportState.test.ts
+++ b/src/analysis/modals/ExportAnalysisModal/useAnalysisExportState.test.ts
@@ -134,10 +134,9 @@ describe('useAnalysisExportState', () => {
       useAnalysisExportState(sourceWorkspace as WorkspaceWrapper, 'PrintName123', runtimeToolLabels.Jupyter)
     );
     const hookResult1 = renderedHook.result.current;
-    act(() => {
+    await act(async () => {
       hookResult1.selectWorkspace('Workspace2');
     });
-    await renderedHook.waitForNextUpdate();
 
     // Assert
     const hookResult = renderedHook.result.current;
@@ -197,10 +196,9 @@ describe('useAnalysisExportState', () => {
       useAnalysisExportState(sourceWorkspace as WorkspaceWrapper, 'PrintName123', runtimeToolLabels.Jupyter)
     );
     const hookResult1 = renderedHook.result.current;
-    act(() => {
+    await act(async () => {
       hookResult1.selectWorkspace('Workspace3');
     });
-    await renderedHook.waitForNextUpdate();
 
     // Assert
     const hookResult = renderedHook.result.current;
@@ -256,15 +254,15 @@ describe('useAnalysisExportState', () => {
       useAnalysisExportState(sourceWorkspace as WorkspaceWrapper, 'PrintName123', runtimeToolLabels.Jupyter)
     );
     const hookResult1 = renderedHook.result.current;
-    act(() => {
+    await act(async () => {
       hookResult1.selectWorkspace('Workspace2');
     });
-    await renderedHook.waitForNextUpdate();
 
     // Act
     const hookResult2 = renderedHook.result.current;
-    hookResult2.copyAnalysis('NewName123');
-    await renderedHook.waitForNextUpdate();
+    await act(async () => {
+      hookResult2.copyAnalysis('NewName123');
+    });
 
     // Assert
     const hookResult = renderedHook.result.current;
@@ -324,8 +322,9 @@ describe('useAnalysisExportState', () => {
 
     // Act
     const hookResult2 = renderedHook.result.current;
-    hookResult2.copyAnalysis('NewName123');
-    await renderedHook.waitForNextUpdate();
+    await act(async () => {
+      hookResult2.copyAnalysis('NewName123');
+    });
 
     // Assert
     const hookResult = renderedHook.result.current;

--- a/src/analysis/utils/file-utils.test.ts
+++ b/src/analysis/utils/file-utils.test.ts
@@ -54,8 +54,7 @@ describe('file-utils', () => {
 
       // Act
       workspaceStore.set(defaultGoogleWorkspace);
-      const { result: hookReturnRef, waitForNextUpdate } = renderHook(() => useAnalysisFiles());
-      await waitForNextUpdate();
+      const { result: hookReturnRef } = await act(() => renderHook(() => useAnalysisFiles()));
       const state = hookReturnRef.current.loadedState;
 
       // Assert
@@ -78,8 +77,7 @@ describe('file-utils', () => {
 
       // Act
       workspaceStore.set(defaultGoogleWorkspace);
-      const { waitForNextUpdate } = renderHook(() => useAnalysisFiles());
-      await waitForNextUpdate();
+      await act(() => renderHook(() => useAnalysisFiles()));
 
       // Assert
       expect(listAnalyses).toHaveBeenCalledWith(
@@ -103,8 +101,7 @@ describe('file-utils', () => {
 
       // Act
       workspaceStore.set(defaultAzureWorkspace);
-      const { waitForNextUpdate } = renderHook(() => useAnalysisFiles());
-      await waitForNextUpdate();
+      await act(() => renderHook(() => useAnalysisFiles()));
 
       // Assert
       expect(calledMock).toHaveBeenCalledWith(defaultAzureWorkspace.workspace.workspaceId);
@@ -130,8 +127,7 @@ describe('file-utils', () => {
 
       // Act
       workspaceStore.set(defaultGoogleWorkspace);
-      const { result: hookReturnRef, waitForNextUpdate } = renderHook(() => useAnalysisFiles());
-      await waitForNextUpdate();
+      const { result: hookReturnRef } = await act(() => renderHook(() => useAnalysisFiles()));
       await act(() => hookReturnRef.current.createAnalysis('AnalysisFile', runtimeToolLabels.Jupyter, 'myContents'));
 
       // Assert
@@ -154,8 +150,7 @@ describe('file-utils', () => {
 
       // Act
       workspaceStore.set(defaultGoogleWorkspace);
-      const hookRender1 = renderHook(() => useAnalysisFiles());
-      await hookRender1.waitForNextUpdate();
+      const hookRender1 = await act(() => renderHook(() => useAnalysisFiles()));
       const hookResult2 = hookRender1.result.current;
       await act(() => hookResult2.createAnalysis('AnalysisFile', runtimeToolLabels.Jupyter, 'myContents'));
 
@@ -182,8 +177,7 @@ describe('file-utils', () => {
       };
       asMockedFn(AzureStorage).mockImplementation(() => azureStorageMock as AzureStorageContract);
       workspaceStore.set(defaultAzureWorkspace);
-      const { result: hookReturnRef, waitForNextUpdate } = renderHook(() => useAnalysisFiles());
-      await waitForNextUpdate();
+      const { result: hookReturnRef } = await act(() => renderHook(() => useAnalysisFiles()));
       // Act
       await act(() => hookReturnRef.current.createAnalysis('AnalysisFile', runtimeToolLabels.Jupyter, 'myContents'));
 
@@ -207,8 +201,7 @@ describe('file-utils', () => {
 
     // Act
     workspaceStore.set(defaultAzureWorkspace);
-    const hookRender1 = renderHook(() => useAnalysisFiles());
-    await hookRender1.waitForNextUpdate();
+    const hookRender1 = await act(() => renderHook(() => useAnalysisFiles()));
     const hookResult2 = hookRender1.result.current;
     await act(() => hookResult2.createAnalysis('AnalysisFile', runtimeToolLabels.Jupyter, 'myContents'));
 
@@ -237,8 +230,7 @@ describe('file-utils', () => {
 
     // Act
     workspaceStore.set(defaultGoogleWorkspace);
-    const { result: hookReturnRef, waitForNextUpdate } = renderHook(() => useAnalysisFiles());
-    await waitForNextUpdate();
+    const { result: hookReturnRef } = await act(() => renderHook(() => useAnalysisFiles()));
     await act(() => hookReturnRef.current.deleteAnalysis(file1Path));
 
     // Assert
@@ -268,8 +260,7 @@ describe('file-utils', () => {
 
     // Act
     workspaceStore.set(defaultGoogleWorkspace);
-    const hookRender1 = renderHook(() => useAnalysisFiles());
-    await hookRender1.waitForNextUpdate();
+    const hookRender1 = await act(() => renderHook(() => useAnalysisFiles()));
     const hookResult2 = hookRender1.result.current;
     await act(() => hookResult2.deleteAnalysis(file1Path));
 
@@ -300,8 +291,7 @@ describe('file-utils', () => {
     };
     asMockedFn(AzureStorage).mockImplementation(() => azureStorageMock as AzureStorageContract);
     workspaceStore.set(defaultAzureWorkspace);
-    const { result: hookReturnRef, waitForNextUpdate } = renderHook(() => useAnalysisFiles());
-    await waitForNextUpdate();
+    const { result: hookReturnRef } = await act(() => renderHook(() => useAnalysisFiles()));
     // Act
     await act(() => hookReturnRef.current.deleteAnalysis(file1Path));
 
@@ -326,8 +316,7 @@ describe('file-utils', () => {
 
     // Act
     workspaceStore.set(defaultAzureWorkspace);
-    const hookRender1 = renderHook(() => useAnalysisFiles());
-    await hookRender1.waitForNextUpdate();
+    const hookRender1 = await act(() => renderHook(() => useAnalysisFiles()));
     const hookResult2 = hookRender1.result.current;
     await act(() => hookResult2.deleteAnalysis(file1Path));
 

--- a/src/analysis/utils/file-utils.test.ts
+++ b/src/analysis/utils/file-utils.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react-hooks';
+import { act } from '@testing-library/react-hooks';
 import { defaultAzureWorkspace, defaultGoogleWorkspace } from 'src/analysis/_testData/testData';
 import { AnalysisFile, getFileFromPath, useAnalysisFiles } from 'src/analysis/useAnalysisFiles';
 import { AbsolutePath, getExtension, getFileName } from 'src/analysis/utils/file-utils';
@@ -8,7 +8,7 @@ import { GoogleStorage, GoogleStorageContract } from 'src/libs/ajax/GoogleStorag
 import { reportError } from 'src/libs/error';
 import { workspaceStore } from 'src/libs/state';
 import { ReadyState } from 'src/libs/type-utils/LoadedState';
-import { asMockedFn } from 'src/testing/test-utils';
+import { asMockedFn, renderHookInAct } from 'src/testing/test-utils';
 
 jest.mock('src/libs/ajax/GoogleStorage');
 jest.mock('src/libs/ajax/AzureStorage');
@@ -54,7 +54,7 @@ describe('file-utils', () => {
 
       // Act
       workspaceStore.set(defaultGoogleWorkspace);
-      const { result: hookReturnRef } = await act(() => renderHook(() => useAnalysisFiles()));
+      const { result: hookReturnRef } = await renderHookInAct(() => useAnalysisFiles());
       const state = hookReturnRef.current.loadedState;
 
       // Assert
@@ -77,7 +77,7 @@ describe('file-utils', () => {
 
       // Act
       workspaceStore.set(defaultGoogleWorkspace);
-      await act(() => renderHook(() => useAnalysisFiles()));
+      await renderHookInAct(() => useAnalysisFiles());
 
       // Assert
       expect(listAnalyses).toHaveBeenCalledWith(
@@ -101,7 +101,7 @@ describe('file-utils', () => {
 
       // Act
       workspaceStore.set(defaultAzureWorkspace);
-      await act(() => renderHook(() => useAnalysisFiles()));
+      await renderHookInAct(() => useAnalysisFiles());
 
       // Assert
       expect(calledMock).toHaveBeenCalledWith(defaultAzureWorkspace.workspace.workspaceId);
@@ -127,7 +127,7 @@ describe('file-utils', () => {
 
       // Act
       workspaceStore.set(defaultGoogleWorkspace);
-      const { result: hookReturnRef } = await act(() => renderHook(() => useAnalysisFiles()));
+      const { result: hookReturnRef } = await renderHookInAct(() => useAnalysisFiles());
       await act(() => hookReturnRef.current.createAnalysis('AnalysisFile', runtimeToolLabels.Jupyter, 'myContents'));
 
       // Assert
@@ -150,7 +150,7 @@ describe('file-utils', () => {
 
       // Act
       workspaceStore.set(defaultGoogleWorkspace);
-      const hookRender1 = await act(() => renderHook(() => useAnalysisFiles()));
+      const hookRender1 = await renderHookInAct(() => useAnalysisFiles());
       const hookResult2 = hookRender1.result.current;
       await act(() => hookResult2.createAnalysis('AnalysisFile', runtimeToolLabels.Jupyter, 'myContents'));
 
@@ -177,7 +177,7 @@ describe('file-utils', () => {
       };
       asMockedFn(AzureStorage).mockImplementation(() => azureStorageMock as AzureStorageContract);
       workspaceStore.set(defaultAzureWorkspace);
-      const { result: hookReturnRef } = await act(() => renderHook(() => useAnalysisFiles()));
+      const { result: hookReturnRef } = await renderHookInAct(() => useAnalysisFiles());
       // Act
       await act(() => hookReturnRef.current.createAnalysis('AnalysisFile', runtimeToolLabels.Jupyter, 'myContents'));
 
@@ -201,7 +201,7 @@ describe('file-utils', () => {
 
     // Act
     workspaceStore.set(defaultAzureWorkspace);
-    const hookRender1 = await act(() => renderHook(() => useAnalysisFiles()));
+    const hookRender1 = await renderHookInAct(() => useAnalysisFiles());
     const hookResult2 = hookRender1.result.current;
     await act(() => hookResult2.createAnalysis('AnalysisFile', runtimeToolLabels.Jupyter, 'myContents'));
 
@@ -230,7 +230,7 @@ describe('file-utils', () => {
 
     // Act
     workspaceStore.set(defaultGoogleWorkspace);
-    const { result: hookReturnRef } = await act(() => renderHook(() => useAnalysisFiles()));
+    const { result: hookReturnRef } = await renderHookInAct(() => useAnalysisFiles());
     await act(() => hookReturnRef.current.deleteAnalysis(file1Path));
 
     // Assert
@@ -260,7 +260,7 @@ describe('file-utils', () => {
 
     // Act
     workspaceStore.set(defaultGoogleWorkspace);
-    const hookRender1 = await act(() => renderHook(() => useAnalysisFiles()));
+    const hookRender1 = await renderHookInAct(() => useAnalysisFiles());
     const hookResult2 = hookRender1.result.current;
     await act(() => hookResult2.deleteAnalysis(file1Path));
 
@@ -291,7 +291,7 @@ describe('file-utils', () => {
     };
     asMockedFn(AzureStorage).mockImplementation(() => azureStorageMock as AzureStorageContract);
     workspaceStore.set(defaultAzureWorkspace);
-    const { result: hookReturnRef } = await act(() => renderHook(() => useAnalysisFiles()));
+    const { result: hookReturnRef } = await renderHookInAct(() => useAnalysisFiles());
     // Act
     await act(() => hookReturnRef.current.deleteAnalysis(file1Path));
 
@@ -316,7 +316,7 @@ describe('file-utils', () => {
 
     // Act
     workspaceStore.set(defaultAzureWorkspace);
-    const hookRender1 = await act(() => renderHook(() => useAnalysisFiles()));
+    const hookRender1 = await renderHookInAct(() => useAnalysisFiles());
     const hookResult2 = hookRender1.result.current;
     await act(() => hookResult2.deleteAnalysis(file1Path));
 

--- a/src/components/file-browser/useFileDownloadCommand.test.ts
+++ b/src/components/file-browser/useFileDownloadCommand.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react-hooks';
 import FileBrowserProvider, { FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider';
 import { reportError } from 'src/libs/error';
 import { controlledPromise } from 'src/testing/test-utils';
@@ -33,11 +33,10 @@ describe('useFileDownloadCommand', () => {
     };
 
     // Act
-    const { result: hookReturnRef, waitForNextUpdate } = renderHook(() =>
-      useFileDownloadCommand({ file, provider: mockProvider })
-    );
-    getDownloadCommandForFileController.resolve('gsutil cp gs://test-bucket/path/to/example.txt .');
-    await waitForNextUpdate();
+    const { result: hookReturnRef } = renderHook(() => useFileDownloadCommand({ file, provider: mockProvider }));
+    await act(async () => {
+      getDownloadCommandForFileController.resolve('gsutil cp gs://test-bucket/path/to/example.txt .');
+    });
     const result = hookReturnRef.current;
 
     // Assert
@@ -55,11 +54,10 @@ describe('useFileDownloadCommand', () => {
     };
 
     // Act
-    const { result: hookReturnRef, waitForNextUpdate } = renderHook(() =>
-      useFileDownloadCommand({ file, provider: mockProvider })
-    );
-    getDownloadCommandForFileController.reject(new Error('Something went wrong'));
-    await waitForNextUpdate();
+    const { result: hookReturnRef } = renderHook(() => useFileDownloadCommand({ file, provider: mockProvider }));
+    await act(async () => {
+      getDownloadCommandForFileController.reject(new Error('Something went wrong'));
+    });
     const result = hookReturnRef.current;
 
     // Assert

--- a/src/components/file-browser/useFileDownloadUrl.test.ts
+++ b/src/components/file-browser/useFileDownloadUrl.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react-hooks';
 import FileBrowserProvider, { FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider';
 import { controlledPromise } from 'src/testing/test-utils';
 
@@ -43,13 +43,12 @@ describe('useFileDownloadUrl', () => {
 
   it('returns URL', async () => {
     // Act
-    const { result: hookReturnRef, waitForNextUpdate } = renderHook(() =>
-      useFileDownloadUrl({ file, provider: mockProvider })
-    );
-    getDownloadUrlForFileController.resolve(
-      'https://storage.googleapis.com/test-bucket/path/to/example.txt?downloadToken=somevalue'
-    );
-    await waitForNextUpdate();
+    const { result: hookReturnRef } = renderHook(() => useFileDownloadUrl({ file, provider: mockProvider }));
+    await act(async () => {
+      getDownloadUrlForFileController.resolve(
+        'https://storage.googleapis.com/test-bucket/path/to/example.txt?downloadToken=somevalue'
+      );
+    });
     const result = hookReturnRef.current;
 
     // Assert
@@ -61,11 +60,10 @@ describe('useFileDownloadUrl', () => {
 
   it('handles errors', async () => {
     // Act
-    const { result: hookReturnRef, waitForNextUpdate } = renderHook(() =>
-      useFileDownloadUrl({ file, provider: mockProvider })
-    );
-    getDownloadUrlForFileController.reject(new Error('Something went wrong'));
-    await waitForNextUpdate();
+    const { result: hookReturnRef } = renderHook(() => useFileDownloadUrl({ file, provider: mockProvider }));
+    await act(async () => {
+      getDownloadUrlForFileController.reject(new Error('Something went wrong'));
+    });
     const result = hookReturnRef.current;
 
     // Assert

--- a/src/libs/ajax/incremental-response/useIncrementalResponse.test.ts
+++ b/src/libs/ajax/incremental-response/useIncrementalResponse.test.ts
@@ -1,7 +1,7 @@
-import { act, renderHook } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react-hooks';
 import _ from 'lodash/fp';
 import { ErrorState, LoadingState, ReadyState } from 'src/libs/type-utils/LoadedState';
-import { controlledPromise, PromiseController } from 'src/testing/test-utils';
+import { controlledPromise, PromiseController, renderHookInAct } from 'src/testing/test-utils';
 
 import IncrementalResponse from './IncrementalResponse';
 import useIncrementalResponse from './useIncrementalResponse';
@@ -33,9 +33,7 @@ describe('useIncrementalResponse', () => {
 
   it('gets initial response', async () => {
     // Act
-    const { result: hookReturnRef } = await act(async () => {
-      return renderHook(() => useIncrementalResponse(getTestIncrementalResponse));
-    });
+    const { result: hookReturnRef } = await renderHookInAct(() => useIncrementalResponse(getTestIncrementalResponse));
     const state = hookReturnRef.current.state;
 
     // Assert
@@ -81,9 +79,7 @@ describe('useIncrementalResponse', () => {
     const throwError = () => Promise.reject(new Error('Something went wrong'));
 
     // Act
-    const { result: hookReturnRef } = await act(async () => {
-      return renderHook(() => useIncrementalResponse(throwError));
-    });
+    const { result: hookReturnRef } = await renderHookInAct(() => useIncrementalResponse(throwError));
     const state = hookReturnRef.current.state;
 
     // Assert
@@ -97,9 +93,7 @@ describe('useIncrementalResponse', () => {
 
   it('loads next page', async () => {
     // Arrange
-    const { result: hookReturnRef } = await act(async () => {
-      return renderHook(() => useIncrementalResponse(getTestIncrementalResponse));
-    });
+    const { result: hookReturnRef } = await renderHookInAct(() => useIncrementalResponse(getTestIncrementalResponse));
 
     // Act
     await act(() => hookReturnRef.current.loadNextPage());
@@ -112,9 +106,7 @@ describe('useIncrementalResponse', () => {
 
   it('loads all remaining pages', async () => {
     // Arrange
-    const { result: hookReturnRef } = await act(async () => {
-      return renderHook(() => useIncrementalResponse(getTestIncrementalResponse));
-    });
+    const { result: hookReturnRef } = await renderHookInAct(() => useIncrementalResponse(getTestIncrementalResponse));
 
     // Act
     await act(() => hookReturnRef.current.loadAllRemainingItems());
@@ -127,9 +119,7 @@ describe('useIncrementalResponse', () => {
 
   it('returns hasNextPage', async () => {
     // Arrange
-    const { result: hookReturnRef } = await act(async () => {
-      return renderHook(() => useIncrementalResponse(getTestIncrementalResponse));
-    });
+    const { result: hookReturnRef } = await renderHookInAct(() => useIncrementalResponse(getTestIncrementalResponse));
 
     // Act
     const firstPageHasNextPage = hookReturnRef.current.hasNextPage;
@@ -144,9 +134,7 @@ describe('useIncrementalResponse', () => {
 
   it('reloads / resets to first page', async () => {
     // Arrange
-    const { result: hookReturnRef } = await act(async () => {
-      return renderHook(() => useIncrementalResponse(getTestIncrementalResponse));
-    });
+    const { result: hookReturnRef } = await renderHookInAct(() => useIncrementalResponse(getTestIncrementalResponse));
     await act(() => hookReturnRef.current.loadAllRemainingItems());
 
     // Act
@@ -174,11 +162,12 @@ describe('useIncrementalResponse', () => {
       });
     };
 
-    const { rerender, result: hookReturnRef } = await act(async () => {
-      return renderHook(({ getFirstPage }) => useIncrementalResponse(getFirstPage), {
+    const { rerender, result: hookReturnRef } = await renderHookInAct(
+      ({ getFirstPage }) => useIncrementalResponse(getFirstPage),
+      {
         initialProps: { getFirstPage: getTestIncrementalResponse },
-      });
-    });
+      }
+    );
 
     // Act
     const stateBeforeChange = hookReturnRef.current.state;

--- a/src/libs/ajax/incremental-response/useIncrementalResponse.test.ts
+++ b/src/libs/ajax/incremental-response/useIncrementalResponse.test.ts
@@ -1,6 +1,7 @@
-import { act, renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react';
 import _ from 'lodash/fp';
 import { ErrorState, LoadingState, ReadyState } from 'src/libs/type-utils/LoadedState';
+import { controlledPromise, PromiseController } from 'src/testing/test-utils';
 
 import IncrementalResponse from './IncrementalResponse';
 import useIncrementalResponse from './useIncrementalResponse';
@@ -32,10 +33,9 @@ describe('useIncrementalResponse', () => {
 
   it('gets initial response', async () => {
     // Act
-    const { result: hookReturnRef, waitForNextUpdate } = renderHook(() =>
-      useIncrementalResponse(getTestIncrementalResponse)
-    );
-    await waitForNextUpdate();
+    const { result: hookReturnRef } = await act(async () => {
+      return renderHook(() => useIncrementalResponse(getTestIncrementalResponse));
+    });
     const state = hookReturnRef.current.state;
 
     // Assert
@@ -44,18 +44,29 @@ describe('useIncrementalResponse', () => {
   });
 
   it('has loading state', async () => {
+    // Arrange
+    let getResponseController: PromiseController<IncrementalResponse<number>>;
+    const getControlledIncrementalResponse = () => {
+      const [promise, controller] = controlledPromise<IncrementalResponse<number>>();
+      getResponseController = controller;
+      return promise;
+    };
+
     // Act
-    const { result: hookReturnRef, waitForNextUpdate } = renderHook(() =>
-      useIncrementalResponse(getTestIncrementalResponse)
-    );
+    const { result: hookReturnRef } = renderHook(() => useIncrementalResponse(getControlledIncrementalResponse));
     const initialState = hookReturnRef.current.state;
-    await waitForNextUpdate();
+    await act(async () => {
+      getResponseController.resolve({
+        items: [1, 2, 3],
+        getNextPage: () => new Promise(() => {}),
+        hasNextPage: true,
+      });
+    });
 
     act(() => {
       hookReturnRef.current.loadNextPage();
     });
-    const stateAfterLoadingNextPage = hookReturnRef.current.state;
-    await waitForNextUpdate();
+    const stateAfterLoadingNextPage = hookReturnRef!.current.state;
 
     // Assert
     const expectedInitialState: LoadingState<number[]> = { status: 'Loading', state: [] };
@@ -70,8 +81,9 @@ describe('useIncrementalResponse', () => {
     const throwError = () => Promise.reject(new Error('Something went wrong'));
 
     // Act
-    const { result: hookReturnRef, waitForNextUpdate } = renderHook(() => useIncrementalResponse(throwError));
-    await waitForNextUpdate();
+    const { result: hookReturnRef } = await act(async () => {
+      return renderHook(() => useIncrementalResponse(throwError));
+    });
     const state = hookReturnRef.current.state;
 
     // Assert
@@ -85,16 +97,12 @@ describe('useIncrementalResponse', () => {
 
   it('loads next page', async () => {
     // Arrange
-    const { result: hookReturnRef, waitForNextUpdate } = renderHook(() =>
-      useIncrementalResponse(getTestIncrementalResponse)
-    );
-    await waitForNextUpdate();
+    const { result: hookReturnRef } = await act(async () => {
+      return renderHook(() => useIncrementalResponse(getTestIncrementalResponse));
+    });
 
     // Act
-    act(() => {
-      hookReturnRef.current.loadNextPage();
-    });
-    await waitForNextUpdate();
+    await act(() => hookReturnRef.current.loadNextPage());
     const state = hookReturnRef.current.state;
 
     // Assert
@@ -104,16 +112,12 @@ describe('useIncrementalResponse', () => {
 
   it('loads all remaining pages', async () => {
     // Arrange
-    const { result: hookReturnRef, waitForNextUpdate } = renderHook(() =>
-      useIncrementalResponse(getTestIncrementalResponse)
-    );
-    await waitForNextUpdate();
+    const { result: hookReturnRef } = await act(async () => {
+      return renderHook(() => useIncrementalResponse(getTestIncrementalResponse));
+    });
 
     // Act
-    act(() => {
-      hookReturnRef.current.loadAllRemainingItems();
-    });
-    await waitForNextUpdate();
+    await act(() => hookReturnRef.current.loadAllRemainingItems());
     const state = hookReturnRef.current.state;
 
     // Assert
@@ -123,18 +127,14 @@ describe('useIncrementalResponse', () => {
 
   it('returns hasNextPage', async () => {
     // Arrange
-    const { result: hookReturnRef, waitForNextUpdate } = renderHook(() =>
-      useIncrementalResponse(getTestIncrementalResponse)
-    );
-    await waitForNextUpdate();
+    const { result: hookReturnRef } = await act(async () => {
+      return renderHook(() => useIncrementalResponse(getTestIncrementalResponse));
+    });
 
     // Act
     const firstPageHasNextPage = hookReturnRef.current.hasNextPage;
 
-    act(() => {
-      hookReturnRef.current.loadAllRemainingItems();
-    });
-    await waitForNextUpdate();
+    await act(() => hookReturnRef.current.loadAllRemainingItems());
     const lastPageHasNextPage = hookReturnRef.current.hasNextPage;
 
     // Assert
@@ -144,21 +144,14 @@ describe('useIncrementalResponse', () => {
 
   it('reloads / resets to first page', async () => {
     // Arrange
-    const { result: hookReturnRef, waitForNextUpdate } = renderHook(() =>
-      useIncrementalResponse(getTestIncrementalResponse)
-    );
-    await waitForNextUpdate();
-    act(() => {
-      hookReturnRef.current.loadAllRemainingItems();
+    const { result: hookReturnRef } = await act(async () => {
+      return renderHook(() => useIncrementalResponse(getTestIncrementalResponse));
     });
-    await waitForNextUpdate();
+    await act(() => hookReturnRef.current.loadAllRemainingItems());
 
     // Act
     const stateBeforeReloading = hookReturnRef.current.state;
-    act(() => {
-      hookReturnRef.current.reload();
-    });
-    await waitForNextUpdate();
+    await act(() => hookReturnRef.current.reload());
     const stateAfterReloading = hookReturnRef.current.state;
 
     // Assert
@@ -181,19 +174,17 @@ describe('useIncrementalResponse', () => {
       });
     };
 
-    const {
-      rerender,
-      result: hookReturnRef,
-      waitForNextUpdate,
-    } = renderHook(({ getFirstPage }) => useIncrementalResponse(getFirstPage), {
-      initialProps: { getFirstPage: getTestIncrementalResponse },
+    const { rerender, result: hookReturnRef } = await act(async () => {
+      return renderHook(({ getFirstPage }) => useIncrementalResponse(getFirstPage), {
+        initialProps: { getFirstPage: getTestIncrementalResponse },
+      });
     });
-    await waitForNextUpdate();
 
     // Act
     const stateBeforeChange = hookReturnRef.current.state;
-    rerender({ getFirstPage: getOtherTestIncrementalResponse });
-    await waitForNextUpdate();
+    await act(async () => {
+      return rerender({ getFirstPage: getOtherTestIncrementalResponse });
+    });
     const stateAfterChange = hookReturnRef.current.state;
 
     // Assert

--- a/src/libs/ajax/loaded-data/useLoadedData.test.ts
+++ b/src/libs/ajax/loaded-data/useLoadedData.test.ts
@@ -24,8 +24,9 @@ describe('useLoadedData hook', () => {
     const hookRender = renderHook(() => useLoadedData<TestData>());
     const hookResult1: UseLoadedDataResult<TestData> = hookRender.result.current;
     const updateData = hookResult1[1];
+    let updatePromise: Promise<void>;
     act(() => {
-      void updateData(async (): Promise<TestData> => {
+      updatePromise = updateData(async (): Promise<TestData> => {
         await delay(100);
         const dataResult: TestData = {
           propA: 'abc',
@@ -35,7 +36,7 @@ describe('useLoadedData hook', () => {
       });
     });
     const hookResult2: UseLoadedDataResult<TestData> = hookRender.result.current;
-    await hookRender.waitForNextUpdate();
+    await act(() => updatePromise);
     const hookResultFinal: UseLoadedDataResult<TestData> = hookRender.result.current;
 
     // Assert
@@ -61,14 +62,15 @@ describe('useLoadedData hook', () => {
     const updateData = hookResult1[1];
 
     // Act
+    let updatePromise: Promise<void>;
     act(() => {
-      void updateData(async (): Promise<TestData> => {
+      updatePromise = updateData(async (): Promise<TestData> => {
         await delay(100);
         throw Error('BOOM!');
       });
     });
     const hookResult2: UseLoadedDataResult<TestData> = hookRender.result.current;
-    await hookRender.waitForNextUpdate();
+    await act(() => updatePromise);
     const hookResultFinal: UseLoadedDataResult<TestData> = hookRender.result.current;
 
     // Assert
@@ -92,8 +94,9 @@ describe('useLoadedData hook', () => {
     const updateData = hookResult1[1];
 
     // Act
+    let updatePromise: Promise<void>;
     act(() => {
-      void updateData(async (): Promise<TestData> => {
+      updatePromise = updateData(async (): Promise<TestData> => {
         await delay(100);
         const mockFetchResponse: Partial<Response> = {
           status: 500,
@@ -107,7 +110,7 @@ describe('useLoadedData hook', () => {
       });
     });
     const hookResult2: UseLoadedDataResult<TestData> = hookRender.result.current;
-    await hookRender.waitForNextUpdate();
+    await act(() => updatePromise);
     const hookResultFinal: UseLoadedDataResult<TestData> = hookRender.result.current;
 
     // Assert
@@ -136,8 +139,9 @@ describe('useLoadedData hook', () => {
     let updateData = hookResult1[1];
 
     // produce ready result
+    let updatePromise: Promise<void>;
     act(() => {
-      void updateData(async (): Promise<TestData> => {
+      updatePromise = updateData(async (): Promise<TestData> => {
         await delay(100);
         const dataResult: TestData = {
           propA: 'abc',
@@ -147,20 +151,20 @@ describe('useLoadedData hook', () => {
       });
     });
     const hookResult2: UseLoadedDataResult<TestData> = hookRender.result.current;
-    await hookRender.waitForNextUpdate();
+    await act(() => updatePromise);
     const hookResultReady: UseLoadedDataResult<TestData> = hookRender.result.current;
     updateData = hookResultReady[1];
 
     // produce error result
     act(() => {
-      void updateData(async (): Promise<TestData> => {
+      updatePromise = updateData(async (): Promise<TestData> => {
         await delay(100);
         throw Error('BOOM!');
       });
     });
 
     const hookResult3: UseLoadedDataResult<TestData> = hookRender.result.current;
-    await hookRender.waitForNextUpdate();
+    await act(() => updatePromise);
     const hookResultFinal: UseLoadedDataResult<TestData> = hookRender.result.current;
 
     // Assert

--- a/src/libs/uploads.test.ts
+++ b/src/libs/uploads.test.ts
@@ -31,7 +31,7 @@ describe('useUploader', () => {
       return promise;
     });
 
-    const { result: hookReturnRef, waitForNextUpdate } = renderHook(() => useUploader(uploadFile));
+    const { result: hookReturnRef } = renderHook(() => useUploader(uploadFile));
     const initialState = hookReturnRef.current.uploadState;
 
     // Act
@@ -40,12 +40,14 @@ describe('useUploader', () => {
     });
     const stateAfterStartingUpload = hookReturnRef.current.uploadState;
 
-    finishCurrentUpload!();
-    await waitForNextUpdate();
+    await act(async () => {
+      finishCurrentUpload!();
+    });
     const stateAfterFinishingFirstUpload = hookReturnRef.current.uploadState;
 
-    finishCurrentUpload!();
-    await waitForNextUpdate();
+    await act(async () => {
+      finishCurrentUpload!();
+    });
     const stateAfterFinishingSecondUpload = hookReturnRef.current.uploadState;
 
     // Assert
@@ -133,14 +135,13 @@ describe('useUploader', () => {
   it('allows canceling upload', async () => {
     // Arrange
     const uploadFile = jest.fn(() => Promise.resolve());
-    const { result: hookReturnRef, waitForNextUpdate } = renderHook(() => useUploader(uploadFile));
+    const { result: hookReturnRef } = renderHook(() => useUploader(uploadFile));
 
     // Act
-    act(() => {
+    await act(async () => {
       hookReturnRef.current.uploadFiles([file1, file2]);
       hookReturnRef.current.cancelUpload();
     });
-    await waitForNextUpdate();
 
     // Assert
     expect(uploadFile).toHaveBeenCalledTimes(1);

--- a/src/pages/ImportWorkflow/useDockstoreWdl.test.ts
+++ b/src/pages/ImportWorkflow/useDockstoreWdl.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react-hooks';
 import { Dockstore, DockstoreContract } from 'src/libs/ajax/Dockstore';
 import { reportError } from 'src/libs/error';
 import { asMockedFn } from 'src/testing/test-utils';
@@ -29,8 +29,9 @@ describe('useDockstoreWdl', () => {
     };
 
     // Act
-    const { result: hookReturnRef, waitForNextUpdate } = renderHook(() => useDockstoreWdl(testWorkflow));
-    await waitForNextUpdate();
+    const { result: hookReturnRef } = await act(async () => {
+      return renderHook(() => useDockstoreWdl(testWorkflow));
+    });
     const result = hookReturnRef.current;
 
     // Assert
@@ -51,8 +52,9 @@ describe('useDockstoreWdl', () => {
     };
 
     // Act
-    const { result: hookReturnRef, waitForNextUpdate } = renderHook(() => useDockstoreWdl(testWorkflow));
-    await waitForNextUpdate();
+    const { result: hookReturnRef } = await act(async () => {
+      return renderHook(() => useDockstoreWdl(testWorkflow));
+    });
     const result = hookReturnRef.current;
 
     // Assert

--- a/src/pages/ImportWorkflow/useDockstoreWdl.test.ts
+++ b/src/pages/ImportWorkflow/useDockstoreWdl.test.ts
@@ -1,7 +1,6 @@
-import { act, renderHook } from '@testing-library/react-hooks';
 import { Dockstore, DockstoreContract } from 'src/libs/ajax/Dockstore';
 import { reportError } from 'src/libs/error';
-import { asMockedFn } from 'src/testing/test-utils';
+import { asMockedFn, renderHookInAct } from 'src/testing/test-utils';
 
 import { useDockstoreWdl } from './useDockstoreWdl';
 
@@ -29,9 +28,7 @@ describe('useDockstoreWdl', () => {
     };
 
     // Act
-    const { result: hookReturnRef } = await act(async () => {
-      return renderHook(() => useDockstoreWdl(testWorkflow));
-    });
+    const { result: hookReturnRef } = await renderHookInAct(() => useDockstoreWdl(testWorkflow));
     const result = hookReturnRef.current;
 
     // Assert
@@ -52,9 +49,7 @@ describe('useDockstoreWdl', () => {
     };
 
     // Act
-    const { result: hookReturnRef } = await act(async () => {
-      return renderHook(() => useDockstoreWdl(testWorkflow));
-    });
+    const { result: hookReturnRef } = await renderHookInAct(() => useDockstoreWdl(testWorkflow));
     const result = hookReturnRef.current;
 
     // Assert

--- a/src/pages/workspaces/workspace/useDeleteWorkspaceState.test.ts
+++ b/src/pages/workspaces/workspace/useDeleteWorkspaceState.test.ts
@@ -94,10 +94,11 @@ describe('useDeleteWorkspaceState', () => {
     asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
 
     // Act
-    const { result, waitForNextUpdate } = renderHook(() =>
-      useDeleteWorkspaceState({ workspace: googleWorkspace, onDismiss: mockOnDismiss, onSuccess: mockOnSuccess })
-    );
-    await waitForNextUpdate();
+    const { result } = await act(async () => {
+      return renderHook(() =>
+        useDeleteWorkspaceState({ workspace: googleWorkspace, onDismiss: mockOnDismiss, onSuccess: mockOnSuccess })
+      );
+    });
 
     // Assert
     expect(result.current.hasApps()).toBe(true);
@@ -143,10 +144,11 @@ describe('useDeleteWorkspaceState', () => {
     asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
 
     // Act
-    const { result, waitForNextUpdate } = renderHook(() =>
-      useDeleteWorkspaceState({ workspace: azureWorkspace, onDismiss: mockOnDismiss, onSuccess: mockOnSuccess })
-    );
-    await waitForNextUpdate();
+    const { result } = await act(async () => {
+      return renderHook(() =>
+        useDeleteWorkspaceState({ workspace: azureWorkspace, onDismiss: mockOnDismiss, onSuccess: mockOnSuccess })
+      );
+    });
 
     // Assert
     expect(result.current.hasApps()).toBe(true);
@@ -184,10 +186,11 @@ describe('useDeleteWorkspaceState', () => {
     asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
 
     // Act
-    const { result, waitForNextUpdate } = renderHook(() =>
-      useDeleteWorkspaceState({ workspace: azureWorkspace, onDismiss: mockOnDismiss, onSuccess: mockOnSuccess })
-    );
-    await waitForNextUpdate();
+    const { result } = await act(async () => {
+      return renderHook(() =>
+        useDeleteWorkspaceState({ workspace: azureWorkspace, onDismiss: mockOnDismiss, onSuccess: mockOnSuccess })
+      );
+    });
     await act(() => result.current.deleteWorkspace());
 
     // Assert
@@ -222,10 +225,11 @@ describe('useDeleteWorkspaceState', () => {
     asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
 
     // Act
-    const { result, waitForNextUpdate } = renderHook(() =>
-      useDeleteWorkspaceState({ workspace: googleWorkspace, onDismiss: mockOnDismiss, onSuccess: mockOnSuccess })
-    );
-    await waitForNextUpdate();
+    const { result } = await act(async () => {
+      return renderHook(() =>
+        useDeleteWorkspaceState({ workspace: googleWorkspace, onDismiss: mockOnDismiss, onSuccess: mockOnSuccess })
+      );
+    });
     await act(() => result.current.deleteWorkspace());
 
     // Assert
@@ -258,10 +262,11 @@ describe('useDeleteWorkspaceState', () => {
     asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
 
     // Act
-    const { result, waitForNextUpdate } = renderHook(() =>
-      useDeleteWorkspaceState({ workspace: googleWorkspace, onDismiss: mockOnDismiss, onSuccess: mockOnSuccess })
-    );
-    await waitForNextUpdate();
+    const { result } = await act(async () => {
+      return renderHook(() =>
+        useDeleteWorkspaceState({ workspace: googleWorkspace, onDismiss: mockOnDismiss, onSuccess: mockOnSuccess })
+      );
+    });
 
     await act(() => result.current.deleteWorkspace());
 
@@ -304,10 +309,11 @@ describe('useDeleteWorkspaceState', () => {
     asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
 
     // Act
-    const { result, waitForNextUpdate } = renderHook(() =>
-      useDeleteWorkspaceState({ workspace: azureWorkspace, onDismiss: mockOnDismiss, onSuccess: mockOnSuccess })
-    );
-    await waitForNextUpdate();
+    const { result } = await act(async () => {
+      return renderHook(() =>
+        useDeleteWorkspaceState({ workspace: azureWorkspace, onDismiss: mockOnDismiss, onSuccess: mockOnSuccess })
+      );
+    });
 
     await act(() => result.current.deleteWorkspaceResources());
 
@@ -359,10 +365,11 @@ describe('useDeleteWorkspaceState', () => {
     asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
 
     // Act
-    const { result, waitForNextUpdate } = renderHook(() =>
-      useDeleteWorkspaceState({ workspace: azureWorkspace, onDismiss: mockOnDismiss, onSuccess: mockOnSuccess })
-    );
-    await waitForNextUpdate();
+    const { result } = await act(async () => {
+      return renderHook(() =>
+        useDeleteWorkspaceState({ workspace: azureWorkspace, onDismiss: mockOnDismiss, onSuccess: mockOnSuccess })
+      );
+    });
     await act(() => result.current.deleteWorkspaceResources());
 
     // Assert
@@ -375,8 +382,9 @@ describe('useDeleteWorkspaceState', () => {
     expect(mockDeleteAllApps).toHaveBeenCalledWith(azureWorkspace.workspace.workspaceId, true);
 
     // Act
-    jest.advanceTimersByTime(WorkspaceResourceDeletionPollRate);
-    await waitForNextUpdate();
+    await act(async () => {
+      jest.advanceTimersByTime(WorkspaceResourceDeletionPollRate);
+    });
 
     expect(result.current.deletingResources).toBe(false);
     expect(result.current.hasApps()).toBe(false);
@@ -421,14 +429,15 @@ describe('useDeleteWorkspaceState', () => {
     asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
 
     // Act
-    const { result, waitForNextUpdate } = renderHook(() =>
-      useDeleteWorkspaceState({
-        workspace: azureWorkspace,
-        onDismiss: mockOnDismiss,
-        onSuccess: mockOnSuccess,
-      })
-    );
-    await waitForNextUpdate();
+    const { result } = await act(async () => {
+      return renderHook(() =>
+        useDeleteWorkspaceState({
+          workspace: azureWorkspace,
+          onDismiss: mockOnDismiss,
+          onSuccess: mockOnSuccess,
+        })
+      );
+    });
     await act(() => result.current.deleteWorkspaceResources());
 
     expect(mockRuntimeDeleteAll).toHaveBeenCalledTimes(1);
@@ -472,10 +481,11 @@ describe('useDeleteWorkspaceState', () => {
     asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
 
     // Act
-    const { result, waitForNextUpdate } = renderHook(() =>
-      useDeleteWorkspaceState({ workspace: azureWorkspace, onDismiss: mockOnDismiss, onSuccess: mockOnSuccess })
-    );
-    await waitForNextUpdate();
+    const { result } = await act(async () => {
+      return renderHook(() =>
+        useDeleteWorkspaceState({ workspace: azureWorkspace, onDismiss: mockOnDismiss, onSuccess: mockOnSuccess })
+      );
+    });
     await act(() => result.current.deleteWorkspaceResources());
 
     // Assert
@@ -484,8 +494,9 @@ describe('useDeleteWorkspaceState', () => {
     expect(mockDelete).toHaveBeenCalledTimes(0);
 
     // Act
-    jest.advanceTimersByTime(WorkspaceResourceDeletionPollRate);
-    await waitForNextUpdate();
+    await act(async () => {
+      jest.advanceTimersByTime(WorkspaceResourceDeletionPollRate);
+    });
 
     expect(result.current.deletingResources).toBe(false);
     expect(reportError).toHaveBeenCalledTimes(1);

--- a/src/pages/workspaces/workspace/useDeleteWorkspaceState.test.ts
+++ b/src/pages/workspaces/workspace/useDeleteWorkspaceState.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react-hooks';
+import { act } from '@testing-library/react-hooks';
 import { generateTestApp } from 'src/analysis/_testData/testData';
 import { Ajax } from 'src/libs/ajax';
 import { reportError } from 'src/libs/error';
@@ -8,7 +8,7 @@ import {
   useDeleteWorkspaceState,
   WorkspaceResourceDeletionPollRate,
 } from 'src/pages/workspaces/workspace/useDeleteWorkspaceState';
-import { asMockedFn } from 'src/testing/test-utils';
+import { asMockedFn, renderHookInAct } from 'src/testing/test-utils';
 
 type AjaxExports = typeof import('src/libs/ajax');
 jest.mock('src/libs/ajax', (): AjaxExports => {
@@ -94,11 +94,9 @@ describe('useDeleteWorkspaceState', () => {
     asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
 
     // Act
-    const { result } = await act(async () => {
-      return renderHook(() =>
-        useDeleteWorkspaceState({ workspace: googleWorkspace, onDismiss: mockOnDismiss, onSuccess: mockOnSuccess })
-      );
-    });
+    const { result } = await renderHookInAct(() =>
+      useDeleteWorkspaceState({ workspace: googleWorkspace, onDismiss: mockOnDismiss, onSuccess: mockOnSuccess })
+    );
 
     // Assert
     expect(result.current.hasApps()).toBe(true);
@@ -144,11 +142,9 @@ describe('useDeleteWorkspaceState', () => {
     asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
 
     // Act
-    const { result } = await act(async () => {
-      return renderHook(() =>
-        useDeleteWorkspaceState({ workspace: azureWorkspace, onDismiss: mockOnDismiss, onSuccess: mockOnSuccess })
-      );
-    });
+    const { result } = await renderHookInAct(() =>
+      useDeleteWorkspaceState({ workspace: azureWorkspace, onDismiss: mockOnDismiss, onSuccess: mockOnSuccess })
+    );
 
     // Assert
     expect(result.current.hasApps()).toBe(true);
@@ -186,11 +182,9 @@ describe('useDeleteWorkspaceState', () => {
     asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
 
     // Act
-    const { result } = await act(async () => {
-      return renderHook(() =>
-        useDeleteWorkspaceState({ workspace: azureWorkspace, onDismiss: mockOnDismiss, onSuccess: mockOnSuccess })
-      );
-    });
+    const { result } = await renderHookInAct(() =>
+      useDeleteWorkspaceState({ workspace: azureWorkspace, onDismiss: mockOnDismiss, onSuccess: mockOnSuccess })
+    );
     await act(() => result.current.deleteWorkspace());
 
     // Assert
@@ -225,11 +219,9 @@ describe('useDeleteWorkspaceState', () => {
     asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
 
     // Act
-    const { result } = await act(async () => {
-      return renderHook(() =>
-        useDeleteWorkspaceState({ workspace: googleWorkspace, onDismiss: mockOnDismiss, onSuccess: mockOnSuccess })
-      );
-    });
+    const { result } = await renderHookInAct(() =>
+      useDeleteWorkspaceState({ workspace: googleWorkspace, onDismiss: mockOnDismiss, onSuccess: mockOnSuccess })
+    );
     await act(() => result.current.deleteWorkspace());
 
     // Assert
@@ -262,11 +254,9 @@ describe('useDeleteWorkspaceState', () => {
     asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
 
     // Act
-    const { result } = await act(async () => {
-      return renderHook(() =>
-        useDeleteWorkspaceState({ workspace: googleWorkspace, onDismiss: mockOnDismiss, onSuccess: mockOnSuccess })
-      );
-    });
+    const { result } = await renderHookInAct(() =>
+      useDeleteWorkspaceState({ workspace: googleWorkspace, onDismiss: mockOnDismiss, onSuccess: mockOnSuccess })
+    );
 
     await act(() => result.current.deleteWorkspace());
 
@@ -309,11 +299,9 @@ describe('useDeleteWorkspaceState', () => {
     asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
 
     // Act
-    const { result } = await act(async () => {
-      return renderHook(() =>
-        useDeleteWorkspaceState({ workspace: azureWorkspace, onDismiss: mockOnDismiss, onSuccess: mockOnSuccess })
-      );
-    });
+    const { result } = await renderHookInAct(() =>
+      useDeleteWorkspaceState({ workspace: azureWorkspace, onDismiss: mockOnDismiss, onSuccess: mockOnSuccess })
+    );
 
     await act(() => result.current.deleteWorkspaceResources());
 
@@ -365,11 +353,9 @@ describe('useDeleteWorkspaceState', () => {
     asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
 
     // Act
-    const { result } = await act(async () => {
-      return renderHook(() =>
-        useDeleteWorkspaceState({ workspace: azureWorkspace, onDismiss: mockOnDismiss, onSuccess: mockOnSuccess })
-      );
-    });
+    const { result } = await renderHookInAct(() =>
+      useDeleteWorkspaceState({ workspace: azureWorkspace, onDismiss: mockOnDismiss, onSuccess: mockOnSuccess })
+    );
     await act(() => result.current.deleteWorkspaceResources());
 
     // Assert
@@ -429,15 +415,13 @@ describe('useDeleteWorkspaceState', () => {
     asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
 
     // Act
-    const { result } = await act(async () => {
-      return renderHook(() =>
-        useDeleteWorkspaceState({
-          workspace: azureWorkspace,
-          onDismiss: mockOnDismiss,
-          onSuccess: mockOnSuccess,
-        })
-      );
-    });
+    const { result } = await renderHookInAct(() =>
+      useDeleteWorkspaceState({
+        workspace: azureWorkspace,
+        onDismiss: mockOnDismiss,
+        onSuccess: mockOnSuccess,
+      })
+    );
     await act(() => result.current.deleteWorkspaceResources());
 
     expect(mockRuntimeDeleteAll).toHaveBeenCalledTimes(1);
@@ -481,11 +465,9 @@ describe('useDeleteWorkspaceState', () => {
     asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
 
     // Act
-    const { result } = await act(async () => {
-      return renderHook(() =>
-        useDeleteWorkspaceState({ workspace: azureWorkspace, onDismiss: mockOnDismiss, onSuccess: mockOnSuccess })
-      );
-    });
+    const { result } = await renderHookInAct(() =>
+      useDeleteWorkspaceState({ workspace: azureWorkspace, onDismiss: mockOnDismiss, onSuccess: mockOnSuccess })
+    );
     await act(() => result.current.deleteWorkspaceResources());
 
     // Assert

--- a/src/pages/workspaces/workspace/useWorkspace.test.ts
+++ b/src/pages/workspaces/workspace/useWorkspace.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react-hooks';
 import _ from 'lodash/fp';
 import { defaultLocation } from 'src/analysis/utils/runtime-utils';
 import { locationTypes } from 'src/components/region-common';
@@ -168,8 +168,9 @@ describe('useActiveWorkspace', () => {
     );
 
     // Act
-    const { result, waitForNextUpdate } = renderHook(() => useWorkspace('testNamespace', 'testName'));
-    await waitForNextUpdate(); // For the bucket location call
+    const { result } = await act(async () => {
+      return renderHook(() => useWorkspace('testNamespace', 'testName'));
+    });
 
     // Assert
     assertResult(result.current, initializedGoogleWorkspace, expectedStorageDetails, false);
@@ -198,8 +199,9 @@ describe('useActiveWorkspace', () => {
     ]);
 
     // Act
-    const { result, waitForNextUpdate } = renderHook(() => useWorkspace('testNamespace', 'testName'));
-    await waitForNextUpdate(); // For the bucket location call
+    const { result } = await act(async () => {
+      return renderHook(() => useWorkspace('testNamespace', 'testName'));
+    });
 
     // Assert
     assertResult(result.current, initializedGoogleWorkspace, expectedStorageDetails, false);
@@ -223,8 +225,10 @@ describe('useActiveWorkspace', () => {
     );
 
     // Act
-    const { result, waitForNextUpdate } = renderHook(() => useWorkspace('testNamespace', 'testName'));
-    await waitForNextUpdate(); // For the azure storage call
+    // Wait for the Azure storage call.
+    const { result } = await act(async () => {
+      return renderHook(() => useWorkspace('testNamespace', 'testName'));
+    });
 
     // Assert
     assertResult(result.current, initializedAzureWorkspace, expectedStorageDetails, false);
@@ -246,9 +250,10 @@ describe('useActiveWorkspace', () => {
     ]);
 
     // Act
-    const renderHookResult = renderHook(() => useWorkspace('testNamespace', 'testName'));
-    const { result, waitForNextUpdate } = renderHookResult;
-    await waitForNextUpdate();
+    const renderHookResult = await act(async () => {
+      return renderHook(() => useWorkspace('testNamespace', 'testName'));
+    });
+    const { result } = renderHookResult;
 
     // Assert
     assertResult(result.current, uninitializedGoogleWorkspace, expectedStillSyncingDetails, false);
@@ -261,7 +266,7 @@ describe('useActiveWorkspace', () => {
     return renderHookResult;
   };
 
-  const verifyGooglePermissionsSuccess = async (result, waitForNextUpdate) => {
+  const verifyGooglePermissionsSuccess = async (result) => {
     // Arrange
     const expectedAllSyncedDetails = _.merge(
       {
@@ -285,8 +290,9 @@ describe('useActiveWorkspace', () => {
     asMockedFn(Ajax).mockImplementation(() => successMockAjax as AjaxContract);
 
     // Act
-    jest.advanceTimersByTime(googlePermissionsRecheckRate);
-    await waitForNextUpdate();
+    await act(async () => {
+      jest.advanceTimersByTime(googlePermissionsRecheckRate);
+    });
 
     // Assert
     assertResult(result.current, initializedGoogleWorkspace, expectedAllSyncedDetails, false);
@@ -309,10 +315,10 @@ describe('useActiveWorkspace', () => {
     asMockedFn(Ajax).mockImplementation(() => errorMockAjax as AjaxContract);
 
     // Verify initial failure based on error mock.
-    const { result, waitForNextUpdate } = await verifyGooglePermissionsFailure();
+    const { result } = await verifyGooglePermissionsFailure();
 
     // Finally, change mock to pass all checks verify success.
-    await verifyGooglePermissionsSuccess(result, waitForNextUpdate);
+    await verifyGooglePermissionsSuccess(result);
   });
 
   it('can read workspace details from server, and poll until permissions synced (handling storageCostEstimate failure)', async () => {
@@ -334,10 +340,10 @@ describe('useActiveWorkspace', () => {
     asMockedFn(Ajax).mockImplementation(() => errorMockAjax as AjaxContract);
 
     // Verify initial failure based on error mock.
-    const { result, waitForNextUpdate } = await verifyGooglePermissionsFailure();
+    const { result } = await verifyGooglePermissionsFailure();
 
     // Finally, change mock to pass all checks verify success.
-    await verifyGooglePermissionsSuccess(result, waitForNextUpdate);
+    await verifyGooglePermissionsSuccess(result);
   });
 
   it('can read workspace details from server, and poll until permissions synced (handling bucketUsage failure)', async () => {
@@ -359,10 +365,10 @@ describe('useActiveWorkspace', () => {
     asMockedFn(Ajax).mockImplementation(() => errorMockAjax as AjaxContract);
 
     // Verify initial failure based on error mock.
-    const { result, waitForNextUpdate } = await verifyGooglePermissionsFailure();
+    const { result } = await verifyGooglePermissionsFailure();
 
     // Finally, change mock to pass all checks verify success.
-    await verifyGooglePermissionsSuccess(result, waitForNextUpdate);
+    await verifyGooglePermissionsSuccess(result);
   });
 
   it('can read workspace details from server, and poll until permissions synced (handling checkBucketLocation failure)', async () => {
@@ -384,10 +390,10 @@ describe('useActiveWorkspace', () => {
     asMockedFn(Ajax).mockImplementation(() => errorMockAjax as AjaxContract);
 
     // Verify initial failure based on error mock.
-    const { result, waitForNextUpdate } = await verifyGooglePermissionsFailure('ERROR');
+    const { result } = await verifyGooglePermissionsFailure('ERROR');
 
     // Finally, change mock to pass all checks verify success.
-    await verifyGooglePermissionsSuccess(result, waitForNextUpdate);
+    await verifyGooglePermissionsSuccess(result);
   });
 
   it('can read workspace details from server for read-only workspace, and poll Google until permissions are synced', async () => {
@@ -422,8 +428,10 @@ describe('useActiveWorkspace', () => {
     );
 
     // Act
-    const { result, waitForNextUpdate } = renderHook(() => useWorkspace('testNamespace', 'testName'));
-    await waitForNextUpdate(); // For the calls to checkBucketReadAccess and checkBucketLocation to execute
+    // Wait for the calls to checkBucketReadAccess and checkBucketLocation to execute
+    const { result } = await act(async () => {
+      return renderHook(() => useWorkspace('testNamespace', 'testName'));
+    });
 
     // Assert
     assertResult(result.current, readOnlyWorkspace, expectedAllSyncedDetails, false);
@@ -457,8 +465,10 @@ describe('useActiveWorkspace', () => {
     );
 
     // Act
-    const { result, waitForNextUpdate } = renderHook(() => useWorkspace('testNamespace', 'testName'));
-    await waitForNextUpdate(); // For the call to checkBucketReadAccess to execute
+    // Wait for the call to checkBucketReadAccess to execute
+    const { result } = await act(async () => {
+      return renderHook(() => useWorkspace('testNamespace', 'testName'));
+    });
 
     // Assert
     assertResult(result.current, initializedGoogleWorkspace, expectedStorageDetails, false);
@@ -503,8 +513,10 @@ describe('useActiveWorkspace', () => {
     );
 
     // Act
-    const { result, waitForNextUpdate } = renderHook(() => useWorkspace('testNamespace', 'testName'));
-    await waitForNextUpdate(); // For the call to AzureStorage.details to execute
+    // Wait for the call to AzureStorage.details to execute.
+    const { result } = await act(async () => {
+      return renderHook(() => useWorkspace('testNamespace', 'testName'));
+    });
 
     // Assert
     assertResult(result.current, uninitializedAzureWorkspace, expectedFirstStorageDetails, false);
@@ -523,8 +535,9 @@ describe('useActiveWorkspace', () => {
 
     // Act
     // next call to AzureStorage.details is on a timer
-    jest.advanceTimersByTime(azureBucketRecheckRate);
-    await waitForNextUpdate();
+    await act(async () => {
+      jest.advanceTimersByTime(azureBucketRecheckRate);
+    });
 
     // Assert
     assertResult(result.current, initializedAzureWorkspace, expectedSecondStorageDetails, false);
@@ -543,8 +556,9 @@ describe('useActiveWorkspace', () => {
     asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
 
     // Act
-    const { result, waitForNextUpdate } = renderHook(() => useWorkspace('testNamespace', 'testName'));
-    await waitForNextUpdate();
+    const { result } = await act(async () => {
+      return renderHook(() => useWorkspace('testNamespace', 'testName'));
+    });
 
     // Assert
     assertResult(result.current, undefined, _.merge(defaultGoogleBucketOptions, defaultAzureStorageOptions), true);
@@ -582,8 +596,10 @@ describe('useActiveWorkspace', () => {
     );
 
     // Act
-    const { result, waitForNextUpdate } = renderHook(() => useWorkspace('testNamespace', 'testName'));
-    await waitForNextUpdate(); // For the call to checkBucketReadAccess to execute
+    // Wait for the call to checkBucketReadAccess to execute
+    const { result } = await act(async () => {
+      return renderHook(() => useWorkspace('testNamespace', 'testName'));
+    });
 
     // Assert
     assertResult(result.current, expectedWorkspaceResponse, expectStorageDetails, false);
@@ -627,8 +643,10 @@ describe('useActiveWorkspace', () => {
     jest.setSystemTime(new Date(Date.UTC(2023, 1, 3, 22, 26, 12, 0)));
 
     // Act
-    const { result, waitForNextUpdate } = renderHook(() => useWorkspace('testNamespace', 'testName'));
-    await waitForNextUpdate(); // For the call to checkBucketReadAccess to execute
+    // Wait for the call to checkBucketReadAccess to execute
+    const { result } = await act(async () => {
+      return renderHook(() => useWorkspace('testNamespace', 'testName'));
+    });
 
     // Assert
     assertResult(result.current, expectedWorkspaceResponse, expectStorageDetails, false);

--- a/src/pages/workspaces/workspace/useWorkspace.test.ts
+++ b/src/pages/workspaces/workspace/useWorkspace.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react-hooks';
+import { act } from '@testing-library/react-hooks';
 import _ from 'lodash/fp';
 import { defaultLocation } from 'src/analysis/utils/runtime-utils';
 import { locationTypes } from 'src/components/region-common';
@@ -14,7 +14,7 @@ import {
   googlePermissionsRecheckRate,
   useWorkspace,
 } from 'src/pages/workspaces/workspace/useWorkspace';
-import { asMockedFn } from 'src/testing/test-utils';
+import { asMockedFn, renderHookInAct } from 'src/testing/test-utils';
 
 jest.mock('src/libs/ajax/AzureStorage');
 
@@ -168,9 +168,8 @@ describe('useActiveWorkspace', () => {
     );
 
     // Act
-    const { result } = await act(async () => {
-      return renderHook(() => useWorkspace('testNamespace', 'testName'));
-    });
+    // Wait for the bucket location call.
+    const { result } = await renderHookInAct(() => useWorkspace('testNamespace', 'testName'));
 
     // Assert
     assertResult(result.current, initializedGoogleWorkspace, expectedStorageDetails, false);
@@ -199,9 +198,8 @@ describe('useActiveWorkspace', () => {
     ]);
 
     // Act
-    const { result } = await act(async () => {
-      return renderHook(() => useWorkspace('testNamespace', 'testName'));
-    });
+    // Wait for the bucket location call.
+    const { result } = await renderHookInAct(() => useWorkspace('testNamespace', 'testName'));
 
     // Assert
     assertResult(result.current, initializedGoogleWorkspace, expectedStorageDetails, false);
@@ -226,9 +224,7 @@ describe('useActiveWorkspace', () => {
 
     // Act
     // Wait for the Azure storage call.
-    const { result } = await act(async () => {
-      return renderHook(() => useWorkspace('testNamespace', 'testName'));
-    });
+    const { result } = await renderHookInAct(() => useWorkspace('testNamespace', 'testName'));
 
     // Assert
     assertResult(result.current, initializedAzureWorkspace, expectedStorageDetails, false);
@@ -250,9 +246,7 @@ describe('useActiveWorkspace', () => {
     ]);
 
     // Act
-    const renderHookResult = await act(async () => {
-      return renderHook(() => useWorkspace('testNamespace', 'testName'));
-    });
+    const renderHookResult = await renderHookInAct(() => useWorkspace('testNamespace', 'testName'));
     const { result } = renderHookResult;
 
     // Assert
@@ -429,9 +423,7 @@ describe('useActiveWorkspace', () => {
 
     // Act
     // Wait for the calls to checkBucketReadAccess and checkBucketLocation to execute
-    const { result } = await act(async () => {
-      return renderHook(() => useWorkspace('testNamespace', 'testName'));
-    });
+    const { result } = await renderHookInAct(() => useWorkspace('testNamespace', 'testName'));
 
     // Assert
     assertResult(result.current, readOnlyWorkspace, expectedAllSyncedDetails, false);
@@ -466,9 +458,7 @@ describe('useActiveWorkspace', () => {
 
     // Act
     // Wait for the call to checkBucketReadAccess to execute
-    const { result } = await act(async () => {
-      return renderHook(() => useWorkspace('testNamespace', 'testName'));
-    });
+    const { result } = await renderHookInAct(() => useWorkspace('testNamespace', 'testName'));
 
     // Assert
     assertResult(result.current, initializedGoogleWorkspace, expectedStorageDetails, false);
@@ -514,9 +504,7 @@ describe('useActiveWorkspace', () => {
 
     // Act
     // Wait for the call to AzureStorage.details to execute.
-    const { result } = await act(async () => {
-      return renderHook(() => useWorkspace('testNamespace', 'testName'));
-    });
+    const { result } = await renderHookInAct(() => useWorkspace('testNamespace', 'testName'));
 
     // Assert
     assertResult(result.current, uninitializedAzureWorkspace, expectedFirstStorageDetails, false);
@@ -556,9 +544,7 @@ describe('useActiveWorkspace', () => {
     asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
 
     // Act
-    const { result } = await act(async () => {
-      return renderHook(() => useWorkspace('testNamespace', 'testName'));
-    });
+    const { result } = await renderHookInAct(() => useWorkspace('testNamespace', 'testName'));
 
     // Assert
     assertResult(result.current, undefined, _.merge(defaultGoogleBucketOptions, defaultAzureStorageOptions), true);
@@ -597,9 +583,7 @@ describe('useActiveWorkspace', () => {
 
     // Act
     // Wait for the call to checkBucketReadAccess to execute
-    const { result } = await act(async () => {
-      return renderHook(() => useWorkspace('testNamespace', 'testName'));
-    });
+    const { result } = await renderHookInAct(() => useWorkspace('testNamespace', 'testName'));
 
     // Assert
     assertResult(result.current, expectedWorkspaceResponse, expectStorageDetails, false);
@@ -644,9 +628,7 @@ describe('useActiveWorkspace', () => {
 
     // Act
     // Wait for the call to checkBucketReadAccess to execute
-    const { result } = await act(async () => {
-      return renderHook(() => useWorkspace('testNamespace', 'testName'));
-    });
+    const { result } = await renderHookInAct(() => useWorkspace('testNamespace', 'testName'));
 
     // Assert
     assertResult(result.current, expectedWorkspaceResponse, expectStorageDetails, false);

--- a/src/testing/test-utils.ts
+++ b/src/testing/test-utils.ts
@@ -1,3 +1,5 @@
+import { act, Renderer, renderHook, RenderHookOptions, RenderHookResult } from '@testing-library/react-hooks';
+
 /*
  * Use when working with a jest.fn() mocked method to get better type safety and IDE hinting on
  * the function signature of what's being mocked.
@@ -54,4 +56,15 @@ export const setUpAutoSizerTesting = () => {
       },
     },
   });
+};
+
+export const renderHookInAct = async <T, U>(
+  callback: (args: T) => U,
+  options?: RenderHookOptions<T>
+): Promise<RenderHookResult<T, U, Renderer<T>>> => {
+  let result: RenderHookResult<T, U, Renderer<T>>;
+  await act(async () => {
+    result = renderHook(callback, options);
+  });
+  return result!;
 };


### PR DESCRIPTION
`@testing-library/react-hooks` does not support React v18. Instead, `renderHook` was added to React Testing Library in v13. However, it has a simplified API. The React Testing Library version of `renderHook` does not return a `waitForNextUpdate` function.
https://testing-library.com/docs/react-testing-library/api#renderhook 

This updates Terra UI tests that use `renderHook` for compatibility with React v18 / React Testing Library v14. Mainly, this is replacing `await waitForNextUpdate()` with `await act(...)`.

Many hooks contain effects that do async things (usually fetching data) when the hook is rendered. For these, `renderHook` has to be wrapped in `act` to wait for those async updates to finish. I added a helper to test-utils to make this more convenient.
```ts
const { result: hookReturnRef } = await renderHookInAct(() => ...);
```
vs
```ts
let hookReturnRef: { current: HookResultType };
await act(async () => {
  hookReturnRef = renderHook(() => ...).result;
})
```

One other stumbling block... it's difficult to test state in the middle of an async update (case in point: the "loading" state in useLoadedData). Testing Library complains if `act` isn't awaited and if the render is not wrapped in `act`. The `useLoadedData` tests are kind of hacky to work around this.

In the update to React v18 / React Testing Library v14, all imports from `@testing-library/react-hooks` will need to be changed to `@testing-library/react`.