### PR TITLE
[UIE-170] Restore Storybook publishing on commits

### DIFF
--- a/.github/workflows/publish-storybook.yml
+++ b/.github/workflows/publish-storybook.yml
@@ -2,6 +2,8 @@ name: Publish Storybook to Chromatic
 
 on:
   push:
+    branches:
+      - '**'
     tags-ignore:
       - v0.*
 


### PR DESCRIPTION

### Jira Ticket: https://broadworkbench.atlassian.net/browse/UIE-170

In #4746 I disabled publishing Storybook versions on tags. However, this inadvertently stopped publishing on branch commits as well, as I did not see this note in the [documentation](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#using-filters-to-target-specific-branches-or-tags-for-push-events):

> If you define only tags/tags-ignore or only branches/branches-ignore, the workflow won't run for events affecting the undefined Git ref. If you define neither tags/tags-ignore or branches/branches-ignore, the workflow will run for events affecting either branches or tags. If you define both branches/branches-ignore and [paths/paths-ignore](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore), the workflow will only run when both filters are satisfied.

I am restoring push on commits by telling it to push on all branches.

Here is the version published on this PR's commit: https://www.chromatic.com/build?appId=65fc89c9335768720ff8605a&number=41

![image](https://github.com/DataBiosphere/terra-ui/assets/484484/b5277095-68b6-4740-a093-11ff8e6abe52)

