### PR TITLE
Environments Page - Environments sub-component breakout pt2

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,7 @@
 # Each line is a file pattern followed by one or more owners.
 # See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
 /src/analysis @DataBiosphere/broad-interactive-analysis
+/src/pages/EnvironmentsPage/ @DataBiosphere/broad-interactive-analysis
 /src/constants/datasets.js @DataBiosphere/data-explorer-eng
 /src/import-data/ @DataBiosphere/data-explorer-eng @DataBiosphere/analysisjourneys
 /src/libs/brand*.js @DataBiosphere/terra-cobranding

--- a/src/libs/routes.js
+++ b/src/libs/routes.js
@@ -8,7 +8,7 @@ import * as DataBrowserPreview from 'src/data-catalog/DataBrowserPreview';
 import * as ImportDataPage from 'src/import-data/ImportDataPage';
 import { routeHandlersStore } from 'src/libs/state';
 import * as Projects from 'src/pages/billing/List/List';
-import * as Environments from 'src/pages/EnvironmentsPage';
+import * as Environments from 'src/pages/EnvironmentsPage/EnvironmentsPage';
 import * as FeaturePreviews from 'src/pages/FeaturePreviews';
 import * as Group from 'src/pages/groups/Group';
 import * as Groups from 'src/pages/groups/List';

--- a/src/pages/EnvironmentsPage/EnvironmentsPage.test.ts
+++ b/src/pages/EnvironmentsPage/EnvironmentsPage.test.ts
@@ -6,12 +6,12 @@ import { leoDiskProvider } from 'src/libs/ajax/leonardo/providers/LeoDiskProvide
 import { leoRuntimeProvider } from 'src/libs/ajax/leonardo/providers/LeoRuntimeProvider';
 import { MetricsProvider, useMetricsEvent } from 'src/libs/ajax/metrics/useMetrics';
 import { terraNavKey, TerraNavLinkProvider } from 'src/libs/nav';
-import { leoResourcePermissions } from 'src/pages/EnvironmentsPage/environmentsPermissions';
 import { asMockedFn } from 'src/testing/test-utils';
 import { useWorkspaces } from 'src/workspaces/useWorkspaces';
 import { UseWorkspaces } from 'src/workspaces/useWorkspaces.models';
 
 import { EnvironmentsPage, makeNavProvider, navProvider } from './EnvironmentsPage';
+import { leoResourcePermissions } from './environmentsPermissions';
 
 jest.mock('src/analysis/Environments/Environments');
 

--- a/src/pages/EnvironmentsPage/EnvironmentsPage.ts
+++ b/src/pages/EnvironmentsPage/EnvironmentsPage.ts
@@ -9,8 +9,9 @@ import { leoDiskProvider } from 'src/libs/ajax/leonardo/providers/LeoDiskProvide
 import { leoRuntimeProvider } from 'src/libs/ajax/leonardo/providers/LeoRuntimeProvider';
 import { useMetricsEvent } from 'src/libs/ajax/metrics/useMetrics';
 import { terraNavKey, TerraNavLinkProvider, terraNavLinkProvider } from 'src/libs/nav';
-import { leoResourcePermissions } from 'src/pages/EnvironmentsPage/environmentsPermissions';
 import { useWorkspaces } from 'src/workspaces/useWorkspaces';
+
+import { leoResourcePermissions } from './environmentsPermissions';
 
 type NavMap<NavTypes, FnReturn> = {
   [Property in keyof NavTypes]: (args: NavTypes[Property]) => FnReturn;


### PR DESCRIPTION
EnvironmentsPage directory cleanup.

- directory cleanup and code-owners patch for EnvironmentsPage top-level component.
- EnvironmentsPage is now moved into it's own subdirectory inside src/pages

- no functional changes

### Why
- aligning with recommended code re-org patterns.
- continued cleanup/improvements for AoU code-sharing benefits and the code-base itself.

### Testing strategy
- [x] ran unit tests.
- [x] Confirmed page can be navigated into as before.

