### PR TITLE
WX-1583 Remove inaccurate error message

### DIFF
--- a/src/workspace-data/Data.js
+++ b/src/workspace-data/Data.js
@@ -303,7 +303,6 @@ const DataTableActions = ({
 }) => {
   const {
     workspace: { namespace, name },
-    workspaceSubmissionStats: { runningSubmissionsCount },
   } = workspace;
 
   const isSet = tableName.endsWith('_set');
@@ -449,7 +448,6 @@ const DataTableActions = ({
         workspace,
         selectedDataType: tableName,
         selectedEntities: entities,
-        runningSubmissionsCount,
       }),
     savingVersion &&
       h(DataTableSaveVersionModal, {

--- a/src/workspace-data/data-table/entity-service/EntitiesContent.js
+++ b/src/workspace-data/data-table/entity-service/EntitiesContent.js
@@ -615,7 +615,6 @@ const EntitiesContent = ({
             workspace,
             selectedEntities: selectedKeys,
             selectedDataType: entityKey,
-            runningSubmissionsCount,
           }),
         showColumnProvenance &&
           h(

--- a/src/workspace-data/data-table/entity-service/EntityDeleter.js
+++ b/src/workspace-data/data-table/entity-service/EntityDeleter.js
@@ -52,7 +52,7 @@ export const EntityDeleter = ({ onDismiss, onSuccess, namespace, name, selectedE
       runningSubmissionsCount > 0 &&
         b({ style: { display: 'block', margin: '1rem 0' } }, [
           `WARNING: ${runningSubmissionsCount} workflows are currently running in this workspace. ` +
-            'Deleting the following entities could cause workflows using them to fail.',
+            'Deleting the following entries could cause workflows using them to fail.',
         ]),
       moreToDelete &&
         b({ style: { display: 'block', margin: '1rem 0' } }, [

--- a/src/workspace-data/data-table/entity-service/EntityDeleter.js
+++ b/src/workspace-data/data-table/entity-service/EntityDeleter.js
@@ -52,7 +52,7 @@ export const EntityDeleter = ({ onDismiss, onSuccess, namespace, name, selectedE
       runningSubmissionsCount > 0 &&
         b({ style: { display: 'block', margin: '1rem 0' } }, [
           `WARNING: ${runningSubmissionsCount} workflows are currently running in this workspace. ` +
-            'Deleting the following entities could cause workflows to fail if they are using the data.',
+            'Deleting the following entities could cause workflows using them to fail.',
         ]),
       moreToDelete &&
         b({ style: { display: 'block', margin: '1rem 0' } }, [

--- a/src/workspace-data/data-table/entity-service/EntityDeleter.js
+++ b/src/workspace-data/data-table/entity-service/EntityDeleter.js
@@ -52,7 +52,7 @@ export const EntityDeleter = ({ onDismiss, onSuccess, namespace, name, selectedE
       runningSubmissionsCount > 0 &&
         b({ style: { display: 'block', margin: '1rem 0' } }, [
           `WARNING: ${runningSubmissionsCount} workflows are currently running in this workspace. ` +
-            'Deleting the following entries could cause workflows to fail if they are using the data.',
+            'Deleting the following entities could cause workflows to fail if they are using the data.',
         ]),
       moreToDelete &&
         b({ style: { display: 'block', margin: '1rem 0' } }, [

--- a/src/workspace-data/data-table/entity-service/EntityDeleter.js
+++ b/src/workspace-data/data-table/entity-service/EntityDeleter.js
@@ -52,7 +52,7 @@ export const EntityDeleter = ({ onDismiss, onSuccess, namespace, name, selectedE
       runningSubmissionsCount > 0 &&
         b({ style: { display: 'block', margin: '1rem 0' } }, [
           `WARNING: ${runningSubmissionsCount} workflows are currently running in this workspace. ` +
-            'Deleting the following data could cause failures if a workflow is using this data.',
+            'Deleting the following entries could cause workflows to fail if they are using the data.',
         ]),
       moreToDelete &&
         b({ style: { display: 'block', margin: '1rem 0' } }, [

--- a/src/workspace-data/data-table/entity-service/ExportDataModal.js
+++ b/src/workspace-data/data-table/entity-service/ExportDataModal.js
@@ -28,13 +28,13 @@ const InfoTile = ({ isError = false, content }) => {
   ]);
 };
 
-const displayEntities = (entities, runningSubmissionsCount, showType) => {
+const displayEntities = (entities, showType) => {
   return _.map(
     ([i, entity]) =>
       div(
         {
           style: {
-            borderTop: i === 0 && runningSubmissionsCount === 0 ? undefined : Style.standardLine,
+            borderTop: i === 0 ? undefined : Style.standardLine,
             padding: '0.6rem 1.25rem',
             ...Style.noWrapEllipsis,
           },
@@ -45,7 +45,7 @@ const displayEntities = (entities, runningSubmissionsCount, showType) => {
   );
 };
 
-export const ExportDataModal = ({ onDismiss, selectedDataType, selectedEntities, runningSubmissionsCount, workspace }) => {
+export const ExportDataModal = ({ onDismiss, selectedDataType, selectedEntities, workspace }) => {
   // State
   const [hardConflicts, setHardConflicts] = useState([]);
   const [softConflicts, setSoftConflicts] = useState([]);
@@ -126,12 +126,6 @@ export const ExportDataModal = ({ onDismiss, selectedDataType, selectedEntities,
         },
       },
       [
-        runningSubmissionsCount > 0 &&
-          InfoTile({
-            content:
-              `WARNING: ${runningSubmissionsCount} workflows are currently running in this workspace. ` +
-              'Copying the following data could cause failures if a workflow is using this data.',
-          }),
         !(!!hardConflicts.length || !!additionalDeletions.length || !!softConflicts.length) &&
           h(Fragment, [
             h(FormLabel, { required: true }, ['Destination']),
@@ -161,10 +155,10 @@ export const ExportDataModal = ({ onDismiss, selectedDataType, selectedEntities,
         // Row height calculation is font size * line height + padding + border
         div({ style: { maxHeight: 'calc((1em * 1.15 + 1.2rem + 1px) * 10.5)', overflowY: 'auto', margin: '0 -1.25rem' } }, [
           ...Utils.cond(
-            [!!additionalDeletions.length, () => displayEntities(additionalDeletions, runningSubmissionsCount, true)],
-            [!!hardConflicts.length, () => displayEntities(hardConflicts, runningSubmissionsCount, true)],
-            [!!softConflicts.length, () => displayEntities(softConflicts, runningSubmissionsCount, true)],
-            () => displayEntities(selectedEntities, runningSubmissionsCount, false)
+            [!!additionalDeletions.length, () => displayEntities(additionalDeletions, true)],
+            [!!hardConflicts.length, () => displayEntities(hardConflicts, true)],
+            [!!softConflicts.length, () => displayEntities(softConflicts, true)],
+            () => displayEntities(selectedEntities, false)
           ),
         ]),
         div(


### PR DESCRIPTION
Story: [WX-1583](https://broadworkbench.atlassian.net/browse/WX-1583)

When a user copies entities from a source workspace to a destination workspace, we display the following message when there are workflows running in the source workspace.

> Copying the following data could cause failures if a workflow is using this data.

This is incorrect and caused [a support request](https://support.terra.bio/hc/en-us/community/posts/24962860646299-WARNING-1-workflows-are-currently-running-in-this-workspace-Copying-the-following-data-could-cause-failures-if-a-workflow-is-using-this-data) that came to me as User Liaison [(Slack link)](https://broadinstitute.slack.com/archives/CBJJ7U293/p1713989673547589).

The message was added in [this PR](https://github.com/DataBiosphere/terra-ui/pull/928) and I think it’s a copy-pasta from this very similar error from [an earlier PR](https://github.com/DataBiosphere/terra-ui/pull/802), this one is actually accurate.

> Deleting the following data could cause failures if a workflow is using this data.

[WX-1583]: https://broadworkbench.atlassian.net/browse/WX-1583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ