### PR TITLE
[IA-4574] Fix app errors and refactor AppErrorModal

### DIFF
--- a/src/analysis/ContextBar.test.ts
+++ b/src/analysis/ContextBar.test.ts
@@ -15,7 +15,7 @@ import {
 import { appToolLabels, isToolHidden, runtimeToolLabels } from 'src/analysis/utils/tool-utils';
 import { MenuTrigger } from 'src/components/PopupTrigger';
 import { Ajax } from 'src/libs/ajax';
-import { App } from 'src/libs/ajax/leonardo/models/app-models';
+import { App, ListAppResponse } from 'src/libs/ajax/leonardo/models/app-models';
 import { PersistentDisk } from 'src/libs/ajax/leonardo/models/disk-models';
 import { Runtime, runtimeStatuses } from 'src/libs/ajax/leonardo/models/runtime-models';
 import { defaultAzureMachineType, defaultAzureRegion } from 'src/libs/azure-utils';
@@ -200,7 +200,7 @@ const cromwellDisk: PersistentDisk = {
   zone: 'us-central1-a',
 };
 
-const cromwellOnAzureRunning: App = {
+const cromwellOnAzureRunning: ListAppResponse = {
   workspaceId: null,
   accessScope: null,
   appName: 'test-cromwell-app',
@@ -222,7 +222,6 @@ const cromwellOnAzureRunning: App = {
     cromwell: 'https://lz123.servicebus.windows.net/test-cromwell-app/cromwell',
     wds: 'https://lz123.servicebus.windows.net/test-cromwell-app/wds',
   },
-  customEnvironmentVariables: {},
   auditInfo: {
     creator: 'abc.testerson@gmail.com',
     createdDate: '2023-01-18T23:28:47.605176Z',
@@ -423,7 +422,7 @@ const contextBarPropsForAzure: ContextBarProps = {
   workspace: defaultAzureWorkspace,
 };
 
-const hailBatchAppRunning: App = {
+const hailBatchAppRunning: ListAppResponse = {
   workspaceId: null,
   accessScope: null,
   appName: 'test-hail-batch-app',
@@ -442,7 +441,6 @@ const hailBatchAppRunning: App = {
   proxyUrls: {
     batch: 'https://lz123.servicebus.windows.net/test-hail-batch-app/batch',
   },
-  customEnvironmentVariables: {},
   auditInfo: {
     creator: 'abc.testerson@gmail.com',
     createdDate: '2023-01-18T23:28:47.605176Z',

--- a/src/analysis/ContextBar.ts
+++ b/src/analysis/ContextBar.ts
@@ -42,7 +42,7 @@ import hailLogo from 'src/images/hail-logo.svg';
 import jupyterLogo from 'src/images/jupyter-logo.svg';
 import rstudioSquareLogo from 'src/images/rstudio-logo-square.png';
 import { Ajax } from 'src/libs/ajax';
-import { App } from 'src/libs/ajax/leonardo/models/app-models';
+import { ListAppResponse } from 'src/libs/ajax/leonardo/models/app-models';
 import { PersistentDisk } from 'src/libs/ajax/leonardo/models/disk-models';
 import { Runtime } from 'src/libs/ajax/leonardo/models/runtime-models';
 import colors from 'src/libs/colors';
@@ -80,7 +80,7 @@ const contextBarStyles: { [label: string]: CSSProperties } = {
 
 export interface ContextBarProps {
   runtimes: Runtime[];
-  apps: App[];
+  apps: ListAppResponse[];
   appDataDisks: PersistentDisk[];
   refreshRuntimes: (maybeStale?: boolean) => Promise<void>;
   storageDetails: StorageDetails;

--- a/src/analysis/Environments/DeleteAppModal.ts
+++ b/src/analysis/Environments/DeleteAppModal.ts
@@ -5,7 +5,7 @@ import { SaveFilesHelpGalaxy } from 'src/analysis/runtime-common-components';
 import { appTools } from 'src/analysis/utils/tool-utils';
 import { LabeledCheckbox, spinnerOverlay } from 'src/components/common';
 import Modal from 'src/components/Modal';
-import { App } from 'src/libs/ajax/leonardo/models/app-models';
+import { ListAppResponse } from 'src/libs/ajax/leonardo/models/app-models';
 import { LeoAppProvider } from 'src/libs/ajax/leonardo/providers/LeoAppProvider';
 import { withErrorReportingInModal } from 'src/libs/error';
 import * as Utils from 'src/libs/utils';
@@ -13,7 +13,7 @@ import * as Utils from 'src/libs/utils';
 export type DeleteAppProvider = Pick<LeoAppProvider, 'delete'>;
 
 export interface DeleteAppModalProps {
-  app: App;
+  app: ListAppResponse;
   onDismiss: () => void;
   onSuccess: () => void;
   deleteProvider: DeleteAppProvider;

--- a/src/analysis/Environments/Environments.models.ts
+++ b/src/analysis/Environments/Environments.models.ts
@@ -1,4 +1,4 @@
-import { App } from 'src/libs/ajax/leonardo/models/app-models';
+import { ListAppResponse } from 'src/libs/ajax/leonardo/models/app-models';
 import { PersistentDisk } from 'src/libs/ajax/leonardo/models/disk-models';
 import { ListRuntimeItem } from 'src/libs/ajax/leonardo/models/runtime-models';
 import { WorkspaceInfo } from 'src/libs/workspace-utils';
@@ -10,7 +10,7 @@ export interface DecoratedResourceAttributes {
 
 export type RuntimeWithWorkspace = DecoratedResourceAttributes & ListRuntimeItem;
 export type DiskWithWorkspace = DecoratedResourceAttributes & PersistentDisk;
-export type AppWithWorkspace = DecoratedResourceAttributes & App;
+export type AppWithWorkspace = DecoratedResourceAttributes & ListAppResponse;
 
 export type DecoratedComputeResource = RuntimeWithWorkspace | AppWithWorkspace;
 export type DecoratedResource = DecoratedComputeResource | DiskWithWorkspace;

--- a/src/analysis/Environments/Environments.test.ts
+++ b/src/analysis/Environments/Environments.test.ts
@@ -58,6 +58,7 @@ const getMockLeoAppProvider = (overrides?: Partial<LeoAppProvider>): LeoAppProvi
     listWithoutProject: jest.fn(),
     pause: jest.fn(),
     delete: jest.fn(),
+    get: jest.fn(),
   };
   asMockedFn(defaultProvider.listWithoutProject).mockResolvedValue([]);
 
@@ -618,6 +619,7 @@ describe('Environments', () => {
           expect.objectContaining({
             appName: app.appName,
             cloudContext: app.cloudContext,
+            workspaceId: app.workspaceId,
           } satisfies AppBasics)
         );
       } else {

--- a/src/analysis/Environments/Environments.ts
+++ b/src/analysis/Environments/Environments.ts
@@ -959,8 +959,7 @@ export const Environments = (props: EnvironmentsProps): ReactNode => {
         }),
       deleteDiskId && renderDeleteDiskModal(_.find({ id: deleteDiskId }, disks) as DiskWithWorkspace),
       deleteAppModal.maybeRender(),
-      errorAppId &&
-        appWithErrors &&
+      appWithErrors &&
         h(AppErrorModal, {
           app: appWithErrors,
           onDismiss: () => setErrorAppId(undefined),

--- a/src/analysis/Environments/Environments.ts
+++ b/src/analysis/Environments/Environments.ts
@@ -2,6 +2,7 @@ import { Mutate, NavLinkProvider } from '@terra-ui-packages/core-utils';
 import _ from 'lodash/fp';
 import { Fragment, ReactNode, useEffect, useState } from 'react';
 import { div, h, h2, p, span, strong } from 'react-hyperscript-helpers';
+import { AppErrorModal } from 'src/analysis/modals/AppErrorModal';
 import { SaveFilesHelp, SaveFilesHelpAzure } from 'src/analysis/runtime-common-components';
 import { RuntimeErrorModal } from 'src/analysis/RuntimeManager';
 import { getDiskAppType } from 'src/analysis/utils/app-utils';
@@ -45,7 +46,6 @@ import * as Style from 'src/libs/style';
 import * as Utils from 'src/libs/utils';
 import { GoogleWorkspaceInfo, isGoogleWorkspaceInfo, WorkspaceWrapper } from 'src/libs/workspace-utils';
 
-import { AppErrorModal } from 'src/analysis/modals/AppErrorModal';
 import { DeleteAppModal } from './DeleteAppModal';
 import { DeleteButton } from './DeleteButton';
 import {

--- a/src/analysis/RuntimeManager.js
+++ b/src/analysis/RuntimeManager.js
@@ -1,9 +1,13 @@
+// This file is where any notifications not tied to a specific action are managed for leonardo-related resource
+// For example, if you load a page and your apps/runtimes are in an error state, this component is responsible for that notification
+
 import { isToday } from 'date-fns';
 import { isAfter } from 'date-fns/fp';
 import _ from 'lodash/fp';
 import PropTypes from 'prop-types';
 import { Fragment, useEffect, useState } from 'react';
 import { div, h, p } from 'react-hyperscript-helpers';
+import { AppErrorModal } from 'src/analysis/modals/AppErrorModal';
 import { appLauncherTabName, GalaxyLaunchButton, GalaxyWarning } from 'src/analysis/runtime-common-components';
 import { getCurrentApp } from 'src/analysis/utils/app-utils';
 import { dataSyncingDocUrl } from 'src/analysis/utils/gce-machines';
@@ -12,6 +16,7 @@ import { appTools, runtimeToolLabels } from 'src/analysis/utils/tool-utils';
 import { ButtonPrimary, Clickable, Link, spinnerOverlay } from 'src/components/common';
 import Modal from 'src/components/Modal';
 import { Ajax } from 'src/libs/ajax';
+import { leoAppProvider } from 'src/libs/ajax/leonardo/providers/LeoAppProvider';
 import { getDynamic, getSessionStorage, setDynamic } from 'src/libs/browser-storage';
 import colors from 'src/libs/colors';
 import { withErrorReporting } from 'src/libs/error';
@@ -89,36 +94,6 @@ const RuntimeErrorNotification = ({ runtime }) => {
   ]);
 };
 
-export const AppErrorModal = ({ app, onDismiss }) => {
-  const [error, setError] = useState();
-  const [loadingAppDetails, setLoadingAppDetails] = useState(false);
-
-  const loadAppError = _.flow(
-    withErrorReporting('Error loading app details'),
-    Utils.withBusyState(setLoadingAppDetails)
-  )(async () => {
-    const { errors: appErrors } = await Ajax().Apps.app(app.cloudContext.cloudResource, app.appName).details();
-    setError(appErrors[0]?.errorMessage);
-  });
-
-  useOnMount(() => {
-    loadAppError();
-  });
-
-  return h(
-    Modal,
-    {
-      title: 'Galaxy App is in error state',
-      showCancel: false,
-      onDismiss,
-    },
-    [
-      div({ style: { whiteSpace: 'pre-wrap', overflowWrap: 'break-word', overflowY: 'auto', maxHeight: 500, background: colors.light() } }, [error]),
-      loadingAppDetails && spinnerOverlay,
-    ]
-  );
-};
-
 const AppErrorNotification = ({ app }) => {
   const [modalOpen, setModalOpen] = useState(false);
 
@@ -140,6 +115,7 @@ const AppErrorNotification = ({ app }) => {
       h(AppErrorModal, {
         app,
         onDismiss: () => setModalOpen(false),
+        appProvider: leoAppProvider,
       }),
   ]);
 };

--- a/src/analysis/_testData/testData.ts
+++ b/src/analysis/_testData/testData.ts
@@ -532,7 +532,7 @@ export const listGoogleRuntime = ({
   };
 };
 
-export const galaxyRunning: App = {
+export const galaxyRunning: ListAppResponse = {
   workspaceId: null,
   accessScope: null,
   cloudContext: {

--- a/src/analysis/_testData/testData.ts
+++ b/src/analysis/_testData/testData.ts
@@ -6,7 +6,7 @@ import {
 } from 'src/analysis/utils/disk-utils';
 import { defaultGceMachineType, defaultLocation, generateRuntimeName } from 'src/analysis/utils/runtime-utils';
 import { runtimeToolLabels, tools } from 'src/analysis/utils/tool-utils';
-import {App, AppError, GetAppResponse, ListAppResponse} from 'src/libs/ajax/leonardo/models/app-models';
+import { App, AppError, GetAppResponse, ListAppResponse } from 'src/libs/ajax/leonardo/models/app-models';
 import { PersistentDisk } from 'src/libs/ajax/leonardo/models/disk-models';
 import {
   AzureConfig,

--- a/src/analysis/_testData/testData.ts
+++ b/src/analysis/_testData/testData.ts
@@ -6,7 +6,7 @@ import {
 } from 'src/analysis/utils/disk-utils';
 import { defaultGceMachineType, defaultLocation, generateRuntimeName } from 'src/analysis/utils/runtime-utils';
 import { runtimeToolLabels, tools } from 'src/analysis/utils/tool-utils';
-import { App, ListAppResponse } from 'src/libs/ajax/leonardo/models/app-models';
+import {App, AppError, GetAppResponse, ListAppResponse} from 'src/libs/ajax/leonardo/models/app-models';
 import { PersistentDisk } from 'src/libs/ajax/leonardo/models/disk-models';
 import {
   AzureConfig,
@@ -237,6 +237,15 @@ export const getRuntimeConfig = (overrides: Partial<RuntimeConfig> = {}): Runtim
     gpuConfig: undefined,
     ...overrides,
   } satisfies GceWithPdConfig);
+
+export const appError: AppError = {
+  action: '',
+  source: '',
+  errorMessage: 'test error message',
+  timestamp: '2022-09-19T15:37:11.035465Z',
+  googleErrorCode: null,
+  traceId: null,
+};
 
 // Use this if you only need to override top-level fields, otherwise use `getGoogleRuntime`
 export const generateTestGetGoogleRuntime = (overrides: Partial<GetRuntimeItem> = {}): GetRuntimeItem => {
@@ -633,6 +642,11 @@ export const generateTestAppWithGoogleWorkspace = (
   status: 'RUNNING',
   region: 'us-central1',
   ...overrides,
+});
+
+export const listAppToGetApp = (listApp: ListAppResponse): GetAppResponse => ({
+  ...listApp,
+  customEnvironmentVariables: {},
 });
 
 export const generateTestAppWithAzureWorkspace = (

--- a/src/analysis/modals/AppErrorModal.test.ts
+++ b/src/analysis/modals/AppErrorModal.test.ts
@@ -16,10 +16,9 @@ jest.mock('src/libs/notifications', () => ({
   notify: jest.fn(),
 }));
 
-type ModalMockExports = typeof import('src/components/Modal.mock');
 jest.mock('src/components/Modal', () => {
-  const mockModal = jest.requireActual<ModalMockExports>('src/components/Modal.mock');
-  return mockModal.mockModalModule();
+  const { mockModalModule } = jest.requireActual('src/components/Modal.mock');
+  return mockModalModule();
 });
 
 const getMockLeoAppProvider = (overrides?: Partial<LeoAppProvider>): LeoAppProvider => {

--- a/src/analysis/modals/AppErrorModal.test.ts
+++ b/src/analysis/modals/AppErrorModal.test.ts
@@ -1,7 +1,3 @@
-// displays error for app, and calls app provider
-// displays no error messages found if there is no returnnn from provider
-// ondismiss is called
-
 import { act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { h } from 'react-hyperscript-helpers';
@@ -12,8 +8,7 @@ import {
   listAppToGetApp,
 } from 'src/analysis/_testData/testData';
 import { AppErrorModal, AppErrorModalProps } from 'src/analysis/modals/AppErrorModal';
-import { LeoError } from 'src/libs/ajax/leonardo/models/core-models';
-import { AppBasics, LeoAppProvider } from 'src/libs/ajax/leonardo/providers/LeoAppProvider';
+import { LeoAppProvider } from 'src/libs/ajax/leonardo/providers/LeoAppProvider';
 import { asMockedFn, renderWithAppContexts as render } from 'src/testing/test-utils';
 import { defaultAzureWorkspace, defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
 
@@ -43,27 +38,30 @@ describe('AppErrorModal', () => {
   it.each([
     { app: generateTestAppWithAzureWorkspace({ errors: [appError] }, defaultAzureWorkspace) },
     { app: generateTestAppWithGoogleWorkspace({ errors: [appError] }, defaultGoogleWorkspace) },
-  ])('displays an error for an app and calls the app provider', async ({ app }) => {
-    // Arrange
-    const providerOverrides = { get: jest.fn(() => Promise.resolve(listAppToGetApp(app))) };
-    const appProvider = getMockLeoAppProvider(providerOverrides);
+  ])(
+    'displays an error for an app and calls the app provider for cloud: ($app.cloudContext.cloudProvider)',
+    async ({ app }) => {
+      // Arrange
+      const providerOverrides = { get: jest.fn(() => Promise.resolve(listAppToGetApp(app))) };
+      const appProvider = getMockLeoAppProvider(providerOverrides);
 
-    const props: AppErrorModalProps = {
-      appProvider,
-      onDismiss: jest.fn(),
-      app,
-    };
+      const props: AppErrorModalProps = {
+        appProvider,
+        onDismiss: jest.fn(),
+        app,
+      };
 
-    // Act
-    await act(async () => {
-      render(h(AppErrorModal, props));
-    });
+      // Act
+      await act(async () => {
+        render(h(AppErrorModal, props));
+      });
 
-    // Assert
-    screen.getByText(appError.errorMessage);
-    expect(appProvider.get).toHaveBeenCalledTimes(1);
-    expect(appProvider.get).toHaveBeenCalledWith(app);
-  });
+      // Assert
+      screen.getByText(appError.errorMessage);
+      expect(appProvider.get).toHaveBeenCalledTimes(1);
+      expect(appProvider.get).toHaveBeenCalledWith(app);
+    }
+  );
 
   it('calls on dismiss', async () => {
     // Arrange
@@ -88,5 +86,24 @@ describe('AppErrorModal', () => {
 
     // Assert
     expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('displays no error messages found if there is no return from provider', async () => {
+    const app = generateTestAppWithAzureWorkspace({ errors: [appError] }, defaultAzureWorkspace);
+    const appProvider = getMockLeoAppProvider();
+
+    const props: AppErrorModalProps = {
+      appProvider,
+      onDismiss: jest.fn(),
+      app,
+    };
+
+    // Act
+    await act(async () => {
+      render(h(AppErrorModal, props));
+    });
+
+    // Assert
+    screen.getByText('No error messages found for app.');
   });
 });

--- a/src/analysis/modals/AppErrorModal.test.ts
+++ b/src/analysis/modals/AppErrorModal.test.ts
@@ -16,11 +16,6 @@ jest.mock('src/libs/notifications', () => ({
   notify: jest.fn(),
 }));
 
-jest.mock('src/components/Modal', () => {
-  const { mockModalModule } = jest.requireActual('src/components/Modal.mock');
-  return mockModalModule();
-});
-
 const getMockLeoAppProvider = (overrides?: Partial<LeoAppProvider>): LeoAppProvider => {
   const defaultProvider: LeoAppProvider = {
     listWithoutProject: jest.fn(),

--- a/src/analysis/modals/AppErrorModal.test.ts
+++ b/src/analysis/modals/AppErrorModal.test.ts
@@ -1,0 +1,3 @@
+// displays error for app, and calls app provider
+// displays no error messages found if there is no returnnn from provider
+// ondismiss is called

--- a/src/analysis/modals/AppErrorModal.test.ts
+++ b/src/analysis/modals/AppErrorModal.test.ts
@@ -1,3 +1,92 @@
 // displays error for app, and calls app provider
 // displays no error messages found if there is no returnnn from provider
 // ondismiss is called
+
+import { act, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { h } from 'react-hyperscript-helpers';
+import {
+  appError,
+  generateTestAppWithAzureWorkspace,
+  generateTestAppWithGoogleWorkspace,
+  listAppToGetApp,
+} from 'src/analysis/_testData/testData';
+import { AppErrorModal, AppErrorModalProps } from 'src/analysis/modals/AppErrorModal';
+import { LeoError } from 'src/libs/ajax/leonardo/models/core-models';
+import { AppBasics, LeoAppProvider } from 'src/libs/ajax/leonardo/providers/LeoAppProvider';
+import { asMockedFn, renderWithAppContexts as render } from 'src/testing/test-utils';
+import { defaultAzureWorkspace, defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
+
+jest.mock('src/libs/notifications', () => ({
+  notify: jest.fn(),
+}));
+
+type ModalMockExports = typeof import('src/components/Modal.mock');
+jest.mock('src/components/Modal', () => {
+  const mockModal = jest.requireActual<ModalMockExports>('src/components/Modal.mock');
+  return mockModal.mockModalModule();
+});
+
+const getMockLeoAppProvider = (overrides?: Partial<LeoAppProvider>): LeoAppProvider => {
+  const defaultProvider: LeoAppProvider = {
+    listWithoutProject: jest.fn(),
+    pause: jest.fn(),
+    delete: jest.fn(),
+    get: jest.fn(),
+  };
+  asMockedFn(defaultProvider.listWithoutProject).mockResolvedValue([]);
+
+  return { ...defaultProvider, ...overrides };
+};
+
+describe('AppErrorModal', () => {
+  it.each([
+    { app: generateTestAppWithAzureWorkspace({ errors: [appError] }, defaultAzureWorkspace) },
+    { app: generateTestAppWithGoogleWorkspace({ errors: [appError] }, defaultGoogleWorkspace) },
+  ])('displays an error for an app and calls the app provider', async ({ app }) => {
+    // Arrange
+    const providerOverrides = { get: jest.fn(() => Promise.resolve(listAppToGetApp(app))) };
+    const appProvider = getMockLeoAppProvider(providerOverrides);
+
+    const props: AppErrorModalProps = {
+      appProvider,
+      onDismiss: jest.fn(),
+      app,
+    };
+
+    // Act
+    await act(async () => {
+      render(h(AppErrorModal, props));
+    });
+
+    // Assert
+    screen.getByText(appError.errorMessage);
+    expect(appProvider.get).toHaveBeenCalledTimes(1);
+    expect(appProvider.get).toHaveBeenCalledWith(app);
+  });
+
+  it('calls on dismiss', async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const app = generateTestAppWithAzureWorkspace({ errors: [appError] }, defaultAzureWorkspace);
+    const providerOverrides = { get: jest.fn(() => Promise.resolve(listAppToGetApp(app))) };
+    const appProvider = getMockLeoAppProvider(providerOverrides);
+    const onDismiss = jest.fn();
+
+    const props: AppErrorModalProps = {
+      appProvider,
+      onDismiss,
+      app,
+    };
+
+    // Act
+    await act(async () => {
+      render(h(AppErrorModal, props));
+    });
+    const okButton = screen.getByText('OK');
+    await user.click(okButton);
+
+    // Assert
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/analysis/modals/AppErrorModal.ts
+++ b/src/analysis/modals/AppErrorModal.ts
@@ -1,0 +1,61 @@
+import _ from 'lodash/fp';
+import { useState } from 'react';
+import { div, h } from 'react-hyperscript-helpers';
+import { spinnerOverlay } from 'src/components/common';
+import Modal from 'src/components/Modal';
+import { Ajax } from 'src/libs/ajax';
+import { ListAppResponse } from 'src/libs/ajax/leonardo/models/app-models';
+import { LeoAppProvider } from 'src/libs/ajax/leonardo/providers/LeoAppProvider';
+import colors from 'src/libs/colors';
+import { withErrorReporting } from 'src/libs/error';
+import { useOnMount } from 'src/libs/react-utils';
+import * as Utils from 'src/libs/utils';
+
+export interface AppErrorModalProps {
+  app: ListAppResponse;
+  onDismiss: () => void;
+  appProvider: Pick<LeoAppProvider, 'get'>;
+}
+
+export const AppErrorModal = (props: AppErrorModalProps) => {
+  const { app, onDismiss, appProvider } = props;
+  const [error, setError] = useState<string>();
+  const [loadingAppDetails, setLoadingAppDetails] = useState(false);
+
+  const loadAppError = _.flow(
+    withErrorReporting('Error loading app details'),
+    Utils.withBusyState(setLoadingAppDetails)
+  )(async () => {
+    const { errors: appErrors } = await appProvider.get(app);
+
+    setError(appErrors[0]?.errorMessage || 'No error messages found for app.');
+  });
+
+  useOnMount(() => {
+    loadAppError();
+  });
+
+  return h(
+    Modal,
+    {
+      title: `App of type '${app.appType}' is in error state`,
+      showCancel: false,
+      onDismiss,
+    },
+    [
+      div(
+        {
+          style: {
+            whiteSpace: 'pre-wrap',
+            overflowWrap: 'break-word',
+            overflowY: 'auto',
+            maxHeight: 500,
+            background: colors.light(),
+          },
+        },
+        [error]
+      ),
+      loadingAppDetails && spinnerOverlay,
+    ]
+  );
+};

--- a/src/analysis/modals/AppErrorModal.ts
+++ b/src/analysis/modals/AppErrorModal.ts
@@ -3,7 +3,6 @@ import { useState } from 'react';
 import { div, h } from 'react-hyperscript-helpers';
 import { spinnerOverlay } from 'src/components/common';
 import Modal from 'src/components/Modal';
-import { Ajax } from 'src/libs/ajax';
 import { ListAppResponse } from 'src/libs/ajax/leonardo/models/app-models';
 import { LeoAppProvider } from 'src/libs/ajax/leonardo/providers/LeoAppProvider';
 import colors from 'src/libs/colors';
@@ -26,10 +25,7 @@ export const AppErrorModal = (props: AppErrorModalProps) => {
     withErrorReporting('Error loading app details'),
     Utils.withBusyState(setLoadingAppDetails)
   )(async () => {
-    console.log('app', app)
     const appDetails = await appProvider.get(app);
-    console.log(appDetails)
-
     setError(appDetails?.errors[0]?.errorMessage || 'No error messages found for app.');
   });
 

--- a/src/analysis/modals/AppErrorModal.ts
+++ b/src/analysis/modals/AppErrorModal.ts
@@ -26,9 +26,11 @@ export const AppErrorModal = (props: AppErrorModalProps) => {
     withErrorReporting('Error loading app details'),
     Utils.withBusyState(setLoadingAppDetails)
   )(async () => {
-    const { errors: appErrors } = await appProvider.get(app);
+    console.log('app', app)
+    const appDetails = await appProvider.get(app);
+    console.log(appDetails)
 
-    setError(appErrors[0]?.errorMessage || 'No error messages found for app.');
+    setError(appDetails?.errors[0]?.errorMessage || 'No error messages found for app.');
   });
 
   useOnMount(() => {

--- a/src/analysis/modals/AppErrorModal.ts
+++ b/src/analysis/modals/AppErrorModal.ts
@@ -36,7 +36,7 @@ export const AppErrorModal = (props: AppErrorModalProps) => {
   return h(
     Modal,
     {
-      title: `App of type '${app.appType}' is in error state`,
+      title: `Your '${app.appType}' app has an error`,
       showCancel: false,
       onDismiss,
     },

--- a/src/analysis/modals/CloudEnvironmentModal.ts
+++ b/src/analysis/modals/CloudEnvironmentModal.ts
@@ -8,9 +8,10 @@ import { CromwellModalBase } from 'src/analysis/modals/CromwellModal';
 import { GalaxyModalBase } from 'src/analysis/modals/GalaxyModal';
 import { HailBatchModal } from 'src/analysis/modals/HailBatchModal';
 import { appLauncherTabName, PeriodicAzureCookieSetter } from 'src/analysis/runtime-common-components';
-import { AppErrorModal, RuntimeErrorModal } from 'src/analysis/RuntimeManager';
+import { RuntimeErrorModal } from 'src/analysis/RuntimeManager';
 import { doesWorkspaceSupportCromwellAppForUser, getCurrentApp, getIsAppBusy } from 'src/analysis/utils/app-utils';
 import { getCostDisplayForDisk, getCostDisplayForTool } from 'src/analysis/utils/cost-utils';
+import { leoAppProvider } from 'src/libs/ajax/leonardo/providers/LeoAppProvider';
 import {
   getCurrentPersistentDisk,
   getReadyPersistentDisk,
@@ -43,7 +44,7 @@ import hailLogo from 'src/images/hail-logo.svg';
 import jupyterLogo from 'src/images/jupyter-logo-long.png';
 import rstudioBioLogo from 'src/images/r-bio-logo.svg';
 import { Apps } from 'src/libs/ajax/leonardo/Apps';
-import { App, appStatuses, LeoAppStatus } from 'src/libs/ajax/leonardo/models/app-models';
+import {App, appStatuses, LeoAppStatus, ListAppResponse} from 'src/libs/ajax/leonardo/models/app-models';
 import { PersistentDisk } from 'src/libs/ajax/leonardo/models/disk-models';
 import { LeoRuntimeStatus, Runtime, runtimeStatuses } from 'src/libs/ajax/leonardo/models/runtime-models';
 import { Runtimes } from 'src/libs/ajax/leonardo/Runtimes';
@@ -62,6 +63,7 @@ import {
   getCloudProviderFromWorkspace,
 } from 'src/libs/workspace-utils';
 import { cromwellLinkProps, getCromwellUnsupportedMessage } from 'src/workflows-app/utils/app-utils';
+import {AppErrorModal} from "src/analysis/modals/AppErrorModal";
 
 const titleId = 'cloud-env-modal';
 
@@ -87,7 +89,7 @@ export const CloudEnvironmentModal = ({
   onDismiss: () => void;
   canCompute: boolean;
   runtimes: Runtime[];
-  apps: App[];
+  apps: ListAppResponse[];
   appDataDisks: PersistentDisk[];
   refreshRuntimes: () => Promise<void>;
   refreshApps: () => Promise<void>;
@@ -634,6 +636,7 @@ export const CloudEnvironmentModal = ({
     [Utils.DEFAULT, () => 430]
   );
 
+  const errorApp: ListAppResponse | undefined = _.find({ appName: errorAppId }, apps);
   const modalBody = h(Fragment, [
     h(TitleBar, {
       id: titleId,
@@ -646,9 +649,11 @@ export const CloudEnvironmentModal = ({
     viewMode !== undefined && hr({ style: { borderTop: '1px solid', width: '100%', color: colors.accent() } }),
     getView(),
     errorAppId &&
+      errorApp &&
       h(AppErrorModal, {
-        app: _.find({ appName: errorAppId }, apps),
+        app: errorApp,
         onDismiss: () => setErrorAppId(undefined),
+        appProvider: leoAppProvider,
       }),
     errorRuntimeId &&
       h(RuntimeErrorModal, {

--- a/src/analysis/modals/CloudEnvironmentModal.ts
+++ b/src/analysis/modals/CloudEnvironmentModal.ts
@@ -2,6 +2,7 @@ import { IconId } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { Fragment, ReactElement, useState } from 'react';
 import { Component, div, h, hr, img, span } from 'react-hyperscript-helpers';
+import { AppErrorModal } from 'src/analysis/modals/AppErrorModal';
 import { AzureComputeModalBase } from 'src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeModal';
 import { GcpComputeModalBase } from 'src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal';
 import { CromwellModalBase } from 'src/analysis/modals/CromwellModal';
@@ -11,7 +12,6 @@ import { appLauncherTabName, PeriodicAzureCookieSetter } from 'src/analysis/runt
 import { RuntimeErrorModal } from 'src/analysis/RuntimeManager';
 import { doesWorkspaceSupportCromwellAppForUser, getCurrentApp, getIsAppBusy } from 'src/analysis/utils/app-utils';
 import { getCostDisplayForDisk, getCostDisplayForTool } from 'src/analysis/utils/cost-utils';
-import { leoAppProvider } from 'src/libs/ajax/leonardo/providers/LeoAppProvider';
 import {
   getCurrentPersistentDisk,
   getReadyPersistentDisk,
@@ -44,9 +44,10 @@ import hailLogo from 'src/images/hail-logo.svg';
 import jupyterLogo from 'src/images/jupyter-logo-long.png';
 import rstudioBioLogo from 'src/images/r-bio-logo.svg';
 import { Apps } from 'src/libs/ajax/leonardo/Apps';
-import {App, appStatuses, LeoAppStatus, ListAppResponse} from 'src/libs/ajax/leonardo/models/app-models';
+import { appStatuses, LeoAppStatus, ListAppResponse } from 'src/libs/ajax/leonardo/models/app-models';
 import { PersistentDisk } from 'src/libs/ajax/leonardo/models/disk-models';
 import { LeoRuntimeStatus, Runtime, runtimeStatuses } from 'src/libs/ajax/leonardo/models/runtime-models';
+import { leoAppProvider } from 'src/libs/ajax/leonardo/providers/LeoAppProvider';
 import { Runtimes } from 'src/libs/ajax/leonardo/Runtimes';
 import { Metrics } from 'src/libs/ajax/Metrics';
 import colors from 'src/libs/colors';
@@ -63,7 +64,6 @@ import {
   getCloudProviderFromWorkspace,
 } from 'src/libs/workspace-utils';
 import { cromwellLinkProps, getCromwellUnsupportedMessage } from 'src/workflows-app/utils/app-utils';
-import {AppErrorModal} from "src/analysis/modals/AppErrorModal";
 
 const titleId = 'cloud-env-modal';
 

--- a/src/analysis/modals/CloudEnvironmentModal.ts
+++ b/src/analysis/modals/CloudEnvironmentModal.ts
@@ -648,8 +648,7 @@ export const CloudEnvironmentModal = ({
     }),
     viewMode !== undefined && hr({ style: { borderTop: '1px solid', width: '100%', color: colors.accent() } }),
     getView(),
-    errorAppId &&
-      errorApp &&
+    errorApp &&
       h(AppErrorModal, {
         app: errorApp,
         onDismiss: () => setErrorAppId(undefined),

--- a/src/analysis/modals/CromwellModal.test.ts
+++ b/src/analysis/modals/CromwellModal.test.ts
@@ -19,6 +19,7 @@ const defaultAjaxImpl = {
   listAppsV2: jest.fn(),
   createAppV2: jest.fn(),
   deleteAppV2: jest.fn(),
+  getAppV2: jest.fn(),
 };
 
 const defaultCromwellProps = {

--- a/src/analysis/modals/HailBatchModal.test.ts
+++ b/src/analysis/modals/HailBatchModal.test.ts
@@ -26,6 +26,7 @@ const defaultAjaxImpl = {
   listAppsV2: jest.fn(),
   createAppV2: jest.fn(),
   deleteAppV2: jest.fn(),
+  getAppV2: jest.fn(),
 };
 
 jest.mock('src/libs/ajax');

--- a/src/libs/ajax/leonardo/Apps.ts
+++ b/src/libs/ajax/leonardo/Apps.ts
@@ -111,6 +111,13 @@ export const Apps = (signal: AbortSignal) => ({
       _.mergeAll([authOpts(), appIdentifier, { signal, method: 'DELETE' }])
     );
   },
+  getAppV2: (appName: string, workspaceId: string): Promise<GetAppResponse> => {
+    const res = fetchLeo(
+      `api/apps/v2/${workspaceId}/${appName}`,
+      _.mergeAll([authOpts(), appIdentifier, { signal, method: 'GET' }])
+    );
+    return res.json();
+  },
 });
 
 export type AppsAjaxContract = ReturnType<typeof Apps>;

--- a/src/libs/ajax/leonardo/Apps.ts
+++ b/src/libs/ajax/leonardo/Apps.ts
@@ -111,8 +111,8 @@ export const Apps = (signal: AbortSignal) => ({
       _.mergeAll([authOpts(), appIdentifier, { signal, method: 'DELETE' }])
     );
   },
-  getAppV2: (appName: string, workspaceId: string): Promise<GetAppResponse> => {
-    const res = fetchLeo(
+  getAppV2: async (appName: string, workspaceId: string): Promise<GetAppResponse> => {
+    const res = await fetchLeo(
       `api/apps/v2/${workspaceId}/${appName}`,
       _.mergeAll([authOpts(), appIdentifier, { signal, method: 'GET' }])
     );

--- a/src/libs/ajax/leonardo/models/app-models.ts
+++ b/src/libs/ajax/leonardo/models/app-models.ts
@@ -10,8 +10,8 @@ export interface KubernetesRuntimeConfig {
 export interface AppError extends LeoError {
   action: string;
   source: string;
-  googleErrorCode?: number;
-  traceId?: string;
+  googleErrorCode: number | null;
+  traceId: string | null;
 }
 
 export type LeoAppStatus =

--- a/src/libs/ajax/leonardo/models/runtime-models.ts
+++ b/src/libs/ajax/leonardo/models/runtime-models.ts
@@ -50,6 +50,7 @@ export type RuntimeLabels = Omit<LeoResourceLabels, 'tool'> & {
 };
 
 export interface RuntimeError extends LeoError {
+
   errorCode: number;
 }
 

--- a/src/libs/ajax/leonardo/models/runtime-models.ts
+++ b/src/libs/ajax/leonardo/models/runtime-models.ts
@@ -50,7 +50,6 @@ export type RuntimeLabels = Omit<LeoResourceLabels, 'tool'> & {
 };
 
 export interface RuntimeError extends LeoError {
-
   errorCode: number;
 }
 

--- a/src/libs/ajax/leonardo/providers/LeoAppProvider.test.ts
+++ b/src/libs/ajax/leonardo/providers/LeoAppProvider.test.ts
@@ -1,14 +1,15 @@
 import { Ajax } from 'src/libs/ajax';
 import { AppAjaxContract, AppsAjaxContract } from 'src/libs/ajax/leonardo/Apps';
 import { asMockedFn } from 'src/testing/test-utils';
+import { defaultAzureWorkspace } from 'src/testing/workspace-fixtures';
 
 import { AppBasics, leoAppProvider } from './LeoAppProvider';
 
 jest.mock('src/libs/ajax');
 
 type AjaxContract = ReturnType<typeof Ajax>;
-type AppNeeds = Pick<AppAjaxContract, 'delete' | 'pause'>;
-type AppsNeeds = Pick<AppsAjaxContract, 'app' | 'listWithoutProject'>;
+type AppNeeds = Pick<AppAjaxContract, 'delete' | 'pause' | 'details'>;
+type AppsNeeds = Pick<AppsAjaxContract, 'app' | 'listWithoutProject' | 'deleteAppV2' | 'getAppV2'>;
 
 interface AjaxMockNeeds {
   Apps: AppsNeeds;
@@ -16,7 +17,7 @@ interface AjaxMockNeeds {
 }
 /**
  * local test utility - mocks the Ajax super-object and the subset of needed multi-contracts it
- * returns with as much type-saftely as possible.
+ * returns with as much type-safely as possible.
  *
  * @return collection of key contract sub-objects for easy
  * mock overrides and/or method spying/assertions
@@ -25,12 +26,15 @@ const mockAjaxNeeds = (): AjaxMockNeeds => {
   const partialApp: AppNeeds = {
     delete: jest.fn(),
     pause: jest.fn(),
+    details: jest.fn(),
   };
   const mockApp = partialApp as AppAjaxContract;
 
   const partialApps: AppsNeeds = {
     app: jest.fn(),
     listWithoutProject: jest.fn(),
+    deleteAppV2: jest.fn(),
+    getAppV2: jest.fn(),
   };
   const mockApps = partialApps as AppsAjaxContract;
 
@@ -43,88 +47,218 @@ const mockAjaxNeeds = (): AjaxMockNeeds => {
   };
 };
 describe('leoAppProvider', () => {
-  it('handles list call', async () => {
-    // Arrange
-    const ajaxMock = mockAjaxNeeds();
-    asMockedFn(ajaxMock.Apps.listWithoutProject).mockResolvedValue([]);
-    const signal = new window.AbortController().signal;
+  describe('GCP', () => {
+    it('handles list call', async () => {
+      // Arrange
+      const ajaxMock = mockAjaxNeeds();
+      asMockedFn(ajaxMock.Apps.listWithoutProject).mockResolvedValue([]);
+      const signal = new window.AbortController().signal;
 
-    // Act
-    const result = await leoAppProvider.listWithoutProject({ arg: '1' }, { signal });
+      // Act
+      const result = await leoAppProvider.listWithoutProject({ arg: '1' }, { signal });
 
-    // Assert;
-    expect(Ajax).toBeCalledTimes(1);
-    expect(Ajax).toBeCalledWith(signal);
-    expect(ajaxMock.Apps.listWithoutProject).toBeCalledTimes(1);
-    expect(ajaxMock.Apps.listWithoutProject).toBeCalledWith({ arg: '1' });
-    expect(result).toEqual([]);
+      // Assert;
+      expect(Ajax).toBeCalledTimes(1);
+      expect(Ajax).toBeCalledWith(signal);
+      expect(ajaxMock.Apps.listWithoutProject).toBeCalledTimes(1);
+      expect(ajaxMock.Apps.listWithoutProject).toBeCalledWith({ arg: '1' });
+      expect(result).toEqual([]);
+    });
+
+    it('handles pause app call', async () => {
+      // Arrange
+      const ajaxMock = mockAjaxNeeds();
+      const abort = new window.AbortController();
+      const app: AppBasics = {
+        appName: 'myAppName',
+        cloudContext: {
+          cloudProvider: 'GCP',
+          cloudResource: 'myGoogleProject',
+        },
+        workspaceId: null,
+      };
+
+      // Act
+      // calls to this method generally don't care about passing in signal, but doing it here for completeness
+      void (await leoAppProvider.pause(app, { signal: abort.signal }));
+
+      // Assert;
+      expect(Ajax).toBeCalledTimes(1);
+      expect(Ajax).toBeCalledWith(abort.signal);
+      expect(ajaxMock.Apps.app).toBeCalledTimes(1);
+      expect(ajaxMock.Apps.app).toBeCalledWith('myGoogleProject', 'myAppName');
+      expect(ajaxMock.app.pause).toBeCalledTimes(1);
+    });
+
+    it('handles delete app call', async () => {
+      // Arrange
+      const ajaxMock = mockAjaxNeeds();
+      const abort = new window.AbortController();
+      const app: AppBasics = {
+        appName: 'myAppName',
+        cloudContext: {
+          cloudProvider: 'GCP',
+          cloudResource: 'myGoogleProject',
+        },
+        workspaceId: null,
+      };
+
+      // Act
+      // calls to this method generally don't care about passing in signal, but doing it here for completeness
+      void (await leoAppProvider.delete(app, { signal: abort.signal }));
+
+      // Assert;
+      expect(Ajax).toBeCalledTimes(1);
+      expect(Ajax).toBeCalledWith(abort.signal);
+      expect(ajaxMock.Apps.app).toBeCalledTimes(1);
+      expect(ajaxMock.Apps.app).toBeCalledWith('myGoogleProject', 'myAppName');
+      expect(ajaxMock.app.delete).toBeCalledTimes(1);
+      expect(ajaxMock.app.delete).toBeCalledWith(false);
+    });
+
+    it('handles get app call', async () => {
+      // Arrange
+      const ajaxMock = mockAjaxNeeds();
+      const abort = new window.AbortController();
+      const app: AppBasics = {
+        appName: 'myAppName',
+        cloudContext: {
+          cloudProvider: 'GCP',
+          cloudResource: 'myGoogleProject',
+        },
+        workspaceId: null,
+      };
+
+      // Act
+      // calls to this method generally don't care about passing in signal, but doing it here for completeness
+      void (await leoAppProvider.get(app, { signal: abort.signal }));
+
+      // Assert;
+      expect(Ajax).toBeCalledTimes(1);
+      expect(Ajax).toBeCalledWith(abort.signal);
+      expect(ajaxMock.Apps.app).toBeCalledTimes(1);
+      expect(ajaxMock.Apps.app).toBeCalledWith('myGoogleProject', 'myAppName');
+      expect(ajaxMock.app.details).toBeCalledTimes(1);
+    });
   });
 
-  it('handles pause app call', async () => {
-    // Arrange
-    const ajaxMock = mockAjaxNeeds();
-    const abort = new window.AbortController();
-    const app: AppBasics = {
-      appName: 'myAppName',
-      cloudContext: {
-        cloudProvider: 'GCP',
-        cloudResource: 'myGoogleProject',
-      },
-    };
+  describe('Azure', () => {
+    it('does not support pause app call', async () => {
+      const abort = new window.AbortController();
+      const app: AppBasics = {
+        appName: 'myAppName',
+        cloudContext: {
+          cloudProvider: 'AZURE',
+          cloudResource: 'myAzureResource',
+        },
+        workspaceId: defaultAzureWorkspace.workspace.workspaceId,
+      };
 
-    // Act
-    // calls to this method generally don't care about passing in signal, but doing it here for completeness
-    void (await leoAppProvider.pause(app, { signal: abort.signal }));
+      // Act
+      // calls to this method generally don't care about passing in signal, but doing it here for completeness
+      const shouldThrow = async () => {
+        await leoAppProvider.pause(app, { signal: abort.signal });
+      };
 
-    // Assert;
-    expect(Ajax).toBeCalledTimes(1);
-    expect(Ajax).toBeCalledWith(abort.signal);
-    expect(ajaxMock.Apps.app).toBeCalledTimes(1);
-    expect(ajaxMock.Apps.app).toBeCalledWith('myGoogleProject', 'myAppName');
-    expect(ajaxMock.app.pause).toBeCalledTimes(1);
-  });
+      // Assert
+      await expect(shouldThrow()).rejects.toEqual(new Error('Pausing apps is not supported for azure'));
+      expect(Ajax).toBeCalledTimes(0);
+    });
 
-  it('handles delete app call - GCP', async () => {
-    // Arrange
-    const ajaxMock = mockAjaxNeeds();
-    const abort = new window.AbortController();
-    const app: AppBasics = {
-      appName: 'myAppName',
-      cloudContext: {
-        cloudProvider: 'GCP',
-        cloudResource: 'myGoogleProject',
-      },
-    };
+    it('handles delete app call', async () => {
+      // Arrange
+      const ajaxMock = mockAjaxNeeds();
+      const abort = new window.AbortController();
+      const app: AppBasics = {
+        appName: 'myAppName',
+        cloudContext: {
+          cloudProvider: 'AZURE',
+          cloudResource: 'myAzureResource',
+        },
+        workspaceId: defaultAzureWorkspace.workspace.workspaceId,
+      };
 
-    // Act
-    // calls to this method generally don't care about passing in signal, but doing it here for completeness
-    void (await leoAppProvider.delete(app, { signal: abort.signal }));
+      // Act
+      void (await leoAppProvider.delete(app, { signal: abort.signal }));
 
-    // Assert;
-    expect(Ajax).toBeCalledTimes(1);
-    expect(Ajax).toBeCalledWith(abort.signal);
-    expect(ajaxMock.Apps.app).toBeCalledTimes(1);
-    expect(ajaxMock.Apps.app).toBeCalledWith('myGoogleProject', 'myAppName');
-    expect(ajaxMock.app.delete).toBeCalledTimes(1);
-    expect(ajaxMock.app.delete).toBeCalledWith(false);
-  });
-  it('handles delete app call - Azure', async () => {
-    // Arrange
-    const app: AppBasics = {
-      appName: 'myAppName',
-      cloudContext: {
-        cloudProvider: 'AZURE',
-        cloudResource: 'myAzureResource',
-      },
-    };
+      // Assert;
+      expect(Ajax).toBeCalledTimes(1);
+      expect(Ajax).toBeCalledWith(abort.signal);
+      expect(ajaxMock.Apps.deleteAppV2).toBeCalledTimes(1);
+      expect(ajaxMock.Apps.deleteAppV2).toBeCalledWith(app.appName, app.workspaceId);
+    });
 
-    // Act (called from assert because expecting throw
-    const shouldThrow = async () => {
-      await leoAppProvider.delete(app);
-    };
+    it('handles delete app error with no workspace', async () => {
+      // Arrange
+      const app: AppBasics = {
+        appName: 'myAppName',
+        cloudContext: {
+          cloudProvider: 'AZURE',
+          cloudResource: 'myAzureResource',
+        },
+        workspaceId: null,
+      };
 
-    // Assert;
-    await expect(shouldThrow()).rejects.toEqual(new Error('Deleting apps is currently only supported on GCP'));
-    expect(Ajax).toBeCalledTimes(0);
+      // Act (called from assert because expecting throw
+      const shouldThrow = async () => {
+        await leoAppProvider.delete(app);
+      };
+
+      // Assert;
+      await expect(shouldThrow()).rejects.toEqual(
+        new Error(
+          `Deleting apps is currently only supported for azure or google apps. Azure apps must have a workspace id. App: ${app.appName} workspaceId: null`
+        )
+      );
+      expect(Ajax).toBeCalledTimes(0);
+    });
+
+    it('handles get app call', async () => {
+      // Arrange
+      const ajaxMock = mockAjaxNeeds();
+      const abort = new window.AbortController();
+      const app: AppBasics = {
+        appName: 'myAppName',
+        cloudContext: {
+          cloudProvider: 'AZURE',
+          cloudResource: 'myAzureResource',
+        },
+        workspaceId: defaultAzureWorkspace.workspace.workspaceId,
+      };
+
+      // Act
+      void (await leoAppProvider.get(app, { signal: abort.signal }));
+
+      // Assert;
+      expect(Ajax).toBeCalledTimes(1);
+      expect(Ajax).toBeCalledWith(abort.signal);
+      expect(ajaxMock.Apps.getAppV2).toBeCalledTimes(1);
+      expect(ajaxMock.Apps.getAppV2).toBeCalledWith(app.appName, app.workspaceId);
+    });
+
+    it('handles get app error with no workspace', async () => {
+      // Arrange
+      const app: AppBasics = {
+        appName: 'myAppName',
+        cloudContext: {
+          cloudProvider: 'AZURE',
+          cloudResource: 'myAzureResource',
+        },
+        workspaceId: null,
+      };
+
+      // Act (called from assert because expecting throw
+      const shouldThrow = async () => {
+        await leoAppProvider.get(app);
+      };
+
+      // Assert;
+      await expect(shouldThrow()).rejects.toEqual(
+        new Error(
+          `Getting apps is currently only supported for azure or google apps. Azure apps must have a workspace id. App: ${app.appName} workspaceId: null`
+        )
+      );
+      expect(Ajax).toBeCalledTimes(0);
+    });
   });
 });

--- a/src/libs/ajax/leonardo/providers/LeoAppProvider.test.ts
+++ b/src/libs/ajax/leonardo/providers/LeoAppProvider.test.ts
@@ -17,7 +17,7 @@ interface AjaxMockNeeds {
 }
 /**
  * local test utility - mocks the Ajax super-object and the subset of needed multi-contracts it
- * returns with as much type-safely as possible.
+ * returns with as much type-safety as possible.
  *
  * @return collection of key contract sub-objects for easy
  * mock overrides and/or method spying/assertions

--- a/src/libs/ajax/leonardo/providers/LeoAppProvider.ts
+++ b/src/libs/ajax/leonardo/providers/LeoAppProvider.ts
@@ -1,9 +1,10 @@
+import { AppWithWorkspace } from 'src/analysis/Environments/Environments.models';
 import { Ajax } from 'src/libs/ajax';
 import { AbortOption } from 'src/libs/ajax/data-provider-common';
-import { App, ListAppResponse } from 'src/libs/ajax/leonardo/models/app-models';
+import { GetAppResponse, ListAppResponse } from 'src/libs/ajax/leonardo/models/app-models';
 
-export type AppBasics = Pick<App, 'appName'> & {
-  cloudContext: Pick<App['cloudContext'], 'cloudProvider' | 'cloudResource'>;
+export type AppBasics = Pick<ListAppResponse, 'appName' | 'workspaceId'> & {
+  cloudContext: Pick<AppWithWorkspace['cloudContext'], 'cloudProvider' | 'cloudResource'>;
 };
 
 export type DeleteAppOptions = AbortOption & {
@@ -14,6 +15,7 @@ export interface LeoAppProvider {
   listWithoutProject: (listArgs: Record<string, string>, options?: AbortOption) => Promise<ListAppResponse[]>;
   delete: (app: AppBasics, options?: DeleteAppOptions) => Promise<void>;
   pause: (app: AppBasics, options?: AbortOption) => Promise<void>;
+  get: (app: AppBasics, options?: AbortOption) => Promise<GetAppResponse>;
 }
 
 export const leoAppProvider: LeoAppProvider = {
@@ -26,16 +28,41 @@ export const leoAppProvider: LeoAppProvider = {
     const { cloudProvider, cloudResource } = app.cloudContext;
     const { deleteDisk, signal } = options;
 
+    const { appName, workspaceId } = app;
     if (cloudProvider === 'GCP') {
-      const { appName } = app;
       return Ajax(signal).Apps.app(cloudResource, appName).delete(!!deleteDisk);
     }
-    throw new Error('Deleting apps is currently only supported on GCP');
+    if (cloudProvider === 'AZURE' && !!workspaceId) {
+      return Ajax(signal).Apps.deleteAppV2(appName, workspaceId);
+    }
+    throw new Error(
+      `Deleting apps is currently only supported for azure or google apps. Azure apps must have a workspace id. App: ${app.appName} workspaceId: ${workspaceId}`
+    );
   },
   pause: (app: AppBasics, options: AbortOption = {}): Promise<void> => {
-    const { cloudResource } = app.cloudContext;
+    const { cloudResource, cloudProvider } = app.cloudContext;
     const { signal } = options;
 
+    if (cloudProvider === 'AZURE') {
+      throw new Error('Pausing apps is not supported for azure');
+    }
+
     return Ajax(signal).Apps.app(cloudResource, app.appName).pause();
+  },
+  get: (app: AppBasics, options: AbortOption = {}): Promise<GetAppResponse> => {
+    const { cloudResource, cloudProvider } = app.cloudContext;
+    const { signal } = options;
+    const { workspaceId } = app;
+
+    if (cloudProvider === 'GCP') {
+      return Ajax(signal).Apps.app(cloudResource, app.appName).details();
+    }
+    if (cloudProvider === 'AZURE' && !!workspaceId) {
+      return Ajax(signal).Apps.getAppV2(app.appName, workspaceId);
+    }
+
+    throw new Error(
+      `Getting apps is currently only supported for azure or google apps. Azure apps must have a workspace id. App: ${app.appName} workspaceId: ${workspaceId}`
+    );
   },
 };


### PR DESCRIPTION
The bug was around the error message for Cromwell apps on Azure showing 'Galaxy' in the error message. However, the bug was a bit more involved than a wording change. We do not have any API code around `GET` for a specific V2 app in leo. As a result, this PR adds:

- The api code for v2 get apps
- The provider code around this endpoint
- unit tests for provider code
- makes several changes around AppErrorModal to support v2 apps
    -  moves it from the RuntimeManager to a typescript file of its own
    - adds unit tests
    - leverages the the provider above

Note that RuntimeManager is extremely poorly named, and should really be called something like `LeoNotificationManager`. I plan to rename this along with a few other things a follow-up PR to not add noise here.

To test, I created a cromwell app in an azure workspace and a galaxy app in a GCP workspace, then modified both records in the dev database to have `Error` status and an corresponding row in the `APP_ERROR` table. Here is what it looks like: 
![image](https://github.com/DataBiosphere/terra-ui/assets/6465084/372389f1-9233-4369-bb4f-da4e30f7e28e)
