### PR TITLE
[AJ-1486] Fail fast when attempting to upload a too large file

### DIFF
--- a/src/libs/ajax/file-browser-providers/AzureBlobStorageFileBrowserProvider.test.ts
+++ b/src/libs/ajax/file-browser-providers/AzureBlobStorageFileBrowserProvider.test.ts
@@ -253,6 +253,25 @@ describe('AzureBlobStorageFileBrowserProvider', () => {
     );
   });
 
+  it('throws an error when attempting to upload a too large file', async () => {
+    // Arrange
+    const testFile = new File(['somecontent'], 'example.txt', { type: 'text/text' });
+    // Fake a 6,000 MiB file.
+    jest.spyOn(testFile, 'size', 'get').mockReturnValue(6000 * 2 ** 20);
+
+    const provider = AzureBlobStorageFileBrowserProvider({ workspaceId: 'test-workspace' });
+
+    // Act
+    const result = provider.uploadFileToDirectory('path/to/directory/', testFile);
+
+    // Assert
+    await expect(result).rejects.toEqual(
+      new Error(
+        'The Terra file browser supports uploading files up to 5,000 MiB. For larger files, use azcopy or the Azure Storage Explorer.'
+      )
+    );
+  });
+
   it('deletes files', async () => {
     // Arrange
     asMockedFn(fetchOk).mockResolvedValue(new Response());

--- a/src/libs/ajax/file-browser-providers/AzureBlobStorageFileBrowserProvider.ts
+++ b/src/libs/ajax/file-browser-providers/AzureBlobStorageFileBrowserProvider.ts
@@ -185,6 +185,19 @@ const AzureBlobStorageFileBrowserProvider = ({
       return `azcopy copy '${blobUrl.href}' .`;
     },
     uploadFileToDirectory: async (directoryPath, file) => {
+      // This provider uses Azure Blob Storage's PUT blob API to upload files.
+      // This API supports blobs up to 5,000 MiB.
+      // https://learn.microsoft.com/en-us/rest/api/storageservices/put-blob#remarks
+      //
+      // If the user attempts to upload a larger file, we can fail fast with a more
+      // useful error message instead of waiting for the file to upload and the
+      // inevitable "Request body too large" error from Azure.
+      if (file.size > 5000 * 2 ** 20) {
+        throw new Error(
+          'The Terra file browser supports uploading files up to 5,000 MiB. For larger files, use azcopy or the Azure Storage Explorer.'
+        );
+      }
+
       const {
         sas: { url: originalSasUrl },
       } = await storageDetailsPromise;

--- a/src/libs/ajax/file-browser-providers/AzureBlobStorageFileBrowserProvider.ts
+++ b/src/libs/ajax/file-browser-providers/AzureBlobStorageFileBrowserProvider.ts
@@ -26,6 +26,11 @@ interface BlobListRequestOptions {
   marker?: string;
 }
 
+// This provider uses Azure Blob Storage's PUT blob API to upload files.
+// This API supports blobs up to 5,000 MiB.
+// https://learn.microsoft.com/en-us/rest/api/storageservices/put-blob#remarks
+const uploadFileSizeLimit = 5000 * 2 ** 20;
+
 const AzureBlobStorageFileBrowserProvider = ({
   workspaceId,
   pageSize = 1000,
@@ -186,13 +191,10 @@ const AzureBlobStorageFileBrowserProvider = ({
     },
     uploadFileToDirectory: async (directoryPath, file) => {
       // This provider uses Azure Blob Storage's PUT blob API to upload files.
-      // This API supports blobs up to 5,000 MiB.
-      // https://learn.microsoft.com/en-us/rest/api/storageservices/put-blob#remarks
-      //
-      // If the user attempts to upload a larger file, we can fail fast with a more
-      // useful error message instead of waiting for the file to upload and the
-      // inevitable "Request body too large" error from Azure.
-      if (file.size > 5000 * 2 ** 20) {
+      // If the user attempts to upload a larger file than that API supports, we can fail fast with
+      // a more useful error message instead of waiting for the file to upload and the inevitable
+      // "Request body too large" error from Azure.
+      if (file.size > uploadFileSizeLimit) {
         throw new Error(
           'The Terra file browser supports uploading files up to 5,000 MiB. For larger files, use azcopy or the Azure Storage Explorer.'
         );


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1486

To upload files to an Azure storage container, Terra's file browser uses Azure Blob Storage's Put Blob API. This API allows uploading files up to 5,000 MiB.
https://learn.microsoft.com/en-us/rest/api/storageservices/put-blob#remarks

Currently, attempting to upload a larger file eventually fails with a "Request body too large" error. However, the user has to wait for the file to upload before seeing that error. Since we know the file size before uploading, we don't have to bother making a request for files over 5,000 MiB. We can fail immediately with a more useful error message pointing to alternative methods for uploading the file.