### PR TITLE
[UIE-103] Convert feature-previews-config to TS

### DIFF
--- a/src/libs/feature-previews-config.ts
+++ b/src/libs/feature-previews-config.ts
@@ -4,7 +4,41 @@ export const HAIL_BATCH_AZURE_FEATURE_ID = 'hail-batch-azure';
 export const WORKFLOWS_TAB_AZURE_FEATURE_ID = 'workflows-tab-azure';
 export const DOCKSTORE_AZURE_FEATURE_ID = 'dockstore-azure';
 
-const featurePreviewsConfig = [
+export type FeaturePreview = {
+  /**
+   * ID for the feature. This is used to check if the feature is enabled and to toggle it enabled/disabled.
+   */
+  readonly id: string;
+
+  /**
+   * Name of the feature. Shown on the feature previews page.
+   */
+  readonly title: string;
+
+  /**
+   * Description for the feature. Shown on the feature previews page.
+   */
+  readonly description: string;
+
+  /**
+   * Optional list of groups. If specified, the feature will only appear on the feature previews page
+   * for users that are a member of at least one of the specified groups.
+   * This only applies in production. In dev environments, all features are available to all users.
+   */
+  readonly groups?: readonly string[];
+
+  /**
+   * Optional URL for feature documentation. Shown on the feature previews page.
+   */
+  readonly documentationUrl?: string;
+
+  /**
+   * Optional URL for users to provide feedback on the feature. Shown on the feature previews page.
+   */
+  readonly feedbackUrl?: string;
+};
+
+const featurePreviewsConfig: readonly FeaturePreview[] = [
   {
     id: 'data-table-versioning',
     title: 'Data Table Versioning',
@@ -16,7 +50,8 @@ const featurePreviewsConfig = [
   {
     id: 'data-table-provenance',
     title: 'Data Table Provenance',
-    description: 'Enabling this feature will allow you to view information about the workflow that generated data table columns and files.',
+    description:
+      'Enabling this feature will allow you to view information about the workflow that generated data table columns and files.',
     groups: ['preview-data-versioning-and-provenance'],
     feedbackUrl: `mailto:dsp-sue@broadinstitute.org?subject=${encodeURIComponent('Feedback on data table provenance')}`,
   },
@@ -32,7 +67,9 @@ const featurePreviewsConfig = [
     title: 'Workspace Files Browser',
     description: 'Enabling this feature will allow you to use the new workspace files browser.',
     groups: ['preview-workspace-files'],
-    feedbackUrl: `mailto:dsp-sue@broadinstitute.org?subject=${encodeURIComponent('Feedback on workspace files browser')}`,
+    feedbackUrl: `mailto:dsp-sue@broadinstitute.org?subject=${encodeURIComponent(
+      'Feedback on workspace files browser'
+    )}`,
   },
   {
     id: HAIL_BATCH_AZURE_FEATURE_ID,

--- a/src/libs/feature-previews-config.ts
+++ b/src/libs/feature-previews-config.ts
@@ -4,6 +4,9 @@ export const HAIL_BATCH_AZURE_FEATURE_ID = 'hail-batch-azure';
 export const WORKFLOWS_TAB_AZURE_FEATURE_ID = 'workflows-tab-azure';
 export const DOCKSTORE_AZURE_FEATURE_ID = 'dockstore-azure';
 
+// If the groups option is defined for a FeaturePreview, it must contain at least one group.
+type GroupsList = readonly [string, ...string[]];
+
 export type FeaturePreview = {
   /**
    * ID for the feature. This is used to check if the feature is enabled and to toggle it enabled/disabled.
@@ -25,7 +28,7 @@ export type FeaturePreview = {
    * for users that are a member of at least one of the specified groups.
    * This only applies in production. In dev environments, all features are available to all users.
    */
-  readonly groups?: readonly string[];
+  readonly groups?: GroupsList;
 
   /**
    * Optional URL for feature documentation. Shown on the feature previews page.


### PR DESCRIPTION
After [confusion about how the `groups` field worked the other day](https://broadinstitute.slack.com/archives/C01EHNUM73R/p1689775988912969?thread_ts=1689775878.454569&cid=C01EHNUM73R), I thought that feature-previews-config could use some in-code documentation. Currently, the config is documented in the wiki (https://github.com/DataBiosphere/terra-ui/wiki/Feature-Flags).