### PR TITLE
[SU-260] Add moveFile method to file browser providers

### DIFF
--- a/src/libs/ajax/GoogleStorage.ts
+++ b/src/libs/ajax/GoogleStorage.ts
@@ -290,6 +290,20 @@ export const GoogleStorage = (signal?: AbortSignal) => ({
     );
   },
 
+  copyWithinBucket: async (
+    googleProject: string,
+    bucket: string,
+    sourceName: string,
+    destinationName: string
+  ): Promise<void> => {
+    await fetchBuckets(
+      `storage/v1/b/${bucket}/o/${encodeURIComponent(sourceName)}/copyTo/b/${bucket}/o/${encodeURIComponent(
+        destinationName
+      )}`,
+      _.mergeAll([authOpts(await saToken(googleProject)), { signal, method: 'POST' }])
+    );
+  },
+
   // TODO: this should be deprecated in favor of the smarter `analysis` set of functions
   notebook: (googleProject, bucket, name) => {
     const bucketUrl = `storage/v1/b/${bucket}/o`;

--- a/src/libs/ajax/file-browser-providers/AzureBlobStorageFileBrowserProvider.test.ts
+++ b/src/libs/ajax/file-browser-providers/AzureBlobStorageFileBrowserProvider.test.ts
@@ -271,6 +271,35 @@ describe('AzureBlobStorageFileBrowserProvider', () => {
     );
   });
 
+  it('moves files', async () => {
+    // Arrange
+    asMockedFn(fetchOk).mockResolvedValue(new Response());
+
+    const provider = AzureBlobStorageFileBrowserProvider({ workspaceId: 'test-workspace' });
+
+    // Act
+    await provider.moveFile('path/to/source.txt', 'path/to/destination.txt');
+
+    // Assert
+    expect(fetchOk).toHaveBeenCalledWith(
+      'https://terra-ui-test.blob.core.windows.net/test-storage-container/path/to/destination.txt?tokenPlaceholder=value',
+      {
+        method: 'PUT',
+        headers: {
+          'x-ms-copy-source':
+            'https://terra-ui-test.blob.core.windows.net/test-storage-container/path/to/source.txt?tokenPlaceholder=value',
+        },
+      }
+    );
+
+    expect(fetchOk).toHaveBeenCalledWith(
+      'https://terra-ui-test.blob.core.windows.net/test-storage-container/path/to/source.txt?tokenPlaceholder=value',
+      {
+        method: 'DELETE',
+      }
+    );
+  });
+
   it('creates empty directories', async () => {
     // Arrange
     asMockedFn(fetchOk).mockResolvedValue(new Response());

--- a/src/libs/ajax/file-browser-providers/FileBrowserProvider.ts
+++ b/src/libs/ajax/file-browser-providers/FileBrowserProvider.ts
@@ -24,6 +24,7 @@ interface FileBrowserProvider {
 
   uploadFileToDirectory(directoryPath: string, file: File): Promise<void>;
   deleteFile(path: string): Promise<void>;
+  moveFile(sourcePath: string, destinationPath: string): Promise<void>;
 
   createEmptyDirectory(directoryPath: string): Promise<FileBrowserDirectory>;
   deleteEmptyDirectory(directoryPath: string): Promise<void>;

--- a/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.test.ts
+++ b/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.test.ts
@@ -213,6 +213,35 @@ describe('GCSFileBrowserProvider', () => {
     expect(del).toHaveBeenCalledWith('test-project', 'test-bucket', 'path/to/file.txt');
   });
 
+  it('moves files', async () => {
+    // Arrange
+    const copyWithinBucket = jest.fn(() => Promise.resolve());
+    const del = jest.fn(() => Promise.resolve());
+    asMockedFn(Ajax).mockImplementation(
+      () =>
+        ({
+          Buckets: {
+            copyWithinBucket,
+            delete: del,
+          } as Partial<GoogleStorageContract>,
+        } as ReturnType<typeof Ajax>)
+    );
+
+    const provider = GCSFileBrowserProvider({ bucket: 'test-bucket', project: 'test-project' });
+
+    // Act
+    await provider.moveFile('path/to/source.txt', 'path/to/destination.txt');
+
+    // Assert
+    expect(copyWithinBucket).toBeCalledWith(
+      'test-project',
+      'test-bucket',
+      'path/to/source.txt',
+      'path/to/destination.txt'
+    );
+    expect(del).toHaveBeenCalledWith('test-project', 'test-bucket', 'path/to/source.txt');
+  });
+
   it('creates empty directories', async () => {
     // Arrange
     const upload = jest.fn(() => Promise.resolve());

--- a/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.ts
+++ b/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.ts
@@ -140,6 +140,10 @@ const GCSFileBrowserProvider = ({
     deleteFile: async (path: string): Promise<void> => {
       await Ajax().Buckets.delete(project, bucket, path);
     },
+    moveFile: async (sourcePath: string, destinationPath: string): Promise<void> => {
+      await Ajax().Buckets.copyWithinBucket(project, bucket, sourcePath, destinationPath);
+      await Ajax().Buckets.delete(project, bucket, sourcePath);
+    },
     createEmptyDirectory: async (directoryPath: string) => {
       // Create a placeholder object for the new folder.
       // See https://cloud.google.com/storage/docs/folders for more information.


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/SU-260

With the goal of allowing renaming files from the workspace files browser, this adds a `moveFile` method to the FileBrowserProvider interface and implements it for GCS and Azure Blob Storage.