### PR TITLE
AJ-1037 copy set table to clipboard

### DIFF
--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -296,7 +296,7 @@ const EntitiesContent = ({
       }, sortedEntities),
     ]);
 
-    if (isSet) {
+    if (isSet && forDownload) {
       const membershipTsv = Utils.makeTSV([
         [`membership:${entityKey}_id`, setRoot],
         ..._.flatMap(({ attributes, name }) => {
@@ -304,13 +304,9 @@ const EntitiesContent = ({
         }, sortedEntities),
       ]);
 
-      if (forDownload) {
-        const zipFile = new JSZip().file(`${entityKey}_entity.tsv`, entityTsv).file(`${entityKey}_membership.tsv`, membershipTsv);
+      const zipFile = new JSZip().file(`${entityKey}_entity.tsv`, entityTsv).file(`${entityKey}_membership.tsv`, membershipTsv);
 
-        return zipFile.generateAsync({ type: 'blob' });
-      }
-
-      return membershipTsv;
+      return zipFile.generateAsync({ type: 'blob' });
     }
     return entityTsv;
   };

--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -434,7 +434,7 @@ const EntitiesContent = ({
               )(async () => {
                 const isSet = _.endsWith('_set', entityKey);
                 const str = buildTSV(columnSettings, _.values(selectedEntities), isSet, false);
-                isSet ? await clipboard.writeText(await str) : await clipboard.writeText(str);
+                await clipboard.writeText(str);
                 notify('success', 'Successfully copied to clipboard.', { timeout: 3000 });
                 Ajax().Metrics.captureEvent(Events.workspaceDataCopyToClipboard, extractWorkspaceDetails(workspace.workspace));
               }),

--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -304,9 +304,13 @@ const EntitiesContent = ({
         }, sortedEntities),
       ]);
 
-      const zipFile = new JSZip().file(`${entityKey}_entity.tsv`, entityTsv).file(`${entityKey}_membership.tsv`, membershipTsv);
+      if (forDownload) {
+        const zipFile = new JSZip().file(`${entityKey}_entity.tsv`, entityTsv).file(`${entityKey}_membership.tsv`, membershipTsv);
 
-      return zipFile.generateAsync({ type: forDownload ? 'blob' : 'string' });
+        return zipFile.generateAsync({ type: 'blob' });
+      }
+
+      return membershipTsv;
     }
     return entityTsv;
   };

--- a/src/components/data/EntitiesContent.test.ts
+++ b/src/components/data/EntitiesContent.test.ts
@@ -1,0 +1,375 @@
+import { DeepPartial } from '@terra-ui-packages/core-utils';
+import { act, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as clipboard from 'clipboard-polyfill/text';
+import { h } from 'react-hyperscript-helpers';
+import { defaultGoogleWorkspace } from 'src/analysis/_testData/testData';
+import { Ajax } from 'src/libs/ajax';
+import { asMockedFn } from 'src/testing/test-utils';
+
+import EntitiesContent from './EntitiesContent';
+
+type AjaxContract = ReturnType<typeof Ajax>;
+
+jest.mock('src/libs/ajax');
+
+type ReactNotificationsComponentExports = typeof import('react-notifications-component');
+jest.mock('react-notifications-component', (): DeepPartial<ReactNotificationsComponentExports> => {
+  return {
+    Store: {
+      addNotification: jest.fn(),
+      removeNotification: jest.fn(),
+    },
+  };
+});
+
+type ReactVirtualizedExports = typeof import('react-virtualized');
+jest.mock('react-virtualized', (): ReactVirtualizedExports => {
+  const actual = jest.requireActual<ReactVirtualizedExports>('react-virtualized');
+
+  const { AutoSizer } = actual;
+  class MockAutoSizer extends AutoSizer {
+    state = {
+      height: 1000,
+      width: 1000,
+    };
+
+    setState = () => {};
+  }
+
+  return {
+    ...actual,
+    AutoSizer: MockAutoSizer,
+  };
+});
+
+type ClipboardPolyfillExports = typeof import('clipboard-polyfill/text');
+jest.mock('clipboard-polyfill/text', (): ClipboardPolyfillExports => {
+  const actual = jest.requireActual<ClipboardPolyfillExports>('clipboard-polyfill/text');
+  return {
+    ...actual,
+    writeText: jest.fn().mockResolvedValue(undefined),
+  };
+});
+
+describe('EntitiesContent', () => {
+  it('copies to clipboard', async () => {
+    // Arrange
+    const user = userEvent.setup();
+
+    const paginatedEntitiesOfType = jest.fn().mockResolvedValue({
+      results: [
+        {
+          entityType: 'sample',
+          name: 'sample_1',
+          attributes: {},
+        },
+      ],
+      resultMetadata: { filteredCount: 1, unfilteredCount: 1 },
+    });
+    const mockAjax: DeepPartial<AjaxContract> = {
+      Workspaces: {
+        workspace: () => {
+          return {
+            paginatedEntitiesOfType,
+          };
+        },
+      },
+      Metrics: {
+        captureEvent: () => {},
+      },
+    };
+    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+
+    await act(async () => {
+      render(
+        h(EntitiesContent, {
+          workspace: {
+            ...defaultGoogleWorkspace,
+            workspace: {
+              ...defaultGoogleWorkspace.workspace,
+              attributes: {},
+            },
+            workspaceSubmissionStats: {
+              runningSubmissionsCount: 0,
+            },
+          },
+          entityKey: 'sample',
+          activeCrossTableTextFilter: '',
+          entityMetadata: {
+            sample: {
+              idName: 'sample_id',
+              attributeNames: [],
+              count: 1,
+            },
+          },
+          setEntityMetadata: () => {},
+          loadMetadata: () => {},
+          snapshotName: null,
+          deleteColumnUpdateMetadata: () => {},
+        })
+      );
+    });
+
+    // Act
+
+    // Select entity
+    const checkbox = screen.getByRole('checkbox', { name: 'sample_1' });
+    await user.click(checkbox);
+    screen.getByText('1 row selected');
+
+    // Copy to clipboard
+    const exportButton = screen.getByText('Export');
+    await user.click(exportButton);
+    const copyMenuItem = screen.getByRole('menuitem', { name: 'Copy to clipboard' });
+    const copyButton = within(copyMenuItem).getByRole('button');
+    await user.click(copyButton);
+
+    // Assert
+    expect(clipboard.writeText).toHaveBeenCalledWith('entity:sample_id\nsample_1\n');
+  });
+
+  it('copies set table to clipboard', async () => {
+    // Arrange
+    const user = userEvent.setup();
+
+    const paginatedEntitiesOfType = jest.fn().mockResolvedValue({
+      results: [
+        {
+          entityType: 'sample_set',
+          name: 'sample_set_1',
+          attributes: {
+            samples: {
+              itemsType: 'EntityReference',
+              items: [
+                {
+                  entityType: 'sample',
+                  entityName: 'sample_1',
+                },
+                {
+                  entityType: 'sample',
+                  entityName: 'sample_2',
+                },
+              ],
+            },
+          },
+        },
+      ],
+      resultMetadata: { filteredCount: 1, unfilteredCount: 1 },
+    });
+    const mockAjax: DeepPartial<AjaxContract> = {
+      Workspaces: {
+        workspace: () => {
+          return {
+            paginatedEntitiesOfType,
+          };
+        },
+      },
+      Metrics: {
+        captureEvent: () => {},
+      },
+    };
+    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+
+    await act(async () => {
+      render(
+        h(EntitiesContent, {
+          workspace: {
+            ...defaultGoogleWorkspace,
+            workspace: {
+              ...defaultGoogleWorkspace.workspace,
+              attributes: {},
+            },
+            workspaceSubmissionStats: {
+              runningSubmissionsCount: 0,
+            },
+          },
+          entityKey: 'sample_set',
+          activeCrossTableTextFilter: '',
+          entityMetadata: {
+            sample_set: {
+              idName: 'sample_set_id',
+              attributeNames: ['samples'],
+              count: 1,
+            },
+          },
+          setEntityMetadata: () => {},
+          loadMetadata: () => {},
+          snapshotName: null,
+          deleteColumnUpdateMetadata: () => {},
+        })
+      );
+    });
+
+    // Act
+
+    // Select entity
+    const checkbox = screen.getByRole('checkbox', { name: 'sample_set_1' });
+    await user.click(checkbox);
+    screen.getByText('1 row selected');
+
+    // Copy to clipboard
+    const exportButton = screen.getByText('Export');
+    await user.click(exportButton);
+    const copyMenuItem = screen.getByRole('menuitem', { name: 'Copy to clipboard' });
+    const copyButton = within(copyMenuItem).getByRole('button');
+    await user.click(copyButton);
+
+    // Assert
+    expect(clipboard.writeText).toHaveBeenCalledWith(
+      'membership:sample_set_id\tsample\nsample_set_1\tsample_1\nsample_set_1\tsample_2'
+    );
+  });
+
+  it('downloads selection to tsv', async () => {
+    // Arrange
+    const user = userEvent.setup();
+
+    const paginatedEntitiesOfType = jest.fn().mockResolvedValue({
+      results: [
+        {
+          entityType: 'sample',
+          name: 'sample_1',
+          attributes: {},
+        },
+      ],
+      resultMetadata: { filteredCount: 1, unfilteredCount: 1 },
+    });
+    const mockAjax: DeepPartial<AjaxContract> = {
+      Workspaces: {
+        workspace: () => {
+          return {
+            paginatedEntitiesOfType,
+          };
+        },
+      },
+      Metrics: {
+        captureEvent: () => {},
+      },
+    };
+    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+
+    await act(async () => {
+      render(
+        h(EntitiesContent, {
+          workspace: {
+            ...defaultGoogleWorkspace,
+            workspace: {
+              ...defaultGoogleWorkspace.workspace,
+              attributes: {},
+            },
+            workspaceSubmissionStats: {
+              runningSubmissionsCount: 0,
+            },
+          },
+          entityKey: 'sample',
+          activeCrossTableTextFilter: '',
+          entityMetadata: {
+            sample: {
+              idName: 'sample_id',
+              attributeNames: [],
+              count: 1,
+            },
+          },
+          setEntityMetadata: () => {},
+          loadMetadata: () => {},
+          snapshotName: null,
+          deleteColumnUpdateMetadata: () => {},
+        })
+      );
+    });
+
+    // Act
+
+    // Select entity
+    const checkbox = screen.getByRole('checkbox', { name: 'sample_1' });
+    await user.click(checkbox);
+    screen.getByText('1 row selected');
+
+    // Copy to clipboard
+    const exportButton = screen.getByText('Export');
+    await user.click(exportButton);
+    const copyMenuItem = screen.getByRole('menuitem', { name: 'Download as TSV' });
+    const copyButton = within(copyMenuItem).getByRole('button');
+    await user.click(copyButton);
+
+    // Assert
+    expect(clipboard.writeText).toHaveBeenCalledWith('entity:sample_id\nsample_1\n');
+  });
+
+  // it('downloads set table selection to tsv', async () => {
+  //   // Arrange
+  //   const user = userEvent.setup();
+  //
+  //   const paginatedEntitiesOfType = jest.fn().mockResolvedValue({
+  //     results: [
+  //       {
+  //         entityType: 'sample',
+  //         name: 'sample_1',
+  //         attributes: {},
+  //       },
+  //     ],
+  //     resultMetadata: { filteredCount: 1, unfilteredCount: 1 },
+  //   });
+  //   const mockAjax: DeepPartial<AjaxContract> = {
+  //     Workspaces: {
+  //       workspace: () => {
+  //         return {
+  //           paginatedEntitiesOfType,
+  //         };
+  //       },
+  //     },
+  //     Metrics: {
+  //       captureEvent: () => {},
+  //     },
+  //   };
+  //   asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+  //
+  //   await act(async () => {
+  //     render(
+  //       h(EntitiesContent, {
+  //         workspace: {
+  //           ...defaultGoogleWorkspace,
+  //           workspace: {
+  //             ...defaultGoogleWorkspace.workspace,
+  //             attributes: {},
+  //           },
+  //           workspaceSubmissionStats: {
+  //             runningSubmissionsCount: 0,
+  //           },
+  //         },
+  //         entityKey: 'sample',
+  //         activeCrossTableTextFilter: '',
+  //         entityMetadata: {
+  //           sample: {
+  //             idName: 'sample_id',
+  //             attributeNames: [],
+  //             count: 1,
+  //           },
+  //         },
+  //         setEntityMetadata: () => {},
+  //         loadMetadata: () => {},
+  //         snapshotName: null,
+  //         deleteColumnUpdateMetadata: () => {},
+  //       })
+  //     );
+  //   });
+  //
+  //   // Act
+  //
+  //   // Select entity
+  //   const checkbox = screen.getByRole('checkbox', { name: 'sample_1' });
+  //   await user.click(checkbox);
+  //   screen.getByText('1 row selected');
+  //
+  //   // Copy to clipboard
+  //   const exportButton = screen.getByText('Export');
+  //   await user.click(exportButton);
+  //   const copyMenuItem = screen.getByRole('menuitem', { name: 'Copy to clipboard' });
+  //   const copyButton = within(copyMenuItem).getByRole('button');
+  //   await user.click(copyButton);
+  //
+  //   // Assert
+  //   expect(clipboard.writeText).toHaveBeenCalledWith('entity:sample_id\nsample_1\n');
+  // });
+});

--- a/src/components/data/EntitiesContent.test.ts
+++ b/src/components/data/EntitiesContent.test.ts
@@ -2,6 +2,7 @@ import { DeepPartial } from '@terra-ui-packages/core-utils';
 import { act, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as clipboard from 'clipboard-polyfill/text';
+import FileSaver from 'file-saver';
 import { h } from 'react-hyperscript-helpers';
 import { defaultGoogleWorkspace } from 'src/analysis/_testData/testData';
 import { Ajax } from 'src/libs/ajax';
@@ -49,6 +50,15 @@ jest.mock('clipboard-polyfill/text', (): ClipboardPolyfillExports => {
   return {
     ...actual,
     writeText: jest.fn().mockResolvedValue(undefined),
+  };
+});
+
+type FileSaveExports = typeof import('file-saver');
+jest.mock('file-saver', (): FileSaveExports => {
+  const actual = jest.requireActual<FileSaveExports>('file-saver');
+  return {
+    ...actual,
+    saveAs: jest.fn().mockResolvedValue(undefined),
   };
 });
 
@@ -217,7 +227,7 @@ describe('EntitiesContent', () => {
 
     // Assert
     expect(clipboard.writeText).toHaveBeenCalledWith(
-      'membership:sample_set_id\tsample\nsample_set_1\tsample_1\nsample_set_1\tsample_2'
+      'membership:sample_set_id\tsample\nsample_set_1\tsample_1\nsample_set_1\tsample_2\n'
     );
   });
 
@@ -286,90 +296,107 @@ describe('EntitiesContent', () => {
     await user.click(checkbox);
     screen.getByText('1 row selected');
 
-    // Copy to clipboard
+    // Download tsv
     const exportButton = screen.getByText('Export');
     await user.click(exportButton);
-    const copyMenuItem = screen.getByRole('menuitem', { name: 'Download as TSV' });
-    const copyButton = within(copyMenuItem).getByRole('button');
-    await user.click(copyButton);
+    const downloadMenuItem = screen.getByRole('menuitem', { name: 'Download as TSV' });
+    const downloadButton = within(downloadMenuItem).getByRole('button');
+    await user.click(downloadButton);
 
     // Assert
-    expect(clipboard.writeText).toHaveBeenCalledWith('entity:sample_id\nsample_1\n');
+    expect(FileSaver.saveAs).toHaveBeenCalledWith(new Blob(['entity:sample_id\nsample_1\n']), 'sample.tsv');
   });
 
-  // it('downloads set table selection to tsv', async () => {
-  //   // Arrange
-  //   const user = userEvent.setup();
-  //
-  //   const paginatedEntitiesOfType = jest.fn().mockResolvedValue({
-  //     results: [
-  //       {
-  //         entityType: 'sample',
-  //         name: 'sample_1',
-  //         attributes: {},
-  //       },
-  //     ],
-  //     resultMetadata: { filteredCount: 1, unfilteredCount: 1 },
-  //   });
-  //   const mockAjax: DeepPartial<AjaxContract> = {
-  //     Workspaces: {
-  //       workspace: () => {
-  //         return {
-  //           paginatedEntitiesOfType,
-  //         };
-  //       },
-  //     },
-  //     Metrics: {
-  //       captureEvent: () => {},
-  //     },
-  //   };
-  //   asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
-  //
-  //   await act(async () => {
-  //     render(
-  //       h(EntitiesContent, {
-  //         workspace: {
-  //           ...defaultGoogleWorkspace,
-  //           workspace: {
-  //             ...defaultGoogleWorkspace.workspace,
-  //             attributes: {},
-  //           },
-  //           workspaceSubmissionStats: {
-  //             runningSubmissionsCount: 0,
-  //           },
-  //         },
-  //         entityKey: 'sample',
-  //         activeCrossTableTextFilter: '',
-  //         entityMetadata: {
-  //           sample: {
-  //             idName: 'sample_id',
-  //             attributeNames: [],
-  //             count: 1,
-  //           },
-  //         },
-  //         setEntityMetadata: () => {},
-  //         loadMetadata: () => {},
-  //         snapshotName: null,
-  //         deleteColumnUpdateMetadata: () => {},
-  //       })
-  //     );
-  //   });
-  //
-  //   // Act
-  //
-  //   // Select entity
-  //   const checkbox = screen.getByRole('checkbox', { name: 'sample_1' });
-  //   await user.click(checkbox);
-  //   screen.getByText('1 row selected');
-  //
-  //   // Copy to clipboard
-  //   const exportButton = screen.getByText('Export');
-  //   await user.click(exportButton);
-  //   const copyMenuItem = screen.getByRole('menuitem', { name: 'Copy to clipboard' });
-  //   const copyButton = within(copyMenuItem).getByRole('button');
-  //   await user.click(copyButton);
-  //
-  //   // Assert
-  //   expect(clipboard.writeText).toHaveBeenCalledWith('entity:sample_id\nsample_1\n');
-  // });
+  it('downloads set table selection to tsv', async () => {
+    // Arrange
+    const user = userEvent.setup();
+
+    const paginatedEntitiesOfType = jest.fn().mockResolvedValue({
+      results: [
+        {
+          entityType: 'sample_set',
+          name: 'sample_set_1',
+          attributes: {
+            samples: {
+              itemsType: 'EntityReference',
+              items: [
+                {
+                  entityType: 'sample',
+                  entityName: 'sample_1',
+                },
+                {
+                  entityType: 'sample',
+                  entityName: 'sample_2',
+                },
+              ],
+            },
+          },
+        },
+      ],
+      resultMetadata: { filteredCount: 1, unfilteredCount: 1 },
+    });
+    const mockAjax: DeepPartial<AjaxContract> = {
+      Workspaces: {
+        workspace: () => {
+          return {
+            paginatedEntitiesOfType,
+          };
+        },
+      },
+      Metrics: {
+        captureEvent: () => {},
+      },
+    };
+    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+
+    await act(async () => {
+      render(
+        h(EntitiesContent, {
+          workspace: {
+            ...defaultGoogleWorkspace,
+            workspace: {
+              ...defaultGoogleWorkspace.workspace,
+              attributes: {},
+            },
+            workspaceSubmissionStats: {
+              runningSubmissionsCount: 0,
+            },
+          },
+          entityKey: 'sample_set',
+          activeCrossTableTextFilter: '',
+          entityMetadata: {
+            sample_set: {
+              idName: 'sample_set_id',
+              attributeNames: ['samples'],
+              count: 1,
+            },
+          },
+          setEntityMetadata: () => {},
+          loadMetadata: () => {},
+          snapshotName: null,
+          deleteColumnUpdateMetadata: () => {},
+        })
+      );
+    });
+
+    // Act
+
+    // Select entity
+    const checkbox = screen.getByRole('checkbox', { name: 'sample_set_1' });
+    await user.click(checkbox);
+    screen.getByText('1 row selected');
+
+    // Download tsv
+    const exportButton = screen.getByText('Export');
+    await user.click(exportButton);
+    const downloadMenuItem = screen.getByRole('menuitem', { name: 'Download as TSV' });
+    const downloadButton = within(downloadMenuItem).getByRole('button');
+    await user.click(downloadButton);
+
+    // Assert
+    expect(FileSaver.saveAs).toHaveBeenCalledWith(
+      new Blob(['membership:sample_set_id\\tsample\\nsample_set_1\\tsample_1\\nsample_set_1\\tsample_2']),
+      'sample_set.zip'
+    );
+  });
 });

--- a/src/components/data/EntitiesContent.test.ts
+++ b/src/components/data/EntitiesContent.test.ts
@@ -226,9 +226,7 @@ describe('EntitiesContent', () => {
     await user.click(copyButton);
 
     // Assert
-    expect(clipboard.writeText).toHaveBeenCalledWith(
-      'membership:sample_set_id\tsample\nsample_set_1\tsample_1\nsample_set_1\tsample_2\n'
-    );
+    expect(clipboard.writeText).toHaveBeenCalledWith('entity:sample_set_id\nsample_set_1\n');
   });
 
   it('downloads selection to tsv', async () => {


### PR DESCRIPTION
### Jira Ticket: [AJ-1037](https://broadworkbench.atlassian.net/browse/AJ-1037)
Selecting rows in a set table and choosing Export -> Copy to Clipboard was not working; in the case of set tables, the copying function returned a promise and so the resulting text would be `[object Promise]`.  This PR adjusts the behavior of the `buildTSV` function to return a string for set tables that are being copied instead of downloaded.  

Downloading a set table creates two files: one of the content of the set table (`_entity.tsv`), and one indexing the rows from the table that the set table references (`_membership.tsv`).  Due to the difficulty of representing two files in a single string and the low priority of this issue, product has approved copying only the content of the set table (`_entity.tsv`).  Inclusion of the content of `_membership.tsv` can be included in clipboard copying at a later date as time and need dictate.

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Add parameter to `buildTsv` function to distinguish between downloading vs copying.
- If `buildTsv` is a set table and copying, return only the `_entity.tsv` instead of both `_entity` and `_membership`
- Adds unit tests for `buildTsv`

### Testing strategy
- [x] Manually verified
- [x] Added unit tests

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 


[AJ-1037]: https://broadworkbench.atlassian.net/browse/AJ-1037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ