### PR TITLE
Narrow switchCase type to exclude collections

### DIFF
--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terra-ui-packages/core-utils",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "scripts": {
     "build": "vite build --emptyOutDir",
     "dev": "vite build --mode=development --watch",

--- a/packages/core-utils/src/logic-utils.errors.ts
+++ b/packages/core-utils/src/logic-utils.errors.ts
@@ -1,0 +1,8 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { switchCase } from './logic-utils';
+
+// THROWS No overload matches this call.
+const switchCaseCollectionArray = switchCase([], [[], () => 'This should not compile.']);
+
+// THROWS No overload matches this call.
+const switchCaseCollectionObject = switchCase({}, [{}, () => 'This should not compile.']);

--- a/packages/core-utils/src/logic-utils.ts
+++ b/packages/core-utils/src/logic-utils.ts
@@ -34,8 +34,11 @@ type SwitchCaseCase<T, U> = [T, () => U];
 type SwitchCaseDefault<U> = [typeof DEFAULT, () => U] | (() => U);
 
 type SwitchCase = {
-  <T extends string | number | boolean, U>(value: T, ...args: [...SwitchCaseCase<T, U>[], SwitchCaseDefault<U>]): U;
-  <T extends string | number | boolean, U>(value: T, ...args: SwitchCaseCase<T, U>[]): U | undefined;
+  <T extends string | number | boolean | undefined, U>(
+    value: T,
+    ...args: [...SwitchCaseCase<T, U>[], SwitchCaseDefault<U>]
+  ): U;
+  <T extends string | number | boolean | undefined, U>(value: T, ...args: SwitchCaseCase<T, U>[]): U | undefined;
 };
 
 /**

--- a/packages/core-utils/src/logic-utils.ts
+++ b/packages/core-utils/src/logic-utils.ts
@@ -34,8 +34,8 @@ type SwitchCaseCase<T, U> = [T, () => U];
 type SwitchCaseDefault<U> = [typeof DEFAULT, () => U] | (() => U);
 
 type SwitchCase = {
-  <T, U>(value: T, ...args: [...SwitchCaseCase<T, U>[], SwitchCaseDefault<U>]): U;
-  <T, U>(value: T, ...args: SwitchCaseCase<T, U>[]): U | undefined;
+  <T extends string | number | boolean, U>(value: T, ...args: [...SwitchCaseCase<T, U>[], SwitchCaseDefault<U>]): U;
+  <T extends string | number | boolean, U>(value: T, ...args: SwitchCaseCase<T, U>[]): U | undefined;
 };
 
 /**

--- a/packages/core-utils/src/logic-utils.ts
+++ b/packages/core-utils/src/logic-utils.ts
@@ -34,11 +34,11 @@ type SwitchCaseCase<T, U> = [T, () => U];
 type SwitchCaseDefault<U> = [typeof DEFAULT, () => U] | (() => U);
 
 type SwitchCase = {
-  <T extends string | number | boolean | undefined, U>(
+  <T extends string | number | boolean | null | undefined, U>(
     value: T,
     ...args: [...SwitchCaseCase<T, U>[], SwitchCaseDefault<U>]
   ): U;
-  <T extends string | number | boolean | undefined, U>(value: T, ...args: SwitchCaseCase<T, U>[]): U | undefined;
+  <T extends string | number | boolean | null | undefined, U>(value: T, ...args: SwitchCaseCase<T, U>[]): U | undefined;
 };
 
 /**


### PR DESCRIPTION
No Jira ticket.

Previous version would allow this syntax:
```javascript
switchCase([isFoo, isBar], [[true, true], () => 'both are true'])
```
Since cases are matched with `===`, this case would never match. This change narrows the type to exclude collections so this mistake is caught earlier. See test for more details.

Manually verified type errors by compiling the *.errors.ts file.