### PR TITLE
[AJ-1843] Combine definitions of AnVIL imports

### DIFF
--- a/src/import-data/ImportData.ts
+++ b/src/import-data/ImportData.ts
@@ -180,7 +180,7 @@ export const ImportData = (props: ImportDataProps): ReactNode => {
     Ajax().Metrics.captureEvent(Events.workspaceDataImport, {
       format,
       ...extractWorkspaceDetails(workspace),
-      importSource: 'url' in importRequest ? getImportSource(importRequest.url) : undefined,
+      importSource: getImportSource(importRequest),
     });
     Nav.goToPath('workspace-data', { namespace, name });
   });

--- a/src/import-data/import-requirements.ts
+++ b/src/import-data/import-requirements.ts
@@ -3,7 +3,7 @@ import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
 import { ENABLE_AZURE_PFB_IMPORT } from 'src/libs/feature-previews-config';
 import { CloudProvider } from 'src/workspaces/utils';
 
-import { urlMatchesSource, UrlSource } from './import-sources';
+import { anvilSources, biodatacatalystSources, urlMatchesSource, UrlSource } from './import-sources';
 import { ImportRequest } from './import-types';
 
 export const getRequiredCloudPlatform = (importRequest: ImportRequest): CloudProvider | undefined => {
@@ -23,19 +23,18 @@ export const getRequiredCloudPlatform = (importRequest: ImportRequest): CloudPro
   }
 };
 
-// These must be kept in sync with CWDS' twds.data-import.sources setting.
-// https://github.com/DataBiosphere/terra-workspace-data-service/blob/main/service/src/main/resources/application.yml
 const sourcesRequiringSecurityMonitoring: UrlSource[] = [
-  // AnVIL production
-  { type: 'http', host: 'service.prod.anvil.gi.ucsc.edu' },
-  { type: 's3', bucket: 'edu-ucsc-gi-platform-anvil-prod-storage-anvilprod.us-east-1' },
-  // AnVIL development
-  { type: 'http', host: 'service.anvil.gi.ucsc.edu' },
-  { type: 's3', bucket: 'edu-ucsc-gi-platform-anvil-dev-storage-anvildev.us-east-1' },
-  // BioData Catalyst
-  { type: 'http', host: 'gen3.biodatacatalyst.nhlbi.nih.gov' },
-  { type: 's3', bucket: 'gen3-biodatacatalyst-nhlbi-nih-gov-pfb-export' },
-  { type: 's3', bucket: 'gen3-theanvil-io-pfb-export' },
+  // AnVIL PFBs refer to TDR snapshots, so security monitoring requirements will be enforced
+  // by policy on the TDR snapshots. In Terra UI, we assume that all AnVIL PFBs reference
+  // a snapshot that requires security monitoring. This reduces that chance that a user
+  // selects a destination workspace that is not permitted to receive the data and encounters
+  // a failure later in the import process.
+  ...anvilSources,
+
+  // For some other sources, secure monitoring requirements are enforced by Terra Workspace Data Service.
+  // This must be kept in sync with the twds.data-import.sources configuration in terra-workspace-data-service.
+  // https://github.com/DataBiosphere/terra-workspace-data-service/blob/main/service/src/main/resources/application.yml
+  ...biodatacatalystSources,
 ];
 
 /**

--- a/src/import-data/import-sources.test.ts
+++ b/src/import-data/import-sources.test.ts
@@ -1,9 +1,12 @@
 import {
   anvilPfbImportRequests,
+  azureTdrSnapshotImportRequest,
   biodataCatalystPfbImportRequests,
+  gcpTdrSnapshotImportRequest,
   genericPfbImportRequest,
 } from './__fixtures__/import-request-fixtures';
-import { getImportSource, ImportSource, urlMatchesSource, UrlSource } from './import-sources';
+import { getImportSource, isAnvilImport, urlMatchesSource, UrlSource } from './import-sources';
+import { ImportRequest } from './import-types';
 
 describe('urlMatchesSource', () => {
   it.each([
@@ -26,19 +29,48 @@ describe('urlMatchesSource', () => {
   );
 });
 
-describe('getImportSource', () => {
+describe('isAnvilImport', () => {
   it.each([
-    ...anvilPfbImportRequests.map((importRequest) => ({ importUrl: importRequest.url, expectedSource: 'anvil' })),
-    ...[genericPfbImportRequest, ...biodataCatalystPfbImportRequests].map((importRequest) => ({
-      importUrl: importRequest.url,
-      expectedSource: '',
+    ...anvilPfbImportRequests.map((importRequest) => ({ importRequest, expected: true })),
+    ...[
+      genericPfbImportRequest,
+      ...biodataCatalystPfbImportRequests,
+      azureTdrSnapshotImportRequest,
+      gcpTdrSnapshotImportRequest,
+    ].map((importRequest) => ({
+      importRequest,
+      expected: false,
     })),
   ] as {
-    importUrl: URL;
-    expectedSource: ImportSource;
-  }[])('identifies import source ($importUrl)', ({ importUrl, expectedSource }) => {
+    importRequest: ImportRequest;
+    expected: boolean;
+  }[])('identifies import source ($importRequest.url)', ({ importRequest, expected }) => {
     // Act
-    const source = getImportSource(importUrl);
+    const isAnvil = isAnvilImport(importRequest);
+
+    // Assert
+    expect(isAnvil).toBe(expected);
+  });
+});
+
+describe('getImportSource', () => {
+  it.each([
+    ...anvilPfbImportRequests.map((importRequest) => ({ importRequest, expectedSource: 'anvil' })),
+    ...[
+      genericPfbImportRequest,
+      ...biodataCatalystPfbImportRequests,
+      azureTdrSnapshotImportRequest,
+      gcpTdrSnapshotImportRequest,
+    ].map((importRequest) => ({
+      importRequest,
+      expectedSource: undefined,
+    })),
+  ] as {
+    importRequest: ImportRequest;
+    expectedSource: string | undefined;
+  }[])('identifies import source ($importRequest.url)', ({ importRequest, expectedSource }) => {
+    // Act
+    const source = getImportSource(importRequest);
 
     // Assert
     expect(source).toBe(expectedSource);

--- a/src/import-data/import-sources.ts
+++ b/src/import-data/import-sources.ts
@@ -1,4 +1,21 @@
+import { ImportRequest } from './import-types';
+
 export type UrlSource = { type: 'http'; host: string } | { type: 's3'; bucket: string };
+
+export const anvilSources: UrlSource[] = [
+  // production
+  { type: 'http', host: 'service.prod.anvil.gi.ucsc.edu' },
+  { type: 's3', bucket: 'edu-ucsc-gi-platform-anvil-prod-storage-anvilprod.us-east-1' },
+  // development
+  { type: 'http', host: 'service.anvil.gi.ucsc.edu' },
+  { type: 's3', bucket: 'edu-ucsc-gi-platform-anvil-dev-storage-anvildev.us-east-1' },
+];
+
+export const biodatacatalystSources: UrlSource[] = [
+  { type: 'http', host: 'gen3.biodatacatalyst.nhlbi.nih.gov' },
+  { type: 's3', bucket: 'gen3-biodatacatalyst-nhlbi-nih-gov-pfb-export' },
+  { type: 's3', bucket: 'gen3-theanvil-io-pfb-export' },
+];
 
 /**
  * Determine if a PFB file is considered protected data.
@@ -25,22 +42,15 @@ export const urlMatchesSource = (url: URL, source: UrlSource): boolean => {
   }
 };
 
-export type ImportSource = 'anvil' | '';
+export const isAnvilImport = (importRequest: ImportRequest): boolean => {
+  return 'url' in importRequest && anvilSources.some((source) => urlMatchesSource(importRequest.url, source));
+};
+
+export type ImportSource = 'anvil';
 
 /**
- * This method identifies an import source. Currently it only identifies AnVIL Explorer.
+ * This method identifies an import source for metrics. Currently it only identifies AnVIL Explorer.
  */
-export const getImportSource = (url: URL): ImportSource => {
-  const anvilSources = [
-    // AnVIL production
-    'service.prod.anvil.gi.ucsc.edu',
-    'edu-ucsc-gi-platform-anvil-prod-storage-anvilprod.us-east-1',
-    // AnVIL development
-    'service.anvil.gi.ucsc.edu',
-    'edu-ucsc-gi-platform-anvil-dev-storage-anvildev.us-east-1',
-  ];
-  if (anvilSources.some((path) => url.href.includes(path))) {
-    return 'anvil';
-  }
-  return '';
+export const getImportSource = (importRequest: ImportRequest): ImportSource | undefined => {
+  return isAnvilImport(importRequest) ? 'anvil' : undefined;
 };


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1843

A bit more AnVIL import related refactoring...

Currently, we have two different ways to identify AnVIL imports:
- Stricter `UrlSource` matching used by `requiresSecurityMonitoring` (which is used for filtering destination workspaces)
- Looser substring matching used by `getImportSource` (which is used for reporting metrics)

This combines the two and uses the same `UrlSource` matching (via a `isAnvilImport` function) for both. It also refactors `getImportSource` to take an `ImportRequest` object like other import related utilities.

Finally, it changes the return type of `getImportSource` from `'anvil' | ''` to `'anvil' | undefined`. Currently, we report the `importSource` field for import metrics as either not set, an empty string, or "anvil". This narrows it down to "anvil" or not set.