### PR TITLE
[UIE-156] Generate source maps for type declarations

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -20,7 +20,7 @@
   "files": [
     "lib/cjs/**",
     "lib/es/**",
-    "lib/types/**"
+    "lib/types/**/*.d.ts"
   ],
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.36",

--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -21,7 +21,7 @@
   "files": [
     "lib/cjs/**",
     "lib/es/**",
-    "lib/types/**"
+    "lib/types/**/*.d.ts"
   ],
   "dependencies": {
     "lodash": "^4.17.21"

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -21,7 +21,7 @@
   "files": [
     "lib/cjs/**",
     "lib/es/**",
-    "lib/types/**",
+    "lib/types/**/*.d.ts",
     "transforms/**"
   ],
   "dependencies": {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
     "declaration": true,
+    "declarationMap": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,


### PR DESCRIPTION
This makes "Go to source definition" in VS Code work correctly for imports from Terra UI packages. Currently, it takes you to the CommonJS build output for the package. With this change, it takes you to the original TypeScript file.

> Generates a source map for .d.ts files which map back to the original .ts source file. This will allow editors such as VS Code to go to the original .ts file when using features like Go to Definition.
> -- https://www.typescriptlang.org/tsconfig#declarationMap