### PR TITLE
WM-2321: Revert incidental removal of shared apps in listAppsV2

### DIFF
--- a/src/pages/workspaces/workspace/WorkspaceContainer.ts
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.ts
@@ -345,7 +345,7 @@ const useAppPolling = (workspace: Workspace): AppDetails => {
           : [];
       const newAzureApps =
         !!workspace && isAzureWorkspace(workspace)
-          ? await Ajax(signal).Apps.listAppsV2(workspace.workspace.workspaceId, { role: 'creator' })
+          ? await Ajax(signal).Apps.listAppsV2(workspace.workspace.workspaceId)
           : [];
       const combinedNewApps = [...newGoogleApps, ...newAzureApps];
 


### PR DESCRIPTION
See ticket: https://broadworkbench.atlassian.net/browse/WM-2321

Reverts azure app listing behavior to the status quo ante (before https://github.com/DataBiosphere/leonardo/pull/3831).

Note: this situation has highlighted that app handling will probably need to be updated in the future, but for now we want a quick patch to un-break workflows tab functionality for non-creator users.