### PR TITLE
UIE-165 error.ts decoupling pt2 followup

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -27,7 +27,7 @@
     "@fortawesome/free-regular-svg-icons": "^5.15.4",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
     "@fortawesome/react-fontawesome": "^0.1.15",
-    "@terra-ui-packages/core-utils": "^0.2.0",
+    "@terra-ui-packages/core-utils": "^0.3.0",
     "color": "^4.0.1",
     "lodash": "^4.17.21",
     "react-focus-lock": "^2.9.5",

--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terra-ui-packages/core-utils",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "scripts": {
     "build": "vite build --emptyOutDir",
     "dev": "vite build --mode=development --watch",

--- a/packages/core-utils/src/error-utils.test.ts
+++ b/packages/core-utils/src/error-utils.test.ts
@@ -1,0 +1,36 @@
+import { withErrorHandling, withErrorIgnoring } from './error-utils';
+
+describe('withErrorHandling', () => {
+  it('calls callback on error', async () => {
+    // Arrange
+    const willThrow = async () => {
+      throw new Error('BOOM!');
+    };
+    const callback = jest.fn();
+    const callMe = withErrorHandling(callback)(willThrow);
+
+    // Act
+    await callMe();
+
+    // Assert
+    expect(callback).toBeCalledTimes(1);
+    expect(callback).toBeCalledWith(new Error('BOOM!'));
+  });
+});
+
+describe('withErrorIgnoring', () => {
+  it('calls callback on error', async () => {
+    // Arrange
+    const willThrow = async () => {
+      throw new Error('BOOM!');
+    };
+    const callMe = withErrorIgnoring(willThrow);
+
+    // Act
+    await callMe();
+
+    // Assert
+    // Nothing should happen.
+    // if test gets here, all is well.
+  });
+});

--- a/packages/core-utils/src/error-utils.test.ts
+++ b/packages/core-utils/src/error-utils.test.ts
@@ -19,7 +19,7 @@ describe('withErrorHandling', () => {
 });
 
 describe('withErrorIgnoring', () => {
-  it('calls callback on error', async () => {
+  it('silences throw on error', async () => {
     // Arrange
     const willThrow = async () => {
       throw new Error('BOOM!');

--- a/packages/core-utils/src/error-utils.ts
+++ b/packages/core-utils/src/error-utils.ts
@@ -1,4 +1,4 @@
-import { AnyPromiseFn } from '@terra-ui-packages/core-utils';
+import { AnyPromiseFn } from './type-utils/general-types';
 
 export type ErrorCallback = (error: unknown) => void | Promise<void>;
 

--- a/packages/core-utils/src/index.ts
+++ b/packages/core-utils/src/index.ts
@@ -1,5 +1,6 @@
 export * from './format/date-format';
 export * from './format/number-format';
+export * from './error-utils';
 export * from './io-utils';
 export * from './logic-utils';
 export * from './nav/nav-utils';

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "@terra-ui-packages/components": "^0.0.6",
-    "@terra-ui-packages/core-utils": "^0.2.0",
+    "@terra-ui-packages/core-utils": "^0.3.0",
     "lodash": "^4.17.21"
   },
   "devDependencies": {

--- a/packages/notifications/src/index.ts
+++ b/packages/notifications/src/index.ts
@@ -1,3 +1,2 @@
-export * from './error';
 export * from './notifications-provider';
 export * from './useNotifications';

--- a/packages/notifications/src/notifications-provider.ts
+++ b/packages/notifications/src/notifications-provider.ts
@@ -1,6 +1,4 @@
-import { AnyPromiseFn } from '@terra-ui-packages/core-utils';
-
-import { withErrorHandling } from './error';
+import { AnyPromiseFn, withErrorHandling } from '@terra-ui-packages/core-utils';
 
 /**
  * Should return true of a given error should be ignored

--- a/src/analysis/Environments/Environments.ts
+++ b/src/analysis/Environments/Environments.ts
@@ -1,6 +1,12 @@
 import { PopupTrigger, TooltipTrigger, useModalHandler, useThemeFromContext } from '@terra-ui-packages/components';
-import { formatDatetime, KeyedEventHandler, Mutate, NavLinkProvider } from '@terra-ui-packages/core-utils';
-import { useNotificationsFromContext, withErrorIgnoring } from '@terra-ui-packages/notifications';
+import {
+  formatDatetime,
+  KeyedEventHandler,
+  Mutate,
+  NavLinkProvider,
+  withErrorIgnoring,
+} from '@terra-ui-packages/core-utils';
+import { useNotificationsFromContext } from '@terra-ui-packages/notifications';
 import _ from 'lodash/fp';
 import { Fragment, ReactNode, useEffect, useState } from 'react';
 import { div, h, h2, span, strong } from 'react-hyperscript-helpers';

--- a/src/libs/error.ts
+++ b/src/libs/error.ts
@@ -2,7 +2,7 @@ import { IgnoreErrorDecider, makeNotificationsProvider, Notifier } from '@terra-
 import { sessionTimedOutErrorMessage } from 'src/auth/auth-errors';
 import { notify } from 'src/libs/notifications';
 
-export { type ErrorCallback, withErrorHandling, withErrorIgnoring } from '@terra-ui-packages/notifications';
+export { type ErrorCallback, withErrorHandling, withErrorIgnoring } from '@terra-ui-packages/core-utils';
 
 export const ignoreSessionTimeout: IgnoreErrorDecider = (_title: string, obj?: unknown): boolean => {
   // Do not show an error notification when a session times out.

--- a/yarn.lock
+++ b/yarn.lock
@@ -4390,7 +4390,7 @@ __metadata:
     "@fortawesome/free-solid-svg-icons": ^5.15.4
     "@fortawesome/react-fontawesome": ^0.1.15
     "@terra-ui-packages/build-utils": ^1.0.0
-    "@terra-ui-packages/core-utils": ^0.2.0
+    "@terra-ui-packages/core-utils": ^0.3.0
     "@terra-ui-packages/test-utils": "*"
     "@testing-library/dom": ^9.3.1
     "@testing-library/react": ^14.0.0
@@ -4422,7 +4422,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@terra-ui-packages/core-utils@*, @terra-ui-packages/core-utils@^0.2.0, @terra-ui-packages/core-utils@workspace:packages/core-utils":
+"@terra-ui-packages/core-utils@*, @terra-ui-packages/core-utils@^0.3.0, @terra-ui-packages/core-utils@workspace:packages/core-utils":
   version: 0.0.0-use.local
   resolution: "@terra-ui-packages/core-utils@workspace:packages/core-utils"
   dependencies:
@@ -4444,7 +4444,7 @@ __metadata:
   dependencies:
     "@terra-ui-packages/build-utils": ^1.0.0
     "@terra-ui-packages/components": ^0.0.6
-    "@terra-ui-packages/core-utils": ^0.2.0
+    "@terra-ui-packages/core-utils": ^0.3.0
     "@terra-ui-packages/test-utils": ^0.0.4
     "@testing-library/dom": ^9.3.1
     "@testing-library/react": ^14.0.0


### PR DESCRIPTION
 - moved basic error utils not entangled with notifications to be in core utils package.
 - fixed references in Environments component, but kept rest of codebase going through src/libs/error.ts export proxy for now.

### Jira Ticket: https://broadworkbench.atlassian.net/browse/[Ticket #]

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
-

### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
