### PR TITLE
[WOR-1438] Fix bug with request of token with undefined googleProject

### DIFF
--- a/src/pages/workspaces/WorkspacesList/RenderedWorkspaces.ts
+++ b/src/pages/workspaces/WorkspacesList/RenderedWorkspaces.ts
@@ -386,7 +386,8 @@ const ActionsCell = (props: ActionsCellProps): ReactNode => {
     workspaceId: string,
     policies?: WorkspacePolicy[],
     bucketName?: string,
-    description?: string
+    description?: string,
+    googleProject?: string
   ): Workspace => {
     // The workspaces from the list API have fewer properties to keep the payload as small as possible.
     const listWorkspace = getWorkspace(workspaceId);
@@ -395,14 +396,20 @@ const ActionsCell = (props: ActionsCellProps): ReactNode => {
       extendedWorkspace.workspace.bucketName = bucketName;
     }
 
+    if (googleProject !== undefined && isGoogleWorkspace(extendedWorkspace)) {
+      extendedWorkspace.workspace.googleProject = googleProject;
+    }
+
     if (description !== undefined && extendedWorkspace.workspace.attributes !== undefined) {
       extendedWorkspace.workspace.attributes.description = description;
     }
     return extendedWorkspace;
   };
 
-  const onClone = (policies, bucketName, description) =>
-    setUserActions({ cloningWorkspace: extendWorkspace(workspaceId, policies, bucketName, description) });
+  const onClone = (policies, bucketName, description, googleProject) =>
+    setUserActions({
+      cloningWorkspace: extendWorkspace(workspaceId, policies, bucketName, description, googleProject),
+    });
   const onDelete = () => setUserActions({ deletingWorkspaceId: workspaceId });
   const onLock = () => setUserActions({ lockingWorkspaceId: workspaceId });
   const onShare = (policies, bucketName) =>

--- a/src/pages/workspaces/workspace/WorkspaceMenu.test.ts
+++ b/src/pages/workspaces/workspace/WorkspaceMenu.test.ts
@@ -367,6 +367,7 @@ describe('DynamicWorkspaceMenuContent fetches specific workspace details', () =>
     // @ts-expect-error - Limit return values based on what is requested
     workspace: {
       cloudPlatform: 'Gcp',
+      googleProject: 'googleProjectName',
       bucketName: 'fc-bucketname',
       isLocked: false,
       state: 'Ready',
@@ -394,7 +395,7 @@ describe('DynamicWorkspaceMenuContent fetches specific workspace details', () =>
     policies: [protectedDataPolicy],
   };
 
-  const onClone = jest.fn((_policies, _bucketName, _description) => {});
+  const onClone = jest.fn((_policies, _bucketName, _description, _googleProject) => {});
   const onShare = jest.fn((_policies, _bucketName) => {});
   const namespace = 'test-namespace';
   const name = 'test-name';
@@ -423,6 +424,7 @@ describe('DynamicWorkspaceMenuContent fetches specific workspace details', () =>
       'workspace.bucketName',
       'workspace.attributes.description',
       'workspace.cloudPlatform',
+      'workspace.googleProject',
       'workspace.isLocked',
       'workspace.state',
     ];
@@ -434,7 +436,7 @@ describe('DynamicWorkspaceMenuContent fetches specific workspace details', () =>
     expect(workspaceDetails).toHaveBeenCalledWith({ namespace, name }, expectedRequestedFields);
   });
 
-  it('passes onClone the bucketName and description for a Google workspace', async () => {
+  it('passes onClone the bucketName, description, and googleProject for a Google workspace', async () => {
     // Arrange
     const user = userEvent.setup();
     asMockedFn(useWorkspaceDetails).mockReturnValue({
@@ -450,7 +452,7 @@ describe('DynamicWorkspaceMenuContent fetches specific workspace details', () =>
     // Assert
     const menuItem = screen.getByText('Clone');
     await user.click(menuItem);
-    expect(onClone).toBeCalledWith([], 'fc-bucketname', descriptionText);
+    expect(onClone).toBeCalledWith([], 'fc-bucketname', descriptionText, 'googleProjectName');
   });
 
   it('passes onClone the policies and description for an Azure workspace', async () => {
@@ -469,7 +471,7 @@ describe('DynamicWorkspaceMenuContent fetches specific workspace details', () =>
     // Assert
     const menuItem = screen.getByText('Clone');
     await user.click(menuItem);
-    expect(onClone).toBeCalledWith([protectedDataPolicy], undefined, descriptionText);
+    expect(onClone).toBeCalledWith([protectedDataPolicy], undefined, descriptionText, undefined);
   });
 
   it('passes onShare the bucketName for a Google workspace', async () => {

--- a/src/pages/workspaces/workspace/WorkspaceMenu.ts
+++ b/src/pages/workspaces/workspace/WorkspaceMenu.ts
@@ -28,7 +28,7 @@ type DynamicWorkspaceInfo = { name: string; namespace: string };
 type WorkspaceInfo = DynamicWorkspaceInfo | LoadedWorkspaceInfo;
 
 interface WorkspaceMenuCallbacks {
-  onClone: (policies?: WorkspacePolicy[], bucketName?: string, description?: string) => void;
+  onClone: (policies?: WorkspacePolicy[], bucketName?: string, description?: string, googleProject?: string) => void;
   onShare: (policies?: WorkspacePolicy[], bucketName?: string) => void;
   onLock: () => void;
   onDelete: () => void;
@@ -99,10 +99,12 @@ const DynamicWorkspaceMenuContent = (props: DynamicWorkspaceMenuContentProps) =>
     'workspace.bucketName',
     'workspace.attributes.description',
     'workspace.cloudPlatform',
+    'workspace.googleProject',
     'workspace.isLocked',
     'workspace.state',
   ]) as { workspace?: Workspace };
   const bucketName = !!workspace && isGoogleWorkspace(workspace) ? workspace.workspace.bucketName : undefined;
+  const googleProject = !!workspace && isGoogleWorkspace(workspace) ? workspace.workspace.googleProject : undefined;
 
   const descriptionText =
     !!workspace && workspace.workspace.attributes !== undefined
@@ -123,7 +125,7 @@ const DynamicWorkspaceMenuContent = (props: DynamicWorkspaceMenuContentProps) =>
     callbacks: {
       ...callbacks,
       onShare: () => callbacks.onShare(workspace?.policies, bucketName),
-      onClone: () => callbacks.onClone(workspace?.policies, bucketName, descriptionText),
+      onClone: () => callbacks.onClone(workspace?.policies, bucketName, descriptionText, googleProject),
     },
   });
 };


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-1438

This bug was not reproducible in dev environments because `getToken` endpoint in the dev environment returns a token, even if the googleProject name is "undefined". So to verify this is fixed, it is necessary to look at the network activity.

Reproduction steps:
From the workspaces list view, try to open the Clone workspace dialog for a Google workspace. Screenshot on prod:

<img width="1308" alt="image" src="https://github.com/DataBiosphere/terra-ui/assets/484484/e3c5466c-a7f0-44e3-89f0-6b8091396180">

Screenshot on dev (note that "undefined" is still in the token URL, but dev Sam returns a token):
<img width="1120" alt="image" src="https://github.com/DataBiosphere/terra-ui/assets/484484/59599d8f-fd0f-43c8-b231-9c093cbeecba">

Screenshot on PR deployment (note google project name in token URL):
<img width="1090" alt="image" src="https://github.com/DataBiosphere/terra-ui/assets/484484/3de3168c-7f3f-4275-8a07-dbd8ff17c59b">


