### PR TITLE
AJ-1473: dont show Authorization Domain panel for Azure workspaces

### DIFF
--- a/src/pages/workspaces/workspace/Dashboard/Dashboard.ts
+++ b/src/pages/workspaces/workspace/Dashboard/Dashboard.ts
@@ -400,7 +400,8 @@ const WorkspaceDashboardForwardRefRenderFunction = (
           ),
         ]
       ),
-      !_.isEmpty(authorizationDomain) &&
+      isGoogleWorkspace(workspace) &&
+        !_.isEmpty(authorizationDomain) &&
         h(
           RightBoxSection,
           {


### PR DESCRIPTION
Status 4:45pm Monday Nov 20: The runtime code for this PR, in the first commit, is simple and I have tested it by running locally. In the second commit, I added my attempt at unit tests. The unit tests have some duplicated code that could be cleaned up, but more importantly they are failing with:
```
    TypeError: Cannot read properties of undefined (reading 'makePath')

      68 |     `No handler found for key ${name}. Valid path keys are: ${_.map('name', routeHandlersStore.get())}`
      69 |   );
    > 70 |   return handler.makePath(params);
```
and I need some help resolving that.

-----

### Jira Ticket: https://broadworkbench.atlassian.net/browse/AJ-1473

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
Remove the "Authorization Domain" panel for Azure workspaces; leave it for Google workspaces.

### Why
From the Jira ticket:
>Rawls returns group constraint policies as authorization domains. As a result, the authorization domains panel shows on the workspace dashboard for workspaces with group constraint policies.
>
> However, we don’t want to mention “authorization domains” for Azure workspaces. They’ve been replaced by “data access controls” and shown in a different place on the dashboard (AJ-1460).
>
> Thus, we should remove this panel for Azure workspaces. 

### Testing strategy
- [ ] View an Azure workspace with auth domain. The panel should not display.
- [ ] View a Google workspace with auth domain. The panel should display.

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 
