### PR TITLE
[FS-1214] Update number of participants for 1000G on Datasets page

### DIFF
--- a/src/pages/library/Datasets.js
+++ b/src/pages/library/Datasets.js
@@ -145,7 +145,7 @@ const thousandGenomesHighCoverage = () =>
       description:
         '1000 Genomes project phase 3 samples sequenced to 30x coverage. This dataset is delivered as a workspace. You may clone ' +
         'this workspace to run analyses or copy specific samples to a workspace of your choice.',
-      sizeText: 'Participants: 2,504',
+      sizeText: 'Participants: 3,202',
     },
     [
       h(


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/FS-1214

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
The count listed on the [Datasets](https://app.terra.bio/#library/datasets) page is 2504.  The correct number of participants, per the workspace 1000G-high-coverage-2019, is 3202.

<img width="890" alt="image" src="https://github.com/DataBiosphere/terra-ui/assets/68919432/36a75d9d-c1f9-4ba6-9e46-ad9195975686">

Before:
<img width="396" alt="image" src="https://github.com/DataBiosphere/terra-ui/assets/68919432/b0d5628d-9348-43a6-a4f8-ab1ec7ebe3e2">
After: 
<img width="363" alt="image" src="https://github.com/DataBiosphere/terra-ui/assets/68919432/5b42f729-d3f5-4115-834d-a5b4a1dacbbf">

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 
