### PR TITLE
[IA-4659] Rename some IA models

### DIFF
--- a/src/analysis/AnalysisLauncher.js
+++ b/src/analysis/AnalysisLauncher.js
@@ -481,7 +481,7 @@ const PreviewHeader = ({
 
         [currentRuntimeToolLabel !== currentFileToolLabel, () => createNewRuntimeOpenButton],
         // If the tool is RStudio and we are in this branch, we need to either start an existing runtime or launch the app
-        // Worth mentioning that the Stopped branch will launch RStudio, and then we depend on the RuntimeManager to prompt user the app is ready to launch
+        // Worth mentioning that the Stopped branch will launch RStudio, and then we depend on the AnalysisNotificationManager to prompt user the app is ready to launch
         // Then open can be clicked again
         [
           currentFileToolLabel === runtimeToolLabels.RStudio && _.includes(runtimeStatus, ['Running', null]),

--- a/src/analysis/ContextBar.test.ts
+++ b/src/analysis/ContextBar.test.ts
@@ -15,7 +15,7 @@ import {
 import { appToolLabels, isToolHidden, runtimeToolLabels } from 'src/analysis/utils/tool-utils';
 import { MenuTrigger } from 'src/components/PopupTrigger';
 import { Ajax } from 'src/libs/ajax';
-import { App, ListAppResponse } from 'src/libs/ajax/leonardo/models/app-models';
+import { App, ListAppItem } from 'src/libs/ajax/leonardo/models/app-models';
 import { PersistentDisk } from 'src/libs/ajax/leonardo/models/disk-models';
 import { NormalizedComputeRegion } from 'src/libs/ajax/leonardo/models/runtime-config-models';
 import { ListRuntimeItem, Runtime, runtimeStatuses } from 'src/libs/ajax/leonardo/models/runtime-models';
@@ -201,7 +201,7 @@ const cromwellDisk: PersistentDisk = {
   zone: 'us-central1-a',
 };
 
-const cromwellOnAzureRunning: ListAppResponse = {
+const cromwellOnAzureRunning: ListAppItem = {
   workspaceId: null,
   accessScope: null,
   appName: 'test-cromwell-app',
@@ -426,7 +426,7 @@ const contextBarPropsForAzure: ContextBarProps = {
   workspace: defaultAzureWorkspace,
 };
 
-const hailBatchAppRunning: ListAppResponse = {
+const hailBatchAppRunning: ListAppItem = {
   workspaceId: null,
   accessScope: null,
   appName: 'test-hail-batch-app',

--- a/src/analysis/ContextBar.ts
+++ b/src/analysis/ContextBar.ts
@@ -42,7 +42,7 @@ import hailLogo from 'src/images/hail-logo.svg';
 import jupyterLogo from 'src/images/jupyter-logo.svg';
 import rstudioSquareLogo from 'src/images/rstudio-logo-square.png';
 import { Ajax } from 'src/libs/ajax';
-import { ListAppResponse } from 'src/libs/ajax/leonardo/models/app-models';
+import { ListAppItem } from 'src/libs/ajax/leonardo/models/app-models';
 import { PersistentDisk } from 'src/libs/ajax/leonardo/models/disk-models';
 import { Runtime } from 'src/libs/ajax/leonardo/models/runtime-models';
 import colors from 'src/libs/colors';
@@ -80,7 +80,7 @@ const contextBarStyles: { [label: string]: CSSProperties } = {
 
 export interface ContextBarProps {
   runtimes: Runtime[];
-  apps: ListAppResponse[];
+  apps: ListAppItem[];
   appDataDisks: PersistentDisk[];
   refreshRuntimes: (maybeStale?: boolean) => Promise<void>;
   storageDetails: StorageDetails;

--- a/src/analysis/Environments/DeleteAppModal.ts
+++ b/src/analysis/Environments/DeleteAppModal.ts
@@ -5,7 +5,7 @@ import { SaveFilesHelpGalaxy } from 'src/analysis/runtime-common-components';
 import { appTools } from 'src/analysis/utils/tool-utils';
 import { LabeledCheckbox, spinnerOverlay } from 'src/components/common';
 import Modal from 'src/components/Modal';
-import { ListAppResponse } from 'src/libs/ajax/leonardo/models/app-models';
+import { ListAppItem } from 'src/libs/ajax/leonardo/models/app-models';
 import { LeoAppProvider } from 'src/libs/ajax/leonardo/providers/LeoAppProvider';
 import { withErrorReportingInModal } from 'src/libs/error';
 import * as Utils from 'src/libs/utils';
@@ -13,7 +13,7 @@ import * as Utils from 'src/libs/utils';
 export type DeleteAppProvider = Pick<LeoAppProvider, 'delete'>;
 
 export interface DeleteAppModalProps {
-  app: ListAppResponse;
+  app: ListAppItem;
   onDismiss: () => void;
   onSuccess: () => void;
   deleteProvider: DeleteAppProvider;

--- a/src/analysis/Environments/Environments.models.ts
+++ b/src/analysis/Environments/Environments.models.ts
@@ -1,4 +1,4 @@
-import { ListAppResponse } from 'src/libs/ajax/leonardo/models/app-models';
+import { ListAppItem } from 'src/libs/ajax/leonardo/models/app-models';
 import { PersistentDisk } from 'src/libs/ajax/leonardo/models/disk-models';
 import { ListRuntimeItem } from 'src/libs/ajax/leonardo/models/runtime-models';
 import { WorkspaceInfo } from 'src/libs/workspace-utils';
@@ -10,7 +10,7 @@ export interface DecoratedResourceAttributes {
 
 export type RuntimeWithWorkspace = DecoratedResourceAttributes & ListRuntimeItem;
 export type DiskWithWorkspace = DecoratedResourceAttributes & PersistentDisk;
-export type AppWithWorkspace = DecoratedResourceAttributes & ListAppResponse;
+export type AppWithWorkspace = DecoratedResourceAttributes & ListAppItem;
 
 export type DecoratedComputeResource = RuntimeWithWorkspace | AppWithWorkspace;
 export type DecoratedResource = DecoratedComputeResource | DiskWithWorkspace;

--- a/src/analysis/Environments/Environments.ts
+++ b/src/analysis/Environments/Environments.ts
@@ -2,9 +2,9 @@ import { Mutate, NavLinkProvider } from '@terra-ui-packages/core-utils';
 import _ from 'lodash/fp';
 import { Fragment, ReactNode, useEffect, useState } from 'react';
 import { div, h, h2, p, span, strong } from 'react-hyperscript-helpers';
+import { RuntimeErrorModal } from 'src/analysis/AnalysisNotificationManager';
 import { AppErrorModal } from 'src/analysis/modals/AppErrorModal';
 import { SaveFilesHelp, SaveFilesHelpAzure } from 'src/analysis/runtime-common-components';
-import { RuntimeErrorModal } from 'src/analysis/RuntimeManager';
 import { getDiskAppType } from 'src/analysis/utils/app-utils';
 import {
   getAppCost,

--- a/src/analysis/_testData/testData.ts
+++ b/src/analysis/_testData/testData.ts
@@ -6,7 +6,7 @@ import {
 } from 'src/analysis/utils/disk-utils';
 import { defaultGceMachineType, defaultLocation, generateRuntimeName } from 'src/analysis/utils/runtime-utils';
 import { runtimeToolLabels, tools } from 'src/analysis/utils/tool-utils';
-import { App, AppError, GetAppResponse, ListAppResponse } from 'src/libs/ajax/leonardo/models/app-models';
+import { App, AppError, GetAppItem, ListAppItem } from 'src/libs/ajax/leonardo/models/app-models';
 import { PersistentDisk } from 'src/libs/ajax/leonardo/models/disk-models';
 import {
   AzureConfig,
@@ -536,7 +536,7 @@ export const listGoogleRuntime = ({
   };
 };
 
-export const galaxyRunning: ListAppResponse = {
+export const galaxyRunning: ListAppItem = {
   workspaceId: null,
   accessScope: null,
   cloudContext: {
@@ -588,7 +588,7 @@ export const galaxyDeleting: App = {
   region: 'us-central1',
 };
 
-export const generateTestApp = (overrides: Partial<ListAppResponse>): ListAppResponse => ({
+export const generateTestApp = (overrides: Partial<ListAppItem>): ListAppItem => ({
   workspaceId: null,
   accessScope: null,
   cloudContext: {
@@ -616,9 +616,9 @@ export const generateTestApp = (overrides: Partial<ListAppResponse>): ListAppRes
 });
 
 export const generateTestAppWithGoogleWorkspace = (
-  overrides: Partial<ListAppResponse> = {},
+  overrides: Partial<ListAppItem> = {},
   workspace: GoogleWorkspace = defaultGoogleWorkspace
-): ListAppResponse => ({
+): ListAppItem => ({
   workspaceId: null,
   accessScope: null,
   cloudContext: {
@@ -648,15 +648,15 @@ export const generateTestAppWithGoogleWorkspace = (
   ...overrides,
 });
 
-export const listAppToGetApp = (listApp: ListAppResponse): GetAppResponse => ({
+export const listAppToGetApp = (listApp: ListAppItem): GetAppItem => ({
   ...listApp,
   customEnvironmentVariables: {},
 });
 
 export const generateTestAppWithAzureWorkspace = (
-  overrides: Partial<ListAppResponse> = {},
+  overrides: Partial<ListAppItem> = {},
   workspace: AzureWorkspace = defaultAzureWorkspace
-): ListAppResponse => ({
+): ListAppItem => ({
   workspaceId: null,
   accessScope: null,
   cloudContext: {

--- a/src/analysis/modals/AppErrorModal.ts
+++ b/src/analysis/modals/AppErrorModal.ts
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { div, h } from 'react-hyperscript-helpers';
 import { spinnerOverlay } from 'src/components/common';
 import Modal from 'src/components/Modal';
-import { ListAppResponse } from 'src/libs/ajax/leonardo/models/app-models';
+import { ListAppItem } from 'src/libs/ajax/leonardo/models/app-models';
 import { LeoAppProvider } from 'src/libs/ajax/leonardo/providers/LeoAppProvider';
 import colors from 'src/libs/colors';
 import { withErrorReporting } from 'src/libs/error';
@@ -11,7 +11,7 @@ import { useOnMount } from 'src/libs/react-utils';
 import * as Utils from 'src/libs/utils';
 
 export interface AppErrorModalProps {
-  app: ListAppResponse;
+  app: ListAppItem;
   onDismiss: () => void;
   appProvider: Pick<LeoAppProvider, 'get'>;
 }

--- a/src/analysis/modals/CloudEnvironmentModal.ts
+++ b/src/analysis/modals/CloudEnvironmentModal.ts
@@ -2,6 +2,7 @@ import { IconId } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { Fragment, ReactElement, useState } from 'react';
 import { Component, div, h, hr, img, span } from 'react-hyperscript-helpers';
+import { RuntimeErrorModal } from 'src/analysis/AnalysisNotificationManager';
 import { AppErrorModal } from 'src/analysis/modals/AppErrorModal';
 import { AzureComputeModalBase } from 'src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeModal';
 import { GcpComputeModalBase } from 'src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal';
@@ -9,7 +10,6 @@ import { CromwellModalBase } from 'src/analysis/modals/CromwellModal';
 import { GalaxyModalBase } from 'src/analysis/modals/GalaxyModal';
 import { HailBatchModal } from 'src/analysis/modals/HailBatchModal';
 import { appLauncherTabName, PeriodicAzureCookieSetter } from 'src/analysis/runtime-common-components';
-import { RuntimeErrorModal } from 'src/analysis/RuntimeManager';
 import { doesWorkspaceSupportCromwellAppForUser, getCurrentApp, getIsAppBusy } from 'src/analysis/utils/app-utils';
 import { getCostDisplayForDisk, getCostDisplayForTool } from 'src/analysis/utils/cost-utils';
 import {
@@ -44,7 +44,7 @@ import hailLogo from 'src/images/hail-logo.svg';
 import jupyterLogo from 'src/images/jupyter-logo-long.png';
 import rstudioBioLogo from 'src/images/r-bio-logo.svg';
 import { Apps } from 'src/libs/ajax/leonardo/Apps';
-import { appStatuses, LeoAppStatus, ListAppResponse } from 'src/libs/ajax/leonardo/models/app-models';
+import { appStatuses, LeoAppStatus, ListAppItem } from 'src/libs/ajax/leonardo/models/app-models';
 import { PersistentDisk } from 'src/libs/ajax/leonardo/models/disk-models';
 import { LeoRuntimeStatus, Runtime, runtimeStatuses } from 'src/libs/ajax/leonardo/models/runtime-models';
 import { leoAppProvider } from 'src/libs/ajax/leonardo/providers/LeoAppProvider';
@@ -89,7 +89,7 @@ export const CloudEnvironmentModal = ({
   onDismiss: () => void;
   canCompute: boolean;
   runtimes: Runtime[];
-  apps: ListAppResponse[];
+  apps: ListAppItem[];
   appDataDisks: PersistentDisk[];
   refreshRuntimes: () => Promise<void>;
   refreshApps: () => Promise<void>;
@@ -636,7 +636,7 @@ export const CloudEnvironmentModal = ({
     [Utils.DEFAULT, () => 430]
   );
 
-  const errorApp: ListAppResponse | undefined = _.find({ appName: errorAppId }, apps);
+  const errorApp: ListAppItem | undefined = _.find({ appName: errorAppId }, apps);
   const modalBody = h(Fragment, [
     h(TitleBar, {
       id: titleId,

--- a/src/components/NewWorkspaceModal.test.ts
+++ b/src/components/NewWorkspaceModal.test.ts
@@ -4,7 +4,7 @@ import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { h } from 'react-hyperscript-helpers';
 import { Ajax } from 'src/libs/ajax';
-import { ListAppResponse } from 'src/libs/ajax/leonardo/models/app-models';
+import { ListAppItem } from 'src/libs/ajax/leonardo/models/app-models';
 import { goToPath } from 'src/libs/nav';
 import { AzureWorkspace, AzureWorkspaceInfo, GoogleWorkspaceInfo, WorkspaceInfo } from 'src/libs/workspace-utils';
 import { AzureBillingProject, CloudPlatform, GCPBillingProject } from 'src/pages/billing/models/BillingProject';
@@ -887,7 +887,7 @@ describe('NewWorkspaceModal', () => {
       };
       const createWorkspace = jest.fn().mockResolvedValue(newWorkspace);
 
-      const wdsApp: ListAppResponse = {
+      const wdsApp: ListAppItem = {
         workspaceId: 'aaaabbbb-cccc-dddd-0000-111122223333',
         cloudContext: {
           cloudProvider: 'AZURE',
@@ -1018,7 +1018,7 @@ describe('NewWorkspaceModal', () => {
       };
       const createWorkspace = jest.fn().mockResolvedValue(newWorkspace);
 
-      const wdsApp: ListAppResponse = {
+      const wdsApp: ListAppItem = {
         workspaceId: 'aaaabbbb-cccc-dddd-0000-111122223333',
         cloudContext: {
           cloudProvider: 'AZURE',

--- a/src/components/NewWorkspaceModal.ts
+++ b/src/components/NewWorkspaceModal.ts
@@ -22,7 +22,7 @@ import { isProtectedWorkspace } from 'src/import-data/protected-data-utils';
 import { Ajax } from 'src/libs/ajax';
 import { resolveWdsApp } from 'src/libs/ajax/data-table-providers/WdsDataTableProvider';
 import { CurrentUserGroupMembership } from 'src/libs/ajax/Groups';
-import { ListAppResponse } from 'src/libs/ajax/leonardo/models/app-models';
+import { ListAppItem } from 'src/libs/ajax/leonardo/models/app-models';
 import colors from 'src/libs/colors';
 import { getConfig } from 'src/libs/config';
 import { reportErrorAndRethrow, withErrorReportingInModal } from 'src/libs/error';
@@ -212,7 +212,7 @@ const NewWorkspaceModal = withDisplayName(
           // Wait for the WDS app to be running.
           const wds = await Utils.poll(
             async () => {
-              const workspaceApps: ListAppResponse[] = await Ajax().Apps.listAppsV2(createdWorkspace.workspaceId);
+              const workspaceApps: ListAppItem[] = await Ajax().Apps.listAppsV2(createdWorkspace.workspaceId);
               const wdsApp = resolveWdsApp(workspaceApps);
               if (wdsApp?.status === 'RUNNING') {
                 return { shouldContinue: false, result: wdsApp };

--- a/src/libs/ajax/ajax-override-utils.ts
+++ b/src/libs/ajax/ajax-override-utils.ts
@@ -4,7 +4,7 @@
  */
 
 import { ensureAuthSettled } from 'src/auth/auth';
-import { ListAppResponse } from 'src/libs/ajax/leonardo/models/app-models';
+import { ListAppItem } from 'src/libs/ajax/leonardo/models/app-models';
 import { AjaxOverride, ajaxOverridesStore, getTerraUser } from 'src/libs/state';
 
 type FetchFn = typeof fetch;
@@ -103,7 +103,7 @@ export const overrideAppsWithLocalWDS = async (workspaceId?: string) => {
   const ajaxOverrides: AjaxOverride[] = [
     {
       filter: { url: new RegExp(`/apps/v2/${workspaceId}`) },
-      fn: mapJsonBody((apps: ListAppResponse[]): ListAppResponse[] => {
+      fn: mapJsonBody((apps: ListAppItem[]): ListAppItem[] => {
         return apps.map((app) => {
           if (app.appType === 'WDS') {
             return {

--- a/src/libs/ajax/data-table-providers/WdsDataTableProvider.test.ts
+++ b/src/libs/ajax/data-table-providers/WdsDataTableProvider.test.ts
@@ -5,7 +5,7 @@ import { WorkspaceData } from 'src/libs/ajax/WorkspaceDataService';
 import { cloudProviderTypes } from 'src/libs/workspace-utils';
 import { asMockedFn } from 'src/testing/test-utils';
 
-import { ListAppResponse } from '../leonardo/models/app-models';
+import { ListAppItem } from '../leonardo/models/app-models';
 import {
   EntityMetadata,
   EntityQueryOptions,
@@ -55,7 +55,7 @@ class TestableWdsProvider extends WdsDataTableProvider {
 const recordType = 'item';
 
 const testProxyUrl = 'https://lzsomeTestUrl.servicebus.windows.net/super-cool-proxy-url/wds';
-const testProxyUrlResponse: ListAppResponse[] = [
+const testProxyUrlResponse: ListAppItem[] = [
   {
     cloudContext: {
       cloudProvider: cloudProviderTypes.GCP,
@@ -171,7 +171,7 @@ describe('WdsDataTableProvider', () => {
     return Promise.resolve(new Response('', { status: 202 }));
   };
 
-  const listAppsV2MockImpl = (_workspaceId: string): Promise<ListAppResponse[]> => {
+  const listAppsV2MockImpl = (_workspaceId: string): Promise<ListAppItem[]> => {
     return Promise.resolve(testProxyUrlResponse);
   };
 

--- a/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
+++ b/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
@@ -12,7 +12,7 @@ import {
   TsvUploadButtonTooltipOptions,
   UploadParameters,
 } from 'src/libs/ajax/data-table-providers/DataTableProvider';
-import { LeoAppStatus, ListAppResponse } from 'src/libs/ajax/leonardo/models/app-models';
+import { LeoAppStatus, ListAppItem } from 'src/libs/ajax/leonardo/models/app-models';
 import { withErrorReporting } from 'src/libs/error';
 import { notify } from 'src/libs/notifications';
 import { notificationStore } from 'src/libs/state';
@@ -91,7 +91,7 @@ const getRelationParts = (val: unknown): string[] => {
 // Invokes logic to determine the appropriate app for WDS
 // If WDS is not running, a URL will not be present -- in some cases, this function may invoke
 // a new call to Leo to instantiate a WDS being available, thus having a valid URL
-export const resolveWdsApp = (apps: ListAppResponse[]): ListAppResponse | undefined => {
+export const resolveWdsApp = (apps: ListAppItem[]): ListAppItem | undefined => {
   // WDS looks for Kubernetes deployment statuses (such as RUNNING or PROVISIONING), expressed by Leo
   // See here for specific enumerations -- https://github.com/DataBiosphere/leonardo/blob/develop/core/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/kubernetesModels.scala
   // look explicitly for a RUNNING app named 'wds-${app.workspaceId}' -- if WDS is healthy and running, there should only be one app RUNNING

--- a/src/libs/ajax/leonardo/Apps.ts
+++ b/src/libs/ajax/leonardo/Apps.ts
@@ -3,18 +3,18 @@ import * as qs from 'qs';
 import { AppToolLabel } from 'src/analysis/utils/tool-utils';
 import { AppAccessScope } from 'src/analysis/utils/tool-utils';
 import { appIdentifier, authOpts, fetchLeo, jsonBody } from 'src/libs/ajax/ajax-common';
-import { CreateAppV1Request, GetAppResponse, ListAppResponse } from 'src/libs/ajax/leonardo/models/app-models';
+import { CreateAppV1Request, GetAppItem, ListAppItem } from 'src/libs/ajax/leonardo/models/app-models';
 import { LeoResourceLabels } from 'src/libs/ajax/leonardo/models/core-models';
 
 export const Apps = (signal: AbortSignal) => ({
-  list: async (project: string, labels: LeoResourceLabels = {}): Promise<ListAppResponse[]> => {
+  list: async (project: string, labels: LeoResourceLabels = {}): Promise<ListAppItem[]> => {
     const res = await fetchLeo(
       `api/google/v1/apps/${project}?${qs.stringify({ saturnAutoCreated: true, ...labels })}`,
       _.mergeAll([authOpts(), appIdentifier, { signal }])
     );
     return res.json();
   },
-  listWithoutProject: async (labels: LeoResourceLabels = {}): Promise<ListAppResponse[]> => {
+  listWithoutProject: async (labels: LeoResourceLabels = {}): Promise<ListAppItem[]> => {
     const res = await fetchLeo(
       `api/google/v1/apps?${qs.stringify({ saturnAutoCreated: true, ...labels })}`,
       _.mergeAll([authOpts(), appIdentifier, { signal }])
@@ -73,13 +73,13 @@ export const Apps = (signal: AbortSignal) => ({
       resume: (): Promise<void> => {
         return fetchLeo(`${root}/start`, _.mergeAll([authOpts(), { signal, method: 'POST' }, appIdentifier]));
       },
-      details: async (): Promise<GetAppResponse> => {
+      details: async (): Promise<GetAppItem> => {
         const res = await fetchLeo(root, _.mergeAll([authOpts(), { signal }, appIdentifier]));
         return res.json();
       },
     };
   },
-  listAppsV2: async (workspaceId: string, labels: LeoResourceLabels = {}): Promise<ListAppResponse[]> => {
+  listAppsV2: async (workspaceId: string, labels: LeoResourceLabels = {}): Promise<ListAppItem[]> => {
     const res = await fetchLeo(
       `api/apps/v2/${workspaceId}?${qs.stringify(labels)}`,
       _.mergeAll([authOpts(), appIdentifier, { signal }])
@@ -111,7 +111,7 @@ export const Apps = (signal: AbortSignal) => ({
       _.mergeAll([authOpts(), appIdentifier, { signal, method: 'DELETE' }])
     );
   },
-  getAppV2: async (appName: string, workspaceId: string): Promise<GetAppResponse> => {
+  getAppV2: async (appName: string, workspaceId: string): Promise<GetAppItem> => {
     const res = await fetchLeo(
       `api/apps/v2/${workspaceId}/${appName}`,
       _.mergeAll([authOpts(), appIdentifier, { signal, method: 'GET' }])

--- a/src/libs/ajax/leonardo/Runtimes.ts
+++ b/src/libs/ajax/leonardo/Runtimes.ts
@@ -11,6 +11,7 @@ import {
   jsonBody,
   makeRequestRetry,
 } from 'src/libs/ajax/ajax-common';
+import { RawRuntimeConfig } from 'src/libs/ajax/leonardo/models/api-runtime-config';
 import {
   getRegionFromZone,
   isAzureConfig,
@@ -18,7 +19,6 @@ import {
   isGceConfig,
   isGceWithPdConfig,
   NormalizedComputeRegion,
-  RawRuntimeConfig,
   RuntimeConfig,
 } from 'src/libs/ajax/leonardo/models/runtime-config-models';
 import {

--- a/src/libs/ajax/leonardo/models/api-runtime-config.ts
+++ b/src/libs/ajax/leonardo/models/api-runtime-config.ts
@@ -1,0 +1,44 @@
+import { ComputeType, GpuConfig } from 'src/libs/ajax/leonardo/models/runtime-config-models';
+
+export interface ApiRuntimeConfig {
+  cloudService: ComputeType;
+}
+
+export interface RawGceConfig extends ApiRuntimeConfig {
+  machineType: string;
+  diskSize: number;
+  bootDiskSize: number | null; // This is optional for supporting old runtimes which only have 1 disk. All new runtime will have a boot disk
+  zone: string;
+  gpuConfig: GpuConfig | null;
+}
+
+export interface RawGceWithPdConfig extends ApiRuntimeConfig {
+  machineType: string;
+  persistentDiskId: number;
+  bootDiskSize: number;
+  zone: string;
+  gpuConfig: GpuConfig | null;
+}
+
+export interface RawDataprocConfig extends ApiRuntimeConfig {
+  numberOfWorkers: number;
+  autopauseThreshold: number | null; // TODO: Add to base config
+  masterMachineType: string;
+  masterDiskSize: number;
+  workerMachineType: string | null;
+  workerDiskSize: number | null;
+  numberOfWorkerLocalSSDs: number | null;
+  numberOfPreemptibleWorkers: number | null;
+  // properties: Record<string, string> TODO: Where is this used?
+  region: string;
+  componentGatewayEnabled: boolean;
+  workerPrivateAccess: boolean;
+}
+
+export interface RawAzureConfig extends ApiRuntimeConfig {
+  machineType: string;
+  persistentDiskId: number;
+  region: string | null;
+}
+
+export type RawRuntimeConfig = RawAzureConfig | RawGceWithPdConfig | RawGceConfig | RawDataprocConfig;

--- a/src/libs/ajax/leonardo/models/app-models.ts
+++ b/src/libs/ajax/leonardo/models/app-models.ts
@@ -56,7 +56,7 @@ export const appStatuses: { [label: string]: AppStatusObject } = {
   status_unspecified: { status: 'STATUS_UNSPECIFIED', statusDisplay: 'Status_unspecified' },
 };
 
-export interface GetAppResponse {
+export interface GetAppItem {
   appName: string;
   cloudContext: CloudContext;
   kubernetesRuntimeConfig: KubernetesRuntimeConfig;
@@ -72,7 +72,7 @@ export interface GetAppResponse {
   region: string;
 }
 
-export interface ListAppResponse {
+export interface ListAppItem {
   workspaceId: string | null;
   appName: string;
   cloudContext: CloudContext;
@@ -100,7 +100,7 @@ export interface CreateAppV1Request {
   workspaceName: string;
 }
 
-export type App = GetAppResponse | ListAppResponse;
+export type App = GetAppItem | ListAppItem;
 
 export const isApp = (obj: any): obj is App => {
   const castApp = obj as App;

--- a/src/libs/ajax/leonardo/models/runtime-config-models.ts
+++ b/src/libs/ajax/leonardo/models/runtime-config-models.ts
@@ -1,4 +1,5 @@
 import { NominalType } from '@terra-ui-packages/core-utils';
+import { RawRuntimeConfig } from 'src/libs/ajax/leonardo/models/api-runtime-config';
 
 export interface GpuConfig {
   gpuType: string;
@@ -17,10 +18,6 @@ export interface BaseRuntimeConfig {
   normalizedRegion: NormalizedComputeRegion;
 }
 
-export interface RawBaseRuntimeConfig {
-  cloudService: ComputeType;
-}
-
 export interface GceConfig extends BaseRuntimeConfig {
   machineType: string;
   diskSize: number;
@@ -28,24 +25,7 @@ export interface GceConfig extends BaseRuntimeConfig {
   zone: string;
   gpuConfig: GpuConfig | null;
 }
-
-export interface RawGceConfig extends RawBaseRuntimeConfig {
-  machineType: string;
-  diskSize: number;
-  bootDiskSize: number | null; // This is optional for supporting old runtimes which only have 1 disk. All new runtime will have a boot disk
-  zone: string;
-  gpuConfig: GpuConfig | null;
-}
-
 export interface GceWithPdConfig extends BaseRuntimeConfig {
-  machineType: string;
-  persistentDiskId: number;
-  bootDiskSize: number;
-  zone: string;
-  gpuConfig: GpuConfig | null;
-}
-
-export interface RawGceWithPdConfig extends RawBaseRuntimeConfig {
   machineType: string;
   persistentDiskId: number;
   bootDiskSize: number;
@@ -68,28 +48,7 @@ export interface DataprocConfig extends BaseRuntimeConfig {
   workerPrivateAccess: boolean;
 }
 
-export interface RawDataprocConfig extends RawBaseRuntimeConfig {
-  numberOfWorkers: number;
-  autopauseThreshold: number | null; // TODO: Add to base config
-  masterMachineType: string;
-  masterDiskSize: number;
-  workerMachineType: string | null;
-  workerDiskSize: number | null;
-  numberOfWorkerLocalSSDs: number | null;
-  numberOfPreemptibleWorkers: number | null;
-  // properties: Record<string, string> TODO: Where is this used?
-  region: string;
-  componentGatewayEnabled: boolean;
-  workerPrivateAccess: boolean;
-}
-
 export interface AzureConfig extends BaseRuntimeConfig {
-  machineType: string;
-  persistentDiskId: number;
-  region: string | null;
-}
-
-export interface RawAzureConfig extends RawBaseRuntimeConfig {
   machineType: string;
   persistentDiskId: number;
   region: string | null;
@@ -97,8 +56,6 @@ export interface RawAzureConfig extends RawBaseRuntimeConfig {
 
 export type GoogleRuntimeConfig = GceConfig | GceWithPdConfig | DataprocConfig;
 export type RuntimeConfig = AzureConfig | GoogleRuntimeConfig;
-
-export type RawRuntimeConfig = RawAzureConfig | RawGceWithPdConfig | RawGceConfig | RawDataprocConfig;
 
 // TODO: should really add a kind in the backend, WIP
 export const isDataprocConfig = (config: RuntimeConfig | RawRuntimeConfig): config is DataprocConfig => {

--- a/src/libs/ajax/leonardo/models/runtime-models.ts
+++ b/src/libs/ajax/leonardo/models/runtime-models.ts
@@ -1,7 +1,8 @@
 import { ToolLabel } from 'src/analysis/utils/tool-utils';
+import { RawRuntimeConfig } from 'src/libs/ajax/leonardo/models/api-runtime-config';
 import { AuditInfo, CloudContext, LeoError, LeoResourceLabels } from 'src/libs/ajax/leonardo/models/core-models';
 import { DiskConfig } from 'src/libs/ajax/leonardo/models/disk-models';
-import { RawRuntimeConfig, RuntimeConfig } from 'src/libs/ajax/leonardo/models/runtime-config-models';
+import { RuntimeConfig } from 'src/libs/ajax/leonardo/models/runtime-config-models';
 
 export type LeoRuntimeStatus =
   | 'Running'

--- a/src/libs/ajax/leonardo/providers/LeoAppProvider.ts
+++ b/src/libs/ajax/leonardo/providers/LeoAppProvider.ts
@@ -1,9 +1,9 @@
 import { AppWithWorkspace } from 'src/analysis/Environments/Environments.models';
 import { Ajax } from 'src/libs/ajax';
 import { AbortOption } from 'src/libs/ajax/data-provider-common';
-import { GetAppResponse, ListAppResponse } from 'src/libs/ajax/leonardo/models/app-models';
+import { GetAppItem, ListAppItem } from 'src/libs/ajax/leonardo/models/app-models';
 
-export type AppBasics = Pick<ListAppResponse, 'appName' | 'workspaceId'> & {
+export type AppBasics = Pick<ListAppItem, 'appName' | 'workspaceId'> & {
   cloudContext: Pick<AppWithWorkspace['cloudContext'], 'cloudProvider' | 'cloudResource'>;
 };
 
@@ -12,14 +12,14 @@ export type DeleteAppOptions = AbortOption & {
 };
 
 export interface LeoAppProvider {
-  listWithoutProject: (listArgs: Record<string, string>, options?: AbortOption) => Promise<ListAppResponse[]>;
+  listWithoutProject: (listArgs: Record<string, string>, options?: AbortOption) => Promise<ListAppItem[]>;
   delete: (app: AppBasics, options?: DeleteAppOptions) => Promise<void>;
   pause: (app: AppBasics, options?: AbortOption) => Promise<void>;
-  get: (app: AppBasics, options?: AbortOption) => Promise<GetAppResponse>;
+  get: (app: AppBasics, options?: AbortOption) => Promise<GetAppItem>;
 }
 
 export const leoAppProvider: LeoAppProvider = {
-  listWithoutProject: (listArgs: Record<string, string>, options: AbortOption = {}): Promise<ListAppResponse[]> => {
+  listWithoutProject: (listArgs: Record<string, string>, options: AbortOption = {}): Promise<ListAppItem[]> => {
     const { signal } = options;
 
     return Ajax(signal).Apps.listWithoutProject(listArgs);
@@ -49,7 +49,7 @@ export const leoAppProvider: LeoAppProvider = {
 
     return Ajax(signal).Apps.app(cloudResource, app.appName).pause();
   },
-  get: (app: AppBasics, options: AbortOption = {}): Promise<GetAppResponse> => {
+  get: (app: AppBasics, options: AbortOption = {}): Promise<GetAppItem> => {
     const { cloudResource, cloudProvider } = app.cloudContext;
     const { signal } = options;
     const { workspaceId } = app;

--- a/src/pages/workspaces/hooks/useAppPolling.ts
+++ b/src/pages/workspaces/hooks/useAppPolling.ts
@@ -1,12 +1,12 @@
 import { useEffect, useRef, useState } from 'react';
 import { Ajax } from 'src/libs/ajax';
-import { ListAppResponse } from 'src/libs/ajax/leonardo/models/app-models';
+import { ListAppItem } from 'src/libs/ajax/leonardo/models/app-models';
 import { withErrorIgnoring, withErrorReporting } from 'src/libs/error';
 import { isAzureWorkspace, isGoogleWorkspace } from 'src/libs/workspace-utils';
 import { InitializedWorkspaceWrapper as Workspace } from 'src/pages/workspaces/hooks/useWorkspace';
 
 export interface AppDetails {
-  apps?: ListAppResponse[];
+  apps?: ListAppItem[];
   refreshApps: (maybeStale?: boolean) => Promise<void>;
 }
 
@@ -18,7 +18,7 @@ export const useAppPolling = (name: string, namespace: string, workspace?: Works
   };
   const signal = controller.signal;
   const timeout = useRef<NodeJS.Timeout>();
-  const [apps, setApps] = useState<ListAppResponse[]>();
+  const [apps, setApps] = useState<ListAppItem[]>();
 
   const reschedule = (ms) => {
     clearTimeout(timeout.current);

--- a/src/pages/workspaces/workspace/WorkspaceContainer.ts
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.ts
@@ -2,8 +2,8 @@ import { Spinner } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { ComponentPropsWithRef, PropsWithChildren, ReactNode, useEffect, useRef, useState } from 'react';
 import { br, div, h, h2, h3, p, span } from 'react-hyperscript-helpers';
+import AnalysisNotificationManager from 'src/analysis/AnalysisNotificationManager';
 import { ContextBar } from 'src/analysis/ContextBar';
-import RuntimeManager from 'src/analysis/RuntimeManager';
 import { ButtonPrimary, Link, spinnerOverlay } from 'src/components/common';
 import FooterWrapper from 'src/components/FooterWrapper';
 import { icon } from 'src/components/icons';
@@ -160,7 +160,7 @@ export const WorkspaceContainer = (props: WorkspaceContainerProps) => {
             div({ style: { fontSize: 12, color: colors.dark() } }, ['COVID-19', br(), 'Data & Tools']),
           ]
         ),
-      h(RuntimeManager, { namespace, name, runtimes, apps }),
+      h(AnalysisNotificationManager, { namespace, name, runtimes, apps }),
     ]),
     h(WorkspaceTabs, {
       namespace,

--- a/src/workspace-data/Data.test.ts
+++ b/src/workspace-data/Data.test.ts
@@ -2,7 +2,7 @@ import { DeepPartial } from '@terra-ui-packages/core-utils';
 import { act, screen } from '@testing-library/react';
 import { h } from 'react-hyperscript-helpers';
 import { Ajax } from 'src/libs/ajax';
-import { LeoAppStatus, ListAppResponse } from 'src/libs/ajax/leonardo/models/app-models';
+import { LeoAppStatus, ListAppItem } from 'src/libs/ajax/leonardo/models/app-models';
 import { reportError } from 'src/libs/error';
 import { WorkspaceWrapper } from 'src/libs/workspace-utils';
 import { StorageDetails } from 'src/pages/workspaces/hooks/useWorkspace';
@@ -63,7 +63,7 @@ describe('WorkspaceData', () => {
   };
   type SetupResult = {
     workspaceDataProps: WorkspaceDataProps;
-    listAppResponse: DeepPartial<ListAppResponse>;
+    listAppResponse: DeepPartial<ListAppItem>;
     mockGetSchema: jest.Mock;
     mockListAppsV2: jest.Mock;
   };
@@ -90,7 +90,7 @@ describe('WorkspaceData', () => {
     status = 'RUNNING',
     wdsUrl = 'http://fake.wds.url',
   }: SetupOptions): SetupResult {
-    const listAppResponse: DeepPartial<ListAppResponse> = {
+    const listAppResponse: DeepPartial<ListAppItem> = {
       proxyUrls: {
         wds: wdsUrl,
       },

--- a/src/workspace-data/data-table/wds/wds-status.test.ts
+++ b/src/workspace-data/data-table/wds/wds-status.test.ts
@@ -1,6 +1,6 @@
 import { abandonedPromise, DeepPartial } from '@terra-ui-packages/core-utils';
 import { Ajax } from 'src/libs/ajax';
-import { ListAppResponse } from 'src/libs/ajax/leonardo/models/app-models';
+import { ListAppItem } from 'src/libs/ajax/leonardo/models/app-models';
 import { WDSCloneStatusResponse } from 'src/libs/ajax/WorkspaceDataService';
 import { asMockedFn, renderHookInAct } from 'src/testing/test-utils';
 
@@ -106,7 +106,7 @@ describe('useWdsStatus', () => {
   });
 
   describe('if WDS app is present', () => {
-    const wdsApp: ListAppResponse = {
+    const wdsApp: ListAppItem = {
       workspaceId: '6601fdbb-4b53-41da-87b2-81385f4a760e',
       cloudContext: {
         cloudProvider: 'AZURE',

--- a/src/workspace-data/data-table/wds/wds-status.ts
+++ b/src/workspace-data/data-table/wds/wds-status.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Ajax } from 'src/libs/ajax';
 import { resolveWdsApp } from 'src/libs/ajax/data-table-providers/WdsDataTableProvider';
-import { ListAppResponse } from 'src/libs/ajax/leonardo/models/app-models';
+import { ListAppItem } from 'src/libs/ajax/leonardo/models/app-models';
 import { useCallback } from 'use-memo-one';
 
 type UseWdsStatusArgs = {
@@ -67,7 +67,7 @@ export const useWdsStatus = ({ workspaceId }: UseWdsStatusArgs) => {
 
     setStatus(() => ({ ...initialStatus }));
 
-    let listAppsResponse: ListAppResponse[];
+    let listAppsResponse: ListAppItem[];
     try {
       listAppsResponse = await Ajax(signal).Apps.listAppsV2(workspaceId);
     } catch (err) {


### PR DESCRIPTION
This is a pretty simple PR that just renames a few things and converts one small file to typescript

Specifically:
- Renames `ListAppResponse/GetAppResponse` to `ListAppItem/GetAppItem` for consistency with other Leo models
- Renames RuntimeManager to something more sensible
- converts RuntimeManager to typescript and fixes existing bugs that typescript identified