### PR TITLE
[UIE-128] Refactor Utils.computeWorkspaceError

### DIFF
--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -102,14 +102,6 @@ export const snapshotReferenceMissingError = (snapshotReferenceName) => {
   return `The requested snapshot reference '${snapshotReferenceName}' could not be found in this workspace.`;
 };
 
-// Returns a message explaining why the user can't compute in the workspace, or undefined if they can
-export const computeWorkspaceError = ({ canCompute, workspace: { isLocked } }) => {
-  return cond(
-    [!canCompute, () => 'You do not have access to run analyses on this workspace.'],
-    [isLocked, () => 'This workspace is locked.']
-  );
-};
-
 export const textMatch = safeCurry((needle: string, haystack: string): boolean => {
   return haystack.toLowerCase().includes(needle.toLowerCase());
 }) as (needle: string, haystack: string) => boolean;

--- a/src/libs/workspace-utils.test.ts
+++ b/src/libs/workspace-utils.test.ts
@@ -8,7 +8,9 @@ import {
 
 import {
   canEditWorkspace,
+  canRunAnalysisInWorkspace,
   getRegionConstraintLabels,
+  getWorkspaceAnalysisControlProps,
   getWorkspaceEditControlProps,
   hasProtectedData,
   hasRegionConstraint,
@@ -223,5 +225,64 @@ describe('getWorkspaceEditControlProps', () => {
 
     // Assert
     expect(result).toStrictEqual({ disabled: true, tooltip: 'This workspace is locked.' });
+  });
+});
+
+describe('canRunAnalysisInWorkspace', () => {
+  it('returns false if the user cannot compute in the workspace', () => {
+    // Act
+    const result = canRunAnalysisInWorkspace({
+      canCompute: false,
+      workspace: { isLocked: false },
+    });
+
+    // Assert
+    expect(result).toEqual({ value: false, message: 'You do not have access to run analyses on this workspace.' });
+  });
+
+  it('returns false if the workspace is locked', () => {
+    // Act
+    const result = canRunAnalysisInWorkspace({
+      canCompute: true,
+      workspace: { isLocked: true },
+    });
+
+    // Assert
+    expect(result).toEqual({ value: false, message: 'This workspace is locked.' });
+  });
+
+  it('returns true otherwise', () => {
+    // Act
+    const result = canRunAnalysisInWorkspace({
+      canCompute: true,
+      workspace: { isLocked: false },
+    });
+
+    // Assert
+    expect(result).toEqual({ value: true, message: undefined });
+  });
+});
+
+describe('getWorkspaceAnalysisControlProps', () => {
+  it('adds no props when analysis is enabled', () => {
+    // Act
+    const props = {
+      tooltip: 'This is a control',
+      ...getWorkspaceAnalysisControlProps({ canCompute: true, workspace: { isLocked: false } }),
+    };
+
+    // Assert
+    expect(props).toEqual({ tooltip: 'This is a control' });
+  });
+
+  it('disables the control and adds a tooltip when the user cannot run analyses in the workspace', () => {
+    // Act
+    const props = {
+      tooltip: 'This is a control',
+      ...getWorkspaceAnalysisControlProps({ canCompute: false, workspace: { isLocked: false } }),
+    };
+
+    // Assert
+    expect(props).toEqual({ disabled: true, tooltip: 'You do not have access to run analyses on this workspace.' });
   });
 });

--- a/src/libs/workspace-utils.ts
+++ b/src/libs/workspace-utils.ts
@@ -202,3 +202,40 @@ export const getWorkspaceEditControlProps = ({
   const { value, message } = canEditWorkspace({ accessLevel, workspace: { isLocked } });
   return value ? {} : { disabled: true, tooltip: message };
 };
+
+/**
+ * The slice of WorkspaceWrapper necessary to determine if a user can run analyses in a workspace.
+ */
+export interface WorkspaceAnalysisAccessInfo {
+  canCompute: boolean;
+  workspace: { isLocked: boolean };
+}
+
+/**
+ * Returns whether or not a user can run analyses in a workspace and a reason if they can't.
+ * @param workspace The workspace.
+ */
+export const canRunAnalysisInWorkspace = (
+  workspace: WorkspaceAnalysisAccessInfo
+): { value: true; message: undefined } | { value: false; message: string } => {
+  const {
+    canCompute,
+    workspace: { isLocked },
+  } = workspace;
+  return cond<{ value: true; message: undefined } | { value: false; message: string }>(
+    [!canCompute, () => ({ value: false, message: 'You do not have access to run analyses on this workspace.' })],
+    [isLocked, () => ({ value: false, message: 'This workspace is locked.' })],
+    () => ({ value: true, message: undefined })
+  );
+};
+
+/**
+ * Returns props to disable and add a tooltip to a control if the user cannot run analyses in the workspace.
+ * @param workspace - The workspace.
+ */
+export const getWorkspaceAnalysisControlProps = (
+  workspace: WorkspaceAnalysisAccessInfo
+): { disabled: true; tooltip: string } | {} => {
+  const { value, message } = canRunAnalysisInWorkspace(workspace);
+  return value ? {} : { disabled: true, tooltip: message };
+};

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -1001,7 +1001,7 @@ const WorkflowView = _.flow(
                     h(
                       LabeledCheckbox,
                       {
-                        disabled: currentSnapRedacted || !!Utils.computeWorkspaceError(ws),
+                        disabled: currentSnapRedacted || !WorkspaceUtils.canRunAnalysisInWorkspace(ws).value,
                         checked: useCallCache,
                         onChange: (v) => this.setState({ useCallCache: v }),
                       },
@@ -1118,8 +1118,9 @@ const WorkflowView = _.flow(
                   ButtonPrimary,
                   {
                     style: { marginLeft: '1rem' },
-                    disabled: !!Utils.computeWorkspaceError(ws) || !!noLaunchReason || currentSnapRedacted || !!snapshotReferenceError,
-                    tooltip: Utils.computeWorkspaceError(ws) || noLaunchReason || (currentSnapRedacted && 'Workflow version was redacted.'),
+                    disabled: !!noLaunchReason || currentSnapRedacted || !!snapshotReferenceError,
+                    tooltip: noLaunchReason || (currentSnapRedacted && 'Workflow version was redacted.'),
+                    ...WorkspaceUtils.getWorkspaceAnalysisControlProps(ws),
                     onClick: () => this.setState({ launching: true }),
                   },
                   ['Run analysis']


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/UIE-128

Continuing to break up the libs/utils module and move pieces of it to more specific locations.

This replaces `Utils.computeWorkspaceError` with a `canRunAnalysisInWorkspace` function in WorkspaceUtils similar to how `Utils.canEditWorkspace` and `Utils.editWorkspaceError` were refactored in #4268.