### PR TITLE
[IA-4783] Increase Stability of IA integration tests.

### DIFF
--- a/integration-tests/tests/run-analysis-azure.ts
+++ b/integration-tests/tests/run-analysis-azure.ts
@@ -1,3 +1,5 @@
+import { dismissAllNotifications } from '../utils/integration-utils';
+
 // This test is owned by the Interactive Analysis (IA) Team.
 const _ = require('lodash/fp');
 const uuid = require('uuid');
@@ -10,13 +12,11 @@ const {
   dismissInfoNotifications,
   fillIn,
   findElement,
-  findErrorPopup,
   findIframe,
   findText,
   getAnimatedDrawer,
   input,
   noSpinnersAfter,
-  openError,
   waitForNoModal,
 } = require('../utils/integration-utils');
 const { registerTest } = require('../utils/jest-utils');
@@ -64,14 +64,11 @@ const testRunAnalysisAzure = _.flowRight(
   await findElement(page, clickable({ textContains: 'Creating' }));
 
   // Wait for env to finish creating, or break early on error
-  await Promise.race([
-    findElement(page, clickable({ textContains: 'Running' }), { timeout: Millis.ofMinutes(18) }),
-    findErrorPopup(page, { timeout: Millis.ofMinutes(18) }),
-  ]);
-  const hasError = await openError(page);
-  if (hasError) {
-    throw new Error('Failed to create cloud environment');
-  }
+  await findElement(page, clickable({ textContains: 'Running' }), { timeout: Millis.ofMinutes(18) });
+
+  // Here, we dismiss any errors or popups. Its common another areas of the application might throw an error or have pop-ups.
+  // However, as long as we have a running runtime (which the previous section asserts), the pop-up is not relevant
+  await dismissAllNotifications(page);
 
   await click(page, clickable({ textContains: 'Open' }));
 

--- a/integration-tests/tests/run-analysis-azure.ts
+++ b/integration-tests/tests/run-analysis-azure.ts
@@ -1,5 +1,3 @@
-import { dismissAllNotifications } from '../utils/integration-utils';
-
 // This test is owned by the Interactive Analysis (IA) Team.
 const _ = require('lodash/fp');
 const uuid = require('uuid');
@@ -9,6 +7,7 @@ const {
   click,
   clickable,
   delay,
+  dismissAllNotifications,
   dismissInfoNotifications,
   fillIn,
   findElement,

--- a/integration-tests/tests/run-analysis.js
+++ b/integration-tests/tests/run-analysis.js
@@ -8,15 +8,14 @@ const {
   clickable,
   delay,
   dismissInfoNotifications,
+  dismissAllNotifications,
   fillIn,
   findElement,
-  findErrorPopup,
   findIframe,
   findText,
   getAnimatedDrawer,
   input,
   noSpinnersAfter,
-  openError,
   waitForNoModal,
 } = require('../utils/integration-utils');
 const { registerTest } = require('../utils/jest-utils');
@@ -66,15 +65,12 @@ const testRunAnalysisFn = _.flowRight(
   await findElement(page, clickable({ textContains: 'Jupyter Environment' }), { timeout: Millis.ofSeconds(40) });
   await findElement(page, clickable({ textContains: 'Creating' }), { timeout: Millis.ofSeconds(40) });
 
-  // Wait for env to finish creating, or break early on error
-  await Promise.race([
-    findElement(page, clickable({ textContains: 'Running' }), { timeout: Millis.ofMinutes(12) }),
-    findErrorPopup(page, { timeout: Millis.ofMinutes(12) }),
-  ]);
-  const hasError = await openError(page);
-  if (hasError) {
-    throw new Error('Failed to create cloud environment');
-  }
+  // Wait for env to finish creating
+  await findElement(page, clickable({ textContains: 'Running' }), { timeout: Millis.ofMinutes(12) });
+
+  // Here, we dismiss any errors or popups. Its common another areas of the application might throw an error or have pop-ups.
+  // However, as long as we have a running runtime (which the previous section asserts), the pop-up is not relevant
+  await dismissAllNotifications(page);
 
   await click(page, clickable({ textContains: 'Open' }));
 

--- a/integration-tests/tests/run-rstudio.js
+++ b/integration-tests/tests/run-rstudio.js
@@ -8,15 +8,14 @@ const {
   clickable,
   delay,
   dismissInfoNotifications,
+  dismissAllNotifications,
   fillIn,
   findElement,
-  findErrorPopup,
   findIframe,
   findText,
   getAnimatedDrawer,
   input,
   noSpinnersAfter,
-  openError,
   waitForNoModal,
 } = require('../utils/integration-utils');
 const { registerTest } = require('../utils/jest-utils');
@@ -67,17 +66,13 @@ const testRunRStudioFn = _.flowRight(
   await findElement(page, clickable({ textContains: 'RStudio Environment' }), { timeout: Millis.ofMinutes(2) });
   await findElement(page, clickable({ textContains: 'Creating' }), { timeout: Millis.ofSeconds(40) });
 
-  // Wait for env to finish creating, or break early on error
-  await Promise.race([
-    findElement(page, clickable({ textContains: 'Running' }), { timeout: Millis.ofMinutes(12) }),
-    findErrorPopup(page, { timeout: Millis.ofMinutes(12) }),
-  ]);
-  const hasError = await openError(page);
-  if (hasError) {
-    throw new Error('Failed to create cloud environment');
-  }
+  // Wait for env to finish creating
+  await findElement(page, clickable({ textContains: 'Running' }), { timeout: Millis.ofMinutes(12) });
 
-  await dismissInfoNotifications(page);
+  // Here, we dismiss any errors or popups. Its common another areas of the application might throw an error or have pop-ups.
+  // However, as long as we have a running runtime (which the previous section asserts), the pop-up is not relevant
+  await dismissAllNotifications(page);
+
   await click(page, clickable({ textContains: 'Open' }));
 
   // Find the iframe, wait until the RStudio iframe is loaded, and execute some code


### PR DESCRIPTION
There are numerous runs as of late where the integration suite fails  because of 500s from orch and a resultant error pop-up (shown below). It can occur in `run-analysis` or `run-studio`. 

We attempted to add logic recently to fail-fast if there is an error pop-up in those tests, but I believe this is trying to have the test be too smart for its own good. Terra UI is a large app and there can be multiple sources of errors. Rather than trying to fail-fast, we should rather rely our assertions to fail (namely the one that a runtime reaches `Creating` and the subsequent assertions). Down the line, if this becomes an issue, we can indeed choose to fail-fast on specific errors, but this is not a necessary requirement/optimization, the tests do not take too long.  

Example run 1: https://circleci.com/gh/DataBiosphere/terra-ui/75166
Example run 2: https://circleci.com/gh/DataBiosphere/terra-ui/75176

![image](https://github.com/DataBiosphere/terra-ui/assets/6465084/03cf403c-f4e3-4bbd-be9d-193bda48bfa1)
