### PR TITLE
[IA-4706] Improve "day" janitor

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,7 +27,7 @@
 /src/workflows-app/ @DataBiosphere/broad-workflow-management @DataBiosphere/broad-workflow-execution
 /src/workspace-data/ @DataBiosphere/analysisjourneys
 /integration-tests/tests/billing-projects.js @DataBiosphere/broadworkspaces-terra-ui
-/integration-tests/tests/janitor.js @DataBiosphere/broadworkspaces-terra-ui
+/integration-tests/tests/workspace-janitor.js @DataBiosphere/broadworkspaces-terra-ui
 /integration-tests/tests/workspace-dashboard.js @DataBiosphere/broadworkspaces-terra-ui
 /integration-tests/tests/run-analysis.js @DataBiosphere/broad-interactive-analysis
 /integration-tests/tests/run-rstudio.js @DataBiosphere/broad-interactive-analysis

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,7 +27,7 @@
 /src/workflows-app/ @DataBiosphere/broad-workflow-management @DataBiosphere/broad-workflow-execution
 /src/workspace-data/ @DataBiosphere/analysisjourneys
 /integration-tests/tests/billing-projects.js @DataBiosphere/broadworkspaces-terra-ui
-/integration-tests/tests/workspace-janitor.js @DataBiosphere/broadworkspaces-terra-ui
+/integration-tests/tests/day-janitor.js @DataBiosphere/broadworkspaces-terra-ui
 /integration-tests/tests/workspace-dashboard.js @DataBiosphere/broadworkspaces-terra-ui
 /integration-tests/tests/run-analysis.js @DataBiosphere/broad-interactive-analysis
 /integration-tests/tests/run-analysis-azure.js @DataBiosphere/broad-interactive-analysis

--- a/integration-tests/slack/slack-notify-channels.json
+++ b/integration-tests/slack/slack-notify-channels.json
@@ -51,7 +51,7 @@
           "name": "billing-projects"
         },
         {
-          "name": "janitor"
+          "name": "day-janitor"
         },
         {
           "name": "workspace-dashboard"

--- a/integration-tests/tests/day-janitor.js
+++ b/integration-tests/tests/day-janitor.js
@@ -1,14 +1,26 @@
 // This test is owned by the Workspaces Team.
 const dateFns = require('date-fns/fp');
 const _ = require('lodash/fp');
-const { testWorkspaceNamePrefix } = require('../utils/integration-helpers');
+const { deleteWorkspaceV2AsUser, testWorkspaceNamePrefix } = require('../utils/integration-helpers');
 const { signIntoTerra } = require('../utils/integration-utils');
 const { registerTest } = require('../utils/jest-utils');
 const { withUserToken } = require('../utils/terra-sa-utils');
 
-const olderThanDays = 2;
+const olderThanTimeUnits = 3;
+const timeUnit =
+  // 'days';
+  'hours';
+// 'minutes';
+const getTimeDifference =
+  // .differenceInDays;
+  dateFns.differenceInHours;
+// .differenceInMinutes;
 
-const runJanitor = withUserToken(async ({ page, testUrl, token }) => {
+/**
+ * Attempts to delete any workspaces which are named with the auto-generated test workspace name prefix,
+ * and are more than a certain configured age.
+ */
+const runDayJanitor = withUserToken(async ({ page, testUrl, token }) => {
   // Sign into Terra so we have the correct credentials.
   await signIntoTerra(page, { token, testUrl });
 
@@ -17,30 +29,30 @@ const runJanitor = withUserToken(async ({ page, testUrl, token }) => {
   // ci test runs also sometimes leak workspaces.
   const workspaces = await page.evaluate(async () => await window.Ajax().Workspaces.list());
   const oldWorkspaces = _.filter(({ workspace: { name, createdDate } }) => {
-    const age = dateFns.differenceInDays(new Date(createdDate), new Date());
+    const age = getTimeDifference(new Date(createdDate), new Date());
     // console.info(`${namespace} ${name}, age ${age} days`)
-    return _.startsWith(testWorkspaceNamePrefix, name) && age > olderThanDays;
+    return _.startsWith(testWorkspaceNamePrefix, name) && age > olderThanTimeUnits;
   }, workspaces);
 
   console.log(
-    `Attempting to delete ${oldWorkspaces.length} workspaces with prefix "${testWorkspaceNamePrefix}" created more than ${olderThanDays} days ago.`
+    `Attempting to delete ${oldWorkspaces.length} workspaces with prefix "${testWorkspaceNamePrefix}" created more than ${olderThanTimeUnits} ${timeUnit} ago.`
   );
   console.log(`${_.filter({ workspace: { cloudPlatform: 'Azure' } }, oldWorkspaces).length} of the old workspaces are Azure workspaces.`);
   return Promise.all(
     _.map(async ({ workspace: { namespace, name, cloudPlatform } }) => {
       try {
         // Unlock the workspace in case it was left in a locked state during a test (locked workspaces can't be deleted).
-        await page.evaluate((namespace, name) => window.Ajax().Workspaces.workspace(namespace, name).unlock(), namespace, name);
-        await page.evaluate((namespace, name) => window.Ajax().Workspaces.workspace(namespace, name).delete(), namespace, name);
-        console.info(`Deleted old workspace: ${name}`);
+        await page.evaluate(async (namespace, name) => await window.Ajax().Workspaces.workspace(namespace, name).unlock(), namespace, name);
+        await deleteWorkspaceV2AsUser({ page, billingProject: namespace, workspaceName: name });
+        console.info(`Triggered delete for old workspace: ${name}`);
       } catch (e) {
-        console.info(`Failed to delete old ${cloudPlatform} workspace: ${name} with billing project ${namespace}`);
+        console.error(`Failed to delete old ${cloudPlatform} workspace: ${name} with billing project ${namespace}`);
       }
     }, oldWorkspaces)
   );
 });
 
 registerTest({
-  name: 'janitor',
-  fn: runJanitor,
+  name: 'day-janitor',
+  fn: runDayJanitor,
 });


### PR DESCRIPTION
Improve "day" janitor by adding configurable age target, deleting workspaces with V2 approach, prechecking child resources for deletability.

### Jira Ticket: https://broadworkbench.atlassian.net/browse/IA-4706
- I'm lumping this into the above ticket given the challenges I've had cleaning up after my Azure test.

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->
- The workspace deletion approach here is granular and tries to delete apps, runtimes, and disks separately before proceeding to workspaces. I think this is merited for the day-janitor as it's not intended to 'test' anything, only to clean up effectively. For now, this is the most reliable approach to get successful deletions when resources are in odd states.

### Testing strategy
- [ ] Run the integration tests (with run-analysis-azure enabled)

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 
