### PR TITLE
[UIE-183] Rename build-utils export

### DIFF
--- a/packages/analysis/package.json
+++ b/packages/analysis/package.json
@@ -27,7 +27,7 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "@terra-ui-packages/build-utils": "^1.2.0",
+    "@terra-ui-packages/build-utils": "^2.0.0",
     "@terra-ui-packages/test-utils": "*",
     "@testing-library/dom": "^9.3.1",
     "@testing-library/react": "^14.0.0",

--- a/packages/analysis/vite.config.ts
+++ b/packages/analysis/vite.config.ts
@@ -1,3 +1,3 @@
-import { viteConfig as defineBaseViteConfig } from '@terra-ui-packages/build-utils';
+import { defineBaseViteConfig } from '@terra-ui-packages/build-utils';
 
 export default defineBaseViteConfig;

--- a/packages/build-utils/package.json
+++ b/packages/build-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terra-ui-packages/build-utils",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "type": "module",
   "module": "./lib/es/index.js",
   "main": "./lib/cjs/index.cjs",

--- a/packages/build-utils/src/index.ts
+++ b/packages/build-utils/src/index.ts
@@ -1,1 +1,1 @@
-export { defineBaseViteConfig as viteConfig } from './baseViteConfig';
+export { defineBaseViteConfig } from './baseViteConfig';

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -37,7 +37,7 @@
     "react-switch": "^6.1.0"
   },
   "devDependencies": {
-    "@terra-ui-packages/build-utils": "^1.2.0",
+    "@terra-ui-packages/build-utils": "^2.0.0",
     "@terra-ui-packages/test-utils": "*",
     "@testing-library/dom": "^9.3.1",
     "@testing-library/react": "^14.0.0",

--- a/packages/components/vite.config.ts
+++ b/packages/components/vite.config.ts
@@ -1,4 +1,4 @@
-import { viteConfig as defineBaseViteConfig } from '@terra-ui-packages/build-utils';
+import { defineBaseViteConfig } from '@terra-ui-packages/build-utils';
 import { defineConfig } from 'vite';
 import svgr from 'vite-plugin-svgr';
 

--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -27,7 +27,7 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "@terra-ui-packages/build-utils": "^1.2.0",
+    "@terra-ui-packages/build-utils": "^2.0.0",
     "@terra-ui-packages/test-utils": "*",
     "@types/jest": "^28.1.8",
     "@types/lodash": "^4.14.184",

--- a/packages/core-utils/vite.config.ts
+++ b/packages/core-utils/vite.config.ts
@@ -1,3 +1,3 @@
-import { viteConfig as defineBaseViteConfig } from '@terra-ui-packages/build-utils';
+import { defineBaseViteConfig } from '@terra-ui-packages/build-utils';
 
 export default defineBaseViteConfig;

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -28,7 +28,7 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "@terra-ui-packages/build-utils": "^1.2.0",
+    "@terra-ui-packages/build-utils": "^2.0.0",
     "@terra-ui-packages/test-utils": "^0.0.4",
     "@testing-library/dom": "^9.3.1",
     "@testing-library/react": "^14.0.0",

--- a/packages/notifications/vite.config.ts
+++ b/packages/notifications/vite.config.ts
@@ -1,3 +1,3 @@
-import { viteConfig as defineBaseViteConfig } from '@terra-ui-packages/build-utils';
+import { defineBaseViteConfig } from '@terra-ui-packages/build-utils';
 
 export default defineBaseViteConfig;

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@jest/types": "^27.5.1",
-    "@terra-ui-packages/build-utils": "^1.2.0",
+    "@terra-ui-packages/build-utils": "^2.0.0",
     "@testing-library/react": "^14.0.0",
     "@types/jest": "^28.1.8",
     "@types/node": "^20.6.2",

--- a/packages/test-utils/vite.config.ts
+++ b/packages/test-utils/vite.config.ts
@@ -1,4 +1,4 @@
-import { viteConfig as defineBaseViteConfig } from '@terra-ui-packages/build-utils';
+import { defineBaseViteConfig } from '@terra-ui-packages/build-utils';
 import { defineConfig } from 'vite';
 
 export default defineConfig((env) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4416,7 +4416,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@terra-ui-packages/analysis@workspace:packages/analysis"
   dependencies:
-    "@terra-ui-packages/build-utils": ^1.2.0
+    "@terra-ui-packages/build-utils": ^2.0.0
     "@terra-ui-packages/components": ^0.0.6
     "@terra-ui-packages/test-utils": "*"
     "@testing-library/dom": ^9.3.1
@@ -4438,7 +4438,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@terra-ui-packages/build-utils@^1.2.0, @terra-ui-packages/build-utils@workspace:packages/build-utils":
+"@terra-ui-packages/build-utils@^2.0.0, @terra-ui-packages/build-utils@workspace:packages/build-utils":
   version: 0.0.0-use.local
   resolution: "@terra-ui-packages/build-utils@workspace:packages/build-utils"
   dependencies:
@@ -4460,7 +4460,7 @@ __metadata:
     "@fortawesome/free-regular-svg-icons": ^5.15.4
     "@fortawesome/free-solid-svg-icons": ^5.15.4
     "@fortawesome/react-fontawesome": ^0.1.15
-    "@terra-ui-packages/build-utils": ^1.2.0
+    "@terra-ui-packages/build-utils": ^2.0.0
     "@terra-ui-packages/core-utils": ^0.3.0
     "@terra-ui-packages/test-utils": "*"
     "@testing-library/dom": ^9.3.1
@@ -4497,7 +4497,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@terra-ui-packages/core-utils@workspace:packages/core-utils"
   dependencies:
-    "@terra-ui-packages/build-utils": ^1.2.0
+    "@terra-ui-packages/build-utils": ^2.0.0
     "@terra-ui-packages/test-utils": "*"
     "@types/jest": ^28.1.8
     "@types/lodash": ^4.14.184
@@ -4513,7 +4513,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@terra-ui-packages/notifications@workspace:packages/notifications"
   dependencies:
-    "@terra-ui-packages/build-utils": ^1.2.0
+    "@terra-ui-packages/build-utils": ^2.0.0
     "@terra-ui-packages/components": ^0.0.6
     "@terra-ui-packages/core-utils": ^0.3.0
     "@terra-ui-packages/test-utils": ^0.0.4
@@ -4543,7 +4543,7 @@ __metadata:
     "@babel/core": ^7.16.0
     "@babel/template": ^7.22.15
     "@jest/types": ^27.5.1
-    "@terra-ui-packages/build-utils": ^1.2.0
+    "@terra-ui-packages/build-utils": ^2.0.0
     "@testing-library/jest-dom": ^5.17.0
     "@testing-library/react": ^14.0.0
     "@types/jest": ^28.1.8


### PR DESCRIPTION
`build-utils` has one export, which is currently named `viteConfig`.

This is a misleading name because it suggests that it's a Vite `UserConfig` configuration object. But it's not. It's a function that takes the environment (`ConfigEnv`) and returns the `UserConfig` configuration object.

This can be seen in `components`' `vite.config.ts`:
https://github.com/DataBiosphere/terra-ui/blob/73f69996dbd9bd0bc0b25e705e64b2c89e7c7e43/packages/components/vite.config.ts#L1-L11

This renames it to `defineBaseViteConfig` to clarify that it's a function.

#4825 had already aliased all imports to this name. This makes the breaking change in `build-utils`.