### PR TITLE
[AJ-1458] Add cloud provider icons to WorkspaceSelector

### DIFF
--- a/src/analysis/modals/ExportAnalysisModal/ExportAnalysisModal.test.ts
+++ b/src/analysis/modals/ExportAnalysisModal/ExportAnalysisModal.test.ts
@@ -6,7 +6,12 @@ import { AnalysisFile } from 'src/analysis/useAnalysisFiles';
 import { AbsolutePath, DisplayName, FileExtension, FileName } from 'src/analysis/utils/file-utils';
 import { runtimeToolLabels } from 'src/analysis/utils/tool-utils';
 import { WorkspaceInfo, WorkspaceWrapper } from 'src/libs/workspace-utils';
-import { asMockedFn, renderWithAppContexts as render, setUpAutoSizerTesting } from 'src/testing/test-utils';
+import {
+  asMockedFn,
+  renderWithAppContexts as render,
+  SelectHelper,
+  setUpAutoSizerTesting,
+} from 'src/testing/test-utils';
 
 import { ExportAnalysisModal } from './ExportAnalysisModal';
 
@@ -155,15 +160,13 @@ describe('ExportAnalysisModal', () => {
     );
 
     // Act
-    const destDropdown = screen.getByLabelText('Destination *');
-    await user.click(destDropdown);
-    const destOptions = screen.getAllByRole('option').map((el: HTMLElement) => el.textContent);
-    const destOption = screen.getByText('name2');
-    await user.click(destOption);
+    const destDropdown = new SelectHelper(screen.getByLabelText('Destination *'), user);
+    const destOptions = await destDropdown.getOptions();
+    await destDropdown.selectOption(/name2/);
 
     // Assert
     // drop-down should only list options that are not same as source workspace (name1)
-    expect(destOptions).toEqual(['name2', 'name3']);
+    expect(destOptions).toEqual([expect.stringMatching(/name2/), expect.stringMatching(/name3/)]);
     expect(selectWorkspaceWatcher).toBeCalledTimes(1);
     expect(selectWorkspaceWatcher).toBeCalledWith('Workspace2');
   });

--- a/src/components/workspace-utils.js
+++ b/src/components/workspace-utils.js
@@ -15,7 +15,7 @@ import { useCancellation, useInstance, useOnMount, useStore, withDisplayName } f
 import { workspacesStore } from 'src/libs/state';
 import * as Style from 'src/libs/style';
 import * as Utils from 'src/libs/utils';
-import { getCloudProviderFromWorkspace } from 'src/libs/workspace-utils';
+import { cloudProviderLabels, getCloudProviderFromWorkspace } from 'src/libs/workspace-utils';
 
 export const useWorkspaces = (fieldsArg, stringAttributeMaxLength) => {
   const signal = useCancellation();
@@ -82,6 +82,7 @@ export const WorkspaceSelector = ({ workspaces, value, onChange, id, 'aria-label
   const options = _.flow(
     _.sortBy((ws) => ws.workspace.name.toLowerCase()),
     _.map(({ workspace: { workspaceId, name, cloudPlatform, bucketName } }) => ({
+      'aria-label': `${cloudProviderLabels[cloudPlatform]} ${name}`,
       value: workspaceId,
       label: name,
       workspace: { cloudPlatform, bucketName },
@@ -95,6 +96,20 @@ export const WorkspaceSelector = ({ workspaces, value, onChange, id, 'aria-label
     value,
     onChange: ({ value }) => onChange(value),
     options,
+    formatOptionLabel: (opt) => {
+      const {
+        label,
+        workspace: { cloudPlatform },
+      } = opt;
+      return div({ style: { display: 'flex', alignItems: 'center' } }, [
+        h(CloudProviderIcon, {
+          // Convert workspace cloudPlatform (Azure, Gcp) to CloudProvider (AZURE, GCP).
+          cloudProvider: cloudPlatform.toUpperCase(),
+          style: { marginRight: '0.5rem' },
+        }),
+        label,
+      ]);
+    },
     ...props,
   });
 };

--- a/src/components/workspace-utils.test.ts
+++ b/src/components/workspace-utils.test.ts
@@ -1,14 +1,16 @@
 import { getAllByRole, getByRole, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { h } from 'react-hyperscript-helpers';
+import { WorkspaceWrapper as Workspace } from 'src/libs/workspace-utils';
+import { makeGoogleWorkspace } from 'src/testing/workspace-fixtures';
 
 import { WorkspaceSelector } from './workspace-utils';
 
 describe('WorkspaceSelector', () => {
-  const workspaces = [
-    { workspace: { workspaceId: 'workspace-a', name: 'Workspace A' } },
-    { workspace: { workspaceId: 'workspace-b', name: 'Workspace B' } },
-    { workspace: { workspaceId: 'workspace-c', name: 'Workspace C' } },
+  const workspaces: Workspace[] = [
+    makeGoogleWorkspace({ workspace: { workspaceId: 'workspace-a', name: 'Workspace A' } }),
+    makeGoogleWorkspace({ workspace: { workspaceId: 'workspace-b', name: 'Workspace B' } }),
+    makeGoogleWorkspace({ workspace: { workspaceId: 'workspace-c', name: 'Workspace C' } }),
   ];
 
   it('renders a list of workspaces', async () => {
@@ -33,7 +35,11 @@ describe('WorkspaceSelector', () => {
     const options = getAllByRole(listbox, 'option');
     const optionLabels = options.map((opt) => opt.textContent!);
 
-    expect(optionLabels).toEqual(['Workspace A', 'Workspace B', 'Workspace C']);
+    expect(optionLabels).toEqual([
+      expect.stringMatching(/Workspace A/),
+      expect.stringMatching(/Workspace B/),
+      expect.stringMatching(/Workspace C/),
+    ]);
   });
 
   it('calls onChange with workspace ID when a workspace is selected', async () => {
@@ -56,7 +62,7 @@ describe('WorkspaceSelector', () => {
     const listboxId = selectInput.getAttribute('aria-controls')!;
     const listbox = document.getElementById(listboxId)!;
 
-    const workspaceBOption = getByRole(listbox, 'option', { name: 'Workspace B' });
+    const workspaceBOption = getByRole(listbox, 'option', { name: /Workspace B/ });
     await user.click(workspaceBOption);
 
     // Assert

--- a/src/import-data/ImportData.test.ts
+++ b/src/import-data/ImportData.test.ts
@@ -188,7 +188,7 @@ const importIntoExistingWorkspace = async (user: UserEvent, workspaceName: strin
   await user.click(existingWorkspace);
 
   const workspaceSelect = new SelectHelper(screen.getByLabelText('Select a workspace'), user);
-  await workspaceSelect.selectOption(workspaceName);
+  await workspaceSelect.selectOption(new RegExp(workspaceName));
 
   await user.click(screen.getByRole('button', { name: 'Import' }));
 };

--- a/src/import-data/ImportDataDestination.test.ts
+++ b/src/import-data/ImportDataDestination.test.ts
@@ -215,7 +215,7 @@ describe('ImportDataDestination', () => {
 
       // Assert
       expect(canImportIntoWorkspace).toHaveBeenCalledWith(expectedArgs, expect.anything());
-      expect(workspaces).toEqual(['allowed-workspace']);
+      expect(workspaces).toEqual([expect.stringMatching(/allowed-workspace/)]);
     }
   );
 

--- a/src/pages/ImportWorkflow/ImportWorkflow.test.ts
+++ b/src/pages/ImportWorkflow/ImportWorkflow.test.ts
@@ -9,7 +9,7 @@ import { errorWatcher } from 'src/libs/error.mock';
 import * as Nav from 'src/libs/nav';
 import { getTerraUser } from 'src/libs/state';
 import { WorkspaceWrapper } from 'src/libs/workspace-utils';
-import { asMockedFn, renderWithAppContexts as render } from 'src/testing/test-utils';
+import { asMockedFn, renderWithAppContexts as render, SelectHelper } from 'src/testing/test-utils';
 
 import { importDockstoreWorkflow } from './importDockstoreWorkflow';
 import { ImportWorkflow } from './ImportWorkflow';
@@ -211,7 +211,7 @@ describe('ImportWorkflow', () => {
         {
           workspace: {
             namespace: 'test',
-            name: 'workspace1',
+            name: 'gcp-workspace1',
             workspaceId: '6771d2c8-cd58-47da-a54c-6cdafacc4175',
             cloudPlatform: 'Gcp',
           },
@@ -220,7 +220,7 @@ describe('ImportWorkflow', () => {
         {
           workspace: {
             namespace: 'test',
-            name: 'workspace2',
+            name: 'gcp-workspace2',
             workspaceId: '5cfa16d8-d604-4de8-8e8a-acde05d71b99',
             cloudPlatform: 'Gcp',
           },
@@ -331,10 +331,8 @@ describe('ImportWorkflow', () => {
     render(h(ImportWorkflow, { ...testWorkflow }));
 
     // Act
-    const workspaceMenu = screen.getByLabelText('Destination Workspace');
-    await user.click(workspaceMenu);
-    const option = screen.getAllByRole('option').find((el) => el.textContent === 'workspace1')!;
-    await user.click(option);
+    const workspaceMenu = new SelectHelper(screen.getByLabelText('Destination Workspace'), user);
+    await workspaceMenu.selectOption(/gcp-workspace1/);
 
     const importButton = screen.getByText('Import');
     await user.click(importButton);
@@ -342,7 +340,7 @@ describe('ImportWorkflow', () => {
     // Assert
     expect(importDockstoreWorkflow).toHaveBeenCalledWith(
       expect.objectContaining({
-        workspace: expect.objectContaining({ namespace: 'test', name: 'workspace1' }),
+        workspace: expect.objectContaining({ namespace: 'test', name: 'gcp-workspace1' }),
         workflow: testWorkflow,
       }),
       { overwrite: false }
@@ -387,10 +385,8 @@ describe('ImportWorkflow', () => {
     render(h(ImportWorkflow, { ...testWorkflow }));
 
     // Act
-    const workspaceMenu = screen.getByLabelText('Destination Workspace');
-    await user.click(workspaceMenu);
-    const option = screen.getAllByRole('option').find((el) => el.textContent === 'azure-workspace1')!;
-    await user.click(option);
+    const workspaceMenu = new SelectHelper(screen.getByLabelText('Destination Workspace'), user);
+    await workspaceMenu.selectOption(/azure-workspace1/);
 
     const importButton = screen.getByText('Import');
     await user.click(importButton);
@@ -439,10 +435,8 @@ describe('ImportWorkflow', () => {
     render(h(ImportWorkflow, { ...testWorkflow }));
 
     // Act
-    const workspaceMenu = screen.getByLabelText('Destination Workspace');
-    await user.click(workspaceMenu);
-    const option = screen.getAllByRole('option').find((el) => el.textContent === 'azure-workspace2')!;
-    await user.click(option);
+    const workspaceMenu = new SelectHelper(screen.getByLabelText('Destination Workspace'), user);
+    await workspaceMenu.selectOption(/azure-workspace2/);
 
     const importButton = screen.getByText('Import');
     await user.click(importButton);
@@ -489,10 +483,8 @@ describe('ImportWorkflow', () => {
     render(h(ImportWorkflow, { ...testWorkflow }));
 
     // Act
-    const workspaceMenu = screen.getByLabelText('Destination Workspace');
-    await user.click(workspaceMenu);
-    const option = screen.getAllByRole('option').find((el) => el.textContent === 'workspace1')!;
-    await user.click(option);
+    const workspaceMenu = new SelectHelper(screen.getByLabelText('Destination Workspace'), user);
+    await workspaceMenu.selectOption(/gcp-workspace1/);
 
     const importButton = screen.getByText('Import');
     await user.click(importButton);
@@ -508,7 +500,7 @@ describe('ImportWorkflow', () => {
     // Assert
     expect(firstImportDockstoreWorkflowCallArgs).toEqual([
       expect.objectContaining({
-        workspace: expect.objectContaining({ namespace: 'test', name: 'workspace1' }),
+        workspace: expect.objectContaining({ namespace: 'test', name: 'gcp-workspace1' }),
         workflow: testWorkflow,
       }),
       { overwrite: false },
@@ -518,7 +510,7 @@ describe('ImportWorkflow', () => {
 
     expect(secondImportDockstoreWorkflowCallArgs).toEqual([
       expect.objectContaining({
-        workspace: expect.objectContaining({ namespace: 'test', name: 'workspace1' }),
+        workspace: expect.objectContaining({ namespace: 'test', name: 'gcp-workspace1' }),
         workflow: testWorkflow,
       }),
       { overwrite: true },


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1458

This adds cloud provider icons to the options in WorkspaceSelector.

## Before
<img width="590" alt="Screenshot 2023-11-13 at 9 13 48 PM" src="https://github.com/DataBiosphere/terra-ui/assets/1156625/03c518d1-9c39-475c-81ba-8e46a5f8a2ab">

## After
<img width="659" alt="Screenshot 2023-11-13 at 9 13 28 PM" src="https://github.com/DataBiosphere/terra-ui/assets/1156625/736d4a47-a954-450d-8662-9b5145d035a3">

--- 

In tests, there is no bundler, so Jest is configured to transform file imports such that icons are rendered as an SVG containing the icon's file name. Thus, in tests, WorkspaceSelectors' options now have text content like `cloud_google_icon.svgworkspace name`. This required some updates to several tests to match options based on a regex / string containing the workspace name vs exactly matching the workspace name.