### PR TITLE
[DC-733] Fixup workspaces tests for React 18

### DIFF
--- a/src/pages/billing/NewBillingProjectWizard/AzureBillingProjectWizard/AddUsersStep.test.ts
+++ b/src/pages/billing/NewBillingProjectWizard/AzureBillingProjectWizard/AddUsersStep.test.ts
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { h } from 'react-hyperscript-helpers';
 import { AddUsersStep } from 'src/pages/billing/NewBillingProjectWizard/AzureBillingProjectWizard/AddUsersStep';
@@ -20,6 +20,7 @@ export const addUserAndOwner = (userEmail, ownerEmail) => {
 };
 
 const defaultProps = {
+  inputDebounce: 0,
   isActive: true,
   userEmails: '',
   ownerEmails: '',
@@ -53,6 +54,8 @@ describe('AddUsersStep', () => {
 
   it('Disables and clears the input fields based on radio button selection', async () => {
     // Arrange
+    const user = userEvent.setup();
+
     const mockAddUsersOrOwners = jest.fn((addUsers) => {
       renderResult.rerender(
         h(AddUsersStep, {
@@ -65,7 +68,7 @@ describe('AddUsersStep', () => {
     const renderResult = render(h(AddUsersStep, { ...defaultProps, onAddUsersOrOwners: mockAddUsersOrOwners }));
 
     // Act
-    fireEvent.click(getAddUsersRadio());
+    await user.click(getAddUsersRadio());
 
     // Assert
     expect(mockAddUsersOrOwners).toBeCalledWith(true);
@@ -75,22 +78,18 @@ describe('AddUsersStep', () => {
     verifyEnabled(getOwnersInput());
 
     // Act and Assert
-    await act(async () => {
-      await userEvent.click(getUsersInput());
-    });
+    await user.click(getUsersInput());
     expect(onOwnersOrUsersInputFocused).toBeCalled();
     fireEvent.change(getUsersInput(), { target: { value: 'user@foo.com' } });
     expect(onSetUserEmails).toBeCalledWith('user@foo.com', false);
 
     onOwnersOrUsersInputFocused.mockReset();
-    await act(async () => {
-      await userEvent.click(getOwnersInput());
-    });
+    await user.click(getOwnersInput());
     expect(onOwnersOrUsersInputFocused).toBeCalled();
     fireEvent.change(getOwnersInput(), { target: { value: 'owner@foo.com' } });
     expect(onSetOwnerEmails).toBeCalledWith('owner@foo.com', false);
 
-    fireEvent.click(getNoUsersRadio());
+    await user.click(getNoUsersRadio());
     expect(mockAddUsersOrOwners).toBeCalledWith(false);
     expect(onSetOwnerEmails).toHaveBeenLastCalledWith('', false);
     expect(onSetUserEmails).toHaveBeenLastCalledWith('', false);

--- a/src/pages/billing/NewBillingProjectWizard/GCPBillingProjectWizard/GCPBillingProjectWizard.test.ts
+++ b/src/pages/billing/NewBillingProjectWizard/GCPBillingProjectWizard/GCPBillingProjectWizard.test.ts
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 import { h } from 'react-hyperscript-helpers';
@@ -280,11 +280,10 @@ describe('GCPBillingProjectWizard Steps', () => {
 
   describe('Step 3 "I have verified" Checkbox Checked', () => {
     beforeEach(async () => {
+      const user = userEvent.setup();
       // Act
-      fireEvent.click(getStep2BillingAccountNoAccessButton());
-      await act(async () => {
-        await userEvent.click(expectNotNull(getStep3VerifyUserAdded()));
-      });
+      await user.click(getStep2BillingAccountNoAccessButton());
+      await user.click(expectNotNull(getStep3VerifyUserAdded()));
       expect(captureEvent).toHaveBeenCalledWith(Events.billingGCPCreationStep3VerifyUserAdded);
     });
     // Assert
@@ -308,10 +307,9 @@ describe('GCPBillingProjectWizard Steps', () => {
   describe('Step 3 Button ("I dont have access to do this") selected', () => {
     // Act
     beforeEach(async () => {
-      fireEvent.click(getStep2HaveBillingAccountButton());
-      await act(async () => {
-        await userEvent.click(expectNotNull(getStep3BillingAccountNoAccessButton()));
-      });
+      const user = userEvent.setup();
+      await user.click(getStep2HaveBillingAccountButton());
+      await user.click(expectNotNull(getStep3BillingAccountNoAccessButton()));
       expect(captureEvent).toHaveBeenCalledWith(Events.billingGCPCreationStep3BillingAccountNoAccess);
     });
     // Assert
@@ -334,10 +332,9 @@ describe('GCPBillingProjectWizard Steps', () => {
   describe('Step 3 Button ("I have added...") selected', () => {
     // Act
     beforeEach(async () => {
-      fireEvent.click(getStep2HaveBillingAccountButton());
-      await act(async () => {
-        await userEvent.click(expectNotNull(getStep3AddedTerraBillingButton()));
-      });
+      const user = userEvent.setup();
+      await user.click(getStep2HaveBillingAccountButton());
+      await user.click(expectNotNull(getStep3AddedTerraBillingButton()));
       expect(captureEvent).toHaveBeenCalledWith(Events.billingGCPCreationStep3AddedTerraBilling);
     });
     // Assert
@@ -370,12 +367,11 @@ describe('GCPBillingProjectWizard Steps', () => {
   describe('Step 4', () => {
     it('tests if Step 4 can create a project given valid inputs', async () => {
       // Arrange
+      const user = userEvent.setup();
       const projectName = 'Billing_Project_Name';
       // Complete Step 2 and 3
-      fireEvent.click(getStep2BillingAccountNoAccessButton());
-      await act(async () => {
-        await userEvent.click(expectNotNull(getStep3VerifyUserAdded()));
-      });
+      await user.click(getStep2BillingAccountNoAccessButton());
+      await user.click(expectNotNull(getStep3VerifyUserAdded()));
 
       // Step 4 status
       testStep4Enabled();
@@ -384,21 +380,19 @@ describe('GCPBillingProjectWizard Steps', () => {
       expect(getStep4RefreshButton()).toBeNull();
 
       // Insert valid project Name
-      await userEvent.type(getBillingProjectInput(), projectName);
+      await user.type(getBillingProjectInput(), projectName);
       expect(captureEvent).toHaveBeenCalledWith(Events.billingCreationGCPProjectNameEntered);
       // Select a billing account
-      await userEvent.click(getBillingAccountInput());
+      await user.click(getBillingAccountInput());
       const selectOption = await screen.findByText(displayName);
-      await userEvent.click(selectOption);
+      await user.click(selectOption);
       expect(captureEvent).toHaveBeenCalledWith(Events.billingCreationGCPBillingAccountSelected);
 
       // Verify accessibility now that all controls are enabled
       expect(await axe(wizardComponent.container)).toHaveNoViolations();
 
       // Act - Click Create
-      await act(async () => {
-        await userEvent.click(expectNotNull(getStep4CreateButton()));
-      });
+      await user.click(expectNotNull(getStep4CreateButton()));
       // Assert
       expect(createGCPProject).toHaveBeenCalledWith(projectName, accountName);
     });
@@ -424,10 +418,9 @@ describe('Step 4 Warning Message', () => {
       })
     );
 
-    fireEvent.click(getStep2BillingAccountNoAccessButton());
-    await act(async () => {
-      await userEvent.click(expectNotNull(getStep3VerifyUserAdded()));
-    });
+    const user = userEvent.setup();
+    await user.click(getStep2BillingAccountNoAccessButton());
+    await user.click(expectNotNull(getStep3VerifyUserAdded()));
   });
 
   it('should show a warning message when there are no billing accounts', () => {
@@ -439,9 +432,8 @@ describe('Step 4 Warning Message', () => {
 
   it('should show the correct message when refresh step 3 is clicked but there are no billing accounts', async () => {
     // Act
-    await act(async () => {
-      await userEvent.click(expectNotNull(screen.queryByText('Refresh Step 3')));
-    });
+    const user = userEvent.setup();
+    await user.click(expectNotNull(screen.queryByText('Refresh Step 3')));
     expect(captureEvent).toHaveBeenCalledWith(Events.billingGCPCreationRefreshStep3);
     // Assert
     expect(
@@ -504,19 +496,16 @@ describe('Changing prior answers', () => {
   });
 
   it('should reset from Step 3 if Step 3 checkbox is unchecked from Step 4', async () => {
+    const user = userEvent.setup();
     // Act - Check
-    fireEvent.click(getStep2BillingAccountNoAccessButton());
-    await act(async () => {
-      await userEvent.click(expectNotNull(getStep3VerifyUserAdded()));
-    });
+    await user.click(getStep2BillingAccountNoAccessButton());
+    await user.click(expectNotNull(getStep3VerifyUserAdded()));
     // Assert
     testStep2DontHaveAccessToBillingChecked();
     verifyChecked(getStep3VerifyUserAdded());
     testStep4Enabled();
     // Act - Uncheck
-    await act(async () => {
-      await userEvent.click(expectNotNull(getStep3VerifyUserAdded()));
-    });
+    await user.click(expectNotNull(getStep3VerifyUserAdded()));
     // Assert
     testStep2DontHaveAccessToBillingChecked();
     verifyUnchecked(getStep3VerifyUserAdded());
@@ -525,11 +514,10 @@ describe('Changing prior answers', () => {
   });
 
   it('should reset from Step 3 if Step 3 radio button answer is changed from Step 4', async () => {
+    const user = userEvent.setup();
     // Act - Check
-    fireEvent.click(getStep2HaveBillingAccountButton());
-    await act(async () => {
-      await userEvent.click(expectNotNull(getStep3AddedTerraBillingButton()));
-    });
+    await user.click(getStep2HaveBillingAccountButton());
+    await user.click(expectNotNull(getStep3AddedTerraBillingButton()));
     // Assert
     testStep2HaveBillingChecked();
     verifyChecked(getStep3AddedTerraBillingButton());

--- a/src/pages/billing/SpendReport/SpendReport.test.ts
+++ b/src/pages/billing/SpendReport/SpendReport.test.ts
@@ -36,7 +36,9 @@ describe('SpendReport', () => {
     // 90 days
     fireEvent.keyDown(getDateRangeSelect, { key: 'ArrowDown', code: 'ArrowDown' });
     // Choose the current focused option.
-    fireEvent.keyDown(getDateRangeSelect, { key: 'Enter', code: 'Enter' });
+    await act(async () => {
+      fireEvent.keyDown(getDateRangeSelect, { key: 'Enter', code: 'Enter' });
+    });
 
     await waitFor(() => {
       // Check that 90 days was actually selected. There will always be a DOM element present with
@@ -136,7 +138,7 @@ describe('SpendReport', () => {
 
     // Act
     await act(async () => {
-      await render(h(SpendReport, { viewSelected: false, billingProjectName: 'thrifty', cloudPlatform: 'GCP' }));
+      render(h(SpendReport, { viewSelected: false, billingProjectName: 'thrifty', cloudPlatform: 'GCP' }));
     });
 
     // Assert
@@ -157,7 +159,7 @@ describe('SpendReport', () => {
 
     // Act
     await act(async () => {
-      await render(h(SpendReport, { viewSelected: true, billingProjectName: 'thrifty', cloudPlatform: 'GCP' }));
+      render(h(SpendReport, { viewSelected: true, billingProjectName: 'thrifty', cloudPlatform: 'GCP' }));
     });
 
     // Assert
@@ -186,7 +188,7 @@ describe('SpendReport', () => {
 
     // Act
     await act(async () => {
-      await render(h(SpendReport, { viewSelected: true, billingProjectName: 'thrifty', cloudPlatform: 'AZURE' }));
+      render(h(SpendReport, { viewSelected: true, billingProjectName: 'thrifty', cloudPlatform: 'AZURE' }));
     });
 
     // Assert
@@ -257,7 +259,7 @@ describe('SpendReport', () => {
 
     // Act
     await act(async () => {
-      await render(h(SpendReport, { viewSelected: true, billingProjectName: 'thrifty', cloudPlatform: 'GCP' }));
+      render(h(SpendReport, { viewSelected: true, billingProjectName: 'thrifty', cloudPlatform: 'GCP' }));
     });
 
     // Assert

--- a/src/pages/workspaces/workspace/Dashboard.test.js
+++ b/src/pages/workspaces/workspace/Dashboard.test.js
@@ -78,7 +78,7 @@ describe('WorkspaceNotifications', () => {
     const { getByLabelText } = render(h(WorkspaceNotifications, { workspace: testWorkspace }));
     const submissionNotificationsCheckbox = getByLabelText('Receive submission notifications');
 
-    await act(() => user.click(submissionNotificationsCheckbox));
+    await user.click(submissionNotificationsCheckbox);
     expect(setPreferences).toHaveBeenCalledWith({
       'notifications/SuccessfulSubmissionNotification/test/test': 'true',
       'notifications/FailedSubmissionNotification/test/test': 'true',


### PR DESCRIPTION
This resolves warnings that appear in a few workspaces tests with upgrades to React 18 and React Testing Library v14.

The newer versions appear to be unhappy with `userEvent` methods wrapped in `act`. That causes warnings about the testing environment not being configured for act.