### PR TITLE
[UIE-51] Move Spinner to components package

### DIFF
--- a/packages/components/src/Spinner.test.ts
+++ b/packages/components/src/Spinner.test.ts
@@ -1,0 +1,36 @@
+import { withFakeTimers } from '@terra-ui-packages/test-utils';
+import { act, screen } from '@testing-library/react';
+import { h } from 'react-hyperscript-helpers';
+
+import { renderWithTheme } from './internal/test-utils';
+import { Spinner } from './Spinner';
+import { visuallyHidden } from './styles';
+
+describe('Spinner', () => {
+  it('renders a spinner icon', () => {
+    // Act
+    renderWithTheme(h(Spinner));
+
+    // Assert
+    const icon = document.querySelector('[data-icon="loadingSpinner"]');
+    expect(icon).toBeInTheDocument();
+  });
+
+  it(
+    'renders a visually hidden alert after a delay',
+    withFakeTimers(() => {
+      // Act
+      renderWithTheme(h(Spinner, { message: 'Loading the data' }));
+
+      const isMessageRenderedImmediately = !!screen.queryByText('Loading the data');
+      act(() => jest.advanceTimersByTime(150));
+
+      // Assert
+      expect(isMessageRenderedImmediately).toBe(false);
+
+      const message = screen.getByText('Loading the data');
+      expect(message).toHaveAttribute('role', 'alert');
+      expect(message).toHaveStyle(visuallyHidden as Record<string, unknown>);
+    })
+  );
+});

--- a/packages/components/src/Spinner.ts
+++ b/packages/components/src/Spinner.ts
@@ -1,0 +1,26 @@
+import { Fragment, ReactNode } from 'react';
+import { h, span } from 'react-hyperscript-helpers';
+
+import { DelayedRender } from './DelayedRender';
+import { icon, IconProps } from './icon';
+import { visuallyHidden } from './styles';
+import { useThemeFromContext } from './theme';
+
+export interface SpinnerProps extends IconProps {
+  /** Message to announce to screen reader users. */
+  message?: string;
+}
+
+/**
+ * Renders a spinner and an alert for screen reader users.
+ */
+export const Spinner = (props: SpinnerProps): ReactNode => {
+  const { message = 'Loading', style, ...otherProps } = props;
+
+  const { colors } = useThemeFromContext();
+
+  return h(Fragment, [
+    icon('loadingSpinner', { size: 24, style: { color: colors.primary(), ...style }, ...otherProps }),
+    h(DelayedRender, { delay: 150 }, [span({ role: 'alert', style: visuallyHidden }, [message])]),
+  ]);
+};

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -11,6 +11,7 @@ export * from './InfoBox';
 export { Interactive } from './Interactive';
 export * from './Link';
 export * from './PopupTrigger';
+export * from './Spinner';
 export * from './Switch';
 export * from './theme';
 export * from './TooltipTrigger';

--- a/packages/components/src/styles.ts
+++ b/packages/components/src/styles.ts
@@ -1,0 +1,12 @@
+import { CSSProperties } from 'react';
+
+export const visuallyHidden: CSSProperties = {
+  position: 'absolute',
+  width: '1px',
+  height: '1px',
+  overflow: 'hidden',
+  padding: 0,
+  border: '0',
+  margin: '-1px',
+  clip: 'rect(0, 0, 0, 0)',
+};

--- a/src/components/icons.ts
+++ b/src/components/icons.ts
@@ -1,22 +1,16 @@
-import { DelayedRender, icon, IconProps } from '@terra-ui-packages/components';
+import { Spinner, SpinnerProps } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
-import { Fragment, ReactNode } from 'react';
-import { div, h, span } from 'react-hyperscript-helpers';
+import { ReactNode } from 'react';
+import { div, h } from 'react-hyperscript-helpers';
 import colors from 'src/libs/colors';
 
 export { icon } from '@terra-ui-packages/components';
 
-export interface SpinnerOptions extends IconProps {
-  message?: string;
-}
+export const spinner = (props: SpinnerProps = {}): ReactNode => {
+  return h(Spinner, props);
+};
 
-export const spinner = ({ message = 'Loading', ...props }: SpinnerOptions = {}): ReactNode =>
-  h(Fragment, [
-    icon('loadingSpinner', _.merge({ size: 24, style: { color: colors.primary() } }, props)),
-    h(DelayedRender, { delay: 150 }, [span({ className: 'sr-only', role: 'alert' }, [message])]),
-  ]);
-
-export const centeredSpinner = ({ size = 48, ...props }: SpinnerOptions = {}): ReactNode =>
+export const centeredSpinner = ({ size = 48, ...props }: SpinnerProps = {}): ReactNode =>
   spinner(
     _.merge(
       {


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/UIE-51

Continuing to move common components to the components package. This adds Spinner, converts it to TS, and adds tests.

Currently, Terra UI uses a `spinner` render function. In order to get theme colors from Context, Spinner needed to be a component. For now, to avoid updating many files in this PR, this keeps the `spinner` render function in Terra UI as a wrapper around the Spinner component. A future PR may remove it and replace `spinner(...)` with `h(Spinner, ...)`.