### PR TITLE
[UIE-120] Add cond and switchCase to core-utils

### DIFF
--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terra-ui-packages/core-utils",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "scripts": {
     "build": "vite build --emptyOutDir",
     "dev": "vite build --mode=development --watch",

--- a/packages/core-utils/src/index.ts
+++ b/packages/core-utils/src/index.ts
@@ -1,3 +1,4 @@
+export * from './logic-utils';
 export * from './timer-utils';
 export * from './type-utils/deep-partial';
 export * from './type-utils/general-types';

--- a/packages/core-utils/src/logic-utils.test.ts
+++ b/packages/core-utils/src/logic-utils.test.ts
@@ -1,4 +1,4 @@
-import { cond, switchCase } from './logic-utils';
+import { cond, DEFAULT, switchCase } from './logic-utils';
 
 describe('cond', () => {
   it('returns result of value factory for first case where condition is true', () => {
@@ -24,6 +24,32 @@ describe('cond', () => {
     // Assert
     expect(result).toBe(undefined);
   });
+
+  describe('with values instead of factories', () => {
+    it('returns value for first case where condition is true', () => {
+      // Act
+      const result = cond([false, 'a'], [true, 'b'], [true, 'c']);
+
+      // Assert
+      expect(result).toBe('b');
+    });
+
+    it("returns default value if one is provided and no case's condition is true", () => {
+      // Act
+      const result = cond([false, 'a'], [false, 'b'], [false, 'c'], 'z');
+
+      // Assert
+      expect(result).toBe('z');
+    });
+
+    it("returns undefined if no case's condition is true and no default value", () => {
+      // Act
+      const result = cond([false, 'a'], [false, 'b'], [false, 'c']);
+
+      // Assert
+      expect(result).toBe(undefined);
+    });
+  });
 });
 
 describe('switchCase', () => {
@@ -38,6 +64,14 @@ describe('switchCase', () => {
   it('returns result of default value factory if one is provided and no case matches value', () => {
     // Act
     const result = switchCase('z', ['a', () => 1], ['b', () => 2], ['c', () => 3], () => -1);
+
+    // Assert
+    expect(result).toBe(-1);
+  });
+
+  it('returns result of default value factory if one is provided and no case matches value', () => {
+    // Act
+    const result = switchCase('z', ['a', () => 1], ['b', () => 2], ['c', () => 3], [DEFAULT, () => -1]);
 
     // Assert
     expect(result).toBe(-1);

--- a/packages/core-utils/src/logic-utils.test.ts
+++ b/packages/core-utils/src/logic-utils.test.ts
@@ -17,6 +17,14 @@ describe('cond', () => {
     expect(result).toBe('z');
   });
 
+  it("returns result of default value factory if one is provided and no case's condition is true", () => {
+    // Act
+    const result = cond([false, () => 'a'], [false, () => 'b'], [false, () => 'c'], [DEFAULT, () => 'z']);
+
+    // Assert
+    expect(result).toBe('z');
+  });
+
   it("returns undefined if no case's condition is true and no default value factory is provided", () => {
     // Act
     const result = cond([false, () => 'a'], [false, () => 'b'], [false, () => 'c']);

--- a/packages/core-utils/src/logic-utils.test.ts
+++ b/packages/core-utils/src/logic-utils.test.ts
@@ -1,0 +1,53 @@
+import { cond, switchCase } from './logic-utils';
+
+describe('cond', () => {
+  it('returns result of value factory for first case where condition is true', () => {
+    // Act
+    const result = cond([false, () => 'a'], [true, () => 'b'], [true, () => 'c']);
+
+    // Assert
+    expect(result).toBe('b');
+  });
+
+  it("returns result of default value factory if one is provided and no case's condition is true", () => {
+    // Act
+    const result = cond([false, () => 'a'], [false, () => 'b'], [false, () => 'c'], () => 'z');
+
+    // Assert
+    expect(result).toBe('z');
+  });
+
+  it("returns undefined if no case's condition is true and no default value factory is provided", () => {
+    // Act
+    const result = cond([false, () => 'a'], [false, () => 'b'], [false, () => 'c']);
+
+    // Assert
+    expect(result).toBe(undefined);
+  });
+});
+
+describe('switchCase', () => {
+  it('returns result of value factory for first case that matches value', () => {
+    // Act
+    const result = switchCase('b', ['a', () => 1], ['b', () => 2], ['c', () => 3]);
+
+    // Assert
+    expect(result).toBe(2);
+  });
+
+  it('returns result of default value factory if one is provided and no case matches value', () => {
+    // Act
+    const result = switchCase('z', ['a', () => 1], ['b', () => 2], ['c', () => 3], () => -1);
+
+    // Assert
+    expect(result).toBe(-1);
+  });
+
+  it('returns undefined if no case matches value and no default value factory is provided', () => {
+    // Act
+    const result = switchCase('z', ['a', () => 1], ['b', () => 2], ['c', () => 3]);
+
+    // Assert
+    expect(result).toBe(undefined);
+  });
+});

--- a/packages/core-utils/src/logic-utils.ts
+++ b/packages/core-utils/src/logic-utils.ts
@@ -1,0 +1,49 @@
+type CondCase<T> = [boolean, () => T];
+type CondDefault<T> = () => T;
+
+type Cond = {
+  <T>(...args: [...CondCase<T>[], CondDefault<T>]): T;
+  <T>(...args: CondCase<T>[]): T | undefined;
+};
+
+/**
+ * Takes any number of [predicate, factory] cases, followed by an optional default factory.
+ * Returns factory() for the first truthy predicate, otherwise returns the default factory().
+ * Returns undefined if no predicate matches and there is no default factory.
+ */
+export const cond: Cond = (...args) => {
+  for (const arg of args) {
+    if (Array.isArray(arg) && arg[0]) {
+      return arg[1]();
+    }
+    if (arg instanceof Function) {
+      return arg();
+    }
+  }
+  return undefined;
+};
+
+type SwitchCaseCase<T, U> = [T, () => U];
+type SwitchCaseDefault<U> = () => U;
+
+type SwitchCase = {
+  <T, U>(value: T, ...args: [...SwitchCaseCase<T, U>[], SwitchCaseDefault<U>]): U;
+  <T, U>(value: T, ...args: SwitchCaseCase<T, U>[]): U | undefined;
+};
+
+/**
+ * Takes a `value` and any number of [candidate, factory] cases, followed by an optional default factory.
+ * Returns factory() for the first case where candidate matches `value`, otherwise returns the default factory().
+ * Returns undefined if no candidate matches and there is no default factory.
+ */
+export const switchCase: SwitchCase = (value, ...args) => {
+  for (const arg of args) {
+    if (Array.isArray(arg) && arg[0] === value) {
+      return arg[1]();
+    }
+    if (arg instanceof Function) {
+      return arg();
+    }
+  }
+  return undefined;
+};

--- a/packages/core-utils/src/logic-utils.ts
+++ b/packages/core-utils/src/logic-utils.ts
@@ -1,5 +1,7 @@
+export const DEFAULT = Symbol('Default switch case');
+
 type CondCase<T> = [boolean, (() => T) | T];
-type CondDefault<T> = (() => T) | T;
+type CondDefault<T> = [typeof DEFAULT, (() => T) | T] | (() => T) | T;
 
 type Cond = {
   <T>(...args: [...CondCase<T>[], CondDefault<T>]): T;
@@ -27,8 +29,6 @@ export const cond: Cond = (...args) => {
   }
   return undefined;
 };
-
-export const DEFAULT = Symbol('Default switch case');
 
 type SwitchCaseCase<T, U> = [T, () => U];
 type SwitchCaseDefault<U> = [typeof DEFAULT, () => U] | (() => U);


### PR DESCRIPTION
@jladieu pointed out that we've labeled `cond` as deprecated in favor of `condTyped`.
https://github.com/DataBiosphere/terra-ui/blob/2262c38847d3850bde85dffdb81e35ef46e48788/src/libs/utils.ts#L152-L170

However, encouraging switching `cond` to `condTyped` isn't great because it's an intermediate/temporary state. The long term goal is to have those sorts of utility functions in the `core-utils` packages.

So, to enable getting type-safe `cond` and `switchCase` functions without having to go through the temporary `condTyped` state, this adds `cond` and `switchCase` functions to `core-utils`. It also improves the type signatures (allowing only one default case as the last argument) and adds unit tests.

The new version of `switchCase` has one new feature: it no longer requires the `DEFAULT` symbol for the default case. Now the default case can be provided as a factory without an associated value, which brings `switchCase` more in line with `cond`.