### PR TITLE
[UIE-184] Update publish packages script

### DIFF
--- a/scripts/publish-packages.sh
+++ b/scripts/publish-packages.sh
@@ -6,11 +6,11 @@ SCRIPTS_DIR="$(dirname "$0")"
 cd "${SCRIPTS_DIR}/.."
 
 # Build all packages.
-yarn build-packages
+echo "Building packages..."
+yarn build-packages >/dev/null
 
-cd "packages"
-for d in */ ; do
-    cd "$d"
+for d in $(yarn workspaces list --no-private --json | jq -r '.location'); do
+    pushd "$d" >/dev/null
 
     # Get the current package name and version from package.json.
     PACKAGE_NAME=$(node -p "require('./package.json').name")
@@ -40,5 +40,5 @@ for d in */ ; do
        echo "Version ${PACKAGE_VERSION} of ${PACKAGE_NAME} has already been published, so no new version has been published."
    fi
    echo " "
-   cd ..
+   popd >/dev/null
 done


### PR DESCRIPTION
Currently, the `publish-packages` script iterates through all subdirectories of `packages` to find packages to publish.

This updates it to use `yarn workspaces list --no-private` to find packages to publish. This allows us to have private packages (used only in Terra UI for organization, not published to Artifact Registry) in `packages` and also allows us to have packages in other directories or in nested directories under `packages`.

A couple of motivations for this:
- I want to add a private package with a script to generate a new package. Currently, I must put that outside of the `packages` directory to avoid this script trying to publish it.
- Organizing data client packages in a subdirectory has been mentioned. Currently, this script assumes that all packages are directly under `packages`.