### PR TITLE
[AJ-1310] Only show protected workspaces when importing protected data

### DIFF
--- a/src/import-data/ImportDataDestination.test.ts
+++ b/src/import-data/ImportDataDestination.test.ts
@@ -65,7 +65,7 @@ describe('ImportDataDestination', () => {
     expect(isWarningShown).toEqual(isProtectedData);
   });
 
-  it('should filters workspaces through canImportIntoWorkspace', async () => {
+  it('should filter workspaces through canImportIntoWorkspace', async () => {
     // Arrange
     const user = userEvent.setup();
 

--- a/src/import-data/ImportDataDestination.ts
+++ b/src/import-data/ImportDataDestination.ts
@@ -22,7 +22,7 @@ import * as Utils from 'src/libs/utils';
 import { WorkspaceInfo } from 'src/libs/workspace-utils';
 
 import { TemplateWorkspaceInfo } from './import-types';
-import { isProtectedWorkspace } from './protected-data-utils';
+import { canImportIntoWorkspace } from './import-utils';
 
 const styles = {
   card: {
@@ -153,16 +153,17 @@ export const ImportDataDestination = (props: ImportDataDestinationProps): ReactN
             // @ts-expect-error
             h(WorkspaceSelector, {
               id,
-              workspaces: _.filter((ws) => {
-                return (
-                  Utils.canWrite(ws.accessLevel) &&
-                  (!requiredAuthorizationDomain ||
-                    _.some({ membersGroupName: requiredAuthorizationDomain }, ws.workspace.authorizationDomain))
+              workspaces: workspaces.filter((workspace) => {
+                return canImportIntoWorkspace(
+                  {
+                    isProtectedData,
+                    requiredAuthorizationDomain,
+                  },
+                  workspace
                 );
-              }, workspaces),
+              }),
               value: selectedWorkspaceId,
               onChange: setSelectedWorkspaceId,
-              isOptionDisabled: (workspace) => isProtectedData && !isProtectedWorkspace(workspace),
             }),
           ]),
       ]),

--- a/src/import-data/import-utils.test.ts
+++ b/src/import-data/import-utils.test.ts
@@ -1,0 +1,86 @@
+import { WorkspaceWrapper } from 'src/libs/workspace-utils';
+import { makeAzureWorkspace, makeGoogleWorkspace } from 'src/testing/workspace-fixtures';
+
+import { canImportIntoWorkspace } from './import-utils';
+
+describe('canImportIntoWorkspace', () => {
+  it('requires permission to write to the workspace', () => {
+    // Arrange
+    const ownedWorkspace = makeAzureWorkspace({ accessLevel: 'OWNER' });
+    const writableWorkspace = makeAzureWorkspace({ accessLevel: 'WRITER' });
+    const readOnlyWorkspace = makeAzureWorkspace({ accessLevel: 'READER' });
+
+    const canImportUnprotectedDataIntoWorkspace = (workspace: WorkspaceWrapper) =>
+      canImportIntoWorkspace({ isProtectedData: false }, workspace);
+
+    // Act
+    const canImportIntoOwnedWorkspace = canImportUnprotectedDataIntoWorkspace(ownedWorkspace);
+    const canImportIntoWritableWorkspace = canImportUnprotectedDataIntoWorkspace(writableWorkspace);
+    const canImportIntoReadOnlyWorkspace = canImportUnprotectedDataIntoWorkspace(readOnlyWorkspace);
+
+    // Assert
+    expect(canImportIntoOwnedWorkspace).toBe(true);
+    expect(canImportIntoWritableWorkspace).toBe(true);
+    expect(canImportIntoReadOnlyWorkspace).toBe(false);
+  });
+
+  it('requires a protected workspace for protected data', () => {
+    // Arrange
+    const unprotectedAzureWorkspace = makeAzureWorkspace();
+
+    const protectedGoogleWorkspace = makeGoogleWorkspace({
+      workspace: { bucketName: 'fc-secure-00001111-2222-3333-aaaa-bbbbccccdddd' },
+    });
+
+    const unprotectedGoogleWorkspace = makeGoogleWorkspace();
+
+    const canImportProtectedDataIntoWorkspace = (workspace: WorkspaceWrapper) =>
+      canImportIntoWorkspace({ isProtectedData: true }, workspace);
+
+    // Act
+    const canImportProtectedDataIntoUnprotectedAzureWorkspace =
+      canImportProtectedDataIntoWorkspace(unprotectedAzureWorkspace);
+
+    const canImportProtectedDataIntoProtectedGoogleWorkspace =
+      canImportProtectedDataIntoWorkspace(protectedGoogleWorkspace);
+
+    const canImportProtectedDataIntoUnprotectedGoogleWorkspace =
+      canImportProtectedDataIntoWorkspace(unprotectedGoogleWorkspace);
+
+    // Assert
+    expect(canImportProtectedDataIntoUnprotectedAzureWorkspace).toBe(false);
+    expect(canImportProtectedDataIntoProtectedGoogleWorkspace).toBe(true);
+    expect(canImportProtectedDataIntoUnprotectedGoogleWorkspace).toBe(false);
+  });
+
+  it('can require an authorization domain', () => {
+    // Arrange
+    const requiredAuthDomain = 'test-ad';
+
+    const workspaceWithRequiredAuthDomain = makeAzureWorkspace({
+      workspace: { authorizationDomain: [{ membersGroupName: requiredAuthDomain }] },
+    });
+
+    const workspaceWithoutRequiredAuthDomain = makeAzureWorkspace();
+
+    const canImportDataWithRequiredAuthDomainIntoWorkspace = (workspace: WorkspaceWrapper) =>
+      canImportIntoWorkspace(
+        {
+          isProtectedData: false,
+          requiredAuthorizationDomain: requiredAuthDomain,
+        },
+        workspace
+      );
+
+    // Act
+    const canImportDataWithRequiredAuthDomainIntoWorkspaceWithRequiredAuthDomain =
+      canImportDataWithRequiredAuthDomainIntoWorkspace(workspaceWithRequiredAuthDomain);
+
+    const canImportDataWithRequiredAuthDomainIntoWorkspaceWithoutRequiredAuthDomain =
+      canImportDataWithRequiredAuthDomainIntoWorkspace(workspaceWithoutRequiredAuthDomain);
+
+    // Assert
+    expect(canImportDataWithRequiredAuthDomainIntoWorkspaceWithRequiredAuthDomain).toBe(true);
+    expect(canImportDataWithRequiredAuthDomainIntoWorkspaceWithoutRequiredAuthDomain).toBe(false);
+  });
+});

--- a/src/import-data/import-utils.ts
+++ b/src/import-data/import-utils.ts
@@ -1,0 +1,46 @@
+import { canWrite } from 'src/libs/utils';
+import { WorkspaceWrapper } from 'src/libs/workspace-utils';
+
+import { isProtectedWorkspace } from './protected-data-utils';
+
+export type ImportOptions = {
+  /** Is the source data protected. */
+  isProtectedData: boolean;
+
+  /** Authorization domain required for the source data. */
+  requiredAuthorizationDomain?: string;
+};
+
+/**
+ * Can the user can import data into a workspace?
+ *
+ * @param importOptions
+ * @param importOptions.isProtectedData - Is the source data protected.
+ * @param importOptions.requiredAuthorizationDomain - Authorization domain required for the source data.
+ * @param workspace - Candidate workspace.
+ */
+export const canImportIntoWorkspace = (importOptions: ImportOptions, workspace: WorkspaceWrapper): boolean => {
+  const { isProtectedData, requiredAuthorizationDomain } = importOptions;
+
+  // The user must be able to write to the workspace to import data.
+  if (!canWrite(workspace.accessLevel)) {
+    return false;
+  }
+
+  // If the source data is protected, the destination workspace must also be protected.
+  if (isProtectedData && !isProtectedWorkspace(workspace)) {
+    return false;
+  }
+
+  // If the import requires an authorization domain, the destination workspace must include that authorization domain.
+  if (
+    requiredAuthorizationDomain &&
+    !workspace.workspace.authorizationDomain.some(
+      ({ membersGroupName }) => membersGroupName === requiredAuthorizationDomain
+    )
+  ) {
+    return false;
+  }
+
+  return true;
+};

--- a/src/testing/workspace-fixtures.ts
+++ b/src/testing/workspace-fixtures.ts
@@ -1,3 +1,4 @@
+import { DeepPartial } from '@terra-ui-packages/core-utils';
 import _ from 'lodash/fp';
 import { defaultLocation } from 'src/analysis/utils/runtime-utils';
 import { locationTypes } from 'src/components/region-common';
@@ -22,6 +23,10 @@ export const defaultAzureWorkspace: AzureWorkspace = {
   accessLevel: 'OWNER',
   canShare: true,
   canCompute: true,
+};
+
+export const makeAzureWorkspace = (workspace?: DeepPartial<AzureWorkspace>): AzureWorkspace => {
+  return _.merge(_.cloneDeep(defaultAzureWorkspace), workspace);
 };
 
 const protectedDataPolicy: WorkspacePolicy = {
@@ -80,6 +85,10 @@ export const defaultGoogleWorkspace: GoogleWorkspace = {
   accessLevel: 'OWNER',
   canShare: true,
   canCompute: true,
+};
+
+export const makeGoogleWorkspace = (workspace?: DeepPartial<GoogleWorkspace>): GoogleWorkspace => {
+  return _.merge(_.cloneDeep(defaultGoogleWorkspace), workspace);
 };
 
 // These defaults are intended to track the default behavior implemented in useWorkspace.ts


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1310

When showing the menu to select a workspace to import data into, workspaces that don't meet the authorization domain requirement are filtered out of the list. But options for workspaces that don't meet the protected data requirement are disabled.

https://github.com/DataBiosphere/terra-ui/blob/e91a6aba8a3a171a3f94c05f7ebd986165f12253/src/import-data/ImportDataDestination.ts#L154-L166

For a more consistent user experience, this also filters out workspaces that don't meet the protected data requirement.

As part of that, it splits out the logic for checking if data can be imported into a workspace into a separate function and adds some additional tests for it.

