### PR TITLE
[IA-4790] Increase slack notification step wait time to 25min

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,7 +202,7 @@ commands:
               bash ../.circleci/wait-for-job-finish.sh
               node --require ../.pnp.cjs ./slack/notify-circleci-test-results.js
             fi
-          no_output_timeout: 15m
+          no_output_timeout: 25m
           when: always
 
   notify-qa:

--- a/.circleci/wait-for-job-finish.sh
+++ b/.circleci/wait-for-job-finish.sh
@@ -8,8 +8,8 @@ set -o pipefail
 
 counter=0
 
-# Wait up to 15 minutes for job to finish. A job can run on multiple nodes: parallelism > 1
-while [ "$counter" -le 900 ]; do
+# Wait up to 25 minutes for job to finish. A job can run on multiple nodes: parallelism > 1
+while [ "$counter" -le 1500 ]; do
   # Find number of nodes in running
   job_detail=$(curl -s "https://circleci.com/api/v2/project/github/DataBiosphere/terra-ui/job/$CIRCLE_BUILD_NUM")
   job_running_nodes_count=$(echo "$job_detail" | jq -r '.parallel_runs[] | select(.status == "running") | select(.index != '"$CIRCLE_NODE_INDEX"')' | grep -c "running")
@@ -27,5 +27,5 @@ date
 
 # Something is wrong. Log response for error troubleshooting
 curl -s "https://circleci.com/api/v2/project/github/DataBiosphere/terra-ui/job/$CIRCLE_BUILD_NUM" | jq -r '.'
-echo "ERROR: Exceeded maximum waiting time 15 minutes."
+echo "ERROR: Exceeded maximum waiting time 25 minutes."
 exit 1


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/IA-4790

Once more increases the wait time on Slack notification to 25 minutes, to accomodate the disparity between other integration test durations and run-analysis-azure.