### PR TITLE
[TUIM-88] Increase resource class for integration tests job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,6 +285,7 @@ jobs:
           env: staging
   integration-tests-staging:
     executor: puppeteer
+    resource_class: medium+
     parallelism: 4
     steps:
       - integration-tests:


### PR DESCRIPTION
We keep seeing integration tests on the dev branch fail with exit code 137, which suggests the job is running into memory limits.

This increases the resource class for integration tests from medium to medium+. The integration tests run against PR branches already use medium+.