### PR TITLE
[UIE-155] Log Slack notifications for test failures

### DIFF
--- a/integration-tests/slack/notify-circleci-test-results.js
+++ b/integration-tests/slack/notify-circleci-test-results.js
@@ -65,7 +65,9 @@ const notifyCircleCITestResults = async () => {
 
   // Slack notification: CircleCI job failed. Message contains list of failed test names.
   const channelIDsAndNames = getFailedTestsAndChannelIDs(failedTestNames);
+  console.log(`Failed tests: \n${failedTestNames.map((test) => `* ${test}`).join('\n')}\n`);
   _.forEach(async ([channelId, testNames]) => {
+    console.log(`Notifying channel ${channelId} of ${testNames.length} test failures (${testNames.join(', ')})`);
     const messageBlocks = getMessageBlockTemplate(testNames);
     await postMessage({ channel: channelId, blocks: messageBlocks });
   }, _.toPairs(channelIDsAndNames));


### PR DESCRIPTION
This adds some logging to the script that sends Slack notifications for test failures.

Attempting to debug some apparently missing Slack notifications.