### PR TITLE
Add aliases for reference data

### DIFF
--- a/src/data/Data.js
+++ b/src/data/Data.js
@@ -45,6 +45,7 @@ import { EntityUploader } from './data-table/shared/EntityUploader';
 import WDSContent from './data-table/wds/WDSContent';
 import { WdsTroubleshooter } from './data-table/wds/WdsTroubleshooter';
 import { useImportJobs } from './import-jobs';
+import { RefNameToAlias } from './reference-data/reference_aliases';
 import { getReferenceData } from './reference-data/reference-data-utils';
 import { ReferenceDataContent } from './reference-data/ReferenceDataContent';
 import { ReferenceDataDeleter } from './reference-data/ReferenceDataDeleter';
@@ -1173,7 +1174,7 @@ export const WorkspaceData = _.flow(
                                   {
                                     style: { flex: 0 },
                                     disabled: !!Utils.editWorkspaceError(workspace),
-                                    tooltip: Utils.editWorkspaceError(workspace) || `Delete ${type}`,
+                                    tooltip: Utils.editWorkspaceError(workspace) || `Delete ${RefNameToAlias[type]} reference`,
                                     onClick: (e) => {
                                       e.stopPropagation();
                                       setDeletingReference(type);
@@ -1182,7 +1183,7 @@ export const WorkspaceData = _.flow(
                                   [icon('minus-circle', { size: 16 })]
                                 ),
                               },
-                              [type]
+                              [RefNameToAlias[type]]
                             ),
                           _.keys(referenceData)
                         ),

--- a/src/data/reference-data/ReferenceDataDeleter.js
+++ b/src/data/reference-data/ReferenceDataDeleter.js
@@ -2,6 +2,7 @@ import _ from 'lodash/fp';
 import { useState } from 'react';
 import { b, div, h } from 'react-hyperscript-helpers';
 import { absoluteSpinnerOverlay, DeleteConfirmationModal } from 'src/components/common';
+import { RefNameToAlias } from 'src/data/reference-data/reference_aliases';
 import { Ajax } from 'src/libs/ajax';
 import { reportError } from 'src/libs/error';
 
@@ -29,6 +30,6 @@ export const ReferenceDataDeleter = ({ onSuccess, onDismiss, namespace, name, re
       },
       onDismiss,
     },
-    [div(['Are you sure you want to delete the ', b([referenceDataType]), ' reference data?']), deleting && absoluteSpinnerOverlay]
+    [div(['Are you sure you want to delete the ', b([RefNameToAlias[referenceDataType]]), ' reference data?']), deleting && absoluteSpinnerOverlay]
   );
 };

--- a/src/data/reference-data/ReferenceDataImporter.js
+++ b/src/data/reference-data/ReferenceDataImporter.js
@@ -6,6 +6,7 @@ import Modal from 'src/components/Modal';
 import { Ajax } from 'src/libs/ajax';
 import { reportError } from 'src/libs/error';
 
+import { RefAliasToName } from './reference_aliases';
 import ReferenceData from './references';
 
 export const ReferenceDataImporter = ({ onSuccess, onDismiss, namespace, name }) => {
@@ -27,7 +28,9 @@ export const ReferenceDataImporter = ({ onSuccess, onDismiss, namespace, name })
             try {
               await Ajax()
                 .Workspaces.workspace(namespace, name)
-                .shallowMergeNewAttributes(_.mapKeys((k) => `referenceData_${selectedReference}_${k}`, ReferenceData[selectedReference]));
+                .shallowMergeNewAttributes(
+                  _.mapKeys((k) => `referenceData_${RefAliasToName[selectedReference]}_${k}`, ReferenceData[RefAliasToName[selectedReference]])
+                );
               onSuccess();
             } catch (error) {
               await reportError('Error importing reference data', error);
@@ -46,7 +49,7 @@ export const ReferenceDataImporter = ({ onSuccess, onDismiss, namespace, name })
         placeholder: 'Select data',
         value: selectedReference,
         onChange: ({ value }) => setSelectedReference(value),
-        options: _.keys(ReferenceData),
+        options: _.keys(RefAliasToName),
       }),
       loading && spinnerOverlay,
     ]

--- a/src/data/reference-data/reference_aliases.ts
+++ b/src/data/reference-data/reference_aliases.ts
@@ -8,6 +8,7 @@ export const RefAliasToName = {
   'Chimp: PanTrog2': 'Clint-PTRv2',
   'Mouse: GRCm39': 'GRCm39',
   'Rat: RatNorvBN7-2': 'mRatBN7-2',
+  'Rat: RatNorvRN6': 'Rnor-6-0',
   'FruitFly: DrosMelan6ISO1': 'Release-6-plus-ISO1-MT',
   'Frog: XenoTropicalis10': 'UCB-Xtro-10-0',
   'Zebrafish: DanioRerio11': 'GRCz11',

--- a/src/data/reference-data/reference_aliases.ts
+++ b/src/data/reference-data/reference_aliases.ts
@@ -1,0 +1,22 @@
+import _ from 'lodash/fp';
+
+// A dictionary taking reference alias names to their backend unique name used in workflow inputs
+export const RefAliasToName = {
+  'Human: hg38': 'hg38',
+  'Human: b37': 'b37Human',
+  'Monkey: MacMul10': 'Mmul-10',
+  'Chimp: PanTrog2': 'Clint-PTRv2',
+  'Mouse: GRCm39': 'GRCm39',
+  'Rat: RatNorvBN7-2': 'mRatBN7-2',
+  'FruitFly: DrosMelan6ISO1': 'Release-6-plus-ISO1-MT',
+  'Frog: XenoTropicalis10': 'UCB-Xtro-10-0',
+  'Zebrafish: DanioRerio11': 'GRCz11',
+  'Nematode: CEle235': 'WBcel235',
+  'Yeast: SacchCerevR64': 'R64',
+  'Dog: CanLupFamROS1': 'ROS-Cfam-1-0',
+  'Dog: CanLupFamGSD1': 'UU-Cfam-GSD-1-0',
+  'Pig: SusScrofa11-1': 'Sscrofa11-1',
+  'Sheep: OAriesUIRamb2': 'ARS-UI-Ramb-v2-0',
+} as const;
+
+export const RefNameToAlias = _.invert(RefAliasToName);

--- a/src/data/reference-data/references.ts
+++ b/src/data/reference-data/references.ts
@@ -94,6 +94,9 @@ export default {
   'mRatBN7-2': {
     ref_fasta: 'gs://gcp-public-data--broad-references/R.norvegicus/mRatBN7.2/GCF_015227675.2_mRatBN7.2_genomic.fna',
   },
+  'Rnor-6-0': {
+    ref_fasta: 'gs://gcp-public-data--broad-references/R.norvegicus/Rnor_6.0/GCA_000001895.4_Rnor_6.0_genomic.fna',
+  },
   'Release-6-plus-ISO1-MT': {
     ref_fasta:
       'gs://gcp-public-data--broad-references/D.melanogaster/Release_6_plus_ISO1_MT/GCF_000001215.4_Release_6_plus_ISO1_MT_genomic.fna',

--- a/src/data/reference-data/references.ts
+++ b/src/data/reference-data/references.ts
@@ -10,7 +10,7 @@ export default {
     ref_sa: 'gs://gcp-public-data--broad-references/t2t/v2/chm13v2.0.maskedY.fasta.sa',
     par_bed: 'gs://gcp-public-data--broad-references/t2t/v2/chm13v2.0_PAR.bed'
   },
-  hg38Human: {
+  hg38: {
     axiomPoly_resource_vcf:
         'gs://gcp-public-data--broad-references/hg38/v0/Axiom_Exome_Plus.genotypes.all_populations.poly.hg38.vcf.gz',
     ref_fasta: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta',

--- a/src/data/reference-data/references.ts
+++ b/src/data/reference-data/references.ts
@@ -1,64 +1,12 @@
 export default {
-  T2THuman: {
-    ref_fasta: 'gs://gcp-public-data--broad-references/t2t/v2/chm13v2.0.maskedY.fasta',
-    ref_fasta_index: 'gs://gcp-public-data--broad-references/t2t/v2/chm13v2.0.maskedY.fasta.fai',
-    ref_dict: 'gs://gcp-public-data--broad-references/t2t/v2/chm13v2.0.maskedY.dict',
-    ref_amb: 'gs://gcp-public-data--broad-references/t2t/v2/chm13v2.0.maskedY.fasta.amb',
-    ref_ann: 'gs://gcp-public-data--broad-references/t2t/v2/chm13v2.0.maskedY.fasta.ann',
-    ref_bwt: 'gs://gcp-public-data--broad-references/t2t/v2/chm13v2.0.maskedY.fasta.bwt',
-    ref_pac: 'gs://gcp-public-data--broad-references/t2t/v2/chm13v2.0.maskedY.fasta.pac',
-    ref_sa: 'gs://gcp-public-data--broad-references/t2t/v2/chm13v2.0.maskedY.fasta.sa',
-    par_bed: 'gs://gcp-public-data--broad-references/t2t/v2/chm13v2.0_PAR.bed'
-  },
-  hg38: {
-    axiomPoly_resource_vcf:
-        'gs://gcp-public-data--broad-references/hg38/v0/Axiom_Exome_Plus.genotypes.all_populations.poly.hg38.vcf.gz',
-    ref_fasta: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta',
-    call_interval_list: 'gs://gcp-public-data--broad-references/hg38/v0/wgs_calling_regions.hg38.interval_list',
-    ref_dict: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dict',
-    unpadded_intervals_file: 'gs://gatk-test-data/intervals/hg38.even.handcurated.20k.intervals',
-    one_thousand_genomes_resource_vcf_index:
-        'gs://gcp-public-data--broad-references/hg38/v0/1000G_phase1.snps.high_confidence.hg38.vcf.gz.tbi',
-    ref_alt: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.alt',
-    dbsnp_vcf: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf',
-    ref_ann: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.ann',
-    omni_resource_vcf: 'gs://gcp-public-data--broad-references/hg38/v0/1000G_omni2.5.hg38.vcf.gz',
-    known_indels_sites_indices: [
-      'gs://gcp-public-data--broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz.tbi',
-      'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.known_indels.vcf.gz.tbi',
-    ],
-    one_thousand_genomes_resource_vcf:
-        'gs://gcp-public-data--broad-references/hg38/v0/1000G_phase1.snps.high_confidence.hg38.vcf.gz',
-    hapmap_resource_vcf: 'gs://gcp-public-data--broad-references/hg38/v0/hapmap_3.3.hg38.vcf.gz',
-    scattered_calling_intervals_list: 'gs://gatk-test-data/intervals/hg38_wgs_scattered_calling_intervals.txt',
-    ref_sa: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.sa',
-    mills_resource_vcf:
-        'gs://gcp-public-data--broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz',
-    ref_amb: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.amb',
-    eval_interval_list: 'gs://gcp-public-data--broad-references/hg38/v0/wgs_evaluation_regions.hg38.interval_list',
-    axiomPoly_resource_vcf_index:
-        'gs://gcp-public-data--broad-references/hg38/v0/Axiom_Exome_Plus.genotypes.all_populations.poly.hg38.vcf.gz.tbi',
-    ref_bwt: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.bwt',
-    ref_fasta_index: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai',
-    dbsnp_vcf_index: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf.idx',
-    omni_resource_vcf_index: 'gs://gcp-public-data--broad-references/hg38/v0/1000G_omni2.5.hg38.vcf.gz.tbi',
-    known_indels_sites_VCFs: [
-      'gs://gcp-public-data--broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz',
-      'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.known_indels.vcf.gz',
-    ],
-    hapmap_resource_vcf_index: 'gs://gcp-public-data--broad-references/hg38/v0/hapmap_3.3.hg38.vcf.gz.tbi',
-    mills_resource_vcf_index:
-        'gs://gcp-public-data--broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz.tbi',
-    ref_pac: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.pac',
-  },
   b37Human: {
     axiomPoly_resource_vcf:
-        'gs://gcp-public-data--broad-references/hg19/v0/Axiom_Exome_Plus.genotypes.all_populations.poly.vcf.gz',
+      'gs://gcp-public-data--broad-references/hg19/v0/Axiom_Exome_Plus.genotypes.all_populations.poly.vcf.gz',
     ref_fasta: 'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta',
     ref_dict: 'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.dict',
     unpadded_intervals_file: 'gs://gatk-test-data/intervals/wgs_calling_regions.v1.list',
     one_thousand_genomes_resource_vcf_index:
-        'gs://gcp-public-data--broad-references/hg19/v0/1000G_phase1.snps.high_confidence.b37.vcf.gz.tbi',
+      'gs://gcp-public-data--broad-references/hg19/v0/1000G_phase1.snps.high_confidence.b37.vcf.gz.tbi',
     ref_alt: 'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.alt',
     dbsnp_vcf: 'gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz',
     ref_ann: 'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.64.ann',
@@ -69,16 +17,16 @@ export default {
       'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.known_indels_20120518.vcf.idx',
     ],
     one_thousand_genomes_resource_vcf:
-        'gs://gcp-public-data--broad-references/hg19/v0/1000G_phase1.snps.high_confidence.b37.vcf.gz',
+      'gs://gcp-public-data--broad-references/hg19/v0/1000G_phase1.snps.high_confidence.b37.vcf.gz',
     hapmap_resource_vcf: 'gs://gcp-public-data--broad-references/hg19/v0/hapmap_3.3.b37.vcf.gz',
     scattered_calling_intervals_list: 'gs://gatk-test-data/intervals/b37_wgs_scattered_calling_intervals.txt',
     ref_sa: 'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.64.sa',
     mills_resource_vcf:
-        'gs://gcp-public-data--broad-references/hg19/v0/Mills_and_1000G_gold_standard.indels.b37.sites.vcf',
+      'gs://gcp-public-data--broad-references/hg19/v0/Mills_and_1000G_gold_standard.indels.b37.sites.vcf',
     ref_amb: 'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.64.amb',
     eval_interval_list: 'gs://gcp-public-data--broad-references/hg19/v0/wgs_evaluation_regions.v1.interval_list',
     axiomPoly_resource_vcf_index:
-        'gs://gcp-public-data--broad-references/hg19/v0/Axiom_Exome_Plus.genotypes.all_populations.poly.vcf.gz.tbi',
+      'gs://gcp-public-data--broad-references/hg19/v0/Axiom_Exome_Plus.genotypes.all_populations.poly.vcf.gz.tbi',
     ref_bwt: 'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.64.bwt',
     ref_fasta_index: 'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai',
     dbsnp_vcf_index: 'gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi',
@@ -89,15 +37,56 @@ export default {
     ],
     hapmap_resource_vcf_index: 'gs://gcp-public-data--broad-references/hg19/v0/hapmap_3.3.b37.vcf.gz.tbi',
     mills_resource_vcf_index:
-        'gs://gcp-public-data--broad-references/hg19/v0/Mills_and_1000G_gold_standard.indels.b37.sites.vcf.idx',
+      'gs://gcp-public-data--broad-references/hg19/v0/Mills_and_1000G_gold_standard.indels.b37.sites.vcf.idx',
     ref_pac: 'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.64.pac',
+  },
+  hg38: {
+    axiomPoly_resource_vcf:
+      'gs://gcp-public-data--broad-references/hg38/v0/Axiom_Exome_Plus.genotypes.all_populations.poly.hg38.vcf.gz',
+    ref_fasta: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta',
+    call_interval_list: 'gs://gcp-public-data--broad-references/hg38/v0/wgs_calling_regions.hg38.interval_list',
+    ref_dict: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dict',
+    unpadded_intervals_file: 'gs://gatk-test-data/intervals/hg38.even.handcurated.20k.intervals',
+    one_thousand_genomes_resource_vcf_index:
+      'gs://gcp-public-data--broad-references/hg38/v0/1000G_phase1.snps.high_confidence.hg38.vcf.gz.tbi',
+    ref_alt: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.alt',
+    dbsnp_vcf: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf',
+    ref_ann: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.ann',
+    omni_resource_vcf: 'gs://gcp-public-data--broad-references/hg38/v0/1000G_omni2.5.hg38.vcf.gz',
+    known_indels_sites_indices: [
+      'gs://gcp-public-data--broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz.tbi',
+      'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.known_indels.vcf.gz.tbi',
+    ],
+    one_thousand_genomes_resource_vcf:
+      'gs://gcp-public-data--broad-references/hg38/v0/1000G_phase1.snps.high_confidence.hg38.vcf.gz',
+    hapmap_resource_vcf: 'gs://gcp-public-data--broad-references/hg38/v0/hapmap_3.3.hg38.vcf.gz',
+    scattered_calling_intervals_list: 'gs://gatk-test-data/intervals/hg38_wgs_scattered_calling_intervals.txt',
+    ref_sa: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.sa',
+    mills_resource_vcf:
+      'gs://gcp-public-data--broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz',
+    ref_amb: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.amb',
+    eval_interval_list: 'gs://gcp-public-data--broad-references/hg38/v0/wgs_evaluation_regions.hg38.interval_list',
+    axiomPoly_resource_vcf_index:
+      'gs://gcp-public-data--broad-references/hg38/v0/Axiom_Exome_Plus.genotypes.all_populations.poly.hg38.vcf.gz.tbi',
+    ref_bwt: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.bwt',
+    ref_fasta_index: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai',
+    dbsnp_vcf_index: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf.idx',
+    omni_resource_vcf_index: 'gs://gcp-public-data--broad-references/hg38/v0/1000G_omni2.5.hg38.vcf.gz.tbi',
+    known_indels_sites_VCFs: [
+      'gs://gcp-public-data--broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz',
+      'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.known_indels.vcf.gz',
+    ],
+    hapmap_resource_vcf_index: 'gs://gcp-public-data--broad-references/hg38/v0/hapmap_3.3.hg38.vcf.gz.tbi',
+    mills_resource_vcf_index:
+      'gs://gcp-public-data--broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz.tbi',
+    ref_pac: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.pac',
   },
   'Mmul-10': {
     ref_fasta: 'gs://gcp-public-data--broad-references/M.mulatta/Mmul_10/GCF_003339765.1_Mmul_10_genomic.fna',
   },
   'Clint-PTRv2': {
     ref_fasta:
-        'gs://gcp-public-data--broad-references/P.troglodytes/Clint_PTRv2/GCF_002880755.1_Clint_PTRv2_genomic.fna',
+      'gs://gcp-public-data--broad-references/P.troglodytes/Clint_PTRv2/GCF_002880755.1_Clint_PTRv2_genomic.fna',
   },
   GRCm39: {
     ref_fasta: 'gs://gcp-public-data--broad-references/GRCm39/GCF_000001635.27_GRCm39_genomic.fna',
@@ -105,16 +94,13 @@ export default {
   'mRatBN7-2': {
     ref_fasta: 'gs://gcp-public-data--broad-references/R.norvegicus/mRatBN7.2/GCF_015227675.2_mRatBN7.2_genomic.fna',
   },
-  'Rnor-6-0': {
-    ref_fasta: 'gs://gcp-public-data--broad-references/R.norvegicus/Rnor_6.0/GCA_000001895.4_Rnor_6.0_genomic.fna',
-  },
   'Release-6-plus-ISO1-MT': {
     ref_fasta:
-        'gs://gcp-public-data--broad-references/D.melanogaster/Release_6_plus_ISO1_MT/GCF_000001215.4_Release_6_plus_ISO1_MT_genomic.fna',
+      'gs://gcp-public-data--broad-references/D.melanogaster/Release_6_plus_ISO1_MT/GCF_000001215.4_Release_6_plus_ISO1_MT_genomic.fna',
   },
   'UCB-Xtro-10-0': {
     ref_fasta:
-        'gs://gcp-public-data--broad-references/X.tropicalis/UCB_Xtro_10.0/GCF_000004195.4_UCB_Xtro_10.0_genomic.fna',
+      'gs://gcp-public-data--broad-references/X.tropicalis/UCB_Xtro_10.0/GCF_000004195.4_UCB_Xtro_10.0_genomic.fna',
   },
   GRCz11: {
     ref_fasta: 'gs://gcp-public-data--broad-references/D.rerio/GRCz11/GCF_000002035.6_GRCz11_genomic.fna',
@@ -127,17 +113,17 @@ export default {
   },
   'ROS-Cfam-1-0': {
     ref_fasta:
-        'gs://gcp-public-data--broad-references/C.lupus_familiaris/ROS_Cfam_1.0/GCF_014441545.1_ROS_Cfam_1.0_genomic.fna',
+      'gs://gcp-public-data--broad-references/C.lupus_familiaris/ROS_Cfam_1.0/GCF_014441545.1_ROS_Cfam_1.0_genomic.fna',
   },
   'UU-Cfam-GSD-1-0': {
     ref_fasta:
-        'gs://gcp-public-data--broad-references/C.lupus_familiaris/UU_Cfam_GSD_1.0/GCA_011100685.1_UU_Cfam_GSD_1.0_genomic.fna',
+      'gs://gcp-public-data--broad-references/C.lupus_familiaris/UU_Cfam_GSD_1.0/GCA_011100685.1_UU_Cfam_GSD_1.0_genomic.fna',
   },
   'Sscrofa11-1': {
     ref_fasta: 'gs://gcp-public-data--broad-references/S.scrofa/Sscrofa11.1/GCF_000003025.6_Sscrofa11.1_genomic.fna',
   },
   'ARS-UI-Ramb-v2-0': {
     ref_fasta:
-        'gs://gcp-public-data--broad-references/O.aries/ARS-UI_Ramb_v2.0/GCF_016772045.1_ARS-UI_Ramb_v2.0_genomic.fna',
+      'gs://gcp-public-data--broad-references/O.aries/ARS-UI_Ramb_v2.0/GCF_016772045.1_ARS-UI_Ramb_v2.0_genomic.fna',
   },
 } as const;

--- a/src/data/reference-data/references.ts
+++ b/src/data/reference-data/references.ts
@@ -1,54 +1,24 @@
 export default {
-  b37Human: {
-    axiomPoly_resource_vcf:
-      'gs://gcp-public-data--broad-references/hg19/v0/Axiom_Exome_Plus.genotypes.all_populations.poly.vcf.gz',
-    ref_fasta: 'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta',
-    ref_dict: 'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.dict',
-    unpadded_intervals_file: 'gs://gatk-test-data/intervals/wgs_calling_regions.v1.list',
-    one_thousand_genomes_resource_vcf_index:
-      'gs://gcp-public-data--broad-references/hg19/v0/1000G_phase1.snps.high_confidence.b37.vcf.gz.tbi',
-    ref_alt: 'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.alt',
-    dbsnp_vcf: 'gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz',
-    ref_ann: 'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.64.ann',
-    ref_name: 'b37',
-    omni_resource_vcf: 'gs://gcp-public-data--broad-references/hg19/v0/1000G_omni2.5.b37.vcf.gz',
-    known_indels_sites_indices: [
-      'gs://gcp-public-data--broad-references/hg19/v0/Mills_and_1000G_gold_standard.indels.b37.vcf.gz.tbi',
-      'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.known_indels_20120518.vcf.idx',
-    ],
-    one_thousand_genomes_resource_vcf:
-      'gs://gcp-public-data--broad-references/hg19/v0/1000G_phase1.snps.high_confidence.b37.vcf.gz',
-    hapmap_resource_vcf: 'gs://gcp-public-data--broad-references/hg19/v0/hapmap_3.3.b37.vcf.gz',
-    scattered_calling_intervals_list: 'gs://gatk-test-data/intervals/b37_wgs_scattered_calling_intervals.txt',
-    ref_sa: 'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.64.sa',
-    mills_resource_vcf:
-      'gs://gcp-public-data--broad-references/hg19/v0/Mills_and_1000G_gold_standard.indels.b37.sites.vcf',
-    ref_amb: 'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.64.amb',
-    eval_interval_list: 'gs://gcp-public-data--broad-references/hg19/v0/wgs_evaluation_regions.v1.interval_list',
-    axiomPoly_resource_vcf_index:
-      'gs://gcp-public-data--broad-references/hg19/v0/Axiom_Exome_Plus.genotypes.all_populations.poly.vcf.gz.tbi',
-    ref_bwt: 'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.64.bwt',
-    ref_fasta_index: 'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai',
-    dbsnp_vcf_index: 'gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi',
-    omni_resource_vcf_index: 'gs://gcp-public-data--broad-references/hg19/v0/1000G_omni2.5.b37.vcf.gz.tbi',
-    known_indels_sites_VCFs: [
-      'gs://gcp-public-data--broad-references/hg19/v0/Mills_and_1000G_gold_standard.indels.b37.vcf.gz',
-      'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.known_indels_20120518.vcf',
-    ],
-    hapmap_resource_vcf_index: 'gs://gcp-public-data--broad-references/hg19/v0/hapmap_3.3.b37.vcf.gz.tbi',
-    mills_resource_vcf_index:
-      'gs://gcp-public-data--broad-references/hg19/v0/Mills_and_1000G_gold_standard.indels.b37.sites.vcf.idx',
-    ref_pac: 'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.64.pac',
+  T2THuman: {
+    ref_fasta: 'gs://gcp-public-data--broad-references/t2t/v2/chm13v2.0.maskedY.fasta',
+    ref_fasta_index: 'gs://gcp-public-data--broad-references/t2t/v2/chm13v2.0.maskedY.fasta.fai',
+    ref_dict: 'gs://gcp-public-data--broad-references/t2t/v2/chm13v2.0.maskedY.dict',
+    ref_amb: 'gs://gcp-public-data--broad-references/t2t/v2/chm13v2.0.maskedY.fasta.amb',
+    ref_ann: 'gs://gcp-public-data--broad-references/t2t/v2/chm13v2.0.maskedY.fasta.ann',
+    ref_bwt: 'gs://gcp-public-data--broad-references/t2t/v2/chm13v2.0.maskedY.fasta.bwt',
+    ref_pac: 'gs://gcp-public-data--broad-references/t2t/v2/chm13v2.0.maskedY.fasta.pac',
+    ref_sa: 'gs://gcp-public-data--broad-references/t2t/v2/chm13v2.0.maskedY.fasta.sa',
+    par_bed: 'gs://gcp-public-data--broad-references/t2t/v2/chm13v2.0_PAR.bed'
   },
-  hg38: {
+  hg38Human: {
     axiomPoly_resource_vcf:
-      'gs://gcp-public-data--broad-references/hg38/v0/Axiom_Exome_Plus.genotypes.all_populations.poly.hg38.vcf.gz',
+        'gs://gcp-public-data--broad-references/hg38/v0/Axiom_Exome_Plus.genotypes.all_populations.poly.hg38.vcf.gz',
     ref_fasta: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta',
     call_interval_list: 'gs://gcp-public-data--broad-references/hg38/v0/wgs_calling_regions.hg38.interval_list',
     ref_dict: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dict',
     unpadded_intervals_file: 'gs://gatk-test-data/intervals/hg38.even.handcurated.20k.intervals',
     one_thousand_genomes_resource_vcf_index:
-      'gs://gcp-public-data--broad-references/hg38/v0/1000G_phase1.snps.high_confidence.hg38.vcf.gz.tbi',
+        'gs://gcp-public-data--broad-references/hg38/v0/1000G_phase1.snps.high_confidence.hg38.vcf.gz.tbi',
     ref_alt: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.alt',
     dbsnp_vcf: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf',
     ref_ann: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.ann',
@@ -58,16 +28,16 @@ export default {
       'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.known_indels.vcf.gz.tbi',
     ],
     one_thousand_genomes_resource_vcf:
-      'gs://gcp-public-data--broad-references/hg38/v0/1000G_phase1.snps.high_confidence.hg38.vcf.gz',
+        'gs://gcp-public-data--broad-references/hg38/v0/1000G_phase1.snps.high_confidence.hg38.vcf.gz',
     hapmap_resource_vcf: 'gs://gcp-public-data--broad-references/hg38/v0/hapmap_3.3.hg38.vcf.gz',
     scattered_calling_intervals_list: 'gs://gatk-test-data/intervals/hg38_wgs_scattered_calling_intervals.txt',
     ref_sa: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.sa',
     mills_resource_vcf:
-      'gs://gcp-public-data--broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz',
+        'gs://gcp-public-data--broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz',
     ref_amb: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.amb',
     eval_interval_list: 'gs://gcp-public-data--broad-references/hg38/v0/wgs_evaluation_regions.hg38.interval_list',
     axiomPoly_resource_vcf_index:
-      'gs://gcp-public-data--broad-references/hg38/v0/Axiom_Exome_Plus.genotypes.all_populations.poly.hg38.vcf.gz.tbi',
+        'gs://gcp-public-data--broad-references/hg38/v0/Axiom_Exome_Plus.genotypes.all_populations.poly.hg38.vcf.gz.tbi',
     ref_bwt: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.bwt',
     ref_fasta_index: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai',
     dbsnp_vcf_index: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf.idx',
@@ -78,15 +48,56 @@ export default {
     ],
     hapmap_resource_vcf_index: 'gs://gcp-public-data--broad-references/hg38/v0/hapmap_3.3.hg38.vcf.gz.tbi',
     mills_resource_vcf_index:
-      'gs://gcp-public-data--broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz.tbi',
+        'gs://gcp-public-data--broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz.tbi',
     ref_pac: 'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.pac',
+  },
+  b37Human: {
+    axiomPoly_resource_vcf:
+        'gs://gcp-public-data--broad-references/hg19/v0/Axiom_Exome_Plus.genotypes.all_populations.poly.vcf.gz',
+    ref_fasta: 'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta',
+    ref_dict: 'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.dict',
+    unpadded_intervals_file: 'gs://gatk-test-data/intervals/wgs_calling_regions.v1.list',
+    one_thousand_genomes_resource_vcf_index:
+        'gs://gcp-public-data--broad-references/hg19/v0/1000G_phase1.snps.high_confidence.b37.vcf.gz.tbi',
+    ref_alt: 'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.alt',
+    dbsnp_vcf: 'gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz',
+    ref_ann: 'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.64.ann',
+    ref_name: 'b37',
+    omni_resource_vcf: 'gs://gcp-public-data--broad-references/hg19/v0/1000G_omni2.5.b37.vcf.gz',
+    known_indels_sites_indices: [
+      'gs://gcp-public-data--broad-references/hg19/v0/Mills_and_1000G_gold_standard.indels.b37.vcf.gz.tbi',
+      'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.known_indels_20120518.vcf.idx',
+    ],
+    one_thousand_genomes_resource_vcf:
+        'gs://gcp-public-data--broad-references/hg19/v0/1000G_phase1.snps.high_confidence.b37.vcf.gz',
+    hapmap_resource_vcf: 'gs://gcp-public-data--broad-references/hg19/v0/hapmap_3.3.b37.vcf.gz',
+    scattered_calling_intervals_list: 'gs://gatk-test-data/intervals/b37_wgs_scattered_calling_intervals.txt',
+    ref_sa: 'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.64.sa',
+    mills_resource_vcf:
+        'gs://gcp-public-data--broad-references/hg19/v0/Mills_and_1000G_gold_standard.indels.b37.sites.vcf',
+    ref_amb: 'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.64.amb',
+    eval_interval_list: 'gs://gcp-public-data--broad-references/hg19/v0/wgs_evaluation_regions.v1.interval_list',
+    axiomPoly_resource_vcf_index:
+        'gs://gcp-public-data--broad-references/hg19/v0/Axiom_Exome_Plus.genotypes.all_populations.poly.vcf.gz.tbi',
+    ref_bwt: 'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.64.bwt',
+    ref_fasta_index: 'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai',
+    dbsnp_vcf_index: 'gs://gcp-public-data--broad-references/hg19/v0/dbsnp_138.b37.vcf.gz.tbi',
+    omni_resource_vcf_index: 'gs://gcp-public-data--broad-references/hg19/v0/1000G_omni2.5.b37.vcf.gz.tbi',
+    known_indels_sites_VCFs: [
+      'gs://gcp-public-data--broad-references/hg19/v0/Mills_and_1000G_gold_standard.indels.b37.vcf.gz',
+      'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.known_indels_20120518.vcf',
+    ],
+    hapmap_resource_vcf_index: 'gs://gcp-public-data--broad-references/hg19/v0/hapmap_3.3.b37.vcf.gz.tbi',
+    mills_resource_vcf_index:
+        'gs://gcp-public-data--broad-references/hg19/v0/Mills_and_1000G_gold_standard.indels.b37.sites.vcf.idx',
+    ref_pac: 'gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.64.pac',
   },
   'Mmul-10': {
     ref_fasta: 'gs://gcp-public-data--broad-references/M.mulatta/Mmul_10/GCF_003339765.1_Mmul_10_genomic.fna',
   },
   'Clint-PTRv2': {
     ref_fasta:
-      'gs://gcp-public-data--broad-references/P.troglodytes/Clint_PTRv2/GCF_002880755.1_Clint_PTRv2_genomic.fna',
+        'gs://gcp-public-data--broad-references/P.troglodytes/Clint_PTRv2/GCF_002880755.1_Clint_PTRv2_genomic.fna',
   },
   GRCm39: {
     ref_fasta: 'gs://gcp-public-data--broad-references/GRCm39/GCF_000001635.27_GRCm39_genomic.fna',
@@ -99,11 +110,11 @@ export default {
   },
   'Release-6-plus-ISO1-MT': {
     ref_fasta:
-      'gs://gcp-public-data--broad-references/D.melanogaster/Release_6_plus_ISO1_MT/GCF_000001215.4_Release_6_plus_ISO1_MT_genomic.fna',
+        'gs://gcp-public-data--broad-references/D.melanogaster/Release_6_plus_ISO1_MT/GCF_000001215.4_Release_6_plus_ISO1_MT_genomic.fna',
   },
   'UCB-Xtro-10-0': {
     ref_fasta:
-      'gs://gcp-public-data--broad-references/X.tropicalis/UCB_Xtro_10.0/GCF_000004195.4_UCB_Xtro_10.0_genomic.fna',
+        'gs://gcp-public-data--broad-references/X.tropicalis/UCB_Xtro_10.0/GCF_000004195.4_UCB_Xtro_10.0_genomic.fna',
   },
   GRCz11: {
     ref_fasta: 'gs://gcp-public-data--broad-references/D.rerio/GRCz11/GCF_000002035.6_GRCz11_genomic.fna',
@@ -116,17 +127,17 @@ export default {
   },
   'ROS-Cfam-1-0': {
     ref_fasta:
-      'gs://gcp-public-data--broad-references/C.lupus_familiaris/ROS_Cfam_1.0/GCF_014441545.1_ROS_Cfam_1.0_genomic.fna',
+        'gs://gcp-public-data--broad-references/C.lupus_familiaris/ROS_Cfam_1.0/GCF_014441545.1_ROS_Cfam_1.0_genomic.fna',
   },
   'UU-Cfam-GSD-1-0': {
     ref_fasta:
-      'gs://gcp-public-data--broad-references/C.lupus_familiaris/UU_Cfam_GSD_1.0/GCA_011100685.1_UU_Cfam_GSD_1.0_genomic.fna',
+        'gs://gcp-public-data--broad-references/C.lupus_familiaris/UU_Cfam_GSD_1.0/GCA_011100685.1_UU_Cfam_GSD_1.0_genomic.fna',
   },
   'Sscrofa11-1': {
     ref_fasta: 'gs://gcp-public-data--broad-references/S.scrofa/Sscrofa11.1/GCF_000003025.6_Sscrofa11.1_genomic.fna',
   },
   'ARS-UI-Ramb-v2-0': {
     ref_fasta:
-      'gs://gcp-public-data--broad-references/O.aries/ARS-UI_Ramb_v2.0/GCF_016772045.1_ARS-UI_Ramb_v2.0_genomic.fna',
+        'gs://gcp-public-data--broad-references/O.aries/ARS-UI_Ramb_v2.0/GCF_016772045.1_ARS-UI_Ramb_v2.0_genomic.fna',
   },
 } as const;


### PR DESCRIPTION
## Summary of changes:
This PR makes a few changes to how reference data names get displayed in Terra. In particular, it introduces the notion of aliases for references to disentangle the backend label for a reference bundle from what the user sees in the front end on the Data tab. These changes should be fully backwards compatible, still maintaining the old convention of accessing the data in workflows via `workspace.referenceData_{old_backend_name}`. 

### What
The key differences introduced are:
* A `reference_aliases.ts` file which provides dictionaries mapping the alias name to the backend label, and vice versa.
* Add aliases for all existing references to fit the format `species: ref` so users can see at a glance which species are supported. 
* Update dropdown for selecting reference data to use the aliases.
* Update text displayed after user has imported reference data to show the alias rather than the backend label.
* Update the tooltip on the "delete" button for reference data to show the alias name.
* ~~[Scientific Update] I removed the Rnor-6-0 reference from our list since it is marked as "suppressed" in NIH. There's a thread in Slack on whether this is the right thing to do or not, and I'm happy to put it back if we want to have that scientific discussion separate of this.~~ Reverted this

### Why
This allows greater flexibility in maintaining references on Terra. Now you can easily update/change the user-side names of references as appropriate. For example, if references continue to accrue on Terra, one might want to change the UI to cluster references by organism (somewhat similar to how this PR suggests using the new `species: ref` paradigm). This PR sets up the appropriate infrastructure to allow for this kind of option without worrying about breaking backwards compatibility in user workflows.

### Testing strategy
I tested it works locally using `yarn start`. :)