### PR TITLE
[WX-1428] Create TypeScript component for FilterableWorkflowTable on Submission Details page

### DIFF
--- a/src/workflows-app/SubmissionDetails.js
+++ b/src/workflows-app/SubmissionDetails.js
@@ -28,7 +28,6 @@ export const BaseSubmissionDetails = ({ name, namespace, workspace, submissionId
   const [runsData, setRunsData] = useState();
   const [runsFullyUpdated, setRunsFullyUpdated] = useState();
   const [loading, setLoading] = useState(false);
-
   const [runSetData, setRunSetData] = useState();
   const [methodsData, setMethodsData] = useState();
 

--- a/src/workflows-app/SubmissionDetails.js
+++ b/src/workflows-app/SubmissionDetails.js
@@ -1,21 +1,16 @@
 import _ from 'lodash/fp';
 import { useCallback, useMemo, useRef, useState } from 'react';
-import { div, h, h2, h3, span } from 'react-hyperscript-helpers';
-import { AutoSizer } from 'react-virtualized';
-import { ClipboardButton } from 'src/components/ClipboardButton';
-import { ButtonPrimary, Link, Select } from 'src/components/common';
+import { div, h, h2, h3 } from 'react-hyperscript-helpers';
+import { Link } from 'src/components/common';
 import { centeredSpinner, icon } from 'src/components/icons';
-import Modal from 'src/components/Modal';
-import { FlexTable, paginator, Sortable, tableHeight, TextCell } from 'src/components/table';
 import { Ajax } from 'src/libs/ajax';
-import colors from 'src/libs/colors';
 import * as Nav from 'src/libs/nav';
 import { notify } from 'src/libs/notifications';
 import { useCancellation, useOnMount, usePollingEffect } from 'src/libs/react-utils';
 import { AppProxyUrlStatus, workflowsAppStore } from 'src/libs/state';
 import * as Utils from 'src/libs/utils';
-import { customFormatDuration, differenceFromNowInSeconds, makeCompleteDate } from 'src/libs/utils';
-import { HeaderSection, statusType, SubmitNewWorkflowButton } from 'src/workflows-app/components/job-common';
+import { customFormatDuration, makeCompleteDate } from 'src/libs/utils';
+import { HeaderSection, SubmitNewWorkflowButton } from 'src/workflows-app/components/job-common';
 import { doesAppProxyUrlExist, loadAppUrls } from 'src/workflows-app/utils/app-utils';
 import {
   AutoRefreshInterval,
@@ -23,68 +18,23 @@ import {
   getDuration,
   isRunInTerminalState,
   isRunSetInTerminalState,
-  makeStatusLine,
 } from 'src/workflows-app/utils/submission-utils';
 import { wrapWorkflowsPage } from 'src/workflows-app/WorkflowsContainer';
 
+import FilterableWorkflowTable from './components/FilterableWorkflowTable';
+
 export const BaseSubmissionDetails = ({ name, namespace, workspace, submissionId }, _ref) => {
   // State
-  const [sort, setSort] = useState({ field: 'duration', direction: 'desc' });
-  const [pageNumber, setPageNumber] = useState(1);
-  const [itemsPerPage, setItemsPerPage] = useState(50);
-  const [viewErrorsId, setViewErrorsId] = useState();
   const [runsData, setRunsData] = useState();
   const [runsFullyUpdated, setRunsFullyUpdated] = useState();
   const [loading, setLoading] = useState(false);
 
   const [runSetData, setRunSetData] = useState();
   const [methodsData, setMethodsData] = useState();
-  const [filterOption, setFilterOption] = useState(null);
 
   const signal = useCancellation();
   const scheduledRefresh = useRef();
   const workspaceId = workspace.workspace.workspaceId;
-
-  const getFilter = (filterOption) => {
-    let filterStatement;
-    switch (filterOption) {
-      case 'Error':
-        filterStatement = _.filter((r) => errorStates.includes(r.state));
-        break;
-      case 'Succeeded':
-        filterStatement = _.filter((r) => r.state === 'COMPLETE');
-        break;
-      default:
-        filterStatement = (data) => data;
-    }
-    return filterStatement;
-  };
-
-  const state = (state, submissionDate) => {
-    switch (state) {
-      case 'SYSTEM_ERROR':
-      case 'EXECUTOR_ERROR':
-        return statusType.failed;
-      case 'COMPLETE':
-        return statusType.succeeded;
-      case 'INITIALIZING':
-        return statusType.initializing;
-      case 'QUEUED':
-        return statusType.queued;
-      case 'RUNNING':
-        return statusType.running;
-      case 'PAUSED':
-        return statusType.paused;
-      case 'CANCELED':
-        return statusType.canceled;
-      case 'CANCELING':
-        return statusType.canceling;
-      default:
-        // 10 seconds should be enough for Cromwell to summarize the new workflow and get a status other
-        // than UNKNOWN. In the meantime, handle this as an edge case in the UI:
-        return differenceFromNowInSeconds(submissionDate) < 10 ? statusType.initializing : statusType.unknown;
-    }
-  };
 
   const loadMethodsData = useCallback(
     async (cbasUrlRoot, methodId, methodVersion) => {
@@ -220,15 +170,6 @@ export const BaseSubmissionDetails = ({ name, namespace, workspace, submissionId
   const methodId = filteredRunSets[0]?.method_id;
   const getSpecificMethod = _.filter((m) => m.method_id === methodId, methodsData);
 
-  const errorStates = ['SYSTEM_ERROR', 'EXECUTOR_ERROR'];
-  const filteredPreviousRuns = filterOption ? getFilter(filterOption)(runsData) : runsData;
-  const sortedPreviousRuns = _.orderBy(sort.field, sort.direction, filteredPreviousRuns);
-  const filterOptions = ['Error', 'No filter', 'Succeeded'];
-
-  const firstPageIndex = (pageNumber - 1) * itemsPerPage;
-  const lastPageIndex = firstPageIndex + itemsPerPage;
-  const paginatedPreviousRuns = sortedPreviousRuns.slice(firstPageIndex, lastPageIndex);
-
   const header = useMemo(() => {
     const breadcrumbPathObjects = [
       {
@@ -244,8 +185,6 @@ export const BaseSubmissionDetails = ({ name, namespace, workspace, submissionId
     return h(HeaderSection, { breadcrumbPathObjects, button: h(SubmitNewWorkflowButton, { name, namespace }), title: 'Submission Details' });
   }, [name, namespace, submissionId]);
 
-  const rowWidth = 100;
-  const rowHeight = 50;
   return loading
     ? centeredSpinner()
     : div({ id: 'submission-details-page' }, [
@@ -298,179 +237,7 @@ export const BaseSubmissionDetails = ({ name, namespace, workspace, submissionId
             ]),
           ]
         ),
-        div(
-          {
-            style: {
-              backgroundColor: 'rgb(235, 236, 238)',
-              display: 'flex',
-              flex: '1 1 auto',
-              flexDirection: 'column',
-              padding: '1rem 3rem',
-            },
-          },
-          [
-            div(
-              {
-                style: {
-                  marginTop: '1em',
-                  height: tableHeight({ actualRows: paginatedPreviousRuns.length, maxRows: 12.5, heightPerRow: 250 }),
-                  minHeight: '10em',
-                },
-              },
-              [
-                div([h2(['Workflows'])]),
-                runsFullyUpdated
-                  ? div([icon('check', { size: 15, style: { color: colors.success() } }), ' Workflow statuses are all up to date.'])
-                  : div([
-                      icon('warning-standard', { size: 15, style: { color: colors.warning() } }),
-                      ' Some workflow statuses are not up to date. Refreshing the page may update more statuses.',
-                    ]),
-                div([h3(['Filter by: '])]),
-                h(Select, {
-                  isDisabled: false,
-                  'aria-label': 'Filter selection',
-                  isClearable: false,
-                  value: filterOption,
-                  placeholder: 'None selected',
-                  onChange: ({ value }) => {
-                    setFilterOption(value);
-                  },
-                  styles: { container: (old) => ({ ...old, display: 'inline-block', width: 200, marginBottom: '1.5rem' }) },
-                  options: filterOptions,
-                }),
-                h(AutoSizer, [
-                  ({ width, height }) =>
-                    h(FlexTable, {
-                      'aria-label': 'previous runs',
-                      width,
-                      height,
-                      sort,
-                      rowCount: paginatedPreviousRuns.length,
-                      noContentMessage: 'Nothing here yet! Your previously run workflows will be displayed here.',
-                      hoverHighlight: true,
-                      rowHeight,
-                      rowWidth,
-                      columns: [
-                        {
-                          size: { basis: 350 },
-                          field: 'record_id',
-                          headerRenderer: () => h(Sortable, { sort, field: 'record_id', onSort: setSort }, ['Sample ID']),
-                          cellRenderer: ({ rowIndex }) => {
-                            const engineId = paginatedPreviousRuns[rowIndex].engine_id;
-
-                            // Engine id may be undefined if CBAS failed to submit to Cromwell
-                            if (engineId === undefined) return h(TextCell, [paginatedPreviousRuns[rowIndex].record_id]);
-
-                            return div({ style: { width: '100%', textAlign: 'left' } }, [
-                              h(
-                                Link,
-                                {
-                                  href: Nav.getLink('workspace-workflows-app-run-details', {
-                                    namespace,
-                                    name,
-                                    submissionId,
-                                    workflowId: engineId,
-                                  }),
-                                  style: { fontWeight: 'bold' },
-                                },
-                                [paginatedPreviousRuns[rowIndex].record_id]
-                              ),
-                            ]);
-                          },
-                        },
-                        {
-                          size: { basis: 600, grow: 0 },
-                          field: 'state',
-                          headerRenderer: () => h(Sortable, { sort, field: 'state', onSort: setSort }, ['Status']),
-                          cellRenderer: ({ rowIndex }) => {
-                            const status = state(paginatedPreviousRuns[rowIndex].state, paginatedPreviousRuns[rowIndex].submission_date);
-                            if (errorStates.includes(paginatedPreviousRuns[rowIndex].state)) {
-                              return div({ style: { width: '100%', textAlign: 'center' } }, [
-                                h(Link, { key: 'error link', style: { fontWeight: 'bold' }, onClick: () => setViewErrorsId(rowIndex) }, [
-                                  makeStatusLine((style) => status.icon(style), status.label(paginatedPreviousRuns[rowIndex].state), {
-                                    textAlign: 'center',
-                                  }),
-                                ]),
-                              ]);
-                            }
-                            return h(TextCell, { style: { fontWeight: 'bold' } }, [
-                              makeStatusLine((style) => status.icon(style), status.label(paginatedPreviousRuns[rowIndex].state), {
-                                textAlign: 'center',
-                              }),
-                            ]);
-                          },
-                        },
-                        {
-                          size: { basis: 500, grow: 0 },
-                          field: 'duration',
-                          headerRenderer: () => h(Sortable, { sort, field: 'duration', onSort: setSort }, ['Duration']),
-                          cellRenderer: ({ rowIndex }) => {
-                            return h(TextCell, [customFormatDuration(paginatedPreviousRuns[rowIndex].duration)]);
-                          },
-                        },
-                        {
-                          size: { basis: 400, grow: 0 },
-                          field: 'workflowId',
-                          headerRenderer: () => h(Sortable, { sort, field: 'workflowId', onSort: setSort }, ['Workflow ID']),
-                          cellRenderer: ({ rowIndex }) => {
-                            const engineId = paginatedPreviousRuns[rowIndex].engine_id;
-                            if (engineId !== undefined) {
-                              return h(TextCell, [
-                                span({ style: { marginRight: '0.5rem' } }, [engineId]),
-                                span({}, [h(ClipboardButton, { text: engineId, 'aria-label': 'Copy workflow id' })]),
-                              ]);
-                            }
-                          },
-                        },
-                      ],
-                    }),
-                ]),
-              ]
-            ),
-            !_.isEmpty(sortedPreviousRuns) &&
-              div({ style: { bottom: 0, position: 'absolute', marginBottom: '1.5rem', right: '4rem' } }, [
-                paginator({
-                  filteredDataLength: sortedPreviousRuns.length,
-                  unfilteredDataLength: sortedPreviousRuns.length,
-                  pageNumber,
-                  setPageNumber,
-                  itemsPerPage,
-                  setItemsPerPage: (v) => {
-                    setPageNumber(1);
-                    setItemsPerPage(v);
-                  },
-                  itemsPerPageOptions: [10, 25, 50, 100],
-                }),
-              ]),
-            viewErrorsId !== undefined &&
-              h(
-                Modal,
-                {
-                  title: 'Error Messages',
-                  width: 600,
-                  onDismiss: () => setViewErrorsId(undefined),
-                  showCancel: false,
-                  okButton: h(
-                    ButtonPrimary,
-                    {
-                      disabled: false,
-                      onClick: () => setViewErrorsId(undefined),
-                    },
-                    ['OK']
-                  ),
-                },
-                [
-                  h(
-                    TextCell,
-                    {
-                      style: { textAlign: 'center', whiteSpace: 'pre-wrap', wordBreak: 'break-word', margin: '3rem', marginBottom: '1rem' },
-                    },
-                    [paginatedPreviousRuns[viewErrorsId]?.error_messages]
-                  ),
-                ]
-              ),
-          ]
-        ),
+        div([h(FilterableWorkflowTable, { runsData, runsFullyUpdated, namespace, submissionId, workspaceName: name })]),
       ]);
 };
 

--- a/src/workflows-app/components/FilterableWorkflowTable.ts
+++ b/src/workflows-app/components/FilterableWorkflowTable.ts
@@ -1,0 +1,346 @@
+import _ from 'lodash/fp';
+import { useState } from 'react';
+import { div, h, h2, h3, span } from 'react-hyperscript-helpers';
+import { AutoSizer } from 'react-virtualized';
+import { ClipboardButton } from 'src/components/ClipboardButton';
+import { ButtonPrimary, Link, Select } from 'src/components/common';
+import { icon } from 'src/components/icons';
+import { FlexTable, paginator, Sortable, tableHeight, TextCell } from 'src/components/table';
+import colors from 'src/libs/colors';
+import * as Nav from 'src/libs/nav';
+import { customFormatDuration } from 'src/libs/utils';
+import { statusType } from 'src/workflows-app/components/job-common';
+import { makeStatusLine } from 'src/workflows-app/utils/submission-utils';
+
+// interface PaginatorProps {
+//   filteredDataLength: number;
+//   unfilteredDataLength: number;
+//   pageNumber: number;
+//   setPageNumber: function(number);
+//   setItemsPerPage: (num: number) => void;
+//   itemsPerPage: number;
+//   itemsPerPageOptions: number[];
+// };
+
+type Run = {
+  duration: number;
+  engine_id: string | undefined;
+  last_modified_timestamp: Date;
+  last_polled_timestamp: Date;
+  record_id: string;
+  run_id: string;
+  run_set_id: string;
+  state: string;
+  submission_date: Date;
+  workflow_outputs: string;
+  workflow_params: string;
+  workflow_url: string;
+  error_messages: string | undefined;
+};
+
+type FilterableWorkflowTableProps = {
+  runsData: Run[];
+  runsFullyUpdated: boolean;
+  namespace: string;
+  submissionId: string;
+  workspaceName: string;
+};
+
+const FilterableWorkflowTable = ({
+  runsData,
+  runsFullyUpdated,
+  namespace,
+  submissionId,
+  workspaceName,
+}: FilterableWorkflowTableProps) => {
+  const [itemsPerPage, setItemsPerPage] = useState(50);
+  const [filterOption, setFilterOption] = useState<string>(null);
+  const [pageNumber, setPageNumber] = useState(1);
+  const [sort, setSort] = useState({ field: 'duration', direction: 'desc' });
+  const [viewErrorsId, setViewErrorsId] = useState<number>();
+
+  const getFilteredRuns = (filterOption: string, runsData: Run[]): Run[] => {
+    const filteredRuns: Run[] = [];
+
+    for (const run of runsData) {
+      switch (filterOption) {
+        case 'Error':
+          if (errorStates.includes(run.state)) {
+            filteredRuns.push(run);
+          }
+          break;
+        case 'Succeeded':
+          if (run.state === 'COMPLETE') {
+            filteredRuns.push(run);
+          }
+          break;
+        default:
+          filteredRuns.push(run);
+      }
+    }
+
+    return filteredRuns;
+  };
+
+  enum FilterOptions {
+    Error = 'Error',
+    NoFilter = 'No filter',
+    Succeeded = 'Succeeded',
+  }
+
+  const filteredPreviousRuns: Run[] = filterOption ? getFilteredRuns(filterOption, runsData) : runsData;
+  const filterOptions: FilterOptions[] = [FilterOptions.Error, FilterOptions.NoFilter, FilterOptions.Succeeded];
+  const firstPageIndex: number = (pageNumber - 1) * itemsPerPage;
+  const lastPageIndex: number = firstPageIndex + itemsPerPage;
+  const sortedPreviousRuns: Run[] = _.orderBy(sort.field, sort.direction, filteredPreviousRuns);
+  const paginatedPreviousRuns: Run[] = sortedPreviousRuns.slice(firstPageIndex, lastPageIndex);
+  const rowWidth = 100;
+  const rowHeight = 50;
+  const errorStates = ['SYSTEM_ERROR', 'EXECUTOR_ERROR'];
+
+  // const paginatorProps: PaginatorProps = {
+  //   filteredDataLength: sortedPreviousRuns.length,
+  //   unfilteredDataLength: sortedPreviousRuns.length,
+  //   pageNumber,
+  //   setPageNumber,
+  //   itemsPerPage,
+  //   setItemsPerPage: (v) => {
+  //     setPageNumber(1);
+  //     setItemsPerPage(v);
+  //   },
+  //   itemsPerPageOptions: [10, 25, 50, 100],
+  // };
+
+  const state = (
+    state: string,
+    submissionDate: Date
+  ): { id: string; label: (state: string) => string; icon: (style: any) => any } => {
+    switch (state) {
+      case 'SYSTEM_ERROR':
+      case 'EXECUTOR_ERROR':
+        return statusType.failed;
+      case 'COMPLETE':
+        return statusType.succeeded;
+      case 'INITIALIZING':
+        return statusType.initializing;
+      case 'QUEUED':
+        return statusType.queued;
+      case 'RUNNING':
+        return statusType.running;
+      case 'PAUSED':
+        return statusType.paused;
+      case 'CANCELED':
+        return statusType.canceled;
+      case 'CANCELING':
+        return statusType.canceling;
+      default:
+        // 10 seconds should be enough for Cromwell to summarize the new workflow and get a status other
+        // than UNKNOWN. In the meantime, handle this as an edge case in the UI:
+        return differenceFromNowInSeconds(submissionDate) < 10 ? statusType.initializing : statusType.unknown;
+    }
+  };
+
+  return div(
+    {
+      style: {
+        backgroundColor: 'rgb(235, 236, 238)',
+        display: 'flex',
+        flex: '1 1 auto',
+        flexDirection: 'column',
+        padding: '1rem 3rem',
+      },
+    },
+    [
+      div(
+        {
+          style: {
+            marginTop: '1em',
+            height: tableHeight({ actualRows: paginatedPreviousRuns.length, maxRows: 12.5, heightPerRow: 250 }),
+            minHeight: '10em',
+          },
+        },
+        [
+          div([h2(['Workflows'])]),
+          runsFullyUpdated
+            ? div([
+                icon('check', { size: 15, style: { color: colors.success() } }),
+                ' Workflow statuses are all up to date.',
+              ])
+            : div([
+                icon('warning-standard', { size: 15, style: { color: colors.warning() } }),
+                ' Some workflow statuses are not up to date. Refreshing the page may update more statuses.',
+              ]),
+          div([h3(['Filter by: '])]),
+          h(Select, {
+            isDisabled: false,
+            'aria-label': 'Filter selection',
+            isClearable: false,
+            value: filterOption,
+            placeholder: 'None selected',
+            onChange: ({ value }) => {
+              setFilterOption(value);
+            },
+            styles: { container: (old) => ({ ...old, display: 'inline-block', width: 200, marginBottom: '1.5rem' }) },
+            options: filterOptions,
+          }),
+          h(AutoSizer, [
+            ({ width, height }) =>
+              h(FlexTable, {
+                'aria-label': 'previous runs',
+                width,
+                height,
+                sort,
+                rowCount: paginatedPreviousRuns.length,
+                noContentMessage: 'Nothing here yet! Your previously run workflows will be displayed here.',
+                hoverHighlight: true,
+                rowHeight,
+                rowWidth,
+                columns: [
+                  {
+                    size: { basis: 350 },
+                    field: 'record_id',
+                    headerRenderer: () => h(Sortable, { sort, field: 'record_id', onSort: setSort }, ['Sample ID']),
+                    cellRenderer: ({ rowIndex }) => {
+                      const engineId = paginatedPreviousRuns[rowIndex].engine_id;
+
+                      // Engine id may be undefined if CBAS failed to submit to Cromwell
+                      if (engineId === undefined) return h(TextCell, [paginatedPreviousRuns[rowIndex].record_id]);
+
+                      return div({ style: { width: '100%', textAlign: 'left' } }, [
+                        h(
+                          Link,
+                          {
+                            href: Nav.getLink('workspace-workflows-app-run-details', {
+                              namespace,
+                              name: workspaceName,
+                              submissionId,
+                              workflowId: engineId,
+                            }),
+                            style: { fontWeight: 'bold' },
+                          },
+                          [paginatedPreviousRuns[rowIndex].record_id]
+                        ),
+                      ]);
+                    },
+                  },
+                  {
+                    size: { basis: 600, grow: 0 },
+                    field: 'state',
+                    headerRenderer: () => h(Sortable, { sort, field: 'state', onSort: setSort }, ['Status']),
+                    cellRenderer: ({ rowIndex }) => {
+                      const status = state(
+                        paginatedPreviousRuns[rowIndex].state,
+                        paginatedPreviousRuns[rowIndex].submission_date
+                      );
+                      if (errorStates.includes(paginatedPreviousRuns[rowIndex].state)) {
+                        return div({ style: { width: '100%', textAlign: 'center' } }, [
+                          h(
+                            Link,
+                            {
+                              key: 'error link',
+                              style: { fontWeight: 'bold' },
+                              onClick: () => setViewErrorsId(rowIndex),
+                            },
+                            [
+                              makeStatusLine(
+                                (style) => status.icon(style),
+                                status.label(paginatedPreviousRuns[rowIndex].state),
+                                {
+                                  textAlign: 'center',
+                                }
+                              ),
+                            ]
+                          ),
+                        ]);
+                      }
+                      return h(TextCell, { style: { fontWeight: 'bold' } }, [
+                        makeStatusLine(
+                          (style) => status.icon(style),
+                          status.label(paginatedPreviousRuns[rowIndex].state),
+                          {
+                            textAlign: 'center',
+                          }
+                        ),
+                      ]);
+                    },
+                  },
+                  {
+                    size: { basis: 500, grow: 0 },
+                    field: 'duration',
+                    headerRenderer: () => h(Sortable, { sort, field: 'duration', onSort: setSort }, ['Duration']),
+                    cellRenderer: ({ rowIndex }) => {
+                      return h(TextCell, [customFormatDuration(paginatedPreviousRuns[rowIndex].duration)]);
+                    },
+                  },
+                  {
+                    size: { basis: 400, grow: 0 },
+                    field: 'workflowId',
+                    headerRenderer: () => h(Sortable, { sort, field: 'workflowId', onSort: setSort }, ['Workflow ID']),
+                    cellRenderer: ({ rowIndex }) => {
+                      const engineId = paginatedPreviousRuns[rowIndex].engine_id;
+                      if (engineId !== undefined) {
+                        return h(TextCell, [
+                          span({ style: { marginRight: '0.5rem' } }, [engineId]),
+                          span({}, [h(ClipboardButton, { text: engineId, 'aria-label': 'Copy workflow id' })]),
+                        ]);
+                      }
+                    },
+                  },
+                ],
+              }),
+          ]),
+        ]
+      ),
+      !_.isEmpty(sortedPreviousRuns) &&
+        div({ style: { bottom: 0, position: 'absolute', marginBottom: '1.5rem', right: '4rem' } }, [
+          paginator({
+            filteredDataLength: sortedPreviousRuns.length,
+            unfilteredDataLength: sortedPreviousRuns.length,
+            pageNumber,
+            setPageNumber,
+            itemsPerPage,
+            setItemsPerPage: (v) => {
+              setPageNumber(1);
+              setItemsPerPage(v);
+            },
+            itemsPerPageOptions: [10, 25, 50, 100],
+          }),
+        ]),
+      viewErrorsId !== undefined &&
+        h(
+          Modal,
+          {
+            title: 'Error Messages',
+            width: 600,
+            onDismiss: () => setViewErrorsId(undefined),
+            showCancel: false,
+            okButton: h(
+              ButtonPrimary,
+              {
+                disabled: false,
+                onClick: () => setViewErrorsId(undefined),
+              },
+              ['OK']
+            ),
+          },
+          [
+            h(
+              TextCell,
+              {
+                style: {
+                  textAlign: 'center',
+                  whiteSpace: 'pre-wrap',
+                  wordBreak: 'break-word',
+                  margin: '3rem',
+                  marginBottom: '1rem',
+                },
+              },
+              [paginatedPreviousRuns[viewErrorsId]?.error_messages]
+            ),
+          ]
+        ),
+    ]
+  );
+};
+
+export default FilterableWorkflowTable;

--- a/src/workflows-app/components/FilterableWorkflowTable.ts
+++ b/src/workflows-app/components/FilterableWorkflowTable.ts
@@ -133,8 +133,13 @@ const FilterableWorkflowTable = ({
         {
           style: {
             marginTop: '1em',
-            height: tableHeight({ actualRows: paginatedPreviousRuns.length, maxRows: 12.5, heightPerRow: 250 }),
+            height: tableHeight({
+              actualRows: paginatedPreviousRuns.length,
+              maxRows: paginatedPreviousRuns.length / 5.2,
+              heightPerRow: 250,
+            }),
             minHeight: '10em',
+            marginBottom: '16.5em',
           },
         },
         [

--- a/src/workflows-app/components/FilterableWorkflowTable.ts
+++ b/src/workflows-app/components/FilterableWorkflowTable.ts
@@ -319,7 +319,7 @@ const FilterableWorkflowTable = ({
         ]
       ),
       !_.isEmpty(sortedPreviousRuns) &&
-        div({ style: { bottom: 0, position: 'absolute', marginBottom: '1.5rem', right: '4rem' } }, [
+        div({ style: { marginBottom: '1.5rem', right: '4rem' } }, [
           // @ts-expect-error
           paginator({
             filteredDataLength: sortedPreviousRuns.length,

--- a/src/workflows-app/components/FilterableWorkflowTable.ts
+++ b/src/workflows-app/components/FilterableWorkflowTable.ts
@@ -5,6 +5,7 @@ import { AutoSizer } from 'react-virtualized';
 import { ClipboardButton } from 'src/components/ClipboardButton';
 import { ButtonPrimary, Link, Select } from 'src/components/common';
 import { icon } from 'src/components/icons';
+import Modal from 'src/components/Modal';
 import { FlexTable, paginator, Sortable, tableHeight, TextCell } from 'src/components/table';
 import colors from 'src/libs/colors';
 import * as Nav from 'src/libs/nav';
@@ -44,7 +45,7 @@ const FilterableWorkflowTable = ({
   workspaceName,
 }: FilterableWorkflowTableProps) => {
   const [itemsPerPage, setItemsPerPage] = useState(50);
-  const [filterOption, setFilterOption] = useState<string>(null);
+  const [filterOption, setFilterOption] = useState<string>();
   const [pageNumber, setPageNumber] = useState(1);
   const [sort, setSort] = useState({ field: 'duration', direction: 'desc' });
   const [viewErrorsId, setViewErrorsId] = useState<number>();
@@ -74,6 +75,38 @@ const FilterableWorkflowTable = ({
     return filteredRuns;
   };
 
+  const sortRuns = (field: string, direction: string, runs: Run[]): Run[] => {
+    const runsSorted: Run[] = [];
+
+    if (runs !== undefined) {
+      for (const run of runs) {
+        runsSorted.push(run);
+      }
+    }
+
+    runsSorted.sort((run1, run2) => {
+      if (direction === 'asc') {
+        if (run1[field] > run2[field]) {
+          return 1;
+        }
+        if (run2[field] > run1[field]) {
+          return -1;
+        }
+      } else {
+        if (run1[field] < run2[field]) {
+          return 1;
+        }
+        if (run2[field] < run1[field]) {
+          return -1;
+        }
+      }
+
+      return 0;
+    });
+
+    return runsSorted;
+  };
+
   enum FilterOptions {
     Error = 'Error',
     NoFilter = 'No filter',
@@ -84,7 +117,7 @@ const FilterableWorkflowTable = ({
   const filterOptions: FilterOptions[] = [FilterOptions.Error, FilterOptions.NoFilter, FilterOptions.Succeeded];
   const firstPageIndex: number = (pageNumber - 1) * itemsPerPage;
   const lastPageIndex: number = firstPageIndex + itemsPerPage;
-  const sortedPreviousRuns: Run[] = _.orderBy(sort.field, sort.direction, filteredPreviousRuns);
+  const sortedPreviousRuns: Run[] = sortRuns(sort.field, sort.direction, filteredPreviousRuns);
   const paginatedPreviousRuns: Run[] = sortedPreviousRuns.slice(firstPageIndex, lastPageIndex);
   const rowWidth = 100;
   const rowHeight = 50;
@@ -160,6 +193,7 @@ const FilterableWorkflowTable = ({
             isClearable: false,
             value: filterOption,
             placeholder: 'None selected',
+            // @ts-expect-error
             onChange: ({ value }) => {
               setFilterOption(value);
             },
@@ -172,6 +206,7 @@ const FilterableWorkflowTable = ({
                 'aria-label': 'previous runs',
                 width,
                 height,
+                // @ts-expect-error
                 sort,
                 rowCount: paginatedPreviousRuns.length,
                 noContentMessage: 'Nothing here yet! Your previously run workflows will be displayed here.',
@@ -276,6 +311,7 @@ const FilterableWorkflowTable = ({
       ),
       !_.isEmpty(sortedPreviousRuns) &&
         div({ style: { bottom: 0, position: 'absolute', marginBottom: '1.5rem', right: '4rem' } }, [
+          // @ts-expect-error
           paginator({
             filteredDataLength: sortedPreviousRuns.length,
             unfilteredDataLength: sortedPreviousRuns.length,

--- a/src/workflows-app/components/FilterableWorkflowTable.ts
+++ b/src/workflows-app/components/FilterableWorkflowTable.ts
@@ -8,19 +8,9 @@ import { icon } from 'src/components/icons';
 import { FlexTable, paginator, Sortable, tableHeight, TextCell } from 'src/components/table';
 import colors from 'src/libs/colors';
 import * as Nav from 'src/libs/nav';
-import { customFormatDuration } from 'src/libs/utils';
+import { customFormatDuration, differenceFromNowInSeconds } from 'src/libs/utils';
 import { statusType } from 'src/workflows-app/components/job-common';
 import { makeStatusLine } from 'src/workflows-app/utils/submission-utils';
-
-// interface PaginatorProps {
-//   filteredDataLength: number;
-//   unfilteredDataLength: number;
-//   pageNumber: number;
-//   setPageNumber: function(number);
-//   setItemsPerPage: (num: number) => void;
-//   itemsPerPage: number;
-//   itemsPerPageOptions: number[];
-// };
 
 type Run = {
   duration: number;
@@ -59,6 +49,8 @@ const FilterableWorkflowTable = ({
   const [sort, setSort] = useState({ field: 'duration', direction: 'desc' });
   const [viewErrorsId, setViewErrorsId] = useState<number>();
 
+  const errorStates = ['SYSTEM_ERROR', 'EXECUTOR_ERROR'];
+
   const getFilteredRuns = (filterOption: string, runsData: Run[]): Run[] => {
     const filteredRuns: Run[] = [];
 
@@ -96,20 +88,6 @@ const FilterableWorkflowTable = ({
   const paginatedPreviousRuns: Run[] = sortedPreviousRuns.slice(firstPageIndex, lastPageIndex);
   const rowWidth = 100;
   const rowHeight = 50;
-  const errorStates = ['SYSTEM_ERROR', 'EXECUTOR_ERROR'];
-
-  // const paginatorProps: PaginatorProps = {
-  //   filteredDataLength: sortedPreviousRuns.length,
-  //   unfilteredDataLength: sortedPreviousRuns.length,
-  //   pageNumber,
-  //   setPageNumber,
-  //   itemsPerPage,
-  //   setItemsPerPage: (v) => {
-  //     setPageNumber(1);
-  //     setItemsPerPage(v);
-  //   },
-  //   itemsPerPageOptions: [10, 25, 50, 100],
-  // };
 
   const state = (
     state: string,

--- a/src/workflows-app/components/FilterableWorkflowTable.ts
+++ b/src/workflows-app/components/FilterableWorkflowTable.ts
@@ -166,13 +166,8 @@ const FilterableWorkflowTable = ({
         {
           style: {
             marginTop: '1em',
-            height: tableHeight({
-              actualRows: paginatedPreviousRuns.length,
-              maxRows: paginatedPreviousRuns.length / 5.2,
-              heightPerRow: 250,
-            }),
             minHeight: '10em',
-            marginBottom: '16.5em',
+            marginBottom: '5em',
           },
         },
         [
@@ -200,113 +195,127 @@ const FilterableWorkflowTable = ({
             styles: { container: (old) => ({ ...old, display: 'inline-block', width: 200, marginBottom: '1.5rem' }) },
             options: filterOptions,
           }),
-          h(AutoSizer, [
-            ({ width, height }) =>
-              h(FlexTable, {
-                'aria-label': 'previous runs',
-                width,
-                height,
-                // @ts-expect-error
-                sort,
-                rowCount: paginatedPreviousRuns.length,
-                noContentMessage: 'Nothing here yet! Your previously run workflows will be displayed here.',
-                hoverHighlight: true,
-                rowHeight,
-                rowWidth,
-                columns: [
-                  {
-                    size: { basis: 350 },
-                    field: 'record_id',
-                    headerRenderer: () => h(Sortable, { sort, field: 'record_id', onSort: setSort }, ['Sample ID']),
-                    cellRenderer: ({ rowIndex }) => {
-                      const engineId = paginatedPreviousRuns[rowIndex].engine_id;
+          div(
+            {
+              style: {
+                height: tableHeight({
+                  actualRows: paginatedPreviousRuns.length,
+                  maxRows: 12.5,
+                  heightPerRow: 50,
+                }),
+              },
+            },
+            [
+              h(AutoSizer, [
+                ({ width, height }) =>
+                  h(FlexTable, {
+                    'aria-label': 'previous runs',
+                    width,
+                    height,
+                    // @ts-expect-error
+                    sort,
+                    rowCount: paginatedPreviousRuns.length,
+                    noContentMessage: 'Nothing here yet! Your previously run workflows will be displayed here.',
+                    hoverHighlight: true,
+                    rowHeight,
+                    rowWidth,
+                    columns: [
+                      {
+                        size: { basis: 350 },
+                        field: 'record_id',
+                        headerRenderer: () => h(Sortable, { sort, field: 'record_id', onSort: setSort }, ['Sample ID']),
+                        cellRenderer: ({ rowIndex }) => {
+                          const engineId = paginatedPreviousRuns[rowIndex].engine_id;
 
-                      // Engine id may be undefined if CBAS failed to submit to Cromwell
-                      if (engineId === undefined) return h(TextCell, [paginatedPreviousRuns[rowIndex].record_id]);
+                          // Engine id may be undefined if CBAS failed to submit to Cromwell
+                          if (engineId === undefined) return h(TextCell, [paginatedPreviousRuns[rowIndex].record_id]);
 
-                      return div({ style: { width: '100%', textAlign: 'left' } }, [
-                        h(
-                          Link,
-                          {
-                            href: Nav.getLink('workspace-workflows-app-run-details', {
-                              namespace,
-                              name: workspaceName,
-                              submissionId,
-                              workflowId: engineId,
-                            }),
-                            style: { fontWeight: 'bold' },
-                          },
-                          [paginatedPreviousRuns[rowIndex].record_id]
-                        ),
-                      ]);
-                    },
-                  },
-                  {
-                    size: { basis: 600, grow: 0 },
-                    field: 'state',
-                    headerRenderer: () => h(Sortable, { sort, field: 'state', onSort: setSort }, ['Status']),
-                    cellRenderer: ({ rowIndex }) => {
-                      const status = state(
-                        paginatedPreviousRuns[rowIndex].state,
-                        paginatedPreviousRuns[rowIndex].submission_date
-                      );
-                      if (errorStates.includes(paginatedPreviousRuns[rowIndex].state)) {
-                        return div({ style: { width: '100%', textAlign: 'center' } }, [
-                          h(
-                            Link,
-                            {
-                              key: 'error link',
-                              style: { fontWeight: 'bold' },
-                              onClick: () => setViewErrorsId(rowIndex),
-                            },
-                            [
-                              makeStatusLine(
-                                (style) => status.icon(style),
-                                status.label(paginatedPreviousRuns[rowIndex].state),
+                          return div({ style: { width: '100%', textAlign: 'left' } }, [
+                            h(
+                              Link,
+                              {
+                                href: Nav.getLink('workspace-workflows-app-run-details', {
+                                  namespace,
+                                  name: workspaceName,
+                                  submissionId,
+                                  workflowId: engineId,
+                                }),
+                                style: { fontWeight: 'bold' },
+                              },
+                              [paginatedPreviousRuns[rowIndex].record_id]
+                            ),
+                          ]);
+                        },
+                      },
+                      {
+                        size: { basis: 600, grow: 0 },
+                        field: 'state',
+                        headerRenderer: () => h(Sortable, { sort, field: 'state', onSort: setSort }, ['Status']),
+                        cellRenderer: ({ rowIndex }) => {
+                          const status = state(
+                            paginatedPreviousRuns[rowIndex].state,
+                            paginatedPreviousRuns[rowIndex].submission_date
+                          );
+                          if (errorStates.includes(paginatedPreviousRuns[rowIndex].state)) {
+                            return div({ style: { width: '100%', textAlign: 'center' } }, [
+                              h(
+                                Link,
                                 {
-                                  textAlign: 'center',
-                                }
+                                  key: 'error link',
+                                  style: { fontWeight: 'bold' },
+                                  onClick: () => setViewErrorsId(rowIndex),
+                                },
+                                [
+                                  makeStatusLine(
+                                    (style) => status.icon(style),
+                                    status.label(paginatedPreviousRuns[rowIndex].state),
+                                    {
+                                      textAlign: 'center',
+                                    }
+                                  ),
+                                ]
                               ),
-                            ]
-                          ),
-                        ]);
-                      }
-                      return h(TextCell, { style: { fontWeight: 'bold' } }, [
-                        makeStatusLine(
-                          (style) => status.icon(style),
-                          status.label(paginatedPreviousRuns[rowIndex].state),
-                          {
-                            textAlign: 'center',
+                            ]);
                           }
-                        ),
-                      ]);
-                    },
-                  },
-                  {
-                    size: { basis: 500, grow: 0 },
-                    field: 'duration',
-                    headerRenderer: () => h(Sortable, { sort, field: 'duration', onSort: setSort }, ['Duration']),
-                    cellRenderer: ({ rowIndex }) => {
-                      return h(TextCell, [customFormatDuration(paginatedPreviousRuns[rowIndex].duration)]);
-                    },
-                  },
-                  {
-                    size: { basis: 400, grow: 0 },
-                    field: 'workflowId',
-                    headerRenderer: () => h(Sortable, { sort, field: 'workflowId', onSort: setSort }, ['Workflow ID']),
-                    cellRenderer: ({ rowIndex }) => {
-                      const engineId = paginatedPreviousRuns[rowIndex].engine_id;
-                      if (engineId !== undefined) {
-                        return h(TextCell, [
-                          span({ style: { marginRight: '0.5rem' } }, [engineId]),
-                          span({}, [h(ClipboardButton, { text: engineId, 'aria-label': 'Copy workflow id' })]),
-                        ]);
-                      }
-                    },
-                  },
-                ],
-              }),
-          ]),
+                          return h(TextCell, { style: { fontWeight: 'bold' } }, [
+                            makeStatusLine(
+                              (style) => status.icon(style),
+                              status.label(paginatedPreviousRuns[rowIndex].state),
+                              {
+                                textAlign: 'center',
+                              }
+                            ),
+                          ]);
+                        },
+                      },
+                      {
+                        size: { basis: 500, grow: 0 },
+                        field: 'duration',
+                        headerRenderer: () => h(Sortable, { sort, field: 'duration', onSort: setSort }, ['Duration']),
+                        cellRenderer: ({ rowIndex }) => {
+                          return h(TextCell, [customFormatDuration(paginatedPreviousRuns[rowIndex].duration)]);
+                        },
+                      },
+                      {
+                        size: { basis: 400, grow: 0 },
+                        field: 'workflowId',
+                        headerRenderer: () =>
+                          h(Sortable, { sort, field: 'workflowId', onSort: setSort }, ['Workflow ID']),
+                        cellRenderer: ({ rowIndex }) => {
+                          const engineId = paginatedPreviousRuns[rowIndex].engine_id;
+                          if (engineId !== undefined) {
+                            return h(TextCell, [
+                              span({ style: { marginRight: '0.5rem' } }, [engineId]),
+                              span({}, [h(ClipboardButton, { text: engineId, 'aria-label': 'Copy workflow id' })]),
+                            ]);
+                          }
+                        },
+                      },
+                    ],
+                  }),
+              ]),
+            ]
+          ),
         ]
       ),
       !_.isEmpty(sortedPreviousRuns) &&


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WX-1428

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

This ticket is the first step in completing WX-1377, adding tabs to the Submission Details page for Workflows, Inputs, and Outputs.

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Refactored table of previously run workflows on Submission Details page to its own TypeScript component
- Removed block of empty space between table and pagination buttons on Submission Details page

### Why
- This is necessary for completing WX-1377, the contents of each tab will need to be their own components

### Testing strategy
- Confirmed that all automated tests pass
- Manually confirmed on the UI that all features work as expected

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 

<img width="1204" alt="Screenshot 2024-01-17 at 11 45 11 AM" src="https://github.com/DataBiosphere/terra-ui/assets/156102201/8a8fa9a7-a094-45a7-87c3-c2ea7f9f0502">