### PR TITLE
[UIE-173] Use single quotes for JSX

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,3 +1,4 @@
 {
+  "jsxSingleQuote": true,
   "singleQuote": true
 }

--- a/packages/components/src/FocusTrap.test.tsx
+++ b/packages/components/src/FocusTrap.test.tsx
@@ -10,9 +10,9 @@ describe('FocusTrap', () => {
 
     const { container } = render(
       <FocusTrap onEscape={jest.fn()}>
-        <button type="button">A</button>
-        <button type="button">B</button>
-        <button type="button">C</button>
+        <button type='button'>A</button>
+        <button type='button'>B</button>
+        <button type='button'>C</button>
       </FocusTrap>
     );
 

--- a/packages/components/src/InfoBox.test.tsx
+++ b/packages/components/src/InfoBox.test.tsx
@@ -19,7 +19,7 @@ describe('InfoBox', () => {
 
   it('allows overriding the default icon', async () => {
     // Act
-    renderWithTheme(<InfoBox icon="error-standard">More information about the thing.</InfoBox>);
+    renderWithTheme(<InfoBox icon='error-standard'>More information about the thing.</InfoBox>);
     const trigger = screen.getByRole('button');
 
     // Assert

--- a/packages/components/src/InfoBox.tsx
+++ b/packages/components/src/InfoBox.tsx
@@ -22,7 +22,7 @@ export const InfoBox = (props: InfoBoxProps): ReactNode => {
 
   return (
     <PopupTrigger content={<div style={{ padding: '0.5rem', width: 300 }}>{children}</div>} side={side}>
-      <Clickable aria-label="More info" tagName="span" tooltip={tooltip}>
+      <Clickable aria-label='More info' tagName='span' tooltip={tooltip}>
         {icon(iconId, { size, style: { color: colors.accent(), cursor: 'pointer', ...style } })}
       </Clickable>
     </PopupTrigger>

--- a/packages/components/src/Link.test.tsx
+++ b/packages/components/src/Link.test.tsx
@@ -16,7 +16,7 @@ jest.mock('./Clickable', (): ClickableExports => {
 describe('Link', () => {
   it('renders a styled Clickable', () => {
     // Act
-    render(<Link href="https://example.com" />);
+    render(<Link href='https://example.com' />);
 
     // Assert
     expect(Clickable).toHaveBeenCalledWith(
@@ -27,10 +27,10 @@ describe('Link', () => {
 
   it('has a light variant that is styled differently', () => {
     // Act
-    render(<Link href="https://example.com" />);
+    render(<Link href='https://example.com' />);
     const defaultStyle = (Clickable as jest.MockedFunction<typeof Clickable>).mock.lastCall[0].style;
 
-    render(<Link href="https://example.com" variant="light" />);
+    render(<Link href='https://example.com' variant='light' />);
     const lightVariantStyle = (Clickable as jest.MockedFunction<typeof Clickable>).mock.lastCall[0].style;
 
     // Assert
@@ -39,10 +39,10 @@ describe('Link', () => {
 
   it('can be styled with a different base color', () => {
     // Act
-    render(<Link href="https://example.com" />);
+    render(<Link href='https://example.com' />);
     const defaultStyle = (Clickable as jest.MockedFunction<typeof Clickable>).mock.lastCall[0].style;
 
-    render(<Link href="https://example.com" baseColor={() => 'blue'} />);
+    render(<Link href='https://example.com' baseColor={() => 'blue'} />);
     const baseColorStyle = (Clickable as jest.MockedFunction<typeof Clickable>).mock.lastCall[0].style;
 
     // Assert
@@ -52,10 +52,10 @@ describe('Link', () => {
   describe('when disabled', () => {
     it('is styled differently', () => {
       // Act
-      render(<Link href="https://example.com" />);
+      render(<Link href='https://example.com' />);
       const enabledStyle = (Clickable as jest.MockedFunction<typeof Clickable>).mock.lastCall[0].style;
 
-      render(<Link href="https://example.com" disabled />);
+      render(<Link href='https://example.com' disabled />);
       const disabledStyle = (Clickable as jest.MockedFunction<typeof Clickable>).mock.lastCall[0].style;
 
       // Assert
@@ -64,7 +64,7 @@ describe('Link', () => {
 
     it('has no hover style', () => {
       // Act
-      render(<Link href="https://example.com" disabled />);
+      render(<Link href='https://example.com' disabled />);
       const disabledHoverStyle = (Clickable as jest.MockedFunction<typeof Clickable>).mock.lastCall[0].hover;
 
       // Assert

--- a/packages/components/src/Modal.test.tsx
+++ b/packages/components/src/Modal.test.tsx
@@ -146,7 +146,7 @@ describe('Modal', () => {
         // Act
         renderModal({
           okButton: (
-            <button type="button" onClick={onOk}>
+            <button type='button' onClick={onOk}>
               Start
             </button>
           ),
@@ -227,11 +227,11 @@ describe('Modal', () => {
       renderWithTheme(
         <>
           <Modal showButtons={false} onDismiss={jest.fn()}>
-            <button type="button">A</button>
-            <button type="button">B</button>
-            <button type="button">C</button>
+            <button type='button'>A</button>
+            <button type='button'>B</button>
+            <button type='button'>C</button>
           </Modal>
-          <button type="button">D</button>
+          <button type='button'>D</button>
         </>
       );
 
@@ -263,7 +263,7 @@ describe('Modal', () => {
           return (
             <>
               <button
-                type="button"
+                type='button'
                 onClick={() => {
                   setIsModalOpen(true);
                 }}

--- a/packages/components/src/Modal.tsx
+++ b/packages/components/src/Modal.tsx
@@ -205,7 +205,7 @@ export const Modal = (props: ModalProps): ReactNode => {
           {titleChildren}
           {showX && (
             <Clickable
-              aria-label="Close modal"
+              aria-label='Close modal'
               style={{ alignSelf: 'flex-start', marginLeft: 'auto' }}
               onClick={onDismiss}
             >

--- a/packages/components/src/PopupTrigger.test.tsx
+++ b/packages/components/src/PopupTrigger.test.tsx
@@ -11,8 +11,8 @@ describe('PopupTrigger', () => {
     childProps: Partial<JSX.IntrinsicElements['button']> = {}
   ): { trigger: HTMLElement } => {
     renderWithTheme(
-      <PopupTrigger content="This is a popup" {...props}>
-        <button type="button" {...childProps}>
+      <PopupTrigger content='This is a popup' {...props}>
+        <button type='button' {...childProps}>
           Toggle Popup
         </button>
       </PopupTrigger>
@@ -146,14 +146,14 @@ describe('PopupTrigger', () => {
         <PopupTrigger
           content={
             <>
-              <button type="button">Button A</button>
-              <button type="button">Button B</button>
+              <button type='button'>Button A</button>
+              <button type='button'>Button B</button>
             </>
           }
         >
-          <button type="button">Toggle Popup</button>
+          <button type='button'>Toggle Popup</button>
         </PopupTrigger>
-        <button type="button">Button C</button>
+        <button type='button'>Button C</button>
       </>
     );
 
@@ -203,8 +203,8 @@ describe('PopupTrigger', () => {
 
     const ref: RefObject<PopupTriggerRef> = { current: null };
     renderWithTheme(
-      <PopupTrigger ref={ref} content="This is a popup">
-        <button type="button">Toggle Popup</button>
+      <PopupTrigger ref={ref} content='This is a popup'>
+        <button type='button'>Toggle Popup</button>
       </PopupTrigger>
     );
 

--- a/packages/components/src/Select.test.tsx
+++ b/packages/components/src/Select.test.tsx
@@ -13,7 +13,7 @@ describe('Select Component', () => {
 
   it('renders', () => {
     // Act
-    renderWithTheme(<Select options={options} value="foo" onChange={() => {}} />);
+    renderWithTheme(<Select options={options} value='foo' onChange={() => {}} />);
 
     // Assert
     expect(screen.getByText('Foo')).toBeInTheDocument();
@@ -25,7 +25,7 @@ describe('Select Component', () => {
     const mockOnChange = jest.fn();
 
     // Act
-    renderWithTheme(<Select options={options} value="foo" onChange={mockOnChange} />);
+    renderWithTheme(<Select options={options} value='foo' onChange={mockOnChange} />);
     await user.click(screen.getByText('Foo'));
     await user.click(screen.getByText('Bar'));
 
@@ -52,7 +52,7 @@ describe('GroupedSelect Component', () => {
 
   it('renders', () => {
     // Act
-    renderWithTheme(<GroupedSelect options={groupedOptions} value="red" onChange={() => {}} />);
+    renderWithTheme(<GroupedSelect options={groupedOptions} value='red' onChange={() => {}} />);
 
     // Assert
     expect(screen.getByText('Red')).toBeInTheDocument();
@@ -65,7 +65,7 @@ describe('GroupedSelect Component', () => {
     const mockOnChange = jest.fn();
 
     // Act
-    renderWithTheme(<GroupedSelect options={groupedOptions} value="blue" onChange={mockOnChange} />);
+    renderWithTheme(<GroupedSelect options={groupedOptions} value='blue' onChange={mockOnChange} />);
     expect(screen.getByText('Blue')).toBeInTheDocument();
     await user.click(screen.getByText('Blue'));
 
@@ -85,7 +85,7 @@ describe('GroupedSelect Component', () => {
     const mockOnChange = jest.fn();
 
     // Act
-    renderWithTheme(<GroupedSelect options={groupedOptions} value="red" onChange={mockOnChange} />);
+    renderWithTheme(<GroupedSelect options={groupedOptions} value='red' onChange={mockOnChange} />);
     expect(screen.getByText('Red')).toBeInTheDocument();
     await user.click(screen.getByText('Red'));
     await user.click(screen.getByText('Medium'));
@@ -104,7 +104,7 @@ describe('AsyncCreatableSelect Component', () => {
   it('renders', async () => {
     // Arrange
     const user = userEvent.setup();
-    renderWithTheme(<AsyncCreatableSelect options={options} value="car" onChange={() => {}} />);
+    renderWithTheme(<AsyncCreatableSelect options={options} value='car' onChange={() => {}} />);
 
     // Act
     const selectComponent = screen.getByText('Select...');

--- a/packages/components/src/Spinner.test.tsx
+++ b/packages/components/src/Spinner.test.tsx
@@ -19,7 +19,7 @@ describe('Spinner', () => {
     'renders a visually hidden alert after a delay',
     withFakeTimers(() => {
       // Act
-      renderWithTheme(<Spinner message="Loading the data" />);
+      renderWithTheme(<Spinner message='Loading the data' />);
 
       const isMessageRenderedImmediately = !!screen.queryByText('Loading the data');
       act(() => jest.advanceTimersByTime(150));

--- a/packages/components/src/Spinner.tsx
+++ b/packages/components/src/Spinner.tsx
@@ -22,7 +22,7 @@ export const Spinner = (props: SpinnerProps): ReactNode => {
     <>
       {icon('loadingSpinner', { size: 24, style: { color: colors.primary(), ...style }, ...otherProps })}
       <DelayedRender delay={150}>
-        <span role="alert" style={visuallyHidden}>
+        <span role='alert' style={visuallyHidden}>
           {message}
         </span>
       </DelayedRender>

--- a/packages/components/src/TooltipTrigger.test.tsx
+++ b/packages/components/src/TooltipTrigger.test.tsx
@@ -16,7 +16,7 @@ describe('TooltipTrigger', () => {
   ) => {
     return renderWithTheme(
       <TooltipTrigger content={tooltipContent} {...props}>
-        <button type="button" {...childProps} />
+        <button type='button' {...childProps} />
       </TooltipTrigger>
     );
   };

--- a/packages/components/src/TooltipTrigger.tsx
+++ b/packages/components/src/TooltipTrigger.tsx
@@ -94,7 +94,7 @@ const Tooltip = (props: TooltipProps): ReactNode => {
     <PopupPortal>
       <div
         id={id}
-        role="tooltip"
+        role='tooltip'
         ref={elementRef}
         style={{
           ...styles.tooltip,
@@ -105,8 +105,8 @@ const Tooltip = (props: TooltipProps): ReactNode => {
         }}
       >
         {children}
-        <svg viewBox="0 0 2 1" style={{ ...styles.notch, ...getNotchPositionStyle() }}>
-          <path d="M0,1l1,-1l1,1Z" />
+        <svg viewBox='0 0 2 1' style={{ ...styles.notch, ...getNotchPositionStyle() }}>
+          <path d='M0,1l1,-1l1,1Z' />
         </svg>
       </div>
     </PopupPortal>

--- a/packages/components/src/internal/popup-utils.test.tsx
+++ b/packages/components/src/internal/popup-utils.test.tsx
@@ -154,7 +154,7 @@ describe('useBoundingRects', () => {
       const [boundingRect] = useBoundingRects([{ id: 'test-element' }]);
       receivedBoundingRect(boundingRect);
 
-      return <div id="test-element" style={{ width: 200, height: 100, margin: '100px 0 0 50px' }} />;
+      return <div id='test-element' style={{ width: 200, height: 100, margin: '100px 0 0 50px' }} />;
     };
 
     // Act

--- a/src/analysis/runtime-common-text.tsx
+++ b/src/analysis/runtime-common-text.tsx
@@ -11,8 +11,8 @@ export const SaveFilesHelp = (props: SaveFilesHelpProps): ReactNode => {
     <p>
       If you want to save some files permanently, such as input data, analysis outputs, or installed packages,&nbsp;
       <Link
-        aria-label="Save file help"
-        href="https://support.terra.bio/hc/en-us/articles/360026639112"
+        aria-label='Save file help'
+        href='https://support.terra.bio/hc/en-us/articles/360026639112'
         {...Utils.newTabLinkProps}
       >
         move them to the workspace bucket.
@@ -30,8 +30,8 @@ export const SaveFilesHelpRStudio = (): ReactNode => {
       If you want to save files permanently, including input data, analysis outputs, installed packages or code in your
       session,&nbsp;
       <Link
-        aria-label="RStudio save help"
-        href="https://support.terra.bio/hc/en-us/articles/360026639112"
+        aria-label='RStudio save help'
+        href='https://support.terra.bio/hc/en-us/articles/360026639112'
         {...Utils.newTabLinkProps}
       >
         move them to the workspace bucket.
@@ -50,8 +50,8 @@ export const SaveFilesHelpGalaxy = (): ReactNode => {
       <p>
         If you want to save some files permanently, such as input data, analysis outputs, or installed packages,&nbsp;
         <Link
-          aria-label="Galaxy save help"
-          href="https://support.terra.bio/hc/en-us/articles/360026639112"
+          aria-label='Galaxy save help'
+          href='https://support.terra.bio/hc/en-us/articles/360026639112'
           {...Utils.newTabLinkProps}
         >
           move them to the workspace bucket.
@@ -66,8 +66,8 @@ export const SaveFilesHelpAzure = (): ReactNode => {
     <p>
       If you want to save some files permanently, such as input data, analysis outputs, or installed packages,&nbsp;
       <Link
-        aria-label="Save file help"
-        href="https://support.terra.bio/hc/en-us/articles/12043575737883"
+        aria-label='Save file help'
+        href='https://support.terra.bio/hc/en-us/articles/12043575737883'
         {...Utils.newTabLinkProps}
       >
         move them to the workspace bucket.

--- a/src/components/CloudProviderIcon.tsx
+++ b/src/components/CloudProviderIcon.tsx
@@ -14,5 +14,5 @@ export const CloudProviderIcon = (props: CloudProviderIconProps): ReactNode => {
     GCP: CloudGcpLogo,
   }[cloudProvider];
 
-  return <Icon role="img" title={cloudProviderLabels[cloudProvider]} {...rest} />;
+  return <Icon role='img' title={cloudProviderLabels[cloudProvider]} {...rest} />;
 };

--- a/src/libs/link-expiration-alerts.tsx
+++ b/src/libs/link-expiration-alerts.tsx
@@ -69,7 +69,7 @@ export const getOAuth2ProviderLinkExpirationAlert = (
           provider={provider}
           button={false}
         />{' '}
-        your access or <UnlinkOAuth2Account linkText="unlink" provider={provider} /> your account.
+        your access or <UnlinkOAuth2Account linkText='unlink' provider={provider} /> your account.
       </div>
     ),
     severity: 'info',

--- a/src/pages/Disabled.tsx
+++ b/src/pages/Disabled.tsx
@@ -4,7 +4,7 @@ import { signOut } from 'src/auth/signout/sign-out';
 
 export const Disabled = (): ReactNode => {
   return (
-    <div role="main" style={{ padding: '1rem' }}>
+    <div role='main' style={{ padding: '1rem' }}>
       <div>
         Thank you for registering. Your account is currently inactive. You will be contacted via email when your account
         is activated.

--- a/src/pages/workspaces/DashboardAuthContainer.test.tsx
+++ b/src/pages/workspaces/DashboardAuthContainer.test.tsx
@@ -56,7 +56,7 @@ describe('DashboardAuthContainer', () => {
     } as DeepPartial<AjaxContract> as AjaxContract);
 
     // Act
-    render(<DashboardAuthContainer namespace="test-namespace" name="test-name" />);
+    render(<DashboardAuthContainer namespace='test-namespace' name='test-name' />);
 
     // Assert
     expect(document.getElementById('loading-spinner')).not.toBeNull();
@@ -77,7 +77,7 @@ describe('DashboardAuthContainer', () => {
 
     // Act
     await act(async () => {
-      render(<DashboardAuthContainer namespace="test-namespace" name="test-name" />);
+      render(<DashboardAuthContainer namespace='test-namespace' name='test-name' />);
     });
 
     // Assert
@@ -95,7 +95,7 @@ describe('DashboardAuthContainer', () => {
 
     // Act
     await act(async () => {
-      render(<DashboardAuthContainer namespace="test-namespace" name="test-name" />);
+      render(<DashboardAuthContainer namespace='test-namespace' name='test-name' />);
     });
 
     // Assert
@@ -120,7 +120,7 @@ describe('DashboardAuthContainer', () => {
     } as DeepPartial<AjaxContract> as AjaxContract);
     // Act
     await act(async () => {
-      render(<DashboardAuthContainer namespace="test-namespace" name="test-name" />);
+      render(<DashboardAuthContainer namespace='test-namespace' name='test-name' />);
     });
 
     // Assert

--- a/src/profile/external-identities/ExternalIdentities.tsx
+++ b/src/profile/external-identities/ExternalIdentities.tsx
@@ -14,7 +14,7 @@ export const ExternalIdentities = (props: ExternalIdentitiesProps): ReactNode =>
   const { queryParams } = props;
 
   return (
-    <PageBox role="main" style={{ flexGrow: 1 }} variant={PageBoxVariants.light}>
+    <PageBox role='main' style={{ flexGrow: 1 }} variant={PageBoxVariants.light}>
       <NihAccount nihToken={queryParams?.['nih-username-token']} />
       {getConfig()
         .externalCreds?.providers.filter((p) => p !== 'github')
@@ -27,7 +27,7 @@ export const ExternalIdentities = (props: ExternalIdentitiesProps): ReactNode =>
         ))}
       {getConfig().externalCreds?.providers.includes('github') &&
         userHasAccessToEnterpriseFeature('github-account-linking') && (
-          <OAuth2Account key="oauth2link-github}" queryParams={queryParams} provider={oauth2Provider('github')} />
+          <OAuth2Account key='oauth2link-github}' queryParams={queryParams} provider={oauth2Provider('github')} />
         )}
     </PageBox>
   );

--- a/src/profile/external-identities/OAuth2Account.tsx
+++ b/src/profile/external-identities/OAuth2Account.tsx
@@ -114,7 +114,7 @@ export const OAuth2Account = (props: OAuth2AccountProps) => {
             <div>
               <LinkOAuth2Account linkText={`Renew your ${provider.short} link`} provider={provider} button={false} />
               <span style={{ margin: '0 0.25rem 0' }}> | </span>
-              <UnlinkOAuth2Account linkText="Unlink" provider={provider} />
+              <UnlinkOAuth2Account linkText='Unlink' provider={provider} />
             </div>
             {provider.supportsIdToken && (
               <ClipboardButton text={Ajax(signal).ExternalCredentials(provider).getIdentityToken}>

--- a/src/profile/external-identities/UnlinkOAuth2Account.tsx
+++ b/src/profile/external-identities/UnlinkOAuth2Account.tsx
@@ -54,7 +54,7 @@ export const UnlinkOAuth2Account = ({ linkText, provider }: UnlinkOAuth2AccountP
         {linkText}
       </Clickable>
       {isModalOpen && (
-        <Modal title="Confirm unlink account" onDismiss={() => setIsModalOpen(false)} okButton={okButton}>
+        <Modal title='Confirm unlink account' onDismiss={() => setIsModalOpen(false)} okButton={okButton}>
           <div>Are you sure you want to unlink from {provider.name}?</div>
           <div style={{ marginTop: '1rem' }}>
             {provider.isFence &&

--- a/src/profile/notification-settings/PreferenceCard.tsx
+++ b/src/profile/notification-settings/PreferenceCard.tsx
@@ -38,7 +38,7 @@ export const NotificationCard: React.FC<NotificationCardProps> = memoWithName(
     const { label, setSaving, prefsData, workspace, options } = props;
 
     return (
-      <div role="listitem" style={{ ...Style.cardList.longCardShadowless, padding: 0, flexDirection: 'column' }}>
+      <div role='listitem' style={{ ...Style.cardList.longCardShadowless, padding: 0, flexDirection: 'column' }}>
         <div style={cardStyles.row}>
           <div style={cardStyles.label}>{label}</div>
           {options.map(
@@ -88,7 +88,7 @@ export const UserAttributesCard: React.FC<UserAttributesCardProps> = memoWithNam
       disabled,
     };
     return (
-      <div role="listitem" style={{ ...Style.cardList.longCardShadowless, padding: 0, flexDirection: 'column' }}>
+      <div role='listitem' style={{ ...Style.cardList.longCardShadowless, padding: 0, flexDirection: 'column' }}>
         <div style={cardStyles.row}>
           <div style={cardStyles.label}>{label}</div>
           <div style={cardStyles.field}>

--- a/src/registration/Register.tsx
+++ b/src/registration/Register.tsx
@@ -111,7 +111,7 @@ export const Register = (): ReactNode => {
   };
 
   return (
-    <div role="main" style={mainStyle}>
+    <div role='main' style={mainStyle}>
       <RegistrationLogo />
       <h1 style={headerStyle('4rem')}>New User Registration</h1>
       <div style={{ marginTop: '1rem', display: 'flex', lineHeight: '170%' }}>
@@ -120,14 +120,14 @@ export const Register = (): ReactNode => {
           value={givenName}
           onChange={setGivenName}
           inputStyle={{ display: 'block' }}
-          label="First Name"
+          label='First Name'
         />
         <LabelledTextInput
           required
           value={familyName}
           onChange={setFamilyName}
           inputStyle={{ display: 'block' }}
-          label="Last Name"
+          label='Last Name'
         />
       </div>
       <div style={{ lineHeight: '170%' }}>
@@ -137,7 +137,7 @@ export const Register = (): ReactNode => {
           onChange={setEmail}
           labelStyle={{ display: 'block', marginTop: '2rem' }}
           inputStyle={{ width: '66ex' }}
-          label="Contact Email for Notifications"
+          label='Contact Email for Notifications'
         />
         <LabelledTextInput
           value={institute}
@@ -145,7 +145,7 @@ export const Register = (): ReactNode => {
           disabled={!partOfOrganization}
           onChange={setInstitute}
           inputStyle={{ width: '66ex' }}
-          label="Organization"
+          label='Organization'
         />
       </div>
       <div style={{ lineHeight: '170%', marginTop: '0.25rem' }}>
@@ -164,14 +164,14 @@ export const Register = (): ReactNode => {
           disabled={!partOfOrganization}
           onChange={setDepartment}
           labelStyle={{ display: 'block' }}
-          label="Department"
+          label='Department'
         />
         <LabelledTextInput
           value={title}
           required={partOfOrganization}
           disabled={!partOfOrganization}
           onChange={setTitle}
-          label="Title"
+          label='Title'
           labelStyle={{ display: 'block' }}
         />
       </div>
@@ -199,9 +199,9 @@ export const Register = (): ReactNode => {
         })}
       </div>
       <FormLabel style={{ marginTop: '2rem' }}>Communication Preferences</FormLabel>
-      <RegistrationPageCheckbox title="Necessary communications related to platform operations" checked />
+      <RegistrationPageCheckbox title='Necessary communications related to platform operations' checked />
       <RegistrationPageCheckbox
-        title="Marketing communications including notifications for upcoming workshops and new flagship dataset additions"
+        title='Marketing communications including notifications for upcoming workshops and new flagship dataset additions'
         checked={marketingConsent}
         onChange={setMarketingConsent}
       />
@@ -215,21 +215,21 @@ export const Register = (): ReactNode => {
         Read Terra Platform Terms of Service here
       </ButtonSecondary>
       {showTermsOfService && (
-        <Modal width="80%" title="Terra Terms of Service" showCancel={false} onDismiss={termsOfServiceViewed}>
+        <Modal width='80%' title='Terra Terms of Service' showCancel={false} onDismiss={termsOfServiceViewed}>
           <RemoteMarkdown
             style={{ height: '75vh', overflowY: 'auto' }}
             getRemoteText={() => Ajax().TermsOfService.getTermsOfServiceText()}
-            failureMessage="Could not get Terms of Service"
+            failureMessage='Could not get Terms of Service'
           />
         </Modal>
       )}
       <RegistrationPageCheckbox
-        title="By checking this box, you are agreeing to the Terra Terms of Service"
+        title='By checking this box, you are agreeing to the Terra Terms of Service'
         checked={termsOfServiceAccepted}
         onChange={setTermsOfServiceAccepted}
         disabled={!termsOfServiceSeen}
         tooltip={!termsOfServiceSeen ? 'You must read the Terms of Service before continuing' : undefined}
-        tooltipSide="right"
+        tooltipSide='right'
       />
 
       <div style={{ marginTop: '3rem' }}>
@@ -241,7 +241,7 @@ export const Register = (): ReactNode => {
               ? 'You must fill out all required fields and accept the Terms of Service before continuing'
               : undefined
           }
-          tooltipSide="right"
+          tooltipSide='right'
         >
           Register
         </ButtonPrimary>

--- a/src/registration/privacy-policy/PrivacyPolicy.tsx
+++ b/src/registration/privacy-policy/PrivacyPolicy.tsx
@@ -8,14 +8,14 @@ import { docContainerStyles, headerStyles, mainStyles } from 'src/registration/l
 
 const PrivacyPolicy = () => {
   return (
-    <div role="main" style={mainStyles}>
-      <img src={scienceBackground} alt="" style={{ position: 'fixed', top: 0, left: 0, zIndex: -1 }} />
+    <div role='main' style={mainStyles}>
+      <img src={scienceBackground} alt='' style={{ position: 'fixed', top: 0, left: 0, zIndex: -1 }} />
       <div style={docContainerStyles}>
         <h1 style={headerStyles}>Terra Privacy Policy</h1>
         <RemoteMarkdown
           style={{ height: '60vh', overflowY: 'auto', lineHeight: 1.5, marginTop: '1rem', paddingRight: '1rem' }}
           getRemoteText={() => Ajax().TermsOfService.getPrivacyPolicyText()}
-          failureMessage="Could not get Privacy Policy"
+          failureMessage='Could not get Privacy Policy'
         />
         <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: '2rem' }}>
           <ButtonPrimary onClick={() => Nav.goToPath('root')}>Back to Terra</ButtonPrimary>

--- a/src/registration/terms-of-service/TermsOfServicePage.tsx
+++ b/src/registration/terms-of-service/TermsOfServicePage.tsx
@@ -75,8 +75,8 @@ export const TermsOfServicePage = () => {
     : spinnerOverlay;
 
   return (
-    <div role="main" style={mainStyles}>
-      <img src={scienceBackground} alt="" style={{ position: 'fixed', top: 0, left: 0, zIndex: -1 }} />
+    <div role='main' style={mainStyles}>
+      <img src={scienceBackground} alt='' style={{ position: 'fixed', top: 0, left: 0, zIndex: -1 }} />
       <div style={docContainerStyles}>
         <h1 style={headerStyles}>Terra Terms of Service</h1>
         {requiredToAcceptTermsOfService && (
@@ -85,7 +85,7 @@ export const TermsOfServicePage = () => {
         <RemoteMarkdown
           style={{ height: '60vh', overflowY: 'auto', lineHeight: 1.5, marginTop: '1rem', paddingRight: '1rem' }}
           getRemoteText={() => Ajax().TermsOfService.getTermsOfServiceText()}
-          failureMessage="Could not get Terms of Service"
+          failureMessage='Could not get Terms of Service'
         />
         {buttons}
       </div>

--- a/src/workspaces/NewWorkspaceModal/CloneEgressWarning.tsx
+++ b/src/workspaces/NewWorkspaceModal/CloneEgressWarning.tsx
@@ -102,7 +102,7 @@ export const CloneEgressWarning = (props: CloneEgressWarningProps): ReactNode =>
           <span> </span>
           To prevent charges, the new bucket location needs to stay in the same region as the original one.
           <span> </span>
-          <Link href="https://support.terra.bio/hc/en-us/articles/360058964552" {...Utils.newTabLinkProps}>
+          <Link href='https://support.terra.bio/hc/en-us/articles/360058964552' {...Utils.newTabLinkProps}>
             For more information please read the documentation.
             {icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })}
           </Link>

--- a/src/workspaces/WorkspacePolicies/WorkspacePolicies.tsx
+++ b/src/workspaces/WorkspacePolicies/WorkspacePolicies.tsx
@@ -45,14 +45,14 @@ export const WorkspacePolicies = (props: WorkspacePoliciesProps): ReactNode => {
           </div>
         </div>
         <div
-          role="list"
+          role='list'
           style={{ marginBlockStart: '0.5rem', marginBlockEnd: '0.5rem' }}
           aria-describedby={`list-title-${id}`}
         >
           {_.map((policyDescription) => {
             if (props.noCheckboxes) {
               return (
-                <div role="listitem" style={{ marginLeft: '1.25rem' }} key={policyDescription.shortDescription}>
+                <div role='listitem' style={{ marginLeft: '1.25rem' }} key={policyDescription.shortDescription}>
                   {icon('check', { size: 12, style: { marginRight: '0.25rem', color: colors.accent() } })}
                   {policyDescription.shortDescription}
                 </div>
@@ -62,7 +62,7 @@ export const WorkspacePolicies = (props: WorkspacePoliciesProps): ReactNode => {
             const labelId = `${policyDescription.shortDescription.replaceAll(' ', '-')}-${id}`;
             return (
               <div
-                role="listitem"
+                role='listitem'
                 style={{ marginLeft: '1.25rem', marginBottom: '0.5rem' }}
                 key={policyDescription.shortDescription}
               >
@@ -74,7 +74,7 @@ export const WorkspacePolicies = (props: WorkspacePoliciesProps): ReactNode => {
             );
           }, policyDescriptions)}
           {!!props.onTogglePhiTracking && (
-            <div role="listitem" style={{ marginLeft: '1.25rem' }} key={phiTrackingLabel}>
+            <div role='listitem' style={{ marginLeft: '1.25rem' }} key={phiTrackingLabel}>
               <LabeledCheckbox checked={phiTracking} aria-label={phiTrackingLabel} onChange={phiTrackingCallback}>
                 <span style={{ marginLeft: '0.25rem' }}>{phiTrackingLabel}</span>
               </LabeledCheckbox>

--- a/src/workspaces/dashboard/RightBoxSection.test.tsx
+++ b/src/workspaces/dashboard/RightBoxSection.test.tsx
@@ -28,7 +28,7 @@ describe('RightBoxSection', () => {
     // Arrange
     // Act
     await act(async () => {
-      render(<RightBoxSection title="Test Title" persistenceId="testId" workspace={workspace} />);
+      render(<RightBoxSection title='Test Title' persistenceId='testId' workspace={workspace} />);
     });
     // Assert
     expect(screen.getByText('Test Title')).toBeInTheDocument();
@@ -38,7 +38,7 @@ describe('RightBoxSection', () => {
     // Arrange
     // Act
     render(
-      <RightBoxSection title="Test Title" persistenceId="testId" workspace={workspace}>
+      <RightBoxSection title='Test Title' persistenceId='testId' workspace={workspace}>
         Panel Content
       </RightBoxSection>
     );
@@ -54,7 +54,7 @@ describe('RightBoxSection', () => {
     // Arrange
     // Act
     render(
-      <RightBoxSection title="Test Title" persistenceId="metricsId" workspace={workspace}>
+      <RightBoxSection title='Test Title' persistenceId='metricsId' workspace={workspace}>
         Panel Content
       </RightBoxSection>
     );


### PR DESCRIPTION
Based on https://github.com/DataBiosphere/terra-ui/pull/4801#discussion_r1594152044.

Since we use single quotes elsewhere, lets be consistent and use it in JSX too. This reduces the reformatting needed when converting existing code to JSX.

The core change here is in `.prettierrc.json`. Everything else was generated by running `yarn run lint`.