### PR TITLE
[UIE-128] Move workflowStatuses to SubmissionDetails

### DIFF
--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -63,17 +63,6 @@ export const formatUSD = (v) =>
 
 export const formatNumber = new Intl.NumberFormat('en-US').format;
 
-export const workflowStatuses = [
-  'Queued',
-  'Launching',
-  'Submitted',
-  'Running',
-  'Aborting',
-  'Succeeded',
-  'Failed',
-  'Aborted',
-];
-
 export const toIndexPairs = <T>(obj: T[]): [number, T][] =>
   _.flow(
     _.toPairs,

--- a/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
+++ b/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
@@ -35,6 +35,8 @@ import { downloadIO, downloadWorkflows, ioTask, ioVariable } from 'src/libs/work
 import UpdateUserCommentModal from 'src/pages/workspaces/workspace/jobHistory/UpdateUserCommentModal';
 import { wrapWorkspace } from 'src/pages/workspaces/workspace/WorkspaceContainer';
 
+const workflowStatuses = ['Queued', 'Launching', 'Submitted', 'Running', 'Aborting', 'Succeeded', 'Failed', 'Aborted'];
+
 // Note: This 'deletionDelayYears' value should reflect the current 'deletion-delay' value configured for PROD in firecloud-develop's
 // 'cromwell.conf.ctmpl' file:
 const deletionDelayYears = 1;
@@ -109,7 +111,7 @@ const SubmissionWorkflowsTable = ({ workspace, submission }) => {
           'aria-label': 'Completion status',
           value: statusFilter,
           onChange: (data) => setStatusFilter(_.map('value', data)),
-          options: Utils.workflowStatuses,
+          options: workflowStatuses,
         }),
       ]),
       h(Link, { onClick: () => downloadWorkflows(filteredWorkflows, submissionId) }, ['Download TSV']),


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/UIE-128

libs/utils contains many unrelated concerns. This moves the `workflowStatuses` constant from libs/utils to SubmissionDetails, which is the only place it's used.