### PR TITLE
[AJ-1310] Refactor ImportData components

### DIFF
--- a/src/import-data/ImportData.ts
+++ b/src/import-data/ImportData.ts
@@ -28,21 +28,7 @@ import {
 } from './import-types';
 import { ImportDataDestination } from './ImportDataDestination';
 import { ImportDataOverview } from './ImportDataOverview';
-import { isProtectedSource } from './protected-data-utils';
 import { useImportRequest } from './useImportRequest';
-
-const getTitleForImportRequest = (importRequest: ImportRequest): string => {
-  switch (importRequest.type) {
-    case 'tdr-snapshot-export':
-      return `Importing snapshot ${importRequest.snapshot.name}`;
-    case 'tdr-snapshot-reference':
-    case 'catalog-dataset':
-    case 'catalog-snapshots':
-      return 'Linking data to a workspace';
-    default:
-      return 'Importing data to a workspace';
-  }
-};
 
 export interface ImportDataProps {
   importRequest: ImportRequest;
@@ -57,10 +43,6 @@ export const ImportData = (props: ImportDataProps): ReactNode => {
   const [userHasBillingProjects, setUserHasBillingProjects] = useState(true);
   const [snapshotResponses, setSnapshotResponses] = useState<{ status: string; message: string | undefined }[]>();
   const [isImporting, setIsImporting] = useState(false);
-
-  const isDataset = !_.includes(format, ['snapshot', 'tdrexport']);
-
-  const isProtectedData = isProtectedSource(importRequest);
 
   // Normalize the snapshot name:
   // Importing snapshot will throw an "enum" error if the name has any spaces or special characters
@@ -205,22 +187,17 @@ export const ImportData = (props: ImportDataProps): ReactNode => {
 
   return h(Fragment, [
     h(ImportDataOverview, {
-      header: getTitleForImportRequest(importRequest),
-      snapshots: importRequest.type === 'catalog-snapshots' ? importRequest.snapshots : [],
-      isDataset,
+      importRequest,
       snapshotResponses,
-      url: 'url' in importRequest ? importRequest.url : undefined,
-      isProtectedData,
     }),
     h(ImportDataDestination, {
+      importRequest,
       initialSelectedWorkspaceId: wid,
+      requiredAuthorizationDomain: ad,
       templateWorkspaces,
       template,
       userHasBillingProjects,
-      importMayTakeTime: isDataset,
-      requiredAuthorizationDomain: ad,
       onImport,
-      isProtectedData,
     }),
     isImporting && spinnerOverlay,
   ]);

--- a/src/import-data/ImportDataDestination.test.ts
+++ b/src/import-data/ImportDataDestination.test.ts
@@ -2,12 +2,14 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { h } from 'react-hyperscript-helpers';
 import { useWorkspaces } from 'src/components/workspace-utils';
+import { Snapshot } from 'src/libs/ajax/DataRepo';
 import { WorkspaceWrapper } from 'src/libs/workspace-utils';
 import { asMockedFn, renderWithAppContexts as render, SelectHelper } from 'src/testing/test-utils';
 import { makeGoogleWorkspace } from 'src/testing/workspace-fixtures';
 
+import { ImportRequest } from './import-types';
 import { canImportIntoWorkspace, ImportOptions } from './import-utils';
-import { ImportDataDestination } from './ImportDataDestination';
+import { ImportDataDestination, ImportDataDestinationProps } from './ImportDataDestination';
 
 type ImportUtilsExports = typeof import('./import-utils');
 jest.mock('./import-utils', (): ImportUtilsExports => {
@@ -25,101 +27,200 @@ jest.mock('src/components/workspace-utils', (): WorkspaceUtilsExports => {
   };
 });
 
-describe('ImportDataDestination', () => {
-  it.each([true, false])('should explain protected data restricts eligible workspaces', async (isProtectedData) => {
-    // Arrange
-    const user = userEvent.setup();
+interface SetupOptions {
+  props?: Partial<ImportDataDestinationProps>;
+  workspaces?: WorkspaceWrapper[];
+}
 
-    asMockedFn(useWorkspaces).mockReturnValue({
-      loading: false,
-      refresh: () => Promise.resolve(),
-      workspaces: [],
-    });
+const setup = (opts: SetupOptions): void => {
+  const { props = {}, workspaces = [] } = opts;
 
-    render(
-      h(ImportDataDestination, {
-        initialSelectedWorkspaceId: undefined,
-        templateWorkspaces: {},
-        template: undefined,
-        userHasBillingProjects: true,
-        importMayTakeTime: true,
-        requiredAuthorizationDomain: undefined,
-        onImport: () => {},
-        isProtectedData,
-      })
-    );
-
-    // Act
-    const existingWorkspace = screen.getByText('Start with an existing workspace', { exact: false });
-    await user.click(existingWorkspace); // select start with existing workspace
-
-    // Assert
-    const protectedWarning = screen.queryByText(
-      'You may only import to workspaces with an Authorization Domain and/or protected data setting.',
-      {
-        exact: false,
-      }
-    );
-
-    const isWarningShown = !!protectedWarning;
-    expect(isWarningShown).toEqual(isProtectedData);
+  asMockedFn(useWorkspaces).mockReturnValue({
+    loading: false,
+    refresh: () => Promise.resolve(),
+    workspaces,
   });
 
-  it('should filter workspaces through canImportIntoWorkspace', async () => {
+  render(
+    h(ImportDataDestination, {
+      importRequest: {
+        type: 'pfb',
+        url: new URL('https://example.com/path/to/file.pfb'),
+      },
+      initialSelectedWorkspaceId: undefined,
+      requiredAuthorizationDomain: undefined,
+      templateWorkspaces: {},
+      template: undefined,
+      userHasBillingProjects: true,
+      onImport: () => {},
+      ...props,
+    })
+  );
+};
+
+describe('ImportDataDestination', () => {
+  it.each([
+    {
+      importRequest: { type: 'pfb', url: new URL('https://service.prod.anvil.gi.ucsc.edu/path/to/file.pfb') },
+      shouldShowProtectedDataWarning: true,
+    },
+    {
+      importRequest: { type: 'pfb', url: new URL('https://example.com/path/to/file.pfb') },
+      shouldShowProtectedDataWarning: false,
+    },
+  ] as {
+    importRequest: ImportRequest;
+    shouldShowProtectedDataWarning: boolean;
+  }[])(
+    'should explain protected data restricts eligible workspaces',
+    async ({ importRequest, shouldShowProtectedDataWarning }) => {
+      // Arrange
+      const user = userEvent.setup();
+
+      setup({
+        props: {
+          importRequest,
+        },
+      });
+
+      // Act
+      const existingWorkspace = screen.getByText('Start with an existing workspace', { exact: false });
+      await user.click(existingWorkspace); // select start with existing workspace
+
+      // Assert
+      const protectedDataWarning = screen.queryByText(
+        'You may only import to workspaces with an Authorization Domain and/or protected data setting.',
+        {
+          exact: false,
+        }
+      );
+
+      const isWarningShown = !!protectedDataWarning;
+      expect(isWarningShown).toEqual(shouldShowProtectedDataWarning);
+    }
+  );
+
+  it.each([
+    {
+      importRequest: { type: 'pfb', url: new URL('https://service.prod.anvil.gi.ucsc.edu/path/to/file.pfb') },
+      requiredAuthorizationDomain: 'test-auth-domain',
+      expectedArgs: { isProtectedData: true, requiredAuthorizationDomain: 'test-auth-domain' },
+    },
+    {
+      importRequest: { type: 'pfb', url: new URL('https://example.com/path/to/file.pfb') },
+      requiredAuthorizationDomain: undefined,
+      expectedArgs: { isProtectedData: false, requiredAuthorizationDomain: undefined },
+    },
+  ] as {
+    importRequest: ImportRequest;
+    requiredAuthorizationDomain?: string;
+    expectedArgs: { isProtectedData: boolean; requiredAuthorizationDomain?: string };
+  }[])(
+    'should filter workspaces through canImportIntoWorkspace',
+    async ({ importRequest, requiredAuthorizationDomain, expectedArgs }) => {
+      // Arrange
+      const user = userEvent.setup();
+
+      asMockedFn(canImportIntoWorkspace).mockImplementation(
+        (_importOptions: ImportOptions, workspace: WorkspaceWrapper): boolean => {
+          return workspace.workspace.name === 'allowed-workspace';
+        }
+      );
+
+      setup({
+        props: {
+          importRequest,
+          requiredAuthorizationDomain,
+        },
+        workspaces: [
+          makeGoogleWorkspace({
+            workspace: {
+              name: 'allowed-workspace',
+            },
+          }),
+          makeGoogleWorkspace({
+            workspace: {
+              name: 'other-workspace',
+            },
+          }),
+        ],
+      });
+
+      // Act
+      const existingWorkspace = screen.getByText('Start with an existing workspace', { exact: false });
+      await user.click(existingWorkspace); // select start with existing workspace
+
+      const workspaceSelect = new SelectHelper(screen.getByLabelText('Select a workspace'), user);
+      const workspaces = await workspaceSelect.getOptions();
+
+      // Assert
+      expect(canImportIntoWorkspace).toHaveBeenCalledWith(expectedArgs, expect.anything());
+      expect(workspaces).toEqual(['allowed-workspace']);
+    }
+  );
+
+  const snapshotFixture: Snapshot = {
+    id: '00001111-2222-3333-aaaa-bbbbccccdddd',
+    name: 'test-snapshot',
+    source: [
+      {
+        dataset: {
+          id: '00001111-2222-3333-aaaa-bbbbccccdddd',
+          name: 'test-dataset',
+          secureMonitoringEnabled: false,
+        },
+      },
+    ],
+    cloudPlatform: 'gcp',
+  };
+
+  it.each([
+    {
+      importRequest: {
+        type: 'pfb',
+        url: new URL('https://example.com/path/to/file.pfb'),
+      },
+      shouldShowNotice: true,
+    },
+    {
+      importRequest: {
+        type: 'tdr-snapshot-export',
+        manifestUrl: new URL('https://example.com/path/to/manifest.json'),
+        snapshot: snapshotFixture,
+        syncPermissions: true,
+      },
+      shouldShowNotice: true,
+    },
+    {
+      importRequest: {
+        type: 'tdr-snapshot-reference',
+        snapshot: snapshotFixture,
+      },
+      shouldShowNotice: false,
+    },
+  ] as {
+    importRequest: ImportRequest;
+    shouldShowNotice: boolean;
+  }[])('should show a notice when an import may take time', async ({ importRequest, shouldShowNotice }) => {
     // Arrange
     const user = userEvent.setup();
 
-    asMockedFn(useWorkspaces).mockReturnValue({
-      loading: false,
-      refresh: () => Promise.resolve(),
-      workspaces: [
-        makeGoogleWorkspace({
-          workspace: {
-            name: 'allowed-workspace',
-          },
-        }),
-        makeGoogleWorkspace({
-          workspace: {
-            name: 'other-workspace',
-          },
-        }),
-      ],
+    setup({
+      props: {
+        importRequest,
+      },
     });
 
-    asMockedFn(canImportIntoWorkspace).mockImplementation(
-      (_importOptions: ImportOptions, workspace: WorkspaceWrapper): boolean => {
-        return workspace.workspace.name === 'allowed-workspace';
-      }
-    );
-
     // Act
-    render(
-      h(ImportDataDestination, {
-        initialSelectedWorkspaceId: undefined,
-        templateWorkspaces: {},
-        template: undefined,
-        userHasBillingProjects: true,
-        importMayTakeTime: true,
-        requiredAuthorizationDomain: 'test-auth-domain',
-        onImport: () => {},
-        isProtectedData: true,
-      })
-    );
-
     const existingWorkspace = screen.getByText('Start with an existing workspace', { exact: false });
     await user.click(existingWorkspace); // select start with existing workspace
 
-    const workspaceSelect = new SelectHelper(screen.getByLabelText('Select a workspace'), user);
-    const workspaces = await workspaceSelect.getOptions();
-
     // Assert
-    expect(canImportIntoWorkspace).toHaveBeenCalledWith(
-      {
-        isProtectedData: true,
-        requiredAuthorizationDomain: 'test-auth-domain',
-      },
-      expect.anything()
+    const notice = screen.queryByText(
+      'Note that the import process may take some time after you are redirected into your destination workspace.'
     );
-    expect(workspaces).toEqual(['allowed-workspace']);
+
+    const isNoticeShown = !!notice;
+    expect(isNoticeShown).toBe(shouldShowNotice);
   });
 });

--- a/src/import-data/ImportDataDestination.ts
+++ b/src/import-data/ImportDataDestination.ts
@@ -107,7 +107,7 @@ export const ImportDataDestination = (props: ImportDataDestinationProps): ReactN
   const isProtectedData = isProtectedSource(importRequest);
 
   // Some import types are finished in a single request.
-  // For most though, the import request starts a background task that times to complete.
+  // For most though, the import request starts a background task that takes time to complete.
   const immediateImportTypes: ImportRequest['type'][] = ['tdr-snapshot-reference', 'catalog-snapshots'];
   const importMayTakeTime = !immediateImportTypes.includes(importRequest.type);
 

--- a/src/import-data/ImportDataOverview.test.ts
+++ b/src/import-data/ImportDataOverview.test.ts
@@ -1,56 +1,42 @@
 import { render, screen } from '@testing-library/react';
 import { h } from 'react-hyperscript-helpers';
 
-import { ImportDataOverview } from './ImportDataOverview';
+import { ImportRequest } from './import-types';
+import { ImportDataOverview, ImportDataOverviewProps } from './ImportDataOverview';
+
+const renderImportDataOverview = (props: Partial<ImportDataOverviewProps> = {}): void => {
+  render(
+    h(ImportDataOverview, {
+      importRequest: { type: 'pfb', url: new URL('https://example.com/path/to/file.pfb') },
+      snapshotResponses: [],
+      ...props,
+    })
+  );
+};
 
 describe('ImportDataOverview', () => {
-  const header = 'Linking data to a workspace';
-  const snapshots = [];
-  const isDataset = true;
-  const snapshotResponses = [];
+  it.each([
+    {
+      importRequest: { type: 'pfb', url: new URL('https://service.prod.anvil.gi.ucsc.edu/path/to/file.pfb') },
+      shouldShowProtectedDataWarning: true,
+    },
+    {
+      importRequest: { type: 'pfb', url: new URL('https://example.com/path/to/file.pfb') },
+      shouldShowProtectedDataWarning: false,
+    },
+  ] as { importRequest: ImportRequest; shouldShowProtectedDataWarning: boolean }[])(
+    'should render warning about protected data',
+    ({ importRequest, shouldShowProtectedDataWarning }) => {
+      renderImportDataOverview({ importRequest });
 
-  it('should render warning about protected data', () => {
-    render(
-      h(ImportDataOverview, {
-        header,
-        snapshots,
-        isDataset,
-        snapshotResponses,
-        url: new URL('https://gen3-theanvil-io-pfb-export.s3.amazonaws.com/export_2023-07-07.avro'),
-        isProtectedData: true,
-      })
-    );
-
-    const protectedWarning = screen.queryByText('The data you chose to import to Terra are identified as protected', {
-      exact: false,
-    });
-    expect(protectedWarning).not.toBeNull();
-    const noWarning = screen.queryByText(
-      'The dataset(s) you just chose to import to Terra will be made available to you',
-      { exact: false }
-    );
-    expect(noWarning).toBeNull();
-  });
-
-  it('should not render warning about unprotected data', () => {
-    render(
-      h(ImportDataOverview, {
-        header,
-        snapshots,
-        isDataset,
-        snapshotResponses,
-        url: new URL('https://google.com/file.pfb'),
-        isProtectedData: false,
-      })
-    );
-    const protectedWarning = screen.queryByText('The data you chose to import to Terra are identified as protected', {
-      exact: false,
-    });
-    expect(protectedWarning).toBeNull();
-    const noWarning = screen.queryByText(
-      'The dataset(s) you just chose to import to Terra will be made available to you',
-      { exact: false }
-    );
-    expect(noWarning).not.toBeNull();
-  });
+      const protectedDataWarning = screen.queryByText(
+        'The data you chose to import to Terra are identified as protected',
+        {
+          exact: false,
+        }
+      );
+      const isWarningShown = !!protectedDataWarning;
+      expect(isWarningShown).toBe(shouldShowProtectedDataWarning);
+    }
+  );
 });


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1310

Some cleanup to the ImportData page. This plumbs the `ImportRequest` object from `ImportData` into `ImportDataOverview` and `ImportDataDestination`. This allows each of those components to derive whatever values they need from it vs `ImportData` deriving those values for both of them and passing the derived values down.

Also in here is a bug fix for the "import may take time message", which did not show up for imports of TDR snapshot exports. Previously, it was based on the vaguely named `isDataset` value, which was mainly used to adjust a label in `ImportDataOverview` but repurposed for the "import may take time message" in `ImportDataDestination`. With this PR, it will show up for anything that's not a snapshot by reference import. This highlights the value of having each component separately derive the values it needs from the `ImportRequest`.

This does mean that `isProtectedSource` is run multiple times on the same page, which isn't ideal. But it's a fairly cheap operation so I'll make that tradeoff in return for the simplicity and clarity.

