### PR TITLE
[WX-1484] Fix bug where include/exclude keys on CromwellApp.workflows.metadata does not send a valid HTTP request.

### DIFF
--- a/src/libs/ajax/workflows-app/CromwellApp.js
+++ b/src/libs/ajax/workflows-app/CromwellApp.js
@@ -5,7 +5,9 @@ import { authOpts, fetchFromProxy } from 'src/libs/ajax/ajax-common';
 export const CromwellApp = (signal) => ({
   workflows: (workflowId) => {
     return {
-      metadata: async (cromwellUrlRoot, includeKey, excludeKey) => {
+      metadata: async (cromwellUrlRoot, options) => {
+        const includeKey = options.includeKey;
+        const excludeKey = options.excludeKey;
         const keyParams = qs.stringify({ includeKey, excludeKey }, { arrayFormat: 'repeat' });
         const res = await fetchFromProxy(cromwellUrlRoot)(
           `api/workflows/v1/${workflowId}/metadata?${keyParams}`,

--- a/src/libs/ajax/workflows-app/CromwellApp.js
+++ b/src/libs/ajax/workflows-app/CromwellApp.js
@@ -6,8 +6,7 @@ export const CromwellApp = (signal) => ({
   workflows: (workflowId) => {
     return {
       metadata: async (cromwellUrlRoot, options) => {
-        const includeKey = options.includeKey;
-        const excludeKey = options.excludeKey;
+        const { includeKey, excludeKey } = options;
         const keyParams = qs.stringify({ includeKey, excludeKey }, { arrayFormat: 'repeat' });
         const res = await fetchFromProxy(cromwellUrlRoot)(
           `api/workflows/v1/${workflowId}/metadata?${keyParams}`,

--- a/src/workflows-app/RunDetails.js
+++ b/src/workflows-app/RunDetails.js
@@ -96,7 +96,7 @@ export const BaseRunDetails = (
   );
   const excludeKey = useMemo(() => [], []);
   const fetchMetadata = useCallback(
-    async (cromwellProxyUrl, workflowId) => Ajax(signal).CromwellApp.workflows(workflowId).metadata(cromwellProxyUrl, includeKey, excludeKey),
+    async (cromwellProxyUrl, workflowId) => Ajax(signal).CromwellApp.workflows(workflowId).metadata(cromwellProxyUrl, { includeKey, excludeKey }),
     [includeKey, excludeKey, signal]
   );
 
@@ -150,7 +150,7 @@ export const BaseRunDetails = (
     async (wfId, includeKey, excludeKey) => {
       const { cromwellProxyUrlState } = await loadAppUrls(workspaceId, 'cromwellProxyUrlState');
       if (cromwellProxyUrlState.status === AppProxyUrlStatus.Ready) {
-        return Ajax(signal).CromwellApp.workflows(wfId).metadata(cromwellProxyUrlState.state, includeKey, excludeKey);
+        return Ajax(signal).CromwellApp.workflows(wfId).metadata(cromwellProxyUrlState.state, { includeKey, excludeKey });
       }
     },
     [signal, workspaceId]

--- a/src/workflows-app/RunDetails.js
+++ b/src/workflows-app/RunDetails.js
@@ -76,8 +76,8 @@ export const BaseRunDetails = (
       'backendStatus',
       'executionStatus',
       'shardIndex',
-      // 'outputs', //not sure if I need this yet
-      // 'inputs', //not sure if I need this yet
+      'outputs',
+      'inputs',
       'jobId',
       'start',
       'end',
@@ -87,13 +87,16 @@ export const BaseRunDetails = (
       'tes_stderr',
       'attempt',
       'subWorkflowId', // needed for task type column
-      // 'subWorkflowMetadata' //may need this later
+      'status',
+      'submittedFiles',
+      'callCaching',
+      'workflowLog',
     ],
     []
   );
   const excludeKey = useMemo(() => [], []);
   const fetchMetadata = useCallback(
-    async (cromwellProxyUrl, workflowId) => Ajax(signal).CromwellApp.workflows(workflowId).metadata(cromwellProxyUrl, { includeKey, excludeKey }),
+    async (cromwellProxyUrl, workflowId) => Ajax(signal).CromwellApp.workflows(workflowId).metadata(cromwellProxyUrl, includeKey, excludeKey),
     [includeKey, excludeKey, signal]
   );
 


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WX-1484

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- The HTTP call on CromwellApp.workflows.metadata was sending invalid HTTP requests due to its arguments being passed as a single object instead of multiple. This caused all of the keys of the workflow metadata to be fetched instead of just the specific keys that are needed. This PR fixes this bug so that we only fetch keys that are needed for the particular page.

### Why
- Fetching all of the keys on the metadata can be a very long process for more complex workflows. This change ensures that we only fetch the keys that are necessary, which will help to save time.

### Testing strategy
- Manually confirmed UI worked as expected
- Confirmed all automated tests pass
