### PR TITLE
[WM-2387] rename and distinguish azure blob storage HEAD and GET requests

### DIFF
--- a/src/libs/ajax/AzureStorage.ts
+++ b/src/libs/ajax/AzureStorage.ts
@@ -134,12 +134,7 @@ export const AzureStorage = (signal?: AbortSignal) => ({
         const res = await fetchOk(azureSasStorageUrl, { method });
         const headerDict = Object.fromEntries(res.headers);
 
-        let textContent;
-        if (method === 'GET') {
-          textContent = await res.text().catch((_err) => undefined);
-        } else {
-          textContent = null;
-        }
+        const textContent = method === 'GET' ? await res.text().catch((_err) => undefined) : null;
 
         return {
           uri: azureStorageUrl,
@@ -170,8 +165,8 @@ export const AzureStorage = (signal?: AbortSignal) => ({
     };
 
     return {
-      getMetadata: () => getBlobByUri('HEAD'),
-      getData: () => getBlobByUri('GET'),
+      getMetadata: async () => getBlobByUri('HEAD'),
+      getData: async () => getBlobByUri('GET'),
     };
   },
 

--- a/src/libs/ajax/AzureStorage.ts
+++ b/src/libs/ajax/AzureStorage.ts
@@ -166,7 +166,7 @@ export const AzureStorage = (signal?: AbortSignal) => ({
 
     return {
       getMetadata: async () => getBlobByUri('HEAD'),
-      getData: async () => getBlobByUri('GET'),
+      getMetadataAndTextContent: async () => getBlobByUri('GET'),
     };
   },
 

--- a/src/libs/ajax/AzureStorage.ts
+++ b/src/libs/ajax/AzureStorage.ts
@@ -116,8 +116,8 @@ export const AzureStorage = (signal?: AbortSignal) => ({
     );
   },
 
-  blobMetadata: (azureStorageUrl: string) => {
-    const getObjectMetadata = async () => {
+  blobByUri: (azureStorageUrl: string) => {
+    const getBlobByUri = async (method) => {
       const fileName = _.last(azureStorageUrl.split('/'))?.split('.').join('.');
 
       try {
@@ -131,10 +131,15 @@ export const AzureStorage = (signal?: AbortSignal) => ({
         const urlwithFolder = new URL(azureStorageUrl);
         const azureSasStorageUrl = `https://${urlwithFolder.hostname}${urlwithFolder.pathname}?${token}`;
 
-        const res = await fetchOk(azureSasStorageUrl, { method: 'GET' });
+        const res = await fetchOk(azureSasStorageUrl, { method });
         const headerDict = Object.fromEntries(res.headers);
 
-        const textContent = await res.text().catch((_err) => undefined);
+        let textContent;
+        if (method === 'GET') {
+          textContent = await res.text().catch((_err) => undefined);
+        } else {
+          textContent = null;
+        }
 
         return {
           uri: azureStorageUrl,
@@ -165,7 +170,8 @@ export const AzureStorage = (signal?: AbortSignal) => ({
     };
 
     return {
-      getData: getObjectMetadata,
+      getMetadata: () => getBlobByUri('HEAD'),
+      getData: () => getBlobByUri('GET'),
     };
   },
 

--- a/src/workflows-app/RunDetails.test.js
+++ b/src/workflows-app/RunDetails.test.js
@@ -66,7 +66,7 @@ const mockObj = {
   },
   AzureStorage: {
     blobByUri: jest.fn(() => ({
-      getData: () =>
+      getMetadataAndTextContent: () =>
         Promise.resolve({
           uri: 'https://someBlobFilePath.blob.core.windows.net/cromwell/user-inputs/inputFile.txt',
           sasToken: '1234-this-is-a-mock-sas-token-5678',
@@ -328,7 +328,7 @@ describe('BaseRunDetails - render smoke test', () => {
 
   it('shows a static error message on LogViewer if log cannot be retrieved', async () => {
     const altMockObj = _.cloneDeep(mockObj);
-    altMockObj.AzureStorage.blobByUri = jest.fn(() => ({ getData: () => Promise.reject('Mock error') }));
+    altMockObj.AzureStorage.blobByUri = jest.fn(() => ({ getMetadataAndTextContent: () => Promise.reject('Mock error') }));
     Ajax.mockImplementation(() => altMockObj);
     const user = userEvent.setup();
     await act(async () => render(h(BaseRunDetails, runDetailsProps)));
@@ -344,7 +344,7 @@ describe('BaseRunDetails - render smoke test', () => {
 
   it('opens a log modal with functional tabs', async () => {
     const altMockObj = _.cloneDeep(mockObj);
-    altMockObj.AzureStorage.blobByUri = jest.fn(() => ({ getData: () => Promise.reject('Mock error') }));
+    altMockObj.AzureStorage.blobByUri = jest.fn(() => ({ getMetadataAndTextContent: () => Promise.reject('Mock error') }));
     Ajax.mockImplementation(() => altMockObj);
     const user = userEvent.setup();
     await act(async () => render(h(BaseRunDetails, runDetailsProps)));
@@ -399,7 +399,7 @@ describe('BaseRunDetails - render smoke test', () => {
   it('shows download button AND error when URI is valid but text could not be parsed', async () => {
     const altMockObj = _.cloneDeep(mockObj);
     altMockObj.AzureStorage.blobByUri = jest.fn(() => ({
-      getData: () =>
+      getMetadataAndTextContent: () =>
         Promise.resolve({
           textContent: undefined,
           azureSasStorageUrl: 'https://someBlobFilePath.blob.core.windows.net/cromwell/user-inputs/inputFile.txt',

--- a/src/workflows-app/RunDetails.test.js
+++ b/src/workflows-app/RunDetails.test.js
@@ -65,7 +65,7 @@ const mockObj = {
     }),
   },
   AzureStorage: {
-    blobMetadata: jest.fn(() => ({
+    blobByUri: jest.fn(() => ({
       getData: () =>
         Promise.resolve({
           uri: 'https://someBlobFilePath.blob.core.windows.net/cromwell/user-inputs/inputFile.txt',
@@ -328,7 +328,7 @@ describe('BaseRunDetails - render smoke test', () => {
 
   it('shows a static error message on LogViewer if log cannot be retrieved', async () => {
     const altMockObj = _.cloneDeep(mockObj);
-    altMockObj.AzureStorage.blobMetadata = jest.fn(() => ({ getData: () => Promise.reject('Mock error') }));
+    altMockObj.AzureStorage.blobByUri = jest.fn(() => ({ getData: () => Promise.reject('Mock error') }));
     Ajax.mockImplementation(() => altMockObj);
     const user = userEvent.setup();
     await act(async () => render(h(BaseRunDetails, runDetailsProps)));
@@ -344,7 +344,7 @@ describe('BaseRunDetails - render smoke test', () => {
 
   it('opens a log modal with functional tabs', async () => {
     const altMockObj = _.cloneDeep(mockObj);
-    altMockObj.AzureStorage.blobMetadata = jest.fn(() => ({ getData: () => Promise.reject('Mock error') }));
+    altMockObj.AzureStorage.blobByUri = jest.fn(() => ({ getData: () => Promise.reject('Mock error') }));
     Ajax.mockImplementation(() => altMockObj);
     const user = userEvent.setup();
     await act(async () => render(h(BaseRunDetails, runDetailsProps)));
@@ -398,7 +398,7 @@ describe('BaseRunDetails - render smoke test', () => {
 
   it('shows download button AND error when URI is valid but text could not be parsed', async () => {
     const altMockObj = _.cloneDeep(mockObj);
-    altMockObj.AzureStorage.blobMetadata = jest.fn(() => ({
+    altMockObj.AzureStorage.blobByUri = jest.fn(() => ({
       getData: () =>
         Promise.resolve({
           textContent: undefined,

--- a/src/workflows-app/components/LogViewer.ts
+++ b/src/workflows-app/components/LogViewer.ts
@@ -105,7 +105,7 @@ export const LogViewer = ({ modalTitle, logs, onDismiss }: LogViewerProps) => {
         return null;
       }
       try {
-        const response = await Ajax(signal).AzureStorage.blobMetadata(azureBlobUri).getData();
+        const response = await Ajax(signal).AzureStorage.blobByUri(azureBlobUri).getData();
         const uri = _.isEmpty(response.azureSasStorageUrl) ? response.azureStorageUrl : response.azureSasStorageUrl;
         return { textContent: response.textContent, downloadUri: uri };
       } catch (e) {

--- a/src/workflows-app/components/LogViewer.ts
+++ b/src/workflows-app/components/LogViewer.ts
@@ -105,7 +105,7 @@ export const LogViewer = ({ modalTitle, logs, onDismiss }: LogViewerProps) => {
         return null;
       }
       try {
-        const response = await Ajax(signal).AzureStorage.blobByUri(azureBlobUri).getData();
+        const response = await Ajax(signal).AzureStorage.blobByUri(azureBlobUri).getMetadataAndTextContent();
         const uri = _.isEmpty(response.azureSasStorageUrl) ? response.azureStorageUrl : response.azureSasStorageUrl;
         return { textContent: response.textContent, downloadUri: uri };
       } catch (e) {

--- a/src/workspace-data/data-table/uri-viewer/UriViewer.js
+++ b/src/workspace-data/data-table/uri-viewer/UriViewer.js
@@ -44,7 +44,7 @@ export const UriViewer = _.flow(
         const metadata = await loadObject(googleProject, bucket, name);
         setMetadata(metadata);
       } else if (isAzureUri(uri)) {
-        const azureMetadata = await Ajax(signal).AzureStorage.blobMetadata(uri).getData();
+        const azureMetadata = await Ajax(signal).AzureStorage.blobByUri(uri).getMetadata();
         setMetadata(azureMetadata);
         setLoadingError(false);
       } else {


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WM-2387

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Updates an Ajax function to get Azure blob storage data. Originally, the function retrieved metadata only. It was then (erroneously) updated to get the entire response body. This PR introduces separate functions for each method so that either metadata or the entire response body can be retrieved.

### Why
- When the function was updated to retrieve the entire response body, it created a situation in which very large files would cause the request to time out when attempting to preview the file in a data table. This PR addresses that situation.

### Testing strategy
- [x] Manual testing in a BEE
- [ ] ...

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 
