### PR TITLE
WX-1368 Add word-wrap styling to FailuresViewer modal on RunDetails page

### DIFF
--- a/src/pages/workspaces/workspace/jobHistory/FailuresViewer.js
+++ b/src/pages/workspaces/workspace/jobHistory/FailuresViewer.js
@@ -27,7 +27,7 @@ export const FailuresViewer = ({ failures }) => {
   };
 
   return h(ReactJson, {
-    style: { whiteSpace: 'pre-wrap' },
+    style: { whiteSpace: 'pre-wrap', wordBreak: 'break-word' },
     name: false,
     collapsed: 4,
     enableClipboard: false,
@@ -45,7 +45,7 @@ export const FailuresModal = ({ callFqn, index, attempt, failures, onDismiss }) 
       onDismiss,
       showButtons: false,
       showX: true,
-      width: '600px',
+      width: '800px',
     },
     [`Failures in ${callFqn} / index ${index} / attempt ${attempt}`, h(FailuresViewer, { failures })]
   );


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WX-1368
<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
Added word-wrap styling and increased width of FailureViewer modal to fix text overflow issues that occurred when it tried to render stack trace errors

## Before:
<img width="1553" alt="Screenshot 2023-11-20 at 10 37 48 AM" src="https://github.com/DataBiosphere/terra-ui/assets/6664778/246a7a6c-03e0-46da-8f32-334fa25e89fc">

## After:
<img width="1430" alt="Screenshot 2023-11-20 at 10 45 18 AM" src="https://github.com/DataBiosphere/terra-ui/assets/6664778/30864083-f105-417f-932a-a39994aa38e4">

