### PR TITLE
[UIE-151] Allow forcing UI updates (part 1)

### DIFF
--- a/src/alerts/version-alerts.test.ts
+++ b/src/alerts/version-alerts.test.ts
@@ -2,42 +2,22 @@ import { DeepPartial } from '@terra-ui-packages/core-utils';
 import { asMockedFn } from '@terra-ui-packages/test-utils';
 import { renderHook } from '@testing-library/react';
 import { Ajax } from 'src/libs/ajax';
-import { getConfig } from 'src/libs/config';
 
-import { getBadVersions, getLatestVersion, latestVersionStore, useVersionAlerts } from './version-alerts';
+import { getBadVersions, useVersionAlerts, versionStore } from './version-alerts';
 
 type AjaxExports = typeof import('src/libs/ajax');
 jest.mock('src/libs/ajax');
 
 type AjaxContract = ReturnType<AjaxExports['Ajax']>;
 
-type ConfigExports = typeof import('src/libs/config');
-jest.mock('src/libs/config', (): ConfigExports => {
-  return {
-    ...jest.requireActual<ConfigExports>('src/libs/config'),
-    getConfig: jest.fn().mockReturnValue({ gitRevision: 'abcd123' }),
-  };
-});
-
-describe('getLatestVersion', () => {
-  it('fetches latest version from app build info', async () => {
-    // Arrange
-    const mockFetch = jest.spyOn(window, 'fetch').mockResolvedValue(new Response('{"gitRevision":"abcd123"}'));
-
-    // Act
-    const latestVersion = await getLatestVersion();
-
-    // Assert
-    expect(mockFetch).toHaveBeenCalledWith('/build-info.json');
-    expect(latestVersion).toBe('abcd123');
-  });
-});
-
 describe('useVersionAlerts', () => {
   it('returns an empty list if current version and latest version match', () => {
     // Arrange
-    asMockedFn(getConfig).mockReturnValue({ gitRevision: 'abcd123' });
-    latestVersionStore.set('abcd123');
+    versionStore.set({
+      currentVersion: 'abcd123',
+      latestVersion: 'abcd123',
+      isUpdateRequired: false,
+    });
 
     // Act
     const { result: hookReturnRef } = renderHook(() => useVersionAlerts());
@@ -48,8 +28,11 @@ describe('useVersionAlerts', () => {
 
   it('returns an alert if current version and latest version do not match', () => {
     // Arrange
-    asMockedFn(getConfig).mockReturnValue({ gitRevision: 'abcd123' });
-    latestVersionStore.set('1234567');
+    versionStore.set({
+      currentVersion: 'abcd123',
+      latestVersion: '1234567',
+      isUpdateRequired: false,
+    });
 
     // Act
     const { result: hookReturnRef } = renderHook(() => useVersionAlerts());

--- a/src/alerts/version-alerts.test.ts
+++ b/src/alerts/version-alerts.test.ts
@@ -48,9 +48,15 @@ describe('useVersionAlerts', () => {
 });
 
 describe('getBadVersions', () => {
-  it('parses list of bad versions from firecloud-alerts bucket', async () => {
+  it.each([
+    { responseText: '# broken\nabcd123 \neeee456\n\n', expectedVersions: ['abcd123', 'eeee456'] },
+    { responseText: 'abcd123', expectedVersions: ['abcd123'] },
+  ] as {
+    responseText: string;
+    expectedVersions: string[];
+  }[])('parses list of bad versions from firecloud-alerts bucket', async ({ responseText, expectedVersions }) => {
     // Arrange
-    const ajaxGetBadVersions = jest.fn().mockResolvedValue('# broken\nabcd123 \neeee456\n\n');
+    const ajaxGetBadVersions = jest.fn().mockResolvedValue(responseText);
     asMockedFn(Ajax).mockReturnValue({
       FirecloudBucket: { getBadVersions: ajaxGetBadVersions },
     } as DeepPartial<AjaxContract> as AjaxContract);
@@ -60,7 +66,7 @@ describe('getBadVersions', () => {
 
     // Assert
     expect(ajaxGetBadVersions).toHaveBeenCalled();
-    expect(badVersions).toEqual(['abcd123', 'eeee456']);
+    expect(badVersions).toEqual(expectedVersions);
   });
 
   it('returns empty list if bad versions file does not exist', async () => {

--- a/src/alerts/version-alerts.test.ts
+++ b/src/alerts/version-alerts.test.ts
@@ -51,6 +51,8 @@ describe('getBadVersions', () => {
   it.each([
     { responseText: '# broken\nabcd123 \neeee456\n\n', expectedVersions: ['abcd123', 'eeee456'] },
     { responseText: 'abcd123', expectedVersions: ['abcd123'] },
+    { responseText: '', expectedVersions: [] },
+    { responseText: '\n  \n', expectedVersions: [] },
   ] as {
     responseText: string;
     expectedVersions: string[];

--- a/src/alerts/version-alerts.ts
+++ b/src/alerts/version-alerts.ts
@@ -1,4 +1,5 @@
 import { atom } from '@terra-ui-packages/core-utils';
+import { Ajax } from 'src/libs/ajax';
 import { getConfig } from 'src/libs/config';
 import { useStore } from 'src/libs/react-utils';
 
@@ -29,4 +30,20 @@ export const useVersionAlerts = (): Alert[] => {
       severity: 'info',
     },
   ];
+};
+
+export const getBadVersions = async (): Promise<string[]> => {
+  try {
+    const versionsText = await Ajax().FirecloudBucket.getBadVersions();
+    return versionsText
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => !!line)
+      .filter((line) => !line.startsWith('#'));
+  } catch (error: unknown) {
+    if (error instanceof Response && error.status === 404) {
+      return [];
+    }
+    throw error;
+  }
 };

--- a/src/alerts/version-alerts.ts
+++ b/src/alerts/version-alerts.ts
@@ -10,13 +10,20 @@ export const getLatestVersion = async (): Promise<string> => {
   return buildInfo.gitRevision;
 };
 
-export const latestVersionStore = atom<string>(getConfig().gitRevision);
+export interface VersionState {
+  currentVersion: string;
+  latestVersion: string;
+  isUpdateRequired: boolean;
+}
 
-export const useLatestVersion = (): string => useStore(latestVersionStore);
+export const versionStore = atom<VersionState>({
+  currentVersion: getConfig().gitRevision,
+  latestVersion: getConfig().gitRevision,
+  isUpdateRequired: false,
+});
 
 export const useVersionAlerts = (): Alert[] => {
-  const latestVersion = useLatestVersion();
-  const currentVersion = getConfig().gitRevision;
+  const { currentVersion, latestVersion } = useStore(versionStore);
 
   if (currentVersion === latestVersion) {
     return [];

--- a/src/alerts/version-polling.test.ts
+++ b/src/alerts/version-polling.test.ts
@@ -1,16 +1,103 @@
 import { asMockedFn, withFakeTimers } from '@terra-ui-packages/test-utils';
 
-import { getLatestVersion, latestVersionStore } from './version-alerts';
-import { startPollingVersion, VERSION_POLLING_INTERVAL } from './version-polling';
+import { getBadVersions, getLatestVersion, latestVersionStore } from './version-alerts';
+import { checkVersion, startPollingVersion, VERSION_POLLING_INTERVAL } from './version-polling';
+
+type ConfigExports = typeof import('src/libs/config');
+jest.mock('src/libs/config', (): ConfigExports => {
+  return {
+    ...jest.requireActual<ConfigExports>('src/libs/config'),
+    getConfig: jest.fn().mockReturnValue({ gitRevision: 'abcd123' }),
+  };
+});
 
 type VersionAlertsExports = typeof import('./version-alerts');
 jest.mock(
   './version-alerts',
   (): VersionAlertsExports => ({
     ...jest.requireActual<VersionAlertsExports>('./version-alerts'),
+    getBadVersions: jest.fn(),
     getLatestVersion: jest.fn(),
   })
 );
+
+describe('checkVersion', () => {
+  const originalLocation = window.location;
+
+  beforeAll(() => {
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: { reload: jest.fn() },
+    });
+  });
+
+  afterAll(() => {
+    window.location = originalLocation;
+  });
+
+  it('fetches latest version and updates store', async () => {
+    // Arrange
+    asMockedFn(getLatestVersion).mockResolvedValue('abcd123');
+
+    // Act
+    await checkVersion();
+
+    // Assert
+    expect(getLatestVersion).toHaveBeenCalled();
+    expect(latestVersionStore.get()).toBe('abcd123');
+  });
+
+  describe('if a new version is available', () => {
+    beforeEach(() => {
+      asMockedFn(getLatestVersion).mockResolvedValue('1234567');
+    });
+
+    it('checks if the current version is bad', async () => {
+      // Arrange
+      asMockedFn(getBadVersions).mockResolvedValue([]);
+
+      // Act
+      await checkVersion();
+
+      // Assert
+      expect(getBadVersions).toHaveBeenCalled();
+    });
+
+    it('reloads the page if current version is bad', async () => {
+      // Arrange
+      asMockedFn(getBadVersions).mockResolvedValue(['abcd123']);
+
+      // Act
+      await checkVersion();
+
+      // Assert
+      expect(window.location.reload).toHaveBeenCalled();
+    });
+
+    it('does not reload the page if current version is good', async () => {
+      // Arrange
+      asMockedFn(getBadVersions).mockResolvedValue([]);
+
+      // Act
+      await checkVersion();
+
+      // Assert
+      expect(window.location.reload).not.toHaveBeenCalled();
+    });
+  });
+
+  it('does not reload if the current version is bad but there is no new version available', async () => {
+    // Arrange
+    asMockedFn(getLatestVersion).mockResolvedValue('abcd123');
+    asMockedFn(getBadVersions).mockResolvedValue(['abcd123']);
+
+    // Act
+    await checkVersion();
+
+    // Assert
+    expect(window.location.reload).not.toHaveBeenCalled();
+  });
+});
 
 const flushPromises = () => new Promise(jest.requireActual('timers').setImmediate);
 

--- a/src/alerts/version-polling.ts
+++ b/src/alerts/version-polling.ts
@@ -1,20 +1,19 @@
-import { getConfig } from 'src/libs/config';
 import { withErrorIgnoring } from 'src/libs/error';
 
-import { getBadVersions, getLatestVersion, latestVersionStore } from './version-alerts';
+import { getBadVersions, getLatestVersion, versionStore } from './version-alerts';
 
 export const VERSION_POLLING_INTERVAL = 15 * 60 * 1000; // 15 minutes
 
 export const checkVersion = withErrorIgnoring(async (): Promise<void> => {
-  const currentVersion = getConfig().gitRevision;
+  const { currentVersion } = versionStore.get();
 
   const latestVersion = await getLatestVersion();
-  latestVersionStore.set(latestVersion);
+  versionStore.update((value) => ({ ...value, latestVersion }));
 
   if (latestVersion !== currentVersion) {
     const badVersions = await getBadVersions();
     if (badVersions.includes(currentVersion)) {
-      window.location.reload();
+      versionStore.update((value) => ({ ...value, isUpdateRequired: true }));
     }
   }
 });

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -603,6 +603,11 @@ const FirecloudBucket = (signal) => ({
     const res = await fetchOk(`${getConfig().firecloudBucketRoot}/template-workspaces.json`, { signal });
     return res.json();
   },
+
+  getBadVersions: async () => {
+    const res = await fetchOk(`${getConfig().firecloudBucketRoot}/bad-versions.txt`, { signal });
+    return res.text();
+  },
 });
 
 const Methods = (signal) => ({


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/UIE-151

A while back, we had an issue ([PROD-896](https://broadworkbench.atlassian.net/browse/PROD-896)) where a UI bug polled an API endpoint much more frequently than intended. We essentially denial of service attacked ourselves. We fixed the issue and pushed an update to Terra UI, but the buggy version was still running in users' browsers and we were dependent on users refreshing in order to update to the fixed version.

This builds on #4539, which notifies users when a new version is available, and adds an option to mark a version as "bad". Currently, Terra UI polls build-info.json to determine if a new version is available. With this change, if it finds that a new version is available, it will check if the currently running version is in a list of "bad versions" defined in a text file in the firecloud-alerts bucket. If the current version is "bad", we can use that to automatically refresh the browser.

## Testing

1. Reduce the `VERSION_POLLING_INTERVAL` in src/alerts/version-polling.ts. It's set to 15 minutes, which is too long for testing.
2. Start a local dev server with `yarn start`.
3. Open public/build-info.json in a text editor. Copy the value of `gitRevision`, which contains the current version of Terra UI.
4. Edit the value of `gitRevision` and save build-info.json. This imitates a new version being deployed. You should see a notification that a new version is available.
5. Mock bad-versions.txt to declare that the current version is "bad".
  ```js
  window.ajaxOverridesStore.set([
    {
      filter: { url: /bad-versions.txt/ },
      fn: () => () => Promise.resolve(new Response('<version from step 3>'))
    }
  ])
  ```

## To do

- [ ] Document how to use this in the Terra UI wiki.

[PROD-896]: https://broadworkbench.atlassian.net/browse/PROD-896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ