### PR TITLE
Add Feature Flag to Call Cache Toggle

### DIFF
--- a/src/libs/feature-previews-config.ts
+++ b/src/libs/feature-previews-config.ts
@@ -2,6 +2,7 @@ export const JUPYTERLAB_GCP_FEATURE_ID = 'jupyterlab-gcp';
 export const ENABLE_JUPYTERLAB_ID = 'enableJupyterLabGCP';
 export const HAIL_BATCH_AZURE_FEATURE_ID = 'hail-batch-azure';
 export const WORKFLOWS_TAB_AZURE_FEATURE_ID = 'workflows-tab-azure';
+export const ENABLE_CROMWELL_APP_CALL_CACHING = 'enableCromwellAppCallCaching';
 
 // If the groups option is defined for a FeaturePreview, it must contain at least one group.
 type GroupsList = readonly [string, ...string[]];
@@ -85,6 +86,15 @@ const featurePreviewsConfig: readonly FeaturePreview[] = [
     title: 'Workflows Tab for Azure workspaces',
     description: 'Enabling this feature will allow you to launch workflows in Azure workspaces.',
     feedbackUrl: `mailto:dsp-sue@broadinstitute.org?subject=${encodeURIComponent('Feedback on Workflows Tab (Azure)')}`,
+  },
+  {
+    id: ENABLE_CROMWELL_APP_CALL_CACHING,
+    title: 'Cromwell App Call Caching',
+    description:
+      'Enabling this feature will allow you to configure call caching for Cromwell apps running in Azure workspaces. Workspace must be running Cromwell and CBAS versions that support Azure call caching.',
+    feedbackUrl: `mailto:dsp-sue@broadinstitute.org?subject=${encodeURIComponent(
+      'Feedback on Cromwell call caching configuration (Azure)'
+    )}`,
   },
 ];
 

--- a/src/workflows-app/SubmissionConfig.js
+++ b/src/workflows-app/SubmissionConfig.js
@@ -14,6 +14,8 @@ import { Ajax } from 'src/libs/ajax';
 import { useMetricsEvent } from 'src/libs/ajax/metrics/useMetrics';
 import colors from 'src/libs/colors';
 import Events, { extractWorkspaceDetails } from 'src/libs/events';
+import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
+import { ENABLE_CROMWELL_APP_CALL_CACHING } from 'src/libs/feature-previews-config';
 import * as Nav from 'src/libs/nav';
 import { notify } from 'src/libs/notifications';
 import { useCancellation, useOnMount, usePollingEffect, useUniqueId } from 'src/libs/react-utils';
@@ -397,28 +399,29 @@ export const BaseSubmissionConfig = (
             ),
           ]),
         ]),
-        div({ style: { marginTop: '1rem' } }, [
-          label({ htmlFor: callCacheId, style: { height: '2rem', marginRight: '0.25rem', fontWeight: 'bold', display: 'inline-block' } }, [
-            'Call Caching:',
-          ]),
-          div({ style: { display: 'inline-block', marginRight: '1rem' } }, [
-            h(InfoBox, [
-              "Call caching detects when a job has been run in the past so that it doesn't have to re-compute results. ",
-              h(Link, { href: getSupportLink('360047664872'), ...Utils.newTabLinkProps }, ['Click here to learn more.']),
+        isFeaturePreviewEnabled(ENABLE_CROMWELL_APP_CALL_CACHING) &&
+          div({ style: { marginTop: '1rem' } }, [
+            label({ htmlFor: callCacheId, style: { height: '2rem', marginRight: '0.25rem', fontWeight: 'bold', display: 'inline-block' } }, [
+              'Call Caching:',
+            ]),
+            div({ style: { display: 'inline-block', marginRight: '1rem' } }, [
+              h(InfoBox, [
+                "Call caching detects when a job has been run in the past so that it doesn't have to re-compute results. ",
+                h(Link, { href: getSupportLink('360047664872'), ...Utils.newTabLinkProps }, ['Click here to learn more.']),
+              ]),
+            ]),
+            div({ style: { display: 'inline-block' } }, [
+              h(Switch, {
+                id: callCacheId,
+                checked: isCallCachingEnabled,
+                onChange: (newValue) => {
+                  setIsCallCachingEnabled(newValue);
+                },
+                onLabel: 'On',
+                offLabel: 'Off',
+              }),
             ]),
           ]),
-          div({ style: { display: 'inline-block' } }, [
-            h(Switch, {
-              id: callCacheId,
-              checked: isCallCachingEnabled,
-              onChange: (newValue) => {
-                setIsCallCachingEnabled(newValue);
-              },
-              onLabel: 'On',
-              offLabel: 'Off',
-            }),
-          ]),
-        ]),
         div({ style: { marginTop: '1rem', height: '2rem', fontWeight: 'bold' } }, ['Select a data table:']),
         div({}, [
           h(Select, {


### PR DESCRIPTION
### Jira Ticket: [WX-1193](https://broadworkbench.atlassian.net/browse/WX-1193)

### Summary of changes:
The toggle component just added in [this recent PR](https://github.com/DataBiosphere/terra-ui/pull/4092) is not yet supported by the CBAS/Cromwell backend. This PR adds a feature flag to hide it in the meantime. Not originally including this feature flag was an oversight on my end, but the amount of impacted users should be very low because it only affects a page behind a different feature flag.

### Testing strategy
- [ ] Manual testing in local environment (see images below)
- [ ] Unit testing verifying that the flag is working properly  

<!-- ### Visual Aids -->
<img width="1444" alt="image" src="https://github.com/DataBiosphere/terra-ui/assets/77803506/382dd925-3d2c-4601-9981-96fcb830c0d1">

<img width="545" alt="image" src="https://github.com/DataBiosphere/terra-ui/assets/77803506/799d2f7a-89e2-41ac-82ee-31e02d7fd020">

<img width="663" alt="image" src="https://github.com/DataBiosphere/terra-ui/assets/77803506/633db8f8-2a13-4972-8e9d-93559b01f050">



[WX-1193]: https://broadworkbench.atlassian.net/browse/WX-1193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ