### PR TITLE
[DC-808] Add Bolding of Searched Term in List of Domain Based Concepts

### DIFF
--- a/src/dataset-builder/ConceptSearch.test.ts
+++ b/src/dataset-builder/ConceptSearch.test.ts
@@ -1,5 +1,6 @@
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import _ from 'lodash/fp';
 import { h } from 'react-hyperscript-helpers';
 import { ConceptSearch } from 'src/dataset-builder/ConceptSearch';
 import { dummyDatasetModel, dummyGetConceptForId } from 'src/dataset-builder/TestConstants';
@@ -22,11 +23,11 @@ describe('ConceptSearch', () => {
   const datasetId = '0';
   const initialCart: SnapshotBuilderConcept[] = [];
   const domainOption = dummyDatasetModel()!.snapshotBuilderSettings!.domainOptions[0];
-  const renderSearch = () => {
+  const renderSearch = (initialSearch = '') => {
     render(
       h(ConceptSearch, {
         actionText,
-        initialSearch: '',
+        initialSearch,
         initialCart,
         onCancel,
         onCommit,
@@ -36,21 +37,6 @@ describe('ConceptSearch', () => {
       })
     );
   };
-
-  // const renderHighlightConceptSearch = () => {
-  //   render(
-  //     h(ConceptSearch, {
-  //       actionText,
-  //       initialSearch: 'Con',
-  //       initialCart,
-  //       onCancel,
-  //       onCommit,
-  //       onOpenHierarchy,
-  //       datasetId,
-  //       domainOption,
-  //     })
-  //   );
-  // };
 
   const displayedConcepts = [dummyGetConceptForId(102), dummyGetConceptForId(103)];
   const mockSearch = jest.fn();
@@ -149,17 +135,27 @@ describe('ConceptSearch', () => {
     expect(onCommit).toHaveBeenCalledWith([concept]);
   });
 
-  // it('testing HighlightConceptNAme', async () => {
-  //   // Arrange
-  //   renderHighlightConceptSearch();
-  //   // Assert
-  //   expect(await screen.findByText(displayedConcepts[0].name)).toBeTruthy();
-  //   console.log(displayedConcepts[0].name);
-  //   expect(await screen.findByText(displayedConcepts[0].id)).toBeTruthy();
-  //   console.log(displayedConcepts[0].id);
-  //   // Search Filter is found
-  //   expect(await screen.getByLabelText('Con')).toBeTruthy();
-  //   expect(await screen.findByText('Condition')).toBeTruthy();
-  //   console.log(screen.findByText('Condition'));
-  // });
+  it('testing HighlightConceptName, "Dis"', async () => {
+    renderSearch('Dis');
+
+    const disText = await screen.findAllByText('Dis');
+
+    const filterDisText = _.filter(
+      (element) => element.tagName === 'DIV' && element.style.fontWeight === '600',
+      disText
+    ).length;
+    expect(filterDisText).toBeGreaterThan(0);
+    expect(await screen.findByText('ease')).toBeTruthy();
+  });
+
+  it('testing HighlightConceptName, "ease"', async () => {
+    renderSearch('ease');
+    const easeText = await screen.findAllByText('ease');
+    const filterEaseText = _.filter(
+      (element) => element.tagName === 'DIV' && element.style.fontWeight === '600',
+      easeText
+    ).length;
+    expect(filterEaseText).toBe(1);
+    expect(await screen.findByText('Dis')).toBeTruthy();
+  });
 });

--- a/src/dataset-builder/ConceptSearch.test.ts
+++ b/src/dataset-builder/ConceptSearch.test.ts
@@ -173,10 +173,11 @@ describe('ConceptSearch', () => {
     expect(filterEaseText).toBe(1);
     expect(await screen.findByText('Dis')).toBeTruthy();
 
-  it('loads the page with the initial cart', async () => {
-    // Arrange
-    renderSearch('', [displayedConcepts[0]]);
-    // Assert
-    expect(screen.queryByText('1 concept', { exact: false })).toBeTruthy();
+    it('loads the page with the initial cart', async () => {
+      // Arrange
+      renderSearch('', [displayedConcepts[0]]);
+      // Assert
+      expect(screen.queryByText('1 concept', { exact: false })).toBeTruthy();
+    });
   });
 });

--- a/src/dataset-builder/ConceptSearch.test.ts
+++ b/src/dataset-builder/ConceptSearch.test.ts
@@ -37,6 +37,21 @@ describe('ConceptSearch', () => {
     );
   };
 
+  // const renderHighlightConceptSearch = () => {
+  //   render(
+  //     h(ConceptSearch, {
+  //       actionText,
+  //       initialSearch: 'Con',
+  //       initialCart,
+  //       onCancel,
+  //       onCommit,
+  //       onOpenHierarchy,
+  //       datasetId,
+  //       domainOption,
+  //     })
+  //   );
+  // };
+
   const displayedConcepts = [dummyGetConceptForId(102), dummyGetConceptForId(103)];
   const mockSearch = jest.fn();
 
@@ -133,4 +148,18 @@ describe('ConceptSearch', () => {
     // Assert
     expect(onCommit).toHaveBeenCalledWith([concept]);
   });
+
+  // it('testing HighlightConceptNAme', async () => {
+  //   // Arrange
+  //   renderHighlightConceptSearch();
+  //   // Assert
+  //   expect(await screen.findByText(displayedConcepts[0].name)).toBeTruthy();
+  //   console.log(displayedConcepts[0].name);
+  //   expect(await screen.findByText(displayedConcepts[0].id)).toBeTruthy();
+  //   console.log(displayedConcepts[0].id);
+  //   // Search Filter is found
+  //   expect(await screen.getByLabelText('Con')).toBeTruthy();
+  //   expect(await screen.findByText('Condition')).toBeTruthy();
+  //   console.log(screen.findByText('Condition'));
+  // });
 });

--- a/src/dataset-builder/ConceptSearch.test.ts
+++ b/src/dataset-builder/ConceptSearch.test.ts
@@ -172,12 +172,12 @@ describe('ConceptSearch', () => {
     ).length;
     expect(filterEaseText).toBe(1);
     expect(await screen.findByText('Dis')).toBeTruthy();
+  });
 
-    it('loads the page with the initial cart', async () => {
-      // Arrange
-      renderSearch('', [displayedConcepts[0]]);
-      // Assert
-      expect(screen.queryByText('1 concept', { exact: false })).toBeTruthy();
-    });
+  it('loads the page with the initial cart', async () => {
+    // Arrange
+    renderSearch('', [displayedConcepts[0]]);
+    // Assert
+    expect(screen.queryByText('1 concept', { exact: false })).toBeTruthy();
   });
 });

--- a/src/dataset-builder/ConceptSearch.ts
+++ b/src/dataset-builder/ConceptSearch.ts
@@ -7,7 +7,6 @@ import { Link, spinnerOverlay } from 'src/components/common';
 import { icon } from 'src/components/icons';
 import { DelayedSearchInput } from 'src/components/input';
 import { SimpleTable } from 'src/components/table';
-import { StringInput } from 'src/data-catalog/create-dataset/CreateDatasetInputs';
 import { GetConceptsResponse, HighlightConceptName } from 'src/dataset-builder/DatasetBuilderUtils';
 import { DataRepo, SnapshotBuilderConcept as Concept, SnapshotBuilderDomainOption } from 'src/libs/ajax/DataRepo';
 import { useLoadedData } from 'src/libs/ajax/loaded-data/useLoadedData';

--- a/src/dataset-builder/ConceptSearch.ts
+++ b/src/dataset-builder/ConceptSearch.ts
@@ -7,9 +7,8 @@ import { Link, spinnerOverlay } from 'src/components/common';
 import { icon } from 'src/components/icons';
 import { SimpleTable } from 'src/components/table';
 import { StringInput } from 'src/data-catalog/create-dataset/CreateDatasetInputs';
-import { GetConceptsResponse } from 'src/dataset-builder/DatasetBuilderUtils';
-import { SnapshotBuilderConcept as Concept, SnapshotBuilderDomainOption } from 'src/libs/ajax/DataRepo';
-import { DataRepo } from 'src/libs/ajax/DataRepo';
+import { boldSubsetWord, GetConceptsResponse } from 'src/dataset-builder/DatasetBuilderUtils';
+import { DataRepo, SnapshotBuilderConcept as Concept, SnapshotBuilderDomainOption } from 'src/libs/ajax/DataRepo';
 import { useLoadedData } from 'src/libs/ajax/loaded-data/useLoadedData';
 import colors from 'src/libs/colors';
 
@@ -36,6 +35,7 @@ export const ConceptSearch = (props: ConceptSearchProps) => {
   const [search, setSearch] = useState<string>(initialSearch);
   const [cart, setCart] = useState<Concept[]>(initialCart);
   const [concepts, searchConcepts] = useLoadedData<GetConceptsResponse>();
+
   useEffect(() => {
     void searchConcepts(() => {
       return DataRepo().dataset(datasetId).searchConcepts(domainOption.root, search);
@@ -94,7 +94,7 @@ export const ConceptSearch = (props: ConceptSearchProps) => {
                   h(Link, { 'aria-label': label, onClick: () => setCart(_.xor(cart, [concept])) }, [
                     icon(iconName, { size: 16 }),
                   ]),
-                  div({ style: { marginLeft: 5 } }, [concept.name]),
+                  div({ style: { marginLeft: 5 } }, [boldSubsetWord(concept.name, search)]),
                 ]),
                 id: concept.id,
                 count: concept.count,

--- a/src/dataset-builder/ConceptSearch.ts
+++ b/src/dataset-builder/ConceptSearch.ts
@@ -7,7 +7,7 @@ import { Link, spinnerOverlay } from 'src/components/common';
 import { icon } from 'src/components/icons';
 import { SimpleTable } from 'src/components/table';
 import { StringInput } from 'src/data-catalog/create-dataset/CreateDatasetInputs';
-import { boldSubsetWord, GetConceptsResponse } from 'src/dataset-builder/DatasetBuilderUtils';
+import { GetConceptsResponse, HighlightConceptName } from 'src/dataset-builder/DatasetBuilderUtils';
 import { DataRepo, SnapshotBuilderConcept as Concept, SnapshotBuilderDomainOption } from 'src/libs/ajax/DataRepo';
 import { useLoadedData } from 'src/libs/ajax/loaded-data/useLoadedData';
 import colors from 'src/libs/colors';
@@ -94,7 +94,7 @@ export const ConceptSearch = (props: ConceptSearchProps) => {
                   h(Link, { 'aria-label': label, onClick: () => setCart(_.xor(cart, [concept])) }, [
                     icon(iconName, { size: 16 }),
                   ]),
-                  div({ style: { marginLeft: 5 } }, [boldSubsetWord(concept.name, search)]),
+                  div({ style: { marginLeft: 5 } }, [HighlightConceptName(concept.name, search)]),
                 ]),
                 id: concept.id,
                 count: concept.count,

--- a/src/dataset-builder/ConceptSearch.ts
+++ b/src/dataset-builder/ConceptSearch.ts
@@ -94,7 +94,9 @@ export const ConceptSearch = (props: ConceptSearchProps) => {
                   h(Link, { 'aria-label': label, onClick: () => setCart(_.xor(cart, [concept])) }, [
                     icon(iconName, { size: 16 }),
                   ]),
-                  div({ style: { marginLeft: 5 } }, [HighlightConceptName(concept.name, search)]),
+                  div({ style: { marginLeft: 5 } }, [
+                    h(HighlightConceptName, { conceptName: concept.name, searchFilter: search }),
+                  ]),
                 ]),
                 id: concept.id,
                 count: concept.count,

--- a/src/dataset-builder/DatasetBuilderUtils.test.ts
+++ b/src/dataset-builder/DatasetBuilderUtils.test.ts
@@ -1,4 +1,4 @@
-import { span, strong } from 'react-hyperscript-helpers';
+import { div } from 'react-hyperscript-helpers';
 import {
   AnyCriteria,
   AnyCriteriaApi,
@@ -187,7 +187,11 @@ describe('test HighlightConceptName', () => {
     const searchFilter = 'Clinic';
     const conceptName = 'Clinical Finding';
 
-    const result = span([span(['']), strong(['Clinic']), span(['al Finding'])]);
+    const result = div({ style: { display: 'flex' } }, [
+      div(['']),
+      div({ style: { fontWeight: 600 } }, ['Clinic']),
+      div(['al Finding']),
+    ]);
     expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
   });
 
@@ -195,8 +199,11 @@ describe('test HighlightConceptName', () => {
     const searchFilter = 'clin';
     const conceptName = 'Clinical Finding';
 
-    const result = span([span(['']), strong(['Clin']), span(['ical Finding'])]);
-
+    const result = div({ style: { display: 'flex' } }, [
+      div(['']),
+      div({ style: { fontWeight: 600 } }, ['Clin']),
+      div(['ical Finding']),
+    ]);
     expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
   });
 
@@ -204,8 +211,11 @@ describe('test HighlightConceptName', () => {
     const searchFilter = 'cal';
     const conceptName = 'Clinical Finding';
 
-    const result = span([span(['Clini']), strong(['cal']), span([' Finding'])]);
-
+    const result = div({ style: { display: 'flex' } }, [
+      div(['Clini']),
+      div({ style: { fontWeight: 600 } }, ['cal']),
+      div([' Finding']),
+    ]);
     expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
   });
 
@@ -213,7 +223,11 @@ describe('test HighlightConceptName', () => {
     const searchFilter = 'Finding';
     const conceptName = 'Clinical Finding';
 
-    const result = span([span(['Clinical ']), strong(['Finding']), span([''])]);
+    const result = div({ style: { display: 'flex' } }, [
+      div(['Clinical ']),
+      div({ style: { fontWeight: 600 } }, ['Finding']),
+      div(['']),
+    ]);
 
     expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
   });
@@ -222,7 +236,7 @@ describe('test HighlightConceptName', () => {
     const searchFilter = 'XXX';
     const conceptName = 'Clinical Finding';
 
-    const result = span(['Clinical Finding']);
+    const result = div(['Clinical Finding']);
 
     expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
   });
@@ -231,7 +245,7 @@ describe('test HighlightConceptName', () => {
     const searchFilter = 'Clinical';
     const conceptName = 'Clin';
 
-    const result = span(['Clin']);
+    const result = div(['Clin']);
 
     expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
   });
@@ -240,7 +254,7 @@ describe('test HighlightConceptName', () => {
     const searchFilter = '';
     const conceptName = 'Condition';
 
-    const result = span(['Condition']);
+    const result = div(['Condition']);
 
     expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
   });
@@ -249,14 +263,14 @@ describe('test HighlightConceptName', () => {
     let searchFilter = ' ';
     let conceptName = 'Clinical Finding';
 
-    let result = span(['Clinical Finding']);
+    let result = div(['Clinical Finding']);
 
     expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
 
     searchFilter = '   ';
     conceptName = 'Clinical Finding';
 
-    result = span(['Clinical Finding']);
+    result = div(['Clinical Finding']);
 
     expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
   });

--- a/src/dataset-builder/DatasetBuilderUtils.test.ts
+++ b/src/dataset-builder/DatasetBuilderUtils.test.ts
@@ -190,9 +190,7 @@ describe('test HighlightConceptName', () => {
     const result = span([span(['']), strong(['Clinic']), span(['al Finding'])]);
     expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
   });
-});
 
-describe('test HighlightConceptName', () => {
   test("Testing to make sure capitalization doesn't change", () => {
     const searchFilter = 'clin';
     const conceptName = 'Clinical Finding';
@@ -201,9 +199,7 @@ describe('test HighlightConceptName', () => {
 
     expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
   });
-});
 
-describe('test HighlightConceptName', () => {
   test('searchedWord in the middle of conceptName', () => {
     const searchFilter = 'cal';
     const conceptName = 'Clinical Finding';
@@ -212,9 +208,7 @@ describe('test HighlightConceptName', () => {
 
     expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
   });
-});
 
-describe('test HighlightConceptName', () => {
   test('searchedWord in the end of conceptName', () => {
     const searchFilter = 'Finding';
     const conceptName = 'Clinical Finding';
@@ -223,9 +217,7 @@ describe('test HighlightConceptName', () => {
 
     expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
   });
-});
 
-describe('test HighlightConceptName', () => {
   test('searchedWord in the not in conceptName: "XXX" in "Clinical Finding"', () => {
     const searchFilter = 'XXX';
     const conceptName = 'Clinical Finding';
@@ -234,9 +226,7 @@ describe('test HighlightConceptName', () => {
 
     expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
   });
-});
 
-describe('test HighlightConceptName', () => {
   test('searchedWord in the not in conceptName: "Clinical" in "Clin"', () => {
     const searchFilter = 'Clinical';
     const conceptName = 'Clin';
@@ -245,9 +235,7 @@ describe('test HighlightConceptName', () => {
 
     expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
   });
-});
 
-describe('test HighlightConceptName', () => {
   test('searchedWord is empty: "" ', () => {
     const searchFilter = '';
     const conceptName = 'Condition';
@@ -256,9 +244,7 @@ describe('test HighlightConceptName', () => {
 
     expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
   });
-});
 
-describe('test HighlightConceptName', () => {
   test("doesn't bold whitespace", () => {
     let searchFilter = ' ';
     let conceptName = 'Clinical Finding';

--- a/src/dataset-builder/DatasetBuilderUtils.test.ts
+++ b/src/dataset-builder/DatasetBuilderUtils.test.ts
@@ -1,3 +1,4 @@
+import { span, strong } from 'react-hyperscript-helpers';
 import {
   AnyCriteria,
   AnyCriteriaApi,
@@ -14,6 +15,7 @@ import {
   DatasetAccessRequestApi,
   DomainCriteria,
   DomainCriteriaApi,
+  HighlightConceptName,
   ProgramDataListCriteria,
   ProgramDataListCriteriaApi,
   ProgramDataListOption,
@@ -177,5 +179,104 @@ describe('test conversion of valueSets', () => {
 describe('test conversion of DatasetAccessRequest', () => {
   test('datasetAccessRequest converted to datasetAccessRequestApi', () => {
     expect(convertDatasetAccessRequest(datasetAccessRequest)).toStrictEqual(datasetAccessRequestApi);
+  });
+});
+
+describe('test HighlightConceptName', () => {
+  test('searching beginning of conceptName', () => {
+    const searchedWord = 'Clinic';
+    const conceptName = 'Clinical Finding';
+
+    const result = span([span(['']), strong(['Clinic']), span(['al Finding'])]);
+
+    expect(HighlightConceptName(conceptName, searchedWord)).toStrictEqual(result);
+  });
+});
+
+describe('test HighlightConceptName', () => {
+  test('Testing to make sure Clin is capitalized', () => {
+    const searchedWord = 'clin';
+    const conceptName = 'Clinical Finding';
+
+    const result = span([span(['']), strong(['Clin']), span(['ical Finding'])]);
+
+    expect(HighlightConceptName(conceptName, searchedWord)).toStrictEqual(result);
+  });
+});
+
+describe('test HighlightConceptName', () => {
+  test('searchedWord in the middle of conceptName', () => {
+    const searchedWord = 'cal';
+    const conceptName = 'Clinical Finding';
+
+    const result = span([span(['Clini']), strong(['cal']), span([' Finding'])]);
+
+    expect(HighlightConceptName(conceptName, searchedWord)).toStrictEqual(result);
+  });
+});
+
+describe('test HighlightConceptName', () => {
+  test('searchedWord in the end of conceptName', () => {
+    const searchedWord = 'Finding';
+    const conceptName = 'Clinical Finding';
+
+    const result = span([span(['Clinical ']), strong(['Finding']), span([''])]);
+
+    expect(HighlightConceptName(conceptName, searchedWord)).toStrictEqual(result);
+  });
+});
+
+describe('test HighlightConceptName', () => {
+  test('searchedWord in the not in conceptName: "XXX" in "Clinical Finding"', () => {
+    const searchedWord = 'XXX';
+    const conceptName = 'Clinical Finding';
+
+    const result = span(['Clinical Finding']);
+
+    expect(HighlightConceptName(conceptName, searchedWord)).toStrictEqual(result);
+  });
+});
+
+describe('test HighlightConceptName', () => {
+  test('searchedWord in the not in conceptName: "Clinical" in "Clin"', () => {
+    const searchedWord = 'Clinical';
+    const conceptName = 'Clin';
+
+    const result = span(['Clin']);
+
+    expect(HighlightConceptName(conceptName, searchedWord)).toStrictEqual(result);
+  });
+});
+
+describe('test HighlightConceptName', () => {
+  test('searchedWord is empty: "" ', () => {
+    const searchedWord = '';
+    const conceptName = 'Condition';
+
+    const result = span(['Condition']);
+
+    expect(HighlightConceptName(conceptName, searchedWord)).toStrictEqual(result);
+  });
+});
+
+describe('test HighlightConceptName', () => {
+  test('searchedWord is empty has one spaces', () => {
+    const searchedWord = ' ';
+    const conceptName = 'Clinical Finding';
+
+    const result = span(['Clinical Finding']);
+
+    expect(HighlightConceptName(conceptName, searchedWord)).toStrictEqual(result);
+  });
+});
+
+describe('test HighlightConceptName', () => {
+  test('searchedWord is empty has three spaces', () => {
+    const searchedWord = '   ';
+    const conceptName = 'Clinical Finding';
+
+    const result = span(['Clinical Finding']);
+
+    expect(HighlightConceptName(conceptName, searchedWord)).toStrictEqual(result);
   });
 });

--- a/src/dataset-builder/DatasetBuilderUtils.test.ts
+++ b/src/dataset-builder/DatasetBuilderUtils.test.ts
@@ -184,99 +184,94 @@ describe('test conversion of DatasetAccessRequest', () => {
 
 describe('test HighlightConceptName', () => {
   test('searching beginning of conceptName', () => {
-    const searchedWord = 'Clinic';
+    const searchFilter = 'Clinic';
     const conceptName = 'Clinical Finding';
 
     const result = span([span(['']), strong(['Clinic']), span(['al Finding'])]);
-
-    expect(HighlightConceptName(conceptName, searchedWord)).toStrictEqual(result);
+    expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
   });
 });
 
 describe('test HighlightConceptName', () => {
-  test('Testing to make sure Clin is capitalized', () => {
-    const searchedWord = 'clin';
+  test("Testing to make sure capitalization doesn't change", () => {
+    const searchFilter = 'clin';
     const conceptName = 'Clinical Finding';
 
     const result = span([span(['']), strong(['Clin']), span(['ical Finding'])]);
 
-    expect(HighlightConceptName(conceptName, searchedWord)).toStrictEqual(result);
+    expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
   });
 });
 
 describe('test HighlightConceptName', () => {
   test('searchedWord in the middle of conceptName', () => {
-    const searchedWord = 'cal';
+    const searchFilter = 'cal';
     const conceptName = 'Clinical Finding';
 
     const result = span([span(['Clini']), strong(['cal']), span([' Finding'])]);
 
-    expect(HighlightConceptName(conceptName, searchedWord)).toStrictEqual(result);
+    expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
   });
 });
 
 describe('test HighlightConceptName', () => {
   test('searchedWord in the end of conceptName', () => {
-    const searchedWord = 'Finding';
+    const searchFilter = 'Finding';
     const conceptName = 'Clinical Finding';
 
     const result = span([span(['Clinical ']), strong(['Finding']), span([''])]);
 
-    expect(HighlightConceptName(conceptName, searchedWord)).toStrictEqual(result);
+    expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
   });
 });
 
 describe('test HighlightConceptName', () => {
   test('searchedWord in the not in conceptName: "XXX" in "Clinical Finding"', () => {
-    const searchedWord = 'XXX';
+    const searchFilter = 'XXX';
     const conceptName = 'Clinical Finding';
 
     const result = span(['Clinical Finding']);
 
-    expect(HighlightConceptName(conceptName, searchedWord)).toStrictEqual(result);
+    expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
   });
 });
 
 describe('test HighlightConceptName', () => {
   test('searchedWord in the not in conceptName: "Clinical" in "Clin"', () => {
-    const searchedWord = 'Clinical';
+    const searchFilter = 'Clinical';
     const conceptName = 'Clin';
 
     const result = span(['Clin']);
 
-    expect(HighlightConceptName(conceptName, searchedWord)).toStrictEqual(result);
+    expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
   });
 });
 
 describe('test HighlightConceptName', () => {
   test('searchedWord is empty: "" ', () => {
-    const searchedWord = '';
+    const searchFilter = '';
     const conceptName = 'Condition';
 
     const result = span(['Condition']);
 
-    expect(HighlightConceptName(conceptName, searchedWord)).toStrictEqual(result);
+    expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
   });
 });
 
 describe('test HighlightConceptName', () => {
-  test('searchedWord is empty has one spaces', () => {
-    const searchedWord = ' ';
-    const conceptName = 'Clinical Finding';
+  test("doesn't bold whitespace", () => {
+    let searchFilter = ' ';
+    let conceptName = 'Clinical Finding';
 
-    const result = span(['Clinical Finding']);
+    let result = span(['Clinical Finding']);
 
-    expect(HighlightConceptName(conceptName, searchedWord)).toStrictEqual(result);
-  });
-});
+    expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
 
-describe('test HighlightConceptName', () => {
-  test('searchedWord is empty has three spaces', () => {
-    const searchedWord = '   ';
-    const conceptName = 'Clinical Finding';
+    searchFilter = '   ';
+    conceptName = 'Clinical Finding';
 
-    const result = span(['Clinical Finding']);
+    result = span(['Clinical Finding']);
 
-    expect(HighlightConceptName(conceptName, searchedWord)).toStrictEqual(result);
+    expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
   });
 });

--- a/src/dataset-builder/DatasetBuilderUtils.ts
+++ b/src/dataset-builder/DatasetBuilderUtils.ts
@@ -271,15 +271,19 @@ export const convertProgramDataOptionToRangeOption = (
   }
 };
 
-export const boldSubsetWord = (conceptName: string, searchedWord: string): ReactElement => {
-  const startIndex = conceptName.toLowerCase().indexOf(searchedWord.toLowerCase());
-  if (startIndex === -1) {
-    return span([conceptName]); // searchedWord is not found in conceptName
+export const HighlightConceptName = (conceptName: string, searchFilter: string): ReactElement => {
+  const startIndex = conceptName.toLowerCase().indexOf(searchFilter.toLowerCase());
+
+  // searchFilter is empty or does not exist in conceptName
+  if (startIndex < 0 || searchFilter.trim() === '') {
+    return span([conceptName]);
   }
-  const endIndex = startIndex + searchedWord.length;
+
+  const endIndex = startIndex + searchFilter.length;
+
   return span([
-    conceptName.substring(0, startIndex),
+    span([conceptName.substring(0, startIndex)]),
     strong([conceptName.substring(startIndex, endIndex)]),
-    conceptName.substring(endIndex),
+    span([conceptName.substring(endIndex)]),
   ]);
 };

--- a/src/dataset-builder/DatasetBuilderUtils.ts
+++ b/src/dataset-builder/DatasetBuilderUtils.ts
@@ -1,5 +1,9 @@
 // Types that can be used to create a criteria.
+// @ts-ignore
+
 import _ from 'lodash/fp';
+import { ReactElement } from 'react';
+import { span, strong } from 'react-hyperscript-helpers';
 import {
   ColumnStatisticsIntOrDoubleModel,
   ColumnStatisticsTextModel,
@@ -265,4 +269,17 @@ export const convertProgramDataOptionToRangeOption = (
         `Datatype ${statistics.dataType} for ${programDataOption.tableName}/${programDataOption.columnName} is not numeric`
       );
   }
+};
+
+export const boldSubsetWord = (conceptName: string, searchedWord: string): ReactElement => {
+  const startIndex = conceptName.toLowerCase().indexOf(searchedWord.toLowerCase());
+  if (startIndex === -1) {
+    return span([conceptName]); // searchedWord is not found in conceptName
+  }
+  const endIndex = startIndex + searchedWord.length;
+  return span([
+    conceptName.substring(0, startIndex),
+    strong([conceptName.substring(startIndex, endIndex)]),
+    conceptName.substring(endIndex),
+  ]);
 };

--- a/src/dataset-builder/DatasetBuilderUtils.ts
+++ b/src/dataset-builder/DatasetBuilderUtils.ts
@@ -268,7 +268,7 @@ export const convertProgramDataOptionToRangeOption = (
   }
 };
 
-export const HighlightConceptName = (conceptName: string, searchFilter: string): ReactElement => {
+export const HighlightConceptName = ({ conceptName, searchFilter }): ReactElement => {
   const startIndex = conceptName.toLowerCase().indexOf(searchFilter.toLowerCase());
 
   // searchFilter is empty or does not exist in conceptName

--- a/src/dataset-builder/DatasetBuilderUtils.ts
+++ b/src/dataset-builder/DatasetBuilderUtils.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp';
 import { ReactElement } from 'react';
-import { span, strong } from 'react-hyperscript-helpers';
+import { div } from 'react-hyperscript-helpers';
 import {
   ColumnStatisticsIntOrDoubleModel,
   ColumnStatisticsTextModel,
@@ -273,14 +273,14 @@ export const HighlightConceptName = ({ conceptName, searchFilter }): ReactElemen
 
   // searchFilter is empty or does not exist in conceptName
   if (startIndex < 0 || searchFilter.trim() === '') {
-    return span([conceptName]);
+    return div([conceptName]);
   }
 
   const endIndex = startIndex + searchFilter.length;
 
-  return span([
-    span([conceptName.substring(0, startIndex)]),
-    strong([conceptName.substring(startIndex, endIndex)]),
-    span([conceptName.substring(endIndex)]),
+  return div({ style: { display: 'flex' } }, [
+    div([conceptName.substring(0, startIndex)]),
+    div({ style: { fontWeight: 600 } }, [conceptName.substring(startIndex, endIndex)]),
+    div([conceptName.substring(endIndex)]),
   ]);
 };

--- a/src/dataset-builder/DatasetBuilderUtils.ts
+++ b/src/dataset-builder/DatasetBuilderUtils.ts
@@ -1,6 +1,3 @@
-// Types that can be used to create a criteria.
-// @ts-ignore
-
 import _ from 'lodash/fp';
 import { ReactElement } from 'react';
 import { span, strong } from 'react-hyperscript-helpers';


### PR DESCRIPTION
### Jira Ticket: [Ticket](https://broadworkbench.atlassian.net/browse/DC-808) 
<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

Branching off of [Text search of Domain-based concepts](https://broadworkbench.atlassian.net/browse/DC-786)

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

Where the domain based concept is listed, the searched term is going to be bolded in the concept name. 


### What
- Where concept names are displayed, we are going to add a function `HighlightConceptName` which takes both the searched term and concept name and returns a ReactElement of the bolded domain phrase.

### Why
- To help users identify where their searched term is in returned domain based concepts

### Testing strategy
- Jest Testing on edge cases where: 
- Search term is in the front of concept name
- Search term is in the middle of concept name
- Search term is in the end of concept name
- Search term is empty
- Search term does not exist in concept name

<!-- ### Visual Aids -->

https://github.com/DataBiosphere/terra-ui/assets/63474660/9848deb5-162a-4345-bba4-ecf03a2242b0

