### PR TITLE
[UIE-171] Mark icon render function as deprecated

### DIFF
--- a/packages/components/src/Icon.tsx
+++ b/packages/components/src/Icon.tsx
@@ -25,7 +25,9 @@ export const Icon = (props: IconProps): ReactNode => {
 };
 
 /**
- * Renders an icon. Prefer the {@link Icon} component in JSX.
+ * Renders an icon.
+ *
+ * @deprecated Use the {@link Icon} component instead.
  *
  * @param icon - The icon to render.
  * @param props - Other props for the icon component.


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/UIE-171

Follow up to #4801 based on https://github.com/DataBiosphere/terra-ui/pull/4801#discussion_r1596016551.

Since we now have an `Icon` component, mark the `icon` render function as deprecated so that IDEs surface that information.