### PR TITLE
[PROD-908] Fix resetting global stores on sign out

### DIFF
--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -657,7 +657,9 @@ authStore.subscribe(
 );
 
 authStore.subscribe((state: AuthState, oldState: AuthState) => {
-  if (oldState.signInStatus === 'userLoaded' && state.signInStatus !== 'userLoaded') {
+  const isSignedOut = state.signInStatus === 'signedOut';
+  const wasSignedIn = oldState.signInStatus !== 'signedOut';
+  if (wasSignedIn && isSignedOut) {
     workspaceStore.reset();
     workspacesStore.reset();
     asyncImportJobStore.reset();


### PR DESCRIPTION
We want to clear/reset several global stores when the user signs out.

#4510 split the previous "signedIn" and "signedOut" status into a more granular "authenticated", "unregistered", "userLoaded", and "signedOut".

https://github.com/DataBiosphere/terra-ui/pull/4510/files#diff-90ba26c0d3fa06b78a8d7c255207bd90f39592ba9140fc89d7430355cad7b503L78-R92

However, with that, it also broke this reset functionality.

https://github.com/DataBiosphere/terra-ui/pull/4510/files#diff-26c98c2ffc5924a448f8384c10793435c826bb2783eff1d4f866784c95575be5L648-R646

The new "userLoaded" status is not equivalent to the old "signedIn" status. When the user's auth token is reloaded (as it is about every hour), the auth store cycles through the "authenticated" status before settling in "userLoaded". This causes all of these stores to be reset.

To users looking a workspace, this manifests as the workspace UI "randomly" going blank.

![Screenshot 2023-12-05 at 1 30 13 PM](https://github.com/DataBiosphere/terra-ui/assets/1156625/c9001cc1-25d1-4203-8dd7-cd0750ed0133)

## Testing

To reproduce this, edit src/auth/auth to make `loadAuthToken` available as a global variable.
```ts
// @ts-expect-error
window.loadAuthToken = loadAuthToken;
```

Then navigate to a workspace and call `loadAuthToken` from the console.