### PR TITLE
[AJ-1470] Load default workspace fields on import data page

### DIFF
--- a/src/import-data/ImportDataDestination.ts
+++ b/src/import-data/ImportDataDestination.ts
@@ -120,23 +120,38 @@ export const ImportDataDestination = (props: ImportDataDestinationProps): ReactN
     workspaces,
     refresh: refreshWorkspaces,
     loading: loadingWorkspaces,
-  } = useWorkspaces([
-    // The decision on whether or data can be imported into a workspace is based on the user's level of access
-    // to the workspace and the workspace's authorization domain, protected status and cloud platform.
-    // When using a template workspace, the NewWorkspaceModal reads the description attribute
-    // from the template.
+  } = useWorkspaces(
+    [
+      // The decision on whether or data can be imported into a workspace is based on the user's level of access
+      // to the workspace and the workspace's authorization domain, protected status and cloud platform.
+      // When using a template workspace, the NewWorkspaceModal reads the description attribute
+      // from the template.
 
-    // Default fields
-    'accessLevel',
-    'public',
-    'workspace',
-    'workspace.state',
-    'workspace.attributes.description',
-    'workspace.attributes.tag:tags',
-    'workspace.workspaceVersion',
-    // Additional fields
-    'policies',
-  ]);
+      // Load the same fields that are loaded by the workspaces list page so that a user can navigate to the
+      // workspaces list without a render error. See AJ-1470 for details.
+      'accessLevel',
+      'public',
+      'workspace.attributes.description',
+      'workspace.attributes.tag:tags',
+      'workspace.authorizationDomain',
+      'workspace.cloudPlatform',
+      'workspace.createdBy',
+      'workspace.lastModified',
+      'workspace.name',
+      'workspace.namespace',
+      'workspace.workspaceId',
+      'workspace.state',
+      'workspace.errorMessage',
+
+      // Add policies field because we need it to decide if a workspace is suitable for importing protected data.
+      'policies',
+      // Add bucket name so we can determine if GCP workspaces have secure monitoring enabled.
+      'workspace.bucketName',
+    ],
+    // Truncate description to save bytes.
+    // This matches the limit used by the workspaces list.
+    250
+  );
   const [mode, setMode] = useState<'existing' | 'template' | undefined>(
     initialSelectedWorkspaceId ? 'existing' : undefined
   );

--- a/src/import-data/ImportDataDestination.ts
+++ b/src/import-data/ImportDataDestination.ts
@@ -121,20 +121,21 @@ export const ImportDataDestination = (props: ImportDataDestinationProps): ReactN
     refresh: refreshWorkspaces,
     loading: loadingWorkspaces,
   } = useWorkspaces([
-    'workspace.workspaceId',
-    'workspace.namespace',
-    'workspace.name',
     // The decision on whether or data can be imported into a workspace is based on the user's level of access
     // to the workspace and the workspace's authorization domain, protected status and cloud platform.
-    // That information needs to be fetched here.
-    'accessLevel',
-    'policies',
     // When using a template workspace, the NewWorkspaceModal reads the description attribute
     // from the template.
-    'workspace.attributes',
-    'workspace.authorizationDomain',
-    'workspace.bucketName',
-    'workspace.cloudPlatform',
+
+    // Default fields
+    'accessLevel',
+    'public',
+    'workspace',
+    'workspace.state',
+    'workspace.attributes.description',
+    'workspace.attributes.tag:tags',
+    'workspace.workspaceVersion',
+    // Additional fields
+    'policies',
   ]);
   const [mode, setMode] = useState<'existing' | 'template' | undefined>(
     initialSelectedWorkspaceId ? 'existing' : undefined


### PR DESCRIPTION
Currently, if you load the import data page and then navigate to the workspaces list, the list fails to render with a bunch of errors about "Invalid time value".

https://github.com/DataBiosphere/terra-ui/assets/1156625/1925e4d9-d7b3-4a3b-8d28-c5f70aed09c1

This is because, while we allow altering the fields requested by `useWorkspaces`, we also save the loaded workspaces in a global store and return the value in that store while loading the workspaces.

Thus, a component can end up getting workspaces that don't include all the fields that it expects (and passed to `useWorkspaces`).

That's what is happening here. ImportDataDestination does not load the last modified date for workspaces because it doesn't need it. But then when the workspaces list is rendered, it gets the workspaces from the global store while the fields that it needs are loading. And the workspaces list doesn't handle missing last modified dates, so they cause a render error.

To work around this, this replaces the minimal list of fields in ImportDataDestination with the default fields + the policies field.