### PR TITLE
[AJ-1303] Include cloud platform in workspace info from NewWorkspaceModal

### DIFF
--- a/src/components/NewWorkspaceModal.test.ts
+++ b/src/components/NewWorkspaceModal.test.ts
@@ -4,6 +4,7 @@ import { act, fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { h } from 'react-hyperscript-helpers';
 import { Ajax } from 'src/libs/ajax';
+import { AzureWorkspaceInfo, GoogleWorkspaceInfo, WorkspaceInfo } from 'src/libs/workspace-utils';
 import { BillingProject, CloudPlatform } from 'src/pages/billing/models/BillingProject';
 import { renderWithAppContexts as render, SelectHelper } from 'src/testing/test-utils';
 
@@ -469,4 +470,87 @@ describe('NewWorkspaceModal', () => {
       expect(screen.queryByRole('button')).toBeNull();
     });
   });
+
+  it.each([
+    { billingProjectName: azureBillingProject.projectName, cloudPlatform: 'Azure' },
+    { billingProjectName: gcpBillingProject.projectName, cloudPlatform: 'Gcp' },
+  ] as { billingProjectName: string; cloudPlatform: WorkspaceInfo['cloudPlatform'] }[])(
+    'adds $cloudPlatform cloud platform to workspace',
+    async ({ billingProjectName, cloudPlatform }) => {
+      // Arrange
+      const user = userEvent.setup();
+
+      // Create workspace response does not include cloudPlatform.
+      // The modal should add it to the workspace passed to onSuccess.
+      const mockWorkspaces: {
+        Azure: Omit<AzureWorkspaceInfo, 'cloudPlatform'>;
+        Gcp: Omit<GoogleWorkspaceInfo, 'cloudPlatform'>;
+      } = {
+        Azure: {
+          namespace: azureBillingProject.projectName,
+          name: 'test-workspace',
+          workspaceId: 'aaaabbbb-cccc-dddd-0000-111122223333',
+          createdBy: 'user@example.com',
+          createdDate: '2023-11-13T18:39:32.267Z',
+          lastModified: '2023-11-13T18:39:32.267Z',
+          authorizationDomain: [],
+        },
+        Gcp: {
+          namespace: gcpBillingProject.projectName,
+          name: 'test-workspace',
+          workspaceId: 'aaaabbbb-cccc-dddd-0000-111122223333',
+          googleProject: 'test-project',
+          bucketName: 'fc-aaaabbbb-cccc-dddd-0000-111122223333',
+          createdBy: 'user@example.com',
+          createdDate: '2023-11-13T18:39:32.267Z',
+          lastModified: '2023-11-13T18:39:32.267Z',
+          authorizationDomain: [],
+        },
+      };
+      const createdWorkspace = mockWorkspaces[cloudPlatform];
+
+      const createWorkspace = jest.fn().mockResolvedValue(createdWorkspace);
+
+      asMockedFn(Ajax).mockImplementation(
+        () =>
+          ({
+            Billing: {
+              listProjects: async () => [azureBillingProject, gcpBillingProject],
+            },
+            Workspaces: {
+              create: createWorkspace,
+            },
+            ...nonBillingAjax,
+          } as AjaxContract)
+      );
+
+      const onSuccess = jest.fn();
+      await act(async () => {
+        render(
+          h(NewWorkspaceModal, {
+            onSuccess,
+            onDismiss: () => {},
+          })
+        );
+      });
+
+      // Act
+      const workspaceNameInput = screen.getByLabelText('Workspace name *');
+      act(() => {
+        fireEvent.change(workspaceNameInput, { target: { value: createdWorkspace.name } });
+      });
+
+      const projectSelect = new SelectHelper(screen.getByLabelText('Billing project *'), user);
+      await projectSelect.selectOption(new RegExp(billingProjectName));
+
+      const createWorkspaceButton = screen.getByRole('button', { name: 'Create Workspace' });
+      await user.click(createWorkspaceButton);
+
+      // Assert
+      expect(onSuccess).toHaveBeenCalledWith({
+        ...createdWorkspace,
+        cloudPlatform,
+      });
+    }
+  );
 });

--- a/src/components/NewWorkspaceModal.ts
+++ b/src/components/NewWorkspaceModal.ts
@@ -176,7 +176,23 @@ const NewWorkspaceModal = withDisplayName(
           }
         );
 
-        onSuccess(createdWorkspace);
+        // The create/clone workspace responses do not include the cloudPlatform field.
+        // Add it based on the billing project used to create the workspace.
+
+        // Translate between billing project cloud platform and workspace cloud platform constants.
+        const workspaceCloudPlatform: WorkspaceInfo['cloudPlatform'] | undefined = (() => {
+          const billingProjectCloudPlatform = getProjectCloudPlatform();
+          switch (billingProjectCloudPlatform) {
+            case 'AZURE':
+              return 'Azure';
+            case 'GCP':
+              return 'Gcp';
+            default:
+              return undefined;
+          }
+        })();
+
+        onSuccess({ ...createdWorkspace, cloudPlatform: workspaceCloudPlatform });
       } catch (error: unknown) {
         const { message } = await (error as Response).json();
         setCreating(false);

--- a/src/import-data/ImportData.ts
+++ b/src/import-data/ImportData.ts
@@ -84,8 +84,7 @@ export const ImportData = (props: ImportDataProps): ReactNode => {
   };
 
   const importTdrExport = async (importRequest: TDRSnapshotExportImportRequest, workspace: WorkspaceInfo) => {
-    // For new workspaces, cloudPlatform is blank
-    if (workspace.cloudPlatform === 'Azure' || workspace.googleProject === '') {
+    if (workspace.cloudPlatform === 'Azure') {
       // find wds for this workspace
       const wdsUrl = await Ajax().Apps.listAppsV2(workspace.workspaceId).then(resolveWdsUrl);
       const wdsDataTableProvider = new WdsDataTableProvider(workspace.workspaceId, wdsUrl);


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1303

The API response from the create/clone workspace endpoints does not include `cloudPlatform`. Thus, the workspace object that NewWorkspaceModal passes to its `onSuccess` handler currently does not include `cloudPlatform`. This does not match its type, which says that `onSuccess` is called with a `WorkspaceInfo` object.

As a result, we have to resort to workarounds like checking if the `googleProject` field is populated empty to determine whether a new workspace is on Azure or GCP (side note: why do Azure workspaces even have a `googleProject` field?). And worse, we have to _know_ that we have to do that: there's no hint in types or documentation.

This adds the `cloudPlatform` field to the workspace object passed to `onSuccess` using the cloud platform of the selected billing project in which the workspace was created.