### PR TITLE
[AJ-1310] Identify protected Azure workspaces

### DIFF
--- a/src/import-data/ImportDataDestination.ts
+++ b/src/import-data/ImportDataDestination.ts
@@ -111,7 +111,23 @@ export const ImportDataDestination = (props: ImportDataDestinationProps): ReactN
   const immediateImportTypes: ImportRequest['type'][] = ['tdr-snapshot-reference', 'catalog-snapshots'];
   const importMayTakeTime = !immediateImportTypes.includes(importRequest.type);
 
-  const { workspaces, refresh: refreshWorkspaces, loading: loadingWorkspaces } = useWorkspaces();
+  const {
+    workspaces,
+    refresh: refreshWorkspaces,
+    loading: loadingWorkspaces,
+  } = useWorkspaces([
+    'workspace.workspaceId',
+    'workspace.namespace',
+    'workspace.name',
+    // The decision on whether or data can be imported into a workspace is based on the user's level of access
+    // to the workspace and the workspace's authorization domain, protected status and cloud platform.
+    // That information needs to be fetched here.
+    'accessLevel',
+    'policies',
+    'workspace.authorizationDomain',
+    'workspace.bucketName',
+    'workspace.cloudPlatform',
+  ]);
   const [mode, setMode] = useState<'existing' | 'template' | undefined>(
     initialSelectedWorkspaceId ? 'existing' : undefined
   );

--- a/src/import-data/protected-data-utils.test.ts
+++ b/src/import-data/protected-data-utils.test.ts
@@ -96,6 +96,21 @@ describe('isProtectedWorkspace', () => {
     expect(isProtectedWorkspace(protectedAzureWorkspace)).toBe(true);
   });
 
+  it('should require a "protected-data" policy for Azure workspaces', () => {
+    const protectedAzureWorkspace: AzureWorkspace = {
+      ...defaultAzureWorkspace,
+      policies: [
+        {
+          additionalData: [],
+          namespace: 'terra',
+          name: 'some-other-policy',
+        },
+      ],
+    };
+
+    expect(isProtectedWorkspace(protectedAzureWorkspace)).toBe(false);
+  });
+
   it('should recognize a protected Google workspace', () => {
     const protectedWorkspace = { ...defaultGoogleWorkspace };
     protectedWorkspace.workspace.bucketName = `fc-secure-${defaultGoogleWorkspace.workspace.bucketName}`;

--- a/src/import-data/protected-data-utils.test.ts
+++ b/src/import-data/protected-data-utils.test.ts
@@ -1,4 +1,5 @@
 import { Snapshot } from 'src/libs/ajax/DataRepo';
+import { AzureWorkspace } from 'src/libs/workspace-utils';
 import { defaultAzureWorkspace, defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
 
 import { ImportRequest } from './import-types';
@@ -80,7 +81,22 @@ describe('isProtectedWorkspace', () => {
     expect(isProtectedWorkspace(workspace)).toBe(false);
   });
 
-  it('should recognize a protected workspace', () => {
+  it('should recognize a protected Azure workspace', () => {
+    const protectedAzureWorkspace: AzureWorkspace = {
+      ...defaultAzureWorkspace,
+      policies: [
+        {
+          additionalData: [],
+          namespace: 'terra',
+          name: 'protected-data',
+        },
+      ],
+    };
+
+    expect(isProtectedWorkspace(protectedAzureWorkspace)).toBe(true);
+  });
+
+  it('should recognize a protected Google workspace', () => {
     const protectedWorkspace = { ...defaultGoogleWorkspace };
     protectedWorkspace.workspace.bucketName = `fc-secure-${defaultGoogleWorkspace.workspace.bucketName}`;
 

--- a/src/import-data/protected-data-utils.ts
+++ b/src/import-data/protected-data-utils.ts
@@ -1,5 +1,5 @@
 import { Snapshot } from 'src/libs/ajax/DataRepo';
-import { getCloudProviderFromWorkspace, GoogleWorkspace, WorkspaceWrapper } from 'src/libs/workspace-utils';
+import { WorkspaceWrapper } from 'src/libs/workspace-utils';
 
 import { ImportRequest } from './import-types';
 
@@ -77,19 +77,18 @@ export const isProtectedSource = (importRequest: ImportRequest): boolean => {
  * @param workspace - The workspace.
  */
 export const isProtectedWorkspace = (workspace: WorkspaceWrapper): boolean => {
-  const cloudProvider = getCloudProviderFromWorkspace(workspace);
-  switch (cloudProvider) {
-    case 'AZURE':
+  switch (workspace.workspace.cloudPlatform) {
+    case 'Azure':
       // The WorkspaceWrapper type specifies policies as optional, but policies are loaded by the ImportData component.
       if (!workspace.policies) {
         return false;
       }
       return workspace.policies.some((policy) => policy.namespace === 'terra' && policy.name === 'protected-data');
-    case 'GCP':
-      return (workspace as GoogleWorkspace).workspace.bucketName.startsWith('fc-secure');
+    case 'Gcp':
+      return workspace.workspace.bucketName.startsWith('fc-secure');
     default:
       // Check that all possible cases are handled.
-      const exhaustiveGuard: never = cloudProvider;
+      const exhaustiveGuard: never = workspace.workspace;
       return exhaustiveGuard;
   }
 };

--- a/src/import-data/protected-data-utils.ts
+++ b/src/import-data/protected-data-utils.ts
@@ -1,5 +1,5 @@
 import { Snapshot } from 'src/libs/ajax/DataRepo';
-import { isGoogleWorkspace, WorkspaceWrapper } from 'src/libs/workspace-utils';
+import { getCloudProviderFromWorkspace, GoogleWorkspace, WorkspaceWrapper } from 'src/libs/workspace-utils';
 
 import { ImportRequest } from './import-types';
 
@@ -68,12 +68,28 @@ export const isProtectedSource = (importRequest: ImportRequest): boolean => {
   }
 };
 
-// This method identifies whether a workspace qualifies as protected.
-// 'Protected' here means that it has enhanced logging - either on its own or because it has an auth domain.
-// For now this also means only GCP workspaces are included.
+/**
+ * Determine whether a workspace is considred protected.
+ *
+ * For Azure workspaces, this checks for the "protected-data" policy.
+ * For Google workspaces, this checks for has enhanced logging - either directly or from an auth domain.
+ *
+ * @param workspace - The workspace.
+ */
 export const isProtectedWorkspace = (workspace: WorkspaceWrapper): boolean => {
-  if (!isGoogleWorkspace(workspace)) {
-    return false;
+  const cloudProvider = getCloudProviderFromWorkspace(workspace);
+  switch (cloudProvider) {
+    case 'AZURE':
+      // The WorkspaceWrapper type specifies policies as optional, but policies are loaded by the ImportData component.
+      if (!workspace.policies) {
+        return false;
+      }
+      return workspace.policies.some((policy) => policy.namespace === 'terra' && policy.name === 'protected-data');
+    case 'GCP':
+      return (workspace as GoogleWorkspace).workspace.bucketName.startsWith('fc-secure');
+    default:
+      // Check that all possible cases are handled.
+      const exhaustiveGuard: never = cloudProvider;
+      return exhaustiveGuard;
   }
-  return !!workspace.workspace.bucketName && workspace.workspace.bucketName.startsWith('fc-secure');
 };


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1310

Currently, `isProtectedWorkspace` returns false for all Azure workspaces.
https://github.com/DataBiosphere/terra-ui/blob/de58681e8d432c0193b728b611a8d9dcdb46747f/src/import-data/protected-data-utils.ts#L74-L79

This means that the UI will not allow selecting an Azure workspace to import protected data into.

This updates the UI to identify protected Azure workspaces based on their policies.