### PR TITLE
[DC-775] Working min and max pulled from actual dataset

### DIFF
--- a/src/dataset-builder/CohortEditor.test.ts
+++ b/src/dataset-builder/CohortEditor.test.ts
@@ -162,20 +162,20 @@ describe('CohortEditor', () => {
       criteria,
     });
     // Act
-    await user.click(await screen.findByLabelText('Remove list 0'));
+    await user.click(await screen.findByLabelText('Remove value 0'));
     // Assert
     expect(updateCriteria).toBeCalledWith({ ...criteria, values: [] });
     // Act
     await user.click(screen.getByLabelText('Select one or more list'));
-    await user.click((await screen.findAllByText('list 0'))[0]);
+    await user.click((await screen.findAllByText('value 0'))[0]);
     await user.click(screen.getByLabelText('Select one or more list'));
-    await user.click((await screen.findAllByText('list 1'))[0]);
+    await user.click((await screen.findAllByText('value 1'))[0]);
     // Assert
     expect(updateCriteria).toBeCalledWith({
       ...criteria,
       values: [
-        { id: 0, name: 'list 0' },
-        { id: 1, name: 'list 1' },
+        { id: 0, name: 'value 0' },
+        { id: 1, name: 'value 1' },
       ],
     });
   });

--- a/src/dataset-builder/CohortEditor.test.ts
+++ b/src/dataset-builder/CohortEditor.test.ts
@@ -113,6 +113,7 @@ describe('CohortEditor', () => {
     const criteria: DomainCriteria = {
       kind: 'domain',
       id: 0,
+      index: 0,
       name: 'test criteria',
       count: 0,
       domainOption: {
@@ -132,7 +133,7 @@ describe('CohortEditor', () => {
   it('renders list criteria', async () => {
     // Arrange
     mockListStatistics();
-    const criteria = (await criteriaFromOption(datasetDetails.id, {
+    const criteria = (await criteriaFromOption(datasetDetails.id, 0, {
       id: 0,
       name: 'list',
       kind: 'list',
@@ -142,7 +143,7 @@ describe('CohortEditor', () => {
     renderCriteriaView({ criteria });
 
     expect(screen.getByText(criteria.name, { exact: false })).toBeTruthy();
-    expect(screen.getByText(criteria.values[0].name)).toBeTruthy();
+    expect(criteria.values.length).toBe(0);
   });
 
   it('updates when list updated', async () => {
@@ -150,13 +151,14 @@ describe('CohortEditor', () => {
     const user = userEvent.setup();
     const updateCriteria = jest.fn();
     mockListStatistics();
-    const criteria = (await criteriaFromOption(datasetDetails.id, {
+    const criteria = (await criteriaFromOption(datasetDetails.id, 0, {
       id: 0,
       name: 'list',
       kind: 'list',
       tableName: 'table',
       columnName: 'column',
     })) as ProgramDataListCriteria;
+    criteria.values = [{ id: 0, name: 'value 0' }];
     renderCriteriaView({
       updateCriteria,
       criteria,
@@ -183,7 +185,7 @@ describe('CohortEditor', () => {
   it('renders range criteria', async () => {
     // Arrange
     mockRangeStatistics();
-    const criteria = (await criteriaFromOption(datasetDetails.id, {
+    const criteria = (await criteriaFromOption(datasetDetails.id, 0, {
       id: 0,
       name: 'range',
       kind: 'range',
@@ -203,7 +205,7 @@ describe('CohortEditor', () => {
     // Arrange
     const user = userEvent.setup();
     mockRangeStatistics();
-    const criteria = (await criteriaFromOption(datasetDetails.id, {
+    const criteria = (await criteriaFromOption(datasetDetails.id, 0, {
       id: 0,
       name: 'range',
       kind: 'range',
@@ -234,7 +236,7 @@ describe('CohortEditor', () => {
     const max = 99;
     mockRangeStatistics(min, max);
 
-    const criteria = (await criteriaFromOption(datasetDetails.id, {
+    const criteria = (await criteriaFromOption(datasetDetails.id, 0, {
       id: 0,
       name: 'range',
       kind: 'range',
@@ -259,7 +261,7 @@ describe('CohortEditor', () => {
   it('can delete criteria', async () => {
     // Arrange
     mockRangeStatistics();
-    const criteria = (await criteriaFromOption(datasetDetails.id, {
+    const criteria = (await criteriaFromOption(datasetDetails.id, 0, {
       id: 0,
       name: 'range',
       kind: 'range',
@@ -364,11 +366,11 @@ describe('CohortEditor', () => {
     expect(updateCohort).toHaveBeenCalledTimes(2);
 
     const updatedCohortWithLoading: Cohort = updateCohort.mock.calls[0][0](cohort);
-    expect(updatedCohortWithLoading.criteriaGroups[0].criteria).toMatchObject([{ loading: true }]);
+    expect(updatedCohortWithLoading.criteriaGroups[0].criteria).toMatchObject([{ loading: true, index: 2 }]);
 
-    const updatedCohort: Cohort = updateCohort.mock.calls[1][0](cohort);
+    const updatedCohort: Cohort = updateCohort.mock.calls[1][0](updatedCohortWithLoading);
     // Remove ID since it won't match up.
-    const { id: _, ...expectedCriteria } = await criteriaFromOption(datasetDetails.id, option);
+    const { index: _, ...expectedCriteria } = await criteriaFromOption(datasetDetails.id, 2, option);
     expect(updatedCohort.criteriaGroups[0].criteria).toMatchObject([expectedCriteria]);
   });
 
@@ -376,7 +378,7 @@ describe('CohortEditor', () => {
     // Arrange
     const option = datasetDetails!.snapshotBuilderSettings!.programDataOptions[0];
     mockOption(option);
-    const criteria = await criteriaFromOption(datasetDetails.id, option);
+    const criteria = await criteriaFromOption(datasetDetails.id, 0, option);
     const { cohort, updateCohort } = showCriteriaGroup((criteriaGroup) => criteriaGroup.criteria.push(criteria));
     const user = userEvent.setup();
     // Act

--- a/src/dataset-builder/DatasetBuilder.ts
+++ b/src/dataset-builder/DatasetBuilder.ts
@@ -702,7 +702,7 @@ export const DatasetBuilderView: React.FC<DatasetBuilderProps> = (props) => {
                   ? h(CohortEditor, {
                       onStateChange,
                       originalCohort: datasetBuilderState.cohort,
-                      snapshotBuilderSettings: datasetDetails.state.snapshotBuilderSettings,
+                      dataset: datasetDetails.state,
                       updateCohorts: setCohorts,
                     })
                   : div(['No Dataset Builder Settings Found']);

--- a/src/dataset-builder/DomainCriteriaSelector.test.ts
+++ b/src/dataset-builder/DomainCriteriaSelector.test.ts
@@ -49,7 +49,13 @@ describe('DomainCriteriaSelector', () => {
     // Assert
     expect(onStateChange).toHaveBeenCalledWith(
       cohortEditorState.new(
-        _.update('criteriaGroups[0].criteria', () => [toCriteria(domainOption)(concept)], state.cohort)
+        _.update(
+          'criteriaGroups[0].criteria',
+          // Since each created criteria has a unique index, we need to subtract one
+          // so the expected value matches the generated value.
+          () => [_.update('index', (x) => x - 1, toCriteria(domainOption)(concept))],
+          state.cohort
+        )
       )
     );
   });

--- a/src/dataset-builder/DomainCriteriaSelector.ts
+++ b/src/dataset-builder/DomainCriteriaSelector.ts
@@ -1,6 +1,7 @@
 import _ from 'lodash/fp';
 import { h } from 'react-hyperscript-helpers';
 import { spinnerOverlay } from 'src/components/common';
+import { getNextCriteriaIndex } from 'src/dataset-builder/CohortEditor';
 import { SnapshotBuilderConcept as Concept, SnapshotBuilderDomainOption as DomainOption } from 'src/libs/ajax/DataRepo';
 import { DatasetBuilder, DomainCriteria, GetConceptsResponse } from 'src/libs/ajax/DatasetBuilder';
 import { useLoadedData } from 'src/libs/ajax/loaded-data/useLoadedData';
@@ -22,6 +23,7 @@ export const toCriteria =
       kind: 'domain',
       name: concept.name,
       id: concept.id,
+      index: getNextCriteriaIndex(),
       count: concept.count,
       domainOption,
     };

--- a/src/dataset-builder/TestConstants.ts
+++ b/src/dataset-builder/TestConstants.ts
@@ -10,38 +10,27 @@ export const dummyDatasetDetails = (datasetId: string): DatasetModel => ({
   properties: {},
   snapshotBuilderSettings: {
     programDataOptions: [
-      { id: 1, name: 'Year of birth', kind: 'range', min: 1900, max: 2023 },
+      { id: 1, name: 'Year of birth', kind: 'range', tableName: 'person', columnName: 'year_of_birth' },
       {
         id: 2,
         name: 'Ethnicity',
         kind: 'list',
-        values: [
-          { name: 'Hispanic or Latino', id: 20 },
-          { name: 'Not Hispanic or Latino', id: 21 },
-          { name: 'No Matching Concept', id: 0 },
-        ],
+        tableName: 'person',
+        columnName: 'ethnicity',
       },
       {
         id: 3,
         name: 'Gender identity',
         kind: 'list',
-        values: [
-          { name: 'FEMALE', id: 22 },
-          { name: 'MALE', id: 23 },
-          { name: 'No Matching Concept', id: 0 },
-        ],
+        tableName: 'person',
+        columnName: 'gender_identity',
       },
       {
         id: 4,
         name: 'Race',
         kind: 'list',
-        values: [
-          { name: 'American Indian or Alaska Native', id: 24 },
-          { name: 'Asian', id: 25 },
-          { name: 'Black', id: 26 },
-          { name: 'White', id: 27 },
-          { name: 'No Matching Concept', id: 0 },
-        ],
+        tableName: 'person',
+        columnName: 'race',
       },
     ],
     domainOptions: [

--- a/src/libs/ajax/DataRepo.ts
+++ b/src/libs/ajax/DataRepo.ts
@@ -86,15 +86,33 @@ export interface Snapshot {
 }
 
 export interface ColumnStatisticsModel {
-  dataType: string;
+  dataType:
+    | 'string'
+    | 'boolean'
+    | 'bytes'
+    | 'date'
+    | 'datetime'
+    | 'dirref'
+    | 'fileref'
+    | 'float'
+    | 'float64'
+    | 'integer'
+    | 'int64'
+    | 'numeric'
+    | 'record'
+    | 'text'
+    | 'time'
+    | 'timestamp';
 }
 
 export interface ColumnStatisticsIntOrDoubleModel extends ColumnStatisticsModel {
+  dataType: 'float' | 'float64' | 'integer' | 'int64' | 'numeric';
   minValue: number;
   maxValue: number;
 }
 
 export interface ColumnStatisticsTextModel extends ColumnStatisticsModel {
+  dataType: 'string' | 'text';
   values: ColumnStatisticsTextValue[];
 }
 

--- a/src/libs/ajax/DatasetBuilder.ts
+++ b/src/libs/ajax/DatasetBuilder.ts
@@ -3,6 +3,7 @@ import _ from 'lodash/fp';
 import { Ajax } from 'src/libs/ajax';
 import {
   ColumnStatisticsIntOrDoubleModel,
+  ColumnStatisticsTextModel,
   SnapshotBuilderConcept as Concept,
   SnapshotBuilderDomainOption as DomainOption,
   SnapshotBuilderProgramDataOption,
@@ -12,7 +13,7 @@ import {
 export interface Criteria {
   kind: 'domain' | 'range' | 'list';
   name: string;
-  id: number;
+  index: number;
   count?: number;
   loading?: boolean;
 }
@@ -20,6 +21,7 @@ export interface Criteria {
 export interface DomainCriteria extends Criteria {
   kind: 'domain';
   domainOption: DomainOption;
+  id: number;
 }
 
 export interface ProgramDataOption {
@@ -62,7 +64,7 @@ export type AnyCriteria = DomainCriteria | ProgramDataRangeCriteria | ProgramDat
 /** A group of criteria. */
 export interface CriteriaGroup {
   name: string;
-  criteria: (AnyCriteria | { loading: true })[];
+  criteria: (AnyCriteria | { loading: true; index: number })[];
   mustMeet: boolean;
   meetAll: boolean;
   count: number;
@@ -171,40 +173,54 @@ const getDummyConcepts = async (parent: Concept): Promise<GetConceptsResponse> =
   };
 };
 
+const convertProgramDataOptionToListOption = (
+  programDataOption: SnapshotBuilderProgramDataOption
+): ProgramDataListOption => ({
+  name: programDataOption.name,
+  kind: 'list',
+  values: _.map(
+    (num) => ({
+      id: num,
+      name: `${programDataOption.name} ${num}`,
+    }),
+    [0, 1, 2, 3, 4]
+  ),
+});
+
+const convertProgramDataOptionToRangeOption = (
+  programDataOption: SnapshotBuilderProgramDataOption,
+  statistics: ColumnStatisticsIntOrDoubleModel | ColumnStatisticsTextModel
+): ProgramDataRangeOption => {
+  switch (statistics.dataType) {
+    case 'float':
+    case 'float64':
+    case 'integer':
+    case 'int64':
+    case 'numeric':
+      return {
+        name: programDataOption.name,
+        kind: 'range',
+        min: statistics.minValue,
+        max: statistics.maxValue,
+      };
+    default:
+      throw new Error(
+        `Datatype ${statistics.dataType} for ${programDataOption.tableName}/${programDataOption.columnName} is not numeric`
+      );
+  }
+};
+
 export const DatasetBuilder = (): DatasetBuilderContract => {
   return {
     getProgramDataStatistics: async (datasetId, programDataOption) => {
       switch (programDataOption.kind) {
         case 'list':
-          return {
-            name: programDataOption.name,
-            kind: programDataOption.kind,
-            values: _.map(
-              (num) => ({
-                id: num,
-                name: `${programDataOption.name} ${num}`,
-              }),
-              [0, 1, 2, 3, 4]
-            ),
-          };
+          return convertProgramDataOptionToListOption(programDataOption);
         case 'range':
           const statistics = await Ajax()
             .DataRepo.dataset(datasetId)
             .lookupDatasetColumnStatisticsById(programDataOption.tableName, programDataOption.columnName);
-
-          switch (statistics.dataType) {
-            case 'float' || 'float64' || 'integer' || 'int64' || 'numeric':
-              return {
-                name: programDataOption.name,
-                kind: programDataOption.kind,
-                min: (statistics as ColumnStatisticsIntOrDoubleModel).minValue,
-                max: (statistics as ColumnStatisticsIntOrDoubleModel).maxValue,
-              };
-            default:
-              throw new Error(
-                `Datatype for ${programDataOption.tableName}/${programDataOption.columnName} is not numeric`
-              );
-          }
+          return convertProgramDataOptionToRangeOption(programDataOption, statistics);
         default:
           throw new Error('Unexpected option');
       }

--- a/src/libs/ajax/DatasetBuilder.ts
+++ b/src/libs/ajax/DatasetBuilder.ts
@@ -2,13 +2,12 @@
 import _ from 'lodash/fp';
 import { Ajax } from 'src/libs/ajax';
 import {
+  ColumnStatisticsIntOrDoubleModel,
   datasetIncludeTypes,
   DatasetModel,
-  ProgramDataListOption,
-  ProgramDataListValue,
-  ProgramDataRangeOption,
   SnapshotBuilderConcept as Concept,
   SnapshotBuilderDomainOption as DomainOption,
+  SnapshotBuilderProgramDataOption,
 } from 'src/libs/ajax/DataRepo';
 
 /** A specific criteria based on a type. */
@@ -17,6 +16,7 @@ export interface Criteria {
   name: string;
   id: number;
   count?: number;
+  loading?: boolean;
 }
 
 export interface DomainCriteria extends Criteria {
@@ -24,11 +24,33 @@ export interface DomainCriteria extends Criteria {
   domainOption: DomainOption;
 }
 
+export interface ProgramDataOption {
+  kind: 'range' | 'list';
+}
+
+export interface ProgramDataRangeOption extends ProgramDataOption {
+  kind: 'range';
+  name: string;
+  min: number;
+  max: number;
+}
+
 export interface ProgramDataRangeCriteria extends Criteria {
   kind: 'range';
   rangeOption: ProgramDataRangeOption;
   low: number;
   high: number;
+}
+
+export interface ProgramDataListValue {
+  id: number;
+  name: string;
+}
+
+export interface ProgramDataListOption extends ProgramDataOption {
+  kind: 'list';
+  name: string;
+  values: ProgramDataListValue[];
 }
 
 export interface ProgramDataListCriteria extends Criteria {
@@ -42,7 +64,7 @@ export type AnyCriteria = DomainCriteria | ProgramDataRangeCriteria | ProgramDat
 /** A group of criteria. */
 export interface CriteriaGroup {
   name: string;
-  criteria: AnyCriteria[];
+  criteria: (AnyCriteria | { loading: true })[];
   mustMeet: boolean;
   meetAll: boolean;
   count: number;
@@ -84,6 +106,10 @@ type DatasetParticipantCountRequest = {
 
 export interface DatasetBuilderContract {
   retrieveDataset: (datasetId: string) => Promise<DatasetModel>;
+  getProgramDataStatistics: (
+    datasetId,
+    programDataOption: SnapshotBuilderProgramDataOption
+  ) => Promise<ProgramDataRangeOption | ProgramDataListOption>;
   getConcepts: (parent: Concept) => Promise<GetConceptsResponse>;
   requestAccess: (request: DatasetAccessRequest) => Promise<void>;
   getParticipantCount: (request: DatasetParticipantCountRequest) => Promise<number>;
@@ -148,13 +174,51 @@ const getDummyConcepts = async (parent: Concept): Promise<GetConceptsResponse> =
   };
 };
 
-export const DatasetBuilder = (): DatasetBuilderContract => ({
-  retrieveDataset: async (datasetId) => {
-    return await Ajax()
-      .DataRepo.dataset(datasetId)
-      .details([datasetIncludeTypes.SNAPSHOT_BUILDER_SETTINGS, datasetIncludeTypes.PROPERTIES]);
-  },
-  getConcepts: (parent: Concept) => Promise.resolve(getDummyConcepts(parent)),
-  requestAccess: (_request) => Promise.resolve(),
-  getParticipantCount: (_request) => Promise.resolve(100),
-});
+export const DatasetBuilder = (): DatasetBuilderContract => {
+  return {
+    retrieveDataset: async (datasetId) => {
+      return await Ajax()
+        .DataRepo.dataset(datasetId)
+        .details([datasetIncludeTypes.SNAPSHOT_BUILDER_SETTINGS, datasetIncludeTypes.PROPERTIES]);
+    },
+    getProgramDataStatistics: async (datasetId, programDataOption) => {
+      switch (programDataOption.kind) {
+        case 'list':
+          return {
+            name: programDataOption.name,
+            kind: programDataOption.kind,
+            values: _.map(
+              (num) => ({
+                id: num,
+                name: `${programDataOption.name} ${num}`,
+              }),
+              [0, 1, 2, 3, 4]
+            ),
+          };
+        case 'range':
+          const statistics = await Ajax()
+            .DataRepo.dataset(datasetId)
+            .lookupDatasetColumnStatisticsById(programDataOption.tableName, programDataOption.columnName);
+
+          switch (statistics.dataType) {
+            case 'integer' || 'int64' || 'numeric':
+              return {
+                name: programDataOption.name,
+                kind: programDataOption.kind,
+                min: (statistics as ColumnStatisticsIntOrDoubleModel).minValue,
+                max: (statistics as ColumnStatisticsIntOrDoubleModel).maxValue,
+              } as ProgramDataRangeOption;
+            default:
+              throw new Error(
+                `Datatype for ${programDataOption.tableName}/${programDataOption.columnName} is not numeric`
+              );
+          }
+        default:
+          throw new Error('Unexpected option');
+      }
+    },
+    getConcepts: (parent: Concept) => Promise.resolve(getDummyConcepts(parent)),
+    requestAccess: (_request) => Promise.resolve(),
+    getParticipantCount: (_request) => Promise.resolve(100),
+  };
+};

--- a/src/libs/ajax/DatasetBuilder.ts
+++ b/src/libs/ajax/DatasetBuilder.ts
@@ -3,8 +3,6 @@ import _ from 'lodash/fp';
 import { Ajax } from 'src/libs/ajax';
 import {
   ColumnStatisticsIntOrDoubleModel,
-  datasetIncludeTypes,
-  DatasetModel,
   SnapshotBuilderConcept as Concept,
   SnapshotBuilderDomainOption as DomainOption,
   SnapshotBuilderProgramDataOption,
@@ -105,7 +103,6 @@ type DatasetParticipantCountRequest = {
 };
 
 export interface DatasetBuilderContract {
-  retrieveDataset: (datasetId: string) => Promise<DatasetModel>;
   getProgramDataStatistics: (
     datasetId,
     programDataOption: SnapshotBuilderProgramDataOption
@@ -176,11 +173,6 @@ const getDummyConcepts = async (parent: Concept): Promise<GetConceptsResponse> =
 
 export const DatasetBuilder = (): DatasetBuilderContract => {
   return {
-    retrieveDataset: async (datasetId) => {
-      return await Ajax()
-        .DataRepo.dataset(datasetId)
-        .details([datasetIncludeTypes.SNAPSHOT_BUILDER_SETTINGS, datasetIncludeTypes.PROPERTIES]);
-    },
     getProgramDataStatistics: async (datasetId, programDataOption) => {
       switch (programDataOption.kind) {
         case 'list':
@@ -201,13 +193,13 @@ export const DatasetBuilder = (): DatasetBuilderContract => {
             .lookupDatasetColumnStatisticsById(programDataOption.tableName, programDataOption.columnName);
 
           switch (statistics.dataType) {
-            case 'integer' || 'int64' || 'numeric':
+            case 'float' || 'float64' || 'integer' || 'int64' || 'numeric':
               return {
                 name: programDataOption.name,
                 kind: programDataOption.kind,
                 min: (statistics as ColumnStatisticsIntOrDoubleModel).minValue,
                 max: (statistics as ColumnStatisticsIntOrDoubleModel).maxValue,
-              } as ProgramDataRangeOption;
+              };
             default:
               throw new Error(
                 `Datatype for ${programDataOption.tableName}/${programDataOption.columnName} is not numeric`


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/dc-775

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
This adds a call to the API to get the actual min and max from the dataset listed. This does not add any caching, although the performance seems okay for now with the synthetic data.

Tests to come.

### What
- This adds loading the actual dataset min/max data rather than our stubs
- It also adds loading mechanics for program data criteria.

### Why
- This is important for us so that we are actually starting to load real data

### Testing strategy
- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 
