### PR TITLE
WM-2170: Allow usage of deployed WORKFLOWS_APP

### DIFF
--- a/src/workflows-app/utils/app-utils.js
+++ b/src/workflows-app/utils/app-utils.js
@@ -23,7 +23,9 @@ export const resolveRunningCromwellAppUrl = (apps, currentUser) => {
   // note: the requirement for checking if the app was created by user will not be needed when we move to multi-user Workflows app where users with
   // OWNER and WRITER roles will be able to import methods to app created by another user
   const filteredApps = apps.filter(
-    (app) => app.appType === appToolLabels.CROMWELL && app.status === 'RUNNING' && app.auditInfo.creator === currentUser
+    (app) =>
+      ((app.appType === appToolLabels.CROMWELL && app.auditInfo.creator === currentUser) || app.appType === appToolLabels.WORKFLOWS_APP) &&
+      app.status === 'RUNNING'
   );
   if (filteredApps.length === 1) {
     return {

--- a/src/workflows-app/utils/app-utils.test.js
+++ b/src/workflows-app/utils/app-utils.test.js
@@ -29,15 +29,19 @@ describe('resolveRunningCromwellAppUrl', () => {
       appType: 'CROMWELL',
       expectedUrl: { cbasUrl: mockCbasUrl, cbasUiUrl: mockCbasUiUrl, cromwellUrl: mockCromwellUrl },
     },
-    { appStatus: appStatuses.provisioning.status, expectedUrl: null },
-    { appStatus: appStatuses.stopped.status, expectedUrl: null },
-    { appStatus: appStatuses.stopping.status, expectedUrl: null },
-    { appStatus: appStatuses.error.status, expectedUrl: null },
+    { appStatus: appStatuses.provisioning.status, appType: 'CROMWELL', expectedUrl: null },
+    { appStatus: appStatuses.stopped.status, appType: 'CROMWELL', expectedUrl: null },
+    { appStatus: appStatuses.stopping.status, appType: 'CROMWELL', expectedUrl: null },
+    { appStatus: appStatuses.error.status, appType: 'CROMWELL', expectedUrl: null },
     {
       appStatus: appStatuses.running.status,
       appType: 'WORKFLOWS_APP',
       expectedUrl: { cbasUrl: mockCbasUrl, cbasUiUrl: mockCbasUiUrl, cromwellUrl: mockCromwellUrl },
     },
+    { appStatus: appStatuses.provisioning.status, appType: 'WORKFLOWS_APP', expectedUrl: null },
+    { appStatus: appStatuses.stopped.status, appType: 'WORKFLOWS_APP', expectedUrl: null },
+    { appStatus: appStatuses.stopping.status, appType: 'WORKFLOWS_APP', expectedUrl: null },
+    { appStatus: appStatuses.error.status, appType: 'WORKFLOWS_APP', expectedUrl: null },
   ])('returns correct value for Cromwell app in $appStatus from the Leo response', ({ appStatus, appType, expectedUrl }) => {
     const mockAppsResponse = [
       {
@@ -81,6 +85,33 @@ describe('resolveRunningCromwellAppUrl', () => {
     ];
 
     expect(resolveRunningCromwellAppUrl(mockApps, mockCurrentUserEmail)).toBe(null);
+  });
+
+  it('returns the correct WORKFLOWS app even if not created by current user in the workspace', () => {
+    const mockApps = [
+      {
+        ...appResponseCommonField,
+        appType: 'WORKFLOWS_APP',
+        status: 'RUNNING',
+        proxyUrls: {
+          cbas: mockCbasUrl,
+          'cbas-ui': mockCbasUiUrl,
+          cromwell: mockCromwellUrl,
+        },
+        auditInfo: {
+          creator: 'not-abc@gmail.com',
+          createdDate: '2021-12-10T20:19:13.162484Z',
+          destroyedDate: null,
+          dateAccessed: '2021-12-11T20:19:13.162484Z',
+        },
+      },
+    ];
+
+    expect(resolveRunningCromwellAppUrl(mockApps, mockCurrentUserEmail)).toStrictEqual({
+      cbasUiUrl: mockCbasUiUrl,
+      cbasUrl: mockCbasUrl,
+      cromwellUrl: mockCromwellUrl,
+    });
   });
 
   it('returns null if there exists apps other than Cromwell in the workspace', () => {

--- a/src/workflows-app/utils/app-utils.test.js
+++ b/src/workflows-app/utils/app-utils.test.js
@@ -24,16 +24,25 @@ describe('resolveRunningCromwellAppUrl', () => {
   };
 
   it.each([
-    { appStatus: appStatuses.running.status, expectedUrl: { cbasUrl: mockCbasUrl, cbasUiUrl: mockCbasUiUrl, cromwellUrl: mockCromwellUrl } },
+    {
+      appStatus: appStatuses.running.status,
+      appType: 'CROMWELL',
+      expectedUrl: { cbasUrl: mockCbasUrl, cbasUiUrl: mockCbasUiUrl, cromwellUrl: mockCromwellUrl },
+    },
     { appStatus: appStatuses.provisioning.status, expectedUrl: null },
     { appStatus: appStatuses.stopped.status, expectedUrl: null },
     { appStatus: appStatuses.stopping.status, expectedUrl: null },
     { appStatus: appStatuses.error.status, expectedUrl: null },
-  ])('returns correct value for Cromwell app in $appStatus from the Leo response', ({ appStatus, expectedUrl }) => {
+    {
+      appStatus: appStatuses.running.status,
+      appType: 'WORKFLOWS_APP',
+      expectedUrl: { cbasUrl: mockCbasUrl, cbasUiUrl: mockCbasUiUrl, cromwellUrl: mockCromwellUrl },
+    },
+  ])('returns correct value for Cromwell app in $appStatus from the Leo response', ({ appStatus, appType, expectedUrl }) => {
     const mockAppsResponse = [
       {
         ...appResponseCommonField,
-        appType: 'CROMWELL',
+        appType,
         status: appStatus,
         proxyUrls: {
           cbas: mockCbasUrl,


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WM-2170

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Allows users to find and interact with a deployed WORKFLOWS_APP instance just like they would with a deployed CROMWELL instance.
- Note: Still depends on the WORKFLOWS_APP having been created, which is still behind a feature flag

### Testing strategy
- Relies on existing unit tests to guarantee nothing has broken in existing functionality.
- Testing in a live environment depends on a working environment and in-flight app deployment tickets. 