### PR TITLE
[AJ-1766] Improve types for persistent disk type inputs

### DIFF
--- a/src/analysis/modal-utils.ts
+++ b/src/analysis/modal-utils.ts
@@ -5,7 +5,7 @@ import {
   getImageUrlFromRuntime,
 } from 'src/analysis/utils/runtime-utils';
 import { getToolLabelFromCloudEnv } from 'src/analysis/utils/tool-utils';
-import { GoogleDiskType, PersistentDisk, SharedPdType } from 'src/libs/ajax/leonardo/models/disk-models';
+import { DiskType, GoogleDiskType, PersistentDisk } from 'src/libs/ajax/leonardo/models/disk-models';
 
 export interface IComputeConfig {
   masterMachineType: string;
@@ -29,7 +29,7 @@ export interface IComputeConfig {
 
   // Used by Azure disk select
   persistentDiskSize: number;
-  persistentDiskType: SharedPdType; // TODO: Switch to DiskType
+  persistentDiskType: DiskType;
 }
 
 export const buildExistingEnvironmentConfig = (

--- a/src/analysis/modals/ComputeModal/AzureComputeModal/AzurePersistentDiskSection.test.ts
+++ b/src/analysis/modals/ComputeModal/AzureComputeModal/AzurePersistentDiskSection.test.ts
@@ -9,10 +9,7 @@ import { defaultAzureDiskSize } from 'src/libs/azure-utils';
 import { renderWithAppContexts as render } from 'src/testing/test-utils';
 
 const defaultAzurePersistentDiskSectionProps: AzurePersistentDiskSectionProps = {
-  persistentDiskType: {
-    value: 'Standard_LRS',
-    label: 'Standard HDD',
-  },
+  persistentDiskType: 'Standard_LRS',
   persistentDiskSize: defaultAzureDiskSize,
   onChangePersistentDiskType: jest.fn(),
   onChangePersistentDiskSize: jest.fn(),
@@ -49,7 +46,7 @@ describe('AzurePersistentDiskSection', () => {
     // Act
     const diskTypeSelect = screen.getByLabelText('Disk Type');
     await userEvent.click(diskTypeSelect);
-    const standardHdd = screen.getByText('Standard HDD');
+    const standardHdd = screen.getByRole('option', { name: 'Standard HDD' });
     await userEvent.click(standardHdd);
     // Assert
     expect(defaultAzurePersistentDiskSectionProps.onChangePersistentDiskType).toHaveBeenCalledWith('Standard_LRS');

--- a/src/analysis/modals/ComputeModal/AzureComputeModal/AzurePersistentDiskSection.ts
+++ b/src/analysis/modals/ComputeModal/AzureComputeModal/AzurePersistentDiskSection.ts
@@ -1,23 +1,22 @@
-import React from 'react';
-import { div } from 'react-hyperscript-helpers';
+import { ReactNode } from 'react';
+import { div, h } from 'react-hyperscript-helpers';
 import { AboutPersistentDiskSection } from 'src/analysis/modals/ComputeModal/AboutPersistentDiskSection';
 import { AzurePersistentDiskSizeSelectInput } from 'src/analysis/modals/ComputeModal/AzureComputeModal/AzurePersistentDiskSizeSelectInput';
 import { PersistentDiskTypeInputContainer } from 'src/analysis/modals/ComputeModal/PersistentDiskTypeInputContainer';
 import { computeStyles } from 'src/analysis/modals/modalStyles';
-import { AzurePdType, AzurePersistentDiskOptions, SharedPdType } from 'src/libs/ajax/leonardo/models/disk-models';
+import { AzureDiskType, AzurePdType, AzurePersistentDiskOptions } from 'src/libs/ajax/leonardo/models/disk-models';
+import { defaultAzurePersistentDiskType } from 'src/libs/azure-utils';
 
 export interface AzurePersistentDiskSectionProps {
   persistentDiskExists: boolean;
   persistentDiskSize: number;
-  persistentDiskType: AzurePdType;
-  onChangePersistentDiskType: (type: SharedPdType) => void;
+  persistentDiskType: AzureDiskType;
+  onChangePersistentDiskType: (type: AzureDiskType | null) => void;
   onChangePersistentDiskSize: (size: number | null | undefined) => void;
   onClickAbout: () => void;
 }
 
-export const AzurePersistentDiskSection: React.FC<AzurePersistentDiskSectionProps> = (
-  props: AzurePersistentDiskSectionProps
-) => {
+export const AzurePersistentDiskSection = (props: AzurePersistentDiskSectionProps): ReactNode => {
   const {
     onClickAbout,
     persistentDiskType,
@@ -29,15 +28,15 @@ export const AzurePersistentDiskSection: React.FC<AzurePersistentDiskSectionProp
 
   const gridStyle = { display: 'grid', gridGap: '1rem', alignItems: 'center', marginTop: '1rem' };
   return div({ style: { ...computeStyles.whiteBoxContainer, marginTop: '1rem' } }, [
-    AboutPersistentDiskSection({ onClick: onClickAbout }),
+    h(AboutPersistentDiskSection, { onClick: onClickAbout }),
     div({ style: { ...gridStyle, gridGap: '1rem', gridTemplateColumns: '15rem 5.5rem', marginTop: '0.75rem' } }, [
-      PersistentDiskTypeInputContainer({
+      h(PersistentDiskTypeInputContainer<AzureDiskType, AzurePdType>, {
         persistentDiskExists,
         value: persistentDiskType,
-        onChange: (e) => onChangePersistentDiskType(e.value),
+        onChange: (e) => onChangePersistentDiskType(e ? e.value : defaultAzurePersistentDiskType),
         options: AzurePersistentDiskOptions,
       }),
-      AzurePersistentDiskSizeSelectInput({
+      h(AzurePersistentDiskSizeSelectInput, {
         persistentDiskSize,
         onChangePersistentDiskSize,
         persistentDiskExists,

--- a/src/analysis/modals/ComputeModal/GcpComputeModal/GcpPersistentDiskSection.ts
+++ b/src/analysis/modals/ComputeModal/GcpComputeModal/GcpPersistentDiskSection.ts
@@ -1,24 +1,24 @@
-import { div } from 'react-hyperscript-helpers';
+import { ReactNode } from 'react';
+import { div, h } from 'react-hyperscript-helpers';
 import { AboutPersistentDiskSection } from 'src/analysis/modals/ComputeModal/AboutPersistentDiskSection';
 import { GcpPersistentDiskSizeNumberInput } from 'src/analysis/modals/ComputeModal/GcpComputeModal/GcpPersistentDiskSizeNumberInput';
 import { PersistentDiskTypeInputContainer } from 'src/analysis/modals/ComputeModal/PersistentDiskTypeInputContainer';
 import { computeStyles } from 'src/analysis/modals/modalStyles';
-import { GcpPersistentDiskOptions, SharedPdType } from 'src/libs/ajax/leonardo/models/disk-models';
+import { defaultPersistentDiskType } from 'src/analysis/utils/disk-utils';
+import { GcpPersistentDiskOptions, GoogleDiskType, GooglePdType } from 'src/libs/ajax/leonardo/models/disk-models';
 import { CloudProvider } from 'src/workspaces/utils';
 
 export interface GcpPersistentDiskSectionProps {
   persistentDiskExists: boolean;
   persistentDiskSize: number;
-  persistentDiskType: SharedPdType;
-  onChangePersistentDiskType: (type: SharedPdType) => void;
+  persistentDiskType: GooglePdType;
+  onChangePersistentDiskType: (type: GooglePdType) => void;
   onChangePersistentDiskSize: (size: number) => void;
   onClickAbout: () => void;
   cloudPlatform: CloudProvider;
 }
 
-export const GcpPersistentDiskSection: React.FC<GcpPersistentDiskSectionProps> = (
-  props: GcpPersistentDiskSectionProps
-) => {
+export const GcpPersistentDiskSection = (props: GcpPersistentDiskSectionProps): ReactNode => {
   const {
     onClickAbout,
     persistentDiskType,
@@ -30,15 +30,15 @@ export const GcpPersistentDiskSection: React.FC<GcpPersistentDiskSectionProps> =
 
   const gridStyle = { display: 'grid', gridGap: '1rem', alignItems: 'center', marginTop: '1rem' };
   return div({ style: { ...computeStyles.whiteBoxContainer, marginTop: '1rem' } }, [
-    AboutPersistentDiskSection({ onClick: onClickAbout }),
+    h(AboutPersistentDiskSection, { onClick: onClickAbout }),
     div({ style: { ...gridStyle, gridGap: '1rem', gridTemplateColumns: '15rem 5.5rem', marginTop: '0.75rem' } }, [
-      PersistentDiskTypeInputContainer({
+      h(PersistentDiskTypeInputContainer<GoogleDiskType, GooglePdType>, {
         persistentDiskExists,
         value: persistentDiskType.value,
-        onChange: (e) => onChangePersistentDiskType(e),
+        onChange: (e) => onChangePersistentDiskType(e || defaultPersistentDiskType),
         options: GcpPersistentDiskOptions,
       }),
-      GcpPersistentDiskSizeNumberInput({
+      h(GcpPersistentDiskSizeNumberInput, {
         persistentDiskSize,
         // GCP disk size may be updated after creation
         isDisabled: false,

--- a/src/analysis/modals/ComputeModal/PersistentDiskTypeInput.test.ts
+++ b/src/analysis/modals/ComputeModal/PersistentDiskTypeInput.test.ts
@@ -5,32 +5,23 @@ import {
   PersistentDiskTypeInput,
   PersistentDiskTypeInputProps,
 } from 'src/analysis/modals/ComputeModal/PersistentDiskTypeInput';
+import { GoogleDiskType, GooglePdType } from 'src/libs/ajax/leonardo/models/disk-models';
 import { renderWithAppContexts as render } from 'src/testing/test-utils';
 
-const defaultPersistentDiskTypeInputProps: PersistentDiskTypeInputProps = {
-  value: {
-    value: 'pd-standard',
-    label: 'Standard',
-    regionToPricesName: 'monthlyStandardDiskPrice',
-  },
+const defaultPersistentDiskTypeInputProps: PersistentDiskTypeInputProps<GoogleDiskType, GooglePdType> = {
+  value: 'pd-standard',
   onChange: jest.fn(),
   isDisabled: false,
   options: [
     {
-      value: {
-        value: 'pd-standard',
-        label: 'Standard',
-        regionToPricesName: 'monthlyStandardDiskPrice',
-      },
+      value: 'pd-standard',
       label: 'Standard',
+      regionToPricesName: 'monthlyStandardDiskPrice',
     },
     {
-      value: {
-        value: 'pd-balanced',
-        label: 'Balanced',
-        regionToPricesName: 'monthlyBalancedDiskPrice',
-      },
+      value: 'pd-balanced',
       label: 'Balanced',
+      regionToPricesName: 'monthlyBalancedDiskPrice',
     },
   ],
 };
@@ -38,7 +29,7 @@ const defaultPersistentDiskTypeInputProps: PersistentDiskTypeInputProps = {
 describe('PersistentDiskTypeInput', () => {
   it('should render with default value selected.', () => {
     // Arrange
-    render(h(PersistentDiskTypeInput, defaultPersistentDiskTypeInputProps));
+    render(h(PersistentDiskTypeInput<GoogleDiskType, GooglePdType>, defaultPersistentDiskTypeInputProps));
 
     // Assert
     screen.getByText('Standard');
@@ -47,7 +38,7 @@ describe('PersistentDiskTypeInput', () => {
   it('should call onChange when value is updated.', async () => {
     // Arrange
     const user = userEvent.setup();
-    render(h(PersistentDiskTypeInput, defaultPersistentDiskTypeInputProps));
+    render(h(PersistentDiskTypeInput<GoogleDiskType, GooglePdType>, defaultPersistentDiskTypeInputProps));
 
     // Act
     const diskTypeSelect = screen.getByLabelText('Disk Type');
@@ -57,19 +48,21 @@ describe('PersistentDiskTypeInput', () => {
 
     // Assert
     expect(screen.findByText('Balanced')).toBeTruthy();
-    expect(defaultPersistentDiskTypeInputProps.onChange).toBeCalledWith({
-      value: {
-        value: 'pd-balanced',
-        label: 'Balanced',
-        regionToPricesName: 'monthlyBalancedDiskPrice',
-      },
+    expect(defaultPersistentDiskTypeInputProps.onChange).toHaveBeenCalledWith({
+      value: 'pd-balanced',
       label: 'Balanced',
+      regionToPricesName: 'monthlyBalancedDiskPrice',
     });
   });
 
   it('should be disabled when isDisabled is true.', () => {
     // Arrange
-    render(h(PersistentDiskTypeInput, { ...defaultPersistentDiskTypeInputProps, isDisabled: true }));
+    render(
+      h(PersistentDiskTypeInput<GoogleDiskType, GooglePdType>, {
+        ...defaultPersistentDiskTypeInputProps,
+        isDisabled: true,
+      })
+    );
 
     // Act
     const diskTypeSelect = screen.getByLabelText('Disk Type');

--- a/src/analysis/modals/ComputeModal/PersistentDiskTypeInput.ts
+++ b/src/analysis/modals/ComputeModal/PersistentDiskTypeInput.ts
@@ -1,30 +1,30 @@
-import { useUniqueId } from '@terra-ui-packages/components';
-import React from 'react';
+import { Select, SelectProps, useUniqueId } from '@terra-ui-packages/components';
+import { ReactNode } from 'react';
 import { div, h, label } from 'react-hyperscript-helpers';
 import { IComputeConfig } from 'src/analysis/modal-utils';
 import { computeStyles } from 'src/analysis/modals/modalStyles';
-import { Select } from 'src/components/common';
-import { PdSelectOption, SharedPdType } from 'src/libs/ajax/leonardo/models/disk-models';
+import { DiskType } from 'src/libs/ajax/leonardo/models/disk-models';
 
-export interface PersistentDiskTypeInputProps {
-  value: SharedPdType;
-  onChange: (e: { value: SharedPdType; label: string | undefined } | null) => void;
-  isDisabled?: boolean;
-  options: PdSelectOption[];
+type PersistentDiskTypeSelectProps<
+  T extends IComputeConfig['persistentDiskType'],
+  Option extends { value: T; label: string }
+> = SelectProps<T, false, Option>;
+
+export interface PersistentDiskTypeInputProps<T extends DiskType, Option extends { value: T; label: string }>
+  extends Pick<PersistentDiskTypeSelectProps<T, Option>, 'isDisabled' | 'options' | 'value'> {
+  onChange: (selectedOption: Option | null) => void;
 }
 
-const PersistentDiskTypeSelect = Select as typeof Select<IComputeConfig['persistentDiskType']>;
-
-export const PersistentDiskTypeInput: React.FC<PersistentDiskTypeInputProps> = (
-  props: PersistentDiskTypeInputProps
-) => {
+export const PersistentDiskTypeInput = <T extends DiskType, Option extends { value: T; label: string }>(
+  props: PersistentDiskTypeInputProps<T, Option>
+): ReactNode => {
   const { value, onChange, isDisabled, options } = props;
   const persistentDiskId = useUniqueId();
 
   return h(div, [
     label({ htmlFor: persistentDiskId, style: computeStyles.label }, ['Disk Type']),
     div({ style: { marginTop: '0.5rem' } }, [
-      h(PersistentDiskTypeSelect, {
+      h(Select<T, false, Option>, {
         value,
         onChange: (e) => onChange(e),
         isDisabled,

--- a/src/analysis/modals/ComputeModal/PersistentDiskTypeInputContainer.ts
+++ b/src/analysis/modals/ComputeModal/PersistentDiskTypeInputContainer.ts
@@ -1,20 +1,23 @@
 import { TooltipTrigger } from '@terra-ui-packages/components';
+import { ReactNode } from 'react';
 import { h } from 'react-hyperscript-helpers';
-import { PersistentDiskTypeInput } from 'src/analysis/modals/ComputeModal/PersistentDiskTypeInput';
+import {
+  PersistentDiskTypeInput,
+  PersistentDiskTypeInputProps,
+} from 'src/analysis/modals/ComputeModal/PersistentDiskTypeInput';
+import { DiskType } from 'src/libs/ajax/leonardo/models/disk-models';
 
-export interface PersistentDiskTypeContainerProps {
+export interface PersistentDiskTypeContainerProps<T extends DiskType, Option extends { value: T; label: string }>
+  extends Pick<PersistentDiskTypeInputProps<T, Option>, 'options' | 'value' | 'onChange'> {
   persistentDiskExists: boolean;
-  value: any;
-  onChange: (e: any) => void;
-  options: any;
 }
 
 // TODO: Move into the AzurePersistentDiskInput component
 // Is there an easy way to remove the duplicate PersistentDiskTypeInputs while
 // keeping the correct functionality and appearance?
-export const PersistentDiskTypeInputContainer: React.FC<PersistentDiskTypeContainerProps> = (
-  props: PersistentDiskTypeContainerProps
-) => {
+export const PersistentDiskTypeInputContainer = <T extends DiskType, Option extends { value: T; label: string }>(
+  props: PersistentDiskTypeContainerProps<T, Option>
+): ReactNode => {
   const { persistentDiskExists, value, onChange, options } = props;
   return persistentDiskExists
     ? h(
@@ -28,7 +31,7 @@ export const PersistentDiskTypeInputContainer: React.FC<PersistentDiskTypeContai
           side: 'bottom',
         },
         [
-          h(PersistentDiskTypeInput, {
+          h(PersistentDiskTypeInput<T, Option>, {
             isDisabled: persistentDiskExists,
             onChange,
             options,
@@ -36,7 +39,7 @@ export const PersistentDiskTypeInputContainer: React.FC<PersistentDiskTypeContai
           }),
         ]
       )
-    : h(PersistentDiskTypeInput, {
+    : h(PersistentDiskTypeInput<T, Option>, {
         isDisabled: persistentDiskExists,
         onChange,
         options,


### PR DESCRIPTION
More prefactoring for [AJ-1766](https://broadworkbench.atlassian.net/browse/AJ-1766)...

Once I started looking at the persistent disk type inputs, I noticed a couple of issues:
- Some components were being called as render functions instead of components (`Component(props)` instead of `h(Component, props)`).
- Some types were incorrect: types specified a `Select` option `{ value: DiskType; label: string }` where a value (`DiskType`) was actually being passed.
- `any` in `PersistentDiskTypeInputContainer`'s props disconnected types in `PersistentDiskTypeInput` from types in `Azure/GcpPersistentDiskTypeSection`.
- Once some of those issues were fixed, there was no handling for the possibility of `Select`'s `onChange` callback being called with `null`. Practically, I don't think this actually happens, but `Select`'s types do indicate that it may be called with `null`.

This fixes all those issues. Except for properly rendering components and returning default values in case of null, this should be all type level and test changes.

[AJ-1766]: https://broadworkbench.atlassian.net/browse/AJ-1766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ