### PR TITLE
[AJ-1850] Show spinner while downloading a TSV

### DIFF
--- a/src/workspace-data/Data.js
+++ b/src/workspace-data/Data.js
@@ -355,7 +355,9 @@ const DataTableActions = ({
                     downloadForm.current.submit();
                   } else if (dataProvider.features.supportsTsvAjaxDownload) {
                     // TODO: this overrides the filename specified by the WDS API. Is that ok?
-                    dataProvider.downloadTsv(signal, tableName).then((blob) => FileSaver.saveAs(blob, `${tableName}.tsv`));
+                    Utils.withBusyState(setLoading, dataProvider.downloadTsv)(signal, tableName).then((blob) =>
+                      FileSaver.saveAs(blob, `${tableName}.tsv`)
+                    );
                   }
                   Ajax().Metrics.captureEvent(Events.workspaceDataDownload, {
                     ...extractWorkspaceDetails(workspace.workspace),


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1850

Downloading a large TSV can take some time. During that time, there's no indication that anything is happening. This adds a spinner.

## Before

https://github.com/DataBiosphere/terra-ui/assets/1156625/d01d8fba-5d80-453f-ade8-14a55a907dc3

## After

https://github.com/DataBiosphere/terra-ui/assets/1156625/69b082f8-dfaa-4e9c-bac7-f1b4ff3241c0
