### PR TITLE
DC-866: Change search API parameter to use domain `id` instead of `name`

### DIFF
--- a/src/libs/ajax/DataRepo.ts
+++ b/src/libs/ajax/DataRepo.ts
@@ -197,7 +197,7 @@ export const DataRepo = (signal?: AbortSignal): DataRepoContract => ({
       searchConcepts: async (domain: SnapshotBuilderConcept, searchText: string): Promise<GetConceptsResponse> => {
         return callDataRepo(
           `repository/v1/datasets/${datasetId}/snapshotBuilder/concepts/${
-            domain.name
+            domain.id
           }/search?searchText=${encodeURIComponent(searchText)}`
         );
       },


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/DC-866

### What

The snapshot builder `search` API previously required the domain name as a parameter, and now it requires the domain's concept ID.

### Why

Earlier it made sense to use the name, for backend purposes, but the backend can now match the concept ID to the name and no longer needs the UI to provide it.

### Testing strategy

Unit tests