### PR TITLE
[WM-2259] Use query params to navigate in Workflows landing page

### DIFF
--- a/src/libs/nav.test.ts
+++ b/src/libs/nav.test.ts
@@ -1,4 +1,23 @@
-import { isTerraNavKey, terraNavKey } from './nav';
+import { getLink, goToPath, history, isTerraNavKey, terraNavKey } from 'src/libs/nav';
+
+jest.mock('src/libs/state', () => {
+  const { compile, pathToRegexp } = jest.requireActual('path-to-regexp');
+  const keys: any[] = [];
+  const regex = pathToRegexp('/url-version-of-path/:name/:namespace', keys);
+  return {
+    ...jest.requireActual('src/libs/state'),
+    routeHandlersStore: {
+      get: jest.fn().mockReturnValue([
+        {
+          name: 'totally-real-path',
+          regex,
+          keys: keys.map((key) => key.name),
+          makePath: compile('/url-version-of-path/:name/:namespace', { encode: encodeURIComponent }),
+        },
+      ]),
+    },
+  };
+});
 
 describe('isTerraNavKey', () => {
   it('validates good key name', () => {
@@ -15,5 +34,60 @@ describe('isTerraNavKey', () => {
 
     // Assert
     expect(result).toBe(false);
+  });
+});
+
+describe('goToPath', () => {
+  it('does not include query params if not provided', () => {
+    const pathname = '/url-version-of-path/foo/bar';
+    const pathRef = 'totally-real-path';
+    const push = jest.spyOn(history, 'push');
+
+    // Act
+    goToPath(pathRef, { name: 'foo', namespace: 'bar' });
+
+    // Assert
+    expect(push).toHaveBeenCalledWith({
+      pathname,
+    });
+  });
+
+  it('includes query params', () => {
+    const pathname = '/url-version-of-path/foo/bar';
+    const pathRef = 'totally-real-path';
+    const push = jest.spyOn(history, 'push');
+
+    // Act
+    goToPath(pathRef, { name: 'foo', namespace: 'bar', queryParams: { red: 'fish', blue: 'fish' } });
+
+    // Assert
+    expect(push).toHaveBeenCalledWith({
+      pathname,
+      search: '?red=fish&blue=fish',
+    });
+  });
+});
+
+describe('getLink', () => {
+  it('does not include query params if not provided', () => {
+    const pathname = '#url-version-of-path/foo/bar';
+    const pathRef = 'totally-real-path';
+
+    // Act
+    const link = getLink(pathRef, { name: 'foo', namespace: 'bar' });
+
+    // Assert
+    expect(link).toEqual(pathname);
+  });
+
+  it('includes query params', () => {
+    const pathname = '#url-version-of-path/foo/bar';
+    const pathRef = 'totally-real-path';
+
+    // Act
+    const link = getLink(pathRef, { name: 'foo', namespace: 'bar', queryParams: { red: 'fish', blue: 'fish' } });
+
+    // Assert
+    expect(link).toEqual(`${pathname}?red=fish&blue=fish`);
   });
 });

--- a/src/libs/nav.test.ts
+++ b/src/libs/nav.test.ts
@@ -39,6 +39,7 @@ describe('isTerraNavKey', () => {
 
 describe('goToPath', () => {
   it('does not include query params if not provided', () => {
+    // Arrange
     const pathname = '/url-version-of-path/foo/bar';
     const pathRef = 'totally-real-path';
     const push = jest.spyOn(history, 'push');
@@ -53,12 +54,13 @@ describe('goToPath', () => {
   });
 
   it('includes query params', () => {
+    // Arrange
     const pathname = '/url-version-of-path/foo/bar';
     const pathRef = 'totally-real-path';
     const push = jest.spyOn(history, 'push');
 
     // Act
-    goToPath(pathRef, { name: 'foo', namespace: 'bar', queryParams: { red: 'fish', blue: 'fish' } });
+    goToPath(pathRef, { name: 'foo', namespace: 'bar' }, { red: 'fish', blue: 'fish' });
 
     // Assert
     expect(push).toHaveBeenCalledWith({
@@ -70,6 +72,7 @@ describe('goToPath', () => {
 
 describe('getLink', () => {
   it('does not include query params if not provided', () => {
+    // Arrange
     const pathname = '#url-version-of-path/foo/bar';
     const pathRef = 'totally-real-path';
 
@@ -81,11 +84,12 @@ describe('getLink', () => {
   });
 
   it('includes query params', () => {
+    // Arrange
     const pathname = '#url-version-of-path/foo/bar';
     const pathRef = 'totally-real-path';
 
     // Act
-    const link = getLink(pathRef, { name: 'foo', namespace: 'bar', queryParams: { red: 'fish', blue: 'fish' } });
+    const link = getLink(pathRef, { name: 'foo', namespace: 'bar' }, { red: 'fish', blue: 'fish' });
 
     // Assert
     expect(link).toEqual(`${pathname}?red=fish&blue=fish`);

--- a/src/libs/nav.ts
+++ b/src/libs/nav.ts
@@ -73,7 +73,7 @@ export const getPath = (name: string, params?: Record<string, any>): string => {
 /**
  * alias for getPath()
  */
-export const getLink = (name: string, pathParams?: Record<string, any>, queryParams?: Record<string, any>) => {
+export const getLink = (name: string, pathParams?: Record<string, any>, queryParams?: Record<string, any>): string => {
   const path = getPath(name, pathParams).slice(1); // slice off leading slash
   const queryString = queryParams ? qs.stringify(queryParams, { addQueryPrefix: true }) : '';
   return `#${path}${queryString}`;
@@ -82,7 +82,7 @@ export const getLink = (name: string, pathParams?: Record<string, any>, queryPar
 /**
  * navigate the application to the desired nav path.
  */
-export const goToPath = (name: string, pathParams?: Record<string, any>, queryParams?: Record<string, any>) => {
+export const goToPath = (name: string, pathParams?: Record<string, any>, queryParams?: Record<string, any>): void => {
   history.push({
     pathname: getPath(name, pathParams),
     ...(queryParams ? { search: qs.stringify(queryParams, { addQueryPrefix: true }) } : {}),

--- a/src/libs/nav.ts
+++ b/src/libs/nav.ts
@@ -175,8 +175,8 @@ export function PathHashInserter() {
 }
 
 export interface TerraNavLinkProvider {
-  getLink: (name: string, params?: Record<string, any>) => string;
-  goToPath: (name: string, params?: Record<string, any>) => void;
+  getLink: (name: string, pathParams?: Record<string, any>, queryParams?: Record<string, any>) => string;
+  goToPath: (name: string, pathParams?: Record<string, any>, queryParams?: Record<string, any>) => void;
 }
 
 export const terraNavLinkProvider: TerraNavLinkProvider = {

--- a/src/libs/nav.ts
+++ b/src/libs/nav.ts
@@ -73,18 +73,19 @@ export const getPath = (name: string, params?: Record<string, any>): string => {
 /**
  * alias for getPath()
  */
-export const getLink = (name: string, params?: Record<string, any>) =>
-  `#${getPath(name, params).slice(1)}${
-    params?.queryParams ? qs.stringify(params.queryParams, { addQueryPrefix: true }) : ''
-  }`; // slice off leading slash
+export const getLink = (name: string, pathParams?: Record<string, any>, queryParams?: Record<string, any>) => {
+  const path = getPath(name, pathParams).slice(1); // slice off leading slash
+  const queryString = queryParams ? qs.stringify(queryParams, { addQueryPrefix: true }) : '';
+  return `#${path}${queryString}`;
+};
 
 /**
  * navigate the application to the desired nav path.
  */
-export const goToPath = (name: string, params?: Record<string, any>) => {
+export const goToPath = (name: string, pathParams?: Record<string, any>, queryParams?: Record<string, any>) => {
   history.push({
-    pathname: getPath(name, params),
-    ...(params?.queryParams ? { search: qs.stringify(params.queryParams, { addQueryPrefix: true }) } : {}),
+    pathname: getPath(name, pathParams),
+    ...(queryParams ? { search: qs.stringify(queryParams, { addQueryPrefix: true }) } : {}),
   });
 };
 

--- a/src/libs/nav.ts
+++ b/src/libs/nav.ts
@@ -71,7 +71,7 @@ export const getPath = (name: string, params?: Record<string, any>): string => {
 };
 
 /**
- * alias for getPath()
+ * gets a link to the desired nav path, with support for query parameters
  */
 export const getLink = (name: string, pathParams?: Record<string, any>, queryParams?: Record<string, any>): string => {
   const path = getPath(name, pathParams).slice(1); // slice off leading slash

--- a/src/libs/nav.ts
+++ b/src/libs/nav.ts
@@ -73,13 +73,19 @@ export const getPath = (name: string, params?: Record<string, any>): string => {
 /**
  * alias for getPath()
  */
-export const getLink = (name: string, params?: Record<string, any>) => `#${getPath(name, params).slice(1)}`; // slice off leading slash
+export const getLink = (name: string, params?: Record<string, any>) =>
+  `#${getPath(name, params).slice(1)}${
+    params?.queryParams ? qs.stringify(params.queryParams, { addQueryPrefix: true }) : ''
+  }`; // slice off leading slash
 
 /**
  * navigate the application to the desired nav path.
  */
 export const goToPath = (name: string, params?: Record<string, any>) => {
-  history.push({ pathname: getPath(name, params) });
+  history.push({
+    pathname: getPath(name, params),
+    ...(params?.queryParams ? { search: qs.stringify(params.queryParams, { addQueryPrefix: true }) } : {}),
+  });
 };
 
 export function Redirector({ pathname, search }) {

--- a/src/workflows-app/RunDetails.js
+++ b/src/workflows-app/RunDetails.js
@@ -158,8 +158,8 @@ export const BaseRunDetails = (
     const breadcrumbPathObjects = [
       {
         label: 'Submission History',
-        path: 'workspace-workflows-app-submission-history',
-        params: { name, namespace },
+        path: 'workspace-workflows-app',
+        params: { name, namespace, queryParams: { tab: 'submission-history' } },
       },
       {
         label: `Submission ${submissionId}`,

--- a/src/workflows-app/RunDetails.js
+++ b/src/workflows-app/RunDetails.js
@@ -159,12 +159,13 @@ export const BaseRunDetails = (
       {
         label: 'Submission History',
         path: 'workspace-workflows-app',
-        params: { name, namespace, queryParams: { tab: 'submission-history' } },
+        pathParams: { name, namespace },
+        queryParams: { tab: 'submission-history' },
       },
       {
         label: `Submission ${submissionId}`,
         path: 'workspace-workflows-app-submission-details',
-        params: { name, namespace, submissionId },
+        pathParams: { name, namespace, submissionId },
       },
       {
         label: workflow?.workflowName,

--- a/src/workflows-app/SubmissionDetails.js
+++ b/src/workflows-app/SubmissionDetails.js
@@ -230,8 +230,8 @@ export const BaseSubmissionDetails = ({ name, namespace, workspace, submissionId
     const breadcrumbPathObjects = [
       {
         label: 'Submission History',
-        path: 'workspace-workflows-app', // TODO: Refactor to reroute to submission history tab in panel
-        params: { name, namespace },
+        path: 'workspace-workflows-app',
+        params: { name, namespace, queryParams: { tab: 'submission-history' } },
       },
       {
         label: `Submission ${submissionId}`,
@@ -265,10 +265,13 @@ export const BaseSubmissionDetails = ({ name, namespace, workspace, submissionId
                       workspace: {
                         workspace: { workspaceId },
                       },
+                      queryParams: {
+                        tab: 'submission-history',
+                      },
                     }),
                   style: { display: 'inline-flex', alignItems: 'center', padding: '1rem 0 0', fontSize: '115%' },
                 },
-                [icon('arrowLeft', { style: { marginRight: '0.5rem' } }), 'Back to workflows']
+                [icon('arrowLeft', { style: { marginRight: '0.5rem' } }), 'Back to submission history']
               ),
               header,
               h2(['Submission name: ', filteredRunSets[0]?.run_set_name]),

--- a/src/workflows-app/SubmissionDetails.js
+++ b/src/workflows-app/SubmissionDetails.js
@@ -258,17 +258,16 @@ export const BaseSubmissionDetails = ({ name, namespace, workspace, submissionId
               h(
                 Link,
                 {
-                  onClick: () =>
-                    Nav.goToPath('workspace-workflows-app', {
-                      name,
-                      namespace,
-                      workspace: {
-                        workspace: { workspaceId },
-                      },
-                      queryParams: {
-                        tab: 'submission-history',
-                      },
-                    }),
+                  href: Nav.getLink('workspace-workflows-app', {
+                    name,
+                    namespace,
+                    workspace: {
+                      workspace: { workspaceId },
+                    },
+                    queryParams: {
+                      tab: 'submission-history',
+                    },
+                  }),
                   style: { display: 'inline-flex', alignItems: 'center', padding: '1rem 0 0', fontSize: '115%' },
                 },
                 [icon('arrowLeft', { style: { marginRight: '0.5rem' } }), 'Back to submission history']
@@ -354,14 +353,12 @@ export const BaseSubmissionDetails = ({ name, namespace, workspace, submissionId
                               h(
                                 Link,
                                 {
-                                  onClick: () => {
-                                    Nav.goToPath('workspace-workflows-app-run-details', {
-                                      namespace,
-                                      name,
-                                      submissionId,
-                                      workflowId: paginatedPreviousRuns[rowIndex].engine_id,
-                                    });
-                                  },
+                                  href: Nav.getLink('workspace-workflows-app-run-details', {
+                                    namespace,
+                                    name,
+                                    submissionId,
+                                    workflowId: paginatedPreviousRuns[rowIndex].engine_id,
+                                  }),
                                   style: { fontWeight: 'bold' },
                                 },
                                 [paginatedPreviousRuns[rowIndex].record_id]

--- a/src/workflows-app/SubmissionDetails.js
+++ b/src/workflows-app/SubmissionDetails.js
@@ -231,7 +231,8 @@ export const BaseSubmissionDetails = ({ name, namespace, workspace, submissionId
       {
         label: 'Submission History',
         path: 'workspace-workflows-app',
-        params: { name, namespace, queryParams: { tab: 'submission-history' } },
+        pathParams: { name, namespace },
+        queryParams: { tab: 'submission-history' },
       },
       {
         label: `Submission ${submissionId}`,
@@ -258,16 +259,19 @@ export const BaseSubmissionDetails = ({ name, namespace, workspace, submissionId
               h(
                 Link,
                 {
-                  href: Nav.getLink('workspace-workflows-app', {
-                    name,
-                    namespace,
-                    workspace: {
-                      workspace: { workspaceId },
+                  href: Nav.getLink(
+                    'workspace-workflows-app',
+                    {
+                      name,
+                      namespace,
+                      workspace: {
+                        workspace: { workspaceId },
+                      },
                     },
-                    queryParams: {
+                    {
                       tab: 'submission-history',
-                    },
-                  }),
+                    }
+                  ),
                   style: { display: 'inline-flex', alignItems: 'center', padding: '1rem 0 0', fontSize: '115%' },
                 },
                 [icon('arrowLeft', { style: { marginRight: '0.5rem' } }), 'Back to submission history']

--- a/src/workflows-app/SubmissionHistory.js
+++ b/src/workflows-app/SubmissionHistory.js
@@ -23,7 +23,6 @@ import {
   makeStatusLine,
   statusType,
 } from 'src/workflows-app/utils/submission-utils';
-import { wrapWorkflowsPage } from 'src/workflows-app/WorkflowsContainer';
 
 export const BaseSubmissionHistory = ({ namespace, workspace }, _ref) => {
   // State
@@ -270,13 +269,11 @@ export const BaseSubmissionHistory = ({ namespace, workspace }, _ref) => {
                                 h(
                                   Link,
                                   {
-                                    onClick: () => {
-                                      Nav.goToPath('workspace-workflows-app-submission-details', {
-                                        name: workspace.workspace.name,
-                                        namespace,
-                                        submissionId: paginatedPreviousRunSets[rowIndex].run_set_id,
-                                      });
-                                    },
+                                    href: Nav.getLink('workspace-workflows-app-submission-details', {
+                                      name: workspace.workspace.name,
+                                      namespace,
+                                      submissionId: paginatedPreviousRunSets[rowIndex].run_set_id,
+                                    }),
                                     style: { fontWeight: 'bold' },
                                   },
                                   [paginatedPreviousRunSets[rowIndex].run_set_name || 'No name']
@@ -357,5 +354,3 @@ export const BaseSubmissionHistory = ({ namespace, workspace }, _ref) => {
         ]),
       ]);
 };
-
-export const SubmissionHistory = wrapWorkflowsPage({ name: 'SubmissionHistory' })(BaseSubmissionHistory);

--- a/src/workflows-app/components/WorkflowsAppNavPanel.test.ts
+++ b/src/workflows-app/components/WorkflowsAppNavPanel.test.ts
@@ -16,6 +16,11 @@ const defaultAnalysesData: AnalysesData = {
 
 jest.mock('src/libs/ajax');
 
+jest.mock('src/libs/nav', () => ({
+  ...jest.requireActual('src/libs/nav'),
+  useQueryParameter: jest.requireActual('react').useState,
+}));
+
 describe('Workflows App Navigation Panel', () => {
   it('renders headers', async () => {
     const user = userEvent.setup();

--- a/src/workflows-app/components/WorkflowsAppNavPanel.ts
+++ b/src/workflows-app/components/WorkflowsAppNavPanel.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp';
-import { CSSProperties } from 'react';
+import { CSSProperties, useEffect } from 'react';
 import { div, h, span } from 'react-hyperscript-helpers';
 import { AnalysesData } from 'src/analysis/Analyses';
 import Collapse from 'src/components/Collapse';
@@ -85,6 +85,12 @@ export const WorkflowsAppNavPanel = ({
   signal,
 }: WorkflowsAppNavPanelProps) => {
   const [selectedSubHeader, setSelectedSubHeader] = useQueryParameter('tab');
+
+  useEffect(() => {
+    if (!(selectedSubHeader in subHeadersMap || selectedSubHeader in findAndAddSubheadersMap)) {
+      setSelectedSubHeader('workspace-workflows');
+    }
+  }, [selectedSubHeader, setSelectedSubHeader]);
 
   const isSubHeaderActive = (subHeader: string) => pageReady && selectedSubHeader === subHeader;
 
@@ -249,8 +255,7 @@ export const WorkflowsAppNavPanel = ({
                 namespace,
                 setSelectedSubHeader,
               }),
-          ],
-          [Utils.DEFAULT, () => () => setSelectedSubHeader('workspace-workflows')]
+          ]
         ),
       ],
       [

--- a/src/workflows-app/components/WorkflowsAppNavPanel.ts
+++ b/src/workflows-app/components/WorkflowsAppNavPanel.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp';
-import { CSSProperties, useState } from 'react';
+import { CSSProperties } from 'react';
 import { div, h, span } from 'react-hyperscript-helpers';
 import { AnalysesData } from 'src/analysis/Analyses';
 import Collapse from 'src/components/Collapse';
@@ -7,6 +7,7 @@ import { Clickable } from 'src/components/common';
 import { centeredSpinner, icon } from 'src/components/icons';
 import colors from 'src/libs/colors';
 import { getConfig } from 'src/libs/config';
+import { useQueryParameter } from 'src/libs/nav';
 import * as Style from 'src/libs/style';
 import * as Utils from 'src/libs/utils';
 import { WorkspaceWrapper } from 'src/libs/workspace-utils';
@@ -83,7 +84,7 @@ export const WorkflowsAppNavPanel = ({
   setLoading,
   signal,
 }: WorkflowsAppNavPanelProps) => {
-  const [selectedSubHeader, setSelectedSubHeader] = useState<string>('workspace-workflows');
+  const [selectedSubHeader, setSelectedSubHeader] = useQueryParameter('tab');
 
   const isSubHeaderActive = (subHeader: string) => pageReady && selectedSubHeader === subHeader;
 
@@ -248,7 +249,8 @@ export const WorkflowsAppNavPanel = ({
                 namespace,
                 setSelectedSubHeader,
               }),
-          ]
+          ],
+          [Utils.DEFAULT, () => () => setSelectedSubHeader('workspace-workflows')]
         ),
       ],
       [

--- a/src/workflows-app/components/job-common.js
+++ b/src/workflows-app/components/job-common.js
@@ -117,11 +117,11 @@ export const PageHeader = ({ breadcrumbPathObjects, title }) => {
 };
 
 export const Breadcrumbs = ({ breadcrumbPathObjects, pageId }) => {
-  const links = breadcrumbPathObjects.map(({ label, path, params }, index) => {
+  const links = breadcrumbPathObjects.map(({ label, path, pathParams, queryParams }, index) => {
     const attributes = { key: `${_.kebabCase(label)}-breadcrumb-link` };
     let component;
     if (!_.isNil(path)) {
-      attributes.href = getLink(path, params);
+      attributes.href = getLink(path, pathParams, queryParams);
       component = h(Link, { ...attributes }, [label]);
     } else {
       component = span({ ...attributes }, [label]);

--- a/src/workflows-app/components/job-common.js
+++ b/src/workflows-app/components/job-common.js
@@ -4,7 +4,7 @@ import { ButtonOutline, Link } from 'src/components/common';
 import { icon } from 'src/components/icons';
 import { breadcrumbHistoryCaret, statusType as gcpStatusType } from 'src/components/job-common';
 import colors from 'src/libs/colors';
-import { goToPath } from 'src/libs/nav';
+import { getLink, goToPath } from 'src/libs/nav';
 
 const iconSize = 18;
 
@@ -121,7 +121,7 @@ export const Breadcrumbs = ({ breadcrumbPathObjects, pageId }) => {
     const attributes = { key: `${_.kebabCase(label)}-breadcrumb-link` };
     let component;
     if (!_.isNil(path)) {
-      attributes.onClick = () => goToPath(path, params);
+      attributes.href = getLink(path, params);
       component = h(Link, { ...attributes }, [label]);
     } else {
       component = span({ ...attributes }, [label]);

--- a/src/workflows-app/components/job-common.test.js
+++ b/src/workflows-app/components/job-common.test.js
@@ -8,11 +8,11 @@ jest.mock('src/libs/nav', () => ({
   getCurrentUrl: jest.fn().mockReturnValue(new URL('https://app.terra.bio')),
   getLink: jest
     .fn()
-    .mockImplementation((path, params) =>
+    .mockImplementation((path, pathParams, queryParams) =>
       path === 'workspace-workflows-app'
-        ? `/#workspaces/${params.namespace}/${params.name}/workflows-app${jest
+        ? `/#workspaces/${pathParams.namespace}/${pathParams.name}/workflows-app${jest
             .requireActual('qs')
-            .stringify(params.queryParams, { addQueryPrefix: true })}`
+            .stringify(queryParams, { addQueryPrefix: true })}`
         : '/#test-link'
     ),
   goToPath: jest.fn(),
@@ -30,7 +30,8 @@ describe('Job Common Components - Page Header', () => {
       {
         label: 'Submission History',
         path: 'workspace-workflows-app',
-        params: { namespace: 'foo', name: 'bar', queryParams: { tab: 'submission-history' } },
+        pathParams: { namespace: 'foo', name: 'bar' },
+        queryParams: { tab: 'submission-history' },
       },
       {
         label: 'Test link',
@@ -46,7 +47,10 @@ describe('Job Common Components - Page Header', () => {
     render(h(PageHeader, props));
 
     const historyLink = screen.getByText(breadcrumbPathObjects[0].label);
-    expect(historyLink).toHaveAttribute('href', Nav.getLink(breadcrumbPathObjects[0].path, breadcrumbPathObjects[0].params));
+    expect(historyLink).toHaveAttribute(
+      'href',
+      Nav.getLink(breadcrumbPathObjects[0].path, breadcrumbPathObjects[0].pathParams, breadcrumbPathObjects[0].queryParams)
+    );
     const testLink = screen.getByText(breadcrumbPathObjects[1].label);
     expect(testLink).toHaveAttribute('href', Nav.getLink(breadcrumbPathObjects[1].path));
   });

--- a/src/workflows-app/components/job-common.test.js
+++ b/src/workflows-app/components/job-common.test.js
@@ -6,7 +6,15 @@ import { HeaderSection, PageHeader } from 'src/workflows-app/components/job-comm
 
 jest.mock('src/libs/nav', () => ({
   getCurrentUrl: jest.fn().mockReturnValue(new URL('https://app.terra.bio')),
-  getLink: jest.fn(),
+  getLink: jest
+    .fn()
+    .mockImplementation((path, params) =>
+      path === 'workspace-workflows-app'
+        ? `/#workspaces/${params.namespace}/${params.name}/workflows-app${jest
+            .requireActual('qs')
+            .stringify(params.queryParams, { addQueryPrefix: true })}`
+        : '/#test-link'
+    ),
   goToPath: jest.fn(),
 }));
 
@@ -21,8 +29,8 @@ describe('Job Common Components - Page Header', () => {
     const breadcrumbPathObjects = [
       {
         label: 'Submission History',
-        path: 'submission-history',
-        params: { namespace: 'foo', name: 'bar' },
+        path: 'workspace-workflows-app',
+        params: { namespace: 'foo', name: 'bar', queryParams: { tab: 'submission-history' } },
       },
       {
         label: 'Test link',
@@ -36,14 +44,11 @@ describe('Job Common Components - Page Header', () => {
     };
 
     render(h(PageHeader, props));
-    const user = userEvent.setup();
 
     const historyLink = screen.getByText(breadcrumbPathObjects[0].label);
-    await user.click(historyLink);
-    expect(Nav.goToPath).toHaveBeenCalledWith(breadcrumbPathObjects[0].path, breadcrumbPathObjects[0].params);
+    expect(historyLink).toHaveAttribute('href', Nav.getLink(breadcrumbPathObjects[0].path, breadcrumbPathObjects[0].params));
     const testLink = screen.getByText(breadcrumbPathObjects[1].label);
-    await user.click(testLink);
-    expect(Nav.goToPath).toHaveBeenCalledWith(breadcrumbPathObjects[1].path, breadcrumbPathObjects[1].params);
+    expect(testLink).toHaveAttribute('href', Nav.getLink(breadcrumbPathObjects[1].path));
   });
 });
 


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WM-2259

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Workflows app landing page navigates between subheaders with a query parameter
- Submission and run details breadcrumbs now point to submission history subtab

### Why
- Users should be able to bookmark specific subheaders, e.g. submission history
- Users should be able to navigate directly to subheaders from other parts of the UI

### Testing strategy
- Unit tests <!-- Test case 1 -->
- Interacted with UI

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 

https://github.com/DataBiosphere/terra-ui/assets/67511512/30eb4c3e-ad18-44e3-be5d-7fe74705db75

