### PR TITLE
[WM-2260] Add Clipboard Icon for copying Submission ID just like Workflow ID in SubmissionDetails

### DIFF
--- a/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
+++ b/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
@@ -526,6 +526,12 @@ const SubmissionDetails = _.flow(
               makeSection('Data Entity', [div([entityName]), div([entityType])]),
               makeSection('Submission ID', [
                 h(Link, { href: bucketBrowserUrl(submissionRoot.replace('gs://', '')), ...Utils.newTabLinkProps }, submissionId),
+                h(ClipboardButton, {
+                  'aria-label': 'Copy submission ID to clipboard',
+                  className: 'cell-hover-only',
+                  style: { marginLeft: '0.5rem' },
+                  text: submissionRoot.split('/').pop(),
+                }),
               ]),
               makeSection('Call Caching', [useCallCache ? 'Enabled' : 'Disabled']),
               makeSection('Delete Intermediate Outputs', [deleteIntermediateOutputFiles ? 'Enabled' : 'Disabled']),


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WM-2260

## Summary of changes:
This adds a clipboard icon for submission IDs for submitted jobs.

### What
This PR introduces a clipboard icon next to the submission ID in the SubmissionDetails page for a submitted job (see image below). When clicked, it copies the submission ID to the clipboard.

### Why
The rationale for this small new feature is as follows:

- The functionality already exists for copying the hash-looking workflow IDs on the same page, so it offers some consistency with the hash-looking submission ID.
- As a Terra user, I’ve often found myself manually copying (either with highlight or right-click + copy) the submission ID more often than workflow ID, given that it’s more useful for writing scripts using the Firecloud API to e.g. gather files across its workflows, etc. Turning a 2-click to a 1-click with existing UI paradigms seems like an easy win to me.

### Testing strategy
I tested locally using yarn!

### Visual Aids
![image](https://github.com/DataBiosphere/terra-ui/assets/81349869/3d763dd5-b5e7-4519-85dc-0e6e31503f02)
