### PR TITLE
[UIE-97] Resolve warnings in ShareWorkspaceModal test

### DIFF
--- a/src/pages/workspaces/workspace/ShareWorkspaceModal/ShareWorkspaceModal.test.ts
+++ b/src/pages/workspaces/workspace/ShareWorkspaceModal/ShareWorkspaceModal.test.ts
@@ -233,57 +233,63 @@ describe('the share workspace modal', () => {
 
     it('shows a warning when sharing a workspace with protected data', async () => {
       mockAjax({}, [], [], jest.fn());
-      render(
-        h(ShareWorkspaceModal, {
-          onDismiss: jest.fn(),
-          workspace: {
-            ...azureWorkspace,
-            policies: [
-              {
-                additionalData: {},
-                name: 'protected-data',
-                namespace: 'terra',
-              },
-            ],
-          },
-        })
-      );
+      await act(async () => {
+        render(
+          h(ShareWorkspaceModal, {
+            onDismiss: jest.fn(),
+            workspace: {
+              ...azureWorkspace,
+              policies: [
+                {
+                  additionalData: {},
+                  name: 'protected-data',
+                  namespace: 'terra',
+                },
+              ],
+            },
+          })
+        );
+      });
       expect(screen.queryByText(/Do not share Unclassified Confidential Information/i)).toBeInTheDocument();
     });
 
     it('does not show a warning for azure workspaces without a protected data policy', async () => {
       mockAjax({}, [], [], jest.fn());
-      render(
-        h(ShareWorkspaceModal, {
-          onDismiss: jest.fn(),
-          workspace: {
-            ...azureWorkspace,
-            policies: [
-              {
-                additionalData: {},
-                name: 'not-protected-data',
-                namespace: 'terra',
-              },
-              {
-                additionalData: {},
-                name: 'protected-data',
-                namespace: 'something-besides-terra',
-              },
-            ],
-          },
-        })
-      );
+      await act(async () => {
+        render(
+          h(ShareWorkspaceModal, {
+            onDismiss: jest.fn(),
+            workspace: {
+              ...azureWorkspace,
+              policies: [
+                {
+                  additionalData: {},
+                  name: 'not-protected-data',
+                  namespace: 'terra',
+                },
+                {
+                  additionalData: {},
+                  name: 'protected-data',
+                  namespace: 'something-besides-terra',
+                },
+              ],
+            },
+          })
+        );
+      });
       expect(screen.queryByText(/Do not share Unclassified Confidential Information/i)).not.toBeInTheDocument();
     });
 
     it('does not get workspace detail or display a warning for a gcp workspace', async () => {
       mockAjax({}, [], [], jest.fn());
-      render(
-        h(ShareWorkspaceModal, {
-          onDismiss: jest.fn(),
-          workspace,
-        })
-      );
+      await act(async () => {
+        render(
+          h(ShareWorkspaceModal, {
+            onDismiss: jest.fn(),
+            workspace,
+          })
+        );
+      });
       expect(screen.queryByText(/Do not share Unclassified Confidential Information/i)).not.toBeInTheDocument();
     });
   });


### PR DESCRIPTION
Currently, the ShareWorkspaceModal test throws _many_ warnings about updates not wrapped in act related to ShareWorkspaceModal's initial data fetching.

```
 Warning: An update to ShareWorkspaceModal inside a test was not wrapped in act(...).
    
    When testing, code that causes React state updates should be wrapped into act(...):
    
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
    
    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
        at fn (/Users/nwatts/workspace/terra-ui/src/pages/workspaces/workspace/ShareWorkspaceModal/ShareWorkspaceModal.ts:33:11)

      60 |
      61 |         const fixedAcl: WorkspaceAcl = transformAcl(acl);
    > 62 |         setAcl(fixedAcl);
         |         ^
      63 |         setOriginalAcl(fixedAcl);
      64 |         setGroups(groups);
      65 |         setShareSuggestions(shareSuggestions);
```

Wrapping `render` in `await act(async () => { ... })` resolves these warnings.

It is a mystery to me why only some of the tests in ShareWorkspaceModal.test.ts throw these warnings.