### PR TITLE
[UIE-102] Allow tests to log in development

### DIFF
--- a/packages/test-utils/src/setupTests.mjs
+++ b/packages/test-utils/src/setupTests.mjs
@@ -9,7 +9,7 @@ import failOnConsole from 'jest-fail-on-console';
 // Fail tests that produce console logs.
 // Console warnings or errors suggest there are issues with the test.
 // Other console logs are noise that make it harder to find informative output when tests do fail.
-if (!process.env.ALLOW_LOGS) {
+if (process.env.CI) {
   failOnConsole({
     shouldFailOnAssert: true,
     shouldFailOnDebug: true,


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/UIE-102

To prevent test output from accumulating noise, #4064 configured Jest to fail tests if they logged to console.

It also added an option to allow tests to log, in order to help with debugging. @s-rubenstein [suggested allowing logs by default and only failing tests that log in CI](https://github.com/DataBiosphere/terra-ui/pull/4064#pullrequestreview-1541610330). [I chose to default to failing tests that log](https://github.com/DataBiosphere/terra-ui/pull/4064#issuecomment-1646073500) in order to get that feedback in dev rather than only after pushing to GitHub.

After a few weeks of experience, I've come around. I almost always want to allow logs in development, and the current configuration makes test failures noisier and adds an extra step (setting the environment variable and re-running tests) to debugging.

This updates the test configuration to only fail on logs in CI.

