### PR TITLE
[UIE-51] Improve types for Interactive component

### DIFF
--- a/packages/components/src/Interactive.ts
+++ b/packages/components/src/Interactive.ts
@@ -46,6 +46,9 @@ const pointerTypes = ['radio', 'checkbox', 'submit', 'button'];
 export interface InteractiveProps extends AllHTMLAttributes<HTMLElement> {
   hover?: React.CSSProperties;
   tagName?: keyof JSX.IntrinsicElements;
+
+  // Allow arbitrary data attributes on the rendered element.
+  [dataAttribute: `data-${string}`]: string;
 }
 
 export const Interactive = forwardRef((props: InteractiveProps, ref: ForwardedRef<HTMLElement>) => {

--- a/packages/components/src/Interactive.ts
+++ b/packages/components/src/Interactive.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp';
-import { createElement, forwardRef, ReactNode, useState } from 'react';
+import { createElement, ForwardedRef, forwardRef, ReactNode, useState } from 'react';
 
 import { injectStyle } from './injectStyle';
 import * as Utils from './utils';
@@ -55,103 +55,101 @@ export type InteractiveProps = {
   onMouseDown?: (event: any) => void;
 };
 
-export const Interactive: React.ForwardRefExoticComponent<InteractiveProps> = forwardRef(
-  (props: InteractiveProps, ref) => {
-    const {
-      children,
-      className = '',
-      disabled,
-      hover = {},
-      role,
-      style = {},
-      tabIndex,
-      tagName: TagName = 'div',
-      type,
-      onBlur,
-      onClick,
-      onKeyDown,
-      onMouseDown,
-      ...otherProps
-    } = props;
+export const Interactive = forwardRef((props: InteractiveProps, ref: ForwardedRef<HTMLElement>) => {
+  const {
+    children,
+    className = '',
+    disabled,
+    hover = {},
+    role,
+    style = {},
+    tabIndex,
+    tagName: TagName = 'div',
+    type,
+    onBlur,
+    onClick,
+    onKeyDown,
+    onMouseDown,
+    ...otherProps
+  } = props;
 
-    const [outline, setOutline] = useState<string>();
-    const { cursor } = style;
+  const [outline, setOutline] = useState<string>();
+  const { cursor } = style;
 
-    const computedCursor = Utils.cond(
-      [!!cursor, () => cursor],
-      [disabled, () => 'not-allowed'],
-      [!!onClick || pointerTags.includes(TagName) || pointerTypes.includes(type!), () => 'pointer']
-    );
+  const computedCursor = Utils.cond(
+    [!!cursor, () => cursor],
+    [disabled, () => 'not-allowed'],
+    [!!onClick || pointerTags.includes(TagName) || pointerTypes.includes(type!), () => 'pointer']
+  );
 
-    const computedTabIndex = Utils.cond(
-      [_.isNumber(tabIndex), () => tabIndex],
-      [disabled, () => -1],
-      [!!onClick, () => 0],
-      () => undefined
-    );
+  const computedTabIndex = Utils.cond(
+    [_.isNumber(tabIndex), () => tabIndex],
+    [disabled, () => -1],
+    [!!onClick, () => 0],
+    () => undefined
+  );
 
-    const computedRole = Utils.cond(
-      [!!role, () => role],
-      [onClick && !['input', ...pointerTags].includes(TagName), () => 'button'],
-      () => undefined
-    );
+  const computedRole = Utils.cond(
+    [!!role, () => role],
+    [onClick && !['input', ...pointerTags].includes(TagName), () => 'button'],
+    () => undefined
+  );
 
-    const cssVariables = _.flow(
-      _.toPairs,
-      _.flatMap(([key, value]) => {
-        console.assert(
-          allowedHoverVariables.includes(key),
-          `${key} needs to be added to the .terra-ui--interactive CSS for the style to be applied`
-        );
-        return [
-          [`--app-hover-${key}`, value],
-          [key, `var(--hover-${key}, ${style[key]})`],
-        ];
-      }),
-      _.fromPairs
-    )(hover);
+  const cssVariables = _.flow(
+    _.toPairs,
+    _.flatMap(([key, value]) => {
+      console.assert(
+        allowedHoverVariables.includes(key),
+        `${key} needs to be added to the .terra-ui--interactive CSS for the style to be applied`
+      );
+      return [
+        [`--app-hover-${key}`, value],
+        [key, `var(--hover-${key}, ${style[key]})`],
+      ];
+    }),
+    _.fromPairs
+  )(hover);
 
-    return createElement(
-      TagName,
-      {
-        ref,
-        className: `terra-ui--interactive ${className}`,
-        style: {
-          ...style,
-          ...cssVariables,
-          fill: `var(--hover-color, ${style.color})`,
-          cursor: computedCursor,
-          outline,
-        },
-        role: computedRole,
-        tabIndex: computedTabIndex,
-        onClick,
-        disabled,
-        onMouseDown: (e) => {
-          setOutline('none');
-          if (onMouseDown) {
-            onMouseDown(e);
-          }
-        },
-        onBlur: (e) => {
-          if (outline) {
-            setOutline(undefined);
-          }
-          if (onBlur) {
-            onBlur(e);
-          }
-        },
-        onKeyDown:
-          onKeyDown ||
-          ((event: React.KeyboardEvent) => {
-            if (event.key === 'Enter') {
-              event.stopPropagation();
-              (event.target as HTMLElement).click();
-            }
-          }),
-        ...otherProps,
+  return createElement(
+    TagName,
+    {
+      ref,
+      className: `terra-ui--interactive ${className}`,
+      style: {
+        ...style,
+        ...cssVariables,
+        fill: `var(--hover-color, ${style.color})`,
+        cursor: computedCursor,
+        outline,
       },
-      [children]
-    );
-  }
-);
+      role: computedRole,
+      tabIndex: computedTabIndex,
+      onClick,
+      disabled,
+      onMouseDown: (e) => {
+        setOutline('none');
+        if (onMouseDown) {
+          onMouseDown(e);
+        }
+      },
+      onBlur: (e) => {
+        if (outline) {
+          setOutline(undefined);
+        }
+        if (onBlur) {
+          onBlur(e);
+        }
+      },
+      onKeyDown:
+        onKeyDown ||
+        ((event: React.KeyboardEvent) => {
+          if (event.key === 'Enter') {
+            event.stopPropagation();
+            (event.target as HTMLElement).click();
+          }
+        }),
+      ...otherProps,
+    },
+    [children]
+  );
+});

--- a/packages/components/src/Interactive.ts
+++ b/packages/components/src/Interactive.ts
@@ -98,13 +98,22 @@ export const Interactive = forwardRef((props: InteractiveProps, ref: ForwardedRe
     () => undefined
   );
 
+  /**
+   * This allow setting :hover and :focus styles using inline styles in JS.
+   * For supported style properties (listed in allowedHoverVariables), this sets the style property
+   * X of the rendered element to be:
+   * - the value of the --hover-X CSS variable if --hover-X is set
+   * - the value of X from the `style` prop otherwise (style[X])
+   *
+   * It also sets the --app-hover-X CSS variable to be the value of X from the `hover` prop (hover[X])
+   *
+   * By default, --hover-X is not set, so the value from the `style` prop is used. When the element
+   * is hovered or focused, the CSS injected above sets --hover-X to be equal to the value of --app-hover-X.
+   * This overrides the value from the `style` prop with the value from the `hover` prop.
+   */
   const cssVariables = _.flow(
     _.toPairs,
     _.flatMap(([key, value]) => {
-      console.assert(
-        (allowedHoverVariables as readonly string[]).includes(key),
-        `${key} needs to be added to the .terra-ui--interactive CSS for the style to be applied`
-      );
       return [
         [`--app-hover-${key}`, value],
         [key, `var(--hover-${key}, ${style[key]})`],

--- a/packages/components/src/Interactive.ts
+++ b/packages/components/src/Interactive.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp';
-import { createElement, ForwardedRef, forwardRef, ReactNode, useState } from 'react';
+import { AllHTMLAttributes, createElement, ForwardedRef, forwardRef, useState } from 'react';
 
 import { injectStyle } from './injectStyle';
 import * as Utils from './utils';
@@ -39,21 +39,14 @@ const allowedHoverVariables = [
 const pointerTags = ['button', 'area', 'a', 'select'];
 const pointerTypes = ['radio', 'checkbox', 'submit', 'button'];
 
-export type InteractiveProps = {
-  children?: ReactNode;
-  className?: string;
-  disabled?: boolean;
+// Since Interactive may render any HTML element based on the tagName prop,
+// use AllHTMLAttributes<HTMLElement> to allow this to accept attributes
+// for any HTML element.
+// TODO: Can a more specific type be used by parameterizing this with a tag name?
+export interface InteractiveProps extends AllHTMLAttributes<HTMLElement> {
   hover?: React.CSSProperties;
-  role?: string;
-  style?: React.CSSProperties;
-  tabIndex?: number;
   tagName?: keyof JSX.IntrinsicElements;
-  type?: string;
-  onBlur?: (event: any) => void;
-  onClick?: (event: any) => void;
-  onKeyDown?: (event: any) => void;
-  onMouseDown?: (event: any) => void;
-};
+}
 
 export const Interactive = forwardRef((props: InteractiveProps, ref: ForwardedRef<HTMLElement>) => {
   const {

--- a/packages/components/src/Interactive.ts
+++ b/packages/components/src/Interactive.ts
@@ -35,7 +35,11 @@ const allowedHoverVariables = [
   'boxShadow',
   'opacity',
   'textDecoration',
-];
+] as const;
+
+// Union type of all values in allowedHoverVariables.
+type HoverStyleProperty = (typeof allowedHoverVariables)[number];
+
 const pointerTags = ['button', 'area', 'a', 'select'];
 const pointerTypes = ['radio', 'checkbox', 'submit', 'button'];
 
@@ -44,7 +48,10 @@ const pointerTypes = ['radio', 'checkbox', 'submit', 'button'];
 // for any HTML element.
 // TODO: Can a more specific type be used by parameterizing this with a tag name?
 export interface InteractiveProps extends AllHTMLAttributes<HTMLElement> {
-  hover?: React.CSSProperties;
+  /** Styles applied when element is hovered or focused. */
+  hover?: Pick<React.CSSProperties, HoverStyleProperty>;
+
+  /** HTML tag to render. */
   tagName?: keyof JSX.IntrinsicElements;
 
   // Allow arbitrary data attributes on the rendered element.
@@ -95,7 +102,7 @@ export const Interactive = forwardRef((props: InteractiveProps, ref: ForwardedRe
     _.toPairs,
     _.flatMap(([key, value]) => {
       console.assert(
-        allowedHoverVariables.includes(key),
+        (allowedHoverVariables as readonly string[]).includes(key),
         `${key} needs to be added to the .terra-ui--interactive CSS for the style to be applied`
       );
       return [

--- a/packages/components/src/Interactive.ts
+++ b/packages/components/src/Interactive.ts
@@ -140,17 +140,13 @@ export const Interactive = forwardRef((props: InteractiveProps, ref: ForwardedRe
       disabled,
       onMouseDown: (e) => {
         setOutline('none');
-        if (onMouseDown) {
-          onMouseDown(e);
-        }
+        onMouseDown?.(e);
       },
       onBlur: (e) => {
         if (outline) {
           setOutline(undefined);
         }
-        if (onBlur) {
-          onBlur(e);
-        }
+        onBlur?.(e);
       },
       onKeyDown:
         onKeyDown ||

--- a/packages/components/src/Interactive.ts
+++ b/packages/components/src/Interactive.ts
@@ -56,8 +56,8 @@ export type InteractiveProps = {
 };
 
 export const Interactive: React.ForwardRefExoticComponent<InteractiveProps> = forwardRef(
-  (
-    {
+  (props: InteractiveProps, ref) => {
+    const {
       children,
       className = '',
       disabled,
@@ -71,10 +71,9 @@ export const Interactive: React.ForwardRefExoticComponent<InteractiveProps> = fo
       onClick,
       onKeyDown,
       onMouseDown,
-      ...props
-    },
-    ref
-  ) => {
+      ...otherProps
+    } = props;
+
     const [outline, setOutline] = useState<string>();
     const { cursor } = style;
 
@@ -150,7 +149,7 @@ export const Interactive: React.ForwardRefExoticComponent<InteractiveProps> = fo
               (event.target as HTMLElement).click();
             }
           }),
-        ...props,
+        ...otherProps,
       },
       [children]
     );


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/UIE-51

Clickable mainly passes through props to Interactive. When trying to add Clickable to the components package, I ran into some type issues that needed to be resolved in Interactive.

- https://github.com/DataBiosphere/terra-ui/commit/52ab0b30ae0d1634137c29ac1463381ffddc2660 moves the props destructuring from the function definition into the function body. This is only a code style change.

- https://github.com/DataBiosphere/terra-ui/commit/62817f3412dc8e2e7fce06d69b62133bb9e1bf0f is where the bulk of the lines changed comes from. It's mostly formatting. The meaningful change here is adding a type to the `ref` object and removing the separate type declaration on Interactive so that it uses the type returned by `forwardRef`.

- https://github.com/DataBiosphere/terra-ui/commit/a76220912f709cf72659c50acd9f517fff19ca39 and https://github.com/DataBiosphere/terra-ui/commit/3e9263637382d9cec80eb9a7050a578f7c62c5b8 expand Interactive's allowed props. Interactive passes through most props to the rendered HTML element, but it's props type currently only allows a few attributes (like whatever we've needed so far when using Interactive in TS files). This expands its props type to accept other attributes like `aria-label`.

- https://github.com/DataBiosphere/terra-ui/commit/8f84f57abaaf53881109eba5be690d5f7a59ffd7 makes the type of the `hover` prop stricter. Currently, it accepts all CSS properties, but only a select few are actually valid and will be applied.

Ignoring whitespace (https://github.com/DataBiosphere/terra-ui/pull/4255/files?w=1) makes the diff a lot smaller.