### PR TITLE
[AJ-1488] Remove DUOS call to get ORSP data use limitations

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -723,13 +723,6 @@ const DrsUriResolver = (signal) => ({
   },
 });
 
-const Duos = (signal) => ({
-  getConsent: async (orspId) => {
-    const res = await fetchOrchestration(`/api/duos/consent/orsp/${orspId}`, _.merge(authOpts(), { signal }));
-    return res.json();
-  },
-});
-
 const Surveys = (signal) => ({
   submitForm: (formId, data) => fetchGoogleForms(`${formId}/formResponse?${qs.stringify(data)}`, { signal }),
 });
@@ -748,7 +741,6 @@ export const Ajax = (signal) => {
     Disks: Disks(signal),
     Dockstore: Dockstore(signal),
     DrsUriResolver: DrsUriResolver(signal),
-    Duos: Duos(signal),
     FirecloudBucket: FirecloudBucket(signal),
     Groups: Groups(signal),
     Methods: Methods(signal),

--- a/src/pages/workspaces/workspace/Dashboard/Dashboard.ts
+++ b/src/pages/workspaces/workspace/Dashboard/Dashboard.ts
@@ -126,7 +126,6 @@ const WorkspaceDashboardForwardRefRenderFunction = (
   const [editDescription, setEditDescription] = useState<string>();
   const [saving, setSaving] = useState<boolean>(false);
   const [busy, setBusy] = useState<boolean>(false);
-  const [consentStatus, setConsentStatus] = useState<string>();
   const [tagsList, setTagsList] = useState<string[]>();
   const [acl, setAcl] = useState<WorkspaceAcl>();
 
@@ -135,7 +134,6 @@ const WorkspaceDashboardForwardRefRenderFunction = (
   const signal = useCancellation();
 
   const refresh = () => {
-    loadConsent();
     loadWsTags();
 
     // If the current user is the only owner of the workspace, load the ACL to check if the workspace is shared.
@@ -231,32 +229,6 @@ const WorkspaceDashboardForwardRefRenderFunction = (
     notificationsPanelOpen,
   ]);
 
-  // Helpers
-  const loadConsent = withErrorReporting('Error loading data', async () => {
-    const orspId = attributes['library:orsp'];
-    if (orspId) {
-      try {
-        const { translatedUseRestriction } = await Ajax(signal).Duos.getConsent(orspId);
-        setConsentStatus(translatedUseRestriction);
-      } catch (error) {
-        if (error instanceof Response) {
-          switch (error.status) {
-            case 400:
-              setConsentStatus(`Structured Data Use Limitations are not approved for ${orspId}`);
-              break;
-            case 404:
-              setConsentStatus(`Structured Data Use Limitations are not available for ${orspId}`);
-              break;
-            default:
-              throw error;
-          }
-        } else {
-          throw error;
-        }
-      }
-    }
-  });
-
   const loadWsTags = withErrorReporting('Error loading workspace tags', async () => {
     setTagsList(await Ajax(signal).Workspaces.workspace(namespace, name).getTags());
   });
@@ -349,7 +321,7 @@ const WorkspaceDashboardForwardRefRenderFunction = (
               _.map(({ key, title }) => ({ name: title, value: displayAttributeValue(attributes[key]) })),
               append({
                 name: 'Structured Data Use Limitations',
-                value: attributes['library:orsp'] ? consentStatus : h(DataUseLimitations, { attributes }),
+                value: attributes['library:orsp'] ? null : h(DataUseLimitations, { attributes }),
               }),
               _.filter('value')
             )(displayLibraryAttributes),


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1488

When a workspace has a `library:orsp` attribute, it makes a request to DUOS to get data use limitations for the workspace.

However, DUOS has removed integration with ORSP and deprecated the API called by `getConsent`. The request currently always returns 404. Thus, there's no reason to call it anymore.

## Before
![Screenshot 2023-11-28 at 4 03 47 PM](https://github.com/DataBiosphere/terra-ui/assets/1156625/5fd8539f-6a89-4765-bd60-ef06d12e8bb1)

## After
![Screenshot 2023-11-28 at 4 04 18 PM](https://github.com/DataBiosphere/terra-ui/assets/1156625/13bc5325-1f19-4b8b-a0b2-b6d34e7ca499)

## Testing

Rawls will not allow updating a workspace with a `library:*` attribute, so we have to mock the workspace details response.

1. Navigate to the workspace dashboard page
2. Run the following code in the console (replace namespace and name with your workspace)
```js
window.ajaxOverridesStore.set([
  {
    filter: { url: /workspaces\/general-dev-billing-account\/my-first-workspace\?/ },
    fn: window.ajaxOverrideUtils.mapJsonBody((workspace) => {
      return {
        ...workspace,
        workspace: {
          ...workspace.workspace,
          attributes: {
            ...workspace.workspace.attributes,
            'library:orsp': 'FOO'
          }
        }
      }
    })
  }
]);
```
3. Click the Dashboard tab to refresh the dashboard (this loads the mocked workspace)
4. Click the Dashboard tab again to refresh the dashboard (the logic for making the DUOS request is called in refresh, so it must be called again after the workspace is mocked)

