### PR TITLE
WM-2303, WM-2341: Workflows user metrics

### DIFF
--- a/src/libs/events.test.ts
+++ b/src/libs/events.test.ts
@@ -51,6 +51,7 @@ describe('extractWorkspaceDetails', () => {
       workspaceNamespace: protectedAzureWorkspace.workspace.namespace,
       cloudPlatform: 'AZURE',
       hasProtectedData: true,
+      workspaceAccessLevel: 'OWNER',
     });
   });
 });

--- a/src/libs/events.test.ts
+++ b/src/libs/events.test.ts
@@ -38,6 +38,7 @@ describe('extractWorkspaceDetails', () => {
       workspaceNamespace: defaultGoogleWorkspace.workspace.namespace,
       cloudPlatform: 'GCP',
       hasProtectedData: false,
+      workspaceAccessLevel: 'OWNER',
     });
   });
 

--- a/src/libs/events.ts
+++ b/src/libs/events.ts
@@ -118,6 +118,7 @@ const eventsList = {
   workflowRerun: 'workflow:rerun',
   workflowUploadIO: 'workflow:uploadIO',
   workflowUseDefaultOutputs: 'workflow:useDefaultOutputs',
+  workflowsAppImport: 'workflowsApp:import',
   workflowsAppLaunchWorkflow: 'workflowsApp:launchWorkflow',
   workspaceClone: 'workspace:clone',
   workspaceCreate: 'workspace:create',

--- a/src/libs/events.ts
+++ b/src/libs/events.ts
@@ -2,7 +2,12 @@ import _ from 'lodash/fp';
 import { ReactNode, useEffect } from 'react';
 import { Ajax } from 'src/libs/ajax';
 import { useRoute } from 'src/libs/nav';
-import { containsProtectedDataPolicy, WorkspaceInfo, WorkspaceWrapper } from 'src/libs/workspace-utils';
+import {
+  containsProtectedDataPolicy,
+  WorkspaceAccessLevel,
+  WorkspaceInfo,
+  WorkspaceWrapper,
+} from 'src/libs/workspace-utils';
 
 /*
  * NOTE: In order to show up in reports, new events MUST be marked as expected in the Mixpanel
@@ -170,6 +175,7 @@ export type EventWorkspaceAttributes =
   | {
       workspace: Pick<WorkspaceInfo, 'namespace' | 'name' | 'cloudPlatform'>;
       policies?: WorkspaceWrapper['policies'];
+      accessLevel?: WorkspaceWrapper['accessLevel'];
     }
   // A WorkspaceInfo object, from which it extracts a few fields.
   | Pick<WorkspaceInfo, 'namespace' | 'name' | 'cloudPlatform'>
@@ -182,6 +188,7 @@ export interface EventWorkspaceDetails {
   workspaceName: string;
   cloudPlatform?: string;
   hasProtectedData?: boolean;
+  workspaceAccessLevel?: WorkspaceAccessLevel;
 }
 
 /**
@@ -193,6 +200,7 @@ export const extractWorkspaceDetails = (workspaceObject: EventWorkspaceAttribute
   // If a WorkspaceWrapper is provided, get the inner WorkspaceInfo. Otherwise, use the provided object directly.
   const workspaceDetails = 'workspace' in workspaceObject ? workspaceObject.workspace : workspaceObject;
   const { name, namespace, cloudPlatform } = workspaceDetails;
+  const accessLevel = 'accessLevel' in workspaceObject ? workspaceObject.accessLevel : undefined;
 
   // Policies are only available if a WorkspaceWrapper object is passed.
   // For other types of input, whether the workspace has protected data is unknown.
@@ -202,6 +210,7 @@ export const extractWorkspaceDetails = (workspaceObject: EventWorkspaceAttribute
   return {
     workspaceNamespace: namespace,
     workspaceName: name,
+    workspaceAccessLevel: accessLevel,
     cloudPlatform: cloudPlatform ? cloudPlatform.toUpperCase() : undefined,
     hasProtectedData,
   };

--- a/src/libs/workspace-utils.ts
+++ b/src/libs/workspace-utils.ts
@@ -26,6 +26,7 @@ export type AuthorizationDomain = {
 interface BaseWorkspaceInfo {
   namespace: string;
   name: string;
+  accessLevel: string;
   workspaceId: string;
   authorizationDomain: AuthorizationDomain[];
   createdDate: string;

--- a/src/libs/workspace-utils.ts
+++ b/src/libs/workspace-utils.ts
@@ -26,7 +26,6 @@ export type AuthorizationDomain = {
 interface BaseWorkspaceInfo {
   namespace: string;
   name: string;
-  accessLevel: string;
   workspaceId: string;
   authorizationDomain: AuthorizationDomain[];
   createdDate: string;

--- a/src/workflows-app/components/ImportGithub.js
+++ b/src/workflows-app/components/ImportGithub.js
@@ -4,7 +4,9 @@ import { ButtonPrimary } from 'src/components/common';
 import { icon } from 'src/components/icons';
 import { ValidatedInput } from 'src/components/input';
 import { TooltipCell } from 'src/components/table';
+import { useMetricsEvent } from 'src/libs/ajax/metrics/useMetrics';
 import colors from 'src/libs/colors';
+import Events, { extractWorkspaceDetails } from 'src/libs/events';
 import { FormLabel } from 'src/libs/forms';
 import * as Utils from 'src/libs/utils';
 import { withBusyState } from 'src/libs/utils';
@@ -53,6 +55,7 @@ const ImportGithub = ({ setLoading, signal, workspace, name, namespace, setSelec
     setSuccessfulImport(false);
     setErrorMessage(JSON.stringify(error instanceof Response ? await error.text() : error, null, 2));
   };
+  const { captureEvent } = useMetricsEvent();
   return div({ style: { display: 'flex', flexDirection: 'column', flexGrow: 1, margin: '1rem 2rem' } }, [
     h2({ style: { marginTop: 0 } }, ['Import a workflow']),
     'Options to add workflows via a link or adding a script.',
@@ -109,6 +112,13 @@ const ImportGithub = ({ setLoading, signal, workspace, name, namespace, setSelec
                 method_url: methodUrl,
                 method_source: 'GitHub',
               };
+              captureEvent(Events.workflowsAppImport, {
+                ...extractWorkspaceDetails(workspace),
+                workflowSource: 'GitHub',
+                workflowName: methodName,
+                workflowUrl: methodUrl,
+                importPage: 'ImportGithub',
+              });
               withBusyState(setLoading, submitMethod(signal, method, workspace, onSuccess, onError));
             },
           },

--- a/src/workflows-app/components/ImportGithub.test.js
+++ b/src/workflows-app/components/ImportGithub.test.js
@@ -21,6 +21,10 @@ jest.mock('src/libs/state', () => ({
   ...jest.requireActual('src/libs/state'),
   getTerraUser: jest.fn(),
 }));
+jest.mock('src/libs/ajax/metrics/useMetrics', () => ({
+  ...jest.requireActual('src/libs/ajax/metrics/useMetrics'),
+  useMetricsEvent: jest.fn(() => ({ captureEvent: jest.fn() })),
+}));
 
 describe('Add a Workflow Link', () => {
   const workspace = {


### PR DESCRIPTION
What:
- Updates EventWorkspaceDetails to include a workspace role (OWNER, WRITER, READER)
- Updates workflows app import buttons to emit an imported event.

Why:
- Measuring usage and success of multi-user workflows

### Visual Aids
Example of a new `workflowsApp:import` event, including the new workspaceAccessLevel field:
![image](https://github.com/DataBiosphere/terra-ui/assets/13006282/2fcfd8b4-d2c4-4b18-a108-cbbef6128ca0)
