### PR TITLE
Add T2T reference

### DIFF
--- a/src/data/reference-data/references.ts
+++ b/src/data/reference-data/references.ts
@@ -10,7 +10,7 @@ export default {
     ref_sa: 'gs://gcp-public-data--broad-references/t2t/v2/chm13v2.0.maskedY.fasta.sa',
     par_bed: 'gs://gcp-public-data--broad-references/t2t/v2/chm13v2.0_PAR.bed'
   },
-  hg38Human: {
+  hg38: {
     axiomPoly_resource_vcf:
         'gs://gcp-public-data--broad-references/hg38/v0/Axiom_Exome_Plus.genotypes.all_populations.poly.hg38.vcf.gz',
     ref_fasta: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta',

--- a/src/data/reference-data/references.ts
+++ b/src/data/reference-data/references.ts
@@ -1,54 +1,24 @@
 export default {
-  b37Human: {
-    axiomPoly_resource_vcf:
-      'gs://gcp-public-data--broad-references/hg19/v0/Axiom_Exome_Plus.genotypes.all_populations.poly.vcf.gz',
-    ref_fasta: 'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta',
-    ref_dict: 'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.dict',
-    unpadded_intervals_file: 'gs://gatk-test-data/intervals/wgs_calling_regions.v1.list',
-    one_thousand_genomes_resource_vcf_index:
-      'gs://gcp-public-data--broad-references/hg19/v0/1000G_phase1.snps.high_confidence.b37.vcf.gz.tbi',
-    ref_alt: 'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.alt',
-    dbsnp_vcf: 'gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz',
-    ref_ann: 'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.64.ann',
-    ref_name: 'b37',
-    omni_resource_vcf: 'gs://gcp-public-data--broad-references/hg19/v0/1000G_omni2.5.b37.vcf.gz',
-    known_indels_sites_indices: [
-      'gs://gcp-public-data--broad-references/hg19/v0/Mills_and_1000G_gold_standard.indels.b37.vcf.gz.tbi',
-      'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.known_indels_20120518.vcf.idx',
-    ],
-    one_thousand_genomes_resource_vcf:
-      'gs://gcp-public-data--broad-references/hg19/v0/1000G_phase1.snps.high_confidence.b37.vcf.gz',
-    hapmap_resource_vcf: 'gs://gcp-public-data--broad-references/hg19/v0/hapmap_3.3.b37.vcf.gz',
-    scattered_calling_intervals_list: 'gs://gatk-test-data/intervals/b37_wgs_scattered_calling_intervals.txt',
-    ref_sa: 'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.64.sa',
-    mills_resource_vcf:
-      'gs://gcp-public-data--broad-references/hg19/v0/Mills_and_1000G_gold_standard.indels.b37.sites.vcf',
-    ref_amb: 'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.64.amb',
-    eval_interval_list: 'gs://gcp-public-data--broad-references/hg19/v0/wgs_evaluation_regions.v1.interval_list',
-    axiomPoly_resource_vcf_index:
-      'gs://gcp-public-data--broad-references/hg19/v0/Axiom_Exome_Plus.genotypes.all_populations.poly.vcf.gz.tbi',
-    ref_bwt: 'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.64.bwt',
-    ref_fasta_index: 'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai',
-    dbsnp_vcf_index: 'gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi',
-    omni_resource_vcf_index: 'gs://gcp-public-data--broad-references/hg19/v0/1000G_omni2.5.b37.vcf.gz.tbi',
-    known_indels_sites_VCFs: [
-      'gs://gcp-public-data--broad-references/hg19/v0/Mills_and_1000G_gold_standard.indels.b37.vcf.gz',
-      'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.known_indels_20120518.vcf',
-    ],
-    hapmap_resource_vcf_index: 'gs://gcp-public-data--broad-references/hg19/v0/hapmap_3.3.b37.vcf.gz.tbi',
-    mills_resource_vcf_index:
-      'gs://gcp-public-data--broad-references/hg19/v0/Mills_and_1000G_gold_standard.indels.b37.sites.vcf.idx',
-    ref_pac: 'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.64.pac',
+  T2THuman: {
+    ref_fasta: 'gs://gcp-public-data--broad-references/t2t/v2/chm13v2.0.maskedY.fasta',
+    ref_fasta_index: 'gs://gcp-public-data--broad-references/t2t/v2/chm13v2.0.maskedY.fasta.fai',
+    ref_dict: 'gs://gcp-public-data--broad-references/t2t/v2/chm13v2.0.maskedY.dict',
+    ref_amb: 'gs://gcp-public-data--broad-references/t2t/v2/chm13v2.0.maskedY.fasta.amb',
+    ref_ann: 'gs://gcp-public-data--broad-references/t2t/v2/chm13v2.0.maskedY.fasta.ann',
+    ref_bwt: 'gs://gcp-public-data--broad-references/t2t/v2/chm13v2.0.maskedY.fasta.bwt',
+    ref_pac: 'gs://gcp-public-data--broad-references/t2t/v2/chm13v2.0.maskedY.fasta.pac',
+    ref_sa: 'gs://gcp-public-data--broad-references/t2t/v2/chm13v2.0.maskedY.fasta.sa',
+    par_bed: 'gs://gcp-public-data--broad-references/t2t/v2/chm13v2.0_PAR.bed'
   },
-  hg38: {
+  hg38Human: {
     axiomPoly_resource_vcf:
-      'gs://gcp-public-data--broad-references/hg38/v0/Axiom_Exome_Plus.genotypes.all_populations.poly.hg38.vcf.gz',
+        'gs://gcp-public-data--broad-references/hg38/v0/Axiom_Exome_Plus.genotypes.all_populations.poly.hg38.vcf.gz',
     ref_fasta: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta',
     call_interval_list: 'gs://gcp-public-data--broad-references/hg38/v0/wgs_calling_regions.hg38.interval_list',
     ref_dict: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dict',
     unpadded_intervals_file: 'gs://gatk-test-data/intervals/hg38.even.handcurated.20k.intervals',
     one_thousand_genomes_resource_vcf_index:
-      'gs://gcp-public-data--broad-references/hg38/v0/1000G_phase1.snps.high_confidence.hg38.vcf.gz.tbi',
+        'gs://gcp-public-data--broad-references/hg38/v0/1000G_phase1.snps.high_confidence.hg38.vcf.gz.tbi',
     ref_alt: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.alt',
     dbsnp_vcf: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf',
     ref_ann: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.ann',
@@ -58,16 +28,16 @@ export default {
       'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.known_indels.vcf.gz.tbi',
     ],
     one_thousand_genomes_resource_vcf:
-      'gs://gcp-public-data--broad-references/hg38/v0/1000G_phase1.snps.high_confidence.hg38.vcf.gz',
+        'gs://gcp-public-data--broad-references/hg38/v0/1000G_phase1.snps.high_confidence.hg38.vcf.gz',
     hapmap_resource_vcf: 'gs://gcp-public-data--broad-references/hg38/v0/hapmap_3.3.hg38.vcf.gz',
     scattered_calling_intervals_list: 'gs://gatk-test-data/intervals/hg38_wgs_scattered_calling_intervals.txt',
     ref_sa: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.sa',
     mills_resource_vcf:
-      'gs://gcp-public-data--broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz',
+        'gs://gcp-public-data--broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz',
     ref_amb: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.amb',
     eval_interval_list: 'gs://gcp-public-data--broad-references/hg38/v0/wgs_evaluation_regions.hg38.interval_list',
     axiomPoly_resource_vcf_index:
-      'gs://gcp-public-data--broad-references/hg38/v0/Axiom_Exome_Plus.genotypes.all_populations.poly.hg38.vcf.gz.tbi',
+        'gs://gcp-public-data--broad-references/hg38/v0/Axiom_Exome_Plus.genotypes.all_populations.poly.hg38.vcf.gz.tbi',
     ref_bwt: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.bwt',
     ref_fasta_index: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai',
     dbsnp_vcf_index: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf.idx',
@@ -78,15 +48,56 @@ export default {
     ],
     hapmap_resource_vcf_index: 'gs://gcp-public-data--broad-references/hg38/v0/hapmap_3.3.hg38.vcf.gz.tbi',
     mills_resource_vcf_index:
-      'gs://gcp-public-data--broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz.tbi',
+        'gs://gcp-public-data--broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz.tbi',
     ref_pac: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.pac',
+  },
+  b37Human: {
+    axiomPoly_resource_vcf:
+        'gs://gcp-public-data--broad-references/hg19/v0/Axiom_Exome_Plus.genotypes.all_populations.poly.vcf.gz',
+    ref_fasta: 'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta',
+    ref_dict: 'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.dict',
+    unpadded_intervals_file: 'gs://gatk-test-data/intervals/wgs_calling_regions.v1.list',
+    one_thousand_genomes_resource_vcf_index:
+        'gs://gcp-public-data--broad-references/hg19/v0/1000G_phase1.snps.high_confidence.b37.vcf.gz.tbi',
+    ref_alt: 'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.alt',
+    dbsnp_vcf: 'gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz',
+    ref_ann: 'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.64.ann',
+    ref_name: 'b37',
+    omni_resource_vcf: 'gs://gcp-public-data--broad-references/hg19/v0/1000G_omni2.5.b37.vcf.gz',
+    known_indels_sites_indices: [
+      'gs://gcp-public-data--broad-references/hg19/v0/Mills_and_1000G_gold_standard.indels.b37.vcf.gz.tbi',
+      'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.known_indels_20120518.vcf.idx',
+    ],
+    one_thousand_genomes_resource_vcf:
+        'gs://gcp-public-data--broad-references/hg19/v0/1000G_phase1.snps.high_confidence.b37.vcf.gz',
+    hapmap_resource_vcf: 'gs://gcp-public-data--broad-references/hg19/v0/hapmap_3.3.b37.vcf.gz',
+    scattered_calling_intervals_list: 'gs://gatk-test-data/intervals/b37_wgs_scattered_calling_intervals.txt',
+    ref_sa: 'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.64.sa',
+    mills_resource_vcf:
+        'gs://gcp-public-data--broad-references/hg19/v0/Mills_and_1000G_gold_standard.indels.b37.sites.vcf',
+    ref_amb: 'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.64.amb',
+    eval_interval_list: 'gs://gcp-public-data--broad-references/hg19/v0/wgs_evaluation_regions.v1.interval_list',
+    axiomPoly_resource_vcf_index:
+        'gs://gcp-public-data--broad-references/hg19/v0/Axiom_Exome_Plus.genotypes.all_populations.poly.vcf.gz.tbi',
+    ref_bwt: 'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.64.bwt',
+    ref_fasta_index: 'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai',
+    dbsnp_vcf_index: 'gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi',
+    omni_resource_vcf_index: 'gs://gcp-public-data--broad-references/hg19/v0/1000G_omni2.5.b37.vcf.gz.tbi',
+    known_indels_sites_VCFs: [
+      'gs://gcp-public-data--broad-references/hg19/v0/Mills_and_1000G_gold_standard.indels.b37.vcf.gz',
+      'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.known_indels_20120518.vcf',
+    ],
+    hapmap_resource_vcf_index: 'gs://gcp-public-data--broad-references/hg19/v0/hapmap_3.3.b37.vcf.gz.tbi',
+    mills_resource_vcf_index:
+        'gs://gcp-public-data--broad-references/hg19/v0/Mills_and_1000G_gold_standard.indels.b37.sites.vcf.idx',
+    ref_pac: 'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.64.pac',
   },
   'Mmul-10': {
     ref_fasta: 'gs://gcp-public-data--broad-references/M.mulatta/Mmul_10/GCF_003339765.1_Mmul_10_genomic.fna',
   },
   'Clint-PTRv2': {
     ref_fasta:
-      'gs://gcp-public-data--broad-references/P.troglodytes/Clint_PTRv2/GCF_002880755.1_Clint_PTRv2_genomic.fna',
+        'gs://gcp-public-data--broad-references/P.troglodytes/Clint_PTRv2/GCF_002880755.1_Clint_PTRv2_genomic.fna',
   },
   GRCm39: {
     ref_fasta: 'gs://gcp-public-data--broad-references/GRCm39/GCF_000001635.27_GRCm39_genomic.fna',
@@ -99,11 +110,11 @@ export default {
   },
   'Release-6-plus-ISO1-MT': {
     ref_fasta:
-      'gs://gcp-public-data--broad-references/D.melanogaster/Release_6_plus_ISO1_MT/GCF_000001215.4_Release_6_plus_ISO1_MT_genomic.fna',
+        'gs://gcp-public-data--broad-references/D.melanogaster/Release_6_plus_ISO1_MT/GCF_000001215.4_Release_6_plus_ISO1_MT_genomic.fna',
   },
   'UCB-Xtro-10-0': {
     ref_fasta:
-      'gs://gcp-public-data--broad-references/X.tropicalis/UCB_Xtro_10.0/GCF_000004195.4_UCB_Xtro_10.0_genomic.fna',
+        'gs://gcp-public-data--broad-references/X.tropicalis/UCB_Xtro_10.0/GCF_000004195.4_UCB_Xtro_10.0_genomic.fna',
   },
   GRCz11: {
     ref_fasta: 'gs://gcp-public-data--broad-references/D.rerio/GRCz11/GCF_000002035.6_GRCz11_genomic.fna',
@@ -116,17 +127,17 @@ export default {
   },
   'ROS-Cfam-1-0': {
     ref_fasta:
-      'gs://gcp-public-data--broad-references/C.lupus_familiaris/ROS_Cfam_1.0/GCF_014441545.1_ROS_Cfam_1.0_genomic.fna',
+        'gs://gcp-public-data--broad-references/C.lupus_familiaris/ROS_Cfam_1.0/GCF_014441545.1_ROS_Cfam_1.0_genomic.fna',
   },
   'UU-Cfam-GSD-1-0': {
     ref_fasta:
-      'gs://gcp-public-data--broad-references/C.lupus_familiaris/UU_Cfam_GSD_1.0/GCA_011100685.1_UU_Cfam_GSD_1.0_genomic.fna',
+        'gs://gcp-public-data--broad-references/C.lupus_familiaris/UU_Cfam_GSD_1.0/GCA_011100685.1_UU_Cfam_GSD_1.0_genomic.fna',
   },
   'Sscrofa11-1': {
     ref_fasta: 'gs://gcp-public-data--broad-references/S.scrofa/Sscrofa11.1/GCF_000003025.6_Sscrofa11.1_genomic.fna',
   },
   'ARS-UI-Ramb-v2-0': {
     ref_fasta:
-      'gs://gcp-public-data--broad-references/O.aries/ARS-UI_Ramb_v2.0/GCF_016772045.1_ARS-UI_Ramb_v2.0_genomic.fna',
+        'gs://gcp-public-data--broad-references/O.aries/ARS-UI_Ramb_v2.0/GCF_016772045.1_ARS-UI_Ramb_v2.0_genomic.fna',
   },
 } as const;


### PR DESCRIPTION
### Dependencies
Depends on [this ticket](https://broadinstitute.atlassian.net/browse/PO-53298?page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel&focusedCommentId=1412547#comment-1412547) to add files to appropriate locations.

## Summary of changes:
This PR adds the T2T human reference genome and accompanying files to the list of default Terra reference files users can add to their workspace. 

It also makes a few other tweaks to the reference files `.ts` file:
* Change the order of the human reference files, so that the newest is first, i.e. T2T > hg38 > hg19. This should help encourage users to upgrade their pipelines to the newer versions of the human reference (less hg19 please!).
* ~~Change the name of the hg38 reference block to `hg38Human`. I'm not sure if this is too big a change to break existing workspaces, but this was suggested by someone to me and I think it makes sense, since we support a few non-human reference genomes, and is consistent with the hg19 convention. But I'm ok keeping it as-is if that might cause issues.~~ Reverted for backwards compatibility

### What
The main (maskedY) reference is added along with ref index and seq dict. This version was chosen from the release since it's scientifically the best for most use cases, particularly for general DNA alignment and variant calling. This version masks the PAR in chrY to avoid multi-mapping to those regions, as done for hg38. Also bwa index files are provided as with other references so users can align short reads using bwa out of the box. Index files for minimap2 however should be regenerated per use case as recommended by the tool, since index files are not generally transferrable across all use cases. 

### Why
The T2T is the latest and greatest in human reference genomes, and can improve sequencing accuracy just by using it for alignment + variant calling. It should be readily accessible to all users who wish to use it in their pipelines.
