### PR TITLE
[UIE-51] Add popup-utils to components

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -5063,22 +5063,26 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@terra-ui-packages/build-utils", "virtual:6fecf1af4cab542f4a06b7ce7d9f710277dce92700e0011a9519e41948eed6d8f54c9d0aa109ead6cf4295edce81cb49620f9e823313e99632229bf20d133cdb#workspace:packages/build-utils"],\
             ["@terra-ui-packages/test-utils", "workspace:packages/test-utils"],\
             ["@testing-library/dom", "npm:9.3.1"],\
-            ["@testing-library/react", "virtual:3cbce82a859ed6a4d5bf57a6b809aea2976beb02c6e1078f18e5e40f750e781222e51bcef76699e2500e623832ea4e45e9647ae7b14a57290a182e58c3827fe8#npm:14.0.0"],\
+            ["@testing-library/react", "virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#npm:14.0.0"],\
             ["@types/jest", "npm:28.1.8"],\
             ["@types/lodash", "npm:4.14.184"],\
             ["@types/react", "npm:18.2.15"],\
+            ["@types/react-dom", "npm:18.2.7"],\
             ["@types/testing-library__jest-dom", "npm:5.14.9"],\
             ["color", "npm:4.0.1"],\
             ["jest", "virtual:8c00fb6d848584930a97145ab92981f57dfda3a26acb7c186ce59ef8e1d0c5c900af7e36dd05e12ff96b7235e88575a55bb45434a9589e1fb111101a9a3d2f5e#npm:27.5.1"],\
             ["lodash", "npm:4.17.21"],\
             ["react", "npm:18.2.0"],\
+            ["react-dom", "virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#npm:18.2.0"],\
             ["react-hyperscript-helpers", "virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#npm:2.0.0"],\
             ["typescript", "patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=289587"],\
             ["vite", "virtual:6fecf1af4cab542f4a06b7ce7d9f710277dce92700e0011a9519e41948eed6d8f54c9d0aa109ead6cf4295edce81cb49620f9e823313e99632229bf20d133cdb#npm:4.4.7"],\
             ["vite-plugin-svgr", "virtual:3cbce82a859ed6a4d5bf57a6b809aea2976beb02c6e1078f18e5e40f750e781222e51bcef76699e2500e623832ea4e45e9647ae7b14a57290a182e58c3827fe8#npm:3.2.0"]\
           ],\
           "packagePeers": [\
+            "@types/react-dom",\
             "@types/react",\
+            "react-dom",\
             "react"\
           ],\
           "linkType": "SOFT"\
@@ -5094,7 +5098,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@terra-ui-packages/build-utils", "virtual:6fecf1af4cab542f4a06b7ce7d9f710277dce92700e0011a9519e41948eed6d8f54c9d0aa109ead6cf4295edce81cb49620f9e823313e99632229bf20d133cdb#workspace:packages/build-utils"],\
             ["@terra-ui-packages/test-utils", "workspace:packages/test-utils"],\
             ["@testing-library/dom", "npm:9.3.1"],\
-            ["@testing-library/react", "virtual:3cbce82a859ed6a4d5bf57a6b809aea2976beb02c6e1078f18e5e40f750e781222e51bcef76699e2500e623832ea4e45e9647ae7b14a57290a182e58c3827fe8#npm:14.0.0"],\
+            ["@testing-library/react", "virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#npm:14.0.0"],\
             ["@types/jest", "npm:28.1.8"],\
             ["@types/lodash", "npm:4.14.184"],\
             ["@types/react", "npm:18.2.15"],\
@@ -5103,6 +5107,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["jest", "virtual:8c00fb6d848584930a97145ab92981f57dfda3a26acb7c186ce59ef8e1d0c5c900af7e36dd05e12ff96b7235e88575a55bb45434a9589e1fb111101a9a3d2f5e#npm:27.5.1"],\
             ["lodash", "npm:4.17.21"],\
             ["react", "npm:18.2.0"],\
+            ["react-dom", "virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#npm:18.2.0"],\
             ["react-hyperscript-helpers", "virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#npm:2.0.0"],\
             ["typescript", "patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=289587"],\
             ["vite", "virtual:6fecf1af4cab542f4a06b7ce7d9f710277dce92700e0011a9519e41948eed6d8f54c9d0aa109ead6cf4295edce81cb49620f9e823313e99632229bf20d133cdb#npm:4.4.7"],\
@@ -5207,24 +5212,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],\
           "packagePeers": [\
             "@types/react-dom",\
-            "@types/react",\
-            "react-dom",\
-            "react"\
-          ],\
-          "linkType": "HARD"\
-        }],\
-        ["virtual:3cbce82a859ed6a4d5bf57a6b809aea2976beb02c6e1078f18e5e40f750e781222e51bcef76699e2500e623832ea4e45e9647ae7b14a57290a182e58c3827fe8#npm:14.0.0", {\
-          "packageLocation": "./.yarn/__virtual__/@testing-library-react-virtual-05aa26d0eb/0/cache/@testing-library-react-npm-14.0.0-84fecd033b-4a54c8f56c.zip/node_modules/@testing-library/react/",\
-          "packageDependencies": [\
-            ["@testing-library/react", "virtual:3cbce82a859ed6a4d5bf57a6b809aea2976beb02c6e1078f18e5e40f750e781222e51bcef76699e2500e623832ea4e45e9647ae7b14a57290a182e58c3827fe8#npm:14.0.0"],\
-            ["@babel/runtime", "npm:7.22.6"],\
-            ["@testing-library/dom", "npm:9.3.1"],\
-            ["@types/react", "npm:18.2.15"],\
-            ["@types/react-dom", "npm:18.2.7"],\
-            ["react", "npm:18.2.0"],\
-            ["react-dom", null]\
-          ],\
-          "packagePeers": [\
             "@types/react",\
             "react-dom",\
             "react"\

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -42,11 +42,13 @@
     "@types/testing-library__jest-dom": "^5.14.9",
     "jest": "^27.4.3",
     "react": "18.2.0",
+    "react-dom": "18.2.0",
     "typescript": "^4.9.5",
     "vite": "^4.3.9",
     "vite-plugin-svgr": "^3.2.0"
   },
   "peerDependencies": {
-    "react": "18.2.0"
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
   }
 }

--- a/packages/components/src/hooks/useWindowDimensions.test.ts
+++ b/packages/components/src/hooks/useWindowDimensions.test.ts
@@ -1,0 +1,59 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { useWindowDimensions } from './useWindowDimensions';
+
+type MockWindowResult = {
+  resizeWindow: (width: number, height: number) => void;
+};
+
+const mockWindow = (): MockWindowResult => {
+  let originalWindowSize = [0, 0];
+
+  beforeAll(() => {
+    originalWindowSize = [window.innerWidth, window.innerHeight];
+  });
+
+  afterAll(() => {
+    window.innerWidth = originalWindowSize[0];
+    window.innerHeight = originalWindowSize[1];
+  });
+
+  const resizeWindow = (width: number, height: number): void => {
+    window.innerWidth = width;
+    window.innerHeight = height;
+
+    const resizeEvent = new Event('resize');
+    window.dispatchEvent(resizeEvent);
+  };
+
+  return { resizeWindow };
+};
+
+describe('useWindowDimensions', () => {
+  const { resizeWindow } = mockWindow();
+
+  it('returns window dimensions', () => {
+    // Arrange
+    resizeWindow(640, 480);
+
+    // Act
+    const { result: hookReturnRef } = renderHook(useWindowDimensions);
+
+    // Assert
+    expect(hookReturnRef.current).toEqual({ width: 640, height: 480 });
+  });
+
+  it('updates when window resizes', () => {
+    // Arrange
+    resizeWindow(640, 480);
+    const { result: hookReturnRef } = renderHook(useWindowDimensions);
+
+    // Act
+    act(() => {
+      resizeWindow(1280, 960);
+    });
+
+    // Assert
+    expect(hookReturnRef.current).toEqual({ width: 1280, height: 960 });
+  });
+});

--- a/packages/components/src/hooks/useWindowDimensions.ts
+++ b/packages/components/src/hooks/useWindowDimensions.ts
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react';
 
 /**
- * Returns the dimensions of the window.
+ * Returns window.innerWidth and window.innerHeight.
+ * Rerenders the component when the window is resized.
  */
 export const useWindowDimensions = (): { width: number; height: number } => {
   const [dimensions, setDimensions] = useState(() => ({ width: window.innerWidth, height: window.innerHeight }));

--- a/packages/components/src/hooks/useWindowDimensions.ts
+++ b/packages/components/src/hooks/useWindowDimensions.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Returns the dimensions of the window.
+ */
+export const useWindowDimensions = (): { width: number; height: number } => {
+  const [dimensions, setDimensions] = useState(() => ({ width: window.innerWidth, height: window.innerHeight }));
+
+  useEffect(() => {
+    const onResize = () => {
+      setDimensions({ width: window.innerWidth, height: window.innerHeight });
+    };
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
+
+  return dimensions;
+};

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,4 +1,5 @@
 export * from './ErrorBoundary';
+export * from './hooks/useWindowDimensions';
 export * from './icon';
 export type { IconId } from './icon-library';
 export { Interactive } from './Interactive';

--- a/packages/components/src/internal/PopupPortal.test.ts
+++ b/packages/components/src/internal/PopupPortal.test.ts
@@ -1,0 +1,41 @@
+import { render } from '@testing-library/react';
+import { div, h } from 'react-hyperscript-helpers';
+
+import { getPopupRoot, PopupPortal, popupRootId } from './PopupPortal';
+
+describe('getPopupRoot', () => {
+  afterEach(() => {
+    // Cleanup
+    document.getElementById(popupRootId)?.remove();
+  });
+
+  it('creates popup root element if one does not exist', () => {
+    // Act
+    const popupRoot = getPopupRoot();
+
+    // Assert
+    expect(popupRoot).toBeInTheDocument();
+    expect(popupRoot).toHaveAttribute('id', popupRootId);
+    expect(popupRoot.role).toBe('complementary');
+  });
+
+  it('returns existing popup root element', () => {
+    // Act
+    const popupRoot1 = getPopupRoot();
+    const popupRoot2 = getPopupRoot();
+
+    // Assert
+    expect(popupRoot1).toBe(popupRoot2);
+    expect(document.querySelectorAll(`#${popupRootId}`).length).toBe(1);
+  });
+});
+
+describe('PopupPortal', () => {
+  it('renders children into popup root element', () => {
+    // Act
+    render(h(PopupPortal, [div(['Hello world'])]));
+
+    // Assert
+    expect(document.getElementById(popupRootId)).toHaveTextContent('Hello world');
+  });
+});

--- a/packages/components/src/internal/PopupPortal.ts
+++ b/packages/components/src/internal/PopupPortal.ts
@@ -18,7 +18,7 @@ export const getPopupRoot = (): HTMLElement => {
   return popupRoot;
 };
 
-type PopupPortalProps = PropsWithChildren<{}>;
+export type PopupPortalProps = PropsWithChildren<{}>;
 
 /**
  * Renders children in the popup root element.

--- a/packages/components/src/internal/PopupPortal.ts
+++ b/packages/components/src/internal/PopupPortal.ts
@@ -1,0 +1,30 @@
+import { Children, PropsWithChildren, ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+
+export const popupRootId = 'modal-root';
+
+/**
+ * Popups, modals, etc. are rendered into the popup root element.
+ * This function returns that element, creating it if it does not exist.
+ */
+export const getPopupRoot = (): HTMLElement => {
+  let popupRoot = document.getElementById(popupRootId);
+  if (!popupRoot) {
+    popupRoot = document.createElement('div');
+    popupRoot.id = popupRootId;
+    popupRoot.role = 'complementary';
+    document.body.append(popupRoot);
+  }
+  return popupRoot;
+};
+
+type PopupPortalProps = PropsWithChildren<{}>;
+
+/**
+ * Renders children in the popup root element.
+ */
+export const PopupPortal = (props: PopupPortalProps): ReactNode => {
+  const { children } = props;
+  const child = Children.only(children);
+  return createPortal(child, getPopupRoot());
+};

--- a/packages/components/src/internal/popup-utils.test.ts
+++ b/packages/components/src/internal/popup-utils.test.ts
@@ -2,70 +2,45 @@ import { render } from '@testing-library/react';
 import { useRef } from 'react';
 import { div, h } from 'react-hyperscript-helpers';
 
-import { computePopupPosition, Position, Size, useBoundingRects } from './popup-utils';
+import { computePopupPosition, Position, Side, Size, useBoundingRects } from './popup-utils';
 
 describe('computePopupPosition', () => {
-  it('computes position of popup element based on position of target element', () => {
-    // Arrange
-    const elementSize: Size = { width: 300, height: 100 };
-    const viewportSize: Size = {
-      width: 1280,
-      height: 960,
-    };
-    const targetPosition: Position = {
-      top: 430,
-      right: 690,
-      bottom: 530,
-      left: 590,
-    };
-    const gap = 10;
+  it.each([
+    { preferredSide: 'top', expectedPosition: { top: 320, right: 790, bottom: 420, left: 490 } },
+    { preferredSide: 'right', expectedPosition: { top: 430, right: 1000, bottom: 530, left: 700 } },
+    { preferredSide: 'bottom', expectedPosition: { top: 540, right: 790, bottom: 640, left: 490 } },
+    { preferredSide: 'left', expectedPosition: { top: 430, right: 580, bottom: 530, left: 280 } },
+  ] as { preferredSide: Side; expectedPosition: Position }[])(
+    'computes position of popup element based on position of target element',
+    ({ preferredSide, expectedPosition }) => {
+      // Arrange
+      const elementSize: Size = { width: 300, height: 100 };
+      const viewportSize: Size = {
+        width: 1280,
+        height: 960,
+      };
+      const targetPosition: Position = {
+        top: 430,
+        right: 690,
+        bottom: 530,
+        left: 590,
+      };
+      const gap = 10;
 
-    // Act
-    const topPopup = computePopupPosition({
-      elementSize,
-      gap,
-      preferredSide: 'top',
-      targetPosition,
-      viewportSize,
-    });
+      // Act
+      const popup = computePopupPosition({
+        elementSize,
+        gap,
+        preferredSide,
+        targetPosition,
+        viewportSize,
+      });
 
-    const rightPopup = computePopupPosition({
-      elementSize,
-      gap,
-      preferredSide: 'right',
-      targetPosition,
-      viewportSize,
-    });
-
-    const bottomPopup = computePopupPosition({
-      elementSize,
-      gap,
-      preferredSide: 'bottom',
-      targetPosition,
-      viewportSize,
-    });
-
-    const leftPopup = computePopupPosition({
-      elementSize,
-      gap,
-      preferredSide: 'left',
-      targetPosition,
-      viewportSize,
-    });
-
-    // Assert
-    expect(topPopup.position).toEqual({ top: 320, right: 790, bottom: 420, left: 490 });
-    expect(topPopup.side).toBe('top');
-
-    expect(rightPopup.position).toEqual({ top: 430, right: 1000, bottom: 530, left: 700 });
-    expect(rightPopup.side).toBe('right');
-
-    expect(bottomPopup.position).toEqual({ top: 540, right: 790, bottom: 640, left: 490 });
-    expect(bottomPopup.side).toBe('bottom');
-
-    expect(leftPopup.position).toEqual({ top: 430, right: 580, bottom: 530, left: 280 });
-    expect(leftPopup.side).toBe('left');
-  });
+      // Assert
+      expect(popup.position).toEqual(expectedPosition);
+      expect(popup.side).toBe(preferredSide);
+    }
+  );
 
   it('moves popup to opposite side if there is not enough space on preferred side', () => {
     // Arrange

--- a/packages/components/src/internal/popup-utils.test.ts
+++ b/packages/components/src/internal/popup-utils.test.ts
@@ -42,34 +42,56 @@ describe('computePopupPosition', () => {
     }
   );
 
-  it('moves popup to opposite side if there is not enough space on preferred side', () => {
-    // Arrange
-    const elementSize: Size = { width: 300, height: 100 };
-    const viewportSize: Size = {
-      width: 1280,
-      height: 960,
-    };
-    const targetPosition: Position = {
-      top: 430,
-      right: 1180,
-      bottom: 530,
-      left: 1080,
-    };
-    const gap = 10;
-
-    // Act
-    const popup = computePopupPosition({
-      elementSize,
-      gap,
+  it.each([
+    {
+      targetPosition: { top: 50, right: 690, bottom: 150, left: 590 },
+      preferredSide: 'top',
+      expectedPosition: { top: 160, right: 790, bottom: 260, left: 490 },
+      expectedSide: 'bottom',
+    },
+    {
+      targetPosition: { top: 430, right: 1180, bottom: 530, left: 1080 },
       preferredSide: 'right',
-      targetPosition,
-      viewportSize,
-    });
+      expectedPosition: { top: 430, right: 1070, bottom: 530, left: 770 },
+      expectedSide: 'left',
+    },
+    {
+      targetPosition: { top: 810, right: 690, bottom: 910, left: 590 },
+      preferredSide: 'bottom',
+      expectedPosition: { top: 700, right: 790, bottom: 800, left: 490 },
+      expectedSide: 'top',
+    },
+    {
+      targetPosition: { top: 430, right: 300, bottom: 530, left: 200 },
+      preferredSide: 'left',
+      expectedPosition: { top: 430, right: 610, bottom: 530, left: 310 },
+      expectedSide: 'right',
+    },
+  ] as { targetPosition: Position; preferredSide: Side; expectedPosition: Position; expectedSide: Side }[])(
+    'moves popup to opposite side if there is not enough space on preferred side',
+    ({ targetPosition, preferredSide, expectedPosition, expectedSide }) => {
+      // Arrange
+      const elementSize: Size = { width: 300, height: 100 };
+      const viewportSize: Size = {
+        width: 1280,
+        height: 960,
+      };
+      const gap = 10;
 
-    // Assert
-    expect(popup.position).toEqual({ top: 430, right: 1070, bottom: 530, left: 770 });
-    expect(popup.side).toBe('left');
-  });
+      // Act
+      const popup = computePopupPosition({
+        elementSize,
+        gap,
+        preferredSide,
+        targetPosition,
+        viewportSize,
+      });
+
+      // Assert
+      expect(popup.position).toEqual(expectedPosition);
+      expect(popup.side).toBe(expectedSide);
+    }
+  );
 });
 
 describe('useBoundingRects', () => {

--- a/packages/components/src/internal/popup-utils.test.ts
+++ b/packages/components/src/internal/popup-utils.test.ts
@@ -2,17 +2,17 @@ import { render } from '@testing-library/react';
 import { useRef } from 'react';
 import { div, h } from 'react-hyperscript-helpers';
 
-import { computePopupPosition, useBoundingRects } from './popup-utils';
+import { computePopupPosition, Position, Size, useBoundingRects } from './popup-utils';
 
 describe('computePopupPosition', () => {
   it('computes position of popup element based on position of target element', () => {
     // Arrange
-    const elementSize = { width: 300, height: 100 };
-    const viewportSize = {
+    const elementSize: Size = { width: 300, height: 100 };
+    const viewportSize: Size = {
       width: 1280,
       height: 960,
     };
-    const targetPosition = {
+    const targetPosition: Position = {
       top: 430,
       right: 690,
       bottom: 530,
@@ -69,12 +69,12 @@ describe('computePopupPosition', () => {
 
   it('moves popup to opposite side if there is not enough space on preferred side', () => {
     // Arrange
-    const elementSize = { width: 300, height: 100 };
-    const viewportSize = {
+    const elementSize: Size = { width: 300, height: 100 };
+    const viewportSize: Size = {
       width: 1280,
       height: 960,
     };
-    const targetPosition = {
+    const targetPosition: Position = {
       top: 430,
       right: 1180,
       bottom: 530,

--- a/packages/components/src/internal/popup-utils.test.ts
+++ b/packages/components/src/internal/popup-utils.test.ts
@@ -1,0 +1,202 @@
+import { render } from '@testing-library/react';
+import { useRef } from 'react';
+import { div, h } from 'react-hyperscript-helpers';
+
+import { computePopupPosition, useBoundingRects } from './popup-utils';
+
+describe('computePopupPosition', () => {
+  it('computes position of popup element based on position of target element', () => {
+    // Arrange
+    const elementSize = { width: 300, height: 100 };
+    const viewportSize = {
+      width: 1280,
+      height: 960,
+    };
+    const targetPosition = {
+      top: 430,
+      right: 690,
+      bottom: 530,
+      left: 590,
+    };
+    const gap = 10;
+
+    // Act
+    const topPopup = computePopupPosition({
+      elementSize,
+      gap,
+      preferredSide: 'top',
+      targetPosition,
+      viewportSize,
+    });
+
+    const rightPopup = computePopupPosition({
+      elementSize,
+      gap,
+      preferredSide: 'right',
+      targetPosition,
+      viewportSize,
+    });
+
+    const bottomPopup = computePopupPosition({
+      elementSize,
+      gap,
+      preferredSide: 'bottom',
+      targetPosition,
+      viewportSize,
+    });
+
+    const leftPopup = computePopupPosition({
+      elementSize,
+      gap,
+      preferredSide: 'left',
+      targetPosition,
+      viewportSize,
+    });
+
+    // Assert
+    expect(topPopup.position).toEqual({ top: 320, right: 790, bottom: 420, left: 490 });
+    expect(topPopup.side).toBe('top');
+
+    expect(rightPopup.position).toEqual({ top: 430, right: 1000, bottom: 530, left: 700 });
+    expect(rightPopup.side).toBe('right');
+
+    expect(bottomPopup.position).toEqual({ top: 540, right: 790, bottom: 640, left: 490 });
+    expect(bottomPopup.side).toBe('bottom');
+
+    expect(leftPopup.position).toEqual({ top: 430, right: 580, bottom: 530, left: 280 });
+    expect(leftPopup.side).toBe('left');
+  });
+
+  it('moves popup to opposite side if there is not enough space on preferred side', () => {
+    // Arrange
+    const elementSize = { width: 300, height: 100 };
+    const viewportSize = {
+      width: 1280,
+      height: 960,
+    };
+    const targetPosition = {
+      top: 430,
+      right: 1180,
+      bottom: 530,
+      left: 1080,
+    };
+    const gap = 10;
+
+    // Act
+    const popup = computePopupPosition({
+      elementSize,
+      gap,
+      preferredSide: 'right',
+      targetPosition,
+      viewportSize,
+    });
+
+    // Assert
+    expect(popup.position).toEqual({ top: 430, right: 1070, bottom: 530, left: 770 });
+    expect(popup.side).toBe('left');
+  });
+});
+
+describe('useBoundingRects', () => {
+  beforeAll(() => {
+    // JSDOM's getBoundingClientRect always returns all zeroes.
+    jest.spyOn(window.HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function () {
+      // @ts-ignore
+      // eslint-disable-next-line
+      const self: HTMLElement = this;
+
+      const width = parseFloat(self.style.width) || 0;
+      const height = parseFloat(self.style.height) || 0;
+      const top = parseFloat(self.style.marginTop) || 0;
+      const left = parseFloat(self.style.marginLeft) || 0;
+
+      return {
+        x: left,
+        y: top,
+        width,
+        height,
+        top,
+        right: left + width,
+        bottom: top + height,
+        left,
+      } as DOMRect;
+    });
+  });
+
+  it('returns bounding rect for elements selected by ref', () => {
+    // Arrange
+    const receivedBoundingRect = jest.fn();
+
+    const TestComponent = () => {
+      const ref = useRef<HTMLDivElement>(null);
+
+      const [boundingRect] = useBoundingRects([{ ref }]);
+      receivedBoundingRect(boundingRect);
+
+      return div({ ref, style: { width: 200, height: 100, margin: '100px 0 0 50px' } });
+    };
+
+    // Act
+    render(h(TestComponent));
+
+    // Assert
+    expect(receivedBoundingRect).toHaveBeenCalledWith({
+      width: 200,
+      height: 100,
+      top: 100,
+      right: 250,
+      bottom: 200,
+      left: 50,
+    });
+  });
+
+  it('returns bounding rect for elements selected by ID', () => {
+    // Arrange
+    const receivedBoundingRect = jest.fn();
+
+    const TestComponent = () => {
+      const [boundingRect] = useBoundingRects([{ id: 'test-element' }]);
+      receivedBoundingRect(boundingRect);
+
+      return div({ id: 'test-element', style: { width: 200, height: 100, margin: '100px 0 0 50px' } });
+    };
+
+    // Act
+    render(h(TestComponent));
+
+    // Assert
+    expect(receivedBoundingRect).toHaveBeenCalledWith({
+      width: 200,
+      height: 100,
+      top: 100,
+      right: 250,
+      bottom: 200,
+      left: 50,
+    });
+  });
+
+  it('returns bounding rect for the window', () => {
+    // Arrange
+    const receivedBoundingRect = jest.fn();
+
+    const TestComponent = () => {
+      const [boundingRect] = useBoundingRects([{ viewport: true }]);
+      receivedBoundingRect(boundingRect);
+
+      return null;
+    };
+
+    // Act
+    render(h(TestComponent));
+
+    // Assert
+    expect(receivedBoundingRect).toHaveBeenCalledWith({
+      width: 1024,
+      height: 768,
+      top: 0,
+      right: 1024,
+      bottom: 768,
+      left: 0,
+    });
+  });
+});

--- a/packages/components/src/internal/popup-utils.ts
+++ b/packages/components/src/internal/popup-utils.ts
@@ -1,0 +1,173 @@
+import _ from 'lodash/fp';
+import { RefObject, useCallback, useEffect, useRef, useState } from 'react';
+
+interface Size {
+  width: number;
+  height: number;
+}
+
+interface Position {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+}
+
+type Side = 'top' | 'right' | 'bottom' | 'left';
+
+interface ComputePopupPositionArgs {
+  /* Size of the popup element. */
+  elementSize: Size;
+
+  /* Gap between popup and target elements. */
+  gap: number;
+
+  /* Preferred side of the target element to place the popup element on. */
+  preferredSide: Side;
+
+  /* Position of the target element. */
+  targetPosition: Position;
+
+  /* Size of the window. */
+  viewportSize: Size;
+}
+
+interface ComputePopupPositionResult {
+  position: Position;
+  side: Side;
+}
+
+/**
+ * Compute a popup's position based on its target element.
+ */
+export const computePopupPosition = (args: ComputePopupPositionArgs): ComputePopupPositionResult => {
+  const { elementSize, gap, preferredSide, targetPosition, viewportSize } = args;
+
+  const getPosition = (s: Side): Pick<Position, 'left' | 'top'> => {
+    const left = _.flow(
+      _.clamp(0, viewportSize.width - elementSize.width),
+      _.clamp(targetPosition.left - elementSize.width + 16, targetPosition.right - 16)
+    )((targetPosition.left + targetPosition.right) / 2 - elementSize.width / 2);
+
+    const top = _.flow(
+      _.clamp(0, viewportSize.height - elementSize.height),
+      _.clamp(targetPosition.top - elementSize.height + 16, targetPosition.bottom - 16)
+    )((targetPosition.top + targetPosition.bottom) / 2 - elementSize.height / 2);
+
+    switch (s) {
+      case 'top':
+        return { top: targetPosition.top - elementSize.height - gap, left };
+      case 'right':
+        return { left: targetPosition.right + gap, top };
+      case 'bottom':
+        return { top: targetPosition.bottom + gap, left };
+      case 'left':
+        return { left: targetPosition.left - elementSize.width - gap, top };
+      default:
+        throw new Error('Invalid side');
+    }
+  };
+
+  const position = getPosition(preferredSide);
+
+  // If the popup would overflow the viewport when placed on the preferred side of the target
+  // element, "flip" it to the other side of the element.
+  const maybeFlip = (d: Side): Side => {
+    switch (d) {
+      case 'top':
+        return position.top < 0 ? 'bottom' : 'top';
+      case 'right':
+        return position.left + elementSize.width >= viewportSize.width ? 'left' : 'right';
+      case 'bottom':
+        return position.top + elementSize.height >= viewportSize.height ? 'top' : 'bottom';
+      case 'left':
+        return position.left < 0 ? 'right' : 'left';
+      default:
+        throw new Error('Invalid side');
+    }
+  };
+
+  const finalSide = maybeFlip(preferredSide);
+
+  // Recompute position after side may have changed.
+  const finalPosition = getPosition(finalSide);
+
+  return {
+    position: {
+      ...finalPosition,
+      right: finalPosition.left + elementSize.width,
+      bottom: finalPosition.top + elementSize.height,
+    },
+    side: finalSide,
+  };
+};
+
+type BoundingRect = Size & Position;
+
+const toBoundingRect: (domRect: DOMRect) => BoundingRect = _.pick([
+  'width',
+  'height',
+  'top',
+  'right',
+  'bottom',
+  'left',
+]);
+
+type UseBoundingRectsSelector =
+  | { ref: RefObject<HTMLElement | null | undefined> }
+  | { id: string }
+  | { viewport: true };
+
+/**
+ * Returns the bounding rectangles of specified elements.
+ * @param selectors - Selectors for elements. Selectors can be by ref, ID, or the viewport/window.
+ */
+export const useBoundingRects = (selectors: UseBoundingRectsSelector[]): BoundingRect[] => {
+  const [dimensions, setDimensions] = useState<BoundingRect[]>(
+    selectors.map(() => ({ width: 0, height: 0, top: 0, right: 0, bottom: 0, left: 0 }))
+  );
+
+  const dimensionsRef = useRef<BoundingRect[]>();
+  dimensionsRef.current = dimensions;
+
+  const animationRef = useRef<number>();
+
+  const computePosition = useCallback(() => {
+    const newDimensions: BoundingRect[] = selectors.map((selector) => {
+      if ('ref' in selector && selector.ref.current) {
+        return toBoundingRect(selector.ref.current.getBoundingClientRect());
+      }
+
+      if ('id' in selector) {
+        const element = document.getElementById(selector.id);
+        if (element) {
+          return toBoundingRect(element.getBoundingClientRect());
+        }
+      }
+
+      if ('viewport' in selector) {
+        const width = window.innerWidth;
+        const height = window.innerHeight;
+        return { width, height, top: 0, right: width, bottom: height, left: 0 };
+      }
+
+      return { width: 0, height: 0, top: 0, right: 0, bottom: 0, left: 0 };
+    });
+
+    if (!_.isEqual(newDimensions, dimensionsRef.current)) {
+      setDimensions(newDimensions);
+    }
+
+    animationRef.current = requestAnimationFrame(computePosition);
+  }, [selectors]);
+
+  useEffect(() => {
+    computePosition();
+    return () => {
+      // animationRef.current is set in computePosition, so it will be non-null here.
+      cancelAnimationFrame(animationRef.current!);
+    };
+  }, [computePosition]);
+
+  return dimensions;
+};

--- a/packages/components/src/internal/popup-utils.ts
+++ b/packages/components/src/internal/popup-utils.ts
@@ -1,21 +1,21 @@
 import _ from 'lodash/fp';
 import { RefObject, useCallback, useEffect, useRef, useState } from 'react';
 
-interface Size {
+export interface Size {
   width: number;
   height: number;
 }
 
-interface Position {
+export interface Position {
   top: number;
   right: number;
   bottom: number;
   left: number;
 }
 
-type Side = 'top' | 'right' | 'bottom' | 'left';
+export type Side = 'top' | 'right' | 'bottom' | 'left';
 
-interface ComputePopupPositionArgs {
+export interface ComputePopupPositionArgs {
   /* Size of the popup element. */
   elementSize: Size;
 
@@ -113,7 +113,7 @@ const toBoundingRect: (domRect: DOMRect) => BoundingRect = _.pick([
   'left',
 ]);
 
-type UseBoundingRectsSelector =
+export type UseBoundingRectsSelector =
   | { ref: RefObject<HTMLElement | null | undefined> }
   | { id: string }
   | { viewport: true };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2987,12 +2987,14 @@ __metadata:
     jest: ^27.4.3
     lodash: ^4.17.21
     react: 18.2.0
+    react-dom: 18.2.0
     react-hyperscript-helpers: ^2.0.0
     typescript: ^4.9.5
     vite: ^4.3.9
     vite-plugin-svgr: ^3.2.0
   peerDependencies:
     react: 18.2.0
+    react-dom: 18.2.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/UIE-51

Continuing to add dependencies of Clickable to components... this adds a version of popup-utils. Along the way, I split up popup-utils into multiple modules, renamed some variables, and adjusted some interfaces to make more sense with types.

Note that this does not replace popup-utils in Terra UI. Most of this will be internal to the components package. Once popup related components are moved to the components package, popup-utils can be removed from Terra UI.