### PR TITLE
Add migrate buttons (WOR-1262).

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -144,11 +144,21 @@ const Workspaces = (signal) => ({
       delete: () => {
         return fetchRawls(root, _.merge(authOpts(), { signal, method: 'DELETE' }));
       },
+
+      migrateWorkspace: async () => {
+        const response = await fetchRawls(`${root}/bucketMigration`, _.merge(authOpts(), { signal, method: 'POST' }));
+        return response.json();
+      },
     };
   },
 
-  bucketMigration: async () => {
+  bucketMigrationInfo: async () => {
     const response = await fetchRawls('workspaces/v2/bucketMigration', _.merge(authOpts(), { signal }));
+    return response.json();
+  },
+
+  startBatchBucketMigration: async (body) => {
+    const response = await fetchRawls('workspaces/v2/bucketMigration', _.mergeAll([authOpts(), jsonBody(body), { signal, method: 'POST' }]));
     return response.json();
   },
 

--- a/src/pages/workspaces/migration/BillingProjectList.test.ts
+++ b/src/pages/workspaces/migration/BillingProjectList.test.ts
@@ -1,11 +1,11 @@
-import { act, render, screen, within } from '@testing-library/react';
+import { act, screen, within } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import { h } from 'react-hyperscript-helpers';
 import { Ajax } from 'src/libs/ajax';
 import { abandonedPromise } from 'src/libs/utils';
 import { BillingProjectList } from 'src/pages/workspaces/migration/BillingProjectList';
 import { mockServerData } from 'src/pages/workspaces/migration/migration-utils.test';
-import { asMockedFn } from 'src/testing/test-utils';
+import { asMockedFn, renderWithAppContexts as render } from 'src/testing/test-utils';
 
 type AjaxContract = ReturnType<typeof Ajax>;
 type AjaxWorkspacesContract = AjaxContract['Workspaces'];

--- a/src/pages/workspaces/migration/BillingProjectList.test.ts
+++ b/src/pages/workspaces/migration/BillingProjectList.test.ts
@@ -15,7 +15,7 @@ describe('BillingProjectList', () => {
   it('shows a loading indicator', async () => {
     // Arrange
     const mockWorkspaces: Partial<AjaxWorkspacesContract> = {
-      bucketMigration: jest.fn().mockReturnValue(abandonedPromise()),
+      bucketMigrationInfo: jest.fn().mockReturnValue(abandonedPromise()),
     };
     const mockAjax: Partial<AjaxContract> = {
       Workspaces: mockWorkspaces as AjaxWorkspacesContract,
@@ -32,7 +32,7 @@ describe('BillingProjectList', () => {
   it('shows a message if there are no workspaces to migrate', async () => {
     // Arrange
     const mockWorkspaces: Partial<AjaxWorkspacesContract> = {
-      bucketMigration: jest.fn().mockResolvedValue({}),
+      bucketMigrationInfo: jest.fn().mockResolvedValue({}),
     };
     const mockAjax: Partial<AjaxContract> = {
       Workspaces: mockWorkspaces as AjaxWorkspacesContract,
@@ -50,7 +50,7 @@ describe('BillingProjectList', () => {
   it('shows the list of billing projects with workspaces, and has no accessibility errors', async () => {
     // Arrange
     const mockWorkspaces: Partial<AjaxWorkspacesContract> = {
-      bucketMigration: jest.fn().mockResolvedValue(mockServerData),
+      bucketMigrationInfo: jest.fn().mockResolvedValue(mockServerData),
     };
     const mockAjax: Partial<AjaxContract> = {
       Workspaces: mockWorkspaces as AjaxWorkspacesContract,

--- a/src/pages/workspaces/migration/BillingProjectList.ts
+++ b/src/pages/workspaces/migration/BillingProjectList.ts
@@ -21,7 +21,7 @@ export const BillingProjectList = (): ReactNode => {
       reportErrorAndRethrow('Error loading workspace migration information'),
       Utils.withBusyState(setLoadingMigrationInformation)
     )(async () => {
-      const migrationResponse = await Ajax(signal).Workspaces.bucketMigration();
+      const migrationResponse = await Ajax(signal).Workspaces.bucketMigrationInfo();
       setBillingProjectWorkspaces(parseServerResponse(migrationResponse));
     });
     loadWorkspaces();

--- a/src/pages/workspaces/migration/BillingProjectParent.test.ts
+++ b/src/pages/workspaces/migration/BillingProjectParent.test.ts
@@ -1,0 +1,79 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+import { div, h } from 'react-hyperscript-helpers';
+import { Ajax } from 'src/libs/ajax';
+import { BillingProjectParent } from 'src/pages/workspaces/migration/BillingProjectParent';
+import { WorkspaceMigrationInfo } from 'src/pages/workspaces/migration/migration-utils';
+import { bpWithSucceededAndUnscheduled } from 'src/pages/workspaces/migration/migration-utils.test';
+import { asMockedFn, renderWithAppContexts as render } from 'src/testing/test-utils';
+
+type AjaxContract = ReturnType<typeof Ajax>;
+type AjaxWorkspacesContract = AjaxContract['Workspaces'];
+jest.mock('src/libs/ajax');
+
+describe('BillingProjectParent', () => {
+  it('shows migrate all button if all workspaces are unscheduled, with no accessibility errors', async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const twoUnscheduledMigrationInfo: WorkspaceMigrationInfo[] = [
+      { migrationStep: 'Unscheduled', name: 'notmigrated1', namespace: 'CARBilling-2' },
+      { migrationStep: 'Unscheduled', name: 'notmigrated2', namespace: 'CARBilling-2' },
+    ];
+    const mockStartBatchBucketMigration = jest.fn().mockResolvedValue({});
+    const mockWorkspaces: Partial<AjaxWorkspacesContract> = {
+      startBatchBucketMigration: mockStartBatchBucketMigration,
+    };
+    const mockAjax: Partial<AjaxContract> = {
+      Workspaces: mockWorkspaces as AjaxWorkspacesContract,
+    };
+    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+
+    // Act
+    const { container } = render(
+      div({ role: 'list' }, [
+        h(BillingProjectParent, {
+          billingProjectMigrationInfo: {
+            namespace: 'CARBilling-2',
+            workspaces: twoUnscheduledMigrationInfo,
+          },
+        }),
+      ])
+    );
+
+    // Assert
+    const migrateButton = screen.getByText('Migrate all workspaces');
+    await user.click(migrateButton);
+    expect(mockStartBatchBucketMigration).toHaveBeenCalledWith([
+      { name: 'notmigrated1', namespace: 'CARBilling-2' },
+      { name: 'notmigrated2', namespace: 'CARBilling-2' },
+    ]);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('shows migrate remaining button if some workspaces are unscheduled', async () => {
+    // Arrange
+    const user = userEvent.setup();
+
+    const mockStartBatchBucketMigration = jest.fn().mockResolvedValue({});
+    const mockWorkspaces: Partial<AjaxWorkspacesContract> = {
+      startBatchBucketMigration: mockStartBatchBucketMigration,
+    };
+    const mockAjax: Partial<AjaxContract> = {
+      Workspaces: mockWorkspaces as AjaxWorkspacesContract,
+    };
+    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+
+    // Act
+    render(
+      h(BillingProjectParent, {
+        billingProjectMigrationInfo: bpWithSucceededAndUnscheduled,
+      })
+    );
+
+    // Assert
+    const migrateButton = screen.getByText('Migrate remaining workspaces');
+    await user.click(migrateButton);
+    expect(mockStartBatchBucketMigration).toHaveBeenCalledWith([{ name: 'notmigrated', namespace: 'CARBilling-2' }]);
+  });
+});

--- a/src/pages/workspaces/migration/BillingProjectParent.ts
+++ b/src/pages/workspaces/migration/BillingProjectParent.ts
@@ -1,3 +1,4 @@
+import { cond, DEFAULT } from '@terra-ui-packages/core-utils';
 import _ from 'lodash/fp';
 import pluralize from 'pluralize';
 import { ReactNode, useState } from 'react';
@@ -7,7 +8,6 @@ import { ButtonOutline } from 'src/components/common';
 import { Ajax } from 'src/libs/ajax';
 import colors from 'src/libs/colors';
 import { reportErrorAndRethrow } from 'src/libs/error';
-import * as Utils from 'src/libs/utils';
 import {
   BillingProjectMigrationInfo,
   errorIcon,
@@ -41,7 +41,7 @@ export const BillingProjectParent = (props: BillingProjectParentProps): ReactNod
   };
 
   const renderMigrationSummary = () => {
-    return Utils.cond(
+    return cond(
       [
         migrationStats.workspaceCount === migrationStats.succeeded,
         () =>
@@ -67,7 +67,7 @@ export const BillingProjectParent = (props: BillingProjectParentProps): ReactNod
           ]),
       ],
       [
-        Utils.DEFAULT,
+        DEFAULT,
         () =>
           span({ style: { paddingRight: '0.5rem' } }, [
             migrationStats.succeeded > 0 && `${pluralize('Workspace', migrationStats.succeeded, true)} Migrated`,

--- a/src/pages/workspaces/migration/BillingProjectParent.ts
+++ b/src/pages/workspaces/migration/BillingProjectParent.ts
@@ -10,7 +10,6 @@ import { reportErrorAndRethrow } from 'src/libs/error';
 import * as Utils from 'src/libs/utils';
 import {
   BillingProjectMigrationInfo,
-  BillingProjectMigrationStats,
   errorIcon,
   getBillingProjectMigrationStats,
   inProgressIcon,
@@ -24,11 +23,10 @@ interface BillingProjectParentProps {
 }
 
 export const BillingProjectParent = (props: BillingProjectParentProps): ReactNode => {
-  const [migrationStats, setMigrationStats] = useState<BillingProjectMigrationStats>();
   const [migrateStarted, setMigrateStarted] = useState<boolean>(false);
 
-  useMemo(() => {
-    setMigrationStats(getBillingProjectMigrationStats(props.billingProjectMigrationInfo));
+  const migrationStats = useMemo(() => {
+    return getBillingProjectMigrationStats(props.billingProjectMigrationInfo);
   }, [props.billingProjectMigrationInfo]);
 
   const renderErrorSummary = () => {

--- a/src/pages/workspaces/migration/BillingProjectParent.ts
+++ b/src/pages/workspaces/migration/BillingProjectParent.ts
@@ -30,12 +30,12 @@ export const BillingProjectParent = (props: BillingProjectParentProps): ReactNod
   }, [props.billingProjectMigrationInfo]);
 
   const renderErrorSummary = () => {
-    return migrationStats?.errored === 0
+    return migrationStats.errored === 0
       ? ''
       : span({ style: { paddingLeft: '0.5rem', paddingRight: '0.5rem' } }, [
           errorIcon,
           span({ style: { paddingLeft: '0.5rem', color: colors.danger() } }, [
-            `${pluralize('Migration', migrationStats?.errored, true)} Failed`,
+            `${pluralize('Migration', migrationStats.errored, true)} Failed`,
           ]),
         ]);
   };
@@ -43,23 +43,23 @@ export const BillingProjectParent = (props: BillingProjectParentProps): ReactNod
   const renderMigrationSummary = () => {
     return Utils.cond(
       [
-        migrationStats?.workspaceCount === migrationStats?.succeeded,
+        migrationStats.workspaceCount === migrationStats.succeeded,
         () =>
           span({}, [
             successIcon,
             span({ style: { paddingLeft: '0.5rem', paddingRight: '0.5rem' } }, [
-              `All ${pluralize('Workspace', migrationStats?.workspaceCount, true)} Migrated`,
+              `All ${pluralize('Workspace', migrationStats.workspaceCount, true)} Migrated`,
             ]),
           ]),
       ],
       [
-        !!migrationStats?.inProgress,
+        !!migrationStats.inProgress,
         () =>
           span({}, [
             inProgressIcon,
             span({ style: { paddingLeft: '0.5rem', paddingRight: '0.5rem' } }, [
-              `${pluralize('Workspace', migrationStats?.inProgress, true)} Migrating`,
-              !!migrationStats?.errored && ', ',
+              `${pluralize('Workspace', migrationStats.inProgress, true)} Migrating`,
+              !!migrationStats.errored && ', ',
               renderErrorSummary(),
             ]),
           ]),
@@ -68,8 +68,8 @@ export const BillingProjectParent = (props: BillingProjectParentProps): ReactNod
         Utils.DEFAULT,
         () =>
           span({ style: { paddingRight: '0.5rem' } }, [
-            !!migrationStats?.succeeded && `${pluralize('Workspace', migrationStats?.succeeded, true)} Migrated`,
-            !!migrationStats?.succeeded && !!migrationStats?.errored && ', ',
+            !!migrationStats.succeeded && `${pluralize('Workspace', migrationStats.succeeded, true)} Migrated`,
+            !!migrationStats.succeeded && !!migrationStats.errored && ', ',
             renderErrorSummary(),
           ]),
       ]
@@ -94,7 +94,7 @@ export const BillingProjectParent = (props: BillingProjectParentProps): ReactNod
           { style: { display: 'flex', marginLeft: 'auto', alignItems: 'center', fontWeight: 'normal' } },
           [
             div({ style: {} }, [renderMigrationSummary()]),
-            !!migrationStats?.unscheduled &&
+            !!migrationStats.unscheduled &&
               h(
                 ButtonOutline,
                 {
@@ -117,7 +117,7 @@ export const BillingProjectParent = (props: BillingProjectParentProps): ReactNod
                   },
                 },
                 [
-                  migrationStats?.workspaceCount === migrationStats?.unscheduled
+                  migrationStats.workspaceCount === migrationStats.unscheduled
                     ? 'Migrate all workspaces'
                     : 'Migrate remaining workspaces',
                 ]

--- a/src/pages/workspaces/migration/BillingProjectParent.ts
+++ b/src/pages/workspaces/migration/BillingProjectParent.ts
@@ -1,21 +1,88 @@
 import _ from 'lodash/fp';
-import { ReactNode } from 'react';
-import { div, h } from 'react-hyperscript-helpers';
+import pluralize from 'pluralize';
+import { ReactNode, useState } from 'react';
+import { div, h, span } from 'react-hyperscript-helpers';
 import Collapse from 'src/components/Collapse';
+import { ButtonOutline } from 'src/components/common';
+import { Ajax } from 'src/libs/ajax';
 import colors from 'src/libs/colors';
-import { BillingProjectMigrationInfo } from 'src/pages/workspaces/migration/migration-utils';
+import { reportErrorAndRethrow } from 'src/libs/error';
+import * as Utils from 'src/libs/utils';
+import {
+  BillingProjectMigrationInfo,
+  BillingProjectMigrationStats,
+  errorIcon,
+  getBillingProjectMigrationStats,
+  inProgressIcon,
+  successIcon,
+} from 'src/pages/workspaces/migration/migration-utils';
 import { WorkspaceItem } from 'src/pages/workspaces/migration/WorkspaceItem';
+import { useMemo } from 'use-memo-one';
 
 interface BillingProjectParentProps {
   billingProjectMigrationInfo: BillingProjectMigrationInfo;
 }
 
 export const BillingProjectParent = (props: BillingProjectParentProps): ReactNode => {
+  const [migrationStats, setMigrationStats] = useState<BillingProjectMigrationStats>();
+  const [migrateStarted, setMigrateStarted] = useState<boolean>(false);
+
+  useMemo(() => {
+    setMigrationStats(getBillingProjectMigrationStats(props.billingProjectMigrationInfo));
+  }, [props.billingProjectMigrationInfo]);
+
+  const renderErrorSummary = () => {
+    return migrationStats?.errored === 0
+      ? ''
+      : span({ style: { paddingLeft: '0.5rem', paddingRight: '0.5rem' } }, [
+          errorIcon,
+          span({ style: { paddingLeft: '0.5rem', color: colors.danger() } }, [
+            `${pluralize('Migration', migrationStats?.errored, true)} Failed`,
+          ]),
+        ]);
+  };
+
+  const renderMigrationSummary = () => {
+    return Utils.cond(
+      [
+        migrationStats?.workspaceCount === migrationStats?.succeeded,
+        () =>
+          span({}, [
+            successIcon,
+            span({ style: { paddingLeft: '0.5rem', paddingRight: '0.5rem' } }, [
+              `All ${pluralize('Workspace', migrationStats?.workspaceCount, true)} Migrated`,
+            ]),
+          ]),
+      ],
+      [
+        !!migrationStats?.inProgress,
+        () =>
+          span({}, [
+            inProgressIcon,
+            span({ style: { paddingLeft: '0.5rem', paddingRight: '0.5rem' } }, [
+              `${pluralize('Workspace', migrationStats?.inProgress, true)} Migrating`,
+              !!migrationStats?.errored && ', ',
+              renderErrorSummary(),
+            ]),
+          ]),
+      ],
+      [
+        Utils.DEFAULT,
+        () =>
+          span({ style: { paddingRight: '0.5rem' } }, [
+            !!migrationStats?.succeeded && `${pluralize('Workspace', migrationStats?.succeeded, true)} Migrated`,
+            !!migrationStats?.succeeded && !!migrationStats?.errored && ', ',
+            renderErrorSummary(),
+          ]),
+      ]
+    );
+  };
+
   return div({ role: 'listitem' }, [
     h(
       Collapse,
       {
-        summaryStyle: { height: 60, padding: '1.5rem', fontWeight: 600 },
+        summaryStyle: { height: 60, paddingLeft: '1.5rem', paddingRight: '1.5rem', fontWeight: 600, display: 'flex' },
         titleFirst: true,
         style: {
           fontSize: 14,
@@ -24,7 +91,41 @@ export const BillingProjectParent = (props: BillingProjectParentProps): ReactNod
           borderRadius: 5,
           background: 'white',
         },
-        title: div({}, [props.billingProjectMigrationInfo.namespace]),
+        title: div({ style: {} }, [props.billingProjectMigrationInfo.namespace]),
+        afterTitle: div(
+          { style: { display: 'flex', marginLeft: 'auto', alignItems: 'center', fontWeight: 'normal' } },
+          [
+            div({ style: {} }, [renderMigrationSummary()]),
+            !!migrationStats?.unscheduled &&
+              h(
+                ButtonOutline,
+                {
+                  disabled: migrateStarted,
+                  tooltip: migrateStarted ? 'Migration has been scheduled' : '',
+                  onClick: () => {
+                    const migrateWorkspace = reportErrorAndRethrow('Error starting migration', async () => {
+                      const workspacesToMigrate: { namespace: string; name: string }[] = [];
+                      props.billingProjectMigrationInfo.workspaces.forEach((workspace) => {
+                        if (workspace.migrationStep === 'Unscheduled') {
+                          workspacesToMigrate.push({ namespace: workspace.namespace, name: workspace.name });
+                        }
+                      });
+                      if (workspacesToMigrate.length > 0) {
+                        setMigrateStarted(true);
+                        await Ajax().Workspaces.startBatchBucketMigration(workspacesToMigrate);
+                      }
+                    });
+                    migrateWorkspace();
+                  },
+                },
+                [
+                  migrationStats?.workspaceCount === migrationStats?.unscheduled
+                    ? 'Migrate all workspaces'
+                    : 'Migrate remaining workspaces',
+                ]
+              ),
+          ]
+        ),
         initialOpenState: true,
       },
       _.map(

--- a/src/pages/workspaces/migration/BillingProjectParent.ts
+++ b/src/pages/workspaces/migration/BillingProjectParent.ts
@@ -48,18 +48,20 @@ export const BillingProjectParent = (props: BillingProjectParentProps): ReactNod
           span({}, [
             successIcon,
             span({ style: { paddingLeft: '0.5rem', paddingRight: '0.5rem' } }, [
-              `All ${pluralize('Workspace', migrationStats.workspaceCount, true)} Migrated`,
+              migrationStats.workspaceCount === 1
+                ? '1 Workspace Migrated'
+                : `All ${migrationStats.workspaceCount} Workspaces Migrated`,
             ]),
           ]),
       ],
       [
-        !!migrationStats.inProgress,
+        migrationStats.inProgress > 0,
         () =>
           span({}, [
             inProgressIcon,
             span({ style: { paddingLeft: '0.5rem', paddingRight: '0.5rem' } }, [
               `${pluralize('Workspace', migrationStats.inProgress, true)} Migrating`,
-              !!migrationStats.errored && ', ',
+              migrationStats.errored > 0 && ', ',
               renderErrorSummary(),
             ]),
           ]),
@@ -68,8 +70,8 @@ export const BillingProjectParent = (props: BillingProjectParentProps): ReactNod
         Utils.DEFAULT,
         () =>
           span({ style: { paddingRight: '0.5rem' } }, [
-            !!migrationStats.succeeded && `${pluralize('Workspace', migrationStats.succeeded, true)} Migrated`,
-            !!migrationStats.succeeded && !!migrationStats.errored && ', ',
+            migrationStats.succeeded > 0 && `${pluralize('Workspace', migrationStats.succeeded, true)} Migrated`,
+            migrationStats.succeeded > 0 && migrationStats.errored > 0 && ', ',
             renderErrorSummary(),
           ]),
       ]
@@ -94,7 +96,7 @@ export const BillingProjectParent = (props: BillingProjectParentProps): ReactNod
           { style: { display: 'flex', marginLeft: 'auto', alignItems: 'center', fontWeight: 'normal' } },
           [
             div({ style: {} }, [renderMigrationSummary()]),
-            !!migrationStats.unscheduled &&
+            migrationStats.unscheduled > 0 &&
               h(
                 ButtonOutline,
                 {

--- a/src/pages/workspaces/migration/WorkspaceItem.test.ts
+++ b/src/pages/workspaces/migration/WorkspaceItem.test.ts
@@ -19,6 +19,7 @@ describe('WorkspaceItem', () => {
     migrationStep: 'Unscheduled',
   };
   const migrateButtonText = `Migrate ${unscheduledWorkspace.name}`;
+  const migrationScheduledTooltipText = 'Migration has been scheduled';
   const mockGetBucketUsage = jest.fn();
 
   beforeEach(() => {
@@ -77,14 +78,16 @@ describe('WorkspaceItem', () => {
 
     // Act
     render(h(WorkspaceItem, { workspaceMigrationInfo: unscheduledWorkspace }));
+    expect(screen.queryByText(migrationScheduledTooltipText)).toBeNull();
+    await user.click(screen.getByLabelText(migrateButtonText));
 
     // Assert
-    const migrateButton = screen.getByLabelText(migrateButtonText);
-    await user.click(migrateButton);
     expect(mockMigrateWorkspace).toHaveBeenCalled();
+    expect(screen.getByLabelText(migrateButtonText).getAttribute('aria-disabled')).toBe('true');
+    await screen.findByText(migrationScheduledTooltipText);
   });
 
-  it('shows if the bucket size cannot be fetched for an unscheduled workspace', async () => {
+  it('shows if the bucket size cannot be fetched for an unscheduled workspace, and shows migrate button', async () => {
     // Arrange
     const mockErrorGetBucketUsage = jest.fn().mockRejectedValue(new Error('testing'));
     const mockWorkspaces: DeepPartial<AjaxWorkspacesContract> = {
@@ -106,7 +109,7 @@ describe('WorkspaceItem', () => {
     await screen.findByLabelText(migrateButtonText);
   });
 
-  it('shows completed workspace status and does not fetch bucket size', async () => {
+  it('shows completed workspace status and does not fetch bucket size, with no migrate button', async () => {
     // Arrange
     const completedWorkspace: WorkspaceMigrationInfo = {
       failureReason: undefined,

--- a/src/pages/workspaces/migration/WorkspaceItem.test.ts
+++ b/src/pages/workspaces/migration/WorkspaceItem.test.ts
@@ -18,6 +18,7 @@ describe('WorkspaceItem', () => {
     name: 'workspace name',
     migrationStep: 'Unscheduled',
   };
+  const migrateButtonText = `Migrate ${unscheduledWorkspace.name}`;
   const mockGetBucketUsage = jest.fn();
 
   beforeEach(() => {
@@ -57,6 +58,32 @@ describe('WorkspaceItem', () => {
     await screen.findByText('Bucket Size: 1.21 KiB');
   });
 
+  it('can start a migration for an unscheduled workspace', async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const mockMigrateWorkspace = jest.fn();
+    const mockWorkspaces: DeepPartial<AjaxWorkspacesContract> = {
+      workspace: () => ({
+        bucketUsage: jest.fn().mockResolvedValue({ usageInBytes: 1234 }),
+      }),
+      workspaceV2: () => ({
+        migrateWorkspace: mockMigrateWorkspace,
+      }),
+    };
+    const mockAjax: Partial<AjaxContract> = {
+      Workspaces: mockWorkspaces as AjaxWorkspacesContract,
+    };
+    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+
+    // Act
+    render(h(WorkspaceItem, { workspaceMigrationInfo: unscheduledWorkspace }));
+
+    // Assert
+    const migrateButton = screen.getByLabelText(migrateButtonText);
+    await user.click(migrateButton);
+    expect(mockMigrateWorkspace).toHaveBeenCalled();
+  });
+
   it('shows if the bucket size cannot be fetched for an unscheduled workspace', async () => {
     // Arrange
     const mockErrorGetBucketUsage = jest.fn().mockRejectedValue(new Error('testing'));
@@ -76,6 +103,7 @@ describe('WorkspaceItem', () => {
     // Assert
     await screen.findByText('workspace name');
     await screen.findByText('Unable to fetch Bucket Size');
+    await screen.findByLabelText(migrateButtonText);
   });
 
   it('shows completed workspace status and does not fetch bucket size', async () => {
@@ -107,9 +135,10 @@ describe('WorkspaceItem', () => {
     await screen.findByText('april29');
     await screen.findByText('Migration Complete');
     expect(mockGetBucketUsage).not.toHaveBeenCalled();
+    expect(screen.queryByText(migrateButtonText)).toBeNull();
   });
 
-  it('shows failed workspace status with no accessibility errors', async () => {
+  it('shows failed workspace status with no accessibility errors and no migrate button', async () => {
     // Arrange
     const user = userEvent.setup();
     const failedWorkspace: WorkspaceMigrationInfo = {
@@ -131,6 +160,7 @@ describe('WorkspaceItem', () => {
     await screen.findByText('testdata');
     await screen.findByText('Migration Failed');
     await screen.findByText('Bucket migration failure reason');
+    expect(screen.queryByText(migrateButtonText)).toBeNull();
     expect(mockGetBucketUsage).not.toHaveBeenCalled();
     expect(await axe(container)).toHaveNoViolations();
   });
@@ -142,7 +172,7 @@ describe('WorkspaceItem', () => {
     { migrationStep: 'FinishingUp' as MigrationStep, expectedStatus: 'Finishing Migration' },
     { migrationStep: 'Finished' as MigrationStep, expectedStatus: 'Finishing Migration' },
   ])(
-    'renders status for state "$migrationStep" with no accessibility errors',
+    'renders status for state "$migrationStep" with no accessibility errors and no migrate button',
     async ({ migrationStep, expectedStatus }) => {
       // Arrange
       const workspace: WorkspaceMigrationInfo = {
@@ -156,6 +186,7 @@ describe('WorkspaceItem', () => {
 
       // Assert
       await screen.findByText(expectedStatus);
+      expect(screen.queryByText(migrateButtonText)).toBeNull();
       expect(mockGetBucketUsage).not.toHaveBeenCalled();
       expect(await axe(container)).toHaveNoViolations();
     }

--- a/src/pages/workspaces/migration/migration-utils.test.ts
+++ b/src/pages/workspaces/migration/migration-utils.test.ts
@@ -1,4 +1,8 @@
-import { parseServerResponse } from 'src/pages/workspaces/migration/migration-utils';
+import {
+  BillingProjectMigrationInfo,
+  getBillingProjectMigrationStats,
+  parseServerResponse,
+} from 'src/pages/workspaces/migration/migration-utils';
 
 export const mockServerData = {
   'CARBilling-2/notmigrated': null,
@@ -42,78 +46,119 @@ export const mockServerData = {
   },
 };
 
+export const bpWithSucceededAndUnscheduled: BillingProjectMigrationInfo = {
+  namespace: 'CARBilling-2',
+  workspaces: [
+    {
+      failureReason: undefined,
+      finalBucketTransferProgress: {
+        bytesTransferred: 288912,
+        objectsTransferred: 561,
+        totalBytesToTransfer: 288912,
+        totalObjectsToTransfer: 561,
+      },
+      migrationStep: 'Finished',
+      name: 'april29',
+      namespace: 'CARBilling-2',
+      outcome: 'success',
+      tempBucketTransferProgress: {
+        bytesTransferred: 288912,
+        objectsTransferred: 561,
+        totalBytesToTransfer: 288912,
+        totalObjectsToTransfer: 561,
+      },
+    },
+    { migrationStep: 'Unscheduled', name: 'notmigrated', namespace: 'CARBilling-2' },
+  ],
+};
+
+export const bpWithFailed = {
+  namespace: 'CARBillingTest',
+  workspaces: [
+    {
+      failureReason:
+        'The bucket migration failed while removing workspace bucket IAM: invalid billing account on billing project.',
+      finalBucketTransferProgress: undefined,
+      migrationStep: 'Finished',
+      name: 'testdata',
+      namespace: 'CARBillingTest',
+      outcome: 'failure',
+      tempBucketTransferProgress: undefined,
+    },
+  ],
+};
+
+export const bpWithInProgress = {
+  namespace: 'general-dev-billing-account',
+  workspaces: [
+    {
+      failureReason: undefined,
+      finalBucketTransferProgress: {
+        bytesTransferred: 0,
+        objectsTransferred: 0,
+        totalBytesToTransfer: 0,
+        totalObjectsToTransfer: 0,
+      },
+      migrationStep: 'TransferringToTempBucket',
+      name: 'Christina test',
+      namespace: 'general-dev-billing-account',
+      outcome: undefined,
+      tempBucketTransferProgress: {
+        bytesTransferred: 1000,
+        objectsTransferred: 2,
+        totalBytesToTransfer: 2000,
+        totalObjectsToTransfer: 4,
+      },
+    },
+  ],
+};
+
+const billingProjectList = [bpWithSucceededAndUnscheduled, bpWithFailed, bpWithInProgress];
+
 describe('parseServerResponse', () => {
   it('Can handle an empty response', () => {
     expect(parseServerResponse({})).toEqual([]);
   });
 
   it('Transforms the server data to a list format', () => {
-    const billingProjectList = [
-      {
-        namespace: 'CARBilling-2',
-        workspaces: [
-          {
-            failureReason: undefined,
-            finalBucketTransferProgress: {
-              bytesTransferred: 288912,
-              objectsTransferred: 561,
-              totalBytesToTransfer: 288912,
-              totalObjectsToTransfer: 561,
-            },
-            migrationStep: 'Finished',
-            name: 'april29',
-            namespace: 'CARBilling-2',
-            outcome: 'success',
-            tempBucketTransferProgress: {
-              bytesTransferred: 288912,
-              objectsTransferred: 561,
-              totalBytesToTransfer: 288912,
-              totalObjectsToTransfer: 561,
-            },
-          },
-          { migrationStep: 'Unscheduled', name: 'notmigrated', namespace: 'CARBilling-2' },
-        ],
-      },
-      {
-        namespace: 'CARBillingTest',
-        workspaces: [
-          {
-            failureReason:
-              'The bucket migration failed while removing workspace bucket IAM: invalid billing account on billing project.',
-            finalBucketTransferProgress: undefined,
-            migrationStep: 'Finished',
-            name: 'testdata',
-            namespace: 'CARBillingTest',
-            outcome: 'failure',
-            tempBucketTransferProgress: undefined,
-          },
-        ],
-      },
-      {
-        namespace: 'general-dev-billing-account',
-        workspaces: [
-          {
-            failureReason: undefined,
-            finalBucketTransferProgress: {
-              bytesTransferred: 0,
-              objectsTransferred: 0,
-              totalBytesToTransfer: 0,
-              totalObjectsToTransfer: 0,
-            },
-            migrationStep: 'TransferringToTempBucket',
-            name: 'Christina test',
-            namespace: 'general-dev-billing-account',
-            outcome: undefined,
-            tempBucketTransferProgress: {
-              bytesTransferred: 1000,
-              objectsTransferred: 2,
-              totalBytesToTransfer: 2000,
-              totalObjectsToTransfer: 4,
-            },
-          },
-        ],
-      },
-    ];
     expect(parseServerResponse(mockServerData)).toEqual(billingProjectList);
+  });
+});
+
+describe('getBillingProjectMigrationStats', () => {
+  it('Can handle an empty workspace array', () => {
+    expect(getBillingProjectMigrationStats({ namespace: 'foo', workspaces: [] })).toEqual({
+      workspaceCount: 0,
+      unscheduled: 0,
+      errored: 0,
+      succeeded: 0,
+      inProgress: 0,
+    });
+  });
+
+  it('Can handle actual data', () => {
+    expect(getBillingProjectMigrationStats(bpWithSucceededAndUnscheduled as BillingProjectMigrationInfo)).toEqual({
+      workspaceCount: 2,
+      unscheduled: 1,
+      errored: 0,
+      succeeded: 1,
+      inProgress: 0,
+    });
+
+    expect(getBillingProjectMigrationStats(bpWithFailed as BillingProjectMigrationInfo)).toEqual({
+      workspaceCount: 1,
+      unscheduled: 0,
+      errored: 1,
+      succeeded: 0,
+      inProgress: 0,
+    });
+
+    expect(getBillingProjectMigrationStats(bpWithInProgress as BillingProjectMigrationInfo)).toEqual({
+      workspaceCount: 1,
+      unscheduled: 0,
+      errored: 0,
+      succeeded: 0,
+      inProgress: 1,
+    });
   });
 });

--- a/src/pages/workspaces/migration/migration-utils.test.ts
+++ b/src/pages/workspaces/migration/migration-utils.test.ts
@@ -123,6 +123,34 @@ describe('parseServerResponse', () => {
   it('Transforms the server data to a list format', () => {
     expect(parseServerResponse(mockServerData)).toEqual(billingProjectList);
   });
+
+  it('Can handle a non-jSON failure message', () => {
+    const alternateErrorFormat = {
+      'CARBillingTest/testdata': {
+        migrationStep: 'Finished' as const,
+        outcome: {
+          failure: 'io.grpc.StatusRuntimeException: NOT_FOUND: Service account',
+        },
+      },
+    };
+    const expected = [
+      {
+        namespace: 'CARBillingTest',
+        workspaces: [
+          {
+            failureReason: 'io.grpc.StatusRuntimeException: NOT_FOUND: Service account',
+            finalBucketTransferProgress: undefined,
+            migrationStep: 'Finished',
+            name: 'testdata',
+            namespace: 'CARBillingTest',
+            outcome: 'failure',
+            tempBucketTransferProgress: undefined,
+          },
+        ],
+      },
+    ];
+    expect(parseServerResponse(alternateErrorFormat)).toEqual(expected);
+  });
 });
 
 describe('getBillingProjectMigrationStats', () => {

--- a/src/pages/workspaces/migration/migration-utils.test.ts
+++ b/src/pages/workspaces/migration/migration-utils.test.ts
@@ -72,7 +72,7 @@ export const bpWithSucceededAndUnscheduled: BillingProjectMigrationInfo = {
   ],
 };
 
-export const bpWithFailed = {
+export const bpWithFailed: BillingProjectMigrationInfo = {
   namespace: 'CARBillingTest',
   workspaces: [
     {
@@ -88,7 +88,7 @@ export const bpWithFailed = {
   ],
 };
 
-export const bpWithInProgress = {
+export const bpWithInProgress: BillingProjectMigrationInfo = {
   namespace: 'general-dev-billing-account',
   workspaces: [
     {

--- a/src/pages/workspaces/migration/migration-utils.ts
+++ b/src/pages/workspaces/migration/migration-utils.ts
@@ -1,8 +1,29 @@
 import _ from 'lodash/fp';
+import { icon } from 'src/components/icons';
+import colors from 'src/libs/colors';
+import * as Utils from 'src/libs/utils';
 
 export type MigrationStep = ServerMigrationStep | 'Unscheduled';
 
 export type MigrationOutcome = 'success' | 'failure';
+
+export const errorIcon = icon('warning-standard', {
+  size: 18,
+  style: { color: colors.danger() },
+});
+
+export const successIcon = icon('check', {
+  size: 18,
+  style: { color: colors.success() },
+});
+
+export const inProgressIcon = icon('syncAlt', {
+  size: 18,
+  style: {
+    animation: 'rotation 2s infinite linear',
+    color: colors.success(),
+  },
+});
 
 interface TransferProgress {
   totalBytesToTransfer: number;
@@ -73,13 +94,24 @@ export const parseServerResponse = (
       if (status === null) {
         return { namespace, name, migrationStep: 'Unscheduled' };
       }
+      const getFailureMessage = () => {
+        let failureMessage;
+        if (_.isObject(status.outcome)) {
+          try {
+            failureMessage = JSON.parse(status.outcome.failure).message;
+          } catch {
+            failureMessage = status.outcome.failure;
+          }
+        }
+        return failureMessage;
+      };
 
       return {
         namespace,
         name,
         migrationStep: status.migrationStep ?? 'Unscheduled',
         outcome: status.outcome === 'success' ? 'success' : _.isObject(status.outcome) ? 'failure' : undefined,
-        failureReason: _.isObject(status.outcome) ? JSON.parse(status.outcome.failure).message : undefined,
+        failureReason: getFailureMessage(),
         tempBucketTransferProgress: status.tempBucketTransferProgress,
         finalBucketTransferProgress: status.finalBucketTransferProgress,
       };
@@ -87,4 +119,55 @@ export const parseServerResponse = (
     return { namespace, workspaces: expandedWorkspaces };
   }, sortedNamespaceKeys);
   return billingProjectWorkspaces;
+};
+
+export interface BillingProjectMigrationStats {
+  workspaceCount: number;
+  succeeded: number;
+  unscheduled: number;
+  errored: number;
+  inProgress: number;
+}
+
+export const getBillingProjectMigrationStats = (
+  billingProjectInfo: BillingProjectMigrationInfo
+): BillingProjectMigrationStats => {
+  const migrationStats: BillingProjectMigrationStats = {
+    workspaceCount: billingProjectInfo.workspaces.length,
+    unscheduled: 0,
+    errored: 0,
+    succeeded: 0,
+    inProgress: 0,
+  };
+
+  billingProjectInfo.workspaces.forEach((workspaceMigrationInfo) => {
+    Utils.cond(
+      [
+        workspaceMigrationInfo.migrationStep === 'Unscheduled',
+        () => {
+          migrationStats.unscheduled += 1;
+          return undefined;
+        },
+      ],
+      [
+        workspaceMigrationInfo.migrationStep === 'Finished',
+        () => {
+          if (workspaceMigrationInfo.outcome === 'success') {
+            migrationStats.succeeded += 1;
+          } else {
+            migrationStats.errored += 1;
+          }
+          return undefined;
+        },
+      ],
+      [
+        Utils.DEFAULT,
+        () => {
+          migrationStats.inProgress += 1;
+          return undefined;
+        },
+      ]
+    );
+  });
+  return migrationStats;
 };

--- a/src/pages/workspaces/migration/migration-utils.ts
+++ b/src/pages/workspaces/migration/migration-utils.ts
@@ -1,7 +1,7 @@
+import { cond, DEFAULT } from '@terra-ui-packages/core-utils';
 import _ from 'lodash/fp';
 import { icon } from 'src/components/icons';
 import colors from 'src/libs/colors';
-import * as Utils from 'src/libs/utils';
 
 export type MigrationStep = ServerMigrationStep | 'Unscheduled';
 
@@ -141,12 +141,11 @@ export const getBillingProjectMigrationStats = (
   };
 
   billingProjectInfo.workspaces.forEach((workspaceMigrationInfo) => {
-    Utils.cond(
+    cond(
       [
         workspaceMigrationInfo.migrationStep === 'Unscheduled',
         () => {
           migrationStats.unscheduled += 1;
-          return undefined;
         },
       ],
       [
@@ -157,14 +156,12 @@ export const getBillingProjectMigrationStats = (
           } else {
             migrationStats.errored += 1;
           }
-          return undefined;
         },
       ],
       [
-        Utils.DEFAULT,
+        DEFAULT,
         () => {
           migrationStats.inProgress += 1;
-          return undefined;
         },
       ]
     );


### PR DESCRIPTION
Jira ticket: https://broadworkbench.atlassian.net/browse/WOR-1262

This PR adds the ability for the user to migrate an individual workspace, or to migrate all unmigrated workspaces in a billing project. It also adds status information at the billing project level. https://pr-4-dot-bvdp-saturn-dev.appspot.com/#workspace-migration

Once a button is pressed, it will remain disabled until the view is refreshed-- currently the user must refresh the page, but the next ticket will introduce auto-refresh behavior.

Screenshot of example billing project status information (billing projects collapsed):
![image](https://github.com/DataBiosphere/terra-ui/assets/484484/98505f6e-3d90-4fc3-9a75-04a9cdc045ae)

Screenshot of the many buttons:

![image](https://github.com/DataBiosphere/terra-ui/assets/484484/0ca62362-25ed-44a8-ae58-fd44a6754042)
