### PR TITLE
[ID-829] add UI version and release date to mixpanel events

### DIFF
--- a/src/libs/ajax/Metrics.ts
+++ b/src/libs/ajax/Metrics.ts
@@ -2,6 +2,7 @@ import { getDefaultProperties } from '@databiosphere/bard-client';
 import _ from 'lodash/fp';
 import { authOpts, fetchBard, jsonBody } from 'src/libs/ajax/ajax-common';
 import { ensureAuthSettled } from 'src/libs/auth';
+import { getConfig } from 'src/libs/config';
 import { withErrorIgnoring } from 'src/libs/error';
 import * as Nav from 'src/libs/nav';
 import { authStore, getSessionId } from 'src/libs/state';
@@ -29,6 +30,8 @@ export const Metrics = (signal?: AbortSignal) => {
         appId: 'Saturn',
         hostname: window.location.hostname,
         appPath: Nav.getCurrentRoute().name,
+        appVersion: `https://github.com/DataBiosphere/terra-ui/commits/${getConfig().gitRevision}`,
+        appVersionPublishDate: new Date(parseInt(getConfig().buildTimestamp, 10)).toLocaleString(),
         ...getDefaultProperties(),
       },
     };


### PR DESCRIPTION
### Jira Ticket: [ID-829](https://broadworkbench.atlassian.net/browse/ID-829)

## Summary of changes:
Added a default property that will be on all mixpanel events to capture the UI version in use (and the release date of that version) when the event was fired. The UI version does not update automatically unless a user refreshes, so this will help us verify bug fixes and behavior changes, so we can be sure we're not getting false positives from users on an old app version. 
<img width="671" alt="Screenshot 2023-09-28 at 3 44 18 PM" src="https://github.com/DataBiosphere/terra-ui/assets/19541449/4c042665-168f-4770-8710-55a1836a0520">



[ID-829]: https://broadworkbench.atlassian.net/browse/ID-829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ