### PR TITLE
UIE-147 Environments Page - decouple permissions

### DIFF
--- a/src/analysis/Environments/Environments.test.ts
+++ b/src/analysis/Environments/Environments.test.ts
@@ -19,7 +19,6 @@ import {
   Environments,
   EnvironmentsProps,
   LeoResourcePermissionsProvider,
-  PauseButton,
 } from 'src/analysis/Environments/Environments';
 import { appToolLabels } from 'src/analysis/utils/tool-utils';
 import { AzureConfig } from 'src/libs/ajax/leonardo/models/runtime-config-models';

--- a/src/analysis/Environments/Environments.test.ts
+++ b/src/analysis/Environments/Environments.test.ts
@@ -16,9 +16,9 @@ import {
 } from 'src/analysis/_testData/testData';
 import {
   EnvironmentNavActions,
-  EnvironmentPermissionsProvider,
   Environments,
   EnvironmentsProps,
+  LeoResourcePermissionsProvider,
   PauseButton,
 } from 'src/analysis/Environments/Environments';
 import { appToolLabels } from 'src/analysis/utils/tool-utils';
@@ -40,7 +40,7 @@ const mockNav: NavLinkProvider<EnvironmentNavActions> = {
   getUrl: jest.fn().mockReturnValue('/'),
   navTo: jest.fn(),
 };
-const mockPermissions: EnvironmentPermissionsProvider = {
+const mockPermissions: LeoResourcePermissionsProvider = {
   canDeleteDisk: jest.fn(),
   canPauseResource: jest.fn(),
 };

--- a/src/analysis/Environments/Environments.ts
+++ b/src/analysis/Environments/Environments.ts
@@ -25,7 +25,6 @@ import { SimpleFlexTable, Sortable } from 'src/components/table';
 import TooltipTrigger from 'src/components/TooltipTrigger';
 import { useModalHandler } from 'src/components/useModalHandler';
 import { App, isApp } from 'src/libs/ajax/leonardo/models/app-models';
-import { IHaveCreator } from 'src/libs/ajax/leonardo/models/core-models';
 import { PersistentDisk } from 'src/libs/ajax/leonardo/models/disk-models';
 import {
   AzureConfig,
@@ -212,8 +211,8 @@ type LeoAppProviderNeeds = Pick<LeoAppProvider, 'listWithoutProject' | 'get' | '
 type LeoRuntimeProviderNeeds = Pick<LeoRuntimeProvider, 'list' | 'stop' | 'delete'>;
 type LeoDiskProviderNeeds = Pick<LeoDiskProvider, 'list' | 'delete'>;
 export interface LeoResourcePermissionsProvider {
-  canDeleteDisk: (disk: IHaveCreator) => boolean;
-  canPauseResource: (resource: IHaveCreator) => boolean;
+  canDeleteDisk: (disk: PersistentDisk) => boolean;
+  canPauseResource: (resource: App | ListRuntimeItem) => boolean;
 }
 
 export interface EnvironmentsProps {

--- a/src/analysis/Environments/Environments.ts
+++ b/src/analysis/Environments/Environments.ts
@@ -191,7 +191,7 @@ export function PauseButton(props: PauseButtonProps): ReactNode {
   const shouldShowPauseButton =
     isPauseSupported(getToolLabelFromCloudEnv(cloudEnvironment)) && permissions.canPauseResource(cloudEnvironment);
 
-    return shouldShowPauseButton
+  return shouldShowPauseButton
     ? h(
         Link,
         {

--- a/src/analysis/utils/disk-utils.ts
+++ b/src/analysis/utils/disk-utils.ts
@@ -10,7 +10,7 @@ import {
   GooglePdType,
   googlePdTypes,
   PersistentDisk,
-  RawPersistentDisk,
+  RawListDiskItem,
 } from 'src/libs/ajax/leonardo/models/disk-models';
 import { Runtime } from 'src/libs/ajax/leonardo/models/runtime-models';
 import * as Utils from 'src/libs/utils';
@@ -38,11 +38,12 @@ export const pdTypeFromDiskType = (type: GoogleDiskType): GooglePdType =>
      */
   ) as GooglePdType; // TODO: Remove cast
 
-export const updatePdType = (disk: RawPersistentDisk): PersistentDisk => ({
+export const updatePdType = <T extends RawListDiskItem>(disk: T): T & { diskType: GooglePdType } => ({
   ...disk,
   diskType: pdTypeFromDiskType(disk.diskType),
 });
-export const mapToPdTypes = (disks: RawPersistentDisk[]): PersistentDisk[] => _.map(updatePdType, disks);
+export const mapToPdTypes = <T extends RawListDiskItem>(disks: T[]): (T & { diskType: GooglePdType })[] =>
+  _.map(updatePdType, disks);
 
 // Dataproc clusters don't have persistent disks.
 export const defaultDataprocMasterDiskSize = 150;

--- a/src/analysis/utils/resource-utils.ts
+++ b/src/analysis/utils/resource-utils.ts
@@ -2,6 +2,7 @@ import _ from 'lodash/fp';
 import { getAppStatusForDisplay } from 'src/analysis/utils/app-utils';
 import { getDisplayRuntimeStatus } from 'src/analysis/utils/runtime-utils';
 import { App, isApp } from 'src/libs/ajax/leonardo/models/app-models';
+import { IHaveCreator } from 'src/libs/ajax/leonardo/models/core-models';
 import { PersistentDisk } from 'src/libs/ajax/leonardo/models/disk-models';
 import { isRuntime, Runtime, runtimeStatuses } from 'src/libs/ajax/leonardo/models/runtime-models';
 import * as Utils from 'src/libs/utils';
@@ -53,7 +54,7 @@ export const isComputePausable = (compute: App | Runtime): boolean =>
     ]
   );
 
-export const getCreatorForCompute = (compute: Runtime | App): string => compute?.auditInfo?.creator;
+export const getCreatorForCompute = (compute: IHaveCreator): string => compute?.auditInfo?.creator;
 
 export const getDisplayStatus = (compute: Runtime | App): string => {
   if (isApp(compute)) {

--- a/src/analysis/utils/resource-utils.ts
+++ b/src/analysis/utils/resource-utils.ts
@@ -2,7 +2,6 @@ import _ from 'lodash/fp';
 import { getAppStatusForDisplay } from 'src/analysis/utils/app-utils';
 import { getDisplayRuntimeStatus } from 'src/analysis/utils/runtime-utils';
 import { App, isApp } from 'src/libs/ajax/leonardo/models/app-models';
-import { IHaveCreator } from 'src/libs/ajax/leonardo/models/core-models';
 import { PersistentDisk } from 'src/libs/ajax/leonardo/models/disk-models';
 import { isRuntime, Runtime, runtimeStatuses } from 'src/libs/ajax/leonardo/models/runtime-models';
 import * as Utils from 'src/libs/utils';
@@ -54,7 +53,10 @@ export const isComputePausable = (compute: App | Runtime): boolean =>
     ]
   );
 
-export const getCreatorForCompute = (compute: IHaveCreator): string => compute?.auditInfo?.creator;
+export interface ComputeWithCreator {
+  auditInfo: { creator: string };
+}
+export const getCreatorForCompute = (compute: ComputeWithCreator): string => compute?.auditInfo?.creator;
 
 export const getDisplayStatus = (compute: Runtime | App): string => {
   if (isApp(compute)) {

--- a/src/libs/ajax/leonardo/Disks.test.ts
+++ b/src/libs/ajax/leonardo/Disks.test.ts
@@ -1,7 +1,7 @@
 import { azureDisk, galaxyDisk } from 'src/analysis/_testData/testData';
 import { authOpts, fetchLeo } from 'src/libs/ajax/ajax-common';
 import { Disks } from 'src/libs/ajax/leonardo/Disks';
-import { PersistentDisk, RawPersistentDisk } from 'src/libs/ajax/leonardo/models/disk-models';
+import { PersistentDisk, RawListDiskItem } from 'src/libs/ajax/leonardo/models/disk-models';
 import { asMockedFn } from 'src/testing/test-utils';
 
 type AjaxCommonExports = typeof import('src/libs/ajax/ajax-common');
@@ -14,7 +14,7 @@ jest.mock(
   })
 );
 
-export const undecoratePd = (disk: PersistentDisk): RawPersistentDisk => ({
+const undecoratePd = (disk: PersistentDisk): RawListDiskItem => ({
   ...disk,
   diskType: disk.diskType.value,
 });

--- a/src/libs/ajax/leonardo/Disks.ts
+++ b/src/libs/ajax/leonardo/Disks.ts
@@ -2,7 +2,12 @@ import _ from 'lodash/fp';
 import * as qs from 'qs';
 import { mapToPdTypes, updatePdType } from 'src/analysis/utils/disk-utils';
 import { appIdentifier, authOpts, fetchLeo, jsonBody } from 'src/libs/ajax/ajax-common';
-import { GetDiskItem, ListDiskItem, PersistentDisk } from 'src/libs/ajax/leonardo/models/disk-models';
+import {
+  PersistentDisk,
+  PersistentDiskDetail,
+  RawGetDiskItem,
+  RawListDiskItem,
+} from 'src/libs/ajax/leonardo/models/disk-models';
 
 export const Disks = (signal: AbortSignal) => {
   const diskV2Root = 'api/v2/disks';
@@ -18,7 +23,7 @@ export const Disks = (signal: AbortSignal) => {
         `api/google/v1/disks${qs.stringify(labels, { addQueryPrefix: true })}`,
         _.mergeAll([authOpts(), appIdentifier, { signal }])
       );
-      const disks: ListDiskItem[] = await res.json();
+      const disks: RawListDiskItem[] = await res.json();
       return mapToPdTypes(disks);
     },
     disk: (project: string, name: string) => ({
@@ -39,12 +44,12 @@ export const Disks = (signal: AbortSignal) => {
           _.mergeAll([authOpts(), jsonBody({ size }), appIdentifier, { signal, method: 'PATCH' }])
         );
       },
-      details: async (): Promise<PersistentDisk> => {
+      details: async (): Promise<PersistentDiskDetail> => {
         const res = await fetchLeo(
           `api/google/v1/disks/${project}/${name}`,
           _.mergeAll([authOpts(), appIdentifier, { signal, method: 'GET' }])
         );
-        const disk: GetDiskItem = await res.json();
+        const disk: RawGetDiskItem = await res.json();
         return updatePdType(disk);
       },
     }),

--- a/src/libs/ajax/leonardo/models/core-models.ts
+++ b/src/libs/ajax/leonardo/models/core-models.ts
@@ -10,6 +10,10 @@ export interface AuditInfo {
   dateAccessed: string;
 }
 
+export interface IHaveCreator {
+  auditInfo: Pick<AuditInfo, 'creator'>;
+}
+
 export interface LeoError {
   errorMessage: string;
   timestamp: string;

--- a/src/libs/ajax/leonardo/models/core-models.ts
+++ b/src/libs/ajax/leonardo/models/core-models.ts
@@ -10,10 +10,6 @@ export interface AuditInfo {
   dateAccessed: string;
 }
 
-export interface IHaveCreator {
-  auditInfo: Pick<AuditInfo, 'creator'>;
-}
-
 export interface LeoError {
   errorMessage: string;
   timestamp: string;

--- a/src/libs/ajax/leonardo/models/disk-models.ts
+++ b/src/libs/ajax/leonardo/models/disk-models.ts
@@ -31,36 +31,24 @@ export const diskStatuses: { [label: string]: DiskStatus } = {
   error: { leoLabel: 'Error' },
 };
 
-export interface GetDiskItem {
+export interface RawListDiskItem {
   id: number;
   cloudContext: CloudContext;
   zone: string;
   name: string;
+  status: LeoDiskStatus;
+  auditInfo: AuditInfo;
+  size: number; // In GB
+  diskType: GoogleDiskType;
+  blockSize: number;
+  labels: LeoResourceLabels;
+}
+
+export interface RawGetDiskItem extends RawListDiskItem {
   serviceAccount: string;
   samResource: number;
-  status: LeoDiskStatus;
-  auditInfo: AuditInfo;
-  size: number; // In GB
-  diskType: GoogleDiskType;
-  blockSize: number;
-  labels: LeoResourceLabels;
   formattedBy: string | null;
 }
-
-export interface ListDiskItem {
-  id: number;
-  cloudContext: CloudContext;
-  zone: string;
-  name: string;
-  status: LeoDiskStatus;
-  auditInfo: AuditInfo;
-  size: number; // In GB
-  diskType: GoogleDiskType;
-  blockSize: number;
-  labels: LeoResourceLabels;
-}
-
-export type RawPersistentDisk = ListDiskItem | GetDiskItem;
 
 export interface GooglePdType {
   value: GoogleDiskType;
@@ -107,10 +95,10 @@ export const googlePdTypes: Record<PDLabels, GooglePdType> = {
     regionToPricesName: 'monthlySSDDiskPrice',
   },
 };
-export type PersistentDisk = {
-  diskType: GooglePdType;
-} & Omit<RawPersistentDisk, 'diskType'>;
+export type PersistentDisk = Mutate<RawListDiskItem, 'diskType', GooglePdType>;
 export type AppDataDisk = PersistentDisk;
+
+export type PersistentDiskDetail = Mutate<RawGetDiskItem, 'diskType', GooglePdType>;
 
 export const GcpPersistentDiskOptions = [googlePdTypes.standard, googlePdTypes.balanced, googlePdTypes.ssd];
 

--- a/src/libs/ajax/leonardo/models/disk-models.ts
+++ b/src/libs/ajax/leonardo/models/disk-models.ts
@@ -1,3 +1,4 @@
+import { Mutate } from '@terra-ui-packages/core-utils';
 import { AuditInfo, CloudContext, LeoResourceLabels } from 'src/libs/ajax/leonardo/models/core-models';
 
 export type AzureDiskType = 'Standard_LRS'; // TODO: Uncomment when enabling SSDs | 'StandardSSD_LRS';

--- a/src/pages/EnvironmentsPage.test.ts
+++ b/src/pages/EnvironmentsPage.test.ts
@@ -6,6 +6,7 @@ import { leoDiskProvider } from 'src/libs/ajax/leonardo/providers/LeoDiskProvide
 import { leoRuntimeProvider } from 'src/libs/ajax/leonardo/providers/LeoRuntimeProvider';
 import { MetricsProvider, useMetricsEvent } from 'src/libs/ajax/metrics/useMetrics';
 import { terraNavKey, TerraNavLinkProvider } from 'src/libs/nav';
+import { environmentsPermissions } from 'src/pages/EnvironmentsPage/environmentsPermissions';
 import { asMockedFn } from 'src/testing/test-utils';
 import { useWorkspaces } from 'src/workspaces/useWorkspaces';
 import { UseWorkspaces } from 'src/workspaces/useWorkspaces.models';
@@ -64,6 +65,7 @@ describe('Environments Page', () => {
         leoAppData: leoAppProvider,
         leoRuntimeData: leoRuntimeProvider,
         leoDiskData: leoDiskProvider,
+        permissions: environmentsPermissions,
         metrics: mockMetricsProvider,
       } satisfies EnvironmentsProps),
       expect.anything()

--- a/src/pages/EnvironmentsPage.test.ts
+++ b/src/pages/EnvironmentsPage.test.ts
@@ -6,7 +6,7 @@ import { leoDiskProvider } from 'src/libs/ajax/leonardo/providers/LeoDiskProvide
 import { leoRuntimeProvider } from 'src/libs/ajax/leonardo/providers/LeoRuntimeProvider';
 import { MetricsProvider, useMetricsEvent } from 'src/libs/ajax/metrics/useMetrics';
 import { terraNavKey, TerraNavLinkProvider } from 'src/libs/nav';
-import { environmentsPermissions } from 'src/pages/EnvironmentsPage/environmentsPermissions';
+import { leoResourcePermissions } from 'src/pages/EnvironmentsPage/environmentsPermissions';
 import { asMockedFn } from 'src/testing/test-utils';
 import { useWorkspaces } from 'src/workspaces/useWorkspaces';
 import { UseWorkspaces } from 'src/workspaces/useWorkspaces.models';
@@ -65,7 +65,7 @@ describe('Environments Page', () => {
         leoAppData: leoAppProvider,
         leoRuntimeData: leoRuntimeProvider,
         leoDiskData: leoDiskProvider,
-        permissions: environmentsPermissions,
+        permissions: leoResourcePermissions,
         metrics: mockMetricsProvider,
       } satisfies EnvironmentsProps),
       expect.anything()

--- a/src/pages/EnvironmentsPage.ts
+++ b/src/pages/EnvironmentsPage.ts
@@ -9,6 +9,7 @@ import { leoDiskProvider } from 'src/libs/ajax/leonardo/providers/LeoDiskProvide
 import { leoRuntimeProvider } from 'src/libs/ajax/leonardo/providers/LeoRuntimeProvider';
 import { useMetricsEvent } from 'src/libs/ajax/metrics/useMetrics';
 import { terraNavKey, TerraNavLinkProvider, terraNavLinkProvider } from 'src/libs/nav';
+import { environmentsPermissions } from 'src/pages/EnvironmentsPage/environmentsPermissions';
 import { useWorkspaces } from 'src/workspaces/useWorkspaces';
 
 type NavMap<NavTypes, FnReturn> = {
@@ -47,6 +48,7 @@ export const EnvironmentsPage = (): ReactNode => {
       leoRuntimeData: leoRuntimeProvider,
       leoDiskData: leoDiskProvider,
       metrics: metricsProvider,
+      permissions: environmentsPermissions,
     }),
   ]);
 };

--- a/src/pages/EnvironmentsPage.ts
+++ b/src/pages/EnvironmentsPage.ts
@@ -9,7 +9,7 @@ import { leoDiskProvider } from 'src/libs/ajax/leonardo/providers/LeoDiskProvide
 import { leoRuntimeProvider } from 'src/libs/ajax/leonardo/providers/LeoRuntimeProvider';
 import { useMetricsEvent } from 'src/libs/ajax/metrics/useMetrics';
 import { terraNavKey, TerraNavLinkProvider, terraNavLinkProvider } from 'src/libs/nav';
-import { environmentsPermissions } from 'src/pages/EnvironmentsPage/environmentsPermissions';
+import { leoResourcePermissions } from 'src/pages/EnvironmentsPage/environmentsPermissions';
 import { useWorkspaces } from 'src/workspaces/useWorkspaces';
 
 type NavMap<NavTypes, FnReturn> = {
@@ -48,7 +48,7 @@ export const EnvironmentsPage = (): ReactNode => {
       leoRuntimeData: leoRuntimeProvider,
       leoDiskData: leoDiskProvider,
       metrics: metricsProvider,
-      permissions: environmentsPermissions,
+      permissions: leoResourcePermissions,
     }),
   ]);
 };

--- a/src/pages/EnvironmentsPage/environmentsPermissions.test.ts
+++ b/src/pages/EnvironmentsPage/environmentsPermissions.test.ts
@@ -4,7 +4,7 @@ import { PersistentDisk } from 'src/libs/ajax/leonardo/models/disk-models';
 import { Runtime } from 'src/libs/ajax/leonardo/models/runtime-models';
 import { getTerraUser, TerraUser } from 'src/libs/state';
 
-import { environmentsPermissions } from './environmentsPermissions';
+import { leoResourcePermissions } from './environmentsPermissions';
 
 jest.mock('src/libs/state', () => ({
   ...jest.requireActual('src/libs/state'),
@@ -22,7 +22,7 @@ describe('environmentsPermissions', () => {
     } as DeepPartial<PersistentDisk> as PersistentDisk;
 
     // Act
-    const canIDeleteDisk = environmentsPermissions.canDeleteDisk(myDisk);
+    const canIDeleteDisk = leoResourcePermissions.canDeleteDisk(myDisk);
 
     // Assert
     expect(canIDeleteDisk).toBe(true);
@@ -38,7 +38,7 @@ describe('environmentsPermissions', () => {
     } as DeepPartial<PersistentDisk> as PersistentDisk;
 
     // Act
-    const canIDeleteDisk = environmentsPermissions.canDeleteDisk(otherDisk);
+    const canIDeleteDisk = leoResourcePermissions.canDeleteDisk(otherDisk);
 
     // Assert
     expect(canIDeleteDisk).toBe(false);
@@ -54,7 +54,7 @@ describe('environmentsPermissions', () => {
     } as DeepPartial<Runtime> as Runtime;
 
     // Act
-    const canIDeleteDisk = environmentsPermissions.canPauseResource(myRuntime);
+    const canIDeleteDisk = leoResourcePermissions.canPauseResource(myRuntime);
 
     // Assert
     expect(canIDeleteDisk).toBe(true);
@@ -70,7 +70,7 @@ describe('environmentsPermissions', () => {
     } as DeepPartial<Runtime> as Runtime;
 
     // Act
-    const canIDeleteDisk = environmentsPermissions.canPauseResource(otherRuntime);
+    const canIDeleteDisk = leoResourcePermissions.canPauseResource(otherRuntime);
 
     // Assert
     expect(canIDeleteDisk).toBe(false);

--- a/src/pages/EnvironmentsPage/environmentsPermissions.test.ts
+++ b/src/pages/EnvironmentsPage/environmentsPermissions.test.ts
@@ -1,7 +1,7 @@
 import { DeepPartial } from '@terra-ui-packages/core-utils';
 import { asMockedFn } from '@terra-ui-packages/test-utils';
 import { PersistentDisk } from 'src/libs/ajax/leonardo/models/disk-models';
-import { Runtime } from 'src/libs/ajax/leonardo/models/runtime-models';
+import { ListRuntimeItem } from 'src/libs/ajax/leonardo/models/runtime-models';
 import { getTerraUser, TerraUser } from 'src/libs/state';
 
 import { leoResourcePermissions } from './environmentsPermissions';
@@ -49,9 +49,9 @@ describe('environmentsPermissions', () => {
       email: 'me@here.org',
     } as Partial<TerraUser> as TerraUser);
 
-    const myRuntime: Runtime = {
+    const myRuntime: ListRuntimeItem = {
       auditInfo: { creator: 'me@here.org' },
-    } as DeepPartial<Runtime> as Runtime;
+    } as DeepPartial<ListRuntimeItem> as ListRuntimeItem;
 
     // Act
     const canIDeleteDisk = leoResourcePermissions.canPauseResource(myRuntime);
@@ -65,9 +65,9 @@ describe('environmentsPermissions', () => {
       email: 'me@here.org',
     } as Partial<TerraUser> as TerraUser);
 
-    const otherRuntime: Runtime = {
+    const otherRuntime: ListRuntimeItem = {
       auditInfo: { creator: 'you@there.org' },
-    } as DeepPartial<Runtime> as Runtime;
+    } as DeepPartial<ListRuntimeItem> as ListRuntimeItem;
 
     // Act
     const canIDeleteDisk = leoResourcePermissions.canPauseResource(otherRuntime);

--- a/src/pages/EnvironmentsPage/environmentsPermissions.test.ts
+++ b/src/pages/EnvironmentsPage/environmentsPermissions.test.ts
@@ -1,0 +1,78 @@
+import { DeepPartial } from '@terra-ui-packages/core-utils';
+import { asMockedFn } from '@terra-ui-packages/test-utils';
+import { PersistentDisk } from 'src/libs/ajax/leonardo/models/disk-models';
+import { Runtime } from 'src/libs/ajax/leonardo/models/runtime-models';
+import { getTerraUser, TerraUser } from 'src/libs/state';
+
+import { environmentsPermissions } from './environmentsPermissions';
+
+jest.mock('src/libs/state', () => ({
+  ...jest.requireActual('src/libs/state'),
+  getTerraUser: jest.fn(),
+}));
+describe('environmentsPermissions', () => {
+  it('allows disk delete for permitted user', () => {
+    // Arrange
+    asMockedFn(getTerraUser).mockReturnValue({
+      email: 'me@here.org',
+    } as Partial<TerraUser> as TerraUser);
+
+    const myDisk: PersistentDisk = {
+      auditInfo: { creator: 'me@here.org' },
+    } as DeepPartial<PersistentDisk> as PersistentDisk;
+
+    // Act
+    const canIDeleteDisk = environmentsPermissions.canDeleteDisk(myDisk);
+
+    // Assert
+    expect(canIDeleteDisk).toBe(true);
+  });
+  it('blocks disk delete for non-permitted user', () => {
+    // Arrange
+    asMockedFn(getTerraUser).mockReturnValue({
+      email: 'me@here.org',
+    } as Partial<TerraUser> as TerraUser);
+
+    const otherDisk: PersistentDisk = {
+      auditInfo: { creator: 'you@there.org' },
+    } as DeepPartial<PersistentDisk> as PersistentDisk;
+
+    // Act
+    const canIDeleteDisk = environmentsPermissions.canDeleteDisk(otherDisk);
+
+    // Assert
+    expect(canIDeleteDisk).toBe(false);
+  });
+  it('allows resource pause for permitted user', () => {
+    // Arrange
+    asMockedFn(getTerraUser).mockReturnValue({
+      email: 'me@here.org',
+    } as Partial<TerraUser> as TerraUser);
+
+    const myRuntime: Runtime = {
+      auditInfo: { creator: 'me@here.org' },
+    } as DeepPartial<Runtime> as Runtime;
+
+    // Act
+    const canIDeleteDisk = environmentsPermissions.canPauseResource(myRuntime);
+
+    // Assert
+    expect(canIDeleteDisk).toBe(true);
+  });
+  it('blocks resource pausing for non-permitted user', () => {
+    // Arrange
+    asMockedFn(getTerraUser).mockReturnValue({
+      email: 'me@here.org',
+    } as Partial<TerraUser> as TerraUser);
+
+    const otherRuntime: Runtime = {
+      auditInfo: { creator: 'you@there.org' },
+    } as DeepPartial<Runtime> as Runtime;
+
+    // Act
+    const canIDeleteDisk = environmentsPermissions.canPauseResource(otherRuntime);
+
+    // Assert
+    expect(canIDeleteDisk).toBe(false);
+  });
+});

--- a/src/pages/EnvironmentsPage/environmentsPermissions.ts
+++ b/src/pages/EnvironmentsPage/environmentsPermissions.ts
@@ -1,16 +1,18 @@
 import { LeoResourcePermissionsProvider } from 'src/analysis/Environments/Environments';
 import { getCreatorForCompute } from 'src/analysis/utils/resource-utils';
-import { IHaveCreator } from 'src/libs/ajax/leonardo/models/core-models';
+import { App } from 'src/libs/ajax/leonardo/models/app-models';
+import { PersistentDisk } from 'src/libs/ajax/leonardo/models/disk-models';
+import { ListRuntimeItem } from 'src/libs/ajax/leonardo/models/runtime-models';
 import { getTerraUser } from 'src/libs/state';
 
 const makePermissionsProvider = (userEmailGetter: () => string): LeoResourcePermissionsProvider => {
   const permissionsProvider: LeoResourcePermissionsProvider = {
-    canDeleteDisk: (disk: IHaveCreator) => {
+    canDeleteDisk: (disk: PersistentDisk) => {
       const currentUserEmail = userEmailGetter();
       const canDelete = disk.auditInfo.creator === currentUserEmail;
       return canDelete;
     },
-    canPauseResource: (resource: IHaveCreator) => {
+    canPauseResource: (resource: App | ListRuntimeItem) => {
       const currentUserEmail = userEmailGetter();
       const creator = getCreatorForCompute(resource);
       return currentUserEmail === creator;

--- a/src/pages/EnvironmentsPage/environmentsPermissions.ts
+++ b/src/pages/EnvironmentsPage/environmentsPermissions.ts
@@ -1,16 +1,16 @@
-import { EnvironmentPermissionsProvider } from 'src/analysis/Environments/Environments';
+import { LeoResourcePermissionsProvider } from 'src/analysis/Environments/Environments';
 import { getCreatorForCompute } from 'src/analysis/utils/resource-utils';
-import { PersistentDisk } from 'src/libs/ajax/leonardo/models/disk-models';
+import { IHaveCreator } from 'src/libs/ajax/leonardo/models/core-models';
 import { getTerraUser } from 'src/libs/state';
 
-const makePermissionsProvider = (userEmailGetter: () => string): EnvironmentPermissionsProvider => {
-  const permissionsProvider: EnvironmentPermissionsProvider = {
-    canDeleteDisk: (disk: PersistentDisk) => {
+const makePermissionsProvider = (userEmailGetter: () => string): LeoResourcePermissionsProvider => {
+  const permissionsProvider: LeoResourcePermissionsProvider = {
+    canDeleteDisk: (disk: IHaveCreator) => {
       const currentUserEmail = userEmailGetter();
       const canDelete = disk.auditInfo.creator === currentUserEmail;
       return canDelete;
     },
-    canPauseResource: (resource) => {
+    canPauseResource: (resource: IHaveCreator) => {
       const currentUserEmail = userEmailGetter();
       const creator = getCreatorForCompute(resource);
       return currentUserEmail === creator;
@@ -23,4 +23,4 @@ const currentUserEmailGetter = (): string => {
   return getTerraUser().email!;
 };
 
-export const environmentsPermissions = makePermissionsProvider(currentUserEmailGetter);
+export const leoResourcePermissions = makePermissionsProvider(currentUserEmailGetter);

--- a/src/pages/EnvironmentsPage/environmentsPermissions.ts
+++ b/src/pages/EnvironmentsPage/environmentsPermissions.ts
@@ -1,0 +1,26 @@
+import { EnvironmentPermissionsProvider } from 'src/analysis/Environments/Environments';
+import { getCreatorForCompute } from 'src/analysis/utils/resource-utils';
+import { PersistentDisk } from 'src/libs/ajax/leonardo/models/disk-models';
+import { getTerraUser } from 'src/libs/state';
+
+const makePermissionsProvider = (userEmailGetter: () => string): EnvironmentPermissionsProvider => {
+  const permissionsProvider: EnvironmentPermissionsProvider = {
+    canDeleteDisk: (disk: PersistentDisk) => {
+      const currentUserEmail = userEmailGetter();
+      const canDelete = disk.auditInfo.creator === currentUserEmail;
+      return canDelete;
+    },
+    canPauseResource: (resource) => {
+      const currentUserEmail = userEmailGetter();
+      const creator = getCreatorForCompute(resource);
+      return currentUserEmail === creator;
+    },
+  };
+  return permissionsProvider;
+};
+
+const currentUserEmailGetter = (): string => {
+  return getTerraUser().email!;
+};
+
+export const environmentsPermissions = makePermissionsProvider(currentUserEmailGetter);


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/UIE-147

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
refactored permissions related logic to be composable instead of hard-wired inside Environments component.

### What
- introduced EnvironmentsPermissionsProvider type and implementation which is now a required prop of Environments component.  This decouples permissions logic so that it can be more easily composed by AoU or other consumers.
- improved related types for code in the path of permissions logic (previously using current user email directly)
- improved clarity around raw disk api data types.
- fixed bug where renderErrorApps was using getDisplayRuntimeStatus helper, instead of getAppStatusForDisplay.
- also created EnvironmentsPage sub-directory for new bits, but will hold off on moving existing EnvironmentsPage bits into it.
---
- PR feedback - renamed permission provider and types.
- changed permission methods to accept narrow IHaveCreator argument, tweaked related bits to use new type.

### Why
- part of enabling code sharing with AoU

### Testing strategy
- smoke/regression test, no functional changes.

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 
