### PR TITLE
UIE-177 Move SupportRequestWrapper to page level

### DIFF
--- a/src/analysis/Environments/Environments.ts
+++ b/src/analysis/Environments/Environments.ts
@@ -26,7 +26,6 @@ import { AppToolLabel } from 'src/analysis/utils/tool-utils';
 import { Clickable, LabeledCheckbox, Link, spinnerOverlay } from 'src/components/common';
 import { icon } from 'src/components/icons';
 import { makeMenuIcon } from 'src/components/PopupTrigger';
-import SupportRequestWrapper from 'src/components/SupportRequest';
 import { SimpleFlexTable, Sortable } from 'src/components/table';
 import { App, isApp } from 'src/libs/ajax/leonardo/models/app-models';
 import { PersistentDisk } from 'src/libs/ajax/leonardo/models/disk-models';
@@ -36,7 +35,6 @@ import { LeoAppProvider } from 'src/libs/ajax/leonardo/providers/LeoAppProvider'
 import { LeoDiskProvider } from 'src/libs/ajax/leonardo/providers/LeoDiskProvider';
 import { LeoRuntimeProvider } from 'src/libs/ajax/leonardo/providers/LeoRuntimeProvider';
 import { useCancellation, useGetter } from 'src/libs/react-utils';
-import { contactUsActive } from 'src/libs/state';
 import { elements as styleElements } from 'src/libs/style';
 import { cond, DEFAULT as COND_DEFAULT, formatUSD, withBusyState } from 'src/libs/utils';
 import { UseWorkspaces, UseWorkspacesResult } from 'src/workspaces/common/state/useWorkspaces.models';
@@ -828,7 +826,6 @@ export const Environments = (props: EnvironmentsProps): ReactNode => {
           appProvider: leoAppData,
         }),
     ]),
-    contactUsActive.get() && h(SupportRequestWrapper),
     loading && spinnerOverlay,
   ]);
 };

--- a/src/pages/EnvironmentsPage/EnvironmentsPage.ts
+++ b/src/pages/EnvironmentsPage/EnvironmentsPage.ts
@@ -3,6 +3,7 @@ import { ReactNode } from 'react';
 import { h } from 'react-hyperscript-helpers';
 import { EnvironmentNavActions, Environments } from 'src/analysis/Environments/Environments';
 import FooterWrapper from 'src/components/FooterWrapper';
+import SupportRequestWrapper from 'src/components/SupportRequest';
 import TopBar from 'src/components/TopBar';
 import { leoAppProvider } from 'src/libs/ajax/leonardo/providers/LeoAppProvider';
 import { leoDiskProvider } from 'src/libs/ajax/leonardo/providers/LeoDiskProvider';
@@ -10,6 +11,7 @@ import { leoRuntimeProvider } from 'src/libs/ajax/leonardo/providers/LeoRuntimeP
 import { useMetricsEvent } from 'src/libs/ajax/metrics/useMetrics';
 import Events from 'src/libs/events';
 import { terraNavKey, TerraNavLinkProvider, terraNavLinkProvider } from 'src/libs/nav';
+import { contactUsActive } from 'src/libs/state';
 import { leoResourcePermissions } from 'src/pages/EnvironmentsPage/environmentsPermissions';
 import { useWorkspaces } from 'src/workspaces/common/state/useWorkspaces';
 
@@ -59,6 +61,7 @@ export const EnvironmentsPage = (): ReactNode => {
         }
       },
     }),
+    contactUsActive.get() && h(SupportRequestWrapper),
   ]);
 };
 

--- a/src/workflows-app/SubmissionConfig.test.js
+++ b/src/workflows-app/SubmissionConfig.test.js
@@ -1865,8 +1865,7 @@ describe('Submitting a run set', () => {
     const myPrimitiveRowCells = within(structRows[5]).getAllByRole('cell');
     within(myPrimitiveRowCells[1]).getByText('myPrimitive');
     const myPrimitiveInput = within(myPrimitiveRowCells[4]).getByDisplayValue('Fiesty');
-    await user.clear(myPrimitiveInput);
-    await user.type(myPrimitiveInput, 'Docile');
+    fireEvent.change(myPrimitiveInput, { target: { value: 'Docile' } });
     within(myPrimitiveRowCells[4]).getByDisplayValue('Docile');
 
     // ** ACT **
@@ -1888,8 +1887,7 @@ describe('Submitting a run set', () => {
     const selectOption = within(screen.getByLabelText('Options')).getByText('Type a Value');
     await user.click(selectOption);
     const myInnermostPrimitiveInput = within(myInnermostPrimitiveRowCells[4]).getByLabelText('Enter a value');
-    await user.clear(myInnermostPrimitiveInput);
-    await user.type(myInnermostPrimitiveInput, 'bar');
+    fireEvent.change(myInnermostPrimitiveInput, { target: { value: 'bar' } });
     within(myInnermostPrimitiveRowCells[4]).getByDisplayValue('bar');
 
     // ** ACT **
@@ -1990,7 +1988,7 @@ describe('Submitting a run set', () => {
         },
       })
     );
-  }, 10000);
+  });
 
   it('should call POST /run_sets endpoint with expected parameters after outputs are set to default', async () => {
     // ** ARRANGE **


### PR DESCRIPTION
 - Environments component usage of SupportReuestWrapper is unnecessary and adds a dependency for AoU code reuse. Move to EnvironmentsPage component level.
 - also fixed a slow running test in SubmissionConfig.test.js that was still using user.type instead of fireEvent.change

### Jira Ticket: https://broadworkbench.atlassian.net/browse/[Ticket #]

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
-

### Why
- Code sharing initiative, and test cleanup

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->
No functionality change

- [x] unit tests pass

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
