### PR TITLE
[AJ-1469] Add notice about policies applied to a new workspace by importing data

### DIFF
--- a/src/import-data/ImportDataDestination.test.ts
+++ b/src/import-data/ImportDataDestination.test.ts
@@ -362,6 +362,7 @@ describe('ImportDataDestination', () => {
         cloudPlatform: 'GCP',
         requiredAuthDomain: undefined,
         requireEnhancedBucketLogging: false,
+        showControlledAccessImportNotice: false,
       },
     },
     // Protected data, required auth domain
@@ -374,6 +375,7 @@ describe('ImportDataDestination', () => {
         cloudPlatform: 'GCP',
         requiredAuthDomain: 'test-auth-domain',
         requireEnhancedBucketLogging: true,
+        showControlledAccessImportNotice: true,
       },
     },
     // Snapshot requiring an Azure workspace
@@ -404,6 +406,7 @@ describe('ImportDataDestination', () => {
         cloudPlatform: 'AZURE',
         requiredAuthDomain: undefined,
         requireEnhancedBucketLogging: false,
+        showControlledAccessImportNotice: false,
       },
     },
     // Snapshot requiring a GCP workspace
@@ -434,6 +437,7 @@ describe('ImportDataDestination', () => {
         cloudPlatform: 'GCP',
         requiredAuthDomain: undefined,
         requireEnhancedBucketLogging: false,
+        showControlledAccessImportNotice: false,
       },
     },
   ] as { props: Partial<ImportDataDestinationProps>; expectedNewWorkspaceModalProps: Record<string, any> }[])(

--- a/src/import-data/ImportDataDestination.ts
+++ b/src/import-data/ImportDataDestination.ts
@@ -177,8 +177,9 @@ export const ImportDataDestination = (props: ImportDataDestinationProps): ReactN
     : [];
   const canUseTemplateWorkspace = filteredTemplates.length > 0;
 
-  const importMayTakeTimeMessage =
-    'Note that the import process may take some time after you are redirected into your destination workspace.';
+  const importMayTakeTimeMessage = p([
+    'Note that the import process may take some time after you are redirected into your destination workspace.',
+  ]);
 
   const linkAccountPrompt = () => {
     return div({}, [

--- a/src/import-data/ImportDataDestination.ts
+++ b/src/import-data/ImportDataDestination.ts
@@ -356,6 +356,7 @@ export const ImportDataDestination = (props: ImportDataDestinationProps): ReactN
                 cloudPlatform: getCloudPlatformRequiredForImport(importRequest),
                 customMessage: importMayTakeTime && importMayTakeTimeMessage,
                 requireEnhancedBucketLogging: isProtectedData,
+                showControlledAccessImportNotice: isProtectedData,
                 waitForServices: {
                   wds: true,
                 },

--- a/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.ts
+++ b/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.ts
@@ -654,7 +654,7 @@ const NewWorkspaceModal = withDisplayName(
                       p([
                         'Importing controlled access data will apply any additional access controls associated with the data to this workspace.',
                       ]),
-                    customMessage && div({ style: { marginTop: '1rem', lineHeight: '1.5rem' } }, [customMessage]),
+                    customMessage,
                     workflowImport &&
                       azureBillingProjectsExist &&
                       div({ style: { paddingTop: '1.0rem', display: 'flex' } }, [

--- a/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.ts
+++ b/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.ts
@@ -88,6 +88,7 @@ export interface NewWorkspaceModalProps {
   customMessage?: ReactNode;
   requiredAuthDomain?: string;
   requireEnhancedBucketLogging?: boolean;
+  showControlledAccessImportNotice?: boolean;
   title?: string;
   waitForServices?: {
     wds?: boolean;
@@ -107,6 +108,7 @@ const NewWorkspaceModal = withDisplayName(
     customMessage,
     requiredAuthDomain,
     requireEnhancedBucketLogging,
+    showControlledAccessImportNotice = false,
     title,
     buttonText,
     waitForServices,
@@ -646,6 +648,11 @@ const NewWorkspaceModal = withDisplayName(
                               options: _.difference(_.uniq(_.map('groupName', allGroups)), existingGroups).sort(),
                             }),
                           ]),
+                      ]),
+                    showControlledAccessImportNotice &&
+                      isAzureBillingProject() &&
+                      p([
+                        'Importing controlled access data will apply any additional access controls associated with the data to this workspace.',
                       ]),
                     customMessage && div({ style: { marginTop: '1rem', lineHeight: '1.5rem' } }, [customMessage]),
                     workflowImport &&


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1469

This adds a notice about policies that may be applied to the workspace when importing protected / controlled access data into a new Azure workspace.

![Screenshot 2023-11-29 at 5 50 12 PM](https://github.com/DataBiosphere/terra-ui/assets/1156625/b73e51ab-aabd-44b7-b9f5-932371904728)

https://github.com/DataBiosphere/terra-ui/commit/6e95daf61f99815edbbf527b7ab7cc8638691486 is the main change.

https://github.com/DataBiosphere/terra-ui/commit/b62fb6d7dff00c8ef7817d11952134171235386d groups some related tests and clarifies what one test is testing.

https://github.com/DataBiosphere/terra-ui/commit/bb99380d759c2a40acef9099947a7392dfe2ab75 restyles one of the notices shown in this modal to match the others.
