### PR TITLE
[WM-2531] Disable WDL button in SubmissionConfig

### DIFF
--- a/src/workflows-app/SubmissionConfig.js
+++ b/src/workflows-app/SubmissionConfig.js
@@ -329,7 +329,7 @@ export const BaseSubmissionConfig = (
             h(
               Link,
               {
-                disabled: workflowScript == null,
+                disabled: workflowScript == null || method.isPrivate === true,
                 onClick: () => setViewWorkflowScriptModal(true),
               },
               'View Workflow Script'

--- a/src/workflows-app/SubmissionConfig.test.js
+++ b/src/workflows-app/SubmissionConfig.test.js
@@ -545,8 +545,12 @@ describe('Initial state', () => {
   });
 
   beforeEach(() => {
-    getConfig.mockReturnValue({ wdsUrlRoot, cbasUrlRoot });
+    getConfig.mockReturnValue({ wdsUrlRoot, cbasUrlRoot, cromwellUrlRoot });
   });
+
+  // beforeEach(() => {
+  //   getConfig.mockReturnValue({ wdsUrlRoot, cbasUrlRoot });
+  // });
 
   afterAll(() => {
     Object.defineProperty(HTMLElement.prototype, 'offsetHeight', originalOffsetHeight);
@@ -905,8 +909,9 @@ describe('Initial state', () => {
     expect(mockTypesResponse).toHaveBeenCalledTimes(1);
     expect(mockMethodsResponse).toHaveBeenCalledTimes(1);
     expect(mockSearchResponse).toHaveBeenCalledTimes(1);
-    expect(mockWdlResponse).toHaveBeenCalledTimes(1);
+    expect(mockWdlResponse).toHaveBeenCalledTimes(0);
 
+    // console.log(await screen.getAllByRole('button'));
     const button = screen.getByRole('button', { name: 'View Workflow Script' });
     expect(button).toBeDisabled();
 

--- a/src/workflows-app/SubmissionConfig.test.js
+++ b/src/workflows-app/SubmissionConfig.test.js
@@ -858,9 +858,8 @@ describe('Initial state', () => {
 
   it('should render disabled script button for private workflow', async () => {
     // ** ARRANGE **
-    // const user = userEvent.setup();
     const methodResponseWithPrivate = {
-      ...methodsResponse,
+      ...methodsResponse.methods[0],
       isPrivate: true,
     };
     const mockRunSetResponse = jest.fn(() => Promise.resolve(runSetResponseForNewMethod));

--- a/src/workflows-app/SubmissionConfig.test.js
+++ b/src/workflows-app/SubmissionConfig.test.js
@@ -908,7 +908,8 @@ describe('Initial state', () => {
     expect(mockSearchResponse).toHaveBeenCalledTimes(1);
     expect(mockWdlResponse).toHaveBeenCalledTimes(1);
 
-    expect(screen.getByRole('button', { name: 'View Workflow Script' }));
+    const button = screen.getByRole('button', { name: 'View Workflow Script' });
+    expect(button).toBeDisabled();
 
     // ** ACT **
     // await user.click(button);

--- a/src/workflows-app/SubmissionConfig.test.js
+++ b/src/workflows-app/SubmissionConfig.test.js
@@ -548,10 +548,6 @@ describe('Initial state', () => {
     getConfig.mockReturnValue({ wdsUrlRoot, cbasUrlRoot, cromwellUrlRoot });
   });
 
-  // beforeEach(() => {
-  //   getConfig.mockReturnValue({ wdsUrlRoot, cbasUrlRoot });
-  // });
-
   afterAll(() => {
     Object.defineProperty(HTMLElement.prototype, 'offsetHeight', originalOffsetHeight);
     Object.defineProperty(HTMLElement.prototype, 'offsetWidth', originalOffsetWidth);
@@ -863,8 +859,12 @@ describe('Initial state', () => {
   it('should render disabled script button for private workflow', async () => {
     // ** ARRANGE **
     const methodResponseWithPrivate = {
-      ...methodsResponse.methods[0],
-      isPrivate: true,
+      methods: [
+        {
+          ...methodsResponse.methods[0],
+          isPrivate: true,
+        },
+      ],
     };
     const mockRunSetResponse = jest.fn(() => Promise.resolve(runSetResponseForNewMethod));
     const mockMethodsResponse = jest.fn(() => Promise.resolve(methodResponseWithPrivate));
@@ -909,11 +909,10 @@ describe('Initial state', () => {
     expect(mockTypesResponse).toHaveBeenCalledTimes(1);
     expect(mockMethodsResponse).toHaveBeenCalledTimes(1);
     expect(mockSearchResponse).toHaveBeenCalledTimes(1);
-    expect(mockWdlResponse).toHaveBeenCalledTimes(0);
+    expect(mockWdlResponse).toHaveBeenCalledTimes(1);
 
-    // console.log(await screen.getAllByRole('button'));
     const button = screen.getByRole('button', { name: 'View Workflow Script' });
-    expect(button).toBeDisabled();
+    expect(button.getAttribute('aria-disabled')).toBe('true');
 
     // ** ACT **
     // await user.click(button);

--- a/src/workflows-app/SubmissionConfig.test.js
+++ b/src/workflows-app/SubmissionConfig.test.js
@@ -913,9 +913,6 @@ describe('Initial state', () => {
 
     const button = screen.getByRole('button', { name: 'View Workflow Script' });
     expect(button.getAttribute('aria-disabled')).toBe('true');
-
-    // ** ACT **
-    // await user.click(button);
   });
 });
 


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/[WM-2531]

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Disabling the View WDL button for private workflows

### Why
- For the new private workflow feature, we do not want users to click this button, as it makes a request without a token and will fail. For now, we will disable the button for workflows marked as private.

### Testing strategy
- [x] Unit tests

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 
<img width="400" alt="image" src="https://github.com/DataBiosphere/terra-ui/assets/68349264/935e690c-142f-436d-a88a-13e3f5855b90">
<img width="400" alt="image" src="https://github.com/DataBiosphere/terra-ui/assets/68349264/0d8ed1df-b686-4f79-8956-ed42b62ab996">



[WM-2531]: https://broadworkbench.atlassian.net/browse/WM-2531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ