### PR TITLE
[AJ-1469] Add notice about policies applied to a new workspace by importing data

### DIFF
--- a/src/import-data/ImportDataDestination.ts
+++ b/src/import-data/ImportDataDestination.ts
@@ -355,7 +355,15 @@ export const ImportDataDestination = (props: ImportDataDestinationProps): ReactN
               h(NewWorkspaceModal, {
                 requiredAuthDomain: requiredAuthorizationDomain,
                 cloudPlatform: getCloudPlatformRequiredForImport(importRequest),
-                renderNotice: () => importMayTakeTime && importMayTakeTimeMessage,
+                renderNotice: ({ selectedBillingProject }) =>
+                  h(Fragment, [
+                    isProtectedData &&
+                      selectedBillingProject?.cloudPlatform === 'AZURE' &&
+                      p([
+                        'Importing controlled access data will apply any additional access controls associated with the data to this workspace.',
+                      ]),
+                    importMayTakeTime && importMayTakeTimeMessage,
+                  ]),
                 requireEnhancedBucketLogging: isProtectedData,
                 waitForServices: {
                   wds: true,

--- a/src/import-data/ImportDataDestination.ts
+++ b/src/import-data/ImportDataDestination.ts
@@ -177,8 +177,9 @@ export const ImportDataDestination = (props: ImportDataDestinationProps): ReactN
     : [];
   const canUseTemplateWorkspace = filteredTemplates.length > 0;
 
-  const importMayTakeTimeMessage =
-    'Note that the import process may take some time after you are redirected into your destination workspace.';
+  const importMayTakeTimeMessage = p([
+    'Note that the import process may take some time after you are redirected into your destination workspace.',
+  ]);
 
   const linkAccountPrompt = () => {
     return div({}, [
@@ -354,7 +355,7 @@ export const ImportDataDestination = (props: ImportDataDestinationProps): ReactN
               h(NewWorkspaceModal, {
                 requiredAuthDomain: requiredAuthorizationDomain,
                 cloudPlatform: getCloudPlatformRequiredForImport(importRequest),
-                customMessage: importMayTakeTime && importMayTakeTimeMessage,
+                renderNotice: () => importMayTakeTime && importMayTakeTimeMessage,
                 requireEnhancedBucketLogging: isProtectedData,
                 waitForServices: {
                   wds: true,
@@ -378,7 +379,7 @@ export const ImportDataDestination = (props: ImportDataDestinationProps): ReactN
         // This modal can only be opened if selectedTemplateWorkspaceKey is set.
         title: `Clone ${selectedTemplateWorkspaceKey!.name} and Import Data`,
         buttonText: 'Clone and Import',
-        customMessage: importMayTakeTime && importMayTakeTimeMessage,
+        renderNotice: () => importMayTakeTime && importMayTakeTimeMessage,
         onDismiss: () => setIsCloneOpen(false),
         onSuccess: (w) => {
           setMode('existing');

--- a/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.ts
+++ b/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.ts
@@ -85,7 +85,7 @@ export interface NewWorkspaceModalProps {
   buttonText?: string;
   cloneWorkspace?: WorkspaceWrapper;
   cloudPlatform?: CloudPlatform;
-  customMessage?: ReactNode;
+  renderNotice?: (args: { selectedBillingProject?: BillingProject }) => ReactNode;
   requiredAuthDomain?: string;
   requireEnhancedBucketLogging?: boolean;
   title?: string;
@@ -104,7 +104,7 @@ const NewWorkspaceModal = withDisplayName(
     cloudPlatform,
     onSuccess,
     onDismiss,
-    customMessage,
+    renderNotice = () => null,
     requiredAuthDomain,
     requireEnhancedBucketLogging,
     title,
@@ -647,7 +647,11 @@ const NewWorkspaceModal = withDisplayName(
                             }),
                           ]),
                       ]),
-                    customMessage && div({ style: { marginTop: '1rem', lineHeight: '1.5rem' } }, [customMessage]),
+                    renderNotice({
+                      selectedBillingProject: namespace
+                        ? billingProjects?.find(({ projectName }) => projectName === namespace)
+                        : undefined,
+                    }),
                     workflowImport &&
                       azureBillingProjectsExist &&
                       div({ style: { paddingTop: '1.0rem', display: 'flex' } }, [


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1469

This adds a notice about "data access controls" (group constraint policies) that may be applied to the workspace when importing protected / controlled access data into a new Azure workspace.

![286764200-b73e51ab-aabd-44b7-b9f5-932371904728](https://github.com/DataBiosphere/terra-ui/assets/1156625/16c6f99b-7211-4f97-86af-f26125f507c3)

It only makes sense to show this message when an Azure billing project is selected, because GCP workspaces don't support policies. To allow conditionally showing the notice, I replaced `customMessage` with a [render prop](https://legacy.reactjs.org/docs/render-props.html) that has access to the selected billing project.