### PR TITLE
[AJ-1310] Validate import data requests

### DIFF
--- a/src/import-data/ImportData.test.ts
+++ b/src/import-data/ImportData.test.ts
@@ -9,7 +9,7 @@ import { useDataCatalog } from 'src/pages/library/dataBrowser-utils';
 import { asMockedFn, renderWithAppContexts as render, SelectHelper } from 'src/testing/test-utils';
 import { defaultAzureWorkspace, defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
 
-import { ImportData } from './ImportData';
+import { ImportDataContainer } from './ImportData';
 
 type UserEvent = ReturnType<typeof userEvent.setup>;
 
@@ -111,7 +111,7 @@ const setup = (opts: SetupOptions) => {
     query: queryParams,
   });
 
-  render(h(ImportData));
+  render(h(ImportDataContainer));
 
   return {
     exportDataset,
@@ -367,25 +367,39 @@ describe('ImportData', () => {
         'Another test snapshot'
       );
     });
-  });
 
-  it('imports from the data catalog', async () => {
-    // Arrange
-    const user = userEvent.setup();
+    it('imports from the data catalog', async () => {
+      // Arrange
+      const user = userEvent.setup();
 
-    const queryParams = {
-      format: 'catalog',
-      catalogDatasetId: '00001111-2222-3333-aaaa-bbbbccccdddd',
-    };
-    const { exportDataset } = setup({ queryParams });
+      const queryParams = {
+        format: 'catalog',
+        catalogDatasetId: '00001111-2222-3333-aaaa-bbbbccccdddd',
+      };
+      const { exportDataset } = setup({ queryParams });
 
-    // Act
-    await importIntoExistingWorkspace(user, defaultGoogleWorkspace.workspace.name);
+      // Act
+      await importIntoExistingWorkspace(user, defaultGoogleWorkspace.workspace.name);
 
-    // Assert
-    expect(exportDataset).toHaveBeenCalledWith({
-      id: queryParams.catalogDatasetId,
-      workspaceId: defaultGoogleWorkspace.workspace.workspaceId,
+      // Assert
+      expect(exportDataset).toHaveBeenCalledWith({
+        id: queryParams.catalogDatasetId,
+        workspaceId: defaultGoogleWorkspace.workspace.workspaceId,
+      });
     });
   });
+
+  it.each([
+    { queryParams: { format: 'pfb' } },
+    { queryParams: { format: 'tdrexport', snapshotId: '00001111-2222-3333-aaaa-bbbbccccdddd' } },
+  ] as { queryParams: Record<string, any> }[])(
+    'renders an error message for invalid import requests',
+    ({ queryParams }) => {
+      // Act
+      setup({ queryParams });
+
+      // Assert
+      screen.getByText('Invalid import request.');
+    }
+  );
 });

--- a/src/import-data/ImportData.ts
+++ b/src/import-data/ImportData.ts
@@ -1,10 +1,11 @@
 import _ from 'lodash/fp';
-import { Fragment, useCallback, useState } from 'react';
-import { h } from 'react-hyperscript-helpers';
+import { Fragment, ReactNode, useState } from 'react';
+import { div, h } from 'react-hyperscript-helpers';
 import { spinnerOverlay } from 'src/components/common';
 import { Ajax } from 'src/libs/ajax';
 import { Dataset } from 'src/libs/ajax/Catalog';
 import { resolveWdsUrl, WdsDataTableProvider } from 'src/libs/ajax/data-table-providers/WdsDataTableProvider';
+import colors from 'src/libs/colors';
 import { withErrorReporting } from 'src/libs/error';
 import Events, { extractWorkspaceDetails } from 'src/libs/events';
 import * as Nav from 'src/libs/nav';
@@ -12,34 +13,50 @@ import { notify } from 'src/libs/notifications';
 import { useOnMount } from 'src/libs/react-utils';
 import { asyncImportJobStore } from 'src/libs/state';
 import * as Utils from 'src/libs/utils';
+import { WorkspaceInfo } from 'src/libs/workspace-utils';
 import { useDataCatalog } from 'src/pages/library/dataBrowser-utils';
 import { notifyDataImportProgress } from 'src/workspace-data/import-jobs';
 
-import { TemplateWorkspaceInfo } from './import-types';
+import {
+  BagItImportRequest,
+  CatalogDatasetImportRequest,
+  CatalogSnapshotsImportRequest,
+  EntitiesImportRequest,
+  ImportRequest,
+  PFBImportRequest,
+  TDRSnapshotExportImportRequest,
+  TDRSnapshotReferenceImportRequest,
+  TemplateWorkspaceInfo,
+} from './import-types';
 import { ImportDataDestination } from './ImportDataDestination';
 import { ImportDataOverview } from './ImportDataOverview';
 import { isProtectedSource } from './protected-data-utils';
+import { useImportRequest } from './useImportRequest';
 
-// ImportData handles all the information relating to the page itself - this includes:
-// * Reading from the URL
-// * Loading initial Data
-// * Managing the import
-export const ImportData = () => {
+const getTitleForImportRequest = (importRequest: ImportRequest): string => {
+  if (importRequest.type === 'tdr-snapshot-export') {
+    return `Importing snapshot ${importRequest.snapshotName}`;
+  }
+
+  if (
+    importRequest.type === 'tdr-snapshot-reference' ||
+    importRequest.type === 'catalog-dataset' ||
+    importRequest.type === 'catalog-snapshots'
+  ) {
+    return 'Linking data to a workspace';
+  }
+
+  return 'Importing data to a workspace';
+};
+
+export interface ImportDataProps {
+  importRequest: ImportRequest;
+}
+
+export const ImportData = (props: ImportDataProps): ReactNode => {
+  const { importRequest } = props;
   const {
-    query: {
-      url,
-      format,
-      ad,
-      wid,
-      template,
-      snapshotId,
-      snapshotName,
-      snapshotIds,
-      referrer,
-      tdrmanifest,
-      catalogDatasetId,
-      tdrSyncPermissions,
-    },
+    query: { ad, format, wid, template },
   } = Nav.useRoute();
   const [templateWorkspaces, setTemplateWorkspaces] = useState<{ [key: string]: TemplateWorkspaceInfo[] }>();
   const [userHasBillingProjects, setUserHasBillingProjects] = useState(true);
@@ -47,26 +64,25 @@ export const ImportData = () => {
   const [isImporting, setIsImporting] = useState(false);
 
   const { dataCatalog } = useDataCatalog();
-  const snapshots = _.flow(
-    _.filter(
-      (snapshot: Dataset) => !!snapshot['dct:identifier'] && _.includes(snapshot['dct:identifier'], snapshotIds)
-    ),
-    _.map((snapshot) => ({
-      // The previous step filters the list to only datasets with 'dct:identifier' defined
-      id: snapshot['dct:identifier']!,
-      title: snapshot['dct:title'],
-      description: snapshot['dct:description'],
-    }))
-  )(dataCatalog);
+  const snapshots =
+    importRequest.type === 'catalog-snapshots'
+      ? _.flow(
+          _.filter(
+            (snapshot: Dataset) =>
+              !!snapshot['dct:identifier'] && _.includes(snapshot['dct:identifier'], importRequest.snapshotIds)
+          ),
+          _.map((snapshot) => ({
+            // The previous step filters the list to only datasets with 'dct:identifier' defined
+            id: snapshot['dct:identifier']!,
+            title: snapshot['dct:title'],
+            description: snapshot['dct:description'],
+          }))
+        )(dataCatalog)
+      : [];
 
   const isDataset = !_.includes(format, ['snapshot', 'tdrexport']);
-  const header = Utils.cond(
-    [referrer === 'data-catalog', () => 'Linking data to a workspace'],
-    [isDataset, () => `Dataset ${snapshotName}`],
-    [Utils.DEFAULT, () => `Snapshot ${snapshotName}`]
-  );
 
-  const isProtectedData = isProtectedSource(url, format);
+  const isProtectedData = importRequest.type === 'pfb' && isProtectedSource(importRequest.url);
 
   // Normalize the snapshot name:
   // Importing snapshot will throw an "enum" error if the name has any spaces or special characters
@@ -87,119 +103,133 @@ export const ImportData = () => {
     loadTemplateWorkspaces();
   });
 
-  const importPFB = (namespace, name) => {
-    return async () => {
-      const { jobId } = await Ajax().Workspaces.workspace(namespace, name).importJob(url, 'pfb', null);
-      asyncImportJobStore.update(Utils.append({ targetWorkspace: { namespace, name }, jobId }));
-      notifyDataImportProgress(jobId);
-    };
+  const importPFB = async (importRequest: PFBImportRequest, workspace: WorkspaceInfo) => {
+    const { namespace, name } = workspace;
+    const { jobId } = await Ajax().Workspaces.workspace(namespace, name).importJob(importRequest.url, 'pfb', null);
+    asyncImportJobStore.update(Utils.append({ targetWorkspace: { namespace, name }, jobId }));
+    notifyDataImportProgress(jobId);
   };
 
-  const importEntitiesJson = (namespace, name) => {
-    return async () => {
-      await Ajax().Workspaces.workspace(namespace, name).importJSON(url);
-      notify('success', 'Data imported successfully.', { timeout: 3000 });
-    };
+  const importBagit = async (importRequest: BagItImportRequest, workspace: WorkspaceInfo) => {
+    const { namespace, name } = workspace;
+    await Ajax().Workspaces.workspace(namespace, name).importBagit(importRequest.url);
+    notify('success', 'Data imported successfully.', { timeout: 3000 });
   };
 
-  const loadWdsUrl = useCallback((workspaceId) => {
-    return Ajax().Apps.listAppsV2(workspaceId).then(resolveWdsUrl);
-  }, []);
+  const importEntitiesJson = async (importRequest: EntitiesImportRequest, workspace: WorkspaceInfo) => {
+    const { namespace, name } = workspace;
+    await Ajax().Workspaces.workspace(namespace, name).importJSON(importRequest.url);
+    notify('success', 'Data imported successfully.', { timeout: 3000 });
+  };
 
-  const importTdrExport = (workspace) => {
+  const importTdrExport = async (importRequest: TDRSnapshotExportImportRequest, workspace: WorkspaceInfo) => {
     // For new workspaces, cloudPlatform is blank
     if (workspace.cloudPlatform === 'Azure' || workspace.googleProject === '') {
-      return async () => {
-        // find wds for this workspace
-        const wdsUrl = await loadWdsUrl(workspace.workspaceId);
-        const wdsDataTableProvider = new WdsDataTableProvider(workspace.workspaceId, wdsUrl);
+      // find wds for this workspace
+      const wdsUrl = await Ajax().Apps.listAppsV2(workspace.workspaceId).then(resolveWdsUrl);
+      const wdsDataTableProvider = new WdsDataTableProvider(workspace.workspaceId, wdsUrl);
 
-        // call import snapshot
-        wdsDataTableProvider.importTdr(workspace.workspaceId, snapshotId);
-      };
+      // call import snapshot
+      wdsDataTableProvider.importTdr(workspace.workspaceId, importRequest.snapshotId);
     }
     const { namespace, name } = workspace;
-    return async () => {
-      const { jobId } = await Ajax()
-        .Workspaces.workspace(namespace, name)
-        .importJob(tdrmanifest, 'tdrexport', { tdrSyncPermissions: tdrSyncPermissions === 'true' });
-      asyncImportJobStore.update(Utils.append({ targetWorkspace: { namespace, name }, jobId }));
-      notifyDataImportProgress(jobId);
-    };
+    const { jobId } = await Ajax()
+      .Workspaces.workspace(namespace, name)
+      .importJob(importRequest.manifestUrl, 'tdrexport', { tdrSyncPermissions: importRequest.syncPermissions });
+    asyncImportJobStore.update(Utils.append({ targetWorkspace: { namespace, name }, jobId }));
+    notifyDataImportProgress(jobId);
   };
 
-  const importSnapshot = (namespace, name) => {
-    return async () => {
-      if (!_.isEmpty(snapshots)) {
-        const responses = await Promise.allSettled(
-          _.map(({ title, id, description }) => {
-            return Ajax()
-              .Workspaces.workspace(namespace, name)
-              .importSnapshot(id, normalizeSnapshotName(title), description);
-          }, snapshots)
+  const importSnapshot = async (
+    importRequest: TDRSnapshotReferenceImportRequest | CatalogSnapshotsImportRequest,
+    workspace: WorkspaceInfo
+  ) => {
+    const { namespace, name } = workspace;
+    if (importRequest.type === 'catalog-snapshots') {
+      const responses = await Promise.allSettled(
+        _.map(({ title, id, description }) => {
+          return Ajax()
+            .Workspaces.workspace(namespace, name)
+            .importSnapshot(id, normalizeSnapshotName(title), description);
+        }, snapshots)
+      );
+
+      if (_.some({ status: 'rejected' }, responses)) {
+        const normalizedResponses = (await Promise.all(
+          _.map(async ({ status, reason }: { status: string; reason: Response | undefined }) => {
+            const reasonJson = await reason?.json();
+            const { message } = JSON.parse(reasonJson?.message || '{}');
+            return { status, message };
+          }, responses)
+        )) as unknown as { status: string; message: string | undefined }[];
+        setSnapshotResponses(normalizedResponses);
+
+        // Consolidate the multiple errors into a single error message
+        const numFailures = _.flow(_.filter({ status: 'rejected' }), _.size)(normalizedResponses);
+        throw new Error(
+          `${numFailures} snapshot${
+            numFailures > 1 ? 's' : ''
+          } failed to import. See details in the "Linking to Workspace" section`
         );
-
-        if (_.some({ status: 'rejected' }, responses)) {
-          const normalizedResponses = (await Promise.all(
-            _.map(async ({ status, reason }: { status: string; reason: Response | undefined }) => {
-              const reasonJson = await reason?.json();
-              const { message } = JSON.parse(reasonJson?.message || '{}');
-              return { status, message };
-            }, responses)
-          )) as unknown as { status: string; message: string | undefined }[];
-          setSnapshotResponses(normalizedResponses);
-
-          // Consolidate the multiple errors into a single error message
-          const numFailures = _.flow(_.filter({ status: 'rejected' }), _.size)(normalizedResponses);
-          throw new Error(
-            `${numFailures} snapshot${
-              numFailures > 1 ? 's' : ''
-            } failed to import. See details in the "Linking to Workspace" section`
-          );
-        }
-      } else {
-        await Ajax()
-          .Workspaces.workspace(namespace, name)
-          .importSnapshot(snapshotId, normalizeSnapshotName(snapshotName));
-        notify('success', 'Snapshot imported successfully.', { timeout: 3000 });
       }
-    };
+    } else {
+      await Ajax()
+        .Workspaces.workspace(namespace, name)
+        .importSnapshot(importRequest.snapshotId, normalizeSnapshotName(importRequest.snapshotName));
+      notify('success', 'Snapshot imported successfully.', { timeout: 3000 });
+    }
   };
 
-  const exportCatalog = (workspaceId) => {
-    return async () => {
-      await Ajax().Catalog.exportDataset({ id: catalogDatasetId, workspaceId });
-      notify('success', 'Catalog dataset imported successfully.', { timeout: 3000 });
-    };
+  const exportCatalog = async (importRequest: CatalogDatasetImportRequest, workspace: WorkspaceInfo) => {
+    const { workspaceId } = workspace;
+    await Ajax().Catalog.exportDataset({ id: importRequest.datasetId, workspaceId });
+    notify('success', 'Catalog dataset imported successfully.', { timeout: 3000 });
   };
 
   const onImport = _.flow(
     Utils.withBusyState(setIsImporting),
     withErrorReporting('Import Error')
-  )(async (workspace) => {
-    const { namespace, name } = workspace;
+  )(async (workspace: WorkspaceInfo) => {
+    switch (importRequest.type) {
+      case 'pfb':
+        await importPFB(importRequest, workspace);
+        break;
+      case 'bagit':
+        await importBagit(importRequest, workspace);
+        break;
+      case 'entities':
+        await importEntitiesJson(importRequest, workspace);
+        break;
+      case 'tdr-snapshot-export':
+        await importTdrExport(importRequest, workspace);
+        break;
+      case 'tdr-snapshot-reference':
+      case 'catalog-snapshots':
+        await importSnapshot(importRequest, workspace);
+        break;
+      case 'catalog-dataset':
+        await exportCatalog(importRequest, workspace);
+        break;
+      default:
+        // Use TypeScript to verify that this switch handles all possible values.
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const exhaustiveGuard: never = importRequest;
+    }
 
-    await Utils.switchCase(
-      format,
-      ['PFB', importPFB(namespace, name)],
-      ['entitiesJson', importEntitiesJson(namespace, name)],
-      ['tdrexport', importTdrExport(workspace)],
-      ['snapshot', importSnapshot(namespace, name)],
-      ['catalog', exportCatalog(workspace.workspaceId)],
-      [
-        Utils.DEFAULT,
-        async () => {
-          await Ajax().Workspaces.workspace(namespace, name).importBagit(url);
-          notify('success', 'Data imported successfully.', { timeout: 3000 });
-        },
-      ]
-    );
+    const { namespace, name } = workspace;
     Ajax().Metrics.captureEvent(Events.workspaceDataImport, { format, ...extractWorkspaceDetails(workspace) });
     Nav.goToPath('workspace-data', { namespace, name });
   });
 
   return h(Fragment, [
-    h(ImportDataOverview, { header, snapshots, isDataset, snapshotResponses, url, isProtectedData }),
+    h(ImportDataOverview, {
+      header: getTitleForImportRequest(importRequest),
+      snapshots,
+      isDataset,
+      snapshotResponses,
+      url: 'url' in importRequest ? importRequest.url : undefined,
+      isProtectedData,
+    }),
     h(ImportDataDestination, {
       initialSelectedWorkspaceId: wid,
       templateWorkspaces,
@@ -212,4 +242,28 @@ export const ImportData = () => {
     }),
     isImporting && spinnerOverlay,
   ]);
+};
+
+/**
+ * Validate the import request from the URL.
+ */
+export const ImportDataContainer = () => {
+  const result = useImportRequest();
+  if (!result.isValid) {
+    return div(
+      {
+        style: {
+          flexGrow: 1,
+          padding: '1rem 1.25rem',
+          border: `1px solid ${colors.warning(0.8)}`,
+          borderRadius: '0.5rem',
+          backgroundColor: colors.warning(0.15),
+          fontWeight: 'bold',
+        },
+      },
+      ['Invalid import request.']
+    );
+  }
+
+  return h(ImportData, { importRequest: result.importRequest });
 };

--- a/src/import-data/ImportData.ts
+++ b/src/import-data/ImportData.ts
@@ -34,19 +34,16 @@ import { isProtectedSource } from './protected-data-utils';
 import { useImportRequest } from './useImportRequest';
 
 const getTitleForImportRequest = (importRequest: ImportRequest): string => {
-  if (importRequest.type === 'tdr-snapshot-export') {
-    return `Importing snapshot ${importRequest.snapshotName}`;
+  switch (importRequest.type) {
+    case 'tdr-snapshot-export':
+      return `Importing snapshot ${importRequest.snapshotName}`;
+    case 'tdr-snapshot-reference':
+    case 'catalog-dataset':
+    case 'catalog-snapshots':
+      return 'Linking data to a workspace';
+    default:
+      return 'Importing data to a workspace';
   }
-
-  if (
-    importRequest.type === 'tdr-snapshot-reference' ||
-    importRequest.type === 'catalog-dataset' ||
-    importRequest.type === 'catalog-snapshots'
-  ) {
-    return 'Linking data to a workspace';
-  }
-
-  return 'Importing data to a workspace';
 };
 
 export interface ImportDataProps {

--- a/src/import-data/ImportDataOverview.ts
+++ b/src/import-data/ImportDataOverview.ts
@@ -75,7 +75,7 @@ interface ImportDataOverviewProps {
   isProtectedData: boolean;
   snapshotResponses: { status: string; message: string | undefined }[] | undefined;
   snapshots: { id: string; title: string }[];
-  url: string;
+  url?: string;
 }
 
 export const ImportDataOverview = (props: ImportDataOverviewProps): ReactNode => {

--- a/src/import-data/ImportDataPage.ts
+++ b/src/import-data/ImportDataPage.ts
@@ -7,7 +7,7 @@ import scienceBackground from 'src/images/science-background.jpg';
 import * as Nav from 'src/libs/nav';
 import * as Utils from 'src/libs/utils';
 
-import { ImportData } from './ImportData';
+import { ImportDataContainer } from './ImportData';
 
 const styles = {
   container: {
@@ -19,10 +19,6 @@ const styles = {
   },
 } as const satisfies Record<string, CSSProperties>;
 
-// ImportData handles all the information relating to the page itself - this includes:
-// * Reading from the URL
-// * Loading initial Data
-// * Managing the import
 const ImportDataPage = () => {
   const {
     query: { format, referrer },
@@ -44,7 +40,7 @@ const ImportDataPage = () => {
         alt: '',
         style: { position: 'fixed', top: 0, left: 0, zIndex: -1 },
       }),
-      h(ImportData),
+      h(ImportDataContainer),
     ]),
   ]);
 };

--- a/src/import-data/import-types.ts
+++ b/src/import-data/import-types.ts
@@ -1,3 +1,53 @@
+export interface PFBImportRequest {
+  type: 'pfb';
+  url: string;
+}
+
+export interface BagItImportRequest {
+  type: 'bagit';
+  url: string;
+}
+
+export interface EntitiesImportRequest {
+  type: 'entities';
+  url: string;
+}
+
+export type FileImportRequest = PFBImportRequest | BagItImportRequest | EntitiesImportRequest;
+
+export interface TDRSnapshotExportImportRequest {
+  type: 'tdr-snapshot-export';
+  manifestUrl: string;
+  snapshotId: string;
+  snapshotName: string;
+  syncPermissions: boolean;
+}
+
+export interface TDRSnapshotReferenceImportRequest {
+  type: 'tdr-snapshot-reference';
+  snapshotId: string;
+  snapshotName: string;
+}
+
+export interface CatalogDatasetImportRequest {
+  type: 'catalog-dataset';
+  datasetId: string;
+}
+
+export interface CatalogSnapshotsImportRequest {
+  type: 'catalog-snapshots';
+  snapshotIds: string[];
+}
+
+export type ImportRequest =
+  | PFBImportRequest
+  | BagItImportRequest
+  | EntitiesImportRequest
+  | TDRSnapshotExportImportRequest
+  | TDRSnapshotReferenceImportRequest
+  | CatalogDatasetImportRequest
+  | CatalogSnapshotsImportRequest;
+
 export interface TemplateWorkspaceInfo {
   name: string;
   namespace: string;

--- a/src/import-data/useImportRequest.test.ts
+++ b/src/import-data/useImportRequest.test.ts
@@ -1,0 +1,117 @@
+import {
+  BagItImportRequest,
+  CatalogDatasetImportRequest,
+  CatalogSnapshotsImportRequest,
+  EntitiesImportRequest,
+  ImportRequest,
+  PFBImportRequest,
+  TDRSnapshotExportImportRequest,
+  TDRSnapshotReferenceImportRequest,
+} from './import-types';
+import { getImportRequest } from './useImportRequest';
+
+describe('getImportRequest', () => {
+  type TestCase = {
+    queryParams: Record<string, any>;
+    expectedResult: ImportRequest;
+  };
+
+  const testCases: TestCase[] = [
+    // PFB
+    {
+      queryParams: {
+        format: 'PFB',
+        url: 'https://example.com/path/to/file.pfb',
+      },
+      expectedResult: {
+        type: 'pfb',
+        url: 'https://example.com/path/to/file.pfb',
+      } satisfies PFBImportRequest,
+    },
+    // BagIt
+    {
+      queryParams: {
+        url: 'https://example.com/path/to/file.bagit',
+      },
+      expectedResult: {
+        type: 'bagit',
+        url: 'https://example.com/path/to/file.bagit',
+      } satisfies BagItImportRequest,
+    },
+    // Rawls entities
+    {
+      queryParams: {
+        format: 'entitiesJson',
+        url: 'https://example.com/path/to/file.json',
+      },
+      expectedResult: {
+        type: 'entities',
+        url: 'https://example.com/path/to/file.json',
+      } satisfies EntitiesImportRequest,
+    },
+    // TDR snapshot export
+    {
+      queryParams: {
+        format: 'tdrexport',
+        snapshotId: '00001111-2222-3333-aaaa-bbbbccccdddd',
+        snapshotName: 'test-snapshot',
+        tdrmanifest: 'https://example.com/path/to/manifest.json',
+        tdrSyncPermissions: 'true',
+        url: 'https://data.terra.bio',
+      },
+      expectedResult: {
+        type: 'tdr-snapshot-export',
+        manifestUrl: 'https://example.com/path/to/manifest.json',
+        snapshotId: '00001111-2222-3333-aaaa-bbbbccccdddd',
+        snapshotName: 'test-snapshot',
+        syncPermissions: true,
+      } satisfies TDRSnapshotExportImportRequest,
+    },
+    // TDR snapshot by reference
+    {
+      queryParams: {
+        format: 'snapshot',
+        snapshotId: '00001111-2222-3333-aaaa-bbbbccccdddd',
+        snapshotName: 'test-snapshot',
+      },
+      expectedResult: {
+        type: 'tdr-snapshot-reference',
+        snapshotId: '00001111-2222-3333-aaaa-bbbbccccdddd',
+        snapshotName: 'test-snapshot',
+      } satisfies TDRSnapshotReferenceImportRequest,
+    },
+    // Catalog dataset
+    {
+      queryParams: {
+        format: 'catalog',
+        catalogDatasetId: '00001111-2222-3333-aaaa-bbbbccccdddd',
+      },
+      expectedResult: {
+        type: 'catalog-dataset',
+        datasetId: '00001111-2222-3333-aaaa-bbbbccccdddd',
+      } satisfies CatalogDatasetImportRequest,
+    },
+    // Catalog snapshots
+    {
+      queryParams: {
+        format: 'snapshot',
+        snapshotIds: ['00001111-2222-3333-aaaa-bbbbccccdddd', 'aaaabbbb-cccc-1111-2222-333333333333'],
+      },
+      expectedResult: {
+        type: 'catalog-snapshots',
+        snapshotIds: ['00001111-2222-3333-aaaa-bbbbccccdddd', 'aaaabbbb-cccc-1111-2222-333333333333'],
+      } satisfies CatalogSnapshotsImportRequest,
+    },
+  ];
+
+  it.each(testCases)(
+    'parses $expectedResult.type import request from query parameters',
+    ({ queryParams, expectedResult }) => {
+      // Act
+      const importRequest = getImportRequest(queryParams);
+
+      // Assert
+      expect(importRequest).toEqual(expectedResult);
+    }
+  );
+});

--- a/src/import-data/useImportRequest.ts
+++ b/src/import-data/useImportRequest.ts
@@ -1,0 +1,136 @@
+import { useRoute } from 'src/libs/nav';
+
+import {
+  CatalogDatasetImportRequest,
+  CatalogSnapshotsImportRequest,
+  FileImportRequest,
+  ImportRequest,
+  TDRSnapshotExportImportRequest,
+  TDRSnapshotReferenceImportRequest,
+} from './import-types';
+
+type QueryParams = { [key: string]: unknown };
+
+/**
+ * Validate that a value is a string. Throw an error if it is not.
+ *
+ * @param value The value to validate.
+ * @param label Label for the value to use in error messages.
+ * @returns The validated string value.
+ */
+const requireString = (value: unknown, label = 'value'): string => {
+  if (value === undefined || value === null) {
+    throw new Error(`A ${label} is required`);
+  }
+  if (typeof value !== 'string') {
+    throw new Error(`Invalid ${label}: ${value}`);
+  }
+  return value;
+};
+
+/**
+ * Get the requested import format from query parameters. Default to 'bagit' if none is specified.
+ *
+ * @param queryParams Query parameters from import request.
+ * @returns Requested import format.
+ */
+const getFormat = (queryParams: QueryParams): string => {
+  const { format } = queryParams;
+  if (format === undefined) {
+    return 'bagit';
+  }
+  if (typeof format !== 'string') {
+    throw new Error(`Invalid format: ${format}`);
+  }
+  return format.toLowerCase();
+};
+
+const getFileImportRequest = (queryParams: QueryParams, type: FileImportRequest['type']): FileImportRequest => {
+  const url = requireString(queryParams.url, 'URL');
+  return { type, url };
+};
+
+const getTDRSnapshotExportImportRequest = (queryParams: QueryParams): TDRSnapshotExportImportRequest => {
+  const manifestUrl = requireString(queryParams.tdrmanifest, 'manifest URL');
+  const snapshotId = requireString(queryParams.snapshotId, 'snapshot ID');
+  const snapshotName = requireString(queryParams.snapshotName, 'snapshot name');
+  const syncPermissions = queryParams.tdrSyncPermissions === 'true';
+
+  return {
+    type: 'tdr-snapshot-export',
+    manifestUrl,
+    snapshotId,
+    snapshotName,
+    syncPermissions,
+  };
+};
+
+const getTDRSnapshotReferenceImportRequest = (queryParams: QueryParams): TDRSnapshotReferenceImportRequest => {
+  const snapshotId = requireString(queryParams.snapshotId, 'snapshot ID');
+  const snapshotName = requireString(queryParams.snapshotName, 'snapshot name');
+  return {
+    type: 'tdr-snapshot-reference',
+    snapshotId,
+    snapshotName,
+  };
+};
+
+const getCatalogDatasetImportRequest = (queryParams: QueryParams): CatalogDatasetImportRequest => {
+  const datasetId = requireString(queryParams.catalogDatasetId, 'dataset ID');
+  return {
+    type: 'catalog-dataset',
+    datasetId,
+  };
+};
+
+const getCatalogSnapshotsImportRequest = (queryParams: QueryParams): CatalogSnapshotsImportRequest => {
+  const { snapshotIds } = queryParams;
+  if (!(Array.isArray(snapshotIds) && snapshotIds.every((snapshotId) => typeof snapshotId === 'string'))) {
+    throw new Error(`Invalid snapshot IDs: ${snapshotIds}`);
+  }
+  return {
+    type: 'catalog-snapshots',
+    snapshotIds,
+  };
+};
+
+export const getImportRequest = (queryParams: QueryParams): ImportRequest => {
+  const format = getFormat(queryParams);
+
+  if (format === 'pfb') {
+    return getFileImportRequest(queryParams, 'pfb');
+  }
+  if (format === 'bagit') {
+    return getFileImportRequest(queryParams, 'bagit');
+  }
+  if (format === 'entitiesjson') {
+    return getFileImportRequest(queryParams, 'entities');
+  }
+  if (format === 'tdrexport') {
+    return getTDRSnapshotExportImportRequest(queryParams);
+  }
+  if (format === 'snapshot') {
+    if (queryParams.snapshotIds) {
+      return getCatalogSnapshotsImportRequest(queryParams);
+    }
+    return getTDRSnapshotReferenceImportRequest(queryParams);
+  }
+  if (format === 'catalog') {
+    return getCatalogDatasetImportRequest(queryParams);
+  }
+
+  throw new Error(`Invalid format: ${format}`);
+};
+
+export type UseImportRequestResult = { isValid: true; importRequest: ImportRequest } | { isValid: false; error: Error };
+
+export const useImportRequest = (): UseImportRequestResult => {
+  const { query } = useRoute();
+  try {
+    const importRequest = getImportRequest(query);
+    return { isValid: true, importRequest };
+  } catch (originalError: unknown) {
+    const error = originalError instanceof Error ? originalError : new Error('Unknown error');
+    return { isValid: false, error };
+  }
+};

--- a/src/import-data/useImportRequest.ts
+++ b/src/import-data/useImportRequest.ts
@@ -97,29 +97,25 @@ const getCatalogSnapshotsImportRequest = (queryParams: QueryParams): CatalogSnap
 export const getImportRequest = (queryParams: QueryParams): ImportRequest => {
   const format = getFormat(queryParams);
 
-  if (format === 'pfb') {
-    return getFileImportRequest(queryParams, 'pfb');
+  switch (format) {
+    case 'pfb':
+      return getFileImportRequest(queryParams, 'pfb');
+    case 'bagit':
+      return getFileImportRequest(queryParams, 'bagit');
+    case 'entitiesjson':
+      return getFileImportRequest(queryParams, 'entities');
+    case 'tdrexport':
+      return getTDRSnapshotExportImportRequest(queryParams);
+    case 'snapshot':
+      if (queryParams.snapshotIds) {
+        return getCatalogSnapshotsImportRequest(queryParams);
+      }
+      return getTDRSnapshotReferenceImportRequest(queryParams);
+    case 'catalog':
+      return getCatalogDatasetImportRequest(queryParams);
+    default:
+      throw new Error(`Invalid format: ${format}`);
   }
-  if (format === 'bagit') {
-    return getFileImportRequest(queryParams, 'bagit');
-  }
-  if (format === 'entitiesjson') {
-    return getFileImportRequest(queryParams, 'entities');
-  }
-  if (format === 'tdrexport') {
-    return getTDRSnapshotExportImportRequest(queryParams);
-  }
-  if (format === 'snapshot') {
-    if (queryParams.snapshotIds) {
-      return getCatalogSnapshotsImportRequest(queryParams);
-    }
-    return getTDRSnapshotReferenceImportRequest(queryParams);
-  }
-  if (format === 'catalog') {
-    return getCatalogDatasetImportRequest(queryParams);
-  }
-
-  throw new Error(`Invalid format: ${format}`);
 };
 
 export type UseImportRequestResult = { isValid: true; importRequest: ImportRequest } | { isValid: false; error: Error };


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1310

The import data page gets the data to be imported from query parameters in the URL. However, currently there is no validation on those query parameters. The UI optimistically assumes that all required query parameters for an import format are provided (for example, if format=pfb is provided, it assumes that a URL is provided). Also, since the query parameters from `useRoute` are typed as `any`, TS is limited in the guarantees it can provide.

This adds a `useImportRequest` hook that gets query parameters from the URL and parses/validates them into an `ImportRequest` object.

If a valid `ImportRequest` cannot be created, then the page renders an "Invalid import request" message.

If an `ImportRequest` can be created, then we have confidence in the types of the various fields of the request. That type safety revealed one bug (fixed here) where the heading shown on the page for file imports would be "Dataset undefined".

This is a fairly large diff, but the tests added in #4293 provide confidence that the page still works correctly for each type of import. I also manually tested TDR snapshot imports and catalog imports.