### PR TITLE
[WOR-1278] Fix workspaces search by keyword

### DIFF
--- a/src/pages/workspaces/WorkspacesList/WorkspaceFilters.ts
+++ b/src/pages/workspaces/WorkspacesList/WorkspaceFilters.ts
@@ -36,7 +36,7 @@ export const WorkspaceFilters = (props: WorkspaceFiltersProps): ReactNode => {
         placeholder: 'Search by keyword',
         'aria-label': 'Search workspaces by keyword',
         onChange: (newFilter) => Nav.updateSearch({ ...query, filter: newFilter || undefined }),
-        value: filters.accessLevels,
+        value: filters.nameFilter,
       }),
     ]),
     div({ style: styles.filter }, [


### PR DESCRIPTION
Currently, whatever is typed in the "Search by keyword" field on the workspaces list disappears after a short delay. The issue is that the input's value is getting set from the wrong query parameter (it's using `accessLevelsFilter` instead of `filter`).