### PR TITLE
Revert "Bond in k8s (prod) (#4146)"

### DIFF
--- a/config/prod.json
+++ b/config/prod.json
@@ -2,7 +2,7 @@
   "agoraUrlRoot": "https://agora.dsde-prod.broadinstitute.org",
   "bardRoot": "https://terra-bard-prod.appspot.com",
   "billingProfileManagerUrlRoot": "https://bpm.dsde-prod.broadinstitute.org",
-  "bondUrlRoot": "https://bond.dsde-prod.broadinstitute.org",
+  "bondUrlRoot": "https://broad-bond-prod.appspot.com",
   "calhounUrlRoot": "https://calhoun.dsde-prod.broadinstitute.org",
   "catalogUrlRoot": "https://catalog.dsde-prod.broadinstitute.org",
   "dataRepoUrlRoot": "https://data.terra.bio",


### PR DESCRIPTION
This reverts commit b64327ef9bba91ffb62672962d07f6ef491dac39.

See https://broadinstitute.slack.com/archives/C02H5JRN68J/p1692890572055949

We probably need to reach out to the 3rd party providers and have them update the allowed Bond url before we can roll out this change.