### PR TITLE
Add capabilities support

### DIFF
--- a/src/libs/ajax/WorkspaceDataService.test.ts
+++ b/src/libs/ajax/WorkspaceDataService.test.ts
@@ -102,6 +102,9 @@ describe('WorkspaceData', () => {
       const { wdsProxyUrl } = setup({
         stubbedCapabilitiesRejection: new Response('{ "message": "Not found"}', { status: 404 }),
       });
+      // this scenario logs a message indicating that capabilities aren't enabled; this should not
+      // appear in test output
+      jest.spyOn(console, 'log').mockImplementation(() => {});
 
       // Act
       const capabilities = await Ajax().WorkspaceData.getCapabilities(wdsProxyUrl);

--- a/src/libs/ajax/WorkspaceDataService.test.ts
+++ b/src/libs/ajax/WorkspaceDataService.test.ts
@@ -7,7 +7,7 @@ type AjaxCommonExports = typeof import('src/libs/ajax/ajax-common');
 
 jest.mock('src/libs/ajax/ajax-common', (): AjaxCommonExports => {
   return {
-    ...jest.requireActual('src/libs/ajax/ajax-common'),
+    ...jest.requireActual<AjaxCommonExports>('src/libs/ajax/ajax-common'),
     fetchWDS: jest.fn(),
   };
 });

--- a/src/libs/ajax/WorkspaceDataService.test.ts
+++ b/src/libs/ajax/WorkspaceDataService.test.ts
@@ -1,0 +1,131 @@
+import { asMockedFn } from '@terra-ui-packages/test-utils';
+import { Ajax } from 'src/libs/ajax';
+
+import { fetchWDS } from './ajax-common';
+
+type AjaxCommonExports = typeof import('src/libs/ajax/ajax-common');
+
+jest.mock('src/libs/ajax/ajax-common', (): AjaxCommonExports => {
+  return {
+    ...jest.requireActual('src/libs/ajax/ajax-common'),
+    fetchWDS: jest.fn(),
+  };
+});
+
+describe('WorkspaceData', () => {
+  describe('getCapabilities', () => {
+    type SetupOptions = {
+      stubbedCapabilitiesJson?: string;
+      stubbedCapabilitiesResponse?: Response;
+      stubbedCapabilitiesRejection?: any;
+      wdsProxyUrl?: string;
+    };
+    type SetupResult = {
+      wdsProxyUrl: string;
+    };
+    function setup({
+      wdsProxyUrl = 'https://wds.test.proxy.url',
+      stubbedCapabilitiesJson = '{"capabilities":true}',
+      stubbedCapabilitiesResponse = new Response(stubbedCapabilitiesJson),
+      stubbedCapabilitiesRejection = undefined,
+    }: SetupOptions): SetupResult {
+      asMockedFn(fetchWDS).mockImplementation((wdsProxyUrlRoot: string) => {
+        if (wdsProxyUrlRoot !== wdsProxyUrl) {
+          throw new Error(`Unexpected wdsProxyUrlRoot: ${wdsProxyUrlRoot}`);
+        }
+        return (path: RequestInfo | URL, _options: RequestInit | undefined) => {
+          if (path === 'capabilities/v1') {
+            if (stubbedCapabilitiesRejection !== undefined) {
+              return Promise.reject(stubbedCapabilitiesRejection);
+            }
+            return Promise.resolve(stubbedCapabilitiesResponse);
+          }
+          throw new Error('Unexpected path');
+        };
+      });
+
+      return {
+        wdsProxyUrl,
+      };
+    }
+
+    it('returns true for capabilities when present and true', async () => {
+      // Arrange
+      const { wdsProxyUrl } = setup({ stubbedCapabilitiesJson: '{ "capabilities": true }' });
+
+      // Act
+      const capabilities = await Ajax().WorkspaceData.getCapabilities(wdsProxyUrl);
+
+      // Assert
+      expect(fetchWDS).toHaveBeenCalledWith(wdsProxyUrl);
+      expect(capabilities.capabilities).toEqual(true);
+    });
+
+    it('returns false for capabilities when present and false', async () => {
+      // Arrange
+      const { wdsProxyUrl } = setup({ stubbedCapabilitiesJson: '{ "capabilities": false }' });
+
+      // Act
+      const capabilities = await Ajax().WorkspaceData.getCapabilities(wdsProxyUrl);
+
+      // Assert
+      expect(fetchWDS).toHaveBeenCalledWith(wdsProxyUrl);
+      expect(capabilities.capabilities).toEqual(false);
+    });
+
+    it('returns false for capabilities when present and non-boolean', async () => {
+      // Arrange
+      const { wdsProxyUrl } = setup({ stubbedCapabilitiesJson: '{ "capabilities": "false" }' });
+
+      // Act
+      const capabilities = await Ajax().WorkspaceData.getCapabilities(wdsProxyUrl);
+
+      // Assert
+      expect(fetchWDS).toHaveBeenCalledWith(wdsProxyUrl);
+      expect(capabilities.capabilities).toEqual(false);
+    });
+
+    it('returns true for an unknown capability that is present and true', async () => {
+      // Arrange
+      const { wdsProxyUrl } = setup({ stubbedCapabilitiesJson: '{ "unknownCapability": true }' });
+
+      // Act
+      const capabilities = await Ajax().WorkspaceData.getCapabilities(wdsProxyUrl);
+
+      // Assert
+      expect(fetchWDS).toHaveBeenCalledWith(wdsProxyUrl);
+      expect(capabilities.unknownCapability).toEqual(true);
+    });
+
+    it('returns false for capabilities when response is a 404', async () => {
+      // Arrange
+      const { wdsProxyUrl } = setup({
+        stubbedCapabilitiesRejection: new Response('{ "message": "Not found"}', { status: 404 }),
+      });
+
+      // Act
+      const capabilities = await Ajax().WorkspaceData.getCapabilities(wdsProxyUrl);
+
+      // Assert
+      expect(fetchWDS).toHaveBeenCalledWith(wdsProxyUrl);
+      expect(capabilities.capabilities).toEqual(false);
+    });
+
+    it('throws on an unexpected error', async () => {
+      // Arrange
+      const { wdsProxyUrl } = setup({
+        stubbedCapabilitiesRejection: new Response('{ "message": "Internal server error"}', { status: 500 }),
+      });
+
+      // Act
+      const act = async () => Ajax().WorkspaceData.getCapabilities(wdsProxyUrl);
+
+      // Assert
+      await expect(act()).rejects.toEqual(
+        expect.objectContaining({
+          status: 500,
+        })
+      );
+    });
+  });
+});

--- a/src/libs/ajax/WorkspaceDataService.test.ts
+++ b/src/libs/ajax/WorkspaceDataService.test.ts
@@ -103,9 +103,6 @@ describe('WorkspaceData', () => {
       const { wdsProxyUrl } = setup({
         stubbedCapabilitiesResponse: Promise.reject(new Response('{ "message": "Not found"}', { status: 404 })),
       });
-      // this scenario logs a message indicating that capabilities aren't enabled; this should not
-      // appear in test output
-      jest.spyOn(console, 'log').mockImplementation(() => {});
 
       // Act
       const capabilities = await Ajax().WorkspaceData.getCapabilities(wdsProxyUrl);

--- a/src/libs/ajax/WorkspaceDataService.ts
+++ b/src/libs/ajax/WorkspaceDataService.ts
@@ -91,7 +91,6 @@ export const WorkspaceData = (signal) => ({
       })
       .catch((error) => {
         if (error instanceof Response && error.status === 404) {
-          console.log("WDS doesn't support capabilities endpoint"); // eslint-disable-line no-console
           return { capabilities: false } as Capabilities;
         }
         throw error;

--- a/src/libs/ajax/WorkspaceDataService.ts
+++ b/src/libs/ajax/WorkspaceDataService.ts
@@ -97,7 +97,7 @@ export const WorkspaceData = (signal) => ({
           console.log("WDS doesn't support capabilities endpoint"); // eslint-disable-line no-console
           return { capabilities: false } as Capabilities;
         }
-        return Promise.reject(error);
+        throw error;
       });
   },
   deleteTable: async (root: string, instanceId: string, recordType: string): Promise<Response> => {

--- a/src/libs/ajax/WorkspaceDataService.ts
+++ b/src/libs/ajax/WorkspaceDataService.ts
@@ -53,6 +53,21 @@ export interface WDSJob {
   updated: string;
 }
 
+// The source of truth of valid capabilities can be found in: https://github.com/DataBiosphere/terra-workspace-data-service/blob/main/service/src/main/resources/capabilities.json
+export type KnownCapability =
+  | 'capabilities'
+  | 'dataimport.pfb'
+  | 'dataimport.tdrmanifest'
+  | 'edit.deleteAttribute'
+  | 'edit.renameAttribute';
+export type UnknownCapability = string;
+export type Capability = KnownCapability | UnknownCapability;
+
+// Capabilities is just a kvp map of capability name to boolean. The value is true if the capability is enabled, false otherwise.
+export type Capabilities = {
+  [key in Capability]: boolean;
+};
+
 export const WorkspaceData = (signal) => ({
   getSchema: async (root: string, instanceId: string): Promise<RecordTypeSchema[]> => {
     const res = await fetchWDS(root)(`${instanceId}/types/v0.2`, _.merge(authOpts(), { signal }));
@@ -68,6 +83,10 @@ export const WorkspaceData = (signal) => ({
       `${instanceId}/search/v0.2/${recordType}`,
       _.mergeAll([authOpts(), jsonBody(parameters), { signal, method: 'POST' }])
     );
+    return res.json();
+  },
+  getCapabilities: async (root: string): Promise<Capabilities> => {
+    const res = await fetchWDS(root)('capabilities/v1', _.mergeAll([authOpts(), { signal, method: 'GET' }]));
     return res.json();
   },
   deleteTable: async (root: string, instanceId: string, recordType: string): Promise<Response> => {

--- a/src/libs/ajax/WorkspaceDataService.ts
+++ b/src/libs/ajax/WorkspaceDataService.ts
@@ -53,15 +53,12 @@ export interface WDSJob {
   updated: string;
 }
 
-// The source of truth of valid capabilities can be found in: https://github.com/DataBiosphere/terra-workspace-data-service/blob/main/service/src/main/resources/capabilities.json
-type KnownCapability =
-  | 'capabilities'
-  | 'dataimport.pfb'
-  | 'dataimport.tdrmanifest'
-  | 'edit.deleteAttribute'
-  | 'edit.renameAttribute';
-type UnknownCapability = string;
-export type Capability = KnownCapability | UnknownCapability;
+// The source of truth of available capabilities can be found in: https://github.com/DataBiosphere/terra-workspace-data-service/blob/main/service/src/main/resources/capabilities.json
+// This list should only contain capabilities actively required or supported by the UI.
+// If a capability is no longer necessary (because all live WDS instances now support it), it should be removed from this list.
+type SupportedCapability = 'capabilities';
+type UnusedCapability = string;
+export type Capability = SupportedCapability | UnusedCapability;
 
 // Capabilities is just a kvp map of capability name to boolean. The value is true if the capability is enabled, false otherwise.
 export type Capabilities = {

--- a/src/libs/ajax/WorkspaceDataService.ts
+++ b/src/libs/ajax/WorkspaceDataService.ts
@@ -89,16 +89,7 @@ export const WorkspaceData = (signal) => ({
     return fetchWDS(root)('capabilities/v1', _.mergeAll([authOpts(), { signal, method: 'GET' }]))
       .then(async (response) => {
         const json = await response.json();
-        const capabilities: Capabilities = {};
-
-        for (const key in json) {
-          if (Object.prototype.hasOwnProperty.call(json, key)) {
-            // Default to false if not boolean
-            const jsonValue = typeof json[key] === 'boolean' ? json[key] : false;
-            capabilities[key as Capability] = jsonValue;
-          }
-        }
-
+        const capabilities: Capabilities = _.mapValues((value) => value === true, json);
         return capabilities;
       })
       .catch((error) => {

--- a/src/libs/ajax/WorkspaceDataService.ts
+++ b/src/libs/ajax/WorkspaceDataService.ts
@@ -54,13 +54,13 @@ export interface WDSJob {
 }
 
 // The source of truth of valid capabilities can be found in: https://github.com/DataBiosphere/terra-workspace-data-service/blob/main/service/src/main/resources/capabilities.json
-export type KnownCapability =
+type KnownCapability =
   | 'capabilities'
   | 'dataimport.pfb'
   | 'dataimport.tdrmanifest'
   | 'edit.deleteAttribute'
   | 'edit.renameAttribute';
-export type UnknownCapability = string;
+type UnknownCapability = string;
 export type Capability = KnownCapability | UnknownCapability;
 
 // Capabilities is just a kvp map of capability name to boolean. The value is true if the capability is enabled, false otherwise.

--- a/src/libs/ajax/WorkspaceDataService.ts
+++ b/src/libs/ajax/WorkspaceDataService.ts
@@ -53,9 +53,12 @@ export interface WDSJob {
   updated: string;
 }
 
-// The source of truth of available capabilities can be found in: https://github.com/DataBiosphere/terra-workspace-data-service/blob/main/service/src/main/resources/capabilities.json
+// The source of truth of available capabilities can be found in:
+// https://github.com/DataBiosphere/terra-workspace-data-service/blob/main/service/src/main/resources/capabilities.json
 // This list should only contain capabilities actively required or supported by the UI.
-// If a capability is no longer necessary (because all live WDS instances now support it), it should be removed from this list.
+// If a capability is no longer necessary (because all live WDS instances now support it),
+// care should be taken to prune the conditional logic that relies on the capability, and
+// then the capability should be removed.
 type SupportedCapability = 'capabilities';
 type UnusedCapability = string;
 export type Capability = SupportedCapability | UnusedCapability;

--- a/src/libs/ajax/data-table-providers/DataTableProvider.ts
+++ b/src/libs/ajax/data-table-providers/DataTableProvider.ts
@@ -108,6 +108,7 @@ export type TsvUploadButtonTooltipFn = (options: TsvUploadButtonTooltipOptions) 
 export type UploadTsvFn = (uploadParams: UploadParameters) => Promise<any>;
 
 export interface DataTableFeatures {
+  supportsCapabilities: boolean;
   supportsTsvDownload: boolean;
   supportsTsvAjaxDownload: boolean;
   supportsTypeDeletion: boolean;

--- a/src/libs/ajax/data-table-providers/EntityServiceDataTableProvider.ts
+++ b/src/libs/ajax/data-table-providers/EntityServiceDataTableProvider.ts
@@ -29,6 +29,7 @@ export class EntityServiceDataTableProvider implements DataTableProvider {
   name: string;
 
   features: DataTableFeatures = {
+    supportsCapabilities: false,
     supportsTsvDownload: true,
     supportsTsvAjaxDownload: false,
     supportsTypeDeletion: true,

--- a/src/libs/ajax/data-table-providers/WdsDataTableProvider.test.ts
+++ b/src/libs/ajax/data-table-providers/WdsDataTableProvider.test.ts
@@ -1,7 +1,7 @@
 import { DeepPartial } from '@terra-ui-packages/core-utils';
 import { Ajax } from 'src/libs/ajax';
 import { Apps } from 'src/libs/ajax/leonardo/Apps';
-import { WorkspaceData } from 'src/libs/ajax/WorkspaceDataService';
+import { Capabilities, WorkspaceData } from 'src/libs/ajax/WorkspaceDataService';
 import { cloudProviderTypes } from 'src/libs/workspace-utils';
 import { asMockedFn } from 'src/testing/test-utils';
 
@@ -38,6 +38,10 @@ const uuid = '123e4567-e89b-12d3-a456-426614174000'; // value doesn't matter for
 
 // shell class that extends WdsDataTableProvider to allow testing protected methods
 class TestableWdsProvider extends WdsDataTableProvider {
+  constructor(capabilities: Capabilities = {}) {
+    super(uuid, testProxyUrl, capabilities);
+  }
+
   transformPageOverride(
     wdsPage: RecordQueryResponse,
     recordType: string,
@@ -146,6 +150,11 @@ describe('WdsDataTableProvider', () => {
     return Promise.resolve(recordQueryResponse);
   };
 
+  const getCapabilitiesMockImpl: WorkspaceDataContract['getCapabilities'] = (_root: string) => {
+    const Capabilities: Capabilities = {};
+    return Promise.resolve(Capabilities);
+  };
+
   const deleteTableMockImpl: WorkspaceDataContract['deleteTable'] = (_instanceId: string, _recordType: string) => {
     return Promise.resolve(new Response('', { status: 204 }));
   };
@@ -168,6 +177,7 @@ describe('WdsDataTableProvider', () => {
   };
 
   let getRecords: jest.MockedFunction<WorkspaceDataContract['getRecords']>;
+  let getCapabilities: jest.MockedFunction<WorkspaceDataContract['getCapabilities']>;
   let deleteTable: jest.MockedFunction<WorkspaceDataContract['deleteTable']>;
   let downloadTsv: jest.MockedFunction<WorkspaceDataContract['downloadTsv']>;
   let uploadTsv: jest.MockedFunction<WorkspaceDataContract['uploadTsv']>;
@@ -175,6 +185,7 @@ describe('WdsDataTableProvider', () => {
 
   beforeEach(() => {
     getRecords = jest.fn().mockImplementation(getRecordsMockImpl);
+    getCapabilities = jest.fn().mockImplementation(getCapabilitiesMockImpl);
     deleteTable = jest.fn().mockImplementation(deleteTableMockImpl);
     downloadTsv = jest.fn().mockImplementation(downloadTsvMockImpl);
     uploadTsv = jest.fn().mockImplementation(uploadTsvMockImpl);
@@ -185,6 +196,7 @@ describe('WdsDataTableProvider', () => {
         ({
           WorkspaceData: {
             getRecords,
+            getCapabilities,
             deleteTable,
             downloadTsv,
             uploadTsv,
@@ -197,7 +209,7 @@ describe('WdsDataTableProvider', () => {
   describe('transformAttributes', () => {
     it('excludes the primary key from the resultant attributes', () => {
       // Arrange
-      const provider = new TestableWdsProvider(uuid, testProxyUrl);
+      const provider = new TestableWdsProvider();
 
       const input: RecordAttributes = {
         something: 123,
@@ -221,7 +233,7 @@ describe('WdsDataTableProvider', () => {
     });
     it('is resilient if the primary key does not exist in input attributes', () => {
       // Arrange
-      const provider = new TestableWdsProvider(uuid, testProxyUrl);
+      const provider = new TestableWdsProvider();
 
       const input: RecordAttributes = {
         something: 123,
@@ -246,7 +258,7 @@ describe('WdsDataTableProvider', () => {
   describe('transformPage', () => {
     it('restructures a WDS response', () => {
       // Arrange
-      const provider = new TestableWdsProvider(uuid, testProxyUrl);
+      const provider = new TestableWdsProvider();
 
       // example response from WDS, copy-pasted from a WDS swagger call
       const wdsPage: RecordQueryResponse = {
@@ -334,7 +346,7 @@ describe('WdsDataTableProvider', () => {
     });
     it('restructures array attributes', () => {
       // Arrange
-      const provider = new TestableWdsProvider(uuid, testProxyUrl);
+      const provider = new TestableWdsProvider();
 
       // example response from WDS, copy-pasted from a WDS swagger call
       const wdsPage: RecordQueryResponse = {
@@ -402,7 +414,7 @@ describe('WdsDataTableProvider', () => {
     });
     it('restructures relation URIs, both scalar and array', () => {
       // Arrange
-      const provider = new TestableWdsProvider(uuid, testProxyUrl);
+      const provider = new TestableWdsProvider();
 
       // example response from WDS, copy-pasted from a WDS swagger call
       const wdsPage: RecordQueryResponse = {
@@ -478,7 +490,7 @@ describe('WdsDataTableProvider', () => {
     });
     it('handles mixed arrays that contain some relation URIs and some strings', () => {
       // Arrange
-      const provider = new TestableWdsProvider(uuid, testProxyUrl);
+      const provider = new TestableWdsProvider();
 
       // example response from WDS, copy-pasted from a WDS swagger call
       const wdsPage: RecordQueryResponse = {
@@ -552,7 +564,7 @@ describe('WdsDataTableProvider', () => {
   describe('getPage', () => {
     it('restructures a WDS response', () => {
       // Arrange
-      const provider = new TestableWdsProvider(uuid, testProxyUrl);
+      const provider = new TestableWdsProvider();
       const signal = new AbortController().signal;
 
       const metadata: EntityMetadata = {
@@ -574,7 +586,7 @@ describe('WdsDataTableProvider', () => {
   describe('deleteTable', () => {
     it('restructures a WDS response', () => {
       // Arrange
-      const provider = new TestableWdsProvider(uuid, testProxyUrl);
+      const provider = new TestableWdsProvider();
 
       // Act
       return provider.deleteTable(recordType).then((actual) => {
@@ -584,10 +596,32 @@ describe('WdsDataTableProvider', () => {
       });
     });
   });
+  describe('features', () => {
+    it('supportsTsvAjaxDownload is true', () => {
+      const provider = new TestableWdsProvider();
+      expect(provider.features.supportsTsvAjaxDownload).toEqual(true);
+    });
+    it('supportsTsvDownload is false', () => {
+      const provider = new TestableWdsProvider();
+      expect(provider.features.supportsTsvDownload).toEqual(false);
+    });
+    it('supportsCapabilities is false by default', () => {
+      const provider = new TestableWdsProvider();
+      expect(provider.features.supportsCapabilities).toEqual(false);
+    });
+    it('supportsCapabilities is false when "capabilities" capability is false', () => {
+      const provider = new TestableWdsProvider({ capabilities: false });
+      expect(provider.features.supportsCapabilities).toEqual(false);
+    });
+    it('supportsCapabilities is true when "capabilities" capability is true', () => {
+      const provider = new TestableWdsProvider({ capabilities: true });
+      expect(provider.features.supportsCapabilities).toEqual(true);
+    });
+  });
   describe('downloadTsv', () => {
     it('restructures a WDS response', () => {
       // Arrange
-      const provider = new TestableWdsProvider(uuid, testProxyUrl);
+      const provider = new TestableWdsProvider();
       const signal = new AbortController().signal;
 
       // Act
@@ -607,12 +641,12 @@ describe('WdsDataTableProvider', () => {
       [{ filePresent: true, uploading: true, recordTypePresent: true }, true],
       [{ filePresent: true, uploading: false, recordTypePresent: false }, true],
     ])('Upload button is disabled', (conditions: TsvUploadButtonDisabledOptions, result: boolean) => {
-      const provider = new TestableWdsProvider(uuid, testProxyUrl);
+      const provider = new TestableWdsProvider();
       expect(provider.tsvFeatures.disabled(conditions)).toEqual(result);
     });
 
     it('Upload button is not disabled', () => {
-      const provider = new TestableWdsProvider(uuid, testProxyUrl);
+      const provider = new TestableWdsProvider();
       const actual = provider.tsvFeatures.disabled({ filePresent: true, uploading: false, recordTypePresent: true });
       expect(actual).toBe(false);
     });
@@ -620,13 +654,13 @@ describe('WdsDataTableProvider', () => {
 
   describe('tooltip', () => {
     it('Tooltip -- needs table name', () => {
-      const provider = new TestableWdsProvider(uuid, testProxyUrl);
+      const provider = new TestableWdsProvider();
       const actual = provider.tsvFeatures.tooltip({ filePresent: true, recordTypePresent: false });
       expect(actual).toBe('Please enter table name');
     });
 
     it('Tooltip -- needs valid data', () => {
-      const provider = new TestableWdsProvider(uuid, testProxyUrl);
+      const provider = new TestableWdsProvider();
       const actual = provider.tsvFeatures.tooltip({ filePresent: false, recordTypePresent: true });
       expect(actual).toBe('Please select valid data to upload');
     });
@@ -635,7 +669,7 @@ describe('WdsDataTableProvider', () => {
   describe('uploadTsv', () => {
     it('uploads a TSV', () => {
       // ====== Arrange
-      const provider = new TestableWdsProvider(uuid, testProxyUrl);
+      const provider = new TestableWdsProvider();
       const tsvFile = new File([''], 'testFile.tsv');
       // ====== Act
       return provider

--- a/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
+++ b/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
@@ -13,7 +13,7 @@ import {
   UploadParameters,
 } from 'src/libs/ajax/data-table-providers/DataTableProvider';
 import { LeoAppStatus, ListAppItem } from 'src/libs/ajax/leonardo/models/app-models';
-import { Capabilities, KnownCapability } from 'src/libs/ajax/WorkspaceDataService';
+import { Capabilities, Capability } from 'src/libs/ajax/WorkspaceDataService';
 import { notificationStore } from 'src/libs/state';
 import * as Utils from 'src/libs/utils';
 import { notifyDataImportProgress } from 'src/workspace-data/import-jobs';
@@ -144,7 +144,7 @@ export class WdsDataTableProvider implements DataTableProvider {
 
   capabilities: Capabilities;
 
-  private isCapabilityEnabled = (capability: KnownCapability): boolean => {
+  private isCapabilityEnabled = (capability: Capability): boolean => {
     return !!(this.capabilities && this.capabilities[capability] === true);
   };
 

--- a/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
+++ b/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
@@ -13,6 +13,7 @@ import {
   UploadParameters,
 } from 'src/libs/ajax/data-table-providers/DataTableProvider';
 import { LeoAppStatus, ListAppItem } from 'src/libs/ajax/leonardo/models/app-models';
+import { Capabilities, KnownCapability } from 'src/libs/ajax/WorkspaceDataService';
 import { notificationStore } from 'src/libs/state';
 import * as Utils from 'src/libs/utils';
 import { notifyDataImportProgress } from 'src/workspace-data/import-jobs';
@@ -129,9 +130,10 @@ export const resolveWdsUrl = (apps) => {
 export const wdsProviderName = 'WDS';
 
 export class WdsDataTableProvider implements DataTableProvider {
-  constructor(workspaceId: string, proxyUrl: string) {
+  constructor(workspaceId: string, proxyUrl: string, capabilities: Capabilities) {
     this.workspaceId = workspaceId;
     this.proxyUrl = proxyUrl;
+    this.capabilities = capabilities;
   }
 
   providerName: string = wdsProviderName;
@@ -140,21 +142,30 @@ export class WdsDataTableProvider implements DataTableProvider {
 
   workspaceId: string;
 
-  features: DataTableFeatures = {
-    supportsTsvDownload: false,
-    supportsTsvAjaxDownload: true,
-    supportsTypeDeletion: true,
-    supportsTypeRenaming: false,
-    supportsEntityRenaming: false,
-    supportsEntityUpdating: false, // TODO: enable as part of AJ-594
-    supportsAttributeRenaming: false, // TODO: enable as part of AJ-1278, requires `edit.renameAttribute` capability
-    supportsAttributeDeleting: false, // TODO: enable as part of AJ-1275, requires `edit.deleteAttribute` capability
-    supportsAttributeClearing: false,
-    supportsExport: false,
-    supportsPointCorrection: false,
-    supportsFiltering: false,
-    supportsRowSelection: false,
+  capabilities: Capabilities;
+
+  private isCapabilityEnabled = (capability: KnownCapability): boolean => {
+    return !!(this.capabilities && this.capabilities[capability] === true);
   };
+
+  get features(): DataTableFeatures {
+    return {
+      supportsCapabilities: this.isCapabilityEnabled('capabilities'),
+      supportsTsvDownload: false,
+      supportsTsvAjaxDownload: true,
+      supportsTypeDeletion: true,
+      supportsTypeRenaming: false,
+      supportsEntityRenaming: false,
+      supportsEntityUpdating: false, // TODO: enable as part of AJ-594
+      supportsAttributeRenaming: false, // TODO: enable as part of AJ-1278, requires `edit.renameAttribute` capability
+      supportsAttributeDeleting: false, // TODO: enable as part of AJ-1275, requires `edit.deleteAttribute` capability
+      supportsAttributeClearing: false,
+      supportsExport: false,
+      supportsPointCorrection: false,
+      supportsFiltering: false,
+      supportsRowSelection: false,
+    };
+  }
 
   tsvFeatures: TSVFeatures = {
     needsTypeInput: true,

--- a/src/workspace-data/Data.js
+++ b/src/workspace-data/Data.js
@@ -573,6 +573,7 @@ export const WorkspaceData = _.flow(
 
     const [wdsApp, setWdsApp] = useState({ status: 'None', state: undefined });
     const [wdsTypes, setWdsTypes] = useState({ status: 'None', state: [] });
+    const [wdsCapabilities, setWdsCapabilities] = useState({ status: 'None', state: undefined });
 
     const { dataTableVersions, loadDataTableVersions, saveDataTableVersion, deleteDataTableVersion, importDataTableVersion } =
       useDataTableVersions(workspace);
@@ -589,8 +590,8 @@ export const WorkspaceData = _.flow(
     const wdsDataTableProvider = useMemo(() => {
       const app = wdsApp?.state;
       const proxyUrl = app?.proxyUrls?.wds;
-      return new WdsDataTableProvider(workspaceId, proxyUrl);
-    }, [workspaceId, wdsApp]);
+      return new WdsDataTableProvider(workspaceId, proxyUrl, wdsCapabilities?.state);
+    }, [workspaceId, wdsApp, wdsCapabilities]);
 
     const loadEntityMetadata = async () => {
       try {
@@ -712,6 +713,21 @@ export const WorkspaceData = _.flow(
       [signal]
     );
 
+    const loadWdsCapabilities = useCallback(
+      (url) => {
+        return Ajax(signal)
+          .WorkspaceData.getCapabilities(url)
+          .then((capabilitiesResult) => {
+            setWdsCapabilities({ status: 'Ready', state: capabilitiesResult });
+          })
+          .catch((error) => {
+            setWdsCapabilities({ status: 'Error', state: 'Error loading WDS capabilities' });
+            reportError('Error loading WDS capabilities', error);
+          });
+      },
+      [signal]
+    );
+
     const loadWdsData = useCallback(async () => {
       // Try to load the proxy URL
       if (!wdsApp || !['Ready', 'Error'].includes(wdsApp.status)) {
@@ -720,14 +736,16 @@ export const WorkspaceData = _.flow(
         // https://github.com/DataBiosphere/terra-ui/pull/4202#discussion_r1319145491
         if (foundApp) {
           loadWdsTypes(foundApp.proxyUrls?.wds, workspaceId);
+          loadWdsCapabilities(foundApp.proxyUrls?.wds);
         }
       }
       // If we have the proxy URL try to load the WDS types
       else if (wdsApp?.status === 'Ready') {
         const proxyUrl = wdsApp.state.proxyUrls?.wds;
         await loadWdsTypes(proxyUrl, workspaceId);
+        await loadWdsCapabilities(proxyUrl);
       }
-    }, [wdsApp, loadWdsApp, loadWdsTypes, workspaceId]);
+    }, [wdsApp, loadWdsApp, loadWdsTypes, loadWdsCapabilities, workspaceId]);
 
     useEffect(() => {
       if (isAzureWorkspace) {

--- a/src/workspace-data/Data.js
+++ b/src/workspace-data/Data.js
@@ -714,16 +714,14 @@ export const WorkspaceData = _.flow(
     );
 
     const loadWdsCapabilities = useCallback(
-      (url) => {
-        return Ajax(signal)
-          .WorkspaceData.getCapabilities(url)
-          .then((capabilitiesResult) => {
-            setWdsCapabilities({ status: 'Ready', state: capabilitiesResult });
-          })
-          .catch((error) => {
-            setWdsCapabilities({ status: 'Error', state: 'Error loading WDS capabilities' });
-            reportError('Error loading WDS capabilities', error);
-          });
+      async (url) => {
+        try {
+          const capabilitiesResult = await Ajax(signal).WorkspaceData.getCapabilities(url);
+          setWdsCapabilities({ status: 'Ready', state: capabilitiesResult });
+        } catch (error) {
+          setWdsCapabilities({ status: 'Error', state: 'Error loading WDS capabilities' });
+          reportError('Error loading WDS capabilities', error);
+        }
       },
       [signal]
     );

--- a/src/workspace-data/Data.test.ts
+++ b/src/workspace-data/Data.test.ts
@@ -100,6 +100,7 @@ describe('WorkspaceData', () => {
       status,
     };
 
+    const mockGetCapabilities = jest.fn().mockResolvedValue({});
     const mockGetSchema = jest.fn().mockResolvedValue([]);
     const mockListAppsV2 = jest.fn().mockResolvedValue([listAppResponse]);
     const mockEntityMetadata = jest.fn().mockRejectedValue([]);
@@ -113,6 +114,7 @@ describe('WorkspaceData', () => {
         }),
       },
       WorkspaceData: {
+        getCapabilities: mockGetCapabilities,
         getSchema: mockGetSchema,
       },
       Apps: {


### PR DESCRIPTION
In support of [AJ-1475](https://broadworkbench.atlassian.net/browse/AJ-1275) and other tickets that need to use the capabilities backend, wire up call to WDS for capabilities.  Fail gracefully on a 404, which might happen for older workspaces.

Depends on https://github.com/DataBiosphere/terra-workspace-data-service/pull/438 and subsequent capabilities added.

### Testing strategy
- New unit tests.
- Tested on localhost against bee backend.

<!-- ### Visual Aids -->
Running localhost:3000 against a bee backend, capabilities enabled:
<img width="1099" alt="image" src="https://github.com/DataBiosphere/terra-ui/assets/111856/e206c10f-5b8d-4663-9efd-ab2794dac920">

against a bee backend with an outdated workspace (no capabilities); in this case, I confirmed no errors popped up in the terra UI:
<img width="919" alt="image" src="https://github.com/DataBiosphere/terra-ui/assets/111856/fdbb1b9d-e30d-4913-a46b-36b0d7bed686">


[AJ-1475]: https://broadworkbench.atlassian.net/browse/AJ-1475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ