### PR TITLE
[IA-4526][UIE-146] Fix fillInReplace test helper

### DIFF
--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -189,8 +189,9 @@ const fillIn = async (page, xpath, text, { initialDelay = Millis.none } = {}) =>
 
 // Replace pre-existing value
 const fillInReplace = async (page, xpath, text) => {
-  await (await findElement(page, xpath)).click({ clickCount: 3 }); // triple-click to replace the default text
-  return await fillIn(page, xpath, text);
+  const input = await findElement(page, xpath);
+  await input.click({ clickCount: 3 }); // triple-click to select the existing text
+  await input.type(text, { delay: Millis.of(20) });
 };
 
 const select = async (page, labelContains, text) => {


### PR DESCRIPTION
Recently, the register-user test is frequently failing with an error "requirement failed: contact email must be valid or empty".

It looks like this may be related to a change made in #4416, which added a click to `fillIn`.

`fillInReplace` triple clicks an input to select all text in an input before typing to replace the existing value. The extra click in `fillIn` undoes the selection.

This updates `fillInReplace` to not use `fillIn`.

register-user has passed twice on this PR and failed twice with a different error (a 500 response from Thurloe).
https://app.circleci.com/pipelines/github/DataBiosphere/terra-ui?branch=fix-fill-in-replace