### PR TITLE
[WM-2263] Update workflow output autofill behavior

### DIFF
--- a/src/workflows-app/SubmissionConfig.test.js
+++ b/src/workflows-app/SubmissionConfig.test.js
@@ -16,9 +16,9 @@ import {
   myStructInput,
   runSetInputDef,
   runSetOutputDef,
-  runSetOutputDefFilled,
   runSetOutputDefWithDefaults,
   runSetResponse,
+  runSetResponseForNewMethod,
   runSetResponseWithStruct,
   searchResponses,
   typesResponse,
@@ -767,14 +767,93 @@ describe('Initial state', () => {
     expect(row1cells[0].textContent).toBe('target_workflow_1');
     within(row1cells[1]).getByText('file_output');
     within(row1cells[2]).getByText('File');
-    within(row1cells[3]).getByDisplayValue('target_workflow_1_file_output'); // autofill from previous run
+    within(row1cells[3]).getByDisplayValue('target_workflow_1_file_output'); // from previous run/template
 
     const row2cells = within(rows[2]).getAllByRole('cell');
     expect(row2cells.length).toBe(4);
     expect(row2cells[0].textContent).toBe('target_workflow_1');
     within(row2cells[1]).getByText('unused_output');
     within(row2cells[2]).getByText('String');
-    within(row2cells[3]).getByDisplayValue('unused_output'); // autofill empty by name
+    within(row2cells[3]).getByDisplayValue(''); // empty from previous run/template
+    within(row2cells[3]).getByPlaceholderText(/enter an attribute/i);
+  });
+
+  it('should initially populate the outputs definition table with autofilled attributes if no template or previously executed run set', async () => {
+    // ** ARRANGE **
+    const user = userEvent.setup();
+    const mockRunSetResponse = jest.fn(() => Promise.resolve(runSetResponseForNewMethod));
+    const mockMethodsResponse = jest.fn(() => Promise.resolve(methodsResponse));
+    const mockSearchResponse = jest.fn((_root, _instanceId, recordType) => Promise.resolve(searchResponses[recordType]));
+    const mockTypesResponse = jest.fn(() => Promise.resolve(typesResponse));
+    const mockWdlResponse = jest.fn(() => Promise.resolve('mock wdl response'));
+
+    Ajax.mockImplementation(() => {
+      return {
+        Cbas: {
+          runSets: {
+            getForMethod: mockRunSetResponse,
+          },
+          methods: {
+            getById: mockMethodsResponse,
+          },
+        },
+        WorkspaceData: {
+          queryRecords: mockSearchResponse,
+          describeAllRecordTypes: mockTypesResponse,
+        },
+        WorkflowScript: {
+          get: mockWdlResponse,
+        },
+      };
+    });
+
+    // ** ACT **
+    await act(async () =>
+      render(
+        h(BaseSubmissionConfig, {
+          methodId: '123',
+          name: 'test-azure-ws-name',
+          namespace: 'test-azure-ws-namespace',
+          workspace: mockAzureWorkspace,
+        })
+      )
+    );
+
+    // ** ASSERT **
+    expect(mockRunSetResponse).toHaveBeenCalledTimes(1);
+    expect(mockTypesResponse).toHaveBeenCalledTimes(1);
+    expect(mockMethodsResponse).toHaveBeenCalledTimes(1);
+    expect(mockSearchResponse).toHaveBeenCalledTimes(1);
+    expect(mockWdlResponse).toHaveBeenCalledTimes(1);
+
+    const button = screen.getByRole('button', { name: 'Outputs' });
+
+    // ** ACT **
+    await user.click(button);
+
+    // ** ASSERT **
+    const table = screen.getByRole('table');
+    const rows = within(table).getAllByRole('row');
+
+    expect(runSetOutputDef.length).toBe(2);
+    expect(rows.length).toBe(runSetOutputDef.length + 1); // one row for each output definition variable, plus headers
+
+    const headers = within(rows[0]).getAllByRole('columnheader');
+    expect(headers.length).toBe(4);
+
+    const row1cells = within(rows[1]).getAllByRole('cell');
+    expect(row1cells.length).toBe(4);
+    expect(row1cells[0].textContent).toBe('target_workflow_1');
+    within(row1cells[1]).getByText('file_output');
+    within(row1cells[2]).getByText('File');
+    within(row1cells[3]).getByDisplayValue('file_output'); // autofill by name, no previous run
+
+    const row2cells = within(rows[2]).getAllByRole('cell');
+    expect(row2cells.length).toBe(4);
+    expect(row2cells[0].textContent).toBe('target_workflow_1');
+    within(row2cells[1]).getByText('unused_output');
+    within(row2cells[2]).getByText('String');
+    within(row2cells[3]).getByDisplayValue('unused_output'); // autofill by name, no previous run
   });
 });
 
@@ -1367,7 +1446,7 @@ describe('Submitting a run set', () => {
       expect.objectContaining({
         method_version_id: runSetResponse.run_sets[0].method_version_id,
         workflow_input_definitions: runSetInputDef,
-        workflow_output_definitions: runSetOutputDefFilled,
+        workflow_output_definitions: runSetOutputDef,
         wds_records: {
           record_type: 'FOO',
           record_ids: ['FOO1'],
@@ -1594,7 +1673,7 @@ describe('Submitting a run set', () => {
             },
           },
         ],
-        workflow_output_definitions: runSetOutputDefFilled,
+        workflow_output_definitions: runSetOutputDef,
         wds_records: {
           record_type: 'FOO',
           record_ids: ['FOO1'],
@@ -1801,7 +1880,7 @@ describe('Submitting a run set', () => {
             },
           },
         ],
-        workflow_output_definitions: runSetOutputDefFilled,
+        workflow_output_definitions: runSetOutputDef,
         wds_records: {
           record_type: 'FOO',
           record_ids: ['FOO1'],

--- a/src/workflows-app/utils/mock-responses.js
+++ b/src/workflows-app/utils/mock-responses.js
@@ -459,10 +459,10 @@ export const runSetResponseForNewMethod = {
       call_caching_enabled: true,
       submission_timestamp: '2022-12-07T17:26:53.153+00:00',
       last_modified_timestamp: '2022-12-07T17:26:53.153+00:00',
-      run_count: 1,
+      run_count: 0,
       error_count: 0,
       input_definition: JSON.stringify(runSetInputDefWithSourceNone),
-      output_definition: JSON.stringify(runSetOutputDef),
+      output_definition: JSON.stringify(runSetOutputDefEmpty),
     },
   ],
 };

--- a/src/workflows-app/utils/submission-utils.js
+++ b/src/workflows-app/utils/submission-utils.js
@@ -3,7 +3,7 @@ import { div } from 'react-hyperscript-helpers';
 import { icon } from 'src/components/icons';
 import { statusType as jobStatusType } from 'src/components/job-common';
 import colors from 'src/libs/colors';
-import { differenceFromDatesInSeconds, differenceFromNowInSeconds } from 'src/libs/utils';
+import { differenceFromDatesInSeconds, differenceFromNowInSeconds, maybeParseJSON } from 'src/libs/utils';
 import * as Utils from 'src/libs/utils';
 
 export const AutoRefreshInterval = 1000 * 60; // 1 minute
@@ -59,6 +59,19 @@ export const parseAttributeName = (attributeName) => {
   const columnName = attributeName.slice(namespaceDelimiterIndex + 1);
   const columnNamespace = attributeName.slice(0, namespaceDelimiterIndex + 1);
   return { columnNamespace, columnName };
+};
+
+// Use output definition if it has been run before or if the template contains non-none destinations
+// Otherwise we will autofill all outputs to default.
+export const autofillOutputDef = (outputDef, runCount) => {
+  const jsonParsedOutput = maybeParseJSON(outputDef);
+  const shouldUseOutputs = runCount > 0 || jsonParsedOutput.some((outputDef) => outputDef.destination.type !== 'none');
+  return shouldUseOutputs
+    ? jsonParsedOutput
+    : jsonParsedOutput.map((outputDef) => ({
+        ...outputDef,
+        destination: { type: 'record_update', record_attribute: parseMethodString(outputDef.output_name).variable || '' },
+      }));
 };
 
 export const inputSourceLabels = {

--- a/src/workflows-app/utils/submission-utils.test.js
+++ b/src/workflows-app/utils/submission-utils.test.js
@@ -1,7 +1,9 @@
 import _ from 'lodash/fp';
 import { resolveWdsUrl } from 'src/libs/ajax/data-table-providers/WdsDataTableProvider';
 import { getConfig } from 'src/libs/config';
+import { runSetOutputDef, runSetOutputDefEmpty, runSetOutputDefFilled, runSetOutputDefWithDefaults } from 'src/workflows-app/utils/mock-responses';
 import {
+  autofillOutputDef,
   convertToPrimitiveType,
   getDuration,
   inputTypeStyle,
@@ -120,6 +122,29 @@ describe('resolveWdsUrl', () => {
     ];
     expect(resolveWdsUrl(testHealthyAppProxyUrlResponse)).toBe(expectedUrl);
   });
+});
+
+describe('autofillOutputDef', () => {
+  it('should use defaults if never run before and empty template', () => {
+    const res = autofillOutputDef(JSON.stringify(runSetOutputDefEmpty), 0);
+    expect(res).toStrictEqual(runSetOutputDefWithDefaults);
+  });
+
+  it.each([[runSetOutputDef], [runSetOutputDefEmpty], [runSetOutputDefWithDefaults], [runSetOutputDefFilled]])(
+    'should use previous run data if run before',
+    (outputDef) => {
+      const res = autofillOutputDef(JSON.stringify(outputDef), 1);
+      expect(res).toStrictEqual(outputDef);
+    }
+  );
+
+  it.each([[runSetOutputDef], [runSetOutputDefWithDefaults], [runSetOutputDefFilled]])(
+    'should use provided output def if non-empty outputs',
+    (outputDef) => {
+      const res = autofillOutputDef(JSON.stringify(outputDef), 0);
+      expect(res).toStrictEqual(outputDef);
+    }
+  );
 });
 
 describe('convertToPrimitiveType', () => {


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WM-2263

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Updates to the output autofill behavior in Azure workflows to not autofill every empty output by default

### Why
- If a user is configuring a workflow with a template (e.g. from one of our featured COVID-19 workflows) we should not autofill empty outputs, and should only provide the output values from the template
- If a user is configuring a workflow that they have run before we should not autofill empty outputs, and should only provide the output values from the previous run (this would also apply to saved configs in the future)
- If a user is configuring a workflow that has not been run before and does not have a template (e.g. they just imported a new workflow from Github), all outputs should be auto-filled by default

### Testing strategy
- Unit tests<!-- Test case 1 -->
- Tested in UI

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 
