### PR TITLE
[WM-2185] render noncreator error card when user can't create cromwell

### DIFF
--- a/src/analysis/modals/CloudEnvironmentModal.ts
+++ b/src/analysis/modals/CloudEnvironmentModal.ts
@@ -60,7 +60,7 @@ import {
   cloudProviderTypes,
   getCloudProviderFromWorkspace,
 } from 'src/libs/workspace-utils';
-import { cromwellLinkProps } from 'src/workflows-app/utils/app-utils';
+import { cromwellLinkProps, getCromwellUnsupportedMessage } from 'src/workflows-app/utils/app-utils';
 
 const titleId = 'cloud-env-modal';
 
@@ -425,8 +425,7 @@ export const CloudEnvironmentModal = ({
         [doesCloudEnvForToolExist && !isDisabled, () => 'Open'],
         [
           isDisabled && !doesWorkspaceSupportCromwellAppForUser(workspace.workspace, cloudProvider, toolLabel),
-          () =>
-            'Cromwell app is either not supported in this workspace or you need to be a workspace creator to access the app. Please create a new workspace to use Cromwell app.',
+          () => getCromwellUnsupportedMessage(),
         ],
         [
           doesCloudEnvForToolExist && isDisabled && isLaunchSupported(toolLabel),

--- a/src/workflows-app/utils/app-utils.js
+++ b/src/workflows-app/utils/app-utils.js
@@ -7,6 +7,9 @@ import { AppProxyUrlStatus, getUser, workflowsAppStore } from 'src/libs/state';
 import * as Utils from 'src/libs/utils';
 import { cloudProviderTypes } from 'src/libs/workspace-utils';
 
+export const getCromwellUnsupportedMessage = () =>
+  'Cromwell app is either not supported in this workspace or you need to be a workspace creator to access the app. Please create a new workspace to use Cromwell app.';
+
 export const doesAppProxyUrlExist = (workspaceId, proxyUrlStateField) => {
   const workflowsAppStoreLocal = workflowsAppStore.get();
   return workflowsAppStoreLocal.workspaceId === workspaceId && workflowsAppStoreLocal[proxyUrlStateField].status === AppProxyUrlStatus.Ready;


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WM-2185

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- When a user in an Azure workspace is not the creator of that workspace, an error message should appear in the Workflows tab. That error message is the same as the one displayed in the Cloud Environment sidebar modal.

### Why
- Until "multi-user Cromwell" is enabled, only the workspace creator should be able to access Cromwell. The logic that determined the content of the Workflows tab was faulty, causing workspace non-creators to see the "Workflow App Launcher" card when they should have seen this error instead.

### Testing strategy
Manual testing only. This is a temporary fix to an experience that will soon be revamped entirely.

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 
![image](https://github.com/DataBiosphere/terra-ui/assets/5531017/fa9db347-f41e-4663-abc6-bf1a7ce43421)
