### PR TITLE
[UIE-51] Import modal from components package

### DIFF
--- a/src/analysis/AnalysisLauncher.js
+++ b/src/analysis/AnalysisLauncher.js
@@ -1,3 +1,4 @@
+import { Modal } from '@terra-ui-packages/components';
 import { atom } from '@terra-ui-packages/core-utils';
 import * as clipboard from 'clipboard-polyfill/text';
 import _ from 'lodash/fp';
@@ -28,7 +29,6 @@ import { requesterPaysWrapper, withRequesterPaysHandler } from 'src/components/b
 import { ButtonPrimary, ButtonSecondary, Clickable, LabeledCheckbox, Link, spinnerOverlay } from 'src/components/common';
 import { icon } from 'src/components/icons';
 import { MenuButton } from 'src/components/MenuButton';
-import Modal from 'src/components/Modal';
 import { makeMenuIcon, MenuTrigger } from 'src/components/PopupTrigger';
 import { Ajax } from 'src/libs/ajax';
 import { Metrics } from 'src/libs/ajax/Metrics';

--- a/src/analysis/AnalysisNotificationManager.ts
+++ b/src/analysis/AnalysisNotificationManager.ts
@@ -1,6 +1,7 @@
 // This file is where any notifications not tied to a specific action are managed for leonardo-related resource
 // For example, if you load a page and your apps/runtimes are in an error state, this component is responsible for that notification
 
+import { Modal } from '@terra-ui-packages/components';
 import { isToday } from 'date-fns';
 import { isAfter } from 'date-fns/fp';
 import _ from 'lodash/fp';
@@ -13,7 +14,6 @@ import { dataSyncingDocUrl } from 'src/analysis/utils/gce-machines';
 import { cloudProviders, getCurrentRuntime } from 'src/analysis/utils/runtime-utils';
 import { appTools, runtimeToolLabels } from 'src/analysis/utils/tool-utils';
 import { ButtonPrimary, Clickable, Link, spinnerOverlay } from 'src/components/common';
-import Modal from 'src/components/Modal';
 import { Ajax } from 'src/libs/ajax';
 import { App } from 'src/libs/ajax/leonardo/models/app-models';
 import { Runtime } from 'src/libs/ajax/leonardo/models/runtime-models';

--- a/src/analysis/AppLauncher.js
+++ b/src/analysis/AppLauncher.js
@@ -1,3 +1,4 @@
+import { Modal } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { Fragment, useEffect, useRef, useState } from 'react';
 import { div, h, iframe, p, strong } from 'react-hyperscript-helpers';
@@ -21,7 +22,6 @@ import {
 } from 'src/analysis/utils/tool-utils';
 import * as breadcrumbs from 'src/components/breadcrumbs';
 import { ButtonPrimary, ButtonSecondary, spinnerOverlay } from 'src/components/common';
-import Modal from 'src/components/Modal';
 import { Ajax } from 'src/libs/ajax';
 import { Metrics } from 'src/libs/ajax/Metrics';
 import { withErrorReporting, withErrorReportingInModal } from 'src/libs/error';

--- a/src/analysis/Environments/DeleteAppModal.ts
+++ b/src/analysis/Environments/DeleteAppModal.ts
@@ -1,10 +1,10 @@
+import { Modal } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { ReactNode, useState } from 'react';
 import { div, h, p, span } from 'react-hyperscript-helpers';
 import { SaveFilesHelpGalaxy } from 'src/analysis/runtime-common-components';
 import { appTools } from 'src/analysis/utils/tool-utils';
 import { LabeledCheckbox, spinnerOverlay } from 'src/components/common';
-import Modal from 'src/components/Modal';
 import { ListAppItem } from 'src/libs/ajax/leonardo/models/app-models';
 import { LeoAppProvider } from 'src/libs/ajax/leonardo/providers/LeoAppProvider';
 import { withErrorReportingInModal } from 'src/libs/error';

--- a/src/analysis/Environments/DeleteDiskModal.ts
+++ b/src/analysis/Environments/DeleteDiskModal.ts
@@ -1,3 +1,4 @@
+import { Modal } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { ReactNode, useState } from 'react';
 import { h, p, span } from 'react-hyperscript-helpers';
@@ -5,7 +6,6 @@ import { SaveFilesHelp } from 'src/analysis/runtime-common-components';
 import { getDiskAppType } from 'src/analysis/utils/app-utils';
 import { appTools } from 'src/analysis/utils/tool-utils';
 import { spinnerOverlay } from 'src/components/common';
-import Modal from 'src/components/Modal';
 import { withErrorReporting } from 'src/libs/error';
 import { withBusyState } from 'src/libs/utils';
 

--- a/src/analysis/Environments/DeleteRuntimeModal.ts
+++ b/src/analysis/Environments/DeleteRuntimeModal.ts
@@ -1,10 +1,10 @@
+import { Modal } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { ReactNode, useState } from 'react';
 import { div, h, p, span } from 'react-hyperscript-helpers';
 import { SaveFilesHelp, SaveFilesHelpAzure } from 'src/analysis/runtime-common-components';
 import { isGcpContext } from 'src/analysis/utils/runtime-utils';
 import { LabeledCheckbox, spinnerOverlay } from 'src/components/common';
-import Modal from 'src/components/Modal';
 import { isAzureConfig, isGceWithPdConfig } from 'src/libs/ajax/leonardo/models/runtime-config-models';
 import { ListRuntimeItem } from 'src/libs/ajax/leonardo/models/runtime-models';
 import { withErrorReporting } from 'src/libs/error';

--- a/src/analysis/modals/AnalysisDuplicator.ts
+++ b/src/analysis/modals/AnalysisDuplicator.ts
@@ -1,3 +1,4 @@
+import { Modal } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { Fragment, useState } from 'react';
 import { h } from 'react-hyperscript-helpers';
@@ -8,7 +9,6 @@ import { analysisNameInput, analysisNameValidator } from 'src/analysis/utils/not
 import { ToolLabel } from 'src/analysis/utils/tool-utils';
 import { ButtonPrimary } from 'src/components/common';
 import { centeredSpinner } from 'src/components/icons';
-import Modal from 'src/components/Modal';
 import { Ajax } from 'src/libs/ajax';
 import { withErrorReportingInModal } from 'src/libs/error';
 import Events, { extractCrossWorkspaceDetails, extractWorkspaceDetails } from 'src/libs/events';

--- a/src/analysis/modals/AppErrorModal.ts
+++ b/src/analysis/modals/AppErrorModal.ts
@@ -1,8 +1,8 @@
+import { Modal } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { useState } from 'react';
 import { div, h } from 'react-hyperscript-helpers';
 import { spinnerOverlay } from 'src/components/common';
-import Modal from 'src/components/Modal';
 import { ListAppItem } from 'src/libs/ajax/leonardo/models/app-models';
 import { LeoAppProvider } from 'src/libs/ajax/leonardo/providers/LeoAppProvider';
 import colors from 'src/libs/colors';

--- a/src/analysis/modals/ExportAnalysisModal/ExportAnalysisModal.ts
+++ b/src/analysis/modals/ExportAnalysisModal/ExportAnalysisModal.ts
@@ -1,4 +1,4 @@
-import { useUniqueId } from '@terra-ui-packages/components';
+import { Modal, useUniqueId } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { Fragment, useState } from 'react';
 import { b, h } from 'react-hyperscript-helpers';
@@ -9,7 +9,6 @@ import { analysisNameInput, analysisNameValidator } from 'src/analysis/utils/not
 import { ToolLabel } from 'src/analysis/utils/tool-utils';
 import { ButtonPrimary, spinnerOverlay } from 'src/components/common';
 import ErrorView from 'src/components/ErrorView';
-import Modal from 'src/components/Modal';
 import { FormLabel } from 'src/libs/forms';
 import { goToPath as navToPath } from 'src/libs/nav';
 import { summarizeErrors } from 'src/libs/utils';

--- a/src/analysis/utils/notebook-utils.js
+++ b/src/analysis/utils/notebook-utils.js
@@ -1,10 +1,10 @@
+import { Modal } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { Fragment, useState } from 'react';
 import { div, h } from 'react-hyperscript-helpers';
 import { addExtensionToNotebook } from 'src/analysis/utils/file-utils';
 import { ButtonPrimary, IdContainer, Select, spinnerOverlay } from 'src/components/common';
 import { ValidatedInput } from 'src/components/input';
-import Modal from 'src/components/Modal';
 import { Ajax } from 'src/libs/ajax';
 import { reportError } from 'src/libs/error';
 import { FormLabel } from 'src/libs/forms';

--- a/src/billing/List/GCPNewBillingProjectModal.ts
+++ b/src/billing/List/GCPNewBillingProjectModal.ts
@@ -1,3 +1,4 @@
+import { Modal } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { Fragment, useState } from 'react';
 import { div, h, span } from 'react-hyperscript-helpers';
@@ -6,7 +7,6 @@ import { billingProjectNameValidator } from 'src/billing/utils';
 import { GoogleBillingAccount } from 'src/billing-core/models';
 import { ButtonPrimary, Link, spinnerOverlay } from 'src/components/common';
 import { icon } from 'src/components/icons';
-import Modal from 'src/components/Modal';
 import { Ajax } from 'src/libs/ajax';
 import colors from 'src/libs/colors';
 import { reportErrorAndRethrow } from 'src/libs/error';

--- a/src/billing/Project.js
+++ b/src/billing/Project.js
@@ -1,3 +1,4 @@
+import { Modal } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import * as qs from 'qs';
 import { Fragment, useEffect, useMemo, useState } from 'react';
@@ -13,7 +14,6 @@ import { icon } from 'src/components/icons';
 import { InfoBox } from 'src/components/InfoBox';
 import { TextInput } from 'src/components/input';
 import { MenuButton } from 'src/components/MenuButton';
-import Modal from 'src/components/Modal';
 import { MenuTrigger } from 'src/components/PopupTrigger';
 import { SimpleTabBar } from 'src/components/tabBars';
 import { ariaSort, HeaderRenderer } from 'src/components/table';

--- a/src/components/CookieRejectModal.js
+++ b/src/components/CookieRejectModal.js
@@ -1,6 +1,6 @@
+import { Modal } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { h } from 'react-hyperscript-helpers';
-import Modal from 'src/components/Modal';
 import { useStore } from 'src/libs/react-utils';
 import { authStore } from 'src/libs/state';
 

--- a/src/components/FeaturePreviewFeedbackModal.js
+++ b/src/components/FeaturePreviewFeedbackModal.js
@@ -1,9 +1,9 @@
+import { Modal } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { Fragment, useState } from 'react';
 import { div, h } from 'react-hyperscript-helpers';
 import { ButtonPrimary, IdContainer, spinnerOverlay } from 'src/components/common';
 import { TextArea, TextInput } from 'src/components/input';
-import Modal from 'src/components/Modal';
 import { Ajax } from 'src/libs/ajax';
 import { withErrorIgnoring } from 'src/libs/error';
 import { FormLabel } from 'src/libs/forms';

--- a/src/components/IGVAddTrackModal.js
+++ b/src/components/IGVAddTrackModal.js
@@ -1,10 +1,10 @@
+import { Modal } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { Fragment, useState } from 'react';
 import { form, h, label } from 'react-hyperscript-helpers';
 import { ButtonPrimary, IdContainer } from 'src/components/common';
 import { parseGsUri } from 'src/components/data/data-utils';
 import { TextInput, ValidatedInput } from 'src/components/input';
-import Modal from 'src/components/Modal';
 import * as Utils from 'src/libs/utils';
 
 const IGVAddTrackModal = ({ onDismiss, onSubmitTrack }) => {

--- a/src/components/IdleStatusMonitor.js
+++ b/src/components/IdleStatusMonitor.js
@@ -1,10 +1,10 @@
+import { Modal } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import * as qs from 'qs';
 import { useEffect, useState } from 'react';
 import { div, h, iframe } from 'react-hyperscript-helpers';
 import { signOut } from 'src/auth/auth';
 import ButtonBar from 'src/components/ButtonBar';
-import Modal from 'src/components/Modal';
 import colors from 'src/libs/colors';
 import * as Nav from 'src/libs/nav';
 import { useCurrentTime, useOnMount, useStore } from 'src/libs/react-utils';

--- a/src/components/LeaveResourceModal.js
+++ b/src/components/LeaveResourceModal.js
@@ -1,8 +1,8 @@
+import { Modal } from '@terra-ui-packages/components';
 import { useState } from 'react';
 import { div, h, span } from 'react-hyperscript-helpers';
 import { ButtonPrimary, spinnerOverlay } from 'src/components/common';
 import { icon } from 'src/components/icons';
-import Modal from 'src/components/Modal';
 import { Ajax } from 'src/libs/ajax';
 import colors from 'src/libs/colors';
 import { reportError } from 'src/libs/error';

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -1,5 +1,0 @@
-import { Modal } from '@terra-ui-packages/components';
-
-export { modalStyles } from '@terra-ui-packages/components';
-
-export default Modal;

--- a/src/components/NameModal.js
+++ b/src/components/NameModal.js
@@ -1,9 +1,9 @@
+import { Modal } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { Fragment, useEffect, useState } from 'react';
 import { h } from 'react-hyperscript-helpers';
 import { ButtonPrimary, IdContainer } from 'src/components/common';
 import { ValidatedInput } from 'src/components/input';
-import Modal from 'src/components/Modal';
 import { FormLabel } from 'src/libs/forms';
 
 export const NameModal = ({ onSuccess, onDismiss, thing, value, validator = null, validationMessage = 'Invalid input' }) => {

--- a/src/components/ProgressBar.js
+++ b/src/components/ProgressBar.js
@@ -1,9 +1,9 @@
+import { Modal } from '@terra-ui-packages/components';
 import filesize from 'filesize';
 import _ from 'lodash/fp';
 import { Fragment } from 'react';
 import { dd, div, dl, dt, h, p, strong } from 'react-hyperscript-helpers';
 import { ButtonPrimary } from 'src/components/common';
-import Modal from 'src/components/Modal';
 import colors from 'src/libs/colors';
 
 export const ProgressBar = ({ max, now }) => {

--- a/src/components/RequesterPaysModal.js
+++ b/src/components/RequesterPaysModal.js
@@ -1,9 +1,9 @@
+import { Modal } from '@terra-ui-packages/components';
 import * as _ from 'lodash/fp';
 import { Fragment, useState } from 'react';
 import { div, h } from 'react-hyperscript-helpers';
 import { ButtonPrimary, IdContainer, Link, spinnerOverlay, VirtualizedSelect } from 'src/components/common';
 import { icon } from 'src/components/icons';
-import Modal from 'src/components/Modal';
 import { FormLabel } from 'src/libs/forms';
 import * as Nav from 'src/libs/nav';
 import { requesterPaysProjectStore } from 'src/libs/state';

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -1,4 +1,4 @@
-import { FocusTrap } from '@terra-ui-packages/components';
+import { FocusTrap, Modal } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { Fragment, useRef, useState } from 'react';
 import { UnmountClosed as RCollapse } from 'react-collapse';
@@ -10,7 +10,6 @@ import { signIn, signOut } from 'src/auth/auth';
 import { Clickable, IdContainer, LabeledCheckbox, Link, spinnerOverlay } from 'src/components/common';
 import { icon } from 'src/components/icons';
 import { TextArea } from 'src/components/input';
-import Modal from 'src/components/Modal';
 import ProfilePicture from 'src/components/ProfilePicture';
 import { SkipNavLink, SkipNavTarget } from 'src/components/skipNavLink';
 import fcIconWhite from 'src/images/brands/firecloud/FireCloud-icon-white.svg';

--- a/src/components/common/DeleteConfirmationModal.js
+++ b/src/components/common/DeleteConfirmationModal.js
@@ -1,10 +1,9 @@
-import { ButtonPrimary } from '@terra-ui-packages/components';
+import { ButtonPrimary, Modal } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { Fragment, useState } from 'react';
 import { b, div, h, label, span } from 'react-hyperscript-helpers';
 import { icon } from 'src/components/icons';
 import { TextInput } from 'src/components/input';
-import Modal from 'src/components/Modal';
 import colors from 'src/libs/colors';
 
 import { IdContainer } from './IdContainer';

--- a/src/components/file-browser/FileBrowser.ts
+++ b/src/components/file-browser/FileBrowser.ts
@@ -1,3 +1,4 @@
+import { Modal } from '@terra-ui-packages/components';
 import { subscribable } from '@terra-ui-packages/core-utils';
 import { Fragment, useCallback, useEffect, useState } from 'react';
 import { div, h } from 'react-hyperscript-helpers';
@@ -6,7 +7,6 @@ import { basename, dirname } from 'src/components/file-browser/file-browser-util
 import { FileDetails } from 'src/components/file-browser/FileDetails';
 import FilesInDirectory from 'src/components/file-browser/FilesInDirectory';
 import PathBreadcrumbs from 'src/components/file-browser/PathBreadcrumbs';
-import Modal from 'src/components/Modal';
 import RequesterPaysModal from 'src/components/RequesterPaysModal';
 import FileBrowserProvider, {
   FileBrowserDirectory,

--- a/src/components/group-common.js
+++ b/src/components/group-common.js
@@ -1,4 +1,4 @@
-import { TooltipTrigger } from '@terra-ui-packages/components';
+import { Modal, TooltipTrigger } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { Fragment, useState } from 'react';
 import { b, div, h, label } from 'react-hyperscript-helpers';
@@ -7,7 +7,6 @@ import { icon } from 'src/components/icons';
 import { InfoBox } from 'src/components/InfoBox';
 import { AutocompleteTextInput } from 'src/components/input';
 import { MenuButton } from 'src/components/MenuButton';
-import Modal from 'src/components/Modal';
 import { makeMenuIcon, MenuTrigger } from 'src/components/PopupTrigger';
 import { ariaSort, HeaderRenderer } from 'src/components/table';
 import { Ajax } from 'src/libs/ajax';

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -1,4 +1,4 @@
-import { Interactive, TooltipTrigger } from '@terra-ui-packages/components';
+import { Interactive, Modal, TooltipTrigger } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import PropTypes from 'prop-types';
 import { Fragment, useImperativeHandle, useRef, useState } from 'react';
@@ -9,7 +9,6 @@ import { defaultCellRangeRenderer, Grid as RVGrid, ScrollSync as RVScrollSync } 
 import { ColumnSettingsList } from 'src/components/ColumnSettingsList';
 import { ButtonPrimary, Clickable, IdContainer, Link } from 'src/components/common';
 import { icon } from 'src/components/icons';
-import Modal from 'src/components/Modal';
 import colors from 'src/libs/colors';
 import { forwardRefWithName, useOnMount } from 'src/libs/react-utils';
 import * as Style from 'src/libs/style';

--- a/src/components/useModalHandler.test.ts
+++ b/src/components/useModalHandler.test.ts
@@ -1,9 +1,9 @@
+import { Modal } from '@terra-ui-packages/components';
 import { fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ReactNode } from 'react';
 import { div, h, span } from 'react-hyperscript-helpers';
 import { ButtonPrimary } from 'src/components/common';
-import Modal from 'src/components/Modal';
 import { useModalHandler } from 'src/components/useModalHandler';
 import { renderWithAppContexts as render } from 'src/testing/test-utils';
 

--- a/src/data-catalog/DataBrowserDetails.ts
+++ b/src/data-catalog/DataBrowserDetails.ts
@@ -1,4 +1,4 @@
-import { Spinner } from '@terra-ui-packages/components';
+import { Modal, Spinner } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import qs from 'qs';
 import { CSSProperties, Fragment, useState } from 'react';
@@ -9,7 +9,6 @@ import FooterWrapper from 'src/components/FooterWrapper';
 import { centeredSpinner, icon } from 'src/components/icons';
 import { libraryTopMatter } from 'src/components/library-common';
 import { MarkdownViewer } from 'src/components/markdown';
-import Modal from 'src/components/Modal';
 import { ReactComponent as AzureLogo } from 'src/images/azure.svg';
 import { ReactComponent as GcpLogo } from 'src/images/gcp.svg';
 import { Ajax } from 'src/libs/ajax';

--- a/src/dataset-builder/DatasetBuilder.ts
+++ b/src/dataset-builder/DatasetBuilder.ts
@@ -1,4 +1,4 @@
-import { Clickable, Spinner } from '@terra-ui-packages/components';
+import { Clickable, Modal, Spinner } from '@terra-ui-packages/components';
 import * as _ from 'lodash/fp';
 import React, { Fragment, ReactElement, useEffect, useMemo, useState } from 'react';
 import { div, h, h2, h3, label, li, ul } from 'react-hyperscript-helpers';
@@ -8,7 +8,6 @@ import FooterWrapper from 'src/components/FooterWrapper';
 import { icon } from 'src/components/icons';
 import { ValidatedInput, ValidatedTextArea } from 'src/components/input';
 import { MenuButton } from 'src/components/MenuButton';
-import Modal from 'src/components/Modal';
 import { makeMenuIcon, MenuTrigger } from 'src/components/PopupTrigger';
 import TopBar from 'src/components/TopBar';
 import { StringInput } from 'src/data-catalog/create-dataset/CreateDatasetInputs';

--- a/src/pages/groups/List.js
+++ b/src/pages/groups/List.js
@@ -1,3 +1,4 @@
+import { Modal } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { Fragment, useEffect, useState } from 'react';
 import { a, div, h, h2 } from 'react-hyperscript-helpers';
@@ -8,7 +9,6 @@ import { AdminNotifierCheckbox } from 'src/components/group-common';
 import { icon } from 'src/components/icons';
 import { DelayedSearchInput, ValidatedInput } from 'src/components/input';
 import LeaveResourceModal from 'src/components/LeaveResourceModal';
-import Modal from 'src/components/Modal';
 import { PageBox, PageBoxVariants } from 'src/components/PageBox';
 import { ariaSort, HeaderRenderer } from 'src/components/table';
 import TopBar from 'src/components/TopBar';

--- a/src/pages/library/Datasets.js
+++ b/src/pages/library/Datasets.js
@@ -1,10 +1,9 @@
-import { TooltipTrigger } from '@terra-ui-packages/components';
+import { Modal, TooltipTrigger } from '@terra-ui-packages/components';
 import { Fragment, useState } from 'react';
 import { b, div, h, img, p, span } from 'react-hyperscript-helpers';
 import { ButtonPrimary, Link } from 'src/components/common';
 import FooterWrapper from 'src/components/FooterWrapper';
 import { libraryTopMatter } from 'src/components/library-common';
-import Modal from 'src/components/Modal';
 import { Browser } from 'src/data-catalog/DataBrowser';
 import thousandGenomesAnvil from 'src/images/library/datasets/1000Genome-Anvil-logo.png';
 import thousandGenomesLogo from 'src/images/library/datasets/1000Genome-logo.png';

--- a/src/pages/library/SearchAndFilterComponent.ts
+++ b/src/pages/library/SearchAndFilterComponent.ts
@@ -1,4 +1,4 @@
-import { useUniqueId } from '@terra-ui-packages/components';
+import { Modal, useUniqueId } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import pluralize from 'pluralize';
 import * as qs from 'qs';
@@ -8,7 +8,6 @@ import Collapse from 'src/components/Collapse';
 import { ButtonPrimary, Clickable, IdContainer, LabeledCheckbox, Link, Select } from 'src/components/common';
 import { icon } from 'src/components/icons';
 import { DelayedAutoCompleteInput, DelayedSearchInput } from 'src/components/input';
-import Modal from 'src/components/Modal';
 import { Ajax } from 'src/libs/ajax';
 import colors from 'src/libs/colors';
 import Events from 'src/libs/events';

--- a/src/pages/workspaces/workspace/JobHistory.js
+++ b/src/pages/workspaces/workspace/JobHistory.js
@@ -1,4 +1,4 @@
-import { TooltipTrigger } from '@terra-ui-packages/components';
+import { Modal, TooltipTrigger } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { Fragment, useImperativeHandle, useRef, useState } from 'react';
 import { div, h, span, table, tbody, td, tr } from 'react-hyperscript-helpers';
@@ -10,7 +10,6 @@ import { icon } from 'src/components/icons';
 import { DelayedSearchInput } from 'src/components/input';
 import { collapseStatus, statusType } from 'src/components/job-common';
 import { MenuButton } from 'src/components/MenuButton';
-import Modal from 'src/components/Modal';
 import { MenuTrigger } from 'src/components/PopupTrigger';
 import { FlexTable, HeaderRenderer, TextCell, TooltipCell } from 'src/components/table';
 import { Ajax } from 'src/libs/ajax';

--- a/src/pages/workspaces/workspace/Workflows.js
+++ b/src/pages/workspaces/workspace/Workflows.js
@@ -1,3 +1,4 @@
+import { Modal } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { Fragment, useEffect, useImperativeHandle, useState } from 'react';
 import { a, div, h, label, span } from 'react-hyperscript-helpers';
@@ -8,7 +9,6 @@ import { centeredSpinner, icon } from 'src/components/icons';
 import { DelayedSearchInput } from 'src/components/input';
 import { MarkdownViewer } from 'src/components/markdown';
 import { MenuButton } from 'src/components/MenuButton';
-import Modal from 'src/components/Modal';
 import { PageBox } from 'src/components/PageBox';
 import { makeMenuIcon, MenuTrigger } from 'src/components/PopupTrigger';
 import { Ajax } from 'src/libs/ajax';

--- a/src/pages/workspaces/workspace/jobHistory/CallCacheWizard.js
+++ b/src/pages/workspaces/workspace/jobHistory/CallCacheWizard.js
@@ -1,4 +1,5 @@
 import ReactJson from '@microlink/react-json-view';
+import { Modal } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { Fragment, useState } from 'react';
 import { div, h, hr, label } from 'react-hyperscript-helpers';
@@ -7,7 +8,6 @@ import ErrorView from 'src/components/ErrorView';
 import { icon } from 'src/components/icons';
 import { TextInput } from 'src/components/input';
 import { breadcrumbHistoryCaret } from 'src/components/job-common';
-import Modal from 'src/components/Modal';
 import colors from 'src/libs/colors';
 import * as Style from 'src/libs/style';
 import * as Utils from 'src/libs/utils';

--- a/src/pages/workspaces/workspace/jobHistory/FailuresViewer.js
+++ b/src/pages/workspaces/workspace/jobHistory/FailuresViewer.js
@@ -1,7 +1,7 @@
 import ReactJson from '@microlink/react-json-view';
+import { Modal } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { h } from 'react-hyperscript-helpers';
-import Modal from 'src/components/Modal';
 
 export const FailuresViewer = ({ failures }) => {
   const restructureFailures = (failuresArray) => {

--- a/src/pages/workspaces/workspace/jobHistory/UpdateUserCommentModal.js
+++ b/src/pages/workspaces/workspace/jobHistory/UpdateUserCommentModal.js
@@ -1,9 +1,9 @@
+import { Modal } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { useState } from 'react';
 import { h } from 'react-hyperscript-helpers';
 import { ButtonPrimary } from 'src/components/common';
 import { ValidatedTextArea } from 'src/components/input';
-import Modal from 'src/components/Modal';
 import { Ajax } from 'src/libs/ajax';
 
 /**

--- a/src/pages/workspaces/workspace/workflows/DataStepContent.js
+++ b/src/pages/workspaces/workspace/workflows/DataStepContent.js
@@ -1,3 +1,4 @@
+import { Modal } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import pluralize from 'pluralize';
 import PropTypes from 'prop-types';
@@ -6,7 +7,6 @@ import { div, h } from 'react-hyperscript-helpers';
 import { ButtonPrimary, ButtonSecondary, IdContainer, RadioButton } from 'src/components/common';
 import { icon } from 'src/components/icons';
 import { ValidatedInput } from 'src/components/input';
-import Modal from 'src/components/Modal';
 import { EntityServiceDataTableProvider } from 'src/libs/ajax/data-table-providers/EntityServiceDataTableProvider';
 import { FormLabel } from 'src/libs/forms';
 import * as Style from 'src/libs/style';

--- a/src/pages/workspaces/workspace/workflows/ExportWorkflowModal.js
+++ b/src/pages/workspaces/workspace/workflows/ExportWorkflowModal.js
@@ -1,10 +1,10 @@
+import { Modal } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { Fragment, useState } from 'react';
 import { b, h } from 'react-hyperscript-helpers';
 import { ButtonPrimary, IdContainer, spinnerOverlay } from 'src/components/common';
 import ErrorView from 'src/components/ErrorView';
 import { ValidatedInput } from 'src/components/input';
-import Modal from 'src/components/Modal';
 import { Ajax } from 'src/libs/ajax';
 import { FormLabel } from 'src/libs/forms';
 import * as Nav from 'src/libs/nav';

--- a/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
+++ b/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
@@ -1,4 +1,4 @@
-import { Spinner } from '@terra-ui-packages/components';
+import { Modal, Spinner } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { Fragment, useState } from 'react';
 import { b, div, h, label, p, span } from 'react-hyperscript-helpers';
@@ -6,7 +6,6 @@ import { ButtonPrimary, IdContainer, Link } from 'src/components/common';
 import { icon } from 'src/components/icons';
 import { InfoBox } from 'src/components/InfoBox';
 import { ValidatedTextArea } from 'src/components/input';
-import Modal from 'src/components/Modal';
 import { getRegionInfo } from 'src/components/region-common';
 import { Ajax } from 'src/libs/ajax';
 import { launch } from 'src/libs/analysis';

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -1,4 +1,4 @@
-import { TooltipTrigger } from '@terra-ui-packages/components';
+import { Modal, TooltipTrigger } from '@terra-ui-packages/components';
 import { readFileAsText } from '@terra-ui-packages/core-utils';
 import _ from 'lodash/fp';
 import { Component, Fragment, useEffect, useState } from 'react';
@@ -22,7 +22,6 @@ import { InfoBox } from 'src/components/InfoBox';
 import { DelayedAutocompleteTextArea, DelayedSearchInput, NumberInput, TextInput } from 'src/components/input';
 import { MarkdownViewer } from 'src/components/markdown';
 import { MenuButton } from 'src/components/MenuButton';
-import Modal from 'src/components/Modal';
 import { makeMenuIcon, MenuTrigger } from 'src/components/PopupTrigger';
 import StepButtons from 'src/components/StepButtons';
 import { HeaderCell, SimpleFlexTable, SimpleTable, Sortable, TextCell } from 'src/components/table';

--- a/src/profile/external-identities/NihAccount.ts
+++ b/src/profile/external-identities/NihAccount.ts
@@ -1,11 +1,10 @@
-import { icon } from '@terra-ui-packages/components';
+import { icon, Modal } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { Fragment, useState } from 'react';
 import { div, h, h3, span } from 'react-hyperscript-helpers';
 import Collapse from 'src/components/Collapse';
 import { ButtonPrimary, Link, spinnerOverlay } from 'src/components/common';
 import { InfoBox } from 'src/components/InfoBox';
-import Modal from 'src/components/Modal';
 import { Ajax } from 'src/libs/ajax';
 import { NihDatasetPermission } from 'src/libs/ajax/User';
 import { withErrorReporting } from 'src/libs/error';

--- a/src/profile/external-identities/UnlinkFenceAccount.ts
+++ b/src/profile/external-identities/UnlinkFenceAccount.ts
@@ -1,9 +1,8 @@
-import { ClickableProps } from '@terra-ui-packages/components';
+import { ClickableProps, Modal } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { useState } from 'react';
 import { div, h } from 'react-hyperscript-helpers';
 import { ButtonPrimary, Link, spinnerOverlay } from 'src/components/common';
-import Modal from 'src/components/Modal';
 import { Ajax } from 'src/libs/ajax';
 import { withErrorReporting } from 'src/libs/error';
 import { notify } from 'src/libs/notifications';

--- a/src/workflows-app/components/FilterableWorkflowTable.ts
+++ b/src/workflows-app/components/FilterableWorkflowTable.ts
@@ -1,3 +1,4 @@
+import { Modal } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { useCallback, useMemo, useState } from 'react';
 import { div, h, h3, span } from 'react-hyperscript-helpers';
@@ -5,7 +6,6 @@ import { AutoSizer } from 'react-virtualized';
 import { ClipboardButton } from 'src/components/ClipboardButton';
 import { ButtonPrimary, Link, Select } from 'src/components/common';
 import { icon } from 'src/components/icons';
-import Modal from 'src/components/Modal';
 import { FlexTable, paginator, Sortable, tableHeight, TextCell } from 'src/components/table';
 import colors from 'src/libs/colors';
 import * as Nav from 'src/libs/nav';

--- a/src/workflows-app/components/ImportWorkflowModal.ts
+++ b/src/workflows-app/components/ImportWorkflowModal.ts
@@ -1,9 +1,9 @@
+import { Modal } from '@terra-ui-packages/components';
 import { CSSProperties } from 'react';
 import { div, h } from 'react-hyperscript-helpers';
 import { ButtonPrimary, ButtonSecondary, Link } from 'src/components/common';
 import { styles as errorStyles } from 'src/components/ErrorView';
 import { centeredSpinner, icon } from 'src/components/icons';
-import Modal from 'src/components/Modal';
 import colors from 'src/libs/colors';
 import * as Nav from 'src/libs/nav';
 import * as Utils from 'src/libs/utils';

--- a/src/workflows-app/components/InputOutputModal.js
+++ b/src/workflows-app/components/InputOutputModal.js
@@ -1,9 +1,9 @@
+import { Modal } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { div, h, span } from 'react-hyperscript-helpers';
 import { AutoSizer } from 'react-virtualized';
 import { Link } from 'src/components/common';
 import { centeredSpinner, icon } from 'src/components/icons';
-import Modal from 'src/components/Modal';
 import { FlexTable, HeaderCell, tableHeight } from 'src/components/table';
 import { getConfig } from 'src/libs/config';
 import { newTabLinkProps } from 'src/libs/utils';

--- a/src/workflows-app/components/LogViewer.ts
+++ b/src/workflows-app/components/LogViewer.ts
@@ -1,10 +1,10 @@
+import { Modal } from '@terra-ui-packages/components';
 import { LoadedState } from '@terra-ui-packages/core-utils';
 import _ from 'lodash/fp';
 import { useCallback, useEffect, useState } from 'react';
 import { div, h, span } from 'react-hyperscript-helpers';
 import { ButtonOutline } from 'src/components/common';
 import { centeredSpinner, icon } from 'src/components/icons';
-import Modal from 'src/components/Modal';
 import { Ajax } from 'src/libs/ajax';
 import { useCancellation } from 'src/libs/react-utils';
 import { newTabLinkProps } from 'src/libs/utils';

--- a/src/workflows-app/components/StructBuilder.ts
+++ b/src/workflows-app/components/StructBuilder.ts
@@ -1,9 +1,9 @@
+import { Modal } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { Dispatch, SetStateAction, useState } from 'react';
 import { div, h } from 'react-hyperscript-helpers';
 import { AutoSizer } from 'react-virtualized';
 import { ButtonPrimary, Link } from 'src/components/common';
-import Modal from 'src/components/Modal';
 import { HeaderCell, SimpleFlexTable, TextCell } from 'src/components/table';
 import { AttributeSchema } from 'src/libs/ajax/data-table-providers/WdsDataTableProvider';
 import * as Utils from 'src/libs/utils';

--- a/src/workflows-app/components/SubmitWorkflowModal.ts
+++ b/src/workflows-app/components/SubmitWorkflowModal.ts
@@ -1,4 +1,4 @@
-import { Spinner } from '@terra-ui-packages/components';
+import { Modal, Spinner } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { CSSProperties, Fragment, useState } from 'react';
 import { div, h, span } from 'react-hyperscript-helpers';
@@ -8,7 +8,6 @@ import { ButtonPrimary } from 'src/components/common';
 import { styles as errorStyles } from 'src/components/ErrorView';
 import { icon } from 'src/components/icons';
 import { TextArea, TextInput } from 'src/components/input';
-import Modal from 'src/components/Modal';
 import { TextCell } from 'src/components/table';
 import { Ajax } from 'src/libs/ajax';
 import { RecordResponse } from 'src/libs/ajax/data-table-providers/WdsDataTableProvider';

--- a/src/workflows-app/components/ViewWorkflowScriptModal.js
+++ b/src/workflows-app/components/ViewWorkflowScriptModal.js
@@ -1,5 +1,5 @@
+import { Modal } from '@terra-ui-packages/components';
 import { h } from 'react-hyperscript-helpers';
-import Modal from 'src/components/Modal';
 import WDLViewer from 'src/components/WDLViewer';
 
 const ViewWorkflowScriptModal = ({ workflowScript, onDismiss }) => {

--- a/src/workspace-data/data-table/entity-service/AddColumnModal.js
+++ b/src/workspace-data/data-table/entity-service/AddColumnModal.js
@@ -1,10 +1,10 @@
+import { Modal } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { Fragment, useState } from 'react';
 import { div, h, label, p, span } from 'react-hyperscript-helpers';
 import { ButtonPrimary, IdContainer, spinnerOverlay } from 'src/components/common';
 import { icon } from 'src/components/icons';
 import { TextInput } from 'src/components/input';
-import Modal from 'src/components/Modal';
 import { Ajax } from 'src/libs/ajax';
 import colors from 'src/libs/colors';
 import { reportError } from 'src/libs/error';

--- a/src/workspace-data/data-table/entity-service/AddEntityModal.js
+++ b/src/workspace-data/data-table/entity-service/AddEntityModal.js
@@ -1,10 +1,10 @@
+import { Modal } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { useState } from 'react';
 import { div, h, label, li, p, ul } from 'react-hyperscript-helpers';
 import Collapse from 'src/components/Collapse';
 import { ButtonPrimary, spinnerOverlay } from 'src/components/common';
 import { ValidatedInput } from 'src/components/input';
-import Modal from 'src/components/Modal';
 import { Ajax } from 'src/libs/ajax';
 import colors from 'src/libs/colors';
 import { reportError } from 'src/libs/error';

--- a/src/workspace-data/data-table/entity-service/CreateEntitySetModal.js
+++ b/src/workspace-data/data-table/entity-service/CreateEntitySetModal.js
@@ -1,10 +1,10 @@
+import { Modal } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { Fragment, useState } from 'react';
 import { div, h, label } from 'react-hyperscript-helpers';
 import { ButtonPrimary, IdContainer, spinnerOverlay } from 'src/components/common';
 import { icon } from 'src/components/icons';
 import { TextInput } from 'src/components/input';
-import Modal from 'src/components/Modal';
 import { Ajax } from 'src/libs/ajax';
 import colors from 'src/libs/colors';
 import { reportError } from 'src/libs/error';

--- a/src/workspace-data/data-table/entity-service/EntitiesContent.js
+++ b/src/workspace-data/data-table/entity-service/EntitiesContent.js
@@ -1,4 +1,4 @@
-import { Spinner } from '@terra-ui-packages/components';
+import { Modal, Spinner } from '@terra-ui-packages/components';
 import * as clipboard from 'clipboard-polyfill/text';
 import FileSaver from 'file-saver';
 import JSZip from 'jszip';
@@ -14,7 +14,6 @@ import { icon } from 'src/components/icons';
 import IGVBrowser from 'src/components/IGVBrowser';
 import IGVFileSelector from 'src/components/IGVFileSelector';
 import { MenuButton } from 'src/components/MenuButton';
-import Modal from 'src/components/Modal';
 import { withModalDrawer } from 'src/components/ModalDrawer';
 import { ModalToolButton } from 'src/components/ModalToolButton';
 import { MenuDivider, MenuTrigger } from 'src/components/PopupTrigger';

--- a/src/workspace-data/data-table/entity-service/EntityRenamer.js
+++ b/src/workspace-data/data-table/entity-service/EntityRenamer.js
@@ -1,9 +1,9 @@
+import { Modal } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { Fragment, useState } from 'react';
 import { h } from 'react-hyperscript-helpers';
 import { ButtonPrimary, IdContainer, spinnerOverlay } from 'src/components/common';
 import { ValidatedInput } from 'src/components/input';
-import Modal from 'src/components/Modal';
 import { Ajax } from 'src/libs/ajax';
 import { reportError } from 'src/libs/error';
 import { FormLabel } from 'src/libs/forms';

--- a/src/workspace-data/data-table/entity-service/ExportDataModal.js
+++ b/src/workspace-data/data-table/entity-service/ExportDataModal.js
@@ -1,9 +1,9 @@
+import { Modal } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { Fragment, useRef, useState } from 'react';
 import { b, div, h } from 'react-hyperscript-helpers';
 import { ButtonPrimary, spinnerOverlay } from 'src/components/common';
 import { icon } from 'src/components/icons';
-import Modal from 'src/components/Modal';
 import { Ajax } from 'src/libs/ajax';
 import colors from 'src/libs/colors';
 import { reportError } from 'src/libs/error';

--- a/src/workspace-data/data-table/entity-service/MultipleEntityEditor.js
+++ b/src/workspace-data/data-table/entity-service/MultipleEntityEditor.js
@@ -1,3 +1,4 @@
+import { Modal } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import pluralize from 'pluralize';
 import { Fragment, useState } from 'react';
@@ -5,7 +6,6 @@ import { div, fieldset, h, label, legend, p, span } from 'react-hyperscript-help
 import { ButtonOutline, ButtonPrimary, ButtonSecondary, IdContainer, RadioButton, spinnerOverlay } from 'src/components/common';
 import { icon } from 'src/components/icons';
 import { AutocompleteTextInput } from 'src/components/input';
-import Modal from 'src/components/Modal';
 import { Ajax } from 'src/libs/ajax';
 import colors from 'src/libs/colors';
 import { reportError } from 'src/libs/error';

--- a/src/workspace-data/data-table/entity-service/RenameTableModal.js
+++ b/src/workspace-data/data-table/entity-service/RenameTableModal.js
@@ -1,10 +1,10 @@
+import { Modal } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { Fragment, useState } from 'react';
 import { div, h } from 'react-hyperscript-helpers';
 import { ButtonPrimary, IdContainer, RadioButton, spinnerOverlay } from 'src/components/common';
 import { icon } from 'src/components/icons';
 import { ValidatedInput } from 'src/components/input';
-import Modal from 'src/components/Modal';
 import { Ajax } from 'src/libs/ajax';
 import colors from 'src/libs/colors';
 import { withErrorReporting } from 'src/libs/error';

--- a/src/workspace-data/data-table/entity-service/SingleEntityEditor.js
+++ b/src/workspace-data/data-table/entity-service/SingleEntityEditor.js
@@ -1,8 +1,8 @@
+import { Modal } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { Fragment, useState } from 'react';
 import { div, h, span } from 'react-hyperscript-helpers';
 import { ButtonOutline, ButtonPrimary, ButtonSecondary, spinnerOverlay } from 'src/components/common';
-import Modal from 'src/components/Modal';
 import { Ajax } from 'src/libs/ajax';
 import { reportError } from 'src/libs/error';
 

--- a/src/workspace-data/data-table/entity-service/SnapshotInfo.js
+++ b/src/workspace-data/data-table/entity-service/SnapshotInfo.js
@@ -1,3 +1,4 @@
+import { Modal } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { Fragment, useState } from 'react';
 import { b, div, h, p } from 'react-hyperscript-helpers';
@@ -6,7 +7,6 @@ import { ButtonPrimary, ButtonSecondary, IdContainer, Link, spinnerOverlay } fro
 import { icon } from 'src/components/icons';
 import { ValidatedInput } from 'src/components/input';
 import { MarkdownEditor, MarkdownViewer } from 'src/components/markdown';
-import Modal from 'src/components/Modal';
 import { Ajax } from 'src/libs/ajax';
 import { getConfig } from 'src/libs/config';
 import { reportError } from 'src/libs/error';

--- a/src/workspace-data/data-table/shared/DataTable.js
+++ b/src/workspace-data/data-table/shared/DataTable.js
@@ -1,3 +1,4 @@
+import { Modal } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { Fragment, useEffect, useRef, useState } from 'react';
 import { b, div, h, span } from 'react-hyperscript-helpers';
@@ -16,7 +17,6 @@ import {
 import { icon } from 'src/components/icons';
 import { ConfirmedSearchInput } from 'src/components/input';
 import { MenuButton } from 'src/components/MenuButton';
-import Modal from 'src/components/Modal';
 import { MenuTrigger } from 'src/components/PopupTrigger';
 import { GridTable, HeaderCell, paginator, Resizable, TooltipCell } from 'src/components/table';
 import { Ajax } from 'src/libs/ajax';

--- a/src/workspace-data/data-table/shared/EntityUploader.js
+++ b/src/workspace-data/data-table/shared/EntityUploader.js
@@ -1,4 +1,4 @@
-import { TooltipTrigger } from '@terra-ui-packages/components';
+import { Modal, TooltipTrigger } from '@terra-ui-packages/components';
 import { readFileAsText } from '@terra-ui-packages/core-utils';
 import _ from 'lodash/fp';
 import { Fragment, useState } from 'react';
@@ -8,7 +8,6 @@ import { ButtonPrimary, Clickable, LabeledCheckbox, Link, RadioButton } from 'sr
 import Dropzone from 'src/components/Dropzone';
 import { icon } from 'src/components/icons';
 import { PasteOnlyInput, ValidatedInput } from 'src/components/input';
-import Modal from 'src/components/Modal';
 import { getRegionInfo, locationTypes } from 'src/components/region-common';
 import { SimpleTabBar } from 'src/components/tabBars';
 import { Ajax } from 'src/libs/ajax';

--- a/src/workspace-data/data-table/shared/RenameColumnModal.ts
+++ b/src/workspace-data/data-table/shared/RenameColumnModal.ts
@@ -1,8 +1,8 @@
+import { Modal } from '@terra-ui-packages/components';
 import { Fragment, ReactNode, useState } from 'react';
 import { div, h } from 'react-hyperscript-helpers';
 import { ButtonPrimary, IdContainer, spinnerOverlay } from 'src/components/common';
 import { ValidatedInput } from 'src/components/input';
-import Modal from 'src/components/Modal';
 import { reportError } from 'src/libs/error';
 import { FormLabel } from 'src/libs/forms';
 import * as Utils from 'src/libs/utils';

--- a/src/workspace-data/data-table/uri-viewer/UriViewer.js
+++ b/src/workspace-data/data-table/uri-viewer/UriViewer.js
@@ -1,4 +1,4 @@
-import { Spinner } from '@terra-ui-packages/components';
+import { Modal, Spinner } from '@terra-ui-packages/components';
 import filesize from 'filesize';
 import _ from 'lodash/fp';
 import { Fragment, useState } from 'react';
@@ -9,7 +9,6 @@ import { ClipboardButton } from 'src/components/ClipboardButton';
 import Collapse from 'src/components/Collapse';
 import { Link } from 'src/components/common';
 import { parseGsUri } from 'src/components/data/data-utils';
-import Modal from 'src/components/Modal';
 import { Ajax } from 'src/libs/ajax';
 import colors from 'src/libs/colors';
 import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';

--- a/src/workspace-data/data-table/versioning/DataTableImportVersionModal.ts
+++ b/src/workspace-data/data-table/versioning/DataTableImportVersionModal.ts
@@ -1,7 +1,7 @@
+import { Modal } from '@terra-ui-packages/components';
 import { ReactNode } from 'react';
 import { h, span } from 'react-hyperscript-helpers';
 import { ButtonPrimary } from 'src/components/common';
-import Modal from 'src/components/Modal';
 
 import { tableNameForImport } from './data-table-versioning-utils';
 

--- a/src/workspace-data/data-table/versioning/DataTableSaveVersionModal.ts
+++ b/src/workspace-data/data-table/versioning/DataTableSaveVersionModal.ts
@@ -1,9 +1,9 @@
+import { Modal } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { Fragment, ReactNode, useState } from 'react';
 import { div, fieldset, h, legend } from 'react-hyperscript-helpers';
 import { ButtonPrimary, IdContainer, LabeledCheckbox } from 'src/components/common';
 import { TextInput } from 'src/components/input';
-import Modal from 'src/components/Modal';
 import { FormLabel } from 'src/libs/forms';
 
 interface DataTableSaveVersionModalProps {

--- a/src/workspace-data/data-table/wds/SingleEntityEditorWds.ts
+++ b/src/workspace-data/data-table/wds/SingleEntityEditorWds.ts
@@ -1,8 +1,8 @@
+import { Modal } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { Fragment, useState } from 'react';
 import { div, h } from 'react-hyperscript-helpers';
 import { ButtonPrimary, ButtonSecondary, spinnerOverlay } from 'src/components/common';
-import Modal from 'src/components/Modal';
 import { reportError } from 'src/libs/error';
 
 import { getAttributeType } from './attribute-utils';

--- a/src/workspace-data/data-table/wds/WdsTroubleshooter.ts
+++ b/src/workspace-data/data-table/wds/WdsTroubleshooter.ts
@@ -1,10 +1,10 @@
+import { Modal } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { ReactNode } from 'react';
 import { div, h, table, tbody, td, tr } from 'react-hyperscript-helpers';
 import { ClipboardButton } from 'src/components/ClipboardButton';
 import { ButtonPrimary, Link } from 'src/components/common';
 import { icon } from 'src/components/icons';
-import Modal from 'src/components/Modal';
 import colors from 'src/libs/colors';
 import * as Style from 'src/libs/style';
 import * as Utils from 'src/libs/utils';

--- a/src/workspace-data/reference-data/ReferenceDataImporter.js
+++ b/src/workspace-data/reference-data/ReferenceDataImporter.js
@@ -1,8 +1,8 @@
+import { Modal } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { useState } from 'react';
 import { h } from 'react-hyperscript-helpers';
 import { ButtonPrimary, Select, spinnerOverlay } from 'src/components/common';
-import Modal from 'src/components/Modal';
 import { Ajax } from 'src/libs/ajax';
 import { reportError } from 'src/libs/error';
 

--- a/src/workspaces/DeleteWorkspaceModal/DeleteWorkspaceModal.ts
+++ b/src/workspaces/DeleteWorkspaceModal/DeleteWorkspaceModal.ts
@@ -1,3 +1,4 @@
+import { Modal } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import pluralize from 'pluralize';
 import { useState } from 'react';
@@ -6,7 +7,6 @@ import { bucketBrowserUrl } from 'src/auth/auth';
 import { ButtonPrimary, Link, spinnerOverlay } from 'src/components/common';
 import { icon } from 'src/components/icons';
 import { TextInput } from 'src/components/input';
-import Modal from 'src/components/Modal';
 import colors from 'src/libs/colors';
 import { warningBoxStyle } from 'src/libs/style';
 import * as Utils from 'src/libs/utils';

--- a/src/workspaces/LockWorkspaceModal/LockWorkspaceModal.js
+++ b/src/workspaces/LockWorkspaceModal/LockWorkspaceModal.js
@@ -1,7 +1,7 @@
+import { Modal } from '@terra-ui-packages/components';
 import { useState } from 'react';
 import { div, h } from 'react-hyperscript-helpers';
 import { ButtonPrimary, spinnerOverlay } from 'src/components/common';
-import Modal from 'src/components/Modal';
 import { Ajax } from 'src/libs/ajax';
 import { withErrorReportingInModal } from 'src/libs/error';
 

--- a/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.ts
+++ b/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.ts
@@ -1,4 +1,4 @@
-import { TooltipTrigger } from '@terra-ui-packages/components';
+import { Modal, TooltipTrigger } from '@terra-ui-packages/components';
 import { delay } from '@terra-ui-packages/core-utils';
 import _ from 'lodash/fp';
 import { CSSProperties, Fragment, ReactNode, useState } from 'react';
@@ -19,7 +19,6 @@ import {
 import { icon } from 'src/components/icons';
 import { InfoBox } from 'src/components/InfoBox';
 import { TextArea, ValidatedInput } from 'src/components/input';
-import Modal from 'src/components/Modal';
 import {
   allRegions,
   availableBucketRegions,

--- a/src/workspaces/RequestAccessModal/RequestAccessModal.ts
+++ b/src/workspaces/RequestAccessModal/RequestAccessModal.ts
@@ -1,9 +1,9 @@
+import { Modal } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { ReactNode, useState } from 'react';
 import { div, h, p, span, table, tbody, td, th, thead, tr } from 'react-hyperscript-helpers';
 import { ButtonPrimary, Link } from 'src/components/common';
 import { centeredSpinner, icon } from 'src/components/icons';
-import Modal from 'src/components/Modal';
 import { Ajax } from 'src/libs/ajax';
 import { CurrentUserGroupMembership } from 'src/libs/ajax/Groups';
 import { withErrorReporting } from 'src/libs/error';

--- a/src/workspaces/ShareWorkspaceModal/ShareWorkspaceModal.ts
+++ b/src/workspaces/ShareWorkspaceModal/ShareWorkspaceModal.ts
@@ -1,11 +1,10 @@
-import { Switch, TooltipTrigger } from '@terra-ui-packages/components';
+import { Modal, modalStyles, Switch, TooltipTrigger } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import React, { useLayoutEffect, useRef, useState } from 'react';
 import { div, h, label, p, span } from 'react-hyperscript-helpers';
 import { ButtonPrimary, ButtonSecondary, IdContainer, spinnerOverlay } from 'src/components/common';
 import { centeredSpinner } from 'src/components/icons';
 import { AutocompleteTextInput } from 'src/components/input';
-import Modal, { modalStyles } from 'src/components/Modal';
 import { Ajax } from 'src/libs/ajax';
 import { CurrentUserGroupMembership } from 'src/libs/ajax/Groups';
 import { reportError } from 'src/libs/error';

--- a/src/workspaces/container/WorkspaceDeletingBanner.ts
+++ b/src/workspaces/container/WorkspaceDeletingBanner.ts
@@ -1,8 +1,7 @@
-import { icon, Link } from '@terra-ui-packages/components';
+import { icon, Link, Modal } from '@terra-ui-packages/components';
 import { Fragment, ReactNode, useState } from 'react';
 import { div, h, span } from 'react-hyperscript-helpers';
 import ErrorView from 'src/components/ErrorView';
-import Modal from 'src/components/Modal';
 import TitleBar from 'src/components/TitleBar';
 import colors from 'src/libs/colors';
 import { WorkspaceWrapper as Workspace } from 'src/workspaces/utils';

--- a/src/workspaces/list/RenderedWorkspaces.ts
+++ b/src/workspaces/list/RenderedWorkspaces.ts
@@ -1,4 +1,4 @@
-import { icon, TooltipTrigger } from '@terra-ui-packages/components';
+import { icon, Modal, TooltipTrigger } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { ReactNode, useContext, useState } from 'react';
 import { div, h, span } from 'react-hyperscript-helpers';
@@ -7,7 +7,6 @@ import { CloudProviderIcon } from 'src/components/CloudProviderIcon';
 import { Link } from 'src/components/common';
 import ErrorView from 'src/components/ErrorView';
 import { FirstParagraphMarkdownViewer } from 'src/components/markdown';
-import Modal from 'src/components/Modal';
 import { FlexTable, HeaderRenderer } from 'src/components/table';
 import { Ajax } from 'src/libs/ajax';
 import colors from 'src/libs/colors';

--- a/src/workspaces/migration/BillingProjectParent.ts
+++ b/src/workspaces/migration/BillingProjectParent.ts
@@ -1,3 +1,4 @@
+import { Modal } from '@terra-ui-packages/components';
 import { cond, DEFAULT } from '@terra-ui-packages/core-utils';
 import _ from 'lodash/fp';
 import pluralize from 'pluralize';
@@ -5,7 +6,6 @@ import { ReactNode, useState } from 'react';
 import { b, div, h, span } from 'react-hyperscript-helpers';
 import Collapse from 'src/components/Collapse';
 import { ButtonOutline, ButtonPrimary } from 'src/components/common';
-import Modal from 'src/components/Modal';
 import { Ajax } from 'src/libs/ajax';
 import colors from 'src/libs/colors';
 import { reportErrorAndRethrow } from 'src/libs/error';

--- a/src/workspaces/migration/WorkspaceItem.ts
+++ b/src/workspaces/migration/WorkspaceItem.ts
@@ -1,9 +1,9 @@
+import { Modal } from '@terra-ui-packages/components';
 import { ReactNode, useEffect, useState } from 'react';
 import { b, div, h, span } from 'react-hyperscript-helpers';
 import { ButtonOutline, ButtonPrimary } from 'src/components/common';
 import { icon } from 'src/components/icons';
 import { InfoBox } from 'src/components/InfoBox';
-import Modal from 'src/components/Modal';
 import { Ajax } from 'src/libs/ajax';
 import colors from 'src/libs/colors';
 import { reportErrorAndRethrow } from 'src/libs/error';


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/UIE-51

Continuing to clean up import paths for components that have been moved to the components package... This changes all imports of Modal to import from the components package and removes the re-export in src/components/Modal.

Used to the jscodeshift transformer added in #4683 to do this:
```
yarn run jscodeshift --transform=./scripts/replace-import.ts --extensions=js,ts --parser=ts src --originalImportPath=src/components/Modal --originalImportName=default --newImportPath='@terra-ui-packages/components' --newImportName=Modal
yarn run jscodeshift --transform=./scripts/replace-import.ts --extensions=jsx,tsx --parser=tsx src --originalImportPath=src/components/Modal --originalImportName=default --newImportPath='@terra-ui-packages/components' --newImportName=Modal

yarn run jscodeshift --transform=./scripts/replace-import.ts --extensions=js,ts --parser=ts src --originalImportPath=src/components/Modal --originalImportName=modalStyles --newImportPath='@terra-ui-packages/components' --newImportName=modalStyles
yarn run jscodeshift --transform=./scripts/replace-import.ts --extensions=jsx,tsx --parser=tsx src --originalImportPath=src/components/Modal --originalImportName=modalStyles --newImportPath='@terra-ui-packages/components' --newImportName=modalStyles

yarn run lint
```