### PR TITLE
[AJ-1770] Hide public workspaces when importing protected data

### DIFF
--- a/src/import-data/import-utils.test.ts
+++ b/src/import-data/import-utils.test.ts
@@ -94,6 +94,23 @@ describe('canImportIntoWorkspace', () => {
     expect(canImportProtectedDataIntoUnprotectedGoogleWorkspace).toBe(false);
   });
 
+  it('requires a non-public workspace for protected data', () => {
+    // Arrange
+    const protectedPublicGoogleWorkspace = makeGoogleWorkspace({
+      workspace: { bucketName: 'fc-secure-00001111-2222-3333-aaaa-bbbbccccdddd' },
+      public: true,
+    });
+
+    // Act
+    const canImportProtectedDataIntoProtectedPublicWorkspace = canImportIntoWorkspace(
+      { isProtectedData: true },
+      protectedPublicGoogleWorkspace
+    );
+
+    // Assert
+    expect(canImportProtectedDataIntoProtectedPublicWorkspace).toBe(false);
+  });
+
   it('can require an authorization domain', () => {
     // Arrange
     const requiredAuthDomain = 'test-ad';

--- a/src/import-data/import-utils.ts
+++ b/src/import-data/import-utils.ts
@@ -61,8 +61,8 @@ export const canImportIntoWorkspace = (importOptions: ImportOptions, workspace: 
     return false;
   }
 
-  // If the source data is protected, the destination workspace must also be protected.
-  if (isProtectedData && !isProtectedWorkspace(workspace)) {
+  // If the source data is protected, the destination workspace must also be protected and not public.
+  if (isProtectedData && !(isProtectedWorkspace(workspace) && !workspace.public)) {
     return false;
   }
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1770

We want to prevent someone from accidentally importing controlled access data into a public workspace and thereby making that data public.

The import data page has a concept of "protected data" (data that requires a workspace with secure monitoring enabled). In practice, this is TDR snapshots with secure monitoring enabled and PFB files from specific sources (AnVIL, etc). 

Currently, when importing "protected data", the UI only shows workspaces that have secure monitoring enabled. This extends that condition to only show workspaces that have secure monitoring enabled _and_ are not public.

I'm not totally convinced this is really necessary. It seems unlikely that we would have a public workspace that has secure monitoring enabled. But I suppose it's plausible... I don't think there's anything technically preventing it. And it's easy enough to add this additional guard rail to protect against accidental data exposures.