### PR TITLE
AJ-1284: Prefactoring for supporting `UPDATING` status in data tab

### DIFF
--- a/src/data/Data.js
+++ b/src/data/Data.js
@@ -747,7 +747,7 @@ export const WorkspaceData = _.flow(
           return '';
         })
         .catch((error) => {
-          setWdsTypes({ status: 'Error', state: 'Error resolving WDS app' });
+          setWdsProxyUrl({ status: 'Error', state: 'Error resolving WDS app' });
           reportError('Error resolving WDS app', error);
         });
     }, []);

--- a/src/data/Data.js
+++ b/src/data/Data.js
@@ -23,6 +23,7 @@ import { SnapshotInfo } from 'src/components/workspace-utils';
 import { Ajax } from 'src/libs/ajax';
 import { EntityServiceDataTableProvider } from 'src/libs/ajax/data-table-providers/EntityServiceDataTableProvider';
 import { resolveWdsApp, WdsDataTableProvider, wdsProviderName } from 'src/libs/ajax/data-table-providers/WdsDataTableProvider';
+import { appStatuses } from 'src/libs/ajax/leonardo/models/app-models';
 import colors from 'src/libs/colors';
 import { getConfig } from 'src/libs/config';
 import { dataTableVersionsPathRoot, useDataTableVersions } from 'src/libs/data-table-versions';
@@ -735,12 +736,12 @@ export const WorkspaceData = _.flow(
         .Apps.listAppsV2(workspaceId)
         .then((apps) => {
           const foundApp = resolveWdsApp(apps);
-          if (foundApp?.status === 'RUNNING') {
+          if (foundApp?.status === appStatuses.running.status) {
             const url = foundApp.proxyUrls.wds;
             setWdsProxyUrl({ status: 'Ready', state: url });
             return url;
           }
-          if (foundApp?.status === 'ERROR') {
+          if (foundApp?.status === appStatuses.error.status) {
             setWdsProxyUrl({ status: 'Error', state: 'WDS app is in ERROR state' });
           }
           return '';

--- a/src/data/Data.js
+++ b/src/data/Data.js
@@ -745,6 +745,10 @@ export const WorkspaceData = _.flow(
             setWdsProxyUrl({ status: 'Error', state: 'WDS app is in ERROR state' });
           }
           return '';
+        })
+        .catch((error) => {
+          setWdsTypes({ status: 'Error', state: 'Error resolving WDS app' });
+          reportError('Error resolving WDS app', error);
         });
     }, []);
 
@@ -755,28 +759,25 @@ export const WorkspaceData = _.flow(
           .then((typesResult) => {
             setWdsTypes({ status: 'Ready', state: typesResult });
           })
-          .catch((err) => {
-            setWdsTypes({ status: 'Error', state: err });
+          .catch((error) => {
+            setWdsTypes({ status: 'Error', state: 'Error loading WDS schema' });
+            reportError('Error loading WDS schema', error);
           });
       },
       [signal]
     );
 
     const loadWdsData = useCallback(async () => {
-      try {
-        // Try to load the proxy URL
-        if (!wdsProxyUrl || wdsProxyUrl.status !== 'Ready') {
-          const wdsUrl = await loadWdsUrl(workspaceId);
-          if (wdsUrl) {
-            await loadWdsTypes(wdsUrl, workspaceId);
-          }
-        } else {
-          // If we have the proxy URL try to load the WDS types
-          const proxyUrl = wdsProxyUrl.state;
-          await loadWdsTypes(proxyUrl, workspaceId);
+      // Try to load the proxy URL
+      if (!wdsProxyUrl || wdsProxyUrl.status !== 'Ready') {
+        const wdsUrl = await loadWdsUrl(workspaceId);
+        if (wdsUrl) {
+          await loadWdsTypes(wdsUrl, workspaceId);
         }
-      } catch (error) {
-        console.log(`Error thrown loading WDS schema: ${error}`); // eslint-disable-line no-console
+      } else {
+        // If we have the proxy URL try to load the WDS types
+        const proxyUrl = wdsProxyUrl.state;
+        await loadWdsTypes(proxyUrl, workspaceId);
       }
     }, [loadWdsUrl, loadWdsTypes, workspaceId, wdsProxyUrl]);
 


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/AJ-1284

## Summary of changes:
In prep for making the UI display differently when a WDS app is in `UPDATING` state, this PR introduces two commits (which I recommend reviewing individually for easier scanning):
* Use `appStatuses` enum instead of hardcoded strings for `LeoAppStatus`
* Do a better job surfacing unhandled errors to the customer using `reportError`

### Testing strategy
- [x] New unit tests.

![image](https://github.com/DataBiosphere/terra-ui/assets/111856/d093e94b-daf3-43cb-9eef-ea12273ce849)