### PR TITLE
[AJ-1358] Add clipboard copy on hover for files in FileBrowser

### DIFF
--- a/src/components/ClipboardButton.js
+++ b/src/components/ClipboardButton.js
@@ -8,7 +8,7 @@ import { icon } from 'src/components/icons';
 import { withErrorReporting } from 'src/libs/error';
 import * as Utils from 'src/libs/utils';
 
-export const ClipboardButton = ({ text, onClick, children, ...props }) => {
+export const ClipboardButton = ({ text, onClick, children, size = 16, ...props }) => {
   const [copied, setCopied] = useState(false);
   return h(
     Link,
@@ -24,6 +24,6 @@ export const ClipboardButton = ({ text, onClick, children, ...props }) => {
         await delay(1500);
       }),
     },
-    [children, icon(copied ? 'check' : 'copy-to-clipboard', !!children && { style: { marginLeft: '0.5rem' } })]
+    [children, icon(copied ? 'check' : 'copy-to-clipboard', { size, ...(!!children && { style: { marginLeft: '0.5rem' } }) })]
   );
 };

--- a/src/components/ClipboardButton.js
+++ b/src/components/ClipboardButton.js
@@ -8,7 +8,7 @@ import { icon } from 'src/components/icons';
 import { withErrorReporting } from 'src/libs/error';
 import * as Utils from 'src/libs/utils';
 
-export const ClipboardButton = ({ text, onClick, children, size = 16, ...props }) => {
+export const ClipboardButton = ({ text, onClick, children, iconSize, ...props }) => {
   const [copied, setCopied] = useState(false);
   return h(
     Link,
@@ -24,6 +24,6 @@ export const ClipboardButton = ({ text, onClick, children, size = 16, ...props }
         await delay(1500);
       }),
     },
-    [children, icon(copied ? 'check' : 'copy-to-clipboard', { size, ...(!!children && { style: { marginLeft: '0.5rem' } }) })]
+    [children, icon(copied ? 'check' : 'copy-to-clipboard', { size: iconSize, ...(!!children && { style: { marginLeft: '0.5rem' } }) })]
   );
 };

--- a/src/components/ClipboardButton.js
+++ b/src/components/ClipboardButton.js
@@ -8,7 +8,7 @@ import { icon } from 'src/components/icons';
 import { withErrorReporting } from 'src/libs/error';
 import * as Utils from 'src/libs/utils';
 
-export const ClipboardButton = ({ text, onClick, children, iconSize, ...props }) => {
+export const ClipboardButton = ({ text, onClick, children, iconSize = undefined, ...props }) => {
   const [copied, setCopied] = useState(false);
   return h(
     Link,

--- a/src/components/data/FileBrowser.js
+++ b/src/components/data/FileBrowser.js
@@ -4,6 +4,7 @@ import pluralize from 'pluralize';
 import { Fragment, useCallback, useEffect, useRef, useState } from 'react';
 import { div, h, span } from 'react-hyperscript-helpers';
 import { AutoSizer } from 'react-virtualized';
+import { ClipboardButton } from 'src/components/ClipboardButton';
 import { ButtonOutline, ButtonPrimary, Checkbox, DeleteConfirmationModal, Link, topSpinnerOverlay } from 'src/components/common';
 import Dropzone from 'src/components/Dropzone';
 import { icon } from 'src/components/icons';
@@ -248,6 +249,13 @@ const BucketBrowserTable = ({
                             },
                             [label]
                           ),
+                          h(ClipboardButton, {
+                            'aria-label': `Copy ${object.name} to clipboard`,
+                            className: 'cell-hover-only',
+                            style: { marginLeft: '1rem' },
+                            text: `gs://${bucketName}/${object.name}`,
+                            size: 14,
+                          }),
                         ]);
                       },
                     ],

--- a/src/components/data/FileBrowser.js
+++ b/src/components/data/FileBrowser.js
@@ -254,7 +254,7 @@ const BucketBrowserTable = ({
                             className: 'cell-hover-only',
                             style: { marginLeft: '1ch' },
                             text: `gs://${bucketName}/${object.name}`,
-                            size: 14,
+                            iconSize: 14,
                           }),
                         ]);
                       },

--- a/src/components/data/FileBrowser.js
+++ b/src/components/data/FileBrowser.js
@@ -254,7 +254,7 @@ const BucketBrowserTable = ({
                             className: 'cell-hover-only',
                             style: { marginLeft: '1ch' },
                             text: `gs://${bucketName}/${object.name}`,
-                            iconSize: 14,
+                            iconSize: 14, // See this PR for reason: https://github.com/DataBiosphere/terra-ui/pull/4288
                           }),
                         ]);
                       },

--- a/src/components/data/FileBrowser.js
+++ b/src/components/data/FileBrowser.js
@@ -250,7 +250,7 @@ const BucketBrowserTable = ({
                             [label]
                           ),
                           h(ClipboardButton, {
-                            'aria-label': `Copy ${object.name} to clipboard`,
+                            tooltip: 'Copy file URL to clipboard',
                             className: 'cell-hover-only',
                             style: { marginLeft: '1rem' },
                             text: `gs://${bucketName}/${object.name}`,

--- a/src/components/data/FileBrowser.js
+++ b/src/components/data/FileBrowser.js
@@ -252,7 +252,7 @@ const BucketBrowserTable = ({
                           h(ClipboardButton, {
                             tooltip: 'Copy file URL to clipboard',
                             className: 'cell-hover-only',
-                            style: { marginLeft: '1rem' },
+                            style: { marginLeft: '1ch' },
                             text: `gs://${bucketName}/${object.name}`,
                             size: 14,
                           }),


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/AJ-1358

## Summary of changes:
This PR adds a copy-clipboard on hover for files in the FileBrowser under the data tab. I tried to achieve this in a few different ways, none of which were perfect from a UI perspective, but ended up deciding on this one which seemed least disruptive. See below for details.

### What
This adds a clipboard on hover object to files, with an explicit size set for the icon to 14, slightly smaller than the default 16. Having a variable size for icons isn't unprecedented in the codebase, but hasn't been done for clipboards prior. It would be nice to avoid this if someone else has a better way to achieve this goal. More details on this choice is provided in the visual section below.

### Why
Recently there was a change to how the pop-up modal for files renders the `gsutil cp` command to include the filename at the end. This makes it even harder to manually copy out *just* the gs URL, which is usually what I want most when I click on the file here. See this animation for a typical set of steps I and some of my coworkers take when we want to grab the gs URL from a file kept in the workspace bucket.

https://github.com/DataBiosphere/terra-ui/assets/81349869/acb61ce1-60f8-47fa-b379-93e027a33a05

It's not ideal and very error prone, so this PR introduces a convenient clipboard 1-click copy for this path. It's modeled after the clipboard on hover from Data table cells.

### Testing strategy
Tested out locally...

### Visual Aids

Here's a demo of the current PR at the time of submission:

https://github.com/DataBiosphere/terra-ui/assets/81349869/6e1c832f-1c76-4ccb-9a94-a7a4c21850b4

Here is what the PR would look like without the slightly smaller size of the clipboard icon:

https://github.com/DataBiosphere/terra-ui/assets/81349869/c2fa79d0-fa22-4282-a395-1b34245a41ea

As you can see, there's a bit of "squishing" that happens when the clipboard icon appears here, most likely due to the fact that the font is size 14 whereas the clipboard defaults to 16. This PR changes the clipboard icon size to 14 *just* in this one place. I'd like to avoid this anti-pattern if possible, but after looking through the Data table cells (where this *doesn't* seem to happen), I can't seem to figure out the right mixture of styles to achieve the same here.

Here's an alternate solution that increases the font size of the file paths here to 16 instead of shrinking the clipboard:

https://github.com/DataBiosphere/terra-ui/assets/81349869/e230311a-db2d-437d-a3ea-cc97f957c0e6

This also doesn't look great, but does "work."

Hopefully a JS expert can suggest a simple fix to get this working without the clipboard shrink, or confirm this might be the best way to go about this.
