### PR TITLE
[UIE-159] Fix publish packages script

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,0 +1,19 @@
+name: Publish packages
+on:
+  push:
+    branches:
+      - dev
+jobs:
+  publish-packages:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Publish packages to NPM registry
+        run: |
+          npx google-artifactregistry-auth --yes --repo-config ./.npmrc
+          yarn install --immutable
+          ./scripts/publish-packages.sh

--- a/.github/workflows/tag-publish.yaml
+++ b/.github/workflows/tag-publish.yaml
@@ -116,13 +116,6 @@ jobs:
             "${{ steps.image-name.outputs.tagged }}" \
             "${{ steps.image-name.outputs.name }}:latest"
 
-      - name: Publish packages to NPM registry on merge commits
-        if: github.event_name != 'pull_request'
-        run: |
-          npx google-artifactregistry-auth --yes --repo-config ./.npmrc
-          yarn install --immutable
-          ./scripts/publish-packages.sh
-
   report-to-sherlock:
     uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
     needs: tag-push-job

--- a/scripts/publish-packages.sh
+++ b/scripts/publish-packages.sh
@@ -3,7 +3,12 @@
 set -euo pipefail
 
 SCRIPTS_DIR="$(dirname "$0")"
-cd "${SCRIPTS_DIR}/../packages"
+cd "${SCRIPTS_DIR}/.."
+
+# Build all packages.
+yarn build-packages
+
+cd "packages"
 for d in */ ; do
     cd "$d"
 
@@ -28,9 +33,6 @@ for d in */ ; do
 
     # If the current and published versions differ, then publish the package.
     if [ "${PUBLISHED_VERSION}" != "${PACKAGE_VERSION}" ]; then
-      echo "Building ${PACKAGE_NAME}."
-      yarn build
-
       echo "Publishing ${PACKAGE_NAME}."
       npm publish
       echo "Successfully published version ${PACKAGE_VERSION} of ${PACKAGE_NAME}."


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/UIE-159

Currently, `scripts/publish-packages.sh` is run on commits to the dev branch as part of the Generate BEE Build workflow.

This script iterates over all packages and checks if each package needs to be published by comparing the current version in package.json to the latest version in the `terra-ui-packages` NPM Artifact Registry. If the versions don't match, it builds the package and publishes it.

However, building the packages that need to be published in isolation does not account for packages that depend on other Terra UI packages which also need to be built. To account for these dependencies, this changes the publish packages script to build all packages up front using `yarn build-packages`, which builds packages in order based on dependencies.

While we're at it, this also moves publishing packages to a separate workflow, since it's unrelated to the Docker build for BEEs and only needs to be run on commits to dev, not pull requests.

