### PR TITLE
[AJ-1864] Fix clipboard appearing on newline for submission history

### DIFF
--- a/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
+++ b/src/pages/workspaces/workspace/jobHistory/SubmissionDetails.js
@@ -530,7 +530,7 @@ const SubmissionDetails = _.flow(
                 h(ClipboardButton, {
                   'aria-label': 'Copy submission ID to clipboard',
                   className: 'cell-hover-only',
-                  style: { marginLeft: '0.5rem' },
+                  style: { marginLeft: '0.5rem', display: 'inline' },
                   text: submissionRoot.split('/').pop(),
                 }),
               ]),


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/AJ-1864

## Summary of changes:
Just fixed a small regression in clipboard icon placement in the submission history view.

Before: 
![FF2A227E-5A81-4BA0-B1E5-8E6776A0F719](https://github.com/DataBiosphere/terra-ui/assets/81349869/840643b4-54e9-44fc-ba38-9c217f1ad9d3)

After:
![E3803FE0-6976-489A-AE95-345CFF1E307F_4_5005_c](https://github.com/DataBiosphere/terra-ui/assets/81349869/6a208efb-1067-4237-9547-f662c93ccb72)

### What
The clipboard icon placement is reverted to previous behavior.

### Why
The icon should appear as before on the same line as the submission id.

### Testing strategy
It works for me.
