### PR TITLE
[WM-1972] Submissions stop refreshing after terminal state

### DIFF
--- a/src/workflows-app/SubmissionDetails.js
+++ b/src/workflows-app/SubmissionDetails.js
@@ -1,4 +1,3 @@
-import { Spinner } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { div, h, h2, h3, span } from 'react-hyperscript-helpers';
@@ -247,7 +246,7 @@ export const BaseSubmissionDetails = ({ name, namespace, workspace, submissionId
 
   const rowWidth = 100;
   const rowHeight = 50;
-  return loading && !runSetData
+  return loading
     ? centeredSpinner()
     : div({ id: 'submission-details-page' }, [
         div(
@@ -320,18 +319,12 @@ export const BaseSubmissionDetails = ({ name, namespace, workspace, submissionId
               },
               [
                 div([h2(['Workflows'])]),
-                Utils.cond(
-                  [loading, () => div([h(Spinner, { size: 15, style: { verticalAlign: '-0.125rem' } }), ' Workflow statuses are updating...'])],
-                  [
-                    runsFullyUpdated,
-                    () => div([icon('check', { size: 15, style: { color: colors.success() } }), ' Workflow statuses are all up to date.']),
-                  ],
-                  () =>
-                    div([
+                runsFullyUpdated
+                  ? div([icon('check', { size: 15, style: { color: colors.success() } }), ' Workflow statuses are all up to date.'])
+                  : div([
                       icon('warning-standard', { size: 15, style: { color: colors.warning() } }),
                       ' Some workflow statuses are not up to date. Refreshing the page may update more statuses.',
-                    ])
-                ),
+                    ]),
                 div([h3(['Filter by: '])]),
                 h(Select, {
                   isDisabled: false,

--- a/src/workflows-app/SubmissionDetails.js
+++ b/src/workflows-app/SubmissionDetails.js
@@ -1,3 +1,4 @@
+import { Spinner } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { div, h, h2, h3, span } from 'react-hyperscript-helpers';
@@ -140,6 +141,7 @@ export const BaseSubmissionDetails = ({ name, namespace, workspace, submissionId
       if (workflowsAppStore.get().cbasProxyUrlState.status === AppProxyUrlStatus.Ready) {
         updatedRunSets = await loadAllRunSets(workflowsAppStore.get().cbasProxyUrlState);
       }
+      // only refresh if _this_ run set is in non-terminal state
       if (
         !updatedRunSets ||
         _.some(({ run_set_id: runSetId, state }) => runSetId === submissionId && !isRunSetInTerminalState(state), updatedRunSets)
@@ -245,7 +247,7 @@ export const BaseSubmissionDetails = ({ name, namespace, workspace, submissionId
 
   const rowWidth = 100;
   const rowHeight = 50;
-  return loading
+  return loading && !runSetData
     ? centeredSpinner()
     : div({ id: 'submission-details-page' }, [
         div(
@@ -318,12 +320,20 @@ export const BaseSubmissionDetails = ({ name, namespace, workspace, submissionId
               },
               [
                 div([h2(['Workflows'])]),
-                runsFullyUpdated
-                  ? div([icon('check', { size: 15, style: { color: colors.success() } }), ' Workflow statuses are all up to date.'])
-                  : div([
-                      icon('warning-standard', { size: 15, style: { color: colors.warning() } }),
-                      ' Some workflow statuses are not up to date. Refreshing the page may update more statuses.',
-                    ]),
+                Utils.cond(
+                  [loading, () => div([h(Spinner, { size: 15, style: { verticalAlign: '-0.125rem' } }), ' Workflow statuses are updating...'])],
+                  [
+                    runsFullyUpdated,
+                    () => div([icon('check', { size: 15, style: { color: colors.success() } }), ' Workflow statuses are all up to date.']),
+                  ],
+                  [
+                    () =>
+                      div([
+                        icon('warning-standard', { size: 15, style: { color: colors.warning() } }),
+                        ' Some workflow statuses are not up to date. Refreshing the page may update more statuses.',
+                      ]),
+                  ]
+                ),
                 div([h3(['Filter by: '])]),
                 h(Select, {
                   isDisabled: false,

--- a/src/workflows-app/SubmissionDetails.js
+++ b/src/workflows-app/SubmissionDetails.js
@@ -326,13 +326,11 @@ export const BaseSubmissionDetails = ({ name, namespace, workspace, submissionId
                     runsFullyUpdated,
                     () => div([icon('check', { size: 15, style: { color: colors.success() } }), ' Workflow statuses are all up to date.']),
                   ],
-                  [
-                    () =>
-                      div([
-                        icon('warning-standard', { size: 15, style: { color: colors.warning() } }),
-                        ' Some workflow statuses are not up to date. Refreshing the page may update more statuses.',
-                      ]),
-                  ]
+                  () =>
+                    div([
+                      icon('warning-standard', { size: 15, style: { color: colors.warning() } }),
+                      ' Some workflow statuses are not up to date. Refreshing the page may update more statuses.',
+                    ])
                 ),
                 div([h3(['Filter by: '])]),
                 h(Select, {

--- a/src/workflows-app/SubmissionDetails.js
+++ b/src/workflows-app/SubmissionDetails.js
@@ -140,8 +140,10 @@ export const BaseSubmissionDetails = ({ name, namespace, workspace, submissionId
       if (workflowsAppStore.get().cbasProxyUrlState.status === AppProxyUrlStatus.Ready) {
         updatedRunSets = await loadAllRunSets(workflowsAppStore.get().cbasProxyUrlState);
       }
-      // only refresh if there are run sets in non-terminal state
-      if (!updatedRunSets || _.some(({ state }) => !isRunSetInTerminalState(state), updatedRunSets)) {
+      if (
+        !updatedRunSets ||
+        _.some(({ run_set_id: runSetId, state }) => runSetId === submissionId && !isRunSetInTerminalState(state), updatedRunSets)
+      ) {
         scheduledRefresh.current = setTimeout(refresh, AutoRefreshInterval);
       }
     } catch (error) {
@@ -201,11 +203,10 @@ export const BaseSubmissionDetails = ({ name, namespace, workspace, submissionId
       const { cbasProxyUrlState } = await loadAppUrls(workspaceId, 'cbasProxyUrlState');
 
       if (cbasProxyUrlState.status === AppProxyUrlStatus.Ready) {
-        await loadAllRunSets(cbasProxyUrlState);
+        await refresh();
       }
     };
     loadWorkflowsApp();
-    refresh();
 
     return () => {
       if (scheduledRefresh.current) {


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WM-1972

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Submissions stop refreshing after terminal state
- Also changed whole-screen spinner to a spinner by the message about statuses up-to-date, so the whole screen doesn't blank out every refresh

### Why
- After submission is in terminal state there will be no more new information that requires polling

### Testing strategy
- Validated by running multiple submissions and checking that they each stopped refreshing once they were complete, even if others were running <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 
