### PR TITLE
WOR-1327 fix dashboard polling

### DIFF
--- a/src/pages/workspaces/WorkspacesList/WorkspacesList.ts
+++ b/src/pages/workspaces/WorkspacesList/WorkspacesList.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp';
-import { ReactNode, useEffect, useMemo, useState } from 'react';
+import { ReactNode, useMemo, useState } from 'react';
 import { div, h, p } from 'react-hyperscript-helpers';
 import { isAzureUser } from 'src/auth/auth';
 import { Link, topSpinnerOverlay, transparentSpinnerOverlay } from 'src/components/common';
@@ -10,10 +10,10 @@ import { Ajax } from 'src/libs/ajax';
 import { withErrorIgnoring } from 'src/libs/error';
 import { updateSearch, useRoute } from 'src/libs/nav';
 import { useOnMount } from 'src/libs/react-utils';
-import { workspacesStore, workspaceStore } from 'src/libs/state';
 import { elements as StyleElements } from 'src/libs/style';
-import { newTabLinkProps, pollWithCancellation } from 'src/libs/utils';
-import { cloudProviderTypes, WorkspaceState, WorkspaceWrapper as Workspace } from 'src/libs/workspace-utils';
+import { newTabLinkProps } from 'src/libs/utils';
+import { cloudProviderTypes, WorkspaceWrapper as Workspace } from 'src/libs/workspace-utils';
+import { useDeletetionPolling } from 'src/pages/workspaces/hooks/useDeletionPolling';
 import { categorizeWorkspaces } from 'src/pages/workspaces/WorkspacesList/CategorizedWorkspaces';
 import { RecentlyViewedWorkspaces } from 'src/pages/workspaces/WorkspacesList/RecentlyViewedWorkspaces';
 import { useWorkspacesWithSubmissionStats } from 'src/pages/workspaces/WorkspacesList/useWorkspacesWithSubmissionStats';
@@ -110,58 +110,4 @@ export const WorkspacesList = (): ReactNode => {
       ]),
     ]),
   ]);
-};
-
-const useDeletetionPolling = (workspaces: Workspace[]) => {
-  // we have to do the signal/abort manually instead of with useCancelable so that the it can be cleaned up in the
-  // this component's useEffect, instead of the useEffect in useCancelable
-  const [controller, setController] = useState(new window.AbortController());
-  const abort = () => {
-    controller.abort();
-    setController(new window.AbortController());
-  };
-  useEffect(() => {
-    const updateWorkspacesStore = (workspace: Workspace, state: WorkspaceState, errorMessage?: string): Workspace[] => {
-      const updateList = _.cloneDeep(workspaces);
-      const updateWS = _.find(
-        (ws: Workspace) => ws.workspace.workspaceId === workspace.workspace.workspaceId,
-        updateList
-      )!;
-      updateWS.workspace.state = state;
-      updateWS.workspace.errorMessage = errorMessage;
-      return updateList;
-    };
-
-    const checkWorkspaceDeletion = async (workspace: Workspace) => {
-      try {
-        const wsResp: Workspace = await Ajax(controller.signal)
-          .Workspaces.workspace(workspace.workspace.namespace, workspace.workspace.name)
-          .details(['workspace.state', 'workspace.errorMessage']);
-        const state = wsResp.workspace.state;
-        if (state === 'DeleteFailed') {
-          abort();
-          workspacesStore.update(() => updateWorkspacesStore(workspace, state, wsResp.workspace.errorMessage));
-          workspaceStore.reset();
-        }
-      } catch (error) {
-        if (error instanceof Response && error.status === 404) {
-          abort();
-          workspacesStore.update(() => updateWorkspacesStore(workspace, 'Deleted'));
-          workspaceStore.reset();
-        }
-      }
-    };
-    const iterateDeletingWorkspaces = async () => {
-      const deletingWorkspaces = _.filter((ws) => ws.workspace.state === 'Deleting', workspaces);
-      for (const ws of deletingWorkspaces) {
-        await checkWorkspaceDeletion(ws);
-      }
-    };
-
-    pollWithCancellation(() => iterateDeletingWorkspaces(), 30000, false, controller.signal);
-    return () => {
-      abort();
-    };
-    //  eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [workspaces]); // adding the controller to deps causes a double fire of the effect
 };

--- a/src/pages/workspaces/WorkspacesList/WorkspacesList.ts
+++ b/src/pages/workspaces/WorkspacesList/WorkspacesList.ts
@@ -13,7 +13,7 @@ import { useOnMount } from 'src/libs/react-utils';
 import { elements as StyleElements } from 'src/libs/style';
 import { newTabLinkProps } from 'src/libs/utils';
 import { cloudProviderTypes, WorkspaceWrapper as Workspace } from 'src/libs/workspace-utils';
-import { useDeletetionPolling } from 'src/pages/workspaces/hooks/useDeletionPolling';
+import { useDeletionPolling } from 'src/pages/workspaces/hooks/useDeletionPolling';
 import { categorizeWorkspaces } from 'src/pages/workspaces/WorkspacesList/CategorizedWorkspaces';
 import { RecentlyViewedWorkspaces } from 'src/pages/workspaces/WorkspacesList/RecentlyViewedWorkspaces';
 import { useWorkspacesWithSubmissionStats } from 'src/pages/workspaces/WorkspacesList/useWorkspacesWithSubmissionStats';
@@ -43,7 +43,7 @@ export const WorkspacesList = (): ReactNode => {
   } = useWorkspacesWithSubmissionStats();
 
   const [featuredList, setFeaturedList] = useState<{ name: string; namespace: string }[]>();
-  useDeletetionPolling(workspaces);
+  useDeletionPolling(workspaces);
   const { query } = useRoute();
   const filters: WorkspaceFilterValues = getWorkspaceFiltersFromQuery(query);
 

--- a/src/pages/workspaces/hooks/useAppPolling.ts
+++ b/src/pages/workspaces/hooks/useAppPolling.ts
@@ -1,8 +1,8 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Ajax } from 'src/libs/ajax';
 import { ListAppResponse } from 'src/libs/ajax/leonardo/models/app-models';
 import { withErrorIgnoring, withErrorReporting } from 'src/libs/error';
-import { useCancellation, useOnMount } from 'src/libs/react-utils';
+import { useCancellation } from 'src/libs/react-utils';
 import { isAzureWorkspace, isGoogleWorkspace } from 'src/libs/workspace-utils';
 import { InitializedWorkspaceWrapper as Workspace } from 'src/pages/workspaces/workspace/useWorkspace';
 
@@ -46,9 +46,10 @@ export const useAppPolling = (workspace: Workspace): AppDetails => {
   };
   const refreshApps = withErrorReporting('Error loading apps', loadApps) as (maybeStale?: boolean) => Promise<void>;
   const refreshAppsSilently = withErrorIgnoring(loadApps);
-  useOnMount(() => {
+  useEffect(() => {
     refreshApps();
     return () => clearTimeout(timeout.current);
-  });
+    //  eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workspace]);
   return { apps, refreshApps };
 };

--- a/src/pages/workspaces/hooks/useAppPolling.ts
+++ b/src/pages/workspaces/hooks/useAppPolling.ts
@@ -1,0 +1,54 @@
+import { useRef, useState } from 'react';
+import { Ajax } from 'src/libs/ajax';
+import { ListAppResponse } from 'src/libs/ajax/leonardo/models/app-models';
+import { withErrorIgnoring, withErrorReporting } from 'src/libs/error';
+import { useCancellation, useOnMount } from 'src/libs/react-utils';
+import { isAzureWorkspace, isGoogleWorkspace } from 'src/libs/workspace-utils';
+import { InitializedWorkspaceWrapper as Workspace } from 'src/pages/workspaces/workspace/useWorkspace';
+
+export interface AppDetails {
+  apps?: ListAppResponse[];
+  refreshApps: (maybeStale?: boolean) => Promise<void>;
+}
+
+export const useAppPolling = (workspace: Workspace): AppDetails => {
+  const signal = useCancellation();
+  const timeout = useRef<NodeJS.Timeout>();
+  const [apps, setApps] = useState<ListAppResponse[]>();
+
+  const reschedule = (ms) => {
+    clearTimeout(timeout.current);
+    timeout.current = setTimeout(refreshAppsSilently, ms);
+  };
+  const loadApps = async (maybeStale?: boolean): Promise<void> => {
+    try {
+      const newGoogleApps =
+        !!workspace && isGoogleWorkspace(workspace)
+          ? await Ajax(signal).Apps.list(workspace.workspace.googleProject, {
+              role: 'creator',
+              saturnWorkspaceName: workspace.workspace.name,
+            })
+          : [];
+      const newAzureApps =
+        !!workspace && isAzureWorkspace(workspace)
+          ? await Ajax(signal).Apps.listAppsV2(workspace.workspace.workspaceId)
+          : [];
+      const combinedNewApps = [...newGoogleApps, ...newAzureApps];
+
+      setApps(combinedNewApps);
+      Object.values(combinedNewApps).forEach((app) => {
+        reschedule(maybeStale || (app && ['PROVISIONING', 'PREDELETING'].includes(app.status)) ? 10000 : 120000);
+      });
+    } catch (error) {
+      reschedule(30000);
+      throw error;
+    }
+  };
+  const refreshApps = withErrorReporting('Error loading apps', loadApps) as (maybeStale?: boolean) => Promise<void>;
+  const refreshAppsSilently = withErrorIgnoring(loadApps);
+  useOnMount(() => {
+    refreshApps();
+    return () => clearTimeout(timeout.current);
+  });
+  return { apps, refreshApps };
+};

--- a/src/pages/workspaces/hooks/useCloudEnvironmentPolling.ts
+++ b/src/pages/workspaces/hooks/useCloudEnvironmentPolling.ts
@@ -45,7 +45,7 @@ export const useCloudEnvironmentPolling = (
         role: 'creator',
         saturnWorkspaceName,
         saturnWorkspaceNamespace,
-      });
+      }) as Record<string, string>; // we literally just filtered out the undefined values, but ts doesn't know this
 
       // Disks.list API takes includeLabels to specify which labels to return in the response
       // Runtimes.listV2 API always returns all labels for a runtime

--- a/src/pages/workspaces/hooks/useCloudEnvironmentPolling.ts
+++ b/src/pages/workspaces/hooks/useCloudEnvironmentPolling.ts
@@ -1,12 +1,12 @@
 import _ from 'lodash/fp';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { getDiskAppType } from 'src/analysis/utils/app-utils';
 import { getConvertedRuntimeStatus, getCurrentRuntime } from 'src/analysis/utils/runtime-utils';
 import { Ajax } from 'src/libs/ajax';
 import { PersistentDisk } from 'src/libs/ajax/leonardo/models/disk-models';
 import { ListRuntimeItem } from 'src/libs/ajax/leonardo/models/runtime-models';
 import { withErrorIgnoring, withErrorReporting } from 'src/libs/error';
-import { useCancellation, useOnMount } from 'src/libs/react-utils';
+import { useCancellation } from 'src/libs/react-utils';
 import { InitializedWorkspaceWrapper as Workspace } from 'src/pages/workspaces/workspace/useWorkspace';
 
 export interface CloudEnvironmentDetails {
@@ -73,9 +73,10 @@ export const useCloudEnvironmentPolling = (workspace: Workspace): CloudEnvironme
     maybeStale?: boolean
   ) => Promise<void>;
   const refreshRuntimesSilently = withErrorIgnoring(load);
-  useOnMount(() => {
+  useEffect(() => {
     refreshRuntimes();
     return () => clearTimeout(timeout.current);
-  });
+    //  eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workspace]);
   return { runtimes, refreshRuntimes, persistentDisks, appDataDisks };
 };

--- a/src/pages/workspaces/hooks/useCloudEnvironmentPolling.ts
+++ b/src/pages/workspaces/hooks/useCloudEnvironmentPolling.ts
@@ -1,0 +1,81 @@
+import _ from 'lodash/fp';
+import { useRef, useState } from 'react';
+import { getDiskAppType } from 'src/analysis/utils/app-utils';
+import { getConvertedRuntimeStatus, getCurrentRuntime } from 'src/analysis/utils/runtime-utils';
+import { Ajax } from 'src/libs/ajax';
+import { PersistentDisk } from 'src/libs/ajax/leonardo/models/disk-models';
+import { ListRuntimeItem } from 'src/libs/ajax/leonardo/models/runtime-models';
+import { withErrorIgnoring, withErrorReporting } from 'src/libs/error';
+import { useCancellation, useOnMount } from 'src/libs/react-utils';
+import { InitializedWorkspaceWrapper as Workspace } from 'src/pages/workspaces/workspace/useWorkspace';
+
+export interface CloudEnvironmentDetails {
+  runtimes?: ListRuntimeItem[];
+  refreshRuntimes: (maybeStale?: boolean) => Promise<void>;
+  persistentDisks?: PersistentDisk[];
+  appDataDisks?: PersistentDisk[];
+}
+
+export const useCloudEnvironmentPolling = (workspace: Workspace): CloudEnvironmentDetails => {
+  const signal = useCancellation();
+  const timeout = useRef<NodeJS.Timeout>();
+  const [runtimes, setRuntimes] = useState<ListRuntimeItem[]>();
+  const [persistentDisks, setPersistentDisks] = useState<PersistentDisk[]>();
+  const [appDataDisks, setAppDataDisks] = useState<PersistentDisk[]>();
+
+  const saturnWorkspaceNamespace = workspace?.workspace.namespace;
+  const saturnWorkspaceName = workspace?.workspace.name;
+
+  const reschedule = (ms) => {
+    clearTimeout(timeout.current);
+    timeout.current = setTimeout(refreshRuntimesSilently, ms);
+  };
+  const load = async (maybeStale?: boolean): Promise<void> => {
+    try {
+      const cloudEnvFilters = _.pickBy((l) => !_.isUndefined(l), {
+        role: 'creator',
+        saturnWorkspaceName,
+        saturnWorkspaceNamespace,
+      });
+
+      // Disks.list API takes includeLabels to specify which labels to return in the response
+      // Runtimes.listV2 API always returns all labels for a runtime
+      const [newDisks, newRuntimes] = workspace
+        ? await Promise.all([
+            Ajax(signal)
+              .Disks.disksV1()
+              .list({
+                ...cloudEnvFilters,
+                includeLabels: 'saturnApplication,saturnWorkspaceName,saturnWorkspaceNamespace',
+              }),
+            Ajax(signal).Runtimes.listV2(cloudEnvFilters),
+          ])
+        : [[], []];
+
+      setRuntimes(newRuntimes);
+      setAppDataDisks(_.remove((disk) => _.isUndefined(getDiskAppType(disk)), newDisks));
+      setPersistentDisks(_.filter((disk) => _.isUndefined(getDiskAppType(disk)), newDisks));
+      const runtime = getCurrentRuntime(newRuntimes);
+      reschedule(
+        maybeStale ||
+          ['Creating', 'Starting', 'Stopping', 'Updating', 'LeoReconfiguring'].includes(
+            getConvertedRuntimeStatus(runtime) ?? ''
+          )
+          ? 10000
+          : 120000
+      );
+    } catch (error) {
+      reschedule(30000);
+      throw error;
+    }
+  };
+  const refreshRuntimes = withErrorReporting('Error loading cloud environments', load) as (
+    maybeStale?: boolean
+  ) => Promise<void>;
+  const refreshRuntimesSilently = withErrorIgnoring(load);
+  useOnMount(() => {
+    refreshRuntimes();
+    return () => clearTimeout(timeout.current);
+  });
+  return { runtimes, refreshRuntimes, persistentDisks, appDataDisks };
+};

--- a/src/pages/workspaces/hooks/useDeletionPolling.ts
+++ b/src/pages/workspaces/hooks/useDeletionPolling.ts
@@ -1,0 +1,137 @@
+import _ from 'lodash/fp';
+import { useEffect, useState } from 'react';
+import { Ajax } from 'src/libs/ajax';
+import { workspacesStore, workspaceStore } from 'src/libs/state';
+import { pollWithCancellation } from 'src/libs/utils';
+import { WorkspaceState, WorkspaceWrapper as Workspace } from 'src/libs/workspace-utils';
+
+const updateWorkspacesList = (
+  workspaces: Workspace[],
+  workspaceId: string,
+  state: WorkspaceState,
+  errorMessage?: string
+): Workspace[] =>
+  workspaces.map((ws) => {
+    if (ws.workspace.workspaceId === workspaceId) {
+      const update = _.cloneDeep(ws);
+      update.workspace.state = state;
+      update.workspace.errorMessage = errorMessage;
+      return update;
+    }
+    return ws;
+  });
+
+const updateWorkspace = (
+  workspace: Workspace,
+  workspaceId: string,
+  state: WorkspaceState,
+  errorMessage?: string
+): Workspace => {
+  if (workspace.workspace.workspaceId === workspaceId) {
+    const update = _.cloneDeep(workspace);
+    update.workspace.state = state;
+    update.workspace.errorMessage = errorMessage;
+    return update;
+  }
+  return workspace;
+};
+
+export const useDeletetionPolling = (workspaces: Workspace[]) => {
+  // we have to do the signal/abort manually instead of with useCancelable so that the it can be cleaned up in the
+  // this component's useEffect, instead of the useEffect in useCancelable
+  // const workspaces: Workspace[] = useStore<Workspace[]>(workspacesStore)
+  const [controller, setController] = useState(new window.AbortController());
+  const abort = () => {
+    controller.abort();
+    setController(new window.AbortController());
+  };
+
+  useEffect(() => {
+    const checkWorkspaceDeletion = async (workspace: Workspace) => {
+      const doUpdate = (state: WorkspaceState, errorMessage?: string) => {
+        const workspaceId = workspace.workspace.workspaceId;
+        abort();
+        workspacesStore.update((wsList) => updateWorkspacesList(wsList, workspaceId, state, errorMessage));
+        workspaceStore.update((ws) => updateWorkspace(ws, workspaceId, state, errorMessage));
+      };
+
+      try {
+        const wsResp: Workspace = await Ajax(controller.signal)
+          .Workspaces.workspace(workspace.workspace.namespace, workspace.workspace.name)
+          .details(['workspace.state', 'workspace.errorMessage']);
+        const state = wsResp.workspace.state;
+
+        if (state === 'DeleteFailed') {
+          doUpdate(state);
+        }
+      } catch (error) {
+        if (error instanceof Response && error.status === 404) {
+          doUpdate('Deleted');
+        }
+      }
+    };
+    const iterateDeletingWorkspaces = async () => {
+      const deletingWorkspaces = _.filter((ws) => ws?.workspace?.state === 'Deleting', workspaces);
+      for (const ws of deletingWorkspaces) {
+        await checkWorkspaceDeletion(ws);
+      }
+    };
+
+    pollWithCancellation(() => iterateDeletingWorkspaces(), 30000, false, controller.signal);
+    return () => {
+      abort();
+    };
+    //  eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workspaces]); // adding the controller to deps causes a double fire of the effect
+};
+
+// we need a separate implementation of this, because using useDeletetionPolling with a list
+// containing a single workspace in the WorkspaceContainer causes a rendering loop
+export const useSingleWorkspaceDeletetionPolling = (workspace: Workspace) => {
+  const [controller, setController] = useState(new window.AbortController());
+  const abort = () => {
+    controller.abort();
+    setController(new window.AbortController());
+  };
+
+  useEffect(() => {
+    const checkWorkspaceDeletion = async () => {
+      const doUpdate = (state: WorkspaceState, errorMessage?: string) => {
+        const workspaceId = workspace.workspace.workspaceId;
+        abort();
+        workspacesStore.update((wsList) => updateWorkspacesList(wsList, workspaceId, state, errorMessage));
+        workspaceStore.update((ws) => updateWorkspace(ws, workspaceId, state, errorMessage));
+      };
+
+      try {
+        const wsResp: Workspace = await Ajax(controller.signal)
+          .Workspaces.workspace(workspace.workspace.namespace, workspace.workspace.name)
+          .details(['workspace.state', 'workspace.errorMessage']);
+        const state = wsResp.workspace.state;
+
+        if (state === 'DeleteFailed') {
+          doUpdate(state);
+        }
+      } catch (error) {
+        if (error instanceof Response && error.status === 404) {
+          doUpdate('Deleted');
+        }
+      }
+    };
+
+    pollWithCancellation(
+      async () => {
+        if (workspace?.workspace?.state === 'Deleting') {
+          await checkWorkspaceDeletion();
+        }
+      },
+      30000,
+      false,
+      controller.signal
+    );
+    return () => {
+      abort();
+    };
+    //  eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workspace]); // adding the controller to deps causes a double fire of the effect
+};

--- a/src/pages/workspaces/workspace/WorkspaceContainer.test.ts
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.test.ts
@@ -1,9 +1,12 @@
+import { DeepPartial } from '@terra-ui-packages/core-utils';
 import { screen, waitFor, within } from '@testing-library/react';
 import { h } from 'react-hyperscript-helpers';
-import { ErrorCallback } from 'src/libs/error';
+import { Ajax } from 'src/libs/ajax';
 import { goToPath } from 'src/libs/nav';
+import { workspacesStore, workspaceStore } from 'src/libs/state';
+import { WorkspaceWrapper } from 'src/libs/workspace-utils';
 import { WorkspaceContainer } from 'src/pages/workspaces/workspace/WorkspaceContainer';
-import { renderWithAppContexts as render } from 'src/testing/test-utils';
+import { asMockedFn, renderWithAppContexts as render } from 'src/testing/test-utils';
 import { defaultAzureWorkspace, defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
 
 import { InitializedWorkspaceWrapper } from './useWorkspace';
@@ -19,12 +22,37 @@ jest.mock(
 );
 
 type AjaxExports = typeof import('src/libs/ajax');
+type AjaxContract = ReturnType<typeof Ajax>;
+type AjaxWorkspacesContract = AjaxContract['Workspaces'];
+
 jest.mock('src/libs/ajax', (): AjaxExports => {
   return {
     ...jest.requireActual('src/libs/ajax'),
     Ajax: jest.fn(),
   };
 });
+
+type StateExports = typeof import('src/libs/state');
+jest.mock<StateExports>(
+  'src/libs/state',
+  (): StateExports => ({
+    ...jest.requireActual('src/libs/state'),
+    workspaceStore: {
+      get: jest.fn(),
+      set: jest.fn(),
+      reset: jest.fn(),
+      subscribe: jest.fn(),
+      update: jest.fn(),
+    },
+    workspacesStore: {
+      get: jest.fn(),
+      set: jest.fn(),
+      reset: jest.fn(),
+      subscribe: jest.fn(),
+      update: jest.fn(),
+    },
+  })
+);
 
 type WorkspaceMenuExports = typeof import('src/pages/workspaces/workspace/WorkspaceMenu');
 jest.mock<WorkspaceMenuExports>('src/pages/workspaces/workspace/WorkspaceMenu', () => ({
@@ -51,7 +79,6 @@ describe('WorkspaceContainer', () => {
       },
       refresh: () => Promise.resolve(),
       refreshWorkspace: () => {},
-      silentlyRefreshWorkspace: () => Promise.resolve(),
       breadcrumbs: [],
       title: '',
       analysesData: {
@@ -81,7 +108,6 @@ describe('WorkspaceContainer', () => {
       },
       refresh: () => Promise.resolve(),
       refreshWorkspace: () => {},
-      silentlyRefreshWorkspace: () => Promise.resolve(),
       breadcrumbs: [],
       title: '',
       analysesData: {
@@ -123,111 +149,21 @@ describe('WorkspaceContainer', () => {
     expect(screen.queryByRole('alert')).toBeNull();
   });
 
-  xit('polls for a workspace in the process of deleting and redirects when deleted', async () => {
-    // Arrange
-    const pollResponse: Response = new Response(null, { status: 404 });
-    const silentlyRefreshWorkspace = jest.fn().mockImplementation((errorHandling?: ErrorCallback) => {
-      if (errorHandling) {
-        errorHandling(pollResponse);
-      }
-    });
-    const workspace: InitializedWorkspaceWrapper = {
-      ...defaultAzureWorkspace,
-      workspace: {
-        ...defaultAzureWorkspace.workspace,
-        state: 'Deleting',
-      },
-      workspaceInitialized: true,
-    };
-    const props = {
-      namespace: workspace.workspace.namespace,
-      name: workspace.workspace.name,
-      workspace,
-      storageDetails: {
-        googleBucketLocation: '',
-        googleBucketType: '',
-        fetchedGoogleBucketLocation: undefined,
-      },
-      refresh: () => Promise.resolve(),
-      refreshWorkspace: () => {},
-      silentlyRefreshWorkspace,
-      breadcrumbs: [],
-      title: '',
-      analysesData: {
-        refreshApps: () => Promise.resolve(),
-        refreshRuntimes: () => Promise.resolve(),
-      },
-    };
-
-    jest.useFakeTimers();
-
-    // Act
-
-    render(h(WorkspaceContainer, props));
-    // trigger first poll
-    jest.advanceTimersByTime(30000);
-
-    // Assert
-    await waitFor(() => expect(silentlyRefreshWorkspace).toBeCalled());
-    await waitFor(() => expect(goToPath).toBeCalledWith('workspaces'));
-  });
-
-  xit('continues polling when a workspace has not been deleted', async () => {
-    // Arrange
-    const silentlyRefreshWorkspace = jest.fn().mockImplementation(() => Promise.resolve());
-    const workspace: InitializedWorkspaceWrapper = {
-      ...defaultAzureWorkspace,
-      workspace: {
-        ...defaultAzureWorkspace.workspace,
-        state: 'Deleting',
-      },
-      workspaceInitialized: true,
-    };
-    const props = {
-      namespace: workspace.workspace.namespace,
-      name: workspace.workspace.name,
-      workspace,
-      storageDetails: {
-        googleBucketLocation: '',
-        googleBucketType: '',
-        fetchedGoogleBucketLocation: undefined,
-      },
-      refresh: () => Promise.resolve(),
-      refreshWorkspace: () => {},
-      silentlyRefreshWorkspace,
-      breadcrumbs: [],
-      title: '',
-      analysesData: {
-        refreshApps: () => Promise.resolve(),
-        refreshRuntimes: () => Promise.resolve(),
-      },
-    };
-
-    jest.useFakeTimers();
-
-    // Act
-
-    render(h(WorkspaceContainer, props));
-    // trigger polls
-    jest.advanceTimersByTime(30000);
-    await waitFor(() => expect(silentlyRefreshWorkspace).toBeCalledTimes(1));
-    jest.advanceTimersByTime(30000);
-    await waitFor(() => expect(silentlyRefreshWorkspace).toBeCalledTimes(2));
-    jest.advanceTimersByTime(30000);
-
-    // Assert
-    await waitFor(() => expect(silentlyRefreshWorkspace).toBeCalledTimes(3));
-    await waitFor(() => expect(goToPath).not.toBeCalled());
-  });
-
   it('does not poll for a workspace that is not deleting', async () => {
     // Arrange
-    const pollResponse: Response = new Response(null, { status: 404 });
-    const silentlyRefreshWorkspace = jest.fn().mockImplementation((errorHandling?: ErrorCallback) => {
-      if (errorHandling) {
-        errorHandling(pollResponse);
-      }
-    });
+
+    const mockDetailsFn = jest.fn().mockResolvedValue({ state: 'Deleting' });
+
+    const mockAjax: DeepPartial<AjaxContract> = {
+      Workspaces: {
+        workspace: () =>
+          ({
+            details: mockDetailsFn,
+          } as Partial<AjaxWorkspacesContract['workspace']>),
+      },
+    };
+    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+
     const workspace: InitializedWorkspaceWrapper = {
       ...defaultAzureWorkspace,
       workspaceInitialized: true,
@@ -243,7 +179,6 @@ describe('WorkspaceContainer', () => {
       },
       refresh: () => Promise.resolve(),
       refreshWorkspace: () => {},
-      silentlyRefreshWorkspace,
       breadcrumbs: [],
       title: '',
       analysesData: {
@@ -261,6 +196,170 @@ describe('WorkspaceContainer', () => {
     await Promise.resolve();
 
     // Assert
-    expect(silentlyRefreshWorkspace).not.toBeCalled();
+    expect(mockDetailsFn).not.toBeCalled();
+  });
+
+  it('continues polling when a workspace has not been deleted', async () => {
+    // Arrange
+    const workspace: WorkspaceWrapper = {
+      ...defaultAzureWorkspace,
+      workspace: {
+        ...defaultAzureWorkspace.workspace,
+        state: 'Deleting',
+      },
+    };
+    const mockDetailsFn = jest.fn().mockResolvedValue({ state: 'Deleting' });
+
+    const mockAjax: DeepPartial<AjaxContract> = {
+      Workspaces: {
+        workspace: () =>
+          ({
+            details: mockDetailsFn,
+          } as Partial<AjaxWorkspacesContract['workspace']>),
+      },
+    };
+    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+
+    const props = {
+      namespace: workspace.workspace.namespace,
+      name: workspace.workspace.name,
+      workspace: { ...workspace, workspaceInitialized: true },
+      storageDetails: {
+        googleBucketLocation: '',
+        googleBucketType: '',
+        fetchedGoogleBucketLocation: undefined,
+      },
+      refresh: () => Promise.resolve(),
+      refreshWorkspace: () => {},
+      breadcrumbs: [],
+      title: '',
+      analysesData: {
+        refreshApps: () => Promise.resolve(),
+        refreshRuntimes: () => Promise.resolve(),
+      },
+    };
+
+    jest.useFakeTimers();
+
+    // Act
+
+    render(h(WorkspaceContainer, props));
+
+    // trigger polls
+    jest.advanceTimersByTime(30000);
+    await waitFor(() => expect(mockDetailsFn).toBeCalledTimes(1));
+    jest.advanceTimersByTime(30000);
+    await waitFor(() => expect(mockDetailsFn).toBeCalledTimes(2));
+    jest.advanceTimersByTime(30000);
+
+    // Assert
+    await waitFor(() => expect(mockDetailsFn).toBeCalledTimes(3));
+    await waitFor(() => expect(goToPath).not.toBeCalled());
+  });
+
+  it('polls for a workspace in the process of deleting and updates the store when deleted', async () => {
+    // Arrange
+    const mockDetailsFn = jest.fn().mockRejectedValue(new Response(null, { status: 404 }));
+
+    const mockAjax: DeepPartial<AjaxContract> = {
+      Workspaces: {
+        workspace: () =>
+          ({
+            details: mockDetailsFn,
+          } as Partial<AjaxWorkspacesContract['workspace']>),
+      },
+    };
+    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+
+    const workspace: InitializedWorkspaceWrapper = {
+      ...defaultAzureWorkspace,
+      workspace: {
+        ...defaultAzureWorkspace.workspace,
+        state: 'Deleting',
+      },
+      workspaceInitialized: true,
+    };
+
+    const mockUpdateWsFn = asMockedFn(workspaceStore.update);
+    const mockUpdateWsListFn = asMockedFn(workspacesStore.update);
+    mockUpdateWsFn.mockImplementation((updateFn) => {
+      const updated = updateFn(workspace);
+      expect(updated.workspace.state).toBe('Deleted');
+    });
+
+    mockUpdateWsListFn.mockImplementation((updateFn) => {
+      const updated = updateFn([workspace]);
+      expect(updated[0].workspace.state).toBe('Deleted');
+    });
+
+    const props = {
+      namespace: workspace.workspace.namespace,
+      name: workspace.workspace.name,
+      workspace,
+      storageDetails: {
+        googleBucketLocation: '',
+        googleBucketType: '',
+        fetchedGoogleBucketLocation: undefined,
+      },
+      refresh: () => Promise.resolve(),
+      refreshWorkspace: () => {},
+      breadcrumbs: [],
+      title: '',
+      analysesData: {
+        refreshApps: () => Promise.resolve(),
+        refreshRuntimes: () => Promise.resolve(),
+      },
+    };
+
+    jest.useFakeTimers();
+
+    // Act
+
+    render(h(WorkspaceContainer, props));
+    // trigger first poll
+    jest.advanceTimersByTime(30000);
+
+    // Assert
+    await waitFor(() => expect(mockDetailsFn).toBeCalled());
+    await waitFor(() => expect(mockUpdateWsListFn).toBeCalled());
+    await waitFor(() => expect(mockUpdateWsFn).toBeCalled());
+  });
+
+  it('redirects for a deleted workspace', async () => {
+    // Arrange
+    const workspace: InitializedWorkspaceWrapper = {
+      ...defaultAzureWorkspace,
+      workspace: {
+        ...defaultAzureWorkspace.workspace,
+        state: 'Deleted',
+      },
+      workspaceInitialized: true,
+    };
+
+    const props = {
+      namespace: workspace.workspace.namespace,
+      name: workspace.workspace.name,
+      workspace,
+      storageDetails: {
+        googleBucketLocation: '',
+        googleBucketType: '',
+        fetchedGoogleBucketLocation: undefined,
+      },
+      refresh: () => Promise.resolve(),
+      refreshWorkspace: () => {},
+      breadcrumbs: [],
+      title: '',
+      analysesData: {
+        refreshApps: () => Promise.resolve(),
+        refreshRuntimes: () => Promise.resolve(),
+      },
+    };
+
+    // Act
+
+    render(h(WorkspaceContainer, props));
+
+    // Assert
+    await waitFor(() => expect(goToPath).toBeCalledWith('workspaces'));
   });
 });

--- a/src/pages/workspaces/workspace/WorkspaceContainer.ts
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.ts
@@ -24,7 +24,7 @@ import {
   CloudEnvironmentDetails,
   useCloudEnvironmentPolling,
 } from 'src/pages/workspaces/hooks/useCloudEnvironmentPolling';
-import { useSingleWorkspaceDeletetionPolling } from 'src/pages/workspaces/hooks/useDeletionPolling';
+import { useSingleWorkspaceDeletionPolling } from 'src/pages/workspaces/hooks/useDeletionPolling';
 import DeleteWorkspaceModal from 'src/pages/workspaces/workspace/DeleteWorkspaceModal';
 import LockWorkspaceModal from 'src/pages/workspaces/workspace/LockWorkspaceModal';
 import ShareWorkspaceModal from 'src/pages/workspaces/workspace/ShareWorkspaceModal/ShareWorkspaceModal';
@@ -124,7 +124,7 @@ export const WorkspaceContainer = (props: WorkspaceContainerProps) => {
   const isGoogleWorkspaceSyncing =
     workspaceLoaded && isGoogleWorkspace(workspace) && workspace?.workspaceInitialized === false;
 
-  useSingleWorkspaceDeletetionPolling(workspace);
+  useSingleWorkspaceDeletionPolling(workspace);
   useEffect(() => {
     if (workspace?.workspace?.state === 'Deleted') {
       Nav.goToPath('workspaces');

--- a/src/pages/workspaces/workspace/WorkspaceContainer.ts
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.ts
@@ -13,7 +13,6 @@ import TitleBar from 'src/components/TitleBar';
 import TopBar from 'src/components/TopBar';
 import { isTerra } from 'src/libs/brand-utils';
 import colors from 'src/libs/colors';
-import { ErrorCallback } from 'src/libs/error';
 import * as Nav from 'src/libs/nav';
 import { withDisplayName } from 'src/libs/react-utils';
 import { getTerraUser, workspaceStore } from 'src/libs/state';
@@ -100,7 +99,6 @@ interface WorkspaceContainerProps extends PropsWithChildren {
   refresh: () => Promise<void>;
   workspace: Workspace;
   refreshWorkspace: () => void;
-  silentlyRefreshWorkspace: (errorHandling?: ErrorCallback) => Promise<void>;
 }
 
 export const WorkspaceContainer = (props: WorkspaceContainerProps) => {
@@ -296,8 +294,10 @@ export const wrapWorkspace = <T extends WrappedComponentProps>(
       const { namespace, name } = props;
       const child = useRef<unknown>();
 
-      const { workspace, accessError, loadingWorkspace, storageDetails, refreshWorkspace, silentlyRefreshWorkspace } =
-        useWorkspace(namespace, name);
+      const { workspace, accessError, loadingWorkspace, storageDetails, refreshWorkspace } = useWorkspace(
+        namespace,
+        name
+      );
       const { runtimes, refreshRuntimes, persistentDisks, appDataDisks } = useCloudEnvironmentPolling(workspace);
       const { apps, refreshApps } = useAppPolling(workspace);
 
@@ -323,7 +323,6 @@ export const wrapWorkspace = <T extends WrappedComponentProps>(
               child.current.refresh();
             }
           },
-          silentlyRefreshWorkspace,
         },
         [
           workspace &&

--- a/src/pages/workspaces/workspace/WorkspaceContainer.ts
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.ts
@@ -298,8 +298,12 @@ export const wrapWorkspace = <T extends WrappedComponentProps>(
         namespace,
         name
       );
-      const { runtimes, refreshRuntimes, persistentDisks, appDataDisks } = useCloudEnvironmentPolling(workspace);
-      const { apps, refreshApps } = useAppPolling(workspace);
+      const { runtimes, refreshRuntimes, persistentDisks, appDataDisks } = useCloudEnvironmentPolling(
+        name,
+        namespace,
+        workspace
+      );
+      const { apps, refreshApps } = useAppPolling(name, namespace, workspace);
 
       if (accessError) {
         return h(FooterWrapper, [h(TopBar), h(WorkspaceAccessError)]);

--- a/src/pages/workspaces/workspace/WorkspaceContainer.ts
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.ts
@@ -301,12 +301,6 @@ export const wrapWorkspace = <T extends WrappedComponentProps>(
       const { runtimes, refreshRuntimes, persistentDisks, appDataDisks } = useCloudEnvironmentPolling(workspace);
       const { apps, refreshApps } = useAppPolling(workspace);
 
-      // The following is necessary to support the context bar properly loading runtimes for google/azure
-      useEffect(() => {
-        refreshRuntimes(true);
-        refreshApps(true);
-      }, [workspace]); // eslint-disable-line react-hooks/exhaustive-deps
-
       if (accessError) {
         return h(FooterWrapper, [h(TopBar), h(WorkspaceAccessError)]);
       }

--- a/src/pages/workspaces/workspace/useWorkspace.ts
+++ b/src/pages/workspaces/workspace/useWorkspace.ts
@@ -46,13 +46,6 @@ export const useWorkspace = (namespace, name): WorkspaceDetails => {
   const accessNotificationId = useRef();
   const workspace: InitializedWorkspaceWrapper | undefined = useStore<InitializedWorkspaceWrapper>(workspaceStore);
 
-  // reset store first if we need to switch workspaces
-  // this prevents rendering and data fetching based off of a missmatching or stale workspace
-  useEffect(() => {
-    if (!!workspace && (workspace.workspace.name !== name || workspace.workspace.namespace !== namespace)) {
-      workspaceStore.reset();
-    }
-  }, [name, namespace, workspace]);
   const [{ location, locationType, fetchedLocation }, setGoogleStorage] = useState<{
     fetchedLocation: 'SUCCESS' | 'ERROR' | undefined;
     location: string;
@@ -267,7 +260,11 @@ export const useWorkspace = (namespace, name): WorkspaceDetails => {
   };
 
   useEffect(() => {
-    if (!workspace || workspace.workspace.namespace !== namespace || workspace.workspace.name !== name) {
+    if (!workspace) {
+      refreshWorkspace();
+    } else if (workspace.workspace.namespace !== namespace || workspace.workspace.name !== name) {
+      // if the workspace is missmatched, clear store before fetching workspace
+      workspaceStore.reset();
       refreshWorkspace();
     } else {
       checkWorkspaceInitialization(workspace);

--- a/src/pages/workspaces/workspace/useWorkspace.ts
+++ b/src/pages/workspaces/workspace/useWorkspace.ts
@@ -70,10 +70,10 @@ export const useWorkspace = (namespace, name): WorkspaceDetails => {
     setController(new window.AbortController());
   };
   const signal = controller.signal;
-  // const signal = useCancellation();
   const checkInitializationTimeout = useRef<number>();
 
   const updateWorkspaceInStore = (workspace, initialized) => {
+    // clone the workspace to force React to re-render components that depend on workspace
     const update = _.clone(workspace);
     update.workspaceInitialized = initialized;
     workspaceStore.set(update);


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WOR-1327

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
* Add separate hook to poll for deletion state for dashboard
* Update other dashboard hooks (`useAppPolling`, `useCloudEnvironmentPolling`, `useWorkspace`) to cancel API calls correctly, and initiate calls based on the correct dependencies
* started moving some hooks to a dedicated folder. I didn't move all of them because it drastically increased the size of the diff, and I wanted to keep this PR more focused, for readability purposed
### Testing strategy
- [ ] Unit tests
- [ ] Manually tested behavior of dashboard when deleting
- [ ] Manually observed behavior of API calls under a variety of circumstances to ensure the correct number of API calls were being initiated (refreshing the dashboard, navigating to the dashboard from links, manually entering url from the dashboard of a different workspace, and of course while polling for deletion. I don't see a good way of writing unit tests for this behavior, given that it relies on relatively complex state interactions, and external api calls.

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 
