### PR TITLE
WOR-1321 - Disable WorkspaceContainer polling

### DIFF
--- a/src/pages/workspaces/workspace/WorkspaceContainer.test.ts
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.test.ts
@@ -123,7 +123,7 @@ describe('WorkspaceContainer', () => {
     expect(screen.queryByRole('alert')).toBeNull();
   });
 
-  it('polls for a workspace in the process of deleting and redirects when deleted', async () => {
+  xit('polls for a workspace in the process of deleting and redirects when deleted', async () => {
     // Arrange
     const pollResponse: Response = new Response(null, { status: 404 });
     const silentlyRefreshWorkspace = jest.fn().mockImplementation((errorHandling?: ErrorCallback) => {
@@ -172,7 +172,7 @@ describe('WorkspaceContainer', () => {
     await waitFor(() => expect(goToPath).toBeCalledWith('workspaces'));
   });
 
-  it('continues polling when a workspace has not been deleted', async () => {
+  xit('continues polling when a workspace has not been deleted', async () => {
     // Arrange
     const silentlyRefreshWorkspace = jest.fn().mockImplementation(() => Promise.resolve());
     const workspace: InitializedWorkspaceWrapper = {

--- a/src/pages/workspaces/workspace/WorkspaceContainer.ts
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.ts
@@ -134,7 +134,15 @@ export const WorkspaceContainer = (props: WorkspaceContainerProps) => {
     }
   };
   // poll workspace state every 30 seconds
-  usePollingEffect(() => silentlyRefreshWorkspace(handleWorkspaceError), { ms: 30000, leading: false });
+  usePollingEffect(
+    () => {
+      if (workspace?.workspace?.state === 'Deleting') {
+        return silentlyRefreshWorkspace(handleWorkspaceError);
+      }
+      return Promise.resolve();
+    },
+    { ms: 30000, leading: false }
+  );
 
   return h(FooterWrapper, [
     h(TopBar, { title: 'Workspaces', href: Nav.getLink('workspaces') }, [

--- a/src/pages/workspaces/workspace/WorkspaceContainer.ts
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.ts
@@ -20,7 +20,7 @@ import { isTerra } from 'src/libs/brand-utils';
 import colors from 'src/libs/colors';
 import { ErrorCallback, withErrorIgnoring, withErrorReporting } from 'src/libs/error';
 import * as Nav from 'src/libs/nav';
-import { useCancellation, useOnMount, usePollingEffect, withDisplayName } from 'src/libs/react-utils';
+import { useCancellation, useOnMount, withDisplayName } from 'src/libs/react-utils';
 import { getTerraUser } from 'src/libs/state';
 import * as Style from 'src/libs/style';
 import * as Utils from 'src/libs/utils';
@@ -114,7 +114,6 @@ export const WorkspaceContainer = (props: WorkspaceContainerProps) => {
     refresh,
     workspace,
     refreshWorkspace,
-    silentlyRefreshWorkspace,
     children,
   } = props;
   const [deletingWorkspace, setDeletingWorkspace] = useState(false);
@@ -128,22 +127,29 @@ export const WorkspaceContainer = (props: WorkspaceContainerProps) => {
 
   // when the workspace refresh polling gets back an error for a workspace that is deleting
   // redirect to list view
+  /*
   const handleWorkspaceError = (error: unknown) => {
     if (error instanceof Response && error.status === 404) {
       Nav.goToPath('workspaces');
     }
   };
+  */
   // poll workspace state every 30 seconds
+  /*
+  this is temporarily disabled to avoid swamping sam with API calls
+  for some reason the conditional works in unit tests but not real runs, 
+  and it's better to completely disable it rather than push out something that's broken for an unknown reason
   usePollingEffect(
-    () => {
-      if (workspace?.workspace?.state === 'Deleting') {
+    (): Promise<void> => {
+      if (workspaceLoaded && workspace.workspace.state === 'Deleting') {
         return silentlyRefreshWorkspace(handleWorkspaceError);
+      } else {
+        return Promise.resolve();
       }
-      return Promise.resolve();
     },
     { ms: 30000, leading: false }
   );
-
+  */
   return h(FooterWrapper, [
     h(TopBar, { title: 'Workspaces', href: Nav.getLink('workspaces') }, [
       div({ style: Style.breadcrumb.breadcrumb }, [


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WOR-1321

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
Only poll to refresh the dashboard if the workspace is in a deleting state.

Refreshing the workspace was causing the calls to get the apps and runtimes to re-fire, creating a lot of excess API calls.
This PR causes them to go from every 30 seconds, back to their original frequency of every 2 minutes.
