### PR TITLE
[DR-3210] Enable test for exporting a catalog snapshot dataset to a workspace

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,7 +30,7 @@
 /integration-tests/tests/run-analysis.js @DataBiosphere/broad-interactive-analysis
 /integration-tests/tests/run-rstudio.js @DataBiosphere/broad-interactive-analysis
 /integration-tests/tests/analysis-context-bar.js @DataBiosphere/broad-interactive-analysis
-/integration-tests/tests/export-*-dataset-to-new-workspace.js @DataBiosphere/data-explorer-eng
+/integration-tests/tests/export-*-dataset-to-workspace.js @DataBiosphere/data-explorer-eng
 /integration-tests/tests/preview-dataset.js @DataBiosphere/data-explorer-eng
 /integration-tests/tests/request-access.js @DataBiosphere/data-explorer-eng
 /integration-tests/tests/run-catalog* @DataBiosphere/data-explorer-eng

--- a/integration-tests/tests/export-tdr-dataset-to-workspace.js
+++ b/integration-tests/tests/export-tdr-dataset-to-workspace.js
@@ -15,5 +15,4 @@ registerTest({
   name: 'export-tdr-dataset-to-workspace',
   fn: exportTdrDatasetToWorkspace,
   timeout: 2 * 60 * 1000,
-  targetEnvironments: [],
 });


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-3210

This test was disabled in #4186 because IAM propagation delays caused it to frequently fail. Now that TDR snapshots exports use signed URLs, this should work again.