### PR TITLE
[WM-2594] Stop error popup for private workflows

### DIFF
--- a/src/workflows-app/SubmissionConfig.js
+++ b/src/workflows-app/SubmissionConfig.js
@@ -249,9 +249,11 @@ export const BaseSubmissionConfig = (
   useEffect(() => {
     async function getWorkflowScript() {
       try {
-        const workflowUrlRaw = await convertToRawUrl(selectedMethodVersion.url, selectedMethodVersion.name, method.source);
-        const script = await Ajax(signal).WorkflowScript.get(workflowUrlRaw);
-        setWorkflowScript(script);
+        if (!method.isPrivate) {
+          const workflowUrlRaw = await convertToRawUrl(selectedMethodVersion.url, selectedMethodVersion.name, method.source);
+          const script = await Ajax(signal).WorkflowScript.get(workflowUrlRaw);
+          setWorkflowScript(script);
+        }
       } catch (error) {
         notify('error', 'Error loading workflow script', { detail: error instanceof Response ? await error.text() : error });
       }
@@ -329,7 +331,8 @@ export const BaseSubmissionConfig = (
             h(
               Link,
               {
-                disabled: workflowScript == null || method.isPrivate === true,
+                tooltip: method?.isPrivate === true ? 'View Workflow Script not yet available for private workflows' : undefined,
+                disabled: workflowScript == null || method?.isPrivate === true,
                 onClick: () => setViewWorkflowScriptModal(true),
               },
               'View Workflow Script'

--- a/src/workflows-app/SubmissionConfig.test.js
+++ b/src/workflows-app/SubmissionConfig.test.js
@@ -909,10 +909,11 @@ describe('Initial state', () => {
     expect(mockTypesResponse).toHaveBeenCalledTimes(1);
     expect(mockMethodsResponse).toHaveBeenCalledTimes(1);
     expect(mockSearchResponse).toHaveBeenCalledTimes(1);
-    expect(mockWdlResponse).toHaveBeenCalledTimes(1);
+    expect(mockWdlResponse).toHaveBeenCalledTimes(0);
 
     const button = screen.getByRole('button', { name: 'View Workflow Script' });
     expect(button.getAttribute('aria-disabled')).toBe('true');
+    expect(screen.getByText('View Workflow Script not yet available for private workflows')).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WM-2594

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Stopping the WDL check function if checking for a private workflow

### Why
- We don't want an error notification to be popping up for private workflows since we do not suppoer this functionality. So, if the workflow is private, we won't try to fetch the wdl script.

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [x] unit tests

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->

<img width="1762" alt="image" src="https://github.com/DataBiosphere/terra-ui/assets/68349264/0adccd5b-5ed7-45d2-b714-9e1775346999">


[WM-2594]: https://broadworkbench.atlassian.net/browse/WM-2594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ