### PR TITLE
[AJ-1075] Fix icon for data app responding in WDS troubleshooter

### DIFF
--- a/src/components/data/WdsTroubleshooter.ts
+++ b/src/components/data/WdsTroubleshooter.ts
@@ -80,7 +80,7 @@ export const WdsTroubleshooter = ({ onDismiss, workspaceId, mrgId }) => {
     ['Data app name', appName, appName === null, !!appName && appName !== 'unknown'],
     ['Data app running?', appStatus, appStatus == null, !!appStatus && appStatus !== 'unknown'],
     ['Data app proxy url', proxyUrl, proxyUrl == null, !!proxyUrl && proxyUrl !== 'unknown', proxyElement],
-    ['Data app responding', `${wdsResponsive}`, wdsResponsive == null, !!wdsResponsive && wdsResponsive !== 'unknown'],
+    ['Data app responding', wdsResponsive, wdsResponsive == null, wdsResponsive === 'true'],
     ['Data app version', version, version == null, !!version && version !== 'unknown'],
     [
       'Data app status',


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1075

Another fixup for #4042...

The current logic for determining whether to show a success or error icon for the "Data app responding" row is based on `wdsResponsive` being a boolean. #4042 changed it to a string.