### PR TITLE
[WOR-1414] Re-enable the test case.

### DIFF
--- a/src/pages/workspaces/workspace/Dashboard/WorkspaceDescription.test.ts
+++ b/src/pages/workspaces/workspace/Dashboard/WorkspaceDescription.test.ts
@@ -124,7 +124,7 @@ describe('WorkspaceDescription', () => {
     );
   });
 
-  xit('saves the description when the button is pressed', async () => {
+  it('saves the description when the button is pressed', async () => {
     // Arrange
     const user = userEvent.setup();
     asMockedFn(canEditWorkspace).mockReturnValue({ value: true });
@@ -154,13 +154,12 @@ describe('WorkspaceDescription', () => {
     const editButton = screen.getByLabelText('Edit description');
     await user.click(editButton);
 
-    await act(() => {
+    act(() => {
       onChange(newDescription);
     });
     const saveButton = screen.getByText('Save');
-    await act(async () => {
-      await user.click(saveButton);
-    });
+    await user.click(saveButton);
+
     // Assert
     expect(mockShallowMergeNewAttributes).toHaveBeenCalledWith({ description: newDescription });
   });


### PR DESCRIPTION
This is a follow-up PR from https://github.com/DataBiosphere/terra-ui/pull/4561.

@blakery was having trouble getting the unit test to pass. Using `act` is tricky because if you use it in places where you DON'T need it, you get very unclear errors.