### PR TITLE
Make destructured arrays ignorable by eslint.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -88,6 +88,7 @@ module.exports = {
         vars: 'all',
         args: 'all',
         argsIgnorePattern: '_|^_|^props',
+        destructuredArrayIgnorePattern: '_|^_',
         ignoreRestSiblings: true,
       },
     ],


### PR DESCRIPTION
This allows the following:

```
// we know array is 3 elements in a test and only want the 2nd item
const [_, something, _] = someArray;
expect(something).toBe('expected value');

// we want to document the unused args but still discard them
const [_first, _second, third] = someArray;
expect(third).toBe('expected value');
```

This is in support of [AJ-1275](https://broadworkbench.atlassian.net/browse/AJ-1275) which has some test cases that benefit from this change.

### Testing strategy
No behavior change here, just changing the linter.  Existing tests should ensure no surprise changes.


[AJ-1275]: https://broadworkbench.atlassian.net/browse/AJ-1275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ