### PR TITLE
WX-1384 Added margins to TroubleshootingBox and WorkflowInfoBox

### DIFF
--- a/src/workflows-app/components/TroubleshootingBox.js
+++ b/src/workflows-app/components/TroubleshootingBox.js
@@ -18,6 +18,7 @@ export const TroubleshootingBox = ({ name, namespace, logUri, submissionId, work
         lineHeight: '24px',
         alignSelf: 'flex-start',
         maxHeight: 'fit-content',
+        margin: '0 10px',
       },
     },
     [

--- a/src/workflows-app/components/WorkflowInfoBox.js
+++ b/src/workflows-app/components/WorkflowInfoBox.js
@@ -23,6 +23,7 @@ export const WorkflowInfoBox = ({ workflow }) => {
         display: 'flex',
         justifyContent: 'space-between',
         width: '60%',
+        margin: '0 10px',
       },
     },
     [


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WX-1384

## Summary of changes:
Added margins to the `TroubleshootingBox` and `WorkflowInfoBox` sub-components on the `WorkflowDetails` page to enforce some degree of spacing between them on smaller devices.

### Before
<img width="1278" alt="Screenshot 2023-11-22 at 7 34 30 AM" src="https://github.com/DataBiosphere/terra-ui/assets/6664778/8fe109c9-5513-48de-ac6a-05b154b03e82">

### After
<img width="1293" alt="Screenshot 2023-11-22 at 7 36 59 AM" src="https://github.com/DataBiosphere/terra-ui/assets/6664778/4e263d8d-a867-460a-8e38-b144fa679ddd">
