### PR TITLE
UIE-93 Decouple data clients - Environments page pt1

### DIFF
--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terra-ui-packages/core-utils",
-  "version": "0.2.0",
+  "version": "0.1.0",
   "scripts": {
     "build": "vite build --emptyOutDir",
     "dev": "vite build --mode=development --watch",

--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terra-ui-packages/core-utils",
-  "version": "0.0.6",
+  "version": "0.1.6",
   "scripts": {
     "build": "vite build --emptyOutDir",
     "dev": "vite build --mode=development --watch",

--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terra-ui-packages/core-utils",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "scripts": {
     "build": "vite build --emptyOutDir",
     "dev": "vite build --mode=development --watch",

--- a/packages/core-utils/src/type-utils/type-helpers.ts
+++ b/packages/core-utils/src/type-utils/type-helpers.ts
@@ -3,3 +3,11 @@
  * A func that takes (a: A, b: B) where A and B are both strings cannot be called like (b,a) with this restriction
  */
 export type NominalType<BaseType, Name extends string> = BaseType & { __typeToken: Name };
+
+/**
+ * Mutates the type of an object or interface property
+ *
+ * @example
+ * type SlightlyDifferentType = Mutate<OriginalType, 'propertyX', NewPropertyType>;
+ */
+export type Mutate<T, Key extends keyof T, Mutation> = { [P in keyof T]: P extends Key ? Mutation : T[P] };

--- a/src/analysis/Environments/DeleteAppModal.ts
+++ b/src/analysis/Environments/DeleteAppModal.ts
@@ -1,0 +1,66 @@
+import _ from 'lodash/fp';
+import { useState } from 'react';
+import { div, h, p, span } from 'react-hyperscript-helpers';
+import { SaveFilesHelpGalaxy } from 'src/analysis/runtime-common-components';
+import { appTools } from 'src/analysis/utils/tool-utils';
+import { LabeledCheckbox, spinnerOverlay } from 'src/components/common';
+import Modal from 'src/components/Modal';
+import { App } from 'src/libs/ajax/leonardo/models/app-models';
+import { LeoAppProvider } from 'src/libs/ajax/leonardo/providers/LeoAppProvider';
+import { withErrorReportingInModal } from 'src/libs/error';
+import * as Utils from 'src/libs/utils';
+
+export type DeleteAppProvider = Pick<LeoAppProvider, 'delete'>;
+
+export interface DeleteAppModalProps {
+  app: App;
+  onDismiss: () => void;
+  onSuccess: () => void;
+  deleteProvider: DeleteAppProvider;
+}
+
+export const DeleteAppModal: React.FC<DeleteAppModalProps> = (props) => {
+  const { app, onDismiss, onSuccess, deleteProvider } = props;
+  const [deleteDisk, setDeleteDisk] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const {
+    appName,
+    appType,
+    cloudContext: { cloudProvider, cloudResource },
+  } = app;
+  const deleteApp = _.flow(
+    Utils.withBusyState(setDeleting),
+    withErrorReportingInModal('Error deleting cloud environment', onDismiss)
+  )(async () => {
+    // TODO: this should use types in IA-3824
+    if (cloudProvider === 'GCP') {
+      // await ajax().Apps.app(cloudResource, appName).delete(deleteDisk);
+      await deleteProvider.delete(cloudResource, appName, deleteDisk);
+      onSuccess();
+    } else {
+      throw new Error('Deleting apps is currently only supported on GCP');
+    }
+  });
+  return h(
+    Modal,
+    {
+      title: 'Delete cloud environment?',
+      onDismiss,
+      okButton: deleteApp,
+    },
+    [
+      div({ style: { lineHeight: 1.5 } }, [
+        app.diskName
+          ? h(LabeledCheckbox, { checked: deleteDisk, onChange: setDeleteDisk }, [
+              span({ style: { fontWeight: 600 } }, [' Also delete the persistent disk and all files on it']),
+            ])
+          : p([
+              'Deleting this cloud environment will also ',
+              span({ style: { fontWeight: 600 } }, ['delete any files on the associated hard disk.']),
+            ]),
+        appType === appTools.GALAXY.label && h(SaveFilesHelpGalaxy),
+      ]),
+      deleting && spinnerOverlay,
+    ]
+  );
+};

--- a/src/analysis/Environments/DeleteAppModal.ts
+++ b/src/analysis/Environments/DeleteAppModal.ts
@@ -23,22 +23,13 @@ export const DeleteAppModal = (props: DeleteAppModalProps): ReactNode => {
   const { app, onDismiss, onSuccess, deleteProvider } = props;
   const [deleteDisk, setDeleteDisk] = useState(false);
   const [deleting, setDeleting] = useState(false);
-  const {
-    appName,
-    appType,
-    cloudContext: { cloudProvider, cloudResource },
-  } = app;
+  const { appType } = app;
   const deleteApp = _.flow(
     Utils.withBusyState(setDeleting),
     withErrorReportingInModal('Error deleting cloud environment', onDismiss)
   )(async () => {
-    // TODO: this should use types in IA-3824
-    if (cloudProvider === 'GCP') {
-      await deleteProvider.delete(cloudResource, appName, deleteDisk);
-      onSuccess();
-    } else {
-      throw new Error('Deleting apps is currently only supported on GCP');
-    }
+    await deleteProvider.delete(app, { deleteDisk });
+    onSuccess();
   });
   return h(
     Modal,

--- a/src/analysis/Environments/DeleteAppModal.ts
+++ b/src/analysis/Environments/DeleteAppModal.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp';
-import { useState } from 'react';
+import { ReactNode, useState } from 'react';
 import { div, h, p, span } from 'react-hyperscript-helpers';
 import { SaveFilesHelpGalaxy } from 'src/analysis/runtime-common-components';
 import { appTools } from 'src/analysis/utils/tool-utils';
@@ -19,7 +19,7 @@ export interface DeleteAppModalProps {
   deleteProvider: DeleteAppProvider;
 }
 
-export const DeleteAppModal: React.FC<DeleteAppModalProps> = (props) => {
+export const DeleteAppModal = (props: DeleteAppModalProps): ReactNode => {
   const { app, onDismiss, onSuccess, deleteProvider } = props;
   const [deleteDisk, setDeleteDisk] = useState(false);
   const [deleting, setDeleting] = useState(false);

--- a/src/analysis/Environments/DeleteAppModal.ts
+++ b/src/analysis/Environments/DeleteAppModal.ts
@@ -34,7 +34,6 @@ export const DeleteAppModal = (props: DeleteAppModalProps): ReactNode => {
   )(async () => {
     // TODO: this should use types in IA-3824
     if (cloudProvider === 'GCP') {
-      // await ajax().Apps.app(cloudResource, appName).delete(deleteDisk);
       await deleteProvider.delete(cloudResource, appName, deleteDisk);
       onSuccess();
     } else {

--- a/src/analysis/Environments/DeleteButton.ts
+++ b/src/analysis/Environments/DeleteButton.ts
@@ -1,4 +1,5 @@
 import _ from 'lodash/fp';
+import { ReactNode } from 'react';
 import { h } from 'react-hyperscript-helpers';
 import { isResourceDeletable } from 'src/analysis/utils/resource-utils';
 import { getDisplayRuntimeStatus } from 'src/analysis/utils/runtime-utils';
@@ -14,7 +15,7 @@ export interface DeleteButtonProps {
   onClick: (resource: DecoratedComputeResource) => void;
 }
 
-export const DeleteButton: React.FC<DeleteButtonProps> = (props) => {
+export const DeleteButton = (props: DeleteButtonProps): ReactNode => {
   const { resource, onClick } = props;
   const resourceType = isApp(resource) ? 'app' : 'runtime';
   const isDeletable = isResourceDeletable(resourceType, resource);

--- a/src/analysis/Environments/DeleteButton.ts
+++ b/src/analysis/Environments/DeleteButton.ts
@@ -1,0 +1,35 @@
+import _ from 'lodash/fp';
+import { h } from 'react-hyperscript-helpers';
+import { isResourceDeletable } from 'src/analysis/utils/resource-utils';
+import { getDisplayRuntimeStatus } from 'src/analysis/utils/runtime-utils';
+import { Link } from 'src/components/common';
+import { makeMenuIcon } from 'src/components/PopupTrigger';
+import { isApp } from 'src/libs/ajax/leonardo/models/app-models';
+import { LeoRuntimeStatus } from 'src/libs/ajax/leonardo/models/runtime-models';
+
+import { DecoratedComputeResource } from './Environments.models';
+
+export interface DeleteButtonProps {
+  resource: DecoratedComputeResource;
+  onClick: (resource: DecoratedComputeResource) => void;
+}
+
+export const DeleteButton: React.FC<DeleteButtonProps> = (props) => {
+  const { resource, onClick } = props;
+  const resourceType = isApp(resource) ? 'app' : 'runtime';
+  const isDeletable = isResourceDeletable(resourceType, resource);
+
+  return h(
+    Link,
+    {
+      disabled: !isDeletable,
+      tooltip: isDeletable
+        ? 'Delete cloud environment'
+        : `Cannot delete a cloud environment while in status ${_.upperCase(
+            getDisplayRuntimeStatus(resource.status as LeoRuntimeStatus)
+          )}.`,
+      onClick: () => onClick(resource),
+    },
+    [makeMenuIcon('trash'), 'Delete']
+  );
+};

--- a/src/analysis/Environments/Environments.models.ts
+++ b/src/analysis/Environments/Environments.models.ts
@@ -4,7 +4,7 @@ import { ListRuntimeItem } from 'src/libs/ajax/leonardo/models/runtime-models';
 import { WorkspaceInfo } from 'src/libs/workspace-utils';
 
 export interface DecoratedResourceAttributes {
-  workspace: WorkspaceInfo;
+  workspace?: WorkspaceInfo;
   unsupportedWorkspace: boolean;
 }
 

--- a/src/analysis/Environments/Environments.models.ts
+++ b/src/analysis/Environments/Environments.models.ts
@@ -1,0 +1,16 @@
+import { App } from 'src/libs/ajax/leonardo/models/app-models';
+import { PersistentDisk } from 'src/libs/ajax/leonardo/models/disk-models';
+import { Runtime } from 'src/libs/ajax/leonardo/models/runtime-models';
+import { WorkspaceInfo } from 'src/libs/workspace-utils';
+
+export interface DecoratedResourceAttributes {
+  workspace: WorkspaceInfo;
+  unsupportedWorkspace: boolean;
+}
+
+export type RuntimeWithWorkspace = DecoratedResourceAttributes & Runtime;
+export type DiskWithWorkspace = DecoratedResourceAttributes & PersistentDisk;
+export type AppWithWorkspace = DecoratedResourceAttributes & App;
+
+export type DecoratedComputeResource = RuntimeWithWorkspace | AppWithWorkspace;
+export type DecoratedResource = DecoratedComputeResource | DiskWithWorkspace;

--- a/src/analysis/Environments/Environments.models.ts
+++ b/src/analysis/Environments/Environments.models.ts
@@ -1,6 +1,6 @@
 import { App } from 'src/libs/ajax/leonardo/models/app-models';
 import { PersistentDisk } from 'src/libs/ajax/leonardo/models/disk-models';
-import { Runtime } from 'src/libs/ajax/leonardo/models/runtime-models';
+import { ListRuntimeItem } from 'src/libs/ajax/leonardo/models/runtime-models';
 import { WorkspaceInfo } from 'src/libs/workspace-utils';
 
 export interface DecoratedResourceAttributes {
@@ -8,7 +8,7 @@ export interface DecoratedResourceAttributes {
   unsupportedWorkspace: boolean;
 }
 
-export type RuntimeWithWorkspace = DecoratedResourceAttributes & Runtime;
+export type RuntimeWithWorkspace = DecoratedResourceAttributes & ListRuntimeItem;
 export type DiskWithWorkspace = DecoratedResourceAttributes & PersistentDisk;
 export type AppWithWorkspace = DecoratedResourceAttributes & App;
 

--- a/src/analysis/Environments/Environments.test.ts
+++ b/src/analysis/Environments/Environments.test.ts
@@ -19,7 +19,7 @@ import { defaultComputeZone } from 'src/analysis/utils/runtime-utils';
 import { appToolLabels } from 'src/analysis/utils/tool-utils';
 import { AzureConfig, GceWithPdConfig } from 'src/libs/ajax/leonardo/models/runtime-config-models';
 import { Runtime, runtimeStatuses } from 'src/libs/ajax/leonardo/models/runtime-models';
-import { LeoAppProvider } from 'src/libs/ajax/leonardo/providers/LeoAppProvider';
+import { AppBasics, LeoAppProvider } from 'src/libs/ajax/leonardo/providers/LeoAppProvider';
 import { LeoDiskProvider } from 'src/libs/ajax/leonardo/providers/LeoDiskProvider';
 import { LeoRuntimeProvider } from 'src/libs/ajax/leonardo/providers/LeoRuntimeProvider';
 import { getTerraUser } from 'src/libs/state';
@@ -611,7 +611,12 @@ describe('Environments', () => {
       await user.click(buttons1[0]);
       if (!isAzure) {
         expect(props.leoAppData.pause).toBeCalledTimes(1);
-        expect(props.leoAppData.pause).toBeCalledWith(expect.anything(), app.appName);
+        expect(props.leoAppData.pause).toBeCalledWith(
+          expect.objectContaining({
+            appName: app.appName,
+            cloudContext: app.cloudContext,
+          } satisfies AppBasics)
+        );
       } else {
         expect(consoleSpy).toHaveBeenCalledWith('Pause is not currently implemented for azure apps');
       }

--- a/src/analysis/Environments/Environments.test.ts
+++ b/src/analysis/Environments/Environments.test.ts
@@ -14,7 +14,12 @@ import {
   generateTestDiskWithGoogleWorkspace,
   generateTestListGoogleRuntime,
 } from 'src/analysis/_testData/testData';
-import { EnvironmentNavActions, Environments, EnvironmentsProps, PauseButton } from 'src/analysis/Environments/Environments';
+import {
+  EnvironmentNavActions,
+  Environments,
+  EnvironmentsProps,
+  PauseButton,
+} from 'src/analysis/Environments/Environments';
 import { defaultComputeZone } from 'src/analysis/utils/runtime-utils';
 import { appToolLabels } from 'src/analysis/utils/tool-utils';
 import { AzureConfig, GceWithPdConfig } from 'src/libs/ajax/leonardo/models/runtime-config-models';

--- a/src/analysis/Environments/Environments.test.ts
+++ b/src/analysis/Environments/Environments.test.ts
@@ -90,15 +90,15 @@ const getMockLeoDiskProvider = (overrides?: Partial<LeoDiskProvider>): LeoDiskPr
 const getEnvironmentsProps = (propsOverrides?: Partial<EnvironmentsProps>): EnvironmentsProps => {
   const defaultProps: EnvironmentsProps = {
     nav: mockNav,
-    useWorkspacesProvider: jest.fn(),
-    leoAppProvider: getMockLeoAppProvider(),
-    leoRuntimeProvider: getMockLeoRuntimeProvider(),
-    leoDiskProvider: getMockLeoDiskProvider(),
-    metricsProvider: {
+    useWorkspacesState: jest.fn(),
+    leoAppData: getMockLeoAppProvider(),
+    leoRuntimeData: getMockLeoRuntimeProvider(),
+    leoDiskData: getMockLeoDiskProvider(),
+    metrics: {
       captureEvent: jest.fn(),
     },
   };
-  asMockedFn(defaultProps.useWorkspacesProvider).mockReturnValue(defaultUseWorkspacesProps);
+  asMockedFn(defaultProps.useWorkspacesState).mockReturnValue(defaultUseWorkspacesProps);
 
   const finalizedProps: EnvironmentsProps = { ...defaultProps, ...propsOverrides };
 
@@ -117,8 +117,8 @@ describe('Environments', () => {
       // Arrange
       const props = getEnvironmentsProps();
       const runtime1 = generateTestListGoogleRuntime();
-      asMockedFn(props.leoRuntimeProvider.list).mockResolvedValue([runtime1]);
-      asMockedFn(props.useWorkspacesProvider).mockReturnValue({
+      asMockedFn(props.leoRuntimeData.list).mockResolvedValue([runtime1]);
+      asMockedFn(props.useWorkspacesState).mockReturnValue({
         ...defaultUseWorkspacesProps,
         workspaces: [],
       });
@@ -139,7 +139,7 @@ describe('Environments', () => {
       // Arrange
       const props = getEnvironmentsProps();
       const runtime1 = generateTestListGoogleRuntime();
-      asMockedFn(props.leoRuntimeProvider.list).mockResolvedValue([runtime1]);
+      asMockedFn(props.leoRuntimeData.list).mockResolvedValue([runtime1]);
 
       // Act
       await act(async () => {
@@ -166,8 +166,8 @@ describe('Environments', () => {
       const props = getEnvironmentsProps();
       const runtime1 = generateTestListGoogleRuntime();
       const runtime2 = azureRuntime;
-      asMockedFn(props.leoRuntimeProvider.list).mockResolvedValue([runtime1, runtime2]);
-      asMockedFn(props.useWorkspacesProvider).mockReturnValue({
+      asMockedFn(props.leoRuntimeData.list).mockResolvedValue([runtime1, runtime2]);
+      asMockedFn(props.useWorkspacesState).mockReturnValue({
         ...defaultUseWorkspacesProps,
         workspaces: [defaultGoogleWorkspace, defaultAzureWorkspace],
       });
@@ -203,8 +203,8 @@ describe('Environments', () => {
     it('Renders page correctly for a Dataproc Runtime', async () => {
       // Arrange
       const props = getEnvironmentsProps();
-      asMockedFn(props.leoRuntimeProvider.list).mockResolvedValue([dataprocRuntime]);
-      asMockedFn(props.useWorkspacesProvider).mockReturnValue({
+      asMockedFn(props.leoRuntimeData.list).mockResolvedValue([dataprocRuntime]);
+      asMockedFn(props.useWorkspacesState).mockReturnValue({
         ...defaultUseWorkspacesProps,
         workspaces: [defaultGoogleWorkspace],
       });
@@ -243,8 +243,8 @@ describe('Environments', () => {
       const runtime3 = azureRuntime;
       const runtime4: Runtime = { ...azureRuntime, status: runtimeStatuses.error.leoLabel };
       // the order in the below array is the default sort order of the table
-      asMockedFn(props.leoRuntimeProvider.list).mockResolvedValue([runtime3, runtime4, runtime1, runtime2]);
-      asMockedFn(props.useWorkspacesProvider).mockReturnValue({
+      asMockedFn(props.leoRuntimeData.list).mockResolvedValue([runtime3, runtime4, runtime1, runtime2]);
+      asMockedFn(props.useWorkspacesState).mockReturnValue({
         ...defaultUseWorkspacesProps,
         workspaces: [defaultGoogleWorkspace, defaultAzureWorkspace],
       });
@@ -302,8 +302,8 @@ describe('Environments', () => {
       // Arrange
       const props = getEnvironmentsProps();
       const runtime1 = generateTestListGoogleRuntime();
-      asMockedFn(props.leoRuntimeProvider.list).mockResolvedValue([runtime1]);
-      asMockedFn(props.useWorkspacesProvider).mockReturnValue({
+      asMockedFn(props.leoRuntimeData.list).mockResolvedValue([runtime1]);
+      asMockedFn(props.useWorkspacesState).mockReturnValue({
         ...defaultUseWorkspacesProps,
         workspaces: [defaultGoogleWorkspace, defaultAzureWorkspace],
       });
@@ -336,8 +336,8 @@ describe('Environments', () => {
     ])('Renders runtime details view correctly', async ({ runtime, workspace }) => {
       // Arrange
       const props = getEnvironmentsProps();
-      asMockedFn(props.leoRuntimeProvider.list).mockResolvedValue([runtime]);
-      asMockedFn(props.useWorkspacesProvider).mockReturnValue({
+      asMockedFn(props.leoRuntimeData.list).mockResolvedValue([runtime]);
+      asMockedFn(props.useWorkspacesState).mockReturnValue({
         ...defaultUseWorkspacesProps,
         workspaces: [workspace],
       });
@@ -371,8 +371,8 @@ describe('Environments', () => {
       // Arrange
       const user = userEvent.setup();
       const props = getEnvironmentsProps();
-      asMockedFn(props.leoRuntimeProvider.list).mockResolvedValue([runtime]);
-      asMockedFn(props.useWorkspacesProvider).mockReturnValue({
+      asMockedFn(props.leoRuntimeData.list).mockResolvedValue([runtime]);
+      asMockedFn(props.useWorkspacesState).mockReturnValue({
         ...defaultUseWorkspacesProps,
         workspaces: [workspace],
       });
@@ -395,8 +395,8 @@ describe('Environments', () => {
       await user.click(buttons1[0]);
 
       // Assert
-      expect(props.leoRuntimeProvider.stop).toBeCalledTimes(1);
-      expect(props.leoRuntimeProvider.stop).toBeCalledWith(
+      expect(props.leoRuntimeData.stop).toBeCalledTimes(1);
+      expect(props.leoRuntimeData.stop).toBeCalledWith(
         expect.objectContaining({
           runtimeName: runtime.runtimeName,
         })
@@ -418,8 +418,8 @@ describe('Environments', () => {
     ])('Renders the error message properly for azure and gce vms', async ({ runtime, workspace }) => {
       // Arrange
       const props = getEnvironmentsProps();
-      asMockedFn(props.leoRuntimeProvider.list).mockResolvedValue([runtime]);
-      asMockedFn(props.useWorkspacesProvider).mockReturnValue({
+      asMockedFn(props.leoRuntimeData.list).mockResolvedValue([runtime]);
+      asMockedFn(props.useWorkspacesState).mockReturnValue({
         ...defaultUseWorkspacesProps,
         workspaces: [workspace],
       });
@@ -444,8 +444,8 @@ describe('Environments', () => {
       // Arrange
       const props = getEnvironmentsProps();
       const galaxyApp = generateTestAppWithGoogleWorkspace({}, defaultGoogleWorkspace);
-      asMockedFn(props.leoAppProvider.listWithoutProject).mockResolvedValue([galaxyApp]);
-      asMockedFn(props.useWorkspacesProvider).mockReturnValue({
+      asMockedFn(props.leoAppData.listWithoutProject).mockResolvedValue([galaxyApp]);
+      asMockedFn(props.useWorkspacesState).mockReturnValue({
         ...defaultUseWorkspacesProps,
         workspaces: [defaultGoogleWorkspace],
       });
@@ -481,13 +481,8 @@ describe('Environments', () => {
       const azureApp1 = generateTestAppWithAzureWorkspace({ appType: appToolLabels.CROMWELL }, defaultAzureWorkspace);
       const azureWorkspace2 = generateAzureWorkspace();
       const azureApp2 = generateTestAppWithAzureWorkspace({ appType: appToolLabels.CROMWELL }, azureWorkspace2);
-      asMockedFn(props.leoAppProvider.listWithoutProject).mockResolvedValue([
-        googleApp1,
-        googleApp2,
-        azureApp1,
-        azureApp2,
-      ]);
-      asMockedFn(props.useWorkspacesProvider).mockReturnValue({
+      asMockedFn(props.leoAppData.listWithoutProject).mockResolvedValue([googleApp1, googleApp2, azureApp1, azureApp2]);
+      asMockedFn(props.useWorkspacesState).mockReturnValue({
         ...defaultUseWorkspacesProps,
         workspaces: [defaultGoogleWorkspace, googleWorkspace2, defaultAzureWorkspace, azureWorkspace2],
       });
@@ -546,8 +541,8 @@ describe('Environments', () => {
     ])('Renders app details view correctly', async ({ app, workspace }) => {
       // Arrange
       const props = getEnvironmentsProps();
-      asMockedFn(props.leoAppProvider.listWithoutProject).mockResolvedValue([app]);
-      asMockedFn(props.useWorkspacesProvider).mockReturnValue({
+      asMockedFn(props.leoAppData.listWithoutProject).mockResolvedValue([app]);
+      asMockedFn(props.useWorkspacesState).mockReturnValue({
         ...defaultUseWorkspacesProps,
         workspaces: [workspace],
       });
@@ -589,8 +584,8 @@ describe('Environments', () => {
       // Arrange
       const user = userEvent.setup();
       const props = getEnvironmentsProps();
-      asMockedFn(props.leoAppProvider.listWithoutProject).mockResolvedValue([app]);
-      asMockedFn(props.useWorkspacesProvider).mockReturnValue({
+      asMockedFn(props.leoAppData.listWithoutProject).mockResolvedValue([app]);
+      asMockedFn(props.useWorkspacesState).mockReturnValue({
         ...defaultUseWorkspacesProps,
         workspaces: [workspace],
       });
@@ -616,8 +611,8 @@ describe('Environments', () => {
       const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
       await user.click(buttons1[0]);
       if (!isAzure) {
-        expect(props.leoAppProvider.pause).toBeCalledTimes(1);
-        expect(props.leoAppProvider.pause).toBeCalledWith(expect.anything(), app.appName);
+        expect(props.leoAppData.pause).toBeCalledTimes(1);
+        expect(props.leoAppData.pause).toBeCalledWith(expect.anything(), app.appName);
       } else {
         expect(consoleSpy).toHaveBeenCalledWith('Pause is not currently implemented for azure apps');
       }
@@ -634,8 +629,8 @@ describe('Environments', () => {
       // Arrange
       const props = getEnvironmentsProps();
       const disk = generateTestDiskWithGoogleWorkspace();
-      asMockedFn(props.leoDiskProvider.list).mockResolvedValue([disk]);
-      asMockedFn(props.useWorkspacesProvider).mockReturnValue({
+      asMockedFn(props.leoDiskData.list).mockResolvedValue([disk]);
+      asMockedFn(props.useWorkspacesState).mockReturnValue({
         ...defaultUseWorkspacesProps,
         workspaces: [defaultGoogleWorkspace],
       });
@@ -671,8 +666,8 @@ describe('Environments', () => {
       const azureWorkspace2 = generateAzureWorkspace();
       const azureDisk2 = generateTestDiskWithAzureWorkspace({}, azureWorkspace2);
 
-      asMockedFn(props.leoDiskProvider.list).mockResolvedValue([googleDisk1, googleDisk2, azureDisk1, azureDisk2]);
-      asMockedFn(props.useWorkspacesProvider).mockReturnValue({
+      asMockedFn(props.leoDiskData.list).mockResolvedValue([googleDisk1, googleDisk2, azureDisk1, azureDisk2]);
+      asMockedFn(props.useWorkspacesState).mockReturnValue({
         ...defaultUseWorkspacesProps,
         workspaces: [defaultGoogleWorkspace, googleWorkspace2, defaultAzureWorkspace, azureWorkspace2],
       });
@@ -730,8 +725,8 @@ describe('Environments', () => {
     ])('Renders disk details view correctly', async ({ disk, workspace }) => {
       // Arrange
       const props = getEnvironmentsProps();
-      asMockedFn(props.leoDiskProvider.list).mockResolvedValue([disk]);
-      asMockedFn(props.useWorkspacesProvider).mockReturnValue({
+      asMockedFn(props.leoDiskData.list).mockResolvedValue([disk]);
+      asMockedFn(props.useWorkspacesState).mockReturnValue({
         ...defaultUseWorkspacesProps,
         workspaces: [workspace],
       });
@@ -764,8 +759,8 @@ describe('Environments', () => {
       // Arrange
       const user = userEvent.setup();
       const props = getEnvironmentsProps();
-      asMockedFn(props.leoDiskProvider.list).mockResolvedValue([disk]);
-      asMockedFn(props.useWorkspacesProvider).mockReturnValue({
+      asMockedFn(props.leoDiskData.list).mockResolvedValue([disk]);
+      asMockedFn(props.useWorkspacesState).mockReturnValue({
         ...defaultUseWorkspacesProps,
         workspaces: [workspace],
       });

--- a/src/analysis/Environments/Environments.test.ts
+++ b/src/analysis/Environments/Environments.test.ts
@@ -29,7 +29,6 @@ import { asMockedFn, renderWithAppContexts as render } from 'src/testing/test-ut
 import { defaultAzureWorkspace, defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
 
 type ModalMockExports = typeof import('src/components/Modal.mock');
-
 jest.mock('src/components/Modal', () => {
   const mockModal = jest.requireActual<ModalMockExports>('src/components/Modal.mock');
   return mockModal.mockModalModule();

--- a/src/analysis/Environments/Environments.ts
+++ b/src/analysis/Environments/Environments.ts
@@ -796,12 +796,9 @@ export const Environments = (props: EnvironmentsProps): ReactNode => {
                 headerRenderer: () =>
                   h(Sortable, { sort: diskSort, field: 'workspace', onSort: setDiskSort }, ['Workspace']),
                 cellRenderer: ({ rowIndex }) => {
-                  const {
-                    status: diskStatus,
-                    googleProject,
-                    workspace: { namespace, name },
-                    creator,
-                  } = filteredDisks[rowIndex];
+                  const { status: diskStatus, googleProject, workspace, creator } = filteredDisks[rowIndex];
+                  const namespace = workspace?.namespace;
+                  const name = workspace?.name;
                   const appType: AppToolLabel | undefined = getDiskAppType(filteredDisks[rowIndex]);
                   const multipleDisks = multipleDisksError(disksByProject[googleProject], appType);
                   return !!namespace && !!name

--- a/src/analysis/Environments/Environments.ts
+++ b/src/analysis/Environments/Environments.ts
@@ -1,6 +1,6 @@
 import { NavLinkProvider } from '@terra-ui-packages/core-utils';
 import _ from 'lodash/fp';
-import { Fragment, useEffect, useState } from 'react';
+import { Fragment, ReactNode, useEffect, useState } from 'react';
 import { div, h, h2, p, span, strong } from 'react-hyperscript-helpers';
 import { SaveFilesHelp, SaveFilesHelpAzure } from 'src/analysis/runtime-common-components';
 import { AppErrorModal, RuntimeErrorModal } from 'src/analysis/RuntimeManager';
@@ -68,7 +68,7 @@ interface DeleteRuntimeModalProps {
   deleteProvider: Pick<LeoRuntimeProvider, 'delete'>;
 }
 
-const DeleteRuntimeModal: React.FC<DeleteRuntimeModalProps> = (props) => {
+const DeleteRuntimeModal = (props: DeleteRuntimeModalProps): ReactNode => {
   const { runtime, workspaceId, deleteProvider, onDismiss, onSuccess } = props;
   const { cloudContext, runtimeConfig } = runtime;
   const [deleteDisk, setDeleteDisk] = useState(false);
@@ -117,7 +117,7 @@ interface DeleteDiskModalProps {
   deleteProvider: Pick<LeoDiskProvider, 'delete'>;
 }
 
-const DeleteDiskModal: React.FC<DeleteDiskModalProps> = (props) => {
+const DeleteDiskModal = (props: DeleteDiskModalProps): ReactNode => {
   const { disk, deleteProvider, onDismiss, onSuccess } = props;
   const { workspace } = disk;
   const [busy, setBusy] = useState(false);
@@ -184,7 +184,8 @@ interface PauseButtonProps {
   pauseComputeAndRefresh: any;
 }
 
-export function PauseButton({ cloudEnvironment, currentUser, pauseComputeAndRefresh }: PauseButtonProps) {
+export function PauseButton(props: PauseButtonProps): ReactNode {
+  const { cloudEnvironment, currentUser, pauseComputeAndRefresh } = props;
   const shouldShowPauseButton =
     isPauseSupported(getToolLabelFromCloudEnv(cloudEnvironment)) &&
     currentUser === getCreatorForCompute(cloudEnvironment);
@@ -229,7 +230,7 @@ export interface EnvironmentsProps {
   metrics: MetricsProvider;
 }
 
-export const Environments: React.FC<EnvironmentsProps> = (props) => {
+export const Environments = (props: EnvironmentsProps): ReactNode => {
   const { nav, useWorkspacesState, leoAppData, leoDiskData, leoRuntimeData, metrics } = props;
   const signal = useCancellation();
   const { workspaces, refresh: refreshWorkspaces } = _.flow(

--- a/src/analysis/Environments/Environments.ts
+++ b/src/analysis/Environments/Environments.ts
@@ -1,8 +1,8 @@
 import { NavLinkProvider } from '@terra-ui-packages/core-utils';
 import _ from 'lodash/fp';
-import { Dispatch, Fragment, SetStateAction, useEffect, useState } from 'react';
+import { Fragment, useEffect, useState } from 'react';
 import { div, h, h2, p, span, strong } from 'react-hyperscript-helpers';
-import { SaveFilesHelp, SaveFilesHelpAzure, SaveFilesHelpGalaxy } from 'src/analysis/runtime-common-components';
+import { SaveFilesHelp, SaveFilesHelpAzure } from 'src/analysis/runtime-common-components';
 import { AppErrorModal, RuntimeErrorModal } from 'src/analysis/RuntimeManager';
 import { getDiskAppType } from 'src/analysis/utils/app-utils';
 import {
@@ -12,12 +12,7 @@ import {
   getRuntimeCost,
 } from 'src/analysis/utils/cost-utils';
 import { workspaceHasMultipleDisks } from 'src/analysis/utils/disk-utils';
-import {
-  getCreatorForCompute,
-  getDisplayStatus,
-  isComputePausable,
-  isResourceDeletable,
-} from 'src/analysis/utils/resource-utils';
+import { getCreatorForCompute, getDisplayStatus, isComputePausable } from 'src/analysis/utils/resource-utils';
 import {
   defaultComputeZone,
   getDisplayRuntimeStatus,
@@ -33,41 +28,56 @@ import PopupTrigger, { makeMenuIcon } from 'src/components/PopupTrigger';
 import SupportRequestWrapper from 'src/components/SupportRequest';
 import { SimpleFlexTable, Sortable } from 'src/components/table';
 import TooltipTrigger from 'src/components/TooltipTrigger';
-import { useWorkspaces } from 'src/components/workspace-utils';
-import { useReplaceableAjaxExperimental } from 'src/libs/ajax';
+import { useModalHandler } from 'src/components/useModalHandler';
 import { App, isApp } from 'src/libs/ajax/leonardo/models/app-models';
 import { PersistentDisk } from 'src/libs/ajax/leonardo/models/disk-models';
-import { isGceConfig, isGceWithPdConfig } from 'src/libs/ajax/leonardo/models/runtime-config-models';
+import { isAzureConfig, isGceConfig, isGceWithPdConfig } from 'src/libs/ajax/leonardo/models/runtime-config-models';
 import { isRuntime, Runtime } from 'src/libs/ajax/leonardo/models/runtime-models';
+import { LeoAppProvider } from 'src/libs/ajax/leonardo/providers/LeoAppProvider';
+import { LeoDiskProvider } from 'src/libs/ajax/leonardo/providers/LeoDiskProvider';
+import { LeoRuntimeProvider } from 'src/libs/ajax/leonardo/providers/LeoRuntimeProvider';
+import { MetricsProvider } from 'src/libs/ajax/metrics/useMetrics';
 import colors from 'src/libs/colors';
-import { withErrorIgnoring, withErrorReporting, withErrorReportingInModal } from 'src/libs/error';
+import { withErrorIgnoring, withErrorReporting } from 'src/libs/error';
 import Events from 'src/libs/events';
 import { useCancellation, useGetter } from 'src/libs/react-utils';
 import { contactUsActive, getTerraUser } from 'src/libs/state';
 import * as Style from 'src/libs/style';
 import * as Utils from 'src/libs/utils';
-import { isGoogleWorkspaceInfo, WorkspaceInfo } from 'src/libs/workspace-utils';
+import { isGoogleWorkspaceInfo, WorkspaceWrapper } from 'src/libs/workspace-utils';
+
+import { DeleteAppModal } from './DeleteAppModal';
+import { DeleteButton } from './DeleteButton';
+import {
+  AppWithWorkspace,
+  DecoratedComputeResource,
+  DecoratedResource,
+  DiskWithWorkspace,
+  RuntimeWithWorkspace,
+} from './Environments.models';
 
 export type EnvironmentNavActions = {
   'workspace-view': { namespace: string; name: string };
 };
 
-const DeleteRuntimeModal = ({
-  runtime: { cloudContext, googleProject, runtimeName, runtimeConfig },
-  workspaceId,
-  onDismiss,
-  onSuccess,
-}) => {
+interface DeleteRuntimeModalProps {
+  runtime: Runtime;
+  workspaceId: string;
+  onDismiss: () => void;
+  onSuccess: () => void;
+  deleteProvider: Pick<LeoRuntimeProvider, 'delete'>;
+}
+
+const DeleteRuntimeModal: React.FC<DeleteRuntimeModalProps> = (props) => {
+  const { runtime, workspaceId, deleteProvider, onDismiss, onSuccess } = props;
+  const { cloudContext, runtimeConfig } = runtime;
   const [deleteDisk, setDeleteDisk] = useState(false);
   const [deleting, setDeleting] = useState(false);
-  const ajax = useReplaceableAjaxExperimental();
   const deleteRuntime = _.flow(
     Utils.withBusyState(setDeleting),
     withErrorReporting('Error deleting cloud environment')
   )(async () => {
-    isGcpContext(cloudContext)
-      ? await ajax().Runtimes.runtime(googleProject, runtimeName).delete(deleteDisk)
-      : await ajax().Runtimes.runtimeV2(workspaceId, runtimeName).delete(deleteDisk);
+    await deleteProvider.delete(runtime, workspaceId, deleteDisk);
     onSuccess();
   });
 
@@ -80,7 +90,8 @@ const DeleteRuntimeModal = ({
     },
     [
       div({ style: { lineHeight: 1.5 } }, [
-        runtimeConfig.persistentDiskId
+        // show checkbox if config has disk
+        isAzureConfig(runtimeConfig) || isGceWithPdConfig(runtimeConfig)
           ? h(LabeledCheckbox, { checked: deleteDisk, onChange: setDeleteDisk }, [
               span({ style: { fontWeight: 600 } }, [' Also delete the persistent disk and all files on it']),
             ])
@@ -99,20 +110,27 @@ const DeleteRuntimeModal = ({
   );
 };
 
-const DeleteDiskModal = ({ disk: { cloudContext, googleProject, name, id }, isGalaxyDisk, onDismiss, onSuccess }) => {
+interface DeleteDiskModalProps {
+  disk: DiskWithWorkspace;
+  onDismiss: () => void;
+  onSuccess: () => void;
+  deleteProvider: Pick<LeoDiskProvider, 'delete'>;
+}
+
+const DeleteDiskModal: React.FC<DeleteDiskModalProps> = (props) => {
+  const { disk, deleteProvider, onDismiss, onSuccess } = props;
+  const { workspace } = disk;
   const [busy, setBusy] = useState(false);
-  const ajax = useReplaceableAjaxExperimental();
 
   const deleteDisk = _.flow(
     Utils.withBusyState(setBusy),
     withErrorReporting('Error deleting persistent disk')
   )(async () => {
-    isGcpContext(cloudContext)
-      ? await ajax().Disks.disksV1().disk(googleProject, name).delete()
-      : await ajax().Disks.disksV2().delete(id);
-
+    await deleteProvider.delete(disk, workspace);
     onSuccess();
   });
+  const isGalaxyDisk = getDiskAppType(disk) === appTools.GALAXY.label;
+
   return h(
     Modal,
     {
@@ -124,57 +142,6 @@ const DeleteDiskModal = ({ disk: { cloudContext, googleProject, name, id }, isGa
       p(['Deleting the persistent disk will ', span({ style: { fontWeight: 600 } }, ['delete all files on it.'])]),
       isGalaxyDisk && h(SaveFilesHelp),
       busy && spinnerOverlay,
-    ]
-  );
-};
-
-interface DeleteAppModalProps {
-  app: App;
-  onDismiss: () => void;
-  onSuccess: () => void;
-}
-
-const DeleteAppModal = ({ app, onDismiss, onSuccess }: DeleteAppModalProps) => {
-  const [deleteDisk, setDeleteDisk] = useState(false);
-  const [deleting, setDeleting] = useState(false);
-  const {
-    appName,
-    appType,
-    cloudContext: { cloudProvider, cloudResource },
-  } = app;
-  const ajax = useReplaceableAjaxExperimental();
-  const deleteApp = _.flow(
-    Utils.withBusyState(setDeleting),
-    withErrorReportingInModal('Error deleting cloud environment', onDismiss)
-  )(async () => {
-    // TODO: this should use types in IA-3824
-    if (cloudProvider === 'GCP') {
-      await ajax().Apps.app(cloudResource, appName).delete(deleteDisk);
-      onSuccess();
-    } else {
-      throw new Error('Deleting apps is currently only supported on GCP');
-    }
-  });
-  return h(
-    Modal,
-    {
-      title: 'Delete cloud environment?',
-      onDismiss,
-      okButton: deleteApp,
-    },
-    [
-      div({ style: { lineHeight: 1.5 } }, [
-        app.diskName
-          ? h(LabeledCheckbox, { checked: deleteDisk, onChange: setDeleteDisk }, [
-              span({ style: { fontWeight: 600 } }, [' Also delete the persistent disk and all files on it']),
-            ])
-          : p([
-              'Deleting this cloud environment will also ',
-              span({ style: { fontWeight: 600 } }, ['delete any files on the associated hard disk.']),
-            ]),
-        appType === appTools.GALAXY.label && h(SaveFilesHelpGalaxy),
-      ]),
-      deleting && spinnerOverlay,
     ]
   );
 };
@@ -238,29 +205,33 @@ export function PauseButton({ cloudEnvironment, currentUser, pauseComputeAndRefr
     : null;
 }
 
-interface DecoratedResourceAttributes {
-  workspace: WorkspaceInfo;
-  unsupportedWorkspace: boolean;
+export interface UseWorkspacesResult {
+  workspaces: WorkspaceWrapper[];
+  refresh: () => Promise<void>;
+  loading: boolean;
 }
 
-type RuntimeWithWorkspace = DecoratedResourceAttributes & Runtime;
-type DiskWithWorkspace = DecoratedResourceAttributes & PersistentDisk;
-type AppWithWorkspace = DecoratedResourceAttributes & App;
-
-type DecoratedComputeResource = RuntimeWithWorkspace | AppWithWorkspace;
-type DecoratedResource = DecoratedComputeResource | DiskWithWorkspace;
+export type UseWorkspacesProvider = (
+  fields?: Record<string, string>,
+  stringAttributeMaxLength?: string | number
+) => UseWorkspacesResult;
 
 export interface EnvironmentsProps {
   nav: NavLinkProvider<EnvironmentNavActions>;
+  useWorkspacesProvider: UseWorkspacesProvider;
+  leoAppProvider: LeoAppProvider;
+  leoRuntimeProvider: LeoRuntimeProvider;
+  leoDiskProvider: LeoDiskProvider;
+  metricsProvider: MetricsProvider;
 }
 
 export const Environments: React.FC<EnvironmentsProps> = (props) => {
-  const { nav } = props;
+  const { nav, useWorkspacesProvider, leoAppProvider, leoDiskProvider, leoRuntimeProvider, metricsProvider } = props;
   const signal = useCancellation();
   const { workspaces, refresh: refreshWorkspaces } = _.flow(
-    useWorkspaces,
+    useWorkspacesProvider,
     _.update('workspaces', _.flow(_.groupBy('workspace.namespace'), _.mapValues(_.keyBy('workspace.name'))))
-  )();
+  )() as UseWorkspacesResult;
 
   const getWorkspaces = useGetter(workspaces);
   const [runtimes, setRuntimes] = useState<RuntimeWithWorkspace[]>();
@@ -269,20 +240,28 @@ export const Environments: React.FC<EnvironmentsProps> = (props) => {
   const [loading, setLoading] = useState(false);
   const [errorRuntimeId, setErrorRuntimeId] = useState();
   const getErrorRuntimeId = useGetter(errorRuntimeId);
-  const [deleteRuntimeId, setDeleteRuntimeId] = useState();
+  const [deleteRuntimeId, setDeleteRuntimeId] = useState<number>();
   const getDeleteRuntimeId = useGetter(deleteRuntimeId);
   const [deleteDiskId, setDeleteDiskId] = useState();
   const getDeleteDiskId = useGetter(deleteDiskId);
   const [errorAppId, setErrorAppId] = useState();
-  const [deleteAppId, setDeleteAppId] = useState();
+  const deleteAppModal = useModalHandler<AppWithWorkspace>((app, close) =>
+    h(DeleteAppModal, {
+      app,
+      onDismiss: close,
+      onSuccess: () => {
+        close();
+        loadData();
+      },
+      deleteProvider: leoAppProvider,
+    })
+  );
   const [sort, setSort] = useState({ field: 'project', direction: 'asc' });
   const [diskSort, setDiskSort] = useState({ field: 'project', direction: 'asc' });
 
   // TODO [IA-4432] restore the stateful var when checkbox reintroduced
   // const [shouldFilterByCreator, setShouldFilterByCreator] = useState(true);
   const shouldFilterByCreator = true;
-
-  const ajax = useReplaceableAjaxExperimental();
 
   const currentUser: string = getTerraUser().email!;
 
@@ -297,17 +276,20 @@ export const Environments: React.FC<EnvironmentsProps> = (props) => {
     const listArgs: Record<string, string> = shouldFilterByCreator
       ? { role: 'creator', includeLabels: 'saturnWorkspaceNamespace,saturnWorkspaceName' }
       : { includeLabels: 'saturnWorkspaceNamespace,saturnWorkspaceName' };
+    const diskArgs: Record<string, string> = {
+      ...listArgs,
+      includeLabels: 'saturnApplication,saturnWorkspaceNamespace,saturnWorkspaceName',
+    };
+
     const [newRuntimes, newDisks, newApps] = await Promise.all([
-      ajax(signal).Runtimes.listV2(listArgs),
-      ajax(signal)
-        .Disks.disksV1()
-        .list({ ...listArgs, includeLabels: 'saturnApplication,saturnWorkspaceNamespace,saturnWorkspaceName' }),
-      ajax(signal).Apps.listWithoutProject(listArgs),
+      leoRuntimeProvider.list(listArgs, signal),
+      leoDiskProvider.list(diskArgs, signal),
+      leoAppProvider.listWithoutProject(listArgs, signal),
     ]);
     const endTimeForLeoCallsEpochMs = Date.now();
 
     const leoCallTimeTotalMs = endTimeForLeoCallsEpochMs - startTimeForLeoCallsEpochMs;
-    ajax(signal).Metrics.captureEvent(Events.cloudEnvironmentDetailsLoad, {
+    metricsProvider.captureEvent(Events.cloudEnvironmentDetailsLoad, {
       leoCallTimeMs: leoCallTimeTotalMs,
       totalCallTimeMs: leoCallTimeTotalMs,
       runtimes: newRuntimes.length,
@@ -350,43 +332,30 @@ export const Environments: React.FC<EnvironmentsProps> = (props) => {
     if (!_.some({ appName: errorAppId }, newApps)) {
       setErrorAppId(undefined);
     }
-    if (!_.some({ appName: deleteAppId }, newApps)) {
-      setDeleteAppId(undefined);
+    if (deleteAppModal.isOpen && !_.some({ appName: deleteAppModal.args?.appName }, newApps)) {
+      deleteAppModal.close();
     }
   });
   const loadData = withErrorIgnoring(refreshData);
 
   const pauseComputeAndRefresh = Utils.withBusyState(setLoading, async (compute: DecoratedComputeResource) => {
-    const wrappedPauseCompute = withErrorReporting('Error pausing compute', () =>
-      Utils.cond(
-        [
-          isRuntime(compute) && isGoogleWorkspaceInfo(compute.workspace),
-          () =>
-            ajax()
-              .Runtimes.runtimeWrapper(compute as RuntimeWithWorkspace)
-              .stop(),
-        ],
-        [
-          isRuntime(compute),
-          () =>
-            ajax()
-              .Runtimes.runtimeWrapper(compute as RuntimeWithWorkspace)
-              .stop(),
-        ],
-        [
-          isApp(compute) && isGoogleWorkspaceInfo(compute.workspace),
-          // @ts-expect-error
-          () => ajax().Apps.app(compute.workspace.googleProject, compute.appName).pause(),
-        ],
-        [
-          Utils.DEFAULT,
-          () => {
-            console.error('Pause is not currently implemented for azure apps');
-            return Promise.resolve();
-          },
-        ]
-      )
-    );
+    const wrappedPauseCompute = withErrorReporting('Error pausing compute', async () => {
+      if (isRuntime(compute) && isGoogleWorkspaceInfo(compute.workspace)) {
+        return leoRuntimeProvider.stop(compute);
+      }
+      if (isRuntime(compute)) {
+        return leoRuntimeProvider.stop(compute);
+      }
+      if (isApp(compute)) {
+        const computeWorkspace = compute.workspace;
+        if (isGoogleWorkspaceInfo(computeWorkspace)) {
+          return leoAppProvider.pause(computeWorkspace.googleProject, compute.appName);
+        }
+      }
+      // default:
+      console.error('Pause is not currently implemented for azure apps');
+      return Promise.resolve();
+    });
     await wrappedPauseCompute();
     await loadData();
   });
@@ -593,30 +562,6 @@ export const Environments: React.FC<EnvironmentsProps> = (props) => {
     return getDetailsPopup(runtimeName, cloudContext?.cloudResource, disk, creator, workspace?.workspaceId);
   };
 
-  const renderDeleteButton = (resourceType: 'app' | 'runtime', resource) => {
-    const isDeletable = isResourceDeletable(resourceType, resource);
-    const resourceId = resourceType === 'app' ? resource.appName : resource.id;
-    const actions: Record<typeof resourceType, Dispatch<SetStateAction<any>>> = {
-      app: setDeleteAppId,
-      runtime: setDeleteRuntimeId,
-    };
-    const action: Dispatch<SetStateAction<any>> = actions[resourceType];
-
-    return h(
-      Link,
-      {
-        disabled: !isDeletable,
-        tooltip: isDeletable
-          ? 'Delete cloud environment'
-          : `Cannot delete a cloud environment while in status ${_.upperCase(
-              getDisplayRuntimeStatus(resource.status)
-            )}.`,
-        onClick: () => action(resourceId),
-      },
-      [makeMenuIcon('trash'), 'Delete']
-    );
-  };
-
   const renderErrorApps = (app) => {
     const convertedAppStatus = getDisplayRuntimeStatus(app.status);
     if (convertedAppStatus !== 'Error' && app.unsupportedWorkspace) {
@@ -661,7 +606,7 @@ export const Environments: React.FC<EnvironmentsProps> = (props) => {
   const renderDeleteDiskModal = (disk) => {
     return h(DeleteDiskModal, {
       disk,
-      isGalaxyDisk: getDiskAppType(disk) === appTools.GALAXY.label,
+      deleteProvider: leoDiskProvider,
       onDismiss: () => setDeleteDiskId(undefined),
       onSuccess: () => {
         setDeleteDiskId(undefined);
@@ -679,7 +624,6 @@ export const Environments: React.FC<EnvironmentsProps> = (props) => {
   };
 
   const runtimeToDelete: RuntimeWithWorkspace | undefined = _.find({ id: deleteRuntimeId }, runtimes);
-  const appToDelete: AppWithWorkspace | undefined = _.find({ appName: deleteAppId }, apps);
 
   return h(Fragment, [
     div({ role: 'main', style: { padding: '1rem', flexGrow: 1 } }, [
@@ -805,10 +749,14 @@ export const Environments: React.FC<EnvironmentsProps> = (props) => {
                 headerRenderer: () => 'Actions',
                 cellRenderer: ({ rowIndex }) => {
                   const cloudEnvironment = filteredCloudEnvironments[rowIndex];
-                  const computeType = isApp(cloudEnvironment) ? 'app' : 'runtime';
                   return h(Fragment, [
                     h(PauseButton, { cloudEnvironment, currentUser, pauseComputeAndRefresh }),
-                    renderDeleteButton(computeType, cloudEnvironment),
+                    h(DeleteButton, {
+                      resource: cloudEnvironment,
+                      onClick: (resource) => {
+                        isApp(resource) ? deleteAppModal.open(resource) : setDeleteRuntimeId((resource as Runtime).id);
+                      },
+                    }),
                   ]);
                 },
               },
@@ -1008,6 +956,7 @@ export const Environments: React.FC<EnvironmentsProps> = (props) => {
         h(DeleteRuntimeModal, {
           runtime: runtimeToDelete,
           workspaceId: runtimeToDelete.workspace.workspaceId,
+          deleteProvider: leoRuntimeProvider,
           onDismiss: () => setDeleteRuntimeId(undefined),
           onSuccess: () => {
             setDeleteRuntimeId(undefined);
@@ -1015,16 +964,7 @@ export const Environments: React.FC<EnvironmentsProps> = (props) => {
           },
         }),
       deleteDiskId && renderDeleteDiskModal(_.find({ id: deleteDiskId }, disks)),
-      deleteAppId &&
-        appToDelete &&
-        h(DeleteAppModal, {
-          app: appToDelete,
-          onDismiss: () => setDeleteAppId(undefined),
-          onSuccess: () => {
-            setDeleteAppId(undefined);
-            loadData();
-          },
-        }),
+      deleteAppModal.maybeRender(),
       errorAppId &&
         h(AppErrorModal, {
           app: _.find({ appName: errorAppId }, apps),
@@ -1035,7 +975,3 @@ export const Environments: React.FC<EnvironmentsProps> = (props) => {
     loading && spinnerOverlay,
   ]);
 };
-
-// Temporary export here for ease of access to it when using the above component from outside of
-// this repository.
-export { ajaxContext } from 'src/libs/ajax';

--- a/src/analysis/Environments/Environments.ts
+++ b/src/analysis/Environments/Environments.ts
@@ -76,7 +76,7 @@ const DeleteRuntimeModal = (props: DeleteRuntimeModalProps): ReactNode => {
     Utils.withBusyState(setDeleting),
     withErrorReporting('Error deleting cloud environment')
   )(async () => {
-    await deleteProvider.delete(runtime, deleteDisk);
+    await deleteProvider.delete(runtime, { deleteDisk });
     onSuccess();
   });
 
@@ -118,14 +118,13 @@ interface DeleteDiskModalProps {
 
 const DeleteDiskModal = (props: DeleteDiskModalProps): ReactNode => {
   const { disk, deleteProvider, onDismiss, onSuccess } = props;
-  const { workspace } = disk;
   const [busy, setBusy] = useState(false);
 
   const deleteDisk = _.flow(
     Utils.withBusyState(setBusy),
     withErrorReporting('Error deleting persistent disk')
   )(async () => {
-    await deleteProvider.delete(disk, workspace);
+    await deleteProvider.delete(disk);
     onSuccess();
   });
   const isGalaxyDisk = getDiskAppType(disk) === appTools.GALAXY.label;
@@ -287,9 +286,9 @@ export const Environments = (props: EnvironmentsProps): ReactNode => {
     };
 
     const [newRuntimes, newDisks, newApps] = await Promise.all([
-      leoRuntimeData.list(listArgs, signal),
-      leoDiskData.list(diskArgs, signal),
-      leoAppData.listWithoutProject(listArgs, signal),
+      leoRuntimeData.list(listArgs, { signal }),
+      leoDiskData.list(diskArgs, { signal }),
+      leoAppData.listWithoutProject(listArgs, { signal }),
     ]);
     const endTimeForLeoCallsEpochMs = Date.now();
 
@@ -354,7 +353,7 @@ export const Environments = (props: EnvironmentsProps): ReactNode => {
       if (isApp(compute)) {
         const computeWorkspace = compute.workspace;
         if (isGoogleWorkspaceInfo(computeWorkspace)) {
-          return leoAppData.pause(computeWorkspace.googleProject, compute.appName);
+          return leoAppData.pause(compute);
         }
       }
       // default:

--- a/src/analysis/Environments/Environments.ts
+++ b/src/analysis/Environments/Environments.ts
@@ -955,7 +955,6 @@ export const Environments = (props: EnvironmentsProps): ReactNode => {
         runtimeToDelete &&
         h(DeleteRuntimeModal, {
           runtime: runtimeToDelete,
-          workspaceId: runtimeToDelete.workspace.workspaceId,
           deleteProvider: leoRuntimeData,
           onDismiss: () => setDeleteRuntimeId(undefined),
           onSuccess: () => {

--- a/src/analysis/_testData/testData.ts
+++ b/src/analysis/_testData/testData.ts
@@ -8,7 +8,12 @@ import { defaultGceMachineType, defaultLocation, generateRuntimeName } from 'src
 import { runtimeToolLabels, tools } from 'src/analysis/utils/tool-utils';
 import { App, ListAppResponse } from 'src/libs/ajax/leonardo/models/app-models';
 import { PersistentDisk } from 'src/libs/ajax/leonardo/models/disk-models';
-import { cloudServiceTypes, RuntimeConfig } from 'src/libs/ajax/leonardo/models/runtime-config-models';
+import {
+  AzureConfig,
+  cloudServiceTypes,
+  GceWithPdConfig,
+  RuntimeConfig,
+} from 'src/libs/ajax/leonardo/models/runtime-config-models';
 import { GetRuntimeItem, ListRuntimeItem, runtimeStatuses } from 'src/libs/ajax/leonardo/models/runtime-models';
 import { defaultAzureRegion } from 'src/libs/azure-utils';
 import * as Utils from 'src/libs/utils';
@@ -222,15 +227,16 @@ export const defaultAuditInfo = {
 
 export const generateGoogleProject = () => `terra-test-${uuid().substring(0, 8)}`;
 
-export const getRuntimeConfig = (overrides: Partial<RuntimeConfig> = {}): RuntimeConfig => ({
-  machineType: defaultGceMachineType,
-  persistentDiskId: getRandomInt(randomMaxInt),
-  cloudService: cloudServiceTypes.GCE,
-  bootDiskSize: defaultGceBootDiskSize,
-  zone: 'us-central1-a',
-  gpuConfig: undefined,
-  ...overrides,
-});
+export const getRuntimeConfig = (overrides: Partial<RuntimeConfig> = {}): RuntimeConfig =>
+  ({
+    machineType: defaultGceMachineType,
+    persistentDiskId: getRandomInt(randomMaxInt),
+    cloudService: cloudServiceTypes.GCE,
+    bootDiskSize: defaultGceBootDiskSize,
+    zone: 'us-central1-a',
+    gpuConfig: undefined,
+    ...overrides,
+  } satisfies GceWithPdConfig);
 
 // Use this if you only need to override top-level fields, otherwise use `getGoogleRuntime`
 export const generateTestGetGoogleRuntime = (overrides: Partial<GetRuntimeItem> = {}): GetRuntimeItem => {
@@ -824,7 +830,7 @@ export const azureRuntime: ListRuntimeItem = {
     machineType: 'Standard_DS2_v2',
     persistentDiskId: 16902,
     region: 'eastus',
-  },
+  } satisfies AzureConfig,
   proxyUrl:
     'https://lzf07312d05014dcfc2a6d8244c0f9b166a3801f44ec2b003d.servicebus.windows.net/saturn-42a4398b-10f8-4626-9025-7abda26aedab',
   status: 'Running',

--- a/src/components/useModalHandler.test.ts
+++ b/src/components/useModalHandler.test.ts
@@ -1,0 +1,164 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ReactNode } from 'react';
+import { div, h, span } from 'react-hyperscript-helpers';
+import { ButtonPrimary } from 'src/components/common';
+import Modal from 'src/components/Modal';
+import { useModalHandler } from 'src/components/useModalHandler';
+
+type ModalMockExports = typeof import('src/components/Modal.mock');
+jest.mock('src/components/Modal', () => {
+  const mockModal = jest.requireActual<ModalMockExports>('src/components/Modal.mock');
+  return mockModal.mockModalModule();
+});
+
+describe('useModalHandler helper hook', () => {
+  interface TestComponentProps {
+    onCloseThing: (args: string) => void;
+    onSuccess: (args: string) => void;
+  }
+  const TestComponent = (props: TestComponentProps): ReactNode => {
+    const { onSuccess, onCloseThing } = props;
+    /* in most cases, usage will leverage a custom variant of Modal that
+       streamlines the hook usage a bit, but we are using raw Modal since
+       it is sufficient for testing */
+    const myModal = useModalHandler((args: string, close: () => void) =>
+      h(
+        Modal,
+        {
+          title: `Modal for ${args}.`,
+          onDismiss: () => {
+            close();
+            onCloseThing(args);
+          },
+          okButton: () => {
+            close();
+            onSuccess(args);
+          },
+        },
+        [span([`content for ${args}`])]
+      )
+    );
+    return div([
+      h(
+        ButtonPrimary,
+        {
+          onClick: () => myModal.open('ThingOne'),
+        },
+        ['Open One']
+      ),
+      h(
+        ButtonPrimary,
+        {
+          onClick: () => myModal.open('ThingTwo'),
+        },
+        ['Open Two']
+      ),
+      myModal.maybeRender(),
+    ]);
+  };
+
+  it('renders no modal initially', () => {
+    // Arrange
+
+    // Act
+    render(
+      h(TestComponent, {
+        onCloseThing: () => {},
+        onSuccess: () => {},
+      })
+    );
+
+    // Assert
+    expect(screen.queryAllByText('Modal for ThingOne.').length).toBe(0);
+    expect(screen.queryAllByText('Modal for ThingTwo.').length).toBe(0);
+  });
+
+  it('opens modal with correct args flow', () => {
+    // Arrange
+    render(
+      h(TestComponent, {
+        onCloseThing: () => {},
+        onSuccess: () => {},
+      })
+    );
+
+    // Act
+    const button = screen.getByText('Open One');
+    fireEvent.click(button);
+
+    // Assert
+    expect(screen.queryAllByText('Modal for ThingOne.').length).toBe(1);
+    expect(screen.queryAllByText('Modal for ThingTwo.').length).toBe(0);
+  });
+
+  it('opens modal with correct args flow - 2nd item', () => {
+    // Arrange
+    render(
+      h(TestComponent, {
+        onCloseThing: () => {},
+        onSuccess: () => {},
+      })
+    );
+
+    // Act
+    const button = screen.getByText('Open Two');
+    fireEvent.click(button);
+
+    // Assert
+    expect(screen.queryAllByText('Modal for ThingOne.').length).toBe(0);
+    expect(screen.queryAllByText('Modal for ThingTwo.').length).toBe(1);
+  });
+
+  it('closes modal - OK button', async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const onSuccessWatcher = jest.fn();
+
+    render(
+      h(TestComponent, {
+        onCloseThing: () => {},
+        onSuccess: onSuccessWatcher,
+      })
+    );
+
+    const button = screen.getByText('Open One');
+    fireEvent.click(button);
+
+    // Act
+    const okButton = screen.getByText('OK');
+    await user.click(okButton);
+
+    // Assert
+    expect(onSuccessWatcher).toBeCalledTimes(1);
+    expect(onSuccessWatcher).toBeCalledWith('ThingOne');
+    expect(screen.queryAllByText('Modal for ThingOne.').length).toBe(0);
+    expect(screen.queryAllByText('Modal for ThingTwo.').length).toBe(0);
+  });
+
+  it('handles modal cancel', async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const onCloseWatcher = jest.fn();
+
+    render(
+      h(TestComponent, {
+        onCloseThing: onCloseWatcher,
+        onSuccess: () => {},
+      })
+    );
+
+    const button = screen.getByText('Open One');
+    fireEvent.click(button);
+
+    // Act
+    const cancelButton = screen.getByText('Cancel');
+    await user.click(cancelButton);
+
+    // Assert
+    expect(onCloseWatcher).toBeCalledTimes(1);
+    expect(onCloseWatcher).toBeCalledWith('ThingOne');
+    expect(screen.queryAllByText('Modal for ThingOne.').length).toBe(0);
+    expect(screen.queryAllByText('Modal for ThingTwo.').length).toBe(0);
+  });
+});

--- a/src/components/useModalHandler.ts
+++ b/src/components/useModalHandler.ts
@@ -1,0 +1,61 @@
+import { ReactNode, useState } from 'react';
+
+export interface ModalHandler<OpenArgs> {
+  /**
+   * consumer can call this method to open the modal with a given args value.
+   * @param args
+   */
+  open: (args: OpenArgs) => void;
+
+  /**
+   * closes the modal, and resets current modal args to undefined
+   */
+  close: () => void;
+
+  /**
+   * can be referenced by consuming component to know if modal is currently open
+   */
+  isOpen: Readonly<boolean>;
+
+  /**
+   * holds the current modal args for reference by the consuming component
+   */
+  args: Readonly<OpenArgs> | undefined;
+
+  /**
+   * A render function that consuming component should call in their render
+   * block so that the modal is rendered if and when open(arg) is called.
+   */
+  maybeRender: () => ReactNode;
+}
+
+export type ModalFactoryFn<OpenArgs> = (args: OpenArgs, close: () => void) => ReactNode;
+
+/**
+ * A hook that returns a modal handler object.  Open/close state is handled
+ * internally, and the modal is associated with a current args value when opened.
+ * @param modalFactory
+ */
+export const useModalHandler = <OpenArgs>(modalFactory: ModalFactoryFn<OpenArgs>): ModalHandler<OpenArgs> => {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const [openArgs, setOpenArgs] = useState<OpenArgs>();
+
+  const handler: ModalHandler<OpenArgs> = {
+    open: (args: OpenArgs) => {
+      setOpenArgs(args);
+      setIsOpen(true);
+    },
+    close: () => {
+      setOpenArgs(undefined);
+      setIsOpen(false);
+    },
+    isOpen,
+    args: openArgs,
+    maybeRender: () => {
+      // openArgs will be given value as part of open() call above,
+      // so it's safe to assume OpenArgs typing when isOpen is true
+      return isOpen && modalFactory(openArgs as OpenArgs, handler.close);
+    },
+  };
+  return handler;
+};

--- a/src/components/useModalHandler.ts
+++ b/src/components/useModalHandler.ts
@@ -54,7 +54,7 @@ export const useModalHandler = <OpenArgs>(modalFactory: ModalFactoryFn<OpenArgs>
     maybeRender: () => {
       // openArgs will be given value as part of open() call above,
       // so it's safe to assume OpenArgs typing when isOpen is true
-      return isOpen && modalFactory(openArgs as OpenArgs, handler.close);
+      return isOpen && modalFactory(openArgs!, handler.close);
     },
   };
   return handler;

--- a/src/components/workspace-utils.js
+++ b/src/components/workspace-utils.js
@@ -5,7 +5,7 @@ import { div, h } from 'react-hyperscript-helpers';
 import { CloudProviderIcon } from 'src/components/CloudProviderIcon';
 import { AsyncCreatableSelect, Clickable, Link, VirtualizedSelect } from 'src/components/common';
 import { WorkspaceSubmissionStatusIcon } from 'src/components/WorkspaceSubmissionStatusIcon';
-import { Ajax, useReplaceableAjaxExperimental } from 'src/libs/ajax';
+import { Ajax } from 'src/libs/ajax';
 import colors from 'src/libs/colors';
 import { withErrorReporting } from 'src/libs/error';
 import Events, { extractWorkspaceDetails } from 'src/libs/events';
@@ -21,7 +21,6 @@ export const useWorkspaces = (fieldsArg, stringAttributeMaxLength) => {
   const signal = useCancellation();
   const [loading, setLoading] = useState(false);
   const workspaces = useStore(workspacesStore);
-  const ajax = useReplaceableAjaxExperimental();
 
   const fields = fieldsArg || [
     'accessLevel',
@@ -37,7 +36,7 @@ export const useWorkspaces = (fieldsArg, stringAttributeMaxLength) => {
     withErrorReporting('Error loading workspace list'),
     Utils.withBusyState(setLoading)
   )(async () => {
-    const ws = await ajax(signal).Workspaces.list(fields, stringAttributeMaxLength);
+    const ws = await Ajax(signal).Workspaces.list(fields, stringAttributeMaxLength);
     workspacesStore.set(ws);
   });
   useOnMount(() => {

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1,6 +1,5 @@
 import _ from 'lodash/fp';
 import * as qs from 'qs';
-import { createContext, useContext } from 'react';
 import {
   appIdentifier,
   authOpts,
@@ -757,11 +756,3 @@ export const Ajax = (signal) => {
 
 // Exposing Ajax for use by integration tests (and debugging, or whatever)
 window.Ajax = Ajax;
-
-// Experimental: Pulling Ajax from context allows replacing for usage outside of Terra UI.
-// https://github.com/DataBiosphere/terra-ui/pull/3669
-export const ajaxContext = createContext(Ajax);
-
-// Experimental: Pulling Ajax from context allows replacing for usage outside of Terra UI.
-// https://github.com/DataBiosphere/terra-ui/pull/3669
-export const useReplaceableAjaxExperimental = () => useContext(ajaxContext);

--- a/src/libs/ajax/data-provider-common.ts
+++ b/src/libs/ajax/data-provider-common.ts
@@ -1,0 +1,3 @@
+export interface AbortOption {
+  signal?: AbortSignal;
+}

--- a/src/libs/ajax/leonardo/Apps.ts
+++ b/src/libs/ajax/leonardo/Apps.ts
@@ -6,7 +6,7 @@ import { appIdentifier, authOpts, fetchLeo, jsonBody } from 'src/libs/ajax/ajax-
 import { CreateAppV1Request, GetAppResponse, ListAppResponse } from 'src/libs/ajax/leonardo/models/app-models';
 import { LeoResourceLabels } from 'src/libs/ajax/leonardo/models/core-models';
 
-export const Apps = (signal) => ({
+export const Apps = (signal: AbortSignal) => ({
   list: async (project: string, labels: LeoResourceLabels = {}): Promise<ListAppResponse[]> => {
     const res = await fetchLeo(
       `api/google/v1/apps/${project}?${qs.stringify({ saturnAutoCreated: true, ...labels })}`,
@@ -120,3 +120,6 @@ export const Apps = (signal) => ({
     return res;
   },
 });
+
+export type AppsAjaxContract = ReturnType<typeof Apps>;
+export type AppAjaxContract = ReturnType<AppsAjaxContract['app']>;

--- a/src/libs/ajax/leonardo/Apps.ts
+++ b/src/libs/ajax/leonardo/Apps.ts
@@ -21,7 +21,7 @@ export const Apps = (signal) => ({
     );
     return res.json();
   },
-  app: (project, name) => {
+  app: (project: string, name: string) => {
     const root = `api/google/v1/apps/${project}/${name}`;
     return {
       delete: (deleteDisk = false): Promise<void> => {

--- a/src/libs/ajax/leonardo/Disks.test.ts
+++ b/src/libs/ajax/leonardo/Disks.test.ts
@@ -24,7 +24,7 @@ const expectedJson = [azureDisk, galaxyDisk];
 const rawJson = [undecoratePd(azureDisk), undecoratePd(galaxyDisk)];
 
 describe('Disks ajax', () => {
-  const signal = jest.fn();
+  const signal = new window.AbortController().signal;
   beforeEach(() => {
     asMockedFn(authOpts).mockImplementation(jest.fn());
   });

--- a/src/libs/ajax/leonardo/Disks.ts
+++ b/src/libs/ajax/leonardo/Disks.ts
@@ -4,7 +4,7 @@ import { mapToPdTypes, updatePdType } from 'src/analysis/utils/disk-utils';
 import { appIdentifier, authOpts, fetchLeo, jsonBody } from 'src/libs/ajax/ajax-common';
 import { GetDiskItem, ListDiskItem, PersistentDisk } from 'src/libs/ajax/leonardo/models/disk-models';
 
-export const Disks = (signal) => {
+export const Disks = (signal: AbortSignal) => {
   const diskV2Root = 'api/v2/disks';
   const v2Func = () => ({
     delete: (diskId: number): Promise<void> => {
@@ -55,3 +55,8 @@ export const Disks = (signal) => {
     disksV2: v2Func,
   };
 };
+
+export type DisksAjaxContract = ReturnType<typeof Disks>;
+export type DisksAjaxContractV1 = ReturnType<DisksAjaxContract['disksV1']>;
+export type DisksAjaxContractV2 = ReturnType<DisksAjaxContract['disksV2']>;
+export type DiskAjaxContract = ReturnType<DisksAjaxContractV1['disk']>;

--- a/src/libs/ajax/leonardo/Runtimes.test.ts
+++ b/src/libs/ajax/leonardo/Runtimes.test.ts
@@ -10,7 +10,7 @@ jest.mock('src/libs/ajax/ajax-common', () => ({
 
 describe('Runtimes ajax', () => {
   const mockFetchLeo = jest.fn();
-  const signal = jest.fn();
+  const signal = new window.AbortController().signal;
   beforeEach(() => {
     asMockedFn(fetchLeo).mockImplementation(mockFetchLeo);
     asMockedFn(authOpts).mockImplementation(jest.fn());

--- a/src/libs/ajax/leonardo/Runtimes.ts
+++ b/src/libs/ajax/leonardo/Runtimes.ts
@@ -24,6 +24,8 @@ export interface AzureRuntimeWrapper {
   runtimeName: string;
 }
 
+export type RuntimeWrapper = GoogleRuntimeWrapper | AzureRuntimeWrapper;
+
 const isAzureRuntimeWrapper = (obj: any): obj is AzureRuntimeWrapper => {
   const castObj = obj as AzureRuntimeWrapper;
   return castObj && !!castObj.workspaceId && !!castObj.runtimeName;
@@ -214,7 +216,7 @@ export const Runtimes = (signal) => {
     runtimeV2: v2Func,
 
     // TODO: Consider refactoring to not use this wrapper
-    runtimeWrapper: (props: GoogleRuntimeWrapper | AzureRuntimeWrapper) => {
+    runtimeWrapper: (props: RuntimeWrapper) => {
       return {
         stop: () => {
           const stopFunc = isAzureRuntimeWrapper(props)

--- a/src/libs/ajax/leonardo/Runtimes.ts
+++ b/src/libs/ajax/leonardo/Runtimes.ts
@@ -31,7 +31,7 @@ const isAzureRuntimeWrapper = (obj: any): obj is AzureRuntimeWrapper => {
   return castObj && !!castObj.workspaceId && !!castObj.runtimeName;
 };
 
-export const Runtimes = (signal) => {
+export const Runtimes = (signal: AbortSignal) => {
   const v1Func = (project: string, name: string) => {
     const root = `api/google/v1/runtimes/${project}/${name}`;
 
@@ -287,3 +287,8 @@ export const Runtimes = (signal) => {
     },
   };
 };
+
+export type RuntimesAjaxContract = ReturnType<typeof Runtimes>;
+export type RuntimeAjaxContractV1 = ReturnType<RuntimesAjaxContract['runtime']>;
+export type RuntimeAjaxContractV2 = ReturnType<RuntimesAjaxContract['runtimeV2']>;
+export type RuntimeWrapperAjaxContract = ReturnType<RuntimesAjaxContract['runtimeWrapper']>;

--- a/src/libs/ajax/leonardo/providers/LeoAppProvider.test.ts
+++ b/src/libs/ajax/leonardo/providers/LeoAppProvider.test.ts
@@ -1,0 +1,97 @@
+import { Ajax } from 'src/libs/ajax';
+import { AppAjaxContract, AppsAjaxContract } from 'src/libs/ajax/leonardo/Apps';
+import { asMockedFn } from 'src/testing/test-utils';
+
+import { leoAppProvider } from './LeoAppProvider';
+
+jest.mock('src/libs/ajax');
+
+type AjaxContract = ReturnType<typeof Ajax>;
+type AppNeeds = Pick<AppAjaxContract, 'delete' | 'pause'>;
+type AppsNeeds = Pick<AppsAjaxContract, 'app' | 'listWithoutProject'>;
+
+interface AjaxMockNeeds {
+  Apps: AppsNeeds;
+  app: AppNeeds;
+}
+/**
+ * local test utility - mocks the Ajax super-object and the subset of needed multi-contracts it
+ * returns with as much type-saftely as possible.
+ *
+ * @return collection of key contract sub-objects for easy
+ * mock overrides and/or method spying/assertions
+ */
+const mockAjaxNeeds = (): AjaxMockNeeds => {
+  const partialApp: AppNeeds = {
+    delete: jest.fn(),
+    pause: jest.fn(),
+  };
+  const mockApp = partialApp as AppAjaxContract;
+
+  const partialApps: AppsNeeds = {
+    app: jest.fn(),
+    listWithoutProject: jest.fn(),
+  };
+  const mockApps = partialApps as AppsAjaxContract;
+
+  asMockedFn(mockApps.app).mockReturnValue(mockApp);
+  asMockedFn(Ajax).mockReturnValue({ Apps: mockApps } as AjaxContract);
+
+  return {
+    Apps: partialApps,
+    app: partialApp,
+  };
+};
+describe('leoAppProvider', () => {
+  it('handles list call', async () => {
+    // Arrange
+    const ajaxMock = mockAjaxNeeds();
+    asMockedFn(ajaxMock.Apps.listWithoutProject).mockResolvedValue([]);
+    const abort = new window.AbortController();
+
+    // Act
+    const result = await leoAppProvider.listWithoutProject({ arg: '1' }, abort.signal);
+
+    // Assert;
+    expect(Ajax).toBeCalledTimes(1);
+    expect(Ajax).toBeCalledWith(abort.signal);
+    expect(ajaxMock.Apps.listWithoutProject).toBeCalledTimes(1);
+    expect(ajaxMock.Apps.listWithoutProject).toBeCalledWith({ arg: '1' });
+    expect(result).toEqual([]);
+  });
+
+  it('handles pause app call', async () => {
+    // Arrange
+    const ajaxMock = mockAjaxNeeds();
+    const abort = new window.AbortController();
+
+    // Act
+    // calls to this method generally don't care about passing in signal, but doing it here for completeness
+    void (await leoAppProvider.pause('myResourceName', 'myAppName', abort.signal));
+
+    // Assert;
+    expect(Ajax).toBeCalledTimes(1);
+    expect(Ajax).toBeCalledWith(abort.signal);
+    expect(ajaxMock.Apps.app).toBeCalledTimes(1);
+    expect(ajaxMock.Apps.app).toBeCalledWith('myResourceName', 'myAppName');
+    expect(ajaxMock.app.pause).toBeCalledTimes(1);
+  });
+
+  it('handles delete app call', async () => {
+    // Arrange
+    const ajaxMock = mockAjaxNeeds();
+    const abort = new window.AbortController();
+
+    // Act
+    // calls to this method generally don't care about passing in signal, but doing it here for completeness
+    void (await leoAppProvider.delete('myResourceName', 'myAppName', false, abort.signal));
+
+    // Assert;
+    expect(Ajax).toBeCalledTimes(1);
+    expect(Ajax).toBeCalledWith(abort.signal);
+    expect(ajaxMock.Apps.app).toBeCalledTimes(1);
+    expect(ajaxMock.Apps.app).toBeCalledWith('myResourceName', 'myAppName');
+    expect(ajaxMock.app.delete).toBeCalledTimes(1);
+    expect(ajaxMock.app.delete).toBeCalledWith(false);
+  });
+});

--- a/src/libs/ajax/leonardo/providers/LeoAppProvider.ts
+++ b/src/libs/ajax/leonardo/providers/LeoAppProvider.ts
@@ -1,0 +1,20 @@
+import { Ajax } from 'src/libs/ajax';
+import { ListAppResponse } from 'src/libs/ajax/leonardo/models/app-models';
+
+export interface LeoAppProvider {
+  listWithoutProject: (args: Record<string, string>, signal?: AbortSignal) => Promise<ListAppResponse[]>;
+  delete: (resourceName: string, appName: string, deleteDisk?: boolean, signal?: AbortSignal) => Promise<void>;
+  pause: (resourceName: string, appName: string, signal?: AbortSignal) => Promise<void>;
+}
+
+export const leoAppProvider: LeoAppProvider = {
+  listWithoutProject: (args: Record<string, string>, signal?: AbortSignal): Promise<ListAppResponse[]> => {
+    return Ajax(signal).Apps.listWithoutProject(args);
+  },
+  delete: (resourceName: string, appName: string, deleteDisk?: boolean, signal?: AbortSignal): Promise<void> => {
+    return Ajax(signal).Apps.app(resourceName, appName).delete(deleteDisk);
+  },
+  pause: (resourceName: string, appName: string, signal?: AbortSignal): Promise<void> => {
+    return Ajax(signal).Apps.app(resourceName, appName).pause();
+  },
+};

--- a/src/libs/ajax/leonardo/providers/LeoAppProvider.ts
+++ b/src/libs/ajax/leonardo/providers/LeoAppProvider.ts
@@ -1,20 +1,41 @@
 import { Ajax } from 'src/libs/ajax';
-import { ListAppResponse } from 'src/libs/ajax/leonardo/models/app-models';
+import { AbortOption } from 'src/libs/ajax/data-provider-common';
+import { App, ListAppResponse } from 'src/libs/ajax/leonardo/models/app-models';
+
+export type AppBasics = Pick<App, 'appName'> & {
+  cloudContext: Pick<App['cloudContext'], 'cloudProvider' | 'cloudResource'>;
+};
+
+export type DeleteAppOptions = AbortOption & {
+  deleteDisk?: boolean;
+};
 
 export interface LeoAppProvider {
-  listWithoutProject: (args: Record<string, string>, signal?: AbortSignal) => Promise<ListAppResponse[]>;
-  delete: (resourceName: string, appName: string, deleteDisk?: boolean, signal?: AbortSignal) => Promise<void>;
-  pause: (resourceName: string, appName: string, signal?: AbortSignal) => Promise<void>;
+  listWithoutProject: (listArgs: Record<string, string>, options?: AbortOption) => Promise<ListAppResponse[]>;
+  delete: (app: AppBasics, options?: DeleteAppOptions) => Promise<void>;
+  pause: (app: AppBasics, options?: AbortOption) => Promise<void>;
 }
 
 export const leoAppProvider: LeoAppProvider = {
-  listWithoutProject: (args: Record<string, string>, signal?: AbortSignal): Promise<ListAppResponse[]> => {
-    return Ajax(signal).Apps.listWithoutProject(args);
+  listWithoutProject: (listArgs: Record<string, string>, options: AbortOption = {}): Promise<ListAppResponse[]> => {
+    const { signal } = options;
+
+    return Ajax(signal).Apps.listWithoutProject(listArgs);
   },
-  delete: (resourceName: string, appName: string, deleteDisk?: boolean, signal?: AbortSignal): Promise<void> => {
-    return Ajax(signal).Apps.app(resourceName, appName).delete(deleteDisk);
+  delete: (app: AppBasics, options: DeleteAppOptions = {}): Promise<void> => {
+    const { cloudProvider, cloudResource } = app.cloudContext;
+    const { deleteDisk, signal } = options;
+
+    if (cloudProvider === 'GCP') {
+      const { appName } = app;
+      return Ajax(signal).Apps.app(cloudResource, appName).delete(!!deleteDisk);
+    }
+    throw new Error('Deleting apps is currently only supported on GCP');
   },
-  pause: (resourceName: string, appName: string, signal?: AbortSignal): Promise<void> => {
-    return Ajax(signal).Apps.app(resourceName, appName).pause();
+  pause: (app: AppBasics, options: AbortOption = {}): Promise<void> => {
+    const { cloudResource } = app.cloudContext;
+    const { signal } = options;
+
+    return Ajax(signal).Apps.app(cloudResource, app.appName).pause();
   },
 };

--- a/src/libs/ajax/leonardo/providers/LeoDiskProvider.test.ts
+++ b/src/libs/ajax/leonardo/providers/LeoDiskProvider.test.ts
@@ -5,11 +5,9 @@ import {
   DisksAjaxContractV1,
   DisksAjaxContractV2,
 } from 'src/libs/ajax/leonardo/Disks';
-import { PersistentDisk } from 'src/libs/ajax/leonardo/models/disk-models';
-import { GoogleWorkspaceInfo, WorkspaceInfo } from 'src/libs/workspace-utils';
 import { asMockedFn } from 'src/testing/test-utils';
 
-import { leoDiskProvider } from './LeoDiskProvider';
+import { DiskBasics, leoDiskProvider } from './LeoDiskProvider';
 
 jest.mock('src/libs/ajax');
 
@@ -71,14 +69,14 @@ describe('leoDiskProvider', () => {
     // Arrange
     const ajaxMock = mockAjaxNeeds();
     asMockedFn(ajaxMock.DisksV1.list).mockResolvedValue([]);
-    const abort = new window.AbortController();
+    const signal = new window.AbortController().signal;
 
     // Act
-    const result = await leoDiskProvider.list({ arg: '1' }, abort.signal);
+    const result = await leoDiskProvider.list({ arg: '1' }, { signal });
 
     // Assert;
     expect(Ajax).toBeCalledTimes(1);
-    expect(Ajax).toBeCalledWith(abort.signal);
+    expect(Ajax).toBeCalledWith(signal);
     expect(ajaxMock.DisksV1.list).toBeCalledTimes(1);
     expect(ajaxMock.DisksV1.list).toBeCalledWith({ arg: '1' });
     expect(result).toEqual([]);
@@ -88,21 +86,18 @@ describe('leoDiskProvider', () => {
     // Arrange
     const ajaxMock = mockAjaxNeeds();
     const abort = new window.AbortController();
-    const disk: Partial<PersistentDisk> = {
+    const disk: DiskBasics = {
       name: 'myDiskName',
       id: 123,
       cloudContext: {
         cloudProvider: 'GCP',
-        cloudResource: 'myGoogleResource',
+        cloudResource: 'myGoogleProject',
       },
-    };
-    const workspace: Partial<GoogleWorkspaceInfo> = {
-      googleProject: 'myGoogleProject',
     };
 
     // Act
     // calls to this method generally don't care about passing in signal, but doing it here for completeness
-    void (await leoDiskProvider.delete(disk as PersistentDisk, workspace as WorkspaceInfo, abort.signal));
+    void (await leoDiskProvider.delete(disk, { signal: abort.signal }));
 
     // Assert;
     expect(Ajax).toBeCalledTimes(1);
@@ -116,7 +111,7 @@ describe('leoDiskProvider', () => {
     // Arrange
     const ajaxMock = mockAjaxNeeds();
     const abort = new window.AbortController();
-    const disk: Partial<PersistentDisk> = {
+    const disk: DiskBasics = {
       name: 'myDiskName',
       id: 123,
       cloudContext: {
@@ -124,13 +119,10 @@ describe('leoDiskProvider', () => {
         cloudResource: 'myAzureResource',
       },
     };
-    const workspace: Partial<WorkspaceInfo> = {
-      // don't actually need anything here for Azure case
-    };
 
     // Act
     // calls to this method generally don't care about passing in signal, but doing it here for completeness
-    void (await leoDiskProvider.delete(disk as PersistentDisk, workspace as WorkspaceInfo, abort.signal));
+    void (await leoDiskProvider.delete(disk, { signal: abort.signal }));
 
     // Assert;
     expect(Ajax).toBeCalledTimes(1);

--- a/src/libs/ajax/leonardo/providers/LeoDiskProvider.test.ts
+++ b/src/libs/ajax/leonardo/providers/LeoDiskProvider.test.ts
@@ -1,0 +1,141 @@
+import { Ajax } from 'src/libs/ajax';
+import {
+  DiskAjaxContract,
+  DisksAjaxContract,
+  DisksAjaxContractV1,
+  DisksAjaxContractV2,
+} from 'src/libs/ajax/leonardo/Disks';
+import { PersistentDisk } from 'src/libs/ajax/leonardo/models/disk-models';
+import { GoogleWorkspaceInfo, WorkspaceInfo } from 'src/libs/workspace-utils';
+import { asMockedFn } from 'src/testing/test-utils';
+
+import { leoDiskProvider } from './LeoDiskProvider';
+
+jest.mock('src/libs/ajax');
+
+type AjaxContract = ReturnType<typeof Ajax>;
+type DiskNeeds = Pick<DiskAjaxContract, 'delete'>;
+type DisksV1Needs = Pick<DisksAjaxContractV1, 'list' | 'disk'>;
+type DisksV2Needs = Pick<DisksAjaxContractV2, 'delete'>;
+
+interface AjaxMockNeeds {
+  DisksV1: DisksV1Needs;
+  DisksV2: DisksV2Needs;
+  disk: DiskNeeds;
+}
+
+/**
+ * local test utility - mocks the Ajax super-object and the subset of needed multi-contracts it
+ * returns with as much type-saftely as possible.
+ *
+ * @return collection of key contract sub-objects for easy
+ * mock overrides and/or method spying/assertions
+ */
+const mockAjaxNeeds = (): AjaxMockNeeds => {
+  const partialDisk: DiskNeeds = {
+    delete: jest.fn(),
+  };
+  const mockDisk = partialDisk as DiskAjaxContract;
+
+  const partialDisksV1: DisksV1Needs = {
+    disk: jest.fn(),
+    list: jest.fn(),
+  };
+  const mockDisksV1 = partialDisksV1 as DisksAjaxContractV1;
+
+  const partialDisksV2: DisksV2Needs = {
+    delete: jest.fn(),
+  };
+  const mockDisksV2 = partialDisksV2 as DisksAjaxContractV2;
+
+  asMockedFn(mockDisksV1.disk).mockReturnValue(mockDisk);
+
+  // Ajax.Disks root
+  const mockDisks: DisksAjaxContract = {
+    disksV1: jest.fn(),
+    disksV2: jest.fn(),
+  };
+  asMockedFn(mockDisks.disksV1).mockReturnValue(mockDisksV1);
+  asMockedFn(mockDisks.disksV2).mockReturnValue(mockDisksV2);
+
+  asMockedFn(Ajax).mockReturnValue({ Disks: mockDisks } as AjaxContract);
+
+  return {
+    DisksV1: partialDisksV1,
+    DisksV2: partialDisksV2,
+    disk: partialDisk,
+  };
+};
+describe('leoDiskProvider', () => {
+  it('handles list call', async () => {
+    // Arrange
+    const ajaxMock = mockAjaxNeeds();
+    asMockedFn(ajaxMock.DisksV1.list).mockResolvedValue([]);
+    const abort = new window.AbortController();
+
+    // Act
+    const result = await leoDiskProvider.list({ arg: '1' }, abort.signal);
+
+    // Assert;
+    expect(Ajax).toBeCalledTimes(1);
+    expect(Ajax).toBeCalledWith(abort.signal);
+    expect(ajaxMock.DisksV1.list).toBeCalledTimes(1);
+    expect(ajaxMock.DisksV1.list).toBeCalledWith({ arg: '1' });
+    expect(result).toEqual([]);
+  });
+
+  it('handles delete disk call for GCP', async () => {
+    // Arrange
+    const ajaxMock = mockAjaxNeeds();
+    const abort = new window.AbortController();
+    const disk: Partial<PersistentDisk> = {
+      name: 'myDiskName',
+      id: 123,
+      cloudContext: {
+        cloudProvider: 'GCP',
+        cloudResource: 'myGoogleResource',
+      },
+    };
+    const workspace: Partial<GoogleWorkspaceInfo> = {
+      googleProject: 'myGoogleProject',
+    };
+
+    // Act
+    // calls to this method generally don't care about passing in signal, but doing it here for completeness
+    void (await leoDiskProvider.delete(disk as PersistentDisk, workspace as WorkspaceInfo, abort.signal));
+
+    // Assert;
+    expect(Ajax).toBeCalledTimes(1);
+    expect(Ajax).toBeCalledWith(abort.signal);
+    expect(ajaxMock.DisksV1.disk).toBeCalledTimes(1);
+    expect(ajaxMock.DisksV1.disk).toBeCalledWith('myGoogleProject', 'myDiskName');
+    expect(ajaxMock.disk.delete).toBeCalledTimes(1);
+  });
+
+  it('handles delete disk call for Azure', async () => {
+    // Arrange
+    const ajaxMock = mockAjaxNeeds();
+    const abort = new window.AbortController();
+    const disk: Partial<PersistentDisk> = {
+      name: 'myDiskName',
+      id: 123,
+      cloudContext: {
+        cloudProvider: 'AZURE',
+        cloudResource: 'myAzureResource',
+      },
+    };
+    const workspace: Partial<WorkspaceInfo> = {
+      // don't actually need anything here for Azure case
+    };
+
+    // Act
+    // calls to this method generally don't care about passing in signal, but doing it here for completeness
+    void (await leoDiskProvider.delete(disk as PersistentDisk, workspace as WorkspaceInfo, abort.signal));
+
+    // Assert;
+    expect(Ajax).toBeCalledTimes(1);
+    expect(Ajax).toBeCalledWith(abort.signal);
+    expect(ajaxMock.DisksV2.delete).toBeCalledTimes(1);
+    expect(ajaxMock.DisksV2.delete).toBeCalledWith(123);
+  });
+});

--- a/src/libs/ajax/leonardo/providers/LeoDiskProvider.ts
+++ b/src/libs/ajax/leonardo/providers/LeoDiskProvider.ts
@@ -1,22 +1,27 @@
 import { isGcpContext } from 'src/analysis/utils/runtime-utils';
 import { Ajax } from 'src/libs/ajax';
+import { AbortOption } from 'src/libs/ajax/data-provider-common';
 import { PersistentDisk } from 'src/libs/ajax/leonardo/models/disk-models';
-import { GoogleWorkspaceInfo, WorkspaceInfo } from 'src/libs/workspace-utils';
+
+export type DiskBasics = Pick<PersistentDisk, 'cloudContext' | 'name' | 'id'>;
 
 export interface LeoDiskProvider {
-  list: (listArgs: Record<string, string>, signal?: AbortSignal) => Promise<PersistentDisk[]>;
-  delete: (disk: PersistentDisk, workspace: WorkspaceInfo, signal?: AbortSignal) => Promise<void>;
+  list: (listArgs: Record<string, string>, options?: AbortOption) => Promise<PersistentDisk[]>;
+  delete: (disk: DiskBasics, options?: AbortOption) => Promise<void>;
 }
 
 export const leoDiskProvider: LeoDiskProvider = {
-  list: (listArgs: Record<string, string>, signal?: AbortSignal): Promise<PersistentDisk[]> => {
+  list: (listArgs: Record<string, string>, options: AbortOption = {}): Promise<PersistentDisk[]> => {
+    const { signal } = options;
+
     return Ajax(signal).Disks.disksV1().list(listArgs);
   },
-  delete: (disk: PersistentDisk, workspace: WorkspaceInfo, signal?: AbortSignal): Promise<void> => {
+  delete: (disk: DiskBasics, options: AbortOption = {}): Promise<void> => {
     const { cloudContext, name, id } = disk;
+    const { signal } = options;
 
     if (isGcpContext(cloudContext)) {
-      const { googleProject } = workspace as GoogleWorkspaceInfo;
+      const googleProject = cloudContext.cloudResource;
       return Ajax(signal).Disks.disksV1().disk(googleProject, name).delete();
     }
     return Ajax(signal).Disks.disksV2().delete(id);

--- a/src/libs/ajax/leonardo/providers/LeoDiskProvider.ts
+++ b/src/libs/ajax/leonardo/providers/LeoDiskProvider.ts
@@ -1,0 +1,24 @@
+import { isGcpContext } from 'src/analysis/utils/runtime-utils';
+import { Ajax } from 'src/libs/ajax';
+import { PersistentDisk } from 'src/libs/ajax/leonardo/models/disk-models';
+import { GoogleWorkspaceInfo, WorkspaceInfo } from 'src/libs/workspace-utils';
+
+export interface LeoDiskProvider {
+  list: (listArgs: Record<string, string>, signal?: AbortSignal) => Promise<PersistentDisk[]>;
+  delete: (disk: PersistentDisk, workspace: WorkspaceInfo, signal?: AbortSignal) => Promise<void>;
+}
+
+export const leoDiskProvider: LeoDiskProvider = {
+  list: (listArgs: Record<string, string>, signal?: AbortSignal): Promise<PersistentDisk[]> => {
+    return Ajax(signal).Disks.disksV1().list(listArgs);
+  },
+  delete: (disk: PersistentDisk, workspace: WorkspaceInfo, signal?: AbortSignal): Promise<void> => {
+    const { cloudContext, name, id } = disk;
+
+    if (isGcpContext(cloudContext)) {
+      const { googleProject } = workspace as GoogleWorkspaceInfo;
+      return Ajax(signal).Disks.disksV1().disk(googleProject, name).delete();
+    }
+    return Ajax(signal).Disks.disksV2().delete(id);
+  },
+};

--- a/src/libs/ajax/leonardo/providers/LeoRuntimeProvider.test.ts
+++ b/src/libs/ajax/leonardo/providers/LeoRuntimeProvider.test.ts
@@ -1,0 +1,165 @@
+import { Ajax } from 'src/libs/ajax';
+import {
+  RuntimeAjaxContractV1,
+  RuntimeAjaxContractV2,
+  RuntimesAjaxContract,
+  RuntimeWrapperAjaxContract,
+} from 'src/libs/ajax/leonardo/Runtimes';
+import { asMockedFn } from 'src/testing/test-utils';
+
+import { leoRuntimeProvider, RuntimeBasics } from './LeoRuntimeProvider';
+
+jest.mock('src/libs/ajax');
+
+type AjaxContract = ReturnType<typeof Ajax>;
+type RuntimesNeeds = Pick<RuntimesAjaxContract, 'listV2' | 'runtime' | 'runtimeV2' | 'runtimeWrapper'>;
+type RuntimeV1Needs = Pick<RuntimeAjaxContractV1, 'delete'>;
+type RuntimeV2Needs = Pick<RuntimeAjaxContractV2, 'delete'>;
+type RuntimeWrapperNeeds = Pick<RuntimeWrapperAjaxContract, 'stop'>;
+
+interface AjaxMockNeeds {
+  Runtimes: RuntimesNeeds;
+  runtimeV1: RuntimeV1Needs;
+  runtimeV2: RuntimeV2Needs;
+  runtimeWrapper: RuntimeWrapperNeeds;
+}
+
+/**
+ * local test utility - mocks the Ajax super-object and the subset of needed multi-contracts it
+ * returns with as much type-saftely as possible.
+ *
+ * @return collection of key contract sub-objects for easy
+ * mock overrides and/or method spying/assertions
+ */
+const mockAjaxNeeds = (): AjaxMockNeeds => {
+  const partialRuntimeV1: RuntimeV1Needs = {
+    delete: jest.fn(),
+  };
+  const mockRuntimeV1 = partialRuntimeV1 as RuntimeAjaxContractV1;
+
+  const partialRuntimeV2: RuntimeV2Needs = {
+    delete: jest.fn(),
+  };
+  const mockRuntimeV2 = partialRuntimeV2 as RuntimeAjaxContractV2;
+
+  const partialRuntimeWrapper: RuntimeWrapperNeeds = {
+    stop: jest.fn(),
+  };
+  const mockRuntimeWrapper = partialRuntimeWrapper as RuntimeWrapperAjaxContract;
+
+  // Ajax.Runtimes root
+  const partialRuntimes: RuntimesNeeds = {
+    listV2: jest.fn(),
+    runtime: jest.fn(),
+    runtimeV2: jest.fn(),
+    runtimeWrapper: jest.fn(),
+  };
+  asMockedFn(partialRuntimes.runtime).mockReturnValue(mockRuntimeV1);
+  asMockedFn(partialRuntimes.runtimeV2).mockReturnValue(mockRuntimeV2);
+  asMockedFn(partialRuntimes.runtimeWrapper).mockReturnValue(mockRuntimeWrapper);
+
+  asMockedFn(Ajax).mockReturnValue({ Runtimes: partialRuntimes } as AjaxContract);
+
+  return {
+    Runtimes: partialRuntimes,
+    runtimeV1: partialRuntimeV1,
+    runtimeV2: partialRuntimeV2,
+    runtimeWrapper: partialRuntimeWrapper,
+  };
+};
+describe('leoRuntimeProvider', () => {
+  it('handles list runtimes call', async () => {
+    // Arrange
+    const ajaxMock = mockAjaxNeeds();
+    asMockedFn(ajaxMock.Runtimes.listV2).mockResolvedValue([]);
+    const abort = new window.AbortController();
+
+    // Act
+    const result = await leoRuntimeProvider.list({ arg: '1' }, abort.signal);
+
+    // Assert;
+    expect(Ajax).toBeCalledTimes(1);
+    expect(Ajax).toBeCalledWith(abort.signal);
+    expect(ajaxMock.Runtimes.listV2).toBeCalledTimes(1);
+    expect(ajaxMock.Runtimes.listV2).toBeCalledWith({ arg: '1' });
+    expect(result).toEqual([]);
+  });
+
+  it('handles stop runtime call', async () => {
+    // Arrange
+    const ajaxMock = mockAjaxNeeds();
+
+    const abort = new window.AbortController();
+
+    const runtime: RuntimeBasics = {
+      runtimeName: 'myRuntime',
+      cloudContext: {
+        cloudProvider: 'GCP',
+        cloudResource: 'myGoogleResource',
+      },
+      googleProject: 'myGoogleProject',
+    };
+
+    // Act
+    void (await leoRuntimeProvider.stop(runtime, abort.signal));
+
+    // Assert;
+    expect(Ajax).toBeCalledTimes(1);
+    expect(Ajax).toBeCalledWith(abort.signal);
+    expect(ajaxMock.Runtimes.runtimeWrapper).toBeCalledTimes(1);
+    expect(ajaxMock.Runtimes.runtimeWrapper).toBeCalledWith(runtime);
+    expect(ajaxMock.runtimeWrapper.stop).toBeCalledTimes(1);
+  });
+
+  it('handles delete runtime call for GCP', async () => {
+    // Arrange
+    const ajaxMock = mockAjaxNeeds();
+    const abort = new window.AbortController();
+    const runtime: RuntimeBasics = {
+      runtimeName: 'myRuntime',
+      cloudContext: {
+        cloudProvider: 'GCP',
+        cloudResource: 'myGoogleResource',
+      },
+      googleProject: 'myGoogleProject',
+    };
+
+    // Act
+    // calls to this method generally don't care about passing in signal, but doing it here for completeness
+    void (await leoRuntimeProvider.delete(runtime, false, abort.signal));
+
+    // Assert;
+    expect(Ajax).toBeCalledTimes(1);
+    expect(Ajax).toBeCalledWith(abort.signal);
+    expect(ajaxMock.Runtimes.runtime).toBeCalledTimes(1);
+    expect(ajaxMock.Runtimes.runtime).toBeCalledWith('myGoogleProject', 'myRuntime');
+    expect(ajaxMock.runtimeV1.delete).toBeCalledTimes(1);
+    expect(ajaxMock.runtimeV1.delete).toBeCalledWith(false);
+  });
+
+  it('handles delete runtime call for Azure', async () => {
+    // Arrange
+    const ajaxMock = mockAjaxNeeds();
+    const abort = new window.AbortController();
+    const runtime: RuntimeBasics = {
+      runtimeName: 'myRuntime',
+      cloudContext: {
+        cloudProvider: 'AZURE',
+        cloudResource: 'myGoogleResource',
+      },
+      workspaceId: 'myWorkspaceId',
+    };
+
+    // Act
+    // calls to this method generally don't care about passing in signal, but doing it here for completeness
+    void (await leoRuntimeProvider.delete(runtime, false, abort.signal));
+
+    // Assert;
+    expect(Ajax).toBeCalledTimes(1);
+    expect(Ajax).toBeCalledWith(abort.signal);
+    expect(ajaxMock.Runtimes.runtimeV2).toBeCalledTimes(1);
+    expect(ajaxMock.Runtimes.runtimeV2).toBeCalledWith('myWorkspaceId', 'myRuntime');
+    expect(ajaxMock.runtimeV2.delete).toBeCalledTimes(1);
+    expect(ajaxMock.runtimeV2.delete).toBeCalledWith(false);
+  });
+});

--- a/src/libs/ajax/leonardo/providers/LeoRuntimeProvider.test.ts
+++ b/src/libs/ajax/leonardo/providers/LeoRuntimeProvider.test.ts
@@ -72,14 +72,14 @@ describe('leoRuntimeProvider', () => {
     // Arrange
     const ajaxMock = mockAjaxNeeds();
     asMockedFn(ajaxMock.Runtimes.listV2).mockResolvedValue([]);
-    const abort = new window.AbortController();
+    const signal = new window.AbortController().signal;
 
     // Act
-    const result = await leoRuntimeProvider.list({ arg: '1' }, abort.signal);
+    const result = await leoRuntimeProvider.list({ arg: '1' }, { signal });
 
     // Assert;
     expect(Ajax).toBeCalledTimes(1);
-    expect(Ajax).toBeCalledWith(abort.signal);
+    expect(Ajax).toBeCalledWith(signal);
     expect(ajaxMock.Runtimes.listV2).toBeCalledTimes(1);
     expect(ajaxMock.Runtimes.listV2).toBeCalledWith({ arg: '1' });
     expect(result).toEqual([]);
@@ -101,7 +101,7 @@ describe('leoRuntimeProvider', () => {
     };
 
     // Act
-    void (await leoRuntimeProvider.stop(runtime, abort.signal));
+    void (await leoRuntimeProvider.stop(runtime, { signal: abort.signal }));
 
     // Assert;
     expect(Ajax).toBeCalledTimes(1);
@@ -126,7 +126,7 @@ describe('leoRuntimeProvider', () => {
 
     // Act
     // calls to this method generally don't care about passing in signal, but doing it here for completeness
-    void (await leoRuntimeProvider.delete(runtime, false, abort.signal));
+    void (await leoRuntimeProvider.delete(runtime, { signal: abort.signal }));
 
     // Assert;
     expect(Ajax).toBeCalledTimes(1);
@@ -152,7 +152,7 @@ describe('leoRuntimeProvider', () => {
 
     // Act
     // calls to this method generally don't care about passing in signal, but doing it here for completeness
-    void (await leoRuntimeProvider.delete(runtime, false, abort.signal));
+    void (await leoRuntimeProvider.delete(runtime, { deleteDisk: true, signal: abort.signal }));
 
     // Assert;
     expect(Ajax).toBeCalledTimes(1);
@@ -160,6 +160,6 @@ describe('leoRuntimeProvider', () => {
     expect(ajaxMock.Runtimes.runtimeV2).toBeCalledTimes(1);
     expect(ajaxMock.Runtimes.runtimeV2).toBeCalledWith('myWorkspaceId', 'myRuntime');
     expect(ajaxMock.runtimeV2.delete).toBeCalledTimes(1);
-    expect(ajaxMock.runtimeV2.delete).toBeCalledWith(false);
+    expect(ajaxMock.runtimeV2.delete).toBeCalledWith(true);
   });
 });

--- a/src/libs/ajax/leonardo/providers/LeoRuntimeProvider.ts
+++ b/src/libs/ajax/leonardo/providers/LeoRuntimeProvider.ts
@@ -1,14 +1,14 @@
 import { isGcpContext } from 'src/analysis/utils/runtime-utils';
 import { Ajax } from 'src/libs/ajax';
 import { ListRuntimeItem, Runtime } from 'src/libs/ajax/leonardo/models/runtime-models';
-import { RuntimeWrapper } from 'src/libs/ajax/leonardo/Runtimes';
+import { AzureRuntimeWrapper, GoogleRuntimeWrapper, RuntimeWrapper } from 'src/libs/ajax/leonardo/Runtimes';
 
-export type RuntimeBasics = Pick<Runtime, 'runtimeName' | 'googleProject' | 'cloudContext'>;
+export type RuntimeBasics = RuntimeWrapper & Pick<Runtime, 'cloudContext'>;
 
 export interface LeoRuntimeProvider {
   list: (listArgs: Record<string, string>, signal?: AbortSignal) => Promise<ListRuntimeItem[]>;
-  stop: (runtime: RuntimeWrapper) => Promise<void>;
-  delete: (runtime: Runtime, workspaceId: string, deleteDisk: boolean) => Promise<void>;
+  stop: (runtime: RuntimeWrapper, signal?: AbortSignal) => Promise<void>;
+  delete: (runtime: RuntimeBasics, deleteDisk: boolean, signal?: AbortSignal) => Promise<void>;
 }
 
 export const leoRuntimeProvider: LeoRuntimeProvider = {
@@ -18,11 +18,13 @@ export const leoRuntimeProvider: LeoRuntimeProvider = {
   stop: (runtime: RuntimeWrapper, signal?: AbortSignal): Promise<void> => {
     return Ajax(signal).Runtimes.runtimeWrapper(runtime).stop();
   },
-  delete: (runtime: RuntimeBasics, workspaceId: string, deleteDisk: boolean): Promise<void> => {
-    const { cloudContext, googleProject, runtimeName } = runtime;
+  delete: (runtime: RuntimeBasics, deleteDisk: boolean, signal?: AbortSignal): Promise<void> => {
+    const { cloudContext, runtimeName } = runtime;
     if (isGcpContext(cloudContext)) {
-      return Ajax().Runtimes.runtime(googleProject, runtimeName).delete(deleteDisk);
+      const googleProject = (runtime as GoogleRuntimeWrapper).googleProject;
+      return Ajax(signal).Runtimes.runtime(googleProject, runtimeName).delete(deleteDisk);
     }
-    return Ajax().Runtimes.runtimeV2(workspaceId, runtimeName).delete(deleteDisk);
+    const workspaceId = (runtime as AzureRuntimeWrapper).workspaceId;
+    return Ajax(signal).Runtimes.runtimeV2(workspaceId, runtimeName).delete(deleteDisk);
   },
 };

--- a/src/libs/ajax/leonardo/providers/LeoRuntimeProvider.ts
+++ b/src/libs/ajax/leonardo/providers/LeoRuntimeProvider.ts
@@ -1,0 +1,28 @@
+import { isGcpContext } from 'src/analysis/utils/runtime-utils';
+import { Ajax } from 'src/libs/ajax';
+import { ListRuntimeItem, Runtime } from 'src/libs/ajax/leonardo/models/runtime-models';
+import { RuntimeWrapper } from 'src/libs/ajax/leonardo/Runtimes';
+
+export type RuntimeBasics = Pick<Runtime, 'runtimeName' | 'googleProject' | 'cloudContext'>;
+
+export interface LeoRuntimeProvider {
+  list: (listArgs: Record<string, string>, signal?: AbortSignal) => Promise<ListRuntimeItem[]>;
+  stop: (runtime: RuntimeWrapper) => Promise<void>;
+  delete: (runtime: Runtime, workspaceId: string, deleteDisk: boolean) => Promise<void>;
+}
+
+export const leoRuntimeProvider: LeoRuntimeProvider = {
+  list: (listArgs: Record<string, string>, signal?: AbortSignal): Promise<ListRuntimeItem[]> => {
+    return Ajax(signal).Runtimes.listV2(listArgs);
+  },
+  stop: (runtime: RuntimeWrapper, signal?: AbortSignal): Promise<void> => {
+    return Ajax(signal).Runtimes.runtimeWrapper(runtime).stop();
+  },
+  delete: (runtime: RuntimeBasics, workspaceId: string, deleteDisk: boolean): Promise<void> => {
+    const { cloudContext, googleProject, runtimeName } = runtime;
+    if (isGcpContext(cloudContext)) {
+      return Ajax().Runtimes.runtime(googleProject, runtimeName).delete(deleteDisk);
+    }
+    return Ajax().Runtimes.runtimeV2(workspaceId, runtimeName).delete(deleteDisk);
+  },
+};

--- a/src/libs/ajax/leonardo/providers/LeoRuntimeProvider.ts
+++ b/src/libs/ajax/leonardo/providers/LeoRuntimeProvider.ts
@@ -1,30 +1,46 @@
 import { isGcpContext } from 'src/analysis/utils/runtime-utils';
 import { Ajax } from 'src/libs/ajax';
+import { AbortOption } from 'src/libs/ajax/data-provider-common';
 import { ListRuntimeItem, Runtime } from 'src/libs/ajax/leonardo/models/runtime-models';
 import { AzureRuntimeWrapper, GoogleRuntimeWrapper, RuntimeWrapper } from 'src/libs/ajax/leonardo/Runtimes';
 
 export type RuntimeBasics = RuntimeWrapper & Pick<Runtime, 'cloudContext'>;
 
+export type DeleteRuntimeOptions = AbortOption & {
+  deleteDisk?: boolean;
+};
+
 export interface LeoRuntimeProvider {
-  list: (listArgs: Record<string, string>, signal?: AbortSignal) => Promise<ListRuntimeItem[]>;
-  stop: (runtime: RuntimeWrapper, signal?: AbortSignal) => Promise<void>;
-  delete: (runtime: RuntimeBasics, deleteDisk: boolean, signal?: AbortSignal) => Promise<void>;
+  list: (listArgs: Record<string, string>, options?: AbortOption) => Promise<ListRuntimeItem[]>;
+  stop: (runtime: RuntimeWrapper, options?: AbortOption) => Promise<void>;
+  delete: (runtime: RuntimeBasics, options?: DeleteRuntimeOptions) => Promise<void>;
 }
 
 export const leoRuntimeProvider: LeoRuntimeProvider = {
-  list: (listArgs: Record<string, string>, signal?: AbortSignal): Promise<ListRuntimeItem[]> => {
+  list: (listArgs: Record<string, string>, options: AbortOption = {}): Promise<ListRuntimeItem[]> => {
+    const { signal } = options;
+
     return Ajax(signal).Runtimes.listV2(listArgs);
   },
-  stop: (runtime: RuntimeWrapper, signal?: AbortSignal): Promise<void> => {
+  stop: (runtime: RuntimeWrapper, options: AbortOption = {}): Promise<void> => {
+    const { signal } = options;
+
+    // TODO: refactor runtimeWrapper and related v1/v2 mechanics into this provider.
+    // This provider largely does the same abstraction pattern that runtimeWrapper is going for.
+    // We should follow-up and see about removing runtimeWrapper from Ajax.Runtimes and point all current
+    // consumers to this leoRuntimeProvider instead.  Any v1/v2 (GCP/Azure) conditional logic should happen
+    // here, and the Ajax layer should just be mirrors of backend endpoints.
     return Ajax(signal).Runtimes.runtimeWrapper(runtime).stop();
   },
-  delete: (runtime: RuntimeBasics, deleteDisk: boolean, signal?: AbortSignal): Promise<void> => {
+  delete: (runtime: RuntimeBasics, options: DeleteRuntimeOptions = {}): Promise<void> => {
     const { cloudContext, runtimeName } = runtime;
+    const { deleteDisk, signal } = options;
+
     if (isGcpContext(cloudContext)) {
       const googleProject = (runtime as GoogleRuntimeWrapper).googleProject;
-      return Ajax(signal).Runtimes.runtime(googleProject, runtimeName).delete(deleteDisk);
+      return Ajax(signal).Runtimes.runtime(googleProject, runtimeName).delete(!!deleteDisk);
     }
     const workspaceId = (runtime as AzureRuntimeWrapper).workspaceId;
-    return Ajax(signal).Runtimes.runtimeV2(workspaceId, runtimeName).delete(deleteDisk);
+    return Ajax(signal).Runtimes.runtimeV2(workspaceId, runtimeName).delete(!!deleteDisk);
   },
 };

--- a/src/libs/ajax/metrics/useMetrics.ts
+++ b/src/libs/ajax/metrics/useMetrics.ts
@@ -3,11 +3,11 @@ import { Ajax } from 'src/libs/ajax';
 
 export type CaptureEventFn = (event: string, details?: {}) => void;
 
-export interface UseMetricsContract {
+export interface MetricsProvider {
   captureEvent: CaptureEventFn;
 }
 
-export const useMetricsEvent = (): UseMetricsContract => {
+export const useMetricsEvent = (): MetricsProvider => {
   const sendEvent = useMemo(() => Ajax().Metrics.captureEvent, []);
   // By returning a wrapper function, we can handle the fire-and-forget promise mechanics properly here
   // instead of burdening the consumer side with silencing the Typescript/lint complaints, which can be

--- a/src/libs/workspace-utils.ts
+++ b/src/libs/workspace-utils.ts
@@ -47,8 +47,8 @@ export interface GoogleWorkspaceInfo extends BaseWorkspaceInfo {
 
 export type WorkspaceInfo = AzureWorkspaceInfo | GoogleWorkspaceInfo;
 
-export const isGoogleWorkspaceInfo = (workspace: WorkspaceInfo): workspace is GoogleWorkspaceInfo => {
-  return workspace.cloudPlatform === 'Gcp';
+export const isGoogleWorkspaceInfo = (workspace: WorkspaceInfo | undefined): workspace is GoogleWorkspaceInfo => {
+  return workspace ? workspace.cloudPlatform === 'Gcp' : false;
 };
 
 export const workspaceAccessLevels = ['NO ACCESS', 'READER', 'WRITER', 'OWNER', 'PROJECT_OWNER'] as const;

--- a/src/pages/EnvironmentsPage.test.ts
+++ b/src/pages/EnvironmentsPage.test.ts
@@ -60,11 +60,11 @@ describe('Environments Page', () => {
     expect(watcher).toBeCalledWith(
       expect.objectContaining({
         nav: navProvider,
-        useWorkspacesProvider: useWorkspaces as UseWorkspacesProvider,
-        leoAppProvider,
-        leoRuntimeProvider,
-        leoDiskProvider,
-        metricsProvider: mockMetricsProvider,
+        useWorkspacesState: useWorkspaces as UseWorkspacesProvider,
+        leoAppData: leoAppProvider,
+        leoRuntimeData: leoRuntimeProvider,
+        leoDiskData: leoDiskProvider,
+        metrics: mockMetricsProvider,
       } satisfies EnvironmentsProps),
       expect.anything()
     );

--- a/src/pages/EnvironmentsPage.test.ts
+++ b/src/pages/EnvironmentsPage.test.ts
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { h } from 'react-hyperscript-helpers';
-import { Environments, EnvironmentsProps, UseWorkspacesProvider } from 'src/analysis/Environments/Environments';
+import { Environments, EnvironmentsProps, UseWorkspacesState } from 'src/analysis/Environments/Environments';
 import { useWorkspaces } from 'src/components/workspace-utils';
 import { leoAppProvider } from 'src/libs/ajax/leonardo/providers/LeoAppProvider';
 import { leoDiskProvider } from 'src/libs/ajax/leonardo/providers/LeoDiskProvider';
@@ -60,7 +60,7 @@ describe('Environments Page', () => {
     expect(watcher).toBeCalledWith(
       expect.objectContaining({
         nav: navProvider,
-        useWorkspacesState: useWorkspaces as UseWorkspacesProvider,
+        useWorkspacesState: useWorkspaces as UseWorkspacesState,
         leoAppData: leoAppProvider,
         leoRuntimeData: leoRuntimeProvider,
         leoDiskData: leoDiskProvider,

--- a/src/pages/EnvironmentsPage.ts
+++ b/src/pages/EnvironmentsPage.ts
@@ -1,4 +1,5 @@
 import { NavLinkProvider } from '@terra-ui-packages/core-utils';
+import { ReactNode } from 'react';
 import { h } from 'react-hyperscript-helpers';
 import { EnvironmentNavActions, Environments, UseWorkspacesProvider } from 'src/analysis/Environments/Environments';
 import FooterWrapper from 'src/components/FooterWrapper';
@@ -35,7 +36,7 @@ export const makeNavProvider = (terraNav: TerraNavLinkProvider): NavLinkProvider
 
 export const navProvider = makeNavProvider(terraNavLinkProvider);
 
-export const EnvironmentsPage = () => {
+export const EnvironmentsPage = (): ReactNode => {
   const metricsProvider = useMetricsEvent();
   return h(FooterWrapper, [
     h(TopBar, { title: 'Cloud Environments', href: '' }, []),

--- a/src/pages/EnvironmentsPage.ts
+++ b/src/pages/EnvironmentsPage.ts
@@ -1,7 +1,7 @@
 import { NavLinkProvider } from '@terra-ui-packages/core-utils';
 import { ReactNode } from 'react';
 import { h } from 'react-hyperscript-helpers';
-import { EnvironmentNavActions, Environments, UseWorkspacesProvider } from 'src/analysis/Environments/Environments';
+import { EnvironmentNavActions, Environments, UseWorkspacesState } from 'src/analysis/Environments/Environments';
 import FooterWrapper from 'src/components/FooterWrapper';
 import TopBar from 'src/components/TopBar';
 import { useWorkspaces } from 'src/components/workspace-utils';
@@ -42,7 +42,7 @@ export const EnvironmentsPage = (): ReactNode => {
     h(TopBar, { title: 'Cloud Environments', href: '' }, []),
     h(Environments, {
       nav: navProvider,
-      useWorkspacesState: useWorkspaces as UseWorkspacesProvider,
+      useWorkspacesState: useWorkspaces as UseWorkspacesState,
       leoAppData: leoAppProvider,
       leoRuntimeData: leoRuntimeProvider,
       leoDiskData: leoDiskProvider,

--- a/src/pages/EnvironmentsPage.ts
+++ b/src/pages/EnvironmentsPage.ts
@@ -1,8 +1,13 @@
 import { NavLinkProvider } from '@terra-ui-packages/core-utils';
 import { h } from 'react-hyperscript-helpers';
-import { EnvironmentNavActions, Environments } from 'src/analysis/Environments/Environments';
+import { EnvironmentNavActions, Environments, UseWorkspacesProvider } from 'src/analysis/Environments/Environments';
 import FooterWrapper from 'src/components/FooterWrapper';
 import TopBar from 'src/components/TopBar';
+import { useWorkspaces } from 'src/components/workspace-utils';
+import { leoAppProvider } from 'src/libs/ajax/leonardo/providers/LeoAppProvider';
+import { leoDiskProvider } from 'src/libs/ajax/leonardo/providers/LeoDiskProvider';
+import { leoRuntimeProvider } from 'src/libs/ajax/leonardo/providers/LeoRuntimeProvider';
+import { useMetricsEvent } from 'src/libs/ajax/metrics/useMetrics';
 import { terraNavKey, TerraNavLinkProvider, terraNavLinkProvider } from 'src/libs/nav';
 
 type NavMap<NavTypes, FnReturn> = {
@@ -30,12 +35,20 @@ export const makeNavProvider = (terraNav: TerraNavLinkProvider): NavLinkProvider
 
 export const navProvider = makeNavProvider(terraNavLinkProvider);
 
-export const EnvironmentsPage = () =>
-  h(FooterWrapper, [
+export const EnvironmentsPage = () => {
+  const metricsProvider = useMetricsEvent();
+  return h(FooterWrapper, [
     h(TopBar, { title: 'Cloud Environments', href: '' }, []),
-    // Passing Nav here allows overriding when this component is used outside of Terra UI.
-    h(Environments, { nav: navProvider }),
+    h(Environments, {
+      nav: navProvider,
+      useWorkspacesProvider: useWorkspaces as UseWorkspacesProvider,
+      leoAppProvider,
+      leoRuntimeProvider,
+      leoDiskProvider,
+      metricsProvider,
+    }),
   ]);
+};
 
 export const navPaths = [
   {

--- a/src/pages/EnvironmentsPage.ts
+++ b/src/pages/EnvironmentsPage.ts
@@ -41,11 +41,11 @@ export const EnvironmentsPage = () => {
     h(TopBar, { title: 'Cloud Environments', href: '' }, []),
     h(Environments, {
       nav: navProvider,
-      useWorkspacesProvider: useWorkspaces as UseWorkspacesProvider,
-      leoAppProvider,
-      leoRuntimeProvider,
-      leoDiskProvider,
-      metricsProvider,
+      useWorkspacesState: useWorkspaces as UseWorkspacesProvider,
+      leoAppData: leoAppProvider,
+      leoRuntimeData: leoRuntimeProvider,
+      leoDiskData: leoDiskProvider,
+      metrics: metricsProvider,
     }),
   ]);
 };


### PR DESCRIPTION
- refactored data needs of Environments component to be aligned with Data Provider layer of the UI stack, above Data Clients (Ajax).
- Environments now requires a number of provider props, and corresponding provider implementations are implemented to abstract Ajax mechanics away.
- useWorkspaces hook decoupled with similar provider decoupling.
- addressing getUser() dependency to come later.
- BREAKING: removed all references to useReplaceableAjaxExperimental mechanic.
- implemented useModalHandler hook to streamline modal mechanics.  Partial application in Environments component modals with deleteAppModal so far.
- Also started to shift sub-components of Environments component to seperate files and improved associated types (more to come later).

### Jira Ticket: https://broadworkbench.atlassian.net/browse/UIE-93

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
Should have no functional change.  

All-of-us consumption would BREAK since useReplaceableAjaxExperimental is being removed.  All-of-us would need to shift to composition similar to what EnvironmentsPage wrapper component is now doing to set provider dependencies through well typed EnvironmentsProps

### What
- Replace the earlier code-sharing mechanic with the first iteration towards a UI-Stack influenced design as outlined in:  [Code Sharing Design Proposals](https://docs.google.com/document/d/1vefkF3tbIPgn_2Kbx6lscFK6nYoZoaowlkXXkszxijA/edit#heading=h.w7o97nwl0rth) .  Thought note that the Composable Dependencies design is being deferred in favor of simpler mechanisms.  Here we are using simple component props for provider dependencies to see how that plays out.  Environments component is still part of main Terra UI project.  Splitting off to a sub-package will come later.

### Why
- hoping to have this serve as the basis for the recommended strategy of dealing with data/state dependencies of large components we want to be shareable across teams.  Further refinement would include more cleanup and creation of an Analysis components package for shared Environments component (and then others), and resolving additional util/sub-dependencies that such a package split would force.

### Testing strategy
- [x] smoke test Environments page
- [x] deeper testing for app, disk, and runtime edge cases not yet covered by unit tests

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 
