### PR TITLE
[AJ-1418] Fix import using template workspace

### DIFF
--- a/src/import-data/ImportDataDestination.ts
+++ b/src/import-data/ImportDataDestination.ts
@@ -130,6 +130,9 @@ export const ImportDataDestination = (props: ImportDataDestinationProps): ReactN
     // That information needs to be fetched here.
     'accessLevel',
     'policies',
+    // When using a template workspace, the NewWorkspaceModal reads the description attribute
+    // from the template.
+    'workspace.attributes',
     'workspace.authorizationDomain',
     'workspace.bucketName',
     'workspace.cloudPlatform',


### PR DESCRIPTION
Importing data using a template workspace involves cloning the selected template workspace.

https://github.com/DataBiosphere/terra-ui/blob/45b27a32abcf2f4ddf6b709fbdaa4f0bbbcae3a7/src/import-data/ImportDataDestination.ts#L347-L362

The NewWorkspaceModal initializes the description field using the template workspace's description attribute.
https://github.com/DataBiosphere/terra-ui/blob/45b27a32abcf2f4ddf6b709fbdaa4f0bbbcae3a7/src/components/NewWorkspaceModal.js#L84

However... since #4327, we're not loading workspace attributes, so attempting to import using a template workspace results in an error "Cannot read properties of undefined (reading 'description')" because the workspace attributes are undefined.

To fix that, this includes attributes in the workspace fields loaded.

To test...

Modify the loaded template workspaces so that one of your workspaces is in the list of "Terra" templates.
https://github.com/DataBiosphere/terra-ui/blob/45b27a32abcf2f4ddf6b709fbdaa4f0bbbcae3a7/src/import-data/ImportData.ts#L57-L58

```js
const templates = await Ajax().FirecloudBucket.getTemplateWorkspaces();
templates.Terra[0].namespace = '<billing project>';
templates.Terra[0].name = '<workspace name>';
setTemplateWorkspaces(templates);
```

Navigate to `http://localhost:3000/#import-data?url=https://example.com/path/to/file.pfb&format=pfb&template=Terra`, select "Start with a template", and click "Import".