### PR TITLE
[UIE-163] Do not run e2e tests on merge queue branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,9 @@ anchors:
   filter-pr-branch: &filter-pr-branch
     filters:
       branches:
-        ignore: dev
+        ignore:
+          - dev
+          - /gh-readonly-queue\/.*/
 
   filter-dev-branch: &filter-dev-branch
     filters:


### PR DESCRIPTION
E2E tests are not a _required_ status check for merging to the `dev` branch. Thus, the merge queue won't consider them when determining whether or not to merge a merge queue branch. If the build and SonarCloud checks pass, the merge queue branch will be merged. Thus, there's no point in running them on merge queue branches. They needlessly consume resources and lead to confusion when, on GitHub, a commit on the `dev` branch appears to have failed CI even if it's passed all checks required for deployment (including `integration-tests-staging`) and only failed the irrelevant `integration-tests-pr-staging` job:
![Screenshot 2024-03-12 at 10 22 19 AM](https://github.com/DataBiosphere/terra-ui/assets/1156625/642532d9-a326-4a1d-b3f8-5fd84a3da8f3)

This updates the CircleCI configuration so that merge queue branches (identified by the `gh-readonly-queue` prefix) are not considered as "PR branches". This avoids running e2e tests on them as well as deploying them to preview environments. 

https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#how-merge-queues-work
https://circleci.com/docs/configuration-reference/#branches