### PR TITLE
[AJ-1296] Move files out of src/data

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # Each line is a file pattern followed by one or more owners.
 # See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
 /src/analysis @DataBiosphere/broad-interactive-analysis
-/src/data/datasets.js @DataBiosphere/data-explorer-eng
+/src/constants/datasets.js @DataBiosphere/data-explorer-eng
 /src/libs/brand*.js @DataBiosphere/terra-cobranding
 /src/libs/colors.js @DataBiosphere/terra-cobranding
 /src/libs/ajax/Apps.ts @DataBiosphere/broad-interactive-analysis

--- a/src/components/DataExplorerFrame.js
+++ b/src/components/DataExplorerFrame.js
@@ -2,7 +2,7 @@ import { iframeResizer } from 'iframe-resizer';
 import _ from 'lodash/fp';
 import { useEffect, useRef } from 'react';
 import { iframe } from 'react-hyperscript-helpers';
-import datasets from 'src/data/datasets';
+import datasets from 'src/constants/datasets';
 import * as Nav from 'src/libs/nav';
 
 const DataExplorerFrame = ({ dataset }) => {

--- a/src/components/PrivateDataExplorer.js
+++ b/src/components/PrivateDataExplorer.js
@@ -4,7 +4,7 @@ import { b, div, h, p } from 'react-hyperscript-helpers';
 import { Link } from 'src/components/common';
 import DataExplorerFrame from 'src/components/DataExplorerFrame';
 import { centeredSpinner } from 'src/components/icons';
-import datasets from 'src/data/datasets';
+import datasets from 'src/constants/datasets';
 import { Ajax } from 'src/libs/ajax';
 import { useCancellation, useOnMount } from 'src/libs/react-utils';
 import { contactUsActive } from 'src/libs/state';

--- a/src/components/data/EntitiesContent.js
+++ b/src/components/data/EntitiesContent.js
@@ -21,6 +21,7 @@ import { withModalDrawer } from 'src/components/ModalDrawer';
 import { MenuDivider, MenuTrigger } from 'src/components/PopupTrigger';
 import TitleBar from 'src/components/TitleBar';
 import WorkflowSelector from 'src/components/WorkflowSelector';
+import datasets from 'src/constants/datasets';
 import { AddColumnModal } from 'src/data/data-table/entity-service/AddColumnModal';
 import { AddEntityModal } from 'src/data/data-table/entity-service/AddEntityModal';
 import { CreateEntitySetModal } from 'src/data/data-table/entity-service/CreateEntitySetModal';
@@ -28,7 +29,6 @@ import { entityAttributeText } from 'src/data/data-table/entity-service/entityAt
 import { EntityDeleter } from 'src/data/data-table/entity-service/EntityDeleter';
 import { ExportDataModal } from 'src/data/data-table/entity-service/ExportDataModal';
 import { MultipleEntityEditor } from 'src/data/data-table/entity-service/MultipleEntityEditor';
-import datasets from 'src/data/datasets';
 import dataExplorerLogo from 'src/images/data-explorer-logo.svg';
 import igvLogo from 'src/images/igv-logo.png';
 import jupyterLogo from 'src/images/jupyter-logo.svg';

--- a/src/constants/datasets.ts
+++ b/src/constants/datasets.ts
@@ -1,6 +1,6 @@
 // name must be name from Data Explorer dataset.json
 // authDomain must be authorization_domain from Data Explorer dataset.json
-const datasets = [
+const datasets: { name: string; origin: string; authDomain?: string; partner?: string }[] = [
   {
     name: '1000 Genomes',
     origin: 'https://test-data-explorer.appspot.com',

--- a/src/pages/library/datasets/DataExplorer.js
+++ b/src/pages/library/datasets/DataExplorer.js
@@ -5,7 +5,7 @@ import DataExplorerFrame from 'src/components/DataExplorerFrame';
 import FooterWrapper from 'src/components/FooterWrapper';
 import PrivateDataExplorer from 'src/components/PrivateDataExplorer';
 import TopBar from 'src/components/TopBar';
-import datasets from 'src/data/datasets';
+import datasets from 'src/constants/datasets';
 import * as Nav from 'src/libs/nav';
 import * as Style from 'src/libs/style';
 

--- a/src/pages/workspaces/workspace/Dashboard.js
+++ b/src/pages/workspaces/workspace/Dashboard.js
@@ -14,7 +14,6 @@ import RequesterPaysModal from 'src/components/RequesterPaysModal';
 import { SimpleTable, TooltipCell } from 'src/components/table';
 import TooltipTrigger from 'src/components/TooltipTrigger';
 import { WorkspaceTagSelect } from 'src/components/workspace-utils';
-import { displayConsentCodes, displayLibraryAttributes } from 'src/data/workspace-attributes';
 import { ReactComponent as AzureLogo } from 'src/images/azure.svg';
 import { ReactComponent as GcpLogo } from 'src/images/gcp.svg';
 import { Ajax } from 'src/libs/ajax';
@@ -33,6 +32,7 @@ import * as Utils from 'src/libs/utils';
 import { isAzureWorkspace, isGoogleWorkspace } from 'src/libs/workspace-utils';
 import SignIn from 'src/pages/SignIn';
 import DashboardPublic from 'src/pages/workspaces/workspace/DashboardPublic';
+import { displayConsentCodes, displayLibraryAttributes } from 'src/pages/workspaces/workspace/library-attributes';
 import { wrapWorkspace } from 'src/pages/workspaces/workspace/WorkspaceContainer';
 
 const styles = {

--- a/src/pages/workspaces/workspace/library-attributes.ts
+++ b/src/pages/workspaces/workspace/library-attributes.ts
@@ -33,11 +33,13 @@ export const displayLibraryAttributes = [
 export const displayConsentCodes = [
   {
     key: 'library:GRU',
-    title: 'For health/medical/biomedical purposes and other biological research, including the study of population origins or ancestry.',
+    title:
+      'For health/medical/biomedical purposes and other biological research, including the study of population origins or ancestry.',
   },
   {
     key: 'library:HMB',
-    title: 'Use of the data is limited to health/medical/biomedical purposes, does not include the study of population origins or ancestry.',
+    title:
+      'Use of the data is limited to health/medical/biomedical purposes, does not include the study of population origins or ancestry.',
   },
   { key: 'library:DS', title: 'Use of the data must be related to a particular disease.' },
   { key: 'library:NCU', title: 'Use of the data is limited to non-commercial use.' },
@@ -54,7 +56,8 @@ export const displayConsentCodes = [
   },
   {
     key: 'library:NCTRL',
-    title: 'Data can be used as a control set ONLY within the bounds of other specified data use limitations (e.g. only for cancer studies).',
+    title:
+      'Data can be used as a control set ONLY within the bounds of other specified data use limitations (e.g. only for cancer studies).',
   },
   { key: 'library:RS-G', title: 'Use of the data is limited to studies of particular gender.' },
   { key: 'library:RS-PD', title: 'Use of the data is limited to pediatric research.' },


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1296

Similar to how we have src/analysis for the Analysis tab, I am looking to take over src/data for the Data tab.

It looks like in the past, src/data has been used to store a mixture of constants.

workspace-attributes.js is only imported by WorkspaceDashboard, so this moves it to src/pages/workspaces/workspace alongside that component.

datasets.js is imported by a few Data Explorer components and EntitiesContent (related to data tables). This moves it to a new src/constants folder.

Since both files export one or a few constants, they were easy to convert to TypeScript along the way.