### PR TITLE
[IA-4659] Fix UI models representing Leo data

### DIFF
--- a/src/analysis/ContextBar.test.ts
+++ b/src/analysis/ContextBar.test.ts
@@ -260,7 +260,7 @@ const rstudioRuntime: ListRuntimeItem = {
     cloudService: 'GCE',
     bootDiskSize: 120,
     zone: 'us-central1-a',
-    gpuConfig: undefined,
+    gpuConfig: null,
     normalizedRegion: 'us-central1' as NormalizedComputeRegion,
   },
   proxyUrl:
@@ -304,7 +304,7 @@ const jupyter: Runtime = {
     cloudService: 'GCE',
     bootDiskSize: 120,
     zone: 'us-central1-a',
-    gpuConfig: undefined,
+    gpuConfig: null,
     normalizedRegion: 'us-central1' as NormalizedComputeRegion,
   },
   proxyUrl:

--- a/src/analysis/_testData/testData.ts
+++ b/src/analysis/_testData/testData.ts
@@ -214,7 +214,7 @@ export const getJupyterRuntimeConfig = ({
   cloudService: cloudServiceTypes.GCE,
   bootDiskSize: defaultGceBootDiskSize,
   zone: 'us-central1-a',
-  gpuConfig: undefined,
+  gpuConfig: null,
   normalizedRegion: 'us-central1' as NormalizedComputeRegion,
 });
 
@@ -236,7 +236,7 @@ export const getRuntimeConfig = (overrides: Partial<RuntimeConfig> = {}): Runtim
     cloudService: cloudServiceTypes.GCE,
     bootDiskSize: defaultGceBootDiskSize,
     zone: 'us-central1-a',
-    gpuConfig: undefined,
+    gpuConfig: null,
     normalizedRegion: 'us-central1' as NormalizedComputeRegion,
     ...overrides,
   } satisfies GceWithPdConfig);

--- a/src/analysis/_testData/testData.ts
+++ b/src/analysis/_testData/testData.ts
@@ -11,7 +11,7 @@ import { PersistentDisk } from 'src/libs/ajax/leonardo/models/disk-models';
 import {
   AzureConfig,
   cloudServiceTypes,
-  GceWithPdConfig,
+  GoogleRuntimeConfig,
   NormalizedComputeRegion,
   RuntimeConfig,
 } from 'src/libs/ajax/leonardo/models/runtime-config-models';
@@ -229,17 +229,16 @@ export const defaultAuditInfo = {
 
 export const generateGoogleProject = () => `terra-test-${uuid().substring(0, 8)}`;
 
-export const getRuntimeConfig = (overrides: Partial<RuntimeConfig> = {}): GceWithPdConfig =>
+export const getRuntimeConfig = (overrides: Partial<RuntimeConfig> = {}): GoogleRuntimeConfig =>
   ({
     machineType: defaultGceMachineType,
     persistentDiskId: getRandomInt(randomMaxInt),
     cloudService: cloudServiceTypes.GCE,
-    bootDiskSize: defaultGceBootDiskSize,
     zone: 'us-central1-a',
     gpuConfig: null,
     normalizedRegion: 'us-central1' as NormalizedComputeRegion,
     ...overrides,
-  } satisfies GceWithPdConfig as GceWithPdConfig);
+  } as GoogleRuntimeConfig satisfies GoogleRuntimeConfig);
 
 export const appError: AppError = {
   action: '',

--- a/src/analysis/_testData/testData.ts
+++ b/src/analysis/_testData/testData.ts
@@ -229,7 +229,7 @@ export const defaultAuditInfo = {
 
 export const generateGoogleProject = () => `terra-test-${uuid().substring(0, 8)}`;
 
-export const getRuntimeConfig = (overrides: Partial<RuntimeConfig> = {}): RuntimeConfig =>
+export const getRuntimeConfig = (overrides: Partial<RuntimeConfig> = {}): GceWithPdConfig =>
   ({
     machineType: defaultGceMachineType,
     persistentDiskId: getRandomInt(randomMaxInt),
@@ -239,7 +239,7 @@ export const getRuntimeConfig = (overrides: Partial<RuntimeConfig> = {}): Runtim
     gpuConfig: null,
     normalizedRegion: 'us-central1' as NormalizedComputeRegion,
     ...overrides,
-  } satisfies GceWithPdConfig);
+  } satisfies GceWithPdConfig as GceWithPdConfig);
 
 export const appError: AppError = {
   action: '',
@@ -888,6 +888,7 @@ export const dataprocRuntime: ListRuntimeItem = {
     dateAccessed: '2023-05-03T19:53:23.559367Z',
   },
   runtimeConfig: {
+    autopauseThreshold: null,
     numberOfWorkers: 2,
     masterMachineType: 'n1-standard-4',
     masterDiskSize: 150,

--- a/src/analysis/utils/cost-utils.test.ts
+++ b/src/analysis/utils/cost-utils.test.ts
@@ -428,7 +428,20 @@ describe('getPersistentDiskCostMonthly', () => {
     expect(result).toBe(getAzurePricesForRegion('eastus')!['S6 LRS']);
   });
 });
-
+// export interface DataprocConfig extends BaseRuntimeConfig {
+//   numberOfWorkers: number;
+//   autopauseThreshold: number | null; // TODO: Add to base config
+//   masterMachineType: string;
+//   masterDiskSize: number;
+//   workerMachineType: string | null;
+//   workerDiskSize: number | null;
+//   numberOfWorkerLocalSSDs: number | null;
+//   numberOfPreemptibleWorkers: number | null;
+//   // properties: Record<string, string> TODO: Where is this used?
+//   region: string;
+//   componentGatewayEnabled: boolean;
+//   workerPrivateAccess: boolean;
+// }
 describe('runtimeConfigCost for dataproc', () => {
   const defaultSparkSingleNode: GoogleRuntimeConfig = {
     cloudService: cloudServiceTypes.DATAPROC,
@@ -441,6 +454,8 @@ describe('runtimeConfigCost for dataproc', () => {
     numberOfPreemptibleWorkers: 0,
     workerDiskSize: 0,
     workerPrivateAccess: false,
+    workerMachineType: null,
+    numberOfWorkerLocalSSDs: null,
     normalizedRegion: 'us-central1' as NormalizedComputeRegion,
   };
 
@@ -456,6 +471,7 @@ describe('runtimeConfigCost for dataproc', () => {
     workerMachineType: 'n1-standard-4',
     workerDiskSize: 150,
     workerPrivateAccess: false,
+    numberOfWorkerLocalSSDs: null,
     normalizedRegion: 'us-central1' as NormalizedComputeRegion,
   };
   it('gets cost for a dataproc cluster', () => {

--- a/src/analysis/utils/cost-utils.test.ts
+++ b/src/analysis/utils/cost-utils.test.ts
@@ -403,7 +403,6 @@ describe('getPersistentDiskCostMonthly', () => {
         dateAccessed: '2020-10-13T15:00:00.000Z',
         destroyedDate: null,
       },
-      // diskType: googlePdTypes.standard,
     };
 
     // Act
@@ -428,20 +427,7 @@ describe('getPersistentDiskCostMonthly', () => {
     expect(result).toBe(getAzurePricesForRegion('eastus')!['S6 LRS']);
   });
 });
-// export interface DataprocConfig extends BaseRuntimeConfig {
-//   numberOfWorkers: number;
-//   autopauseThreshold: number | null; // TODO: Add to base config
-//   masterMachineType: string;
-//   masterDiskSize: number;
-//   workerMachineType: string | null;
-//   workerDiskSize: number | null;
-//   numberOfWorkerLocalSSDs: number | null;
-//   numberOfPreemptibleWorkers: number | null;
-//   // properties: Record<string, string> TODO: Where is this used?
-//   region: string;
-//   componentGatewayEnabled: boolean;
-//   workerPrivateAccess: boolean;
-// }
+
 describe('runtimeConfigCost for dataproc', () => {
   const defaultSparkSingleNode: GoogleRuntimeConfig = {
     cloudService: cloudServiceTypes.DATAPROC,

--- a/src/libs/ajax/leonardo/models/disk-models.ts
+++ b/src/libs/ajax/leonardo/models/disk-models.ts
@@ -44,7 +44,7 @@ export interface GetDiskItem {
   diskType: GoogleDiskType;
   blockSize: number;
   labels: LeoResourceLabels;
-  formattedBy?: string;
+  formattedBy: string | null;
 }
 
 export interface ListDiskItem {

--- a/src/libs/ajax/leonardo/models/runtime-config-models.ts
+++ b/src/libs/ajax/leonardo/models/runtime-config-models.ts
@@ -24,17 +24,17 @@ export interface RawBaseRuntimeConfig {
 export interface GceConfig extends BaseRuntimeConfig {
   machineType: string;
   diskSize: number;
-  bootDiskSize?: number; // This is optional for supporting old runtimes which only have 1 disk. All new runtime will have a boot disk
+  bootDiskSize: number | null; // This is optional for supporting old runtimes which only have 1 disk. All new runtime will have a boot disk
   zone: string;
-  gpuConfig?: GpuConfig;
+  gpuConfig: GpuConfig | null;
 }
 
 export interface RawGceConfig extends RawBaseRuntimeConfig {
   machineType: string;
   diskSize: number;
-  bootDiskSize?: number; // This is optional for supporting old runtimes which only have 1 disk. All new runtime will have a boot disk
+  bootDiskSize: number | null; // This is optional for supporting old runtimes which only have 1 disk. All new runtime will have a boot disk
   zone: string;
-  gpuConfig?: GpuConfig;
+  gpuConfig: GpuConfig | null;
 }
 
 export interface GceWithPdConfig extends BaseRuntimeConfig {
@@ -42,7 +42,7 @@ export interface GceWithPdConfig extends BaseRuntimeConfig {
   persistentDiskId: number;
   bootDiskSize: number;
   zone: string;
-  gpuConfig?: GpuConfig;
+  gpuConfig: GpuConfig | null;
 }
 
 export interface RawGceWithPdConfig extends RawBaseRuntimeConfig {
@@ -50,18 +50,18 @@ export interface RawGceWithPdConfig extends RawBaseRuntimeConfig {
   persistentDiskId: number;
   bootDiskSize: number;
   zone: string;
-  gpuConfig?: GpuConfig;
+  gpuConfig: GpuConfig | null;
 }
 
 export interface DataprocConfig extends BaseRuntimeConfig {
   numberOfWorkers: number;
-  autopauseThreshold?: number; // TODO: Add to base config
+  autopauseThreshold: number | null; // TODO: Add to base config
   masterMachineType: string;
   masterDiskSize: number;
-  workerMachineType?: string;
-  workerDiskSize?: number;
-  numberOfWorkerLocalSSDs?: number;
-  numberOfPreemptibleWorkers?: number;
+  workerMachineType: string | null;
+  workerDiskSize: number | null;
+  numberOfWorkerLocalSSDs: number | null;
+  numberOfPreemptibleWorkers: number | null;
   // properties: Record<string, string> TODO: Where is this used?
   region: string;
   componentGatewayEnabled: boolean;
@@ -70,13 +70,13 @@ export interface DataprocConfig extends BaseRuntimeConfig {
 
 export interface RawDataprocConfig extends RawBaseRuntimeConfig {
   numberOfWorkers: number;
-  autopauseThreshold?: number; // TODO: Add to base config
+  autopauseThreshold: number | null; // TODO: Add to base config
   masterMachineType: string;
   masterDiskSize: number;
-  workerMachineType?: string;
-  workerDiskSize?: number;
-  numberOfWorkerLocalSSDs?: number;
-  numberOfPreemptibleWorkers?: number;
+  workerMachineType: string | null;
+  workerDiskSize: number | null;
+  numberOfWorkerLocalSSDs: number | null;
+  numberOfPreemptibleWorkers: number | null;
   // properties: Record<string, string> TODO: Where is this used?
   region: string;
   componentGatewayEnabled: boolean;


### PR DESCRIPTION
Originally when these models were written, there was a mismatch between Typescript and Leonardo's definition of `Optional`. Leo serializes fields it labels as optional into null. Typescript expects a field to be omitted if it's optional, and provides no protection against something you state as `myVar?: string` ending up as null. 

As such, the fields here were not correctly typed. 