### PR TITLE
AJ-1283: Add `defaultGoogleBucketOptions` and `defaultAzureStorageOptions` to `testData`

### DIFF
--- a/src/analysis/Analyses.test.ts
+++ b/src/analysis/Analyses.test.ts
@@ -2,7 +2,6 @@ import { LoadedState } from '@terra-ui-packages/core-utils';
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { h } from 'react-hyperscript-helpers';
-import { defaultAzureWorkspace, defaultGoogleWorkspace } from 'src/analysis/_testData/testData';
 import { AnalysesData, AnalysesProps, BaseAnalyses, getUniqueFileName } from 'src/analysis/Analyses';
 import { analysisLauncherTabName } from 'src/analysis/runtime-common-components';
 import { AnalysisFile, getFileFromPath, useAnalysisFiles } from 'src/analysis/useAnalysisFiles';
@@ -14,6 +13,7 @@ import { ENABLE_JUPYTERLAB_ID, JUPYTERLAB_GCP_FEATURE_ID } from 'src/libs/featur
 import { goToPath } from 'src/libs/nav';
 import { getLocalPref, setLocalPref } from 'src/libs/prefs';
 import { asMockedFn } from 'src/testing/test-utils';
+import { defaultAzureWorkspace, defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
 
 type NavExports = typeof import('src/libs/nav');
 jest.mock(

--- a/src/analysis/ContextBar.test.ts
+++ b/src/analysis/ContextBar.test.ts
@@ -1,12 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { div, h } from 'react-hyperscript-helpers';
-import {
-  defaultAzureWorkspace,
-  defaultGoogleWorkspace,
-  galaxyDisk,
-  galaxyRunning,
-} from 'src/analysis/_testData/testData';
+import { galaxyDisk, galaxyRunning } from 'src/analysis/_testData/testData';
 import { ContextBar, ContextBarProps } from 'src/analysis/ContextBar';
 import { CloudEnvironmentModal } from 'src/analysis/modals/CloudEnvironmentModal';
 import { doesWorkspaceSupportCromwellAppForUser } from 'src/analysis/utils/app-utils';
@@ -17,10 +12,8 @@ import {
   getRuntimeCost,
   runtimeConfigCost,
 } from 'src/analysis/utils/cost-utils';
-import { defaultLocation } from 'src/analysis/utils/runtime-utils';
 import { appToolLabels, isToolHidden, runtimeToolLabels } from 'src/analysis/utils/tool-utils';
 import { MenuTrigger } from 'src/components/PopupTrigger';
-import { locationTypes } from 'src/components/region-common';
 import { Ajax } from 'src/libs/ajax';
 import { App } from 'src/libs/ajax/leonardo/models/app-models';
 import { PersistentDisk } from 'src/libs/ajax/leonardo/models/disk-models';
@@ -31,6 +24,11 @@ import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
 import * as Utils from 'src/libs/utils';
 import { cloudProviderTypes } from 'src/libs/workspace-utils';
 import { asMockedFn } from 'src/testing/test-utils';
+import {
+  defaultAzureWorkspace,
+  defaultGoogleBucketOptions,
+  defaultGoogleWorkspace,
+} from 'src/testing/workspace-fixtures';
 
 const GALAXY_COMPUTE_COST = 10;
 const GALAXY_DISK_COST = 1;
@@ -383,12 +381,7 @@ const runtimeDisk: PersistentDisk = {
   },
 };
 
-const defaultGoogleBucketOptions = {
-  googleBucketLocation: defaultLocation,
-  googleBucketType: locationTypes.default,
-  fetchedGoogleBucketLocation: undefined,
-};
-const defaultAzureStorageOptions = {
+const populatedAzureStorageOptions = {
   azureContainerRegion: 'eastus',
   azureContainerUrl: 'container-url',
   azureContainerSasUrl: 'container-url?sas',
@@ -411,7 +404,7 @@ const contextBarPropsForAzure: ContextBarProps = {
   appDataDisks: [],
   persistentDisks: [],
   refreshRuntimes: () => Promise.resolve(),
-  storageDetails: { ...defaultGoogleBucketOptions, ...defaultAzureStorageOptions },
+  storageDetails: { ...defaultGoogleBucketOptions, ...populatedAzureStorageOptions },
   refreshApps: () => Promise.resolve(),
   workspace: defaultAzureWorkspace,
 };

--- a/src/analysis/Environments/Environments.test.ts
+++ b/src/analysis/Environments/Environments.test.ts
@@ -6,8 +6,6 @@ import { h } from 'react-hyperscript-helpers';
 import {
   azureRuntime,
   dataprocRuntime,
-  defaultAzureWorkspace,
-  defaultGoogleWorkspace,
   generateAzureWorkspace,
   generateGoogleWorkspace,
   generateTestAppWithAzureWorkspace,
@@ -29,6 +27,7 @@ import { getUser } from 'src/libs/state';
 import * as Utils from 'src/libs/utils';
 import { WorkspaceWrapper } from 'src/libs/workspace-utils';
 import { asMockedFn } from 'src/testing/test-utils';
+import { defaultAzureWorkspace, defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
 
 type ModalMockExports = typeof import('src/components/Modal.mock');
 

--- a/src/analysis/_testData/testData.ts
+++ b/src/analysis/_testData/testData.ts
@@ -13,9 +13,8 @@ import { ListRuntimeItem, Runtime, runtimeStatuses } from 'src/libs/ajax/leonard
 import { defaultAzureRegion } from 'src/libs/azure-utils';
 import * as Utils from 'src/libs/utils';
 import { AzureWorkspace, cloudProviderTypes, GoogleWorkspace } from 'src/libs/workspace-utils';
+import { defaultAzureWorkspace, defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
 import { v4 as uuid } from 'uuid';
-
-const defaultGoogleWorkspaceNamespace = 'test-ws';
 
 // this is important, so the test impl can diverge
 export const testDefaultLocation = defaultLocation;
@@ -122,23 +121,6 @@ export const imageDocs = [
   },
 ];
 
-export const defaultGoogleWorkspace: GoogleWorkspace = {
-  workspace: {
-    authorizationDomain: [],
-    cloudPlatform: 'Gcp',
-    bucketName: 'test-bucket',
-    googleProject: `${defaultGoogleWorkspaceNamespace}-project`,
-    name: `${defaultGoogleWorkspaceNamespace}_ws`,
-    namespace: defaultGoogleWorkspaceNamespace,
-    workspaceId: 'testGoogleWorkspaceId',
-    createdDate: '2023-02-15T19:17:15.711Z',
-    createdBy: 'groot@gmail.com',
-  },
-  accessLevel: 'OWNER',
-  canShare: true,
-  canCompute: true,
-};
-
 export const generateGoogleWorkspace = (prefix: string = uuid().substring(0, 8)): GoogleWorkspace => ({
   workspace: {
     authorizationDomain: [],
@@ -175,26 +157,6 @@ export const generateAzureWorkspace = (prefix: string = uuid().substring(0, 8)):
   canShare: true,
   canCompute: true,
 });
-
-export const defaultAzureWorkspace: AzureWorkspace = {
-  workspace: {
-    authorizationDomain: [],
-    cloudPlatform: 'Azure',
-    name: 'test-azure-ws-name',
-    namespace: 'test-azure-ws-namespace',
-    workspaceId: 'fafbb550-62eb-4135-8b82-3ce4d53446af',
-    createdDate: '2023-02-15T19:17:15.711Z',
-    createdBy: 'justin@gmail.com',
-  },
-  azureContext: {
-    managedResourceGroupId: 'test-mrg',
-    subscriptionId: 'test-sub-id',
-    tenantId: 'test-tenant-id',
-  },
-  accessLevel: 'OWNER',
-  canShare: true,
-  canCompute: true,
-};
 
 export const defaultTestDisk = {
   id: 15778,

--- a/src/analysis/modals/AnalysisDuplicator.test.ts
+++ b/src/analysis/modals/AnalysisDuplicator.test.ts
@@ -1,7 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { h } from 'react-hyperscript-helpers';
-import { defaultAzureWorkspace, defaultGoogleWorkspace } from 'src/analysis/_testData/testData';
 import { AnalysisDuplicator, AnalysisDuplicatorProps } from 'src/analysis/modals/AnalysisDuplicator';
 import { AnalysisFile, getFileFromPath, useAnalysisFiles } from 'src/analysis/useAnalysisFiles';
 import { AbsolutePath, getExtension } from 'src/analysis/utils/file-utils';
@@ -10,6 +9,7 @@ import { AzureStorage, AzureStorageContract } from 'src/libs/ajax/AzureStorage';
 import { GoogleStorage, GoogleStorageContract } from 'src/libs/ajax/GoogleStorage';
 import { errorWatcher } from 'src/libs/error.mock';
 import { asMockedFn } from 'src/testing/test-utils';
+import { defaultAzureWorkspace, defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
 
 type ModalMockExports = typeof import('src/components/Modal.mock');
 jest.mock('src/components/Modal', () => {

--- a/src/analysis/modals/AnalysisModal.test.ts
+++ b/src/analysis/modals/AnalysisModal.test.ts
@@ -2,14 +2,7 @@ import { LoadedState } from '@terra-ui-packages/core-utils';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { h } from 'react-hyperscript-helpers';
-import {
-  defaultAzureWorkspace,
-  defaultGoogleWorkspace,
-  galaxyDisk,
-  galaxyRunning,
-  getGoogleRuntime,
-  imageDocs,
-} from 'src/analysis/_testData/testData';
+import { galaxyDisk, galaxyRunning, getGoogleRuntime, imageDocs } from 'src/analysis/_testData/testData';
 import { AnalysisFile, getFileFromPath } from 'src/analysis/useAnalysisFiles';
 import { AbsolutePath } from 'src/analysis/utils/file-utils';
 import { tools } from 'src/analysis/utils/tool-utils';
@@ -19,6 +12,7 @@ import { App } from 'src/libs/ajax/leonardo/models/app-models';
 import { reportError } from 'src/libs/error';
 import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
 import { asMockedFn } from 'src/testing/test-utils';
+import { defaultAzureWorkspace, defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
 
 import { AnalysisModal, AnalysisModalProps } from './AnalysisModal';
 

--- a/src/analysis/modals/CloudEnvironmentModal.test.ts
+++ b/src/analysis/modals/CloudEnvironmentModal.test.ts
@@ -4,8 +4,6 @@ import { h, p } from 'react-hyperscript-helpers';
 import {
   azureDisk,
   azureRuntime,
-  defaultAzureWorkspace,
-  defaultGoogleWorkspace,
   defaultTestDisk,
   galaxyRunning,
   generateTestApp,
@@ -20,6 +18,7 @@ import { App } from 'src/libs/ajax/leonardo/models/app-models';
 import { Runtimes } from 'src/libs/ajax/leonardo/Runtimes';
 import { cloudProviderTypes } from 'src/libs/workspace-utils';
 import { asMockedFn } from 'src/testing/test-utils';
+import { defaultAzureWorkspace, defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
 
 type RuntimesAjaxExports = typeof import('src/libs/ajax/leonardo/Runtimes');
 type AppsAjaxExports = typeof import('src/libs/ajax/leonardo/Apps');

--- a/src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeModal.test.js
+++ b/src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeModal.test.js
@@ -2,7 +2,7 @@ import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import _ from 'lodash/fp';
 import { h } from 'react-hyperscript-helpers';
-import { azureRuntime, defaultAzureWorkspace, defaultTestDisk, getDisk, imageDocs, testAzureDefaultRegion } from 'src/analysis/_testData/testData';
+import { azureRuntime, defaultTestDisk, getDisk, imageDocs, testAzureDefaultRegion } from 'src/analysis/_testData/testData';
 import { getAzureComputeCostEstimate, getAzureDiskCostEstimate } from 'src/analysis/utils/cost-utils';
 import { autopauseDisabledValue, defaultAutopauseThreshold } from 'src/analysis/utils/runtime-utils';
 import { runtimeToolLabels, runtimeTools } from 'src/analysis/utils/tool-utils';
@@ -10,6 +10,7 @@ import { Ajax } from 'src/libs/ajax';
 import { azureMachineTypes, defaultAzureMachineType, getMachineTypeLabel } from 'src/libs/azure-utils';
 import { formatUSD } from 'src/libs/utils';
 import { asMockedFn } from 'src/testing/test-utils';
+import { defaultAzureWorkspace } from 'src/testing/workspace-fixtures';
 
 import { AzureComputeModalBase } from './AzureComputeModal';
 

--- a/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeImageSection.test.ts
+++ b/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeImageSection.test.ts
@@ -3,7 +3,6 @@ import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { h } from 'react-hyperscript-helpers';
 import {
-  defaultGoogleWorkspace,
   defaultImage,
   defaultRImage,
   generateTestGoogleRuntime,
@@ -20,6 +19,7 @@ import { Ajax } from 'src/libs/ajax';
 import { ComputeImageRaw } from 'src/libs/ajax/compute-image-providers/ComputeImageProvider';
 import { GetRuntimeItem } from 'src/libs/ajax/leonardo/models/runtime-models';
 import { asMockedFn } from 'src/testing/test-utils';
+import { defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
 
 type UseComputeImagesExport = typeof import('src/analysis/useComputeImages');
 jest.mock(

--- a/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal.test.js
+++ b/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal.test.js
@@ -3,7 +3,6 @@ import userEvent from '@testing-library/user-event';
 import _ from 'lodash/fp';
 import { h } from 'react-hyperscript-helpers';
 import {
-  defaultGoogleWorkspace,
   defaultImage,
   defaultTestDisk,
   getDisk,
@@ -32,6 +31,7 @@ import { Ajax } from 'src/libs/ajax';
 import { runtimeStatuses } from 'src/libs/ajax/leonardo/models/runtime-models';
 import { formatUSD } from 'src/libs/utils';
 import { asMockedFn } from 'src/testing/test-utils';
+import { defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
 
 jest.mock('src/libs/notifications', () => ({
   notify: (...args) => {

--- a/src/analysis/modals/HailBatchModal.test.ts
+++ b/src/analysis/modals/HailBatchModal.test.ts
@@ -1,9 +1,10 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { h } from 'react-hyperscript-helpers';
-import { defaultAzureWorkspace, generateTestAppWithAzureWorkspace } from 'src/analysis/_testData/testData';
+import { generateTestAppWithAzureWorkspace } from 'src/analysis/_testData/testData';
 import { Apps } from 'src/libs/ajax/leonardo/Apps';
 import { asMockedFn } from 'src/testing/test-utils';
+import { defaultAzureWorkspace } from 'src/testing/workspace-fixtures';
 
 import { appToolLabels } from '../utils/tool-utils';
 import { HailBatchModal, HailBatchModalProps } from './HailBatchModal';

--- a/src/analysis/utils/file-utils.test.ts
+++ b/src/analysis/utils/file-utils.test.ts
@@ -1,6 +1,5 @@
 import { ReadyState } from '@terra-ui-packages/core-utils';
 import { act } from '@testing-library/react';
-import { defaultAzureWorkspace, defaultGoogleWorkspace } from 'src/analysis/_testData/testData';
 import { AnalysisFile, getFileFromPath, useAnalysisFiles } from 'src/analysis/useAnalysisFiles';
 import { AbsolutePath, getExtension, getFileName } from 'src/analysis/utils/file-utils';
 import { getToolLabelFromFileExtension, runtimeToolLabels } from 'src/analysis/utils/tool-utils';
@@ -9,6 +8,7 @@ import { GoogleStorage, GoogleStorageContract } from 'src/libs/ajax/GoogleStorag
 import { reportError } from 'src/libs/error';
 import { workspaceStore } from 'src/libs/state';
 import { asMockedFn, renderHookInAct } from 'src/testing/test-utils';
+import { defaultAzureWorkspace, defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
 
 jest.mock('src/libs/ajax/GoogleStorage');
 jest.mock('src/libs/ajax/AzureStorage');

--- a/src/components/data/DataTable.test.ts
+++ b/src/components/data/DataTable.test.ts
@@ -4,11 +4,11 @@ import userEvent from '@testing-library/user-event';
 import _ from 'lodash/fp';
 import { useState } from 'react';
 import { h } from 'react-hyperscript-helpers';
-import { defaultGoogleWorkspace } from 'src/analysis/_testData/testData';
 import DataTable from 'src/components/data/DataTable';
 import { Ajax } from 'src/libs/ajax';
 import { DataTableProvider } from 'src/libs/ajax/data-table-providers/DataTableProvider';
 import { asMockedFn } from 'src/testing/test-utils';
+import { defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
 
 type AjaxContract = ReturnType<typeof Ajax>;
 

--- a/src/components/data/EntitiesContent.test.ts
+++ b/src/components/data/EntitiesContent.test.ts
@@ -4,9 +4,9 @@ import userEvent from '@testing-library/user-event';
 import * as clipboard from 'clipboard-polyfill/text';
 import FileSaver from 'file-saver';
 import { h } from 'react-hyperscript-helpers';
-import { defaultGoogleWorkspace } from 'src/analysis/_testData/testData';
 import { Ajax } from 'src/libs/ajax';
 import { asMockedFn } from 'src/testing/test-utils';
+import { defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
 
 import EntitiesContent from './EntitiesContent';
 

--- a/src/libs/workspace-utils.test.ts
+++ b/src/libs/workspace-utils.test.ts
@@ -1,4 +1,4 @@
-import { defaultAzureWorkspace, defaultGoogleWorkspace } from 'src/analysis/_testData/testData';
+import { defaultAzureWorkspace, defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
 
 import { isValidWsExportTarget, WorkspaceWrapper } from './workspace-utils';
 

--- a/src/pages/ImportData.test.js
+++ b/src/pages/ImportData.test.js
@@ -1,7 +1,7 @@
 import { getAllByRole, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { h } from 'react-hyperscript-helpers';
-import { defaultAzureWorkspace, defaultGoogleWorkspace } from 'src/analysis/_testData/testData';
+import { defaultAzureWorkspace, defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
 
 import { ImportDataDestination, ImportDataOverview, isProtectedSource, isProtectedWorkspace } from './ImportData';
 

--- a/src/pages/workspaces/workspace/Dashboard.test.js
+++ b/src/pages/workspaces/workspace/Dashboard.test.js
@@ -3,12 +3,11 @@ import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 import _ from 'lodash/fp';
 import { h } from 'react-hyperscript-helpers';
-import { defaultLocation } from 'src/analysis/utils/runtime-utils';
-import { locationTypes } from 'src/components/region-common';
 import { Ajax } from 'src/libs/ajax';
 import { authStore } from 'src/libs/state';
 import { AzureStorageDetails, BucketLocation, WorkspaceNotifications } from 'src/pages/workspaces/workspace/Dashboard';
 import { asMockedFn } from 'src/testing/test-utils';
+import { defaultAzureStorageOptions, defaultGoogleBucketOptions } from 'src/testing/workspace-fixtures';
 
 jest.mock('src/libs/ajax');
 
@@ -99,17 +98,6 @@ describe('WorkspaceNotifications', () => {
     expect(await axe(container)).toHaveNoViolations();
   });
 });
-
-const defaultGoogleBucketOptions = {
-  googleBucketLocation: defaultLocation,
-  googleBucketType: locationTypes.default,
-  fetchedGoogleBucketLocation: undefined,
-};
-const defaultAzureStorageOptions = {
-  azureContainerRegion: undefined,
-  azureContainerUrl: undefined,
-  azureContainerSasUrl: undefined,
-};
 
 describe('BucketLocation', () => {
   const workspace = { workspace: { namespace: 'test', name: 'test', cloudPlatform: 'Gcp' }, workspaceInitialized: true };

--- a/src/pages/workspaces/workspace/useWorkspace.test.ts
+++ b/src/pages/workspaces/workspace/useWorkspace.test.ts
@@ -1,8 +1,6 @@
 import { DeepPartial } from '@terra-ui-packages/core-utils';
 import { act } from '@testing-library/react';
 import _ from 'lodash/fp';
-import { defaultLocation } from 'src/analysis/utils/runtime-utils';
-import { locationTypes } from 'src/components/region-common';
 import * as WorkspaceUtils from 'src/components/workspace-utils';
 import { Ajax } from 'src/libs/ajax';
 import { AzureStorage, AzureStorageContract } from 'src/libs/ajax/AzureStorage';
@@ -15,6 +13,7 @@ import {
   useWorkspace,
 } from 'src/pages/workspaces/workspace/useWorkspace';
 import { asMockedFn, renderHookInAct } from 'src/testing/test-utils';
+import { defaultAzureStorageOptions, defaultGoogleBucketOptions } from 'src/testing/workspace-fixtures';
 
 jest.mock('src/libs/ajax/AzureStorage');
 
@@ -103,21 +102,9 @@ describe('useActiveWorkspace', () => {
     locationType: 'location-type',
   };
 
-  const defaultGoogleBucketOptions = {
-    googleBucketLocation: defaultLocation,
-    googleBucketType: locationTypes.default,
-    fetchedGoogleBucketLocation: undefined,
-  };
-
   const azureStorageDetails = {
     location: 'container-location',
     sas: { url: 'container-url?sas-token' },
-  };
-
-  const defaultAzureStorageOptions = {
-    azureContainerRegion: undefined,
-    azureContainerUrl: undefined,
-    azureContainerSasUrl: undefined,
   };
 
   beforeEach(() => {

--- a/src/pages/workspaces/workspace/useWorkspace.ts
+++ b/src/pages/workspaces/workspace/useWorkspace.ts
@@ -53,6 +53,8 @@ export const useWorkspace = (namespace, name): WorkspaceDetails => {
     location: string;
     locationType: string;
   }>({
+    // Changes to these defaults should be reflected by the `defaultGoogleBucketOptions` defined in
+    // workspace-fixtures.ts, which are intended to follow this implementation.
     fetchedLocation: undefined,
     location: defaultLocation,
     locationType: locationTypes.default, // These default types are historical

--- a/src/testing/workspace-fixtures.ts
+++ b/src/testing/workspace-fixtures.ts
@@ -1,0 +1,57 @@
+import { defaultLocation } from 'src/analysis/utils/runtime-utils';
+import { locationTypes } from 'src/components/region-common';
+import { AzureWorkspace, GoogleWorkspace } from 'src/libs/workspace-utils';
+
+export const defaultAzureWorkspace: AzureWorkspace = {
+  workspace: {
+    authorizationDomain: [],
+    cloudPlatform: 'Azure',
+    name: 'test-azure-ws-name',
+    namespace: 'test-azure-ws-namespace',
+    workspaceId: 'fafbb550-62eb-4135-8b82-3ce4d53446af',
+    createdDate: '2023-02-15T19:17:15.711Z',
+    createdBy: 'justin@gmail.com',
+  },
+  azureContext: {
+    managedResourceGroupId: 'test-mrg',
+    subscriptionId: 'test-sub-id',
+    tenantId: 'test-tenant-id',
+  },
+  accessLevel: 'OWNER',
+  canShare: true,
+  canCompute: true,
+};
+
+// These values are not populated by default, and for the majority of existing
+// Google workspaces will remain undefined.  This definition should only be
+// changed to include test values if the default behavior also changes to always
+// set these fields.
+export const defaultAzureStorageOptions = {
+  azureContainerRegion: undefined,
+  azureContainerUrl: undefined,
+  azureContainerSasUrl: undefined,
+};
+
+export const defaultGoogleWorkspace: GoogleWorkspace = {
+  workspace: {
+    authorizationDomain: [],
+    cloudPlatform: 'Gcp',
+    bucketName: 'test-bucket',
+    googleProject: 'test-gcp-ws-project',
+    name: 'test-gcp-ws-name',
+    namespace: 'test-gcp-ws-namespace',
+    workspaceId: 'testGoogleWorkspaceId',
+    createdDate: '2023-02-15T19:17:15.711Z',
+    createdBy: 'groot@gmail.com',
+  },
+  accessLevel: 'OWNER',
+  canShare: true,
+  canCompute: true,
+};
+
+// These defaults are intended to track the default behavior implemented in useWorkspace.ts
+export const defaultGoogleBucketOptions = {
+  googleBucketLocation: defaultLocation,
+  googleBucketType: locationTypes.default,
+  fetchedGoogleBucketLocation: undefined,
+};


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/AJ-1283

<!-- ### Dependencies --->
This is a prefactor to improve reuse of exports I'll need while introducing test coverage to safeguard a changes to `Data.js`.  It is self-contained refactoring in test-only code & has no dependencies on other work.

## Summary of changes:
Extract default workspace test data into shared testing lib

Since these defaults are useful beyond just analysis, bringing them up a level makes them reusable to the whole codebase without requiring dependencies into the `analysis` subdir.

### Testing strategy
- [x] Existing unit tests that use these constructs continue to pass.  Production codepaths are untouched.

<!-- ### Visual Aids -->
N/A
