### PR TITLE
[UIE-180] Remove `setViewMode` from ComputeModal subcomponents

### DIFF
--- a/src/analysis/modals/ComputeModal/AboutPersistentDiskSection.test.ts
+++ b/src/analysis/modals/ComputeModal/AboutPersistentDiskSection.test.ts
@@ -20,7 +20,7 @@ describe('AboutPersistentDiskSection', () => {
     expect(screen.getByText('Learn more about persistent disks and where your disk is mounted.')).toBeTruthy();
   });
 
-  it('should call setViewMode when clicked', async () => {
+  it('should call onClick when clicked', async () => {
     // Arrange
     render(h(AboutPersistentDiskSection, defaultAboutPersistentDiskSectionProps));
     await userEvent.click(screen.getByText('Learn more about persistent disks and where your disk is mounted.'));

--- a/src/analysis/modals/ComputeModal/AboutPersistentDiskView.ts
+++ b/src/analysis/modals/ComputeModal/AboutPersistentDiskView.ts
@@ -1,9 +1,8 @@
+import { Icon, Link } from '@terra-ui-packages/components';
 import { ReactNode } from 'react';
 import { br, div, h, p } from 'react-hyperscript-helpers';
 import { computeStyles } from 'src/analysis/modals/modalStyles';
 import { getCurrentMountDirectory, RuntimeToolLabel } from 'src/analysis/utils/tool-utils';
-import { Link } from 'src/components/common';
-import { icon } from 'src/components/icons';
 import TitleBar from 'src/components/TitleBar';
 import * as Utils from 'src/libs/utils';
 
@@ -44,7 +43,7 @@ export const AboutPersistentDiskView = (props: PersistentDiskAboutProps): ReactN
       ]),
       h(Link, { href: 'https://support.terra.bio/hc/en-us/articles/360047318551', ...Utils.newTabLinkProps }, [
         'Learn more about persistent disks',
-        icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } }),
+        h(Icon, { icon: 'pop-out', size: 12, style: { marginLeft: '0.25rem' } }),
       ]),
     ]),
   ]);

--- a/src/analysis/modals/ComputeModal/AboutPersistentDiskView.ts
+++ b/src/analysis/modals/ComputeModal/AboutPersistentDiskView.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import { ReactNode } from 'react';
 import { br, div, h, p } from 'react-hyperscript-helpers';
 import { computeStyles } from 'src/analysis/modals/modalStyles';
 import { getCurrentMountDirectory, RuntimeToolLabel } from 'src/analysis/utils/tool-utils';
@@ -9,14 +9,13 @@ import * as Utils from 'src/libs/utils';
 
 export interface PersistentDiskAboutProps {
   titleId: string;
-  // TODO: Remove this and use the same type as the one in AzurePersistentDiskSection.ts
-  setViewMode: (viewMode: string | undefined) => void;
   tool: RuntimeToolLabel;
   onDismiss: () => void;
+  onPrevious: () => void;
 }
 
-export const AboutPersistentDiskView: React.FC<PersistentDiskAboutProps> = (props: PersistentDiskAboutProps) => {
-  const { titleId, setViewMode, tool, onDismiss } = props;
+export const AboutPersistentDiskView = (props: PersistentDiskAboutProps): ReactNode => {
+  const { titleId, tool, onDismiss, onPrevious } = props;
   return div({ style: computeStyles.drawerContent }, [
     h(TitleBar, {
       id: titleId,
@@ -25,7 +24,7 @@ export const AboutPersistentDiskView: React.FC<PersistentDiskAboutProps> = (prop
       titleChildren: [],
       hideCloseButton: true,
       onDismiss,
-      onPrevious: () => setViewMode(undefined),
+      onPrevious,
     }),
     div({ style: { lineHeight: 1.5 } }, [
       p([

--- a/src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeModal.js
+++ b/src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeModal.js
@@ -309,17 +309,17 @@ export const AzureComputeModalBase = ({
       [
         'deleteEnvironment',
         () =>
-          DeleteEnvironment({
+          h(DeleteEnvironment, {
             id: titleId,
             runtimeConfig: currentRuntimeDetails && currentRuntimeDetails.runtimeConfig,
             persistentDiskId: currentPersistentDiskDetails?.id,
             persistentDiskCostDisplay: Utils.formatUSD(getAzureDiskCostEstimate(computeConfig)),
             deleteDiskSelected,
             setDeleteDiskSelected,
-            setViewMode,
             renderActionButton,
             hideCloseButton: false,
             onDismiss,
+            onPrevious: () => setViewMode(undefined),
             toolLabel: currentRuntimeDetails && currentRuntimeDetails.labels.tool,
           }),
       ],

--- a/src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeModal.js
+++ b/src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeModal.js
@@ -305,7 +305,7 @@ export const AzureComputeModalBase = ({
   return h(Fragment, [
     Utils.switchCase(
       viewMode,
-      ['aboutPersistentDisk', () => AboutPersistentDiskView({ titleId, setViewMode, onDismiss, tool })],
+      ['aboutPersistentDisk', () => h(AboutPersistentDiskView, { titleId, tool, onDismiss, onPrevious: () => setViewMode(undefined) })],
       [
         'deleteEnvironment',
         () =>

--- a/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal.js
+++ b/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal.js
@@ -1715,7 +1715,7 @@ export const GcpComputeModalBase = ({
     Utils.switchCase(
       viewMode,
       ['packages', renderPackages],
-      ['aboutPersistentDisk', () => AboutPersistentDiskView({ titleId, setViewMode, onDismiss, tool })],
+      ['aboutPersistentDisk', () => h(AboutPersistentDiskView, { titleId, tool, onDismiss, onPrevious: () => setViewMode(undefined) })],
       ['sparkConsole', renderSparkConsole],
       ['customImageWarning', renderCustomImageWarning],
       ['environmentWarning', renderEnvironmentWarning],

--- a/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal.js
+++ b/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal.js
@@ -1724,7 +1724,7 @@ export const GcpComputeModalBase = ({
       [
         'deleteEnvironment',
         () =>
-          DeleteEnvironment({
+          h(DeleteEnvironment, {
             id: titleId,
             runtimeConfig: currentRuntime && currentRuntime.runtimeConfig,
             persistentDiskId: currentPersistentDiskDetails?.id,
@@ -1733,10 +1733,10 @@ export const GcpComputeModalBase = ({
               : 'N/A',
             deleteDiskSelected,
             setDeleteDiskSelected,
-            setViewMode,
             renderActionButton,
             hideCloseButton: false,
             onDismiss,
+            onPrevious: () => setViewMode(undefined),
             toolLabel: currentRuntime && currentRuntime.labels.tool,
           }),
       ],

--- a/src/analysis/modals/DeleteDiskChoices.test.ts
+++ b/src/analysis/modals/DeleteDiskChoices.test.ts
@@ -146,7 +146,6 @@ describe('DeleteEnvironment', () => {
     (toolLabel) => {
       // Arrange
       const setDeleteDiskSelected = jest.fn();
-      const setViewMode = jest.fn();
 
       // Act
       render(
@@ -154,11 +153,11 @@ describe('DeleteEnvironment', () => {
           id: 'not-relevant',
           deleteDiskSelected: false,
           setDeleteDiskSelected,
-          setViewMode,
           persistentDiskCostDisplay: formatUSD(1.01),
           renderActionButton,
           hideCloseButton: false,
           onDismiss: () => {},
+          onPrevious: () => {},
           toolLabel,
         })
       );
@@ -174,7 +173,6 @@ describe('DeleteEnvironment', () => {
   ])('Should properly render when provided no runtime but a disk', ({ disk, toolLabel }) => {
     // Arrange
     const setDeleteDiskSelected = jest.fn();
-    const setViewMode = jest.fn();
 
     // Act
     render(
@@ -184,10 +182,10 @@ describe('DeleteEnvironment', () => {
         persistentDiskId: disk.id,
         persistentDiskCostDisplay: formatUSD(1.01),
         setDeleteDiskSelected,
-        setViewMode,
         renderActionButton,
         hideCloseButton: false,
         onDismiss: () => {},
+        onPrevious: () => {},
         toolLabel,
       })
     );
@@ -200,7 +198,6 @@ describe('DeleteEnvironment', () => {
   it('Should properly render when provided Azure config', () => {
     // Arrange
     const setDeleteDiskSelected = jest.fn();
-    const setViewMode = jest.fn();
     const disk = getAzureDisk();
     const runtimeConfig = azureRuntime.runtimeConfig;
 
@@ -213,10 +210,10 @@ describe('DeleteEnvironment', () => {
         persistentDiskCostDisplay: formatUSD(1.01),
         deleteDiskSelected: false,
         setDeleteDiskSelected,
-        setViewMode,
         renderActionButton,
         hideCloseButton: false,
         onDismiss: () => {},
+        onPrevious: () => {},
         toolLabel: 'JupyterLab',
       })
     );
@@ -230,7 +227,6 @@ describe('DeleteEnvironment', () => {
     (toolLabel) => {
       // Arrange
       const setDeleteDiskSelected = jest.fn();
-      const setViewMode = jest.fn();
       const disk = getDisk();
       const runtimeConfig = getRuntimeConfig({ persistentDiskId: disk.id });
 
@@ -243,10 +239,10 @@ describe('DeleteEnvironment', () => {
           persistentDiskCostDisplay: formatUSD(1.01),
           deleteDiskSelected: false,
           setDeleteDiskSelected,
-          setViewMode,
           renderActionButton,
           hideCloseButton: false,
           onDismiss: () => {},
+          onPrevious: () => {},
           toolLabel,
         })
       );
@@ -260,7 +256,6 @@ describe('DeleteEnvironment', () => {
   it('Should properly render when provided a GCE config', () => {
     // Arrange
     const setDeleteDiskSelected = jest.fn();
-    const setViewMode = jest.fn();
     const disk = getDisk();
     const runtimeConfig = getRuntimeConfig();
 
@@ -273,10 +268,10 @@ describe('DeleteEnvironment', () => {
         persistentDiskCostDisplay: formatUSD(1.01),
         deleteDiskSelected: false,
         setDeleteDiskSelected,
-        setViewMode,
         renderActionButton,
         hideCloseButton: false,
         onDismiss: () => {},
+        onPrevious: () => {},
         toolLabel: 'RStudio',
       })
     );
@@ -290,7 +285,6 @@ describe('DeleteEnvironment', () => {
     (toolLabel) => {
       // Arrange
       const setDeleteDiskSelected = jest.fn();
-      const setViewMode = jest.fn();
       const disk = getDisk();
       const runtimeConfig = getRuntimeConfig({ persistentDiskId: disk.id });
       if ('persistentDiskId' in runtimeConfig) runtimeConfig.persistentDiskId = disk.id;
@@ -304,10 +298,10 @@ describe('DeleteEnvironment', () => {
           persistentDiskCostDisplay: formatUSD(2.0),
           deleteDiskSelected: false,
           setDeleteDiskSelected,
-          setViewMode,
           renderActionButton,
           hideCloseButton: false,
           onDismiss: () => {},
+          onPrevious: () => {},
           toolLabel,
         })
       );
@@ -323,7 +317,6 @@ describe('DeleteEnvironment', () => {
   it('Should properly render when provided Azure config that had matching PDID', () => {
     // Arrange
     const setDeleteDiskSelected = jest.fn();
-    const setViewMode = jest.fn();
     const disk = getAzureDisk();
     const runtimeConfig = azureRuntime.runtimeConfig;
     // this if statement is to satisfy typescript
@@ -338,10 +331,10 @@ describe('DeleteEnvironment', () => {
         persistentDiskCostDisplay: formatUSD(3.01),
         deleteDiskSelected: false,
         setDeleteDiskSelected,
-        setViewMode,
         renderActionButton,
         hideCloseButton: false,
         onDismiss: () => {},
+        onPrevious: () => {},
         toolLabel: 'JupyterLab',
       })
     );

--- a/src/analysis/modals/DeleteEnvironment.ts
+++ b/src/analysis/modals/DeleteEnvironment.ts
@@ -22,10 +22,10 @@ type DeleteEnvironmentProps = {
   persistentDiskCostDisplay: string;
   deleteDiskSelected: boolean;
   setDeleteDiskSelected: (p1: boolean) => void;
-  setViewMode: (value: React.SetStateAction<string | undefined>) => void;
   renderActionButton: () => React.ReactElement<any, any>;
   hideCloseButton: boolean;
   onDismiss: () => void;
+  onPrevious: () => void;
   toolLabel?: ToolLabel;
 };
 
@@ -36,10 +36,10 @@ export const DeleteEnvironment = ({
   persistentDiskCostDisplay,
   deleteDiskSelected,
   setDeleteDiskSelected,
-  setViewMode,
   renderActionButton,
   hideCloseButton,
   onDismiss,
+  onPrevious,
   toolLabel,
 }: DeleteEnvironmentProps) => {
   return div({ style: { ...computeStyles.drawerContent, ...computeStyles.warningView } }, [
@@ -51,7 +51,7 @@ export const DeleteEnvironment = ({
       onDismiss,
       titleChildren: [],
       onPrevious: () => {
-        setViewMode(undefined);
+        onPrevious();
         setDeleteDiskSelected(false);
       },
     }),

--- a/src/analysis/modals/DeleteEnvironment.ts
+++ b/src/analysis/modals/DeleteEnvironment.ts
@@ -1,4 +1,4 @@
-import { Fragment, ReactNode } from 'react';
+import { Fragment, ReactNode, useEffect } from 'react';
 import { div, h, p, span } from 'react-hyperscript-helpers';
 import { DeleteDiskChoices } from 'src/analysis/modals/DeleteDiskChoices';
 import { computeStyles } from 'src/analysis/modals/modalStyles';
@@ -43,6 +43,16 @@ export const DeleteEnvironment = (props: DeleteEnvironmentProps): ReactNode => {
     onPrevious,
     toolLabel,
   } = props;
+
+  /*
+   * If the application configuration/compute profile has been deleted, and the only
+   * piece remaining is the persistent disk, default to deleting the disk.
+   */
+  useEffect(() => {
+    if (!runtimeConfig && !!persistentDiskId && !deleteDiskSelected) {
+      setDeleteDiskSelected(true);
+    }
+  }, [runtimeConfig, persistentDiskId, deleteDiskSelected, setDeleteDiskSelected]);
 
   return div({ style: { ...computeStyles.drawerContent, ...computeStyles.warningView } }, [
     h(TitleBar, {
@@ -118,9 +128,6 @@ export const DeleteEnvironment = (props: DeleteEnvironmentProps): ReactNode => {
         [
           !runtimeConfig && !!persistentDiskId,
           () => {
-            if (!deleteDiskSelected) {
-              setDeleteDiskSelected(true);
-            }
             return h(Fragment, [
               h(
                 RadioBlock,

--- a/src/analysis/modals/DeleteEnvironment.ts
+++ b/src/analysis/modals/DeleteEnvironment.ts
@@ -29,19 +29,21 @@ type DeleteEnvironmentProps = {
   toolLabel?: ToolLabel;
 };
 
-export const DeleteEnvironment = ({
-  id,
-  runtimeConfig,
-  persistentDiskId,
-  persistentDiskCostDisplay,
-  deleteDiskSelected,
-  setDeleteDiskSelected,
-  renderActionButton,
-  hideCloseButton,
-  onDismiss,
-  onPrevious,
-  toolLabel,
-}: DeleteEnvironmentProps) => {
+export const DeleteEnvironment = (props: DeleteEnvironmentProps): ReactNode => {
+  const {
+    id,
+    runtimeConfig,
+    persistentDiskId,
+    persistentDiskCostDisplay,
+    deleteDiskSelected,
+    setDeleteDiskSelected,
+    renderActionButton,
+    hideCloseButton,
+    onDismiss,
+    onPrevious,
+    toolLabel,
+  } = props;
+
   return div({ style: { ...computeStyles.drawerContent, ...computeStyles.warningView } }, [
     h(TitleBar, {
       id,


### PR DESCRIPTION
Another small step towards converting `AzureComputeModal` to TypeScript...

Currently, `Azure/GcpComputeModal` passes `setViewMode` to two of its child components: `AboutPersistentDiskView` and `DeleteEnvironment`.

However, these components don't need to be concerned with the parent modal's `viewMode`. They only call `setViewMode(undefined)` to go back to the default view. Changing these components to take a more generic `onPrevious` callback instead of `setViewMode` simplifies type definitions when we try to add a type for the `viewMode` state.

It's also more conventional to have the parent update its state based on a callbacks from the child (the callback conventionally named `on...`) vs the parent passing the child a function that allows it to directly update the parent's state.

Along the way, fixed another issue with components being called as render functions (`Component(...)` instead of `h(Component, ...)`. And made a few other small changes to follow Terra UI conventions and use components from shared packages.