### PR TITLE
WM-2658: Workflows app status panel POC

### DIFF
--- a/src/libs/ajax/workflows-app/CromwellApp.js
+++ b/src/libs/ajax/workflows-app/CromwellApp.js
@@ -38,4 +38,9 @@ export const CromwellApp = (signal) => ({
     const res = await fetchFromProxy(cromwellUrlRoot)(`api/workflows/v1/callcaching/diff?${qs.stringify(params)}`, _.merge(authOpts(), { signal }));
     return res.json();
   },
+  engineStatus: async (cromwellUrlRoot) => {
+    const res = await fetchFromProxy(cromwellUrlRoot)('engine/v1/status', _.mergeAll([authOpts(), { signal, method: 'GET' }]));
+
+    return res.json();
+  },
 });

--- a/src/libs/feature-previews-config.ts
+++ b/src/libs/feature-previews-config.ts
@@ -124,7 +124,7 @@ const featurePreviewsConfig: readonly FeaturePreview[] = [
     title: 'Workflows App Status Modal',
     description: 'Enabling this feature will allow you to view the status of the workflows app.',
     feedbackUrl: `mailto:dsp-workflow-management@broadinstitute.org?subject=${encodeURIComponent(
-      'Feedback on deprecating Firecloud UI'
+      'Feedback on Workflows App Status Modal'
     )}`,
   },
 ];

--- a/src/libs/feature-previews-config.ts
+++ b/src/libs/feature-previews-config.ts
@@ -5,7 +5,6 @@ export const ENABLE_WORKFLOW_RESOURCE_MONITORING = 'enableWorkflowResourceMonito
 export const ENABLE_AZURE_PFB_IMPORT = 'enableAzurePfbImport';
 export const ENABLE_AZURE_TDR_IMPORT = 'enableAzureTdrImport';
 export const FIRECLOUD_UI_MIGRATION = 'firecloudUiMigration';
-export const WORKFLOWS_APP_STATUS = 'workflowsAppStatus';
 
 // If the groups option is defined for a FeaturePreview, it must contain at least one group.
 type GroupsList = readonly [string, ...string[]];
@@ -117,14 +116,6 @@ const featurePreviewsConfig: readonly FeaturePreview[] = [
     description: 'Enabling this feature will update replaceable links to Firecloud UI with new links to Terra UI',
     feedbackUrl: `mailto:dsp-workflow-management@broadinstitute.org?subject=${encodeURIComponent(
       'Feedback on deprecating Firecloud UI'
-    )}`,
-  },
-  {
-    id: WORKFLOWS_APP_STATUS,
-    title: 'Workflows App Status Modal',
-    description: 'Enabling this feature will allow you to view the status of the workflows app.',
-    feedbackUrl: `mailto:dsp-workflow-management@broadinstitute.org?subject=${encodeURIComponent(
-      'Feedback on Workflows App Status Modal'
     )}`,
   },
 ];

--- a/src/libs/feature-previews-config.ts
+++ b/src/libs/feature-previews-config.ts
@@ -5,6 +5,7 @@ export const ENABLE_WORKFLOW_RESOURCE_MONITORING = 'enableWorkflowResourceMonito
 export const ENABLE_AZURE_PFB_IMPORT = 'enableAzurePfbImport';
 export const ENABLE_AZURE_TDR_IMPORT = 'enableAzureTdrImport';
 export const FIRECLOUD_UI_MIGRATION = 'firecloudUiMigration';
+export const WORKFLOWS_APP_STATUS = 'workflowsAppStatus';
 
 // If the groups option is defined for a FeaturePreview, it must contain at least one group.
 type GroupsList = readonly [string, ...string[]];
@@ -114,6 +115,14 @@ const featurePreviewsConfig: readonly FeaturePreview[] = [
     id: FIRECLOUD_UI_MIGRATION,
     title: 'Firecloud UI Feature Migration',
     description: 'Enabling this feature will update replaceable links to Firecloud UI with new links to Terra UI',
+    feedbackUrl: `mailto:dsp-workflow-management@broadinstitute.org?subject=${encodeURIComponent(
+      'Feedback on deprecating Firecloud UI'
+    )}`,
+  },
+  {
+    id: WORKFLOWS_APP_STATUS,
+    title: 'Workflows App Status Modal',
+    description: 'Enabling this feature will allow you to view the status of the workflows app.',
     feedbackUrl: `mailto:dsp-workflow-management@broadinstitute.org?subject=${encodeURIComponent(
       'Feedback on deprecating Firecloud UI'
     )}`,

--- a/src/workflows-app/components/WorkflowsAppNavPanel.ts
+++ b/src/workflows-app/components/WorkflowsAppNavPanel.ts
@@ -250,7 +250,6 @@ export const WorkflowsAppNavPanel = ({
             'aria-label': 'troubleshooting-button',
             style: {
               ...styles.subHeaders(false),
-              // color: colors.accent(1.1),
               fontSize: 16,
             },
             onClick: () => setStatusModalVisible(true),

--- a/src/workflows-app/components/WorkflowsAppNavPanel.ts
+++ b/src/workflows-app/components/WorkflowsAppNavPanel.ts
@@ -25,7 +25,7 @@ import { WorkflowsTroubleshooter } from 'src/workflows-app/status/WorkflowsTroub
 import { BaseSubmissionHistory } from 'src/workflows-app/SubmissionHistory';
 import { analysesDataInitialized, loadingYourWorkflowsApp } from 'src/workflows-app/utils/app-utils';
 import { WorkflowsInWorkspace } from 'src/workflows-app/WorkflowsInWorkspace';
-import { WorkspaceWrapper } from 'src/workspaces/utils';
+import { AzureWorkspace } from 'src/workspaces/utils';
 
 const subHeadersMap = {
   'workspace-workflows': 'Workflows in this workspace',
@@ -72,7 +72,7 @@ type WorkflowsAppNavPanelProps = {
   loading: boolean;
   name: string;
   namespace: string;
-  workspace: WorkspaceWrapper;
+  workspace: AzureWorkspace;
   analysesData: AnalysesData;
   launcherDisabled: boolean;
   launching: boolean;

--- a/src/workflows-app/components/WorkflowsAppNavPanel.ts
+++ b/src/workflows-app/components/WorkflowsAppNavPanel.ts
@@ -11,8 +11,6 @@ import { useMetricsEvent } from 'src/libs/ajax/metrics/useMetrics';
 import colors from 'src/libs/colors';
 import { getConfig } from 'src/libs/config';
 import Events, { extractWorkspaceDetails } from 'src/libs/events';
-import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
-import { WORKFLOWS_APP_STATUS } from 'src/libs/feature-previews-config';
 import { useQueryParameter } from 'src/libs/nav';
 import * as Style from 'src/libs/style';
 import * as Utils from 'src/libs/utils';
@@ -246,25 +244,24 @@ export const WorkflowsAppNavPanel = ({
             ),
           ]
         ),
-        isFeaturePreviewEnabled(WORKFLOWS_APP_STATUS) &&
-          h(
-            Clickable,
-            {
-              'aria-label': 'troubleshooting-button',
-              style: {
-                ...styles.subHeaders(false),
-                // color: colors.accent(1.1),
-                fontSize: 16,
-              },
-              onClick: () => setStatusModalVisible(true),
+        h(
+          Clickable,
+          {
+            'aria-label': 'troubleshooting-button',
+            style: {
+              ...styles.subHeaders(false),
+              // color: colors.accent(1.1),
+              fontSize: 16,
             },
-            [
-              h(ListItem, {
-                title: 'Workflows app status',
-                pageReady: true,
-              }),
-            ]
-          ),
+            onClick: () => setStatusModalVisible(true),
+          },
+          [
+            h(ListItem, {
+              title: 'Workflows app status',
+              pageReady: true,
+            }),
+          ]
+        ),
         div(
           {
             style: { marginTop: '2rem' },

--- a/src/workflows-app/status/WorkflowsTroubleshooter.test.ts
+++ b/src/workflows-app/status/WorkflowsTroubleshooter.test.ts
@@ -1,0 +1,259 @@
+import { screen, within } from '@testing-library/react';
+import { h } from 'react-hyperscript-helpers';
+import { asMockedFn, renderWithAppContexts as render } from 'src/testing/test-utils';
+import { useWorkflowsStatus, WorkflowsStatus } from 'src/workflows-app/status/workflows-status';
+import { WorkflowsTroubleshooter } from 'src/workflows-app/status/WorkflowsTroubleshooter';
+
+type WorkflowsStatusExports = typeof import('./workflows-status');
+jest.mock('./workflows-status', (): WorkflowsStatusExports => {
+  return {
+    useWorkflowsStatus: jest.fn(),
+  };
+});
+
+type TroubleshooterRow = {
+  label: string;
+  content: string;
+  icon: string;
+};
+const extractRow = (cells: HTMLElement[]): TroubleshooterRow => {
+  const label: string = cells.at(1)!.textContent!.trim();
+  const content: string = cells.at(2)!.textContent!.trim();
+
+  const iconCell = cells.at(0)!;
+  let icon: string;
+  if (within(iconCell).queryAllByLabelText('Validation Success').length > 0) {
+    icon = 'CHECK';
+  } else if (within(iconCell).queryAllByLabelText('Validation Running').length > 0) {
+    icon = 'SPINNER';
+  } else if (within(iconCell).queryAllByLabelText('Validation Failure').length > 0) {
+    icon = 'ERROR';
+  } else {
+    throw new Error('Unknown icon');
+  }
+
+  return { label, content, icon };
+};
+
+const noDataYetStatus: WorkflowsStatus = {
+  cbasCromwellConnection: null,
+  cbasEcmConnection: null,
+  cbasLeonardoConnection: null,
+  cbasProxyUrl: null,
+  cbasResponsive: null,
+  cbasSamConnection: null,
+  cromwellReaderDatabaseConnection: null,
+  cromwellReaderProxyUrl: null,
+  cromwellReaderResponsive: null,
+  cromwellRunnerAppName: null,
+  cromwellRunnerAppStatus: null,
+  cromwellRunnerDatabaseConnection: null,
+  cromwellRunnerProxyUrl: null,
+  cromwellRunnerResponsive: null,
+  totalVisibleApps: null,
+  workflowsAppName: null,
+  workflowsAppStatus: null,
+};
+
+const textStatusFields = {
+  totalVisibleApps: 'Total apps visible',
+  workflowsAppName: 'Workflows app name',
+  workflowsAppStatus: 'Workflows app status',
+  cromwellRunnerAppName: 'Cromwell runner app name',
+  cromwellRunnerAppStatus: 'Cromwell runner app status',
+  cbasProxyUrl: 'CBAS proxy url',
+  cromwellReaderProxyUrl: 'Cromwell reader proxy url',
+  cromwellRunnerProxyUrl: 'Cromwell runner proxy url',
+};
+
+const booleanStatusFields = {
+  cbasResponsive: 'CBAS responsive',
+  cbasCromwellConnection: 'CBAS / Cromwell link',
+  cbasEcmConnection: 'CBAS / ECM link',
+  cbasSamConnection: 'CBAS / SAM link',
+  cbasLeonardoConnection: 'CBAS / Leonardo link',
+  cromwellReaderResponsive: 'Cromwell reader responsive',
+  cromwellReaderDatabaseConnection: 'Cromwell reader database',
+  cromwellRunnerResponsive: 'Cromwell runner responsive',
+  cromwellRunnerDatabaseConnection: 'Cromwell runner database',
+};
+
+const noDataYetExpectation: TroubleshooterRow[] = [
+  {
+    label: 'Workspace Id',
+    content: 'test-workspace',
+    icon: 'CHECK',
+  },
+  {
+    label: 'Tenant Id',
+    content: 'test-tenant',
+    icon: 'CHECK',
+  },
+  {
+    label: 'Subscription Id',
+    content: 'test-subscription',
+    icon: 'CHECK',
+  },
+  {
+    label: 'Resource Group Id',
+    content: 'test-mrg',
+    icon: 'CHECK',
+  },
+  {
+    label: 'Total apps visible',
+    content: '',
+    icon: 'SPINNER',
+  },
+  {
+    label: 'Workflows app name',
+    content: '',
+    icon: 'SPINNER',
+  },
+  {
+    label: 'Workflows app status',
+    content: '',
+    icon: 'SPINNER',
+  },
+  {
+    label: 'Cromwell runner app name',
+    content: '',
+    icon: 'SPINNER',
+  },
+  {
+    label: 'Cromwell runner app status',
+    content: '',
+    icon: 'SPINNER',
+  },
+  {
+    label: 'CBAS proxy url',
+    content: '',
+    icon: 'SPINNER',
+  },
+  {
+    label: 'Cromwell reader proxy url',
+    content: '',
+    icon: 'SPINNER',
+  },
+  {
+    label: 'Cromwell runner proxy url',
+    content: '',
+    icon: 'SPINNER',
+  },
+  {
+    label: 'CBAS responsive',
+    content: '',
+    icon: 'SPINNER',
+  },
+  {
+    label: 'CBAS / Cromwell link',
+    content: '',
+    icon: 'SPINNER',
+  },
+  {
+    label: 'CBAS / ECM link',
+    content: '',
+    icon: 'SPINNER',
+  },
+  {
+    label: 'CBAS / SAM link',
+    content: '',
+    icon: 'SPINNER',
+  },
+  {
+    label: 'CBAS / Leonardo link',
+    content: '',
+    icon: 'SPINNER',
+  },
+  {
+    label: 'Cromwell reader responsive',
+    content: '',
+    icon: 'SPINNER',
+  },
+  {
+    label: 'Cromwell reader database',
+    content: '',
+    icon: 'SPINNER',
+  },
+  {
+    label: 'Cromwell runner responsive',
+    content: '',
+    icon: 'SPINNER',
+  },
+  {
+    label: 'Cromwell runner database',
+    content: '',
+    icon: 'SPINNER',
+  },
+].sort();
+
+const updatedUninitializedTroubleshooterRows = (label: string, content: string, icon: string) => {
+  const expectedRows = [...noDataYetExpectation];
+  const indexToReplace = expectedRows.findIndex((row) => row.label === label);
+  expectedRows[indexToReplace] = { label, content, icon };
+  return expectedRows;
+};
+
+const renderPageAndValidateRows: (status: WorkflowsStatus, expectedRows: TroubleshooterRow[]) => void = (
+  status: WorkflowsStatus,
+  expectedRows: TroubleshooterRow[]
+) => {
+  asMockedFn(useWorkflowsStatus).mockReturnValue({
+    status,
+    refreshStatus: jest.fn(),
+  });
+
+  render(
+    h(WorkflowsTroubleshooter, {
+      workspaceId: 'test-workspace',
+      mrgId: 'test-mrg',
+      tenantId: 'test-tenant',
+      subscriptionId: 'test-subscription',
+      onDismiss: jest.fn(),
+    })
+  );
+
+  const tableRows = screen.getAllByRole('row');
+  const statusLabelAndValueCells = tableRows.map((row) => {
+    const cells = within(row).getAllByRole('cell');
+    return extractRow(cells);
+  });
+
+  expect(statusLabelAndValueCells.sort()).toEqual(expectedRows.sort());
+};
+
+describe('WorkflowsTroubleshooter', () => {
+  it('renders null (non-initialized) values as empty with spinner icon', () => {
+    renderPageAndValidateRows(noDataYetStatus, noDataYetExpectation);
+  });
+
+  Object.entries(textStatusFields).forEach(([field, label]) => {
+    it(`renders text value ${label} as ${field}`, () => {
+      const testStatus: WorkflowsStatus = { ...noDataYetStatus };
+      testStatus[field] = 'test-value';
+
+      const expectedRows = updatedUninitializedTroubleshooterRows(label, 'test-value', 'CHECK');
+
+      renderPageAndValidateRows(testStatus, expectedRows);
+    });
+  });
+
+  Object.entries(booleanStatusFields).forEach(([field, label]) => {
+    it(`renders successful ${field} status in ${label}`, () => {
+      const testStatus: WorkflowsStatus = { ...noDataYetStatus };
+      testStatus[field] = 'true';
+
+      const expectedRows = updatedUninitializedTroubleshooterRows(label, 'true', 'CHECK');
+
+      renderPageAndValidateRows(testStatus, expectedRows);
+    });
+
+    it(`renders unsuccessful ${label} status in ${field}`, () => {
+      const testStatus: WorkflowsStatus = { ...noDataYetStatus };
+      testStatus[field] = 'false';
+
+      const expectedRows = updatedUninitializedTroubleshooterRows(label, 'false', 'ERROR');
+
+      renderPageAndValidateRows(testStatus, expectedRows);
+    });
+  });
+});

--- a/src/workflows-app/status/WorkflowsTroubleshooter.ts
+++ b/src/workflows-app/status/WorkflowsTroubleshooter.ts
@@ -70,7 +70,7 @@ export const WorkflowsTroubleshooter = ({ onDismiss, workspaceId, mrgId, tenantI
       td([element || content]),
       td([
         h(ClipboardButton, {
-          text: content,
+          text: content || '',
           style: { marginLeft: '0.5rem' },
           onClick: (e) => e.stopPropagation(), // this stops the collapse when copying
         }),

--- a/src/workflows-app/status/WorkflowsTroubleshooter.ts
+++ b/src/workflows-app/status/WorkflowsTroubleshooter.ts
@@ -1,0 +1,230 @@
+import { Modal } from '@terra-ui-packages/components';
+import _ from 'lodash/fp';
+import { ReactNode } from 'react';
+import { div, h, table, tbody, td, tr } from 'react-hyperscript-helpers';
+import { ClipboardButton } from 'src/components/ClipboardButton';
+import { ButtonPrimary, Link } from 'src/components/common';
+import { icon } from 'src/components/icons';
+import colors from 'src/libs/colors';
+import * as Style from 'src/libs/style';
+import * as Utils from 'src/libs/utils';
+
+import { useWorkflowsStatus } from './workflows-status';
+
+export const WorkflowsTroubleshooter = ({ onDismiss, workspaceId, mrgId, tenantId, subscriptionId }) => {
+  const { status } = useWorkflowsStatus({ workspaceId });
+
+  const {
+    totalVisibleApps,
+    workflowsAppName,
+    workflowsAppStatus,
+    cromwellRunnerAppName,
+    cromwellRunnerAppStatus,
+    cbasProxyUrl,
+    cromwellReaderProxyUrl,
+    cromwellRunnerProxyUrl,
+    cbasResponsive,
+    cbasCromwellConnection,
+    cbasEcmConnection,
+    cbasSamConnection,
+    cbasLeonardoConnection,
+    cromwellReaderResponsive,
+    cromwellReaderDatabaseConnection,
+    cromwellRunnerResponsive,
+    cromwellRunnerDatabaseConnection,
+  } = status;
+
+  const checkIcon = (status, size = 24) =>
+    Utils.switchCase(
+      status,
+      [
+        'success',
+        () =>
+          icon('success-standard', { size, style: { color: colors.success() }, 'aria-label': 'Validation Success' }),
+      ],
+      [
+        'failure',
+        () =>
+          icon('error-standard', { size, style: { color: colors.danger(0.85) }, 'aria-label': 'Validation Failure' }),
+      ],
+      [
+        'running',
+        () => icon('loadingSpinner', { size, style: { color: colors.primary() }, 'aria-label': 'Validation Running' }),
+      ]
+    );
+
+  const troubleShooterRow = ([label, content, iconRunning, iconSuccess, element]: [
+    string,
+    string | null,
+    boolean,
+    boolean,
+    ReactNode?
+  ]) => {
+    return tr({ key: label }, [
+      td({ style: { fontWeight: 'bold' } }, [
+        // TODO: Remove nested ternary to align with style guide
+        // eslint-disable-next-line no-nested-ternary
+        iconRunning ? checkIcon('running') : iconSuccess ? checkIcon('success') : checkIcon('failure'),
+      ]),
+      td({ style: { fontWeight: 'bold', whiteSpace: 'nowrap' } }, [label]),
+      td([element || content]),
+      td([
+        h(ClipboardButton, {
+          text: content,
+          style: { marginLeft: '0.5rem' },
+          onClick: (e) => e.stopPropagation(), // this stops the collapse when copying
+        }),
+      ]),
+    ]);
+  };
+
+  // The proxyUrl is long and should be truncated,
+  // so it gets it own special element
+  const proxyElement = (proxyUrl) =>
+    div({ style: _.merge({ width: '400px', float: 'left' }, Style.noWrapEllipsis) }, [proxyUrl]);
+
+  const subscriptionLinkElement =
+    mrgId && tenantId && subscriptionId
+      ? h(
+          Link,
+          {
+            href: `https://portal.azure.com/#@${tenantId}}/resource/subscriptions/${subscriptionId}/overview`,
+            target: '_blank',
+            rel: 'noopener noreferrer',
+          },
+          [subscriptionId, ' ', icon('pop-out')]
+        )
+      : subscriptionId;
+  const mrgLinkElement =
+    mrgId && tenantId && subscriptionId
+      ? h(
+          Link,
+          {
+            href: `https://portal.azure.com/#@${tenantId}}/resource/subscriptions/${subscriptionId}/resourceGroups/${mrgId}/overview`,
+            target: '_blank',
+            rel: 'noopener noreferrer',
+          },
+          [mrgId, ' ', icon('pop-out')]
+        )
+      : null;
+
+  /** For each piece of information we want to include in the troubleshooter, we want:
+   * 1. A label
+   * 2. The rendered information
+   * 3. A function or variable that evaluates to boolean, determining whether the info/validation is still running
+   * 4. A function or variable that evaluates to boolean, determining whether the info/validation is successful
+   * 5. An optional element to use in place of the standard defined in troubleShooterRow
+   * */
+  const troubleShooterText: [string, string | null, boolean, boolean, ReactNode?][] = [
+    ['Workspace Id', workspaceId, false, !!workspaceId],
+    ['Tenant Id', tenantId, false, !!tenantId],
+    ['Subscription Id', subscriptionId, false, !!subscriptionId, subscriptionLinkElement],
+    ['Resource Group Id', mrgId, false, !!mrgId, mrgLinkElement],
+    [
+      'Total apps visible',
+      totalVisibleApps,
+      totalVisibleApps === null,
+      !!totalVisibleApps && totalVisibleApps !== 'unknown',
+    ],
+
+    [
+      'Workflows app name',
+      workflowsAppName,
+      workflowsAppName === null,
+      !!workflowsAppName && workflowsAppName !== 'unknown',
+    ],
+    [
+      'Workflows app status',
+      workflowsAppStatus,
+      workflowsAppStatus == null,
+      !!workflowsAppStatus && workflowsAppStatus !== 'unknown' && workflowsAppStatus !== 'ERROR',
+    ],
+    [
+      'Cromwell runner app name',
+      cromwellRunnerAppName,
+      cromwellRunnerAppName === null,
+      !!cromwellRunnerAppName && cromwellRunnerAppName !== 'unknown',
+    ],
+    [
+      'Cromwell runner app status',
+      cromwellRunnerAppStatus,
+      cromwellRunnerAppStatus == null,
+      !!cromwellRunnerAppStatus && cromwellRunnerAppStatus !== 'unknown' && cromwellRunnerAppStatus !== 'ERROR',
+    ],
+    [
+      'CBAS proxy url',
+      cbasProxyUrl,
+      cbasProxyUrl == null,
+      !!cbasProxyUrl && cbasProxyUrl !== 'unknown',
+      proxyElement(cbasProxyUrl),
+    ],
+    [
+      'Cromwell reader proxy url',
+      cromwellReaderProxyUrl,
+      cromwellReaderProxyUrl == null,
+      !!cromwellReaderProxyUrl && cromwellReaderProxyUrl !== 'unknown',
+      proxyElement(cromwellReaderProxyUrl),
+    ],
+    [
+      'Cromwell runner proxy url',
+      cromwellRunnerProxyUrl,
+      cromwellRunnerProxyUrl == null,
+      !!cromwellRunnerProxyUrl && cromwellRunnerProxyUrl !== 'unknown',
+      proxyElement(cromwellRunnerProxyUrl),
+    ],
+    ['CBAS responsive', cbasResponsive, cbasResponsive == null, cbasResponsive === 'true'],
+    ['CBAS / Cromwell link', cbasCromwellConnection, cbasCromwellConnection == null, cbasCromwellConnection === 'true'],
+    ['CBAS / ECM link', cbasEcmConnection, cbasEcmConnection == null, cbasEcmConnection === 'true'],
+    ['CBAS / SAM link', cbasSamConnection, cbasSamConnection == null, cbasSamConnection === 'true'],
+    ['CBAS / Leonardo link', cbasLeonardoConnection, cbasLeonardoConnection == null, cbasLeonardoConnection === 'true'],
+    [
+      'Cromwell reader responsive',
+      cromwellReaderResponsive,
+      cromwellReaderResponsive == null,
+      cromwellReaderResponsive === 'true',
+    ],
+    [
+      'Cromwell reader database',
+      cromwellReaderDatabaseConnection,
+      cromwellReaderDatabaseConnection == null,
+      cromwellReaderDatabaseConnection === 'true',
+    ],
+    [
+      'Cromwell runner responsive',
+      cromwellRunnerResponsive,
+      cromwellRunnerResponsive == null,
+      cromwellRunnerResponsive === 'true',
+    ],
+    [
+      'Cromwell runner database',
+      cromwellRunnerDatabaseConnection,
+      cromwellRunnerDatabaseConnection == null,
+      cromwellRunnerDatabaseConnection === 'true',
+    ],
+  ];
+
+  const tableRows = troubleShooterText.map((x) => troubleShooterRow(x));
+
+  return h(
+    Modal,
+    {
+      showCancel: false,
+      onDismiss,
+      title: 'Workflows Status',
+      width: '55rem',
+      okButton: h(
+        ButtonPrimary,
+        {
+          tooltip: 'Close',
+          onClick: onDismiss,
+        },
+        ['Close']
+      ),
+    },
+    [
+      div({ style: { padding: '1rem 0.5rem', lineHeight: '1.4rem' } }, [
+        table({ style: { borderSpacing: '1rem 0', borderCollapse: 'separate' } }, [tbody([tableRows])]),
+      ]),
+    ]
+  );
+};

--- a/src/workflows-app/status/WorkflowsTroubleshooter.ts
+++ b/src/workflows-app/status/WorkflowsTroubleshooter.ts
@@ -53,6 +53,16 @@ export const WorkflowsTroubleshooter = ({ onDismiss, workspaceId, mrgId, tenantI
       ]
     );
 
+  const iconFromBooleans = (iconRunning, iconSuccess) => {
+    if (iconRunning) {
+      return checkIcon('running');
+    }
+    if (iconSuccess) {
+      return checkIcon('success');
+    }
+    return checkIcon('failure');
+  };
+
   const troubleShooterRow = ([label, content, iconRunning, iconSuccess, element]: [
     string,
     string | null,
@@ -61,16 +71,12 @@ export const WorkflowsTroubleshooter = ({ onDismiss, workspaceId, mrgId, tenantI
     ReactNode?
   ]) => {
     return tr({ key: label }, [
-      td({ style: { fontWeight: 'bold' } }, [
-        // TODO: Remove nested ternary to align with style guide
-        // eslint-disable-next-line no-nested-ternary
-        iconRunning ? checkIcon('running') : iconSuccess ? checkIcon('success') : checkIcon('failure'),
-      ]),
+      td({ style: { fontWeight: 'bold' } }, [iconFromBooleans(iconRunning, iconSuccess)]),
       td({ style: { fontWeight: 'bold', whiteSpace: 'nowrap' } }, [label]),
       td([element || content]),
       td([
         h(ClipboardButton, {
-          text: content || '',
+          text: content ?? '',
           style: { marginLeft: '0.5rem' },
           onClick: (e) => e.stopPropagation(), // this stops the collapse when copying
         }),

--- a/src/workflows-app/status/workflows-status.test.ts
+++ b/src/workflows-app/status/workflows-status.test.ts
@@ -232,8 +232,8 @@ describe('useWorkflowsStatus', () => {
         cromwellRunnerResponsive: 'unknown',
         cromwellRunnerDatabaseConnection: 'unknown',
       });
-      expect(mockAjax.Cbas.status).toHaveBeenCalledWith(workflowsAppObject.proxyUrls.cbas);
-      expect(mockAjax.CromwellApp.engineStatus).toHaveBeenCalledWith(workflowsAppObject.proxyUrls['cromwell-reader']);
+      expect(mockAjax.Cbas!.status).toHaveBeenCalledWith(workflowsAppObject.proxyUrls.cbas);
+      expect(mockAjax.CromwellApp!.engineStatus).toHaveBeenCalledWith(workflowsAppObject.proxyUrls['cromwell-reader']);
     });
 
     it('uses CBAS and Cromwell status endpoints', async () => {
@@ -315,7 +315,7 @@ describe('useWorkflowsStatus', () => {
         cromwellRunnerResponsive: null,
         cromwellRunnerDatabaseConnection: null,
       });
-      expect(mockAjax.CromwellApp.engineStatus).toHaveBeenCalledWith(
+      expect(mockAjax.CromwellApp!.engineStatus).toHaveBeenCalledWith(
         cromwellRunnerAppObject.proxyUrls['cromwell-runner']
       );
     });

--- a/src/workflows-app/status/workflows-status.test.ts
+++ b/src/workflows-app/status/workflows-status.test.ts
@@ -1,0 +1,404 @@
+import { abandonedPromise, DeepPartial } from '@terra-ui-packages/core-utils';
+import { Ajax } from 'src/libs/ajax';
+import { ListAppItem } from 'src/libs/ajax/leonardo/models/app-models';
+import { asMockedFn, renderHookInAct } from 'src/testing/test-utils';
+import { useWorkflowsStatus } from 'src/workflows-app/status/workflows-status';
+
+type AjaxExports = typeof import('src/libs/ajax');
+jest.mock('src/libs/ajax', (): Partial<AjaxExports> => {
+  return { Ajax: jest.fn() };
+});
+
+type AjaxContract = ReturnType<typeof Ajax>;
+
+const workspaceId = 'test-workspace-id';
+
+const workflowsAppObject: ListAppItem = {
+  workspaceId,
+  cloudContext: {
+    cloudProvider: 'AZURE',
+    cloudResource: '(unused)',
+  },
+  kubernetesRuntimeConfig: {
+    numNodes: 1,
+    machineType: 'Standard_A2_v2',
+    autoscalingEnabled: false,
+  },
+  errors: [],
+  status: 'RUNNING',
+  proxyUrls: {
+    cbas: 'https://test-url/cbas-blah/',
+    'cromwell-reader': 'https://test-url/cromwell-reader-blah/',
+    listener: 'https://test-url/listener-blah/',
+  },
+  appName: 'wfa-blah',
+  appType: 'WORKFLOWS_APP',
+  diskName: null,
+  auditInfo: {
+    creator: 'user@example.com',
+    createdDate: '2023-07-11T18:59:09.369822Z',
+    destroyedDate: null,
+    dateAccessed: '2023-07-11T18:59:09.369822Z',
+  },
+  accessScope: 'WORKSPACE_SHARED',
+  labels: {},
+  region: 'is-central1',
+};
+
+const cromwellRunnerAppObject: ListAppItem = {
+  workspaceId,
+  cloudContext: {
+    cloudProvider: 'AZURE',
+    cloudResource: '(unused)',
+  },
+  kubernetesRuntimeConfig: {
+    numNodes: 1,
+    machineType: 'Standard_A2_v2',
+    autoscalingEnabled: false,
+  },
+  errors: [],
+  status: 'RUNNING',
+  proxyUrls: {
+    'cromwell-runner': 'https://test-url/cromwell-runner-blah/',
+    listener: 'https://test-url/listener-blah/',
+  },
+  appName: 'cra-blah',
+  appType: 'CROMWELL_RUNNER_APP',
+  diskName: null,
+  auditInfo: {
+    creator: 'user@example.com',
+    createdDate: '2023-07-11T18:59:09.369822Z',
+    destroyedDate: null,
+    dateAccessed: '2023-07-11T18:59:09.369822Z',
+  },
+  accessScope: 'USER_PRIVATE',
+  labels: {},
+  region: 'is-central1',
+};
+
+const cbasStatusResponse = {
+  ok: true,
+  systems: {
+    cromwell: {
+      ok: true,
+      messages: ['(unused)'],
+    },
+    ecm: {
+      ok: true,
+      messages: ['(unused)'],
+    },
+    sam: {
+      ok: true,
+      messages: ['(unused)'],
+    },
+    leonardo: {
+      ok: true,
+      messages: ['(unused)'],
+    },
+  },
+};
+
+const cromwellStatusResponse = { 'Engine Database': { ok: true } };
+
+describe('useWorkflowsStatus', () => {
+  it('fetches Leo apps', async () => {
+    // Arrange
+    const listAppsV2 = jest.fn().mockResolvedValue([]);
+    const mockAjax: DeepPartial<AjaxContract> = {
+      Apps: {
+        listAppsV2,
+      },
+    };
+    asMockedFn(Ajax).mockReturnValue(mockAjax as AjaxContract);
+
+    // Act
+    await renderHookInAct(() => useWorkflowsStatus({ workspaceId }));
+
+    // Assert
+    expect(listAppsV2).toHaveBeenCalledWith(workspaceId);
+  });
+
+  describe('if fetching Leo apps fails', () => {
+    it('returns unknown for all fields', async () => {
+      // Arrange
+      const mockAjax: DeepPartial<AjaxContract> = {
+        Apps: {
+          listAppsV2: jest.fn().mockRejectedValue(new Error('Something went wrong')),
+        },
+      };
+      asMockedFn(Ajax).mockReturnValue(mockAjax as AjaxContract);
+
+      // Act
+      const { result: hookReturnRef } = await renderHookInAct(() => useWorkflowsStatus({ workspaceId }));
+
+      // Assert
+      expect(hookReturnRef.current.status).toEqual({
+        totalVisibleApps: 'unknown',
+        workflowsAppName: 'unknown',
+        workflowsAppStatus: 'unknown',
+        cromwellRunnerAppName: 'unknown',
+        cromwellRunnerAppStatus: 'unknown',
+        cbasProxyUrl: 'unknown',
+        cromwellReaderProxyUrl: 'unknown',
+        cromwellRunnerProxyUrl: 'unknown',
+        cbasResponsive: 'unknown',
+        cbasCromwellConnection: 'unknown',
+        cbasEcmConnection: 'unknown',
+        cbasSamConnection: 'unknown',
+        cbasLeonardoConnection: 'unknown',
+        cromwellReaderResponsive: 'unknown',
+        cromwellReaderDatabaseConnection: 'unknown',
+        cromwellRunnerResponsive: 'unknown',
+        cromwellRunnerDatabaseConnection: 'unknown',
+      });
+    });
+  });
+
+  describe('if Leo apps are fetched successfully', () => {
+    describe('if no apps are present', () => {
+      it('returns number of apps and unknown for other fields', async () => {
+        // Arrange
+        const mockAjax: DeepPartial<AjaxContract> = {
+          Apps: {
+            listAppsV2: jest.fn().mockResolvedValue([]),
+          },
+        };
+        asMockedFn(Ajax).mockReturnValue(mockAjax as AjaxContract);
+
+        // Act
+        const { result: hookReturnRef } = await renderHookInAct(() => useWorkflowsStatus({ workspaceId }));
+
+        // Assert
+        expect(hookReturnRef.current.status).toEqual({
+          totalVisibleApps: '0',
+          workflowsAppName: 'unknown',
+          workflowsAppStatus: 'unknown',
+          cromwellRunnerAppName: 'unknown',
+          cromwellRunnerAppStatus: 'unknown',
+          cbasProxyUrl: 'unknown',
+          cromwellReaderProxyUrl: 'unknown',
+          cromwellRunnerProxyUrl: 'unknown',
+          cbasResponsive: 'unknown',
+          cbasCromwellConnection: 'unknown',
+          cbasEcmConnection: 'unknown',
+          cbasSamConnection: 'unknown',
+          cbasLeonardoConnection: 'unknown',
+          cromwellReaderResponsive: 'unknown',
+          cromwellReaderDatabaseConnection: 'unknown',
+          cromwellRunnerResponsive: 'unknown',
+          cromwellRunnerDatabaseConnection: 'unknown',
+        });
+      });
+    });
+  });
+
+  describe('if workflows app is present', () => {
+    it('uses Leo app response to fill in fields while waiting for service status', async () => {
+      // Arrange
+      const mockAjax: DeepPartial<AjaxContract> = {
+        Apps: {
+          listAppsV2: jest.fn().mockResolvedValue([workflowsAppObject]),
+        },
+        Cbas: {
+          status: jest.fn().mockReturnValue(abandonedPromise()),
+        },
+        CromwellApp: {
+          engineStatus: jest.fn().mockReturnValue(abandonedPromise()),
+        },
+      };
+      asMockedFn(Ajax).mockReturnValue(mockAjax as AjaxContract);
+
+      // Act
+      const { result: hookReturnRef } = await renderHookInAct(() => useWorkflowsStatus({ workspaceId }));
+
+      // Assert
+      // Note: remember 'null' means pending and 'unknown' means failed.
+      expect(hookReturnRef.current.status).toEqual({
+        totalVisibleApps: '1',
+        workflowsAppName: 'wfa-blah',
+        workflowsAppStatus: 'RUNNING',
+        cromwellRunnerAppName: 'unknown',
+        cromwellRunnerAppStatus: 'unknown',
+        cbasProxyUrl: 'https://test-url/cbas-blah/',
+        cromwellReaderProxyUrl: 'https://test-url/cromwell-reader-blah/',
+        cromwellRunnerProxyUrl: 'unknown',
+        cbasResponsive: null,
+        cbasCromwellConnection: null,
+        cbasEcmConnection: null,
+        cbasSamConnection: null,
+        cbasLeonardoConnection: null,
+        cromwellReaderResponsive: null,
+        cromwellReaderDatabaseConnection: null,
+        cromwellRunnerResponsive: 'unknown',
+        cromwellRunnerDatabaseConnection: 'unknown',
+      });
+      expect(mockAjax.Cbas.status).toHaveBeenCalledWith(workflowsAppObject.proxyUrls.cbas);
+      expect(mockAjax.CromwellApp.engineStatus).toHaveBeenCalledWith(workflowsAppObject.proxyUrls['cromwell-reader']);
+    });
+
+    it('uses CBAS and Cromwell status endpoints', async () => {
+      // Arrange
+      const mockAjax: DeepPartial<AjaxContract> = {
+        Apps: {
+          listAppsV2: jest.fn().mockResolvedValue([workflowsAppObject]),
+        },
+        Cbas: {
+          status: jest.fn().mockResolvedValue(cbasStatusResponse),
+        },
+        CromwellApp: {
+          engineStatus: jest.fn().mockResolvedValue(cromwellStatusResponse),
+        },
+      };
+      asMockedFn(Ajax).mockReturnValue(mockAjax as AjaxContract);
+
+      // Act
+      const { result: hookReturnRef } = await renderHookInAct(() => useWorkflowsStatus({ workspaceId }));
+
+      // Assert
+      // Note: remember 'null' means pending and 'unknown' means failed.
+      expect(hookReturnRef.current.status).toEqual({
+        totalVisibleApps: '1',
+        workflowsAppName: 'wfa-blah',
+        workflowsAppStatus: 'RUNNING',
+        cromwellRunnerAppName: 'unknown',
+        cromwellRunnerAppStatus: 'unknown',
+        cbasProxyUrl: 'https://test-url/cbas-blah/',
+        cromwellReaderProxyUrl: 'https://test-url/cromwell-reader-blah/',
+        cromwellRunnerProxyUrl: 'unknown',
+        cbasResponsive: 'true',
+        cbasCromwellConnection: 'true',
+        cbasEcmConnection: 'true',
+        cbasSamConnection: 'true',
+        cbasLeonardoConnection: 'true',
+        cromwellReaderResponsive: 'true',
+        cromwellReaderDatabaseConnection: 'true',
+        cromwellRunnerResponsive: 'unknown',
+        cromwellRunnerDatabaseConnection: 'unknown',
+      });
+    });
+  });
+
+  describe('if CROMWELL_RUNNER_APP is present', () => {
+    it('uses Leo app response to fill in fields while waiting for service status', async () => {
+      // Arrange
+      const mockAjax: DeepPartial<AjaxContract> = {
+        Apps: {
+          listAppsV2: jest.fn().mockResolvedValue([cromwellRunnerAppObject]),
+        },
+        CromwellApp: {
+          engineStatus: jest.fn().mockReturnValue(abandonedPromise()),
+        },
+      };
+      asMockedFn(Ajax).mockReturnValue(mockAjax as AjaxContract);
+
+      // Act
+      const { result: hookReturnRef } = await renderHookInAct(() => useWorkflowsStatus({ workspaceId }));
+
+      // Assert
+      // Note: remember 'null' means pending and 'unknown' means failed.
+      expect(hookReturnRef.current.status).toEqual({
+        totalVisibleApps: '1',
+        workflowsAppName: 'unknown',
+        workflowsAppStatus: 'unknown',
+        cromwellRunnerAppName: 'cra-blah',
+        cromwellRunnerAppStatus: 'RUNNING',
+        cbasProxyUrl: 'unknown',
+        cromwellReaderProxyUrl: 'unknown',
+        cromwellRunnerProxyUrl: 'https://test-url/cromwell-runner-blah/',
+        cbasResponsive: 'unknown',
+        cbasCromwellConnection: 'unknown',
+        cbasEcmConnection: 'unknown',
+        cbasSamConnection: 'unknown',
+        cbasLeonardoConnection: 'unknown',
+        cromwellReaderResponsive: 'unknown',
+        cromwellReaderDatabaseConnection: 'unknown',
+        cromwellRunnerResponsive: null,
+        cromwellRunnerDatabaseConnection: null,
+      });
+      expect(mockAjax.CromwellApp.engineStatus).toHaveBeenCalledWith(
+        cromwellRunnerAppObject.proxyUrls['cromwell-runner']
+      );
+    });
+
+    it('fetches values from Cromwell status endpoint', async () => {
+      // Arrange
+      const mockAjax: DeepPartial<AjaxContract> = {
+        Apps: {
+          listAppsV2: jest.fn().mockResolvedValue([cromwellRunnerAppObject]),
+        },
+        CromwellApp: {
+          engineStatus: jest.fn().mockResolvedValue(cromwellStatusResponse),
+        },
+      };
+      asMockedFn(Ajax).mockReturnValue(mockAjax as AjaxContract);
+
+      // Act
+      const { result: hookReturnRef } = await renderHookInAct(() => useWorkflowsStatus({ workspaceId }));
+
+      // Assert
+      // Note: remember 'null' means pending and 'unknown' means failed.
+      expect(hookReturnRef.current.status).toEqual({
+        totalVisibleApps: '1',
+        workflowsAppName: 'unknown',
+        workflowsAppStatus: 'unknown',
+        cromwellRunnerAppName: 'cra-blah',
+        cromwellRunnerAppStatus: 'RUNNING',
+        cbasProxyUrl: 'unknown',
+        cromwellReaderProxyUrl: 'unknown',
+        cromwellRunnerProxyUrl: 'https://test-url/cromwell-runner-blah/',
+        cbasResponsive: 'unknown',
+        cbasCromwellConnection: 'unknown',
+        cbasEcmConnection: 'unknown',
+        cbasSamConnection: 'unknown',
+        cbasLeonardoConnection: 'unknown',
+        cromwellReaderResponsive: 'unknown',
+        cromwellReaderDatabaseConnection: 'unknown',
+        cromwellRunnerResponsive: 'true',
+        cromwellRunnerDatabaseConnection: 'true',
+      });
+    });
+  });
+
+  describe('if both apps are present', () => {
+    it('fetches values from CBAS and both Cromwell status endpoints', async () => {
+      // Arrange
+      const mockAjax: DeepPartial<AjaxContract> = {
+        Apps: {
+          listAppsV2: jest.fn().mockResolvedValue([workflowsAppObject, cromwellRunnerAppObject]),
+        },
+        Cbas: {
+          status: jest.fn().mockResolvedValue(cbasStatusResponse),
+        },
+        CromwellApp: {
+          engineStatus: jest.fn().mockResolvedValue(cromwellStatusResponse),
+        },
+      };
+      asMockedFn(Ajax).mockReturnValue(mockAjax as AjaxContract);
+
+      // Act
+      const { result: hookReturnRef } = await renderHookInAct(() => useWorkflowsStatus({ workspaceId }));
+
+      // Assert
+      // Note: remember 'null' means pending and 'unknown' means failed.
+      expect(hookReturnRef.current.status).toEqual({
+        totalVisibleApps: '2',
+        workflowsAppName: 'wfa-blah',
+        workflowsAppStatus: 'RUNNING',
+        cromwellRunnerAppName: 'cra-blah',
+        cromwellRunnerAppStatus: 'RUNNING',
+        cbasProxyUrl: 'https://test-url/cbas-blah/',
+        cromwellReaderProxyUrl: 'https://test-url/cromwell-reader-blah/',
+        cromwellRunnerProxyUrl: 'https://test-url/cromwell-runner-blah/',
+        cbasResponsive: 'true',
+        cbasCromwellConnection: 'true',
+        cbasEcmConnection: 'true',
+        cbasSamConnection: 'true',
+        cbasLeonardoConnection: 'true',
+        cromwellReaderResponsive: 'true',
+        cromwellReaderDatabaseConnection: 'true',
+        cromwellRunnerResponsive: 'true',
+        cromwellRunnerDatabaseConnection: 'true',
+      });
+    });
+  });
+});

--- a/src/workflows-app/status/workflows-status.ts
+++ b/src/workflows-app/status/workflows-status.ts
@@ -9,7 +9,7 @@ type UseWorkflowsStatusArgs = {
 };
 
 export type WorkflowsStatus = {
-  totalVisibleApps: number | null;
+  totalVisibleApps: string | null;
 
   workflowsAppName: string | null;
   cromwellRunnerAppName: string | null;
@@ -217,7 +217,7 @@ export const useWorkflowsStatus = ({ workspaceId }: UseWorkflowsStatusArgs) => {
       listAppsResponse = await Ajax(signal).Apps.listAppsV2(workspaceId);
     } catch (err) {
       setStatus({
-        totalVisibleApps: 0,
+        totalVisibleApps: 'unknown',
 
         workflowsAppName: 'unknown',
         workflowsAppStatus: 'unknown',
@@ -241,7 +241,7 @@ export const useWorkflowsStatus = ({ workspaceId }: UseWorkflowsStatusArgs) => {
       return;
     }
 
-    setStatus((previouStatus) => ({ ...previouStatus, totalVisibleApps: listAppsResponse.length }));
+    setStatus((previousStatus) => ({ ...previousStatus, totalVisibleApps: listAppsResponse.length.toString() }));
 
     const workflowsApp = getCurrentApp('WORKFLOWS_APP', listAppsResponse);
     await analyzeWorkflowsApp(workflowsApp, signal);

--- a/src/workflows-app/status/workflows-status.ts
+++ b/src/workflows-app/status/workflows-status.ts
@@ -1,0 +1,259 @@
+import { useEffect, useRef, useState } from 'react';
+import { getCurrentApp } from 'src/analysis/utils/app-utils';
+import { Ajax } from 'src/libs/ajax';
+import { GetAppItem, ListAppItem } from 'src/libs/ajax/leonardo/models/app-models';
+import { useCallback } from 'use-memo-one';
+
+type UseWorkflowsStatusArgs = {
+  workspaceId: string;
+};
+
+export type WorkflowsStatus = {
+  totalVisibleApps: number | null;
+
+  workflowsAppName: string | null;
+  cromwellRunnerAppName: string | null;
+  workflowsAppStatus: string | null;
+  cromwellRunnerAppStatus: string | null;
+
+  cbasProxyUrl: string | null;
+  cromwellReaderProxyUrl: string | null;
+  cromwellRunnerProxyUrl: string | null;
+
+  cbasResponsive: string | null;
+  cbasCromwellConnection: string | null;
+  cbasEcmConnection: string | null;
+  cbasSamConnection: string | null;
+  cbasLeonardoConnection: string | null;
+  cromwellReaderResponsive: string | null;
+  cromwellReaderDatabaseConnection: string | null;
+  cromwellRunnerResponsive: string | null;
+  cromwellRunnerDatabaseConnection: string | null;
+};
+
+export type UseWorkflowsStatusResult = {
+  status: WorkflowsStatus;
+  refreshStatus: () => Promise<void>;
+};
+
+const initialStatus: WorkflowsStatus = {
+  totalVisibleApps: null,
+
+  workflowsAppName: null,
+  workflowsAppStatus: null,
+  cromwellRunnerAppName: null,
+  cromwellRunnerAppStatus: null,
+
+  cbasProxyUrl: null,
+  cromwellReaderProxyUrl: null,
+  cromwellRunnerProxyUrl: null,
+
+  cbasResponsive: null,
+  cbasCromwellConnection: null,
+  cbasEcmConnection: null,
+  cbasSamConnection: null,
+  cbasLeonardoConnection: null,
+  cromwellReaderResponsive: null,
+  cromwellReaderDatabaseConnection: null,
+  cromwellRunnerResponsive: null,
+  cromwellRunnerDatabaseConnection: null,
+};
+
+export const useWorkflowsStatus = ({ workspaceId }: UseWorkflowsStatusArgs) => {
+  const [status, setStatus] = useState<WorkflowsStatus>(() => ({ ...initialStatus }));
+
+  const controllerRef = useRef<AbortController>();
+
+  async function analyzeWorkflowsApp(workflowsApp: GetAppItem | ListAppItem | undefined, signal: AbortSignal) {
+    if (!workflowsApp) {
+      setStatus((previousStatus) => ({
+        ...previousStatus,
+        workflowsAppName: 'unknown',
+        workflowsAppStatus: 'unknown',
+
+        cbasProxyUrl: 'unknown',
+        cromwellReaderProxyUrl: 'unknown',
+
+        cbasResponsive: 'unknown',
+        cbasCromwellConnection: 'unknown',
+        cbasEcmConnection: 'unknown',
+        cbasSamConnection: 'unknown',
+        cbasLeonardoConnection: 'unknown',
+        cromwellReaderResponsive: 'unknown',
+        cromwellReaderDatabaseConnection: 'unknown',
+      }));
+      return;
+    }
+
+    const cbasProxyUrl = workflowsApp.proxyUrls.cbas;
+    const cromwellReaderProxyUrl = workflowsApp.proxyUrls['cromwell-reader'];
+    setStatus((previousStatus) => ({
+      ...previousStatus,
+      workflowsAppName: workflowsApp.appName,
+      workflowsAppStatus: workflowsApp.status,
+
+      cbasProxyUrl,
+      cromwellReaderProxyUrl,
+    }));
+
+    if (workflowsApp.status !== 'RUNNING') {
+      setStatus((previousStatus) => ({
+        ...previousStatus,
+        cbasResponsive: 'unknown',
+        cbasCromwellConnection: 'unknown',
+        cbasEcmConnection: 'unknown',
+        cbasSamConnection: 'unknown',
+        cbasLeonardoConnection: 'unknown',
+        cromwellReaderResponsive: 'unknown',
+        cromwellReaderDatabaseConnection: 'unknown',
+      }));
+      return;
+    }
+
+    await Promise.allSettled([
+      Ajax(signal)
+        .Cbas.status(cbasProxyUrl)
+        .then((statusResponse) => {
+          setStatus((previouStatus) => ({
+            ...previouStatus,
+            cbasResponsive: statusResponse.ok.toString(),
+            cbasCromwellConnection: statusResponse.systems.cromwell.ok.toString(),
+            cbasEcmConnection: statusResponse.systems.ecm.ok.toString(),
+            cbasSamConnection: statusResponse.systems.sam.ok.toString(),
+            cbasLeonardoConnection: statusResponse.systems.leonardo.ok.toString(),
+          }));
+        })
+        .catch(() => {
+          setStatus((previousStatus) => ({
+            ...previousStatus,
+            cbasResponsive: 'false',
+            cbasCromwellConnection: 'unknown',
+            cbasEcmConnection: 'unknown',
+            cbasSamConnection: 'unknown',
+            cbasLeonardoConnection: 'unknown',
+          }));
+        }),
+
+      Ajax(signal)
+        .CromwellApp.engineStatus(cromwellReaderProxyUrl)
+        .then((statusResponse) => {
+          setStatus((previousStatus) => ({
+            ...previousStatus,
+            cromwellReaderResponsive: 'true',
+            cromwellReaderDatabaseConnection: statusResponse['Engine Database']?.ok.toString(),
+          }));
+        })
+        .catch(() => {
+          setStatus((previousStatus) => ({
+            ...previousStatus,
+            cromwellReaderResponsive: 'false',
+            cromwellReaderDatabaseConnection: 'unknown',
+          }));
+        }),
+    ]);
+  }
+
+  async function analyzeCromwellRunnerApp(
+    cromwellRunnerApp: GetAppItem | ListAppItem | undefined,
+    signal: AbortSignal
+  ) {
+    if (!cromwellRunnerApp) {
+      setStatus((previousStatus) => ({
+        ...previousStatus,
+        cromwellRunnerAppName: 'unknown',
+        cromwellRunnerAppStatus: 'unknown',
+        cromwellRunnerProxyUrl: 'unknown',
+        cromwellRunnerResponsive: 'unknown',
+      }));
+      return;
+    }
+
+    const cromwellRunnerProxyUrl = cromwellRunnerApp.proxyUrls['cromwell-runner'];
+    setStatus((previousStatus) => ({
+      ...previousStatus,
+      cromwellRunnerAppName: cromwellRunnerApp.appName,
+      cromwellRunnerAppStatus: cromwellRunnerApp.status,
+      cromwellRunnerProxyUrl,
+    }));
+
+    if (cromwellRunnerApp.status !== 'RUNNING') {
+      setStatus((previousStatus) => ({
+        ...previousStatus,
+        cromwellRunnerResponsive: 'unknown',
+        cromwellRunnerDatabaseConnection: 'unknown',
+      }));
+      return;
+    }
+
+    await Promise.allSettled([
+      Ajax(signal)
+        .CromwellApp.engineStatus(cromwellRunnerProxyUrl)
+        .then((statusResponse) => {
+          setStatus((previousStatus) => ({
+            ...previousStatus,
+            cromwellRunnerResponsive: 'true',
+            cromwellRunnerDatabaseConnection: statusResponse['Engine Database']?.ok.toString(),
+          }));
+        })
+        .catch(() => {
+          setStatus((previousStatus) => ({
+            ...previousStatus,
+            cromwellRunnerResponsive: 'false',
+            cromwellRunnerDatabaseConnection: 'unknown',
+          }));
+        }),
+    ]);
+  }
+
+  const refreshStatus = useCallback(async (workspaceId: string) => {
+    controllerRef.current?.abort();
+    controllerRef.current = new AbortController();
+    const signal = controllerRef.current.signal;
+
+    setStatus(() => ({ ...initialStatus }));
+
+    let listAppsResponse: ListAppItem[];
+    try {
+      listAppsResponse = await Ajax(signal).Apps.listAppsV2(workspaceId);
+    } catch (err) {
+      setStatus({
+        totalVisibleApps: 0,
+
+        workflowsAppName: 'unknown',
+        workflowsAppStatus: 'unknown',
+        cromwellRunnerAppName: 'unknown',
+        cromwellRunnerAppStatus: 'unknown',
+
+        cbasProxyUrl: 'unknown',
+        cromwellReaderProxyUrl: 'unknown',
+        cromwellRunnerProxyUrl: 'unknown',
+
+        cbasResponsive: 'unknown',
+        cbasCromwellConnection: 'unknown',
+        cbasEcmConnection: 'unknown',
+        cbasSamConnection: 'unknown',
+        cbasLeonardoConnection: 'unknown',
+        cromwellReaderResponsive: 'unknown',
+        cromwellReaderDatabaseConnection: 'unknown',
+        cromwellRunnerResponsive: 'unknown',
+        cromwellRunnerDatabaseConnection: 'unknown',
+      });
+      return;
+    }
+
+    setStatus((previouStatus) => ({ ...previouStatus, totalVisibleApps: listAppsResponse.length }));
+
+    const workflowsApp = getCurrentApp('WORKFLOWS_APP', listAppsResponse);
+    await analyzeWorkflowsApp(workflowsApp, signal);
+    await analyzeCromwellRunnerApp(getCurrentApp('CROMWELL_RUNNER_APP', listAppsResponse), signal);
+  }, []);
+
+  useEffect(() => {
+    refreshStatus(workspaceId);
+    return () => {
+      controllerRef.current?.abort();
+    };
+  }, [refreshStatus, workspaceId]);
+
+  return { status, refreshStatus };
+};

--- a/src/workflows-app/status/workflows-status.ts
+++ b/src/workflows-app/status/workflows-status.ts
@@ -164,6 +164,7 @@ export const useWorkflowsStatus = ({ workspaceId }: UseWorkflowsStatusArgs) => {
         cromwellRunnerAppStatus: 'unknown',
         cromwellRunnerProxyUrl: 'unknown',
         cromwellRunnerResponsive: 'unknown',
+        cromwellRunnerDatabaseConnection: 'unknown',
       }));
       return;
     }
@@ -243,9 +244,10 @@ export const useWorkflowsStatus = ({ workspaceId }: UseWorkflowsStatusArgs) => {
 
     setStatus((previousStatus) => ({ ...previousStatus, totalVisibleApps: listAppsResponse.length.toString() }));
 
-    const workflowsApp = getCurrentApp('WORKFLOWS_APP', listAppsResponse);
-    await analyzeWorkflowsApp(workflowsApp, signal);
-    await analyzeCromwellRunnerApp(getCurrentApp('CROMWELL_RUNNER_APP', listAppsResponse), signal);
+    await Promise.allSettled([
+      analyzeWorkflowsApp(getCurrentApp('WORKFLOWS_APP', listAppsResponse), signal),
+      analyzeCromwellRunnerApp(getCurrentApp('CROMWELL_RUNNER_APP', listAppsResponse), signal),
+    ]);
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WM-2658

## Summary of changes:
- Adds a Workflow Apps Status panel in analogy to the Data Table Status panel.
- Behind a feature flag to emphasise its use as a developer / maintainer tool, not necessarily user facing

### What
Workflow status app panel - 

<img width="892" alt="image" src="https://github.com/DataBiosphere/terra-ui/assets/13006282/11b65c5a-7c16-4429-bead-e43627e960bb">


### Why
To help developer debugging and validation during upgrades

### Testing strategy
Tested in a working workspace.
Tested in a workspace with a bad CBAS instance, which was correctly reported.

