### PR TITLE
[WOR-1553] Improve stability of AzureBillingProjectWizard unittest

### DIFF
--- a/src/billing/NewBillingProjectWizard/AzureBillingProjectWizard/AzureBillingProjectWizard.test.ts
+++ b/src/billing/NewBillingProjectWizard/AzureBillingProjectWizard/AzureBillingProjectWizard.test.ts
@@ -109,7 +109,6 @@ describe('AzureBillingProjectWizard', () => {
     testStepActive(4);
     verifyCreateBillingProjectDisabled();
     await nameBillingProject(billingProjectName);
-    expect(await axe(renderResult.container)).toHaveNoViolations();
 
     await clickCreateBillingProject();
     expect(createAzureProject).toBeCalledWith(
@@ -183,7 +182,6 @@ describe('AzureBillingProjectWizard', () => {
     fireEvent.click(getNoUsersRadio());
     verifyCreateBillingProjectDisabled();
     await nameBillingProject(billingProjectName);
-    expect(await axe(renderResult.container)).toHaveNoViolations();
     await clickCreateBillingProject();
     expect(createAzureProject).toBeCalledWith(
       billingProjectName,
@@ -193,9 +191,9 @@ describe('AzureBillingProjectWizard', () => {
       [],
       false
     );
+    await screen.findByText('Billing project name already exists');
     verifyCreateBillingProjectDisabled();
     expect(onSuccess).not.toBeCalled();
-    await screen.findByText('Billing project name already exists');
     expect(captureEvent).toHaveBeenCalledWith(Events.billingAzureCreationProjectCreateFail, { existingName: true });
     expect(await axe(renderResult.container)).toHaveNoViolations();
   });


### PR DESCRIPTION
JIRA ticket: https://broadworkbench.atlassian.net/browse/WOR-1553

Folks have seen this test flake on build a couple of times, in 2 different ways. I have attempted to address both of the failures, though I could not reproduce them locally.

One failure signature was the create button not being disabled-- I think this is a race condition, so I moved the order of operations so we wait first for the message about the billing project being in use to appear before checking the state of the button.

The second failure signature was a timeout of the test itself. The test was doing 2 accessibility checks in the same method, each of which are slow. I removed one of them, and also took the opportunity to remove one that I don't think was really needed in a different test. Here are the times before and after the changes.

Before:
```
  AzureBillingProjectWizard
    ✓ should not fail any accessibility tests in initial state (1329 ms)
    ✓ should support happy path of submitting with no users/owners and without protected data (1444 ms)
    ✓ should support happy path of submitting with owners and users and protected data (1442 ms)
    ✓ shows error if billing project already exists with the name (2280 ms)
    ✓ shows error if there is no billing project name or name is badly formatted (186 ms)
```

After:
```
  AzureBillingProjectWizard
    ✓ should not fail any accessibility tests in initial state (1111 ms)
    ✓ should support happy path of submitting with no users/owners and without protected data (376 ms)
    ✓ should support happy path of submitting with owners and users and protected data (1241 ms)
    ✓ shows error if billing project already exists with the name (1129 ms)
    ✓ shows error if there is no billing project name or name is badly formatted (150 ms)
```
