### PR TITLE
[WM-2255] Fix small JSON parser bug for workflow inputs

### DIFF
--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -44,6 +44,7 @@ import { chooseBaseType, chooseRootType, chooseSetType, processSnapshotTable } f
 import ExportWorkflowModal from 'src/pages/workspaces/workspace/workflows/ExportWorkflowModal';
 import LaunchAnalysisModal from 'src/pages/workspaces/workspace/workflows/LaunchAnalysisModal';
 import { methodLink } from 'src/pages/workspaces/workspace/workflows/methodLink';
+import { sanitizeAttributeUpdateString } from 'src/pages/workspaces/workspace/workflows/workflow-view-utils';
 import { wrapWorkspace } from 'src/pages/workspaces/workspace/WorkspaceContainer';
 
 const sideMargin = '3rem';
@@ -1219,9 +1220,7 @@ const WorkflowView = _.flow(
     async uploadJson(key, file) {
       try {
         const rawUpdates = JSON.parse(await readFileAsText(file));
-        const updates = _.mapValues((v) =>
-          _.isString(v) && v.match(/\${([\s\S]*)}/) ? v.replace(/\${([\s\S]*)}/, (_, match) => match) : JSON.stringify(v)
-        )(rawUpdates);
+        const updates = _.mapValues((v) => sanitizeAttributeUpdateString(v))(rawUpdates);
         this.setState(({ modifiedConfig, modifiedInputsOutputs }) => {
           const existing = _.map('name', modifiedInputsOutputs[key]);
           return {

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -1219,9 +1219,9 @@ const WorkflowView = _.flow(
     async uploadJson(key, file) {
       try {
         const rawUpdates = JSON.parse(await readFileAsText(file));
-        const updates = _.mapValues((v) => (_.isString(v) && v.match(/\${(.*)}/) ? v.replace(/\${(.*)}/, (_, match) => match) : JSON.stringify(v)))(
-          rawUpdates
-        );
+        const updates = _.mapValues((v) => (
+          _.isString(v) && v.match(/\${([\s\S]*)}/) ? v.replace(/\${([\s\S]*)}/, (_, match) => match) : JSON.stringify(v))
+        )(rawUpdates);
         this.setState(({ modifiedConfig, modifiedInputsOutputs }) => {
           const existing = _.map('name', modifiedInputsOutputs[key]);
           return {

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -1219,8 +1219,8 @@ const WorkflowView = _.flow(
     async uploadJson(key, file) {
       try {
         const rawUpdates = JSON.parse(await readFileAsText(file));
-        const updates = _.mapValues((v) => (
-          _.isString(v) && v.match(/\${([\s\S]*)}/) ? v.replace(/\${([\s\S]*)}/, (_, match) => match) : JSON.stringify(v))
+        const updates = _.mapValues((v) =>
+          _.isString(v) && v.match(/\${([\s\S]*)}/) ? v.replace(/\${([\s\S]*)}/, (_, match) => match) : JSON.stringify(v)
         )(rawUpdates);
         this.setState(({ modifiedConfig, modifiedInputsOutputs }) => {
           const existing = _.map('name', modifiedInputsOutputs[key]);

--- a/src/pages/workspaces/workspace/workflows/workflow-view-utils.test.ts
+++ b/src/pages/workspaces/workspace/workflows/workflow-view-utils.test.ts
@@ -1,0 +1,17 @@
+import { sanitizeAttributeUpdateString } from 'src/pages/workspaces/workspace/workflows/workflow-view-utils';
+
+describe('sanitizeAttributeUpdateString', () => {
+  it('handles update text without newlines', () => {
+    const input = ''; // COMPLETE ME
+    const expected = ''; // COMPLETE ME
+    const actual = sanitizeAttributeUpdateString(input);
+    expect(actual).toEqual(expected);
+  });
+
+  it('handles update text with newlines', () => {
+    const input = ''; // COMPLETE ME
+    const expected = ''; // COMPLETE ME
+    const actual = sanitizeAttributeUpdateString(input);
+    expect(actual).toEqual(expected);
+  });
+});

--- a/src/pages/workspaces/workspace/workflows/workflow-view-utils.test.ts
+++ b/src/pages/workspaces/workspace/workflows/workflow-view-utils.test.ts
@@ -2,15 +2,27 @@ import { sanitizeAttributeUpdateString } from 'src/pages/workspaces/workspace/wo
 
 describe('sanitizeAttributeUpdateString', () => {
   it('handles update text without newlines', () => {
-    const input = ''; // COMPLETE ME
-    const expected = ''; // COMPLETE ME
+    // eslint-disable-next-line no-template-curly-in-string
+    const input = '${"Hello World"}';
+    const expected = '"Hello World"';
     const actual = sanitizeAttributeUpdateString(input);
     expect(actual).toEqual(expected);
   });
 
   it('handles update text with newlines', () => {
-    const input = ''; // COMPLETE ME
-    const expected = ''; // COMPLETE ME
+    // prettier-ignore
+    // eslint-disable-next-line no-template-curly-in-string, no-useless-escape
+    const input = '${[\"test1\",\n\"test2\"]}';
+    const expected = '["test1",\n"test2"]';
+    const actual = sanitizeAttributeUpdateString(input);
+    expect(actual).toEqual(expected);
+  });
+
+  it('handles badly formatted JSON input without dollar sign not downloaded from Terra', () => {
+    // prettier-ignore
+    // eslint-disable-next-line no-useless-escape
+    const input = '[\"test1\", \"test2\"]';
+    const expected = '"[\\"test1\\", \\"test2\\"]"';
     const actual = sanitizeAttributeUpdateString(input);
     expect(actual).toEqual(expected);
   });

--- a/src/pages/workspaces/workspace/workflows/workflow-view-utils.ts
+++ b/src/pages/workspaces/workspace/workflows/workflow-view-utils.ts
@@ -1,0 +1,7 @@
+import _ from 'lodash/fp';
+
+export const sanitizeAttributeUpdateString = (rawUpdate: string): string => {
+  return _.isString(rawUpdate) && rawUpdate.match(/\${([\s\S]*)}/)
+    ? rawUpdate.replace(/\${([\s\S]*)}/, (_, match) => match)
+    : JSON.stringify(rawUpdate);
+};


### PR DESCRIPTION
## Ticket
https://broadworkbench.atlassian.net/browse/WM-2255

## Summary of changes:
When saving/re-uploading configurations for workflows, there's a small bug that causes the inputs to be incorrectly parsed when a variable is an array containing newlines. This short PR resolves this issue by correcting the regex used to parse JSON files here.

### What
When saving a multi-line array inside your workflow inputs like below
![image](https://github.com/DataBiosphere/terra-ui/assets/81349869/d4a8b7b2-e9e9-4a0e-8c6c-89823f51ab85)
and then re-uploading, it gets incorrectly parsed like so:
![image](https://github.com/DataBiosphere/terra-ui/assets/81349869/99d0cc52-7e6e-476f-bf66-5753fc4a32c4)

### Why
This was previously occurring due to a small quirk in JS regex, where `.` matches any character *except* newlines. This has been replaced with the more generic, newline-matching-inclusive regex `[\s\S]` so that multi-line arrays like the above get matched with the built-in regex matcher and correctly parsed, as opposed to being dumped into a generic "not sure what this is" string. It seems there are other expressions for "match all characters including newline" for JS, but after reading around a bit, it seemed like this was one of the most universally recognized across browsers.

### Testing strategy
I tried it out with my local `yarn start` instance. 
