### PR TITLE
WM-2538 Redirect method repo links (behind feature flag)

### DIFF
--- a/src/libs/feature-previews-config.ts
+++ b/src/libs/feature-previews-config.ts
@@ -4,6 +4,7 @@ export const HAIL_BATCH_AZURE_FEATURE_ID = 'hail-batch-azure';
 export const ENABLE_WORKFLOW_RESOURCE_MONITORING = 'enableWorkflowResourceMonitoring';
 export const ENABLE_AZURE_PFB_IMPORT = 'enableAzurePfbImport';
 export const ENABLE_AZURE_TDR_IMPORT = 'enableAzureTdrImport';
+export const FIRECLOUD_UI_MIGRATION = 'firecloudUiMigration';
 
 // If the groups option is defined for a FeaturePreview, it must contain at least one group.
 type GroupsList = readonly [string, ...string[]];
@@ -107,6 +108,14 @@ const featurePreviewsConfig: readonly FeaturePreview[] = [
     groups: ['dsp-analysis-journeys'],
     feedbackUrl: `mailto:dsp-analysis-journeys@broadinstitute.org?subject=${encodeURIComponent(
       'Feedback on Azure TDR snapshot Import'
+    )}`,
+  },
+  {
+    id: FIRECLOUD_UI_MIGRATION,
+    title: 'Firecloud UI Feature Migration',
+    description: 'Enabling this feature will update replaceable links to Firecloud UI with new links to Terra UI',
+    feedbackUrl: `mailto:dsp-workflow-management@broadinstitute.org?subject=${encodeURIComponent(
+      'Feedback on deprecating Firecloud UI'
     )}`,
   },
 ];

--- a/src/pages/library/Code.js
+++ b/src/pages/library/Code.js
@@ -14,7 +14,7 @@ import colors from 'src/libs/colors';
 import { getConfig } from 'src/libs/config';
 import { withErrorReporting } from 'src/libs/error';
 import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
-import { DEPRECATE_FIRECLOUD_UI } from 'src/libs/feature-previews-config';
+import { FIRECLOUD_UI_MIGRATION } from 'src/libs/feature-previews-config';
 import * as Nav from 'src/libs/nav';
 import { useCancellation, useOnMount } from 'src/libs/react-utils';
 import * as Style from 'src/libs/style';
@@ -104,7 +104,7 @@ export const MethodRepoTile = () => {
       h(
         Link,
         {
-          href: isFeaturePreviewEnabled(DEPRECATE_FIRECLOUD_UI)
+          href: isFeaturePreviewEnabled(FIRECLOUD_UI_MIGRATION)
             ? Nav.getLink('workflows')
             : `${getConfig().firecloudUrlRoot}/?return=${getEnabledBrand().queryName}#methods`,
           style: { color: colors.accent(1.1) }, // For a11y, we need at least 4.5:1 contrast agaisnst the gray background

--- a/src/pages/library/Code.js
+++ b/src/pages/library/Code.js
@@ -13,6 +13,9 @@ import { getEnabledBrand } from 'src/libs/brand-utils';
 import colors from 'src/libs/colors';
 import { getConfig } from 'src/libs/config';
 import { withErrorReporting } from 'src/libs/error';
+import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
+import { DEPRECATE_FIRECLOUD_UI } from 'src/libs/feature-previews-config';
+import * as Nav from 'src/libs/nav';
 import { useCancellation, useOnMount } from 'src/libs/react-utils';
 import * as Style from 'src/libs/style';
 import * as Utils from 'src/libs/utils';
@@ -101,7 +104,9 @@ export const MethodRepoTile = () => {
       h(
         Link,
         {
-          href: `${getConfig().firecloudUrlRoot}/?return=${getEnabledBrand().queryName}#methods`,
+          href: isFeaturePreviewEnabled(DEPRECATE_FIRECLOUD_UI)
+            ? Nav.getLink('workflows')
+            : `${getConfig().firecloudUrlRoot}/?return=${getEnabledBrand().queryName}#methods`,
           style: { color: colors.accent(1.1) }, // For a11y, we need at least 4.5:1 contrast agaisnst the gray background
         },
         'Broad Methods Repository'

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -31,7 +31,7 @@ import colors, { terraSpecial } from 'src/libs/colors';
 import { reportError, withErrorReporting } from 'src/libs/error';
 import Events, { extractWorkspaceDetails } from 'src/libs/events';
 import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
-import { DEPRECATE_FIRECLOUD_UI, ENABLE_WORKFLOW_RESOURCE_MONITORING } from 'src/libs/feature-previews-config';
+import { ENABLE_WORKFLOW_RESOURCE_MONITORING, FIRECLOUD_UI_MIGRATION } from 'src/libs/feature-previews-config';
 import { HiddenLabel } from 'src/libs/forms';
 import * as Nav from 'src/libs/nav';
 import { useCancellation, useOnMount, withCancellationSignal } from 'src/libs/react-utils';
@@ -890,7 +890,7 @@ export const WorkflowView = _.flow(
                       Link,
                       {
                         href: methodLink(modifiedConfig),
-                        ...(isFeaturePreviewEnabled(DEPRECATE_FIRECLOUD_UI) ? {} : Utils.newTabLinkProps),
+                        ...(isFeaturePreviewEnabled(FIRECLOUD_UI_MIGRATION) ? {} : Utils.newTabLinkProps),
                       },
                       [sourceDisplay]
                     ),

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -31,7 +31,7 @@ import colors, { terraSpecial } from 'src/libs/colors';
 import { reportError, withErrorReporting } from 'src/libs/error';
 import Events, { extractWorkspaceDetails } from 'src/libs/events';
 import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
-import { ENABLE_WORKFLOW_RESOURCE_MONITORING } from 'src/libs/feature-previews-config';
+import { DEPRECATE_FIRECLOUD_UI, ENABLE_WORKFLOW_RESOURCE_MONITORING } from 'src/libs/feature-previews-config';
 import { HiddenLabel } from 'src/libs/forms';
 import * as Nav from 'src/libs/nav';
 import { useCancellation, useOnMount, withCancellationSignal } from 'src/libs/react-utils';
@@ -890,7 +890,7 @@ export const WorkflowView = _.flow(
                       Link,
                       {
                         href: methodLink(modifiedConfig),
-                        ...Utils.newTabLinkProps,
+                        ...(isFeaturePreviewEnabled(DEPRECATE_FIRECLOUD_UI) ? {} : Utils.newTabLinkProps),
                       },
                       [sourceDisplay]
                     ),

--- a/src/pages/workspaces/workspace/workflows/methodLink.js
+++ b/src/pages/workspaces/workspace/workflows/methodLink.js
@@ -1,7 +1,7 @@
 import { getEnabledBrand } from 'src/libs/brand-utils';
 import { getConfig } from 'src/libs/config';
 import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
-import { DEPRECATE_FIRECLOUD_UI } from 'src/libs/feature-previews-config';
+import { FIRECLOUD_UI_MIGRATION } from 'src/libs/feature-previews-config';
 import * as Nav from 'src/libs/nav';
 
 export const methodLink = (config) => {
@@ -10,7 +10,7 @@ export const methodLink = (config) => {
   } = config;
 
   if (sourceRepo === 'agora') {
-    if (isFeaturePreviewEnabled(DEPRECATE_FIRECLOUD_UI)) {
+    if (isFeaturePreviewEnabled(FIRECLOUD_UI_MIGRATION)) {
       return Nav.getLink('workflow-dashboard', { namespace: methodNamespace, name: methodName, snapshotId: methodVersion });
     }
     return `${getConfig().firecloudUrlRoot}/?return=${getEnabledBrand().queryName}#methods/${methodNamespace}/${methodName}/${methodVersion}`;

--- a/src/pages/workspaces/workspace/workflows/methodLink.js
+++ b/src/pages/workspaces/workspace/workflows/methodLink.js
@@ -1,11 +1,19 @@
 import { getEnabledBrand } from 'src/libs/brand-utils';
 import { getConfig } from 'src/libs/config';
+import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
+import { DEPRECATE_FIRECLOUD_UI } from 'src/libs/feature-previews-config';
+import * as Nav from 'src/libs/nav';
 
 export const methodLink = (config) => {
   const {
     methodRepoMethod: { sourceRepo, methodVersion, methodNamespace, methodName, methodPath },
   } = config;
-  return sourceRepo === 'agora'
-    ? `${getConfig().firecloudUrlRoot}/?return=${getEnabledBrand().queryName}#methods/${methodNamespace}/${methodName}/${methodVersion}`
-    : `${getConfig().dockstoreUrlRoot}/workflows/${methodPath}:${methodVersion}`;
+
+  if (sourceRepo === 'agora') {
+    if (isFeaturePreviewEnabled(DEPRECATE_FIRECLOUD_UI)) {
+      return Nav.getLink('workflow-dashboard', { namespace: methodNamespace, name: methodName, snapshotId: methodVersion });
+    }
+    return `${getConfig().firecloudUrlRoot}/?return=${getEnabledBrand().queryName}#methods/${methodNamespace}/${methodName}/${methodVersion}`;
+  }
+  return `${getConfig().dockstoreUrlRoot}/workflows/${methodPath}:${methodVersion}`;
 };


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WM-2538

## Summary of changes:
Redirect current links to the method repo to instead target workflows pages in Terra UI.

Behind feature flag because these pages are currently incomplete.

<!-- ### Visual Aids -->
Broad Methods Repository link updated (but only behind feature flag) - 
<img width="1310" alt="image" src="https://github.com/DataBiosphere/terra-ui/assets/13006282/02f15cd9-158b-47cc-90d4-47a0de462815">

