### PR TITLE
[WX-1299] Add WX to Workflows App CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,7 +10,7 @@
 /src/libs/ajax/AzureStorage.js @DataBiosphere/broad-interactive-analysis
 /src/libs/ajax/GoogleStorage.js @DataBiosphere/broad-interactive-analysis
 /src/libs/ajax/Catalog.ts @DataBiosphere/data-explorer-eng
-/src/libs/ajax/workflows-app/ @DataBiosphere/broad-workflow-management
+/src/libs/ajax/workflows-app/ @DataBiosphere/broad-workflow-management @DataBiosphere/broad-workflow-execution
 /src/pages/library/DataBrowser* @DataBiosphere/data-explorer-eng
 /src/pages/library/dataBrowser-utils* @DataBiosphere/data-explorer-eng
 /src/pages/library/Datasets* @DataBiosphere/data-explorer-eng
@@ -23,7 +23,7 @@
 /src/pages/workspaces/workspace/*Workspace* @DataBiosphere/broadworkspaces
 /src/components/*Workspace* @DataBiosphere/broadworkspaces
 /src/components/workspace-utils* @DataBiosphere/broadworkspaces
-/src/workflows-app/ @DataBiosphere/broad-workflow-management
+/src/workflows-app/ @DataBiosphere/broad-workflow-management @DataBiosphere/broad-workflow-execution
 /integration-tests/tests/billing-projects.js @DataBiosphere/broadworkspaces
 /integration-tests/tests/janitor.js @DataBiosphere/broadworkspaces
 /integration-tests/tests/workspace-dashboard.js @DataBiosphere/broadworkspaces


### PR DESCRIPTION
[WX-1299](https://broadworkbench.atlassian.net/browse/WX-1299?atlOrigin=eyJpIjoiY2VmNDFlNjA2MmU3NDEyZGI3NmU0YWUzNGM4OTgxMTUiLCJwIjoiaiJ9)

## Summary of changes:
After a cross-team discussion, we decided that it makes sense for WX and WM to share Github code ownership of the Workflows App in Terra UI. 

[WX-1299]: https://broadworkbench.atlassian.net/browse/WX-1299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ