### PR TITLE
[AJ-1215] Replace "log in" with "sign in"

### DIFF
--- a/src/components/SignInButton.js
+++ b/src/components/SignInButton.js
@@ -19,7 +19,7 @@ const SignInButton = () => {
           onClick: () => signIn(false),
           style: { marginTop: '0.875rem', width: '9.4rem', height: '3.2rem', fontSize: '1rem' },
         },
-        ['log in']
+        ['Sign In']
       );
 };
 

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -297,9 +297,10 @@ const TopBar = ({ showMenu = true, title, href, children }) => {
                               display: 'flex',
                               alignItems: 'center',
                               justifyContent: 'center',
+                              textTransform: 'uppercase',
                             },
                           },
-                          ['LOG IN']
+                          ['Sign In']
                         ),
                       ]
                     ),

--- a/src/pages/SignIn.js
+++ b/src/pages/SignIn.js
@@ -23,7 +23,9 @@ const styles = {
 const SignIn = () => {
   return h(HeroWrapper, { showMenu: false, showDocLink: true }, [
     div({ style: { maxWidth: 600 } }, [
-      div({ style: { fontSize: 16, lineHeight: 1.5, marginBottom: '2rem' } }, ['If you are a new user or returning user, click log in to continue.']),
+      div({ style: { fontSize: 16, lineHeight: 1.5, marginBottom: '2rem' } }, [
+        'If you are a new user or returning user, click sign in to continue.',
+      ]),
       h(SignInButton),
       !isAnvil() &&
         !isElwazi() &&
@@ -31,7 +33,7 @@ const SignIn = () => {
           div({ style: styles.warningNotice }, ['Warning Notice']),
           p([
             `
-          By continuing to log in, you acknowledge that you are accessing a US Government web site
+          By continuing to sign in, you acknowledge that you are accessing a US Government web site
           which may contain information that must be protected under the US Privacy Act or other
           sensitive information and is intended for Government authorized use only.
         `,
@@ -123,7 +125,7 @@ const SignIn = () => {
           ]),
           p([
             `
-          By continuing to log in, anyone accessing this website expressly consents to monitoring
+          By continuing to sign in, anyone accessing this website expressly consents to monitoring
           of their actions and all communications or data transiting or stored on related to this
           website and is advised that if such monitoring reveals possible evidence of criminal activity,
           evidence may be provided to law enforcement officials.

--- a/src/pages/workspaces/workspace/DashboardPublic.js
+++ b/src/pages/workspaces/workspace/DashboardPublic.js
@@ -47,7 +47,7 @@ const DashboardPublic = ({ namespace, name }) => {
         workspace?.description && h(MarkdownViewer, [workspace.description]),
       ]),
       div({ style: Style.dashboard.rightBox }, [
-        div({ style: signInStyle }, [div(['Log in to view full workspace']), div([h(SignInButton, { theme: 'dark' })])]),
+        div({ style: signInStyle }, [div(['Sign in to view full workspace']), div([h(SignInButton, { theme: 'dark' })])]),
       ]),
     ]),
   ]);


### PR DESCRIPTION
Currently, Terra uses "Log in" but "Sign out". Also, after clicking "Log in", you are prompted to "Sign in" with either Google or Microsoft.

![Screenshot 2023-07-31 at 4 31 42 PM](https://github.com/DataBiosphere/terra-ui/assets/1156625/4d5d6166-26db-4cd7-9546-704b3280f8e6)

This replaces "log in" with "sign in" to make language consistent throughout.

