### PR TITLE
[UIE-128] Move truncateInteger out of libs/utils

### DIFF
--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -251,15 +251,6 @@ export const sha256 = async (message) => {
   )(new Uint8Array(hashBuffer));
 };
 
-// Truncates an integer to the thousands, i.e. 10363 -> 10k
-export const truncateInteger = (integer) => {
-  if (integer < 10000) {
-    return `${integer}`;
-  }
-
-  return `${Math.floor(integer / 1000)}k`;
-};
-
 /**
  * Polls using a given function until the pollUntil function returns true.
  * @param pollFn - The function to poll using

--- a/src/workspace-data/Data.js
+++ b/src/workspace-data/Data.js
@@ -84,6 +84,15 @@ const styles = {
   },
 };
 
+// Truncates an integer to the thousands, i.e. 10363 -> 10k
+const formatSearchResultsCount = (integer) => {
+  if (integer < 10000) {
+    return `${integer}`;
+  }
+
+  return `${Math.floor(integer / 1000)}k`;
+};
+
 const SearchResultsPill = ({ filteredCount, searching }) => {
   return div(
     {
@@ -98,7 +107,7 @@ const SearchResultsPill = ({ filteredCount, searching }) => {
         color: 'white',
       },
     },
-    searching ? [icon('loadingSpinner', { size: 13, color: 'white' })] : `${Utils.truncateInteger(filteredCount)}`
+    searching ? [icon('loadingSpinner', { size: 13, color: 'white' })] : `${formatSearchResultsCount(filteredCount)}`
   );
 };
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/UIE-128

Continuing to break up libs/utils....

`truncateInteger` is used in one place. Thus, it doesn't need to be in libs/utils. This PR moves it into workspace-data/Data.