### PR TITLE
[AJ-1310] Load catalog on import data page only when necessary

### DIFF
--- a/src/import-data/ImportData.test.ts
+++ b/src/import-data/ImportData.test.ts
@@ -5,7 +5,7 @@ import { h } from 'react-hyperscript-helpers';
 import { useWorkspaces } from 'src/components/workspace-utils';
 import { Ajax } from 'src/libs/ajax';
 import { useRoute } from 'src/libs/nav';
-import { useDataCatalog } from 'src/pages/library/dataBrowser-utils';
+import { fetchDataCatalog } from 'src/pages/library/dataBrowser-utils';
 import { asMockedFn, renderWithAppContexts as render, SelectHelper } from 'src/testing/test-utils';
 import { defaultAzureWorkspace, defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
 
@@ -46,7 +46,7 @@ type DataBrowserUtilsExports = typeof import('src/pages/library/dataBrowser-util
 jest.mock('src/pages/library/dataBrowser-utils', (): DataBrowserUtilsExports => {
   return {
     ...jest.requireActual<DataBrowserUtilsExports>('src/pages/library/dataBrowser-utils'),
-    useDataCatalog: jest.fn(),
+    fetchDataCatalog: jest.fn(),
   };
 });
 
@@ -144,12 +144,6 @@ describe('ImportData', () => {
     // Arrange
     asMockedFn(useWorkspaces).mockReturnValue({
       workspaces: [defaultAzureWorkspace, defaultGoogleWorkspace],
-      loading: false,
-      refresh: () => Promise.resolve(),
-    });
-
-    asMockedFn(useDataCatalog).mockReturnValue({
-      dataCatalog: [],
       loading: false,
       refresh: () => Promise.resolve(),
     });
@@ -306,44 +300,40 @@ describe('ImportData', () => {
       // Arrange
       const user = userEvent.setup();
 
-      asMockedFn(useDataCatalog).mockReturnValue({
-        dataCatalog: [
-          {
-            id: 'aaaabbbb-cccc-dddd-eeee-ffffgggghhhh',
-            'dct:creator': 'testowner',
-            'dct:description': 'A test snapshot',
-            'dct:identifier': '00001111-2222-3333-aaaa-bbbbccccdddd',
-            'dct:issued': '2023-10-02T11:30:00.000000Z',
-            'dct:title': 'test-snapshot-1',
-            'dcat:accessURL':
-              'https://jade.datarepo-dev.broadinstitute.org/snapshots/details/00001111-2222-3333-aaaa-bbbbccccdddd',
-            'TerraDCAT_ap:hasDataCollection': [],
-            accessLevel: 'reader',
-            storage: [],
-            counts: {},
-            samples: {},
-            contributors: [],
-          },
-          {
-            id: '11112222-3333-4444-5555-666677778888',
-            'dct:creator': 'testowner',
-            'dct:description': 'Another test snapshot',
-            'dct:identifier': 'aaaabbbb-cccc-1111-2222-333333333333',
-            'dct:issued': '2023-10-02T11:30:00.000000Z',
-            'dct:title': 'test-snapshot-2',
-            'dcat:accessURL':
-              'https://jade.datarepo-dev.broadinstitute.org/snapshots/details/aaaabbbb-cccc-1111-2222-333333333333',
-            'TerraDCAT_ap:hasDataCollection': [],
-            accessLevel: 'reader',
-            storage: [],
-            counts: {},
-            samples: {},
-            contributors: [],
-          },
-        ],
-        loading: false,
-        refresh: () => Promise.resolve(),
-      });
+      asMockedFn(fetchDataCatalog).mockResolvedValue([
+        {
+          id: 'aaaabbbb-cccc-dddd-eeee-ffffgggghhhh',
+          'dct:creator': 'testowner',
+          'dct:description': 'A test snapshot',
+          'dct:identifier': '00001111-2222-3333-aaaa-bbbbccccdddd',
+          'dct:issued': '2023-10-02T11:30:00.000000Z',
+          'dct:title': 'test-snapshot-1',
+          'dcat:accessURL':
+            'https://jade.datarepo-dev.broadinstitute.org/snapshots/details/00001111-2222-3333-aaaa-bbbbccccdddd',
+          'TerraDCAT_ap:hasDataCollection': [],
+          accessLevel: 'reader',
+          storage: [],
+          counts: {},
+          samples: {},
+          contributors: [],
+        },
+        {
+          id: '11112222-3333-4444-5555-666677778888',
+          'dct:creator': 'testowner',
+          'dct:description': 'Another test snapshot',
+          'dct:identifier': 'aaaabbbb-cccc-1111-2222-333333333333',
+          'dct:issued': '2023-10-02T11:30:00.000000Z',
+          'dct:title': 'test-snapshot-2',
+          'dcat:accessURL':
+            'https://jade.datarepo-dev.broadinstitute.org/snapshots/details/aaaabbbb-cccc-1111-2222-333333333333',
+          'TerraDCAT_ap:hasDataCollection': [],
+          accessLevel: 'reader',
+          storage: [],
+          counts: {},
+          samples: {},
+          contributors: [],
+        },
+      ]);
 
       const queryParams = {
         format: 'snapshot',

--- a/src/import-data/ImportData.ts
+++ b/src/import-data/ImportData.ts
@@ -250,7 +250,12 @@ export const ImportData = (props: ImportDataProps): ReactNode => {
  */
 export const ImportDataContainer = () => {
   const result = useImportRequest();
-  if (!result.isValid) {
+
+  if (result.status === 'Loading') {
+    return spinnerOverlay;
+  }
+
+  if (result.status === 'Error') {
     return div(
       {
         style: {

--- a/src/import-data/import-types.ts
+++ b/src/import-data/import-types.ts
@@ -36,7 +36,11 @@ export interface CatalogDatasetImportRequest {
 
 export interface CatalogSnapshotsImportRequest {
   type: 'catalog-snapshots';
-  snapshotIds: string[];
+  snapshots: {
+    id: string;
+    title: string;
+    description: string;
+  }[];
 }
 
 export type ImportRequest =

--- a/src/import-data/useImportRequest.test.ts
+++ b/src/import-data/useImportRequest.test.ts
@@ -1,3 +1,6 @@
+import { fetchDataCatalog } from 'src/pages/library/dataBrowser-utils';
+import { asMockedFn } from 'src/testing/test-utils';
+
 import {
   BagItImportRequest,
   CatalogDatasetImportRequest,
@@ -9,6 +12,14 @@ import {
   TDRSnapshotReferenceImportRequest,
 } from './import-types';
 import { getImportRequest } from './useImportRequest';
+
+type DataBrowserUtilsExports = typeof import('src/pages/library/dataBrowser-utils');
+jest.mock('src/pages/library/dataBrowser-utils', (): DataBrowserUtilsExports => {
+  return {
+    ...jest.requireActual<DataBrowserUtilsExports>('src/pages/library/dataBrowser-utils'),
+    fetchDataCatalog: jest.fn(),
+  };
+});
 
 describe('getImportRequest', () => {
   type TestCase = {
@@ -95,14 +106,78 @@ describe('getImportRequest', () => {
     {
       queryParams: {
         format: 'snapshot',
-        snapshotIds: ['00001111-2222-3333-aaaa-bbbbccccdddd', 'aaaabbbb-cccc-1111-2222-333333333333'],
+        snapshotIds: ['aaaabbbb-cccc-1111-2222-333333333333', '00001111-2222-3333-aaaa-bbbbccccdddd'],
       },
       expectedResult: {
         type: 'catalog-snapshots',
-        snapshotIds: ['00001111-2222-3333-aaaa-bbbbccccdddd', 'aaaabbbb-cccc-1111-2222-333333333333'],
+        snapshots: [
+          {
+            id: '00001111-2222-3333-aaaa-bbbbccccdddd',
+            title: 'test-snapshot-1',
+            description: 'A test snapshot',
+          },
+          {
+            id: 'aaaabbbb-cccc-1111-2222-333333333333',
+            title: 'test-snapshot-2',
+            description: 'Another test snapshot',
+          },
+        ],
       } satisfies CatalogSnapshotsImportRequest,
     },
   ];
+
+  beforeAll(() => {
+    asMockedFn(fetchDataCatalog).mockResolvedValue([
+      {
+        id: 'aaaabbbb-cccc-dddd-eeee-ffffgggghhhh',
+        'dct:creator': 'testowner',
+        'dct:description': 'A test snapshot',
+        'dct:identifier': '00001111-2222-3333-aaaa-bbbbccccdddd',
+        'dct:issued': '2023-10-02T11:30:00.000000Z',
+        'dct:title': 'test-snapshot-1',
+        'dcat:accessURL':
+          'https://jade.datarepo-dev.broadinstitute.org/snapshots/details/00001111-2222-3333-aaaa-bbbbccccdddd',
+        'TerraDCAT_ap:hasDataCollection': [],
+        accessLevel: 'reader',
+        storage: [],
+        counts: {},
+        samples: {},
+        contributors: [],
+      },
+      {
+        id: '11112222-3333-4444-5555-666677778888',
+        'dct:creator': 'testowner',
+        'dct:description': 'Another test snapshot',
+        'dct:identifier': 'aaaabbbb-cccc-1111-2222-333333333333',
+        'dct:issued': '2023-10-02T11:30:00.000000Z',
+        'dct:title': 'test-snapshot-2',
+        'dcat:accessURL':
+          'https://jade.datarepo-dev.broadinstitute.org/snapshots/details/aaaabbbb-cccc-1111-2222-333333333333',
+        'TerraDCAT_ap:hasDataCollection': [],
+        accessLevel: 'reader',
+        storage: [],
+        counts: {},
+        samples: {},
+        contributors: [],
+      },
+      {
+        id: 'zzzzyyyy-xxxx-1111-2222-333333333333',
+        'dct:creator': 'testowner',
+        'dct:description': 'Yet another test snapshot',
+        'dct:identifier': '99998888-7777-xxxx-yyyy-zzzzzzzzzzzz',
+        'dct:issued': '2023-10-02T11:30:00.000000Z',
+        'dct:title': 'test-snapshot-3',
+        'dcat:accessURL':
+          'https://jade.datarepo-dev.broadinstitute.org/snapshots/details/99998888-7777-xxxx-yyyy-zzzzzzzzzzzz',
+        'TerraDCAT_ap:hasDataCollection': [],
+        accessLevel: 'reader',
+        storage: [],
+        counts: {},
+        samples: {},
+        contributors: [],
+      },
+    ]);
+  });
 
   it.each(testCases)(
     'parses $expectedResult.type import request from query parameters',

--- a/src/import-data/useImportRequest.test.ts
+++ b/src/import-data/useImportRequest.test.ts
@@ -189,4 +189,55 @@ describe('getImportRequest', () => {
       expect(importRequest).toEqual(expectedResult);
     }
   );
+
+  describe('catalog snapshot imports', () => {
+    it('throws an error if unable to load the catalog', async () => {
+      // Arrange
+      asMockedFn(fetchDataCatalog).mockRejectedValue(new Response('Something went wrong', { status: 500 }));
+
+      // Act
+      const queryParams = {
+        format: 'snapshot',
+        snapshotIds: ['aaaabbbb-cccc-1111-2222-333333333333', '00001111-2222-3333-aaaa-bbbbccccdddd'],
+      };
+      const importRequestPromise = getImportRequest(queryParams);
+
+      // Assert
+      await expect(importRequestPromise).rejects.toEqual(new Error('Failed to load data catalog.'));
+    });
+
+    it('throws an error if any requested snapshots are not found in catalog', async () => {
+      // Arrange
+      asMockedFn(fetchDataCatalog).mockResolvedValue([
+        {
+          id: 'aaaabbbb-cccc-dddd-eeee-ffffgggghhhh',
+          'dct:creator': 'testowner',
+          'dct:description': 'A test snapshot',
+          'dct:identifier': '00001111-2222-3333-aaaa-bbbbccccdddd',
+          'dct:issued': '2023-10-02T11:30:00.000000Z',
+          'dct:title': 'test-snapshot-1',
+          'dcat:accessURL':
+            'https://jade.datarepo-dev.broadinstitute.org/snapshots/details/00001111-2222-3333-aaaa-bbbbccccdddd',
+          'TerraDCAT_ap:hasDataCollection': [],
+          accessLevel: 'reader',
+          storage: [],
+          counts: {},
+          samples: {},
+          contributors: [],
+        },
+      ]);
+
+      // Act
+      const queryParams = {
+        format: 'snapshot',
+        snapshotIds: ['00001111-2222-3333-aaaa-bbbbccccdddd', 'ddddeeee-ffff-4444-5555-666666666666'],
+      };
+      const importRequestPromise = getImportRequest(queryParams);
+
+      // Assert
+      await expect(importRequestPromise).rejects.toEqual(
+        new Error('Unable to find snapshot ddddeeee-ffff-4444-5555-666666666666 in catalog.')
+      );
+    });
+  });
 });

--- a/src/import-data/useImportRequest.test.ts
+++ b/src/import-data/useImportRequest.test.ts
@@ -106,9 +106,9 @@ describe('getImportRequest', () => {
 
   it.each(testCases)(
     'parses $expectedResult.type import request from query parameters',
-    ({ queryParams, expectedResult }) => {
+    async ({ queryParams, expectedResult }) => {
       // Act
-      const importRequest = getImportRequest(queryParams);
+      const importRequest = await getImportRequest(queryParams);
 
       // Assert
       expect(importRequest).toEqual(expectedResult);

--- a/src/import-data/useImportRequest.ts
+++ b/src/import-data/useImportRequest.ts
@@ -101,15 +101,22 @@ const getCatalogDatasetImportRequest = (queryParams: QueryParams): CatalogDatase
   };
 };
 
+/**
+ * Validate that an unknown value is an array of strings.
+ */
+const isStringArray = (value: unknown): value is string[] => {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string');
+};
+
 const getCatalogSnapshotsImportRequest = async (queryParams: QueryParams): Promise<CatalogSnapshotsImportRequest> => {
   const { snapshotIds } = queryParams;
-  if (!(Array.isArray(snapshotIds) && snapshotIds.every((snapshotId) => typeof snapshotId === 'string'))) {
+  if (!isStringArray(snapshotIds)) {
     throw new Error(`Invalid snapshot IDs: ${snapshotIds}`);
   }
 
   const catalogDatasets = await fetchDataCatalog();
   const snapshots = catalogDatasets
-    .filter((dataset) => snapshotIds.includes(dataset['dct:identifier']))
+    .filter((dataset) => dataset['dct:identifier'] && snapshotIds.includes(dataset['dct:identifier']))
     .map((dataset) => {
       return {
         // The previous step filters the list to only datasets with 'dct:identifier' defined

--- a/src/libs/state.ts
+++ b/src/libs/state.ts
@@ -1,6 +1,7 @@
 import { AnyPromiseFn, Atom, atom } from '@terra-ui-packages/core-utils';
 import { UserManager } from 'oidc-client-ts';
 import { AuthContextProps } from 'react-oidc-context';
+import { Dataset } from 'src/libs/ajax/Catalog';
 import { NihDatasetPermission } from 'src/libs/ajax/User';
 import { OidcUser } from 'src/libs/auth';
 import { getLocalStorage, getSessionStorage, staticStorageSlot } from 'src/libs/browser-storage';
@@ -225,7 +226,7 @@ export const snapshotsListStore = atom<unknown>(undefined);
 
 export const snapshotStore = atom<unknown>(undefined);
 
-export const dataCatalogStore = atom<any[]>([]);
+export const dataCatalogStore = atom<Dataset[]>([]);
 
 type AjaxOverride = {
   fn: (fetch: AnyPromiseFn) => AnyPromiseFn;


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1310

For TDR snapshot imports, I want to fetch the snapshot information from TDR and add it to the `ImportRequest` object. This will allow us to determine whether or not the snapshot is protected and needs to be imported into a protected workspace. The first commit in this PR (https://github.com/DataBiosphere/terra-ui/commit/07e0e4701bcd09dc7b62923327768997e91eff9c) prepares for that by making the `getImportRequest` function async.

That also allows a little more efficiency in the Import Data page's requests. Currently, it always loads the data catalog. But the catalog information is only used in the relatively rare case of importing multiple snapshot-based catalog datasets. https://github.com/DataBiosphere/terra-ui/commit/f148db98157a7c3615c4b9dd4f760ea32b0d3103 moves loading the catalog into `getImportRequest`, so that's it's only loaded when it's actually needed.