### PR TITLE
[UIE-121] Convert libs/state to TypeScript

### DIFF
--- a/src/libs/state.ts
+++ b/src/libs/state.ts
@@ -3,7 +3,7 @@ import { getLocalStorage, getSessionStorage, staticStorageSlot } from 'src/libs/
 import * as Utils from 'src/libs/utils';
 import type { WorkspaceWrapper } from 'src/libs/workspace-utils';
 
-export const routeHandlersStore = Utils.atom([]);
+export const routeHandlersStore = Utils.atom<unknown[]>([]);
 
 export const authStore = Utils.atom<any>({
   isSignedIn: undefined,
@@ -43,25 +43,25 @@ toggleStateAtom.update((v) => v || { notebooksTab: true });
 export const azurePreviewStore = staticStorageSlot(getLocalStorage(), 'azurePreview');
 azurePreviewStore.update((v) => v || false);
 
-export const notificationStore = Utils.atom([]);
+export const notificationStore = Utils.atom<any[]>([]);
 
 export const contactUsActive = Utils.atom(false);
 
-export const workspaceStore = Utils.atom<any>();
+export const workspaceStore = Utils.atom<any>(undefined);
 
 export const workspacesStore = Utils.atom<WorkspaceWrapper[]>([]);
 
-export const rerunFailuresStatus = Utils.atom();
+export const rerunFailuresStatus = Utils.atom<unknown>(undefined);
 
-export const errorNotifiedRuntimes = Utils.atom([]);
+export const errorNotifiedRuntimes = Utils.atom<unknown[]>([]);
 
-export const errorNotifiedApps = Utils.atom([]);
+export const errorNotifiedApps = Utils.atom<unknown[]>([]);
 
 export const knownBucketRequesterPaysStatuses = Utils.atom({});
 
-export const requesterPaysProjectStore = Utils.atom();
+export const requesterPaysProjectStore = Utils.atom<unknown>(undefined);
 
-export const runtimesStore = Utils.atom();
+export const runtimesStore = Utils.atom<unknown>(undefined);
 
 export const workflowSelectionStore = Utils.atom({
   key: undefined,
@@ -79,9 +79,9 @@ export type AsyncImportJob = {
 
 export const asyncImportJobStore = Utils.atom<AsyncImportJob[]>([]);
 
-export const snapshotsListStore = Utils.atom();
+export const snapshotsListStore = Utils.atom<unknown>(undefined);
 
-export const snapshotStore = Utils.atom();
+export const snapshotStore = Utils.atom<unknown>(undefined);
 
 export const dataCatalogStore = Utils.atom<any[]>([]);
 
@@ -97,7 +97,7 @@ type AjaxOverride = {
 
 declare global {
   interface Window {
-    ajaxOverridesStore: Utils.Atom<AjaxOverride[] | undefined>;
+    ajaxOverridesStore: Utils.Atom<AjaxOverride[]>;
     configOverridesStore: any;
   }
 }
@@ -108,7 +108,7 @@ declare global {
  * The fn should be a fetch wrapper (oldFetch => newFetch) that modifies the request process. (See ajaxOverrideUtils)
  * If present, filter should be a RegExp that is matched against the url to target specific requests.
  */
-export const ajaxOverridesStore = Utils.atom<AjaxOverride[]>();
+export const ajaxOverridesStore = Utils.atom<AjaxOverride[]>([]);
 window.ajaxOverridesStore = ajaxOverridesStore;
 
 /*

--- a/src/libs/state.ts
+++ b/src/libs/state.ts
@@ -1,9 +1,11 @@
+import { AnyPromiseFn } from '@terra-ui-packages/core-utils';
 import { getLocalStorage, getSessionStorage, staticStorageSlot } from 'src/libs/browser-storage';
 import * as Utils from 'src/libs/utils';
+import type { WorkspaceWrapper } from 'src/libs/workspace-utils';
 
 export const routeHandlersStore = Utils.atom([]);
 
-export const authStore = Utils.atom({
+export const authStore = Utils.atom<any>({
   isSignedIn: undefined,
   anonymousId: undefined,
   registrationStatus: undefined,
@@ -45,9 +47,9 @@ export const notificationStore = Utils.atom([]);
 
 export const contactUsActive = Utils.atom(false);
 
-export const workspaceStore = Utils.atom();
+export const workspaceStore = Utils.atom<any>();
 
-export const workspacesStore = Utils.atom();
+export const workspacesStore = Utils.atom<WorkspaceWrapper[]>([]);
 
 export const rerunFailuresStatus = Utils.atom();
 
@@ -67,23 +69,38 @@ export const workflowSelectionStore = Utils.atom({
   entities: undefined,
 });
 
-/**
- * @typedef {Object} AsyncImportJob
- * @property {string} jobId
- * @property {Object} targetWorkspace
- * @property {string} targetWorkspace.namespace
- * @property {string} targetWorkspace.name
- */
+export type AsyncImportJob = {
+  jobId: string;
+  targetWorkspace: {
+    namespace: string;
+    name: string;
+  };
+};
 
-/** @type {Utils.Atom<AsyncImportJob[]>} */
-export const asyncImportJobStore = Utils.atom([]);
+export const asyncImportJobStore = Utils.atom<AsyncImportJob[]>([]);
 
 export const snapshotsListStore = Utils.atom();
 
 export const snapshotStore = Utils.atom();
 
-/** @type {Utils.Atom<any[]>} */
-export const dataCatalogStore = Utils.atom([]);
+export const dataCatalogStore = Utils.atom<any[]>([]);
+
+type AjaxOverride = {
+  fn: (fetch: AnyPromiseFn) => AnyPromiseFn;
+  filter:
+    | {
+        url: RegExp;
+        method?: string;
+      }
+    | ((...args: any[]) => boolean);
+};
+
+declare global {
+  interface Window {
+    ajaxOverridesStore: Utils.Atom<AjaxOverride[] | undefined>;
+    configOverridesStore: any;
+  }
+}
 
 /*
  * Modifies ajax responses for testing purposes.
@@ -91,7 +108,7 @@ export const dataCatalogStore = Utils.atom([]);
  * The fn should be a fetch wrapper (oldFetch => newFetch) that modifies the request process. (See ajaxOverrideUtils)
  * If present, filter should be a RegExp that is matched against the url to target specific requests.
  */
-export const ajaxOverridesStore = Utils.atom();
+export const ajaxOverridesStore = Utils.atom<AjaxOverride[]>();
 window.ajaxOverridesStore = ajaxOverridesStore;
 
 /*

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -41,21 +41,16 @@ export interface Atom<T> {
   reset: () => void;
 }
 
-type AtomFactory = {
-  <T = unknown>(initialValue: T): Atom<T>;
-  <T = unknown>(): Atom<T | undefined>;
-};
-
 /**
  * A simple state container inspired by clojure atoms. Method names were chosen based on similarity
  * to lodash and Immutable. (deref => get, reset! => set, swap! => update, reset to go back to initial value)
  * Implements the Store interface
  */
-export const atom: AtomFactory = <T = unknown>(initialValue?: T): Atom<T | undefined> => {
+export const atom = <T>(initialValue: T): Atom<T> => {
   let value = initialValue;
-  const { subscribe, next } = subscribable<[T | undefined, T | undefined]>();
+  const { subscribe, next } = subscribable<[T, T]>();
   const get = () => value;
-  const set = (newValue: T | undefined) => {
+  const set = (newValue: T) => {
     const oldValue = value;
     value = newValue;
     next(newValue, oldValue);

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -41,16 +41,21 @@ export interface Atom<T> {
   reset: () => void;
 }
 
+type AtomFactory = {
+  <T = unknown>(initialValue: T): Atom<T>;
+  <T = unknown>(): Atom<T | undefined>;
+};
+
 /**
  * A simple state container inspired by clojure atoms. Method names were chosen based on similarity
  * to lodash and Immutable. (deref => get, reset! => set, swap! => update, reset to go back to initial value)
  * Implements the Store interface
  */
-export const atom = <T = any>(initialValue: T): Atom<T> => {
+export const atom: AtomFactory = <T = unknown>(initialValue?: T): Atom<T | undefined> => {
   let value = initialValue;
-  const { subscribe, next } = subscribable<[T, T]>();
+  const { subscribe, next } = subscribable<[T | undefined, T | undefined]>();
   const get = () => value;
-  const set = (newValue: T) => {
+  const set = (newValue: T | undefined) => {
     const oldValue = value;
     value = newValue;
     next(newValue, oldValue);


### PR DESCRIPTION
A lot of files reference the global state in libs/state, so the sooner it's converted to TS, the better. In particular, we want to start adding type safety for the state in authStore.

Unlike #4141, this does the initial conversion without tangling it up with the authStore type.