### PR TITLE
[AJ-1843] Refactor canImportIntoWorkspace

### DIFF
--- a/src/import-data/ImportDataDestination.ts
+++ b/src/import-data/ImportDataDestination.ts
@@ -22,7 +22,7 @@ import { WorkspaceInfo } from 'src/workspaces/utils';
 import { WorkspacePolicies } from 'src/workspaces/WorkspacePolicies/WorkspacePolicies';
 
 import { ImportRequest, TemplateWorkspaceInfo } from './import-types';
-import { canImportIntoWorkspace, getCloudPlatformRequiredForImport } from './import-utils';
+import { buildDestinationWorkspaceFilter, getCloudPlatformRequiredForImport } from './import-utils';
 import { isProtectedSource } from './protected-data-utils';
 
 const styles = {
@@ -108,7 +108,6 @@ export const ImportDataDestination = (props: ImportDataDestinationProps): ReactN
   } = props;
 
   const isProtectedData = isProtectedSource(importRequest);
-  const requiredCloudPlatform = getCloudPlatformRequiredForImport(importRequest);
 
   // Some import types are finished in a single request.
   // For most though, the import request starts a background task that takes time to complete.
@@ -186,16 +185,9 @@ export const ImportDataDestination = (props: ImportDataDestinationProps): ReactN
     ]);
   };
 
-  const workspacesToImportTo = workspaces.filter((workspace) => {
-    return canImportIntoWorkspace(
-      {
-        cloudPlatform: requiredCloudPlatform,
-        isProtectedData,
-        requiredAuthorizationDomain,
-      },
-      workspace
-    );
-  });
+  const workspacesToImportTo = workspaces.filter(
+    buildDestinationWorkspaceFilter(importRequest, { requiredAuthorizationDomain })
+  );
 
   // disable import into existing workspaces if data is marked as protected but no protected workspaces are available
   const disableExportIntoExisting = isProtectedData && workspacesToImportTo.length === 0;

--- a/src/import-data/import-utils.test.ts
+++ b/src/import-data/import-utils.test.ts
@@ -1,13 +1,14 @@
 import { makeAzureWorkspace, makeGoogleWorkspace } from 'src/testing/workspace-fixtures';
-import { CloudProvider, WorkspaceWrapper } from 'src/workspaces/utils';
+import { CloudProvider } from 'src/workspaces/utils';
 
 import {
   azureTdrSnapshotImportRequest,
   gcpTdrSnapshotImportRequest,
   genericPfbImportRequest,
+  protectedGcpTdrSnapshotImportRequest,
 } from './__fixtures__/import-request-fixtures';
 import { ImportRequest } from './import-types';
-import { canImportIntoWorkspace, getCloudPlatformRequiredForImport } from './import-utils';
+import { buildDestinationWorkspaceFilter, getCloudPlatformRequiredForImport } from './import-utils';
 
 describe('getRequiredCloudPlatformForImport', () => {
   it.each([
@@ -42,8 +43,7 @@ describe('canImportIntoWorkspace', () => {
     const writableWorkspace = makeAzureWorkspace({ accessLevel: 'WRITER' });
     const readOnlyWorkspace = makeAzureWorkspace({ accessLevel: 'READER' });
 
-    const canImportUnprotectedDataIntoWorkspace = (workspace: WorkspaceWrapper) =>
-      canImportIntoWorkspace({ isProtectedData: false }, workspace);
+    const canImportUnprotectedDataIntoWorkspace = buildDestinationWorkspaceFilter(azureTdrSnapshotImportRequest);
 
     // Act
     const canImportIntoOwnedWorkspace = canImportUnprotectedDataIntoWorkspace(ownedWorkspace);
@@ -66,8 +66,7 @@ describe('canImportIntoWorkspace', () => {
 
     const unprotectedGoogleWorkspace = makeGoogleWorkspace();
 
-    const canImportProtectedDataIntoWorkspace = (workspace: WorkspaceWrapper) =>
-      canImportIntoWorkspace({ isProtectedData: true }, workspace);
+    const canImportProtectedDataIntoWorkspace = buildDestinationWorkspaceFilter(protectedGcpTdrSnapshotImportRequest);
 
     // Act
     const canImportProtectedDataIntoUnprotectedAzureWorkspace =
@@ -93,10 +92,9 @@ describe('canImportIntoWorkspace', () => {
     });
 
     // Act
-    const canImportProtectedDataIntoProtectedPublicWorkspace = canImportIntoWorkspace(
-      { isProtectedData: true },
-      protectedPublicGoogleWorkspace
-    );
+    const canImportProtectedDataIntoProtectedPublicWorkspace = buildDestinationWorkspaceFilter(
+      protectedGcpTdrSnapshotImportRequest
+    )(protectedPublicGoogleWorkspace);
 
     // Assert
     expect(canImportProtectedDataIntoProtectedPublicWorkspace).toBe(false);
@@ -104,22 +102,20 @@ describe('canImportIntoWorkspace', () => {
 
   it('can require an authorization domain', () => {
     // Arrange
-    const requiredAuthDomain = 'test-ad';
+    const requiredAuthorizationDomain = 'test-ad';
 
     const workspaceWithRequiredAuthDomain = makeAzureWorkspace({
-      workspace: { authorizationDomain: [{ membersGroupName: requiredAuthDomain }] },
+      workspace: { authorizationDomain: [{ membersGroupName: requiredAuthorizationDomain }] },
     });
 
     const workspaceWithoutRequiredAuthDomain = makeAzureWorkspace();
 
-    const canImportDataWithRequiredAuthDomainIntoWorkspace = (workspace: WorkspaceWrapper) =>
-      canImportIntoWorkspace(
-        {
-          isProtectedData: false,
-          requiredAuthorizationDomain: requiredAuthDomain,
-        },
-        workspace
-      );
+    const canImportDataWithRequiredAuthDomainIntoWorkspace = buildDestinationWorkspaceFilter(
+      azureTdrSnapshotImportRequest,
+      {
+        requiredAuthorizationDomain,
+      }
+    );
 
     // Act
     const canImportDataWithRequiredAuthDomainIntoWorkspaceWithRequiredAuthDomain =
@@ -142,20 +138,15 @@ describe('canImportIntoWorkspace', () => {
 
     // Act
     const workspacesForAzureImports = workspaces
-      .filter((workspace) => canImportIntoWorkspace({ cloudPlatform: 'AZURE', isProtectedData: false }, workspace))
+      .filter(buildDestinationWorkspaceFilter(azureTdrSnapshotImportRequest))
       .map((workspace) => workspace.workspace.name);
 
     const workspacesForGoogleImports = workspaces
-      .filter((workspace) => canImportIntoWorkspace({ cloudPlatform: 'GCP', isProtectedData: false }, workspace))
-      .map((workspace) => workspace.workspace.name);
-
-    const workspacesForUndefinedPlatformImports = workspaces
-      .filter((workspace) => canImportIntoWorkspace({ isProtectedData: false }, workspace))
+      .filter(buildDestinationWorkspaceFilter(gcpTdrSnapshotImportRequest))
       .map((workspace) => workspace.workspace.name);
 
     // Assert
     expect(workspacesForAzureImports).toEqual(['azure-workspace']);
     expect(workspacesForGoogleImports).toEqual(['google-workspace']);
-    expect(workspacesForUndefinedPlatformImports).toEqual(['azure-workspace', 'google-workspace']);
   });
 });

--- a/src/import-data/import-utils.ts
+++ b/src/import-data/import-utils.ts
@@ -10,6 +10,7 @@ import {
 } from 'src/workspaces/utils';
 
 import { ImportRequest } from './import-types';
+import { isProtectedSource } from './protected-data-utils';
 
 export const getCloudPlatformRequiredForImport = (importRequest: ImportRequest): CloudProvider | undefined => {
   switch (importRequest.type) {
@@ -29,52 +30,52 @@ export const getCloudPlatformRequiredForImport = (importRequest: ImportRequest):
 };
 
 export type ImportOptions = {
-  /** Cloud platform required for the import. */
-  cloudPlatform?: CloudProvider;
-
-  /** Is the source data protected. */
-  isProtectedData: boolean;
-
-  /** Authorization domain required for the source data. */
+  /** Authorization domain requested for destination workspace. */
   requiredAuthorizationDomain?: string;
 };
 
 /**
- * Can the user can import data into a workspace?
+ * Returns a function to filter workspaces to available destinations for an import.
  *
+ * @param importRequest - Import request.
  * @param importOptions
- * @param importOptions.cloudPlatform - Cloud platform required for the import.
- * @param importOptions.isProtectedData - Is the source data protected.
- * @param importOptions.requiredAuthorizationDomain - Authorization domain required for the source data.
- * @param workspace - Candidate workspace.
+ * @param importOptions.requiredAuthorizationDomain - Require destination workspace has this authorization domain.
  */
-export const canImportIntoWorkspace = (importOptions: ImportOptions, workspace: WorkspaceWrapper): boolean => {
-  const { cloudPlatform, isProtectedData, requiredAuthorizationDomain } = importOptions;
+export const buildDestinationWorkspaceFilter = (
+  importRequest: ImportRequest,
+  importOptions: ImportOptions = {}
+): ((workspace: WorkspaceWrapper) => boolean) => {
+  const { requiredAuthorizationDomain } = importOptions;
 
-  // The user must be able to write to the workspace to import data.
-  if (!canWrite(workspace.accessLevel)) {
-    return false;
-  }
+  const isProtectedData = isProtectedSource(importRequest);
+  const requiredCloudPlatform = getCloudPlatformRequiredForImport(importRequest);
 
-  // If a cloud platform is required, the destination workspace must be on that cloud platform.
-  if (cloudPlatform && getCloudProviderFromWorkspace(workspace) !== cloudPlatform) {
-    return false;
-  }
+  return (workspace: WorkspaceWrapper): boolean => {
+    // The user must be able to write to the workspace to import data.
+    if (!canWrite(workspace.accessLevel)) {
+      return false;
+    }
 
-  // If the source data is protected, the destination workspace must also be protected and not public.
-  if (isProtectedData && !(isProtectedWorkspace(workspace) && !workspace.public)) {
-    return false;
-  }
+    // If a cloud platform is required, the destination workspace must be on that cloud platform.
+    if (requiredCloudPlatform && getCloudProviderFromWorkspace(workspace) !== requiredCloudPlatform) {
+      return false;
+    }
 
-  // If the import requires an authorization domain, the destination workspace must include that authorization domain.
-  if (
-    requiredAuthorizationDomain &&
-    !workspace.workspace.authorizationDomain.some(
-      ({ membersGroupName }) => membersGroupName === requiredAuthorizationDomain
-    )
-  ) {
-    return false;
-  }
+    // If the source data is protected, the destination workspace must also be protected and not public.
+    if (isProtectedData && !(isProtectedWorkspace(workspace) && !workspace.public)) {
+      return false;
+    }
 
-  return true;
+    // If an authorization domain was requested, the destination workspace must include that authorization domain.
+    if (
+      requiredAuthorizationDomain &&
+      !workspace.workspace.authorizationDomain.some(
+        ({ membersGroupName }) => membersGroupName === requiredAuthorizationDomain
+      )
+    ) {
+      return false;
+    }
+
+    return true;
+  };
 };


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1843

In preparation for more complex logic to determine whether a user can import a dataset into a workspace, this refactors `canImportIntoWorkspace` into `buildDestinationWorkspaceFilter`, which takes the full `ImportRequest` instead of a few derived properties (`cloudPlatform` and `isProtectedData`).

Suggest reviewing with whitespace ignored: https://github.com/DataBiosphere/terra-ui/pull/4849/files?w=1.