### PR TITLE
Correct when not to display policies section in ShareWorkspaceModal (WOR-1347).

### DIFF
--- a/src/libs/events.test.ts
+++ b/src/libs/events.test.ts
@@ -1,4 +1,4 @@
-import { defaultAzureWorkspace, defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
+import { defaultAzureWorkspace, defaultGoogleWorkspace, protectedAzureWorkspace } from 'src/testing/workspace-fixtures';
 
 import { extractBillingDetails, extractCrossWorkspaceDetails, extractWorkspaceDetails } from './events';
 
@@ -37,7 +37,20 @@ describe('extractWorkspaceDetails', () => {
       workspaceName: defaultGoogleWorkspace.workspace.name,
       workspaceNamespace: defaultGoogleWorkspace.workspace.namespace,
       cloudPlatform: 'GCP',
-      hasProtectedData: undefined,
+      hasProtectedData: false,
+    });
+  });
+
+  it('Determine hasProtectedData based on workspace.policies', () => {
+    // Act
+    const workspaceDetails = extractWorkspaceDetails(protectedAzureWorkspace);
+
+    // Assert
+    expect(workspaceDetails).toEqual({
+      workspaceName: protectedAzureWorkspace.workspace.name,
+      workspaceNamespace: protectedAzureWorkspace.workspace.namespace,
+      cloudPlatform: 'AZURE',
+      hasProtectedData: true,
     });
   });
 });

--- a/src/testing/workspace-fixtures.ts
+++ b/src/testing/workspace-fixtures.ts
@@ -23,6 +23,7 @@ export const defaultAzureWorkspace: AzureWorkspace = {
   accessLevel: 'OWNER',
   canShare: true,
   canCompute: true,
+  policies: [],
 };
 
 export const makeAzureWorkspace = (workspace?: DeepPartial<AzureWorkspace>): AzureWorkspace => {
@@ -91,6 +92,7 @@ export const defaultGoogleWorkspace: GoogleWorkspace = {
   accessLevel: 'OWNER',
   canShare: true,
   canCompute: true,
+  policies: [],
 };
 
 export const makeGoogleWorkspace = (workspace?: DeepPartial<GoogleWorkspace>): GoogleWorkspace => {

--- a/src/workflows-app/SubmissionConfig.test.js
+++ b/src/workflows-app/SubmissionConfig.test.js
@@ -1930,7 +1930,7 @@ describe('Submitting a run set', () => {
         },
       })
     );
-  }, 7000);
+  }, 10000);
 
   it('should call POST /run_sets endpoint with expected parameters after outputs are set to default', async () => {
     // ** ARRANGE **

--- a/src/workspace-data/data-table/shared/DataTable.test.ts
+++ b/src/workspace-data/data-table/shared/DataTable.test.ts
@@ -349,7 +349,7 @@ describe('DataTable', () => {
       'sample',
       expect.objectContaining({ columnFilter: 'sample_id=even' })
     );
-  }, 10000);
+  }, 13000);
 
   it('selects filtered', async () => {
     // Arrange

--- a/src/workspaces/ShareWorkspaceModal/ShareWorkspaceModal.test.ts
+++ b/src/workspaces/ShareWorkspaceModal/ShareWorkspaceModal.test.ts
@@ -281,6 +281,7 @@ describe('the share workspace modal', () => {
           })
         );
       });
+      expect(defaultAzureWorkspace.policies).toEqual([]);
       expect(screen.queryByText('Policies')).toBeNull();
     });
   });

--- a/src/workspaces/ShareWorkspaceModal/ShareWorkspaceModal.ts
+++ b/src/workspaces/ShareWorkspaceModal/ShareWorkspaceModal.ts
@@ -14,7 +14,6 @@ import { reportError } from 'src/libs/error';
 import Events, { extractWorkspaceDetails } from 'src/libs/events';
 import { FormLabel } from 'src/libs/forms';
 import { useCancellation, useOnMount } from 'src/libs/react-utils';
-import * as Style from 'src/libs/style';
 import { append, cond, withBusyState } from 'src/libs/utils';
 import { isAzureWorkspace, isProtectedWorkspace, WorkspaceWrapper } from 'src/libs/workspace-utils';
 import {
@@ -190,9 +189,7 @@ const ShareWorkspaceModal: React.FC<ShareWorkspaceModalProps> = (props: ShareWor
       ]),
       searchValueValid && !searchHasFocus && p([addUserReminder]),
       h(CurrentCollaborators, { acl, setAcl, originalAcl, lastAddedEmail, workspace }),
-      !!workspace.policies &&
-        div({ style: { ...Style.elements.sectionHeader, margin: '1rem 0 0.5rem 0' } }, ['Policies']),
-      !!workspace.policies && h(WorkspacePolicies, { workspace, style: { marginBottom: '1.5rem' } }),
+      h(WorkspacePolicies, { workspace, title: 'Policies', style: { marginBottom: '1.5rem' } }),
       !loaded && centeredSpinner(),
       updateError && div({ style: { marginTop: '1rem' } }, [div(['An error occurred:']), updateError]),
       div({ style: { ...modalStyles.buttonRow, justifyContent: 'space-between' } }, [

--- a/src/workspaces/WorkspacePolicies/WorkspacePolicies.ts
+++ b/src/workspaces/WorkspacePolicies/WorkspacePolicies.ts
@@ -3,10 +3,12 @@ import _ from 'lodash/fp';
 import pluralize from 'pluralize';
 import { CSSProperties, ReactNode } from 'react';
 import { div, h, li, p, ul } from 'react-hyperscript-helpers';
+import * as Style from 'src/libs/style';
 import { getPolicyDescriptions, WorkspaceWrapper } from 'src/libs/workspace-utils';
 
 type WorkspacePoliciesProps = {
   workspace: WorkspaceWrapper;
+  title?: string;
   style?: CSSProperties;
 };
 
@@ -15,6 +17,7 @@ export const WorkspacePolicies = (props: WorkspacePoliciesProps): ReactNode => {
 
   if (policyDescriptions.length > 0) {
     return div({ style: props.style }, [
+      !!props.title && div({ style: { ...Style.elements.sectionHeader, margin: '1rem 0 0.5rem 0' } }, [props.title]),
       p({}, [`This workspace has the following ${pluralize('policy', policyDescriptions.length)}:`]),
       ul(
         {},


### PR DESCRIPTION
Follow-up bug fix to https://github.com/DataBiosphere/terra-ui/pull/4519.

Towards the end of the review cycle, I pulled the "Policies" title out of the component because the Import workflow doesn't want it. I then had to conditionalize when to display the "Policies" title and did it incorrectly in a couple of different ways:

1) workspace.policies in reality always exists, it will just be empty if there are no policies (mock data was missing the property).
2) GCP workspaces don't depend on workspace.policies to determine whether the workspace is protected

The `WorkspacePolicies` component itself has the correct smarts about when not to display anything (based on empty policy description array), so move the title back into `WorkspacePolicies` in such a way that it is optional. This will also be useful for my next ticket, which is to add this component to `NewWorkspaceModal` in the cloning case.

Before (workspace with no policies):

<img width="697" alt="image" src="https://github.com/DataBiosphere/terra-ui/assets/484484/25ec7124-4ce9-4aad-a34b-a70838518ba5">

After:

<img width="759" alt="image" src="https://github.com/DataBiosphere/terra-ui/assets/484484/775b440f-3731-406a-a44c-182f996c5c41">

And when it should show up (GCP case with Auth Domain):

<img width="713" alt="image" src="https://github.com/DataBiosphere/terra-ui/assets/484484/e5380751-0f88-4f64-8e5c-4b1696ffa632">
