### PR TITLE
[UIE-153] Remove Environments page's dependency on Utils.append

### DIFF
--- a/src/analysis/AnalysisNotificationManager.ts
+++ b/src/analysis/AnalysisNotificationManager.ts
@@ -174,7 +174,7 @@ export const AnalysisNotificationManager = (props: AnalysisNotificationManagerPr
       notify('error', 'Error Creating Cloud Environment', {
         message: h(RuntimeErrorNotification, { runtime }),
       });
-      errorNotifiedRuntimes.update(Utils.append(runtime.id));
+      errorNotifiedRuntimes.update((value) => [...value, runtime.id]);
     } else if (
       runtime?.status === 'Running' &&
       prevRuntime?.status !== 'Running' &&
@@ -227,7 +227,7 @@ export const AnalysisNotificationManager = (props: AnalysisNotificationManagerPr
       notify('error', 'Error Creating Galaxy App', {
         message: h(AppErrorNotification, { app: galaxyApp }),
       });
-      errorNotifiedApps.update(Utils.append(galaxyApp.appName));
+      errorNotifiedApps.update((value) => [...value, galaxyApp.appName]);
     }
   }, [runtimes, apps, namespace, name]); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/src/libs/state.ts
+++ b/src/libs/state.ts
@@ -259,9 +259,9 @@ export const workspacesStore = atom<WorkspaceWrapper[]>([]);
 
 export const rerunFailuresStatus = atom<unknown>(undefined);
 
-export const errorNotifiedRuntimes = atom<unknown[]>([]);
+export const errorNotifiedRuntimes = atom<number[]>([]);
 
-export const errorNotifiedApps = atom<unknown[]>([]);
+export const errorNotifiedApps = atom<string[]>([]);
 
 export const knownBucketRequesterPaysStatuses = atom({});
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/UIE-153

Replacement for #4647...

Working on decoupling the Environments page (and analysis components in general) for reuse in All of Us...

This removes one of Environments' dependencies on Terra UI's libs/utils by replacing `Utils.append` with an inline function.