### PR TITLE
[UIE-78] Configure ESLint to not allow nested ternaries

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -70,7 +70,6 @@ module.exports = {
     'no-constant-condition': ['error', {checkLoops: false}],
     'no-empty': ['error', { allowEmptyCatch: true }],
     'no-continue': 'off',
-    'no-nested-ternary': 'off',
     'no-param-reassign': 'off',
     'no-plusplus': 'off',
     'no-promise-executor-return': 'off',

--- a/packages/components/src/buttons.tsx
+++ b/packages/components/src/buttons.tsx
@@ -30,10 +30,12 @@ export const ButtonPrimary = (props: ButtonPrimaryProps): ReactNode => {
       disabled={disabled}
       style={{
         ...buttonStyle,
+        // eslint-disable-next-line no-nested-ternary
         border: `1px solid ${disabled ? colors.dark(0.4) : danger ? colors.danger(1.2) : colors.accent(1.2)}`,
         borderRadius: 5,
         color: 'white',
         padding: '0.875rem',
+        // eslint-disable-next-line no-nested-ternary
         backgroundColor: disabled ? colors.dark(0.25) : danger ? colors.danger() : colors.accent(),
         cursor: disabled ? 'not-allowed' : 'pointer',
         ...style,

--- a/packages/components/src/buttons.tsx
+++ b/packages/components/src/buttons.tsx
@@ -30,11 +30,13 @@ export const ButtonPrimary = (props: ButtonPrimaryProps): ReactNode => {
       disabled={disabled}
       style={{
         ...buttonStyle,
+        // TODO: Remove nested ternary to align with style guide
         // eslint-disable-next-line no-nested-ternary
         border: `1px solid ${disabled ? colors.dark(0.4) : danger ? colors.danger(1.2) : colors.accent(1.2)}`,
         borderRadius: 5,
         color: 'white',
         padding: '0.875rem',
+        // TODO: Remove nested ternary to align with style guide
         // eslint-disable-next-line no-nested-ternary
         backgroundColor: disabled ? colors.dark(0.25) : danger ? colors.danger() : colors.accent(),
         cursor: disabled ? 'not-allowed' : 'pointer',

--- a/src/analysis/Analyses.ts
+++ b/src/analysis/Analyses.ts
@@ -171,6 +171,7 @@ const AnalysisCard = ({
   // if there is a currentUserHash & lastLockedBy, they are not equal, and the lock isn't expired
   const isLocked: boolean =
     currentUserHash && lastLockedBy ? lastLockedBy !== currentUserHash && !isLockExpired : false;
+  // eslint-disable-next-line no-nested-ternary
   const lockedBy = lastLockedBy ? (potentialLockers ? potentialLockers[lastLockedBy] : null) : null;
 
   const analysisName: FileName = getFileName(name);

--- a/src/analysis/Analyses.ts
+++ b/src/analysis/Analyses.ts
@@ -171,6 +171,7 @@ const AnalysisCard = ({
   // if there is a currentUserHash & lastLockedBy, they are not equal, and the lock isn't expired
   const isLocked: boolean =
     currentUserHash && lastLockedBy ? lastLockedBy !== currentUserHash && !isLockExpired : false;
+  // TODO: Remove nested ternary to align with style guide
   // eslint-disable-next-line no-nested-ternary
   const lockedBy = lastLockedBy ? (potentialLockers ? potentialLockers[lastLockedBy] : null) : null;
 

--- a/src/analysis/utils/cost-utils.ts
+++ b/src/analysis/utils/cost-utils.ts
@@ -118,6 +118,7 @@ export const runtimeConfigCost = (config: GoogleRuntimeConfig): number => {
   if (!config) return 0;
   const computeRegion = config.normalizedRegion;
 
+  // TODO: Remove nested ternary to align with style guide
   // eslint-disable-next-line no-nested-ternary
   const machineType: string = isGceRuntimeConfig(config)
     ? config.machineType

--- a/src/analysis/utils/cost-utils.ts
+++ b/src/analysis/utils/cost-utils.ts
@@ -118,6 +118,7 @@ export const runtimeConfigCost = (config: GoogleRuntimeConfig): number => {
   if (!config) return 0;
   const computeRegion = config.normalizedRegion;
 
+  // eslint-disable-next-line no-nested-ternary
   const machineType: string = isGceRuntimeConfig(config)
     ? config.machineType
     : isDataprocConfig(config)

--- a/src/components/NameModal.js
+++ b/src/components/NameModal.js
@@ -19,6 +19,7 @@ export const NameModal = ({ onSuccess, onDismiss, thing, value, validator = null
       setError(validationMessage);
     } else if (_.isFunction(validator)) {
       const msg = validator(name);
+      // TODO: Remove nested ternary to align with style guide
       // eslint-disable-next-line no-nested-ternary
       setError(msg === false ? null : _.isString(msg) ? msg : validationMessage);
     } else {

--- a/src/components/NameModal.js
+++ b/src/components/NameModal.js
@@ -19,6 +19,7 @@ export const NameModal = ({ onSuccess, onDismiss, thing, value, validator = null
       setError(validationMessage);
     } else if (_.isFunction(validator)) {
       const msg = validator(name);
+      // eslint-disable-next-line no-nested-ternary
       setError(msg === false ? null : _.isString(msg) ? msg : validationMessage);
     } else {
       setError(null);

--- a/src/components/region-common.js
+++ b/src/components/region-common.js
@@ -14,6 +14,7 @@ import * as Utils from 'src/libs/utils';
 const unknownRegionFlag = '❓';
 export const getRegionInfo = (location, locationType) => {
   const regionDescription =
+    // TODO: Remove nested ternary to align with style guide
     // eslint-disable-next-line no-nested-ternary
     locationType === locationTypes.multiRegion ? `${location} (${locationTypes.multiRegion})` : location ? location.toLowerCase() : 'UNKNOWN';
   return Utils.switchCase(

--- a/src/components/region-common.js
+++ b/src/components/region-common.js
@@ -14,6 +14,7 @@ import * as Utils from 'src/libs/utils';
 const unknownRegionFlag = '❓';
 export const getRegionInfo = (location, locationType) => {
   const regionDescription =
+    // eslint-disable-next-line no-nested-ternary
     locationType === locationTypes.multiRegion ? `${location} (${locationTypes.multiRegion})` : location ? location.toLowerCase() : 'UNKNOWN';
   return Utils.switchCase(
     locationType,

--- a/src/libs/ajax/loaded-data/withCachedData.ts
+++ b/src/libs/ajax/loaded-data/withCachedData.ts
@@ -27,6 +27,7 @@ export const withCachedData = <S, F extends LoadedDataFn<S>>(store: Atom<S>, use
     });
 
     const finalResult: typeof dataResult =
+      // eslint-disable-next-line no-nested-ternary
       dataResult.status !== 'None'
         ? {
             ...dataResult,

--- a/src/libs/ajax/loaded-data/withCachedData.ts
+++ b/src/libs/ajax/loaded-data/withCachedData.ts
@@ -27,6 +27,7 @@ export const withCachedData = <S, F extends LoadedDataFn<S>>(store: Atom<S>, use
     });
 
     const finalResult: typeof dataResult =
+      // TODO: Remove nested ternary to align with style guide
       // eslint-disable-next-line no-nested-ternary
       dataResult.status !== 'None'
         ? {

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -219,6 +219,7 @@ export const commaJoin = (list, conjunction = 'or') => {
     _.flow(
       toIndexPairs,
       _.flatMap(([i, val]) => {
+        // eslint-disable-next-line no-nested-ternary
         return [i === 0 ? '' : i === list.length - 1 ? ` ${conjunction} ` : ', ', val];
       })
     )(list)

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -219,6 +219,7 @@ export const commaJoin = (list, conjunction = 'or') => {
     _.flow(
       toIndexPairs,
       _.flatMap(([i, val]) => {
+        // TODO: Remove nested ternary to align with style guide
         // eslint-disable-next-line no-nested-ternary
         return [i === 0 ? '' : i === list.length - 1 ? ` ${conjunction} ` : ', ', val];
       })

--- a/src/pages/workspaces/workspace/jobHistory/CallCacheWizard.js
+++ b/src/pages/workspaces/workspace/jobHistory/CallCacheWizard.js
@@ -263,6 +263,7 @@ const CallCacheWizard = ({ onDismiss, workflowId, callFqn, index, loadCallCacheD
       ]),
       divider,
       div({ style: { display: 'flex', alignItems: 'center', fontSize: 16, fontWeight: 500 } }, ['Result: View cache diff']),
+      // TODO: Remove nested ternary to align with style guide
       // eslint-disable-next-line no-nested-ternary
       diffError
         ? h(ErrorView, { error: diffError })

--- a/src/pages/workspaces/workspace/jobHistory/CallCacheWizard.js
+++ b/src/pages/workspaces/workspace/jobHistory/CallCacheWizard.js
@@ -263,6 +263,7 @@ const CallCacheWizard = ({ onDismiss, workflowId, callFqn, index, loadCallCacheD
       ]),
       divider,
       div({ style: { display: 'flex', alignItems: 'center', fontSize: 16, fontWeight: 500 } }, ['Result: View cache diff']),
+      // eslint-disable-next-line no-nested-ternary
       diffError
         ? h(ErrorView, { error: diffError })
         : diff

--- a/src/registration/terms-of-service/TermsOfServicePage.tsx
+++ b/src/registration/terms-of-service/TermsOfServicePage.tsx
@@ -65,6 +65,7 @@ export const TermsOfServicePage = () => {
     </div>
   );
 
+  // eslint-disable-next-line no-nested-ternary
   const buttons = showButtons
     ? requiredToAcceptTermsOfService
       ? acceptTosButtons

--- a/src/registration/terms-of-service/TermsOfServicePage.tsx
+++ b/src/registration/terms-of-service/TermsOfServicePage.tsx
@@ -65,6 +65,7 @@ export const TermsOfServicePage = () => {
     </div>
   );
 
+  // TODO: Remove nested ternary to align with style guide
   // eslint-disable-next-line no-nested-ternary
   const buttons = showButtons
     ? requiredToAcceptTermsOfService

--- a/src/workspace-data/Data.js
+++ b/src/workspace-data/Data.js
@@ -1146,6 +1146,7 @@ export const WorkspaceData = _.flow(
                                           {
                                             wrapperProps: { role: 'listitem' },
                                             buttonStyle: { borderBottom: 0, height: 40, ...(canCompute ? {} : { color: colors.dark(0.25) }) },
+                                            // eslint-disable-next-line no-nested-ternary
                                             tooltip: canCompute
                                               ? tableName
                                                 ? `${tableName} (${count} row${count === 1 ? '' : 's'})`

--- a/src/workspace-data/Data.js
+++ b/src/workspace-data/Data.js
@@ -1146,6 +1146,7 @@ export const WorkspaceData = _.flow(
                                           {
                                             wrapperProps: { role: 'listitem' },
                                             buttonStyle: { borderBottom: 0, height: 40, ...(canCompute ? {} : { color: colors.dark(0.25) }) },
+                                            // TODO: Remove nested ternary to align with style guide
                                             // eslint-disable-next-line no-nested-ternary
                                             tooltip: canCompute
                                               ? tableName

--- a/src/workspace-data/data-table/shared/DataTable.js
+++ b/src/workspace-data/data-table/shared/DataTable.js
@@ -647,6 +647,7 @@ const DataTable = (props) => {
                           });
                       if (!!dataInfo && _.isArray(dataInfo.items)) {
                         const isPlural = dataInfo.items.length !== 1;
+                        // eslint-disable-next-line no-nested-ternary
                         const label = dataInfo?.itemsType === 'EntityReference' ? (isPlural ? 'entities' : 'entity') : isPlural ? 'items' : 'item';
                         const itemsLink = h(
                           Link,
@@ -677,6 +678,7 @@ const DataTable = (props) => {
                 initialX,
                 initialY,
                 sort,
+                // eslint-disable-next-line no-nested-ternary
                 numFixedColumns: visibleColumns.length > 0 ? (dataProvider.features.supportsRowSelection ? 2 : 1) : 0,
                 columns: defaultColumns,
                 styleCell: ({ rowIndex }) => {

--- a/src/workspace-data/data-table/shared/DataTable.js
+++ b/src/workspace-data/data-table/shared/DataTable.js
@@ -678,6 +678,7 @@ const DataTable = (props) => {
                 initialX,
                 initialY,
                 sort,
+                // TODO: Remove nested ternary to align with style guide
                 // eslint-disable-next-line no-nested-ternary
                 numFixedColumns: visibleColumns.length > 0 ? (dataProvider.features.supportsRowSelection ? 2 : 1) : 0,
                 columns: defaultColumns,

--- a/src/workspace-data/data-table/wds/WdsTroubleshooter.ts
+++ b/src/workspace-data/data-table/wds/WdsTroubleshooter.ts
@@ -62,6 +62,7 @@ export const WdsTroubleshooter = ({ onDismiss, workspaceId, mrgId }) => {
   ]) => {
     return tr({ key: label }, [
       td({ style: { fontWeight: 'bold' } }, [
+        // TODO: Remove nested ternary to align with style guide
         // eslint-disable-next-line no-nested-ternary
         iconRunning ? checkIcon('running') : iconSuccess ? checkIcon('success') : checkIcon('failure'),
       ]),

--- a/src/workspace-data/data-table/wds/WdsTroubleshooter.ts
+++ b/src/workspace-data/data-table/wds/WdsTroubleshooter.ts
@@ -62,6 +62,7 @@ export const WdsTroubleshooter = ({ onDismiss, workspaceId, mrgId }) => {
   ]) => {
     return tr({ key: label }, [
       td({ style: { fontWeight: 'bold' } }, [
+        // eslint-disable-next-line no-nested-ternary
         iconRunning ? checkIcon('running') : iconSuccess ? checkIcon('success') : checkIcon('failure'),
       ]),
       td({ style: { fontWeight: 'bold', whiteSpace: 'nowrap' } }, [label]),

--- a/src/workspaces/migration/migration-utils.ts
+++ b/src/workspaces/migration/migration-utils.ts
@@ -115,6 +115,7 @@ export const parseServerResponse = (
         namespace,
         name,
         migrationStep: status.migrationStep ?? 'Unscheduled',
+        // eslint-disable-next-line no-nested-ternary
         outcome: status.outcome === 'success' ? 'success' : _.isObject(status.outcome) ? 'failure' : undefined,
         failureReason: getFailureMessage(),
         tempBucketTransferProgress: status.tempBucketTransferProgress,

--- a/src/workspaces/migration/migration-utils.ts
+++ b/src/workspaces/migration/migration-utils.ts
@@ -115,6 +115,7 @@ export const parseServerResponse = (
         namespace,
         name,
         migrationStep: status.migrationStep ?? 'Unscheduled',
+        // TODO: Remove nested ternary to align with style guide
         // eslint-disable-next-line no-nested-ternary
         outcome: status.outcome === 'success' ? 'success' : _.isObject(status.outcome) ? 'failure' : undefined,
         failureReason: getFailureMessage(),


### PR DESCRIPTION
Based on https://github.com/DataBiosphere/terra-ui/pull/4652#discussion_r1489916173, it seems like there's support from at least 3 teams for avoiding nested ternaries.

This configures ESLint not to allow them, adding ESLint ignore comments to all existing uses.
https://eslint.org/docs/latest/rules/no-nested-ternary

In many cases, I think `cond` from `@terra-ui-packages/core-utils` would be the preferred replacement. Unfortunately, with `cond`, you don't get the type narrowing that you do with native branching.