### PR TITLE
[WM-2551] Allow struct-building optional structs

### DIFF
--- a/src/workflows-app/components/InputsTable.ts
+++ b/src/workflows-app/components/InputsTable.ts
@@ -15,8 +15,9 @@ import {
   WithWarnings,
 } from 'src/workflows-app/components/inputs-common';
 import { StructBuilderModal } from 'src/workflows-app/components/StructBuilder';
-import { InputDefinition, ObjectBuilderInputSource, StructInputType } from 'src/workflows-app/models/submission-models';
+import { InputDefinition, ObjectBuilderInputSource } from 'src/workflows-app/models/submission-models';
 import {
+  asStructType,
   getInputTableData,
   InputTableData,
   inputTypeStyle,
@@ -158,7 +159,7 @@ const InputsTable = ({
       structBuilderRow !== undefined &&
       h(StructBuilderModal, {
         structName: inputTableData[structBuilderRow].variable,
-        structType: inputTableData[structBuilderRow].inputType as StructInputType,
+        structType: asStructType(inputTableData[structBuilderRow].inputType),
         structSource: inputTableData[structBuilderRow].source as ObjectBuilderInputSource,
         setStructSource: (source) =>
           setConfiguredInputDefinition(

--- a/src/workflows-app/components/StructBuilder.ts
+++ b/src/workflows-app/components/StructBuilder.ts
@@ -22,6 +22,7 @@ import {
   StructInputType,
 } from 'src/workflows-app/models/submission-models';
 import {
+  asStructType,
   inputTypeStyle,
   isInputOptional,
   renderTypeText,
@@ -86,7 +87,7 @@ export const StructBuilder = (props: StructBuilderProps) => {
   const structSourcePath = buildStructSourcePath(structIndexPath);
   const structTypeNamePath = buildStructTypeNamePath(structIndexPath);
 
-  const currentStructType = structTypePath ? (_.get(structTypePath, structType) as StructInputType) : structType;
+  const currentStructType = structTypePath ? asStructType(_.get(structTypePath, structType)) : structType;
   const currentStructSource = structSourcePath
     ? (_.get(structSourcePath, structSource) as ObjectBuilderInputSource)
     : structSource;

--- a/src/workflows-app/components/inputs-common.js
+++ b/src/workflows-app/components/inputs-common.js
@@ -177,7 +177,7 @@ export const InputSourceSelect = (props) => {
           type: newType,
         };
       } else {
-        const paramDefault = inputTypeParamDefaults[newType](inputType);
+        const paramDefault = inputTypeParamDefaults[newType](unwrappedType);
         newSource = {
           type: newType,
           ...paramDefault,

--- a/src/workflows-app/components/inputs-common.js
+++ b/src/workflows-app/components/inputs-common.js
@@ -177,7 +177,7 @@ export const InputSourceSelect = (props) => {
           type: newType,
         };
       } else {
-        const paramDefault = inputTypeParamDefaults[newType](unwrappedType);
+        const paramDefault = inputTypeParamDefaults[newType](inputType);
         newSource = {
           type: newType,
           ...paramDefault,

--- a/src/workflows-app/utils/submission-utils.ts
+++ b/src/workflows-app/utils/submission-utils.ts
@@ -194,6 +194,14 @@ export const renderTypeText = (iotype: InputType): string => {
 export const unwrapOptional = (input: InputType): Exclude<InputType, OptionalInputType> =>
   input.type === 'optional' ? input.optional_type : input;
 
+export const asStructType = (input: InputType): StructInputType => {
+  const unwrapped = unwrapOptional(input);
+  if (unwrapped.type === 'struct') {
+    return unwrapped as StructInputType;
+  }
+  throw new Error('Not a struct');
+};
+
 type InputValidation =
   | {
       type: 'error' | 'info' | 'success';

--- a/src/workflows-app/utils/submission-utils.ts
+++ b/src/workflows-app/utils/submission-utils.ts
@@ -158,8 +158,8 @@ export const inputSourceTypes = _.invert(inputSourceLabels);
 export const inputTypeParamDefaults = {
   literal: () => ({ parameter_value: '' }),
   record_lookup: () => ({ record_attribute: '' }),
-  object_builder: (inputType: StructInputType) => ({
-    fields: inputType.fields.map((field) => ({ name: field.field_name, source: { type: 'none' } })),
+  object_builder: (inputType: InputType) => ({
+    fields: asStructType(inputType).fields.map((field) => ({ name: field.field_name, source: { type: 'none' } })),
   }),
 };
 


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WM-2551

## Summary of changes:
Update struct builder to support optional struct inputs

### What
Fix instances of `x as StructInputType` to instead go via a a function which correctly handles optional input types containing structs

