### PR TITLE
[WM-2073] launch workflow app component

### DIFF
--- a/src/workflows-app/SubmitWorkflow.js
+++ b/src/workflows-app/SubmitWorkflow.js
@@ -1,15 +1,19 @@
-import { Fragment, useCallback, useState } from 'react';
+import { Fragment, useCallback, useEffect, useState } from 'react';
 import { div, h, h2 } from 'react-hyperscript-helpers';
-import { ButtonOutline, Clickable } from 'src/components/common';
+import { getCurrentApp, getIsAppBusy } from 'src/analysis/utils/app-utils';
+import { appToolLabels, appTools } from 'src/analysis/utils/tool-utils';
+import { ButtonOutline, ButtonPrimary, Clickable } from 'src/components/common';
 import { centeredSpinner, icon } from 'src/components/icons';
+import TitleBar from 'src/components/TitleBar';
 import { Ajax } from 'src/libs/ajax';
 import colors from 'src/libs/colors';
+import Events, { extractWorkspaceDetails } from 'src/libs/events';
 import * as Nav from 'src/libs/nav';
 import { notify } from 'src/libs/notifications';
 import { useCancellation, useOnMount, usePollingEffect } from 'src/libs/react-utils';
 import { AppProxyUrlStatus, workflowsAppStore } from 'src/libs/state';
 import * as Style from 'src/libs/style';
-import { withBusyState } from 'src/libs/utils';
+import * as Utils from 'src/libs/utils';
 import FindWorkflowModal from 'src/workflows-app/components/FindWorkflowModal';
 import { SavedWorkflows } from 'src/workflows-app/components/SavedWorkflows';
 import { doesAppProxyUrlExist, loadAppUrls } from 'src/workflows-app/utils/app-utils';
@@ -38,11 +42,13 @@ export const SubmitWorkflow = wrapWorkflowsPage({ name: 'SubmitWorkflow' })(
       workspace: {
         workspace: { workspaceId },
       },
+      analysesData: { apps, refreshApps },
     },
     _ref
   ) => {
     const [methodsData, setMethodsData] = useState();
     const [loading, setLoading] = useState(false);
+    const [appCreating, setAppCreating] = useState(false);
     const [viewFindWorkflowModal, setViewFindWorkflowModal] = useState(false);
 
     const signal = useCancellation();
@@ -69,6 +75,12 @@ export const SubmitWorkflow = wrapWorkflowsPage({ name: 'SubmitWorkflow' })(
       [signal, workspaceId]
     );
 
+    useEffect(() => {
+      const app = getCurrentApp(appToolLabels.CROMWELL, apps);
+      setAppCreating(getIsAppBusy(app));
+      refreshApps();
+    }, [apps, refreshApps]);
+
     // poll if we're missing CBAS proxy url and stop polling when we have it
     usePollingEffect(() => !doesAppProxyUrlExist(workspaceId, 'cbasProxyUrlState') && loadRunsData(workflowsAppStore.get().cbasProxyUrlState), {
       ms: CbasPollInterval,
@@ -76,7 +88,7 @@ export const SubmitWorkflow = wrapWorkflowsPage({ name: 'SubmitWorkflow' })(
     });
 
     useOnMount(() => {
-      const load = withBusyState(setLoading, async () => {
+      const load = Utils.withBusyState(setLoading, async () => {
         const { cbasProxyUrlState } = await loadAppUrls(workspaceId, 'cbasProxyUrlState');
 
         if (cbasProxyUrlState.status === AppProxyUrlStatus.Ready) {
@@ -85,49 +97,81 @@ export const SubmitWorkflow = wrapWorkflowsPage({ name: 'SubmitWorkflow' })(
       });
       load();
     });
-
+    const pleaseWaitMessage = 'Workflows App is being created. Please wait.';
     return loading
       ? centeredSpinner()
       : div([
-          div({ style: { margin: '2rem 4rem' } }, [
-            div({ style: { display: 'flex', marginTop: '1rem', justifyContent: 'space-between' } }, [
-              h2(['Submit a workflow']),
-              h(
-                ButtonOutline,
-                {
-                  onClick: () =>
-                    Nav.goToPath('workspace-workflows-app-submission-history', {
-                      name,
-                      namespace,
-                    }),
-                },
-                ['Submission history']
-              ),
-            ]),
-            div(['Run a workflow in Terra using Cromwell engine. Full feature workflow submission coming soon.']),
-            !cbasReady &&
-              div({ style: { marginTop: '2rem' } }, [icon('loadingSpinner'), ' Loading your Workflows app, this may take a few minutes.']),
-            cbasReady &&
-              div({ style: { marginTop: '3rem' } }, [
-                h(
-                  Clickable,
-                  {
-                    'aria-haspopup': 'dialog',
-                    style: {
-                      ...styles.card,
-                      ...styles.shortCard,
-                      color: colors.accent(),
-                      fontSize: 18,
-                      lineHeight: '22px',
-                    },
-                    onClick: () => setViewFindWorkflowModal(true),
-                  },
-                  ['Find a Workflow', icon('plus-circle', { size: 32 })]
-                ),
-                h(Fragment, [h(SavedWorkflows, { workspaceName: name, namespace, methodsData })]),
+          !cbasReady &&
+            div({ style: styles.card }, [
+              h(TitleBar, {
+                id: 'workflow-app-launch-page',
+                title: 'Start the Workflows App to launch workflows',
+                style: { marginBottom: '0.5rem' },
+              }),
+              div(['The Workflows App must be running to launch workflows. Running the Workflows App may incur additional costs.']),
+              div({ style: { display: 'flex', marginTop: '2rem', justifyContent: 'flex-center' } }, [
+                !appCreating && 'Would you like to start the Workflows App?',
+                appCreating && pleaseWaitMessage,
               ]),
-            viewFindWorkflowModal && h(FindWorkflowModal, { name, namespace, workspace, onDismiss: () => setViewFindWorkflowModal(false) }),
-          ]),
+              div({ style: { display: 'flex', marginTop: '2rem', justifyContent: 'flex-end' } }, [
+                h(
+                  ButtonPrimary,
+                  {
+                    disabled: appCreating,
+                    tooltip: appCreating ? pleaseWaitMessage : 'Create Workflows App',
+                    onClick: Utils.withBusyState(setLoading, async () => {
+                      await Ajax(signal).Apps.createAppV2(Utils.generateAppName(), workspace.workspace.workspaceId, appToolLabels.CROMWELL);
+                      await Ajax(signal).Metrics.captureEvent(Events.applicationCreate, {
+                        app: appTools.CROMWELL.label,
+                        ...extractWorkspaceDetails(workspace),
+                      });
+                      setAppCreating(true);
+                    }),
+                  },
+                  ['Create']
+                ),
+              ]),
+            ]),
+          cbasReady &&
+            div({ style: { margin: '2rem 4rem' } }, [
+              div({ style: { display: 'flex', marginTop: '1rem', justifyContent: 'space-between' } }, [
+                h2(['Submit a workflow']),
+                h(
+                  ButtonOutline,
+                  {
+                    onClick: () =>
+                      Nav.goToPath('workspace-workflows-app-submission-history', {
+                        name,
+                        namespace,
+                      }),
+                  },
+                  ['Submission history']
+                ),
+              ]),
+              div(['Run a workflow in Terra using Cromwell engine. Full feature workflow submission coming soon.']),
+              !cbasReady && // probably don't need to check cbasReady here, because it's being checked at the top level now
+                div({ style: { marginTop: '2rem' } }, [icon('loadingSpinner'), ' Loading your Workflows app, this may take a few minutes.']),
+              cbasReady &&
+                div({ style: { marginTop: '3rem' } }, [
+                  h(
+                    Clickable,
+                    {
+                      'aria-haspopup': 'dialog',
+                      style: {
+                        ...styles.card,
+                        ...styles.shortCard,
+                        color: colors.accent(),
+                        fontSize: 18,
+                        lineHeight: '22px',
+                      },
+                      onClick: () => setViewFindWorkflowModal(true),
+                    },
+                    ['Find a Workflow', icon('plus-circle', { size: 32 })]
+                  ),
+                  h(Fragment, [h(SavedWorkflows, { workspaceName: name, namespace, methodsData })]),
+                ]),
+              viewFindWorkflowModal && h(FindWorkflowModal, { name, namespace, workspace, onDismiss: () => setViewFindWorkflowModal(false) }),
+            ]),
         ]);
   }
 );

--- a/src/workflows-app/SubmitWorkflow.js
+++ b/src/workflows-app/SubmitWorkflow.js
@@ -158,27 +158,24 @@ export const SubmitWorkflow = wrapWorkflowsPage({ name: 'SubmitWorkflow' })(
                 ),
               ]),
               div(['Run a workflow in Terra using Cromwell engine. Full feature workflow submission coming soon.']),
-              !cbasReady && // probably don't need to check cbasReady here, because it's being checked at the top level now
-                div({ style: { marginTop: '2rem' } }, [icon('loadingSpinner'), ' Loading your Workflows app, this may take a few minutes.']),
-              cbasReady &&
-                div({ style: { marginTop: '3rem' } }, [
-                  h(
-                    Clickable,
-                    {
-                      'aria-haspopup': 'dialog',
-                      style: {
-                        ...styles.card,
-                        ...styles.shortCard,
-                        color: colors.accent(),
-                        fontSize: 18,
-                        lineHeight: '22px',
-                      },
-                      onClick: () => setViewFindWorkflowModal(true),
+              div({ style: { marginTop: '3rem' } }, [
+                h(
+                  Clickable,
+                  {
+                    'aria-haspopup': 'dialog',
+                    style: {
+                      ...styles.card,
+                      ...styles.shortCard,
+                      color: colors.accent(),
+                      fontSize: 18,
+                      lineHeight: '22px',
                     },
-                    ['Find a Workflow', icon('plus-circle', { size: 32 })]
-                  ),
-                  h(Fragment, [h(SavedWorkflows, { workspaceName: name, namespace, methodsData })]),
-                ]),
+                    onClick: () => setViewFindWorkflowModal(true),
+                  },
+                  ['Find a Workflow', icon('plus-circle', { size: 32 })]
+                ),
+                h(Fragment, [h(SavedWorkflows, { workspaceName: name, namespace, methodsData })]),
+              ]),
               viewFindWorkflowModal && h(FindWorkflowModal, { name, namespace, workspace, onDismiss: () => setViewFindWorkflowModal(false) }),
             ]),
         ]);

--- a/src/workflows-app/SubmitWorkflow.js
+++ b/src/workflows-app/SubmitWorkflow.js
@@ -1,4 +1,4 @@
-import { Fragment, useCallback, useEffect, useState } from 'react';
+import { Fragment, useCallback, useState } from 'react';
 import { div, h, h2 } from 'react-hyperscript-helpers';
 import { getCurrentApp, getIsAppBusy } from 'src/analysis/utils/app-utils';
 import { appToolLabels, appTools } from 'src/analysis/utils/tool-utils';
@@ -94,15 +94,18 @@ export const SubmitWorkflow = wrapWorkflowsPage({ name: 'SubmitWorkflow' })(
       load();
     });
 
-    useEffect(() => {
-      const refresh = async () => {
-        await refreshApps(true);
-      };
-
-      if (!currentApp || getIsAppBusy(currentApp)) {
-        refresh();
+    usePollingEffect(
+      () => {
+        const refresh = async () => await refreshApps(true);
+        if (!currentApp || getIsAppBusy(currentApp)) {
+          refresh();
+        }
+      },
+      {
+        ms: 10000,
+        leading: false,
       }
-    }, [currentApp, refreshApps]);
+    );
 
     const createWorkflowsApp = Utils.withBusyState(setCreating, async () => {
       try {

--- a/src/workflows-app/SubmitWorkflow.js
+++ b/src/workflows-app/SubmitWorkflow.js
@@ -144,24 +144,27 @@ export const SubmitWorkflow = wrapWorkflowsPage({ name: 'SubmitWorkflow' })(
                 ),
               ]),
               div(['Run a workflow in Terra using Cromwell engine. Full feature workflow submission coming soon.']),
-              div({ style: { marginTop: '3rem' } }, [
-                h(
-                  Clickable,
-                  {
-                    'aria-haspopup': 'dialog',
-                    style: {
-                      ...styles.card,
-                      ...styles.shortCard,
-                      color: colors.accent(),
-                      fontSize: 18,
-                      lineHeight: '22px',
+              !cbasReady &&
+                div({ style: { marginTop: '2rem' } }, [icon('loadingSpinner'), ' Loading your Workflows app, this may take a few minutes.']),
+              cbasReady &&
+                div({ style: { marginTop: '3rem' } }, [
+                  h(
+                    Clickable,
+                    {
+                      'aria-haspopup': 'dialog',
+                      style: {
+                        ...styles.card,
+                        ...styles.shortCard,
+                        color: colors.accent(),
+                        fontSize: 18,
+                        lineHeight: '22px',
+                      },
+                      onClick: () => setViewFindWorkflowModal(true),
                     },
-                    onClick: () => setViewFindWorkflowModal(true),
-                  },
-                  ['Find a Workflow', icon('plus-circle', { size: 32 })]
-                ),
-                h(Fragment, [h(SavedWorkflows, { workspaceName: name, namespace, methodsData })]),
-              ]),
+                    ['Find a Workflow', icon('plus-circle', { size: 32 })]
+                  ),
+                  h(Fragment, [h(SavedWorkflows, { workspaceName: name, namespace, methodsData })]),
+                ]),
               viewFindWorkflowModal && h(FindWorkflowModal, { name, namespace, workspace, onDismiss: () => setViewFindWorkflowModal(false) }),
             ]),
         ]);

--- a/src/workflows-app/SubmitWorkflow.js
+++ b/src/workflows-app/SubmitWorkflow.js
@@ -55,6 +55,8 @@ export const SubmitWorkflow = wrapWorkflowsPage({ name: 'SubmitWorkflow' })(
     const signal = useCancellation();
     const cbasReady = doesAppProxyUrlExist(workspaceId, 'cbasProxyUrlState');
     const currentApp = getCurrentApp(appToolLabels.CROMWELL, apps);
+    const pageReady = cbasReady && currentApp && !getIsAppBusy(currentApp);
+    const launcherDisabled = creating || (currentApp && getIsAppBusy(currentApp)) || (currentApp && !pageReady);
 
     const loadRunsData = useCallback(
       async (cbasProxyUrlDetails) => {
@@ -122,9 +124,6 @@ export const SubmitWorkflow = wrapWorkflowsPage({ name: 'SubmitWorkflow' })(
         setCreating(false);
       }
     });
-
-    const pageReady = cbasReady && currentApp && !getIsAppBusy(currentApp);
-    const launcherDisabled = creating || (currentApp && getIsAppBusy(currentApp)) || (currentApp && !pageReady);
 
     return loading
       ? centeredSpinner()

--- a/src/workflows-app/SubmitWorkflow.js
+++ b/src/workflows-app/SubmitWorkflow.js
@@ -120,7 +120,7 @@ export const SubmitWorkflow = wrapWorkflowsPage({ name: 'SubmitWorkflow' })(
       }
     });
 
-    const pageReady = cbasReady || (currentApp && !getIsAppBusy(currentApp));
+    const pageReady = cbasReady && currentApp && !getIsAppBusy(currentApp);
     const launcherDisabled = creating || (currentApp && getIsAppBusy(currentApp)) || (currentApp && !pageReady);
 
     return loading

--- a/src/workflows-app/SubmitWorkflow.js
+++ b/src/workflows-app/SubmitWorkflow.js
@@ -2,7 +2,7 @@ import { Fragment, useCallback, useEffect, useState } from 'react';
 import { div, h, h2 } from 'react-hyperscript-helpers';
 import { getCurrentApp, getIsAppBusy } from 'src/analysis/utils/app-utils';
 import { appToolLabels, appTools } from 'src/analysis/utils/tool-utils';
-import { ButtonOutline, ButtonPrimary, Clickable } from 'src/components/common';
+import { ButtonOutline, ButtonPrimary, Clickable, Link } from 'src/components/common';
 import { centeredSpinner, icon } from 'src/components/icons';
 import TitleBar from 'src/components/TitleBar';
 import { Ajax } from 'src/libs/ajax';
@@ -102,18 +102,18 @@ export const SubmitWorkflow = wrapWorkflowsPage({ name: 'SubmitWorkflow' })(
       ? centeredSpinner()
       : div([
           !cbasReady &&
-            div({ style: styles.card }, [
+            div({ style: { ...styles.card, margin: '2rem 4rem' } }, [
               h(TitleBar, {
                 id: 'workflow-app-launch-page',
-                title: 'Start the Workflows App to launch workflows',
+                title: 'Launch the Workflows App to run workflows',
                 style: { marginBottom: '0.5rem' },
               }),
-              div(['The Workflows App must be running to launch workflows. Running the Workflows App may incur additional costs.']),
+              div(['The Workflows App must be launched in order to explore, view, and submit workflows.']),
               div({ style: { display: 'flex', marginTop: '2rem', justifyContent: 'flex-center' } }, [
-                !appCreating && 'Would you like to start the Workflows App?',
+                !appCreating && 'Would you like to get started?',
                 appCreating && pleaseWaitMessage,
               ]),
-              div({ style: { display: 'flex', marginTop: '2rem', justifyContent: 'flex-end' } }, [
+              div({ style: { display: 'flex', marginTop: '1rem', justifyContent: 'flex-center' } }, [
                 h(
                   ButtonPrimary,
                   {
@@ -128,9 +128,18 @@ export const SubmitWorkflow = wrapWorkflowsPage({ name: 'SubmitWorkflow' })(
                       setAppCreating(true);
                     }),
                   },
-                  ['Create']
+                  ['Yes, launch the Workflows App']
                 ),
               ]),
+              h(
+                Link,
+                {
+                  ...Utils.newTabLinkProps,
+                  href: 'https://support.terra.bio/hc/en-us/articles/360024743371-Working-with-workspaces',
+                  style: { marginTop: '2rem' },
+                },
+                ['Learn more about managing cloud cost']
+              ),
             ]),
           cbasReady &&
             div({ style: { margin: '2rem 4rem' } }, [

--- a/src/workflows-app/components/WorkflowsAppLauncherCard.js
+++ b/src/workflows-app/components/WorkflowsAppLauncherCard.js
@@ -1,5 +1,6 @@
 import { div, h } from 'react-hyperscript-helpers';
 import { ButtonPrimary, Link } from 'src/components/common';
+import { centeredSpinner } from 'src/components/icons';
 import TitleBar from 'src/components/TitleBar';
 import * as Style from 'src/libs/style';
 import * as Utils from 'src/libs/utils';
@@ -19,22 +20,30 @@ export const WorkflowsAppLauncherCard = ({ onClick, disabled, ...props }) => {
       title: 'Launch the Workflows App to run workflows',
       style: { marginBottom: '0.5rem' },
     }),
-    div(['The Workflows App must be launched in order to explore, view, and submit workflows.']),
-    div({ style: { display: 'flex', marginTop: '2rem', justifyContent: 'flex-center' } }, [
-      !disabled && 'Would you like to get started?',
-      disabled &&
-        'Workflows App is being created. This could take several minutes. You may exit this page and return later without interrupting the creation process.',
-    ]),
     div({ style: { display: 'flex', marginTop: '1rem', justifyContent: 'flex-center' } }, [
-      h(
-        ButtonPrimary,
-        {
-          disabled,
-          tooltip: disabled ? 'Workflows App is being created' : 'Create Workflows App',
-          onClick,
-        },
-        ['Yes, launch the Workflows App']
-      ),
+      'The Workflows App must be launched in order to explore, view, and submit workflows.',
+    ]),
+    div({ style: { display: 'flex', marginTop: '.5rem', justifyContent: 'flex-center' } }, [
+      'Once launched, it will stay on until the workspace is deleted.',
+    ]),
+    div({ style: { display: 'flex', marginTop: '2rem', justifyContent: 'flex-center' } }, [
+      disabled
+        ? 'Workflows App is being created. You may exit this page and return later without interrupting the creation process.'
+        : 'Would you like to get started?',
+    ]),
+    div({ style: { display: 'flex', marginTop: '1rem', justifyContent: 'flex-center', width: '18rem' } }, [
+      disabled
+        ? div({ style: { marginLeft: '1rem' } }, [centeredSpinner({ size: 36 })])
+        : h(
+            ButtonPrimary,
+            {
+              disabled,
+              tooltip: disabled ? 'Workflows App is being created' : 'Create Workflows App',
+              onClick,
+              style: { width: '100%' },
+            },
+            ['Yes, launch the Workflows App ']
+          ),
     ]),
     h(
       Link,

--- a/src/workflows-app/components/WorkflowsAppLauncherCard.js
+++ b/src/workflows-app/components/WorkflowsAppLauncherCard.js
@@ -14,21 +14,21 @@ const styles = {
 };
 
 export const WorkflowsAppLauncherCard = ({ onClick, disabled, ...props }) => {
-  return div({ style: { ...styles.card, margin: '2rem 4rem' } }, [
+  return div({ style: { ...styles.card, width: '50rem', margin: '2rem 4rem' } }, [
     h(TitleBar, {
       id: 'workflow-app-launch-page',
-      title: 'Launch the Workflows App to run workflows',
+      title: 'Launch Cromwell to run workflows',
       style: { marginBottom: '0.5rem' },
     }),
     div({ style: { display: 'flex', marginTop: '1rem', justifyContent: 'flex-center' } }, [
-      'The Workflows App must be launched in order to explore, view, and submit workflows.',
+      'Cromwell must be launched in order to explore, view, and submit workflows.',
     ]),
     div({ style: { display: 'flex', marginTop: '.5rem', justifyContent: 'flex-center' } }, [
-      'Once launched, it will stay on until the workspace is deleted.',
+      'Once launched, Cromwell will remain active until the workspace is deleted.',
     ]),
     div({ style: { display: 'flex', marginTop: '2rem', justifyContent: 'flex-center' } }, [
       disabled
-        ? 'Workflows App is being created. You may exit this page and return later without interrupting the creation process.'
+        ? 'Cromwell is being launched. You may exit this page and return later without interrupting the launching process.'
         : 'Would you like to get started?',
     ]),
     div({ style: { display: 'flex', marginTop: '1rem', justifyContent: 'flex-center', width: '18rem' } }, [
@@ -38,11 +38,11 @@ export const WorkflowsAppLauncherCard = ({ onClick, disabled, ...props }) => {
             ButtonPrimary,
             {
               disabled,
-              tooltip: disabled ? 'Workflows App is being created' : 'Create Workflows App',
+              tooltip: disabled ? 'Cromwell is being launched' : 'Launch Cromwell',
               onClick,
               style: { width: '100%' },
             },
-            ['Yes, launch the Workflows App ']
+            ['Yes, launch Cromwell']
           ),
     ]),
     h(

--- a/src/workflows-app/components/WorkflowsAppLauncherCard.js
+++ b/src/workflows-app/components/WorkflowsAppLauncherCard.js
@@ -1,0 +1,49 @@
+import { div, h } from 'react-hyperscript-helpers';
+import { ButtonPrimary, Link } from 'src/components/common';
+import TitleBar from 'src/components/TitleBar';
+import * as Style from 'src/libs/style';
+import * as Utils from 'src/libs/utils';
+
+const styles = {
+  // Card's position: relative and the outer/inner styles are a little hack to fake nested links
+  card: {
+    ...Style.elements.card.container,
+    position: 'absolute',
+  },
+};
+
+export const WorkflowsAppLauncherCard = ({ onClick, appCreating, ...props }) => {
+  return div({ style: { ...styles.card, margin: '2rem 4rem' } }, [
+    h(TitleBar, {
+      id: 'workflow-app-launch-page',
+      title: 'Launch the Workflows App to run workflows',
+      style: { marginBottom: '0.5rem' },
+    }),
+    div(['The Workflows App must be launched in order to explore, view, and submit workflows.']),
+    div({ style: { display: 'flex', marginTop: '2rem', justifyContent: 'flex-center' } }, [
+      !appCreating && 'Would you like to get started?',
+      appCreating &&
+        'Workflows App is being created. This could take several minutes. You may exit this page and return later without interrupting the creation process.',
+    ]),
+    div({ style: { display: 'flex', marginTop: '1rem', justifyContent: 'flex-center' } }, [
+      h(
+        ButtonPrimary,
+        {
+          disabled: appCreating,
+          tooltip: appCreating ? 'Workflows App is being created' : 'Create Workflows App',
+          onClick,
+        },
+        ['Yes, launch the Workflows App']
+      ),
+    ]),
+    h(
+      Link,
+      {
+        ...Utils.newTabLinkProps,
+        href: 'https://support.terra.bio/hc/en-us/articles/360024743371-Working-with-workspaces',
+        style: { marginTop: '2rem' },
+      },
+      ['Learn more about managing cloud cost']
+    ),
+  ]);
+};

--- a/src/workflows-app/components/WorkflowsAppLauncherCard.js
+++ b/src/workflows-app/components/WorkflowsAppLauncherCard.js
@@ -12,7 +12,7 @@ const styles = {
   },
 };
 
-export const WorkflowsAppLauncherCard = ({ onClick, appCreating, ...props }) => {
+export const WorkflowsAppLauncherCard = ({ onClick, disabled, ...props }) => {
   return div({ style: { ...styles.card, margin: '2rem 4rem' } }, [
     h(TitleBar, {
       id: 'workflow-app-launch-page',
@@ -21,16 +21,16 @@ export const WorkflowsAppLauncherCard = ({ onClick, appCreating, ...props }) => 
     }),
     div(['The Workflows App must be launched in order to explore, view, and submit workflows.']),
     div({ style: { display: 'flex', marginTop: '2rem', justifyContent: 'flex-center' } }, [
-      !appCreating && 'Would you like to get started?',
-      appCreating &&
+      !disabled && 'Would you like to get started?',
+      disabled &&
         'Workflows App is being created. This could take several minutes. You may exit this page and return later without interrupting the creation process.',
     ]),
     div({ style: { display: 'flex', marginTop: '1rem', justifyContent: 'flex-center' } }, [
       h(
         ButtonPrimary,
         {
-          disabled: appCreating,
-          tooltip: appCreating ? 'Workflows App is being created' : 'Create Workflows App',
+          disabled,
+          tooltip: disabled ? 'Workflows App is being created' : 'Create Workflows App',
           onClick,
         },
         ['Yes, launch the Workflows App']


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/[Ticket #]

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Introduce the WorkflowsAppLauncherCard component
- Render it in Azure workspaces, under the Workflows tab, when there is no running Cromwell instance

### Why
- This is part of the CBAS UI -> Terra UI migration plan. In the original CBAS UI user experience, we could assume that the Cromwell app was up and running by the time the user arrived at the "Submit Workflow" page. That will no longer be a safe assumption after the migration, so this component is needed to make the user experience complete.

### Testing strategy
- Thorough manual tests were performed to ensure that the context bar and WorkflowsAppLauncherCard state would remain in sync. Automated tests not included because this is a stopgap feature that will likely change very soon.

### Visual Aids


https://github.com/DataBiosphere/terra-ui/assets/5531017/bc75857a-103d-4b47-b038-015ac78a168c

