### PR TITLE
[AJ-1746] Load Google project for workspaces on import data page

### DIFF
--- a/src/import-data/ImportDataDestination.ts
+++ b/src/import-data/ImportDataDestination.ts
@@ -135,6 +135,7 @@ export const ImportDataDestination = (props: ImportDataDestinationProps): ReactN
       'workspace.authorizationDomain',
       'workspace.cloudPlatform',
       'workspace.createdBy',
+      'workspace.googleProject',
       'workspace.lastModified',
       'workspace.name',
       'workspace.namespace',


### PR DESCRIPTION
When importing data into a template workspace, `NewWorkspaceModal` is rendered with its `cloneWorkspace` prop set to the selected template workspace.

https://github.com/DataBiosphere/terra-ui/blob/f5cd9a8cf723dcd66748b3703ac9d79c16f79227/src/import-data/ImportDataDestination.ts#L386-L401

The selected template workspace is pulled from the list of workspaces loaded by `ImportDataDestination`

https://github.com/DataBiosphere/terra-ui/blob/f5cd9a8cf723dcd66748b3703ac9d79c16f79227/src/import-data/ImportDataDestination.ts#L388

https://github.com/DataBiosphere/terra-ui/blob/f5cd9a8cf723dcd66748b3703ac9d79c16f79227/src/import-data/ImportDataDestination.ts#L118-L153

When `NewWorkspaceModal` is rendered with a `cloneWorkspace`, it (among other things) loads the clone workspace's bucket location if the clone workspace is a Google workspace.

https://github.com/DataBiosphere/terra-ui/blob/f5cd9a8cf723dcd66748b3703ac9d79c16f79227/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.ts#L287-L303

However, because `ImportDataDestination` does not request the `workspace.googleProject` attribute, `cloneWorkspace.workspace.googleProject` is undefined here and the `checkBucketLocation` call fails when it asks Sam for a token for a pet service account in a Google project named "undefined".

https://github.com/DataBiosphere/terra-ui/blob/f5cd9a8cf723dcd66748b3703ac9d79c16f79227/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.ts#L291

https://github.com/DataBiosphere/terra-ui/blob/f5cd9a8cf723dcd66748b3703ac9d79c16f79227/src/libs/ajax/GoogleStorage.ts#L159-L166

This resolves the issue by loading the `workspace.googleProject` attribute.

