### PR TITLE
[WOR-1312] Add storage cost column to workspace list with ability to sort

### DIFF
--- a/src/libs/workspace-utils.ts
+++ b/src/libs/workspace-utils.ts
@@ -34,6 +34,7 @@ interface BaseWorkspaceInfo {
   isLocked?: boolean;
   state?: WorkspaceState;
   errorMessage?: string;
+  storageCost?: string;
 }
 
 export interface AzureWorkspaceInfo extends BaseWorkspaceInfo {


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WOR-1312

## Summary of changes:
This PR adds a column to the workspaces list containing the latest estimate for monthly storage costs. Currently, this only applies to GCP workspaces due to existing infrastructure, but inserts a placeholder value for Azure workspaces. In the future, this feature can be hopefully extended to all workspaces. This column can be sorted by so users can easily tell which of their workspaces are racking up lots of storage costs. 

I've discussed this feature with Adam Mullen a bit who liked the idea, but had a few reasonable concerns. I address some obvious concerns and questions in further detail at the end.

Here is an animated demo of the added feature.

https://github.com/DataBiosphere/terra-ui/assets/81349869/4d641064-c542-4414-b378-f8084f3a5fa0


### What
I reused the code from the Dashboard display of cost for GCP workspaces and ported it over to create a new column in the workspaces list. See below for further remarks on the coding choices, and potential improvements in the future.

### Why
This has been a [popular feature request](https://support.terra.bio/hc/en-us/community/posts/360071604332-Please-add-estimated-monthly-storage-cost-on-the-workspaces-page) for some time. This is particularly relevant to developers who might have old stale workspaces and not realize how much money they are wasting on old storage. The sorting ability allows users to triage and make choices about deleting old data/workspaces much more easily.

### Testing strategy
Tested it out a bit locally with different types of workspaces with different running storage costs.

### Further Details
The general strategy was to reuse existing code to also provide conveniently listed storage cost estimates in one place for all users. There were some obvious limitations to this strategy:
- It does not allow you to display running storage costs for Azure workspaces, but I don't think this is implemented anywhere in terra-ui yet. Once this is added (assuming it eventually will), the code can be modified slightly to allow for it. Instead, it will print an `N/A` placeholder for these workspaces, so the code should still "work" but just does not apply for Azure workspaces yet.
- The code uses an Ajax request to load the latest storage estimate, just as in the Dashboard. This seems to work OK in the examples I tested, but it obviously lags behind the other loaded fields slightly. It would be great to see the code move away from loading this asynchronously, and instead storing some latest estimate as part of the workspace metadata itself that can be queried on equal footing as the name, owner, etc. I can imagine a few different strategies, but updating this field daily (for recently accessed workspaces only?) as seems to be done currently behind the scenes based on the Dashboard display would allow for the same information to be readily displayed in a possibly much faster fashion. Also, if the Ajax takes a very long time to load, this could cause some issues with the sorting.

When chatting with Adam about this, we agreed this was a bit of a "quickfix" solution that would still be very useful to have in the short term, but there might be more careful thought about a longer term strategy when it comes to managing exposing these costs to users for all workspaces.

About the code itself, here are some reasons behind some of the non-obvious technical choices:
- In order to allow the column to be sort-able using the existing `FlexTable` infrastructure, I needed to actually add the `storageCost` as an (optional) field to the `Workspace` data type itself. In hindsight, I think this might help set up a vision where workspaces store this (periodically updated) data and can have it loaded all at once with the other attributes. This value gets updated dynamically using the result of the Ajax request.
- I wanted to reuse the Dashboard code as much as possible in loading the storage costs with Ajax, but found myself having to wrap the function call in a `useEffect` block, which I found by just Googling around after getting some tricky React rendering infinite loop errors with the `setState` happening inside the memo. I hope a more experienced JS developer could suggest a better way of handling this. 
- In general, there could some refactoring the code to include a utility for grabbing storage cost from a workspace, but unsure where that would go. I'd be happy to try implementing this sort of refactor if someone with more experience in the repo wanted to suggest some high level ideas. Of course, in a future model where the workspace object might hold this attribute already, it might not be needed.

Thanks for reading! I'm excited about getting a feature like this added to help better control cost spending on Terra, especially as a Terra user. 