### PR TITLE
[WOR-1349] Improve error reporting for new workspace modal

### DIFF
--- a/src/components/NewWorkspaceModal.ts
+++ b/src/components/NewWorkspaceModal.ts
@@ -21,7 +21,7 @@ import { Ajax } from 'src/libs/ajax';
 import { CurrentUserGroupMembership } from 'src/libs/ajax/Groups';
 import colors from 'src/libs/colors';
 import { getConfig } from 'src/libs/config';
-import { reportErrorAndRethrow, withErrorReporting } from 'src/libs/error';
+import { reportErrorAndRethrow, withErrorReportingInModal } from 'src/libs/error';
 import Events, { extractCrossWorkspaceDetails, extractWorkspaceDetails } from 'src/libs/events';
 import { FormLabel } from 'src/libs/forms';
 import * as Nav from 'src/libs/nav';
@@ -185,7 +185,7 @@ const NewWorkspaceModal = withDisplayName(
     };
 
     const loadData = _.flow(
-      withErrorReporting('Error loading data'),
+      withErrorReportingInModal('Error loading data', onDismiss),
       Utils.withBusyState(setLoading)
     )(() =>
       Promise.all([

--- a/src/libs/error.ts
+++ b/src/libs/error.ts
@@ -11,7 +11,7 @@ export const reportError = async (title, obj) => {
     return;
   }
 
-  notify('error', title, { detail: await (obj instanceof Response ? obj.text() : obj) });
+  notify('error', title, { detail: await (obj instanceof Response ? obj.text().catch(() => 'Unknown error') : obj) });
 };
 
 export type ErrorCallback = (error: unknown) => void | Promise<void>;
@@ -58,8 +58,8 @@ export const reportErrorAndRethrow = _.curry((title, fn) => {
  *  As such, we must ensure we call the dismiss function if an error occurs
  */
 export const withErrorReportingInModal = _.curry((title, onDismiss, fn) => {
-  return _.flip(withErrorHandling)(fn, (error) => {
-    reportError(title, error);
+  return _.flip(withErrorHandling)(fn, async (error) => {
+    await reportError(title, error);
     onDismiss();
     throw error;
   });


### PR DESCRIPTION
Today's issues with listing billing projects revealed an issue with NewWorkspaceModal.

As I'm writing this, https://rawls.dsde-dev.broadinstitute.org/api/billing/v2 is returning a 500 error. NewWorkspaceModal calls  that endpoint to list billing projects when it is mounted.

Currently, when it fails, an error notification is shown, but there's also an infinite spinner.

https://github.com/DataBiosphere/terra-ui/assets/1156625/5f44f552-568d-4aa6-9e80-609d580050a6

At first, I tried changing NewWorkspaceModal to use `withErrorReportingInModal` instead of `withErrorReporting`, so that the modal (which rendered the spinner) would be removed on an error.

That resolved the infinite spinner, but resulted in no error notification being shown.

https://github.com/DataBiosphere/terra-ui/assets/1156625/23788229-119c-43d3-9a9c-12525a340f4a

Finally, I determined the issue is that when NewWorkspaceModal is unmounted by `withErrorReportingInModal` calling `onDismiss`, it fires the abort signal from `useCancellation` to abort all ongoing requests. This signal is also given to the request that caused the error, and cancelling that request prevents `reportError` from reading the Response's text (`obj.text()` rejects with an error "Uncaught DOMException: The user aborted a request."). That error prevents the error notification from being shown and bubbles up as an uncaught promise rejection.

https://github.com/DataBiosphere/terra-ui/blob/e87918b552ab4dcfd234d4ac55e36fddc788b5ec/src/libs/error.ts#L14

The solution to this is to await `reportError` in `withErrorHandlingInModal` so that the error response is read _before_ the modal is dismissed and the request aborted.

This results in the desired behavior: the modal and its spinner are removed and an error notification is shown.

https://github.com/DataBiosphere/terra-ui/assets/1156625/f22fd70d-e647-4ba3-ab0f-4c9d2e278660

Awaiting `reportError` also means that if `reportError` throws an error, `withErrorReportingInModal`'s error handling function will not continue and call `onDismiss`. To prevent that, this also adds handling for errors reading the response text in `reportError`. If there's an error reading the response, `reportError` will now succeed and show an error notification with "Unknown error", whereas currently it fails and shows no error notification in that case.