### PR TITLE
[WOR-1372] When cloning a requester pays workspace, show a generic egress message.

### DIFF
--- a/src/components/bucket-utils.js
+++ b/src/components/bucket-utils.js
@@ -3,15 +3,22 @@ import _ from 'lodash/fp';
 import { useState } from 'react';
 import { h } from 'react-hyperscript-helpers';
 import RequesterPaysModal from 'src/components/RequesterPaysModal';
+import { isRequesterPaysErrorInfo } from 'src/libs/ajax/ajax-common';
 import { forwardRefWithName } from 'src/libs/react-utils';
 import { requesterPaysProjectStore } from 'src/libs/state';
 import * as Utils from 'src/libs/utils';
+
+// Returns true if the error object passed in was marked as a requester pays error. Note that this parsing of the
+// error response is done in checkRequesterPaysError, which is used by the GoogleStorage ajax library.
+export const isBucketErrorRequesterPays = (error) => {
+  return isRequesterPaysErrorInfo(error) && error.requesterPaysError;
+};
 
 export const withRequesterPaysHandler = _.curry((handler, fn) => async (...args) => {
   try {
     return await fn(...args);
   } catch (error) {
-    if (error.requesterPaysError) {
+    if (isBucketErrorRequesterPays(error)) {
       handler();
       return abandonedPromise();
     }

--- a/src/libs/ajax/ajax-common.ts
+++ b/src/libs/ajax/ajax-common.ts
@@ -146,7 +146,7 @@ export const isRequesterPaysErrorInfo = (error: any): error is RequesterPaysErro
   return error != null && typeof error === 'object' && 'requesterPaysError' in error;
 };
 
-export const checkRequesterPaysError = async (response): RequesterPaysErrorInfo => {
+export const checkRequesterPaysError = async (response): Promise<RequesterPaysErrorInfo> => {
   if (response.status === 400) {
     const data = await response.text();
     const requesterPaysErrorInfo: RequesterPaysErrorInfo = {

--- a/src/libs/ajax/ajax-common.ts
+++ b/src/libs/ajax/ajax-common.ts
@@ -138,13 +138,24 @@ const withAppIdentifier = (wrappedFetch) => (url, options) => {
   return wrappedFetch(url, _.merge(options, appIdentifier));
 };
 
-export const checkRequesterPaysError = async (response) => {
+export type RequesterPaysErrorInfo = {
+  requesterPaysError: boolean;
+};
+
+export const isRequesterPaysErrorInfo = (error: any): error is RequesterPaysErrorInfo => {
+  return error != null && typeof error === 'object' && 'requesterPaysError' in error;
+};
+
+export const checkRequesterPaysError = async (response): RequesterPaysErrorInfo => {
   if (response.status === 400) {
     const data = await response.text();
-    const requesterPaysError = responseContainsRequesterPaysError(data);
-    return Object.assign(new Response(new Blob([data]), response), { requesterPaysError });
+    const requesterPaysErrorInfo: RequesterPaysErrorInfo = {
+      requesterPaysError: responseContainsRequesterPaysError(data),
+    };
+    return Object.assign(new Response(new Blob([data]), response), requesterPaysErrorInfo);
   }
-  return Object.assign(response, { requesterPaysError: false });
+  const unrecognizedErrorInfo: RequesterPaysErrorInfo = { requesterPaysError: false };
+  return Object.assign(response, unrecognizedErrorInfo);
 };
 
 export const responseContainsRequesterPaysError = (responseText) => {

--- a/src/pages/workspaces/workspace/Dashboard/BucketLocation.test.ts
+++ b/src/pages/workspaces/workspace/Dashboard/BucketLocation.test.ts
@@ -13,6 +13,7 @@ import {
   defaultAzureStorageOptions,
   defaultGoogleBucketOptions,
   defaultGoogleWorkspace,
+  mockBucketRequesterPaysError,
 } from 'src/testing/workspace-fixtures';
 
 type AjaxContract = ReturnType<typeof Ajax>;
@@ -141,7 +142,6 @@ describe('BucketLocation', () => {
         defaultAzureStorageOptions,
       ]),
     };
-    const requesterPaysError = { message: 'Requester pays bucket', requesterPaysError: true };
     const captureEvent = jest.fn();
     asMockedFn(Ajax).mockImplementation(
       () =>
@@ -150,7 +150,7 @@ describe('BucketLocation', () => {
           Workspaces: {
             workspace: () =>
               ({
-                checkBucketLocation: () => Promise.reject(requesterPaysError),
+                checkBucketLocation: () => Promise.reject(mockBucketRequesterPaysError),
               } as Partial<AjaxContract['Workspaces']['workspace']>),
           } as Partial<AjaxContract['Workspaces']>,
         } as Partial<AjaxContract> as AjaxContract)

--- a/src/pages/workspaces/workspace/Dashboard/BucketLocation.ts
+++ b/src/pages/workspaces/workspace/Dashboard/BucketLocation.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp';
 import { Fragment, ReactNode, useCallback, useEffect, useState } from 'react';
 import { h } from 'react-hyperscript-helpers';
-import { requesterPaysWrapper } from 'src/components/bucket-utils';
+import { isBucketErrorRequesterPays, requesterPaysWrapper } from 'src/components/bucket-utils';
 import { ButtonSecondary } from 'src/components/common';
 import { icon } from 'src/components/icons';
 import { getRegionInfo } from 'src/components/region-common';
@@ -42,7 +42,7 @@ export const BucketLocation = requesterPaysWrapper({ onDismiss: _.noop })((props
         .checkBucketLocation(googleProject, bucketName);
       setBucketLocation(response);
     } catch (error) {
-      if (error != null && typeof error === 'object' && 'requesterPaysError' in error) {
+      if (isBucketErrorRequesterPays(error)) {
         setNeedsRequesterPaysProject(true);
       } else {
         reportError('Unable to get bucket location.', error);

--- a/src/testing/workspace-fixtures.ts
+++ b/src/testing/workspace-fixtures.ts
@@ -2,6 +2,7 @@ import { DeepPartial } from '@terra-ui-packages/core-utils';
 import _ from 'lodash/fp';
 import { defaultLocation } from 'src/analysis/utils/runtime-utils';
 import { locationTypes } from 'src/components/region-common';
+import { RequesterPaysErrorInfo } from 'src/libs/ajax/ajax-common';
 import { AzureWorkspace, GoogleWorkspace, WorkspacePolicy } from 'src/libs/workspace-utils';
 
 export const defaultAzureWorkspace: AzureWorkspace = {
@@ -109,3 +110,5 @@ export const defaultGoogleBucketOptions = {
   googleBucketType: locationTypes.default,
   fetchedGoogleBucketLocation: undefined,
 };
+
+export const mockBucketRequesterPaysError: RequesterPaysErrorInfo = { requesterPaysError: true };

--- a/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.test.ts
+++ b/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.test.ts
@@ -1396,4 +1396,104 @@ describe('NewWorkspaceModal', () => {
       })
     );
   });
+
+  describe('shows egress warnings for cloning GCP workspaces', () => {
+    it('shows a message if the destination bucket location is in a different region', async () => {
+      // Arrange
+      const user = userEvent.setup();
+      asMockedFn(Ajax).mockImplementation(
+        () =>
+          ({
+            Workspaces: {
+              workspace: () => ({
+                checkBucketLocation: jest.fn().mockResolvedValue({
+                  location: 'US-CENTRAL1',
+                  locationType: 'location-type',
+                }),
+              }),
+            },
+            Billing: {
+              listProjects: async () => [gcpBillingProject],
+            },
+            ...nonBillingAjax,
+          } as AjaxContract)
+      );
+
+      // Act
+      await act(async () => {
+        render(
+          h(NewWorkspaceModal, {
+            cloneWorkspace: defaultGoogleWorkspace,
+            onDismiss: () => {},
+            onSuccess: () => {},
+          })
+        );
+      });
+
+      const projectSelector = screen.getByText('Select a billing project');
+      await user.click(projectSelector);
+
+      const googleBillingProject = screen.getByText('Google Billing Project');
+      await user.click(googleBillingProject);
+
+      const bucketLocationSelector = screen.getByLabelText('Bucket location');
+      await user.click(bucketLocationSelector);
+
+      // Verify warning doesn't show initially
+      expect(screen.queryByText(/may incur network egress charges./)).toBeNull();
+      // Select a different bucket location from the source workspace one.
+      const montrealLocation = screen.getByText('northamerica-northeast1 (Montreal)');
+      await user.click(montrealLocation);
+
+      // Assert
+      // Have to use textContent to work around bolded sections of text.
+      const warning = screen.getByText('Copying data from', { exact: false });
+      expect(warning.textContent).toEqual(
+        'Copying data from us-central1 (Iowa) to northamerica-northeast1 (Montreal) may incur network egress charges. '
+      );
+    });
+
+    it('shows a generic message if the source workspace is requester pays', async () => {
+      // Arrange
+      const user = userEvent.setup();
+      const requesterPaysError = { message: 'Requester pays bucket', requesterPaysError: true };
+      asMockedFn(Ajax).mockImplementation(
+        () =>
+          ({
+            Workspaces: {
+              workspace: () => ({
+                checkBucketLocation: () => Promise.reject(requesterPaysError),
+              }),
+            },
+            Billing: {
+              listProjects: async () => [gcpBillingProject],
+            },
+            ...nonBillingAjax,
+          } as AjaxContract)
+      );
+
+      // Act
+      await act(async () => {
+        render(
+          h(NewWorkspaceModal, {
+            cloneWorkspace: defaultGoogleWorkspace,
+            onDismiss: () => {},
+            onSuccess: () => {},
+          })
+        );
+      });
+
+      // Verify warning doesn't show up until a destination billing project is selected.
+      expect(screen.queryByText(/Copying data may incur network egress charges/)).toBeNull();
+
+      const projectSelector = screen.getByText('Select a billing project');
+      await user.click(projectSelector);
+
+      const googleBillingProject = screen.getByText('Google Billing Project');
+      await user.click(googleBillingProject);
+
+      // Assert
+      screen.getByText(/Copying data may incur network egress charges/);
+    });
+  });
 });

--- a/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.test.ts
+++ b/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.test.ts
@@ -14,7 +14,12 @@ import {
   gcpBillingProject,
 } from 'src/testing/billing-project-fixtures';
 import { renderWithAppContexts as render, SelectHelper } from 'src/testing/test-utils';
-import { defaultAzureWorkspace, defaultGoogleWorkspace, protectedAzureWorkspace } from 'src/testing/workspace-fixtures';
+import {
+  defaultAzureWorkspace,
+  defaultGoogleWorkspace,
+  mockBucketRequesterPaysError,
+  protectedAzureWorkspace,
+} from 'src/testing/workspace-fixtures';
 
 import NewWorkspaceModal from './NewWorkspaceModal';
 
@@ -1456,13 +1461,12 @@ describe('NewWorkspaceModal', () => {
     it('shows a generic message if the source workspace is requester pays', async () => {
       // Arrange
       const user = userEvent.setup();
-      const requesterPaysError = { message: 'Requester pays bucket', requesterPaysError: true };
       asMockedFn(Ajax).mockImplementation(
         () =>
           ({
             Workspaces: {
               workspace: () => ({
-                checkBucketLocation: () => Promise.reject(requesterPaysError),
+                checkBucketLocation: () => Promise.reject(mockBucketRequesterPaysError),
               }),
             },
             Billing: {

--- a/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.ts
+++ b/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.ts
@@ -319,7 +319,7 @@ const NewWorkspaceModal = withDisplayName(
     const shouldShowDifferentRegionWarning =
       !!cloneWorkspace && !requesterPaysError && bucketLocation !== sourceWorkspaceLocation;
 
-    const cloningRequesterPaysWorkspace = !!cloneWorkspace && requesterPaysError && !!namespace;
+    const cloningRequesterPaysWorkspace = !!cloneWorkspace && requesterPaysError;
 
     const isAzureBillingProject = (project?: BillingProject): project is AzureBillingProject =>
       isCloudProviderBillingProject(project, 'AZURE');
@@ -551,7 +551,8 @@ const NewWorkspaceModal = withDisplayName(
                             }),
                           ]),
                       ]),
-                    (shouldShowDifferentRegionWarning || cloningRequesterPaysWorkspace) &&
+                    !!namespace &&
+                      (shouldShowDifferentRegionWarning || cloningRequesterPaysWorkspace) &&
                       div({ style: { ...warningStyle } }, [
                         icon('warning-standard', {
                           size: 24,

--- a/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.ts
+++ b/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.ts
@@ -559,7 +559,7 @@ const NewWorkspaceModal = withDisplayName(
                         }),
                         div({ style: { flex: 1 } }, [
                           cloningRequesterPaysWorkspace
-                            ? span('Copying data may incur network egress charges. ')
+                            ? span(['Copying data may incur network egress charges. '])
                             : span([
                                 'Copying data from ',
                                 strong([getRegionInfo(sourceWorkspaceLocation, sourceLocationType).regionDescription]),

--- a/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.ts
+++ b/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.ts
@@ -3,6 +3,7 @@ import _ from 'lodash/fp';
 import { CSSProperties, Fragment, ReactNode, useState } from 'react';
 import { div, h, label, p, span, strong } from 'react-hyperscript-helpers';
 import { defaultLocation } from 'src/analysis/utils/runtime-utils';
+import { isBucketErrorRequesterPays } from 'src/components/bucket-utils';
 import { CloudProviderIcon } from 'src/components/CloudProviderIcon';
 import {
   ButtonPrimary,
@@ -306,7 +307,7 @@ const NewWorkspaceModal = withDisplayName(
               setSourceWorkspaceLocation(location);
             })
             .catch((error) => {
-              if (error != null && typeof error === 'object' && 'requesterPaysError' in error) {
+              if (isBucketErrorRequesterPays(error)) {
                 setRequesterPaysError(true);
               } else {
                 throw error;

--- a/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.ts
+++ b/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.ts
@@ -1,7 +1,7 @@
 import { delay } from '@terra-ui-packages/core-utils';
 import _ from 'lodash/fp';
 import { CSSProperties, Fragment, ReactNode, useState } from 'react';
-import { div, h, label, p, strong } from 'react-hyperscript-helpers';
+import { div, h, label, p, span, strong } from 'react-hyperscript-helpers';
 import { defaultLocation } from 'src/analysis/utils/runtime-utils';
 import { CloudProviderIcon } from 'src/components/CloudProviderIcon';
 import {
@@ -138,6 +138,7 @@ const NewWorkspaceModal = withDisplayName(
     const [createError, setCreateError] = useState<string>();
     const [bucketLocation, setBucketLocation] = useState(defaultLocation);
     const [sourceWorkspaceLocation, setSourceWorkspaceLocation] = useState(defaultLocation);
+    const [requesterPaysError, setRequesterPaysError] = useState(false);
     const [isAlphaRegionalityUser, setIsAlphaRegionalityUser] = useState(false);
     const signal = useCancellation();
 
@@ -303,13 +304,21 @@ const NewWorkspaceModal = withDisplayName(
               // For current phased regionality release, we only allow US or NORTHAMERICA-NORTHEAST1 (Montreal) workspace buckets.
               setBucketLocation(isSupportedBucketLocation(location) ? location : defaultLocation);
               setSourceWorkspaceLocation(location);
+            })
+            .catch((error) => {
+              if (error != null && typeof error === 'object' && 'requesterPaysError' in error) {
+                setRequesterPaysError(true);
+              } else {
+                throw error;
+              }
             }),
       ])
     );
 
-    const shouldShowDifferentRegionWarning = () => {
-      return !!cloneWorkspace && bucketLocation !== sourceWorkspaceLocation;
-    };
+    const shouldShowDifferentRegionWarning =
+      !!cloneWorkspace && !requesterPaysError && bucketLocation !== sourceWorkspaceLocation;
+
+    const cloningRequesterPaysWorkspace = !!cloneWorkspace && requesterPaysError && !!namespace;
 
     const isAzureBillingProject = (project?: BillingProject): project is AzureBillingProject =>
       isCloudProviderBillingProject(project, 'AZURE');
@@ -541,18 +550,22 @@ const NewWorkspaceModal = withDisplayName(
                             }),
                           ]),
                       ]),
-                    shouldShowDifferentRegionWarning() &&
+                    (shouldShowDifferentRegionWarning || cloningRequesterPaysWorkspace) &&
                       div({ style: { ...warningStyle } }, [
                         icon('warning-standard', {
                           size: 24,
                           style: { color: colors.warning(), flex: 'none', marginRight: '0.5rem' },
                         }),
                         div({ style: { flex: 1 } }, [
-                          'Copying data from ',
-                          strong([getRegionInfo(sourceWorkspaceLocation, sourceLocationType).regionDescription]),
-                          ' to ',
-                          strong([getRegionInfo(bucketLocation, destLocationType).regionDescription]),
-                          ' may incur network egress charges. ',
+                          cloningRequesterPaysWorkspace
+                            ? span('Copying data may incur network egress charges. ')
+                            : span([
+                                'Copying data from ',
+                                strong([getRegionInfo(sourceWorkspaceLocation, sourceLocationType).regionDescription]),
+                                ' to ',
+                                strong([getRegionInfo(bucketLocation, destLocationType).regionDescription]),
+                                ' may incur network egress charges. ',
+                              ]),
                           'To prevent charges, the new bucket location needs to stay in the same region as the original one. ',
                           h(
                             Link,


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-1372

When going to a requester pays workspace, the bucket location cannot be fetched. We currently show this in the bucket location section:

<img width="602" alt="image" src="https://github.com/DataBiosphere/terra-ui/assets/484484/383cd20d-1171-4650-895c-09e979da780d">

However, trying to bring up the clone workspace dialog would throw an error because we attempt to get the bucket location so that we can display an egress warning:

(Current situation on dev/prod):
<img width="1305" alt="image" src="https://github.com/DataBiosphere/terra-ui/assets/484484/34909c29-dbf2-4077-a27c-cc755c3750c2">

To fix this, we catch the requester pays error and show a generic egress message when the user selects a billing project to clone to… in this case, we don't know if the user will actually hit an egress issue.

Requester pays workspace:
<img width="491" alt="image" src="https://github.com/DataBiosphere/terra-ui/assets/484484/9b747c5a-7a95-4143-9481-611e246c0edb">

Contrast with the case of a non-requester pays workspace, where we only show the warning when the user WILL incur egress:
<img width="495" alt="image" src="https://github.com/DataBiosphere/terra-ui/assets/484484/924875eb-72ae-43e7-bc72-a3ea0b99aa24">
<img width="515" alt="image" src="https://github.com/DataBiosphere/terra-ui/assets/484484/027cd01f-3687-4c32-8ca5-2c397af11e77">


