### PR TITLE
[ID-1244] add NPS-specific events and properties to appcues metrics

### DIFF
--- a/src/libs/events.ts
+++ b/src/libs/events.ts
@@ -299,7 +299,8 @@ export const PageViewReporter = (): ReactNode => {
 };
 
 export const captureAppcuesEvent = (eventName: string, event: any) => {
-  // Only record "public-facing events" (and related properties) as documented by Appcues: https://docs.appcues.com/article/301-client-side-events-reference
+  // record different event properties for "public-facing events" and NPS events
+  // Appcues event properties are listed here: https://docs.appcues.com/article/301-client-side-events-reference
   const publicEvents = [
     'flow_started',
     'flow_completed',
@@ -312,6 +313,8 @@ export const captureAppcuesEvent = (eventName: string, event: any) => {
     'step_interacted',
     'form_submitted',
     'form_field_submitted',
+  ];
+  const npsEvents = [
     'nps_survey_started',
     'nps_score',
     'nps_feedback',
@@ -345,6 +348,20 @@ export const captureAppcuesEvent = (eventName: string, event: any) => {
       'appcues.stepId': event.stepId,
       'appcues.stepNumber': event.stepNumber,
       'appcues.stepType': event.stepType,
+      'appcues.timestamp': event.timestamp,
+    };
+    return Ajax().Metrics.captureEvent(eventsList.appcuesEvent, eventProps);
+  }
+  if (_.includes(eventName, npsEvents)) {
+    const eventProps = {
+      // the NPS survey related events have additional special properties
+      'appcues.flowId': event.flowId,
+      'appcues.flowName': event.flowName,
+      'appcues.flowType': event.flowType,
+      'appcues.flowVersion': event.flowVersion,
+      'appcues.id': event.id,
+      'appcues.name': event.name,
+      'appcues.sessionId': event.sessionId,
       'appcues.timestamp': event.timestamp,
       'appcues.npsScore': event.score,
       'appcues.npsFeedback': event.feedback,

--- a/src/libs/events.ts
+++ b/src/libs/events.ts
@@ -312,6 +312,11 @@ export const captureAppcuesEvent = (eventName: string, event: any) => {
     'step_interacted',
     'form_submitted',
     'form_field_submitted',
+    'nps_survey_started',
+    'nps_score',
+    'nps_feedback',
+    'nps_ask_me_later_selected_at',
+    'nps_clicked_update_nps_score',
   ];
   if (_.includes(eventName, publicEvents)) {
     const eventProps = {
@@ -341,6 +346,10 @@ export const captureAppcuesEvent = (eventName: string, event: any) => {
       'appcues.stepNumber': event.stepNumber,
       'appcues.stepType': event.stepType,
       'appcues.timestamp': event.timestamp,
+      'appcues.npsScore': event.score,
+      'appcues.npsFeedback': event.feedback,
+      'appcues.npsAskMeLaterSelectedAt': event.askMeLaterSelectedAt,
+      'appcues.npsClickedUpdateNpsScore': event.score,
     };
     return Ajax().Metrics.captureEvent(eventsList.appcuesEvent, eventProps);
   }


### PR DESCRIPTION
### Jira Ticket: [https://broadworkbench.atlassian.net/browse/[Ticket #]](https://broadworkbench.atlassian.net/browse/ID-1244)

## Summary of changes:
This will add NPS survey events to our existing appcues reporting. These are going to Bard which will allow us to see them in BigQuery and easily incorporate them into a dashboard for NPS metrics. 

If a property doesn't exist for a certain event it will come through as `null`. This is existing behavior so I haven't added any property filtering per event type. The below screenshots are just a sample of what some of the NPS data will look like in logs, it will also include all the default event properties including a timestamp and user id. 


<img width="307" alt="Screenshot 2024-05-23 at 3 02 13 PM" src="https://github.com/DataBiosphere/terra-ui/assets/19541449/62c4f798-74bd-4322-9520-647f1ea50c70">
<img width="307" alt="Screenshot 2024-05-23 at 2 57 08 PM" src="https://github.com/DataBiosphere/terra-ui/assets/19541449/d6cf5033-2c40-4ea1-8b83-ebbfabfa4d9c">
