### PR TITLE
[UIE-51] Remove Clickable module

### DIFF
--- a/src/components/common/Clickable.ts
+++ b/src/components/common/Clickable.ts
@@ -1,2 +1,0 @@
-export { Clickable } from '@terra-ui-packages/components';
-export type { ClickableProps } from '@terra-ui-packages/components';

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,7 +1,6 @@
-export { ButtonOutline, ButtonPrimary, ButtonSecondary, Link } from '@terra-ui-packages/components';
-export type { LinkProps } from '@terra-ui-packages/components';
+export { ButtonOutline, ButtonPrimary, ButtonSecondary, Clickable, Link } from '@terra-ui-packages/components';
+export type { ClickableProps, LinkProps } from '@terra-ui-packages/components';
 export * from './Checkbox';
-export * from './Clickable';
 export * from './DeleteConfirmationModal';
 export * from './IdContainer';
 export * from './RadioButton';

--- a/src/pages/library/datasetBuilder/DatasetBuilder.ts
+++ b/src/pages/library/datasetBuilder/DatasetBuilder.ts
@@ -1,9 +1,9 @@
+import { Clickable } from '@terra-ui-packages/components';
 import * as _ from 'lodash/fp';
 import React, { Fragment, ReactElement, useEffect, useMemo, useState } from 'react';
 import { div, h, h2, h3, label, li, ul } from 'react-hyperscript-helpers';
 import { ActionBar } from 'src/components/ActionBar';
 import { ButtonPrimary, LabeledCheckbox, Link, spinnerOverlay } from 'src/components/common';
-import { Clickable } from 'src/components/common/Clickable';
 import FooterWrapper from 'src/components/FooterWrapper';
 import { icon, spinner } from 'src/components/icons';
 import { ValidatedInput, ValidatedTextArea } from 'src/components/input';


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/UIE-51

Small cleanup PR... There's only one import directly from src/components/common/Clickable. Most older code imports it from src/components/common and new code should import it from terra-ui-packages/components.

This updates DatasetBuilder to import Clickable from the components package, which allows removing the old Clickable module.