### PR TITLE
ID-1189 Remediate Signout Redirect Regression

### DIFF
--- a/src/auth/signout/SignOutPage.test.tsx
+++ b/src/auth/signout/SignOutPage.test.tsx
@@ -2,7 +2,9 @@ import { render } from '@testing-library/react';
 import React from 'react';
 import { OidcUser } from 'src/auth/oidc-broker';
 import { SignOutPage } from 'src/auth/signout/SignOutPage';
+import * as Nav from 'src/libs/nav';
 import { authStore, azureCookieReadyStore, cookieReadyStore, metricStore, oidcStore, userStore } from 'src/libs/state';
+import { asMockedFn } from 'src/testing/test-utils';
 
 type NavExports = typeof import('src/libs/nav');
 jest.mock(
@@ -12,6 +14,7 @@ jest.mock(
     getCurrentUrl: jest.fn().mockReturnValue(new URL('https://app.terra.bio')),
     getLink: jest.fn().mockImplementation((_) => _),
     goToPath: jest.fn(),
+    useRoute: jest.fn().mockReturnValue({ query: {} }),
   })
 );
 
@@ -37,5 +40,22 @@ describe('SignOutPage', () => {
     expect(metricStore.get().anonymousId).toBe('12345');
     expect(metricStore.get().sessionId).toBeUndefined();
     expect(userStore.get().enterpriseFeatures).toEqual([]);
+  });
+  it('redirects to the root path if no state is provided', () => {
+    // Act
+    render(<SignOutPage />);
+    // Assert
+    expect(Nav.goToPath).toHaveBeenCalledWith('root');
+  });
+  it('redirects to the decoded state path if state is provided', () => {
+    // Arrange
+    const encodedState = btoa(
+      JSON.stringify({ postLogoutRedirect: { name: 'foo', query: { a: 'a', b: 'b' }, params: { foo: 'bar' } } })
+    );
+    asMockedFn(Nav.useRoute).mockReturnValue({ query: { state: encodedState } });
+    // Act
+    render(<SignOutPage />);
+    // Assert
+    expect(Nav.goToPath).toHaveBeenCalledWith('foo', { foo: 'bar' }, { a: 'a', b: 'b' });
   });
 });

--- a/src/auth/signout/SignOutPage.tsx
+++ b/src/auth/signout/SignOutPage.tsx
@@ -1,17 +1,24 @@
 import { useEffect } from 'react';
-import { userSignedOut } from 'src/auth/signout/sign-out';
+import { SignOutState, userSignedOut } from 'src/auth/signout/sign-out';
 import * as Nav from 'src/libs/nav';
 
 export const signOutCallbackLinkName = 'signout-callback';
 export const SignOutPage = () => {
+  const { query } = Nav.useRoute();
+  const { state } = query;
+  const decodedState: SignOutState | undefined = state ? JSON.parse(atob(state)).postLogoutRedirect : undefined;
   useEffect(() => {
     try {
       userSignedOut();
     } catch (e) {
       console.error(e);
     }
-    Nav.goToPath('root');
-  }, []);
+    if (decodedState) {
+      Nav.goToPath(decodedState.name, decodedState.params, decodedState.query);
+    } else {
+      Nav.goToPath('root');
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
   return null;
 };
 


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/ID-1189

When signing in after being signed out, Terra-UI used to redirect the user to the page they were on pre-signout. When we updated the signout process, we introduced a regression which just redirected the user to the home page when signing in again.

To do this, we can give B2C a `state` param, which it will include in its redirect after sign out. On `SignOutPage`, we can read that state. So, just include the route that the user was on pre-signout, then redirect them there post-signout, using the `state` parameter to persist the information.

### Testing strategy
- [x] Tested Locally
- [x] Unit Tests

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
