### PR TITLE
[WOR-794, WOR-1343] Switch to virtualized select to handle large numbers of projects or workspaces

### DIFF
--- a/src/components/RequesterPaysModal.js
+++ b/src/components/RequesterPaysModal.js
@@ -1,7 +1,7 @@
 import * as _ from 'lodash/fp';
 import { Fragment, useState } from 'react';
 import { div, h } from 'react-hyperscript-helpers';
-import { ButtonPrimary, IdContainer, Link, Select, spinnerOverlay } from 'src/components/common';
+import { ButtonPrimary, IdContainer, Link, spinnerOverlay, VirtualizedSelect } from 'src/components/common';
 import { icon } from 'src/components/icons';
 import Modal from 'src/components/Modal';
 import { FormLabel } from 'src/libs/forms';
@@ -72,7 +72,7 @@ const RequesterPaysModal = ({ onDismiss, onSuccess }) => {
               (id) =>
                 h(Fragment, [
                   h(FormLabel, { htmlFor: id, required: true }, ['Workspace']),
-                  h(Select, {
+                  h(VirtualizedSelect, {
                     id,
                     isClearable: false,
                     value: selectedGoogleProject,

--- a/src/pages/billing/CreateGCPBillingProject.ts
+++ b/src/pages/billing/CreateGCPBillingProject.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp';
 import { Fragment, useState } from 'react';
 import { div, h } from 'react-hyperscript-helpers';
-import { IdContainer, Select } from 'src/components/common';
+import { IdContainer, VirtualizedSelect } from 'src/components/common';
 import { ValidatedInput } from 'src/components/input';
 import { Ajax } from 'src/libs/ajax';
 import Events from 'src/libs/events';
@@ -11,7 +11,7 @@ import { billingProjectNameValidator } from 'src/pages/billing/billing-utils';
 import { GoogleBillingAccount } from 'src/pages/billing/models/GoogleBillingAccount';
 import validate from 'validate.js';
 
-const BillingAccountSelect = Select as typeof Select<GoogleBillingAccount>;
+const BillingAccountSelect = VirtualizedSelect as typeof VirtualizedSelect<GoogleBillingAccount>;
 
 interface CreateGCPBillingProjectProps {
   billingAccounts: Record<string, GoogleBillingAccount>;

--- a/src/pages/billing/CreateGCPBillingProject.ts
+++ b/src/pages/billing/CreateGCPBillingProject.ts
@@ -11,8 +11,6 @@ import { billingProjectNameValidator } from 'src/pages/billing/billing-utils';
 import { GoogleBillingAccount } from 'src/pages/billing/models/GoogleBillingAccount';
 import validate from 'validate.js';
 
-const BillingAccountSelect = VirtualizedSelect as typeof VirtualizedSelect<GoogleBillingAccount>;
-
 interface CreateGCPBillingProjectProps {
   billingAccounts: Record<string, GoogleBillingAccount>;
   chosenBillingAccount?: GoogleBillingAccount;
@@ -66,7 +64,7 @@ const CreateGCPBillingProject = ({
         h(Fragment, [
           h(FormLabel, { htmlFor: id, required: true }, ['Select billing account']),
           div({ style: { fontSize: 14 } }, [
-            h(BillingAccountSelect, {
+            h(VirtualizedSelect, {
               id,
               isMulti: false,
               placeholder: 'Select a billing account',

--- a/src/pages/billing/Project.js
+++ b/src/pages/billing/Project.js
@@ -4,7 +4,7 @@ import { Fragment, useEffect, useMemo, useState } from 'react';
 import { div, h, p, span } from 'react-hyperscript-helpers';
 import { cloudProviders } from 'src/analysis/utils/runtime-utils';
 import * as Auth from 'src/auth/auth';
-import { ButtonPrimary, customSpinnerOverlay, IdContainer, Link, Select } from 'src/components/common';
+import { ButtonPrimary, customSpinnerOverlay, IdContainer, Link, VirtualizedSelect } from 'src/components/common';
 import { DeleteUserModal, EditUserModal, MemberCard, MemberCardHeaders, NewUserCard, NewUserModal } from 'src/components/group-common';
 import { icon } from 'src/components/icons';
 import { InfoBox } from 'src/components/InfoBox';
@@ -362,7 +362,7 @@ const GcpBillingAccountControls = ({
                 (id) =>
                   h(Fragment, [
                     h(FormLabel, { htmlFor: id, required: true }, ['Select billing account']),
-                    h(Select, {
+                    h(VirtualizedSelect, {
                       id,
                       value: selectedBilling || billingProject.billingAccount,
                       isClearable: false,

--- a/src/workspace-data/upload-data/UploadData.js
+++ b/src/workspace-data/upload-data/UploadData.js
@@ -2,7 +2,7 @@ import { readFileAsText } from '@terra-ui-packages/core-utils';
 import _ from 'lodash/fp';
 import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
 import { code, div, h, h2, h3, li, p, span, strong, ul } from 'react-hyperscript-helpers';
-import { ButtonPrimary, Link, Select, topSpinnerOverlay, transparentSpinnerOverlay } from 'src/components/common';
+import { ButtonPrimary, Link, topSpinnerOverlay, transparentSpinnerOverlay, VirtualizedSelect } from 'src/components/common';
 import FileBrowser from 'src/components/data/FileBrowser';
 import Dropzone from 'src/components/Dropzone';
 import FloatingActionButton from 'src/components/FloatingActionButton';
@@ -262,7 +262,7 @@ const WorkspaceSelectorPanel = ({ workspaces, selectedWorkspaceId, setWorkspaceI
         }),
       ]),
       div({ style: styles.filter }, [
-        h(Select, {
+        h(VirtualizedSelect, {
           isClearable: true,
           isMulti: false,
           placeholder: 'Billing project',

--- a/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.ts
+++ b/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.ts
@@ -4,7 +4,15 @@ import { CSSProperties, Fragment, ReactNode, useState } from 'react';
 import { div, h, label, p, strong } from 'react-hyperscript-helpers';
 import { defaultLocation } from 'src/analysis/utils/runtime-utils';
 import { CloudProviderIcon } from 'src/components/CloudProviderIcon';
-import { ButtonPrimary, IdContainer, LabeledCheckbox, Link, Select, spinnerOverlay } from 'src/components/common';
+import {
+  ButtonPrimary,
+  IdContainer,
+  LabeledCheckbox,
+  Link,
+  Select,
+  spinnerOverlay,
+  VirtualizedSelect,
+} from 'src/components/common';
 import { icon } from 'src/components/icons';
 import { InfoBox } from 'src/components/InfoBox';
 import { TextArea, ValidatedInput } from 'src/components/input';
@@ -454,7 +462,7 @@ const NewWorkspaceModal = withDisplayName(
                       (id) =>
                         h(Fragment, [
                           h(FormLabel, { htmlFor: id, required: true }, ['Billing project']),
-                          h(Select as typeof Select<string>, {
+                          h(VirtualizedSelect, {
                             id,
                             isClearable: false,
                             placeholder: 'Select a billing project',
@@ -462,7 +470,6 @@ const NewWorkspaceModal = withDisplayName(
                             ariaLiveMessages: { onFocus: onFocusAria, onChange: onChangeAria },
                             onChange: (opt) => setNamespace(opt!.value),
                             styles: { option: (provided) => ({ ...provided, padding: 10 }) },
-                            // @ts-expect-error
                             options: _.map((project: BillingProject) => {
                               const { projectName, invalidBillingAccount, cloudPlatform } = project;
                               return {


### PR DESCRIPTION
Tickets: 
- [Create a Google billing project](https://broadworkbench.atlassian.net/browse/WOR-794)
- [Requester Pays modal](https://broadworkbench.atlassian.net/browse/WOR-1343)

While I was in here, I changed a couple of other usages related to selecting billing projects.

Tested manually by using the PR deployment (logging as Hermione for usages of billing accounts). I made sure that the selects shows the appropriate elements, though depending on the usage I did not have enough entries to trigger the virtualization.

See screenshots on individual changes.