### PR TITLE
[UIE-120] Move readFileAsText into core-utils

### DIFF
--- a/packages/core-utils/src/index.ts
+++ b/packages/core-utils/src/index.ts
@@ -1,3 +1,4 @@
+export * from './io-utils';
 export * from './logic-utils';
 export * from './nav/nav-utils';
 export * from './state-utils';

--- a/packages/core-utils/src/io-utils.test.ts
+++ b/packages/core-utils/src/io-utils.test.ts
@@ -11,4 +11,29 @@ describe('readFileAsText', () => {
     // Assert
     expect(content).toEqual('Hello world');
   });
+
+  it('throws an error if read fails', async () => {
+    // Arrange
+    class MockFileReader {
+      onError: ((err: any) => void) | null = null;
+
+      readAsText() {
+        this.onError?.(new Error('Something went wrong'));
+      }
+    }
+
+    const FileReader = window.FileReader;
+    window.FileReader = MockFileReader as any;
+
+    const file = new File(['Hello world'], 'test-file.txt');
+
+    // Act
+    const result = readFileAsText(file);
+
+    // Assert
+    expect(result).rejects.toEqual(new Error('Something went wrong'));
+
+    // Cleanup
+    window.FileReader = FileReader;
+  });
 });

--- a/packages/core-utils/src/io-utils.test.ts
+++ b/packages/core-utils/src/io-utils.test.ts
@@ -1,0 +1,14 @@
+import { readFileAsText } from './io-utils';
+
+describe('readFileAsText', () => {
+  it('returns file contents', async () => {
+    // Arrange
+    const file = new File(['Hello world'], 'test-file.txt');
+
+    // Act
+    const content = await readFileAsText(file);
+
+    // Assert
+    expect(content).toEqual('Hello world');
+  });
+});

--- a/packages/core-utils/src/io-utils.ts
+++ b/packages/core-utils/src/io-utils.ts
@@ -1,0 +1,9 @@
+export const readFileAsText = (file: File): Promise<string | null> => {
+  const reader = new FileReader();
+  return new Promise((resolve, reject) => {
+    // reader.result is a string here because we call reader.readAsText
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = reject;
+    reader.readAsText(file);
+  });
+};

--- a/src/data/data-table/shared/EntityUploader.js
+++ b/src/data/data-table/shared/EntityUploader.js
@@ -1,3 +1,4 @@
+import { readFileAsText } from '@terra-ui-packages/core-utils';
 import _ from 'lodash/fp';
 import { Fragment, useState } from 'react';
 import { div, h, p, span } from 'react-hyperscript-helpers';
@@ -108,7 +109,7 @@ export const EntityUploader = ({ onSuccess, onDismiss, namespace, name, entityTy
       activeStyle: { cursor: 'copy' },
       onDropAccepted: async ([file]) => {
         setFile(file);
-        const fileContentPreview = await Utils.readFileAsText(file.slice(0, 1000));
+        const fileContentPreview = await readFileAsText(file.slice(0, 1000));
         setFileContents(fileContentPreview);
         if (!recordType) {
           setRecordType(getSuggestedTableName(fileContentPreview) || '');

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -195,15 +195,6 @@ export const summarizeErrors = (errors) => {
   }
 };
 
-export const readFileAsText = (file) => {
-  const reader = new FileReader();
-  return new Promise((resolve, reject) => {
-    reader.onload = () => resolve(reader.result);
-    reader.onerror = reject;
-    reader.readAsText(file);
-  });
-};
-
 /**
  * Returns true if a value can't be coerced into a number.
  */

--- a/src/pages/Upload.js
+++ b/src/pages/Upload.js
@@ -1,3 +1,4 @@
+import { readFileAsText } from '@terra-ui-packages/core-utils';
 import _ from 'lodash/fp';
 import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
 import { code, div, h, h2, h3, li, p, span, strong, ul } from 'react-hyperscript-helpers';
@@ -604,7 +605,7 @@ const MetadataUploadPanel = ({
 
     try {
       // Read the file contents
-      const text = await Utils.readFileAsText(file);
+      const text = await readFileAsText(file);
 
       // Split rows by newlines and columns by tabs
       const rows = _.flow(

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -1,3 +1,4 @@
+import { readFileAsText } from '@terra-ui-packages/core-utils';
 import _ from 'lodash/fp';
 import { Component, Fragment, useEffect, useState } from 'react';
 import { b, div, h, label, span } from 'react-hyperscript-helpers';
@@ -1217,7 +1218,7 @@ const WorkflowView = _.flow(
 
     async uploadJson(key, file) {
       try {
-        const rawUpdates = JSON.parse(await Utils.readFileAsText(file));
+        const rawUpdates = JSON.parse(await readFileAsText(file));
         const updates = _.mapValues((v) => (_.isString(v) && v.match(/\${(.*)}/) ? v.replace(/\${(.*)}/, (_, match) => match) : JSON.stringify(v)))(
           rawUpdates
         );


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/UIE-120

Working on pulling more of libs/utils into the core-utils package. This moves `readFileAsText` into core-utils and adds a test.