### PR TITLE
Add query param support to goToPath and getLink

### DIFF
--- a/src/libs/nav.test.ts
+++ b/src/libs/nav.test.ts
@@ -1,4 +1,23 @@
-import { isTerraNavKey, terraNavKey } from './nav';
+import { getLink, goToPath, history, isTerraNavKey, terraNavKey } from 'src/libs/nav';
+
+jest.mock('src/libs/state', () => {
+  const { compile, pathToRegexp } = jest.requireActual('path-to-regexp');
+  const keys: any[] = [];
+  const regex = pathToRegexp('/url-version-of-path/:name/:namespace', keys);
+  return {
+    ...jest.requireActual('src/libs/state'),
+    routeHandlersStore: {
+      get: jest.fn().mockReturnValue([
+        {
+          name: 'totally-real-path',
+          regex,
+          keys: keys.map((key) => key.name),
+          makePath: compile('/url-version-of-path/:name/:namespace', { encode: encodeURIComponent }),
+        },
+      ]),
+    },
+  };
+});
 
 describe('isTerraNavKey', () => {
   it('validates good key name', () => {
@@ -15,5 +34,60 @@ describe('isTerraNavKey', () => {
 
     // Assert
     expect(result).toBe(false);
+  });
+});
+
+describe('goToPath', () => {
+  it('does not include query params if not provided', () => {
+    const pathname = '/url-version-of-path/foo/bar';
+    const pathRef = 'totally-real-path';
+    const push = jest.spyOn(history, 'push');
+
+    // Act
+    goToPath(pathRef, { name: 'foo', namespace: 'bar' });
+
+    // Assert
+    expect(push).toHaveBeenCalledWith({
+      pathname,
+    });
+  });
+
+  it('includes query params', () => {
+    const pathname = '/url-version-of-path/foo/bar';
+    const pathRef = 'totally-real-path';
+    const push = jest.spyOn(history, 'push');
+
+    // Act
+    goToPath(pathRef, { name: 'foo', namespace: 'bar', queryParams: { red: 'fish', blue: 'fish' } });
+
+    // Assert
+    expect(push).toHaveBeenCalledWith({
+      pathname,
+      search: '?red=fish&blue=fish',
+    });
+  });
+});
+
+describe('getLink', () => {
+  it('does not include query params if not provided', () => {
+    const pathname = '#url-version-of-path/foo/bar';
+    const pathRef = 'totally-real-path';
+
+    // Act
+    const link = getLink(pathRef, { name: 'foo', namespace: 'bar' });
+
+    // Assert
+    expect(link).toEqual(pathname);
+  });
+
+  it('includes query params', () => {
+    const pathname = '#url-version-of-path/foo/bar';
+    const pathRef = 'totally-real-path';
+
+    // Act
+    const link = getLink(pathRef, { name: 'foo', namespace: 'bar', queryParams: { red: 'fish', blue: 'fish' } });
+
+    // Assert
+    expect(link).toEqual(`${pathname}?red=fish&blue=fish`);
   });
 });

--- a/src/libs/nav.test.ts
+++ b/src/libs/nav.test.ts
@@ -39,6 +39,7 @@ describe('isTerraNavKey', () => {
 
 describe('goToPath', () => {
   it('does not include query params if not provided', () => {
+    // Arrange
     const pathname = '/url-version-of-path/foo/bar';
     const pathRef = 'totally-real-path';
     const push = jest.spyOn(history, 'push');
@@ -53,12 +54,13 @@ describe('goToPath', () => {
   });
 
   it('includes query params', () => {
+    // Arrange
     const pathname = '/url-version-of-path/foo/bar';
     const pathRef = 'totally-real-path';
     const push = jest.spyOn(history, 'push');
 
     // Act
-    goToPath(pathRef, { name: 'foo', namespace: 'bar', queryParams: { red: 'fish', blue: 'fish' } });
+    goToPath(pathRef, { name: 'foo', namespace: 'bar' }, { red: 'fish', blue: 'fish' });
 
     // Assert
     expect(push).toHaveBeenCalledWith({
@@ -70,6 +72,7 @@ describe('goToPath', () => {
 
 describe('getLink', () => {
   it('does not include query params if not provided', () => {
+    // Arrange
     const pathname = '#url-version-of-path/foo/bar';
     const pathRef = 'totally-real-path';
 
@@ -81,11 +84,12 @@ describe('getLink', () => {
   });
 
   it('includes query params', () => {
+    // Arrange
     const pathname = '#url-version-of-path/foo/bar';
     const pathRef = 'totally-real-path';
 
     // Act
-    const link = getLink(pathRef, { name: 'foo', namespace: 'bar', queryParams: { red: 'fish', blue: 'fish' } });
+    const link = getLink(pathRef, { name: 'foo', namespace: 'bar' }, { red: 'fish', blue: 'fish' });
 
     // Assert
     expect(link).toEqual(`${pathname}?red=fish&blue=fish`);

--- a/src/libs/nav.ts
+++ b/src/libs/nav.ts
@@ -73,7 +73,7 @@ export const getPath = (name: string, params?: Record<string, any>): string => {
 /**
  * alias for getPath()
  */
-export const getLink = (name: string, pathParams?: Record<string, any>, queryParams?: Record<string, any>) => {
+export const getLink = (name: string, pathParams?: Record<string, any>, queryParams?: Record<string, any>): string => {
   const path = getPath(name, pathParams).slice(1); // slice off leading slash
   const queryString = queryParams ? qs.stringify(queryParams, { addQueryPrefix: true }) : '';
   return `#${path}${queryString}`;
@@ -82,7 +82,7 @@ export const getLink = (name: string, pathParams?: Record<string, any>, queryPar
 /**
  * navigate the application to the desired nav path.
  */
-export const goToPath = (name: string, pathParams?: Record<string, any>, queryParams?: Record<string, any>) => {
+export const goToPath = (name: string, pathParams?: Record<string, any>, queryParams?: Record<string, any>): void => {
   history.push({
     pathname: getPath(name, pathParams),
     ...(queryParams ? { search: qs.stringify(queryParams, { addQueryPrefix: true }) } : {}),

--- a/src/libs/nav.ts
+++ b/src/libs/nav.ts
@@ -175,8 +175,8 @@ export function PathHashInserter() {
 }
 
 export interface TerraNavLinkProvider {
-  getLink: (name: string, params?: Record<string, any>) => string;
-  goToPath: (name: string, params?: Record<string, any>) => void;
+  getLink: (name: string, pathParams?: Record<string, any>, queryParams?: Record<string, any>) => string;
+  goToPath: (name: string, pathParams?: Record<string, any>, queryParams?: Record<string, any>) => void;
 }
 
 export const terraNavLinkProvider: TerraNavLinkProvider = {

--- a/src/libs/nav.ts
+++ b/src/libs/nav.ts
@@ -73,18 +73,19 @@ export const getPath = (name: string, params?: Record<string, any>): string => {
 /**
  * alias for getPath()
  */
-export const getLink = (name: string, params?: Record<string, any>) =>
-  `#${getPath(name, params).slice(1)}${
-    params?.queryParams ? qs.stringify(params.queryParams, { addQueryPrefix: true }) : ''
-  }`; // slice off leading slash
+export const getLink = (name: string, pathParams?: Record<string, any>, queryParams?: Record<string, any>) => {
+  const path = getPath(name, pathParams).slice(1); // slice off leading slash
+  const queryString = queryParams ? qs.stringify(queryParams, { addQueryPrefix: true }) : '';
+  return `#${path}${queryString}`;
+};
 
 /**
  * navigate the application to the desired nav path.
  */
-export const goToPath = (name: string, params?: Record<string, any>) => {
+export const goToPath = (name: string, pathParams?: Record<string, any>, queryParams?: Record<string, any>) => {
   history.push({
-    pathname: getPath(name, params),
-    ...(params?.queryParams ? { search: qs.stringify(params.queryParams, { addQueryPrefix: true }) } : {}),
+    pathname: getPath(name, pathParams),
+    ...(queryParams ? { search: qs.stringify(queryParams, { addQueryPrefix: true }) } : {}),
   });
 };
 

--- a/src/libs/nav.ts
+++ b/src/libs/nav.ts
@@ -71,7 +71,7 @@ export const getPath = (name: string, params?: Record<string, any>): string => {
 };
 
 /**
- * alias for getPath()
+ * gets a link to the desired nav path, with support for query parameters
  */
 export const getLink = (name: string, pathParams?: Record<string, any>, queryParams?: Record<string, any>): string => {
   const path = getPath(name, pathParams).slice(1); // slice off leading slash

--- a/src/libs/nav.ts
+++ b/src/libs/nav.ts
@@ -73,13 +73,19 @@ export const getPath = (name: string, params?: Record<string, any>): string => {
 /**
  * alias for getPath()
  */
-export const getLink = (name: string, params?: Record<string, any>) => `#${getPath(name, params).slice(1)}`; // slice off leading slash
+export const getLink = (name: string, params?: Record<string, any>) =>
+  `#${getPath(name, params).slice(1)}${
+    params?.queryParams ? qs.stringify(params.queryParams, { addQueryPrefix: true }) : ''
+  }`; // slice off leading slash
 
 /**
  * navigate the application to the desired nav path.
  */
 export const goToPath = (name: string, params?: Record<string, any>) => {
-  history.push({ pathname: getPath(name, params) });
+  history.push({
+    pathname: getPath(name, params),
+    ...(params?.queryParams ? { search: qs.stringify(params.queryParams, { addQueryPrefix: true }) } : {}),
+  });
 };
 
 export function Redirector({ pathname, search }) {


### PR DESCRIPTION
<!-- ### Jira Ticket: https://broadworkbench.atlassian.net/browse/[Ticket #] --->

### Dependencies
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->
https://broadworkbench.atlassian.net/browse/WM-2259 depends on this work

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Allows navigation to pages with query params

### Why
- Some pages use `useQueryParameter`
- Users should be able to navigate to pages with a parameter already set

### Testing strategy
- Added unit tests <!-- Test case 1 -->
- Verified expected behavior in work for WM-2259 (PR to follow)

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 
