### PR TITLE
[UIE-52] Use React Context for theming components

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,8 @@ module.exports = {
     'react/destructuring-assignment': 'off',
     // Use TypeScript instead of PropTypes for new code.
     'react/forbid-prop-types': 'off',
+    // Allow writing components as arrow functions.
+    'react/function-component-definition': 'off',
     'react/prop-types': 'off',
     'react/require-default-props': 'off',
     'react/sort-comp': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,6 +33,8 @@ module.exports = {
     // With eslint-import-resolver-typescript, ESLint sees 'date-fns' and 'date-fns/fp' as
     // duplicates and combines them into one import from 'date-fns'.
     'import/no-duplicates': 'off',
+    // Allow tests' dependencies to be listed in devDependencies or dependencies.
+    'import/no-extraneous-dependencies': ['error', { devDependencies: ['**/*.test.{js,ts}'] }],
     'import/no-named-as-default': 'off',
     // Named exports are more convenient for mocking.
     'import/prefer-default-export': 'off',

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -5064,6 +5064,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/jest", "npm:28.1.8"],\
             ["@types/lodash", "npm:4.14.184"],\
             ["@types/react", "npm:18.2.15"],\
+            ["color", "npm:4.0.1"],\
             ["jest", "virtual:8c00fb6d848584930a97145ab92981f57dfda3a26acb7c186ce59ef8e1d0c5c900af7e36dd05e12ff96b7235e88575a55bb45434a9589e1fb111101a9a3d2f5e#npm:27.5.1"],\
             ["lodash", "npm:4.17.21"],\
             ["react", "npm:18.2.0"],\
@@ -5085,6 +5086,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/jest", "npm:28.1.8"],\
             ["@types/lodash", "npm:4.14.184"],\
             ["@types/react", "npm:18.2.15"],\
+            ["color", "npm:4.0.1"],\
             ["jest", "virtual:8c00fb6d848584930a97145ab92981f57dfda3a26acb7c186ce59ef8e1d0c5c900af7e36dd05e12ff96b7235e88575a55bb45434a9589e1fb111101a9a3d2f5e#npm:27.5.1"],\
             ["lodash", "npm:4.17.21"],\
             ["react", "npm:18.2.0"],\

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -5061,13 +5061,17 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@terra-ui-packages/components", "virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#workspace:packages/components"],\
             ["@terra-ui-packages/build-utils", "virtual:6fecf1af4cab542f4a06b7ce7d9f710277dce92700e0011a9519e41948eed6d8f54c9d0aa109ead6cf4295edce81cb49620f9e823313e99632229bf20d133cdb#workspace:packages/build-utils"],\
             ["@terra-ui-packages/test-utils", "workspace:packages/test-utils"],\
+            ["@testing-library/dom", "npm:9.3.1"],\
+            ["@testing-library/react", "virtual:3cbce82a859ed6a4d5bf57a6b809aea2976beb02c6e1078f18e5e40f750e781222e51bcef76699e2500e623832ea4e45e9647ae7b14a57290a182e58c3827fe8#npm:14.0.0"],\
             ["@types/jest", "npm:28.1.8"],\
             ["@types/lodash", "npm:4.14.184"],\
             ["@types/react", "npm:18.2.15"],\
+            ["@types/testing-library__jest-dom", "npm:5.14.9"],\
             ["color", "npm:4.0.1"],\
             ["jest", "virtual:8c00fb6d848584930a97145ab92981f57dfda3a26acb7c186ce59ef8e1d0c5c900af7e36dd05e12ff96b7235e88575a55bb45434a9589e1fb111101a9a3d2f5e#npm:27.5.1"],\
             ["lodash", "npm:4.17.21"],\
             ["react", "npm:18.2.0"],\
+            ["react-hyperscript-helpers", "virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#npm:2.0.0"],\
             ["typescript", "patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=289587"],\
             ["vite", "virtual:6fecf1af4cab542f4a06b7ce7d9f710277dce92700e0011a9519e41948eed6d8f54c9d0aa109ead6cf4295edce81cb49620f9e823313e99632229bf20d133cdb#npm:4.4.7"]\
           ],\
@@ -5083,13 +5087,17 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@terra-ui-packages/components", "workspace:packages/components"],\
             ["@terra-ui-packages/build-utils", "virtual:6fecf1af4cab542f4a06b7ce7d9f710277dce92700e0011a9519e41948eed6d8f54c9d0aa109ead6cf4295edce81cb49620f9e823313e99632229bf20d133cdb#workspace:packages/build-utils"],\
             ["@terra-ui-packages/test-utils", "workspace:packages/test-utils"],\
+            ["@testing-library/dom", "npm:9.3.1"],\
+            ["@testing-library/react", "virtual:3cbce82a859ed6a4d5bf57a6b809aea2976beb02c6e1078f18e5e40f750e781222e51bcef76699e2500e623832ea4e45e9647ae7b14a57290a182e58c3827fe8#npm:14.0.0"],\
             ["@types/jest", "npm:28.1.8"],\
             ["@types/lodash", "npm:4.14.184"],\
             ["@types/react", "npm:18.2.15"],\
+            ["@types/testing-library__jest-dom", "npm:5.14.9"],\
             ["color", "npm:4.0.1"],\
             ["jest", "virtual:8c00fb6d848584930a97145ab92981f57dfda3a26acb7c186ce59ef8e1d0c5c900af7e36dd05e12ff96b7235e88575a55bb45434a9589e1fb111101a9a3d2f5e#npm:27.5.1"],\
             ["lodash", "npm:4.17.21"],\
             ["react", "npm:18.2.0"],\
+            ["react-hyperscript-helpers", "virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#npm:2.0.0"],\
             ["typescript", "patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=289587"],\
             ["vite", "virtual:6fecf1af4cab542f4a06b7ce7d9f710277dce92700e0011a9519e41948eed6d8f54c9d0aa109ead6cf4295edce81cb49620f9e823313e99632229bf20d133cdb#npm:4.4.7"]\
           ],\
@@ -5192,6 +5200,24 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],\
           "packagePeers": [\
             "@types/react-dom",\
+            "@types/react",\
+            "react-dom",\
+            "react"\
+          ],\
+          "linkType": "HARD"\
+        }],\
+        ["virtual:3cbce82a859ed6a4d5bf57a6b809aea2976beb02c6e1078f18e5e40f750e781222e51bcef76699e2500e623832ea4e45e9647ae7b14a57290a182e58c3827fe8#npm:14.0.0", {\
+          "packageLocation": "./.yarn/__virtual__/@testing-library-react-virtual-05aa26d0eb/0/cache/@testing-library-react-npm-14.0.0-84fecd033b-4a54c8f56c.zip/node_modules/@testing-library/react/",\
+          "packageDependencies": [\
+            ["@testing-library/react", "virtual:3cbce82a859ed6a4d5bf57a6b809aea2976beb02c6e1078f18e5e40f750e781222e51bcef76699e2500e623832ea4e45e9647ae7b14a57290a182e58c3827fe8#npm:14.0.0"],\
+            ["@babel/runtime", "npm:7.22.6"],\
+            ["@testing-library/dom", "npm:9.3.1"],\
+            ["@types/react", "npm:18.2.15"],\
+            ["@types/react-dom", "npm:18.2.7"],\
+            ["react", "npm:18.2.0"],\
+            ["react-dom", null]\
+          ],\
+          "packagePeers": [\
             "@types/react",\
             "react-dom",\
             "react"\

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -24,14 +24,18 @@
   ],
   "dependencies": {
     "color": "^4.0.1",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "react-hyperscript-helpers": "^2.0.0"
   },
   "devDependencies": {
     "@terra-ui-packages/build-utils": "^1.0.0",
     "@terra-ui-packages/test-utils": "*",
+    "@testing-library/dom": "^9.3.1",
+    "@testing-library/react": "^14.0.0",
     "@types/jest": "^28.1.8",
     "@types/lodash": "^4.14.184",
     "@types/react": "^18.2.15",
+    "@types/testing-library__jest-dom": "^5.14.9",
     "jest": "^27.4.3",
     "react": "18.2.0",
     "typescript": "^4.9.5",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -23,6 +23,7 @@
     "lib/types/**"
   ],
   "dependencies": {
+    "color": "^4.0.1",
     "lodash": "^4.17.21"
   },
   "devDependencies": {

--- a/packages/components/src/ErrorBoundary.test.ts
+++ b/packages/components/src/ErrorBoundary.test.ts
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import { div, h } from 'react-hyperscript-helpers';
+
+import { ErrorBoundary } from './ErrorBoundary';
+
+describe('ErrorBoundary', () => {
+  it('renders children', () => {
+    // Act
+    render(h(ErrorBoundary, [div(['Hello world'])]));
+
+    // Assert
+    screen.getByText('Hello world');
+  });
+
+  it('catches render error and renders nothing', () => {
+    // Arrange
+    const TestComponent = () => {
+      throw new Error('Something went wrong!');
+    };
+
+    // Prevent React from logging the error.
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    // Act
+    const { container } = render(h(ErrorBoundary, [h(TestComponent)]));
+
+    // Assert
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('calls onError callback with error', () => {
+    // Arrange
+    const TestComponent = () => {
+      throw new Error('Something went wrong!');
+    };
+
+    const onError = jest.fn();
+
+    // Prevent React from logging the error.
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    // Act
+    render(h(ErrorBoundary, { onError }, [h(TestComponent)]));
+
+    // Assert
+    expect(onError).toHaveBeenCalledWith(new Error('Something went wrong!'));
+  });
+});

--- a/packages/components/src/ErrorBoundary.ts
+++ b/packages/components/src/ErrorBoundary.ts
@@ -1,0 +1,31 @@
+import { Component, PropsWithChildren } from 'react';
+
+export type ErrorBoundaryProps = PropsWithChildren<{
+  onError?: (error: unknown) => void;
+}>;
+
+type ErrorBoundaryState = {
+  hasError: boolean;
+};
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error) {
+    const { onError } = this.props;
+    onError?.(error);
+  }
+
+  render() {
+    const { children } = this.props;
+    const { hasError } = this.state;
+    return hasError ? null : children;
+  }
+}

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,2 +1,3 @@
+export * from './ErrorBoundary';
 export { Interactive } from './Interactive';
 export * from './theme';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,1 +1,2 @@
 export { Interactive } from './Interactive';
+export * from './theme';

--- a/packages/components/src/theme.test.ts
+++ b/packages/components/src/theme.test.ts
@@ -4,7 +4,7 @@ import { h } from 'react-hyperscript-helpers';
 import { ErrorBoundary } from './ErrorBoundary';
 import { Theme, ThemeProvider, useThemeFromContext } from './theme';
 
-describe('useContextFromTheme', () => {
+describe('useThemeFromContext', () => {
   it('gets theme from context', () => {
     // Arrange
     const onRenderWithTheme = jest.fn();

--- a/packages/components/src/theme.test.ts
+++ b/packages/components/src/theme.test.ts
@@ -1,0 +1,60 @@
+import { render } from '@testing-library/react';
+import { h } from 'react-hyperscript-helpers';
+
+import { ErrorBoundary } from './ErrorBoundary';
+import { Theme, ThemeProvider, useThemeFromContext } from './theme';
+
+describe('useContextFromTheme', () => {
+  it('gets theme from context', () => {
+    // Arrange
+    const onRenderWithTheme = jest.fn();
+
+    const TestComponent = () => {
+      const theme = useThemeFromContext();
+      onRenderWithTheme(theme);
+      return null;
+    };
+
+    const theme: Theme = {
+      colorPalette: {
+        primary: '#74ae43',
+        secondary: '#6d6e70',
+        accent: '#4d72aa',
+        success: '#74ae43',
+        warning: '#f7981c',
+        danger: '#db3214',
+        light: '#e9ecef',
+        dark: '#333f52',
+        grey: '#808080',
+        disabled: '#b6b7b8',
+      },
+    };
+
+    // Act
+    render(h(ThemeProvider, { theme }, [h(TestComponent)]));
+
+    // Assert
+    expect(onRenderWithTheme).toHaveBeenCalledWith(expect.objectContaining(theme));
+  });
+
+  it('throw an error if no theme is provided', () => {
+    // Arrange
+    const onRenderError = jest.fn();
+
+    const TestComponent = () => {
+      useThemeFromContext();
+      return null;
+    };
+
+    // Prevent React from logging the error.
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    // Act
+    render(h(ErrorBoundary, { onError: onRenderError }, [h(TestComponent)]));
+
+    // Assert
+    expect(onRenderError).toHaveBeenCalledWith(
+      new Error('No theme provided. Components using useThemeFromContext must be descendants of ThemeProvider.')
+    );
+  });
+});

--- a/packages/components/src/theme.ts
+++ b/packages/components/src/theme.ts
@@ -24,21 +24,6 @@ export type Theme = {
   colorPalette: ColorPalette;
 };
 
-const defaultTheme: Theme = {
-  colorPalette: {
-    primary: '#74ae43',
-    secondary: '#6d6e70',
-    accent: '#4d72aa',
-    success: '#74ae43',
-    warning: '#f7981c',
-    danger: '#db3214',
-    light: '#e9ecef',
-    dark: '#333f52',
-    grey: '#808080',
-    disabled: '#b6b7b8',
-  },
-};
-
 type EnrichedTheme = Theme & {
   colors: { [Color in keyof ColorPalette]: (intensity?: number) => string };
 };
@@ -58,7 +43,7 @@ const enrichTheme = (theme: Theme): EnrichedTheme => {
   };
 };
 
-const EnrichedThemeContext = createContext(enrichTheme(defaultTheme));
+const EnrichedThemeContext = createContext<EnrichedTheme | null>(null);
 
 type ThemeProviderProps = PropsWithChildren<{
   theme: Theme;
@@ -69,4 +54,10 @@ export const ThemeProvider = (props: ThemeProviderProps) => {
   return createElement(EnrichedThemeContext.Provider, { value: enrichTheme(theme) }, children);
 };
 
-export const useThemeFromContext = (): EnrichedTheme => useContext(EnrichedThemeContext);
+export const useThemeFromContext = (): EnrichedTheme => {
+  const theme = useContext(EnrichedThemeContext);
+  if (!theme) {
+    throw new Error('No theme provided. Components using useThemeFromContext must be descendants of ThemeProvider.');
+  }
+  return theme;
+};

--- a/packages/components/src/theme.ts
+++ b/packages/components/src/theme.ts
@@ -25,13 +25,13 @@ export type Theme = {
   colorPalette: ColorPalette;
 };
 
-type EnrichedTheme = Theme & {
+export type EnrichedTheme = Theme & {
   /** Color mixing functions. Each takes an "intensity" and returns a modified color. */
   colors: { [Color in keyof ColorPalette]: (intensity?: number) => string };
 };
 
 /** Add additional functionality (color mixing functions) to theme. */
-const enrichTheme = (theme: Theme): EnrichedTheme => {
+export const enrichTheme = (theme: Theme): EnrichedTheme => {
   const colors = mapValues((color: string) => {
     return (intensity = 1): string => {
       return Color(color)

--- a/packages/components/src/theme.ts
+++ b/packages/components/src/theme.ts
@@ -1,0 +1,72 @@
+import Color from 'color';
+import { mapValues } from 'lodash/fp';
+import { createContext, createElement, PropsWithChildren, useContext } from 'react';
+
+type ColorPalette = {
+  /** Used as accent on header, loading spinner, background of beta version tag and some buttons */
+  primary: string;
+  /** Used as footer background */
+  secondary: string;
+  /** Used as button backgrounds, headers, links */
+  accent: string;
+  success: string;
+  warning: string;
+  danger: string;
+  /** Used as header background color, lightened for background of cells, panels, etc. */
+  light: string;
+  /** Used as text color, menu background (lightened), selected background (lightened) */
+  dark: string;
+  grey: string;
+  disabled: string;
+};
+
+export type Theme = {
+  colorPalette: ColorPalette;
+};
+
+const defaultTheme: Theme = {
+  colorPalette: {
+    primary: '#74ae43',
+    secondary: '#6d6e70',
+    accent: '#4d72aa',
+    success: '#74ae43',
+    warning: '#f7981c',
+    danger: '#db3214',
+    light: '#e9ecef',
+    dark: '#333f52',
+    grey: '#808080',
+    disabled: '#b6b7b8',
+  },
+};
+
+type EnrichedTheme = Theme & {
+  colors: { [Color in keyof ColorPalette]: (intensity?: number) => string };
+};
+
+const enrichTheme = (theme: Theme): EnrichedTheme => {
+  const colors = mapValues((color: string) => {
+    return (intensity = 1): string => {
+      return Color(color)
+        .mix(Color('white'), 1 - intensity)
+        .hex();
+    };
+  }, theme.colorPalette) as EnrichedTheme['colors'];
+
+  return {
+    ...theme,
+    colors,
+  };
+};
+
+const EnrichedThemeContext = createContext(enrichTheme(defaultTheme));
+
+type ThemeProviderProps = PropsWithChildren<{
+  theme: Theme;
+}>;
+
+export const ThemeProvider = (props: ThemeProviderProps) => {
+  const { children, theme } = props;
+  return createElement(EnrichedThemeContext.Provider, { value: enrichTheme(theme) }, children);
+};
+
+export const useTheme = (): EnrichedTheme => useContext(EnrichedThemeContext);

--- a/packages/components/src/theme.ts
+++ b/packages/components/src/theme.ts
@@ -21,13 +21,16 @@ type ColorPalette = {
 };
 
 export type Theme = {
+  /** Base color palette for theme. */
   colorPalette: ColorPalette;
 };
 
 type EnrichedTheme = Theme & {
+  /** Color mixing functions. Each takes an "intensity" and returns a modified color. */
   colors: { [Color in keyof ColorPalette]: (intensity?: number) => string };
 };
 
+/** Add additional functionality (color mixing functions) to theme. */
 const enrichTheme = (theme: Theme): EnrichedTheme => {
   const colors = mapValues((color: string) => {
     return (intensity = 1): string => {
@@ -49,11 +52,13 @@ type ThemeProviderProps = PropsWithChildren<{
   theme: Theme;
 }>;
 
+/** Provides a theme to descendents via React Context. */
 export const ThemeProvider = (props: ThemeProviderProps) => {
   const { children, theme } = props;
   return createElement(EnrichedThemeContext.Provider, { value: enrichTheme(theme) }, children);
 };
 
+/** Gets the current theme from React context. */
 export const useThemeFromContext = (): EnrichedTheme => {
   const theme = useContext(EnrichedThemeContext);
   if (!theme) {

--- a/packages/components/src/theme.ts
+++ b/packages/components/src/theme.ts
@@ -69,4 +69,4 @@ export const ThemeProvider = (props: ThemeProviderProps) => {
   return createElement(EnrichedThemeContext.Provider, { value: enrichTheme(theme) }, children);
 };
 
-export const useTheme = (): EnrichedTheme => useContext(EnrichedThemeContext);
+export const useThemeFromContext = (): EnrichedTheme => useContext(EnrichedThemeContext);

--- a/src/components/common/buttons.js
+++ b/src/components/common/buttons.js
@@ -1,4 +1,4 @@
-import { useTheme } from '@terra-ui-packages/components';
+import { useThemeFromContext } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { h } from 'react-hyperscript-helpers';
 
@@ -17,7 +17,7 @@ const buttonStyle = {
 };
 
 export const ButtonPrimary = ({ disabled, danger = false, children, ...props }) => {
-  const { colors } = useTheme();
+  const { colors } = useThemeFromContext();
   return h(
     Clickable,
     _.merge(
@@ -41,7 +41,7 @@ export const ButtonPrimary = ({ disabled, danger = false, children, ...props }) 
 };
 
 export const ButtonSecondary = ({ disabled, children, ...props }) => {
-  const { colors } = useTheme();
+  const { colors } = useThemeFromContext();
   return h(
     Clickable,
     _.merge(
@@ -61,7 +61,7 @@ export const ButtonSecondary = ({ disabled, children, ...props }) => {
 };
 
 export const ButtonOutline = ({ disabled, children, ...props }) => {
-  const { colors } = useTheme();
+  const { colors } = useThemeFromContext();
   return h(
     ButtonPrimary,
     _.merge(

--- a/src/components/common/buttons.js
+++ b/src/components/common/buttons.js
@@ -1,6 +1,6 @@
+import { useTheme } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { h } from 'react-hyperscript-helpers';
-import colors from 'src/libs/colors';
 
 import { Clickable } from './Clickable';
 
@@ -17,6 +17,7 @@ const buttonStyle = {
 };
 
 export const ButtonPrimary = ({ disabled, danger = false, children, ...props }) => {
+  const { colors } = useTheme();
   return h(
     Clickable,
     _.merge(
@@ -40,6 +41,7 @@ export const ButtonPrimary = ({ disabled, danger = false, children, ...props }) 
 };
 
 export const ButtonSecondary = ({ disabled, children, ...props }) => {
+  const { colors } = useTheme();
   return h(
     Clickable,
     _.merge(
@@ -59,6 +61,7 @@ export const ButtonSecondary = ({ disabled, children, ...props }) => {
 };
 
 export const ButtonOutline = ({ disabled, children, ...props }) => {
+  const { colors } = useTheme();
   return h(
     ButtonPrimary,
     _.merge(

--- a/src/libs/brand-utils.test.ts
+++ b/src/libs/brand-utils.test.ts
@@ -25,6 +25,7 @@ describe('brand-utils', () => {
       color: '',
       white: '',
     },
+    theme: defaultBrand.theme,
   };
 
   describe('isBrand', () => {

--- a/src/libs/brands.ts
+++ b/src/libs/brands.ts
@@ -1,3 +1,4 @@
+import { Theme } from '@terra-ui-packages/components';
 import anvilLogo from 'src/images/brands/anvil/ANVIL-Logo.svg';
 import anvilLogoWhite from 'src/images/brands/anvil/ANVIL-Logo-White.svg';
 import baselineLogo from 'src/images/brands/baseline/baseline-logo-color.svg';
@@ -60,7 +61,23 @@ export interface BrandConfiguration {
 
   /** Optionally filter which datasets show up in the Data Catalog */
   catalogDataCollectionsToInclude?: string[];
+
+  /** Theme for components */
+  theme: Theme;
 }
+
+const baseColors = {
+  primary: '#74ae43', // Used as accent on header, loading spinner, background of beta version tag and some buttons
+  secondary: '#6d6e70', // Used as footer background
+  accent: '#4d72aa', // Used as button backgrounds, headers, links
+  success: '#74ae43',
+  warning: '#f7981c',
+  danger: '#db3214',
+  light: '#e9ecef', // Used as header background color, lightened for background of cells, panels, etc.
+  dark: '#333f52', // Used as text color, menu background (lightened), selected background (lightened)
+  grey: '#808080',
+  disabled: '#b6b7b8',
+};
 
 /**
  * Configuration for Terra co-brands (a.k.a. white label sites)
@@ -84,6 +101,9 @@ export const brands: Record<string, BrandConfiguration> = {
       color: anvilLogo,
       white: anvilLogoWhite,
     },
+    theme: {
+      colorPalette: { ...baseColors, primary: '#e0dd10', accent: '#035c94', light: '#f6f7f4', dark: '#012840' },
+    },
   },
   baseline: {
     name: 'Project Baseline',
@@ -101,6 +121,9 @@ export const brands: Record<string, BrandConfiguration> = {
     logos: {
       color: baselineLogo,
       white: baselineLogoWhite,
+    },
+    theme: {
+      colorPalette: { ...baseColors, primary: '#c41061', secondary: '#31164c', light: '#f6f7f4', dark: '#012840' },
     },
   },
   bioDataCatalyst: {
@@ -120,6 +143,16 @@ export const brands: Record<string, BrandConfiguration> = {
       color: bioDataCatalystLogo,
       white: bioDataCatalystLogoWhite,
     },
+    theme: {
+      colorPalette: {
+        ...baseColors,
+        primary: '#c0143c',
+        secondary: '#1a568c',
+        accent: '#1a568c',
+        light: '#f4f4f6',
+        dark: '#12385a',
+      },
+    },
   },
   datastage: {
     name: 'DataStage',
@@ -138,6 +171,16 @@ export const brands: Record<string, BrandConfiguration> = {
       color: datastageLogo,
       white: datastageLogoWhite,
     },
+    theme: {
+      colorPalette: {
+        ...baseColors,
+        primary: '#c02f42',
+        secondary: '#1a568c',
+        accent: '#1a568c',
+        light: '#f4f4f6',
+        dark: '#12385a',
+      },
+    },
   },
   elwazi: {
     name: 'eLwazi',
@@ -155,6 +198,16 @@ export const brands: Record<string, BrandConfiguration> = {
     logos: {
       color: elwaziLogo,
       white: elwaziLogoWhite,
+    },
+    theme: {
+      colorPalette: {
+        ...baseColors,
+        primary: '#c13f27',
+        secondary: '#c13f27',
+        dark: '#1d1d1b',
+        accent: '#6e3d3b',
+        success: '#9eb642',
+      },
     },
   },
   firecloud: {
@@ -182,6 +235,9 @@ export const brands: Record<string, BrandConfiguration> = {
       color: fcLogo,
       white: fcLogoWhite,
     },
+    theme: {
+      colorPalette: { ...baseColors, primary: '#4d72aa' },
+    },
   },
   projectSingular: {
     name: 'Project Singular',
@@ -199,6 +255,9 @@ export const brands: Record<string, BrandConfiguration> = {
     logos: {
       color: projectSingularLogo,
       white: projectSingularLogoWhite,
+    },
+    theme: {
+      colorPalette: { ...baseColors, primary: '#521b93', secondary: '#011c48', accent: '#521b93' },
     },
   },
   rareX: {
@@ -225,6 +284,16 @@ export const brands: Record<string, BrandConfiguration> = {
       color: rareXLogo,
       white: rareXLogoWhite,
     },
+    theme: {
+      colorPalette: {
+        ...baseColors,
+        primary: '#26355c',
+        secondary: '#26355c',
+        dark: '#414042',
+        accent: '#4e6888',
+        light: '#f4efea',
+      },
+    },
   },
   terra: {
     name: 'Terra',
@@ -247,6 +316,9 @@ export const brands: Record<string, BrandConfiguration> = {
       color: terraLogo,
       white: terraLogoWhite,
       shadow: terraLogoShadow,
+    },
+    theme: {
+      colorPalette: { ...baseColors },
     },
   },
 };

--- a/src/libs/brands.ts
+++ b/src/libs/brands.ts
@@ -66,15 +66,15 @@ export interface BrandConfiguration {
   theme: Theme;
 }
 
-const baseColors = {
-  primary: '#74ae43', // Used as accent on header, loading spinner, background of beta version tag and some buttons
-  secondary: '#6d6e70', // Used as footer background
-  accent: '#4d72aa', // Used as button backgrounds, headers, links
+const baseColors: Theme['colorPalette'] = {
+  primary: '#74ae43',
+  secondary: '#6d6e70',
+  accent: '#4d72aa',
   success: '#74ae43',
   warning: '#f7981c',
   danger: '#db3214',
-  light: '#e9ecef', // Used as header background color, lightened for background of cells, panels, etc.
-  dark: '#333f52', // Used as text color, menu background (lightened), selected background (lightened)
+  light: '#e9ecef',
+  dark: '#333f52',
   grey: '#808080',
   disabled: '#b6b7b8',
 };

--- a/src/libs/colors.js
+++ b/src/libs/colors.js
@@ -1,57 +1,16 @@
 import Color from 'color';
 import _ from 'lodash/fp';
-import {
-  isAnvil,
-  isBaseline,
-  isBioDataCatalyst,
-  isDatastage,
-  isElwazi,
-  isFirecloud,
-  isProjectSingular,
-  isRareX,
-  isTerra,
-} from 'src/libs/brand-utils';
-import * as Utils from 'src/libs/utils';
+import { getEnabledBrand, isTerra } from 'src/libs/brand-utils';
 
-const ALL_COLORS = ['primary', 'secondary', 'accent', 'success', 'warning', 'danger', 'light', 'dark', 'grey', 'disabled'];
+const enabledBrand = getEnabledBrand();
 
-const baseColors = {
-  primary: '#4d72aa', // Used as accent on header, loading spinner, background of beta version tag and some buttons
-  secondary: '#6d6e70', // Used as footer background
-  accent: '#4d72aa', // Used as button backgrounds, headers, links
-  success: '#74ae43',
-  warning: '#f7981c',
-  danger: '#db3214',
-  light: '#e9ecef', // Used as header background color, lightened for background of cells, panels, etc.
-  dark: '#333f52', // Used as text color, menu background (lightened), selected background (lightened)
-  grey: '#808080',
-  disabled: '#b6b7b8',
-};
-
-const colorPalette = Utils.cond(
-  [isFirecloud(), () => baseColors],
-  [isDatastage(), () => ({ ...baseColors, primary: '#c02f42', secondary: '#1a568c', accent: '#1a568c', light: '#f4f4f6', dark: '#12385a' })],
-  [isAnvil(), () => ({ ...baseColors, primary: '#e0dd10', accent: '#035c94', light: '#f6f7f4', dark: '#012840' })],
-  [isBioDataCatalyst(), () => ({ ...baseColors, primary: '#c0143c', secondary: '#1a568c', accent: '#1a568c', light: '#f4f4f6', dark: '#12385a' })],
-  [isBaseline(), () => ({ ...baseColors, primary: '#c41061', secondary: '#31164c', light: '#f6f7f4', dark: '#012840' })],
-  [isElwazi(), () => ({ ...baseColors, primary: '#c13f27', secondary: '#c13f27', dark: '#1d1d1b', accent: '#6e3d3b', success: '#9eb642' })],
-  [isProjectSingular(), () => ({ ...baseColors, primary: '#521b93', secondary: '#011c48', accent: '#521b93' })],
-  [isRareX(), () => ({ ...baseColors, primary: '#26355c', secondary: '#26355c', dark: '#414042', accent: '#4e6888', light: '#f4efea' })],
-  () => ({ ...baseColors, primary: '#74ae43' })
-);
-
-const colors = _.fromPairs(
-  _.map(
-    (color) => [
-      color,
-      (intensity = 1) =>
-        Color(colorPalette[color])
-          .mix(Color('white'), 1 - intensity)
-          .hex(),
-    ],
-    ALL_COLORS
-  )
-);
+const colors = _.mapValues((color) => {
+  return (intensity = 1) => {
+    return Color(color)
+      .mix(Color('white'), 1 - intensity)
+      .hex();
+  };
+}, enabledBrand.theme.colorPalette);
 
 export const terraSpecial = (intensity) => (isTerra() ? colors.primary(intensity) : colors.accent(intensity));
 

--- a/src/pages/Main.js
+++ b/src/pages/Main.js
@@ -1,5 +1,6 @@
 import 'src/libs/routes';
 
+import { ThemeProvider } from '@terra-ui-packages/components';
 import { h } from 'react-hyperscript-helpers';
 import { ReactNotifications } from 'react-notifications-component';
 import { AuthProvider } from 'react-oidc-context';
@@ -17,28 +18,31 @@ import ImportStatus from 'src/components/ImportStatus';
 import SupportRequest from 'src/components/SupportRequest';
 import { TitleManager } from 'src/components/TitleManager';
 import { getOidcConfig } from 'src/libs/auth';
+import { getEnabledBrand } from 'src/libs/brand-utils';
 import { PageViewReporter } from 'src/libs/events';
 import { LocationProvider, PathHashInserter, Router } from 'src/libs/nav';
 
 const Main = () => {
-  return h(LocationProvider, [
-    h(PathHashInserter),
-    h(CookieRejectModal),
-    h(CookieWarning),
-    h(ReactNotifications),
-    h(ImportStatus),
-    h(Favicon),
-    h(IdleStatusMonitor),
-    h(ErrorWrapper, [
-      h(TitleManager),
-      h(FirecloudNotification),
-      h(AuthenticatedCookieSetter),
-      h(AuthProvider, getOidcConfig(), [h(AuthStoreSetter)]),
-      h(AuthContainer, [h(Router)]),
+  return h(ThemeProvider, { theme: getEnabledBrand().theme }, [
+    h(LocationProvider, [
+      h(PathHashInserter),
+      h(CookieRejectModal),
+      h(CookieWarning),
+      h(ReactNotifications),
+      h(ImportStatus),
+      h(Favicon),
+      h(IdleStatusMonitor),
+      h(ErrorWrapper, [
+        h(TitleManager),
+        h(FirecloudNotification),
+        h(AuthenticatedCookieSetter),
+        h(AuthProvider, getOidcConfig(), [h(AuthStoreSetter)]),
+        h(AuthContainer, [h(Router)]),
+      ]),
+      h(PageViewReporter),
+      h(SupportRequest),
+      h(ConfigOverridesWarning),
     ]),
-    h(PageViewReporter),
-    h(SupportRequest),
-    h(ConfigOverridesWarning),
   ]);
 };
 

--- a/src/pages/library/Datasets.test.js
+++ b/src/pages/library/Datasets.test.js
@@ -1,16 +1,18 @@
 import { render } from '@testing-library/react';
 import { h } from 'react-hyperscript-helpers';
-import { getEnabledBrand } from 'src/libs/brand-utils';
 import { brands } from 'src/libs/brands';
 import * as Nav from 'src/libs/nav';
 import { dataCatalogStore } from 'src/libs/state';
 import { prepareDatasetsForDisplay } from 'src/pages/library/dataBrowser-utils';
 import { Datasets } from 'src/pages/library/Datasets';
 
-jest.mock('src/libs/brand-utils', () => ({
-  ...jest.requireActual('src/libs/brand-utils'),
-  getEnabledBrand: jest.fn(),
-}));
+jest.mock('src/libs/brand-utils', () => {
+  const { brands } = jest.requireActual('src/libs/brands');
+  return {
+    ...jest.requireActual('src/libs/brand-utils'),
+    getEnabledBrand: jest.fn().mockReturnValue(brands.terra),
+  };
+});
 
 jest.mock('src/libs/nav', () => ({
   ...jest.requireActual('src/libs/nav'),
@@ -25,14 +27,12 @@ beforeEach(() => {
 
 describe('Datasets', () => {
   it('shows a toggle for the data catalog', () => {
-    getEnabledBrand.mockReturnValue(brands.terra);
     const { getByLabelText, getByText } = render(h(Datasets));
     expect(getByText('Preview the new Data Catalog')).toBeTruthy();
     expect(getByLabelText('New Catalog OFF')).toBeTruthy();
   });
 
   it('shows all datasets in terra', () => {
-    getEnabledBrand.mockReturnValue(brands.terra);
     expect(
       prepareDatasetsForDisplay(
         [{ 'dct:title': 'radx-up', 'TerraDCAT_ap:hasDataCollection': [{ 'dct:title': 'RADx-UP' }] }, { 'dct:title': 'not-radx' }],

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,3 +1,33 @@
+import type { Theme } from '@terra-ui-packages/components';
+
+// Basic Terra UI components access the current theme via React Context.
+// To avoid having to wrap nearly every component rendered in a test in a ThemeProvider,
+// this mocks useThemeFromContext to provide a default theme for tests.
+type TerraUIComponentsExports = typeof import('@terra-ui-packages/components');
+jest.mock('@terra-ui-packages/components', (): TerraUIComponentsExports => {
+  const theme: Theme = {
+    colorPalette: {
+      primary: '#74ae43',
+      secondary: '#6d6e70',
+      accent: '#4d72aa',
+      success: '#74ae43',
+      warning: '#f7981c',
+      danger: '#db3214',
+      light: '#e9ecef',
+      dark: '#333f52',
+      grey: '#808080',
+      disabled: '#b6b7b8',
+    },
+  };
+
+  const actual = jest.requireActual<TerraUIComponentsExports>('@terra-ui-packages/components');
+  const enrichedTheme = actual.enrichTheme(theme);
+  return {
+    ...actual,
+    useThemeFromContext: () => enrichedTheme,
+  };
+});
+
 // VirtualizedSelect uses react-virtualized's AutoSizer to size the options menu.
 // Left to its own devices, in the unit test environment, AutoSizer makes the menu
 // list 0px wide and no options are rendered. Mocking AutoSizer makes the virtualized

--- a/yarn.lock
+++ b/yarn.lock
@@ -2976,6 +2976,7 @@ __metadata:
     "@types/jest": ^28.1.8
     "@types/lodash": ^4.14.184
     "@types/react": ^18.2.15
+    color: ^4.0.1
     jest: ^27.4.3
     lodash: ^4.17.21
     react: 18.2.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -2973,13 +2973,17 @@ __metadata:
   dependencies:
     "@terra-ui-packages/build-utils": ^1.0.0
     "@terra-ui-packages/test-utils": "*"
+    "@testing-library/dom": ^9.3.1
+    "@testing-library/react": ^14.0.0
     "@types/jest": ^28.1.8
     "@types/lodash": ^4.14.184
     "@types/react": ^18.2.15
+    "@types/testing-library__jest-dom": ^5.14.9
     color: ^4.0.1
     jest: ^27.4.3
     lodash: ^4.17.21
     react: 18.2.0
+    react-hyperscript-helpers: ^2.0.0
     typescript: ^4.9.5
     vite: ^4.3.9
   peerDependencies:


### PR DESCRIPTION
In order to move basic components to the components package, we must disentangle them from Terra UI's branding. Currently, many components import from libs/colors, which exports color functions based on the current brand (which is determined by the window's location).

This proposes one way to do that, using [React Context](https://react.dev/learn/passing-data-deeply-with-context). With this change, instead of importing from libs/colors, components can retrieve those same color functions from a Theme context using the `useTheme` hook. See buttons.js for an example.

Applications render a ThemeProvider component, which wraps the entire application, and takes a theme configuration as props. This way, Terra UI can swap out the theme passed to the provider based on the current brand and components can remain unaware of that.