### PR TITLE
[DC-733] Fixup data catalog tests for React 18

### DIFF
--- a/src/pages/library/data-catalog/CreateDataset/CreateDataset.test.ts
+++ b/src/pages/library/data-catalog/CreateDataset/CreateDataset.test.ts
@@ -3,6 +3,14 @@ import userEvent from '@testing-library/user-event';
 import { h } from 'react-hyperscript-helpers';
 import { CreateDataset } from 'src/pages/library/data-catalog/CreateDataset/CreateDataset';
 
+type MarkdownExports = typeof import('src/components/markdown');
+jest.mock('src/components/markdown', (): Partial<MarkdownExports> => {
+  const { createElement } = jest.requireActual('react');
+  return {
+    MarkdownEditor: jest.fn().mockImplementation(() => createElement('div')),
+  };
+});
+
 type NavExports = typeof import('src/libs/nav');
 jest.mock(
   'src/libs/nav',
@@ -14,7 +22,7 @@ jest.mock(
 );
 
 describe('CreateDataset', () => {
-  it('Prepopulates storage system', async () => {
+  it('Prepopulates storage system', () => {
     // Act
     render(
       h(CreateDataset, {
@@ -23,17 +31,17 @@ describe('CreateDataset', () => {
       })
     );
     // Assert
-    expect(await screen.queryAllByText('Workspace').length).toBe(1);
+    expect(screen.queryAllByText('Workspace').length).toBe(1);
   });
 
-  it('Validates storage system', async () => {
+  it('Validates storage system', () => {
     // Act
     render(h(CreateDataset));
     // Assert
-    expect(await screen.queryAllByText("Storage system can't be blank").length).toBe(1);
+    expect(screen.queryAllByText("Storage system can't be blank").length).toBe(1);
   });
 
-  it('Prepopulates storage source id', async () => {
+  it('Prepopulates storage source id', () => {
     // Act
     render(
       h(CreateDataset, {
@@ -42,14 +50,14 @@ describe('CreateDataset', () => {
       })
     );
     // Assert
-    expect(await screen.queryAllByText("Storage source id can't be blank").length).toBe(0);
+    expect(screen.queryAllByText("Storage source id can't be blank").length).toBe(0);
   });
 
-  it('Validates storage source id', async () => {
+  it('Validates storage source id', () => {
     // Act
     render(h(CreateDataset));
     // Assert
-    expect(await screen.queryAllByText("Storage source id can't be blank").length).toBe(2);
+    expect(screen.queryAllByText("Storage source id can't be blank").length).toBe(2);
   });
 
   it('Validates for title', async () => {
@@ -61,13 +69,13 @@ describe('CreateDataset', () => {
         storageSourceId: 'abcdef',
       })
     );
-    expect(await screen.queryAllByText("Dct:title can't be blank").length).toBe(1);
+    expect(screen.queryAllByText("Dct:title can't be blank").length).toBe(1);
     const titleInput = screen.getByLabelText('Title *');
     await user.type(titleInput, 'title');
-    expect(await screen.queryByText("Dct:title can't be blank")).toBeFalsy();
+    expect(screen.queryByText("Dct:title can't be blank")).toBeFalsy();
     await user.clear(titleInput);
     // Count increases because we show the red error message after title has been touched
-    expect(await screen.queryAllByText("Dct:title can't be blank").length).toBe(2);
+    expect(screen.queryAllByText("Dct:title can't be blank").length).toBe(2);
   });
 
   // No description test due to label bug with markdown input
@@ -81,19 +89,19 @@ describe('CreateDataset', () => {
         storageSourceId: 'abcdef',
       })
     );
-    expect(await screen.queryAllByText("Dcat:access url can't be blank").length).toBe(1);
+    expect(screen.queryAllByText("Dcat:access url can't be blank").length).toBe(1);
     // One extra for the publication list
-    expect(await screen.queryAllByText('Dcat:access url is not a valid url').length).toBe(2);
+    expect(screen.queryAllByText('Dcat:access url is not a valid url').length).toBe(2);
     const accessURLInput = screen.getByLabelText('Access URL *');
     await user.type(accessURLInput, 'title');
-    expect(await screen.queryByText("Dcat:access url can't be blank")).toBeFalsy();
-    expect(await screen.queryAllByText('Dcat:access url is not a valid url').length).toBe(3);
+    expect(screen.queryByText("Dcat:access url can't be blank")).toBeFalsy();
+    expect(screen.queryAllByText('Dcat:access url is not a valid url').length).toBe(3);
     await user.clear(accessURLInput);
     await user.type(accessURLInput, 'https://url.com');
-    expect(await screen.queryAllByText('Dcat:access url is not a valid url').length).toBe(1);
+    expect(screen.queryAllByText('Dcat:access url is not a valid url').length).toBe(1);
     await user.clear(accessURLInput);
     // Count increases because we show the red error message after access URL has been touched
-    expect(await screen.queryAllByText("Dcat:access url can't be blank").length).toBe(2);
+    expect(screen.queryAllByText("Dcat:access url can't be blank").length).toBe(2);
   });
 
   it('Validates for creator', async () => {
@@ -105,12 +113,12 @@ describe('CreateDataset', () => {
         storageSourceId: 'abcdef',
       })
     );
-    expect(await screen.queryAllByText("Dct:creator can't be blank").length).toBe(1);
+    expect(screen.queryAllByText("Dct:creator can't be blank").length).toBe(1);
     const creatorInput = screen.getByLabelText('Dataset Creator *');
     await user.type(creatorInput, 'creator');
-    expect(await screen.queryByText("Dct:creator can't be blank")).toBeFalsy();
+    expect(screen.queryByText("Dct:creator can't be blank")).toBeFalsy();
     await user.clear(creatorInput);
     // Count increases because we show the red error message after creator has been touched
-    expect(await screen.queryAllByText("Dct:creator can't be blank").length).toBe(2);
+    expect(screen.queryAllByText("Dct:creator can't be blank").length).toBe(2);
   });
 });

--- a/src/pages/library/data-catalog/CreateDataset/CreateDatasetInputs.test.ts
+++ b/src/pages/library/data-catalog/CreateDataset/CreateDatasetInputs.test.ts
@@ -109,7 +109,6 @@ describe('CreateDatasetInputs', () => {
     );
     // Assert
     expect(screen.getByText('Title')).toBeTruthy();
-    // Cannot test for value because the it gets into testing underlying library behavior
     expect(MarkdownEditor).toHaveBeenCalledWith(
       expect.objectContaining({
         value: 'Abc',

--- a/src/pages/library/data-catalog/CreateDataset/CreateDatasetInputs.test.ts
+++ b/src/pages/library/data-catalog/CreateDataset/CreateDatasetInputs.test.ts
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import * as _ from 'lodash/fp';
 import { useState } from 'react';
 import { h } from 'react-hyperscript-helpers';
+import { MarkdownEditor } from 'src/components/markdown';
 import {
   CatalogNumberInput,
   ListInput,
@@ -10,6 +11,14 @@ import {
   SelectInput,
   StringInput,
 } from 'src/pages/library/data-catalog/CreateDataset/CreateDatasetInputs';
+
+type MarkdownExports = typeof import('src/components/markdown');
+jest.mock('src/components/markdown', (): Partial<MarkdownExports> => {
+  const { createElement } = jest.requireActual('react');
+  return {
+    MarkdownEditor: jest.fn().mockImplementation(() => createElement('div')),
+  };
+});
 
 // These components are needed to test inputs, because they are designed with their value being managed in a parent component's state
 const InputWithState = ({ initialValue, input, props }) => {
@@ -101,6 +110,12 @@ describe('CreateDatasetInputs', () => {
     // Assert
     expect(screen.getByText('Title')).toBeTruthy();
     // Cannot test for value because the it gets into testing underlying library behavior
+    expect(MarkdownEditor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        value: 'Abc',
+      }),
+      expect.any(Object)
+    );
   });
 
   it('Renders a Select input with the title and value and selectable options', async () => {


### PR DESCRIPTION
This resolves warnings that appear in a few data catalog tests with upgrades to React 18 and React Testing Library v14.

Rendering MarkdownEditor threw a warning about "A suspended resource finished loading inside a test, but the event was not wrapped in act". The tests didn't seem to need the actual Markdown component to be rendered, so this mocks it.

Also, `queryBy...` queries are not async, so this removes unnecessary awaits.