### PR TITLE
[WOR-1350] If Azure workspace to clone is protected, only show protected billing projects.

### DIFF
--- a/src/components/NewWorkspaceModal.test.ts
+++ b/src/components/NewWorkspaceModal.test.ts
@@ -313,7 +313,7 @@ describe('NewWorkspaceModal', () => {
       () =>
         ({
           Billing: {
-            listProjects: async () => [gcpBillingProject, azureBillingProject],
+            listProjects: async () => [gcpBillingProject, azureBillingProject, azureProtectedDataBillingProject],
           },
           ...nonBillingAjax,
         } as AjaxContract)
@@ -331,7 +331,10 @@ describe('NewWorkspaceModal', () => {
     });
 
     // Assert
-    expect(await getAvailableBillingProjects(user)).toEqual(['Azure Billing Project']);
+    expect(await getAvailableBillingProjects(user)).toEqual([
+      'Azure Billing Project',
+      'Protected Azure Billing Project',
+    ]);
   });
 
   it('Hides billing projects that cannot be used for cloning a protected data Azure workspace', async () => {

--- a/src/components/NewWorkspaceModal.ts
+++ b/src/components/NewWorkspaceModal.ts
@@ -324,7 +324,7 @@ const NewWorkspaceModal = withDisplayName(
       if (!!workflowImport || !!requireEnhancedBucketLogging) {
         return !isAzureBillingProject(project);
       }
-      // Only support cloning a workspace to the same cloud environment. If this changes, also update
+      // Only support cloning a workspace to the same cloud platform. If this changes, also update
       // the Events.workspaceClone event data.
       if (!!cloneWorkspace && isAzureWorkspace(cloneWorkspace)) {
         if (isAzureBillingProject(project)) {

--- a/src/pages/billing/models/BillingProject.ts
+++ b/src/pages/billing/models/BillingProject.ts
@@ -24,6 +24,7 @@ export interface AzureBillingProject extends BaseBillingProject {
   cloudPlatform: 'AZURE';
   managedAppCoordinates: AzureManagedAppCoordinates;
   landingZoneId: string;
+  protectedData: boolean;
 }
 
 export interface GCPBillingProject extends BaseBillingProject {


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WOR-1350

This adds filtering to the `NewWorkspaceModal` so that if an Azure workspace has the `protectedData` policy, when the user attempts to clone the workspace they are only presented with with billing projects with the `protectedData` policy (which is added to Rawls responses for Azure workspaces in https://github.com/broadinstitute/rawls/pull/2627).

Screenshot with a somewhat hacked protected data billing project:

<img width="496" alt="image" src="https://github.com/DataBiosphere/terra-ui/assets/484484/45f249be-60c7-4152-8373-0bbcc9219ee4">

Screenshot when no protected data billing projects exist:

<img width="527" alt="image" src="https://github.com/DataBiosphere/terra-ui/assets/484484/0f25f44d-a762-4a01-ac6b-8c953c5f2b68">
