### PR TITLE
[UIE-120] Move abandonedPromise to core-utils

### DIFF
--- a/packages/core-utils/src/index.ts
+++ b/packages/core-utils/src/index.ts
@@ -2,6 +2,7 @@ export * from './format/number-format';
 export * from './io-utils';
 export * from './logic-utils';
 export * from './nav/nav-utils';
+export * from './promise-utils';
 export * from './state-utils';
 export * from './timer-utils';
 export * from './type-utils/deep-partial';

--- a/packages/core-utils/src/promise-utils.ts
+++ b/packages/core-utils/src/promise-utils.ts
@@ -1,0 +1,8 @@
+/**
+ * Returns a promise that will never resolve or reject.
+ *
+ * Useful for cancelling async flows.
+ */
+export const abandonedPromise = (): Promise<any> => {
+  return new Promise(() => {});
+};

--- a/src/components/bucket-utils.js
+++ b/src/components/bucket-utils.js
@@ -1,3 +1,4 @@
+import { abandonedPromise } from '@terra-ui-packages/core-utils';
 import _ from 'lodash/fp';
 import { useState } from 'react';
 import { h } from 'react-hyperscript-helpers';
@@ -12,7 +13,7 @@ export const withRequesterPaysHandler = _.curry((handler, fn) => async (...args)
   } catch (error) {
     if (error.requesterPaysError) {
       handler();
-      return Utils.abandonedPromise();
+      return abandonedPromise();
     }
     throw error;
   }

--- a/src/libs/ajax/ajax-common.ts
+++ b/src/libs/ajax/ajax-common.ts
@@ -1,10 +1,9 @@
-import { delay } from '@terra-ui-packages/core-utils';
+import { abandonedPromise, delay } from '@terra-ui-packages/core-utils';
 import _ from 'lodash/fp';
 import { sessionTimedOutErrorMessage } from 'src/auth/auth-errors';
 import { AuthTokenState, loadAuthToken, signOut, SignOutCause } from 'src/libs/auth';
 import { getConfig } from 'src/libs/config';
 import { ajaxOverridesStore, getTerraUser } from 'src/libs/state';
-import * as Utils from 'src/libs/utils';
 
 export const authOpts = (token = getTerraUser().token) => ({ headers: { Authorization: `Bearer ${token}` } });
 export const jsonBody = (body) => ({
@@ -133,7 +132,7 @@ const withCancellation =
       return await wrappedFetch(...args);
     } catch (error) {
       if (error instanceof DOMException && error.name === 'AbortError') {
-        return Utils.abandonedPromise();
+        return abandonedPromise();
       }
       throw error;
     }

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -94,11 +94,6 @@ export const memoizeAsync = (asyncFn, { keyFn = _.identity, expires = Infinity }
   };
 };
 
-// Returns a promise that will never resolve or reject. Useful for cancelling async flows.
-export const abandonedPromise = () => {
-  return new Promise(() => {});
-};
-
 export const textMatch = safeCurry((needle: string, haystack: string): boolean => {
   return haystack.toLowerCase().includes(needle.toLowerCase());
 }) as (needle: string, haystack: string) => boolean;

--- a/src/pages/workspaces/migration/BillingProjectList.test.ts
+++ b/src/pages/workspaces/migration/BillingProjectList.test.ts
@@ -1,8 +1,8 @@
+import { abandonedPromise } from '@terra-ui-packages/core-utils';
 import { act, screen, within } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import { h } from 'react-hyperscript-helpers';
 import { Ajax } from 'src/libs/ajax';
-import { abandonedPromise } from 'src/libs/utils';
 import { BillingProjectList } from 'src/pages/workspaces/migration/BillingProjectList';
 import { mockServerData } from 'src/pages/workspaces/migration/migration-utils.test';
 import { asMockedFn, renderWithAppContexts as render } from 'src/testing/test-utils';

--- a/src/workspace-data/data-table/wds/wds-status.test.ts
+++ b/src/workspace-data/data-table/wds/wds-status.test.ts
@@ -1,8 +1,7 @@
-import { DeepPartial } from '@terra-ui-packages/core-utils';
+import { abandonedPromise, DeepPartial } from '@terra-ui-packages/core-utils';
 import { Ajax } from 'src/libs/ajax';
 import { ListAppResponse } from 'src/libs/ajax/leonardo/models/app-models';
 import { WDSCloneStatusResponse } from 'src/libs/ajax/WorkspaceDataService';
-import { abandonedPromise } from 'src/libs/utils';
 import { asMockedFn, renderHookInAct } from 'src/testing/test-utils';
 
 import { useWdsStatus } from './wds-status';


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/UIE-120

Continuing to break up libs/utils...

This moves `abandonedPromise` to the core-utils package. This function is one line, so it's debatable whether or not it's worth keeping as a separate function. I'll claim that it is because the name is a readability improvement over an inline `new Promise(() => {})`. Its use in multiple tests suggests that it's worth moving up to a package where it can be reused in other packages.