### PR TITLE
Adjust parallelism and resource_class for integration-tests-staging to reduce flakiness

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -276,7 +276,7 @@ jobs:
           channel: "C7H40L71D" # dsde-qa-notify
   integration-tests-pr-staging:
     executor: puppeteer
-    parallelism: 2
+    parallelism: 1
     steps:
       - integration-tests:
           local: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,7 +277,6 @@ jobs:
   integration-tests-pr-staging:
     executor: puppeteer
     parallelism: 1
-    resource_class: small
     steps:
       - integration-tests:
           local: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,6 +277,7 @@ jobs:
   integration-tests-pr-staging:
     executor: puppeteer
     parallelism: 1
+    resource_class: small
     steps:
       - integration-tests:
           local: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -276,7 +276,7 @@ jobs:
           channel: "C7H40L71D" # dsde-qa-notify
   integration-tests-pr-staging:
     executor: puppeteer
-    parallelism: 4
+    parallelism: 2
     steps:
       - integration-tests:
           local: true

--- a/.github/workflows/run-integration-tests.yaml
+++ b/.github/workflows/run-integration-tests.yaml
@@ -62,9 +62,9 @@ on:
     # technically, the emails are not secret, but they're stored w/ the private key so
     # we'll just pull them to avoid potential sync/typo/refresh issues.
     secrets:
-      LYLE_CLIENT_EMAIL: 
+      LYLE_CLIENT_EMAIL:
         required: true
-      LYLE_PRIVATE_KEY: 
+      LYLE_PRIVATE_KEY:
         required: true
       FIRECLOUD_ACCOUNT_CLIENT_EMAIL:
         required: true
@@ -80,6 +80,7 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       contents: 'read'
+    resource_class: medium+
     steps:
 
       ##
@@ -108,7 +109,7 @@ jobs:
           --arg client_email "${{ secrets.LYLE_CLIENT_EMAIL }}" \
           --arg key"${{ secrets.LYLE_PRIVATE_KEY }}" \
           '{"client_email": $client_email, "key": $key}') >> $GITHUB_ENV
-          
+
           echo \
           TERRA_SA_KEY=$(jq --null-input \
           --arg client_email "${{ secrets.FIRECLOUD_ACCOUNT_CLIENT_EMAIL }}" \

--- a/.github/workflows/run-integration-tests.yaml
+++ b/.github/workflows/run-integration-tests.yaml
@@ -80,7 +80,6 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       contents: 'read'
-    resource_class: medium+
     steps:
 
       ##


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/ID-942

## Summary of changes:
We have been noticing flakiness of the register-user test (and other tests) that is hard to reproduce locally, and only seems to be appearing when running against the staging environment. I ran the register-user test locally against staging using the test-flakes script and noticed a pattern. When I reduce the concurrency to 1 the test doesn't flake at all, when it is set to 4 it flakes around 15% of the time. I am not positive what the root cause is but the tests seem to run more reliably with reduced concurrency. 

### What
I changed the resource_class for integration-tests-staging to medium+ which will give it 3 cpu's to work with, and I reduced the parallelism to 3 so that each run will have a whole cpu to work with. In my testing so far running this in circle things are looking good. 

### Why
Flakey tests waste a ton of time making it harder to iterate on, merge, and deploy code, ultimately wasting a ton of dev time. 

### Testing strategy
- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 
