### PR TITLE
[AJ-1303] Fix branching for TDR imports

### DIFF
--- a/src/import-data/ImportData.test.ts
+++ b/src/import-data/ImportData.test.ts
@@ -293,7 +293,7 @@ describe('ImportData', () => {
           ...commonSnapshotExportQueryParams,
           snapshotId: googleSnapshotFixture.id,
         };
-        const { getWorkspaceApi, importJob } = await setup({ queryParams });
+        const { getWorkspaceApi, importJob, importTdr } = await setup({ queryParams });
 
         // Act
         await importIntoExistingWorkspace(user, defaultGoogleWorkspace.workspace.name);
@@ -305,6 +305,7 @@ describe('ImportData', () => {
         );
 
         expect(importJob).toHaveBeenCalledWith(queryParams.tdrmanifest, 'tdrexport', { tdrSyncPermissions: true });
+        expect(importTdr).not.toHaveBeenCalled();
       });
 
       it('imports snapshots into Azure workspaces', async () => {
@@ -315,7 +316,7 @@ describe('ImportData', () => {
           ...commonSnapshotExportQueryParams,
           snapshotId: azureSnapshotFixture.id,
         };
-        const { importTdr, wdsProxyUrl } = await setup({ queryParams });
+        const { importJob, importTdr, wdsProxyUrl } = await setup({ queryParams });
 
         // Act
         await importIntoExistingWorkspace(user, defaultAzureWorkspace.workspace.name);
@@ -326,6 +327,7 @@ describe('ImportData', () => {
           defaultAzureWorkspace.workspace.workspaceId,
           queryParams.snapshotId
         );
+        expect(importJob).not.toHaveBeenCalled();
       });
     });
 

--- a/src/import-data/ImportData.ts
+++ b/src/import-data/ImportData.ts
@@ -91,16 +91,17 @@ export const ImportData = (props: ImportDataProps): ReactNode => {
       const wdsDataTableProvider = new WdsDataTableProvider(workspace.workspaceId, wdsUrl);
 
       // call import snapshot
-      wdsDataTableProvider.importTdr(workspace.workspaceId, importRequest.snapshot.id);
+      await wdsDataTableProvider.importTdr(workspace.workspaceId, importRequest.snapshot.id);
+    } else {
+      const { namespace, name } = workspace;
+      const { jobId } = await Ajax()
+        .Workspaces.workspace(namespace, name)
+        .importJob(importRequest.manifestUrl.toString(), 'tdrexport', {
+          tdrSyncPermissions: importRequest.syncPermissions,
+        });
+      asyncImportJobStore.update(Utils.append({ targetWorkspace: { namespace, name }, jobId }));
+      notifyDataImportProgress(jobId);
     }
-    const { namespace, name } = workspace;
-    const { jobId } = await Ajax()
-      .Workspaces.workspace(namespace, name)
-      .importJob(importRequest.manifestUrl.toString(), 'tdrexport', {
-        tdrSyncPermissions: importRequest.syncPermissions,
-      });
-    asyncImportJobStore.update(Utils.append({ targetWorkspace: { namespace, name }, jobId }));
-    notifyDataImportProgress(jobId);
   };
 
   const importSnapshot = async (importRequest: TDRSnapshotReferenceImportRequest, workspace: WorkspaceInfo) => {


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1303

Currently, when importing a TDR snapshot into an Azure workspace, requests are made to _both_ WDS and import service. An early return got lost in refactoring in https://github.com/DataBiosphere/terra-ui/pull/4300.

This fixes it to only send a request to WDS.