### PR TITLE
[WOR-1364] Create WorkspaceDashboard component and fix wrapWorkspace types

### DIFF
--- a/src/pages/workspaces/workspace/Dashboard/Dashboard.ts
+++ b/src/pages/workspaces/workspace/Dashboard/Dashboard.ts
@@ -4,6 +4,7 @@ import _ from 'lodash/fp';
 import {
   CSSProperties,
   ForwardedRef,
+  forwardRef,
   Fragment,
   ReactNode,
   useCallback,
@@ -26,7 +27,7 @@ import colors from 'src/libs/colors';
 import { reportError, withErrorReporting } from 'src/libs/error';
 import * as Nav from 'src/libs/nav';
 import { getLocalPref, setLocalPref } from 'src/libs/prefs';
-import { forwardRefWithName, useCancellation, useOnMount, useStore } from 'src/libs/react-utils';
+import { useCancellation, useOnMount, useStore } from 'src/libs/react-utils';
 import { authStore } from 'src/libs/state';
 import * as Style from 'src/libs/style';
 import { append, formatBytes, newTabLinkProps, withBusyState } from 'src/libs/utils';
@@ -61,7 +62,12 @@ const styles: Record<string, CSSProperties> = {
   },
 };
 
-const DashboardAuthContainer = (props: WorkspaceDashboardProps): ReactNode => {
+interface DashboardAuthContainerProps {
+  namespace: string;
+  name: string;
+}
+
+const DashboardAuthContainer = (props: DashboardAuthContainerProps): ReactNode => {
   const { namespace, name } = props;
   const { signInStatus } = useStore(authStore);
   const [featuredWorkspaces, setFeaturedWorkspaces] = useState<{ name: string; namespace: string }[]>();
@@ -86,25 +92,19 @@ const DashboardAuthContainer = (props: WorkspaceDashboardProps): ReactNode => {
     ],
     [signInStatus === 'signedOut' && isFeaturedWorkspace(), () => h(DashboardPublic, props)],
     [signInStatus === 'signedOut', () => h(SignIn)],
-    () => h(WorkspaceDashboard, props)
+    () => h(WorkspaceDashboardPage, props)
   );
 };
 
 interface WorkspaceDashboardProps {
   namespace: string;
   name: string;
-}
-
-interface WorkspaceDashboardComponentProps extends WorkspaceDashboardProps {
   refreshWorkspace: () => void;
   storageDetails: StorageDetails;
   workspace: Workspace;
 }
 
-const WorkspaceDashboardForwardRefRenderFunction = (
-  props: WorkspaceDashboardComponentProps,
-  ref: ForwardedRef<unknown>
-): ReactNode => {
+const WorkspaceDashboard = forwardRef((props: WorkspaceDashboardProps, ref: ForwardedRef<unknown>): ReactNode => {
   const {
     namespace,
     name,
@@ -490,16 +490,15 @@ const WorkspaceDashboardForwardRefRenderFunction = (
       ),
     ]),
   ]);
-};
+});
 
-const WorkspaceDashboard: (props: WorkspaceDashboardProps) => ReactNode = _.flow(
-  forwardRefWithName('WorkspaceDashboard'),
-  wrapWorkspace({
-    breadcrumbs: (props) => breadcrumbs.commonPaths.workspaceDashboard(props),
-    activeTab: 'dashboard',
-    title: 'Dashboard',
-  })
-)(WorkspaceDashboardForwardRefRenderFunction);
+WorkspaceDashboard.displayName = 'WorkspaceDashboard';
+
+const WorkspaceDashboardPage = wrapWorkspace({
+  breadcrumbs: (props) => breadcrumbs.commonPaths.workspaceDashboard(props),
+  activeTab: 'dashboard',
+  title: 'Dashboard',
+})(WorkspaceDashboard);
 
 export const navPaths = [
   {

--- a/src/pages/workspaces/workspace/WorkspaceContainer.ts
+++ b/src/pages/workspaces/workspace/WorkspaceContainer.ts
@@ -281,13 +281,21 @@ export interface WorkspaceWrapperProps {
   name: string;
 }
 
+export type WorkspaceWrapperComponent = (props: WorkspaceWrapperProps) => ReactNode;
+
+export type WrapWorkspaceFn = (WrappedComponent: WrappedWorkspaceComponent) => WorkspaceWrapperComponent;
+
 /**
- * wrapWorkspaces contains a component in the WorkspaceContainer
- * and provides the workspace analysesData and storageDetails
- * */
-export const wrapWorkspace = (opts: WrapWorkspaceOptions) => {
+ * Wrap a component in the workspace-specific page UI (the main layout and workspace tabs).
+ *
+ * @returns A {@link https://legacy.reactjs.org/docs/higher-order-components.html higher order component} that
+ * takes a component and wraps it with {@link WorkspaceContainer}. The returned wrapper component accepts a workspace
+ * namespace and name as props. It loads information about the workspace and passes that information, along with
+ * the namespace and name, to the wrapped component.
+ */
+export const wrapWorkspace = (opts: WrapWorkspaceOptions): WrapWorkspaceFn => {
   const { breadcrumbs, activeTab, title } = opts;
-  return (WrappedComponent: WrappedWorkspaceComponent) => {
+  return (WrappedComponent: WrappedWorkspaceComponent): WorkspaceWrapperComponent => {
     const Wrapper = (props: WorkspaceWrapperProps): ReactNode => {
       const { namespace, name } = props;
       const child = useRef<{ refresh: () => void } | null>(null);


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/WOR-1364

The workspace dashboard has proven difficult to write tests for.

Part of that is because the component we actually want to test doesn't exist independently of the WorkspaceContainer wrapper. There is a forwarded ref render function for WorkspaceDashboard, but it's only turned into a component (with forwardRef) in the flow that also wraps it with wrapWorkspace.

This defines WorkspaceDashboard as a component, which can be exported and tested independently of its wrappers.

Removing the Lodash flow from wrapWorkspace revealed that the types for wrapWorkspace are wrong. Currently, they type the wrapper component props the same as the wrapped component props. Actually, the wrapper component takes a workspace namespace and name, while the wrapped component takes those as well as various workspace info loaded by WorkspaceContainer. This also corrects the types for wrapWorkspace.