### PR TITLE
AJ-1283: Add unit tests to `Data.js`

### DIFF
--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -605,7 +605,7 @@ const DataTableFeaturePreviewFeedbackBanner = () => {
 
 const workspaceDataTypes = Utils.enumify(['entities', 'entitiesVersion', 'snapshot', 'referenceData', 'localVariables', 'bucketObjects', 'wds']);
 
-const WorkspaceData = _.flow(
+export const WorkspaceData = _.flow(
   forwardRefWithName('WorkspaceData'),
   wrapWorkspace({
     breadcrumbs: (props) => breadcrumbs.commonPaths.workspaceDashboard(props),
@@ -1532,8 +1532,3 @@ export const navPaths = [
     title: ({ name }) => `${name} - Data`,
   },
 ];
-
-// These exports are for testing only.
-export const testOnlyExports = {
-  WorkspaceData,
-};

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -1533,7 +1533,7 @@ export const navPaths = [
   },
 ];
 
-// These modules are exported for testing only.
+// These exports are for testing only.
 export const testOnlyExports = {
   WorkspaceData,
 };

--- a/src/pages/workspaces/workspace/Data.js
+++ b/src/pages/workspaces/workspace/Data.js
@@ -1532,3 +1532,8 @@ export const navPaths = [
     title: ({ name }) => `${name} - Data`,
   },
 ];
+
+// These modules are exported for testing only.
+export const testOnlyExports = {
+  WorkspaceData,
+};

--- a/src/pages/workspaces/workspace/Data.test.ts
+++ b/src/pages/workspaces/workspace/Data.test.ts
@@ -95,7 +95,7 @@ describe('WorkspaceData', () => {
     const { workspaceDataProps } = setup({ workspace: defaultAzureWorkspace, status: 'PROVISIONING' });
 
     // Act
-    await act(async () => {
+    await act(() => {
       render(h(WorkspaceData, workspaceDataProps));
     });
 
@@ -111,7 +111,7 @@ describe('WorkspaceData', () => {
     mockGetSchema.mockRejectedValue(new Error('schema error'));
 
     // Act
-    await act(async () => {
+    await act(() => {
       render(h(WorkspaceData, workspaceDataProps));
     });
 
@@ -125,7 +125,7 @@ describe('WorkspaceData', () => {
     const { workspaceDataProps } = setup({ workspace: defaultAzureWorkspace, status: 'RUNNING' });
 
     // Act
-    await act(async () => {
+    await act(() => {
       render(h(WorkspaceData, workspaceDataProps));
     });
 

--- a/src/pages/workspaces/workspace/Data.test.ts
+++ b/src/pages/workspaces/workspace/Data.test.ts
@@ -1,0 +1,137 @@
+import { DeepPartial } from '@terra-ui-packages/core-utils';
+import { act, render, screen } from '@testing-library/react';
+import { h } from 'react-hyperscript-helpers';
+import { Ajax } from 'src/libs/ajax';
+import { LeoAppStatus, ListAppResponse } from 'src/libs/ajax/leonardo/models/app-models';
+import { WorkspaceWrapper } from 'src/libs/workspace-utils';
+import { testOnlyExports } from 'src/pages/workspaces/workspace/Data';
+import { asMockedFn } from 'src/testing/test-utils';
+import { defaultAzureWorkspace } from 'src/testing/workspace-fixtures';
+
+import { StorageDetails } from './useWorkspace';
+
+const { WorkspaceData } = testOnlyExports;
+
+type WorkspaceContainerExports = typeof import('src/pages/workspaces/workspace/WorkspaceContainer');
+jest.mock('src/pages/workspaces/workspace/WorkspaceContainer', (): WorkspaceContainerExports => {
+  return {
+    ...jest.requireActual<WorkspaceContainerExports>('src/pages/workspaces/workspace/WorkspaceContainer'),
+    wrapWorkspace: jest.fn().mockImplementation((_opts) => (wrappedComponent) => wrappedComponent),
+  };
+});
+
+type AjaxExports = typeof import('src/libs/ajax');
+jest.mock('src/libs/ajax', (): AjaxExports => {
+  return {
+    ...jest.requireActual<AjaxExports>('src/libs/ajax'),
+    Ajax: jest.fn(),
+  };
+});
+
+describe('WorkspaceData', () => {
+  // When Data.js is broken apart and the WorkspaceData component is converted to TypeScript,
+  // this type belongs there.
+  interface WorkspaceDataProps {
+    namespace: string;
+    name: string;
+    workspace: WorkspaceWrapper;
+    refreshWorkspace: () => void;
+    storageDetails: StorageDetails;
+  }
+
+  // SIFERS setup, see: https://medium.com/@kolodny/testing-with-sifers-c9d6bb5b362
+  function setup({
+    namespace = 'test-namespace',
+    name = 'test-name',
+    workspace,
+    refreshWorkspace = () => {},
+    storageDetails = {},
+    status = 'RUNNING' as LeoAppStatus,
+  }) {
+    type AjaxContract = ReturnType<typeof Ajax>;
+    type WorkspacesContract = AjaxContract['Workspaces'];
+    type AppsContract = AjaxContract['Apps'];
+    type WorkspaceDataContract = AjaxContract['WorkspaceData'];
+
+    const wdsApp: DeepPartial<ListAppResponse> = {
+      proxyUrls: {
+        wds: 'https://fake.wds.url/',
+      },
+      appType: 'WDS',
+    };
+
+    const mockGetSchema = jest.fn().mockResolvedValue([]);
+    const mockAjax: DeepPartial<AjaxContract> = {
+      Workspaces: {
+        workspace: (_namespace, _name) => ({
+          details: jest.fn().mockResolvedValue(workspace),
+          listSnapshots: jest.fn().mockResolvedValue([]),
+          entityMetadata: jest.fn().mockResolvedValue({}),
+        }),
+      } as DeepPartial<WorkspacesContract>,
+      WorkspaceData: {
+        getSchema: mockGetSchema,
+      } as DeepPartial<WorkspaceDataContract>,
+      Apps: {
+        listAppsV2: jest.fn().mockResolvedValue([{ ...wdsApp, status }]),
+      } as DeepPartial<AppsContract>,
+    };
+
+    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+
+    const workspaceDataProps = {
+      namespace,
+      name,
+      workspace,
+      refreshWorkspace,
+      storageDetails,
+    } as WorkspaceDataProps;
+
+    return { workspaceDataProps, mockGetSchema };
+  }
+
+  it('displays a waiting message for an azure workspace that is still provisioning in WDS', async () => {
+    // Arrange
+    const { workspaceDataProps } = setup({ workspace: defaultAzureWorkspace, status: 'PROVISIONING' });
+
+    // Act
+    await act(async () => {
+      render(h(WorkspaceData, workspaceDataProps));
+    });
+
+    // Assert
+    expect(screen.getByText(/Preparing your data tables/)).toBeVisible();
+    expect(screen.queryByText(/Data tables are unavailable/)).toBeNull(); // no error message
+  });
+
+  it('displays an error message for an azure workspace that fails when loading schema info', async () => {
+    // Arrange
+    const { workspaceDataProps, mockGetSchema } = setup({ workspace: defaultAzureWorkspace, status: 'RUNNING' });
+
+    mockGetSchema.mockRejectedValue(new Error('schema error'));
+
+    // Act
+    await act(async () => {
+      render(h(WorkspaceData, workspaceDataProps));
+    });
+
+    // Assert
+    expect(screen.getByText(/Data tables are unavailable/)).toBeVisible();
+    expect(screen.getByText(/Preparing your data tables/)).toBeVisible(); // weird, but current behavior
+  });
+
+  it('displays a prompt to select a data type once azure workspace is loaded', async () => {
+    // Arrange
+    const { workspaceDataProps } = setup({ workspace: defaultAzureWorkspace, status: 'RUNNING' });
+
+    // Act
+    await act(async () => {
+      render(h(WorkspaceData, workspaceDataProps));
+    });
+
+    // Assert
+    expect(screen.getByText(/Select a data type/)).toBeVisible();
+    expect(screen.queryByText(/Data tables are unavailable/)).toBeNull(); // no error message
+    expect(screen.queryByText(/Preparing your data tables/)).toBeNull(); // no waiting message
+  });
+});

--- a/src/pages/workspaces/workspace/Data.test.ts
+++ b/src/pages/workspaces/workspace/Data.test.ts
@@ -39,11 +39,11 @@ type AjaxContract = ReturnType<typeof Ajax>;
 
 describe('WorkspaceData', () => {
   type SetupOptions = {
-    namespace: string;
-    name: string;
+    namespace?: string;
+    name?: string;
     workspace: WorkspaceWrapper;
-    refreshWorkspace: () => void;
-    storageDetails: StorageDetails;
+    refreshWorkspace?: () => void;
+    storageDetails?: StorageDetails;
     status: LeoAppStatus;
   };
   type SetupResult = {
@@ -57,18 +57,15 @@ describe('WorkspaceData', () => {
     azureContainerSasUrl: 'container-url?sas',
   };
 
-  const defaultSetupOptions: SetupOptions = {
-    namespace: 'test-namespace',
-    name: 'test-name',
-    workspace: defaultAzureWorkspace,
-    refreshWorkspace: () => {},
-    storageDetails: { ...defaultGoogleBucketOptions, ...populatedAzureStorageOptions },
-    status: 'RUNNING',
-  };
-
   // SIFERS setup, see: https://medium.com/@kolodny/testing-with-sifers-c9d6bb5b362
-  function setup(opts: SetupOptions = defaultSetupOptions): SetupResult {
-    const { namespace, name, workspace, refreshWorkspace, storageDetails, status } = opts;
+  function setup({
+    namespace = 'test-namespace',
+    name = 'test-name',
+    workspace,
+    refreshWorkspace = () => {},
+    storageDetails = { ...defaultGoogleBucketOptions, ...populatedAzureStorageOptions },
+    status = 'RUNNING',
+  }: SetupOptions): SetupResult {
     const wdsApp: DeepPartial<ListAppResponse> = {
       proxyUrls: {
         wds: 'https://fake.wds.url/',
@@ -109,7 +106,6 @@ describe('WorkspaceData', () => {
   it('displays a waiting message for an azure workspace that is still provisioning in WDS', async () => {
     // Arrange
     const { workspaceDataProps } = setup({
-      ...defaultSetupOptions,
       workspace: defaultAzureWorkspace,
       status: 'PROVISIONING',
     });
@@ -127,7 +123,6 @@ describe('WorkspaceData', () => {
   it('displays an error message for an azure workspace that fails when loading schema info', async () => {
     // Arrange
     const { workspaceDataProps, mockGetSchema } = setup({
-      ...defaultSetupOptions,
       workspace: defaultAzureWorkspace,
       status: 'RUNNING',
     });
@@ -147,7 +142,6 @@ describe('WorkspaceData', () => {
   it('displays a prompt to select a data type once azure workspace is loaded', async () => {
     // Arrange
     const { workspaceDataProps } = setup({
-      ...defaultSetupOptions,
       workspace: defaultAzureWorkspace,
       status: 'RUNNING',
     });


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/AJ-1283

### Dependencies
Depends on https://github.com/DataBiosphere/terra-ui/pull/4157 for common test fixture data.

## Summary of changes:
This will provide a baseline to act as guardrails for changes I'll be making to the status polling.

### What
- Adds tests in prep for making changes to `Data.js`

### Why
- `Data.js` is large and unwieldy and lacks unit tests; this baseline will make it easier to add more tests going forward, and provide some basic protection for some changes targeted to the status polling.

### Testing strategy
- Add new tests to establish baseline expected behavior.