### PR TITLE
[SUP-824] Prevent alerts list from overflowing page

### DIFF
--- a/src/components/Alerts.js
+++ b/src/components/Alerts.js
@@ -112,7 +112,7 @@ const AlertsIndicator = ({ style }) => {
       {
         side: 'bottom',
         onChange: setOpen,
-        content: div({ style: { padding: '0.5rem', width: 300 } }, [
+        content: div({ style: { padding: '0.5rem', width: 300, maxHeight: 'calc(100vh - 5rem)', overflowY: 'auto' } }, [
           _.size(alerts) > 0 ? h(AlertsList, { alerts }) : p(['No system alerts at this time.']),
         ]),
       },


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/SUP-824

If the alerts list (opened from the bell icon at the top right of Terra) is too long, it will get positioned above the bell icon instead of below, rendering it nearly invisible and useless.

To prevent this, this PR adds a max height to the alerts list container and makes the list scrollable.

## Before
<img width="343" alt="Screenshot 2023-08-03 at 4 33 48 PM" src="https://github.com/DataBiosphere/terra-ui/assets/1156625/9fbf2e67-3dfc-4ea4-bb61-797f87515478">

## After
<img width="323" alt="Screenshot 2023-08-03 at 4 31 54 PM" src="https://github.com/DataBiosphere/terra-ui/assets/1156625/e6a1d9c6-922a-491a-aab1-64d910065671">

## Testing

To test, you can either use `ajaxOverrideUtils` to mock the service alerts response and wait for it to update (it polls every minute). The example here is the current service alert copied 5 times.

```
window.ajaxOverridesStore.set([
  {
    filter: { url: /alerts\.json$/ },
    fn: window.ajaxOverrideUtils.makeSuccess([
      {
        title: 'Service Notification - August 3rd, 2023 (VM Python Upgrades)',
        message:
          'Our engineers will be upgrading our virtual machine images from Python 3.7 to Python 3.10 on August 8, 2023 at 8 PM EST. Please follow this article for additional details and updates.',
        link: 'https://support.terra.bio/hc/en-us/articles/16102157837339-Service-Notification-June-5th-2023-VM-Python-Upgrades-',
        incident_id: '1',
      },
      {
        title: 'Service Notification - August 3rd, 2023 (VM Python Upgrades)',
        message:
          'Our engineers will be upgrading our virtual machine images from Python 3.7 to Python 3.10 on August 8, 2023 at 8 PM EST. Please follow this article for additional details and updates.',
        link: 'https://support.terra.bio/hc/en-us/articles/16102157837339-Service-Notification-June-5th-2023-VM-Python-Upgrades-',
        incident_id: '2',
      },
      {
        title: 'Service Notification - August 3rd, 2023 (VM Python Upgrades)',
        message:
          'Our engineers will be upgrading our virtual machine images from Python 3.7 to Python 3.10 on August 8, 2023 at 8 PM EST. Please follow this article for additional details and updates.',
        link: 'https://support.terra.bio/hc/en-us/articles/16102157837339-Service-Notification-June-5th-2023-VM-Python-Upgrades-',
        incident_id: '3',
      },
      {
        title: 'Service Notification - August 3rd, 2023 (VM Python Upgrades)',
        message:
          'Our engineers will be upgrading our virtual machine images from Python 3.7 to Python 3.10 on August 8, 2023 at 8 PM EST. Please follow this article for additional details and updates.',
        link: 'https://support.terra.bio/hc/en-us/articles/16102157837339-Service-Notification-June-5th-2023-VM-Python-Upgrades-',
        incident_id: '4',
      },
      {
        title: 'Service Notification - August 3rd, 2023 (VM Python Upgrades)',
        message:
          'Our engineers will be upgrading our virtual machine images from Python 3.7 to Python 3.10 on August 8, 2023 at 8 PM EST. Please follow this article for additional details and updates.',
        link: 'https://support.terra.bio/hc/en-us/articles/16102157837339-Service-Notification-June-5th-2023-VM-Python-Upgrades-',
        incident_id: '5',
      },
    ])
  }
])
```

Or you can edit `useServiceAlerts` in src/libs/service-alerts to return a list of alerts.
