### PR TITLE
[UIE-128] Move snapshotReferenceMissingError out of libs/utils

### DIFF
--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -91,11 +91,6 @@ export const abandonedPromise = () => {
   return new Promise(() => {});
 };
 
-// Returns a message explaining that the desired snapshot reference could not be found by name
-export const snapshotReferenceMissingError = (snapshotReferenceName) => {
-  return `The requested snapshot reference '${snapshotReferenceName}' could not be found in this workspace.`;
-};
-
 export const textMatch = safeCurry((needle: string, haystack: string): boolean => {
   return haystack.toLowerCase().includes(needle.toLowerCase());
 }) as (needle: string, haystack: string) => boolean;

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -906,12 +906,16 @@ const WorkflowView = _.flow(
                       div({ style: { height: '2rem', fontWeight: 'bold' } }, ['Step 1']),
                       label(['Select root entity type:']),
                       snapshotReferenceError &&
-                        h(TooltipTrigger, { content: Utils.snapshotReferenceMissingError(modifiedConfig.dataReferenceName) }, [
-                          icon('error-standard', {
-                            size: 14,
-                            style: { marginLeft: '0.5rem', color: colors.warning(), cursor: 'help' },
-                          }),
-                        ]),
+                        h(
+                          TooltipTrigger,
+                          { content: `The requested snapshot reference '${modifiedConfig.dataReferenceName}' could not be found in this workspace.` },
+                          [
+                            icon('error-standard', {
+                              size: 14,
+                              style: { marginLeft: '0.5rem', color: colors.warning(), cursor: 'help' },
+                            }),
+                          ]
+                        ),
                       h(GroupedSelect, {
                         'aria-label': 'Entity type selector',
                         isClearable: false,


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/UIE-128

Continuing to split up libs/utils.

`snapshotReferenceMissingError` is used in one place. Thus, it doesn't need to be in libs/utils. This PR inlines it into WorkflowView.