### PR TITLE
[UIE-51] Use useWindowDimensions from components

### DIFF
--- a/src/components/input.js
+++ b/src/components/input.js
@@ -1,3 +1,4 @@
+import { useWindowDimensions } from '@terra-ui-packages/components';
 import Downshift from 'downshift';
 import _ from 'lodash/fp';
 import { Fragment, useRef, useState } from 'react';
@@ -5,7 +6,7 @@ import { div, h, input, textarea } from 'react-hyperscript-helpers';
 import TextAreaAutosize from 'react-textarea-autosize';
 import { ButtonPrimary } from 'src/components/common';
 import { icon } from 'src/components/icons';
-import { PopupPortal, useDynamicPosition, useWindowDimensions } from 'src/components/popup-utils';
+import { PopupPortal, useDynamicPosition } from 'src/components/popup-utils';
 import TooltipTrigger from 'src/components/TooltipTrigger';
 import colors from 'src/libs/colors';
 import { combineRefs, forwardRefWithName, useGetter, useInstance, useOnMount } from 'src/libs/react-utils';

--- a/src/components/popup-utils.js
+++ b/src/components/popup-utils.js
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp';
-import { Children, useEffect, useRef, useState } from 'react';
+import { Children, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useGetter, useOnMount } from 'src/libs/react-utils';
 import * as Utils from 'src/libs/utils';
@@ -30,20 +30,6 @@ export const useDynamicPosition = (selectors) => {
     computePosition();
     return () => cancelAnimationFrame(animation.current);
   });
-  return dimensions;
-};
-
-export const useWindowDimensions = () => {
-  const [dimensions, setDimensions] = useState(() => ({ width: window.innerWidth, height: window.innerHeight }));
-
-  useEffect(() => {
-    const onResize = () => {
-      setDimensions({ width: window.innerWidth, height: window.innerHeight });
-    };
-    window.addEventListener('resize', onResize);
-    return () => window.removeEventListener('resize', onResize);
-  }, []);
-
   return dimensions;
 };
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/UIE-51

#4234 added `useWindowDimensions` to the components package. This replaces the Terra UI copy of the hook with the components copy.