### PR TITLE
[TUIM-82] Update to a supported App Engine runtime

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,4 +1,4 @@
-runtime: nodejs16
+runtime: nodejs20
 default_expiration: 2m
 
 handlers:


### PR DESCRIPTION
The Node 16 App Engine runtime has reached the end of support. This updates to the Node 20 runtime. Node 20 is the current LTS version.

The version of Node used in App Engine doesn't impact Terra UI since the App Engine deployment has no server side component, it only serves static files.

> Node.js 10, 12, 14, and 16 have reached [end of support](https://cloud.google.com/appengine/docs/standard/lifecycle/runtime-lifecycle#end_of_support) on January 30, 2024. Your existing applications using these versions will continue to run and receive traffic. However, App Engine might block re-deployments of applications that use runtimes [after their end of support date](https://cloud.google.com/appengine/docs/standard/lifecycle/support-schedule#nodejs). We recommend that you [upgrade to the latest supported version of Node.js](https://cloud.google.com/appengine/docs/standard/nodejs/runtime).

https://cloud.google.com/appengine/docs/standard/nodejs/release-notes#January_30_2024