### PR TITLE
WX-1371 LogViewer info box matches logs shown

### DIFF
--- a/src/workflows-app/RunDetails.test.js
+++ b/src/workflows-app/RunDetails.test.js
@@ -147,7 +147,7 @@ describe('BaseRunDetails - render smoke test', () => {
     screen.getByText('Troubleshooting?');
     screen.getByText(runDetailsProps.workflowId);
     screen.getByText(runDetailsProps.submissionId);
-    screen.getByText('Execution Log');
+    screen.getByText('Workflow Execution Log');
   });
 
   it('has copy buttons', async () => {
@@ -286,10 +286,17 @@ describe('BaseRunDetails - render smoke test', () => {
   it('opens the log viewer modal when Execution Logs is clicked', async () => {
     const user = userEvent.setup();
     await act(async () => render(h(BaseRunDetails, runDetailsProps)));
-    const executionLogButton = screen.getByText('Execution Log');
+    const executionLogButton = screen.getByText('Workflow Execution Log');
     await user.click(executionLogButton);
     screen.getByText('workflow.log');
     screen.getByText('this is the text of a mock file');
+
+    // Make sure the info box only include execution log info
+    const logInfoBox = screen.getByLabelText('More info');
+    await user.click(logInfoBox);
+    screen.getByText('Each workflow has a single execution log', { exact: false });
+    expect(screen.queryByText('Task logs are from user-defined commands', { exact: false })).toBeNull;
+    expect(screen.queryByText('Backend logs are from the Azure Cloud compute job', { exact: false })).toBeNull;
   });
 
   it('opens the log viewer modal when Logs is clicked', async () => {
@@ -299,6 +306,13 @@ describe('BaseRunDetails - render smoke test', () => {
     const logsLink = within(table).getAllByText('Logs');
     await user.click(logsLink[0]);
     screen.getByText('Task Standard Out');
+
+    // Make sure the info box only includes task and and backend log info
+    const logInfoBox = screen.getByLabelText('More info');
+    await user.click(logInfoBox);
+    expect(screen.queryByText('Each workflow has a single execution log', { exact: false })).toBeNull;
+    screen.getByText('Task logs are from user-defined commands', { exact: false });
+    screen.getByText('Backend logs are from the Azure Cloud compute job', { exact: false });
   });
 
   it('shows a static error message on LogViewer if log cannot be retrieved', async () => {

--- a/src/workflows-app/RunDetails.test.js
+++ b/src/workflows-app/RunDetails.test.js
@@ -283,7 +283,7 @@ describe('BaseRunDetails - render smoke test', () => {
     screen.getByText('Messages');
   });
 
-  it('opens the log viewer modal when Execution Logs is clicked', async () => {
+  it('opens the log viewer modal when Workflow Execution Logs is clicked', async () => {
     const user = userEvent.setup();
     await act(async () => render(h(BaseRunDetails, runDetailsProps)));
     const executionLogButton = screen.getByText('Workflow Execution Log');

--- a/src/workflows-app/components/TroubleshootingBox.js
+++ b/src/workflows-app/components/TroubleshootingBox.js
@@ -35,10 +35,12 @@ export const TroubleshootingBox = ({ name, namespace, logUri, submissionId, work
           Link,
           {
             onClick: () => {
-              showLogModal('Execution Log', [{ logUri, logTitle: 'Execution Log', logKey: 'execution_log', logFilename: 'workflow.log' }]);
+              showLogModal('Workflow Execution Log', [
+                { logUri, logTitle: 'Workflow Execution Log', logKey: 'execution_log', logFilename: 'workflow.log' },
+              ]);
             },
           },
-          [div({ style: { marginRight: '1.5rem' } }, [icon('fileAlt', { size: 18 }), ' Execution Log'], {})]
+          [div({ style: { marginRight: '1.5rem' } }, [icon('fileAlt', { size: 18 }), ' Workflow Execution Log'], {})]
         ),
         h(Link, { href: Nav.getLink('workspace-files', { name, namespace }), target: '_blank' }, [
           icon('folder-open', { size: 18 }),


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WX-1371

## Summary of changes:
 * Rename Execution Log to Workflow Execution Log in troubleshooting box.
 * In LogViewer info box, only show info about the logs currently displayed.

### Testing strategy
- [x] Open log viewer for workflow execution logs, observe that info box shows only that item
- [x] Open log viewer for task logs, observe that info box shows only task and backend log items
- [x] Open log viewer for workflow execution logs again and confirm that is still shows the correct item

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 
