### PR TITLE
added session start metrics to metricStore

### DIFF
--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -145,11 +145,14 @@ export const signIn = async (includeBillingScope = false): Promise<OidcUser> => 
   authStore.update((state) => ({ ...state, userJustSignedIn: true }));
   const authTokenState: AuthTokenState = await loadAuthToken({ includeBillingScope, popUp: true });
   if (authTokenState.status === 'success') {
-    const sessionId = uuid();
-    const sessionStartTime: number = Date.now();
     authStore.update((state) => ({
       ...state,
       hasGcpBillingScopeThroughB2C: includeBillingScope,
+    }));
+    const sessionId = uuid();
+    const sessionStartTime: number = Date.now();
+    metricStore.update((state) => ({
+      ...state,
       sessionId,
       sessionStartTime,
     }));


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/ID-972

This is just a clean up from https://github.com/DataBiosphere/terra-ui/pull/4498 where props that were supposed to be in the metrics store did not get moved out of the authStore. This PR restores that functionality.

### Testing strategy
Manually tested on local, the sessionStartTime and sessionId were defined.
