### PR TITLE
[WM-2305] Prevent workspace readers from trying to import workflows

### DIFF
--- a/src/workflows-app/SubmitWorkflow.js
+++ b/src/workflows-app/SubmitWorkflow.js
@@ -134,7 +134,7 @@ export const SubmitWorkflow = wrapWorkflowsPage({ name: 'SubmitWorkflow' })(
           getCloudProviderFromWorkspace(workspace),
           isFeaturePreviewEnabled(ENABLE_AZURE_COLLABORATIVE_WORKFLOW_READERS) ? appToolLabels.WORKFLOWS_APP : appToolLabels.CROMWELL
         ),
-        () => h(WorkflowsAppNavPanel, { pageReady, launching, launcherDisabled: !canLaunch, loading, createWorkflowsApp }),
+        () => h(WorkflowsAppNavPanel, { pageReady, launching, launcherDisabled: !canLaunch, loading, createWorkflowsApp, workspace }),
       ],
       [Utils.DEFAULT, () => div({ style: { ...styles.card, width: '50rem', margin: '2rem 4rem' } }, [getCromwellUnsupportedMessage()])]
     );

--- a/src/workflows-app/components/WorkflowsAppNavPanel.test.ts
+++ b/src/workflows-app/components/WorkflowsAppNavPanel.test.ts
@@ -92,6 +92,43 @@ describe('Workflows App Navigation Panel', () => {
     expect(submissionHistoryButton).toHaveAttribute('aria-disabled', 'true');
   });
 
+  it('disables find and add workflows when user is reader', async () => {
+    await act(() =>
+      render(
+        h(WorkflowsAppNavPanel, {
+          loading: false,
+          launcherDisabled: true,
+          launching: false,
+          createWorkflowsApp: jest.fn(),
+          pageReady: true,
+          name: 'test-azure-ws-name',
+          namespace: 'test-azure-ws-namespace',
+          workspace: {
+            ...mockAzureWorkspace,
+            canCompute: false,
+          },
+          analysesData: defaultAnalysesData,
+          setLoading: jest.fn(),
+          signal: jest.fn(),
+        })
+      )
+    );
+
+    expect(screen.queryByText('Featured workflows')).not.toBeInTheDocument();
+    expect(screen.queryByText('Import a workflow')).not.toBeInTheDocument();
+    expect(screen.queryByText('Dockstore')).not.toBeInTheDocument();
+
+    const workflowsInWorkspaceButton = screen.getAllByRole('button')[0];
+    const submissionHistoryButton = screen.getAllByRole('button')[1];
+
+    expect(workflowsInWorkspaceButton).not.toHaveAttribute('aria-disabled', 'true');
+    expect(submissionHistoryButton).not.toHaveAttribute('aria-disabled', 'true');
+
+    const findAndAddWorkflowsCollapse = screen.getByRole('button', { name: 'Find & add workflows' });
+
+    expect(findAndAddWorkflowsCollapse).toHaveAttribute('aria-disabled', 'true');
+  });
+
   it('renders workflow launch card when page is not ready', async () => {
     const { rerender } = render(
       h(WorkflowsAppNavPanel, {

--- a/src/workflows-app/components/WorkflowsAppNavPanel.ts
+++ b/src/workflows-app/components/WorkflowsAppNavPanel.ts
@@ -89,10 +89,12 @@ export const WorkflowsAppNavPanel = ({
   const [selectedSubHeader, setSelectedSubHeader] = useQueryParameter('tab');
 
   useEffect(() => {
-    if (!(selectedSubHeader in subHeadersMap || selectedSubHeader in findAndAddSubheadersMap)) {
+    if (
+      !(selectedSubHeader in subHeadersMap || (workspace.canCompute && selectedSubHeader in findAndAddSubheadersMap))
+    ) {
       setSelectedSubHeader('workspace-workflows');
     }
-  }, [selectedSubHeader, setSelectedSubHeader]);
+  }, [workspace, selectedSubHeader, setSelectedSubHeader]);
 
   const isSubHeaderActive = (subHeader: string) => pageReady && selectedSubHeader === subHeader;
 
@@ -138,13 +140,22 @@ export const WorkflowsAppNavPanel = ({
           Collapse,
           {
             style: { borderBottom: `1px solid ${colors.dark(0.2)}` },
-            title: span({ style: { color: !pageReady ? colors.disabled() : colors.accent(), fontSize: 15 } }, [
-              'Find & add workflows',
-            ]),
-            initialOpenState: pageReady,
+            title: span(
+              {
+                style: {
+                  color: !pageReady || !workspace.canCompute ? colors.disabled() : colors.accent(),
+                  fontSize: 15,
+                },
+              },
+              ['Find & add workflows']
+            ),
+            tooltip: !workspace.canCompute
+              ? 'You must be a workspace writer/owner to add workflows to this workspace.'
+              : undefined,
+            initialOpenState: pageReady && workspace.canCompute,
             titleFirst: true,
             summaryStyle: { padding: '1rem 1rem 1rem 1.5rem' },
-            disabled: !pageReady,
+            disabled: !pageReady || !workspace.canCompute,
           },
           [
             div(

--- a/src/workflows-app/components/WorkflowsAppNavPanel.ts
+++ b/src/workflows-app/components/WorkflowsAppNavPanel.ts
@@ -150,7 +150,7 @@ export const WorkflowsAppNavPanel = ({
               ['Find & add workflows']
             ),
             tooltip: !workspace.canCompute
-              ? 'You must be a workspace writer/owner to add workflows to this workspace.'
+              ? 'You must be a workspace writer/owner to add workflows to this workspace. To import (and run) workflows, you can clone this workspace.'
               : undefined,
             initialOpenState: pageReady && workspace.canCompute,
             titleFirst: true,


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WM-2305

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Provide more useful messages to workspace readers and prevent them from making import requests to workflows app

### Why
- Workflows app will always reject these requests for readers, so we may as well provide them with better UX in this case

### Testing strategy
- Unit tests <!-- Test case 1 -->
- Validated in workspace locally

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 
![Screenshot 2023-11-02 at 4 24 05 PM](https://github.com/DataBiosphere/terra-ui/assets/67511512/ae988e78-a3bf-4a92-8b11-3368197b013b)
