### PR TITLE
[AJ-1394] Remove support for importing multiple catalog datasets using snapshot by reference

### DIFF
--- a/src/import-data/ImportData.test.ts
+++ b/src/import-data/ImportData.test.ts
@@ -6,7 +6,6 @@ import { useWorkspaces } from 'src/components/workspace-utils';
 import { Ajax } from 'src/libs/ajax';
 import { DataRepo, DataRepoContract, Snapshot } from 'src/libs/ajax/DataRepo';
 import { useRoute } from 'src/libs/nav';
-import { fetchDataCatalog } from 'src/pages/library/dataBrowser-utils';
 import { asMockedFn, renderWithAppContexts as render, SelectHelper } from 'src/testing/test-utils';
 import { defaultAzureWorkspace, defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
 
@@ -356,72 +355,6 @@ describe('ImportData', () => {
   });
 
   describe('catalog', () => {
-    it('imports multiple snapshots by reference from the data catalog', async () => {
-      // Arrange
-      const user = userEvent.setup();
-
-      asMockedFn(fetchDataCatalog).mockResolvedValue([
-        {
-          id: 'aaaabbbb-cccc-dddd-eeee-ffffgggghhhh',
-          'dct:creator': 'testowner',
-          'dct:description': 'A test snapshot',
-          'dct:identifier': '00001111-2222-3333-aaaa-bbbbccccdddd',
-          'dct:issued': '2023-10-02T11:30:00.000000Z',
-          'dct:title': 'test-snapshot-1',
-          'dcat:accessURL':
-            'https://jade.datarepo-dev.broadinstitute.org/snapshots/details/00001111-2222-3333-aaaa-bbbbccccdddd',
-          'TerraDCAT_ap:hasDataCollection': [],
-          accessLevel: 'reader',
-          storage: [],
-          counts: {},
-          samples: {},
-          contributors: [],
-        },
-        {
-          id: '11112222-3333-4444-5555-666677778888',
-          'dct:creator': 'testowner',
-          'dct:description': 'Another test snapshot',
-          'dct:identifier': 'aaaabbbb-cccc-1111-2222-333333333333',
-          'dct:issued': '2023-10-02T11:30:00.000000Z',
-          'dct:title': 'test-snapshot-2',
-          'dcat:accessURL':
-            'https://jade.datarepo-dev.broadinstitute.org/snapshots/details/aaaabbbb-cccc-1111-2222-333333333333',
-          'TerraDCAT_ap:hasDataCollection': [],
-          accessLevel: 'reader',
-          storage: [],
-          counts: {},
-          samples: {},
-          contributors: [],
-        },
-      ]);
-
-      const queryParams = {
-        format: 'snapshot',
-        snapshotIds: ['00001111-2222-3333-aaaa-bbbbccccdddd', 'aaaabbbb-cccc-1111-2222-333333333333'],
-      };
-      const { getWorkspaceApi, importSnapshot } = await setup({ queryParams });
-
-      // Act
-      await importIntoExistingWorkspace(user, defaultGoogleWorkspace.workspace.name);
-
-      // Assert
-      expect(getWorkspaceApi).toHaveBeenCalledWith(
-        defaultGoogleWorkspace.workspace.namespace,
-        defaultGoogleWorkspace.workspace.name
-      );
-
-      expect(importSnapshot).toHaveBeenCalledWith(
-        '00001111-2222-3333-aaaa-bbbbccccdddd',
-        'test-snapshot-1',
-        'A test snapshot'
-      );
-      expect(importSnapshot).toHaveBeenCalledWith(
-        'aaaabbbb-cccc-1111-2222-333333333333',
-        'test-snapshot-2',
-        'Another test snapshot'
-      );
-    });
-
     it('imports from the data catalog', async () => {
       // Arrange
       const user = userEvent.setup();

--- a/src/import-data/ImportDataDestination.ts
+++ b/src/import-data/ImportDataDestination.ts
@@ -109,7 +109,7 @@ export const ImportDataDestination = (props: ImportDataDestinationProps): ReactN
 
   // Some import types are finished in a single request.
   // For most though, the import request starts a background task that takes time to complete.
-  const immediateImportTypes: ImportRequest['type'][] = ['tdr-snapshot-reference', 'catalog-snapshots'];
+  const immediateImportTypes: ImportRequest['type'][] = ['tdr-snapshot-reference'];
   const importMayTakeTime = !immediateImportTypes.includes(importRequest.type);
 
   const {

--- a/src/import-data/ImportDataOverview.test.ts
+++ b/src/import-data/ImportDataOverview.test.ts
@@ -8,7 +8,6 @@ const renderImportDataOverview = (props: Partial<ImportDataOverviewProps> = {}):
   render(
     h(ImportDataOverview, {
       importRequest: { type: 'pfb', url: new URL('https://example.com/path/to/file.pfb') },
-      snapshotResponses: [],
       ...props,
     })
   );

--- a/src/import-data/ImportDataOverview.ts
+++ b/src/import-data/ImportDataOverview.ts
@@ -1,7 +1,5 @@
-import { IconId } from '@terra-ui-packages/components';
-import { DEFAULT, switchCase } from '@terra-ui-packages/core-utils';
-import { CSSProperties, Fragment, ReactNode } from 'react';
-import { div, h, h2, li, strong, ul } from 'react-hyperscript-helpers';
+import { CSSProperties, ReactNode } from 'react';
+import { div, h, h2 } from 'react-hyperscript-helpers';
 import { Link } from 'src/components/common';
 import { icon } from 'src/components/icons';
 import colors from 'src/libs/colors';
@@ -35,49 +33,12 @@ const styles = {
   },
 } as const satisfies Record<string, CSSProperties>;
 
-interface ResponseFragmentProps {
-  responseIndex: number;
-  snapshotResponses: { status: string; message: string | undefined }[] | undefined;
-  title: string;
-}
-
-const ResponseFragment = (props: ResponseFragmentProps): ReactNode => {
-  const { title, snapshotResponses, responseIndex } = props;
-  const { status, message } = snapshotResponses
-    ? snapshotResponses[responseIndex]
-    : { status: undefined, message: undefined };
-
-  const [color, iconKey, children] = switchCase<string | undefined, [string, IconId, ReactNode]>(
-    status,
-    [
-      'fulfilled',
-      () => [
-        colors.primary(),
-        'success-standard',
-        h(Fragment, [strong(['Success: ']), 'Snapshot successfully imported']),
-      ],
-    ],
-    ['rejected', () => [colors.danger(), 'warning-standard', h(Fragment, [strong(['Error: ']), message])]],
-    [DEFAULT, () => [colors.primary(), 'success-standard', null]]
-  );
-
-  return h(Fragment, [
-    icon(iconKey, { size: 18, style: { position: 'absolute', left: 0, color } }),
-    title,
-    children &&
-      div({ style: { color, fontWeight: 'normal', fontSize: '0.625rem', marginTop: 5, wordBreak: 'break-word' } }, [
-        children,
-      ]),
-  ]);
-};
-
 const getTitleForImportRequest = (importRequest: ImportRequest): string => {
   switch (importRequest.type) {
     case 'tdr-snapshot-export':
       return `Importing snapshot ${importRequest.snapshot.name}`;
     case 'tdr-snapshot-reference':
     case 'catalog-dataset':
-    case 'catalog-snapshots':
       return 'Linking data to a workspace';
     default:
       return 'Importing data to a workspace';
@@ -86,37 +47,15 @@ const getTitleForImportRequest = (importRequest: ImportRequest): string => {
 
 export interface ImportDataOverviewProps {
   importRequest: ImportRequest;
-  snapshotResponses: { status: string; message: string | undefined }[] | undefined;
 }
 
 export const ImportDataOverview = (props: ImportDataOverviewProps): ReactNode => {
-  const { importRequest, snapshotResponses } = props;
+  const { importRequest } = props;
 
   const isProtectedData = isProtectedSource(importRequest);
 
   return div({ style: styles.card }, [
     h2({ style: styles.title }, [getTitleForImportRequest(importRequest)]),
-    importRequest.type === 'catalog-snapshots' &&
-      div({ style: { marginTop: 20, marginBottom: 60 } }, [
-        'Dataset(s):',
-        ul({ style: { listStyle: 'none', position: 'relative', marginLeft: 0, paddingLeft: '2rem' } }, [
-          importRequest.snapshots.map(({ title, id }, index) => {
-            return li(
-              {
-                key: `snapshot_${id}`,
-                style: {
-                  fontSize: 16,
-                  fontWeight: 'bold',
-                  marginTop: 20,
-                  paddingTop: index ? 20 : 0,
-                  borderTop: `${index ? 1 : 0}px solid #AAA`,
-                },
-              },
-              [h(ResponseFragment, { snapshotResponses, responseIndex: index, title })]
-            );
-          }),
-        ]),
-      ]),
     'url' in importRequest && div({ style: { fontSize: 16 } }, ['From: ', importRequest.url.hostname]),
     div(
       { style: { marginTop: '1rem' } },

--- a/src/import-data/import-types.ts
+++ b/src/import-data/import-types.ts
@@ -34,23 +34,13 @@ export interface CatalogDatasetImportRequest {
   datasetId: string;
 }
 
-export interface CatalogSnapshotsImportRequest {
-  type: 'catalog-snapshots';
-  snapshots: {
-    id: string;
-    title: string;
-    description: string;
-  }[];
-}
-
 export type ImportRequest =
   | PFBImportRequest
   | BagItImportRequest
   | EntitiesImportRequest
   | TDRSnapshotExportImportRequest
   | TDRSnapshotReferenceImportRequest
-  | CatalogDatasetImportRequest
-  | CatalogSnapshotsImportRequest;
+  | CatalogDatasetImportRequest;
 
 export interface TemplateWorkspaceInfo {
   name: string;

--- a/src/import-data/useImportRequest.test.ts
+++ b/src/import-data/useImportRequest.test.ts
@@ -5,7 +5,6 @@ import { asMockedFn } from 'src/testing/test-utils';
 import {
   BagItImportRequest,
   CatalogDatasetImportRequest,
-  CatalogSnapshotsImportRequest,
   EntitiesImportRequest,
   ImportRequest,
   PFBImportRequest,
@@ -141,28 +140,6 @@ describe('getImportRequest', () => {
         datasetId: '00001111-2222-3333-aaaa-bbbbccccdddd',
       } satisfies CatalogDatasetImportRequest,
     },
-    // Catalog snapshots
-    {
-      queryParams: {
-        format: 'snapshot',
-        snapshotIds: ['aaaabbbb-cccc-1111-2222-333333333333', '00001111-2222-3333-aaaa-bbbbccccdddd'],
-      },
-      expectedResult: {
-        type: 'catalog-snapshots',
-        snapshots: [
-          {
-            id: '00001111-2222-3333-aaaa-bbbbccccdddd',
-            title: 'test-snapshot-1',
-            description: 'A test snapshot',
-          },
-          {
-            id: 'aaaabbbb-cccc-1111-2222-333333333333',
-            title: 'test-snapshot-2',
-            description: 'Another test snapshot',
-          },
-        ],
-      } satisfies CatalogSnapshotsImportRequest,
-    },
   ];
 
   beforeAll(() => {
@@ -285,57 +262,6 @@ describe('getImportRequest', () => {
       // Assert
       await expect(importRequest).rejects.toEqual(
         new Error('Importing by reference is not supported for Azure snapshots.')
-      );
-    });
-  });
-
-  describe('catalog snapshot imports', () => {
-    it('throws an error if unable to load the catalog', async () => {
-      // Arrange
-      asMockedFn(fetchDataCatalog).mockRejectedValue(new Response('Something went wrong', { status: 500 }));
-
-      // Act
-      const queryParams = {
-        format: 'snapshot',
-        snapshotIds: ['aaaabbbb-cccc-1111-2222-333333333333', '00001111-2222-3333-aaaa-bbbbccccdddd'],
-      };
-      const importRequestPromise = getImportRequest(queryParams);
-
-      // Assert
-      await expect(importRequestPromise).rejects.toEqual(new Error('Failed to load data catalog.'));
-    });
-
-    it('throws an error if any requested snapshots are not found in catalog', async () => {
-      // Arrange
-      asMockedFn(fetchDataCatalog).mockResolvedValue([
-        {
-          id: 'aaaabbbb-cccc-dddd-eeee-ffffgggghhhh',
-          'dct:creator': 'testowner',
-          'dct:description': 'A test snapshot',
-          'dct:identifier': '00001111-2222-3333-aaaa-bbbbccccdddd',
-          'dct:issued': '2023-10-02T11:30:00.000000Z',
-          'dct:title': 'test-snapshot-1',
-          'dcat:accessURL':
-            'https://jade.datarepo-dev.broadinstitute.org/snapshots/details/00001111-2222-3333-aaaa-bbbbccccdddd',
-          'TerraDCAT_ap:hasDataCollection': [],
-          accessLevel: 'reader',
-          storage: [],
-          counts: {},
-          samples: {},
-          contributors: [],
-        },
-      ]);
-
-      // Act
-      const queryParams = {
-        format: 'snapshot',
-        snapshotIds: ['00001111-2222-3333-aaaa-bbbbccccdddd', 'ddddeeee-ffff-4444-5555-666666666666'],
-      };
-      const importRequestPromise = getImportRequest(queryParams);
-
-      // Assert
-      await expect(importRequestPromise).rejects.toEqual(
-        new Error('Unable to find snapshot ddddeeee-ffff-4444-5555-666666666666 in catalog.')
       );
     });
   });


### PR DESCRIPTION
Following up on https://github.com/DataBiosphere/terra-ui/pull/4329#discussion_r1353024568...

It looks like this feature is unused. I don't see any snapshot based datasets in the production Catalog and there doesn't seem to be UI support for importing multiple Catalog datasets at once. There's a fair bit of complexity in the import data components to handle error responses from the multiple import requests that this import type uses, and it would be nice to remove that complexity if it's not required.