### PR TITLE
[AJ-1843] Collect import request fixtures

### DIFF
--- a/src/import-data/ImportDataOverview.test.ts
+++ b/src/import-data/ImportDataOverview.test.ts
@@ -2,6 +2,7 @@ import { screen } from '@testing-library/react';
 import { h } from 'react-hyperscript-helpers';
 import { renderWithAppContexts as render } from 'src/testing/test-utils';
 
+import { anvilPfbImportRequests, genericPfbImportRequest } from './__fixtures__/import-request-fixtures';
 import { ImportRequest } from './import-types';
 import { ImportDataOverview, ImportDataOverviewProps } from './ImportDataOverview';
 
@@ -17,11 +18,11 @@ const renderImportDataOverview = (props: Partial<ImportDataOverviewProps> = {}):
 describe('ImportDataOverview', () => {
   it.each([
     {
-      importRequest: { type: 'pfb', url: new URL('https://service.prod.anvil.gi.ucsc.edu/path/to/file.pfb') },
+      importRequest: anvilPfbImportRequests[0],
       shouldShowProtectedDataWarning: true,
     },
     {
-      importRequest: { type: 'pfb', url: new URL('https://example.com/path/to/file.pfb') },
+      importRequest: genericPfbImportRequest,
       shouldShowProtectedDataWarning: false,
     },
   ] as { importRequest: ImportRequest; shouldShowProtectedDataWarning: boolean }[])(

--- a/src/import-data/__fixtures__/import-request-fixtures.ts
+++ b/src/import-data/__fixtures__/import-request-fixtures.ts
@@ -1,0 +1,85 @@
+import { Snapshot } from 'src/libs/ajax/DataRepo';
+
+import { PFBImportRequest, TDRSnapshotExportImportRequest, TDRSnapshotReferenceImportRequest } from '../import-types';
+
+/**
+ * TDR import requests
+ */
+
+interface SnapshotFixtureOptions {
+  cloudPlatform: 'azure' | 'gcp';
+  secureMonitoringEnabled?: boolean;
+}
+
+const getSnapshot = (options: SnapshotFixtureOptions): Snapshot => {
+  const { cloudPlatform, secureMonitoringEnabled = false } = options;
+  return {
+    id: '00001111-2222-3333-aaaa-bbbbccccdddd',
+    name: 'test-snapshot',
+    source: [
+      {
+        dataset: {
+          id: '00001111-2222-3333-aaaa-bbbbccccdddd',
+          name: 'test-dataset',
+          secureMonitoringEnabled,
+        },
+      },
+    ],
+    cloudPlatform,
+  };
+};
+
+export const azureTdrSnapshotImportRequest: TDRSnapshotExportImportRequest = {
+  type: 'tdr-snapshot-export',
+  manifestUrl: new URL('https://example.com/path/to/manifest.json'),
+  snapshot: getSnapshot({ cloudPlatform: 'azure' }),
+  syncPermissions: false,
+};
+
+export const gcpTdrSnapshotImportRequest: TDRSnapshotExportImportRequest = {
+  type: 'tdr-snapshot-export',
+  manifestUrl: new URL('https://example.com/path/to/manifest.json'),
+  snapshot: getSnapshot({ cloudPlatform: 'gcp' }),
+  syncPermissions: false,
+};
+
+export const gcpTdrSnapshotReferenceImportRequest: TDRSnapshotReferenceImportRequest = {
+  type: 'tdr-snapshot-reference',
+  snapshot: getSnapshot({ cloudPlatform: 'gcp' }),
+};
+
+export const protectedGcpTdrSnapshotImportRequest: TDRSnapshotExportImportRequest = {
+  type: 'tdr-snapshot-export',
+  manifestUrl: new URL('https://example.com/path/to/manifest.json'),
+  snapshot: getSnapshot({ cloudPlatform: 'gcp', secureMonitoringEnabled: true }),
+  syncPermissions: false,
+};
+
+export const protectedGcpTdrSnapshotReferenceImportRequest: TDRSnapshotReferenceImportRequest = {
+  type: 'tdr-snapshot-reference',
+  snapshot: getSnapshot({ cloudPlatform: 'gcp', secureMonitoringEnabled: true }),
+};
+
+/**
+ * PFB import requests
+ */
+
+export const anvilPfbImportRequests: PFBImportRequest[] = [
+  // AnVIL production
+  { type: 'pfb', url: new URL('https://service.prod.anvil.gi.ucsc.edu/file.pfb') },
+  {
+    type: 'pfb',
+    url: new URL('https://s3.amazonaws.com/edu-ucsc-gi-platform-anvil-prod-storage-anvilprod.us-east-1/file.pfb'),
+  },
+  // AnVIL development
+  { type: 'pfb', url: new URL('https://service.anvil.gi.ucsc.edu/file.pfb') },
+];
+
+export const biodataCatalystPfbImportRequests: PFBImportRequest[] = [
+  { type: 'pfb', url: new URL('https://gen3.biodatacatalyst.nhlbi.nih.gov/file.pfb') },
+  { type: 'pfb', url: new URL('https://gen3-biodatacatalyst-nhlbi-nih-gov-pfb-export.s3.amazonaws.com/file.pfb') },
+  { type: 'pfb', url: new URL('https://s3.amazonaws.com/gen3-biodatacatalyst-nhlbi-nih-gov-pfb-export/file.pfb') },
+  { type: 'pfb', url: new URL('https://gen3-theanvil-io-pfb-export.s3.amazonaws.com/file.pfb') },
+];
+
+export const genericPfbImportRequest: PFBImportRequest = { type: 'pfb', url: new URL('https://example.com/file.pfb') };

--- a/src/import-data/import-utils.feature-flag.test.ts
+++ b/src/import-data/import-utils.feature-flag.test.ts
@@ -1,3 +1,4 @@
+import { genericPfbImportRequest } from './__fixtures__/import-request-fixtures';
 import { ImportRequest } from './import-types';
 import { getCloudPlatformRequiredForImport } from './import-utils';
 
@@ -17,7 +18,7 @@ jest.mock(
 describe('getRequiredCloudPlatformForImport', () => {
   it('should respect the feature flag for PFB imports', async () => {
     // Arrange
-    const importRequest: ImportRequest = { type: 'pfb', url: new URL('https://example.com/path/to/file.pfb') };
+    const importRequest: ImportRequest = genericPfbImportRequest;
 
     // Act
     const cloudPlatform = getCloudPlatformRequiredForImport(importRequest);

--- a/src/import-data/import-utils.test.ts
+++ b/src/import-data/import-utils.test.ts
@@ -1,35 +1,26 @@
 import { makeAzureWorkspace, makeGoogleWorkspace } from 'src/testing/workspace-fixtures';
 import { CloudProvider, WorkspaceWrapper } from 'src/workspaces/utils';
 
+import {
+  azureTdrSnapshotImportRequest,
+  gcpTdrSnapshotImportRequest,
+  genericPfbImportRequest,
+} from './__fixtures__/import-request-fixtures';
 import { ImportRequest } from './import-types';
 import { canImportIntoWorkspace, getCloudPlatformRequiredForImport } from './import-utils';
 
 describe('getRequiredCloudPlatformForImport', () => {
   it.each([
     {
-      importRequest: { type: 'pfb', url: new URL('https://example.com/path/to/file.pfb') },
+      importRequest: genericPfbImportRequest,
       expectedCloudPlatform: 'GCP',
     },
     {
-      importRequest: {
-        type: 'tdr-snapshot-export',
-        manifestUrl: new URL('https://example.com/path/to/manifest.json'),
-        snapshot: {
-          id: '00001111-2222-3333-aaaa-bbbbccccdddd',
-          name: 'test-snapshot',
-          source: [
-            {
-              dataset: {
-                id: '00001111-2222-3333-aaaa-bbbbccccdddd',
-                name: 'test-dataset',
-                secureMonitoringEnabled: false,
-              },
-            },
-          ],
-          cloudPlatform: 'gcp',
-        },
-        syncPermissions: false,
-      },
+      importRequest: azureTdrSnapshotImportRequest,
+      expectedCloudPlatform: 'AZURE',
+    },
+    {
+      importRequest: gcpTdrSnapshotImportRequest,
       expectedCloudPlatform: 'GCP',
     },
   ] as {

--- a/src/import-data/protected-data-utils.test.ts
+++ b/src/import-data/protected-data-utils.test.ts
@@ -1,76 +1,30 @@
-import { Snapshot } from 'src/libs/ajax/DataRepo';
-
-import { ImportRequest, PFBImportRequest } from './import-types';
+import {
+  anvilPfbImportRequests,
+  biodataCatalystPfbImportRequests,
+  gcpTdrSnapshotImportRequest,
+  gcpTdrSnapshotReferenceImportRequest,
+  genericPfbImportRequest,
+  protectedGcpTdrSnapshotImportRequest,
+  protectedGcpTdrSnapshotReferenceImportRequest,
+} from './__fixtures__/import-request-fixtures';
+import { ImportRequest } from './import-types';
 import { getImportSource, isProtectedSource } from './protected-data-utils';
 
-const getSnapshot = (secureMonitoringEnabled: boolean): Snapshot => {
-  return {
-    id: '00001111-2222-3333-aaaa-bbbbccccdddd',
-    name: 'test-snapshot',
-    source: [
-      {
-        dataset: {
-          id: '00001111-2222-3333-aaaa-bbbbccccdddd',
-          name: 'test-dataset',
-          secureMonitoringEnabled,
-        },
-      },
-    ],
-    cloudPlatform: 'gcp',
-  };
-};
-
-const protectedAnvilImports: PFBImportRequest[] = [
-  // AnVIL production
-  { type: 'pfb', url: new URL('https://service.prod.anvil.gi.ucsc.edu/file.pfb') },
-  {
-    type: 'pfb',
-    url: new URL('https://s3.amazonaws.com/edu-ucsc-gi-platform-anvil-prod-storage-anvilprod.us-east-1/file.pfb'),
-  },
-];
-
-const nonAnvilExplorerUrls: PFBImportRequest[] = [
-  { type: 'pfb', url: new URL('https://example.com/file.pfb') },
-  { type: 'pfb', url: new URL('https://s3.amazonaws.com/gen3-biodatacatalyst-nhlbi-nih-gov-pfb-export/file.pfb') },
-  { type: 'pfb', url: new URL('https://gen3-theanvil-io-pfb-export.s3.amazonaws.com/file.pfb') },
-];
-
 const protectedImports: ImportRequest[] = [
-  // AnVIL production
-  ...protectedAnvilImports,
-  // AnVIL development
-  { type: 'pfb', url: new URL('https://service.anvil.gi.ucsc.edu/file.pfb') },
+  // AnVIL
+  ...anvilPfbImportRequests,
   // BioData Catalyst
-  { type: 'pfb', url: new URL('https://gen3.biodatacatalyst.nhlbi.nih.gov/file.pfb') },
-  { type: 'pfb', url: new URL('https://gen3-biodatacatalyst-nhlbi-nih-gov-pfb-export.s3.amazonaws.com/file.pfb') },
-  { type: 'pfb', url: new URL('https://s3.amazonaws.com/gen3-biodatacatalyst-nhlbi-nih-gov-pfb-export/file.pfb') },
-  { type: 'pfb', url: new URL('https://gen3-theanvil-io-pfb-export.s3.amazonaws.com/file.pfb') },
+  ...biodataCatalystPfbImportRequests,
   // Protected TDR snapshots
-  {
-    type: 'tdr-snapshot-export',
-    manifestUrl: new URL('https://example.com/path/to/manifest.json'),
-    snapshot: getSnapshot(true),
-    syncPermissions: false,
-  },
-  {
-    type: 'tdr-snapshot-reference',
-    snapshot: getSnapshot(true),
-  },
+  protectedGcpTdrSnapshotImportRequest,
+  protectedGcpTdrSnapshotReferenceImportRequest,
 ];
 
 const unprotectedImports: ImportRequest[] = [
-  { type: 'pfb', url: new URL('https://example.com/file.pfb') },
-  { type: 'entities', url: new URL('https://service.prod.anvil.gi.ucsc.edu/file.json') },
-  {
-    type: 'tdr-snapshot-export',
-    manifestUrl: new URL('https://example.com/path/to/manifest.json'),
-    snapshot: getSnapshot(false),
-    syncPermissions: false,
-  },
-  {
-    type: 'tdr-snapshot-reference',
-    snapshot: getSnapshot(false),
-  },
+  genericPfbImportRequest,
+  { type: 'entities', url: new URL('https://example.com/file.json') },
+  gcpTdrSnapshotImportRequest,
+  gcpTdrSnapshotReferenceImportRequest,
 ];
 
 describe('isProtectedSource', () => {
@@ -84,11 +38,14 @@ describe('isProtectedSource', () => {
 });
 
 describe('getImportSource', () => {
-  it.each(protectedAnvilImports)('$url source should be categorized as anvil', (importRequest) => {
+  it.each(anvilPfbImportRequests)('$url source should be categorized as anvil', (importRequest) => {
     expect(getImportSource(importRequest.url)).toBe('anvil');
   });
 
-  it.each(nonAnvilExplorerUrls)('$url source should be empty', (importRequest) => {
-    expect(getImportSource(importRequest.url)).toBe('');
-  });
+  it.each([genericPfbImportRequest, ...biodataCatalystPfbImportRequests])(
+    '$url source should be empty',
+    (importRequest) => {
+      expect(getImportSource(importRequest.url)).toBe('');
+    }
+  );
 });

--- a/src/import-data/protected-data-utils.ts
+++ b/src/import-data/protected-data-utils.ts
@@ -75,8 +75,12 @@ export const isProtectedSource = (importRequest: ImportRequest): boolean => {
  */
 export const getImportSource = (url: URL): ImportSource => {
   const anvilSources = [
+    // AnVIL production
     'service.prod.anvil.gi.ucsc.edu',
     'edu-ucsc-gi-platform-anvil-prod-storage-anvilprod.us-east-1',
+    // AnVIL development
+    'service.anvil.gi.ucsc.edu',
+    'edu-ucsc-gi-platform-anvil-dev-storage-anvildev.us-east-1',
   ];
   if (anvilSources.some((path) => url.href.includes(path))) {
     return 'anvil';


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1843

To avoid continuing to duplicate fixtures for import request test cases, this collects fixtures into one module where they can be reused by multiple tests.