### PR TITLE
[AJ-1312] Fix display of default instance exists in WDS status

### DIFF
--- a/src/components/data/WdsTroubleshooter.ts
+++ b/src/components/data/WdsTroubleshooter.ts
@@ -119,12 +119,7 @@ export const WdsTroubleshooter = ({ onDismiss, workspaceId, mrgId }) => {
       wdsIamStatus == null,
       !!wdsIamStatus && wdsIamStatus !== 'unknown' && wdsIamStatus !== 'DOWN',
     ],
-    [
-      'Default Instance exists',
-      defaultInstanceExists,
-      defaultInstanceExists == null,
-      !!defaultInstanceExists && defaultInstanceExists !== 'unknown',
-    ],
+    ['Default Instance exists', defaultInstanceExists, defaultInstanceExists == null, defaultInstanceExists === 'true'],
   ];
 
   if (cloneSourceWorkspaceId !== null) {


### PR DESCRIPTION
Currently, the logic for displaying a success or error icon on the "Default instance exists" row in the WDS status modal is broken. The display logic is written as if the status were a boolean, but it is actually a string.

## Before
Default instance does not exist, but it's shown as successful.

![Screenshot 2023-08-30 at 4 00 42 PM](https://github.com/DataBiosphere/terra-ui/assets/1156625/3914613c-54c4-4af3-af20-221524975355)

## After
![Screenshot 2023-08-30 at 4 00 28 PM](https://github.com/DataBiosphere/terra-ui/assets/1156625/c2ce9bb8-2c6e-499f-bcdc-c28b529dc3a8)

