### PR TITLE
[UIE-120] Add number format functions to core-utils

### DIFF
--- a/packages/core-utils/src/format/number-format.test.ts
+++ b/packages/core-utils/src/format/number-format.test.ts
@@ -1,0 +1,57 @@
+import { formatBytes, formatNumber, formatUSD } from './number-format';
+
+describe('formatBytes', () => {
+  const testCases: { value: number; expectedOutput: string }[] = [
+    { value: 40000000000, expectedOutput: '37.3 GiB' },
+    { value: 40000000, expectedOutput: '38.1 MiB' },
+    { value: 40, expectedOutput: '40 B' },
+  ];
+
+  it.each(testCases)('formats $value as $expectedOutput', ({ value, expectedOutput }) => {
+    // Act
+    const result = formatBytes(value);
+
+    // Assert
+    expect(result).toBe(expectedOutput);
+  });
+});
+
+describe('formatNumber', () => {
+  const testCases: { value: number; expectedOutput: string }[] = [
+    { value: 99.99, expectedOutput: '99.99' },
+    { value: 99.999, expectedOutput: '99.999' },
+    { value: 99.9999, expectedOutput: '100' },
+    { value: 10, expectedOutput: '10' },
+    { value: 0.1, expectedOutput: '0.1' },
+    { value: 0.01, expectedOutput: '0.01' },
+    { value: 0, expectedOutput: '0' },
+    { value: 0 / 0, expectedOutput: 'NaN' },
+  ];
+
+  it.each(testCases)('formats $value as $expectedOutput', ({ value, expectedOutput }) => {
+    // Act
+    const result = formatNumber(value);
+
+    // Assert
+    expect(result).toBe(expectedOutput);
+  });
+});
+
+describe('formatUSD', () => {
+  const testCases: { value: number; expectedOutput: string }[] = [
+    { value: 99.99, expectedOutput: '$99.99' },
+    { value: 10, expectedOutput: '$10.00' },
+    { value: 0.1, expectedOutput: '$0.10' },
+    { value: 0.001, expectedOutput: '< $0.01' },
+    { value: 0, expectedOutput: '$0.00' },
+    { value: 0 / 0, expectedOutput: 'unknown' },
+  ];
+
+  it.each(testCases)('formats $value as $expectedOutput', ({ value, expectedOutput }) => {
+    // Act
+    const result = formatUSD(value);
+
+    // Assert
+    expect(result).toBe(expectedOutput);
+  });
+});

--- a/packages/core-utils/src/format/number-format.ts
+++ b/packages/core-utils/src/format/number-format.ts
@@ -1,0 +1,44 @@
+/**
+ * Format a size in bytes for display.
+ *
+ * Formats the size in kibibytes, mebibtyes, gibibytes, etc.
+ */
+export const formatBytes = (bytes: number): string => {
+  const prefixes: [string, number][] = [
+    ['P', 2 ** 50],
+    ['T', 2 ** 40],
+    ['G', 2 ** 30],
+    ['M', 2 ** 20],
+    ['K', 2 ** 10],
+  ];
+  const maybePrefixAndDivisor = prefixes.find(([_prefix, divisor]) => bytes >= divisor);
+  if (maybePrefixAndDivisor) {
+    const [prefix, divisor] = maybePrefixAndDivisor;
+    return `${(bytes / divisor).toPrecision(3)} ${prefix}iB`;
+  }
+  return `${bytes} B`;
+};
+
+const numberFormatter = new Intl.NumberFormat('en-US');
+
+/**
+ * Format a number for display.
+ */
+export const formatNumber = (n: number): string => numberFormatter.format(n);
+
+const usdFormatter = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' });
+
+/**
+ * Format a dollar amount for display.
+ */
+export const formatUSD = (value: number): string => {
+  if (Number.isNaN(value)) {
+    return 'unknown';
+  }
+
+  if (value > 0 && value < 0.01) {
+    return '< $0.01';
+  }
+
+  return usdFormatter.format(value);
+};

--- a/packages/core-utils/src/index.ts
+++ b/packages/core-utils/src/index.ts
@@ -1,3 +1,4 @@
+export * from './format/number-format';
 export * from './io-utils';
 export * from './logic-utils';
 export * from './nav/nav-utils';

--- a/src/libs/utils.test.ts
+++ b/src/libs/utils.test.ts
@@ -1,4 +1,4 @@
-import { differenceFromDatesInSeconds, differenceFromNowInSeconds, formatBytes, textMatch } from 'src/libs/utils';
+import { differenceFromDatesInSeconds, differenceFromNowInSeconds, textMatch } from 'src/libs/utils';
 
 beforeAll(() => {
   jest.useFakeTimers();
@@ -35,30 +35,6 @@ describe('differenceFromDatesInSeconds', () => {
     expect(differenceFromDatesInSeconds(startDate, threeSecondsLater)).toBe(3);
     expect(differenceFromDatesInSeconds(startDate, oneMinuteLater)).toBe(60);
     expect(differenceFromDatesInSeconds(startDate, twoDaysLater)).toBe(172800);
-  });
-});
-
-describe('formatBytes', () => {
-  it('handles GB', () => {
-    // Act
-    const result = formatBytes(40000000000);
-
-    // Assert
-    expect(result).toBe('37.3 GiB');
-  });
-  it('handles MB', () => {
-    // Act
-    const result = formatBytes(40000000);
-
-    // Assert
-    expect(result).toBe('38.1 MiB');
-  });
-  it('handles fallback case', () => {
-    // Act
-    const result = formatBytes(40);
-
-    // Assert
-    expect(result).toBe('40 B');
   });
 });
 

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -5,7 +5,7 @@ import _ from 'lodash/fp';
 import * as qs from 'qs';
 import { div, span } from 'react-hyperscript-helpers';
 
-export { cond, DEFAULT, switchCase } from '@terra-ui-packages/core-utils';
+export { cond, DEFAULT, formatBytes, formatNumber, formatUSD, switchCase } from '@terra-ui-packages/core-utils';
 
 const dateFormat = new Intl.DateTimeFormat('default', { day: 'numeric', month: 'short', year: 'numeric' });
 const monthYearFormat = new Intl.DateTimeFormat('default', { month: 'short', year: 'numeric' });
@@ -54,12 +54,6 @@ export const differenceFromNowInSeconds = (jsonDateString) => {
 export const differenceFromDatesInSeconds = (jsonDateStringStart, jsonDateStringEnd) => {
   return differenceInSeconds(parseJSON(jsonDateStringStart), parseJSON(jsonDateStringEnd));
 };
-
-const usdFormatter = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' });
-export const formatUSD = (v) =>
-  cond([_.isNaN(v), () => 'unknown'], [v > 0 && v < 0.01, () => '< $0.01'], () => usdFormatter.format(v));
-
-export const formatNumber = new Intl.NumberFormat('en-US').format;
 
 export const toIndexPairs = <T>(obj: T[]): [number, T][] =>
   _.flow(
@@ -263,23 +257,6 @@ export const sha256 = async (message) => {
     _.map((v: any) => v.toString(16).padStart(2, '0')),
     _.join('')
   )(new Uint8Array(hashBuffer));
-};
-
-export const formatBytes = (bytes: number): string => {
-  const lookup: [string, number][] = [
-    ['P', 2 ** 50],
-    ['T', 2 ** 40],
-    ['G', 2 ** 30],
-    ['M', 2 ** 20],
-    ['K', 2 ** 10],
-  ];
-  const maybeLookup = lookup.find(([_p, d]: [string, number]) => bytes >= d);
-  if (maybeLookup) {
-    const [prefix, divisor] = maybeLookup;
-    return `${(bytes / divisor).toPrecision(3)} ${prefix}iB`;
-  }
-  // fallback is to return unformatted
-  return `${bytes} B`;
 };
 
 // Truncates an integer to the thousands, i.e. 10363 -> 10k


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/UIE-120

Continuing to move over parts of libs/utils into the core-utils package... This moves over number format utilities. They're re-exported from libs/utils to preserve import paths.