### PR TITLE
[DC-835] Add Real Counts to Search Concepts API

### DIFF
--- a/src/dataset-builder/ConceptSearch.ts
+++ b/src/dataset-builder/ConceptSearch.ts
@@ -44,7 +44,7 @@ export const ConceptSearch = (props: ConceptSearchProps) => {
     });
   });
   useEffect(() => {
-    if (searchText.length > 2 || searchText === '') {
+    if (searchText.length > 2) {
       void searchConcepts(() => {
         return DataRepo().dataset(datasetId).searchConcepts(domainOption.root, searchText);
       });

--- a/src/dataset-builder/DatasetBuilderUtils.test.ts
+++ b/src/dataset-builder/DatasetBuilderUtils.test.ts
@@ -1,4 +1,4 @@
-import { div } from 'react-hyperscript-helpers';
+import { div, span } from 'react-hyperscript-helpers';
 import {
   AnyCriteria,
   AnyCriteriaApi,
@@ -184,10 +184,10 @@ describe('test conversion of DatasetAccessRequest', () => {
 
 describe('test HighlightConceptName', () => {
   const createHighlightConceptName = (beforeHighlight: string, highlightWord: string, afterHighlight: string) => {
-    return div({ style: { display: 'flex' } }, [
-      div({ style: { whiteSpace: 'pre' } }, [beforeHighlight]),
-      div({ style: { fontWeight: 600, whiteSpace: 'pre' } }, [highlightWord]),
-      div({ style: { whiteSpace: 'pre' } }, [afterHighlight]),
+    return div({ style: { whiteSpace: 'pre-wrap' } }, [
+      span([beforeHighlight]),
+      span({ style: { fontWeight: 600 } }, [highlightWord]),
+      span([afterHighlight]),
     ]);
   };
 

--- a/src/dataset-builder/DatasetBuilderUtils.ts
+++ b/src/dataset-builder/DatasetBuilderUtils.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp';
 import { ReactElement } from 'react';
-import { div } from 'react-hyperscript-helpers';
+import { div, span } from 'react-hyperscript-helpers';
 import {
   ColumnStatisticsIntOrDoubleModel,
   ColumnStatisticsTextModel,
@@ -278,9 +278,9 @@ export const HighlightConceptName = ({ conceptName, searchFilter }): ReactElemen
 
   const endIndex = startIndex + searchFilter.length;
 
-  return div({ style: { display: 'flex' } }, [
-    div({ style: { whiteSpace: 'pre' } }, [conceptName.substring(0, startIndex)]),
-    div({ style: { fontWeight: 600, whiteSpace: 'pre' } }, [conceptName.substring(startIndex, endIndex)]),
-    div({ style: { whiteSpace: 'pre' } }, [conceptName.substring(endIndex)]),
+  return div({ style: { whiteSpace: 'pre-wrap' } }, [
+    span([conceptName.substring(0, startIndex)]),
+    span({ style: { fontWeight: 600 } }, [conceptName.substring(startIndex, endIndex)]),
+    span([conceptName.substring(endIndex)]),
   ]);
 };

--- a/src/libs/ajax/DataRepo.ts
+++ b/src/libs/ajax/DataRepo.ts
@@ -13,7 +13,6 @@ import {
   ProgramDataRangeOption,
   SearchConceptsResponse,
 } from 'src/dataset-builder/DatasetBuilderUtils';
-import { dummyConcepts } from 'src/dataset-builder/TestConstants';
 import { authOpts, fetchDataRepo, jsonBody } from 'src/libs/ajax/ajax-common';
 
 export type SnapshotBuilderConcept = {
@@ -229,12 +228,12 @@ export const DataRepo = (signal?: AbortSignal): DataRepoContract => ({
         ),
       getConcepts: async (parent: SnapshotBuilderConcept): Promise<GetConceptsResponse> =>
         callDataRepo(`repository/v1/datasets/${datasetId}/snapshotBuilder/concepts/${parent.id}`),
-      searchConcepts: async (_domain: SnapshotBuilderConcept, text: string) => {
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-        return Promise.resolve({
-          result: _.filter((concept) => concept.name.toLowerCase().includes(text.toLowerCase()), dummyConcepts),
-        });
-      },
+      searchConcepts: async (_domain: SnapshotBuilderConcept, searchText: string): Promise<GetConceptsResponse> =>
+        callDataRepo(
+          `repository/v1/datasets/${datasetId}/snapshotBuilder/concepts/${_domain.name}/${encodeURIComponent(
+            searchText !== '' ? searchText : ' '
+          )}`
+        ),
       queryDatasetColumnStatisticsById: (programDataOption) =>
         handleProgramDataOptions(datasetId, programDataOption, signal),
     };


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/DC-835

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->
[[backend] Service support text search of Domain-based concepts](https://broadworkbench.atlassian.net/browse/DC-743) creates the servce to support a text search of domains. The service will return a list of concepts with roll-up counts that match the search string. 

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->
- Remove the stubbed call with the live synapse database query. 
- If text in search (searchText) is empty (i.e ''), query with a string that has one space: ' '
- if searchText has a length greater than 2, call query
- when rendering every row, the rows should be sorted in descending order first
- change HighlightConceptName because text was stretching into other componenets

### What
- Replaced stubbed api with live synapse api and implemented conditions where query will and will not call. 

### Why
- As a researcher I want to know how many participants have each concept when I go to add concepts to my cohort query

### Testing strategy
- [ ] Unit Tests

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 

https://github.com/DataBiosphere/terra-ui/assets/63474660/ce81c056-59b3-4783-b7c6-2969dcc90b49




