### PR TITLE
Ia 4790 increase test wait

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,6 +202,7 @@ commands:
               bash ../.circleci/wait-for-job-finish.sh
               node --require ../.pnp.cjs ./slack/notify-circleci-test-results.js
             fi
+          no_output_timeout: 15m
           when: always
 
   notify-qa:

--- a/.circleci/wait-for-job-finish.sh
+++ b/.circleci/wait-for-job-finish.sh
@@ -8,8 +8,8 @@ set -o pipefail
 
 counter=0
 
-# Wait up to 7 minutes for job to finish. A job can run on multiple nodes: parallelism > 1
-while [ "$counter" -le 420 ]; do
+# Wait up to 15 minutes for job to finish. A job can run on multiple nodes: parallelism > 1
+while [ "$counter" -le 900 ]; do
   # Find number of nodes in running
   job_detail=$(curl -s "https://circleci.com/api/v2/project/github/DataBiosphere/terra-ui/job/$CIRCLE_BUILD_NUM")
   job_running_nodes_count=$(echo "$job_detail" | jq -r '.parallel_runs[] | select(.status == "running") | select(.index != '"$CIRCLE_NODE_INDEX"')' | grep -c "running")

--- a/.circleci/wait-for-job-finish.sh
+++ b/.circleci/wait-for-job-finish.sh
@@ -27,5 +27,5 @@ date
 
 # Something is wrong. Log response for error troubleshooting
 curl -s "https://circleci.com/api/v2/project/github/DataBiosphere/terra-ui/job/$CIRCLE_BUILD_NUM" | jq -r '.'
-echo "ERROR: Exceeded maximum waiting time 7 minutes."
+echo "ERROR: Exceeded maximum waiting time 15 minutes."
 exit 1


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/IA-4790

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Add a no_output_timeout to the Slack notification step in integration test workflow.

### Why
- Long runs time out on the notification step.

### Testing strategy
- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 
