### PR TITLE
[UIE-71] Add VSCode launch config for running current test file

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Jest - current file",
+      "cwd": "${workspaceFolder}",
+      "runtimeExecutable": "yarn",
+      "runtimeArgs": ["test", "${relativeFile}"],
+      "console": "integratedTerminal"
+    }
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,8 +8,13 @@
       "type": "node",
       "request": "launch",
       "name": "Jest - current file",
+      // Run yarn from the directory containing the test.
+      // Yarn will run the test script from the nearest package.json in parent directories.
       "cwd": "${fileDirname}",
       "runtimeExecutable": "yarn",
+      // Pass the test file's path to yarn to filter to run only the current test.
+      // Use the path instead of the file name to avoid also running any tests with the same
+      // name in different directories.
       "runtimeArgs": ["test", "${relativeFile}"],
       "console": "integratedTerminal"
     }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
       "type": "node",
       "request": "launch",
       "name": "Jest - current file",
-      "cwd": "${workspaceFolder}",
+      "cwd": "${fileDirname}",
       "runtimeExecutable": "yarn",
       "runtimeArgs": ["test", "${relativeFile}"],
       "console": "integratedTerminal"


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/UIE-71

This adds a [launch configuration](https://code.visualstudio.com/docs/editor/debugging#_launch-configurations) for VSCode to run the current file with jest.

This can be useful for debugging tests. To use, open a test file and optionally set a breakpoint either using VSCode or by adding a `debugger` statement. Then open the "Run and Debug" panel, choose "Jest - current file", and run.

https://github.com/DataBiosphere/terra-ui/assets/1156625/e301e521-406d-4774-873f-613ad8f0ce53


