### PR TITLE
[UIE-152] Update VS Code setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,7 +14,7 @@
   },
   "editor.defaultFormatter": "dbaeumer.vscode-eslint",
   "editor.codeActionsOnSave": {
-    "source.organizeImports": true
+    "source.organizeImports": "explicit"
   },
   "[javascript]": {
     "editor.defaultFormatter": "dbaeumer.vscode-eslint"


### PR DESCRIPTION
As part of enforcing consistent formatting, we have VS Code configured to organize (sort and remove unused) imports on save.
https://code.visualstudio.com/docs/typescript/typescript-refactoring#_organize-imports

The November 2023 update to VS Code changed the format of this setting.
https://code.visualstudio.com/updates/v1_85#_code-actions-on-save-and-auto

This updates the setting to the new format so that it doesn't become noise in another PR.