### PR TITLE
[AJ-1310] Block cross-platform TDR imports

### DIFF
--- a/src/import-data/ImportData.test.ts
+++ b/src/import-data/ImportData.test.ts
@@ -279,16 +279,20 @@ describe('ImportData', () => {
 
   describe('TDR', () => {
     describe('snapshot exports', () => {
+      const commonSnapshotExportQueryParams = {
+        format: 'tdrexport',
+        tdrmanifest: 'https://example.com/path/to/manifest.json',
+        tdrSyncPermissions: 'true',
+        url: 'https://data.terra.bio',
+      };
+
       it('imports snapshot exports into Google workspaces', async () => {
         // Arrange
         const user = userEvent.setup();
 
         const queryParams = {
-          format: 'tdrexport',
+          ...commonSnapshotExportQueryParams,
           snapshotId: googleSnapshotFixture.id,
-          tdrmanifest: 'https://example.com/path/to/manifest.json',
-          tdrSyncPermissions: 'true',
-          url: 'https://data.terra.bio',
         };
         const { getWorkspaceApi, importJob } = await setup({ queryParams });
 
@@ -309,11 +313,8 @@ describe('ImportData', () => {
         const user = userEvent.setup();
 
         const queryParams = {
-          format: 'tdrexport',
+          ...commonSnapshotExportQueryParams,
           snapshotId: azureSnapshotFixture.id,
-          tdrmanifest: 'https://example.com/path/to/manifest.json',
-          tdrSyncPermissions: 'true',
-          url: 'https://data.terra.bio',
         };
         const { importTdr, wdsProxyUrl } = await setup({ queryParams });
 

--- a/src/import-data/ImportData.test.ts
+++ b/src/import-data/ImportData.test.ts
@@ -59,7 +59,22 @@ jest.mock('src/pages/library/dataBrowser-utils', (): DataBrowserUtilsExports => 
   };
 });
 
-const snapshotFixture: Snapshot = {
+const azureSnapshotFixture: Snapshot = {
+  id: 'aaaabbbb-cccc-dddd-0000-111122223333',
+  name: 'test-snapshot',
+  source: [
+    {
+      dataset: {
+        id: 'aaaabbbb-cccc-dddd-0000-111122223333',
+        name: 'test-dataset',
+        secureMonitoringEnabled: false,
+      },
+    },
+  ],
+  cloudPlatform: 'azure',
+};
+
+const googleSnapshotFixture: Snapshot = {
   id: '00001111-2222-3333-aaaa-bbbbccccdddd',
   name: 'test-snapshot',
   source: [
@@ -84,8 +99,11 @@ const setup = async (opts: SetupOptions) => {
   const mockDataRepo = {
     snapshot: (snapshotId: string): Partial<ReturnType<DataRepoContract['snapshot']>> => ({
       details: jest.fn().mockImplementation(() => {
-        if (snapshotId === snapshotFixture.id) {
-          return snapshotFixture;
+        if (snapshotId === azureSnapshotFixture.id) {
+          return azureSnapshotFixture;
+        }
+        if (snapshotId === googleSnapshotFixture.id) {
+          return googleSnapshotFixture;
         }
         throw new Response('{"message":"Snapshot not found"}', { status: 404 });
       }),
@@ -261,18 +279,17 @@ describe('ImportData', () => {
 
   describe('TDR', () => {
     describe('snapshot exports', () => {
-      const queryParams = {
-        format: 'tdrexport',
-        snapshotId: '00001111-2222-3333-aaaa-bbbbccccdddd',
-        tdrmanifest: 'https://example.com/path/to/manifest.json',
-        tdrSyncPermissions: 'true',
-        url: 'https://data.terra.bio',
-      };
-
       it('imports snapshot exports into Google workspaces', async () => {
         // Arrange
         const user = userEvent.setup();
 
+        const queryParams = {
+          format: 'tdrexport',
+          snapshotId: googleSnapshotFixture.id,
+          tdrmanifest: 'https://example.com/path/to/manifest.json',
+          tdrSyncPermissions: 'true',
+          url: 'https://data.terra.bio',
+        };
         const { getWorkspaceApi, importJob } = await setup({ queryParams });
 
         // Act
@@ -291,6 +308,13 @@ describe('ImportData', () => {
         // Arrange
         const user = userEvent.setup();
 
+        const queryParams = {
+          format: 'tdrexport',
+          snapshotId: azureSnapshotFixture.id,
+          tdrmanifest: 'https://example.com/path/to/manifest.json',
+          tdrSyncPermissions: 'true',
+          url: 'https://data.terra.bio',
+        };
         const { importTdr, wdsProxyUrl } = await setup({ queryParams });
 
         // Act
@@ -312,7 +336,7 @@ describe('ImportData', () => {
 
         const queryParams = {
           format: 'snapshot',
-          snapshotId: '00001111-2222-3333-aaaa-bbbbccccdddd',
+          snapshotId: googleSnapshotFixture.id,
         };
         const { getWorkspaceApi, importSnapshot } = await setup({ queryParams });
 
@@ -325,7 +349,7 @@ describe('ImportData', () => {
           defaultGoogleWorkspace.workspace.name
         );
 
-        expect(importSnapshot).toHaveBeenCalledWith(queryParams.snapshotId, snapshotFixture.name);
+        expect(importSnapshot).toHaveBeenCalledWith(queryParams.snapshotId, googleSnapshotFixture.name);
       });
     });
   });

--- a/src/import-data/ImportDataDestination.test.ts
+++ b/src/import-data/ImportDataDestination.test.ts
@@ -138,6 +138,29 @@ describe('ImportDataDestination', () => {
       requiredAuthorizationDomain: undefined,
       expectedArgs: { cloudPlatform: 'GCP', isProtectedData: false, requiredAuthorizationDomain: undefined },
     },
+    {
+      importRequest: {
+        type: 'tdr-snapshot-export',
+        manifestUrl: new URL('https://example.com/path/to/manifest.json'),
+        snapshot: {
+          id: '00001111-2222-3333-aaaa-bbbbccccdddd',
+          name: 'test-snapshot',
+          source: [
+            {
+              dataset: {
+                id: '00001111-2222-3333-aaaa-bbbbccccdddd',
+                name: 'test-dataset',
+                secureMonitoringEnabled: false,
+              },
+            },
+          ],
+          cloudPlatform: 'azure',
+        },
+        syncPermissions: false,
+      },
+      requiredAuthorizationDomain: undefined,
+      expectedArgs: { cloudPlatform: 'AZURE', isProtectedData: false, requiredAuthorizationDomain: undefined },
+    },
   ] as {
     importRequest: ImportRequest;
     requiredAuthorizationDomain?: string;

--- a/src/import-data/ImportDataDestination.test.ts
+++ b/src/import-data/ImportDataDestination.test.ts
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { h } from 'react-hyperscript-helpers';
 import { useWorkspaces } from 'src/components/workspace-utils';
 import { Snapshot } from 'src/libs/ajax/DataRepo';
-import { WorkspaceWrapper } from 'src/libs/workspace-utils';
+import { CloudProvider, WorkspaceWrapper } from 'src/libs/workspace-utils';
 import { asMockedFn, renderWithAppContexts as render, SelectHelper } from 'src/testing/test-utils';
 import { makeGoogleWorkspace } from 'src/testing/workspace-fixtures';
 
@@ -104,17 +104,44 @@ describe('ImportDataDestination', () => {
     {
       importRequest: { type: 'pfb', url: new URL('https://service.prod.anvil.gi.ucsc.edu/path/to/file.pfb') },
       requiredAuthorizationDomain: 'test-auth-domain',
-      expectedArgs: { isProtectedData: true, requiredAuthorizationDomain: 'test-auth-domain' },
+      expectedArgs: {
+        cloudPlatform: undefined,
+        isProtectedData: true,
+        requiredAuthorizationDomain: 'test-auth-domain',
+      },
     },
     {
       importRequest: { type: 'pfb', url: new URL('https://example.com/path/to/file.pfb') },
       requiredAuthorizationDomain: undefined,
-      expectedArgs: { isProtectedData: false, requiredAuthorizationDomain: undefined },
+      expectedArgs: { cloudPlatform: undefined, isProtectedData: false, requiredAuthorizationDomain: undefined },
+    },
+    {
+      importRequest: {
+        type: 'tdr-snapshot-export',
+        manifestUrl: new URL('https://example.com/path/to/manifest.json'),
+        snapshot: {
+          id: '00001111-2222-3333-aaaa-bbbbccccdddd',
+          name: 'test-snapshot',
+          source: [
+            {
+              dataset: {
+                id: '00001111-2222-3333-aaaa-bbbbccccdddd',
+                name: 'test-dataset',
+                secureMonitoringEnabled: false,
+              },
+            },
+          ],
+          cloudPlatform: 'gcp',
+        },
+        syncPermissions: false,
+      },
+      requiredAuthorizationDomain: undefined,
+      expectedArgs: { cloudPlatform: 'GCP', isProtectedData: false, requiredAuthorizationDomain: undefined },
     },
   ] as {
     importRequest: ImportRequest;
     requiredAuthorizationDomain?: string;
-    expectedArgs: { isProtectedData: boolean; requiredAuthorizationDomain?: string };
+    expectedArgs: { cloudPlatform?: CloudProvider; isProtectedData: boolean; requiredAuthorizationDomain?: string };
   }[])(
     'should filter workspaces through canImportIntoWorkspace',
     async ({ importRequest, requiredAuthorizationDomain, expectedArgs }) => {

--- a/src/import-data/ImportDataDestination.ts
+++ b/src/import-data/ImportDataDestination.ts
@@ -22,7 +22,7 @@ import * as Utils from 'src/libs/utils';
 import { WorkspaceInfo } from 'src/libs/workspace-utils';
 
 import { ImportRequest, TemplateWorkspaceInfo } from './import-types';
-import { canImportIntoWorkspace } from './import-utils';
+import { canImportIntoWorkspace, getCloudPlatformRequiredForImport } from './import-utils';
 import { isProtectedSource } from './protected-data-utils';
 
 const styles = {
@@ -105,6 +105,7 @@ export const ImportDataDestination = (props: ImportDataDestinationProps): ReactN
   } = props;
 
   const isProtectedData = isProtectedSource(importRequest);
+  const requiredCloudPlatform = getCloudPlatformRequiredForImport(importRequest);
 
   // Some import types are finished in a single request.
   // For most though, the import request starts a background task that takes time to complete.
@@ -163,6 +164,7 @@ export const ImportDataDestination = (props: ImportDataDestinationProps): ReactN
               workspaces: workspaces.filter((workspace) => {
                 return canImportIntoWorkspace(
                   {
+                    cloudPlatform: requiredCloudPlatform,
                     isProtectedData,
                     requiredAuthorizationDomain,
                   },

--- a/src/import-data/import-utils.test.ts
+++ b/src/import-data/import-utils.test.ts
@@ -1,7 +1,48 @@
-import { WorkspaceWrapper } from 'src/libs/workspace-utils';
+import { CloudProvider, WorkspaceWrapper } from 'src/libs/workspace-utils';
 import { makeAzureWorkspace, makeGoogleWorkspace } from 'src/testing/workspace-fixtures';
 
-import { canImportIntoWorkspace } from './import-utils';
+import { ImportRequest } from './import-types';
+import { canImportIntoWorkspace, getCloudPlatformRequiredForImport } from './import-utils';
+
+describe('getRequiredCloudPlatformForImport', () => {
+  it.each([
+    {
+      importRequest: { type: 'pfb', url: new URL('https://example.com/path/to/file.pfb') },
+      expectedCloudPlatfrom: undefined,
+    },
+    {
+      importRequest: {
+        type: 'tdr-snapshot-export',
+        manifestUrl: new URL('https://example.com/path/to/manifest.json'),
+        snapshot: {
+          id: '00001111-2222-3333-aaaa-bbbbccccdddd',
+          name: 'test-snapshot',
+          source: [
+            {
+              dataset: {
+                id: '00001111-2222-3333-aaaa-bbbbccccdddd',
+                name: 'test-dataset',
+                secureMonitoringEnabled: false,
+              },
+            },
+          ],
+          cloudPlatform: 'gcp',
+        },
+        syncPermissions: false,
+      },
+      expectedCloudPlatform: 'GCP',
+    },
+  ] as {
+    importRequest: ImportRequest;
+    expectedCloudPlatform: CloudProvider | undefined;
+  }[])('returns cloud platform required for import', async ({ importRequest, expectedCloudPlatform }) => {
+    // Act
+    const cloudPlatform = getCloudPlatformRequiredForImport(importRequest);
+
+    // Assert
+    expect(cloudPlatform).toEqual(expectedCloudPlatform);
+  });
+});
 
 describe('canImportIntoWorkspace', () => {
   it('requires permission to write to the workspace', () => {
@@ -82,5 +123,31 @@ describe('canImportIntoWorkspace', () => {
     // Assert
     expect(canImportDataWithRequiredAuthDomainIntoWorkspaceWithRequiredAuthDomain).toBe(true);
     expect(canImportDataWithRequiredAuthDomainIntoWorkspaceWithoutRequiredAuthDomain).toBe(false);
+  });
+
+  it('can require a cloud platform', () => {
+    // Arrange
+    const workspaces = [
+      makeAzureWorkspace({ workspace: { name: 'azure-workspace' } }),
+      makeGoogleWorkspace({ workspace: { name: 'google-workspace' } }),
+    ];
+
+    // Act
+    const workspacesForAzureImports = workspaces
+      .filter((workspace) => canImportIntoWorkspace({ cloudPlatform: 'AZURE', isProtectedData: false }, workspace))
+      .map((workspace) => workspace.workspace.name);
+
+    const workspacesForGoogleImports = workspaces
+      .filter((workspace) => canImportIntoWorkspace({ cloudPlatform: 'GCP', isProtectedData: false }, workspace))
+      .map((workspace) => workspace.workspace.name);
+
+    const workspacesForUndefinedPlatformImports = workspaces
+      .filter((workspace) => canImportIntoWorkspace({ isProtectedData: false }, workspace))
+      .map((workspace) => workspace.workspace.name);
+
+    // Assert
+    expect(workspacesForAzureImports).toEqual(['azure-workspace']);
+    expect(workspacesForGoogleImports).toEqual(['google-workspace']);
+    expect(workspacesForUndefinedPlatformImports).toEqual(['azure-workspace', 'google-workspace']);
   });
 });

--- a/src/import-data/import-utils.ts
+++ b/src/import-data/import-utils.ts
@@ -1,8 +1,27 @@
-import { canWrite, WorkspaceWrapper } from 'src/libs/workspace-utils';
+import { Snapshot } from 'src/libs/ajax/DataRepo';
+import { canWrite, CloudProvider, getCloudProviderFromWorkspace, WorkspaceWrapper } from 'src/libs/workspace-utils';
 
+import { ImportRequest } from './import-types';
 import { isProtectedWorkspace } from './protected-data-utils';
 
+export const getCloudPlatformRequiredForImport = (importRequest: ImportRequest): CloudProvider | undefined => {
+  switch (importRequest.type) {
+    case 'tdr-snapshot-export':
+    case 'tdr-snapshot-reference':
+      const tdrCloudPlatformToCloudProvider: Record<Snapshot['cloudPlatform'], CloudProvider> = {
+        azure: 'AZURE',
+        gcp: 'GCP',
+      };
+      return tdrCloudPlatformToCloudProvider[importRequest.snapshot.cloudPlatform];
+    default:
+      return undefined;
+  }
+};
+
 export type ImportOptions = {
+  /** Cloud platform required for the import. */
+  cloudPlatform?: CloudProvider;
+
   /** Is the source data protected. */
   isProtectedData: boolean;
 
@@ -14,15 +33,21 @@ export type ImportOptions = {
  * Can the user can import data into a workspace?
  *
  * @param importOptions
+ * @param importOptions.cloudPlatform - Cloud platform required for the import.
  * @param importOptions.isProtectedData - Is the source data protected.
  * @param importOptions.requiredAuthorizationDomain - Authorization domain required for the source data.
  * @param workspace - Candidate workspace.
  */
 export const canImportIntoWorkspace = (importOptions: ImportOptions, workspace: WorkspaceWrapper): boolean => {
-  const { isProtectedData, requiredAuthorizationDomain } = importOptions;
+  const { cloudPlatform, isProtectedData, requiredAuthorizationDomain } = importOptions;
 
   // The user must be able to write to the workspace to import data.
   if (!canWrite(workspace.accessLevel)) {
+    return false;
+  }
+
+  // If a cloud platform is required, the destination workspace must be on that cloud platform.
+  if (cloudPlatform && getCloudProviderFromWorkspace(workspace) !== cloudPlatform) {
     return false;
   }
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1310

Until the story for egress costs is figured out, we want to block imports of TDR snapshots across cloud platforms (GCP snapshot => Azure workspace, Azure snapshot => GCP workspace). This updates the UI to block cross-platform TDR imports, which matches the behavior of import service (https://github.com/broadinstitute/import-service/pull/145).