### PR TITLE
[AJ-1678] Do not display purpose: policy snapshot references

### DIFF
--- a/src/workspace-data/Data.js
+++ b/src/workspace-data/Data.js
@@ -626,7 +626,11 @@ export const WorkspaceData = _.flow(
             return _.set([name, 'resource'], _.merge(metadata, attributes), acc);
           },
           _.pick(_.map('name', _.map('metadata', snapshotBody)), snapshotDetails) || {}, // retain entities if loaded from state history, but only for snapshots that exist
-          snapshotBody
+          _.filter((snapshot) => {
+            // Do not display snapshot references that are only created for linking policies.
+            const isForPolicy = snapshot.metadata.properties.some((p) => p.key === 'purpose' && p.value === 'policy');
+            return !isForPolicy;
+          }, snapshotBody)
         );
 
         setSnapshotDetails(snapshots);


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1678

When importing data from a TDR snapshot (including snapshot data contained in PFB files), CWDS links the snapshot policies to the workspace by creating a snapshot reference with a "purpose: policy" flag.

In the past, we used snapshot references as a way to access snapshot data in a workspace. Thus, Terra UI displays a workspace's snapshot references on the Data tab and allows information about the referenced snapshot.

However, we've since moved to import snapshot data by coping the tabular data into the workspace. As a result, when snapshot data is imported using CWDS, currently Terra UI shows _both_ the copied data in the workspace's data tables _and_ the snapshot reference. We want to only show the data table and hide the snapshot reference.


Note: this is definitely the shortcut method. I did start on factoring out the snapshot list but it was turning into a larger project. I went this route to go ahead and unblock deploying CWDS.