### PR TITLE
WM-2325: Hide old CROMWELL app with feature flag set

### DIFF
--- a/src/analysis/modals/AnalysisModal.test.ts
+++ b/src/analysis/modals/AnalysisModal.test.ts
@@ -11,6 +11,7 @@ import { GoogleStorage, GoogleStorageContract } from 'src/libs/ajax/GoogleStorag
 import { App } from 'src/libs/ajax/leonardo/models/app-models';
 import { reportError } from 'src/libs/error';
 import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
+import { HAIL_BATCH_AZURE_FEATURE_ID } from 'src/libs/feature-previews-config';
 import { asMockedFn, renderWithAppContexts as render } from 'src/testing/test-utils';
 import { defaultAzureWorkspace, defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
 
@@ -298,7 +299,8 @@ describe('AnalysisModal', () => {
 
   it('Azure - Renders Hail Batch when feature flag is enabled', () => {
     // Arrange
-    asMockedFn(isFeaturePreviewEnabled).mockReturnValue(true);
+    asMockedFn(isFeaturePreviewEnabled).mockImplementation((preview) => preview === HAIL_BATCH_AZURE_FEATURE_ID);
+
     // Act
     render(h(AnalysisModal, defaultAzureModalProps));
     // Assert

--- a/src/analysis/utils/tool-utils.ts
+++ b/src/analysis/utils/tool-utils.ts
@@ -5,6 +5,7 @@ import { App } from 'src/libs/ajax/leonardo/models/app-models';
 import { Runtime } from 'src/libs/ajax/leonardo/models/runtime-models';
 import { isCromwellAppVisible } from 'src/libs/config';
 import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
+import { ENABLE_AZURE_COLLABORATIVE_WORKFLOW_READERS } from 'src/libs/feature-previews-config';
 import * as Utils from 'src/libs/utils';
 import { CloudProvider, cloudProviderTypes } from 'src/libs/workspace-utils';
 
@@ -225,8 +226,18 @@ export const isPauseSupported = (toolLabel: ToolLabel): boolean =>
 export const isToolHidden = (toolLabel: ToolLabel, cloudProvider: CloudProvider): boolean =>
   Utils.cond(
     [
-      toolLabel === appToolLabels.CROMWELL && cloudProvider === cloudProviderTypes.GCP && !isCromwellAppVisible(),
-      () => true,
+      toolLabel === appToolLabels.CROMWELL,
+      () =>
+        Utils.cond(
+          [cloudProvider === cloudProviderTypes.GCP, () => !isCromwellAppVisible()],
+          [
+            cloudProvider === cloudProviderTypes.AZURE,
+            () => {
+              return isFeaturePreviewEnabled(ENABLE_AZURE_COLLABORATIVE_WORKFLOW_READERS);
+            },
+          ],
+          [Utils.DEFAULT, () => false]
+        ),
     ],
     [
       toolLabel === appToolLabels.HAIL_BATCH &&


### PR DESCRIPTION
With the collaboration feature flag enabled, the CROMWELL app is no longer used. So it no longer makes sense to track it in the sidebar. There might be a call for a WORKFLOWS or CROMWELL_RUNNER sidebar, but it won't necessarily re-use this component (and will need plenty of effort put in to make it work, in any case)

Therefore: with the feature flag set, disable this option, for now.