### PR TITLE
[AJ-1659] Attempt to decrease run time of DataTable tests

### DIFF
--- a/src/workspace-data/data-table/shared/DataTable.js
+++ b/src/workspace-data/data-table/shared/DataTable.js
@@ -86,6 +86,7 @@ const displayData = ({ itemsType, items }) => {
 
 const DataTable = (props) => {
   const {
+    defaultItemsPerPage = 100,
     entityType,
     entityMetadata,
     setEntityMetadata,
@@ -122,7 +123,7 @@ const DataTable = (props) => {
   const [filteredCount, setFilteredCount] = useState(0);
   const [totalRowCount, setTotalRowCount] = useState(0);
 
-  const [itemsPerPage, setItemsPerPage] = useState(100);
+  const [itemsPerPage, setItemsPerPage] = useState(defaultItemsPerPage);
   const [pageNumber, setPageNumber] = useState(1);
   const [sort, setSort] = useState({ field: 'name', direction: 'asc' });
   const [activeTextFilter, setActiveTextFilter] = useState(activeCrossTableTextFilter || '');

--- a/src/workspace-data/data-table/shared/DataTable.test.ts
+++ b/src/workspace-data/data-table/shared/DataTable.test.ts
@@ -5,7 +5,7 @@ import _ from 'lodash/fp';
 import { useState } from 'react';
 import { h } from 'react-hyperscript-helpers';
 import { Ajax } from 'src/libs/ajax';
-import { DataTableProvider } from 'src/libs/ajax/data-table-providers/DataTableProvider';
+import { EntityServiceDataTableProvider } from 'src/libs/ajax/data-table-providers/EntityServiceDataTableProvider';
 import { asMockedFn, renderWithAppContexts as render } from 'src/testing/test-utils';
 import { defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
 
@@ -25,10 +25,18 @@ jest.mock('react-notifications-component', (): DeepPartial<ReactNotificationsCom
   };
 });
 
+const entityType = 'sample';
 const entities = _.map(
   (n) => ({ entityType: 'sample', name: `sample_${n}`, attributes: { attr: n % 2 === 0 ? 'even' : 'odd' } }),
   _.range(0, 250)
 );
+const entityMetadata = {
+  sample: {
+    idName: 'sample_id',
+    attributeNames: [],
+    count: entities.length,
+  },
+};
 
 type ReactVirtualizedExports = typeof import('react-virtualized');
 jest.mock('react-virtualized', (): ReactVirtualizedExports => {
@@ -50,43 +58,7 @@ jest.mock('react-virtualized', (): ReactVirtualizedExports => {
   };
 });
 
-// Returns a filtered subset of |entities| if a filter is included - more than one page
-// Else 100-item pages depending on page number
-const getPage = jest
-  .fn()
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  .mockImplementation((signal, entityType, queryOptions: { pageNumber; columnFilter }, entityMetadata) => {
-    if (queryOptions.columnFilter) {
-      return Promise.resolve({
-        results: _.filter((s: { attributes: { attr: string } }) => s.attributes.attr === 'even', entities),
-        resultMetadata: { filteredCount: 125, unfilteredCount: 250, filteredPageCount: 2 },
-      });
-    }
-    if (!queryOptions.pageNumber || queryOptions.pageNumber === 1) {
-      return Promise.resolve({
-        results: entities.slice(0, 100),
-        resultMetadata: { filteredCount: 250, unfilteredCount: 250, filteredPageCount: 3 },
-      });
-    }
-    if (queryOptions.pageNumber === 2) {
-      return Promise.resolve({
-        results: entities.slice(100, 200),
-        resultMetadata: { filteredCount: 250, unfilteredCount: 250, filteredPageCount: 3 },
-      });
-    }
-    return Promise.resolve({
-      results: entities.slice(200),
-      resultMetadata: { filteredCount: 250, unfilteredCount: 250, filteredPageCount: 3 },
-    });
-  });
-
-const mockDataProvider: DeepPartial<DataTableProvider> = {
-  getPage,
-  features: {
-    supportsFiltering: true,
-    supportsRowSelection: true,
-  },
-};
+const mockDataProvider = new EntityServiceDataTableProvider('test-namespace', 'test-workspace');
 
 const EntitiesContentHarness = (props) => {
   const [selectedEntities, setSelectedEntities] = useState({});
@@ -101,15 +73,27 @@ const EntitiesContentHarness = (props) => {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const paginatedEntitiesOfType = jest.fn().mockImplementation((entityType, params) => {
-  if (params.columnFilter) {
-    return Promise.resolve({
-      results: _.filter((s: { attributes: { attr: string } }) => s.attributes.attr === 'even', entities),
-      resultMetadata: { filteredCount: 125, unfilteredCount: 250, filteredPageCount: 2 },
-    });
+  const { columnFilter, page = 1, pageSize } = params;
+
+  let results = entities;
+  let filteredCount = entities.length;
+
+  if (columnFilter) {
+    results = results.filter((e) => e.attributes.attr === 'even');
+    filteredCount = results.length;
   }
+
+  const offset = (page - 1) * pageSize;
+  const limit = pageSize;
+  results = results.slice(offset, offset + limit);
+
   return Promise.resolve({
-    results: entities,
-    resultMetadata: { filteredCount: 250, unfilteredCount: 250, filteredPageCount: 3 },
+    results,
+    resultMetadata: {
+      filteredCount,
+      unfilteredCount: entities.length,
+      filteredPageCount: Math.ceil(filteredCount / pageSize),
+    },
   });
 });
 
@@ -135,14 +119,8 @@ describe('DataTable', () => {
     await act(async () => {
       render(
         h(EntitiesContentHarness, {
-          entityType: 'sample',
-          entityMetadata: {
-            sample: {
-              idName: 'sample_id',
-              attributeNames: [],
-              count: 250,
-            },
-          },
+          entityType,
+          entityMetadata,
           setEntityMetadata: () => {},
           workspace: {
             ...defaultGoogleWorkspace,
@@ -208,14 +186,8 @@ describe('DataTable', () => {
     await act(async () => {
       render(
         h(EntitiesContentHarness, {
-          entityType: 'sample',
-          entityMetadata: {
-            sample: {
-              idName: 'sample_id',
-              attributeNames: [],
-              count: 250,
-            },
-          },
+          entityType,
+          entityMetadata,
           setEntityMetadata: () => {},
           workspace: {
             ...defaultGoogleWorkspace,
@@ -281,14 +253,8 @@ describe('DataTable', () => {
     await act(async () => {
       render(
         h(EntitiesContentHarness, {
-          entityType: 'sample',
-          entityMetadata: {
-            sample: {
-              idName: 'sample_id',
-              attributeNames: [],
-              count: 250,
-            },
-          },
+          entityType,
+          entityMetadata,
           setEntityMetadata: () => {},
           workspace: {
             ...defaultGoogleWorkspace,
@@ -355,14 +321,8 @@ describe('DataTable', () => {
     await act(async () => {
       render(
         h(EntitiesContentHarness, {
-          entityType: 'sample',
-          entityMetadata: {
-            sample: {
-              idName: 'sample_id',
-              attributeNames: [],
-              count: 250,
-            },
-          },
+          entityType,
+          entityMetadata,
           setEntityMetadata: () => {},
           workspace: {
             ...defaultGoogleWorkspace,
@@ -418,6 +378,6 @@ describe('DataTable', () => {
 
     // Should include all (filtered) entities + select all checkbox
     const allChecks = screen.getAllByRole('checkbox', { checked: true });
-    expect(allChecks.length).toEqual(126);
+    expect(allChecks.length).toEqual(101);
   }, 15000);
 });

--- a/src/workspace-data/data-table/shared/DataTable.test.ts
+++ b/src/workspace-data/data-table/shared/DataTable.test.ts
@@ -181,7 +181,7 @@ describe('DataTable', () => {
     // Get the checkboxes on this page
     const newPageChecks = screen.getAllByRole('checkbox', { checked: true });
     expect(newPageChecks.length).toEqual(11);
-  }, 20000);
+  });
 
   it('selects page', async () => {
     // Arrange
@@ -249,7 +249,7 @@ describe('DataTable', () => {
     // Get the checkboxes on this page
     const newPageChecks = screen.getAllByRole('checkbox', { checked: false });
     expect(newPageChecks.length).toEqual(11);
-  }, 10000);
+  });
 
   it('passes filters to getPaginatedEntities', async () => {
     // Arrange
@@ -318,7 +318,7 @@ describe('DataTable', () => {
       'sample',
       expect.objectContaining({ columnFilter: 'sample_id=even' })
     );
-  }, 13000);
+  });
 
   it('selects filtered', async () => {
     // Arrange
@@ -386,5 +386,5 @@ describe('DataTable', () => {
     // Should include all (filtered) entities + select all checkbox
     const allChecks = screen.getAllByRole('checkbox', { checked: true });
     expect(allChecks.length).toEqual(11);
-  }, 15000);
+  });
 });

--- a/src/workspace-data/data-table/shared/DataTable.test.ts
+++ b/src/workspace-data/data-table/shared/DataTable.test.ts
@@ -60,7 +60,10 @@ jest.mock('react-virtualized', (): ReactVirtualizedExports => {
 
 const mockDataProvider = new EntityServiceDataTableProvider('test-namespace', 'test-workspace');
 
-const EntitiesContentHarness = (props) => {
+/**
+ * TestHarness provides some of the same state management that EntitiesContent/WDSContent do in the app.
+ */
+const TestHarness = (props) => {
   const [selectedEntities, setSelectedEntities] = useState({});
   return h(DataTable, {
     ...props,
@@ -118,7 +121,7 @@ describe('DataTable', () => {
 
     await act(async () => {
       render(
-        h(EntitiesContentHarness, {
+        h(TestHarness, {
           entityType,
           entityMetadata,
           setEntityMetadata: () => {},
@@ -185,7 +188,7 @@ describe('DataTable', () => {
 
     await act(async () => {
       render(
-        h(EntitiesContentHarness, {
+        h(TestHarness, {
           entityType,
           entityMetadata,
           setEntityMetadata: () => {},
@@ -252,7 +255,7 @@ describe('DataTable', () => {
 
     await act(async () => {
       render(
-        h(EntitiesContentHarness, {
+        h(TestHarness, {
           entityType,
           entityMetadata,
           setEntityMetadata: () => {},
@@ -320,7 +323,7 @@ describe('DataTable', () => {
 
     await act(async () => {
       render(
-        h(EntitiesContentHarness, {
+        h(TestHarness, {
           entityType,
           entityMetadata,
           setEntityMetadata: () => {},

--- a/src/workspace-data/data-table/shared/DataTable.test.ts
+++ b/src/workspace-data/data-table/shared/DataTable.test.ts
@@ -28,7 +28,7 @@ jest.mock('react-notifications-component', (): DeepPartial<ReactNotificationsCom
 const entityType = 'sample';
 const entities = _.map(
   (n) => ({ entityType: 'sample', name: `sample_${n}`, attributes: { attr: n % 2 === 0 ? 'even' : 'odd' } }),
-  _.range(0, 250)
+  _.range(0, 25)
 );
 const entityMetadata = {
   sample: {
@@ -154,6 +154,7 @@ describe('DataTable', () => {
           border: true,
           extraColumnActions: '',
           dataProvider: mockDataProvider,
+          defaultItemsPerPage: 10,
         })
       );
     });
@@ -164,14 +165,14 @@ describe('DataTable', () => {
     const button = screen.getByRole('button', { name: '"Select All" options' });
     await user.click(button);
 
-    const pageButton = screen.getByRole('button', { name: 'All (250)' });
+    const pageButton = screen.getByRole('button', { name: 'All (25)' });
     await user.click(pageButton);
 
     // Assert
 
     // Should include all rows + the 'Select all' check
     const allChecks = screen.getAllByRole('checkbox', { checked: true });
-    expect(allChecks.length).toEqual(101);
+    expect(allChecks.length).toEqual(11);
 
     // Go to next page
     const nextPageButton = screen.getByRole('button', { name: 'Next page' });
@@ -179,7 +180,7 @@ describe('DataTable', () => {
 
     // Get the checkboxes on this page
     const newPageChecks = screen.getAllByRole('checkbox', { checked: true });
-    expect(newPageChecks.length).toEqual(101);
+    expect(newPageChecks.length).toEqual(11);
   }, 20000);
 
   it('selects page', async () => {
@@ -221,6 +222,7 @@ describe('DataTable', () => {
           border: true,
           extraColumnActions: '',
           dataProvider: mockDataProvider,
+          defaultItemsPerPage: 10,
         })
       );
     });
@@ -238,7 +240,7 @@ describe('DataTable', () => {
 
     // Should include all rows + the 'Select all' check
     const allChecks = screen.getAllByRole('checkbox', { checked: true });
-    expect(allChecks.length).toEqual(101);
+    expect(allChecks.length).toEqual(11);
 
     // Go to next page
     const nextPageButton = screen.getByRole('button', { name: 'Next page' });
@@ -246,7 +248,7 @@ describe('DataTable', () => {
 
     // Get the checkboxes on this page
     const newPageChecks = screen.getAllByRole('checkbox', { checked: false });
-    expect(newPageChecks.length).toEqual(101);
+    expect(newPageChecks.length).toEqual(11);
   }, 10000);
 
   it('passes filters to getPaginatedEntities', async () => {
@@ -288,6 +290,7 @@ describe('DataTable', () => {
           border: true,
           extraColumnActions: '',
           dataProvider: mockDataProvider,
+          defaultItemsPerPage: 10,
         })
       );
     });
@@ -308,7 +311,7 @@ describe('DataTable', () => {
     const checkbox = screen.getByRole('button', { name: '"Select All" options' });
     await user.click(checkbox);
 
-    const pageButton = screen.getByRole('button', { name: 'Filtered (125)' });
+    const pageButton = screen.getByRole('button', { name: 'Filtered (13)' });
     await user.click(pageButton);
 
     expect(paginatedEntitiesOfType).toHaveBeenCalledWith(
@@ -356,6 +359,7 @@ describe('DataTable', () => {
           border: true,
           extraColumnActions: '',
           dataProvider: mockDataProvider,
+          defaultItemsPerPage: 10,
         })
       );
     });
@@ -376,11 +380,11 @@ describe('DataTable', () => {
     const checkbox = screen.getByRole('button', { name: '"Select All" options' });
     await user.click(checkbox);
 
-    const pageButton = screen.getByRole('button', { name: 'Filtered (125)' });
+    const pageButton = screen.getByRole('button', { name: 'Filtered (13)' });
     await user.click(pageButton);
 
     // Should include all (filtered) entities + select all checkbox
     const allChecks = screen.getAllByRole('checkbox', { checked: true });
-    expect(allChecks.length).toEqual(101);
+    expect(allChecks.length).toEqual(11);
   }, 15000);
 });


### PR DESCRIPTION
Attempting to decrease the run time of DataTable tests by having them render fewer rows, using a page size of 10 instead of 100.

Along the way, refactored mocks to simplify them and make them more realistic.

Before
```
$ yarn test DataTable.test
 PASS  src/workspace-data/data-table/shared/DataTable.test.ts (14.099 s)
  DataTable
    ✓ selects all (3111 ms)
    ✓ selects page (2847 ms)
    ✓ passes filters to getPaginatedEntities (2966 ms)
    ✓ selects filtered (3572 ms)

Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
Snapshots:   0 total
Time:        14.46 s
```

After
```
$ yarn test DataTable.test
 PASS  src/workspace-data/data-table/shared/DataTable.test.ts
  DataTable
    ✓ selects all (721 ms)
    ✓ selects page (590 ms)
    ✓ passes filters to getPaginatedEntities (700 ms)
    ✓ selects filtered (775 ms)

Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
Snapshots:   0 total
Time:        5.078 s, estimated 7 s
```