### PR TITLE
[DC-733] Fix SubmissionConfig effect function

### DIFF
--- a/src/workflows-app/SubmissionConfig.js
+++ b/src/workflows-app/SubmissionConfig.js
@@ -209,23 +209,26 @@ export const BaseSubmissionConfig = (
     }
   };
 
-  useOnMount(async () => {
-    const {
-      cbasProxyUrlResponse: { status, state: cbasUrlRoot },
-      wdsProxyUrlResponse,
-    } = await loadAppProxyUrls();
+  useOnMount(() => {
+    const loadWorkflowsApp = async () => {
+      const {
+        cbasProxyUrlResponse: { status, state: cbasUrlRoot },
+        wdsProxyUrlResponse,
+      } = await loadAppProxyUrls();
 
-    if (status === 'Unauthorized') {
-      notify('warn', 'Error loading workflows app', {
-        detail: 'Service returned Unauthorized error. Session might have expired. Please refresh the page or login again.',
-      });
-    } else if (cbasUrlRoot) {
-      loadRunSet(cbasUrlRoot).then((runSet) => {
-        setRunSetRecordType(runSet.record_type);
-        loadMethodsData(cbasUrlRoot, runSet.method_id, runSet.method_version_id);
-        loadWdsData({ wdsProxyUrlState: wdsProxyUrlResponse, recordType: runSetRecordType });
-      });
-    }
+      if (status === 'Unauthorized') {
+        notify('warn', 'Error loading workflows app', {
+          detail: 'Service returned Unauthorized error. Session might have expired. Please refresh the page or login again.',
+        });
+      } else if (cbasUrlRoot) {
+        loadRunSet(cbasUrlRoot).then((runSet) => {
+          setRunSetRecordType(runSet.record_type);
+          loadMethodsData(cbasUrlRoot, runSet.method_id, runSet.method_version_id);
+          loadWdsData({ wdsProxyUrlState: wdsProxyUrlResponse, recordType: runSetRecordType });
+        });
+      }
+    };
+    loadWorkflowsApp();
   });
 
   useEffect(() => {


### PR DESCRIPTION
`useOnMount` is a thin wrapper around React's [`useEffect`](https://react.dev/reference/react/useEffect#useeffect).

```ts
export const useOnMount = (fn: EffectCallback): void => {
  useEffect(fn, []);
};
```

The effect function passed to `useEffect` / `useOnMount` must either return nothing or a cleanup function that is called when dependencies change / when the component is unmounted.

`async` functions return Promises, so they cannot be used as effect functions. As a workaround, an `async` function can be created and immediately called within a synchronous effect function.

With upgraded versions of React and React Testing Library, this causes test failures:
```
Error: Uncaught [TypeError: destroy is not a function]
```

With the warning:
```
Warning: useEffect must not return anything besides a function, which is used for clean-up.
    
    It looks like you wrote useEffect(async () => ...) or returned a Promise. Instead, write the async function inside your effect and call it immediately:
    
    useEffect(() => {
      async function fetchData() {
        // You can await here
        const response = await MyAPI.getData(someId);
        // ...
      }
      fetchData();
    }, [someId]); // Or [] if effect doesn't need props or state
    
    Learn more about data fetching with Hooks: https://reactjs.org/link/hooks-data-fetching
        at fn (/Users/nwatts/workspace/terra-ui/src/workflows-app/SubmissionConfig.js:29:5)
```