### PR TITLE
[UIE-126] Resolve ESLint warning

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,6 +9,9 @@ module.exports = {
         ],
       },
     },
+    react: {
+      version: require('react').version,
+    },
   },
   rules: {
     'simple-import-sort/imports': 'warn',

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "save-build-info": "echo \\{\\\"gitRevision\\\": \\\"$(git rev-parse HEAD)\\\", \\\"buildTimestamp\\\": $(date -u '+%s000')\\} > public/build-info.json"
   },
   "devDependencies": {
-    "setimmediate": "^1.0.5",
     "@axe-core/react": "^4.6.1",
     "@pact-foundation/pact": "10.2.2",
     "@terra-ui-packages/test-utils": "*",
@@ -123,6 +122,7 @@
     "postcss-normalize": "^10.0.1",
     "postcss-preset-env": "^7.8.2",
     "prettier": "^2.8.8",
+    "setimmediate": "^1.0.5",
     "source-map-explorer": "^2.5.2",
     "svgo": "^1.3.2",
     "typescript": "^4.9.5",


### PR DESCRIPTION
Currently, running ESLint with `yarn run lint` shows this warning:
> Warning: React version was set to "detect" in eslint-plugin-react settings, but the "react" package is not installed. Assuming latest React version for linting.

I don't know why `eslint-plugin-import` couldn't detect the version (I suspect maybe some interaction with Yarn PnP), but this resolves the warning.