### PR TITLE
UIE-165 error.ts more decoupling for Environments code sharing

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -8494,6 +8494,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@terra-ui-packages/notifications", "virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#workspace:packages/notifications"],\
             ["@terra-ui-packages/build-utils", "virtual:6fecf1af4cab542f4a06b7ce7d9f710277dce92700e0011a9519e41948eed6d8f54c9d0aa109ead6cf4295edce81cb49620f9e823313e99632229bf20d133cdb#workspace:packages/build-utils"],\
             ["@terra-ui-packages/components", "virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#workspace:packages/components"],\
+            ["@terra-ui-packages/core-utils", "workspace:packages/core-utils"],\
             ["@terra-ui-packages/test-utils", "virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#workspace:packages/test-utils"],\
             ["@testing-library/dom", "npm:9.3.1"],\
             ["@testing-library/react", "virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#npm:14.0.0"],\
@@ -8524,6 +8525,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@terra-ui-packages/notifications", "workspace:packages/notifications"],\
             ["@terra-ui-packages/build-utils", "virtual:6fecf1af4cab542f4a06b7ce7d9f710277dce92700e0011a9519e41948eed6d8f54c9d0aa109ead6cf4295edce81cb49620f9e823313e99632229bf20d133cdb#workspace:packages/build-utils"],\
             ["@terra-ui-packages/components", "virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#workspace:packages/components"],\
+            ["@terra-ui-packages/core-utils", "workspace:packages/core-utils"],\
             ["@terra-ui-packages/test-utils", "virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#workspace:packages/test-utils"],\
             ["@testing-library/dom", "npm:9.3.1"],\
             ["@testing-library/react", "virtual:3bc50e11628962e2d3d040387b897fa78149010dc0c7837774133f031c81b063c69d97afa708f6f7b77daf0a0d6419898bc26265121b2bec06dfc7ebf0feed1d#npm:14.0.0"],\

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -24,12 +24,12 @@
   ],
   "dependencies": {
     "@terra-ui-packages/components": "^0.0.6",
-    "@terra-ui-packages/core-utils": "*",
+    "@terra-ui-packages/core-utils": "^0.1.0",
     "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@terra-ui-packages/build-utils": "^1.0.0",
-    "@terra-ui-packages/test-utils": "*",
+    "@terra-ui-packages/test-utils": "^0.0.4",
     "@testing-library/dom": "^9.3.1",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "@terra-ui-packages/components": "^0.0.6",
-    "@terra-ui-packages/core-utils": "^0.1.0",
+    "@terra-ui-packages/core-utils": "^0.2.0",
     "lodash": "^4.17.21"
   },
   "devDependencies": {

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -24,6 +24,7 @@
   ],
   "dependencies": {
     "@terra-ui-packages/components": "^0.0.6",
+    "@terra-ui-packages/core-utils": "*",
     "lodash": "^4.17.21"
   },
   "devDependencies": {

--- a/packages/notifications/src/error.test.ts
+++ b/packages/notifications/src/error.test.ts
@@ -1,0 +1,121 @@
+import { IgnoreErrorDecider, makeNotificationsContract } from './error';
+import { Notifier } from './useNotifications';
+
+const mockNotifications: Notifier = {
+  notify: jest.fn(),
+};
+
+const ignoreError: IgnoreErrorDecider = (title: string, _obj?: unknown): boolean => {
+  return title === 'Ignore Me';
+};
+describe('reportError', () => {
+  it('calls notify and console.error', async () => {
+    // Arrange
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const { reportError } = makeNotificationsContract(mockNotifications, ignoreError);
+
+    // Act
+    await reportError('Things went BOOM', new Error('BOOM!'));
+
+    // Assert
+    const expectedError = new Error('BOOM!');
+    expect(mockNotifications.notify).toBeCalledTimes(1);
+    expect(mockNotifications.notify).toBeCalledWith('error', 'Things went BOOM', { detail: expectedError });
+    expect(console.error).toBeCalledTimes(1);
+    expect(console.error).toBeCalledWith('Things went BOOM', expectedError);
+  });
+
+  it('ignores session timeout error', async () => {
+    // Arrange
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const { reportError } = makeNotificationsContract(mockNotifications, ignoreError);
+
+    // Act
+    await reportError('Ignore Me', new Error('I cried wolf.'));
+
+    // Assert
+    expect(mockNotifications.notify).toBeCalledTimes(0);
+    expect(console.error).toBeCalledTimes(1);
+    expect(console.error).toBeCalledWith('Ignore Me', new Error('I cried wolf.'));
+  });
+});
+
+describe('reportErrorAndRethrow', () => {
+  it('calls notify and rethrows error', async () => {
+    // Arrange
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const { reportErrorAndRethrow } = makeNotificationsContract(mockNotifications, ignoreError);
+    const callMe = reportErrorAndRethrow('Things went BOOM')(async () => {
+      throw new Error('BOOM!');
+    });
+    let outerThrow: unknown | null = null;
+
+    // Act
+    try {
+      await callMe();
+    } catch (e) {
+      outerThrow = e;
+    }
+
+    // Assert
+    const expectedError = new Error('BOOM!');
+    expect(mockNotifications.notify).toBeCalledTimes(1);
+    expect(mockNotifications.notify).toBeCalledWith('error', 'Things went BOOM', { detail: expectedError });
+    expect(console.error).toBeCalledTimes(1);
+    expect(console.error).toBeCalledWith('Things went BOOM', expectedError);
+    expect(outerThrow).toEqual(expectedError);
+  });
+});
+
+describe('withErrorReporting', () => {
+  it('calls dismiss and notify', async () => {
+    // Arrange
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const { withErrorReporting } = makeNotificationsContract(mockNotifications, ignoreError);
+    const callMe = withErrorReporting('Things went BOOM')(async () => {
+      throw new Error('BOOM!');
+    });
+
+    // Act
+    await callMe();
+
+    // Assert
+    const expectedError = new Error('BOOM!');
+    expect(mockNotifications.notify).toBeCalledTimes(1);
+    expect(mockNotifications.notify).toBeCalledWith('error', 'Things went BOOM', { detail: expectedError });
+    expect(console.error).toBeCalledTimes(1);
+    expect(console.error).toBeCalledWith('Things went BOOM', expectedError);
+  });
+});
+
+describe('withErrorReportingInModal', () => {
+  it('calls dismiss and notify', async () => {
+    // Arrange
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const { withErrorReportingInModal } = makeNotificationsContract(mockNotifications, ignoreError);
+    const onDismiss = jest.fn();
+    const callMe = withErrorReportingInModal(
+      'Things went BOOM',
+      onDismiss
+    )(async () => {
+      throw new Error('BOOM!');
+    });
+    let outerThrow: unknown | null = null;
+
+    // Act
+    try {
+      await callMe();
+    } catch (e) {
+      outerThrow = e;
+    }
+
+    // Assert
+    const expectedError = new Error('BOOM!');
+    expect(onDismiss).toBeCalledTimes(1);
+    expect(mockNotifications.notify).toBeCalledTimes(1);
+    expect(mockNotifications.notify).toBeCalledWith('error', 'Things went BOOM', { detail: expectedError });
+    expect(console.error).toBeCalledTimes(1);
+    expect(console.error).toBeCalledWith('Things went BOOM', expectedError);
+    expect(outerThrow).toEqual(expectedError);
+  });
+});

--- a/packages/notifications/src/error.ts
+++ b/packages/notifications/src/error.ts
@@ -1,13 +1,6 @@
 import { AnyPromiseFn } from '@terra-ui-packages/core-utils';
 
-import { ErrorReportingOptions, NotificationsProvider, Notifier } from './useNotifications';
-
 export type ErrorCallback = (error: unknown) => void | Promise<void>;
-
-/**
- * Should return true of a given error should be ignored
- */
-export type IgnoreErrorDecider = (title: string, obj?: unknown) => boolean;
 
 /**
  * Invoke the `callback` with any error thrown when evaluating the async `fn` with `...args`.
@@ -29,39 +22,3 @@ export const withErrorHandling = (callback: ErrorCallback) => {
  * evaluation fails.
  */
 export const withErrorIgnoring = withErrorHandling(() => {});
-
-/**
- * allows composition of NotificationsProvider dependency when useful for code reuse
- * @param notifier
- */
-export const makeNotificationsProvider = (
-  notifier: Notifier,
-  shouldIgnoreError: IgnoreErrorDecider
-): NotificationsProvider => {
-  const notifications: NotificationsProvider = {
-    notify: notifier.notify,
-
-    reportError: async (title: string, obj?: unknown) => {
-      console.error(title, obj); // helpful when the notify component fails to render
-      // Do not do anything if error should be ignored
-      if (shouldIgnoreError(title, obj)) {
-        return;
-      }
-      const detail = await (obj instanceof Response ? obj.text().catch(() => 'Unknown error') : obj);
-      notifier.notify('error', title, { detail });
-    },
-
-    withErrorReporting: (title: string, args?: ErrorReportingOptions) => {
-      return withErrorHandling(async (error) => {
-        await notifications.reportError(title, error);
-        if (args && args.onReported) {
-          args.onReported();
-        }
-        if (args && args.rethrow) {
-          throw error;
-        }
-      });
-    },
-  };
-  return notifications;
-};

--- a/packages/notifications/src/error.ts
+++ b/packages/notifications/src/error.ts
@@ -1,0 +1,87 @@
+import { AnyPromiseFn } from '@terra-ui-packages/core-utils';
+
+import { NotificationsContract, Notifier } from './useNotifications';
+
+export type ErrorCallback = (error: unknown) => void | Promise<void>;
+
+/**
+ * Should return true of a given error should be ignored
+ */
+export type IgnoreErrorDecider = (title: string, obj?: unknown) => boolean;
+
+/**
+ * Invoke the `callback` with any error thrown when evaluating the async `fn` with `...args`.
+ */
+export const withErrorHandling = (callback: ErrorCallback) => {
+  return <F extends AnyPromiseFn>(fn: F) => {
+    return (async (...args: Parameters<F>) => {
+      try {
+        return await fn(...args);
+      } catch (error) {
+        await callback(error);
+      }
+    }) as F;
+  };
+};
+
+/**
+ * Return a Promise to the result of evaluating the async `fn` with `...args` or undefined if
+ * evaluation fails.
+ */
+export const withErrorIgnoring = withErrorHandling(() => {});
+
+/**
+ * allows composition of NotificationsContract dependency when useful for code reuse
+ * @param notifier
+ */
+export const makeNotificationsContract = (
+  notifier: Notifier,
+  ignoreError: IgnoreErrorDecider
+): NotificationsContract => ({
+  notify: notifier.notify,
+
+  reportError: async (title: string, obj?: unknown) => {
+    console.error(title, obj); // helpful when the notify component fails to render
+    // Do not show an error notification if error should be ignored
+    if (ignoreError(title, obj)) {
+      return;
+    }
+    const detail = await (obj instanceof Response ? obj.text().catch(() => 'Unknown error') : obj);
+    notifier.notify('error', title, { detail });
+  },
+
+  /**
+   * Return a Promise to the result of evaluating the async `fn` with `...args`. If evaluation fails,
+   * report the error to the user with `title` as a side effect.
+   */
+  reportErrorAndRethrow: (title: string) => {
+    return <F extends AnyPromiseFn>(fn: F) =>
+      withErrorHandling(async (error): Promise<void> => {
+        await makeNotificationsContract(notifier, ignoreError).reportError(title, error);
+        throw error;
+      })(fn);
+  },
+
+  /**
+   *  This function is designed for use in modals.
+   *  Modals can overlay any error reporting, with the `throw` in the default `withErrorReporting`
+   *  preventing the modal itself from closing on error
+   *  As such, we must ensure we call the dismiss function if an error occurs
+   */
+  withErrorReportingInModal: (title: string, onDismiss: () => void) => {
+    return withErrorHandling(async (error) => {
+      await makeNotificationsContract(notifier, ignoreError).reportError(title, error);
+      onDismiss();
+      throw error;
+    });
+  },
+
+  /**
+   * Return a Promise to the result of evaluating the async `fn` with `...args` or undefined if
+   * evaluation fails. If evaluation fails, report the error to the user with `title`.
+   */
+  withErrorReporting: (title: string) => {
+    return <F extends AnyPromiseFn>(fn: F) =>
+      withErrorIgnoring(makeNotificationsContract(notifier, ignoreError).reportErrorAndRethrow(title)(fn)) as F;
+  },
+});

--- a/packages/notifications/src/index.ts
+++ b/packages/notifications/src/index.ts
@@ -1,1 +1,2 @@
+export * from './error';
 export * from './useNotifications';

--- a/packages/notifications/src/index.ts
+++ b/packages/notifications/src/index.ts
@@ -1,2 +1,3 @@
 export * from './error';
+export * from './notifications-provider';
 export * from './useNotifications';

--- a/packages/notifications/src/notifications-provider.test.ts
+++ b/packages/notifications/src/notifications-provider.test.ts
@@ -1,5 +1,4 @@
-import { IgnoreErrorDecider, makeNotificationsProvider } from './error';
-import { Notifier } from './useNotifications';
+import { IgnoreErrorDecider, makeNotificationsProvider, Notifier } from './notifications-provider';
 
 const mockNotifications: Notifier = {
   notify: jest.fn(),
@@ -48,22 +47,15 @@ describe('withErrorReporting (and rethrow)', () => {
     const callMe = withErrorReporting('Things went BOOM', { rethrow: true })(async () => {
       throw new Error('BOOM!');
     });
-    let outerThrow: unknown | null = null;
 
-    // Act
-    try {
-      await callMe();
-    } catch (e) {
-      outerThrow = e;
-    }
-
-    // Assert
+    // Act / Assert
     const expectedError = new Error('BOOM!');
+    await expect(callMe).rejects.toThrow(expectedError);
+
     expect(mockNotifications.notify).toBeCalledTimes(1);
     expect(mockNotifications.notify).toBeCalledWith('error', 'Things went BOOM', { detail: expectedError });
     expect(console.error).toBeCalledTimes(1);
     expect(console.error).toBeCalledWith('Things went BOOM', expectedError);
-    expect(outerThrow).toEqual(expectedError);
   });
 });
 
@@ -99,22 +91,15 @@ describe('withErrorReporting (in modal)', () => {
     const callMe = withErrorReporting('Things went BOOM', { onReported: onDismiss, rethrow: true })(async () => {
       throw new Error('BOOM!');
     });
-    let outerThrow: unknown | null = null;
 
-    // Act
-    try {
-      await callMe();
-    } catch (e) {
-      outerThrow = e;
-    }
-
-    // Assert
+    // Act / Assert
     const expectedError = new Error('BOOM!');
+    await expect(callMe).rejects.toThrow(expectedError);
+
     expect(onDismiss).toBeCalledTimes(1);
     expect(mockNotifications.notify).toBeCalledTimes(1);
     expect(mockNotifications.notify).toBeCalledWith('error', 'Things went BOOM', { detail: expectedError });
     expect(console.error).toBeCalledTimes(1);
     expect(console.error).toBeCalledWith('Things went BOOM', expectedError);
-    expect(outerThrow).toEqual(expectedError);
   });
 });

--- a/packages/notifications/src/notifications-provider.test.ts
+++ b/packages/notifications/src/notifications-provider.test.ts
@@ -11,7 +11,10 @@ describe('reportError', () => {
   it('calls notify and console.error', async () => {
     // Arrange
     jest.spyOn(console, 'error').mockImplementation(() => {});
-    const { reportError } = makeNotificationsProvider(mockNotifications, ignoreError);
+    const { reportError } = makeNotificationsProvider({
+      notifier: mockNotifications,
+      shouldIgnoreError: ignoreError,
+    });
 
     // Act
     await reportError('Things went BOOM', new Error('BOOM!'));
@@ -27,7 +30,10 @@ describe('reportError', () => {
   it('ignores error when ignore-checker is given', async () => {
     // Arrange
     jest.spyOn(console, 'error').mockImplementation(() => {});
-    const { reportError } = makeNotificationsProvider(mockNotifications, ignoreError);
+    const { reportError } = makeNotificationsProvider({
+      notifier: mockNotifications,
+      shouldIgnoreError: ignoreError,
+    });
 
     // Act
     await reportError('Ignore Me', new Error('I cried wolf.'));
@@ -43,7 +49,10 @@ describe('withErrorReporting (and rethrow)', () => {
   it('calls notify and rethrows error', async () => {
     // Arrange
     jest.spyOn(console, 'error').mockImplementation(() => {});
-    const { withErrorReporting } = makeNotificationsProvider(mockNotifications, ignoreError);
+    const { withErrorReporting } = makeNotificationsProvider({
+      notifier: mockNotifications,
+      shouldIgnoreError: ignoreError,
+    });
     const callMe = withErrorReporting('Things went BOOM', { rethrow: true })(async () => {
       throw new Error('BOOM!');
     });
@@ -63,7 +72,10 @@ describe('withErrorReporting', () => {
   it('calls notify and console.error', async () => {
     // Arrange
     jest.spyOn(console, 'error').mockImplementation(() => {});
-    const { withErrorReporting } = makeNotificationsProvider(mockNotifications, ignoreError);
+    const { withErrorReporting } = makeNotificationsProvider({
+      notifier: mockNotifications,
+      shouldIgnoreError: ignoreError,
+    });
     const callMe = withErrorReporting('Things went BOOM')(async () => {
       throw new Error('BOOM!');
     });
@@ -84,7 +96,10 @@ describe('withErrorReporting (in modal)', () => {
   it('calls dismiss and notify', async () => {
     // Arrange
     jest.spyOn(console, 'error').mockImplementation(() => {});
-    const { withErrorReporting } = makeNotificationsProvider(mockNotifications, ignoreError);
+    const { withErrorReporting } = makeNotificationsProvider({
+      notifier: mockNotifications,
+      shouldIgnoreError: ignoreError,
+    });
     const onDismiss = jest.fn();
 
     // have withErrorReporting use args that match commonly desired behavior within a Modal

--- a/packages/notifications/src/notifications-provider.ts
+++ b/packages/notifications/src/notifications-provider.ts
@@ -1,0 +1,77 @@
+import { AnyPromiseFn } from '@terra-ui-packages/core-utils';
+
+import { withErrorHandling } from './error';
+
+/**
+ * Should return true of a given error should be ignored
+ */
+export type IgnoreErrorDecider = (title: string, obj?: unknown) => boolean;
+
+export type NotificationType = 'error' | 'warn' | 'info' | 'success' | 'welcome';
+export interface NotificationOptions {
+  /**
+   * string, Error(unknown), or json object to be displayed in detail section
+   */
+  detail?: unknown;
+}
+
+export interface Notifier {
+  notify: (type: NotificationType, title: string, options?: NotificationOptions) => void;
+}
+
+export interface ErrorReportingOptions {
+  rethrow?: boolean; // default: false
+  onReported?: () => void;
+}
+
+export interface ErrorReporter {
+  /**
+   * Reports the error visually to the user using the app's notification system
+   * @param title - error title
+   * @param obj - an error, response, or arbitrary json-style object
+   */
+  reportError: (title: string, obj?: unknown) => Promise<void>;
+
+  /**
+   * Returns a function augmenter (HoF).
+   * If provided function fails when called, report the error to the user with `title` as a side effect.
+   * Use options arg to give onReported callback, and/or rethrow on error.
+   */
+  withErrorReporting: <F extends AnyPromiseFn>(title: string, options?: ErrorReportingOptions) => (fn: F) => F;
+}
+
+export interface NotificationsProvider extends Notifier, ErrorReporter {}
+
+/**
+ * allows composition of NotificationsProvider dependency when useful for code reuse
+ * @param notifier
+ */
+export const makeNotificationsProvider = (
+  notifier: Notifier,
+  shouldIgnoreError: IgnoreErrorDecider
+): NotificationsProvider => {
+  const notifications: NotificationsProvider = {
+    notify: notifier.notify,
+
+    reportError: async (title: string, obj?: unknown) => {
+      console.error(title, obj); // helpful when the notify component fails to render
+      // Do not do anything if error should be ignored
+      if (shouldIgnoreError(title, obj)) {
+        return;
+      }
+      const detail = await (obj instanceof Response ? obj.text().catch(() => 'Unknown error') : obj);
+      notifier.notify('error', title, { detail });
+    },
+
+    withErrorReporting: (title: string, args?: ErrorReportingOptions) => {
+      return withErrorHandling(async (error) => {
+        await notifications.reportError(title, error);
+        args?.onReported?.();
+        if (args?.rethrow) {
+          throw error;
+        }
+      });
+    },
+  };
+  return notifications;
+};

--- a/packages/notifications/src/notifications-provider.ts
+++ b/packages/notifications/src/notifications-provider.ts
@@ -43,24 +43,29 @@ export interface ErrorReporter {
 export interface NotificationsProvider extends Notifier, ErrorReporter {}
 
 /**
- * allows composition of NotificationsProvider dependency when useful for code reuse
- * @param notifier
+ * dependencies for NotificationsProvider factory method makeNotificationsProvider
  */
-export const makeNotificationsProvider = (
-  notifier: Notifier,
-  shouldIgnoreError: IgnoreErrorDecider
-): NotificationsProvider => {
+export interface NotificationsProviderDeps {
+  notifier: Notifier;
+  shouldIgnoreError: IgnoreErrorDecider;
+}
+
+/**
+ * allows composition of NotificationsProvider dependency when useful for code reuse
+ * @param deps
+ */
+export const makeNotificationsProvider = (deps: NotificationsProviderDeps): NotificationsProvider => {
   const notifications: NotificationsProvider = {
-    notify: notifier.notify,
+    notify: deps.notifier.notify,
 
     reportError: async (title: string, obj?: unknown) => {
       console.error(title, obj); // helpful when the notify component fails to render
       // Do not do anything if error should be ignored
-      if (shouldIgnoreError(title, obj)) {
+      if (deps.shouldIgnoreError(title, obj)) {
         return;
       }
       const detail = await (obj instanceof Response ? obj.text().catch(() => 'Unknown error') : obj);
-      notifier.notify('error', title, { detail });
+      deps.notifier.notify('error', title, { detail });
     },
 
     withErrorReporting: (title: string, args?: ErrorReportingOptions) => {

--- a/packages/notifications/src/useNotifications.test.tsx
+++ b/packages/notifications/src/useNotifications.test.tsx
@@ -17,6 +17,10 @@ describe('useNotificationsFromContext', () => {
 
     const reporter: NotificationsContract = {
       notify: jest.fn(),
+      reportError: jest.fn(),
+      reportErrorAndRethrow: jest.fn(),
+      withErrorReporting: jest.fn(),
+      withErrorReportingInModal: jest.fn(),
     };
 
     // Act

--- a/packages/notifications/src/useNotifications.test.tsx
+++ b/packages/notifications/src/useNotifications.test.tsx
@@ -2,12 +2,8 @@ import { ErrorBoundary } from '@terra-ui-packages/components';
 import { render } from '@testing-library/react';
 import React from 'react';
 
-import {
-  NotificationsContextProvider,
-  NotificationsProvider,
-  text,
-  useNotificationsFromContext,
-} from './useNotifications';
+import { NotificationsProvider } from './notifications-provider';
+import { NotificationsContextProvider, text, useNotificationsFromContext } from './useNotifications';
 
 describe('useNotificationsFromContext', () => {
   it('gets notifications provider from context', () => {

--- a/packages/notifications/src/useNotifications.test.tsx
+++ b/packages/notifications/src/useNotifications.test.tsx
@@ -2,7 +2,12 @@ import { ErrorBoundary } from '@terra-ui-packages/components';
 import { render } from '@testing-library/react';
 import React from 'react';
 
-import { NotificationsContract, NotificationsProvider, text, useNotificationsFromContext } from './useNotifications';
+import {
+  NotificationsContextProvider,
+  NotificationsProvider,
+  text,
+  useNotificationsFromContext,
+} from './useNotifications';
 
 describe('useNotificationsFromContext', () => {
   it('gets notifications provider from context', () => {
@@ -15,19 +20,17 @@ describe('useNotificationsFromContext', () => {
       return null;
     };
 
-    const reporter: NotificationsContract = {
+    const reporter: NotificationsProvider = {
       notify: jest.fn(),
       reportError: jest.fn(),
-      reportErrorAndRethrow: jest.fn(),
       withErrorReporting: jest.fn(),
-      withErrorReportingInModal: jest.fn(),
     };
 
     // Act
     render(
-      <NotificationsProvider notifications={reporter}>
+      <NotificationsContextProvider notifications={reporter}>
         <TestComponent />
-      </NotificationsProvider>
+      </NotificationsContextProvider>
     );
 
     // Assert

--- a/packages/notifications/src/useNotifications.ts
+++ b/packages/notifications/src/useNotifications.ts
@@ -1,3 +1,4 @@
+import { AnyPromiseFn } from '@terra-ui-packages/core-utils';
 import { createContext, createElement, PropsWithChildren, ReactNode, useContext } from 'react';
 
 export type NotificationType = 'error' | 'warn' | 'info' | 'success' | 'welcome';
@@ -8,9 +9,17 @@ export interface NotificationOptions {
   detail?: unknown;
 }
 
-export interface NotificationsContract {
+export interface Notifier {
   notify: (type: NotificationType, title: string, options?: NotificationOptions) => void;
 }
+
+export interface NotificationsContract extends Notifier {
+  reportError: (title: string, obj?: unknown) => Promise<void>;
+  reportErrorAndRethrow: <F extends AnyPromiseFn>(title: string) => (fn: F) => F;
+  withErrorReportingInModal: <F extends AnyPromiseFn>(title: string, onDismiss: () => void) => (fn: F) => F;
+  withErrorReporting: <F extends AnyPromiseFn>(title: string) => (fn: F) => F;
+}
+
 const NotificationsContext = createContext<NotificationsContract | null>(null);
 
 export type NotificationsProviderProps = PropsWithChildren<{

--- a/packages/notifications/src/useNotifications.ts
+++ b/packages/notifications/src/useNotifications.ts
@@ -1,40 +1,6 @@
-import { AnyPromiseFn } from '@terra-ui-packages/core-utils';
 import { createContext, createElement, PropsWithChildren, ReactNode, useContext } from 'react';
 
-export type NotificationType = 'error' | 'warn' | 'info' | 'success' | 'welcome';
-export interface NotificationOptions {
-  /**
-   * string, Error(unknown), or json object to be displayed in detail section
-   */
-  detail?: unknown;
-}
-
-export interface Notifier {
-  notify: (type: NotificationType, title: string, options?: NotificationOptions) => void;
-}
-
-export interface ErrorReportingOptions {
-  rethrow?: boolean; // default: false
-  onReported?: () => void;
-}
-
-export interface ErrorReporter {
-  /**
-   * Reports the error visually to the user using the app's notification system
-   * @param title - error title
-   * @param obj - an error, response, or arbitrary json-style object
-   */
-  reportError: (title: string, obj?: unknown) => Promise<void>;
-
-  /**
-   * Returns a function augmenter (HoF).
-   * If provided function fails when called, report the error to the user with `title` as a side effect.
-   * Use options arg to give onReported callback, and/or rethrow on error.
-   */
-  withErrorReporting: <F extends AnyPromiseFn>(title: string, options?: ErrorReportingOptions) => (fn: F) => F;
-}
-
-export interface NotificationsProvider extends Notifier, ErrorReporter {}
+import { NotificationsProvider } from './notifications-provider';
 
 const NotificationsContext = createContext<NotificationsProvider | null>(null);
 
@@ -54,7 +20,7 @@ export const NotificationsContextProvider = (props: NotificationsContextProvider
   const { children, notifications } = props;
   return createElement(NotificationsContext.Provider, { value: notifications }, children);
 };
-/** Gets the current NotificationsContextProvider from React context. */
+/** Gets the current NotificationsProvider from React context. */
 export const useNotificationsFromContext = (): NotificationsProvider => {
   const notifier = useContext(NotificationsContext);
   if (!notifier) {

--- a/src/analysis/Environments/DeleteAppModal.ts
+++ b/src/analysis/Environments/DeleteAppModal.ts
@@ -21,13 +21,13 @@ export interface DeleteAppModalProps {
 
 export const DeleteAppModal = (props: DeleteAppModalProps): ReactNode => {
   const { app, onDismiss, onSuccess, deleteProvider } = props;
-  const { withErrorReportingInModal } = useNotificationsFromContext();
+  const { withErrorReporting } = useNotificationsFromContext();
   const [deleteDisk, setDeleteDisk] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const { appType } = app;
   const deleteApp = _.flow(
     Utils.withBusyState(setDeleting),
-    withErrorReportingInModal('Error deleting cloud environment', onDismiss)
+    withErrorReporting('Error deleting cloud environment', { rethrow: true, onNotified: onDismiss })
   )(async () => {
     await deleteProvider.delete(app, { deleteDisk });
     onSuccess();

--- a/src/analysis/Environments/DeleteAppModal.ts
+++ b/src/analysis/Environments/DeleteAppModal.ts
@@ -27,7 +27,7 @@ export const DeleteAppModal = (props: DeleteAppModalProps): ReactNode => {
   const { appType } = app;
   const deleteApp = _.flow(
     Utils.withBusyState(setDeleting),
-    withErrorReporting('Error deleting cloud environment', { rethrow: true, onNotified: onDismiss })
+    withErrorReporting('Error deleting cloud environment', { rethrow: true, onReported: onDismiss })
   )(async () => {
     await deleteProvider.delete(app, { deleteDisk });
     onSuccess();

--- a/src/analysis/Environments/DeleteAppModal.ts
+++ b/src/analysis/Environments/DeleteAppModal.ts
@@ -8,7 +8,6 @@ import { appTools } from 'src/analysis/utils/tool-utils';
 import { LabeledCheckbox, spinnerOverlay } from 'src/components/common';
 import { ListAppItem } from 'src/libs/ajax/leonardo/models/app-models';
 import { LeoAppProvider } from 'src/libs/ajax/leonardo/providers/LeoAppProvider';
-import { withErrorReporter } from 'src/libs/error';
 import * as Utils from 'src/libs/utils';
 
 export type DeleteAppProvider = Pick<LeoAppProvider, 'delete'>;
@@ -22,7 +21,7 @@ export interface DeleteAppModalProps {
 
 export const DeleteAppModal = (props: DeleteAppModalProps): ReactNode => {
   const { app, onDismiss, onSuccess, deleteProvider } = props;
-  const { withErrorReportingInModal } = withErrorReporter(useNotificationsFromContext());
+  const { withErrorReportingInModal } = useNotificationsFromContext();
   const [deleteDisk, setDeleteDisk] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const { appType } = app;

--- a/src/analysis/Environments/DeleteDiskModal.ts
+++ b/src/analysis/Environments/DeleteDiskModal.ts
@@ -7,7 +7,6 @@ import { SaveFilesHelp } from 'src/analysis/runtime-common-text';
 import { getDiskAppType } from 'src/analysis/utils/app-utils';
 import { appTools } from 'src/analysis/utils/tool-utils';
 import { spinnerOverlay } from 'src/components/common';
-import { withErrorReporter } from 'src/libs/error';
 import { withBusyState } from 'src/libs/utils';
 
 import { DeleteDiskProvider, DiskWithWorkspace } from './Environments.models';
@@ -21,7 +20,7 @@ export interface DeleteDiskModalProps {
 
 export const DeleteDiskModal = (props: DeleteDiskModalProps): ReactNode => {
   const { disk, deleteProvider, onDismiss, onSuccess } = props;
-  const { withErrorReporting } = withErrorReporter(useNotificationsFromContext());
+  const { withErrorReporting } = useNotificationsFromContext();
   const [busy, setBusy] = useState(false);
 
   const deleteDisk = _.flow(

--- a/src/analysis/Environments/DeleteRuntimeModal.ts
+++ b/src/analysis/Environments/DeleteRuntimeModal.ts
@@ -8,7 +8,6 @@ import { isGcpContext } from 'src/analysis/utils/runtime-utils';
 import { LabeledCheckbox, spinnerOverlay } from 'src/components/common';
 import { isAzureConfig, isGceWithPdConfig } from 'src/libs/ajax/leonardo/models/runtime-config-models';
 import { ListRuntimeItem } from 'src/libs/ajax/leonardo/models/runtime-models';
-import { withErrorReporter } from 'src/libs/error';
 import { withBusyState } from 'src/libs/utils';
 
 import { DeleteRuntimeProvider } from './Environments.models';
@@ -22,7 +21,7 @@ export interface DeleteRuntimeModalProps {
 
 export const DeleteRuntimeModal = (props: DeleteRuntimeModalProps): ReactNode => {
   const { runtime, deleteProvider, onDismiss, onSuccess } = props;
-  const { withErrorReporting } = withErrorReporter(useNotificationsFromContext());
+  const { withErrorReporting } = useNotificationsFromContext();
   const { cloudContext, runtimeConfig } = runtime;
   const [deleteDisk, setDeleteDisk] = useState(false);
   const [deleting, setDeleting] = useState(false);

--- a/src/analysis/Environments/Environments.stories.tsx
+++ b/src/analysis/Environments/Environments.stories.tsx
@@ -1,7 +1,7 @@
 import { action } from '@storybook/addon-actions';
 import type { Meta, StoryObj } from '@storybook/react';
 import { atom, delay } from '@terra-ui-packages/core-utils';
-import { makeNotificationsContract, NotificationsProvider, Notifier } from '@terra-ui-packages/notifications';
+import { makeNotificationsProvider, NotificationsContextProvider, Notifier } from '@terra-ui-packages/notifications';
 import React, { useEffect, useState } from 'react';
 import {
   azureRuntime,
@@ -127,7 +127,7 @@ const getMockNav = (): EnvironmentsProps['nav'] => ({
 const mockNotifier: Notifier = {
   notify: actionLogAsyncFn('Notifications.notify'),
 };
-const mockNotifications = makeNotificationsContract(mockNotifier, () => false);
+const mockNotifications = makeNotificationsProvider(mockNotifier, () => false);
 
 const happyPermissions: LeoResourcePermissionsProvider = {
   canDeleteDisk: () => true,
@@ -145,7 +145,7 @@ export const HappyEnvironments: Story = {
         disksStore.set([generateTestDiskWithGoogleWorkspace()]);
       }, []);
       return (
-        <NotificationsProvider notifications={mockNotifications}>
+        <NotificationsContextProvider notifications={mockNotifications}>
           <Environments
             nav={getMockNav()}
             useWorkspaces={getMockUseWorkspaces([defaultGoogleWorkspace, defaultAzureWorkspace])}
@@ -155,7 +155,7 @@ export const HappyEnvironments: Story = {
             permissions={happyPermissions}
             onEvent={actionLogFn('onEvent')}
           />
-        </NotificationsProvider>
+        </NotificationsContextProvider>
       );
     };
     return <StoryWrapper />;
@@ -171,7 +171,7 @@ export const NoEnvironments: Story = {
         disksStore.set([]);
       }, []);
       return (
-        <NotificationsProvider notifications={mockNotifications}>
+        <NotificationsContextProvider notifications={mockNotifications}>
           <Environments
             nav={getMockNav()}
             useWorkspaces={getMockUseWorkspaces([defaultGoogleWorkspace, defaultAzureWorkspace])}
@@ -181,7 +181,7 @@ export const NoEnvironments: Story = {
             permissions={happyPermissions}
             onEvent={actionLogFn('onEvent')}
           />
-        </NotificationsProvider>
+        </NotificationsContextProvider>
       );
     };
     return <StoryWrapper />;
@@ -197,7 +197,7 @@ export const DeleteError: Story = {
         disksStore.set([generateTestDiskWithGoogleWorkspace()]);
       }, []);
       return (
-        <NotificationsProvider notifications={mockNotifications}>
+        <NotificationsContextProvider notifications={mockNotifications}>
           <Environments
             nav={getMockNav()}
             useWorkspaces={getMockUseWorkspaces([defaultGoogleWorkspace, defaultAzureWorkspace])}
@@ -210,7 +210,7 @@ export const DeleteError: Story = {
             permissions={happyPermissions}
             onEvent={actionLogFn('onEvent')}
           />
-        </NotificationsProvider>
+        </NotificationsContextProvider>
       );
     };
     return <StoryWrapper />;

--- a/src/analysis/Environments/Environments.stories.tsx
+++ b/src/analysis/Environments/Environments.stories.tsx
@@ -127,7 +127,10 @@ const getMockNav = (): EnvironmentsProps['nav'] => ({
 const mockNotifier: Notifier = {
   notify: actionLogAsyncFn('Notifications.notify'),
 };
-const mockNotifications = makeNotificationsProvider(mockNotifier, () => false);
+const mockNotifications = makeNotificationsProvider({
+  notifier: mockNotifier,
+  shouldIgnoreError: () => false,
+});
 
 const happyPermissions: LeoResourcePermissionsProvider = {
   canDeleteDisk: () => true,

--- a/src/analysis/Environments/Environments.stories.tsx
+++ b/src/analysis/Environments/Environments.stories.tsx
@@ -1,7 +1,7 @@
 import { action } from '@storybook/addon-actions';
 import type { Meta, StoryObj } from '@storybook/react';
 import { atom, delay } from '@terra-ui-packages/core-utils';
-import { NotificationsContract, NotificationsProvider } from '@terra-ui-packages/notifications';
+import { makeNotificationsContract, NotificationsProvider, Notifier } from '@terra-ui-packages/notifications';
 import React, { useEffect, useState } from 'react';
 import {
   azureRuntime,
@@ -124,9 +124,10 @@ const getMockNav = (): EnvironmentsProps['nav'] => ({
   getUrl: (navKey, args) => `javascript:alert('nav to ${navKey} with: ${JSON.stringify(args)}')`,
 });
 
-const mockNotifications: NotificationsContract = {
+const mockNotifier: Notifier = {
   notify: actionLogAsyncFn('Notifications.notify'),
 };
+const mockNotifications = makeNotificationsContract(mockNotifier, () => false);
 
 const happyPermissions: LeoResourcePermissionsProvider = {
   canDeleteDisk: () => true,

--- a/src/analysis/Environments/Environments.ts
+++ b/src/analysis/Environments/Environments.ts
@@ -1,6 +1,6 @@
 import { PopupTrigger, TooltipTrigger, useModalHandler, useThemeFromContext } from '@terra-ui-packages/components';
 import { formatDatetime, KeyedEventHandler, Mutate, NavLinkProvider } from '@terra-ui-packages/core-utils';
-import { useNotificationsFromContext } from '@terra-ui-packages/notifications';
+import { useNotificationsFromContext, withErrorIgnoring } from '@terra-ui-packages/notifications';
 import _ from 'lodash/fp';
 import { Fragment, ReactNode, useEffect, useState } from 'react';
 import { div, h, h2, span, strong } from 'react-hyperscript-helpers';
@@ -29,7 +29,6 @@ import { isRuntime, ListRuntimeItem } from 'src/libs/ajax/leonardo/models/runtim
 import { LeoAppProvider } from 'src/libs/ajax/leonardo/providers/LeoAppProvider';
 import { LeoDiskProvider } from 'src/libs/ajax/leonardo/providers/LeoDiskProvider';
 import { LeoRuntimeProvider } from 'src/libs/ajax/leonardo/providers/LeoRuntimeProvider';
-import { withErrorIgnoring, withErrorReporter } from 'src/libs/error';
 import { useCancellation, useGetter } from 'src/libs/react-utils';
 import { contactUsActive } from 'src/libs/state';
 import { elements as styleElements } from 'src/libs/style';
@@ -89,7 +88,7 @@ export interface EnvironmentsProps {
 export const Environments = (props: EnvironmentsProps): ReactNode => {
   const { nav, useWorkspaces, leoAppData, leoDiskData, leoRuntimeData, permissions, onEvent } = props;
   const { colors } = useThemeFromContext();
-  const { withErrorReporting } = withErrorReporter(useNotificationsFromContext());
+  const { withErrorReporting } = useNotificationsFromContext();
   const signal = useCancellation();
 
   type WorkspaceWrapperLookup = { [namespace: string]: { [name: string]: WorkspaceWrapper } };

--- a/src/billing/List/BillingList.ts
+++ b/src/billing/List/BillingList.ts
@@ -1,3 +1,4 @@
+import { withHandlers } from '@terra-ui-packages/core-utils';
 import _ from 'lodash/fp';
 import * as qs from 'qs';
 import { useEffect, useRef, useState } from 'react';
@@ -86,17 +87,17 @@ export const BillingList = (props: BillingListProps) => {
     Utils.withBusyState(setIsAuthorizing)
   )(Auth.tryBillingScope);
 
-  const loadAccounts = _.flow(
-    reportErrorAndRethrow('Error loading billing accounts'),
-    Utils.withBusyState(setIsLoadingAccounts)
-  )(() => {
-    if (Auth.hasBillingScope()) {
-      return Ajax(signal)
-        .Billing.listAccounts()
-        .then(_.keyBy('accountName')) // @ts-ignore
-        .then(setBillingAccounts);
+  const loadAccounts = withHandlers(
+    [reportErrorAndRethrow('Error loading billing accounts'), Utils.withBusyState(setIsLoadingAccounts)],
+    async () => {
+      if (Auth.hasBillingScope()) {
+        void (await Ajax(signal)
+          .Billing.listAccounts()
+          .then(_.keyBy('accountName')) // @ts-ignore
+          .then(setBillingAccounts));
+      }
     }
-  });
+  );
 
   const authorizeAndLoadAccounts = () => authorizeAccounts().then(loadAccounts);
 

--- a/src/libs/error.test.ts
+++ b/src/libs/error.test.ts
@@ -1,100 +1,9 @@
 import { sessionTimedOutErrorMessage } from 'src/auth/auth-errors';
-import { reportError as reportErrorFallback, withErrorReporter } from 'src/libs/error';
+import { reportError as reportErrorFallback } from 'src/libs/error';
 import { notify } from 'src/libs/notifications';
 import { mockNotifications } from 'src/testing/test-utils';
 
 jest.mock('src/libs/notifications');
-
-describe('report', () => {
-  it('calls notify and console.error', async () => {
-    // Arrange
-    jest.spyOn(console, 'error').mockImplementation(() => {});
-    const { reportError } = withErrorReporter(mockNotifications);
-
-    // Act
-    await reportError('Things went BOOM', new Error('BOOM!'));
-
-    // Assert
-    const expectedError = new Error('BOOM!');
-    expect(mockNotifications.notify).toBeCalledTimes(1);
-    expect(mockNotifications.notify).toBeCalledWith('error', 'Things went BOOM', { detail: expectedError });
-    expect(console.error).toBeCalledTimes(1);
-    expect(console.error).toBeCalledWith('Things went BOOM', expectedError);
-  });
-
-  it('ignores session timeout error', async () => {
-    // Arrange
-    jest.spyOn(console, 'error').mockImplementation(() => {});
-    const { reportError } = withErrorReporter(mockNotifications);
-
-    // Act
-    await reportError('Things went BOOM', new Error(sessionTimedOutErrorMessage));
-
-    // Assert
-    expect(mockNotifications.notify).toBeCalledTimes(0);
-    expect(console.error).toBeCalledTimes(1);
-    expect(console.error).toBeCalledWith('Things went BOOM', new Error(sessionTimedOutErrorMessage));
-  });
-});
-
-describe('reportErrorAndRethrow', () => {
-  it('calls notify and rethrows error', async () => {
-    // Arrange
-    jest.spyOn(console, 'error').mockImplementation(() => {});
-    const { reportErrorAndRethrow } = withErrorReporter(mockNotifications);
-    const callMe = reportErrorAndRethrow('Things went BOOM')(async () => {
-      throw new Error('BOOM!');
-    });
-    let outerThrow: unknown | null = null;
-
-    // Act
-    try {
-      await callMe();
-    } catch (e) {
-      outerThrow = e;
-    }
-
-    // Assert
-    const expectedError = new Error('BOOM!');
-    expect(mockNotifications.notify).toBeCalledTimes(1);
-    expect(mockNotifications.notify).toBeCalledWith('error', 'Things went BOOM', { detail: expectedError });
-    expect(console.error).toBeCalledTimes(1);
-    expect(console.error).toBeCalledWith('Things went BOOM', expectedError);
-    expect(outerThrow).toEqual(expectedError);
-  });
-});
-
-describe('withErrorReportingInModal', () => {
-  it('calls dismiss and notify', async () => {
-    // Arrange
-    jest.spyOn(console, 'error').mockImplementation(() => {});
-    const { withErrorReportingInModal } = withErrorReporter(mockNotifications);
-    const onDismiss = jest.fn();
-    const callMe = withErrorReportingInModal(
-      'Things went BOOM',
-      onDismiss
-    )(async () => {
-      throw new Error('BOOM!');
-    });
-    let outerThrow: unknown | null = null;
-
-    // Act
-    try {
-      await callMe();
-    } catch (e) {
-      outerThrow = e;
-    }
-
-    // Assert
-    const expectedError = new Error('BOOM!');
-    expect(onDismiss).toBeCalledTimes(1);
-    expect(mockNotifications.notify).toBeCalledTimes(1);
-    expect(mockNotifications.notify).toBeCalledWith('error', 'Things went BOOM', { detail: expectedError });
-    expect(console.error).toBeCalledTimes(1);
-    expect(console.error).toBeCalledWith('Things went BOOM', expectedError);
-    expect(outerThrow).toEqual(expectedError);
-  });
-});
 
 describe('reportError - using terra notificationsProvider fallback', () => {
   it('calls notify and console.error', async () => {
@@ -110,5 +19,18 @@ describe('reportError - using terra notificationsProvider fallback', () => {
     expect(notify).toBeCalledWith('error', 'Things went BOOM', { detail: expectedError });
     expect(console.error).toBeCalledTimes(1);
     expect(console.error).toBeCalledWith('Things went BOOM', expectedError);
+  });
+
+  it('ignores session timeout error', async () => {
+    // Arrange
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    // Act
+    await reportErrorFallback('Session is over', new Error(sessionTimedOutErrorMessage));
+
+    // Assert
+    expect(mockNotifications.notify).toBeCalledTimes(0);
+    expect(console.error).toBeCalledTimes(1);
+    expect(console.error).toBeCalledWith('Session is over', new Error(sessionTimedOutErrorMessage));
   });
 });

--- a/src/libs/error.test.ts
+++ b/src/libs/error.test.ts
@@ -1,17 +1,16 @@
 import { sessionTimedOutErrorMessage } from 'src/auth/auth-errors';
-import { reportError as reportErrorFallback } from 'src/libs/error';
+import { reportError, reportErrorAndRethrow, withErrorReportingInModal } from 'src/libs/error';
 import { notify } from 'src/libs/notifications';
-import { mockNotifications } from 'src/testing/test-utils';
 
 jest.mock('src/libs/notifications');
 
-describe('reportError - using terra notificationsProvider fallback', () => {
+describe('reportError - using terra NotificationsContextProvider fallback', () => {
   it('calls notify and console.error', async () => {
     // Arrange
     jest.spyOn(console, 'error').mockImplementation(() => {});
 
     // Act
-    await reportErrorFallback('Things went BOOM', new Error('BOOM!'));
+    await reportError('Things went BOOM', new Error('BOOM!'));
 
     // Assert
     const expectedError = new Error('BOOM!');
@@ -26,11 +25,68 @@ describe('reportError - using terra notificationsProvider fallback', () => {
     jest.spyOn(console, 'error').mockImplementation(() => {});
 
     // Act
-    await reportErrorFallback('Session is over', new Error(sessionTimedOutErrorMessage));
+    await reportError('Session is over', new Error(sessionTimedOutErrorMessage));
 
     // Assert
-    expect(mockNotifications.notify).toBeCalledTimes(0);
+    expect(notify).toBeCalledTimes(0);
     expect(console.error).toBeCalledTimes(1);
     expect(console.error).toBeCalledWith('Session is over', new Error(sessionTimedOutErrorMessage));
+  });
+});
+
+describe('withErrorReporting fallbacks', () => {
+  it('calls notify and rethrows error', async () => {
+    // Arrange
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const callMe = reportErrorAndRethrow('Things went BOOM')(async () => {
+      throw new Error('BOOM!');
+    });
+    let outerThrow: unknown | null = null;
+
+    // Act
+    try {
+      await callMe();
+    } catch (e) {
+      outerThrow = e;
+    }
+
+    // Assert
+    const expectedError = new Error('BOOM!');
+    expect(notify).toBeCalledTimes(1);
+    expect(notify).toBeCalledWith('error', 'Things went BOOM', { detail: expectedError });
+    expect(console.error).toBeCalledTimes(1);
+    expect(console.error).toBeCalledWith('Things went BOOM', expectedError);
+    expect(outerThrow).toEqual(expectedError);
+  });
+
+  it('calls dismiss and notify (in modal)', async () => {
+    // Arrange
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const onDismiss = jest.fn();
+
+    // have withErrorReporting use args that match commonly desired behavior within a Modal
+    const callMe = withErrorReportingInModal(
+      'Things went BOOM',
+      onDismiss
+    )(async () => {
+      throw new Error('BOOM!');
+    });
+    let outerThrow: unknown | null = null;
+
+    // Act
+    try {
+      await callMe();
+    } catch (e) {
+      outerThrow = e;
+    }
+
+    // Assert
+    const expectedError = new Error('BOOM!');
+    expect(onDismiss).toBeCalledTimes(1);
+    expect(notify).toBeCalledTimes(1);
+    expect(notify).toBeCalledWith('error', 'Things went BOOM', { detail: expectedError });
+    expect(console.error).toBeCalledTimes(1);
+    expect(console.error).toBeCalledWith('Things went BOOM', expectedError);
+    expect(outerThrow).toEqual(expectedError);
   });
 });

--- a/src/libs/error.test.ts
+++ b/src/libs/error.test.ts
@@ -41,22 +41,15 @@ describe('withErrorReporting fallbacks', () => {
     const callMe = reportErrorAndRethrow('Things went BOOM')(async () => {
       throw new Error('BOOM!');
     });
-    let outerThrow: unknown | null = null;
 
-    // Act
-    try {
-      await callMe();
-    } catch (e) {
-      outerThrow = e;
-    }
-
-    // Assert
+    // Act / Assert
     const expectedError = new Error('BOOM!');
+    await expect(callMe).rejects.toThrow(expectedError);
+
     expect(notify).toBeCalledTimes(1);
     expect(notify).toBeCalledWith('error', 'Things went BOOM', { detail: expectedError });
     expect(console.error).toBeCalledTimes(1);
     expect(console.error).toBeCalledWith('Things went BOOM', expectedError);
-    expect(outerThrow).toEqual(expectedError);
   });
 
   it('calls dismiss and notify (in modal)', async () => {
@@ -71,22 +64,15 @@ describe('withErrorReporting fallbacks', () => {
     )(async () => {
       throw new Error('BOOM!');
     });
-    let outerThrow: unknown | null = null;
 
-    // Act
-    try {
-      await callMe();
-    } catch (e) {
-      outerThrow = e;
-    }
-
-    // Assert
+    // Act / Assert
     const expectedError = new Error('BOOM!');
+    await expect(callMe).rejects.toThrow(expectedError);
+
     expect(onDismiss).toBeCalledTimes(1);
     expect(notify).toBeCalledTimes(1);
     expect(notify).toBeCalledWith('error', 'Things went BOOM', { detail: expectedError });
     expect(console.error).toBeCalledTimes(1);
     expect(console.error).toBeCalledWith('Things went BOOM', expectedError);
-    expect(outerThrow).toEqual(expectedError);
   });
 });

--- a/src/libs/error.ts
+++ b/src/libs/error.ts
@@ -14,7 +14,10 @@ const notifier: Notifier = {
   notify,
 };
 
-export const terraUINotifications = makeNotificationsProvider(notifier, ignoreSessionTimeout);
+export const terraUINotifications = makeNotificationsProvider({
+  notifier,
+  shouldIgnoreError: ignoreSessionTimeout,
+});
 
 // provide backwards compatible fail-safes for existing code that is not yet ready for code-reuse
 

--- a/src/libs/error.ts
+++ b/src/libs/error.ts
@@ -1,4 +1,4 @@
-import { IgnoreErrorDecider, makeNotificationsContract, Notifier } from '@terra-ui-packages/notifications';
+import { IgnoreErrorDecider, makeNotificationsProvider, Notifier } from '@terra-ui-packages/notifications';
 import { sessionTimedOutErrorMessage } from 'src/auth/auth-errors';
 import { notify } from 'src/libs/notifications';
 
@@ -14,11 +14,16 @@ const notifier: Notifier = {
   notify,
 };
 
-export const terraUIReporter = makeNotificationsContract(notifier, ignoreSessionTimeout);
+export const terraUINotifications = makeNotificationsProvider(notifier, ignoreSessionTimeout);
 
 // provide backwards compatible fail-safes for existing code that is not yet ready for code-reuse
 
-export const reportError = terraUIReporter.reportError;
-export const reportErrorAndRethrow = terraUIReporter.reportErrorAndRethrow;
-export const withErrorReportingInModal = terraUIReporter.withErrorReportingInModal;
-export const withErrorReporting = terraUIReporter.withErrorReporting;
+export const reportError = terraUINotifications.reportError;
+
+export const reportErrorAndRethrow = (title: string) =>
+  terraUINotifications.withErrorReporting(title, { rethrow: true });
+
+export const withErrorReportingInModal = (title: string, onDismiss: () => void) =>
+  terraUINotifications.withErrorReporting(title, { rethrow: true, onReported: onDismiss });
+
+export const withErrorReporting = terraUINotifications.withErrorReporting;

--- a/src/libs/error.ts
+++ b/src/libs/error.ts
@@ -1,91 +1,24 @@
-import { AnyPromiseFn } from '@terra-ui-packages/core-utils';
-import { NotificationOptions, NotificationsContract, NotificationType } from '@terra-ui-packages/notifications';
+import { IgnoreErrorDecider, makeNotificationsContract, Notifier } from '@terra-ui-packages/notifications';
 import { sessionTimedOutErrorMessage } from 'src/auth/auth-errors';
 import { notify } from 'src/libs/notifications';
 
-export type ErrorCallback = (error: unknown) => void | Promise<void>;
+export { type ErrorCallback, withErrorHandling, withErrorIgnoring } from '@terra-ui-packages/notifications';
 
-/**
- * Invoke the `callback` with any error thrown when evaluating the async `fn` with `...args`.
- */
-export const withErrorHandling = (callback: ErrorCallback) => {
-  return <F extends AnyPromiseFn>(fn: F) => {
-    return (async (...args: Parameters<F>) => {
-      try {
-        return await fn(...args);
-      } catch (error) {
-        await callback(error);
-      }
-    }) as F;
-  };
+export const ignoreSessionTimeout: IgnoreErrorDecider = (_title: string, obj?: unknown): boolean => {
+  // Do not show an error notification when a session times out.
+  // Notification for this case is handled elsewhere.
+  return obj instanceof Error && obj.message === sessionTimedOutErrorMessage;
 };
 
-/**
- * Return a Promise to the result of evaluating the async `fn` with `...args` or undefined if
- * evaluation fails.
- */
-export const withErrorIgnoring = withErrorHandling(() => {});
-
-/**
- * allows composition of NotificationsContract dependency when useful for code reuse
- * @param reporter
- */
-export const withErrorReporter = (reporter: NotificationsContract) => ({
-  reportError: async (title: string, obj?: unknown) => {
-    console.error(title, obj); // helpful when the notify component fails to render
-    // Do not show an error notification when a session times out.
-    // Notification for this case is handled elsewhere.
-    if (obj instanceof Error && obj.message === sessionTimedOutErrorMessage) {
-      return;
-    }
-    const detail = await (obj instanceof Response ? obj.text().catch(() => 'Unknown error') : obj);
-    reporter.notify('error', title, { detail });
-  },
-
-  /**
-   * Return a Promise to the result of evaluating the async `fn` with `...args`. If evaluation fails,
-   * report the error to the user with `title` as a side effect.
-   */
-  reportErrorAndRethrow: (title: string) => {
-    return <F extends AnyPromiseFn>(fn: F) =>
-      withErrorHandling(async (error): Promise<void> => {
-        await withErrorReporter(reporter).reportError(title, error);
-        throw error;
-      })(fn);
-  },
-
-  /**
-   *  This function is designed for use in modals.
-   *  Modals can overlay any error reporting, with the `throw` in the default `withErrorReporting`
-   *  preventing the modal itself from closing on error
-   *  As such, we must ensure we call the dismiss function if an error occurs
-   */
-  withErrorReportingInModal: (title: string, onDismiss: () => void) => {
-    return withErrorHandling(async (error) => {
-      await withErrorReporter(reporter).reportError(title, error);
-      onDismiss();
-      throw error;
-    });
-  },
-
-  /**
-   * Return a Promise to the result of evaluating the async `fn` with `...args` or undefined if
-   * evaluation fails. If evaluation fails, report the error to the user with `title`.
-   */
-  withErrorReporting: (title: string) => {
-    return <F extends AnyPromiseFn>(fn: F) =>
-      withErrorIgnoring(withErrorReporter(reporter).reportErrorAndRethrow(title)(fn));
-  },
-});
-
-export const notificationsProvider: NotificationsContract = {
-  notify: (type: NotificationType, title: string, options?: NotificationOptions) => notify(type, title, options),
+const notifier: Notifier = {
+  notify,
 };
 
-// provide backwards compatible fail-safe for existing code that is not yet ready for code-reuse
-const withTerraUIReporter = withErrorReporter(notificationsProvider);
+export const terraUIReporter = makeNotificationsContract(notifier, ignoreSessionTimeout);
 
-export const reportError = withTerraUIReporter.reportError;
-export const reportErrorAndRethrow = withTerraUIReporter.reportErrorAndRethrow;
-export const withErrorReportingInModal = withTerraUIReporter.withErrorReportingInModal;
-export const withErrorReporting = withTerraUIReporter.withErrorReporting;
+// provide backwards compatible fail-safes for existing code that is not yet ready for code-reuse
+
+export const reportError = terraUIReporter.reportError;
+export const reportErrorAndRethrow = terraUIReporter.reportErrorAndRethrow;
+export const withErrorReportingInModal = terraUIReporter.withErrorReportingInModal;
+export const withErrorReporting = terraUIReporter.withErrorReporting;

--- a/src/pages/Main.ts
+++ b/src/pages/Main.ts
@@ -1,7 +1,7 @@
 import 'src/libs/routes';
 
 import { ErrorBoundary, ThemeProvider } from '@terra-ui-packages/components';
-import { NotificationsProvider } from '@terra-ui-packages/notifications';
+import { NotificationsContextProvider } from '@terra-ui-packages/notifications';
 import { ReactNode } from 'react';
 import { h } from 'react-hyperscript-helpers';
 import { ReactNotifications } from 'react-notifications-component';
@@ -19,14 +19,14 @@ import IdleStatusMonitor from 'src/components/IdleStatusMonitor';
 import SupportRequest from 'src/components/SupportRequest';
 import { TitleManager } from 'src/components/TitleManager';
 import { getEnabledBrand } from 'src/libs/brand-utils';
-import { reportError, terraUIReporter } from 'src/libs/error';
+import { reportError, terraUINotifications } from 'src/libs/error';
 import { PageViewReporter } from 'src/libs/events';
 import { LocationProvider, PathHashInserter, Router } from 'src/libs/nav';
 import ImportStatus from 'src/workspace-data/ImportStatus';
 
 const Main = (): ReactNode => {
   return h(ThemeProvider, { theme: getEnabledBrand().theme }, [
-    h(NotificationsProvider, { notifications: terraUIReporter }, [
+    h(NotificationsContextProvider, { notifications: terraUINotifications }, [
       h(LocationProvider, [
         h(PathHashInserter),
         h(CookieRejectModal),

--- a/src/pages/Main.ts
+++ b/src/pages/Main.ts
@@ -19,14 +19,14 @@ import IdleStatusMonitor from 'src/components/IdleStatusMonitor';
 import SupportRequest from 'src/components/SupportRequest';
 import { TitleManager } from 'src/components/TitleManager';
 import { getEnabledBrand } from 'src/libs/brand-utils';
-import { notificationsProvider, reportError } from 'src/libs/error';
+import { reportError, terraUIReporter } from 'src/libs/error';
 import { PageViewReporter } from 'src/libs/events';
 import { LocationProvider, PathHashInserter, Router } from 'src/libs/nav';
 import ImportStatus from 'src/workspace-data/ImportStatus';
 
 const Main = (): ReactNode => {
   return h(ThemeProvider, { theme: getEnabledBrand().theme }, [
-    h(NotificationsProvider, { notifications: notificationsProvider }, [
+    h(NotificationsProvider, { notifications: terraUIReporter }, [
       h(LocationProvider, [
         h(PathHashInserter),
         h(CookieRejectModal),

--- a/src/testing/test-utils.ts
+++ b/src/testing/test-utils.ts
@@ -39,7 +39,10 @@ const mockNotifier: Notifier = {
   notify: jest.fn(),
 };
 
-export const mockNotifications: NotificationsProvider = makeNotificationsProvider(mockNotifier, () => false);
+export const mockNotifications: NotificationsProvider = makeNotificationsProvider({
+  notifier: mockNotifier,
+  shouldIgnoreError: () => false,
+});
 
 const AppProviders = ({ children }: PropsWithChildren<{}>): ReactElement => {
   return h(ThemeProvider, { theme: testTheme }, [

--- a/src/testing/test-utils.ts
+++ b/src/testing/test-utils.ts
@@ -1,5 +1,10 @@
 import { Theme, ThemeProvider } from '@terra-ui-packages/components';
-import { NotificationsContract, NotificationsProvider } from '@terra-ui-packages/notifications';
+import {
+  makeNotificationsContract,
+  NotificationsContract,
+  NotificationsProvider,
+  Notifier,
+} from '@terra-ui-packages/notifications';
 import {
   act,
   render,
@@ -30,9 +35,11 @@ const testTheme: Theme = {
   },
 };
 
-export const mockNotifications: NotificationsContract = {
+const mockNotifier: Notifier = {
   notify: jest.fn(),
 };
+
+export const mockNotifications: NotificationsContract = makeNotificationsContract(mockNotifier, () => false);
 
 const AppProviders = ({ children }: PropsWithChildren<{}>): ReactElement => {
   return h(ThemeProvider, { theme: testTheme }, [

--- a/src/testing/test-utils.ts
+++ b/src/testing/test-utils.ts
@@ -1,7 +1,7 @@
 import { Theme, ThemeProvider } from '@terra-ui-packages/components';
 import {
-  makeNotificationsContract,
-  NotificationsContract,
+  makeNotificationsProvider,
+  NotificationsContextProvider,
   NotificationsProvider,
   Notifier,
 } from '@terra-ui-packages/notifications';
@@ -39,11 +39,11 @@ const mockNotifier: Notifier = {
   notify: jest.fn(),
 };
 
-export const mockNotifications: NotificationsContract = makeNotificationsContract(mockNotifier, () => false);
+export const mockNotifications: NotificationsProvider = makeNotificationsProvider(mockNotifier, () => false);
 
 const AppProviders = ({ children }: PropsWithChildren<{}>): ReactElement => {
   return h(ThemeProvider, { theme: testTheme }, [
-    h(NotificationsProvider, { notifications: mockNotifications }, [children]),
+    h(NotificationsContextProvider, { notifications: mockNotifications }, [children]),
   ]);
 };
 

--- a/src/workspaces/common/state/useWorkspaces.ts
+++ b/src/workspaces/common/state/useWorkspaces.ts
@@ -1,7 +1,6 @@
 import { useAutoLoadedData, useLoadedDataEvents, withCachedData } from '@terra-ui-packages/components';
 import { useNotificationsFromContext } from '@terra-ui-packages/notifications';
 import { FieldsArg, workspaceProvider } from 'src/libs/ajax/workspaces/providers/WorkspaceProvider';
-import { withErrorReporter } from 'src/libs/error';
 import { useCancellation } from 'src/libs/react-utils';
 import { workspacesStore } from 'src/libs/state';
 import { UseWorkspacesResult } from 'src/workspaces/common/state/useWorkspaces.models';
@@ -25,7 +24,7 @@ const defaultFieldsArgs: FieldsArg = [
  */
 export const useWorkspaces = (fieldsArg?: FieldsArg, stringAttributeMaxLength?: number): UseWorkspacesResult => {
   const signal = useCancellation();
-  const { reportError } = withErrorReporter(useNotificationsFromContext());
+  const { reportError } = useNotificationsFromContext();
   const fields: FieldsArg = fieldsArg || defaultFieldsArgs;
   const getData = async (): Promise<WorkspaceWrapper[]> =>
     await workspaceProvider.list(fields, { stringAttributeMaxLength, signal });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4925,8 +4925,8 @@ __metadata:
   dependencies:
     "@terra-ui-packages/build-utils": ^1.0.0
     "@terra-ui-packages/components": ^0.0.6
-    "@terra-ui-packages/core-utils": "*"
-    "@terra-ui-packages/test-utils": "*"
+    "@terra-ui-packages/core-utils": ^0.1.0
+    "@terra-ui-packages/test-utils": ^0.0.4
     "@testing-library/dom": ^9.3.1
     "@testing-library/react": ^14.0.0
     "@testing-library/user-event": ^14.4.3
@@ -4946,7 +4946,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@terra-ui-packages/test-utils@*, @terra-ui-packages/test-utils@workspace:packages/test-utils":
+"@terra-ui-packages/test-utils@*, @terra-ui-packages/test-utils@^0.0.4, @terra-ui-packages/test-utils@workspace:packages/test-utils":
   version: 0.0.0-use.local
   resolution: "@terra-ui-packages/test-utils@workspace:packages/test-utils"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -4925,7 +4925,7 @@ __metadata:
   dependencies:
     "@terra-ui-packages/build-utils": ^1.0.0
     "@terra-ui-packages/components": ^0.0.6
-    "@terra-ui-packages/core-utils": ^0.1.0
+    "@terra-ui-packages/core-utils": ^0.2.0
     "@terra-ui-packages/test-utils": ^0.0.4
     "@testing-library/dom": ^9.3.1
     "@testing-library/react": ^14.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -4925,6 +4925,7 @@ __metadata:
   dependencies:
     "@terra-ui-packages/build-utils": ^1.0.0
     "@terra-ui-packages/components": ^0.0.6
+    "@terra-ui-packages/core-utils": "*"
     "@terra-ui-packages/test-utils": "*"
     "@testing-library/dom": ^9.3.1
     "@testing-library/react": ^14.0.0


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/UIE-165

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
Complete the dependency decoupling on error.ts utils to be workable for Environments component code sharing goals for AoU.

### What
- promoted error.ts to notifications package.
- removed dependencies to terra-ui specific things like session timeout ignore-error check with generic IgnoreErrorDecider function callback.
- doing this entangled the use of withErrorReporter to require an additional arg on each use... so instead, this was changed to makeNotificationsProvider, with the NotificationsProvider placed in react context with useNotificationsFromContext hook being shifted and expanded to directly expose a notify method and the withErrorReporter methods.
- composing apps are encouraged to leverage makeNotificationsProvider to initialize the value of useNotificationsFromContext context provider at the root of app visual tree.
- withErrorReporting variant methods like withErrorReporingInModal have been consolidated in the NotificationsProvider interface to all come from a parameterized withErrorReporting method:
  - i.e. withErrorReportingInModal becomes:
     `withErrorReporting('Error deleting cloud environment', { rethrow: true, onReported: onDismiss })`
- backwards compatible proxies for error methods are still in place, to leave code not ready for code-sharing unchanged.

### Why
- unblock eventual cross-app code sharing of Environments and other complex components.

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] No functional change expected.  Unit test coverage is robust.

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
