### PR TITLE
[ID-917] Added terraDeploymentEnv to metrics

### DIFF
--- a/src/libs/ajax/Metrics.ts
+++ b/src/libs/ajax/Metrics.ts
@@ -23,7 +23,7 @@ export const Metrics = (signal?: AbortSignal) => {
         anonymousId: uuid(),
       }));
     }
-
+    const { buildTimestamp, gitRevision, terraDeploymentEnv } = getConfig();
     const body = {
       event,
       properties: {
@@ -33,9 +33,10 @@ export const Metrics = (signal?: AbortSignal) => {
         sessionId: getSessionId(),
         appId: 'Saturn',
         hostname: window.location.hostname,
+        env: terraDeploymentEnv,
         appPath: Nav.getCurrentRoute().name,
-        appVersion: getConfig().gitRevision,
-        appVersionBuildTime: new Date(getConfig().buildTimestamp).toISOString(),
+        appVersion: gitRevision,
+        appVersionBuildTime: new Date(buildTimestamp).toISOString(),
         ...getDefaultProperties(),
       },
     };


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/ID-917

### Dependencies
https://github.com/broadinstitute/terra-helmfile/pull/4765 Adds terraDeploymentEnv to BEEs.

## Summary of changes:
Mixpanel only has one project for all non-prod envs. This will allow differentiation for where metrics were sent from.

### What
- Added `env` to payload sent to mixpanel.

### Testing strategy
- [ ] Verified running on BEEs
