### PR TITLE
[ID-838] IdentiTeam hotfix release 2023-10-02

### DIFF
--- a/src/components/WorkspaceStarControl.ts
+++ b/src/components/WorkspaceStarControl.ts
@@ -36,8 +36,7 @@ export const WorkspaceStarControl = (props: WorkspaceStarControlProps): ReactNod
   const maxStarredWorkspacesReached = _.size(stars) >= MAX_STARRED_WORKSPACES;
 
   const refreshStarredWorkspacesList = async () => {
-    // @ts-expect-error
-    const { starredWorkspaces } = Utils.kvArrayToObject((await Ajax().User.profile.get()).keyValuePairs);
+    const { starredWorkspaces } = await Ajax().User.profile.get();
     return _.isEmpty(starredWorkspaces) ? [] : _.split(',', starredWorkspaces);
   };
 

--- a/src/libs/ajax/User.ts
+++ b/src/libs/ajax/User.ts
@@ -56,7 +56,7 @@ export type TerraUserPreferences = {
 
 export interface OrchestrationUserProfileResponse {
   userId: string;
-  keyValuePairs: any; // This is not a TerraUserProfile until Utils.kvArrayToObject is called on this
+  keyValuePairs: { key: string; value: string }[];
 }
 
 export interface SetTerraUserProfileRequest {
@@ -145,9 +145,10 @@ export const User = (signal?: AbortSignal) => {
     },
 
     profile: {
-      get: async (): Promise<OrchestrationUserProfileResponse> => {
+      get: async (): Promise<TerraUserProfile> => {
         const res = await fetchOrchestration('register/profile', _.merge(authOpts(), { signal }));
-        return res.json();
+        const rawResponseJson = res.json();
+        return Utils.kvArrayToObject(rawResponseJson) as TerraUserProfile;
       },
 
       // We are not calling Thurloe directly because free credits logic was in orchestration

--- a/src/libs/ajax/User.ts
+++ b/src/libs/ajax/User.ts
@@ -147,7 +147,8 @@ export const User = (signal?: AbortSignal) => {
     profile: {
       get: async (): Promise<TerraUserProfile> => {
         const res = await fetchOrchestration('register/profile', _.merge(authOpts(), { signal }));
-        const rawResponseJson = res.json();
+        const rawResponseJson: OrchestrationUserProfileResponse = res.json();
+        // @ts-expect-error
         return Utils.kvArrayToObject(rawResponseJson) as TerraUserProfile;
       },
 

--- a/src/libs/ajax/User.ts
+++ b/src/libs/ajax/User.ts
@@ -56,7 +56,7 @@ export type TerraUserPreferences = {
 
 export interface OrchestrationUserProfileResponse {
   userId: string;
-  keyValuePairs: TerraUserProfile;
+  keyValuePairs: any; // This is not a TerraUserProfile until Utils.kvArrayToObject is called on this
 }
 
 export interface SetTerraUserProfileRequest {

--- a/src/libs/ajax/User.ts
+++ b/src/libs/ajax/User.ts
@@ -147,9 +147,8 @@ export const User = (signal?: AbortSignal) => {
     profile: {
       get: async (): Promise<TerraUserProfile> => {
         const res = await fetchOrchestration('register/profile', _.merge(authOpts(), { signal }));
-        const rawResponseJson: OrchestrationUserProfileResponse = res.json();
-        // @ts-expect-error
-        return Utils.kvArrayToObject(rawResponseJson) as TerraUserProfile;
+        const rawResponseJson: OrchestrationUserProfileResponse = await res.json();
+        return Utils.kvArrayToObject(rawResponseJson.keyValuePairs) as TerraUserProfile;
       },
 
       // We are not calling Thurloe directly because free credits logic was in orchestration

--- a/src/libs/auth.ts
+++ b/src/libs/auth.ts
@@ -597,9 +597,7 @@ authStore.subscribe(
 );
 
 export const refreshTerraProfile = async () => {
-  const profile: TerraUserProfile = Utils.kvArrayToObject(
-    (await Ajax().User.profile.get()).keyValuePairs
-  ) as TerraUserProfile;
+  const profile: TerraUserProfile = await Ajax().User.profile.get();
   authStore.update((state: AuthState) => ({ ...state, profile }));
 };
 

--- a/src/libs/auth.ts
+++ b/src/libs/auth.ts
@@ -597,7 +597,6 @@ authStore.subscribe(
 );
 
 export const refreshTerraProfile = async () => {
-  // @ts-expect-error
   const profile: TerraUserProfile = Utils.kvArrayToObject(
     (await Ajax().User.profile.get()).keyValuePairs
   ) as TerraUserProfile;

--- a/src/libs/auth.ts
+++ b/src/libs/auth.ts
@@ -597,7 +597,10 @@ authStore.subscribe(
 );
 
 export const refreshTerraProfile = async () => {
-  const profile: TerraUserProfile = (await Ajax().User.profile.get()).keyValuePairs;
+  // @ts-expect-error
+  const profile: TerraUserProfile = Utils.kvArrayToObject(
+    (await Ajax().User.profile.get()).keyValuePairs
+  ) as TerraUserProfile;
   authStore.update((state: AuthState) => ({ ...state, profile }));
 };
 


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/ID-838

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:

### What
- The changes here https://github.com/DataBiosphere/terra-ui/pull/4284/commits/ff518fd03e05c54073cec5d3cfb72e2aedce7865# in `auth.ts` caused the Orch response to not be parsed correctly. This PR reverts that change.

### Why
- The bug this fixes caused the user profile to not be loaded so no user profile data could be loaded.

### Testing strategy
- Manual testing. Unit tests to cover this bug will be added in a future ticket.

<!-- ### Visual Aids -->
Bug this remediates:
<img width="1498" alt="Screenshot 2023-10-02 at 11 44 01 AM" src="https://github.com/DataBiosphere/terra-ui/assets/56648914/b7b8894f-4b2b-4b09-9779-38eebf9f9a72">
<img width="289" alt="Screenshot 2023-10-02 at 11 42 06 AM" src="https://github.com/DataBiosphere/terra-ui/assets/56648914/471b1dd4-2831-4d20-baaa-87afed4840d5">

![image](https://github.com/DataBiosphere/terra-ui/assets/56648914/815b818c-bcd4-46c9-9b01-9e040075cca1)



[PROD-875]: https://broadworkbench.atlassian.net/browse/PROD-875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ