### PR TITLE
WM-2324: Make sure only workspace creators can submit/abort in Azure

### DIFF
--- a/src/workflows-app/SubmissionConfig.js
+++ b/src/workflows-app/SubmissionConfig.js
@@ -17,7 +17,7 @@ import Events, { extractWorkspaceDetails } from 'src/libs/events';
 import * as Nav from 'src/libs/nav';
 import { notify } from 'src/libs/notifications';
 import { useCancellation, useOnMount, usePollingEffect } from 'src/libs/react-utils';
-import { AppProxyUrlStatus, workflowsAppStore } from 'src/libs/state';
+import { AppProxyUrlStatus, getTerraUser, workflowsAppStore } from 'src/libs/state';
 import * as Utils from 'src/libs/utils';
 import { maybeParseJSON } from 'src/libs/utils';
 import HelpfulLinksBox from 'src/workflows-app/components/HelpfulLinksBox';
@@ -348,6 +348,7 @@ export const BaseSubmissionConfig = (
   };
 
   const callCacheId = useUniqueId();
+  const permissionToSubmit = workspace.workspace.createdBy === getTerraUser()?.email;
 
   const renderSummary = () => {
     return div({ style: { marginLeft: '2em', marginTop: '1rem', display: 'flex', justifyContent: 'space-between' } }, [
@@ -470,8 +471,9 @@ export const BaseSubmissionConfig = (
             {
               'aria-label': 'Submit button',
               style: { marginLeft: '1rem' },
-              disabled: _.isEmpty(selectedRecords) || errorMessageCount > 0,
+              disabled: _.isEmpty(selectedRecords) || errorMessageCount > 0 || !permissionToSubmit,
               tooltip: Utils.cond(
+                [!permissionToSubmit, () => 'Only the creator can submit workflows in this workspace'],
                 [_.isEmpty(selectedRecords), () => 'No records selected'],
                 [errorMessageCount > 0, () => `${errorMessageCount} input(s) have missing/invalid values`],
                 () => ''

--- a/src/workflows-app/SubmissionHistory.test.js
+++ b/src/workflows-app/SubmissionHistory.test.js
@@ -412,7 +412,6 @@ describe('SubmissionHistory tab', () => {
     });
   });
 
-  // Formatted as:
   const abortTestCases = [
     ['abort successfully', { workspace: mockAzureWorkspace, userEmail: mockAzureWorkspace.workspace.createdBy, abortAllowed: true }],
     ['not allow abort for non-creators', { workspace: mockAzureWorkspace, userEmail: 'someoneelse@gmail.com', abortAllowed: false }],

--- a/src/workflows-app/SubmissionHistory.test.js
+++ b/src/workflows-app/SubmissionHistory.test.js
@@ -413,7 +413,6 @@ describe('SubmissionHistory tab', () => {
   });
 
   // Formatted as:
-  // ('test name, 'workspace', 'user email', 'expected result')
   const abortTestCases = [
     ['abort successfully', { workspace: mockAzureWorkspace, userEmail: mockAzureWorkspace.workspace.createdBy, abortAllowed: true }],
     ['not allow abort for non-creators', { workspace: mockAzureWorkspace, userEmail: 'someoneelse@gmail.com', abortAllowed: false }],

--- a/src/workflows-app/SubmissionHistory.test.js
+++ b/src/workflows-app/SubmissionHistory.test.js
@@ -4,6 +4,7 @@ import { div, h } from 'react-hyperscript-helpers';
 import { MenuTrigger } from 'src/components/PopupTrigger';
 import { Ajax } from 'src/libs/ajax';
 import { getConfig } from 'src/libs/config';
+import { getTerraUser } from 'src/libs/state';
 import { renderWithAppContexts as render, SelectHelper } from 'src/testing/test-utils';
 import { BaseSubmissionHistory } from 'src/workflows-app/SubmissionHistory';
 import { mockAbortResponse, mockAzureApps, mockAzureWorkspace } from 'src/workflows-app/utils/mock-responses';
@@ -36,6 +37,10 @@ jest.mock('src/libs/feature-previews', () => ({
 jest.mock('src/libs/config', () => ({
   ...jest.requireActual('src/libs/config'),
   getConfig: jest.fn().mockReturnValue({}),
+}));
+jest.mock('src/libs/state', () => ({
+  ...jest.requireActual('src/libs/state'),
+  getTerraUser: jest.fn(),
 }));
 
 // SubmissionHistory component uses AutoSizer to determine the right size for table to be displayed. As a result we need to
@@ -407,7 +412,14 @@ describe('SubmissionHistory tab', () => {
     });
   });
 
-  it('should abort successfully', async () => {
+  // Formatted as:
+  // ('test name, 'workspace', 'user email', 'expected result')
+  const abortTestCases = [
+    ['abort successfully', { workspace: mockAzureWorkspace, userEmail: mockAzureWorkspace.workspace.createdBy, abortAllowed: true }],
+    ['not allow abort for non-creators', { workspace: mockAzureWorkspace, userEmail: 'someoneelse@gmail.com', abortAllowed: false }],
+  ];
+
+  it.each(abortTestCases)('should %s', async (_unused, { workspace, userEmail, abortAllowed }) => {
     const user = userEvent.setup();
     const getRunSetsMethod = jest.fn(() => Promise.resolve(simpleRunSetData));
     const cancelSubmissionFunction = jest.fn(() => Promise.resolve(mockAbortResponse));
@@ -427,13 +439,17 @@ describe('SubmissionHistory tab', () => {
       };
     });
 
+    getTerraUser.mockReturnValue({
+      email: userEmail,
+    });
+
     // Act
     await act(async () => {
       render(
         h(BaseSubmissionHistory, {
           name: 'test-azure-ws-name',
           namespace: 'test-azure-ws-namespace',
-          workspace: mockAzureWorkspace,
+          workspace,
         })
       );
     });
@@ -457,10 +473,12 @@ describe('SubmissionHistory tab', () => {
     });
 
     const abortButton = screen.getByText('Abort');
-    expect(abortButton).toHaveAttribute('aria-disabled', 'false');
+    expect(abortButton).toHaveAttribute('aria-disabled', (!abortAllowed).toString());
     await user.click(abortButton);
 
-    expect(cancelSubmissionFunction).toHaveBeenCalled();
-    expect(cancelSubmissionFunction).toBeCalledWith('https://lz-abc/terra-app-abc/cbas', '20000000-0000-0000-0000-200000000002');
+    if (abortAllowed) {
+      expect(cancelSubmissionFunction).toHaveBeenCalled();
+      expect(cancelSubmissionFunction).toBeCalledWith('https://lz-abc/terra-app-abc/cbas', '20000000-0000-0000-0000-200000000002');
+    }
   });
 });


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WM-2324

As multi-user workflows roll out, it's no yet possible for users who are not workspace creators to submit or abort workflows in Azure. Therefore, we should not (yet!) be giving them these options.

### Visual Aids
#### Workspace creator attempting to submit:

<img width="174" alt="image" src="https://github.com/DataBiosphere/terra-ui/assets/13006282/124c694e-e08e-4fa2-906e-05639a11f928">

#### Other workspace owner attempting to submit:

![image](https://github.com/DataBiosphere/terra-ui/assets/13006282/7ba876de-a5ad-4a5b-a047-8f62f7998afd)

#### Workspace creator attempting to abort:

<img width="403" alt="image" src="https://github.com/DataBiosphere/terra-ui/assets/13006282/eb285b4c-97d8-4bd5-a86a-510513766c81">

#### Other workspace owner attempting to abort:

![image](https://github.com/DataBiosphere/terra-ui/assets/13006282/30ea1842-2daf-4887-9a4a-d79a6a61d187)
