### PR TITLE
DC-903: Snapshot Builder - Handle case where participant count  is between 1 and 20

### DIFF
--- a/src/dataset-builder/CohortEditor.ts
+++ b/src/dataset-builder/CohortEditor.ts
@@ -13,7 +13,7 @@ import {
   convertApiDomainOptionToDomainOption,
   CriteriaGroup,
   DatasetParticipantCountResponse,
-  DisplayParticipantCount,
+  displayParticipantCount,
   DomainOption,
   ProgramDataListCriteria,
   ProgramDataListOption,
@@ -168,7 +168,7 @@ export const CriteriaView = (props: CriteriaViewProps) => {
       ]),
       div([
         'Count: ',
-        criteriaCount.status === 'Ready' ? DisplayParticipantCount(criteriaCount.state.result.total) : h(Spinner),
+        criteriaCount.status === 'Ready' ? displayParticipantCount(criteriaCount.state.result.total) : h(Spinner),
       ]),
     ]
   );
@@ -427,7 +427,7 @@ export const CriteriaGroupView: React.FC<CriteriaGroupViewProps> = (props) => {
           div({ style: { marginRight: wideMargin } }, [
             'Group count: ',
             groupParticipantCount.status === 'Ready'
-              ? DisplayParticipantCount(groupParticipantCount.state.result.total)
+              ? displayParticipantCount(groupParticipantCount.state.result.total)
               : h(Spinner),
           ]),
         ]

--- a/src/dataset-builder/CohortEditor.ts
+++ b/src/dataset-builder/CohortEditor.ts
@@ -1,4 +1,3 @@
-import { Spinner } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import React, { Fragment, useEffect, useState } from 'react';
 import { div, h, h2, h3, strong } from 'react-hyperscript-helpers';
@@ -13,6 +12,7 @@ import {
   convertApiDomainOptionToDomainOption,
   CriteriaGroup,
   DatasetParticipantCountResponse,
+  DisplayParticipantCount,
   DomainOption,
   ProgramDataListCriteria,
   ProgramDataListOption,
@@ -165,15 +165,7 @@ export const CriteriaView = (props: CriteriaViewProps) => {
           })(),
         ]),
       ]),
-      div([
-        'Count: ',
-        // eslint-disable-next-line no-nested-ternary
-        criteriaCount.status === 'Ready'
-          ? criteriaCount.state.result.total === 19
-            ? '<20'
-            : criteriaCount.state.result.total
-          : h(Spinner),
-      ]),
+      div(['Count: ', DisplayParticipantCount(criteriaCount)]),
     ]
   );
 };
@@ -427,17 +419,7 @@ export const CriteriaGroupView: React.FC<CriteriaGroupViewProps> = (props) => {
             fontWeight: 'bold',
           },
         },
-        [
-          div({ style: { marginRight: wideMargin } }, [
-            'Group count: ',
-            // eslint-disable-next-line no-nested-ternary
-            groupParticipantCount.status === 'Ready'
-              ? groupParticipantCount.state.result.total === 19
-                ? '<20'
-                : groupParticipantCount.state.result.total
-              : h(Spinner),
-          ]),
-        ]
+        [div({ style: { marginRight: wideMargin } }, ['Group count: ', DisplayParticipantCount(groupParticipantCount)])]
       ),
     ]
   );

--- a/src/dataset-builder/CohortEditor.ts
+++ b/src/dataset-builder/CohortEditor.ts
@@ -165,7 +165,15 @@ export const CriteriaView = (props: CriteriaViewProps) => {
           })(),
         ]),
       ]),
-      div(['Count: ', criteriaCount.status === 'Ready' ? criteriaCount.state.result.total : h(Spinner)]),
+      div([
+        'Count: ',
+        // eslint-disable-next-line no-nested-ternary
+        criteriaCount.status === 'Ready'
+          ? criteriaCount.state.result.total === 19
+            ? '<20'
+            : criteriaCount.state.result.total
+          : h(Spinner),
+      ]),
     ]
   );
 };
@@ -422,7 +430,12 @@ export const CriteriaGroupView: React.FC<CriteriaGroupViewProps> = (props) => {
         [
           div({ style: { marginRight: wideMargin } }, [
             'Group count: ',
-            groupParticipantCount.status === 'Ready' ? groupParticipantCount.state.result.total : h(Spinner),
+            // eslint-disable-next-line no-nested-ternary
+            groupParticipantCount.status === 'Ready'
+              ? groupParticipantCount.state.result.total === 19
+                ? '<20'
+                : groupParticipantCount.state.result.total
+              : h(Spinner),
           ]),
         ]
       ),

--- a/src/dataset-builder/CohortEditor.ts
+++ b/src/dataset-builder/CohortEditor.ts
@@ -1,3 +1,4 @@
+import { Spinner } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import React, { Fragment, useEffect, useState } from 'react';
 import { div, h, h2, h3, strong } from 'react-hyperscript-helpers';
@@ -165,7 +166,10 @@ export const CriteriaView = (props: CriteriaViewProps) => {
           })(),
         ]),
       ]),
-      div(['Count: ', DisplayParticipantCount(criteriaCount)]),
+      div([
+        'Count: ',
+        criteriaCount.status === 'Ready' ? DisplayParticipantCount(criteriaCount.state.result.total) : h(Spinner),
+      ]),
     ]
   );
 };
@@ -419,7 +423,14 @@ export const CriteriaGroupView: React.FC<CriteriaGroupViewProps> = (props) => {
             fontWeight: 'bold',
           },
         },
-        [div({ style: { marginRight: wideMargin } }, ['Group count: ', DisplayParticipantCount(groupParticipantCount)])]
+        [
+          div({ style: { marginRight: wideMargin } }, [
+            'Group count: ',
+            groupParticipantCount.status === 'Ready'
+              ? DisplayParticipantCount(groupParticipantCount.state.result.total)
+              : h(Spinner),
+          ]),
+        ]
       ),
     ]
   );

--- a/src/dataset-builder/DatasetBuilder.test.ts
+++ b/src/dataset-builder/DatasetBuilder.test.ts
@@ -273,6 +273,22 @@ describe('DatasetBuilder', () => {
     expect(await screen.findByText('Request access to this dataset')).toBeTruthy();
   });
 
+  it('hides the count with there are few participants in this dataset ', async () => {
+    const mockDataRepoContract: Partial<DataRepoContract> = {
+      dataset: (_datasetId) =>
+        ({
+          getCounts: () => Promise.resolve({ result: { total: 19 }, sql: '' }),
+        } as Partial<DataRepoContract['dataset']>),
+    } as Partial<DataRepoContract> as DataRepoContract;
+    asMockedFn(DataRepo).mockImplementation(() => mockDataRepoContract as DataRepoContract);
+    // Arrange
+    const user = userEvent.setup();
+    await initializeValidDatasetRequest(user);
+    // Assert
+    expect(await screen.findByText('Less than 20 participants in this dataset')).toBeTruthy();
+    expect(await screen.findByText('Request access to this dataset')).toBeTruthy();
+  });
+
   it('opens the modal when requesting access to the dataset', async () => {
     // Arrange
     const user = userEvent.setup();

--- a/src/dataset-builder/DatasetBuilder.test.ts
+++ b/src/dataset-builder/DatasetBuilder.test.ts
@@ -269,8 +269,7 @@ describe('DatasetBuilder', () => {
     const user = userEvent.setup();
     await initializeValidDatasetRequest(user);
     // Assert
-    expect(await screen.findByText('100')).toBeTruthy();
-    expect(await screen.findByText('participants in this dataset')).toBeTruthy();
+    expect(await screen.findByText('100 participants in this dataset')).toBeTruthy();
     expect(await screen.findByText('Request access to this dataset')).toBeTruthy();
   });
 

--- a/src/dataset-builder/DatasetBuilder.test.ts
+++ b/src/dataset-builder/DatasetBuilder.test.ts
@@ -269,7 +269,8 @@ describe('DatasetBuilder', () => {
     const user = userEvent.setup();
     await initializeValidDatasetRequest(user);
     // Assert
-    expect(await screen.findByText('100 Participants in this dataset')).toBeTruthy();
+    expect(await screen.findByText('100')).toBeTruthy();
+    expect(await screen.findByText('participants in this dataset')).toBeTruthy();
     expect(await screen.findByText('Request access to this dataset')).toBeTruthy();
   });
 

--- a/src/dataset-builder/DatasetBuilder.ts
+++ b/src/dataset-builder/DatasetBuilder.ts
@@ -17,7 +17,7 @@ import {
   DatasetBuilderType,
   DatasetBuilderValue,
   DatasetParticipantCountResponse,
-  DisplayParticipantCount,
+  displayParticipantCount,
   ProgramDataListOption,
   ProgramDataRangeOption,
 } from 'src/dataset-builder/DatasetBuilderUtils';
@@ -647,9 +647,9 @@ export const DatasetBuilderContents = ({
         h(ActionBar, {
           prompt: h(Fragment, [
             datasetRequestParticipantCount.status === 'Ready'
-              ? DisplayParticipantCount(datasetRequestParticipantCount.state.result.total)
+              ? displayParticipantCount(datasetRequestParticipantCount.state.result.total)
               : h(Spinner),
-            ' Participants in this dataset',
+            'participants in this dataset',
           ]),
           actionText: 'Request access to this dataset',
           onClick: () => setRequestingAccess(true),

--- a/src/dataset-builder/DatasetBuilder.ts
+++ b/src/dataset-builder/DatasetBuilder.ts
@@ -1,4 +1,4 @@
-import { Clickable, Modal } from '@terra-ui-packages/components';
+import { Clickable, Modal, Spinner } from '@terra-ui-packages/components';
 import * as _ from 'lodash/fp';
 import React, { Fragment, ReactElement, useEffect, useMemo, useState } from 'react';
 import { div, h, h2, h3, label, li, ul } from 'react-hyperscript-helpers';
@@ -646,7 +646,9 @@ export const DatasetBuilderContents = ({
       requestValid &&
         h(ActionBar, {
           prompt: h(Fragment, [
-            DisplayParticipantCount(datasetRequestParticipantCount),
+            datasetRequestParticipantCount.status === 'Ready'
+              ? DisplayParticipantCount(datasetRequestParticipantCount.state.result.total)
+              : h(Spinner),
             ' Participants in this dataset',
           ]),
           actionText: 'Request access to this dataset',

--- a/src/dataset-builder/DatasetBuilder.ts
+++ b/src/dataset-builder/DatasetBuilder.ts
@@ -645,8 +645,11 @@ export const DatasetBuilderContents = ({
       requestValid &&
         h(ActionBar, {
           prompt: h(Fragment, [
+            // eslint-disable-next-line no-nested-ternary
             datasetRequestParticipantCount.status === 'Ready'
-              ? datasetRequestParticipantCount.state.result.total
+              ? datasetRequestParticipantCount.state.result.total === 19
+                ? '<20'
+                : datasetRequestParticipantCount.state.result.total
               : h(Spinner),
             ' Participants in this dataset',
           ]),

--- a/src/dataset-builder/DatasetBuilder.ts
+++ b/src/dataset-builder/DatasetBuilder.ts
@@ -1,4 +1,4 @@
-import { Clickable, Modal, Spinner } from '@terra-ui-packages/components';
+import { Clickable, Modal } from '@terra-ui-packages/components';
 import * as _ from 'lodash/fp';
 import React, { Fragment, ReactElement, useEffect, useMemo, useState } from 'react';
 import { div, h, h2, h3, label, li, ul } from 'react-hyperscript-helpers';
@@ -17,6 +17,7 @@ import {
   DatasetBuilderType,
   DatasetBuilderValue,
   DatasetParticipantCountResponse,
+  DisplayParticipantCount,
   ProgramDataListOption,
   ProgramDataRangeOption,
 } from 'src/dataset-builder/DatasetBuilderUtils';
@@ -645,12 +646,7 @@ export const DatasetBuilderContents = ({
       requestValid &&
         h(ActionBar, {
           prompt: h(Fragment, [
-            // eslint-disable-next-line no-nested-ternary
-            datasetRequestParticipantCount.status === 'Ready'
-              ? datasetRequestParticipantCount.state.result.total === 19
-                ? '<20'
-                : datasetRequestParticipantCount.state.result.total
-              : h(Spinner),
+            DisplayParticipantCount(datasetRequestParticipantCount),
             ' Participants in this dataset',
           ]),
           actionText: 'Request access to this dataset',

--- a/src/dataset-builder/DatasetBuilder.ts
+++ b/src/dataset-builder/DatasetBuilder.ts
@@ -649,7 +649,7 @@ export const DatasetBuilderContents = ({
             datasetRequestParticipantCount.status === 'Ready'
               ? displayParticipantCount(datasetRequestParticipantCount.state.result.total)
               : h(Spinner),
-            'participants in this dataset',
+            ' participants in this dataset',
           ]),
           actionText: 'Request access to this dataset',
           onClick: () => setRequestingAccess(true),

--- a/src/dataset-builder/DatasetBuilderUtils.ts
+++ b/src/dataset-builder/DatasetBuilderUtils.ts
@@ -1,4 +1,5 @@
 import { Spinner } from '@terra-ui-packages/components';
+import { LoadedState } from '@terra-ui-packages/core-utils';
 import _ from 'lodash/fp';
 import { ReactElement } from 'react';
 import { div, h, span } from 'react-hyperscript-helpers';
@@ -314,7 +315,9 @@ export const HighlightConceptName = ({ conceptName, searchFilter }): ReactElemen
   ]);
 };
 
-export const DisplayParticipantCount = (participantCountResponse: DatasetParticipantCountResponse): ReactElement => {
+export const DisplayParticipantCount = (
+  participantCountResponse: LoadedState<DatasetParticipantCountResponse, unknown>
+): ReactElement => {
   if (participantCountResponse.status === 'Ready') {
     return div([
       participantCountResponse.state.result.total === 20 ? '<20' : participantCountResponse.state.result.total,

--- a/src/dataset-builder/DatasetBuilderUtils.ts
+++ b/src/dataset-builder/DatasetBuilderUtils.ts
@@ -311,6 +311,5 @@ export const HighlightConceptName = ({ conceptName, searchFilter }): ReactElemen
 };
 
 export const displayParticipantCount = (count: number): string => {
-  // TODO before merge - switch this count to 19 to match api change
-  return count <= 20 && count > 0 ? 'Less than 20' : count.toString();
+  return count <= 19 && count > 0 ? 'Less than 20' : count.toString();
 };

--- a/src/dataset-builder/DatasetBuilderUtils.ts
+++ b/src/dataset-builder/DatasetBuilderUtils.ts
@@ -310,7 +310,7 @@ export const HighlightConceptName = ({ conceptName, searchFilter }): ReactElemen
   ]);
 };
 
-export const DisplayParticipantCount = (count: number): ReactElement => {
+export const displayParticipantCount = (count: number): string => {
   // TODO before merge - switch this count to 19 to match api change
-  return div([count === 20 ? 'less than 20' : count]);
+  return count < 20 && count > 0 ? 'Less than 20' : count.toString();
 };

--- a/src/dataset-builder/DatasetBuilderUtils.ts
+++ b/src/dataset-builder/DatasetBuilderUtils.ts
@@ -312,5 +312,5 @@ export const HighlightConceptName = ({ conceptName, searchFilter }): ReactElemen
 
 export const displayParticipantCount = (count: number): string => {
   // TODO before merge - switch this count to 19 to match api change
-  return count < 20 && count > 0 ? 'Less than 20' : count.toString();
+  return count <= 20 && count > 0 ? 'Less than 20' : count.toString();
 };

--- a/src/dataset-builder/DatasetBuilderUtils.ts
+++ b/src/dataset-builder/DatasetBuilderUtils.ts
@@ -243,7 +243,6 @@ export type DatasetParticipantCountResponse = {
     total: number;
   };
   sql: string;
-  status: string;
 };
 
 export const convertApiDomainOptionToDomainOption = (domainOption: SnapshotBuilderDomainOption): DomainOption => ({

--- a/src/dataset-builder/DatasetBuilderUtils.ts
+++ b/src/dataset-builder/DatasetBuilderUtils.ts
@@ -1,8 +1,6 @@
-import { Spinner } from '@terra-ui-packages/components';
-import { LoadedState } from '@terra-ui-packages/core-utils';
 import _ from 'lodash/fp';
 import { ReactElement } from 'react';
-import { div, h, span } from 'react-hyperscript-helpers';
+import { div, span } from 'react-hyperscript-helpers';
 import {
   ColumnStatisticsIntOrDoubleModel,
   ColumnStatisticsTextModel,
@@ -241,10 +239,8 @@ export type DatasetParticipantCountRequest = {
 };
 
 export type DatasetParticipantCountResponse = {
-  state: {
-    result: {
-      total: number;
-    };
+  result: {
+    total: number;
   };
   sql: string;
   status: string;
@@ -315,13 +311,7 @@ export const HighlightConceptName = ({ conceptName, searchFilter }): ReactElemen
   ]);
 };
 
-export const DisplayParticipantCount = (
-  participantCountResponse: LoadedState<DatasetParticipantCountResponse, unknown>
-): ReactElement => {
-  if (participantCountResponse.status === 'Ready') {
-    return div([
-      participantCountResponse.state.result.total === 20 ? '<20' : participantCountResponse.state.result.total,
-    ]);
-  }
-  return h(Spinner);
+export const DisplayParticipantCount = (count: number): ReactElement => {
+  // TODO before merge - switch this count to 19 to match api change
+  return div([count === 20 ? 'less than 20' : count]);
 };

--- a/src/dataset-builder/DatasetBuilderUtils.ts
+++ b/src/dataset-builder/DatasetBuilderUtils.ts
@@ -1,6 +1,7 @@
+import { Spinner } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { ReactElement } from 'react';
-import { div, span } from 'react-hyperscript-helpers';
+import { div, h, span } from 'react-hyperscript-helpers';
 import {
   ColumnStatisticsIntOrDoubleModel,
   ColumnStatisticsTextModel,
@@ -239,10 +240,13 @@ export type DatasetParticipantCountRequest = {
 };
 
 export type DatasetParticipantCountResponse = {
-  result: {
-    total: number;
+  state: {
+    result: {
+      total: number;
+    };
   };
   sql: string;
+  status: string;
 };
 
 export const convertApiDomainOptionToDomainOption = (domainOption: SnapshotBuilderDomainOption): DomainOption => ({
@@ -308,4 +312,13 @@ export const HighlightConceptName = ({ conceptName, searchFilter }): ReactElemen
     span({ style: { fontWeight: 600 } }, [conceptName.substring(startIndex, endIndex)]),
     span([conceptName.substring(endIndex)]),
   ]);
+};
+
+export const DisplayParticipantCount = (participantCountResponse: DatasetParticipantCountResponse): ReactElement => {
+  if (participantCountResponse.status === 'Ready') {
+    return div([
+      participantCountResponse.state.result.total === 20 ? '<20' : participantCountResponse.state.result.total,
+    ]);
+  }
+  return h(Spinner);
 };


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/DC-888

### Dependencies
jade-data-repo change to return 0 if 0 and 19 if count is between 1 and 20 - https://github.com/DataBiosphere/jade-data-repo/pull/1611/files

## Summary of changes:
- Before this change we were displaying "20" if the participant count was less than 20. Now, we are displaying 0 if there are 0 participants and "<20" if the number of participants is between 1 and 20.

### Testing strategy
- Unit tests
- Deploy both this terra-ui change and jade-data-repo change to a BEE

 ### Visual Aids
![Screenshot 2024-03-08 at 3 01 38 PM](https://github.com/DataBiosphere/terra-ui/assets/13254229/4dfc8c3f-3b55-4e24-9c40-9fe4bd70f3c6)


![Screenshot 2024-03-08 at 2 57 14 PM](https://github.com/DataBiosphere/terra-ui/assets/13254229/f08c9b5d-7ad0-4496-8a75-3ce7a17311dc)

