### PR TITLE
[AJ-1310] Show error for requests to import an Azure snapshot by reference

### DIFF
--- a/src/import-data/ImportData.test.ts
+++ b/src/import-data/ImportData.test.ts
@@ -444,16 +444,20 @@ describe('ImportData', () => {
   });
 
   it.each([
-    { queryParams: { format: 'pfb' } },
-    { queryParams: { format: 'tdrexport', snapshotId: '00001111-2222-3333-aaaa-bbbbccccdddd' } },
-  ] as { queryParams: Record<string, any> }[])(
+    { queryParams: { format: 'pfb' }, expectedErrorMessage: 'A URL is required' },
+    {
+      queryParams: { format: 'tdrexport', snapshotId: '00001111-2222-3333-aaaa-bbbbccccdddd' },
+      expectedErrorMessage: 'A manifest URL is required',
+    },
+  ] as { queryParams: Record<string, any>; expectedErrorMessage: string }[])(
     'renders an error message for invalid import requests',
-    async ({ queryParams }) => {
+    async ({ queryParams, expectedErrorMessage }) => {
       // Act
       await setup({ queryParams });
 
       // Assert
       screen.getByText('Invalid import request.');
+      screen.getByText(expectedErrorMessage);
     }
   );
 });

--- a/src/import-data/ImportData.ts
+++ b/src/import-data/ImportData.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp';
 import { Fragment, ReactNode, useState } from 'react';
-import { div, h } from 'react-hyperscript-helpers';
+import { div, h, h2 } from 'react-hyperscript-helpers';
 import { spinnerOverlay } from 'src/components/common';
 import { Ajax } from 'src/libs/ajax';
 import { resolveWdsUrl, WdsDataTableProvider } from 'src/libs/ajax/data-table-providers/WdsDataTableProvider';
@@ -225,7 +225,20 @@ export const ImportDataContainer = () => {
           fontWeight: 'bold',
         },
       },
-      ['Invalid import request.']
+      [
+        h2(
+          {
+            style: {
+              fontSize: 24,
+              fontWeight: 600,
+              color: colors.dark(),
+              margin: '0 0 1rem 0',
+            },
+          },
+          ['Invalid import request.']
+        ),
+        result.error.message,
+      ]
     );
   }
 

--- a/src/import-data/useImportRequest.test.ts
+++ b/src/import-data/useImportRequest.test.ts
@@ -273,6 +273,20 @@ describe('getImportRequest', () => {
         expect(importRequestPromise).rejects.toEqual(new Error('Unable to load snapshot.'));
       }
     );
+
+    it('rejects snapshot by reference imports for Azure snapshots', async () => {
+      // Act
+      const queryParams = {
+        format: 'snapshot',
+        snapshotId: azureSnapshotFixture.id,
+      };
+      const importRequest = getImportRequest(queryParams);
+
+      // Assert
+      await expect(importRequest).rejects.toEqual(
+        new Error('Importing by reference is not supported for Azure snapshots.')
+      );
+    });
   });
 
   describe('catalog snapshot imports', () => {

--- a/src/import-data/useImportRequest.ts
+++ b/src/import-data/useImportRequest.ts
@@ -103,6 +103,10 @@ const getTDRSnapshotReferenceImportRequest = async (
     throw new Error('Unable to load snapshot.');
   }
 
+  if (snapshot.cloudPlatform === 'azure') {
+    throw new Error('Importing by reference is not supported for Azure snapshots.');
+  }
+
   return {
     type: 'tdr-snapshot-reference',
     snapshot,


### PR DESCRIPTION
Imports by reference are not supported for Azure snapshots. This shows an error message if one is requested.

- https://github.com/DataBiosphere/terra-ui/pull/4332/commits/bbbe5775063c4b51e00739598240f5cbafc647c3 "prefactors" the tests.
- https://github.com/DataBiosphere/terra-ui/pull/4332/commits/b745c6f11308ed181acf0017206a85802d5bcd23 is the core change.
- https://github.com/DataBiosphere/terra-ui/pull/4332/commits/47fe04f691267af149484a6ce0c233c8b0c28f94 adds detail to the "invalid import" error message

![Screenshot 2023-10-10 at 12 17 36 PM](https://github.com/DataBiosphere/terra-ui/assets/1156625/8e00b343-4050-4759-85ad-dcf22ea002c7)
