### PR TITLE
[WOR-1313] Show confirmation dialog before starting a workspace migration

### DIFF
--- a/src/pages/workspaces/migration/BillingProjectParent.test.ts
+++ b/src/pages/workspaces/migration/BillingProjectParent.test.ts
@@ -137,6 +137,10 @@ describe('BillingProjectParent', () => {
       screen.queryByText(/Are you sure you want to migrate all remaining workspaces in billing project CARBilling-2/i)
     ).toBeTruthy();
     await user.click(screen.getByText('Migrate Remaining'));
+    // Confirmation dialog
+    expect(
+      screen.queryByText(/Are you sure you want to migrate all remaining workspaces in billing project CARBilling-2/i)
+    ).toBeFalsy();
 
     // Assert
     expect(mockStartBatchBucketMigration).toHaveBeenCalledWith([{ name: 'notmigrated', namespace: 'CARBilling-2' }]);

--- a/src/pages/workspaces/migration/BillingProjectParent.test.ts
+++ b/src/pages/workspaces/migration/BillingProjectParent.test.ts
@@ -23,6 +23,50 @@ describe('BillingProjectParent', () => {
     jest.resetAllMocks();
   });
 
+  it('shows migrate all button if all workspaces are unscheduled, with a cancelable confirmation dialog', async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const twoUnscheduledMigrationInfo: WorkspaceMigrationInfo[] = [
+      { migrationStep: 'Unscheduled', name: 'notmigrated1', namespace: 'CARBilling-2' },
+      { migrationStep: 'Unscheduled', name: 'notmigrated2', namespace: 'CARBilling-2' },
+    ];
+    const mockStartBatchBucketMigration = jest.fn().mockResolvedValue({});
+    const mockWorkspaces: Partial<AjaxWorkspacesContract> = {
+      startBatchBucketMigration: mockStartBatchBucketMigration,
+    };
+    const mockAjax: Partial<AjaxContract> = {
+      Workspaces: mockWorkspaces as AjaxWorkspacesContract,
+    };
+    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+
+    // Act
+    render(
+      div({ role: 'list' }, [
+        h(BillingProjectParent, {
+          billingProjectMigrationInfo: {
+            namespace: 'CARBilling-2',
+            workspaces: twoUnscheduledMigrationInfo,
+          },
+          migrationStartedCallback: mockMigrationStartedCallback,
+        }),
+      ])
+    );
+    await user.click(screen.getByText('Migrate all workspaces'));
+
+    // Confirmation dialog
+    expect(
+      screen.queryByText(/Are you sure you want to migrate all workspaces in billing project CARBilling-2/i)
+    ).toBeTruthy();
+    await user.click(screen.getByText('Cancel'));
+
+    // Assert
+    expect(
+      screen.queryByText(/Are you sure you want to migrate all workspaces in billing project CARBilling-2/i)
+    ).toBeFalsy();
+    expect(mockStartBatchBucketMigration).not.toHaveBeenCalled();
+    expect(mockMigrationStartedCallback).not.toHaveBeenCalled();
+  });
+
   it('shows migrate all button if all workspaces are unscheduled, with no accessibility errors', async () => {
     // Arrange
     const user = userEvent.setup();
@@ -53,6 +97,8 @@ describe('BillingProjectParent', () => {
     );
     expect(await axe(container)).toHaveNoViolations();
     await user.click(screen.getByText('Migrate all workspaces'));
+    // Confirmation dialog
+    await user.click(screen.getByText('Migrate All'));
 
     // Assert
     expect(mockStartBatchBucketMigration).toHaveBeenCalledWith([
@@ -86,6 +132,11 @@ describe('BillingProjectParent', () => {
       })
     );
     await user.click(screen.getByText('Migrate remaining workspaces'));
+    // Confirmation dialog
+    expect(
+      screen.queryByText(/Are you sure you want to migrate all remaining workspaces in billing project CARBilling-2/i)
+    ).toBeTruthy();
+    await user.click(screen.getByText('Migrate Remaining'));
 
     // Assert
     expect(mockStartBatchBucketMigration).toHaveBeenCalledWith([{ name: 'notmigrated', namespace: 'CARBilling-2' }]);

--- a/src/pages/workspaces/migration/BillingProjectParent.test.ts
+++ b/src/pages/workspaces/migration/BillingProjectParent.test.ts
@@ -54,15 +54,11 @@ describe('BillingProjectParent', () => {
     await user.click(screen.getByText('Migrate all workspaces'));
 
     // Confirmation dialog
-    expect(
-      screen.queryByText(/Are you sure you want to migrate all workspaces in billing project CARBilling-2/i)
-    ).toBeTruthy();
+    expect(screen.queryByText(/Are you sure you want to migrate all workspaces/i)).toBeTruthy();
     await user.click(screen.getByText('Cancel'));
 
     // Assert
-    expect(
-      screen.queryByText(/Are you sure you want to migrate all workspaces in billing project CARBilling-2/i)
-    ).toBeFalsy();
+    expect(screen.queryByText(/Are you sure you want to migrate all workspaces/i)).toBeFalsy();
     expect(mockStartBatchBucketMigration).not.toHaveBeenCalled();
     expect(mockMigrationStartedCallback).not.toHaveBeenCalled();
   });
@@ -133,16 +129,11 @@ describe('BillingProjectParent', () => {
     );
     await user.click(screen.getByText('Migrate remaining workspaces'));
     // Confirmation dialog
-    expect(
-      screen.queryByText(/Are you sure you want to migrate all remaining workspaces in billing project CARBilling-2/i)
-    ).toBeTruthy();
+    expect(screen.queryByText(/Are you sure you want to migrate all remaining workspaces/i)).toBeTruthy();
     await user.click(screen.getByText('Migrate Remaining'));
-    // Confirmation dialog
-    expect(
-      screen.queryByText(/Are you sure you want to migrate all remaining workspaces in billing project CARBilling-2/i)
-    ).toBeFalsy();
 
     // Assert
+    expect(screen.queryByText(/Are you sure you want to migrate all remaining workspaces/i)).toBeFalsy();
     expect(mockStartBatchBucketMigration).toHaveBeenCalledWith([{ name: 'notmigrated', namespace: 'CARBilling-2' }]);
     await screen.findByText('1 Workspace Migrated');
     expect(mockMigrationStartedCallback).toHaveBeenCalledWith([{ name: 'notmigrated', namespace: 'CARBilling-2' }]);

--- a/src/pages/workspaces/migration/BillingProjectParent.ts
+++ b/src/pages/workspaces/migration/BillingProjectParent.ts
@@ -69,6 +69,9 @@ export const BillingProjectParent = (props: BillingProjectParentProps): ReactNod
     // Some migrations may have started, but the page will not auto-refresh due to the error.
     'Error starting migration. Please refresh the page to get the most current status.',
     async () => {
+      // Dismiss the confirmation dialog.
+      setMigratingAll(false);
+
       const workspacesToMigrate: { namespace: string; name: string }[] = [];
       props.billingProjectMigrationInfo.workspaces.forEach((workspace) => {
         if (workspace.migrationStep === 'Unscheduled') {

--- a/src/pages/workspaces/migration/BillingProjectParent.ts
+++ b/src/pages/workspaces/migration/BillingProjectParent.ts
@@ -44,7 +44,9 @@ const MigrateAllConfirmation = (props: MigrateAllConfirmationProps) => {
     },
     [
       div([
-        `Are you sure you want to migrate all ${remainingWording} workspaces in billing project ${props.billingProject}?`,
+        `Are you sure you want to migrate all ${remainingWording} workspaces in billing project `,
+        b([props.billingProject]),
+        '?',
         b({ style: { display: 'block', marginTop: '1rem', marginBottom: '1.5rem' } }, [
           'This cannot be stopped or undone.',
         ]),
@@ -59,7 +61,7 @@ interface BillingProjectParentProps {
 }
 
 export const BillingProjectParent = (props: BillingProjectParentProps): ReactNode => {
-  const [migratingAll, setMigratingAll] = useState(false);
+  const [confirmMigration, setConfirmMigration] = useState(false);
 
   const migrationStats = useMemo(() => {
     return getBillingProjectMigrationStats(props.billingProjectMigrationInfo);
@@ -70,7 +72,7 @@ export const BillingProjectParent = (props: BillingProjectParentProps): ReactNod
     'Error starting migration. Please refresh the page to get the most current status.',
     async () => {
       // Dismiss the confirmation dialog.
-      setMigratingAll(false);
+      setConfirmMigration(false);
 
       const workspacesToMigrate: { namespace: string; name: string }[] = [];
       props.billingProjectMigrationInfo.workspaces.forEach((workspace) => {
@@ -156,7 +158,7 @@ export const BillingProjectParent = (props: BillingProjectParentProps): ReactNod
               h(
                 ButtonOutline,
                 {
-                  onClick: () => setMigratingAll(true),
+                  onClick: () => setConfirmMigration(true),
                 },
                 [
                   migrationStats.workspaceCount === migrationStats.unscheduled
@@ -174,9 +176,9 @@ export const BillingProjectParent = (props: BillingProjectParentProps): ReactNod
         props.billingProjectMigrationInfo.workspaces
       )
     ),
-    migratingAll &&
+    confirmMigration &&
       h(MigrateAllConfirmation, {
-        onDismiss: () => setMigratingAll(false),
+        onDismiss: () => setConfirmMigration(false),
         onSubmit: migrateWorkspace,
         billingProject: props.billingProjectMigrationInfo.namespace,
         remaining: migrationStats.workspaceCount !== migrationStats.unscheduled,


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-1313

To avoid a user accidentally clicking "Migrate All/Remaining Workspaces" (which can have a big impact, and is easy to accidentally click if you are collapsing/expanding a billing project), add a confirmation dialog to it.

And after further team discussion, we increased the scope to showing a confirmation dialog for single workspace migration as well.

1) Single workspace migration:
<img width="477" alt="image" src="https://github.com/DataBiosphere/terra-ui/assets/484484/15766f92-9975-4d41-8b89-7d58247ad688">

2) Migrate all workspaces:
<img width="469" alt="image" src="https://github.com/DataBiosphere/terra-ui/assets/484484/ef139d11-cd85-4832-920a-5e9c13e8c060">

3) Migrate remaining workspaces:
<img width="481" alt="image" src="https://github.com/DataBiosphere/terra-ui/assets/484484/bd444d69-aff4-4523-a634-d40638fd9ab8">
