### PR TITLE
[DC-818] Bug with Spacing in Bolding of Searched Concept

### DIFF
--- a/src/dataset-builder/ConceptSearch.test.ts
+++ b/src/dataset-builder/ConceptSearch.test.ts
@@ -163,17 +163,6 @@ describe('ConceptSearch', () => {
     expect(await screen.findByText('ease')).toBeTruthy();
   });
 
-  it('testing HighlightConceptName, "ease"', async () => {
-    renderSearch('ease');
-    const easeText = await screen.findAllByText('ease');
-    const filterEaseText = _.filter(
-      (element) => element.tagName === 'DIV' && element.style.fontWeight === '600',
-      easeText
-    ).length;
-    expect(filterEaseText).toBe(1);
-    expect(await screen.findByText('Dis')).toBeTruthy();
-  });
-
   it('testing HighlightConceptName, Checking that spaces still exist on both sides', async () => {
     renderSearch('by');
     const byText = await screen.findAllByText('by');

--- a/src/dataset-builder/ConceptSearch.test.ts
+++ b/src/dataset-builder/ConceptSearch.test.ts
@@ -174,6 +174,22 @@ describe('ConceptSearch', () => {
     expect(await screen.findByText('Dis')).toBeTruthy();
   });
 
+  it('testing HighlightConceptName, Checking that spaces still exist on both sides', async () => {
+    renderSearch('by');
+    const byText = await screen.findAllByText('by');
+    const filterByText = _.filter(
+      (element) => element.tagName === 'DIV' && element.style.fontWeight === '600',
+      byText
+    ).length;
+    expect(filterByText).toBe(1);
+
+    const disorderText = await screen.findByText('Disorder');
+    expect(disorderText.innerHTML).toBe('Disorder ');
+
+    const byBodySiteText = await screen.findByText('body site');
+    expect(byBodySiteText.innerHTML).toBe(' body site');
+  });
+
   it('loads the page with the initial cart', async () => {
     // Arrange
     renderSearch('', [displayedConcepts[0]]);

--- a/src/dataset-builder/DatasetBuilderUtils.test.ts
+++ b/src/dataset-builder/DatasetBuilderUtils.test.ts
@@ -183,95 +183,72 @@ describe('test conversion of DatasetAccessRequest', () => {
 });
 
 describe('test HighlightConceptName', () => {
+  const createHighlightConceptName = (beforeHighlight: string, highlightWord: string, afterHighlight: string) => {
+    return div({ style: { display: 'flex' } }, [
+      div({ style: { whiteSpace: 'pre' } }, [beforeHighlight]),
+      div({ style: { fontWeight: 600, whiteSpace: 'pre' } }, [highlightWord]),
+      div({ style: { whiteSpace: 'pre' } }, [afterHighlight]),
+    ]);
+  };
+
   test('searching beginning of conceptName', () => {
     const searchFilter = 'Clinic';
     const conceptName = 'Clinical Finding';
-
-    const result = div({ style: { display: 'flex' } }, [
-      div({ style: { whiteSpace: 'pre' } }, ['']),
-      div({ style: { fontWeight: 600, whiteSpace: 'pre' } }, ['Clinic']),
-      div({ style: { whiteSpace: 'pre' } }, ['al Finding']),
-    ]);
+    const result = createHighlightConceptName('', 'Clinic', 'al Finding');
     expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
   });
 
   test("Testing to make sure capitalization doesn't change", () => {
     const searchFilter = 'clin';
     const conceptName = 'Clinical Finding';
-
-    const result = div({ style: { display: 'flex' } }, [
-      div({ style: { whiteSpace: 'pre' } }, ['']),
-      div({ style: { fontWeight: 600, whiteSpace: 'pre' } }, ['Clin']),
-      div({ style: { whiteSpace: 'pre' } }, ['ical Finding']),
-    ]);
+    const result = createHighlightConceptName('', 'Clin', 'ical Finding');
     expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
   });
 
   test('searchedWord in the middle of conceptName', () => {
     const searchFilter = 'cal';
     const conceptName = 'Clinical Finding';
-
-    const result = div({ style: { display: 'flex' } }, [
-      div({ style: { whiteSpace: 'pre' } }, ['Clini']),
-      div({ style: { fontWeight: 600, whiteSpace: 'pre' } }, ['cal']),
-      div({ style: { whiteSpace: 'pre' } }, [' Finding']),
-    ]);
+    const result = createHighlightConceptName('Clini', 'cal', ' Finding');
     expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
   });
 
   test('searchedWord in the end of conceptName', () => {
     const searchFilter = 'Finding';
     const conceptName = 'Clinical Finding';
-
-    const result = div({ style: { display: 'flex' } }, [
-      div({ style: { whiteSpace: 'pre' } }, ['Clinical ']),
-      div({ style: { fontWeight: 600, whiteSpace: 'pre' } }, ['Finding']),
-      div({ style: { whiteSpace: 'pre' } }, ['']),
-    ]);
-
+    const result = createHighlightConceptName('Clinical ', 'Finding', '');
     expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
   });
 
   test('searchedWord in the not in conceptName: "XXX" in "Clinical Finding"', () => {
     const searchFilter = 'XXX';
     const conceptName = 'Clinical Finding';
-
     const result = div(['Clinical Finding']);
-
     expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
   });
 
   test('searchedWord in the not in conceptName: "Clinical" in "Clin"', () => {
     const searchFilter = 'Clinical';
     const conceptName = 'Clin';
-
     const result = div(['Clin']);
-
     expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
   });
 
   test('searchedWord is empty: "" ', () => {
     const searchFilter = '';
     const conceptName = 'Condition';
-
     const result = div(['Condition']);
-
     expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
   });
 
   test("doesn't bold whitespace", () => {
     let searchFilter = ' ';
     let conceptName = 'Clinical Finding';
-
     let result = div(['Clinical Finding']);
-
     expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
 
     searchFilter = '   ';
     conceptName = 'Clinical Finding';
-
     result = div(['Clinical Finding']);
-
     expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
   });
 });

--- a/src/dataset-builder/DatasetBuilderUtils.test.ts
+++ b/src/dataset-builder/DatasetBuilderUtils.test.ts
@@ -188,9 +188,9 @@ describe('test HighlightConceptName', () => {
     const conceptName = 'Clinical Finding';
 
     const result = div({ style: { display: 'flex' } }, [
-      div(['']),
-      div({ style: { fontWeight: 600 } }, ['Clinic']),
-      div(['al Finding']),
+      div({ style: { whiteSpace: 'pre' } }, ['']),
+      div({ style: { fontWeight: 600, whiteSpace: 'pre' } }, ['Clinic']),
+      div({ style: { whiteSpace: 'pre' } }, ['al Finding']),
     ]);
     expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
   });
@@ -200,9 +200,9 @@ describe('test HighlightConceptName', () => {
     const conceptName = 'Clinical Finding';
 
     const result = div({ style: { display: 'flex' } }, [
-      div(['']),
-      div({ style: { fontWeight: 600 } }, ['Clin']),
-      div(['ical Finding']),
+      div({ style: { whiteSpace: 'pre' } }, ['']),
+      div({ style: { fontWeight: 600, whiteSpace: 'pre' } }, ['Clin']),
+      div({ style: { whiteSpace: 'pre' } }, ['ical Finding']),
     ]);
     expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
   });
@@ -212,9 +212,9 @@ describe('test HighlightConceptName', () => {
     const conceptName = 'Clinical Finding';
 
     const result = div({ style: { display: 'flex' } }, [
-      div(['Clini']),
-      div({ style: { fontWeight: 600 } }, ['cal']),
-      div([' Finding']),
+      div({ style: { whiteSpace: 'pre' } }, ['Clini']),
+      div({ style: { fontWeight: 600, whiteSpace: 'pre' } }, ['cal']),
+      div({ style: { whiteSpace: 'pre' } }, [' Finding']),
     ]);
     expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
   });
@@ -224,9 +224,9 @@ describe('test HighlightConceptName', () => {
     const conceptName = 'Clinical Finding';
 
     const result = div({ style: { display: 'flex' } }, [
-      div(['Clinical ']),
-      div({ style: { fontWeight: 600 } }, ['Finding']),
-      div(['']),
+      div({ style: { whiteSpace: 'pre' } }, ['Clinical ']),
+      div({ style: { fontWeight: 600, whiteSpace: 'pre' } }, ['Finding']),
+      div({ style: { whiteSpace: 'pre' } }, ['']),
     ]);
 
     expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);

--- a/src/dataset-builder/DatasetBuilderUtils.ts
+++ b/src/dataset-builder/DatasetBuilderUtils.ts
@@ -279,8 +279,8 @@ export const HighlightConceptName = ({ conceptName, searchFilter }): ReactElemen
   const endIndex = startIndex + searchFilter.length;
 
   return div({ style: { display: 'flex' } }, [
-    div([conceptName.substring(0, startIndex)]),
-    div({ style: { fontWeight: 600 } }, [conceptName.substring(startIndex, endIndex)]),
-    div([conceptName.substring(endIndex)]),
+    div({ style: { whiteSpace: 'pre' } }, [conceptName.substring(0, startIndex)]),
+    div({ style: { fontWeight: 600, whiteSpace: 'pre' } }, [conceptName.substring(startIndex, endIndex)]),
+    div({ style: { whiteSpace: 'pre' } }, [conceptName.substring(endIndex)]),
   ]);
 };


### PR DESCRIPTION
### Jira Ticket: [Ticket](https://broadworkbench.atlassian.net/browse/DC-818)

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->
Added styling for div elements to persist white spacing in divs. 

### What
- After merging [DC-808](https://github.com/DataBiosphere/terra-ui/pull/4590), the white space was being collided on render. After inspecting element, the white space existed in the innerHTML of div elements; however, they were getting collided 👎 

- After doing a little bit of researching, I followed the advice from this [stack overflow response ](https://stackoverflow.com/questions/6151554/text-inside-div-not-showing-multiple-white-spaces-between-words) and everything was working 👍 

- [this added styling preserves white spaces](https://developer.mozilla.org/en-US/docs/Web/CSS/white-space#pre)

- Adjusted old tests to incorporate the new style element in the expected result

### Why
- The (bolded) searched word in concept name is collapsing the words around it because spacing is getting ignored. 

### Testing strategy
- Added a test in SearchConcepts to ensure spaces exist! 

<!-- ### Visual Aids -->

https://github.com/DataBiosphere/terra-ui/assets/63474660/caf6a8cb-7094-4342-8389-109dbc0ffd78

<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 


[DC-808]: https://broadworkbench.atlassian.net/browse/DC-808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ