### PR TITLE
AJ-1459: Display policies during import to existing workspace.

### DIFF
--- a/src/import-data/ImportDataDestination.test.ts
+++ b/src/import-data/ImportDataDestination.test.ts
@@ -391,7 +391,6 @@ describe('ImportDataDestination', () => {
       await user.click(existingWorkspaceButton);
 
       const workspaceSelect = new SelectHelper(screen.getByLabelText('Select a workspace'), user);
-      screen.debug();
 
       await workspaceSelect.selectOption(new RegExp('workspace-name'));
 

--- a/src/import-data/ImportDataDestination.test.ts
+++ b/src/import-data/ImportDataDestination.test.ts
@@ -114,8 +114,8 @@ describe('ImportDataDestination', () => {
       });
 
       // Act
-      const existingWorkspace = screen.getByText(selectExistingWorkspacePrompt, { exact: false });
-      await user.click(existingWorkspace); // select start with existing workspace
+      const existingWorkspaceButton = screen.getByText(selectExistingWorkspacePrompt, { exact: false });
+      await user.click(existingWorkspaceButton);
 
       // Assert
       const protectedDataWarning = screen.queryByText(
@@ -167,8 +167,8 @@ describe('ImportDataDestination', () => {
       ],
     });
     // Act
-    const existingWorkspace = screen.getByText(selectExistingWorkspacePrompt, { exact: false });
-    await user.click(existingWorkspace); // select start with existing workspace
+    const existingWorkspaceButton = screen.getByText(selectExistingWorkspacePrompt, { exact: false });
+    await user.click(existingWorkspaceButton);
 
     // Assert
     const selectWorkspace = screen.queryByText('Select a workspace', {
@@ -276,8 +276,8 @@ describe('ImportDataDestination', () => {
       });
 
       // Act
-      const existingWorkspace = screen.getByText(selectExistingWorkspacePrompt, { exact: false });
-      await user.click(existingWorkspace); // select start with existing workspace
+      const existingWorkspaceButton = screen.getByText(selectExistingWorkspacePrompt, { exact: false });
+      await user.click(existingWorkspaceButton);
 
       const workspaceSelect = new SelectHelper(screen.getByLabelText('Select a workspace'), user);
       const workspaces = await workspaceSelect.getOptions();
@@ -341,8 +341,8 @@ describe('ImportDataDestination', () => {
     });
 
     // Act
-    const existingWorkspace = screen.getByText(selectExistingWorkspacePrompt, { exact: false });
-    await user.click(existingWorkspace); // select start with existing workspace
+    const existingWorkspaceButton = screen.getByText(selectExistingWorkspacePrompt, { exact: false });
+    await user.click(existingWorkspaceButton);
 
     // Assert
     const notice = screen.queryByText(

--- a/src/import-data/ImportDataDestination.test.ts
+++ b/src/import-data/ImportDataDestination.test.ts
@@ -145,9 +145,7 @@ describe('ImportDataDestination', () => {
   }[])('should disable select an existing workspace option', async ({ importRequest, shouldSelectExisting }) => {
     // Arrange
     const user = userEvent.setup();
-    asMockedFn(canImportIntoWorkspace).mockImplementation((_importOptions: ImportOptions): boolean => {
-      return false;
-    });
+    asMockedFn(canImportIntoWorkspace).mockReturnValue(false);
 
     setup({
       props: {
@@ -424,11 +422,7 @@ describe('ImportDataDestination', () => {
       // Arrange
       const user = userEvent.setup();
 
-      asMockedFn(canImportIntoWorkspace).mockImplementation(
-        (_importOptions: ImportOptions, _workspace: WorkspaceWrapper): boolean => {
-          return true;
-        }
-      );
+      asMockedFn(canImportIntoWorkspace).mockReturnValue(true);
 
       setup({
         props: {

--- a/src/import-data/ImportDataDestination.test.ts
+++ b/src/import-data/ImportDataDestination.test.ts
@@ -371,11 +371,7 @@ describe('ImportDataDestination', () => {
       // Arrange
       const user = userEvent.setup();
 
-      asMockedFn(canImportIntoWorkspace).mockImplementation(
-        (_importOptions: ImportOptions, _workspace: WorkspaceWrapper): boolean => {
-          return true;
-        }
-      );
+      asMockedFn(canImportIntoWorkspace).mockReturnValue(true);
 
       setup({
         props: {

--- a/src/import-data/ImportDataDestination.test.ts
+++ b/src/import-data/ImportDataDestination.test.ts
@@ -450,7 +450,6 @@ describe('ImportDataDestination', () => {
 
       const workspaceSelect = new SelectHelper(screen.getByLabelText('Select a workspace'), user);
 
-      screen.debug();
       await workspaceSelect.selectOption(new RegExp('workspace-name'));
 
       // Assert

--- a/src/import-data/ImportDataDestination.ts
+++ b/src/import-data/ImportDataDestination.ts
@@ -1,7 +1,7 @@
 import { icon, IconId } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { AriaAttributes, CSSProperties, Fragment, ReactNode, useState } from 'react';
-import { div, h, h2, img, p, span } from 'react-hyperscript-helpers';
+import { div, h, h2, img, li, p, span, ul } from 'react-hyperscript-helpers';
 import Collapse from 'src/components/Collapse';
 import {
   ButtonPrimary,
@@ -19,6 +19,7 @@ import * as Utils from 'src/libs/utils';
 import { WorkspaceInfo } from 'src/libs/workspace-utils';
 import NewWorkspaceModal from 'src/workspaces/NewWorkspaceModal/NewWorkspaceModal';
 import { useWorkspaces } from 'src/workspaces/useWorkspaces';
+import { WorkspacePolicies } from 'src/workspaces/WorkspacePolicies/WorkspacePolicies';
 
 import { ImportRequest, TemplateWorkspaceInfo } from './import-types';
 import { canImportIntoWorkspace, getCloudPlatformRequiredForImport } from './import-utils';
@@ -219,6 +220,12 @@ export const ImportDataDestination = (props: ImportDataDestinationProps): ReactN
           ]),
       ]),
       importMayTakeTime && div({ style: { marginTop: '0.5rem', lineHeight: '1.5' } }, [importMayTakeTimeMessage]),
+      !!selectedWorkspace &&
+        h(Fragment, [
+          h(WorkspacePolicies, { workspace: selectedWorkspace }),
+          !!isProtectedData &&
+            div({}, [p({}, ['Importing this data may add:']), ul({}, [li({}, ['Additional access controls'])])]),
+        ]),
       div({ style: { display: 'flex', alignItems: 'center', marginTop: '1rem' } }, [
         h(ButtonSecondary, { onClick: () => setMode(undefined), style: { marginLeft: 'auto' } }, ['Back']),
         h(

--- a/src/import-data/ImportDataDestination.ts
+++ b/src/import-data/ImportDataDestination.ts
@@ -224,7 +224,7 @@ export const ImportDataDestination = (props: ImportDataDestinationProps): ReactN
         h(Fragment, [
           h(WorkspacePolicies, { workspace: selectedWorkspace }),
           !!isProtectedData &&
-            div({}, [p({}, ['Importing this data may add:']), ul({}, [li({}, ['Additional access controls'])])]),
+            div([p(['Importing this data may add:']), ul([li(['Additional access controls'])])]),
         ]),
       div({ style: { display: 'flex', alignItems: 'center', marginTop: '1rem' } }, [
         h(ButtonSecondary, { onClick: () => setMode(undefined), style: { marginLeft: 'auto' } }, ['Back']),

--- a/src/import-data/ImportDataDestination.ts
+++ b/src/import-data/ImportDataDestination.ts
@@ -16,7 +16,7 @@ import jupyterLogo from 'src/images/jupyter-logo.svg';
 import colors from 'src/libs/colors';
 import * as Style from 'src/libs/style';
 import * as Utils from 'src/libs/utils';
-import { WorkspaceInfo } from 'src/libs/workspace-utils';
+import { isAzureWorkspace, WorkspaceInfo } from 'src/libs/workspace-utils';
 import NewWorkspaceModal from 'src/workspaces/NewWorkspaceModal/NewWorkspaceModal';
 import { useWorkspaces } from 'src/workspaces/useWorkspaces';
 import { WorkspacePolicies } from 'src/workspaces/WorkspacePolicies/WorkspacePolicies';
@@ -223,7 +223,9 @@ export const ImportDataDestination = (props: ImportDataDestinationProps): ReactN
       !!selectedWorkspace &&
         h(Fragment, [
           h(WorkspacePolicies, { workspace: selectedWorkspace }),
-          !!isProtectedData && div([p(['Importing this data may add:']), ul([li(['Additional access controls'])])]),
+          !!isProtectedData &&
+            isAzureWorkspace(selectedWorkspace) &&
+            div([p(['Importing this data may add:']), ul([li(['Additional access controls'])])]),
         ]),
       div({ style: { display: 'flex', alignItems: 'center', marginTop: '1rem' } }, [
         h(ButtonSecondary, { onClick: () => setMode(undefined), style: { marginLeft: 'auto' } }, ['Back']),

--- a/src/import-data/ImportDataDestination.ts
+++ b/src/import-data/ImportDataDestination.ts
@@ -223,8 +223,7 @@ export const ImportDataDestination = (props: ImportDataDestinationProps): ReactN
       !!selectedWorkspace &&
         h(Fragment, [
           h(WorkspacePolicies, { workspace: selectedWorkspace }),
-          !!isProtectedData &&
-            div([p(['Importing this data may add:']), ul([li(['Additional access controls'])])]),
+          !!isProtectedData && div([p(['Importing this data may add:']), ul([li(['Additional access controls'])])]),
         ]),
       div({ style: { display: 'flex', alignItems: 'center', marginTop: '1rem' } }, [
         h(ButtonSecondary, { onClick: () => setMode(undefined), style: { marginLeft: 'auto' } }, ['Back']),


### PR DESCRIPTION
Ticket: [AJ-1459](https://broadworkbench.atlassian.net/browse/AJ-1459)

1) When a customer imports data into an existing workspace that has policies, display details about those policies.
2) Additionally, if the data that is being imported is considered protected, display a notice indicating that it may affect the existing workspace by adding additional access controls.

To test locally:

Pre-requesites:
* Go to: http://localhost:3000/#feature-preview and enable "Azure PFB Import"
* Have an existing protected Azure workspace.
* Have an existing protected Azure workspace with policies attached.

To see the message about additional policies:
1. Go to: http://localhost:3000/#import-data?format=pfb&url=https://storage.googleapis.com/davidan/protected_group_constraint_snapshot.avro (this PFB is not recognized as protected data)
2. Click 'Select an existing workspace'
3. Select a protected Azure workspace with policies attached.

To see the message indicating additional access controls may be added:
1. Go to: http://localhost:3000/#import-data?format=pfb&url=https%3A%2F%2Fservice.anvil.gi.ucsc.edu%2Ffile.pfb (a PFB we will recognize as protected data)
2. Click 'Select an existing workspace'
3. Select a protected Azure workspace.

Screenshots of various UI state:

* Import non-protected data into a non-protected workspace (without policies) - _this also matches the UI before these changes_:
![image](https://github.com/DataBiosphere/terra-ui/assets/111856/1afe1cac-5043-46e3-9660-9f1fda86cf47)

* Import non-protected data into a protected workspace (with policies):
![image](https://github.com/DataBiosphere/terra-ui/assets/111856/4b885bee-3759-4064-a990-9f7b45b60b02)
After https://github.com/DataBiosphere/terra-ui/pull/4537: 
![image](https://github.com/DataBiosphere/terra-ui/assets/111856/c355ee3c-dd5a-4de8-8848-7f3d6bc318bc)

* Import protected data into a protected workspace (with policies):
![image](https://github.com/DataBiosphere/terra-ui/assets/111856/f59109bd-42ff-44e6-88ca-ad5ea9b43688)
After https://github.com/DataBiosphere/terra-ui/pull/4537: ![image](https://github.com/DataBiosphere/terra-ui/assets/111856/1ca7d873-2651-49a3-9d01-ccbb9762c953)

* Note, there's no screenshot for importing protected data into a non-protected workspace, as that is disallowed.


[AJ-1459]: https://broadworkbench.atlassian.net/browse/AJ-1459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ