### PR TITLE
[WM-2341] Appcues flag for wait to refresh

### DIFF
--- a/src/libs/ajax/Metrics.ts
+++ b/src/libs/ajax/Metrics.ts
@@ -10,7 +10,11 @@ import { authStore, getSessionId, getTerraUser, MetricState, metricStore } from 
 import { v4 as uuid } from 'uuid';
 
 export const Metrics = (signal?: AbortSignal) => {
-  const captureEventFn = async (event: MetricsEventName, details: Record<string, any> = {}): Promise<void> => {
+  const captureEventFn = async (
+    event: MetricsEventName,
+    details: Record<string, any> = {},
+    refreshAppcues = true
+  ): Promise<void> => {
     await ensureAuthSettled();
     const metricState: MetricState = metricStore.get();
     const { signInStatus } = authStore.get();
@@ -27,7 +31,9 @@ export const Metrics = (signal?: AbortSignal) => {
 
     // Send event to Appcues and refresh Appcues state
     window.Appcues?.track(event);
-    window.Appcues?.page();
+    if (refreshAppcues) {
+      window.Appcues?.page();
+    }
 
     const { buildTimestamp, gitRevision, terraDeploymentEnv } = getConfig();
     const signedInProps =

--- a/src/libs/ajax/metrics/useMetrics.ts
+++ b/src/libs/ajax/metrics/useMetrics.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { Ajax } from 'src/libs/ajax';
 import { MetricsEventName } from 'src/libs/events';
 
-export type CaptureEventFn = (event: MetricsEventName, details?: Record<string, any>) => void;
+export type CaptureEventFn = (event: MetricsEventName, details?: Record<string, any>, refreshAppcues?: boolean) => void;
 
 export interface MetricsProvider {
   captureEvent: CaptureEventFn;
@@ -13,9 +13,9 @@ export const useMetricsEvent = (): MetricsProvider => {
   // By returning a wrapper function, we can handle the fire-and-forget promise mechanics properly here
   // instead of burdening the consumer side with silencing the Typescript/lint complaints, which can be
   // quite awkward in some nested functional uses.
-  const captureEvent: CaptureEventFn = (event, details): void => {
+  const captureEvent: CaptureEventFn = (event, details, refreshAppcues): void => {
     // fire and forget
-    void sendEvent(event, details);
+    void sendEvent(event, details, refreshAppcues);
   };
   return { captureEvent };
 };

--- a/src/workflows-app/FeaturedWorkflows.ts
+++ b/src/workflows-app/FeaturedWorkflows.ts
@@ -132,13 +132,17 @@ export const FeaturedWorkflows = ({
               cbasProxyUrlState: { state },
             } = await loadAppUrls(workspaceId, 'cbasProxyUrlState');
             const importMethod = (state, method) => {
-              captureEvent(Events.workflowsAppImport, {
-                ...extractWorkspaceDetails(workspace),
-                workflowSource: method.source,
-                workflowName: method.name,
-                workflowUrl: method.method_versions[0].url,
-                importPage: 'FeaturedWorkflows',
-              });
+              captureEvent(
+                Events.workflowsAppImport,
+                {
+                  ...extractWorkspaceDetails(workspace),
+                  workflowSource: method.source,
+                  workflowName: method.name,
+                  workflowUrl: method.method_versions[0].url,
+                  importPage: 'FeaturedWorkflows',
+                },
+                false
+              );
 
               return Cbas().methods.post(state, {
                 method_name: method.name,
@@ -260,7 +264,10 @@ export const FeaturedWorkflows = ({
       h(ImportWorkflowModal, {
         importLoading,
         methodName,
-        onDismiss: () => setImportWorkflowModal(false),
+        onDismiss: () => {
+          setImportWorkflowModal(false);
+          window.Appcues?.page();
+        },
         workspace,
         namespace,
         name,

--- a/src/workflows-app/RunDetails.test.js
+++ b/src/workflows-app/RunDetails.test.js
@@ -307,7 +307,7 @@ describe('BaseRunDetails - render smoke test', () => {
     const closeButton = screen.getByLabelText('Close modal');
     expect(captureEvent).not.toHaveBeenCalled();
     await user.click(closeButton);
-    expect(captureEvent).toHaveBeenCalledWith(Events.workflowsAppCloseLogViewer, undefined);
+    expect(captureEvent).toHaveBeenCalledWith(Events.workflowsAppCloseLogViewer, undefined, undefined);
   });
 
   it('opens the log viewer modal when Logs is clicked', async () => {

--- a/src/workflows-app/components/ImportGithub.js
+++ b/src/workflows-app/components/ImportGithub.js
@@ -112,13 +112,17 @@ const ImportGithub = ({ setLoading, signal, workspace, name, namespace, setSelec
                 method_url: methodUrl,
                 method_source: 'GitHub',
               };
-              captureEvent(Events.workflowsAppImport, {
-                ...extractWorkspaceDetails(workspace),
-                workflowSource: 'GitHub',
-                workflowName: methodName,
-                workflowUrl: methodUrl,
-                importPage: 'ImportGithub',
-              });
+              captureEvent(
+                Events.workflowsAppImport,
+                {
+                  ...extractWorkspaceDetails(workspace),
+                  workflowSource: 'GitHub',
+                  workflowName: methodName,
+                  workflowUrl: methodUrl,
+                  importPage: 'ImportGithub',
+                },
+                false
+              );
               withBusyState(setLoading, submitMethod(signal, method, workspace, onSuccess, onError));
             },
           },
@@ -130,7 +134,10 @@ const ImportGithub = ({ setLoading, signal, workspace, name, namespace, setSelec
       h(ImportWorkflowModal, {
         importLoading,
         methodName,
-        onDismiss: () => setImportWorkflowModal(false),
+        onDismiss: () => {
+          setImportWorkflowModal(false);
+          window.Appcues?.page();
+        },
         workspace,
         namespace,
         name,


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WM-2341

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Add optional refreshAppcues flag to captureEvent

### Why
- We don't always want to show new flows to users immediately after they've taken an event
- Ex: in workflows tab, we only want to show import flow to users after they have exited import modal

### Testing strategy
- <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 
