### PR TITLE
AJ-1527, AJ-1528 remove wds-specific tdr and use startimportjob instead

### DIFF
--- a/src/import-data/ImportData.test.ts
+++ b/src/import-data/ImportData.test.ts
@@ -167,7 +167,6 @@ const setup = async (opts: SetupOptions) => {
     },
     WorkspaceData: {
       startImportJob,
-      importTdr,
     },
     Workspaces: {
       workspace: getWorkspaceApi,
@@ -366,17 +365,15 @@ describe('ImportData', () => {
           ...commonSnapshotExportQueryParams,
           snapshotId: azureSnapshotFixture.id,
         };
-        const { importJob, importTdr, wdsProxyUrl } = await setup({ queryParams });
+        const { importJob, startImportJob, wdsProxyUrl } = await setup({ queryParams });
 
         // Act
         await importIntoExistingWorkspace(user, defaultAzureWorkspace.workspace.name);
 
-        // Assert
-        expect(importTdr).toHaveBeenCalledWith(
-          wdsProxyUrl,
-          defaultAzureWorkspace.workspace.workspaceId,
-          new URL(queryParams.tdrmanifest)
-        );
+        expect(startImportJob).toHaveBeenCalledWith(wdsProxyUrl, defaultAzureWorkspace.workspace.workspaceId, {
+          url: queryParams.tdrmanifest,
+          type: 'TDRMANIFEST',
+        });
         expect(importJob).not.toHaveBeenCalled();
       });
     });

--- a/src/import-data/ImportData.ts
+++ b/src/import-data/ImportData.ts
@@ -75,7 +75,7 @@ export const ImportData = (props: ImportDataProps): ReactNode => {
         jobId,
         wdsProxyUrl: wdsUrl,
       };
-      asyncImportJobStore.update((previousJobs) => [...previousJobs, newJob]);
+      asyncImportJobStore.update(Utils.append(newJob));
       notifyDataImportProgress(jobId);
     } else {
       const { namespace, name } = workspace;
@@ -86,7 +86,7 @@ export const ImportData = (props: ImportDataProps): ReactNode => {
         targetWorkspace: { namespace, name },
         jobId,
       };
-      asyncImportJobStore.update((previousJobs) => [...previousJobs, newJob]);
+      asyncImportJobStore.update(Utils.append(newJob));
       notifyDataImportProgress(jobId);
     }
   };
@@ -109,7 +109,7 @@ export const ImportData = (props: ImportDataProps): ReactNode => {
       const wdsUrl = await Ajax().Apps.listAppsV2(workspace.workspaceId).then(resolveWdsUrl);
       const { namespace, name } = workspace;
 
-      // call import snapshot
+      // call import API
       const { jobId } = await Ajax().WorkspaceData.startImportJob(wdsUrl, workspace.workspaceId, {
         url: importRequest.manifestUrl.toString(),
         type: 'TDRMANIFEST',
@@ -119,7 +119,7 @@ export const ImportData = (props: ImportDataProps): ReactNode => {
         jobId,
         wdsProxyUrl: wdsUrl,
       };
-      asyncImportJobStore.update((previousJobs) => [...previousJobs, newJob]);
+      asyncImportJobStore.update(Utils.append(newJob));
       notifyDataImportProgress(jobId);
     } else {
       const { namespace, name } = workspace;

--- a/src/libs/ajax/WorkspaceDataService.ts
+++ b/src/libs/ajax/WorkspaceDataService.ts
@@ -118,13 +118,6 @@ export const WorkspaceData = (signal) => ({
     );
     return await res.json();
   },
-  importTdr: async (root: string, instanceId: string, manifestURL: URL): Promise<Response> => {
-    const res = await fetchWDS(root)(
-      `${instanceId}/import/v1`,
-      _.mergeAll([authOpts(), { method: 'POST' }, jsonBody({ type: 'TDRMANIFEST', url: manifestURL })])
-    );
-    return res;
-  },
   queryRecords: async (root: string, instanceId: string, wdsType: string): Promise<any> => {
     const searchPayload = { limit: 100 };
     const res = await fetchWDS(root)(

--- a/src/libs/ajax/data-table-providers/WdsDataTableProvider.test.ts
+++ b/src/libs/ajax/data-table-providers/WdsDataTableProvider.test.ts
@@ -163,14 +163,6 @@ describe('WdsDataTableProvider', () => {
     return Promise.resolve({ message: 'Upload Succeeded', recordsModified: 1 });
   };
 
-  const importTdrMockImpl: WorkspaceDataContract['importTdr'] = (
-    _root: string,
-    _workspaceId: string,
-    _manifestUrl: URL
-  ) => {
-    return Promise.resolve(new Response('', { status: 202 }));
-  };
-
   const listAppsV2MockImpl = (_workspaceId: string): Promise<ListAppItem[]> => {
     return Promise.resolve(testProxyUrlResponse);
   };
@@ -179,7 +171,6 @@ describe('WdsDataTableProvider', () => {
   let deleteTable: jest.MockedFunction<WorkspaceDataContract['deleteTable']>;
   let downloadTsv: jest.MockedFunction<WorkspaceDataContract['downloadTsv']>;
   let uploadTsv: jest.MockedFunction<WorkspaceDataContract['uploadTsv']>;
-  let importTdr: jest.MockedFunction<WorkspaceDataContract['importTdr']>;
   let listAppsV2: jest.MockedFunction<AppsContract['listAppsV2']>;
 
   beforeEach(() => {
@@ -187,7 +178,6 @@ describe('WdsDataTableProvider', () => {
     deleteTable = jest.fn().mockImplementation(deleteTableMockImpl);
     downloadTsv = jest.fn().mockImplementation(downloadTsvMockImpl);
     uploadTsv = jest.fn().mockImplementation(uploadTsvMockImpl);
-    importTdr = jest.fn().mockImplementation(importTdrMockImpl);
     listAppsV2 = jest.fn().mockImplementation(listAppsV2MockImpl);
 
     asMockedFn(Ajax).mockImplementation(
@@ -198,7 +188,6 @@ describe('WdsDataTableProvider', () => {
             deleteTable,
             downloadTsv,
             uploadTsv,
-            importTdr,
           } as Partial<WorkspaceDataContract>,
           Apps: { listAppsV2 } as Partial<AppsContract>,
         } as Partial<AjaxContract> as AjaxContract)
@@ -664,20 +653,6 @@ describe('WdsDataTableProvider', () => {
           expect(uploadTsv.mock.calls.length).toBe(1);
           expect(actual.recordsModified).toBe(1);
         });
-    });
-  });
-
-  describe('importTdr', () => {
-    it('imports a snapshot from tdr', () => {
-      // ====== Arrange
-      const provider = new TestableWdsProvider(uuid, testProxyUrl);
-      // ====== Act
-      return provider.importTdr(uuid, 'manifest.url&snapshotId=anyUuid&other=parameters').then(() => {
-        // ====== Assert
-        expect(importTdr.mock.calls.length).toBe(1);
-        expect(importTdr).toHaveBeenCalledWith(testProxyUrl, uuid, 'manifest.url&snapshotId=anyUuid&other=parameters');
-        // expect(actual.status).toBe(202);
-      });
     });
   });
 });

--- a/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
+++ b/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
@@ -13,8 +13,6 @@ import {
   UploadParameters,
 } from 'src/libs/ajax/data-table-providers/DataTableProvider';
 import { LeoAppStatus, ListAppItem } from 'src/libs/ajax/leonardo/models/app-models';
-import { withErrorReporting } from 'src/libs/error';
-import { notify } from 'src/libs/notifications';
 import { notificationStore } from 'src/libs/state';
 import * as Utils from 'src/libs/utils';
 import { notifyDataImportProgress } from 'src/workspace-data/import-jobs';
@@ -304,21 +302,4 @@ export class WdsDataTableProvider implements DataTableProvider {
       uploadParams.file
     );
   };
-
-  importTdr = withErrorReporting('Error importing')(async (workspaceId: string, manifestURL: URL): Promise<any> => {
-    if (!this.proxyUrl) return Promise.reject('Proxy Url not loaded');
-    setTimeout(() => {
-      if (
-        notificationStore.get().length === 0 ||
-        !notificationStore.get().some((notif: { title: string }) => ['Error importing'].includes(notif.title))
-      ) {
-        notifyDataImportProgress('tdr-import', 'Your data will show up under Tables once import is complete.');
-      }
-    }, 1000);
-    await Ajax().WorkspaceData.importTdr(this.proxyUrl, workspaceId, manifestURL);
-    notify('success', 'Snapshot successfully imported', {
-      message: 'Successfully imported snapshot.  Please refresh the page to see your changes.',
-      timeout: 3000,
-    });
-  });
 }


### PR DESCRIPTION
## [AJ-1527](https://broadworkbench.atlassian.net/browse/AJ-1527)

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
https://github.com/DataBiosphere/terra-ui/pull/4576 simply replaced the API being called by the `importTdr` method, when `startImportJob` already existed and was calling the `importv1` API, just with a different parameter.  This PR removes the deprecated `importTdr` method altogether and uses `startImportJob` as the original PR should have done.  Also accidentally completes [AJ-1528](https://broadworkbench.atlassian.net/browse/AJ-1528) since`startImportJob` is already set up for polling.

### What
- 

### Why
- 

### Testing strategy
- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 


[AJ-1527]: https://broadworkbench.atlassian.net/browse/AJ-1527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AJ-1528]: https://broadworkbench.atlassian.net/browse/AJ-1528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ