### PR TITLE
[UIE-31] Remove duplicate useUniqueId hooks

### DIFF
--- a/src/analysis/modals/AnalysisModal.ts
+++ b/src/analysis/modals/AnalysisModal.ts
@@ -1,3 +1,4 @@
+import { useUniqueId } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import React, { Fragment, ReactElement, useState } from 'react';
 import { div, h, h2, hr, img, span } from 'react-hyperscript-helpers';
@@ -29,7 +30,7 @@ import {
   ToolLabel,
   tools,
 } from 'src/analysis/utils/tool-utils';
-import { ButtonPrimary, Clickable, Select, spinnerOverlay, useUniqueId } from 'src/components/common';
+import { ButtonPrimary, Clickable, Select, spinnerOverlay } from 'src/components/common';
 import Dropzone from 'src/components/Dropzone';
 import { icon } from 'src/components/icons';
 import ModalDrawer from 'src/components/ModalDrawer';

--- a/src/analysis/modals/ComputeModal/AzureComputeModal/AzurePersistentDiskSizeSelectInput.ts
+++ b/src/analysis/modals/ComputeModal/AzureComputeModal/AzurePersistentDiskSizeSelectInput.ts
@@ -1,3 +1,4 @@
+import { useUniqueId } from '@terra-ui-packages/components';
 import React from 'react';
 import { div, h, label } from 'react-hyperscript-helpers';
 import { SingleValue } from 'react-select';
@@ -6,7 +7,6 @@ import { computeStyles } from 'src/analysis/modals/modalStyles';
 import { Select } from 'src/components/common';
 import { azureDiskSizes } from 'src/libs/ajax/leonardo/models/disk-models';
 import { defaultAzureDiskSize } from 'src/libs/azure-utils';
-import { useUniqueId } from 'src/libs/react-utils';
 
 export interface AzurePersistentDiskSizeSelectInputProps {
   persistentDiskSize: number;

--- a/src/analysis/modals/ComputeModal/GcpComputeModal/GcpPersistentDiskSizeNumberInput.ts
+++ b/src/analysis/modals/ComputeModal/GcpComputeModal/GcpPersistentDiskSizeNumberInput.ts
@@ -1,7 +1,7 @@
+import { useUniqueId } from '@terra-ui-packages/components';
 import { div, h, label } from 'react-hyperscript-helpers';
 import { computeStyles } from 'src/analysis/modals/modalStyles';
 import { NumberInput } from 'src/components/input';
-import { useUniqueId } from 'src/libs/react-utils';
 
 export interface GcpPersistentDiskSizeNumberInputProps {
   persistentDiskSize: number;

--- a/src/analysis/modals/ComputeModal/PersistentDiskTypeInput.ts
+++ b/src/analysis/modals/ComputeModal/PersistentDiskTypeInput.ts
@@ -1,3 +1,4 @@
+import { useUniqueId } from '@terra-ui-packages/components';
 import React from 'react';
 import { div, h, label } from 'react-hyperscript-helpers';
 import { SingleValue } from 'react-select';
@@ -5,7 +6,6 @@ import { IComputeConfig } from 'src/analysis/modal-utils';
 import { computeStyles } from 'src/analysis/modals/modalStyles';
 import { Select } from 'src/components/common';
 import { PdSelectOption, SharedPdType } from 'src/libs/ajax/leonardo/models/disk-models';
-import { useUniqueId } from 'src/libs/react-utils';
 
 export interface PersistentDiskTypeInputProps {
   value: SharedPdType;

--- a/src/analysis/modals/ExportAnalysisModal/ExportAnalysisModal.ts
+++ b/src/analysis/modals/ExportAnalysisModal/ExportAnalysisModal.ts
@@ -1,3 +1,4 @@
+import { useUniqueId } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { Fragment, useState } from 'react';
 import { b, h } from 'react-hyperscript-helpers';
@@ -6,7 +7,7 @@ import { analysisLauncherTabName, analysisTabName } from 'src/analysis/runtime-c
 import { getAnalysisFileExtension, stripExtension } from 'src/analysis/utils/file-utils';
 import { analysisNameInput, analysisNameValidator } from 'src/analysis/utils/notebook-utils';
 import { ToolLabel } from 'src/analysis/utils/tool-utils';
-import { ButtonPrimary, spinnerOverlay, useUniqueId } from 'src/components/common';
+import { ButtonPrimary, spinnerOverlay } from 'src/components/common';
 import ErrorView from 'src/components/ErrorView';
 import Modal from 'src/components/Modal';
 import { WorkspaceSelector } from 'src/components/workspace-utils';

--- a/src/components/Collapse.js
+++ b/src/components/Collapse.js
@@ -1,10 +1,10 @@
+import { useUniqueId } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { useEffect, useRef, useState } from 'react';
 import { div, h } from 'react-hyperscript-helpers';
 import { Link } from 'src/components/common';
 import { icon } from 'src/components/icons';
 import colors from 'src/libs/colors';
-import { useUniqueId } from 'src/libs/react-utils';
 import * as Style from 'src/libs/style';
 
 const Collapse = ({

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -1,3 +1,4 @@
+import { useUniqueId } from '@terra-ui-packages/components';
 import { delay } from '@terra-ui-packages/core-utils';
 import _ from 'lodash/fp';
 import PropTypes from 'prop-types';
@@ -7,7 +8,7 @@ import RModal from 'react-modal';
 import { ButtonPrimary, ButtonSecondary, Clickable } from 'src/components/common';
 import { icon } from 'src/components/icons';
 import { getPopupRoot } from 'src/components/popup-utils';
-import { useOnMount, useUniqueId } from 'src/libs/react-utils';
+import { useOnMount } from 'src/libs/react-utils';
 import * as Style from 'src/libs/style';
 import * as Utils from 'src/libs/utils';
 

--- a/src/components/PopupTrigger.js
+++ b/src/components/PopupTrigger.js
@@ -1,3 +1,4 @@
+import { useUniqueId } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { Children, cloneElement, Fragment, useEffect, useImperativeHandle, useRef, useState } from 'react';
 import { div, h, hr } from 'react-hyperscript-helpers';
@@ -7,7 +8,7 @@ import { icon } from 'src/components/icons';
 import { VerticalNavigation } from 'src/components/keyboard-nav';
 import { computePopupPosition, PopupPortal, useDynamicPosition } from 'src/components/popup-utils';
 import colors from 'src/libs/colors';
-import { forwardRefWithName, useUniqueId } from 'src/libs/react-utils';
+import { forwardRefWithName } from 'src/libs/react-utils';
 import * as Style from 'src/libs/style';
 
 const styles = {

--- a/src/components/TooltipTrigger.js
+++ b/src/components/TooltipTrigger.js
@@ -1,10 +1,11 @@
+import { useUniqueId } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { Children, cloneElement, Fragment, useRef, useState } from 'react';
 import { div, h, path, svg } from 'react-hyperscript-helpers';
 import { containsUnlabelledIcon } from 'src/components/icons';
 import { computePopupPosition, PopupPortal, useDynamicPosition } from 'src/components/popup-utils';
 import colors from 'src/libs/colors';
-import { useOnMount, useUniqueId } from 'src/libs/react-utils';
+import { useOnMount } from 'src/libs/react-utils';
 import * as Style from 'src/libs/style';
 import * as Utils from 'src/libs/utils';
 

--- a/src/components/WorkflowSelector.js
+++ b/src/components/WorkflowSelector.js
@@ -1,3 +1,4 @@
+import { useUniqueId } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { Fragment, useState } from 'react';
 import { div, h } from 'react-hyperscript-helpers';
@@ -7,7 +8,7 @@ import { Ajax } from 'src/libs/ajax';
 import { withErrorReporting } from 'src/libs/error';
 import Events, { extractWorkspaceDetails } from 'src/libs/events';
 import * as Nav from 'src/libs/nav';
-import { useCancellation, useOnMount, useUniqueId } from 'src/libs/react-utils';
+import { useCancellation, useOnMount } from 'src/libs/react-utils';
 import { workflowSelectionStore } from 'src/libs/state';
 import * as Style from 'src/libs/style';
 import * as Utils from 'src/libs/utils';

--- a/src/components/common/IdContainer.ts
+++ b/src/components/common/IdContainer.ts
@@ -1,14 +1,14 @@
-import _ from 'lodash/fp';
-import { ReactElement, useState } from 'react';
+import { useUniqueId } from '@terra-ui-packages/components';
+import { ReactNode } from 'react';
 
 type IdContainerProps = {
-  children: (id: string) => ReactElement<any, any> | null;
+  children: (id: string) => ReactNode;
 };
 
 /**
  * DEPRECATED - should switch to useUniqueId pattern (below)
  */
-export const IdContainer = ({ children }: IdContainerProps) => {
-  const [id] = useState(() => _.uniqueId('element-'));
+export const IdContainer = ({ children }: IdContainerProps): ReactNode => {
+  const id = useUniqueId();
   return children(id);
 };

--- a/src/components/common/IdContainer.ts
+++ b/src/components/common/IdContainer.ts
@@ -1,8 +1,6 @@
 import _ from 'lodash/fp';
 import { ReactElement, useState } from 'react';
 
-export { useUniqueId } from '@terra-ui-packages/components';
-
 type IdContainerProps = {
   children: (id: string) => ReactElement<any, any> | null;
 };

--- a/src/components/common/Select.ts
+++ b/src/components/common/Select.ts
@@ -1,3 +1,4 @@
+import { useUniqueId } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { Children, useCallback, useEffect, useRef } from 'react';
 import { div, h } from 'react-hyperscript-helpers';
@@ -14,7 +15,7 @@ import { List } from 'react-virtualized';
 import { AutoSizer } from 'src/components/common/VirtualizedSelectAutoSizer';
 import { icon } from 'src/components/icons';
 import colors from 'src/libs/colors';
-import { useOnMount, useUniqueId } from 'src/libs/react-utils';
+import { useOnMount } from 'src/libs/react-utils';
 
 const commonSelectProps: Partial<RSelectProps> = {
   theme: (base) =>

--- a/src/components/tabBars.js
+++ b/src/components/tabBars.js
@@ -1,3 +1,4 @@
+import { useUniqueId } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import PropTypes from 'prop-types';
 import { Fragment, useRef } from 'react';
@@ -6,7 +7,7 @@ import { Clickable } from 'src/components/common';
 import { HorizontalNavigation } from 'src/components/keyboard-nav';
 import { Ajax } from 'src/libs/ajax';
 import { terraSpecial } from 'src/libs/colors';
-import { useOnMount, useUniqueId } from 'src/libs/react-utils';
+import { useOnMount } from 'src/libs/react-utils';
 import * as Style from 'src/libs/style';
 import * as Utils from 'src/libs/utils';
 
@@ -168,7 +169,8 @@ export function SimpleTabBar({
   children,
   ...props
 }) {
-  const tabIds = _.map(useUniqueId, _.range(0, tabs.length));
+  const baseId = useUniqueId();
+  const tabIds = _.map((i) => `${baseId}-tab-${i}`, _.range(0, tabs.length));
   const panelRef = useRef();
   const maybeEmitViewMetric = (key) => {
     !!metricsPrefix && Ajax().Metrics.captureEvent(`${metricsPrefix}:view:${_.replace(/\s/g, '-', key)}`, metricsData);

--- a/src/libs/react-utils.ts
+++ b/src/libs/react-utils.ts
@@ -54,10 +54,6 @@ export const useInstance = <T>(fn: () => T): T => {
   return ref.current;
 };
 
-export const useUniqueId = (): string => {
-  return useInstance(() => _.uniqueId('unique-id-'));
-};
-
 type UseCancelableResult = {
   signal: AbortSignal;
   abort: () => void;

--- a/src/pages/billing/NewBillingProjectWizard/AzureBillingProjectWizard/AddUsersStep.ts
+++ b/src/pages/billing/NewBillingProjectWizard/AzureBillingProjectWizard/AddUsersStep.ts
@@ -1,7 +1,7 @@
+import { useUniqueId } from '@terra-ui-packages/components';
 import pluralize from 'pluralize';
 import { ReactNode, useState } from 'react';
 import { div, h, p } from 'react-hyperscript-helpers';
-import { useUniqueId } from 'src/components/common';
 import { ValidatedInput } from 'src/components/input';
 import { formHint, FormLabel } from 'src/libs/forms';
 import { useDebouncedValue } from 'src/libs/react-utils';

--- a/src/pages/billing/NewBillingProjectWizard/AzureBillingProjectWizard/AzureSubscriptionStep.ts
+++ b/src/pages/billing/NewBillingProjectWizard/AzureBillingProjectWizard/AzureSubscriptionStep.ts
@@ -1,13 +1,14 @@
+import { useUniqueId } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { ReactNode, useEffect, useRef, useState } from 'react';
 import { div, h, p } from 'react-hyperscript-helpers';
-import { customSpinnerOverlay, Link, Select, useUniqueId } from 'src/components/common';
+import { customSpinnerOverlay, Link, Select } from 'src/components/common';
 import { ValidatedInputWithRef } from 'src/components/input';
 import { Ajax } from 'src/libs/ajax';
 import { useLoadedData } from 'src/libs/ajax/loaded-data/useLoadedData';
 import { useCancellation } from 'src/libs/react-utils';
-import { summarizeErrors } from 'src/libs/utils';
 import * as Utils from 'src/libs/utils';
+import { summarizeErrors } from 'src/libs/utils';
 import { AzureManagedAppCoordinates } from 'src/pages/billing/models/AzureManagedAppCoordinates';
 import { columnEntryStyle, rowStyle } from 'src/pages/billing/NewBillingProjectWizard/AzureBillingProjectWizard/styles';
 import { ExternalLink } from 'src/pages/billing/NewBillingProjectWizard/StepWizard/ExternalLink';

--- a/src/pages/billing/NewBillingProjectWizard/AzureBillingProjectWizard/CreateNamedProjectStep.ts
+++ b/src/pages/billing/NewBillingProjectWizard/AzureBillingProjectWizard/CreateNamedProjectStep.ts
@@ -1,6 +1,7 @@
+import { useUniqueId } from '@terra-ui-packages/components';
 import { CSSProperties, ReactNode } from 'react';
 import { div, h } from 'react-hyperscript-helpers';
-import { ButtonPrimary, useUniqueId } from 'src/components/common';
+import { ButtonPrimary } from 'src/components/common';
 import { icon } from 'src/components/icons';
 import { ValidatedInput } from 'src/components/input';
 import colors from 'src/libs/colors';

--- a/src/pages/library/SearchAndFilterComponent.ts
+++ b/src/pages/library/SearchAndFilterComponent.ts
@@ -1,3 +1,4 @@
+import { useUniqueId } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import pluralize from 'pluralize';
 import * as qs from 'qs';
@@ -12,7 +13,6 @@ import { Ajax } from 'src/libs/ajax';
 import colors from 'src/libs/colors';
 import Events from 'src/libs/events';
 import * as Nav from 'src/libs/nav';
-import { useUniqueId } from 'src/libs/react-utils';
 import * as Utils from 'src/libs/utils';
 
 export interface FilterSection<DataType> {

--- a/src/pages/library/data-catalog/CreateDataset/CreateDatasetInputs.ts
+++ b/src/pages/library/data-catalog/CreateDataset/CreateDatasetInputs.ts
@@ -1,3 +1,4 @@
+import { useUniqueId } from '@terra-ui-packages/components';
 import * as _ from 'lodash/fp';
 import { ReactElement } from 'react';
 import { div, h } from 'react-hyperscript-helpers';
@@ -6,7 +7,6 @@ import { icon } from 'src/components/icons';
 import { NumberInput, ValidatedInput } from 'src/components/input';
 import { MarkdownEditor } from 'src/components/markdown';
 import { FormLabel } from 'src/libs/forms';
-import { useUniqueId } from 'src/libs/react-utils';
 import * as Utils from 'src/libs/utils';
 
 interface InputProps<T> {

--- a/src/pages/workflows/workflow/WorkflowDetails.js
+++ b/src/pages/workflows/workflow/WorkflowDetails.js
@@ -1,3 +1,4 @@
+import { useUniqueId } from '@terra-ui-packages/components';
 import * as clipboard from 'clipboard-polyfill/text';
 import FileSaver from 'file-saver';
 import _ from 'lodash/fp';
@@ -19,7 +20,7 @@ import colors from 'src/libs/colors';
 import { getConfig } from 'src/libs/config';
 import { withErrorReporting } from 'src/libs/error';
 import * as Nav from 'src/libs/nav';
-import { useCancellation, useOnMount, useStore, useUniqueId } from 'src/libs/react-utils';
+import { useCancellation, useOnMount, useStore } from 'src/libs/react-utils';
 import { snapshotsListStore, snapshotStore } from 'src/libs/state';
 import * as Style from 'src/libs/style';
 import * as Utils from 'src/libs/utils';

--- a/src/workflows-app/SubmissionConfig.js
+++ b/src/workflows-app/SubmissionConfig.js
@@ -1,3 +1,4 @@
+import { useUniqueId } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { Fragment, useCallback, useEffect, useRef, useState } from 'react';
 import { a, div, h, h2, label, span } from 'react-hyperscript-helpers';
@@ -18,7 +19,7 @@ import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
 import { ENABLE_CROMWELL_APP_CALL_CACHING } from 'src/libs/feature-previews-config';
 import * as Nav from 'src/libs/nav';
 import { notify } from 'src/libs/notifications';
-import { useCancellation, useOnMount, usePollingEffect, useUniqueId } from 'src/libs/react-utils';
+import { useCancellation, useOnMount, usePollingEffect } from 'src/libs/react-utils';
 import { AppProxyUrlStatus, workflowsAppStore } from 'src/libs/state';
 import * as Utils from 'src/libs/utils';
 import { maybeParseJSON } from 'src/libs/utils';


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/UIE-31

Over time, Terra UI has accumulated multiple versions of a `useUniqueId` hook. This updates everything to use the version in the components package and removes the other versions.