### PR TITLE
[UIE-151] Show countdown to refresh for required update

### DIFF
--- a/src/alerts/RequiredUpdateAlert.test.ts
+++ b/src/alerts/RequiredUpdateAlert.test.ts
@@ -1,0 +1,39 @@
+import { h } from 'react-hyperscript-helpers';
+import { asMockedFn, renderWithAppContexts } from 'src/testing/test-utils';
+
+import { RequiredUpdateAlert } from './RequiredUpdateAlert';
+import { useTimeUntilRequiredUpdate } from './version-alerts';
+
+type VersionAlertsExports = typeof import('./version-alerts');
+jest.mock('./version-alerts', (): VersionAlertsExports => {
+  return {
+    ...jest.requireActual<VersionAlertsExports>('./version-alerts'),
+    useTimeUntilRequiredUpdate: jest.fn(),
+  };
+});
+
+describe('RequiredUpdateAlert', () => {
+  it('renders nothing if no update is required', () => {
+    // Arrange
+    asMockedFn(useTimeUntilRequiredUpdate).mockReturnValue(undefined);
+
+    // Act
+    const { container } = renderWithAppContexts(h(RequiredUpdateAlert));
+
+    // Assert
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders time until required update', () => {
+    // Arrange
+    asMockedFn(useTimeUntilRequiredUpdate).mockReturnValue(90);
+
+    // Act
+    const { container } = renderWithAppContexts(h(RequiredUpdateAlert));
+
+    // Assert
+    expect(container).toHaveTextContent(
+      'A required update is available. Terra will automatically refresh your browser in 1 minute 30 seconds.'
+    );
+  });
+});

--- a/src/alerts/RequiredUpdateAlert.ts
+++ b/src/alerts/RequiredUpdateAlert.ts
@@ -1,0 +1,46 @@
+import { icon, useThemeFromContext } from '@terra-ui-packages/components';
+import { formatDuration } from 'date-fns';
+import { ReactNode } from 'react';
+import { div, span } from 'react-hyperscript-helpers';
+
+import { useTimeUntilRequiredUpdate } from './version-alerts';
+
+export const RequiredUpdateAlert = (): ReactNode => {
+  const { colors } = useThemeFromContext();
+
+  const timeUntilRequiredUpdate = useTimeUntilRequiredUpdate();
+
+  if (timeUntilRequiredUpdate === undefined) {
+    return null;
+  }
+
+  const minutesRemaining = Math.floor(timeUntilRequiredUpdate / 60);
+  const secondsRemaining = timeUntilRequiredUpdate % 60;
+
+  return div(
+    {
+      role: 'alert',
+      style: {
+        display: 'flex',
+        alignItems: 'center',
+        padding: '1rem 1.25rem',
+        border: `2px solid ${colors.warning()}`,
+        backgroundColor: colors.warning(0.15),
+        color: colors.dark(),
+        fontWeight: 'bold',
+        fontSize: 12,
+      },
+    },
+    [
+      icon('warning-standard', { size: 26, color: colors.warning(), style: { marginRight: '1ch' } }),
+      'A required update is available. Terra will automatically refresh your browser in ',
+      span({ role: 'timer', style: { marginLeft: '0.5ch' } }, [
+        formatDuration({
+          minutes: minutesRemaining,
+          seconds: secondsRemaining,
+        }),
+      ]),
+      '.',
+    ]
+  );
+};

--- a/src/alerts/RequiredUpdateAlert.ts
+++ b/src/alerts/RequiredUpdateAlert.ts
@@ -1,7 +1,7 @@
 import { icon, useThemeFromContext } from '@terra-ui-packages/components';
 import { formatDuration } from 'date-fns';
-import { ReactNode } from 'react';
-import { div, span } from 'react-hyperscript-helpers';
+import { Fragment, ReactNode } from 'react';
+import { div, h, span } from 'react-hyperscript-helpers';
 
 import { useTimeUntilRequiredUpdate } from './version-alerts';
 
@@ -33,13 +33,18 @@ export const RequiredUpdateAlert = (): ReactNode => {
     },
     [
       icon('warning-standard', { size: 26, color: colors.warning(), style: { marginRight: '1ch' } }),
-      'A required update is available. Terra will automatically refresh your browser in ',
-      span({ role: 'timer', style: { marginLeft: '0.5ch' } }, [
-        formatDuration({
-          minutes: minutesRemaining,
-          seconds: secondsRemaining,
-        }),
-      ]),
+      'A required update is available. Terra will automatically refresh your browser ',
+      timeUntilRequiredUpdate > 0
+        ? h(Fragment, [
+            'in ',
+            span({ role: 'timer', style: { marginLeft: '0.5ch' } }, [
+              formatDuration({
+                minutes: minutesRemaining,
+                seconds: secondsRemaining,
+              }),
+            ]),
+          ])
+        : 'now',
       '.',
     ]
   );

--- a/src/alerts/version-alerts.test.ts
+++ b/src/alerts/version-alerts.test.ts
@@ -119,25 +119,27 @@ describe('useTimeUntilRequiredUpdate', () => {
     'returns time until required update',
     withFakeTimers(() => {
       // Arrange
+      const initialTime = 1706504400000;
+      const timeUntilUpdateInSeconds = 60;
       versionStore.set({
         currentVersion: 'abcd123',
         latestVersion: '1234567',
-        updateRequiredBy: 1702396702141,
+        updateRequiredBy: initialTime + timeUntilUpdateInSeconds * 1000,
       });
 
-      jest.setSystemTime(1702396642141);
+      jest.setSystemTime(initialTime);
 
       // Act
       const { result: hookReturnRef } = renderHook(() => useTimeUntilRequiredUpdate());
 
       // Assert
-      expect(hookReturnRef.current).toBe(60);
+      expect(hookReturnRef.current).toBe(timeUntilUpdateInSeconds);
 
       // Act
-      act(() => jest.advanceTimersByTime(30000));
+      act(() => jest.advanceTimersByTime((timeUntilUpdateInSeconds / 2) * 1000));
 
       // Assert
-      expect(hookReturnRef.current).toBe(30);
+      expect(hookReturnRef.current).toBe(timeUntilUpdateInSeconds / 2);
     })
   );
 
@@ -145,17 +147,19 @@ describe('useTimeUntilRequiredUpdate', () => {
     'reloads browser when time until required update elapses',
     withFakeTimers(() => {
       // Arrange
+      const initialTime = 1706504400000;
+      const timeUntilUpdate = 60000;
       versionStore.set({
         currentVersion: 'abcd123',
         latestVersion: '1234567',
-        updateRequiredBy: 1702396702141,
+        updateRequiredBy: initialTime + timeUntilUpdate,
       });
 
-      jest.setSystemTime(1702396642141);
+      jest.setSystemTime(initialTime);
 
       // Act
       renderHook(() => useTimeUntilRequiredUpdate());
-      act(() => jest.advanceTimersByTime(60000));
+      act(() => jest.advanceTimersByTime(timeUntilUpdate));
 
       // Assert
       expect(window.location.reload).toHaveBeenCalled();

--- a/src/alerts/version-alerts.test.ts
+++ b/src/alerts/version-alerts.test.ts
@@ -116,6 +116,36 @@ describe('useTimeUntilRequiredUpdate', () => {
   });
 
   it(
+    'rerenders when version store is updated',
+    withFakeTimers(() => {
+      // Arrange
+      versionStore.set({
+        currentVersion: 'abcd123',
+        latestVersion: '1234567',
+        updateRequiredBy: undefined,
+      });
+
+      const initialTime = 1706504400000;
+      jest.setSystemTime(initialTime);
+
+      const { result: hookReturnRef } = renderHook(() => useTimeUntilRequiredUpdate());
+
+      // Act
+      const updateIntervalInSeconds = 300;
+      act(() => {
+        versionStore.set({
+          currentVersion: 'abcd123',
+          latestVersion: '1234567',
+          updateRequiredBy: initialTime + updateIntervalInSeconds * 1000,
+        });
+      });
+
+      // Assert
+      expect(hookReturnRef.current).toBe(updateIntervalInSeconds);
+    })
+  );
+
+  it(
     'returns time until required update',
     withFakeTimers(() => {
       // Arrange

--- a/src/alerts/version-alerts.ts
+++ b/src/alerts/version-alerts.ts
@@ -85,5 +85,13 @@ export const useTimeUntilRequiredUpdate = (): number | undefined => {
     }
   }, [updateRequiredBy, updateTimeRemaining]);
 
+  useEffect(() => {
+    return () => {
+      if (countdownInterval.current) {
+        clearInterval(countdownInterval.current);
+      }
+    };
+  }, []);
+
   return timeRemaining;
 };

--- a/src/alerts/version-alerts.ts
+++ b/src/alerts/version-alerts.ts
@@ -60,11 +60,11 @@ export const useTimeUntilRequiredUpdate = (): number | undefined => {
   const { updateRequiredBy } = useStore(versionStore);
 
   const [timeRemaining, setTimeRemaining] = useState(
-    updateRequiredBy ? Math.floor((updateRequiredBy - Date.now()) / 1000) : undefined
+    updateRequiredBy ? Math.ceil((updateRequiredBy - Date.now()) / 1000) : undefined
   );
   const updateTimeRemaining = useCallback(() => {
     if (updateRequiredBy) {
-      const timeRemaining = Math.floor((updateRequiredBy - Date.now()) / 1000);
+      const timeRemaining = Math.ceil((updateRequiredBy - Date.now()) / 1000);
       if (timeRemaining <= 0) {
         window.location.reload();
       }
@@ -77,6 +77,7 @@ export const useTimeUntilRequiredUpdate = (): number | undefined => {
 
   const countdownInterval = useRef<number>();
   useEffect(() => {
+    updateTimeRemaining();
     if (updateRequiredBy && !countdownInterval.current) {
       countdownInterval.current = window.setInterval(updateTimeRemaining, 1000);
     } else if (!updateRequiredBy && countdownInterval.current) {

--- a/src/alerts/version-polling.test.ts
+++ b/src/alerts/version-polling.test.ts
@@ -1,7 +1,7 @@
 import { asMockedFn, withFakeTimers } from '@terra-ui-packages/test-utils';
 
 import { getBadVersions, getLatestVersion, versionStore } from './version-alerts';
-import { checkVersion, startPollingVersion, VERSION_POLLING_INTERVAL } from './version-polling';
+import { checkVersion, FORCED_UPDATE_DELAY, startPollingVersion, VERSION_POLLING_INTERVAL } from './version-polling';
 
 type VersionAlertsExports = typeof import('./version-alerts');
 jest.mock(
@@ -48,7 +48,8 @@ describe('checkVersion', () => {
       'sets update required time if current version is bad',
       withFakeTimers(async () => {
         // Arrange
-        jest.setSystemTime(1702396702141);
+        const initialTime = 1706504400000;
+        jest.setSystemTime(initialTime);
         asMockedFn(getBadVersions).mockResolvedValue(['abcd123']);
 
         // Act
@@ -56,7 +57,7 @@ describe('checkVersion', () => {
 
         // Assert
         const { updateRequiredBy } = versionStore.get();
-        expect(updateRequiredBy).toBe(1702396822141);
+        expect(updateRequiredBy).toBe(initialTime + FORCED_UPDATE_DELAY);
       })
     );
   });

--- a/src/alerts/version-polling.test.ts
+++ b/src/alerts/version-polling.test.ts
@@ -60,6 +60,29 @@ describe('checkVersion', () => {
         expect(updateRequiredBy).toBe(initialTime + FORCED_UPDATE_DELAY);
       })
     );
+
+    it(
+      'does not overwrite update required time on subsequent checks',
+      withFakeTimers(async () => {
+        // Arrange
+        const initialTime = 1706504400000;
+        jest.setSystemTime(initialTime);
+        asMockedFn(getBadVersions).mockResolvedValue(['abcd123']);
+
+        await checkVersion();
+
+        const { updateRequiredBy: updateRequiredByAfterFirstPoll } = versionStore.get();
+        expect(updateRequiredByAfterFirstPoll).toBe(initialTime + FORCED_UPDATE_DELAY);
+
+        // Act
+        jest.advanceTimersByTime(VERSION_POLLING_INTERVAL);
+        await checkVersion();
+
+        // Assert
+        const { updateRequiredBy: updateRequiredByAfterSecondPoll } = versionStore.get();
+        expect(updateRequiredByAfterSecondPoll).toBe(updateRequiredByAfterFirstPoll);
+      })
+    );
   });
 });
 

--- a/src/alerts/version-polling.ts
+++ b/src/alerts/version-polling.ts
@@ -15,7 +15,11 @@ export const checkVersion = withErrorIgnoring(async (): Promise<void> => {
   if (latestVersion !== currentVersion) {
     const badVersions = await getBadVersions();
     if (badVersions.includes(currentVersion)) {
-      versionStore.update((value) => ({ ...value, updateRequiredBy: Date.now() + FORCED_UPDATE_DELAY }));
+      versionStore.update((value) => ({
+        ...value,
+        updateRequiredBy:
+          value.updateRequiredBy === undefined ? Date.now() + FORCED_UPDATE_DELAY : value.updateRequiredBy,
+      }));
     }
   }
 });

--- a/src/alerts/version-polling.ts
+++ b/src/alerts/version-polling.ts
@@ -4,6 +4,8 @@ import { getBadVersions, getLatestVersion, versionStore } from './version-alerts
 
 export const VERSION_POLLING_INTERVAL = 15 * 60 * 1000; // 15 minutes
 
+export const FORCED_UPDATE_DELAY = 2 * 60 * 1000; // 2 minutes
+
 export const checkVersion = withErrorIgnoring(async (): Promise<void> => {
   const { currentVersion } = versionStore.get();
 
@@ -13,7 +15,7 @@ export const checkVersion = withErrorIgnoring(async (): Promise<void> => {
   if (latestVersion !== currentVersion) {
     const badVersions = await getBadVersions();
     if (badVersions.includes(currentVersion)) {
-      versionStore.update((value) => ({ ...value, isUpdateRequired: true }));
+      versionStore.update((value) => ({ ...value, updateRequiredBy: Date.now() + FORCED_UPDATE_DELAY }));
     }
   }
 });

--- a/src/alerts/version-polling.ts
+++ b/src/alerts/version-polling.ts
@@ -4,7 +4,7 @@ import { getBadVersions, getLatestVersion, versionStore } from './version-alerts
 
 export const VERSION_POLLING_INTERVAL = 15 * 60 * 1000; // 15 minutes
 
-export const FORCED_UPDATE_DELAY = 2 * 60 * 1000; // 2 minutes
+export const FORCED_UPDATE_DELAY = 10 * 60 * 1000; // 10 minutes
 
 export const checkVersion = withErrorIgnoring(async (): Promise<void> => {
   const { currentVersion } = versionStore.get();

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -5,6 +5,7 @@ import { UnmountClosed as RCollapse } from 'react-collapse';
 import { a, div, h, h1, img, span } from 'react-hyperscript-helpers';
 import { Transition } from 'react-transition-group';
 import { AlertsIndicator } from 'src/alerts/Alerts';
+import { RequiredUpdateAlert } from 'src/alerts/RequiredUpdateAlert';
 import { signIn, signOut } from 'src/auth/auth';
 import { Clickable, IdContainer, LabeledCheckbox, Link, spinnerOverlay } from 'src/components/common';
 import { icon } from 'src/components/icons';
@@ -625,6 +626,7 @@ const TopBar = ({ showMenu = true, title, href, children }) => {
           ),
         ]
       ),
+      h(RequiredUpdateAlert),
       h(SkipNavTarget, { ref: mainRef }),
     ]
   );


### PR DESCRIPTION
Stacked on #4544

Building on #4544 and based on feedback on that PR, once the current version has been determined to be "bad", show a countdown before automatically refreshing the browser.

The following screen recording uses shorter polling / update intervals for demo purposes. The UI detects a new version is available ~4s in and detects that the current version is bad ~10s in.

https://github.com/DataBiosphere/terra-ui/assets/1156625/e90380e9-6614-4113-a935-a50c19b0a4fe



## Testing

1. Reduce the `VERSION_POLLING_INTERVAL` in src/alerts/version-polling.ts. It's set to 15 minutes, which is too long for testing.
2. Start a local dev server with `yarn start`.
3. Open public/build-info.json in a text editor. Copy the value of `gitRevision`, which contains the current version of Terra UI.
4. Edit the value of `gitRevision` and save build-info.json. This imitates a new version being deployed. You should see a notification that a new version is available.
5. Mock bad-versions.txt to declare that the current version is "bad".
  ```js
  window.ajaxOverridesStore.set([
    {
      filter: { url: /bad-versions.txt/ },
      fn: () => () => Promise.resolve(new Response('<version from step 3>'))
    }
  ])
  ```