### PR TITLE
[AJ-1310] Import data page cleanup

### DIFF
--- a/src/import-data/ImportData.ts
+++ b/src/import-data/ImportData.ts
@@ -1,6 +1,7 @@
 import _ from 'lodash/fp';
 import { Fragment, useCallback, useState } from 'react';
 import { h } from 'react-hyperscript-helpers';
+import { spinnerOverlay } from 'src/components/common';
 import { notifyDataImportProgress } from 'src/data/import-jobs';
 import { Ajax } from 'src/libs/ajax';
 import { Dataset } from 'src/libs/ajax/Catalog';
@@ -204,8 +205,8 @@ export const ImportData = () => {
       importMayTakeTime: isDataset,
       authorizationDomain: ad,
       onImport,
-      isImporting,
       isProtectedData,
     }),
+    isImporting && spinnerOverlay,
   ]);
 };

--- a/src/import-data/ImportData.ts
+++ b/src/import-data/ImportData.ts
@@ -203,7 +203,7 @@ export const ImportData = () => {
       template,
       userHasBillingProjects,
       importMayTakeTime: isDataset,
-      authorizationDomain: ad,
+      requiredAuthorizationDomain: ad,
       onImport,
       isProtectedData,
     }),

--- a/src/import-data/ImportData.ts
+++ b/src/import-data/ImportData.ts
@@ -198,7 +198,7 @@ export const ImportData = () => {
   return h(Fragment, [
     h(ImportDataOverview, { header, snapshots, isDataset, snapshotResponses, url, isProtectedData }),
     h(ImportDataDestination, {
-      workspaceId: wid,
+      initialSelectedWorkspaceId: wid,
       templateWorkspaces,
       template,
       userHasBillingProjects,

--- a/src/import-data/ImportDataDestination.test.ts
+++ b/src/import-data/ImportDataDestination.test.ts
@@ -56,7 +56,6 @@ describe('ImportDataDestination', () => {
         importMayTakeTime: true,
         authorizationDomain: '',
         onImport: () => {},
-        isImporting: false,
         isProtectedData: true,
       })
     );
@@ -84,7 +83,6 @@ describe('ImportDataDestination', () => {
         importMayTakeTime: true,
         authorizationDomain: '',
         onImport: () => {},
-        isImporting: false,
         isProtectedData: false,
       })
     );
@@ -111,7 +109,6 @@ describe('ImportDataDestination', () => {
         importMayTakeTime: true,
         authorizationDomain: '',
         onImport: () => {},
-        isImporting: false,
         isProtectedData: true,
       })
     );

--- a/src/import-data/ImportDataDestination.test.ts
+++ b/src/import-data/ImportDataDestination.test.ts
@@ -44,7 +44,8 @@ jest.mock(
 );
 
 describe('ImportDataDestination', () => {
-  it('should explain protected data restricts eligible workspaces', async () => {
+  it.each([true, false])('should explain protected data restricts eligible workspaces', async (isProtectedData) => {
+    // Arrange
     const user = userEvent.setup();
 
     render(
@@ -56,45 +57,24 @@ describe('ImportDataDestination', () => {
         importMayTakeTime: true,
         requiredAuthorizationDomain: undefined,
         onImport: () => {},
-        isProtectedData: true,
+        isProtectedData,
       })
     );
+
+    // Act
     const existingWorkspace = screen.getByText('Start with an existing workspace', { exact: false });
     await user.click(existingWorkspace); // select start with existing workspace
 
+    // Assert
     const protectedWarning = screen.queryByText(
       'You may only import to workspaces with an Authorization Domain and/or protected data setting.',
       {
         exact: false,
       }
     );
-    expect(protectedWarning).not.toBeNull();
-  });
 
-  it('should not inform about protected data', async () => {
-    const user = userEvent.setup();
-
-    render(
-      h(ImportDataDestination, {
-        initialSelectedWorkspaceId: undefined,
-        templateWorkspaces: {},
-        template: undefined,
-        userHasBillingProjects: true,
-        importMayTakeTime: true,
-        requiredAuthorizationDomain: undefined,
-        onImport: () => {},
-        isProtectedData: false,
-      })
-    );
-    const existingWorkspace = screen.getByText('Start with an existing workspace', { exact: false });
-    await user.click(existingWorkspace); // select start with existing workspace
-    const protectedWarning = screen.queryByText(
-      'You may only import to workspaces with an Authorization Domain and/or protected data setting.',
-      {
-        exact: false,
-      }
-    );
-    expect(protectedWarning).toBeNull();
+    const isWarningShown = !!protectedWarning;
+    expect(isWarningShown).toEqual(isProtectedData);
   });
 
   it('should disable noncompliant workspaces', async () => {

--- a/src/import-data/ImportDataDestination.test.ts
+++ b/src/import-data/ImportDataDestination.test.ts
@@ -54,7 +54,7 @@ describe('ImportDataDestination', () => {
         template: undefined,
         userHasBillingProjects: true,
         importMayTakeTime: true,
-        authorizationDomain: '',
+        requiredAuthorizationDomain: undefined,
         onImport: () => {},
         isProtectedData: true,
       })
@@ -81,7 +81,7 @@ describe('ImportDataDestination', () => {
         template: undefined,
         userHasBillingProjects: true,
         importMayTakeTime: true,
-        authorizationDomain: '',
+        requiredAuthorizationDomain: undefined,
         onImport: () => {},
         isProtectedData: false,
       })
@@ -107,7 +107,7 @@ describe('ImportDataDestination', () => {
         template: undefined,
         userHasBillingProjects: true,
         importMayTakeTime: true,
-        authorizationDomain: '',
+        requiredAuthorizationDomain: undefined,
         onImport: () => {},
         isProtectedData: true,
       })

--- a/src/import-data/ImportDataDestination.test.ts
+++ b/src/import-data/ImportDataDestination.test.ts
@@ -49,7 +49,7 @@ describe('ImportDataDestination', () => {
 
     render(
       h(ImportDataDestination, {
-        workspaceId: undefined,
+        initialSelectedWorkspaceId: undefined,
         templateWorkspaces: {},
         template: undefined,
         userHasBillingProjects: true,
@@ -76,7 +76,7 @@ describe('ImportDataDestination', () => {
 
     render(
       h(ImportDataDestination, {
-        workspaceId: undefined,
+        initialSelectedWorkspaceId: undefined,
         templateWorkspaces: {},
         template: undefined,
         userHasBillingProjects: true,
@@ -102,7 +102,7 @@ describe('ImportDataDestination', () => {
 
     render(
       h(ImportDataDestination, {
-        workspaceId: undefined,
+        initialSelectedWorkspaceId: undefined,
         templateWorkspaces: {},
         template: undefined,
         userHasBillingProjects: true,

--- a/src/import-data/ImportDataDestination.ts
+++ b/src/import-data/ImportDataDestination.ts
@@ -84,18 +84,18 @@ const ChoiceButton = (props: ChoiceButtonProps): ReactNode => {
 
 interface ImportDataDestinationProps {
   importMayTakeTime: boolean;
+  initialSelectedWorkspaceId: string | undefined;
   isProtectedData: boolean;
   requiredAuthorizationDomain: string | undefined;
   template: string | undefined;
   templateWorkspaces: { [key: string]: TemplateWorkspaceInfo[] } | undefined;
   userHasBillingProjects: boolean;
-  workspaceId: string | undefined;
   onImport: (workspace: WorkspaceInfo) => void;
 }
 
 export const ImportDataDestination = (props: ImportDataDestinationProps): ReactNode => {
   const {
-    workspaceId,
+    initialSelectedWorkspaceId,
     templateWorkspaces,
     template,
     userHasBillingProjects,
@@ -105,7 +105,9 @@ export const ImportDataDestination = (props: ImportDataDestinationProps): ReactN
     isProtectedData,
   } = props;
   const { workspaces, refresh: refreshWorkspaces, loading: loadingWorkspaces } = useWorkspaces();
-  const [mode, setMode] = useState<'existing' | 'template' | undefined>(workspaceId ? 'existing' : undefined);
+  const [mode, setMode] = useState<'existing' | 'template' | undefined>(
+    initialSelectedWorkspaceId ? 'existing' : undefined
+  );
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [isCloneOpen, setIsCloneOpen] = useState(false);
   const [selectedTemplateWorkspaceKey, setSelectedTemplateWorkspaceKey] = useState<{
@@ -113,7 +115,7 @@ export const ImportDataDestination = (props: ImportDataDestinationProps): ReactN
     name: string;
   }>();
 
-  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState(workspaceId);
+  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState(initialSelectedWorkspaceId);
 
   const selectedWorkspace = _.find({ workspace: { workspaceId: selectedWorkspaceId } }, workspaces);
 

--- a/src/import-data/ImportDataDestination.ts
+++ b/src/import-data/ImportDataDestination.ts
@@ -85,7 +85,6 @@ const ChoiceButton = (props: ChoiceButtonProps): ReactNode => {
 interface ImportDataDestinationProps {
   authorizationDomain: string | undefined;
   importMayTakeTime: boolean;
-  isImporting: boolean;
   isProtectedData: boolean;
   template: string | undefined;
   templateWorkspaces: { [key: string]: TemplateWorkspaceInfo[] } | undefined;
@@ -103,7 +102,6 @@ export const ImportDataDestination = (props: ImportDataDestinationProps): ReactN
     importMayTakeTime,
     authorizationDomain,
     onImport,
-    isImporting,
     isProtectedData,
   } = props;
   const { workspaces, refresh: refreshWorkspaces, loading: loadingWorkspaces } = useWorkspaces();
@@ -325,6 +323,6 @@ export const ImportDataDestination = (props: ImportDataDestinationProps): ReactN
           onImport(w);
         },
       }),
-    (isImporting || loadingWorkspaces) && spinnerOverlay,
+    loadingWorkspaces && spinnerOverlay,
   ]);
 };

--- a/src/import-data/ImportDataDestination.ts
+++ b/src/import-data/ImportDataDestination.ts
@@ -83,9 +83,9 @@ const ChoiceButton = (props: ChoiceButtonProps): ReactNode => {
 };
 
 interface ImportDataDestinationProps {
-  authorizationDomain: string | undefined;
   importMayTakeTime: boolean;
   isProtectedData: boolean;
+  requiredAuthorizationDomain: string | undefined;
   template: string | undefined;
   templateWorkspaces: { [key: string]: TemplateWorkspaceInfo[] } | undefined;
   userHasBillingProjects: boolean;
@@ -100,7 +100,7 @@ export const ImportDataDestination = (props: ImportDataDestinationProps): ReactN
     template,
     userHasBillingProjects,
     importMayTakeTime,
-    authorizationDomain,
+    requiredAuthorizationDomain,
     onImport,
     isProtectedData,
   } = props;
@@ -154,8 +154,8 @@ export const ImportDataDestination = (props: ImportDataDestinationProps): ReactN
               workspaces: _.filter((ws) => {
                 return (
                   Utils.canWrite(ws.accessLevel) &&
-                  (!authorizationDomain ||
-                    _.some({ membersGroupName: authorizationDomain }, ws.workspace.authorizationDomain))
+                  (!requiredAuthorizationDomain ||
+                    _.some({ membersGroupName: requiredAuthorizationDomain }, ws.workspace.authorizationDomain))
                 );
               }, workspaces),
               value: selectedWorkspaceId,
@@ -291,7 +291,7 @@ export const ImportDataDestination = (props: ImportDataDestinationProps): ReactN
             }),
             isCreateOpen &&
               h(NewWorkspaceModal, {
-                requiredAuthDomain: authorizationDomain,
+                requiredAuthDomain: requiredAuthorizationDomain,
                 customMessage: importMayTakeTime && importMayTakeTimeMessage,
                 requireEnhancedBucketLogging: isProtectedData,
                 onDismiss: () => setIsCreateOpen(false),


### PR DESCRIPTION
Building on #4213 and #4227, this continues to tidy up the import data page.

https://github.com/DataBiosphere/terra-ui/pull/4237/commits/70af37b1afe1e4d19750c9c9c63044fbf2ac37ad simplifies ImportDataDestination's props. Previously, ImportData passed `isImporting` to ImportDataDestination so that ImportDataDestination would render a spinner while data is importing. Since ImportData handles the import request, it makes sense that it should show the spinner while that request is going on. This narrows ImportDataDestination's concerns.

https://github.com/DataBiosphere/terra-ui/pull/4237/commits/2dd5b12ab173f8689be8616be246013c9f1debe4 and https://github.com/DataBiosphere/terra-ui/pull/4237/commits/a5c38811031f93459ecfe5b155611a710d8672ef rename some props to be more descriptive of what they represent (`authorizationDomain` => `requiredAuthorizationDomain`, `workspaceId` => `initialSelectedWorkspaceId`). This makes the code easier to understand.

And https://github.com/DataBiosphere/terra-ui/pull/4237/commits/2e0aa6ddbd6bda601ce889af55e48a702d65f3a0 consolidates two similar tests into one using `it.each`. This removes some duplicated test setup code.