### PR TITLE
[AJ-1296] Move upload data components into src/workspace-data

### DIFF
--- a/src/libs/routes.js
+++ b/src/libs/routes.js
@@ -26,6 +26,7 @@ import * as NotFound from 'src/pages/NotFound';
 import * as PrivacyPolicy from 'src/pages/PrivacyPolicy';
 import * as Profile from 'src/pages/Profile';
 import * as TermsOfService from 'src/pages/TermsOfService';
+import * as UploadData from 'src/pages/UploadDataPage';
 import * as WorkflowsList from 'src/pages/workflows/List';
 import * as WorkflowDetails from 'src/pages/workflows/workflow/WorkflowDetails';
 import * as WorkspaceList from 'src/pages/workspaces/List';
@@ -39,7 +40,6 @@ import * as Workflows from 'src/pages/workspaces/workspace/Workflows';
 import * as WorkflowView from 'src/pages/workspaces/workspace/workflows/WorkflowView';
 import * as WorkflowsApp from 'src/workflows-app/routes';
 import * as Data from 'src/workspace-data/Data';
-import * as Upload from 'src/workspace-data/upload-data/UploadData';
 
 /*
  * NOTE: In order to show up in reports, new events[^1] MUST be marked as expected in the Mixpanel
@@ -81,7 +81,7 @@ const routes = _.flatten([
   Environments.navPaths,
   WorkflowsList.navPaths,
   WorkflowDetails.navPaths,
-  Upload.navPaths,
+  UploadData.navPaths,
   FeaturePreviews.navPaths,
   WorkspaceFiles.navPaths,
   AzurePreview.navPaths,

--- a/src/libs/routes.js
+++ b/src/libs/routes.js
@@ -26,7 +26,6 @@ import * as NotFound from 'src/pages/NotFound';
 import * as PrivacyPolicy from 'src/pages/PrivacyPolicy';
 import * as Profile from 'src/pages/Profile';
 import * as TermsOfService from 'src/pages/TermsOfService';
-import * as Upload from 'src/pages/Upload';
 import * as WorkflowsList from 'src/pages/workflows/List';
 import * as WorkflowDetails from 'src/pages/workflows/workflow/WorkflowDetails';
 import * as WorkspaceList from 'src/pages/workspaces/List';
@@ -40,6 +39,7 @@ import * as Workflows from 'src/pages/workspaces/workspace/Workflows';
 import * as WorkflowView from 'src/pages/workspaces/workspace/workflows/WorkflowView';
 import * as WorkflowsApp from 'src/workflows-app/routes';
 import * as Data from 'src/workspace-data/Data';
+import * as Upload from 'src/workspace-data/upload-data/UploadData';
 
 /*
  * NOTE: In order to show up in reports, new events[^1] MUST be marked as expected in the Mixpanel

--- a/src/pages/UploadDataPage.js
+++ b/src/pages/UploadDataPage.js
@@ -1,0 +1,10 @@
+import { UploadData } from 'src/workspace-data/upload-data/UploadData';
+
+export const navPaths = [
+  {
+    name: 'upload',
+    path: '/upload',
+    component: UploadData,
+    title: 'Upload',
+  },
+];

--- a/src/workspace-data/upload-data/UploadData.js
+++ b/src/workspace-data/upload-data/UploadData.js
@@ -4,7 +4,6 @@ import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
 import { code, div, h, h2, h3, li, p, span, strong, ul } from 'react-hyperscript-helpers';
 import { ButtonPrimary, Link, Select, topSpinnerOverlay, transparentSpinnerOverlay } from 'src/components/common';
 import FileBrowser from 'src/components/data/FileBrowser';
-import UploadPreviewTable from 'src/components/data/UploadPreviewTable';
 import Dropzone from 'src/components/Dropzone';
 import FloatingActionButton from 'src/components/FloatingActionButton';
 import FooterWrapper from 'src/components/FooterWrapper';
@@ -23,6 +22,8 @@ import * as StateHistory from 'src/libs/state-history';
 import * as Style from 'src/libs/style';
 import * as Utils from 'src/libs/utils';
 import * as WorkspaceUtils from 'src/libs/workspace-utils';
+
+import UploadPreviewTable from './UploadPreviewTable';
 
 // As you add support for uploading additional types of metadata, add them here.
 // You may also need to adjust the validation logic.

--- a/src/workspace-data/upload-data/UploadData.js
+++ b/src/workspace-data/upload-data/UploadData.js
@@ -889,7 +889,7 @@ const DonePanel = ({
   ]);
 };
 
-const UploadData = _.flow(
+export const UploadData = _.flow(
   // eslint-disable-line lodash-fp/no-single-composition
   forwardRefWithName('Upload')
 )((props, _ref) => {
@@ -1149,12 +1149,3 @@ const UploadData = _.flow(
     ]),
   ]);
 });
-
-export const navPaths = [
-  {
-    name: 'upload',
-    path: '/upload',
-    component: UploadData,
-    title: 'Upload',
-  },
-];

--- a/src/workspace-data/upload-data/UploadPreviewTable.js
+++ b/src/workspace-data/upload-data/UploadPreviewTable.js
@@ -13,7 +13,8 @@ import { withErrorReporting } from 'src/libs/error';
 import { getLocalPref } from 'src/libs/prefs';
 import { useCancellation, useOnMount } from 'src/libs/react-utils';
 import * as Utils from 'src/libs/utils';
-import { renderDataCell } from 'src/workspace-data/data-table/entity-service/renderDataCell';
+
+import { renderDataCell } from '../data-table/entity-service/renderDataCell';
 
 const UploadDataTable = (props) => {
   const {


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1296

Continuing to collect workspace data-related / AJ owned code into src/workspace-data...

This moves components for the upload data page (`/#upload`). If manually testing, note that the upload data page only works with GCP workspaces.

Done in two commits to make the diff smaller / so that git recognizes UploadData as a renamed file instead of an entirely new one.