### PR TITLE
[UIE-128] Move date format functions to core-utils

### DIFF
--- a/packages/core-utils/src/format/date-format.test.ts
+++ b/packages/core-utils/src/format/date-format.test.ts
@@ -1,0 +1,21 @@
+import { formatDate, formatDatetime } from './date-format';
+
+describe('formatDate', () => {
+  it.each([
+    { type: 'date', value: new Date(2024, 0, 1, 9, 30) },
+    { type: 'date string', value: '2024-01-01T09:30:00' },
+    { type: 'timestamp', value: 1704101400000 },
+  ])('formats a $type', ({ value }) => {
+    expect(formatDate(value)).toBe('Jan 1, 2024');
+  });
+});
+
+describe('formatDatetime', () => {
+  it.each([
+    { type: 'date', value: new Date(2024, 0, 1, 9, 30) },
+    { type: 'date string', value: '2024-01-01T09:30:00' },
+    { type: 'timestamp', value: 1704101400000 },
+  ])('formats a $type', ({ value }) => {
+    expect(formatDatetime(value)).toBe('Jan 1, 2024, 9:30 AM');
+  });
+});

--- a/packages/core-utils/src/format/date-format.ts
+++ b/packages/core-utils/src/format/date-format.ts
@@ -1,0 +1,27 @@
+const dateFormat = new Intl.DateTimeFormat('default', { day: 'numeric', month: 'short', year: 'numeric' });
+
+const datetimeFormat = new Intl.DateTimeFormat('default', {
+  day: 'numeric',
+  month: 'short',
+  year: 'numeric',
+  hour: 'numeric',
+  minute: 'numeric',
+});
+
+type DateLike = number | string | Date;
+
+/**
+ * Format a date.
+ *
+ * @example
+ * formatDate(new Date(2024, 0, 1, 9, 30, 0)); // 'Jan 1, 2024'
+ */
+export const formatDate = (date: DateLike): string => dateFormat.format(new Date(date));
+
+/**
+ * Format a date and time.
+ *
+ * @example
+ * formatDatetime(new Date(2024, 0, 1, 9, 30)); // 'Jan 1, 2024, 9:30 AM'
+ */
+export const formatDatetime = (date: DateLike): string => datetimeFormat.format(new Date(date));

--- a/packages/core-utils/src/index.ts
+++ b/packages/core-utils/src/index.ts
@@ -1,3 +1,4 @@
+export * from './format/date-format';
 export * from './format/number-format';
 export * from './io-utils';
 export * from './logic-utils';
@@ -5,9 +6,9 @@ export * from './nav/nav-utils';
 export * from './promise-utils';
 export * from './state-utils';
 export * from './timer-utils';
+export * from './type-utils/LoadedState';
 export * from './type-utils/deep-partial';
 export * from './type-utils/general-types';
-export * from './type-utils/LoadedState';
 export * from './type-utils/lodash-fp-helpers';
 export * from './type-utils/lodash-fp-types';
 export * from './type-utils/type-helpers';

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -1,4 +1,12 @@
-import { AnyPromiseFn, cond, delay, GenericPromiseFn, safeCurry } from '@terra-ui-packages/core-utils';
+import {
+  AnyPromiseFn,
+  cond,
+  delay,
+  formatDate,
+  formatDatetime,
+  GenericPromiseFn,
+  safeCurry,
+} from '@terra-ui-packages/core-utils';
 import { formatDuration, intervalToDuration, isToday, isYesterday } from 'date-fns';
 import { differenceInCalendarMonths, differenceInSeconds, parseJSON } from 'date-fns/fp';
 import _ from 'lodash/fp';
@@ -11,19 +19,13 @@ export {
   formatBytes,
   formatNumber,
   formatUSD,
+  formatDatetime as makeCompleteDate,
+  formatDate as makeStandardDate,
   maybeParseJSON,
   switchCase,
 } from '@terra-ui-packages/core-utils';
 
-const dateFormat = new Intl.DateTimeFormat('default', { day: 'numeric', month: 'short', year: 'numeric' });
 const monthYearFormat = new Intl.DateTimeFormat('default', { month: 'short', year: 'numeric' });
-const completeDateFormat = new Intl.DateTimeFormat('default', {
-  day: 'numeric',
-  month: 'short',
-  year: 'numeric',
-  hour: 'numeric',
-  minute: 'numeric',
-});
 const completeDateFormatParts = [
   new Intl.DateTimeFormat('default', { day: 'numeric', month: 'short', year: 'numeric' }),
   new Intl.DateTimeFormat('default', { hour: 'numeric', minute: 'numeric' }),
@@ -35,18 +37,12 @@ export const makePrettyDate = (dateString: number | string | Date): string => {
   return cond(
     [isToday(date), () => 'Today'],
     [isYesterday(date), () => 'Yesterday'],
-    [differenceInCalendarMonths(date, Date.now()) <= 6, () => dateFormat.format(date)],
+    [differenceInCalendarMonths(date, Date.now()) <= 6, () => formatDate(date)],
     () => monthYearFormat.format(date)
   );
 };
 
-export const makeStandardDate = (dateString: number | string | Date): string => dateFormat.format(new Date(dateString));
-
-export const makeCompleteDate = (dateString: number | string | Date): string =>
-  completeDateFormat.format(new Date(dateString));
-
-export const formatTimestampInSeconds = (secondsSinceEpoch: number): string =>
-  completeDateFormat.format(new Date(secondsSinceEpoch * 1000));
+export const formatTimestampInSeconds = (secondsSinceEpoch: number): string => formatDatetime(secondsSinceEpoch * 1000);
 
 export const makeCompleteDateParts = (dateString) => {
   return _.map((part) => part.format(new Date(dateString)), completeDateFormatParts);


### PR DESCRIPTION
Continuing to split up libs/utils and package dependencies of the Environments page...

This moves some date format utilities to the core-utils package. I couldn't resist renaming them for clarity. `makeDate` sounded like it was constructing a Date object.