### PR TITLE
WOR-1235 Changes to dashboard for workspace deletion

### DIFF
--- a/src/analysis/modals/CloudEnvironmentModal.ts
+++ b/src/analysis/modals/CloudEnvironmentModal.ts
@@ -372,9 +372,6 @@ export const CloudEnvironmentModal = ({
     );
 
   const isCloudEnvModalDisabled = (toolLabel: ToolLabel): boolean => {
-    if (workspace.workspace.state === 'Deleting' || workspace.workspace.state === 'DeleteFailed') {
-      return true;
-    }
     if (isAppToolLabel(toolLabel)) {
       return (
         !canCompute ||

--- a/src/analysis/modals/CloudEnvironmentModal.ts
+++ b/src/analysis/modals/CloudEnvironmentModal.ts
@@ -372,6 +372,9 @@ export const CloudEnvironmentModal = ({
     );
 
   const isCloudEnvModalDisabled = (toolLabel: ToolLabel): boolean => {
+    if (workspace.workspace.state === 'Deleting' || workspace.workspace.state === 'DeleteFailed') {
+      return true;
+    }
     if (isAppToolLabel(toolLabel)) {
       return (
         !canCompute ||

--- a/src/libs/workspace-utils.ts
+++ b/src/libs/workspace-utils.ts
@@ -33,6 +33,7 @@ interface BaseWorkspaceInfo {
   attributes?: Record<string, unknown>;
   isLocked?: boolean;
   state?: WorkspaceState;
+  errorMessage?: string;
 }
 
 export interface AzureWorkspaceInfo extends BaseWorkspaceInfo {

--- a/src/pages/workspaces/workspace/Dashboard/CloudInformation.ts
+++ b/src/pages/workspaces/workspace/Dashboard/CloudInformation.ts
@@ -140,39 +140,37 @@ const GoogleCloudInformation = (props: GoogleCloudInformationProps): ReactNode =
           [bucketSize?.usage]
         ),
     ]),
-    h(Fragment, [
-      div({ style: { paddingBottom: '0.5rem' } }, [
-        h(
-          Link,
-          {
-            style: { margin: '1rem 0.5rem' },
-            ...newTabLinkProps,
-            onClick: () => {
-              Ajax().Metrics.captureEvent(Events.workspaceOpenedBucketInBrowser, {
-                ...extractWorkspaceDetails(workspace),
-              });
-            },
-            href: bucketBrowserUrl(bucketName),
+    div({ style: { paddingBottom: '0.5rem' } }, [
+      h(
+        Link,
+        {
+          style: { margin: '1rem 0.5rem' },
+          ...newTabLinkProps,
+          onClick: () => {
+            Ajax().Metrics.captureEvent(Events.workspaceOpenedBucketInBrowser, {
+              ...extractWorkspaceDetails(workspace),
+            });
           },
-          ['Open bucket in browser', icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })]
-        ),
-      ]),
-      div({ style: { paddingBottom: '0.5rem' } }, [
-        h(
-          Link,
-          {
-            style: { margin: '1rem 0.5rem' },
-            ...newTabLinkProps,
-            onClick: () => {
-              Ajax().Metrics.captureEvent(Events.workspaceOpenedProjectInConsole, {
-                ...extractWorkspaceDetails(workspace),
-              });
-            },
-            href: `https://console.cloud.google.com/welcome?project=${googleProject}`,
+          href: bucketBrowserUrl(bucketName),
+        },
+        ['Open bucket in browser', icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })]
+      ),
+    ]),
+    div({ style: { paddingBottom: '0.5rem' } }, [
+      h(
+        Link,
+        {
+          style: { margin: '1rem 0.5rem' },
+          ...newTabLinkProps,
+          onClick: () => {
+            Ajax().Metrics.captureEvent(Events.workspaceOpenedProjectInConsole, {
+              ...extractWorkspaceDetails(workspace),
+            });
           },
-          ['Open project in Google Cloud Console', icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })]
-        ),
-      ]),
+          href: `https://console.cloud.google.com/welcome?project=${googleProject}`,
+        },
+        ['Open project in Google Cloud Console', icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })]
+      ),
     ]),
   ]);
 };

--- a/src/pages/workspaces/workspace/Dashboard/Dashboard.ts
+++ b/src/pages/workspaces/workspace/Dashboard/Dashboard.ts
@@ -3,6 +3,7 @@ import _ from 'lodash/fp';
 import {
   CSSProperties,
   ForwardedRef,
+  ForwardRefRenderFunction,
   Fragment,
   ReactNode,
   useCallback,
@@ -491,7 +492,9 @@ const WorkspaceDashboardComponent = (
   ]);
 };
 
-const WorkspaceDashboard: (props: WorkspaceDashboardProps) => typeof WorkspaceDashboardComponent = _.flow(
+const WorkspaceDashboard: (
+  props: WorkspaceDashboardProps
+) => ForwardRefRenderFunction<typeof WorkspaceDashboardComponent, WorkspaceDashboardProps> = _.flow(
   forwardRefWithName('WorkspaceDashboard'),
   wrapWorkspace({
     breadcrumbs: (props) => breadcrumbs.commonPaths.workspaceDashboard(props),

--- a/src/pages/workspaces/workspace/Dashboard/OwnerNotice.ts
+++ b/src/pages/workspaces/workspace/Dashboard/OwnerNotice.ts
@@ -1,6 +1,6 @@
-import { cond } from '@terra-ui-packages/core-utils';
+import { cond, DEFAULT } from '@terra-ui-packages/core-utils';
 import _ from 'lodash/fp';
-import { Fragment, ReactNode } from 'react';
+import { ReactNode } from 'react';
 import { h } from 'react-hyperscript-helpers';
 import { Link } from 'src/components/common';
 import { InfoBox } from 'src/components/InfoBox';
@@ -17,36 +17,41 @@ interface OwnerNoticeProps {
 
 export const OwnerNotice = (props: OwnerNoticeProps): ReactNode => {
   const { owners, accessLevel, acl } = props;
-  const notice = cond(
+  return cond(
     // No warning if there are multiple owners.
     [_.size(owners) !== 1, () => null],
     // If the current user does not own the workspace, then then workspace must be shared.
     [
       !isOwner(accessLevel),
       () =>
-        h(Fragment, [
-          'This shared workspace has only one owner. Consider requesting ',
-          h(Link, { href: `mailto:${owners[0]}` }, [owners[0]]),
-          ' to add another owner to ensure someone is able to manage the workspace in case they lose access to their account.',
-        ]),
+        h(
+          InfoBox,
+          {
+            icon: 'error-standard',
+            style: { color: colors.accent() },
+          },
+          [
+            'This shared workspace has only one owner. Consider requesting ',
+            h(Link, { href: `mailto:${owners[0]}` }, [owners[0]]),
+            ' to add another owner to ensure someone is able to manage the workspace in case they lose access to their account.',
+          ]
+        ),
     ],
     // If the current user is the only owner of the workspace, check if the workspace is shared.
     [
       _.size(acl) > 1,
       () =>
-        h(Fragment, [
-          'You are the only owner of this shared workspace. Consider adding another owner to ensure someone is able to manage the workspace in case you lose access to your account.',
-        ]),
-    ]
+        h(
+          InfoBox,
+          {
+            icon: 'error-standard',
+            style: { color: colors.accent() },
+          },
+          [
+            'You are the only owner of this shared workspace. Consider adding another owner to ensure someone is able to manage the workspace in case you lose access to your account.',
+          ]
+        ),
+    ],
+    [DEFAULT, () => null]
   );
-  return !notice
-    ? undefined
-    : h(
-        InfoBox,
-        {
-          icon: 'error-standard',
-          style: { color: colors.accent() },
-        },
-        [notice]
-      );
 };

--- a/src/pages/workspaces/workspace/WorkspaceContainer.ts
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.ts
@@ -33,6 +33,7 @@ import {
   StorageDetails,
   useWorkspace,
 } from 'src/pages/workspaces/workspace/useWorkspace';
+import { WorkspaceDeletingBanner } from 'src/pages/workspaces/workspace/WorkspaceDeletingBanner';
 import { WorkspaceTabs } from 'src/pages/workspaces/workspace/WorkspaceTabs';
 
 const TitleBarWarning = (props: PropsWithChildren): ReactNode => {
@@ -165,6 +166,7 @@ export const WorkspaceContainer = (props: WorkspaceContainerProps) => {
       setSharingWorkspace,
       setShowLockWorkspaceModal,
     }),
+    h(WorkspaceDeletingBanner, { workspace }),
     workspaceLoaded && isAzureWorkspace(workspace) && h(AzureWarning),
     isGoogleWorkspaceSyncing && h(GooglePermissionsSpinner),
     div({ role: 'main', style: Style.elements.pageContentContainer }, [

--- a/src/pages/workspaces/workspace/WorkspaceContainer.ts
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.ts
@@ -49,6 +49,7 @@ const TitleBarWarning = (props: PropsWithChildren): ReactNode => {
     ),
     style: { backgroundColor: colors.accent(0.35), borderBottom: `1px solid ${colors.accent()}` },
     onDismiss: () => {},
+    hideCloseButton: true,
   });
 };
 

--- a/src/pages/workspaces/workspace/WorkspaceContainer.ts
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.ts
@@ -87,7 +87,7 @@ const GooglePermissionsSpinner = (): ReactNode => {
   return h(TitleBarSpinner, warningMessage);
 };
 
-interface WorkspaceContainerProps {
+interface WorkspaceContainerProps extends PropsWithChildren {
   namespace: string;
   name: string;
   breadcrumbs: ReactNode;
@@ -100,7 +100,7 @@ interface WorkspaceContainerProps {
   refreshWorkspace: () => void;
 }
 
-export const WorkspaceContainer = (props: PropsWithChildren<WorkspaceContainerProps>) => {
+export const WorkspaceContainer = (props: WorkspaceContainerProps) => {
   const {
     namespace,
     name,

--- a/src/pages/workspaces/workspace/WorkspaceContainer.ts
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.ts
@@ -171,6 +171,8 @@ export const WorkspaceContainer = (props: PropsWithChildren<WorkspaceContainerPr
       div({ style: { flex: 1, display: 'flex' } }, [
         div({ style: { flex: 1, display: 'flex', flexDirection: 'column' } }, [children]),
         workspace &&
+          workspace?.workspace.state !== 'Deleting' &&
+          workspace?.workspace.state !== 'DeleteFailed' &&
           h(ContextBar, {
             workspace,
             apps,

--- a/src/pages/workspaces/workspace/WorkspaceContainer.ts
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.ts
@@ -90,7 +90,7 @@ const GooglePermissionsSpinner = (): ReactNode => {
 interface WorkspaceContainerProps extends PropsWithChildren {
   namespace: string;
   name: string;
-  breadcrumbs: ReactNode;
+  breadcrumbs: ReactNode[];
   title: string;
   activeTab?: string;
   analysesData: AppDetails & CloudEnvironmentDetails;
@@ -126,7 +126,7 @@ export const WorkspaceContainer = (props: WorkspaceContainerProps) => {
   return h(FooterWrapper, [
     h(TopBar, { title: 'Workspaces', href: Nav.getLink('workspaces') }, [
       div({ style: Style.breadcrumb.breadcrumb }, [
-        div({ style: Style.noWrapEllipsis }, [breadcrumbs]),
+        div({ style: Style.noWrapEllipsis }, breadcrumbs),
         h2({ style: Style.breadcrumb.textUnderBreadcrumb }, [title || `${namespace}/${name}`]),
       ]),
       div({ style: { flexGrow: 1 } }),
@@ -371,7 +371,7 @@ const useAppPolling = (workspace: Workspace): AppDetails => {
 };
 
 interface WrapWorkspaceProps {
-  breadcrumbs: (props: { name: string; namespace: string }) => ReactNode;
+  breadcrumbs: (props: { name: string; namespace: string }) => ReactNode[];
   activeTab?: string;
   title: string;
 }

--- a/src/pages/workspaces/workspace/WorkspaceDeletingBanner.test.ts
+++ b/src/pages/workspaces/workspace/WorkspaceDeletingBanner.test.ts
@@ -57,6 +57,8 @@ describe('WorkspaceDeletingBanner', () => {
     expect(detailsLink).toBeNull();
   });
 
+  /*
+  TODO: re-enable when https://broadworkbench.atlassian.net/browse/WOR-1283 is complete
   it('gives a link to display the workspace error message if present', () => {
     // Arrange
     const workspace: Workspace = {
@@ -75,8 +77,7 @@ describe('WorkspaceDeletingBanner', () => {
     expect(detailsLink).not.toBeNull();
   });
 
-  /*
-  TODO: re-enable when https://broadworkbench.atlassian.net/browse/WOR-1283 is complete
+  
   it('shows the error message in a modal when the details link is clicked', () => {
     // Arrange
     const workspace: Workspace = {

--- a/src/pages/workspaces/workspace/WorkspaceDeletingBanner.test.ts
+++ b/src/pages/workspaces/workspace/WorkspaceDeletingBanner.test.ts
@@ -1,4 +1,4 @@
-import { fireEvent, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { h } from 'react-hyperscript-helpers';
 import { WorkspaceWrapper as Workspace } from 'src/libs/workspace-utils';
 import { WorkspaceDeletingBanner } from 'src/pages/workspaces/workspace/WorkspaceDeletingBanner';
@@ -75,6 +75,8 @@ describe('WorkspaceDeletingBanner', () => {
     expect(detailsLink).not.toBeNull();
   });
 
+  /*
+  TODO: re-enable when https://broadworkbench.atlassian.net/browse/WOR-1283 is complete
   it('shows the error message in a modal when the details link is clicked', () => {
     // Arrange
     const workspace: Workspace = {
@@ -95,4 +97,5 @@ describe('WorkspaceDeletingBanner', () => {
     const message = screen.getByText('A semi-helpful message!');
     expect(message).not.toBeNull();
   });
+  */
 });

--- a/src/pages/workspaces/workspace/WorkspaceDeletingBanner.test.ts
+++ b/src/pages/workspaces/workspace/WorkspaceDeletingBanner.test.ts
@@ -1,0 +1,98 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { h } from 'react-hyperscript-helpers';
+import { WorkspaceWrapper as Workspace } from 'src/libs/workspace-utils';
+import { WorkspaceDeletingBanner } from 'src/pages/workspaces/workspace/WorkspaceDeletingBanner';
+import { renderWithAppContexts as render } from 'src/testing/test-utils';
+import { defaultAzureWorkspace } from 'src/testing/workspace-fixtures';
+
+// Mocking for Nav.getLink
+type NavExports = typeof import('src/libs/nav');
+jest.mock(
+  'src/libs/nav',
+  (): NavExports => ({
+    ...jest.requireActual<NavExports>('src/libs/nav'),
+    getLink: jest.fn(() => '/'),
+  })
+);
+
+describe('WorkspaceDeletingBanner', () => {
+  it('shows a message when the workspace is deleting', () => {
+    // Arrange
+    const workspace: Workspace = {
+      ...defaultAzureWorkspace,
+      workspace: {
+        ...defaultAzureWorkspace.workspace,
+        state: 'Deleting',
+      },
+    };
+    // Act
+    render(h(WorkspaceDeletingBanner, { workspace }));
+
+    // Assert
+    const message = screen.getByText(
+      'Workspace deletion in progress. Analyses, Workflow, and Data tools are no longer accessible.'
+    );
+    expect(message).not.toBeNull();
+  });
+
+  it('shows a message when the workspace has failed deletion', () => {
+    // Arrange
+    const workspace: Workspace = {
+      ...defaultAzureWorkspace,
+      workspace: {
+        ...defaultAzureWorkspace.workspace,
+        state: 'DeleteFailed',
+      },
+    };
+    // Act
+    render(h(WorkspaceDeletingBanner, { workspace }));
+
+    // Assert
+    const message = screen.getByText(
+      'Error deleting workspace. Analyses, Workflow, and Data tools are no longer accessible.'
+    );
+    expect(message).not.toBeNull();
+    // we didn't set the workspace error message, so there should not be a link for details
+    const detailsLink = screen.queryByText('See error details.');
+    expect(detailsLink).toBeNull();
+  });
+
+  it('gives a link to display the workspace error message if present', () => {
+    // Arrange
+    const workspace: Workspace = {
+      ...defaultAzureWorkspace,
+      workspace: {
+        ...defaultAzureWorkspace.workspace,
+        state: 'DeleteFailed',
+        errorMessage: 'A semi-helpful message!',
+      },
+    };
+    // Act
+    render(h(WorkspaceDeletingBanner, { workspace }));
+
+    // Assert
+    const detailsLink = screen.getByText('See error details.');
+    expect(detailsLink).not.toBeNull();
+  });
+
+  it('shows the error message in a modal when the details link is clicked', () => {
+    // Arrange
+    const workspace: Workspace = {
+      ...defaultAzureWorkspace,
+      workspace: {
+        ...defaultAzureWorkspace.workspace,
+        state: 'DeleteFailed',
+        errorMessage: 'A semi-helpful message!',
+      },
+    };
+    // Act
+    render(h(WorkspaceDeletingBanner, { workspace }));
+
+    // Assert
+    const detailsLink = screen.getByText('See error details.');
+    expect(detailsLink).not.toBeNull();
+    fireEvent.click(detailsLink);
+    const message = screen.getByText('A semi-helpful message!');
+    expect(message).not.toBeNull();
+  });
+});

--- a/src/pages/workspaces/workspace/WorkspaceDeletingBanner.test.ts
+++ b/src/pages/workspaces/workspace/WorkspaceDeletingBanner.test.ts
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import { h } from 'react-hyperscript-helpers';
 import { WorkspaceWrapper as Workspace } from 'src/libs/workspace-utils';
 import { WorkspaceDeletingBanner } from 'src/pages/workspaces/workspace/WorkspaceDeletingBanner';
@@ -57,9 +57,8 @@ describe('WorkspaceDeletingBanner', () => {
     expect(detailsLink).toBeNull();
   });
 
-  /*
-  TODO: re-enable when https://broadworkbench.atlassian.net/browse/WOR-1283 is complete
-  it('gives a link to display the workspace error message if present', () => {
+  // TODO: re-enable when https://broadworkbench.atlassian.net/browse/WOR-1283 is complete
+  xit('gives a link to display the workspace error message if present', () => {
     // Arrange
     const workspace: Workspace = {
       ...defaultAzureWorkspace,
@@ -77,8 +76,8 @@ describe('WorkspaceDeletingBanner', () => {
     expect(detailsLink).not.toBeNull();
   });
 
-  
-  it('shows the error message in a modal when the details link is clicked', () => {
+  // TODO: re-enable when https://broadworkbench.atlassian.net/browse/WOR-1283 is complete
+  xit('shows the error message in a modal when the details link is clicked', () => {
     // Arrange
     const workspace: Workspace = {
       ...defaultAzureWorkspace,
@@ -98,5 +97,4 @@ describe('WorkspaceDeletingBanner', () => {
     const message = screen.getByText('A semi-helpful message!');
     expect(message).not.toBeNull();
   });
-  */
 });

--- a/src/pages/workspaces/workspace/WorkspaceDeletingBanner.ts
+++ b/src/pages/workspaces/workspace/WorkspaceDeletingBanner.ts
@@ -37,7 +37,7 @@ const DeletingStateBanner = (): ReactNode => {
         ]),
       ]
     ),
-    style: { backgroundColor: colors.warning(0.35), borderBottom: `1px solid ${colors.accent()}` },
+    style: { backgroundColor: colors.warning(0.1), borderBottom: `1px solid ${colors.accent()}` },
     onDismiss: () => {},
     hideCloseButton: true,
   });
@@ -53,7 +53,6 @@ const DeleteFailedStateBanner = (props: WorkspaceDeletingBannerProps): ReactNode
         {
           role: 'alert',
           style: { display: 'flex', alignItems: 'center', margin: '1rem' },
-          // backgroundColor: colors.
         },
         [
           icon('error-standard', { size: 32, style: { color: colors.danger(), marginRight: '0.5rem' } }),
@@ -75,7 +74,7 @@ const DeleteFailedStateBanner = (props: WorkspaceDeletingBannerProps): ReactNode
             */
         ]
       ),
-      style: { backgroundColor: colors.warning(0.35), borderBottom: `1px solid ${colors.accent()}` },
+      style: { backgroundColor: colors.warning(0.1), borderBottom: `1px solid ${colors.accent()}` },
       onDismiss: () => {},
       hideCloseButton: true,
     }),

--- a/src/pages/workspaces/workspace/WorkspaceDeletingBanner.ts
+++ b/src/pages/workspaces/workspace/WorkspaceDeletingBanner.ts
@@ -1,8 +1,6 @@
-import { icon, Link } from '@terra-ui-packages/components';
-import { Fragment, ReactNode, useState } from 'react';
+import { icon } from '@terra-ui-packages/components';
+import { Fragment, ReactNode } from 'react';
 import { div, h, span } from 'react-hyperscript-helpers';
-import ErrorView from 'src/components/ErrorView';
-import Modal from 'src/components/Modal';
 import TitleBar from 'src/components/TitleBar';
 import colors from 'src/libs/colors';
 import { WorkspaceWrapper as Workspace } from 'src/libs/workspace-utils';
@@ -30,7 +28,10 @@ const DeletingStateBanner = (): ReactNode => {
         style: { display: 'flex', alignItems: 'center', margin: '1rem' },
       },
       [
-        icon('syncAlt', { size: 32, style: { color: colors.danger(), marginRight: '0.5rem' } }),
+        icon('syncAlt', {
+          size: 32,
+          style: { color: colors.danger(), animation: 'rotation 2s infinite linear', marginRight: '0.5rem' },
+        }),
         span({ style: { color: colors.dark(), fontSize: 14 } }, [
           'Workspace deletion in progress. Analyses, Workflow, and Data tools are no longer accessible.',
         ]),
@@ -43,20 +44,24 @@ const DeletingStateBanner = (): ReactNode => {
 };
 
 const DeleteFailedStateBanner = (props: WorkspaceDeletingBannerProps): ReactNode => {
-  const { workspace } = props;
-  const [showDetails, setShowDetails] = useState<boolean>(false);
+  // TODO: re-enable when https://broadworkbench.atlassian.net/browse/WOR-1283 is complete
+  // const { workspace } = props;
+  // const [showDetails, setShowDetails] = useState<boolean>(false);
   return h(Fragment, [
     h(TitleBar, {
       title: div(
         {
           role: 'alert',
           style: { display: 'flex', alignItems: 'center', margin: '1rem' },
+          // backgroundColor: colors.
         },
         [
-          icon('syncAlt', { size: 32, style: { color: colors.danger(), marginRight: '0.5rem' } }),
+          icon('error-standard', { size: 32, style: { color: colors.danger(), marginRight: '0.5rem' } }),
           span({ style: { color: colors.dark(), fontSize: 14, marginRight: '0.5rem' } }, [
             'Error deleting workspace. Analyses, Workflow, and Data tools are no longer accessible.',
           ]),
+          /*
+          // TODO: re-enable when https://broadworkbench.atlassian.net/browse/WOR-1283 is complete
           workspace?.workspace.errorMessage
             ? h(
                 Link,
@@ -67,12 +72,15 @@ const DeleteFailedStateBanner = (props: WorkspaceDeletingBannerProps): ReactNode
                 ['See error details.']
               )
             : null,
+            */
         ]
       ),
       style: { backgroundColor: colors.accent(0.35), borderBottom: `1px solid ${colors.accent()}` },
       onDismiss: () => {},
       hideCloseButton: true,
     }),
+    /*
+    // TODO: re-enable when https://broadworkbench.atlassian.net/browse/WOR-1283 is complete
     showDetails
       ? h(
           Modal,
@@ -86,5 +94,6 @@ const DeleteFailedStateBanner = (props: WorkspaceDeletingBannerProps): ReactNode
           [h(ErrorView, { error: workspace?.workspace.errorMessage ?? 'No error message available' })]
         )
       : null,
+      */
   ]);
 };

--- a/src/pages/workspaces/workspace/WorkspaceDeletingBanner.ts
+++ b/src/pages/workspaces/workspace/WorkspaceDeletingBanner.ts
@@ -1,0 +1,34 @@
+import { icon } from '@terra-ui-packages/components';
+import { ReactNode } from 'react';
+import { div, h, span } from 'react-hyperscript-helpers';
+import TitleBar from 'src/components/TitleBar';
+import colors from 'src/libs/colors';
+import { WorkspaceWrapper as Workspace } from 'src/libs/workspace-utils';
+
+interface WorkspaceDeletingBannerProps {
+  workspace?: Workspace;
+}
+
+export const WorkspaceDeletingBanner = (props: WorkspaceDeletingBannerProps): ReactNode => {
+  const { workspace } = props;
+  if (workspace?.workspace?.state === 'Deleting' || workspace?.workspace?.state === 'DeleteFailed') {
+    return h(TitleBar, {
+      title: div(
+        {
+          role: 'alert',
+          style: { display: 'flex', alignItems: 'center', margin: '1rem' },
+        },
+        [
+          icon('syncAlt', { size: 32, style: { color: colors.danger(), marginRight: '0.5rem' } }),
+          span({ style: { color: colors.dark(), fontSize: 14 } }, [
+            'Workspace deletion in progress. Analyses, Workflow, and Data tools are no longer accessible.',
+          ]),
+        ]
+      ),
+      style: { backgroundColor: colors.accent(0.35), borderBottom: `1px solid ${colors.accent()}` },
+      onDismiss: () => {},
+      hideCloseButton: true,
+    });
+  }
+  return undefined;
+};

--- a/src/pages/workspaces/workspace/WorkspaceDeletingBanner.ts
+++ b/src/pages/workspaces/workspace/WorkspaceDeletingBanner.ts
@@ -1,6 +1,8 @@
-import { icon } from '@terra-ui-packages/components';
-import { ReactNode } from 'react';
+import { icon, Link } from '@terra-ui-packages/components';
+import { Fragment, ReactNode, useState } from 'react';
 import { div, h, span } from 'react-hyperscript-helpers';
+import ErrorView from 'src/components/ErrorView';
+import Modal from 'src/components/Modal';
 import TitleBar from 'src/components/TitleBar';
 import colors from 'src/libs/colors';
 import { WorkspaceWrapper as Workspace } from 'src/libs/workspace-utils';
@@ -11,8 +13,40 @@ interface WorkspaceDeletingBannerProps {
 
 export const WorkspaceDeletingBanner = (props: WorkspaceDeletingBannerProps): ReactNode => {
   const { workspace } = props;
-  if (workspace?.workspace?.state === 'Deleting' || workspace?.workspace?.state === 'DeleteFailed') {
-    return h(TitleBar, {
+  if (workspace?.workspace?.state === 'Deleting') {
+    return h(DeletingStateBanner);
+  }
+  if (workspace?.workspace?.state === 'DeleteFailed') {
+    return h(DeleteFailedStateBanner, props);
+  }
+  return undefined;
+};
+
+const DeletingStateBanner = (): ReactNode => {
+  return h(TitleBar, {
+    title: div(
+      {
+        role: 'alert',
+        style: { display: 'flex', alignItems: 'center', margin: '1rem' },
+      },
+      [
+        icon('syncAlt', { size: 32, style: { color: colors.danger(), marginRight: '0.5rem' } }),
+        span({ style: { color: colors.dark(), fontSize: 14 } }, [
+          'Workspace deletion in progress. Analyses, Workflow, and Data tools are no longer accessible.',
+        ]),
+      ]
+    ),
+    style: { backgroundColor: colors.accent(0.35), borderBottom: `1px solid ${colors.accent()}` },
+    onDismiss: () => {},
+    hideCloseButton: true,
+  });
+};
+
+const DeleteFailedStateBanner = (props: WorkspaceDeletingBannerProps): ReactNode => {
+  const { workspace } = props;
+  const [showDetails, setShowDetails] = useState<boolean>(false);
+  return h(Fragment, [
+    h(TitleBar, {
       title: div(
         {
           role: 'alert',
@@ -20,15 +54,37 @@ export const WorkspaceDeletingBanner = (props: WorkspaceDeletingBannerProps): Re
         },
         [
           icon('syncAlt', { size: 32, style: { color: colors.danger(), marginRight: '0.5rem' } }),
-          span({ style: { color: colors.dark(), fontSize: 14 } }, [
-            'Workspace deletion in progress. Analyses, Workflow, and Data tools are no longer accessible.',
+          span({ style: { color: colors.dark(), fontSize: 14, marginRight: '0.5rem' } }, [
+            'Error deleting workspace. Analyses, Workflow, and Data tools are no longer accessible.',
           ]),
+          workspace?.workspace.errorMessage
+            ? h(
+                Link,
+                {
+                  onClick: () => setShowDetails(true),
+                  style: { fontSize: 14, marginRight: '0.5rem' },
+                },
+                ['See error details.']
+              )
+            : null,
         ]
       ),
       style: { backgroundColor: colors.accent(0.35), borderBottom: `1px solid ${colors.accent()}` },
       onDismiss: () => {},
       hideCloseButton: true,
-    });
-  }
-  return undefined;
+    }),
+    showDetails
+      ? h(
+          Modal,
+          {
+            width: 800,
+            title: 'Error deleting workspace',
+            showCancel: false,
+            showX: true,
+            onDismiss: () => setShowDetails(false),
+          },
+          [h(ErrorView, { error: workspace?.workspace.errorMessage ?? 'No error message available' })]
+        )
+      : null,
+  ]);
 };

--- a/src/pages/workspaces/workspace/WorkspaceDeletingBanner.ts
+++ b/src/pages/workspaces/workspace/WorkspaceDeletingBanner.ts
@@ -37,7 +37,7 @@ const DeletingStateBanner = (): ReactNode => {
         ]),
       ]
     ),
-    style: { backgroundColor: colors.accent(0.35), borderBottom: `1px solid ${colors.accent()}` },
+    style: { backgroundColor: colors.warning(0.35), borderBottom: `1px solid ${colors.accent()}` },
     onDismiss: () => {},
     hideCloseButton: true,
   });
@@ -75,7 +75,7 @@ const DeleteFailedStateBanner = (props: WorkspaceDeletingBannerProps): ReactNode
             */
         ]
       ),
-      style: { backgroundColor: colors.accent(0.35), borderBottom: `1px solid ${colors.accent()}` },
+      style: { backgroundColor: colors.warning(0.35), borderBottom: `1px solid ${colors.accent()}` },
       onDismiss: () => {},
       hideCloseButton: true,
     }),

--- a/src/pages/workspaces/workspace/WorkspaceMenu.test.ts
+++ b/src/pages/workspaces/workspace/WorkspaceMenu.test.ts
@@ -145,6 +145,73 @@ describe('WorkspaceMenu - defined workspace (GCP or Azure)', () => {
     }
   });
 
+  it('disables all items except Share for a workspace that is deleting', () => {
+    // Arrange
+    asMockedFn(useWorkspaceDetails).mockReturnValue({
+      // @ts-expect-error - the type checker thinks workspace is only of type undefined
+      workspace: {
+        ...defaultGoogleWorkspace,
+        workspace: {
+          ...defaultGoogleWorkspace.workspace,
+          state: 'Deleting',
+        },
+      },
+      refresh: jest.fn(),
+      loading: false,
+    });
+    // Act
+    render(h(WorkspaceMenu, workspaceMenuProps));
+    // Assert
+    const share = screen.getByText('Share');
+    expect(share).not.toHaveAttribute('disabled');
+
+    const clone = screen.getByText('Clone');
+    expect(clone).toHaveAttribute('disabled');
+
+    const lock = screen.getByText('Lock');
+    expect(lock).toHaveAttribute('disabled');
+
+    const leave = screen.getByText('Leave');
+    expect(leave).toHaveAttribute('disabled');
+
+    const deleteItem = screen.getByText('Delete');
+    expect(deleteItem).toHaveAttribute('disabled');
+  });
+
+  it('disables all items except Share and Delete for a workspace in state DeleteFailed', () => {
+    // Arrange
+    asMockedFn(useWorkspaceDetails).mockReturnValue({
+      // @ts-expect-error - the type checker thinks workspace is only of type undefined
+      workspace: {
+        ...defaultGoogleWorkspace,
+        workspace: {
+          ...defaultGoogleWorkspace.workspace,
+          state: 'DeleteFailed',
+        },
+      },
+      refresh: jest.fn(),
+      loading: false,
+    });
+    // Act
+    render(h(WorkspaceMenu, workspaceMenuProps));
+
+    // Assert
+    const share = screen.getByText('Share');
+    expect(share).not.toHaveAttribute('disabled');
+
+    const deleteItem = screen.getByText('Delete');
+    expect(deleteItem).not.toHaveAttribute('disabled');
+
+    const clone = screen.getByText('Clone');
+    expect(clone).toHaveAttribute('disabled');
+
+    const lock = screen.getByText('Lock');
+    expect(lock).toHaveAttribute('disabled');
+
+    const leave = screen.getByText('Leave');
+    expect(leave).toHaveAttribute('disabled');
+  });
+
   it.each([true, false])('renders Share tooltip based on canShare: %s', (canShare) => {
     // Arrange
     asMockedFn(useWorkspaceDetails).mockReturnValue({

--- a/src/pages/workspaces/workspace/WorkspaceMenu.test.ts
+++ b/src/pages/workspaces/workspace/WorkspaceMenu.test.ts
@@ -236,31 +236,34 @@ describe('WorkspaceMenu - defined workspace (GCP or Azure)', () => {
     { menuText: 'Lock', accessLevel: 'READER' },
     { menuText: 'Unlock', accessLevel: 'OWNER' },
     { menuText: 'Unlock', accessLevel: 'READER' },
-  ])('enables/disables $menuText menu item based on access level $accessLevel', ({ menuText, accessLevel }) => {
-    // Arrange
-    asMockedFn(useWorkspaceDetails).mockReturnValue({
-      // @ts-expect-error - the type checker thinks workspace is only of type undefined
-      workspace: {
-        ...defaultGoogleWorkspace,
-        accessLevel: accessLevel as WorkspaceAccessLevel,
+  ] as { menuText: string; accessLevel: WorkspaceAccessLevel }[])(
+    'enables/disables $menuText menu item based on access level $accessLevel',
+    ({ menuText, accessLevel }) => {
+      // Arrange
+      asMockedFn(useWorkspaceDetails).mockReturnValue({
+        // @ts-expect-error - the type checker thinks workspace is only of type undefined
         workspace: {
-          ...defaultGoogleWorkspace.workspace,
-          isLocked: menuText === 'Unlock',
+          ...defaultGoogleWorkspace,
+          accessLevel: accessLevel as WorkspaceAccessLevel,
+          workspace: {
+            ...defaultGoogleWorkspace.workspace,
+            isLocked: menuText === 'Unlock',
+          },
         },
-      },
-      refresh: jest.fn(),
-      loading: false,
-    });
-    // Act
-    render(h(WorkspaceMenu, workspaceMenuProps));
-    const menuItem = screen.getByText(menuText);
-    // Assert
-    if (WorkspaceUtils.isOwner(accessLevel as WorkspaceAccessLevel)) {
-      expect(menuItem).not.toHaveAttribute('disabled');
-    } else {
-      expect(menuItem).toHaveAttribute('disabled');
+        refresh: jest.fn(),
+        loading: false,
+      });
+      // Act
+      render(h(WorkspaceMenu, workspaceMenuProps));
+      const menuItem = screen.getByText(menuText);
+      // Assert
+      if (WorkspaceUtils.isOwner(accessLevel)) {
+        expect(menuItem).not.toHaveAttribute('disabled');
+      } else {
+        expect(menuItem).toHaveAttribute('disabled');
+      }
     }
-  });
+  );
 
   it.each([
     { menuText: 'Unlock', tooltipText: tooltipText.unlockNoPermission },

--- a/src/pages/workspaces/workspace/WorkspaceMenu.ts
+++ b/src/pages/workspaces/workspace/WorkspaceMenu.ts
@@ -6,12 +6,18 @@ import { Clickable } from 'src/components/common';
 import { MenuButton } from 'src/components/MenuButton';
 import { makeMenuIcon, MenuTrigger } from 'src/components/PopupTrigger';
 import { useWorkspaceDetails } from 'src/components/workspace-utils';
-import { isOwner, WorkspacePolicy, WorkspaceWrapper as Workspace } from 'src/libs/workspace-utils';
+import { isOwner, WorkspacePolicy, WorkspaceState, WorkspaceWrapper as Workspace } from 'src/libs/workspace-utils';
 
 const isNameType = (o: WorkspaceInfo): o is DynamicWorkspaceInfo =>
   'name' in o && typeof o.name === 'string' && 'namespace' in o && typeof o.namespace === 'string';
 
-type LoadedWorkspaceInfo = { canShare: boolean; isLocked: boolean; isOwner: boolean; workspaceLoaded: boolean };
+type LoadedWorkspaceInfo = {
+  state?: WorkspaceState;
+  canShare: boolean;
+  isLocked: boolean;
+  isOwner: boolean;
+  workspaceLoaded: boolean;
+};
 type DynamicWorkspaceInfo = { name: string; namespace: string };
 type WorkspaceInfo = DynamicWorkspaceInfo | LoadedWorkspaceInfo;
 
@@ -80,12 +86,14 @@ const DynamicWorkspaceMenuContent = (props: DynamicWorkspaceMenuContentProps) =>
     'policies',
     'canShare',
     'workspace.isLocked',
+    'workspace.state',
   ]) as { workspace?: Workspace };
 
   return h(LoadedWorkspaceMenuContent, {
     workspaceInfo: {
+      state: workspace?.workspace?.state,
       canShare: !!workspace?.canShare,
-      isLocked: !!workspace?.workspace.isLocked,
+      isLocked: !!workspace?.workspace?.isLocked,
       isOwner: !!workspace && isOwner(workspace.accessLevel),
       workspaceLoaded: !!workspace,
     },
@@ -115,7 +123,7 @@ interface LoadedWorkspaceMenuContentProps {
 }
 const LoadedWorkspaceMenuContent = (props: LoadedWorkspaceMenuContentProps) => {
   const {
-    workspaceInfo: { canShare, isLocked, isOwner, workspaceLoaded },
+    workspaceInfo: { state, canShare, isLocked, isOwner, workspaceLoaded },
     callbacks: { onShare, onLock, onLeave, onClone, onDelete },
   } = props;
   const shareTooltip = cond([workspaceLoaded && !canShare, () => tooltipText.shareNoPermission], [DEFAULT, () => '']);
@@ -129,7 +137,7 @@ const LoadedWorkspaceMenuContent = (props: LoadedWorkspaceMenuContentProps) => {
     h(
       MenuButton,
       {
-        disabled: !workspaceLoaded,
+        disabled: !workspaceLoaded || state === 'Deleting' || state === 'DeleteFailed',
         tooltipSide: 'left',
         onClick: onClone,
       },
@@ -148,7 +156,7 @@ const LoadedWorkspaceMenuContent = (props: LoadedWorkspaceMenuContentProps) => {
     h(
       MenuButton,
       {
-        disabled: !workspaceLoaded || !isOwner,
+        disabled: !workspaceLoaded || !isOwner || state === 'Deleting' || state === 'DeleteFailed',
         tooltip: workspaceLoaded &&
           !isOwner && [isLocked ? tooltipText.unlockNoPermission : tooltipText.lockNoPermission],
         tooltipSide: 'left',
@@ -159,7 +167,7 @@ const LoadedWorkspaceMenuContent = (props: LoadedWorkspaceMenuContentProps) => {
     h(
       MenuButton,
       {
-        disabled: !workspaceLoaded,
+        disabled: !workspaceLoaded || state === 'Deleting' || state === 'DeleteFailed',
         onClick: onLeave,
       },
       [makeMenuIcon('arrowRight'), 'Leave']
@@ -167,7 +175,7 @@ const LoadedWorkspaceMenuContent = (props: LoadedWorkspaceMenuContentProps) => {
     h(
       MenuButton,
       {
-        disabled: !workspaceLoaded || !isOwner || isLocked,
+        disabled: !workspaceLoaded || !isOwner || isLocked || state === 'Deleting',
         tooltip: deleteTooltip,
         tooltipSide: 'left',
         onClick: onDelete,

--- a/src/pages/workspaces/workspace/WorkspaceMenu.ts
+++ b/src/pages/workspaces/workspace/WorkspaceMenu.ts
@@ -76,6 +76,11 @@ interface DynamicWorkspaceMenuContentProps {
   callbacks: WorkspaceMenuCallbacks;
 }
 
+/**
+ * DynamicWorkspaceInfo is invoked when the name/namespace is passed instead of the dirived states.
+ * This happens from the list component, which also needs the workspace policies for sharing the workspace.
+ * So the onShare callback is wrapped here, and passed to LoadedWorkspaceMenuContent.
+ */
 const DynamicWorkspaceMenuContent = (props: DynamicWorkspaceMenuContentProps) => {
   const {
     workspaceInfo: { name, namespace },

--- a/src/pages/workspaces/workspace/WorkspaceTabs.test.ts
+++ b/src/pages/workspaces/workspace/WorkspaceTabs.test.ts
@@ -2,7 +2,6 @@ import { render, screen, within } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import { ReactNode } from 'react';
 import { h } from 'react-hyperscript-helpers';
-import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
 import { WorkspaceWrapper as Workspace } from 'src/libs/workspace-utils';
 import { WorkspaceTabs } from 'src/pages/workspaces/workspace/WorkspaceTabs';
 import { defaultAzureWorkspace, defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';

--- a/src/pages/workspaces/workspace/WorkspaceTabs.test.ts
+++ b/src/pages/workspaces/workspace/WorkspaceTabs.test.ts
@@ -2,9 +2,10 @@ import { render, screen, within } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import { ReactNode } from 'react';
 import { h } from 'react-hyperscript-helpers';
+import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
+import { WorkspaceWrapper as Workspace } from 'src/libs/workspace-utils';
 import { WorkspaceTabs } from 'src/pages/workspaces/workspace/WorkspaceTabs';
 import { defaultAzureWorkspace, defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
-
 // Mocking for Nav.getLink
 jest.mock('src/libs/nav', () => ({
   ...jest.requireActual('src/libs/nav'),
@@ -161,5 +162,56 @@ describe('WorkspaceTabs', () => {
         workspaceInfo: { canShare: false, isLocked: false, isOwner: false, workspaceLoaded: false },
       })
     );
+  });
+
+  it('hides all tabs except Dashboard if the workspace is in a state of Deleting', () => {
+    const workspace: Workspace = {
+      ...defaultGoogleWorkspace,
+      workspace: { ...defaultGoogleWorkspace.workspace, state: 'Deleting' },
+    };
+    // Arrange
+    const props = {
+      name: workspace.workspace.name,
+      namespace: workspace.workspace.namespace,
+      workspace,
+      setDeletingWorkspace: () => {},
+      setCloningWorkspace: () => {},
+      setSharingWorkspace: () => {},
+      setShowLockWorkspaceModal: () => {},
+      setLeavingWorkspace: () => {},
+      refresh: () => {},
+    };
+    // Act
+    render(h(WorkspaceTabs, props));
+    // Assert
+    const tabs = screen.getAllByRole('menuitem');
+    expect(tabs.length).toBe(1);
+    expect(within(tabs[0]).getByText('dashboard')).not.toBeNull();
+  });
+
+  it('hides all tabs except Dashboard if the workspace is in a state of Delete Failed', () => {
+    const workspace: Workspace = {
+      ...defaultGoogleWorkspace,
+      workspace: { ...defaultGoogleWorkspace.workspace, state: 'DeleteFailed' },
+    };
+
+    // Arrange
+    const props = {
+      name: workspace.workspace.name,
+      namespace: workspace.workspace.namespace,
+      workspace,
+      setDeletingWorkspace: () => {},
+      setCloningWorkspace: () => {},
+      setSharingWorkspace: () => {},
+      setShowLockWorkspaceModal: () => {},
+      setLeavingWorkspace: () => {},
+      refresh: () => {},
+    };
+    // Act
+    render(h(WorkspaceTabs, props));
+    // Assert
+    const tabs = screen.getAllByRole('menuitem');
+    expect(tabs.length).toBe(1);
+    expect(within(tabs[0]).getByText('dashboard')).not.toBeNull();
   });
 });

--- a/src/pages/workspaces/workspace/WorkspaceTabs.test.ts
+++ b/src/pages/workspaces/workspace/WorkspaceTabs.test.ts
@@ -1,9 +1,10 @@
-import { render, screen, within } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import { ReactNode } from 'react';
 import { h } from 'react-hyperscript-helpers';
 import { WorkspaceWrapper as Workspace } from 'src/libs/workspace-utils';
 import { WorkspaceTabs } from 'src/pages/workspaces/workspace/WorkspaceTabs';
+import { renderWithAppContexts as render } from 'src/testing/test-utils';
 import { defaultAzureWorkspace, defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
 // Mocking for Nav.getLink
 jest.mock('src/libs/nav', () => ({

--- a/src/pages/workspaces/workspace/WorkspaceTabs.ts
+++ b/src/pages/workspaces/workspace/WorkspaceTabs.ts
@@ -14,6 +14,7 @@ import {
   WorkspaceWrapper as Workspace,
 } from 'src/libs/workspace-utils';
 import { WorkspaceAttributeNotice } from 'src/pages/workspaces/workspace/WorkspaceAttributeNotice';
+import { WorkspaceDeletingBanner } from 'src/pages/workspaces/workspace/WorkspaceDeletingBanner';
 import { WorkspaceMenu } from 'src/pages/workspaces/workspace/WorkspaceMenu';
 
 export interface WorkspaceTabsProps {
@@ -86,6 +87,7 @@ export const WorkspaceTabs = (props: WorkspaceTabsProps): ReactNode => {
         }),
       ]
     ),
+    h(WorkspaceDeletingBanner, { workspace }),
   ]);
 };
 

--- a/src/pages/workspaces/workspace/WorkspaceTabs.ts
+++ b/src/pages/workspaces/workspace/WorkspaceTabs.ts
@@ -88,15 +88,15 @@ export const WorkspaceTabs = (props: WorkspaceTabsProps): ReactNode => {
 };
 
 const getTabs = (workspace?: Workspace): { name: string; link: string }[] => {
+  if (workspace?.workspace?.state === 'Deleting' || workspace?.workspace?.state === 'DeleteFailed') {
+    return [{ name: 'dashboard', link: 'workspace-dashboard' }];
+  }
+
   const commonTabs = [
     { name: 'dashboard', link: 'workspace-dashboard' },
     { name: 'data', link: 'workspace-data' },
     { name: 'analyses', link: analysisTabName },
   ];
-
-  if (workspace?.workspace?.state === 'Deleting' || workspace?.workspace?.state === 'DeleteFailed') {
-    return [{ name: 'dashboard', link: 'workspace-dashboard' }];
-  }
   if (!!workspace && isGoogleWorkspace(workspace)) {
     return [
       ...commonTabs,

--- a/src/pages/workspaces/workspace/WorkspaceTabs.ts
+++ b/src/pages/workspaces/workspace/WorkspaceTabs.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp';
-import { Dispatch, Fragment, ReactNode } from 'react';
+import { Dispatch, ReactNode } from 'react';
 import { h } from 'react-hyperscript-helpers';
 import { analysisTabName } from 'src/analysis/runtime-common-components';
 import { TabBar } from 'src/components/tabBars';
@@ -14,7 +14,6 @@ import {
   WorkspaceWrapper as Workspace,
 } from 'src/libs/workspace-utils';
 import { WorkspaceAttributeNotice } from 'src/pages/workspaces/workspace/WorkspaceAttributeNotice';
-import { WorkspaceDeletingBanner } from 'src/pages/workspaces/workspace/WorkspaceDeletingBanner';
 import { WorkspaceMenu } from 'src/pages/workspaces/workspace/WorkspaceMenu';
 
 export interface WorkspaceTabsProps {
@@ -55,40 +54,37 @@ export const WorkspaceTabs = (props: WorkspaceTabsProps): ReactNode => {
 
   const tabs = getTabs(workspace);
 
-  return h(Fragment, [
-    h(
-      TabBar,
-      {
-        'aria-label': 'Workspace Navigation Tabs',
-        activeTab,
-        refresh,
-        tabNames: _.map('name', tabs),
-        getHref: (currentTab) => Nav.getLink(_.find({ name: currentTab }, tabs)?.link ?? '', { namespace, name }),
-      },
-      [
-        workspace &&
-          h(WorkspaceAttributeNotice, {
-            accessLevel: workspace.accessLevel,
-            isLocked,
-            workspaceProtectedMessage: hasProtectedData(workspace) ? protectedDataMessage : undefined,
-            workspaceRegionConstraintMessage: regionConstraintMessage(workspace),
-          }),
-        h(WorkspaceMenu, {
-          iconSize: 27,
-          popupLocation: 'bottom',
-          callbacks: { onClone, onShare, onLock, onDelete, onLeave },
-          workspaceInfo: {
-            state: workspace?.workspace?.state,
-            canShare: !!canShare,
-            isLocked,
-            isOwner: wsOwner,
-            workspaceLoaded,
-          },
+  return h(
+    TabBar,
+    {
+      'aria-label': 'Workspace Navigation Tabs',
+      activeTab,
+      refresh,
+      tabNames: _.map('name', tabs),
+      getHref: (currentTab) => Nav.getLink(_.find({ name: currentTab }, tabs)?.link ?? '', { namespace, name }),
+    },
+    [
+      workspace &&
+        h(WorkspaceAttributeNotice, {
+          accessLevel: workspace.accessLevel,
+          isLocked,
+          workspaceProtectedMessage: hasProtectedData(workspace) ? protectedDataMessage : undefined,
+          workspaceRegionConstraintMessage: regionConstraintMessage(workspace),
         }),
-      ]
-    ),
-    h(WorkspaceDeletingBanner, { workspace }),
-  ]);
+      h(WorkspaceMenu, {
+        iconSize: 27,
+        popupLocation: 'bottom',
+        callbacks: { onClone, onShare, onLock, onDelete, onLeave },
+        workspaceInfo: {
+          state: workspace?.workspace?.state,
+          canShare: !!canShare,
+          isLocked,
+          isOwner: wsOwner,
+          workspaceLoaded,
+        },
+      }),
+    ]
+  );
 };
 
 const getTabs = (workspace?: Workspace): { name: string; link: string }[] => {

--- a/src/pages/workspaces/workspace/WorkspaceTabs.ts
+++ b/src/pages/workspaces/workspace/WorkspaceTabs.ts
@@ -76,7 +76,13 @@ export const WorkspaceTabs = (props: WorkspaceTabsProps): ReactNode => {
           iconSize: 27,
           popupLocation: 'bottom',
           callbacks: { onClone, onShare, onLock, onDelete, onLeave },
-          workspaceInfo: { canShare: !!canShare, isLocked, isOwner: wsOwner, workspaceLoaded },
+          workspaceInfo: {
+            state: workspace?.workspace?.state,
+            canShare: !!canShare,
+            isLocked,
+            isOwner: wsOwner,
+            workspaceLoaded,
+          },
         }),
       ]
     ),

--- a/src/pages/workspaces/workspace/WorkspaceTabs.ts
+++ b/src/pages/workspaces/workspace/WorkspaceTabs.ts
@@ -45,8 +45,6 @@ export const WorkspaceTabs = (props: WorkspaceTabsProps): ReactNode => {
   const canShare = workspace?.canShare;
   const isLocked = !!workspace?.workspace.isLocked;
   const workspaceLoaded = !!workspace;
-  const googleWorkspace = workspaceLoaded && isGoogleWorkspace(workspace);
-  const azureWorkspace = workspaceLoaded && isAzureWorkspace(workspace);
 
   const onClone = () => setCloningWorkspace(true);
   const onDelete = () => setDeletingWorkspace(true);
@@ -54,18 +52,8 @@ export const WorkspaceTabs = (props: WorkspaceTabsProps): ReactNode => {
   const onShare = () => setSharingWorkspace(true);
   const onLeave = () => setLeavingWorkspace(true);
 
-  const tabs = [
-    { name: 'dashboard', link: 'workspace-dashboard' },
-    { name: 'data', link: 'workspace-data' },
-    { name: 'analyses', link: analysisTabName },
-    ...(googleWorkspace
-      ? [
-          { name: 'workflows', link: 'workspace-workflows' },
-          { name: 'job history', link: 'workspace-job-history' },
-        ]
-      : []),
-    ...(azureWorkspace ? [{ name: 'workflows', link: 'workspace-workflows-app' }] : []),
-  ];
+  const tabs = getTabs(workspace);
+
   return h(Fragment, [
     h(
       TabBar,
@@ -93,4 +81,27 @@ export const WorkspaceTabs = (props: WorkspaceTabsProps): ReactNode => {
       ]
     ),
   ]);
+};
+
+const getTabs = (workspace?: Workspace): { name: string; link: string }[] => {
+  const commonTabs = [
+    { name: 'dashboard', link: 'workspace-dashboard' },
+    { name: 'data', link: 'workspace-data' },
+    { name: 'analyses', link: analysisTabName },
+  ];
+
+  if (workspace?.workspace?.state === 'Deleting' || workspace?.workspace?.state === 'DeleteFailed') {
+    return [{ name: 'dashboard', link: 'workspace-dashboard' }];
+  }
+  if (!!workspace && isGoogleWorkspace(workspace)) {
+    return [
+      ...commonTabs,
+      { name: 'workflows', link: 'workspace-workflows' },
+      { name: 'job history', link: 'workspace-job-history' },
+    ];
+  }
+  if (!!workspace && isAzureWorkspace(workspace)) {
+    return [...commonTabs, { name: 'workflows', link: 'workspace-workflows-app' }];
+  }
+  return commonTabs;
 };

--- a/src/pages/workspaces/workspace/useDeleteWorkspaceState.ts
+++ b/src/pages/workspaces/workspace/useDeleteWorkspaceState.ts
@@ -6,7 +6,7 @@ import { App } from 'src/libs/ajax/leonardo/models/app-models';
 import { Runtime } from 'src/libs/ajax/leonardo/models/runtime-models';
 import { reportError, withErrorReportingInModal } from 'src/libs/error';
 import { useCancellation, useOnMount } from 'src/libs/react-utils';
-import { getTerraUser } from 'src/libs/state';
+import { getTerraUser, workspaceStore } from 'src/libs/state';
 import * as Utils from 'src/libs/utils';
 import { BaseWorkspace, isAzureWorkspace, isGoogleWorkspace, WorkspaceInfo } from 'src/libs/workspace-utils';
 
@@ -130,6 +130,7 @@ export const useDeleteWorkspaceState = (hookArgs: DeleteWorkspaceHookArgs): Dele
       await Ajax(signal).Workspaces.workspaceV2(workspaceInfo.namespace, workspaceInfo.name).delete();
       hookArgs.onDismiss();
       hookArgs.onSuccess();
+      workspaceStore.reset();
     } catch (error) {
       setDeleting(false);
       reportError('Error deleting workspace', error);

--- a/src/pages/workspaces/workspace/useWorkspace.ts
+++ b/src/pages/workspaces/workspace/useWorkspace.ts
@@ -192,6 +192,7 @@ export const useWorkspace = (namespace, name): WorkspaceDetails => {
           'workspace.attributes',
           'workspace.authorizationDomain',
           'workspace.cloudPlatform',
+          'workspace.errorMessage',
           'workspace.isLocked',
           'workspace.workspaceId',
           'workspaceSubmissionStats',


### PR DESCRIPTION
### Jira Ticket: [https://broadworkbench.atlassian.net/browse/WOR-1235](https://broadworkbench.atlassian.net/browse/WOR-1235)

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
For a workspace in a state of `Deleting` or `DeletionFailed`
* All tabs except “Dashboard” are hidden. 
* Disable the ability to create a new Cloud Environment from the right context bar.
* All menu items are disabled except “Share” (for both states) and “Delete” (for Delete Failed state only). Also includes the workspace menu as shown on the Workspaces List view.
* Show banner with a message about the current state of the workspace.
   (Include link to error message if there is one.)

Not included in this PR:
Auto-refresh the dashboard and either transition from deleting → delete failed or from deleting → redirect to workspaces list once the workspace does completely delete.
This requires changes that are more invasive, and better addressed separately.


### Testing strategy
- [ ] Functionality tested with Unit tests

Manual samples:
<img width="349" alt="Screenshot 2023-10-13 at 12 20 45 PM" src="https://github.com/DataBiosphere/terra-ui/assets/1930315/fbd59b1c-c273-419b-808d-e9af35daa7ab">
No tabs besides dashboard, and banner shown. No link to display an error message, because no message is present:
<img width="1385" alt="Screenshot 2023-10-17 at 9 25 21 AM" src="https://github.com/DataBiosphere/terra-ui/assets/1930315/e29b6f4b-5055-4f82-afed-eb368610e34d">

<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 
