### PR TITLE
[AJ-1444][AJ-1383] Add feature flag for importing Azure TDR snapshots

### DIFF
--- a/src/import-data/ImportData.test.ts
+++ b/src/import-data/ImportData.test.ts
@@ -5,7 +5,7 @@ import { h } from 'react-hyperscript-helpers';
 import { Ajax } from 'src/libs/ajax';
 import { DataRepo, DataRepoContract, Snapshot } from 'src/libs/ajax/DataRepo';
 import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
-import { ENABLE_AZURE_PFB_IMPORT } from 'src/libs/feature-previews-config';
+import { ENABLE_AZURE_PFB_IMPORT, ENABLE_AZURE_TDR_IMPORT } from 'src/libs/feature-previews-config';
 import { useRoute } from 'src/libs/nav';
 import { asMockedFn, renderWithAppContexts as render, SelectHelper } from 'src/testing/test-utils';
 import { defaultAzureWorkspace, defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
@@ -356,6 +356,10 @@ describe('ImportData', () => {
       it('imports snapshots into Azure workspaces', async () => {
         // Arrange
         const user = userEvent.setup();
+
+        asMockedFn(isFeaturePreviewEnabled).mockImplementation(
+          (featurePreview) => featurePreview === ENABLE_AZURE_TDR_IMPORT
+        );
 
         const queryParams = {
           ...commonSnapshotExportQueryParams,

--- a/src/import-data/ImportDataDestination.test.ts
+++ b/src/import-data/ImportDataDestination.test.ts
@@ -499,34 +499,4 @@ describe('ImportDataDestination', () => {
       expect(isNoticeShownForBillingProject(azureProtectedDataBillingProject)).toBe(noticeExpected);
     }
   );
-
-  it('hides new workspace option for imports of protected Azure snapshots', async () => {
-    // Arrange
-    setup({
-      props: {
-        importRequest: {
-          type: 'tdr-snapshot-export',
-          manifestUrl: new URL('https://example.com/path/to/manifest.json'),
-          snapshot: {
-            id: '00001111-2222-3333-aaaa-bbbbccccdddd',
-            name: 'test-snapshot',
-            source: [
-              {
-                dataset: {
-                  id: '00001111-2222-3333-aaaa-bbbbccccdddd',
-                  name: 'test-dataset',
-                  secureMonitoringEnabled: true,
-                },
-              },
-            ],
-            cloudPlatform: 'azure',
-          },
-          syncPermissions: false,
-        },
-      },
-    });
-
-    // Assert
-    expect(screen.queryByText('Create a new workspace')).toBeNull();
-  });
 });

--- a/src/import-data/ImportDataDestination.ts
+++ b/src/import-data/ImportDataDestination.ts
@@ -109,11 +109,6 @@ export const ImportDataDestination = (props: ImportDataDestinationProps): ReactN
   const isProtectedData = isProtectedSource(importRequest);
   const requiredCloudPlatform = getCloudPlatformRequiredForImport(importRequest);
 
-  // There is not yet a way to create a protected Azure via Terra UI.
-  // Thus, there is no way to create a new workspace that satisfies the requirements
-  // for a protected Azure snapshot.
-  const canUseNewWorkspace = !(isProtectedData && requiredCloudPlatform === 'AZURE');
-
   // Some import types are finished in a single request.
   // For most though, the import request starts a background task that takes time to complete.
   const immediateImportTypes: ImportRequest['type'][] = ['tdr-snapshot-reference'];
@@ -342,15 +337,14 @@ export const ImportDataDestination = (props: ImportDataDestinationProps): ReactN
                   ? 'No existing protected workspace is present.'
                   : undefined,
             }),
-            canUseNewWorkspace &&
-              h(ChoiceButton, {
-                onClick: () => setIsCreateOpen(true),
-                iconName: 'plus-circle',
-                title: 'Create a new workspace',
-                detail: 'Set up an empty workspace that you will configure for analysis',
-                'aria-haspopup': 'dialog',
-                disabled: !userHasBillingProjects,
-              }),
+            h(ChoiceButton, {
+              onClick: () => setIsCreateOpen(true),
+              iconName: 'plus-circle',
+              title: 'Create a new workspace',
+              detail: 'Set up an empty workspace that you will configure for analysis',
+              'aria-haspopup': 'dialog',
+              disabled: !userHasBillingProjects,
+            }),
             isCreateOpen &&
               h(NewWorkspaceModal, {
                 requiredAuthDomain: requiredAuthorizationDomain,

--- a/src/import-data/useImportRequest.ts
+++ b/src/import-data/useImportRequest.ts
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
 import { DataRepo, Snapshot } from 'src/libs/ajax/DataRepo';
+import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
+import { ENABLE_AZURE_TDR_IMPORT } from 'src/libs/feature-previews-config';
 import { useRoute } from 'src/libs/nav';
 
 import {
@@ -77,6 +79,10 @@ const getTDRSnapshotExportImportRequest = async (queryParams: QueryParams): Prom
     snapshot = await DataRepo().snapshot(snapshotId).details();
   } catch (err: unknown) {
     throw new Error('Unable to load snapshot.');
+  }
+
+  if (snapshot.cloudPlatform === 'azure' && !isFeaturePreviewEnabled(ENABLE_AZURE_TDR_IMPORT)) {
+    throw new Error('Importing Azure snapshots is not supported.');
   }
 
   return {

--- a/src/libs/feature-previews-config.ts
+++ b/src/libs/feature-previews-config.ts
@@ -3,6 +3,7 @@ export const ENABLE_JUPYTERLAB_ID = 'enableJupyterLabGCP';
 export const HAIL_BATCH_AZURE_FEATURE_ID = 'hail-batch-azure';
 export const ENABLE_WORKFLOW_RESOURCE_MONITORING = 'enableWorkflowResourceMonitoring';
 export const ENABLE_AZURE_PFB_IMPORT = 'enableAzurePfbImport';
+export const ENABLE_AZURE_TDR_IMPORT = 'enableAzureTdrImport';
 
 // If the groups option is defined for a FeaturePreview, it must contain at least one group.
 type GroupsList = readonly [string, ...string[]];
@@ -97,6 +98,15 @@ const featurePreviewsConfig: readonly FeaturePreview[] = [
     groups: ['preview-azure-pfb-import'],
     feedbackUrl: `mailto:dsp-analysis-journeys@broadinstitute.org?subject=${encodeURIComponent(
       'Feedback on Azure PFB Import'
+    )}`,
+  },
+  {
+    id: ENABLE_AZURE_TDR_IMPORT,
+    title: 'Azure TDR Import',
+    description: 'Enabling this feature will allow importing TDR snapshots into Azure workspaces.',
+    groups: ['dsp-analysis-journeys'],
+    feedbackUrl: `mailto:dsp-analysis-journeys@broadinstitute.org?subject=${encodeURIComponent(
+      'Feedback on Azure TDR snapshot Import'
     )}`,
   },
 ];


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1444
https://broadworkbench.atlassian.net/browse/AJ-1383

WDS does not yet support importing TDR snapshots, so we want to require that a feature flag is enabled in order to attempt importing a TDR snapshot into WDS. Since cross-cloud imports are not allowed, this we can accomplish this by blocking imports of Azure TDR snapshots unless the feature flag is enabled. This PR does that. If a user attempts to import an Azure snapshot without the feature flag enabled, they'll get a screen like this:

![Screenshot 2023-11-30 at 4 44 07 PM](https://github.com/DataBiosphere/terra-ui/assets/1156625/db210f36-7f42-425e-8b31-8a40874b69c5)

Since we've now blocked _all_ Azure snapshot imports, we can go ahead and restore the "start with a new workspace" option for protected Azure snapshots since now the only people who will see it are developers with the feature flag enabled. That option was previously hidden because there was no way for a user to create a protected Azure billing project / workspace.