### PR TITLE
[WOR-1348] When creating a workspace from an Azure protected billing project, show the policy section

### DIFF
--- a/src/import-data/ImportDataDestination.ts
+++ b/src/import-data/ImportDataDestination.ts
@@ -222,7 +222,7 @@ export const ImportDataDestination = (props: ImportDataDestinationProps): ReactN
       importMayTakeTime && div({ style: { marginTop: '0.5rem', lineHeight: '1.5' } }, [importMayTakeTimeMessage]),
       !!selectedWorkspace &&
         h(Fragment, [
-          h(WorkspacePolicies, { workspace: selectedWorkspace }),
+          h(WorkspacePolicies, { workspaceOrBillingProject: selectedWorkspace }),
           !!isProtectedData &&
             isAzureWorkspace(selectedWorkspace) &&
             div([p(['Importing this data may add:']), ul([li(['Additional access controls'])])]),

--- a/src/import-data/ImportDataDestination.ts
+++ b/src/import-data/ImportDataDestination.ts
@@ -222,8 +222,8 @@ export const ImportDataDestination = (props: ImportDataDestinationProps): ReactN
       importMayTakeTime && div({ style: { marginTop: '0.5rem', lineHeight: '1.5' } }, [importMayTakeTimeMessage]),
       !!selectedWorkspace &&
         h(Fragment, [
-          h(WorkspacePolicies, { workspaceOrBillingProject: selectedWorkspace }),
-          !!isProtectedData &&
+          h(WorkspacePolicies, { policySource: selectedWorkspace }),
+          isProtectedData &&
             isAzureWorkspace(selectedWorkspace) &&
             div([p(['Importing this data may add:']), ul([li(['Additional access controls'])])]),
         ]),

--- a/src/libs/workspace-utils.ts
+++ b/src/libs/workspace-utils.ts
@@ -118,7 +118,7 @@ export const getPolicyDescriptions = (workspace: WorkspaceWrapper): PolicyDescri
   const policyDescriptions: PolicyDescription[] = [];
   if (isProtectedWorkspace(workspace)) {
     policyDescriptions.push({
-      shortDescription: 'Additional security monitoring',
+      shortDescription: protectedDataLabel,
       longDescription: protectedDataMessage,
     });
   }
@@ -127,7 +127,7 @@ export const getPolicyDescriptions = (workspace: WorkspaceWrapper): PolicyDescri
   }
   if (hasRegionConstraintPolicy(workspace)) {
     policyDescriptions.push({
-      shortDescription: 'Region constraint',
+      shortDescription: regionConstraintLabel,
       longDescription: regionConstraintMessage(workspace)!,
     });
   }
@@ -179,8 +179,10 @@ export const isProtectedWorkspace = (workspace: WorkspaceWrapper): boolean => {
 export const containsProtectedDataPolicy = (policies: WorkspacePolicy[] | undefined): boolean =>
   _.any((policy: WorkspacePolicy) => policy.namespace === 'terra' && policy.name === 'protected-data', policies);
 
+export const protectedDataLabel = 'Additional security monitoring';
 export const protectedDataMessage =
   'Enhanced logging and monitoring are enabled to support the use of controlled-access data in this workspace.';
+export const protectedDataIcon = 'shield';
 
 export const groupConstraintMessage =
   'Data Access Controls add additional permission restrictions to a workspace. These were added when you imported data from a controlled access source. All workspace collaborators must also be current users on an approved Data Access Request (DAR).';
@@ -205,6 +207,8 @@ export const getRegionConstraintLabels = (policies: WorkspacePolicy[] | undefine
   }, regionPolicies);
   return regionLabels;
 };
+
+export const regionConstraintLabel = 'Region constraint';
 
 export const regionConstraintMessage = (workspace: BaseWorkspace): string | undefined => {
   const regions = getRegionConstraintLabels(workspace.policies);

--- a/src/pages/workspaces/workspace/WorkspaceAttributeNotice.ts
+++ b/src/pages/workspaces/workspace/WorkspaceAttributeNotice.ts
@@ -3,7 +3,13 @@ import { div, h, span } from 'react-hyperscript-helpers';
 import { icon } from 'src/components/icons';
 import TooltipTrigger from 'src/components/TooltipTrigger';
 import colors from 'src/libs/colors';
-import { canWrite, WorkspaceAccessLevel } from 'src/libs/workspace-utils';
+import {
+  canWrite,
+  protectedDataIcon,
+  protectedDataLabel,
+  regionConstraintLabel,
+  WorkspaceAccessLevel,
+} from 'src/libs/workspace-utils';
 
 interface WorkspaceAttributeNoticeProperties {
   accessLevel: WorkspaceAccessLevel;
@@ -19,9 +25,9 @@ export const WorkspaceAttributeNotice = (props: WorkspaceAttributeNoticeProperti
     props.isLocked && h(Notice, { label: 'Locked', tooltip: 'Workspace is locked', iconName: 'lock' }),
     isReadOnly && h(Notice, { label: 'Read-only', tooltip: 'Workspace is read-only', iconName: 'eye' }),
     !!props.workspaceProtectedMessage &&
-      h(Notice, { label: 'Protected', tooltip: props.workspaceProtectedMessage, iconName: 'shield' }),
+      h(Notice, { label: protectedDataLabel, tooltip: props.workspaceProtectedMessage, iconName: protectedDataIcon }),
     !!props.workspaceRegionConstraintMessage &&
-      h(Notice, { label: 'Region-restricted', tooltip: props.workspaceRegionConstraintMessage, iconName: 'globe' }),
+      h(Notice, { label: regionConstraintLabel, tooltip: props.workspaceRegionConstraintMessage, iconName: 'globe' }),
   ]);
 };
 

--- a/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.test.ts
+++ b/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.test.ts
@@ -410,7 +410,7 @@ describe('NewWorkspaceModal', () => {
   });
 
   describe('decides when to show a policy section ', () => {
-    const clonePolicyLabel = 'The cloned workspace will inherit:';
+    const clonePolicyLabel = 'The workspace will inherit:';
     it('Shows a policy section when cloning an Azure workspace with polices', async () => {
       asMockedFn(Ajax).mockImplementation(
         () =>

--- a/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.test.ts
+++ b/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.test.ts
@@ -410,7 +410,7 @@ describe('NewWorkspaceModal', () => {
   });
 
   describe('decides when to show a policy section ', () => {
-    const clonePolicyLabel = 'The workspace will inherit:';
+    const policyLabel = 'The workspace will inherit:';
     it('Shows a policy section when cloning an Azure workspace with polices', async () => {
       asMockedFn(Ajax).mockImplementation(
         () =>
@@ -435,7 +435,7 @@ describe('NewWorkspaceModal', () => {
 
       // Assert
       screen.getByText('Policies');
-      screen.getByText(clonePolicyLabel);
+      screen.getByText(policyLabel);
     });
 
     it('Does not show a policy section when cloning an Azure workspace without polices', async () => {
@@ -462,7 +462,7 @@ describe('NewWorkspaceModal', () => {
 
       // Assert
       expect(screen.queryByText('Policies')).toBeNull();
-      expect(screen.queryByText(clonePolicyLabel)).toBeNull();
+      expect(screen.queryByText(policyLabel)).toBeNull();
     });
 
     it('Does not show a policy section when cloning a protected GCP workspace', async () => {
@@ -500,7 +500,72 @@ describe('NewWorkspaceModal', () => {
 
       // Assert
       expect(screen.queryByText('Policies')).toBeNull();
-      expect(screen.queryByText(clonePolicyLabel)).toBeNull();
+      expect(screen.queryByText(policyLabel)).toBeNull();
+    });
+
+    it('Shows a policy section when creating a new workspace from a protected data billing project', async () => {
+      // Arrange
+      const user = userEvent.setup();
+      asMockedFn(Ajax).mockImplementation(
+        () =>
+          ({
+            Billing: {
+              listProjects: async () => [azureProtectedDataBillingProject],
+            },
+            ...nonBillingAjax,
+          } as AjaxContract)
+      );
+
+      // Act
+      await act(async () => {
+        render(
+          h(NewWorkspaceModal, {
+            onDismiss: () => {},
+            onSuccess: () => {},
+          })
+        );
+      });
+
+      // No policy section until billing project is selected.
+      expect(screen.queryByText('Policies')).toBeNull();
+
+      await user.click(screen.getByText('Select a billing project'));
+      await user.click(screen.getByText('Protected Azure Billing Project'));
+
+      // Assert
+      screen.getByText('Policies');
+      screen.getByText(policyLabel);
+    });
+
+    it('Does not shows a policy section when creating a new workspace from an unprotected data billing project', async () => {
+      // Arrange
+      const user = userEvent.setup();
+      asMockedFn(Ajax).mockImplementation(
+        () =>
+          ({
+            Billing: {
+              listProjects: async () => [azureBillingProject],
+            },
+            ...nonBillingAjax,
+          } as AjaxContract)
+      );
+
+      // Act
+      await act(async () => {
+        render(
+          h(NewWorkspaceModal, {
+            onDismiss: () => {},
+            onSuccess: () => {},
+          })
+        );
+      });
+
+      await user.click(screen.getByText('Select a billing project'));
+      await user.click(screen.getByText('Azure Billing Project'));
+
+      // Assert
+      expect(screen.queryByText('Policies')).toBeNull();
+      expect(screen.queryByText(policyLabel)).toBeNull();
     });
   });
 

--- a/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.ts
+++ b/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.ts
@@ -462,7 +462,6 @@ const NewWorkspaceModal = withDisplayName(
                             ariaLiveMessages: { onFocus: onFocusAria, onChange: onChangeAria },
                             onChange: (opt) => setNamespace(opt!.value),
                             styles: { option: (provided) => ({ ...provided, padding: 10 }) },
-                            // @ts-expect-error
                             options: _.map((project: BillingProject) => {
                               const { projectName, invalidBillingAccount, cloudPlatform } = project;
                               return {

--- a/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.ts
+++ b/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.ts
@@ -35,6 +35,8 @@ import {
   isAzureWorkspace,
   isGoogleWorkspace,
   isProtectedWorkspace,
+  protectedDataIcon,
+  protectedDataLabel,
   protectedDataMessage,
   WorkspaceInfo,
   WorkspaceWrapper,
@@ -312,9 +314,13 @@ const NewWorkspaceModal = withDisplayName(
       cloudProvider: CloudPlatform
     ): boolean => getProjectCloudPlatform(project) === cloudProvider;
 
+    const selectedBillingProject: BillingProject = namespace
+      ? billingProjects?.find(({ projectName }) => projectName === namespace)
+      : undefined;
+
     const getProjectCloudPlatform = (project?: BillingProject): CloudPlatform | undefined => {
       if (project === undefined) {
-        project = _.find({ projectName: namespace }, billingProjects);
+        project = selectedBillingProject;
       }
       return project?.cloudPlatform;
     };
@@ -458,7 +464,12 @@ const NewWorkspaceModal = withDisplayName(
                             styles: { option: (provided) => ({ ...provided, padding: 10 }) },
                             // @ts-expect-error
                             options: _.map(
-                              ({ projectName, invalidBillingAccount, cloudPlatform }: BillingProject) => ({
+                              ({
+                                projectName,
+                                invalidBillingAccount,
+                                cloudPlatform,
+                                protectedData,
+                              }: BillingProject) => ({
                                 'aria-label': `${
                                   cloudProviderLabels[cloudPlatform]
                                 } ${projectName}${ariaInvalidBillingAccountMsg(invalidBillingAccount)}`,
@@ -477,6 +488,12 @@ const NewWorkspaceModal = withDisplayName(
                                           style: { marginRight: '0.5rem' },
                                         }),
                                       projectName,
+                                      !!protectedData &&
+                                        icon(protectedDataIcon, {
+                                          size: 18,
+                                          'aria-label': protectedDataLabel,
+                                          style: { marginLeft: '0.5rem' },
+                                        }),
                                     ]),
                                   ]
                                 ),
@@ -576,7 +593,7 @@ const NewWorkspaceModal = withDisplayName(
                                 },
                                 [
                                   label({ style: { ...Style.elements.sectionHeader } }, [
-                                    'Enable additional security monitoring',
+                                    `Enable ${_.toLower(protectedDataLabel)}`,
                                   ]),
                                 ]
                               ),
@@ -627,18 +644,23 @@ const NewWorkspaceModal = withDisplayName(
                             }),
                           ]),
                       ]),
+                    // If cloning an Azure workspace, show the source workspace policies.
                     !!cloneWorkspace &&
                       isAzureWorkspace(cloneWorkspace) &&
                       h(WorkspacePolicies, {
-                        workspace: cloneWorkspace,
+                        workspaceOrBillingProject: cloneWorkspace,
                         title: 'Policies',
-                        policiesLabel: 'The cloned workspace will inherit:',
+                        policiesLabel: 'The workspace will inherit:',
                       }),
-                    renderNotice({
-                      selectedBillingProject: namespace
-                        ? billingProjects?.find(({ projectName }) => projectName === namespace)
-                        : undefined,
-                    }),
+                    // If creating a new workspace using a protected data Azure billing project,
+                    // show the policies that will be inherited from the billing project.
+                    !cloneWorkspace &&
+                      h(WorkspacePolicies, {
+                        workspaceOrBillingProject: selectedBillingProject,
+                        title: 'Policies',
+                        policiesLabel: 'The workspace will inherit:',
+                      }),
+                    renderNotice({ selectedBillingProject }),
                     workflowImport &&
                       azureBillingProjectsExist &&
                       div({ style: { paddingTop: '1.0rem', display: 'flex' } }, [

--- a/src/workspaces/ShareWorkspaceModal/ShareWorkspaceModal.ts
+++ b/src/workspaces/ShareWorkspaceModal/ShareWorkspaceModal.ts
@@ -188,7 +188,7 @@ const ShareWorkspaceModal: React.FC<ShareWorkspaceModalProps> = (props: ShareWor
       searchValueValid && !searchHasFocus && p([addUserReminder]),
       h(CurrentCollaborators, { acl, setAcl, originalAcl, lastAddedEmail, workspace }),
       h(WorkspacePolicies, {
-        workspace,
+        workspaceOrBillingProject: workspace,
         title: isAzureWorkspace(workspace) ? 'Policies' : undefined,
         policiesLabel: isGoogleWorkspace(workspace) ? 'This workspace has the following:' : undefined,
         style: { marginTop: '1.0rem', marginBottom: '1.5rem' },

--- a/src/workspaces/ShareWorkspaceModal/ShareWorkspaceModal.ts
+++ b/src/workspaces/ShareWorkspaceModal/ShareWorkspaceModal.ts
@@ -188,7 +188,7 @@ const ShareWorkspaceModal: React.FC<ShareWorkspaceModalProps> = (props: ShareWor
       searchValueValid && !searchHasFocus && p([addUserReminder]),
       h(CurrentCollaborators, { acl, setAcl, originalAcl, lastAddedEmail, workspace }),
       h(WorkspacePolicies, {
-        workspaceOrBillingProject: workspace,
+        policySource: workspace,
         title: isAzureWorkspace(workspace) ? 'Policies' : undefined,
         policiesLabel: isGoogleWorkspace(workspace) ? 'This workspace has the following:' : undefined,
         style: { marginTop: '1.0rem', marginBottom: '1.5rem' },

--- a/src/workspaces/WorkspacePolicies/WorkspacePolicies.test.ts
+++ b/src/workspaces/WorkspacePolicies/WorkspacePolicies.test.ts
@@ -3,6 +3,11 @@ import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 import { h } from 'react-hyperscript-helpers';
 import { AzureWorkspace } from 'src/libs/workspace-utils';
+import {
+  azureBillingProject,
+  azureProtectedDataBillingProject,
+  gcpBillingProject,
+} from 'src/testing/billing-project-fixtures';
 import { renderWithAppContexts as render } from 'src/testing/test-utils';
 import {
   defaultAzureWorkspace,
@@ -14,80 +19,123 @@ import {
 import { WorkspacePolicies } from 'src/workspaces/WorkspacePolicies/WorkspacePolicies';
 
 describe('WorkspacePolicies', () => {
-  it('renders nothing if the policy array is empty', () => {
-    // Act
-    render(
-      h(WorkspacePolicies, {
-        policySource: defaultAzureWorkspace,
-      })
-    );
+  const policyLabel = /This workspace has the following/;
 
-    // Assert
-    expect(screen.queryByText(/This workspace has the following/)).toBeNull();
+  describe('handles a workspace as the source of the policies', () => {
+    it('renders nothing if the policy array is empty', () => {
+      // Act
+      render(
+        h(WorkspacePolicies, {
+          policySource: defaultAzureWorkspace,
+        })
+      );
+
+      // Assert
+      expect(screen.queryByText(policyLabel)).toBeNull();
+    });
+
+    it('renders nothing if the policy array does not contain known policies', () => {
+      // Arrange
+      const nonProtectedAzureWorkspace: AzureWorkspace = {
+        ...defaultAzureWorkspace,
+        policies: [
+          {
+            additionalData: [],
+            namespace: 'terra',
+            name: 'some-other-policy',
+          },
+        ],
+      };
+
+      // Act
+      render(
+        h(WorkspacePolicies, {
+          policySource: nonProtectedAzureWorkspace,
+        })
+      );
+
+      // Assert
+      expect(screen.queryByText(policyLabel)).toBeNull();
+    });
+
+    it('renders policies with no accessibility errors', async () => {
+      // Arrange
+      const workspaceWithAllPolicies: AzureWorkspace = {
+        ...defaultAzureWorkspace,
+        policies: [protectedDataPolicy, groupConstraintPolicy, regionConstraintPolicy],
+      };
+
+      // Act
+      const { container } = render(
+        h(WorkspacePolicies, {
+          policySource: workspaceWithAllPolicies,
+        })
+      );
+
+      // Assert
+      expect(await axe(container)).toHaveNoViolations();
+      expect(screen.getByText('This workspace has the following policies:')).toBeInTheDocument();
+      screen.getByText('Additional security monitoring');
+      screen.getByText('Data access controls');
+      screen.getByText('Region constraint');
+    });
+
+    it('renders a tooltip', async () => {
+      // Arrange
+      const user = userEvent.setup();
+
+      // Act
+      render(
+        h(WorkspacePolicies, {
+          policySource: protectedAzureWorkspace,
+        })
+      );
+
+      // Act, click on the info button to get tooltip text to render.
+      await user.click(screen.getByLabelText('More info'));
+
+      // Assert
+      expect(screen.getAllByText(policyLabel)).not.toBeNull();
+    });
   });
 
-  it('renders nothing if the policy array does not contain known policies', () => {
-    // Arrange
-    const nonProtectedAzureWorkspace: AzureWorkspace = {
-      ...defaultAzureWorkspace,
-      policies: [
-        {
-          additionalData: [],
-          namespace: 'terra',
-          name: 'some-other-policy',
-        },
-      ],
-    };
+  describe('handles a billing project as the source of the policies', () => {
+    it('renders nothing for a GCP billing project', () => {
+      // Act
+      render(
+        h(WorkspacePolicies, {
+          policySource: gcpBillingProject,
+        })
+      );
 
-    // Act
-    render(
-      h(WorkspacePolicies, {
-        policySource: nonProtectedAzureWorkspace,
-      })
-    );
+      // Assert
+      expect(screen.queryByText(policyLabel)).toBeNull();
+    });
 
-    // Assert
-    expect(screen.queryByText(/This workspace has the following/)).toBeNull();
-  });
+    it('renders nothing for an Azure unprotected billing project', () => {
+      // Act
+      render(
+        h(WorkspacePolicies, {
+          policySource: azureBillingProject,
+        })
+      );
 
-  it('renders policies with no accessibility errors', async () => {
-    // Arrange
-    const workspaceWithAllPolicies: AzureWorkspace = {
-      ...defaultAzureWorkspace,
-      policies: [protectedDataPolicy, groupConstraintPolicy, regionConstraintPolicy],
-    };
+      // Assert
+      expect(screen.queryByText(policyLabel)).toBeNull();
+    });
 
-    // Act
-    const { container } = render(
-      h(WorkspacePolicies, {
-        policySource: workspaceWithAllPolicies,
-      })
-    );
+    it('renders policies for an Azure protected data billing project', async () => {
+      // Act
+      render(
+        h(WorkspacePolicies, {
+          policySource: azureProtectedDataBillingProject,
+        })
+      );
 
-    // Assert
-    expect(await axe(container)).toHaveNoViolations();
-    expect(screen.getByText(/This workspace has the following/i)).toBeInTheDocument();
-    screen.getByText('Additional security monitoring');
-    screen.getByText('Data access controls');
-    screen.getByText('Region constraint');
-  });
-
-  it('renders a tooltip', async () => {
-    // Arrange
-    const user = userEvent.setup();
-
-    // Act
-    render(
-      h(WorkspacePolicies, {
-        policySource: protectedAzureWorkspace,
-      })
-    );
-
-    // Act, click on the info button to get tooltip text to render.
-    await user.click(screen.getByLabelText('More info'));
-
-    // Assert
-    expect(screen.getAllByText(/controlled-access data/)).not.toBeNull();
+      // Assert
+      expect(screen.getByText(policyLabel)).toBeInTheDocument();
+      screen.getByText('Additional security monitoring');
+    });
   });
 
   it('allows passing a title and label about the list', async () => {

--- a/src/workspaces/WorkspacePolicies/WorkspacePolicies.test.ts
+++ b/src/workspaces/WorkspacePolicies/WorkspacePolicies.test.ts
@@ -18,7 +18,7 @@ describe('WorkspacePolicies', () => {
     // Act
     render(
       h(WorkspacePolicies, {
-        workspaceOrBillingProject: defaultAzureWorkspace,
+        policySource: defaultAzureWorkspace,
       })
     );
 
@@ -42,7 +42,7 @@ describe('WorkspacePolicies', () => {
     // Act
     render(
       h(WorkspacePolicies, {
-        workspaceOrBillingProject: nonProtectedAzureWorkspace,
+        policySource: nonProtectedAzureWorkspace,
       })
     );
 
@@ -60,7 +60,7 @@ describe('WorkspacePolicies', () => {
     // Act
     const { container } = render(
       h(WorkspacePolicies, {
-        workspaceOrBillingProject: workspaceWithAllPolicies,
+        policySource: workspaceWithAllPolicies,
       })
     );
 
@@ -79,7 +79,7 @@ describe('WorkspacePolicies', () => {
     // Act
     render(
       h(WorkspacePolicies, {
-        workspaceOrBillingProject: protectedAzureWorkspace,
+        policySource: protectedAzureWorkspace,
       })
     );
 
@@ -96,7 +96,7 @@ describe('WorkspacePolicies', () => {
       h(WorkspacePolicies, {
         title: 'Test title',
         policiesLabel: 'About this list:',
-        workspaceOrBillingProject: protectedAzureWorkspace,
+        policySource: protectedAzureWorkspace,
       })
     );
 

--- a/src/workspaces/WorkspacePolicies/WorkspacePolicies.test.ts
+++ b/src/workspaces/WorkspacePolicies/WorkspacePolicies.test.ts
@@ -18,7 +18,7 @@ describe('WorkspacePolicies', () => {
     // Act
     render(
       h(WorkspacePolicies, {
-        workspace: defaultAzureWorkspace,
+        workspaceOrBillingProject: defaultAzureWorkspace,
       })
     );
 
@@ -42,7 +42,7 @@ describe('WorkspacePolicies', () => {
     // Act
     render(
       h(WorkspacePolicies, {
-        workspace: nonProtectedAzureWorkspace,
+        workspaceOrBillingProject: nonProtectedAzureWorkspace,
       })
     );
 
@@ -60,7 +60,7 @@ describe('WorkspacePolicies', () => {
     // Act
     const { container } = render(
       h(WorkspacePolicies, {
-        workspace: workspaceWithAllPolicies,
+        workspaceOrBillingProject: workspaceWithAllPolicies,
       })
     );
 
@@ -79,7 +79,7 @@ describe('WorkspacePolicies', () => {
     // Act
     render(
       h(WorkspacePolicies, {
-        workspace: protectedAzureWorkspace,
+        workspaceOrBillingProject: protectedAzureWorkspace,
       })
     );
 
@@ -96,7 +96,7 @@ describe('WorkspacePolicies', () => {
       h(WorkspacePolicies, {
         title: 'Test title',
         policiesLabel: 'About this list:',
-        workspace: protectedAzureWorkspace,
+        workspaceOrBillingProject: protectedAzureWorkspace,
       })
     );
 

--- a/src/workspaces/WorkspacePolicies/WorkspacePolicies.ts
+++ b/src/workspaces/WorkspacePolicies/WorkspacePolicies.ts
@@ -13,24 +13,29 @@ import {
 import { AzureBillingProject, BillingProject } from 'src/pages/billing/models/BillingProject';
 
 type WorkspacePoliciesProps = {
-  workspaceOrBillingProject: WorkspaceWrapper | BillingProject;
+  policySource: WorkspaceWrapper | BillingProject;
   title?: string;
   policiesLabel?: string;
   style?: CSSProperties;
 };
 
 export const WorkspacePolicies = (props: WorkspacePoliciesProps): ReactNode => {
-  const isWorkspaceWrapper = (workspace?: WorkspaceWrapper): workspace is WorkspaceWrapper =>
+  const isWorkspaceWrapper = (workspace: WorkspaceWrapper | BillingProject): workspace is WorkspaceWrapper =>
     _.has('workspace', workspace);
-  const isAzureBillingProject = (project?: BillingProject): project is AzureBillingProject =>
-    _.has('projectName', project) && project?.cloudPlatform === 'AZURE';
+  const isProtectedAzureBillingProject = (project: WorkspaceWrapper | BillingProject) => {
+    const isBillingProject = (project?: WorkspaceWrapper | BillingProject): project is BillingProject =>
+      _.has('projectName', project);
+    const isAzureBillingProject = (project: BillingProject): project is AzureBillingProject =>
+      project.cloudPlatform === 'AZURE';
+    return isBillingProject(project) && isAzureBillingProject(project) && project.protectedData;
+  };
+  const policySource = props.policySource;
 
-  const billingProjectPolicyDescriptions =
-    isAzureBillingProject(props.workspaceOrBillingProject) && props.workspaceOrBillingProject.protectedData
-      ? [{ shortDescription: protectedDataLabel, longDescription: protectedDataMessage }]
-      : [];
-  const policyDescriptions = isWorkspaceWrapper(props.workspaceOrBillingProject)
-    ? getPolicyDescriptions(props.workspaceOrBillingProject)
+  const billingProjectPolicyDescriptions = isProtectedAzureBillingProject(policySource)
+    ? [{ shortDescription: protectedDataLabel, longDescription: protectedDataMessage }]
+    : [];
+  const policyDescriptions = isWorkspaceWrapper(policySource)
+    ? getPolicyDescriptions(policySource)
     : billingProjectPolicyDescriptions;
   const description = props.policiesLabel
     ? props.policiesLabel

--- a/src/workspaces/WorkspacePolicies/WorkspacePolicies.ts
+++ b/src/workspaces/WorkspacePolicies/WorkspacePolicies.ts
@@ -4,17 +4,34 @@ import pluralize from 'pluralize';
 import { CSSProperties, ReactNode } from 'react';
 import { div, h, li, ul } from 'react-hyperscript-helpers';
 import * as Style from 'src/libs/style';
-import { getPolicyDescriptions, WorkspaceWrapper } from 'src/libs/workspace-utils';
+import {
+  getPolicyDescriptions,
+  protectedDataLabel,
+  protectedDataMessage,
+  WorkspaceWrapper,
+} from 'src/libs/workspace-utils';
+import { AzureBillingProject, BillingProject } from 'src/pages/billing/models/BillingProject';
 
 type WorkspacePoliciesProps = {
-  workspace: WorkspaceWrapper;
+  workspaceOrBillingProject: WorkspaceWrapper | BillingProject;
   title?: string;
   policiesLabel?: string;
   style?: CSSProperties;
 };
 
 export const WorkspacePolicies = (props: WorkspacePoliciesProps): ReactNode => {
-  const policyDescriptions = getPolicyDescriptions(props.workspace);
+  const isWorkspaceWrapper = (workspace?: WorkspaceWrapper): workspace is WorkspaceWrapper =>
+    _.has('workspace', workspace);
+  const isAzureBillingProject = (project?: BillingProject): project is AzureBillingProject =>
+    _.has('projectName', project) && project?.cloudPlatform === 'AZURE';
+
+  const billingProjectPolicyDescriptions =
+    isAzureBillingProject(props.workspaceOrBillingProject) && props.workspaceOrBillingProject.protectedData
+      ? [{ shortDescription: protectedDataLabel, longDescription: protectedDataMessage }]
+      : [];
+  const policyDescriptions = isWorkspaceWrapper(props.workspaceOrBillingProject)
+    ? getPolicyDescriptions(props.workspaceOrBillingProject)
+    : billingProjectPolicyDescriptions;
   const description = props.policiesLabel
     ? props.policiesLabel
     : `This workspace has the following ${pluralize('policy', policyDescriptions.length)}:`;


### PR DESCRIPTION
This is the final part of https://broadworkbench.atlassian.net/browse/WOR-1348.

When a new workspace is created from a protected data Azure billing project, the policy section is shown in the NewWorkspaceModal. Note that during the cloning workflow, policies will inherit from the source workspace due to earlier work for WOR-1348.

Also, we show a shield icon by the billing project name to make it easier for users to find the protected billing projects (the shield icon will also display during the cloning workflow).

Before:

After:

View when cloning a protected data workspace:

View when cloning a non-protected data worskpace:
