### PR TITLE
[IA-4422] Resolve warning in GCP Compute Modal test

### DIFF
--- a/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal.js
+++ b/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal.js
@@ -761,7 +761,7 @@ export const GcpComputeModalBase = ({
       setLeoImages(filteredNewLeoImages);
       setCurrentRuntimeDetails(currentRuntimeDetails);
       setCurrentPersistentDiskDetails(currentPersistentDiskDetails);
-      setCustomEnvImage(!foundImage ? imageUrl : '');
+      setCustomEnvImage(!foundImage && imageUrl ? imageUrl : '');
       setJupyterUserScriptUri(currentRuntimeDetails?.jupyterUserScriptUri || '');
 
       const locationType = getLocationType(location);


### PR DESCRIPTION
The GCPComputeModal unit test throws a warning:
```
console.error
      Warning: A component is changing a controlled input to be uncontrolled. This is likely caused by the value changing from a defined to undefined, which should not happen. Decide between using a controlled or uncontrolled input element for the lifetime of the component. More info: https://reactjs.org/link/controlled-components
          at input
          at fn (/Users/nwatts/workspace/terra-ui/src/components/input.js:82:61)
          at div
          at fn (/Users/nwatts/workspace/terra-ui/src/components/input.js:235:34)
          at div
          at fn (/Users/nwatts/workspace/terra-ui/src/components/common/IdContainer.ts:11:31)
          at div
          at div
          at fn (/Users/nwatts/workspace/terra-ui/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal.js:216:3)
```

This points out a bug in the component: it may set the `customEnvImage` state variable to undefined instead of a string. This ensures that `customEnvImage` is set to a string value, which resolves the warning.