### PR TITLE
[UIE-128] Move generateThingName functions out of utils

### DIFF
--- a/src/analysis/_testData/testData.ts
+++ b/src/analysis/_testData/testData.ts
@@ -4,7 +4,7 @@ import {
   defaultGcePersistentDiskSize,
   defaultPersistentDiskType,
 } from 'src/analysis/utils/disk-utils';
-import { defaultGceMachineType, defaultLocation } from 'src/analysis/utils/runtime-utils';
+import { defaultGceMachineType, defaultLocation, generateRuntimeName } from 'src/analysis/utils/runtime-utils';
 import { runtimeToolLabels, tools } from 'src/analysis/utils/tool-utils';
 import { App, ListAppResponse } from 'src/libs/ajax/leonardo/models/app-models';
 import { PersistentDisk } from 'src/libs/ajax/leonardo/models/disk-models';
@@ -343,7 +343,7 @@ export const generateTestListGoogleRuntime = (overrides: Partial<ListRuntimeItem
 
 export const getGoogleDataProcRuntime = ({
   workspace = defaultGoogleWorkspace,
-  runtimeName = Utils.generateRuntimeName(),
+  runtimeName = generateRuntimeName(),
   status = runtimeStatuses.running.leoLabel,
   tool = tools.HAIL_BATCH.label,
   runtimeConfig = getRuntimeConfig(),
@@ -387,7 +387,7 @@ export const getGoogleDataProcRuntime = ({
 // Use this if you want a shortcut to override nested fields. Otherwise use `generateTestGoogleGetRuntime`
 export const getGoogleRuntime = ({
   workspace = defaultGoogleWorkspace,
-  runtimeName = Utils.generateRuntimeName(),
+  runtimeName = generateRuntimeName(),
   status = runtimeStatuses.running.leoLabel,
   tool = tools.Jupyter,
   runtimeConfig = getJupyterRuntimeConfig(),
@@ -477,7 +477,7 @@ export const getGoogleRuntime = ({
 // Use this if you want a shortcut to override nested fields. Otherwise use `generateTestListGoogleRuntime`
 export const listGoogleRuntime = ({
   workspace = defaultGoogleWorkspace,
-  runtimeName = Utils.generateRuntimeName(),
+  runtimeName = generateRuntimeName(),
   status = runtimeStatuses.running.leoLabel,
   tool = tools.Jupyter,
   runtimeConfig = getJupyterRuntimeConfig(),

--- a/src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeModal.js
+++ b/src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeModal.js
@@ -6,9 +6,11 @@ import { AzurePersistentDiskSection } from 'src/analysis/modals/ComputeModal/Azu
 import { DeleteEnvironment } from 'src/analysis/modals/DeleteEnvironment';
 import { computeStyles } from 'src/analysis/modals/modalStyles';
 import { getAzureComputeCostEstimate, getAzureDiskCostEstimate } from 'src/analysis/utils/cost-utils';
+import { generatePersistentDiskName } from 'src/analysis/utils/disk-utils';
 import {
   autopauseDisabledValue,
   defaultAutopauseThreshold,
+  generateRuntimeName,
   getAutopauseThreshold,
   getIsRuntimeBusy,
   isAutopauseEnabled,
@@ -341,12 +343,12 @@ export const AzureComputeModalBase = ({
         () => {
           const disk = {
             size: computeConfig.persistentDiskSize,
-            name: Utils.generatePersistentDiskName(),
+            name: generatePersistentDiskName(),
             labels: { saturnWorkspaceNamespace: namespace, saturnWorkspaceName: workspaceName },
           };
 
           return Ajax()
-            .Runtimes.runtimeV2(workspaceId, Utils.generateRuntimeName())
+            .Runtimes.runtimeV2(workspaceId, generateRuntimeName())
             .create(
               {
                 autopauseThreshold: computeConfig.autopauseThreshold,

--- a/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal.js
+++ b/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal.js
@@ -16,6 +16,7 @@ import {
   defaultGceBootDiskSize,
   defaultGcePersistentDiskSize,
   defaultPersistentDiskType,
+  generatePersistentDiskName,
   pdTypeFromDiskType,
 } from 'src/analysis/utils/disk-utils';
 import { cloudServices, isMachineTypeSmaller, machineTypes } from 'src/analysis/utils/gce-machines';
@@ -31,6 +32,7 @@ import {
   defaultNumGpus,
   displayNameForGpuType,
   findMachineType,
+  generateRuntimeName,
   getAutopauseThreshold,
   getDefaultMachineType,
   getImageUrlFromRuntime,
@@ -374,7 +376,7 @@ export const GcpComputeModalBase = ({
             Utils.DEFAULT,
             () => ({
               persistentDisk: {
-                name: Utils.generatePersistentDiskName(),
+                name: generatePersistentDiskName(),
                 size: desiredPersistentDisk.size,
                 diskType: desiredPersistentDisk.diskType,
                 labels: { saturnWorkspaceNamespace: namespace, saturnWorkspaceName: name },
@@ -389,7 +391,7 @@ export const GcpComputeModalBase = ({
 
         const createRuntimeConfig = { ...runtimeConfig, ...diskConfig };
         await Ajax()
-          .Runtimes.runtime(googleProject, Utils.generateRuntimeName())
+          .Runtimes.runtime(googleProject, generateRuntimeName())
           .create({
             runtimeConfig: createRuntimeConfig,
             autopauseThreshold: computeConfig.autopauseThreshold,

--- a/src/analysis/modals/CromwellModal.js
+++ b/src/analysis/modals/CromwellModal.js
@@ -1,8 +1,8 @@
 import _ from 'lodash/fp';
 import { Fragment, useState } from 'react';
 import { div, h } from 'react-hyperscript-helpers';
-import { getCurrentApp, getEnvMessageBasedOnStatus } from 'src/analysis/utils/app-utils';
-import { getCurrentAppDataDisk } from 'src/analysis/utils/disk-utils';
+import { generateAppName, getCurrentApp, getEnvMessageBasedOnStatus } from 'src/analysis/utils/app-utils';
+import { generatePersistentDiskName, getCurrentAppDataDisk } from 'src/analysis/utils/disk-utils';
 import { appToolLabels, appTools } from 'src/analysis/utils/tool-utils';
 import { ButtonPrimary, spinnerOverlay } from 'src/components/common';
 import { withModalDrawer } from 'src/components/ModalDrawer';
@@ -50,13 +50,13 @@ export const CromwellModalBase = withDisplayName('CromwellModal')(
       withErrorReportingInModal('Error creating Cromwell', onError)
     )(async () => {
       if (isAzureWorkspace(workspace)) {
-        await Ajax().Apps.createAppV2(Utils.generateAppName(), workspace.workspace.workspaceId, appToolLabels.CROMWELL);
+        await Ajax().Apps.createAppV2(generateAppName(), workspace.workspace.workspaceId, appToolLabels.CROMWELL);
       } else {
         await Ajax()
-          .Apps.app(googleProject, Utils.generateAppName())
+          .Apps.app(googleProject, generateAppName())
           .create({
             defaultKubernetesRuntimeConfig,
-            diskName: currentDataDisk ? currentDataDisk.name : Utils.generatePersistentDiskName(),
+            diskName: currentDataDisk ? currentDataDisk.name : generatePersistentDiskName(),
             diskSize: defaultDataDiskSize,
             appType: appTools.CROMWELL.label,
             namespace,

--- a/src/analysis/modals/GalaxyModal.js
+++ b/src/analysis/modals/GalaxyModal.js
@@ -3,9 +3,9 @@ import { Fragment, useState } from 'react';
 import { div, h, label, p, span } from 'react-hyperscript-helpers';
 import { WarningTitle } from 'src/analysis/modals/WarningTitle';
 import { GalaxyLaunchButton, GalaxyWarning, RadioBlock, SaveFilesHelpGalaxy } from 'src/analysis/runtime-common-components';
-import { getCurrentApp, getEnvMessageBasedOnStatus } from 'src/analysis/utils/app-utils';
+import { generateAppName, getCurrentApp, getEnvMessageBasedOnStatus } from 'src/analysis/utils/app-utils';
 import { getGalaxyComputeCost, getGalaxyDiskCost } from 'src/analysis/utils/cost-utils';
-import { getCurrentAppDataDisk, getCurrentAttachedDataDisk } from 'src/analysis/utils/disk-utils';
+import { generatePersistentDiskName, getCurrentAppDataDisk, getCurrentAttachedDataDisk } from 'src/analysis/utils/disk-utils';
 import { machineTypes } from 'src/analysis/utils/gce-machines';
 import { findMachineType } from 'src/analysis/utils/runtime-utils';
 import { appTools } from 'src/analysis/utils/tool-utils';
@@ -65,10 +65,10 @@ export const GalaxyModalBase = withDisplayName('GalaxyModal')(
       withErrorReportingInModal('Error creating app', onError)
     )(async () => {
       await Ajax()
-        .Apps.app(googleProject, Utils.generateAppName())
+        .Apps.app(googleProject, generateAppName())
         .create({
           kubernetesRuntimeConfig,
-          diskName: currentDataDisk ? currentDataDisk.name : Utils.generatePersistentDiskName(),
+          diskName: currentDataDisk ? currentDataDisk.name : generatePersistentDiskName(),
           diskSize: dataDisk.size,
           diskType: dataDisk.diskType.value,
           appType: appTools.GALAXY.label,

--- a/src/analysis/modals/HailBatchModal.ts
+++ b/src/analysis/modals/HailBatchModal.ts
@@ -2,7 +2,7 @@ import _ from 'lodash/fp';
 import { Fragment, useState } from 'react';
 import { div, h } from 'react-hyperscript-helpers';
 import { WarningTitle } from 'src/analysis/modals/WarningTitle';
-import { getCurrentApp, getEnvMessageBasedOnStatus } from 'src/analysis/utils/app-utils';
+import { generateAppName, getCurrentApp, getEnvMessageBasedOnStatus } from 'src/analysis/utils/app-utils';
 import { appToolLabels, appTools } from 'src/analysis/utils/tool-utils';
 import { ButtonOutline, ButtonPrimary, Link, spinnerOverlay } from 'src/components/common';
 import { icon } from 'src/components/icons';
@@ -48,7 +48,7 @@ export const HailBatchModal = withDisplayName('HailBatchModal')(
       Utils.withBusyState(setLoading),
       withErrorReportingInModal('Error creating Hail Batch', onError)
     )(async () => {
-      await Apps(signal).createAppV2(Utils.generateAppName(), workspaceId, appToolLabels.HAIL_BATCH);
+      await Apps(signal).createAppV2(generateAppName(), workspaceId, appToolLabels.HAIL_BATCH);
       Metrics().captureEvent(Events.applicationCreate, {
         app: appTools.CROMWELL.label,
         ...extractWorkspaceDetails(workspace),

--- a/src/analysis/utils/app-utils.ts
+++ b/src/analysis/utils/app-utils.ts
@@ -6,6 +6,7 @@ import { getConfig } from 'src/libs/config';
 import { getUser } from 'src/libs/state';
 import * as Utils from 'src/libs/utils';
 import { CloudProvider, cloudProviderTypes, WorkspaceInfo } from 'src/libs/workspace-utils';
+import { v4 as uuid } from 'uuid';
 
 const getCurrentAppExcludingStatuses = (
   appType: AppToolLabel,
@@ -108,3 +109,5 @@ export const getEnvMessageBasedOnStatus = (app: App | undefined): string | undef
   };
   return statusMessages[app.status];
 };
+
+export const generateAppName = () => `terra-app-${uuid()}`;

--- a/src/analysis/utils/disk-utils.ts
+++ b/src/analysis/utils/disk-utils.ts
@@ -14,6 +14,7 @@ import {
 } from 'src/libs/ajax/leonardo/models/disk-models';
 import { Runtime } from 'src/libs/ajax/leonardo/models/runtime-models';
 import * as Utils from 'src/libs/utils';
+import { v4 as uuid } from 'uuid';
 
 export const pdTypeFromDiskType = (type: GoogleDiskType): GooglePdType =>
   Utils.switchCase(
@@ -152,3 +153,5 @@ export const isCurrentGalaxyDiskDetaching = (apps: App[]): boolean => {
   const currentGalaxyApp = getCurrentAppIncludingDeleting(appTools.GALAXY.label, apps);
   return !!currentGalaxyApp && _.includes(currentGalaxyApp.status, ['DELETING', 'PREDELETING']);
 };
+
+export const generatePersistentDiskName = () => `saturn-pd-${uuid()}`;

--- a/src/analysis/utils/runtime-utils.ts
+++ b/src/analysis/utils/runtime-utils.ts
@@ -27,6 +27,7 @@ import {
 } from 'src/libs/ajax/leonardo/models/runtime-models';
 import * as Utils from 'src/libs/utils';
 import { CloudProvider } from 'src/libs/workspace-utils';
+import { v4 as uuid } from 'uuid';
 
 export const runtimeTypes = {
   gceVm: 'Standard VM',
@@ -205,3 +206,5 @@ export const isGcpContext = (cloudContext: CloudContext): boolean =>
   cloudContext.cloudProvider === cloudProviders.gcp.label;
 export const isAzureContext = (cloudContext: CloudContext): boolean =>
   cloudContext.cloudProvider === cloudProviders.azure.label;
+
+export const generateRuntimeName = () => `saturn-${uuid()}`;

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -5,7 +5,6 @@ import _ from 'lodash/fp';
 import * as qs from 'qs';
 import { div, span } from 'react-hyperscript-helpers';
 import { canWrite } from 'src/libs/workspace-utils';
-import { v4 as uuid } from 'uuid';
 
 export { cond, DEFAULT, switchCase } from '@terra-ui-packages/core-utils';
 export { canRead, canWrite, isOwner } from 'src/libs/workspace-utils';
@@ -132,12 +131,6 @@ export const onNextTick = (fn, ...args) => setTimeout(() => fn(...args), 0);
 export const abandonedPromise = () => {
   return new Promise(() => {});
 };
-
-export const generateRuntimeName = () => `saturn-${uuid()}`;
-
-export const generateAppName = () => `terra-app-${uuid()}`;
-
-export const generatePersistentDiskName = () => `saturn-pd-${uuid()}`;
 
 export const waitOneTick = () => new Promise(setImmediate);
 

--- a/src/workflows-app/SubmitWorkflow.js
+++ b/src/workflows-app/SubmitWorkflow.js
@@ -1,6 +1,6 @@
 import { Fragment, useCallback, useState } from 'react';
 import { div, h, h2 } from 'react-hyperscript-helpers';
-import { doesWorkspaceSupportCromwellAppForUser, getCurrentApp, getIsAppBusy } from 'src/analysis/utils/app-utils';
+import { doesWorkspaceSupportCromwellAppForUser, generateAppName, getCurrentApp, getIsAppBusy } from 'src/analysis/utils/app-utils';
 import { appToolLabels, appTools } from 'src/analysis/utils/tool-utils';
 import { ButtonOutline, Clickable } from 'src/components/common';
 import { centeredSpinner, icon } from 'src/components/icons';
@@ -114,7 +114,7 @@ export const SubmitWorkflow = wrapWorkflowsPage({ name: 'SubmitWorkflow' })(
     const createWorkflowsApp = Utils.withBusyState(setCreating, async () => {
       try {
         setCreating(true);
-        await Ajax(signal).Apps.createAppV2(Utils.generateAppName(), workspace.workspace.workspaceId, appToolLabels.CROMWELL);
+        await Ajax(signal).Apps.createAppV2(generateAppName(), workspace.workspace.workspaceId, appToolLabels.CROMWELL);
         await Ajax(signal).Metrics.captureEvent(Events.applicationCreate, {
           app: appTools.CROMWELL.label,
           ...extractWorkspaceDetails(workspace),


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/UIE-128

libs/utils contains many unrelated concerns. This moves functions to generate names for apps/persistent disks/runtimes into the app/persistent disk/runtime utils modules.