### PR TITLE
[WOR-1399] Fix bug with bringing up ShareWorkspace modal from the Workspaces list view (GCP workspace)

### DIFF
--- a/src/analysis/_testData/testData.ts
+++ b/src/analysis/_testData/testData.ts
@@ -143,6 +143,7 @@ export const generateGoogleWorkspace = (prefix: string = uuid().substring(0, 8))
   accessLevel: 'OWNER',
   canShare: true,
   canCompute: true,
+  policies: [],
 });
 
 export const generateAzureWorkspace = (prefix: string = uuid().substring(0, 8)): AzureWorkspace => ({
@@ -164,6 +165,7 @@ export const generateAzureWorkspace = (prefix: string = uuid().substring(0, 8)):
   accessLevel: 'OWNER',
   canShare: true,
   canCompute: true,
+  policies: [],
 });
 
 export const defaultTestDisk = {

--- a/src/components/WorkspaceLinks.test.ts
+++ b/src/components/WorkspaceLinks.test.ts
@@ -69,6 +69,7 @@ describe('WorkspaceLinkById', () => {
     accessLevel: 'OWNER',
     canShare: true,
     canCompute: true,
+    policies: [],
   };
 
   it('fetches workspace by ID', async () => {

--- a/src/libs/workspace-utils.ts
+++ b/src/libs/workspace-utils.ts
@@ -90,9 +90,7 @@ export interface BaseWorkspace {
   canShare: boolean;
   canCompute: boolean;
   workspace: WorkspaceInfo;
-  // Currently will always be empty for GCP workspaces, but this will change in the future.
-  // For the purposes of test data, not requiring the specification of the field.
-  policies?: WorkspacePolicy[];
+  policies: WorkspacePolicy[];
   public?: boolean;
   workspaceSubmissionStats?: WorkspaceSubmissionStats;
 }

--- a/src/pages/workspaces/WorkspacesList/RenderedWorkspaces.ts
+++ b/src/pages/workspaces/WorkspacesList/RenderedWorkspaces.ts
@@ -384,7 +384,7 @@ const ActionsCell = (props: ActionsCellProps): ReactNode => {
   const onClone = () => setUserActions({ cloningWorkspaceId: workspaceId });
   const onDelete = () => setUserActions({ deletingWorkspaceId: workspaceId });
   const onLock = () => setUserActions({ lockingWorkspaceId: workspaceId });
-  const onShare = (policies) => setUserActions({ sharingWorkspace: { ...getWorkspace(workspaceId), policies } });
+  const onShare = () => setUserActions({ sharingWorkspace: getWorkspace(workspaceId) });
   const onLeave = () => setUserActions({ leavingWorkspaceId: workspaceId });
 
   return div({ style: { ...styles.tableCellContainer, paddingRight: 0 } }, [

--- a/src/pages/workspaces/hooks/useWorkspacesWithSubmissionStats.ts
+++ b/src/pages/workspaces/hooks/useWorkspacesWithSubmissionStats.ts
@@ -22,10 +22,12 @@ export const useWorkspacesWithSubmissionStats = (): WorkspacesWithSubmissionStat
   } = useWorkspaces(
     [
       'accessLevel',
+      'policies', // Needed for ShareWorkspace modal on list view
       'public',
       'workspace.attributes.description',
       'workspace.attributes.tag:tags',
       'workspace.authorizationDomain',
+      'workspace.bucketName', // Needed for ShareWorkspace modal on list view
       'workspace.cloudPlatform',
       'workspace.createdBy',
       'workspace.lastModified',

--- a/src/pages/workspaces/workspace/WorkspaceMenu.ts
+++ b/src/pages/workspaces/workspace/WorkspaceMenu.ts
@@ -6,7 +6,7 @@ import { Clickable } from 'src/components/common';
 import { MenuButton } from 'src/components/MenuButton';
 import { makeMenuIcon, MenuTrigger } from 'src/components/PopupTrigger';
 import { useWorkspaceDetails } from 'src/components/workspace-utils';
-import { isOwner, WorkspacePolicy, WorkspaceState, WorkspaceWrapper as Workspace } from 'src/libs/workspace-utils';
+import { isOwner, WorkspaceState, WorkspaceWrapper as Workspace } from 'src/libs/workspace-utils';
 
 const isNameType = (o: WorkspaceInfo): o is DynamicWorkspaceInfo =>
   'name' in o && typeof o.name === 'string' && 'namespace' in o && typeof o.namespace === 'string';
@@ -23,7 +23,7 @@ type WorkspaceInfo = DynamicWorkspaceInfo | LoadedWorkspaceInfo;
 
 interface WorkspaceMenuCallbacks {
   onClone: () => void;
-  onShare: (policies?: WorkspacePolicy[]) => void;
+  onShare: () => void;
   onLock: () => void;
   onDelete: () => void;
   onLeave: () => void;
@@ -88,7 +88,6 @@ const DynamicWorkspaceMenuContent = (props: DynamicWorkspaceMenuContentProps) =>
   } = props;
   const { workspace } = useWorkspaceDetails({ namespace, name }, [
     'accessLevel',
-    'policies',
     'canShare',
     'workspace.isLocked',
     'workspace.state',
@@ -102,9 +101,7 @@ const DynamicWorkspaceMenuContent = (props: DynamicWorkspaceMenuContentProps) =>
       isOwner: !!workspace && isOwner(workspace.accessLevel),
       workspaceLoaded: !!workspace,
     },
-    // the list component doesn't have workspace details, so we need to pass policies so it can add it for the ShareWorkspaceModal modal
-    // the dashboard component already has the field, so it will ignore the parameter of onShare
-    callbacks: { ...callbacks, onShare: () => callbacks.onShare(workspace?.policies) },
+    callbacks,
   });
 };
 

--- a/src/workflows-app/utils/mock-responses.ts
+++ b/src/workflows-app/utils/mock-responses.ts
@@ -845,9 +845,5 @@ export const mockAzureWorkspace: AzureWorkspace = {
   accessLevel: 'OWNER',
   canShare: true,
   canCompute: true,
-};
-
-export const azureStorageDetails = {
-  location: 'container-location',
-  sas: { url: 'container-url?sas-token' },
+  policies: [],
 };

--- a/src/workspace-data/data-table/wds/WdsTroubleshooter.test.ts
+++ b/src/workspace-data/data-table/wds/WdsTroubleshooter.test.ts
@@ -221,6 +221,7 @@ describe('WdsTroubleshooter', () => {
       accessLevel: 'OWNER',
       canShare: true,
       canCompute: true,
+      policies: [],
     };
 
     asMockedFn(useWorkspaceById).mockReturnValue({
@@ -314,6 +315,7 @@ describe('WdsTroubleshooter', () => {
       accessLevel: 'OWNER',
       canShare: true,
       canCompute: true,
+      policies: [],
     };
 
     asMockedFn(useWorkspaceById).mockReturnValue({

--- a/src/workspace-data/import-jobs.test.ts
+++ b/src/workspace-data/import-jobs.test.ts
@@ -30,6 +30,7 @@ describe('useImportJobs', () => {
       accessLevel: 'OWNER',
       canShare: true,
       canCompute: true,
+      policies: [],
     };
 
     it('returns list of running jobs in workspace', () => {
@@ -94,6 +95,7 @@ describe('useImportJobs', () => {
       accessLevel: 'OWNER',
       canShare: true,
       canCompute: true,
+      policies: [],
     };
 
     it('returns list of jobs in workspace', () => {

--- a/src/workspaces/RequestAccessModal/RequestAccessModal.test.ts
+++ b/src/workspaces/RequestAccessModal/RequestAccessModal.test.ts
@@ -61,6 +61,7 @@ const googleWorkspace: GoogleWorkspace = {
     bucketName: 'test-bucket',
     lastModified: '',
   },
+  policies: [],
 };
 
 describe('RequestAccessModal', () => {

--- a/src/workspaces/ShareWorkspaceModal/Collaborator.test.ts
+++ b/src/workspaces/ShareWorkspaceModal/Collaborator.test.ts
@@ -5,6 +5,7 @@ import { getTerraUser } from 'src/libs/state';
 import { BaseWorkspace } from 'src/libs/workspace-utils';
 import { AccessEntry, WorkspaceAcl } from 'src/pages/workspaces/workspace/WorkspaceAcl';
 import { asMockedFn, renderWithAppContexts as render } from 'src/testing/test-utils';
+import { defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
 import { Collaborator } from 'src/workspaces/ShareWorkspaceModal/Collaborator';
 
 jest.mock('src/libs/state', () => ({
@@ -34,23 +35,7 @@ describe('a Collaborator component', () => {
     });
   });
 
-  const workspace: BaseWorkspace = {
-    accessLevel: 'OWNER',
-    canShare: true,
-    canCompute: true,
-    workspace: {
-      namespace: 'namespace',
-      name: 'name',
-      workspaceId: 'test-ws-id',
-      cloudPlatform: 'Gcp',
-      authorizationDomain: [],
-      createdDate: '',
-      createdBy: '',
-      googleProject: 'test-project',
-      bucketName: 'test-bucket',
-      lastModified: '',
-    },
-  };
+  const workspace: BaseWorkspace = defaultGoogleWorkspace;
 
   it('displays the email of the access item', () => {
     const item: AccessEntry = {

--- a/src/workspaces/ShareWorkspaceModal/ShareWorkspaceModal.test.ts
+++ b/src/workspaces/ShareWorkspaceModal/ShareWorkspaceModal.test.ts
@@ -27,23 +27,7 @@ describe('the share workspace modal', () => {
     });
   });
 
-  const workspace: GoogleWorkspace = {
-    accessLevel: 'PROJECT_OWNER',
-    canShare: true,
-    canCompute: true,
-    workspace: {
-      namespace: 'namespace',
-      name: 'name',
-      workspaceId: 'test-ws-id',
-      cloudPlatform: 'Gcp',
-      authorizationDomain: [],
-      createdDate: '',
-      createdBy: '',
-      googleProject: 'test-project',
-      bucketName: 'test-bucket',
-      lastModified: '',
-    },
-  };
+  const workspace: GoogleWorkspace = defaultGoogleWorkspace;
 
   const mockAjax = (
     acl: RawWorkspaceAcl,


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-1399

This bug was introduced about a [week ago](https://github.com/DataBiosphere/terra-ui/pull/4519). The issue is that the ShareWorkspace modal can be opened in two ways-- from the Workspace Dashboard, and from the Workspaces List. The properties populated on the workspace are not automatically consistent as a result of different Ajax calls being used (individual workspace details vs. workspaces list API), and thus `workspace.bucketName` was not being fetched in the list result.

I added `workspace.bucketName` to the properties requested in the list API call, as well as `policies` which had a special workaround for in the menu code.

I don't know a good way to add test coverage for this, outside of an integration test where we actually bring up the dialog from the list view (which is not attractive). I have manually tested opening all workspace menu options from both the list and dashboard view, for both an Azure and a GCP workspace.

![image](https://github.com/DataBiosphere/terra-ui/assets/484484/9fa9c938-dd70-4739-a70f-ad19684e6859)
