### PR TITLE
[SU-288] Sync file browser path with URL query parameter

### DIFF
--- a/src/components/file-browser/FileBrowser.ts
+++ b/src/components/file-browser/FileBrowser.ts
@@ -17,14 +17,25 @@ import { requesterPaysProjectStore } from 'src/libs/state';
 import * as Utils from 'src/libs/utils';
 
 interface FileBrowserProps {
+  initialPath?: string;
   provider: FileBrowserProvider;
   rootLabel: string;
   title: string;
   workspace: any; // TODO: Type for workspace
+  onChangePath?: (newPath: string) => void;
 }
 
-const FileBrowser = ({ provider, rootLabel, title, workspace }: FileBrowserProps) => {
-  const [path, setPath] = useState('');
+const FileBrowser = (props: FileBrowserProps) => {
+  const { initialPath = '', provider, rootLabel, title, workspace, onChangePath } = props;
+
+  const [path, _setPath] = useState(initialPath);
+  const setPath = useCallback(
+    (newPath: string) => {
+      _setPath(newPath);
+      onChangePath?.(newPath);
+    },
+    [onChangePath]
+  );
 
   // refreshKey is a hack to make hooks in DirectoryTree and FilesInDirectory reload
   // after selecting a workspace to bill requester pays request to.

--- a/src/libs/nav.js
+++ b/src/libs/nav.js
@@ -106,6 +106,17 @@ export const updateSearch = (params) => {
   }
 };
 
+export const useQueryParameter = (key) => {
+  const { query } = useRoute();
+
+  return [
+    query[key],
+    (value) => {
+      updateSearch({ ...query, [key]: value });
+    },
+  ];
+};
+
 export function PathHashInserter() {
   useOnMount(() => {
     const loc = window.location;

--- a/src/pages/workspaces/workspace/Files.ts
+++ b/src/pages/workspaces/workspace/Files.ts
@@ -4,6 +4,7 @@ import * as breadcrumbs from 'src/components/breadcrumbs';
 import FileBrowser from 'src/components/file-browser/FileBrowser';
 import AzureBlobStorageFileBrowserProvider from 'src/libs/ajax/file-browser-providers/AzureBlobStorageFileBrowserProvider';
 import GCSFileBrowserProvider from 'src/libs/ajax/file-browser-providers/GCSFileBrowserProvider';
+import { useQueryParameter } from 'src/libs/nav';
 import { forwardRefWithName } from 'src/libs/react-utils';
 import { isAzureWorkspace } from 'src/libs/workspace-utils';
 import { wrapWorkspace } from 'src/pages/workspaces/workspace/WorkspaceContainer';
@@ -29,6 +30,8 @@ export const Files = _.flow(
 
   const rootLabel = isAzureWorkspace(workspace) ? 'Workspace cloud storage' : 'Workspace bucket';
 
+  const [path, setPath] = useQueryParameter('path');
+
   return div(
     {
       style: {
@@ -36,7 +39,16 @@ export const Files = _.flow(
         overflow: 'hidden',
       },
     },
-    [h(FileBrowser, { workspace, provider: fileBrowserProvider, rootLabel, title: 'Files' })]
+    [
+      h(FileBrowser, {
+        initialPath: path || '',
+        workspace,
+        provider: fileBrowserProvider,
+        rootLabel,
+        title: 'Files',
+        onChangePath: setPath,
+      }),
+    ]
   );
 });
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/SU-288

This gets the initial path for the workspace files browser from the URL, specifically the `path` query parameter, and keeps that query parameter in sync with the selected path.

This allows deep linking to a specific folder in the file browser and also means that the selected folder is preserved across browser refreshes.