### PR TITLE
AJ-1440: pfb import->Azure feature flag

### DIFF
--- a/src/import-data/ImportDataDestination.test.ts
+++ b/src/import-data/ImportDataDestination.test.ts
@@ -123,11 +123,7 @@ describe('ImportDataDestination', () => {
     {
       importRequest: { type: 'pfb', url: new URL('https://example.com/path/to/file.pfb') },
       requiredAuthorizationDomain: undefined,
-      expectedArgs: {
-        cloudPlatform: 'GCP',
-        isProtectedData: false,
-        requiredAuthorizationDomain: undefined,
-      },
+      expectedArgs: { cloudPlatform: 'GCP', isProtectedData: false, requiredAuthorizationDomain: undefined },
     },
     {
       importRequest: {
@@ -178,11 +174,7 @@ describe('ImportDataDestination', () => {
   ] as {
     importRequest: ImportRequest;
     requiredAuthorizationDomain?: string;
-    expectedArgs: {
-      cloudPlatform?: CloudProvider;
-      isProtectedData: boolean;
-      requiredAuthorizationDomain?: string;
-    };
+    expectedArgs: { cloudPlatform?: CloudProvider; isProtectedData: boolean; requiredAuthorizationDomain?: string };
   }[])(
     'should filter workspaces through canImportIntoWorkspace',
     async ({ importRequest, requiredAuthorizationDomain, expectedArgs }) => {

--- a/src/import-data/ImportDataDestination.test.ts
+++ b/src/import-data/ImportDataDestination.test.ts
@@ -115,7 +115,7 @@ describe('ImportDataDestination', () => {
       importRequest: { type: 'pfb', url: new URL('https://service.prod.anvil.gi.ucsc.edu/path/to/file.pfb') },
       requiredAuthorizationDomain: 'test-auth-domain',
       expectedArgs: {
-        cloudPlatform: undefined,
+        cloudPlatform: 'GCP',
         isProtectedData: true,
         requiredAuthorizationDomain: 'test-auth-domain',
         importType: 'pfb',
@@ -125,7 +125,7 @@ describe('ImportDataDestination', () => {
       importRequest: { type: 'pfb', url: new URL('https://example.com/path/to/file.pfb') },
       requiredAuthorizationDomain: undefined,
       expectedArgs: {
-        cloudPlatform: undefined,
+        cloudPlatform: 'GCP',
         isProtectedData: false,
         requiredAuthorizationDomain: undefined,
         importType: 'pfb',
@@ -313,7 +313,7 @@ describe('ImportDataDestination', () => {
         requiredAuthorizationDomain: undefined,
       },
       expectedNewWorkspaceModalProps: {
-        cloudPlatform: undefined,
+        cloudPlatform: 'GCP',
         requiredAuthDomain: undefined,
         requireEnhancedBucketLogging: false,
       },
@@ -325,7 +325,7 @@ describe('ImportDataDestination', () => {
         requiredAuthorizationDomain: 'test-auth-domain',
       },
       expectedNewWorkspaceModalProps: {
-        cloudPlatform: undefined,
+        cloudPlatform: 'GCP',
         requiredAuthDomain: 'test-auth-domain',
         requireEnhancedBucketLogging: true,
       },

--- a/src/import-data/ImportDataDestination.test.ts
+++ b/src/import-data/ImportDataDestination.test.ts
@@ -150,11 +150,7 @@ describe('ImportDataDestination', () => {
         syncPermissions: false,
       },
       requiredAuthorizationDomain: undefined,
-      expectedArgs: {
-        cloudPlatform: 'GCP',
-        isProtectedData: false,
-        requiredAuthorizationDomain: undefined,
-      },
+      expectedArgs: { cloudPlatform: 'GCP', isProtectedData: false, requiredAuthorizationDomain: undefined },
     },
     {
       importRequest: {
@@ -177,11 +173,7 @@ describe('ImportDataDestination', () => {
         syncPermissions: false,
       },
       requiredAuthorizationDomain: undefined,
-      expectedArgs: {
-        cloudPlatform: 'AZURE',
-        isProtectedData: false,
-        requiredAuthorizationDomain: undefined,
-      },
+      expectedArgs: { cloudPlatform: 'AZURE', isProtectedData: false, requiredAuthorizationDomain: undefined },
     },
   ] as {
     importRequest: ImportRequest;

--- a/src/import-data/ImportDataDestination.test.ts
+++ b/src/import-data/ImportDataDestination.test.ts
@@ -118,12 +118,18 @@ describe('ImportDataDestination', () => {
         cloudPlatform: undefined,
         isProtectedData: true,
         requiredAuthorizationDomain: 'test-auth-domain',
+        importType: 'pfb',
       },
     },
     {
       importRequest: { type: 'pfb', url: new URL('https://example.com/path/to/file.pfb') },
       requiredAuthorizationDomain: undefined,
-      expectedArgs: { cloudPlatform: undefined, isProtectedData: false, requiredAuthorizationDomain: undefined },
+      expectedArgs: {
+        cloudPlatform: undefined,
+        isProtectedData: false,
+        requiredAuthorizationDomain: undefined,
+        importType: 'pfb',
+      },
     },
     {
       importRequest: {
@@ -146,7 +152,12 @@ describe('ImportDataDestination', () => {
         syncPermissions: false,
       },
       requiredAuthorizationDomain: undefined,
-      expectedArgs: { cloudPlatform: 'GCP', isProtectedData: false, requiredAuthorizationDomain: undefined },
+      expectedArgs: {
+        cloudPlatform: 'GCP',
+        isProtectedData: false,
+        requiredAuthorizationDomain: undefined,
+        importType: 'tdr-snapshot-export',
+      },
     },
     {
       importRequest: {
@@ -169,12 +180,22 @@ describe('ImportDataDestination', () => {
         syncPermissions: false,
       },
       requiredAuthorizationDomain: undefined,
-      expectedArgs: { cloudPlatform: 'AZURE', isProtectedData: false, requiredAuthorizationDomain: undefined },
+      expectedArgs: {
+        cloudPlatform: 'AZURE',
+        isProtectedData: false,
+        requiredAuthorizationDomain: undefined,
+        importType: 'tdr-snapshot-export',
+      },
     },
   ] as {
     importRequest: ImportRequest;
     requiredAuthorizationDomain?: string;
-    expectedArgs: { cloudPlatform?: CloudProvider; isProtectedData: boolean; requiredAuthorizationDomain?: string };
+    expectedArgs: {
+      cloudPlatform?: CloudProvider;
+      isProtectedData: boolean;
+      requiredAuthorizationDomain?: string;
+      importType?: string;
+    };
   }[])(
     'should filter workspaces through canImportIntoWorkspace',
     async ({ importRequest, requiredAuthorizationDomain, expectedArgs }) => {

--- a/src/import-data/ImportDataDestination.test.ts
+++ b/src/import-data/ImportDataDestination.test.ts
@@ -118,7 +118,6 @@ describe('ImportDataDestination', () => {
         cloudPlatform: 'GCP',
         isProtectedData: true,
         requiredAuthorizationDomain: 'test-auth-domain',
-        importType: 'pfb',
       },
     },
     {
@@ -128,7 +127,6 @@ describe('ImportDataDestination', () => {
         cloudPlatform: 'GCP',
         isProtectedData: false,
         requiredAuthorizationDomain: undefined,
-        importType: 'pfb',
       },
     },
     {
@@ -156,7 +154,6 @@ describe('ImportDataDestination', () => {
         cloudPlatform: 'GCP',
         isProtectedData: false,
         requiredAuthorizationDomain: undefined,
-        importType: 'tdr-snapshot-export',
       },
     },
     {
@@ -184,7 +181,6 @@ describe('ImportDataDestination', () => {
         cloudPlatform: 'AZURE',
         isProtectedData: false,
         requiredAuthorizationDomain: undefined,
-        importType: 'tdr-snapshot-export',
       },
     },
   ] as {
@@ -194,7 +190,6 @@ describe('ImportDataDestination', () => {
       cloudPlatform?: CloudProvider;
       isProtectedData: boolean;
       requiredAuthorizationDomain?: string;
-      importType?: string;
     };
   }[])(
     'should filter workspaces through canImportIntoWorkspace',

--- a/src/import-data/ImportDataDestination.ts
+++ b/src/import-data/ImportDataDestination.ts
@@ -191,7 +191,7 @@ export const ImportDataDestination = (props: ImportDataDestinationProps): ReactN
                     cloudPlatform: requiredCloudPlatform,
                     isProtectedData,
                     requiredAuthorizationDomain,
-                    importRequest,
+                    importType: importRequest.type,
                   },
                   workspace
                 );

--- a/src/import-data/ImportDataDestination.ts
+++ b/src/import-data/ImportDataDestination.ts
@@ -191,6 +191,7 @@ export const ImportDataDestination = (props: ImportDataDestinationProps): ReactN
                     cloudPlatform: requiredCloudPlatform,
                     isProtectedData,
                     requiredAuthorizationDomain,
+                    importRequest,
                   },
                   workspace
                 );

--- a/src/import-data/ImportDataDestination.ts
+++ b/src/import-data/ImportDataDestination.ts
@@ -191,7 +191,6 @@ export const ImportDataDestination = (props: ImportDataDestinationProps): ReactN
                     cloudPlatform: requiredCloudPlatform,
                     isProtectedData,
                     requiredAuthorizationDomain,
-                    importType: importRequest.type,
                   },
                   workspace
                 );

--- a/src/import-data/import-utils.feature-flag.test.ts
+++ b/src/import-data/import-utils.feature-flag.test.ts
@@ -18,6 +18,6 @@ describe('getRequiredCloudPlatformForImport', () => {
     const cloudPlatform = getCloudPlatformRequiredForImport(importRequest);
 
     // Assert
-    expect(cloudPlatform).toEqual(undefined);
+    expect(cloudPlatform).toBeUndefined();
   });
 });

--- a/src/import-data/import-utils.feature-flag.test.ts
+++ b/src/import-data/import-utils.feature-flag.test.ts
@@ -1,0 +1,23 @@
+import { ImportRequest } from './import-types';
+import { getCloudPlatformRequiredForImport } from './import-utils';
+
+jest.mock('src/libs/feature-previews', () => ({
+  ...jest.requireActual('src/libs/feature-previews'),
+  isFeaturePreviewEnabled: jest.fn().mockReturnValue(true),
+}));
+
+// Note that behavior of getRequiredCloudPlatformForImport when the feature flag is set to false is tested
+// in import-utils.test.ts. This file only tests behavior when the feature flag is set to true.
+// Since `jest.mock` is global for any given file, the test below is given this new file.
+describe('getRequiredCloudPlatformForImport', () => {
+  it('should respect the feature flag for PFB imports', async () => {
+    // Arrange
+    const importRequest: ImportRequest = { type: 'pfb', url: new URL('https://example.com/path/to/file.pfb') };
+
+    // Act
+    const cloudPlatform = getCloudPlatformRequiredForImport(importRequest);
+
+    // Assert
+    expect(cloudPlatform).toEqual(undefined);
+  });
+});

--- a/src/import-data/import-utils.feature-flag.test.ts
+++ b/src/import-data/import-utils.feature-flag.test.ts
@@ -1,10 +1,15 @@
 import { ImportRequest } from './import-types';
 import { getCloudPlatformRequiredForImport } from './import-utils';
 
-jest.mock('src/libs/feature-previews', () => ({
-  ...jest.requireActual('src/libs/feature-previews'),
-  isFeaturePreviewEnabled: jest.fn().mockReturnValue(true),
-}));
+type FeaturePreviewExports = typeof import('src/libs/feature-previews');
+
+jest.mock(
+  'src/libs/feature-previews',
+  (): FeaturePreviewExports => ({
+    ...jest.requireActual('src/libs/feature-previews'),
+    isFeaturePreviewEnabled: jest.fn().mockReturnValue(true),
+  })
+);
 
 // Note that behavior of getRequiredCloudPlatformForImport when the feature flag is set to false is tested
 // in import-utils.test.ts. This file only tests behavior when the feature flag is set to true.

--- a/src/import-data/import-utils.test.ts
+++ b/src/import-data/import-utils.test.ts
@@ -8,7 +8,7 @@ describe('getRequiredCloudPlatformForImport', () => {
   it.each([
     {
       importRequest: { type: 'pfb', url: new URL('https://example.com/path/to/file.pfb') },
-      expectedCloudPlatfrom: undefined,
+      expectedCloudPlatform: 'GCP',
     },
     {
       importRequest: {

--- a/src/import-data/import-utils.ts
+++ b/src/import-data/import-utils.ts
@@ -15,6 +15,9 @@ export const getCloudPlatformRequiredForImport = (importRequest: ImportRequest):
         gcp: 'GCP',
       };
       return tdrCloudPlatformToCloudProvider[importRequest.snapshot.cloudPlatform];
+    case 'pfb':
+      // restrict PFB imports to GCP unless the user has the right feature flag enabled
+      return isFeaturePreviewEnabled(ENABLE_AZURE_PFB_IMPORT) ? undefined : 'GCP';
     default:
       return undefined;
   }

--- a/src/import-data/import-utils.ts
+++ b/src/import-data/import-utils.ts
@@ -32,9 +32,6 @@ export type ImportOptions = {
 
   /** Authorization domain required for the source data. */
   requiredAuthorizationDomain?: string;
-
-  /** The import request, used to calculate feature flags */
-  importType?: string;
 };
 
 /**
@@ -47,7 +44,7 @@ export type ImportOptions = {
  * @param workspace - Candidate workspace.
  */
 export const canImportIntoWorkspace = (importOptions: ImportOptions, workspace: WorkspaceWrapper): boolean => {
-  const { cloudPlatform, isProtectedData, requiredAuthorizationDomain, importType } = importOptions;
+  const { cloudPlatform, isProtectedData, requiredAuthorizationDomain } = importOptions;
 
   // The user must be able to write to the workspace to import data.
   if (!canWrite(workspace.accessLevel)) {
@@ -70,15 +67,6 @@ export const canImportIntoWorkspace = (importOptions: ImportOptions, workspace: 
     !workspace.workspace.authorizationDomain.some(
       ({ membersGroupName }) => membersGroupName === requiredAuthorizationDomain
     )
-  ) {
-    return false;
-  }
-
-  // Check feature flags to see if this particular import use case is supported
-  if (
-    importType === 'pfb' &&
-    getCloudProviderFromWorkspace(workspace) === 'AZURE' &&
-    !isFeaturePreviewEnabled(ENABLE_AZURE_PFB_IMPORT)
   ) {
     return false;
   }

--- a/src/import-data/import-utils.ts
+++ b/src/import-data/import-utils.ts
@@ -31,7 +31,7 @@ export type ImportOptions = {
   requiredAuthorizationDomain?: string;
 
   /** The import request, used to calculate feature flags */
-  importRequest: ImportRequest;
+  importType?: string;
 };
 
 /**
@@ -44,7 +44,7 @@ export type ImportOptions = {
  * @param workspace - Candidate workspace.
  */
 export const canImportIntoWorkspace = (importOptions: ImportOptions, workspace: WorkspaceWrapper): boolean => {
-  const { cloudPlatform, isProtectedData, requiredAuthorizationDomain, importRequest } = importOptions;
+  const { cloudPlatform, isProtectedData, requiredAuthorizationDomain, importType } = importOptions;
 
   // The user must be able to write to the workspace to import data.
   if (!canWrite(workspace.accessLevel)) {
@@ -73,7 +73,7 @@ export const canImportIntoWorkspace = (importOptions: ImportOptions, workspace: 
 
   // Check feature flags to see if this particular import use case is supported
   if (
-    importRequest.type === 'pfb' &&
+    importType === 'pfb' &&
     getCloudProviderFromWorkspace(workspace) === 'AZURE' &&
     !isFeaturePreviewEnabled(ENABLE_AZURE_PFB_IMPORT)
   ) {

--- a/src/libs/feature-previews-config.ts
+++ b/src/libs/feature-previews-config.ts
@@ -3,6 +3,7 @@ export const ENABLE_JUPYTERLAB_ID = 'enableJupyterLabGCP';
 export const HAIL_BATCH_AZURE_FEATURE_ID = 'hail-batch-azure';
 export const ENABLE_AZURE_COLLABORATIVE_WORKFLOW_READERS = 'enableCollborativeWorkflowReaders';
 export const ENABLE_WORKFLOW_RESOURCE_MONITORING = 'enableWorkflowResourceMonitoring';
+export const ENABLE_AZURE_PFB_IMPORT = 'enableAzurePfbImport';
 
 // If the groups option is defined for a FeaturePreview, it must contain at least one group.
 type GroupsList = readonly [string, ...string[]];
@@ -96,6 +97,15 @@ const featurePreviewsConfig: readonly FeaturePreview[] = [
       "Configure the 'monitoring_script', 'monitoring_image', and 'monitoring_image_script' options for sending to Cromwell.",
     feedbackUrl: `mailto:dsp-workflow-execution@broadinstitute.org?subject=${encodeURIComponent(
       'Feedback on workflow resource monitoring'
+    )}`,
+  },
+  {
+    id: ENABLE_AZURE_PFB_IMPORT,
+    title: 'Azure PFB Import',
+    description: 'Enabling this feature will allow PFB import into Azure workspaces.',
+    groups: ['preview-azure-pfb-import'],
+    feedbackUrl: `mailto:dsp-analysis-journeys@broadinstitute.org?subject=${encodeURIComponent(
+      'Feedback on Azure PFB Import'
     )}`,
   },
 ];


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/AJ-1440

### Dependencies
AJ-1303, AJ-1427, AJ-1228, AJ-1383 all deal with imports into Azure workspaces; they should be careful to integrate with this feature flag.

## Summary of changes:
Adds a new feature flag to enable/disable PFB import into Azure workspaces.

### What
The new 'Azure PFB Import' feature flag now controls if PFB imports are allowed to use Azure workspaces. When the flag is not set, Azure workspaces are not allowed.

This is implemented by setting the required cloud platform in `getCloudPlatformRequiredForImport()`. Previously, all PFB imports returned `undefined`, which means any workspace is allowed. Now, PFB imports return `undefined`  iff the  'Azure PFB Import' feature flag is set; else, they return 'GCP'.

The required cloud platform affects import into both new and existing workspaces.

### Why
PFB import to Azure workspaces is a work in progress; we want to disable it for most users and roll it out slowly. Thus, a feature flag.

### Testing strategy
- [x] Tested locally
- [x] Added unit test and updated existing unit tests

### Visual Aids
![Screenshot 11-14-2023 at 02 23 PM](https://github.com/DataBiosphere/terra-ui/assets/6041577/d7a4789b-2f88-43ec-90dd-2a555c4a9c3c)
