### PR TITLE
[IA-4882] add full interface to disk provider and add tests

### DIFF
--- a/src/analysis/Environments/Environments.test.ts
+++ b/src/analysis/Environments/Environments.test.ts
@@ -62,7 +62,6 @@ const getMockLeoRuntimeProvider = (overrides?: Partial<LeoRuntimeProvider>): Leo
     delete: jest.fn(),
   };
   asMockedFn(defaultProvider.list).mockResolvedValue([]);
-  q;
   return { ...defaultProvider, ...overrides };
 };
 

--- a/src/analysis/Environments/Environments.test.ts
+++ b/src/analysis/Environments/Environments.test.ts
@@ -62,7 +62,7 @@ const getMockLeoRuntimeProvider = (overrides?: Partial<LeoRuntimeProvider>): Leo
     delete: jest.fn(),
   };
   asMockedFn(defaultProvider.list).mockResolvedValue([]);
-
+  q;
   return { ...defaultProvider, ...overrides };
 };
 
@@ -70,6 +70,8 @@ const getMockLeoDiskProvider = (overrides?: Partial<LeoDiskProvider>): LeoDiskPr
   const defaultProvider: LeoDiskProvider = {
     list: jest.fn(),
     delete: jest.fn(),
+    update: jest.fn(),
+    details: jest.fn(),
   };
   asMockedFn(defaultProvider.list).mockResolvedValue([]);
 

--- a/src/libs/ajax/leonardo/Disks.ts
+++ b/src/libs/ajax/leonardo/Disks.ts
@@ -9,7 +9,7 @@ import {
   RawListDiskItem,
 } from 'src/libs/ajax/leonardo/models/disk-models';
 
-export const Disks = (signal: AbortSignal) => {
+export const Disks = (signal?: AbortSignal) => {
   const diskV2Root = 'api/v2/disks';
   const v2Func = () => ({
     delete: (diskId: number): Promise<void> => {
@@ -27,11 +27,6 @@ export const Disks = (signal: AbortSignal) => {
       return mapToPdTypes(disks);
     },
     disk: (project: string, name: string) => ({
-      create: (props): Promise<void> =>
-        fetchLeo(
-          `api/google/v1/disks/${project}/${name}`,
-          _.mergeAll([authOpts(), appIdentifier, { signal, method: 'POST' }, jsonBody(props)])
-        ),
       delete: (): Promise<void> => {
         return fetchLeo(
           `api/google/v1/disks/${project}/${name}`,
@@ -61,6 +56,7 @@ export const Disks = (signal: AbortSignal) => {
   };
 };
 
+// TODO: these should be deletable?
 export type DisksAjaxContract = ReturnType<typeof Disks>;
 export type DisksAjaxContractV1 = ReturnType<DisksAjaxContract['disksV1']>;
 export type DisksAjaxContractV2 = ReturnType<DisksAjaxContract['disksV2']>;

--- a/src/libs/ajax/leonardo/Disks.ts
+++ b/src/libs/ajax/leonardo/Disks.ts
@@ -56,8 +56,7 @@ export const Disks = (signal?: AbortSignal) => {
   };
 };
 
-// TODO: these should be deletable?
-export type DisksAjaxContract = ReturnType<typeof Disks>;
-export type DisksAjaxContractV1 = ReturnType<DisksAjaxContract['disksV1']>;
-export type DisksAjaxContractV2 = ReturnType<DisksAjaxContract['disksV2']>;
-export type DiskAjaxContract = ReturnType<DisksAjaxContractV1['disk']>;
+export type DisksDataClientContract = ReturnType<typeof Disks>;
+export type DisksContractV1 = ReturnType<DisksDataClientContract['disksV1']>;
+export type DisksContractV2 = ReturnType<DisksDataClientContract['disksV2']>;
+export type DiskWrapperContract = ReturnType<DisksContractV1['disk']>;

--- a/src/libs/ajax/leonardo/providers/LeoDiskProvider.test.ts
+++ b/src/libs/ajax/leonardo/providers/LeoDiskProvider.test.ts
@@ -1,9 +1,9 @@
 import {
-  DiskAjaxContract,
   Disks,
-  DisksAjaxContract,
-  DisksAjaxContractV1,
-  DisksAjaxContractV2,
+  DisksContractV1,
+  DisksContractV2,
+  DisksDataClientContract,
+  DiskWrapperContract,
 } from 'src/libs/ajax/leonardo/Disks';
 import { asMockedFn } from 'src/testing/test-utils';
 
@@ -11,9 +11,9 @@ import { DiskBasics, leoDiskProvider } from './LeoDiskProvider';
 
 jest.mock('src/libs/ajax/leonardo/Disks');
 
-type DiskNeeds = Pick<DiskAjaxContract, 'delete' | 'details' | 'update'>;
-type DisksV1Needs = Pick<DisksAjaxContractV1, 'list' | 'disk'>;
-type DisksV2Needs = Pick<DisksAjaxContractV2, 'delete'>;
+type DiskNeeds = Pick<DiskWrapperContract, 'delete' | 'details' | 'update'>;
+type DisksV1Needs = Pick<DisksContractV1, 'list' | 'disk'>;
+type DisksV2Needs = Pick<DisksContractV2, 'delete'>;
 
 interface DiskMockNeeds {
   DisksV1: DisksV1Needs;
@@ -34,23 +34,23 @@ const mockDiskNeeds = (): DiskMockNeeds => {
     details: jest.fn(),
     update: jest.fn(),
   };
-  const mockDisk = partialDisk as DiskAjaxContract;
+  const mockDisk = partialDisk as DiskWrapperContract;
 
   const partialDisksV1: DisksV1Needs = {
     disk: jest.fn(),
     list: jest.fn(),
   };
-  const mockDisksV1 = partialDisksV1 as DisksAjaxContractV1;
+  const mockDisksV1 = partialDisksV1 as DisksContractV1;
 
   const partialDisksV2: DisksV2Needs = {
     delete: jest.fn(),
   };
-  const mockDisksV2 = partialDisksV2 as DisksAjaxContractV2;
+  const mockDisksV2 = partialDisksV2 as DisksContractV2;
 
   asMockedFn(mockDisksV1.disk).mockReturnValue(mockDisk);
 
   // Ajax.Disks root
-  const mockDisks: DisksAjaxContract = {
+  const mockDisks: DisksDataClientContract = {
     disksV1: jest.fn(),
     disksV2: jest.fn(),
   };

--- a/src/libs/ajax/leonardo/providers/LeoDiskProvider.ts
+++ b/src/libs/ajax/leonardo/providers/LeoDiskProvider.ts
@@ -51,6 +51,6 @@ export const leoDiskProvider: LeoDiskProvider = {
       const googleProject = cloudContext.cloudResource;
       return Disks(signal).disksV1().disk(googleProject, name).update(newSize);
     }
-    throw new Error(`Updating disk details is currently only supported for google disks. Disk: ${disk}`);
+    throw new Error(`Updating disk is currently only supported for google disks. Disk: ${disk}`);
   },
 };

--- a/src/libs/ajax/leonardo/providers/LeoDiskProvider.ts
+++ b/src/libs/ajax/leonardo/providers/LeoDiskProvider.ts
@@ -42,7 +42,6 @@ export const leoDiskProvider: LeoDiskProvider = {
     }
     throw new Error(`Getting disk details is currently only supported for google disks. Disk: ${disk}`);
   },
-  // TODO: validation discussion
   update: (disk: DiskBasics, newSize: number, options: AbortOption = {}): Promise<void> => {
     const { signal } = options;
     const { cloudContext, name } = disk;

--- a/src/libs/ajax/leonardo/providers/LeoDiskProvider.ts
+++ b/src/libs/ajax/leonardo/providers/LeoDiskProvider.ts
@@ -1,20 +1,23 @@
 import { isGcpContext } from 'src/analysis/utils/runtime-utils';
-import { Ajax } from 'src/libs/ajax';
 import { AbortOption } from 'src/libs/ajax/data-provider-common';
-import { PersistentDisk } from 'src/libs/ajax/leonardo/models/disk-models';
+import { PersistentDisk, PersistentDiskDetail } from 'src/libs/ajax/leonardo/models/disk-models';
+
+import { Disks } from '../Disks';
 
 export type DiskBasics = Pick<PersistentDisk, 'cloudContext' | 'name' | 'id'>;
 
 export interface LeoDiskProvider {
   list: (listArgs: Record<string, string>, options?: AbortOption) => Promise<PersistentDisk[]>;
   delete: (disk: DiskBasics, options?: AbortOption) => Promise<void>;
+  update: (disk: DiskBasics, newSize: number, options?: AbortOption) => Promise<void>;
+  details: (disk: DiskBasics, options?: AbortOption) => Promise<PersistentDiskDetail>;
 }
 
 export const leoDiskProvider: LeoDiskProvider = {
   list: (listArgs: Record<string, string>, options: AbortOption = {}): Promise<PersistentDisk[]> => {
     const { signal } = options;
 
-    return Ajax(signal).Disks.disksV1().list(listArgs);
+    return Disks(signal).disksV1().list(listArgs);
   },
   delete: (disk: DiskBasics, options: AbortOption = {}): Promise<void> => {
     const { cloudContext, name, id } = disk;
@@ -22,8 +25,32 @@ export const leoDiskProvider: LeoDiskProvider = {
 
     if (isGcpContext(cloudContext)) {
       const googleProject = cloudContext.cloudResource;
-      return Ajax(signal).Disks.disksV1().disk(googleProject, name).delete();
+      return Disks(signal).disksV1().disk(googleProject, name).delete();
     }
-    return Ajax(signal).Disks.disksV2().delete(id);
+    return Disks(signal).disksV2().delete(id);
+  },
+  details: async (disk: DiskBasics, options: AbortOption = {}): Promise<PersistentDiskDetail> => {
+    const { signal } = options;
+    const { cloudContext, name } = disk;
+
+    if (isGcpContext(cloudContext)) {
+      const googleProject = cloudContext.cloudResource;
+      const decoratedDisk: PersistentDiskDetail = await Disks(signal).disksV1().disk(googleProject, name).details();
+      // TODO: IA-4883, uncomment when the provider does the sanitization
+      // return updatePdType(undecoratedDisk);
+      return decoratedDisk;
+    }
+    throw new Error(`Getting disk details is currently only supported for google disks. Disk: ${disk}`);
+  },
+  // TODO: validation discussion
+  update: (disk: DiskBasics, newSize: number, options: AbortOption = {}): Promise<void> => {
+    const { signal } = options;
+    const { cloudContext, name } = disk;
+
+    if (isGcpContext(cloudContext)) {
+      const googleProject = cloudContext.cloudResource;
+      return Disks(signal).disksV1().disk(googleProject, name).update(newSize);
+    }
+    throw new Error(`Updating disk details is currently only supported for google disks. Disk: ${disk}`);
   },
 };


### PR DESCRIPTION
This PR:
- makes disk provider interface feature complete
- removes unused `create` method from disk data client (To test it, we would need to solidify the exact parameters for disk creation, which is not a trivial. Therefore, it seems better to remove it rather than establishing typing for a contract not currently used.)
- removes references from Disk provider to Ajax and has it consume the Disk module directly
- Adds tests for all disk provider methods
- Punts moving utility methods from the Disk client to the Disk provider - this is better done in a PR that also addresses the call-sites of the data client methods, since it will be a breaking change and require further testing 