### PR TITLE
[SU-287] Allow creating empty folders in Azure workspaces

### DIFF
--- a/src/components/file-browser/FilesInDirectory.test.ts
+++ b/src/components/file-browser/FilesInDirectory.test.ts
@@ -303,7 +303,6 @@ describe('FilesInDirectory', () => {
 
     const deleteEmptyDirectory = jest.fn(() => Promise.resolve());
     const mockProvider = {
-      supportsEmptyDirectories: true,
       deleteEmptyDirectory,
     } as Partial<FileBrowserProvider> as FileBrowserProvider;
 

--- a/src/components/file-browser/FilesInDirectory.ts
+++ b/src/components/file-browser/FilesInDirectory.ts
@@ -202,32 +202,32 @@ const FilesInDirectory = (props: FilesInDirectoryProps) => {
                     Utils.cond(
                       [status === 'Loading', () => 'Loading files...'],
                       [status === 'Error', () => 'Unable to load files'],
-                      [
-                        path !== '',
-                        () =>
-                          h(
-                            ButtonOutline,
-                            {
-                              style: { marginTop: '1rem', textTransform: 'none' },
-                              onClick: async () => {
-                                // Attempt to delete folder placeholder object.
-                                // A placeholder object may not exist for the prefix being viewed, so do not an report error for 404 responses.
-                                // See https://cloud.google.com/storage/docs/folders for more information on placeholder objects.
-                                setBusy(true);
-                                try {
-                                  await provider.deleteEmptyDirectory(path);
-                                  setBusy(false);
-                                  onDeleteDirectory();
-                                } catch (error) {
-                                  setBusy(false);
-                                  reportError('Error deleting folder', error);
-                                }
+                      () =>
+                        h(Fragment, [
+                          div(['No files have been uploaded yet']),
+                          path !== '' &&
+                            h(
+                              ButtonOutline,
+                              {
+                                style: { marginTop: '1rem', textTransform: 'none' },
+                                onClick: async () => {
+                                  // Attempt to delete folder placeholder object.
+                                  // A placeholder object may not exist for the prefix being viewed, so do not an report error for 404 responses.
+                                  // See https://cloud.google.com/storage/docs/folders for more information on placeholder objects.
+                                  setBusy(true);
+                                  try {
+                                    await provider.deleteEmptyDirectory(path);
+                                    setBusy(false);
+                                    onDeleteDirectory();
+                                  } catch (error) {
+                                    setBusy(false);
+                                    reportError('Error deleting folder', error);
+                                  }
+                                },
                               },
-                            },
-                            ['Delete this folder']
-                          ),
-                      ],
-                      () => 'No files have been uploaded yet'
+                              ['Delete this folder']
+                            ),
+                        ])
                     ),
                   ]
                 ),

--- a/src/components/file-browser/FilesInDirectory.ts
+++ b/src/components/file-browser/FilesInDirectory.ts
@@ -203,7 +203,7 @@ const FilesInDirectory = (props: FilesInDirectoryProps) => {
                       [status === 'Loading', () => 'Loading files...'],
                       [status === 'Error', () => 'Unable to load files'],
                       [
-                        path !== '' && provider.supportsEmptyDirectories,
+                        path !== '',
                         () =>
                           h(
                             ButtonOutline,

--- a/src/components/file-browser/FilesMenu.test.ts
+++ b/src/components/file-browser/FilesMenu.test.ts
@@ -94,7 +94,6 @@ describe('FilesMenu', () => {
 
     const createEmptyDirectory = jest.fn((path: string) => Promise.resolve({ path }));
     const mockProvider = {
-      supportsEmptyDirectories: true,
       createEmptyDirectory,
     } as Partial<FileBrowserProvider> as FileBrowserProvider;
 

--- a/src/components/file-browser/FilesMenu.ts
+++ b/src/components/file-browser/FilesMenu.ts
@@ -73,17 +73,16 @@ export const FilesMenu = (props: FilesMenuProps) => {
         ]
       ),
 
-      provider.supportsEmptyDirectories &&
-        h(
-          Link,
-          {
-            disabled,
-            tooltip: disabled ? disabledReason : undefined,
-            style: { padding: '0.5rem' },
-            onClick: () => setCreatingNewDirectory(true),
-          },
-          [icon('folder'), ' New folder']
-        ),
+      h(
+        Link,
+        {
+          disabled,
+          tooltip: disabled ? disabledReason : undefined,
+          style: { padding: '0.5rem' },
+          onClick: () => setCreatingNewDirectory(true),
+        },
+        [icon('folder'), ' New folder']
+      ),
 
       h(
         Link,

--- a/src/libs/ajax/file-browser-providers/AzureBlobStorageFileBrowserProvider.test.ts
+++ b/src/libs/ajax/file-browser-providers/AzureBlobStorageFileBrowserProvider.test.ts
@@ -269,4 +269,48 @@ describe('AzureBlobStorageFileBrowserProvider', () => {
       }
     );
   });
+
+  it('creates empty directories', async () => {
+    // Arrange
+    asMockedFn(fetchOk).mockResolvedValue(new Response());
+
+    const provider = AzureBlobStorageFileBrowserProvider({ workspaceId: 'test-workspace' });
+
+    // Act
+    const directory = await provider.createEmptyDirectory('foo/bar/baz/');
+
+    // Assert
+    expect(fetchOk).toHaveBeenCalledWith(
+      'https://terra-ui-test.blob.core.windows.net/test-storage-container/foo/bar/baz/?tokenPlaceholder=value',
+      {
+        body: expect.any(File),
+        headers: {
+          'Content-Length': 0,
+          'Content-Type': 'text/text',
+          'x-ms-blob-type': 'BlockBlob',
+        },
+        method: 'PUT',
+      }
+    );
+
+    expect(directory).toEqual({ path: 'foo/bar/baz/' });
+  });
+
+  it('deletes empty directories', async () => {
+    // Arrange
+    asMockedFn(fetchOk).mockResolvedValue(new Response());
+
+    const provider = AzureBlobStorageFileBrowserProvider({ workspaceId: 'test-workspace' });
+
+    // Act
+    await provider.deleteEmptyDirectory('foo/bar/baz/');
+
+    // Assert
+    expect(fetchOk).toHaveBeenCalledWith(
+      'https://terra-ui-test.blob.core.windows.net/test-storage-container/foo/bar/baz/?tokenPlaceholder=value',
+      {
+        method: 'DELETE',
+      }
+    );
+  });
 });

--- a/src/libs/ajax/file-browser-providers/FileBrowserProvider.ts
+++ b/src/libs/ajax/file-browser-providers/FileBrowserProvider.ts
@@ -13,8 +13,6 @@ export interface FileBrowserDirectory {
 }
 
 interface FileBrowserProvider {
-  supportsEmptyDirectories: boolean;
-
   getDirectoriesInDirectory(
     path: string,
     options?: { signal?: AbortSignal }

--- a/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.ts
+++ b/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.ts
@@ -101,7 +101,6 @@ const GCSFileBrowserProvider = ({
   };
 
   return {
-    supportsEmptyDirectories: true,
     getFilesInDirectory: (path, { signal } = {}) =>
       getNextPage({
         isFirstPage: true,


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/SU-287

Currently, the file browser only allows creating empty "folders" in GCP workspaces. This adds support for empty folders to Azure workspaces. Folders don't really exist in blob storage. The illusion of a folder is created by creating a placeholder object named `path/to/directory/`.

## Before
![Screenshot 2023-07-24 at 4 24 03 PM](https://github.com/DataBiosphere/terra-ui/assets/1156625/cd17e9a7-d30c-4b30-949e-fdb325683d4f)

## After
https://github.com/DataBiosphere/terra-ui/assets/1156625/c13fa6c9-a9c4-4495-b32b-5c5085fb038a

