### PR TITLE
[PROD-928] Fix analyses list in Azure workspaces

### DIFF
--- a/src/libs/ajax/AzureStorage.ts
+++ b/src/libs/ajax/AzureStorage.ts
@@ -104,7 +104,7 @@ export const AzureStorage = (signal?: AbortSignal) => ({
   },
 
   listNotebooks: async (workspaceId: string): Promise<AnalysisFile[]> => {
-    const notebooks = await AzureStorage(signal).listFiles(workspaceId, '.ipynb');
+    const notebooks = await AzureStorage(signal).listFiles(workspaceId, '', '.ipynb');
     return _.map(
       (notebook) => ({
         lastModified: new Date(notebook.lastModified).getTime(),


### PR DESCRIPTION
#4630 changed the signature of AzureStorage's `listFiles` function without also updating the call in `listNotebooks`. As a result, no analyses show up in Azure workspaces because Terra UI is asking for files starting with ".ipynb" instead of ending with ".ipynb".

This updates the call in `listNotebooks` so that ".ipynb" is passed as a suffix filter instead of a prefix filter.