### PR TITLE
[DC-859] Fix HighlightConceptName to pre-wrap text

### DIFF
--- a/src/dataset-builder/ConceptSearch.test.ts
+++ b/src/dataset-builder/ConceptSearch.test.ts
@@ -146,12 +146,12 @@ describe('ConceptSearch', () => {
   });
 
   it('bolds the search term and leaves the rest unbolded, "Dis"', async () => {
-    renderSearch('Dis');
+    await act(() => renderSearch('Dis'));
 
-    const disText = await screen.findAllByText('Dis');
+    const disText = await screen.getAllByText('Dis');
 
     const filterDisText = _.filter(
-      (element) => element.tagName === 'DIV' && element.style.fontWeight === '600',
+      (element) => element.tagName === 'SPAN' && element.style.fontWeight === '600',
       disText
     ).length;
     expect(filterDisText).toBeGreaterThan(0);

--- a/src/dataset-builder/ConceptSearch.test.ts
+++ b/src/dataset-builder/ConceptSearch.test.ts
@@ -147,6 +147,7 @@ describe('ConceptSearch', () => {
 
   it('bolds the search term and leaves the rest unbolded, "Dis"', async () => {
     renderSearch('Dis');
+
     const disText = await screen.findAllByText('Dis');
 
     const filterDisText = _.filter(

--- a/src/dataset-builder/ConceptSearch.test.ts
+++ b/src/dataset-builder/ConceptSearch.test.ts
@@ -146,8 +146,7 @@ describe('ConceptSearch', () => {
   });
 
   it('bolds the search term and leaves the rest unbolded, "Dis"', async () => {
-    await act(() => renderSearch('Dis'));
-
+    renderSearch('Dis');
     const disText = await screen.findAllByText('Dis');
 
     const filterDisText = _.filter(

--- a/src/dataset-builder/ConceptSearch.test.ts
+++ b/src/dataset-builder/ConceptSearch.test.ts
@@ -148,7 +148,7 @@ describe('ConceptSearch', () => {
   it('bolds the search term and leaves the rest unbolded, "Dis"', async () => {
     await act(() => renderSearch('Dis'));
 
-    const disText = await screen.getAllByText('Dis');
+    const disText = await screen.findAllByText('Dis');
 
     const filterDisText = _.filter(
       (element) => element.tagName === 'SPAN' && element.style.fontWeight === '600',

--- a/src/dataset-builder/DatasetBuilderUtils.test.ts
+++ b/src/dataset-builder/DatasetBuilderUtils.test.ts
@@ -1,4 +1,4 @@
-import { div } from 'react-hyperscript-helpers';
+import { div, span } from 'react-hyperscript-helpers';
 import {
   AnyCriteria,
   AnyCriteriaApi,
@@ -184,10 +184,10 @@ describe('test conversion of DatasetAccessRequest', () => {
 
 describe('test HighlightConceptName', () => {
   const createHighlightConceptName = (beforeHighlight: string, highlightWord: string, afterHighlight: string) => {
-    return div({ style: { display: 'flex' } }, [
-      div({ style: { whiteSpace: 'pre' } }, [beforeHighlight]),
-      div({ style: { fontWeight: 600, whiteSpace: 'pre' } }, [highlightWord]),
-      div({ style: { whiteSpace: 'pre' } }, [afterHighlight]),
+    return div({ style: { display: 'pre-wrap' } }, [
+      span([beforeHighlight]),
+      span({ style: { fontWeight: 600 } }, [highlightWord]),
+      span([afterHighlight]),
     ]);
   };
 

--- a/src/dataset-builder/DatasetBuilderUtils.ts
+++ b/src/dataset-builder/DatasetBuilderUtils.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp';
 import { ReactElement } from 'react';
-import { div } from 'react-hyperscript-helpers';
+import { div, span } from 'react-hyperscript-helpers';
 import {
   ColumnStatisticsIntOrDoubleModel,
   ColumnStatisticsTextModel,
@@ -278,9 +278,9 @@ export const HighlightConceptName = ({ conceptName, searchFilter }): ReactElemen
 
   const endIndex = startIndex + searchFilter.length;
 
-  return div({ style: { display: 'flex' } }, [
-    div({ style: { whiteSpace: 'pre' } }, [conceptName.substring(0, startIndex)]),
-    div({ style: { fontWeight: 600, whiteSpace: 'pre' } }, [conceptName.substring(startIndex, endIndex)]),
-    div({ style: { whiteSpace: 'pre' } }, [conceptName.substring(endIndex)]),
+  return div({ style: { display: 'pre-wrap' } }, [
+    span([conceptName.substring(0, startIndex)]),
+    span({ style: { fontWeight: 600 } }, [conceptName.substring(startIndex, endIndex)]),
+    span([conceptName.substring(endIndex)]),
   ]);
 };


### PR DESCRIPTION
### Jira Ticket: [Fix HighlightConceptName to pre-wrap text instead of flowing into other components on Search](https://broadworkbench.atlassian.net/browse/DC-859)

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->
[We can see that text flows into other components](https://github.com/DataBiosphere/terra-ui/pull/4660/files) 

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Changed div style of HighlightConceptName to pre-wrap instead of flex. The flex, caused the entire text to stretch out across the screen. 
- Changed tests to follow the HTML structure

### Why
- Text was flowing into other components and made it impossible to read

### Testing strategy
- Unit tests

<!-- ### Visual Aids -->

https://github.com/DataBiosphere/terra-ui/assets/63474660/b3794361-0543-443c-b8c6-c5968065cac7


