### PR TITLE
Display bucket size for unmigrated workspaces (WOR-1261).

### DIFF
--- a/src/pages/workspaces/migration/WorkspaceItem.ts
+++ b/src/pages/workspaces/migration/WorkspaceItem.ts
@@ -1,8 +1,10 @@
-import { ReactNode } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 import { div, h, span } from 'react-hyperscript-helpers';
 import { icon } from 'src/components/icons';
 import { InfoBox } from 'src/components/InfoBox';
+import { Ajax } from 'src/libs/ajax';
 import colors from 'src/libs/colors';
+import { useCancellation } from 'src/libs/react-utils';
 import * as Utils from 'src/libs/utils';
 import { WorkspaceMigrationInfo } from 'src/pages/workspaces/migration/migration-utils';
 
@@ -12,6 +14,33 @@ interface WorkspaceItemProps {
 
 export const WorkspaceItem = (props: WorkspaceItemProps): ReactNode => {
   const workspaceInfo = props.workspaceMigrationInfo;
+  const [unmigratedBucketSize, setUnmigratedBucketSize] = useState<string>();
+  const bucketSizeFailed = 'Unable to fetch Bucket Size';
+  const signal = useCancellation();
+
+  useEffect(() => {
+    const fetchBucketSize = async () => {
+      // Set to an empty string as a flag that we have sent an Ajax request.
+      setUnmigratedBucketSize('');
+      try {
+        const { usageInBytes } = await Ajax(signal)
+          .Workspaces.workspace(workspaceInfo.namespace, workspaceInfo.name)
+          .bucketUsage();
+        setUnmigratedBucketSize(`Bucket Size: ${Utils.formatBytes(usageInBytes)}`);
+      } catch (error) {
+        // This is typically a 404 with no message to display
+        setUnmigratedBucketSize(bucketSizeFailed);
+      }
+    };
+
+    if (unmigratedBucketSize === undefined && workspaceInfo.migrationStep === 'Unscheduled') {
+      fetchBucketSize();
+    }
+    // If the workspace has started migration, clear the bucket size.
+    if (unmigratedBucketSize !== undefined && workspaceInfo.migrationStep !== 'Unscheduled') {
+      setUnmigratedBucketSize(undefined);
+    }
+  }, [setUnmigratedBucketSize, signal, unmigratedBucketSize, workspaceInfo]);
 
   const renderMigrationIcon = () => {
     return Utils.cond(
@@ -40,6 +69,14 @@ export const WorkspaceItem = (props: WorkspaceItemProps): ReactNode => {
               animation: 'rotation 2s infinite linear',
               color: colors.success(),
             },
+          }),
+      ],
+      [
+        workspaceInfo.migrationStep === 'Unscheduled' && unmigratedBucketSize === bucketSizeFailed,
+        () =>
+          icon('warning-info', {
+            size: 22,
+            style: { color: colors.warning() },
           }),
       ]
     );
@@ -103,7 +140,8 @@ export const WorkspaceItem = (props: WorkspaceItemProps): ReactNode => {
       [
         workspaceInfo.migrationStep === 'FinishingUp' || workspaceInfo.migrationStep === 'Finished',
         () => span(['Finishing Migration']),
-      ]
+      ],
+      [workspaceInfo.migrationStep === 'Unscheduled' && !!unmigratedBucketSize, () => span([unmigratedBucketSize])]
     );
   };
 


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WOR-1261

Adds display of the bucket size for unmigrated workspaces. https://pr-3-dot-bvdp-saturn-dev.appspot.com/#workspace-migration

I logged in as Hermione which has a large number of unscheduled workspaces and did not see any issues with all the individual bucketUsage calls.

![image](https://github.com/DataBiosphere/terra-ui/assets/484484/b4be00e0-397a-4c41-85d0-6379af259ff6)
