### PR TITLE
DRAFT [QA-TICKET] Slack test results notification fails to report failed E2E test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,11 +199,10 @@ commands:
           working_directory: integration-tests
           name: Slack notification on dev branch only
           command: |
-            if [ "$CIRCLE_NODE_INDEX" -eq 0 ] && [ "$CIRCLE_BRANCH" = "dev" ]; then
+            if [ "$CIRCLE_BRANCH" = "alex-ci-testing" ]; then
               bash ../.circleci/wait-for-job-finish.sh
               node --require ../.pnp.cjs ./slack/notify-circleci-test-results.js
             fi
-          no_output_timeout: 30m
           when: always
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,7 +199,7 @@ commands:
           working_directory: integration-tests
           name: Slack notification on dev branch only
           command: |
-            if [ "$CIRCLE_BRANCH" = "alex-ci-testing" ]; then
+            if [ "$CIRCLE_NODE_INDEX" -eq 0 ] && [ "$CIRCLE_BRANCH" = "alex-ci-testing" ]; then
               bash ../.circleci/wait-for-job-finish.sh
               node --require ../.pnp.cjs ./slack/notify-circleci-test-results.js
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -226,18 +226,7 @@ jobs:
             fi
       - run: yarn run build
       - run: yarn eslint --max-warnings=0 .
-      - run: yarn workspaces foreach --exclude terra-integration-tests run test --coverage --maxWorkers=2 --passWithNoTests
-      - store_artifacts:
-          path: test-report/index.html
-      - run: yarn check-types
-      - save_cache:
-          key: deps-{{ .Branch }}-{{ checksum ".pnp.cjs" }}
-          paths:
-            - .yarn/unplugged
-            - node_modules/.cache
       - run: tar -czf build.tgz .gcloudignore app.yaml build config
-      - store_artifacts:
-          path: build.tgz
       - persist_to_workspace:
           root: .
           paths:
@@ -291,10 +280,6 @@ workflows:
     jobs:
       - build
       - integration-tests-pr-staging:
-          <<: *filter-pr-branch
-          requires:
-            - build
-      - deploy-pr:
           <<: *filter-pr-branch
           requires:
             - build

--- a/.circleci/wait-for-job-finish.sh
+++ b/.circleci/wait-for-job-finish.sh
@@ -16,22 +16,24 @@ URL_BASE="https://circleci.com/api/v2/project/github/DataBiosphere/terra-ui"
 
 # Wait up to 30 minutes for job to finish. A job can run on multiple nodes: parallelism > 1
 while [ "$counter" -le 1800 ]; do
+  counter=$(($counter + 10))
+  sleep 10
+
   # Get job details
   job_detail=$(curl -s "$URL_BASE/job/$CIRCLE_BUILD_NUM")
 
   # Wait for all nodes with status==running excluding self node
   nodes=$(echo "$job_detail" | jq -r '.parallel_runs[]')
   running_nodes=$(echo "$nodes" | jq -r --arg IDX "$CIRCLE_NODE_INDEX" 'select(.status=="running") | select(.index|tostring!=$IDX)')
-  count=$(echo "$running_nodes" | grep -c -e "running" || test $? = 1;)
+  count=$(echo "$running_nodes" | length)
+
   if [ "$count" -eq 0 ]; then
       echo "Checking from NODE_INDEX #$CIRCLE_NODE_INDEX: Parallel running nodes have finished. Waited $counter seconds."
       echo "$running_nodes"
       exit 0
   fi
 
-  echo "Checking from NODE_INDEX #$CIRCLE_NODE_INDEX: Waiting for parallel running nodes to finish. Sleep 10 seconds."
-  sleep 10
-  counter=$(($counter + 10))
+  echo "Checking from NODE_INDEX #$CIRCLE_NODE_INDEX: Waiting for parallel running nodes to finish."
 done
 
 # Something is wrong. Log response for error troubleshooting

--- a/.circleci/wait-for-job-finish.sh
+++ b/.circleci/wait-for-job-finish.sh
@@ -29,7 +29,10 @@ while [ "$counter" -le 1800 ]; do
 
   if [ "$count" -eq 0 ]; then
       echo "Checking from NODE_INDEX #$CIRCLE_NODE_INDEX: Parallel running nodes have finished. Waited $counter seconds."
-      echo "$running_nodes"
+      echo "$nodes"
+
+      artifacts=$(curl -s "$URL_BASE/$CIRCLE_BUILD_NUM/artifacts")
+      echo "$artifacts"
       exit 0
   fi
 

--- a/.circleci/wait-for-job-finish.sh
+++ b/.circleci/wait-for-job-finish.sh
@@ -14,8 +14,8 @@ date
 counter=0
 URL_BASE="https://circleci.com/api/v2/project/github/DataBiosphere/terra-ui"
 
-# Wait up to 25 minutes for job to finish. A job can run on multiple nodes: parallelism > 1
-while [ "$counter" -le 1500 ]; do
+# Wait up to 30 minutes for job to finish. A job can run on multiple nodes: parallelism > 1
+while [ "$counter" -le 1800 ]; do
   # Get job details
   job_detail=$(curl -s "$URL_BASE/job/$CIRCLE_BUILD_NUM")
 
@@ -25,11 +25,11 @@ while [ "$counter" -le 1500 ]; do
   count=$(echo "$running_nodes" | grep -c -e "running" || test $? = 1;)
   if [ "$count" -eq 0 ]; then
       echo "Checking from NODE_INDEX #$CIRCLE_NODE_INDEX: Parallel running nodes have finished. Waited $counter seconds."
-      echo "$nodes"
+      echo "$running_nodes"
       exit 0
   fi
 
-  echo "Waiting for parallel running nodes to finish. Sleep 10 seconds."
+  echo "Checking from NODE_INDEX #$CIRCLE_NODE_INDEX: Waiting for parallel running nodes to finish. Sleep 10 seconds."
   sleep 10
   counter=$(($counter + 10))
 done

--- a/.circleci/wait-for-job-finish.sh
+++ b/.circleci/wait-for-job-finish.sh
@@ -6,26 +6,35 @@ set -o nounset
 # Use the error status of the first failure, rather than that of the last item in a pipeline. Also fail explicitly on any exit code.
 set -eo pipefail
 
+trap 's=$?; echo -e >&2 "\nError in $0:\nat line "$LINENO": $BASH_COMMAND"; exit $s' ERR
+
+echo "Starting wait-for-job-finish script"
+
+date
 counter=0
+URL_BASE="https://circleci.com/api/v2/project/github/DataBiosphere/terra-ui"
 
 # Wait up to 25 minutes for job to finish. A job can run on multiple nodes: parallelism > 1
 while [ "$counter" -le 1500 ]; do
-  # Find number of nodes in running
-  job_detail=$(curl -s "https://circleci.com/api/v2/project/github/DataBiosphere/terra-ui/job/$CIRCLE_BUILD_NUM")
-  job_running_nodes_count=$(echo "$job_detail" | jq -r '[.parallel_runs[] | select(.status == "running") | select(.index != '"$CIRCLE_NODE_INDEX"')] | length')
+  # Get job details
+  job_detail=$(curl -s "$URL_BASE/job/$CIRCLE_BUILD_NUM")
 
-  if [ "$job_running_nodes_count" -eq 0 ]; then
-    exit 0
+  # Wait for all nodes with status==running excluding self node
+  nodes=$(echo "$job_detail" | jq -r '.parallel_runs[]')
+  running_nodes=$(echo "$nodes" | jq -r --arg IDX "$CIRCLE_NODE_INDEX" 'select(.status=="running") | select(.index|tostring!=$IDX)')
+  count=$(echo "$running_nodes" | grep -c -e "running" || test $? = 1;)
+  if [ "$count" -eq 0 ]; then
+      echo "Checking from NODE_INDEX #$CIRCLE_NODE_INDEX: Parallel running nodes have finished. Waited $counter seconds."
+      echo "$nodes"
+      exit 0
   fi
 
+  echo "Waiting for parallel running nodes to finish. Sleep 10 seconds."
   sleep 10
   counter=$(($counter + 10))
 done
 
-echo "Waited total $counter seconds"
-date
-
 # Something is wrong. Log response for error troubleshooting
 curl -s "https://circleci.com/api/v2/project/github/DataBiosphere/terra-ui/job/$CIRCLE_BUILD_NUM" | jq -r '.'
-echo "ERROR: Exceeded maximum waiting time 25 minutes."
+echo "ERROR: Exceeded maximum wait time 25 minutes."
 exit 1

--- a/.circleci/wait-for-job-finish.sh
+++ b/.circleci/wait-for-job-finish.sh
@@ -25,7 +25,7 @@ while [ "$counter" -le 1800 ]; do
   # Wait for all nodes with status==running excluding self node
   nodes=$(echo "$job_detail" | jq -r '.parallel_runs[]')
   running_nodes=$(echo "$nodes" | jq -r --arg IDX "$CIRCLE_NODE_INDEX" 'select(.status=="running") | select(.index|tostring!=$IDX)')
-  count=$(echo "$running_nodes" | length)
+  count=$(echo "$running_nodes" | grep -c -e "running" || test $? = 1;)
 
   if [ "$count" -eq 0 ]; then
       echo "Checking from NODE_INDEX #$CIRCLE_NODE_INDEX: Parallel running nodes have finished. Waited $counter seconds."

--- a/integration-tests/slack/circleci-utils.js
+++ b/integration-tests/slack/circleci-utils.js
@@ -33,6 +33,8 @@ const fetchJobArtifacts = async ({ buildNum = process.env.CIRCLE_BUILD_NUM } = {
  * @returns {Array[string]}
  */
 const getFailedTestNames = (aggregatedResults) => {
+  console.log(`aggregatedResults.testResults: ${aggregatedResults.testResults}`);
+  console.log('**');
   return _.flow(
     _.filter((testResult) => testResult.numFailingTests > 0),
     _.map((testResult) => parse(testResult.testFilePath).name)
@@ -45,6 +47,7 @@ const getFailedTestNames = (aggregatedResults) => {
  */
 const getFailedTestNamesFromArtifacts = async () => {
   const urls = await fetchJobArtifacts();
+  console.log(`urls: ${urls}`);
   return _.flatten(
     await Promise.all(
       _.map(async (url) => {

--- a/integration-tests/slack/circleci-utils.js
+++ b/integration-tests/slack/circleci-utils.js
@@ -19,7 +19,10 @@ const fetchJobArtifacts = async ({ buildNum = process.env.CIRCLE_BUILD_NUM } = {
     // Because terra-ui is a public repository on GitHub, API token is not required. See: https://circleci.com/docs/oss#security
     const response = await fetch(`${apiUrlRoot}/${buildNum}/artifacts`);
     const { items } = await response.json();
-    const testSummaryArtifacts = _.filter(_.flow(_.get('path'), _.includes('tests-summary')), items);
+    const itm = JSON.stringify(items, null, 2);
+    console.log(`items: ${itm}`);
+    const testSummaryArtifacts = _.filter(_.flow(_.get('path'), _.includes('tests-summary-')), items);
+    console.log(`testSummaryArtifacts: ${testSummaryArtifacts}`);
     return _.map('url', testSummaryArtifacts);
   } catch (e) {
     console.error(`**  ERROR: Encountered error when getting CircleCI JOB_BUILD_NUM: ${buildNum} artifacts.`, e);

--- a/integration-tests/slack/circleci-utils.js
+++ b/integration-tests/slack/circleci-utils.js
@@ -18,9 +18,13 @@ const fetchJobArtifacts = async ({ buildNum = process.env.CIRCLE_BUILD_NUM } = {
   try {
     // Because terra-ui is a public repository on GitHub, API token is not required. See: https://circleci.com/docs/oss#security
     const response = await fetch(`${apiUrlRoot}/${buildNum}/artifacts`);
+    const resp = await response.json();
+    console.log(`response json: ${JSON.stringify(resp, null, 2)}`);
+
     const { items } = await response.json();
     const itm = JSON.stringify(items, null, 2);
     console.log(`items: ${itm}`);
+
     const testSummaryArtifacts = _.filter(_.flow(_.get('path'), _.includes('tests-summary-')), items);
     console.log(`testSummaryArtifacts: ${testSummaryArtifacts}`);
     return _.map('url', testSummaryArtifacts);

--- a/integration-tests/slack/notify-circleci-test-results.js
+++ b/integration-tests/slack/notify-circleci-test-results.js
@@ -1,6 +1,8 @@
 const _ = require('lodash/fp');
 const { getFailedTestNamesFromArtifacts } = require('./circleci-utils');
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const { getMessageBlockTemplate } = require('./message-templates');
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const { postMessage } = require('./post-message');
 const testsInfo = require('./slack-notify-channels.json');
 
@@ -8,6 +10,7 @@ const testsInfo = require('./slack-notify-channels.json');
  * Get array of Slack channel IDs for succeeded job notification
  * @returns {Array[string]}
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const getAllSlackChannelsForPassedJob = () => {
   return _.map('id', testsInfo.pass);
 };
@@ -31,6 +34,7 @@ const getAllSlackChannelsForFailedJob = () => {
  * @param {Array[string]} failedTests
  * @returns {Map<string, Array[string]>} A map object where key is channel_id, value is test_names array
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const getFailedTestsAndChannelIDs = (failedTests) => {
   const allChannelsAndTests = getAllSlackChannelsForFailedJob();
 

--- a/integration-tests/slack/notify-circleci-test-results.js
+++ b/integration-tests/slack/notify-circleci-test-results.js
@@ -53,7 +53,8 @@ const getFailedTestsAndChannelIDs = (failedTests) => {
 // Post CircleCI UI test report to Slack channels
 const notifyCircleCITestResults = async () => {
   const failedTestNames = await getFailedTestNamesFromArtifacts();
-
+  console.log(`failedTestNames: ${failedTestNames}`);
+  /*
   if (failedTestNames.length === 0) {
     // Slack notification: CircleCI job succeeded
     const channelIDs = getAllSlackChannelsForPassedJob();
@@ -70,7 +71,7 @@ const notifyCircleCITestResults = async () => {
     console.log(`Notifying channel ${channelId} of ${testNames.length} test failures (${testNames.join(', ')})`);
     const messageBlocks = getMessageBlockTemplate(testNames);
     await postMessage({ channel: channelId, blocks: messageBlocks });
-  }, _.toPairs(channelIDsAndNames));
+  }, _.toPairs(channelIDsAndNames)); */
 };
 
 (async () => {


### PR DESCRIPTION
**hypothesis**, need testing.

### Jira Ticket: https://broadworkbench.atlassian.net/browse/[Ticket #]

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
terra-ui integration tests Slack notification were not reporting failed tests in the notifications sometimes. Seeing in this [job](https://app.circleci.com/pipelines/github/DataBiosphere/terra-ui/23706/workflows/2e6c2649-332c-4b00-8c52-924760159770/jobs/80045) and [job](https://app.circleci.com/pipelines/github/DataBiosphere/terra-ui/23703/workflows/77698a11-ebe6-4fdc-9525-2fd0174b475d/jobs/80041).

### Why
I think it's a timing issue, occurs when the data update time in CircleCI varies. While CircleCI is in the middle of updating job data from remaining `CIRCLE_NODE_INDEX: 0` node, the execution of `notify-circleci-test-results.js` has prematurely gathered incomplete test results and finished slack notification.

either `test-summary-0.json` does't show failed test because it was the "final" or this file could be missing and not read at all.


### Testing strategy


- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
