### PR TITLE
ID-1213 Collect OAuth2 Account Link/Unlink Metrics

### DIFF
--- a/src/libs/events.ts
+++ b/src/libs/events.ts
@@ -111,6 +111,10 @@ const eventsList = {
     },
     register: 'user:register',
     sessionTimeout: 'user:sessionTimeout',
+    externalCredential: {
+      link: 'user:externalCredential:link',
+      unlink: 'user:externalCredential:unlink',
+    },
   },
   workflowClearIO: 'workflow:clearIO',
   workflowImport: 'workflow:import',

--- a/src/profile/external-identities/OAuth2Account.tsx
+++ b/src/profile/external-identities/OAuth2Account.tsx
@@ -4,6 +4,7 @@ import { ClipboardButton } from 'src/components/ClipboardButton';
 import { Ajax } from 'src/libs/ajax';
 import colors from 'src/libs/colors';
 import { withErrorReporting } from 'src/libs/error';
+import Events from 'src/libs/events';
 import * as Nav from 'src/libs/nav';
 import { useCancellation, useOnMount, useStore } from 'src/libs/react-utils';
 import { authStore } from 'src/libs/state';
@@ -79,6 +80,7 @@ export const OAuth2Account = (props: OAuth2AccountProps) => {
         .ExternalCredentials(provider)
         .linkAccountWithAuthorizationCode(code, state);
       authStore.update(_.set(['oAuth2AccountStatus', provider.key], accountInfo));
+      Ajax().Metrics.captureEvent(Events.user.externalCredential.link, { provider: provider.key });
       setIsLinking(false);
     });
 

--- a/src/profile/external-identities/UnlinkOAuth2Account.tsx
+++ b/src/profile/external-identities/UnlinkOAuth2Account.tsx
@@ -5,6 +5,7 @@ import { ButtonPrimary, spinnerOverlay } from 'src/components/common';
 import { Ajax } from 'src/libs/ajax';
 import colors from 'src/libs/colors';
 import { withErrorReporting } from 'src/libs/error';
+import Events from 'src/libs/events';
 import { notify } from 'src/libs/notifications';
 import { authStore } from 'src/libs/state';
 import * as Utils from 'src/libs/utils';
@@ -35,6 +36,7 @@ export const UnlinkOAuth2Account = ({ linkText, provider }: UnlinkOAuth2AccountP
       )(async () => {
         await Ajax().ExternalCredentials(provider).unlinkAccount();
         authStore.update(_.unset(['oAuth2AccountStatus', provider.key]));
+        Ajax().Metrics.captureEvent(Events.user.externalCredential.unlink, { provider: provider.key });
         setIsModalOpen(false);
         notify('success', 'Successfully unlinked account', {
           message: `Successfully unlinked your account from ${provider.name}`,


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/ID-1213
<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:

Collect metrics for OAuth2 Account Linking and Unlinking. This covers RAS, GitHub, and all Gen3 Fence Accounts.

### Why
- We love metrics!

### Testing strategy

- [x] Unit Tests

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
