### PR TITLE
[AJ-1310] Load snapshot information from TDR for snapshot imports

### DIFF
--- a/src/import-data/ImportData.ts
+++ b/src/import-data/ImportData.ts
@@ -34,7 +34,7 @@ import { useImportRequest } from './useImportRequest';
 const getTitleForImportRequest = (importRequest: ImportRequest): string => {
   switch (importRequest.type) {
     case 'tdr-snapshot-export':
-      return `Importing snapshot ${importRequest.snapshotName}`;
+      return `Importing snapshot ${importRequest.snapshot.name}`;
     case 'tdr-snapshot-reference':
     case 'catalog-dataset':
     case 'catalog-snapshots':
@@ -110,7 +110,7 @@ export const ImportData = (props: ImportDataProps): ReactNode => {
       const wdsDataTableProvider = new WdsDataTableProvider(workspace.workspaceId, wdsUrl);
 
       // call import snapshot
-      wdsDataTableProvider.importTdr(workspace.workspaceId, importRequest.snapshotId);
+      wdsDataTableProvider.importTdr(workspace.workspaceId, importRequest.snapshot.id);
     }
     const { namespace, name } = workspace;
     const { jobId } = await Ajax()
@@ -157,7 +157,7 @@ export const ImportData = (props: ImportDataProps): ReactNode => {
     } else {
       await Ajax()
         .Workspaces.workspace(namespace, name)
-        .importSnapshot(importRequest.snapshotId, normalizeSnapshotName(importRequest.snapshotName));
+        .importSnapshot(importRequest.snapshot.id, normalizeSnapshotName(importRequest.snapshot.name));
       notify('success', 'Snapshot imported successfully.', { timeout: 3000 });
     }
   };

--- a/src/import-data/import-types.ts
+++ b/src/import-data/import-types.ts
@@ -1,3 +1,5 @@
+import { Snapshot } from 'src/libs/ajax/DataRepo';
+
 export interface PFBImportRequest {
   type: 'pfb';
   url: URL;
@@ -18,15 +20,13 @@ export type FileImportRequest = PFBImportRequest | BagItImportRequest | Entities
 export interface TDRSnapshotExportImportRequest {
   type: 'tdr-snapshot-export';
   manifestUrl: URL;
-  snapshotId: string;
-  snapshotName: string;
+  snapshot: Snapshot;
   syncPermissions: boolean;
 }
 
 export interface TDRSnapshotReferenceImportRequest {
   type: 'tdr-snapshot-reference';
-  snapshotId: string;
-  snapshotName: string;
+  snapshot: Snapshot;
 }
 
 export interface CatalogDatasetImportRequest {

--- a/src/libs/ajax/DataRepo.ts
+++ b/src/libs/ajax/DataRepo.ts
@@ -86,13 +86,26 @@ export const datasetIncludeTypes: Record<DatasetInclude, DatasetInclude> = {
   SNAPSHOT_BUILDER_SETTINGS: 'SNAPSHOT_BUILDER_SETTINGS',
 };
 
+interface SnapshotDataset {
+  id: string;
+  name: string;
+  secureMonitoringEnabled: boolean;
+}
+
+export interface Snapshot {
+  id: string;
+  name: string;
+  source: { dataset: SnapshotDataset }[];
+  cloudPlatform: 'azure' | 'gcp';
+}
+
 export interface DataRepoContract {
   dataset: (datasetId: string) => {
     details: (include?: DatasetInclude[]) => Promise<DatasetModel>;
     roles: () => Promise<string[]>;
   };
   snapshot: (snapshotId: string) => {
-    details: () => Promise<{}>;
+    details: () => Promise<Snapshot>;
     exportSnapshot: () => Promise<{}>;
   };
   job: (jobId: string) => {


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1310

Continuing to work on the import data UI... this loads the snapshot information from TDR when a snapshot export or snapshot reference import is requested. Having this information will allow us to determine which workspaces the snapshot can be imported into based on the snapshot's cloud platform and whether it has secure monitoring enabled (Note that this PR only loads the snapshot information).