### PR TITLE
[AJ-1310] Update protected PFB sources to match import service

### DIFF
--- a/src/import-data/ImportData.ts
+++ b/src/import-data/ImportData.ts
@@ -79,7 +79,7 @@ export const ImportData = (props: ImportDataProps): ReactNode => {
 
   const isDataset = !_.includes(format, ['snapshot', 'tdrexport']);
 
-  const isProtectedData = importRequest.type === 'pfb' && isProtectedSource(importRequest.url);
+  const isProtectedData = isProtectedSource(importRequest);
 
   // Normalize the snapshot name:
   // Importing snapshot will throw an "enum" error if the name has any spaces or special characters

--- a/src/import-data/ImportData.ts
+++ b/src/import-data/ImportData.ts
@@ -102,20 +102,22 @@ export const ImportData = (props: ImportDataProps): ReactNode => {
 
   const importPFB = async (importRequest: PFBImportRequest, workspace: WorkspaceInfo) => {
     const { namespace, name } = workspace;
-    const { jobId } = await Ajax().Workspaces.workspace(namespace, name).importJob(importRequest.url, 'pfb', null);
+    const { jobId } = await Ajax()
+      .Workspaces.workspace(namespace, name)
+      .importJob(importRequest.url.toString(), 'pfb', null);
     asyncImportJobStore.update(Utils.append({ targetWorkspace: { namespace, name }, jobId }));
     notifyDataImportProgress(jobId);
   };
 
   const importBagit = async (importRequest: BagItImportRequest, workspace: WorkspaceInfo) => {
     const { namespace, name } = workspace;
-    await Ajax().Workspaces.workspace(namespace, name).importBagit(importRequest.url);
+    await Ajax().Workspaces.workspace(namespace, name).importBagit(importRequest.url.toString());
     notify('success', 'Data imported successfully.', { timeout: 3000 });
   };
 
   const importEntitiesJson = async (importRequest: EntitiesImportRequest, workspace: WorkspaceInfo) => {
     const { namespace, name } = workspace;
-    await Ajax().Workspaces.workspace(namespace, name).importJSON(importRequest.url);
+    await Ajax().Workspaces.workspace(namespace, name).importJSON(importRequest.url.toString());
     notify('success', 'Data imported successfully.', { timeout: 3000 });
   };
 
@@ -132,7 +134,9 @@ export const ImportData = (props: ImportDataProps): ReactNode => {
     const { namespace, name } = workspace;
     const { jobId } = await Ajax()
       .Workspaces.workspace(namespace, name)
-      .importJob(importRequest.manifestUrl, 'tdrexport', { tdrSyncPermissions: importRequest.syncPermissions });
+      .importJob(importRequest.manifestUrl.toString(), 'tdrexport', {
+        tdrSyncPermissions: importRequest.syncPermissions,
+      });
     asyncImportJobStore.update(Utils.append({ targetWorkspace: { namespace, name }, jobId }));
     notifyDataImportProgress(jobId);
   };

--- a/src/import-data/ImportDataOverview.test.ts
+++ b/src/import-data/ImportDataOverview.test.ts
@@ -16,7 +16,7 @@ describe('ImportDataOverview', () => {
         snapshots,
         isDataset,
         snapshotResponses,
-        url: 'https://gen3-theanvil-io-pfb-export.s3.amazonaws.com/export_2023-07-07.avro',
+        url: new URL('https://gen3-theanvil-io-pfb-export.s3.amazonaws.com/export_2023-07-07.avro'),
         isProtectedData: true,
       })
     );
@@ -39,7 +39,7 @@ describe('ImportDataOverview', () => {
         snapshots,
         isDataset,
         snapshotResponses,
-        url: 'https://google.com/file.pfb',
+        url: new URL('https://google.com/file.pfb'),
         isProtectedData: false,
       })
     );

--- a/src/import-data/ImportDataOverview.ts
+++ b/src/import-data/ImportDataOverview.ts
@@ -75,7 +75,7 @@ interface ImportDataOverviewProps {
   isProtectedData: boolean;
   snapshotResponses: { status: string; message: string | undefined }[] | undefined;
   snapshots: { id: string; title: string }[];
-  url?: string;
+  url?: URL;
 }
 
 export const ImportDataOverview = (props: ImportDataOverviewProps): ReactNode => {
@@ -103,7 +103,7 @@ export const ImportDataOverview = (props: ImportDataOverviewProps): ReactNode =>
             }),
           ]),
         ])
-      : url && div({ style: { fontSize: 16 } }, ['From: ', new URL(url).hostname]),
+      : url && div({ style: { fontSize: 16 } }, ['From: ', url.hostname]),
     div(
       { style: { marginTop: '1rem' } },
       isProtectedData

--- a/src/import-data/import-types.ts
+++ b/src/import-data/import-types.ts
@@ -1,23 +1,23 @@
 export interface PFBImportRequest {
   type: 'pfb';
-  url: string;
+  url: URL;
 }
 
 export interface BagItImportRequest {
   type: 'bagit';
-  url: string;
+  url: URL;
 }
 
 export interface EntitiesImportRequest {
   type: 'entities';
-  url: string;
+  url: URL;
 }
 
 export type FileImportRequest = PFBImportRequest | BagItImportRequest | EntitiesImportRequest;
 
 export interface TDRSnapshotExportImportRequest {
   type: 'tdr-snapshot-export';
-  manifestUrl: string;
+  manifestUrl: URL;
   snapshotId: string;
   snapshotName: string;
   syncPermissions: boolean;

--- a/src/import-data/protected-data-utils.test.ts
+++ b/src/import-data/protected-data-utils.test.ts
@@ -5,20 +5,23 @@ import { isProtectedSource, isProtectedWorkspace } from './protected-data-utils'
 
 const protectedImports: ImportRequest[] = [
   // AnVIL production
-  { type: 'pfb', url: 'https://service.prod.anvil.gi.ucsc.edu/file.pfb' },
-  { type: 'pfb', url: 'https://s3.amazonaws.com/edu-ucsc-gi-platform-anvil-prod-storage-anvilprod.us-east-1/file.pfb' },
+  { type: 'pfb', url: new URL('https://service.prod.anvil.gi.ucsc.edu/file.pfb') },
+  {
+    type: 'pfb',
+    url: new URL('https://s3.amazonaws.com/edu-ucsc-gi-platform-anvil-prod-storage-anvilprod.us-east-1/file.pfb'),
+  },
   // AnVIL development
-  { type: 'pfb', url: 'https://service.anvil.gi.ucsc.edu/file.pfb' },
+  { type: 'pfb', url: new URL('https://service.anvil.gi.ucsc.edu/file.pfb') },
   // BioData Catalyst
-  { type: 'pfb', url: 'https://gen3.biodatacatalyst.nhlbi.nih.gov/file.pfb' },
-  { type: 'pfb', url: 'https://gen3-biodatacatalyst-nhlbi-nih-gov-pfb-export.s3.amazonaws.com/file.pfb' },
-  { type: 'pfb', url: 'https://s3.amazonaws.com/gen3-biodatacatalyst-nhlbi-nih-gov-pfb-export/file.pfb' },
-  { type: 'pfb', url: 'https://gen3-theanvil-io-pfb-export.s3.amazonaws.com/file.pfb' },
+  { type: 'pfb', url: new URL('https://gen3.biodatacatalyst.nhlbi.nih.gov/file.pfb') },
+  { type: 'pfb', url: new URL('https://gen3-biodatacatalyst-nhlbi-nih-gov-pfb-export.s3.amazonaws.com/file.pfb') },
+  { type: 'pfb', url: new URL('https://s3.amazonaws.com/gen3-biodatacatalyst-nhlbi-nih-gov-pfb-export/file.pfb') },
+  { type: 'pfb', url: new URL('https://gen3-theanvil-io-pfb-export.s3.amazonaws.com/file.pfb') },
 ];
 
 const unprotectedImports: ImportRequest[] = [
-  { type: 'pfb', url: 'https://example.com/file.pfb' },
-  { type: 'entities', url: 'https://service.prod.anvil.gi.ucsc.edu/file.json' },
+  { type: 'pfb', url: new URL('https://example.com/file.pfb') },
+  { type: 'entities', url: new URL('https://service.prod.anvil.gi.ucsc.edu/file.json') },
 ];
 
 describe('isProtectedSource', () => {

--- a/src/import-data/protected-data-utils.test.ts
+++ b/src/import-data/protected-data-utils.test.ts
@@ -1,37 +1,33 @@
 import { defaultAzureWorkspace, defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
 
+import { ImportRequest } from './import-types';
 import { isProtectedSource, isProtectedWorkspace } from './protected-data-utils';
 
-const protectedUrls = [
-  { url: 'https://prod.anvil.gi.ucsc.edu/file', format: 'pfb' },
-  { url: 'https://anvilproject.org/file2', format: 'PFB' },
-  { url: 'https://dev.anvil.gi.ucsc.edu/manifest/files', format: 'pFb' },
-  { url: 'https://gen3.biodatacatalyst.nhlbi.nih.gov/explorer', format: 'PFB' },
-  { url: 'https://gen3-biodatacatalyst-nhlbi-nih-gov-pfb-export.s3.amazonaws.com/dataset', format: 'pfB' },
-  { url: 'https://gen3-theanvil-io-pfb-export.s3.amazonaws.com/export_2023-07-07.avro', format: 'PFB' },
+const protectedImports: ImportRequest[] = [
+  // AnVIL production
+  { type: 'pfb', url: 'https://service.prod.anvil.gi.ucsc.edu/file.pfb' },
+  { type: 'pfb', url: 'https://s3.amazonaws.com/edu-ucsc-gi-platform-anvil-prod-storage-anvilprod.us-east-1/file.pfb' },
+  // AnVIL development
+  { type: 'pfb', url: 'https://service.anvil.gi.ucsc.edu/file.pfb' },
+  // BioData Catalyst
+  { type: 'pfb', url: 'https://gen3.biodatacatalyst.nhlbi.nih.gov/file.pfb' },
+  { type: 'pfb', url: 'https://gen3-biodatacatalyst-nhlbi-nih-gov-pfb-export.s3.amazonaws.com/file.pfb' },
+  { type: 'pfb', url: 'https://s3.amazonaws.com/gen3-biodatacatalyst-nhlbi-nih-gov-pfb-export/file.pfb' },
+  { type: 'pfb', url: 'https://gen3-theanvil-io-pfb-export.s3.amazonaws.com/file.pfb' },
 ];
 
-const nonProtectedUrls = [
-  { url: 'https://nonanvil.site.org/file', format: 'pfb' },
-  { url: 'https://prod.anvil.gi.ucsc.edu/file', format: 'entitiesJson' },
-  { url: 'https://google.com/file.pfb', format: 'PFB' },
-  { url: 'https://nonanvil.site.org/file', format: 'tdrexport' },
-  { url: 'https://prod.anvil.gi.ucsc.edu/file', format: 'snapshot' },
-  { url: 'https://anvilproject.org/', format: 'catalog' },
-  { url: 'https://gen3.biodatacatalyst.nhlbi.nih.gov/explorer', format: 'snapShot' },
-  { url: 'http://localhost:3000', format: '' },
-  { url: '', format: 'pfb' },
-  { url: null, format: 'PFB' },
-  { url: 'https://example.com/path/to/file', format: undefined },
+const unprotectedImports: ImportRequest[] = [
+  { type: 'pfb', url: 'https://example.com/file.pfb' },
+  { type: 'entities', url: 'https://service.prod.anvil.gi.ucsc.edu/file.json' },
 ];
 
 describe('isProtectedSource', () => {
-  it.each(protectedUrls)('%o should  be protected', ({ url, format }) => {
-    expect(isProtectedSource(url, format)).toBe(true);
+  it.each(protectedImports)('$url should be protected', (importRequest) => {
+    expect(isProtectedSource(importRequest)).toBe(true);
   });
 
-  it.each(nonProtectedUrls)('%o should not be protected', ({ url, format }) => {
-    expect(isProtectedSource(url!, format)).toBe(false);
+  it.each(unprotectedImports)('$url should not be protected', (importRequest) => {
+    expect(isProtectedSource(importRequest)).toBe(false);
   });
 });
 

--- a/src/import-data/protected-data-utils.ts
+++ b/src/import-data/protected-data-utils.ts
@@ -23,21 +23,25 @@ const protectedSources: ProtectedSource[] = [
  * */
 export const isProtectedPfbSource = (pfbUrl: URL): boolean => {
   return protectedSources.some((source) => {
-    if (source.type === 'http') {
-      // Match the hostname or subdomains of protected hosts.
-      return pfbUrl.hostname === source.host || pfbUrl.hostname.endsWith(`.${source.host}`);
-    }
+    switch (source.type) {
+      case 'http':
+        // Match the hostname or subdomains of protected hosts.
+        return pfbUrl.hostname === source.host || pfbUrl.hostname.endsWith(`.${source.host}`);
 
-    if (source.type === 's3') {
-      // S3 supports multiple URL formats
-      // https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html
-      return (
-        pfbUrl.hostname === `${source.bucket}.s3.amazonaws.com` ||
-        (pfbUrl.hostname === 's3.amazonaws.com' && pfbUrl.pathname.startsWith(`/${source.bucket}/`))
-      );
-    }
+      case 's3':
+        // S3 supports multiple URL formats
+        // https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html
+        return (
+          pfbUrl.hostname === `${source.bucket}.s3.amazonaws.com` ||
+          (pfbUrl.hostname === 's3.amazonaws.com' && pfbUrl.pathname.startsWith(`/${source.bucket}/`))
+        );
 
-    return false;
+      default:
+        // Use TypeScript to verify that all cases have been handled.
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const exhaustiveGuard: never = source;
+        return false;
+    }
   });
 };
 

--- a/src/import-data/protected-data-utils.ts
+++ b/src/import-data/protected-data-utils.ts
@@ -49,10 +49,12 @@ export const isProtectedPfbSource = (pfbUrl: URL): boolean => {
  * Determine whether an import source is considered protected.
  */
 export const isProtectedSource = (importRequest: ImportRequest): boolean => {
-  if (importRequest.type === 'pfb') {
-    return isProtectedPfbSource(importRequest.url);
+  switch (importRequest.type) {
+    case 'pfb':
+      return isProtectedPfbSource(importRequest.url);
+    default:
+      return false;
   }
-  return false;
 };
 
 // This method identifies whether a workspace qualifies as protected.

--- a/src/import-data/protected-data-utils.ts
+++ b/src/import-data/protected-data-utils.ts
@@ -21,20 +21,19 @@ const protectedSources: ProtectedSource[] = [
 /**
  * Determine if a PFB file is considered protected data.
  * */
-export const isProtectedPfbSource = (pfbUrl: string): boolean => {
-  const parsedUrl = new URL(pfbUrl);
+export const isProtectedPfbSource = (pfbUrl: URL): boolean => {
   return protectedSources.some((source) => {
     if (source.type === 'http') {
       // Match the hostname or subdomains of protected hosts.
-      return parsedUrl.hostname === source.host || parsedUrl.hostname.endsWith(`.${source.host}`);
+      return pfbUrl.hostname === source.host || pfbUrl.hostname.endsWith(`.${source.host}`);
     }
 
     if (source.type === 's3') {
       // S3 supports multiple URL formats
       // https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html
       return (
-        parsedUrl.hostname === `${source.bucket}.s3.amazonaws.com` ||
-        (parsedUrl.hostname === 's3.amazonaws.com' && parsedUrl.pathname.startsWith(`/${source.bucket}/`))
+        pfbUrl.hostname === `${source.bucket}.s3.amazonaws.com` ||
+        (pfbUrl.hostname === 's3.amazonaws.com' && pfbUrl.pathname.startsWith(`/${source.bucket}/`))
       );
     }
 

--- a/src/import-data/useImportRequest.test.ts
+++ b/src/import-data/useImportRequest.test.ts
@@ -25,7 +25,7 @@ describe('getImportRequest', () => {
       },
       expectedResult: {
         type: 'pfb',
-        url: 'https://example.com/path/to/file.pfb',
+        url: new URL('https://example.com/path/to/file.pfb'),
       } satisfies PFBImportRequest,
     },
     // BagIt
@@ -35,7 +35,7 @@ describe('getImportRequest', () => {
       },
       expectedResult: {
         type: 'bagit',
-        url: 'https://example.com/path/to/file.bagit',
+        url: new URL('https://example.com/path/to/file.bagit'),
       } satisfies BagItImportRequest,
     },
     // Rawls entities
@@ -46,7 +46,7 @@ describe('getImportRequest', () => {
       },
       expectedResult: {
         type: 'entities',
-        url: 'https://example.com/path/to/file.json',
+        url: new URL('https://example.com/path/to/file.json'),
       } satisfies EntitiesImportRequest,
     },
     // TDR snapshot export
@@ -61,7 +61,7 @@ describe('getImportRequest', () => {
       },
       expectedResult: {
         type: 'tdr-snapshot-export',
-        manifestUrl: 'https://example.com/path/to/manifest.json',
+        manifestUrl: new URL('https://example.com/path/to/manifest.json'),
         snapshotId: '00001111-2222-3333-aaaa-bbbbccccdddd',
         snapshotName: 'test-snapshot',
         syncPermissions: true,

--- a/src/import-data/useImportRequest.ts
+++ b/src/import-data/useImportRequest.ts
@@ -29,6 +29,23 @@ const requireString = (value: unknown, label = 'value'): string => {
 };
 
 /**
+ * Validate that a value can be parsed as a URL. Throw an error if it cannot.
+ *
+ * @param value The value to validate.
+ * @param label Label for the value to use in error messages.
+ * @returns The validated string value.
+ */
+const requireUrl = (value: unknown, label = 'value'): string => {
+  const stringValue = requireString(value, label);
+  try {
+    const url = new URL(stringValue);
+    return url.toString();
+  } catch {
+    throw new Error(`Invalid ${label}: ${value}`);
+  }
+};
+
+/**
  * Get the requested import format from query parameters. Default to 'bagit' if none is specified.
  *
  * @param queryParams Query parameters from import request.
@@ -46,12 +63,12 @@ const getFormat = (queryParams: QueryParams): string => {
 };
 
 const getFileImportRequest = (queryParams: QueryParams, type: FileImportRequest['type']): FileImportRequest => {
-  const url = requireString(queryParams.url, 'URL');
+  const url = requireUrl(queryParams.url, 'URL');
   return { type, url };
 };
 
 const getTDRSnapshotExportImportRequest = (queryParams: QueryParams): TDRSnapshotExportImportRequest => {
-  const manifestUrl = requireString(queryParams.tdrmanifest, 'manifest URL');
+  const manifestUrl = requireUrl(queryParams.tdrmanifest, 'manifest URL');
   const snapshotId = requireString(queryParams.snapshotId, 'snapshot ID');
   const snapshotName = requireString(queryParams.snapshotName, 'snapshot name');
   const syncPermissions = queryParams.tdrSyncPermissions === 'true';

--- a/src/import-data/useImportRequest.ts
+++ b/src/import-data/useImportRequest.ts
@@ -33,13 +33,12 @@ const requireString = (value: unknown, label = 'value'): string => {
  *
  * @param value The value to validate.
  * @param label Label for the value to use in error messages.
- * @returns The validated string value.
+ * @returns The parsed URL.
  */
-const requireUrl = (value: unknown, label = 'value'): string => {
+const requireUrl = (value: unknown, label = 'value'): URL => {
   const stringValue = requireString(value, label);
   try {
-    const url = new URL(stringValue);
-    return url.toString();
+    return new URL(stringValue);
   } catch {
     throw new Error(`Invalid ${label}: ${value}`);
   }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1310

This updates Terra UI's logic for determining whether or not a PFB import should be considered "protected" to match import service's. This is necessary for the UI to block attempts at imports that import service would reject. In particular, Terra UI was missing support for the path style S3 URLs that was added to import service in https://github.com/broadinstitute/import-service/pull/142.

See https://github.com/broadinstitute/import-service/blob/develop/app/protected_data.py

It also adds stricter validation for URLs in the import request.