### PR TITLE
[TUIM-87] Update service account used to run integration tests locally

### DIFF
--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "test": "jest",
-    "test-local": "TERRA_SA_KEY=$(vault read --format=json secret/dsde/firecloud/alpha/common/firecloud-account.json | jq .data) LYLE_SA_KEY=$(vault read --format=json secret/dsde/terra/envs/common/lyle-user-service-account-key | jq .data) TEST_URL=http://localhost:3000 yarn test",
+    "test-local": "TERRA_SA_KEY=$(vault read --format=json secret/dsde/firecloud/dev/common/firecloud-account.json | jq .data) LYLE_SA_KEY=$(vault read --format=json secret/dsde/terra/envs/common/lyle-user-service-account-key | jq .data) TEST_URL=http://localhost:3000 yarn test",
     "test-flakes": "FLAKES=true yarn test-local --runInBand"
   },
   "devDependencies": {


### PR DESCRIPTION
The service account passed via `TERRA_SA_KEY` is used to create tokens for the test user (`Scarlett.Flowerpicker@test.firecloud.org`).

We're currently using a service account in the alpha project. Since that project is no more, we need to use a different service account. This switches the `test-local` script to use a service account from the dev project. This is the same service account that is now used for tests run in CircleCI.