### PR TITLE
[IA-4883] changes to tests and modules moved from other branch

### DIFF
--- a/src/auth/AuthContainer.test.tsx
+++ b/src/auth/AuthContainer.test.tsx
@@ -7,7 +7,7 @@ import { Metrics } from 'src/libs/ajax/Metrics';
 import { TermsOfService } from 'src/libs/ajax/TermsOfService';
 import { User } from 'src/libs/ajax/User';
 import { useRoute } from 'src/libs/nav';
-import { AuthState, authStore } from 'src/libs/state';
+import { AuthState, authStore, oidcStore } from 'src/libs/state';
 import { Disabled } from 'src/pages/Disabled';
 import SignIn from 'src/pages/SignIn';
 import { Register } from 'src/registration/Register';
@@ -23,19 +23,11 @@ jest.mock('react-notifications-component', () => {
   };
 });
 
-jest.mock('src/libs/state', () => {
-  const state = jest.requireActual('src/libs/state');
-  return {
-    ...state,
-    oidcStore: {
-      ...state.oidcStore,
-      get: jest.fn().mockReturnValue({
-        ...state.oidcStore.get,
-        userManager: { getUser: jest.fn() },
-      }),
-    },
-  };
-});
+jest.spyOn(oidcStore, 'get').mockImplementation(
+  jest.fn().mockReturnValue({
+    userManager: { getUser: jest.fn() },
+  })
+);
 
 jest.mock('src/libs/ajax');
 

--- a/src/auth/AuthContainer.test.tsx
+++ b/src/auth/AuthContainer.test.tsx
@@ -23,6 +23,20 @@ jest.mock('react-notifications-component', () => {
   };
 });
 
+jest.mock('src/libs/state', () => {
+  const state = jest.requireActual('src/libs/state');
+  return {
+    ...state,
+    oidcStore: {
+      ...state.oidcStore,
+      get: jest.fn().mockReturnValue({
+        ...state.oidcStore.get,
+        userManager: { getUser: jest.fn() },
+      }),
+    },
+  };
+});
+
 jest.mock('src/libs/ajax');
 
 type AuthExports = typeof import('src/auth/auth');

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -463,7 +463,7 @@ authStore.subscribe((state: AuthState) => {
 authStore.subscribe(
   withErrorReporting('Error checking groups for timeout status')(async (state: AuthState, oldState: AuthState) => {
     if (userCanNowUseTerra(oldState, state)) {
-      const isTimeoutEnabled = _.some({ groupName: 'session_timeout' }, Groups().list());
+      const isTimeoutEnabled = _.some({ groupName: 'session_timeout' }, await Groups().list());
       authStore.update((state) => ({ ...state, isTimeoutEnabled }));
     }
   })

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -9,9 +9,12 @@ import {
   OidcUser,
 } from 'src/auth/oidc-broker';
 import { cookiesAcceptedKey } from 'src/components/CookieWarning';
-import { Ajax } from 'src/libs/ajax';
 import { fetchOk } from 'src/libs/ajax/ajax-common';
-import { SamUserAttributes } from 'src/libs/ajax/User';
+import { ExternalCredentials } from 'src/libs/ajax/ExternalCredentials';
+import { Groups } from 'src/libs/ajax/Groups';
+import { Metrics } from 'src/libs/ajax/Metrics';
+import { TermsOfService } from 'src/libs/ajax/TermsOfService';
+import { SamUserAttributes, User } from 'src/libs/ajax/User';
 import { withErrorIgnoring, withErrorReporting } from 'src/libs/error';
 import Events, { captureAppcuesEvent, MetricsEventName } from 'src/libs/events';
 import * as Nav from 'src/libs/nav';
@@ -50,7 +53,7 @@ export const getAuthTokenFromLocalStorage = async (): Promise<string | undefined
 };
 
 export const sendRetryMetric = () => {
-  Ajax().Metrics.captureEvent(Events.user.authToken.load.retry, {});
+  Metrics().captureEvent(Events.user.authToken.load.retry, {});
 };
 
 export const signIn = async (includeBillingScope = false): Promise<OidcUser> => {
@@ -71,13 +74,13 @@ export const signIn = async (includeBillingScope = false): Promise<OidcUser> => 
       sessionId,
       sessionStartTime,
     }));
-    Ajax().Metrics.captureEvent(Events.user.login.success, {
+    Metrics().captureEvent(Events.user.login.success, {
       sessionStartTime: Utils.makeCompleteDate(sessionStartTime),
     });
     return authTokenState.oidcUser;
   }
   if (authTokenState.status === 'error') {
-    Ajax().Metrics.captureEvent(Events.user.login.error, {});
+    Metrics().captureEvent(Events.user.login.error, {});
   }
   throw new Error('Auth token failed to load when signing in');
 };
@@ -170,7 +173,7 @@ export const loadAuthToken = async (
     }));
     const { refreshTokenMetadata: currentRefreshTokenMetadata } = metricStore.get();
 
-    Ajax().Metrics.captureEvent(Events.user.authToken.load.success, {
+    Metrics().captureEvent(Events.user.authToken.load.success, {
       authProvider: oidcUser.profile.idp,
       ...getOldAuthTokenLabels(oldAuthTokenMetadata),
       authTokenCreatedAt: getTimestampMetricLabel(authTokenCreatedAt),
@@ -182,7 +185,7 @@ export const loadAuthToken = async (
       jwtExpiresAt: getTimestampMetricLabel(jwtExpiresAt),
     });
   } else if (loadedAuthTokenState.status === 'error') {
-    Ajax().Metrics.captureEvent(Events.user.authToken.load.error, {
+    Metrics().captureEvent(Events.user.authToken.load.error, {
       // we could potentially log the reason, but I don't know if that data is safe to log
       ...getOldAuthTokenLabels(oldAuthTokenMetadata),
       refreshTokenId: oldRefreshTokenMetadata.id,
@@ -460,31 +463,31 @@ authStore.subscribe((state: AuthState) => {
 authStore.subscribe(
   withErrorReporting('Error checking groups for timeout status')(async (state: AuthState, oldState: AuthState) => {
     if (userCanNowUseTerra(oldState, state)) {
-      const isTimeoutEnabled = _.some({ groupName: 'session_timeout' }, await Ajax().Groups.list());
+      const isTimeoutEnabled = _.some({ groupName: 'session_timeout' }, Groups().list());
       authStore.update((state) => ({ ...state, isTimeoutEnabled }));
     }
   })
 );
 
 export const refreshTerraProfile = async () => {
-  const profile: TerraUserProfile = await Ajax().User.profile.get();
+  const profile: TerraUserProfile = await User().profile.get();
   userStore.update((state: TerraUserState) => ({ ...state, profile }));
 };
 
 export const refreshSamUserAttributes = async (): Promise<void> => {
-  const terraUserAttributes: SamUserAttributes = await Ajax().User.getUserAttributes();
+  const terraUserAttributes: SamUserAttributes = await User().getUserAttributes();
   userStore.update((state: TerraUserState) => ({ ...state, terraUserAttributes }));
 };
 
 export const loadTerraUser = async (): Promise<void> => {
   try {
     const signInStatus = 'userLoaded';
-    const getProfile = Ajax().User.profile.get();
-    const getAllowances = Ajax().User.getUserAllowances();
-    const getAttributes = Ajax().User.getUserAttributes();
-    const getTermsOfService = Ajax().TermsOfService.getUserTermsOfServiceDetails();
-    const getEnterpriseFeatures = Ajax().User.getEnterpriseFeatures();
-    const getSamUser = Ajax().User.getSamUserResponse();
+    const getProfile = User().profile.get();
+    const getAllowances = User().getUserAllowances();
+    const getAttributes = User().getUserAttributes();
+    const getTermsOfService = TermsOfService().getUserTermsOfServiceDetails();
+    const getEnterpriseFeatures = User().getEnterpriseFeatures();
+    const getSamUser = User().getSamUserResponse();
     const [profile, terraUserAllowances, terraUserAttributes, termsOfService, enterpriseFeatures, samUser] =
       await Promise.all([
         getProfile,
@@ -544,7 +547,7 @@ authStore.subscribe(
 authStore.subscribe(
   withErrorReporting('Error loading NIH account link status')(async (state: AuthState, oldState: AuthState) => {
     if (userCanNowUseTerra(oldState, state)) {
-      const nihStatus = await Ajax().User.getNihStatus();
+      const nihStatus = await User().getNihStatus();
       authStore.update((state: AuthState) => ({ ...state, nihStatus, nihStatusLoaded: true }));
     }
   })
@@ -553,7 +556,7 @@ authStore.subscribe(
 authStore.subscribe(
   withErrorIgnoring(async (state: AuthState, oldState: AuthState) => {
     if (userCanNowUseTerra(oldState, state)) {
-      await Ajax().Metrics.syncProfile();
+      await Metrics().syncProfile();
     }
   })
 );
@@ -563,7 +566,7 @@ authStore.subscribe(
     if (userCanNowUseTerra(oldState, state)) {
       const { anonymousId } = metricStore.get();
       if (anonymousId) {
-        return await Ajax().Metrics.identify(anonymousId);
+        return await Metrics().identify(anonymousId);
       }
     }
   })
@@ -574,7 +577,7 @@ authStore.subscribe(
     if (userCanNowUseTerra(oldState, state)) {
       await Promise.all(
         _.map(async (provider) => {
-          const status = await Ajax().ExternalCredentials(provider).getAccountLinkStatus();
+          const status = await ExternalCredentials()(provider).getAccountLinkStatus();
           authStore.update(_.set(['oAuth2AccountStatus', provider.key], status));
         }, allOAuth2Providers)
       );

--- a/src/auth/login.test.ts
+++ b/src/auth/login.test.ts
@@ -6,7 +6,7 @@ import { Groups, GroupsContract } from 'src/libs/ajax/Groups';
 import { Metrics, MetricsContract } from 'src/libs/ajax/Metrics';
 import { SamUserTermsOfServiceDetails, TermsOfService, TermsOfServiceContract } from 'src/libs/ajax/TermsOfService';
 import { SamUserResponse, User, UserContract } from 'src/libs/ajax/User';
-import { TerraUserState, userStore } from 'src/libs/state';
+import { oidcStore, TerraUserState, userStore } from 'src/libs/state';
 
 jest.mock('src/libs/ajax/TermsOfService');
 jest.mock('src/libs/ajax/User');
@@ -22,19 +22,11 @@ jest.mock('react-notifications-component', () => {
   };
 });
 
-jest.mock('src/libs/state', () => {
-  const state = jest.requireActual('src/libs/state');
-  return {
-    ...state,
-    oidcStore: {
-      ...state.oidcStore,
-      get: jest.fn().mockReturnValue({
-        ...state.oidcStore.get,
-        userManager: { getUser: jest.fn() },
-      }),
-    },
-  };
-});
+jest.spyOn(oidcStore, 'get').mockImplementation(
+  jest.fn().mockReturnValue({
+    userManager: { getUser: jest.fn() },
+  })
+);
 
 const samUserDate = new Date('1970-01-01');
 
@@ -104,7 +96,7 @@ describe('a request to load a terra user', () => {
   const getFenceStatusFunction = jest.fn().mockResolvedValue({});
 
   beforeEach(() => {
-    userStore.reset;
+    userStore.reset();
   });
 
   // reset userStore state before each test

--- a/src/auth/login.test.ts
+++ b/src/auth/login.test.ts
@@ -2,8 +2,7 @@ import { DeepPartial } from '@terra-ui-packages/core-utils';
 import { asMockedFn } from '@terra-ui-packages/test-utils';
 import { act } from '@testing-library/react';
 import { loadTerraUser } from 'src/auth/auth';
-import { Ajax } from 'src/libs/ajax';
-import { GroupRole, Groups, GroupsContract } from 'src/libs/ajax/Groups';
+import { Groups, GroupsContract } from 'src/libs/ajax/Groups';
 import { Metrics, MetricsContract } from 'src/libs/ajax/Metrics';
 import { SamUserTermsOfServiceDetails, TermsOfService, TermsOfServiceContract } from 'src/libs/ajax/TermsOfService';
 import { SamUserResponse, User, UserContract } from 'src/libs/ajax/User';
@@ -12,11 +11,7 @@ import { TerraUserState, userStore } from 'src/libs/state';
 jest.mock('src/libs/ajax/TermsOfService');
 jest.mock('src/libs/ajax/User');
 jest.mock('src/libs/ajax/Groups');
-jest.mock('src/libs/ajax');
 jest.mock('src/libs/ajax/Metrics');
-
-type AjaxExports = typeof import('src/libs/ajax');
-type AjaxContract = ReturnType<AjaxExports['Ajax']>;
 
 jest.mock('react-notifications-component', () => {
   return {
@@ -97,12 +92,6 @@ const mockOrchestrationNihStatusResponse = {
   linkExpireTime: 1234,
 };
 
-const mockCurrentUserGroupMembership = {
-  groupEmail: 'testGroupEmail',
-  groupName: 'testGroupName',
-  role: 'member' as GroupRole,
-};
-
 // TODO centralize Ajax mock setup so it can be reused across tests
 describe('a request to load a terra user', () => {
   // Arrange (shared between tests for the success case)
@@ -143,30 +132,6 @@ describe('a request to load a terra user', () => {
     asMockedFn(TermsOfService).mockReturnValue({
       getUserTermsOfServiceDetails: jest.fn().mockReturnValue({}),
     } as Partial<TermsOfServiceContract> as TermsOfServiceContract);
-
-    asMockedFn(Ajax).mockImplementation(
-      () =>
-        ({
-          User: {
-            getUserAllowances: getUserAllowancesFunction,
-            getUserAttributes: getUserAttributesFunction,
-            getUserTermsOfServiceDetails: getUserTermsOfServiceDetailsFunction,
-            getEnterpriseFeatures: getEnterpriseFeaturesFunction,
-            getSamUserResponse: getSamUserResponseFunction,
-            getNihStatus: getNihStatusFunction,
-            getFenceStatus: getFenceStatusFunction,
-            profile: {
-              get: jest.fn().mockReturnValue(mockTerraUserProfile),
-            },
-          },
-          TermsOfService: {
-            getUserTermsOfServiceDetails: jest.fn().mockReturnValue({}),
-          },
-          Groups: {
-            list: jest.fn().mockReturnValue([mockCurrentUserGroupMembership]),
-          },
-        } as DeepPartial<AjaxContract> as AjaxContract)
-    );
   });
   describe('when successful', () => {
     it('should include a samUserResponse', async () => {
@@ -210,13 +175,6 @@ describe('a request to load a terra user', () => {
           getNihStatus: getNihStatusFunction,
         } as DeepPartial<UserContract> as UserContract);
 
-        asMockedFn(Groups).mockReturnValue({
-          list: jest.fn(),
-        } as Partial<GroupsContract> as GroupsContract);
-
-        asMockedFn(TermsOfService).mockReturnValue({
-          getUserTermsOfServiceDetails: jest.fn().mockReturnValue({}),
-        } as Partial<TermsOfServiceContract> as TermsOfServiceContract);
         // Act, Assert
         // this expect.assertions is here to prevent the test from passing if the error is not thrown
         expect.assertions(1);

--- a/src/auth/oidc-broker.ts
+++ b/src/auth/oidc-broker.ts
@@ -1,8 +1,7 @@
 import _ from 'lodash/fp';
 import { ExtraSigninRequestArgs, IdTokenClaims, User, UserManager, WebStorageStateStore } from 'oidc-client-ts';
 import { AuthContextProps } from 'react-oidc-context';
-import { Ajax } from 'src/libs/ajax';
-import { OidcConfig } from 'src/libs/ajax/OAuth2';
+import { OAuth2, OidcConfig } from 'src/libs/ajax/OAuth2';
 import { getLocalStorage } from 'src/libs/browser-storage';
 import { getConfig } from 'src/libs/config';
 import { oidcStore } from 'src/libs/state';
@@ -50,7 +49,7 @@ export const getOidcConfig = () => {
 
 // This is the first thing that happens on app load.
 export const initializeClientId = _.memoize(async (): Promise<void> => {
-  const oidcConfig: OidcConfig = await Ajax().OAuth2.getConfiguration();
+  const oidcConfig: OidcConfig = await OAuth2().getConfiguration();
   oidcStore.update((state) => ({ ...state, config: oidcConfig }));
 });
 

--- a/src/auth/signout/sign-out.test.ts
+++ b/src/auth/signout/sign-out.test.ts
@@ -1,7 +1,6 @@
-import { DeepPartial } from '@terra-ui-packages/core-utils';
 import { removeUserFromLocalState } from 'src/auth/oidc-broker';
 import { signOut } from 'src/auth/signout/sign-out';
-import { Ajax } from 'src/libs/ajax';
+import { Metrics, MetricsContract } from 'src/libs/ajax/Metrics';
 import Events from 'src/libs/events';
 import * as Nav from 'src/libs/nav';
 import { goToPath } from 'src/libs/nav';
@@ -12,10 +11,7 @@ jest.mock('src/auth/oidc-broker');
 
 jest.mock('react-oidc-context');
 
-jest.mock('src/libs/ajax');
-
-type AjaxExports = typeof import('src/libs/ajax');
-type AjaxContract = ReturnType<AjaxExports['Ajax']>;
+jest.mock('src/libs/ajax/Metrics');
 
 const currentRoute = {
   name: 'routeName',
@@ -52,11 +48,9 @@ describe('sign-out', () => {
   it('sends sign out metrics', async () => {
     // Arrange
     const captureEventFn = jest.fn();
-    asMockedFn(Ajax).mockReturnValue({
-      Metrics: {
-        captureEvent: captureEventFn,
-      },
-    } as DeepPartial<AjaxContract> as AjaxContract);
+    asMockedFn(Metrics).mockReturnValue({
+      captureEvent: captureEventFn,
+    } as Partial<MetricsContract> as MetricsContract);
 
     // Act
     signOut();
@@ -66,11 +60,9 @@ describe('sign-out', () => {
   it('sends sign out metrics with a specified event', async () => {
     // Arrange
     const captureEventFn = jest.fn();
-    asMockedFn(Ajax).mockReturnValue({
-      Metrics: {
-        captureEvent: captureEventFn,
-      },
-    } as DeepPartial<AjaxContract> as AjaxContract);
+    asMockedFn(Metrics).mockReturnValue({
+      captureEvent: captureEventFn,
+    } as Partial<MetricsContract> as MetricsContract);
 
     // Act
     signOut('idleStatusMonitor');

--- a/src/auth/signout/sign-out.ts
+++ b/src/auth/signout/sign-out.ts
@@ -1,7 +1,7 @@
 import { sessionExpirationErrorMessage } from 'src/auth/auth-errors';
 import { removeUserFromLocalState } from 'src/auth/oidc-broker';
 import { signOutCallbackLinkName } from 'src/auth/signout/SignOutPage';
-import { Ajax } from 'src/libs/ajax';
+import { Metrics } from 'src/libs/ajax/Metrics';
 import { getSessionStorage } from 'src/libs/browser-storage';
 import Events, { MetricsEventName } from 'src/libs/events';
 import * as Nav from 'src/libs/nav';
@@ -73,7 +73,7 @@ const sendSignOutMetrics = async (cause: SignOutCause): Promise<void> => {
   const metricStoreState: MetricState = metricStore.get();
   const tokenMetadata: TokenMetadata = metricStoreState.authTokenMetadata;
 
-  await Ajax().Metrics.captureEvent(eventToFire, {
+  await Metrics().captureEvent(eventToFire, {
     sessionEndTime: Utils.makeCompleteDate(sessionEndTime),
     sessionDurationInSeconds:
       metricStoreState.sessionStartTime < 0 ? undefined : (sessionEndTime - metricStoreState.sessionStartTime) / 1000.0,

--- a/src/components/CookieWarning.js
+++ b/src/components/CookieWarning.js
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from 'react';
 import { aside, div, h } from 'react-hyperscript-helpers';
 import { Transition } from 'react-transition-group';
 import { ButtonPrimary, ButtonSecondary, Link } from 'src/components/common';
-import { Ajax } from 'src/libs/ajax';
+import { Runtimes } from 'src/libs/ajax/leonardo/Runtimes';
 import { getEnabledBrand } from 'src/libs/brand-utils';
 import { getSessionStorage } from 'src/libs/browser-storage';
 import colors from 'src/libs/colors';
@@ -48,8 +48,8 @@ const CookieWarning = () => {
     const cookies = document.cookie.split(';');
     acceptCookies(false);
     // TODO: call azure invalidate cookie once endpoint exists, https://broadworkbench.atlassian.net/browse/IA-3498
-    await Ajax(signal)
-      .Runtimes.invalidateCookie()
+    await Runtimes(signal)
+      .invalidateCookie()
       .catch(() => {});
     // Expire all cookies
     _.forEach((cookie) => {

--- a/src/libs/ajax/Groups.ts
+++ b/src/libs/ajax/Groups.ts
@@ -94,3 +94,4 @@ export const Groups = (signal?: AbortSignal) => ({
     };
   },
 });
+export type GroupsContract = ReturnType<typeof Groups>;

--- a/src/libs/ajax/Metrics.ts
+++ b/src/libs/ajax/Metrics.ts
@@ -90,3 +90,5 @@ export const Metrics = (signal?: AbortSignal) => {
     }) as (anonId: string) => Promise<void>,
   };
 };
+
+export type MetricsContract = ReturnType<typeof Metrics>;

--- a/src/libs/ajax/TermsOfService.ts
+++ b/src/libs/ajax/TermsOfService.ts
@@ -58,3 +58,5 @@ export const TermsOfService = (signal?: AbortSignal) => {
     },
   };
 };
+
+export type TermsOfServiceContract = ReturnType<typeof TermsOfService>;

--- a/src/libs/ajax/User.ts
+++ b/src/libs/ajax/User.ts
@@ -326,3 +326,5 @@ export const User = (signal?: AbortSignal) => {
     },
   };
 };
+
+export type UserContract = ReturnType<typeof User>;

--- a/src/libs/events.ts
+++ b/src/libs/events.ts
@@ -366,7 +366,7 @@ export const captureAppcuesEvent = (eventName: string, event: any) => {
       'appcues.npsAskMeLaterSelectedAt': event.askMeLaterSelectedAt,
       'appcues.npsClickedUpdateNpsScore': event.score,
     };
-    return Ajax().Metrics.captureEvent(eventsList.appcuesEvent, eventProps);
+    return Metrics().captureEvent(eventsList.appcuesEvent, eventProps);
   }
 };
 

--- a/src/libs/events.ts
+++ b/src/libs/events.ts
@@ -1,6 +1,5 @@
 import _ from 'lodash/fp';
 import { ReactNode, useEffect } from 'react';
-import { Ajax } from 'src/libs/ajax';
 import { useRoute } from 'src/libs/nav';
 import {
   containsPhiTrackingPolicy,
@@ -9,6 +8,8 @@ import {
   WorkspaceInfo,
   WorkspaceWrapper,
 } from 'src/workspaces/utils';
+
+import { Metrics } from './ajax/Metrics';
 
 /*
  * NOTE: In order to show up in reports, new events MUST be marked as expected in the Mixpanel
@@ -289,10 +290,7 @@ export const PageViewReporter = (): ReactNode => {
   useEffect(() => {
     const isWorkspace = /^#workspaces\/.+\/.+/.test(window.location.hash);
 
-    Ajax().Metrics.captureEvent(
-      `${eventsList.pageView}:${name}`,
-      isWorkspace ? extractWorkspaceDetails(params) : undefined
-    );
+    Metrics().captureEvent(`${eventsList.pageView}:${name}`, isWorkspace ? extractWorkspaceDetails(params) : undefined);
   }, [name, params]);
 
   return null;
@@ -350,7 +348,7 @@ export const captureAppcuesEvent = (eventName: string, event: any) => {
       'appcues.stepType': event.stepType,
       'appcues.timestamp': event.timestamp,
     };
-    return Ajax().Metrics.captureEvent(eventsList.appcuesEvent, eventProps);
+    return Metrics().captureEvent(eventsList.appcuesEvent, eventProps);
   }
   if (_.includes(eventName, npsEvents)) {
     const eventProps = {

--- a/src/registration/terms-of-service/TermsOfServicePage.test.ts
+++ b/src/registration/terms-of-service/TermsOfServicePage.test.ts
@@ -2,12 +2,18 @@ import { DeepPartial } from '@terra-ui-packages/core-utils';
 import { act, fireEvent, screen } from '@testing-library/react';
 import { h } from 'react-hyperscript-helpers';
 import { Ajax } from 'src/libs/ajax';
-import { SamUserTermsOfServiceDetails } from 'src/libs/ajax/TermsOfService';
-import { SamUserAllowances, SamUserResponse } from 'src/libs/ajax/User';
+import { Groups, GroupsContract } from 'src/libs/ajax/Groups';
+import { Metrics, MetricsContract } from 'src/libs/ajax/Metrics';
+import { SamUserTermsOfServiceDetails, TermsOfService, TermsOfServiceContract } from 'src/libs/ajax/TermsOfService';
+import { SamUserAllowances, SamUserResponse, User, UserContract } from 'src/libs/ajax/User';
 import { AuthState, authStore } from 'src/libs/state';
 import { TermsOfServicePage } from 'src/registration/terms-of-service/TermsOfServicePage';
 import { asMockedFn, renderWithAppContexts as render } from 'src/testing/test-utils';
 
+jest.mock('src/libs/ajax/Metrics');
+jest.mock('src/libs/ajax/TermsOfService');
+jest.mock('src/libs/ajax/User');
+jest.mock('src/libs/ajax/Groups');
 jest.mock('src/libs/ajax');
 jest.mock('react-notifications-component', () => {
   return {
@@ -42,6 +48,8 @@ jest.mock(
   'src/auth/auth',
   (): AuthExports => ({
     ...jest.requireActual<AuthExports>('src/auth/auth'),
+    getAuthToken: jest.fn(),
+    getAuthTokenFromLocalStorage: jest.fn(),
   })
 );
 
@@ -85,33 +93,41 @@ const setupMockAjax = async (
   asMockedFn(Ajax).mockImplementation(
     () =>
       ({
-        Metrics: {
-          captureEvent: jest.fn(),
-        },
-        User: {
-          getUserAttributes: jest.fn().mockResolvedValue({ marketingConsent: true }),
-          getUserAllowances: jest.fn().mockResolvedValue(terraUserAllowances),
-          getEnterpriseFeatures: jest.fn().mockResolvedValue([]),
-          getSamUserResponse: jest.fn().mockResolvedValue(mockSamUserResponse),
-          profile: {
-            get: jest.fn().mockResolvedValue({ keyValuePairs: [] }),
-            update: jest.fn().mockResolvedValue({ keyValuePairs: [] }),
-            setPreferences: jest.fn().mockResolvedValue({}),
-            preferLegacyFirecloud: jest.fn().mockResolvedValue({}),
-          },
-          getNihStatus,
-        },
         TermsOfService: {
           getUserTermsOfServiceDetails,
           acceptTermsOfService,
           rejectTermsOfService,
           getTermsOfServiceText,
         },
-        Groups: {
-          list: jest.fn(),
-        },
       } as DeepPartial<AjaxContract> as AjaxContract)
   );
+
+  asMockedFn(Metrics).mockReturnValue({
+    captureEvent: jest.fn(),
+  } as Partial<MetricsContract> as MetricsContract);
+
+  asMockedFn(User).mockReturnValue({
+    getUserAttributes: jest.fn().mockResolvedValue({ marketingConsent: true }),
+    getUserAllowances: jest.fn().mockResolvedValue(terraUserAllowances),
+    getEnterpriseFeatures: jest.fn().mockResolvedValue([]),
+    getSamUserResponse: jest.fn().mockResolvedValue(mockSamUserResponse),
+    profile: {
+      get: jest.fn().mockResolvedValue({ keyValuePairs: [] }),
+      update: jest.fn().mockResolvedValue({ keyValuePairs: [] }),
+      setPreferences: jest.fn().mockResolvedValue({}),
+      preferLegacyFirecloud: jest.fn().mockResolvedValue({}),
+    },
+    getNihStatus,
+  } as Partial<UserContract> as UserContract);
+
+  asMockedFn(Groups).mockReturnValue({
+    list: jest.fn(),
+  } as Partial<GroupsContract> as GroupsContract);
+
+  asMockedFn(TermsOfService).mockReturnValue({
+    acceptTermsOfService,
+    getUserTermsOfServiceDetails,
+  } as Partial<TermsOfServiceContract> as TermsOfServiceContract);
 
   await act(async () => {
     authStore.update((state: AuthState) => ({ ...state, termsOfService, signInStatus, terraUserAllowances }));

--- a/src/registration/terms-of-service/TermsOfServicePage.test.ts
+++ b/src/registration/terms-of-service/TermsOfServicePage.test.ts
@@ -33,23 +33,12 @@ jest.mock(
   })
 );
 
-type AuthExports = typeof import('src/auth/auth');
-
 type SignOutExports = typeof import('src/auth/signout/sign-out');
 jest.mock(
   'src/auth/signout/sign-out',
   (): SignOutExports => ({
     ...jest.requireActual<SignOutExports>('src/auth/signout/sign-out'),
     signOut: jest.fn(),
-  })
-);
-
-jest.mock(
-  'src/auth/auth',
-  (): AuthExports => ({
-    ...jest.requireActual<AuthExports>('src/auth/auth'),
-    getAuthToken: jest.fn(),
-    getAuthTokenFromLocalStorage: jest.fn(),
   })
 );
 
@@ -94,7 +83,6 @@ const setupMockAjax = async (
     () =>
       ({
         TermsOfService: {
-          getUserTermsOfServiceDetails,
           acceptTermsOfService,
           rejectTermsOfService,
           getTermsOfServiceText,
@@ -125,7 +113,6 @@ const setupMockAjax = async (
   } as Partial<GroupsContract> as GroupsContract);
 
   asMockedFn(TermsOfService).mockReturnValue({
-    acceptTermsOfService,
     getUserTermsOfServiceDetails,
   } as Partial<TermsOfServiceContract> as TermsOfServiceContract);
 

--- a/src/registration/terms-of-service/terms-of-service-alerts.test.ts
+++ b/src/registration/terms-of-service/terms-of-service-alerts.test.ts
@@ -1,11 +1,29 @@
+import { DeepPartial } from '@terra-ui-packages/core-utils';
+import { asMockedFn } from '@terra-ui-packages/test-utils';
 import { act } from '@testing-library/react';
 import { h } from 'react-hyperscript-helpers';
 import { AlertsIndicator } from 'src/alerts/Alerts';
+import { Metrics, MetricsContract } from 'src/libs/ajax/Metrics';
+import { SamUserTermsOfServiceDetails, TermsOfServiceContract } from 'src/libs/ajax/TermsOfService';
+import { SamUserResponse, User, UserContract } from 'src/libs/ajax/User';
 import { authStore, TermsOfServiceStatus } from 'src/libs/state';
 import * as TosAlerts from 'src/registration/terms-of-service/terms-of-service-alerts';
 import { renderWithAppContexts as render } from 'src/testing/test-utils';
 
+import { TermsOfService } from '../../libs/ajax/TermsOfService';
+
+jest.mock('src/libs/ajax/User');
+jest.mock('src/libs/ajax/TermsOfService');
 jest.mock('src/libs/ajax');
+jest.mock('src/libs/ajax/Metrics');
+
+// jest.mock('src/libs/ajax/ajax-common', () => ({
+//   ...jest.requireActual('src/libs/ajax/ajax-common'),
+//   fetchFromProxy: jest.fn(),
+//   fetchOk: jest.fn(),
+//   authOpts: jest.fn(),
+//   fetchSam: jest.fn(),
+// }));
 
 jest.mock('src/libs/nav', () => ({
   ...jest.requireActual('src/libs/nav'),
@@ -19,6 +37,82 @@ jest.mock('react-notifications-component', () => {
       removeNotification: jest.fn(),
     },
   };
+});
+
+jest.mock('src/libs/state', () => {
+  const state = jest.requireActual('src/libs/state');
+  return {
+    ...state,
+    oidcStore: {
+      ...state.oidcStore,
+      get: jest.fn().mockReturnValue({
+        ...state.oidcStore.get,
+        userManager: { getUser: jest.fn() },
+      }),
+    },
+  };
+});
+
+const samUserDate = new Date('1970-01-01');
+const mockSamUserResponse: SamUserResponse = {
+  id: 'testId',
+  googleSubjectId: 'testGoogleSubjectId',
+  email: 'testEmail',
+  azureB2CId: 'testAzureB2CId',
+  allowed: true,
+  createdAt: samUserDate,
+  registeredAt: samUserDate,
+  updatedAt: samUserDate,
+};
+const mockTerraUserProfile = {
+  firstName: 'testFirstName',
+  lastName: 'testLastName',
+  institute: 'testInstitute',
+  contactEmail: 'testContactEmail',
+  title: 'testTitle',
+  department: 'testDepartment',
+  interestInTerra: 'testInterestInTerra',
+  programLocationCity: 'testProgramLocationCity',
+  programLocationState: 'testProgramLocationState',
+  programLocationCountry: 'testProgramLocationCountry',
+  researchArea: 'testResearchArea',
+  starredWorkspaces: 'testStarredWorkspaces',
+};
+const testSamUserAllowancesDetails = {
+  enabled: true,
+  termsOfService: true,
+};
+const testSamUserAllowances = {
+  allowed: true,
+  details: testSamUserAllowancesDetails,
+};
+const mockSamUserTermsOfServiceDetails: SamUserTermsOfServiceDetails = {
+  latestAcceptedVersion: '1234',
+  acceptedOn: samUserDate,
+  permitsSystemUsage: true,
+  isCurrentVersion: true,
+};
+const getUserTermsOfServiceDetailsFunction = jest.fn().mockResolvedValue(mockSamUserTermsOfServiceDetails);
+const getSamUserResponseFunction = jest.fn().mockResolvedValue(mockSamUserResponse);
+const getUserAllowancesFunction = jest.fn().mockResolvedValue(testSamUserAllowances);
+beforeEach(() => {
+  asMockedFn(User).mockReturnValue({
+    profile: { get: jest.fn().mockReturnValue(mockTerraUserProfile) },
+    getUserAllowances: getUserAllowancesFunction,
+    getUserAttributes: jest.fn(),
+    getEnterpriseFeatures: jest.fn(),
+    getSamUserResponse: getSamUserResponseFunction,
+    getNihStatus: jest.fn(),
+    getUserTermsOfServiceDetailsFunction,
+  } as DeepPartial<UserContract> as UserContract);
+
+  asMockedFn(TermsOfService).mockReturnValue({
+    getUserTermsOfServiceDetails: getUserTermsOfServiceDetailsFunction,
+  } as Partial<TermsOfServiceContract> as TermsOfServiceContract);
+
+  asMockedFn(Metrics).mockReturnValue({
+    captureEvent: jest.fn(),
+  } as Partial<MetricsContract> as MetricsContract);
 });
 
 afterEach(() => {

--- a/src/registration/terms-of-service/terms-of-service-alerts.test.ts
+++ b/src/registration/terms-of-service/terms-of-service-alerts.test.ts
@@ -1,29 +1,14 @@
-import { DeepPartial } from '@terra-ui-packages/core-utils';
 import { asMockedFn } from '@terra-ui-packages/test-utils';
 import { act } from '@testing-library/react';
 import { h } from 'react-hyperscript-helpers';
 import { AlertsIndicator } from 'src/alerts/Alerts';
 import { Metrics, MetricsContract } from 'src/libs/ajax/Metrics';
-import { SamUserTermsOfServiceDetails, TermsOfServiceContract } from 'src/libs/ajax/TermsOfService';
-import { SamUserResponse, User, UserContract } from 'src/libs/ajax/User';
 import { authStore, TermsOfServiceStatus } from 'src/libs/state';
 import * as TosAlerts from 'src/registration/terms-of-service/terms-of-service-alerts';
 import { renderWithAppContexts as render } from 'src/testing/test-utils';
 
-import { TermsOfService } from '../../libs/ajax/TermsOfService';
-
-jest.mock('src/libs/ajax/User');
-jest.mock('src/libs/ajax/TermsOfService');
 jest.mock('src/libs/ajax');
 jest.mock('src/libs/ajax/Metrics');
-
-// jest.mock('src/libs/ajax/ajax-common', () => ({
-//   ...jest.requireActual('src/libs/ajax/ajax-common'),
-//   fetchFromProxy: jest.fn(),
-//   fetchOk: jest.fn(),
-//   authOpts: jest.fn(),
-//   fetchSam: jest.fn(),
-// }));
 
 jest.mock('src/libs/nav', () => ({
   ...jest.requireActual('src/libs/nav'),
@@ -39,77 +24,7 @@ jest.mock('react-notifications-component', () => {
   };
 });
 
-jest.mock('src/libs/state', () => {
-  const state = jest.requireActual('src/libs/state');
-  return {
-    ...state,
-    oidcStore: {
-      ...state.oidcStore,
-      get: jest.fn().mockReturnValue({
-        ...state.oidcStore.get,
-        userManager: { getUser: jest.fn() },
-      }),
-    },
-  };
-});
-
-const samUserDate = new Date('1970-01-01');
-const mockSamUserResponse: SamUserResponse = {
-  id: 'testId',
-  googleSubjectId: 'testGoogleSubjectId',
-  email: 'testEmail',
-  azureB2CId: 'testAzureB2CId',
-  allowed: true,
-  createdAt: samUserDate,
-  registeredAt: samUserDate,
-  updatedAt: samUserDate,
-};
-const mockTerraUserProfile = {
-  firstName: 'testFirstName',
-  lastName: 'testLastName',
-  institute: 'testInstitute',
-  contactEmail: 'testContactEmail',
-  title: 'testTitle',
-  department: 'testDepartment',
-  interestInTerra: 'testInterestInTerra',
-  programLocationCity: 'testProgramLocationCity',
-  programLocationState: 'testProgramLocationState',
-  programLocationCountry: 'testProgramLocationCountry',
-  researchArea: 'testResearchArea',
-  starredWorkspaces: 'testStarredWorkspaces',
-};
-const testSamUserAllowancesDetails = {
-  enabled: true,
-  termsOfService: true,
-};
-const testSamUserAllowances = {
-  allowed: true,
-  details: testSamUserAllowancesDetails,
-};
-const mockSamUserTermsOfServiceDetails: SamUserTermsOfServiceDetails = {
-  latestAcceptedVersion: '1234',
-  acceptedOn: samUserDate,
-  permitsSystemUsage: true,
-  isCurrentVersion: true,
-};
-const getUserTermsOfServiceDetailsFunction = jest.fn().mockResolvedValue(mockSamUserTermsOfServiceDetails);
-const getSamUserResponseFunction = jest.fn().mockResolvedValue(mockSamUserResponse);
-const getUserAllowancesFunction = jest.fn().mockResolvedValue(testSamUserAllowances);
-beforeEach(() => {
-  asMockedFn(User).mockReturnValue({
-    profile: { get: jest.fn().mockReturnValue(mockTerraUserProfile) },
-    getUserAllowances: getUserAllowancesFunction,
-    getUserAttributes: jest.fn(),
-    getEnterpriseFeatures: jest.fn(),
-    getSamUserResponse: getSamUserResponseFunction,
-    getNihStatus: jest.fn(),
-    getUserTermsOfServiceDetailsFunction,
-  } as DeepPartial<UserContract> as UserContract);
-
-  asMockedFn(TermsOfService).mockReturnValue({
-    getUserTermsOfServiceDetails: getUserTermsOfServiceDetailsFunction,
-  } as Partial<TermsOfServiceContract> as TermsOfServiceContract);
-
+beforeAll(() => {
   asMockedFn(Metrics).mockReturnValue({
     captureEvent: jest.fn(),
   } as Partial<MetricsContract> as MetricsContract);

--- a/src/workspaces/dashboard/WorkspaceDescription.test.ts
+++ b/src/workspaces/dashboard/WorkspaceDescription.test.ts
@@ -20,7 +20,15 @@ jest.mock('src/libs/ajax', () => ({
   Ajax: jest.fn(),
 }));
 
-jest.mock('src/libs/notifications');
+type MockErrorExports = typeof import('src/libs/error.mock');
+jest.mock('src/libs/error', () => {
+  const errorModule = jest.requireActual('src/libs/error');
+  const mockErrorModule = jest.requireActual<MockErrorExports>('src/libs/error.mock');
+  return {
+    ...errorModule,
+    withErrorReporting: mockErrorModule.mockWithErrorReporting,
+  };
+});
 
 type WorkspaceUtilsExports = typeof import('src/workspaces/utils');
 
@@ -85,6 +93,7 @@ describe('WorkspaceDescription', () => {
     asMockedFn(Ajax).mockReturnValue({
       Metrics: { captureEvent } as Partial<AjaxContract['Metrics']>,
     } as DeepPartial<AjaxContract> as AjaxContract);
+
     const props = {
       workspace: _.merge(defaultGoogleWorkspace, { workspace: { attributes: { description: undefined } } }),
       refreshWorkspace: jest.fn(),
@@ -147,12 +156,12 @@ describe('WorkspaceDescription', () => {
     const mockShallowMergeNewAttributes = jest.fn().mockResolvedValue({});
     const captureEvent = jest.fn();
     asMockedFn(Ajax).mockReturnValue({
-      Metrics: { captureEvent } as Partial<AjaxContract['Metrics']>,
       Workspaces: {
         workspace: jest.fn().mockReturnValue({
           shallowMergeNewAttributes: mockShallowMergeNewAttributes,
         }),
       },
+      Metrics: { captureEvent } as Partial<AjaxContract['Metrics']>,
     } as DeepPartial<AjaxContract> as AjaxContract);
     const newDescription = 'the description the user edited';
 


### PR DESCRIPTION
This PR is needed in preparation for the linked [ticket](https://broadworkbench.atlassian.net/browse/IA-4883), which involves separately packaging the disk client. 

- removes circular ajax dependencies from auth module
- updates tests with appropriate mock changes

These changes shift to the data client modules instead of importing ajax directly, which requires
1) mocking some of the underlying data client mechanics in various tests
2) solves  circular dependencies involving modules pulling in both ajax and other modules that also get pulled in by ajax