### PR TITLE
[AJ-1125] Do not fetch data import jobs for Azure workspaces

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -835,7 +835,6 @@ const Workspaces = (signal) => ({
       },
 
       listImportJobs: async (isRunning) => {
-        // ToDo: This endpoint should be deprecated in favor of more generic "importJob" endpoint
         const res = await fetchOrchestration(`api/${root}/importJob?running_only=${isRunning}`, _.merge(authOpts(), { signal }));
         return res.json();
       },

--- a/src/libs/import-jobs.test.ts
+++ b/src/libs/import-jobs.test.ts
@@ -1,0 +1,125 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import { Ajax } from 'src/libs/ajax';
+import { asyncImportJobStore } from 'src/libs/state';
+import { DeepPartial } from 'src/libs/type-utils/deep-partial';
+import { AzureWorkspace, GoogleWorkspace } from 'src/libs/workspace-utils';
+import { asMockedFn } from 'src/testing/test-utils';
+
+import { useImportJobs } from './import-jobs';
+
+jest.mock('src/libs/ajax');
+type AjaxExports = typeof import('src/libs/ajax');
+type AjaxContract = ReturnType<AjaxExports['Ajax']>;
+
+describe('useImportJobs', () => {
+  describe('for Google workspaces', () => {
+    // Arrange
+    const workspace: GoogleWorkspace = {
+      workspace: {
+        authorizationDomain: [],
+        cloudPlatform: 'Gcp',
+        bucketName: 'test-bucket',
+        googleProject: 'test-project',
+        name: 'google-workspace',
+        namespace: 'test-workspaces',
+        workspaceId: 'testGoogleWorkspaceId',
+        createdDate: '2023-02-15T19:17:15.711Z',
+        createdBy: 'user@example.com',
+      },
+      accessLevel: 'OWNER',
+      canShare: true,
+      canCompute: true,
+    };
+
+    it('returns list of running jobs in workspace', () => {
+      // Arrange
+      asyncImportJobStore.set([
+        { targetWorkspace: { namespace: 'test-workspaces', name: 'other-workspace' }, jobId: 'other-workspace-job' },
+        { targetWorkspace: { namespace: 'test-workspaces', name: 'google-workspace' }, jobId: 'workspace-job-1' },
+        { targetWorkspace: { namespace: 'test-workspaces', name: 'google-workspace' }, jobId: 'workspace-job-2' },
+      ]);
+
+      // Act
+      const { result: hookReturnRef } = renderHook(() => useImportJobs(workspace));
+
+      // Assert
+      expect(hookReturnRef.current.runningJobs).toEqual(['workspace-job-1', 'workspace-job-2']);
+    });
+
+    it('returns a function that refreshes running jobs', async () => {
+      // Arrange
+      asyncImportJobStore.set([
+        { targetWorkspace: { namespace: 'test-workspaces', name: 'google-workspace' }, jobId: 'job-1' },
+        { targetWorkspace: { namespace: 'test-workspaces', name: 'google-workspace' }, jobId: 'job-2' },
+      ]);
+
+      const listImportJobs = jest.fn().mockResolvedValue([{ jobId: 'job-2' }, { jobId: 'job-3' }]);
+      const mockAjax: DeepPartial<AjaxContract> = {
+        Workspaces: {
+          workspace: () => ({ listImportJobs }),
+        },
+      };
+      asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+
+      const { result: hookReturnRef } = renderHook(() => useImportJobs(workspace));
+
+      // Act
+      await act(() => hookReturnRef.current.refresh());
+
+      // Assert
+      expect(listImportJobs).toHaveBeenCalledWith(true);
+      expect(hookReturnRef.current.runningJobs).toEqual(['job-2', 'job-3']);
+    });
+  });
+
+  describe('for Azure workspaces', () => {
+    // Arrange
+    const workspace: AzureWorkspace = {
+      workspace: {
+        authorizationDomain: [],
+        cloudPlatform: 'Azure',
+        name: 'azure-workspace',
+        namespace: 'test-workspaces',
+        workspaceId: 'fafbb550-62eb-4135-8b82-3ce4d53446af',
+        createdDate: '2023-02-15T19:17:15.711Z',
+        createdBy: 'user@example.com',
+      },
+      azureContext: {
+        managedResourceGroupId: 'test-mrg',
+        subscriptionId: 'test-sub-id',
+        tenantId: 'test-tenant-id',
+      },
+      accessLevel: 'OWNER',
+      canShare: true,
+      canCompute: true,
+    };
+
+    it('returns empty list of jobs', () => {
+      // Act
+      const { result: hookReturnRef } = renderHook(() => useImportJobs(workspace));
+
+      // Assert
+      expect(hookReturnRef.current.runningJobs).toEqual([]);
+    });
+
+    it('returns a no-op for refreshing jobs', async () => {
+      // Arrange
+      const listImportJobs = jest.fn().mockResolvedValue([]);
+      const mockAjax: DeepPartial<AjaxContract> = {
+        Workspaces: {
+          workspace: () => ({ listImportJobs }),
+        },
+      };
+      asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+
+      const { result: hookReturnRef } = renderHook(() => useImportJobs(workspace));
+
+      // Act
+      await act(() => hookReturnRef.current.refresh());
+
+      // Assert
+      expect(listImportJobs).not.toHaveBeenCalled();
+      expect(hookReturnRef.current.runningJobs).toEqual([]);
+    });
+  });
+});

--- a/src/libs/import-jobs.ts
+++ b/src/libs/import-jobs.ts
@@ -1,0 +1,57 @@
+import { useCallback } from 'react';
+import { Ajax } from 'src/libs/ajax';
+import { reportError } from 'src/libs/error';
+import { useCancellation, useStore } from 'src/libs/react-utils';
+import { AsyncImportJob, asyncImportJobStore } from 'src/libs/state';
+import { isAzureWorkspace, WorkspaceWrapper } from 'src/libs/workspace-utils';
+
+export type UseImportJobsResult = {
+  runningJobs: string[];
+  refresh: () => Promise<void>;
+};
+
+const isJobInWorkspace = (job: AsyncImportJob, workspace: WorkspaceWrapper): boolean => {
+  return (
+    job.targetWorkspace.namespace === workspace.workspace.namespace &&
+    job.targetWorkspace.name === workspace.workspace.name
+  );
+};
+
+export const useImportJobs = (workspace: WorkspaceWrapper): UseImportJobsResult => {
+  const allRunningJobs = useStore(asyncImportJobStore);
+
+  const signal = useCancellation();
+  const refresh = useCallback(async () => {
+    const {
+      workspace: { namespace, name },
+    } = workspace;
+    try {
+      const runningJobsInWorkspace: { jobId: string }[] = await Ajax(signal)
+        .Workspaces.workspace(namespace, name)
+        .listImportJobs(true);
+
+      asyncImportJobStore.update((previousState) => {
+        return [
+          ...previousState.filter((job) => !isJobInWorkspace(job, workspace)),
+          ...runningJobsInWorkspace.map(({ jobId }) => ({ jobId, targetWorkspace: { namespace, name } })),
+        ];
+      });
+    } catch (error) {
+      reportError('Error loading running import jobs in this workspace', error);
+    }
+  }, [workspace, signal]);
+
+  // Azure workspaces don't import data using async import jobs.
+  if (isAzureWorkspace(workspace)) {
+    return {
+      runningJobs: [],
+      refresh: () => Promise.resolve(),
+    };
+  }
+
+  const runningJobsInWorkspace = allRunningJobs.filter((job) => isJobInWorkspace(job, workspace));
+  return {
+    runningJobs: runningJobsInWorkspace.map((job) => job.jobId),
+    refresh,
+  };
+};

--- a/src/libs/state.js
+++ b/src/libs/state.js
@@ -67,7 +67,15 @@ export const workflowSelectionStore = Utils.atom({
   entities: undefined,
 });
 
-/** @type {Utils.Atom<any[]>} */
+/**
+ * @typedef {Object} AsyncImportJob
+ * @property {string} jobId
+ * @property {Object} targetWorkspace
+ * @property {string} targetWorkspace.namespace
+ * @property {string} targetWorkspace.name
+ */
+
+/** @type {Utils.Atom<AsyncImportJob[]>} */
 export const asyncImportJobStore = Utils.atom([]);
 
 export const snapshotsListStore = Utils.atom();


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1125

Azure workspaces do not import data in the same way as Google workspaces, so they do not need to check Orchestration for in progress import jobs.

This adds a hook that returns a `refresh` function that handles fetching running import jobs for the given workspaces from Orchestration. For Azure workspaces, refresh is a no-op.