### PR TITLE
WM-2537: Add firecloud UI migration feature flag

### DIFF
--- a/src/libs/feature-previews-config.ts
+++ b/src/libs/feature-previews-config.ts
@@ -4,6 +4,7 @@ export const HAIL_BATCH_AZURE_FEATURE_ID = 'hail-batch-azure';
 export const ENABLE_WORKFLOW_RESOURCE_MONITORING = 'enableWorkflowResourceMonitoring';
 export const ENABLE_AZURE_PFB_IMPORT = 'enableAzurePfbImport';
 export const ENABLE_AZURE_TDR_IMPORT = 'enableAzureTdrImport';
+export const FIRECLOUD_UI_MIGRATION = 'firecloudUiMigration';
 
 // If the groups option is defined for a FeaturePreview, it must contain at least one group.
 type GroupsList = readonly [string, ...string[]];
@@ -107,6 +108,14 @@ const featurePreviewsConfig: readonly FeaturePreview[] = [
     groups: ['dsp-analysis-journeys'],
     feedbackUrl: `mailto:dsp-analysis-journeys@broadinstitute.org?subject=${encodeURIComponent(
       'Feedback on Azure TDR snapshot Import'
+    )}`,
+  },
+  {
+    id: FIRECLOUD_UI_MIGRATION,
+    title: 'Firecloud UI Feature Migration',
+    description: 'Enabling this feature will update replaceable links to Firecloud UI with new links to Terra UI',
+    feedbackUrl: `mailto:dsp-workflow-management@broadinstitute.org?subject=${encodeURIComponent(
+      'Feedback on deprecating Firecloud UI'
     )}`,
   },
 ];


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WM-2537

## Summary of changes:
Adds a feature flag with no impact yet, to start staging firecloud ui migration work before rolling it out to everyone

<!-- ### Visual Aids -->
Now on the feature preview page:
<img width="847" alt="image" src="https://github.com/DataBiosphere/terra-ui/assets/13006282/cd0b42c7-e35f-474a-8bb9-d83935fbffd5">

