### PR TITLE
[IA-4790] Wait 15 minutes for parallel circleCI runs to complete

### DIFF
--- a/.circleci/wait-for-job-finish.sh
+++ b/.circleci/wait-for-job-finish.sh
@@ -8,8 +8,8 @@ set -o pipefail
 
 counter=0
 
-# Wait up to 7 minutes for job to finish. A job can run on multiple nodes: parallelism > 1
-while [ "$counter" -le 420 ]; do
+# Wait up to 15 minutes for job to finish. A job can run on multiple nodes: parallelism > 1
+while [ "$counter" -le 900 ]; do
   # Find number of nodes in running
   job_detail=$(curl -s "https://circleci.com/api/v2/project/github/DataBiosphere/terra-ui/job/$CIRCLE_BUILD_NUM")
   job_running_nodes_count=$(echo "$job_detail" | jq -r '.parallel_runs[] | select(.status == "running") | select(.index != '"$CIRCLE_NODE_INDEX"')' | grep -c "running")


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/IA-4790

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Let CircleCI wait much longer (15 minutes, not 7) for other parallel integration test runs to finish.
- run-analysis-azure has an inelastic >15 minute runtime, and even in its own container will time out this timer otherwise.

### Why
- Run-analysis-azure was reenabled.

### Testing strategy
- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 
