### PR TITLE
[AJ-1377] Add T2T reference files

### DIFF
--- a/src/workspace-data/reference-data/reference-metadata.ts
+++ b/src/workspace-data/reference-data/reference-metadata.ts
@@ -1,4 +1,7 @@
 export const referenceMetadata = {
+  'T2T-v2': {
+    species: 'Human',
+  },
   hg38: {
     species: 'Human',
   },

--- a/src/workspace-data/reference-data/references.ts
+++ b/src/workspace-data/reference-data/references.ts
@@ -1,4 +1,15 @@
 export default {
+  'T2T-v2': {
+    ref_fasta: 'gs://gcp-public-data--broad-references/t2t/v2/chm13v2.0.maskedY.rCRS.EBV.fasta',
+    ref_fasta_index: 'gs://gcp-public-data--broad-references/t2t/v2/chm13v2.0.maskedY.rCRS.EBV.fasta.fai',
+    ref_dict: 'gs://gcp-public-data--broad-references/t2t/v2/chm13v2.0.maskedY.rCRS.EBV.dict',
+    ref_amb: 'gs://gcp-public-data--broad-references/t2t/v2/chm13v2.0.maskedY.rCRS.EBV.fasta.amb',
+    ref_ann: 'gs://gcp-public-data--broad-references/t2t/v2/chm13v2.0.maskedY.rCRS.EBV.fasta.ann',
+    ref_bwt: 'gs://gcp-public-data--broad-references/t2t/v2/chm13v2.0.maskedY.rCRS.EBV.fasta.bwt',
+    ref_pac: 'gs://gcp-public-data--broad-references/t2t/v2/chm13v2.0.maskedY.rCRS.EBV.fasta.pac',
+    ref_sa: 'gs://gcp-public-data--broad-references/t2t/v2/chm13v2.0.maskedY.rCRS.EBV.fasta.sa',
+    par_bed: 'gs://gcp-public-data--broad-references/t2t/v2/chm13v2.0_PAR.bed',
+  },
   hg38: {
     axiomPoly_resource_vcf:
       'gs://gcp-public-data--broad-references/hg38/v0/Axiom_Exome_Plus.genotypes.all_populations.poly.hg38.vcf.gz',


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/AJ-1377

## Summary of changes:
This adds the new T2T human reference files to the list of Terra references. They were recently added to the appropriate GCP bucket location. This replaces #4220. 

### What
Add new reference files.

### Why
The T2T human reference is the latest and greatest for human genome references, and researchers are starting to use it more for greater accuracy in their workflows. Terra should definitely provide a copy as a convenience as it does other references. The particular version included here is one choice from the multiple provided via the consortium, based on some recommendations after discussing with folks in DSP Methods + others in the T2T group, which is meant to be a good choice for most "generic" use cases. It might be nice to have a Terra blog post explaining the new capabilities and decision-making behind the choice (but haven't heard back from reaching out to some people about this).

### Testing strategy
There exist tests already for whether references have metadata associated with them.
