### PR TITLE
[WX-1642] Fix Submission Details Inputs and Outputs tabs showing incorrect data

### DIFF
--- a/src/workflows-app/SubmissionDetails.js
+++ b/src/workflows-app/SubmissionDetails.js
@@ -91,7 +91,7 @@ export const BaseSubmissionDetails = ({ name, namespace, workspace, submissionId
     async (cbasUrlRoot) => {
       try {
         const runSets = await Ajax(signal).Cbas.runSets.get(cbasUrlRoot);
-        const newRunSetData = runSets.run_sets[0];
+        const newRunSetData = runSets.run_sets.find((runSet) => runSet.run_set_id === submissionId);
         setRunSetData(runSets.run_sets);
         setConfiguredInputDefinition(maybeParseJSON(newRunSetData.input_definition));
         setConfiguredOutputDefinition(maybeParseJSON(newRunSetData.output_definition));
@@ -100,7 +100,7 @@ export const BaseSubmissionDetails = ({ name, namespace, workspace, submissionId
         notify('error', 'Error getting run set data', { detail: error instanceof Response ? await error.text() : error });
       }
     },
-    [signal]
+    [signal, submissionId]
   );
 
   // helper for auto-refresh


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WX-1642

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Instead of showing inputs and outputs for the selected submission, the Inputs and Outputs tabs showed the inputs and outputs for the first run set fetched from the server (which is not necessarily the selected submission). This fix searches the fetched run sets for the current submission, so now the correct information will be displayed.

### Why
- Bug fix

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- Manually confirmed in a workspace with multiple run sets that each shows the correct inputs and outputs <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
