### PR TITLE
ID-1197 Correct Error During Account Linking

### DIFF
--- a/src/libs/ajax/ExternalCredentials.ts
+++ b/src/libs/ajax/ExternalCredentials.ts
@@ -49,7 +49,12 @@ export const ExternalCredentials = (signal?: AbortSignal) => (oAuth2Provider: OA
         )}`,
         _.merge(authOpts(), { signal, method: 'POST' })
       );
-      return res.json();
+      const json = await res.json();
+      return {
+        externalUserId: json.externalUserId,
+        expirationTimestamp: new Date(json.expirationTimestamp),
+        authenticated: json.authenticated,
+      };
     },
     unlinkAccount: async (): Promise<void> => {
       await fetchEcm(oauthRoot, _.merge(authOpts(), { signal, method: 'DELETE' }));

--- a/src/libs/link-expiration-alerts.tsx
+++ b/src/libs/link-expiration-alerts.tsx
@@ -45,35 +45,40 @@ export const getOAuth2ProviderLinkExpirationAlert = (
   status: EcmLinkAccountResponse,
   now: number
 ) => {
-  const { key, name } = provider;
-  const { expirationTimestamp } = status;
+  if (status) {
+    const { key, name } = provider;
+    const { expirationTimestamp } = status;
 
-  const dateOfExpiration = expirationTimestamp.getTime();
-  const shouldNotify = Boolean(dateOfExpiration) && now >= addDays(-5, dateOfExpiration).getTime();
+    const dateOfExpiration = expirationTimestamp.getTime();
+    const shouldNotify = Boolean(dateOfExpiration) && now >= addDays(-5, dateOfExpiration).getTime();
 
-  if (!shouldNotify) {
-    return null;
+    if (!shouldNotify) {
+      return null;
+    }
+
+    const hasExpired = now >= dateOfExpiration;
+    const expireStatus = hasExpired
+      ? 'has expired'
+      : `will expire in ${differenceInDays(now, dateOfExpiration)} day(s)`;
+
+    return {
+      id: `oauth2-account-link-expiration/${key}`,
+      title: `Your access to ${name} ${expireStatus}.`,
+      message: (
+        <div>
+          Log in to{' '}
+          <LinkOAuth2Account
+            linkText={expireStatus === 'has expired' ? 'restore ' : 'renew '}
+            provider={provider}
+            button={false}
+          />{' '}
+          your access or <UnlinkOAuth2Account linkText="unlink" provider={provider} /> your account.
+        </div>
+      ),
+      severity: 'info',
+    };
   }
-
-  const hasExpired = now >= dateOfExpiration;
-  const expireStatus = hasExpired ? 'has expired' : `will expire in ${differenceInDays(now, dateOfExpiration)} day(s)`;
-
-  return {
-    id: `oauth2-account-link-expiration/${key}`,
-    title: `Your access to ${name} ${expireStatus}.`,
-    message: (
-      <div>
-        Log in to{' '}
-        <LinkOAuth2Account
-          linkText={expireStatus === 'has expired' ? 'restore ' : 'renew '}
-          provider={provider}
-          button={false}
-        />{' '}
-        your access or <UnlinkOAuth2Account linkText="unlink" provider={provider} /> your account.
-      </div>
-    ),
-    severity: 'info',
-  };
+  return undefined;
 };
 
 export const getLinkExpirationAlerts = (authState: AuthState): Alert[] => {

--- a/src/libs/link-expiration-alerts.tsx
+++ b/src/libs/link-expiration-alerts.tsx
@@ -45,40 +45,35 @@ export const getOAuth2ProviderLinkExpirationAlert = (
   status: EcmLinkAccountResponse,
   now: number
 ) => {
-  if (status) {
-    const { key, name } = provider;
-    const { expirationTimestamp } = status;
+  const { key, name } = provider;
+  const { expirationTimestamp } = status;
 
-    const dateOfExpiration = expirationTimestamp.getTime();
-    const shouldNotify = Boolean(dateOfExpiration) && now >= addDays(-5, dateOfExpiration).getTime();
+  const dateOfExpiration = expirationTimestamp.getTime();
+  const shouldNotify = Boolean(dateOfExpiration) && now >= addDays(-5, dateOfExpiration).getTime();
 
-    if (!shouldNotify) {
-      return null;
-    }
-
-    const hasExpired = now >= dateOfExpiration;
-    const expireStatus = hasExpired
-      ? 'has expired'
-      : `will expire in ${differenceInDays(now, dateOfExpiration)} day(s)`;
-
-    return {
-      id: `oauth2-account-link-expiration/${key}`,
-      title: `Your access to ${name} ${expireStatus}.`,
-      message: (
-        <div>
-          Log in to{' '}
-          <LinkOAuth2Account
-            linkText={expireStatus === 'has expired' ? 'restore ' : 'renew '}
-            provider={provider}
-            button={false}
-          />{' '}
-          your access or <UnlinkOAuth2Account linkText="unlink" provider={provider} /> your account.
-        </div>
-      ),
-      severity: 'info',
-    };
+  if (!shouldNotify) {
+    return null;
   }
-  return undefined;
+
+  const hasExpired = now >= dateOfExpiration;
+  const expireStatus = hasExpired ? 'has expired' : `will expire in ${differenceInDays(now, dateOfExpiration)} day(s)`;
+
+  return {
+    id: `oauth2-account-link-expiration/${key}`,
+    title: `Your access to ${name} ${expireStatus}.`,
+    message: (
+      <div>
+        Log in to{' '}
+        <LinkOAuth2Account
+          linkText={expireStatus === 'has expired' ? 'restore ' : 'renew '}
+          provider={provider}
+          button={false}
+        />{' '}
+        your access or <UnlinkOAuth2Account linkText="unlink" provider={provider} /> your account.
+      </div>
+    ),
+    severity: 'info',
+  };
 };
 
 export const getLinkExpirationAlerts = (authState: AuthState): Alert[] => {

--- a/src/profile/external-identities/OAuth2Account.tsx
+++ b/src/profile/external-identities/OAuth2Account.tsx
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp';
-import React from 'react';
+import React, { useState } from 'react';
 import { ClipboardButton } from 'src/components/ClipboardButton';
 import { Ajax } from 'src/libs/ajax';
 import colors from 'src/libs/colors';
@@ -69,8 +69,9 @@ export const OAuth2Account = (props: OAuth2AccountProps) => {
   };
   const signal = useCancellation();
   const callbacks: Array<OAuth2Callback['name']> = ['oauth-callback', 'ecm-callback', 'fence-callback']; // ecm-callback is deprecated, but still needs to be supported
-  const isLinking =
-    callbacks.includes(Nav.getCurrentRoute().name) && state && JSON.parse(atob(state)).provider === provider.key;
+  const [isLinking, setIsLinking] = useState(
+    callbacks.includes(Nav.getCurrentRoute().name) && state && JSON.parse(atob(state)).provider === provider.key
+  );
 
   useOnMount(() => {
     const linkAccount = withErrorReporting(`Error linking ${provider.short} account`)(async (code, state) => {
@@ -78,6 +79,7 @@ export const OAuth2Account = (props: OAuth2AccountProps) => {
         .ExternalCredentials(provider)
         .linkAccountWithAuthorizationCode(code, state);
       authStore.update(_.set(['oAuth2AccountStatus', provider.key], accountInfo));
+      setIsLinking(false);
     });
 
     if (isLinking) {


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/ID-1197

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
Correct error during account linking

### What
- An error in account linking was discovered when ECM Account Linking was merged to Dev. This could only have been found on dev, and not before in BEEs or local testing.

We forgot to wrap the timestamp returned by ECM during account linking in `new Date()`, which caused the a `s.getTime is not a function` error down the line.
 

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [x] Testing by deploying this branch to dev manually and linking accounts

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
