### PR TITLE
[WX-1300] Only show task data in Azure workflows

### DIFF
--- a/src/pages/workspaces/workspace/jobHistory/CallTable.js
+++ b/src/pages/workspaces/workspace/jobHistory/CallTable.js
@@ -120,6 +120,7 @@ const CallTable = ({
   workflowName,
   workflowId,
   failedTasks,
+  isAzure,
 }) => {
   const [failuresModalParams, setFailuresModalParams] = useState();
   const [wizardSelection, setWizardSelection] = useState();
@@ -335,84 +336,88 @@ const CallTable = ({
                 return div({ style: { color: colors.dark(0.7) } }, [effectiveCallCachingMode]);
               },
             },
-            {
-              size: { basis: 200, grow: 1 },
-              field: 'logs',
-              headerRenderer: () => h(HeaderCell, { fontWeight: 500 }, ['Task Data']),
-              cellRenderer: ({ rowIndex }) => {
-                const {
-                  stdout,
-                  stderr,
-                  inputs,
-                  outputs,
-                  subWorkflowId,
-                  // disable linting to match the backend keys
-                  // eslint-disable-next-line camelcase
-                  tes_stderr,
-                  // eslint-disable-next-line camelcase
-                  tes_stdout,
-                } = filteredCallObjects[rowIndex];
-                const style =
-                  enableExplorer && !_.isEmpty(subWorkflowId)
-                    ? {
-                        display: 'flex',
-                        justifyContent: 'flex-start',
-                      }
-                    : {
-                        display: 'grid',
-                        gridTemplateColumns: '1fr 1fr 1fr',
-                        gridColumnGap: '0.6em',
-                        gridRowGap: '0.3em',
-                      };
-                const linkTemplate =
-                  enableExplorer && !_.isEmpty(subWorkflowId)
-                    ? [
-                        h(
-                          Link,
-                          {
-                            onClick: () => {
-                              loadWorkflow(subWorkflowId, updateWorkflowPath);
-                            },
-                          },
-                          ['View sub-workflow']
-                        ),
-                      ]
-                    : _.isEmpty(subWorkflowId) && [
-                        h(
-                          Link,
-                          {
-                            'aria-label': 'View task inputs',
-                            onClick: () => showTaskDataModal('Inputs', inputs),
-                          },
-                          ['Inputs']
-                        ),
-                        h(
-                          Link,
-                          {
-                            'aria-label': 'View task outputs',
-                            onClick: () => showTaskDataModal('Outputs', outputs),
-                          },
-                          ['Outputs']
-                        ),
-                        h(
-                          Link,
-                          {
-                            onClick: () =>
-                              showLogModal('Task Logs', [
-                                { logUri: stdout, logTitle: 'Task Standard Out', logKey: 'stdout', logFilename: 'stdout.txt' },
-                                { logUri: stderr, logTitle: 'Task Standard Err', logKey: 'stderr', logFilename: 'stderr.txt' },
-                                // eslint-disable-next-line camelcase
-                                { logUri: tes_stdout, logTitle: 'Backend Standard Out', logKey: 'tes_stdout', logFilename: 'stdout.txt' },
-                                // eslint-disable-next-line camelcase
-                                { logUri: tes_stderr, logTitle: 'Backend Standard Err', logKey: 'tes_stderr', logFilename: 'stderr.txt' },
-                              ]),
-                          },
-                          ['Logs']
-                        ),
-                      ];
-                return div({ style }, linkTemplate);
-              },
-            },
+            ...(isAzure // GCP workspaces do not have inputs/outputs/logs (only log file is at top level, linked in workflow dashboard)
+              ? [
+                  {
+                    size: { basis: 200, grow: 1 },
+                    field: 'logs',
+                    headerRenderer: () => h(HeaderCell, { fontWeight: 500 }, ['Task Data']),
+                    cellRenderer: ({ rowIndex }) => {
+                      const {
+                        stdout,
+                        stderr,
+                        inputs,
+                        outputs,
+                        subWorkflowId,
+                        // disable linting to match the backend keys
+                        // eslint-disable-next-line camelcase
+                        tes_stderr,
+                        // eslint-disable-next-line camelcase
+                        tes_stdout,
+                      } = filteredCallObjects[rowIndex];
+                      const style =
+                        enableExplorer && !_.isEmpty(subWorkflowId)
+                          ? {
+                              display: 'flex',
+                              justifyContent: 'flex-start',
+                            }
+                          : {
+                              display: 'grid',
+                              gridTemplateColumns: '1fr 1fr 1fr',
+                              gridColumnGap: '0.6em',
+                              gridRowGap: '0.3em',
+                            };
+                      const linkTemplate =
+                        enableExplorer && !_.isEmpty(subWorkflowId)
+                          ? [
+                              h(
+                                Link,
+                                {
+                                  onClick: () => {
+                                    loadWorkflow(subWorkflowId, updateWorkflowPath);
+                                  },
+                                },
+                                ['View sub-workflow']
+                              ),
+                            ]
+                          : _.isEmpty(subWorkflowId) && [
+                              h(
+                                Link,
+                                {
+                                  'aria-label': 'View task inputs',
+                                  onClick: () => showTaskDataModal('Inputs', inputs),
+                                },
+                                ['Inputs']
+                              ),
+                              h(
+                                Link,
+                                {
+                                  'aria-label': 'View task outputs',
+                                  onClick: () => showTaskDataModal('Outputs', outputs),
+                                },
+                                ['Outputs']
+                              ),
+                              h(
+                                Link,
+                                {
+                                  onClick: () =>
+                                    showLogModal('Task Logs', [
+                                      { logUri: stdout, logTitle: 'Task Standard Out', logKey: 'stdout', logFilename: 'stdout.txt' },
+                                      { logUri: stderr, logTitle: 'Task Standard Err', logKey: 'stderr', logFilename: 'stderr.txt' },
+                                      // eslint-disable-next-line camelcase
+                                      { logUri: tes_stdout, logTitle: 'Backend Standard Out', logKey: 'tes_stdout', logFilename: 'stdout.txt' },
+                                      // eslint-disable-next-line camelcase
+                                      { logUri: tes_stderr, logTitle: 'Backend Standard Err', logKey: 'tes_stderr', logFilename: 'stderr.txt' },
+                                    ]),
+                                },
+                                ['Logs']
+                              ),
+                            ];
+                      return div({ style }, linkTemplate);
+                    },
+                  },
+                ]
+              : []),
           ],
         }),
     ]),

--- a/src/workflows-app/RunDetails.js
+++ b/src/workflows-app/RunDetails.js
@@ -237,6 +237,7 @@ export const BaseRunDetails = (
                 name,
                 namespace,
                 submissionId,
+                isAzure: true,
               }),
             ]
           ),


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WX-1300

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Remove task data column from GCP job history

### Why
- Inputs, Outputs, Logs links are exclusive to Azure
- Normal failure messages will be shown in status column

### Testing strategy
- Tested visually with successful and failed workflows in GCP and Azure <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 
