### PR TITLE
[AJ-1828] Fix regression on clipboard hover behavior in FileBrowser

### DIFF
--- a/src/components/data/FileBrowser.js
+++ b/src/components/data/FileBrowser.js
@@ -252,7 +252,7 @@ const BucketBrowserTable = ({
                           h(ClipboardButton, {
                             tooltip: 'Copy file URL to clipboard',
                             className: 'cell-hover-only',
-                            style: { marginLeft: '1rem', display: 'inline-table' },
+                            style: { marginLeft: '1rem', display: 'inline' },
                             text: `gs://${bucketName}/${object.name}`,
                             iconSize: 14, // See this PR for reason: https://github.com/DataBiosphere/terra-ui/pull/4288
                           }),

--- a/src/components/data/FileBrowser.js
+++ b/src/components/data/FileBrowser.js
@@ -252,7 +252,7 @@ const BucketBrowserTable = ({
                           h(ClipboardButton, {
                             tooltip: 'Copy file URL to clipboard',
                             className: 'cell-hover-only',
-                            style: { marginLeft: '1ch' },
+                            style: { marginLeft: '1rem', display: 'inline-table' },
                             text: `gs://${bucketName}/${object.name}`,
                             iconSize: 14, // See this PR for reason: https://github.com/DataBiosphere/terra-ui/pull/4288
                           }),


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/AJ-1828

## Summary of changes:
This is a 1-line change to fix a regression where the clipboard on hover icon in the FileBrowser was changed to appear on a newline rather than right after the file name as was done previously. 

I'm not sure this is the best way to do it, but it seems changing the `display` prop to `inline-table` makes it behave as before. Perhaps there was originally some inherited `display` prop like this or similar that was changed in some recent refactoring, which made the behavior regress. I also updated the `marginLeft` to use `1rem` instead of `1ch` to match what's done in the `DataTable` for their clipboard on hover.

**Before** (current):

https://github.com/DataBiosphere/terra-ui/assets/81349869/dd04bbf5-87e9-40bb-a292-0f9c99c82b8c

**After**:

https://github.com/DataBiosphere/terra-ui/assets/81349869/1d4cd0fe-69c5-4fdf-af49-f870306f16fc



### What
Changed the style of the clipboard on hover icon for the FileBrowser.

### Why
The icon was a bit annoying to try to click when it appeared on the newline rather than after the file name, and reverts it back to the original behavior.

### Testing strategy
It worked for me locally.

