### PR TITLE
[IA-4620] invalidate cookies on sign out

### DIFF
--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -12,6 +12,7 @@ import {
   OidcUser,
   revokeTokens,
 } from 'src/auth/oidc-broker';
+import { cookieProvider } from 'src/components/CookieProvider';
 import { cookiesAcceptedKey } from 'src/components/CookieWarning';
 import { Ajax } from 'src/libs/ajax';
 import { fetchOk } from 'src/libs/ajax/ajax-common';
@@ -27,9 +28,7 @@ import {
   asyncImportJobStore,
   AuthState,
   authStore,
-  azureCookieReadyStore,
   azurePreviewStore,
-  cookieReadyStore,
   getTerraUser,
   MetricState,
   metricStore,
@@ -106,12 +105,11 @@ export const signOut = (cause: SignOutCause = 'unspecified'): void => {
   if (cause === 'expiredRefreshToken' || cause === 'errorRefreshingAuthToken') {
     notify('info', sessionTimedOutErrorMessage, sessionTimeoutProps);
   }
-  // TODO: invalidate runtime cookies https://broadworkbench.atlassian.net/browse/IA-3498
-  cookieReadyStore.reset();
-  azureCookieReadyStore.reset();
-  getSessionStorage().clear();
+
   azurePreviewStore.set(false);
 
+  cookieProvider.invalidateCookies();
+  getSessionStorage().clear();
   revokeTokens();
 
   const { cookiesAccepted } = authStore.get();

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -100,7 +100,7 @@ export const sendAuthTokenDesyncMetric = () => {
   Ajax().Metrics.captureEvent(Events.user.authToken.desync, {});
 };
 
-export const signOut = (cause: SignOutCause = 'unspecified'): void => {
+export const signOut = async (cause: SignOutCause = 'unspecified') => {
   sendSignOutMetrics(cause);
   if (cause === 'expiredRefreshToken' || cause === 'errorRefreshingAuthToken') {
     notify('info', sessionTimedOutErrorMessage, sessionTimeoutProps);
@@ -108,9 +108,9 @@ export const signOut = (cause: SignOutCause = 'unspecified'): void => {
 
   azurePreviewStore.set(false);
 
-  cookieProvider.invalidateCookies();
+  await cookieProvider.invalidateCookies();
   getSessionStorage().clear();
-  revokeTokens();
+  await revokeTokens();
 
   const { cookiesAccepted } = authStore.get();
 

--- a/src/components/CookieProvider.test.ts
+++ b/src/components/CookieProvider.test.ts
@@ -12,13 +12,14 @@ jest.mock('src/libs/ajax');
  * @return collection of key contract sub-objects for easy
  * mock overrides and/or method spying/assertions
  */
+type AjaxContract = ReturnType<typeof Ajax>;
 type RuntimesNeeds = Pick<RuntimesAjaxContract, 'invalidateCookie'>;
 interface AjaxMockNeeds {
   Runtimes: RuntimesNeeds;
 }
 
 const mockAjaxNeeds = (): AjaxMockNeeds => {
-  const partialRuntimes: RuntimeNeeds = {
+  const partialRuntimes: RuntimesNeeds = {
     invalidateCookie: jest.fn(),
   };
   const mockRuntimes = partialRuntimes as RuntimesAjaxContract;

--- a/src/components/CookieProvider.test.ts
+++ b/src/components/CookieProvider.test.ts
@@ -1,16 +1,10 @@
-import {Ajax} from "src/libs/ajax";
-import {AppAjaxContract, AppsAjaxContract} from "src/libs/ajax/leonardo/Apps";
+import { cookieProvider } from 'src/components/CookieProvider';
+import { Ajax } from 'src/libs/ajax';
+import { RuntimesAjaxContract } from 'src/libs/ajax/leonardo/Runtimes';
 import { asMockedFn } from 'src/testing/test-utils';
-import {RuntimesAjaxContract} from "src/libs/ajax/leonardo/Runtimes";
 
 jest.mock('src/libs/ajax');
 
-type AjaxContract = ReturnType<typeof Ajax>;
-type RuntimeNeeds = Pick<RuntimesAjaxContract, 'invalidateCookie'>;
-
-interface AjaxMockNeeds {
-  Runtimes: RuntimeNeeds;
-}
 /**
  * local test utility - mocks the Ajax super-object and the subset of needed multi-contracts it
  * returns with as much type-safety as possible.
@@ -18,18 +12,32 @@ interface AjaxMockNeeds {
  * @return collection of key contract sub-objects for easy
  * mock overrides and/or method spying/assertions
  */
+type RuntimesNeeds = Pick<RuntimesAjaxContract, 'invalidateCookie'>;
+interface AjaxMockNeeds {
+  Runtimes: RuntimesNeeds;
+}
+
 const mockAjaxNeeds = (): AjaxMockNeeds => {
   const partialRuntimes: RuntimeNeeds = {
-    invalidateCookie: jest.fn();
+    invalidateCookie: jest.fn(),
   };
   const mockRuntimes = partialRuntimes as RuntimesAjaxContract;
 
-  asMockedFn(Ajax).m({ Runtimes: mockRuntimes } as AjaxContract);
+  asMockedFn(Ajax).mockReturnValue({ Runtimes: mockRuntimes } as AjaxContract);
 
   return {
-    Runtimes: partialRuntimes
+    Runtimes: partialRuntimes,
   };
 };
-describe('leoAppProvider', () => {
+describe('CookieProvider', () => {
+  it('calls the leo endpoint on invalidateCookie', async () => {
+    const ajaxMock = mockAjaxNeeds();
 
-})
+    // Act
+    await cookieProvider.invalidateCookies();
+
+    // Assert
+    expect(Ajax).toBeCalledTimes(1);
+    expect(ajaxMock.Runtimes.invalidateCookie).toBeCalledTimes(1);
+  });
+});

--- a/src/components/CookieProvider.test.ts
+++ b/src/components/CookieProvider.test.ts
@@ -1,0 +1,35 @@
+import {Ajax} from "src/libs/ajax";
+import {AppAjaxContract, AppsAjaxContract} from "src/libs/ajax/leonardo/Apps";
+import { asMockedFn } from 'src/testing/test-utils';
+import {RuntimesAjaxContract} from "src/libs/ajax/leonardo/Runtimes";
+
+jest.mock('src/libs/ajax');
+
+type AjaxContract = ReturnType<typeof Ajax>;
+type RuntimeNeeds = Pick<RuntimesAjaxContract, 'invalidateCookie'>;
+
+interface AjaxMockNeeds {
+  Runtimes: RuntimeNeeds;
+}
+/**
+ * local test utility - mocks the Ajax super-object and the subset of needed multi-contracts it
+ * returns with as much type-safety as possible.
+ *
+ * @return collection of key contract sub-objects for easy
+ * mock overrides and/or method spying/assertions
+ */
+const mockAjaxNeeds = (): AjaxMockNeeds => {
+  const partialRuntimes: RuntimeNeeds = {
+    invalidateCookie: jest.fn();
+  };
+  const mockRuntimes = partialRuntimes as RuntimesAjaxContract;
+
+  asMockedFn(Ajax).m({ Runtimes: mockRuntimes } as AjaxContract);
+
+  return {
+    Runtimes: partialRuntimes
+  };
+};
+describe('leoAppProvider', () => {
+
+})

--- a/src/components/CookieProvider.ts
+++ b/src/components/CookieProvider.ts
@@ -5,21 +5,12 @@ import { azureCookieReadyStore, cookieReadyStore } from 'src/libs/state';
 export interface CookieProvider {
   invalidateCookies: (options?: AbortOption) => Promise<void>;
 }
+
 export const cookieProvider: CookieProvider = {
   invalidateCookies: async (options: AbortOption = {}) => {
     const { signal } = options;
-    const cookies: string[] = document.cookie.split(';');
     // TODO: call azure invalidate cookie once endpoint exists, https://broadworkbench.atlassian.net/browse/IA-3498
-    await Ajax(signal)
-      .Runtimes.invalidateCookie()
-      .catch(() => {});
-    // Expire all cookies
-    cookies.forEach((cookie: string) => {
-      // Find an equals sign and uses it to grab the substring of the cookie that is its name
-      const eqPos = cookie.indexOf('=');
-      const cookieName = eqPos > -1 ? cookie.substr(0, eqPos) : cookie;
-      document.cookie = `${cookieName}=;expires=Thu, 01 Jan 1970 00:00:00 GMT`;
-    });
+    await Ajax(signal).Runtimes.invalidateCookie();
 
     cookieReadyStore.reset();
     azureCookieReadyStore.reset();

--- a/src/components/CookieProvider.ts
+++ b/src/components/CookieProvider.ts
@@ -1,0 +1,27 @@
+import { Ajax } from 'src/libs/ajax';
+import { AbortOption } from 'src/libs/ajax/data-provider-common';
+import { azureCookieReadyStore, cookieReadyStore } from 'src/libs/state';
+
+export interface CookieProvider {
+  invalidateCookies: (options?: AbortOption) => Promise<void>;
+}
+export const cookieProvider: CookieProvider = {
+  invalidateCookies: async (options: AbortOption = {}) => {
+    const { signal } = options;
+    const cookies: string[] = document.cookie.split(';');
+    // TODO: call azure invalidate cookie once endpoint exists, https://broadworkbench.atlassian.net/browse/IA-3498
+    await Ajax(signal)
+      .Runtimes.invalidateCookie()
+      .catch(() => {});
+    // Expire all cookies
+    cookies.forEach((cookie: string) => {
+      // Find an equals sign and uses it to grab the substring of the cookie that is its name
+      const eqPos = cookie.indexOf('=');
+      const cookieName = eqPos > -1 ? cookie.substr(0, eqPos) : cookie;
+      document.cookie = `${cookieName}=;expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+    });
+
+    cookieReadyStore.reset();
+    azureCookieReadyStore.reset();
+  },
+};

--- a/src/components/CookieWarning.js
+++ b/src/components/CookieWarning.js
@@ -3,13 +3,13 @@ import { useEffect, useRef, useState } from 'react';
 import { aside, div, h } from 'react-hyperscript-helpers';
 import { Transition } from 'react-transition-group';
 import { ButtonPrimary, ButtonSecondary, Link } from 'src/components/common';
-import { Ajax } from 'src/libs/ajax';
+import { cookieProvider } from 'src/components/CookieProvider';
 import { getEnabledBrand } from 'src/libs/brand-utils';
 import { getSessionStorage } from 'src/libs/browser-storage';
 import colors from 'src/libs/colors';
 import * as Nav from 'src/libs/nav';
 import { useCancellation, useStore } from 'src/libs/react-utils';
-import { authStore, azureCookieReadyStore, cookieReadyStore } from 'src/libs/state';
+import { authStore } from 'src/libs/state';
 
 export const cookiesAcceptedKey = 'cookiesAccepted';
 
@@ -22,10 +22,10 @@ const transitionStyle = {
 
 const CookieWarning = () => {
   const animTime = 0.3;
-  const signal = useCancellation();
   const [showWarning, setShowWarning] = useState(false);
   const { cookiesAccepted } = useStore(authStore);
   const timeout = useRef();
+  const signal = useCancellation();
   const brand = getEnabledBrand();
 
   const acceptCookies = (acceptedCookies) => {
@@ -45,23 +45,9 @@ const CookieWarning = () => {
   }, [cookiesAccepted]);
 
   const rejectCookies = async () => {
-    const cookies = document.cookie.split(';');
-    acceptCookies(false);
-    // TODO: call azure invalidate cookie once endpoint exists, https://broadworkbench.atlassian.net/browse/IA-3498
-    await Ajax(signal)
-      .Runtimes.invalidateCookie()
-      .catch(() => {});
-    // Expire all cookies
-    _.forEach((cookie) => {
-      // Find an equals sign and uses it to grab the substring of the cookie that is its name
-      const eqPos = cookie.indexOf('=');
-      const cookieName = eqPos > -1 ? cookie.substr(0, eqPos) : cookie;
-      document.cookie = `${cookieName}=;expires=Thu, 01 Jan 1970 00:00:00 GMT`;
-    }, cookies);
-
-    cookieReadyStore.reset();
-    azureCookieReadyStore.reset();
+    await cookieProvider.invalidateCookies({ signal });
     getSessionStorage().clear();
+    acceptCookies(false);
   };
 
   return h(

--- a/src/libs/ajax/leonardo/Runtimes.ts
+++ b/src/libs/ajax/leonardo/Runtimes.ts
@@ -178,7 +178,7 @@ export const Runtimes = (signal: AbortSignal) => {
     },
 
     invalidateCookie: () => {
-      return fetchLeo('proxy/invalidateToken', _.merge(authOpts(), { signal }));
+      return fetchLeo('proxy/invalidateToken', _.merge(authOpts(), { signal, credentials: 'include' }));
     },
 
     setCookie: () => {


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/IA-4620

## Summary of changes:
It seems we stopped calling invalidateCookie on signOut in some refactor, which also unsets the Leo token in the browser. It's a bit pedantic, since the token, while still set on the browser, is no longer valid after we revoke the tokens (which sign out already does). All the endpoint does is echo back a header that tells the browser to unset the token. We got pinged on a security review though, and should probably be cleaning it up anyways.

### What
Call the leo invalidate token endpoint on terra UI sign out

### Why
So the token does not persist in the browser

Before, this token viewable in dev tools would persist after you click sign out
![image](https://github.com/DataBiosphere/terra-ui/assets/6465084/75d2a96e-205f-4aa7-bcd7-effae8dd17b9)

Now it is not present (1), and we can see the invalidateToken call (2). Note we are only invalidatingn the google token here, as more work is needed for azure, which is already noted in a ticket.

1.
![image](https://github.com/DataBiosphere/terra-ui/assets/6465084/4abf1ce4-322d-4096-bb19-878f17809272)

2.
![image](https://github.com/DataBiosphere/terra-ui/assets/6465084/49851c4b-fc3b-4f13-8ddf-55e4ba6dadff)


