### PR TITLE
Aj 1037 select filtered

### DIFF
--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -169,6 +169,10 @@ const DataTable = (props) => {
   const table = useRef();
   const signal = useCancellation();
 
+  const getColumnFilterQueryString = () => {
+    return !!columnFilter.filterColAttr && !!columnFilter.filterColTerm ? `${columnFilter.filterColAttr}=${columnFilter.filterColTerm}` : '';
+  };
+
   // Helpers
   const loadData =
     !!entityMetadata &&
@@ -176,8 +180,7 @@ const DataTable = (props) => {
       Utils.withBusyState(setLoading),
       withErrorReporting('Error loading entities')
     )(async () => {
-      const colFilt =
-        !!columnFilter.filterColAttr && !!columnFilter.filterColTerm ? `${columnFilter.filterColAttr}=${columnFilter.filterColTerm}` : '';
+      const columnFilterQueryString = getColumnFilterQueryString();
       const queryOptions = {
         pageNumber,
         itemsPerPage,
@@ -187,7 +190,7 @@ const DataTable = (props) => {
         googleProject,
         activeTextFilter,
         filterOperator,
-        columnFilter: colFilt,
+        columnFilter: columnFilterQueryString,
       };
       const {
         results,
@@ -211,8 +214,13 @@ const DataTable = (props) => {
     });
 
   const getAllEntities = async () => {
-    const colFilt = !!columnFilter.filterColAttr && !!columnFilter.filterColTerm ? `${columnFilter.filterColAttr}=${columnFilter.filterColTerm}` : '';
-    const params = _.pickBy(_.trim, { pageSize: filteredCount, filterTerms: activeTextFilter, filterOperator, columnFilter: colFilt });
+    const columnFilterQueryString = getColumnFilterQueryString();
+    const params = _.pickBy(_.trim, {
+      pageSize: filteredCount,
+      filterTerms: activeTextFilter,
+      filterOperator,
+      columnFilter: columnFilterQueryString,
+    });
     const queryResults = await Ajax(signal).Workspaces.workspace(namespace, name).paginatedEntitiesOfType(entityType, params);
     return queryResults.results;
   };

--- a/src/components/data/DataTable.js
+++ b/src/components/data/DataTable.js
@@ -211,7 +211,8 @@ const DataTable = (props) => {
     });
 
   const getAllEntities = async () => {
-    const params = _.pickBy(_.trim, { pageSize: filteredCount, filterTerms: activeTextFilter, filterOperator });
+    const colFilt = !!columnFilter.filterColAttr && !!columnFilter.filterColTerm ? `${columnFilter.filterColAttr}=${columnFilter.filterColTerm}` : '';
+    const params = _.pickBy(_.trim, { pageSize: filteredCount, filterTerms: activeTextFilter, filterOperator, columnFilter: colFilt });
     const queryResults = await Ajax(signal).Workspaces.workspace(namespace, name).paginatedEntitiesOfType(entityType, params);
     return queryResults.results;
   };

--- a/src/components/data/DataTable.test.ts
+++ b/src/components/data/DataTable.test.ts
@@ -49,31 +49,34 @@ jest.mock('react-virtualized', (): ReactVirtualizedExports => {
   };
 });
 
-const getPage = jest.fn().mockImplementation((queryOptions: { pageNumber; columnFilter }) => {
-  if (queryOptions.columnFilter) {
+const getPage = jest
+  .fn()
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  .mockImplementation((signal, entityType, queryOptions: { pageNumber; columnFilter }, entityMetadata) => {
+    if (queryOptions.columnFilter) {
+      return Promise.resolve({
+        results: _.filter((s: { attributes: { attr: string } }) => s.attributes.attr === 'even'),
+        entities,
+        resultMetadata: { filteredCount: 150, unfilteredCount: 300, filteredPageCount: 2 },
+      });
+    }
+    if (queryOptions.pageNumber === 1) {
+      return Promise.resolve({
+        results: entities.slice(0, 100),
+        resultMetadata: { filteredCount: 300, unfilteredCount: 300, filteredPageCount: 3 },
+      });
+    }
+    if (queryOptions.pageNumber === 2) {
+      return Promise.resolve({
+        results: entities.slice(100, 200),
+        resultMetadata: { filteredCount: 300, unfilteredCount: 300, filteredPageCount: 3 },
+      });
+    }
     return Promise.resolve({
-      results: _.filter((s) => s.attributes.attr === 'even'),
-      entities,
-      resultMetadata: { filteredCount: 150, unfilteredCount: 300, filteredPageCount: 2 },
-    });
-  }
-  if (queryOptions.pageNumber === 1) {
-    return Promise.resolve({
-      results: entities.slice(0, 100),
+      results: entities.slice(200),
       resultMetadata: { filteredCount: 300, unfilteredCount: 300, filteredPageCount: 3 },
     });
-  }
-  if (queryOptions.pageNumber === 2) {
-    return Promise.resolve({
-      results: entities.slice(100, 200),
-      resultMetadata: { filteredCount: 300, unfilteredCount: 300, filteredPageCount: 3 },
-    });
-  }
-  return Promise.resolve({
-    results: entities.slice(200),
-    resultMetadata: { filteredCount: 300, unfilteredCount: 300, filteredPageCount: 3 },
   });
-});
 
 const mockDataProvider: DeepPartial<DataTableProvider> = {
   getPage,

--- a/src/components/data/DataTable.test.ts
+++ b/src/components/data/DataTable.test.ts
@@ -49,6 +49,8 @@ jest.mock('react-virtualized', (): ReactVirtualizedExports => {
   };
 });
 
+// Returns a filtered subset of |entities| if a filter is included - more than one page
+// Else 100-item pages depending on page number
 const getPage = jest
   .fn()
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/components/data/DataTable.test.ts
+++ b/src/components/data/DataTable.test.ts
@@ -1,0 +1,377 @@
+import { DeepPartial } from '@terra-ui-packages/core-utils';
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import { h } from 'react-hyperscript-helpers';
+import { defaultGoogleWorkspace } from 'src/analysis/_testData/testData';
+import DataTable from 'src/components/data/DataTable';
+import { Ajax } from 'src/libs/ajax';
+import { DataTableProvider } from 'src/libs/ajax/data-table-providers/DataTableProvider';
+import { asMockedFn } from 'src/testing/test-utils';
+
+type AjaxContract = ReturnType<typeof Ajax>;
+
+jest.mock('src/libs/ajax');
+
+type ReactNotificationsComponentExports = typeof import('react-notifications-component');
+jest.mock('react-notifications-component', (): DeepPartial<ReactNotificationsComponentExports> => {
+  return {
+    Store: {
+      addNotification: jest.fn(),
+      removeNotification: jest.fn(),
+    },
+  };
+});
+
+type ReactVirtualizedExports = typeof import('react-virtualized');
+jest.mock('react-virtualized', (): ReactVirtualizedExports => {
+  const actual = jest.requireActual<ReactVirtualizedExports>('react-virtualized');
+
+  const { AutoSizer } = actual;
+  class MockAutoSizer extends AutoSizer {
+    state = {
+      height: 1000,
+      width: 1000,
+    };
+
+    setState = () => {};
+  }
+
+  return {
+    ...actual,
+    AutoSizer: MockAutoSizer,
+  };
+});
+
+const mockDataProvider: DeepPartial<DataTableProvider> = {
+  getPage: jest.fn().mockResolvedValue({
+    results: [
+      {
+        entityType: 'sample',
+        name: 'sample_1',
+        attributes: {},
+      },
+    ],
+    resultMetadata: { filteredCount: 1, unfilteredCount: 1 },
+  }),
+  features: {
+    supportsFiltering: true,
+    supportsRowSelection: true,
+  },
+};
+
+const EntitiesContentHarness = (props) => {
+  const [selectedEntities, setSelectedEntities] = useState({});
+  return h(DataTable, {
+    ...props,
+    selectionModel: {
+      selected: selectedEntities,
+      setSelected: setSelectedEntities,
+    },
+  });
+};
+
+describe('DataTable', () => {
+  it('selects all', async () => {
+    // Arrange
+    const user = userEvent.setup();
+
+    const paginatedEntitiesOfType = jest.fn().mockResolvedValue({
+      results: [
+        {
+          entityType: 'sample',
+          name: 'sample_1',
+          attributes: {},
+        },
+      ],
+      resultMetadata: { filteredCount: 1, unfilteredCount: 1 },
+    });
+    const mockAjax: DeepPartial<AjaxContract> = {
+      Workspaces: {
+        workspace: () => {
+          return {
+            paginatedEntitiesOfType,
+          };
+        },
+      },
+      Metrics: {
+        captureEvent: () => {},
+      },
+    };
+    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+
+    await act(async () => {
+      render(
+        h(EntitiesContentHarness, {
+          entityType: 'sample',
+          entityMetadata: {
+            sample: {
+              idName: 'sample_id',
+              attributeNames: [],
+              count: 1,
+            },
+          },
+          setEntityMetadata: () => {},
+          workspaceId: defaultGoogleWorkspace.workspace.workspaceId,
+          workspace: {
+            ...defaultGoogleWorkspace,
+            workspace: {
+              ...defaultGoogleWorkspace.workspace,
+              attributes: {},
+            },
+            workspaceSubmissionStats: {
+              runningSubmissionsCount: 0,
+            },
+          },
+          googleProject: defaultGoogleWorkspace.workspace.googleProject,
+          workspaceId: {
+            namespace: defaultGoogleWorkspace.workspace.namespace,
+            name: defaultGoogleWorkspace.workspace.name,
+          },
+          onScroll: () => {},
+          initialX: 0,
+          initialY: 0,
+          loadMetadata: () => {},
+          childrenBefore: '',
+          editable: '',
+          activeCrossTableTextFilter: '',
+          persist: '',
+          refreshKey: 0,
+          snapshotName: null,
+          deleteColumnUpdateMetadata: () => {},
+          controlPanelStyle: '',
+          border: true,
+          extraColumnActions: '',
+          dataProvider: mockDataProvider,
+        })
+      );
+    });
+
+    // Act
+    // screen.debug();
+
+    // Select all entities
+    const checkbox = screen.getByRole('checkbox', { name: 'Select all' });
+    await user.click(checkbox);
+
+    // Should include all rows + the 'Select all' check
+    const allChecks = screen.getAllByRole('checkbox');
+    // console.log(allChecks.length);
+    // TODO: have more than one row and check length
+    // Assert
+    // They should all be checked
+    allChecks.forEach((checkbox) => {
+      expect(checkbox).toBeChecked();
+    });
+
+    // const exportButton = screen.getByText('Export');
+    // await user.click(exportButton);
+    // const copyMenuItem = screen.getByRole('menuitem', { name: 'Copy to clipboard' });
+    // const copyButton = within(copyMenuItem).getByRole('button');
+    // await user.click(copyButton);
+    //
+    // expect(clipboard.writeText).toHaveBeenCalledWith('entity:sample_id\nsample_1\n');
+  });
+
+  it('selects page', async () => {
+    // Arrange
+    const user = userEvent.setup();
+
+    const paginatedEntitiesOfType = jest.fn().mockResolvedValue({
+      results: [
+        {
+          entityType: 'sample',
+          name: 'sample_1',
+          attributes: {},
+        },
+      ],
+      resultMetadata: { filteredCount: 1, unfilteredCount: 1 },
+    });
+    const mockAjax: DeepPartial<AjaxContract> = {
+      Workspaces: {
+        workspace: () => {
+          return {
+            paginatedEntitiesOfType,
+          };
+        },
+      },
+      Metrics: {
+        captureEvent: () => {},
+      },
+    };
+    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+
+    await act(async () => {
+      render(
+        h(EntitiesContentHarness, {
+          entityType: 'sample',
+          entityMetadata: {
+            sample: {
+              idName: 'sample_id',
+              attributeNames: [],
+              count: 1,
+            },
+          },
+          setEntityMetadata: () => {},
+          workspaceId: defaultGoogleWorkspace.workspace.workspaceId,
+          workspace: {
+            ...defaultGoogleWorkspace,
+            workspace: {
+              ...defaultGoogleWorkspace.workspace,
+              attributes: {},
+            },
+            workspaceSubmissionStats: {
+              runningSubmissionsCount: 0,
+            },
+          },
+          googleProject: defaultGoogleWorkspace.workspace.googleProject,
+          workspaceId: {
+            namespace: defaultGoogleWorkspace.workspace.namespace,
+            name: defaultGoogleWorkspace.workspace.name,
+          },
+          onScroll: () => {},
+          initialX: 0,
+          initialY: 0,
+          loadMetadata: () => {},
+          childrenBefore: '',
+          editable: '',
+          activeCrossTableTextFilter: '',
+          persist: '',
+          refreshKey: 0,
+          snapshotName: null,
+          deleteColumnUpdateMetadata: () => {},
+          controlPanelStyle: '',
+          border: true,
+          extraColumnActions: '',
+          dataProvider: mockDataProvider,
+        })
+      );
+    });
+
+    // Act
+    // screen.debug();
+
+    // Select all entities
+    const checkbox = screen.getByRole('checkbox', { name: 'Select all' });
+    await user.click(checkbox);
+
+    // Should include all rows + the 'Select all' check
+    const allChecks = screen.getAllByRole('checkbox');
+    // console.log(allChecks.length);
+    // TODO: have more than one row and check length
+    // Assert
+    // They should all be checked
+    allChecks.forEach((checkbox) => {
+      expect(checkbox).toBeChecked();
+    });
+
+    // const exportButton = screen.getByText('Export');
+    // await user.click(exportButton);
+    // const copyMenuItem = screen.getByRole('menuitem', { name: 'Copy to clipboard' });
+    // const copyButton = within(copyMenuItem).getByRole('button');
+    // await user.click(copyButton);
+    //
+    // expect(clipboard.writeText).toHaveBeenCalledWith('entity:sample_id\nsample_1\n');
+  });
+
+  it('selects filtered', async () => {
+    // Arrange
+    const user = userEvent.setup();
+
+    const paginatedEntitiesOfType = jest.fn().mockResolvedValue({
+      results: [
+        {
+          entityType: 'sample',
+          name: 'sample_1',
+          attributes: {},
+        },
+      ],
+      resultMetadata: { filteredCount: 1, unfilteredCount: 1 },
+    });
+    const mockAjax: DeepPartial<AjaxContract> = {
+      Workspaces: {
+        workspace: () => {
+          return {
+            paginatedEntitiesOfType,
+          };
+        },
+      },
+      Metrics: {
+        captureEvent: () => {},
+      },
+    };
+    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+
+    await act(async () => {
+      render(
+        h(EntitiesContentHarness, {
+          entityType: 'sample',
+          entityMetadata: {
+            sample: {
+              idName: 'sample_id',
+              attributeNames: [],
+              count: 1,
+            },
+          },
+          setEntityMetadata: () => {},
+          workspaceId: defaultGoogleWorkspace.workspace.workspaceId,
+          workspace: {
+            ...defaultGoogleWorkspace,
+            workspace: {
+              ...defaultGoogleWorkspace.workspace,
+              attributes: {},
+            },
+            workspaceSubmissionStats: {
+              runningSubmissionsCount: 0,
+            },
+          },
+          googleProject: defaultGoogleWorkspace.workspace.googleProject,
+          workspaceId: {
+            namespace: defaultGoogleWorkspace.workspace.namespace,
+            name: defaultGoogleWorkspace.workspace.name,
+          },
+          onScroll: () => {},
+          initialX: 0,
+          initialY: 0,
+          loadMetadata: () => {},
+          childrenBefore: '',
+          editable: '',
+          activeCrossTableTextFilter: '',
+          persist: '',
+          refreshKey: 0,
+          snapshotName: null,
+          deleteColumnUpdateMetadata: () => {},
+          controlPanelStyle: '',
+          border: true,
+          extraColumnActions: '',
+          dataProvider: mockDataProvider,
+        })
+      );
+    });
+
+    // Act
+    // screen.debug();
+
+    // Select all entities
+    const checkbox = screen.getByRole('checkbox', { name: 'Select all' });
+    await user.click(checkbox);
+
+    // Should include all rows + the 'Select all' check
+    const allChecks = screen.getAllByRole('checkbox');
+    // console.log(allChecks.length);
+    // TODO: have more than one row and check length
+    // Assert
+    // They should all be checked
+    allChecks.forEach((checkbox) => {
+      expect(checkbox).toBeChecked();
+    });
+
+    // const exportButton = screen.getByText('Export');
+    // await user.click(exportButton);
+    // const copyMenuItem = screen.getByRole('menuitem', { name: 'Copy to clipboard' });
+    // const copyButton = within(copyMenuItem).getByRole('button');
+    // await user.click(copyButton);
+    //
+    // expect(clipboard.writeText).toHaveBeenCalledWith('entity:sample_id\nsample_1\n');
+  });
+});

--- a/src/components/data/DataTable.test.ts
+++ b/src/components/data/DataTable.test.ts
@@ -197,7 +197,7 @@ describe('DataTable', () => {
     // Get the checkboxes on this page
     const newPageChecks = screen.getAllByRole('checkbox', { checked: true });
     expect(newPageChecks.length).toEqual(101);
-  });
+  }, 10000);
 
   it('selects page', async () => {
     // Arrange
@@ -271,7 +271,7 @@ describe('DataTable', () => {
     // Get the checkboxes on this page
     const newPageChecks = screen.getAllByRole('checkbox', { checked: false });
     expect(newPageChecks.length).toEqual(101);
-  });
+  }, 10000);
 
   it('passes filters to getPaginatedEntities', async () => {
     // Arrange
@@ -346,7 +346,7 @@ describe('DataTable', () => {
       'sample',
       expect.objectContaining({ columnFilter: 'sample_id=even' })
     );
-  });
+  }, 10000);
 
   it('selects filtered', async () => {
     // Arrange
@@ -420,5 +420,5 @@ describe('DataTable', () => {
     // Should include all (filtered) entities + select all checkbox
     const allChecks = screen.getAllByRole('checkbox', { checked: true });
     expect(allChecks.length).toEqual(126);
-  });
+  }, 10000);
 });

--- a/src/components/data/DataTable.test.ts
+++ b/src/components/data/DataTable.test.ts
@@ -1,5 +1,5 @@
 import { DeepPartial } from '@terra-ui-packages/core-utils';
-import { act, render, screen, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import _ from 'lodash/fp';
 import { useState } from 'react';
@@ -329,7 +329,7 @@ describe('DataTable', () => {
     await user.click(columnMenu);
 
     // Filter
-    await user.type(screen.getByLabelText('Exact match filter'), 'even');
+    fireEvent.change(screen.getByLabelText('Exact match filter'), { target: { value: 'even' } });
 
     const menuModal = screen.getByRole('dialog');
     const searchButton = within(menuModal).getByRole('button', { name: 'Search' });
@@ -404,7 +404,7 @@ describe('DataTable', () => {
     await user.click(columnMenu);
 
     // Filter
-    await user.type(screen.getByLabelText('Exact match filter'), 'even');
+    fireEvent.change(screen.getByLabelText('Exact match filter'), { target: { value: 'even' } });
 
     const menuModal = screen.getByRole('dialog');
     const searchButton = within(menuModal).getByRole('button', { name: 'Search' });

--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -284,9 +284,11 @@ const EntitiesContent = ({
   } = useColumnProvenance(workspace, entityKey);
   const [showColumnProvenance, setShowColumnProvenance] = useState(undefined);
 
-  const buildTSV = (columnSettings, entities, isSet, forDownload) => {
+  const buildTSV = (columnSettings, entities, forDownload) => {
     const sortedEntities = _.sortBy('name', entities);
     const setRoot = entityKey.slice(0, -4);
+    const isSet = _.endsWith('_set', entityKey);
+
     const attributeNames = _.flow(_.filter('visible'), _.map('name'), isSet ? _.without([`${setRoot}s`]) : _.identity)(columnSettings);
 
     const entityTsv = Utils.makeTSV([
@@ -296,7 +298,7 @@ const EntitiesContent = ({
       }, sortedEntities),
     ]);
 
-    if (isSet) {
+    if (isSet && forDownload) {
       const membershipTsv = Utils.makeTSV([
         [`membership:${entityKey}_id`, setRoot],
         ..._.flatMap(({ attributes, name }) => {
@@ -304,20 +306,16 @@ const EntitiesContent = ({
         }, sortedEntities),
       ]);
 
-      if (forDownload) {
-        const zipFile = new JSZip().file(`${entityKey}_entity.tsv`, entityTsv).file(`${entityKey}_membership.tsv`, membershipTsv);
+      const zipFile = new JSZip().file(`${entityKey}_entity.tsv`, entityTsv).file(`${entityKey}_membership.tsv`, membershipTsv);
 
-        return zipFile.generateAsync({ type: 'blob' });
-      }
-
-      return membershipTsv;
+      return zipFile.generateAsync({ type: 'blob' });
     }
     return entityTsv;
   };
 
   const downloadSelectedRows = async (columnSettings) => {
+    const tsv = buildTSV(columnSettings, selectedEntities, true);
     const isSet = _.endsWith('_set', entityKey);
-    const tsv = buildTSV(columnSettings, selectedEntities, isSet, true);
     isSet
       ? FileSaver.saveAs(await tsv, `${entityKey}.zip`)
       : FileSaver.saveAs(new Blob([tsv], { type: 'text/tab-separated-values' }), `${entityKey}.tsv`);
@@ -436,9 +434,8 @@ const EntitiesContent = ({
                 withErrorReporting('Error copying to clipboard.'),
                 Utils.withBusyState(setNowCopying)
               )(async () => {
-                const isSet = _.endsWith('_set', entityKey);
-                const str = buildTSV(columnSettings, _.values(selectedEntities), isSet, false);
-                isSet ? await clipboard.writeText(await str) : await clipboard.writeText(str);
+                const str = buildTSV(columnSettings, _.values(selectedEntities), false);
+                await clipboard.writeText(str);
                 notify('success', 'Successfully copied to clipboard.', { timeout: 3000 });
                 Ajax().Metrics.captureEvent(Events.workspaceDataCopyToClipboard, extractWorkspaceDetails(workspace.workspace));
               }),

--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -304,9 +304,13 @@ const EntitiesContent = ({
         }, sortedEntities),
       ]);
 
-      const zipFile = new JSZip().file(`${entityKey}_entity.tsv`, entityTsv).file(`${entityKey}_membership.tsv`, membershipTsv);
+      if (forDownload) {
+        const zipFile = new JSZip().file(`${entityKey}_entity.tsv`, entityTsv).file(`${entityKey}_membership.tsv`, membershipTsv);
 
-      return zipFile.generateAsync({ type: forDownload ? 'blob' : 'string' });
+        return zipFile.generateAsync({ type: 'blob' });
+      }
+
+      return membershipTsv;
     }
     return entityTsv;
   };

--- a/src/components/data/EntitiesContent.test.ts
+++ b/src/components/data/EntitiesContent.test.ts
@@ -229,6 +229,94 @@ describe('EntitiesContent', () => {
     expect(clipboard.writeText).toHaveBeenCalledWith('entity:sample_set_id\nsample_set_1\n');
   });
 
+  it('copies filtered table to clipboard', async () => {
+    // Arrange
+    const user = userEvent.setup();
+
+    const paginatedEntitiesOfType = jest.fn().mockResolvedValue({
+      results: [
+        {
+          entityType: 'sample',
+          name: 'sample_1',
+          attributes: {},
+        },
+      ],
+      resultMetadata: { filteredCount: 1, unfilteredCount: 2 },
+    });
+    const mockAjax: DeepPartial<AjaxContract> = {
+      Workspaces: {
+        workspace: () => {
+          return {
+            paginatedEntitiesOfType,
+          };
+        },
+      },
+      Metrics: {
+        captureEvent: () => {},
+      },
+    };
+    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+
+    await act(async () => {
+      render(
+        h(EntitiesContent, {
+          workspace: {
+            ...defaultGoogleWorkspace,
+            workspace: {
+              ...defaultGoogleWorkspace.workspace,
+              attributes: {},
+            },
+            workspaceSubmissionStats: {
+              runningSubmissionsCount: 0,
+            },
+          },
+          entityKey: 'sample',
+          activeCrossTableTextFilter: '',
+          entityMetadata: {
+            sample: {
+              idName: 'sample_id',
+              attributeNames: [],
+              count: 2,
+            },
+          },
+          setEntityMetadata: () => {},
+          loadMetadata: () => {},
+          snapshotName: null,
+          deleteColumnUpdateMetadata: () => {},
+        })
+      );
+    });
+
+    // Act
+
+    const columnMenu = screen.getByRole('button', { name: 'Column menu' });
+    await user.click(columnMenu);
+
+    // Filter
+    await user.type(screen.getByLabelText('Exact match filter'), 'even');
+
+    const menuModal = screen.getByRole('dialog');
+    const searchButton = within(menuModal).getByRole('button', { name: 'Search' });
+    await user.click(searchButton);
+
+    // Select filtered entity
+    const checkbox = screen.getByRole('button', { name: '"Select All" options' });
+    await user.click(checkbox);
+
+    const pageButton = screen.getByRole('button', { name: 'Filtered (1)' });
+    await user.click(pageButton);
+
+    // Copy to clipboard
+    const exportButton = screen.getByText('Export');
+    await user.click(exportButton);
+    const copyMenuItem = screen.getByRole('menuitem', { name: 'Copy to clipboard' });
+    const copyButton = within(copyMenuItem).getByRole('button');
+    await user.click(copyButton);
+
+    // Assert
+    expect(clipboard.writeText).toHaveBeenCalledWith('entity:sample_id\nsample_1\n');
+  });
+
   it('downloads selection to tsv', async () => {
     // Arrange
     const user = userEvent.setup();

--- a/src/components/data/EntitiesContent.test.ts
+++ b/src/components/data/EntitiesContent.test.ts
@@ -1,0 +1,375 @@
+import { DeepPartial } from '@terra-ui-packages/core-utils';
+import { act, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as clipboard from 'clipboard-polyfill/text';
+import { h } from 'react-hyperscript-helpers';
+import { defaultGoogleWorkspace } from 'src/analysis/_testData/testData';
+import { Ajax } from 'src/libs/ajax';
+import { asMockedFn } from 'src/testing/test-utils';
+
+import EntitiesContent from './EntitiesContent';
+
+type AjaxContract = ReturnType<typeof Ajax>;
+
+jest.mock('src/libs/ajax');
+
+type ReactNotificationsComponentExports = typeof import('react-notifications-component');
+jest.mock('react-notifications-component', (): DeepPartial<ReactNotificationsComponentExports> => {
+  return {
+    Store: {
+      addNotification: jest.fn(),
+      removeNotification: jest.fn(),
+    },
+  };
+});
+
+type ReactVirtualizedExports = typeof import('react-virtualized');
+jest.mock('react-virtualized', (): ReactVirtualizedExports => {
+  const actual = jest.requireActual<ReactVirtualizedExports>('react-virtualized');
+
+  const { AutoSizer } = actual;
+  class MockAutoSizer extends AutoSizer {
+    state = {
+      height: 1000,
+      width: 1000,
+    };
+
+    setState = () => {};
+  }
+
+  return {
+    ...actual,
+    AutoSizer: MockAutoSizer,
+  };
+});
+
+type ClipboardPolyfillExports = typeof import('clipboard-polyfill/text');
+jest.mock('clipboard-polyfill/text', (): ClipboardPolyfillExports => {
+  const actual = jest.requireActual<ClipboardPolyfillExports>('clipboard-polyfill/text');
+  return {
+    ...actual,
+    writeText: jest.fn().mockResolvedValue(undefined),
+  };
+});
+
+describe('EntitiesContent', () => {
+  it('copies to clipboard', async () => {
+    // Arrange
+    const user = userEvent.setup();
+
+    const paginatedEntitiesOfType = jest.fn().mockResolvedValue({
+      results: [
+        {
+          entityType: 'sample',
+          name: 'sample_1',
+          attributes: {},
+        },
+      ],
+      resultMetadata: { filteredCount: 1, unfilteredCount: 1 },
+    });
+    const mockAjax: DeepPartial<AjaxContract> = {
+      Workspaces: {
+        workspace: () => {
+          return {
+            paginatedEntitiesOfType,
+          };
+        },
+      },
+      Metrics: {
+        captureEvent: () => {},
+      },
+    };
+    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+
+    await act(async () => {
+      render(
+        h(EntitiesContent, {
+          workspace: {
+            ...defaultGoogleWorkspace,
+            workspace: {
+              ...defaultGoogleWorkspace.workspace,
+              attributes: {},
+            },
+            workspaceSubmissionStats: {
+              runningSubmissionsCount: 0,
+            },
+          },
+          entityKey: 'sample',
+          activeCrossTableTextFilter: '',
+          entityMetadata: {
+            sample: {
+              idName: 'sample_id',
+              attributeNames: [],
+              count: 1,
+            },
+          },
+          setEntityMetadata: () => {},
+          loadMetadata: () => {},
+          snapshotName: null,
+          deleteColumnUpdateMetadata: () => {},
+        })
+      );
+    });
+
+    // Act
+
+    // Select entity
+    const checkbox = screen.getByRole('checkbox', { name: 'sample_1' });
+    await user.click(checkbox);
+    screen.getByText('1 row selected');
+
+    // Copy to clipboard
+    const exportButton = screen.getByText('Export');
+    await user.click(exportButton);
+    const copyMenuItem = screen.getByRole('menuitem', { name: 'Copy to clipboard' });
+    const copyButton = within(copyMenuItem).getByRole('button');
+    await user.click(copyButton);
+
+    // Assert
+    expect(clipboard.writeText).toHaveBeenCalledWith('entity:sample_id\nsample_1\n');
+  });
+
+  it('copies set table to clipboard', async () => {
+    // Arrange
+    const user = userEvent.setup();
+
+    const paginatedEntitiesOfType = jest.fn().mockResolvedValue({
+      results: [
+        {
+          entityType: 'sample_set',
+          name: 'sample_set_1',
+          attributes: {
+            samples: {
+              itemsType: 'EntityReference',
+              items: [
+                {
+                  entityType: 'sample',
+                  entityName: 'sample_1',
+                },
+                {
+                  entityType: 'sample',
+                  entityName: 'sample_2',
+                },
+              ],
+            },
+          },
+        },
+      ],
+      resultMetadata: { filteredCount: 1, unfilteredCount: 1 },
+    });
+    const mockAjax: DeepPartial<AjaxContract> = {
+      Workspaces: {
+        workspace: () => {
+          return {
+            paginatedEntitiesOfType,
+          };
+        },
+      },
+      Metrics: {
+        captureEvent: () => {},
+      },
+    };
+    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+
+    await act(async () => {
+      render(
+        h(EntitiesContent, {
+          workspace: {
+            ...defaultGoogleWorkspace,
+            workspace: {
+              ...defaultGoogleWorkspace.workspace,
+              attributes: {},
+            },
+            workspaceSubmissionStats: {
+              runningSubmissionsCount: 0,
+            },
+          },
+          entityKey: 'sample_set',
+          activeCrossTableTextFilter: '',
+          entityMetadata: {
+            sample_set: {
+              idName: 'sample_set_id',
+              attributeNames: ['samples'],
+              count: 1,
+            },
+          },
+          setEntityMetadata: () => {},
+          loadMetadata: () => {},
+          snapshotName: null,
+          deleteColumnUpdateMetadata: () => {},
+        })
+      );
+    });
+
+    // Act
+
+    // Select entity
+    const checkbox = screen.getByRole('checkbox', { name: 'sample_set_1' });
+    await user.click(checkbox);
+    screen.getByText('1 row selected');
+
+    // Copy to clipboard
+    const exportButton = screen.getByText('Export');
+    await user.click(exportButton);
+    const copyMenuItem = screen.getByRole('menuitem', { name: 'Copy to clipboard' });
+    const copyButton = within(copyMenuItem).getByRole('button');
+    await user.click(copyButton);
+
+    // Assert
+    expect(clipboard.writeText).toHaveBeenCalledWith(
+      'membership:sample_set_id\tsample\nsample_set_1\tsample_1\nsample_set_1\tsample_2'
+    );
+  });
+
+  it('downloads selection to tsv', async () => {
+    // Arrange
+    const user = userEvent.setup();
+
+    const paginatedEntitiesOfType = jest.fn().mockResolvedValue({
+      results: [
+        {
+          entityType: 'sample',
+          name: 'sample_1',
+          attributes: {},
+        },
+      ],
+      resultMetadata: { filteredCount: 1, unfilteredCount: 1 },
+    });
+    const mockAjax: DeepPartial<AjaxContract> = {
+      Workspaces: {
+        workspace: () => {
+          return {
+            paginatedEntitiesOfType,
+          };
+        },
+      },
+      Metrics: {
+        captureEvent: () => {},
+      },
+    };
+    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+
+    await act(async () => {
+      render(
+        h(EntitiesContent, {
+          workspace: {
+            ...defaultGoogleWorkspace,
+            workspace: {
+              ...defaultGoogleWorkspace.workspace,
+              attributes: {},
+            },
+            workspaceSubmissionStats: {
+              runningSubmissionsCount: 0,
+            },
+          },
+          entityKey: 'sample',
+          activeCrossTableTextFilter: '',
+          entityMetadata: {
+            sample: {
+              idName: 'sample_id',
+              attributeNames: [],
+              count: 1,
+            },
+          },
+          setEntityMetadata: () => {},
+          loadMetadata: () => {},
+          snapshotName: null,
+          deleteColumnUpdateMetadata: () => {},
+        })
+      );
+    });
+
+    // Act
+
+    // Select entity
+    const checkbox = screen.getByRole('checkbox', { name: 'sample_1' });
+    await user.click(checkbox);
+    screen.getByText('1 row selected');
+
+    // Copy to clipboard
+    const exportButton = screen.getByText('Export');
+    await user.click(exportButton);
+    const copyMenuItem = screen.getByRole('menuitem', { name: 'Download as TSV' });
+    const copyButton = within(copyMenuItem).getByRole('button');
+    await user.click(copyButton);
+
+    // Assert
+    expect(clipboard.writeText).toHaveBeenCalledWith('entity:sample_id\nsample_1\n');
+  });
+
+  // it('downloads set table selection to tsv', async () => {
+  //   // Arrange
+  //   const user = userEvent.setup();
+  //
+  //   const paginatedEntitiesOfType = jest.fn().mockResolvedValue({
+  //     results: [
+  //       {
+  //         entityType: 'sample',
+  //         name: 'sample_1',
+  //         attributes: {},
+  //       },
+  //     ],
+  //     resultMetadata: { filteredCount: 1, unfilteredCount: 1 },
+  //   });
+  //   const mockAjax: DeepPartial<AjaxContract> = {
+  //     Workspaces: {
+  //       workspace: () => {
+  //         return {
+  //           paginatedEntitiesOfType,
+  //         };
+  //       },
+  //     },
+  //     Metrics: {
+  //       captureEvent: () => {},
+  //     },
+  //   };
+  //   asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+  //
+  //   await act(async () => {
+  //     render(
+  //       h(EntitiesContent, {
+  //         workspace: {
+  //           ...defaultGoogleWorkspace,
+  //           workspace: {
+  //             ...defaultGoogleWorkspace.workspace,
+  //             attributes: {},
+  //           },
+  //           workspaceSubmissionStats: {
+  //             runningSubmissionsCount: 0,
+  //           },
+  //         },
+  //         entityKey: 'sample',
+  //         activeCrossTableTextFilter: '',
+  //         entityMetadata: {
+  //           sample: {
+  //             idName: 'sample_id',
+  //             attributeNames: [],
+  //             count: 1,
+  //           },
+  //         },
+  //         setEntityMetadata: () => {},
+  //         loadMetadata: () => {},
+  //         snapshotName: null,
+  //         deleteColumnUpdateMetadata: () => {},
+  //       })
+  //     );
+  //   });
+  //
+  //   // Act
+  //
+  //   // Select entity
+  //   const checkbox = screen.getByRole('checkbox', { name: 'sample_1' });
+  //   await user.click(checkbox);
+  //   screen.getByText('1 row selected');
+  //
+  //   // Copy to clipboard
+  //   const exportButton = screen.getByText('Export');
+  //   await user.click(exportButton);
+  //   const copyMenuItem = screen.getByRole('menuitem', { name: 'Copy to clipboard' });
+  //   const copyButton = within(copyMenuItem).getByRole('button');
+  //   await user.click(copyButton);
+  //
+  //   // Assert
+  //   expect(clipboard.writeText).toHaveBeenCalledWith('entity:sample_id\nsample_1\n');
+  // });
+});

--- a/src/components/data/EntitiesContent.test.ts
+++ b/src/components/data/EntitiesContent.test.ts
@@ -1,5 +1,5 @@
 import { DeepPartial } from '@terra-ui-packages/core-utils';
-import { act, render, screen, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as clipboard from 'clipboard-polyfill/text';
 import FileSaver from 'file-saver';
@@ -293,7 +293,7 @@ describe('EntitiesContent', () => {
     await user.click(columnMenu);
 
     // Filter
-    await user.type(screen.getByLabelText('Exact match filter'), 'even');
+    fireEvent.change(screen.getByLabelText('Exact match filter'), { target: { value: 'even' } });
 
     const menuModal = screen.getByRole('dialog');
     const searchButton = within(menuModal).getByRole('button', { name: 'Search' });

--- a/src/components/data/EntitiesContent.test.ts
+++ b/src/components/data/EntitiesContent.test.ts
@@ -317,7 +317,6 @@ describe('EntitiesContent', () => {
     expect(clipboard.writeText).toHaveBeenCalledWith('entity:sample_id\nsample_1\n');
   });
 
-
   it('downloads selection to tsv', async () => {
     // Arrange
     const user = userEvent.setup();

--- a/src/components/data/EntitiesContent.test.ts
+++ b/src/components/data/EntitiesContent.test.ts
@@ -2,6 +2,7 @@ import { DeepPartial } from '@terra-ui-packages/core-utils';
 import { act, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as clipboard from 'clipboard-polyfill/text';
+import FileSaver from 'file-saver';
 import { h } from 'react-hyperscript-helpers';
 import { defaultGoogleWorkspace } from 'src/analysis/_testData/testData';
 import { Ajax } from 'src/libs/ajax';
@@ -49,6 +50,15 @@ jest.mock('clipboard-polyfill/text', (): ClipboardPolyfillExports => {
   return {
     ...actual,
     writeText: jest.fn().mockResolvedValue(undefined),
+  };
+});
+
+type FileSaveExports = typeof import('file-saver');
+jest.mock('file-saver', (): FileSaveExports => {
+  const actual = jest.requireActual<FileSaveExports>('file-saver');
+  return {
+    ...actual,
+    saveAs: jest.fn().mockResolvedValue(undefined),
   };
 });
 
@@ -217,7 +227,7 @@ describe('EntitiesContent', () => {
 
     // Assert
     expect(clipboard.writeText).toHaveBeenCalledWith(
-      'membership:sample_set_id\tsample\nsample_set_1\tsample_1\nsample_set_1\tsample_2'
+      'membership:sample_set_id\tsample\nsample_set_1\tsample_1\nsample_set_1\tsample_2\n'
     );
   });
 
@@ -286,90 +296,107 @@ describe('EntitiesContent', () => {
     await user.click(checkbox);
     screen.getByText('1 row selected');
 
-    // Copy to clipboard
+    // Download tsv
     const exportButton = screen.getByText('Export');
     await user.click(exportButton);
-    const copyMenuItem = screen.getByRole('menuitem', { name: 'Download as TSV' });
-    const copyButton = within(copyMenuItem).getByRole('button');
-    await user.click(copyButton);
+    const downloadMenuItem = screen.getByRole('menuitem', { name: 'Download as TSV' });
+    const downloadButton = within(downloadMenuItem).getByRole('button');
+    await user.click(downloadButton);
 
     // Assert
-    expect(clipboard.writeText).toHaveBeenCalledWith('entity:sample_id\nsample_1\n');
+    expect(FileSaver.saveAs).toHaveBeenCalledWith(new Blob(['entity:sample_id\nsample_1\n']), 'sample.tsv');
   });
 
-  // it('downloads set table selection to tsv', async () => {
-  //   // Arrange
-  //   const user = userEvent.setup();
-  //
-  //   const paginatedEntitiesOfType = jest.fn().mockResolvedValue({
-  //     results: [
-  //       {
-  //         entityType: 'sample',
-  //         name: 'sample_1',
-  //         attributes: {},
-  //       },
-  //     ],
-  //     resultMetadata: { filteredCount: 1, unfilteredCount: 1 },
-  //   });
-  //   const mockAjax: DeepPartial<AjaxContract> = {
-  //     Workspaces: {
-  //       workspace: () => {
-  //         return {
-  //           paginatedEntitiesOfType,
-  //         };
-  //       },
-  //     },
-  //     Metrics: {
-  //       captureEvent: () => {},
-  //     },
-  //   };
-  //   asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
-  //
-  //   await act(async () => {
-  //     render(
-  //       h(EntitiesContent, {
-  //         workspace: {
-  //           ...defaultGoogleWorkspace,
-  //           workspace: {
-  //             ...defaultGoogleWorkspace.workspace,
-  //             attributes: {},
-  //           },
-  //           workspaceSubmissionStats: {
-  //             runningSubmissionsCount: 0,
-  //           },
-  //         },
-  //         entityKey: 'sample',
-  //         activeCrossTableTextFilter: '',
-  //         entityMetadata: {
-  //           sample: {
-  //             idName: 'sample_id',
-  //             attributeNames: [],
-  //             count: 1,
-  //           },
-  //         },
-  //         setEntityMetadata: () => {},
-  //         loadMetadata: () => {},
-  //         snapshotName: null,
-  //         deleteColumnUpdateMetadata: () => {},
-  //       })
-  //     );
-  //   });
-  //
-  //   // Act
-  //
-  //   // Select entity
-  //   const checkbox = screen.getByRole('checkbox', { name: 'sample_1' });
-  //   await user.click(checkbox);
-  //   screen.getByText('1 row selected');
-  //
-  //   // Copy to clipboard
-  //   const exportButton = screen.getByText('Export');
-  //   await user.click(exportButton);
-  //   const copyMenuItem = screen.getByRole('menuitem', { name: 'Copy to clipboard' });
-  //   const copyButton = within(copyMenuItem).getByRole('button');
-  //   await user.click(copyButton);
-  //
-  //   // Assert
-  //   expect(clipboard.writeText).toHaveBeenCalledWith('entity:sample_id\nsample_1\n');
-  // });
+  it('downloads set table selection to tsv', async () => {
+    // Arrange
+    const user = userEvent.setup();
+
+    const paginatedEntitiesOfType = jest.fn().mockResolvedValue({
+      results: [
+        {
+          entityType: 'sample_set',
+          name: 'sample_set_1',
+          attributes: {
+            samples: {
+              itemsType: 'EntityReference',
+              items: [
+                {
+                  entityType: 'sample',
+                  entityName: 'sample_1',
+                },
+                {
+                  entityType: 'sample',
+                  entityName: 'sample_2',
+                },
+              ],
+            },
+          },
+        },
+      ],
+      resultMetadata: { filteredCount: 1, unfilteredCount: 1 },
+    });
+    const mockAjax: DeepPartial<AjaxContract> = {
+      Workspaces: {
+        workspace: () => {
+          return {
+            paginatedEntitiesOfType,
+          };
+        },
+      },
+      Metrics: {
+        captureEvent: () => {},
+      },
+    };
+    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+
+    await act(async () => {
+      render(
+        h(EntitiesContent, {
+          workspace: {
+            ...defaultGoogleWorkspace,
+            workspace: {
+              ...defaultGoogleWorkspace.workspace,
+              attributes: {},
+            },
+            workspaceSubmissionStats: {
+              runningSubmissionsCount: 0,
+            },
+          },
+          entityKey: 'sample_set',
+          activeCrossTableTextFilter: '',
+          entityMetadata: {
+            sample_set: {
+              idName: 'sample_set_id',
+              attributeNames: ['samples'],
+              count: 1,
+            },
+          },
+          setEntityMetadata: () => {},
+          loadMetadata: () => {},
+          snapshotName: null,
+          deleteColumnUpdateMetadata: () => {},
+        })
+      );
+    });
+
+    // Act
+
+    // Select entity
+    const checkbox = screen.getByRole('checkbox', { name: 'sample_set_1' });
+    await user.click(checkbox);
+    screen.getByText('1 row selected');
+
+    // Download tsv
+    const exportButton = screen.getByText('Export');
+    await user.click(exportButton);
+    const downloadMenuItem = screen.getByRole('menuitem', { name: 'Download as TSV' });
+    const downloadButton = within(downloadMenuItem).getByRole('button');
+    await user.click(downloadButton);
+
+    // Assert
+    expect(FileSaver.saveAs).toHaveBeenCalledWith(
+      new Blob(['membership:sample_set_id\\tsample\\nsample_set_1\\tsample_1\\nsample_set_1\\tsample_2']),
+      'sample_set.zip'
+    );
+  });
 });

--- a/src/components/data/EntitiesContent.test.ts
+++ b/src/components/data/EntitiesContent.test.ts
@@ -226,9 +226,7 @@ describe('EntitiesContent', () => {
     await user.click(copyButton);
 
     // Assert
-    expect(clipboard.writeText).toHaveBeenCalledWith(
-      'membership:sample_set_id\tsample\nsample_set_1\tsample_1\nsample_set_1\tsample_2\n'
-    );
+    expect(clipboard.writeText).toHaveBeenCalledWith('entity:sample_set_id\nsample_set_1\n');
   });
 
   it('downloads selection to tsv', async () => {

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -905,8 +905,8 @@ export const TooltipCell = ({ children, tooltip, ...props }) =>
     [h(TextCell, props, [children])]
   );
 
-export const HeaderCell = (props) => {
-  return h(TextCell, _.merge({ style: { fontWeight: 600 } }, props));
+export const HeaderCell = ({ children, ...props }) => {
+  return h(TextCell, _.merge({ style: { fontWeight: 600 } }, props), [children]);
 };
 
 const getSortIcon = (sort, field, hovered) => {


### PR DESCRIPTION
### Jira Ticket: [AJ-1037](https://broadworkbench.atlassian.net/browse/AJ-1037)

Using the 'exact match filter' on a column was not propagating correctly to either selecting rows or exporting.  Thus, if a user used exact match filter and then chose 'select all filtered' and tried to download to a tsv, the result would be the entier entity set instead of the filtered set as expected.  This was due to the filter not being included as a parameter when determining which entities were on the page/selected.

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Adds the 'columnFilter' parameter to `paginatedEntitiesOfType`
- Adds unit tests around selecting rows and copying filtered selections
- Fixes a pre-existing problem with `HeaderCell` that caused ` Warning: Each child in a list should have a unique "key" prop`

### Testing strategy
- [x] Manually testing
- [x] Added unit tests

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 


[AJ-1037]: https://broadworkbench.atlassian.net/browse/AJ-1037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ