### PR TITLE
[UIE-121] Update config overrides warning

### DIFF
--- a/src/components/ConfigOverridesWarning.js
+++ b/src/components/ConfigOverridesWarning.js
@@ -8,7 +8,7 @@ const ConfigOverridesWarning = () => {
   const configOverrides = useStore(configOverridesStore);
   const ajaxOverrides = useStore(ajaxOverridesStore);
   return (
-    (!!configOverrides || !!ajaxOverrides) &&
+    (!!configOverrides || ajaxOverrides.length > 0) &&
     div(
       {
         style: {
@@ -23,7 +23,8 @@ const ConfigOverridesWarning = () => {
       [
         !!configOverrides &&
           div(['Config overrides are in effect.', h(Link, { variant: 'light', onClick: () => configOverridesStore.set() }, [' clear'])]),
-        !!ajaxOverrides && div(['Ajax overrides are in effect.', h(Link, { variant: 'light', onClick: () => ajaxOverridesStore.set() }, [' clear'])]),
+        ajaxOverrides.length > 0 &&
+          div(['Ajax overrides are in effect.', h(Link, { variant: 'light', onClick: () => ajaxOverridesStore.set([]) }, [' clear'])]),
       ]
     )
   );


### PR DESCRIPTION
Fixup for #4148.

Initializing `ajaxOverridesStore` with an empty array causes the config overrides warning to always show up. This updates the warning to not show if the store contains an empty array.

![Screenshot 2023-08-24 at 2 41 18 PM](https://github.com/DataBiosphere/terra-ui/assets/1156625/5d654572-13d9-43ce-ae40-f651a4ae9f6a)
