### PR TITLE
[WM-2333] Fix call caching support link in Azure

### DIFF
--- a/src/workflows-app/SubmissionConfig.js
+++ b/src/workflows-app/SubmissionConfig.js
@@ -349,7 +349,7 @@ export const BaseSubmissionConfig = (
           div({ style: { display: 'inline-block', marginRight: '1rem' } }, [
             h(InfoBox, [
               "Call caching detects when a job has been run in the past so that it doesn't have to re-compute results. ",
-              h(Link, { href: getSupportLink('360047664872'), ...Utils.newTabLinkProps }, ['Click here to learn more.']),
+              h(Link, { href: getSupportLink('19619225467163'), ...Utils.newTabLinkProps }, ['Click here to learn more.']),
             ]),
           ]),
           div({ style: { display: 'inline-block' } }, [


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WM-2333

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Tooltip link points to https://support.terra.bio/hc/en-us/articles/19619225467163 in Azure workspaces instead of https://support.terra.bio/hc/en-us/articles/360047664872

### Why
- Azure users should be directed to the appropriate support link for their use case

### Testing strategy
- Validated locally <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 
