### PR TITLE
[UIE-98] Add test for workspace selector

### DIFF
--- a/src/components/workspace-utils.test.ts
+++ b/src/components/workspace-utils.test.ts
@@ -1,0 +1,78 @@
+import { getAllByRole, getByRole, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { h } from 'react-hyperscript-helpers';
+
+import { WorkspaceSelector } from './workspace-utils';
+
+// The workspace menu uses react-virtualized's AutoSizer to size the options menu.
+// Left to its own devices, in the unit test environment, AutoSizer makes the menu
+// list 0px wide and no options are rendered. Mocking AutoSizer makes the virtualized
+// window large enough for options to be rendered.
+type ReactVirtualizedExports = typeof import('react-virtualized');
+jest.mock('react-virtualized', (): ReactVirtualizedExports => {
+  return {
+    ...jest.requireActual('react-virtualized'),
+    // @ts-expect-error
+    AutoSizer: ({ children }) => children({ height: 300, width: 300 }),
+  };
+});
+
+describe('WorkspaceSelector', () => {
+  const workspaces = [
+    { workspace: { workspaceId: 'workspace-a', name: 'Workspace A' } },
+    { workspace: { workspaceId: 'workspace-b', name: 'Workspace B' } },
+    { workspace: { workspaceId: 'workspace-c', name: 'Workspace C' } },
+  ];
+
+  it('renders a list of workspaces', async () => {
+    // Arrange
+    const user = userEvent.setup();
+
+    // Act
+    render(
+      // @ts-expect-error
+      h(WorkspaceSelector, {
+        workspaces,
+      })
+    );
+
+    // Assert
+    const selectInput = screen.getByLabelText('Select a workspace');
+    await user.click(selectInput);
+
+    const listboxId = selectInput.getAttribute('aria-controls')!;
+    const listbox = document.getElementById(listboxId)!;
+
+    const options = getAllByRole(listbox, 'option');
+    const optionLabels = options.map((opt) => opt.textContent!);
+
+    expect(optionLabels).toEqual(['Workspace A', 'Workspace B', 'Workspace C']);
+  });
+
+  it('calls onChange with workspace ID when a workspace is selected', async () => {
+    // Arrange
+    const user = userEvent.setup();
+
+    const onChange = jest.fn();
+    render(
+      // @ts-expect-error
+      h(WorkspaceSelector, {
+        workspaces,
+        onChange,
+      })
+    );
+
+    // Act
+    const selectInput = screen.getByLabelText('Select a workspace');
+    await user.click(selectInput);
+
+    const listboxId = selectInput.getAttribute('aria-controls')!;
+    const listbox = document.getElementById(listboxId)!;
+
+    const workspaceBOption = getByRole(listbox, 'option', { name: 'Workspace B' });
+    await user.click(workspaceBOption);
+
+    // Assert
+    expect(onChange).toHaveBeenCalledWith('workspace-b');
+  });
+});


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/UIE-98

The WorkspaceSelector component has proven difficult to write unit tests for:
https://broadinstitute.slack.com/archives/C01EHNUM73R/p1689350043388169

I believe the cause of this is that, unlike most other Select components, the WorkspaceSelector uses a virtualized list to render its menu. Because of this, `react-virtualizer`'s `AutoSizer` must be mocked to get any options to render. I think some tests have worked around this by using the keyboard to select options.

This adds a basic unit test for WorkspaceSelector that also serves as an example of how to interact with it in unit tests.