### PR TITLE
AJ-1494 don't call rawls for azure workspaces

### DIFF
--- a/src/workspace-data/Data.js
+++ b/src/workspace-data/Data.js
@@ -637,13 +637,13 @@ export const WorkspaceData = _.flow(
       }
     };
 
-    const loadAzureSnapshotMetadata = async () => {
+    const azureLoadSnapshotMetadata = async () => {
       setSnapshotMetadataError(false);
     };
 
     const loadMetadata = () =>
       isAzureWorkspace
-        ? Promise.all([azureLoadEntityMetadata(), loadAzureSnapshotMetadata(), refreshRunningImportJobs(), loadWdsSchema()])
+        ? Promise.all([azureLoadEntityMetadata(), azureLoadSnapshotMetadata(), refreshRunningImportJobs(), loadWdsSchema()])
         : Promise.all([loadEntityMetadata(), loadSnapshotMetadata(), refreshRunningImportJobs()]);
 
     const loadSnapshotEntities = async (snapshotName) => {

--- a/src/workspace-data/Data.test.ts
+++ b/src/workspace-data/Data.test.ts
@@ -421,6 +421,4 @@ describe('WorkspaceData', () => {
     // Assert
     expect(mockListSnapshots).not.toHaveBeenCalled();
   });
-
-  // TODO should I also simulate refreshing the page or some action that calls loadMetadata, or is this sufficient?
 });


### PR DESCRIPTION
[AJ-1494](https://broadworkbench.atlassian.net/browse/AJ-1494)

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
This adds checks for cloud platform before making calls to Rawls or WDS when loading the Data tab.

### Why
- Not only were the calls to Rawls from an azure workspace extraneous, they were blocking the completion of https://broadworkbench.atlassian.net/browse/AJ-1438

### Testing strategy
- [x] Added unit tests
- [x] Verified locally

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 


[AJ-1494]: https://broadworkbench.atlassian.net/browse/AJ-1494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ