### PR TITLE
ID-1212 Restore Session Timeout Notification

### DIFF
--- a/src/auth/signout/SignOutPage.tsx
+++ b/src/auth/signout/SignOutPage.tsx
@@ -6,10 +6,9 @@ export const signOutCallbackLinkName = 'signout-callback';
 export const SignOutPage = () => {
   const { query } = Nav.useRoute();
   const { state } = query;
-  const decoded: { signOutRedirect?: SignOutRedirect; signOutCause?: SignOutCause } = state
+  const { signOutRedirect, signOutCause }: { signOutRedirect?: SignOutRedirect; signOutCause?: SignOutCause } = state
     ? JSON.parse(atob(state))
     : {};
-  const { signOutRedirect, signOutCause } = decoded;
   useEffect(() => {
     try {
       userSignedOut(signOutCause);

--- a/src/auth/signout/SignOutPage.tsx
+++ b/src/auth/signout/SignOutPage.tsx
@@ -1,20 +1,23 @@
 import { useEffect } from 'react';
-import { SignOutState, userSignedOut } from 'src/auth/signout/sign-out';
+import { SignOutCause, SignOutRedirect, userSignedOut } from 'src/auth/signout/sign-out';
 import * as Nav from 'src/libs/nav';
 
 export const signOutCallbackLinkName = 'signout-callback';
 export const SignOutPage = () => {
   const { query } = Nav.useRoute();
   const { state } = query;
-  const decodedState: SignOutState | undefined = state ? JSON.parse(atob(state)).postLogoutRedirect : undefined;
+  const decoded: { signOutRedirect?: SignOutRedirect; signOutCause?: SignOutCause } = state
+    ? JSON.parse(atob(state))
+    : {};
+  const { signOutRedirect, signOutCause } = decoded;
   useEffect(() => {
     try {
-      userSignedOut();
+      userSignedOut(signOutCause);
     } catch (e) {
       console.error(e);
     }
-    if (decodedState) {
-      Nav.goToPath(decodedState.name, decodedState.params, decodedState.query);
+    if (signOutRedirect) {
+      Nav.goToPath(signOutRedirect.name, signOutRedirect.params, signOutRedirect.query);
     } else {
       Nav.goToPath('root');
     }

--- a/src/auth/signout/sign-out.test.ts
+++ b/src/auth/signout/sign-out.test.ts
@@ -1,12 +1,10 @@
 import { DeepPartial } from '@terra-ui-packages/core-utils';
-import { sessionTimedOutErrorMessage } from 'src/auth/auth-errors';
 import { removeUserFromLocalState } from 'src/auth/oidc-broker';
 import { signOut } from 'src/auth/signout/sign-out';
 import { Ajax } from 'src/libs/ajax';
 import Events from 'src/libs/events';
 import * as Nav from 'src/libs/nav';
 import { goToPath } from 'src/libs/nav';
-import { notify, sessionTimeoutProps } from 'src/libs/notifications';
 import { OidcState, oidcStore } from 'src/libs/state';
 import { asMockedFn } from 'src/testing/test-utils';
 
@@ -18,15 +16,6 @@ jest.mock('src/libs/ajax');
 
 type AjaxExports = typeof import('src/libs/ajax');
 type AjaxContract = ReturnType<AjaxExports['Ajax']>;
-
-type NotificationExports = typeof import('src/libs/notifications');
-jest.mock(
-  'src/libs/notifications',
-  (): NotificationExports => ({
-    ...jest.requireActual('src/libs/notifications'),
-    notify: jest.fn(),
-  })
-);
 
 const currentRoute = {
   name: 'routeName',
@@ -88,26 +77,13 @@ describe('sign-out', () => {
     // Assert
     expect(captureEventFn).toHaveBeenCalledWith(Events.user.signOut.idleStatusMonitor, expect.any(Object));
   });
-  it('displays a session expired notification for an expired refresh token', () => {
-    // Arrange
-    // Act
-    signOut('expiredRefreshToken');
-    // Assert
-    expect(notify).toHaveBeenCalledWith('info', sessionTimedOutErrorMessage, sessionTimeoutProps);
-  });
-  it('displays a session expired notification for an error refreshing tokens', () => {
-    // Arrange
-    // Act
-    signOut('errorRefreshingAuthToken');
-    // Assert
-    expect(notify).toHaveBeenCalledWith('info', sessionTimedOutErrorMessage, sessionTimeoutProps);
-  });
+
   it('redirects to the signout callback page', () => {
     // Arrange
     const signoutRedirectFn = jest.fn();
     const hostname = 'https://mycoolhost.horse';
     const link = 'signout';
-    const expectedState = btoa(JSON.stringify({ postLogoutRedirect: currentRoute }));
+    const expectedState = btoa(JSON.stringify({ signOutRedirect: currentRoute, signOutCause: 'unspecified' }));
     asMockedFn(oidcStore.get).mockReturnValue({
       userManager: {
         signoutRedirect: signoutRedirectFn,


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/ID-1212


## Summary of changes:
Restored the Session Timeout notification. When we refactored the sign-out process, we neglected to move the notification firing to after the redirect. This meant that the notification fired, but the user was immediately redirected, which cleared the notification. 

### Testing strategy
Because this is the sign-out code, the best we can really do is unit test it. 

- [ ] Unit Tests

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
