### PR TITLE
[UIE-112] Move isValidWsExportTarget out of utils

### DIFF
--- a/src/analysis/modals/ExportAnalysisModal/ExportAnalysisModal.test.ts
+++ b/src/analysis/modals/ExportAnalysisModal/ExportAnalysisModal.test.ts
@@ -35,12 +35,12 @@ jest.mock(
   })
 );
 
-type UtilsExports = typeof import('src/libs/utils');
+type WorkspaceUtilsExports = typeof import('src/libs/workspace-utils');
 type LodashFpExports = typeof import('lodash/fp');
-jest.mock('src/libs/utils', (): UtilsExports => {
+jest.mock('src/libs/workspace-utils', (): WorkspaceUtilsExports => {
   const _ = jest.requireActual<LodashFpExports>('lodash/fp');
   return {
-    ...jest.requireActual('src/libs/utils'),
+    ...jest.requireActual('src/libs/workspace-utils'),
     isValidWsExportTarget: jest.fn().mockImplementation(
       _.curry((sourceWs: WorkspaceWrapper, destWs: WorkspaceWrapper) => {
         // mock this to have a much simpler check then the real implementation

--- a/src/analysis/modals/ExportAnalysisModal/ExportAnalysisModal.ts
+++ b/src/analysis/modals/ExportAnalysisModal/ExportAnalysisModal.ts
@@ -12,8 +12,8 @@ import Modal from 'src/components/Modal';
 import { WorkspaceSelector } from 'src/components/workspace-utils';
 import { FormLabel } from 'src/libs/forms';
 import { goToPath as navToPath } from 'src/libs/nav';
-import { isValidWsExportTarget, summarizeErrors } from 'src/libs/utils';
-import { WorkspaceInfo, WorkspaceWrapper } from 'src/libs/workspace-utils';
+import { summarizeErrors } from 'src/libs/utils';
+import { isValidWsExportTarget, WorkspaceInfo, WorkspaceWrapper } from 'src/libs/workspace-utils';
 import validate from 'validate.js';
 
 export interface ExportAnalysisModalProps {

--- a/src/components/data/ExportDataModal.js
+++ b/src/components/data/ExportDataModal.js
@@ -13,6 +13,7 @@ import { FormLabel } from 'src/libs/forms';
 import * as Nav from 'src/libs/nav';
 import * as Style from 'src/libs/style';
 import * as Utils from 'src/libs/utils';
+import { isValidWsExportTarget } from 'src/libs/workspace-utils';
 import validate from 'validate.js';
 
 const InfoTile = ({ isError = false, content }) => {
@@ -134,7 +135,7 @@ const ExportDataModal = ({ onDismiss, selectedDataType, selectedEntities, runnin
           h(Fragment, [
             h(FormLabel, { required: true }, ['Destination']),
             h(WorkspaceSelector, {
-              workspaces: _.filter(Utils.isValidWsExportTarget(workspace), workspaces),
+              workspaces: _.filter(isValidWsExportTarget(workspace), workspaces),
               value: selectedWorkspaceId,
               onChange: setSelectedWorkspaceId,
             }),

--- a/src/libs/utils.test.ts
+++ b/src/libs/utils.test.ts
@@ -1,11 +1,9 @@
-import { defaultAzureWorkspace, defaultGoogleWorkspace } from 'src/analysis/_testData/testData';
 import {
   condTyped,
   DEFAULT,
   differenceFromDatesInSeconds,
   differenceFromNowInSeconds,
   formatBytes,
-  isValidWsExportTarget,
   textMatch,
 } from 'src/libs/utils';
 
@@ -44,116 +42,6 @@ describe('differenceFromDatesInSeconds', () => {
     expect(differenceFromDatesInSeconds(startDate, threeSecondsLater)).toBe(3);
     expect(differenceFromDatesInSeconds(startDate, oneMinuteLater)).toBe(60);
     expect(differenceFromDatesInSeconds(startDate, twoDaysLater)).toBe(172800);
-  });
-});
-
-describe('isValidWsExportTarget', () => {
-  it('Returns true because source and dest workspaces are the same', () => {
-    // Arrange
-    const sourceWs = {
-      ...defaultGoogleWorkspace,
-      workspace: {
-        ...defaultGoogleWorkspace,
-        authorizationDomain: [{}],
-      },
-    };
-
-    const destWs = {
-      ...defaultGoogleWorkspace,
-      workspace: {
-        ...defaultGoogleWorkspace.workspace,
-        workspaceId: 'test-different-workspace-id',
-        authorizationDomain: [{}],
-      },
-    };
-
-    // Act
-    const result = isValidWsExportTarget(sourceWs, destWs);
-
-    // Assert
-    expect(result).toBe(true);
-  });
-
-  it('Returns false match because source and dest workspaces are the same', () => {
-    // Arrange
-    const sourceWs = defaultGoogleWorkspace;
-    const destWs = defaultGoogleWorkspace;
-
-    // Act
-    const result = isValidWsExportTarget(sourceWs, destWs);
-
-    // Assert
-    expect(result).toBe(false);
-  });
-
-  it('Returns false because AccessLevel does not contain Writer', () => {
-    // Arrange
-    const sourceWs = defaultGoogleWorkspace;
-    const destWs = {
-      ...defaultGoogleWorkspace,
-      accessLevel: 'READER',
-      workspace: {
-        ...defaultGoogleWorkspace.workspace,
-        workspaceId: 'test-different-workspace-id',
-      },
-    };
-
-    // Act
-    const result = isValidWsExportTarget(sourceWs, destWs);
-
-    // Assert
-    expect(result).toBe(false);
-  });
-
-  it('Returns false because source and destination cloud platforms are not the same.', () => {
-    // Arrange
-    const sourceWs = {
-      ...defaultGoogleWorkspace,
-      workspace: {
-        ...defaultGoogleWorkspace.workspace,
-        authorizationDomain: [{}],
-      },
-    };
-
-    const destWs = {
-      ...defaultAzureWorkspace,
-      workspace: {
-        ...defaultAzureWorkspace.workspace,
-        authorizationDomain: [{}],
-      },
-    };
-
-    // Act
-    const result = isValidWsExportTarget(sourceWs, destWs);
-
-    // Assert
-    expect(result).toBe(false);
-  });
-
-  it('Returns false because source and destination cloud platforms are not the same.', () => {
-    // Arrange
-    const sourceWs = {
-      ...defaultGoogleWorkspace,
-      workspace: {
-        ...defaultGoogleWorkspace.workspace,
-        authorizationDomain: [{}],
-      },
-    };
-
-    const destWs = {
-      ...defaultGoogleWorkspace,
-      workspace: {
-        ...defaultGoogleWorkspace.workspace,
-        authorizationDomain: [{ membersGroupName: 'wooo' }],
-        workspaceId: 'test-different-workspace-id',
-      },
-    };
-
-    // Act
-    const result = isValidWsExportTarget(sourceWs, destWs);
-
-    // Assert
-    expect(result).toBe(false);
   });
 });
 

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -7,7 +7,7 @@ import { AnyPromiseFn, GenericPromiseFn } from 'src/libs/type-utils/general-type
 import { safeCurry } from 'src/libs/type-utils/lodash-fp-helpers';
 import { v4 as uuid } from 'uuid';
 
-import { getCloudProviderFromWorkspace, hasAccessLevel } from './workspace-utils';
+import { hasAccessLevel } from './workspace-utils';
 
 export interface Subscribable<T extends any[]> {
   subscribe: (fn: (...args: T) => void) => { unsubscribe: () => void };
@@ -317,25 +317,6 @@ export const normalizeLabel = _.flow(_.camelCase, _.startCase);
 
 // TODO: add good typing (remove any's) - ticket: https://broadworkbench.atlassian.net/browse/UIE-67
 export const kvArrayToObject = _.reduce((acc, { key, value }) => _.set(key, value, acc) as any, {});
-
-export const isValidWsExportTarget = _.curry((sourceWs, destWs) => {
-  const {
-    workspace: { workspaceId: sourceId, authorizationDomain: sourceAD },
-  } = sourceWs;
-  const {
-    accessLevel,
-    workspace: { workspaceId: destId, authorizationDomain: destAD },
-  } = destWs;
-  const sourceWsCloudPlatform = getCloudProviderFromWorkspace(sourceWs);
-  const destWsCloudPlatform = getCloudProviderFromWorkspace(destWs);
-
-  return (
-    sourceId !== destId &&
-    canWrite(accessLevel) &&
-    _.intersectionWith(_.isEqual, sourceAD, destAD).length === sourceAD.length &&
-    sourceWsCloudPlatform === destWsCloudPlatform
-  );
-});
 
 export const append = _.curry((value, arr) => _.concat(arr, [value]));
 

--- a/src/libs/workspace-utils.test.ts
+++ b/src/libs/workspace-utils.test.ts
@@ -1,0 +1,113 @@
+import { defaultAzureWorkspace, defaultGoogleWorkspace } from 'src/analysis/_testData/testData';
+
+import { isValidWsExportTarget } from './workspace-utils';
+
+describe('isValidWsExportTarget', () => {
+  it('Returns true because source and dest workspaces are the same', () => {
+    // Arrange
+    const sourceWs = {
+      ...defaultGoogleWorkspace,
+      workspace: {
+        ...defaultGoogleWorkspace,
+        authorizationDomain: [{}],
+      },
+    };
+
+    const destWs = {
+      ...defaultGoogleWorkspace,
+      workspace: {
+        ...defaultGoogleWorkspace.workspace,
+        workspaceId: 'test-different-workspace-id',
+        authorizationDomain: [{}],
+      },
+    };
+
+    // Act
+    const result = isValidWsExportTarget(sourceWs, destWs);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  it('Returns false match because source and dest workspaces are the same', () => {
+    // Arrange
+    const sourceWs = defaultGoogleWorkspace;
+    const destWs = defaultGoogleWorkspace;
+
+    // Act
+    const result = isValidWsExportTarget(sourceWs, destWs);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it('Returns false because AccessLevel does not contain Writer', () => {
+    // Arrange
+    const sourceWs = defaultGoogleWorkspace;
+    const destWs = {
+      ...defaultGoogleWorkspace,
+      accessLevel: 'READER',
+      workspace: {
+        ...defaultGoogleWorkspace.workspace,
+        workspaceId: 'test-different-workspace-id',
+      },
+    };
+
+    // Act
+    const result = isValidWsExportTarget(sourceWs, destWs);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it('Returns false because source and destination cloud platforms are not the same.', () => {
+    // Arrange
+    const sourceWs = {
+      ...defaultGoogleWorkspace,
+      workspace: {
+        ...defaultGoogleWorkspace.workspace,
+        authorizationDomain: [{}],
+      },
+    };
+
+    const destWs = {
+      ...defaultAzureWorkspace,
+      workspace: {
+        ...defaultAzureWorkspace.workspace,
+        authorizationDomain: [{}],
+      },
+    };
+
+    // Act
+    const result = isValidWsExportTarget(sourceWs, destWs);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it('Returns false because source and destination cloud platforms are not the same.', () => {
+    // Arrange
+    const sourceWs = {
+      ...defaultGoogleWorkspace,
+      workspace: {
+        ...defaultGoogleWorkspace.workspace,
+        authorizationDomain: [{}],
+      },
+    };
+
+    const destWs = {
+      ...defaultGoogleWorkspace,
+      workspace: {
+        ...defaultGoogleWorkspace.workspace,
+        authorizationDomain: [{ membersGroupName: 'wooo' }],
+        workspaceId: 'test-different-workspace-id',
+      },
+    };
+
+    // Act
+    const result = isValidWsExportTarget(sourceWs, destWs);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+});


### PR DESCRIPTION
Move `isValidWsExportTarget` from utils to workspace-utils.

Because utils is depended on by so many modules, having it import from higher level modules results in import loops that cause problems in tests. For example, I cannot add anything that uses Ajax to libs/workspace-utils because Ajax imports from utils imports from workspace-utils.

This starts to resolve those loops by moving `isValidWsExportTarget` out of utils, which allows us to avoid having utils import `getCloudProviderFromWorkspace` from workspace-utils.