### PR TITLE
WOR-1283: reenable workspace error display

### DIFF
--- a/src/pages/workspaces/workspace/WorkspaceDeletingBanner.test.ts
+++ b/src/pages/workspaces/workspace/WorkspaceDeletingBanner.test.ts
@@ -57,8 +57,7 @@ describe('WorkspaceDeletingBanner', () => {
     expect(detailsLink).toBeNull();
   });
 
-  // TODO: re-enable when https://broadworkbench.atlassian.net/browse/WOR-1283 is complete
-  xit('gives a link to display the workspace error message if present', () => {
+  it('gives a link to display the workspace error message if present', () => {
     // Arrange
     const workspace: Workspace = {
       ...defaultAzureWorkspace,
@@ -76,8 +75,7 @@ describe('WorkspaceDeletingBanner', () => {
     expect(detailsLink).not.toBeNull();
   });
 
-  // TODO: re-enable when https://broadworkbench.atlassian.net/browse/WOR-1283 is complete
-  xit('shows the error message in a modal when the details link is clicked', () => {
+  it('shows the error message in a modal when the details link is clicked', () => {
     // Arrange
     const workspace: Workspace = {
       ...defaultAzureWorkspace,

--- a/src/pages/workspaces/workspace/WorkspaceDeletingBanner.ts
+++ b/src/pages/workspaces/workspace/WorkspaceDeletingBanner.ts
@@ -1,6 +1,8 @@
-import { icon } from '@terra-ui-packages/components';
-import { Fragment, ReactNode } from 'react';
+import { icon, Link } from '@terra-ui-packages/components';
+import { Fragment, ReactNode, useState } from 'react';
 import { div, h, span } from 'react-hyperscript-helpers';
+import ErrorView from 'src/components/ErrorView';
+import Modal from 'src/components/Modal';
 import TitleBar from 'src/components/TitleBar';
 import colors from 'src/libs/colors';
 import { WorkspaceWrapper as Workspace } from 'src/libs/workspace-utils';
@@ -44,9 +46,8 @@ const DeletingStateBanner = (): ReactNode => {
 };
 
 const DeleteFailedStateBanner = (props: WorkspaceDeletingBannerProps): ReactNode => {
-  // TODO: re-enable when https://broadworkbench.atlassian.net/browse/WOR-1283 is complete
-  // const { workspace } = props;
-  // const [showDetails, setShowDetails] = useState<boolean>(false);
+  const { workspace } = props;
+  const [showDetails, setShowDetails] = useState<boolean>(false);
   return h(Fragment, [
     h(TitleBar, {
       title: div(
@@ -59,8 +60,7 @@ const DeleteFailedStateBanner = (props: WorkspaceDeletingBannerProps): ReactNode
           span({ style: { color: colors.dark(), fontSize: 14, marginRight: '0.5rem' } }, [
             'Error deleting workspace. Analyses, Workflow, and Data tools are no longer accessible.',
           ]),
-          /*
-          // TODO: re-enable when https://broadworkbench.atlassian.net/browse/WOR-1283 is complete
+
           workspace?.workspace.errorMessage
             ? h(
                 Link,
@@ -71,15 +71,13 @@ const DeleteFailedStateBanner = (props: WorkspaceDeletingBannerProps): ReactNode
                 ['See error details.']
               )
             : null,
-            */
         ]
       ),
       style: { backgroundColor: colors.warning(0.1), borderBottom: `1px solid ${colors.accent()}` },
       onDismiss: () => {},
       hideCloseButton: true,
     }),
-    /*
-    // TODO: re-enable when https://broadworkbench.atlassian.net/browse/WOR-1283 is complete
+
     showDetails
       ? h(
           Modal,
@@ -93,6 +91,5 @@ const DeleteFailedStateBanner = (props: WorkspaceDeletingBannerProps): ReactNode
           [h(ErrorView, { error: workspace?.workspace.errorMessage ?? 'No error message available' })]
         )
       : null,
-      */
   ]);
 };


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WOR-1283

## Summary of changes:
Re-enables link and error view for workspaces that have failed deletion and have an error attached (and associated unit tests).

Screenshots with real errors:
<img width="1453" alt="Screenshot 2023-10-23 at 4 23 35 PM" src="https://github.com/DataBiosphere/terra-ui/assets/1930315/1851c7ca-f2b5-4241-9f6c-814cb7da22c2">
<img width="1453" alt="Screenshot 2023-10-23 at 4 23 14 PM" src="https://github.com/DataBiosphere/terra-ui/assets/1930315/fbcec8b5-df44-475d-8120-33ad93b33957">

<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 
