### PR TITLE
[UIE-57] Add test helpers for Select component

### DIFF
--- a/src/testing/test-utils.test.ts
+++ b/src/testing/test-utils.test.ts
@@ -30,6 +30,8 @@ describe('SelectHelper', () => {
 
     // Assert
     expect(options).toEqual(['Foo', 'Bar', 'Baz']);
+
+    expect(screen.getByLabelText('Test Select')).toHaveAttribute('aria-expanded', 'false');
   });
 });
 

--- a/src/testing/test-utils.test.ts
+++ b/src/testing/test-utils.test.ts
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { h } from 'react-hyperscript-helpers';
+import { Select } from 'src/components/common';
+
+import { SelectHelper } from './test-utils';
+
+const TextSelect = Select as typeof Select<string>;
+
+describe('SelectHelper', () => {
+  it('returns options from Select', async () => {
+    // Arrange
+    const user = userEvent.setup();
+
+    render(
+      h(TextSelect, {
+        'aria-label': 'Test Select',
+        options: [
+          { label: 'Foo', value: 'foo' },
+          { label: 'Bar', value: 'bar' },
+          { label: 'Baz', value: 'baz' },
+        ],
+        value: null,
+      })
+    );
+
+    // Act
+    const select = new SelectHelper(screen.getByLabelText('Test Select'), user);
+    const options = await select.getOptions();
+
+    // Assert
+    expect(options).toEqual(['Foo', 'Bar', 'Baz']);
+  });
+});
+
+describe('selectOption', () => {
+  it('it selects a Select option', async () => {
+    // Arrange
+    const user = userEvent.setup();
+
+    const onChange = jest.fn();
+    render(
+      h(TextSelect, {
+        'aria-label': 'Test Select',
+        options: [
+          { label: 'Foo', value: 'foo' },
+          { label: 'Bar', value: 'bar' },
+          { label: 'Baz', value: 'baz' },
+        ],
+        value: null,
+        onChange,
+      })
+    );
+
+    // Act
+    const select = new SelectHelper(screen.getByLabelText('Test Select'), user);
+    await select.selectOption('Bar');
+
+    // Assert
+    expect(onChange).toHaveBeenCalledWith({ label: 'Bar', value: 'bar' }, expect.any(Object));
+  });
+});

--- a/src/testing/test-utils.ts
+++ b/src/testing/test-utils.ts
@@ -1,4 +1,7 @@
-import { act, renderHook, RenderHookOptions, RenderHookResult } from '@testing-library/react';
+import { act, renderHook, RenderHookOptions, RenderHookResult, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+type UserEvent = ReturnType<typeof userEvent.setup>;
 
 /*
  * Use when working with a jest.fn() mocked method to get better type safety and IDE hinting on
@@ -68,3 +71,31 @@ export const renderHookInAct = async <T, U>(
   });
   return result!;
 };
+
+export class SelectHelper {
+  selectElement: HTMLElement;
+
+  user: UserEvent;
+
+  constructor(selectElement: HTMLElement, user: UserEvent) {
+    this.selectElement = selectElement;
+    this.user = user;
+  }
+
+  async getOptions(): Promise<string[]> {
+    await this.user.click(this.selectElement);
+    const listboxId = this.selectElement.getAttribute('aria-controls')!;
+    const listBox = document.getElementById(listboxId)!;
+    const options = Array.from(listBox.querySelectorAll('[role="option"]'));
+    const optionLabels = options.map((opt) => opt.textContent!);
+    return optionLabels;
+  }
+
+  async selectOption(optionLabel: string): Promise<void> {
+    await this.user.click(this.selectElement);
+    const listboxId = this.selectElement.getAttribute('aria-controls')!;
+    const listBox = document.getElementById(listboxId)!;
+    const option = within(listBox).getByRole('option', { name: optionLabel });
+    await this.user.click(option);
+  }
+}

--- a/src/testing/test-utils.ts
+++ b/src/testing/test-utils.ts
@@ -73,27 +73,43 @@ export const renderHookInAct = async <T, U>(
 };
 
 export class SelectHelper {
-  selectElement: HTMLElement;
+  inputElement: HTMLElement;
 
   user: UserEvent;
 
-  constructor(selectElement: HTMLElement, user: UserEvent) {
-    this.selectElement = selectElement;
+  constructor(inputElement: HTMLElement, user: UserEvent) {
+    this.inputElement = inputElement;
     this.user = user;
   }
 
+  async openMenu(): Promise<void> {
+    const expanded = this.inputElement.getAttribute('aria-expanded');
+    if (expanded === 'false') {
+      await this.user.click(this.inputElement);
+    }
+  }
+
+  async closeMenu(): Promise<void> {
+    const expanded = this.inputElement.getAttribute('aria-expanded');
+    if (expanded === 'true') {
+      this.inputElement.focus();
+      await this.user.keyboard('{Escape}');
+    }
+  }
+
   async getOptions(): Promise<string[]> {
-    await this.user.click(this.selectElement);
-    const listboxId = this.selectElement.getAttribute('aria-controls')!;
+    await this.openMenu();
+    const listboxId = this.inputElement.getAttribute('aria-controls')!;
     const listBox = document.getElementById(listboxId)!;
     const options = Array.from(listBox.querySelectorAll('[role="option"]'));
     const optionLabels = options.map((opt) => opt.textContent!);
+    await this.closeMenu();
     return optionLabels;
   }
 
   async selectOption(optionLabel: string): Promise<void> {
-    await this.user.click(this.selectElement);
-    const listboxId = this.selectElement.getAttribute('aria-controls')!;
+    await this.openMenu();
+    const listboxId = this.inputElement.getAttribute('aria-controls')!;
     const listBox = document.getElementById(listboxId)!;
     const option = within(listBox).getByRole('option', { name: optionLabel });
     await this.user.click(option);


### PR DESCRIPTION
The Select component has been difficult to use in unit tests. This adds helpers to get the list of options from a Select component and to select an option with a given label. See tests for examples of how to use them.