### PR TITLE
[WM-2352] Fix submission details page

### DIFF
--- a/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
+++ b/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
@@ -43,13 +43,13 @@ const deletionDelayYears = 1;
 const deletionDelayString = `${deletionDelayYears} year${deletionDelayYears > 1 ? 's' : ''}`;
 const isDeleted = (statusLastChangedDate) => differenceInDays(parseISO(statusLastChangedDate), Date.now()) > deletionDelayYears * 365;
 
-const deletedInfoIcon = ({ name, icon }) => {
+const deletedInfoIcon = ({ name, icon: iconName }) => {
   return h(
     InfoBox,
     {
       style: { color: colors.secondary(), margin: '0.5rem' },
       tooltip: `${name} unavailable. Click to learn more.`,
-      icon,
+      icon: iconName,
     },
     [
       div({ style: Style.elements.sectionHeader }, 'Workflow Details Archived'),


### PR DESCRIPTION
`icon` in the `deletedInfoIcon` parameter shadows the `icon` function and results in an error that prevents the page from rendering for submissions more than a year old.

This was broken in #4367