### PR TITLE
WM-2169: Support WORKFLOWS app creation (feature preview)

### DIFF
--- a/src/analysis/modals/CromwellModal.js
+++ b/src/analysis/modals/CromwellModal.js
@@ -54,13 +54,13 @@ export const CromwellModalBase = withDisplayName('CromwellModal')(
       if (isAzureWorkspace(workspace)) {
         if (isFeaturePreviewEnabled(ENABLE_AZURE_COLLABORATIVE_WORKFLOWS)) {
           await Ajax().Apps.createAppV2(
-            Utils.generateAppName(),
+            generateAppName(),
             workspace.workspace.workspaceId,
             appToolLabels.WORKFLOWS_APP,
             appAccessScopes.WORKSPACE_SHARED
           );
           await Ajax().Apps.createAppV2(
-            Utils.generateAppName(),
+            generateAppName(),
             workspace.workspace.workspaceId,
             appToolLabels.CROMWELL_RUNNER_APP,
             appAccessScopes.USER_PRIVATE

--- a/src/analysis/modals/CromwellModal.js
+++ b/src/analysis/modals/CromwellModal.js
@@ -3,13 +3,15 @@ import { Fragment, useState } from 'react';
 import { div, h } from 'react-hyperscript-helpers';
 import { generateAppName, getCurrentApp, getEnvMessageBasedOnStatus } from 'src/analysis/utils/app-utils';
 import { generatePersistentDiskName, getCurrentAppDataDisk } from 'src/analysis/utils/disk-utils';
-import { appToolLabels, appTools } from 'src/analysis/utils/tool-utils';
+import { appAccessScopes, appToolLabels, appTools } from 'src/analysis/utils/tool-utils';
 import { ButtonPrimary, spinnerOverlay } from 'src/components/common';
 import { withModalDrawer } from 'src/components/ModalDrawer';
 import TitleBar from 'src/components/TitleBar';
 import { Ajax } from 'src/libs/ajax';
 import { withErrorReportingInModal } from 'src/libs/error';
 import Events, { extractWorkspaceDetails } from 'src/libs/events';
+import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
+import { ENABLE_AZURE_COLLABORATIVE_WORKFLOWS } from 'src/libs/feature-previews-config';
 import { useStore, withDisplayName } from 'src/libs/react-utils';
 import { azureCookieReadyStore, cookieReadyStore } from 'src/libs/state';
 import * as Utils from 'src/libs/utils';
@@ -50,7 +52,27 @@ export const CromwellModalBase = withDisplayName('CromwellModal')(
       withErrorReportingInModal('Error creating Cromwell', onError)
     )(async () => {
       if (isAzureWorkspace(workspace)) {
-        await Ajax().Apps.createAppV2(generateAppName(), workspace.workspace.workspaceId, appToolLabels.CROMWELL);
+        if (isFeaturePreviewEnabled(ENABLE_AZURE_COLLABORATIVE_WORKFLOWS)) {
+          await Ajax().Apps.createAppV2(
+            Utils.generateAppName(),
+            workspace.workspace.workspaceId,
+            appToolLabels.WORKFLOWS_APP,
+            appAccessScopes.WORKSPACE_SHARED
+          );
+          await Ajax().Apps.createAppV2(
+            Utils.generateAppName(),
+            workspace.workspace.workspaceId,
+            appToolLabels.CROMWELL_RUNNER_APP,
+            appAccessScopes.USER_PRIVATE
+          );
+        } else {
+          await Ajax().Apps.createAppV2(
+            generateAppName(),
+            workspace.workspace.workspaceId,
+            appToolLabels.CROMWELL,
+            appAccessScopes.USER_PRIVATE
+          );
+        }
       } else {
         await Ajax()
           .Apps.app(googleProject, generateAppName())

--- a/src/analysis/modals/CromwellModal.js
+++ b/src/analysis/modals/CromwellModal.js
@@ -66,12 +66,7 @@ export const CromwellModalBase = withDisplayName('CromwellModal')(
             appAccessScopes.USER_PRIVATE
           );
         } else {
-          await Ajax().Apps.createAppV2(
-            generateAppName(),
-            workspace.workspace.workspaceId,
-            appToolLabels.CROMWELL,
-            appAccessScopes.USER_PRIVATE
-          );
+          await Ajax().Apps.createAppV2(generateAppName(), workspace.workspace.workspaceId, appToolLabels.CROMWELL, appAccessScopes.USER_PRIVATE);
         }
       } else {
         await Ajax()

--- a/src/analysis/modals/CromwellModal.test.ts
+++ b/src/analysis/modals/CromwellModal.test.ts
@@ -1,0 +1,124 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { h } from 'react-hyperscript-helpers';
+import { Ajax } from 'src/libs/ajax';
+import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
+import { ENABLE_AZURE_COLLABORATIVE_WORKFLOWS } from 'src/libs/feature-previews-config';
+import { asMockedFn } from 'src/testing/test-utils';
+import { defaultAzureWorkspace } from 'src/testing/workspace-fixtures';
+
+import { appAccessScopes, appToolLabels } from '../utils/tool-utils';
+import { CromwellModal } from './CromwellModal';
+
+const onSuccess = jest.fn();
+
+const defaultAjaxImpl = {
+  list: jest.fn(),
+  listWithoutProject: jest.fn(),
+  app: jest.fn(),
+  listAppsV2: jest.fn(),
+  createAppV2: jest.fn(),
+  deleteAppV2: jest.fn(),
+  deleteAllAppsV2: jest.fn(),
+};
+
+const defaultCromwellProps = {
+  onDismiss: () => {},
+  onError: () => {},
+  onSuccess,
+  apps: [],
+  workspace: defaultAzureWorkspace,
+  isOpen: true,
+  onExited: () => {},
+};
+
+jest.mock('src/libs/ajax');
+jest.mock('src/libs/ajax/leonardo/Apps');
+type FeaturePrev = typeof import('src/libs/feature-previews');
+jest.mock(
+  'src/libs/feature-previews',
+  (): FeaturePrev => ({
+    ...jest.requireActual('src/libs/feature-previews'),
+    isFeaturePreviewEnabled: jest.fn(),
+  })
+);
+
+type AjaxContract = ReturnType<typeof Ajax>;
+
+function createAppV2Func() {
+  const createFunc = jest.fn();
+  asMockedFn(Ajax).mockImplementation(
+    () =>
+      ({
+        Apps: {
+          ...defaultAjaxImpl,
+          createAppV2: createFunc,
+        },
+        Metrics: { captureEvent: jest.fn() } as Partial<AjaxContract['Metrics']>,
+      } as Partial<AjaxContract> as AjaxContract)
+  );
+  return createFunc;
+}
+
+describe('CromwellModal', () => {
+  it('Renders correctly by default', () => {
+    // Act
+    render(h(CromwellModal, defaultCromwellProps));
+    // Assert
+    screen.getByText('Cromwell Cloud Environment');
+    screen.getByText('Create');
+  });
+
+  it('Use new WORKFLOW apps when feature flag is enabled', async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const createFunc = createAppV2Func();
+    asMockedFn(isFeaturePreviewEnabled).mockImplementation((key) => {
+      return key === ENABLE_AZURE_COLLABORATIVE_WORKFLOWS;
+    });
+
+    // Act
+    render(h(CromwellModal, defaultCromwellProps));
+
+    const createButton = screen.getByText('Create');
+    await user.click(createButton);
+
+    expect(createFunc).toHaveBeenCalledWith(
+      expect.anything(),
+      defaultAzureWorkspace.workspace.workspaceId,
+      appToolLabels.WORKFLOWS_APP,
+      appAccessScopes.WORKSPACE_SHARED
+    );
+    expect(createFunc).toHaveBeenCalledWith(
+      expect.anything(),
+      defaultAzureWorkspace.workspace.workspaceId,
+      appToolLabels.CROMWELL_RUNNER_APP,
+      appAccessScopes.USER_PRIVATE
+    );
+    expect(onSuccess).toHaveBeenCalled();
+  });
+
+  it('Use old CROMWELL app when feature flag is not enabled', async () => {
+    // Arrange
+    const user = userEvent.setup();
+
+    const createFunc = createAppV2Func();
+    asMockedFn(isFeaturePreviewEnabled).mockImplementation(() => {
+      return false;
+    });
+
+    // Act
+    render(h(CromwellModal, defaultCromwellProps));
+
+    const createButton = screen.getByText('Create');
+    await user.click(createButton);
+
+    expect(createFunc).toHaveBeenCalledWith(
+      expect.anything(),
+      defaultAzureWorkspace.workspace.workspaceId,
+      appToolLabels.CROMWELL,
+      appAccessScopes.USER_PRIVATE
+    );
+    expect(onSuccess).toHaveBeenCalled();
+  });
+});

--- a/src/analysis/modals/HailBatchModal.test.ts
+++ b/src/analysis/modals/HailBatchModal.test.ts
@@ -6,7 +6,7 @@ import { Apps } from 'src/libs/ajax/leonardo/Apps';
 import { asMockedFn } from 'src/testing/test-utils';
 import { defaultAzureWorkspace } from 'src/testing/workspace-fixtures';
 
-import { appToolLabels } from '../utils/tool-utils';
+import { appAccessScopes, appToolLabels } from '../utils/tool-utils';
 import { HailBatchModal, HailBatchModalProps } from './HailBatchModal';
 
 const onSuccess = jest.fn();
@@ -63,7 +63,8 @@ describe('HailBatchModal', () => {
     expect(createFunc).toHaveBeenCalledWith(
       expect.anything(),
       defaultAzureWorkspace.workspace.workspaceId,
-      appToolLabels.HAIL_BATCH
+      appToolLabels.HAIL_BATCH,
+      appAccessScopes.USER_PRIVATE
     );
     expect(onSuccess).toHaveBeenCalled();
   });

--- a/src/analysis/modals/HailBatchModal.ts
+++ b/src/analysis/modals/HailBatchModal.ts
@@ -3,7 +3,7 @@ import { Fragment, useState } from 'react';
 import { div, h } from 'react-hyperscript-helpers';
 import { WarningTitle } from 'src/analysis/modals/WarningTitle';
 import { generateAppName, getCurrentApp, getEnvMessageBasedOnStatus } from 'src/analysis/utils/app-utils';
-import { appToolLabels, appTools } from 'src/analysis/utils/tool-utils';
+import { appAccessScopes, appToolLabels, appTools } from 'src/analysis/utils/tool-utils';
 import { ButtonOutline, ButtonPrimary, Link, spinnerOverlay } from 'src/components/common';
 import { icon } from 'src/components/icons';
 import ModalDrawer from 'src/components/ModalDrawer';
@@ -48,7 +48,12 @@ export const HailBatchModal = withDisplayName('HailBatchModal')(
       Utils.withBusyState(setLoading),
       withErrorReportingInModal('Error creating Hail Batch', onError)
     )(async () => {
-      await Apps(signal).createAppV2(generateAppName(), workspaceId, appToolLabels.HAIL_BATCH);
+      await Apps(signal).createAppV2(
+        generateAppName(),
+        workspaceId,
+        appToolLabels.HAIL_BATCH,
+        appAccessScopes.USER_PRIVATE
+      );
       Metrics().captureEvent(Events.applicationCreate, {
         app: appTools.CROMWELL.label,
         ...extractWorkspaceDetails(workspace),

--- a/src/analysis/utils/tool-utils.ts
+++ b/src/analysis/utils/tool-utils.ts
@@ -9,7 +9,8 @@ import * as Utils from 'src/libs/utils';
 import { CloudProvider, cloudProviderTypes } from 'src/libs/workspace-utils';
 
 export type RuntimeToolLabel = 'Jupyter' | 'RStudio' | 'JupyterLab';
-export type AppToolLabel = 'GALAXY' | 'CROMWELL' | 'HAIL_BATCH' | 'WDS';
+export type AppToolLabel = 'GALAXY' | 'CROMWELL' | 'HAIL_BATCH' | 'WDS' | 'WORKFLOWS_APP' | 'CROMWELL_RUNNER_APP';
+export type AppAccessScope = 'USER_PRIVATE' | 'WORKSPACE_SHARED';
 export type LaunchableToolLabel = 'spark' | 'terminal' | 'RStudio' | 'JupyterLab';
 export type ToolLabel = RuntimeToolLabel | AppToolLabel;
 
@@ -32,6 +33,8 @@ export const toolLabelDisplays: Record<ToolLabel, string> = {
   JupyterLab: 'JupyterLab',
   GALAXY: 'Galaxy',
   CROMWELL: 'Cromwell',
+  WORKFLOWS_APP: 'Workflows',
+  CROMWELL_RUNNER_APP: 'Cromwell runner',
   HAIL_BATCH: 'Hail Batch',
   WDS: 'Workspace Data Service',
 };
@@ -39,8 +42,15 @@ export const toolLabelDisplays: Record<ToolLabel, string> = {
 export const appToolLabels: Record<AppToolLabel, AppToolLabel> = {
   GALAXY: 'GALAXY',
   CROMWELL: 'CROMWELL',
+  WORKFLOWS_APP: 'WORKFLOWS_APP',
+  CROMWELL_RUNNER_APP: 'CROMWELL_RUNNER_APP',
   HAIL_BATCH: 'HAIL_BATCH',
   WDS: 'WDS',
+};
+
+export const appAccessScopes: Record<AppAccessScope, AppAccessScope> = {
+  USER_PRIVATE: 'USER_PRIVATE',
+  WORKSPACE_SHARED: 'WORKSPACE_SHARED',
 };
 
 export const isAppToolLabel = (x: ToolLabel): x is AppToolLabel => x in appToolLabels;

--- a/src/analysis/utils/tool-utils.ts
+++ b/src/analysis/utils/tool-utils.ts
@@ -124,6 +124,10 @@ const Galaxy = { label: 'GALAXY' } as const satisfies AppTool;
 
 const Cromwell = { label: 'CROMWELL', isPauseUnsupported: true } as const satisfies AppTool;
 
+const Workflows = { label: 'WORKFLOWS_APP', isPauseUnsupported: true } as const satisfies AppTool;
+
+const CromwellRunner = { label: 'CROMWELL_RUNNER_APP', isPauseUnsupported: true } as const satisfies AppTool;
+
 const HailBatch = { label: 'HAIL_BATCH', isPauseUnsupported: true } as const satisfies AppTool;
 
 const Wds = { label: 'WDS', isPauseUnsupported: true } as const satisfies AppTool;
@@ -131,6 +135,8 @@ const Wds = { label: 'WDS', isPauseUnsupported: true } as const satisfies AppToo
 export const appTools: Record<AppToolLabel, AppTool> = {
   GALAXY: Galaxy,
   CROMWELL: Cromwell,
+  WORKFLOWS_APP: Workflows,
+  CROMWELL_RUNNER_APP: CromwellRunner,
   HAIL_BATCH: HailBatch,
   WDS: Wds,
 };

--- a/src/libs/ajax/leonardo/Apps.ts
+++ b/src/libs/ajax/leonardo/Apps.ts
@@ -1,6 +1,7 @@
 import _ from 'lodash/fp';
 import * as qs from 'qs';
 import { AppToolLabel } from 'src/analysis/utils/tool-utils';
+import { AppAccessScope } from 'src/analysis/utils/tool-utils';
 import { appIdentifier, authOpts, fetchLeo, jsonBody } from 'src/libs/ajax/ajax-common';
 import { CreateAppV1Request, GetAppResponse, ListAppResponse } from 'src/libs/ajax/leonardo/models/app-models';
 import { LeoResourceLabels } from 'src/libs/ajax/leonardo/models/core-models';
@@ -85,9 +86,15 @@ export const Apps = (signal) => ({
     );
     return res.json();
   },
-  createAppV2: (appName: string, workspaceId: string, appType: AppToolLabel): Promise<void> => {
+  createAppV2: (
+    appName: string,
+    workspaceId: string,
+    appType: AppToolLabel,
+    accessScope: AppAccessScope
+  ): Promise<void> => {
     const body = {
       appType,
+      accessScope,
       labels: {
         saturnAutoCreated: 'true',
       },

--- a/src/workflows-app/SubmitWorkflow.js
+++ b/src/workflows-app/SubmitWorkflow.js
@@ -131,12 +131,7 @@ export const SubmitWorkflow = wrapWorkflowsPage({ name: 'SubmitWorkflow' })(
             appAccessScopes.USER_PRIVATE
           );
         } else {
-          await Ajax().Apps.createAppV2(
-            generateAppName(),
-            workspace.workspace.workspaceId,
-            appToolLabels.CROMWELL,
-            appAccessScopes.USER_PRIVATE
-          );
+          await Ajax().Apps.createAppV2(generateAppName(), workspace.workspace.workspaceId, appToolLabels.CROMWELL, appAccessScopes.USER_PRIVATE);
         }
         await Ajax(signal).Metrics.captureEvent(Events.applicationCreate, {
           app: appTools.CROMWELL.label,

--- a/src/workflows-app/SubmitWorkflow.js
+++ b/src/workflows-app/SubmitWorkflow.js
@@ -119,13 +119,13 @@ export const SubmitWorkflow = wrapWorkflowsPage({ name: 'SubmitWorkflow' })(
         setCreating(true);
         if (isFeaturePreviewEnabled(ENABLE_AZURE_COLLABORATIVE_WORKFLOWS)) {
           await Ajax().Apps.createAppV2(
-            Utils.generateAppName(),
+            generateAppName(),
             workspace.workspace.workspaceId,
             appToolLabels.WORKFLOWS_APP,
             appAccessScopes.WORKSPACE_SHARED
           );
           await Ajax().Apps.createAppV2(
-            Utils.generateAppName(),
+            generateAppName(),
             workspace.workspace.workspaceId,
             appToolLabels.CROMWELL_RUNNER_APP,
             appAccessScopes.USER_PRIVATE


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WM-2169

## Summary of changes:
Modifies the "deploy Cromwell app" logic to deploy the new `WORKFLOWS` app instead, if the appropriate feature preview is checked.

### Why
- Early testing access of a not-yet-functional app type

