### PR TITLE
[UIE-172] Move controlledPromise to core-utils to deduplicate

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -27,7 +27,7 @@
     "@fortawesome/free-regular-svg-icons": "^5.15.4",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
     "@fortawesome/react-fontawesome": "^0.1.15",
-    "@terra-ui-packages/core-utils": "^0.1.0",
+    "@terra-ui-packages/core-utils": "^0.2.0",
     "color": "^4.0.1",
     "lodash": "^4.17.21",
     "react-focus-lock": "^2.9.5",

--- a/packages/components/src/hooks/useAutoLoadedData.test.ts
+++ b/packages/components/src/hooks/useAutoLoadedData.test.ts
@@ -1,7 +1,6 @@
-import { LoadedState } from '@terra-ui-packages/core-utils';
+import { controlledPromise, LoadedState } from '@terra-ui-packages/core-utils';
 import { act, renderHook } from '@testing-library/react';
 
-import { controlledPromise } from '../internal/test-utils';
 import { useAutoLoadedData } from './useAutoLoadedData';
 import { UseLoadedDataResult } from './useLoadedData';
 

--- a/packages/components/src/hooks/useLoadedData.test.ts
+++ b/packages/components/src/hooks/useLoadedData.test.ts
@@ -1,7 +1,6 @@
-import { ErrorState, LoadedState, ReadyState } from '@terra-ui-packages/core-utils';
+import { controlledPromise, ErrorState, LoadedState, ReadyState } from '@terra-ui-packages/core-utils';
 import { act, renderHook } from '@testing-library/react';
 
-import { controlledPromise } from '../internal/test-utils';
 import { useLoadedData, UseLoadedDataResult } from './useLoadedData';
 
 interface TestData {

--- a/packages/components/src/hooks/useLoadedDataEvents.test.ts
+++ b/packages/components/src/hooks/useLoadedDataEvents.test.ts
@@ -1,7 +1,6 @@
-import { ErrorState, ReadyState } from '@terra-ui-packages/core-utils';
+import { controlledPromise, ErrorState, ReadyState } from '@terra-ui-packages/core-utils';
 import { act, renderHook } from '@testing-library/react';
 
-import { controlledPromise } from '../internal/test-utils';
 import { useLoadedData, UseLoadedDataResult } from './useLoadedData';
 import { useLoadedDataEvents } from './useLoadedDataEvents';
 

--- a/packages/components/src/hooks/withCachedData.test.ts
+++ b/packages/components/src/hooks/withCachedData.test.ts
@@ -1,7 +1,6 @@
-import { atom } from '@terra-ui-packages/core-utils';
+import { atom, controlledPromise } from '@terra-ui-packages/core-utils';
 import { act, renderHook } from '@testing-library/react';
 
-import { controlledPromise } from '../internal/test-utils';
 import { useLoadedData, UseLoadedDataResult } from './useLoadedData';
 import { withCachedData } from './withCachedData';
 

--- a/packages/components/src/internal/test-utils.tsx
+++ b/packages/components/src/internal/test-utils.tsx
@@ -27,22 +27,3 @@ export const TestThemeProvider = (props: Omit<ThemeProviderProps, 'theme'>) => {
 export const renderWithTheme = (ui: ReactElement) => {
   return render(ui, { wrapper: TestThemeProvider });
 };
-
-export type PromiseController<T> = {
-  resolve: (value: T) => void;
-  reject: (reason: unknown) => void;
-};
-
-export const controlledPromise = <T,>(): [Promise<T>, PromiseController<T>] => {
-  const controller: PromiseController<T> = {
-    resolve: () => {},
-    reject: () => {},
-  };
-
-  const promise = new Promise<T>((resolve, reject) => {
-    controller.resolve = resolve;
-    controller.reject = reject;
-  });
-
-  return [promise, controller];
-};

--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terra-ui-packages/core-utils",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "scripts": {
     "build": "vite build --emptyOutDir",
     "dev": "vite build --mode=development --watch",

--- a/packages/core-utils/src/promise-utils.test.ts
+++ b/packages/core-utils/src/promise-utils.test.ts
@@ -1,0 +1,35 @@
+import { controlledPromise } from './promise-utils';
+
+describe('controlledPromise', () => {
+  it('returns a promise that can be resolved by the controller', async () => {
+    // Arrange
+    const onResolved = jest.fn();
+    const [promise, controller] = controlledPromise<string>();
+    promise.then(onResolved);
+
+    // Act
+    controller.resolve('foo');
+
+    // Wait a tick for the promise callback
+    await Promise.resolve();
+
+    // Assert
+    expect(onResolved).toHaveBeenCalledWith('foo');
+  });
+
+  it('returns a promise that can be rejected by the controller', async () => {
+    // Arrange
+    const onRejected = jest.fn();
+    const [promise, controller] = controlledPromise<string>();
+    promise.catch(onRejected);
+
+    // Act
+    controller.reject(new Error('Something went wrong'));
+
+    // Wait a tick for the promise callback
+    await Promise.resolve();
+
+    // Assert
+    expect(onRejected).toHaveBeenCalledWith(new Error('Something went wrong'));
+  });
+});

--- a/packages/core-utils/src/promise-utils.ts
+++ b/packages/core-utils/src/promise-utils.ts
@@ -6,3 +6,25 @@
 export const abandonedPromise = (): Promise<any> => {
   return new Promise(() => {});
 };
+
+export interface PromiseController<T> {
+  resolve: (value: T) => void;
+  reject: (reason: unknown) => void;
+}
+
+/**
+ * Returns a promise and a controller that allows manually resolving/rejecting the promise.
+ */
+export const controlledPromise = <T>(): [Promise<T>, PromiseController<T>] => {
+  const controller: PromiseController<T> = {
+    resolve: () => {},
+    reject: () => {},
+  };
+
+  const promise = new Promise<T>((resolve, reject) => {
+    controller.resolve = resolve;
+    controller.reject = reject;
+  });
+
+  return [promise, controller];
+};

--- a/src/components/file-browser/useFileDownloadCommand.test.ts
+++ b/src/components/file-browser/useFileDownloadCommand.test.ts
@@ -1,7 +1,7 @@
+import { controlledPromise } from '@terra-ui-packages/core-utils';
 import { act, renderHook } from '@testing-library/react';
 import FileBrowserProvider, { FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider';
 import { reportError } from 'src/libs/error';
-import { controlledPromise } from 'src/testing/test-utils';
 
 import { useFileDownloadCommand } from './useFileDownloadCommand';
 

--- a/src/components/file-browser/useFileDownloadUrl.test.ts
+++ b/src/components/file-browser/useFileDownloadUrl.test.ts
@@ -1,6 +1,6 @@
+import { controlledPromise } from '@terra-ui-packages/core-utils';
 import { act, renderHook } from '@testing-library/react';
 import FileBrowserProvider, { FileBrowserFile } from 'src/libs/ajax/file-browser-providers/FileBrowserProvider';
-import { controlledPromise } from 'src/testing/test-utils';
 
 import { reportError } from '../../libs/error';
 import { useFileDownloadUrl } from './useFileDownloadUrl';

--- a/src/libs/ajax/incremental-response/useIncrementalResponse.test.ts
+++ b/src/libs/ajax/incremental-response/useIncrementalResponse.test.ts
@@ -1,7 +1,13 @@
-import { ErrorState, LoadingState, ReadyState } from '@terra-ui-packages/core-utils';
+import {
+  controlledPromise,
+  ErrorState,
+  LoadingState,
+  PromiseController,
+  ReadyState,
+} from '@terra-ui-packages/core-utils';
 import { act, renderHook } from '@testing-library/react';
 import _ from 'lodash/fp';
-import { controlledPromise, PromiseController, renderHookInAct } from 'src/testing/test-utils';
+import { renderHookInAct } from 'src/testing/test-utils';
 
 import IncrementalResponse from './IncrementalResponse';
 import useIncrementalResponse from './useIncrementalResponse';

--- a/src/libs/uploads.test.ts
+++ b/src/libs/uploads.test.ts
@@ -1,5 +1,5 @@
+import { controlledPromise } from '@terra-ui-packages/core-utils';
 import { act, renderHook } from '@testing-library/react';
-import { controlledPromise } from 'src/testing/test-utils';
 
 import { UploadState, useOnUploadFinished, useUploader } from './uploads';
 

--- a/src/testing/test-utils.ts
+++ b/src/testing/test-utils.ts
@@ -46,11 +46,6 @@ export const renderWithAppContexts = (ui: ReactElement, options?: Omit<RenderOpt
 
 type UserEvent = ReturnType<typeof userEvent.setup>;
 
-export type PromiseController<T> = {
-  resolve: (value: T) => void;
-  reject: (reason: unknown) => void;
-};
-
 export const renderHookWithAppContexts = <T, U>(
   hook: (args: T) => U,
   options?: RenderHookOptions<T>
@@ -60,23 +55,6 @@ export const renderHookWithAppContexts = <T, U>(
   };
   const mergedOptions: RenderHookOptions<T> = { ...baseOptions, ...options };
   return renderHook(hook, mergedOptions);
-};
-
-/**
- * Returns a promise and a controller that allows manually resolving/rejecting the promise.
- */
-export const controlledPromise = <T>(): [Promise<T>, PromiseController<T>] => {
-  const controller: PromiseController<T> = {
-    resolve: () => {},
-    reject: () => {},
-  };
-
-  const promise = new Promise<T>((resolve, reject) => {
-    controller.resolve = resolve;
-    controller.reject = reject;
-  });
-
-  return [promise, controller];
 };
 
 // This is for the AutoSizer component. It requires screen dimensions in order to be tested properly.

--- a/yarn.lock
+++ b/yarn.lock
@@ -4594,7 +4594,7 @@ __metadata:
     "@fortawesome/free-solid-svg-icons": ^5.15.4
     "@fortawesome/react-fontawesome": ^0.1.15
     "@terra-ui-packages/build-utils": ^1.0.0
-    "@terra-ui-packages/core-utils": ^0.1.0
+    "@terra-ui-packages/core-utils": ^0.2.0
     "@terra-ui-packages/test-utils": "*"
     "@testing-library/dom": ^9.3.1
     "@testing-library/react": ^14.0.0
@@ -4626,7 +4626,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@terra-ui-packages/core-utils@*, @terra-ui-packages/core-utils@^0.1.0, @terra-ui-packages/core-utils@workspace:packages/core-utils":
+"@terra-ui-packages/core-utils@*, @terra-ui-packages/core-utils@^0.2.0, @terra-ui-packages/core-utils@workspace:packages/core-utils":
   version: 0.0.0-use.local
   resolution: "@terra-ui-packages/core-utils@workspace:packages/core-utils"
   dependencies:


### PR DESCRIPTION
Follow up to https://github.com/DataBiosphere/terra-ui/pull/4805#discussion_r1591417029

Since tests in the components package now also use `controlledPromise`, this moves `controlledPromise` to core-utils to avoid having two copies of it (one in components and one in Terra UI). 