### PR TITLE
add notification type for no icon

### DIFF
--- a/packages/notifications/src/notifications-provider.ts
+++ b/packages/notifications/src/notifications-provider.ts
@@ -5,7 +5,7 @@ import { AnyPromiseFn, withErrorHandling } from '@terra-ui-packages/core-utils';
  */
 export type IgnoreErrorDecider = (title: string, obj?: unknown) => boolean;
 
-export type NotificationType = 'error' | 'warn' | 'info' | 'success' | 'welcome';
+export type NotificationType = 'error' | 'warn' | 'info' | 'success' | 'welcome' | 'custom';
 export interface NotificationOptions {
   /**
    * string, Error(unknown), or json object to be displayed in detail section

--- a/src/libs/notifications.test.tsx
+++ b/src/libs/notifications.test.tsx
@@ -102,6 +102,21 @@ describe('notify', () => {
     screen.getByLabelText('info notification');
   });
 
+  it('renders custom notifications without an icon', () => {
+    // Arrange
+    notify('custom', 'Test notification', {
+      id: 'test-notification',
+      message: 'This is only a test',
+    });
+
+    // Act
+    render(<div>{notificationContent}</div>);
+
+    // Assert
+    screen.getByText('This is only a test');
+    // the label is only for the icon, which is not present for custom notifications
+  });
+
   it('renders warning notification', () => {
     // Arrange
     notify('warn', 'Test notification', {

--- a/src/libs/notifications.ts
+++ b/src/libs/notifications.ts
@@ -97,11 +97,12 @@ const NotificationDisplay = ({ id }) => {
     ['error', () => [colors.danger, 'error notification']],
     [DEFAULT, () => [colors.accent, 'notification']]
   );
-  const iconType = switchCase<string, IconId>(
+  const iconType = switchCase<string, IconId | undefined>(
     type,
     ['success', () => 'success-standard'],
     ['warn', () => 'warning-standard'],
     ['error', () => 'error-standard'],
+    ['custom', () => undefined],
     [DEFAULT, () => 'info-circle-regular']
   );
   const labelId = useUniqueId();


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WOR-718

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->
Needed to support a notification message that doesn't have an icon for https://broadworkbench.atlassian.net/browse/WOR-718 (also [mockup here])(https://www.figma.com/design/UNmXglpW0Myoh5ylKTnj2b/Clone-Workspace?node-id=225-97).

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->
This adds a new notification type, so as to not disturb the behavior or any existing types.

How the notification looks in use:
<img width="551" alt="Screenshot 2024-05-22 at 9 35 09 AM" src="https://github.com/DataBiosphere/terra-ui/assets/1930315/d7f9ae48-6b77-46c0-9c40-0a9eaa94e7cd">

### What
Adds a new notification type

### Why
To provide a  notification type that does not include an icon alongside the text.

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->


- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
