### PR TITLE
ID-1240 Fix Appcues User Identification

### DIFF
--- a/src/libs/ajax/User.ts
+++ b/src/libs/ajax/User.ts
@@ -218,7 +218,17 @@ export const User = (signal?: AbortSignal) => {
           { signal, method: 'POST' },
         ])
       );
-      return res.json();
+      const json = await res.json();
+      return {
+        id: json.id,
+        googleSubjectId: json.googleSubjectId,
+        email: json.email,
+        azureB2CId: json.azureB2CId,
+        allowed: json.allowed,
+        createdAt: json.createdAt ? new Date(json.createdAt) : undefined,
+        registeredAt: json.registeredAt ? new Date(json.registeredAt) : undefined,
+        updatedAt: json.updatedAt ? new Date(json.updatedAt) : undefined,
+      };
     },
 
     profile: {
@@ -259,7 +269,17 @@ export const User = (signal?: AbortSignal) => {
 
     getSamUserResponse: async (): Promise<SamUserResponse> => {
       const res = await fetchSam('api/users/v2/self', _.mergeAll([authOpts(), { method: 'GET' }]));
-      return res.json();
+      const json = await res.json();
+      return {
+        id: json.id,
+        googleSubjectId: json.googleSubjectId,
+        email: json.email,
+        azureB2CId: json.azureB2CId,
+        allowed: json.allowed,
+        createdAt: json.createdAt ? new Date(json.createdAt) : undefined,
+        registeredAt: json.registeredAt ? new Date(json.registeredAt) : undefined,
+        updatedAt: json.updatedAt ? new Date(json.updatedAt) : undefined,
+      };
     },
 
     getNihStatus: async (): Promise<OrchestrationNihStatusResponse | undefined> => {


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/ID-1240

A recent update to retire rex ended up breaking Appcues user identification. The reason for this is that turning a network response as JSON does not create objects out of values. Normally, this would have resulted in an error, but the code that called `getTime` on a `string` literal was wrapped in `withErrorIgnoring`. So, there was never any indication that the call was failing.

### Testing strategy
- [x] Manually tested locally with console.log statements