### PR TITLE
AJ-1554 - Fix download link for wds data table modal

### DIFF
--- a/src/workspace-data/data-table/uri-viewer/UriViewer.js
+++ b/src/workspace-data/data-table/uri-viewer/UriViewer.js
@@ -196,6 +196,7 @@ export const UriViewer = _.flow(
                 els.cell([els.label('File size'), els.data(filesize(size))]),
                 renderTerminalCommand(metadata),
                 renderMoreInfo(metadata),
+                !isAzureUri(uri) && div({ style: { fontSize: 10 } }, ['* Estimated. Download cost may be higher in China or Australia.']),
               ]),
           ],
           () => renderLoadingSymbol(uri)


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/AJ-1554

## Summary of changes:
The azcopy download command was not working for downloading Azure file from storage. It looks like this was caused by the following [PR](https://github.com/DataBiosphere/terra-ui/pull/4100/files#diff-4a7efd7c236e633b3f47c86c2b7180cb60ce0521715a4545e0842fb06e3744b1L90). 

Digging more into this, it also looks like a few other things changed: 
- the reason why this line was set was due to a SAS token being returned for Azure Blob links that were public and therefore didnt need a sas token (they would actually fail if one was [provided](https://github.com/DataBiosphere/terra-ui/pull/3868#discussion_r1160701112))
- however now the Azure Client does the right thing and indeed doesnt send a token for public blobs

### What
This PR makes sure that both public and nonpublic blobs can be downloaded via the "download" and az copy methods. 

<!-- ### Visual Aids -->
pubic Blob urls will have no sas token
![image](https://github.com/DataBiosphere/terra-ui/assets/9418602/2b166dd4-d1ee-4ecb-9985-e3d81debcfef)

while non public ones will
![image](https://github.com/DataBiosphere/terra-ui/assets/9418602/54d0a041-f2f2-478f-a81b-38a979d0606e)

