### PR TITLE
[UIE-95] Run yarn install before publishing packages

### DIFF
--- a/.github/workflows/tag-publish.yaml
+++ b/.github/workflows/tag-publish.yaml
@@ -118,10 +118,10 @@ jobs:
 
       - name: Publish packages to NPM registry on merge commits
         if: github.event_name != 'pull_request'
-        working-directory: packages
         run: |
           npx google-artifactregistry-auth --yes --repo-config ../.npmrc
-          ../scripts/publish-packages.sh
+          yarn install --immutable-cache
+          ./scripts/publish-packages.sh
 
   report-to-sherlock:
     uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terra-ui-packages/components",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "scripts": {
     "build": "vite build --emptyOutDir",
     "dev": "vite build --mode=development --watch",

--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terra-ui-packages/core-utils",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "scripts": {
     "build": "vite build --emptyOutDir",
     "dev": "vite build --mode=development --watch",


### PR DESCRIPTION
#4116 changed packages to be built with Vite. 

The publish job run after merging that PR failed because ESBuild wasn't available. This is because we aren't running `yarn install` in that workflow.
```
Building @terra-ui-packages/components.
/home/runner/work/terra-ui/terra-ui/.pnp.cjs:261[60](https://github.com/DataBiosphere/terra-ui/actions/runs/5860272821/job/15887987415#step:14:61)
  return Object.defineProperties(new Error(message), {
                                 ^

Error: Required unplugged package missing from disk. This may happen when switching branches without running installs (unplugged packages must be fully materialized on disk to work).

Missing package: esbuild@npm:0.18.17
Expected package location: /home/runner/work/terra-ui/terra-ui/.yarn/unplugged/esbuild-npm-0.18.17-384f2c63dc/node_modules/esbuild/

    at makeError (/home/runner/work/terra-ui/terra-ui/.pnp.cjs:2[61](https://github.com/DataBiosphere/terra-ui/actions/runs/5860272821/job/15887987415#step:14:62)60:34)
    at resolveUnqualified (/home/runner/work/terra-ui/terra-ui/.pnp.cjs:27921:17)
    at resolveRequest (/home/runner/work/terra-ui/terra-ui/.pnp.cjs:27973:14)
    at Object.resolveRequest (/home/runner/work/terra-ui/terra-ui/.pnp.cjs:28029:26)
    at resolve$1 (file:///home/runner/work/terra-ui/terra-ui/.pnp.loader.mjs:1989:21)
    at async nextResolve (node:internal/modules/esm/loader:1[63](https://github.com/DataBiosphere/terra-ui/actions/runs/5860272821/job/15887987415#step:14:64):22)
    at async ESMLoader.resolve (node:internal/modules/esm/loader:835:24)
    at async ESMLoader.getModuleJob (node:internal/modules/esm/loader:424:7)
    at async ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:79:21)
```
https://github.com/DataBiosphere/terra-ui/actions/runs/5860272821/job/15887987415