### PR TITLE
[WOR-1235] properly invoke share callback from workspace menu

### DIFF
--- a/src/pages/workspaces/workspace/WorkspaceMenu.ts
+++ b/src/pages/workspaces/workspace/WorkspaceMenu.ts
@@ -105,7 +105,13 @@ export const tooltipText = {
 
 interface LoadedWorkspaceMenuContentProps {
   workspaceInfo: LoadedWorkspaceInfo;
-  callbacks: WorkspaceMenuCallbacks;
+  callbacks: {
+    onClone: () => void;
+    onShare: () => void;
+    onLock: () => void;
+    onDelete: () => void;
+    onLeave: () => void;
+  };
 }
 const LoadedWorkspaceMenuContent = (props: LoadedWorkspaceMenuContentProps) => {
   const {
@@ -135,7 +141,7 @@ const LoadedWorkspaceMenuContent = (props: LoadedWorkspaceMenuContentProps) => {
         disabled: !workspaceLoaded || !canShare,
         tooltip: shareTooltip,
         tooltipSide: 'left',
-        onClick: () => onShare,
+        onClick: onShare,
       },
       [makeMenuIcon('share'), 'Share']
     ),


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/WOR-1235

Small bug fix related to a [PR](https://github.com/DataBiosphere/terra-ui/pull/4356) that already merged to dev but has not yet been released to production.

Without this change, the Share modal does not come up when "Share" is selected from the Workspace menu on either the Workspace Dashboard or List view.

