### PR TITLE
[UIE-74] Convert icons to TypeScript

### DIFF
--- a/src/components/WorkspaceStarControl.ts
+++ b/src/components/WorkspaceStarControl.ts
@@ -93,8 +93,7 @@ export const WorkspaceStarControl = (props: WorkspaceStarControlProps): ReactNod
     },
     [
       updatingStars
-        ? // @ts-expect-error
-          spinner({ size: 20 })
+        ? spinner({ size: 20 })
         : icon('star', { size: 20, color: isStarred ? colors.warning() : colors.light(2) }),
     ]
   );

--- a/src/components/WorkspaceSubmissionStatusIcon.ts
+++ b/src/components/WorkspaceSubmissionStatusIcon.ts
@@ -44,7 +44,6 @@ export const WorkspaceSubmissionStatusIcon = (props: WorkspaceSubmissionStatusIc
               content: 'Loading submission status',
               side: 'left',
             },
-            // @ts-expect-error
             [spinner({ size })]
           ),
         ]),

--- a/src/components/file-browser/DownloadFileCommand.ts
+++ b/src/components/file-browser/DownloadFileCommand.ts
@@ -19,7 +19,6 @@ export const DownloadFileCommand = (props: DownloadFileCommandProps) => {
   return h(Fragment, [
     p({ style: { marginBottom: '0.5rem', fontWeight: 500 } }, [
       'Terminal download command',
-      // @ts-expect-error
       status === 'Loading' && spinner({ size: 12, style: { color: '#000', marginLeft: '1ch' } }),
     ]),
     pre(

--- a/src/components/file-browser/DownloadFileLink.ts
+++ b/src/components/file-browser/DownloadFileLink.ts
@@ -24,10 +24,6 @@ export const DownloadFileLink = (props: DownloadFileLinkProps) => {
       download: basename(file.path),
       href: downloadUrl,
     },
-    [
-      'Download',
-      // @ts-expect-error
-      status === 'Loading' && spinner({ size: 12, style: { color: '#fff', marginLeft: '1ch' } }),
-    ]
+    ['Download', status === 'Loading' && spinner({ size: 12, style: { color: '#fff', marginLeft: '1ch' } })]
   );
 };

--- a/src/components/icons.ts
+++ b/src/components/icons.ts
@@ -1,6 +1,6 @@
 import { icon, IconProps } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
-import { Children, Fragment } from 'react';
+import { Children, Fragment, ReactNode } from 'react';
 import { div, h, span } from 'react-hyperscript-helpers';
 // Temporary workaround to avoid a circular import.
 // components/icons => components/common => components/common/spinners => components/icons
@@ -42,13 +42,13 @@ export interface SpinnerOptions extends IconProps {
   message?: string;
 }
 
-export const spinner = ({ message = 'Loading', ...props }: SpinnerOptions = {}) =>
+export const spinner = ({ message = 'Loading', ...props }: SpinnerOptions = {}): ReactNode =>
   h(Fragment, [
     icon('loadingSpinner', _.merge({ size: 24, style: { color: colors.primary() } }, props)),
     h(DelayedRender, { delay: 150 }, [span({ className: 'sr-only', role: 'alert' }, [message])]),
   ]);
 
-export const centeredSpinner = ({ size = 48, ...props }: SpinnerOptions = {}) =>
+export const centeredSpinner = ({ size = 48, ...props }: SpinnerOptions = {}): ReactNode =>
   spinner(
     _.merge(
       {
@@ -66,7 +66,7 @@ export const centeredSpinner = ({ size = 48, ...props }: SpinnerOptions = {}) =>
     )
   );
 
-export const wdlIcon = ({ style = {}, ...props }: JSX.IntrinsicElements['div'] = {}) =>
+export const wdlIcon = ({ style = {}, ...props }: JSX.IntrinsicElements['div'] = {}): ReactNode =>
   div(
     {
       style: {

--- a/src/components/icons.ts
+++ b/src/components/icons.ts
@@ -1,4 +1,4 @@
-import { icon } from '@terra-ui-packages/components';
+import { icon, IconProps } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { Children, Fragment } from 'react';
 import { div, h, span } from 'react-hyperscript-helpers';
@@ -38,13 +38,17 @@ export const containsUnlabelledIcon = ({ children, 'aria-label': ariaLabel, 'ari
   return false;
 };
 
-export const spinner = ({ message = 'Loading', ...props } = {}) =>
+export interface SpinnerOptions extends IconProps {
+  message?: string;
+}
+
+export const spinner = ({ message = 'Loading', ...props }: SpinnerOptions = {}) =>
   h(Fragment, [
     icon('loadingSpinner', _.merge({ size: 24, style: { color: colors.primary() } }, props)),
     h(DelayedRender, { delay: 150 }, [span({ className: 'sr-only', role: 'alert' }, [message])]),
   ]);
 
-export const centeredSpinner = ({ size = 48, ...props } = {}) =>
+export const centeredSpinner = ({ size = 48, ...props }: SpinnerOptions = {}) =>
   spinner(
     _.merge(
       {
@@ -62,7 +66,7 @@ export const centeredSpinner = ({ size = 48, ...props } = {}) =>
     )
   );
 
-export const wdlIcon = ({ style = {}, ...props } = {}) =>
+export const wdlIcon = ({ style = {}, ...props }: JSX.IntrinsicElements['div'] = {}) =>
   div(
     {
       style: {

--- a/src/pages/Register.ts
+++ b/src/pages/Register.ts
@@ -246,7 +246,7 @@ const Register = () => {
         busy &&
           centeredSpinner({
             size: 34,
-            ...{ style: { display: null, margin: null, marginLeft: '1ex' } },
+            ...{ style: { display: undefined, margin: undefined, marginLeft: '1ex' } },
           }),
       ]),
     ]


### PR DESCRIPTION
The `spinner` function in libs/icons is used in several places and its lack of types often causes type errors (as evidenced by the `ts-expect-error` comments this PR removes). This converts libs/icons to TypeScript.