### PR TITLE
[AJ-1405] Remove extra slash in WDS request URLs

### DIFF
--- a/src/libs/ajax/ajax-common.ts
+++ b/src/libs/ajax/ajax-common.ts
@@ -244,8 +244,8 @@ export const fetchGoogleForms = _.flow(
   (wrappedFetch) => (url, options) => wrappedFetch(url, _.merge(options, { mode: 'no-cors' }))
 )(fetch);
 
-export const fetchWDS = (wdsProxyUrlRoot) =>
-  _.flow(withUrlPrefix(`${wdsProxyUrlRoot}/`), withRetryAfterReloadingExpiredAuthToken)(fetchOk);
+export const fetchWDS = (wdsProxyUrlRoot: string): FetchFn =>
+  _.flow(withUrlPrefix(`${wdsProxyUrlRoot.replace(/\/$/, '')}/`), withRetryAfterReloadingExpiredAuthToken)(fetchOk);
 
 export const fetchFromProxy = (proxyUrlRoot) =>
   _.flow(withUrlPrefix(`${proxyUrlRoot}/`), withRetryAfterReloadingExpiredAuthToken)(fetchOk);


### PR DESCRIPTION
A minor thing, but it kind of bugged me...

Leo returns a proxy URL for WDS that includes a trailing slash. For example, `https://lza09f0cae2d71d26deb105ae6043d2b1d9c55c7c5cd103ac6.servicebus.windows.net/wds-ed0b4126-e607-4b03-8a01-c65334e98a4c-ed0b4126-e607-4b03-8a01-c65334e98a4c/`.

That proxy URL gets passed to `fetchWds`, which appends another trailing slash. This results in requests to WDS like `https://lza09f0cae2d71d26deb105ae6043d2b1d9c55c7c5cd103ac6.servicebus.windows.net/wds-ed0b4126-e607-4b03-8a01-c65334e98a4c-ed0b4126-e607-4b03-8a01-c65334e98a4c//version`.

This updates `fetchWds` to remove any trailing slash on the passed URL.

And added some type definitions while I was here.