### PR TITLE
[TUIM-96] Fix wait-for-job-finish script

### DIFF
--- a/.circleci/wait-for-job-finish.sh
+++ b/.circleci/wait-for-job-finish.sh
@@ -12,7 +12,7 @@ counter=0
 while [ "$counter" -le 1500 ]; do
   # Find number of nodes in running
   job_detail=$(curl -s "https://circleci.com/api/v2/project/github/DataBiosphere/terra-ui/job/$CIRCLE_BUILD_NUM")
-  job_running_nodes_count=$(echo "$job_detail" | jq -r '.parallel_runs[] | select(.status == "running") | select(.index != '"$CIRCLE_NODE_INDEX"')' | grep -c "running")
+  job_running_nodes_count=$(echo "$job_detail" | jq -r '[.parallel_runs[] | select(.status == "running") | select(.index != '"$CIRCLE_NODE_INDEX"')] | length')
 
   if [ "$job_running_nodes_count" -eq 0 ]; then
     exit 0


### PR DESCRIPTION
#4831 added `set -e` to the wait-for-job-finish.sh script.

However, when all other parallel runners finish, `grep` finds no matches for "running" and returns a non-zero exit status:
https://github.com/DataBiosphere/terra-ui/blob/4fd128c50ba8f3173a49cc1faea8d7ad1207d87d/.circleci/wait-for-job-finish.sh#L15

With `set -e`, this causes the script to fail. This wasn't caught in the PR because the Slack notification step only runs on commits to the `dev` branch.

This uses `jq` to do the counting instead of `grep`, avoiding this problem.