### PR TITLE
[AJ-1310] Block cross-platform TDR imports into new workspaces

### DIFF
--- a/src/components/NewWorkspaceModal.js
+++ b/src/components/NewWorkspaceModal.js
@@ -63,7 +63,18 @@ const ariaInvalidBillingAccountMsg = (invalidBillingAccount) => {
 };
 const NewWorkspaceModal = withDisplayName(
   'NewWorkspaceModal',
-  ({ cloneWorkspace, onSuccess, onDismiss, customMessage, requiredAuthDomain, requireEnhancedBucketLogging, title, buttonText, workflowImport }) => {
+  ({
+    cloneWorkspace,
+    cloudPlatform,
+    onSuccess,
+    onDismiss,
+    customMessage,
+    requiredAuthDomain,
+    requireEnhancedBucketLogging,
+    title,
+    buttonText,
+    workflowImport,
+  }) => {
     // State
     const [billingProjects, setBillingProjects] = useState();
     const [azureBillingProjectsExist, setAzureBillingProjectsExist] = useState(false);
@@ -303,7 +314,7 @@ const NewWorkspaceModal = withDisplayName(
                           value: projectName,
                           isDisabled: invalidBillingAccount,
                         }),
-                        _.sortBy('projectName', _.uniq(billingProjects))
+                        _.sortBy('projectName', _.uniq(cloudPlatform ? _.filter({ cloudPlatform }, billingProjects) : billingProjects))
                       ),
                     }),
                   ]),

--- a/src/import-data/ImportDataDestination.ts
+++ b/src/import-data/ImportDataDestination.ts
@@ -320,6 +320,7 @@ export const ImportDataDestination = (props: ImportDataDestinationProps): ReactN
             isCreateOpen &&
               h(NewWorkspaceModal, {
                 requiredAuthDomain: requiredAuthorizationDomain,
+                cloudPlatform: getCloudPlatformRequiredForImport(importRequest),
                 customMessage: importMayTakeTime && importMayTakeTimeMessage,
                 requireEnhancedBucketLogging: isProtectedData,
                 onDismiss: () => setIsCreateOpen(false),


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1310

#4329 blocked cross-cloud platform TDR imports into existing workspace. This does the same for new workspaces. It passes the cloud platform required for the import (only TDR snapshot imports require a specific cloud platform) to NewWorkspaceModal, which filters the billing projects options by cloud platform.