### PR TITLE
[AJ-1766] Add support for limits in cloud environment configuration components

### DIFF
--- a/src/analysis/modals/ComputeModal/AutopauseConfiguration.test.ts
+++ b/src/analysis/modals/ComputeModal/AutopauseConfiguration.test.ts
@@ -44,6 +44,46 @@ describe('AutopauseConfiguration', () => {
     expect(autopauseThresholdInput).toBeDisabled();
   });
 
+  it('can disable the option to disable autopause', () => {
+    // Act
+    setup({ autopauseRequired: true });
+
+    // Assert
+    const enableAutopauseCheckbox = screen.getByRole('checkbox', { name: 'Enable autopause' });
+    expect(enableAutopauseCheckbox).toHaveAttribute('disabled');
+
+    const autopauseThresholdInput = screen.getByRole('spinbutton', {
+      name: 'Minutes of inactivity before autopausing',
+    });
+    expect(autopauseThresholdInput).not.toBeDisabled();
+  });
+
+  it('sets default min and max values', () => {
+    // Act
+    setup();
+
+    // Assert
+    const autopauseThresholdInput = screen.getByRole('spinbutton', {
+      name: 'Minutes of inactivity before autopausing',
+    });
+
+    expect(autopauseThresholdInput).toHaveAttribute('min', '10');
+    expect(autopauseThresholdInput).toHaveAttribute('max', '999');
+  });
+
+  it('allows configuring min and max values', () => {
+    // Act
+    setup({ minThreshold: 15, maxThreshold: 30 });
+
+    // Assert
+    const autopauseThresholdInput = screen.getByRole('spinbutton', {
+      name: 'Minutes of inactivity before autopausing',
+    });
+
+    expect(autopauseThresholdInput).toHaveAttribute('min', '15');
+    expect(autopauseThresholdInput).toHaveAttribute('max', '30');
+  });
+
   it('calls onChangeAutopauseThreshold when the threshold is changed', () => {
     // Arrange
     const onChangeAutopauseThreshold = jest.fn();

--- a/src/analysis/modals/ComputeModal/AutopauseConfiguration.ts
+++ b/src/analysis/modals/ComputeModal/AutopauseConfiguration.ts
@@ -8,14 +8,25 @@ import { NumberInput } from 'src/components/input';
 import * as Utils from 'src/libs/utils';
 
 export interface AutopauseConfigurationProps {
+  autopauseRequired?: boolean;
   autopauseThreshold: number;
   disabled?: boolean;
+  maxThreshold?: number;
+  minThreshold?: number;
   style?: CSSProperties;
   onChangeAutopauseThreshold: (autopauseThreshold: number) => void;
 }
 
 export const AutopauseConfiguration = (props: AutopauseConfigurationProps): ReactNode => {
-  const { autopauseThreshold, disabled = false, style, onChangeAutopauseThreshold } = props;
+  const {
+    autopauseRequired = false,
+    autopauseThreshold,
+    disabled = false,
+    maxThreshold = 999,
+    minThreshold = 10,
+    style,
+    onChangeAutopauseThreshold,
+  } = props;
 
   const id = useUniqueId();
 
@@ -25,7 +36,7 @@ export const AutopauseConfiguration = (props: AutopauseConfigurationProps): Reac
       {
         id: `${id}-enable`,
         checked: isAutopauseEnabled(autopauseThreshold),
-        disabled,
+        disabled: disabled || autopauseRequired,
         onChange: (v) => onChangeAutopauseThreshold(getAutopauseThreshold(v)),
       },
       [span({ style: { ...computeStyles.label } }, ['Enable autopause'])]
@@ -52,8 +63,8 @@ export const AutopauseConfiguration = (props: AutopauseConfigurationProps): Reac
       [
         h(NumberInput, {
           id: `${id}-threshold`,
-          min: 10,
-          max: 999,
+          min: minThreshold,
+          max: maxThreshold,
           isClearable: false,
           onlyInteger: true,
           disabled,

--- a/src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeModal.js
+++ b/src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeModal.js
@@ -238,6 +238,7 @@ export const AzureComputeModalBase = ({
         h(AzureApplicationConfigurationSection),
         div({ style: { ...computeStyles.whiteBoxContainer, marginTop: '1.5rem' } }, [
           h(AzureComputeProfileSelect, {
+            disabled: doesRuntimeExist(),
             machineType: computeConfig.machineType,
             style: { marginBottom: '1.5rem' },
             onChangeMachineType: (v) => updateComputeConfig('machineType', v),

--- a/src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeProfileSelect.test.ts
+++ b/src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeProfileSelect.test.ts
@@ -37,6 +37,27 @@ describe('AzureComputeProfileSelect', () => {
     expect(selectedOption).toEqual(expectedSelectedOption);
   });
 
+  it('can provide a limited set of options', async () => {
+    // Arrange
+    const machineTypes = ['Standard_DS2_v2', 'Standard_DS3_v2'];
+    const expectedOptions = machineTypes.map(getMachineTypeLabel);
+    const expectedSelectedOption = getMachineTypeLabel(defaultAzureMachineType);
+
+    const user = userEvent.setup();
+
+    // Act
+    setup({ machineTypeOptions: machineTypes });
+
+    // Assert
+    const select = new SelectHelper(screen.getByLabelText('Cloud compute profile'), user);
+
+    const options = await select.getOptions();
+    expect(options).toEqual(expectedOptions);
+
+    const [selectedOption] = await select.getSelectedOptions();
+    expect(selectedOption).toEqual(expectedSelectedOption);
+  });
+
   it('calls onChangeMachineType when a profile is selected', async () => {
     // Arrange
     const user = userEvent.setup();

--- a/src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeProfileSelect.ts
+++ b/src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeProfileSelect.ts
@@ -7,13 +7,21 @@ import colors from 'src/libs/colors';
 import * as Utils from 'src/libs/utils';
 
 export interface AzureComputeProfileSelectProps {
+  disabled?: boolean;
   machineType: string;
+  machineTypeOptions?: string[];
   style?: CSSProperties;
   onChangeMachineType: (machineType: string) => void;
 }
 
 export const AzureComputeProfileSelect = (props: AzureComputeProfileSelectProps): ReactNode => {
-  const { machineType, style, onChangeMachineType } = props;
+  const {
+    disabled = false,
+    machineType,
+    machineTypeOptions = Object.keys(azureMachineTypes),
+    style,
+    onChangeMachineType,
+  } = props;
 
   const id = useUniqueId();
 
@@ -41,6 +49,7 @@ export const AzureComputeProfileSelect = (props: AzureComputeProfileSelectProps)
     div({ style: { width: 400 } }, [
       h(Select<AzureComputeProfileSelectProps['machineType']>, {
         id,
+        isDisabled: disabled,
         isSearchable: false,
         isClearable: false,
         value: machineType,
@@ -49,7 +58,7 @@ export const AzureComputeProfileSelect = (props: AzureComputeProfileSelectProps)
             onChangeMachineType(selectedOption.value);
           }
         },
-        options: Object.keys(azureMachineTypes),
+        options: machineTypeOptions,
         getOptionLabel: ({ value }) => getMachineTypeLabel(value),
       }),
     ]),

--- a/src/analysis/modals/ComputeModal/AzureComputeModal/AzurePersistentDiskSection.ts
+++ b/src/analysis/modals/ComputeModal/AzureComputeModal/AzurePersistentDiskSection.ts
@@ -8,6 +8,7 @@ import { AzureDiskType, AzurePdType, AzurePersistentDiskOptions } from 'src/libs
 import { defaultAzurePersistentDiskType } from 'src/libs/azure-utils';
 
 export interface AzurePersistentDiskSectionProps {
+  maxPersistentDiskSize?: number;
   persistentDiskExists: boolean;
   persistentDiskSize: number;
   persistentDiskType: AzureDiskType;
@@ -18,6 +19,7 @@ export interface AzurePersistentDiskSectionProps {
 
 export const AzurePersistentDiskSection = (props: AzurePersistentDiskSectionProps): ReactNode => {
   const {
+    maxPersistentDiskSize,
     onClickAbout,
     persistentDiskType,
     persistentDiskSize,
@@ -37,6 +39,7 @@ export const AzurePersistentDiskSection = (props: AzurePersistentDiskSectionProp
         options: AzurePersistentDiskOptions,
       }),
       h(AzurePersistentDiskSizeSelectInput, {
+        maxPersistentDiskSize,
         persistentDiskSize,
         onChangePersistentDiskSize,
         persistentDiskExists,

--- a/src/analysis/modals/ComputeModal/AzureComputeModal/AzurePersistentDiskSizeSelectInput.test.ts
+++ b/src/analysis/modals/ComputeModal/AzureComputeModal/AzurePersistentDiskSizeSelectInput.test.ts
@@ -6,7 +6,7 @@ import {
   AzurePersistentDiskSizeSelectInputProps,
 } from 'src/analysis/modals/ComputeModal/AzureComputeModal/AzurePersistentDiskSizeSelectInput';
 import { defaultAzureDiskSize } from 'src/libs/azure-utils';
-import { renderWithAppContexts as render } from 'src/testing/test-utils';
+import { renderWithAppContexts as render, SelectHelper } from 'src/testing/test-utils';
 
 const defaultAzurePersistentDiskSizeSelectInputProps: AzurePersistentDiskSizeSelectInputProps = {
   persistentDiskSize: defaultAzureDiskSize,
@@ -60,5 +60,40 @@ describe('AzurePersistentDiskSizeSelectInput', () => {
 
     // Assert
     expect(screen.findByText('30')).toBeTruthy();
+  });
+
+  it('shows default disk size options', async () => {
+    // Arrange
+    const user = userEvent.setup();
+
+    // Act
+    render(h(AzurePersistentDiskSizeSelectInput, defaultAzurePersistentDiskSizeSelectInputProps));
+
+    // Assert
+    const input = screen.getByLabelText('Disk Size (GB)');
+    const select = new SelectHelper(input, user);
+
+    const options = await select.getOptions();
+    expect(options).toEqual(['32', '64', '128', '256', '512', '1024', '2048', '4095']);
+  });
+
+  it('allows limiting max disk size', async () => {
+    // Arrange
+    const user = userEvent.setup();
+
+    // Act
+    render(
+      h(AzurePersistentDiskSizeSelectInput, {
+        ...defaultAzurePersistentDiskSizeSelectInputProps,
+        maxPersistentDiskSize: 128,
+      })
+    );
+
+    // Assert
+    const input = screen.getByLabelText('Disk Size (GB)');
+    const select = new SelectHelper(input, user);
+
+    const options = await select.getOptions();
+    expect(options).toEqual(['32', '64', '128']);
   });
 });

--- a/src/analysis/modals/ComputeModal/AzureComputeModal/AzurePersistentDiskSizeSelectInput.ts
+++ b/src/analysis/modals/ComputeModal/AzureComputeModal/AzurePersistentDiskSizeSelectInput.ts
@@ -1,5 +1,5 @@
 import { useUniqueId } from '@terra-ui-packages/components';
-import React from 'react';
+import { ReactNode } from 'react';
 import { div, h, label } from 'react-hyperscript-helpers';
 import { IComputeConfig } from 'src/analysis/modal-utils';
 import { computeStyles } from 'src/analysis/modals/modalStyles';
@@ -8,6 +8,7 @@ import { azureDiskSizes } from 'src/libs/ajax/leonardo/models/disk-models';
 import { defaultAzureDiskSize } from 'src/libs/azure-utils';
 
 export interface AzurePersistentDiskSizeSelectInputProps {
+  maxPersistentDiskSize?: number;
   persistentDiskSize: number;
   onChangePersistentDiskSize: (e: number | null | undefined) => void;
   persistentDiskExists: boolean;
@@ -15,15 +16,16 @@ export interface AzurePersistentDiskSizeSelectInputProps {
 
 const AzurePersistentDiskSizeSelect = Select as typeof Select<IComputeConfig['persistentDiskSize']>;
 
-export const AzurePersistentDiskSizeSelectInput: React.FC<AzurePersistentDiskSizeSelectInputProps> = (
-  props: AzurePersistentDiskSizeSelectInputProps
-) => {
-  const { persistentDiskSize, onChangePersistentDiskSize, persistentDiskExists } = props;
+export const AzurePersistentDiskSizeSelectInput = (props: AzurePersistentDiskSizeSelectInputProps): ReactNode => {
+  const { maxPersistentDiskSize, persistentDiskSize, onChangePersistentDiskSize, persistentDiskExists } = props;
   const diskSizeId = useUniqueId();
 
   // If the user created a PD before the select implementation, we should still
   // show the correct disk size.
   let extendedAzureDiskSizes = azureDiskSizes;
+  if (maxPersistentDiskSize) {
+    extendedAzureDiskSizes = azureDiskSizes.filter((size) => size <= maxPersistentDiskSize);
+  }
   if (!azureDiskSizes.includes(persistentDiskSize)) {
     extendedAzureDiskSizes = azureDiskSizes.concat(persistentDiskSize);
   }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1766

For AnVIL Lite and other trial billing projects, we want to impose limits on the resources that a user can use (in order to limit the cost they can incur).

Part of this is limits on cloud environments. We want to...
- Limit available machine types
- Require auto pause
- Limit max size of persistent disk

This adds support for limits to the these sub-components of AzureComputeModal. A following PR will set these limits based on the current workspace's billing project.