### PR TITLE
[WOR-1348] Combine policy information from an Azure protected billing project and workspace policies

### DIFF
--- a/src/libs/workspace-utils.test.ts
+++ b/src/libs/workspace-utils.test.ts
@@ -17,6 +17,7 @@ import {
   getRegionConstraintLabels,
   getWorkspaceAnalysisControlProps,
   getWorkspaceEditControlProps,
+  groupConstraintLabel,
   groupConstraintMessage,
   hasGroupConstraintPolicy,
   hasRegionConstraintPolicy,
@@ -149,7 +150,7 @@ describe('getPolicyDescriptions', () => {
     };
     expect(getPolicyDescriptions(workspace)).toEqual([
       { shortDescription: protectedDataLabel, longDescription: protectedDataMessage },
-      { shortDescription: 'Data access controls', longDescription: groupConstraintMessage },
+      { shortDescription: groupConstraintLabel, longDescription: groupConstraintMessage },
     ]);
   });
 
@@ -193,7 +194,7 @@ describe('getPolicyDescriptions', () => {
     };
     expect(getPolicyDescriptions(workspace, azureProtectedDataBillingProject)).toEqual([
       { shortDescription: protectedDataLabel, longDescription: protectedDataMessage },
-      { shortDescription: 'Data access controls', longDescription: groupConstraintMessage },
+      { shortDescription: groupConstraintLabel, longDescription: groupConstraintMessage },
     ]);
   });
 });

--- a/src/libs/workspace-utils.test.ts
+++ b/src/libs/workspace-utils.test.ts
@@ -1,4 +1,5 @@
 import { azureRegions } from 'src/libs/azure-regions';
+import { azureProtectedDataBillingProject } from 'src/testing/billing-project-fixtures';
 import {
   defaultAzureWorkspace,
   defaultGoogleWorkspace,
@@ -21,7 +22,9 @@ import {
   hasRegionConstraintPolicy,
   isProtectedWorkspace,
   isValidWsExportTarget,
+  protectedDataLabel,
   protectedDataMessage,
+  regionConstraintLabel,
   regionConstraintMessage,
   WorkspaceAccessLevel,
   WorkspacePolicy,
@@ -145,7 +148,7 @@ describe('getPolicyDescriptions', () => {
       policies: [protectedDataPolicy, groupConstraintPolicy],
     };
     expect(getPolicyDescriptions(workspace)).toEqual([
-      { shortDescription: 'Additional security monitoring', longDescription: protectedDataMessage },
+      { shortDescription: protectedDataLabel, longDescription: protectedDataMessage },
       { shortDescription: 'Data access controls', longDescription: groupConstraintMessage },
     ]);
   });
@@ -153,7 +156,7 @@ describe('getPolicyDescriptions', () => {
   it('Returns policy information for a region-constrained workspace', () => {
     expect(getPolicyDescriptions(regionRestrictedAzureWorkspace)).toEqual([
       {
-        shortDescription: 'Region constraint',
+        shortDescription: regionConstraintLabel,
         longDescription: regionConstraintMessage(regionRestrictedAzureWorkspace),
       },
     ]);
@@ -171,6 +174,27 @@ describe('getPolicyDescriptions', () => {
       ],
     };
     expect(getPolicyDescriptions(workspaceWithOtherPolicy)).toEqual([]);
+  });
+
+  it('Returns policy information from a protected billing project', () => {
+    expect(getPolicyDescriptions(undefined, azureProtectedDataBillingProject)).toEqual([
+      { shortDescription: protectedDataLabel, longDescription: protectedDataMessage },
+    ]);
+  });
+
+  it('Returns an empty array for undefined inputs', () => {
+    expect(getPolicyDescriptions(undefined, undefined)).toEqual([]);
+  });
+
+  it('Combines policy information from a billing project and a workspace', () => {
+    const workspace: WorkspaceWrapper = {
+      ...defaultAzureWorkspace,
+      policies: [protectedDataPolicy, groupConstraintPolicy],
+    };
+    expect(getPolicyDescriptions(workspace, azureProtectedDataBillingProject)).toEqual([
+      { shortDescription: protectedDataLabel, longDescription: protectedDataMessage },
+      { shortDescription: 'Data access controls', longDescription: groupConstraintMessage },
+    ]);
   });
 });
 

--- a/src/libs/workspace-utils.ts
+++ b/src/libs/workspace-utils.ts
@@ -219,7 +219,6 @@ export const getRegionConstraintLabels = (policies: WorkspacePolicy[] | undefine
 };
 
 export const regionConstraintLabel = 'Region constraint';
-
 export const regionConstraintMessage = (workspace: BaseWorkspace): string | undefined => {
   const regions = getRegionConstraintLabels(workspace.policies);
   return regions.length === 0

--- a/src/libs/workspace-utils.ts
+++ b/src/libs/workspace-utils.ts
@@ -132,7 +132,7 @@ export const getPolicyDescriptions = (
     });
   }
   if (!!workspace && hasGroupConstraintPolicy(workspace)) {
-    policyDescriptions.push({ shortDescription: 'Data access controls', longDescription: groupConstraintMessage });
+    policyDescriptions.push({ shortDescription: groupConstraintLabel, longDescription: groupConstraintMessage });
   }
   if (!!workspace && hasRegionConstraintPolicy(workspace)) {
     policyDescriptions.push({
@@ -193,6 +193,7 @@ export const protectedDataMessage =
   'Enhanced logging and monitoring are enabled to support the use of controlled-access data in this workspace.';
 export const protectedDataIcon = 'shield';
 
+export const groupConstraintLabel = 'Data access controls';
 export const groupConstraintMessage =
   'Data Access Controls add additional permission restrictions to a workspace. These were added when you imported data from a controlled access source. All workspace collaborators must also be current users on an approved Data Access Request (DAR).';
 

--- a/src/pages/workspaces/workspace/WorkspaceAttributeNotice.ts
+++ b/src/pages/workspaces/workspace/WorkspaceAttributeNotice.ts
@@ -3,7 +3,13 @@ import { div, h, span } from 'react-hyperscript-helpers';
 import { icon } from 'src/components/icons';
 import TooltipTrigger from 'src/components/TooltipTrigger';
 import colors from 'src/libs/colors';
-import { canWrite, WorkspaceAccessLevel } from 'src/libs/workspace-utils';
+import {
+  canWrite,
+  protectedDataIcon,
+  protectedDataLabel,
+  regionConstraintLabel,
+  WorkspaceAccessLevel,
+} from 'src/libs/workspace-utils';
 
 interface WorkspaceAttributeNoticeProperties {
   accessLevel: WorkspaceAccessLevel;
@@ -19,9 +25,9 @@ export const WorkspaceAttributeNotice = (props: WorkspaceAttributeNoticeProperti
     props.isLocked && h(Notice, { label: 'Locked', tooltip: 'Workspace is locked', iconName: 'lock' }),
     isReadOnly && h(Notice, { label: 'Read-only', tooltip: 'Workspace is read-only', iconName: 'eye' }),
     !!props.workspaceProtectedMessage &&
-      h(Notice, { label: 'Protected', tooltip: props.workspaceProtectedMessage, iconName: 'shield' }),
+      h(Notice, { label: protectedDataLabel, tooltip: props.workspaceProtectedMessage, iconName: protectedDataIcon }),
     !!props.workspaceRegionConstraintMessage &&
-      h(Notice, { label: 'Region-restricted', tooltip: props.workspaceRegionConstraintMessage, iconName: 'globe' }),
+      h(Notice, { label: regionConstraintLabel, tooltip: props.workspaceRegionConstraintMessage, iconName: 'globe' }),
   ]);
 };
 

--- a/src/workspaces/WorkspacePolicies/WorkspacePolicies.test.ts
+++ b/src/workspaces/WorkspacePolicies/WorkspacePolicies.test.ts
@@ -3,6 +3,11 @@ import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 import { h } from 'react-hyperscript-helpers';
 import { AzureWorkspace } from 'src/libs/workspace-utils';
+import {
+  azureBillingProject,
+  azureProtectedDataBillingProject,
+  gcpBillingProject,
+} from 'src/testing/billing-project-fixtures';
 import { renderWithAppContexts as render } from 'src/testing/test-utils';
 import {
   defaultAzureWorkspace,
@@ -14,80 +19,171 @@ import {
 import { WorkspacePolicies } from 'src/workspaces/WorkspacePolicies/WorkspacePolicies';
 
 describe('WorkspacePolicies', () => {
-  it('renders nothing if the policy array is empty', () => {
-    // Act
-    render(
-      h(WorkspacePolicies, {
-        workspace: defaultAzureWorkspace,
-      })
-    );
+  const policyLabel = /This workspace has the following/;
 
-    // Assert
-    expect(screen.queryByText(/This workspace has the following/)).toBeNull();
+  describe('handles a workspace as the source of the policies', () => {
+    it('renders nothing if the policy array is empty', () => {
+      // Act
+      render(
+        h(WorkspacePolicies, {
+          workspace: defaultAzureWorkspace,
+        })
+      );
+
+      // Assert
+      expect(screen.queryByText(policyLabel)).toBeNull();
+    });
+
+    it('renders nothing if the workspace does not have known policies', () => {
+      // Arrange
+      const nonProtectedAzureWorkspace: AzureWorkspace = {
+        ...defaultAzureWorkspace,
+        policies: [
+          {
+            additionalData: [],
+            namespace: 'terra',
+            name: 'some-other-policy',
+          },
+        ],
+      };
+
+      // Act
+      render(
+        h(WorkspacePolicies, {
+          workspace: nonProtectedAzureWorkspace,
+        })
+      );
+
+      // Assert
+      expect(screen.queryByText(policyLabel)).toBeNull();
+    });
+
+    it('renders policies with no accessibility errors', async () => {
+      // Arrange
+      const workspaceWithAllPolicies: AzureWorkspace = {
+        ...defaultAzureWorkspace,
+        policies: [protectedDataPolicy, groupConstraintPolicy, regionConstraintPolicy],
+      };
+
+      // Act
+      const { container } = render(
+        h(WorkspacePolicies, {
+          workspace: workspaceWithAllPolicies,
+        })
+      );
+
+      // Assert
+      expect(await axe(container)).toHaveNoViolations();
+      screen.getByText('This workspace has the following policies:');
+      screen.getByText('Additional security monitoring');
+      screen.getByText('Data access controls');
+      screen.getByText('Region constraint');
+    });
+
+    it('renders a tooltip', async () => {
+      // Arrange
+      const user = userEvent.setup();
+
+      // Act
+      render(
+        h(WorkspacePolicies, {
+          workspace: protectedAzureWorkspace,
+        })
+      );
+
+      // Act, click on the info button to get tooltip text to render.
+      await user.click(screen.getByLabelText('More info'));
+
+      // Assert
+      expect(screen.getAllByText(policyLabel)).not.toBeNull();
+    });
   });
 
-  it('renders nothing if the policy array does not contain known policies', () => {
-    // Arrange
-    const nonProtectedAzureWorkspace: AzureWorkspace = {
-      ...defaultAzureWorkspace,
-      policies: [
-        {
-          additionalData: [],
-          namespace: 'terra',
-          name: 'some-other-policy',
-        },
-      ],
-    };
+  describe('handles a billing project as the source of the policies', () => {
+    it('renders nothing for a GCP billing project', () => {
+      // Act
+      render(
+        h(WorkspacePolicies, {
+          billingProject: gcpBillingProject,
+        })
+      );
 
-    // Act
-    render(
-      h(WorkspacePolicies, {
-        workspace: nonProtectedAzureWorkspace,
-      })
-    );
+      // Assert
+      expect(screen.queryByText(policyLabel)).toBeNull();
+    });
 
-    // Assert
-    expect(screen.queryByText(/This workspace has the following/)).toBeNull();
+    it('renders nothing for an Azure unprotected billing project', () => {
+      // Act
+      render(
+        h(WorkspacePolicies, {
+          billingProject: azureBillingProject,
+        })
+      );
+
+      // Assert
+      expect(screen.queryByText(policyLabel)).toBeNull();
+    });
+
+    it('renders policies for an Azure protected data billing project', async () => {
+      // Act
+      render(
+        h(WorkspacePolicies, {
+          billingProject: azureProtectedDataBillingProject,
+        })
+      );
+
+      // Assert
+      screen.getByText(policyLabel);
+      screen.getByText('Additional security monitoring');
+    });
   });
 
-  it('renders policies with no accessibility errors', async () => {
-    // Arrange
-    const workspaceWithAllPolicies: AzureWorkspace = {
-      ...defaultAzureWorkspace,
-      policies: [protectedDataPolicy, groupConstraintPolicy, regionConstraintPolicy],
-    };
+  describe('handles both a workspace and a billing project ', () => {
+    it('combines together policy information from workspace and billingProject', async () => {
+      // Act
+      const workspaceWithPolicies: AzureWorkspace = {
+        ...defaultAzureWorkspace,
+        policies: [regionConstraintPolicy],
+      };
+      render(
+        h(WorkspacePolicies, {
+          billingProject: azureProtectedDataBillingProject,
+          workspace: workspaceWithPolicies,
+        })
+      );
 
-    // Act
-    const { container } = render(
-      h(WorkspacePolicies, {
-        workspace: workspaceWithAllPolicies,
-      })
-    );
+      // Assert
+      screen.getByText(policyLabel);
+      expect(screen.getAllByText('Additional security monitoring')).toHaveLength(1);
+      screen.getByText('Region constraint');
+    });
 
-    // Assert
-    expect(await axe(container)).toHaveNoViolations();
-    expect(screen.getByText(/This workspace has the following/i)).toBeInTheDocument();
-    screen.getByText('Additional security monitoring');
-    screen.getByText('Data access controls');
-    screen.getByText('Region constraint');
-  });
+    it('removes duplicate policy information', async () => {
+      // Act
+      const workspaceWithPolicies: AzureWorkspace = {
+        ...defaultAzureWorkspace,
+        policies: [protectedDataPolicy, regionConstraintPolicy],
+      };
+      render(
+        h(WorkspacePolicies, {
+          billingProject: azureProtectedDataBillingProject,
+          workspace: workspaceWithPolicies,
+        })
+      );
 
-  it('renders a tooltip', async () => {
-    // Arrange
-    const user = userEvent.setup();
+      // Assert
+      screen.getByText(policyLabel);
+      expect(screen.getAllByText('Additional security monitoring')).toHaveLength(1);
+      screen.getByText('Region constraint');
+    });
 
-    // Act
-    render(
-      h(WorkspacePolicies, {
-        workspace: protectedAzureWorkspace,
-      })
-    );
+    it('renders nothing if workspace and billing project are undefined', () => {
+      // Act
+      render(h(WorkspacePolicies, {}));
 
-    // Act, click on the info button to get tooltip text to render.
-    await user.click(screen.getByLabelText('More info'));
-
-    // Assert
-    expect(screen.getAllByText(/controlled-access data/)).not.toBeNull();
+      // Assert
+      expect(screen.queryByText(policyLabel)).toBeNull();
+    });
   });
 
   it('allows passing a title and label about the list', async () => {

--- a/src/workspaces/WorkspacePolicies/WorkspacePolicies.test.ts
+++ b/src/workspaces/WorkspacePolicies/WorkspacePolicies.test.ts
@@ -2,7 +2,13 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 import { h } from 'react-hyperscript-helpers';
-import { AzureWorkspace } from 'src/libs/workspace-utils';
+import {
+  AzureWorkspace,
+  groupConstraintLabel,
+  protectedDataLabel,
+  protectedDataMessage,
+  regionConstraintLabel,
+} from 'src/libs/workspace-utils';
 import {
   azureBillingProject,
   azureProtectedDataBillingProject,
@@ -75,9 +81,9 @@ describe('WorkspacePolicies', () => {
       // Assert
       expect(await axe(container)).toHaveNoViolations();
       screen.getByText('This workspace has the following policies:');
-      screen.getByText('Additional security monitoring');
-      screen.getByText('Data access controls');
-      screen.getByText('Region constraint');
+      screen.getByText(protectedDataLabel);
+      screen.getByText(groupConstraintLabel);
+      screen.getByText(regionConstraintLabel);
     });
 
     it('renders a tooltip', async () => {
@@ -95,7 +101,7 @@ describe('WorkspacePolicies', () => {
       await user.click(screen.getByLabelText('More info'));
 
       // Assert
-      expect(screen.getAllByText(policyLabel)).not.toBeNull();
+      expect(screen.getAllByText(protectedDataMessage)).not.toBeNull();
     });
   });
 
@@ -134,7 +140,7 @@ describe('WorkspacePolicies', () => {
 
       // Assert
       screen.getByText(policyLabel);
-      screen.getByText('Additional security monitoring');
+      screen.getByText(protectedDataLabel);
     });
   });
 
@@ -154,8 +160,8 @@ describe('WorkspacePolicies', () => {
 
       // Assert
       screen.getByText(policyLabel);
-      expect(screen.getAllByText('Additional security monitoring')).toHaveLength(1);
-      screen.getByText('Region constraint');
+      expect(screen.getAllByText(protectedDataLabel)).toHaveLength(1);
+      screen.getByText(regionConstraintLabel);
     });
 
     it('removes duplicate policy information', async () => {
@@ -173,8 +179,8 @@ describe('WorkspacePolicies', () => {
 
       // Assert
       screen.getByText(policyLabel);
-      expect(screen.getAllByText('Additional security monitoring')).toHaveLength(1);
-      screen.getByText('Region constraint');
+      expect(screen.getAllByText(protectedDataLabel)).toHaveLength(1);
+      screen.getByText(regionConstraintLabel);
     });
 
     it('renders nothing if workspace and billing project are undefined', () => {

--- a/src/workspaces/WorkspacePolicies/WorkspacePolicies.test.ts
+++ b/src/workspaces/WorkspacePolicies/WorkspacePolicies.test.ts
@@ -160,7 +160,7 @@ describe('WorkspacePolicies', () => {
 
       // Assert
       screen.getByText(policyLabel);
-      expect(screen.getAllByText(protectedDataLabel)).toHaveLength(1);
+      screen.getByText(protectedDataLabel);
       screen.getByText(regionConstraintLabel);
     });
 

--- a/src/workspaces/WorkspacePolicies/WorkspacePolicies.ts
+++ b/src/workspaces/WorkspacePolicies/WorkspacePolicies.ts
@@ -5,16 +5,19 @@ import { CSSProperties, ReactNode } from 'react';
 import { div, h, li, ul } from 'react-hyperscript-helpers';
 import * as Style from 'src/libs/style';
 import { getPolicyDescriptions, WorkspaceWrapper } from 'src/libs/workspace-utils';
+import { BillingProject } from 'src/pages/billing/models/BillingProject';
 
 type WorkspacePoliciesProps = {
-  workspace: WorkspaceWrapper;
+  workspace?: WorkspaceWrapper;
+  billingProject?: BillingProject;
   title?: string;
   policiesLabel?: string;
   style?: CSSProperties;
 };
 
 export const WorkspacePolicies = (props: WorkspacePoliciesProps): ReactNode => {
-  const policyDescriptions = getPolicyDescriptions(props.workspace);
+  const policyDescriptions = getPolicyDescriptions(props.workspace, props.billingProject);
+
   const description = props.policiesLabel
     ? props.policiesLabel
     : `This workspace has the following ${pluralize('policy', policyDescriptions.length)}:`;


### PR DESCRIPTION
This is the last PR in the under-pointed saga of https://broadworkbench.atlassian.net/browse/WOR-1348.

In the NewWorkspaceModal, this PR merges the protected data policy from an Azure protected data billing project in with whatever policies exist for the workspace (if cloning). It also adds a shield icon beside the name of protected data billing projects.

**Before, new workspace creation with protected data billing project selected:**
![image](https://github.com/DataBiosphere/terra-ui/assets/484484/ae21ecdd-38fd-448b-a85d-3b984ef861d4)

**After, new workspace creation with protected data billing project selected:**
![image](https://github.com/DataBiosphere/terra-ui/assets/484484/480c631e-6315-4945-b558-e1cb5218d715)


**Before, cloning of an unprotected (but region-constrained) workspace to a protected billing project:**
![image](https://github.com/DataBiosphere/terra-ui/assets/484484/009515b4-81d0-4d33-b76a-03ad605dc3df)

**After, cloning of an unprotected workspace to a protected billing project, note merging of policies:**
![image](https://github.com/DataBiosphere/terra-ui/assets/484484/3dbd77fb-ea69-4085-bb88-eb79bc60e175)


**Before, cloning of a protected workspace to a protected billing project:**
![image](https://github.com/DataBiosphere/terra-ui/assets/484484/be893f55-bdb9-4207-9ce2-2360fd15edce)

**After, cloning of a protected workspace to a protected billing project (no change except shield icon, as code does not duplicate the policy information):**
![image](https://github.com/DataBiosphere/terra-ui/assets/484484/6787e2ca-c97c-4b18-8213-db8dfc66fbe2)

