### PR TITLE
[WOR-1285] Transition deleting workspaces to deleted in the workspace list view

### DIFF
--- a/src/libs/workspace-utils.ts
+++ b/src/libs/workspace-utils.ts
@@ -79,7 +79,8 @@ export type WorkspaceState =
   | 'Updating'
   | 'UpdateFailed'
   | 'Deleting'
-  | 'DeleteFailed';
+  | 'DeleteFailed'
+  | 'Deleted'; // For UI only - not a state in rawls
 
 export interface BaseWorkspace {
   owners?: string[];

--- a/src/pages/workspaces/WorkspacesList/RecentlyViewedWorkspaces.ts
+++ b/src/pages/workspaces/WorkspacesList/RecentlyViewedWorkspaces.ts
@@ -25,7 +25,10 @@ export const RecentlyViewedWorkspaces = (props: RecentlyViewedWorkspacesProps): 
   // A user may have lost access to a workspace after viewing it, so we'll filter those out just in case
   const recentlyViewed = useMemo(() => {
     const recent = getLocalPref(recentlyViewedPersistenceId)?.recentlyViewed || [];
-    return _.filter((w) => getWorkspace(w.workspaceId, workspaces), recent);
+    return _.filter((w) => {
+      const ws = getWorkspace(w.workspaceId, workspaces);
+      return !!ws && ws.workspace.state !== 'Deleted';
+    }, recent);
   }, [workspaces]);
 
   return !_.isEmpty(workspaces) && !_.isEmpty(recentlyViewed)

--- a/src/pages/workspaces/WorkspacesList/RenderedWorkspaces.test.ts
+++ b/src/pages/workspaces/WorkspacesList/RenderedWorkspaces.test.ts
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import { div, h } from 'react-hyperscript-helpers';
 import { WorkspaceWrapper } from 'src/libs/workspace-utils';
 import { RenderedWorkspaces } from 'src/pages/workspaces/WorkspacesList/RenderedWorkspaces';
@@ -36,6 +36,7 @@ describe('The behavior of the RenderedWorkspaces component', () => {
     expect(renderedGoogleWS).not.toBeNull();
     const renderedAzureWS = screen.getAllByText(defaultAzureWorkspace.workspace.name);
     expect(renderedAzureWS).not.toBeNull();
+    expect(renderedAzureWS).toHaveLength(1);
   });
 
   it('should indicate when the workspace is in the process of deleting instead of displaying the description', () => {
@@ -61,6 +62,7 @@ describe('The behavior of the RenderedWorkspaces component', () => {
 
     const workspaceStateDisplay = screen.getAllByText('Workspace deletion in progress');
     expect(workspaceStateDisplay).not.toBeNull();
+    expect(workspaceStateDisplay).toHaveLength(1);
   });
 
   it('should indicate when the workspace failed to delete instead of displaying the description', () => {
@@ -86,6 +88,7 @@ describe('The behavior of the RenderedWorkspaces component', () => {
 
     const workspaceStateDisplay = screen.getAllByText('Error deleting workspace');
     expect(workspaceStateDisplay).not.toBeNull();
+    expect(workspaceStateDisplay).toHaveLength(1);
   });
 
   it('should render the description when the workspace is not in the process of deleting', () => {
@@ -108,5 +111,52 @@ describe('The behavior of the RenderedWorkspaces component', () => {
     // Assert
     const workspaceDescriptionDisplay = screen.queryAllByText('some description');
     expect(workspaceDescriptionDisplay).toHaveLength(1);
+  });
+
+  it('gives a link to display the workspace error message if present', () => {
+    // Arrange
+    const workspace: WorkspaceWrapper = {
+      ...defaultAzureWorkspace,
+      workspace: {
+        ...defaultAzureWorkspace.workspace,
+        state: 'DeleteFailed',
+        errorMessage: 'A semi-helpful message!',
+      },
+    };
+    const label = 'myWorkspaces';
+
+    // Act
+    render(
+      h(RenderedWorkspaces, { workspaces: [workspace], label, noContent: div({}), loadingSubmissionStats: false })
+    );
+
+    // Assert
+    const detailsLink = screen.getByText('See error details.');
+    expect(detailsLink).not.toBeNull();
+    expect(detailsLink).toHaveLength[1];
+  });
+
+  it('shows the error message in a modal when the details link is clicked', () => {
+    // Arrange
+    const workspace: WorkspaceWrapper = {
+      ...defaultAzureWorkspace,
+      workspace: {
+        ...defaultAzureWorkspace.workspace,
+        state: 'DeleteFailed',
+        errorMessage: 'A semi-helpful message!',
+      },
+    };
+    const label = 'myWorkspaces';
+
+    // Act
+    render(
+      h(RenderedWorkspaces, { workspaces: [workspace], label, noContent: div({}), loadingSubmissionStats: false })
+    );
+    const detailsLink = screen.getByText('See error details.');
+    fireEvent.click(detailsLink);
+    // Assert
+
+    const message = screen.getByText('A semi-helpful message!');
+    expect(message).not.toBeNull();
   });
 });

--- a/src/pages/workspaces/WorkspacesList/RenderedWorkspaces.ts
+++ b/src/pages/workspaces/WorkspacesList/RenderedWorkspaces.ts
@@ -197,6 +197,7 @@ const NameCell = (props: CellProps): ReactNode => {
             !canView &&
             'You cannot access this workspace because it is protected by an Authorization Domain. Click to learn about gaining access.',
           tooltipSide: 'right',
+          disabled: workspace.state === 'Deleted',
         },
         [name]
       ),
@@ -204,6 +205,7 @@ const NameCell = (props: CellProps): ReactNode => {
     Utils.cond(
       [state === 'Deleting', () => h(WorkspaceDeletingCell)],
       [state === 'DeleteFailed', () => h(WorkspaceDeletionFailedCell, { workspace: props.workspace })],
+      [state === 'Deleted', () => h(WorkspaceDeletedCell)],
       [Utils.DEFAULT, () => h(WorkspaceDescriptionCell, { description })]
     ),
   ]);
@@ -241,7 +243,7 @@ const WorkspaceDeletingCell = (): ReactNode => {
         color: colors.danger(),
       },
     },
-    [deletingIcon, 'Workspace deletion in progress']
+    [deletingIcon, 'Workspace deletion in progress.']
   );
 };
 
@@ -291,6 +293,16 @@ const WorkspaceDeletionFailedCell = (props: CellProps): ReactNode => {
     ]
   );
 };
+
+const WorkspaceDeletedCell = (): ReactNode =>
+  div(
+    {
+      style: {
+        color: colors.danger(),
+      },
+    },
+    ['Workspace has been deleted. Refresh to remove from list.']
+  );
 
 const LastModifiedCell = (props: CellProps): ReactNode => {
   const {
@@ -357,13 +369,16 @@ interface ActionsCellProps extends CellProps {
 const ActionsCell = (props: ActionsCellProps): ReactNode => {
   const {
     accessLevel,
-    workspace: { workspaceId, namespace, name },
+    workspace: { workspaceId, namespace, name, state },
   } = props.workspace;
   const { setUserActions } = useContext(WorkspaceUserActionsContext);
 
   if (!canRead(accessLevel)) {
     // No menu shown if user does not have read access.
     return div({ className: 'sr-only' }, ['You do not have permission to perform actions on this workspace.']);
+  }
+  if (state === 'Deleted') {
+    return null;
   }
   const getWorkspace = (id: string): Workspace => _.find({ workspace: { workspaceId: id } }, props.workspaces)!;
 

--- a/src/pages/workspaces/WorkspacesList/RenderedWorkspaces.ts
+++ b/src/pages/workspaces/WorkspacesList/RenderedWorkspaces.ts
@@ -243,7 +243,7 @@ const WorkspaceDeletingCell = (): ReactNode => {
         color: colors.danger(),
       },
     },
-    [deletingIcon, 'Workspace deletion in progress.']
+    [deletingIcon, 'Workspace deletion in progress']
   );
 };
 

--- a/src/pages/workspaces/WorkspacesList/RenderedWorkspaces.ts
+++ b/src/pages/workspaces/WorkspacesList/RenderedWorkspaces.ts
@@ -5,7 +5,9 @@ import { div, h, span } from 'react-hyperscript-helpers';
 import { AutoSizer } from 'react-virtualized';
 import { CloudProviderIcon } from 'src/components/CloudProviderIcon';
 import { Link } from 'src/components/common';
+import ErrorView from 'src/components/ErrorView';
 import { FirstParagraphMarkdownViewer } from 'src/components/markdown';
+import Modal from 'src/components/Modal';
 import { FlexTable, HeaderRenderer } from 'src/components/table';
 import { WorkspaceStarControl } from 'src/components/WorkspaceStarControl';
 import { workspaceSubmissionStatus, WorkspaceSubmissionStatusIcon } from 'src/components/WorkspaceSubmissionStatusIcon';
@@ -201,7 +203,7 @@ const NameCell = (props: CellProps): ReactNode => {
     ]),
     Utils.cond(
       [state === 'Deleting', () => h(WorkspaceDeletingCell)],
-      [state === 'DeleteFailed', () => h(WorkspaceDeletionFailedCell)],
+      [state === 'DeleteFailed', () => h(WorkspaceDeletionFailedCell, { workspace: props.workspace })],
       [Utils.DEFAULT, () => h(WorkspaceDescriptionCell, { description })]
     ),
   ]);
@@ -243,7 +245,10 @@ const WorkspaceDeletingCell = (): ReactNode => {
   );
 };
 
-const WorkspaceDeletionFailedCell = (): ReactNode => {
+const WorkspaceDeletionFailedCell = (props: CellProps): ReactNode => {
+  const { workspace } = props;
+  const [showDetails, setShowDetails] = useState<boolean>(false);
+
   const errorIcon = icon('warning-standard', {
     size: 18,
     style: {
@@ -257,7 +262,33 @@ const WorkspaceDeletionFailedCell = (): ReactNode => {
         color: colors.danger(),
       },
     },
-    [errorIcon, 'Error deleting workspace']
+    [
+      errorIcon,
+      'Error deleting workspace',
+      workspace.workspace.errorMessage
+        ? h(
+            Link,
+            {
+              onClick: () => setShowDetails(true),
+              style: { fontSize: 14, marginRight: '0.5rem', marginLeft: '0.5rem' },
+            },
+            ['See error details.']
+          )
+        : null,
+      showDetails
+        ? h(
+            Modal,
+            {
+              width: 800,
+              title: 'Error deleting workspace',
+              showCancel: false,
+              showX: true,
+              onDismiss: () => setShowDetails(false),
+            },
+            [h(ErrorView, { error: workspace?.workspace.errorMessage ?? 'No error message available' })]
+          )
+        : null,
+    ]
   );
 };
 

--- a/src/pages/workspaces/WorkspacesList/WorkspacesList.test.ts
+++ b/src/pages/workspaces/WorkspacesList/WorkspacesList.test.ts
@@ -147,10 +147,9 @@ describe('WorkspaceList', () => {
     });
     // trigger first poll
     jest.advanceTimersByTime(30000);
-    // wait for any promises to complete
-    await Promise.resolve();
+    // Waiting on the assertion here also ensures promises have time to complete
+    await waitFor(() => expect(mockDetailsFn).toBeCalledTimes(1));
     jest.advanceTimersByTime(30000);
-    await Promise.resolve();
 
     // Assert
     await waitFor(() => expect(mockDetailsFn).toBeCalledTimes(2));
@@ -216,16 +215,13 @@ describe('WorkspaceList', () => {
     await act(async () => {
       render(h(WorkspacesList));
     });
-    // trigger first poll
-    await Promise.resolve();
 
     jest.advanceTimersByTime(30000);
-    // wait for any promises to complete
-    await Promise.resolve();
-    jest.advanceTimersByTime(30000);
-    await Promise.resolve();
 
     // Assert
+    await waitFor(() => expect(mockDetailsFn).toBeCalledTimes(2));
+
+    jest.advanceTimersByTime(30000);
 
     await waitFor(() => expect(mockDetailsFn).toBeCalledTimes(4));
     expect(mockWorkspacesFn).toHaveBeenNthCalledWith(

--- a/src/pages/workspaces/WorkspacesList/WorkspacesList.test.ts
+++ b/src/pages/workspaces/WorkspacesList/WorkspacesList.test.ts
@@ -1,0 +1,252 @@
+import { DeepPartial } from '@terra-ui-packages/core-utils';
+import { act, waitFor } from '@testing-library/react';
+import { h } from 'react-hyperscript-helpers';
+import { Ajax } from 'src/libs/ajax';
+import { WorkspaceWrapper as Workspace } from 'src/libs/workspace-utils';
+import { useWorkspacesWithSubmissionStats } from 'src/pages/workspaces/WorkspacesList/useWorkspacesWithSubmissionStats';
+import { WorkspacesList } from 'src/pages/workspaces/WorkspacesList/WorkspacesList';
+import { asMockedFn, renderWithAppContexts as render } from 'src/testing/test-utils';
+import { defaultAzureWorkspace, defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
+
+type NavExports = typeof import('src/libs/nav');
+jest.mock(
+  'src/libs/nav',
+  (): NavExports => ({
+    ...jest.requireActual<NavExports>('src/libs/nav'),
+    getLink: jest.fn(() => '/'),
+    goToPath: jest.fn(),
+    useRoute: jest.fn().mockReturnValue({ query: {} }),
+    updateSearch: jest.fn(),
+  })
+);
+
+type StateExports = typeof import('src/libs/state');
+jest.mock('src/libs/state', (): StateExports => {
+  return {
+    ...jest.requireActual('src/libs/state'),
+    getTerraUser: jest.fn(() => ({ email: 'someone@emails.com' })),
+  };
+});
+
+type NotificationExports = typeof import('src/libs/notifications');
+jest.mock('src/libs/notifications', (): NotificationExports => {
+  return {
+    ...jest.requireActual('src/libs/notifications'),
+    notify: jest.fn(),
+  };
+});
+
+type AjaxExports = typeof import('src/libs/ajax');
+type AjaxContract = ReturnType<AjaxExports['Ajax']>;
+
+jest.mock('src/libs/ajax', (): AjaxExports => {
+  return {
+    ...jest.requireActual('src/libs/ajax'),
+    Ajax: jest.fn(),
+  };
+});
+
+type WorkspaceFiltersExports = typeof import('src/pages/workspaces/WorkspacesList/WorkspaceFilters');
+jest.mock<WorkspaceFiltersExports>('src/pages/workspaces/WorkspacesList/WorkspaceFilters', () => ({
+  ...jest.requireActual('src/pages/workspaces/WorkspacesList/WorkspaceFilters'),
+  WorkspaceFilters: jest.fn().mockReturnValue(null),
+}));
+
+jest.mock<UseWorkspaceWithSubmissionStatsExports>(
+  'src/pages/workspaces/WorkspacesList/useWorkspacesWithSubmissionStats',
+  () => ({
+    ...jest.requireActual('src/pages/workspaces/WorkspacesList/useWorkspacesWithSubmissionStats'),
+    useWorkspacesWithSubmissionStats: jest.fn(),
+  })
+);
+type UseWorkspaceWithSubmissionStatsExports =
+  typeof import('src/pages/workspaces/WorkspacesList/useWorkspacesWithSubmissionStats');
+
+describe('WorkspaceList', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('does not poll workspaces that are not deleting', async () => {
+    // Arrange
+    asMockedFn(useWorkspacesWithSubmissionStats).mockReturnValue({
+      workspaces: [defaultAzureWorkspace, defaultGoogleWorkspace],
+      refresh: () => jest.fn(),
+      loadingWorkspaces: false,
+      loadingSubmissionStats: false,
+    });
+    const mockDetailsFn = jest.fn();
+    const mockAjax: DeepPartial<AjaxContract> = {
+      Workspaces: {
+        workspace: () => ({
+          details: mockDetailsFn,
+        }),
+      },
+      FirecloudBucket: {
+        getFeaturedWorkspaces: () => [],
+      },
+    };
+
+    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+
+    jest.useFakeTimers();
+
+    // Act
+
+    await act(async () => {
+      render(h(WorkspacesList));
+    });
+    // trigger first poll
+    jest.advanceTimersByTime(30000);
+    // wait for any promises to complete
+    await Promise.resolve();
+
+    // Assert
+    expect(mockDetailsFn).not.toBeCalled();
+  });
+
+  it('polls for a deleting workspace', async () => {
+    // Arrange
+    const deletingWorkspace: Workspace = {
+      ...defaultAzureWorkspace,
+      workspace: {
+        ...defaultAzureWorkspace.workspace,
+        state: 'Deleting',
+      },
+    };
+    asMockedFn(useWorkspacesWithSubmissionStats).mockReturnValue({
+      workspaces: [deletingWorkspace, defaultGoogleWorkspace],
+      refresh: () => jest.fn(),
+      loadingWorkspaces: false,
+      loadingSubmissionStats: false,
+    });
+    const mockDetailsFn: ReturnType<AjaxContract['Workspaces']['workspace']>['details'] = jest
+      .fn()
+      .mockResolvedValue({ workspace: { state: 'Deleting' } } satisfies DeepPartial<Workspace>);
+    const mockWorkspacesFn = jest.fn().mockReturnValue({
+      details: mockDetailsFn,
+    } satisfies DeepPartial<AjaxContract['Workspaces']['workspace']>);
+
+    const mockAjax: DeepPartial<AjaxContract> = {
+      Workspaces: {
+        workspace: mockWorkspacesFn,
+      },
+      FirecloudBucket: {
+        getFeaturedWorkspaces: () => [],
+      },
+    };
+
+    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+
+    jest.useFakeTimers();
+
+    // Act
+
+    await act(async () => {
+      render(h(WorkspacesList));
+    });
+    // trigger first poll
+    jest.advanceTimersByTime(30000);
+    // wait for any promises to complete
+    await Promise.resolve();
+    jest.advanceTimersByTime(30000);
+    await Promise.resolve();
+
+    // Assert
+    await waitFor(() => expect(mockDetailsFn).toBeCalledTimes(2));
+    expect(mockWorkspacesFn).toHaveBeenNthCalledWith(
+      1,
+      defaultAzureWorkspace.workspace.namespace,
+      defaultAzureWorkspace.workspace.name
+    );
+    expect(mockWorkspacesFn).toHaveBeenNthCalledWith(
+      2,
+      defaultAzureWorkspace.workspace.namespace,
+      defaultAzureWorkspace.workspace.name
+    );
+  });
+
+  it('polls for all deleting workspaces', async () => {
+    // Arrange
+    const deletingWorkspaces: Workspace[] = [
+      {
+        ...defaultAzureWorkspace,
+        workspace: {
+          ...defaultAzureWorkspace.workspace,
+          state: 'Deleting',
+        },
+      },
+      {
+        ...defaultGoogleWorkspace,
+        workspace: {
+          ...defaultGoogleWorkspace.workspace,
+          state: 'Deleting',
+        },
+      },
+    ];
+
+    asMockedFn(useWorkspacesWithSubmissionStats).mockReturnValue({
+      workspaces: deletingWorkspaces,
+      refresh: () => jest.fn(),
+      loadingWorkspaces: false,
+      loadingSubmissionStats: false,
+    });
+    const mockDetailsFn: ReturnType<AjaxContract['Workspaces']['workspace']>['details'] = jest
+      .fn()
+      .mockResolvedValue({ workspace: { state: 'Deleting' } } satisfies DeepPartial<Workspace>);
+    const mockWorkspacesFn = jest.fn().mockReturnValue({
+      details: mockDetailsFn,
+    } satisfies DeepPartial<AjaxContract['Workspaces']['workspace']>);
+
+    const mockAjax: DeepPartial<AjaxContract> = {
+      Workspaces: {
+        workspace: mockWorkspacesFn,
+      },
+      FirecloudBucket: {
+        getFeaturedWorkspaces: () => [],
+      },
+    };
+
+    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+
+    jest.useFakeTimers();
+
+    // Act
+
+    await act(async () => {
+      render(h(WorkspacesList));
+    });
+    // trigger first poll
+    await Promise.resolve();
+
+    jest.advanceTimersByTime(30000);
+    // wait for any promises to complete
+    await Promise.resolve();
+    jest.advanceTimersByTime(30000);
+    await Promise.resolve();
+
+    // Assert
+
+    await waitFor(() => expect(mockDetailsFn).toBeCalledTimes(4));
+    expect(mockWorkspacesFn).toHaveBeenNthCalledWith(
+      1,
+      defaultAzureWorkspace.workspace.namespace,
+      defaultAzureWorkspace.workspace.name
+    );
+    expect(mockWorkspacesFn).toHaveBeenNthCalledWith(
+      2,
+      defaultGoogleWorkspace.workspace.namespace,
+      defaultGoogleWorkspace.workspace.name
+    );
+    expect(mockWorkspacesFn).toHaveBeenNthCalledWith(
+      3,
+      defaultAzureWorkspace.workspace.namespace,
+      defaultAzureWorkspace.workspace.name
+    );
+    expect(mockWorkspacesFn).toHaveBeenNthCalledWith(
+      4,
+      defaultGoogleWorkspace.workspace.namespace,
+      defaultGoogleWorkspace.workspace.name
+    );
+  });
+});

--- a/src/pages/workspaces/WorkspacesList/WorkspacesList.ts
+++ b/src/pages/workspaces/WorkspacesList/WorkspacesList.ts
@@ -131,7 +131,7 @@ const useDeletetionPolling = (workspaces: Workspace[]) => {
     const checkWorkspaceDeletion = async (workspace: Workspace) => {
       try {
         const wsResp: Workspace = await Ajax(signal)
-          .Workspaces.workspace(workspace.workspace.namespace)
+          .Workspaces.workspace(workspace.workspace.namespace, workspace.workspace.name)
           .details(['workspace.state', 'workspace.errorMessage']);
         const state = wsResp.workspace.state;
         if (state === 'DeleteFailed') {

--- a/src/pages/workspaces/WorkspacesList/useWorkspacesWithSubmissionStats.ts
+++ b/src/pages/workspaces/WorkspacesList/useWorkspacesWithSubmissionStats.ts
@@ -33,6 +33,7 @@ export const useWorkspacesWithSubmissionStats = (): WorkspacesWithSubmissionStat
       'workspace.namespace',
       'workspace.workspaceId',
       'workspace.state',
+      'workspace.errorMessage',
     ],
     250
   );


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WOR-1285

## Summary of changes:
* Adds a hook to poll workspaces that are in a deleting state
* For a workspace that has been deleted, disable the link to the dashboard, and display a message indicating it has been deleted

Getting the hook to work correctly was a bit tricky. 
Using the useCancelation or useCancellable hooks caused either duplicate polling loops, polling to not stop when a workspace was deleted or polling to not work at all, depending on how it was set up.


<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 
<img width="1385" alt="Screenshot 2023-10-26 at 3 26 17 PM" src="https://github.com/DataBiosphere/terra-ui/assets/1930315/4e2d1663-5ccf-4849-87b5-f07688224c8f">
