### PR TITLE
[UIE-137] Add type for MixPanel event names

### DIFF
--- a/src/libs/ajax/Metrics.ts
+++ b/src/libs/ajax/Metrics.ts
@@ -4,13 +4,13 @@ import { authOpts, fetchBard, jsonBody } from 'src/libs/ajax/ajax-common';
 import { ensureAuthSettled } from 'src/libs/auth';
 import { getConfig } from 'src/libs/config';
 import { withErrorIgnoring } from 'src/libs/error';
-import { MetricsEvent } from 'src/libs/events';
+import { MetricsEventName } from 'src/libs/events';
 import * as Nav from 'src/libs/nav';
 import { authStore, getSessionId } from 'src/libs/state';
 import { v4 as uuid } from 'uuid';
 
 export const Metrics = (signal?: AbortSignal) => {
-  const captureEventFn = async (event: MetricsEvent, details: Record<string, any> = {}): Promise<void> => {
+  const captureEventFn = async (event: MetricsEventName, details: Record<string, any> = {}): Promise<void> => {
     await ensureAuthSettled();
     const { signInStatus, registrationStatus } = authStore.get(); // NOTE: This is intentionally read after ensureAuthSettled
     const isRegistered = signInStatus === 'signedIn' && registrationStatus === 'registered';

--- a/src/libs/ajax/Metrics.ts
+++ b/src/libs/ajax/Metrics.ts
@@ -4,12 +4,13 @@ import { authOpts, fetchBard, jsonBody } from 'src/libs/ajax/ajax-common';
 import { ensureAuthSettled } from 'src/libs/auth';
 import { getConfig } from 'src/libs/config';
 import { withErrorIgnoring } from 'src/libs/error';
+import { MetricsEvent } from 'src/libs/events';
 import * as Nav from 'src/libs/nav';
 import { authStore, getSessionId } from 'src/libs/state';
 import { v4 as uuid } from 'uuid';
 
 export const Metrics = (signal?: AbortSignal) => {
-  const captureEventFn = async (event, details = {}) => {
+  const captureEventFn = async (event: MetricsEvent, details: Record<string, any> = {}): Promise<void> => {
     await ensureAuthSettled();
     const { signInStatus, registrationStatus } = authStore.get(); // NOTE: This is intentionally read after ensureAuthSettled
     const isRegistered = signInStatus === 'signedIn' && registrationStatus === 'registered';
@@ -55,11 +56,11 @@ export const Metrics = (signal?: AbortSignal) => {
 
     syncProfile: withErrorIgnoring(() => {
       return fetchBard('api/syncProfile', _.merge(authOpts(), { signal, method: 'POST' }));
-    }),
+    }) as () => Promise<void>,
 
-    identify: withErrorIgnoring((anonId) => {
+    identify: withErrorIgnoring((anonId: string) => {
       const body = { anonId };
       return fetchBard('api/identify', _.mergeAll([authOpts(), jsonBody(body), { signal, method: 'POST' }]));
-    }),
+    }) as (anonId: string) => Promise<void>,
   };
 };

--- a/src/libs/ajax/metrics/useMetrics.test.ts
+++ b/src/libs/ajax/metrics/useMetrics.test.ts
@@ -1,5 +1,6 @@
 import { renderHook } from '@testing-library/react';
 import { Ajax } from 'src/libs/ajax';
+import Events from 'src/libs/events';
 import { asMockedFn } from 'src/testing/test-utils';
 
 import { useMetricsEvent } from './useMetrics';
@@ -30,10 +31,10 @@ describe('useMetricsEvent', () => {
     // Act
     const renderedHook = renderHook(() => useMetricsEvent());
     const { captureEvent } = renderedHook.result.current;
-    captureEvent('hi there', { something: 'interesting' });
+    captureEvent(Events.workspaceCreate, { something: 'interesting' });
 
     // Assert
     expect(watchCaptureEvent).toBeCalledTimes(1);
-    expect(watchCaptureEvent).toBeCalledWith('hi there', { something: 'interesting' });
+    expect(watchCaptureEvent).toBeCalledWith(Events.workspaceCreate, { something: 'interesting' });
   });
 });

--- a/src/libs/ajax/metrics/useMetrics.ts
+++ b/src/libs/ajax/metrics/useMetrics.ts
@@ -1,8 +1,8 @@
 import { useMemo } from 'react';
 import { Ajax } from 'src/libs/ajax';
-import { MetricsEvent } from 'src/libs/events';
+import { MetricsEventName } from 'src/libs/events';
 
-export type CaptureEventFn = (event: MetricsEvent, details?: Record<string, any>) => void;
+export type CaptureEventFn = (event: MetricsEventName, details?: Record<string, any>) => void;
 
 export interface MetricsProvider {
   captureEvent: CaptureEventFn;

--- a/src/libs/ajax/metrics/useMetrics.ts
+++ b/src/libs/ajax/metrics/useMetrics.ts
@@ -1,7 +1,8 @@
 import { useMemo } from 'react';
 import { Ajax } from 'src/libs/ajax';
+import { MetricsEvent } from 'src/libs/events';
 
-export type CaptureEventFn = (event: string, details?: {}) => void;
+export type CaptureEventFn = (event: MetricsEvent, details?: Record<string, any>) => void;
 
 export interface MetricsProvider {
   captureEvent: CaptureEventFn;
@@ -12,7 +13,7 @@ export const useMetricsEvent = (): MetricsProvider => {
   // By returning a wrapper function, we can handle the fire-and-forget promise mechanics properly here
   // instead of burdening the consumer side with silencing the Typescript/lint complaints, which can be
   // quite awkward in some nested functional uses.
-  const captureEvent: CaptureEventFn = (event: string, details?: {}): void => {
+  const captureEvent: CaptureEventFn = (event, details): void => {
     // fire and forget
     void sendEvent(event, details);
   };

--- a/src/libs/auth.ts
+++ b/src/libs/auth.ts
@@ -11,7 +11,7 @@ import { fetchOk } from 'src/libs/ajax/ajax-common';
 import { getLocalStorage, getSessionStorage } from 'src/libs/browser-storage';
 import { getConfig } from 'src/libs/config';
 import { withErrorIgnoring, withErrorReporting } from 'src/libs/error';
-import Events, { captureAppcuesEvent } from 'src/libs/events';
+import Events, { captureAppcuesEvent, MetricsEvent } from 'src/libs/events';
 import { clearNotification, notify, sessionTimeoutProps } from 'src/libs/notifications';
 import { getLocalPref, getLocalPrefForUserId, setLocalPref } from 'src/libs/prefs';
 import allProviders from 'src/libs/providers';
@@ -92,7 +92,7 @@ export type SignOutCause =
   | 'unspecified';
 
 const sendSignOutMetrics = async (cause: SignOutCause): Promise<void> => {
-  const eventToFire: string = switchCase<SignOutCause, string>(
+  const eventToFire: MetricsEvent = switchCase<SignOutCause, MetricsEvent>(
     cause,
     ['requested', () => Events.user.signOut.requested],
     ['disabled', () => Events.user.signOut.disabled],

--- a/src/libs/auth.ts
+++ b/src/libs/auth.ts
@@ -11,7 +11,7 @@ import { fetchOk } from 'src/libs/ajax/ajax-common';
 import { getLocalStorage, getSessionStorage } from 'src/libs/browser-storage';
 import { getConfig } from 'src/libs/config';
 import { withErrorIgnoring, withErrorReporting } from 'src/libs/error';
-import Events, { captureAppcuesEvent, MetricsEvent } from 'src/libs/events';
+import Events, { captureAppcuesEvent, MetricsEventName } from 'src/libs/events';
 import { clearNotification, notify, sessionTimeoutProps } from 'src/libs/notifications';
 import { getLocalPref, getLocalPrefForUserId, setLocalPref } from 'src/libs/prefs';
 import allProviders from 'src/libs/providers';
@@ -92,7 +92,7 @@ export type SignOutCause =
   | 'unspecified';
 
 const sendSignOutMetrics = async (cause: SignOutCause): Promise<void> => {
-  const eventToFire: MetricsEvent = switchCase<SignOutCause, MetricsEvent>(
+  const eventToFire: MetricsEventName = switchCase<SignOutCause, MetricsEventName>(
     cause,
     ['requested', () => Events.user.signOut.requested],
     ['disabled', () => Events.user.signOut.disabled],

--- a/src/libs/events.ts
+++ b/src/libs/events.ts
@@ -4,6 +4,8 @@ import { Ajax } from 'src/libs/ajax';
 import { useRoute } from 'src/libs/nav';
 import { containsProtectedDataPolicy, WorkspaceInfo, WorkspaceWrapper } from 'src/libs/workspace-utils';
 
+type NestedEnum<T> = { [key: string]: T | NestedEnum<T> };
+
 /*
  * NOTE: In order to show up in reports, new events MUST be marked as expected in the Mixpanel
  * lexicon. See the Mixpanel guide in the terra-ui GitHub Wiki for more details:
@@ -53,11 +55,13 @@ const eventsList = {
   cloudEnvironmentDelete: 'cloudEnvironment:delete',
   cloudEnvironmentUpdate: 'cloudEnvironment:update',
   cloudEnvironmentDetailsLoad: 'analysis:details:load',
-  catalogFilter: 'catalog:filter',
+  catalogFilterSearch: 'catalog:filter:search',
+  catalogFilterSidebar: 'catalog:filter:sidebar',
   catalogRequestAccess: 'catalog:requestAccess',
   catalogToggle: 'catalog:toggle',
   catalogLandingPageBanner: 'catalog:landingPageBanner',
-  catalogView: 'catalog:view',
+  catalogViewDetails: 'catalog:view:details',
+  catalogViewPreviewData: 'catalog:view:previewData',
   catalogWorkspaceLink: 'catalog:workspaceLink',
   catalogWorkspaceLinkExportFinished: 'catalog:workspaceLink:completed',
   datasetLibraryBrowseData: 'library:browseData',
@@ -138,7 +142,20 @@ const eventsList = {
   workspaceSnapshotDelete: 'workspace:snapshot:delete',
   workspaceSnapshotContentsView: 'workspace:snapshot:contents:view',
   workspaceStar: 'workspace:star',
-};
+} as const satisfies NestedEnum<string>;
+
+/**
+ * Extract the type of leaf nodes in a NestedEnum.
+ */
+type NestedEnumValue<T> = T extends NestedEnum<infer U> ? U : never;
+
+/**
+ * Union type of all metrics event names.
+ */
+export type MetricsEvent =
+  | NestedEnumValue<typeof eventsList>
+  // Each route has its own page view event, where the event name includes the name of the route.
+  | `${typeof eventsList.pageView}:${string}`;
 
 // extractWorkspaceDetails accepts multiple types of input...
 export type EventWorkspaceAttributes =

--- a/src/libs/events.ts
+++ b/src/libs/events.ts
@@ -4,8 +4,6 @@ import { Ajax } from 'src/libs/ajax';
 import { useRoute } from 'src/libs/nav';
 import { containsProtectedDataPolicy, WorkspaceInfo, WorkspaceWrapper } from 'src/libs/workspace-utils';
 
-type NestedEnum<T> = { [key: string]: T | NestedEnum<T> };
-
 /*
  * NOTE: In order to show up in reports, new events MUST be marked as expected in the Mixpanel
  * lexicon. See the Mixpanel guide in the terra-ui GitHub Wiki for more details:
@@ -142,20 +140,17 @@ const eventsList = {
   workspaceSnapshotDelete: 'workspace:snapshot:delete',
   workspaceSnapshotContentsView: 'workspace:snapshot:contents:view',
   workspaceStar: 'workspace:star',
-} as const satisfies NestedEnum<string>;
+} as const;
 
-/**
- * Extract the type of leaf nodes in a NestedEnum.
- */
-type NestedEnumValue<T> = T extends NestedEnum<infer U> ? U : never;
+type MetricsEventsMap<EventName> = { [key: string]: EventName | MetricsEventsMap<EventName> };
+type BaseMetricsEvent = typeof eventsList extends MetricsEventsMap<infer EventName> ? EventName : never;
+// Each route has its own page view event, where the event name includes the name of the route.
+type PageViewMetricsEvent = `${typeof eventsList.pageView}:${string}`;
 
 /**
  * Union type of all metrics event names.
  */
-export type MetricsEvent =
-  | NestedEnumValue<typeof eventsList>
-  // Each route has its own page view event, where the event name includes the name of the route.
-  | `${typeof eventsList.pageView}:${string}`;
+export type MetricsEvent = BaseMetricsEvent | PageViewMetricsEvent;
 
 // extractWorkspaceDetails accepts multiple types of input...
 export type EventWorkspaceAttributes =

--- a/src/libs/events.ts
+++ b/src/libs/events.ts
@@ -142,7 +142,9 @@ const eventsList = {
   workspaceStar: 'workspace:star',
 } as const;
 
+// Helper type to create BaseMetricsEvent.
 type MetricsEventsMap<EventName> = { [key: string]: EventName | MetricsEventsMap<EventName> };
+// Union type of all event names configured in eventsList.
 type BaseMetricsEvent = typeof eventsList extends MetricsEventsMap<infer EventName> ? EventName : never;
 // Each route has its own page view event, where the event name includes the name of the route.
 type PageViewMetricsEvent = `${typeof eventsList.pageView}:${string}`;

--- a/src/libs/events.ts
+++ b/src/libs/events.ts
@@ -142,17 +142,17 @@ const eventsList = {
   workspaceStar: 'workspace:star',
 } as const;
 
-// Helper type to create BaseMetricsEvent.
+// Helper type to create BaseMetricsEventName.
 type MetricsEventsMap<EventName> = { [key: string]: EventName | MetricsEventsMap<EventName> };
 // Union type of all event names configured in eventsList.
-type BaseMetricsEvent = typeof eventsList extends MetricsEventsMap<infer EventName> ? EventName : never;
+type BaseMetricsEventName = typeof eventsList extends MetricsEventsMap<infer EventName> ? EventName : never;
 // Each route has its own page view event, where the event name includes the name of the route.
-type PageViewMetricsEvent = `${typeof eventsList.pageView}:${string}`;
+type PageViewMetricsEventName = `${typeof eventsList.pageView}:${string}`;
 
 /**
  * Union type of all metrics event names.
  */
-export type MetricsEvent = BaseMetricsEvent | PageViewMetricsEvent;
+export type MetricsEventName = BaseMetricsEventName | PageViewMetricsEventName;
 
 // extractWorkspaceDetails accepts multiple types of input...
 export type EventWorkspaceAttributes =

--- a/src/pages/library/DataBrowser.ts
+++ b/src/pages/library/DataBrowser.ts
@@ -209,7 +209,7 @@ const DataBrowserTableComponent = ({ sort, setSort, cols, setCols, filteredList 
             Link,
             {
               onClick: () => {
-                Ajax().Metrics.captureEvent(`${Events.catalogView}:details`, {
+                Ajax().Metrics.captureEvent(Events.catalogViewDetails, {
                   id: datum.id,
                   title: datum['dct:title'],
                 });

--- a/src/pages/library/DataBrowserDetails.js
+++ b/src/pages/library/DataBrowserDetails.js
@@ -206,7 +206,7 @@ export const SidebarComponent = ({ dataObj, id }) => {
                 tooltip: actionTooltip,
                 style: { fontSize: 16, textTransform: 'none', height: 'unset', width: sidebarButtonWidth, marginTop: 20 },
                 onClick: () => {
-                  Ajax().Metrics.captureEvent(`${Events.catalogView}:previewData`, {
+                  Ajax().Metrics.captureEvent(Events.catalogViewPreviewData, {
                     id: dataObj.id,
                     title: dataObj['dct:title'],
                   });

--- a/src/pages/library/SearchAndFilterComponent.ts
+++ b/src/pages/library/SearchAndFilterComponent.ts
@@ -379,7 +379,7 @@ const getContextualSuggestion = ([leftContext, match, rightContext]) => {
   ];
 };
 
-const sendSearchEvent = (term) => Ajax().Metrics.captureEvent(`${Events.catalogFilter}:search`, { term });
+const sendSearchEvent = (term) => Ajax().Metrics.captureEvent(Events.catalogFilterSearch, { term });
 const debounceSearchEvent = _.debounce(5000, sendSearchEvent);
 
 /**
@@ -760,7 +760,7 @@ export const SearchAndFilterComponent = <ListItem>({
               const sectionToAlter = selectedSections[sectionSelected];
               const valuesSelected = _.xor(sectionEntries, sectionToAlter.values);
               _.forEach(
-                (sectionEntry) => Ajax().Metrics.captureEvent(`${Events.catalogFilter}:sidebar`, { tag: sectionEntry }),
+                (sectionEntry) => Ajax().Metrics.captureEvent(Events.catalogFilterSidebar, { tag: sectionEntry }),
                 sectionEntries
               );
               valuesSelected.length > 0


### PR DESCRIPTION
Follow up to #4276.

This adds a `MetricEvent` type that includes all event names listed in libs/events.ts. By typing  `captureEvent` to accept a `MetricsEvent` parameter, we can require that all MixPanel events are listed in libs/events. This gives us a central place to see what events we're capturing, which is useful when Product asks if we have metrics for something.

Most metrics reporting already follows this pattern, but there were a few events created inline in Catalog components.