### PR TITLE
[UIE-51] Clean up PopupTrigger imports

### DIFF
--- a/src/alerts/Alerts.ts
+++ b/src/alerts/Alerts.ts
@@ -1,10 +1,9 @@
-import { IconId } from '@terra-ui-packages/components';
+import { IconId, PopupTrigger } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { CSSProperties, Fragment, ReactNode, useEffect, useState } from 'react';
 import { div, h, li, p, span, ul } from 'react-hyperscript-helpers';
 import { Clickable, Link } from 'src/components/common';
 import { icon } from 'src/components/icons';
-import PopupTrigger from 'src/components/PopupTrigger';
 import colors from 'src/libs/colors';
 import { useLinkExpirationAlerts } from 'src/libs/link-expiration-alerts';
 import { usePrevious } from 'src/libs/react-utils';

--- a/src/analysis/Environments/Environments.ts
+++ b/src/analysis/Environments/Environments.ts
@@ -1,3 +1,4 @@
+import { PopupTrigger } from '@terra-ui-packages/components';
 import { Mutate, NavLinkProvider } from '@terra-ui-packages/core-utils';
 import _ from 'lodash/fp';
 import { Fragment, ReactNode, useEffect, useState } from 'react';
@@ -17,7 +18,7 @@ import { getDisplayRuntimeStatus, isGcpContext } from 'src/analysis/utils/runtim
 import { AppToolLabel } from 'src/analysis/utils/tool-utils';
 import { Clickable, Link, spinnerOverlay } from 'src/components/common';
 import { icon } from 'src/components/icons';
-import PopupTrigger, { makeMenuIcon } from 'src/components/PopupTrigger';
+import { makeMenuIcon } from 'src/components/PopupTrigger';
 import SupportRequestWrapper from 'src/components/SupportRequest';
 import { SimpleFlexTable, Sortable } from 'src/components/table';
 import TooltipTrigger from 'src/components/TooltipTrigger';

--- a/src/components/PopupTrigger.js
+++ b/src/components/PopupTrigger.js
@@ -5,8 +5,6 @@ import { icon } from 'src/components/icons';
 import { VerticalNavigation } from 'src/components/keyboard-nav';
 import colors from 'src/libs/colors';
 
-export default PopupTrigger;
-
 export const makeMenuIcon = (iconName, props) => {
   return icon(iconName, _.merge({ size: 15, style: { marginRight: '.3rem' } }, props));
 };

--- a/src/workspace-data/data-table/shared/HeaderOptions.js
+++ b/src/workspace-data/data-table/shared/HeaderOptions.js
@@ -1,3 +1,4 @@
+import { PopupTrigger } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { Fragment, useRef } from 'react';
 import { div, h } from 'react-hyperscript-helpers';
@@ -5,7 +6,7 @@ import { Link } from 'src/components/common';
 import { icon } from 'src/components/icons';
 import { ConfirmedSearchInput } from 'src/components/input';
 import { MenuButton } from 'src/components/MenuButton';
-import PopupTrigger, { MenuDivider } from 'src/components/PopupTrigger';
+import { MenuDivider } from 'src/components/PopupTrigger';
 import { Sortable } from 'src/components/table';
 
 export const HeaderOptions = ({ sort, field, onSort, extraActions, renderSearch, searchByColumn, children }) => {


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/UIE-51

Cleaning up imports after moving PopupTrigger to the components package. This changes all imports to import directly from `@terra-ui-packages/components` and removes the re-export from `src/components/PopupTrigger`.