### PR TITLE
[AJ-1766] Split compute profile and autopause out of AzureComputeModal

### DIFF
--- a/src/analysis/modals/ComputeModal/AutopauseConfiguration.test.ts
+++ b/src/analysis/modals/ComputeModal/AutopauseConfiguration.test.ts
@@ -1,0 +1,90 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { h } from 'react-hyperscript-helpers';
+import { defaultAutopauseThreshold } from 'src/analysis/utils/runtime-utils';
+import { renderWithAppContexts as render } from 'src/testing/test-utils';
+
+import { AutopauseConfiguration, AutopauseConfigurationProps } from './AutopauseConfiguration';
+
+describe('AutopauseConfiguration', () => {
+  const setup = (props: Partial<AutopauseConfigurationProps> = {}) => {
+    render(
+      h(AutopauseConfiguration, {
+        autopauseThreshold: defaultAutopauseThreshold,
+        onChangeAutopauseThreshold: () => {},
+        ...props,
+      })
+    );
+  };
+
+  it('renders a checkbox and input for autopause threshold', () => {
+    // Act
+    setup();
+
+    // Assert
+    const enableAutopauseCheckbox = screen.getByRole('checkbox', { name: 'Enable autopause' });
+    expect(enableAutopauseCheckbox).toBeChecked();
+
+    const autopauseThresholdInput = screen.getByRole('spinbutton', {
+      name: 'Minutes of inactivity before autopausing',
+    });
+    expect(autopauseThresholdInput).toHaveValue(defaultAutopauseThreshold);
+  });
+
+  it('can disable both inputs', () => {
+    // Act
+    setup({ disabled: true });
+
+    // Assert
+    const enableAutopauseCheckbox = screen.getByRole('checkbox', { name: 'Enable autopause' });
+    expect(enableAutopauseCheckbox).toHaveAttribute('disabled');
+
+    const autopauseThresholdInput = screen.getByRole('spinbutton', {
+      name: 'Minutes of inactivity before autopausing',
+    });
+    expect(autopauseThresholdInput).toBeDisabled();
+  });
+
+  it('calls onChangeAutopauseThreshold when the threshold is changed', () => {
+    // Arrange
+    const onChangeAutopauseThreshold = jest.fn();
+    setup({ onChangeAutopauseThreshold });
+
+    // Act
+    const autopauseThresholdInput = screen.getByRole('spinbutton', {
+      name: 'Minutes of inactivity before autopausing',
+    });
+    fireEvent.change(autopauseThresholdInput, { target: { value: '15' } });
+
+    // Assert
+    expect(onChangeAutopauseThreshold).toHaveBeenCalledWith(15);
+  });
+
+  it('clears autopause threshold when checkbox is unchecked', () => {
+    // Arrange
+    const onChangeAutopauseThreshold = jest.fn();
+    setup({ onChangeAutopauseThreshold });
+
+    // Act
+    const enableAutopauseCheckbox = screen.getByRole('checkbox', { name: 'Enable autopause' });
+    fireEvent.click(enableAutopauseCheckbox);
+
+    // Assert
+    expect(onChangeAutopauseThreshold).toHaveBeenCalledWith(0);
+  });
+
+  it('sets default autopause threshold when checkbox is checked', () => {
+    // Arrange
+    const onChangeAutopauseThreshold = jest.fn();
+    setup({ autopauseThreshold: 0, onChangeAutopauseThreshold });
+
+    // Assert
+    const enableAutopauseCheckbox = screen.getByRole('checkbox', { name: 'Enable autopause' });
+    expect(enableAutopauseCheckbox).not.toBeChecked();
+
+    // Act
+    fireEvent.click(enableAutopauseCheckbox);
+
+    // Assert
+    expect(onChangeAutopauseThreshold).toHaveBeenCalledWith(defaultAutopauseThreshold);
+  });
+});

--- a/src/analysis/modals/ComputeModal/AutopauseConfiguration.ts
+++ b/src/analysis/modals/ComputeModal/AutopauseConfiguration.ts
@@ -1,0 +1,78 @@
+import { icon, Link, useUniqueId } from '@terra-ui-packages/components';
+import { CSSProperties, ReactNode } from 'react';
+import { div, h, label, span } from 'react-hyperscript-helpers';
+import { computeStyles } from 'src/analysis/modals/modalStyles';
+import { getAutopauseThreshold, isAutopauseEnabled } from 'src/analysis/utils/runtime-utils';
+import { LabeledCheckbox } from 'src/components/common';
+import { NumberInput } from 'src/components/input';
+import * as Utils from 'src/libs/utils';
+
+export interface AutopauseConfigurationProps {
+  autopauseThreshold: number;
+  disabled?: boolean;
+  style?: CSSProperties;
+  onChangeAutopauseThreshold: (autopauseThreshold: number) => void;
+}
+
+export const AutopauseConfiguration = (props: AutopauseConfigurationProps): ReactNode => {
+  const { autopauseThreshold, disabled = false, style, onChangeAutopauseThreshold } = props;
+
+  const id = useUniqueId();
+
+  return div({ style }, [
+    h(
+      LabeledCheckbox,
+      {
+        id: `${id}-enable`,
+        checked: isAutopauseEnabled(autopauseThreshold),
+        disabled,
+        onChange: (v) => onChangeAutopauseThreshold(getAutopauseThreshold(v)),
+      },
+      [span({ style: { ...computeStyles.label } }, ['Enable autopause'])]
+    ),
+    h(
+      Link,
+      {
+        style: { marginLeft: '1rem', verticalAlign: 'bottom' },
+        href: 'https://support.terra.bio/hc/en-us/articles/360029761352-Preventing-runaway-costs-with-Cloud-Environment-autopause-#h_27c11f46-a6a7-4860-b5e7-fac17df2b2b5',
+        ...Utils.newTabLinkProps,
+      },
+      ['Learn more about autopause.', icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })]
+    ),
+    div(
+      {
+        style: {
+          display: 'grid',
+          alignItems: 'center',
+          gridGap: '0.7rem',
+          gridTemplateColumns: '4.5rem 9.5rem',
+          marginTop: '0.75rem',
+        },
+      },
+      [
+        h(NumberInput, {
+          id: `${id}-threshold`,
+          min: 10,
+          max: 999,
+          isClearable: false,
+          onlyInteger: true,
+          disabled,
+          value: autopauseThreshold,
+          hidden: !isAutopauseEnabled(autopauseThreshold),
+          tooltip: !isAutopauseEnabled(autopauseThreshold)
+            ? 'Autopause must be enabled to configure pause time.'
+            : undefined,
+          onChange: (v) => onChangeAutopauseThreshold(Number(v)),
+          'aria-label': 'Minutes of inactivity before autopausing',
+        }),
+        label(
+          {
+            htmlFor: `${id}-threshold`,
+            hidden: !isAutopauseEnabled(autopauseThreshold),
+          },
+          ['minutes of inactivity']
+        ),
+      ]
+    ),
+  ]);
+};

--- a/src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeModal.js
+++ b/src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeModal.js
@@ -2,35 +2,28 @@ import _ from 'lodash/fp';
 import { Fragment, useEffect, useState } from 'react';
 import { div, h, label, p, span } from 'react-hyperscript-helpers';
 import { AboutPersistentDiskView } from 'src/analysis/modals/ComputeModal/AboutPersistentDiskView';
+import { AutopauseConfiguration } from 'src/analysis/modals/ComputeModal/AutopauseConfiguration';
+import { AzureComputeProfileSelect } from 'src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeProfileSelect';
 import { AzurePersistentDiskSection } from 'src/analysis/modals/ComputeModal/AzureComputeModal/AzurePersistentDiskSection';
 import { DeleteEnvironment } from 'src/analysis/modals/DeleteEnvironment';
 import { computeStyles } from 'src/analysis/modals/modalStyles';
 import { getAzureComputeCostEstimate, getAzureDiskCostEstimate } from 'src/analysis/utils/cost-utils';
 import { generatePersistentDiskName } from 'src/analysis/utils/disk-utils';
-import {
-  autopauseDisabledValue,
-  defaultAutopauseThreshold,
-  generateRuntimeName,
-  getAutopauseThreshold,
-  getIsRuntimeBusy,
-  isAutopauseEnabled,
-} from 'src/analysis/utils/runtime-utils';
+import { autopauseDisabledValue, defaultAutopauseThreshold, generateRuntimeName, getIsRuntimeBusy } from 'src/analysis/utils/runtime-utils';
 import { runtimeToolLabels } from 'src/analysis/utils/tool-utils';
-import { ButtonOutline, ButtonPrimary, IdContainer, LabeledCheckbox, Link, Select, spinnerOverlay } from 'src/components/common';
+import { ButtonOutline, ButtonPrimary, IdContainer, Link, spinnerOverlay } from 'src/components/common';
 import { icon } from 'src/components/icons';
 import { InfoBox } from 'src/components/InfoBox';
-import { NumberInput } from 'src/components/input';
 import { withModalDrawer } from 'src/components/ModalDrawer';
 import TitleBar from 'src/components/TitleBar';
 import { Ajax } from 'src/libs/ajax';
 import {
-  azureMachineTypes,
   defaultAzureComputeConfig,
   defaultAzureDiskSize,
   defaultAzureMachineType,
   defaultAzurePersistentDiskType,
   defaultAzureRegion,
-  getMachineTypeLabel,
+  machineTypeHasGpu,
 } from 'src/libs/azure-utils';
 import colors from 'src/libs/colors';
 import { withErrorReportingInModal } from 'src/libs/error';
@@ -62,7 +55,7 @@ export const AzureComputeModalBase = ({
   const { namespace, name: workspaceName, workspaceId } = workspace.workspace;
   const persistentDiskExists = !!currentPersistentDiskDetails;
   const [deleteDiskSelected, setDeleteDiskSelected] = useState(false);
-  const hasGpu = () => !!azureMachineTypes[computeConfig.machineType]?.hasGpu;
+
   // Lifecycle
   useEffect(() => {
     Ajax().Metrics.captureEvent(Events.cloudEnvironmentConfigOpen, {
@@ -151,120 +144,6 @@ export const AzureComputeModalBase = ({
     ]);
   };
 
-  const renderComputeProfileSection = () => {
-    const autoPauseCheckboxEnabled = !doesRuntimeExist();
-    const gridStyle = { display: 'grid', gridGap: '1rem', alignItems: 'center', marginTop: '1rem' };
-
-    return div({ style: { ...computeStyles.whiteBoxContainer, marginTop: '1.5rem' } }, [
-      div({ style: { marginBottom: '1.5rem' } }, [
-        h(IdContainer, [
-          (id) =>
-            h(Fragment, [
-              div({ style: { marginBottom: '1rem', display: 'flex' } }, [
-                label(
-                  {
-                    htmlFor: id,
-                    style: {
-                      ...computeStyles.label,
-                      marginRight: '1rem',
-                    },
-                  },
-                  ['Cloud compute profile']
-                ),
-                h(Link, { href: 'https://azure.microsoft.com/en-us/pricing/details/virtual-machines/series/', ...Utils.newTabLinkProps }, [
-                  'Learn more about cloud compute profiles.',
-                  icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } }),
-                ]),
-              ]),
-              div({ style: { width: 400 } }, [
-                h(Select, {
-                  id,
-                  isSearchable: false,
-                  isClearable: false,
-                  value: computeConfig.machineType,
-                  onChange: ({ value }) => {
-                    updateComputeConfig('machineType', value);
-                  },
-                  options: _.keys(azureMachineTypes),
-                  getOptionLabel: ({ value }) => getMachineTypeLabel(value),
-                  styles: { width: '400' },
-                }),
-              ]),
-            ]),
-        ]),
-        hasGpu() &&
-          div({ style: { display: 'flex', marginTop: '.5rem' } }, [
-            icon('warning-standard', { size: 16, style: { marginRight: '0.5rem', color: colors.warning() } }),
-            div([
-              span({ style: { marginRight: '0.5rem' } }, 'This VM is powered by an NVIDIA GPU; availability may vary.'),
-              h(
-                Link,
-                {
-                  style: { marginRight: '0.25rem' },
-                  href: 'https://support.terra.bio/hc/en-us/articles/16921184286491-How-to-use-GPUs-in-a-notebook-Azure-',
-                  ...Utils.newTabLinkProps,
-                },
-                ['Learn more about enabling GPUs.', icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })]
-              ),
-            ]),
-          ]),
-      ]),
-      div({ style: { gridColumnEnd: 'span 6' } }, [
-        h(IdContainer, [
-          (id1) =>
-            h(Fragment, [
-              h(
-                LabeledCheckbox,
-                {
-                  id1,
-                  checked: isAutopauseEnabled(computeConfig.autopauseThreshold),
-                  disabled: !autoPauseCheckboxEnabled,
-                  onChange: (v) => updateComputeConfig('autopauseThreshold', getAutopauseThreshold(v)),
-                },
-                [span({ style: { ...computeStyles.label } }, ['Enable autopause'])]
-              ),
-            ]),
-        ]),
-        h(
-          Link,
-          {
-            style: { marginLeft: '1rem', verticalAlign: 'bottom' },
-            href: 'https://support.terra.bio/hc/en-us/articles/360029761352-Preventing-runaway-costs-with-Cloud-Environment-autopause-#h_27c11f46-a6a7-4860-b5e7-fac17df2b2b5',
-            ...Utils.newTabLinkProps,
-          },
-          ['Learn more about autopause.', icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })]
-        ),
-        div({ style: { ...gridStyle, gridGap: '0.7rem', gridTemplateColumns: '4.5rem 9.5rem', marginTop: '0.75rem' } }, [
-          h(IdContainer, [
-            (id) =>
-              h(Fragment, [
-                h(NumberInput, {
-                  id,
-                  min: 10,
-                  max: 999,
-                  isClearable: false,
-                  onlyInteger: true,
-                  disabled: !autoPauseCheckboxEnabled,
-                  value: computeConfig.autopauseThreshold,
-                  hidden: !isAutopauseEnabled(computeConfig.autopauseThreshold),
-                  tooltip: !isAutopauseEnabled(computeConfig.autopauseThreshold) ? 'Autopause must be enabled to configure pause time.' : undefined,
-                  onChange: (v) => updateComputeConfig('autopauseThreshold', Number(v)),
-                  'aria-label': 'Minutes of inactivity before autopausing',
-                }),
-                label(
-                  {
-                    htmlFor: id,
-                    hidden: !isAutopauseEnabled(computeConfig.autopauseThreshold),
-                  },
-                  ['minutes of inactivity']
-                ),
-              ]),
-          ]),
-        ]),
-      ]),
-    ]);
-  };
-
   // Will be used once we support update
   // const hasChanges = () => {
   //   const existingConfig = adaptRuntimeDetailsToFormConfig()
@@ -324,7 +203,7 @@ export const AzureComputeModalBase = ({
       desiredPersistentDisk_size: computeConfig.persistentDiskSize,
       desiredPersistentDisk_type: 'Standard', // IA-4164 - Azure disks are currently only Standard (HDD), when we add types update this.
       desiredPersistentDisk_costPerMonth: getAzureDiskCostEstimate(computeConfig),
-      desiredRuntime_gpuEnabled: hasGpu(),
+      desiredRuntime_gpuEnabled: machineTypeHasGpu(computeConfig.machineType),
       tool: runtimeToolLabels.JupyterLab,
       application: runtimeToolLabels.JupyterLab,
     });
@@ -382,7 +261,19 @@ export const AzureComputeModalBase = ({
       div({ style: { padding: '1.5rem', borderBottom: `1px solid ${colors.dark(0.4)}` } }, [renderTitleAndTagline(), renderCostBreakdown()]),
       div({ style: { padding: '1.5rem', overflowY: 'auto', flex: 'auto' } }, [
         renderApplicationConfigurationSection(),
-        renderComputeProfileSection(),
+        div({ style: { ...computeStyles.whiteBoxContainer, marginTop: '1.5rem' } }, [
+          h(AzureComputeProfileSelect, {
+            machineType: computeConfig.machineType,
+            style: { marginBottom: '1.5rem' },
+            onChangeMachineType: (v) => updateComputeConfig('machineType', v),
+          }),
+          h(AutopauseConfiguration, {
+            autopauseThreshold: computeConfig.autopauseThreshold,
+            disabled: doesRuntimeExist(),
+            style: { gridColumnEnd: 'span 6' },
+            onChangeAutopauseThreshold: (v) => updateComputeConfig('autopauseThreshold', v),
+          }),
+        ]),
         h(AzurePersistentDiskSection, {
           persistentDiskExists,
           onClickAbout: () => {

--- a/src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeProfileSelect.test.ts
+++ b/src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeProfileSelect.test.ts
@@ -1,0 +1,53 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { h } from 'react-hyperscript-helpers';
+import { azureMachineTypes, defaultAzureMachineType, getMachineTypeLabel } from 'src/libs/azure-utils';
+import { renderWithAppContexts as render, SelectHelper } from 'src/testing/test-utils';
+
+import { AzureComputeProfileSelect, AzureComputeProfileSelectProps } from './AzureComputeProfileSelect';
+
+describe('AzureComputeProfileSelect', () => {
+  const setup = (props: Partial<AzureComputeProfileSelectProps> = {}) => {
+    render(
+      h(AzureComputeProfileSelect, {
+        machineType: defaultAzureMachineType,
+        onChangeMachineType: () => {},
+        ...props,
+      })
+    );
+  };
+
+  it('renders a menu of compute profiles', async () => {
+    // Arrange
+    const expectedOptions = Object.keys(azureMachineTypes).map(getMachineTypeLabel);
+    const expectedSelectedOption = getMachineTypeLabel(defaultAzureMachineType);
+
+    const user = userEvent.setup();
+
+    // Act
+    setup();
+
+    // Assert
+    const select = new SelectHelper(screen.getByLabelText('Cloud compute profile'), user);
+
+    const options = await select.getOptions();
+    expect(options).toEqual(expectedOptions);
+
+    const [selectedOption] = await select.getSelectedOptions();
+    expect(selectedOption).toEqual(expectedSelectedOption);
+  });
+
+  it('calls onChangeMachineType when a profile is selected', async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const onChangeMachineType = jest.fn();
+    setup({ onChangeMachineType });
+    const select = new SelectHelper(screen.getByLabelText('Cloud compute profile'), user);
+
+    // Act
+    await select.selectOption(getMachineTypeLabel('Standard_DS3_v2'));
+
+    // Assert
+    expect(onChangeMachineType).toHaveBeenCalledWith('Standard_DS3_v2');
+  });
+});

--- a/src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeProfileSelect.ts
+++ b/src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeProfileSelect.ts
@@ -1,0 +1,73 @@
+import { icon, Link, Select, useUniqueId } from '@terra-ui-packages/components';
+import { CSSProperties, ReactNode } from 'react';
+import { div, h, label, span } from 'react-hyperscript-helpers';
+import { computeStyles } from 'src/analysis/modals/modalStyles';
+import { azureMachineTypes, getMachineTypeLabel, machineTypeHasGpu } from 'src/libs/azure-utils';
+import colors from 'src/libs/colors';
+import * as Utils from 'src/libs/utils';
+
+export interface AzureComputeProfileSelectProps {
+  machineType: string;
+  style?: CSSProperties;
+  onChangeMachineType: (machineType: string) => void;
+}
+
+export const AzureComputeProfileSelect = (props: AzureComputeProfileSelectProps): ReactNode => {
+  const { machineType, style, onChangeMachineType } = props;
+
+  const id = useUniqueId();
+
+  return div({ style }, [
+    div({ style: { marginBottom: '1rem', display: 'flex' } }, [
+      label(
+        {
+          htmlFor: id,
+          style: {
+            ...computeStyles.label,
+            marginRight: '1rem',
+          },
+        },
+        ['Cloud compute profile']
+      ),
+      h(
+        Link,
+        {
+          href: 'https://azure.microsoft.com/en-us/pricing/details/virtual-machines/series/',
+          ...Utils.newTabLinkProps,
+        },
+        ['Learn more about cloud compute profiles.', icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })]
+      ),
+    ]),
+    div({ style: { width: 400 } }, [
+      h(Select<AzureComputeProfileSelectProps['machineType']>, {
+        id,
+        isSearchable: false,
+        isClearable: false,
+        value: machineType,
+        onChange: (selectedOption) => {
+          if (selectedOption) {
+            onChangeMachineType(selectedOption.value);
+          }
+        },
+        options: Object.keys(azureMachineTypes),
+        getOptionLabel: ({ value }) => getMachineTypeLabel(value),
+      }),
+    ]),
+    machineTypeHasGpu(machineType) &&
+      div({ style: { display: 'flex', marginTop: '.5rem' } }, [
+        icon('warning-standard', { size: 16, style: { marginRight: '0.5rem', color: colors.warning() } }),
+        div([
+          span({ style: { marginRight: '0.5rem' } }, ['This VM is powered by an NVIDIA GPU; availability may vary.']),
+          h(
+            Link,
+            {
+              style: { marginRight: '0.25rem' },
+              href: 'https://support.terra.bio/hc/en-us/articles/16921184286491-How-to-use-GPUs-in-a-notebook-Azure-',
+              ...Utils.newTabLinkProps,
+            },
+            ['Learn more about enabling GPUs.', icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })]
+          ),
+        ]),
+      ]),
+  ]);
+};

--- a/src/analysis/utils/runtime-utils.ts
+++ b/src/analysis/utils/runtime-utils.ts
@@ -44,9 +44,10 @@ export const defaultAutopauseThreshold = 30;
 // Leonardo considers autopause disabled when the threshold is set to 0
 export const autopauseDisabledValue = 0;
 
-export const isAutopauseEnabled = (threshold) => threshold > autopauseDisabledValue;
+export const isAutopauseEnabled = (threshold: number): boolean => threshold > autopauseDisabledValue;
 
-export const getAutopauseThreshold = (isEnabled) => (isEnabled ? defaultAutopauseThreshold : autopauseDisabledValue);
+export const getAutopauseThreshold = (isEnabled: boolean): number =>
+  isEnabled ? defaultAutopauseThreshold : autopauseDisabledValue;
 
 export const usableStatuses: LeoRuntimeStatus[] = ['Updating', 'Running'];
 

--- a/src/libs/azure-utils.js
+++ b/src/libs/azure-utils.js
@@ -35,6 +35,8 @@ export const azureMachineTypes = {
 export const getMachineTypeLabel = (key) =>
   _.has(key, azureMachineTypes) ? `${key}, ${azureMachineTypes[key].cpu} CPU(s), ${azureMachineTypes[key].ramInGb} GBs` : 'Unknown machine type';
 
+export const machineTypeHasGpu = (machineType) => !!azureMachineTypes[machineType]?.hasGpu;
+
 export const azureDiskTypes = {
   standard: {
     value: 'Standard_LRS',


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1766

Prefactoring for [AJ-1766](https://broadworkbench.atlassian.net/browse/AJ-1766). We want to limit the available compute profiles and require auto-pause for cloud environments in "Lite" billing projects.

To make those changes easier to test, this extracts compute profile and auto-pause configuration from AzureComputeModal into separate components.

I wasn't sure if IA has adopted JSX yet. If desired, I can update these new components to TSX?

Also, while I left existing AzureComputeModal tests alone, some may be duplicated now that these components have their own individual tests.

[AJ-1766]: https://broadworkbench.atlassian.net/browse/AJ-1766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ