### PR TITLE
[IA-4432] HACK: Quietly force role=creator param into all listApp queries

### DIFF
--- a/src/analysis/Environments.ts
+++ b/src/analysis/Environments.ts
@@ -289,12 +289,20 @@ export const Environments = ({ nav = undefined }: EnvironmentsProps) => {
     const listArgs: Record<string, string> = shouldFilterByCreator
       ? { role: 'creator', includeLabels: 'saturnWorkspaceNamespace,saturnWorkspaceName' }
       : { includeLabels: 'saturnWorkspaceNamespace,saturnWorkspaceName' };
+
+    // TODO [IA-4432] remove this restriction and fix performance of this endpoint
+    // HACK disable unfiltered apps listing; queries take >30s on prod and may break the server
+    const appsListArgs: Record<string, string> = {
+      role: 'creator',
+      includeLabels: 'saturnWorkspaceNamespace,saturnWorkspaceName',
+    };
+
     const [newRuntimes, newDisks, newApps] = await Promise.all([
       ajax(signal).Runtimes.listV2(listArgs),
       ajax(signal)
         .Disks.disksV1()
         .list({ ...listArgs, includeLabels: 'saturnApplication,saturnWorkspaceNamespace,saturnWorkspaceName' }),
-      ajax(signal).Apps.listWithoutProject(listArgs),
+      ajax(signal).Apps.listWithoutProject(appsListArgs),
     ]);
     const endTimeForLeoCallsEpochMs = Date.now();
 


### PR DESCRIPTION
Only the Cloud Envs page makes these queries; the one for Apps times out after 30s on prod and is likely the cause of memory leaks. This is a HACK pending fix of app query performance.

### Jira Ticket: https://broadworkbench.atlassian.net/browse/IA-4432

### Testing strategy
- [ ] As user U1...
- [ ] in workspace W1, create app A1
- [ ] in workspace W2, create runtime R1
- [ ] Share workspaces W1 and W2 with user U2
- [ ] As user U2...
- [ ] Goto Cloud Environments page
- [ ] Check and uncheck the checkbox
- [ ] See just your environments (when checked)
- [ ] See all permitted envs (when unchecked) INCLUDING runtime R1 and NOT INCLUDING app A1

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 
