### PR TITLE
[AJ-1464] Add dev AnVIL bucket to protected data sources

### DIFF
--- a/src/import-data/protected-data-utils.ts
+++ b/src/import-data/protected-data-utils.ts
@@ -15,6 +15,7 @@ const protectedSources: ProtectedSource[] = [
   { type: 's3', bucket: 'edu-ucsc-gi-platform-anvil-prod-storage-anvilprod.us-east-1' },
   // AnVIL development
   { type: 'http', host: 'service.anvil.gi.ucsc.edu' },
+  { type: 's3', bucket: 'edu-ucsc-gi-platform-anvil-dev-storage-anvildev.us-east-1' },
   //  BioData Catalyst
   { type: 'http', host: 'gen3.biodatacatalyst.nhlbi.nih.gov' },
   { type: 's3', bucket: 'gen3-biodatacatalyst-nhlbi-nih-gov-pfb-export' },


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1464

This adds the dev AnVIL bucket to the list of protected data sources. This will make manual testing of importing AnVIL data easier since we will be able to see the expected protected data UI in development.