### PR TITLE
[AJ-1182] Return errored apps from resolveWdsApp

### DIFF
--- a/src/components/data/WdsTroubleshooter.ts
+++ b/src/components/data/WdsTroubleshooter.ts
@@ -80,7 +80,12 @@ export const WdsTroubleshooter = ({ onDismiss, workspaceId, mrgId }) => {
     ['Resource Group Id', mrgId, false, !!mrgId],
     ['App listing', `${numApps} app(s) total`, numApps == null, !!numApps && numApps !== 'unknown'],
     ['Data app name', appName, appName === null, !!appName && appName !== 'unknown'],
-    ['Data app running?', appStatus, appStatus == null, !!appStatus && appStatus !== 'unknown'],
+    [
+      'Data app running?',
+      appStatus,
+      appStatus == null,
+      !!appStatus && appStatus !== 'unknown' && appStatus !== 'ERROR',
+    ],
     ['Data app proxy url', proxyUrl, proxyUrl == null, !!proxyUrl && proxyUrl !== 'unknown', proxyElement],
     ['Data app responding', wdsResponsive, wdsResponsive == null, wdsResponsive === 'true'],
     ['Data app version', version, version == null, !!version && version !== 'unknown'],

--- a/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
+++ b/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
@@ -98,16 +98,13 @@ export const resolveWdsApp = (apps: ListAppResponse[]): ListAppResponse | undefi
   // an app may be in the 'PROVISIONING', 'STOPPED', 'STOPPING', which can still be deemed as an OK state for WDS
   const healthyStates = ['RUNNING', 'PROVISIONING', 'STOPPED', 'STOPPING'];
 
-  // @ts-expect-error Leo type definitions do not include WDS
   const eligibleApps = apps.filter((app) => app.appType === 'WDS' || app.appType === 'CROMWELL');
 
   const prioritizedApps = _.sortBy(
     [
       // Prefer WDS app with the proper name
-      // @ts-expect-error Leo type definitions do not include WDS
       (app) => (app.appType === 'WDS' && app.appName === `wds-${app.workspaceId}` ? -1 : 1),
       // Prefer WDS apps over CROMWELL apps
-      // @ts-expect-error Leo type definitions do not include WDS
       (app) => (app.appType === 'WDS' ? -1 : 1),
       // Prefer running apps
       (app) => (app.status === 'RUNNING' ? -1 : 1),

--- a/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
+++ b/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
@@ -13,6 +13,7 @@ import {
   TsvUploadButtonTooltipOptions,
   UploadParameters,
 } from 'src/libs/ajax/data-table-providers/DataTableProvider';
+import { ListAppResponse } from 'src/libs/ajax/leonardo/models/app-models';
 import { withErrorReporting } from 'src/libs/error';
 import { notify } from 'src/libs/notifications';
 import { notificationStore } from 'src/libs/state';
@@ -90,48 +91,35 @@ const getRelationParts = (val: unknown): string[] => {
 // Invokes logic to determine the appropriate app for WDS
 // If WDS is not running, a URL will not be present -- in some cases, this function may invoke
 // a new call to Leo to instantiate a WDS being available, thus having a valid URL
-export const resolveWdsApp = (apps) => {
+export const resolveWdsApp = (apps: ListAppResponse[]): ListAppResponse | undefined => {
   // WDS looks for Kubernetes deployment statuses (such as RUNNING or PROVISIONING), expressed by Leo
   // See here for specific enumerations -- https://github.com/DataBiosphere/leonardo/blob/develop/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
   // look explicitly for a RUNNING app named 'wds-${app.workspaceId}' -- if WDS is healthy and running, there should only be one app RUNNING
   // an app may be in the 'PROVISIONING', 'STOPPED', 'STOPPING', which can still be deemed as an OK state for WDS
   const healthyStates = ['RUNNING', 'PROVISIONING', 'STOPPED', 'STOPPING'];
 
-  // WDS appType is checked first and takes precedence over CROMWELL apps in the workspace
-  const wdsAppTypes = ['WDS', 'CROMWELL'];
-  for (const wdsAppType of wdsAppTypes) {
-    const namedApp = apps.filter(
-      (app) =>
-        app.appType === wdsAppType && app.appName === `wds-${app.workspaceId}` && healthyStates.includes(app.status)
-    );
-    if (namedApp.length === 1) {
-      return namedApp[0];
-    }
+  // @ts-expect-error Leo type definitions do not include WDS
+  const eligibleApps = apps.filter((app) => app.appType === 'WDS' || app.appType === 'CROMWELL');
 
-    // Failed to find an app with the proper name, look for a RUNNING WDS or CROMWELL app
-    const runningWdsApps = apps.filter((app) => app.appType === wdsAppType && app.status === 'RUNNING');
-    if (runningWdsApps.length > 0) {
-      // Evaluate the earliest-created WDS app
-      runningWdsApps.sort(
-        (a, b) => new Date(a.auditInfo.createdDate).valueOf() - new Date(b.auditInfo.createdDate).valueOf()
-      );
-      return runningWdsApps[0];
-    }
+  const prioritizedApps = _.sortBy(
+    [
+      // Prefer WDS app with the proper name
+      // @ts-expect-error Leo type definitions do not include WDS
+      (app) => (app.appType === 'WDS' && app.appName === `wds-${app.workspaceId}` ? -1 : 1),
+      // Prefer WDS apps over CROMWELL apps
+      // @ts-expect-error Leo type definitions do not include WDS
+      (app) => (app.appType === 'WDS' ? -1 : 1),
+      // Prefer running apps
+      (app) => (app.status === 'RUNNING' ? -1 : 1),
+      // Prefer healthy apps
+      (app) => (healthyStates.includes(app.status) ? -1 : 1),
+      // Prefer apps created earlier
+      (app) => new Date(app.auditInfo?.createdDate).valueOf(),
+    ],
+    eligibleApps
+  );
 
-    // If we reach this logic, we have more than one Leo app with the associated workspace Id...
-    const allWdsApps = apps.filter(
-      (app) => app.appType === wdsAppType && ['PROVISIONING', 'STOPPED', 'STOPPING'].includes(app.status)
-    );
-    if (allWdsApps.length > 0) {
-      // Evaluate the earliest-created WDS app
-      allWdsApps.sort(
-        (a, b) => new Date(a.auditInfo.createdDate).valueOf() - new Date(b.auditInfo.createdDate).valueOf()
-      );
-      return allWdsApps[0];
-    }
-  }
-
-  return '';
+  return prioritizedApps[0];
 };
 
 // Extract wds URL from Leo response. exported for testing

--- a/src/libs/wds-status.ts
+++ b/src/libs/wds-status.ts
@@ -109,6 +109,22 @@ export const useWdsStatus = ({ workspaceId }: UseWdsStatusArgs) => {
       proxyUrl,
     }));
 
+    if (wdsApp.status !== 'RUNNING') {
+      setStatus((previousStatus) => ({
+        ...previousStatus,
+        wdsResponsive: 'unknown',
+        version: 'unknown',
+        chartVersion: 'unknown',
+        image: 'unknown',
+        wdsStatus: 'unresponsive',
+        wdsDbStatus: 'unknown',
+        wdsPingStatus: 'unknown',
+        wdsIamStatus: 'unknown',
+        defaultInstanceExists: 'unknown',
+      }));
+      return;
+    }
+
     await Promise.allSettled([
       Ajax(signal)
         .WorkspaceData.getVersion(proxyUrl)


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1182

Currently, `resolveWdsApp` only returns "healthy" (running, provisioning, stopping, or stopped) apps. This limits the usefulness of the WDS troubleshooter, which will show the WDS app status as "unknown" even when the app has errored / failed to start.

This changes `resolveWdsApp` to return apps of any status, prioritized as before. The impact of this change is limited because `resolveWdsApp` is only used in two places: the WDS Troubleshooter and `resolveWdsUrl`. `resolveWdsUrl`, which is more broadly used, only returns a URL if the app's status is running.

## Before
<img width="841" alt="Screenshot 2023-07-21 at 11 36 50 AM" src="https://github.com/DataBiosphere/terra-ui/assets/1156625/f38b8488-947e-4133-a1c7-7d6f36769865">

## After  
<img width="838" alt="Screenshot 2023-07-21 at 12 01 06 PM" src="https://github.com/DataBiosphere/terra-ui/assets/1156625/b424185c-274f-49a5-9360-b1172f1d29df">

## Testing

The prioritization of apps is covered by unit tests for `resolveWdsUrl`. 

You can override the list apps response to return an errored app with:
```js
ajaxOverridesStore.set([
  {
    filter: { url: /\/apps\/v2\// },
    fn: ajaxOverrideUtils.makeSuccess([
        {
            "workspaceId": "eeff20de-0070-4c1c-809c-6f0c2e01eb24",
            "cloudContext": {
                "cloudProvider": "AZURE",
                "cloudResource": "0cb7a640-45a2-4ed6-be9f-63519f86e04b/0fa61a72-3a6b-4d51-a7e9-75fbeb7c7ed9/mrg-terra-dev-previ-20230626173007"
            },
            "kubernetesRuntimeConfig": {
                "numNodes": 1,
                "machineType": "Standard_A2_v2",
                "autoscalingEnabled": false
            },
            "errors": [],
            "status": "ERROR",
            "proxyUrls": {
                "wds": "https://lz81067ca761368f63128f883248bc7c26e250eaa41f49a163.servicebus.windows.net/wds-eeff20de-0070-4c1c-809c-6f0c2e01eb24-eeff20de-0070-4c1c-809c-6f0c2e01eb24/"
            },
            "appName": "wds-eeff20de-0070-4c1c-809c-6f0c2e01eb24",
            "appType": "WDS",
            "diskName": null,
            "auditInfo": {
                "creator": "user@example.com",
                "createdDate": "2023-07-20T18:42:28.798500Z",
                "destroyedDate": null,
                "dateAccessed": "2023-07-20T18:42:28.798500Z"
            },
            "accessScope": "WORKSPACE_SHARED",
            "labels": {}
        }
    ])
  }
])
```