### PR TITLE
[AJ-1467] Changes to allow Azure protected billing projects on import of data

### DIFF
--- a/src/components/NewWorkspaceModal.test.ts
+++ b/src/components/NewWorkspaceModal.test.ts
@@ -171,7 +171,7 @@ describe('NewWorkspaceModal', () => {
     });
 
     // Assert
-    screen.getByText('You do not have access to a billing project with additional security monitoring.');
+    screen.getByText('You do not have access to a billing project that supports additional security monitoring.');
   });
 
   it('shows a message if there are no billing projects to use for cloning', async () => {

--- a/src/components/NewWorkspaceModal.test.ts
+++ b/src/components/NewWorkspaceModal.test.ts
@@ -147,6 +147,33 @@ describe('NewWorkspaceModal', () => {
     screen.getByText('You need a billing project to create a new workspace.');
   });
 
+  it('shows a message if there are no protected billing projects to use for creating a workspace with additional security monitoring ', async () => {
+    // Arrange
+    asMockedFn(Ajax).mockImplementation(
+      () =>
+        ({
+          Billing: {
+            listProjects: async () => [azureBillingProject],
+          },
+          ...nonBillingAjax,
+        } as AjaxContract)
+    );
+
+    // Act
+    await act(async () => {
+      render(
+        h(NewWorkspaceModal, {
+          requireEnhancedBucketLogging: true,
+          onSuccess: () => {},
+          onDismiss: () => {},
+        })
+      );
+    });
+
+    // Assert
+    screen.getByText('You do not have access to a billing project with additional security monitoring.');
+  });
+
   it('shows a message if there are no billing projects to use for cloning', async () => {
     // Arrange
     asMockedFn(Ajax).mockImplementation(
@@ -239,11 +266,21 @@ describe('NewWorkspaceModal', () => {
   });
 
   it.each([
-    { cloudPlatform: 'AZURE', expectedBillingProjects: ['Azure Billing Project'] },
-    { cloudPlatform: 'GCP', expectedBillingProjects: ['Google Billing Project'] },
-  ] as { cloudPlatform: CloudPlatform; expectedBillingProjects: string[] }[])(
-    'can limit billing projects to one cloud platform',
-    async ({ cloudPlatform, expectedBillingProjects }) => {
+    {
+      cloudPlatform: 'AZURE',
+      expectedBillingProjects: ['Azure Billing Project', 'Protected Azure Billing Project'],
+      requireEnhancedBucketLogging: false,
+    },
+    {
+      cloudPlatform: 'AZURE',
+      expectedBillingProjects: ['Protected Azure Billing Project'],
+      requireEnhancedBucketLogging: true,
+    },
+    { cloudPlatform: 'GCP', expectedBillingProjects: ['Google Billing Project'], requireEnhancedBucketLogging: false },
+    { cloudPlatform: 'GCP', expectedBillingProjects: ['Google Billing Project'], requireEnhancedBucketLogging: true },
+  ] as { cloudPlatform: CloudPlatform; expectedBillingProjects: string[]; requireEnhancedBucketLogging: boolean }[])(
+    'can limit billing projects to $cloudPlatform with requireEnhancedBucketLogging=$requireEnhancedBucketLogging',
+    async ({ cloudPlatform, expectedBillingProjects, requireEnhancedBucketLogging }) => {
       // Arrange
       const user = userEvent.setup();
 
@@ -251,7 +288,7 @@ describe('NewWorkspaceModal', () => {
         () =>
           ({
             Billing: {
-              listProjects: async () => [gcpBillingProject, azureBillingProject],
+              listProjects: async () => [gcpBillingProject, azureBillingProject, azureProtectedDataBillingProject],
             },
             ...nonBillingAjax,
           } as AjaxContract)
@@ -262,6 +299,7 @@ describe('NewWorkspaceModal', () => {
         render(
           h(NewWorkspaceModal, {
             cloudPlatform,
+            requireEnhancedBucketLogging,
             onDismiss: () => {},
             onSuccess: () => {},
           })

--- a/src/components/NewWorkspaceModal.ts
+++ b/src/components/NewWorkspaceModal.ts
@@ -326,7 +326,7 @@ const NewWorkspaceModal = withDisplayName(
       if (workflowImport) {
         return !isAzureBillingProject(project);
       }
-      // If creating a new workspace and enhanced bucket logging is required, allow all GCP projects
+      // If we aren't cloning a workspace and enhanced bucket logging is required, allow all GCP projects
       // (user will be forced to select "Workspace will have protected data" for GCP projects)
       // and Azure billing projects that support protected Data.
       if (!cloneWorkspace && requireEnhancedBucketLogging && isAzureBillingProject(project)) {
@@ -375,7 +375,7 @@ const NewWorkspaceModal = withDisplayName(
         return 'You do not have a billing project that is able to clone this workspace.';
       }
       return requireEnhancedBucketLogging
-        ? 'You do not have access to a billing project with additional security monitoring.'
+        ? 'You do not have access to a billing project that supports additional security monitoring.'
         : 'You need a billing project to create a new workspace.';
     };
 

--- a/src/components/NewWorkspaceModal.ts
+++ b/src/components/NewWorkspaceModal.ts
@@ -319,10 +319,18 @@ const NewWorkspaceModal = withDisplayName(
     };
 
     const isBillingProjectApplicable = (project: BillingProject): boolean => {
-      // As of AJ-1164, if requireEnhancedBucketLogging is true, then azure billing projects are ineligible.
-      // This coupling of enhanced bucket logging and billing project may change in the future.
-      if (!!workflowImport || !!requireEnhancedBucketLogging) {
+      // This is used when importing data to enforce a specific cloud.
+      if (cloudPlatform && project.cloudPlatform !== cloudPlatform) {
+        return false;
+      }
+      if (workflowImport) {
         return !isAzureBillingProject(project);
+      }
+      // If creating a new workspace and enhanced bucket logging is required, allow all GCP projects
+      // (user will be forced to select "Workspace will have protected data" for GCP projects)
+      // and Azure billing projects that support protected Data.
+      if (!cloneWorkspace && requireEnhancedBucketLogging && isAzureBillingProject(project)) {
+        return project.protectedData;
       }
       // Only support cloning a workspace to the same cloud platform. If this changes, also update
       // the Events.workspaceClone event data.
@@ -362,8 +370,17 @@ const NewWorkspaceModal = withDisplayName(
       return !value ? '' : `Option ${value['aria-label']} selected.`;
     };
 
+    const getNoApplicableBillingProjectsMessage = () => {
+      if (cloneWorkspace) {
+        return 'You do not have a billing project that is able to clone this workspace.';
+      }
+      return requireEnhancedBucketLogging
+        ? 'You do not have access to a billing project with additional security monitoring.'
+        : 'You need a billing project to create a new workspace.';
+    };
+
     return Utils.cond(
-      [loading || billingProjects === undefined, () => spinnerOverlay],
+      [loading, () => spinnerOverlay],
       [
         hasBillingProjects,
         () =>
@@ -458,10 +475,7 @@ const NewWorkspaceModal = withDisplayName(
                                 value: projectName,
                                 isDisabled: invalidBillingAccount,
                               }),
-                              _.sortBy(
-                                'projectName',
-                                _.uniq(cloudPlatform ? _.filter({ cloudPlatform }, billingProjects) : billingProjects)
-                              )
+                              _.sortBy('projectName', billingProjects)
                             ),
                           }),
                         ]),
@@ -699,9 +713,7 @@ const NewWorkspaceModal = withDisplayName(
           [
             div([
               icon('error-standard', { size: 16, style: { marginRight: '0.5rem', color: colors.warning() } }),
-              cloneWorkspace
-                ? 'You do not have a billing project that is able to clone this workspace.'
-                : 'You need a billing project to create a new workspace.',
+              getNoApplicableBillingProjectsMessage(),
             ]),
           ]
         )


### PR DESCRIPTION
Changes for https://broadworkbench.atlassian.net/browse/AJ-1467. I think that I fulfilled the requirements on the ticket, though I do not know the Import Data workflow and definitely depend on AJ folks to verify that my understanding is correct.

I am not sure if this can be manually tested because it depends on some other tickets in flight (both by AJ and Workspaces). However, I have added unittest coverage. 

Description from the ticket:

> For GCP, any billing project is allowed as long as the workspace has the “Workspace will have protected data” box checked. Currently, this checkbox is checked and disabled when importing protected data.
> 
> For Azure, this requires selecting a billing project that supports protected data.
> 
> Thus, if a flag to require secure monitoring is passed to NewWorkspaceModal, it should continue the current behavior for GCP workspaces and also filter Azure billing projects to only protected billing projects.
>
> If a user does not have access to any suitable billing projects, a message should be displayed. This can happen in two ways: 1. if a user does not have access to either a GCP billing project or a protected Azure billing project or 2. if the import requires an Azure workspace and the user does not have access to a protected Azure billing project. 

