### PR TITLE
[WOR-1348] Show workspace policies when cloning

### DIFF
--- a/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.ts
+++ b/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.ts
@@ -46,6 +46,7 @@ import {
   GCPBillingProject,
 } from 'src/pages/billing/models/BillingProject';
 import { CreatingWorkspaceMessage } from 'src/workspaces/NewWorkspaceModal/CreatingWorkspaceMessage';
+import { WorkspacePolicies } from 'src/workspaces/WorkspacePolicies/WorkspacePolicies';
 import validate from 'validate.js';
 
 const warningStyle: CSSProperties = {
@@ -647,11 +648,19 @@ const NewWorkspaceModal = withDisplayName(
                             }),
                           ]),
                       ]),
+                    !!cloneWorkspace &&
+                      h(WorkspacePolicies, {
+                        workspace: cloneWorkspace,
+                        title: 'Policies',
+                        policiesLabel: 'The cloned workspace will inherit:',
+                        // style: { lineHeight: '1.0'},
+                      }),
                     renderNotice({
                       selectedBillingProject: namespace
                         ? billingProjects?.find(({ projectName }) => projectName === namespace)
                         : undefined,
                     }),
+                    // workflowImport is never true if we are cloning a workspace.
                     workflowImport &&
                       azureBillingProjectsExist &&
                       div({ style: { paddingTop: '1.0rem', display: 'flex' } }, [

--- a/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.ts
+++ b/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.ts
@@ -653,14 +653,12 @@ const NewWorkspaceModal = withDisplayName(
                         workspace: cloneWorkspace,
                         title: 'Policies',
                         policiesLabel: 'The cloned workspace will inherit:',
-                        // style: { lineHeight: '1.0'},
                       }),
                     renderNotice({
                       selectedBillingProject: namespace
                         ? billingProjects?.find(({ projectName }) => projectName === namespace)
                         : undefined,
                     }),
-                    // workflowImport is never true if we are cloning a workspace.
                     workflowImport &&
                       azureBillingProjectsExist &&
                       div({ style: { paddingTop: '1.0rem', display: 'flex' } }, [

--- a/src/workspaces/WorkspacePolicies/WorkspacePolicies.test.ts
+++ b/src/workspaces/WorkspacePolicies/WorkspacePolicies.test.ts
@@ -89,4 +89,19 @@ describe('WorkspacePolicies', () => {
     // Assert
     expect(screen.getAllByText(/controlled-access data/)).not.toBeNull();
   });
+
+  it('allows passing a title and label about the list', async () => {
+    // Act
+    render(
+      h(WorkspacePolicies, {
+        title: 'Test title',
+        policiesLabel: 'About this list:',
+        workspace: protectedAzureWorkspace,
+      })
+    );
+
+    // Assert
+    expect(screen.getAllByText('Test title')).not.toBeNull();
+    expect(screen.getAllByText('About this list:')).not.toBeNull();
+  });
 });

--- a/src/workspaces/WorkspacePolicies/WorkspacePolicies.ts
+++ b/src/workspaces/WorkspacePolicies/WorkspacePolicies.ts
@@ -2,25 +2,29 @@ import { InfoBox } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import pluralize from 'pluralize';
 import { CSSProperties, ReactNode } from 'react';
-import { div, h, li, p, ul } from 'react-hyperscript-helpers';
+import { div, h, li, ul } from 'react-hyperscript-helpers';
 import * as Style from 'src/libs/style';
 import { getPolicyDescriptions, WorkspaceWrapper } from 'src/libs/workspace-utils';
 
 type WorkspacePoliciesProps = {
   workspace: WorkspaceWrapper;
   title?: string;
+  policiesLabel?: string;
   style?: CSSProperties;
 };
 
 export const WorkspacePolicies = (props: WorkspacePoliciesProps): ReactNode => {
   const policyDescriptions = getPolicyDescriptions(props.workspace);
+  const description = props.policiesLabel
+    ? props.policiesLabel
+    : `This workspace has the following ${pluralize('policy', policyDescriptions.length)}:`;
 
   if (policyDescriptions.length > 0) {
     return div({ style: props.style }, [
       !!props.title && div({ style: { ...Style.elements.sectionHeader, margin: '1rem 0 0.5rem 0' } }, [props.title]),
-      p({}, [`This workspace has the following ${pluralize('policy', policyDescriptions.length)}:`]),
+      div({}, [description]),
       ul(
-        {},
+        { style: { marginBlockStart: '0.5rem', marginBlockEnd: '0.5rem' } },
         _.map((policyDescription) => {
           return li({}, [
             policyDescription.shortDescription,


### PR DESCRIPTION
This is the first half of WOR-1348: https://broadworkbench.atlassian.net/browse/WOR-1348

Screenshots:

No policies on the workspace being cloned:
![image](https://github.com/DataBiosphere/terra-ui/assets/484484/0dd22485-b3da-4301-bcee-d7a97b1385a1)

Cloning a GCP workspace with an auth domain:
![image](https://github.com/DataBiosphere/terra-ui/assets/484484/ca69d14f-3e04-400b-adc2-1d2348813bbf)

Cloning an azure workspace with a region constraint:
![image](https://github.com/DataBiosphere/terra-ui/assets/484484/c86cb3e6-1953-4515-b118-e2b6e5a724dc)
