### PR TITLE
[UIE-138] Move asMockedFn to test-utils package

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -78,7 +78,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["animate.css", "npm:4.1.1"],\
             ["array-move", "npm:4.0.0"],\
             ["browserslist", "npm:4.21.10"],\
-            ["check-dts", "virtual:6fecf1af4cab542f4a06b7ce7d9f710277dce92700e0011a9519e41948eed6d8f54c9d0aa109ead6cf4295edce81cb49620f9e823313e99632229bf20d133cdb#npm:0.7.2"],\
+            ["check-dts", "virtual:8c00fb6d848584930a97145ab92981f57dfda3a26acb7c186ce59ef8e1d0c5c900af7e36dd05e12ff96b7235e88575a55bb45434a9589e1fb111101a9a3d2f5e#npm:0.7.2"],\
             ["clipboard-polyfill", "npm:3.0.3"],\
             ["color", "npm:4.0.1"],\
             ["date-fns", "npm:2.24.0"],\
@@ -5150,7 +5150,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@terra-ui-packages/test-utils", "workspace:packages/test-utils"],\
             ["@types/jest", "npm:28.1.8"],\
             ["@types/lodash", "npm:4.14.184"],\
-            ["check-dts", "virtual:6fecf1af4cab542f4a06b7ce7d9f710277dce92700e0011a9519e41948eed6d8f54c9d0aa109ead6cf4295edce81cb49620f9e823313e99632229bf20d133cdb#npm:0.7.2"],\
+            ["check-dts", "virtual:8c00fb6d848584930a97145ab92981f57dfda3a26acb7c186ce59ef8e1d0c5c900af7e36dd05e12ff96b7235e88575a55bb45434a9589e1fb111101a9a3d2f5e#npm:0.7.2"],\
             ["jest", "virtual:8c00fb6d848584930a97145ab92981f57dfda3a26acb7c186ce59ef8e1d0c5c900af7e36dd05e12ff96b7235e88575a55bb45434a9589e1fb111101a9a3d2f5e#npm:27.5.1"],\
             ["lodash", "npm:4.17.21"],\
             ["typescript", "patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=289587"],\
@@ -5175,6 +5175,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["blob-polyfill", "npm:7.0.20220408"],\
             ["browserslist", "npm:4.21.10"],\
             ["camelcase", "npm:6.3.0"],\
+            ["check-dts", "virtual:8c00fb6d848584930a97145ab92981f57dfda3a26acb7c186ce59ef8e1d0c5c900af7e36dd05e12ff96b7235e88575a55bb45434a9589e1fb111101a9a3d2f5e#npm:0.7.2"],\
             ["identity-obj-proxy", "npm:3.0.0"],\
             ["jest", "virtual:8c00fb6d848584930a97145ab92981f57dfda3a26acb7c186ce59ef8e1d0c5c900af7e36dd05e12ff96b7235e88575a55bb45434a9589e1fb111101a9a3d2f5e#npm:27.5.1"],\
             ["jest-axe", "npm:6.0.0"],\
@@ -7336,10 +7337,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],\
           "linkType": "SOFT"\
         }],\
-        ["virtual:6fecf1af4cab542f4a06b7ce7d9f710277dce92700e0011a9519e41948eed6d8f54c9d0aa109ead6cf4295edce81cb49620f9e823313e99632229bf20d133cdb#npm:0.7.2", {\
-          "packageLocation": "./.yarn/__virtual__/check-dts-virtual-fa49c1546e/0/cache/check-dts-npm-0.7.2-b91f3005a2-c870c71969.zip/node_modules/check-dts/",\
+        ["virtual:8c00fb6d848584930a97145ab92981f57dfda3a26acb7c186ce59ef8e1d0c5c900af7e36dd05e12ff96b7235e88575a55bb45434a9589e1fb111101a9a3d2f5e#npm:0.7.2", {\
+          "packageLocation": "./.yarn/__virtual__/check-dts-virtual-fe7cb514f6/0/cache/check-dts-npm-0.7.2-b91f3005a2-c870c71969.zip/node_modules/check-dts/",\
           "packageDependencies": [\
-            ["check-dts", "virtual:6fecf1af4cab542f4a06b7ce7d9f710277dce92700e0011a9519e41948eed6d8f54c9d0aa109ead6cf4295edce81cb49620f9e823313e99632229bf20d133cdb#npm:0.7.2"],\
+            ["check-dts", "virtual:8c00fb6d848584930a97145ab92981f57dfda3a26acb7c186ce59ef8e1d0c5c900af7e36dd05e12ff96b7235e88575a55bb45434a9589e1fb111101a9a3d2f5e#npm:0.7.2"],\
             ["@types/typescript", null],\
             ["fast-glob", "npm:3.3.0"],\
             ["nanospinner", "npm:1.1.0"],\
@@ -17914,7 +17915,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["animate.css", "npm:4.1.1"],\
             ["array-move", "npm:4.0.0"],\
             ["browserslist", "npm:4.21.10"],\
-            ["check-dts", "virtual:6fecf1af4cab542f4a06b7ce7d9f710277dce92700e0011a9519e41948eed6d8f54c9d0aa109ead6cf4295edce81cb49620f9e823313e99632229bf20d133cdb#npm:0.7.2"],\
+            ["check-dts", "virtual:8c00fb6d848584930a97145ab92981f57dfda3a26acb7c186ce59ef8e1d0c5c900af7e36dd05e12ff96b7235e88575a55bb45434a9589e1fb111101a9a3d2f5e#npm:0.7.2"],\
             ["clipboard-polyfill", "npm:3.0.3"],\
             ["color", "npm:4.0.1"],\
             ["date-fns", "npm:2.24.0"],\

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "build": "vite build --emptyOutDir",
     "dev": "vite build --mode=development --watch",
-    "test": "yarn run build >/dev/null && jest"
+    "test": "yarn run build >/dev/null && jest",
+    "check-dts": "check-dts"
   },
   "type": "module",
   "module": "./lib/es/index.js",
@@ -43,6 +44,7 @@
     "@terra-ui-packages/build-utils": "^1.0.0",
     "@types/jest": "^28.1.8",
     "@types/node": "^20.6.2",
+    "check-dts": "^0.7.2",
     "typescript": "^4.9.5",
     "vite": "^4.3.9"
   }

--- a/packages/test-utils/src/asMockedFn.errors.ts
+++ b/packages/test-utils/src/asMockedFn.errors.ts
@@ -1,0 +1,18 @@
+import { asMockedFn } from './asMockedFn';
+import { add } from './asMockedFnTestHelper';
+
+type AsMockedFnTestHelperExports = typeof import('./asMockedFnTestHelper');
+jest.mock('./asMockedFnTestHelper', (): AsMockedFnTestHelperExports => {
+  return {
+    ...jest.requireActual<AsMockedFnTestHelperExports>('./asMockedFnTestHelper'),
+    add: jest.fn(),
+  };
+});
+
+// THROWS Argument of type '(arg1: string, arg2: string) => number' is not assignable to parameter of type '(arg1: number, arg2: number) => number'.
+asMockedFn(add).mockImplementation((arg1: string, arg2: string): number => {
+  return arg1.length + arg2.length;
+});
+
+// THROWS Argument of type 'string' is not assignable to parameter of type 'number'.
+asMockedFn(add).mockReturnValue('2');

--- a/packages/test-utils/src/asMockedFn.ts
+++ b/packages/test-utils/src/asMockedFn.ts
@@ -1,0 +1,21 @@
+export type AnyFn = (...args: any[]) => any;
+
+/**
+ * Use when working with a function mocked with jest.mock to tell TypeScript that
+ * the function has been mocked and allow accessing mock methods/properties.
+ *
+ * @example
+ * import { someFunction } from 'path/to/module';
+ *
+ * jest.mock('path/to/module', () => {
+ *   return {
+ *     ...jest.requireActual('path/to/module'),
+ *     someFunction: jest.fn(),
+ *   }
+ * })
+ *
+ * asMockedFn(someFunction).mockImplementation(...)
+ */
+export const asMockedFn = <T extends AnyFn>(fn: T): jest.MockedFunction<T> => {
+  return fn as jest.MockedFunction<T>;
+};

--- a/packages/test-utils/src/asMockedFn.types.ts
+++ b/packages/test-utils/src/asMockedFn.types.ts
@@ -1,0 +1,16 @@
+import { asMockedFn } from './asMockedFn';
+import { add } from './asMockedFnTestHelper';
+
+type AsMockedFnTestHelperExports = typeof import('./asMockedFnTestHelper');
+jest.mock('./asMockedFnTestHelper', (): AsMockedFnTestHelperExports => {
+  return {
+    ...jest.requireActual<AsMockedFnTestHelperExports>('./asMockedFnTestHelper'),
+    add: jest.fn(),
+  };
+});
+
+asMockedFn(add).mockImplementation((arg1: number, arg2: number): number => {
+  return arg1 + arg2;
+});
+
+asMockedFn(add).mockReturnValue(2);

--- a/packages/test-utils/src/asMockedFnTestHelper.ts
+++ b/packages/test-utils/src/asMockedFnTestHelper.ts
@@ -1,0 +1,3 @@
+export const add = (arg1: number, arg2: number): number => {
+  return arg1 + arg2;
+};

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -1,2 +1,3 @@
+export * from './asMockedFn';
 export * from './jestConfig';
 export * from './withFakeTimers';

--- a/src/testing/test-utils.ts
+++ b/src/testing/test-utils.ts
@@ -12,6 +12,8 @@ import userEvent from '@testing-library/user-event';
 import { PropsWithChildren, ReactElement } from 'react';
 import { h } from 'react-hyperscript-helpers';
 
+export { asMockedFn } from '@terra-ui-packages/test-utils';
+
 const testTheme: Theme = {
   colorPalette: {
     primary: '#74ae43',
@@ -36,16 +38,6 @@ export const renderWithAppContexts = (ui: ReactElement, options?: Omit<RenderOpt
 };
 
 type UserEvent = ReturnType<typeof userEvent.setup>;
-
-/*
- * Use when working with a jest.fn() mocked method to get better type safety and IDE hinting on
- * the function signature of what's being mocked.
- *
- * Type "any" is used here to allow for desired type flow during usage where T "looks like a function".
- */
-export const asMockedFn = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> => {
-  return fn as jest.MockedFunction<T>;
-};
 
 export type PromiseController<T> = {
   resolve: (value: T) => void;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3033,6 +3033,7 @@ __metadata:
     blob-polyfill: ^7.0.20220408
     browserslist: ^4.18.1
     camelcase: ^6.2.1
+    check-dts: ^0.7.2
     identity-obj-proxy: ^3.0.0
     jest: ^27.4.3
     jest-axe: ^6.0.0


### PR DESCRIPTION
The `asMockedFn` helper is useful in any test that mocks dependencies. So that we're able to use it in tests in packages, this PR moves it to the test-utils package. It also updates its documentation and adds type tests.