### PR TITLE
[AJ-970] Handle changes to schema in WDS data tables

### DIFF
--- a/src/components/data/WDSContent.js
+++ b/src/components/data/WDSContent.js
@@ -17,7 +17,7 @@ const WDSContent = ({
   const [refreshKey] = useState(0);
 
   // Render
-  const entityMetadata = wdsToEntityServiceMetadata(wdsSchema);
+  const [entityMetadata, setEntityMetadata] = useState(() => wdsToEntityServiceMetadata(wdsSchema));
 
   return h(Fragment, [
     h(DataTable, {
@@ -36,6 +36,7 @@ const WDSContent = ({
         selected: [],
         setSelected: () => [],
       },
+      setEntityMetadata,
       childrenBefore: undefined,
       enableSearch: false,
       controlPanelStyle: {


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-970

When DataTable refreshes its data if the updated data has additional columns that were not present when the DataTable first loaded its data. If so, it calls `setEntityMetadata` to update the table "schema".
https://github.com/DataBiosphere/terra-ui/blob/fe2da14d705851c0d8e2461c6e7866ac3c5dfe91/src/components/data/DataTable.js#L199-L209

When this situation occurs in a WDS data table, Terra shows an error message "setEntityMetadata is not a function".

This is because WDSContent does not provide DataTable with a `setEntityMetadata` prop. This PR adds it.