### PR TITLE
[UIE-128] Move kvArrayToObject out of libs/utils

### DIFF
--- a/src/libs/ajax/User.test.ts
+++ b/src/libs/ajax/User.test.ts
@@ -1,0 +1,38 @@
+import { kvArrayToObject } from './User';
+
+// Workaround for circular import issues.
+jest.mock('src/libs/auth');
+
+describe('kvArrayToObject', () => {
+  it('converts an array of key/value objects to an object', () => {
+    // Act
+    const result = kvArrayToObject([
+      { key: 'foo', value: 1 },
+      { key: 'bar', value: 2 },
+      { key: 'baz', value: 3 },
+    ]);
+
+    // Assert
+    expect(result).toEqual({
+      foo: 1,
+      bar: 2,
+      baz: 3,
+    });
+  });
+
+  it('handles empty arrays', () => {
+    // Act
+    const result = kvArrayToObject([]);
+
+    // Assert
+    expect(result).toEqual({});
+  });
+
+  it('handles undefined input', () => {
+    // Act
+    const result = kvArrayToObject(undefined);
+
+    // Assert
+    expect(result).toEqual({});
+  });
+});

--- a/src/libs/ajax/User.ts
+++ b/src/libs/ajax/User.ts
@@ -88,7 +88,13 @@ export const makeSetUserProfileRequest = (terraUserProfile: TerraUserProfile): S
   };
 };
 
-export const kvArrayToObject = _.reduce((acc, { key, value }) => _.set(key, value, acc) as any, {});
+/**
+ * Orchestration's /register/profile endpoint returns profile attributes as an
+ * array of { key, value } objects. This converts that array into single object.
+ */
+export const kvArrayToObject = (kvArray: { key: string; value: any }[] | undefined): Record<string, any> => {
+  return Object.fromEntries((kvArray || []).map(({ key, value }) => [key, value]));
+};
 
 export interface OrchestrationUserPreferLegacyFireCloudResponse {
   preferTerra: boolean;

--- a/src/libs/ajax/User.ts
+++ b/src/libs/ajax/User.ts
@@ -88,6 +88,8 @@ export const makeSetUserProfileRequest = (terraUserProfile: TerraUserProfile): S
   };
 };
 
+export const kvArrayToObject = _.reduce((acc, { key, value }) => _.set(key, value, acc) as any, {});
+
 export interface OrchestrationUserPreferLegacyFireCloudResponse {
   preferTerra: boolean;
   preferTerraLastUpdated: number;
@@ -148,7 +150,7 @@ export const User = (signal?: AbortSignal) => {
       get: async (): Promise<TerraUserProfile> => {
         const res = await fetchOrchestration('register/profile', _.merge(authOpts(), { signal }));
         const rawResponseJson: OrchestrationUserProfileResponse = await res.json();
-        return Utils.kvArrayToObject(rawResponseJson.keyValuePairs) as TerraUserProfile;
+        return kvArrayToObject(rawResponseJson.keyValuePairs) as TerraUserProfile;
       },
 
       // We are not calling Thurloe directly because free credits logic was in orchestration

--- a/src/libs/ajax/User.ts
+++ b/src/libs/ajax/User.ts
@@ -93,7 +93,7 @@ export const makeSetUserProfileRequest = (terraUserProfile: TerraUserProfile): S
  * array of { key, value } objects. This converts that array into single object.
  */
 export const kvArrayToObject = (kvArray: { key: string; value: any }[] | undefined): Record<string, any> => {
-  return Object.fromEntries((kvArray || []).map(({ key, value }) => [key, value]));
+  return Object.fromEntries((kvArray ?? []).map(({ key, value }) => [key, value]));
 };
 
 export interface OrchestrationUserPreferLegacyFireCloudResponse {

--- a/src/libs/utils.test.ts
+++ b/src/libs/utils.test.ts
@@ -1,4 +1,4 @@
-import { differenceFromDatesInSeconds, differenceFromNowInSeconds, kvArrayToObject, textMatch } from 'src/libs/utils';
+import { differenceFromDatesInSeconds, differenceFromNowInSeconds, textMatch } from 'src/libs/utils';
 
 beforeAll(() => {
   jest.useFakeTimers();
@@ -47,39 +47,5 @@ describe('textMatch', () => {
     // Act
     const doesMatch = textMatch(needle, haystack);
     expect(doesMatch).toBe(result);
-  });
-});
-
-describe('kvArrayToObject', () => {
-  it('converts an array of key/value objects to an object', () => {
-    // Act
-    const result = kvArrayToObject([
-      { key: 'foo', value: 1 },
-      { key: 'bar', value: 2 },
-      { key: 'baz', value: 3 },
-    ]);
-
-    // Assert
-    expect(result).toEqual({
-      foo: 1,
-      bar: 2,
-      baz: 3,
-    });
-  });
-
-  it('handles empty arrays', () => {
-    // Act
-    const result = kvArrayToObject([]);
-
-    // Assert
-    expect(result).toEqual({});
-  });
-
-  it('handles undefined input', () => {
-    // Act
-    const result = kvArrayToObject(undefined);
-
-    // Assert
-    expect(result).toEqual({});
   });
 });

--- a/src/libs/utils.test.ts
+++ b/src/libs/utils.test.ts
@@ -1,4 +1,4 @@
-import { differenceFromDatesInSeconds, differenceFromNowInSeconds, textMatch } from 'src/libs/utils';
+import { differenceFromDatesInSeconds, differenceFromNowInSeconds, kvArrayToObject, textMatch } from 'src/libs/utils';
 
 beforeAll(() => {
   jest.useFakeTimers();
@@ -47,5 +47,39 @@ describe('textMatch', () => {
     // Act
     const doesMatch = textMatch(needle, haystack);
     expect(doesMatch).toBe(result);
+  });
+});
+
+describe('kvArrayToObject', () => {
+  it('converts an array of key/value objects to an object', () => {
+    // Act
+    const result = kvArrayToObject([
+      { key: 'foo', value: 1 },
+      { key: 'bar', value: 2 },
+      { key: 'baz', value: 3 },
+    ]);
+
+    // Assert
+    expect(result).toEqual({
+      foo: 1,
+      bar: 2,
+      baz: 3,
+    });
+  });
+
+  it('handles empty arrays', () => {
+    // Act
+    const result = kvArrayToObject([]);
+
+    // Assert
+    expect(result).toEqual({});
+  });
+
+  it('handles undefined input', () => {
+    // Act
+    const result = kvArrayToObject(undefined);
+
+    // Assert
+    expect(result).toEqual({});
   });
 });

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -155,9 +155,6 @@ export const convertValue = _.curry((type, value) => {
  */
 export const normalizeLabel = _.flow(_.camelCase, _.startCase);
 
-// TODO: add good typing (remove any's) - ticket: https://broadworkbench.atlassian.net/browse/UIE-67
-export const kvArrayToObject = _.reduce((acc, { key, value }) => _.set(key, value, acc) as any, {});
-
 export const append = _.curry((value, arr) => _.concat(arr, [value]));
 
 const withBusyStateFn =


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/UIE-128

Continuing to break up libs/utils...

`kvArrayToObject` is used in one place (src/libs/ajax/User.ts). Thus, that module is a more appropriate place for it than src/libs/utils. This moves it and rewrites it to use vanilla JS instead of Lodash.