### PR TITLE
[AJ-1572] Add e2e test for importing TDR snapshot

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,3 +37,4 @@
 /integration-tests/tests/request-access.js @DataBiosphere/data-explorer-eng
 /integration-tests/tests/run-catalog* @DataBiosphere/data-explorer-eng
 /integration-tests/utils/catalog-utils.js @DataBiosphere/data-explorer-eng
+/integration-tests/utils/import-tdr-snapshot.ts @DataBiosphere/analysisjourneys

--- a/integration-tests/slack/slack-notify-channels.json
+++ b/integration-tests/slack/slack-notify-channels.json
@@ -100,6 +100,9 @@
         },
         {
           "name": "preview-drs-uri"
+        },
+        {
+          "name": "import-tdr-snapshot"
         }
       ]
     }

--- a/integration-tests/tests/import-tdr-snapshot.ts
+++ b/integration-tests/tests/import-tdr-snapshot.ts
@@ -23,7 +23,7 @@ const importTdrSnapshot = _.flow(
   const importUrl = `${testUrl}/#import-data?${qs.stringify({
     format: 'tdrexport',
     snapshotId: tdrSnapshot.id,
-    snapshotName: 'aj_group_constraint_test_dataset_1_snapshot_1',
+    snapshotName: tdrSnapshot.name,
     tdrmanifest: tdrSnapshot.manifestUrl,
     tdrSyncPermissions: false,
     url: tdrSnapshot.tdrUrl,

--- a/integration-tests/tests/import-tdr-snapshot.ts
+++ b/integration-tests/tests/import-tdr-snapshot.ts
@@ -55,6 +55,7 @@ const importTdrSnapshot = _.flow(
   await waitForNoSpinners(page);
 
   // Assert policy has propagated from snapshot to workspace
+  await findText(page, 'Data Access ControlsYes');
   await click(page, clickable({ text: 'Authorization domain' }));
   await findText(page, tdrSnapshot.groupConstraint);
 });

--- a/integration-tests/tests/import-tdr-snapshot.ts
+++ b/integration-tests/tests/import-tdr-snapshot.ts
@@ -62,5 +62,4 @@ const importTdrSnapshot = _.flow(
 registerTest({
   name: 'import-tdr-snapshot',
   fn: importTdrSnapshot,
-  targetEnvironments: ['dev'],
 });

--- a/integration-tests/tests/import-tdr-snapshot.ts
+++ b/integration-tests/tests/import-tdr-snapshot.ts
@@ -1,0 +1,66 @@
+const _ = require('lodash/fp');
+const qs = require('qs');
+
+const { withProtectedWorkspace } = require('../utils/integration-helpers');
+const {
+  click,
+  clickable,
+  dismissInfoNotifications,
+  findText,
+  navChild,
+  select,
+  signIntoTerra,
+  waitForNoSpinners,
+} = require('../utils/integration-utils');
+const { registerTest } = require('../utils/jest-utils');
+const { withUserToken } = require('../utils/terra-sa-utils');
+
+const importTdrSnapshot = _.flow(
+  withProtectedWorkspace,
+  withUserToken
+)(async ({ page, tdrSnapshot, testUrl, token, workspaceName }) => {
+  // Navigate to import page
+  const importUrl = `${testUrl}/#import-data?${qs.stringify({
+    format: 'tdrexport',
+    snapshotId: tdrSnapshot.id,
+    snapshotName: 'aj_group_constraint_test_dataset_1_snapshot_1',
+    tdrmanifest: tdrSnapshot.manifestUrl,
+    tdrSyncPermissions: false,
+    url: tdrSnapshot.tdrUrl,
+  })}`;
+  await signIntoTerra(page, { token, testUrl: importUrl });
+
+  // Select workspace
+  await click(page, clickable({ textContains: 'Select an existing workspace' }));
+  await select(page, 'Select a workspace', workspaceName);
+
+  // Import
+  await click(page, clickable({ text: 'Import' }));
+  await waitForNoSpinners(page);
+
+  // Wait for import to complete
+  await findText(page, 'Data import in progress');
+  await findText(page, 'Data imported successfully', { timeout: 180000 });
+  await dismissInfoNotifications(page);
+
+  // Refresh data tab
+  await click(page, navChild('data'));
+  await waitForNoSpinners(page);
+
+  // Assert data is present
+  await findText(page, 'things (3 rows)');
+
+  // Go to workspace dashboard
+  await click(page, navChild('dashboard'));
+  await waitForNoSpinners(page);
+
+  // Assert policy has propagated from snapshot to workspace
+  await click(page, clickable({ text: 'Authorization domain' }));
+  await findText(page, tdrSnapshot.groupConstraint);
+});
+
+registerTest({
+  name: 'import-tdr-snapshot',
+  fn: importTdrSnapshot,
+  targetEnvironments: ['dev'],
+});

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -219,19 +219,7 @@ const withWorkspace = (test) => async (options) => {
 };
 
 const withProtectedWorkspace = (test) => async (options) => {
-  console.log('withWorkspace ...');
-  const { workspaceName } = await makeGcpWorkspace({ ...options, isProtected: true });
-
-  try {
-    await test({ ...options, workspaceName });
-  } finally {
-    console.log('withWorkspace cleanup ...');
-    const didDelete = await withSignedInPage(deleteWorkspaceInUi)({ ...options, workspaceName });
-    if (!didDelete) {
-      // Pass test on a failed cleanup - expect leaked resources to be cleaned up by the test `delete-orphaned-workspaces`
-      console.error(`Unable to delete workspace ${workspaceName} via the UI. The resource will be leaked!`);
-    }
-  }
+  return withWorkspace(test)({ ...options, isProtected: true });
 };
 
 /** Create an Azure workspace, run the given test, then delete the workspace. */

--- a/integration-tests/utils/terra-envs.js
+++ b/integration-tests/utils/terra-envs.js
@@ -22,5 +22,17 @@ module.exports = {
     billingProjectAzure: 'dsp-staging-testing-20230915',
     testUrl: 'https://bvdp-saturn-staging.appspot.com',
     workflowName: 'echo_to_file',
+    /**
+     * Snapshot imported in import-tdr-snapshot
+     * https://data.staging.envs-terra.bio/snapshots/cbd9a3a6-76ea-4311-bcd8-9be2d7cd2731
+     * */
+    tdrSnapshot: {
+      id: 'cbd9a3a6-76ea-4311-bcd8-9be2d7cd2731',
+      name: 'aj_group_constraint_test_dataset_1_snapshot_1',
+      manifestUrl:
+        'https://storage.googleapis.com/fixtures-for-tests/fixtures/public/tdr-snapshot/staging/aj_group_constraint_test_dataset_1_snapshot_1/manifest.json',
+      tdrUrl: 'https://data.staging.envs-terra.bio.broadinstitute.org',
+      groupConstraint: 'aj-group-constraint-test',
+    },
   },
 };

--- a/integration-tests/utils/terra-envs.js
+++ b/integration-tests/utils/terra-envs.js
@@ -2,27 +2,24 @@ module.exports = {
   dev: {
     billingProject: 'saturn-integration-test-dev',
     billingProjectAzure: 'mnolting20231030_azBpDev-1',
-    snapshotColumnName: 'name',
-    snapshotId: 'f90f5d7f-c507-4e56-abfc-b965a66023fb',
-    snapshotTableName: 'tableA',
     testUrl: 'https://bvdp-saturn-dev.appspot.com',
     workflowName: 'echo_to_file',
-  },
-  alpha: {
-    billingProject: 'saturn-integration-test-alpha',
-    billingProjectAzure: '',
-    snapshotColumnName: 'VCF_File_Name',
-    snapshotId: 'd56f4db5-b6c6-4a7e-8be2-ff6aa21c4fa6',
-    snapshotTableName: 'vcf_file',
-    testUrl: 'https://bvdp-saturn-alpha.appspot.com',
-    workflowName: 'echo_to_file',
+    /**
+     * Snapshot imported in import-tdr-snapshot
+     * https://jade.datarepo-dev.broadinstitute.org/snapshots/44108c93-f2e6-4d58-b700-425756d72db0
+     * */
+    tdrSnapshot: {
+      id: '44108c93-f2e6-4d58-b700-425756d72db0',
+      name: 'aj_group_constraint_test_dataset_1_snapshot_1',
+      manifestUrl:
+        'https://storage.googleapis.com/fixtures-for-tests/fixtures/public/tdr-snapshot/dev/aj_group_constraint_test_dataset_1_snapshot_1/manifest.json',
+      tdrUrl: 'https://jade.datarepo-dev.broadinstitute.org',
+      groupConstraint: 'aj-group-constraint-test',
+    },
   },
   staging: {
     billingProject: 'saturn-integration-test-stage',
     billingProjectAzure: 'dsp-staging-testing-20230915',
-    snapshotColumnName: 'VCF_File_Name',
-    snapshotId: 'a5624b5c-df41-4a02-8013-d3b6cd51b22a',
-    snapshotTableName: 'vcf_file',
     testUrl: 'https://bvdp-saturn-staging.appspot.com',
     workflowName: 'echo_to_file',
   },


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1572

This adds an end to end test that imports a TDR snapshot with a data access control group.

It verifies that the policy gets applied to the workspace. Currently, that means the workspace gets an authorization domain with the same group as the snapshot's data access control group.

The test is configured to only run in dev because this test relies on CWDS and it's only deployed in dev so far.