### PR TITLE
[UIE-118] Add request response times to e2e test logs

### DIFF
--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -405,7 +405,8 @@ const logPageResponses = (page) => {
     if (shouldLogRequest) {
       const method = request.method();
       const status = response.status();
-      console.log('page.http', `${method} ${status} ${url}`);
+      const timing = response.timing();
+      console.log('page.http', `${method} ${status} ${url} ${timing.receiveHeadersEnd}ms`);
 
       const isErrorResponse = status >= 400;
       if (isErrorResponse) {


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/UIE-118

To assist in determining if an e2e test failure/timeout is related to slow API responses, this adds response timing to the test logs.

Relevant docs:
https://pptr.dev/api/puppeteer.httpresponse.timing
https://chromedevtools.github.io/devtools-protocol/tot/Network/#type-ResourceTiming