### PR TITLE
[ID-885] Add missing fields to update profile request

### DIFF
--- a/src/libs/ajax/User.ts
+++ b/src/libs/ajax/User.ts
@@ -84,6 +84,8 @@ export const makeSetUserProfileRequest = (terraUserProfile: TerraUserProfile): S
     programLocationState: terraUserProfile.programLocationState ?? 'N/A',
     programLocationCountry: terraUserProfile.programLocationCountry ?? 'N/A',
     department: terraUserProfile.department,
+    contactEmail: terraUserProfile.contactEmail,
+    researchArea: terraUserProfile.researchArea,
     interestInTerra: terraUserProfile.interestInTerra,
   };
 };

--- a/src/libs/state.ts
+++ b/src/libs/state.ts
@@ -32,6 +32,7 @@ export type TerraUserProfile = {
   programLocationCity: string | undefined;
   programLocationState: string | undefined;
   programLocationCountry: string | undefined;
+  researchArea: string | undefined;
   starredWorkspaces: string | undefined;
 };
 
@@ -119,6 +120,7 @@ export const authStore: Atom<AuthState> = atom<AuthState>({
     programLocationCity: undefined,
     programLocationState: undefined,
     programLocationCountry: undefined,
+    researchArea: undefined,
     interestInTerra: undefined,
     starredWorkspaces: undefined,
   },


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/ID-885

Saving the profile ignores the contact email and research area inputs. Those fields are always cleared.

This happens because they are not passed through to the update profile request. This adds them to `makeSetUserProfileRequest`.