### PR TITLE
[UIE-120] Move toIndexPairs to core-utils package

### DIFF
--- a/packages/core-utils/src/fp-utils.test.ts
+++ b/packages/core-utils/src/fp-utils.test.ts
@@ -1,0 +1,15 @@
+import { toIndexPairs } from './fp-utils';
+
+describe('toIndexPairs', () => {
+  it('maps array to index pairs', () => {
+    // Act
+    const indexPairs = toIndexPairs([1, 2, 3]);
+
+    // Assert
+    expect(indexPairs).toEqual([
+      [0, 1],
+      [1, 2],
+      [2, 3],
+    ]);
+  });
+});

--- a/packages/core-utils/src/fp-utils.ts
+++ b/packages/core-utils/src/fp-utils.ts
@@ -1,0 +1,3 @@
+export const toIndexPairs = <T>(list: T[]): [number, T][] => {
+  return list.map((val, i) => [i, val]);
+};

--- a/packages/core-utils/src/index.ts
+++ b/packages/core-utils/src/index.ts
@@ -1,5 +1,6 @@
 export * from './format/date-format';
 export * from './format/number-format';
+export * from './fp-utils';
 export * from './io-utils';
 export * from './logic-utils';
 export * from './nav/nav-utils';

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -726,7 +726,8 @@ export const GridTable = forwardRefWithName(
                   // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/cell_role
                   return _.flow(
                     _.groupBy('rowIndex'),
-                    Utils.toIndexPairs,
+                    _.toPairs,
+                    _.map(([k, v]) => [+k, v]),
                     _.map(([rowIndex, cells]) => {
                       const rowDatum = rowSizeAndPositionManager.getSizeAndPositionOfCell(rowIndex);
                       return div(

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -6,6 +6,7 @@ import {
   formatDatetime,
   GenericPromiseFn,
   safeCurry,
+  toIndexPairs,
 } from '@terra-ui-packages/core-utils';
 import { formatDuration, intervalToDuration, isToday, isYesterday } from 'date-fns';
 import { differenceInCalendarMonths, differenceInSeconds, parseJSON } from 'date-fns/fp';
@@ -23,6 +24,7 @@ export {
   formatDate as makeStandardDate,
   maybeParseJSON,
   switchCase,
+  toIndexPairs,
 } from '@terra-ui-packages/core-utils';
 
 const monthYearFormat = new Intl.DateTimeFormat('default', { month: 'short', year: 'numeric' });
@@ -58,12 +60,6 @@ export const differenceFromNowInSeconds = (jsonDateString) => {
 export const differenceFromDatesInSeconds = (jsonDateStringStart, jsonDateStringEnd) => {
   return differenceInSeconds(parseJSON(jsonDateStringStart), parseJSON(jsonDateStringEnd));
 };
-
-export const toIndexPairs = <T>(obj: T[]): [number, T][] =>
-  _.flow(
-    _.toPairs,
-    _.map(([k, v]: [string, T]) => [+k, v])
-  )(obj);
 
 // TODO: add good typing (remove any's) - ticket: https://broadworkbench.atlassian.net/browse/UIE-67
 /**


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/UIE-120

Continuing to split up the libs/utils module and package dependencies of the Environments page... This moves the `toIndexPairs` function to the core-utils package and rewrites it using native JS instead of Lodash.