### PR TITLE
[UIE-143] Convert ajax/Billing to TypeScript

### DIFF
--- a/src/pages/billing/List/GCPNewBillingProjectModal.ts
+++ b/src/pages/billing/List/GCPNewBillingProjectModal.ts
@@ -32,7 +32,8 @@ export const GCPNewBillingProjectModal = (props: GCPNewBillingProjectModalProps)
     Utils.withBusyState(setIsBusy)
   )(async () => {
     try {
-      await Ajax().Billing.createGCPProject(billingProjectName, chosenBillingAccount?.accountName);
+      // Submit is only enabled when choseBillingAccount is non-null.
+      await Ajax().Billing.createGCPProject(billingProjectName, chosenBillingAccount!.accountName);
       props.onSuccess(billingProjectName);
     } catch (error: any) {
       if (error?.status === 409) {

--- a/src/pages/billing/List/List.ts
+++ b/src/pages/billing/List/List.ts
@@ -72,7 +72,8 @@ export const List = (props: ListProps) => {
   )(async ({ projectName }) => {
     const index = _.findIndex({ projectName }, billingProjects);
     // fetch the project to error if it doesn't exist/user can't access
-    const project = await Ajax(signal).Billing.getProject(selectedName);
+    // The component that calls this function is only rendered when selectedName is non-null.
+    const project = await Ajax(signal).Billing.getProject(selectedName!);
     setBillingProjects(_.set([index], project));
   });
 

--- a/src/pages/billing/List/ProjectListItem.test.ts
+++ b/src/pages/billing/List/ProjectListItem.test.ts
@@ -27,6 +27,7 @@ describe('ProjectListItem', () => {
     billingProject = {
       cloudPlatform: 'GCP',
       projectName: 'testProject',
+      billingAccount: 'billingAccounts/123456-ABCDEF-ABCDEF',
       invalidBillingAccount: false,
       roles: ['Owner'],
       status: 'Ready',

--- a/src/pages/billing/NewBillingProjectWizard/AzureBillingProjectWizard/AzureBillingProjectWizard.ts
+++ b/src/pages/billing/NewBillingProjectWizard/AzureBillingProjectWizard/AzureBillingProjectWizard.ts
@@ -58,9 +58,10 @@ export const AzureBillingProjectWizard = ({ onSuccess }: AzureBillingProjectWiza
       const members = _.concat(users, owners);
       await Ajax().Billing.createAzureProject(
         billingProjectName,
-        managedApp?.tenantId,
-        subscriptionId,
-        managedApp?.managedResourceGroupId,
+        // managedApp and subscriptionId are set in previous steps before this function is called.
+        managedApp!.tenantId,
+        subscriptionId!,
+        managedApp!.managedResourceGroupId,
         members
       );
       onSuccess(billingProjectName);

--- a/src/pages/billing/NewBillingProjectWizard/AzureBillingProjectWizard/AzureSubscriptionStep.test.ts
+++ b/src/pages/billing/NewBillingProjectWizard/AzureBillingProjectWizard/AzureSubscriptionStep.test.ts
@@ -110,7 +110,7 @@ describe('AzureSubscriptionStep', () => {
     // Arrange
     renderAzureSubscriptionStep({});
     // Mock managed app Ajax call, should not be called
-    const listAzureManagedApplications = jest.fn(() => Promise.resolve());
+    const listAzureManagedApplications = jest.fn(() => Promise.resolve({ managedApps: [] }));
     asMockedFn(Ajax).mockImplementation(
       () =>
         ({

--- a/src/pages/billing/models/BillingProject.ts
+++ b/src/pages/billing/models/BillingProject.ts
@@ -6,7 +6,7 @@ export type BillingRole = 'Owner' | 'User';
 
 export const allBillingRoles: BillingRole[] = ['Owner', 'User'];
 
-export interface BillingProject {
+interface BaseBillingProject {
   cloudPlatform: CloudPlatform;
   projectName: string;
   invalidBillingAccount: boolean;
@@ -15,17 +15,23 @@ export interface BillingProject {
   message?: string;
 }
 
-export interface AzureBillingProject extends BillingProject {
+export interface AzureBillingProject extends BaseBillingProject {
   cloudPlatform: 'AZURE';
   managedAppCoordinates: AzureManagedAppCoordinates;
   landingZoneId: string;
 }
 
-export interface GCPBillingProject extends BillingProject {
+export interface GCPBillingProject extends BaseBillingProject {
   cloudPlatform: 'GCP';
   billingAccount: string;
   servicePerimeter?: string;
 }
+
+export interface UnknownBillingProject extends BaseBillingProject {
+  cloudPlatform: 'UNKNOWN';
+}
+
+export type BillingProject = AzureBillingProject | GCPBillingProject | UnknownBillingProject;
 
 export const isCreating = (project: BillingProject) =>
   project.status === 'Creating' || project.status === 'CreatingLandingZone';

--- a/src/pages/billing/models/BillingProject.ts
+++ b/src/pages/billing/models/BillingProject.ts
@@ -6,6 +6,11 @@ export type BillingRole = 'Owner' | 'User';
 
 export const allBillingRoles: BillingRole[] = ['Owner', 'User'];
 
+export interface BillingProjectMember {
+  email: string;
+  role: BillingRole;
+}
+
 interface BaseBillingProject {
   cloudPlatform: CloudPlatform;
   projectName: string;


### PR DESCRIPTION
Working towards converting NewWorkspaceModal to TypeScript as part of updating it to support importing data into new Azure workspaces. NewWorkspaceModal depends on the ajax/Billing module and has a good bit of logic based on the list billing projects response.

This updates most of ajax/Billing to TypeScript (I didn't get into the spend report types). It also updates the BillingProject type to take advantage of type narrowing.