### PR TITLE
[AJ-1460] Add notice to dashboard if workspace has group constraint policies

### DIFF
--- a/src/libs/workspace-utils.test.ts
+++ b/src/libs/workspace-utils.test.ts
@@ -165,6 +165,15 @@ describe('hasGroupConstraint', () => {
   it.each([
     { policies: [], expectedResult: false },
     {
+      polices: [
+        {
+          namespace: 'terra',
+          name: 'protected-data',
+        },
+      ],
+      expectedResult: false,
+    },
+    {
       policies: [
         {
           namespace: 'terra',

--- a/src/libs/workspace-utils.ts
+++ b/src/libs/workspace-utils.ts
@@ -1,5 +1,6 @@
 import { cond, safeCurry } from '@terra-ui-packages/core-utils';
 import _ from 'lodash/fp';
+import pluralize from 'pluralize';
 import { azureRegions } from 'src/libs/azure-regions';
 
 export type CloudProvider = 'AZURE' | 'GCP';
@@ -183,9 +184,10 @@ export const groupConstraintMessage = (workspace: WorkspaceWrapper): string | un
     _.uniq,
     _.sortBy(_.identity)
   )(groupConstraintPolicies);
-  return `Data Access Controls add additional permission restrictions to a workspace. These were added when you imported data from a controlled access source. All workspace collaborators must also be members of the following groups: ${requiredGroups.join(
-    ', '
-  )}.`;
+  return `Data Access Controls add additional permission restrictions to a workspace. These were added when you imported data from a controlled access source. All workspace collaborators must also be members of the following ${pluralize(
+    'groups',
+    requiredGroups.length
+  )}: ${requiredGroups.join(', ')}.`;
 };
 
 export const isValidWsExportTarget = safeCurry((sourceWs: WorkspaceWrapper, destWs: WorkspaceWrapper) => {

--- a/src/libs/workspace-utils.ts
+++ b/src/libs/workspace-utils.ts
@@ -185,7 +185,7 @@ export const groupConstraintMessage = (workspace: WorkspaceWrapper): string | un
     _.sortBy(_.identity)
   )(groupConstraintPolicies);
   return `Data Access Controls add additional permission restrictions to a workspace. These were added when you imported data from a controlled access source. All workspace collaborators must also be members of the following ${pluralize(
-    'groups',
+    'group',
     requiredGroups.length
   )}: ${requiredGroups.join(', ')}.`;
 };

--- a/src/pages/workspaces/workspace/Dashboard/WorkspaceInformation.test.ts
+++ b/src/pages/workspaces/workspace/Dashboard/WorkspaceInformation.test.ts
@@ -114,7 +114,7 @@ describe('WorkspaceInformation', () => {
         {
           namespace: 'terra',
           name: 'group-constraint',
-          additionalData: [{ group: 'foo' }, { group: 'bar' }],
+          additionalData: [{ group: 'bar' }],
         },
       ],
     },

--- a/src/pages/workspaces/workspace/Dashboard/WorkspaceInformation.test.ts
+++ b/src/pages/workspaces/workspace/Dashboard/WorkspaceInformation.test.ts
@@ -136,7 +136,7 @@ describe('WorkspaceInformation', () => {
         screen.getByText('Data Access Controls');
 
         await user.click(screen.getByLabelText('More info'));
-        screen.getByText(/All workspace collaborators must also be members of the following groups: bar, foo./);
+        screen.getByText(/Data Access Controls add additional permission restrictions to a workspace/);
       }
     }
   );

--- a/src/pages/workspaces/workspace/Dashboard/WorkspaceInformation.ts
+++ b/src/pages/workspaces/workspace/Dashboard/WorkspaceInformation.ts
@@ -2,6 +2,8 @@ import { ReactNode } from 'react';
 import { dl, h } from 'react-hyperscript-helpers';
 import { InfoBox } from 'src/components/InfoBox';
 import {
+  groupConstraintMessage,
+  hasGroupConstraint,
   hasProtectedData,
   hasRegionConstraint,
   protectedDataMessage,
@@ -35,6 +37,11 @@ export const WorkspaceInformation = (props: WorkspaceInformationProps): ReactNod
       h(InfoRow, { title: 'Region Constraint' }, [
         'Yes',
         h(InfoBox, { style: { marginLeft: '0.50rem' }, side: 'bottom' }, [regionConstraintMessage(workspace)]),
+      ]),
+    hasGroupConstraint(workspace) &&
+      h(InfoRow, { title: 'Data Access Controls' }, [
+        'Yes',
+        h(InfoBox, { style: { marginLeft: '0.50rem' }, side: 'bottom' }, [groupConstraintMessage(workspace)]),
       ]),
   ]);
 };

--- a/src/pages/workspaces/workspace/Dashboard/WorkspaceInformation.ts
+++ b/src/pages/workspaces/workspace/Dashboard/WorkspaceInformation.ts
@@ -2,8 +2,8 @@ import { ReactNode } from 'react';
 import { dl, h } from 'react-hyperscript-helpers';
 import { InfoBox } from 'src/components/InfoBox';
 import {
-  groupConstraintMessage,
-  hasGroupConstraint,
+  dataAccessControlsMessage,
+  hasDataAccessControls,
   hasProtectedData,
   hasRegionConstraint,
   protectedDataMessage,
@@ -38,10 +38,10 @@ export const WorkspaceInformation = (props: WorkspaceInformationProps): ReactNod
         'Yes',
         h(InfoBox, { style: { marginLeft: '0.50rem' }, side: 'bottom' }, [regionConstraintMessage(workspace)]),
       ]),
-    hasGroupConstraint(workspace) &&
+    hasDataAccessControls(workspace) &&
       h(InfoRow, { title: 'Data Access Controls' }, [
         'Yes',
-        h(InfoBox, { style: { marginLeft: '0.50rem' }, side: 'bottom' }, [groupConstraintMessage(workspace)]),
+        h(InfoBox, { style: { marginLeft: '0.50rem' }, side: 'bottom' }, [dataAccessControlsMessage(workspace)]),
       ]),
   ]);
 };


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1460

This adds a notice to the workspace dashboard if the workspace has group constraint policies.

Clicking on the info icon shows a message describing data access controls and listing the groups that a user must be a member of in order to gain access to the workspace.

<img width="453" alt="Screenshot 2023-11-14 at 7 26 46 PM" src="https://github.com/DataBiosphere/terra-ui/assets/1156625/f7271917-124a-4bdb-b119-33cc193b4bb2">

<img width="313" alt="Screenshot 2023-11-14 at 7 26 52 PM" src="https://github.com/DataBiosphere/terra-ui/assets/1156625/b3ad5c37-1bc9-4398-b778-2edaf8743f53">

## Testing

To mock group constraint policies for a workspace, run the following the console (replacing NAMESPACE and NAME with the namespace and name of your workspace) and click the "Dashboard" tab to refresh it.

```js
window.ajaxOverridesStore.set([
  {
    filter: { url: /api\/workspaces\/NAMESPACE\/NAME/ },
    fn: window.ajaxOverrideUtils.mapJsonBody(workspace => {
      return {
        ...workspace,
        policies: [
          {
            namespace: 'terra',
            name: 'group-constraint',
            additionalData: [{ group: 'example-group' }]
          }
        ]
      }
    })
  }
]);
```
