### PR TITLE
[UIE-51] Add containsOnlyUnlabelledIcon to components

### DIFF
--- a/packages/components/src/icon.ts
+++ b/packages/components/src/icon.ts
@@ -4,6 +4,7 @@ import iconLibrary, { IconId } from './icon-library';
 
 export interface IconProps {
   'aria-label'?: string;
+  'aria-labelledby'?: string;
   className?: string;
   size?: number;
   style?: CSSProperties;

--- a/packages/components/src/internal/a11y-utils.test.ts
+++ b/packages/components/src/internal/a11y-utils.test.ts
@@ -1,0 +1,38 @@
+import { icon } from '../icon';
+import { containsOnlyUnlabelledIcon } from './a11y-utils';
+
+describe('containsOnlyUnlabelledIcon', () => {
+  it('returns true if element has no label and only child is an icon without a label', () => {
+    expect(
+      containsOnlyUnlabelledIcon({
+        children: icon('bell'),
+      })
+    ).toBe(true);
+
+    expect(
+      containsOnlyUnlabelledIcon({
+        'aria-label': 'Label',
+        children: icon('bell'),
+      })
+    ).toBe(false);
+
+    expect(
+      containsOnlyUnlabelledIcon({
+        'aria-labelledby': 'label-id',
+        children: icon('bell'),
+      })
+    ).toBe(false);
+
+    expect(
+      containsOnlyUnlabelledIcon({
+        children: icon('bell', { 'aria-label': 'Label' }),
+      })
+    ).toBe(false);
+
+    expect(
+      containsOnlyUnlabelledIcon({
+        children: icon('bell', { 'aria-labelledby': 'label-id' }),
+      })
+    ).toBe(false);
+  });
+});

--- a/packages/components/src/internal/a11y-utils.test.ts
+++ b/packages/components/src/internal/a11y-utils.test.ts
@@ -17,7 +17,10 @@ describe('containsOnlyUnlabelledIcon', () => {
   ] as [ContainsOnlyUnlabelledIconArgs, boolean][])(
     'returns true if element has no label and only child is an icon without a label',
     (props, expectedResult) => {
+      // Act
       const result = containsOnlyUnlabelledIcon(props);
+
+      // Assert
       expect(result).toBe(expectedResult);
     }
   );

--- a/packages/components/src/internal/a11y-utils.test.ts
+++ b/packages/components/src/internal/a11y-utils.test.ts
@@ -1,38 +1,24 @@
 import { icon } from '../icon';
-import { containsOnlyUnlabelledIcon } from './a11y-utils';
+import { containsOnlyUnlabelledIcon, ContainsOnlyUnlabelledIconArgs } from './a11y-utils';
 
 describe('containsOnlyUnlabelledIcon', () => {
-  it('returns true if element has no label and only child is an icon without a label', () => {
-    expect(
-      containsOnlyUnlabelledIcon({
-        children: icon('bell'),
-      })
-    ).toBe(true);
-
-    expect(
-      containsOnlyUnlabelledIcon({
-        'aria-label': 'Label',
-        children: icon('bell'),
-      })
-    ).toBe(false);
-
-    expect(
-      containsOnlyUnlabelledIcon({
-        'aria-labelledby': 'label-id',
-        children: icon('bell'),
-      })
-    ).toBe(false);
-
-    expect(
-      containsOnlyUnlabelledIcon({
-        children: icon('bell', { 'aria-label': 'Label' }),
-      })
-    ).toBe(false);
-
-    expect(
-      containsOnlyUnlabelledIcon({
-        children: icon('bell', { 'aria-labelledby': 'label-id' }),
-      })
-    ).toBe(false);
-  });
+  it.each([
+    [{ children: icon('bell') }, true],
+    // Element has label
+    [{ 'aria-label': 'Button', children: icon('bell') }, false],
+    [{ 'aria-labelledby': 'label-element', children: icon('bell') }, false],
+    // Icon has label
+    [{ children: icon('bell', { 'aria-label': 'Icon' }) }, false],
+    [{ children: icon('bell', { 'aria-labelledby': 'label-element' }) }, false],
+    // Multiple children
+    [{ children: [icon('bell'), 'Label'] }, false],
+    // Non-element child
+    [{ children: 'Label' }, false],
+  ] as [ContainsOnlyUnlabelledIconArgs, boolean][])(
+    'returns true if element has no label and only child is an icon without a label',
+    (props, expectedResult) => {
+      const result = containsOnlyUnlabelledIcon(props);
+      expect(result).toBe(expectedResult);
+    }
+  );
 });

--- a/packages/components/src/internal/a11y-utils.ts
+++ b/packages/components/src/internal/a11y-utils.ts
@@ -1,0 +1,40 @@
+import { Children, ReactNode } from 'react';
+
+interface ContainsOnlyUnlabelledIconArgs {
+  'aria-label'?: string;
+  'aria-labelledby'?: string;
+  children?: ReactNode;
+}
+
+/**
+ * Returns true if a component contains only one child and that child is an icon without a label.
+ * @param args - Relevant props from the element in question.
+ *
+ * For accessibility, interactive elements must have an accessible name. That name can come from
+ * the element's content or from ARIA attributes (aria-label, aria-labelledby).
+ *
+ * However, a common pattern is to have an "icon button" where a button has no visible text content.
+ * In those cases, an accessible name needs to be provided with visibly hidden text or ARIA attributes.
+ *
+ * This function is intended to identify those cases and helpfully fall back to using the component's
+ * tooltip (if it has one) as the accessible name.
+ */
+export const containsOnlyUnlabelledIcon = (args: ContainsOnlyUnlabelledIconArgs): boolean => {
+  const { children, 'aria-label': ariaLabel, 'aria-labelledby': ariaLabelledBy } = args;
+  if (!ariaLabel && !ariaLabelledBy && Children.count(children) === 1 && typeof children !== 'string') {
+    try {
+      const onlyChild = Children.only(children);
+
+      // Is there a better way to test for an icon component other than duck-typing?
+      // @ts-expect-error
+      // TODO: Make this check type safe
+      // icon sets aria-hidden to true if neither aria-label or aria-labelledby is provided.
+      if ('data-icon' in onlyChild.props && onlyChild.props['aria-hidden'] === true) {
+        return true;
+      }
+    } catch (e) {
+      /* do nothing */
+    }
+  }
+  return false;
+};

--- a/packages/components/src/internal/a11y-utils.ts
+++ b/packages/components/src/internal/a11y-utils.ts
@@ -39,7 +39,7 @@ export const containsOnlyUnlabelledIcon = (args: ContainsOnlyUnlabelledIconArgs)
   } catch (e) {
     // Children.only throws an error if the component has multiple children.
     // `'data-icon' in onlyChild.props` throws an error if onlyChild is not a React element
-    // (if it's a string, number, etc.)
+    // (if it's a string, number, etc.) and thus does not have a 'props' property.
     // Both of those possibilities are expected and should result in this function returning false.
   }
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/UIE-51

Moving dependencies of Clickable to the components package... This adds a version of `containsUnlabelledIcon` to components.

https://github.com/DataBiosphere/terra-ui/blob/6012e5914cd25f2c74ed1b0d2153a117e1c814e1/src/components/icons.js#L13-L39

I renamed the function to `containsOnlyUnlabelledIcon` to better describe what it checks for. I also updated the documentation to (in my opinion) better describe what it is used for.

Note that this does not remove `containsUnlabelledIcon` from Terra UI. This helper is pretty niche (it's only used by two components) and so I don't want to add it to components' public API. Once TooltipTrigger and Clickable are moved to components, this `containsUnlabelledIcon` can be removed from Terra UI.