### PR TITLE
WM-2106: Allow anyone to opt-in to the Azure workflows tab

### DIFF
--- a/src/libs/feature-previews-config.js
+++ b/src/libs/feature-previews-config.js
@@ -12,7 +12,6 @@ const featurePreviewsConfig = [
       'Enabling this feature will allow you to save uniquely named versions of data tables. These saved versions will appear in the Data tab and can be restored at any time.',
     groups: ['preview-data-versioning-and-provenance'],
     feedbackUrl: `mailto:dsp-sue@broadinstitute.org?subject=${encodeURIComponent('Feedback on data table versioning')}`,
-    order: 1,
   },
   {
     id: 'data-table-provenance',
@@ -20,7 +19,6 @@ const featurePreviewsConfig = [
     description: 'Enabling this feature will allow you to view information about the workflow that generated data table columns and files.',
     groups: ['preview-data-versioning-and-provenance'],
     feedbackUrl: `mailto:dsp-sue@broadinstitute.org?subject=${encodeURIComponent('Feedback on data table provenance')}`,
-    order: 2,
   },
   {
     id: JUPYTERLAB_GCP_FEATURE_ID,
@@ -28,7 +26,6 @@ const featurePreviewsConfig = [
     description: 'Enabling this feature will allow you to launch notebooks using JupyterLab in GCP workspaces.',
     groups: ['preview-jupyterlab-gcp'],
     feedbackUrl: `mailto:dsp-sue@broadinstitute.org?subject=${encodeURIComponent('Feedback on JupyterLab (GCP)')}`,
-    order: 3,
   },
   {
     id: 'workspace-files',
@@ -36,7 +33,6 @@ const featurePreviewsConfig = [
     description: 'Enabling this feature will allow you to use the new workspace files browser.',
     groups: ['preview-workspace-files'],
     feedbackUrl: `mailto:dsp-sue@broadinstitute.org?subject=${encodeURIComponent('Feedback on workspace files browser')}`,
-    order: 4,
   },
   {
     id: HAIL_BATCH_AZURE_FEATURE_ID,
@@ -44,21 +40,18 @@ const featurePreviewsConfig = [
     description: 'Enabling this feature will allow you to launch the Hail Batch app in Azure workspaces.',
     groups: ['preview-hail-batch-azure'],
     feedbackUrl: `mailto:dsp-sue@broadinstitute.org?subject=${encodeURIComponent('Feedback on Hail Batch (Azure)')}`,
-    order: 5,
   },
   {
     id: WORKFLOWS_TAB_AZURE_FEATURE_ID,
     title: 'Workflows Tab for Azure workspaces',
     description: 'Enabling this feature will allow you to launch workflows in Azure workspaces.',
     feedbackUrl: `mailto:dsp-sue@broadinstitute.org?subject=${encodeURIComponent('Feedback on Workflows Tab (Azure)')}`,
-    order: 6,
   },
   {
     id: FIND_WORKFLOWS_AZURE_FEATURE_ID,
     title: 'Find Workflows for Azure workspaces',
     description: 'Enabling this feature will allow you to find and import new workflows in Azure workspaces. Requires the Workflows Tab.',
     feedbackUrl: `mailto:dsp-sue@broadinstitute.org?subject=${encodeURIComponent('Feedback on Find Workflows (Azure)')}`,
-    order: 7,
   },
 ];
 

--- a/src/libs/feature-previews-config.js
+++ b/src/libs/feature-previews-config.js
@@ -56,7 +56,7 @@ const featurePreviewsConfig = [
   {
     id: FIND_WORKFLOWS_AZURE_FEATURE_ID,
     title: 'Find Workflows for Azure workspaces',
-    description: 'Enabling this feature will allow you to find and import new workflows in Azure workspaces.',
+    description: 'Enabling this feature will allow you to find and import new workflows in Azure workspaces. Requires the Workflows Tab.',
     feedbackUrl: `mailto:dsp-sue@broadinstitute.org?subject=${encodeURIComponent('Feedback on Find Workflows (Azure)')}`,
     order: 7,
   },

--- a/src/libs/feature-previews-config.js
+++ b/src/libs/feature-previews-config.js
@@ -12,6 +12,7 @@ const featurePreviewsConfig = [
       'Enabling this feature will allow you to save uniquely named versions of data tables. These saved versions will appear in the Data tab and can be restored at any time.',
     groups: ['preview-data-versioning-and-provenance'],
     feedbackUrl: `mailto:dsp-sue@broadinstitute.org?subject=${encodeURIComponent('Feedback on data table versioning')}`,
+    order: 1,
   },
   {
     id: 'data-table-provenance',
@@ -19,6 +20,7 @@ const featurePreviewsConfig = [
     description: 'Enabling this feature will allow you to view information about the workflow that generated data table columns and files.',
     groups: ['preview-data-versioning-and-provenance'],
     feedbackUrl: `mailto:dsp-sue@broadinstitute.org?subject=${encodeURIComponent('Feedback on data table provenance')}`,
+    order: 2,
   },
   {
     id: JUPYTERLAB_GCP_FEATURE_ID,
@@ -26,6 +28,7 @@ const featurePreviewsConfig = [
     description: 'Enabling this feature will allow you to launch notebooks using JupyterLab in GCP workspaces.',
     groups: ['preview-jupyterlab-gcp'],
     feedbackUrl: `mailto:dsp-sue@broadinstitute.org?subject=${encodeURIComponent('Feedback on JupyterLab (GCP)')}`,
+    order: 3,
   },
   {
     id: 'workspace-files',
@@ -33,6 +36,7 @@ const featurePreviewsConfig = [
     description: 'Enabling this feature will allow you to use the new workspace files browser.',
     groups: ['preview-workspace-files'],
     feedbackUrl: `mailto:dsp-sue@broadinstitute.org?subject=${encodeURIComponent('Feedback on workspace files browser')}`,
+    order: 4,
   },
   {
     id: HAIL_BATCH_AZURE_FEATURE_ID,
@@ -40,20 +44,21 @@ const featurePreviewsConfig = [
     description: 'Enabling this feature will allow you to launch the Hail Batch app in Azure workspaces.',
     groups: ['preview-hail-batch-azure'],
     feedbackUrl: `mailto:dsp-sue@broadinstitute.org?subject=${encodeURIComponent('Feedback on Hail Batch (Azure)')}`,
+    order: 5,
   },
   {
     id: WORKFLOWS_TAB_AZURE_FEATURE_ID,
     title: 'Workflows Tab for Azure workspaces',
     description: 'Enabling this feature will allow you to launch workflows in Azure workspaces.',
-    groups: ['preview-workflows-azure'],
     feedbackUrl: `mailto:dsp-sue@broadinstitute.org?subject=${encodeURIComponent('Feedback on Workflows Tab (Azure)')}`,
+    order: 6,
   },
   {
     id: FIND_WORKFLOWS_AZURE_FEATURE_ID,
     title: 'Find Workflows for Azure workspaces',
     description: 'Enabling this feature will allow you to find and import new workflows in Azure workspaces.',
-    groups: ['preview-workflows-azure'],
     feedbackUrl: `mailto:dsp-sue@broadinstitute.org?subject=${encodeURIComponent('Feedback on Find Workflows (Azure)')}`,
+    order: 7,
   },
 ];
 

--- a/src/libs/feature-previews.js
+++ b/src/libs/feature-previews.js
@@ -25,19 +25,16 @@ const getGroups = async ({ signal } = {}) => {
 export const getAvailableFeaturePreviews = async ({ signal } = {}) => {
   const userGroups = await getGroups({ signal });
 
-  return _.flow(
-    _.filter(({ id, groups: previewGroups }) =>
-      Utils.cond(
-        // Allow access to all feature previews in development.
-        [!getConfig().isProd, () => true],
-        // Feature previews may be configured to only be available for members of certain groups.
-        // Any enabled feature previews should always be shown to allow users to turn them off
-        // even if they've been removed from the preview group.
-        [!_.isNil(previewGroups), () => _.size(_.intersection(userGroups, previewGroups)) > 0 || isFeaturePreviewEnabled(id)],
-        () => true
-      )
-    ),
-    _.sortBy('order')
+  return _.filter(({ id, groups: previewGroups }) =>
+    Utils.cond(
+      // Allow access to all feature previews in development.
+      [!getConfig().isProd, () => true],
+      // Feature previews may be configured to only be available for members of certain groups.
+      // Any enabled feature previews should always be shown to allow users to turn them off
+      // even if they've been removed from the preview group.
+      [!_.isNil(previewGroups), () => _.size(_.intersection(userGroups, previewGroups)) > 0 || isFeaturePreviewEnabled(id)],
+      () => true
+    )
   )(featurePreviewsConfig);
 };
 

--- a/src/libs/feature-previews.js
+++ b/src/libs/feature-previews.js
@@ -37,7 +37,7 @@ export const getAvailableFeaturePreviews = async ({ signal } = {}) => {
         () => true
       )
     ),
-    _.sortBy('title')
+    _.sortBy('order')
   )(featurePreviewsConfig);
 };
 


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WM-2106

## Summary of changes:
- Allows anyone to opt-in to use the workflows tab
- Stabilizes the order in which features are presented to users

### Why
- We don't want to put workflow tab opt-in behind too many gates. Finding the `/#feature-preview` page should be enough of a hurdle and enough of a warning that what they're seeing is not necessarily in a finished state.
- Ordering based on the user-friendly titles is unstable when new entries are added, and either results in a bad or awkward ordering, or obtuse naming to force the right order.

### Testing strategy
- Tested locally

 ### Visual Aids
#### Before
The feature preview page if the user is in no groups:
<img width="646" alt="image" src="https://github.com/DataBiosphere/terra-ui/assets/13006282/d5c56565-d749-410e-abfc-1e68925ddca1">

The feature preview page if the user is in all groups (or on dev):
<img width="1499" alt="image" src="https://github.com/DataBiosphere/terra-ui/assets/13006282/1c85234d-d6b5-47dd-b87a-82ea6c258a21">

#### After
The feature preview page if the user is in no groups:
![image](https://github.com/DataBiosphere/terra-ui/assets/13006282/4aeb352b-f26c-48f5-8177-3e4bb36c3ebf)

The feature preview page if the user is in all groups (or on dev):
![image](https://github.com/DataBiosphere/terra-ui/assets/13006282/7bfe9860-8e41-4282-a98e-1e2cada85e78)

