### PR TITLE
UIE-120 Moved makeMenuIcon to package and export it from internal PopupTrigger.

### DIFF
--- a/packages/components/src/PopupTrigger.tsx
+++ b/packages/components/src/PopupTrigger.tsx
@@ -14,8 +14,10 @@ import {
 } from 'react';
 import onClickOutside from 'react-onclickoutside';
 
+import { IconId } from '.';
 import { FocusTrap } from './FocusTrap';
 import { useUniqueId } from './hooks/useUniqueId';
+import { icon, IconProps } from './icon';
 import { computePopupPosition, Side, useBoundingRects } from './internal/popup-utils';
 import { PopupPortal } from './internal/PopupPortal';
 import { useThemeFromContext } from './theme';
@@ -25,6 +27,10 @@ type DivProps = JSX.IntrinsicElements['div'];
 // The role of the popup element must match the aria-haspopup attribute of the popup trigger element.
 // aria-popup supports a limited subset of ARIA roles.
 type PopupRole = Exclude<AriaAttributes['aria-haspopup'], boolean | 'true' | 'false'>;
+
+export const makeMenuIcon = (iconName: IconId, props?: IconProps | undefined) => {
+  return icon(iconName, { ...{ size: 15, style: { marginRight: '.3rem' } }, ...props });
+};
 
 interface PopupElementProps extends Omit<DivProps, 'role'> {
   role: PopupRole;

--- a/src/components/PopupTrigger.js
+++ b/src/components/PopupTrigger.js
@@ -1,13 +1,9 @@
 import { PopupTrigger } from '@terra-ui-packages/components';
-import _ from 'lodash/fp';
 import { h, hr } from 'react-hyperscript-helpers';
-import { icon } from 'src/components/icons';
 import { VerticalNavigation } from 'src/components/keyboard-nav';
 import colors from 'src/libs/colors';
 
-export const makeMenuIcon = (iconName, props) => {
-  return icon(iconName, _.merge({ size: 15, style: { marginRight: '.3rem' } }, props));
-};
+export { makeMenuIcon } from '@terra-ui-packages/components';
 
 export const MenuDivider = () =>
   hr({


### PR DESCRIPTION
### Jira Ticket: [UIE-120](https://broadworkbench.atlassian.net/browse/UIE-120)

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Move makeMenuIcon method to components package

### Why
- To support porting the Cloud Environments page to a package.

### Testing strategy
- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac --> 


[UIE-120]: https://broadworkbench.atlassian.net/browse/UIE-120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ