### PR TITLE
[UIE-51] Remove dependency on react-select

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -150,7 +150,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["react-notifications-component", "virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#npm:4.0.1"],\
             ["react-oidc-context", "virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#npm:2.1.0"],\
             ["react-paginating", "virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#npm:1.4.0"],\
-            ["react-select", "virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#npm:5.7.4"],\
             ["react-simplemde-editor", "virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#npm:5.0.2"],\
             ["react-textarea-autosize", "virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#npm:8.5.2"],\
             ["react-transition-group", "virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#npm:4.4.5"],\
@@ -3884,10 +3883,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],\
           "linkType": "SOFT"\
         }],\
-        ["virtual:78df86ad5dfe72b608fb496d44e416cd9611c8aacb1e1a81ae9d184ee55a841bba22bcc747279d3f6f304cb25a2b6d16cdf32a99dd32370f375b22988ff23963#npm:11.11.1", {\
-          "packageLocation": "./.yarn/__virtual__/@emotion-react-virtual-3618d80bf9/0/cache/@emotion-react-npm-11.11.1-a07d6a6ebd-aec3c36650.zip/node_modules/@emotion/react/",\
+        ["virtual:cf0e3993392eb61e8a3ccdd4da5ec26fefceeac48fef2dac57469d3339f0715075e9dc723aebea551df66fc9d42df413f8c44cdfc2a3fd42d7f3f4d09016aae2#npm:11.11.1", {\
+          "packageLocation": "./.yarn/__virtual__/@emotion-react-virtual-ea568e8222/0/cache/@emotion-react-npm-11.11.1-a07d6a6ebd-aec3c36650.zip/node_modules/@emotion/react/",\
           "packageDependencies": [\
-            ["@emotion/react", "virtual:78df86ad5dfe72b608fb496d44e416cd9611c8aacb1e1a81ae9d184ee55a841bba22bcc747279d3f6f304cb25a2b6d16cdf32a99dd32370f375b22988ff23963#npm:11.11.1"],\
+            ["@emotion/react", "virtual:cf0e3993392eb61e8a3ccdd4da5ec26fefceeac48fef2dac57469d3339f0715075e9dc723aebea551df66fc9d42df413f8c44cdfc2a3fd42d7f3f4d09016aae2#npm:11.11.1"],\
             ["@babel/runtime", "npm:7.23.8"],\
             ["@emotion/babel-plugin", "npm:11.11.0"],\
             ["@emotion/cache", "npm:11.11.0"],\
@@ -8112,7 +8111,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["react-focus-lock", "virtual:3cbce82a859ed6a4d5bf57a6b809aea2976beb02c6e1078f18e5e40f750e781222e51bcef76699e2500e623832ea4e45e9647ae7b14a57290a182e58c3827fe8#npm:2.9.5"],\
             ["react-modal", "virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#npm:3.16.1"],\
             ["react-onclickoutside", "virtual:3cbce82a859ed6a4d5bf57a6b809aea2976beb02c6e1078f18e5e40f750e781222e51bcef76699e2500e623832ea4e45e9647ae7b14a57290a182e58c3827fe8#npm:6.13.0"],\
-            ["react-select", "virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#npm:5.7.4"],\
+            ["react-select", "virtual:3cbce82a859ed6a4d5bf57a6b809aea2976beb02c6e1078f18e5e40f750e781222e51bcef76699e2500e623832ea4e45e9647ae7b14a57290a182e58c3827fe8#npm:5.7.4"],\
             ["react-switch", "virtual:3cbce82a859ed6a4d5bf57a6b809aea2976beb02c6e1078f18e5e40f750e781222e51bcef76699e2500e623832ea4e45e9647ae7b14a57290a182e58c3827fe8#npm:6.1.0"],\
             ["typescript", "patch:typescript@npm%3A5.1.6#~builtin<compat/typescript>::version=5.1.6&hash=5da071"],\
             ["vite", "virtual:6fecf1af4cab542f4a06b7ce7d9f710277dce92700e0011a9519e41948eed6d8f54c9d0aa109ead6cf4295edce81cb49620f9e823313e99632229bf20d133cdb#npm:4.5.2"],\
@@ -21529,13 +21528,13 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],\
           "linkType": "SOFT"\
         }],\
-        ["virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#npm:5.7.4", {\
-          "packageLocation": "./.yarn/__virtual__/react-select-virtual-78df86ad5d/0/cache/react-select-npm-5.7.4-a84a65df36-ca72941ad1.zip/node_modules/react-select/",\
+        ["virtual:3cbce82a859ed6a4d5bf57a6b809aea2976beb02c6e1078f18e5e40f750e781222e51bcef76699e2500e623832ea4e45e9647ae7b14a57290a182e58c3827fe8#npm:5.7.4", {\
+          "packageLocation": "./.yarn/__virtual__/react-select-virtual-cf0e399339/0/cache/react-select-npm-5.7.4-a84a65df36-ca72941ad1.zip/node_modules/react-select/",\
           "packageDependencies": [\
-            ["react-select", "virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#npm:5.7.4"],\
+            ["react-select", "virtual:3cbce82a859ed6a4d5bf57a6b809aea2976beb02c6e1078f18e5e40f750e781222e51bcef76699e2500e623832ea4e45e9647ae7b14a57290a182e58c3827fe8#npm:5.7.4"],\
             ["@babel/runtime", "npm:7.23.8"],\
             ["@emotion/cache", "npm:11.11.0"],\
-            ["@emotion/react", "virtual:78df86ad5dfe72b608fb496d44e416cd9611c8aacb1e1a81ae9d184ee55a841bba22bcc747279d3f6f304cb25a2b6d16cdf32a99dd32370f375b22988ff23963#npm:11.11.1"],\
+            ["@emotion/react", "virtual:cf0e3993392eb61e8a3ccdd4da5ec26fefceeac48fef2dac57469d3339f0715075e9dc723aebea551df66fc9d42df413f8c44cdfc2a3fd42d7f3f4d09016aae2#npm:11.11.1"],\
             ["@floating-ui/dom", "npm:1.5.4"],\
             ["@types/react", "npm:18.2.47"],\
             ["@types/react-dom", "npm:18.2.7"],\
@@ -21561,7 +21560,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["react-select", "virtual:f14c7c2b623bfe35a608f25e5b8f5582c71bc9475deb0d9650188d23bcf292a9531c8cce96f863c9a827a93aa74f4453675de981d038283eed4a2d8e81e490f7#npm:5.7.4"],\
             ["@babel/runtime", "npm:7.23.8"],\
             ["@emotion/cache", "npm:11.11.0"],\
-            ["@emotion/react", "virtual:78df86ad5dfe72b608fb496d44e416cd9611c8aacb1e1a81ae9d184ee55a841bba22bcc747279d3f6f304cb25a2b6d16cdf32a99dd32370f375b22988ff23963#npm:11.11.1"],\
+            ["@emotion/react", "virtual:cf0e3993392eb61e8a3ccdd4da5ec26fefceeac48fef2dac57469d3339f0715075e9dc723aebea551df66fc9d42df413f8c44cdfc2a3fd42d7f3f4d09016aae2#npm:11.11.1"],\
             ["@floating-ui/dom", "npm:1.5.4"],\
             ["@types/react", "npm:18.2.47"],\
             ["@types/react-dom", null],\
@@ -23468,7 +23467,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["react-notifications-component", "virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#npm:4.0.1"],\
             ["react-oidc-context", "virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#npm:2.1.0"],\
             ["react-paginating", "virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#npm:1.4.0"],\
-            ["react-select", "virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#npm:5.7.4"],\
             ["react-simplemde-editor", "virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#npm:5.0.2"],\
             ["react-textarea-autosize", "virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#npm:8.5.2"],\
             ["react-transition-group", "virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#npm:4.4.5"],\

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "react-notifications-component": "^4.0.1",
     "react-oidc-context": "^2.1.0",
     "react-paginating": "^1.4.0",
-    "react-select": "^5.7.4",
     "react-simplemde-editor": "^5.0.2",
     "react-textarea-autosize": "^8.5.2",
     "react-transition-group": "^4.4.5",

--- a/src/analysis/modals/ComputeModal/AzureComputeModal/AzurePersistentDiskSection.ts
+++ b/src/analysis/modals/ComputeModal/AzureComputeModal/AzurePersistentDiskSection.ts
@@ -1,6 +1,5 @@
 import React from 'react';
 import { div } from 'react-hyperscript-helpers';
-import { SingleValue } from 'react-select';
 import { AboutPersistentDiskSection } from 'src/analysis/modals/ComputeModal/AboutPersistentDiskSection';
 import { AzurePersistentDiskSizeSelectInput } from 'src/analysis/modals/ComputeModal/AzureComputeModal/AzurePersistentDiskSizeSelectInput';
 import { PersistentDiskTypeInputContainer } from 'src/analysis/modals/ComputeModal/PersistentDiskTypeInputContainer';
@@ -12,7 +11,7 @@ export interface AzurePersistentDiskSectionProps {
   persistentDiskSize: number;
   persistentDiskType: AzurePdType;
   onChangePersistentDiskType: (type: SharedPdType) => void;
-  onChangePersistentDiskSize: (size: SingleValue<number | undefined>) => void;
+  onChangePersistentDiskSize: (size: number | null | undefined) => void;
   onClickAbout: () => void;
 }
 

--- a/src/analysis/modals/ComputeModal/AzureComputeModal/AzurePersistentDiskSizeSelectInput.ts
+++ b/src/analysis/modals/ComputeModal/AzureComputeModal/AzurePersistentDiskSizeSelectInput.ts
@@ -1,7 +1,6 @@
 import { useUniqueId } from '@terra-ui-packages/components';
 import React from 'react';
 import { div, h, label } from 'react-hyperscript-helpers';
-import { SingleValue } from 'react-select';
 import { IComputeConfig } from 'src/analysis/modal-utils';
 import { computeStyles } from 'src/analysis/modals/modalStyles';
 import { Select } from 'src/components/common';
@@ -10,7 +9,7 @@ import { defaultAzureDiskSize } from 'src/libs/azure-utils';
 
 export interface AzurePersistentDiskSizeSelectInputProps {
   persistentDiskSize: number;
-  onChangePersistentDiskSize: (e: SingleValue<number | undefined>) => void;
+  onChangePersistentDiskSize: (e: number | null | undefined) => void;
   persistentDiskExists: boolean;
 }
 

--- a/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeImageSelect.ts
+++ b/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeImageSelect.ts
@@ -1,7 +1,6 @@
 import _ from 'lodash/fp';
 import React from 'react';
 import { h } from 'react-hyperscript-helpers';
-import { SingleValue } from 'react-select';
 import { ComputeImage } from 'src/analysis/useComputeImages';
 import { GroupedSelect } from 'src/components/common';
 
@@ -66,7 +65,7 @@ export const GcpComputeImageSelect: React.FC<GcpComputeImageSelectProps> = (prop
   return h(GroupedSelect, {
     ...restProps,
     value: selectedComputeImageUrl,
-    onChange: ({ value }: SingleValue<any>) => {
+    onChange: ({ value }: any) => {
       setSelectedComputeImageUrl(value);
     },
     isSearchable: true,

--- a/src/analysis/modals/ComputeModal/PersistentDiskTypeInput.ts
+++ b/src/analysis/modals/ComputeModal/PersistentDiskTypeInput.ts
@@ -1,7 +1,6 @@
 import { useUniqueId } from '@terra-ui-packages/components';
 import React from 'react';
 import { div, h, label } from 'react-hyperscript-helpers';
-import { SingleValue } from 'react-select';
 import { IComputeConfig } from 'src/analysis/modal-utils';
 import { computeStyles } from 'src/analysis/modals/modalStyles';
 import { Select } from 'src/components/common';
@@ -9,7 +8,7 @@ import { PdSelectOption, SharedPdType } from 'src/libs/ajax/leonardo/models/disk
 
 export interface PersistentDiskTypeInputProps {
   value: SharedPdType;
-  onChange: (e: SingleValue<{ value: SharedPdType; label: string | undefined }>) => void;
+  onChange: (e: { value: SharedPdType; label: string | undefined } | null) => void;
   isDisabled?: boolean;
   options: PdSelectOption[];
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -16896,7 +16896,6 @@ __metadata:
     react-notifications-component: ^4.0.1
     react-oidc-context: ^2.1.0
     react-paginating: ^1.4.0
-    react-select: ^5.7.4
     react-simplemde-editor: ^5.0.2
     react-textarea-autosize: ^8.5.2
     react-transition-group: ^4.4.5


### PR DESCRIPTION
Follow up to #4681.

Now that the Select component has been moved to the components package, we can remove Terra UI's dependency on react-select.

The only thing Terra UI still uses from react-select is the `SingleValue` type, which is defined as `type SingleValue<Option> = Option | null`. It's easy enough to inline that in the few places it's used.