### PR TITLE
[UIE-142] Update app version properties in metric events

### DIFF
--- a/src/libs/ajax/Metrics.ts
+++ b/src/libs/ajax/Metrics.ts
@@ -34,7 +34,7 @@ export const Metrics = (signal?: AbortSignal) => {
         appId: 'Saturn',
         hostname: window.location.hostname,
         appPath: Nav.getCurrentRoute().name,
-        appVersion: `https://github.com/DataBiosphere/terra-ui/commits/${getConfig().gitRevision}`,
+        appVersion: getConfig().gitRevision,
         appVersionBuildTime: new Date(getConfig().buildTimestamp).toISOString(),
         ...getDefaultProperties(),
       },

--- a/src/libs/ajax/Metrics.ts
+++ b/src/libs/ajax/Metrics.ts
@@ -35,7 +35,7 @@ export const Metrics = (signal?: AbortSignal) => {
         hostname: window.location.hostname,
         appPath: Nav.getCurrentRoute().name,
         appVersion: `https://github.com/DataBiosphere/terra-ui/commits/${getConfig().gitRevision}`,
-        appVersionBuildTime: new Date(parseInt(getConfig().buildTimestamp, 10)).toISOString(),
+        appVersionBuildTime: new Date(getConfig().buildTimestamp).toISOString(),
         ...getDefaultProperties(),
       },
     };

--- a/src/libs/ajax/Metrics.ts
+++ b/src/libs/ajax/Metrics.ts
@@ -35,7 +35,7 @@ export const Metrics = (signal?: AbortSignal) => {
         hostname: window.location.hostname,
         appPath: Nav.getCurrentRoute().name,
         appVersion: `https://github.com/DataBiosphere/terra-ui/commits/${getConfig().gitRevision}`,
-        appVersionPublishDate: new Date(parseInt(getConfig().buildTimestamp, 10)).toLocaleString(),
+        appVersionPublishDate: new Date(parseInt(getConfig().buildTimestamp, 10)).toISOString(),
         ...getDefaultProperties(),
       },
     };

--- a/src/libs/ajax/Metrics.ts
+++ b/src/libs/ajax/Metrics.ts
@@ -35,7 +35,7 @@ export const Metrics = (signal?: AbortSignal) => {
         hostname: window.location.hostname,
         appPath: Nav.getCurrentRoute().name,
         appVersion: `https://github.com/DataBiosphere/terra-ui/commits/${getConfig().gitRevision}`,
-        appVersionPublishDate: new Date(parseInt(getConfig().buildTimestamp, 10)).toISOString(),
+        appVersionBuildTime: new Date(parseInt(getConfig().buildTimestamp, 10)).toISOString(),
         ...getDefaultProperties(),
       },
     };


### PR DESCRIPTION
Currently, we attach an `appVersionPublishDate` property to metrics events. That property contains the time that Terra Ui was built (not deployed). It's formatted with [toLocaleString](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString), meaning that it differs based on users' time zone and locale settings. This makes it difficult to associate events with one version.

This renames to property to `appVersionBuildTime` to more accurately reflect what it contains and formats it with [toISOString](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString) so that it's consistent across users' time zones / locales.

Also, `appVersion` is currently sent as a link to a revision in GitHub. The length of that string makes it difficult to see the revision in MixPanel. For example, this screenshot shows events for revision `e9ae98dfe302844b6b67c627349ff823ca5cf55e`:
<img width="331" alt="Screenshot 2023-10-26 at 2 22 56 PM" src="https://github.com/DataBiosphere/terra-ui/assets/1156625/9f74847f-8a69-4492-ae80-80b98b317a8c">
Only the second half the of the hash is visible, when we want the first 7 characters to compare with the list of commits on GitHub (https://github.com/DataBiosphere/terra-ui/commits/dev/).