### PR TITLE
[SU-345] Store content type for files in file browser

### DIFF
--- a/src/components/file-browser/DeleteFilesConfirmationModal.test.ts
+++ b/src/components/file-browser/DeleteFilesConfirmationModal.test.ts
@@ -11,6 +11,7 @@ describe('DeleteFilesConfirmationModal', () => {
           {
             path: 'path/to/file1.txt',
             url: 'gs://test-bucket/path/to/file1.txt',
+            contentType: 'text/plain',
             size: 1024,
             createdAt: 1667408400000,
             updatedAt: 1667408400000,
@@ -18,6 +19,7 @@ describe('DeleteFilesConfirmationModal', () => {
           {
             path: 'path/to/file2.bam',
             url: 'gs://test-bucket/path/to/file2.bam',
+            contentType: 'application/octet-stream',
             size: 1024 ** 2,
             createdAt: 1667410200000,
             updatedAt: 1667410200000,
@@ -25,6 +27,7 @@ describe('DeleteFilesConfirmationModal', () => {
           {
             path: 'path/to/file3.vcf',
             url: 'gs://test-bucket/path/to/file3.vcf',
+            contentType: 'application/octet-stream',
             size: 1024 ** 3,
             createdAt: 1667412000000,
             updatedAt: 1667412000000,

--- a/src/components/file-browser/DownloadFileCommand.test.ts
+++ b/src/components/file-browser/DownloadFileCommand.test.ts
@@ -16,6 +16,7 @@ describe('DownloadFileComamnd', () => {
   const file: FileBrowserFile = {
     path: 'path/to/example.txt',
     url: 'gs://test-bucket/path/to/example.txt',
+    contentType: 'text/plain',
     size: 1024 ** 2,
     createdAt: 1667408400000,
     updatedAt: 1667494800000,

--- a/src/components/file-browser/DownloadFileLink.test.ts
+++ b/src/components/file-browser/DownloadFileLink.test.ts
@@ -16,6 +16,7 @@ describe('DownloadFileLink', () => {
   const file: FileBrowserFile = {
     path: 'path/to/example.txt',
     url: 'gs://test-bucket/path/to/example.txt',
+    contentType: 'text/plain',
     size: 1024 ** 2,
     createdAt: 1667408400000,
     updatedAt: 1667494800000,

--- a/src/components/file-browser/FileBrowser.test.ts
+++ b/src/components/file-browser/FileBrowser.test.ts
@@ -41,6 +41,7 @@ describe('FileBrowser', () => {
       {
         path: 'file.txt',
         url: 'gs://test-bucket/file.txt',
+        contentType: 'text/plain',
         size: 1024,
         createdAt: 1667408400000,
         updatedAt: 1667408400000,
@@ -77,6 +78,7 @@ describe('FileBrowser', () => {
           {
             path: 'file.txt',
             url: 'gs://test-bucket/file.txt',
+            contentType: 'text/plain',
             size: 1024,
             createdAt: 1667408400000,
             updatedAt: 1667408400000,

--- a/src/components/file-browser/FileDetails.test.ts
+++ b/src/components/file-browser/FileDetails.test.ts
@@ -26,6 +26,7 @@ describe('FileDetails', () => {
   const file: FileBrowserFile = {
     path: 'path/to/example.txt',
     url: 'gs://test-bucket/path/to/example.txt',
+    contentType: 'text/plain',
     size: 1024 ** 2,
     createdAt: 1667408400000,
     updatedAt: 1667494800000,

--- a/src/components/file-browser/FilesInDirectory.test.ts
+++ b/src/components/file-browser/FilesInDirectory.test.ts
@@ -74,6 +74,7 @@ describe('FilesInDirectory', () => {
       {
         path: 'path/to/file.txt',
         url: 'gs://test-bucket/path/to/file.txt',
+        contentType: 'text/plain',
         size: 1024,
         createdAt: 1667408400000,
         updatedAt: 1667408400000,
@@ -189,6 +190,7 @@ describe('FilesInDirectory', () => {
       {
         path: 'path/to/file.txt',
         url: 'gs://test-bucket/path/to/file.txt',
+        contentType: 'text/plain',
         size: 1024,
         createdAt: 1667408400000,
         updatedAt: 1667408400000,

--- a/src/components/file-browser/FilesMenu.test.ts
+++ b/src/components/file-browser/FilesMenu.test.ts
@@ -19,6 +19,7 @@ describe('FilesMenu', () => {
       'path/to/file1.txt': {
         path: 'path/to/file1.txt',
         url: 'gs://test-bucket/path/to/file1.txt',
+        contentType: 'text/plain',
         size: 1024,
         createdAt: 1667408400000,
         updatedAt: 1667408400000,
@@ -26,6 +27,7 @@ describe('FilesMenu', () => {
       'path/to/file2.bam': {
         path: 'path/to/file2.bam',
         url: 'gs://test-bucket/path/to/file2.bam',
+        contentType: 'application/octet-stream',
         size: 1024 ** 2,
         createdAt: 1667410200000,
         updatedAt: 1667410200000,
@@ -33,6 +35,7 @@ describe('FilesMenu', () => {
       'path/to/file3.vcf': {
         path: 'path/to/file3.vcf',
         url: 'gs://test-bucket/path/to/file3.vcf',
+        contentType: 'application/octet-stream',
         size: 1024 ** 3,
         createdAt: 1667412000000,
         updatedAt: 1667412000000,

--- a/src/components/file-browser/FilesTable.test.ts
+++ b/src/components/file-browser/FilesTable.test.ts
@@ -18,6 +18,7 @@ describe('FilesTable', () => {
     {
       path: 'path/to/file1.txt',
       url: 'gs://test-bucket/path/to/file1.txt',
+      contentType: 'text/plain',
       size: 1024,
       createdAt: 1667408400000,
       updatedAt: 1667408400000,
@@ -25,6 +26,7 @@ describe('FilesTable', () => {
     {
       path: 'path/to/file2.bam',
       url: 'gs://test-bucket/path/to/file2.bam',
+      contentType: 'application/octet-stream',
       size: 1024 ** 2,
       createdAt: 1667410200000,
       updatedAt: 1667410200000,
@@ -32,6 +34,7 @@ describe('FilesTable', () => {
     {
       path: 'path/to/file3.vcf',
       url: 'gs://test-bucket/path/to/file3.vcf',
+      contentType: 'application/octet-stream',
       size: 1024 ** 3,
       createdAt: 1667412000000,
       updatedAt: 1667412000000,
@@ -112,6 +115,7 @@ describe('FilesTable', () => {
       {
         path: 'path/to/file1.txt',
         url: 'gs://test-bucket/path/to/file1.txt',
+        contentType: 'text/plain',
         size: 1024,
         createdAt: 1667408400000,
         updatedAt: 1667408400000,
@@ -119,6 +123,7 @@ describe('FilesTable', () => {
       {
         path: 'path/to/file2.bam',
         url: 'gs://test-bucket/path/to/file2.bam',
+        contentType: 'application/octet-stream',
         size: 1024 ** 2,
         createdAt: 1667410200000,
         updatedAt: 1667410200000,

--- a/src/components/file-browser/useFileDownloadCommand.test.ts
+++ b/src/components/file-browser/useFileDownloadCommand.test.ts
@@ -27,6 +27,7 @@ describe('useFileDownloadCommand', () => {
     const file: FileBrowserFile = {
       path: 'path/to/example.txt',
       url: 'gs://test-bucket/path/to/example.txt',
+      contentType: 'text/plain',
       size: 1024 ** 2,
       createdAt: 1667408400000,
       updatedAt: 1667494800000,
@@ -48,6 +49,7 @@ describe('useFileDownloadCommand', () => {
     const file: FileBrowserFile = {
       path: 'path/to/example.txt',
       url: 'gs://test-bucket/path/to/example.txt',
+      contentType: 'text/plain',
       size: 1024 ** 2,
       createdAt: 1667408400000,
       updatedAt: 1667494800000,

--- a/src/components/file-browser/useFileDownloadUrl.test.ts
+++ b/src/components/file-browser/useFileDownloadUrl.test.ts
@@ -24,6 +24,7 @@ describe('useFileDownloadUrl', () => {
   const file: FileBrowserFile = {
     path: 'path/to/example.txt',
     url: 'gs://test-bucket/path/to/example.txt',
+    contentType: 'text/plain',
     size: 1024 ** 2,
     createdAt: 1667408400000,
     updatedAt: 1667494800000,

--- a/src/libs/ajax/GoogleStorage.ts
+++ b/src/libs/ajax/GoogleStorage.ts
@@ -101,6 +101,7 @@ export type GCSMetadata = { [key: string]: string };
 // https://cloud.google.com/storage/docs/json_api/v1/objects/list
 export type GCSItem = {
   bucket: string;
+  contentType?: string;
   crc32c: string;
   etag: string;
   generation: string;

--- a/src/libs/ajax/file-browser-providers/AzureBlobStorageFileBrowserProvider.test.ts
+++ b/src/libs/ajax/file-browser-providers/AzureBlobStorageFileBrowserProvider.test.ts
@@ -64,6 +64,7 @@ const blobPrefixXml = (name: string): string => {
 const expectedFile = (path: string): FileBrowserFile => ({
   path,
   url: `https://terra-ui-test.blob.core.windows.net/test-storage-container/${path}`,
+  contentType: 'text/plain',
   size: 1,
   createdAt: 1670455500000,
   updatedAt: 1670455800000,

--- a/src/libs/ajax/file-browser-providers/AzureBlobStorageFileBrowserProvider.ts
+++ b/src/libs/ajax/file-browser-providers/AzureBlobStorageFileBrowserProvider.ts
@@ -123,6 +123,7 @@ const AzureBlobStorageFileBrowserProvider = ({
           const creationTime = blobProperties.getElementsByTagName('Creation-Time').item(0)!.textContent!;
           const lastModified = blobProperties.getElementsByTagName('Last-Modified').item(0)!.textContent!;
           const contentLength = blobProperties.getElementsByTagName('Content-Length').item(0)!.textContent!;
+          const contentType = blobProperties.getElementsByTagName('Content-Type').item(0)!.textContent!;
 
           const blobUrl = new URL(sasUrl);
           blobUrl.pathname += `/${name}`;
@@ -131,6 +132,7 @@ const AzureBlobStorageFileBrowserProvider = ({
           return {
             path: name,
             url: blobUrl.href,
+            contentType,
             size: parseInt(contentLength),
             createdAt: new Date(creationTime).getTime(),
             updatedAt: new Date(lastModified).getTime(),

--- a/src/libs/ajax/file-browser-providers/FileBrowserProvider.ts
+++ b/src/libs/ajax/file-browser-providers/FileBrowserProvider.ts
@@ -3,6 +3,7 @@ import IncrementalResponse from 'src/libs/ajax/incremental-response/IncrementalR
 export interface FileBrowserFile {
   path: string;
   url: string;
+  contentType: string;
   size: number;
   createdAt: number;
   updatedAt: number;

--- a/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.test.ts
+++ b/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.test.ts
@@ -9,6 +9,7 @@ jest.mock('src/libs/ajax');
 
 const gcsObject = (name: string): GCSItem => ({
   bucket: 'test-bucket',
+  contentType: 'text/plain',
   crc32c: 'crc32c',
   etag: 'etag',
   generation: '1666792590000000',
@@ -29,6 +30,7 @@ const gcsObject = (name: string): GCSItem => ({
 const expectedFile = (path: string): FileBrowserFile => ({
   path,
   url: `gs://test-bucket/${path}`,
+  contentType: 'text/plain',
   size: 1,
   createdAt: 1666792590000,
   updatedAt: 1666792590000,

--- a/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.ts
+++ b/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.ts
@@ -109,6 +109,9 @@ const GCSFileBrowserProvider = ({
         mapItemOrPrefix: (item) => ({
           path: item.name,
           url: `gs://${item.bucket}/${item.name}`,
+          // If an object is stored without a Content-Type, it is served as application/octet-stream.
+          // https://cloud.google.com/storage/docs/json_api/v1/objects#resource-representations
+          contentType: item.contentType || 'application/octet-stream',
           size: parseInt(item.size),
           createdAt: new Date(item.timeCreated).getTime(),
           updatedAt: new Date(item.updated).getTime(),


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/SU-345

In preparation for previewing files in the file browser, this stores the content type header from the list files request.

We need the content type in order to determine if the file can be previewed (binary files cannot) and how to display it if it can (image vs text, etc.).

Most of this PR is updating test data.