### PR TITLE
[WM-2164] redirect CBAS UI links

### DIFF
--- a/src/analysis/modals/CloudEnvironmentModal.ts
+++ b/src/analysis/modals/CloudEnvironmentModal.ts
@@ -50,6 +50,8 @@ import { Metrics } from 'src/libs/ajax/Metrics';
 import colors from 'src/libs/colors';
 import { reportError } from 'src/libs/error';
 import Events from 'src/libs/events';
+import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
+import { WORKFLOWS_TAB_AZURE_FEATURE_ID } from 'src/libs/feature-previews-config';
 import * as Nav from 'src/libs/nav';
 import { useCancellation, useStore } from 'src/libs/react-utils';
 import { azureCookieReadyStore, cookieReadyStore } from 'src/libs/state';
@@ -463,7 +465,9 @@ export const CloudEnvironmentModal = ({
             href:
               app &&
               (cloudProvider === cloudProviderTypes.AZURE
-                ? Nav.getLink('workspace-workflows-app', { namespace, name })
+                ? isFeaturePreviewEnabled(WORKFLOWS_TAB_AZURE_FEATURE_ID)
+                  ? Nav.getLink('workspace-workflows-app', { namespace, name })
+                  : app?.proxyUrls['cbas-ui']
                 : app?.proxyUrls['cromwell-service']),
             onClick: () => {
               onDismiss();

--- a/src/analysis/modals/CloudEnvironmentModal.ts
+++ b/src/analysis/modals/CloudEnvironmentModal.ts
@@ -463,13 +463,12 @@ export const CloudEnvironmentModal = ({
             href:
               app &&
               (cloudProvider === cloudProviderTypes.AZURE
-                ? app?.proxyUrls['cbas-ui']
+                ? Nav.getLink('workspace-workflows-app', { namespace, name })
                 : app?.proxyUrls['cromwell-service']),
             onClick: () => {
               onDismiss();
               Metrics(signal).captureEvent(Events.applicationLaunch, { app: appTools.CROMWELL.label });
             },
-            ...Utils.newTabLinkPropsWithReferrer,
           };
         },
       ],

--- a/src/analysis/modals/CloudEnvironmentModal.ts
+++ b/src/analysis/modals/CloudEnvironmentModal.ts
@@ -466,8 +466,8 @@ export const CloudEnvironmentModal = ({
             ...cromwellLinkProps({
               cloudProvider,
               namespace,
+              app,
               name,
-              proxyUrls: app?.proxyUrls,
               isAzureWorkflowsTabEnabled: isFeaturePreviewEnabled(WORKFLOWS_TAB_AZURE_FEATURE_ID),
             }),
             onClick: () => {

--- a/src/analysis/modals/CloudEnvironmentModal.ts
+++ b/src/analysis/modals/CloudEnvironmentModal.ts
@@ -62,6 +62,7 @@ import {
   cloudProviderTypes,
   getCloudProviderFromWorkspace,
 } from 'src/libs/workspace-utils';
+import { cromwellLinkProps } from 'src/workflows-app/utils/app-utils';
 
 const titleId = 'cloud-env-modal';
 
@@ -462,27 +463,17 @@ export const CloudEnvironmentModal = ({
         () => {
           return {
             ...baseProps,
-            href:
-              app &&
-              Utils.cond(
-                [
-                  cloudProvider === cloudProviderTypes.AZURE && isFeaturePreviewEnabled(WORKFLOWS_TAB_AZURE_FEATURE_ID),
-                  () => Nav.getLink('workspace-workflows-app', { namespace, name }),
-                ],
-                [cloudProvider === cloudProviderTypes.AZURE, () => app?.proxyUrls['cbas-ui']],
-                () => app?.proxyUrls['cromwell-service']
-              ),
+            ...cromwellLinkProps({
+              cloudProvider,
+              namespace,
+              name,
+              proxyUrls: app?.proxyUrls,
+              isAzureWorkflowsTabEnabled: isFeaturePreviewEnabled(WORKFLOWS_TAB_AZURE_FEATURE_ID),
+            }),
             onClick: () => {
               onDismiss();
               Metrics(signal).captureEvent(Events.applicationLaunch, { app: appTools.CROMWELL.label });
             },
-            ...Utils.cond(
-              [
-                cloudProvider === cloudProviderTypes.AZURE && isFeaturePreviewEnabled(WORKFLOWS_TAB_AZURE_FEATURE_ID),
-                () => {},
-              ],
-              () => Utils.newTabLinkPropsWithReferrer
-            ),
           };
         },
       ],

--- a/src/analysis/modals/CloudEnvironmentModal.ts
+++ b/src/analysis/modals/CloudEnvironmentModal.ts
@@ -473,6 +473,7 @@ export const CloudEnvironmentModal = ({
               onDismiss();
               Metrics(signal).captureEvent(Events.applicationLaunch, { app: appTools.CROMWELL.label });
             },
+            ...(!isFeaturePreviewEnabled(WORKFLOWS_TAB_AZURE_FEATURE_ID) ? Utils.newTabLinkPropsWithReferrer : {}),
           };
         },
       ],

--- a/src/analysis/modals/CloudEnvironmentModal.ts
+++ b/src/analysis/modals/CloudEnvironmentModal.ts
@@ -460,14 +460,16 @@ export const CloudEnvironmentModal = ({
         () => {
           return {
             ...baseProps,
-            href:
-              app &&
-              (cloudProvider === cloudProviderTypes.AZURE
-                ? app?.proxyUrls['cbas-ui']
-                : app?.proxyUrls['cromwell-service']),
+            href: app && (cloudProvider === cloudProviderTypes.GCP ? app?.proxyUrls['cromwell-service'] : ''),
             onClick: () => {
               onDismiss();
               Metrics(signal).captureEvent(Events.applicationLaunch, { app: appTools.CROMWELL.label });
+              if (
+                cloudProvider === cloudProviderTypes.AZURE &&
+                Nav.getCurrentRoute().name !== 'workspace-workflows-app'
+              ) {
+                Nav.goToPath('workspace-workflows-app', { namespace, name });
+              }
             },
             ...Utils.newTabLinkPropsWithReferrer,
           };

--- a/src/analysis/modals/CloudEnvironmentModal.ts
+++ b/src/analysis/modals/CloudEnvironmentModal.ts
@@ -473,7 +473,7 @@ export const CloudEnvironmentModal = ({
               onDismiss();
               Metrics(signal).captureEvent(Events.applicationLaunch, { app: appTools.CROMWELL.label });
             },
-            ...(!isFeaturePreviewEnabled(WORKFLOWS_TAB_AZURE_FEATURE_ID || cloudProvider === cloudProviderTypes.GCP)
+            ...(!isFeaturePreviewEnabled(WORKFLOWS_TAB_AZURE_FEATURE_ID) || cloudProvider === cloudProviderTypes.GCP
               ? Utils.newTabLinkPropsWithReferrer
               : {}),
           };

--- a/src/analysis/modals/CloudEnvironmentModal.ts
+++ b/src/analysis/modals/CloudEnvironmentModal.ts
@@ -460,16 +460,14 @@ export const CloudEnvironmentModal = ({
         () => {
           return {
             ...baseProps,
-            href: app && (cloudProvider === cloudProviderTypes.GCP ? app?.proxyUrls['cromwell-service'] : ''),
+            href:
+              app &&
+              (cloudProvider === cloudProviderTypes.AZURE
+                ? app?.proxyUrls['cbas-ui']
+                : app?.proxyUrls['cromwell-service']),
             onClick: () => {
               onDismiss();
               Metrics(signal).captureEvent(Events.applicationLaunch, { app: appTools.CROMWELL.label });
-              if (
-                cloudProvider === cloudProviderTypes.AZURE &&
-                Nav.getCurrentRoute().name !== 'workspace-workflows-app'
-              ) {
-                Nav.goToPath('workspace-workflows-app', { namespace, name });
-              }
             },
             ...Utils.newTabLinkPropsWithReferrer,
           };

--- a/src/analysis/modals/CloudEnvironmentModal.ts
+++ b/src/analysis/modals/CloudEnvironmentModal.ts
@@ -464,18 +464,25 @@ export const CloudEnvironmentModal = ({
             ...baseProps,
             href:
               app &&
-              (cloudProvider === cloudProviderTypes.AZURE
-                ? isFeaturePreviewEnabled(WORKFLOWS_TAB_AZURE_FEATURE_ID)
-                  ? Nav.getLink('workspace-workflows-app', { namespace, name })
-                  : app?.proxyUrls['cbas-ui']
-                : app?.proxyUrls['cromwell-service']),
+              Utils.cond(
+                [
+                  cloudProvider === cloudProviderTypes.AZURE && isFeaturePreviewEnabled(WORKFLOWS_TAB_AZURE_FEATURE_ID),
+                  () => Nav.getLink('workspace-workflows-app', { namespace, name }),
+                ],
+                [cloudProvider === cloudProviderTypes.AZURE, () => app?.proxyUrls['cbas-ui']],
+                () => app?.proxyUrls['cromwell-service']
+              ),
             onClick: () => {
               onDismiss();
               Metrics(signal).captureEvent(Events.applicationLaunch, { app: appTools.CROMWELL.label });
             },
-            ...(!isFeaturePreviewEnabled(WORKFLOWS_TAB_AZURE_FEATURE_ID) || cloudProvider === cloudProviderTypes.GCP
-              ? Utils.newTabLinkPropsWithReferrer
-              : {}),
+            ...Utils.cond(
+              [
+                cloudProvider === cloudProviderTypes.AZURE && isFeaturePreviewEnabled(WORKFLOWS_TAB_AZURE_FEATURE_ID),
+                () => {},
+              ],
+              () => Utils.newTabLinkPropsWithReferrer
+            ),
           };
         },
       ],

--- a/src/analysis/modals/CloudEnvironmentModal.ts
+++ b/src/analysis/modals/CloudEnvironmentModal.ts
@@ -473,7 +473,9 @@ export const CloudEnvironmentModal = ({
               onDismiss();
               Metrics(signal).captureEvent(Events.applicationLaunch, { app: appTools.CROMWELL.label });
             },
-            ...(!isFeaturePreviewEnabled(WORKFLOWS_TAB_AZURE_FEATURE_ID) ? Utils.newTabLinkPropsWithReferrer : {}),
+            ...(!isFeaturePreviewEnabled(WORKFLOWS_TAB_AZURE_FEATURE_ID || cloudProvider === cloudProviderTypes.GCP)
+              ? Utils.newTabLinkPropsWithReferrer
+              : {}),
           };
         },
       ],

--- a/src/analysis/modals/CromwellModal.js
+++ b/src/analysis/modals/CromwellModal.js
@@ -90,6 +90,7 @@ export const CromwellModalBase = withDisplayName('CromwellModal')(
                 onDismiss();
                 Ajax().Metrics.captureEvent(Events.applicationLaunch, { app: appTools.CROMWELL.label });
               },
+              ...(!isFeaturePreviewEnabled(WORKFLOWS_TAB_AZURE_FEATURE_ID) ? Utils.newTabLinkPropsWithReferrer : {}),
             },
             ['Open Cromwell']
           );

--- a/src/analysis/modals/CromwellModal.js
+++ b/src/analysis/modals/CromwellModal.js
@@ -10,6 +10,7 @@ import TitleBar from 'src/components/TitleBar';
 import { Ajax } from 'src/libs/ajax';
 import { withErrorReportingInModal } from 'src/libs/error';
 import Events, { extractWorkspaceDetails } from 'src/libs/events';
+import * as Nav from 'src/libs/nav';
 import { useStore, withDisplayName } from 'src/libs/react-utils';
 import { azureCookieReadyStore, cookieReadyStore } from 'src/libs/state';
 import * as Utils from 'src/libs/utils';
@@ -78,13 +79,13 @@ export const CromwellModalBase = withDisplayName('CromwellModal')(
         : h(
             ButtonPrimary,
             {
-              href: app?.proxyUrls['cbas-ui'],
+              href: Nav.getLink('workspace-workflows-app', { namespace, name: workspaceName }),
               disabled: !cookieReady,
               tooltip: Utils.cond([cookieReady, () => 'Open'], [Utils.DEFAULT, () => 'Please wait until Cromwell is running']),
               onClick: () => {
+                onDismiss();
                 Ajax().Metrics.captureEvent(Events.applicationLaunch, { app: appTools.CROMWELL.label });
               },
-              ...Utils.newTabLinkPropsWithReferrer,
             },
             ['Open Cromwell']
           );

--- a/src/analysis/modals/CromwellModal.js
+++ b/src/analysis/modals/CromwellModal.js
@@ -90,7 +90,7 @@ export const CromwellModalBase = withDisplayName('CromwellModal')(
                 onDismiss();
                 Ajax().Metrics.captureEvent(Events.applicationLaunch, { app: appTools.CROMWELL.label });
               },
-              ...(!isFeaturePreviewEnabled(WORKFLOWS_TAB_AZURE_FEATURE_ID || cloudProvider === cloudProviderTypes.GCP)
+              ...(!isFeaturePreviewEnabled(WORKFLOWS_TAB_AZURE_FEATURE_ID) || cloudProvider === cloudProviderTypes.GCP
                 ? Utils.newTabLinkPropsWithReferrer
                 : {}),
             },

--- a/src/analysis/modals/CromwellModal.js
+++ b/src/analysis/modals/CromwellModal.js
@@ -90,7 +90,9 @@ export const CromwellModalBase = withDisplayName('CromwellModal')(
                 onDismiss();
                 Ajax().Metrics.captureEvent(Events.applicationLaunch, { app: appTools.CROMWELL.label });
               },
-              ...(!isFeaturePreviewEnabled(WORKFLOWS_TAB_AZURE_FEATURE_ID) ? Utils.newTabLinkPropsWithReferrer : {}),
+              ...(!isFeaturePreviewEnabled(WORKFLOWS_TAB_AZURE_FEATURE_ID || cloudProvider === cloudProviderTypes.GCP)
+                ? Utils.newTabLinkPropsWithReferrer
+                : {}),
             },
             ['Open Cromwell']
           );

--- a/src/analysis/modals/CromwellModal.js
+++ b/src/analysis/modals/CromwellModal.js
@@ -84,8 +84,8 @@ export const CromwellModalBase = withDisplayName('CromwellModal')(
               ...cromwellLinkProps({
                 cloudProvider,
                 namespace,
+                app,
                 name: workspaceName,
-                proxyUrls: app?.proxyUrls,
                 isAzureWorkflowsTabEnabled: isFeaturePreviewEnabled(WORKFLOWS_TAB_AZURE_FEATURE_ID),
               }),
               disabled: !cookieReady,

--- a/src/analysis/modals/CromwellModal.js
+++ b/src/analysis/modals/CromwellModal.js
@@ -10,6 +10,8 @@ import TitleBar from 'src/components/TitleBar';
 import { Ajax } from 'src/libs/ajax';
 import { withErrorReportingInModal } from 'src/libs/error';
 import Events, { extractWorkspaceDetails } from 'src/libs/events';
+import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
+import { WORKFLOWS_TAB_AZURE_FEATURE_ID } from 'src/libs/feature-previews-config';
 import * as Nav from 'src/libs/nav';
 import { useStore, withDisplayName } from 'src/libs/react-utils';
 import { azureCookieReadyStore, cookieReadyStore } from 'src/libs/state';
@@ -79,7 +81,9 @@ export const CromwellModalBase = withDisplayName('CromwellModal')(
         : h(
             ButtonPrimary,
             {
-              href: Nav.getLink('workspace-workflows-app', { namespace, name: workspaceName }),
+              href: isFeaturePreviewEnabled(WORKFLOWS_TAB_AZURE_FEATURE_ID)
+                ? Nav.getLink('workspace-workflows-app', { namespace, name: workspaceName })
+                : app?.proxyUrls['cbas-ui'],
               disabled: !cookieReady,
               tooltip: Utils.cond([cookieReady, () => 'Open'], [Utils.DEFAULT, () => 'Please wait until Cromwell is running']),
               onClick: () => {

--- a/src/analysis/modals/CromwellModal.js
+++ b/src/analysis/modals/CromwellModal.js
@@ -81,18 +81,24 @@ export const CromwellModalBase = withDisplayName('CromwellModal')(
         : h(
             ButtonPrimary,
             {
-              href: isFeaturePreviewEnabled(WORKFLOWS_TAB_AZURE_FEATURE_ID)
-                ? Nav.getLink('workspace-workflows-app', { namespace, name: workspaceName })
-                : app?.proxyUrls['cbas-ui'],
+              href: Utils.cond(
+                [
+                  cloudProvider === cloudProviderTypes.AZURE && isFeaturePreviewEnabled(WORKFLOWS_TAB_AZURE_FEATURE_ID),
+                  () => Nav.getLink('workspace-workflows-app', { namespace, name: workspaceName }),
+                ],
+                [cloudProvider === cloudProviderTypes.AZURE, () => app?.proxyUrls['cbas-ui']],
+                () => app?.proxyUrls['cromwell-service']
+              ),
               disabled: !cookieReady,
               tooltip: Utils.cond([cookieReady, () => 'Open'], [Utils.DEFAULT, () => 'Please wait until Cromwell is running']),
               onClick: () => {
                 onDismiss();
                 Ajax().Metrics.captureEvent(Events.applicationLaunch, { app: appTools.CROMWELL.label });
               },
-              ...(!isFeaturePreviewEnabled(WORKFLOWS_TAB_AZURE_FEATURE_ID) || cloudProvider === cloudProviderTypes.GCP
-                ? Utils.newTabLinkPropsWithReferrer
-                : {}),
+              ...Utils.cond(
+                [cloudProvider === cloudProviderTypes.AZURE && isFeaturePreviewEnabled(WORKFLOWS_TAB_AZURE_FEATURE_ID), () => {}],
+                () => Utils.newTabLinkPropsWithReferrer
+              ),
             },
             ['Open Cromwell']
           );

--- a/src/analysis/modals/CromwellModal.js
+++ b/src/analysis/modals/CromwellModal.js
@@ -12,11 +12,11 @@ import { withErrorReportingInModal } from 'src/libs/error';
 import Events, { extractWorkspaceDetails } from 'src/libs/events';
 import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
 import { WORKFLOWS_TAB_AZURE_FEATURE_ID } from 'src/libs/feature-previews-config';
-import * as Nav from 'src/libs/nav';
 import { useStore, withDisplayName } from 'src/libs/react-utils';
 import { azureCookieReadyStore, cookieReadyStore } from 'src/libs/state';
 import * as Utils from 'src/libs/utils';
 import { cloudProviderTypes, getCloudProviderFromWorkspace, isAzureWorkspace } from 'src/libs/workspace-utils';
+import { cromwellLinkProps } from 'src/workflows-app/utils/app-utils';
 
 import { computeStyles } from './modalStyles';
 
@@ -81,24 +81,19 @@ export const CromwellModalBase = withDisplayName('CromwellModal')(
         : h(
             ButtonPrimary,
             {
-              href: Utils.cond(
-                [
-                  cloudProvider === cloudProviderTypes.AZURE && isFeaturePreviewEnabled(WORKFLOWS_TAB_AZURE_FEATURE_ID),
-                  () => Nav.getLink('workspace-workflows-app', { namespace, name: workspaceName }),
-                ],
-                [cloudProvider === cloudProviderTypes.AZURE, () => app?.proxyUrls['cbas-ui']],
-                () => app?.proxyUrls['cromwell-service']
-              ),
+              ...cromwellLinkProps({
+                cloudProvider,
+                namespace,
+                name: workspaceName,
+                proxyUrls: app?.proxyUrls,
+                isAzureWorkflowsTabEnabled: isFeaturePreviewEnabled(WORKFLOWS_TAB_AZURE_FEATURE_ID),
+              }),
               disabled: !cookieReady,
               tooltip: Utils.cond([cookieReady, () => 'Open'], [Utils.DEFAULT, () => 'Please wait until Cromwell is running']),
               onClick: () => {
                 onDismiss();
                 Ajax().Metrics.captureEvent(Events.applicationLaunch, { app: appTools.CROMWELL.label });
               },
-              ...Utils.cond(
-                [cloudProvider === cloudProviderTypes.AZURE && isFeaturePreviewEnabled(WORKFLOWS_TAB_AZURE_FEATURE_ID), () => {}],
-                () => Utils.newTabLinkPropsWithReferrer
-              ),
             },
             ['Open Cromwell']
           );

--- a/src/analysis/modals/CromwellModal.js
+++ b/src/analysis/modals/CromwellModal.js
@@ -10,7 +10,6 @@ import TitleBar from 'src/components/TitleBar';
 import { Ajax } from 'src/libs/ajax';
 import { withErrorReportingInModal } from 'src/libs/error';
 import Events, { extractWorkspaceDetails } from 'src/libs/events';
-import * as Nav from 'src/libs/nav';
 import { useStore, withDisplayName } from 'src/libs/react-utils';
 import { azureCookieReadyStore, cookieReadyStore } from 'src/libs/state';
 import * as Utils from 'src/libs/utils';
@@ -79,16 +78,11 @@ export const CromwellModalBase = withDisplayName('CromwellModal')(
         : h(
             ButtonPrimary,
             {
-              href: cloudProvider === cloudProviderTypes.GCP ? app?.proxyUrls['cromwell-service'] : '',
+              href: app?.proxyUrls['cbas-ui'],
               disabled: !cookieReady,
               tooltip: Utils.cond([cookieReady, () => 'Open'], [Utils.DEFAULT, () => 'Please wait until Cromwell is running']),
               onClick: () => {
                 Ajax().Metrics.captureEvent(Events.applicationLaunch, { app: appTools.CROMWELL.label });
-                if (Nav.getCurrentRoute().name !== 'workspace-workflows-app') {
-                  Nav.goToPath('workspace-workflows-app', { namespace, name: workspaceName });
-                } else {
-                  onDismiss();
-                }
               },
               ...Utils.newTabLinkPropsWithReferrer,
             },

--- a/src/analysis/modals/CromwellModal.js
+++ b/src/analysis/modals/CromwellModal.js
@@ -10,6 +10,7 @@ import TitleBar from 'src/components/TitleBar';
 import { Ajax } from 'src/libs/ajax';
 import { withErrorReportingInModal } from 'src/libs/error';
 import Events, { extractWorkspaceDetails } from 'src/libs/events';
+import * as Nav from 'src/libs/nav';
 import { useStore, withDisplayName } from 'src/libs/react-utils';
 import { azureCookieReadyStore, cookieReadyStore } from 'src/libs/state';
 import * as Utils from 'src/libs/utils';
@@ -78,11 +79,16 @@ export const CromwellModalBase = withDisplayName('CromwellModal')(
         : h(
             ButtonPrimary,
             {
-              href: app?.proxyUrls['cbas-ui'],
+              href: cloudProvider === cloudProviderTypes.GCP ? app?.proxyUrls['cromwell-service'] : '',
               disabled: !cookieReady,
               tooltip: Utils.cond([cookieReady, () => 'Open'], [Utils.DEFAULT, () => 'Please wait until Cromwell is running']),
               onClick: () => {
                 Ajax().Metrics.captureEvent(Events.applicationLaunch, { app: appTools.CROMWELL.label });
+                if (Nav.getCurrentRoute().name !== 'workspace-workflows-app') {
+                  Nav.goToPath('workspace-workflows-app', { namespace, name: workspaceName });
+                } else {
+                  onDismiss();
+                }
               },
               ...Utils.newTabLinkPropsWithReferrer,
             },

--- a/src/workflows-app/SubmitWorkflow.js
+++ b/src/workflows-app/SubmitWorkflow.js
@@ -91,6 +91,7 @@ export const SubmitWorkflow = wrapWorkflowsPage({ name: 'SubmitWorkflow' })(
 
         if (cbasProxyUrlState.status === AppProxyUrlStatus.Ready) {
           await loadRunsData(cbasProxyUrlState);
+          await refreshApps(true);
         }
       });
       load();
@@ -105,7 +106,7 @@ export const SubmitWorkflow = wrapWorkflowsPage({ name: 'SubmitWorkflow' })(
       },
       {
         ms: 10000,
-        leading: false,
+        leading: true,
       }
     );
 

--- a/src/workflows-app/utils/app-utils.js
+++ b/src/workflows-app/utils/app-utils.js
@@ -123,12 +123,12 @@ export const loadAppUrls = async (workspaceId, proxyUrlStateField) => {
   };
 };
 
-export const cromwellLinkProps = ({ cloudProvider, namespace, name, proxyUrls, isAzureWorkflowsTabEnabled }) => {
+export const cromwellLinkProps = ({ cloudProvider, namespace, name, app, isAzureWorkflowsTabEnabled }) => {
   return {
     href: Utils.cond(
       [cloudProvider === cloudProviderTypes.AZURE && isAzureWorkflowsTabEnabled, () => Nav.getLink('workspace-workflows-app', { namespace, name })],
-      [cloudProvider === cloudProviderTypes.AZURE, () => proxyUrls?.['cbas-ui']],
-      () => proxyUrls?.['cromwell-service']
+      [cloudProvider === cloudProviderTypes.AZURE, () => app?.proxyUrls['cbas-ui']],
+      () => app?.proxyUrls['cromwell-service']
     ),
     ...Utils.cond(
       [cloudProvider === cloudProviderTypes.AZURE && isAzureWorkflowsTabEnabled, () => {}],

--- a/src/workflows-app/utils/app-utils.js
+++ b/src/workflows-app/utils/app-utils.js
@@ -2,7 +2,10 @@ import { appToolLabels } from 'src/analysis/utils/tool-utils';
 import { Ajax } from 'src/libs/ajax';
 import { resolveWdsUrl } from 'src/libs/ajax/data-table-providers/WdsDataTableProvider';
 import { getConfig } from 'src/libs/config';
+import * as Nav from 'src/libs/nav';
 import { AppProxyUrlStatus, getUser, workflowsAppStore } from 'src/libs/state';
+import * as Utils from 'src/libs/utils';
+import { cloudProviderTypes } from 'src/libs/workspace-utils';
 
 export const doesAppProxyUrlExist = (workspaceId, proxyUrlStateField) => {
   const workflowsAppStoreLocal = workflowsAppStore.get();
@@ -117,5 +120,19 @@ export const loadAppUrls = async (workspaceId, proxyUrlStateField) => {
     wdsProxyUrlState: workflowsAppStoreLocal.wdsProxyUrlState,
     cbasProxyUrlState: workflowsAppStoreLocal.cbasProxyUrlState,
     cromwellProxyUrlState: workflowsAppStoreLocal.cromwellProxyUrlState,
+  };
+};
+
+export const cromwellLinkProps = ({ cloudProvider, namespace, name, proxyUrls, isAzureWorkflowsTabEnabled }) => {
+  return {
+    href: Utils.cond(
+      [cloudProvider === cloudProviderTypes.AZURE && isAzureWorkflowsTabEnabled, () => Nav.getLink('workspace-workflows-app', { namespace, name })],
+      [cloudProvider === cloudProviderTypes.AZURE, () => proxyUrls?.['cbas-ui']],
+      () => proxyUrls?.['cromwell-service']
+    ),
+    ...Utils.cond(
+      [cloudProvider === cloudProviderTypes.AZURE && isAzureWorkflowsTabEnabled, () => {}],
+      () => Utils.newTabLinkPropsWithReferrer // if present, opens link in new tab
+    ),
   };
 };

--- a/src/workflows-app/utils/app-utils.test.js
+++ b/src/workflows-app/utils/app-utils.test.js
@@ -186,9 +186,11 @@ jest.mock('src/libs/nav', () => ({
 }));
 
 describe('cromwellLinkProps', () => {
-  const proxyUrls = {
-    'cbas-ui': 'http://cbas-ui.mock',
-    'cromwell-service': 'http://cromwell-service.mock',
+  const app = {
+    proxyUrls: {
+      'cbas-ui': 'http://cbas-ui.mock',
+      'cromwell-service': 'http://cromwell-service.mock',
+    },
   };
   const namespace = 'mock-namespace';
   const name = 'mock-workspace-name';
@@ -200,7 +202,7 @@ describe('cromwellLinkProps', () => {
         isAzureWorkflowsTabEnabled: true,
         namespace,
         name,
-        proxyUrls,
+        app,
       })
     ).toEqual({
       href: `#workspaces/${namespace}/${name}/workflows-app`,
@@ -208,7 +210,7 @@ describe('cromwellLinkProps', () => {
   });
 
   it('props for Azure with workflows tab disabled', () => {
-    expect(cromwellLinkProps({ cloudProvider: cloudProviderTypes.AZURE, isAzureWorkflowsTabEnabled: false, namespace, name, proxyUrls })).toEqual({
+    expect(cromwellLinkProps({ cloudProvider: cloudProviderTypes.AZURE, isAzureWorkflowsTabEnabled: false, namespace, name, app })).toEqual({
       href: 'http://cbas-ui.mock',
       rel: 'noopener',
       target: '_blank',
@@ -216,7 +218,7 @@ describe('cromwellLinkProps', () => {
   });
 
   it('props for GCP with workflows tab enabled', () => {
-    expect(cromwellLinkProps({ cloudProvider: cloudProviderTypes.GCP, isAzureWorkflowsTabEnabled: true, namespace, name, proxyUrls })).toEqual({
+    expect(cromwellLinkProps({ cloudProvider: cloudProviderTypes.GCP, isAzureWorkflowsTabEnabled: true, namespace, name, app })).toEqual({
       href: 'http://cromwell-service.mock',
       rel: 'noopener',
       target: '_blank',
@@ -224,7 +226,7 @@ describe('cromwellLinkProps', () => {
   });
 
   it('props for GCP with workflows tab disabled', () => {
-    expect(cromwellLinkProps({ cloudProvider: cloudProviderTypes.GCP, isAzureWorkflowsTabEnabled: false, namespace, name, proxyUrls })).toEqual({
+    expect(cromwellLinkProps({ cloudProvider: cloudProviderTypes.GCP, isAzureWorkflowsTabEnabled: false, namespace, name, app })).toEqual({
       href: 'http://cromwell-service.mock',
       rel: 'noopener',
       target: '_blank',

--- a/src/workflows-app/utils/app-utils.test.js
+++ b/src/workflows-app/utils/app-utils.test.js
@@ -1,7 +1,7 @@
 import { appStatuses } from 'src/libs/ajax/leonardo/models/app-models';
 import { AppProxyUrlStatus, workflowsAppStore } from 'src/libs/state';
 import { cloudProviderTypes } from 'src/libs/workspace-utils';
-import { doesAppProxyUrlExist, resolveRunningCromwellAppUrl } from 'src/workflows-app/utils/app-utils';
+import { cromwellLinkProps, doesAppProxyUrlExist, resolveRunningCromwellAppUrl } from 'src/workflows-app/utils/app-utils';
 
 describe('resolveRunningCromwellAppUrl', () => {
   const mockCbasUrl = 'https://abc.servicebus.windows.net/terra-app-3b8d9c55-7eee-49e9-a998-e8c6db05e374-79201ea6-519a-4077-a9a4-75b2a7c4cdeb/cbas';
@@ -177,5 +177,57 @@ describe('doesAppProxyUrlExist', () => {
     });
 
     expect(doesAppProxyUrlExist(currentWorkspaceId, 'cromwellProxyUrlState')).toBe(false);
+  });
+});
+
+jest.mock('src/libs/nav', () => ({
+  ...jest.requireActual('src/libs/nav'),
+  getLink: jest.fn().mockImplementation((_, { namespace, name }) => `#workspaces/${namespace}/${name}/workflows-app`),
+}));
+
+describe('cromwellLinkProps', () => {
+  const proxyUrls = {
+    'cbas-ui': 'http://cbas-ui.mock',
+    'cromwell-service': 'http://cromwell-service.mock',
+  };
+  const namespace = 'mock-namespace';
+  const name = 'mock-workspace-name';
+
+  it('props for Azure with workflows tab enabled', () => {
+    expect(
+      cromwellLinkProps({
+        cloudProvider: cloudProviderTypes.AZURE,
+        isAzureWorkflowsTabEnabled: true,
+        namespace,
+        name,
+        proxyUrls,
+      })
+    ).toEqual({
+      href: `#workspaces/${namespace}/${name}/workflows-app`,
+    });
+  });
+
+  it('props for Azure with workflows tab disabled', () => {
+    expect(cromwellLinkProps({ cloudProvider: cloudProviderTypes.AZURE, isAzureWorkflowsTabEnabled: false, namespace, name, proxyUrls })).toEqual({
+      href: 'http://cbas-ui.mock',
+      rel: 'noopener',
+      target: '_blank',
+    });
+  });
+
+  it('props for GCP with workflows tab enabled', () => {
+    expect(cromwellLinkProps({ cloudProvider: cloudProviderTypes.GCP, isAzureWorkflowsTabEnabled: true, namespace, name, proxyUrls })).toEqual({
+      href: 'http://cromwell-service.mock',
+      rel: 'noopener',
+      target: '_blank',
+    });
+  });
+
+  it('props for GCP with workflows tab disabled', () => {
+    expect(cromwellLinkProps({ cloudProvider: cloudProviderTypes.GCP, isAzureWorkflowsTabEnabled: false, namespace, name, proxyUrls })).toEqual({
+      href: 'http://cromwell-service.mock',
+      rel: 'noopener',
+      target: '_blank',
+    });
   });
 });


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/[Ticket #]

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- This PR changes the behavior of the Cromwell buttons in the context bar and the Cromwell environment modal. Previously, these buttons would open CBAS UI in a new window, served from the app. Now, these buttons will redirect the user to the Workflows tab within Terra UI (if they are in an Azure workspace).

### Why
- This is temporary polish to the user experience, as part of the CBAS UI to Terra UI migration plan.

### Testing strategy
- Manual testing only - this is a small, time-sensitive change that will soon be replaced by something more permanent.

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 
