### PR TITLE
WOR-1373 Billing Project user feedback: Update cost groupings in ToA Billing Project spend report

### DIFF
--- a/integration-tests/tests/billing-projects.js
+++ b/integration-tests/tests/billing-projects.js
@@ -131,6 +131,7 @@ const setAjaxMockValues = async (
         spendData: [
           { cost: '999', category: 'Compute' },
           { cost: '22', category: 'Storage' },
+          { cost: '11', category: 'WorkspaceInfrastructure' },
           { cost: '89', category: 'Other' },
         ],
       },
@@ -402,9 +403,10 @@ const testBillingSpendReportFn = withUserToken(async ({ page, testUrl, token }) 
   await billingPage.selectSpendReport();
 
   // Title and cost are in different elements, but check both in same text assert to verify that category is correctly associated to its cost.
-  await billingPage.assertText('Total spend$1,110.17');
+  await billingPage.assertText('Total spend$1,121.17');
   await billingPage.assertText('Total compute$999.00');
   await billingPage.assertText('Total storage$22.00');
+  await billingPage.assertText('Total workspace infrastructure$11.00');
   await billingPage.assertText(
     'Total spend includes $89.00 in other infrastructure or query costs related to the general operations of Terra. See our documentation to learn more about Azure costs.'
   );

--- a/integration-tests/tests/billing-projects.js
+++ b/integration-tests/tests/billing-projects.js
@@ -404,8 +404,8 @@ const testBillingSpendReportFn = withUserToken(async ({ page, testUrl, token }) 
 
   // Title and cost are in different elements, but check both in same text assert to verify that category is correctly associated to its cost.
   await billingPage.assertText('Total spend$1,110.17');
-  await billingPage.assertText('Total compute$999.00');
-  await billingPage.assertText('Total storage$22.00');
+  await billingPage.assertText('Total analysis compute$999.00');
+  await billingPage.assertText('Total workspace storage$22.00');
   await billingPage.assertText('Total workspace infrastructure$11.00');
   await billingPage.assertText(
     'Total spend includes $89.00 in other infrastructure or query costs related to the general operations of Terra. See our documentation to learn more about Azure costs.'

--- a/integration-tests/tests/billing-projects.js
+++ b/integration-tests/tests/billing-projects.js
@@ -403,7 +403,7 @@ const testBillingSpendReportFn = withUserToken(async ({ page, testUrl, token }) 
   await billingPage.selectSpendReport();
 
   // Title and cost are in different elements, but check both in same text assert to verify that category is correctly associated to its cost.
-  await billingPage.assertText('Total spend$1,121.17');
+  await billingPage.assertText('Total spend$1,110.17');
   await billingPage.assertText('Total compute$999.00');
   await billingPage.assertText('Total storage$22.00');
   await billingPage.assertText('Total workspace infrastructure$11.00');

--- a/src/pages/billing/SpendReport/SpendReport.test.ts
+++ b/src/pages/billing/SpendReport/SpendReport.test.ts
@@ -57,6 +57,7 @@ describe('SpendReport', () => {
       spendData: [
         { cost: '999', category: 'Compute', credits: '0.00', currency: 'USD' },
         { cost: '22', category: 'Storage', credits: '0.00', currency: 'USD' },
+        { cost: '55', category: 'WorkspaceInfrastructure', credits: '0.00', currency: 'USD' },
         { cost: '89', category: 'Other', credits: '0.00', currency: 'USD' },
       ],
     };
@@ -170,6 +171,8 @@ describe('SpendReport', () => {
     expect(screen.getByTestId('spend')).toHaveTextContent('$1,110.00*');
     expect(screen.getByTestId('compute')).toHaveTextContent('$999.00');
     expect(screen.getByTestId('storage')).toHaveTextContent('$22.00');
+    // validate that 'workspaceinfractructure' card is not shown for GCP report
+    expect(screen.queryByTestId('workspaceinfrastructure')).not.toBeInTheDocument();
 
     // Highcharts content is very minimal when rendered in the unit test. Testing of "most expensive workspaces"
     // is in the integration test. Accessibility is also tested in the integration test.
@@ -204,6 +207,7 @@ describe('SpendReport', () => {
     expect(screen.getByTestId('spend')).toHaveTextContent('$1,110.00*');
     expect(screen.getByTestId('compute')).toHaveTextContent('$999.00');
     expect(screen.getByTestId('storage')).toHaveTextContent('$22.00');
+    expect(screen.getByTestId('workspaceinfrastructure')).toHaveTextContent('$55.00');
   });
 
   it('fetches reports based on selected date range, if active', async () => {

--- a/src/pages/billing/SpendReport/SpendReport.test.ts
+++ b/src/pages/billing/SpendReport/SpendReport.test.ts
@@ -207,7 +207,7 @@ describe('SpendReport', () => {
     expect(screen.getByTestId('spend')).toHaveTextContent('$1,110.00*');
     expect(screen.getByTestId('compute')).toHaveTextContent('$999.00');
     expect(screen.getByTestId('storage')).toHaveTextContent('$22.00');
-    expect(screen.getByTestId('workspaceinfrastructure')).toHaveTextContent('$55.00');
+    expect(screen.getByTestId('workspaceInfrastructure')).toHaveTextContent('$55.00');
   });
 
   it('fetches reports based on selected date range, if active', async () => {

--- a/src/pages/billing/SpendReport/SpendReport.test.ts
+++ b/src/pages/billing/SpendReport/SpendReport.test.ts
@@ -171,8 +171,8 @@ describe('SpendReport', () => {
     expect(screen.getByTestId('spend')).toHaveTextContent('$1,110.00*');
     expect(screen.getByTestId('compute')).toHaveTextContent('$999.00');
     expect(screen.getByTestId('storage')).toHaveTextContent('$22.00');
-    // validate that 'workspaceinfractructure' card is not shown for GCP report
-    expect(screen.queryByTestId('workspaceinfrastructure')).not.toBeInTheDocument();
+    // validate that 'workspaceInfractructure' card is not shown for GCP report
+    expect(screen.queryByTestId('workspaceInfrastructure')).not.toBeInTheDocument();
 
     // Highcharts content is very minimal when rendered in the unit test. Testing of "most expensive workspaces"
     // is in the integration test. Accessibility is also tested in the integration test.

--- a/src/pages/billing/SpendReport/SpendReport.ts
+++ b/src/pages/billing/SpendReport/SpendReport.ts
@@ -48,7 +48,7 @@ interface ProjectCost {
   spend: string;
   compute: string;
   storage: string;
-  workspaceinfrastructure: string;
+  workspaceInfrastructure: string;
   other: string;
 }
 // End of interfaces for internal storage of data
@@ -185,7 +185,7 @@ export const SpendReport = (props: SpendReportProps) => {
   const isProjectCostReady = projectCost !== null;
 
   const TOTAL_SPEND_CATEGORY = 'spend';
-  const WORKSPACEINFRASTRUCTURE_CATEGORY = 'workspaceinfrastructure';
+  const WORKSPACEINFRASTRUCTURE_CATEGORY = 'workspaceInfrastructure';
   const COMPUTE_CATEGORY = 'compute';
   const STORAGE_CATEGORY = 'storage';
 
@@ -230,11 +230,11 @@ export const SpendReport = (props: SpendReportProps) => {
         console.assert(categoryDetails !== undefined, 'Spend report details do not include aggregation by Category');
         const getCategoryCosts = (
           categorySpendData: CategorySpendData[]
-        ): { compute: number; storage: number; workspaceinfrastructure: number; other: number } => {
+        ): { compute: number; storage: number; workspaceInfrastructure: number; other: number } => {
           return {
             compute: parseFloat(_.find(['category', 'Compute'], categorySpendData)?.cost ?? '0'),
             storage: parseFloat(_.find(['category', 'Storage'], categorySpendData)?.cost ?? '0'),
-            workspaceinfrastructure: parseFloat(
+            workspaceInfrastructure: parseFloat(
               _.find(['category', 'WorkspaceInfrastructure'], categorySpendData)?.cost ?? '0'
             ),
             other: parseFloat(_.find(['category', 'Other'], categorySpendData)?.cost ?? '0'),
@@ -246,7 +246,7 @@ export const SpendReport = (props: SpendReportProps) => {
           spend: costFormatter.format(parseFloat(spend.spendSummary.cost)),
           compute: costFormatter.format(costDict.compute),
           storage: costFormatter.format(costDict.storage),
-          workspaceinfrastructure: costFormatter.format(costDict.workspaceinfrastructure),
+          workspaceInfrastructure: costFormatter.format(costDict.workspaceInfrastructure),
           other: costFormatter.format(costDict.other),
         });
 

--- a/src/pages/billing/SpendReport/SpendReport.ts
+++ b/src/pages/billing/SpendReport/SpendReport.ts
@@ -184,12 +184,27 @@ export const SpendReport = (props: SpendReportProps) => {
 
   const isProjectCostReady = projectCost !== null;
 
-  const azureCategoryCardCaptionMap = new Map([
-    ['spend', 'spend'],
-    ['workspaceinfrastructure', 'workspace infrastructure'],
-    ['compute', 'analysis compute'],
-    ['storage', 'workspace storage'],
-  ]);
+  const TOTAL_SPEND_CATEGORY = 'spend';
+  const WORKSPACEINFRASTRUCTURE_CATEGORY = 'workspaceinfrastructure';
+  const COMPUTE_CATEGORY = 'compute';
+  const STORAGE_CATEGORY = 'storage';
+
+  const getReportCategoryCardCaption = (name, cloudPlatformName) => {
+    const azureCategoryCardCaptionMap = new Map([
+      [TOTAL_SPEND_CATEGORY, 'spend'],
+      [WORKSPACEINFRASTRUCTURE_CATEGORY, 'workspace infrastructure'],
+      [COMPUTE_CATEGORY, 'analysis compute'],
+      [STORAGE_CATEGORY, 'workspace storage'],
+    ]);
+
+    return cloudPlatformName === 'GCP' ? name : azureCategoryCardCaptionMap.get(name);
+  };
+
+  // the order of the arrays below is important. it defines the order of elements on UI.
+  const reportCategories =
+    props.cloudPlatform === 'GCP'
+      ? [TOTAL_SPEND_CATEGORY, COMPUTE_CATEGORY, STORAGE_CATEGORY]
+      : [TOTAL_SPEND_CATEGORY, WORKSPACEINFRASTRUCTURE_CATEGORY, COMPUTE_CATEGORY, STORAGE_CATEGORY];
 
   useEffect(() => {
     const maybeLoadProjectCost = async () => {
@@ -299,7 +314,7 @@ export const SpendReport = (props: SpendReportProps) => {
         {
           style: {
             display: 'grid',
-            gridTemplateColumns: `repeat(${props.cloudPlatform === 'GCP' ? 3 : 4}, minmax(max-content, 1fr))`,
+            gridTemplateColumns: `repeat(${reportCategories.length}, minmax(max-content, 1fr))`,
             rowGap: '1.66rem',
             columnGap: '1.25rem',
           },
@@ -336,14 +351,12 @@ export const SpendReport = (props: SpendReportProps) => {
             (name) =>
               h(CostCard, {
                 type: name,
-                title: `Total ${props.cloudPlatform === 'GCP' ? name : azureCategoryCardCaptionMap.get(name)}`,
+                title: `Total ${getReportCategoryCardCaption(name, props.cloudPlatform)}`,
                 amount: !isProjectCostReady ? '...' : projectCost[name],
                 isProjectCostReady,
                 showAsterisk: name === 'spend',
               }),
-            props.cloudPlatform === 'GCP'
-              ? ['spend', 'compute', 'storage']
-              : ['spend', 'workspaceinfrastructure', 'compute', 'storage']
+            reportCategories
           ),
         ]
       ),

--- a/src/pages/billing/SpendReport/SpendReport.ts
+++ b/src/pages/billing/SpendReport/SpendReport.ts
@@ -213,29 +213,26 @@ export const SpendReport = (props: SpendReportProps) => {
           spend.spendDetails
         ) as AggregatedCategorySpendData;
         console.assert(categoryDetails !== undefined, 'Spend report details do not include aggregation by Category');
-        const extractCategorizedCostItem = (category: string, categorySpendData: CategorySpendData[]) => {
-          return parseFloat(_.find(['category', category], categorySpendData)?.cost ?? '0');
-        };
-        const getCategoryCosts = (categorySpendData: CategorySpendData[]): Map<string, number> => {
-          const categoryCosts = new Map();
-          categoryCosts.set('compute', extractCategorizedCostItem('Compute', categorySpendData));
-          categoryCosts.set('storage', extractCategorizedCostItem('Storage', categorySpendData));
-          categoryCosts.set('other', extractCategorizedCostItem('Other', categorySpendData));
-          if (props.cloudPlatform !== 'GCP') {
-            categoryCosts.set(
-              'workspaceinfrastructure',
-              extractCategorizedCostItem('WorkspaceInfrastructure', categorySpendData)
-            );
-          }
-          return categoryCosts;
+        const getCategoryCosts = (
+          categorySpendData: CategorySpendData[]
+        ): { compute: number; storage: number; workspaceinfrastructure: number; other: number } => {
+          return {
+            compute: parseFloat(_.find(['category', 'Compute'], categorySpendData)?.cost ?? '0'),
+            storage: parseFloat(_.find(['category', 'Storage'], categorySpendData)?.cost ?? '0'),
+            workspaceinfrastructure: parseFloat(
+              _.find(['category', 'WorkspaceInfrastructure'], categorySpendData)?.cost ?? '0'
+            ),
+            other: parseFloat(_.find(['category', 'Other'], categorySpendData)?.cost ?? '0'),
+          };
         };
         const costDict = getCategoryCosts(categoryDetails.spendData);
+
         setProjectCost({
           spend: costFormatter.format(parseFloat(spend.spendSummary.cost)),
-          compute: costFormatter.format(costDict.get('compute')),
-          storage: costFormatter.format(costDict.get('storage')),
-          workspaceinfrastructure: costFormatter.format(costDict.get('workspaceinfrastructure')),
-          other: costFormatter.format(costDict.get('other')),
+          compute: costFormatter.format(costDict.compute),
+          storage: costFormatter.format(costDict.storage),
+          workspaceinfrastructure: costFormatter.format(costDict.workspaceinfrastructure),
+          other: costFormatter.format(costDict.other),
         });
 
         if (includePerWorkspaceCosts) {
@@ -272,9 +269,9 @@ export const SpendReport = (props: SpendReportProps) => {
               'Workspace spend report details do not include sub-aggregation by Category'
             );
             const costDict = getCategoryCosts(categoryDetails.spendData);
-            costPerWorkspace.computeCosts.push(costDict.get('compute'));
-            costPerWorkspace.storageCosts.push(costDict.get('storage'));
-            costPerWorkspace.otherCosts.push(costDict.get('other'));
+            costPerWorkspace.computeCosts.push(costDict.compute);
+            costPerWorkspace.storageCosts.push(costDict.storage);
+            costPerWorkspace.otherCosts.push(costDict.other);
           }, mostExpensiveWorkspaces);
           setCostPerWorkspace(costPerWorkspace);
         }


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WOR-1373

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->
No dependent tickets. But there are related PRs in [BPM ](https://github.com/DataBiosphere/terra-billing-profile-manager/pull/394) and [Rawls](https://github.com/broadinstitute/rawls/pull/2708).

## Summary of changes:
This PR introduce changes to Azure spend report only. No changes to GCP reporting.
-new 'workspace infrastructure' category will be shown.
-category card captions are changed: ('Total compute' -> 'Total analysis compute'; 'Total storage' -> 'Total workspace storage')

<img width="1280" alt="image" src="https://github.com/DataBiosphere/terra-ui/assets/91149690/da13a9eb-b0ea-453b-9c06-cad78d2b17d9">

### What
Azure spend reporting format

### Why
- To show more detailed information

### Testing strategy
- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 
