### PR TITLE
[UIE-120] Use delay function from core-utils package

### DIFF
--- a/packages/core-utils/src/timer-utils.test.ts
+++ b/packages/core-utils/src/timer-utils.test.ts
@@ -1,0 +1,33 @@
+import { delay } from './timer-utils';
+
+describe('delay', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns a Promise that resolves after the given delay', async () => {
+    // Arrange
+    const resolved = jest.fn();
+
+    // Act
+    delay(2000).then(resolved);
+    const isResolvedImmediately = resolved.mock.calls.length > 0;
+
+    jest.advanceTimersByTime(1000);
+    await Promise.resolve();
+    const isResolvedAfterOneSecond = resolved.mock.calls.length > 0;
+
+    jest.advanceTimersByTime(1000);
+    await Promise.resolve();
+    const isResolvedAfterTwoSeconds = resolved.mock.calls.length > 0;
+
+    // Assert
+    expect(isResolvedImmediately).toBe(false);
+    expect(isResolvedAfterOneSecond).toBe(false);
+    expect(isResolvedAfterTwoSeconds).toBe(true);
+  });
+});

--- a/packages/core-utils/src/timer-utils.ts
+++ b/packages/core-utils/src/timer-utils.ts
@@ -1,3 +1,7 @@
+/**
+ * Returns a Promise that resolves in `ms` milliseconds.
+ * @param ms - Time to delay in milliseconds.
+ */
 export const delay = (ms: number): Promise<void> => {
   return new Promise((resolve) => setTimeout(resolve, ms));
 };

--- a/src/analysis/runtime-common-components.js
+++ b/src/analysis/runtime-common-components.js
@@ -1,3 +1,4 @@
+import { delay } from '@terra-ui-packages/core-utils';
 import _ from 'lodash/fp';
 import { Fragment, useEffect, useState } from 'react';
 import { b, div, h, input, label, p } from 'react-hyperscript-helpers';
@@ -69,7 +70,7 @@ export function RuntimeKicker({ runtime, refreshRuntimes }) {
         return;
       }
       if (currentRuntime === undefined || status === 'Stopping') {
-        await Utils.delay(500);
+        await delay(500);
       } else {
         return;
       }

--- a/src/components/ClipboardButton.js
+++ b/src/components/ClipboardButton.js
@@ -1,3 +1,4 @@
+import { delay } from '@terra-ui-packages/core-utils';
 import * as clipboard from 'clipboard-polyfill/text';
 import _ from 'lodash/fp';
 import { useState } from 'react';
@@ -20,7 +21,7 @@ export const ClipboardButton = ({ text, onClick, children, ...props }) => {
       )(async (e) => {
         onClick?.(e);
         await clipboard.writeText(text);
-        await Utils.delay(1500);
+        await delay(1500);
       }),
     },
     [children, icon(copied ? 'check' : 'copy-to-clipboard', !!children && { style: { marginLeft: '0.5rem' } })]

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -1,3 +1,4 @@
+import { delay } from '@terra-ui-packages/core-utils';
 import _ from 'lodash/fp';
 import PropTypes from 'prop-types';
 import { useRef } from 'react';
@@ -82,7 +83,7 @@ function Modal({
         const nodeToFocus = modalNode.current.contains(document.activeElement) ? document.activeElement : modalNode.current;
         // Add the focus update to the end of the event queue
         // Per react-focus-lock: https://github.com/theKashey/react-focus-lock#unmounting-and-focus-management
-        await Utils.delay(0);
+        await delay(0);
         previouslyFocusedNode.current = modalNode.current.contains(document.activeElement) ? previouslyFocusedNode.current : document.activeElement;
         nodeToFocus.focus();
       },

--- a/src/libs/react-utils.ts
+++ b/src/libs/react-utils.ts
@@ -1,4 +1,4 @@
-import { Atom, safeCurry } from '@terra-ui-packages/core-utils';
+import { Atom, delay, safeCurry } from '@terra-ui-packages/core-utils';
 import _ from 'lodash/fp';
 import {
   EffectCallback,
@@ -11,7 +11,7 @@ import {
   useState,
 } from 'react';
 import { h } from 'react-hyperscript-helpers';
-import { delay, pollWithCancellation } from 'src/libs/utils';
+import { pollWithCancellation } from 'src/libs/utils';
 
 /**
  * Performs the given effect, but only on component mount.

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -1,4 +1,4 @@
-import { AnyPromiseFn, cond, GenericPromiseFn, safeCurry } from '@terra-ui-packages/core-utils';
+import { AnyPromiseFn, cond, delay, GenericPromiseFn, safeCurry } from '@terra-ui-packages/core-utils';
 import { formatDuration, intervalToDuration, isToday, isYesterday } from 'date-fns';
 import { differenceInCalendarMonths, differenceInSeconds, parseJSON } from 'date-fns/fp';
 import _ from 'lodash/fp';
@@ -119,10 +119,6 @@ export const memoizeAsync = (asyncFn, { keyFn = _.identity, expires = Infinity }
     });
     return value;
   };
-};
-
-export const delay = (ms) => {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 };
 
 export const withDelay = _.curry((ms, wrappedFn) => async (...args) => {

--- a/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
+++ b/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
@@ -1,3 +1,4 @@
+import { delay } from '@terra-ui-packages/core-utils';
 import { differenceInDays, parseISO } from 'date-fns/fp';
 import _ from 'lodash/fp';
 import { Fragment, useEffect, useState } from 'react';
@@ -361,7 +362,7 @@ const SubmissionDetails = _.flow(
         _.some(({ status }) => _.includes(collapseStatus(status), [statusType.running, statusType.submitted]), submission.workflows)
       ) {
         if (!_.isEmpty(submission)) {
-          await Utils.delay(60000);
+          await delay(60000);
         }
         const sub = _.update(
           ['workflows'],

--- a/src/pages/workspaces/workspace/workflows/FailureRerunner.js
+++ b/src/pages/workspaces/workspace/workflows/FailureRerunner.js
@@ -1,3 +1,4 @@
+import { delay } from '@terra-ui-packages/core-utils';
 import _ from 'lodash/fp';
 import { div, h } from 'react-hyperscript-helpers';
 import { icon, spinner } from 'src/components/icons';
@@ -66,7 +67,7 @@ export const rerunFailures = async ({
     onDone();
     Ajax().Metrics.captureEvent(Events.workflowRerun, { ...eventData, success: true });
 
-    await Utils.delay(2000);
+    await delay(2000);
   } catch (error) {
     Ajax().Metrics.captureEvent(Events.workflowRerun, { ...eventData, success: false });
     reportError('Error rerunning failed workflows', error);

--- a/src/workflows-app/components/StructBuilder.test.js
+++ b/src/workflows-app/components/StructBuilder.test.js
@@ -1,7 +1,7 @@
+import { delay } from '@terra-ui-packages/core-utils';
 import { act, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { h } from 'react-hyperscript-helpers';
-import { delay } from 'src/libs/utils';
 import { buildStructBreadcrumbs, StructBuilder, StructBuilderModal } from 'src/workflows-app/components/StructBuilder';
 
 describe('unit tests', () => {


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/UIE-120

Continuing to move parts of libs/utils into the core-utils package. core-utils already contains a copy of the `delay` function. This PR adds a test for it and replaces all uses of `Utils.delay` with the `delay` from the core-utils package.