### PR TITLE
[WM-2208] Submission Unknown status

### DIFF
--- a/src/workflows-app/SubmissionDetails.js
+++ b/src/workflows-app/SubmissionDetails.js
@@ -13,7 +13,7 @@ import { notify } from 'src/libs/notifications';
 import { useCancellation, useOnMount, usePollingEffect } from 'src/libs/react-utils';
 import { AppProxyUrlStatus, workflowsAppStore } from 'src/libs/state';
 import * as Utils from 'src/libs/utils';
-import { customFormatDuration, differenceFromNowInSeconds, makeCompleteDate } from 'src/libs/utils';
+import { customFormatDuration, makeCompleteDate } from 'src/libs/utils';
 import { HeaderSection, statusType, SubmitNewWorkflowButton } from 'src/workflows-app/components/job-common';
 import { doesAppProxyUrlExist, loadAppUrls } from 'src/workflows-app/utils/app-utils';
 import {
@@ -59,7 +59,7 @@ export const BaseSubmissionDetails = ({ name, namespace, workspace, submissionId
     return filterStatement;
   };
 
-  const state = (state, submissionDate) => {
+  const state = (state) => {
     switch (state) {
       case 'SYSTEM_ERROR':
       case 'EXECUTOR_ERROR':
@@ -79,9 +79,7 @@ export const BaseSubmissionDetails = ({ name, namespace, workspace, submissionId
       case 'CANCELING':
         return statusType.canceling;
       default:
-        // 10 seconds should be enough for Cromwell to summarize the new workflow and get a status other
-        // than UNKNOWN. In the meantime, handle this as an edge case in the UI:
-        return differenceFromNowInSeconds(submissionDate) < 10 ? statusType.initializing : statusType.unknown;
+        return statusType.unknown;
     }
   };
 
@@ -371,7 +369,7 @@ export const BaseSubmissionDetails = ({ name, namespace, workspace, submissionId
                           field: 'state',
                           headerRenderer: () => h(Sortable, { sort, field: 'state', onSort: setSort }, ['Status']),
                           cellRenderer: ({ rowIndex }) => {
-                            const status = state(paginatedPreviousRuns[rowIndex].state, paginatedPreviousRuns[rowIndex].submission_date);
+                            const status = state(paginatedPreviousRuns[rowIndex].state);
                             if (errorStates.includes(paginatedPreviousRuns[rowIndex].state)) {
                               return div({ style: { width: '100%', textAlign: 'center' } }, [
                                 h(Link, { key: 'error link', style: { fontWeight: 'bold' }, onClick: () => setViewErrorsId(rowIndex) }, [

--- a/src/workflows-app/SubmissionDetails.js
+++ b/src/workflows-app/SubmissionDetails.js
@@ -391,7 +391,8 @@ export const BaseSubmissionDetails = ({ name, namespace, workspace, submissionId
                           field: 'duration',
                           headerRenderer: () => h(Sortable, { sort, field: 'duration', onSort: setSort }, ['Duration']),
                           cellRenderer: ({ rowIndex }) => {
-                            return h(TextCell, [customFormatDuration(paginatedPreviousRuns[rowIndex].duration)]);
+                            const formattedDuration = customFormatDuration(paginatedPreviousRuns[rowIndex].duration);
+                            return h(TextCell, [formattedDuration === '' ? '0 seconds' : formattedDuration]);
                           },
                         },
                       ],

--- a/src/workflows-app/SubmissionDetails.test.js
+++ b/src/workflows-app/SubmissionDetails.test.js
@@ -366,7 +366,7 @@ describe('Submission Details page', () => {
           run_set_id: '0cd15673-7342-4cfa-883d-819660184a16',
           record_id: 'FOO2',
           workflow_url: 'https://xyz.wdl',
-          state: 'UNKNOWN',
+          state: 'INITIALIZING',
           workflow_params:
             "[{'input_name':'wf_hello.hello.addressee','input_type':{'type':'primitive','primitive_type':'String'},'source':{'type':'record_lookup','record_attribute':'foo_name'}}]",
           workflow_outputs: '[]',
@@ -419,7 +419,7 @@ describe('Submission Details page', () => {
     const cellsFromDataRow1 = within(rows[1]).getAllByRole('cell');
     expect(cellsFromDataRow1.length).toBe(3);
     within(cellsFromDataRow1[0]).getByText('FOO2');
-    within(cellsFromDataRow1[1]).getByText('Initializing'); // Note: not UNKNOWN!
+    within(cellsFromDataRow1[1]).getByText('Initializing');
     // << Don't validate duration here since it depends on the test rendering time and is not particularly relevant >>
   });
 


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WM-2208

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Removing a temporary bandaid in the UI to address the `unknown` status coming from CBAS right after workflow submission
- CBAS should no longer be sending an `unknown` status right after submission, see https://github.com/DataBiosphere/cbas/pull/201

### Why
- Visual bug where workflows transition from `intializing` -> `unknown` -> `running` that was only being held together by a 10 second bandaid

### Testing strategy
- Unit tests
- Local testing <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 
