### PR TITLE
WOR-1306 Automatically refresh workspace dashboard

### DIFF
--- a/src/pages/workspaces/workspace/WorkspaceContainer.ts
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.ts
@@ -430,7 +430,6 @@ export const wrapWorkspace = <T extends WrappedComponentProps>(
       if (accessError) {
         return h(FooterWrapper, [h(TopBar), h(WorkspaceAccessError)]);
       }
-      //   silentlyRefreshWorkspace : (errorHandling?: ErrorCallback) => Promise<void>;
 
       return h(
         WorkspaceContainer,

--- a/src/pages/workspaces/workspace/WorkspaceContainer.ts
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.ts
@@ -129,11 +129,7 @@ export const WorkspaceContainer = (props: WorkspaceContainerProps) => {
   // when the workspace refresh polling gets back an error for a workspace that is deleting
   // redirect to list view
   const handleWorkspaceError = (error: unknown) => {
-    if (
-      workspace?.workspace?.state === 'Deleting' &&
-      error instanceof Response &&
-      (error.status === 501 || error.status === 403 || error.status === 404)
-    ) {
+    if (workspace?.workspace?.state === 'Deleting' && error instanceof Response && error.status === 404) {
       Nav.goToPath('workspaces');
     }
   };

--- a/src/pages/workspaces/workspace/WorkspaceContainer.ts
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.ts
@@ -129,7 +129,7 @@ export const WorkspaceContainer = (props: WorkspaceContainerProps) => {
   // when the workspace refresh polling gets back an error for a workspace that is deleting
   // redirect to list view
   const handleWorkspaceError = (error: unknown) => {
-    if (workspace?.workspace?.state === 'Deleting' && error instanceof Response && error.status === 404) {
+    if (error instanceof Response && error.status === 404) {
       Nav.goToPath('workspaces');
     }
   };

--- a/src/pages/workspaces/workspace/useWorkspace.ts
+++ b/src/pages/workspaces/workspace/useWorkspace.ts
@@ -189,6 +189,7 @@ export const useWorkspace = (namespace, name): WorkspaceDetails => {
           'owners',
           'policies',
           'workspace',
+          'workspace.state',
           'workspace.attributes',
           'workspace.authorizationDomain',
           'workspace.cloudPlatform',


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WOR-1306

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
Poll in background to update workspace, and redirect to list view when a workspace is deleted.

I initially set this up to poll only for a workspace that was in the process of being deleted; then I realized the ticket included updating for all changes to the workspace. So I added a function to useWorkspace to update without setting the busy state, and switched to polling using that.


### Testing strategy
- [ ]  Manually tested that the UI pick up changes to the workspace, and redirects when it has been deleted.
- [ ] Added unit tests for polling functionality

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 
