### PR TITLE
[AJ-1166] Add ajax override util to use local WDS

### DIFF
--- a/src/appLoader.js
+++ b/src/appLoader.js
@@ -1,3 +1,4 @@
+import 'src/libs/ajax/ajax-override-utils';
 import 'src/style.css';
 
 import _ from 'lodash/fp';

--- a/src/libs/ajax/ajax-override-utils.ts
+++ b/src/libs/ajax/ajax-override-utils.ts
@@ -3,6 +3,9 @@
  * See https://github.com/DataBiosphere/terra-ui/wiki/Mocking-API-Responses.
  */
 
+import { ListAppResponse } from 'src/libs/ajax/leonardo/models/app-models';
+import { AjaxOverride, ajaxOverridesStore, getTerraUser } from 'src/libs/state';
+
 type FetchFn = typeof fetch;
 type FetchWrapper = (wrappedFetch: FetchFn) => FetchFn;
 
@@ -57,12 +60,61 @@ export const makeSuccess = (body: any): FetchWrapper => {
 };
 
 /**
+ * Override WDS app listings to use a local instance of WDS for relevant workspaces.
+ */
+export const overrideAppsWithLocalWDS = async () => {
+  const wdsUrl = 'http://localhost:8080';
+  const token = getTerraUser().token;
+
+  if (!token) {
+    throw new Error('Must be signed in to use local WDS');
+  }
+
+  // Get list of instances from local WDS.
+  // Using base fetch here to avoid an import cycle with ajax-common.ts.
+  const instancesResponse = await fetch(`${wdsUrl}/instances/v0.2`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+  });
+  const instances: string[] = await instancesResponse.json();
+
+  // For each instance on the local WDS, override the Leo apps list
+  // for the corresponding workspace to return the local WDS' URL
+  // as the WDS proxy URL for that workspace.
+  const ajaxOverrides: AjaxOverride[] = instances.map((instanceId) => {
+    const workspaceId = instanceId;
+    return {
+      filter: { url: new RegExp(`/apps/v2/${workspaceId}`) },
+      fn: mapJsonBody((apps: ListAppResponse[]): ListAppResponse[] => {
+        return apps.map((app) => {
+          if (app.appType === 'WDS') {
+            return {
+              ...app,
+              proxyUrls: {
+                ...app.proxyUrls,
+                wds: wdsUrl,
+              },
+            };
+          }
+          return app;
+        });
+      }),
+    };
+  });
+
+  ajaxOverridesStore.set(ajaxOverrides);
+};
+
+/**
  * Utilities to be exposed as globals.
  */
 const ajaxOverrideUtils = {
   mapJsonBody,
   makeError,
   makeSuccess,
+  overrideAppsWithLocalWDS,
 };
 
 declare global {

--- a/src/libs/state.ts
+++ b/src/libs/state.ts
@@ -232,7 +232,7 @@ export const snapshotStore = atom<unknown>(undefined);
 
 export const dataCatalogStore = atom<Dataset[]>([]);
 
-type AjaxOverride = {
+export type AjaxOverride = {
   fn: (fetch: AnyPromiseFn) => AnyPromiseFn;
   filter:
     | {

--- a/src/pages/Main.ts
+++ b/src/pages/Main.ts
@@ -1,4 +1,3 @@
-import 'src/libs/ajax/ajax-override-utils';
 import 'src/libs/routes';
 
 import { ErrorBoundary, ThemeProvider } from '@terra-ui-packages/components';


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1166

Currently, it's difficult to use a local WDS without modifying Terra UI code. This adds friction to manually testing WDS changes.

This adds a new ajax override utility to make that easier. Running `window.ajaxOverrideUtils.overrideAppsWithLocalWDS()` will identify the workspaces served by the local WDS and override Leo app listings for those workspaces to return `http://localhost:8080` as the WDS proxy URL.

To test:
1. Configure WDS' workspace ID to match one of your workspaces
2. Start a local WDS
3. Sign into Terra UI
4. Run ajaxOverrideUtils.overrideAppsWithLocalWDS() in the console
5. Navigate to the Data tab for the workspace served by the local WDS
6. Observe requests in the Network inspector