### PR TITLE
[AJ-1801] Show spinner within ContextBar instead of a full page overlay

### DIFF
--- a/src/analysis/ContextBar.test.ts
+++ b/src/analysis/ContextBar.test.ts
@@ -474,6 +474,14 @@ describe('ContextBar - buttons', () => {
     expect(queryByTestId('terminal-button-id')).not.toBeInTheDocument();
   });
 
+  it('disables environment configuration button while loading environments', () => {
+    // Act
+    const { getByLabelText } = render(h(ContextBar, { ...contextBarProps, isLoadingCloudEnvironments: true }));
+
+    // Assert
+    expect(getByLabelText('Environment Configuration')).toHaveAttribute('aria-disabled', 'true');
+  });
+
   it('will render Jupyter button with an enabled Terminal Button', () => {
     // Arrange
     const jupyterContextBarProps: ContextBarProps = {

--- a/src/analysis/ContextBar.ts
+++ b/src/analysis/ContextBar.ts
@@ -8,7 +8,7 @@
  * $ yarn test-local analysis-context-bar
  */
 
-import { Interactive, TooltipTrigger } from '@terra-ui-packages/components';
+import { Interactive, Spinner, TooltipTrigger } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { CSSProperties, Fragment, useState } from 'react';
 import { br, div, h, img, span } from 'react-hyperscript-helpers';
@@ -32,7 +32,7 @@ import {
   runtimeToolLabels,
   toolLabelDisplays,
 } from 'src/analysis/utils/tool-utils';
-import { Clickable, spinnerOverlay } from 'src/components/common';
+import { Clickable } from 'src/components/common';
 import { icon } from 'src/components/icons';
 import { getRegionInfo } from 'src/components/region-common';
 import cromwellImg from 'src/images/cromwell-logo.png'; // To be replaced by something square
@@ -294,19 +294,23 @@ export const ContextBar = ({
                   hover: { ...contextBarStyles.hover },
                 },
                 [
-                  div({ style: { textAlign: 'center', color: colors.dark(), fontSize: 12 } }, ['Rate:']),
-                  div(
-                    {
-                      style: {
-                        textAlign: 'center',
-                        color: colors.dark(),
-                        fontWeight: 'bold',
-                        fontSize: 16,
-                      },
-                    },
-                    [getTotalToolAndDiskCostDisplay(), span({ style: { fontWeight: 'normal' } })]
-                  ),
-                  div({ style: { textAlign: 'center', color: colors.dark(), fontSize: 12 } }, ['per hour']),
+                  isLoadingCloudEnvironments
+                    ? h(Spinner, { size: 32, style: { alignSelf: 'center', color: 'inherit' } })
+                    : h(Fragment, [
+                        div({ style: { textAlign: 'center', color: colors.dark(), fontSize: 12 } }, ['Rate:']),
+                        div(
+                          {
+                            style: {
+                              textAlign: 'center',
+                              color: colors.dark(),
+                              fontWeight: 'bold',
+                              fontSize: 16,
+                            },
+                          },
+                          [getTotalToolAndDiskCostDisplay(), span({ style: { fontWeight: 'normal' } })]
+                        ),
+                        div({ style: { textAlign: 'center', color: colors.dark(), fontSize: 12 } }, ['per hour']),
+                      ]),
                 ]
               ),
             ]
@@ -321,6 +325,7 @@ export const ContextBar = ({
                 ...contextBarStyles.contextBarButton,
                 borderBottom: '0px',
               },
+              disabled: isLoadingCloudEnvironments,
               hover: contextBarStyles.hover,
               tooltipSide: 'left',
               onClick: () => setCloudEnvOpen(true),
@@ -381,6 +386,5 @@ export const ContextBar = ({
           ),
       ]),
     ]),
-    isLoadingCloudEnvironments && spinnerOverlay,
   ]);
 };


### PR DESCRIPTION
Currently, while cloud environments are loading, the ContextBar component shows a full page spinner overlay. This blocks interaction with the entire page even when all the data necessary for the main panel has been loaded.

![Screenshot 2024-04-29 at 8 13 08 AM](https://github.com/DataBiosphere/terra-ui/assets/1156625/265639cf-af2d-4dde-8bff-e354f60690eb)

This changes ContextBar to show a spinner only within the ContextBar. This prevents unnecessarily blocking interaction with the page and makes navigation between tabs feel snappier.

![Screenshot 2024-04-29 at 8 13 40 AM](https://github.com/DataBiosphere/terra-ui/assets/1156625/aa8a6c1a-1a34-465c-8c6f-b8ea46059bd2)

