### PR TITLE
[AJ-1486] Show errors uploading files in file browser

### DIFF
--- a/src/components/file-browser/FilesInDirectory.ts
+++ b/src/components/file-browser/FilesInDirectory.ts
@@ -16,7 +16,8 @@ import FileBrowserProvider, {
 } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider';
 import colors from 'src/libs/colors';
 import { reportError } from 'src/libs/error';
-import { useUploader } from 'src/libs/uploads';
+import { notify } from 'src/libs/notifications';
+import { useOnUploadFinished, useUploader } from 'src/libs/uploads';
 import * as Utils from 'src/libs/utils';
 import { dataTableVersionsPathRoot } from 'src/workspace-data/data-table/versioning/data-table-versioning-utils';
 
@@ -63,6 +64,15 @@ const FilesInDirectory = (props: FilesInDirectoryProps) => {
 
   const { uploadState, uploadFiles, cancelUpload } = useUploader((file) => {
     return provider.uploadFileToDirectory(path, file);
+  });
+  useOnUploadFinished(uploadState, (finishedUploadState) => {
+    finishedUploadState.errors.forEach(({ file, error }) => {
+      notify('error', 'Error uploading file', {
+        id: 'file-browser-upload-error',
+        message: `Failed to upload ${file.name}`,
+        detail: error,
+      });
+    });
   });
 
   const { status, files } = state;


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1486

Currently, Terra doesn't show any errors that occur while uploading files through the file browser. This adds notifications for any upload errors that occurred after all files have been uploaded/attempted.

An easy way to see this to replace the actual file upload in FilesInDirectory.ts with a fake one that throws an error and then upload some files.

```ts
const { uploadState, uploadFiles, cancelUpload } = useUploader((file) => {
  // return provider.uploadFileToDirectory(path, file);
  throw new Error('Something went wrong');
});
```

There's still an improvement to be made for the case that the ticket originated from (attempting to upload a file larger than 5 GB). This at least results in a somewhat informative error message ("Request body too large...") for that case.

## Before
https://github.com/DataBiosphere/terra-ui/assets/1156625/2b90f628-87f5-4bf0-bb53-a956d6e51946

## After
https://github.com/DataBiosphere/terra-ui/assets/1156625/fb977e95-bda7-42f6-b9ac-b2893d0f7263