### PR TITLE
[AJ-1191] Support TDR URLs for IGV

### DIFF
--- a/src/components/IGVFileSelector.js
+++ b/src/components/IGVFileSelector.js
@@ -30,7 +30,7 @@ const isTdrUrl = (fileUrl) => {
   const bucket = parts[0];
   const datasetId = parts[1];
   const fileRefId = parts[2];
-  return /datarepo-[a-f0-9]+-bucket/.test(bucket) && isUUID(datasetId) && isUUID(fileRefId);
+  return /datarepo(-(dev|alpha|perf|staging|tools))?-[a-f0-9]+-bucket/.test(bucket) && isUUID(datasetId) && isUUID(fileRefId);
 };
 
 const findIndexForFile = (fileUrl, fileUrls) => {

--- a/src/components/IGVFileSelector.js
+++ b/src/components/IGVFileSelector.js
@@ -4,7 +4,6 @@ import { div, h } from 'react-hyperscript-helpers';
 import { AutoSizer, List } from 'react-virtualized';
 import ButtonBar from 'src/components/ButtonBar';
 import { ButtonPrimary, LabeledCheckbox, Link } from 'src/components/common';
-import { parseGsUri } from 'src/components/data/data-utils';
 import IGVReferenceSelector, { addIgvRecentlyUsedReference, defaultIgvReference } from 'src/components/IGVReferenceSelector';
 import * as Style from 'src/libs/style';
 import * as Utils from 'src/libs/utils';
@@ -13,27 +12,58 @@ const getStrings = (v) => {
   return Utils.cond([_.isString(v), () => [v]], [!!v?.items, () => _.flatMap(getStrings, v.items)], () => []);
 };
 
+const splitExtension = (fileUrl) => {
+  const extensionDelimiterIndex = fileUrl.lastIndexOf('.');
+  const base = fileUrl.slice(0, extensionDelimiterIndex);
+  const extension = fileUrl.slice(extensionDelimiterIndex + 1);
+  return [base, extension];
+};
+
+const findIndexForFile = (fileUrl, fileUrls) => {
+  const [base, extension] = splitExtension(fileUrl);
+
+  const indexCandidates = {
+    cram: [`${base}.crai`, `${base}.cram.crai`],
+    bam: [`${base}.bai`, `${base}.bam.bai`],
+    vcf: [`${base}.idx`, `${base}.vcf.idx`, `${base}.tbi`, `${base}.vcf.tbi`],
+  }[extension];
+
+  if (!indexCandidates) {
+    return undefined;
+  }
+
+  return fileUrls.find((url) => indexCandidates.includes(url));
+};
+
 export const getValidIgvFiles = (values) => {
-  return _.flatMap((value) => {
-    const possibleFile = /(.+)\.([^.]+)$/.exec(value);
+  const relevantFileTypes = ['bam', 'bai', 'cram', 'crai', 'vcf', 'idx', 'tbi', 'bed'];
+  const fileUrls = values.filter((value) => {
+    let url;
+    try {
+      // Filter to values containing URLs.
+      url = new URL(value);
 
-    if (_.isEmpty(parseGsUri(value)) || !possibleFile) {
-      return [];
+      // Filter to GCS URLs (IGV.js supports GCS URLs).
+      if (url.protocol !== 'gs:') {
+        return false;
+      }
+
+      // Filter to URLs that point to a file with one of the relevant extensions.
+      const basename = url.pathname.split('/').at(-1);
+      const [base, extension] = basename.split('.');
+      return !!base && relevantFileTypes.includes(extension);
+    } catch (err) {
+      return false;
     }
+  });
 
-    const [, base, extension] = possibleFile;
-
-    const matchingIndexFilePath = Utils.switchCase(
-      extension,
-      ['cram', () => _.find((v) => _.includes(v, [`${base}.crai`, `${base}.cram.crai`]), values)],
-      ['bam', () => _.find((v) => _.includes(v, [`${base}.bai`, `${base}.bam.bai`]), values)],
-      ['vcf', () => _.find((v) => _.includes(v, [`${base}.idx`, `${base}.vcf.idx`, `${base}.tbi`, `${base}.vcf.tbi`]), values)],
-      ['bed', () => false],
-      [Utils.DEFAULT, () => undefined]
-    );
-
-    return matchingIndexFilePath !== undefined ? [{ filePath: value, indexFilePath: matchingIndexFilePath }] : [];
-  }, values);
+  return fileUrls.flatMap((fileUrl) => {
+    if (fileUrl.endsWith('.bed')) {
+      return [{ filePath: fileUrl, indexFilePath: false }];
+    }
+    const indexFileUrl = findIndexForFile(fileUrl, fileUrls);
+    return indexFileUrl !== undefined ? [{ filePath: fileUrl, indexFilePath: indexFileUrl }] : [];
+  });
 };
 
 export const getValidIgvFilesFromAttributeValues = (attributeValues) => {

--- a/src/components/IGVFileSelector.js
+++ b/src/components/IGVFileSelector.js
@@ -19,14 +19,15 @@ const splitExtension = (fileUrl) => {
   return [base, extension];
 };
 
+const UUID_PATTERN = '[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}';
+
+const UUID_REGEX = new RegExp(UUID_PATTERN);
+
+const isUUID = (s) => UUID_REGEX.test(s);
+
 const isTdrUrl = (fileUrl) => {
   const parts = fileUrl.split('/');
-  return (
-    parts.length === 6 &&
-    /datarepo-[a-f0-9]+-bucket/.test(parts[2]) &&
-    /[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/.test(parts[3]) &&
-    /[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/.test(parts[4])
-  );
+  return parts.length === 6 && /datarepo-[a-f0-9]+-bucket/.test(parts[2]) && isUUID(parts[3]) && isUUID(parts[4]);
 };
 
 const findIndexForFile = (fileUrl, fileUrls) => {
@@ -42,9 +43,7 @@ const findIndexForFile = (fileUrl, fileUrls) => {
       cram: [`${base}.crai`, `${base}.cram.crai`],
       bam: [`${base}.bai`, `${base}.bam.bai`],
       vcf: [`${base}.idx`, `${base}.vcf.idx`, `${base}.tbi`, `${base}.vcf.tbi`],
-    }[extension].map(
-      (candidate) => new RegExp(`gs://${bucket}/${datasetId}/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/${candidate}`)
-    );
+    }[extension].map((candidate) => new RegExp(`gs://${bucket}/${datasetId}/${UUID_PATTERN}/${candidate}`));
     return fileUrls.find((url) => indexCandidates.some((candidate) => candidate.test(url)));
   }
   const [base, extension] = splitExtension(fileUrl);

--- a/src/components/IGVFileSelector.test.js
+++ b/src/components/IGVFileSelector.test.js
@@ -123,6 +123,20 @@ describe('getValidIgvFiles', () => {
         },
       ]);
     });
+
+    it('allows TDR URLs from non-production environments', () => {
+      expect(
+        getValidIgvFiles([
+          'gs://datarepo-dev-ab123456-bucket/cae37a2a-657f-4b04-9fef-59c215020078/5f5f634d-70f3-4914-9c71-9d14c7f98e60/test.bam',
+          'gs://datarepo-dev-ab123456-bucket/cae37a2a-657f-4b04-9fef-59c215020078/2eeff61f-ae9e-41ae-bb40-909ff6bdfba8/test.bam.bai',
+        ])
+      ).toEqual([
+        {
+          filePath: 'gs://datarepo-dev-ab123456-bucket/cae37a2a-657f-4b04-9fef-59c215020078/5f5f634d-70f3-4914-9c71-9d14c7f98e60/test.bam',
+          indexFilePath: 'gs://datarepo-dev-ab123456-bucket/cae37a2a-657f-4b04-9fef-59c215020078/2eeff61f-ae9e-41ae-bb40-909ff6bdfba8/test.bam.bai',
+        },
+      ]);
+    });
   });
 });
 

--- a/src/components/IGVFileSelector.test.js
+++ b/src/components/IGVFileSelector.test.js
@@ -94,18 +94,35 @@ describe('getValidIgvFiles', () => {
     ]);
   });
 
-  it('allows TDR URLs', () => {
-    expect(
-      getValidIgvFiles([
-        'gs://datarepo-ab123456-bucket/cae37a2a-657f-4b04-9fef-59c215020078/5f5f634d-70f3-4914-9c71-9d14c7f98e60/test.bam',
-        'gs://datarepo-ab123456-bucket/cae37a2a-657f-4b04-9fef-59c215020078/2eeff61f-ae9e-41ae-bb40-909ff6bdfba8/test.bam.bai',
-      ])
-    ).toEqual([
-      {
-        filePath: 'gs://datarepo-ab123456-bucket/cae37a2a-657f-4b04-9fef-59c215020078/5f5f634d-70f3-4914-9c71-9d14c7f98e60/test.bam',
-        indexFilePath: 'gs://datarepo-ab123456-bucket/cae37a2a-657f-4b04-9fef-59c215020078/2eeff61f-ae9e-41ae-bb40-909ff6bdfba8/test.bam.bai',
-      },
-    ]);
+  describe('TDR URLs', () => {
+    it('allows TDR URLs', () => {
+      expect(
+        getValidIgvFiles([
+          'gs://datarepo-ab123456-bucket/cae37a2a-657f-4b04-9fef-59c215020078/5f5f634d-70f3-4914-9c71-9d14c7f98e60/test.bam',
+          'gs://datarepo-ab123456-bucket/cae37a2a-657f-4b04-9fef-59c215020078/2eeff61f-ae9e-41ae-bb40-909ff6bdfba8/test.bam.bai',
+        ])
+      ).toEqual([
+        {
+          filePath: 'gs://datarepo-ab123456-bucket/cae37a2a-657f-4b04-9fef-59c215020078/5f5f634d-70f3-4914-9c71-9d14c7f98e60/test.bam',
+          indexFilePath: 'gs://datarepo-ab123456-bucket/cae37a2a-657f-4b04-9fef-59c215020078/2eeff61f-ae9e-41ae-bb40-909ff6bdfba8/test.bam.bai',
+        },
+      ]);
+    });
+
+    it('allows TDR URLs with additional path segments', () => {
+      expect(
+        getValidIgvFiles([
+          'gs://datarepo-ab123456-bucket/cae37a2a-657f-4b04-9fef-59c215020078/5f5f634d-70f3-4914-9c71-9d14c7f98e60/path/to/test.bam',
+          'gs://datarepo-ab123456-bucket/cae37a2a-657f-4b04-9fef-59c215020078/2eeff61f-ae9e-41ae-bb40-909ff6bdfba8/path/to/test.bam.bai',
+        ])
+      ).toEqual([
+        {
+          filePath: 'gs://datarepo-ab123456-bucket/cae37a2a-657f-4b04-9fef-59c215020078/5f5f634d-70f3-4914-9c71-9d14c7f98e60/path/to/test.bam',
+          indexFilePath:
+            'gs://datarepo-ab123456-bucket/cae37a2a-657f-4b04-9fef-59c215020078/2eeff61f-ae9e-41ae-bb40-909ff6bdfba8/path/to/test.bam.bai',
+        },
+      ]);
+    });
   });
 });
 

--- a/src/components/IGVFileSelector.test.js
+++ b/src/components/IGVFileSelector.test.js
@@ -86,10 +86,24 @@ describe('getValidIgvFiles', () => {
   });
 
   it('requires GCS URLs', () => {
-    expect(getValidIgvFiles(['gs://bucket/test.bed', 'test.bed'])).toEqual([
+    expect(getValidIgvFiles(['gs://bucket/test.bed', 'https://example.com/test.bed', 'test.bed'])).toEqual([
       {
         filePath: 'gs://bucket/test.bed',
         indexFilePath: false,
+      },
+    ]);
+  });
+
+  it('allows TDR URLs', () => {
+    expect(
+      getValidIgvFiles([
+        'gs://datarepo-ab123456-bucket/cae37a2a-657f-4b04-9fef-59c215020078/5f5f634d-70f3-4914-9c71-9d14c7f98e60/test.bam',
+        'gs://datarepo-ab123456-bucket/cae37a2a-657f-4b04-9fef-59c215020078/2eeff61f-ae9e-41ae-bb40-909ff6bdfba8/test.bam.bai',
+      ])
+    ).toEqual([
+      {
+        filePath: 'gs://datarepo-ab123456-bucket/cae37a2a-657f-4b04-9fef-59c215020078/5f5f634d-70f3-4914-9c71-9d14c7f98e60/test.bam',
+        indexFilePath: 'gs://datarepo-ab123456-bucket/cae37a2a-657f-4b04-9fef-59c215020078/2eeff61f-ae9e-41ae-bb40-909ff6bdfba8/test.bam.bai',
       },
     ]);
   });


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1191

In order to display some types of files (CRAMs, BAMs, and VCFs), IGV requires an index file.

Currently, IGV takes all the string values in a data table and matches index URLs to file URLs based on a few patterns. For example, for a BAM file `gs://my-bucket/path/to/file.bam`, IGV looks for `gs://my-bucket/path/to/file.bai` or `gs://my-bucket/path/to/file.bam.bai`.

This breaks down for URLs to files in TDR. Those URLs follow a pattern `gs://datarepo-<projectId>-bucket>/<datasetId>/<fileRefId>/<object>`. The index files have a different `fileRefId` than the file they match with, so IGV doesn't find them.

This updates IGV to support TDR URLs by ignoring the `fileRefId` for those URLs.

I'll suggest reviewing the two commits one at a time. The first refactors the existing code for finding valid files for IGV. The second adds support for TDR URLs.

## Testing

Add the CRAM and CRAI URLs from the ticket to a data table, select the relevant rows, open with IGV, and see if the CRAM file appears as an option in the sidebar.