### PR TITLE
[WM-2140] Allow scrolling in Submission Config

### DIFF
--- a/src/workflows-app/SubmissionConfig.js
+++ b/src/workflows-app/SubmissionConfig.js
@@ -348,7 +348,7 @@ export const BaseSubmissionConfig = (
   const callCacheId = useUniqueId();
 
   const renderSummary = () => {
-    return div({ style: { marginLeft: '2em', marginTop: '1rem', display: 'flex', justifyContent: 'space-between' } }, [
+    return div({ style: { marginLeft: '2em', paddingTop: '1rem', display: 'flex', justifyContent: 'space-between' } }, [
       div([
         h(
           Link,
@@ -595,36 +595,47 @@ export const BaseSubmissionConfig = (
 
   return loading
     ? centeredSpinner()
-    : h(Fragment, [
-        div(
-          {
-            style: {
-              borderBottom: '2px solid rgb(116, 174, 67)',
-              boxShadow: 'rgb(0 0 0 / 26%) 0px 2px 5px 0px, rgb(0 0 0 / 16%) 0px 2px 10px 0px',
-              position: 'relative',
-            },
+    : div(
+        {
+          style: {
+            display: 'flex',
+            flex: '1 1 auto',
+            flexDirection: 'column',
+            overflowY: 'scroll',
           },
-          [renderSummary()]
-        ),
-        div(
-          {
-            style: {
-              display: 'flex',
-              flex: '1 1 auto',
-              flexDirection: 'column',
-              padding: '1rem 3rem',
+        },
+        [
+          div(
+            {
+              style: {
+                borderBottom: '2px solid rgb(116, 174, 67)',
+                boxShadow: 'rgb(0 0 0 / 26%) 0px 2px 5px 0px, rgb(0 0 0 / 16%) 0px 2px 10px 0px',
+                position: 'relative',
+              },
             },
-          },
-          [
-            Utils.switchCase(
-              activeTab.key || 'select-data',
-              ['select-data', () => renderRecordSelector()],
-              ['inputs', () => renderInputs()],
-              ['outputs', () => renderOutputs()]
-            ),
-          ]
-        ),
-      ]);
+            [renderSummary()]
+          ),
+          div(
+            {
+              style: {
+                display: 'flex',
+                flex: '1 1 auto',
+                minHeight: '30rem',
+                flexDirection: 'column',
+                padding: '1rem 3rem',
+              },
+            },
+            [
+              Utils.switchCase(
+                activeTab.key || 'select-data',
+                ['select-data', () => renderRecordSelector()],
+                ['inputs', () => renderInputs()],
+                ['outputs', () => renderOutputs()]
+              ),
+            ]
+          ),
+        ]
+      );
 };
 
 export const SubmissionConfig = wrapWorkflowsPage({ name: 'SubmissionConfig' })(BaseSubmissionConfig);

--- a/src/workflows-app/SubmissionConfig.js
+++ b/src/workflows-app/SubmissionConfig.js
@@ -348,7 +348,7 @@ export const BaseSubmissionConfig = (
   const callCacheId = useUniqueId();
 
   const renderSummary = () => {
-    return div({ style: { marginLeft: '2em', paddingTop: '1rem', display: 'flex', justifyContent: 'space-between' } }, [
+    return div({ style: { marginLeft: '2em', marginTop: '1rem', display: 'flex', justifyContent: 'space-between' } }, [
       div([
         h(
           Link,
@@ -595,47 +595,36 @@ export const BaseSubmissionConfig = (
 
   return loading
     ? centeredSpinner()
-    : div(
-        {
-          style: {
-            display: 'flex',
-            flex: '1 1 auto',
-            flexDirection: 'column',
-            overflowY: 'scroll',
+    : h(Fragment, [
+        div(
+          {
+            style: {
+              borderBottom: '2px solid rgb(116, 174, 67)',
+              boxShadow: 'rgb(0 0 0 / 26%) 0px 2px 5px 0px, rgb(0 0 0 / 16%) 0px 2px 10px 0px',
+              position: 'relative',
+            },
           },
-        },
-        [
-          div(
-            {
-              style: {
-                borderBottom: '2px solid rgb(116, 174, 67)',
-                boxShadow: 'rgb(0 0 0 / 26%) 0px 2px 5px 0px, rgb(0 0 0 / 16%) 0px 2px 10px 0px',
-                position: 'relative',
-              },
+          [renderSummary()]
+        ),
+        div(
+          {
+            style: {
+              display: 'flex',
+              flex: '1 1 auto',
+              flexDirection: 'column',
+              padding: '1rem 3rem',
             },
-            [renderSummary()]
-          ),
-          div(
-            {
-              style: {
-                display: 'flex',
-                flex: '1 1 auto',
-                minHeight: '30rem',
-                flexDirection: 'column',
-                padding: '1rem 3rem',
-              },
-            },
-            [
-              Utils.switchCase(
-                activeTab.key || 'select-data',
-                ['select-data', () => renderRecordSelector()],
-                ['inputs', () => renderInputs()],
-                ['outputs', () => renderOutputs()]
-              ),
-            ]
-          ),
-        ]
-      );
+          },
+          [
+            Utils.switchCase(
+              activeTab.key || 'select-data',
+              ['select-data', () => renderRecordSelector()],
+              ['inputs', () => renderInputs()],
+              ['outputs', () => renderOutputs()]
+            ),
+          ]
+        ),
+      ]);
 };
 
 export const SubmissionConfig = wrapWorkflowsPage({ name: 'SubmissionConfig' })(BaseSubmissionConfig);

--- a/src/workflows-app/components/InputsTable.js
+++ b/src/workflows-app/components/InputsTable.js
@@ -1,9 +1,8 @@
 import _ from 'lodash/fp';
 import { useState } from 'react';
 import { div, h } from 'react-hyperscript-helpers';
-import { AutoSizer } from 'react-virtualized';
 import { Link } from 'src/components/common';
-import { FlexTable, HeaderCell, Sortable, TextCell } from 'src/components/table';
+import { HeaderCell, SimpleFlexTable, Sortable, TextCell } from 'src/components/table';
 import * as Utils from 'src/libs/utils';
 import {
   InputsButtonRow,
@@ -132,7 +131,7 @@ const InputsTable = ({ selectedDataTable, configuredInputDefinition, setConfigur
     );
   };
 
-  return h(div, { style: { height: '100%' } }, [
+  return h(div, { style: { flex: '1 0 auto' } }, [
     h(InputsButtonRow, {
       optionalButtonProps: {
         includeOptionalInputs,
@@ -147,95 +146,79 @@ const InputsTable = ({ selectedDataTable, configuredInputDefinition, setConfigur
         setSearchFilter,
       },
     }),
-    h(div, { style: { height: 'calc(100% - 2.5rem)' } }, [
-      h(AutoSizer, [
-        ({ width, height }) => {
-          return h(div, {}, [
-            structBuilderVisible &&
-              h(StructBuilderModal, {
-                structName: _.get('variable', inputTableData[structBuilderRow]),
-                structType: _.get('input_type', inputTableData[structBuilderRow]),
-                structSource: _.get('source', inputTableData[structBuilderRow]),
-                setStructSource: (source) =>
-                  setConfiguredInputDefinition(
-                    _.set(`${inputTableData[structBuilderRow].configurationIndex}.source`, source, configuredInputDefinition)
-                  ),
-                dataTableAttributes,
-                onDismiss: () => {
-                  setStructBuilderVisible(false);
-                },
-              }),
-            h(FlexTable, {
-              'aria-label': 'input-table',
-              rowCount: inputTableData.length,
-              sort: inputTableSort,
-              readOnly: false,
-              height,
-              width,
-              columns: [
-                {
-                  size: { basis: 250, grow: 0 },
-                  field: 'taskName',
-                  headerRenderer: () =>
-                    h(Sortable, { sort: inputTableSort, field: 'taskName', onSort: setInputTableSort }, [h(HeaderCell, ['Task name'])]),
-                  cellRenderer: ({ rowIndex }) => {
-                    return h(TextCell, { style: { fontWeight: 500 } }, [inputTableData[rowIndex].taskName]);
-                  },
-                },
-                {
-                  size: { basis: 360, grow: 0 },
-                  field: 'variable',
-                  headerRenderer: () =>
-                    h(Sortable, { sort: inputTableSort, field: 'variable', onSort: setInputTableSort }, [h(HeaderCell, ['Variable'])]),
-                  cellRenderer: ({ rowIndex }) => {
-                    return h(TextCell, { style: inputTypeStyle(inputTableData[rowIndex].input_type) }, [inputTableData[rowIndex].variable]);
-                  },
-                },
-                {
-                  size: { basis: 160, grow: 0 },
-                  field: 'inputTypeStr',
-                  headerRenderer: () => h(HeaderCell, ['Type']),
-                  cellRenderer: ({ rowIndex }) => {
-                    return h(TextCell, { style: inputTypeStyle(inputTableData[rowIndex].input_type) }, [inputTableData[rowIndex].inputTypeStr]);
-                  },
-                },
-                {
-                  size: { basis: 300, grow: 0 },
-                  headerRenderer: () => h(HeaderCell, ['Input sources']),
-                  cellRenderer: ({ rowIndex }) => {
-                    return InputSourceSelect({
-                      source: _.get('source', inputTableData[rowIndex]),
-                      inputType: _.get('input_type', inputTableData[rowIndex]),
-                      setSource: (source) =>
-                        setConfiguredInputDefinition(
-                          _.set(`[${inputTableData[rowIndex].configurationIndex}].source`, source, configuredInputDefinition)
-                        ),
-                    });
-                  },
-                },
-                {
-                  headerRenderer: () => h(HeaderCell, ['Attribute']),
-                  cellRenderer: ({ rowIndex }) => {
-                    const source = _.get(`${rowIndex}.source`, inputTableData);
-                    const inputName = _.get(`${rowIndex}.input_name`, inputTableData);
-                    return h(WithWarnings, {
-                      baseComponent: Utils.switchCase(
-                        source.type || 'none',
-                        ['record_lookup', () => recordLookup(rowIndex)],
-                        ['literal', () => parameterValueSelect(rowIndex)],
-                        ['object_builder', () => structBuilderLink(rowIndex)],
-                        ['none', () => sourceNone(rowIndex)]
-                      ),
-                      message: _.find((message) => message.name === inputName)(inputValidations),
-                    });
-                  },
-                },
-              ],
-            }),
-          ]);
+    structBuilderVisible &&
+      h(StructBuilderModal, {
+        structName: _.get('variable', inputTableData[structBuilderRow]),
+        structType: _.get('input_type', inputTableData[structBuilderRow]),
+        structSource: _.get('source', inputTableData[structBuilderRow]),
+        setStructSource: (source) =>
+          setConfiguredInputDefinition(_.set(`${inputTableData[structBuilderRow].configurationIndex}.source`, source, configuredInputDefinition)),
+        dataTableAttributes,
+        onDismiss: () => {
+          setStructBuilderVisible(false);
         },
-      ]),
-    ]),
+      }),
+    h(SimpleFlexTable, {
+      'aria-label': 'input-table',
+      rowCount: inputTableData.length,
+      sort: inputTableSort,
+      readOnly: false,
+      columns: [
+        {
+          size: { basis: 250, grow: 0 },
+          field: 'taskName',
+          headerRenderer: () => h(Sortable, { sort: inputTableSort, field: 'taskName', onSort: setInputTableSort }, [h(HeaderCell, ['Task name'])]),
+          cellRenderer: ({ rowIndex }) => {
+            return h(TextCell, { style: { fontWeight: 500 } }, [inputTableData[rowIndex].taskName]);
+          },
+        },
+        {
+          size: { basis: 360, grow: 0 },
+          field: 'variable',
+          headerRenderer: () => h(Sortable, { sort: inputTableSort, field: 'variable', onSort: setInputTableSort }, [h(HeaderCell, ['Variable'])]),
+          cellRenderer: ({ rowIndex }) => {
+            return h(TextCell, { style: inputTypeStyle(inputTableData[rowIndex].input_type) }, [inputTableData[rowIndex].variable]);
+          },
+        },
+        {
+          size: { basis: 160, grow: 0 },
+          field: 'inputTypeStr',
+          headerRenderer: () => h(HeaderCell, ['Type']),
+          cellRenderer: ({ rowIndex }) => {
+            return h(TextCell, { style: inputTypeStyle(inputTableData[rowIndex].input_type) }, [inputTableData[rowIndex].inputTypeStr]);
+          },
+        },
+        {
+          size: { basis: 300, grow: 0 },
+          headerRenderer: () => h(HeaderCell, ['Input sources']),
+          cellRenderer: ({ rowIndex }) => {
+            return InputSourceSelect({
+              source: _.get('source', inputTableData[rowIndex]),
+              inputType: _.get('input_type', inputTableData[rowIndex]),
+              setSource: (source) =>
+                setConfiguredInputDefinition(_.set(`[${inputTableData[rowIndex].configurationIndex}].source`, source, configuredInputDefinition)),
+            });
+          },
+        },
+        {
+          headerRenderer: () => h(HeaderCell, ['Attribute']),
+          cellRenderer: ({ rowIndex }) => {
+            const source = _.get(`${rowIndex}.source`, inputTableData);
+            const inputName = _.get(`${rowIndex}.input_name`, inputTableData);
+            return h(WithWarnings, {
+              baseComponent: Utils.switchCase(
+                source.type || 'none',
+                ['record_lookup', () => recordLookup(rowIndex)],
+                ['literal', () => parameterValueSelect(rowIndex)],
+                ['object_builder', () => structBuilderLink(rowIndex)],
+                ['none', () => sourceNone(rowIndex)]
+              ),
+              message: _.find((message) => message.name === inputName)(inputValidations),
+            });
+          },
+        },
+      ],
+    }),
   ]);
 };
 

--- a/src/workflows-app/components/OutputsTable.js
+++ b/src/workflows-app/components/OutputsTable.js
@@ -39,7 +39,7 @@ const OutputsTable = (props) => {
     );
   };
 
-  return div({ style: { flex: '1 1 auto' } }, [
+  return div({ style: { flex: '1 0 auto' } }, [
     h(SimpleFlexTable, {
       'aria-label': 'output-table',
       rowCount: outputTableData.length,

--- a/src/workflows-app/components/OutputsTable.js
+++ b/src/workflows-app/components/OutputsTable.js
@@ -1,10 +1,9 @@
 import _ from 'lodash/fp';
 import { Fragment, useState } from 'react';
 import { div, h } from 'react-hyperscript-helpers';
-import { AutoSizer } from 'react-virtualized';
 import { Link } from 'src/components/common';
 import { TextInput } from 'src/components/input';
-import { FlexTable, HeaderCell, Sortable, TextCell } from 'src/components/table';
+import { HeaderCell, SimpleFlexTable, Sortable, TextCell } from 'src/components/table';
 import { WithWarnings } from 'src/workflows-app/components/inputs-common';
 import { parseMethodString, renderTypeText } from 'src/workflows-app/utils/submission-utils';
 
@@ -40,86 +39,80 @@ const OutputsTable = (props) => {
     );
   };
 
-  return h(AutoSizer, [
-    ({ width, height }) => {
-      return h(FlexTable, {
-        'aria-label': 'output-table',
-        rowCount: outputTableData.length,
-        sort: outputTableSort,
-        readOnly: false,
-        height,
-        width,
-        columns: [
-          {
-            size: { basis: 250, grow: 0 },
-            field: 'taskName',
-            headerRenderer: () =>
-              h(Sortable, { sort: outputTableSort, field: 'taskName', onSort: setOutputTableSort }, [h(HeaderCell, ['Task name'])]),
-            cellRenderer: ({ rowIndex }) => {
-              return h(TextCell, { style: { fontWeight: 500 } }, [outputTableData[rowIndex].taskName]);
-            },
+  return div({ style: { flex: '1 1 auto' } }, [
+    h(SimpleFlexTable, {
+      'aria-label': 'output-table',
+      rowCount: outputTableData.length,
+      sort: outputTableSort,
+      readOnly: false,
+      columns: [
+        {
+          size: { basis: 250, grow: 0 },
+          field: 'taskName',
+          headerRenderer: () => h(Sortable, { sort: outputTableSort, field: 'taskName', onSort: setOutputTableSort }, [h(HeaderCell, ['Task name'])]),
+          cellRenderer: ({ rowIndex }) => {
+            return h(TextCell, { style: { fontWeight: 500 } }, [outputTableData[rowIndex].taskName]);
           },
-          {
-            size: { basis: 360, grow: 0 },
-            field: 'variable',
-            headerRenderer: () =>
-              h(Sortable, { sort: outputTableSort, field: 'variable', onSort: setOutputTableSort }, [h(HeaderCell, ['Variable'])]),
-            cellRenderer: ({ rowIndex }) => {
-              return h(TextCell, {}, [outputTableData[rowIndex].variable]);
-            },
+        },
+        {
+          size: { basis: 360, grow: 0 },
+          field: 'variable',
+          headerRenderer: () => h(Sortable, { sort: outputTableSort, field: 'variable', onSort: setOutputTableSort }, [h(HeaderCell, ['Variable'])]),
+          cellRenderer: ({ rowIndex }) => {
+            return h(TextCell, {}, [outputTableData[rowIndex].variable]);
           },
-          {
-            size: { basis: 160, grow: 0 },
-            field: 'outputTypeStr',
-            headerRenderer: () => h(HeaderCell, ['Type']),
-            cellRenderer: ({ rowIndex }) => {
-              return h(TextCell, {}, [outputTableData[rowIndex].outputTypeStr]);
-            },
+        },
+        {
+          size: { basis: 160, grow: 0 },
+          field: 'outputTypeStr',
+          headerRenderer: () => h(HeaderCell, ['Type']),
+          cellRenderer: ({ rowIndex }) => {
+            return h(TextCell, {}, [outputTableData[rowIndex].outputTypeStr]);
           },
-          {
-            headerRenderer: () =>
+        },
+        {
+          headerRenderer: () =>
+            h(Fragment, [
+              h(HeaderCell, { style: { overflow: 'visible' } }, ['Attribute']),
               h(Fragment, [
-                h(HeaderCell, { style: { overflow: 'visible' } }, ['Attribute']),
-                h(Fragment, [
-                  div({ style: { whiteSpace: 'pre' } }, ['  |  ']),
-                  WithWarnings({
-                    baseComponent: h(Link, { onClick: setDefaultOutputs }, [`Autofill (${nonDefaultOutputs.length}) outputs`]),
-                    message: _.some((output) => output.destination.type === 'record_update')(nonDefaultOutputs)
-                      ? { type: 'error', message: 'This will overwrite existing output names' }
-                      : { type: 'none' },
-                  }),
-                ]),
+                div({ style: { whiteSpace: 'pre' } }, ['  |  ']),
+                WithWarnings({
+                  baseComponent: h(Link, { onClick: setDefaultOutputs }, [`Autofill (${nonDefaultOutputs.length}) outputs`]),
+                  message: _.some((output) => output.destination.type === 'record_update')(nonDefaultOutputs)
+                    ? { type: 'error', message: 'This will overwrite existing output names' }
+                    : { type: 'none' },
+                }),
               ]),
-            cellRenderer: ({ rowIndex }) => {
-              const outputValue = (configurationIndex) => {
-                const destType = _.get('destination.type', configuredOutputDefinition[configurationIndex]);
-                if (destType === 'record_update') {
-                  return _.get('destination.record_attribute', configuredOutputDefinition[configurationIndex]);
-                }
-                return '';
-              };
+            ]),
+          cellRenderer: ({ rowIndex }) => {
+            const outputValue = (configurationIndex) => {
+              const destType = _.get('destination.type', configuredOutputDefinition[configurationIndex]);
+              if (destType === 'record_update') {
+                return _.get('destination.record_attribute', configuredOutputDefinition[configurationIndex]);
+              }
+              return '';
+            };
 
-              return h(TextInput, {
-                id: `output-parameter-${rowIndex}`,
-                style: { display: 'block', width: '100%' },
-                value: outputValue(outputTableData[rowIndex].configurationIndex),
-                placeholder: '[Enter an attribute name to save this output to your data table]',
-                onChange: (value) => {
-                  const configurationIndex = outputTableData[rowIndex].configurationIndex;
-                  if (!!value && value !== '') {
-                    setConfiguredOutputDefinition(
-                      _.set(`${configurationIndex}.destination`, { type: 'record_update', record_attribute: value }, configuredOutputDefinition)
-                    );
-                  } else {
-                    setConfiguredOutputDefinition(_.set(`${configurationIndex}.destination`, { type: 'none' }, configuredOutputDefinition));
-                  }
-                },
-              });
-            },
+            return h(TextInput, {
+              id: `output-parameter-${rowIndex}`,
+              style: { display: 'block', width: '100%' },
+              value: outputValue(outputTableData[rowIndex].configurationIndex),
+              placeholder: '[Enter an attribute name to save this output to your data table]',
+              onChange: (value) => {
+                const configurationIndex = outputTableData[rowIndex].configurationIndex;
+                if (!!value && value !== '') {
+                  setConfiguredOutputDefinition(
+                    _.set(`${configurationIndex}.destination`, { type: 'record_update', record_attribute: value }, configuredOutputDefinition)
+                  );
+                } else {
+                  setConfiguredOutputDefinition(_.set(`${configurationIndex}.destination`, { type: 'none' }, configuredOutputDefinition));
+                }
+              },
+            });
           },
-        ],
-      });
-    },
+        },
+      ],
+    }),
   ]);
 };
 


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WM-2140

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Change tables in submission config to not be scrollable

### Why
- Users on smaller computers should be able to scroll inputs and outputs easily
- Consistency with GCP

### Testing strategy
- Tested with different screen sizes <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 

Small screen:

https://github.com/DataBiosphere/terra-ui/assets/67511512/42a20186-d425-40b4-acbf-290c02df703d


Monitor:

https://github.com/DataBiosphere/terra-ui/assets/67511512/8869bd10-2907-48fa-bca8-8cf97fa45ee0


