### PR TITLE
ID-882 Fix register-user integration test flakeyness.

### DIFF
--- a/integration-tests/tests/register-user.js
+++ b/integration-tests/tests/register-user.js
@@ -17,6 +17,10 @@ const { registerTest } = require('../utils/jest-utils');
 
 const testRegisterUserFn = withUser(async ({ page, testUrl, token }) => {
   await gotoPage(page, testUrl);
+  await findText(page, 'Terra uses cookies');
+  await click(page, clickable({ textContains: 'Agree' }));
+  // We wait here for the cookie message to disappear, it has a fixed duration fading animation of 300ms
+  await delay(350);
   await verifyAccessibility(page);
   await click(page, clickable({ textContains: 'View Workspaces' }));
   await signIntoTerra(page, { token });


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/ID-882


## Summary of changes:
The cookie warning is causing the accessibility verification to fail, so this pr makes the verifyAccessibility call run more reliably as the cookie warning is fading out, which makes the error reliably reproducible locally. Then we added a delay to fix the failure.

### Why
- This test flakeyness blocks people from deploying

### Testing strategy
- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 
