### PR TITLE
[AJ-1310] Refactor isProtectedWorkspace

### DIFF
--- a/src/import-data/protected-data-utils.ts
+++ b/src/import-data/protected-data-utils.ts
@@ -1,5 +1,5 @@
 import { Snapshot } from 'src/libs/ajax/DataRepo';
-import { WorkspaceWrapper } from 'src/libs/workspace-utils';
+import { hasProtectedData, WorkspaceWrapper } from 'src/libs/workspace-utils';
 
 import { ImportRequest } from './import-types';
 
@@ -95,11 +95,7 @@ export const getImportSource = (url: URL): ImportSource => {
 export const isProtectedWorkspace = (workspace: WorkspaceWrapper): boolean => {
   switch (workspace.workspace.cloudPlatform) {
     case 'Azure':
-      // The WorkspaceWrapper type specifies policies as optional, but policies are loaded by the ImportData component.
-      if (!workspace.policies) {
-        return false;
-      }
-      return workspace.policies.some((policy) => policy.namespace === 'terra' && policy.name === 'protected-data');
+      return hasProtectedData(workspace);
     case 'Gcp':
       return workspace.workspace.bucketName.startsWith('fc-secure');
     default:


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1310

Follow up to #4327.

@cahrens pointed out that workspace-utils already contains a function for checking if a workspace has the protected data policy. This function can use it instead of duplicating the logic.