### PR TITLE
[TUIM-71] Stop running nightly end to end tests against alpha

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,5 +341,4 @@ workflows:
           <<: *filter-dev-branch
           cron: "0 13 * * *"
     jobs:
-      - integration-tests-alpha
       - integration-tests-staging


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/TUIM-71

With the alpha environment being deprecated, this stops running nightly end to end tests against alpha.

It leaves the job configuration intact so that they can still be [run manually](https://github.com/DataBiosphere/terra-ui/wiki/Running-e2e-tests-against-alpha-and-staging) if desired.