### PR TITLE
[AJ-1310] Hide new workspace option when importing protected Azure data

### DIFF
--- a/src/import-data/ImportDataDestination.test.ts
+++ b/src/import-data/ImportDataDestination.test.ts
@@ -388,4 +388,34 @@ describe('ImportDataDestination', () => {
       );
     }
   );
+
+  it('hides new workspace option for imports of protected Azure snapshots', async () => {
+    // Arrange
+    setup({
+      props: {
+        importRequest: {
+          type: 'tdr-snapshot-export',
+          manifestUrl: new URL('https://example.com/path/to/manifest.json'),
+          snapshot: {
+            id: '00001111-2222-3333-aaaa-bbbbccccdddd',
+            name: 'test-snapshot',
+            source: [
+              {
+                dataset: {
+                  id: '00001111-2222-3333-aaaa-bbbbccccdddd',
+                  name: 'test-dataset',
+                  secureMonitoringEnabled: true,
+                },
+              },
+            ],
+            cloudPlatform: 'azure',
+          },
+          syncPermissions: false,
+        },
+      },
+    });
+
+    // Assert
+    expect(screen.queryByText('Start with a new workspace')).toBeNull();
+  });
 });

--- a/src/import-data/ImportDataDestination.ts
+++ b/src/import-data/ImportDataDestination.ts
@@ -154,6 +154,7 @@ export const ImportDataDestination = (props: ImportDataDestinationProps): ReactN
         _.filter(({ name, namespace }) => _.some({ workspace: { namespace, name } }, workspaces))
       )(_.castArray(template))
     : [];
+  const canUseTemplateWorkspace = filteredTemplates.length > 0;
 
   const importMayTakeTimeMessage =
     'Note that the import process may take some time after you are redirected into your destination workspace.';
@@ -298,9 +299,10 @@ export const ImportDataDestination = (props: ImportDataDestinationProps): ReactN
         () => {
           return h(Fragment, [
             h2({ style: styles.title }, ['Destination of the prepared data']),
-            div({ style: { marginTop: '0.5rem' } }, ['Choose the option below that best suits your needs.']),
+            (canUseTemplateWorkspace || canUseNewWorkspace) &&
+              div({ style: { marginTop: '0.5rem' } }, ['Choose the option below that best suits your needs.']),
             !userHasBillingProjects && h(linkAccountPrompt),
-            !!filteredTemplates.length &&
+            canUseTemplateWorkspace &&
               h(ChoiceButton, {
                 onClick: () => setMode('template'),
                 iconName: 'copySolid',

--- a/src/import-data/ImportDataDestination.ts
+++ b/src/import-data/ImportDataDestination.ts
@@ -107,6 +107,11 @@ export const ImportDataDestination = (props: ImportDataDestinationProps): ReactN
   const isProtectedData = isProtectedSource(importRequest);
   const requiredCloudPlatform = getCloudPlatformRequiredForImport(importRequest);
 
+  // There is not yet a way to create a protected Azure via Terra UI.
+  // Thus, there is no way to create a new workspace that satisfies the requirements
+  // for a protected Azure snapshot.
+  const canUseNewWorkspace = !(isProtectedData && requiredCloudPlatform === 'AZURE');
+
   // Some import types are finished in a single request.
   // For most though, the import request starts a background task that takes time to complete.
   const immediateImportTypes: ImportRequest['type'][] = ['tdr-snapshot-reference', 'catalog-snapshots'];
@@ -309,14 +314,15 @@ export const ImportDataDestination = (props: ImportDataDestinationProps): ReactN
               detail: 'Select one of your workspaces',
               disabled: !userHasBillingProjects,
             }),
-            h(ChoiceButton, {
-              onClick: () => setIsCreateOpen(true),
-              iconName: 'plus-circle',
-              title: 'Start with a new workspace',
-              detail: 'Set up an empty workspace that you will configure for analysis',
-              'aria-haspopup': 'dialog',
-              disabled: !userHasBillingProjects,
-            }),
+            canUseNewWorkspace &&
+              h(ChoiceButton, {
+                onClick: () => setIsCreateOpen(true),
+                iconName: 'plus-circle',
+                title: 'Start with a new workspace',
+                detail: 'Set up an empty workspace that you will configure for analysis',
+                'aria-haspopup': 'dialog',
+                disabled: !userHasBillingProjects,
+              }),
             isCreateOpen &&
               h(NewWorkspaceModal, {
                 requiredAuthDomain: requiredAuthorizationDomain,


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1310

Protected data can only be imported into a protected workspace. And TDR snapshots can only be imported to workspaces on the same cloud platform. Thus, protected Azure snapshots can only be imported into protected Azure workspaces.

There is currently no way to create a protected Azure workspace via Terra UI (it requires a direct API call). Therefore, there is no reason to show the "Start with a new workspace" option when importing a protected Azure snapshot, because that option cannot create a workspace that satisfies the import's requirements.

This PR hides the "Start with a new workspace" option when importing a protected Azure snapshot.