### PR TITLE
[WOR-1264] Add auto-refresh behavior for workspace migrations.

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -157,6 +157,14 @@ const Workspaces = (signal) => ({
     return response.json();
   },
 
+  bucketMigrationProgress: async (body) => {
+    const response = await fetchRawls(
+      'workspaces/v2/bucketMigration/getProgress',
+      _.mergeAll([authOpts(), jsonBody(body), { signal, method: 'POST' }])
+    );
+    return response.json();
+  },
+
   startBatchBucketMigration: async (body) => {
     const response = await fetchRawls('workspaces/v2/bucketMigration', _.mergeAll([authOpts(), jsonBody(body), { signal, method: 'POST' }]));
     return response.json();

--- a/src/pages/workspaces/migration/BillingProjectList.test.ts
+++ b/src/pages/workspaces/migration/BillingProjectList.test.ts
@@ -1,9 +1,8 @@
 import { act, screen, within } from '@testing-library/react';
-import { axe } from 'jest-axe';
 import { h } from 'react-hyperscript-helpers';
 import { Ajax } from 'src/libs/ajax';
 import { abandonedPromise } from 'src/libs/utils';
-import { BillingProjectList } from 'src/pages/workspaces/migration/BillingProjectList';
+import { BillingProjectList, inProgressRefreshRate } from 'src/pages/workspaces/migration/BillingProjectList';
 import { mockServerData } from 'src/pages/workspaces/migration/migration-utils.test';
 import { asMockedFn, renderWithAppContexts as render } from 'src/testing/test-utils';
 
@@ -12,6 +11,14 @@ type AjaxWorkspacesContract = AjaxContract['Workspaces'];
 jest.mock('src/libs/ajax');
 
 describe('BillingProjectList', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
   it('shows a loading indicator', async () => {
     // Arrange
     const mockWorkspaces: Partial<AjaxWorkspacesContract> = {
@@ -47,7 +54,7 @@ describe('BillingProjectList', () => {
     expect(screen.queryByText('Fetching billing projects')).toBeNull();
   });
 
-  it('shows the list of billing projects with workspaces, and has no accessibility errors', async () => {
+  it('shows the list of billing projects with workspaces', async () => {
     // Arrange
     const mockWorkspaces: Partial<AjaxWorkspacesContract> = {
       bucketMigrationInfo: jest.fn().mockResolvedValue(mockServerData),
@@ -58,10 +65,7 @@ describe('BillingProjectList', () => {
     asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
 
     // Act
-    let renderResult;
-    act(() => {
-      renderResult = render(h(BillingProjectList, []));
-    });
+    render(h(BillingProjectList, []));
 
     // Assert
     const billingProjects = await screen.findAllByRole('listitem');
@@ -77,7 +81,52 @@ describe('BillingProjectList', () => {
 
     expect(screen.queryByText('Fetching billing projects')).toBeNull();
     expect(screen.queryByText('You have no workspaces to migrate')).toBeNull();
+  });
 
-    expect(await axe(renderResult.container)).toHaveNoViolations();
+  it('refreshes an in-progress workspace', async () => {
+    // Arrange
+    const mockUpdateData = {
+      'general-dev-billing-account/Christina test': {
+        finalBucketTransferProgress: {
+          bytesTransferred: 0,
+          objectsTransferred: 0,
+          totalBytesToTransfer: 0,
+          totalObjectsToTransfer: 0,
+        },
+        migrationStep: 'PreparingTransferToFinalBucket' as const,
+        tempBucketTransferProgress: {
+          bytesTransferred: 1000,
+          objectsTransferred: 2,
+          totalBytesToTransfer: 2000,
+          totalObjectsToTransfer: 4,
+        },
+      },
+    };
+    const mockBatchProgress = jest.fn().mockResolvedValue(mockUpdateData);
+    const mockWorkspaces: Partial<AjaxWorkspacesContract> = {
+      bucketMigrationInfo: jest.fn().mockResolvedValue(mockServerData),
+      bucketMigrationProgress: mockBatchProgress,
+    };
+    const mockAjax: Partial<AjaxContract> = {
+      Workspaces: mockWorkspaces as AjaxWorkspacesContract,
+    };
+    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+
+    await act(() => render(h(BillingProjectList, [])));
+
+    let billingProjects = await screen.findAllByRole('listitem');
+    await within(billingProjects[2]).findByText('Initial Transfer in Progress (1000 B/1.95 KiB)');
+
+    // Act
+    await act(async () => {
+      jest.advanceTimersByTime(inProgressRefreshRate);
+    });
+
+    expect(mockBatchProgress).toHaveBeenCalledWith([
+      { name: 'Christina test', namespace: 'general-dev-billing-account' },
+    ]);
+
+    billingProjects = await screen.findAllByRole('listitem');
+    await within(billingProjects[2]).findByText('Creating Destination Bucket');
   });
 });

--- a/src/pages/workspaces/migration/BillingProjectList.ts
+++ b/src/pages/workspaces/migration/BillingProjectList.ts
@@ -1,31 +1,86 @@
 import _ from 'lodash/fp';
-import { ReactNode, useEffect, useState } from 'react';
+import { ReactNode, useEffect, useRef, useState } from 'react';
 import { div, h, h2, span } from 'react-hyperscript-helpers';
 import { spinner } from 'src/components/icons';
 import { Ajax } from 'src/libs/ajax';
 import colors from 'src/libs/colors';
-import { reportErrorAndRethrow } from 'src/libs/error';
-import { useCancellation } from 'src/libs/react-utils';
+import { reportErrorAndRethrow, withErrorIgnoring } from 'src/libs/error';
+import { useCancellation, useGetter } from 'src/libs/react-utils';
 import * as Utils from 'src/libs/utils';
 import { BillingProjectParent } from 'src/pages/workspaces/migration/BillingProjectParent';
-import { BillingProjectMigrationInfo, parseServerResponse } from 'src/pages/workspaces/migration/migration-utils';
+import {
+  BillingProjectMigrationInfo,
+  mergeBillingProjectMigrationInfo,
+  mergeWorkspacesWithNamespaces,
+  parseServerResponse,
+  WorkspaceWithNamespace,
+} from 'src/pages/workspaces/migration/migration-utils';
+
+export const inProgressRefreshRate = 10000;
 
 export const BillingProjectList = (): ReactNode => {
   const [loadingMigrationInformation, setLoadingMigrationInformation] = useState(true);
   const [billingProjectWorkspaces, setBillingProjectWorkspaces] = useState<BillingProjectMigrationInfo[]>([]);
+  const getBillingProjectWorkspaces = useGetter(billingProjectWorkspaces);
+  const [inProgressWorkspaces, setInProgressWorkspaces] = useState<{ namespace: string; name: string }[]>([]);
+  const getInProgressWorkspaces = useGetter(inProgressWorkspaces);
   const signal = useCancellation();
   const fontSize = 16;
+  const interval = useRef<number>();
 
-  useEffect(() => {
-    const loadWorkspaces = _.flow(
-      reportErrorAndRethrow('Error loading workspace migration information'),
-      Utils.withBusyState(setLoadingMigrationInformation)
-    )(async () => {
-      const migrationResponse = await Ajax(signal).Workspaces.bucketMigrationInfo();
-      setBillingProjectWorkspaces(parseServerResponse(migrationResponse));
-    });
-    loadWorkspaces();
-  }, [setBillingProjectWorkspaces, signal]);
+  const updateWorkspacesSilently = withErrorIgnoring(
+    async (workspacesWithNamespaces: { namespace: string; name: string }[]) => {
+      if (!workspacesWithNamespaces) {
+        workspacesWithNamespaces = getInProgressWorkspaces();
+      } else {
+        // Add to the list of in-progress workspaces for future refreshes.
+        setInProgressWorkspaces(mergeWorkspacesWithNamespaces(getInProgressWorkspaces(), workspacesWithNamespaces));
+      }
+      if (workspacesWithNamespaces.length > 0) {
+        const updatedWorkspaceInfo = parseServerResponse(
+          await Ajax(signal).Workspaces.bucketMigrationProgress(workspacesWithNamespaces)
+        );
+        const merged = mergeBillingProjectMigrationInfo(getBillingProjectWorkspaces(), updatedWorkspaceInfo);
+        setBillingProjectWorkspaces(merged);
+      }
+    }
+  );
+
+  useEffect(
+    () => {
+      const loadWorkspaces = _.flow(
+        reportErrorAndRethrow('Error loading workspace migration information'),
+        Utils.withBusyState(setLoadingMigrationInformation)
+      )(async () => {
+        const migrationResponse = await Ajax(signal).Workspaces.bucketMigrationInfo();
+        const billingProjectsWithWorkspaces = parseServerResponse(migrationResponse);
+        setBillingProjectWorkspaces(billingProjectsWithWorkspaces);
+
+        const inProgressWorkspacesWithNamespaces: WorkspaceWithNamespace[] = [];
+        billingProjectsWithWorkspaces.forEach((billingProject) => {
+          billingProject.workspaces.forEach((workspace) => {
+            if (workspace.migrationStep !== 'Unscheduled' && workspace.migrationStep !== 'Finished') {
+              inProgressWorkspacesWithNamespaces.push({ namespace: workspace.namespace, name: workspace.name });
+            }
+          });
+        });
+        setInProgressWorkspaces(inProgressWorkspacesWithNamespaces);
+
+        //  Start timer to auto-refresh state
+        if (!interval.current) {
+          // @ts-ignore
+          interval.current = setInterval(updateWorkspacesSilently, inProgressRefreshRate);
+        }
+      });
+      loadWorkspaces();
+
+      return () => {
+        clearInterval(interval.current);
+        interval.current = undefined;
+      };
+    }, // Adding updateWorkspacesSilently to the dependency list causes unittests to hang
+    [setBillingProjectWorkspaces, signal] // eslint-disable-line react-hooks/exhaustive-deps
+  );
 
   return div({ style: { padding: '10px', backgroundColor: colors.light(), flexGrow: 1 } }, [
     h2({ style: { fontSize, marginLeft: '1.0rem' } }, ['Billing Projects']),
@@ -41,7 +96,8 @@ export const BillingProjectList = (): ReactNode => {
         billingProjectWorkspaces.length === 0 &&
         div({ style: { fontSize, marginTop: '1.5rem', marginLeft: '1.5rem' } }, ['You have no workspaces to migrate']),
       ..._.map(
-        (billingProjectMigrationInfo) => h(BillingProjectParent, { billingProjectMigrationInfo }),
+        (billingProjectMigrationInfo) =>
+          h(BillingProjectParent, { billingProjectMigrationInfo, migrationStartedCallback: updateWorkspacesSilently }),
         billingProjectWorkspaces
       ),
     ]),

--- a/src/pages/workspaces/migration/BillingProjectList.ts
+++ b/src/pages/workspaces/migration/BillingProjectList.ts
@@ -68,8 +68,7 @@ export const BillingProjectList = (): ReactNode => {
 
         //  Start timer to auto-refresh state
         if (!interval.current) {
-          // @ts-ignore
-          interval.current = setInterval(updateWorkspacesSilently, inProgressRefreshRate);
+          interval.current = window.setInterval(updateWorkspacesSilently, inProgressRefreshRate);
         }
       });
       loadWorkspaces();

--- a/src/pages/workspaces/migration/BillingProjectParent.test.ts
+++ b/src/pages/workspaces/migration/BillingProjectParent.test.ts
@@ -17,7 +17,11 @@ type AjaxWorkspacesContract = AjaxContract['Workspaces'];
 jest.mock('src/libs/ajax');
 
 describe('BillingProjectParent', () => {
-  const migrationScheduledTooltipText = 'Migration has been scheduled';
+  const mockMigrationStartedCallback = jest.fn();
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
 
   it('shows migrate all button if all workspaces are unscheduled, with no accessibility errors', async () => {
     // Arrange
@@ -43,11 +47,11 @@ describe('BillingProjectParent', () => {
             namespace: 'CARBilling-2',
             workspaces: twoUnscheduledMigrationInfo,
           },
+          migrationStartedCallback: mockMigrationStartedCallback,
         }),
       ])
     );
     expect(await axe(container)).toHaveNoViolations();
-    expect(screen.queryByText(migrationScheduledTooltipText)).toBeNull();
     await user.click(screen.getByText('Migrate all workspaces'));
 
     // Assert
@@ -55,8 +59,10 @@ describe('BillingProjectParent', () => {
       { name: 'notmigrated1', namespace: 'CARBilling-2' },
       { name: 'notmigrated2', namespace: 'CARBilling-2' },
     ]);
-    expect(screen.getByText('Migrate all workspaces').getAttribute('aria-disabled')).toBe('true');
-    await screen.findByText(migrationScheduledTooltipText);
+    expect(mockMigrationStartedCallback).toHaveBeenCalledWith([
+      { name: 'notmigrated1', namespace: 'CARBilling-2' },
+      { name: 'notmigrated2', namespace: 'CARBilling-2' },
+    ]);
   });
 
   it('shows migrate remaining button if some workspaces are unscheduled', async () => {
@@ -76,6 +82,7 @@ describe('BillingProjectParent', () => {
     render(
       h(BillingProjectParent, {
         billingProjectMigrationInfo: bpWithSucceededAndUnscheduled,
+        migrationStartedCallback: mockMigrationStartedCallback,
       })
     );
     await user.click(screen.getByText('Migrate remaining workspaces'));
@@ -83,6 +90,7 @@ describe('BillingProjectParent', () => {
     // Assert
     expect(mockStartBatchBucketMigration).toHaveBeenCalledWith([{ name: 'notmigrated', namespace: 'CARBilling-2' }]);
     await screen.findByText('1 Workspace Migrated');
+    expect(mockMigrationStartedCallback).toHaveBeenCalledWith([{ name: 'notmigrated', namespace: 'CARBilling-2' }]);
   });
 
   it('does not show a migrate button if the only workspace is in progress', async () => {
@@ -90,6 +98,7 @@ describe('BillingProjectParent', () => {
     render(
       h(BillingProjectParent, {
         billingProjectMigrationInfo: bpWithInProgress,
+        migrationStartedCallback: mockMigrationStartedCallback,
       })
     );
 
@@ -104,6 +113,7 @@ describe('BillingProjectParent', () => {
     render(
       h(BillingProjectParent, {
         billingProjectMigrationInfo: bpWithFailed,
+        migrationStartedCallback: mockMigrationStartedCallback,
       })
     );
 
@@ -149,6 +159,7 @@ describe('BillingProjectParent', () => {
           namespace: 'CARBilling-2',
           workspaces: twoSucceededMigrationInfo,
         },
+        migrationStartedCallback: mockMigrationStartedCallback,
       })
     );
 

--- a/src/pages/workspaces/migration/BillingProjectParent.ts
+++ b/src/pages/workspaces/migration/BillingProjectParent.ts
@@ -1,7 +1,7 @@
 import { cond, DEFAULT } from '@terra-ui-packages/core-utils';
 import _ from 'lodash/fp';
 import pluralize from 'pluralize';
-import { ReactNode, useState } from 'react';
+import { ReactNode } from 'react';
 import { div, h, span } from 'react-hyperscript-helpers';
 import Collapse from 'src/components/Collapse';
 import { ButtonOutline } from 'src/components/common';
@@ -14,17 +14,17 @@ import {
   getBillingProjectMigrationStats,
   inProgressIcon,
   successIcon,
+  WorkspaceWithNamespace,
 } from 'src/pages/workspaces/migration/migration-utils';
 import { WorkspaceItem } from 'src/pages/workspaces/migration/WorkspaceItem';
 import { useMemo } from 'use-memo-one';
 
 interface BillingProjectParentProps {
   billingProjectMigrationInfo: BillingProjectMigrationInfo;
+  migrationStartedCallback: (p: WorkspaceWithNamespace[]) => {};
 }
 
 export const BillingProjectParent = (props: BillingProjectParentProps): ReactNode => {
-  const [migrateStarted, setMigrateStarted] = useState<boolean>(false);
-
   const migrationStats = useMemo(() => {
     return getBillingProjectMigrationStats(props.billingProjectMigrationInfo);
   }, [props.billingProjectMigrationInfo]);
@@ -100,21 +100,23 @@ export const BillingProjectParent = (props: BillingProjectParentProps): ReactNod
               h(
                 ButtonOutline,
                 {
-                  disabled: migrateStarted,
-                  tooltip: migrateStarted ? 'Migration has been scheduled' : '',
                   onClick: () => {
-                    const migrateWorkspace = reportErrorAndRethrow('Error starting migration', async () => {
-                      const workspacesToMigrate: { namespace: string; name: string }[] = [];
-                      props.billingProjectMigrationInfo.workspaces.forEach((workspace) => {
-                        if (workspace.migrationStep === 'Unscheduled') {
-                          workspacesToMigrate.push({ namespace: workspace.namespace, name: workspace.name });
+                    const migrateWorkspace = reportErrorAndRethrow(
+                      // Some migrations may have started, but the page will not auto-refresh due to the error.
+                      'Error starting migration. Please refresh the page to get the most current status.',
+                      async () => {
+                        const workspacesToMigrate: { namespace: string; name: string }[] = [];
+                        props.billingProjectMigrationInfo.workspaces.forEach((workspace) => {
+                          if (workspace.migrationStep === 'Unscheduled') {
+                            workspacesToMigrate.push({ namespace: workspace.namespace, name: workspace.name });
+                          }
+                        });
+                        if (workspacesToMigrate.length > 0) {
+                          await Ajax().Workspaces.startBatchBucketMigration(workspacesToMigrate);
+                          props.migrationStartedCallback(workspacesToMigrate);
                         }
-                      });
-                      if (workspacesToMigrate.length > 0) {
-                        setMigrateStarted(true);
-                        await Ajax().Workspaces.startBatchBucketMigration(workspacesToMigrate);
                       }
-                    });
+                    );
                     migrateWorkspace();
                   },
                 },
@@ -129,7 +131,8 @@ export const BillingProjectParent = (props: BillingProjectParentProps): ReactNod
         initialOpenState: true,
       },
       _.map(
-        (workspaceMigrationInfo) => h(WorkspaceItem, { workspaceMigrationInfo }),
+        (workspaceMigrationInfo) =>
+          h(WorkspaceItem, { workspaceMigrationInfo, migrationStartedCallback: props.migrationStartedCallback }),
         props.billingProjectMigrationInfo.workspaces
       )
     ),

--- a/src/pages/workspaces/migration/WorkspaceItem.test.ts
+++ b/src/pages/workspaces/migration/WorkspaceItem.test.ts
@@ -21,6 +21,7 @@ describe('WorkspaceItem', () => {
   const migrateButtonText = `Migrate ${unscheduledWorkspace.name}`;
   const migrationScheduledTooltipText = 'Migration has been scheduled';
   const mockGetBucketUsage = jest.fn();
+  const mockMigrationStartedCallback = jest.fn();
 
   beforeEach(() => {
     const mockWorkspaces: DeepPartial<AjaxWorkspacesContract> = {
@@ -52,7 +53,12 @@ describe('WorkspaceItem', () => {
     asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
 
     // Act
-    render(h(WorkspaceItem, { workspaceMigrationInfo: unscheduledWorkspace }));
+    render(
+      h(WorkspaceItem, {
+        workspaceMigrationInfo: unscheduledWorkspace,
+        migrationStartedCallback: mockMigrationStartedCallback,
+      })
+    );
 
     // Assert
     await screen.findByText('workspace name');
@@ -77,7 +83,12 @@ describe('WorkspaceItem', () => {
     asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
 
     // Act
-    render(h(WorkspaceItem, { workspaceMigrationInfo: unscheduledWorkspace }));
+    render(
+      h(WorkspaceItem, {
+        workspaceMigrationInfo: unscheduledWorkspace,
+        migrationStartedCallback: mockMigrationStartedCallback,
+      })
+    );
     expect(screen.queryByText(migrationScheduledTooltipText)).toBeNull();
     await user.click(screen.getByLabelText(migrateButtonText));
 
@@ -85,6 +96,9 @@ describe('WorkspaceItem', () => {
     expect(mockMigrateWorkspace).toHaveBeenCalled();
     expect(screen.getByLabelText(migrateButtonText).getAttribute('aria-disabled')).toBe('true');
     await screen.findByText(migrationScheduledTooltipText);
+    expect(mockMigrationStartedCallback).toHaveBeenCalledWith([
+      { name: unscheduledWorkspace.name, namespace: unscheduledWorkspace.namespace },
+    ]);
   });
 
   it('shows if the bucket size cannot be fetched for an unscheduled workspace, and shows migrate button', async () => {
@@ -101,7 +115,12 @@ describe('WorkspaceItem', () => {
     asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
 
     // Act
-    render(h(WorkspaceItem, { workspaceMigrationInfo: unscheduledWorkspace }));
+    render(
+      h(WorkspaceItem, {
+        workspaceMigrationInfo: unscheduledWorkspace,
+        migrationStartedCallback: mockMigrationStartedCallback,
+      })
+    );
 
     // Assert
     await screen.findByText('workspace name');
@@ -132,7 +151,12 @@ describe('WorkspaceItem', () => {
     };
 
     // Act
-    render(h(WorkspaceItem, { workspaceMigrationInfo: completedWorkspace }));
+    render(
+      h(WorkspaceItem, {
+        workspaceMigrationInfo: completedWorkspace,
+        migrationStartedCallback: mockMigrationStartedCallback,
+      })
+    );
 
     // Assert
     await screen.findByText('april29');
@@ -155,7 +179,12 @@ describe('WorkspaceItem', () => {
     };
 
     // Act
-    const { container } = render(h(WorkspaceItem, { workspaceMigrationInfo: failedWorkspace }));
+    const { container } = render(
+      h(WorkspaceItem, {
+        workspaceMigrationInfo: failedWorkspace,
+        migrationStartedCallback: mockMigrationStartedCallback,
+      })
+    );
     const infoButton = screen.getByLabelText('More info');
     await user.click(infoButton);
 
@@ -185,7 +214,9 @@ describe('WorkspaceItem', () => {
       };
 
       // Act
-      const { container } = render(h(WorkspaceItem, { workspaceMigrationInfo: workspace }));
+      const { container } = render(
+        h(WorkspaceItem, { workspaceMigrationInfo: workspace, migrationStartedCallback: mockMigrationStartedCallback })
+      );
 
       // Assert
       await screen.findByText(expectedStatus);
@@ -218,7 +249,12 @@ describe('WorkspaceItem', () => {
     };
 
     // Act
-    render(h(WorkspaceItem, { workspaceMigrationInfo: transferringWorkspace }));
+    render(
+      h(WorkspaceItem, {
+        workspaceMigrationInfo: transferringWorkspace,
+        migrationStartedCallback: mockMigrationStartedCallback,
+      })
+    );
 
     // Assert
     await screen.findByText('Christina test');
@@ -249,7 +285,12 @@ describe('WorkspaceItem', () => {
     };
 
     // Act
-    render(h(WorkspaceItem, { workspaceMigrationInfo: transferringWorkspace }));
+    render(
+      h(WorkspaceItem, {
+        workspaceMigrationInfo: transferringWorkspace,
+        migrationStartedCallback: mockMigrationStartedCallback,
+      })
+    );
 
     // Assert
     await screen.findByText('Christina test');
@@ -280,7 +321,12 @@ describe('WorkspaceItem', () => {
     };
 
     // Act
-    render(h(WorkspaceItem, { workspaceMigrationInfo: transferringWorkspace }));
+    render(
+      h(WorkspaceItem, {
+        workspaceMigrationInfo: transferringWorkspace,
+        migrationStartedCallback: mockMigrationStartedCallback,
+      })
+    );
 
     // Assert
     await screen.findByText('Christina test');
@@ -292,26 +338,21 @@ describe('WorkspaceItem', () => {
     // Arrange
     const transferringWorkspace: WorkspaceMigrationInfo = {
       failureReason: undefined,
-      finalBucketTransferProgress: {
-        bytesTransferred: 0,
-        objectsTransferred: 0,
-        totalBytesToTransfer: 0,
-        totalObjectsToTransfer: 0,
-      },
+      finalBucketTransferProgress: undefined,
       migrationStep: 'TransferringToFinalBucket',
       name: 'Christina test',
       namespace: 'general-dev-billing-account',
       outcome: undefined,
-      tempBucketTransferProgress: {
-        bytesTransferred: 0,
-        objectsTransferred: 0,
-        totalBytesToTransfer: 0,
-        totalObjectsToTransfer: 0,
-      },
+      tempBucketTransferProgress: undefined,
     };
 
     // Act
-    render(h(WorkspaceItem, { workspaceMigrationInfo: transferringWorkspace }));
+    render(
+      h(WorkspaceItem, {
+        workspaceMigrationInfo: transferringWorkspace,
+        migrationStartedCallback: mockMigrationStartedCallback,
+      })
+    );
 
     // Assert
     await screen.findByText('Christina test');

--- a/src/pages/workspaces/migration/WorkspaceItem.ts
+++ b/src/pages/workspaces/migration/WorkspaceItem.ts
@@ -13,10 +13,12 @@ import {
   inProgressIcon,
   successIcon,
   WorkspaceMigrationInfo,
+  WorkspaceWithNamespace,
 } from 'src/pages/workspaces/migration/migration-utils';
 
 interface WorkspaceItemProps {
   workspaceMigrationInfo: WorkspaceMigrationInfo;
+  migrationStartedCallback: (p: WorkspaceWithNamespace[]) => {};
 }
 
 export const WorkspaceItem = (props: WorkspaceItemProps): ReactNode => {
@@ -68,7 +70,8 @@ export const WorkspaceItem = (props: WorkspaceItemProps): ReactNode => {
 
   const renderMigrationText = () => {
     const getTransferProgress = (transferType, processed, total) => {
-      if (total === 0) {
+      if (!total) {
+        // handle both 0 and undefined
         return `${transferType} Bucket Transfer`;
       }
       return `${transferType} Transfer in Progress (${Utils.formatBytes(processed)}/${Utils.formatBytes(total)})`;
@@ -154,8 +157,9 @@ export const WorkspaceItem = (props: WorkspaceItemProps): ReactNode => {
                 tooltip: migrateStarted ? 'Migration has been scheduled' : '',
                 onClick: () => {
                   const migrateWorkspace = reportErrorAndRethrow('Error starting migration', async () => {
-                    setMigrateStarted(true);
                     await Ajax().Workspaces.workspaceV2(workspaceInfo.namespace, workspaceInfo.name).migrateWorkspace();
+                    props.migrationStartedCallback([{ name: workspaceInfo.name, namespace: workspaceInfo.namespace }]);
+                    setMigrateStarted(true);
                   });
                   migrateWorkspace();
                 },

--- a/src/pages/workspaces/migration/WorkspaceMigration.ts
+++ b/src/pages/workspaces/migration/WorkspaceMigration.ts
@@ -1,15 +1,12 @@
 import { useEffect, useState } from 'react';
 import { div, h, h2, p } from 'react-hyperscript-helpers';
 import Collapse from 'src/components/Collapse';
-import { Link } from 'src/components/common';
 import FooterWrapper from 'src/components/FooterWrapper';
-import { icon } from 'src/components/icons';
 import TopBar from 'src/components/TopBar';
 import colors from 'src/libs/colors';
 import * as Nav from 'src/libs/nav';
 import { getLocalPref, setLocalPref } from 'src/libs/prefs';
 import * as Style from 'src/libs/style';
-import * as Utils from 'src/libs/utils';
 import { BillingProjectList } from 'src/pages/workspaces/migration/BillingProjectList';
 
 const MigrationInformation = () => {
@@ -41,18 +38,22 @@ const MigrationInformation = () => {
             ]),
             p([
               'Some buckets may take a very long time to migrate. You are responsible for coordinating any extended downtime with users of your workspaces. ' +
-                'Migrations cannot be stopped once they begin. Migrations are only supported form US multi-region to ' +
-                'US Central 1 (Iowa) at this time. Buckets that already exist in a single region will not be displayed.',
+                'We recommend planning for at least 24 hours of downtime for every 100TB of data in a bucket.',
             ]),
             p([
-              h(Link, { href: 'TBD', ...Utils.newTabLinkProps }, [
-                'Blog post with additional information',
-                icon('pop-out', {
-                  size: 12,
-                  style: { marginLeft: '0.25rem' },
-                }),
-              ]),
+              'Migrations cannot be stopped once they begin. Migrations are only supported form US multi-region to US Central 1 (Iowa) at this time. ' +
+                'Buckets that already exist in a single region will not be displayed.',
             ]),
+            // Don't yet have the link
+            // p([
+            //   h(Link, { href: 'TBD', ...Utils.newTabLinkProps }, [
+            //     'Blog post with additional information',
+            //     icon('pop-out', {
+            //       size: 12,
+            //       style: { marginLeft: '0.25rem' },
+            //     }),
+            //   ]),
+            // ]),
           ]),
         ]
       ),

--- a/src/pages/workspaces/migration/migration-utils.test.ts
+++ b/src/pages/workspaces/migration/migration-utils.test.ts
@@ -1,7 +1,11 @@
+import _ from 'lodash/fp';
 import {
   BillingProjectMigrationInfo,
   getBillingProjectMigrationStats,
+  mergeBillingProjectMigrationInfo,
+  mergeWorkspacesWithNamespaces,
   parseServerResponse,
+  WorkspaceMigrationInfo,
 } from 'src/pages/workspaces/migration/migration-utils';
 
 export const mockServerData = {
@@ -188,5 +192,118 @@ describe('getBillingProjectMigrationStats', () => {
       succeeded: 0,
       inProgress: 1,
     });
+  });
+});
+
+describe('mergeBillingProjectMigrationInfo', () => {
+  it('Can handle an empty update list', () => {
+    const original = [bpWithSucceededAndUnscheduled, bpWithInProgress];
+    expect(mergeBillingProjectMigrationInfo(original, [])).toEqual(original);
+  });
+
+  it('Can merge in a workspace that has started migration', () => {
+    const original: BillingProjectMigrationInfo[] = [bpWithSucceededAndUnscheduled, bpWithInProgress];
+    const updatedWorkspaceInfo: WorkspaceMigrationInfo = {
+      migrationStep: 'ScheduledForMigration',
+      name: 'notmigrated',
+      namespace: 'CARBilling-2',
+      failureReason: undefined,
+      outcome: undefined,
+      finalBucketTransferProgress: undefined,
+      tempBucketTransferProgress: undefined,
+    };
+
+    const updated: BillingProjectMigrationInfo[] = [
+      {
+        namespace: 'CARBilling-2',
+        workspaces: [updatedWorkspaceInfo],
+      },
+    ];
+    const expected = [
+      {
+        namespace: 'CARBilling-2',
+        workspaces: [bpWithSucceededAndUnscheduled.workspaces[0], updatedWorkspaceInfo],
+      },
+      bpWithInProgress,
+    ];
+    expect(mergeBillingProjectMigrationInfo(original, updated)).toMatchObject(expected);
+  });
+
+  it('Can merge in a workspace that has finished migration', () => {
+    const original: BillingProjectMigrationInfo[] = [bpWithSucceededAndUnscheduled, bpWithInProgress];
+    const updatedWorkspaceInfo: WorkspaceMigrationInfo = {
+      failureReason: undefined,
+      finalBucketTransferProgress: {
+        bytesTransferred: 288912,
+        objectsTransferred: 561,
+        totalBytesToTransfer: 288912,
+        totalObjectsToTransfer: 561,
+      },
+      migrationStep: 'Finished',
+      name: 'Christina test',
+      namespace: 'general-dev-billing-account',
+      outcome: 'success',
+      tempBucketTransferProgress: {
+        bytesTransferred: 288912,
+        objectsTransferred: 561,
+        totalBytesToTransfer: 288912,
+        totalObjectsToTransfer: 561,
+      },
+    };
+    const updated: BillingProjectMigrationInfo[] = [
+      {
+        namespace: 'general-dev-billing-account',
+        workspaces: [updatedWorkspaceInfo],
+      },
+    ];
+    const expected = [bpWithSucceededAndUnscheduled, updated[0]];
+    expect(mergeBillingProjectMigrationInfo(original, updated)).toMatchObject(expected);
+  });
+
+  it('Can merge in a workspace that has failed', () => {
+    const original: BillingProjectMigrationInfo[] = [bpWithInProgress];
+    const updatedWorkspaceInfo: WorkspaceMigrationInfo = {
+      failureReason:
+        'The bucket migration failed while removing workspace bucket IAM: invalid billing account on billing project.',
+      finalBucketTransferProgress: undefined,
+      migrationStep: 'Finished',
+      name: 'Christina test',
+      namespace: 'general-dev-billing-account',
+      outcome: 'failure',
+      tempBucketTransferProgress: undefined,
+    };
+    const updated: BillingProjectMigrationInfo[] = [
+      {
+        namespace: 'general-dev-billing-account',
+        workspaces: [updatedWorkspaceInfo],
+      },
+    ];
+    expect(mergeBillingProjectMigrationInfo(original, updated)).toMatchObject(updated);
+  });
+});
+
+describe('mergeWorkspacesWithNamespaces', () => {
+  it('Can handle an empty update list', () => {
+    const original = [{ name: 'name1', namespace: 'namespace1' }];
+    expect(mergeWorkspacesWithNamespaces(original, [])).toEqual(original);
+  });
+
+  it('Can handle an empty update list with duplicates', () => {
+    const original = [
+      { name: 'name1', namespace: 'namespace1' },
+      { name: 'name2', namespace: 'namespace2' },
+    ];
+    const updated = [
+      { name: 'name3', namespace: 'namespace3' },
+      { name: 'name2', namespace: 'namespace2' },
+    ];
+
+    const merged = mergeWorkspacesWithNamespaces(original, updated);
+    const expected = [
+      { name: 'name1', namespace: 'namespace1' },
+      { name: 'name3', namespace: 'namespace3' },
+      { name: 'name2', namespace: 'namespace2' },
+    ];
+    expect(_.sortBy('name', merged)).toEqual(_.sortBy('name', expected));
   });
 });

--- a/src/pages/workspaces/migration/migration-utils.ts
+++ b/src/pages/workspaces/migration/migration-utils.ts
@@ -47,6 +47,11 @@ export interface BillingProjectMigrationInfo {
   workspaces: WorkspaceMigrationInfo[];
 }
 
+export interface WorkspaceWithNamespace {
+  name: string;
+  namespace: string;
+}
+
 // Server types that are transformed into the exported types.
 type ServerMigrationStep =
   | 'ScheduledForMigration'
@@ -167,4 +172,35 @@ export const getBillingProjectMigrationStats = (
     );
   });
   return migrationStats;
+};
+
+export const mergeBillingProjectMigrationInfo = (
+  original: BillingProjectMigrationInfo[],
+  updated: BillingProjectMigrationInfo[]
+) => {
+  const modified = _.cloneDeep(original);
+  updated.forEach((migrationInfo) => {
+    modified.forEach((modifiedMigrationInfo) => {
+      if (migrationInfo.namespace === modifiedMigrationInfo.namespace) {
+        modifiedMigrationInfo.workspaces = _.unionBy(
+          'name',
+          migrationInfo.workspaces,
+          modifiedMigrationInfo.workspaces
+        );
+        modifiedMigrationInfo.workspaces = _.orderBy(
+          [({ name }) => _.lowerCase(name)],
+          ['asc'],
+          modifiedMigrationInfo.workspaces
+        );
+      }
+    });
+  });
+  return modified;
+};
+
+export const mergeWorkspacesWithNamespaces = (
+  original: WorkspaceWithNamespace[],
+  updated: WorkspaceWithNamespace[]
+) => {
+  return _.unionWith(_.isEqual, original, updated);
 };


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-1264

Adds auto-refresh on in progress workspaces. The only workspaces that we should be querying on are those that were in the process of migrating when the page was first loaded, plus any that the user pressed the "migrate" button for (at the workspace or billing project level).

For example:

![image](https://github.com/DataBiosphere/terra-ui/assets/484484/b6f0d64c-98f6-494e-b5a1-7148e47a525c)

