### PR TITLE
[AJ-1220] Support URLs with multiple extensions in IGV

### DIFF
--- a/src/components/IGVFileSelector.js
+++ b/src/components/IGVFileSelector.js
@@ -78,7 +78,7 @@ export const getValidIgvFiles = (values) => {
 
       // Filter to URLs that point to a file with one of the relevant extensions.
       const basename = url.pathname.split('/').at(-1);
-      const [base, extension] = basename.split('.');
+      const [base, extension] = splitExtension(basename);
       return !!base && relevantFileTypes.includes(extension);
     } catch (err) {
       return false;

--- a/src/components/IGVFileSelector.test.js
+++ b/src/components/IGVFileSelector.test.js
@@ -9,6 +9,8 @@ describe('getValidIgvFiles', () => {
         'gs://bucket/test2.bai',
         'gs://bucket/test3.bam',
         'gs://bucket/test3.bam.bai',
+        'gs://bucket/test4.sorted.bam',
+        'gs://bucket/test4.sorted.bam.bai',
       ])
     ).toEqual([
       {
@@ -18,6 +20,10 @@ describe('getValidIgvFiles', () => {
       {
         filePath: 'gs://bucket/test3.bam',
         indexFilePath: 'gs://bucket/test3.bam.bai',
+      },
+      {
+        filePath: 'gs://bucket/test4.sorted.bam',
+        indexFilePath: 'gs://bucket/test4.sorted.bam.bai',
       },
     ]);
   });


### PR DESCRIPTION
While updating IGV to support TDR URLs in #4084, support for files with multiple extensions (for example, `file.sorted.bam`) got broken. Such files don't show up as options to view in IGV.

The problem is related to splitting the extension from a path based on the first `.` vs the last.