### PR TITLE
[DC-733] Fixup file browser tests for React 18

### DIFF
--- a/src/components/file-browser/FilesInDirectory.test.ts
+++ b/src/components/file-browser/FilesInDirectory.test.ts
@@ -1,4 +1,4 @@
-import { act, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { div, h } from 'react-hyperscript-helpers';
 import { useFilesInDirectory } from 'src/components/file-browser/file-browser-hooks';
@@ -291,7 +291,7 @@ describe('FilesInDirectory', () => {
     const file = new File(['somecontent'], 'example.txt');
 
     // Act
-    await act(() => user.upload(fileInput, [file]));
+    await user.upload(fileInput, [file]);
 
     // Assert
     expect(uploadFileToDirectory).toHaveBeenCalledWith('path/to/directory/', file);
@@ -334,7 +334,7 @@ describe('FilesInDirectory', () => {
 
     // Act
     const deleteButton = screen.getByText('Delete this folder');
-    await act(() => user.click(deleteButton));
+    await user.click(deleteButton);
 
     // Assert
     expect(deleteEmptyDirectory).toHaveBeenCalledWith('path/to/directory/');

--- a/src/components/file-browser/FilesMenu.test.ts
+++ b/src/components/file-browser/FilesMenu.test.ts
@@ -1,4 +1,4 @@
-import { act, getByText, render, screen } from '@testing-library/react';
+import { getByText, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { h } from 'react-hyperscript-helpers';
 import FileBrowserProvider, { FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider';
@@ -72,9 +72,7 @@ describe('FilesMenu', () => {
     it('deletes selected files', async () => {
       // Act
       const confirmDeleteButton = screen.getByText('Delete files');
-      await act(async () => {
-        await user.click(confirmDeleteButton);
-      });
+      await user.click(confirmDeleteButton);
 
       // Assert
       expect(deleteFile.mock.calls).toEqual([['path/to/file1.txt'], ['path/to/file2.bam'], ['path/to/file3.vcf']]);
@@ -83,9 +81,7 @@ describe('FilesMenu', () => {
     it('calls onDeleteFiles callback', async () => {
       // Act
       const confirmDeleteButton = screen.getByText('Delete files');
-      await act(async () => {
-        await user.click(confirmDeleteButton);
-      });
+      await user.click(confirmDeleteButton);
 
       // Assert
       expect(onDeleteFiles).toHaveBeenCalled();
@@ -123,7 +119,7 @@ describe('FilesMenu', () => {
     await user.type(nameInput, 'test-folder');
 
     const createButton = screen.getByText('Create Folder');
-    await act(() => user.click(createButton));
+    await user.click(createButton);
 
     // Assert
     expect(createEmptyDirectory).toHaveBeenCalledWith('path/to/directory/test-folder/');

--- a/src/pages/AzurePreview.test.js
+++ b/src/pages/AzurePreview.test.js
@@ -1,4 +1,4 @@
-import { act, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { h } from 'react-hyperscript-helpers';
 import { Ajax } from 'src/libs/ajax';
@@ -183,7 +183,7 @@ describe('AzurePreview', () => {
 
           // Act
           const submitButton = screen.getByText('Submit');
-          await act(() => user.click(submitButton));
+          await user.click(submitButton);
         });
 
         it('submits user info', () => {


### PR DESCRIPTION
This resolves warnings that appear in a few file tests with upgrades to React 18 and React Testing Library v14.