### PR TITLE
PROD-894 Persists anonId after signOut, made signOut sync

### DIFF
--- a/src/libs/auth.ts
+++ b/src/libs/auth.ts
@@ -118,13 +118,8 @@ const sendSignOutMetrics = async (cause: SignOutCause): Promise<void> => {
   });
 };
 
-export const signOut = async (cause: SignOutCause = 'unspecified'): Promise<void> => {
-  try {
-    await sendSignOutMetrics(cause);
-  } catch (error) {
-    console.error('Failed to send sign out metrics');
-    console.error(error);
-  }
+export const signOut = (cause: SignOutCause = 'unspecified'): void => {
+  sendSignOutMetrics(cause);
   if (cause === 'expiredRefreshToken' || cause === 'errorRefreshingAuthToken') {
     notify('info', sessionTimedOutErrorMessage, sessionTimeoutProps);
   }
@@ -139,9 +134,11 @@ export const signOut = async (cause: SignOutCause = 'unspecified'): Promise<void
     .finally(() => auth.removeUser())
     .finally(() => auth.clearStaleState());
   const cookiesAccepted: boolean | undefined = authStore.get().cookiesAccepted;
+  const anonymousId: string | undefined = authStore.get().anonymousId;
   authStore.reset();
   authStore.update((state) => ({
     ...state,
+    anonymousId,
     signInStatus: 'signedOut',
     // TODO: If allowed, this should be moved to the cookie store
     // Load whether a user has input a cookie acceptance in a previous session on this system,


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/PROD-894

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- 

### Why
- 

### Testing strategy
- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 
