### PR TITLE
[TUIM-80] Remove unnecessary CircleCI token

### DIFF
--- a/.circleci/wait-for-job-finish.sh
+++ b/.circleci/wait-for-job-finish.sh
@@ -11,7 +11,7 @@ counter=0
 # Wait up to 7 minutes for job to finish. A job can run on multiple nodes: parallelism > 1
 while [ "$counter" -le 420 ]; do
   # Find number of nodes in running
-  job_detail=$(curl -s "https://circleci.com/api/v2/project/github/DataBiosphere/terra-ui/job/$CIRCLE_BUILD_NUM" --header 'Circle-Token: "'"$CIRCLECI_USER_TOKEN"'"')
+  job_detail=$(curl -s "https://circleci.com/api/v2/project/github/DataBiosphere/terra-ui/job/$CIRCLE_BUILD_NUM")
   job_running_nodes_count=$(echo "$job_detail" | jq -r '.parallel_runs[] | select(.status == "running") | select(.index != '"$CIRCLE_NODE_INDEX"')' | grep -c "running")
 
   if [ "$job_running_nodes_count" -eq 0 ]; then
@@ -26,6 +26,6 @@ echo "Waited total $counter seconds"
 date
 
 # Something is wrong. Log response for error troubleshooting
-curl -s "https://circleci.com/api/v2/project/github/DataBiosphere/terra-ui/job/$CIRCLE_BUILD_NUM" --header 'Circle-Token: "'"$CIRCLECI_USER_TOKEN"'"' | jq -r '.'
+curl -s "https://circleci.com/api/v2/project/github/DataBiosphere/terra-ui/job/$CIRCLE_BUILD_NUM" | jq -r '.'
 echo "ERROR: Exceeded maximum waiting time 7 minutes."
 exit 1


### PR DESCRIPTION
Lately, we've been seeing integration test failures on the dev branch that aren't reported via Slack.

For example, both run-analysis and run-studio failed on [792941e](https://github.com/DataBiosphere/terra-ui/commit/792941e4a809fff0b6d7d508f7d137081e30e482): https://app.circleci.com/pipelines/github/DataBiosphere/terra-ui/22060/workflows/1bee1a27-24ed-40c6-b2cb-c69667d88b22/jobs/76494

But the notification in the `#ia-notification-test` channel only shows run-analysis: https://broadinstitute.slack.com/archives/C03ATF4QXEV/p1707242431513189

The output of the "Slack notifications for dev branch only" step in parallel runner 0 shows an error involving `jq`:
```
jq: error (at <stdin>:3): Cannot iterate over null (null)
Failed tests: 
* run-analysis

Notifying channel C53JYBV9A of 1 test failures (run-analysis)
Notifying channel C03ATF4QXEV of 1 test failures (run-analysis)
...
```

Which, based on the error message ("Cannot iterate over null") must be related to the `.parallel_runs[] ...` `jq` expression in wait-for-job-finish.sh.
https://github.com/DataBiosphere/terra-ui/blob/2bdca509e87ff9bbaba2971073f5428d0a0300d2/.circleci/wait-for-job-finish.sh#L15

This same error appears in other jobs, including those where all tests pass
- https://app.circleci.com/pipelines/github/DataBiosphere/terra-ui/22073/workflows/933058a6-ad41-4721-9093-33055215fd10/jobs/76528
- https://app.circleci.com/pipelines/github/DataBiosphere/terra-ui/22054/workflows/903a0787-d6ad-4ab9-a6c6-ea29ae945f79/jobs/76483

Some background... we parallelize tests across 4 parallel runners to decrease the wall clock time to run tests. However, that complicates the Slack notifications step. If every parallel runner runs the same script, we'd get 4 Slack notifications per test job. To avoid this, on parallel runner 0, we run wait-for-job-finish.sh to wait for all other runners to finish and then send Slack notifications once, from parallel runner 0.

It looks like what is happening is that `wait-for-job-finish.sh` always fails immediately and thus there's no wait before sending Slack notifications. If parallel runner 0 is the last parallel runner to finish, this is fine and notifications work as expected. However, if other parallel runners are still running, the Slack notification sent will not include tests from those runners.

I suspect this may be caused by the CircleCI token that we send with the requests to get the job status.

Compare:
```
curl https://circleci.com/api/v2/project/github/DataBiosphere/terra-ui/job/76494
```

to the same request with an invalid token:
```
curl https://circleci.com/api/v2/project/github/DataBiosphere/terra-ui/job/76494 --header "Circle-Token: token"
```

Based on our last inventory of CircleCI environments variables, the token used in the tests is an individual developer's token. I suspect that token has either expired or been removed by the developer.

Fortunately, since Terra UI is a public project, we don't actually need to send a token with requests. Indeed, this is the only request that we do send a token with. So let's try removing it and see if that fixes the issue.