### PR TITLE
[TUIM-65] Update SonarCloud Orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ parameters:
 
 orbs:
   slack: circleci/slack@3.4.2
-  sonarcloud: sonarsource/sonarcloud@1.0.3
+  sonarcloud: sonarsource/sonarcloud@2.0.0
 
 executors:
   node:


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/TUIM-65

Recently, PR comments from SonarCloud have started included the following notice:
> warning The version of Java (11.0.11) you have used to run this analysis is deprecated and we will stop accepting it soon. Please update to at least Java 17.
Read more [here](https://docs.sonarcloud.io/appendices/scanner-environment/)

For example: https://github.com/DataBiosphere/terra-ui/pull/4112#issuecomment-1673815152

The log output of the SonarCloud step in the CircleCI `build` job includes a similar warning:
> WARN: The version of Java (11.0.11) you have used to run this analysis is deprecated and we will stop accepting it soon. Please update to at least Java 17.

This updates the SonarCloud CircleCI Orb to resolve that warning.