### PR TITLE
[UIE-169] Fix useWorkspace return type

### DIFF
--- a/src/analysis/_testData/testData.ts
+++ b/src/analysis/_testData/testData.ts
@@ -131,6 +131,7 @@ export const generateGoogleWorkspace = (prefix: string = uuid().substring(0, 8))
   workspace: {
     authorizationDomain: [],
     cloudPlatform: 'Gcp',
+    billingAccount: 'billingAccounts/123456-ABCDEF-ABCDEF',
     bucketName: 'test-bucket',
     googleProject: `${prefix}-project`,
     name: `${prefix}_ws`,

--- a/src/analysis/useAnalysisFiles.ts
+++ b/src/analysis/useAnalysisFiles.ts
@@ -16,7 +16,7 @@ import { reportError, withErrorReporting } from 'src/libs/error';
 import { useCancellation, useStore } from 'src/libs/react-utils';
 import { workspaceStore } from 'src/libs/state';
 import * as Utils from 'src/libs/utils';
-import { CloudProvider, cloudProviderTypes, WorkspaceWrapper } from 'src/workspaces/utils';
+import { CloudProvider, cloudProviderTypes } from 'src/workspaces/utils';
 
 export interface AnalysisFileMetadata {
   lockExpiresAt: string;
@@ -51,7 +51,7 @@ export interface AnalysisFileStore {
 export const useAnalysisFiles = (): AnalysisFileStore => {
   const signal = useCancellation();
   const [loading, setLoading] = useState(false);
-  const workspace: WorkspaceWrapper = useStore(workspaceStore);
+  const workspace = useStore(workspaceStore);
   const [analyses, setAnalyses] = useState<AnalysisFile[]>([]);
   const [pendingCreate, setPendingCreate] = useLoadedData<true>();
   const [pendingDelete, setPendingDelete] = useLoadedData<true>();
@@ -59,14 +59,14 @@ export const useAnalysisFiles = (): AnalysisFileStore => {
   const refresh = withHandlers(
     [withErrorReporting('Error loading analysis files'), Utils.withBusyState(setLoading)],
     async (): Promise<void> => {
-      const analysis = await AnalysisProvider.listAnalyses(workspace.workspace, signal);
+      const analysis = await AnalysisProvider.listAnalyses(workspace!.workspace, signal);
       setAnalyses(analysis);
     }
   );
 
   const createAnalysis = async (fullAnalysisName: string, toolLabel: ToolLabel, contents: any): Promise<void> => {
     await setPendingCreate(async () => {
-      await AnalysisProvider.createAnalysis(workspace.workspace, fullAnalysisName, toolLabel, contents, signal);
+      await AnalysisProvider.createAnalysis(workspace!.workspace, fullAnalysisName, toolLabel, contents, signal);
       await refresh();
       return true;
     });
@@ -74,7 +74,7 @@ export const useAnalysisFiles = (): AnalysisFileStore => {
 
   const deleteAnalysis = async (path: AbsolutePath): Promise<void> => {
     await setPendingDelete(async () => {
-      await AnalysisProvider.deleteAnalysis(workspace.workspace, path, signal);
+      await AnalysisProvider.deleteAnalysis(workspace!.workspace, path, signal);
       await refresh();
       return true;
     });
@@ -82,7 +82,7 @@ export const useAnalysisFiles = (): AnalysisFileStore => {
 
   useEffect(() => {
     refresh();
-  }, [workspace.workspace]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [workspace!.workspace]); // eslint-disable-line react-hooks/exhaustive-deps
   // refresh depends only on workspace.workspace, do not want to refresh on workspace.workspaceInitialized
 
   useEffect(() => {

--- a/src/analysis/useComputeImages.ts
+++ b/src/analysis/useComputeImages.ts
@@ -5,7 +5,7 @@ import { ComputeImageProvider } from 'src/libs/ajax/compute-image-providers/Comp
 import { useLoadedData } from 'src/libs/ajax/loaded-data/useLoadedData';
 import { useCancellation, useStore } from 'src/libs/react-utils';
 import { workspaceStore } from 'src/libs/state';
-import { isGoogleWorkspaceInfo, WorkspaceInfo, WorkspaceWrapper } from 'src/workspaces/utils';
+import { isGoogleWorkspaceInfo, WorkspaceInfo } from 'src/workspaces/utils';
 
 export interface ComputeImage {
   id: string;
@@ -28,7 +28,7 @@ export interface ComputeImageStore {
 
 export const useComputeImages = (): ComputeImageStore => {
   const signal = useCancellation();
-  const workspace: WorkspaceWrapper = useStore<WorkspaceWrapper>(workspaceStore);
+  const workspace = useStore(workspaceStore);
   const [loadedState, setLoadedState] = useLoadedData<ComputeImage[]>({
     onError: (state) => {
       // We can't rely on the formatting of the error, so show a generic message but include the error in the console for debugging purposes.
@@ -42,7 +42,7 @@ export const useComputeImages = (): ComputeImageStore => {
 
   const doRefresh = async (): Promise<void> => {
     await setLoadedState(async () => {
-      const workspaceInfo: WorkspaceInfo = workspace.workspace;
+      const workspaceInfo: WorkspaceInfo = workspace!.workspace;
       if (isGoogleWorkspaceInfo(workspaceInfo)) {
         const loadedImages: ComputeImage[] = await ComputeImageProvider.listImages(workspaceInfo.googleProject, signal);
         return loadedImages;

--- a/src/analysis/utils/file-utils.test.ts
+++ b/src/analysis/utils/file-utils.test.ts
@@ -53,7 +53,7 @@ describe('file-utils', () => {
       asMockedFn(GoogleStorage).mockImplementation(() => googleStorageMock as GoogleStorageContract);
 
       // Act
-      workspaceStore.set(defaultGoogleWorkspace);
+      workspaceStore.set({ ...defaultGoogleWorkspace, workspaceInitialized: true });
       const { result: hookReturnRef } = await renderHookInAct(() => useAnalysisFiles());
       const state = hookReturnRef.current.loadedState;
 
@@ -76,7 +76,7 @@ describe('file-utils', () => {
       asMockedFn(GoogleStorage).mockImplementation(() => googleStorageMock as GoogleStorageContract);
 
       // Act
-      workspaceStore.set(defaultGoogleWorkspace);
+      workspaceStore.set({ ...defaultGoogleWorkspace, workspaceInitialized: true });
       await renderHookInAct(() => useAnalysisFiles());
 
       // Assert
@@ -100,7 +100,7 @@ describe('file-utils', () => {
       asMockedFn(AzureStorage).mockImplementation(() => azureStorageMock as AzureStorageContract);
 
       // Act
-      workspaceStore.set(defaultAzureWorkspace);
+      workspaceStore.set({ ...defaultAzureWorkspace, workspaceInitialized: true });
       await renderHookInAct(() => useAnalysisFiles());
 
       // Assert
@@ -126,7 +126,7 @@ describe('file-utils', () => {
       asMockedFn(GoogleStorage).mockImplementation(() => googleStorageMock as GoogleStorageContract);
 
       // Act
-      workspaceStore.set(defaultGoogleWorkspace);
+      workspaceStore.set({ ...defaultGoogleWorkspace, workspaceInitialized: true });
       const { result: hookReturnRef } = await renderHookInAct(() => useAnalysisFiles());
       await act(() => hookReturnRef.current.createAnalysis('AnalysisFile', runtimeToolLabels.Jupyter, 'myContents'));
 
@@ -149,7 +149,7 @@ describe('file-utils', () => {
       asMockedFn(GoogleStorage).mockImplementation(() => googleStorageMock as GoogleStorageContract);
 
       // Act
-      workspaceStore.set(defaultGoogleWorkspace);
+      workspaceStore.set({ ...defaultGoogleWorkspace, workspaceInitialized: true });
       const hookRender1 = await renderHookInAct(() => useAnalysisFiles());
       const hookResult2 = hookRender1.result.current;
       await act(() => hookResult2.createAnalysis('AnalysisFile', runtimeToolLabels.Jupyter, 'myContents'));
@@ -176,7 +176,7 @@ describe('file-utils', () => {
         blob: blobMock as AzureStorageContract['blob'],
       };
       asMockedFn(AzureStorage).mockImplementation(() => azureStorageMock as AzureStorageContract);
-      workspaceStore.set(defaultAzureWorkspace);
+      workspaceStore.set({ ...defaultAzureWorkspace, workspaceInitialized: true });
       const { result: hookReturnRef } = await renderHookInAct(() => useAnalysisFiles());
       // Act
       await act(() => hookReturnRef.current.createAnalysis('AnalysisFile', runtimeToolLabels.Jupyter, 'myContents'));
@@ -200,7 +200,7 @@ describe('file-utils', () => {
     asMockedFn(AzureStorage).mockImplementation(() => googleStorageMock as AzureStorageContract);
 
     // Act
-    workspaceStore.set(defaultAzureWorkspace);
+    workspaceStore.set({ ...defaultAzureWorkspace, workspaceInitialized: true });
     const hookRender1 = await renderHookInAct(() => useAnalysisFiles());
     const hookResult2 = hookRender1.result.current;
     await act(() => hookResult2.createAnalysis('AnalysisFile', runtimeToolLabels.Jupyter, 'myContents'));
@@ -229,7 +229,7 @@ describe('file-utils', () => {
     asMockedFn(GoogleStorage).mockImplementation(() => googleStorageMock as GoogleStorageContract);
 
     // Act
-    workspaceStore.set(defaultGoogleWorkspace);
+    workspaceStore.set({ ...defaultGoogleWorkspace, workspaceInitialized: true });
     const { result: hookReturnRef } = await renderHookInAct(() => useAnalysisFiles());
     await act(() => hookReturnRef.current.deleteAnalysis(file1Path));
 
@@ -259,7 +259,7 @@ describe('file-utils', () => {
     asMockedFn(GoogleStorage).mockImplementation(() => googleStorageMock as GoogleStorageContract);
 
     // Act
-    workspaceStore.set(defaultGoogleWorkspace);
+    workspaceStore.set({ ...defaultGoogleWorkspace, workspaceInitialized: true });
     const hookRender1 = await renderHookInAct(() => useAnalysisFiles());
     const hookResult2 = hookRender1.result.current;
     await act(() => hookResult2.deleteAnalysis(file1Path));
@@ -290,7 +290,7 @@ describe('file-utils', () => {
       blob: blobMock as AzureStorageContract['blob'],
     };
     asMockedFn(AzureStorage).mockImplementation(() => azureStorageMock as AzureStorageContract);
-    workspaceStore.set(defaultAzureWorkspace);
+    workspaceStore.set({ ...defaultAzureWorkspace, workspaceInitialized: true });
     const { result: hookReturnRef } = await renderHookInAct(() => useAnalysisFiles());
     // Act
     await act(() => hookReturnRef.current.deleteAnalysis(file1Path));
@@ -315,7 +315,7 @@ describe('file-utils', () => {
     asMockedFn(AzureStorage).mockImplementation(() => azureStorageMock as AzureStorageContract);
 
     // Act
-    workspaceStore.set(defaultAzureWorkspace);
+    workspaceStore.set({ ...defaultAzureWorkspace, workspaceInitialized: true });
     const hookRender1 = await renderHookInAct(() => useAnalysisFiles());
     const hookResult2 = hookRender1.result.current;
     await act(() => hookResult2.deleteAnalysis(file1Path));

--- a/src/libs/ajax/GoogleStorage.ts
+++ b/src/libs/ajax/GoogleStorage.ts
@@ -22,7 +22,7 @@ import { canUseWorkspaceProject } from 'src/libs/ajax/Billing';
 import { getConfig } from 'src/libs/config';
 import { knownBucketRequesterPaysStatuses, requesterPaysProjectStore, workspaceStore } from 'src/libs/state';
 import * as Utils from 'src/libs/utils';
-import { canWrite, cloudProviderTypes } from 'src/workspaces/utils';
+import { canWrite, cloudProviderTypes, GoogleWorkspace } from 'src/workspaces/utils';
 
 /*
  * Detects errors due to requester pays buckets, and adds the current workspace's billing
@@ -36,7 +36,7 @@ const withRequesterPays =
 
     const getUserProject = async () => {
       if (!requesterPaysProjectStore.get() && workspace && (await canUseWorkspaceProject(workspace))) {
-        requesterPaysProjectStore.set(workspace.workspace.googleProject);
+        requesterPaysProjectStore.set((workspace as GoogleWorkspace).workspace.googleProject);
       }
       return requesterPaysProjectStore.get();
     };

--- a/src/libs/state.ts
+++ b/src/libs/state.ts
@@ -262,7 +262,9 @@ export const notificationStore = atom<any[]>([]);
 
 export const contactUsActive = atom(false);
 
-export const workspaceStore = atom<any>(undefined);
+export type InitializedWorkspaceWrapper = WorkspaceWrapper & { workspaceInitialized: boolean };
+
+export const workspaceStore = atom<InitializedWorkspaceWrapper | undefined>(undefined);
 
 export const workspacesStore = atom<WorkspaceWrapper[]>([]);
 

--- a/src/testing/workspace-fixtures.ts
+++ b/src/testing/workspace-fixtures.ts
@@ -81,6 +81,7 @@ export const defaultGoogleWorkspace: GoogleWorkspace = {
   workspace: {
     authorizationDomain: [],
     cloudPlatform: 'Gcp',
+    billingAccount: 'billingAccounts/123456-ABCDEF-ABCDEF',
     bucketName: 'test-bucket',
     googleProject: 'test-gcp-ws-project',
     name: 'test-gcp-ws-name',

--- a/src/workspace-data/data-table/uri-viewer/UriDownloadButton.ts
+++ b/src/workspace-data/data-table/uri-viewer/UriDownloadButton.ts
@@ -92,7 +92,7 @@ export const UriDownloadButton = ({ uri, metadata: { bucket, name, fileName, siz
         disabled: !url,
         onClick: () => {
           Ajax().Metrics.captureEvent(Events.workspaceDataDownload, {
-            ...extractWorkspaceDetails(workspaceStore.get().workspace),
+            ...extractWorkspaceDetails(workspaceStore.get()!.workspace),
             fileType: _.head(/\.\w+$/.exec(uri)),
             downloadFrom: 'file direct',
           });

--- a/src/workspace-data/data-table/wds/WorkspaceLinks.test.ts
+++ b/src/workspace-data/data-table/wds/WorkspaceLinks.test.ts
@@ -58,6 +58,7 @@ describe('WorkspaceLinkById', () => {
       name: 'test-workspace',
       namespace: 'test-workspaces',
       cloudPlatform: 'Gcp',
+      billingAccount: 'billingAccounts/123456-ABCDEF-ABCDEF',
       bucketName: 'test-bucket',
       googleProject: 'google-project',
       authorizationDomain: [],

--- a/src/workspace-data/import-jobs.test.ts
+++ b/src/workspace-data/import-jobs.test.ts
@@ -18,6 +18,7 @@ describe('useImportJobs', () => {
       workspace: {
         authorizationDomain: [],
         cloudPlatform: 'Gcp',
+        billingAccount: 'billingAccounts/123456-ABCDEF-ABCDEF',
         bucketName: 'test-bucket',
         googleProject: 'test-project',
         name: 'google-workspace',

--- a/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.test.ts
+++ b/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.test.ts
@@ -155,6 +155,7 @@ const mockWorkspaces: {
     namespace: gcpBillingProject.projectName,
     name: 'test-workspace',
     workspaceId: 'aaaabbbb-cccc-dddd-0000-111122223333',
+    billingAccount: 'billingAccounts/123456-ABCDEF-ABCDEF',
     googleProject: 'test-project',
     bucketName: 'fc-aaaabbbb-cccc-dddd-0000-111122223333',
     createdBy: 'user@example.com',

--- a/src/workspaces/RequestAccessModal/RequestAccessModal.test.ts
+++ b/src/workspaces/RequestAccessModal/RequestAccessModal.test.ts
@@ -57,6 +57,7 @@ const googleWorkspace: GoogleWorkspace = {
     ],
     createdDate: '',
     createdBy: '',
+    billingAccount: 'billingAccounts/123456-ABCDEF-ABCDEF',
     googleProject: 'test-project',
     bucketName: 'test-bucket',
     lastModified: '',

--- a/src/workspaces/common/state/useDeletionPolling.ts
+++ b/src/workspaces/common/state/useDeletionPolling.ts
@@ -12,12 +12,12 @@ const updateWorkspacesList = (
   errorMessage?: string
 ): Workspace[] => workspaces.map((ws) => updateWorkspace(ws, workspaceId, state, errorMessage));
 
-const updateWorkspace = (
-  workspace: Workspace,
+const updateWorkspace = <T extends Workspace>(
+  workspace: T,
   workspaceId: string,
   state: WorkspaceState,
   errorMessage?: string
-): Workspace => {
+): T => {
   if (workspace.workspace.workspaceId === workspaceId) {
     const update = _.cloneDeep(workspace);
     update.workspace.state = state;
@@ -32,7 +32,7 @@ const checkWorkspaceDeletion = async (workspace: Workspace, abort: () => void, s
     const workspaceId = workspace.workspace.workspaceId;
     abort();
     workspacesStore.update((wsList) => updateWorkspacesList(wsList, workspaceId, state, errorMessage));
-    workspaceStore.update((ws) => updateWorkspace(ws, workspaceId, state, errorMessage));
+    workspaceStore.update((ws) => updateWorkspace(ws!, workspaceId, state, errorMessage));
   };
 
   try {

--- a/src/workspaces/common/state/useWorkspace.test.ts
+++ b/src/workspaces/common/state/useWorkspace.test.ts
@@ -6,7 +6,7 @@ import { Ajax } from 'src/libs/ajax';
 import { AzureStorage, AzureStorageContract } from 'src/libs/ajax/AzureStorage';
 import * as GoogleStorage from 'src/libs/ajax/GoogleStorage';
 import * as Notifications from 'src/libs/notifications';
-import { workspaceStore } from 'src/libs/state';
+import { InitializedWorkspaceWrapper, workspaceStore } from 'src/libs/state';
 import { renderHookInAct } from 'src/testing/test-utils';
 import { defaultAzureStorageOptions, defaultGoogleBucketOptions } from 'src/testing/workspace-fixtures';
 import * as recentlyViewedWorkspaces from 'src/workspaces/common/state/recentlyViewedWorkspaces';
@@ -48,7 +48,7 @@ jest.mock('src/libs/config', () => ({
 }));
 
 describe('useWorkspace', () => {
-  const initializedGoogleWorkspace = {
+  const initializedGoogleWorkspace: InitializedWorkspaceWrapper = {
     accessLevel: 'PROJECT_OWNER',
     owners: ['christina@foo.com'],
     workspace: {
@@ -73,10 +73,11 @@ describe('useWorkspace', () => {
     },
     canShare: true,
     canCompute: true,
+    policies: [],
     workspaceInitialized: true,
   };
 
-  const initializedAzureWorkspace = {
+  const initializedAzureWorkspace: InitializedWorkspaceWrapper = {
     accessLevel: 'PROJECT_OWNER',
     owners: ['christina@foo.com'],
     azureContext: {
@@ -105,6 +106,7 @@ describe('useWorkspace', () => {
     },
     canShare: true,
     canCompute: true,
+    policies: [],
     workspaceInitialized: true,
   };
 

--- a/src/workspaces/common/state/useWorkspace.ts
+++ b/src/workspaces/common/state/useWorkspace.ts
@@ -12,10 +12,12 @@ import { ErrorCallback, withErrorHandling, withErrorIgnoring, withErrorReporting
 import Events, { extractWorkspaceDetails } from 'src/libs/events';
 import { clearNotification, notify } from 'src/libs/notifications';
 import { useStore } from 'src/libs/react-utils';
-import { getTerraUser, workspaceStore } from 'src/libs/state';
+import { getTerraUser, InitializedWorkspaceWrapper, workspaceStore } from 'src/libs/state';
 import { differenceFromNowInSeconds, withBusyState } from 'src/libs/utils';
 import { updateRecentlyViewedWorkspaces } from 'src/workspaces/common/state/recentlyViewedWorkspaces';
-import { canWrite, isAzureWorkspace, isGoogleWorkspace, isOwner, WorkspaceWrapper } from 'src/workspaces/utils';
+import { canWrite, isAzureWorkspace, isGoogleWorkspace, isOwner } from 'src/workspaces/utils';
+
+export type { InitializedWorkspaceWrapper } from 'src/libs/state';
 
 export interface StorageDetails {
   googleBucketLocation: string; // historically returns defaultLocation if bucket location cannot be retrieved or Azure
@@ -26,10 +28,8 @@ export interface StorageDetails {
   azureContainerSasUrl?: string;
 }
 
-export type InitializedWorkspaceWrapper = WorkspaceWrapper & { workspaceInitialized: boolean };
-
 export interface WorkspaceDetails {
-  workspace: InitializedWorkspaceWrapper;
+  workspace: InitializedWorkspaceWrapper | undefined;
   accessError: boolean;
   loadingWorkspace: boolean;
   storageDetails: StorageDetails;
@@ -43,7 +43,7 @@ export const useWorkspace = (namespace, name): WorkspaceDetails => {
   const [accessError, setAccessError] = useState(false);
   const [loadingWorkspace, setLoadingWorkspace] = useState(false);
   const accessNotificationId = useRef<string | undefined>();
-  const workspace: InitializedWorkspaceWrapper | undefined = useStore<InitializedWorkspaceWrapper>(workspaceStore);
+  const workspace = useStore(workspaceStore);
 
   const [{ location, locationType, fetchedLocation }, setGoogleStorage] = useState<{
     fetchedLocation: 'SUCCESS' | 'ERROR' | undefined;

--- a/src/workspaces/container/WorkspaceContainer.test.ts
+++ b/src/workspaces/container/WorkspaceContainer.test.ts
@@ -261,7 +261,7 @@ describe('WorkspaceContainer', () => {
     const mockUpdateWsListFn = asMockedFn(workspacesStore.update);
     mockUpdateWsFn.mockImplementation((updateFn) => {
       const updated = updateFn(workspace);
-      expect(updated.workspace.state).toBe('Deleted');
+      expect(updated!.workspace.state).toBe('Deleted');
     });
 
     mockUpdateWsListFn.mockImplementation((updateFn) => {
@@ -332,8 +332,8 @@ describe('WorkspaceContainer', () => {
     const mockUpdateWsListFn = asMockedFn(workspacesStore.update);
     mockUpdateWsFn.mockImplementation((updateFn) => {
       const updated = updateFn(workspace);
-      expect(updated.workspace.state).toBe('DeleteFailed');
-      expect(updated.workspace.errorMessage).toBe(errorMessage);
+      expect(updated!.workspace.state).toBe('DeleteFailed');
+      expect(updated!.workspace.errorMessage).toBe(errorMessage);
     });
 
     mockUpdateWsListFn.mockImplementation((updateFn) => {

--- a/src/workspaces/container/WorkspaceContainer.ts
+++ b/src/workspaces/container/WorkspaceContainer.ts
@@ -19,11 +19,7 @@ import * as Utils from 'src/libs/utils';
 import { useAppPolling } from 'src/workspaces/common/state/useAppPolling';
 import { useCloudEnvironmentPolling } from 'src/workspaces/common/state/useCloudEnvironmentPolling';
 import { useSingleWorkspaceDeletionPolling } from 'src/workspaces/common/state/useDeletionPolling';
-import {
-  InitializedWorkspaceWrapper as Workspace,
-  StorageDetails,
-  useWorkspace,
-} from 'src/workspaces/common/state/useWorkspace';
+import { InitializedWorkspaceWrapper, StorageDetails, useWorkspace } from 'src/workspaces/common/state/useWorkspace';
 import { WorkspaceDeletingBanner } from 'src/workspaces/container/WorkspaceDeletingBanner';
 import { WorkspaceTabs } from 'src/workspaces/container/WorkspaceTabs';
 import DeleteWorkspaceModal from 'src/workspaces/DeleteWorkspaceModal/DeleteWorkspaceModal';
@@ -68,7 +64,7 @@ interface WorkspaceContainerProps extends PropsWithChildren {
   analysesData: AnalysesData;
   storageDetails: StorageDetails;
   refresh: () => Promise<void>;
-  workspace: Workspace;
+  workspace: InitializedWorkspaceWrapper | undefined;
   refreshWorkspace: () => void;
 }
 
@@ -103,7 +99,7 @@ export const WorkspaceContainer = (props: WorkspaceContainerProps) => {
   const isGoogleWorkspaceSyncing =
     workspaceLoaded && isGoogleWorkspace(workspace) && workspace?.workspaceInitialized === false;
 
-  useSingleWorkspaceDeletionPolling(workspace);
+  useSingleWorkspaceDeletionPolling(workspace!);
   useEffect(() => {
     if (workspace?.workspace?.state === 'Deleted') {
       Nav.goToPath('workspaces');
@@ -155,7 +151,7 @@ export const WorkspaceContainer = (props: WorkspaceContainerProps) => {
     ]),
     deletingWorkspace &&
       h(DeleteWorkspaceModal, {
-        workspace,
+        workspace: workspace!,
         onDismiss: () => setDeletingWorkspace(false),
         onSuccess: () => Nav.goToPath('workspaces'),
       }),
@@ -174,7 +170,7 @@ export const WorkspaceContainer = (props: WorkspaceContainerProps) => {
       }),
     leavingWorkspace &&
       h(LeaveResourceModal, {
-        samResourceId: workspace.workspace.workspaceId,
+        samResourceId: workspace!.workspace.workspaceId,
         samResourceType: 'workspace',
         displayName: 'workspace',
         onDismiss: () => setLeavingWorkspace(false),
@@ -182,7 +178,7 @@ export const WorkspaceContainer = (props: WorkspaceContainerProps) => {
       }),
     sharingWorkspace &&
       h(ShareWorkspaceModal, {
-        workspace,
+        workspace: workspace!,
         onDismiss: () => setSharingWorkspace(false),
       }),
   ]);
@@ -226,7 +222,7 @@ export interface WrappedComponentProps {
   ref: Ref<{ refresh: () => void }>;
   namespace: string;
   name: string;
-  workspace: Workspace;
+  workspace: InitializedWorkspaceWrapper;
   refreshWorkspace: () => void;
   analysesData: AnalysesData;
   storageDetails: StorageDetails;

--- a/src/workspaces/utils.ts
+++ b/src/workspaces/utils.ts
@@ -36,15 +36,21 @@ interface BaseWorkspaceInfo {
   isLocked?: boolean;
   state?: WorkspaceState;
   errorMessage?: string;
+  completedCloneWorkspaceFileTransfer?: string;
+  workspaceType?: 'mc' | 'rawls';
+  workspaceVersion?: string;
 }
 
 export interface AzureWorkspaceInfo extends BaseWorkspaceInfo {
   cloudPlatform: 'Azure';
+  bucketName?: '';
+  googleProject?: '';
 }
 
 export interface GoogleWorkspaceInfo extends BaseWorkspaceInfo {
   cloudPlatform: 'Gcp';
   googleProject: string;
+  billingAccount: string;
   bucketName: string;
 }
 


### PR DESCRIPTION
Currently, the `workspace` value in the object returned by `useWorkspace` is typed as `InitializedWorkspaceWrapper`. However, it actually can be undefined while the workspace is loading. This corrects `useWorkspace`'s return type and types the global `workspaceStore`.

Everything here should be type level changes and corresponding updates to test fixtures. No behavioral changes.