### PR TITLE
[UIE-119] Delete isFetchResponse function

### DIFF
--- a/packages/core-utils/src/type-utils/type-helpers.ts
+++ b/packages/core-utils/src/type-utils/type-helpers.ts
@@ -3,16 +3,3 @@
  * A func that takes (a: A, b: B) where A and B are both strings cannot be called like (b,a) with this restriction
  */
 export type NominalType<BaseType, Name extends string> = BaseType & { __typeToken: Name };
-
-/**
- * Type predicate that will check if variable (obj) is a Fetch Response
- * @param obj
- */
-export const isFetchResponse = (obj: unknown): obj is Response => {
-  const maybeResponse = obj as Response;
-  const isResponse =
-    typeof maybeResponse.text === 'function' &&
-    typeof maybeResponse.status === 'number' &&
-    typeof maybeResponse.statusText === 'string';
-  return isResponse;
-};

--- a/src/libs/ajax/loaded-data/useLoadedData.test.ts
+++ b/src/libs/ajax/loaded-data/useLoadedData.test.ts
@@ -98,11 +98,7 @@ describe('useLoadedData hook', () => {
     });
     const hookResult2: UseLoadedDataResult<TestData> = hookRender.result.current;
 
-    const mockFetchResponse: Partial<Response> = {
-      status: 500,
-      statusText: 'Server Error',
-      text: () => Promise.resolve('BOOM!'),
-    };
+    const mockFetchResponse = new Response('BOOM!', { status: 500, statusText: 'Server Error' });
     await act(async () => {
       controller.reject(mockFetchResponse);
     });

--- a/src/libs/ajax/loaded-data/useLoadedData.ts
+++ b/src/libs/ajax/loaded-data/useLoadedData.ts
@@ -1,4 +1,4 @@
-import { ErrorState, isFetchResponse, LoadedState } from '@terra-ui-packages/core-utils';
+import { ErrorState, LoadedState } from '@terra-ui-packages/core-utils';
 import { useCallback, useEffect, useState } from 'react';
 import { usePrevious } from 'src/libs/react-utils';
 
@@ -68,7 +68,7 @@ export const useLoadedData = <T>(hookArgs?: UseLoadedDataArgs<T>): UseLoadedData
         state: result,
       });
     } catch (err: unknown) {
-      const error = isFetchResponse(err) ? Error(await err.text()) : err;
+      const error = err instanceof Response ? Error(await err.text()) : err;
       setLoadedData((previousLoadedData) => {
         const previousState = previousLoadedData.status !== 'None' ? previousLoadedData.state : null;
         const errorResult: ErrorState<T, unknown> = {


### PR DESCRIPTION
Reaching 100% test coverage in core-utils by deleting uncovered code!

`isFetchResponse` asserts that an unknown object is a [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response) based on `status`, `statusText`, and `text` properties.

Currently, `useLoadedData` uses it to "duck type" the thrown object and not require a specific type.
https://github.com/DataBiosphere/terra-ui/pull/3565#discussion_r1044703942

I claim that, for that purpose, it does too much...
- It shouldn't assert that the passed object is a Response based on checking a subset of the Response interface.
- It checks for `status` and `statusText` fields when all `useLoadedData` cares about is the `text` method.

And too little...
- `useLoadedData` doesn't check if the return value of the `text` method is actually a string before using it as an error message.


I think that, for checking if an object is a Response, `isFetchResponse(obj)` should be replaced with the simpler `obj instanceof Response`. `useLoadedData` could use that if it's going to rely on the Response interface. Or it could check for only the parts of the Response interface it needs before using them.