### PR TITLE
[AJ-1296] Move LocalVariablesContent to workspace-data

### DIFF
--- a/src/workspace-data/Data.js
+++ b/src/workspace-data/Data.js
@@ -11,7 +11,6 @@ import Collapse from 'src/components/Collapse';
 import { ButtonOutline, Clickable, DeleteConfirmationModal, Link, spinnerOverlay } from 'src/components/common';
 import { DataTableSaveVersionModal, DataTableVersion, DataTableVersions } from 'src/components/data/data-table-versions';
 import FileBrowser from 'src/components/data/FileBrowser';
-import LocalVariablesContent from 'src/components/data/LocalVariablesContent';
 import { icon, spinner } from 'src/components/icons';
 import { ConfirmedSearchInput } from 'src/components/input';
 import { MenuButton } from 'src/components/MenuButton';
@@ -50,6 +49,7 @@ import { getReferenceData } from './reference-data/reference-data-utils';
 import { ReferenceDataContent } from './reference-data/ReferenceDataContent';
 import { ReferenceDataDeleter } from './reference-data/ReferenceDataDeleter';
 import { ReferenceDataImporter } from './reference-data/ReferenceDataImporter';
+import { WorkspaceAttributes } from './WorkspaceAttributes';
 
 const styles = {
   tableContainer: {
@@ -1356,7 +1356,7 @@ export const WorkspaceData = _.flow(
                 [
                   workspaceDataTypes.localVariables,
                   () =>
-                    h(LocalVariablesContent, {
+                    h(WorkspaceAttributes, {
                       workspace,
                       refreshKey,
                     }),

--- a/src/workspace-data/WorkspaceAttributes.js
+++ b/src/workspace-data/WorkspaceAttributes.js
@@ -37,7 +37,7 @@ export const convertInitialAttributes = _.flow(
   _.sortBy(_.first)
 );
 
-const LocalVariablesContent = ({
+export const WorkspaceAttributes = ({
   workspace,
   workspace: {
     workspace: { namespace, name },
@@ -353,5 +353,3 @@ const LocalVariablesContent = ({
     ]
   );
 };
-
-export default LocalVariablesContent;

--- a/src/workspace-data/WorkspaceAttributes.test.js
+++ b/src/workspace-data/WorkspaceAttributes.test.js
@@ -1,4 +1,4 @@
-import { convertInitialAttributes, getDisplayedAttribute, renameAttribute } from 'src/components/data/LocalVariablesContent';
+import { convertInitialAttributes, getDisplayedAttribute, renameAttribute } from './WorkspaceAttributes';
 
 describe('getDisplayedAttribute', () => {
   it('gets a displayed attribute with a description', () => {


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1296

Continuing to collect workspace data code...

This moves LocalVariablesContent to the workspace-data folder and renames it to WorkspaceAttributes since it is responsible for editing workspace attributes. In the UI, this panel is named "Workspace Data", but I since the entire feature area is "workspace-data", I didn't want to use that name for this component.