### PR TITLE
Separate analyses from WorkspaceContainer

### DIFF
--- a/src/analysis/WorkspaceAnalysesContainer.ts
+++ b/src/analysis/WorkspaceAnalysesContainer.ts
@@ -1,0 +1,54 @@
+import { ReactNode } from 'react';
+import { div, h } from 'react-hyperscript-helpers';
+import { AnalysesData } from 'src/analysis/Analyses';
+import AnalysisNotificationManager from 'src/analysis/AnalysisNotificationManager';
+import { ContextBar } from 'src/analysis/ContextBar';
+import { useAppPolling } from 'src/workspaces/common/state/useAppPolling';
+import { useCloudEnvironmentPolling } from 'src/workspaces/common/state/useCloudEnvironmentPolling';
+import { StorageDetails } from 'src/workspaces/common/state/useWorkspace';
+import { WorkspaceWrapper } from 'src/workspaces/utils';
+
+export interface WorkspaceAnalysesContainerProps {
+  children: (analysesData: AnalysesData) => ReactNode;
+  storageDetails: StorageDetails;
+  workspace: WorkspaceWrapper;
+}
+
+export const WorkspaceAnalysesContainer = (props: WorkspaceAnalysesContainerProps): ReactNode => {
+  const { children, storageDetails, workspace } = props;
+  const { namespace, name } = workspace.workspace;
+
+  const { runtimes, refreshRuntimes, persistentDisks, appDataDisks, isLoadingCloudEnvironments } =
+    useCloudEnvironmentPolling(name, namespace, workspace);
+  const { apps, refreshApps, lastRefresh } = useAppPolling(name, namespace, workspace);
+
+  return div({ style: { flex: 1, display: 'flex' } }, [
+    div({ style: { flex: 1, display: 'flex', flexDirection: 'column' } }, [
+      children({
+        apps,
+        appDataDisks,
+        refreshApps,
+        runtimes,
+        persistentDisks,
+        refreshRuntimes,
+        isLoadingCloudEnvironments,
+        lastRefresh,
+      }),
+    ]),
+    workspace &&
+      workspace?.workspace.state !== 'Deleting' &&
+      workspace?.workspace.state !== 'DeleteFailed' &&
+      h(ContextBar, {
+        workspace,
+        apps: apps || [],
+        appDataDisks: appDataDisks || [],
+        refreshApps,
+        runtimes: runtimes || [],
+        persistentDisks: persistentDisks || [],
+        refreshRuntimes,
+        isLoadingCloudEnvironments,
+        storageDetails,
+      }),
+    h(AnalysisNotificationManager, { namespace, name, runtimes: runtimes || [], apps: apps || [] }),
+  ]);
+};

--- a/src/workspaces/common/state/useCloudEnvironmentPolling.ts
+++ b/src/workspaces/common/state/useCloudEnvironmentPolling.ts
@@ -6,7 +6,7 @@ import { Ajax } from 'src/libs/ajax';
 import { PersistentDisk } from 'src/libs/ajax/leonardo/models/disk-models';
 import { ListRuntimeItem } from 'src/libs/ajax/leonardo/models/runtime-models';
 import { withErrorIgnoring, withErrorReporting } from 'src/libs/error';
-import { InitializedWorkspaceWrapper as Workspace } from 'src/workspaces/common/state/useWorkspace';
+import { WorkspaceWrapper } from 'src/workspaces/utils';
 
 export interface CloudEnvironmentDetails {
   runtimes?: ListRuntimeItem[];
@@ -20,7 +20,7 @@ export interface CloudEnvironmentDetails {
 export const useCloudEnvironmentPolling = (
   name: string,
   namespace: string,
-  workspace?: Workspace
+  workspace: WorkspaceWrapper
 ): CloudEnvironmentDetails => {
   const controller = useRef(new window.AbortController());
   const abort = () => {
@@ -81,11 +81,7 @@ export const useCloudEnvironmentPolling = (
   const refreshRuntimes = withErrorReporting('Error loading cloud environments')(load);
   const refreshRuntimesSilently = withErrorIgnoring(load);
   useEffect(() => {
-    if (
-      workspace?.workspaceInitialized &&
-      workspace.workspace.name === name &&
-      workspace.workspace.namespace === namespace
-    ) {
+    if (workspace.workspace.name === name && workspace.workspace.namespace === namespace) {
       refreshRuntimes();
     }
     return () => {


### PR DESCRIPTION
Currently, components for pages within a workspace are wrapped with `wrapWorkspace`.

`wrapWorkspace` creates a higher order `Wrapper` component that loads the workspace and its cloud environments and apps. `Wrapper` then renders `WorkspaceContainer` and within it, the wrapped component for the page.

Currently, analyses are entangled in the core workspace components here. `WorkspaceContainer` renders `ContextBar` and `AnalysisNotificationManager` and the higher order `Wrapper` component handles polling for cloud environments and apps. Preferably, we could separate those two concerns.

This moves the analyses related concerns (rendering `ContextBar` and `AnalysisNotificationManager`, loading cloud environments and apps) into a new `WorkspaceAnalysesContainer` component. The higher order `Wrapper` component renders that around the wrapped page component and within `WorkspaceContainer`.

This means that `useCloudEnvironmentPolling` and `useAppPolling` no longer have to deal with the possibility of an undefined `workspace` argument. That was my initial goal when starting this.

Note: `WorkspaceAnalysesContainer`'s `children` prop is a render function. This allows passing cloud environment and app data from `WorkspaceAnalysesContainer` down to the page component. This may be controversial, but it is a well established pattern in React. We already use it in Terra UI for [IdContainer](https://github.com/DataBiosphere/terra-ui/blob/498f6d45a1cebcb163cbd198df3475175843bb27/src/components/common/IdContainer.ts).
- https://www.patterns.dev/react/render-props-pattern#children-as-a-function
- https://blog.logrocket.com/react-design-patterns/#render-props-pattern
- https://reactpatterns.com/#render-prop