### PR TITLE
[IA-4822] Wait for runtime fetch before enabling runtime actions in UI

### DIFF
--- a/integration-tests/tests/run-analysis-azure.ts
+++ b/integration-tests/tests/run-analysis-azure.ts
@@ -44,7 +44,7 @@ const testRunAnalysisAzure = _.flowRight(
     action: () => findText(page, 'Azure Cloud Environment'),
     timeout: Millis.ofMinute,
   });
-  await click(page, clickable({ textContains: 'Close', isEnabled: true }), { timeout: Millis.ofMinute });
+  await click(page, clickable({ textContains: 'Close' }), { timeout: Millis.ofMinute });
   await waitForNoModal(page);
 
   // Navigate to analysis launcher

--- a/integration-tests/tests/run-analysis.js
+++ b/integration-tests/tests/run-analysis.js
@@ -17,6 +17,7 @@ const {
   input,
   noSpinnersAfter,
   waitForNoModal,
+  waitForNoSpinners,
 } = require('../utils/integration-utils');
 const { registerTest } = require('../utils/jest-utils');
 const { withUserToken } = require('../utils/terra-sa-utils');
@@ -45,13 +46,14 @@ const testRunAnalysisFn = _.flowRight(
     action: () => findText(page, 'Jupyter Cloud Environment'),
     timeout: Millis.ofMinute,
   });
-  await click(page, clickable({ textContains: 'Close', isEnabled: true }), { timeout: Millis.ofMinute });
+  await click(page, clickable({ textContains: 'Close' }), { timeout: Millis.ofMinute });
   await waitForNoModal(page);
 
   // Navigate to analysis launcher
   await click(page, `//*[@title="${notebookName}.ipynb"]`);
   await dismissInfoNotifications(page);
   await findText(page, 'PREVIEW (READ-ONLY)');
+  await waitForNoSpinners(page);
 
   // Attempt to open analysis; create a cloud env
   await noSpinnersAfter(page, {

--- a/integration-tests/tests/run-rstudio.js
+++ b/integration-tests/tests/run-rstudio.js
@@ -17,6 +17,7 @@ const {
   input,
   noSpinnersAfter,
   waitForNoModal,
+  waitForNoSpinners,
 } = require('../utils/integration-utils');
 const { registerTest } = require('../utils/jest-utils');
 const { withUserToken } = require('../utils/terra-sa-utils');
@@ -48,12 +49,14 @@ const testRunRStudioFn = _.flowRight(
     action: () => findText(page, 'RStudio Cloud Environment'),
     timeout: Millis.ofMinute,
   });
-  await click(page, clickable({ textContains: 'Close', isEnabled: true }), { timeout: Millis.ofMinute });
+  await click(page, clickable({ textContains: 'Close' }), { timeout: Millis.ofMinute });
   await waitForNoModal(page);
 
   // Navigate to analysis launcher
   await click(page, `//*[@title="${rFileName}.Rmd"]`);
   await dismissInfoNotifications(page);
+  await findText(page, 'PREVIEW (READ-ONLY)');
+  await waitForNoSpinners(page);
 
   // Attempt to open analysis; create a cloud env
   await noSpinnersAfter(page, {

--- a/src/analysis/Analyses.test.ts
+++ b/src/analysis/Analyses.test.ts
@@ -80,6 +80,7 @@ const defaultAnalysesData: AnalysesData = {
   lastRefresh: null,
   runtimes: [],
   refreshRuntimes: () => Promise.resolve(),
+  isLoadingCloudEnvironments: false,
   appDataDisks: [],
   persistentDisks: [],
 };

--- a/src/analysis/Analyses.ts
+++ b/src/analysis/Analyses.ts
@@ -428,7 +428,15 @@ export interface SortOrderInfo {
 export const BaseAnalyses = (
   {
     workspace,
-    analysesData: { apps, refreshApps, runtimes, refreshRuntimes, appDataDisks, persistentDisks },
+    analysesData: {
+      apps,
+      refreshApps,
+      runtimes,
+      refreshRuntimes,
+      appDataDisks,
+      persistentDisks,
+      isLoadingCloudEnvironments,
+    },
     storageDetails: { googleBucketLocation, azureContainerRegion },
     onRequesterPaysError,
   }: AnalysesProps,
@@ -752,6 +760,7 @@ export const BaseAnalyses = (
                   runtimes,
                   persistentDisks,
                   refreshRuntimes,
+                  isLoadingCloudEnvironments,
                   appDataDisks,
                   refreshAnalyses,
                   analyses,

--- a/src/analysis/AnalysisLauncher.js
+++ b/src/analysis/AnalysisLauncher.js
@@ -71,7 +71,7 @@ const AnalysisLauncher = _.flow(
       analysisName,
       workspace,
       workspace: { accessLevel, canCompute },
-      analysesData: { runtimes, refreshRuntimes, persistentDisks },
+      analysesData: { runtimes, refreshRuntimes, persistentDisks, isLoadingCloudEnvironments },
       storageDetails: { googleBucketLocation, azureContainerRegion },
     },
     _ref
@@ -117,6 +117,7 @@ const AnalysisLauncher = _.flow(
                   workspace,
                   setCreateOpen,
                   refreshRuntimes,
+                  isLoadingCloudEnvironments,
                   readOnlyAccess: !(canWrite(accessLevel) && canCompute),
                 }),
                 h(AnalysisPreviewFrame, { styles: iframeStyles, analysisName, toolLabel: currentFileToolLabel, workspace }),
@@ -166,7 +167,7 @@ const AnalysisLauncher = _.flow(
             setCreateOpen(false);
           },
         }),
-        busy && spinnerOverlay,
+        (busy || isLoadingCloudEnvironments) && spinnerOverlay,
       ]),
     ]);
   }

--- a/src/analysis/ContextBar.test.ts
+++ b/src/analysis/ContextBar.test.ts
@@ -412,6 +412,7 @@ const contextBarProps: ContextBarProps = {
   refreshRuntimes: () => Promise.resolve(),
   storageDetails: defaultGoogleBucketOptions,
   refreshApps: () => Promise.resolve(),
+  isLoadingCloudEnvironments: false,
   workspace: defaultGoogleWorkspace,
 };
 
@@ -423,6 +424,7 @@ const contextBarPropsForAzure: ContextBarProps = {
   refreshRuntimes: () => Promise.resolve(),
   storageDetails: { ...defaultGoogleBucketOptions, ...populatedAzureStorageOptions },
   refreshApps: () => Promise.resolve(),
+  isLoadingCloudEnvironments: false,
   workspace: defaultAzureWorkspace,
 };
 

--- a/src/analysis/ContextBar.ts
+++ b/src/analysis/ContextBar.ts
@@ -85,6 +85,7 @@ export interface ContextBarProps {
   refreshRuntimes: (maybeStale?: boolean) => Promise<void>;
   storageDetails: StorageDetails;
   refreshApps: (maybeStale?: boolean) => Promise<void>;
+  isLoadingCloudEnvironments: boolean;
   workspace: BaseWorkspace;
   persistentDisks: PersistentDisk[];
 }
@@ -96,6 +97,7 @@ export const ContextBar = ({
   refreshRuntimes,
   storageDetails,
   refreshApps,
+  isLoadingCloudEnvironments,
   workspace,
   persistentDisks,
 }: ContextBarProps) => {
@@ -248,6 +250,7 @@ export const ContextBar = ({
       appDataDisks,
       refreshRuntimes,
       refreshApps,
+      isLoadingCloudEnvironments,
       workspace,
       canCompute,
       persistentDisks,

--- a/src/analysis/modals/AnalysisModal.test.ts
+++ b/src/analysis/modals/AnalysisModal.test.ts
@@ -26,6 +26,7 @@ const defaultGcpModalProps: AnalysisModalProps = {
   apps: [] as App[],
   appDataDisks: [],
   persistentDisks: [],
+  isLoadingCloudEnvironments: false,
   onDismiss: () => {},
   onError: () => {},
   onSuccess: () => {},

--- a/src/analysis/modals/AnalysisModal.ts
+++ b/src/analysis/modals/AnalysisModal.ts
@@ -513,7 +513,7 @@ export const AnalysisModal = withDisplayName('AnalysisModal')(
             ButtonPrimary,
             {
               disabled: loading || errors,
-              tooltip: errors ? Utils.summarizeErrors(errors) : loading ? 'Loading' : '',
+              tooltip: (!!errors && Utils.summarizeErrors(errors)) || (loading && 'Loading') || '',
               onClick: async () => {
                 try {
                   const contents = Utils.cond(

--- a/src/analysis/modals/AnalysisModal.ts
+++ b/src/analysis/modals/AnalysisModal.ts
@@ -328,7 +328,7 @@ export const AnalysisModal = withDisplayName('AnalysisModal')(
               },
               hover: !currentApp ? styles.hover : undefined,
               disabled: !!currentApp || loading,
-              tooltip: currentApp ? appDisabledMessages[appTool.label] : loading ? 'Loading' : '',
+              tooltip: (currentApp && appDisabledMessages[appTool.label]) || (loading && 'Loading') || '',
               key: appTool.label,
             },
             [toolImages[appTool.label]]

--- a/src/analysis/modals/AnalysisModal.ts
+++ b/src/analysis/modals/AnalysisModal.ts
@@ -79,6 +79,7 @@ export interface AnalysisModalProps {
   apps: App[] | undefined;
   appDataDisks: AppDataDisk[] | undefined;
   persistentDisks: PersistentDisk[] | undefined;
+  isLoadingCloudEnvironments: boolean;
   onDismiss: () => void;
   onError: () => void;
   onSuccess: () => void;
@@ -94,6 +95,7 @@ export const AnalysisModal = withDisplayName('AnalysisModal')(
     onError,
     onSuccess,
     runtimes,
+    isLoadingCloudEnvironments,
     apps,
     appDataDisks,
     persistentDisks,
@@ -110,18 +112,17 @@ export const AnalysisModal = withDisplayName('AnalysisModal')(
     const prevAnalysisName = usePrevious(analysisName);
     const [currentToolObj, setCurrentToolObj] = useState<Tool>();
     const [fileExt, setFileExt] = useState('');
-    const currentTool: ToolLabel | undefined = currentToolObj?.label;
 
+    const { loadedState, createAnalysis, pendingCreate } = analysisFileStore;
+    const loading =
+      isLoadingCloudEnvironments || loadedState.status === 'Loading' || pendingCreate.status === 'Loading';
+
+    const currentTool: ToolLabel | undefined = currentToolObj?.label;
     const currentRuntime: Runtime | undefined = getCurrentRuntime(runtimes);
     const currentDisk = getCurrentPersistentDisk(runtimes, persistentDisks);
     const currentRuntimeToolLabel = currentRuntime && getToolLabelFromCloudEnv(currentRuntime);
     const currentApp = (toolLabel: AppToolLabel): App | undefined => getCurrentApp(toolLabel, apps);
 
-    // TODO: Bring in as props from Analyses OR bring entire AnalysisFileStore from props.
-    const { loadedState, createAnalysis, pendingCreate } = analysisFileStore;
-    // TODO: When the above is done, this check below may not be necessary.
-    const analyses = loadedState.status !== 'None' ? loadedState.state : null;
-    const status = loadedState.status;
     const resetView = () => {
       setViewMode(undefined);
       setAnalysisName('');
@@ -217,6 +218,7 @@ export const AnalysisModal = withDisplayName('AnalysisModal')(
         tool: currentTool,
         currentRuntime,
         currentDisk,
+        isLoadingCloudEnvironments,
         onDismiss,
         onError,
         onSuccess,
@@ -229,6 +231,7 @@ export const AnalysisModal = withDisplayName('AnalysisModal')(
         tool: currentTool,
         currentRuntime,
         currentDisk: persistentDisks ? persistentDisks[0] : undefined,
+        isLoadingCloudEnvironments,
         onDismiss,
         onSuccess,
       });
@@ -294,6 +297,8 @@ export const AnalysisModal = withDisplayName('AnalysisModal')(
             Clickable,
             {
               style: styles.toolCard,
+              disabled: loading,
+              tooltip: loading ? 'Loading' : runtimeTool.label,
               onClick: () => {
                 setCurrentToolObj(runtimeTool);
                 setFileExt(runtimeTool.defaultExt);
@@ -322,8 +327,8 @@ export const AnalysisModal = withDisplayName('AnalysisModal')(
                 enterNextViewMode(appTool.label);
               },
               hover: !currentApp ? styles.hover : undefined,
-              disabled: !!currentApp,
-              tooltip: currentApp ? appDisabledMessages[appTool.label] : '',
+              disabled: !!currentApp || loading,
+              tooltip: currentApp ? appDisabledMessages[appTool.label] : loading ? 'Loading' : '',
               key: appTool.label,
             },
             [toolImages[appTool.label]]
@@ -352,6 +357,7 @@ export const AnalysisModal = withDisplayName('AnalysisModal')(
               accept: `.${runtimeTools.Jupyter.ext.join(', .')}, .${runtimeTools.RStudio.ext.join(', .')}`,
               style: { flexGrow: 1, backgroundColor: colors.light(), height: '100%' },
               activeStyle: { backgroundColor: colors.accent(0.2), cursor: 'copy' },
+              disabled: loading,
               onDropRejected: () =>
                 reportError(
                   'Not a valid analysis file',
@@ -441,7 +447,9 @@ export const AnalysisModal = withDisplayName('AnalysisModal')(
       const errors = validate(
         { analysisName: `${analysisName}.${fileExt}`, notebookKernel },
         {
-          analysisName: analysisNameValidator(_.map(({ name }) => getFileName(name), analyses)),
+          analysisName: analysisNameValidator(
+            _.map(({ name }) => getFileName(name), loadedState.status === 'None' ? [] : loadedState.state)
+          ),
           notebookKernel: { presence: { allowEmpty: true } },
         }
       );
@@ -504,9 +512,8 @@ export const AnalysisModal = withDisplayName('AnalysisModal')(
           h(
             ButtonPrimary,
             {
-              // TODO: See spinner overlay comment. Change to pendingCreate.status === 'Loading' || errors.
-              disabled: status === 'Loading' || pendingCreate.status === 'Loading' || errors,
-              tooltip: Utils.summarizeErrors(errors),
+              disabled: loading || errors,
+              tooltip: errors ? Utils.summarizeErrors(errors) : loading ? 'Loading' : '',
               onClick: async () => {
                 try {
                   const contents = Utils.cond(
@@ -531,10 +538,7 @@ export const AnalysisModal = withDisplayName('AnalysisModal')(
             ['Create Analysis']
           ),
         ]),
-        // TODO: Once Analyses.js is converted to implement useAnalysisFiles and refresh is called within create,
-        // change next line to pendingCreate.status === 'Loading' && spinnerOverlay
-        // Currently this will be close enough to the desired functionality.
-        (status === 'Loading' || pendingCreate.status === 'Loading') && spinnerOverlay,
+        loading && spinnerOverlay,
       ]);
     };
 

--- a/src/analysis/modals/CloudEnvironmentModal.ts
+++ b/src/analysis/modals/CloudEnvironmentModal.ts
@@ -72,6 +72,7 @@ export const CloudEnvironmentModal = ({
   appDataDisks,
   refreshRuntimes,
   refreshApps,
+  isLoadingCloudEnvironments,
   workspace,
   persistentDisks,
   // Note: for Azure environments `location` and `computeRegion` are identical
@@ -88,6 +89,7 @@ export const CloudEnvironmentModal = ({
   appDataDisks: PersistentDisk[];
   refreshRuntimes: () => Promise<void>;
   refreshApps: () => Promise<void>;
+  isLoadingCloudEnvironments: boolean;
   workspace: BaseWorkspace;
   persistentDisks: PersistentDisk[];
   location: string;
@@ -115,6 +117,7 @@ export const CloudEnvironmentModal = ({
       tool,
       currentRuntime,
       currentDisk,
+      isLoadingCloudEnvironments,
       location,
       onDismiss,
       onSuccess,
@@ -128,6 +131,7 @@ export const CloudEnvironmentModal = ({
       workspace,
       currentRuntime,
       currentDisk: getReadyPersistentDisk(persistentDisks),
+      isLoadingCloudEnvironments,
       location,
       tool,
       onDismiss,

--- a/src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeModal.js
+++ b/src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeModal.js
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp';
-import { Fragment, useState } from 'react';
+import { Fragment, useEffect, useState } from 'react';
 import { div, h, label, p, span } from 'react-hyperscript-helpers';
 import { AboutPersistentDiskView } from 'src/analysis/modals/ComputeModal/AboutPersistentDiskView';
 import { AzurePersistentDiskSection } from 'src/analysis/modals/ComputeModal/AzureComputeModal/AzurePersistentDiskSection';
@@ -48,11 +48,13 @@ export const AzureComputeModalBase = ({
   workspace,
   currentRuntime,
   currentDisk,
+  isLoadingCloudEnvironments,
   location,
   tool,
   hideCloseButton = false,
 }) => {
-  const [loading, setLoading] = useState(false);
+  const [_loading, setLoading] = useState(false);
+  const loading = _loading || isLoadingCloudEnvironments;
   const [viewMode, setViewMode] = useState(undefined);
   const [currentRuntimeDetails, setCurrentRuntimeDetails] = useState(currentRuntime);
   const [currentPersistentDiskDetails] = useState(currentDisk);
@@ -64,15 +66,21 @@ export const AzureComputeModalBase = ({
   const hasGpu = () => !!azureMachineTypes[computeConfig.machineType]?.hasGpu;
   // Lifecycle
   useOnMount(() => {
-    const loadCloudEnvironment = _.flow(
-      withErrorReportingInModal('Error loading cloud environment', onError),
-      Utils.withBusyState(setLoading)
-    )(async () => {
-      const runtimeDetails = currentRuntime ? await Ajax().Runtimes.runtimeV2(workspaceId, currentRuntime.runtimeName).details() : null;
+    const announceModalOpen = async () => {
       Ajax().Metrics.captureEvent(Events.cloudEnvironmentConfigOpen, {
         existingConfig: !!currentRuntime,
         ...extractWorkspaceDetails(workspace.workspace),
       });
+    };
+    announceModalOpen();
+  });
+
+  useEffect(() => {
+    const refreshRuntime = _.flow(
+      withErrorReportingInModal('Error loading cloud environment', onError),
+      Utils.withBusyState(setLoading)
+    )(async () => {
+      const runtimeDetails = currentRuntime ? await Ajax().Runtimes.runtimeV2(workspaceId, currentRuntime.runtimeName).details() : null;
       setCurrentRuntimeDetails(runtimeDetails);
       setComputeConfig({
         machineType: runtimeDetails?.runtimeConfig?.machineType || defaultAzureMachineType,
@@ -83,8 +91,8 @@ export const AzureComputeModalBase = ({
         autopauseThreshold: runtimeDetails ? runtimeDetails.autopauseThreshold || autopauseDisabledValue : defaultAutopauseThreshold,
       });
     });
-    loadCloudEnvironment();
-  });
+    refreshRuntime();
+  }, [currentRuntime, location, onError, workspaceId, setCurrentRuntimeDetails, setComputeConfig]);
 
   const renderTitleAndTagline = () => {
     return h(Fragment, [
@@ -106,6 +114,7 @@ export const AzureComputeModalBase = ({
           ButtonOutline,
           {
             onClick: () => setViewMode('deleteEnvironment'),
+            disabled: loading,
           },
           [
             Utils.cond(
@@ -280,8 +289,11 @@ export const AzureComputeModalBase = ({
   const renderActionButton = () => {
     const commonButtonProps = {
       tooltipSide: 'left',
-      disabled: Utils.cond([viewMode === 'deleteEnvironment', () => getIsRuntimeBusy(currentRuntimeDetails)], () => doesRuntimeExist()),
+      disabled: Utils.cond([loading, true], [viewMode === 'deleteEnvironment', () => getIsRuntimeBusy(currentRuntimeDetails)], () =>
+        doesRuntimeExist()
+      ),
       tooltip: Utils.cond(
+        [loading, 'Loading cloud environments'],
         [viewMode === 'deleteEnvironment', () => (getIsRuntimeBusy(currentRuntimeDetails) ? 'Cannot delete a runtime while it is busy' : undefined)],
         [doesRuntimeExist(), () => 'Update not supported for azure runtimes'],
         () => undefined

--- a/src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeModal.js
+++ b/src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeModal.js
@@ -35,7 +35,6 @@ import {
 import colors from 'src/libs/colors';
 import { withErrorReportingInModal } from 'src/libs/error';
 import Events, { extractWorkspaceDetails } from 'src/libs/events';
-import { useOnMount } from 'src/libs/react-utils';
 import * as Utils from 'src/libs/utils';
 import { cloudProviderTypes } from 'src/workspaces/utils';
 
@@ -65,14 +64,11 @@ export const AzureComputeModalBase = ({
   const [deleteDiskSelected, setDeleteDiskSelected] = useState(false);
   const hasGpu = () => !!azureMachineTypes[computeConfig.machineType]?.hasGpu;
   // Lifecycle
-  useOnMount(() => {
-    const announceModalOpen = async () => {
-      Ajax().Metrics.captureEvent(Events.cloudEnvironmentConfigOpen, {
-        existingConfig: !!currentRuntime,
-        ...extractWorkspaceDetails(workspace.workspace),
-      });
-    };
-    announceModalOpen();
+  useEffect(() => {
+    Ajax().Metrics.captureEvent(Events.cloudEnvironmentConfigOpen, {
+      existingConfig: !!currentRuntime,
+      ...extractWorkspaceDetails(workspace.workspace),
+    });
   });
 
   useEffect(() => {
@@ -92,7 +88,7 @@ export const AzureComputeModalBase = ({
       });
     });
     refreshRuntime();
-  }, [currentRuntime, location, onError, workspaceId, setCurrentRuntimeDetails, setComputeConfig]);
+  }, [currentRuntime, location, onError, workspaceId]);
 
   const renderTitleAndTagline = () => {
     return h(Fragment, [

--- a/src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeModal.test.js
+++ b/src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeModal.test.js
@@ -95,8 +95,6 @@ describe('AzureComputeModal', () => {
   });
 
   it('disables submit while loading', async () => {
-    // Arrange
-
     // Act
     await act(async () => {
       render(h(AzureComputeModalBase, { ...defaultModalProps, isLoadingCloudEnvironments: true }));

--- a/src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeModal.test.js
+++ b/src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeModal.test.js
@@ -61,6 +61,7 @@ const defaultAjaxImpl = {
 };
 
 const verifyEnabled = (item) => expect(item).not.toHaveAttribute('disabled');
+const verifyDisabled = (item) => expect(item).toHaveAttribute('disabled');
 
 describe('AzureComputeModal', () => {
   beforeAll(() => {});
@@ -91,6 +92,19 @@ describe('AzureComputeModal', () => {
     screen.getByText('Azure Cloud Environment');
     const deleteButton = screen.queryByText('Delete Environment');
     expect(deleteButton).toBeNull();
+  });
+
+  it('disables submit while loading', async () => {
+    // Arrange
+
+    // Act
+    await act(async () => {
+      render(h(AzureComputeModalBase, { ...defaultModalProps, isLoadingCloudEnvironments: true }));
+    });
+
+    // Assert
+    verifyDisabled(getCreateButton());
+    screen.getByText('Azure Cloud Environment');
   });
 
   it('sends the proper leo API call in default create case (no runtimes or disks)', async () => {

--- a/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeImageSection.test.ts
+++ b/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeImageSection.test.ts
@@ -158,7 +158,7 @@ describe('GcpComputeImageSection', () => {
     // Assert
     // Change event fired
     expect(mockOnSelect).lastCalledWith(undefined, true);
-  });
+  }, 30000);
 
   it('loads RStudio tool images', async () => {
     // Arrange

--- a/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeImageSection.test.ts
+++ b/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeImageSection.test.ts
@@ -158,7 +158,7 @@ describe('GcpComputeImageSection', () => {
     // Assert
     // Change event fired
     expect(mockOnSelect).lastCalledWith(undefined, true);
-  }, 30000);
+  }, 10000);
 
   it('loads RStudio tool images', async () => {
     // Arrange

--- a/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal.js
+++ b/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal.js
@@ -216,6 +216,7 @@ export const GcpComputeModalBase = ({
   onSuccess,
   currentRuntime,
   currentDisk,
+  isLoadingCloudEnvironments,
   tool,
   workspace,
   location,
@@ -223,7 +224,8 @@ export const GcpComputeModalBase = ({
 }) => {
   // State -- begin
   const [showDebugger, setShowDebugger] = useState(false);
-  const [loading, setLoading] = useState(false);
+  const [_loading, setLoading] = useState(false);
+  const loading = _loading || isLoadingCloudEnvironments;
   const [currentRuntimeDetails, setCurrentRuntimeDetails] = useState(currentRuntime);
   const [currentPersistentDiskDetails, setCurrentPersistentDiskDetails] = useState(currentDisk);
   const [viewMode, setViewMode] = useState(undefined);
@@ -840,6 +842,7 @@ export const GcpComputeModalBase = ({
     const { runtime: existingRuntime, hasGpu } = getExistingEnvironmentConfig();
     const { runtime: desiredRuntime } = getDesiredEnvironmentConfig();
     const commonButtonProps = Utils.cond(
+      [loading, () => ({ disabled: true, tooltip: 'Loading cloud environments' })],
       [
         hasGpu && viewMode !== 'deleteEnvironment',
         () => ({ disabled: true, tooltip: 'Cloud compute with GPU(s) cannot be updated. Please delete it and create a new one.' }),
@@ -1590,6 +1593,7 @@ export const GcpComputeModalBase = ({
             ButtonOutline,
             {
               onClick: () => setViewMode('deleteEnvironment'),
+              disabled: isLoadingCloudEnvironments,
             },
             [
               Utils.cond(

--- a/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal.js
+++ b/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal.js
@@ -773,7 +773,7 @@ export const GcpComputeModalBase = ({
 
   useEffect(() => {
     // Can't pass an async function into useEffect so we define the function in the body and then call it
-    const doUseOnMount = _.flow(
+    const doUseCurrentRuntime = _.flow(
       withErrorReporting('Error loading cloud environment'),
       Utils.withBusyState(setLoading)
     )(async () => {
@@ -834,7 +834,7 @@ export const GcpComputeModalBase = ({
       });
     });
 
-    doUseOnMount();
+    doUseCurrentRuntime();
   }, [currentRuntime, currentDisk, location]);
 
   // Render functions -- begin

--- a/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal.test.js
+++ b/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal.test.js
@@ -62,6 +62,7 @@ const defaultModalProps = {
   onError: jest.fn(),
   currentRuntime: undefined,
   currentDisk: undefined,
+  isLoadingCloudEnvironments: false,
   tool: runtimeToolLabels.Jupyter,
   workspace: defaultGoogleWorkspace,
   location: testDefaultLocation,
@@ -132,6 +133,19 @@ describe('GcpComputeModal', () => {
 
     // Assert
     verifyEnabled(getCreateButton());
+    screen.getByText('Jupyter Cloud Environment');
+  });
+
+  it('disables submit while loading', async () => {
+    // Arrange
+
+    // Act
+    await act(async () => {
+      render(h(GcpComputeModalBase, { ...defaultModalProps, isLoadingCloudEnvironments: true }));
+    });
+
+    // Assert
+    verifyDisabled(getCreateButton());
     screen.getByText('Jupyter Cloud Environment');
   });
 

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.test.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.test.js
@@ -350,5 +350,5 @@ describe('Workflow View (GCP)', () => {
       name: 'echo_to_file-configured',
       namespace: 'gatk',
     });
-  }, 10000);
+  });
 });

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.test.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.test.js
@@ -350,5 +350,5 @@ describe('Workflow View (GCP)', () => {
       name: 'echo_to_file-configured',
       namespace: 'gatk',
     });
-  });
+  }, 10000);
 });

--- a/src/workflows-app/FeaturedWorkflows.test.ts
+++ b/src/workflows-app/FeaturedWorkflows.test.ts
@@ -17,6 +17,7 @@ const defaultAnalysesData: AnalysesData = {
   refreshRuntimes: () => Promise.resolve(),
   appDataDisks: [],
   persistentDisks: [],
+  isLoadingCloudEnvironments: false,
 };
 
 jest.mock('src/libs/config', () => ({

--- a/src/workflows-app/WorkflowsInWorkspace.test.ts
+++ b/src/workflows-app/WorkflowsInWorkspace.test.ts
@@ -18,6 +18,7 @@ const defaultAnalysesData: AnalysesData = {
   refreshRuntimes: () => Promise.resolve(),
   appDataDisks: [],
   persistentDisks: [],
+  isLoadingCloudEnvironments: false,
 };
 
 jest.mock('src/libs/config', () => ({

--- a/src/workflows-app/components/WorkflowsAppNavPanel.test.ts
+++ b/src/workflows-app/components/WorkflowsAppNavPanel.test.ts
@@ -15,6 +15,7 @@ const defaultAnalysesData: AnalysesData = {
   refreshRuntimes: () => Promise.resolve(),
   appDataDisks: [],
   persistentDisks: [],
+  isLoadingCloudEnvironments: false,
 };
 
 const defaultAnalysesDataWithAppsRefreshed: AnalysesData = {

--- a/src/workspace-data/data-table/shared/DataTable.test.ts
+++ b/src/workspace-data/data-table/shared/DataTable.test.ts
@@ -199,7 +199,7 @@ describe('DataTable', () => {
     // Get the checkboxes on this page
     const newPageChecks = screen.getAllByRole('checkbox', { checked: true });
     expect(newPageChecks.length).toEqual(101);
-  }, 10000);
+  }, 20000);
 
   it('selects page', async () => {
     // Arrange

--- a/src/workspaces/common/state/useCloudEnvironmentPolling.ts
+++ b/src/workspaces/common/state/useCloudEnvironmentPolling.ts
@@ -13,6 +13,7 @@ export interface CloudEnvironmentDetails {
   refreshRuntimes: (maybeStale?: boolean) => Promise<void>;
   persistentDisks?: PersistentDisk[];
   appDataDisks?: PersistentDisk[];
+  isLoadingCloudEnvironments: boolean;
 }
 
 export const useCloudEnvironmentPolling = (
@@ -29,6 +30,7 @@ export const useCloudEnvironmentPolling = (
 
   const timeout = useRef<NodeJS.Timeout>();
   const [runtimes, setRuntimes] = useState<ListRuntimeItem[]>();
+  const [isLoadingCloudEnvironments, setIsLoadingCloudEnvironments] = useState<boolean>(true);
   const [persistentDisks, setPersistentDisks] = useState<PersistentDisk[]>();
   const [appDataDisks, setAppDataDisks] = useState<PersistentDisk[]>();
 
@@ -41,6 +43,7 @@ export const useCloudEnvironmentPolling = (
   };
   const load = async (maybeStale?: boolean): Promise<void> => {
     try {
+      setIsLoadingCloudEnvironments(true);
       const cloudEnvFilters = _.pickBy((l) => !_.isUndefined(l), {
         role: 'creator',
         saturnWorkspaceName,
@@ -63,6 +66,7 @@ export const useCloudEnvironmentPolling = (
       setAppDataDisks(_.remove((disk) => _.isUndefined(getDiskAppType(disk)), newDisks));
       setPersistentDisks(_.filter((disk) => _.isUndefined(getDiskAppType(disk)), newDisks));
       const runtime = getCurrentRuntime(newRuntimes);
+      setIsLoadingCloudEnvironments(false);
       reschedule(
         maybeStale ||
           ['Creating', 'Starting', 'Stopping', 'Updating', 'LeoReconfiguring'].includes(
@@ -94,5 +98,5 @@ export const useCloudEnvironmentPolling = (
     };
     //  eslint-disable-next-line react-hooks/exhaustive-deps
   }, [name, namespace, workspace]);
-  return { runtimes, refreshRuntimes, persistentDisks, appDataDisks };
+  return { runtimes, refreshRuntimes, persistentDisks, appDataDisks, isLoadingCloudEnvironments };
 };

--- a/src/workspaces/common/state/useCloudEnvironmentPolling.ts
+++ b/src/workspaces/common/state/useCloudEnvironmentPolling.ts
@@ -13,6 +13,7 @@ export interface CloudEnvironmentDetails {
   refreshRuntimes: (maybeStale?: boolean) => Promise<void>;
   persistentDisks?: PersistentDisk[];
   appDataDisks?: PersistentDisk[];
+  // TODO use LoadedState instead
   isLoadingCloudEnvironments: boolean;
 }
 
@@ -43,7 +44,6 @@ export const useCloudEnvironmentPolling = (
   };
   const load = async (maybeStale?: boolean): Promise<void> => {
     try {
-      setIsLoadingCloudEnvironments(true);
       const cloudEnvFilters = _.pickBy((l) => !_.isUndefined(l), {
         role: 'creator',
         saturnWorkspaceName,

--- a/src/workspaces/container/WorkspaceContainer.test.ts
+++ b/src/workspaces/container/WorkspaceContainer.test.ts
@@ -84,6 +84,7 @@ describe('WorkspaceContainer', () => {
         refreshApps: () => Promise.resolve(),
         lastRefresh: null,
         refreshRuntimes: () => Promise.resolve(),
+        isLoadingCloudEnvironments: false,
       },
     };
     // Act
@@ -112,6 +113,7 @@ describe('WorkspaceContainer', () => {
         refreshApps: () => Promise.resolve(),
         refreshRuntimes: () => Promise.resolve(),
         lastRefresh: null,
+        isLoadingCloudEnvironments: false,
       },
     };
     // Act
@@ -156,6 +158,7 @@ describe('WorkspaceContainer', () => {
         refreshApps: () => Promise.resolve(),
         refreshRuntimes: () => Promise.resolve(),
         lastRefresh: null,
+        isLoadingCloudEnvironments: false,
       },
     };
 
@@ -209,6 +212,7 @@ describe('WorkspaceContainer', () => {
         refreshApps: () => Promise.resolve(),
         refreshRuntimes: () => Promise.resolve(),
         lastRefresh: null,
+        isLoadingCloudEnvironments: false,
       },
     };
 
@@ -282,6 +286,7 @@ describe('WorkspaceContainer', () => {
         refreshApps: () => Promise.resolve(),
         refreshRuntimes: () => Promise.resolve(),
         lastRefresh: null,
+        isLoadingCloudEnvironments: false,
       },
     };
 
@@ -354,6 +359,7 @@ describe('WorkspaceContainer', () => {
         refreshApps: () => Promise.resolve(),
         refreshRuntimes: () => Promise.resolve(),
         lastRefresh: null,
+        isLoadingCloudEnvironments: false,
       },
     };
 
@@ -399,6 +405,7 @@ describe('WorkspaceContainer', () => {
         refreshApps: () => Promise.resolve(),
         refreshRuntimes: () => Promise.resolve(),
         lastRefresh: null,
+        isLoadingCloudEnvironments: false,
       },
     };
 

--- a/src/workspaces/container/WorkspaceContainer.ts
+++ b/src/workspaces/container/WorkspaceContainer.ts
@@ -79,7 +79,15 @@ export const WorkspaceContainer = (props: WorkspaceContainerProps) => {
     breadcrumbs,
     title,
     activeTab,
-    analysesData: { apps = [], refreshApps, runtimes = [], refreshRuntimes, appDataDisks = [], persistentDisks = [] },
+    analysesData: {
+      apps = [],
+      refreshApps,
+      runtimes = [],
+      refreshRuntimes,
+      appDataDisks = [],
+      persistentDisks = [],
+      isLoadingCloudEnvironments,
+    },
     storageDetails,
     refresh,
     workspace,
@@ -140,6 +148,7 @@ export const WorkspaceContainer = (props: WorkspaceContainerProps) => {
             runtimes,
             persistentDisks,
             refreshRuntimes,
+            isLoadingCloudEnvironments,
             storageDetails,
           }),
       ]),
@@ -253,11 +262,8 @@ export const wrapWorkspace = (opts: WrapWorkspaceOptions): WrapWorkspaceFn => {
         namespace,
         name
       );
-      const { runtimes, refreshRuntimes, persistentDisks, appDataDisks } = useCloudEnvironmentPolling(
-        name,
-        namespace,
-        workspace
-      );
+      const { runtimes, refreshRuntimes, persistentDisks, appDataDisks, isLoadingCloudEnvironments } =
+        useCloudEnvironmentPolling(name, namespace, workspace);
       const { apps, refreshApps, lastRefresh } = useAppPolling(name, namespace, workspace);
 
       if (accessError) {
@@ -274,7 +280,16 @@ export const wrapWorkspace = (opts: WrapWorkspaceOptions): WrapWorkspaceFn => {
           refreshWorkspace,
           title: _.isFunction(title) ? title(props) : title,
           breadcrumbs: breadcrumbs(props),
-          analysesData: { apps, refreshApps, lastRefresh, runtimes, refreshRuntimes, appDataDisks, persistentDisks },
+          analysesData: {
+            apps,
+            refreshApps,
+            lastRefresh,
+            runtimes,
+            refreshRuntimes,
+            appDataDisks,
+            persistentDisks,
+            isLoadingCloudEnvironments,
+          },
           storageDetails,
           refresh: async () => {
             await refreshWorkspace();
@@ -297,6 +312,7 @@ export const wrapWorkspace = (opts: WrapWorkspaceOptions): WrapWorkspaceFn => {
                 refreshRuntimes,
                 appDataDisks,
                 persistentDisks,
+                isLoadingCloudEnvironments,
               },
               storageDetails,
               ...props,


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/IA-4822

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Add wait for spinner in analysis preview page, to solve issue IA-4822
- Apply SHA `792941e4` (isLoadingCloudEnvironments) to solve issue IA-4667
- Make above flag apply only on initial fetch

### Why
- Buttons are now disabled while state loads.

### Testing strategy
- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 


[IA-4667]: https://broadworkbench.atlassian.net/browse/IA-4667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IA-4822]: https://broadworkbench.atlassian.net/browse/IA-4822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ