### PR TITLE
[IA-4884] use provider over disk client

### DIFF
--- a/src/analysis/_testData/testData.ts
+++ b/src/analysis/_testData/testData.ts
@@ -218,6 +218,15 @@ export const getPersistentDiskDetail = (): PersistentDiskDetail => {
   };
 };
 
+export const getDetailFromDisk = (disk: PersistentDisk): PersistentDiskDetail => {
+  return {
+    ...disk,
+    serviceAccount: 'testuser123@broad.com',
+    samResource: 1,
+    formattedBy: 'Jupyter',
+  };
+};
+
 export const getAzureDisk = ({ size = defaultGcePersistentDiskSize } = {}) => ({
   ...azureDisk,
   id: getRandomInt(10000),

--- a/src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeModal.js
+++ b/src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeModal.js
@@ -23,6 +23,7 @@ import { NumberInput } from 'src/components/input';
 import { withModalDrawer } from 'src/components/ModalDrawer';
 import TitleBar from 'src/components/TitleBar';
 import { Ajax } from 'src/libs/ajax';
+import { leoDiskProvider } from 'src/libs/ajax/leonardo/providers/LeoDiskProvider';
 import {
   azureMachineTypes,
   defaultAzureComputeConfig,
@@ -344,7 +345,7 @@ export const AzureComputeModalBase = ({
         () =>
           Utils.cond(
             [doesRuntimeExist(), () => Ajax().Runtimes.runtimeV2(workspaceId, currentRuntime.runtimeName).delete(deleteDiskSelected)], // delete runtime
-            [!!persistentDiskExists, () => Ajax().Disks.disksV2().delete(currentPersistentDiskDetails.id)] // delete disk
+            [!!persistentDiskExists, () => leoDiskProvider.delete(currentPersistentDiskDetails)] // delete disk
           ),
       ],
       [

--- a/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal.js
+++ b/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal.js
@@ -54,6 +54,7 @@ import { withModalDrawer } from 'src/components/ModalDrawer';
 import { getAvailableComputeRegions, getLocationType, getRegionInfo, isLocationMultiRegion, isUSLocation } from 'src/components/region-common';
 import TitleBar from 'src/components/TitleBar';
 import { Ajax } from 'src/libs/ajax';
+import { leoDiskProvider } from 'src/libs/ajax/leonardo/providers/LeoDiskProvider';
 import colors from 'src/libs/colors';
 import { getConfig } from 'src/libs/config';
 import { withErrorReporting, withErrorReportingInModal } from 'src/libs/error';
@@ -332,7 +333,7 @@ export const GcpComputeModalBase = ({
         .delete(hasAttachedDisk() && shouldDeletePersistentDisk);
     }
     if (shouldDeletePersistentDisk && !hasAttachedDisk()) {
-      await Ajax().Disks.disksV1().disk(googleProject, currentPersistentDiskDetails.name).delete();
+      await leoDiskProvider.delete(currentPersistentDiskDetails);
     }
 
     if (shouldUpdateRuntime || shouldCreateRuntime) {
@@ -387,7 +388,7 @@ export const GcpComputeModalBase = ({
         );
 
         if (shouldUpdatePersistentDisk) {
-          await Ajax().Disks.disksV1().disk(googleProject, currentPersistentDiskDetails.name).update(desiredPersistentDisk.size);
+          await leoDiskProvider.update(currentPersistentDiskDetails, desiredPersistentDisk.size);
         }
 
         const createRuntimeConfig = { ...runtimeConfig, ...diskConfig };
@@ -780,7 +781,7 @@ export const GcpComputeModalBase = ({
     )(async () => {
       const [runtimeDetails, persistentDiskDetails] = await Promise.all([
         currentRuntime ? Ajax().Runtimes.runtime(currentRuntime.googleProject, currentRuntime.runtimeName).details() : null,
-        currentDisk ? Ajax().Disks.disksV1().disk(currentDisk.googleProject, currentDisk.name).details() : null,
+        currentDisk ? leoDiskProvider.details(currentDisk) : null,
       ]);
       const diskTypeName = persistentDiskDetails?.diskType?.value ?? persistentDiskDetails?.diskType;
       setCurrentRuntimeDetails(runtimeDetails);

--- a/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal.test.ts
+++ b/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal.test.ts
@@ -34,10 +34,10 @@ import {
 } from 'src/analysis/utils/runtime-utils';
 import { runtimeToolLabels, runtimeTools, terraSupportedRuntimeImageIds } from 'src/analysis/utils/tool-utils';
 import { Ajax } from 'src/libs/ajax';
-import { DisksContractV1, DisksDataClientContract, DiskWrapperContract } from 'src/libs/ajax/leonardo/Disks';
 import { PersistentDisk } from 'src/libs/ajax/leonardo/models/disk-models';
 import { cloudServiceTypes, NormalizedComputeRegion } from 'src/libs/ajax/leonardo/models/runtime-config-models';
 import { runtimeStatuses } from 'src/libs/ajax/leonardo/models/runtime-models';
+import { leoDiskProvider } from 'src/libs/ajax/leonardo/providers/LeoDiskProvider';
 import { RuntimeAjaxContractV1, RuntimesAjaxContract } from 'src/libs/ajax/leonardo/Runtimes';
 import { formatUSD } from 'src/libs/utils';
 import { asMockedFn, renderWithAppContexts as render } from 'src/testing/test-utils';
@@ -50,6 +50,7 @@ jest.mock('src/libs/notifications', () => ({
   },
 }));
 
+jest.mock('src/libs/ajax/leonardo/providers/LeoDiskProvider');
 jest.mock('src/libs/ajax');
 jest.mock('src/analysis/utils/cost-utils');
 jest.mock('src/libs/config', () => ({
@@ -90,15 +91,6 @@ const defaultAjaxImpl: AjaxContract = {
         details: jest.fn(),
       } as Partial<RuntimeAjaxContractV1>),
   } as Partial<RuntimesAjaxContract>,
-  Disks: {
-    disksV1: () =>
-      ({
-        disk: () =>
-          ({
-            details: jest.fn(),
-          } as Partial<DiskWrapperContract>),
-      } as Partial<DisksContractV1>),
-  } as Partial<DisksDataClientContract>,
   Metrics: {
     captureEvent: jest.fn(),
   } as Partial<AjaxContract['Metrics']>,
@@ -273,6 +265,7 @@ describe('GcpComputeModal', () => {
     // put value into local var so its easier to refactor
     const disk: PersistentDisk = defaultTestDisk;
     const createFunc = jest.fn();
+    const diskDetailsFunc = jest.fn().mockResolvedValue(disk);
     const runtimeFunc = jest.fn(() => ({
       create: createFunc,
       details: jest.fn(),
@@ -282,16 +275,8 @@ describe('GcpComputeModal', () => {
       Runtimes: {
         runtime: runtimeFunc as Partial<RuntimeAjaxContractV1>,
       } as Partial<RuntimesAjaxContract>,
-      Disks: {
-        disksV1: () =>
-          ({
-            disk: () =>
-              ({
-                details: () => Promise.resolve(disk),
-              } as Partial<DiskWrapperContract>),
-          } as Partial<DisksContractV1>),
-      } as Partial<AjaxContract['Disks']>,
     } as AjaxContract);
+    asMockedFn(leoDiskProvider.details).mockImplementation(diskDetailsFunc);
 
     // Act
     await act(async () => {
@@ -314,6 +299,7 @@ describe('GcpComputeModal', () => {
         }),
       })
     );
+    expect(diskDetailsFunc).toBeCalledTimes(1);
     expect(onSuccess).toHaveBeenCalled();
   });
 
@@ -338,16 +324,8 @@ describe('GcpComputeModal', () => {
         Runtimes: {
           runtime: runtimeFunc as Partial<RuntimeAjaxContractV1>,
         } as Partial<RuntimesAjaxContract>,
-        Disks: {
-          disksV1: () =>
-            ({
-              disk: () =>
-                ({
-                  details: () => Promise.resolve(disk),
-                } as Partial<DiskWrapperContract>),
-            } as Partial<DisksContractV1>),
-        } as Partial<AjaxContract['Disks']>,
       } as AjaxContract);
+      asMockedFn(leoDiskProvider.details).mockResolvedValue(disk);
 
       // Act
       await act(async () => {
@@ -397,16 +375,8 @@ describe('GcpComputeModal', () => {
         Runtimes: {
           runtime: runtimeFunc as Partial<RuntimeAjaxContractV1>,
         } as Partial<RuntimesAjaxContract>,
-        Disks: {
-          disksV1: () =>
-            ({
-              disk: () =>
-                ({
-                  details: () => Promise.resolve(disk),
-                } as Partial<DiskWrapperContract>),
-            } as Partial<DisksContractV1>),
-        } as Partial<AjaxContract['Disks']>,
       } as AjaxContract);
+      asMockedFn(leoDiskProvider.details).mockResolvedValue(disk);
 
       // Act
       await act(async () => {
@@ -450,16 +420,8 @@ describe('GcpComputeModal', () => {
         Runtimes: {
           runtime: runtimeFunc as Partial<RuntimeAjaxContractV1>,
         } as Partial<RuntimesAjaxContract>,
-        Disks: {
-          disksV1: () =>
-            ({
-              disk: () =>
-                ({
-                  details: () => Promise.resolve(disk),
-                } as Partial<DiskWrapperContract>),
-            } as Partial<DisksContractV1>),
-        } as Partial<AjaxContract['Disks']>,
       } as AjaxContract);
+      asMockedFn(leoDiskProvider.details).mockResolvedValue(disk);
 
       // Act
       await act(async () => {
@@ -509,16 +471,8 @@ describe('GcpComputeModal', () => {
         Runtimes: {
           runtime: runtimeFunc as Partial<RuntimeAjaxContractV1>,
         } as Partial<RuntimesAjaxContract>,
-        Disks: {
-          disksV1: () =>
-            ({
-              disk: () =>
-                ({
-                  details: () => Promise.resolve(disk),
-                } as Partial<DiskWrapperContract>),
-            } as Partial<DisksContractV1>),
-        } as Partial<AjaxContract['Disks']>,
       } as AjaxContract);
+      asMockedFn(leoDiskProvider.details).mockResolvedValue(disk);
 
       // Act
       await act(async () => {
@@ -562,16 +516,8 @@ describe('GcpComputeModal', () => {
         Runtimes: {
           runtime: runtimeFunc as Partial<RuntimeAjaxContractV1>,
         } as Partial<RuntimesAjaxContract>,
-        Disks: {
-          disksV1: () =>
-            ({
-              disk: () =>
-                ({
-                  details: () => Promise.resolve(disk),
-                } as Partial<DiskWrapperContract>),
-            } as Partial<DisksContractV1>),
-        } as Partial<AjaxContract['Disks']>,
       } as AjaxContract);
+      asMockedFn(leoDiskProvider.details).mockResolvedValue(disk);
 
       // Act
       await act(async () => {
@@ -623,7 +569,6 @@ describe('GcpComputeModal', () => {
       const runtime = getGoogleRuntime(runtimeProps);
 
       const updateRuntimeFunc = jest.fn();
-      const updateDiskFunc = jest.fn();
 
       const runtimeFunc = jest.fn(() => ({
         details: () => runtime,
@@ -634,17 +579,8 @@ describe('GcpComputeModal', () => {
         Runtimes: {
           runtime: runtimeFunc as Partial<RuntimeAjaxContractV1>,
         } as Partial<RuntimesAjaxContract>,
-        Disks: {
-          disksV1: () =>
-            ({
-              disk: () =>
-                ({
-                  update: updateDiskFunc,
-                  details: () => Promise.resolve(disk),
-                } as Partial<DiskWrapperContract>),
-            } as Partial<DisksContractV1>),
-        } as Partial<AjaxContract['Disks']>,
       } as AjaxContract);
+      asMockedFn(leoDiskProvider.details).mockResolvedValue(disk);
 
       // Act
       await act(async () => {
@@ -687,7 +623,6 @@ describe('GcpComputeModal', () => {
 
       const createFunc = jest.fn();
       const deleteFunc = jest.fn();
-      const deleteDiskFunc = jest.fn();
 
       const runtimeFunc = jest.fn(() => ({
         details: () => runtime,
@@ -699,17 +634,8 @@ describe('GcpComputeModal', () => {
         Runtimes: {
           runtime: runtimeFunc as Partial<RuntimeAjaxContractV1>,
         } as Partial<RuntimesAjaxContract>,
-        Disks: {
-          disksV1: () =>
-            ({
-              disk: () =>
-                ({
-                  delete: deleteDiskFunc,
-                  details: () => Promise.resolve(disk),
-                } as Partial<DiskWrapperContract>),
-            } as Partial<DisksContractV1>),
-        } as Partial<AjaxContract['Disks']>,
       } as AjaxContract);
+      asMockedFn(leoDiskProvider.details).mockResolvedValue(disk);
 
       // Act
       await act(async () => {
@@ -755,7 +681,7 @@ describe('GcpComputeModal', () => {
   );
 
   it('Should call delete disk when clicked', async () => {
-    const disk = getPersistentDiskDetail();
+    const disk = getDisk();
 
     const deleteDiskFunc = jest.fn();
 
@@ -767,17 +693,9 @@ describe('GcpComputeModal', () => {
       Runtimes: {
         runtime: runtimeFunc as Partial<RuntimeAjaxContractV1>,
       } as Partial<RuntimesAjaxContract>,
-      Disks: {
-        disksV1: () =>
-          ({
-            disk: () =>
-              ({
-                delete: deleteDiskFunc,
-                details: () => Promise.resolve(disk),
-              } as Partial<DiskWrapperContract>),
-          } as Partial<DisksContractV1>),
-      } as Partial<AjaxContract['Disks']>,
     } as AjaxContract);
+    asMockedFn(leoDiskProvider.details).mockResolvedValue(disk);
+    asMockedFn(leoDiskProvider.delete).mockImplementation(deleteDiskFunc);
 
     // Act
     await act(async () => {
@@ -798,6 +716,13 @@ describe('GcpComputeModal', () => {
     await userEvent.click(deleteConfirmationButton);
 
     expect(deleteDiskFunc).toHaveBeenCalledTimes(1);
+    expect(deleteDiskFunc).toBeCalledWith(
+      expect.objectContaining({
+        name: disk.name,
+        cloudContext: disk.cloudContext,
+        id: disk.id,
+      })
+    );
   });
 
   it('Should call update disk when creating a runtime', async () => {
@@ -816,17 +741,9 @@ describe('GcpComputeModal', () => {
       Runtimes: {
         runtime: runtimeFunc as Partial<RuntimeAjaxContractV1>,
       } as Partial<RuntimesAjaxContract>,
-      Disks: {
-        disksV1: () =>
-          ({
-            disk: () =>
-              ({
-                update: updateDiskFunc,
-                details: () => Promise.resolve(disk),
-              } as Partial<DiskWrapperContract>),
-          } as Partial<DisksContractV1>),
-      } as Partial<AjaxContract['Disks']>,
     } as AjaxContract);
+    asMockedFn(leoDiskProvider.details).mockResolvedValue(disk);
+    asMockedFn(leoDiskProvider.update).mockImplementation(updateDiskFunc);
 
     // Act
     await act(async () => {
@@ -847,7 +764,14 @@ describe('GcpComputeModal', () => {
     expect(runtimeFunc).toHaveBeenCalledWith(defaultModalProps.workspace.workspace.googleProject, expect.any(String));
     expect(createFunc).toHaveBeenCalledTimes(1);
     expect(updateDiskFunc).toHaveBeenCalledTimes(1);
-    expect(updateDiskFunc).toHaveBeenCalledWith(disk.size + 1);
+    expect(updateDiskFunc).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: disk.name,
+        cloudContext: disk.cloudContext,
+        id: disk.id,
+      }),
+      disk.size + 1
+    );
   });
 
   it.each([{ tool: runtimeTools.Jupyter }, { tool: runtimeTools.RStudio }])(
@@ -869,17 +793,9 @@ describe('GcpComputeModal', () => {
         Runtimes: {
           runtime: runtimeFunc as Partial<RuntimeAjaxContractV1>,
         } as Partial<RuntimesAjaxContract>,
-        Disks: {
-          disksV1: () =>
-            ({
-              disk: () =>
-                ({
-                  update: updateDiskFunc,
-                  details: () => Promise.resolve(disk),
-                } as Partial<DiskWrapperContract>),
-            } as Partial<DisksContractV1>),
-        } as Partial<AjaxContract['Disks']>,
       } as AjaxContract);
+      asMockedFn(leoDiskProvider.details).mockResolvedValue(disk);
+      asMockedFn(leoDiskProvider.update).mockImplementation(updateDiskFunc);
 
       // Act
       await act(async () => {
@@ -1201,16 +1117,8 @@ describe('GcpComputeModal', () => {
         Runtimes: {
           runtime: runtimeFunc as Partial<RuntimeAjaxContractV1>,
         } as Partial<RuntimesAjaxContract>,
-        Disks: {
-          disksV1: () =>
-            ({
-              disk: () =>
-                ({
-                  details: () => Promise.resolve(disk),
-                } as Partial<DiskWrapperContract>),
-            } as Partial<DisksContractV1>),
-        } as Partial<AjaxContract['Disks']>,
       } as AjaxContract);
+      asMockedFn(leoDiskProvider.details).mockResolvedValue(disk);
 
       // Act and assert
       await act(async () => {
@@ -1253,16 +1161,8 @@ describe('GcpComputeModal', () => {
         Runtimes: {
           runtime: runtimeFunc as Partial<RuntimeAjaxContractV1>,
         } as Partial<RuntimesAjaxContract>,
-        Disks: {
-          disksV1: () =>
-            ({
-              disk: () =>
-                ({
-                  details: () => Promise.resolve(disk),
-                } as Partial<DiskWrapperContract>),
-            } as Partial<DisksContractV1>),
-        } as Partial<AjaxContract['Disks']>,
       } as AjaxContract);
+      asMockedFn(leoDiskProvider.details).mockResolvedValue(disk);
 
       // Act and assert
       await act(async () => {

--- a/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal.test.ts
+++ b/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal.test.ts
@@ -5,6 +5,7 @@ import { h } from 'react-hyperscript-helpers';
 import {
   defaultImage,
   defaultTestDisk,
+  getDetailFromDisk,
   getDisk,
   getGoogleDataProcRuntime,
   getGoogleRuntime,
@@ -325,7 +326,7 @@ describe('GcpComputeModal', () => {
           runtime: runtimeFunc as Partial<RuntimeAjaxContractV1>,
         } as Partial<RuntimesAjaxContract>,
       } as AjaxContract);
-      asMockedFn(leoDiskProvider.details).mockResolvedValue(disk);
+      asMockedFn(leoDiskProvider.details).mockResolvedValue(getDetailFromDisk(disk));
 
       // Act
       await act(async () => {
@@ -376,7 +377,7 @@ describe('GcpComputeModal', () => {
           runtime: runtimeFunc as Partial<RuntimeAjaxContractV1>,
         } as Partial<RuntimesAjaxContract>,
       } as AjaxContract);
-      asMockedFn(leoDiskProvider.details).mockResolvedValue(disk);
+      asMockedFn(leoDiskProvider.details).mockResolvedValue(getDetailFromDisk(disk));
 
       // Act
       await act(async () => {
@@ -421,7 +422,7 @@ describe('GcpComputeModal', () => {
           runtime: runtimeFunc as Partial<RuntimeAjaxContractV1>,
         } as Partial<RuntimesAjaxContract>,
       } as AjaxContract);
-      asMockedFn(leoDiskProvider.details).mockResolvedValue(disk);
+      asMockedFn(leoDiskProvider.details).mockResolvedValue(getDetailFromDisk(disk));
 
       // Act
       await act(async () => {
@@ -472,7 +473,7 @@ describe('GcpComputeModal', () => {
           runtime: runtimeFunc as Partial<RuntimeAjaxContractV1>,
         } as Partial<RuntimesAjaxContract>,
       } as AjaxContract);
-      asMockedFn(leoDiskProvider.details).mockResolvedValue(disk);
+      asMockedFn(leoDiskProvider.details).mockResolvedValue(getDetailFromDisk(disk));
 
       // Act
       await act(async () => {
@@ -517,7 +518,7 @@ describe('GcpComputeModal', () => {
           runtime: runtimeFunc as Partial<RuntimeAjaxContractV1>,
         } as Partial<RuntimesAjaxContract>,
       } as AjaxContract);
-      asMockedFn(leoDiskProvider.details).mockResolvedValue(disk);
+      asMockedFn(leoDiskProvider.details).mockResolvedValue(getDetailFromDisk(disk));
 
       // Act
       await act(async () => {
@@ -580,7 +581,7 @@ describe('GcpComputeModal', () => {
           runtime: runtimeFunc as Partial<RuntimeAjaxContractV1>,
         } as Partial<RuntimesAjaxContract>,
       } as AjaxContract);
-      asMockedFn(leoDiskProvider.details).mockResolvedValue(disk);
+      asMockedFn(leoDiskProvider.details).mockResolvedValue(getDetailFromDisk(disk));
 
       // Act
       await act(async () => {
@@ -635,7 +636,7 @@ describe('GcpComputeModal', () => {
           runtime: runtimeFunc as Partial<RuntimeAjaxContractV1>,
         } as Partial<RuntimesAjaxContract>,
       } as AjaxContract);
-      asMockedFn(leoDiskProvider.details).mockResolvedValue(disk);
+      asMockedFn(leoDiskProvider.details).mockResolvedValue(getDetailFromDisk(disk));
 
       // Act
       await act(async () => {
@@ -694,7 +695,7 @@ describe('GcpComputeModal', () => {
         runtime: runtimeFunc as Partial<RuntimeAjaxContractV1>,
       } as Partial<RuntimesAjaxContract>,
     } as AjaxContract);
-    asMockedFn(leoDiskProvider.details).mockResolvedValue(disk);
+    asMockedFn(leoDiskProvider.details).mockResolvedValue(getDetailFromDisk(disk));
     asMockedFn(leoDiskProvider.delete).mockImplementation(deleteDiskFunc);
 
     // Act
@@ -742,7 +743,7 @@ describe('GcpComputeModal', () => {
         runtime: runtimeFunc as Partial<RuntimeAjaxContractV1>,
       } as Partial<RuntimesAjaxContract>,
     } as AjaxContract);
-    asMockedFn(leoDiskProvider.details).mockResolvedValue(disk);
+    asMockedFn(leoDiskProvider.details).mockResolvedValue(getDetailFromDisk(disk));
     asMockedFn(leoDiskProvider.update).mockImplementation(updateDiskFunc);
 
     // Act
@@ -794,7 +795,7 @@ describe('GcpComputeModal', () => {
           runtime: runtimeFunc as Partial<RuntimeAjaxContractV1>,
         } as Partial<RuntimesAjaxContract>,
       } as AjaxContract);
-      asMockedFn(leoDiskProvider.details).mockResolvedValue(disk);
+      asMockedFn(leoDiskProvider.details).mockResolvedValue(getDetailFromDisk(disk));
       asMockedFn(leoDiskProvider.update).mockImplementation(updateDiskFunc);
 
       // Act
@@ -1118,7 +1119,7 @@ describe('GcpComputeModal', () => {
           runtime: runtimeFunc as Partial<RuntimeAjaxContractV1>,
         } as Partial<RuntimesAjaxContract>,
       } as AjaxContract);
-      asMockedFn(leoDiskProvider.details).mockResolvedValue(disk);
+      asMockedFn(leoDiskProvider.details).mockResolvedValue(getDetailFromDisk(disk));
 
       // Act and assert
       await act(async () => {
@@ -1162,7 +1163,7 @@ describe('GcpComputeModal', () => {
           runtime: runtimeFunc as Partial<RuntimeAjaxContractV1>,
         } as Partial<RuntimesAjaxContract>,
       } as AjaxContract);
-      asMockedFn(leoDiskProvider.details).mockResolvedValue(disk);
+      asMockedFn(leoDiskProvider.details).mockResolvedValue(getDetailFromDisk(disk));
 
       // Act and assert
       await act(async () => {

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.test.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.test.js
@@ -2,11 +2,12 @@ import { act, fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { h } from 'react-hyperscript-helpers';
 import { Ajax } from 'src/libs/ajax';
+import { leoDiskProvider } from 'src/libs/ajax/leonardo/providers/LeoDiskProvider';
 import DataStepContent from 'src/pages/workspaces/workspace/workflows/DataStepContent';
 import { chooseRootType } from 'src/pages/workspaces/workspace/workflows/EntitySelectionType';
 import LaunchAnalysisModal from 'src/pages/workspaces/workspace/workflows/LaunchAnalysisModal';
 import { WorkflowView } from 'src/pages/workspaces/workspace/workflows/WorkflowView';
-import { renderWithAppContexts as render, SelectHelper } from 'src/testing/test-utils';
+import { asMockedFn, renderWithAppContexts as render, SelectHelper } from 'src/testing/test-utils';
 
 jest.mock('src/libs/ajax');
 jest.mock('src/libs/nav', () => ({
@@ -18,6 +19,7 @@ jest.mock('src/libs/nav', () => ({
 jest.mock('src/libs/notifications', () => ({
   notify: jest.fn(),
 }));
+jest.mock('src/libs/ajax/leonardo/providers/LeoDiskProvider');
 
 // Space for tables is rendered based on the available space. In unit tests, there is no available space, and so we must mock out the space needed to get the data table to render.
 jest.mock('react-virtualized', () => {
@@ -234,6 +236,7 @@ describe('Workflow View (GCP)', () => {
   const mockLaunchResponse = jest.fn(() => Promise.resolve({ submissionId: 'abc123', ...initializedGoogleWorkspace.workspaceId }));
 
   const renderWorkflowView = () => {
+    asMockedFn(leoDiskProvider.list).mockImplementation(jest.fn());
     Ajax.mockImplementation(() => ({
       Methods: {
         list: jest.fn(() => Promise.resolve(methodList)),

--- a/src/workspaces/common/state/useCloudEnvironmentPolling.test.ts
+++ b/src/workspaces/common/state/useCloudEnvironmentPolling.test.ts
@@ -2,6 +2,7 @@ import { generateTestDiskWithGoogleWorkspace } from 'src/analysis/_testData/test
 import { Ajax } from 'src/libs/ajax';
 import { PersistentDisk } from 'src/libs/ajax/leonardo/models/disk-models';
 import { leoDiskProvider } from 'src/libs/ajax/leonardo/providers/LeoDiskProvider';
+import { RuntimesAjaxContract } from 'src/libs/ajax/leonardo/Runtimes';
 import { asMockedFn, renderHookInAct } from 'src/testing/test-utils';
 import { defaultGoogleWorkspace, defaultInitializedGoogleWorkspace } from 'src/testing/workspace-fixtures';
 
@@ -11,14 +12,14 @@ jest.mock('src/libs/ajax');
 jest.mock('src/libs/ajax/leonardo/providers/LeoDiskProvider');
 
 // This code will be needed when we mock and test the runtime methods
-// type AjaxContract = ReturnType<typeof Ajax>;
-// type RuntimesNeeds = Pick<RuntimesAjaxContract, 'listV2'>;
-// interface RuntimeMockNeeds {
-//   topLevel: RuntimesNeeds;
-// }
-// interface AjaxMockNeeds {
-//   Runtimes: RuntimeMockNeeds;
-// }
+type AjaxContract = ReturnType<typeof Ajax>;
+type RuntimesNeeds = Pick<RuntimesAjaxContract, 'listV2'>;
+interface RuntimeMockNeeds {
+  topLevel: RuntimesNeeds;
+}
+interface AjaxMockNeeds {
+  Runtimes: RuntimeMockNeeds;
+}
 /**
  * local test utility - mocks the Ajax super-object and the subset of needed multi-contracts it
  * returns with as much type-safety as possible.
@@ -26,22 +27,25 @@ jest.mock('src/libs/ajax/leonardo/providers/LeoDiskProvider');
  * @return collection of key contract sub-objects for easy
  * mock overrides and/or method spying/assertions
  */
-// const mockAjaxNeeds = (): AjaxMockNeeds => {
-//   const partialRuntimes: RuntimesNeeds = {
-//     listV2: jest.fn(),
-//   };
-//   const mockRuntimes = partialRuntimes as RuntimesAjaxContract;
+const mockAjaxNeeds = (): AjaxMockNeeds => {
+  const partialRuntimes: RuntimesNeeds = {
+    listV2: jest.fn(),
+  };
+  const mockRuntimes = partialRuntimes as RuntimesAjaxContract;
 
-//   asMockedFn(Ajax).mockReturnValue({ Runtimes: mockRuntimes } as AjaxContract);
+  asMockedFn(Ajax).mockReturnValue({ Runtimes: mockRuntimes } as AjaxContract);
 
-//   return {
-//     Runtimes: {
-//       topLevel: partialRuntimes,
-//     },
-//   };
-// };
+  return {
+    Runtimes: {
+      topLevel: partialRuntimes,
+    },
+  };
+};
 
 describe('useCloudEnvironmentPolling', () => {
+  beforeAll(() => {
+    mockAjaxNeeds();
+  });
   it('calls list disk', async () => {
     // Arrange
     const appDisk = generateTestDiskWithGoogleWorkspace({}, defaultGoogleWorkspace);

--- a/src/workspaces/common/state/useCloudEnvironmentPolling.ts
+++ b/src/workspaces/common/state/useCloudEnvironmentPolling.ts
@@ -5,6 +5,7 @@ import { getConvertedRuntimeStatus, getCurrentRuntime } from 'src/analysis/utils
 import { Ajax } from 'src/libs/ajax';
 import { PersistentDisk } from 'src/libs/ajax/leonardo/models/disk-models';
 import { ListRuntimeItem } from 'src/libs/ajax/leonardo/models/runtime-models';
+import { leoDiskProvider } from 'src/libs/ajax/leonardo/providers/LeoDiskProvider';
 import { withErrorIgnoring, withErrorReporting } from 'src/libs/error';
 import { InitializedWorkspaceWrapper as Workspace } from 'src/workspaces/common/state/useWorkspace';
 
@@ -51,12 +52,13 @@ export const useCloudEnvironmentPolling = (
       // Disks.list API takes includeLabels to specify which labels to return in the response
       // Runtimes.listV2 API always returns all labels for a runtime
       const [newDisks, newRuntimes] = await Promise.all([
-        Ajax(controller.current.signal)
-          .Disks.disksV1()
-          .list({
+        leoDiskProvider.list(
+          {
             ...cloudEnvFilters,
             includeLabels: 'saturnApplication,saturnWorkspaceName,saturnWorkspaceNamespace',
-          }),
+          },
+          { signal: controller.current.signal }
+        ),
         Ajax(controller.current.signal).Runtimes.listV2(cloudEnvFilters),
       ]);
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-4884

This migrates from using the Disk Data client directly to using the disk provider in all cases, and updates relevant tests.