### PR TITLE
[UIE-113] Fix type for workspace authorization domain

### DIFF
--- a/src/libs/workspace-utils.test.ts
+++ b/src/libs/workspace-utils.test.ts
@@ -1,24 +1,24 @@
 import { defaultAzureWorkspace, defaultGoogleWorkspace } from 'src/analysis/_testData/testData';
 
-import { isValidWsExportTarget } from './workspace-utils';
+import { isValidWsExportTarget, WorkspaceWrapper } from './workspace-utils';
 
 describe('isValidWsExportTarget', () => {
   it('Returns true because source and dest workspaces are the same', () => {
     // Arrange
-    const sourceWs = {
+    const sourceWs: WorkspaceWrapper = {
       ...defaultGoogleWorkspace,
       workspace: {
-        ...defaultGoogleWorkspace,
-        authorizationDomain: [{}],
+        ...defaultGoogleWorkspace.workspace,
+        authorizationDomain: [],
       },
     };
 
-    const destWs = {
+    const destWs: WorkspaceWrapper = {
       ...defaultGoogleWorkspace,
       workspace: {
         ...defaultGoogleWorkspace.workspace,
         workspaceId: 'test-different-workspace-id',
-        authorizationDomain: [{}],
+        authorizationDomain: [],
       },
     };
 
@@ -44,7 +44,7 @@ describe('isValidWsExportTarget', () => {
   it('Returns false because AccessLevel does not contain Writer', () => {
     // Arrange
     const sourceWs = defaultGoogleWorkspace;
-    const destWs = {
+    const destWs: WorkspaceWrapper = {
       ...defaultGoogleWorkspace,
       accessLevel: 'READER',
       workspace: {
@@ -62,19 +62,19 @@ describe('isValidWsExportTarget', () => {
 
   it('Returns false because source and destination cloud platforms are not the same.', () => {
     // Arrange
-    const sourceWs = {
+    const sourceWs: WorkspaceWrapper = {
       ...defaultGoogleWorkspace,
       workspace: {
         ...defaultGoogleWorkspace.workspace,
-        authorizationDomain: [{}],
+        authorizationDomain: [],
       },
     };
 
-    const destWs = {
+    const destWs: WorkspaceWrapper = {
       ...defaultAzureWorkspace,
       workspace: {
         ...defaultAzureWorkspace.workspace,
-        authorizationDomain: [{}],
+        authorizationDomain: [],
       },
     };
 
@@ -85,17 +85,17 @@ describe('isValidWsExportTarget', () => {
     expect(result).toBe(false);
   });
 
-  it('Returns false because source and destination cloud platforms are not the same.', () => {
+  it('Returns false because source and destination authorization domains are not the same.', () => {
     // Arrange
-    const sourceWs = {
+    const sourceWs: WorkspaceWrapper = {
       ...defaultGoogleWorkspace,
       workspace: {
         ...defaultGoogleWorkspace.workspace,
-        authorizationDomain: [{}],
+        authorizationDomain: [{ membersGroupName: 'auth-domain' }],
       },
     };
 
-    const destWs = {
+    const destWs: WorkspaceWrapper = {
       ...defaultGoogleWorkspace,
       workspace: {
         ...defaultGoogleWorkspace.workspace,

--- a/src/libs/workspace-utils.ts
+++ b/src/libs/workspace-utils.ts
@@ -1,3 +1,4 @@
+import { safeCurry } from '@terra-ui-packages/core-utils';
 import _ from 'lodash/fp';
 import { canWrite } from 'src/libs/utils';
 
@@ -16,11 +17,15 @@ export const isKnownCloudProvider = (x: unknown): x is CloudProvider => {
   return (x as string) in cloudProviderTypes;
 };
 
+export type AuthorizationDomain = {
+  membersGroupName: string;
+};
+
 interface BaseWorkspaceInfo {
   namespace: string;
   name: string;
   workspaceId: string;
-  authorizationDomain: string[];
+  authorizationDomain: AuthorizationDomain[];
   createdDate: string;
   createdBy: string;
 }
@@ -97,7 +102,7 @@ export const hasProtectedData = (workspace: AzureWorkspace): boolean => contains
 export const containsProtectedDataPolicy = (policies: WorkspacePolicy[] | undefined): boolean =>
   _.any((policy) => policy.namespace === 'terra' && policy.name === 'protected-data', policies);
 
-export const isValidWsExportTarget = _.curry((sourceWs, destWs) => {
+export const isValidWsExportTarget = safeCurry((sourceWs: WorkspaceWrapper, destWs: WorkspaceWrapper) => {
   const {
     workspace: { workspaceId: sourceId, authorizationDomain: sourceAD },
   } = sourceWs;


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/UIE-113

I started to add types to the `isValidWsExportTarget` function in #4081, but when adding types to the test, I discovered that the type declaration for a workspace's authorization domains is incorrect.

Currently, it is typed as a `string[]`, but the API actually returns `{ membersGroupName: string }[]`. This corrects the type and adds types to `isValidWsExportTarget` and its tests.