### PR TITLE
[UIE-130] Move Environments tests out of FeaturePreviews tests

### DIFF
--- a/src/analysis/Environments/Environments.test.ts
+++ b/src/analysis/Environments/Environments.test.ts
@@ -14,7 +14,7 @@ import {
   generateTestDiskWithGoogleWorkspace,
   generateTestListGoogleRuntime,
 } from 'src/analysis/_testData/testData';
-import { EnvironmentNavActions, Environments } from 'src/analysis/Environments/Environments';
+import { EnvironmentNavActions, Environments, PauseButton } from 'src/analysis/Environments/Environments';
 import { defaultComputeZone } from 'src/analysis/utils/runtime-utils';
 import { appToolLabels } from 'src/analysis/utils/tool-utils';
 import { useWorkspaces } from 'src/components/workspace-utils';
@@ -772,6 +772,35 @@ describe('Environments', () => {
       await user.click(buttons1[0]);
       screen.getByText('Delete persistent disk?');
     });
+  });
+
+  describe('PauseButton', () => {
+    it.each([{ app: generateTestAppWithGoogleWorkspace() }, { app: generateTestAppWithAzureWorkspace() }])(
+      'should enable pause for azure and google',
+      async ({ app }) => {
+        // Arrange
+        const pauseComputeAndRefresh = jest.fn();
+
+        await act(async () => {
+          render(
+            h(PauseButton, {
+              computeType: 'app',
+              cloudEnvironment: app,
+              currentUser: app.auditInfo.creator,
+              pauseComputeAndRefresh,
+            })
+          );
+        });
+        // Act
+        const pauseButton = screen.getByText('Pause');
+        // Assert
+        expect(pauseButton).toBeEnabled();
+        // Act
+        await userEvent.click(pauseButton);
+        // Assert
+        expect(pauseComputeAndRefresh).toHaveBeenCalled();
+      }
+    );
   });
 });
 

--- a/src/pages/FeaturePreviews.test.ts
+++ b/src/pages/FeaturePreviews.test.ts
@@ -1,111 +1,79 @@
-import { act, fireEvent, getByText, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { fireEvent, getByText } from '@testing-library/react';
 import { h } from 'react-hyperscript-helpers';
-import { generateTestAppWithAzureWorkspace, generateTestAppWithGoogleWorkspace } from 'src/analysis/_testData/testData';
-import { PauseButton } from 'src/analysis/Environments/Environments';
 import { isFeaturePreviewEnabled, toggleFeaturePreview, useAvailableFeaturePreviews } from 'src/libs/feature-previews';
 import { FeaturePreviews } from 'src/pages/FeaturePreviews';
 import { asMockedFn, renderWithAppContexts as render } from 'src/testing/test-utils';
 
-jest.mock('src/libs/ajax');
 jest.mock('src/libs/feature-previews');
-describe('Environments', () => {
-  describe('FeaturePreviews', () => {
-    beforeEach(() => {
-      asMockedFn(useAvailableFeaturePreviews).mockReturnValue({
-        featurePreviews: [
-          // @ts-expect-error
-          {
-            id: 'feature1',
-            title: 'Feature #1',
-            description: 'A new feature',
-            documentationUrl: 'https://example.com/feature-1-docs',
-          },
-          // @ts-expect-error
-          {
-            id: 'feature2',
-            title: 'Feature #2',
-            description: 'Another new feature',
-            feedbackUrl: 'mailto:feature2-feedback@example.com',
-          },
-        ],
-        loading: false,
-      });
 
-      asMockedFn(isFeaturePreviewEnabled).mockReturnValue(false);
+describe('FeaturePreviews', () => {
+  beforeEach(() => {
+    asMockedFn(useAvailableFeaturePreviews).mockReturnValue({
+      featurePreviews: [
+        // @ts-expect-error
+        {
+          id: 'feature1',
+          title: 'Feature #1',
+          description: 'A new feature',
+          documentationUrl: 'https://example.com/feature-1-docs',
+        },
+        // @ts-expect-error
+        {
+          id: 'feature2',
+          title: 'Feature #2',
+          description: 'Another new feature',
+          feedbackUrl: 'mailto:feature2-feedback@example.com',
+        },
+      ],
+      loading: false,
     });
 
-    it('should render available feature previews', () => {
-      const { getAllByRole } = render(h(FeaturePreviews));
-      const cells = getAllByRole('cell');
-
-      expect(getByText(cells[1], 'Feature #1')).toBeTruthy();
-      expect(getByText(cells[1], 'A new feature')).toBeTruthy();
-
-      expect(getByText(cells[3], 'Feature #2')).toBeTruthy();
-      expect(getByText(cells[3], 'Another new feature')).toBeTruthy();
-    });
-
-    it('should render whether features are enabled', () => {
-      asMockedFn(isFeaturePreviewEnabled).mockImplementation((id) => id === 'feature1');
-
-      const { getAllByRole } = render(h(FeaturePreviews));
-      const checkboxes = getAllByRole('checkbox');
-
-      expect(checkboxes[0].getAttribute('aria-checked')).toBe('true');
-      expect(checkboxes[1].getAttribute('aria-checked')).toBe('false');
-    });
-
-    it('checking a checkbox should toggle feature previews', () => {
-      const { getAllByRole } = render(h(FeaturePreviews));
-      const checkboxes = getAllByRole('checkbox');
-
-      fireEvent.click(checkboxes[0]);
-      expect(toggleFeaturePreview).toHaveBeenCalledWith('feature1', true);
-
-      fireEvent.click(checkboxes[0]);
-      expect(toggleFeaturePreview).toHaveBeenCalledWith('feature1', false);
-    });
-
-    it('should render documentation link if provided', () => {
-      const { getAllByText } = render(h(FeaturePreviews));
-      const docLinks = getAllByText('Documentation');
-      expect(docLinks.length).toBe(1);
-      expect(docLinks[0].getAttribute('href')).toBe('https://example.com/feature-1-docs');
-    });
-
-    it('should render feedback link if provided', () => {
-      const { getAllByText } = render(h(FeaturePreviews));
-      const feedbackLinks = getAllByText('Submit feedback');
-      expect(feedbackLinks.length).toBe(1);
-      expect(feedbackLinks[0].getAttribute('href')).toBe('mailto:feature2-feedback@example.com');
-    });
+    asMockedFn(isFeaturePreviewEnabled).mockReturnValue(false);
   });
 
-  it.each([{ app: generateTestAppWithGoogleWorkspace() }, { app: generateTestAppWithAzureWorkspace() }])(
-    'should enable pause for azure and google',
-    async ({ app }) => {
-      // Arrange
-      const pauseComputeAndRefresh = jest.fn();
+  it('should render available feature previews', () => {
+    const { getAllByRole } = render(h(FeaturePreviews));
+    const cells = getAllByRole('cell');
 
-      await act(async () => {
-        render(
-          h(PauseButton, {
-            computeType: 'app',
-            cloudEnvironment: app,
-            currentUser: app.auditInfo.creator,
-            pauseComputeAndRefresh,
-          })
-        );
-      });
-      // Act
-      const pauseButton = screen.getByText('Pause');
-      // Assert
-      expect(pauseButton).toBeEnabled();
-      // Act
-      await userEvent.click(pauseButton);
-      // Assert
-      expect(pauseComputeAndRefresh).toHaveBeenCalled();
-    }
-  );
+    expect(getByText(cells[1], 'Feature #1')).toBeTruthy();
+    expect(getByText(cells[1], 'A new feature')).toBeTruthy();
+
+    expect(getByText(cells[3], 'Feature #2')).toBeTruthy();
+    expect(getByText(cells[3], 'Another new feature')).toBeTruthy();
+  });
+
+  it('should render whether features are enabled', () => {
+    asMockedFn(isFeaturePreviewEnabled).mockImplementation((id) => id === 'feature1');
+
+    const { getAllByRole } = render(h(FeaturePreviews));
+    const checkboxes = getAllByRole('checkbox');
+
+    expect(checkboxes[0].getAttribute('aria-checked')).toBe('true');
+    expect(checkboxes[1].getAttribute('aria-checked')).toBe('false');
+  });
+
+  it('checking a checkbox should toggle feature previews', () => {
+    const { getAllByRole } = render(h(FeaturePreviews));
+    const checkboxes = getAllByRole('checkbox');
+
+    fireEvent.click(checkboxes[0]);
+    expect(toggleFeaturePreview).toHaveBeenCalledWith('feature1', true);
+
+    fireEvent.click(checkboxes[0]);
+    expect(toggleFeaturePreview).toHaveBeenCalledWith('feature1', false);
+  });
+
+  it('should render documentation link if provided', () => {
+    const { getAllByText } = render(h(FeaturePreviews));
+    const docLinks = getAllByText('Documentation');
+    expect(docLinks.length).toBe(1);
+    expect(docLinks[0].getAttribute('href')).toBe('https://example.com/feature-1-docs');
+  });
+
+  it('should render feedback link if provided', () => {
+    const { getAllByText } = render(h(FeaturePreviews));
+    const feedbackLinks = getAllByText('Submit feedback');
+    expect(feedbackLinks.length).toBe(1);
+    expect(feedbackLinks[0].getAttribute('href')).toBe('mailto:feature2-feedback@example.com');
+  });
 });


### PR DESCRIPTION
It looks like some tests for the PauseButton from the Environments module got added to the FeaturePreviews test file in #3914. This moves those tests to Environments.test.