### PR TITLE
[AJ-1166] Convert Ajax override utils to TS and add tests

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -35,17 +35,6 @@ import { getConfig } from 'src/libs/config';
 import { getTerraUser } from 'src/libs/state';
 import * as Utils from 'src/libs/utils';
 
-window.ajaxOverrideUtils = {
-  mapJsonBody: _.curry((fn, wrappedFetch) => async (...args) => {
-    const res = await wrappedFetch(...args);
-    return new Response(JSON.stringify(fn(await res.json())), res);
-  }),
-  makeError: _.curry(({ status, frequency = 1 }, wrappedFetch) => (...args) => {
-    return Math.random() < frequency ? Promise.resolve(new Response('Instrumented error', { status })) : wrappedFetch(...args);
-  }),
-  makeSuccess: (body) => (_wrappedFetch) => () => Promise.resolve(new Response(JSON.stringify(body), { status: 200 })),
-};
-
 const getSnapshotEntityMetadata = Utils.memoizeAsync(
   async (token, workspaceNamespace, workspaceName, googleProject, dataReference) => {
     const res = await fetchRawls(

--- a/src/libs/ajax/ajax-override-utils.test.ts
+++ b/src/libs/ajax/ajax-override-utils.test.ts
@@ -1,0 +1,89 @@
+import { makeError, makeSuccess, mapJsonBody } from './ajax-override-utils';
+
+type FetchFn = typeof fetch;
+
+describe('mapJsonBody', () => {
+  it('updates response body', async () => {
+    // Arrange
+    const fetch: FetchFn = jest.fn().mockResolvedValue(new Response(JSON.stringify({ foo: 1, bar: 2, baz: 3 })));
+
+    const incrementValues = mapJsonBody((obj) =>
+      Object.fromEntries(Object.entries(obj).map(([k, v]) => [k, Number(v) + 1]))
+    );
+    const fetchWithOverride = incrementValues(fetch);
+
+    // Act
+    const response = await fetchWithOverride('/api', { headers: { Authorization: 'Bearer token' } });
+    const responseBody = await response.json();
+
+    // Assert
+    expect(fetch).toHaveBeenCalledWith('/api', { headers: { Authorization: 'Bearer token' } });
+    expect(response).toBeInstanceOf(Response);
+    expect(responseBody).toEqual({ foo: 2, bar: 3, baz: 4 });
+  });
+});
+
+describe('makeError', () => {
+  it('overrides response with error response', async () => {
+    // Arrange
+    const fetch: FetchFn = jest.fn().mockResolvedValue(new Response('{}', { status: 200 }));
+
+    const fetchWithOverride = makeError({ status: 500 })(fetch);
+
+    // Act
+    const response = await fetchWithOverride('/api', { headers: { Authorization: 'Bearer token' } });
+    const responseBody = await response.text();
+
+    // Assert
+    expect(fetch).not.toHaveBeenCalled();
+    expect(response).toBeInstanceOf(Response);
+    expect(response.status).toBe(500);
+    expect(responseBody).toBe('Instrumented error');
+  });
+
+  it('can override responses randomly', async () => {
+    // Arrange
+    const random = jest.spyOn(Math, 'random');
+
+    const fetch: FetchFn = jest.fn().mockResolvedValue(new Response('Success', { status: 200 }));
+
+    const fetchWithOverride = makeError({ status: 500, frequency: 0.5 })(fetch);
+
+    // Act
+    random.mockReturnValue(0.25);
+    const firstResponse = await fetchWithOverride('/api', { headers: { Authorization: 'Bearer token' } });
+    const firstResponseBody = await firstResponse.text();
+
+    random.mockReturnValue(0.75);
+    const secondResponse = await fetchWithOverride('/api', { headers: { Authorization: 'Bearer token' } });
+    const secondResponseBody = await secondResponse.text();
+
+    // Assert
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    expect(firstResponse.status).toBe(500);
+    expect(firstResponseBody).toBe('Instrumented error');
+
+    expect(secondResponse.status).toBe(200);
+    expect(secondResponseBody).toBe('Success');
+  });
+});
+
+describe('makeSuccess', () => {
+  it('overrides response with success response', async () => {
+    // Arrange
+    const fetch: FetchFn = jest.fn().mockResolvedValue(new Response('Error', { status: 500 }));
+
+    const fetchWithOverride = makeSuccess({ message: 'Success' })(fetch);
+
+    // Act
+    const response = await fetchWithOverride('/api', { headers: { Authorization: 'Bearer token' } });
+    const responseBody = await response.json();
+
+    // Assert
+    expect(fetch).not.toHaveBeenCalled();
+    expect(response).toBeInstanceOf(Response);
+    expect(response.status).toBe(200);
+    expect(responseBody).toEqual({ message: 'Success' });
+  });
+});

--- a/src/libs/ajax/ajax-override-utils.test.ts
+++ b/src/libs/ajax/ajax-override-utils.test.ts
@@ -5,19 +5,23 @@ type FetchFn = typeof fetch;
 describe('mapJsonBody', () => {
   it('updates response body', async () => {
     // Arrange
-    const fetch: FetchFn = jest.fn().mockResolvedValue(new Response(JSON.stringify({ foo: 1, bar: 2, baz: 3 })));
-
-    const incrementValues = mapJsonBody((obj) =>
-      Object.fromEntries(Object.entries(obj).map(([k, v]) => [k, Number(v) + 1]))
-    );
-    const fetchWithOverride = incrementValues(fetch);
+    const originalFetch: FetchFn = jest
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({ foo: 1, bar: 2, baz: 3 })));
 
     // Act
+    // Wrap fetch in an override that modifies the response body by incrementing all values in the object.
+    const withModifiedResponse = mapJsonBody((obj) =>
+      Object.fromEntries(Object.entries(obj).map(([k, v]) => [k, Number(v) + 1]))
+    );
+    const fetchWithOverride = withModifiedResponse(originalFetch);
+
+    // Make a request using the wrapped fetch.
     const response = await fetchWithOverride('/api', { headers: { Authorization: 'Bearer token' } });
     const responseBody = await response.json();
 
     // Assert
-    expect(fetch).toHaveBeenCalledWith('/api', { headers: { Authorization: 'Bearer token' } });
+    expect(originalFetch).toHaveBeenCalledWith('/api', { headers: { Authorization: 'Bearer token' } });
     expect(response).toBeInstanceOf(Response);
     expect(responseBody).toEqual({ foo: 2, bar: 3, baz: 4 });
   });
@@ -26,16 +30,19 @@ describe('mapJsonBody', () => {
 describe('makeError', () => {
   it('overrides response with error response', async () => {
     // Arrange
-    const fetch: FetchFn = jest.fn().mockResolvedValue(new Response('{}', { status: 200 }));
-
-    const fetchWithOverride = makeError({ status: 500 })(fetch);
+    const originalFetch: FetchFn = jest.fn().mockResolvedValue(new Response('{}', { status: 200 }));
 
     // Act
+    // Wrap fetch in an override that always returns an error response.
+    const withErrorResponse = makeError({ status: 500 });
+    const fetchWithOverride = withErrorResponse(originalFetch);
+
+    // Make a request using the wrapped fetch.
     const response = await fetchWithOverride('/api', { headers: { Authorization: 'Bearer token' } });
     const responseBody = await response.text();
 
     // Assert
-    expect(fetch).not.toHaveBeenCalled();
+    expect(originalFetch).not.toHaveBeenCalled();
     expect(response).toBeInstanceOf(Response);
     expect(response.status).toBe(500);
     expect(responseBody).toBe('Instrumented error');
@@ -45,11 +52,14 @@ describe('makeError', () => {
     // Arrange
     const random = jest.spyOn(Math, 'random');
 
-    const fetch: FetchFn = jest.fn().mockResolvedValue(new Response('Success', { status: 200 }));
-
-    const fetchWithOverride = makeError({ status: 500, frequency: 0.5 })(fetch);
+    const originalFetch: FetchFn = jest.fn().mockResolvedValue(new Response('Success', { status: 200 }));
 
     // Act
+    // Wrap fetch in an override that returns an error response for 50% of requests.
+    const withIntermittentErrorResponse = makeError({ status: 500, frequency: 0.5 });
+    const fetchWithOverride = withIntermittentErrorResponse(originalFetch);
+
+    // Make requests using the wrapped fetch.
     random.mockReturnValue(0.25);
     const firstResponse = await fetchWithOverride('/api', { headers: { Authorization: 'Bearer token' } });
     const firstResponseBody = await firstResponse.text();
@@ -59,7 +69,7 @@ describe('makeError', () => {
     const secondResponseBody = await secondResponse.text();
 
     // Assert
-    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(originalFetch).toHaveBeenCalledTimes(1);
 
     expect(firstResponse.status).toBe(500);
     expect(firstResponseBody).toBe('Instrumented error');
@@ -72,16 +82,19 @@ describe('makeError', () => {
 describe('makeSuccess', () => {
   it('overrides response with success response', async () => {
     // Arrange
-    const fetch: FetchFn = jest.fn().mockResolvedValue(new Response('Error', { status: 500 }));
-
-    const fetchWithOverride = makeSuccess({ message: 'Success' })(fetch);
+    const originalFetch: FetchFn = jest.fn().mockResolvedValue(new Response('Error', { status: 500 }));
 
     // Act
+    // Wrap fetch in an override that always returns a successful response.
+    const withSuccessResponse = makeSuccess({ message: 'Success' });
+    const fetchWithOverride = withSuccessResponse(originalFetch);
+
+    // Make a request using the wrapped fetch.
     const response = await fetchWithOverride('/api', { headers: { Authorization: 'Bearer token' } });
     const responseBody = await response.json();
 
     // Assert
-    expect(fetch).not.toHaveBeenCalled();
+    expect(originalFetch).not.toHaveBeenCalled();
     expect(response).toBeInstanceOf(Response);
     expect(response.status).toBe(200);
     expect(responseBody).toEqual({ message: 'Success' });

--- a/src/libs/ajax/ajax-override-utils.ts
+++ b/src/libs/ajax/ajax-override-utils.ts
@@ -1,0 +1,69 @@
+type FetchFn = typeof fetch;
+type FetchWrapper = (wrappedFetch: FetchFn) => FetchFn;
+
+/**
+ * Modify the body of a response.
+ *
+ * @param fn - Function that accepts actual response body and returns overriden response body.
+ */
+export const mapJsonBody = (fn: (body: any) => any): FetchWrapper => {
+  return (wrappedFetch: FetchFn): FetchFn => {
+    return async (...args) => {
+      const response: Response = await wrappedFetch(...args);
+      const responseBody: any = await response.json();
+      const newResponseBody: any = fn(responseBody);
+      return new Response(JSON.stringify(newResponseBody), response);
+    };
+  };
+};
+
+/**
+ * Replace a response with an error response.
+ *
+ * @param opts
+ * @param opts.status - Status code for error response.
+ * @param opts.frequency - Frequency with which to return errors, between 0 (never) and 1 (always).
+ */
+export const makeError = (opts: { status: number; frequency?: number }): FetchWrapper => {
+  const { status, frequency = 1 } = opts;
+  return (wrappedFetch: FetchFn): FetchFn => {
+    return async (...args) => {
+      if (Math.random() < frequency) {
+        const response = new Response('Instrumented error', { status });
+        return Promise.resolve(response);
+      }
+      return wrappedFetch(...args);
+    };
+  };
+};
+
+/**
+ * Replace a response with a success response with the given body.
+ *
+ * @param body - Response body.
+ */
+export const makeSuccess = (body: any): FetchWrapper => {
+  return (): FetchFn => {
+    return () => {
+      const response = new Response(JSON.stringify(body), { status: 200 });
+      return Promise.resolve(response);
+    };
+  };
+};
+
+/**
+ * Utilities to be exposed as globals.
+ */
+const ajaxOverrideUtils = {
+  mapJsonBody,
+  makeError,
+  makeSuccess,
+};
+
+declare global {
+  interface Window {
+    ajaxOverrideUtils: typeof ajaxOverrideUtils;
+  }
+}
+
+window.ajaxOverrideUtils = ajaxOverrideUtils;

--- a/src/libs/ajax/ajax-override-utils.ts
+++ b/src/libs/ajax/ajax-override-utils.ts
@@ -1,3 +1,8 @@
+/**
+ * Utilities for overriding API responses for manual testing.
+ * See https://github.com/DataBiosphere/terra-ui/wiki/Mocking-API-Responses.
+ */
+
 type FetchFn = typeof fetch;
 type FetchWrapper = (wrappedFetch: FetchFn) => FetchFn;
 

--- a/src/pages/Main.ts
+++ b/src/pages/Main.ts
@@ -1,3 +1,4 @@
+import 'src/libs/ajax/ajax-override-utils';
 import 'src/libs/routes';
 
 import { ErrorBoundary, ThemeProvider } from '@terra-ui-packages/components';


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1166

I want to add another ajax override utility to make it easier to point Terra UI at a local instance of WDS. Before doing that, this extracts existing ajax override utilities into their own module, converts them to TypeScript, and adds tests.