### PR TITLE
[AJ-1706] Add support link to analyses page in Azure workspaces

### DIFF
--- a/src/analysis/Analyses.ts
+++ b/src/analysis/Analyses.ts
@@ -836,6 +836,20 @@ export const BaseAnalyses = (
                     onDismiss: () => setDeletingAnalysisName(undefined),
                   }),
               ]),
+              isAzureWorkspace(workspace) &&
+                div({ style: { marginBottom: '1rem' } }, [
+                  h(
+                    Link,
+                    {
+                      ...Utils.newTabLinkProps,
+                      href: 'https://support.terra.bio/hc/en-us/articles/22950635210395-Add-Python-3-10-to-access-DRS-URIs-in-JupyterLab',
+                    },
+                    [
+                      'See instructions for accessing DRS URIs in JupyterLab',
+                      icon('pop-out', { style: { marginLeft: '1ch' } }),
+                    ]
+                  ),
+                ]),
               renderAnalyses(),
             ]),
           (loadedState.status === 'Loading' || busy) && spinnerOverlay,


### PR DESCRIPTION
As requested by User Education.

![Screenshot 2024-03-15 at 12 41 33 PM](https://github.com/DataBiosphere/terra-ui/assets/1156625/71a0969b-d4bb-4eee-8cdc-330ad26e627f)
