### PR TITLE
[UIE-97][AJ-1103] Resolve warning about missing key

### DIFF
--- a/src/pages/ImportData.js
+++ b/src/pages/ImportData.js
@@ -125,7 +125,7 @@ export const ImportDataOverview = ({ header, snapshots, isDataset, snapshotRespo
       : url && div({ style: { fontSize: 16 } }, ['From: ', new URL(url).hostname]),
     div({ style: { marginTop: '1rem' } }, [
       !!url && isProtected(url, format)
-        ? [
+        ? h(Fragment, [
             icon('warning-standard', { size: 15, style: { marginRight: '0.25rem' }, color: colors.warning() }),
             ' The data you chose to import to Terra are identified as protected and require additional security settings. Please select a workspace that has an Authorization Domain and/or protected data setting.',
             h(
@@ -137,7 +137,7 @@ export const ImportDataOverview = ({ header, snapshots, isDataset, snapshotRespo
               },
               ['Learn more about protected data', icon('pop-out', { size: 12 })]
             ),
-          ]
+          ])
         : `The ${isDataset ? 'dataset' : 'snapshot'}(s) you just chose to import to Terra will be made available to you `,
       'within a workspace of your choice where you can then perform analysis.',
     ]),


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/UIE-97
https://broadworkbench.atlassian.net/browse/AJ-1103

Fixup for #3994.

The unit tests for ImportData throws a React warning:
```
Warning: Each child in a list should have a unique "key" prop.
```

Turning the list of elements into a Fragment resolves the warning.