### PR TITLE
[WM-2186] Fix logs column in GCP Job History

### DIFF
--- a/src/pages/workspaces/workspace/jobHistory/CallTable.js
+++ b/src/pages/workspaces/workspace/jobHistory/CallTable.js
@@ -333,19 +333,22 @@ const CallTable = ({
                   attempt,
                 } = filteredCallObjects[rowIndex];
                 const failureCount = _.size(failures);
-                if (_.isEmpty(subWorkflowId) && !stdout && !stderr && !inputs && !outputs && failureCount) {
-                  return h(
-                    Link,
-                    {
-                      style: { marginLeft: '0.5rem' },
-                      onClick: () => setFailuresModalParams({ callFqn: taskName, index, attempt, failures }),
-                    },
-                    [
-                      div({ style: { display: 'flex', alignItems: 'center' } }, [
-                        icon('warning-standard', { size: 18, style: { color: colors.warning(), marginRight: '0.5rem' } }),
-                        `${failureCount} Message${failureCount > 1 ? 's' : ''}`,
-                      ]),
-                    ]
+                if (_.isEmpty(subWorkflowId) && !stdout && !stderr && !inputs && !outputs) {
+                  return (
+                    !!failureCount &&
+                    h(
+                      Link,
+                      {
+                        style: { marginLeft: '0.5rem' },
+                        onClick: () => setFailuresModalParams({ callFqn: taskName, index, attempt, failures }),
+                      },
+                      [
+                        div({ style: { display: 'flex', alignItems: 'center' } }, [
+                          icon('warning-standard', { size: 18, style: { color: colors.warning(), marginRight: '0.5rem' } }),
+                          `${failureCount} Message${failureCount > 1 ? 's' : ''}`,
+                        ]),
+                      ]
+                    )
                   );
                 }
                 const style =


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WM-2186

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- GCP logs should show failure message if failed, and empty logs if not
- Azure logs should show inputs, outputs, stdout, stderr regardless of success/failure

### Why
- Previous logic to differentiate between GCP and Azure rendered inputs, outputs, stdout, stderr when workflows succeeded instead of rendering nothing

### Testing strategy
- Tested locally with both successful and failed workflows in GCP and Azure workspaces

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 
