### PR TITLE
[UIE-120] Move maybeParseJson to core-utils

### DIFF
--- a/packages/core-utils/src/io-utils.test.ts
+++ b/packages/core-utils/src/io-utils.test.ts
@@ -1,4 +1,22 @@
-import { readFileAsText } from './io-utils';
+import { maybeParseJSON, readFileAsText } from './io-utils';
+
+describe('maybeParseJSON', () => {
+  it('parses JSON and returns the decoded value', () => {
+    // Act
+    const result = maybeParseJSON('{"key": "value"}');
+
+    // Assert
+    expect(result).toEqual({ key: 'value' });
+  });
+
+  it('returns undefined if the string cannot be parsed as JSON', () => {
+    // Act
+    const result = maybeParseJSON('{"Invalid JSON"}');
+
+    // Assert
+    expect(result).toBe(undefined);
+  });
+});
 
 describe('readFileAsText', () => {
   it('returns file contents', async () => {

--- a/packages/core-utils/src/io-utils.ts
+++ b/packages/core-utils/src/io-utils.ts
@@ -1,3 +1,17 @@
+/**
+ * Attempt to parse a JSON string and return the decoded value.
+ * If the string cannot be parsed, return undefined.
+ *
+ * @param maybeJSONString - The string to attempt to parse.
+ */
+export const maybeParseJSON = (maybeJSONString: string): unknown => {
+  try {
+    return JSON.parse(maybeJSONString);
+  } catch {
+    return undefined;
+  }
+};
+
 export const readFileAsText = (file: File): Promise<string | null> => {
   const reader = new FileReader();
   return new Promise((resolve, reject) => {

--- a/src/libs/browser-storage.js
+++ b/src/libs/browser-storage.js
@@ -152,7 +152,7 @@ export const listenDynamic = (storage, key, fn) => {
  *
  * @param storage an object implementing the Storage interface
  * @param key the key for storing the value
- * @returns stateful object that manages the given storage location
+ * @returns {import("@terra-ui-packages/core-utils").Atom<any>} stateful object that manages the given storage location
  */
 export const staticStorageSlot = (storage, key) => {
   const { subscribe, next } = subscribable();

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -5,7 +5,15 @@ import _ from 'lodash/fp';
 import * as qs from 'qs';
 import { div, span } from 'react-hyperscript-helpers';
 
-export { cond, DEFAULT, formatBytes, formatNumber, formatUSD, switchCase } from '@terra-ui-packages/core-utils';
+export {
+  cond,
+  DEFAULT,
+  formatBytes,
+  formatNumber,
+  formatUSD,
+  maybeParseJSON,
+  switchCase,
+} from '@terra-ui-packages/core-utils';
 
 const dateFormat = new Intl.DateTimeFormat('default', { day: 'numeric', month: 'short', year: 'numeric' });
 const monthYearFormat = new Intl.DateTimeFormat('default', { month: 'short', year: 'numeric' });
@@ -212,14 +220,6 @@ export const getAriaLabelOrTooltip = ({
   tooltip,
 }) => {
   return ariaLabel || ariaLabelledBy || (allowId && id) ? ariaLabel : tooltip;
-};
-
-export const maybeParseJSON = (maybeJSONString) => {
-  try {
-    return JSON.parse(maybeJSONString);
-  } catch {
-    return undefined;
-  }
 };
 
 export const sanitizeEntityName = (unsafe) => unsafe.replace(/[^\w]/g, '-');


### PR DESCRIPTION
Continuing to move shared utilities to the core-utils package...

This moves `maybeParseJSON`. It's re-exported from libs/utils to avoid updating import paths yet.

This also changes the type signature of `maybeParseJSON`. Currently, it returns `any`. This changes it to return `unknown`. The whole point of this function is that we're not confident in what we're parsing and think it may be invalid JSON. Thus, it makes sense to use `unknown` to require checking what type of data we get if parsing is successful.

https://www.typescriptlang.org/docs/handbook/type-compatibility.html#any-unknown-object-void-undefined-null-and-never-assignability

Changing the type ended up changing the return type of `configOverridesStore.get()` to `unknown` and `getConfig()` to `undefined`, which resulted in a bunch of type errors. I was impressed that TS could trace that through multiple JS files.

I added a type annotation to `staticStorageSlot` to restore the current type until browser-storage can be converted to TS.