### PR TITLE
[UIE-97] Mock modal in ImportWorkflow test

### DIFF
--- a/src/pages/ImportWorkflow/ImportWorkflow.test.ts
+++ b/src/pages/ImportWorkflow/ImportWorkflow.test.ts
@@ -21,6 +21,12 @@ type AppsContract = ReturnType<typeof Apps>;
 jest.mock('src/libs/ajax');
 jest.mock('src/libs/ajax/leonardo/Apps');
 
+type ModalExports = typeof import('src/components/Modal');
+jest.mock('src/components/Modal', (): ModalExports => {
+  const { mockModalModule } = jest.requireActual('src/components/Modal.mock');
+  return mockModalModule();
+});
+
 type WorkspaceUtilsExports = typeof import('src/components/workspace-utils');
 jest.mock('src/components/workspace-utils', (): WorkspaceUtilsExports => {
   const { h } = jest.requireActual('react-hyperscript-helpers');


### PR DESCRIPTION
Unit tests involving the Modal component occasionally flake. This mocks the Modal component in ImportWorkflow after I notificed it experience such a flake.

```
    TypeError: Cannot read properties of null (reading 'contains')

      84 |         // Per react-focus-lock: https://github.com/theKashey/react-focus-lock#unmounting-and-focus-management
      85 |         await Utils.delay(0);
    > 86 |         previouslyFocusedNode.current = modalNode.current.contains(document.activeElement) ? previouslyFocusedNode.current : document.activeElement;
         |                                                           ^
      87 |         nodeToFocus.focus();
      88 |       },
      89 |       style: { overlay: styles.overlay, content: { ...styles.modal, width, ...props.styles?.modal } },

      at Object.onAfterOpen (src/components/Modal.js:86:59)
```