### PR TITLE
[AJ-1720] Use dedicated group for Azure TDR import feature preview

### DIFF
--- a/src/libs/feature-previews-config.ts
+++ b/src/libs/feature-previews-config.ts
@@ -105,7 +105,7 @@ const featurePreviewsConfig: readonly FeaturePreview[] = [
     id: ENABLE_AZURE_TDR_IMPORT,
     title: 'Azure TDR Import',
     description: 'Enabling this feature will allow importing TDR snapshots into Azure workspaces.',
-    groups: ['dsp-analysis-journeys'],
+    groups: ['preview-azure-tdr-import'],
     feedbackUrl: `mailto:dsp-analysis-journeys@broadinstitute.org?subject=${encodeURIComponent(
       'Feedback on Azure TDR snapshot Import'
     )}`,


### PR DESCRIPTION
Add a dedicated group for this feature preview so we can grant access to users outside of our team.

I've added the AJ group as an admin of this group, so AJ developers should not lose access to the feature preview with this change.