### PR TITLE
ID-822 Support Requester Pays URLs from Sam

### DIFF
--- a/src/libs/ajax/SamResources.ts
+++ b/src/libs/ajax/SamResources.ts
@@ -1,4 +1,5 @@
 import _ from 'lodash/fp';
+import { Ajax } from 'src/libs/ajax';
 import { appIdentifier, authOpts, fetchSam, jsonBody } from 'src/libs/ajax/ajax-common';
 
 type RequesterPaysProject = undefined | string;
@@ -9,21 +10,22 @@ export const SamResources = (signal: AbortSignal) => ({
       `api/resources/v2/${samResourceType}/${samResourceId}/leave`,
       _.mergeAll([authOpts(), appIdentifier, { method: 'DELETE' }])
     ),
+  getRequesterPaysSignedUrl: async (
+    gsPath: string,
+    requesterPaysProject: RequesterPaysProject = undefined
+  ): Promise<string> => {
+    const res = await fetchSam(
+      'api/google/v1/user/signedUrlForBlob',
+      _.mergeAll([jsonBody({ gsPath, requesterPaysProject }), authOpts(), appIdentifier, { signal, method: 'POST' }])
+    );
+    return res.json();
+  },
 
   getSignedUrl: async (
     bucket: string,
     object: string,
     requesterPaysProject: RequesterPaysProject = undefined
   ): Promise<string> => {
-    const res = await fetchSam(
-      'api/google/v1/user/signedUrlForBlob',
-      _.mergeAll([
-        jsonBody({ bucketName: bucket, blobName: object, requesterPaysProject }),
-        authOpts(),
-        appIdentifier,
-        { signal, method: 'POST' },
-      ])
-    );
-    return res.json();
+    return Ajax(signal).SamResources.getRequesterPaysSignedUrl(`gs://${bucket}/${object}`, requesterPaysProject);
   },
 });

--- a/src/libs/ajax/SamResources.ts
+++ b/src/libs/ajax/SamResources.ts
@@ -1,6 +1,8 @@
 import _ from 'lodash/fp';
 import { appIdentifier, authOpts, fetchSam, jsonBody } from 'src/libs/ajax/ajax-common';
 
+type RequesterPaysProject = undefined | string;
+
 export const SamResources = (signal: AbortSignal) => ({
   leave: (samResourceType, samResourceId): Promise<void> =>
     fetchSam(
@@ -8,11 +10,15 @@ export const SamResources = (signal: AbortSignal) => ({
       _.mergeAll([authOpts(), appIdentifier, { method: 'DELETE' }])
     ),
 
-  getSignedUrl: async (bucket: string, object: string, project: string, requesterPays = false): Promise<string> => {
+  getSignedUrl: async (
+    bucket: string,
+    object: string,
+    requesterPaysProject: RequesterPaysProject = undefined
+  ): Promise<string> => {
     const res = await fetchSam(
-      `api/google/v1/user/petServiceAccount/${project}/signedUrlForBlob`,
+      'api/google/v1/user/signedUrlForBlob',
       _.mergeAll([
-        jsonBody({ bucketName: bucket, blobName: object, requesterPays }),
+        jsonBody({ bucketName: bucket, blobName: object, requesterPaysProject }),
         authOpts(),
         appIdentifier,
         { signal, method: 'POST' },

--- a/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.test.ts
+++ b/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.test.ts
@@ -161,7 +161,7 @@ describe('GCSFileBrowserProvider', () => {
     const downloadUrl = await provider.getDownloadUrlForFile('path/to/example.txt');
 
     // Assert
-    expect(getSignedUrl).toHaveBeenCalledWith('test-bucket', 'path/to/example.txt', 'test-project', false);
+    expect(getSignedUrl).toHaveBeenCalledWith('test-bucket', 'path/to/example.txt');
     expect(downloadUrl).toBe('signedUrl');
   });
 

--- a/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.ts
+++ b/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.ts
@@ -129,7 +129,7 @@ const GCSFileBrowserProvider = ({
         signal,
       }),
     getDownloadUrlForFile: async (path, { signal } = {}) => {
-      return await Ajax(signal).SamResources.getSignedUrl(bucket, path, project, false);
+      return await Ajax(signal).SamResources.getSignedUrl(bucket, path);
     },
     getDownloadCommandForFile: (path) => {
       return Promise.resolve(`gsutil cp 'gs://${bucket}/${path}' .`);

--- a/src/workspace-data/data-table/uri-viewer/UriDownloadButton.js
+++ b/src/workspace-data/data-table/uri-viewer/UriDownloadButton.js
@@ -33,8 +33,9 @@ export const UriDownloadButton = ({ uri, metadata: { bucket, name, fileName, siz
     });
     return url;
   };
-  const getUrlFromSam = async () => {
-    return await Ajax(signal).SamResources.getSignedUrl(bucket, name, workspace.workspace.googleProject, false);
+  const getUrlFromSam = async (userProject) => {
+    const requesterPaysProject = knownBucketRequesterPaysStatuses.get()[bucket] ? userProject : undefined;
+    return await Ajax(signal).SamResources.getSignedUrl(bucket, name, requesterPaysProject);
   };
   const getUrl = async () => {
     if (accessUrl?.url) {
@@ -52,8 +53,8 @@ export const UriDownloadButton = ({ uri, metadata: { bucket, name, fileName, siz
     } else {
       try {
         const userProject = await getUserProjectForWorkspace(workspace);
-        const url = isDrsUri(uri) ? await getUrlFromDrsProvider() : await getUrlFromSam();
-        setUrl(knownBucketRequesterPaysStatuses.get()[bucket] ? Utils.mergeQueryParams({ userProject }, url) : url);
+        const url = isDrsUri(uri) ? await getUrlFromDrsProvider() : await getUrlFromSam(userProject);
+        setUrl(knownBucketRequesterPaysStatuses.get()[bucket] && isDrsUri(uri) ? Utils.mergeQueryParams({ userProject }, url) : url);
       } catch (error) {
         setUrl(null);
       }

--- a/src/workspace-data/data-table/uri-viewer/UriDownloadButton.ts
+++ b/src/workspace-data/data-table/uri-viewer/UriDownloadButton.ts
@@ -67,7 +67,7 @@ export const UriDownloadButton = ({ uri, metadata: { bucket, name, fileName, siz
   });
 
   const loadingSpinner = () => {
-    // @ts-expect-error
+    // @ts-ignore
     return h(Fragment, ['Generating download link...', spinner({ style: { color: 'white', marginLeft: 4 } })]);
   };
 

--- a/src/workspace-data/data-table/uri-viewer/UriDownloadButton.ts
+++ b/src/workspace-data/data-table/uri-viewer/UriDownloadButton.ts
@@ -14,28 +14,29 @@ import DownloadPrices from 'src/workspace-data/download-prices';
 import els from './uri-viewer-styles';
 import { isAzureUri, isDrsUri } from './uri-viewer-utils';
 
-const getMaxDownloadCostNA = (bytes) => {
+const getMaxDownloadCostNA = (bytes: number) => {
   const nanos = DownloadPrices.pricingInfo[0].pricingExpression.tieredRates[1].unitPrice.nanos;
-  const downloadPrice = (bytes * nanos) / DownloadPrices.pricingInfo[0].pricingExpression.baseUnitConversionFactor / 10e8;
+  const downloadPrice =
+    (bytes * nanos) / DownloadPrices.pricingInfo[0].pricingExpression.baseUnitConversionFactor / 10e8;
 
   return Utils.formatUSD(downloadPrice);
 };
 
 export const UriDownloadButton = ({ uri, metadata: { bucket, name, fileName, size }, accessUrl, workspace }) => {
   const signal = useCancellation();
-  const [url, setUrl] = useState();
-  const getUrlFromDrsProvider = async () => {
+  const [url, setUrl] = useState<string | null>();
+  const getUrlFromDrsProvider = async (userProject: string) => {
     const { url } = await Ajax(signal).DrsUriResolver.getSignedUrl({
       bucket,
       object: name,
       googleProject: workspace.workspace.googleProject,
       dataObjectUri: uri,
     });
-    return url;
+    return knownBucketRequesterPaysStatuses.get()[bucket] ? Utils.mergeQueryParams({ userProject }, url) : url;
   };
-  const getUrlFromSam = async (userProject) => {
+  const getUrlFromSam = async (userProject: string) => {
     const requesterPaysProject = knownBucketRequesterPaysStatuses.get()[bucket] ? userProject : undefined;
-    return await Ajax(signal).SamResources.getSignedUrl(bucket, name, requesterPaysProject);
+    return await Ajax(signal).SamResources.getRequesterPaysSignedUrl(uri, requesterPaysProject);
   };
   const getUrl = async () => {
     if (accessUrl?.url) {
@@ -53,8 +54,8 @@ export const UriDownloadButton = ({ uri, metadata: { bucket, name, fileName, siz
     } else {
       try {
         const userProject = await getUserProjectForWorkspace(workspace);
-        const url = isDrsUri(uri) ? await getUrlFromDrsProvider() : await getUrlFromSam(userProject);
-        setUrl(knownBucketRequesterPaysStatuses.get()[bucket] && isDrsUri(uri) ? Utils.mergeQueryParams({ userProject }, url) : url);
+        const url = isDrsUri(uri) ? await getUrlFromDrsProvider(userProject) : await getUrlFromSam(userProject);
+        setUrl(url);
       } catch (error) {
         setUrl(null);
       }
@@ -66,6 +67,7 @@ export const UriDownloadButton = ({ uri, metadata: { bucket, name, fileName, siz
   });
 
   const loadingSpinner = () => {
+    // @ts-expect-error
     return h(Fragment, ['Generating download link...', spinner({ style: { color: 'white', marginLeft: 4 } })]);
   };
 
@@ -113,6 +115,8 @@ export const UriDownloadButton = ({ uri, metadata: { bucket, name, fileName, siz
   return els.cell([
     _.isEmpty(url)
       ? 'Unable to generate download link.'
-      : div({ style: { display: 'flex', justifyContent: 'center' } }, [isAzureUri(uri) ? azureDownloadButton() : googleDownloadButton()]),
+      : div({ style: { display: 'flex', justifyContent: 'center' } }, [
+          isAzureUri(uri) ? azureDownloadButton() : googleDownloadButton(),
+        ]),
   ]);
 };


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/ID-822

<!-- ### Dependencies --->
https://github.com/broadinstitute/sam/pull/1193

## Summary of changes:
Fix Requester Pays signed URLs

### What
- Use new endpoint for getting signed urls from Sam to support objects in Requester Pays buckets

### Why
- It was broken. Now its not.

### Testing strategy
- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 
