### PR TITLE
AJ-1527 use import v1 for tdr

### DIFF
--- a/src/import-data/ImportData.test.ts
+++ b/src/import-data/ImportData.test.ts
@@ -361,9 +361,10 @@ describe('ImportData', () => {
           (featurePreview) => featurePreview === ENABLE_AZURE_TDR_IMPORT
         );
 
+        // Azure tdr import expects the tdrmanifest to be a URL object, not a string
         const queryParams = {
           ...commonSnapshotExportQueryParams,
-          snapshotId: azureSnapshotFixture.id,
+          tdrmanifest: new URL(commonSnapshotExportQueryParams.tdrmanifest),
         };
         const { importJob, importTdr, wdsProxyUrl } = await setup({ queryParams });
 

--- a/src/import-data/ImportData.test.ts
+++ b/src/import-data/ImportData.test.ts
@@ -374,7 +374,7 @@ describe('ImportData', () => {
         expect(importTdr).toHaveBeenCalledWith(
           wdsProxyUrl,
           defaultAzureWorkspace.workspace.workspaceId,
-          queryParams.snapshotId
+          queryParams.tdrmanifest
         );
         expect(importJob).not.toHaveBeenCalled();
       });

--- a/src/import-data/ImportData.test.ts
+++ b/src/import-data/ImportData.test.ts
@@ -364,7 +364,7 @@ describe('ImportData', () => {
         // Azure tdr import expects the tdrmanifest to be a URL object, not a string
         const queryParams = {
           ...commonSnapshotExportQueryParams,
-          tdrmanifest: new URL(commonSnapshotExportQueryParams.tdrmanifest),
+          snapshotId: azureSnapshotFixture.id,
         };
         const { importJob, importTdr, wdsProxyUrl } = await setup({ queryParams });
 
@@ -375,7 +375,7 @@ describe('ImportData', () => {
         expect(importTdr).toHaveBeenCalledWith(
           wdsProxyUrl,
           defaultAzureWorkspace.workspace.workspaceId,
-          queryParams.tdrmanifest
+          new URL(queryParams.tdrmanifest)
         );
         expect(importJob).not.toHaveBeenCalled();
       });

--- a/src/import-data/ImportData.ts
+++ b/src/import-data/ImportData.ts
@@ -110,7 +110,7 @@ export const ImportData = (props: ImportDataProps): ReactNode => {
       const wdsDataTableProvider = new WdsDataTableProvider(workspace.workspaceId, wdsUrl);
 
       // call import snapshot
-      await wdsDataTableProvider.importTdr(workspace.workspaceId, importRequest.manifestUrl.toString());
+      await wdsDataTableProvider.importTdr(workspace.workspaceId, importRequest.manifestUrl);
     } else {
       const { namespace, name } = workspace;
       const { jobId } = await Ajax()

--- a/src/import-data/ImportData.ts
+++ b/src/import-data/ImportData.ts
@@ -110,7 +110,7 @@ export const ImportData = (props: ImportDataProps): ReactNode => {
       const wdsDataTableProvider = new WdsDataTableProvider(workspace.workspaceId, wdsUrl);
 
       // call import snapshot
-      await wdsDataTableProvider.importTdr(workspace.workspaceId, importRequest.snapshot.id);
+      await wdsDataTableProvider.importTdr(workspace.workspaceId, importRequest.manifestUrl.toString());
     } else {
       const { namespace, name } = workspace;
       const { jobId } = await Ajax()

--- a/src/libs/ajax/WorkspaceDataService.ts
+++ b/src/libs/ajax/WorkspaceDataService.ts
@@ -118,10 +118,10 @@ export const WorkspaceData = (signal) => ({
     );
     return await res.json();
   },
-  importTdr: async (root: string, instanceId: string, snapshotUrl: string): Promise<Response> => {
+  importTdr: async (root: string, instanceId: string, manifestURL: URL): Promise<Response> => {
     const res = await fetchWDS(root)(
       `${instanceId}/import/v1`,
-      _.mergeAll([authOpts(), { method: 'POST' }, jsonBody({ type: 'TDRMANIFEST', url: snapshotUrl })])
+      _.mergeAll([authOpts(), { method: 'POST' }, jsonBody({ type: 'TDRMANIFEST', url: manifestURL })])
     );
     return res;
   },

--- a/src/libs/ajax/WorkspaceDataService.ts
+++ b/src/libs/ajax/WorkspaceDataService.ts
@@ -118,10 +118,10 @@ export const WorkspaceData = (signal) => ({
     );
     return await res.json();
   },
-  importTdr: async (root: string, instanceId: string, snapshotId: string): Promise<Response> => {
+  importTdr: async (root: string, instanceId: string, snapshotUrl: string): Promise<Response> => {
     const res = await fetchWDS(root)(
-      `${instanceId}/snapshots/v0.2/${snapshotId}`,
-      _.mergeAll([authOpts(), { method: 'POST' }])
+      `${instanceId}/import/v1`,
+      _.mergeAll([authOpts(), { method: 'POST' }, jsonBody({ type: 'TDRMANIFEST', url: snapshotUrl })])
     );
     return res;
   },

--- a/src/libs/ajax/data-table-providers/WdsDataTableProvider.test.ts
+++ b/src/libs/ajax/data-table-providers/WdsDataTableProvider.test.ts
@@ -672,7 +672,7 @@ describe('WdsDataTableProvider', () => {
       // ====== Arrange
       const provider = new TestableWdsProvider(uuid, testProxyUrl);
       // ====== Act
-      return provider.importTdr(uuid, uuid).then(() => {
+      return provider.importTdr(uuid, 'manifest.url&snapshotId=anyUuid&other=parameters').then(() => {
         // ====== Assert
         expect(importTdr.mock.calls.length).toBe(1);
         // expect(actual.status).toBe(202);

--- a/src/libs/ajax/data-table-providers/WdsDataTableProvider.test.ts
+++ b/src/libs/ajax/data-table-providers/WdsDataTableProvider.test.ts
@@ -166,7 +166,7 @@ describe('WdsDataTableProvider', () => {
   const importTdrMockImpl: WorkspaceDataContract['importTdr'] = (
     _root: string,
     _workspaceId: string,
-    _snapshotId: string
+    _manifestUrl: URL
   ) => {
     return Promise.resolve(new Response('', { status: 202 }));
   };

--- a/src/libs/ajax/data-table-providers/WdsDataTableProvider.test.ts
+++ b/src/libs/ajax/data-table-providers/WdsDataTableProvider.test.ts
@@ -675,6 +675,7 @@ describe('WdsDataTableProvider', () => {
       return provider.importTdr(uuid, 'manifest.url&snapshotId=anyUuid&other=parameters').then(() => {
         // ====== Assert
         expect(importTdr.mock.calls.length).toBe(1);
+        expect(importTdr).toHaveBeenCalledWith(testProxyUrl, uuid, 'manifest.url&snapshotId=anyUuid&other=parameters');
         // expect(actual.status).toBe(202);
       });
     });

--- a/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
+++ b/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
@@ -305,7 +305,7 @@ export class WdsDataTableProvider implements DataTableProvider {
     );
   };
 
-  importTdr = withErrorReporting('Error importing')(async (workspaceId: string, snapshotId: string): Promise<any> => {
+  importTdr = withErrorReporting('Error importing')(async (workspaceId: string, snapshotUrl: string): Promise<any> => {
     if (!this.proxyUrl) return Promise.reject('Proxy Url not loaded');
     setTimeout(() => {
       if (
@@ -315,7 +315,7 @@ export class WdsDataTableProvider implements DataTableProvider {
         notifyDataImportProgress('tdr-import', 'Your data will show up under Tables once import is complete.');
       }
     }, 1000);
-    await Ajax().WorkspaceData.importTdr(this.proxyUrl, workspaceId, snapshotId);
+    await Ajax().WorkspaceData.importTdr(this.proxyUrl, workspaceId, snapshotUrl);
     notify('success', 'Snapshot successfully imported', {
       message: 'Successfully imported snapshot.  Please refresh the page to see your changes.',
       timeout: 3000,

--- a/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
+++ b/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
@@ -305,7 +305,7 @@ export class WdsDataTableProvider implements DataTableProvider {
     );
   };
 
-  importTdr = withErrorReporting('Error importing')(async (workspaceId: string, snapshotUrl: string): Promise<any> => {
+  importTdr = withErrorReporting('Error importing')(async (workspaceId: string, manifestURL: URL): Promise<any> => {
     if (!this.proxyUrl) return Promise.reject('Proxy Url not loaded');
     setTimeout(() => {
       if (
@@ -315,7 +315,7 @@ export class WdsDataTableProvider implements DataTableProvider {
         notifyDataImportProgress('tdr-import', 'Your data will show up under Tables once import is complete.');
       }
     }, 1000);
-    await Ajax().WorkspaceData.importTdr(this.proxyUrl, workspaceId, snapshotUrl);
+    await Ajax().WorkspaceData.importTdr(this.proxyUrl, workspaceId, manifestURL);
     notify('success', 'Snapshot successfully imported', {
       message: 'Successfully imported snapshot.  Please refresh the page to see your changes.',
       timeout: 3000,


### PR DESCRIPTION
### [AJ-1527](https://broadworkbench.atlassian.net/browse/AJ-1527)
## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Call `/{instanceUuid}/import/v1` for TDR imports instead of `/{instanceid}/snapshots/{v}/{snapshotid}`, which is deprecated
- Pass the entire manifest URL in the body of the API call instead of using the snapshotId as a parameter

### Why
- 

### Testing strategy
- [ ] Verified correct URL was called locally

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 


[AJ-1527]: https://broadworkbench.atlassian.net/browse/AJ-1527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ