### PR TITLE
[UIE-134] Add types for libs/events

### DIFF
--- a/src/libs/events.test.ts
+++ b/src/libs/events.test.ts
@@ -1,4 +1,7 @@
-import { extractBillingDetails, extractCrossWorkspaceDetails, extractWorkspaceDetails } from 'src/libs/events';
+import { DeepPartial } from '@terra-ui-packages/core-utils';
+import { WorkspaceWrapper } from 'src/libs/workspace-utils';
+
+import { extractBillingDetails, extractCrossWorkspaceDetails, extractWorkspaceDetails } from './events';
 
 const gcpWorkspace = {
   workspace: {
@@ -10,7 +13,7 @@ const gcpWorkspace = {
   accessLevel: 'OWNER',
   canShare: true,
   canCompute: true,
-};
+} as const satisfies DeepPartial<WorkspaceWrapper>;
 
 const azureWorkspace = {
   workspace: {
@@ -22,40 +25,55 @@ const azureWorkspace = {
   accessLevel: 'OWNER',
   canShare: true,
   canCompute: true,
-};
+} as const satisfies DeepPartial<WorkspaceWrapper>;
 
 describe('extractWorkspaceDetails', () => {
   it('Handles properties at top level, converts cloudPlatform to upper case', () => {
-    expect(
-      extractWorkspaceDetails({ name: 'wsName', namespace: 'wsNamespace', cloudPlatform: 'wsCloudPlatform' })
-    ).toEqual({
+    // Act
+    const workspaceDetails = extractWorkspaceDetails({
+      name: 'wsName',
+      namespace: 'wsNamespace',
+      cloudPlatform: 'Gcp',
+    });
+
+    // Assert
+    expect(workspaceDetails).toEqual({
       workspaceName: 'wsName',
       workspaceNamespace: 'wsNamespace',
-      cloudPlatform: 'WSCLOUDPLATFORM',
-      hasProtectedData: false,
+      cloudPlatform: 'GCP',
+      hasProtectedData: undefined,
     });
   });
 
   it('Does not include cloud platform if undefined', () => {
-    expect(extractWorkspaceDetails({ name: 'wsName', namespace: 'wsNamespace' })).toEqual({
-      workspaceName: 'wsName',
-      workspaceNamespace: 'wsNamespace',
-    });
+    // Act
+    const workspaceDetails = extractWorkspaceDetails({ name: 'wsName', namespace: 'wsNamespace' });
+
+    // Assert
+    expect(workspaceDetails.cloudPlatform).toBeUndefined();
   });
 
   it('Handles nested workspace details (like from workspace object)', () => {
-    expect(extractWorkspaceDetails(gcpWorkspace)).toEqual({
+    // Act
+    const workspaceDetails = extractWorkspaceDetails(gcpWorkspace);
+
+    // Assert
+    expect(workspaceDetails).toEqual({
       workspaceName: 'wsName',
       workspaceNamespace: 'wsNamespace',
       cloudPlatform: 'GCP',
-      hasProtectedData: false,
+      hasProtectedData: undefined,
     });
   });
 });
 
 describe('extractCrossWorkspaceDetails', () => {
   it('Extracts name, namespace, and upper-cased cloudPlatform', () => {
-    expect(extractCrossWorkspaceDetails(gcpWorkspace, azureWorkspace)).toEqual({
+    // Act
+    const crossWorkspaceDetails = extractCrossWorkspaceDetails(gcpWorkspace, azureWorkspace);
+
+    // Assert
+    expect(crossWorkspaceDetails).toEqual({
       fromWorkspaceNamespace: 'wsNamespace',
       fromWorkspaceName: 'wsName',
       fromWorkspaceCloudPlatform: 'GCP',
@@ -68,7 +86,11 @@ describe('extractCrossWorkspaceDetails', () => {
 
 describe('extractBillingDetails', () => {
   it('Extracts billing project name and cloudPlatform (as upper case)', () => {
-    expect(extractBillingDetails({ projectName: 'projectName', cloudPlatform: 'cloudPlatform' })).toEqual({
+    // Act
+    const billingDetails = extractBillingDetails({ projectName: 'projectName', cloudPlatform: 'cloudPlatform' });
+
+    // Assert
+    expect(billingDetails).toEqual({
       billingProjectName: 'projectName',
       cloudPlatform: 'CLOUDPLATFORM',
     });

--- a/src/libs/events.test.ts
+++ b/src/libs/events.test.ts
@@ -1,31 +1,6 @@
-import { DeepPartial } from '@terra-ui-packages/core-utils';
-import { WorkspaceWrapper } from 'src/libs/workspace-utils';
+import { defaultAzureWorkspace, defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
 
 import { extractBillingDetails, extractCrossWorkspaceDetails, extractWorkspaceDetails } from './events';
-
-const gcpWorkspace = {
-  workspace: {
-    cloudPlatform: 'Gcp',
-    name: 'wsName',
-    namespace: 'wsNamespace',
-    workspaceId: 'testGoogleWorkspaceId',
-  },
-  accessLevel: 'OWNER',
-  canShare: true,
-  canCompute: true,
-} as const satisfies DeepPartial<WorkspaceWrapper>;
-
-const azureWorkspace = {
-  workspace: {
-    cloudPlatform: 'Azure',
-    name: 'azName',
-    namespace: 'azNamespace',
-    workspaceId: 'azWorkspaceId',
-  },
-  accessLevel: 'OWNER',
-  canShare: true,
-  canCompute: true,
-} as const satisfies DeepPartial<WorkspaceWrapper>;
 
 describe('extractWorkspaceDetails', () => {
   it('Handles properties at top level, converts cloudPlatform to upper case', () => {
@@ -55,12 +30,12 @@ describe('extractWorkspaceDetails', () => {
 
   it('Handles nested workspace details (like from workspace object)', () => {
     // Act
-    const workspaceDetails = extractWorkspaceDetails(gcpWorkspace);
+    const workspaceDetails = extractWorkspaceDetails(defaultGoogleWorkspace);
 
     // Assert
     expect(workspaceDetails).toEqual({
-      workspaceName: 'wsName',
-      workspaceNamespace: 'wsNamespace',
+      workspaceName: defaultGoogleWorkspace.workspace.name,
+      workspaceNamespace: defaultGoogleWorkspace.workspace.namespace,
       cloudPlatform: 'GCP',
       hasProtectedData: undefined,
     });
@@ -70,15 +45,15 @@ describe('extractWorkspaceDetails', () => {
 describe('extractCrossWorkspaceDetails', () => {
   it('Extracts name, namespace, and upper-cased cloudPlatform', () => {
     // Act
-    const crossWorkspaceDetails = extractCrossWorkspaceDetails(gcpWorkspace, azureWorkspace);
+    const crossWorkspaceDetails = extractCrossWorkspaceDetails(defaultGoogleWorkspace, defaultAzureWorkspace);
 
     // Assert
     expect(crossWorkspaceDetails).toEqual({
-      fromWorkspaceNamespace: 'wsNamespace',
-      fromWorkspaceName: 'wsName',
+      fromWorkspaceNamespace: defaultGoogleWorkspace.workspace.namespace,
+      fromWorkspaceName: defaultGoogleWorkspace.workspace.name,
       fromWorkspaceCloudPlatform: 'GCP',
-      toWorkspaceNamespace: 'azNamespace',
-      toWorkspaceName: 'azName',
+      toWorkspaceNamespace: defaultAzureWorkspace.workspace.namespace,
+      toWorkspaceName: defaultAzureWorkspace.workspace.name,
       toWorkspaceCloudPlatform: 'AZURE',
     });
   });

--- a/src/libs/events.ts
+++ b/src/libs/events.ts
@@ -1,8 +1,8 @@
 import _ from 'lodash/fp';
-import { useEffect } from 'react';
+import { ReactNode, useEffect } from 'react';
 import { Ajax } from 'src/libs/ajax';
 import { useRoute } from 'src/libs/nav';
-import { containsProtectedDataPolicy } from 'src/libs/workspace-utils';
+import { containsProtectedDataPolicy, WorkspaceInfo, WorkspaceWrapper } from 'src/libs/workspace-utils';
 
 /*
  * NOTE: In order to show up in reports, new events MUST be marked as expected in the Mixpanel
@@ -140,26 +140,66 @@ const eventsList = {
   workspaceStar: 'workspace:star',
 };
 
+// extractWorkspaceDetails accepts multiple types of input...
+export type EventWorkspaceAttributes =
+  // A WorkspaceWrapper object, from which it extracts the policies and a few fields from the inner WorkspaceInfo.
+  | {
+      workspace: Pick<WorkspaceInfo, 'namespace' | 'name' | 'cloudPlatform'>;
+      policies?: WorkspaceWrapper['policies'];
+    }
+  // A WorkspaceInfo object, from which it extracts a few fields.
+  | Pick<WorkspaceInfo, 'namespace' | 'name' | 'cloudPlatform'>
+  // A workspace namespace and name on their own.
+  // cloudPlatform may also be passed, but it's mainly here to make the types easier in extractWorkspaceDetails.
+  | { namespace: string; name: string; cloudPlatform?: WorkspaceInfo['cloudPlatform'] };
+
+export interface EventWorkspaceDetails {
+  workspaceNamespace: string;
+  workspaceName: string;
+  cloudPlatform?: string;
+  hasProtectedData?: boolean;
+}
+
 /**
- * Extracts name, namespace, and cloudPlatform and policies (if present) from an object. The object can either have these
- * as top-level properties (such as would be returned from parseNav), or nested within a workspace object
- * (such as would be returned from the ajax workspace details API).
+ * Extracts name, namespace, cloudPlatform, and policies (if present) from an object.
+ *
+ * @param workspace - Workspace attributes. These can be provided with a WorkspaceWrapper object, a WorkspaceInfo object, or a plain { namespace, name } object.
  */
-export const extractWorkspaceDetails = (workspaceObject) => {
-  // A "workspace" as returned from the workspace list or details API method has as "workspace" object within it
-  // containing the workspace details.
+export const extractWorkspaceDetails = (workspaceObject: EventWorkspaceAttributes): EventWorkspaceDetails => {
+  // If a WorkspaceWrapper is provided, get the inner WorkspaceInfo. Otherwise, use the provided object directly.
   const workspaceDetails = 'workspace' in workspaceObject ? workspaceObject.workspace : workspaceObject;
   const { name, namespace, cloudPlatform } = workspaceDetails;
-  const hasProtectedData = containsProtectedDataPolicy(workspaceObject.policies ?? workspaceDetails.policies);
-  const data = { workspaceName: name, workspaceNamespace: namespace };
-  // When workspace details are obtained from the nav path, the cloudPlatform will not be available.
-  // Uppercase cloud platform because we mix camelcase and uppercase depending on which server API it came from (rawls/workspace vs. leo).
-  return _.isUndefined(cloudPlatform)
-    ? data
-    : _.merge(data, { cloudPlatform: _.toUpper(cloudPlatform), hasProtectedData });
+
+  // Policies are only available if a WorkspaceWrapper object is passed.
+  // For other types of input, whether the workspace has protected data is unknown.
+  const hasProtectedData =
+    'policies' in workspaceObject ? containsProtectedDataPolicy(workspaceObject.policies) : undefined;
+
+  return {
+    workspaceNamespace: namespace,
+    workspaceName: name,
+    cloudPlatform: cloudPlatform ? cloudPlatform.toUpperCase() : undefined,
+    hasProtectedData,
+  };
 };
 
-export const extractCrossWorkspaceDetails = (fromWorkspace, toWorkspace) => {
+export interface CrossWorkspaceEventWorkspaceAttributes {
+  workspace: Pick<WorkspaceWrapper['workspace'], 'namespace' | 'name' | 'cloudPlatform'>;
+}
+
+export interface CrossWorkspaceEventWorkspaceDetails {
+  fromWorkspaceNamespace: string;
+  fromWorkspaceName: string;
+  fromWorkspaceCloudPlatform: string;
+  toWorkspaceNamespace: string;
+  toWorkspaceName: string;
+  toWorkspaceCloudPlatform: string;
+}
+
+export const extractCrossWorkspaceDetails = (
+  fromWorkspace: CrossWorkspaceEventWorkspaceAttributes,
+  toWorkspace: CrossWorkspaceEventWorkspaceAttributes
+): CrossWorkspaceEventWorkspaceDetails => {
   return {
     fromWorkspaceNamespace: fromWorkspace.workspace.namespace,
     fromWorkspaceName: fromWorkspace.workspace.name,
@@ -170,14 +210,24 @@ export const extractCrossWorkspaceDetails = (fromWorkspace, toWorkspace) => {
   };
 };
 
-export const extractBillingDetails = (billingProject) => {
+export interface EventBillingProjectAttributes {
+  projectName: string;
+  cloudPlatform: string;
+}
+
+export interface EventBillingDetails {
+  billingProjectName: string;
+  cloudPlatform: string;
+}
+
+export const extractBillingDetails = (billingProject: EventBillingProjectAttributes): EventBillingDetails => {
   return {
     billingProjectName: billingProject.projectName,
     cloudPlatform: _.toUpper(billingProject.cloudPlatform), // Should already be uppercase, but enforce for consistency.
   };
 };
 
-export function PageViewReporter() {
+export const PageViewReporter = (): ReactNode => {
   const { name, params } = useRoute();
 
   useEffect(() => {
@@ -190,9 +240,9 @@ export function PageViewReporter() {
   }, [name, params]);
 
   return null;
-}
+};
 
-export const captureAppcuesEvent = (eventName, event) => {
+export const captureAppcuesEvent = (eventName: string, event: any) => {
   // Only record "public-facing events" (and related properties) as documented by Appcues: https://docs.appcues.com/article/301-client-side-events-reference
   const publicEvents = [
     'flow_started',


### PR DESCRIPTION
This adds types to libs/events.ts and updates its tests to match the AAA pattern and use shared workspace fixtures.

One change in behavior... currently, the result of `extractWorkspaceDetails` includes `hasProtectedData: false` in cases where it's actually unknown whether or not the workspace has protected data. This updates it to set `hasProtectedData` to `undefined` in those cases.