### PR TITLE
[WOR-1399] Follow-up to reduce the size of payload for list API.

### DIFF
--- a/src/pages/workspaces/WorkspacesList/RenderedWorkspaces.ts
+++ b/src/pages/workspaces/WorkspacesList/RenderedWorkspaces.ts
@@ -386,7 +386,7 @@ const ActionsCell = (props: ActionsCellProps): ReactNode => {
     // The workspaces from the list API have fewer properties to keep the payload as small as possible.
     const listWorkspace = getWorkspace(workspaceId);
     const extendedWorkspace = policies === undefined ? listWorkspace : { ...listWorkspace, policies };
-    if (!!bucketName && isGoogleWorkspace(extendedWorkspace)) {
+    if (bucketName !== undefined && isGoogleWorkspace(extendedWorkspace)) {
       extendedWorkspace.workspace.bucketName = bucketName;
     }
     return extendedWorkspace;

--- a/src/pages/workspaces/WorkspacesList/RenderedWorkspaces.ts
+++ b/src/pages/workspaces/WorkspacesList/RenderedWorkspaces.ts
@@ -22,8 +22,10 @@ import * as Utils from 'src/libs/utils';
 import {
   canRead,
   getCloudProviderFromWorkspace,
+  isGoogleWorkspace,
   workspaceAccessLevels,
   WorkspaceInfo,
+  WorkspacePolicy,
   WorkspaceWrapper as Workspace,
 } from 'src/libs/workspace-utils';
 import { WorkspaceMenu } from 'src/pages/workspaces/workspace/WorkspaceMenu';
@@ -380,11 +382,22 @@ const ActionsCell = (props: ActionsCellProps): ReactNode => {
     return null;
   }
   const getWorkspace = (id: string): Workspace => _.find({ workspace: { workspaceId: id } }, props.workspaces)!;
+  const extendWorkspace = (workspaceId: string, policies?: WorkspacePolicy[], bucketName?: string): Workspace => {
+    // The workspaces from the list API have fewer properties to keep the payload as small as possible.
+    const listWorkspace = getWorkspace(workspaceId);
+    const extendedWorkspace = policies === undefined ? listWorkspace : { ...listWorkspace, policies };
+    if (!!bucketName && isGoogleWorkspace(extendedWorkspace)) {
+      extendedWorkspace.workspace.bucketName = bucketName;
+    }
+    return extendedWorkspace;
+  };
 
-  const onClone = () => setUserActions({ cloningWorkspaceId: workspaceId });
+  const onClone = (policies, bucketName) =>
+    setUserActions({ cloningWorkspace: extendWorkspace(workspaceId, policies, bucketName) });
   const onDelete = () => setUserActions({ deletingWorkspaceId: workspaceId });
   const onLock = () => setUserActions({ lockingWorkspaceId: workspaceId });
-  const onShare = () => setUserActions({ sharingWorkspace: getWorkspace(workspaceId) });
+  const onShare = (policies, bucketName) =>
+    setUserActions({ sharingWorkspace: extendWorkspace(workspaceId, policies, bucketName) });
   const onLeave = () => setUserActions({ leavingWorkspaceId: workspaceId });
 
   return div({ style: { ...styles.tableCellContainer, paddingRight: 0 } }, [

--- a/src/pages/workspaces/WorkspacesList/WorkspaceUserActions.ts
+++ b/src/pages/workspaces/WorkspacesList/WorkspaceUserActions.ts
@@ -16,10 +16,10 @@ export interface WorkspaceUserActionsState {
 // TODO: these should be removed in favor of the modal manager once available
 export interface WorkspaceUserActions {
   creatingNewWorkspace: boolean;
-  cloningWorkspaceId?: string;
   deletingWorkspaceId?: string;
   lockingWorkspaceId?: string;
   leavingWorkspaceId?: string;
   requestingAccessWorkspaceId?: string;
   sharingWorkspace?: WorkspaceWrapper;
+  cloningWorkspace?: WorkspaceWrapper;
 }

--- a/src/pages/workspaces/WorkspacesList/WorkspacesListModals.ts
+++ b/src/pages/workspaces/WorkspacesList/WorkspacesListModals.ts
@@ -25,10 +25,10 @@ export const WorkspacesListModals = (props: WorkspacesListModalsProps): ReactNod
         onDismiss: () => setUserActions({ creatingNewWorkspace: false }),
         onSuccess: ({ namespace, name }) => goToPath('workspace-dashboard', { namespace, name }),
       }),
-    !!userActions.cloningWorkspaceId &&
+    !!userActions.cloningWorkspace &&
       h(NewWorkspaceModal, {
-        cloneWorkspace: getWorkspace(userActions.cloningWorkspaceId),
-        onDismiss: () => setUserActions({ cloningWorkspaceId: undefined }),
+        cloneWorkspace: userActions.cloningWorkspace,
+        onDismiss: () => setUserActions({ cloningWorkspace: undefined }),
         onSuccess: ({ namespace, name }) => goToPath('workspace-dashboard', { namespace, name }),
       }),
     !!userActions.deletingWorkspaceId &&

--- a/src/pages/workspaces/hooks/useWorkspacesWithSubmissionStats.ts
+++ b/src/pages/workspaces/hooks/useWorkspacesWithSubmissionStats.ts
@@ -22,12 +22,10 @@ export const useWorkspacesWithSubmissionStats = (): WorkspacesWithSubmissionStat
   } = useWorkspaces(
     [
       'accessLevel',
-      'policies', // Needed for ShareWorkspace modal on list view
       'public',
       'workspace.attributes.description',
       'workspace.attributes.tag:tags',
       'workspace.authorizationDomain',
-      'workspace.bucketName', // Needed for ShareWorkspace modal on list view
       'workspace.cloudPlatform',
       'workspace.createdBy',
       'workspace.lastModified',

--- a/src/pages/workspaces/workspace/WorkspaceMenu.ts
+++ b/src/pages/workspaces/workspace/WorkspaceMenu.ts
@@ -83,9 +83,9 @@ interface DynamicWorkspaceMenuContentProps {
 }
 
 /**
- * DynamicWorkspaceInfo is invoked when the name/namespace is passed instead of the dirived states.
- * This happens from the list component, which also needs the workspace policies for sharing the workspace.
- * So the onShare callback is wrapped here, and passed to LoadedWorkspaceMenuContent.
+ * DynamicWorkspaceInfo is invoked when the name/namespace is passed instead of the derived states.
+ * This happens from the list component, which also needs the workspace policies and bucketName for
+ * sharing and cloning the workspace.
  */
 const DynamicWorkspaceMenuContent = (props: DynamicWorkspaceMenuContentProps) => {
   const {

--- a/src/pages/workspaces/workspace/WorkspaceMenu.ts
+++ b/src/pages/workspaces/workspace/WorkspaceMenu.ts
@@ -97,6 +97,7 @@ const DynamicWorkspaceMenuContent = (props: DynamicWorkspaceMenuContentProps) =>
     'canShare',
     'policies',
     'workspace.bucketName',
+    'workspace.cloudPlatform',
     'workspace.isLocked',
     'workspace.state',
   ]) as { workspace?: Workspace };


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-1399.

Follow-up to address https://github.com/DataBiosphere/terra-ui/pull/4552#issuecomment-1846136120.

Puts back in the merging of `policy` and extends the same pattern for `bucketLocation`. Note that although WOR-1399 was created specifically for the share action, cloning from the WorkspaceList was also broken.