### PR TITLE
[UIE-150] Notify users when a new version of Terra UI is available

### DIFF
--- a/src/alerts/Alerts.ts
+++ b/src/alerts/Alerts.ts
@@ -13,6 +13,7 @@ import { useTermsOfServiceAlerts } from 'src/registration/terms-of-service/terms
 
 import { Alert as AlertType } from './Alert';
 import { useServiceAlerts } from './service-alerts';
+import { useVersionAlerts } from './version-alerts';
 
 interface AlertProps {
   alert: AlertType;
@@ -113,7 +114,12 @@ export const AlertsIndicator = (props: AlertsIndicatorProps): ReactNode => {
   const [open, setOpen] = useState(false);
   const [animating, setAnimating] = useState(false);
 
-  const alerts: AlertType[] = [...useServiceAlerts(), ...useLinkExpirationAlerts(), ...useTermsOfServiceAlerts()];
+  const alerts: AlertType[] = [
+    ...useVersionAlerts(),
+    ...useServiceAlerts(),
+    ...useLinkExpirationAlerts(),
+    ...useTermsOfServiceAlerts(),
+  ];
 
   const previousAlertIds = usePrevious(_.map('id', alerts)) || [];
   const hasNewAlerts = _.size(_.difference(_.map('id', alerts), previousAlertIds)) > 0;

--- a/src/alerts/version-alerts.test.ts
+++ b/src/alerts/version-alerts.test.ts
@@ -1,0 +1,58 @@
+import { asMockedFn } from '@terra-ui-packages/test-utils';
+import { renderHook } from '@testing-library/react';
+import { getConfig } from 'src/libs/config';
+
+import { getLatestVersion, latestVersionStore, useVersionAlerts } from './version-alerts';
+
+type ConfigExports = typeof import('src/libs/config');
+jest.mock('src/libs/config', (): ConfigExports => {
+  return {
+    ...jest.requireActual<ConfigExports>('src/libs/config'),
+    getConfig: jest.fn().mockReturnValue({ gitRevision: 'abcd123' }),
+  };
+});
+
+describe('getLatestVersion', () => {
+  it('fetches latest version from app build info', async () => {
+    // Arrange
+    const mockFetch = jest.spyOn(window, 'fetch').mockResolvedValue(new Response('{"gitRevision":"abcd123"}'));
+
+    // Act
+    const latestVersion = await getLatestVersion();
+
+    // Assert
+    expect(mockFetch).toHaveBeenCalledWith('/build-info.json');
+    expect(latestVersion).toBe('abcd123');
+  });
+});
+
+describe('useVersionAlerts', () => {
+  it('returns an empty list if current version and latest version match', () => {
+    // Arrange
+    asMockedFn(getConfig).mockReturnValue({ gitRevision: 'abcd123' });
+    latestVersionStore.set('abcd123');
+
+    // Act
+    const { result: hookReturnRef } = renderHook(() => useVersionAlerts());
+
+    // Assert
+    expect(hookReturnRef.current).toEqual([]);
+  });
+
+  it('returns an alert if current version and latest version do not match', () => {
+    // Arrange
+    asMockedFn(getConfig).mockReturnValue({ gitRevision: 'abcd123' });
+    latestVersionStore.set('1234567');
+
+    // Act
+    const { result: hookReturnRef } = renderHook(() => useVersionAlerts());
+
+    // Assert
+    expect(hookReturnRef.current).toContainEqual(
+      expect.objectContaining({
+        id: 'update-available',
+        title: 'Update available',
+      })
+    );
+  });
+});

--- a/src/alerts/version-alerts.ts
+++ b/src/alerts/version-alerts.ts
@@ -1,0 +1,32 @@
+import { atom } from '@terra-ui-packages/core-utils';
+import { getConfig } from 'src/libs/config';
+import { useStore } from 'src/libs/react-utils';
+
+import { Alert } from './Alert';
+
+export const getLatestVersion = async (): Promise<string> => {
+  const buildInfo = await fetch('/build-info.json').then((response) => response.json());
+  return buildInfo.gitRevision;
+};
+
+export const latestVersionStore = atom<string>(getConfig().gitRevision);
+
+export const useLatestVersion = (): string => useStore(latestVersionStore);
+
+export const useVersionAlerts = (): Alert[] => {
+  const latestVersion = useLatestVersion();
+  const currentVersion = getConfig().gitRevision;
+
+  if (currentVersion === latestVersion) {
+    return [];
+  }
+
+  return [
+    {
+      id: 'update-available',
+      title: 'Update available',
+      message: 'A new version of Terra is available. Refresh your browser to update.',
+      severity: 'info',
+    },
+  ];
+};

--- a/src/alerts/version-polling.test.ts
+++ b/src/alerts/version-polling.test.ts
@@ -1,0 +1,49 @@
+import { asMockedFn, withFakeTimers } from '@terra-ui-packages/test-utils';
+
+import { getLatestVersion, latestVersionStore } from './version-alerts';
+import { startPollingVersion, VERSION_POLLING_INTERVAL } from './version-polling';
+
+type VersionAlertsExports = typeof import('./version-alerts');
+jest.mock(
+  './version-alerts',
+  (): VersionAlertsExports => ({
+    ...jest.requireActual<VersionAlertsExports>('./version-alerts'),
+    getLatestVersion: jest.fn(),
+  })
+);
+
+const flushPromises = () => new Promise(jest.requireActual('timers').setImmediate);
+
+describe('startPollingVersion', () => {
+  it(
+    'periodically fetches latest version and updates store',
+    withFakeTimers(async () => {
+      // Arrange
+      asMockedFn(getLatestVersion).mockResolvedValue('abcd123');
+
+      // Act
+      const stopPolling = startPollingVersion();
+      jest.advanceTimersByTime(VERSION_POLLING_INTERVAL);
+      await flushPromises();
+
+      // Assert
+      expect(asMockedFn(getLatestVersion).mock.calls.length).toBe(1);
+      expect(latestVersionStore.get()).toBe('abcd123');
+
+      // Act
+      jest.advanceTimersByTime(VERSION_POLLING_INTERVAL);
+      await flushPromises();
+
+      // Assert
+      expect(asMockedFn(getLatestVersion).mock.calls.length).toBe(2);
+
+      // Act
+      stopPolling();
+      jest.advanceTimersByTime(VERSION_POLLING_INTERVAL);
+      await flushPromises();
+
+      // Assert
+      expect(asMockedFn(getLatestVersion).mock.calls.length).toBe(2);
+    })
+  );
+});

--- a/src/alerts/version-polling.ts
+++ b/src/alerts/version-polling.ts
@@ -1,0 +1,12 @@
+import _ from 'lodash/fp';
+
+import { getLatestVersion, latestVersionStore } from './version-alerts';
+
+export const VERSION_POLLING_INTERVAL = 15 * 60 * 1000; // 15 minutes
+
+export const startPollingVersion = (): (() => void) => {
+  const loadLatestVersion = () => getLatestVersion().then((version) => latestVersionStore.set(version), _.noop);
+
+  const interval = setInterval(loadLatestVersion, VERSION_POLLING_INTERVAL);
+  return () => clearInterval(interval);
+};

--- a/src/appLoader.js
+++ b/src/appLoader.js
@@ -6,6 +6,7 @@ import { createRoot } from 'react-dom/client';
 import { h } from 'react-hyperscript-helpers';
 import RModal from 'react-modal';
 import { startPollingServiceAlerts } from 'src/alerts/service-alerts-polling';
+import { startPollingVersion } from 'src/alerts/version-polling';
 import { initializeAuth } from 'src/auth/auth';
 import { initializeClientId } from 'src/auth/oidc-broker';
 import { initializeSystemProperties } from 'src/auth/system-loader';
@@ -31,6 +32,7 @@ initializeClientId().then(() => {
     initializeAuth();
     initializeTCell();
     startPollingServiceAlerts();
+    startPollingVersion();
   }, 0);
 
   if (isAxeEnabled()) {


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/UIE-150

From MixPanel, we're seeing that it takes several days for a version of Terra UI to phase out of use after a new version is published. We'd like to encourage users to proactively update to the latest version.

This polls build-info.json every 15 minutes to check if a new version is available. If so, it shows a notification in the service alerts panel asking the user to refresh their browser.

![Screenshot 2023-12-05 at 10 18 46 AM](https://github.com/DataBiosphere/terra-ui/assets/1156625/ae4fe796-3dc8-46cd-b871-4a3b00be5b31)

## Testing

Edit the `gitRevision` field in public/build-info.json and wait for the next poll.