### PR TITLE
[AJ-1310] Check for protected data in snapshot imports

### DIFF
--- a/src/import-data/protected-data-utils.test.ts
+++ b/src/import-data/protected-data-utils.test.ts
@@ -1,7 +1,25 @@
+import { Snapshot } from 'src/libs/ajax/DataRepo';
 import { defaultAzureWorkspace, defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
 
 import { ImportRequest } from './import-types';
 import { isProtectedSource, isProtectedWorkspace } from './protected-data-utils';
+
+const getSnapshot = (secureMonitoringEnabled: boolean): Snapshot => {
+  return {
+    id: '00001111-2222-3333-aaaa-bbbbccccdddd',
+    name: 'test-snapshot',
+    source: [
+      {
+        dataset: {
+          id: '00001111-2222-3333-aaaa-bbbbccccdddd',
+          name: 'test-dataset',
+          secureMonitoringEnabled,
+        },
+      },
+    ],
+    cloudPlatform: 'gcp',
+  };
+};
 
 const protectedImports: ImportRequest[] = [
   // AnVIL production
@@ -17,11 +35,32 @@ const protectedImports: ImportRequest[] = [
   { type: 'pfb', url: new URL('https://gen3-biodatacatalyst-nhlbi-nih-gov-pfb-export.s3.amazonaws.com/file.pfb') },
   { type: 'pfb', url: new URL('https://s3.amazonaws.com/gen3-biodatacatalyst-nhlbi-nih-gov-pfb-export/file.pfb') },
   { type: 'pfb', url: new URL('https://gen3-theanvil-io-pfb-export.s3.amazonaws.com/file.pfb') },
+  // Protected TDR snapshots
+  {
+    type: 'tdr-snapshot-export',
+    manifestUrl: new URL('https://example.com/path/to/manifest.json'),
+    snapshot: getSnapshot(true),
+    syncPermissions: false,
+  },
+  {
+    type: 'tdr-snapshot-reference',
+    snapshot: getSnapshot(true),
+  },
 ];
 
 const unprotectedImports: ImportRequest[] = [
   { type: 'pfb', url: new URL('https://example.com/file.pfb') },
   { type: 'entities', url: new URL('https://service.prod.anvil.gi.ucsc.edu/file.json') },
+  {
+    type: 'tdr-snapshot-export',
+    manifestUrl: new URL('https://example.com/path/to/manifest.json'),
+    snapshot: getSnapshot(false),
+    syncPermissions: false,
+  },
+  {
+    type: 'tdr-snapshot-reference',
+    snapshot: getSnapshot(false),
+  },
 ];
 
 describe('isProtectedSource', () => {

--- a/src/import-data/protected-data-utils.ts
+++ b/src/import-data/protected-data-utils.ts
@@ -21,7 +21,7 @@ const protectedSources: ProtectedSource[] = [
 
 /**
  * Determine if a PFB file is considered protected data.
- * */
+ */
 const isProtectedPfbSource = (pfbUrl: URL): boolean => {
   return protectedSources.some((source) => {
     switch (source.type) {
@@ -48,7 +48,7 @@ const isProtectedPfbSource = (pfbUrl: URL): boolean => {
 
 /**
  * Determine if a TDR snapshot is considered protected data.
- * */
+ */
 const isProtectedSnapshotSource = (snapshot: Snapshot): boolean => {
   return snapshot.source.some((source) => source.dataset.secureMonitoringEnabled);
 };

--- a/src/import-data/protected-data-utils.ts
+++ b/src/import-data/protected-data-utils.ts
@@ -1,3 +1,4 @@
+import { Snapshot } from 'src/libs/ajax/DataRepo';
 import { isGoogleWorkspace, WorkspaceWrapper } from 'src/libs/workspace-utils';
 
 import { ImportRequest } from './import-types';
@@ -21,7 +22,7 @@ const protectedSources: ProtectedSource[] = [
 /**
  * Determine if a PFB file is considered protected data.
  * */
-export const isProtectedPfbSource = (pfbUrl: URL): boolean => {
+const isProtectedPfbSource = (pfbUrl: URL): boolean => {
   return protectedSources.some((source) => {
     switch (source.type) {
       case 'http':
@@ -46,12 +47,22 @@ export const isProtectedPfbSource = (pfbUrl: URL): boolean => {
 };
 
 /**
+ * Determine if a TDR snapshot is considered protected data.
+ * */
+const isProtectedSnapshotSource = (snapshot: Snapshot): boolean => {
+  return snapshot.source.some((source) => source.dataset.secureMonitoringEnabled);
+};
+
+/**
  * Determine whether an import source is considered protected.
  */
 export const isProtectedSource = (importRequest: ImportRequest): boolean => {
   switch (importRequest.type) {
     case 'pfb':
       return isProtectedPfbSource(importRequest.url);
+    case 'tdr-snapshot-export':
+    case 'tdr-snapshot-reference':
+      return isProtectedSnapshotSource(importRequest.snapshot);
     default:
       return false;
   }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1310

Finally, getting to the core of the ticket... This checks for protected data in TDR snapshot imports (both imports from an export / import by copy and import by reference). If the snapshot's source dataset has secure monitoring enabled, it's treated the same as "protected" PFB imports: notices are displayed and it can only be imported into a "protected" workspace. This matches the requirements enforced on the backend by import service and Rawls.

Note that there is one case left unhandled here: importing multiple snapshots from the catalog. I don't think there's any way to get to that case via the UI and I'm not sure if we need to keep supporting that, so I didn't want to invest in updating it right now.

## Before
![Screenshot 2023-10-06 at 8 49 46 AM](https://github.com/DataBiosphere/terra-ui/assets/1156625/59c830d1-8171-4c05-8083-d4f1ab0ed7cc)

## After
![Screenshot 2023-10-06 at 8 49 50 AM](https://github.com/DataBiosphere/terra-ui/assets/1156625/dd09effc-a65d-4184-b2c6-ef7ee7d297c6)
