### PR TITLE
[ID-967] Removed unreachable code in oidc-broker

### DIFF
--- a/src/auth/oidc-broker.ts
+++ b/src/auth/oidc-broker.ts
@@ -108,17 +108,6 @@ export const oidcSignIn = async (args: OidcSignInArgs): Promise<OidcUser | null>
 export const revokeTokens = async (): Promise<void> => {
   // send back auth instance, so we can use it for remove and clear stale state
   const auth: AuthContextProps = getAuthInstance();
-  if (auth.settings.metadata?.revocation_endpoint) {
-    // revokeTokens can fail if the token has already been revoked.
-    // Recover from invalid_token errors to make sure signOut completes successfully.
-    try {
-      await auth.revokeTokens();
-    } catch (e: unknown) {
-      if ((e as any).error !== 'invalid_token') {
-        throw e;
-      }
-    }
-  }
   auth.removeUser();
   auth.clearStaleState();
 };


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/ID-967

### Related Tickets
https://broadworkbench.atlassian.net/browse/ID-928 was closed due to not having b2c support to revoke refresh tokens + no current business "need" to do so, however, it is likely that this will need revisiting. But in the meantime, we are removing confusing code leftover from when Google was out OAuth2 broker.

Revocation endpoint was added: https://github.com/DataBiosphere/terra-ui/pull/3117/files#diff-a4ba38b20453374fed28d8c26c28f5b20b486db965bbfd9c47032a9cb99c122c 

Revocation endpoint was removed: https://github.com/DataBiosphere/terra-ui/pull/4135/files#diff-e801232acea1d7f9dd68d112a2c6ed2da031ec77d195accc951a51cb98d05202 (was only for google)

## Summary of changes:
Removed code dependent on a nonexistent config field: `revocation_endpoint`, which is a holdover from when Google was out OAuth2 broker.

### Why
- Confusing for developers and removing it will make the sign out flow clearer.
