### PR TITLE
[UIE-124] Update RHH types to allow components to return ReactNode

### DIFF
--- a/types/react-hyperscript-helpers/index.d.ts
+++ b/types/react-hyperscript-helpers/index.d.ts
@@ -3,7 +3,17 @@
 import type * as React from 'react';
 
 declare module 'react-hyperscript-helpers' {
-  type Component<P> = React.FunctionComponent<P> | React.ComponentClass<P>;
+  // TODO: After upgrading to TypeScript >= 5.1, replace this with React.FunctionComponent.
+  // For TypeScript 5.1, @types/react defines FunctionComponent as returning ReactNode.
+  // For earlier versions of TypeScript, it defines FunctionComponent as returning
+  // ReactElement<any, any> | null. That limitation is related to JSX, which Terra UI
+  // does not use. Thus, we can use the updated type signature without TypeScript 5.1.
+  interface FunctionComponent<P = {}> {
+    (props: P, context?: any): ReactNode;
+    displayName?: string | undefined;
+  }
+
+  type Component<P> = FunctionComponent<P> | React.ComponentClass<P>;
 
   type Children<Props> = Props extends { children?: React.ReactNode }
     ? React.ReactNode[]

--- a/types/react-hyperscript-helpers/index.d.ts
+++ b/types/react-hyperscript-helpers/index.d.ts
@@ -10,7 +10,7 @@ declare module 'react-hyperscript-helpers' {
   // does not use. Thus, we can use the updated type signature without TypeScript 5.1.
   interface FunctionComponent<P = {}> {
     (props: P, context?: any): ReactNode;
-    displayName?: string | undefined;
+    displayName?: string;
   }
 
   type Component<P> = FunctionComponent<P> | React.ComponentClass<P>;

--- a/types/react-hyperscript-helpers/react-hyperscript-helpers.types.ts
+++ b/types/react-hyperscript-helpers/react-hyperscript-helpers.types.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { PropsWithChildren, ReactElement } from 'react';
+import { PropsWithChildren, ReactElement, ReactNode } from 'react';
 import { div, h } from 'react-hyperscript-helpers';
 
 // Empty element
@@ -43,6 +43,13 @@ h(TestComponent, { stringProp: 'value' }, ['Content']);
 h(TestComponent, [div()]);
 h(TestComponent, [div(), div()]);
 h(TestComponent, ['Content']);
+
+// Component typed as returning ReactNode
+const TestComponent2 = (props: TestComponentProps): ReactNode => {
+  return 'Hello world';
+};
+
+h(TestComponent2, { stringProp: 'value' });
 
 // Component that takes a function as a child
 interface FunctionChildComponentProps {


### PR DESCRIPTION
`@types/react` defines `FunctionComponent` as returning `ReactNode`:
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/336eedc2c9db5e36ef071bfb8d8c8017f7e81210/types/react/index.d.ts#L562-L568

But it only exports that definition when using TypeScript 5.1+. For older versions of TypeScript, `FunctionComponent` is defined as returning `ReactElement<any, any> | null`. This is related to TypeScript's handling of JSX (more information at https://devblogs.microsoft.com/typescript/announcing-typescript-5-1-beta/#decoupled-type-checking-between-jsx-elements-and-jsx-tag-types).

Terra UI doesn't use JSX, so we don't need TypeScript 5.1+ to use function components that return ReactNode. We only need to update our types for react-hyperscript-helpers, which this PR does.

This PR enables the convention we discussed earlier this week in the UI working group, where function components have types declared like:
```ts
type MyComponentProps = { ... }

const MyComponent = (props: MyComponentProps): ReactNode => { ... }
```