### PR TITLE
[UIE-157] Switch components package from react-hyperscript-helpers to JSX

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,6 +27,8 @@ module.exports = {
     // Allow writing components as arrow functions.
     'react/function-component-definition': 'off',
     'react/prop-types': 'off',
+    'react/jsx-props-no-spreading': 'off',
+    'react/react-in-jsx-scope': 'off',
     'react/require-default-props': 'off',
     'react/sort-comp': 'off',
     'react/static-property-placement': 'off',
@@ -37,7 +39,7 @@ module.exports = {
     // duplicates and combines them into one import from 'date-fns'.
     'import/no-duplicates': 'off',
     // Allow tests' dependencies to be listed in devDependencies or dependencies.
-    'import/no-extraneous-dependencies': ['error', { devDependencies: ['**/*.test.{js,ts}'] }],
+    'import/no-extraneous-dependencies': ['error', { devDependencies: ['**/*.test.{js,ts,tsx}'] }],
     'import/no-named-as-default': 'off',
     // Named exports are more convenient for mocking.
     'import/prefer-default-export': 'off',

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -10138,7 +10138,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["react", "npm:18.2.0"],\
             ["react-dom", "virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#npm:18.2.0"],\
             ["react-focus-lock", "virtual:3cbce82a859ed6a4d5bf57a6b809aea2976beb02c6e1078f18e5e40f750e781222e51bcef76699e2500e623832ea4e45e9647ae7b14a57290a182e58c3827fe8#npm:2.9.5"],\
-            ["react-hyperscript-helpers", "virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#npm:2.0.0"],\
             ["react-modal", "virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#npm:3.16.1"],\
             ["react-onclickoutside", "virtual:3cbce82a859ed6a4d5bf57a6b809aea2976beb02c6e1078f18e5e40f750e781222e51bcef76699e2500e623832ea4e45e9647ae7b14a57290a182e58c3827fe8#npm:6.13.0"],\
             ["react-switch", "virtual:3cbce82a859ed6a4d5bf57a6b809aea2976beb02c6e1078f18e5e40f750e781222e51bcef76699e2500e623832ea4e45e9647ae7b14a57290a182e58c3827fe8#npm:6.1.0"],\
@@ -10179,7 +10178,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["react", "npm:18.2.0"],\
             ["react-dom", "virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#npm:18.2.0"],\
             ["react-focus-lock", "virtual:3cbce82a859ed6a4d5bf57a6b809aea2976beb02c6e1078f18e5e40f750e781222e51bcef76699e2500e623832ea4e45e9647ae7b14a57290a182e58c3827fe8#npm:2.9.5"],\
-            ["react-hyperscript-helpers", "virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#npm:2.0.0"],\
             ["react-modal", "virtual:f14c7c2b623bfe35a608f25e5b8f5582c71bc9475deb0d9650188d23bcf292a9531c8cce96f863c9a827a93aa74f4453675de981d038283eed4a2d8e81e490f7#npm:3.16.1"],\
             ["react-onclickoutside", "virtual:f14c7c2b623bfe35a608f25e5b8f5582c71bc9475deb0d9650188d23bcf292a9531c8cce96f863c9a827a93aa74f4453675de981d038283eed4a2d8e81e490f7#npm:6.13.0"],\
             ["react-switch", "virtual:f14c7c2b623bfe35a608f25e5b8f5582c71bc9475deb0d9650188d23bcf292a9531c8cce96f863c9a827a93aa74f4453675de981d038283eed4a2d8e81e490f7#npm:6.1.0"],\
@@ -10221,6 +10219,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@testing-library/react", "virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#npm:14.0.0"],\
             ["@types/jest", "npm:28.1.8"],\
             ["@types/node", "npm:20.6.2"],\
+            ["@types/react", "npm:18.2.15"],\
             ["@types/testing-library__react", null],\
             ["babel-jest", "virtual:c61c4ebeda316964fa7846363a7565f2740824705a1360049b2c57598f5a019c8e10d28d26e7d0f8012883671f61d8251daaead08ed2a3d1744547f0a0f71840#npm:27.5.1"],\
             ["babel-preset-react-app", "npm:10.0.1"],\
@@ -10233,13 +10232,16 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["jest-axe", "npm:6.0.0"],\
             ["jest-fail-on-console", "npm:3.1.1"],\
             ["jest-watch-typeahead", "virtual:c61c4ebeda316964fa7846363a7565f2740824705a1360049b2c57598f5a019c8e10d28d26e7d0f8012883671f61d8251daaead08ed2a3d1744547f0a0f71840#npm:1.0.0"],\
+            ["react", "npm:18.2.0"],\
             ["typescript", "patch:typescript@npm%3A5.1.6#~builtin<compat/typescript>::version=5.1.6&hash=5da071"],\
             ["vite", "virtual:c61c4ebeda316964fa7846363a7565f2740824705a1360049b2c57598f5a019c8e10d28d26e7d0f8012883671f61d8251daaead08ed2a3d1744547f0a0f71840#npm:4.5.2"],\
             ["whatwg-fetch", "npm:3.6.2"]\
           ],\
           "packagePeers": [\
             "@testing-library/react",\
-            "@types/testing-library__react"\
+            "@types/react",\
+            "@types/testing-library__react",\
+            "react"\
           ],\
           "linkType": "SOFT"\
         }],\
@@ -10255,6 +10257,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@testing-library/react", "virtual:c61c4ebeda316964fa7846363a7565f2740824705a1360049b2c57598f5a019c8e10d28d26e7d0f8012883671f61d8251daaead08ed2a3d1744547f0a0f71840#npm:14.0.0"],\
             ["@types/jest", "npm:28.1.8"],\
             ["@types/node", "npm:20.6.2"],\
+            ["@types/react", null],\
             ["@types/testing-library__react", null],\
             ["babel-jest", "virtual:c61c4ebeda316964fa7846363a7565f2740824705a1360049b2c57598f5a019c8e10d28d26e7d0f8012883671f61d8251daaead08ed2a3d1744547f0a0f71840#npm:27.5.1"],\
             ["babel-preset-react-app", "npm:10.0.1"],\
@@ -10267,12 +10270,15 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["jest-axe", "npm:6.0.0"],\
             ["jest-fail-on-console", "npm:3.1.1"],\
             ["jest-watch-typeahead", "virtual:c61c4ebeda316964fa7846363a7565f2740824705a1360049b2c57598f5a019c8e10d28d26e7d0f8012883671f61d8251daaead08ed2a3d1744547f0a0f71840#npm:1.0.0"],\
+            ["react", null],\
             ["typescript", "patch:typescript@npm%3A5.1.6#~builtin<compat/typescript>::version=5.1.6&hash=5da071"],\
             ["vite", "virtual:c61c4ebeda316964fa7846363a7565f2740824705a1360049b2c57598f5a019c8e10d28d26e7d0f8012883671f61d8251daaead08ed2a3d1744547f0a0f71840#npm:4.5.2"],\
             ["whatwg-fetch", "npm:3.6.2"]\
           ],\
           "packagePeers": [\
-            "@types/testing-library__react"\
+            "@types/react",\
+            "@types/testing-library__react",\
+            "react"\
           ],\
           "linkType": "SOFT"\
         }],\

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -30,7 +30,6 @@
     "color": "^4.0.1",
     "lodash": "^4.17.21",
     "react-focus-lock": "^2.9.5",
-    "react-hyperscript-helpers": "^2.0.0",
     "react-modal": "^3.16.1",
     "react-onclickoutside": "^6.13.0",
     "react-switch": "^6.1.0"

--- a/packages/components/src/Clickable.test.tsx
+++ b/packages/components/src/Clickable.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { h } from 'react-hyperscript-helpers';
 
 import { Clickable, ClickableProps } from './Clickable';
 import { TooltipTrigger, TooltipTriggerProps } from './TooltipTrigger';
@@ -16,7 +15,7 @@ jest.mock('./TooltipTrigger', (): TooltipTriggerExports => {
 
 describe('Clickable', () => {
   const renderClickable = (props: ClickableProps = {}): HTMLElement => {
-    render(h(Clickable, props, ['Click here']));
+    render(<Clickable {...props}>Click here</Clickable>);
     return screen.getByText('Click here');
   };
 

--- a/packages/components/src/Clickable.tsx
+++ b/packages/components/src/Clickable.tsx
@@ -1,5 +1,4 @@
 import { ForwardedRef, forwardRef, ReactNode } from 'react';
-import { h } from 'react-hyperscript-helpers';
 
 import { Interactive, InteractiveProps } from './Interactive';
 import { Side } from './internal/popup-utils';
@@ -26,25 +25,27 @@ export const Clickable = forwardRef((props: ClickableProps, ref: ForwardedRef<HT
     ...otherProps
   } = props;
 
-  const interactiveElement = h(
-    Interactive,
-    {
-      ref,
-      'aria-disabled': !!disabled,
-      disabled,
-      href: !disabled ? href : undefined,
-      tabIndex: disabled ? -1 : 0,
-      tagName,
-      onClick: (e) => onClick && !disabled && onClick(e),
-      ...otherProps,
-    },
-    [children]
+  const interactiveElement = (
+    <Interactive
+      ref={ref}
+      aria-disabled={!!disabled}
+      disabled={disabled}
+      href={!disabled ? href : undefined}
+      tabIndex={disabled ? -1 : 0}
+      tagName={tagName}
+      onClick={(e) => onClick && !disabled && onClick(e)}
+      {...otherProps}
+    >
+      {children}
+    </Interactive>
   );
 
   if (tooltip) {
-    return h(TooltipTrigger, { content: tooltip, side: tooltipSide, delay: tooltipDelay, useTooltipAsLabel }, [
-      interactiveElement,
-    ]);
+    return (
+      <TooltipTrigger content={tooltip} side={tooltipSide} delay={tooltipDelay} useTooltipAsLabel={useTooltipAsLabel}>
+        {interactiveElement}
+      </TooltipTrigger>
+    );
   }
   return interactiveElement;
 });

--- a/packages/components/src/DelayedRender.test.tsx
+++ b/packages/components/src/DelayedRender.test.tsx
@@ -1,5 +1,4 @@
 import { act, render, screen } from '@testing-library/react';
-import { div, h } from 'react-hyperscript-helpers';
 
 import { DelayedRender } from './DelayedRender';
 
@@ -9,7 +8,7 @@ describe('DelayedRender', () => {
     jest.useFakeTimers();
 
     // Act
-    render(h(DelayedRender, { delay: 3000 }, [div(['Hello world'])]));
+    render(<DelayedRender delay={3000}>Hello world</DelayedRender>);
 
     const isRenderedInitially = screen.queryByText('Hello world') !== null;
 

--- a/packages/components/src/ErrorBoundary.test.tsx
+++ b/packages/components/src/ErrorBoundary.test.tsx
@@ -1,12 +1,11 @@
 import { render, screen } from '@testing-library/react';
-import { div, h } from 'react-hyperscript-helpers';
 
 import { ErrorBoundary } from './ErrorBoundary';
 
 describe('ErrorBoundary', () => {
   it('renders children', () => {
     // Act
-    render(h(ErrorBoundary, [div(['Hello world'])]));
+    render(<ErrorBoundary>Hello world</ErrorBoundary>);
 
     // Assert
     screen.getByText('Hello world');
@@ -22,7 +21,11 @@ describe('ErrorBoundary', () => {
     jest.spyOn(console, 'error').mockImplementation(() => {});
 
     // Act
-    const { container } = render(h(ErrorBoundary, [h(TestComponent)]));
+    const { container } = render(
+      <ErrorBoundary>
+        <TestComponent />
+      </ErrorBoundary>
+    );
 
     // Assert
     expect(container).toBeEmptyDOMElement();
@@ -40,7 +43,11 @@ describe('ErrorBoundary', () => {
     jest.spyOn(console, 'error').mockImplementation(() => {});
 
     // Act
-    render(h(ErrorBoundary, { onError }, [h(TestComponent)]));
+    render(
+      <ErrorBoundary onError={onError}>
+        <TestComponent />
+      </ErrorBoundary>
+    );
 
     // Assert
     expect(onError).toHaveBeenCalledWith(new Error('Something went wrong!'));

--- a/packages/components/src/FocusTrap.test.tsx
+++ b/packages/components/src/FocusTrap.test.tsx
@@ -1,7 +1,5 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { Fragment } from 'react';
-import { button, h } from 'react-hyperscript-helpers';
 
 import { FocusTrap } from './FocusTrap';
 
@@ -11,7 +9,11 @@ describe('FocusTrap', () => {
     const user = userEvent.setup();
 
     const { container } = render(
-      h(Fragment, [h(FocusTrap, [button(['A']), button(['B']), button(['C'])]), button(['D'])])
+      <FocusTrap onEscape={jest.fn()}>
+        <button type="button">A</button>
+        <button type="button">B</button>
+        <button type="button">C</button>
+      </FocusTrap>
     );
 
     const wrapper = container.children.item(1) as HTMLElement;

--- a/packages/components/src/FocusTrap.tsx
+++ b/packages/components/src/FocusTrap.tsx
@@ -1,6 +1,5 @@
 import { ReactNode } from 'react';
 import FocusLock from 'react-focus-lock';
-import { h } from 'react-hyperscript-helpers';
 
 export type FocusTrapProps = JSX.IntrinsicElements['div'] & {
   onEscape: () => void;
@@ -15,10 +14,9 @@ export type FocusTrapProps = JSX.IntrinsicElements['div'] & {
 export const FocusTrap = (props: FocusTrapProps): ReactNode => {
   const { children, style, onEscape, ...otherProps } = props;
 
-  return h(
-    FocusLock,
-    {
-      lockProps: {
+  return (
+    <FocusLock
+      lockProps={{
         tabIndex: 0,
         style: {
           outline: 'none',
@@ -31,9 +29,10 @@ export const FocusTrap = (props: FocusTrapProps): ReactNode => {
             e.stopPropagation();
           }
         },
-      },
-      returnFocus: true,
-    },
-    [children]
+      }}
+      returnFocus
+    >
+      {children}
+    </FocusLock>
   );
 };

--- a/packages/components/src/InfoBox.test.tsx
+++ b/packages/components/src/InfoBox.test.tsx
@@ -1,6 +1,5 @@
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { h } from 'react-hyperscript-helpers';
 
 import { InfoBox } from './InfoBox';
 import { renderWithTheme } from './internal/test-utils';
@@ -8,7 +7,7 @@ import { renderWithTheme } from './internal/test-utils';
 describe('InfoBox', () => {
   it('renders an icon button', async () => {
     // Act
-    renderWithTheme(h(InfoBox, ['More information about the thing.']));
+    renderWithTheme(<InfoBox>More information about the thing.</InfoBox>);
     const trigger = screen.getByRole('button');
 
     // Assert
@@ -20,7 +19,7 @@ describe('InfoBox', () => {
 
   it('allows overriding the default icon', async () => {
     // Act
-    renderWithTheme(h(InfoBox, { icon: 'error-standard' }, ['More information about the thing.']));
+    renderWithTheme(<InfoBox icon="error-standard">More information about the thing.</InfoBox>);
     const trigger = screen.getByRole('button');
 
     // Assert
@@ -32,7 +31,7 @@ describe('InfoBox', () => {
     // Arrange
     const user = userEvent.setup();
 
-    renderWithTheme(h(InfoBox, ['More information about the thing.']));
+    renderWithTheme(<InfoBox>More information about the thing.</InfoBox>);
 
     // Act
     const trigger = screen.getByRole('button');

--- a/packages/components/src/InfoBox.tsx
+++ b/packages/components/src/InfoBox.tsx
@@ -1,5 +1,4 @@
 import { CSSProperties, ReactNode } from 'react';
-import { div, h } from 'react-hyperscript-helpers';
 
 import { Clickable } from './Clickable';
 import { icon } from './icon';
@@ -21,22 +20,11 @@ export const InfoBox = (props: InfoBoxProps): ReactNode => {
 
   const { colors } = useThemeFromContext();
 
-  return h(
-    PopupTrigger,
-    {
-      side,
-      content: div({ style: { padding: '0.5rem', width: 300 } }, [children]),
-    },
-    [
-      h(
-        Clickable,
-        {
-          'aria-label': 'More info',
-          tagName: 'span',
-          tooltip,
-        },
-        [icon(iconId, { size, style: { color: colors.accent(), cursor: 'pointer', ...style } })]
-      ),
-    ]
+  return (
+    <PopupTrigger content={<div style={{ padding: '0.5rem', width: 300 }}>{children}</div>} side={side}>
+      <Clickable aria-label="More info" tagName="span" tooltip={tooltip}>
+        {icon(iconId, { size, style: { color: colors.accent(), cursor: 'pointer', ...style } })}
+      </Clickable>
+    </PopupTrigger>
   );
 };

--- a/packages/components/src/Link.test.tsx
+++ b/packages/components/src/Link.test.tsx
@@ -1,5 +1,3 @@
-import { h } from 'react-hyperscript-helpers';
-
 import { Clickable } from './Clickable';
 import { renderWithTheme as render } from './internal/test-utils';
 import { Link } from './Link';
@@ -18,7 +16,7 @@ jest.mock('./Clickable', (): ClickableExports => {
 describe('Link', () => {
   it('renders a styled Clickable', () => {
     // Act
-    render(h(Link));
+    render(<Link href="https://example.com" />);
 
     // Assert
     expect(Clickable).toHaveBeenCalledWith(
@@ -29,10 +27,10 @@ describe('Link', () => {
 
   it('has a light variant that is styled differently', () => {
     // Act
-    render(h(Link));
+    render(<Link href="https://example.com" />);
     const defaultStyle = (Clickable as jest.MockedFunction<typeof Clickable>).mock.lastCall[0].style;
 
-    render(h(Link, { variant: 'light' }));
+    render(<Link href="https://example.com" variant="light" />);
     const lightVariantStyle = (Clickable as jest.MockedFunction<typeof Clickable>).mock.lastCall[0].style;
 
     // Assert
@@ -41,10 +39,10 @@ describe('Link', () => {
 
   it('can be styled with a different base color', () => {
     // Act
-    render(h(Link));
+    render(<Link href="https://example.com" />);
     const defaultStyle = (Clickable as jest.MockedFunction<typeof Clickable>).mock.lastCall[0].style;
 
-    render(h(Link, { baseColor: () => 'blue' }));
+    render(<Link href="https://example.com" baseColor={() => 'blue'} />);
     const baseColorStyle = (Clickable as jest.MockedFunction<typeof Clickable>).mock.lastCall[0].style;
 
     // Assert
@@ -54,10 +52,10 @@ describe('Link', () => {
   describe('when disabled', () => {
     it('is styled differently', () => {
       // Act
-      render(h(Link));
+      render(<Link href="https://example.com" />);
       const enabledStyle = (Clickable as jest.MockedFunction<typeof Clickable>).mock.lastCall[0].style;
 
-      render(h(Link, { disabled: true }));
+      render(<Link href="https://example.com" disabled />);
       const disabledStyle = (Clickable as jest.MockedFunction<typeof Clickable>).mock.lastCall[0].style;
 
       // Assert
@@ -66,7 +64,7 @@ describe('Link', () => {
 
     it('has no hover style', () => {
       // Act
-      render(h(Link, { disabled: true }));
+      render(<Link href="https://example.com" disabled />);
       const disabledHoverStyle = (Clickable as jest.MockedFunction<typeof Clickable>).mock.lastCall[0].hover;
 
       // Assert

--- a/packages/components/src/Link.tsx
+++ b/packages/components/src/Link.tsx
@@ -1,5 +1,4 @@
 import { ForwardedRef, forwardRef } from 'react';
-import { h } from 'react-hyperscript-helpers';
 
 import { Clickable, ClickableProps } from './Clickable';
 import { useThemeFromContext } from './theme';
@@ -15,27 +14,29 @@ export const Link = forwardRef((props: LinkProps, ref: ForwardedRef<HTMLElement>
   const { colors } = useThemeFromContext();
   const baseColor = baseColorProp || colors.accent;
 
-  return h(
-    Clickable,
-    {
-      ref,
-      ...otherProps,
-      disabled,
-      style: {
+  return (
+    <Clickable
+      ref={ref}
+      {...otherProps}
+      disabled={disabled}
+      style={{
         display: 'inline',
         color: disabled ? colors.disabled() : baseColor(variant === 'light' ? 0.3 : 1),
         cursor: disabled ? 'not-allowed' : 'pointer',
         fontWeight: 500,
         ...style,
-      },
-      hover: disabled
-        ? undefined
-        : {
-            color: baseColor(variant === 'light' ? 0.1 : 0.8),
-            ...hover,
-          },
-    },
-    [children]
+      }}
+      hover={
+        disabled
+          ? undefined
+          : {
+              color: baseColor(variant === 'light' ? 0.1 : 0.8),
+              ...hover,
+            }
+      }
+    >
+      {children}
+    </Clickable>
   );
 });
 

--- a/packages/components/src/Modal.test.tsx
+++ b/packages/components/src/Modal.test.tsx
@@ -1,8 +1,7 @@
 import { withFakeTimers } from '@terra-ui-packages/test-utils';
 import { act, fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { Fragment, useState } from 'react';
-import { button, h } from 'react-hyperscript-helpers';
+import { useState } from 'react';
 
 import { getPopupRoot } from './internal/PopupPortal';
 import { renderWithTheme } from './internal/test-utils';
@@ -12,14 +11,9 @@ describe('Modal', () => {
   const renderModal = (props: Partial<ModalProps> = {}): void => {
     const { children, ...otherProps } = props;
     renderWithTheme(
-      h(
-        Modal,
-        {
-          onDismiss: jest.fn(),
-          ...otherProps,
-        },
-        [children]
-      )
+      <Modal onDismiss={jest.fn()} {...otherProps}>
+        {children}
+      </Modal>
     );
   };
 
@@ -151,7 +145,11 @@ describe('Modal', () => {
 
         // Act
         renderModal({
-          okButton: button({ onClick: onOk }, ['Start']),
+          okButton: (
+            <button type="button" onClick={onOk}>
+              Start
+            </button>
+          ),
         });
 
         const okButton = screen.getByText('Start');
@@ -227,14 +225,16 @@ describe('Modal', () => {
       const user = userEvent.setup();
 
       renderWithTheme(
-        h(Fragment, [
-          h(Modal, { showButtons: false, onDismiss: jest.fn() }, [
-            button({ style: { display: 'contents', width: 100 } }, ['A']),
-            button(['B']),
-            button(['C']),
-          ]),
-          button(['D']),
-        ])
+        <>
+          <Modal showButtons={false} onDismiss={jest.fn()}>
+            <button type="button" style={{ display: 'contents', width: 100 }}>
+              A
+            </button>
+            <button type="button">B</button>
+            <button type="button">C</button>
+          </Modal>
+          <button type="button">D</button>
+        </>
       );
 
       const [buttonA, buttonB, buttonC] = ['A', 'B', 'C'].map((btnText) =>
@@ -262,25 +262,28 @@ describe('Modal', () => {
         const TestHarness = () => {
           const [isModalOpen, setIsModalOpen] = useState(false);
 
-          return h(Fragment, [
-            button(
-              {
-                onClick: () => {
+          return (
+            <>
+              <button
+                type="button"
+                onClick={() => {
                   setIsModalOpen(true);
-                },
-              },
-              ['Open modal']
-            ),
-            isModalOpen &&
-              h(Modal, {
-                onDismiss: () => {
-                  setIsModalOpen(false);
-                },
-              }),
-          ]);
+                }}
+              >
+                Open modal
+              </button>
+              {isModalOpen && (
+                <Modal
+                  onDismiss={() => {
+                    setIsModalOpen(false);
+                  }}
+                />
+              )}
+            </>
+          );
         };
 
-        renderWithTheme(h(TestHarness));
+        renderWithTheme(<TestHarness />);
 
         // Move focus to the "Open modal" button.
         const openModalButton = screen.getByText('Open modal');

--- a/packages/components/src/Modal.test.tsx
+++ b/packages/components/src/Modal.test.tsx
@@ -227,9 +227,7 @@ describe('Modal', () => {
       renderWithTheme(
         <>
           <Modal showButtons={false} onDismiss={jest.fn()}>
-            <button type="button" style={{ display: 'contents', width: 100 }}>
-              A
-            </button>
+            <button type="button">A</button>
             <button type="button">B</button>
             <button type="button">C</button>
           </Modal>

--- a/packages/components/src/Modal.tsx
+++ b/packages/components/src/Modal.tsx
@@ -1,5 +1,4 @@
 import { CSSProperties, ReactNode, useEffect, useRef } from 'react';
-import { div, h } from 'react-hyperscript-helpers';
 import RModal, { Props as RModalProps } from 'react-modal';
 
 import { ButtonPrimary, ButtonSecondary } from './buttons';
@@ -137,35 +136,34 @@ export const Modal = (props: ModalProps): ReactNode => {
     };
   }, []);
 
-  return h(
-    RModal,
-    {
-      aria: {
+  return (
+    <RModal
+      aria={{
         labelledby: hasTitle ? titleId : undefined,
         modal: true,
-      },
+      }}
       // Adding aria-hidden to the app container is unnecessary with aria-modal set on the modal.
       // See https://github.com/DataBiosphere/terra-ui/pull/2541
-      ariaHideApp: false,
-      contentRef: (node: HTMLDivElement) => {
+      ariaHideApp={false}
+      contentRef={(node: HTMLDivElement) => {
         modalElement.current = node;
-      },
-      isOpen: true,
-      parentSelector: getPopupRoot,
+      }}
+      isOpen
+      parentSelector={getPopupRoot}
       // Customize focus handling using onAfterOpen to properly manage focus where
       // react-modal and react-focus-lock interact.
       // See https://github.com/DataBiosphere/terra-ui/pull/1938
-      shouldFocusAfterRender: false,
-      shouldReturnFocusAfterClose: false,
-      style: {
+      shouldFocusAfterRender={false}
+      shouldReturnFocusAfterClose={false}
+      style={{
         overlay: modalStyles.overlay,
         content: {
           ...modalStyles.modal,
           width,
           ...styles?.modal,
         },
-      },
-      onAfterOpen: () => {
+      }}
+      onAfterOpen={() => {
         // Since this is called right after the Modal is mounted, modalElement.current should always be non-null here.
         const nodeToFocus = modalElement.current!.contains(document.activeElement)
           ? document.activeElement
@@ -195,51 +193,61 @@ export const Modal = (props: ModalProps): ReactNode => {
             }
           }
         }, 0);
-      },
-      onRequestClose: onDismiss,
-      ...otherProps,
-    },
-    [
-      hasTitle &&
-        div({ style: modalStyles.header }, [
-          div({ id: titleId, style: modalStyles.title }, [title]),
-          titleChildren,
-          showX &&
-            h(
-              Clickable,
-              {
-                'aria-label': 'Close modal',
-                style: { alignSelf: 'flex-start', marginLeft: 'auto' },
-                onClick: onDismiss,
-              },
-              [icon('times-circle')]
-            ),
-        ]),
-      children,
-      showButtons &&
-        div({ style: { ...modalStyles.buttonRow, ...styles?.buttonRow } }, [
-          showCancel &&
-            h(
-              ButtonSecondary,
-              {
-                style: { marginRight: '1rem' },
-                onClick: onDismiss,
-              },
-              [cancelText]
-            ),
-          (() => {
+      }}
+      onRequestClose={onDismiss}
+      {...otherProps}
+    >
+      {hasTitle && (
+        <div style={modalStyles.header}>
+          <div id={titleId} style={modalStyles.title}>
+            {title}
+          </div>
+          {titleChildren}
+          {showX && (
+            <Clickable
+              aria-label="Close modal"
+              style={{ alignSelf: 'flex-start', marginLeft: 'auto' }}
+              onClick={onDismiss}
+            >
+              {icon('times-circle')}
+            </Clickable>
+          )}
+        </div>
+      )}
+      {children}
+      {showButtons && (
+        <div style={{ ...modalStyles.buttonRow, ...styles?.buttonRow }}>
+          {showCancel && (
+            <ButtonSecondary style={{ marginRight: '1rem' }} onClick={onDismiss}>
+              {cancelText}
+            </ButtonSecondary>
+          )}
+          {(() => {
             if (okButton === undefined) {
-              return h(ButtonPrimary, { onClick: onDismiss, danger }, ['OK']);
+              return (
+                <ButtonPrimary danger={danger} onClick={onDismiss}>
+                  OK
+                </ButtonPrimary>
+              );
             }
             if (typeof okButton === 'string') {
-              return h(ButtonPrimary, { onClick: onDismiss, danger }, [okButton]);
+              return (
+                <ButtonPrimary danger={danger} onClick={onDismiss}>
+                  {okButton}
+                </ButtonPrimary>
+              );
             }
             if (typeof okButton === 'function') {
-              return h(ButtonPrimary, { onClick: okButton, danger }, ['OK']);
+              return (
+                <ButtonPrimary danger={danger} onClick={okButton}>
+                  OK
+                </ButtonPrimary>
+              );
             }
             return okButton;
-          })(),
-        ]),
-    ]
+          })()}
+        </div>
+      )}
+    </RModal>
   );
 };

--- a/packages/components/src/PopupTrigger.test.tsx
+++ b/packages/components/src/PopupTrigger.test.tsx
@@ -1,7 +1,6 @@
 import { act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { Fragment, RefObject } from 'react';
-import { button, h } from 'react-hyperscript-helpers';
+import { RefObject } from 'react';
 
 import { renderWithTheme } from './internal/test-utils';
 import { PopupTrigger, PopupTriggerProps, PopupTriggerRef } from './PopupTrigger';
@@ -12,14 +11,11 @@ describe('PopupTrigger', () => {
     childProps: Partial<JSX.IntrinsicElements['button']> = {}
   ): { trigger: HTMLElement } => {
     renderWithTheme(
-      h(
-        PopupTrigger,
-        {
-          content: 'This is a popup',
-          ...props,
-        },
-        [button(childProps, ['Toggle Popup'])]
-      )
+      <PopupTrigger content="This is a popup" {...props}>
+        <button type="button" {...childProps}>
+          Toggle Popup
+        </button>
+      </PopupTrigger>
     );
 
     const trigger = screen.getByRole('button');
@@ -146,16 +142,19 @@ describe('PopupTrigger', () => {
     const user = userEvent.setup();
 
     renderWithTheme(
-      h(Fragment, [
-        h(
-          PopupTrigger,
-          {
-            content: h(Fragment, [button(['Button A']), button(['Button B'])]),
-          },
-          [button(['Toggle Popup'])]
-        ),
-        button(['Button C']),
-      ])
+      <>
+        <PopupTrigger
+          content={
+            <>
+              <button type="button">Button A</button>
+              <button type="button">Button B</button>
+            </>
+          }
+        >
+          <button type="button">Toggle Popup</button>
+        </PopupTrigger>
+        <button type="button">Button C</button>
+      </>
     );
 
     const trigger = screen.getByRole('button', { name: 'Toggle Popup' });
@@ -204,14 +203,9 @@ describe('PopupTrigger', () => {
 
     const ref: RefObject<PopupTriggerRef> = { current: null };
     renderWithTheme(
-      h(
-        PopupTrigger,
-        {
-          ref,
-          content: 'This is a popup',
-        },
-        [button(['Toggle Popup'])]
-      )
+      <PopupTrigger ref={ref} content="This is a popup">
+        <button type="button">Toggle Popup</button>
+      </PopupTrigger>
     );
 
     const trigger = screen.getByRole('button', { name: 'Toggle Popup' });

--- a/packages/components/src/Spinner.test.tsx
+++ b/packages/components/src/Spinner.test.tsx
@@ -1,6 +1,5 @@
 import { withFakeTimers } from '@terra-ui-packages/test-utils';
 import { act, screen } from '@testing-library/react';
-import { h } from 'react-hyperscript-helpers';
 
 import { renderWithTheme } from './internal/test-utils';
 import { Spinner } from './Spinner';
@@ -9,7 +8,7 @@ import { visuallyHidden } from './styles';
 describe('Spinner', () => {
   it('renders a spinner icon', () => {
     // Act
-    renderWithTheme(h(Spinner));
+    renderWithTheme(<Spinner />);
 
     // Assert
     const icon = document.querySelector('[data-icon="loadingSpinner"]');
@@ -20,7 +19,7 @@ describe('Spinner', () => {
     'renders a visually hidden alert after a delay',
     withFakeTimers(() => {
       // Act
-      renderWithTheme(h(Spinner, { message: 'Loading the data' }));
+      renderWithTheme(<Spinner message="Loading the data" />);
 
       const isMessageRenderedImmediately = !!screen.queryByText('Loading the data');
       act(() => jest.advanceTimersByTime(150));

--- a/packages/components/src/Spinner.tsx
+++ b/packages/components/src/Spinner.tsx
@@ -1,5 +1,4 @@
-import { Fragment, ReactNode } from 'react';
-import { h, span } from 'react-hyperscript-helpers';
+import { ReactNode } from 'react';
 
 import { DelayedRender } from './DelayedRender';
 import { icon, IconProps } from './icon';
@@ -19,8 +18,14 @@ export const Spinner = (props: SpinnerProps): ReactNode => {
 
   const { colors } = useThemeFromContext();
 
-  return h(Fragment, [
-    icon('loadingSpinner', { size: 24, style: { color: colors.primary(), ...style }, ...otherProps }),
-    h(DelayedRender, { delay: 150 }, [span({ role: 'alert', style: visuallyHidden }, [message])]),
-  ]);
+  return (
+    <>
+      {icon('loadingSpinner', { size: 24, style: { color: colors.primary(), ...style }, ...otherProps })}
+      <DelayedRender delay={150}>
+        <span role="alert" style={visuallyHidden}>
+          {message}
+        </span>
+      </DelayedRender>
+    </>
+  );
 };

--- a/packages/components/src/Switch.test.tsx
+++ b/packages/components/src/Switch.test.tsx
@@ -1,6 +1,5 @@
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { h } from 'react-hyperscript-helpers';
 
 import { renderWithTheme } from './internal/test-utils';
 import { Switch } from './Switch';
@@ -8,7 +7,7 @@ import { Switch } from './Switch';
 describe('Switch', () => {
   it('renders a switch', () => {
     // Act
-    renderWithTheme(h(Switch, { checked: false, onChange: jest.fn() }));
+    renderWithTheme(<Switch checked={false} onChange={jest.fn()} />);
 
     // Assert
     screen.getByRole('switch');
@@ -16,7 +15,7 @@ describe('Switch', () => {
 
   it.each([{ checked: true }, { checked: false }])('is controlled ($checked)', ({ checked }) => {
     // Act
-    renderWithTheme(h(Switch, { checked, onChange: jest.fn() }));
+    renderWithTheme(<Switch checked={checked} onChange={jest.fn()} />);
 
     // Assert
     const inputElement: HTMLInputElement = screen.getByRole('switch');
@@ -29,7 +28,7 @@ describe('Switch', () => {
     const offLabel = 'Off';
 
     // Act
-    renderWithTheme(h(Switch, { checked: false, onLabel, offLabel, onChange: jest.fn() }));
+    renderWithTheme(<Switch checked={false} onLabel={onLabel} offLabel={offLabel} onChange={jest.fn()} />);
 
     // Assert
     screen.getByText(onLabel);
@@ -41,7 +40,7 @@ describe('Switch', () => {
     const user = userEvent.setup();
 
     const onChange = jest.fn();
-    renderWithTheme(h(Switch, { checked: false, onChange }));
+    renderWithTheme(<Switch checked={false} onChange={onChange} />);
 
     const inputElement = screen.getByRole('switch');
 
@@ -57,7 +56,7 @@ describe('Switch', () => {
     const ref = { current: null };
 
     // Act
-    renderWithTheme(h(Switch, { ref, checked: false, onChange: jest.fn() }));
+    renderWithTheme(<Switch ref={ref} checked={false} onChange={jest.fn()} />);
 
     // Assert
     expect(ref.current).toBeInstanceOf(HTMLInputElement);
@@ -68,7 +67,7 @@ describe('Switch', () => {
     const ref = jest.fn();
 
     // Act
-    renderWithTheme(h(Switch, { ref, checked: false, onChange: jest.fn() }));
+    renderWithTheme(<Switch ref={ref} checked={false} onChange={jest.fn()} />);
 
     // Assert
     expect(ref).toHaveBeenCalledWith(expect.any(HTMLInputElement));

--- a/packages/components/src/Switch.tsx
+++ b/packages/components/src/Switch.tsx
@@ -1,5 +1,4 @@
 import { ForwardedRef, forwardRef, ReactNode } from 'react';
-import { div, h } from 'react-hyperscript-helpers';
 import RSwitch, { ReactSwitchProps } from 'react-switch';
 
 import { useThemeFromContext } from './theme';
@@ -11,9 +10,9 @@ interface SwitchLabelProps {
 
 const SwitchLabel = (props: SwitchLabelProps): ReactNode => {
   const { children, isOn } = props;
-  return div(
-    {
-      style: {
+  return (
+    <div
+      style={{
         display: 'flex',
         justifyContent: isOn ? 'flex-start' : 'flex-end',
         fontSize: 15,
@@ -22,9 +21,10 @@ const SwitchLabel = (props: SwitchLabelProps): ReactNode => {
         height: '100%',
         lineHeight: '28px',
         ...(isOn ? { marginLeft: '0.75rem' } : { marginRight: '0.5rem' }),
-      },
-    },
-    [children]
+      }}
+    >
+      {children}
+    </div>
   );
 };
 
@@ -39,25 +39,26 @@ export const Switch = forwardRef((props: SwitchProps, ref: ForwardedRef<HTMLInpu
 
   const { colors } = useThemeFromContext();
 
-  return h(RSwitch, {
-    // Forward ref to underlying input element instead of RSwitch instance.
-    // @ts-expect-error Types for React Hyperscript Helpers don't support refs well.
-    ref: (rSwitch: any) => {
-      const inputEl: HTMLInputElement = rSwitch ? rSwitch.$inputRef : null;
-      if (ref && 'current' in ref) {
-        ref.current = inputEl;
-      } else if (typeof ref === 'function') {
-        ref(inputEl);
-      }
-    },
-    onColor: colors.success(1.5),
-    offColor: colors.dark(0.8),
-    checkedIcon: h(SwitchLabel, { isOn: true }, [onLabel]),
-    uncheckedIcon: h(SwitchLabel, { isOn: false }, [offLabel]),
-    width: 80,
-    onChange: (checked) => onChange(checked),
-    ...otherProps,
-  });
+  return (
+    <RSwitch
+      // Forward ref to underlying input element instead of RSwitch instance.
+      ref={(rSwitch: any) => {
+        const inputEl: HTMLInputElement = rSwitch ? rSwitch.$inputRef : null;
+        if (ref && 'current' in ref) {
+          ref.current = inputEl;
+        } else if (typeof ref === 'function') {
+          ref(inputEl);
+        }
+      }}
+      onColor={colors.success(1.5)}
+      offColor={colors.dark(0.8)}
+      checkedIcon={<SwitchLabel isOn>{onLabel}</SwitchLabel>}
+      uncheckedIcon={<SwitchLabel isOn={false}>{offLabel}</SwitchLabel>}
+      width={80}
+      onChange={(checked) => onChange(checked)}
+      {...otherProps}
+    />
+  );
 });
 
 Switch.displayName = 'Switch';

--- a/packages/components/src/TooltipTrigger.test.tsx
+++ b/packages/components/src/TooltipTrigger.test.tsx
@@ -1,7 +1,6 @@
 import { withFakeTimers } from '@terra-ui-packages/test-utils';
 import { act, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { button, h } from 'react-hyperscript-helpers';
 
 import { icon } from './icon';
 import { getPopupRoot } from './internal/PopupPortal';
@@ -16,14 +15,9 @@ describe('TooltipTrigger', () => {
     childProps: Partial<JSX.IntrinsicElements['button']> = {}
   ) => {
     return renderWithTheme(
-      h(
-        TooltipTrigger,
-        {
-          content: tooltipContent,
-          ...props,
-        },
-        [button(childProps)]
-      )
+      <TooltipTrigger content={tooltipContent} {...props}>
+        <button type="button" {...childProps} />
+      </TooltipTrigger>
     );
   };
 

--- a/packages/components/src/TooltipTrigger.tsx
+++ b/packages/components/src/TooltipTrigger.tsx
@@ -1,16 +1,5 @@
 import _ from 'lodash/fp';
-import {
-  Children,
-  cloneElement,
-  CSSProperties,
-  Fragment,
-  ReactElement,
-  ReactNode,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
-import { div, h, path, svg } from 'react-hyperscript-helpers';
+import { Children, cloneElement, CSSProperties, ReactElement, ReactNode, useEffect, useRef, useState } from 'react';
 
 import { useUniqueId } from './hooks/useUniqueId';
 import { containsOnlyUnlabelledIcon } from './internal/a11y-utils';
@@ -101,28 +90,27 @@ const Tooltip = (props: TooltipProps): ReactNode => {
     }
   };
 
-  return h(PopupPortal, [
-    div(
-      {
-        id,
-        role: 'tooltip',
-        ref: elementRef,
-        style: {
+  return (
+    <PopupPortal>
+      <div
+        id={id}
+        role="tooltip"
+        ref={elementRef}
+        style={{
           ...styles.tooltip,
           display: shouldRender ? undefined : 'none',
           transform: `translate(${position.left}px, ${position.top}px)`,
           color: theme.colors.dark(),
           borderColor: theme.colors.secondary(),
-        },
-      },
-      [
-        children,
-        svg({ viewBox: '0 0 2 1', style: { ...styles.notch, ...getNotchPositionStyle() } }, [
-          path({ d: 'M0,1l1,-1l1,1Z' }),
-        ]),
-      ]
-    ),
-  ]);
+        }}
+      >
+        {children}
+        <svg viewBox="0 0 2 1" style={{ ...styles.notch, ...getNotchPositionStyle() }}>
+          <path d="M0,1l1,-1l1,1Z" />
+        </svg>
+      </div>
+    </PopupPortal>
+  );
 };
 
 export interface TooltipTriggerProps extends Pick<TooltipProps, 'delay' | 'side'> {
@@ -152,32 +140,41 @@ export const TooltipTrigger = (props: TooltipTriggerProps): ReactNode => {
   // you can explicitly pass in a boolean as `useTooltipAsLabel` to force the correct behavior.
   const useAsLabel = _.isNil(useTooltipAsLabel) ? containsOnlyUnlabelledIcon(child.props) : useTooltipAsLabel;
 
-  return h(Fragment, [
-    cloneElement(child, {
-      id: childId,
-      'aria-labelledby': hasTooltipContent && useAsLabel ? descriptionId : undefined,
-      'aria-describedby': hasTooltipContent && !useAsLabel ? descriptionId : undefined,
-      onMouseEnter: (...args) => {
-        child.props.onMouseEnter?.(...args);
-        setIsOpen(true);
-      },
-      onMouseLeave: (...args) => {
-        child.props.onMouseLeave?.(...args);
-        setIsOpen(false);
-      },
-      onFocus: (...args) => {
-        child.props.onFocus?.(...args);
-        setIsOpen(true);
-      },
-      onBlur: (...args) => {
-        child.props.onBlur?.(...args);
-        setIsOpen(false);
-      },
-    }),
-    hasTooltipContent &&
-      h(Fragment, [
-        isOpen && h(Tooltip, { delay, id: tooltipId, side, targetId: childId }, [content]),
-        div({ id: descriptionId, style: { display: 'none' } }, [content]),
-      ]),
-  ]);
+  return (
+    <>
+      {cloneElement(child, {
+        id: childId,
+        'aria-labelledby': hasTooltipContent && useAsLabel ? descriptionId : undefined,
+        'aria-describedby': hasTooltipContent && !useAsLabel ? descriptionId : undefined,
+        onMouseEnter: (...args) => {
+          child.props.onMouseEnter?.(...args);
+          setIsOpen(true);
+        },
+        onMouseLeave: (...args) => {
+          child.props.onMouseLeave?.(...args);
+          setIsOpen(false);
+        },
+        onFocus: (...args) => {
+          child.props.onFocus?.(...args);
+          setIsOpen(true);
+        },
+        onBlur: (...args) => {
+          child.props.onBlur?.(...args);
+          setIsOpen(false);
+        },
+      })}
+      {hasTooltipContent && (
+        <>
+          {isOpen && (
+            <Tooltip delay={delay} id={tooltipId} side={side} targetId={childId}>
+              {content}
+            </Tooltip>
+          )}
+          <div id={descriptionId} style={{ display: 'none' }}>
+            {content}
+          </div>
+        </>
+      )}
+    </>
+  );
 };

--- a/packages/components/src/buttons.test.tsx
+++ b/packages/components/src/buttons.test.tsx
@@ -1,5 +1,3 @@
-import { h } from 'react-hyperscript-helpers';
-
 import { ButtonOutline, ButtonPrimary, ButtonSecondary } from './buttons';
 import { Clickable } from './Clickable';
 import { renderWithTheme as render } from './internal/test-utils';
@@ -17,10 +15,10 @@ jest.mock('./Clickable', (): ClickableExports => {
 
 describe.each([{ component: ButtonPrimary }, { component: ButtonSecondary }, { component: ButtonOutline }])(
   '$component.name',
-  ({ component }) => {
+  ({ component: Component }) => {
     it('renders a styled Clickable', () => {
       // Act
-      render(h(component));
+      render(<Component />);
 
       // Assert
       expect(Clickable).toHaveBeenCalledWith(
@@ -32,10 +30,10 @@ describe.each([{ component: ButtonPrimary }, { component: ButtonSecondary }, { c
     describe('when disabled', () => {
       it('is styled differently', () => {
         // Act
-        render(h(component));
+        render(<Component />);
         const enabledStyle = (Clickable as jest.MockedFunction<typeof Clickable>).mock.lastCall[0].style;
 
-        render(h(component, { disabled: true }));
+        render(<Component disabled />);
         const disabledStyle = (Clickable as jest.MockedFunction<typeof Clickable>).mock.lastCall[0].style;
 
         // Assert
@@ -44,7 +42,7 @@ describe.each([{ component: ButtonPrimary }, { component: ButtonSecondary }, { c
 
       it('has no hover style', () => {
         // Act
-        render(h(component, { disabled: true }));
+        render(<Component disabled />);
         const disabledHoverStyle = (Clickable as jest.MockedFunction<typeof Clickable>).mock.lastCall[0].hover;
 
         // Assert
@@ -57,10 +55,10 @@ describe.each([{ component: ButtonPrimary }, { component: ButtonSecondary }, { c
 describe('ButtonPrimary', () => {
   it('can be styled differently to indicate a dangerous action', () => {
     // Act
-    render(h(ButtonPrimary));
+    render(<ButtonPrimary />);
     const defaultStyle = (Clickable as jest.MockedFunction<typeof Clickable>).mock.lastCall[0].style;
 
-    render(h(ButtonPrimary, { danger: true }));
+    render(<ButtonPrimary danger />);
     const dangerStyle = (Clickable as jest.MockedFunction<typeof Clickable>).mock.lastCall[0].style;
 
     // Assert

--- a/packages/components/src/buttons.test.tsx
+++ b/packages/components/src/buttons.test.tsx
@@ -15,10 +15,10 @@ jest.mock('./Clickable', (): ClickableExports => {
 
 describe.each([{ component: ButtonPrimary }, { component: ButtonSecondary }, { component: ButtonOutline }])(
   '$component.name',
-  ({ component: Component }) => {
+  ({ component: ButtonComponent }) => {
     it('renders a styled Clickable', () => {
       // Act
-      render(<Component />);
+      render(<ButtonComponent />);
 
       // Assert
       expect(Clickable).toHaveBeenCalledWith(
@@ -30,10 +30,10 @@ describe.each([{ component: ButtonPrimary }, { component: ButtonSecondary }, { c
     describe('when disabled', () => {
       it('is styled differently', () => {
         // Act
-        render(<Component />);
+        render(<ButtonComponent />);
         const enabledStyle = (Clickable as jest.MockedFunction<typeof Clickable>).mock.lastCall[0].style;
 
-        render(<Component disabled />);
+        render(<ButtonComponent disabled />);
         const disabledStyle = (Clickable as jest.MockedFunction<typeof Clickable>).mock.lastCall[0].style;
 
         // Assert
@@ -42,7 +42,7 @@ describe.each([{ component: ButtonPrimary }, { component: ButtonSecondary }, { c
 
       it('has no hover style', () => {
         // Act
-        render(<Component disabled />);
+        render(<ButtonComponent disabled />);
         const disabledHoverStyle = (Clickable as jest.MockedFunction<typeof Clickable>).mock.lastCall[0].hover;
 
         // Assert

--- a/packages/components/src/buttons.tsx
+++ b/packages/components/src/buttons.tsx
@@ -1,5 +1,4 @@
 import { CSSProperties, ReactNode } from 'react';
-import { h } from 'react-hyperscript-helpers';
 
 import { Clickable, ClickableProps } from './Clickable';
 import { useThemeFromContext } from './theme';
@@ -25,12 +24,11 @@ export const ButtonPrimary = (props: ButtonPrimaryProps): ReactNode => {
 
   const { colors } = useThemeFromContext();
 
-  return h(
-    Clickable,
-    {
-      ...otherProps,
-      disabled,
-      style: {
+  return (
+    <Clickable
+      {...otherProps}
+      disabled={disabled}
+      style={{
         ...buttonStyle,
         border: `1px solid ${disabled ? colors.dark(0.4) : danger ? colors.danger(1.2) : colors.accent(1.2)}`,
         borderRadius: 5,
@@ -39,15 +37,18 @@ export const ButtonPrimary = (props: ButtonPrimaryProps): ReactNode => {
         backgroundColor: disabled ? colors.dark(0.25) : danger ? colors.danger() : colors.accent(),
         cursor: disabled ? 'not-allowed' : 'pointer',
         ...style,
-      },
-      hover: disabled
-        ? undefined
-        : {
-            backgroundColor: danger ? colors.danger(0.85) : colors.accent(0.85),
-            ...hover,
-          },
-    },
-    [children]
+      }}
+      hover={
+        disabled
+          ? undefined
+          : {
+              backgroundColor: danger ? colors.danger(0.85) : colors.accent(0.85),
+              ...hover,
+            }
+      }
+    >
+      {children}
+    </Clickable>
   );
 };
 
@@ -58,25 +59,27 @@ export const ButtonSecondary = (props: ButtonSecondaryProps): ReactNode => {
 
   const { colors } = useThemeFromContext();
 
-  return h(
-    Clickable,
-    {
-      ...otherProps,
-      disabled,
-      style: {
+  return (
+    <Clickable
+      {...otherProps}
+      disabled={disabled}
+      style={{
         ...buttonStyle,
         color: disabled ? colors.dark(0.7) : colors.accent(),
         cursor: disabled ? 'not-allowed' : 'pointer',
         ...style,
-      },
-      hover: disabled
-        ? undefined
-        : {
-            color: colors.accent(0.8),
-            ...hover,
-          },
-    },
-    [children]
+      }}
+      hover={
+        disabled
+          ? undefined
+          : {
+              color: colors.accent(0.8),
+              ...hover,
+            }
+      }
+    >
+      {children}
+    </Clickable>
   );
 };
 
@@ -87,24 +90,26 @@ export const ButtonOutline = (props: ButtonOutlineProps): ReactNode => {
 
   const { colors } = useThemeFromContext();
 
-  return h(
-    ButtonPrimary,
-    {
-      ...otherProps,
-      disabled,
-      style: {
+  return (
+    <ButtonPrimary
+      {...otherProps}
+      disabled={disabled}
+      style={{
         border: `1px solid ${disabled ? colors.dark(0.4) : colors.accent()}`,
         color: colors.accent(),
         backgroundColor: disabled ? colors.dark(0.25) : 'white',
         ...style,
-      },
-      hover: disabled
-        ? undefined
-        : {
-            backgroundColor: colors.accent(0.1),
-            ...hover,
-          },
-    },
-    [children]
+      }}
+      hover={
+        disabled
+          ? undefined
+          : {
+              backgroundColor: colors.accent(0.1),
+              ...hover,
+            }
+      }
+    >
+      {children}
+    </ButtonPrimary>
   );
 };

--- a/packages/components/src/icon-library.tsx
+++ b/packages/components/src/icon-library.tsx
@@ -63,7 +63,6 @@ import {
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import _ from 'lodash/fp';
 import { ReactNode } from 'react';
-import { h } from 'react-hyperscript-helpers';
 
 import { ReactComponent as angleDoubleUp } from './icons/angle-double-up-regular.svg';
 import { ReactComponent as angleUp } from './icons/angle-up-regular.svg';
@@ -95,12 +94,12 @@ import { ReactComponent as trashCircleFilled } from './icons/trash-circle-filled
 import { ReactComponent as warningInfo } from './icons/warning-info.svg';
 import { ReactComponent as wdl } from './icons/wdl.svg';
 
-const fa = _.curry((shape, { size, ...props }) =>
-  h(FontAwesomeIcon, _.merge({ icon: shape, style: { height: size, width: size } }, props))
-);
-const custom = _.curry((shape, { size, ...props }) =>
-  h(shape, _.merge({ 'aria-hidden': true, focusable: false, style: { height: size, width: size } }, props))
-);
+const fa = _.curry((shape, { size, ...props }) => (
+  <FontAwesomeIcon {..._.merge({ icon: shape, style: { height: size, width: size } }, props)} />
+));
+const custom = _.curry((Shape, { size, ...props }) => (
+  <Shape {..._.merge({ 'aria-hidden': true, focusable: false, style: { height: size, width: size } }, props)} />
+));
 
 const rotate = _.curry((rotation, shape, props) =>
   shape(_.merge({ style: { transform: `rotate(${rotation}deg)` } }, props))

--- a/packages/components/src/internal/PopupPortal.test.tsx
+++ b/packages/components/src/internal/PopupPortal.test.tsx
@@ -1,5 +1,4 @@
 import { render } from '@testing-library/react';
-import { div, h } from 'react-hyperscript-helpers';
 
 import { getPopupRoot, PopupPortal, popupRootId } from './PopupPortal';
 
@@ -33,7 +32,11 @@ describe('getPopupRoot', () => {
 describe('PopupPortal', () => {
   it('renders children into popup root element', () => {
     // Act
-    render(h(PopupPortal, [div(['Hello world'])]));
+    render(
+      <PopupPortal>
+        <div>Hello world</div>
+      </PopupPortal>
+    );
 
     // Assert
     expect(document.getElementById(popupRootId)).toHaveTextContent('Hello world');

--- a/packages/components/src/internal/popup-utils.test.tsx
+++ b/packages/components/src/internal/popup-utils.test.tsx
@@ -1,6 +1,5 @@
 import { render } from '@testing-library/react';
 import { useRef } from 'react';
-import { div, h } from 'react-hyperscript-helpers';
 
 import { computePopupPosition, Position, Side, Size, useBoundingRects } from './popup-utils';
 
@@ -130,11 +129,11 @@ describe('useBoundingRects', () => {
       const [boundingRect] = useBoundingRects([{ ref }]);
       receivedBoundingRect(boundingRect);
 
-      return div({ ref, style: { width: 200, height: 100, margin: '100px 0 0 50px' } });
+      return <div ref={ref} style={{ width: 200, height: 100, margin: '100px 0 0 50px' }} />;
     };
 
     // Act
-    render(h(TestComponent));
+    render(<TestComponent />);
 
     // Assert
     expect(receivedBoundingRect).toHaveBeenCalledWith({
@@ -155,11 +154,11 @@ describe('useBoundingRects', () => {
       const [boundingRect] = useBoundingRects([{ id: 'test-element' }]);
       receivedBoundingRect(boundingRect);
 
-      return div({ id: 'test-element', style: { width: 200, height: 100, margin: '100px 0 0 50px' } });
+      return <div id="test-element" style={{ width: 200, height: 100, margin: '100px 0 0 50px' }} />;
     };
 
     // Act
-    render(h(TestComponent));
+    render(<TestComponent />);
 
     // Assert
     expect(receivedBoundingRect).toHaveBeenCalledWith({
@@ -184,7 +183,7 @@ describe('useBoundingRects', () => {
     };
 
     // Act
-    render(h(TestComponent));
+    render(<TestComponent />);
 
     // Assert
     expect(receivedBoundingRect).toHaveBeenCalledWith({

--- a/packages/components/src/internal/test-utils.tsx
+++ b/packages/components/src/internal/test-utils.tsx
@@ -2,7 +2,6 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { render } from '@testing-library/react';
 import { ReactElement } from 'react';
-import { h } from 'react-hyperscript-helpers';
 
 import { Theme, ThemeProvider } from '../theme';
 
@@ -22,10 +21,7 @@ const terraTheme: Theme = {
 };
 
 export const TestThemeProvider = (props) => {
-  return h(ThemeProvider, {
-    ...props,
-    theme: terraTheme,
-  });
+  return <ThemeProvider {...props} theme={terraTheme} />;
 };
 
 export const renderWithTheme = (ui: ReactElement) => {

--- a/packages/components/src/theme.test.tsx
+++ b/packages/components/src/theme.test.tsx
@@ -1,5 +1,4 @@
 import { render } from '@testing-library/react';
-import { h } from 'react-hyperscript-helpers';
 
 import { ErrorBoundary } from './ErrorBoundary';
 import { Theme, ThemeProvider, useThemeFromContext } from './theme';
@@ -31,7 +30,11 @@ describe('useThemeFromContext', () => {
     };
 
     // Act
-    render(h(ThemeProvider, { theme }, [h(TestComponent)]));
+    render(
+      <ThemeProvider theme={theme}>
+        <TestComponent />
+      </ThemeProvider>
+    );
 
     // Assert
     expect(onRenderWithTheme).toHaveBeenCalledWith(expect.objectContaining(theme));
@@ -50,7 +53,11 @@ describe('useThemeFromContext', () => {
     jest.spyOn(console, 'error').mockImplementation(() => {});
 
     // Act
-    render(h(ErrorBoundary, { onError: onRenderError }, [h(TestComponent)]));
+    render(
+      <ErrorBoundary onError={onRenderError}>
+        <TestComponent />
+      </ErrorBoundary>
+    );
 
     // Assert
     expect(onRenderError).toHaveBeenCalledWith(

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -41,7 +41,8 @@
     "whatwg-fetch": "^3.6.2"
   },
   "peerDependencies": {
-    "@testing-library/react": "^14.0.0"
+    "@testing-library/react": "^14.0.0",
+    "react": "18.2.0"
   },
   "devDependencies": {
     "@jest/types": "^27.5.1",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,4 +5,4 @@ sonar.javascript.lcov.reportPaths=coverage/lcov.info,packages/*/coverage/lcov.in
 
 sonar.sources=packages,src
 # Skip test files, which can be anywhere in the source tree.
-sonar.exclusions=**/**.test.js,**/**.test.ts
+sonar.exclusions=**/**.test.js,**/**.test.ts,**/**.test.tsx

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -13,9 +13,6 @@
     "module": "esnext",
     "moduleResolution": "node",
     "noFallthroughCasesInSwitch": true,
-    "paths": {
-      "react-hyperscript-helpers": ["./types/react-hyperscript-helpers"]
-    },
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5891,7 +5891,6 @@ __metadata:
     react: 18.2.0
     react-dom: 18.2.0
     react-focus-lock: ^2.9.5
-    react-hyperscript-helpers: ^2.0.0
     react-modal: ^3.16.1
     react-onclickoutside: ^6.13.0
     react-switch: ^6.1.0
@@ -5948,6 +5947,7 @@ __metadata:
     whatwg-fetch: ^3.6.2
   peerDependencies:
     "@testing-library/react": ^14.0.0
+    react: 18.2.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Since we've decided to switch from React Hyperscript Helpers, this removes React Hyperscript Helpers from the components package so that any components added to it must be converted to JSX.