### PR TITLE
[UIE-144] Fix group listMembers type

### DIFF
--- a/src/libs/ajax/Groups.ts
+++ b/src/libs/ajax/Groups.ts
@@ -44,7 +44,7 @@ export const Groups = (signal?: AbortSignal) => ({
         return res.json();
       },
 
-      listMembers: async (): Promise<string> => {
+      listMembers: async (): Promise<string[]> => {
         const res = await fetchSam(`${root}/member`, _.merge(authOpts(), { signal }));
         return res.json();
       },


### PR DESCRIPTION
Fixup for #4406

`listMembers` returns an array, not a string.