### PR TITLE
[UIE-99] Fix dependencies on ua-parser-js

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -132,7 +132,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["source-map-explorer", "npm:2.5.2"],\
             ["svgo", "npm:1.3.2"],\
             ["typescript", "patch:typescript@npm%3A4.8.3#~builtin<compat/typescript>::version=4.8.3&hash=a1c5e5"],\
-            ["ua-parser-js", "npm:1.0.33"],\
             ["use-memo-one", "virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#npm:1.1.3"],\
             ["uuid", "npm:8.3.2"],\
             ["validate.js", "npm:0.13.1"],\
@@ -10662,7 +10661,8 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["loose-envify", "npm:1.4.0"],\
             ["object-assign", "npm:4.1.1"],\
             ["promise", "npm:7.3.1"],\
-            ["setimmediate", "npm:1.0.5"]\
+            ["setimmediate", "npm:1.0.5"],\
+            ["ua-parser-js", "npm:1.0.33"]\
           ],\
           "linkType": "HARD"\
         }]\
@@ -15285,7 +15285,8 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         ["npm:3.0.1", {\
           "packageLocation": "./.yarn/cache/outdated-browser-rework-npm-3.0.1-c88216a104-ac23a952ba.zip/node_modules/outdated-browser-rework/",\
           "packageDependencies": [\
-            ["outdated-browser-rework", "npm:3.0.1"]\
+            ["outdated-browser-rework", "npm:3.0.1"],\
+            ["ua-parser-js", "npm:1.0.33"]\
           ],\
           "linkType": "HARD"\
         }]\
@@ -20438,7 +20439,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["source-map-explorer", "npm:2.5.2"],\
             ["svgo", "npm:1.3.2"],\
             ["typescript", "patch:typescript@npm%3A4.8.3#~builtin<compat/typescript>::version=4.8.3&hash=a1c5e5"],\
-            ["ua-parser-js", "npm:1.0.33"],\
             ["use-memo-one", "virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#npm:1.1.3"],\
             ["uuid", "npm:8.3.2"],\
             ["validate.js", "npm:0.13.1"],\

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "react-textarea-autosize": "^8.5.2",
     "react-transition-group": "^4.4.5",
     "react-virtualized": "^9.22.5",
-    "ua-parser-js": "^1.0.33",
     "use-memo-one": "^1.1.3",
     "uuid": "^8.3.2",
     "validate.js": "^0.13.1"
@@ -112,6 +111,10 @@
     "source-map-explorer": "^2.5.2",
     "svgo": "^1.3.2",
     "typescript": "^4.8.3"
+  },
+  "resolutions": {
+    "fbjs/ua-parser-js": "^1.0.33",
+    "outdated-browser-rework/ua-parser-js": "^1.0.33"
   },
   "browserslist": [
     ">0.2%",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7490,6 +7490,7 @@ __metadata:
     object-assign: ^4.1.0
     promise: ^7.1.1
     setimmediate: ^1.0.5
+    ua-parser-js: ^0.7.30
   checksum: ebb1dc7a8caff563e4bf07b6e5e59a4052ea94d59faf73522b7e3ab20f7147c076aa565dfd04b648f5eb0ff357e1e18682dd17c490060b508f4fde8c70cfae06
   languageName: node
   linkType: hard
@@ -11503,6 +11504,8 @@ __metadata:
 "outdated-browser-rework@npm:^3.0.1":
   version: 3.0.1
   resolution: "outdated-browser-rework@npm:3.0.1"
+  dependencies:
+    ua-parser-js: ^0.7.22
   checksum: ac23a952ba26a64cd20c5b8e2cbaa38f85c4f018d5b5ab99288ef0be84ec3694fcc3fa3f0bbef00eef177684a82814bae623a51771405756b28e3d14d3fa9668
   languageName: node
   linkType: hard
@@ -15160,7 +15163,6 @@ __metadata:
     source-map-explorer: ^2.5.2
     svgo: ^1.3.2
     typescript: ^4.8.3
-    ua-parser-js: ^1.0.33
     use-memo-one: ^1.1.3
     uuid: ^8.3.2
     validate.js: ^0.13.1


### PR DESCRIPTION
#3809 updated `ua-parser-js` from v0.7.31 to v1.0.33 to resolve a security warning ([TUIM-54](https://broadworkbench.atlassian.net/browse/TUIM-54)).

`ua-parser-js` is a transitive dependency of Terra UI (via `outdated-browser-rework` and `react-json-view`) and the libraries that depend on it specified version selectors (`^0.7.22` and `^0.7.30`) that didn't match a patched version.

To work around this, #3809 removed `ua-parser-js` from the dependency list of `fbjs` (a transitive dependency of `react-json-view`) and `outdated-browser-rework` in yarn.lock and added an updated version of `ua-parser-js` to Terra UI's dependencies in package.json. This caused the `ua-parser-js` imports from `fbjs` and `outdated-browser-rework` to resolve to the updated version and addressed the security issue.

However, this isn't ideal. It obscures why `ua-parser-js` is installed. Currently, `ua-parser-js` appears unused (because it doesn't show up in any Terra UI code and it's not a peer dependency of any other Terra UI dependency) but removing it causes the build to fail.
```
ERROR in ./.yarn/cache/outdated-browser-rework-npm-3.0.1-c88216a104-ac23a952ba.zip/node_modules/outdated-browser-rework/index.js 4:22-45
Module not found: Error: Can't resolve 'ua-parser-js' in '/terra-ui/.yarn/cache/outdated-browser-rework-npm-3.0.1-c88216a104-ac23a952ba.zip/node_modules/outdated-browser-rework'
```

A better way to get an updated version of `ua-parser-js` is to use yarn's [resolutions](https://yarnpkg.com/configuration/manifest#resolutions) feature to override `fbjs` and `outdated-browser-rework`'s requests for `ua-parser-js` and resolve them to the updated version. This maintains the information about what depends on `ua-parser-js` and avoids adding indirect dependencies to package.json.

[TUIM-54]: https://broadworkbench.atlassian.net/browse/TUIM-54?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ