### PR TITLE
[UIE-109] Delete LGTM config

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,5 +1,0 @@
-path_classifiers:
-  library:
-    - .pnp.loader.mjs
-  generated:
-    - .pnp.cjs


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/UIE-109

We used to use LGTM (https://lgtm.com/) for code scanning. However, it has been shut down and we’re now using SonarCloud. Thus, we no longer need the configuration for it.