### PR TITLE
[WOR-1348] Update language around "protected data" for GCP workspaces.

### DIFF
--- a/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.test.ts
+++ b/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.test.ts
@@ -87,117 +87,116 @@ describe('NewWorkspaceModal', () => {
     return availableBillingProjectOptions.map((opt) => opt.split('.svg')[1]);
   };
 
-  const additionalSecurityMonitoring = 'Enable additional security monitoring';
-  const clonePolicyLabel = 'The cloned workspace will inherit:';
-
-  it('shows a message if there are no billing projects to use for creation', async () => {
-    // Arrange
-    asMockedFn(Ajax).mockImplementation(
-      () =>
-        ({
-          Billing: {
-            listProjects: async () => [],
-          },
-          ...nonBillingAjax,
-        } as AjaxContract)
-    );
-
-    // Act
-    await act(async () => {
-      render(
-        h(NewWorkspaceModal, {
-          onSuccess: () => {},
-          onDismiss: () => {},
-        })
+  describe('handles when no appropriate billing projects are available', () => {
+    it('shows a message if there are no billing projects to use for creation', async () => {
+      // Arrange
+      asMockedFn(Ajax).mockImplementation(
+        () =>
+          ({
+            Billing: {
+              listProjects: async () => [],
+            },
+            ...nonBillingAjax,
+          } as AjaxContract)
       );
+
+      // Act
+      await act(async () => {
+        render(
+          h(NewWorkspaceModal, {
+            onSuccess: () => {},
+            onDismiss: () => {},
+          })
+        );
+      });
+
+      // Assert
+      screen.getByText('You need a billing project to create a new workspace.');
     });
 
-    // Assert
-    screen.getByText('You need a billing project to create a new workspace.');
-  });
-
-  it('shows a message if there are no protected billing projects to use for creating a workspace with additional security monitoring ', async () => {
-    // Arrange
-    asMockedFn(Ajax).mockImplementation(
-      () =>
-        ({
-          Billing: {
-            listProjects: async () => [azureBillingProject],
-          },
-          ...nonBillingAjax,
-        } as AjaxContract)
-    );
-
-    // Act
-    await act(async () => {
-      render(
-        h(NewWorkspaceModal, {
-          requireEnhancedBucketLogging: true,
-          onSuccess: () => {},
-          onDismiss: () => {},
-        })
+    it('shows a message if there are no protected billing projects to use for creating a workspace with additional security monitoring ', async () => {
+      // Arrange
+      asMockedFn(Ajax).mockImplementation(
+        () =>
+          ({
+            Billing: {
+              listProjects: async () => [azureBillingProject],
+            },
+            ...nonBillingAjax,
+          } as AjaxContract)
       );
+
+      // Act
+      await act(async () => {
+        render(
+          h(NewWorkspaceModal, {
+            requireEnhancedBucketLogging: true,
+            onSuccess: () => {},
+            onDismiss: () => {},
+          })
+        );
+      });
+
+      // Assert
+      screen.getByText('You do not have access to a billing project that supports additional security monitoring.');
     });
 
-    // Assert
-    screen.getByText('You do not have access to a billing project that supports additional security monitoring.');
-  });
-
-  it('shows a message if there are no billing projects to use for cloning', async () => {
-    // Arrange
-    asMockedFn(Ajax).mockImplementation(
-      () =>
-        ({
-          Billing: {
-            listProjects: async () => [],
-          },
-          ...nonBillingAjax,
-        } as AjaxContract)
-    );
-
-    // Act
-    await act(async () => {
-      render(
-        h(NewWorkspaceModal, {
-          cloneWorkspace: defaultAzureWorkspace,
-          onSuccess: () => {},
-          onDismiss: () => {},
-        })
+    it('shows a message if there are no billing projects to use for cloning', async () => {
+      // Arrange
+      asMockedFn(Ajax).mockImplementation(
+        () =>
+          ({
+            Billing: {
+              listProjects: async () => [],
+            },
+            ...nonBillingAjax,
+          } as AjaxContract)
       );
+
+      // Act
+      await act(async () => {
+        render(
+          h(NewWorkspaceModal, {
+            cloneWorkspace: defaultAzureWorkspace,
+            onSuccess: () => {},
+            onDismiss: () => {},
+          })
+        );
+      });
+
+      // Assert
+      screen.getByText('You do not have a billing project that is able to clone this workspace.');
     });
 
-    // Assert
-    screen.getByText('You do not have a billing project that is able to clone this workspace.');
-  });
-
-  it('redirects to billing if there are no suitable billing projects', async () => {
-    // Arrange
-    const user = userEvent.setup();
-    asMockedFn(Ajax).mockImplementation(
-      () =>
-        ({
-          Billing: {
-            listProjects: async () => [],
-          },
-          ...nonBillingAjax,
-        } as AjaxContract)
-    );
-
-    // Arrange
-    await act(async () => {
-      render(
-        h(NewWorkspaceModal, {
-          cloneWorkspace: defaultAzureWorkspace,
-          onSuccess: () => {},
-          onDismiss: () => {},
-        })
+    it('redirects to billing if there are no suitable billing projects', async () => {
+      // Arrange
+      const user = userEvent.setup();
+      asMockedFn(Ajax).mockImplementation(
+        () =>
+          ({
+            Billing: {
+              listProjects: async () => [],
+            },
+            ...nonBillingAjax,
+          } as AjaxContract)
       );
-    });
-    const goToBilling = screen.getByText('Go to Billing');
-    await user.click(goToBilling);
 
-    // Assert
-    await waitFor(() => expect(goToPath).toBeCalledWith('billing'));
+      // Arrange
+      await act(async () => {
+        render(
+          h(NewWorkspaceModal, {
+            cloneWorkspace: defaultAzureWorkspace,
+            onSuccess: () => {},
+            onDismiss: () => {},
+          })
+        );
+      });
+      const goToBilling = screen.getByText('Go to Billing');
+      await user.click(goToBilling);
+
+      // Assert
+      await waitFor(() => expect(goToPath).toBeCalledWith('billing'));
+    });
   });
 
   it('Shows all available billing projects by default', async () => {
@@ -234,54 +233,123 @@ describe('NewWorkspaceModal', () => {
     expect(screen.queryByText('Importing directly into new Azure workspaces is not currently supported.')).toBeNull();
   });
 
-  it('hides unprotected Azure billing projects when additional security monitoring is required', async () => {
-    // Arrange
-    const user = userEvent.setup();
+  describe('handles the requireEnhancedBucketLogging option', () => {
+    it('hides unprotected Azure billing projects when additional security monitoring is required', async () => {
+      // Arrange
+      const user = userEvent.setup();
 
-    asMockedFn(Ajax).mockImplementation(
-      () =>
-        ({
-          Billing: {
-            listProjects: async () => [gcpBillingProject, azureBillingProject, azureProtectedDataBillingProject],
-          },
-          ...nonBillingAjax,
-        } as AjaxContract)
-    );
-
-    await act(async () => {
-      render(
-        h(NewWorkspaceModal, {
-          onSuccess: () => {},
-          onDismiss: () => {},
-          requireEnhancedBucketLogging: true,
-        })
+      asMockedFn(Ajax).mockImplementation(
+        () =>
+          ({
+            Billing: {
+              listProjects: async () => [gcpBillingProject, azureBillingProject, azureProtectedDataBillingProject],
+            },
+            ...nonBillingAjax,
+          } as AjaxContract)
       );
+
+      await act(async () => {
+        render(
+          h(NewWorkspaceModal, {
+            onSuccess: () => {},
+            onDismiss: () => {},
+            requireEnhancedBucketLogging: true,
+          })
+        );
+      });
+
+      // Assert
+      expect(await getAvailableBillingProjects(user)).toEqual([
+        'Google Billing Project',
+        'Protected Azure Billing Project',
+      ]);
     });
 
-    // Assert
-    expect(await getAvailableBillingProjects(user)).toEqual([
-      'Google Billing Project',
-      'Protected Azure Billing Project',
-    ]);
-  });
+    it.each([
+      {
+        cloudPlatform: 'AZURE',
+        expectedBillingProjects: ['Azure Billing Project', 'Protected Azure Billing Project'],
+        requireEnhancedBucketLogging: false,
+      },
+      {
+        cloudPlatform: 'AZURE',
+        expectedBillingProjects: ['Protected Azure Billing Project'],
+        requireEnhancedBucketLogging: true,
+      },
+      {
+        cloudPlatform: 'GCP',
+        expectedBillingProjects: ['Google Billing Project'],
+        requireEnhancedBucketLogging: false,
+      },
+      { cloudPlatform: 'GCP', expectedBillingProjects: ['Google Billing Project'], requireEnhancedBucketLogging: true },
+    ] as { cloudPlatform: CloudPlatform; expectedBillingProjects: string[]; requireEnhancedBucketLogging: boolean }[])(
+      'can limit billing projects to $cloudPlatform with requireEnhancedBucketLogging=$requireEnhancedBucketLogging',
+      async ({ cloudPlatform, expectedBillingProjects, requireEnhancedBucketLogging }) => {
+        // Arrange
+        const user = userEvent.setup();
 
-  it.each([
-    {
-      cloudPlatform: 'AZURE',
-      expectedBillingProjects: ['Azure Billing Project', 'Protected Azure Billing Project'],
-      requireEnhancedBucketLogging: false,
-    },
-    {
-      cloudPlatform: 'AZURE',
-      expectedBillingProjects: ['Protected Azure Billing Project'],
-      requireEnhancedBucketLogging: true,
-    },
-    { cloudPlatform: 'GCP', expectedBillingProjects: ['Google Billing Project'], requireEnhancedBucketLogging: false },
-    { cloudPlatform: 'GCP', expectedBillingProjects: ['Google Billing Project'], requireEnhancedBucketLogging: true },
-  ] as { cloudPlatform: CloudPlatform; expectedBillingProjects: string[]; requireEnhancedBucketLogging: boolean }[])(
-    'can limit billing projects to $cloudPlatform with requireEnhancedBucketLogging=$requireEnhancedBucketLogging',
-    async ({ cloudPlatform, expectedBillingProjects, requireEnhancedBucketLogging }) => {
-      // Arrange
+        asMockedFn(Ajax).mockImplementation(
+          () =>
+            ({
+              Billing: {
+                listProjects: async () => [gcpBillingProject, azureBillingProject, azureProtectedDataBillingProject],
+              },
+              ...nonBillingAjax,
+            } as AjaxContract)
+        );
+
+        // Act
+        await act(async () => {
+          render(
+            h(NewWorkspaceModal, {
+              cloudPlatform,
+              requireEnhancedBucketLogging,
+              onDismiss: () => {},
+              onSuccess: () => {},
+            })
+          );
+        });
+
+        // Assert
+        expect(await getAvailableBillingProjects(user)).toEqual(expectedBillingProjects);
+      }
+    );
+  });
+  describe('filters billing projects when cloning a workspace ', () => {
+    it('Hides Azure billing projects when cloning a GCP workspace', async () => {
+      const user = userEvent.setup();
+      const mockAjax: DeepPartial<AjaxContract> = {
+        Workspaces: {
+          workspace: () => ({
+            checkBucketLocation: jest.fn().mockResolvedValue({
+              location: 'US-CENTRAL1',
+              locationType: 'location-type',
+            }),
+          }),
+        },
+        Billing: {
+          listProjects: async () => [gcpBillingProject, azureBillingProject],
+        },
+        ...nonBillingAjax,
+      };
+      asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+
+      // Act
+      await act(async () => {
+        render(
+          h(NewWorkspaceModal, {
+            cloneWorkspace: defaultGoogleWorkspace,
+            onDismiss: () => {},
+            onSuccess: () => {},
+          })
+        );
+      });
+
+      // Assert
+      expect(await getAvailableBillingProjects(user)).toEqual(['Google Billing Project']);
+    });
+
+    it('Hides GCP billing projects when cloning an Azure workspace', async () => {
       const user = userEvent.setup();
 
       asMockedFn(Ajax).mockImplementation(
@@ -298,8 +366,7 @@ describe('NewWorkspaceModal', () => {
       await act(async () => {
         render(
           h(NewWorkspaceModal, {
-            cloudPlatform,
-            requireEnhancedBucketLogging,
+            cloneWorkspace: defaultAzureWorkspace,
             onDismiss: () => {},
             onSuccess: () => {},
           })
@@ -307,269 +374,216 @@ describe('NewWorkspaceModal', () => {
       });
 
       // Assert
-      expect(await getAvailableBillingProjects(user)).toEqual(expectedBillingProjects);
-    }
-  );
-
-  it('Hides Azure billing projects when cloning a GCP workspace', async () => {
-    const user = userEvent.setup();
-    const mockAjax: DeepPartial<AjaxContract> = {
-      Workspaces: {
-        workspace: () => ({
-          checkBucketLocation: jest.fn().mockResolvedValue({
-            location: 'US-CENTRAL1',
-            locationType: 'location-type',
-          }),
-        }),
-      },
-      Billing: {
-        listProjects: async () => [gcpBillingProject, azureBillingProject],
-      },
-      ...nonBillingAjax,
-    };
-    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
-
-    // Act
-    await act(async () => {
-      render(
-        h(NewWorkspaceModal, {
-          cloneWorkspace: defaultGoogleWorkspace,
-          onDismiss: () => {},
-          onSuccess: () => {},
-        })
-      );
+      expect(await getAvailableBillingProjects(user)).toEqual([
+        'Azure Billing Project',
+        'Protected Azure Billing Project',
+      ]);
     });
 
-    // Assert
-    expect(await getAvailableBillingProjects(user)).toEqual(['Google Billing Project']);
+    it('Hides billing projects that cannot be used for cloning a protected data Azure workspace', async () => {
+      const user = userEvent.setup();
+
+      asMockedFn(Ajax).mockImplementation(
+        () =>
+          ({
+            Billing: {
+              listProjects: async () => [gcpBillingProject, azureBillingProject, azureProtectedDataBillingProject],
+            },
+            ...nonBillingAjax,
+          } as AjaxContract)
+      );
+
+      // Act
+      await act(async () => {
+        render(
+          h(NewWorkspaceModal, {
+            cloneWorkspace: protectedAzureWorkspace,
+            onDismiss: () => {},
+            onSuccess: () => {},
+          })
+        );
+      });
+
+      // Assert
+      expect(await getAvailableBillingProjects(user)).toEqual(['Protected Azure Billing Project']);
+    });
   });
 
-  it('Hides GCP billing projects when cloning an Azure workspace', async () => {
-    const user = userEvent.setup();
+  describe('decides when to show a policy section ', () => {
+    const clonePolicyLabel = 'The cloned workspace will inherit:';
 
-    asMockedFn(Ajax).mockImplementation(
-      () =>
-        ({
-          Billing: {
-            listProjects: async () => [gcpBillingProject, azureBillingProject, azureProtectedDataBillingProject],
-          },
-          ...nonBillingAjax,
-        } as AjaxContract)
-    );
-
-    // Act
-    await act(async () => {
-      render(
-        h(NewWorkspaceModal, {
-          cloneWorkspace: defaultAzureWorkspace,
-          onDismiss: () => {},
-          onSuccess: () => {},
-        })
+    it('Shows a policy section when cloning an Azure workspace with polices', async () => {
+      asMockedFn(Ajax).mockImplementation(
+        () =>
+          ({
+            Billing: {
+              listProjects: async () => [azureProtectedDataBillingProject],
+            },
+            ...nonBillingAjax,
+          } as AjaxContract)
       );
+
+      // Act
+      await act(async () => {
+        render(
+          h(NewWorkspaceModal, {
+            cloneWorkspace: protectedAzureWorkspace,
+            onDismiss: () => {},
+            onSuccess: () => {},
+          })
+        );
+      });
+
+      // Assert
+      screen.getByText('Policies');
+      screen.getByText(clonePolicyLabel);
     });
 
-    // Assert
-    expect(await getAvailableBillingProjects(user)).toEqual([
-      'Azure Billing Project',
-      'Protected Azure Billing Project',
-    ]);
-  });
-
-  it('Hides billing projects that cannot be used for cloning a protected data Azure workspace', async () => {
-    const user = userEvent.setup();
-
-    asMockedFn(Ajax).mockImplementation(
-      () =>
-        ({
-          Billing: {
-            listProjects: async () => [gcpBillingProject, azureBillingProject, azureProtectedDataBillingProject],
-          },
-          ...nonBillingAjax,
-        } as AjaxContract)
-    );
-
-    // Act
-    await act(async () => {
-      render(
-        h(NewWorkspaceModal, {
-          cloneWorkspace: protectedAzureWorkspace,
-          onDismiss: () => {},
-          onSuccess: () => {},
-        })
+    it('Does not show a policy section when cloning an Azure workspace without polices', async () => {
+      asMockedFn(Ajax).mockImplementation(
+        () =>
+          ({
+            Billing: {
+              listProjects: async () => [azureBillingProject],
+            },
+            ...nonBillingAjax,
+          } as AjaxContract)
       );
+
+      // Act
+      await act(async () => {
+        render(
+          h(NewWorkspaceModal, {
+            cloneWorkspace: defaultAzureWorkspace,
+            onDismiss: () => {},
+            onSuccess: () => {},
+          })
+        );
+      });
+
+      // Assert
+      expect(screen.queryByText('Policies')).toBeNull();
+      expect(screen.queryByText(clonePolicyLabel)).toBeNull();
     });
 
-    // Assert
-    expect(await getAvailableBillingProjects(user)).toEqual(['Protected Azure Billing Project']);
-  });
-
-  it('Shows a policy section when cloning an Azure workspace with polices', async () => {
-    asMockedFn(Ajax).mockImplementation(
-      () =>
-        ({
-          Billing: {
-            listProjects: async () => [azureProtectedDataBillingProject],
-          },
-          ...nonBillingAjax,
-        } as AjaxContract)
-    );
-
-    // Act
-    await act(async () => {
-      render(
-        h(NewWorkspaceModal, {
-          cloneWorkspace: protectedAzureWorkspace,
-          onDismiss: () => {},
-          onSuccess: () => {},
-        })
-      );
-    });
-
-    // Assert
-    screen.getByText('Policies');
-    screen.getByText(clonePolicyLabel);
-  });
-
-  it('Does not show a policy section when cloning an Azure workspace without polices', async () => {
-    asMockedFn(Ajax).mockImplementation(
-      () =>
-        ({
-          Billing: {
-            listProjects: async () => [azureBillingProject],
-          },
-          ...nonBillingAjax,
-        } as AjaxContract)
-    );
-
-    // Act
-    await act(async () => {
-      render(
-        h(NewWorkspaceModal, {
-          cloneWorkspace: defaultAzureWorkspace,
-          onDismiss: () => {},
-          onSuccess: () => {},
-        })
-      );
-    });
-
-    // Assert
-    expect(screen.queryByText('Policies')).toBeNull();
-    expect(screen.queryByText(clonePolicyLabel)).toBeNull();
-  });
-
-  it('Does not show a policy section when cloning a protected GCP workspace', async () => {
-    // Arrange
-    const protectedWorkspace = { ...defaultGoogleWorkspace };
-    protectedWorkspace.workspace.bucketName = `fc-secure-${defaultGoogleWorkspace.workspace.bucketName}`;
-    asMockedFn(Ajax).mockImplementation(
-      () =>
-        ({
-          Workspaces: {
-            workspace: () => ({
-              checkBucketLocation: jest.fn().mockResolvedValue({
-                location: 'US-CENTRAL1',
-                locationType: 'location-type',
+    it('Does not show a policy section when cloning a protected GCP workspace', async () => {
+      // Arrange
+      const protectedWorkspace = { ...defaultGoogleWorkspace };
+      protectedWorkspace.workspace.bucketName = `fc-secure-${defaultGoogleWorkspace.workspace.bucketName}`;
+      asMockedFn(Ajax).mockImplementation(
+        () =>
+          ({
+            Workspaces: {
+              workspace: () => ({
+                checkBucketLocation: jest.fn().mockResolvedValue({
+                  location: 'US-CENTRAL1',
+                  locationType: 'location-type',
+                }),
               }),
-            }),
-          },
-          Billing: {
-            listProjects: async () => [gcpBillingProject],
-          },
-          ...nonBillingAjax,
-        } as AjaxContract)
-    );
-
-    // Act
-    await act(async () => {
-      render(
-        h(NewWorkspaceModal, {
-          cloneWorkspace: protectedWorkspace,
-          onDismiss: () => {},
-          onSuccess: () => {},
-        })
+            },
+            Billing: {
+              listProjects: async () => [gcpBillingProject],
+            },
+            ...nonBillingAjax,
+          } as AjaxContract)
       );
-    });
 
-    // Assert
-    expect(screen.queryByText('Policies')).toBeNull();
-    expect(screen.queryByText(clonePolicyLabel)).toBeNull();
+      // Act
+      await act(async () => {
+        render(
+          h(NewWorkspaceModal, {
+            cloneWorkspace: protectedWorkspace,
+            onDismiss: () => {},
+            onSuccess: () => {},
+          })
+        );
+      });
+
+      // Assert
+      expect(screen.queryByText('Policies')).toBeNull();
+      expect(screen.queryByText(clonePolicyLabel)).toBeNull();
+    });
   });
 
-  it('Hides azure billing projects if part of workflow import', async () => {
-    // Arrange
-    const user = userEvent.setup();
+  describe('respects the workflowImport option ', () => {
+    it('Hides azure billing projects if part of workflow import', async () => {
+      // Arrange
+      const user = userEvent.setup();
 
-    asMockedFn(Ajax).mockImplementation(
-      () =>
-        ({
-          Billing: {
-            listProjects: async () => [gcpBillingProject, azureBillingProject],
-          },
-          ...nonBillingAjax,
-        } as AjaxContract)
-    );
-
-    await act(async () => {
-      render(
-        h(NewWorkspaceModal, {
-          onSuccess: () => {},
-          onDismiss: () => {},
-          workflowImport: true,
-        })
+      asMockedFn(Ajax).mockImplementation(
+        () =>
+          ({
+            Billing: {
+              listProjects: async () => [gcpBillingProject, azureBillingProject],
+            },
+            ...nonBillingAjax,
+          } as AjaxContract)
       );
-    });
 
-    const projectSelector = screen.getByText('Select a billing project');
-    await user.click(projectSelector);
+      await act(async () => {
+        render(
+          h(NewWorkspaceModal, {
+            onSuccess: () => {},
+            onDismiss: () => {},
+            workflowImport: true,
+          })
+        );
+      });
 
-    // Assert
-    screen.getByText('Google Billing Project');
-    expect(screen.queryByText('Azure Billing Project')).toBeNull();
-    screen.getByText(
-      'Importing directly into new Azure workspaces is not currently supported. To create a new workspace with an Azure billing project, visit the main',
-      { exact: false }
-    );
-  });
+      const projectSelector = screen.getByText('Select a billing project');
+      await user.click(projectSelector);
 
-  it('Does not warn about no Azure support if no billing projects were hidden', async () => {
-    // Arrange
-    const user = userEvent.setup();
-
-    asMockedFn(Ajax).mockImplementation(
-      () =>
-        ({
-          Billing: {
-            listProjects: async () => [gcpBillingProject],
-          },
-          ...nonBillingAjax,
-        } as AjaxContract)
-    );
-
-    await act(async () => {
-      render(
-        h(NewWorkspaceModal, {
-          onSuccess: () => {},
-          onDismiss: () => {},
-          workflowImport: true,
-        })
-      );
-    });
-
-    const projectSelector = screen.getByText('Select a billing project');
-    await user.click(projectSelector);
-
-    // Assert
-    screen.getByText('Google Billing Project');
-    expect(screen.queryByText('Azure Billing Project')).toBeNull();
-    expect(
-      screen.queryByText(
+      // Assert
+      screen.getByText('Google Billing Project');
+      expect(screen.queryByText('Azure Billing Project')).toBeNull();
+      screen.getByText(
         'Importing directly into new Azure workspaces is not currently supported. To create a new workspace with an Azure billing project, visit the main',
         { exact: false }
-      )
-    ).toBeNull();
+      );
+    });
+
+    it('Does not warn about no Azure support if no billing projects were hidden', async () => {
+      // Arrange
+      const user = userEvent.setup();
+
+      asMockedFn(Ajax).mockImplementation(
+        () =>
+          ({
+            Billing: {
+              listProjects: async () => [gcpBillingProject],
+            },
+            ...nonBillingAjax,
+          } as AjaxContract)
+      );
+
+      await act(async () => {
+        render(
+          h(NewWorkspaceModal, {
+            onSuccess: () => {},
+            onDismiss: () => {},
+            workflowImport: true,
+          })
+        );
+      });
+
+      const projectSelector = screen.getByText('Select a billing project');
+      await user.click(projectSelector);
+
+      // Assert
+      screen.getByText('Google Billing Project');
+      expect(screen.queryByText('Azure Billing Project')).toBeNull();
+      expect(
+        screen.queryByText(
+          'Importing directly into new Azure workspaces is not currently supported. To create a new workspace with an Azure billing project, visit the main',
+          { exact: false }
+        )
+      ).toBeNull();
+    });
   });
 
   describe('handles Additional Security Monitoring for GCP billing projects/workspaces ', () => {
+    const additionalSecurityMonitoring = 'Enable additional security monitoring';
+
     it.each([{ selectCheckbox: true }, { selectCheckbox: false }] as { selectCheckbox: boolean }[])(
       'shows the checkbox if a Google billing project is selected, and correctly passes the value $selectCheckbox on create',
       async ({ selectCheckbox }) => {
@@ -671,7 +685,7 @@ describe('NewWorkspaceModal', () => {
       expect(screen.queryByText(additionalSecurityMonitoring)).toBeNull();
     });
 
-    it('does not let the user uncheck the option if it is passed in as required', async () => {
+    it('does not let the user uncheck the option if requireEnhancedBucketLogging is passed in as true', async () => {
       // Arrange
       const user = userEvent.setup();
 
@@ -979,24 +993,72 @@ describe('NewWorkspaceModal', () => {
     }
   );
 
-  it.each([
-    {
-      response: new Response('{"message":"Something went wrong."}', { status: 500 }),
-      format: 'JSON',
-      expectedMessage: 'Something went wrong.',
-    },
-    {
-      response: new Response('Something went wrong.', { status: 500 }),
-      format: 'text',
-      expectedMessage: 'Unknown error.',
-    },
-  ] as { response: Response; format: string; expectedMessage: string }[])(
-    'shows an error message if create workspace request returns a $format error response',
-    async ({ response, expectedMessage }) => {
+  describe('handles server errors responses from creating a workspace', () => {
+    it.each([
+      {
+        response: new Response('{"message":"Something went wrong."}', { status: 500 }),
+        format: 'JSON',
+        expectedMessage: 'Something went wrong.',
+      },
+      {
+        response: new Response('Something went wrong.', { status: 500 }),
+        format: 'text',
+        expectedMessage: 'Unknown error.',
+      },
+    ] as { response: Response; format: string; expectedMessage: string }[])(
+      'shows an error message if create workspace request returns a $format error response',
+      async ({ response, expectedMessage }) => {
+        // Arrange
+        const user = userEvent.setup();
+
+        const createWorkspace = jest.fn().mockRejectedValue(response);
+
+        asMockedFn(Ajax).mockImplementation(
+          () =>
+            ({
+              Billing: {
+                listProjects: async () => [azureBillingProject],
+              },
+              Workspaces: {
+                create: createWorkspace,
+              },
+              ...nonBillingAjax,
+            } as AjaxContract)
+        );
+
+        await act(async () => {
+          render(
+            h(NewWorkspaceModal, {
+              onSuccess: () => {},
+              onDismiss: () => {},
+            })
+          );
+        });
+
+        // Act
+        const workspaceNameInput = screen.getByLabelText('Workspace name *');
+        act(() => {
+          fireEvent.change(workspaceNameInput, { target: { value: 'Test workspace' } });
+        });
+
+        const projectSelect = new SelectHelper(screen.getByLabelText('Billing project *'), user);
+        await projectSelect.selectOption(/Azure Billing Project/);
+
+        const createWorkspaceButton = screen.getByRole('button', { name: 'Create Workspace' });
+        await user.click(createWorkspaceButton);
+
+        // Assert
+        screen.getByText(expectedMessage);
+      }
+    );
+
+    it('shows an error message if creating a workspace throws an error', async () => {
       // Arrange
       const user = userEvent.setup();
 
-      const createWorkspace = jest.fn().mockRejectedValue(response);
+      const createWorkspace = jest.fn().mockImplementation(() => {
+        throw new Error('Something went wrong.');
+      });
 
       asMockedFn(Ajax).mockImplementation(
         () =>
@@ -1033,285 +1095,241 @@ describe('NewWorkspaceModal', () => {
       await user.click(createWorkspaceButton);
 
       // Assert
-      screen.getByText(expectedMessage);
-    }
-  );
-
-  it('shows an error message if creating a workspace throws an error', async () => {
-    // Arrange
-    const user = userEvent.setup();
-
-    const createWorkspace = jest.fn().mockImplementation(() => {
-      throw new Error('Something went wrong.');
+      screen.getByText('Something went wrong.');
     });
-
-    asMockedFn(Ajax).mockImplementation(
-      () =>
-        ({
-          Billing: {
-            listProjects: async () => [azureBillingProject],
-          },
-          Workspaces: {
-            create: createWorkspace,
-          },
-          ...nonBillingAjax,
-        } as AjaxContract)
-    );
-
-    await act(async () => {
-      render(
-        h(NewWorkspaceModal, {
-          onSuccess: () => {},
-          onDismiss: () => {},
-        })
-      );
-    });
-
-    // Act
-    const workspaceNameInput = screen.getByLabelText('Workspace name *');
-    act(() => {
-      fireEvent.change(workspaceNameInput, { target: { value: 'Test workspace' } });
-    });
-
-    const projectSelect = new SelectHelper(screen.getByLabelText('Billing project *'), user);
-    await projectSelect.selectOption(/Azure Billing Project/);
-
-    const createWorkspaceButton = screen.getByRole('button', { name: 'Create Workspace' });
-    await user.click(createWorkspaceButton);
-
-    // Assert
-    screen.getByText('Something went wrong.');
   });
 
-  it(
-    'can wait for WDS to start for Azure workspaces',
-    withFakeTimers(async () => {
-      // Arrange
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+  describe('has logic for WDS starting', () => {
+    it(
+      'can wait for WDS to start for Azure workspaces',
+      withFakeTimers(async () => {
+        // Arrange
+        const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
-      // Create workspace endpoint response does not include cloudPlatform.
-      const newWorkspace: Omit<AzureWorkspaceInfo, 'cloudPlatform'> = {
-        namespace: azureBillingProject.projectName,
-        name: 'test-workspace',
-        workspaceId: 'aaaabbbb-cccc-dddd-0000-111122223333',
-        createdBy: 'user@example.com',
-        createdDate: '2023-11-13T18:39:32.267Z',
-        lastModified: '2023-11-13T18:39:32.267Z',
-        authorizationDomain: [],
-      };
-      const createWorkspace = jest.fn().mockResolvedValue(newWorkspace);
+        // Create workspace endpoint response does not include cloudPlatform.
+        const newWorkspace: Omit<AzureWorkspaceInfo, 'cloudPlatform'> = {
+          namespace: azureBillingProject.projectName,
+          name: 'test-workspace',
+          workspaceId: 'aaaabbbb-cccc-dddd-0000-111122223333',
+          createdBy: 'user@example.com',
+          createdDate: '2023-11-13T18:39:32.267Z',
+          lastModified: '2023-11-13T18:39:32.267Z',
+          authorizationDomain: [],
+        };
+        const createWorkspace = jest.fn().mockResolvedValue(newWorkspace);
 
-      const wdsApp: ListAppItem = {
-        workspaceId: 'aaaabbbb-cccc-dddd-0000-111122223333',
-        cloudContext: {
-          cloudProvider: 'AZURE',
-          cloudResource:
-            '0cb7a640-45a2-4ed6-be9f-63519f86e04b/ffd1069e-e34f-4d87-a8b8-44abfcba39af/mrg-terra-dev-previ-20230623095104',
-        },
-        kubernetesRuntimeConfig: {
-          numNodes: 1,
-          machineType: 'Standard_A2_v2',
-          autoscalingEnabled: false,
-        },
-        errors: [],
-        status: 'RUNNING',
-        proxyUrls: {
-          wds: 'https://lz34dd00bf3fdaa72f755eeea8f928bab7cd135043043d59d5.servicebus.windows.net/wds-aaaabbbb-cccc-dddd-0000-111122223333-aaaabbbb-cccc-dddd-0000-111122223333/',
-        },
-        appName: 'wds-aaaabbbb-cccc-dddd-0000-111122223333',
-        appType: 'WDS',
-        diskName: null,
-        auditInfo: {
-          creator: 'user@example.com',
-          createdDate: '2023-11-13T18:41:32.267Z',
-          destroyedDate: null,
-          dateAccessed: '2023-11-13T18:41:32.267Z',
-        },
-        accessScope: 'WORKSPACE_SHARED',
-        labels: {},
-        region: 'us-central1',
-      };
+        const wdsApp: ListAppItem = {
+          workspaceId: 'aaaabbbb-cccc-dddd-0000-111122223333',
+          cloudContext: {
+            cloudProvider: 'AZURE',
+            cloudResource:
+              '0cb7a640-45a2-4ed6-be9f-63519f86e04b/ffd1069e-e34f-4d87-a8b8-44abfcba39af/mrg-terra-dev-previ-20230623095104',
+          },
+          kubernetesRuntimeConfig: {
+            numNodes: 1,
+            machineType: 'Standard_A2_v2',
+            autoscalingEnabled: false,
+          },
+          errors: [],
+          status: 'RUNNING',
+          proxyUrls: {
+            wds: 'https://lz34dd00bf3fdaa72f755eeea8f928bab7cd135043043d59d5.servicebus.windows.net/wds-aaaabbbb-cccc-dddd-0000-111122223333-aaaabbbb-cccc-dddd-0000-111122223333/',
+          },
+          appName: 'wds-aaaabbbb-cccc-dddd-0000-111122223333',
+          appType: 'WDS',
+          diskName: null,
+          auditInfo: {
+            creator: 'user@example.com',
+            createdDate: '2023-11-13T18:41:32.267Z',
+            destroyedDate: null,
+            dateAccessed: '2023-11-13T18:41:32.267Z',
+          },
+          accessScope: 'WORKSPACE_SHARED',
+          labels: {},
+          region: 'us-central1',
+        };
 
-      const listAppsV2 = jest
-        .fn()
-        .mockResolvedValue([wdsApp])
-        .mockResolvedValueOnce([{ ...wdsApp, status: 'PROVISIONING', proxyUrls: {} }]);
+        const listAppsV2 = jest
+          .fn()
+          .mockResolvedValue([wdsApp])
+          .mockResolvedValueOnce([{ ...wdsApp, status: 'PROVISIONING', proxyUrls: {} }]);
 
-      const listInstances = jest
-        .fn()
-        .mockResolvedValue(['aaaabbbb-cccc-dddd-0000-111122223333'])
-        .mockResolvedValueOnce([]);
+        const listInstances = jest
+          .fn()
+          .mockResolvedValue(['aaaabbbb-cccc-dddd-0000-111122223333'])
+          .mockResolvedValueOnce([]);
 
-      asMockedFn(Ajax).mockImplementation(
-        () =>
-          ({
-            Apps: {
-              listAppsV2,
-            },
-            Billing: {
-              listProjects: async () => [azureBillingProject],
-            },
-            Workspaces: {
-              create: createWorkspace,
-            },
-            WorkspaceData: {
-              listInstances,
-            },
-            ...nonBillingAjax,
-          } as AjaxContract)
-      );
-
-      const onSuccess = jest.fn();
-
-      await act(async () => {
-        render(
-          h(NewWorkspaceModal, {
-            waitForServices: {
-              wds: true,
-            },
-            onSuccess,
-            onDismiss: () => {},
-          })
+        asMockedFn(Ajax).mockImplementation(
+          () =>
+            ({
+              Apps: {
+                listAppsV2,
+              },
+              Billing: {
+                listProjects: async () => [azureBillingProject],
+              },
+              Workspaces: {
+                create: createWorkspace,
+              },
+              WorkspaceData: {
+                listInstances,
+              },
+              ...nonBillingAjax,
+            } as AjaxContract)
         );
-      });
 
-      // Act
-      const workspaceNameInput = screen.getByLabelText('Workspace name *');
-      await user.type(workspaceNameInput, newWorkspace.name);
+        const onSuccess = jest.fn();
 
-      const projectSelect = new SelectHelper(screen.getByLabelText('Billing project *'), user);
-      await projectSelect.selectOption(/Azure Billing Project/);
+        await act(async () => {
+          render(
+            h(NewWorkspaceModal, {
+              waitForServices: {
+                wds: true,
+              },
+              onSuccess,
+              onDismiss: () => {},
+            })
+          );
+        });
 
-      const createWorkspaceButton = screen.getByRole('button', { name: 'Create Workspace' });
-      await user.click(createWorkspaceButton);
+        // Act
+        const workspaceNameInput = screen.getByLabelText('Workspace name *');
+        await user.type(workspaceNameInput, newWorkspace.name);
 
-      // Assert
-      expect(onSuccess).not.toHaveBeenCalled();
+        const projectSelect = new SelectHelper(screen.getByLabelText('Billing project *'), user);
+        await projectSelect.selectOption(/Azure Billing Project/);
 
-      // Act
-      await act(() => jest.advanceTimersByTime(30000));
+        const createWorkspaceButton = screen.getByRole('button', { name: 'Create Workspace' });
+        await user.click(createWorkspaceButton);
 
-      // Assert
-      expect(listAppsV2).toHaveBeenCalledTimes(1);
-      expect(onSuccess).not.toHaveBeenCalled();
+        // Assert
+        expect(onSuccess).not.toHaveBeenCalled();
 
-      // Act
-      await act(() => jest.advanceTimersByTime(15000));
+        // Act
+        await act(() => jest.advanceTimersByTime(30000));
 
-      // Assert
-      expect(listAppsV2).toHaveBeenCalledTimes(2);
-      expect(listInstances).toHaveBeenCalledTimes(1);
-      expect(onSuccess).not.toHaveBeenCalled();
+        // Assert
+        expect(listAppsV2).toHaveBeenCalledTimes(1);
+        expect(onSuccess).not.toHaveBeenCalled();
 
-      // Act
-      await act(() => jest.advanceTimersByTime(5000));
+        // Act
+        await act(() => jest.advanceTimersByTime(15000));
 
-      // Assert
-      expect(listAppsV2).toHaveBeenCalledTimes(2);
-      expect(listInstances).toHaveBeenCalledTimes(2);
+        // Assert
+        expect(listAppsV2).toHaveBeenCalledTimes(2);
+        expect(listInstances).toHaveBeenCalledTimes(1);
+        expect(onSuccess).not.toHaveBeenCalled();
 
-      expect(onSuccess).toHaveBeenCalled();
-    })
-  );
+        // Act
+        await act(() => jest.advanceTimersByTime(5000));
 
-  it(
-    'shows an error if WDS fails to start',
-    withFakeTimers(async () => {
-      // Arrange
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+        // Assert
+        expect(listAppsV2).toHaveBeenCalledTimes(2);
+        expect(listInstances).toHaveBeenCalledTimes(2);
 
-      // Create workspace endpoint response does not include cloudPlatform.
-      const newWorkspace: Omit<AzureWorkspaceInfo, 'cloudPlatform'> = {
-        namespace: azureBillingProject.projectName,
-        name: 'test-workspace',
-        workspaceId: 'aaaabbbb-cccc-dddd-0000-111122223333',
-        createdBy: 'user@example.com',
-        createdDate: '2023-11-13T18:39:32.267Z',
-        lastModified: '2023-11-13T18:39:32.267Z',
-        authorizationDomain: [],
-      };
-      const createWorkspace = jest.fn().mockResolvedValue(newWorkspace);
+        expect(onSuccess).toHaveBeenCalled();
+      })
+    );
 
-      const wdsApp: ListAppItem = {
-        workspaceId: 'aaaabbbb-cccc-dddd-0000-111122223333',
-        cloudContext: {
-          cloudProvider: 'AZURE',
-          cloudResource:
-            '0cb7a640-45a2-4ed6-be9f-63519f86e04b/ffd1069e-e34f-4d87-a8b8-44abfcba39af/mrg-terra-dev-previ-20230623095104',
-        },
-        kubernetesRuntimeConfig: {
-          numNodes: 1,
-          machineType: 'Standard_A2_v2',
-          autoscalingEnabled: false,
-        },
-        errors: [],
-        status: 'ERROR',
-        proxyUrls: {},
-        appName: 'wds-aaaabbbb-cccc-dddd-0000-111122223333',
-        appType: 'WDS',
-        diskName: null,
-        auditInfo: {
-          creator: 'user@example.com',
-          createdDate: '2023-11-13T18:41:32.267Z',
-          destroyedDate: null,
-          dateAccessed: '2023-11-13T18:41:32.267Z',
-        },
-        accessScope: 'WORKSPACE_SHARED',
-        labels: {},
-        region: 'us-central1',
-      };
+    it(
+      'shows an error if WDS fails to start',
+      withFakeTimers(async () => {
+        // Arrange
+        const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
-      const listAppsV2 = jest
-        .fn()
-        .mockResolvedValue([wdsApp])
-        .mockResolvedValueOnce([{ ...wdsApp, status: 'PROVISIONING', proxyUrls: {} }]);
+        // Create workspace endpoint response does not include cloudPlatform.
+        const newWorkspace: Omit<AzureWorkspaceInfo, 'cloudPlatform'> = {
+          namespace: azureBillingProject.projectName,
+          name: 'test-workspace',
+          workspaceId: 'aaaabbbb-cccc-dddd-0000-111122223333',
+          createdBy: 'user@example.com',
+          createdDate: '2023-11-13T18:39:32.267Z',
+          lastModified: '2023-11-13T18:39:32.267Z',
+          authorizationDomain: [],
+        };
+        const createWorkspace = jest.fn().mockResolvedValue(newWorkspace);
 
-      asMockedFn(Ajax).mockImplementation(
-        () =>
-          ({
-            Apps: {
-              listAppsV2,
-            },
-            Billing: {
-              listProjects: async () => [azureBillingProject],
-            },
-            Workspaces: {
-              create: createWorkspace,
-            },
-            ...nonBillingAjax,
-          } as AjaxContract)
-      );
+        const wdsApp: ListAppItem = {
+          workspaceId: 'aaaabbbb-cccc-dddd-0000-111122223333',
+          cloudContext: {
+            cloudProvider: 'AZURE',
+            cloudResource:
+              '0cb7a640-45a2-4ed6-be9f-63519f86e04b/ffd1069e-e34f-4d87-a8b8-44abfcba39af/mrg-terra-dev-previ-20230623095104',
+          },
+          kubernetesRuntimeConfig: {
+            numNodes: 1,
+            machineType: 'Standard_A2_v2',
+            autoscalingEnabled: false,
+          },
+          errors: [],
+          status: 'ERROR',
+          proxyUrls: {},
+          appName: 'wds-aaaabbbb-cccc-dddd-0000-111122223333',
+          appType: 'WDS',
+          diskName: null,
+          auditInfo: {
+            creator: 'user@example.com',
+            createdDate: '2023-11-13T18:41:32.267Z',
+            destroyedDate: null,
+            dateAccessed: '2023-11-13T18:41:32.267Z',
+          },
+          accessScope: 'WORKSPACE_SHARED',
+          labels: {},
+          region: 'us-central1',
+        };
 
-      await act(async () => {
-        render(
-          h(NewWorkspaceModal, {
-            waitForServices: {
-              wds: true,
-            },
-            onSuccess: () => {},
-            onDismiss: () => {},
-          })
+        const listAppsV2 = jest
+          .fn()
+          .mockResolvedValue([wdsApp])
+          .mockResolvedValueOnce([{ ...wdsApp, status: 'PROVISIONING', proxyUrls: {} }]);
+
+        asMockedFn(Ajax).mockImplementation(
+          () =>
+            ({
+              Apps: {
+                listAppsV2,
+              },
+              Billing: {
+                listProjects: async () => [azureBillingProject],
+              },
+              Workspaces: {
+                create: createWorkspace,
+              },
+              ...nonBillingAjax,
+            } as AjaxContract)
         );
-      });
 
-      // Act
-      const workspaceNameInput = screen.getByLabelText('Workspace name *');
-      await user.type(workspaceNameInput, newWorkspace.name);
+        await act(async () => {
+          render(
+            h(NewWorkspaceModal, {
+              waitForServices: {
+                wds: true,
+              },
+              onSuccess: () => {},
+              onDismiss: () => {},
+            })
+          );
+        });
 
-      const projectSelect = new SelectHelper(screen.getByLabelText('Billing project *'), user);
-      await projectSelect.selectOption(/Azure Billing Project/);
+        // Act
+        const workspaceNameInput = screen.getByLabelText('Workspace name *');
+        await user.type(workspaceNameInput, newWorkspace.name);
 
-      const createWorkspaceButton = screen.getByRole('button', { name: 'Create Workspace' });
-      await user.click(createWorkspaceButton);
+        const projectSelect = new SelectHelper(screen.getByLabelText('Billing project *'), user);
+        await projectSelect.selectOption(/Azure Billing Project/);
 
-      // Act
-      await act(() => jest.advanceTimersByTime(30000));
-      await act(() => jest.advanceTimersByTime(15000));
+        const createWorkspaceButton = screen.getByRole('button', { name: 'Create Workspace' });
+        await user.click(createWorkspaceButton);
 
-      // Assert
-      expect(listAppsV2).toHaveBeenCalledTimes(2);
+        // Act
+        await act(() => jest.advanceTimersByTime(30000));
+        await act(() => jest.advanceTimersByTime(15000));
 
-      screen.getByText('Failed to provision data services for new workspace.');
-    })
-  );
+        // Assert
+        expect(listAppsV2).toHaveBeenCalledTimes(2);
+
+        screen.getByText('Failed to provision data services for new workspace.');
+      })
+    );
+  });
 });

--- a/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.test.ts
+++ b/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.test.ts
@@ -411,7 +411,6 @@ describe('NewWorkspaceModal', () => {
 
   describe('decides when to show a policy section ', () => {
     const clonePolicyLabel = 'The cloned workspace will inherit:';
-
     it('Shows a policy section when cloning an Azure workspace with polices', async () => {
       asMockedFn(Ajax).mockImplementation(
         () =>
@@ -583,7 +582,6 @@ describe('NewWorkspaceModal', () => {
 
   describe('handles Additional Security Monitoring for GCP billing projects/workspaces ', () => {
     const additionalSecurityMonitoring = 'Enable additional security monitoring';
-
     it.each([{ selectCheckbox: true }, { selectCheckbox: false }] as { selectCheckbox: boolean }[])(
       'shows the checkbox if a Google billing project is selected, and correctly passes the value $selectCheckbox on create',
       async ({ selectCheckbox }) => {
@@ -640,6 +638,7 @@ describe('NewWorkspaceModal', () => {
         expect(createWorkspaceButton).not.toHaveAttribute('disabled');
         await user.click(createWorkspaceButton);
 
+        // Assert arguments sent to Ajax method for creating a workspace.
         expect(createWorkspace).toBeCalledWith({
           attributes: { description: '' },
           authorizationDomain: [],

--- a/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.ts
+++ b/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.ts
@@ -347,8 +347,15 @@ const NewWorkspaceModal = withDisplayName(
       return true;
     };
 
+    const cloningGcpProtectedWorkspace =
+      !!cloneWorkspace && isGoogleWorkspace(cloneWorkspace) && isProtectedWorkspace(cloneWorkspace);
+
     // Lifecycle
     useOnMount(() => {
+      // If cloning a GCP protected workspace, override whatever may have been passed via `requireEnhancedBucketLogging`
+      if (cloningGcpProtectedWorkspace) {
+        setEnhancedBucketLogging(true);
+      }
       loadData();
       loadAlphaRegionalityUser();
     });
@@ -560,9 +567,10 @@ const NewWorkspaceModal = withDisplayName(
                               h(
                                 LabeledCheckbox,
                                 {
-                                  style: { marginRight: '0.25rem' },
+                                  style: { margin: '0rem 0.25rem 0.25rem 0rem' },
                                   checked: enhancedBucketLogging,
-                                  disabled: !!requireEnhancedBucketLogging || groups.length > 0,
+                                  disabled:
+                                    !!requireEnhancedBucketLogging || groups.length > 0 || cloningGcpProtectedWorkspace,
                                   onChange: () => setEnhancedBucketLogging(!enhancedBucketLogging),
                                   'aria-describedby': id,
                                 },

--- a/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.ts
+++ b/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.ts
@@ -560,7 +560,7 @@ const NewWorkspaceModal = withDisplayName(
                               h(
                                 LabeledCheckbox,
                                 {
-                                  style: { margin: '0rem 0.25rem 0.25rem 0' },
+                                  style: { marginRight: '0.25rem' },
                                   checked: enhancedBucketLogging,
                                   disabled: !!requireEnhancedBucketLogging || groups.length > 0,
                                   onChange: () => setEnhancedBucketLogging(!enhancedBucketLogging),

--- a/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.ts
+++ b/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.ts
@@ -35,6 +35,7 @@ import {
   isAzureWorkspace,
   isGoogleWorkspace,
   isProtectedWorkspace,
+  protectedDataMessage,
   WorkspaceInfo,
   WorkspaceWrapper,
 } from 'src/libs/workspace-utils';
@@ -567,15 +568,13 @@ const NewWorkspaceModal = withDisplayName(
                                 },
                                 [
                                   label({ style: { ...Style.elements.sectionHeader } }, [
-                                    'Workspace will have protected data',
+                                    'Enable additional security monitoring',
                                   ]),
                                 ]
                               ),
                               h(InfoBox, { style: { marginLeft: '0.25rem', verticalAlign: 'middle' } }, [
-                                'If checked, Terra will log all data access requests to the workspace bucket. ' +
-                                  'This feature is automatically enabled when a workspace is created with Authorization Domains.',
+                                protectedDataMessage,
                               ]),
-                              p({ id, style: { marginTop: '.25rem' } }, ['Access to data will be logged by Terra']),
                             ]),
                         ]),
                       ]),
@@ -621,6 +620,7 @@ const NewWorkspaceModal = withDisplayName(
                           ]),
                       ]),
                     !!cloneWorkspace &&
+                      isAzureWorkspace(cloneWorkspace) &&
                       h(WorkspacePolicies, {
                         workspace: cloneWorkspace,
                         title: 'Policies',

--- a/src/workspaces/ShareWorkspaceModal/ShareWorkspaceModal.test.ts
+++ b/src/workspaces/ShareWorkspaceModal/ShareWorkspaceModal.test.ts
@@ -45,9 +45,6 @@ describe('the share workspace modal', () => {
     },
   };
 
-  const defaultPolicyLabel = 'This workspace has the following policy:';
-  const gcpPolicyLabel = 'This workspace has the following:';
-
   const mockAjax = (
     acl: RawWorkspaceAcl,
     shareLog: string[],
@@ -208,6 +205,8 @@ describe('the share workspace modal', () => {
   });
 
   describe('the policy section for sharing workspaces', () => {
+    const defaultPolicyLabel = 'This workspace has the following policy:';
+    const gcpPolicyLabel = 'This workspace has the following:';
     it('shows a policy section for Azure workspaces that have them', async () => {
       mockAjax({}, [], [], jest.fn());
       await act(async () => {

--- a/src/workspaces/ShareWorkspaceModal/ShareWorkspaceModal.test.ts
+++ b/src/workspaces/ShareWorkspaceModal/ShareWorkspaceModal.test.ts
@@ -45,7 +45,8 @@ describe('the share workspace modal', () => {
     },
   };
 
-  const policyLabel = 'This workspace has the following:';
+  const defaultPolicyLabel = 'This workspace has the following policy:';
+  const gcpPolicyLabel = 'This workspace has the following:';
 
   const mockAjax = (
     acl: RawWorkspaceAcl,
@@ -218,7 +219,7 @@ describe('the share workspace modal', () => {
         );
       });
       screen.getByText('Policies');
-      screen.getByText(policyLabel);
+      screen.getByText(defaultPolicyLabel);
     });
 
     it('shows a policy section without the Policies title for GCP workspaces that have them', async () => {
@@ -227,16 +228,15 @@ describe('the share workspace modal', () => {
       protectedWorkspace.workspace.bucketName = `fc-secure-${defaultGoogleWorkspace.workspace.bucketName}`;
       await act(async () => {
         render(
-            h(ShareWorkspaceModal, {
-              onDismiss: jest.fn(),
-              workspace: protectedWorkspace,
-            })
+          h(ShareWorkspaceModal, {
+            onDismiss: jest.fn(),
+            workspace: protectedWorkspace,
+          })
         );
       });
       expect(screen.queryByText('Policies')).toBeNull();
-      screen.getByText(policyLabel);
+      screen.getByText(gcpPolicyLabel);
     });
-
 
     it('does not show a policy section for Azure workspaces without them', async () => {
       mockAjax({}, [], [], jest.fn());
@@ -250,7 +250,7 @@ describe('the share workspace modal', () => {
       });
       expect(defaultAzureWorkspace.policies).toEqual([]);
       expect(screen.queryByText('Policies')).toBeNull();
-      expect(screen.queryByText(policyLabel)).toBeNull();
+      expect(screen.queryByText(defaultPolicyLabel)).toBeNull();
     });
   });
 });

--- a/src/workspaces/ShareWorkspaceModal/ShareWorkspaceModal.ts
+++ b/src/workspaces/ShareWorkspaceModal/ShareWorkspaceModal.ts
@@ -14,7 +14,7 @@ import Events, { extractWorkspaceDetails } from 'src/libs/events';
 import { FormLabel } from 'src/libs/forms';
 import { useCancellation, useOnMount } from 'src/libs/react-utils';
 import { append, cond, withBusyState } from 'src/libs/utils';
-import { WorkspaceWrapper } from 'src/libs/workspace-utils';
+import { isAzureWorkspace, isGoogleWorkspace, WorkspaceWrapper } from 'src/libs/workspace-utils';
 import {
   aclEntryIsTerraSupport,
   terraSupportAccessLevel,
@@ -190,6 +190,7 @@ const ShareWorkspaceModal: React.FC<ShareWorkspaceModalProps> = (props: ShareWor
       h(WorkspacePolicies, {
         workspace,
         title: isAzureWorkspace(workspace) ? 'Policies' : undefined,
+        policiesLabel: isGoogleWorkspace(workspace) ? 'This workspace has the following:' : undefined,
         style: { marginTop: '1.0rem', marginBottom: '1.5rem' },
       }),
       !loaded && centeredSpinner(),

--- a/src/workspaces/ShareWorkspaceModal/ShareWorkspaceModal.ts
+++ b/src/workspaces/ShareWorkspaceModal/ShareWorkspaceModal.ts
@@ -187,7 +187,11 @@ const ShareWorkspaceModal: React.FC<ShareWorkspaceModalProps> = (props: ShareWor
       ]),
       searchValueValid && !searchHasFocus && p([addUserReminder]),
       h(CurrentCollaborators, { acl, setAcl, originalAcl, lastAddedEmail, workspace }),
-      h(WorkspacePolicies, { workspace, title: 'Policies', style: { marginBottom: '1.5rem' } }),
+      h(WorkspacePolicies, {
+        workspace,
+        title: isAzureWorkspace(workspace) ? 'Policies' : undefined,
+        style: { marginTop: '1.0rem', marginBottom: '1.5rem' },
+      }),
       !loaded && centeredSpinner(),
       updateError && div({ style: { marginTop: '1rem' } }, [div(['An error occurred:']), updateError]),
       div({ style: { ...modalStyles.buttonRow, justifyContent: 'space-between' } }, [

--- a/src/workspaces/WorkspacePolicies/WorkspacePolicies.ts
+++ b/src/workspaces/WorkspacePolicies/WorkspacePolicies.ts
@@ -1,6 +1,5 @@
 import { InfoBox } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
-import pluralize from 'pluralize';
 import { CSSProperties, ReactNode } from 'react';
 import { div, h, li, ul } from 'react-hyperscript-helpers';
 import * as Style from 'src/libs/style';
@@ -15,9 +14,7 @@ type WorkspacePoliciesProps = {
 
 export const WorkspacePolicies = (props: WorkspacePoliciesProps): ReactNode => {
   const policyDescriptions = getPolicyDescriptions(props.workspace);
-  const description = props.policiesLabel
-    ? props.policiesLabel
-    : `This workspace has the following ${pluralize('policy', policyDescriptions.length)}:`;
+  const description = props.policiesLabel ? props.policiesLabel : 'This workspace has the following:';
 
   if (policyDescriptions.length > 0) {
     return div({ style: props.style }, [

--- a/src/workspaces/WorkspacePolicies/WorkspacePolicies.ts
+++ b/src/workspaces/WorkspacePolicies/WorkspacePolicies.ts
@@ -1,5 +1,6 @@
 import { InfoBox } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
+import pluralize from 'pluralize';
 import { CSSProperties, ReactNode } from 'react';
 import { div, h, li, ul } from 'react-hyperscript-helpers';
 import * as Style from 'src/libs/style';
@@ -14,7 +15,9 @@ type WorkspacePoliciesProps = {
 
 export const WorkspacePolicies = (props: WorkspacePoliciesProps): ReactNode => {
   const policyDescriptions = getPolicyDescriptions(props.workspace);
-  const description = props.policiesLabel ? props.policiesLabel : 'This workspace has the following:';
+  const description = props.policiesLabel
+    ? props.policiesLabel
+    : `This workspace has the following ${pluralize('policy', policyDescriptions.length)}:`;
 
   if (policyDescriptions.length > 0) {
     return div({ style: props.style }, [


### PR DESCRIPTION
Changes requested by @bethsheets in response to work I did for https://broadworkbench.atlassian.net/browse/WOR-1348.

1. Before when cloning a GCP workspace with "protected data". Note the display of the Policy at the bottom, which it turns out that we don't want to show. Also the language around the "Workspace will have protected data" checkbox, and the fact that it wasn't enforced previously.

Before:
<img width="535" alt="image" src="https://github.com/DataBiosphere/terra-ui/assets/484484/900418e3-6f11-4c29-b85f-5fb409ce708a">

After:
![image](https://github.com/DataBiosphere/terra-ui/assets/484484/8064f6c6-b2e3-41df-85d2-1468d84bcb17)

2. For the ShareWorkspace modal, don't show "Policy" language for GCP workspaces. 

Before (same for both GCP and Azure):
<img width="599" alt="image" src="https://github.com/DataBiosphere/terra-ui/assets/484484/89850cb0-640e-4e9d-97e1-e479d1ecb2fb">

After (GCP):
<img width="591" alt="image" src="https://github.com/DataBiosphere/terra-ui/assets/484484/5b931c7a-c822-4692-92b9-4c82a12e377a">

After (Azure):
![image](https://github.com/DataBiosphere/terra-ui/assets/484484/05970396-c8df-468a-8d0c-3ccb806c9a11)

