### PR TITLE
[UIE-120] Move atom and subscribable to core-utils

### DIFF
--- a/packages/core-utils/src/index.ts
+++ b/packages/core-utils/src/index.ts
@@ -1,4 +1,5 @@
 export * from './logic-utils';
+export * from './state-utils';
 export * from './timer-utils';
 export * from './type-utils/deep-partial';
 export * from './type-utils/general-types';

--- a/packages/core-utils/src/state-utils.test.ts
+++ b/packages/core-utils/src/state-utils.test.ts
@@ -1,0 +1,113 @@
+import { atom, subscribable } from './state-utils';
+
+describe('subscribable', () => {
+  it('next calls all registered callbacks', () => {
+    // Arrange
+    const fn1 = jest.fn();
+    const fn2 = jest.fn();
+
+    const sub = subscribable();
+    sub.subscribe(fn1);
+    sub.subscribe(fn2);
+
+    // Act
+    sub.next('a', 'b', 'c');
+
+    // Assert
+    expect(fn1).toHaveBeenCalledWith('a', 'b', 'c');
+    expect(fn2).toHaveBeenCalledWith('a', 'b', 'c');
+  });
+
+  it('subscribe returns a handle to unsubscribe', () => {
+    // Arrange
+    const fn1 = jest.fn();
+    const fn2 = jest.fn();
+
+    const sub = subscribable();
+    sub.subscribe(fn1);
+    const { unsubscribe: unsubscribeFn2 } = sub.subscribe(fn2);
+
+    // Act
+    sub.next();
+    unsubscribeFn2();
+    sub.next();
+
+    // Assert
+    expect(fn1).toHaveBeenCalledTimes(2);
+    expect(fn2).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('atom', () => {
+  it('initializes state', () => {
+    // Act
+    const state = atom('foo');
+
+    // Assert
+    expect(state.get()).toBe('foo');
+  });
+
+  it('sets state', () => {
+    // Arrange
+    const state = atom('foo');
+
+    // Act
+    state.set('bar');
+
+    // Assert
+    expect(state.get()).toBe('bar');
+  });
+
+  it('updates state', () => {
+    // Arrange
+    const state = atom(1);
+
+    // Act
+    state.update((n) => n + 1);
+
+    // Assert
+    expect(state.get()).toBe(2);
+  });
+
+  it('resets state', () => {
+    // Arrange
+    const state = atom('foo');
+    state.set('bar');
+
+    // Act
+    state.reset();
+
+    // Assert
+    expect(state.get()).toBe('foo');
+  });
+
+  it('allows subscribing to changes', () => {
+    // Arrange
+    const state = atom('foo');
+
+    const fn = jest.fn();
+    state.subscribe(fn);
+
+    // Act
+    state.set('bar');
+
+    // Assert
+    expect(fn).toHaveBeenCalledWith('bar', 'foo');
+  });
+
+  it('subscriptions can be unsubscribed', () => {
+    // Arrange
+    const state = atom('foo');
+
+    const fn = jest.fn();
+    const { unsubscribe } = state.subscribe(fn);
+
+    // Act
+    state.set('bar');
+    unsubscribe();
+    state.set('baz');
+
+    // Assert
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core-utils/src/state-utils.ts
+++ b/packages/core-utils/src/state-utils.ts
@@ -1,0 +1,68 @@
+export type SubscribableSubscription = {
+  /** Unsubscribe this callback. */
+  unsubscribe: () => void;
+};
+
+export type Subscribable<T extends any[]> = {
+  /** Subscribe to changes. Callback `fn` will be called each time subscribable's `next` method is called. */
+  subscribe: (fn: (...args: T) => void) => SubscribableSubscription;
+
+  /** Call all subscribed callbacks with `args`. */
+  next: (...args: T) => void;
+};
+
+/**
+ * A mechanism for registering callbacks for some state change.
+ */
+export const subscribable = <T extends any[]>(): Subscribable<T> => {
+  let subscribers: ((...args: T) => void)[] = [];
+  return {
+    subscribe: (fn: (...args: T) => void) => {
+      subscribers = [...subscribers, fn];
+      return {
+        unsubscribe: () => {
+          subscribers = subscribers.filter((s) => s !== fn);
+        },
+      };
+    },
+    next: (...args: T) => {
+      subscribers.forEach((fn) => {
+        fn(...args);
+      });
+    },
+  };
+};
+
+export type Atom<T> = {
+  /** Subscribe to changes. When state is changed, `fn` will be called with the new state and previous state. */
+  subscribe: (fn: (value: T, previousValue: T) => void) => SubscribableSubscription;
+
+  /** Get state. */
+  get: () => T;
+
+  /** Set state to `value`. */
+  set: (value: T) => void;
+
+  /** Update state. Function `fn` is called with the current state and returns the new state. */
+  update: (fn: (currentValue: T) => T) => void;
+
+  /** Reset state to intial value. */
+  reset: () => void;
+};
+
+/**
+ * A simple state container inspired by clojure atoms.
+ *
+ * Method names were chosen based on similarity to lodash and Immutable. (deref => get, reset! => set, swap! => update, reset to go back to initial value).
+ */
+export const atom = <T>(initialValue: T): Atom<T> => {
+  let value = initialValue;
+  const { subscribe, next } = subscribable<[T, T]>();
+  const get = () => value;
+  const set = (newValue: T) => {
+    const oldValue = value;
+    value = newValue;
+    next(newValue, oldValue);
+  };
+  return { subscribe, get, set, update: (fn) => set(fn(get())), reset: () => set(initialValue) };
+};

--- a/src/analysis/AnalysisLauncher.js
+++ b/src/analysis/AnalysisLauncher.js
@@ -1,3 +1,4 @@
+import { atom } from '@terra-ui-packages/core-utils';
 import * as clipboard from 'clipboard-polyfill/text';
 import _ from 'lodash/fp';
 import * as qs from 'qs';
@@ -712,7 +713,7 @@ function JupyterFrameManager({ onClose, frameRef, details = {} }) {
       cloudPlatform: details.cloudPlatform,
     });
 
-    const isSaved = Utils.atom(true);
+    const isSaved = atom(true);
     const onMessage = (e) => {
       switch (e.data) {
         case 'close':

--- a/src/components/file-browser/DirectoryTree.test.ts
+++ b/src/components/file-browser/DirectoryTree.test.ts
@@ -1,3 +1,4 @@
+import { subscribable } from '@terra-ui-packages/core-utils';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
@@ -5,7 +6,6 @@ import { h, ul } from 'react-hyperscript-helpers';
 import { Directory } from 'src/components/file-browser/DirectoryTree';
 import { useDirectoriesInDirectory } from 'src/components/file-browser/file-browser-hooks';
 import FileBrowserProvider from 'src/libs/ajax/file-browser-providers/FileBrowserProvider';
-import * as Utils from 'src/libs/utils';
 import { asMockedFn } from 'src/testing/test-utils';
 
 jest.mock('src/components/file-browser/file-browser-hooks', () => ({
@@ -27,7 +27,7 @@ describe('Directory', () => {
         id: 'node-0',
         path: 'path/to/directory/',
         provider: mockFileBrowserProvider,
-        reloadRequests: Utils.subscribable(),
+        reloadRequests: subscribable(),
         rootLabel: 'Workspace bucket',
         selectedDirectory: '',
         setActiveDescendant: () => {},
@@ -73,7 +73,7 @@ describe('Directory', () => {
           level: 0,
           path: '',
           provider: mockFileBrowserProvider,
-          reloadRequests: Utils.subscribable(),
+          reloadRequests: subscribable(),
           rootLabel: 'Workspace bucket',
           selectedDirectory: '',
           setActiveDescendant: () => {},
@@ -128,7 +128,7 @@ describe('Directory', () => {
           level: 0,
           path: 'path/to/directory/',
           provider: mockFileBrowserProvider,
-          reloadRequests: Utils.subscribable(),
+          reloadRequests: subscribable(),
           rootLabel: 'Workspace bucket',
           selectedDirectory: '',
           setActiveDescendant: () => {},
@@ -192,7 +192,7 @@ describe('Directory', () => {
           level: 0,
           path: 'path/to/directory/',
           provider: mockFileBrowserProvider,
-          reloadRequests: Utils.subscribable(),
+          reloadRequests: subscribable(),
           rootLabel: 'Workspace bucket',
           selectedDirectory: '',
           setActiveDescendant: () => {},
@@ -243,7 +243,7 @@ describe('Directory', () => {
         level: 0,
         path: 'path/to/directory/',
         provider: mockFileBrowserProvider,
-        reloadRequests: Utils.subscribable(),
+        reloadRequests: subscribable(),
         rootLabel: 'Workspace bucket',
         selectedDirectory: '',
         setActiveDescendant: () => {},
@@ -288,7 +288,7 @@ describe('Directory', () => {
         level: 0,
         path: 'path/to/directory/',
         provider: mockFileBrowserProvider,
-        reloadRequests: Utils.subscribable(),
+        reloadRequests: subscribable(),
         rootLabel: 'Workspace bucket',
         selectedDirectory: '',
         setActiveDescendant: () => {},
@@ -334,7 +334,7 @@ describe('Directory', () => {
         level: 0,
         path: 'path/to/directory/',
         provider: mockFileBrowserProvider,
-        reloadRequests: Utils.subscribable(),
+        reloadRequests: subscribable(),
         rootLabel: 'Workspace bucket',
         selectedDirectory: '',
         setActiveDescendant: () => {},
@@ -385,7 +385,7 @@ describe('Directory', () => {
           level: 0,
           path: 'path/to/directory/',
           provider: mockFileBrowserProvider,
-          reloadRequests: Utils.subscribable(),
+          reloadRequests: subscribable(),
           rootLabel: 'Workspace bucket',
           selectedDirectory: '',
           setActiveDescendant: () => {},

--- a/src/components/file-browser/FileBrowser.ts
+++ b/src/components/file-browser/FileBrowser.ts
@@ -1,3 +1,4 @@
+import { subscribable } from '@terra-ui-packages/core-utils';
 import { Fragment, useCallback, useEffect, useState } from 'react';
 import { div, h } from 'react-hyperscript-helpers';
 import DirectoryTree from 'src/components/file-browser/DirectoryTree';
@@ -68,7 +69,7 @@ const FileBrowser = (props: FileBrowserProps) => {
     () => ({ editDisabled: false, editDisabledReason: undefined })
   );
 
-  const reloadRequests = Utils.subscribable();
+  const reloadRequests = subscribable();
 
   return h(Fragment, [
     div({ style: { display: 'flex', height: '100%' } }, [

--- a/src/libs/browser-storage.js
+++ b/src/libs/browser-storage.js
@@ -1,5 +1,6 @@
+import { subscribable } from '@terra-ui-packages/core-utils';
 import _ from 'lodash/fp';
-import { maybeParseJSON, subscribable } from 'src/libs/utils';
+import { maybeParseJSON } from 'src/libs/utils';
 
 /**
  * This library provides a higher level interface on top of localStorage and sessionStorage.

--- a/src/libs/nav.js
+++ b/src/libs/nav.js
@@ -1,3 +1,4 @@
+import { atom } from '@terra-ui-packages/core-utils';
 import { createHashHistory as createHistory } from 'history';
 import _ from 'lodash/fp';
 import * as qs from 'qs';
@@ -5,9 +6,8 @@ import { createContext, useContext, useEffect, useState } from 'react';
 import { div, h } from 'react-hyperscript-helpers';
 import { useOnMount, useStore } from 'src/libs/react-utils';
 import { routeHandlersStore } from 'src/libs/state';
-import * as Utils from 'src/libs/utils';
 
-export const blockNav = Utils.atom(() => Promise.resolve());
+export const blockNav = atom(() => Promise.resolve());
 
 export const history = createHistory({
   hashType: 'noslash',

--- a/src/libs/react-utils.ts
+++ b/src/libs/react-utils.ts
@@ -1,4 +1,4 @@
-import { safeCurry } from '@terra-ui-packages/core-utils';
+import { Atom, safeCurry } from '@terra-ui-packages/core-utils';
 import _ from 'lodash/fp';
 import {
   EffectCallback,
@@ -11,7 +11,7 @@ import {
   useState,
 } from 'react';
 import { h } from 'react-hyperscript-helpers';
-import { Atom, delay, pollWithCancellation } from 'src/libs/utils';
+import { delay, pollWithCancellation } from 'src/libs/utils';
 
 /**
  * Performs the given effect, but only on component mount.

--- a/src/libs/service-alerts.js
+++ b/src/libs/service-alerts.js
@@ -1,3 +1,4 @@
+import { atom } from '@terra-ui-packages/core-utils';
 import _ from 'lodash/fp';
 import { Ajax } from 'src/libs/ajax';
 import { useStore } from 'src/libs/react-utils';
@@ -14,6 +15,6 @@ export const getServiceAlerts = async () => {
   )(serviceAlerts);
 };
 
-export const serviceAlertsStore = Utils.atom([]);
+export const serviceAlertsStore = atom([]);
 
 export const useServiceAlerts = () => useStore(serviceAlertsStore);

--- a/src/libs/state.ts
+++ b/src/libs/state.ts
@@ -1,11 +1,10 @@
-import { AnyPromiseFn } from '@terra-ui-packages/core-utils';
+import { AnyPromiseFn, Atom, atom } from '@terra-ui-packages/core-utils';
 import { getLocalStorage, getSessionStorage, staticStorageSlot } from 'src/libs/browser-storage';
-import * as Utils from 'src/libs/utils';
 import type { WorkspaceWrapper } from 'src/libs/workspace-utils';
 
-export const routeHandlersStore = Utils.atom<unknown[]>([]);
+export const routeHandlersStore = atom<unknown[]>([]);
 
-export const authStore = Utils.atom<any>({
+export const authStore = atom<any>({
   anonymousId: undefined,
   authContext: undefined,
   authTokenMetadata: {
@@ -38,8 +37,8 @@ export const userStatus = {
   disabled: 'disabled',
 };
 
-export const cookieReadyStore = Utils.atom(false);
-export const azureCookieReadyStore = Utils.atom({
+export const cookieReadyStore = atom(false);
+export const azureCookieReadyStore = atom({
   readyForRuntime: false,
   readyForApp: false,
 });
@@ -53,27 +52,27 @@ toggleStateAtom.update((v) => v || { notebooksTab: true });
 export const azurePreviewStore = staticStorageSlot(getLocalStorage(), 'azurePreview');
 azurePreviewStore.update((v) => v || false);
 
-export const notificationStore = Utils.atom<any[]>([]);
+export const notificationStore = atom<any[]>([]);
 
-export const contactUsActive = Utils.atom(false);
+export const contactUsActive = atom(false);
 
-export const workspaceStore = Utils.atom<any>(undefined);
+export const workspaceStore = atom<any>(undefined);
 
-export const workspacesStore = Utils.atom<WorkspaceWrapper[]>([]);
+export const workspacesStore = atom<WorkspaceWrapper[]>([]);
 
-export const rerunFailuresStatus = Utils.atom<unknown>(undefined);
+export const rerunFailuresStatus = atom<unknown>(undefined);
 
-export const errorNotifiedRuntimes = Utils.atom<unknown[]>([]);
+export const errorNotifiedRuntimes = atom<unknown[]>([]);
 
-export const errorNotifiedApps = Utils.atom<unknown[]>([]);
+export const errorNotifiedApps = atom<unknown[]>([]);
 
-export const knownBucketRequesterPaysStatuses = Utils.atom({});
+export const knownBucketRequesterPaysStatuses = atom({});
 
-export const requesterPaysProjectStore = Utils.atom<unknown>(undefined);
+export const requesterPaysProjectStore = atom<unknown>(undefined);
 
-export const runtimesStore = Utils.atom<unknown>(undefined);
+export const runtimesStore = atom<unknown>(undefined);
 
-export const workflowSelectionStore = Utils.atom({
+export const workflowSelectionStore = atom({
   key: undefined,
   entityType: undefined,
   entities: undefined,
@@ -87,13 +86,13 @@ export type AsyncImportJob = {
   };
 };
 
-export const asyncImportJobStore = Utils.atom<AsyncImportJob[]>([]);
+export const asyncImportJobStore = atom<AsyncImportJob[]>([]);
 
-export const snapshotsListStore = Utils.atom<unknown>(undefined);
+export const snapshotsListStore = atom<unknown>(undefined);
 
-export const snapshotStore = Utils.atom<unknown>(undefined);
+export const snapshotStore = atom<unknown>(undefined);
 
-export const dataCatalogStore = Utils.atom<any[]>([]);
+export const dataCatalogStore = atom<any[]>([]);
 
 type AjaxOverride = {
   fn: (fetch: AnyPromiseFn) => AnyPromiseFn;
@@ -107,7 +106,7 @@ type AjaxOverride = {
 
 declare global {
   interface Window {
-    ajaxOverridesStore: Utils.Atom<AjaxOverride[]>;
+    ajaxOverridesStore: Atom<AjaxOverride[]>;
     configOverridesStore: any;
   }
 }
@@ -118,7 +117,7 @@ declare global {
  * The fn should be a fetch wrapper (oldFetch => newFetch) that modifies the request process. (See ajaxOverrideUtils)
  * If present, filter should be a RegExp that is matched against the url to target specific requests.
  */
-export const ajaxOverridesStore = Utils.atom<AjaxOverride[]>([]);
+export const ajaxOverridesStore = atom<AjaxOverride[]>([]);
 window.ajaxOverridesStore = ajaxOverridesStore;
 
 /*
@@ -140,7 +139,7 @@ export const AppProxyUrlStatus = Object.freeze({
  * Status can be one of None, Ready and Error. The proxy url will be in 'state' field when 'status' is Ready.
  * When 'state' is Error the 'state' field will contain the error that was returned from Leo (if any).
  */
-export const workflowsAppStore = Utils.atom({
+export const workflowsAppStore = atom({
   workspaceId: undefined,
   wdsProxyUrlState: { status: AppProxyUrlStatus.None, state: '' },
   cbasProxyUrlState: { status: AppProxyUrlStatus.None, state: '' },

--- a/src/libs/terms-of-service-alerts.js
+++ b/src/libs/terms-of-service-alerts.js
@@ -1,3 +1,4 @@
+import { atom } from '@terra-ui-packages/core-utils';
 import _ from 'lodash/fp';
 import { Fragment, useEffect } from 'react';
 import { br, h } from 'react-hyperscript-helpers';
@@ -6,7 +7,6 @@ import { Ajax } from 'src/libs/ajax';
 import * as Nav from 'src/libs/nav';
 import { useStore } from 'src/libs/react-utils';
 import { authStore } from 'src/libs/state';
-import * as Utils from 'src/libs/utils';
 
 const getNewTermsOfServiceNeedsAcceptingAlert = async (termsOfServiceState) => {
   const shouldNotify = !termsOfServiceState.userHasAcceptedLatestTos && termsOfServiceState.permitsSystemUsage;
@@ -42,7 +42,7 @@ export const getTermsOfServiceAlerts = async (authState) => {
   return _.compact([alerts]);
 };
 
-export const tosGracePeriodAlertsStore = Utils.atom([]);
+export const tosGracePeriodAlertsStore = atom([]);
 
 export const useTermsOfServiceAlerts = () => {
   useEffect(() => {

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -10,56 +10,6 @@ import { hasAccessLevel } from './workspace-utils';
 
 export { DEFAULT, switchCase } from '@terra-ui-packages/core-utils';
 
-export interface Subscribable<T extends any[]> {
-  subscribe: (fn: (...args: T) => void) => { unsubscribe: () => void };
-  next: (...args: T) => void;
-}
-
-/**
- * A mechanism for registering callbacks for some state change.
- */
-export const subscribable = <T extends any[]>(): Subscribable<T> => {
-  let subscribers: ((...args: T) => void)[] = [];
-  return {
-    subscribe: (fn: (...args: T) => void) => {
-      subscribers = append(fn, subscribers);
-      return {
-        unsubscribe: () => {
-          subscribers = _.without([fn], subscribers);
-        },
-      };
-    },
-    next: (...args: T) => {
-      _.forEach((fn) => fn(...args), subscribers);
-    },
-  };
-};
-
-export interface Atom<T> {
-  subscribe: (fn: (value: T, previousValue: T) => void) => { unsubscribe: () => void };
-  get: () => T;
-  set: (value: T) => void;
-  update: (fn: (currentValue: T) => T) => void;
-  reset: () => void;
-}
-
-/**
- * A simple state container inspired by clojure atoms. Method names were chosen based on similarity
- * to lodash and Immutable. (deref => get, reset! => set, swap! => update, reset to go back to initial value)
- * Implements the Store interface
- */
-export const atom = <T>(initialValue: T): Atom<T> => {
-  let value = initialValue;
-  const { subscribe, next } = subscribable<[T, T]>();
-  const get = () => value;
-  const set = (newValue: T) => {
-    const oldValue = value;
-    value = newValue;
-    next(newValue, oldValue);
-  };
-  return { subscribe, get, set, update: (fn) => set(fn(get())), reset: () => set(initialValue) };
-};
-
 const dateFormat = new Intl.DateTimeFormat('default', { day: 'numeric', month: 'short', year: 'numeric' });
 const monthYearFormat = new Intl.DateTimeFormat('default', { month: 'short', year: 'numeric' });
 const completeDateFormat = new Intl.DateTimeFormat('default', {


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/UIE-120

Continuing to move parts of libs/utils into the core-utils package. This also adds tests for atom and subscribable.