### PR TITLE
[UIE-97] Resolve warnings in AzureBillingProjectWizard test

### DIFF
--- a/src/libs/react-utils.test.ts
+++ b/src/libs/react-utils.test.ts
@@ -1,0 +1,35 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+
+import { useDebouncedValue } from './react-utils';
+
+describe('useDebouncedValue', () => {
+  it('debounces changes to value', () => {
+    // Arrange
+    jest.useFakeTimers();
+
+    const { result: hookReturnRef, rerender } = renderHook((args: [string, number]) => useDebouncedValue(...args), {
+      initialProps: ['foo', 1000],
+    });
+    const initialValue = hookReturnRef.current;
+
+    // Act
+    rerender(['bar', 1000]);
+    const valueAfterUpdate = hookReturnRef.current;
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+    const valueAfte500ms = hookReturnRef.current;
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+    const valueAfter1000ms = hookReturnRef.current;
+
+    // Assert
+    expect(initialValue).toBe('foo');
+    expect(valueAfterUpdate).toBe('foo');
+    expect(valueAfte500ms).toBe('foo');
+    expect(valueAfter1000ms).toBe('bar');
+  });
+});

--- a/src/libs/react-utils.ts
+++ b/src/libs/react-utils.ts
@@ -256,3 +256,16 @@ export const useLabelAssert = (componentName: string, options: UseLabelAssertOpt
     }
   }
 };
+
+export const useDebouncedValue = <T>(value: T, wait: number): T => {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      setDebouncedValue(value);
+    }, wait);
+    return () => clearTimeout(timeout);
+  }, [value, wait]);
+
+  return debouncedValue;
+};

--- a/src/pages/billing/NewBillingProjectWizard/AzureBillingProjectWizard/AddUsersStep.ts
+++ b/src/pages/billing/NewBillingProjectWizard/AzureBillingProjectWizard/AddUsersStep.ts
@@ -1,9 +1,10 @@
 import pluralize from 'pluralize';
-import { ReactNode, useEffect, useState } from 'react';
+import { ReactNode, useState } from 'react';
 import { div, h, p } from 'react-hyperscript-helpers';
 import { useUniqueId } from 'src/components/common';
 import { ValidatedInput } from 'src/components/input';
 import { formHint, FormLabel } from 'src/libs/forms';
+import { useDebouncedValue } from 'src/libs/react-utils';
 import * as Utils from 'src/libs/utils';
 import {
   columnEntryStyle,
@@ -38,16 +39,9 @@ interface EmailInputProps {
 
 const EmailInput = (props: EmailInputProps) => {
   const inputId = useUniqueId();
-  const [debouncedEmails, setDebouncedEmails] = useState<ReactNode>();
-  const [debouncedErrors, setDebouncedErrors] = useState<ReactNode>();
 
-  useEffect(() => {
-    const timeoutId = setTimeout(() => {
-      setDebouncedEmails(props.emails);
-      setDebouncedErrors(props.errors);
-    }, props.inputDebounce);
-    return () => clearTimeout(timeoutId);
-  }, [props.emails, props.errors, props.inputDebounce]);
+  const debouncedEmails = useDebouncedValue(props.emails, props.inputDebounce || 0);
+  const debouncedErrors = useDebouncedValue(props.errors, props.inputDebounce || 0);
 
   const getIndividualEmails = (emails) =>
     emails

--- a/src/pages/billing/NewBillingProjectWizard/AzureBillingProjectWizard/AzureBillingProjectWizard.test.ts
+++ b/src/pages/billing/NewBillingProjectWizard/AzureBillingProjectWizard/AzureBillingProjectWizard.test.ts
@@ -24,6 +24,15 @@ import { asMockedFn } from 'src/testing/test-utils';
 type AjaxContract = ReturnType<typeof Ajax>;
 jest.mock('src/libs/ajax');
 
+type ReactUtilsExports = typeof import('src/libs/react-utils');
+jest.mock('src/libs/react-utils', (): ReactUtilsExports => {
+  const actual = jest.requireActual<ReactUtilsExports>('src/libs/react-utils');
+  return {
+    ...actual,
+    useDebouncedValue: (value) => value,
+  };
+});
+
 describe('transforming user info to the request object', () => {
   beforeEach(() => {
     jest.resetAllMocks();


### PR DESCRIPTION
Currently, the AzureBillingProjectWizard unit test throws several warnings about `An update to EmailInput inside a test was not wrapped in act(...).`

```
console.error
      Warning: An update to EmailInput inside a test was not wrapped in act(...).
      
      When testing, code that causes React state updates should be wrapped into act(...):
      
      act(() => {
        /* fire events that update state */
      });
      /* assert on the output */
      
      This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
          at fn (/workspace/terra-ui/src/pages/billing/NewBillingProjectWizard/AzureBillingProjectWizard/AddUsersStep.ts:40:30)
          at div
          at div
          at fieldset
          at fn (/workspace/terra-ui/src/pages/billing/NewBillingProjectWizard/StepWizard/StepFields.ts:9:30)
          at li
          at fn (/workspace/terra-ui/src/pages/billing/NewBillingProjectWizard/StepWizard/Step.ts:25:24)
          at fn (/workspace/terra-ui/src/pages/billing/NewBillingProjectWizard/AzureBillingProjectWizard/AddUsersStep.ts:109:32)
          at ul
          at section
          at fn (/workspace/terra-ui/src/pages/billing/NewBillingProjectWizard/StepWizard/StepWizard.ts:9:30)
          at fn (/workspace/terra-ui/src/pages/billing/NewBillingProjectWizard/AzureBillingProjectWizard/AzureBillingProjectWizard.ts:34:45)

      44 |   useEffect(() => {
      45 |     const timeoutId = setTimeout(() => {
    > 46 |       setDebouncedEmails(props.emails);
         |       ^
      47 |       setDebouncedErrors(props.errors);
      48 |     }, props.inputDebounce);
      49 |     return () => clearTimeout(timeoutId);

      at console.call [as error] (.yarn/__virtual__/@testing-library-react-hooks-virtual-e2863ed913/0/cache/@testing-library-react-hooks-npm-8.0.1-e0c7be6ffb-7fe44352e9.zip/node_modules/@testing-library/react-hooks/lib/core/console.js:19:7)
      at printWarning (.yarn/__virtual__/react-dom-virtual-148c633abb/0/cache/react-dom-npm-17.0.2-f551215af1-1c1eaa3bca.zip/node_modules/react-dom/cjs/react-dom.development.js:67:30)
      at error (.yarn/__virtual__/react-dom-virtual-148c633abb/0/cache/react-dom-npm-17.0.2-f551215af1-1c1eaa3bca.zip/node_modules/react-dom/cjs/react-dom.development.js:43:5)
      at warnIfNotCurrentlyActingUpdatesInDev (.yarn/__virtual__/react-dom-virtual-148c633abb/0/cache/react-dom-npm-17.0.2-f551215af1-1c1eaa3bca.zip/node_modules/react-dom/cjs/react-dom.development.js:24064:9)
      at setDebouncedEmails (.yarn/__virtual__/react-dom-virtual-148c633abb/0/cache/react-dom-npm-17.0.2-f551215af1-1c1eaa3bca.zip/node_modules/react-dom/cjs/react-dom.development.js:16135:9)
      at src/pages/billing/NewBillingProjectWizard/AzureBillingProjectWizard/AddUsersStep.ts:46:7
      at Timeout.task [as _onTimeout] (.yarn/__virtual__/jsdom-virtual-f91bf4c0c4/0/cache/jsdom-npm-16.7.0-216c5c4bf9-454b833718.zip/node_modules/jsdom/lib/jsdom/browser/Window.js:516:19)
```

This replaces the `useEffect` hook in EmailInput with a new `useDebouncedValue` hook that can be mocked in those tests. Mocking the hook to remove the timeout resolves the warning.