### PR TITLE
[UIE-76] Add external link component

### DIFF
--- a/packages/components/src/ExternalLink.test.tsx
+++ b/packages/components/src/ExternalLink.test.tsx
@@ -1,0 +1,41 @@
+import { screen } from '@testing-library/react';
+
+import { ExternalLink } from './ExternalLink';
+import { renderWithTheme as render } from './internal/test-utils';
+
+describe('ExternalLink', () => {
+  it('renders a link with target and rel attributes', () => {
+    // Act
+    render(<ExternalLink href='https://example.com'>Example</ExternalLink>);
+
+    // Assert
+    const anchor = screen.getByRole('link');
+    expect(anchor).toHaveAttribute('href', 'https://example.com');
+    expect(anchor).toHaveAttribute('target', '_blank');
+    expect(anchor).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('can include referrer', () => {
+    // Act
+    render(
+      <ExternalLink href='https://example.com' includeReferrer>
+        Example
+      </ExternalLink>
+    );
+
+    // Assert
+    const anchor = screen.getByRole('link');
+    expect(anchor).toHaveAttribute('href', 'https://example.com');
+    expect(anchor).toHaveAttribute('target', '_blank');
+    expect(anchor).toHaveAttribute('rel', 'noopener');
+  });
+
+  it('renders an icon', () => {
+    // Act
+    const { container } = render(<ExternalLink href='https://example.com'>Example</ExternalLink>);
+
+    // Assert
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('data-icon', 'pop-out');
+  });
+});

--- a/packages/components/src/ExternalLink.tsx
+++ b/packages/components/src/ExternalLink.tsx
@@ -1,0 +1,21 @@
+import { ReactNode } from 'react';
+
+import { Icon } from './Icon';
+import { Link, LinkProps } from './Link';
+
+export interface ExternalLinkProps extends LinkProps {
+  includeReferrer?: boolean;
+}
+
+export const ExternalLink = (props: ExternalLinkProps): ReactNode => {
+  const { children, includeReferrer, ...otherProps } = props;
+
+  const rel = `noopener${includeReferrer ? '' : ' noreferrer'}`;
+
+  return (
+    <Link rel={rel} target='_blank' {...otherProps}>
+      {children}
+      <Icon icon='pop-out' size={12} style={{ marginLeft: '0.25rem' }} />
+    </Link>
+  );
+};

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,6 +1,7 @@
 export * from './Clickable';
 export * from './DelayedRender';
 export * from './ErrorBoundary';
+export * from './ExternalLink';
 export * from './FocusTrap';
 export * from './Icon';
 export * from './InfoBox';

--- a/src/stories/packages/components/ExternalLink.stories.ts
+++ b/src/stories/packages/components/ExternalLink.stories.ts
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ExternalLink } from '@terra-ui-packages/components';
+
+const meta: Meta<typeof ExternalLink> = {
+  title: 'Packages/Components/ExternalLink',
+  component: ExternalLink,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    children: {
+      control: 'text',
+      description: 'link text',
+    },
+    href: {
+      control: 'text',
+      description: 'link URL',
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'disable the link',
+      table: {
+        defaultValue: { summary: 'false' },
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ExternalLink>;
+
+export const Primary: Story = {
+  args: {
+    children: 'Terra Support',
+    href: 'https://support.terra.bio',
+  },
+};


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/UIE-76

Links to pages outside of Terra are currently coded like:
```ts
<Link href={url} {...Utils.newTabLinkProps}>
  {text} <Icon icon="pop-out" size={12} style={{ marginLeft: ... }} />
</Link>
```

To simplify this common pattern, this adds an ExternalLink component to the components package. The former example can now be written as:
```ts
<ExternalLink href={url}>{text}</ExternalLink>
```

Story: https://65fc89c9335768720ff8605a-hhqsseohiz.chromatic.com/?path=/docs/packages-components-externallink--docs