### PR TITLE
[ID-823] Refresh profile when viewing profile page

### DIFF
--- a/integration-tests/tests/register-user.js
+++ b/integration-tests/tests/register-user.js
@@ -11,6 +11,7 @@ const {
   getLabelledTextInputValue,
   assertLabelledTextInputValue,
   delay,
+  waitForNoSpinners,
 } = require('../utils/integration-utils');
 const { fillInReplace, gotoPage } = require('../utils/integration-utils');
 const { registerTest } = require('../utils/jest-utils');
@@ -37,14 +38,18 @@ const testRegisterUserFn = withUser(async ({ page, testUrl, token }) => {
 
   // This is the hamburger menu
   await click(page, '/html/body/div[1]/div[2]/div/div[1]/div[1]/div[1]/div/div[1]');
-  await delay(1000);
+  // Wait for sidebar to transition in.
+  // Matches transition durations in ModalDrawer.
+  await delay(200);
 
   await findText(page, 'Integration Test');
   await click(page, clickable({ textContains: 'Integration Test' }));
-  await delay(1000);
+  // Wait for user menu to open.
+  // Matches transition duration on .ReactCollapse--collapse in style.css.
+  await delay(500);
 
   await click(page, clickable({ textContains: 'Profile' }));
-  await delay(1000);
+  await waitForNoSpinners(page);
 
   await findText(page, 'Hello again, Integration');
 

--- a/src/auth/profile/NotificationSettings.js
+++ b/src/auth/profile/NotificationSettings.js
@@ -1,6 +1,7 @@
 import _ from 'lodash/fp';
+import { useState } from 'react';
 import { div, h, h2 } from 'react-hyperscript-helpers';
-import { Checkbox } from 'src/components/common';
+import { Checkbox, spinnerOverlay } from 'src/components/common';
 import { InfoBox } from 'src/components/InfoBox';
 import { PageBox, PageBoxVariants } from 'src/components/PageBox';
 import { useWorkspaces } from 'src/components/workspace-utils';
@@ -59,9 +60,10 @@ const NotificationCard = memoWithName('NotificationCard', ({ label, notification
   ]);
 });
 
-export const NotificationSettings = ({ setSaving }) => {
+export const NotificationSettings = () => {
   const { workspaces } = useWorkspaces();
   const [prefsData] = _.over(_.pickBy)((_v, k) => _.startsWith('notifications/', k), authStore.get().profile);
+  const [saving, setSaving] = useState(false);
 
   return h(PageBox, { role: 'main', style: { flexGrow: 1 }, variant: PageBoxVariants.light }, [
     div({ style: Style.cardList.toolbarContainer }, [
@@ -125,5 +127,6 @@ export const NotificationSettings = ({ setSaving }) => {
         })
       )(workspaces)
     ),
+    saving && spinnerOverlay,
   ]);
 };

--- a/src/auth/profile/PersonalInfo.test.ts
+++ b/src/auth/profile/PersonalInfo.test.ts
@@ -1,0 +1,107 @@
+import { act, fireEvent, screen } from '@testing-library/react';
+import { h } from 'react-hyperscript-helpers';
+import { TerraUserProfile } from 'src/libs/state';
+import { renderWithAppContexts as render } from 'src/testing/test-utils';
+
+import { PersonalInfo } from './PersonalInfo';
+
+// Workaround for import cycle.
+jest.mock('src/libs/auth');
+
+type UseProxyGroupExports = typeof import('./useProxyGroup');
+jest.mock('./useProxyGroup', (): UseProxyGroupExports => {
+  return {
+    ...jest.requireActual<UseProxyGroupExports>('./useProxyGroup'),
+    useProxyGroup: jest
+      .fn()
+      .mockReturnValue({ proxyGroup: { status: 'Ready', state: 'PROXY_abc123@dev.test.firecloud.org' } }),
+  };
+});
+
+describe('PersonalInfo', () => {
+  const mockProfile: TerraUserProfile = {
+    firstName: 'Test',
+    lastName: 'User',
+
+    email: 'user@example.com',
+    contactEmail: '',
+
+    institute: 'Broad Institute',
+    title: 'Automated Test',
+    department: 'Data Sciences Platform',
+
+    programLocationCity: 'Cambridge',
+    programLocationState: 'MA',
+    programLocationCountry: 'USA',
+
+    researchArea: '',
+    interestInTerra: '',
+
+    starredWorkspaces: undefined,
+  };
+
+  it('renders the initial profile', () => {
+    // Act
+    const onSave = jest.fn().mockReturnValue(Promise.resolve());
+    render(h(PersonalInfo, { initialProfile: mockProfile, onSave }));
+
+    // Assert
+    const firstNameInput = screen.getByLabelText('First Name');
+    const lastNameInput = screen.getByLabelText('Last Name');
+
+    const organizationInput = screen.getByLabelText('Organization');
+    const titleInput = screen.getByLabelText('Title');
+    const departmentInput = screen.getByLabelText('Department');
+
+    const cityInput = screen.getByLabelText('City');
+    const stateInput = screen.getByLabelText('State');
+    const countryInput = screen.getByLabelText('Country');
+
+    const contactEmailInput = screen.getByLabelText('Contact Email for Notifications (if different)');
+
+    expect(firstNameInput).toHaveValue(mockProfile.firstName);
+    expect(lastNameInput).toHaveValue(mockProfile.lastName);
+
+    expect(organizationInput).toHaveValue(mockProfile.institute);
+    expect(titleInput).toHaveValue(mockProfile.title);
+    expect(departmentInput).toHaveValue(mockProfile.department);
+
+    expect(cityInput).toHaveValue(mockProfile.programLocationCity);
+    expect(stateInput).toHaveValue(mockProfile.programLocationState);
+    expect(countryInput).toHaveValue(mockProfile.programLocationCountry);
+
+    expect(contactEmailInput).toHaveValue(mockProfile.contactEmail);
+  });
+
+  it('calls onSave with the updated profile', () => {
+    // Arrange
+    const onSave = jest.fn().mockReturnValue(Promise.resolve());
+    render(h(PersonalInfo, { initialProfile: mockProfile, onSave }));
+
+    // Act
+    const firstNameInput = screen.getByLabelText('First Name');
+    const lastNameInput = screen.getByLabelText('Last Name');
+
+    act(() => fireEvent.change(firstNameInput, { target: { value: 'Updated' } }));
+    act(() => fireEvent.change(lastNameInput, { target: { value: 'Name' } }));
+
+    const saveButton = screen.getByText('Save Profile');
+    act(() => fireEvent.click(saveButton));
+
+    // Assert
+    expect(onSave).toHaveBeenCalledWith({
+      ...mockProfile,
+      firstName: 'Updated',
+      lastName: 'Name',
+    });
+  });
+
+  it("shows the user's proxy group", () => {
+    // Arrange
+    const onSave = jest.fn().mockReturnValue(Promise.resolve());
+    render(h(PersonalInfo, { initialProfile: mockProfile, onSave }));
+
+    // Assert
+    screen.getByText('PROXY_abc123@dev.test.firecloud.org');
+  });
+});

--- a/src/auth/profile/PersonalInfo.ts
+++ b/src/auth/profile/PersonalInfo.ts
@@ -7,10 +7,7 @@ import { TextInput, ValidatedInput } from 'src/components/input';
 import { PageBox, PageBoxVariants } from 'src/components/PageBox';
 import ProfilePicture from 'src/components/ProfilePicture';
 import { Ajax } from 'src/libs/ajax';
-import { makeSetUserProfileRequest } from 'src/libs/ajax/User';
-import { refreshTerraProfile } from 'src/libs/auth';
 import colors from 'src/libs/colors';
-import { withErrorReporting } from 'src/libs/error';
 import { useCancellation } from 'src/libs/react-utils';
 import { authStore, getTerraUser, TerraUserProfile } from 'src/libs/state';
 import * as Utils from 'src/libs/utils';
@@ -68,14 +65,15 @@ const styles = {
 };
 
 export interface PersonalInfoProps {
-  setSaving: (saving: boolean) => void;
+  initialProfile: TerraUserProfile;
+  onSave: (newProfile: TerraUserProfile) => void;
 }
 
 export const PersonalInfo = (props: PersonalInfoProps): ReactNode => {
-  const { setSaving } = props;
+  const { initialProfile, onSave } = props;
 
   const [profileInfo, setProfileInfo] = useState<TerraUserProfile>(
-    () => _.mapValues((v) => (v === 'N/A' ? '' : v), authStore.get().profile) as TerraUserProfile
+    () => _.mapValues((v) => (v === 'N/A' ? '' : v), initialProfile) as TerraUserProfile
   );
   const [proxyGroup, setProxyGroup] = useState<string>();
   const { researchArea } = profileInfo;
@@ -237,13 +235,9 @@ export const PersonalInfo = (props: PersonalInfoProps): ReactNode => {
         h(
           ButtonPrimary,
           {
-            onClick: _.flow(
-              Utils.withBusyState(setSaving),
-              withErrorReporting('Error saving profile')
-            )(async () => {
-              await Ajax().User.profile.set(makeSetUserProfileRequest(profileInfo));
-              await refreshTerraProfile();
-            }),
+            onClick: () => {
+              onSave(profileInfo);
+            },
             disabled: !!errors,
             tooltip: !!errors && 'Please fill out all required fields',
           },

--- a/src/auth/profile/Profile.js
+++ b/src/auth/profile/Profile.js
@@ -56,7 +56,7 @@ export const Profile = () => {
             tab,
             ['personalInfo', () => h(PersonalInfo, { setSaving })],
             ['externalIdentities', () => h(ExternalIdentities, { queryParams: query })],
-            ['notificationSettings', () => h(NotificationSettings, { setSaving })],
+            ['notificationSettings', () => h(NotificationSettings)],
             [Utils.DEFAULT, () => null]
           ),
         ]

--- a/src/auth/profile/Profile.test.ts
+++ b/src/auth/profile/Profile.test.ts
@@ -1,0 +1,150 @@
+import { MutableRefObject } from 'react';
+import { h } from 'react-hyperscript-helpers';
+import { TerraUserProfile } from 'src/libs/state';
+import { asMockedFn, renderWithAppContexts as render } from 'src/testing/test-utils';
+
+import { PersonalInfo, PersonalInfoProps } from './PersonalInfo';
+import { Profile } from './Profile';
+import { useUserProfile } from './useUserProfile';
+
+// Workaround for import cycle.
+jest.mock('src/libs/auth');
+
+type NavExports = typeof import('src/libs/nav');
+jest.mock('src/libs/nav', (): NavExports => {
+  return {
+    ...jest.requireActual<NavExports>('src/libs/nav'),
+    useRoute: jest.fn().mockReturnValue({ name: 'profile', query: {} }),
+  };
+});
+
+type PersonalInfoExports = typeof import('./PersonalInfo');
+jest.mock('./PersonalInfo', (): PersonalInfoExports => {
+  return {
+    ...jest.requireActual<PersonalInfoExports>('./PersonalInfo'),
+    PersonalInfo: jest.fn().mockReturnValue(null),
+  };
+});
+
+type UseUserProfileExports = typeof import('./useUserProfile');
+jest.mock('./useUserProfile', (): UseUserProfileExports => {
+  return {
+    ...jest.requireActual<UseUserProfileExports>('./useUserProfile'),
+    useUserProfile: jest.fn(),
+  };
+});
+
+describe('Profile', () => {
+  const mockProfile: TerraUserProfile = {
+    firstName: 'Test',
+    lastName: 'User',
+
+    email: 'user@example.com',
+    contactEmail: '',
+
+    institute: 'Broad Institute',
+    title: 'Automated Test',
+    department: 'Data Sciences Platform',
+
+    programLocationCity: 'Cambridge',
+    programLocationState: 'MA',
+    programLocationCountry: 'USA',
+
+    researchArea: '',
+    interestInTerra: '',
+
+    starredWorkspaces: undefined,
+  };
+
+  it('loads the user profile', () => {
+    // Arrange
+    asMockedFn(useUserProfile).mockReturnValue({
+      profile: {
+        status: 'Loading',
+        state: mockProfile,
+      },
+      refresh: () => Promise.resolve(),
+      update: () => Promise.resolve(),
+    });
+
+    // Act
+    render(h(Profile));
+
+    // Assert
+    expect(useUserProfile).toHaveBeenCalled();
+  });
+
+  it('renders a spinner and no content while the profile is refreshing', () => {
+    // Arrange
+    asMockedFn(useUserProfile).mockReturnValue({
+      profile: {
+        status: 'Loading',
+        state: mockProfile,
+      },
+      refresh: () => Promise.resolve(),
+      update: () => Promise.resolve(),
+    });
+
+    // Act
+    render(h(Profile));
+
+    // Assert
+    expect(document.querySelector('[data-icon="loadingSpinner"]')).not.toBeNull();
+    expect(PersonalInfo).not.toHaveBeenCalled();
+  });
+
+  it('renders content after the profile is refreshed', () => {
+    // Arrange
+    asMockedFn(useUserProfile).mockReturnValue({
+      profile: {
+        status: 'Ready',
+        state: mockProfile,
+      },
+      refresh: () => Promise.resolve(),
+      update: () => Promise.resolve(),
+    });
+
+    // Act
+    render(h(Profile));
+
+    // Assert
+    expect(PersonalInfo).toHaveBeenCalledWith(
+      {
+        initialProfile: mockProfile,
+        onSave: expect.any(Function),
+      } satisfies PersonalInfoProps,
+      expect.anything()
+    );
+  });
+
+  describe('PersonalInfo tab', () => {
+    it('updates the profile when personal info is saved', () => {
+      // Arrange
+      const updateProfile = jest.fn().mockReturnValue(Promise.resolve());
+      asMockedFn(useUserProfile).mockReturnValue({
+        profile: {
+          status: 'Ready',
+          state: mockProfile,
+        },
+        refresh: () => Promise.resolve(),
+        update: updateProfile,
+      });
+
+      // Get a reference to the onSave function passed to PersonalInfo.
+      const personalInfoPropsRef: MutableRefObject<PersonalInfoProps | null> = { current: null };
+      asMockedFn(PersonalInfo).mockImplementation((props) => {
+        personalInfoPropsRef.current = props;
+        return null;
+      });
+
+      render(h(Profile));
+
+      // Act
+      const updatedProfile = { ...mockProfile, firstName: 'Updated', lastName: 'Profile' };
+      personalInfoPropsRef.current?.onSave(updatedProfile);
+
+      // Assert
+      expect(updateProfile).toHaveBeenCalledWith(updatedProfile);
+    });
+  });
+});

--- a/src/auth/profile/Profile.ts
+++ b/src/auth/profile/Profile.ts
@@ -1,4 +1,4 @@
-import { Fragment, useState } from 'react';
+import { CSSProperties, Fragment, ReactNode, useState } from 'react';
 import { div, h, h2 } from 'react-hyperscript-helpers';
 import { spinnerOverlay } from 'src/components/common';
 import { SimpleTabBar } from 'src/components/tabBars';
@@ -18,29 +18,39 @@ const styles = {
     fontWeight: 600,
     textTransform: 'uppercase',
   },
-};
+} as const satisfies Record<string, CSSProperties>;
 
-export const Profile = () => {
+export const Profile = (): ReactNode => {
   // State
   const [saving, setSaving] = useState();
 
   // Render
   const { query, name } = Nav.useRoute();
-  const tab = query.tab || (name === 'fence-callback' ? 'externalIdentities' : 'personalInfo');
+  const tab: string = query.tab || (name === 'fence-callback' ? 'externalIdentities' : 'personalInfo');
 
   const tabs = [
     { key: 'personalInfo', title: 'Personal Information' },
     { key: 'externalIdentities', title: 'External Identities' },
     { key: 'notificationSettings', title: 'Notification Settings' },
-  ];
+  ] as const;
 
   // Render
   return h(Fragment, [
     saving && spinnerOverlay,
     div({ style: { flexGrow: 1, display: 'flex', flexDirection: 'column' } }, [
-      div({ style: { color: colors.dark(), fontSize: 18, fontWeight: 600, display: 'flex', alignItems: 'center', marginLeft: '1rem' } }, [
-        h2({ style: styles.pageHeading }, ['Profile']),
-      ]),
+      div(
+        {
+          style: {
+            color: colors.dark(),
+            fontSize: 18,
+            fontWeight: 600,
+            display: 'flex',
+            alignItems: 'center',
+            marginLeft: '1rem',
+          },
+        },
+        [h2({ style: styles.pageHeading }, ['Profile'])]
+      ),
       h(
         SimpleTabBar,
         {

--- a/src/auth/profile/useProxyGroup.test.ts
+++ b/src/auth/profile/useProxyGroup.test.ts
@@ -1,0 +1,79 @@
+import { abandonedPromise } from '@terra-ui-packages/core-utils';
+import { asMockedFn } from '@terra-ui-packages/test-utils';
+import { renderHook } from '@testing-library/react';
+import { User } from 'src/libs/ajax/User';
+import { renderHookInAct } from 'src/testing/test-utils';
+
+import { useProxyGroup } from './useProxyGroup';
+
+// Workaround for import cycle.
+jest.mock('src/libs/auth');
+
+type UserExports = typeof import('src/libs/ajax/User');
+jest.mock('src/libs/ajax/User', (): UserExports => {
+  return {
+    ...jest.requireActual<UserExports>('src/libs/ajax/User'),
+    User: jest.fn(),
+  };
+});
+
+type UserContract = ReturnType<typeof User>;
+
+describe('useProxyGroup', () => {
+  it('requests proxy group', () => {
+    // Arrange
+    const getProxyGroup = jest.fn().mockImplementation(() => abandonedPromise());
+    asMockedFn(User).mockImplementation(() => ({ getProxyGroup } as unknown as UserContract));
+
+    // Act
+    const { result: hookReturnRef } = renderHook(() => useProxyGroup('user@example.com'));
+
+    // Assert
+    expect(getProxyGroup).toHaveBeenCalledWith('user@example.com');
+
+    const result = hookReturnRef.current;
+    expect(result).toEqual({
+      proxyGroup: {
+        status: 'Loading',
+        state: null,
+      },
+    });
+  });
+
+  it('returns URL', async () => {
+    // Arrange
+    const getProxyGroup = jest.fn().mockResolvedValue('PROXY_123abc@dev.test.firecloud.org');
+    asMockedFn(User).mockImplementation(() => ({ getProxyGroup } as unknown as UserContract));
+
+    // Act
+    const { result: hookReturnRef } = await renderHookInAct(() => useProxyGroup('user@example.com'));
+
+    // Assert
+    const result = hookReturnRef.current;
+    expect(result).toEqual({
+      proxyGroup: {
+        status: 'Ready',
+        state: 'PROXY_123abc@dev.test.firecloud.org',
+      },
+    });
+  });
+
+  it('handles errors', async () => {
+    // Arrange
+    const getProxyGroup = jest.fn().mockRejectedValue(new Error('Something went wrong'));
+    asMockedFn(User).mockImplementation(() => ({ getProxyGroup } as unknown as UserContract));
+
+    // Act
+    const { result: hookReturnRef } = await renderHookInAct(() => useProxyGroup('user@example.com'));
+
+    // Assert
+    const result = hookReturnRef.current;
+    expect(result).toEqual({
+      proxyGroup: {
+        status: 'Error',
+        state: null,
+        error: new Error('Something went wrong'),
+      },
+    });
+  });
+});

--- a/src/auth/profile/useProxyGroup.ts
+++ b/src/auth/profile/useProxyGroup.ts
@@ -1,0 +1,41 @@
+import { LoadedState, NoneState } from '@terra-ui-packages/core-utils';
+import { useEffect, useState } from 'react';
+import { User } from 'src/libs/ajax/User';
+import { useCancellation } from 'src/libs/react-utils';
+
+export interface UseProxyGroupResult {
+  /** The proxy group and its loading status. */
+  proxyGroup: Exclude<LoadedState<string, unknown>, NoneState>;
+}
+
+/**
+ * Load a user's proxy group
+ *
+ * @param userEmail - The user's email.
+ */
+export const useProxyGroup = (userEmail: string | undefined): UseProxyGroupResult => {
+  const [proxyGroupState, setProxyGroupState] = useState<UseProxyGroupResult['proxyGroup']>({
+    status: 'Loading',
+    state: null,
+  });
+
+  const signal = useCancellation();
+  useEffect(() => {
+    if (userEmail) {
+      (async () => {
+        try {
+          const proxyGroup = await User(signal).getProxyGroup(userEmail);
+          setProxyGroupState({ status: 'Ready', state: proxyGroup });
+        } catch (error) {
+          setProxyGroupState({
+            status: 'Error',
+            state: null,
+            error,
+          });
+        }
+      })();
+    }
+  }, [signal, userEmail]);
+
+  return { proxyGroup: proxyGroupState };
+};

--- a/src/auth/profile/useUserProfile.test.ts
+++ b/src/auth/profile/useUserProfile.test.ts
@@ -1,0 +1,256 @@
+import { abandonedPromise } from '@terra-ui-packages/core-utils';
+import { act } from '@testing-library/react';
+import _ from 'lodash/fp';
+import { User } from 'src/libs/ajax/User';
+import { refreshTerraProfile } from 'src/libs/auth';
+import { reportError } from 'src/libs/error';
+import { authStore, TerraUserProfile } from 'src/libs/state';
+import { asMockedFn, renderHookInAct } from 'src/testing/test-utils';
+
+import { useUserProfile } from './useUserProfile';
+
+type UserExports = typeof import('src/libs/ajax/User');
+jest.mock('src/libs/ajax/User', (): UserExports => {
+  return {
+    ...jest.requireActual<UserExports>('src/libs/ajax/User'),
+    User: jest.fn(),
+  };
+});
+
+// Mock the entire auth module to work around the auth/ajax-common import cycle.
+jest.mock('src/libs/auth');
+
+type ErrorExports = typeof import('src/libs/error');
+jest.mock('src/libs/error', (): ErrorExports => {
+  return {
+    ...jest.requireActual<ErrorExports>('src/libs/error'),
+    reportError: jest.fn(),
+  };
+});
+
+type UserContract = ReturnType<typeof User>;
+
+const mockProfile: TerraUserProfile = {
+  firstName: 'Test',
+  lastName: 'User',
+
+  email: 'user@example.com',
+  contactEmail: '',
+
+  institute: '',
+  title: '',
+  department: '',
+
+  programLocationCity: '',
+  programLocationState: '',
+  programLocationCountry: '',
+
+  researchArea: '',
+  interestInTerra: '',
+
+  starredWorkspaces: undefined,
+};
+
+describe('useUserProfile', () => {
+  beforeEach(() => {
+    authStore.update((state) => {
+      return {
+        ...state,
+        profile: mockProfile,
+      };
+    });
+  });
+
+  it('returns user profile from global auth store', async () => {
+    // Act
+    const { result: hookReturnRef } = await renderHookInAct(() => useUserProfile());
+    const initialResult = hookReturnRef.current;
+
+    // Any change to the auth store should cause the hook to rerender.
+    const updatedProfile = { ...mockProfile, firstName: 'Test' };
+    act(() =>
+      authStore.update((state) => {
+        return {
+          ...state,
+          profile: updatedProfile,
+        };
+      })
+    );
+    const resultAfterUpdate = hookReturnRef.current;
+
+    // Assert
+    expect(initialResult.profile.state).toEqual(mockProfile);
+    expect(resultAfterUpdate.profile.state).toEqual(updatedProfile);
+  });
+
+  describe('refreshing the profile', () => {
+    it('refreshes the profile when mounted', async () => {
+      // Act
+      await renderHookInAct(() => useUserProfile());
+
+      // Assert
+      expect(refreshTerraProfile).toHaveBeenCalled();
+    });
+
+    it('returns a function to refresh the profile', async () => {
+      // Arrange
+      const { result: hookReturnRef } = await renderHookInAct(() => useUserProfile());
+
+      // Clear the mock after the hook's initial/automatic refresh.
+      asMockedFn(refreshTerraProfile).mockReset();
+      expect(refreshTerraProfile).not.toHaveBeenCalled();
+
+      // Act
+      await act(() => hookReturnRef.current.refresh());
+
+      // Assert
+      expect(refreshTerraProfile).toHaveBeenCalled();
+    });
+
+    it('returns loading status while profile is loading', async () => {
+      // Arrange
+      asMockedFn(refreshTerraProfile).mockReturnValue(abandonedPromise());
+
+      // Act
+      const { result: hookReturnRef } = await renderHookInAct(() => useUserProfile());
+
+      // Assert
+      expect(hookReturnRef.current.profile.status).toBe('Loading');
+    });
+
+    it('returns ready status after profile has loaded', async () => {
+      // Arrange
+      asMockedFn(refreshTerraProfile).mockResolvedValue();
+
+      // Act
+      const { result: hookReturnRef } = await renderHookInAct(() => useUserProfile());
+
+      // Assert
+      expect(hookReturnRef.current.profile.status).toBe('Ready');
+    });
+
+    it('returns error status if profile refresh fails', async () => {
+      // Arrange
+      asMockedFn(refreshTerraProfile).mockRejectedValue(new Error('Something went wrong'));
+
+      // Act
+      const { result: hookReturnRef } = await renderHookInAct(() => useUserProfile());
+
+      // Assert
+      expect(hookReturnRef.current.profile.status).toBe('Error');
+    });
+
+    it('returns reports error if profile refresh fails', async () => {
+      // Arrange
+      asMockedFn(refreshTerraProfile).mockRejectedValue(new Error('Something went wrong'));
+
+      // Act
+      await renderHookInAct(() => useUserProfile());
+
+      // Assert
+      expect(reportError).toHaveBeenCalledWith('Error loading profile', new Error('Something went wrong'));
+    });
+  });
+
+  describe('updating the profile', () => {
+    let setProfile;
+
+    beforeEach(() => {
+      asMockedFn(refreshTerraProfile).mockReturnValue(Promise.resolve());
+
+      setProfile = jest.fn().mockReturnValue(abandonedPromise());
+      asMockedFn(User).mockImplementation(() => {
+        return {
+          profile: {
+            set: setProfile,
+          },
+        } as unknown as UserContract;
+      });
+    });
+
+    const updatedProfile: TerraUserProfile = {
+      ...mockProfile,
+      firstName: 'Updated',
+      lastName: 'Name',
+    };
+
+    it('returns a function to update the profile', async () => {
+      const { result: hookReturnRef } = await renderHookInAct(() => useUserProfile());
+
+      // Act
+      act(() => {
+        hookReturnRef.current.update(updatedProfile);
+      });
+
+      // Assert
+      // Not all profile fields are updated via this request.
+      expect(setProfile).toHaveBeenCalledWith(_.omit(['email', 'starredWorkspaces'], updatedProfile));
+    });
+
+    it('returns loading status while profile is updating', async () => {
+      // Arrange
+      const { result: hookReturnRef } = await renderHookInAct(() => useUserProfile());
+
+      // Act
+      act(() => {
+        hookReturnRef.current.update(updatedProfile);
+      });
+
+      // Assert
+      expect(hookReturnRef.current.profile.status).toBe('Loading');
+    });
+
+    it('refreshes profile after updating profile', async () => {
+      // Arrange
+      setProfile.mockReturnValue(Promise.resolve());
+      const { result: hookReturnRef } = await renderHookInAct(() => useUserProfile());
+
+      // Reset mock after initial refresh.
+      asMockedFn(refreshTerraProfile).mockReset();
+      expect(refreshTerraProfile).not.toHaveBeenCalled();
+
+      // Act
+      await act(() => hookReturnRef.current.update(updatedProfile));
+
+      // Assert
+      expect(refreshTerraProfile).toHaveBeenCalled();
+    });
+
+    it('returns ready status after profile has updated and refreshed', async () => {
+      // Arrange
+      setProfile.mockReturnValue(Promise.resolve());
+
+      // Act
+      const { result: hookReturnRef } = await renderHookInAct(() => useUserProfile());
+
+      // Assert
+      expect(hookReturnRef.current.profile.status).toBe('Ready');
+    });
+
+    it('returns error status if profile update fails', async () => {
+      // Arrange
+      asMockedFn(setProfile).mockRejectedValue(new Error('Something went wrong'));
+
+      const { result: hookReturnRef } = await renderHookInAct(() => useUserProfile());
+
+      // Act
+      await act(() => hookReturnRef.current.update(updatedProfile));
+
+      // Assert
+      expect(hookReturnRef.current.profile.status).toBe('Error');
+    });
+
+    it('returns reports error if profile update fails', async () => {
+      // Arrange
+      asMockedFn(setProfile).mockRejectedValue(new Error('Something went wrong'));
+
+      const { result: hookReturnRef } = await renderHookInAct(() => useUserProfile());
+
+      // Act
+      await act(() => hookReturnRef.current.update(updatedProfile));
+
+      // Assert
+      expect(reportError).toHaveBeenCalledWith('Error saving profile', new Error('Something went wrong'));
+    });
+  });
+});

--- a/src/auth/profile/useUserProfile.ts
+++ b/src/auth/profile/useUserProfile.ts
@@ -1,0 +1,69 @@
+import { useCallback, useEffect, useState } from 'react';
+import { makeSetUserProfileRequest, User } from 'src/libs/ajax/User';
+import { refreshTerraProfile } from 'src/libs/auth';
+import { reportError } from 'src/libs/error';
+import { useStore } from 'src/libs/react-utils';
+import { authStore, TerraUserProfile } from 'src/libs/state';
+
+/**
+ * Custom LoadedState because we always have a value for the profile from the global state.
+ */
+interface ProfileLoadedState {
+  /** Status of a request to refresh or update the profile. */
+  status: 'Loading' | 'Ready' | 'Error';
+
+  /** The user's profile. */
+  state: TerraUserProfile;
+}
+
+export interface UseUserProfileResult {
+  /** The user's profile and its refresh status. */
+  profile: ProfileLoadedState;
+
+  /** Refresh the user's profile. */
+  refresh: () => Promise<void>;
+
+  /** Update the user's profile. */
+  update: (profile: TerraUserProfile) => Promise<void>;
+}
+
+export const useUserProfile = (): UseUserProfileResult => {
+  const { profile } = useStore(authStore);
+
+  const [status, setStatus] = useState<'Loading' | 'Ready' | 'Error'>('Loading');
+
+  const refresh = useCallback(async () => {
+    setStatus('Loading');
+    try {
+      await refreshTerraProfile();
+      setStatus('Ready');
+    } catch (err) {
+      reportError('Error loading profile', err);
+      setStatus('Error');
+    }
+  }, []);
+
+  const update = useCallback(async (updatedProfile: TerraUserProfile): Promise<void> => {
+    setStatus('Loading');
+    try {
+      await User().profile.set(makeSetUserProfileRequest(updatedProfile));
+      await refreshTerraProfile();
+      setStatus('Ready');
+    } catch (err) {
+      reportError('Error saving profile', err);
+      setStatus('Error');
+    }
+  }, []);
+
+  // exhaustive-deps is disabled because this should run only once, when the hook mounts.
+  // It should not re-run in the event refresh is recreated.
+  useEffect(() => {
+    refresh();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return {
+    profile: { status, state: profile },
+    refresh,
+    update,
+  };
+};

--- a/src/libs/state.ts
+++ b/src/libs/state.ts
@@ -25,6 +25,7 @@ export type TerraUserProfile = {
   firstName: string | undefined;
   lastName: string | undefined;
   institute: string | undefined;
+  email: string | undefined;
   contactEmail: string | undefined;
   title: string | undefined;
   department: string | undefined;
@@ -113,6 +114,7 @@ export const authStore: Atom<AuthState> = atom<AuthState>({
   profile: {
     firstName: undefined,
     lastName: undefined,
+    email: undefined,
     contactEmail: undefined,
     title: undefined,
     institute: undefined,
@@ -151,6 +153,7 @@ export const authStore: Atom<AuthState> = atom<AuthState>({
     idp: undefined,
   },
 });
+
 export const getTerraUser = (): TerraUser => authStore.get().terraUser;
 
 export const getSessionId = () => authStore.get().sessionId;


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/ID-823

Currently, the Profile page reads the user's profile out of the global auth store when it's mounted. However, that results in a bug when the page is reloaded and the Profile page is rendered before the profile is loaded.

To reproduce, navigate the Profile page and reload the page.
![Screenshot 2023-10-24 at 12 54 24 PM](https://github.com/DataBiosphere/terra-ui/assets/1156625/1f91dad6-399a-462c-9994-9a0dc991d05f)

This bug has also caused flakiness in the register-user test, which asserts the contents of the personal info tab.

With this PR, navigating to the Profile page refreshes the profile and waits for it to be refreshed before showing the personal information form. Refreshing the data being displayed is consistent with other pages (such as the workspaces list) and ensures that we're showing the latest information if the user has updated their profile in another window/tab.

This also does a fair bit of refactoring. It adds hooks to load/update the user profile and to load the user's proxy group. The profile state is managed by the Profile component, and PersonalInfo becomes mostly a form component that's unaware of Ajax (it does still request the proxy group, but via a hook).

The diff is large, but it's mostly unit tests. Reviewing commit by commit may make the changes clearer.