### PR TITLE
AJ-1449 - Ensure full description is seen when cloning from workspace list view

### DIFF
--- a/src/pages/workspaces/WorkspacesList/RenderedWorkspaces.ts
+++ b/src/pages/workspaces/WorkspacesList/RenderedWorkspaces.ts
@@ -382,18 +382,27 @@ const ActionsCell = (props: ActionsCellProps): ReactNode => {
     return null;
   }
   const getWorkspace = (id: string): Workspace => _.find({ workspace: { workspaceId: id } }, props.workspaces)!;
-  const extendWorkspace = (workspaceId: string, policies?: WorkspacePolicy[], bucketName?: string): Workspace => {
+  const extendWorkspace = (
+    workspaceId: string,
+    policies?: WorkspacePolicy[],
+    bucketName?: string,
+    description?: string
+  ): Workspace => {
     // The workspaces from the list API have fewer properties to keep the payload as small as possible.
     const listWorkspace = getWorkspace(workspaceId);
     const extendedWorkspace = policies === undefined ? listWorkspace : { ...listWorkspace, policies };
     if (bucketName !== undefined && isGoogleWorkspace(extendedWorkspace)) {
       extendedWorkspace.workspace.bucketName = bucketName;
     }
+
+    if (description !== undefined) {
+      extendedWorkspace.workspace.attributes.description = description;
+    }
     return extendedWorkspace;
   };
 
-  const onClone = (policies, bucketName) =>
-    setUserActions({ cloningWorkspace: extendWorkspace(workspaceId, policies, bucketName) });
+  const onClone = (policies, bucketName, description) =>
+    setUserActions({ cloningWorkspace: extendWorkspace(workspaceId, policies, bucketName, description) });
   const onDelete = () => setUserActions({ deletingWorkspaceId: workspaceId });
   const onLock = () => setUserActions({ lockingWorkspaceId: workspaceId });
   const onShare = (policies, bucketName) =>

--- a/src/pages/workspaces/WorkspacesList/RenderedWorkspaces.ts
+++ b/src/pages/workspaces/WorkspacesList/RenderedWorkspaces.ts
@@ -395,7 +395,7 @@ const ActionsCell = (props: ActionsCellProps): ReactNode => {
       extendedWorkspace.workspace.bucketName = bucketName;
     }
 
-    if (description !== undefined) {
+    if (description !== undefined && extendedWorkspace.workspace.attributes !== undefined) {
       extendedWorkspace.workspace.attributes.description = description;
     }
     return extendedWorkspace;

--- a/src/pages/workspaces/workspace/WorkspaceMenu.test.ts
+++ b/src/pages/workspaces/workspace/WorkspaceMenu.test.ts
@@ -434,7 +434,7 @@ describe('DynamicWorkspaceMenuContent fetches specific workspace details', () =>
     expect(workspaceDetails).toHaveBeenCalledWith({ namespace, name }, expectedRequestedFields);
   });
 
-  it('passes onClone the bucketName for a Google workspace', async () => {
+  it('passes onClone the bucketName and decription for a Google workspace', async () => {
     // Arrange
     const user = userEvent.setup();
     asMockedFn(useWorkspaceDetails).mockReturnValue({
@@ -453,7 +453,7 @@ describe('DynamicWorkspaceMenuContent fetches specific workspace details', () =>
     expect(onClone).toBeCalledWith([], 'fc-bucketname', descriptionText);
   });
 
-  it('passes onClone the policies for an Azure workspace', async () => {
+  it('passes onClone the policies and description for an Azure workspace', async () => {
     // Arrange
     const user = userEvent.setup();
     asMockedFn(useWorkspaceDetails).mockReturnValue({

--- a/src/pages/workspaces/workspace/WorkspaceMenu.test.ts
+++ b/src/pages/workspaces/workspace/WorkspaceMenu.test.ts
@@ -434,7 +434,7 @@ describe('DynamicWorkspaceMenuContent fetches specific workspace details', () =>
     expect(workspaceDetails).toHaveBeenCalledWith({ namespace, name }, expectedRequestedFields);
   });
 
-  it('passes onClone the bucketName and decription for a Google workspace', async () => {
+  it('passes onClone the bucketName and description for a Google workspace', async () => {
     // Arrange
     const user = userEvent.setup();
     asMockedFn(useWorkspaceDetails).mockReturnValue({

--- a/src/pages/workspaces/workspace/WorkspaceMenu.test.ts
+++ b/src/pages/workspaces/workspace/WorkspaceMenu.test.ts
@@ -450,7 +450,7 @@ describe('DynamicWorkspaceMenuContent fetches specific workspace details', () =>
     // Assert
     const menuItem = screen.getByText('Clone');
     await user.click(menuItem);
-    expect(onClone).toBeCalledWith([], 'fc-bucketname');
+    expect(onClone).toBeCalledWith([], 'fc-bucketname', descriptionText);
   });
 
   it('passes onClone the policies for an Azure workspace', async () => {
@@ -469,7 +469,7 @@ describe('DynamicWorkspaceMenuContent fetches specific workspace details', () =>
     // Assert
     const menuItem = screen.getByText('Clone');
     await user.click(menuItem);
-    expect(onClone).toBeCalledWith([protectedDataPolicy], undefined);
+    expect(onClone).toBeCalledWith([protectedDataPolicy], undefined, descriptionText);
   });
 
   it('passes onShare the bucketName for a Google workspace', async () => {
@@ -508,24 +508,5 @@ describe('DynamicWorkspaceMenuContent fetches specific workspace details', () =>
     const menuItem = screen.getByText('Share');
     await user.click(menuItem);
     expect(onShare).toBeCalledWith([protectedDataPolicy], undefined);
-  });
-
-  it('passes onShare the workspace description for a Google workspace', async () => {
-    // Arrange
-    const user = userEvent.setup();
-    asMockedFn(useWorkspaceDetails).mockReturnValue({
-      // @ts-expect-error - the type checker thinks workspace is only of type undefined
-      workspace: googleWorkspace,
-      refresh: jest.fn(),
-      loading: false,
-    });
-
-    // Act
-    render(h(WorkspaceMenu, workspaceMenuProps));
-
-    // Assert
-    const menuItem = screen.getByText('Share');
-    await user.click(menuItem);
-    expect(onShare).toBeCalledWith([], 'fc-bucketname', descriptionText);
   });
 });

--- a/src/pages/workspaces/workspace/WorkspaceMenu.ts
+++ b/src/pages/workspaces/workspace/WorkspaceMenu.ts
@@ -28,7 +28,7 @@ type DynamicWorkspaceInfo = { name: string; namespace: string };
 type WorkspaceInfo = DynamicWorkspaceInfo | LoadedWorkspaceInfo;
 
 interface WorkspaceMenuCallbacks {
-  onClone: (policies?: WorkspacePolicy[], bucketName?: string) => void;
+  onClone: (policies?: WorkspacePolicy[], bucketName?: string, description?: string) => void;
   onShare: (policies?: WorkspacePolicy[], bucketName?: string) => void;
   onLock: () => void;
   onDelete: () => void;
@@ -85,7 +85,7 @@ interface DynamicWorkspaceMenuContentProps {
 /**
  * DynamicWorkspaceInfo is invoked when the name/namespace is passed instead of the derived states.
  * This happens from the list component, which also needs the workspace policies and bucketName for
- * sharing and cloning the workspace.
+ * sharing and cloning the workspace. This is also leveraged to pass the full decription during cloning as well.
  */
 const DynamicWorkspaceMenuContent = (props: DynamicWorkspaceMenuContentProps) => {
   const {
@@ -97,6 +97,7 @@ const DynamicWorkspaceMenuContent = (props: DynamicWorkspaceMenuContentProps) =>
     'canShare',
     'policies',
     'workspace.bucketName',
+    'workspace.attributes.description',
     'workspace.cloudPlatform',
     'workspace.isLocked',
     'workspace.state',
@@ -113,11 +114,11 @@ const DynamicWorkspaceMenuContent = (props: DynamicWorkspaceMenuContentProps) =>
     },
     // The list component doesn't fetch all the workspace details in order to keep the size of returned payload
     // as small as possible, so we need to pass policies and bucketName for use by the ShareWorkspaceModal
-    // and NewWorkspaceModal (cloning). The dashboard component already has the fields, so it will ignore them.
+    // and NewWorkspaceModal (cloning, this will include the full description). The dashboard component already has the fields, so it will ignore them.
     callbacks: {
       ...callbacks,
       onShare: () => callbacks.onShare(workspace?.policies, bucketName),
-      onClone: () => callbacks.onClone(workspace?.policies, bucketName),
+      onClone: () => callbacks.onClone(workspace?.policies, bucketName, workspace?.workspace?.attributes?.description),
     },
   });
 };

--- a/src/pages/workspaces/workspace/WorkspaceMenu.ts
+++ b/src/pages/workspaces/workspace/WorkspaceMenu.ts
@@ -104,6 +104,11 @@ const DynamicWorkspaceMenuContent = (props: DynamicWorkspaceMenuContentProps) =>
   ]) as { workspace?: Workspace };
   const bucketName = !!workspace && isGoogleWorkspace(workspace) ? workspace.workspace.bucketName : undefined;
 
+  const descriptionText =
+    !!workspace && workspace.workspace.attributes !== undefined
+      ? (workspace.workspace.attributes.description as string)
+      : undefined;
+
   return h(LoadedWorkspaceMenuContent, {
     workspaceInfo: {
       state: workspace?.workspace?.state,
@@ -118,7 +123,7 @@ const DynamicWorkspaceMenuContent = (props: DynamicWorkspaceMenuContentProps) =>
     callbacks: {
       ...callbacks,
       onShare: () => callbacks.onShare(workspace?.policies, bucketName),
-      onClone: () => callbacks.onClone(workspace?.policies, bucketName, workspace?.workspace?.attributes?.description),
+      onClone: () => callbacks.onClone(workspace?.policies, bucketName, descriptionText),
     },
   });
 };


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/AJ-1449

## Summary of changes:
Propagate full description (not just 250 chars) to the cloning modal when loaded from workspace list view. https://github.com/DataBiosphere/terra-ui/pull/4556/files used for reference. 


### Testing strategy
-Create a workspace that has a description of larger then 250 chars, ensure that when cloning from workspace list view, the whole description is propagated to the new workspace (not making any description changes before pushing clone)

<!-- ### Visual Aids -->
The text used to be cut off at 250 chars, but now you can see it in full
![image](https://github.com/DataBiosphere/terra-ui/assets/9418602/a9283135-b51a-4a44-b17f-b07a9fd8e229)

