### PR TITLE
[AJ-1766] Apply billing project resource limits to cloud environment form

### DIFF
--- a/src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeModal.test.ts
+++ b/src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeModal.test.ts
@@ -1,4 +1,5 @@
 import { DeepPartial } from '@terra-ui-packages/core-utils';
+import { partial } from '@terra-ui-packages/test-utils';
 import { act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import _ from 'lodash/fp';
@@ -14,12 +15,13 @@ import { getAzureComputeCostEstimate, getAzureDiskCostEstimate } from 'src/analy
 import { autopauseDisabledValue, defaultAutopauseThreshold } from 'src/analysis/utils/runtime-utils';
 import { runtimeToolLabels } from 'src/analysis/utils/tool-utils';
 import { Ajax } from 'src/libs/ajax';
+import { Billing, BillingContract } from 'src/libs/ajax/Billing';
 import { AzureConfig } from 'src/libs/ajax/leonardo/models/runtime-config-models';
 import { leoDiskProvider } from 'src/libs/ajax/leonardo/providers/LeoDiskProvider';
 import { RuntimeAjaxContractV2 } from 'src/libs/ajax/leonardo/Runtimes';
 import { azureMachineTypes, defaultAzureMachineType, getMachineTypeLabel } from 'src/libs/azure-utils';
 import { formatUSD } from 'src/libs/utils';
-import { asMockedFn, renderWithAppContexts as render } from 'src/testing/test-utils';
+import { asMockedFn, renderWithAppContexts as render, SelectHelper } from 'src/testing/test-utils';
 import { defaultAzureWorkspace } from 'src/testing/workspace-fixtures';
 
 import { AzureComputeModalBase } from './AzureComputeModal';
@@ -28,6 +30,7 @@ jest.mock('src/analysis/utils/cost-utils');
 jest.mock('src/libs/ajax/leonardo/providers/LeoDiskProvider');
 
 jest.mock('src/libs/ajax');
+jest.mock('src/libs/ajax/Billing');
 jest.mock('src/libs/notifications', () => ({
   notify: jest.fn(),
 }));
@@ -71,11 +74,28 @@ const verifyEnabled = (item) => expect(item).not.toHaveAttribute('disabled');
 const verifyDisabled = (item) => expect(item).toHaveAttribute('disabled');
 
 describe('AzureComputeModal', () => {
-  beforeAll(() => {});
-
   beforeEach(() => {
     // Arrange
     asMockedFn(Ajax).mockReturnValue(defaultAjaxImpl);
+
+    asMockedFn(Billing).mockReturnValue(
+      partial<BillingContract>({
+        getProject: jest.fn().mockResolvedValue({
+          cloudPlatform: 'AZURE',
+          landingZoneId: 'aaaabbbb-cccc-dddd-0000-111122223333',
+          managedAppCoordinates: {
+            tenantId: 'aaaabbbb-cccc-dddd-0000-111122223333',
+            subscriptionId: 'aaaabbbb-cccc-dddd-0000-111122223333',
+            managedResourceGroupId: 'aaaabbbb-cccc-dddd-0000-111122223333',
+          },
+          invalidBillingAccount: false,
+          projectName: 'Azure Billing Project',
+          roles: ['Owner'],
+          status: 'Ready',
+          protectedData: false,
+        }),
+      })
+    );
   });
 
   const getCreateButton = () => screen.getByText('Create');
@@ -454,5 +474,89 @@ describe('AzureComputeModal', () => {
 
     // Assert
     expect(screen.queryByText('Learn more about enabling GPUs.')).not.toBeInTheDocument();
+  });
+
+  describe('with resource limits', () => {
+    beforeEach(() => {
+      // Arrange
+      asMockedFn(Billing).mockReturnValue(
+        partial<BillingContract>({
+          getProject: jest.fn().mockResolvedValue({
+            cloudPlatform: 'AZURE',
+            landingZoneId: 'aaaabbbb-cccc-dddd-0000-111122223333',
+            managedAppCoordinates: {
+              tenantId: 'aaaabbbb-cccc-dddd-0000-111122223333',
+              subscriptionId: 'aaaabbbb-cccc-dddd-0000-111122223333',
+              managedResourceGroupId: 'aaaabbbb-cccc-dddd-0000-111122223333',
+            },
+            invalidBillingAccount: false,
+            projectName: 'Azure Billing Project',
+            roles: ['Owner'],
+            status: 'Ready',
+            protectedData: false,
+            organization: {
+              limits: {
+                machinetypes: 'Standard_DS2_v2,Standard_DS3_v2',
+                autopause: '30',
+                persistentdisk: '32',
+              },
+            },
+          }),
+        })
+      );
+    });
+
+    it('limits machine type options', async () => {
+      // Arrange
+      const user = userEvent.setup();
+
+      // Act
+      await act(async () => {
+        render(h(AzureComputeModalBase, defaultModalProps));
+      });
+
+      // Assert
+      const machineTypeSelect = new SelectHelper(screen.getByLabelText('Cloud compute profile'), user);
+      const machineTypeOptions = await machineTypeSelect.getOptions();
+      expect(machineTypeOptions).toEqual(['Standard_DS2_v2, 2 CPU(s), 7 GBs', 'Standard_DS3_v2, 4 CPU(s), 14 GBs']);
+    });
+
+    it('requires autopause', async () => {
+      // Act
+      await act(async () => {
+        render(h(AzureComputeModalBase, defaultModalProps));
+      });
+
+      // Assert
+      const autopauseCheckbox = screen.getByLabelText('Enable autopause');
+      expect(autopauseCheckbox).toBeChecked();
+      expect(autopauseCheckbox).toHaveAttribute('disabled');
+    });
+
+    it('limits max autopause', async () => {
+      // Act
+      await act(async () => {
+        render(h(AzureComputeModalBase, defaultModalProps));
+      });
+
+      // Assert
+      const autopauseInput = screen.getByLabelText('minutes of inactivity');
+      expect(autopauseInput).toHaveAttribute('max', '30');
+    });
+
+    it('limits persistent disk size', async () => {
+      // Arrange
+      const user = userEvent.setup();
+
+      // Act
+      await act(async () => {
+        render(h(AzureComputeModalBase, defaultModalProps));
+      });
+
+      // Assert
+      const diskSizeSelect = new SelectHelper(screen.getByLabelText('Disk Size (GB)'), user);
+      const diskSizeOptions = await diskSizeSelect.getOptions();
+      expect(diskSizeOptions).toEqual(['32']);
+    });
   });
 });

--- a/src/billing-core/resource-limits.test.ts
+++ b/src/billing-core/resource-limits.test.ts
@@ -1,0 +1,85 @@
+import { BillingProject } from './models';
+import { BillingProjectResourceLimits, getResourceLimits } from './resource-limits';
+
+describe('getResourceLimits', () => {
+  const baseGoogleBillingProject: BillingProject = {
+    billingAccount: 'billingAccounts/FOO-BAR-BAZ',
+    cloudPlatform: 'GCP',
+    invalidBillingAccount: false,
+    projectName: 'Google Billing Project',
+    roles: ['Owner'],
+    status: 'Ready',
+  };
+
+  const baseAzureBillingProject: BillingProject = {
+    cloudPlatform: 'AZURE',
+    landingZoneId: 'aaaabbbb-cccc-dddd-0000-111122223333',
+    managedAppCoordinates: {
+      tenantId: 'aaaabbbb-cccc-dddd-0000-111122223333',
+      subscriptionId: 'aaaabbbb-cccc-dddd-0000-111122223333',
+      managedResourceGroupId: 'aaaabbbb-cccc-dddd-0000-111122223333',
+    },
+    invalidBillingAccount: false,
+    projectName: 'Azure Billing Project',
+    roles: ['Owner'],
+    status: 'Ready',
+    protectedData: false,
+  };
+
+  it.each([
+    {
+      billingProject: baseGoogleBillingProject,
+      expectedResourceLimits: undefined,
+    },
+    {
+      billingProject: baseAzureBillingProject,
+      expectedResourceLimits: undefined,
+    },
+    {
+      billingProject: {
+        ...baseAzureBillingProject,
+        organization: { limits: {} },
+      },
+      expectedResourceLimits: undefined,
+    },
+    {
+      billingProject: {
+        ...baseAzureBillingProject,
+        organization: {
+          limits: { machinetypes: 'Standard_DS2_v2,Standard_DS3_v2', autopause: '30', persistentdisk: '32' },
+        },
+      },
+      expectedResourceLimits: {
+        availableMachineTypes: ['Standard_DS2_v2', 'Standard_DS3_v2'],
+        maxAutopause: 30,
+        maxPersistentDiskSize: 32,
+      },
+    },
+    {
+      billingProject: {
+        ...baseAzureBillingProject,
+        organization: {
+          limits: {
+            machinetypes: '',
+            autopause: 30,
+            persistentdisk: '',
+          },
+        },
+      },
+      expectedResourceLimits: {
+        availableMachineTypes: undefined,
+        maxAutopause: 30,
+        maxPersistentDiskSize: undefined,
+      },
+    },
+  ] as { billingProject: BillingProject; expectedResourceLimits: BillingProjectResourceLimits | undefined }[])(
+    'should return the expected resource limits',
+    ({ billingProject, expectedResourceLimits }) => {
+      // Act
+      const resourceLimits = getResourceLimits(billingProject);
+
+      // Assert
+      expect(resourceLimits).toEqual(expectedResourceLimits);
+    }
+  );
+});

--- a/src/billing-core/resource-limits.ts
+++ b/src/billing-core/resource-limits.ts
@@ -1,0 +1,58 @@
+import { BillingProject } from 'src/billing-core/models';
+
+export interface BillingProjectResourceLimits {
+  availableMachineTypes?: string[];
+  maxAutopause?: number;
+  maxPersistentDiskSize?: number;
+}
+
+/**
+ * Parses a comma-separated string into an array of strings.
+ * If the input is not a string or an empty string, returns undefined.
+ */
+const getCommaSeparatedValues = (value: unknown): string[] | undefined => {
+  if (typeof value === 'string' && value.length !== 0) {
+    return value.split(',');
+  }
+  return undefined;
+};
+
+/**
+ * Parses a value into a number.
+ */
+const getNumberValue = (value: unknown): number | undefined => {
+  if (typeof value === 'number') {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const n = parseInt(value, 10);
+    return Number.isNaN(n) ? undefined : n;
+  }
+  return undefined;
+};
+
+/**
+ * Parse a billing project's resource limits (if any).
+ *
+ * @param project - The billing project.
+ * @returns The billing project's resource limits, or undefined if the project does not have any.
+ */
+export const getResourceLimits = (project: BillingProject): BillingProjectResourceLimits | undefined => {
+  if (project.cloudPlatform !== 'AZURE' || !project.organization?.limits) {
+    return undefined;
+  }
+
+  const limits = project.organization.limits;
+  if (Object.keys(limits).length === 0) {
+    return undefined;
+  }
+
+  // The BPM API returns all resource limits as strings. This parses them into more structured types.
+  const resourceLimits: BillingProjectResourceLimits = {
+    availableMachineTypes: getCommaSeparatedValues(limits.machinetypes),
+    maxAutopause: getNumberValue(limits.autopause),
+    maxPersistentDiskSize: getNumberValue(limits.persistentdisk),
+  };
+
+  return resourceLimits;
+};

--- a/src/billing/useBillingProject.test.ts
+++ b/src/billing/useBillingProject.test.ts
@@ -1,0 +1,43 @@
+import { Billing } from 'src/libs/ajax/Billing';
+import { azureBillingProject } from 'src/testing/billing-project-fixtures';
+import { asMockedFn, mockNotifications, renderHookInActWithAppContexts } from 'src/testing/test-utils';
+
+import { useBillingProject } from './useBillingProject';
+
+jest.mock('src/libs/ajax/Billing', () => ({ Billing: jest.fn() }));
+type BillingContract = ReturnType<typeof Billing>;
+
+describe('useBillingProject', () => {
+  it('returns billing project', async () => {
+    // Arrange
+    const getProject = jest.fn(() => Promise.resolve(azureBillingProject));
+    asMockedFn(Billing).mockImplementation(() => ({ getProject } as Partial<BillingContract> as BillingContract));
+
+    // Act
+    const { result: hookReturnRef } = await renderHookInActWithAppContexts(() =>
+      useBillingProject(azureBillingProject.projectName)
+    );
+    const result = hookReturnRef.current;
+
+    // Assert
+    expect(getProject).toHaveBeenCalledWith(azureBillingProject.projectName);
+    expect(result).toEqual({ status: 'Ready', state: azureBillingProject });
+  });
+
+  it('handles errors', async () => {
+    // Arrange
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    asMockedFn(Billing).mockReturnValue({
+      getProject: (_name) => Promise.reject(new Error('Something went wrong')),
+    } as BillingContract);
+
+    // Act
+    const { result: hookReturnRef } = await renderHookInActWithAppContexts(() => useBillingProject('test-project'));
+    const result = hookReturnRef.current;
+
+    // Assert
+    expect(mockNotifications.notify).toHaveBeenCalled();
+    expect(result).toEqual({ status: 'Error', state: null, error: new Error('Something went wrong') });
+  });
+});

--- a/src/billing/useBillingProject.ts
+++ b/src/billing/useBillingProject.ts
@@ -1,0 +1,30 @@
+import { useLoadedData, UseLoadedDataArgs } from '@terra-ui-packages/components';
+import { LoadedState } from '@terra-ui-packages/core-utils';
+import { useNotificationsFromContext } from '@terra-ui-packages/notifications';
+import { useEffect } from 'react';
+import { BillingProject } from 'src/billing-core/models';
+import { Billing } from 'src/libs/ajax/Billing';
+
+export const useBillingProject = (
+  name: string,
+  options: UseLoadedDataArgs<BillingProject, unknown> = {}
+): LoadedState<BillingProject, unknown> => {
+  const { reportError } = useNotificationsFromContext();
+  const [state, load] = useLoadedData<BillingProject>({
+    ...options,
+    onError: (error) => {
+      reportError('Error loading billing project.', error);
+      options.onError?.(error);
+    },
+  });
+
+  useEffect(() => {
+    const abortController = new AbortController();
+    load(() => Billing(abortController.signal).getProject(name));
+    return () => {
+      abortController.abort();
+    };
+  }, [load, name]);
+
+  return state;
+};

--- a/src/libs/ajax/Billing.ts
+++ b/src/libs/ajax/Billing.ts
@@ -24,6 +24,9 @@ export interface AzureManagedAppCoordinates {
 
 export interface Organization {
   enterprise?: boolean;
+
+  /** Resource limits for the billing profile. */
+  limits?: { [resource: string]: unknown };
 }
 
 export type CloudPlatform = 'GCP' | 'AZURE' | 'UNKNOWN';
@@ -221,6 +224,8 @@ export const Billing = (signal?: AbortSignal) => ({
     return response.json();
   },
 });
+
+export type BillingContract = ReturnType<typeof Billing>;
 
 export const canUseWorkspaceProject = async ({
   canCompute,


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1766

For AnVIL Lite billing projects, we want to limit the cost of cloud environments by limiting the size of the machine and persistent disk and requiring autopause.

Billing projects can now include a `limits` object that defines various resource limits. This updates AzureComputeModal to check for limits on the workspace's billing project and apply those limits to the cloud environment configuration form.

For example, this billing project limits cloud environments to two small machine types, limits persistent disks to 32 GB, and requires a maximum autopause setting of 30 minutes.

https://github.com/DataBiosphere/terra-ui/assets/1156625/7679bff4-31bb-4bf1-9d5b-7df77bb1f2e4

These limits will also be enforced by Leonardo (see [AJ-1838](https://broadworkbench.atlassian.net/browse/AJ-1838)).

[AJ-1838]: https://broadworkbench.atlassian.net/browse/AJ-1838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ