### PR TITLE
[UIE-115] Exit publish-packages script on error

### DIFF
--- a/scripts/publish-packages.sh
+++ b/scripts/publish-packages.sh
@@ -1,6 +1,6 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-set -eu
+set -euo pipefail
 
 SCRIPTS_DIR="$(dirname "$0")"
 cd "${SCRIPTS_DIR}/../packages"

--- a/scripts/publish-packages.sh
+++ b/scripts/publish-packages.sh
@@ -15,11 +15,7 @@ for d in */ ; do
     # Look up the currently published version of the package in the registry.
     # npm view will fail if the package does not exist. This case needs to be handled
     # in order to support publishing new packages for the first time.
-    set +e
-    PUBLISHED_VERSION=$(npm --loglevel=error view "${PACKAGE_NAME}" version 2>&1)
-    NPM_VIEW_STATUS=$?
-    set -e
-    if [ $NPM_VIEW_STATUS != 0 ]; then
+    if ! PUBLISHED_VERSION=$(npm --loglevel=error view "${PACKAGE_NAME}" version 2>&1); then
       if echo "${PUBLISHED_VERSION}" | grep "E404" >/dev/null; then
         PUBLISHED_VERSION="unpublished"
       else

--- a/scripts/publish-packages.sh
+++ b/scripts/publish-packages.sh
@@ -1,16 +1,37 @@
+#!/bin/sh
+
+set -eu
+
 SCRIPTS_DIR="$(dirname "$0")"
 cd "${SCRIPTS_DIR}/../packages"
 for d in */ ; do
-    cd $d
+    cd "$d"
 
+    # Get the current package name and version from package.json.
     PACKAGE_NAME=$(node -p "require('./package.json').name")
     PACKAGE_VERSION=$(node -p -e "require('./package.json').version")
     echo "Will check if version ${PACKAGE_VERSION} of ${PACKAGE_NAME} should be published."
 
-    PUBLISHED_VERSION=$(npm view "${PACKAGE_NAME}" version)
+    # Look up the currently published version of the package in the registry.
+    # npm view will fail if the package does not exist. This case needs to be handled
+    # in order to support publishing new packages for the first time.
+    set +e
+    PUBLISHED_VERSION=$(npm --loglevel=error view "${PACKAGE_NAME}" version 2>&1)
+    NPM_VIEW_STATUS=$?
+    set -e
+    if [ $NPM_VIEW_STATUS != 0 ]; then
+      if echo "${PUBLISHED_VERSION}" | grep "E404" >/dev/null; then
+        PUBLISHED_VERSION="unpublished"
+      else
+        echo "Unable to get published package version" >&2
+        exit 1
+      fi
+    fi
+
     echo "Current version of ${PACKAGE_NAME} in repository is ${PUBLISHED_VERSION}."
 
-    if [[ ${PUBLISHED_VERSION} != ${PACKAGE_VERSION} ]]; then
+    # If the current and published versions differ, then publish the package.
+    if [ "${PUBLISHED_VERSION}" != "${PACKAGE_VERSION}" ]; then
       echo "Building ${PACKAGE_NAME}."
       yarn build
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/UIE-115

https://github.com/DataBiosphere/terra-ui/actions/runs/5860272821/job/15887987415 published empty packages after `yarn build` failed.

To avoid this sort of thing from happening again, this adds `set -e` to the publish packages script, so the script will exit immediately on an error.

However, `npm view` is expected to fail when there is a new package that has not yet been published to the registry. This handles those errors without exiting the script.

This also adds some quotes that [shellcheck](https://www.shellcheck.net/) suggested.