### PR TITLE
add failures key

### DIFF
--- a/src/workflows-app/RunDetails.js
+++ b/src/workflows-app/RunDetails.js
@@ -93,6 +93,7 @@ export const BaseRunDetails = (
       'submittedFiles',
       'callCaching',
       'workflowLog',
+      'failures',
     ],
     []
   );


### PR DESCRIPTION
### [Jira Ticket](https://broadworkbench.atlassian.net/jira/software/c/projects/WX/boards/174?selectedIssue=WX-1492)

## Summary of changes:
Added an include key to the metadata request that the frontend makes to Cromwell when serving the Run Details Page. 

### Why
Some internal users find this metadata useful, even though there is no UI built for it yet. We [recently removed it](https://github.com/DataBiosphere/terra-ui/pull/4676/files) when we fixed a bug, but want to add this specific key back to unblock certain workflow debugging strategies on azure. 

### Testing strategy
A/B tested my workspace, and confirmed that my change causes the desired metadata to be included in the backend response. My testing included a workflow with nested scatters that failed. 

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 
