### PR TITLE
[AJ-1303] Show message and animation while creating workspace

### DIFF
--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -8,6 +8,7 @@ export * from './hooks/useWindowDimensions';
 export * from './icon';
 export type { IconId } from './icon-library';
 export * from './InfoBox';
+export * from './injectStyle';
 export { Interactive } from './Interactive';
 export * from './Link';
 export * from './Modal';

--- a/packages/components/src/injectStyle.ts
+++ b/packages/components/src/injectStyle.ts
@@ -1,3 +1,8 @@
+/**
+ * Add a CSS stylesheet to the document.
+ *
+ * @param css - The CSS.
+ */
 export const injectStyle = (css: string): void => {
   const style = document.createElement('style');
   style.appendChild(document.createTextNode(css));

--- a/src/branding/TerraHexagonsAnimation.ts
+++ b/src/branding/TerraHexagonsAnimation.ts
@@ -1,0 +1,93 @@
+import { injectStyle } from '@terra-ui-packages/components';
+import { CSSProperties, ReactNode } from 'react';
+import { div } from 'react-hyperscript-helpers';
+
+type DivProps = JSX.IntrinsicElements['div'];
+
+export interface TerraHexagonsAnimationProps extends DivProps {
+  size?: number;
+}
+
+injectStyle(`
+@keyframes terraRockingHexagon {
+  from {
+    transform: rotate(-20deg);
+  }
+  to {
+    transform: rotate(10deg);
+  }
+}
+`);
+
+const hexStyle: CSSProperties = {
+  position: 'absolute',
+  borderRadius: '100%',
+  animation: 'terraRockingHexagon .9s ease-in-out infinite',
+  clipPath: 'polygon(25% 5%, 75% 5%, 100% 50%, 75% 95%, 25% 95%, 0% 50%)',
+  rotate: '90deg',
+};
+
+export const TerraHexagonsAnimation = (props: TerraHexagonsAnimationProps): ReactNode => {
+  const { children, size = 125, style, ...otherProps } = props;
+
+  return div(
+    {
+      ...otherProps,
+      style: {
+        ...style,
+        position: 'relative',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        height: size,
+        width: size,
+      },
+    },
+    [
+      div({
+        style: {
+          ...hexStyle,
+          height: size,
+          width: size,
+          backgroundColor: '#359348',
+          animationDirection: 'alternate-reverse',
+        },
+      }),
+
+      div({
+        style: {
+          ...hexStyle,
+          height: size * 0.825,
+          width: size * 0.825,
+          backgroundColor: '#73ad43',
+          animationDirection: 'alternate',
+        },
+      }),
+
+      div({
+        style: {
+          ...hexStyle,
+          height: size * 0.65,
+          width: size * 0.65,
+          backgroundColor: '#afd139',
+          animationDirection: 'alternate-reverse',
+        },
+      }),
+
+      !!children &&
+        div(
+          {
+            style: {
+              // Position children above the hexagons.
+              // z-index is necessary here because the hexagons have clip-path and transform styles
+              // which create new stacking contexts.
+              zIndex: 1,
+              color: '#3b5822',
+              fontWeight: 'bold',
+            },
+          },
+          [children]
+        ),
+    ]
+  );
+};

--- a/src/components/NewWorkspaceModal.ts
+++ b/src/components/NewWorkspaceModal.ts
@@ -36,6 +36,7 @@ import {
   WorkspaceWrapper,
 } from 'src/libs/workspace-utils';
 import { BillingProject, CloudPlatform } from 'src/pages/billing/models/BillingProject';
+import { CreatingWorkspaceMessage } from 'src/workspaces/NewWorkspaceModal/CreatingWorkspaceMessage';
 import validate from 'validate.js';
 
 const warningStyle: CSSProperties = {
@@ -288,6 +289,10 @@ const NewWorkspaceModal = withDisplayName(
                 [!!cloneWorkspace, () => 'Clone this workspace'],
                 () => 'Create a New Workspace'
               ),
+              // Hold modal open while waiting for create workspace request.
+              shouldCloseOnOverlayClick: !creating,
+              shouldCloseOnEsc: !creating,
+              showButtons: !creating,
               onDismiss,
               okButton: h(
                 ButtonPrimary,
@@ -306,276 +311,288 @@ const NewWorkspaceModal = withDisplayName(
               ),
             },
             [
-              h(IdContainer, [
-                (id) =>
-                  h(Fragment, [
-                    h(FormLabel, { htmlFor: id, required: true }, ['Workspace name']),
-                    h(ValidatedInput, {
-                      inputProps: {
-                        id,
-                        autoFocus: true,
-                        placeholder: 'Enter a name',
-                        value: name,
-                        onChange: (v) => {
-                          setName(v);
-                          setNameModified(true);
-                        },
-                      },
-                      error: Utils.summarizeErrors(nameModified && errors?.name),
-                    }),
-                  ]),
-              ]),
-              h(IdContainer, [
-                (id) =>
-                  h(Fragment, [
-                    h(FormLabel, { htmlFor: id, required: true }, ['Billing project']),
-                    h(Select<string>, {
-                      id,
-                      isClearable: false,
-                      placeholder: 'Select a billing project',
-                      value: namespace || null,
-                      ariaLiveMessages: { onFocus: onFocusAria, onChange: onChangeAria },
-                      onChange: (opt) => setNamespace(opt!.value),
-                      styles: { option: (provided) => ({ ...provided, padding: 10 }) },
-                      // @ts-expect-error
-                      options: _.map(
-                        ({ projectName, invalidBillingAccount, cloudPlatform }: BillingProject) => ({
-                          'aria-label': `${
-                            cloudProviderLabels[cloudPlatform]
-                          } ${projectName}${ariaInvalidBillingAccountMsg(invalidBillingAccount)}`,
-                          label: h(
-                            TooltipTrigger,
-                            {
-                              content: invalidBillingAccount && invalidBillingAccountMsg,
-                              side: 'left',
+              creating
+                ? h(CreatingWorkspaceMessage)
+                : h(Fragment, [
+                    h(IdContainer, [
+                      (id) =>
+                        h(Fragment, [
+                          h(FormLabel, { htmlFor: id, required: true }, ['Workspace name']),
+                          h(ValidatedInput, {
+                            inputProps: {
+                              id,
+                              autoFocus: true,
+                              placeholder: 'Enter a name',
+                              value: name,
+                              onChange: (v) => {
+                                setName(v);
+                                setNameModified(true);
+                              },
                             },
-                            [
-                              div({ style: { display: 'flex', alignItems: 'center' } }, [
-                                (cloudPlatform === 'GCP' || cloudPlatform === 'AZURE') &&
-                                  h(CloudProviderIcon, {
-                                    key: projectName,
-                                    cloudProvider: cloudPlatform,
-                                    style: { marginRight: '0.5rem' },
-                                  }),
-                                projectName,
+                            error: Utils.summarizeErrors(nameModified && errors?.name),
+                          }),
+                        ]),
+                    ]),
+                    h(IdContainer, [
+                      (id) =>
+                        h(Fragment, [
+                          h(FormLabel, { htmlFor: id, required: true }, ['Billing project']),
+                          h(Select<string>, {
+                            id,
+                            isClearable: false,
+                            placeholder: 'Select a billing project',
+                            value: namespace || null,
+                            ariaLiveMessages: { onFocus: onFocusAria, onChange: onChangeAria },
+                            onChange: (opt) => setNamespace(opt!.value),
+                            styles: { option: (provided) => ({ ...provided, padding: 10 }) },
+                            // @ts-expect-error
+                            options: _.map(
+                              ({ projectName, invalidBillingAccount, cloudPlatform }: BillingProject) => ({
+                                'aria-label': `${
+                                  cloudProviderLabels[cloudPlatform]
+                                } ${projectName}${ariaInvalidBillingAccountMsg(invalidBillingAccount)}`,
+                                label: h(
+                                  TooltipTrigger,
+                                  {
+                                    content: invalidBillingAccount && invalidBillingAccountMsg,
+                                    side: 'left',
+                                  },
+                                  [
+                                    div({ style: { display: 'flex', alignItems: 'center' } }, [
+                                      (cloudPlatform === 'GCP' || cloudPlatform === 'AZURE') &&
+                                        h(CloudProviderIcon, {
+                                          key: projectName,
+                                          cloudProvider: cloudPlatform,
+                                          style: { marginRight: '0.5rem' },
+                                        }),
+                                      projectName,
+                                    ]),
+                                  ]
+                                ),
+                                value: projectName,
+                                isDisabled: invalidBillingAccount,
+                              }),
+                              _.sortBy(
+                                'projectName',
+                                _.uniq(cloudPlatform ? _.filter({ cloudPlatform }, billingProjects) : billingProjects)
+                              )
+                            ),
+                          }),
+                        ]),
+                    ]),
+                    isGoogleBillingProject() &&
+                      h(IdContainer, [
+                        (id) =>
+                          h(Fragment, [
+                            h(FormLabel, { htmlFor: id }, [
+                              'Bucket location',
+                              h(InfoBox, { style: { marginLeft: '0.25rem' } }, [
+                                'A bucket location can only be set when creating a workspace. ',
+                                'Once set, it cannot be changed. ',
+                                'A cloned workspace will automatically inherit the bucket location from the original workspace but this may be changed at clone time.',
+                                p([
+                                  'By default, workflow and Cloud Environments will run in the same region as the workspace bucket. ',
+                                  'Changing bucket or Cloud Environment locations from the defaults can lead to network egress charges.',
+                                ]),
+                                h(
+                                  Link,
+                                  {
+                                    href: 'https://support.terra.bio/hc/en-us/articles/360058964552',
+                                    ...Utils.newTabLinkProps,
+                                  },
+                                  ['Read more about bucket locations']
+                                ),
                               ]),
-                            ]
-                          ),
-                          value: projectName,
-                          isDisabled: invalidBillingAccount,
-                        }),
-                        _.sortBy(
-                          'projectName',
-                          _.uniq(cloudPlatform ? _.filter({ cloudPlatform }, billingProjects) : billingProjects)
-                        )
-                      ),
-                    }),
-                  ]),
-              ]),
-              isGoogleBillingProject() &&
-                h(IdContainer, [
-                  (id) =>
-                    h(Fragment, [
-                      h(FormLabel, { htmlFor: id }, [
-                        'Bucket location',
-                        h(InfoBox, { style: { marginLeft: '0.25rem' } }, [
-                          'A bucket location can only be set when creating a workspace. ',
-                          'Once set, it cannot be changed. ',
-                          'A cloned workspace will automatically inherit the bucket location from the original workspace but this may be changed at clone time.',
-                          p([
-                            'By default, workflow and Cloud Environments will run in the same region as the workspace bucket. ',
-                            'Changing bucket or Cloud Environment locations from the defaults can lead to network egress charges.',
+                            ]),
+                            h(Select<string>, {
+                              id,
+                              value: bucketLocation,
+                              onChange: (opt) => setBucketLocation(opt!.value),
+                              options: isAlphaRegionalityUser ? allRegions : availableBucketRegions,
+                            }),
                           ]),
+                      ]),
+                    isLocationMultiRegion(bucketLocation) &&
+                      div({ style: { ...warningStyle } }, [
+                        icon('warning-standard', {
+                          size: 24,
+                          style: { color: colors.warning(), flex: 'none', marginRight: '0.5rem' },
+                        }),
+                        div({ style: { flex: 1 } }, [
+                          'Effective October 1, 2022, Google Cloud will charge egress fees on data stored in multi-region storage buckets.',
+                          p([
+                            'Choosing a multi-region bucket location may result in additional storage costs for your workspace.',
+                          ]),
+                          p([
+                            'Unless you require geo-redundancy for maximum availabity for your data, you should choose a single region bucket location.',
+                            h(
+                              Link,
+                              {
+                                href: 'https://terra.bio/moving-away-from-multi-regional-storage-buckets',
+                                ...Utils.newTabLinkProps,
+                              },
+                              [
+                                ' For more information see this blog post.',
+                                icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } }),
+                              ]
+                            ),
+                          ]),
+                        ]),
+                      ]),
+                    shouldShowDifferentRegionWarning() &&
+                      div({ style: { ...warningStyle } }, [
+                        icon('warning-standard', {
+                          size: 24,
+                          style: { color: colors.warning(), flex: 'none', marginRight: '0.5rem' },
+                        }),
+                        div({ style: { flex: 1 } }, [
+                          'Copying data from ',
+                          strong([getRegionInfo(sourceWorkspaceLocation, sourceLocationType).regionDescription]),
+                          ' to ',
+                          strong([getRegionInfo(bucketLocation, destLocationType).regionDescription]),
+                          ' may incur network egress charges. ',
+                          'To prevent charges, the new bucket location needs to stay in the same region as the original one. ',
                           h(
                             Link,
                             {
                               href: 'https://support.terra.bio/hc/en-us/articles/360058964552',
                               ...Utils.newTabLinkProps,
                             },
-                            ['Read more about bucket locations']
+                            [
+                              'For more information please read the documentation.',
+                              icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } }),
+                            ]
                           ),
                         ]),
                       ]),
-                      h(Select<string>, {
-                        id,
-                        value: bucketLocation,
-                        onChange: (opt) => setBucketLocation(opt!.value),
-                        options: isAlphaRegionalityUser ? allRegions : availableBucketRegions,
-                      }),
-                    ]),
-                ]),
-              isLocationMultiRegion(bucketLocation) &&
-                div({ style: { ...warningStyle } }, [
-                  icon('warning-standard', {
-                    size: 24,
-                    style: { color: colors.warning(), flex: 'none', marginRight: '0.5rem' },
-                  }),
-                  div({ style: { flex: 1 } }, [
-                    'Effective October 1, 2022, Google Cloud will charge egress fees on data stored in multi-region storage buckets.',
-                    p([
-                      'Choosing a multi-region bucket location may result in additional storage costs for your workspace.',
-                    ]),
-                    p([
-                      'Unless you require geo-redundancy for maximum availabity for your data, you should choose a single region bucket location.',
-                      h(
-                        Link,
-                        {
-                          href: 'https://terra.bio/moving-away-from-multi-regional-storage-buckets',
-                          ...Utils.newTabLinkProps,
-                        },
-                        [
-                          ' For more information see this blog post.',
-                          icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } }),
-                        ]
-                      ),
-                    ]),
-                  ]),
-                ]),
-              shouldShowDifferentRegionWarning() &&
-                div({ style: { ...warningStyle } }, [
-                  icon('warning-standard', {
-                    size: 24,
-                    style: { color: colors.warning(), flex: 'none', marginRight: '0.5rem' },
-                  }),
-                  div({ style: { flex: 1 } }, [
-                    'Copying data from ',
-                    strong([getRegionInfo(sourceWorkspaceLocation, sourceLocationType).regionDescription]),
-                    ' to ',
-                    strong([getRegionInfo(bucketLocation, destLocationType).regionDescription]),
-                    ' may incur network egress charges. ',
-                    'To prevent charges, the new bucket location needs to stay in the same region as the original one. ',
-                    h(
-                      Link,
-                      { href: 'https://support.terra.bio/hc/en-us/articles/360058964552', ...Utils.newTabLinkProps },
-                      [
-                        'For more information please read the documentation.',
-                        icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } }),
-                      ]
-                    ),
-                  ]),
-                ]),
-              h(IdContainer, [
-                (id) =>
-                  h(Fragment, [
-                    h(FormLabel, { htmlFor: id }, ['Description']),
-                    h(TextArea, {
-                      id,
-                      style: { height: 100 },
-                      placeholder: 'Enter a description',
-                      value: description,
-                      onChange: setDescription,
-                    }),
-                  ]),
-              ]),
-              isGoogleBillingProject() &&
-                div({ style: { margin: '1rem 0.25rem 0.25rem 0' } }, [
-                  h(IdContainer, [
-                    (id) =>
-                      h(Fragment, [
-                        h(
-                          LabeledCheckbox,
-                          {
-                            style: { margin: '0rem 0.25rem 0.25rem 0' },
-                            checked: enhancedBucketLogging,
-                            disabled: !!requireEnhancedBucketLogging || groups.length > 0,
-                            onChange: () => setEnhancedBucketLogging(!enhancedBucketLogging),
-                            'aria-describedby': id,
-                          },
-                          [
-                            label({ style: { ...Style.elements.sectionHeader } }, [
-                              'Workspace will have protected data',
-                            ]),
-                          ]
-                        ),
-                        h(InfoBox, { style: { marginLeft: '0.25rem', verticalAlign: 'middle' } }, [
-                          'If checked, Terra will log all data access requests to the workspace bucket. ' +
-                            'This feature is automatically enabled when a workspace is created with Authorization Domains.',
+                    h(IdContainer, [
+                      (id) =>
+                        h(Fragment, [
+                          h(FormLabel, { htmlFor: id }, ['Description']),
+                          h(TextArea, {
+                            id,
+                            style: { height: 100 },
+                            placeholder: 'Enter a description',
+                            value: description,
+                            onChange: setDescription,
+                          }),
                         ]),
-                        p({ id, style: { marginTop: '.25rem' } }, ['Access to data will be logged by Terra']),
+                    ]),
+                    isGoogleBillingProject() &&
+                      div({ style: { margin: '1rem 0.25rem 0.25rem 0' } }, [
+                        h(IdContainer, [
+                          (id) =>
+                            h(Fragment, [
+                              h(
+                                LabeledCheckbox,
+                                {
+                                  style: { margin: '0rem 0.25rem 0.25rem 0' },
+                                  checked: enhancedBucketLogging,
+                                  disabled: !!requireEnhancedBucketLogging || groups.length > 0,
+                                  onChange: () => setEnhancedBucketLogging(!enhancedBucketLogging),
+                                  'aria-describedby': id,
+                                },
+                                [
+                                  label({ style: { ...Style.elements.sectionHeader } }, [
+                                    'Workspace will have protected data',
+                                  ]),
+                                ]
+                              ),
+                              h(InfoBox, { style: { marginLeft: '0.25rem', verticalAlign: 'middle' } }, [
+                                'If checked, Terra will log all data access requests to the workspace bucket. ' +
+                                  'This feature is automatically enabled when a workspace is created with Authorization Domains.',
+                              ]),
+                              p({ id, style: { marginTop: '.25rem' } }, ['Access to data will be logged by Terra']),
+                            ]),
+                        ]),
                       ]),
-                  ]),
-                ]),
-              isGoogleBillingProject() &&
-                h(IdContainer, [
-                  (id) =>
-                    h(Fragment, [
-                      h(FormLabel, { htmlFor: id }, [
-                        'Authorization domain (optional)',
-                        h(InfoBox, { style: { marginLeft: '0.25rem' } }, [
-                          'An authorization domain can only be set when creating a workspace. ',
-                          'Once set, it cannot be changed. ',
-                          'Any cloned workspace will automatically inherit the authorization domain(s) from the original workspace and cannot be removed. ',
+                    isGoogleBillingProject() &&
+                      h(IdContainer, [
+                        (id) =>
+                          h(Fragment, [
+                            h(FormLabel, { htmlFor: id }, [
+                              'Authorization domain (optional)',
+                              h(InfoBox, { style: { marginLeft: '0.25rem' } }, [
+                                'An authorization domain can only be set when creating a workspace. ',
+                                'Once set, it cannot be changed. ',
+                                'Any cloned workspace will automatically inherit the authorization domain(s) from the original workspace and cannot be removed. ',
+                                h(
+                                  Link,
+                                  {
+                                    href: 'https://support.terra.bio/hc/en-us/articles/360026775691',
+                                    ...Utils.newTabLinkProps,
+                                  },
+                                  ['Read more about authorization domains']
+                                ),
+                              ]),
+                            ]),
+                            p({ style: { marginTop: '.25rem' } }, ['Additional group management controls']),
+                            !!existingGroups.length &&
+                              div({ style: { marginBottom: '0.5rem', fontSize: 12 } }, [
+                                div({ style: { marginBottom: '0.2rem' } }, ['Inherited groups:']),
+                                ...existingGroups.join(', '),
+                              ]),
+                            h(Select<string, true>, {
+                              id,
+                              isClearable: false,
+                              isMulti: true,
+                              placeholder: 'Select groups',
+                              isDisabled: !allGroups || !billingProjects,
+                              value: groups,
+                              onChange: (data) => {
+                                setGroups(_.map('value', data));
+                                setEnhancedBucketLogging(!!requireEnhancedBucketLogging || data.length > 0);
+                              },
+                              options: _.difference(_.uniq(_.map('groupName', allGroups)), existingGroups).sort(),
+                            }),
+                          ]),
+                      ]),
+                    customMessage && div({ style: { marginTop: '1rem', lineHeight: '1.5rem' } }, [customMessage]),
+                    workflowImport &&
+                      azureBillingProjectsExist &&
+                      div({ style: { paddingTop: '1.0rem', display: 'flex' } }, [
+                        icon('info-circle', { size: 16, style: { marginRight: '0.5rem', color: colors.accent() } }),
+                        div([
+                          'Importing directly into new Azure workspaces is not currently supported. To create a new workspace with an Azure billing project, visit the main ',
                           h(
                             Link,
                             {
-                              href: 'https://support.terra.bio/hc/en-us/articles/360026775691',
+                              href: Nav.getLink('workspaces'),
+                            },
+                            ['Workspaces']
+                          ),
+                          ' page.',
+                        ]),
+                      ]),
+                    isAzureBillingProject() &&
+                      div({ style: { paddingTop: '1.0rem', display: 'flex' } }, [
+                        icon('warning-standard', {
+                          size: 16,
+                          style: { marginRight: '0.5rem', color: colors.warning() },
+                        }),
+                        div([
+                          'Creating a workspace currently costs about $5 per day. ',
+                          h(
+                            Link,
+                            {
+                              href: 'https://support.terra.bio/hc/en-us/articles/12029087819291',
                               ...Utils.newTabLinkProps,
                             },
-                            ['Read more about authorization domains']
+                            [
+                              'Learn more and follow changes',
+                              icon('pop-out', { size: 14, style: { marginLeft: '0.25rem' } }),
+                            ]
                           ),
                         ]),
                       ]),
-                      p({ style: { marginTop: '.25rem' } }, ['Additional group management controls']),
-                      !!existingGroups.length &&
-                        div({ style: { marginBottom: '0.5rem', fontSize: 12 } }, [
-                          div({ style: { marginBottom: '0.2rem' } }, ['Inherited groups:']),
-                          ...existingGroups.join(', '),
-                        ]),
-                      h(Select<string, true>, {
-                        id,
-                        isClearable: false,
-                        isMulti: true,
-                        placeholder: 'Select groups',
-                        isDisabled: !allGroups || !billingProjects,
-                        value: groups,
-                        onChange: (data) => {
-                          setGroups(_.map('value', data));
-                          setEnhancedBucketLogging(!!requireEnhancedBucketLogging || data.length > 0);
+                    createError &&
+                      div(
+                        {
+                          style: { marginTop: '1rem', color: colors.danger() },
                         },
-                        options: _.difference(_.uniq(_.map('groupName', allGroups)), existingGroups).sort(),
-                      }),
-                    ]),
-                ]),
-              customMessage && div({ style: { marginTop: '1rem', lineHeight: '1.5rem' } }, [customMessage]),
-              workflowImport &&
-                azureBillingProjectsExist &&
-                div({ style: { paddingTop: '1.0rem', display: 'flex' } }, [
-                  icon('info-circle', { size: 16, style: { marginRight: '0.5rem', color: colors.accent() } }),
-                  div([
-                    'Importing directly into new Azure workspaces is not currently supported. To create a new workspace with an Azure billing project, visit the main ',
-                    h(
-                      Link,
-                      {
-                        href: Nav.getLink('workspaces'),
-                      },
-                      ['Workspaces']
-                    ),
-                    ' page.',
+                        [createError]
+                      ),
                   ]),
-                ]),
-              isAzureBillingProject() &&
-                div({ style: { paddingTop: '1.0rem', display: 'flex' } }, [
-                  icon('warning-standard', { size: 16, style: { marginRight: '0.5rem', color: colors.warning() } }),
-                  div([
-                    'Creating a workspace currently costs about $5 per day. ',
-                    h(
-                      Link,
-                      {
-                        href: 'https://support.terra.bio/hc/en-us/articles/12029087819291',
-                        ...Utils.newTabLinkProps,
-                      },
-                      ['Learn more and follow changes', icon('pop-out', { size: 14, style: { marginLeft: '0.25rem' } })]
-                    ),
-                  ]),
-                ]),
-              createError &&
-                div(
-                  {
-                    style: { marginTop: '1rem', color: colors.danger() },
-                  },
-                  [createError]
-                ),
-              creating && spinnerOverlay,
             ]
           ),
       ],

--- a/src/testing/test-utils.ts
+++ b/src/testing/test-utils.ts
@@ -133,7 +133,7 @@ export class SelectHelper {
     return optionLabels;
   }
 
-  async selectOption(optionLabel: string): Promise<void> {
+  async selectOption(optionLabel: string | RegExp): Promise<void> {
     await this.openMenu();
     const listboxId = this.inputElement.getAttribute('aria-controls')!;
     const listBox = document.getElementById(listboxId)!;

--- a/src/workspaces/NewWorkspaceModal/CreatingWorkspaceMessage.ts
+++ b/src/workspaces/NewWorkspaceModal/CreatingWorkspaceMessage.ts
@@ -1,0 +1,33 @@
+import { ReactNode } from 'react';
+import { div, h, p } from 'react-hyperscript-helpers';
+import { TerraHexagonsAnimation } from 'src/branding/TerraHexagonsAnimation';
+
+export const CreatingWorkspaceMessage = (): ReactNode => {
+  return div(
+    {
+      style: {
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+      },
+    },
+    [
+      h(TerraHexagonsAnimation, { 'aria-hidden': true, size: 150, style: { margin: '2rem 0' } }, [
+        div(
+          {
+            style: {
+              color: '#225C00',
+              fontWeight: 'bold',
+            },
+          },
+          ['Loading...']
+        ),
+      ]),
+      div({ role: 'alert', style: { marginBottom: '2rem', textAlign: 'center' } }, [
+        p({ style: { fontWeight: 'bold' } }, ['Please stand by...']),
+        p(["Creating and provisioning your workspace. Once it's ready, Terra will take you there."]),
+        p(['This may take a few minutes.']),
+      ]),
+    ]
+  );
+};


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1303

Currently, the new workspace modal shows a spinner while creating a workspace. This expands on that to show a more elaborate loading animation and a message while creating the workspace.

![Screenshot 2023-11-07 at 12 32 03 PM](https://github.com/DataBiosphere/terra-ui/assets/1156625/2ed5412f-ba9d-44f0-8837-9a30f0012867)

When importing data into Terra, we provide an option to create a new workspace. Currently, the user has to wait for the workspace to create and then the import can proceed. However, for Azure workspaces, they also have to wait for WDS to spin up. For that case, we want to include spinning up WDS in the "creating workspace" step. Since users will be waiting for significantly longer in that case, we wanted to provide additional feedback about what's going on.

For reviewers, the diff to NewWorkspaceModal is much smaller with whitespace changes ignored: https://github.com/DataBiosphere/terra-ui/pull/4429/files?w=1.