### PR TITLE
[DRAFT]Domain Selection (2nd panel)

### DIFF
--- a/src/dataset-builder/ConceptSearch.ts
+++ b/src/dataset-builder/ConceptSearch.ts
@@ -1,4 +1,3 @@
-import { IconId } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { Fragment, useEffect, useState } from 'react';
 import { div, h, h2, strong } from 'react-hyperscript-helpers';
@@ -6,10 +5,9 @@ import { ActionBar } from 'src/components/ActionBar';
 import { Link, spinnerOverlay } from 'src/components/common';
 import { icon } from 'src/components/icons';
 import { TextInput, withDebouncedChange } from 'src/components/input';
-import { SimpleTable } from 'src/components/table';
-import { tableHeaderStyle } from 'src/dataset-builder/ConceptSelector';
 import { BuilderPageHeader } from 'src/dataset-builder/DatasetBuilderHeader';
-import { DomainOption, GetConceptsResponse, HighlightConceptName } from 'src/dataset-builder/DatasetBuilderUtils';
+import { DomainOption, GetConceptsResponse } from 'src/dataset-builder/DatasetBuilderUtils';
+import { StyledSimpleTable } from 'src/dataset-builder/StyledSimpleTable';
 import { DataRepo, SnapshotBuilderConcept as Concept } from 'src/libs/ajax/DataRepo';
 import { useLoadedData } from 'src/libs/ajax/loaded-data/useLoadedData';
 import colors from 'src/libs/colors';
@@ -45,7 +43,6 @@ export const ConceptSearch = (props: ConceptSearchProps) => {
       });
     }
   }, [searchText, datasetId, domainOption.root, searchConcepts]);
-  const tableLeftPadding = { paddingLeft: '2rem' };
   const iconSize = 18;
 
   return h(Fragment, [
@@ -85,22 +82,15 @@ export const ConceptSearch = (props: ConceptSearchProps) => {
         }),
       ]),
       concepts.status === 'Ready'
-        ? h(SimpleTable, {
-            'aria-label': 'concept search results',
-            underRowKey: 'underRow',
-            rowStyle: {
-              backgroundColor: 'white',
-              ...tableLeftPadding,
-            },
-            headerRowStyle: {
-              ...tableHeaderStyle,
-              ...tableLeftPadding,
-              marginTop: '1rem',
-            },
-            cellStyle: {
-              paddingTop: 10,
-              paddingBottom: 10,
-            },
+        ? h(StyledSimpleTable, {
+            search: true,
+            hierarchy: true,
+            searchText,
+            cart,
+            setCart,
+            onOpenHierarchy,
+            concepts: concepts.state.result,
+            domainOption,
             columns: [
               { header: strong(['Concept name']), width: 710, key: 'name' },
               { header: strong(['Concept ID']), width: 195, key: 'id' },
@@ -108,34 +98,6 @@ export const ConceptSearch = (props: ConceptSearchProps) => {
               { header: strong(['Roll-up count']), width: 205, key: 'count' },
               { width: 100, key: 'hierarchy' },
             ],
-            rows: _.map((concept) => {
-              const [label, iconName]: [string, IconId] = _.contains(concept, cart)
-                ? ['remove', 'minus-circle-red']
-                : ['add', 'plus-circle-filled'];
-              return {
-                name: div({ style: { display: 'flex' } }, [
-                  h(Link, { 'aria-label': `${label} ${concept.id}`, onClick: () => setCart(_.xor(cart, [concept])) }, [
-                    icon(iconName, { size: 16 }),
-                  ]),
-                  div({ style: { marginLeft: 5 } }, [
-                    h(HighlightConceptName, { conceptName: concept.name, searchFilter: searchText }),
-                  ]),
-                ]),
-                id: concept.id,
-                count: concept.count,
-                hierarchy: div({ style: { display: 'flex' } }, [
-                  h(
-                    Link,
-                    {
-                      'aria-label': `open hierarchy ${concept.id}`,
-                      onClick: () => onOpenHierarchy(domainOption, cart, searchText, concept),
-                    },
-                    [icon('view-list')]
-                  ),
-                  div({ style: { marginLeft: 5 } }, ['Hierarchy']),
-                ]),
-              };
-            }, concepts.state.result),
           })
         : spinnerOverlay,
     ]),

--- a/src/dataset-builder/ConceptSelector.ts
+++ b/src/dataset-builder/ConceptSelector.ts
@@ -1,13 +1,12 @@
-import { IconId } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { CSSProperties, Fragment, useState } from 'react';
-import { div, h, h2 } from 'react-hyperscript-helpers';
+import { div, h, h2, strong } from 'react-hyperscript-helpers';
 import { ActionBar } from 'src/components/ActionBar';
 import { Link } from 'src/components/common';
 import { icon } from 'src/components/icons';
-import { TreeGrid } from 'src/components/TreeGrid';
 import { BuilderPageHeader } from 'src/dataset-builder/DatasetBuilderHeader';
-import { DataRepo, SnapshotBuilderConcept as Concept } from 'src/libs/ajax/DataRepo';
+import { StyledSimpleTable } from 'src/dataset-builder/StyledSimpleTable';
+import { SnapshotBuilderConcept as Concept } from 'src/libs/ajax/DataRepo';
 import colors from 'src/libs/colors';
 
 type ConceptSelectorProps = {
@@ -15,10 +14,8 @@ type ConceptSelectorProps = {
   readonly onCancel: (selected: Concept[]) => void;
   readonly onCommit: (selected: Concept[]) => void;
   readonly actionText: string;
-  readonly datasetId: string;
   readonly initialCart: Concept[];
   readonly rootConcept: Concept;
-  readonly openedConcept?: Concept;
 };
 
 export const tableHeaderStyle: CSSProperties = {
@@ -32,13 +29,13 @@ export const tableHeaderStyle: CSSProperties = {
 };
 
 export const ConceptSelector = (props: ConceptSelectorProps) => {
-  const { title, onCancel, onCommit, actionText, datasetId, initialCart, rootConcept, openedConcept } = props;
-
+  const { title, onCancel, onCommit, actionText, initialCart, rootConcept } = props;
   const [cart, setCart] = useState<Concept[]>(initialCart);
-  const getChildren = async (concept: Concept): Promise<Concept[]> => {
-    const result = await DataRepo().dataset(datasetId).getConcepts(concept);
-    return result.result;
-  };
+  const columns = [
+    { header: strong(['Table name']), width: 710, key: 'name' },
+    { header: strong(['Table ID']), width: 195, key: 'id' },
+    { header: strong(['Roll-up count']), width: 205, key: 'count' },
+  ];
 
   return h(Fragment, [
     h(BuilderPageHeader, [
@@ -53,39 +50,22 @@ export const ConceptSelector = (props: ConceptSelectorProps) => {
         ),
         div({ style: { marginLeft: 15 } }, [title]),
       ]),
-      h(TreeGrid<Concept>, {
-        columns: [
-          {
-            name: 'Concept Name',
-            width: 710,
-            render: (concept) => {
-              const [label, iconName]: [string, IconId] = (() => {
-                if (_.contains(concept, cart)) {
-                  return ['remove', 'minus-circle-red'];
-                }
-                return ['add', 'plus-circle-filled'];
-              })();
-              return h(Fragment, [
-                h(Link, { 'aria-label': `${label} ${concept.id}`, onClick: () => setCart(_.xor(cart, [concept])) }, [
-                  icon(iconName, { size: 16 }),
-                ]),
-                div({ style: { marginLeft: 5 } }, [
-                  openedConcept?.id === concept.id ? div({ style: { fontWeight: 600 } }, [concept.name]) : concept.name,
-                ]),
-              ]);
-            },
-          },
-          { name: 'Concept ID', width: 195, render: _.get('id') },
-          { name: 'Roll-up count', width: 205, render: _.get('count') },
-        ],
-        root: rootConcept,
-        getChildren,
-        headerStyle: tableHeaderStyle,
+      h(StyledSimpleTable, {
+        search: false,
+        hierarchy: false,
+        searchText: '',
+        cart,
+        setCart,
+        onOpenHierarchy: () => {},
+        concepts: rootConcept.children ? rootConcept.children : [],
+        // domainOption unused
+        domainOption: { kind: 'domain', id: 0, name: '', root: rootConcept },
+        columns,
       }),
     ]),
     cart.length !== 0 &&
       h(ActionBar, {
-        prompt: cart.length === 1 ? '1 concept selected' : `${cart.length} concepts selected`,
+        prompt: cart.length === 1 ? '1 table selected' : `${cart.length} tables selected`,
         actionText,
         onClick: () => _.flow(onCommit)(cart),
       }),

--- a/src/dataset-builder/ConceptSetCreator.ts
+++ b/src/dataset-builder/ConceptSetCreator.ts
@@ -34,13 +34,13 @@ export const ConceptSetCreator = (props: ConceptSetCreatorProps) => {
   return h(ConceptSelector, {
     rootConcept: domainOptionRoot,
     initialCart: [],
-    title: 'Add concept',
+    title: 'Add tables',
     onCancel: () => onStateChange(homepageState.new()),
     onCommit: (selected: Concept[]) => {
       conceptSetUpdater((conceptSets) => _.flow(_.map(toConceptSet), _.union(conceptSets))(selected));
       onStateChange(homepageState.new());
     },
-    actionText: 'Add to concept sets',
+    actionText: 'Add to tables',
     datasetId: id,
   });
 };

--- a/src/dataset-builder/DatasetBuilder.ts
+++ b/src/dataset-builder/DatasetBuilder.ts
@@ -386,7 +386,7 @@ export const ConceptSetSelector = ({
     onChange,
     objectSets: [
       {
-        header: 'Concept sets',
+        header: 'Tables',
         values: conceptSets,
         makeIcon: (value, header) =>
           h(
@@ -398,10 +398,10 @@ export const ConceptSetSelector = ({
             [icon('trash-circle-filled', { size: 20 })]
           ),
       },
-      { header: 'Prepackaged concept sets', values: prepackagedConceptSets ?? [] },
+      { header: 'Prepackaged tables', values: prepackagedConceptSets ?? [] },
     ],
     selectedObjectSets: selectedConceptSets,
-    header: 'Select concept sets',
+    header: 'Select tables',
     subheader: 'Which information to include about participants',
     style: { marginLeft: '1rem' },
   });

--- a/src/dataset-builder/StyledSimpleTable.ts
+++ b/src/dataset-builder/StyledSimpleTable.ts
@@ -1,0 +1,83 @@
+import { IconId } from '@terra-ui-packages/components';
+import _ from 'lodash/fp';
+import { ReactElement } from 'react';
+import { div, h } from 'react-hyperscript-helpers';
+import { Link } from 'src/components/common';
+import { icon } from 'src/components/icons';
+import { SimpleTable } from 'src/components/table';
+import { tableHeaderStyle } from 'src/dataset-builder/ConceptSelector';
+import { DomainOption, HighlightConceptName } from 'src/dataset-builder/DatasetBuilderUtils';
+import { SnapshotBuilderConcept as Concept } from 'src/libs/ajax/DataRepo';
+
+type StyledSimpleTableProps = {
+  readonly search: boolean;
+  readonly hierarchy: boolean;
+  readonly searchText: string;
+  readonly onOpenHierarchy: (
+    domainOption: DomainOption,
+    cart: Concept[],
+    searchText: string,
+    openedConcept?: Concept
+  ) => void;
+  readonly domainOption: DomainOption;
+  readonly cart: Concept[];
+  readonly setCart: (selected: Concept[]) => void;
+  readonly concepts: Concept[];
+  readonly columns: { header?: ReactElement<any, any>; width: number; key: string }[];
+};
+
+export const StyledSimpleTable = (props: StyledSimpleTableProps) => {
+  const { search, searchText, hierarchy, onOpenHierarchy, domainOption, cart, setCart, concepts, columns } = props;
+  const tableLeftPadding = { paddingLeft: '2rem' };
+
+  return h(SimpleTable, {
+    'aria-label': 'concept search results',
+    underRowKey: 'underRow',
+    rowStyle: {
+      backgroundColor: 'white',
+      ...tableLeftPadding,
+    },
+    headerRowStyle: {
+      ...tableHeaderStyle,
+      ...tableLeftPadding,
+      marginTop: '1rem',
+    },
+    cellStyle: {
+      paddingTop: 10,
+      paddingBottom: 10,
+    },
+    columns,
+    rows: _.map((concept) => {
+      const [label, iconName]: [string, IconId] = _.contains(concept, cart)
+        ? ['remove', 'minus-circle-red']
+        : ['add', 'plus-circle-filled'];
+      return {
+        name: div({ style: { display: 'flex' } }, [
+          h(Link, { 'aria-label': `${label} ${concept.id}`, onClick: () => setCart(_.xor(cart, [concept])) }, [
+            icon(iconName, { size: 16 }),
+          ]),
+          search
+            ? div({ style: { marginLeft: 5 } }, [
+                h(HighlightConceptName, { conceptName: concept.name, searchFilter: searchText }),
+              ])
+            : div({ style: { marginLeft: 5 } }, [concept.name]),
+        ]),
+        id: concept.id,
+        count: concept.count,
+        hierarchy: hierarchy
+          ? div({ style: { display: 'flex' } }, [
+              h(
+                Link,
+                {
+                  'aria-label': `open hierarchy ${concept.id}`,
+                  onClick: () => onOpenHierarchy(domainOption, cart, searchText, concept),
+                },
+                [icon('view-list')]
+              ),
+              div({ style: { marginLeft: 5 } }, ['Hierarchy']),
+            ])
+          : {},
+      };
+    }, concepts),
+  });
+};


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/[DC-885]
Read updated ticket description. This work is no longer to display a comprehensive concept list. Instead we want to display the domain list, which represents tables (occurrence tables). The domain list is pulled from the snapshot builder settings. When the data is un-stubbed in the snapshot builder settings, there will be about 5 domains on the list. So search is not necessary.

Changes:
1. Remove the tree grid from ConceptSelector since this is not going to be a hierarchy view
2. Add a simple table to ConceptSelector to display the domains
     a. retrieve domains from where they are stored in the settings.
3. Make a shared component for ConceptSearch and Concept Selector
     a. this does not affect the view or functionality of ConceptSearch. It just reduces the duplicated code from having SimpleTable styled in the same way in two places.
4. This changes the term 'concept set' to 'table'. I think concept set is unclear and table better represents the domain selection. Let me know what you think of this change.

TODO: not tested yet, no tests updated

This is what the page looks like now that it is updated. Still there are only 3 concepts because this is what is stored in the settings. A future ticket https://broadworkbench.atlassian.net/browse/[DC-901] will unstub the domain retrieval in the settings. 

https://github.com/DataBiosphere/terra-ui/assets/55256690/d01d3e9a-9a0b-4833-afd7-e67f8eaedfb0



[DC-885]: https://broadworkbench.atlassian.net/browse/DC-885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DC-901]: https://broadworkbench.atlassian.net/browse/DC-901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ