### PR TITLE
[DC-733] Fixup IA unit tests for React 18

### DIFF
--- a/src/analysis/Analyses.test.ts
+++ b/src/analysis/Analyses.test.ts
@@ -389,11 +389,10 @@ describe('Analyses', () => {
 
     // Act
     await act(async () => {
-      // eslint-disable-line require-await
       render(h(BaseAnalyses, defaultAnalysesProps));
-      const fileInput = document.querySelector<HTMLInputElement>('input[type="file"]')!;
-      await user.upload(fileInput, [fileToDrop]);
     });
+    const fileInput = document.querySelector<HTMLInputElement>('input[type="file"]')!;
+    await user.upload(fileInput, [fileToDrop]);
 
     expect(createObservable).toHaveBeenCalledWith(droppedFileName, runtimeToolLabels.Jupyter, fileToDrop);
   });

--- a/src/analysis/ContextBar.test.ts
+++ b/src/analysis/ContextBar.test.ts
@@ -1,4 +1,5 @@
-import { act, fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { div, h } from 'react-hyperscript-helpers';
 import {
   defaultAzureWorkspace,
@@ -704,6 +705,8 @@ describe('ContextBar - actions', () => {
 
   it('clicking Terminal will attempt to start currently stopped runtime', async () => {
     // Arrange
+    const user = userEvent.setup();
+
     const mockRuntimesStartFn = jest.fn();
     type RuntimesContract = AjaxContract['Runtimes'];
 
@@ -732,10 +735,8 @@ describe('ContextBar - actions', () => {
     };
 
     // Act
-    await act(async () => {
-      const { getByTestId } = render(h(ContextBar, jupyterContextBarProps));
-      await fireEvent.click(getByTestId('terminal-button-id'));
-    });
+    render(h(ContextBar, jupyterContextBarProps));
+    await user.click(screen.getByTestId('terminal-button-id'));
 
     // Assert
     expect(mockRuntimeWrapper).toHaveBeenCalledWith(

--- a/src/analysis/Environments.test.ts
+++ b/src/analysis/Environments.test.ts
@@ -145,7 +145,7 @@ describe('Environments', () => {
       });
 
       await act(async () => {
-        await render(h(Environments, { nav: defaultNav }));
+        render(h(Environments, { nav: defaultNav }));
       });
 
       const tableRows: HTMLElement[] = screen.getAllByRole('row').slice(1); // skip header row
@@ -159,7 +159,7 @@ describe('Environments', () => {
       asMockedFn(listRuntimesV2).mockReturnValue(Promise.resolve([runtime1]));
 
       await act(async () => {
-        await render(h(Environments, { nav: defaultNav }));
+        render(h(Environments, { nav: defaultNav }));
       });
 
       const tableRows: HTMLElement[] = screen.getAllByRole('row').slice(1); // skip header row
@@ -188,7 +188,7 @@ describe('Environments', () => {
       });
 
       await act(async () => {
-        await render(h(Environments, { nav: defaultNav }));
+        render(h(Environments, { nav: defaultNav }));
       });
 
       const tableRows: HTMLElement[] = screen.getAllByRole('row');
@@ -223,7 +223,7 @@ describe('Environments', () => {
       });
 
       await act(async () => {
-        await render(h(Environments, { nav: defaultNav }));
+        render(h(Environments, { nav: defaultNav }));
       });
 
       const tableRows: HTMLElement[] = screen.getAllByRole('row');
@@ -260,7 +260,7 @@ describe('Environments', () => {
       });
 
       await act(async () => {
-        await render(h(Environments, { nav: defaultNav }));
+        render(h(Environments, { nav: defaultNav }));
       });
 
       const tableRows: HTMLElement[] = screen.getAllByRole('row');
@@ -320,7 +320,7 @@ describe('Environments', () => {
       });
 
       await act(async () => {
-        await render(h(Environments, { nav: defaultNav }));
+        render(h(Environments, { nav: defaultNav }));
       });
 
       const tableRows: HTMLElement[] = screen.getAllByRole('row');
@@ -346,7 +346,7 @@ describe('Environments', () => {
       });
 
       await act(async () => {
-        await render(h(Environments, { nav: defaultNav }));
+        render(h(Environments, { nav: defaultNav }));
       });
 
       const tableRows: HTMLElement[] = screen.getAllByRole('row');
@@ -386,7 +386,7 @@ describe('Environments', () => {
       asMockedFn(useReplaceableAjaxExperimental).mockReturnValue(() => newMockAjax as AjaxContract);
 
       await act(async () => {
-        await render(h(Environments, { nav: defaultNav }));
+        render(h(Environments, { nav: defaultNav }));
       });
 
       const tableRows: HTMLElement[] = screen.getAllByRole('row');
@@ -426,7 +426,7 @@ describe('Environments', () => {
       });
 
       await act(async () => {
-        await render(h(Environments, { nav: defaultNav }));
+        render(h(Environments, { nav: defaultNav }));
       });
 
       const tableRows: HTMLElement[] = screen.getAllByRole('row');
@@ -448,7 +448,7 @@ describe('Environments', () => {
       });
 
       await act(async () => {
-        await render(h(Environments, { nav: defaultNav }));
+        render(h(Environments, { nav: defaultNav }));
       });
 
       const tableRows: HTMLElement[] = screen.getAllByRole('row').slice(1); // skip header row
@@ -481,7 +481,7 @@ describe('Environments', () => {
       });
 
       await act(async () => {
-        await render(h(Environments, { nav: defaultNav }));
+        render(h(Environments, { nav: defaultNav }));
       });
 
       const tableRows: HTMLElement[] = screen.getAllByRole('row').slice(1); // skip header row
@@ -537,7 +537,7 @@ describe('Environments', () => {
       });
 
       await act(async () => {
-        await render(h(Environments, { nav: defaultNav }));
+        render(h(Environments, { nav: defaultNav }));
       });
 
       const tableRows: HTMLElement[] = screen.getAllByRole('row');
@@ -589,7 +589,7 @@ describe('Environments', () => {
       asMockedFn(useReplaceableAjaxExperimental).mockReturnValue(() => newMockAjax as AjaxContract);
 
       await act(async () => {
-        await render(h(Environments, { nav: defaultNav }));
+        render(h(Environments, { nav: defaultNav }));
       });
 
       const tableRows: HTMLElement[] = screen.getAllByRole('row');
@@ -628,7 +628,7 @@ describe('Environments', () => {
       });
 
       await act(async () => {
-        await render(h(Environments, { nav: defaultNav }));
+        render(h(Environments, { nav: defaultNav }));
       });
 
       const tableRows: HTMLElement[] = screen.getAllByRole('row');
@@ -659,7 +659,7 @@ describe('Environments', () => {
       });
 
       await act(async () => {
-        await render(h(Environments, { nav: defaultNav }));
+        render(h(Environments, { nav: defaultNav }));
       });
 
       const tableRows: HTMLElement[] = screen.getAllByRole('row');
@@ -714,7 +714,7 @@ describe('Environments', () => {
       });
 
       await act(async () => {
-        await render(h(Environments, { nav: defaultNav }));
+        render(h(Environments, { nav: defaultNav }));
       });
 
       const tableRows: HTMLElement[] = screen.getAllByRole('row');
@@ -763,7 +763,7 @@ describe('Environments', () => {
       asMockedFn(useReplaceableAjaxExperimental).mockReturnValue(() => newMockAjax as AjaxContract);
 
       await act(async () => {
-        await render(h(Environments, { nav: defaultNav }));
+        render(h(Environments, { nav: defaultNav }));
       });
 
       const tableRows: HTMLElement[] = screen.getAllByRole('row');

--- a/src/analysis/PeriodicAzureCookieSetter.test.ts
+++ b/src/analysis/PeriodicAzureCookieSetter.test.ts
@@ -28,30 +28,30 @@ jest.mock('src/libs/error', () => {
 });
 
 describe('PeriodicAzureCookieSetter', () => {
-  it('should call usePollingEffect', async () => {
+  it('should call usePollingEffect', () => {
     // Arrange
-    await render(h(PeriodicAzureCookieSetter));
+    render(h(PeriodicAzureCookieSetter));
 
     // Assert
     expect(usePollingEffect).toHaveBeenCalled();
   });
 
-  it('should call usePollingEffect and withErrorIgnoring', async () => {
+  it('should call usePollingEffect and withErrorIgnoring', () => {
     usePollingEffectMock.mockImplementationOnce(() => withErrorIgnoring);
     // Arrange
-    await render(h(PeriodicAzureCookieSetter));
+    render(h(PeriodicAzureCookieSetter));
 
     // Assert
     expect(usePollingEffect).toHaveBeenCalled();
     expect(withErrorIgnoring).toHaveBeenCalled();
   });
 
-  it('should call withErrorIgnoring', async () => {
+  it('should call withErrorIgnoring', () => {
     usePollingEffectMock.mockImplementation((effectFn, { ms, leading }) =>
       withErrorIgnoring(effectFn, { ms, leading })
     );
     // Arrange
-    await render(h(PeriodicAzureCookieSetter));
+    render(h(PeriodicAzureCookieSetter));
 
     // Assert
     expect(usePollingEffect).toHaveBeenCalled();

--- a/src/analysis/modals/AnalysisModal.test.ts
+++ b/src/analysis/modals/AnalysisModal.test.ts
@@ -1,4 +1,4 @@
-import { act, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { h } from 'react-hyperscript-helpers';
 import {
@@ -158,19 +158,17 @@ describe('AnalysisModal', () => {
       const button = screen.getByAltText('Create new notebook');
       await user.click(button);
 
-      const fileTypeSelect = await screen.getByLabelText('Language *');
+      const fileTypeSelect = screen.getByLabelText('Language *');
       await user.click(fileTypeSelect);
 
       const selectOption = await screen.findAllByText(fileType);
       await user.click(selectOption[1]);
 
       const nameInput = screen.getByLabelText('Name of the notebook *');
-      await userEvent.type(nameInput, 'MyNewFile');
+      await user.type(nameInput, 'MyNewFile');
 
       const createButton = await screen.findByText('Create Analysis');
-      await act(async () => {
-        await user.click(createButton);
-      });
+      await user.click(createButton);
 
       // Assert
       screen.getByText('Jupyter Cloud Environment');
@@ -187,19 +185,17 @@ describe('AnalysisModal', () => {
     const button = screen.getByAltText('Create new notebook');
     await user.click(button);
 
-    const fileTypeSelect = await screen.getByLabelText('Language *');
+    const fileTypeSelect = screen.getByLabelText('Language *');
     await user.click(fileTypeSelect);
 
     const selectOption = await screen.findAllByText('Python 3');
     await user.click(selectOption[1]);
 
     const nameInput = screen.getByLabelText('Name of the notebook *');
-    await userEvent.type(nameInput, 'MyNewFile');
+    await user.type(nameInput, 'MyNewFile');
 
     const createButton = await screen.findByText('Create Analysis');
-    await act(async () => {
-      await user.click(createButton);
-    });
+    await user.click(createButton);
 
     // Assert
     expect(screen.queryByText('Jupyter Cloud Environment')).toBeNull();
@@ -217,20 +213,17 @@ describe('AnalysisModal', () => {
       const button = screen.getByAltText('Create new R file');
       await user.click(button);
 
-      const fileTypeSelect = await screen.getByLabelText('File Type *');
+      const fileTypeSelect = screen.getByLabelText('File Type *');
       await user.click(fileTypeSelect);
 
       const selectOption = await screen.findAllByText(fileType);
       await user.click(selectOption[1]);
 
       const nameInput = screen.getByLabelText('Name of the R file *');
-      await userEvent.type(nameInput, 'MyNewFile');
+      await user.type(nameInput, 'MyNewFile');
 
-      const createButton = await screen.getByText('Create Analysis');
-
-      await act(async () => {
-        await user.click(createButton);
-      });
+      const createButton = screen.getByText('Create Analysis');
+      await user.click(createButton);
 
       // Assert
       screen.getByText('RStudio Cloud Environment');
@@ -248,13 +241,11 @@ describe('AnalysisModal', () => {
     await user.click(button);
 
     const nameInput = screen.getByLabelText('Name of the R file *');
-    await userEvent.type(nameInput, 'MyNewFile');
+    await user.type(nameInput, 'MyNewFile');
 
-    const createButton = await screen.getByText('Create Analysis');
+    const createButton = screen.getByText('Create Analysis');
 
-    await act(async () => {
-      await user.click(createButton);
-    });
+    await user.click(createButton);
 
     // Assert
     expect(screen.queryByText('RStudio Cloud Environment')).toBeNull();
@@ -267,10 +258,8 @@ describe('AnalysisModal', () => {
     render(h(AnalysisModal, defaultGcpModalProps));
 
     // Act
-    await act(async () => {
-      const button = screen.getByAltText('Create new Galaxy app');
-      await user.click(button);
-    });
+    const button = screen.getByAltText('Create new Galaxy app');
+    await user.click(button);
 
     screen.getByText('Galaxy Cloud Environment');
   });
@@ -285,7 +274,7 @@ describe('AnalysisModal', () => {
     await user.hover(button);
 
     // Assert
-    expect(await screen.queryAllByText('You already have a Galaxy environment').length).toBeGreaterThanOrEqual(2);
+    expect(screen.queryAllByText('You already have a Galaxy environment').length).toBeGreaterThanOrEqual(2);
   });
 
   it('Azure - Renders correctly by default', () => {
@@ -340,22 +329,20 @@ describe('AnalysisModal', () => {
       render(h(AnalysisModal, defaultAzureModalProps));
 
       // Act
-      await act(async () => {
-        const button = screen.getByAltText('Create new notebook');
-        await user.click(button);
+      const button = screen.getByAltText('Create new notebook');
+      await user.click(button);
 
-        const fileTypeSelect = await screen.getByLabelText('Language *');
-        await user.click(fileTypeSelect);
+      const fileTypeSelect = screen.getByLabelText('Language *');
+      await user.click(fileTypeSelect);
 
-        const selectOption = await screen.findAllByText(fileType);
-        await user.click(selectOption[1]);
+      const selectOption = await screen.findAllByText(fileType);
+      await user.click(selectOption[1]);
 
-        const nameInput = screen.getByLabelText('Name of the notebook *');
-        await userEvent.type(nameInput, 'MyNewFile');
+      const nameInput = screen.getByLabelText('Name of the notebook *');
+      await user.type(nameInput, 'MyNewFile');
 
-        const createButton = await screen.findByText('Create Analysis');
-        await user.click(createButton);
-      });
+      const createButton = await screen.findByText('Create Analysis');
+      await user.click(createButton);
 
       // Assert
       screen.getByText('Azure Cloud Environment');
@@ -387,16 +374,14 @@ describe('AnalysisModal', () => {
     );
 
     // Act
-    await act(async () => {
-      const button = screen.getByAltText('Create new notebook');
-      await user.click(button);
+    const button = screen.getByAltText('Create new notebook');
+    await user.click(button);
 
-      const nameInput = screen.getByLabelText('Name of the notebook *');
-      await userEvent.type(nameInput, fileList[0].displayName);
-    });
+    const nameInput = screen.getByLabelText('Name of the notebook *');
+    await user.type(nameInput, fileList[0].displayName);
 
     // Assert
-    expect(await screen.queryAllByText('Analysis name already exists').length).toBeGreaterThanOrEqual(2);
+    expect(screen.queryAllByText('Analysis name already exists').length).toBeGreaterThanOrEqual(2);
   });
 
   it('Error on create', async () => {
@@ -421,16 +406,14 @@ describe('AnalysisModal', () => {
     );
 
     // Act
-    await act(async () => {
-      const button = screen.getByAltText('Create new notebook');
-      await user.click(button);
+    const button = screen.getByAltText('Create new notebook');
+    await user.click(button);
 
-      const nameInput = screen.getByLabelText('Name of the notebook *');
-      await userEvent.type(nameInput, 'My New Notebook');
+    const nameInput = screen.getByLabelText('Name of the notebook *');
+    await user.type(nameInput, 'My New Notebook');
 
-      const createButton = await screen.findByText('Create Analysis');
-      await user.click(createButton);
-    });
+    const createButton = await screen.findByText('Create Analysis');
+    await user.click(createButton);
 
     // Assert
     expect(createAnalysisMock).toHaveBeenCalled();

--- a/src/analysis/modals/CloudEnvironmentModal.test.ts
+++ b/src/analysis/modals/CloudEnvironmentModal.test.ts
@@ -1,4 +1,4 @@
-import { act, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { h, p } from 'react-hyperscript-helpers';
 import {
@@ -519,9 +519,7 @@ describe('CloudEnvironmentModal', () => {
       // Assert
       const pauseButtons = screen.getAllByText('Pause');
       expect(pauseButtons.length).toBe(3);
-      await act(async () => {
-        await user.click(pauseButtons[expectedOutput.buttonIndex]);
-      });
+      await user.click(pauseButtons[expectedOutput.buttonIndex]);
       expect(stopFn).toBeCalledTimes(expectedOutput.stopTimes);
       expect(pauseFn).toBeCalledTimes(expectedOutput.pauseTimes);
     }
@@ -575,9 +573,7 @@ describe('CloudEnvironmentModal', () => {
     render(h(CloudEnvironmentModal, cloneAzure));
     // Assert
     const pauseButton = screen.getByText('Pause');
-    await act(async () => {
-      await user.click(pauseButton);
-    });
+    await user.click(pauseButton);
     expect(stopFn).toBeCalledTimes(1);
   });
 
@@ -717,9 +713,7 @@ describe('CloudEnvironmentModal', () => {
     // Assert
     const settingsButtons = screen.getAllByText('Settings');
     expect(settingsButtons.length).toBe(3);
-    await act(async () => {
-      await user.click(settingsButtons[buttonIndex]);
-    });
+    await user.click(settingsButtons[buttonIndex]);
     screen.getByText(modalName);
   });
 
@@ -734,9 +728,7 @@ describe('CloudEnvironmentModal', () => {
     render(h(CloudEnvironmentModal, cloneAzure));
     // Assert
     const settingsButton = screen.getByText('Settings');
-    await act(async () => {
-      await user.click(settingsButton);
-    });
+    await user.click(settingsButton);
     screen.getByText('AzureComputeModalBase');
   });
 });
@@ -763,7 +755,7 @@ describe('renderToolButtons', () => {
       apps: [cromwellRunning],
     };
     // Act
-    await render(h(CloudEnvironmentModal, testProps));
+    render(h(CloudEnvironmentModal, testProps));
 
     // Assert
     expect(PeriodicAzureCookieSetter).toHaveBeenCalled();
@@ -790,7 +782,7 @@ describe('renderToolButtons', () => {
       apps: [hailBatchAppRunning],
     };
     // Act
-    await render(h(CloudEnvironmentModal, testProps));
+    render(h(CloudEnvironmentModal, testProps));
 
     // Assert
     expect(PeriodicAzureCookieSetter).toHaveBeenCalled();

--- a/src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeModal.js
+++ b/src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeModal.js
@@ -61,8 +61,8 @@ export const AzureComputeModalBase = ({
   const [deleteDiskSelected, setDeleteDiskSelected] = useState(false);
   const hasGpu = () => !!azureMachineTypes[computeConfig.machineType]?.hasGpu;
   // Lifecycle
-  useOnMount(
-    _.flow(
+  useOnMount(() => {
+    const loadCloudEnvironment = _.flow(
       withErrorReportingInModal('Error loading cloud environment', onError),
       Utils.withBusyState(setLoading)
     )(async () => {
@@ -80,8 +80,9 @@ export const AzureComputeModalBase = ({
         region: runtimeDetails?.runtimeConfig?.region || location || defaultAzureRegion,
         autopauseThreshold: runtimeDetails ? runtimeDetails.autopauseThreshold || autopauseDisabledValue : defaultAutopauseThreshold,
       });
-    })
-  );
+    });
+    loadCloudEnvironment();
+  });
 
   const renderTitleAndTagline = () => {
     return h(Fragment, [

--- a/src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeModal.test.js
+++ b/src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeModal.test.js
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import _ from 'lodash/fp';
 import { h } from 'react-hyperscript-helpers';
@@ -82,7 +82,7 @@ describe('AzureComputeModal', () => {
     // Act
     // wrapping component init-time stateful side-effects with act()
     await act(async () => {
-      await render(h(AzureComputeModalBase, defaultModalProps));
+      render(h(AzureComputeModalBase, defaultModalProps));
     });
 
     // Assert
@@ -94,6 +94,8 @@ describe('AzureComputeModal', () => {
 
   it('sends the proper leo API call in default create case (no runtimes or disks)', async () => {
     // Arrange
+    const user = userEvent.setup();
+
     const createFunc = jest.fn();
     const runtimeFunc = jest.fn(() => ({
       create: createFunc,
@@ -109,9 +111,10 @@ describe('AzureComputeModal', () => {
     // Act
     // wrapping component init-time stateful side-effects with act()
     await act(async () => {
-      await render(h(AzureComputeModalBase, defaultModalProps));
-      await userEvent.click(getCreateButton());
+      render(h(AzureComputeModalBase, defaultModalProps));
     });
+
+    await user.click(getCreateButton());
 
     // Assert
     const labels = {
@@ -136,6 +139,8 @@ describe('AzureComputeModal', () => {
 
   it('sends the proper leo API call in the case of a persistent disk', async () => {
     // Arrange
+    const user = userEvent.setup();
+
     const createFunc = jest.fn();
     const runtimeFunc = jest.fn(() => ({
       create: createFunc,
@@ -151,9 +156,10 @@ describe('AzureComputeModal', () => {
     // Act
     // wrapping component init-time stateful side-effects with act()
     await act(async () => {
-      await render(h(AzureComputeModalBase, persistentDiskModalProps));
-      await userEvent.click(getCreateButton());
+      render(h(AzureComputeModalBase, persistentDiskModalProps));
     });
+
+    await user.click(getCreateButton());
 
     // Assert
     const labels = {
@@ -196,15 +202,15 @@ describe('AzureComputeModal', () => {
     // Act
     // wrapping component init-time stateful side-effects with act()
     await act(async () => {
-      await render(h(AzureComputeModalBase, defaultModalProps));
-
-      const numberInput = await screen.getByLabelText('minutes of inactivity');
-      expect(numberInput).toBeInTheDocument();
-      await user.type(numberInput, '0');
-      expect(numberInput.value).toBe('300');
-
-      await user.click(getCreateButton());
+      render(h(AzureComputeModalBase, defaultModalProps));
     });
+
+    const numberInput = await screen.getByLabelText('minutes of inactivity');
+    expect(numberInput).toBeInTheDocument();
+    await user.type(numberInput, '0');
+    expect(numberInput.value).toBe('300');
+
+    await user.click(getCreateButton());
 
     // Assert
     const labels = {
@@ -230,6 +236,8 @@ describe('AzureComputeModal', () => {
 
   it('sends the proper leo API call in create case (autopause disabled)', async () => {
     // Arrange
+    const user = userEvent.setup();
+
     const createFunc = jest.fn();
     const runtimeFunc = jest.fn(() => ({
       create: createFunc,
@@ -245,19 +253,18 @@ describe('AzureComputeModal', () => {
     // Act
     // wrapping component init-time stateful side-effects with act()
     await act(async () => {
-      await render(h(AzureComputeModalBase, defaultModalProps));
-
-      const autopauseCheckbox = await screen.getByLabelText('Enable autopause');
-      expect(autopauseCheckbox).toBeInTheDocument();
-      await expect(autopauseCheckbox).toBeChecked();
-      await fireEvent.click(autopauseCheckbox); // click to focus?
-      await fireEvent.click(autopauseCheckbox);
-      await expect(autopauseCheckbox).not.toBeChecked();
-      const numberInput = await screen.getByLabelText('minutes of inactivity');
-      await expect(numberInput).not.toBeVisible();
-
-      await userEvent.click(getCreateButton());
+      render(h(AzureComputeModalBase, defaultModalProps));
     });
+
+    const autopauseCheckbox = screen.getByLabelText('Enable autopause');
+    expect(autopauseCheckbox).toBeInTheDocument();
+    expect(autopauseCheckbox).toBeChecked();
+    await user.click(autopauseCheckbox);
+    expect(autopauseCheckbox).not.toBeChecked();
+    const numberInput = screen.getByLabelText('minutes of inactivity');
+    expect(numberInput).not.toBeVisible();
+
+    await user.click(getCreateButton());
 
     // Assert
     const labels = {
@@ -290,7 +297,7 @@ describe('AzureComputeModal', () => {
     // Act
     // wrapping component init-time stateful side-effects with act()
     await act(async () => {
-      await render(h(AzureComputeModalBase, defaultModalProps));
+      render(h(AzureComputeModalBase, defaultModalProps));
     });
 
     // Assert
@@ -315,14 +322,15 @@ describe('AzureComputeModal', () => {
     // Act
     // wrapping component init-time stateful side-effects with act()
     await act(async () => {
-      await render(h(AzureComputeModalBase, defaultModalProps));
-      expect(screen.getAllByText(formatUSD(initialComputeCost)).length).toBeTruthy(); // Verify initial value
-
-      const selectCompute = screen.getByLabelText('Cloud compute profile');
-      await user.click(selectCompute);
-      const selectOption = await screen.getByText(_.keys(azureMachineTypes)[1], { exact: false });
-      await user.click(selectOption);
+      render(h(AzureComputeModalBase, defaultModalProps));
     });
+
+    expect(screen.getAllByText(formatUSD(initialComputeCost)).length).toBeTruthy(); // Verify initial value
+
+    const selectCompute = screen.getByLabelText('Cloud compute profile');
+    await user.click(selectCompute);
+    const selectOption = await screen.getByText(_.keys(azureMachineTypes)[1], { exact: false });
+    await user.click(selectOption);
 
     // Assert
     expect(screen.getAllByText(formatUSD(expectedComputeCost)).length).toBeTruthy(); // Currently stopped and running are the same cost.
@@ -332,6 +340,8 @@ describe('AzureComputeModal', () => {
   // click delete environment on an existing [jupyter, rstudio] runtime with disk should bring up confirmation
   it('deletes environment with a confirmation for disk deletion for tool $tool.label', async () => {
     // Arrange
+    const user = userEvent.setup();
+
     const disk = getDisk();
     const runtime = azureRuntime;
     runtime.runtimeConfig.persistentDiskId = disk.id;
@@ -361,8 +371,9 @@ describe('AzureComputeModal', () => {
           currentRuntime: runtime,
         })
       );
-      await userEvent.click(screen.getByText('Delete Environment'));
     });
+
+    await user.click(screen.getByText('Delete Environment'));
 
     // Assert
     verifyEnabled(screen.getByText('Delete'));
@@ -374,6 +385,8 @@ describe('AzureComputeModal', () => {
 
   it('deletes disk when there is no runtime present.', async () => {
     // Arrange
+    const user = userEvent.setup();
+
     const disk = getDisk();
 
     const runtimeFunc = jest.fn(() => ({
@@ -400,8 +413,9 @@ describe('AzureComputeModal', () => {
           currentRuntime: null,
         })
       );
-      await userEvent.click(screen.getByText('Delete Persistent Disk'));
     });
+
+    await user.click(screen.getByText('Delete Persistent Disk'));
 
     // Assert
     verifyEnabled(screen.getByText('Delete'));
@@ -411,20 +425,22 @@ describe('AzureComputeModal', () => {
 
   it('toggles GPU on azure warning when GPU cloud compute profile is selected and unselected', async () => {
     // Arrange
-    await render(h(AzureComputeModalBase, defaultModalProps));
+    const user = userEvent.setup();
+
+    render(h(AzureComputeModalBase, defaultModalProps));
 
     // Act
     const selectCompute = screen.getByLabelText('Cloud compute profile');
-    await userEvent.click(selectCompute);
+    await user.click(selectCompute);
 
-    await userEvent.click(screen.getByText(getMachineTypeLabel('Standard_NC6s_v3')));
+    await user.click(screen.getByText(getMachineTypeLabel('Standard_NC6s_v3')));
 
     // Assert
     expect(screen.getByText('Learn more about enabling GPUs.')).toBeInTheDocument();
 
     // Act
-    await userEvent.click(selectCompute);
-    await userEvent.click(screen.getByText(getMachineTypeLabel('Standard_DS2_v2')));
+    await user.click(selectCompute);
+    await user.click(screen.getByText(getMachineTypeLabel('Standard_DS2_v2')));
 
     // Assert
     expect(screen.queryByText('Learn more about enabling GPUs.')).not.toBeInTheDocument();

--- a/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal.test.js
+++ b/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal.test.js
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import _ from 'lodash/fp';
 import { h } from 'react-hyperscript-helpers';
@@ -103,7 +103,9 @@ describe('GcpComputeModal', () => {
     // Arrange
 
     // Act
-    await act(async () => await render(h(GcpComputeModalBase, defaultModalProps)));
+    await act(async () => {
+      render(h(GcpComputeModalBase, defaultModalProps));
+    });
 
     // Assert
     verifyEnabled(getCreateButton());
@@ -112,6 +114,8 @@ describe('GcpComputeModal', () => {
 
   it('passes the TERRA_DEPLOYMENT_ENV env var through to the notebook through custom env vars', async () => {
     // Arrange
+    const user = userEvent.setup();
+
     const createFunc = jest.fn();
     const runtimeFunc = jest.fn(() => ({
       create: createFunc,
@@ -126,9 +130,10 @@ describe('GcpComputeModal', () => {
 
     // Act
     await act(async () => {
-      await render(h(GcpComputeModalBase, defaultModalProps));
-      await userEvent.click(getCreateButton());
+      render(h(GcpComputeModalBase, defaultModalProps));
     });
+
+    await user.click(getCreateButton());
 
     // Assert
     expect(runtimeFunc).toHaveBeenCalledWith(defaultModalProps.workspace.workspace.googleProject, expect.anything());
@@ -144,6 +149,8 @@ describe('GcpComputeModal', () => {
 
   it('sends the proper leo API call in default create case (no runtimes or disks)', async () => {
     // Arrange
+    const user = userEvent.setup();
+
     const createFunc = jest.fn();
     const runtimeFunc = jest.fn(() => ({
       create: createFunc,
@@ -158,9 +165,10 @@ describe('GcpComputeModal', () => {
 
     // Act
     await act(async () => {
-      await render(h(GcpComputeModalBase, defaultModalProps));
-      await userEvent.click(getCreateButton());
+      render(h(GcpComputeModalBase, defaultModalProps));
     });
+
+    await user.click(getCreateButton());
 
     // Assert
     const labels = {
@@ -189,6 +197,8 @@ describe('GcpComputeModal', () => {
   // create button with disk but no runtime
   it('sends the proper API call in create case with an existing disk but no runtime', async () => {
     // Arrange
+    const user = userEvent.setup();
+
     // put value into local var so its easier to refactor
     const disk = defaultTestDisk;
     const createFunc = jest.fn();
@@ -212,14 +222,15 @@ describe('GcpComputeModal', () => {
 
     // Act
     await act(async () => {
-      await render(
+      render(
         h(GcpComputeModalBase, {
           ...defaultModalProps,
           currentDisk: disk,
         })
       );
-      await userEvent.click(getCreateButton());
     });
+
+    await user.click(getCreateButton());
 
     // Assert
     expect(runtimeFunc).toHaveBeenCalledWith(defaultGoogleWorkspace.workspace.googleProject, expect.anything());
@@ -263,7 +274,7 @@ describe('GcpComputeModal', () => {
 
       // Act
       await act(async () => {
-        await render(
+        render(
           h(GcpComputeModalBase, {
             ...defaultModalProps,
             currentDisk: disk,
@@ -319,7 +330,7 @@ describe('GcpComputeModal', () => {
 
       // Act
       await act(async () => {
-        await render(
+        render(
           h(GcpComputeModalBase, {
             ...defaultModalProps,
             currentDisk: disk,
@@ -342,6 +353,8 @@ describe('GcpComputeModal', () => {
     'deletes environment with a confirmation for disk deletion for tool $tool.label',
     async ({ tool }) => {
       // Arrange
+      const user = userEvent.setup();
+
       const disk = getDisk();
       const runtimeProps = { runtimeConfig: getJupyterRuntimeConfig({ diskId: disk.id, tool }) };
       const runtime = getGoogleRuntime(runtimeProps);
@@ -372,8 +385,9 @@ describe('GcpComputeModal', () => {
             currentRuntime: runtime,
           })
         );
-        await userEvent.click(screen.getByText('Delete Environment'));
       });
+
+      await user.click(screen.getByText('Delete Environment'));
 
       // Assert
       verifyEnabled(screen.getByText('Delete'));
@@ -389,6 +403,8 @@ describe('GcpComputeModal', () => {
     'clicking through delete confirmation and then delete should call delete for tool $tool.label',
     async ({ tool }) => {
       // Arrange
+      const user = userEvent.setup();
+
       const disk = getDisk();
       const runtimeProps = { runtimeConfig: getJupyterRuntimeConfig({ diskId: disk.id, tool }) };
       const runtime = getGoogleRuntime(runtimeProps);
@@ -422,9 +438,10 @@ describe('GcpComputeModal', () => {
             currentRuntime: runtime,
           })
         );
-        await userEvent.click(screen.getByText('Delete Environment'));
-        await userEvent.click(screen.getByText('Delete'));
       });
+
+      await user.click(screen.getByText('Delete Environment'));
+      await user.click(screen.getByText('Delete'));
 
       // Assert
       expect(runtimeFunc).toHaveBeenCalledWith(defaultModalProps.workspace.workspace.googleProject, expect.anything());
@@ -436,6 +453,8 @@ describe('GcpComputeModal', () => {
     'updating a runtime after changing a field that requires downtime should call update for tool $tool.label',
     async ({ tool }) => {
       // Arrange
+      const user = userEvent.setup();
+
       const disk = getDisk();
       const runtimeProps = { runtimeConfig: getJupyterRuntimeConfig({ diskId: disk.id, tool }) };
       const runtime = getGoogleRuntime(runtimeProps);
@@ -462,29 +481,27 @@ describe('GcpComputeModal', () => {
 
       // Act
       await act(async () => {
-        await render(
+        render(
           h(GcpComputeModalBase, {
             ...defaultModalProps,
             currentDisk: disk,
             currentRuntime: runtime,
           })
         );
-
-        await userEvent.click(screen.getByLabelText('CPUs'));
-        const selectOption = await screen.findByText('2');
-        await userEvent.click(selectOption);
-        const nextButton = await screen.findByText('Next');
-        await userEvent.click(nextButton);
       });
+
+      await user.click(screen.getByLabelText('CPUs'));
+      const selectOption = await screen.findByText('2');
+      await user.click(selectOption);
+      const nextButton = await screen.findByText('Next');
+      await user.click(nextButton);
 
       // Assert
       await screen.findByText('Downtime required');
 
       // Act
-      await act(async () => {
-        const updateButton = await screen.findByText('Update');
-        await userEvent.click(updateButton);
-      });
+      const updateButton = await screen.findByText('Update');
+      await user.click(updateButton);
 
       // Assert
       expect(runtimeFunc).toHaveBeenCalledWith(defaultModalProps.workspace.workspace.googleProject, expect.anything());
@@ -626,6 +643,8 @@ describe('GcpComputeModal', () => {
 
   it('should create dataproc spark cluster successfully', async () => {
     // Arrange
+    const user = userEvent.setup();
+
     const createFunc = jest.fn();
     const runtimeFunc = jest.fn(() => ({
       create: createFunc,
@@ -645,21 +664,21 @@ describe('GcpComputeModal', () => {
 
     // Act
     await act(async () => {
-      await render(h(GcpComputeModalBase, defaultModalProps));
-
-      const selectMenu = await screen.getByLabelText('Application configuration');
-      await userEvent.click(selectMenu);
-      const selectOption = await screen.findByText(hailImage.label);
-      await userEvent.click(selectOption);
-
-      const computeTypeSelect = await screen.getByLabelText('Compute type');
-      await userEvent.click(computeTypeSelect);
-      const sparkClusterOption = await screen.findByText('Spark cluster');
-      await userEvent.click(sparkClusterOption);
-
-      const create = await screen.getByText('Create');
-      await userEvent.click(create);
+      render(h(GcpComputeModalBase, defaultModalProps));
     });
+
+    const selectMenu = screen.getByLabelText('Application configuration');
+    await user.click(selectMenu);
+    const selectOption = await screen.findByText(hailImage.label);
+    await user.click(selectOption);
+
+    const computeTypeSelect = screen.getByLabelText('Compute type');
+    await user.click(computeTypeSelect);
+    const sparkClusterOption = await screen.findByText('Spark cluster');
+    await user.click(sparkClusterOption);
+
+    const create = screen.getByText('Create');
+    await user.click(create);
 
     expect(runtimeFunc).toHaveBeenCalledWith(defaultModalProps.workspace.workspace.googleProject, expect.anything());
     expect(createFunc).toHaveBeenCalledWith(
@@ -703,13 +722,14 @@ describe('GcpComputeModal', () => {
     // Act
     await act(async () => {
       render(h(GcpComputeModalBase, defaultModalProps));
-      const selectMenu = screen.getByLabelText('Application configuration');
-      await user.click(selectMenu);
-      const selectOption = await screen.findByText(hailImage.label);
-      await user.click(selectOption);
-      const create = screen.getByText('Create');
-      await user.click(create);
     });
+
+    const selectMenu = screen.getByLabelText('Application configuration');
+    await user.click(selectMenu);
+    const selectOption = await screen.findByText(hailImage.label);
+    await user.click(selectOption);
+    const create = screen.getByText('Create');
+    await user.click(create);
 
     expect(runtimeFunc).toHaveBeenCalledWith(defaultModalProps.workspace.workspace.googleProject, expect.anything());
 
@@ -732,6 +752,8 @@ describe('GcpComputeModal', () => {
   // Strongly recommend typing the compute modal before attempting to fix
   it('should delete spark single node successfully', async () => {
     // Arrange
+    const user = userEvent.setup();
+
     const runtimeProps = {
       runtimeConfig: getJupyterRuntimeConfig({
         diskId: undefined,
@@ -762,16 +784,17 @@ describe('GcpComputeModal', () => {
 
     // Act
     await act(async () => {
-      await render(
+      render(
         h(GcpComputeModalBase, {
           ...defaultModalProps,
           currentDisk: undefined,
           currentRuntime: runtime,
         })
       );
-      await userEvent.click(screen.getByText('Delete Runtime'));
-      await userEvent.click(screen.getByText('Delete'));
     });
+
+    await user.click(screen.getByText('Delete Runtime'));
+    await user.click(screen.getByText('Delete'));
 
     // Assert
     expect(runtimeFunc).toHaveBeenCalledWith(defaultModalProps.workspace.workspace.googleProject, expect.anything());
@@ -820,7 +843,7 @@ describe('GcpComputeModal', () => {
 
     // Act
     await act(async () => {
-      await render(
+      render(
         h(GcpComputeModalBase, {
           ...defaultModalProps,
           currentRuntime: runtime,
@@ -856,6 +879,8 @@ describe('GcpComputeModal', () => {
   // spark cluster (pass a dataproc runtime and ensure it loads correctly) (
   it('creates a dataproc runtime', async () => {
     // Arrange
+    const user = userEvent.setup();
+
     const createFunc = jest.fn();
     const runtimeFunc = jest.fn(() => ({
       create: createFunc,
@@ -875,20 +900,20 @@ describe('GcpComputeModal', () => {
 
     // Act
     await act(async () => {
-      await render(h(GcpComputeModalBase, defaultModalProps));
-
-      const selectMenu = await screen.getByLabelText('Application configuration');
-      await userEvent.click(selectMenu);
-      const selectOption = await screen.findByText(hailImage.label);
-      await userEvent.click(selectOption);
-      const computeTypeSelect = await screen.getByLabelText('Compute type');
-      await userEvent.click(computeTypeSelect);
-      const sparkClusterOption = await screen.findByText('Spark cluster');
-      await userEvent.click(sparkClusterOption);
-
-      const create = await screen.getByText('Create');
-      await userEvent.click(create);
+      render(h(GcpComputeModalBase, defaultModalProps));
     });
+
+    const selectMenu = screen.getByLabelText('Application configuration');
+    await user.click(selectMenu);
+    const selectOption = await screen.findByText(hailImage.label);
+    await user.click(selectOption);
+    const computeTypeSelect = screen.getByLabelText('Compute type');
+    await user.click(computeTypeSelect);
+    const sparkClusterOption = await screen.findByText('Spark cluster');
+    await user.click(sparkClusterOption);
+
+    const create = screen.getByText('Create');
+    await user.click(create);
 
     expect(runtimeFunc).toHaveBeenCalledWith(defaultModalProps.workspace.workspace.googleProject, expect.anything());
     expect(createFunc).toHaveBeenCalledWith(
@@ -914,6 +939,8 @@ describe('GcpComputeModal', () => {
     'custom Environment pane should behave correctly with an invalid image URI',
     async ({ tool }) => {
       // Arrange
+      const user = userEvent.setup();
+
       const createFunc = jest.fn();
       const disk = getDisk();
       const runtimeProps = { runtimeConfig: getJupyterRuntimeConfig({ diskId: disk.id, tool }) };
@@ -937,22 +964,22 @@ describe('GcpComputeModal', () => {
 
       // Act and assert
       await act(async () => {
-        await render(h(GcpComputeModalBase, defaultModalProps));
-
-        const selectMenu = await screen.getByLabelText('Application configuration');
-        await userEvent.click(selectMenu);
-        const selectOption = await screen.findByText('Custom Environment');
-        await userEvent.click(selectOption);
-
-        const imageInput = await screen.getByLabelText('Container image');
-        expect(imageInput).toBeInTheDocument();
-        const invalidImageUri = 'b';
-        await userEvent.type(imageInput, invalidImageUri);
-
-        const nextButton = await screen.findByText('Next');
-
-        verifyDisabled(nextButton);
+        render(h(GcpComputeModalBase, defaultModalProps));
       });
+
+      const selectMenu = screen.getByLabelText('Application configuration');
+      await user.click(selectMenu);
+      const selectOption = await screen.findByText('Custom Environment');
+      await user.click(selectOption);
+
+      const imageInput = screen.getByLabelText('Container image');
+      expect(imageInput).toBeInTheDocument();
+      const invalidImageUri = 'b';
+      await user.type(imageInput, invalidImageUri);
+
+      const nextButton = await screen.findByText('Next');
+
+      verifyDisabled(nextButton);
     }
   );
 
@@ -961,6 +988,8 @@ describe('GcpComputeModal', () => {
     'custom Environment pane should work with a valid image URI ',
     async ({ tool }) => {
       // Arrange
+      const user = userEvent.setup();
+
       const createFunc = jest.fn();
       const disk = getDisk();
       const runtimeProps = { runtimeConfig: getJupyterRuntimeConfig({ diskId: disk.id, tool }) };
@@ -984,44 +1013,47 @@ describe('GcpComputeModal', () => {
 
       // Act and assert
       await act(async () => {
-        await render(h(GcpComputeModalBase, defaultModalProps));
-
-        const selectMenu = await screen.getByLabelText('Application configuration');
-        await userEvent.click(selectMenu);
-        const selectOption = await screen.findByText('Custom Environment');
-        await userEvent.click(selectOption);
-
-        const imageInput = await screen.getByLabelText('Container image');
-        expect(imageInput).toBeInTheDocument();
-        const customImageUri = 'us';
-        await fireEvent.change(imageInput, { target: { value: customImageUri } });
-
-        await screen.findByText('Creation Timeout Limit');
-
-        const nextButton = await screen.findByText('Next');
-        verifyEnabled(nextButton);
-        await userEvent.click(nextButton);
-        const unverifiedDockerWarningHeader = await screen.findByText('Unverified Docker image');
-
-        expect(unverifiedDockerWarningHeader).toBeInTheDocument();
-        const createButton = await screen.findByText('Create');
-        await userEvent.click(createButton);
-        expect(runtimeFunc).toHaveBeenCalledWith(defaultModalProps.workspace.workspace.googleProject, expect.anything());
-        expect(createFunc).toHaveBeenCalledWith(
-          expect.objectContaining({
-            toolDockerImage: customImageUri,
-          })
-        );
+        render(h(GcpComputeModalBase, defaultModalProps));
       });
+
+      const selectMenu = screen.getByLabelText('Application configuration');
+      await user.click(selectMenu);
+      const selectOption = await screen.findByText('Custom Environment');
+      await user.click(selectOption);
+
+      const imageInput = screen.getByLabelText('Container image');
+      expect(imageInput).toBeInTheDocument();
+      const customImageUri = 'us';
+      await user.type(imageInput, customImageUri);
+
+      await screen.findByText('Creation Timeout Limit');
+
+      const nextButton = await screen.findByText('Next');
+      verifyEnabled(nextButton);
+      await user.click(nextButton);
+      const unverifiedDockerWarningHeader = await screen.findByText('Unverified Docker image');
+
+      expect(unverifiedDockerWarningHeader).toBeInTheDocument();
+      const createButton = await screen.findByText('Create');
+      await user.click(createButton);
+      expect(runtimeFunc).toHaveBeenCalledWith(defaultModalProps.workspace.workspace.googleProject, expect.anything());
+      expect(createFunc).toHaveBeenCalledWith(
+        expect.objectContaining({
+          toolDockerImage: customImageUri,
+        })
+      );
     }
   );
 
   // click learn more about persistent disk
   it('should render learn more about persistent disks', async () => {
+    // Arrange
+    const user = userEvent.setup();
+
     // Act
     render(h(GcpComputeModalBase, defaultModalProps));
     const link = screen.getByText('Learn more about persistent disks and where your disk is mounted.');
-    await userEvent.click(link);
+    await user.click(link);
 
     // Assert
     screen.getByText('About persistent disk');
@@ -1032,12 +1064,14 @@ describe('GcpComputeModal', () => {
     'should check successfully that the disk type is clickable',
     async ({ tool }) => {
       // arrange
+      const user = userEvent.setup();
+
       const runtimeProps = { runtimeConfig: getJupyterRuntimeConfig({ tool }) };
       const runtime = getGoogleRuntime(runtimeProps);
 
       // Act
       await act(async () => {
-        await render(
+        render(
           h(GcpComputeModalBase, {
             ...defaultModalProps,
             currentRuntime: runtime,
@@ -1047,17 +1081,21 @@ describe('GcpComputeModal', () => {
 
       // Assert
       const diskTypeDropdown = screen.getByLabelText('Disk Type');
-      await userEvent.click(diskTypeDropdown);
+      await user.click(diskTypeDropdown);
     }
   );
 
   it('should render whats installed on this environment', async () => {
+    // Arrange
+    const user = userEvent.setup();
+
     // Act
     await act(async () => {
-      await render(h(GcpComputeModalBase, defaultModalProps));
-      const link = await screen.getByText('What’s installed on this environment?');
-      await userEvent.click(link);
+      render(h(GcpComputeModalBase, defaultModalProps));
     });
+
+    const link = await screen.getByText('What’s installed on this environment?');
+    await user.click(link);
 
     // Assert
     screen.getByText('Installed packages');
@@ -1068,6 +1106,8 @@ describe('GcpComputeModal', () => {
   // GPUs should function properly
   it.each([{ tool: runtimeTools.Jupyter.label }, { tool: runtimeTools.RStudio.label }])('creates a runtime with GPUs for $tool', async ({ tool }) => {
     // Arrange
+    const user = userEvent.setup();
+
     const createFunc = jest.fn();
     const runtimeFunc = jest.fn(() => ({
       create: createFunc,
@@ -1081,25 +1121,24 @@ describe('GcpComputeModal', () => {
     }));
     // Act
     await act(async () => {
-      await render(
+      render(
         h(GcpComputeModalBase, {
           ...defaultModalProps,
           tool,
         })
       );
-      const enableGPU = await screen.getByText('Enable GPUs');
-      await userEvent.click(enableGPU);
     });
+
+    const enableGPU = await screen.getByText('Enable GPUs');
+    await user.click(enableGPU);
 
     // Assert
     screen.getByText('GPU type');
     screen.getByText('GPUs');
 
     // Act
-    await act(async () => {
-      const create = screen.getByText('Create');
-      await userEvent.click(create);
-    });
+    const create = screen.getByText('Create');
+    await user.click(create);
 
     // Assert
     expect(createFunc).toHaveBeenCalledWith(
@@ -1117,6 +1156,8 @@ describe('GcpComputeModal', () => {
     { tool: runtimeTools.RStudio.label, expectedLabel: '/home/rstudio' },
   ])('should render learn more about persistent disks', async ({ tool, expectedLabel }) => {
     // Arrange
+    const user = userEvent.setup();
+
     const disk = getDisk();
     const runtimeProps = { runtimeConfig: getJupyterRuntimeConfig({ diskId: disk.id, tool }) };
     const runtime = getGoogleRuntime(runtimeProps);
@@ -1136,14 +1177,54 @@ describe('GcpComputeModal', () => {
 
     // Assert
     const link = screen.getByText('Learn more about persistent disks and where your disk is mounted.');
-    await userEvent.click(link);
+    await user.click(link);
     screen.getByText('About persistent disk');
     screen.getByText(expectedLabel);
   });
 
   it('correctly renders and updates timeoutInMinutes', async () => {
-    await act(async () => {
+    // Arrange
+    const user = userEvent.setup();
+
+    const createFunc = jest.fn();
+    const runtimeFunc = jest.fn(() => ({
+      create: createFunc,
+      details: jest.fn(),
+    }));
+    Ajax.mockImplementation(() => ({
+      ...defaultAjaxImpl,
+      Runtimes: {
+        runtime: runtimeFunc,
+      },
+    }));
+    render(h(GcpComputeModalBase, defaultModalProps));
+
+    // Act
+    const selectMenu = screen.getByLabelText('Application configuration');
+    await user.click(selectMenu);
+    const selectOption = await screen.findByText(/Legacy GATK:/);
+    await user.click(selectOption);
+
+    await screen.findByText('Creation Timeout Limit');
+    const timeoutInput = screen.getByLabelText('Creation Timeout Limit');
+    await user.type(timeoutInput, '20');
+
+    // Assert
+    expect(timeoutInput.value).toBe('20');
+
+    // Act
+    await user.click(selectMenu);
+    const selectOption2 = await screen.findByText(defaultImage.label);
+    await user.click(selectOption2);
+    // Assert
+    expect(timeoutInput).not.toBeVisible();
+  });
+
+  it.each([{ runtimeTool: runtimeTools.Jupyter }, { runtimeTool: runtimeTools.RStudio }])(
+    'correctly sends timeoutInMinutes to create for tool $runtimeTool.label',
+    async ({ runtimeTool }) => {
       // Arrange
+      const user = userEvent.setup();
       const createFunc = jest.fn();
       const runtimeFunc = jest.fn(() => ({
         create: createFunc,
@@ -1155,87 +1236,43 @@ describe('GcpComputeModal', () => {
           runtime: runtimeFunc,
         },
       }));
-      await render(h(GcpComputeModalBase, defaultModalProps));
 
       // Act
-      const selectMenu = await screen.getByLabelText('Application configuration');
-      await userEvent.click(selectMenu);
-      const selectOption = await screen.findByText(/Legacy GATK:/);
-      await userEvent.click(selectOption);
+      await act(async () => {
+        render(h(GcpComputeModalBase, { ...defaultModalProps, tool: runtimeTool.label }));
+      });
+
+      const selectMenu = screen.getByLabelText('Application configuration');
+      await user.click(selectMenu);
+      const customImageSelect = await screen.findByText('Custom Environment');
+      await user.click(customImageSelect);
 
       await screen.findByText('Creation Timeout Limit');
-      const timeoutInput = await screen.getByLabelText('Creation Timeout Limit');
-      await fireEvent.change(timeoutInput, { target: { value: 20 } });
+      const timeoutInput = screen.getByLabelText('Creation Timeout Limit');
+
+      const imageInput = screen.getByLabelText('Container image');
+      expect(imageInput).toBeInTheDocument();
+      const customImageUri = 'us';
+      await user.type(imageInput, customImageUri);
+
+      await user.type(timeoutInput, '20');
+      await user.click(selectMenu);
+
+      const nextButton = await screen.findByText('Next');
+      verifyEnabled(nextButton);
+      await user.click(nextButton);
+      const unverifiedDockerWarningHeader = await screen.findByText('Unverified Docker image');
+
+      expect(unverifiedDockerWarningHeader).toBeInTheDocument();
+      const createButton = await screen.findByText('Create');
+      await user.click(createButton);
 
       // Assert
-      expect(timeoutInput.value).toBe('20');
-
-      // Act
-      await userEvent.click(selectMenu);
-      const selectOption2 = await screen.findByText(defaultImage.label);
-      await userEvent.click(selectOption2);
-      // Assert
-      expect(timeoutInput).not.toBeVisible();
-    });
-  });
-
-  it.each([{ runtimeTool: runtimeTools.Jupyter }, { runtimeTool: runtimeTools.RStudio }])(
-    'correctly sends timeoutInMinutes to create for tool $runtimeTool.label',
-    async ({ runtimeTool }) => {
-      await act(async () => {
-        // Arrange
-        const createFunc = jest.fn();
-        const runtimeFunc = jest.fn(() => ({
-          create: createFunc,
-          details: jest.fn(),
-        }));
-        Ajax.mockImplementation(() => ({
-          ...defaultAjaxImpl,
-          Runtimes: {
-            runtime: runtimeFunc,
-          },
-        }));
-
-        // Act
-        await act(async () => {
-          await render(h(GcpComputeModalBase, { ...defaultModalProps, tool: runtimeTool.label }));
-
-          const selectMenu = await screen.getByLabelText('Application configuration');
-          await userEvent.click(selectMenu);
-          const customImageSelect = await screen.findByText('Custom Environment');
-          await userEvent.click(customImageSelect);
-
-          await screen.findByText('Creation Timeout Limit');
-          const timeoutInput = await screen.getByLabelText('Creation Timeout Limit');
-
-          const imageInput = await screen.getByLabelText('Container image');
-          expect(imageInput).toBeInTheDocument();
-          const customImageUri = 'us';
-          await fireEvent.change(imageInput, { target: { value: customImageUri } });
-
-          await fireEvent.change(timeoutInput, { target: { value: 20 } });
-          await userEvent.click(selectMenu);
-        });
-
-        // Act
-        await act(async () => {
-          const nextButton = await screen.findByText('Next');
-          verifyEnabled(nextButton);
-          await userEvent.click(nextButton);
-          const unverifiedDockerWarningHeader = await screen.findByText('Unverified Docker image');
-
-          expect(unverifiedDockerWarningHeader).toBeInTheDocument();
-          const createButton = await screen.findByText('Create');
-          await userEvent.click(createButton);
-        });
-
-        // Assert
-        expect(createFunc).toHaveBeenCalledWith(
-          expect.objectContaining({
-            timeoutInMinutes: 20,
-          })
-        );
-      });
+      expect(createFunc).toHaveBeenCalledWith(
+        expect.objectContaining({
+          timeoutInMinutes: 20,
+        })
+      );
     }
   );
 
@@ -1243,54 +1280,52 @@ describe('GcpComputeModal', () => {
     { runtimeTool: runtimeTools.Jupyter, imageLabel: defaultImage.label },
     { runtimeTool: runtimeTools.RStudio, imageLabel: defaultRImage.label },
   ])('sends null timeout in minutes  for tool $runtimeTool.label after setting and clearing the field', async ({ runtimeTool, imageLabel }) => {
+    // Arrange
+    const user = userEvent.setup();
+
+    const createFunc = jest.fn();
+    const runtimeFunc = jest.fn(() => ({
+      create: createFunc,
+      details: jest.fn(),
+    }));
+    Ajax.mockImplementation(() => ({
+      ...defaultAjaxImpl,
+      Runtimes: {
+        runtime: runtimeFunc,
+      },
+    }));
+
+    // Act
     await act(async () => {
-      // Arrange
-      const createFunc = jest.fn();
-      const runtimeFunc = jest.fn(() => ({
-        create: createFunc,
-        details: jest.fn(),
-      }));
-      Ajax.mockImplementation(() => ({
-        ...defaultAjaxImpl,
-        Runtimes: {
-          runtime: runtimeFunc,
-        },
-      }));
-
-      // Act
-      await act(async () => {
-        await render(h(GcpComputeModalBase, { ...defaultModalProps, tool: runtimeTool.label }));
-
-        const selectMenu = await screen.getByLabelText('Application configuration');
-        await userEvent.click(selectMenu);
-        const customImageSelect = await screen.findByText('Custom Environment');
-        await userEvent.click(customImageSelect);
-
-        await screen.findByText('Creation Timeout Limit');
-        const timeoutInput = await screen.getByLabelText('Creation Timeout Limit');
-        // Set the field to an arbitrary value
-        await fireEvent.change(timeoutInput, { target: { value: 20 } });
-        await userEvent.click(selectMenu);
-        const supportedImageSelect = await screen.findByText(imageLabel);
-        // Clear timeoutInput by selecting
-        await userEvent.click(supportedImageSelect);
-      });
-
-      // Act
-      await act(async () => {
-        const create = screen.getByText('Create');
-        await userEvent.click(create);
-      });
-
-      // Assert
-      expect(createFunc).toHaveBeenCalledWith(
-        expect.objectContaining({
-          // Verify that timeoutInMinutes is actually cleared by selecting
-          // a supported image.
-          timeoutInMinutes: null,
-        })
-      );
+      render(h(GcpComputeModalBase, { ...defaultModalProps, tool: runtimeTool.label }));
     });
+
+    const selectMenu = screen.getByLabelText('Application configuration');
+    await user.click(selectMenu);
+    const customImageSelect = await screen.findByText('Custom Environment');
+    await user.click(customImageSelect);
+
+    await screen.findByText('Creation Timeout Limit');
+    const timeoutInput = screen.getByLabelText('Creation Timeout Limit');
+    // Set the field to an arbitrary value
+    await user.type(timeoutInput, '20');
+    await user.click(selectMenu);
+    const supportedImageSelect = await screen.findByText(imageLabel);
+    // Clear timeoutInput by selecting
+    await user.click(supportedImageSelect);
+
+    // Act
+    const create = screen.getByText('Create');
+    await user.click(create);
+
+    // Assert
+    expect(createFunc).toHaveBeenCalledWith(
+      expect.objectContaining({
+        // Verify that timeoutInMinutes is actually cleared by selecting
+        // a supported image.
+        timeoutInMinutes: null,
+      })
+    );
   });
 
   it('renders default cost estimate', async () => {
@@ -1305,7 +1340,7 @@ describe('GcpComputeModal', () => {
 
     // Act
     await act(async () => {
-      await render(h(GcpComputeModalBase, defaultModalProps));
+      render(h(GcpComputeModalBase, defaultModalProps));
     });
 
     // Assert

--- a/src/analysis/modals/HailBatchModal.test.ts
+++ b/src/analysis/modals/HailBatchModal.test.ts
@@ -43,6 +43,8 @@ describe('HailBatchModal', () => {
 
   it('Calls createAppV2 API when create button is clicked', async () => {
     // Arrange
+    const user = userEvent.setup();
+
     const createFunc = jest.fn();
     asMockedFn(Apps).mockImplementation(() => {
       return {
@@ -53,10 +55,11 @@ describe('HailBatchModal', () => {
 
     // Act
     await act(async () => {
-      await render(h(HailBatchModal, defaultHailBatchProps));
-      const createButton = screen.getByText('Create');
-      await userEvent.click(createButton);
+      render(h(HailBatchModal, defaultHailBatchProps));
     });
+
+    const createButton = screen.getByText('Create');
+    await user.click(createButton);
 
     expect(createFunc).toHaveBeenCalledWith(
       expect.anything(),
@@ -68,6 +71,8 @@ describe('HailBatchModal', () => {
 
   it('shows deleteWarn message after initial delete click', async () => {
     // Arrange
+    const user = userEvent.setup();
+
     const deleteFunc = jest.fn();
     asMockedFn(Apps).mockImplementation(() => {
       return {
@@ -83,10 +88,11 @@ describe('HailBatchModal', () => {
 
     // Act
     await act(async () => {
-      await render(h(HailBatchModal, props));
-      const deleteButton = screen.getByText('Delete Environment');
-      await userEvent.click(deleteButton);
+      render(h(HailBatchModal, props));
     });
+
+    const deleteButton = screen.getByText('Delete Environment');
+    await user.click(deleteButton);
 
     // Assert
     screen.getByText('Delete environment');
@@ -98,7 +104,9 @@ describe('HailBatchModal', () => {
   });
 
   it('Calls deleteAppV2 API when delete button is clicked', async () => {
-    // Arrange
+    // Arrang
+    const user = userEvent.setup();
+
     const deleteFunc = jest.fn();
     asMockedFn(Apps).mockImplementation(() => {
       return {
@@ -114,12 +122,13 @@ describe('HailBatchModal', () => {
 
     // Act
     await act(async () => {
-      await render(h(HailBatchModal, props));
-      const deleteButton = screen.getByText('Delete Environment');
-      await userEvent.click(deleteButton);
-      const deleteButtonAgain = screen.getByText('Delete');
-      await userEvent.click(deleteButtonAgain);
+      render(h(HailBatchModal, props));
     });
+
+    const deleteButton = screen.getByText('Delete Environment');
+    await user.click(deleteButton);
+    const deleteButtonAgain = screen.getByText('Delete');
+    await user.click(deleteButtonAgain);
 
     // Assert
     expect(deleteFunc).toHaveBeenCalled();

--- a/src/analysis/modals/HailBatchModal.test.ts
+++ b/src/analysis/modals/HailBatchModal.test.ts
@@ -104,7 +104,7 @@ describe('HailBatchModal', () => {
   });
 
   it('Calls deleteAppV2 API when delete button is clicked', async () => {
-    // Arrang
+    // Arrange
     const user = userEvent.setup();
 
     const deleteFunc = jest.fn();

--- a/src/analysis/modals/HailBatchModal.test.ts
+++ b/src/analysis/modals/HailBatchModal.test.ts
@@ -1,4 +1,4 @@
-import { act, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { h } from 'react-hyperscript-helpers';
 import { defaultAzureWorkspace, generateTestAppWithAzureWorkspace } from 'src/analysis/_testData/testData';
@@ -54,9 +54,7 @@ describe('HailBatchModal', () => {
     });
 
     // Act
-    await act(async () => {
-      render(h(HailBatchModal, defaultHailBatchProps));
-    });
+    render(h(HailBatchModal, defaultHailBatchProps));
 
     const createButton = screen.getByText('Create');
     await user.click(createButton);
@@ -87,9 +85,7 @@ describe('HailBatchModal', () => {
     };
 
     // Act
-    await act(async () => {
-      render(h(HailBatchModal, props));
-    });
+    render(h(HailBatchModal, props));
 
     const deleteButton = screen.getByText('Delete Environment');
     await user.click(deleteButton);
@@ -121,9 +117,7 @@ describe('HailBatchModal', () => {
     };
 
     // Act
-    await act(async () => {
-      render(h(HailBatchModal, props));
-    });
+    render(h(HailBatchModal, props));
 
     const deleteButton = screen.getByText('Delete Environment');
     await user.click(deleteButton);

--- a/src/analysis/setAzureCookieOnUrl.test.ts
+++ b/src/analysis/setAzureCookieOnUrl.test.ts
@@ -47,9 +47,9 @@ describe('setAzureCookieOnUrl', () => {
     expect(azureCookieReadyStore.get().readyForApp).toBe(false);
   });
 
-  it('should call setAzureCookieOnUrl on cookie setter render', async () => {
+  it('should call setAzureCookieOnUrl on cookie setter render', () => {
     // Arrange
-    await render(h(PeriodicAzureCookieSetter));
+    render(h(PeriodicAzureCookieSetter));
 
     // Assert
     expect(mockSetAzureCookie).toHaveBeenCalled();


### PR DESCRIPTION
With upgraded versions of React and React Testing Library, several IA tests fail and/or throw warnings.

This resolves those issues. The main theme here seems to be unnecessarily wrapping things in `act`. This moves queries outside of `act` (which seemed to be the cause of test failures). And User Event methods use `act` internally, so they do not need to be wrapped in `act`. Wrapping them in `act` causes warnings with upgraded versions of React and React Testing Library.

It also changes some tests to use methods on a UserEvent instance returned by `userEvent.setup()` instead of directly calling them on `userEvent` as recommended in https://testing-library.com/docs/user-event/intro#writing-tests-with-userevent.

And it removes some unnecessary `awaits` from `render` and `getBy...` / `queryBy...` queries, which are all synchronous.