### PR TITLE
[DC-733] Fixup AzureBillingProjectWizard unit tests for React 18

### DIFF
--- a/src/pages/billing/NewBillingProjectWizard/AzureBillingProjectWizard/CreateNamedProjectStep.test.ts
+++ b/src/pages/billing/NewBillingProjectWizard/AzureBillingProjectWizard/CreateNamedProjectStep.test.ts
@@ -1,21 +1,17 @@
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { h } from 'react-hyperscript-helpers';
 import { CreateNamedProjectStep } from 'src/pages/billing/NewBillingProjectWizard/AzureBillingProjectWizard/CreateNamedProjectStep';
 
 // Exported for wizard integration test.
 export const nameBillingProject = async (billingProjectName) => {
-  await act(async () => {
-    await userEvent.click(getBillingProjectInput());
-  });
+  await userEvent.click(getBillingProjectInput());
   fireEvent.change(getBillingProjectInput(), { target: { value: billingProjectName } });
 };
 export const clickCreateBillingProject = async () => {
   const createButton = getCreateButton();
   verifyEnabled(createButton);
-  await act(async () => {
-    await userEvent.click(createButton);
-  });
+  await userEvent.click(createButton);
 };
 export const verifyCreateBillingProjectDisabled = () => {
   verifyDisabled(getCreateButton());
@@ -79,12 +75,12 @@ describe('CreateNamedProjectStep', () => {
 
   it('fires an event when the billing project input is focused', async () => {
     // Arrange
+    const user = userEvent.setup();
+
     render(h(CreateNamedProjectStep, defaultProps));
 
     // Act
-    await act(async () => {
-      await userEvent.click(getBillingProjectInput());
-    });
+    await user.click(getBillingProjectInput());
 
     // Assert
     expect(onBillingProjectInputFocused).toHaveBeenCalled();


### PR DESCRIPTION
With upgraded React and React Testing Library, tests warn (and thus fail) if userEvent methods are unnecessarily wrapped in act.