### PR TITLE
[IA-4962] timeout change

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,7 +182,7 @@ commands:
             JEST_JUNIT_OUTPUT_DIR: "<< parameters.log_dir >>/<< parameters.env >>/test-results/junit"
             SCREENSHOT_DIR: "<< parameters.log_dir >>/<< parameters.env >>/test-results/failure-screenshots"
             ENVIRONMENT: << parameters.env >>
-          no_output_timeout: 25m
+          no_output_timeout: 30m
           command: |
             mkdir -p ${SCREENSHOT_DIR}
             TESTS_TO_RUN=$(yarn run jest --listTests | sed "s|$(pwd)/||")

--- a/.circleci/wait-for-job-finish.sh
+++ b/.circleci/wait-for-job-finish.sh
@@ -9,18 +9,18 @@ set -eo pipefail
 counter=0
 
 # Wait up to 25 minutes for job to finish. A job can run on multiple nodes: parallelism > 1
-# while [ "$counter" -le 1500 ]; do
-#   # Find number of nodes in running
-#   job_detail=$(curl -s "https://circleci.com/api/v2/project/github/DataBiosphere/terra-ui/job/$CIRCLE_BUILD_NUM")
-#   job_running_nodes_count=$(echo "$job_detail" | jq -r '.parallel_runs[] | select(.status == "running") | select(.index != '"$CIRCLE_NODE_INDEX"')' | grep -c "running")
+while [ "$counter" -le 1500 ]; do
+  # Find number of nodes in running
+  job_detail=$(curl -s "https://circleci.com/api/v2/project/github/DataBiosphere/terra-ui/job/$CIRCLE_BUILD_NUM")
+  job_running_nodes_count=$(echo "$job_detail" | jq -r '.parallel_runs[] | select(.status == "running") | select(.index != '"$CIRCLE_NODE_INDEX"')' | grep -c "running")
 
-#   if [ "$job_running_nodes_count" -eq 0 ]; then
-#     exit 0
-#   fi
+  if [ "$job_running_nodes_count" -eq 0 ]; then
+    exit 0
+  fi
 
-#   sleep 10
-#   counter=$(($counter + 10))
-# done
+  sleep 10
+  counter=$(($counter + 10))
+done
 
 echo "Waited total $counter seconds"
 date

--- a/.circleci/wait-for-job-finish.sh
+++ b/.circleci/wait-for-job-finish.sh
@@ -9,18 +9,18 @@ set -eo pipefail
 counter=0
 
 # Wait up to 25 minutes for job to finish. A job can run on multiple nodes: parallelism > 1
-while [ "$counter" -le 1500 ]; do
-  # Find number of nodes in running
-  job_detail=$(curl -s "https://circleci.com/api/v2/project/github/DataBiosphere/terra-ui/job/$CIRCLE_BUILD_NUM")
-  job_running_nodes_count=$(echo "$job_detail" | jq -r '.parallel_runs[] | select(.status == "running") | select(.index != '"$CIRCLE_NODE_INDEX"')' | grep -c "running")
+# while [ "$counter" -le 1500 ]; do
+#   # Find number of nodes in running
+#   job_detail=$(curl -s "https://circleci.com/api/v2/project/github/DataBiosphere/terra-ui/job/$CIRCLE_BUILD_NUM")
+#   job_running_nodes_count=$(echo "$job_detail" | jq -r '.parallel_runs[] | select(.status == "running") | select(.index != '"$CIRCLE_NODE_INDEX"')' | grep -c "running")
 
-  if [ "$job_running_nodes_count" -eq 0 ]; then
-    exit 0
-  fi
+#   if [ "$job_running_nodes_count" -eq 0 ]; then
+#     exit 0
+#   fi
 
-  sleep 10
-  counter=$(($counter + 10))
-done
+#   sleep 10
+#   counter=$(($counter + 10))
+# done
 
 echo "Waited total $counter seconds"
 date

--- a/.circleci/wait-for-job-finish.sh
+++ b/.circleci/wait-for-job-finish.sh
@@ -3,7 +3,7 @@
 # Exit script if you try to use an uninitialized variable.
 set -o nounset
 
-# Use the error status of the first failure, rather than that of the last item in a pipeline.
+# Use the error status of the first failure, rather than that of the last item in a pipeline. Also fail explicitly on any exit code.
 set -eo pipefail
 
 counter=0

--- a/.circleci/wait-for-job-finish.sh
+++ b/.circleci/wait-for-job-finish.sh
@@ -4,7 +4,7 @@
 set -o nounset
 
 # Use the error status of the first failure, rather than that of the last item in a pipeline.
-set -o pipefail
+set -eo pipefail
 
 counter=0
 

--- a/integration-tests/tests/run-analysis-azure.ts
+++ b/integration-tests/tests/run-analysis-azure.ts
@@ -70,7 +70,7 @@ const testRunAnalysisAzure = _.flowRight(
   await findElement(page, clickable({ textContains: 'Creating' }));
 
   // Wait for env to finish creating, or break early on error
-  await findElement(page, clickable({ textContains: 'Running' }), { timeout: Millis.ofMinutes(20) });
+  await findElement(page, clickable({ textContains: 'Running' }), { timeout: Millis.ofMinutes(25) });
 
   // Here, we dismiss any errors or popups. Its common another areas of the application might throw an error or have pop-ups.
   // However, as long as we have a running runtime (which the previous section asserts), the pop-up is not relevant


### PR DESCRIPTION
Test 30min timeout.

Note that I know this isn't ideal, but it would seem it is actually taking this long. We are investigating deprecating DSVMs entirely in favor of using K8s apps (with a pre-created cluster) which should significantly speed this test up in the long term.