### PR TITLE
Workspace migration status view (WOR-1260).

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,6 +19,7 @@
 /src/pages/LandingPage* @DataBiosphere/terra-cobranding
 /src/pages/billing/ @DataBiosphere/broadworkspaces
 /src/pages/workspaces/* @DataBiosphere/broadworkspaces
+/src/pages/workspaces/migration/* @DataBiosphere/broadworkspaces
 /src/pages/workspaces/workspace/*Dashboard* @DataBiosphere/broadworkspaces
 /src/pages/workspaces/workspace/*Workspace* @DataBiosphere/broadworkspaces
 /src/components/*Workspace* @DataBiosphere/broadworkspaces

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -147,6 +147,11 @@ const Workspaces = (signal) => ({
     };
   },
 
+  bucketMigration: async () => {
+    const response = await fetchRawls('workspaces/v2/bucketMigration', _.merge(authOpts(), { signal }));
+    return response.json();
+  },
+
   workspace: (namespace, name) => {
     const root = `workspaces/${namespace}/${name}`;
     const mcPath = `${root}/methodconfigs`;

--- a/src/libs/routes.js
+++ b/src/libs/routes.js
@@ -30,6 +30,7 @@ import * as Upload from 'src/pages/Upload';
 import * as WorkflowsList from 'src/pages/workflows/List';
 import * as WorkflowDetails from 'src/pages/workflows/workflow/WorkflowDetails';
 import * as WorkspaceList from 'src/pages/workspaces/List';
+import * as WorkspaceMigration from 'src/pages/workspaces/migration/WorkspaceMigration';
 import * as Dashboard from 'src/pages/workspaces/workspace/Dashboard';
 import * as WorkspaceFiles from 'src/pages/workspaces/workspace/Files';
 import * as JobHistory from 'src/pages/workspaces/workspace/JobHistory';
@@ -85,6 +86,7 @@ const routes = _.flatten([
   WorkspaceFiles.navPaths,
   AzurePreview.navPaths,
   WorkflowsApp.navPaths,
+  WorkspaceMigration.navPaths,
   NotFound.navPaths, // must be last
 ]);
 

--- a/src/libs/style.ts
+++ b/src/libs/style.ts
@@ -229,7 +229,7 @@ export const dashboard = {
   collapsibleHeader: {
     ...elements.sectionHeader,
     color: colors.accent(),
-    textTransform: 'uppercase' as const,
+    textTransform: 'uppercase',
     padding: '0.5rem 0 0.5rem 0.5rem',
     display: 'flex',
     fontSize: 14,

--- a/src/libs/style.ts
+++ b/src/libs/style.ts
@@ -229,7 +229,7 @@ export const dashboard = {
   collapsibleHeader: {
     ...elements.sectionHeader,
     color: colors.accent(),
-    textTransform: 'uppercase',
+    textTransform: 'uppercase' as const,
     padding: '0.5rem 0 0.5rem 0.5rem',
     display: 'flex',
     fontSize: 14,

--- a/src/pages/workspaces/migration/BillingProjectList.test.ts
+++ b/src/pages/workspaces/migration/BillingProjectList.test.ts
@@ -1,0 +1,83 @@
+import { act, render, screen, within } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { h } from 'react-hyperscript-helpers';
+import { Ajax } from 'src/libs/ajax';
+import { abandonedPromise } from 'src/libs/utils';
+import { BillingProjectList } from 'src/pages/workspaces/migration/BillingProjectList';
+import { mockServerData } from 'src/pages/workspaces/migration/migration-utils.test';
+import { asMockedFn } from 'src/testing/test-utils';
+
+type AjaxContract = ReturnType<typeof Ajax>;
+type AjaxWorkspacesContract = AjaxContract['Workspaces'];
+jest.mock('src/libs/ajax');
+
+describe('BillingProjectList', () => {
+  it('shows a loading indicator', async () => {
+    // Arrange
+    const mockWorkspaces: Partial<AjaxWorkspacesContract> = {
+      bucketMigration: jest.fn().mockReturnValue(abandonedPromise()),
+    };
+    const mockAjax: Partial<AjaxContract> = {
+      Workspaces: mockWorkspaces as AjaxWorkspacesContract,
+    };
+    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+
+    // Act
+    render(h(BillingProjectList, []));
+
+    // Assert
+    await screen.findByText('Fetching billing projects');
+  });
+
+  it('shows a message if there are no workspaces to migrate', async () => {
+    // Arrange
+    const mockWorkspaces: Partial<AjaxWorkspacesContract> = {
+      bucketMigration: jest.fn().mockResolvedValue({}),
+    };
+    const mockAjax: Partial<AjaxContract> = {
+      Workspaces: mockWorkspaces as AjaxWorkspacesContract,
+    };
+    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+
+    // Act
+    render(h(BillingProjectList, []));
+
+    // Assert
+    await screen.findByText('You have no workspaces to migrate');
+    expect(screen.queryByText('Fetching billing projects')).toBeNull();
+  });
+
+  it('shows the list of billing projects with workspaces, and has no accessibility errors', async () => {
+    // Arrange
+    const mockWorkspaces: Partial<AjaxWorkspacesContract> = {
+      bucketMigration: jest.fn().mockResolvedValue(mockServerData),
+    };
+    const mockAjax: Partial<AjaxContract> = {
+      Workspaces: mockWorkspaces as AjaxWorkspacesContract,
+    };
+    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+
+    // Act
+    let renderResult;
+    act(() => {
+      renderResult = render(h(BillingProjectList, []));
+    });
+
+    // Assert
+    const billingProjects = await screen.findAllByRole('listitem');
+    await within(billingProjects[0]).findByText('CARBilling-2');
+    await within(billingProjects[0]).findByText('april29');
+    await within(billingProjects[0]).findByText('notmigrated');
+
+    await within(billingProjects[1]).findByText('CARBillingTest');
+    await within(billingProjects[1]).findByText('testdata');
+
+    await within(billingProjects[2]).findByText('general-dev-billing-account');
+    await within(billingProjects[2]).findByText('Christina test');
+
+    expect(screen.queryByText('Fetching billing projects')).toBeNull();
+    expect(screen.queryByText('You have no workspaces to migrate')).toBeNull();
+
+    expect(await axe(renderResult.container)).toHaveNoViolations();
+  });
+});

--- a/src/pages/workspaces/migration/BillingProjectList.ts
+++ b/src/pages/workspaces/migration/BillingProjectList.ts
@@ -1,0 +1,49 @@
+import _ from 'lodash/fp';
+import { useEffect, useState } from 'react';
+import { div, h, h2, span } from 'react-hyperscript-helpers';
+import { spinner } from 'src/components/icons';
+import { Ajax } from 'src/libs/ajax';
+import colors from 'src/libs/colors';
+import { reportErrorAndRethrow } from 'src/libs/error';
+import { useCancellation } from 'src/libs/react-utils';
+import * as Utils from 'src/libs/utils';
+import { BillingProjectParent } from 'src/pages/workspaces/migration/BillingProjectParent';
+import { BillingProjectMigrationInfo, parseServerResponse } from 'src/pages/workspaces/migration/migration-utils';
+
+export const BillingProjectList = () => {
+  const [loadingMigrationInformation, setLoadingMigrationInformation] = useState(true);
+  const [billingProjectWorkspaces, setBillingProjectWorkspaces] = useState<BillingProjectMigrationInfo[]>([]);
+  const signal = useCancellation();
+  const fontSize = 16;
+
+  useEffect(() => {
+    const loadWorkspaces = _.flow(
+      reportErrorAndRethrow('Error loading workspace migration information'),
+      Utils.withBusyState(setLoadingMigrationInformation)
+    )(async () => {
+      const migrationResponse = (await Ajax(signal).Workspaces.bucketMigration()) as Record<string, any>;
+      setBillingProjectWorkspaces(parseServerResponse(migrationResponse));
+    });
+    loadWorkspaces();
+  }, [setBillingProjectWorkspaces, signal]);
+
+  return div({ style: { padding: '10px', backgroundColor: colors.light(), flexGrow: 1 } }, [
+    h2({ style: { fontSize, marginLeft: '1.0rem' } }, ['Billing Projects']),
+    loadingMigrationInformation &&
+      div({ style: { display: 'flex', alignItems: 'center', marginLeft: '1.0rem' } }, [
+        spinner({ size: 36 }),
+        span({ style: { fontSize, marginLeft: '0.5rem', marginTop: '0.5rem', fontStyle: 'italic' } }, [
+          'Fetching billing projects',
+        ]),
+      ]),
+    div({ role: 'list' }, [
+      !loadingMigrationInformation &&
+        billingProjectWorkspaces.length === 0 &&
+        div({ style: { fontSize, marginTop: '1.5rem', marginLeft: '1.5rem' } }, ['You have no workspaces to migrate']),
+      ..._.map(
+        (billingProjectWorkspaces) => h(BillingProjectParent, billingProjectWorkspaces),
+        billingProjectWorkspaces
+      ),
+    ]),
+  ]);
+};

--- a/src/pages/workspaces/migration/BillingProjectList.ts
+++ b/src/pages/workspaces/migration/BillingProjectList.ts
@@ -21,7 +21,7 @@ export const BillingProjectList = () => {
       reportErrorAndRethrow('Error loading workspace migration information'),
       Utils.withBusyState(setLoadingMigrationInformation)
     )(async () => {
-      const migrationResponse = (await Ajax(signal).Workspaces.bucketMigration()) as Record<string, any>;
+      const migrationResponse = await Ajax(signal).Workspaces.bucketMigration();
       setBillingProjectWorkspaces(parseServerResponse(migrationResponse));
     });
     loadWorkspaces();
@@ -41,7 +41,7 @@ export const BillingProjectList = () => {
         billingProjectWorkspaces.length === 0 &&
         div({ style: { fontSize, marginTop: '1.5rem', marginLeft: '1.5rem' } }, ['You have no workspaces to migrate']),
       ..._.map(
-        (billingProjectWorkspaces) => h(BillingProjectParent, billingProjectWorkspaces),
+        (billingProjectMigrationInfo) => h(BillingProjectParent, billingProjectMigrationInfo),
         billingProjectWorkspaces
       ),
     ]),

--- a/src/pages/workspaces/migration/BillingProjectList.ts
+++ b/src/pages/workspaces/migration/BillingProjectList.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp';
-import { useEffect, useState } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 import { div, h, h2, span } from 'react-hyperscript-helpers';
 import { spinner } from 'src/components/icons';
 import { Ajax } from 'src/libs/ajax';
@@ -10,7 +10,7 @@ import * as Utils from 'src/libs/utils';
 import { BillingProjectParent } from 'src/pages/workspaces/migration/BillingProjectParent';
 import { BillingProjectMigrationInfo, parseServerResponse } from 'src/pages/workspaces/migration/migration-utils';
 
-export const BillingProjectList = () => {
+export const BillingProjectList = (): ReactNode => {
   const [loadingMigrationInformation, setLoadingMigrationInformation] = useState(true);
   const [billingProjectWorkspaces, setBillingProjectWorkspaces] = useState<BillingProjectMigrationInfo[]>([]);
   const signal = useCancellation();
@@ -41,7 +41,7 @@ export const BillingProjectList = () => {
         billingProjectWorkspaces.length === 0 &&
         div({ style: { fontSize, marginTop: '1.5rem', marginLeft: '1.5rem' } }, ['You have no workspaces to migrate']),
       ..._.map(
-        (billingProjectMigrationInfo) => h(BillingProjectParent, billingProjectMigrationInfo),
+        (billingProjectMigrationInfo) => h(BillingProjectParent, { billingProjectMigrationInfo }),
         billingProjectWorkspaces
       ),
     ]),

--- a/src/pages/workspaces/migration/BillingProjectParent.ts
+++ b/src/pages/workspaces/migration/BillingProjectParent.ts
@@ -5,7 +5,7 @@ import colors from 'src/libs/colors';
 import { BillingProjectMigrationInfo } from 'src/pages/workspaces/migration/migration-utils';
 import { WorkspaceItem } from 'src/pages/workspaces/migration/WorkspaceItem';
 
-export const BillingProjectParent = (billingProjectWorkspaces: BillingProjectMigrationInfo) => {
+export const BillingProjectParent = (billingProjectMigrationInfo: BillingProjectMigrationInfo) => {
   return div({ role: 'listitem' }, [
     h(
       Collapse,
@@ -19,10 +19,10 @@ export const BillingProjectParent = (billingProjectWorkspaces: BillingProjectMig
           borderRadius: 5,
           background: 'white',
         },
-        title: div({}, [billingProjectWorkspaces.namespace]),
+        title: div({}, [billingProjectMigrationInfo.namespace]),
         initialOpenState: true,
       },
-      _.map((workspace) => h(WorkspaceItem, workspace), billingProjectWorkspaces.workspaces)
+      _.map((workspace) => h(WorkspaceItem, workspace), billingProjectMigrationInfo.workspaces)
     ),
   ]);
 };

--- a/src/pages/workspaces/migration/BillingProjectParent.ts
+++ b/src/pages/workspaces/migration/BillingProjectParent.ts
@@ -1,0 +1,28 @@
+import _ from 'lodash/fp';
+import { div, h } from 'react-hyperscript-helpers';
+import Collapse from 'src/components/Collapse';
+import colors from 'src/libs/colors';
+import { BillingProjectMigrationInfo } from 'src/pages/workspaces/migration/migration-utils';
+import { WorkspaceItem } from 'src/pages/workspaces/migration/WorkspaceItem';
+
+export const BillingProjectParent = (billingProjectWorkspaces: BillingProjectMigrationInfo) => {
+  return div({ role: 'listitem' }, [
+    h(
+      Collapse,
+      {
+        summaryStyle: { height: 60, padding: '1.5rem', fontWeight: 600 },
+        titleFirst: true,
+        style: {
+          fontSize: 14,
+          margin: '10px 15px',
+          borderBottom: `1px solid ${colors.dark(0.2)}`,
+          borderRadius: 5,
+          background: 'white',
+        },
+        title: div({}, [billingProjectWorkspaces.namespace]),
+        initialOpenState: true,
+      },
+      _.map((workspace) => h(WorkspaceItem, workspace), billingProjectWorkspaces.workspaces)
+    ),
+  ]);
+};

--- a/src/pages/workspaces/migration/BillingProjectParent.ts
+++ b/src/pages/workspaces/migration/BillingProjectParent.ts
@@ -1,11 +1,16 @@
 import _ from 'lodash/fp';
+import { ReactNode } from 'react';
 import { div, h } from 'react-hyperscript-helpers';
 import Collapse from 'src/components/Collapse';
 import colors from 'src/libs/colors';
 import { BillingProjectMigrationInfo } from 'src/pages/workspaces/migration/migration-utils';
 import { WorkspaceItem } from 'src/pages/workspaces/migration/WorkspaceItem';
 
-export const BillingProjectParent = (billingProjectMigrationInfo: BillingProjectMigrationInfo) => {
+interface BillingProjectParentProps {
+  billingProjectMigrationInfo: BillingProjectMigrationInfo;
+}
+
+export const BillingProjectParent = (props: BillingProjectParentProps): ReactNode => {
   return div({ role: 'listitem' }, [
     h(
       Collapse,
@@ -19,10 +24,13 @@ export const BillingProjectParent = (billingProjectMigrationInfo: BillingProject
           borderRadius: 5,
           background: 'white',
         },
-        title: div({}, [billingProjectMigrationInfo.namespace]),
+        title: div({}, [props.billingProjectMigrationInfo.namespace]),
         initialOpenState: true,
       },
-      _.map((workspace) => h(WorkspaceItem, workspace), billingProjectMigrationInfo.workspaces)
+      _.map(
+        (workspaceMigrationInfo) => h(WorkspaceItem, { workspaceMigrationInfo }),
+        props.billingProjectMigrationInfo.workspaces
+      )
     ),
   ]);
 };

--- a/src/pages/workspaces/migration/WorkspaceItem.test.ts
+++ b/src/pages/workspaces/migration/WorkspaceItem.test.ts
@@ -1,0 +1,224 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+import { h } from 'react-hyperscript-helpers';
+import { MigrationStep, WorkspaceMigrationInfo } from 'src/pages/workspaces/migration/migration-utils';
+import { WorkspaceItem } from 'src/pages/workspaces/migration/WorkspaceItem';
+import { renderWithAppContexts as render } from 'src/testing/test-utils';
+
+describe('WorkspaceItem', () => {
+  it('shows the workspace name for an unscheduled workspace', async () => {
+    // Arrange
+    const unscheduledWorkspace: WorkspaceMigrationInfo = {
+      namespace: 'billing project',
+      name: 'workspace name',
+      migrationStep: 'Unscheduled',
+    };
+
+    // Act
+    render(h(WorkspaceItem, unscheduledWorkspace));
+
+    // Assert
+    await screen.findByText('workspace name');
+  });
+
+  it('shows completed workspace status', async () => {
+    // Arrange
+    const completedWorkspace: WorkspaceMigrationInfo = {
+      failureReason: undefined,
+      finalBucketTransferProgress: {
+        bytesTransferred: 288912,
+        objectsTransferred: 561,
+        totalBytesToTransfer: 288912,
+        totalObjectsToTransfer: 561,
+      },
+      migrationStep: 'Finished',
+      name: 'april29',
+      namespace: 'CARBilling-2',
+      outcome: 'success',
+      tempBucketTransferProgress: {
+        bytesTransferred: 288912,
+        objectsTransferred: 561,
+        totalBytesToTransfer: 288912,
+        totalObjectsToTransfer: 561,
+      },
+    };
+
+    // Act
+    render(h(WorkspaceItem, completedWorkspace));
+
+    // Assert
+    await screen.findByText('april29');
+    await screen.findByText('Migration Complete');
+  });
+
+  it('shows failed workspace status with no accessibility errors', async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const failedWorkspace: WorkspaceMigrationInfo = {
+      failureReason: 'Bucket migration failure reason',
+      finalBucketTransferProgress: undefined,
+      migrationStep: 'Finished',
+      name: 'testdata',
+      namespace: 'CARBillingTest',
+      outcome: 'failure',
+      tempBucketTransferProgress: undefined,
+    };
+
+    // Act
+    const { container } = render(h(WorkspaceItem, failedWorkspace));
+    const infoButton = screen.getByLabelText('More info');
+    await user.click(infoButton);
+
+    // Assert
+    await screen.findByText('testdata');
+    await screen.findByText('Migration Failed');
+    await screen.findByText('Bucket migration failure reason');
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it.each([
+    { migrationStep: 'ScheduledForMigration' as MigrationStep, expectedStatus: 'Starting Migration' },
+    { migrationStep: 'PreparingTransferToTempBucket' as MigrationStep, expectedStatus: 'Preparing Original Bucket' },
+    { migrationStep: 'PreparingTransferToFinalBucket' as MigrationStep, expectedStatus: 'Creating Destination Bucket' },
+    { migrationStep: 'FinishingUp' as MigrationStep, expectedStatus: 'Finishing Migration' },
+    { migrationStep: 'Finished' as MigrationStep, expectedStatus: 'Finishing Migration' },
+  ])(
+    'renders status for state "$migrationStep" with no accessibility errors',
+    async ({ migrationStep, expectedStatus }) => {
+      // Arrange
+      const workspace: WorkspaceMigrationInfo = {
+        namespace: 'billing project',
+        name: 'workspace name',
+        migrationStep,
+      };
+
+      // Act
+      const { container } = render(h(WorkspaceItem, workspace));
+
+      // Assert
+      await screen.findByText(expectedStatus);
+      expect(await axe(container)).toHaveNoViolations();
+    }
+  );
+
+  it('shows transfer to temp bucket state with bytes', async () => {
+    // Arrange
+    const transferringWorkspace: WorkspaceMigrationInfo = {
+      failureReason: undefined,
+      finalBucketTransferProgress: {
+        bytesTransferred: 0,
+        objectsTransferred: 0,
+        totalBytesToTransfer: 0,
+        totalObjectsToTransfer: 0,
+      },
+      migrationStep: 'TransferringToTempBucket',
+      name: 'Christina test',
+      namespace: 'general-dev-billing-account',
+      outcome: undefined,
+      tempBucketTransferProgress: {
+        bytesTransferred: 1000,
+        objectsTransferred: 2,
+        totalBytesToTransfer: 2000,
+        totalObjectsToTransfer: 4,
+      },
+    };
+
+    // Act
+    render(h(WorkspaceItem, transferringWorkspace));
+
+    // Assert
+    await screen.findByText('Christina test');
+    await screen.findByText('Initial Transfer in Progress (1000 B/1.95 KiB)');
+  });
+
+  it('shows transfer to temp bucket state with no files', async () => {
+    // Arrange
+    const transferringWorkspace: WorkspaceMigrationInfo = {
+      failureReason: undefined,
+      finalBucketTransferProgress: {
+        bytesTransferred: 0,
+        objectsTransferred: 0,
+        totalBytesToTransfer: 0,
+        totalObjectsToTransfer: 0,
+      },
+      migrationStep: 'TransferringToTempBucket',
+      name: 'Christina test',
+      namespace: 'general-dev-billing-account',
+      outcome: undefined,
+      tempBucketTransferProgress: {
+        bytesTransferred: 0,
+        objectsTransferred: 0,
+        totalBytesToTransfer: 0,
+        totalObjectsToTransfer: 0,
+      },
+    };
+
+    // Act
+    render(h(WorkspaceItem, transferringWorkspace));
+
+    // Assert
+    await screen.findByText('Christina test');
+    await screen.findByText('Initial Bucket Transfer');
+  });
+
+  it('shows transfer to temp bucket state with bytes', async () => {
+    // Arrange
+    const transferringWorkspace: WorkspaceMigrationInfo = {
+      failureReason: undefined,
+      finalBucketTransferProgress: {
+        bytesTransferred: 1000,
+        objectsTransferred: 2,
+        totalBytesToTransfer: 2000,
+        totalObjectsToTransfer: 4,
+      },
+      migrationStep: 'TransferringToFinalBucket',
+      name: 'Christina test',
+      namespace: 'general-dev-billing-account',
+      outcome: undefined,
+      tempBucketTransferProgress: {
+        bytesTransferred: 2000,
+        objectsTransferred: 4,
+        totalBytesToTransfer: 2000,
+        totalObjectsToTransfer: 4,
+      },
+    };
+
+    // Act
+    render(h(WorkspaceItem, transferringWorkspace));
+
+    // Assert
+    await screen.findByText('Christina test');
+    await screen.findByText('Final Transfer in Progress (1000 B/1.95 KiB)');
+  });
+
+  it('shows transfer to temp bucket state with no files', async () => {
+    // Arrange
+    const transferringWorkspace: WorkspaceMigrationInfo = {
+      failureReason: undefined,
+      finalBucketTransferProgress: {
+        bytesTransferred: 0,
+        objectsTransferred: 0,
+        totalBytesToTransfer: 0,
+        totalObjectsToTransfer: 0,
+      },
+      migrationStep: 'TransferringToFinalBucket',
+      name: 'Christina test',
+      namespace: 'general-dev-billing-account',
+      outcome: undefined,
+      tempBucketTransferProgress: {
+        bytesTransferred: 0,
+        objectsTransferred: 0,
+        totalBytesToTransfer: 0,
+        totalObjectsToTransfer: 0,
+      },
+    };
+
+    // Act
+    render(h(WorkspaceItem, transferringWorkspace));
+
+    // Assert
+    await screen.findByText('Christina test');
+    await screen.findByText('Final Bucket Transfer');
+  });
+});

--- a/src/pages/workspaces/migration/WorkspaceItem.test.ts
+++ b/src/pages/workspaces/migration/WorkspaceItem.test.ts
@@ -16,7 +16,7 @@ describe('WorkspaceItem', () => {
     };
 
     // Act
-    render(h(WorkspaceItem, unscheduledWorkspace));
+    render(h(WorkspaceItem, { workspaceMigrationInfo: unscheduledWorkspace }));
 
     // Assert
     await screen.findByText('workspace name');
@@ -45,7 +45,7 @@ describe('WorkspaceItem', () => {
     };
 
     // Act
-    render(h(WorkspaceItem, completedWorkspace));
+    render(h(WorkspaceItem, { workspaceMigrationInfo: completedWorkspace }));
 
     // Assert
     await screen.findByText('april29');
@@ -66,7 +66,7 @@ describe('WorkspaceItem', () => {
     };
 
     // Act
-    const { container } = render(h(WorkspaceItem, failedWorkspace));
+    const { container } = render(h(WorkspaceItem, { workspaceMigrationInfo: failedWorkspace }));
     const infoButton = screen.getByLabelText('More info');
     await user.click(infoButton);
 
@@ -94,7 +94,7 @@ describe('WorkspaceItem', () => {
       };
 
       // Act
-      const { container } = render(h(WorkspaceItem, workspace));
+      const { container } = render(h(WorkspaceItem, { workspaceMigrationInfo: workspace }));
 
       // Assert
       await screen.findByText(expectedStatus);
@@ -125,7 +125,7 @@ describe('WorkspaceItem', () => {
     };
 
     // Act
-    render(h(WorkspaceItem, transferringWorkspace));
+    render(h(WorkspaceItem, { workspaceMigrationInfo: transferringWorkspace }));
 
     // Assert
     await screen.findByText('Christina test');
@@ -155,7 +155,7 @@ describe('WorkspaceItem', () => {
     };
 
     // Act
-    render(h(WorkspaceItem, transferringWorkspace));
+    render(h(WorkspaceItem, { workspaceMigrationInfo: transferringWorkspace }));
 
     // Assert
     await screen.findByText('Christina test');
@@ -185,7 +185,7 @@ describe('WorkspaceItem', () => {
     };
 
     // Act
-    render(h(WorkspaceItem, transferringWorkspace));
+    render(h(WorkspaceItem, { workspaceMigrationInfo: transferringWorkspace }));
 
     // Assert
     await screen.findByText('Christina test');
@@ -215,7 +215,7 @@ describe('WorkspaceItem', () => {
     };
 
     // Act
-    render(h(WorkspaceItem, transferringWorkspace));
+    render(h(WorkspaceItem, { workspaceMigrationInfo: transferringWorkspace }));
 
     // Assert
     await screen.findByText('Christina test');

--- a/src/pages/workspaces/migration/WorkspaceItem.ts
+++ b/src/pages/workspaces/migration/WorkspaceItem.ts
@@ -1,0 +1,78 @@
+import { div, h, span } from 'react-hyperscript-helpers';
+import { icon } from 'src/components/icons';
+import { InfoBox } from 'src/components/PopupTrigger';
+import colors from 'src/libs/colors';
+import * as Utils from 'src/libs/utils';
+import { WorkspaceMigrationInfo } from 'src/pages/workspaces/migration/migration-utils';
+
+export const WorkspaceItem = (workspace: WorkspaceMigrationInfo) => {
+  const renderMigrationState = () => {
+    const text = Utils.cond(
+      [
+        workspace.outcome === 'failure',
+        () =>
+          span({ style: { color: colors.danger() } }, [
+            'Migration Failed',
+            h(
+              InfoBox,
+              {
+                style: { marginLeft: '0.5rem' },
+                side: 'bottom',
+                tooltip: 'Failure information',
+                size: 18,
+                iconOverride: undefined,
+              },
+              [workspace.failureReason]
+            ),
+          ]),
+      ],
+      [workspace.outcome === 'success', () => span(['Migration Complete'])],
+      [workspace.migrationStep !== 'Unscheduled', span(['Migration in Progress'])]
+    );
+    const statusIcon = Utils.cond(
+      [
+        workspace.outcome === 'failure',
+        () =>
+          icon('warning-standard', {
+            size: 18,
+            style: { color: colors.danger() },
+          }),
+      ],
+      [
+        workspace.outcome === 'success',
+        () =>
+          icon('check', {
+            size: 18,
+            style: { color: colors.success() },
+          }),
+      ],
+      [
+        workspace.migrationStep !== 'Unscheduled',
+        () =>
+          icon('syncAlt', {
+            size: 18,
+            style: {
+              animation: 'rotation 2s infinite linear',
+              color: colors.success(),
+            },
+          }),
+      ]
+    );
+    return div({ style: { display: 'flex' } }, [
+      statusIcon,
+      div({ style: { display: 'flex', paddingLeft: '0.5rem', alignItems: 'center' } }, [text]),
+    ]);
+  };
+
+  return div(
+    {
+      style: {
+        display: 'flex',
+        justifyContent: 'space-between',
+        padding: '1.0rem 2.5rem',
+        borderTop: `1px solid ${colors.dark(0.2)}`,
+      },
+    },
+    [span([workspace.name]), renderMigrationState()]
+  );
+};

--- a/src/pages/workspaces/migration/WorkspaceItem.ts
+++ b/src/pages/workspaces/migration/WorkspaceItem.ts
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react';
 import { div, h, span } from 'react-hyperscript-helpers';
 import { icon } from 'src/components/icons';
-import { InfoBox } from 'src/components/PopupTrigger';
+import { InfoBox } from 'src/components/InfoBox';
 import colors from 'src/libs/colors';
 import * as Utils from 'src/libs/utils';
 import { WorkspaceMigrationInfo } from 'src/pages/workspaces/migration/migration-utils';

--- a/src/pages/workspaces/migration/WorkspaceItem.ts
+++ b/src/pages/workspaces/migration/WorkspaceItem.ts
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react';
 import { div, h, span } from 'react-hyperscript-helpers';
 import { icon } from 'src/components/icons';
 import { InfoBox } from 'src/components/PopupTrigger';
@@ -5,8 +6,46 @@ import colors from 'src/libs/colors';
 import * as Utils from 'src/libs/utils';
 import { WorkspaceMigrationInfo } from 'src/pages/workspaces/migration/migration-utils';
 
-export const WorkspaceItem = (workspaceInfo: WorkspaceMigrationInfo) => {
-  const renderMigrationState = () => {
+interface WorkspaceItemProps {
+  workspaceMigrationInfo: WorkspaceMigrationInfo;
+}
+
+export const WorkspaceItem = (props: WorkspaceItemProps): ReactNode => {
+  const workspaceInfo = props.workspaceMigrationInfo;
+
+  const renderMigrationIcon = () => {
+    return Utils.cond(
+      [
+        workspaceInfo.outcome === 'failure',
+        () =>
+          icon('warning-standard', {
+            size: 18,
+            style: { color: colors.danger() },
+          }),
+      ],
+      [
+        workspaceInfo.outcome === 'success',
+        () =>
+          icon('check', {
+            size: 18,
+            style: { color: colors.success() },
+          }),
+      ],
+      [
+        workspaceInfo.migrationStep !== 'Unscheduled',
+        () =>
+          icon('syncAlt', {
+            size: 18,
+            style: {
+              animation: 'rotation 2s infinite linear',
+              color: colors.success(),
+            },
+          }),
+      ]
+    );
+  };
+
+  const renderMigrationText = () => {
     const getTransferProgress = (transferType, processed, total) => {
       if (total === 0) {
         return `${transferType} Bucket Transfer`;
@@ -14,7 +53,7 @@ export const WorkspaceItem = (workspaceInfo: WorkspaceMigrationInfo) => {
       return `${transferType} Transfer in Progress (${Utils.formatBytes(processed)}/${Utils.formatBytes(total)})`;
     };
 
-    const text = Utils.cond(
+    return Utils.cond(
       [
         workspaceInfo.outcome === 'failure',
         () =>
@@ -66,39 +105,6 @@ export const WorkspaceItem = (workspaceInfo: WorkspaceMigrationInfo) => {
         () => span(['Finishing Migration']),
       ]
     );
-    const statusIcon = Utils.cond(
-      [
-        workspaceInfo.outcome === 'failure',
-        () =>
-          icon('warning-standard', {
-            size: 18,
-            style: { color: colors.danger() },
-          }),
-      ],
-      [
-        workspaceInfo.outcome === 'success',
-        () =>
-          icon('check', {
-            size: 18,
-            style: { color: colors.success() },
-          }),
-      ],
-      [
-        workspaceInfo.migrationStep !== 'Unscheduled',
-        () =>
-          icon('syncAlt', {
-            size: 18,
-            style: {
-              animation: 'rotation 2s infinite linear',
-              color: colors.success(),
-            },
-          }),
-      ]
-    );
-    return div({ style: { display: 'flex' } }, [
-      statusIcon,
-      div({ style: { display: 'flex', paddingLeft: '0.5rem', alignItems: 'center' } }, [text]),
-    ]);
   };
 
   return div(
@@ -110,6 +116,12 @@ export const WorkspaceItem = (workspaceInfo: WorkspaceMigrationInfo) => {
         borderTop: `1px solid ${colors.dark(0.2)}`,
       },
     },
-    [span([workspaceInfo.name]), renderMigrationState()]
+    [
+      span([workspaceInfo.name]),
+      div({ style: { display: 'flex' } }, [
+        renderMigrationIcon(),
+        div({ style: { display: 'flex', paddingLeft: '0.5rem', alignItems: 'center' } }, [renderMigrationText()]),
+      ]),
+    ]
   );
 };

--- a/src/pages/workspaces/migration/WorkspaceItem.ts
+++ b/src/pages/workspaces/migration/WorkspaceItem.ts
@@ -5,7 +5,7 @@ import colors from 'src/libs/colors';
 import * as Utils from 'src/libs/utils';
 import { WorkspaceMigrationInfo } from 'src/pages/workspaces/migration/migration-utils';
 
-export const WorkspaceItem = (workspace: WorkspaceMigrationInfo) => {
+export const WorkspaceItem = (workspaceInfo: WorkspaceMigrationInfo) => {
   const renderMigrationState = () => {
     const getTransferProgress = (transferType, processed, total) => {
       if (total === 0) {
@@ -16,7 +16,7 @@ export const WorkspaceItem = (workspace: WorkspaceMigrationInfo) => {
 
     const text = Utils.cond(
       [
-        workspace.outcome === 'failure',
+        workspaceInfo.outcome === 'failure',
         () =>
           span({ style: { color: colors.danger() } }, [
             'Migration Failed',
@@ -29,46 +29,46 @@ export const WorkspaceItem = (workspace: WorkspaceMigrationInfo) => {
                 size: 18,
                 iconOverride: undefined,
               },
-              [workspace.failureReason]
+              [workspaceInfo.failureReason]
             ),
           ]),
       ],
-      [workspace.outcome === 'success', () => span(['Migration Complete'])],
-      [workspace.migrationStep === 'ScheduledForMigration', () => span(['Starting Migration'])],
-      [workspace.migrationStep === 'PreparingTransferToTempBucket', () => span(['Preparing Original Bucket'])],
+      [workspaceInfo.outcome === 'success', () => span(['Migration Complete'])],
+      [workspaceInfo.migrationStep === 'ScheduledForMigration', () => span(['Starting Migration'])],
+      [workspaceInfo.migrationStep === 'PreparingTransferToTempBucket', () => span(['Preparing Original Bucket'])],
       [
-        workspace.migrationStep === 'TransferringToTempBucket',
+        workspaceInfo.migrationStep === 'TransferringToTempBucket',
         () =>
           span([
             getTransferProgress(
               'Initial',
-              workspace.tempBucketTransferProgress?.bytesTransferred,
-              workspace.tempBucketTransferProgress?.totalBytesToTransfer
+              workspaceInfo.tempBucketTransferProgress?.bytesTransferred,
+              workspaceInfo.tempBucketTransferProgress?.totalBytesToTransfer
             ),
           ]),
       ],
-      [workspace.migrationStep === 'PreparingTransferToFinalBucket', () => span(['Creating Destination Bucket'])],
+      [workspaceInfo.migrationStep === 'PreparingTransferToFinalBucket', () => span(['Creating Destination Bucket'])],
       [
-        workspace.migrationStep === 'TransferringToFinalBucket',
+        workspaceInfo.migrationStep === 'TransferringToFinalBucket',
         () =>
           span([
             getTransferProgress(
               'Final',
-              workspace.finalBucketTransferProgress?.bytesTransferred,
-              workspace.finalBucketTransferProgress?.totalBytesToTransfer
+              workspaceInfo.finalBucketTransferProgress?.bytesTransferred,
+              workspaceInfo.finalBucketTransferProgress?.totalBytesToTransfer
             ),
           ]),
       ],
       // If workspace.outcome === 'success', we end earlier with a "Migration Complete" message.
       // Therefor we shouldn't encounter 'Finished' here, but handling it in case `outcome` updates later.
       [
-        workspace.migrationStep === 'FinishingUp' || workspace.migrationStep === 'Finished',
+        workspaceInfo.migrationStep === 'FinishingUp' || workspaceInfo.migrationStep === 'Finished',
         () => span(['Finishing Migration']),
       ]
     );
     const statusIcon = Utils.cond(
       [
-        workspace.outcome === 'failure',
+        workspaceInfo.outcome === 'failure',
         () =>
           icon('warning-standard', {
             size: 18,
@@ -76,7 +76,7 @@ export const WorkspaceItem = (workspace: WorkspaceMigrationInfo) => {
           }),
       ],
       [
-        workspace.outcome === 'success',
+        workspaceInfo.outcome === 'success',
         () =>
           icon('check', {
             size: 18,
@@ -84,7 +84,7 @@ export const WorkspaceItem = (workspace: WorkspaceMigrationInfo) => {
           }),
       ],
       [
-        workspace.migrationStep !== 'Unscheduled',
+        workspaceInfo.migrationStep !== 'Unscheduled',
         () =>
           icon('syncAlt', {
             size: 18,
@@ -110,6 +110,6 @@ export const WorkspaceItem = (workspace: WorkspaceMigrationInfo) => {
         borderTop: `1px solid ${colors.dark(0.2)}`,
       },
     },
-    [span([workspace.name]), renderMigrationState()]
+    [span([workspaceInfo.name]), renderMigrationState()]
   );
 };

--- a/src/pages/workspaces/migration/WorkspaceItem.ts
+++ b/src/pages/workspaces/migration/WorkspaceItem.ts
@@ -1,8 +1,10 @@
-import { ReactNode } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 import { div, h, span } from 'react-hyperscript-helpers';
 import { icon } from 'src/components/icons';
 import { InfoBox } from 'src/components/InfoBox';
+import { Ajax } from 'src/libs/ajax';
 import colors from 'src/libs/colors';
+import { useCancellation } from 'src/libs/react-utils';
 import * as Utils from 'src/libs/utils';
 import { WorkspaceMigrationInfo } from 'src/pages/workspaces/migration/migration-utils';
 
@@ -12,6 +14,33 @@ interface WorkspaceItemProps {
 
 export const WorkspaceItem = (props: WorkspaceItemProps): ReactNode => {
   const workspaceInfo = props.workspaceMigrationInfo;
+  const [unmigratedBucketSize, setUnmigratedBucketSize] = useState<string>();
+  const bucketSizeFailed = 'Unable to fetch Bucket Size';
+  const signal = useCancellation();
+
+  useEffect(() => {
+    const fetchBucketSize = async () => {
+      // Set to an empty string as a flag that we have sent an Ajax request.
+      setUnmigratedBucketSize('');
+      try {
+        const { usageInBytes } = await Ajax(signal)
+          .Workspaces.workspace(workspaceInfo.namespace, workspaceInfo.name)
+          .bucketUsage();
+        setUnmigratedBucketSize(`Bucket Size: ${Utils.formatBytes(usageInBytes)}`);
+      } catch (error) {
+        // This is typically a 404 with no message to display
+        setUnmigratedBucketSize(bucketSizeFailed);
+      }
+    };
+
+    if (unmigratedBucketSize === undefined && workspaceInfo.migrationStep === 'Unscheduled') {
+      fetchBucketSize();
+    }
+    // If the workspace has started migration, clear the bucket size.
+    if (unmigratedBucketSize !== undefined && workspaceInfo.migrationStep !== 'Unscheduled') {
+      setUnmigratedBucketSize(undefined);
+    }
+  }, [setUnmigratedBucketSize, signal, unmigratedBucketSize, workspaceInfo]);
 
   const renderMigrationIcon = () => {
     return Utils.cond(
@@ -40,6 +69,14 @@ export const WorkspaceItem = (props: WorkspaceItemProps): ReactNode => {
               animation: 'rotation 2s infinite linear',
               color: colors.success(),
             },
+          }),
+      ],
+      [
+        workspaceInfo.migrationStep === 'Unscheduled' && unmigratedBucketSize === bucketSizeFailed,
+        () =>
+          icon('warning-info', {
+            size: 22,
+            style: { color: colors.warning() },
           }),
       ]
     );
@@ -103,7 +140,8 @@ export const WorkspaceItem = (props: WorkspaceItemProps): ReactNode => {
       [
         workspaceInfo.migrationStep === 'FinishingUp' || workspaceInfo.migrationStep === 'Finished',
         () => span(['Finishing Migration']),
-      ]
+      ],
+      [workspaceInfo.migrationStep === 'Unscheduled' && !!unmigratedBucketSize, () => span([unmigratedBucketSize])]
     );
   };
 

--- a/src/pages/workspaces/migration/WorkspaceMigration.ts
+++ b/src/pages/workspaces/migration/WorkspaceMigration.ts
@@ -1,21 +1,16 @@
-import _ from 'lodash/fp';
 import { useEffect, useState } from 'react';
-import { div, h, h2, p, span } from 'react-hyperscript-helpers';
+import { div, h, h2, p } from 'react-hyperscript-helpers';
 import Collapse from 'src/components/Collapse';
 import { Link } from 'src/components/common';
 import FooterWrapper from 'src/components/FooterWrapper';
-import { icon, spinner } from 'src/components/icons';
+import { icon } from 'src/components/icons';
 import TopBar from 'src/components/TopBar';
-import { Ajax } from 'src/libs/ajax';
 import colors from 'src/libs/colors';
-import { reportErrorAndRethrow } from 'src/libs/error';
 import * as Nav from 'src/libs/nav';
 import { getLocalPref, setLocalPref } from 'src/libs/prefs';
-import { useCancellation } from 'src/libs/react-utils';
 import * as Style from 'src/libs/style';
 import * as Utils from 'src/libs/utils';
-import { BillingProjectParent } from 'src/pages/workspaces/migration/BillingProjectParent';
-import { BillingProjectMigrationInfo, parseServerResponse } from 'src/pages/workspaces/migration/migration-utils';
+import { BillingProjectList } from 'src/pages/workspaces/migration/BillingProjectList';
 
 const MigrationInformation = () => {
   const persistenceId = 'multiregionBucketMigration';
@@ -65,43 +60,12 @@ const MigrationInformation = () => {
   ]);
 };
 
-const ListView = () => {
-  const [loadingMigrationInformation, setLoadingMigrationInformation] = useState(true);
-  const [billingProjectWorkspaces, setBillingProjectWorkspaces] = useState<BillingProjectMigrationInfo[]>([]);
-  const signal = useCancellation();
-  useEffect(() => {
-    const loadWorkspaces = _.flow(
-      reportErrorAndRethrow('Error loading workspace migration information'),
-      Utils.withBusyState(setLoadingMigrationInformation)
-    )(async () => {
-      const migrationResponse = (await Ajax(signal).Workspaces.bucketMigration()) as Record<string, any>;
-      setBillingProjectWorkspaces(parseServerResponse(migrationResponse));
-    });
-    loadWorkspaces();
-  }, [setBillingProjectWorkspaces, signal]);
-
-  return div({ style: { padding: '10px', backgroundColor: colors.light(), flexGrow: 1 } }, [
-    h2({ style: { fontSize: 16, marginLeft: '1rem' } }, ['Billing Projects']),
-    loadingMigrationInformation &&
-      div({ style: { display: 'flex', alignItems: 'center', marginLeft: '1rem' } }, [
-        spinner({ size: 36 }),
-        span({ style: { fontSize: 16, marginLeft: '0.5rem', marginTop: '0.5rem', fontStyle: 'italic' } }, [
-          'Fetching billing projects',
-        ]),
-      ]),
-    div(
-      { role: 'list' },
-      _.map((billingProjectWorkspaces) => h(BillingProjectParent, billingProjectWorkspaces), billingProjectWorkspaces)
-    ),
-  ]);
-};
-
 export const WorkspaceMigrationPage = () => {
   return h(FooterWrapper, [
     h(TopBar, { title: 'Workspace Multi-Region Bucket Migrations', href: Nav.getLink('workspace-migration') }, []),
     div({ role: 'main', style: { display: 'flex', flex: '1 1 auto', flexFlow: 'column' } }, [
       h(MigrationInformation, {}),
-      h(ListView, {}),
+      h(BillingProjectList, {}),
     ]),
   ]);
 };

--- a/src/pages/workspaces/migration/WorkspaceMigration.ts
+++ b/src/pages/workspaces/migration/WorkspaceMigration.ts
@@ -1,0 +1,116 @@
+import _ from 'lodash/fp';
+import { useEffect, useState } from 'react';
+import { div, h, h2, p, span } from 'react-hyperscript-helpers';
+import Collapse from 'src/components/Collapse';
+import { Link } from 'src/components/common';
+import FooterWrapper from 'src/components/FooterWrapper';
+import { icon, spinner } from 'src/components/icons';
+import TopBar from 'src/components/TopBar';
+import { Ajax } from 'src/libs/ajax';
+import colors from 'src/libs/colors';
+import { reportErrorAndRethrow } from 'src/libs/error';
+import * as Nav from 'src/libs/nav';
+import { getLocalPref, setLocalPref } from 'src/libs/prefs';
+import { useCancellation } from 'src/libs/react-utils';
+import * as Style from 'src/libs/style';
+import * as Utils from 'src/libs/utils';
+import { BillingProjectParent } from 'src/pages/workspaces/migration/BillingProjectParent';
+import { BillingProjectMigrationInfo, parseServerResponse } from 'src/pages/workspaces/migration/migration-utils';
+
+const MigrationInformation = () => {
+  const persistenceId = 'multiregionBucketMigration';
+  const [infoPanelOpen, setInfoPanelOpen] = useState(() => getLocalPref(persistenceId)?.infoPanelOpen);
+
+  useEffect(() => {
+    setLocalPref(persistenceId, {
+      infoPanelOpen,
+    });
+  }, [persistenceId, infoPanelOpen]);
+
+  return div({ style: { backgroundColor: 'white', borderBottom: `2px solid ${colors.primary(0.55)}` } }, [
+    div({ style: Style.dashboard.rightBoxContainer }, [
+      h(
+        Collapse,
+        {
+          initialOpenState: infoPanelOpen !== undefined ? infoPanelOpen : true,
+          titleFirst: false,
+          title: h2({ style: { ...Style.dashboard.collapsibleHeader } }, ['Important information on bucket migration']),
+          onClick: () => setInfoPanelOpen(!infoPanelOpen),
+        },
+        [
+          div({ style: { margin: '10px 20px' } }, [
+            p([
+              'While we have done our best to protect bucket migration from egress charges through December 15, 2023, ' +
+                'we cannot guarantee that there will be no egress or other operational charges when migrating buckets. ' +
+                'If you have any concerns, you should contact your Google Billing Representative prior to migrating your buckets.',
+            ]),
+            p([
+              'Some buckets may take a very long time to migrate. You are responsible for coordinating any extended downtime with users of your workspaces. ' +
+                'Migrations cannot be stopped once they begin. Migrations are only supported form US multi-region to ' +
+                'US Central 1 (Iowa) at this time. Buckets that already exist in a single region will not be displayed.',
+            ]),
+            p([
+              h(Link, { href: 'TBD', ...Utils.newTabLinkProps }, [
+                'Blog post with additional information',
+                icon('pop-out', {
+                  size: 12,
+                  style: { marginLeft: '0.25rem' },
+                }),
+              ]),
+            ]),
+          ]),
+        ]
+      ),
+    ]),
+  ]);
+};
+
+const ListView = () => {
+  const [loadingMigrationInformation, setLoadingMigrationInformation] = useState(true);
+  const [billingProjectWorkspaces, setBillingProjectWorkspaces] = useState<BillingProjectMigrationInfo[]>([]);
+  const signal = useCancellation();
+  useEffect(() => {
+    const loadWorkspaces = _.flow(
+      reportErrorAndRethrow('Error loading workspace migration information'),
+      Utils.withBusyState(setLoadingMigrationInformation)
+    )(async () => {
+      const migrationResponse = (await Ajax(signal).Workspaces.bucketMigration()) as Record<string, any>;
+      setBillingProjectWorkspaces(parseServerResponse(migrationResponse));
+    });
+    loadWorkspaces();
+  }, [setBillingProjectWorkspaces, signal]);
+
+  return div({ style: { padding: '10px', backgroundColor: colors.light(), flexGrow: 1 } }, [
+    h2({ style: { fontSize: 16, marginLeft: '1rem' } }, ['Billing Projects']),
+    loadingMigrationInformation &&
+      div({ style: { display: 'flex', alignItems: 'center', marginLeft: '1rem' } }, [
+        spinner({ size: 36 }),
+        span({ style: { fontSize: 16, marginLeft: '0.5rem', marginTop: '0.5rem', fontStyle: 'italic' } }, [
+          'Fetching billing projects',
+        ]),
+      ]),
+    div(
+      { role: 'list' },
+      _.map((billingProjectWorkspaces) => h(BillingProjectParent, billingProjectWorkspaces), billingProjectWorkspaces)
+    ),
+  ]);
+};
+
+export const WorkspaceMigrationPage = () => {
+  return h(FooterWrapper, [
+    h(TopBar, { title: 'Workspace Multi-Region Bucket Migrations', href: Nav.getLink('workspace-migration') }, []),
+    div({ role: 'main', style: { display: 'flex', flex: '1 1 auto', flexFlow: 'column' } }, [
+      h(MigrationInformation, {}),
+      h(ListView, {}),
+    ]),
+  ]);
+};
+
+export const navPaths = [
+  {
+    name: 'workspace-migration',
+    path: '/workspace-migration',
+    component: WorkspaceMigrationPage,
+    title: 'Workspace Migration',
+  },
+];

--- a/src/pages/workspaces/migration/migration-utils.test.ts
+++ b/src/pages/workspaces/migration/migration-utils.test.ts
@@ -1,0 +1,119 @@
+import { parseServerResponse } from 'src/pages/workspaces/migration/migration-utils';
+
+export const mockServerData = {
+  'CARBilling-2/notmigrated': null,
+  'CARBilling-2/april29': {
+    finalBucketTransferProgress: {
+      bytesTransferred: 288912,
+      objectsTransferred: 561,
+      totalBytesToTransfer: 288912,
+      totalObjectsToTransfer: 561,
+    },
+    migrationStep: 'Finished' as const,
+    outcome: 'success' as const,
+    tempBucketTransferProgress: {
+      bytesTransferred: 288912,
+      objectsTransferred: 561,
+      totalBytesToTransfer: 288912,
+      totalObjectsToTransfer: 561,
+    },
+  },
+  'general-dev-billing-account/Christina test': {
+    finalBucketTransferProgress: {
+      bytesTransferred: 0,
+      objectsTransferred: 0,
+      totalBytesToTransfer: 0,
+      totalObjectsToTransfer: 0,
+    },
+    migrationStep: 'TransferringToTempBucket' as const,
+    tempBucketTransferProgress: {
+      bytesTransferred: 1000,
+      objectsTransferred: 2,
+      totalBytesToTransfer: 2000,
+      totalObjectsToTransfer: 4,
+    },
+  },
+  'CARBillingTest/testdata': {
+    migrationStep: 'Finished' as const,
+    outcome: {
+      failure:
+        '{"billingProjectBillingAccount":"RawlsBillingAccountName(billingAccounts/00708C-45D19D-27AAFA)","migrationId":"3","workspace":"CARBillingTest/testdata","billingProject":"RawlsBillingProjectName(CARBillingTest)","message":"The bucket migration failed while removing workspace bucket IAM: invalid billing account on billing project."}',
+    },
+  },
+};
+
+describe('parseServerResponse', () => {
+  it('Can handle an empty response', () => {
+    expect(parseServerResponse({})).toEqual([]);
+  });
+
+  it('Transforms the server data to a list format', () => {
+    const billingProjectList = [
+      {
+        namespace: 'CARBilling-2',
+        workspaces: [
+          {
+            failureReason: undefined,
+            finalBucketTransferProgress: {
+              bytesTransferred: 288912,
+              objectsTransferred: 561,
+              totalBytesToTransfer: 288912,
+              totalObjectsToTransfer: 561,
+            },
+            migrationStep: 'Finished',
+            name: 'april29',
+            namespace: 'CARBilling-2',
+            outcome: 'success',
+            tempBucketTransferProgress: {
+              bytesTransferred: 288912,
+              objectsTransferred: 561,
+              totalBytesToTransfer: 288912,
+              totalObjectsToTransfer: 561,
+            },
+          },
+          { migrationStep: 'Unscheduled', name: 'notmigrated', namespace: 'CARBilling-2' },
+        ],
+      },
+      {
+        namespace: 'CARBillingTest',
+        workspaces: [
+          {
+            failureReason:
+              'The bucket migration failed while removing workspace bucket IAM: invalid billing account on billing project.',
+            finalBucketTransferProgress: undefined,
+            migrationStep: 'Finished',
+            name: 'testdata',
+            namespace: 'CARBillingTest',
+            outcome: 'failure',
+            tempBucketTransferProgress: undefined,
+          },
+        ],
+      },
+      {
+        namespace: 'general-dev-billing-account',
+        workspaces: [
+          {
+            failureReason: undefined,
+            finalBucketTransferProgress: {
+              bytesTransferred: 0,
+              objectsTransferred: 0,
+              totalBytesToTransfer: 0,
+              totalObjectsToTransfer: 0,
+            },
+            migrationStep: 'TransferringToTempBucket',
+            name: 'Christina test',
+            namespace: 'general-dev-billing-account',
+            outcome: undefined,
+            tempBucketTransferProgress: {
+              bytesTransferred: 1000,
+              objectsTransferred: 2,
+              totalBytesToTransfer: 2000,
+              totalObjectsToTransfer: 4,
+            },
+          },
+        ],
+      },
+    ];
+    expect(parseServerResponse(mockServerData)).toEqual(billingProjectList);
+  });
+});

--- a/src/pages/workspaces/migration/migration-utils.ts
+++ b/src/pages/workspaces/migration/migration-utils.ts
@@ -1,0 +1,91 @@
+import _ from 'lodash/fp';
+
+export type MigrationStep = ServerMigrationStep | 'Unscheduled';
+
+export type MigrationOutcome = 'success' | 'failure' | 'in progress';
+
+interface TransferProgress {
+  totalBytesToTransfer: number;
+  bytesTransferred: number;
+  totalObjectsToTransfer: number;
+  objectsTransferred: number;
+}
+
+export interface WorkspaceMigrationInfo {
+  namespace: string;
+  name: string;
+  migrationStep: MigrationStep;
+  outcome?: MigrationOutcome;
+  failureReason?: string;
+  tempBucketTransferProgress?: TransferProgress;
+  finalBucketTransferProgress?: TransferProgress;
+}
+
+export interface BillingProjectMigrationInfo {
+  namespace: string;
+  workspaces: WorkspaceMigrationInfo[];
+}
+
+// Server types that are transformed into the exported types.
+type ServerMigrationStep =
+  | 'ScheduledForMigration'
+  | 'PreparingTransferToTempBucket'
+  | 'TransferringToTempBucket'
+  | 'PreparingTransferToFinalBucket'
+  | 'TransferringToFinalBucket'
+  | 'FinishingUp'
+  | 'Finished';
+
+interface ServerMigrationStatus {
+  migrationStep: ServerMigrationStep;
+  outcome: 'success' | { failure: string };
+  tempBucketTransferProgress: TransferProgress;
+  finalBucketTransferProgress: TransferProgress;
+}
+
+export const parseServerResponse = (
+  response: Record<string, ServerMigrationStatus | null>
+): BillingProjectMigrationInfo[] => {
+  // Group workspaces by namespace (billing project)
+  const workspacesByNamespace: Record<
+    string,
+    { namespace: string; name: string; status: ServerMigrationStatus | null }[]
+  > = {};
+  _.forEach((workspace) => {
+    const workspaceNameParts = workspace.split('/');
+    const namespace = workspaceNameParts[0];
+    const name = workspaceNameParts[1];
+    if (!(namespace in workspacesByNamespace)) {
+      workspacesByNamespace[namespace] = [];
+    }
+    workspacesByNamespace[namespace].push({ namespace, name, status: response[workspace] });
+  }, _.keys(response));
+
+  // Sort namespaces
+  const sortedNamespaceKeys = _.orderBy([(key) => _.lowerCase(key)], ['asc'], _.keys(workspacesByNamespace));
+
+  // Transform workspace information into exported types.
+  const billingProjectWorkspaces: BillingProjectMigrationInfo[] = _.map((namespace: string) => {
+    // Sort workspaces
+    const sortedWorkspaces = _.orderBy([({ name }) => _.lowerCase(name)], ['asc'], workspacesByNamespace[namespace]);
+    // Transform the information
+    const expandedWorkspaces: WorkspaceMigrationInfo[] = _.map(({ name, status }) => {
+      if (!_.isObjectLike(status)) {
+        return { namespace, name, migrationStep: 'Unscheduled' };
+      }
+      const serverStatus = status as ServerMigrationStatus;
+      return {
+        namespace,
+        name,
+        migrationStep: serverStatus.migrationStep ?? 'Unscheduled',
+        outcome:
+          serverStatus.outcome === 'success' ? 'success' : _.isObject(serverStatus.outcome) ? 'failure' : undefined,
+        failureReason: _.isObject(serverStatus.outcome) ? JSON.parse(serverStatus.outcome.failure).message : undefined,
+        tempBucketTransferProgress: serverStatus.tempBucketTransferProgress,
+        finalBucketTransferProgress: serverStatus.finalBucketTransferProgress,
+      };
+    }, sortedWorkspaces);
+    return { namespace, workspaces: expandedWorkspaces };
+  }, sortedNamespaceKeys);
+  return billingProjectWorkspaces;
+};


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WOR-1260

This adds a status view of multi-region bucket migration, via the unpublicized workspace-migration [page](https://pr-3-dot-bvdp-saturn-dev.appspot.com/#workspace-migration). Subsequent tickets will add controls for the user to initiate migrations.

For now, a migration can be kicked off via the Rawls API: https://rawls.dsde-dev.broadinstitute.org/#/workspaces_v2/startBucketMigrationForWorkspace

Example of what the view looks like with migrations in progress and a failed migration (note that "Migration in Progress" has been made more granular since this screenshot was taken):

![image](https://github.com/DataBiosphere/terra-ui/assets/484484/af69061e-e573-468e-8930-bebf7a512553)

