### PR TITLE
Convert libs/state to TypeScript

### DIFF
--- a/src/analysis/Analyses.ts
+++ b/src/analysis/Analyses.ts
@@ -500,7 +500,7 @@ export const BaseAnalyses = (
     )(async () => {
       const [currentUserHash, potentialLockers]: [string | undefined, any] = isGoogleWorkspace(workspace)
         ? await Promise.all([
-            notebookLockHash(workspace.workspace.bucketName, authState.user.email),
+            notebookLockHash(workspace.workspace.bucketName, authState.user.email!),
             findPotentialNotebookLockers(workspace),
           ])
         : await Promise.all([Promise.resolve(undefined), Promise.resolve([])]);

--- a/src/analysis/Environments.ts
+++ b/src/analysis/Environments.ts
@@ -796,7 +796,7 @@ export const Environments = ({ nav = undefined }: EnvironmentsProps) => {
                   const cloudEnvironment = filteredCloudEnvironments[rowIndex];
                   const computeType = isApp(cloudEnvironment) ? 'app' : 'runtime';
                   return h(Fragment, [
-                    h(PauseButton, { cloudEnvironment, currentUser, pauseComputeAndRefresh }),
+                    h(PauseButton, { cloudEnvironment, currentUser: currentUser!, pauseComputeAndRefresh }),
                     renderDeleteButton(computeType, cloudEnvironment),
                   ]);
                 },

--- a/src/libs/ajax/GoogleStorage.ts
+++ b/src/libs/ajax/GoogleStorage.ts
@@ -94,7 +94,7 @@ const getServiceAccountToken: (googleProject: string, token: string) => Promise<
 );
 
 export const saToken = (googleProject: string): Promise<string> =>
-  getServiceAccountToken(googleProject, getUser().token);
+  getServiceAccountToken(googleProject, getUser().token!);
 
 export type GCSMetadata = { [key: string]: string };
 

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -41,12 +41,17 @@ export interface Atom<T> {
   reset: () => void;
 }
 
+type AtomConstructor = {
+  <T = any>(): Atom<T | undefined>;
+  <T = any>(initialValue: T): Atom<T>;
+};
+
 /**
  * A simple state container inspired by clojure atoms. Method names were chosen based on similarity
  * to lodash and Immutable. (deref => get, reset! => set, swap! => update, reset to go back to initial value)
  * Implements the Store interface
  */
-export const atom = <T = any>(initialValue: T): Atom<T> => {
+export const atom: AtomConstructor = <T = any>(initialValue?: any) => {
   let value = initialValue;
   const { subscribe, next } = subscribable<[T, T]>();
   const get = () => value;

--- a/src/pages/workspaces/workspace/useDeleteWorkspaceState.ts
+++ b/src/pages/workspaces/workspace/useDeleteWorkspaceState.ts
@@ -94,7 +94,7 @@ export const useDeleteWorkspaceState = (hookArgs: DeleteWorkspaceHookArgs): Dele
           Ajax(signal).Workspaces.workspace(workspaceInfo.namespace, workspaceInfo.name).getAcl(),
           Ajax(signal).Workspaces.workspace(workspaceInfo.namespace, workspaceInfo.name).bucketUsage(),
         ]);
-        setCollaboratorEmails(_.without([getUser().email], _.keys(acl)));
+        setCollaboratorEmails(_.without([getUser().email!], _.keys(acl)));
         setWorkspaceBucketUsageInBytes(usageInBytes);
       }
     });


### PR DESCRIPTION
A lot of files reference the global state in libs/state, so the sooner it's converted to TS, the better. In particular, we want to start adding type safety for the state in authStore.
