### PR TITLE
WM-2434: Show error messages on workflows app startup failure

### DIFF
--- a/src/alerts/ErrorAlert.ts
+++ b/src/alerts/ErrorAlert.ts
@@ -5,8 +5,14 @@ import { icon } from 'src/components/icons';
 import colors from 'src/libs/colors';
 import * as Utils from 'src/libs/utils';
 
-export const ErrorAlert = ({ errorMessage }) => {
-  const error: any | undefined = Utils.maybeParseJSON(errorMessage);
+type ErrorAlertProps = {
+  errorValue: string | object;
+  mainMessageField?: string;
+};
+
+export const ErrorAlert = ({ errorValue, mainMessageField = 'message' }: ErrorAlertProps) => {
+  const errorObject: any | undefined = _.isObject(errorValue) ? errorValue : Utils.maybeParseJSON(errorValue);
+  const mainMessage = errorObject?.[mainMessageField];
   return div(
     {
       style: {
@@ -31,13 +37,13 @@ export const ErrorAlert = ({ errorMessage }) => {
         ]),
         Utils.cond(
           [
-            _.isString(errorMessage),
+            _.isObject(errorObject),
             () =>
               div({ style: { display: 'flex', flexDirection: 'column', justifyContent: 'center' } }, [
                 div(
                   { style: { fontWeight: 'bold', marginLeft: '0.2rem' }, role: 'alert' },
                   // @ts-ignore
-                  _.upperFirst(error.message)
+                  _.upperFirst(mainMessage)
                 ),
                 h(Collapse, { title: 'Full Error Detail', style: { marginTop: '0.5rem' } }, [
                   div(
@@ -53,12 +59,12 @@ export const ErrorAlert = ({ errorMessage }) => {
                         maxHeight: 400,
                       },
                     },
-                    [JSON.stringify(error, null, 2)]
+                    [JSON.stringify(errorObject, null, 2)]
                   ),
                 ]),
               ]),
           ],
-          () => div({ style: { display: 'flex', alignItems: 'center' }, role: 'alert' }, errorMessage.toString())
+          () => div({ style: { display: 'flex', alignItems: 'center' }, role: 'alert' }, [errorValue.toString()])
         ),
       ]),
     ]

--- a/src/billing/SpendReport/SpendReport.ts
+++ b/src/billing/SpendReport/SpendReport.ts
@@ -2,9 +2,9 @@ import { subDays } from 'date-fns/fp';
 import _ from 'lodash/fp';
 import { Fragment, lazy, Suspense, useEffect, useState } from 'react';
 import { div, h, span } from 'react-hyperscript-helpers';
+import { ErrorAlert } from 'src/alerts/ErrorAlert';
 import { ExternalLink } from 'src/billing/NewBillingProjectWizard/StepWizard/ExternalLink';
 import { CostCard } from 'src/billing/SpendReport/CostCard';
-import { ErrorAlert } from 'src/billing/SpendReport/ErrorAlert';
 import { CloudPlatform } from 'src/billing-core/models';
 import { customSpinnerOverlay, IdContainer, Select } from 'src/components/common';
 import { Ajax } from 'src/libs/ajax';
@@ -309,7 +309,7 @@ export const SpendReport = (props: SpendReportProps) => {
 
   return h(Fragment, [
     div({ style: { display: 'grid', rowGap: '0.5rem' } }, [
-      !!errorMessage && h(ErrorAlert, { errorMessage }),
+      !!errorMessage && h(ErrorAlert, { errorValue: errorMessage }),
       div(
         {
           style: {

--- a/src/components/TitleBar.ts
+++ b/src/components/TitleBar.ts
@@ -7,7 +7,7 @@ interface TitleBarProps {
   id?: string;
   onPrevious?: MouseEventHandler;
   title: ReactNode;
-  onDismiss: MouseEventHandler;
+  onDismiss?: MouseEventHandler;
   titleChildren?: ReactNode;
   style?: React.CSSProperties;
   titleStyles?: React.CSSProperties;

--- a/src/workflows-app/components/WorkflowsAppNavPanel.test.ts
+++ b/src/workflows-app/components/WorkflowsAppNavPanel.test.ts
@@ -244,6 +244,14 @@ describe('Workflows App Navigation Panel', () => {
               googleErrorCode: null,
               traceId: null,
             },
+            {
+              errorMessage: 'Second error message',
+              timestamp: '2024-01-23T18:41:42.831Z',
+              action: 'deleteApp',
+              source: 'app',
+              googleErrorCode: null,
+              traceId: null,
+            },
           ],
           status: 'ERROR',
           auditInfo: {
@@ -275,7 +283,7 @@ describe('Workflows App Navigation Panel', () => {
       );
     });
 
-    expect(screen.getByText('Workflows Infrastructure Error')).toBeInTheDocument();
+    expect(screen.getByText('Error launching Workflows app')).toBeInTheDocument();
     expect(screen.getByText('Sample error message')).toBeInTheDocument();
   });
 });

--- a/src/workflows-app/components/WorkflowsAppNavPanel.test.ts
+++ b/src/workflows-app/components/WorkflowsAppNavPanel.test.ts
@@ -213,4 +213,69 @@ describe('Workflows App Navigation Panel', () => {
 
     expect(screen.queryByText('Launch Workflows app to run workflows')).not.toBeInTheDocument();
   });
+
+  it('renders an error screen when WORKFLOWS_APP is in error state', async () => {
+    const analysesDataWithAppsInError: AnalysesData = {
+      ...defaultAnalysesDataWithAppsRefreshed,
+      apps: [
+        {
+          workspaceId: 'test-id',
+          cloudContext: {
+            cloudProvider: 'AZURE',
+            cloudResource: 'test-resource',
+          },
+          kubernetesRuntimeConfig: {
+            numNodes: 1,
+            machineType: 'test-machine-type',
+            autoscalingEnabled: false,
+          },
+          proxyUrls: {},
+          diskName: 'test-disk',
+          accessScope: 'test-scope',
+          labels: {},
+          region: 'test-region',
+          appName: 'WORKFLOWS_APP',
+          errors: [
+            {
+              errorMessage: 'Sample error message',
+              timestamp: '2024-01-23T18:41:42.831Z',
+              action: 'createApp',
+              source: 'app',
+              googleErrorCode: null,
+              traceId: null,
+            },
+          ],
+          status: 'ERROR',
+          auditInfo: {
+            creator: 'ssalahi@broadinstitute.org',
+            createdDate: '2024-01-23T18:41:42.186232Z',
+            destroyedDate: null,
+            dateAccessed: '2024-01-23T18:41:42.186232Z',
+          },
+          appType: 'WORKFLOWS_APP',
+        },
+      ],
+    };
+
+    await act(() => {
+      render(
+        h(WorkflowsAppNavPanel, {
+          loading: false,
+          launcherDisabled: true,
+          launching: false,
+          createWorkflowsApp: jest.fn(),
+          pageReady: true,
+          name: 'test-azure-ws-name',
+          namespace: 'test-azure-ws-namespace',
+          workspace: mockAzureWorkspace,
+          analysesData: analysesDataWithAppsInError,
+          setLoading: jest.fn(),
+          signal: jest.fn(),
+        })
+      );
+    });
+
+    expect(screen.getByText('Workflows Infrastructure Error')).toBeInTheDocument();
+    expect(screen.getByText('Sample error message')).toBeInTheDocument();
+  });
 });

--- a/src/workflows-app/components/WorkflowsAppNavPanel.ts
+++ b/src/workflows-app/components/WorkflowsAppNavPanel.ts
@@ -1,6 +1,7 @@
 import _ from 'lodash/fp';
 import { CSSProperties, useEffect } from 'react';
 import { div, h, h2, span } from 'react-hyperscript-helpers';
+import { ErrorAlert } from 'src/alerts/ErrorAlert';
 import { AnalysesData } from 'src/analysis/Analyses';
 import Collapse from 'src/components/Collapse';
 import { Clickable } from 'src/components/common';
@@ -107,6 +108,9 @@ export const WorkflowsAppNavPanel = ({
   }, [name, namespace, selectedSubHeader]);
 
   const isSubHeaderActive = (subHeader: string) => pageReady && selectedSubHeader === subHeader;
+
+  const workflowsApp = analysesData.apps ? analysesData.apps.find((app) => app.appType === 'WORKFLOWS_APP') : undefined;
+  const workflowsAppErrors = workflowsApp && workflowsApp.status === 'ERROR' ? workflowsApp.errors : [];
 
   return div({ style: { display: 'flex', flex: 1, height: 'calc(100% - 66px)', position: 'relative' } }, [
     div(
@@ -258,6 +262,19 @@ export const WorkflowsAppNavPanel = ({
           div({ style: { display: 'flex', flexDirection: 'column', flexGrow: 1, margin: '1rem 2rem' } }, [
             h2({ style: { marginTop: 0 } }, ['Loading Workflows App']),
             loadingYourWorkflowsApp(),
+          ]),
+      ],
+      [
+        workflowsAppErrors.length !== 0,
+        () =>
+          div({ style: { display: 'flex', flexDirection: 'column', flexGrow: 1, margin: '1rem 2rem' } }, [
+            h2({ style: { marginTop: 0 } }, ['Workflows Infrastructure Error']),
+            div({ style: { marginTop: '1rem' } }, [
+              h(ErrorAlert, {
+                errorValue: workflowsAppErrors[0],
+                mainMessageField: 'errorMessage',
+              }),
+            ]),
           ]),
       ],
       [

--- a/src/workflows-app/components/WorkflowsAppNavPanel.ts
+++ b/src/workflows-app/components/WorkflowsAppNavPanel.ts
@@ -6,6 +6,7 @@ import { AnalysesData } from 'src/analysis/Analyses';
 import Collapse from 'src/components/Collapse';
 import { Clickable } from 'src/components/common';
 import { centeredSpinner, icon } from 'src/components/icons';
+import TitleBar from 'src/components/TitleBar';
 import { useMetricsEvent } from 'src/libs/ajax/metrics/useMetrics';
 import colors from 'src/libs/colors';
 import { getConfig } from 'src/libs/config';
@@ -267,15 +268,25 @@ export const WorkflowsAppNavPanel = ({
       [
         workflowsAppErrors.length !== 0,
         () =>
-          div({ style: { display: 'flex', flexDirection: 'column', flexGrow: 1, margin: '1rem 2rem' } }, [
-            h2({ style: { marginTop: 0 } }, ['Workflows Infrastructure Error']),
-            div({ style: { marginTop: '1rem' } }, [
-              h(ErrorAlert, {
-                errorValue: workflowsAppErrors[0],
-                mainMessageField: 'errorMessage',
+          div(
+            { style: { ...Style.elements.card.container, height: 'fit-content', width: '50rem', margin: '2rem 4rem' } },
+            [
+              h(TitleBar, {
+                id: 'workflow-app-launch-page',
+                title: 'Error launching Workflows app',
+                style: { marginBottom: '0.5rem' },
               }),
-            ]),
-          ]),
+              div({ style: { display: 'flex', marginTop: '1rem', justifyContent: 'flex-center' } }, [
+                'A problem has occurred launching the shared Workflows App ("WORKFLOWS_APP") in this workspace. If the problem persists, please contact support.',
+              ]),
+              _.map((error) => {
+                return h(ErrorAlert, {
+                  errorValue: error,
+                  mainMessageField: 'errorMessage',
+                });
+              }, workflowsAppErrors),
+            ]
+          ),
       ],
       [
         pageReady,

--- a/src/workflows-app/components/WorkflowsAppNavPanel.ts
+++ b/src/workflows-app/components/WorkflowsAppNavPanel.ts
@@ -279,11 +279,13 @@ export const WorkflowsAppNavPanel = ({
               div({ style: { display: 'flex', marginTop: '1rem', justifyContent: 'flex-center' } }, [
                 'A problem has occurred launching the shared Workflows App ("WORKFLOWS_APP") in this workspace. If the problem persists, please contact support.',
               ]),
-              _.map((error) => {
-                return h(ErrorAlert, {
-                  errorValue: error,
-                  mainMessageField: 'errorMessage',
-                });
+              _.map.convert({ cap: false })((error, index) => {
+                return div({ key: index }, [
+                  h(ErrorAlert, {
+                    errorValue: error,
+                    mainMessageField: 'errorMessage',
+                  }),
+                ]);
               }, workflowsAppErrors),
             ]
           ),

--- a/src/workflows-app/components/WorkflowsAppNavPanel.ts
+++ b/src/workflows-app/components/WorkflowsAppNavPanel.ts
@@ -14,6 +14,7 @@ import Events, { extractWorkspaceDetails } from 'src/libs/events';
 import { useQueryParameter } from 'src/libs/nav';
 import * as Style from 'src/libs/style';
 import * as Utils from 'src/libs/utils';
+import { toIndexPairs } from 'src/libs/utils';
 import HelpfulLinksBox from 'src/workflows-app/components/HelpfulLinksBox';
 import ImportGithub from 'src/workflows-app/components/ImportGithub';
 import { WorkflowsAppLauncherCard } from 'src/workflows-app/components/WorkflowsAppLauncherCard';
@@ -279,14 +280,14 @@ export const WorkflowsAppNavPanel = ({
               div({ style: { display: 'flex', marginTop: '1rem', justifyContent: 'flex-center' } }, [
                 'A problem has occurred launching the shared Workflows App ("WORKFLOWS_APP") in this workspace. If the problem persists, please contact support.',
               ]),
-              _.map.convert({ cap: false })((error, index) => {
+              _.map(([index, error]) => {
                 return div({ key: index }, [
                   h(ErrorAlert, {
                     errorValue: error,
                     mainMessageField: 'errorMessage',
                   }),
                 ]);
-              }, workflowsAppErrors),
+              }, toIndexPairs(workflowsAppErrors)),
             ]
           ),
       ],


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WM-2434

## Summary of changes:
Adds visible error messages when apps fail to start, replacing the "Loading" messaging, and spinning wheel

## Testing strategy
- [X] Unit tests
- [x] Manual observation in a workspace with a broken app

## Visual Aids
### Before Change
<img width="971" alt="image" src="https://github.com/DataBiosphere/terra-ui/assets/13006282/91729a57-4ab5-42ab-9dae-a40e43f794f9">

### After Change

Note: the message content is made up, everything else (like the layout and the shape of the json structure) is "correct".

One message box is shown per error, full details can be opened or collapsed:
<img width="876" alt="image" src="https://github.com/DataBiosphere/terra-ui/assets/13006282/f5b89d37-c73a-4d12-818c-9cb1ae0e7f99">

